### PR TITLE
fix(concurrency): B2 real mutex, lease lifecycle, request context

### DIFF
--- a/docs/analysis/b2-concurrency-hardening.md
+++ b/docs/analysis/b2-concurrency-hardening.md
@@ -1,0 +1,44 @@
+# B2 concurrency hardening (#18)
+
+Last updated: 2026-07-16
+
+## Scope
+
+CRITICAL residual races around shared stable-first maps, lease lock-order / lifecycle
+hygiene, and request-context propagation on the upstream proxy path.
+
+## Changes
+
+### 1. Stable-first map locking (`routing/weights.go`)
+
+- Removed the `sync_RWMutex` type alias; `stableFirstStateMu` is a real `sync.RWMutex`.
+- `selectStableFirstCandidate` now reads `stableFirstLastSelectedSiteByKey` under
+  `RLock`.
+- `UpdateStableFirstObservationProgress` holds one exclusive lock for the full
+  read-modify-write (progress + optional site cooldown) via locked helpers.
+- Added `-race` coverage: `TestStableFirstStateMaps_ConcurrentRace`.
+
+### 2. Lease lifecycle (`proxy/session.go`)
+
+- Original touchLease-per-tick goroutine leak is already fixed (single expiry
+  goroutine + non-blocking Touch via `expiryCh`).
+- Hardened further:
+  - `nextLeaseID` is `atomic.Int64` so `createTrackedLease` never takes `c.mu`
+    while `state.mu` is held (lock order stays `c.mu` then `state.mu`).
+  - `doneCh` is unbuffered close-only.
+- Added stress test: `TestLeaseLifecycle_ConcurrentAcquireSnapshot`.
+
+### 3. Request context (`handler/proxy/upstream.go`)
+
+- Production dispatch already uses `r.Context()` for channel selection, request
+  construction, success/failure recording, and SSE cancel checks.
+- Hardened SSE path: upstream `resp.Body` is always closed via `defer` after
+  stream handling (including early client disconnect).
+
+## Verification
+
+```bash
+go test ./routing -run 'StableFirstStateMaps_ConcurrentRace|StableFirst' -race -count=1
+go test ./proxy -run 'LeaseLifecycle_Concurrent|LeaseLifecycle|AcquireChannelLease' -race -count=1
+go test ./handler/proxy -run 'Upstream|Stream' -count=1
+```

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -181,9 +181,12 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 				relayBufferedUpstreamErrorResponse(w, resp, bodyBytes)
 				return
 			}
-			handleStreamUpstream(w, r, resp, latencyMs)
+			// Always close the upstream body, including early client disconnects.
+			func() {
+				defer resp.Body.Close()
+				handleStreamUpstream(w, r, resp, latencyMs)
+			}()
 			recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs)
