### PR TITLE
ci(actions): S3 docs paths-ignore + scoped CD cache

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -116,8 +116,8 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=metapi-go
+          cache-to: type=gha,mode=max,scope=metapi-go
           platforms: linux/amd64
           load: true
       - name: Smoke Docker image
@@ -157,8 +157,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=metapi-go
+          cache-to: type=gha,mode=max,scope=metapi-go
           platforms: linux/amd64
           provenance: mode=max
           sbom: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,14 @@ name: CI
 on:
   pull_request:
     branches: [master, main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
   push:
     branches: [master, main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Reduce docs-only burns; scope GHA cache for metapi-go CD.