-			resp.Body.Close()
 		} else {
 			bodyBytes, readErr := proxy.ReadBufferedResponseBody(resp.Body)
 			resp.Body.Close()
@@ -377,6 +380,9 @@ func writeStubResponse(w http.ResponseWriter, ctx *Ctx) {
 // Disables the server-level WriteTimeout via http.ResponseController so long-running
 // LLM streams (>60s) are not torn down mid-response.
 func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Response, latencyMs int64) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		relayUpstreamErrorResponse(w, resp, latencyMs)
 		return

--- a/proxy/session.go
+++ b/proxy/session.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/tokendancelab/metapi-go/config"
@@ -96,21 +97,24 @@ type channelRuntimeState struct {
 // Both are conditional: only activate when the downstream request has a valid sticky
 // session key AND the channel's account uses session-scoped credentials.
 type ProxyChannelCoordinator struct {
-	stickyBindings    map[string]StickyEntry
-	channelStates     map[int64]*channelRuntimeState
-	nextLeaseID       int
-	mu                sync.Mutex
-	cfg               *config.Config
+	stickyBindings map[string]StickyEntry
+	channelStates  map[int64]*channelRuntimeState
+	// nextLeaseID is allocated with atomic ops so createTrackedLease never needs
+	// c.mu while state.mu is already held (lock order: c.mu then state.mu).
+	nextLeaseID atomic.Int64
+	mu          sync.Mutex
+	cfg         *config.Config
 }
 
 // NewProxyChannelCoordinator creates a new coordinator.
 func NewProxyChannelCoordinator(cfg *config.Config) *ProxyChannelCoordinator {
-	return &ProxyChannelCoordinator{
+	c := &ProxyChannelCoordinator{
 		stickyBindings: make(map[string]StickyEntry),
 		channelStates:  make(map[int64]*channelRuntimeState),
-		nextLeaseID:    1,
 		cfg:            cfg,
 	}
+	c.nextLeaseID.Store(1)
+	return c
 }
 
 // ---- Sticky Session Key ----
@@ -265,11 +269,8 @@ func (c *ProxyChannelCoordinator) getOrCreateChannelState(channelID int64) *chan
 }
 
 func (c *ProxyChannelCoordinator) nextLeaseIDValue() int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	id := c.nextLeaseID
-	c.nextLeaseID++
-	return id
+	// Atomic allocation: safe under state.mu without taking c.mu.
+	return int(c.nextLeaseID.Add(1) - 1)
 }
 
 // AcquireChannelLease acquires a lease for a channel. Returns noop if channelID <= 0
@@ -295,9 +296,10 @@ func (c *ProxyChannelCoordinator) AcquireChannelLease(
 	}
 
 	state := c.getOrCreateChannelState(channelID)
-	state.concurrencyLimit = concurrencyLimit
 
 	state.mu.Lock()
+	// concurrencyLimit is shared state; always update under state.mu.
+	state.concurrencyLimit = concurrencyLimit
 	c.pruneCancelledWaitersLocked(state)
 
 	if len(state.activeLeaseIDs) < concurrencyLimit {
@@ -348,9 +350,9 @@ func (c *ProxyChannelCoordinator) createNoopLease(channelID int64) *ChannelLease
 }
 
 func (c *ProxyChannelCoordinator) createTrackedLease(channelID int64, state *channelRuntimeState) *ChannelLease {
+	// Caller (AcquireChannelLease / drainQueueLocked) already holds state.mu.
+	// Lease IDs are atomic so we never take c.mu while holding state.mu.
 	leaseID := c.nextLeaseIDValue()
-
-	// Caller (AcquireChannelLease) already holds state.mu
 	state.activeLeaseIDs[leaseID] = true
 
 	lease := &ChannelLease{
@@ -360,7 +362,7 @@ func (c *ProxyChannelCoordinator) createTrackedLease(channelID int64, state *cha
 		coord:     c,
 		state:     state,
 		expiryCh:  make(chan struct{}, 1),
-		doneCh:    make(chan struct{}, 1),
+		doneCh:    make(chan struct{}), // close-only signal; unbuffered is intentional
 	}
 
 	// Start expiry timer (single goroutine; resets via expiryCh on Touch)
@@ -582,5 +584,5 @@ func (c *ProxyChannelCoordinator) Reset() {
 	defer c.mu.Unlock()
 	c.stickyBindings = make(map[string]StickyEntry)
 	c.channelStates = make(map[int64]*channelRuntimeState)
-	c.nextLeaseID = 1
+	c.nextLeaseID.Store(1)
 }

--- a/proxy/session_test.go
+++ b/proxy/session_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -523,4 +524,56 @@ func TestCredentialModeIntegration(t *testing.T) {
 			t.Errorf("expected empty mode for nil config, got %q", mode)
 		}
 	})
+}
+
+
+// TestLeaseLifecycle_ConcurrentAcquireSnapshot stresses acquire/touch/release
+// against GetActiveChannelIDs under -race and verifies lock-order safety.
+func TestLeaseLifecycle_ConcurrentAcquireSnapshot(t *testing.T) {
+	coord := newTestCoordinator()
+	coord.cfg.ProxySessionChannelConcurrencyLimit = 4
+	coord.cfg.ProxySessionChannelQueueWaitMs = 20
+	coord.cfg.ProxySessionChannelLeaseTtlMs = 500
+	coord.cfg.ProxySessionChannelLeaseKeepaliveMs = 50
+	ec, op := sessionScopedConfig()
+
+	var wg sync.WaitGroup
+	const workers = 8
+	const iters = 40
+	wg.Add(workers + 1)
+
+	// Snapshotter
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters*workers; i++ {
+			_ = coord.GetActiveChannelIDs()
+			_ = coord.GetChannelLoadSnapshot(int64(1000+(i%3)), ec, op)
+		}
+	}()
+
+	for w := 0; w < workers; w++ {
+		go func(worker int) {
+			defer wg.Done()
+			channelID := int64(1000 + (worker % 3))
+			for i := 0; i < iters; i++ {
+				result := coord.AcquireChannelLease(channelID, ec, op)
+				if result.Status != "acquired" || result.Lease == nil {
+					continue
+				}
+				// Keepalive path: Touch must not spawn unbounded goroutines.
+				for k := 0; k < 3; k++ {
+					result.Lease.Touch()
+				}
+				result.Lease.Release()
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// Allow expiry/keepalive goroutines to observe doneCh.
+	time.Sleep(50 * time.Millisecond)
+	ids := coord.GetActiveChannelIDs()
+	if len(ids) != 0 {
+		t.Fatalf("expected no active leases after concurrent release, got %v", ids)
+	}
 }

--- a/routing/weights.go
+++ b/routing/weights.go
@@ -354,7 +354,7 @@ var (
 	stableFirstLastSelectedSiteByKey        = make(map[string]int64)
 	stableFirstObservationProgressByKey     = make(map[string]StableFirstObservationProgressState)
 	stableFirstObservationSiteCooldownByKey = make(map[string]int64)
-	stableFirstStateMu                      sync_RWMutex
+	stableFirstStateMu                      sync.RWMutex
 )
 
 const (
@@ -369,14 +369,16 @@ type StableFirstObservationProgressState struct {
 	LastObservationAtMs *int64
 }
 
-type sync_RWMutex = sync.RWMutex
-
 func rememberStableFirstSiteSelectionForKey(rotationKey string, siteID int64) {
 	if rotationKey == "" || siteID <= 0 {
 		return
 	}
 	stableFirstStateMu.Lock()
 	defer stableFirstStateMu.Unlock()
+	rememberStableFirstSiteSelectionForKeyLocked(rotationKey, siteID)
+}
+
+func rememberStableFirstSiteSelectionForKeyLocked(rotationKey string, siteID int64) {
 	delete(stableFirstLastSelectedSiteByKey, rotationKey)
 	stableFirstLastSelectedSiteByKey[rotationKey] = siteID
 	for len(stableFirstLastSelectedSiteByKey) > MaxStableFirstRotationKeys {
@@ -393,6 +395,10 @@ func rememberStableFirstObservationProgressForKey(rotationKey string, state Stab
 	}
 	stableFirstStateMu.Lock()
 	defer stableFirstStateMu.Unlock()
+	rememberStableFirstObservationProgressForKeyLocked(rotationKey, state)
+}
+
+func rememberStableFirstObservationProgressForKeyLocked(rotationKey string, state StableFirstObservationProgressState) {
 	delete(stableFirstObservationProgressByKey, rotationKey)
 	stableFirstObservationProgressByKey[rotationKey] = state
 	for len(stableFirstObservationProgressByKey) > MaxStableFirstObservationProgressKeys {
@@ -407,9 +413,13 @@ func rememberStableFirstObservationSiteCooldown(rotationKey string, siteID int64
 	if rotationKey == "" || siteID <= 0 {
 		return
 	}
-	scopedKey := rotationKey + ":" + formatInt(siteID)
 	stableFirstStateMu.Lock()
 	defer stableFirstStateMu.Unlock()
+	rememberStableFirstObservationSiteCooldownLocked(rotationKey, siteID, observedAtMs)
+}
+
+func rememberStableFirstObservationSiteCooldownLocked(rotationKey string, siteID int64, observedAtMs int64) {
+	scopedKey := rotationKey + ":" + formatInt(siteID)
 	delete(stableFirstObservationSiteCooldownByKey, scopedKey)
 	stableFirstObservationSiteCooldownByKey[scopedKey] = observedAtMs
 	for len(stableFirstObservationSiteCooldownByKey) > MaxStableFirstObservationSiteCooldownKeys {
@@ -503,7 +513,9 @@ func selectStableFirstCandidate(candidates []RouteChannelCandidate, contribution
 
 	orderedSiteLeaderIndices := getStableFirstOrderedSiteLeaderIndices(candidates, stableSiteLeaderIndices)
 
+	stableFirstStateMu.RLock()
 	lastSelectedSiteID := stableFirstLastSelectedSiteByKey[rotationKey]
+	stableFirstStateMu.RUnlock()
 	lastSelectedIndex := -1
 	for i, idx := range orderedSiteLeaderIndices {
 		if candidates[idx].Site.ID == lastSelectedSiteID {
@@ -588,26 +600,31 @@ func ShouldUseStableFirstObservationCandidate(rotationKey string, observationCan
 }
 
 // UpdateStableFirstObservationProgress updates observation progress after a selection.
+// The full read-modify-write of progress (and optional cooldown) is held under a
+// single exclusive lock to avoid TOCTOU races on the shared maps.
 func UpdateStableFirstObservationProgress(rotationKey string, usedObservation bool, selectedSiteID int64) {
 	if rotationKey == "" {
 		return
 	}
 	n := nowMs()
+	stableFirstStateMu.Lock()
+	defer stableFirstStateMu.Unlock()
+
 	previous, ok := stableFirstObservationProgressByKey[rotationKey]
 	if !ok {
 		previous = StableFirstObservationProgressState{}
 	}
 	if usedObservation {
-		rememberStableFirstObservationProgressForKey(rotationKey, StableFirstObservationProgressState{
+		rememberStableFirstObservationProgressForKeyLocked(rotationKey, StableFirstObservationProgressState{
 			RequestCount:        0,
 			LastObservationAtMs: &n,
 		})
 		if selectedSiteID > 0 {
-			rememberStableFirstObservationSiteCooldown(rotationKey, selectedSiteID, n)
+			rememberStableFirstObservationSiteCooldownLocked(rotationKey, selectedSiteID, n)
 		}
 		return
 	}
-	rememberStableFirstObservationProgressForKey(rotationKey, StableFirstObservationProgressState{
+	rememberStableFirstObservationProgressForKeyLocked(rotationKey, StableFirstObservationProgressState{
 		RequestCount:        previous.RequestCount + 1,
 		LastObservationAtMs: previous.LastObservationAtMs,
 	})

--- a/routing/weights_test.go
+++ b/routing/weights_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/tokendancelab/metapi-go/store"
@@ -554,4 +555,51 @@ func BenchmarkMakeCandidate(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = makeCandidate(int64(i%100)+1, int64(i%10)*10, int64(i)+1, 10, 0, 100, 5, 50.0, 1.0, nil, 0, nil)
 	}
+}
+
+
+// TestStableFirstStateMaps_ConcurrentRace exercises concurrent select + update + clear
+// against the shared stable-first maps. Run with -race.
+func TestStableFirstStateMaps_ConcurrentRace(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	ClearStableFirstCachesForRoute(42)
+
+	candidates := []RouteChannelCandidate{
+		makeCandidate(1, 100, 1001, 10, 0, 100, 5, 50.0, 1.0, nil, 0, nil),
+		makeCandidate(2, 200, 2001, 10, 0, 100, 5, 50.0, 1.0, nil, 0, nil),
+		makeCandidate(3, 300, 3001, 10, 0, 100, 5, 50.0, 1.0, nil, 0, nil),
+	}
+	routingWeights := RoutingWeightsConfig{
+		BaseWeightFactor: 0.5,
+		ValueScoreFactor: 0.5,
+		CostWeight:       0.4,
+		BalanceWeight:    0.3,
+		UsageWeight:      0.3,
+	}
+	rotationKey := BuildStableFirstRotationKey(42, "gpt-4")
+
+	var wg sync.WaitGroup
+	const workers = 8
+	const iters = 200
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				result := CalculateWeightedSelection(
+					candidates, staticModel("gpt-4"), routingWeights,
+					nil, nil, 0, StableFirstMode, rotationKey, nil, 1.0,
+				)
+				if result.Selected != nil {
+					rememberStableFirstSiteSelectionForKey(rotationKey, result.Selected.Site.ID)
+					UpdateStableFirstObservationProgress(rotationKey, i%17 == 0, result.Selected.Site.ID)
+				}
+				_ = ShouldUseStableFirstObservationCandidate(rotationKey, candidates)
+				if i%50 == 0 {
+					ClearStableFirstCachesForRoute(42)
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
Closes #18. Lane: lane-backend. Race tests green for routing/proxy.