### PR TITLE
fix(reliability): R0 upstream error classification guards

### DIFF
--- a/docs/analysis/error-classification.md
+++ b/docs/analysis/error-classification.md
@@ -1,0 +1,72 @@
+# Upstream Error Classification (R0 / #24)
+
+**Date:** 2026-07-16  
+**Lane:** reliability  
+**SSOT code:** `platform/error_classification.go`  
+**Mark path consumers:** `service/alert.IsTokenExpiredError` → balance/checkin `ReportTokenExpired`; proxy `SurfaceFailureToolkit` (wired via `ShouldMarkAccountExpired`)
+
+## Purpose
+
+Prevent non-auth upstream failures (billing, model capability, validation, rate-limit) from flipping `accounts.status` to `expired`. Auto-relogin and UI failure-reason labels may still use broader heuristics; **only `ClassExpired` may mark the account expired**.
+
+## Signal → Class → Action
+
+| Signal (status / message) | Class | Action |
+|:--------------------------|:------|:-------|
+| `jwt expired`, `token expired`, `access token expired` | **expired** | Mark `accounts.status=expired`; event + notify + runtime health auth-unhealthy; allow auto-relogin |
+| `invalid access token` / `access token is invalid` / `access token无效` | **expired** | Same as above |
+| `令牌/访问令牌` + `过期/无效` | **expired** | Same as above |
+| HTTP **401** with **empty** body | **expired** | Same as above (legacy bare-401 policy; residual risk below) |
+| `HTTP 401 Unauthorized` / clear 401 + unauthorized | **expired** | Same as above |
+| HTTP 401/403 with auth wording but **no** expiry/invalid-credential phrase | **auth** | Do **not** mark expired; auto-relogin callers may still try via broader local heuristics |
+| `未登录且未提供 access token` (NewAPI probe) | **auth** | Do **not** mark expired |
+| `invalid_argument` / `invalid_request_error` / `input token limit` / `context length` / `max_tokens` / dispatch denied | **validation** | Do **not** mark; do not treat as credential loss |
+| `model … is not supported` / `unsupported model` / `不支持…模型` / `model_not_found` | **model** | Do **not** mark; channel/model failover only |
+| `billing` / `payment method` / `insufficient_quota` / `quota exceeded` / `余额不足` / `额度不足` | **billing** | Do **not** mark; surface as quota/billing health if needed |
+| HTTP 408/409/425/429/5xx, `rate limit`, `timeout`, `bad gateway`, Cloudflare challenge | **transient** | Do **not** mark; retry / cooldown / breaker |
+| Opaque 401 body without auth/billing/model/validation signal | **unknown** | Do **not** mark expired |
+| Empty message + non-401 status | **unknown** | No mark |
+
+### Action legend
+
+| Action | Meaning |
+|:-------|:--------|
+| **Mark expired** | `ReportTokenExpired` → `UPDATE accounts SET status='expired'` + event + notification + `HealthSourceAuth` |
+| **Auto-relogin** | Balance/checkin may re-login when local `shouldAttemptAutoRelogin*` is true (broader than mark) |
+| **Retry / failover** | Proxy `ShouldRetryProxyRequest` / channel penalty — independent of account status |
+| **No account status write** | Classification only; health may still go unhealthy from the calling job |
+
+## Call-site matrix
+
+| Call site | Uses classifier? | Marks expired? |
+|:----------|:-----------------|:---------------|
+| `service/alert.IsTokenExpiredError` | Yes (delegates to `platform`) | Indirect — callers decide |
+| `service/balance.handleBalanceError` | Via alert | Yes if expired class |
+| `service/checkin` post-failure | Via alert | Yes if expired class |
+| `service/checkin.ClassifyFailureReason` | Via alert (display) | No (UI only) |
+| `proxy.SurfaceFailureToolkit.HandleUpstreamFailure` | `platform.ShouldMarkAccountExpired` | Yes when hook set |
+| `platform.resolveGroupFetchErrorMessage` | Session UX string only | No |
+| `platform.isCookieSessionFailureMessage` | Cookie/session retry heuristic | No |
+| `auth/downstream` managed-key `ExpiresAt` | Separate concept | No (`downstream_api_keys`, not accounts) |
+
+## Residual risks
+
+1. **Bare HTTP 401 + empty body** still classifies as **expired** (legacy parity with TS / auto-relogin). Any upstream that returns 401 with an empty body for non-auth reasons can still mark the account. Mitigation later: require a second signal or consecutive failures.
+2. **Substring heuristics remain**. Novel billing/quota wording without `billing`/`quota`/`payment`/`余额` may fall through to unknown (safe: no mark) or, if paired with 401 + `unauthorized`, to expired (unsafe). Expand exclusion lists when new providers appear.
+3. **Balance auto-relogin is broader than mark** (`unauthorized`/`forbidden`/`not login`). Relogin can run without marking; marking still requires **expired** class.
+4. **Checkin failure_reason priority** can show Turnstile/Cloudflare over token_expired in UI while the post-failure mark path uses the raw message classifier independently — after R0 they stay consistent on non-auth exclusions, but priority demotion is display-only.
+5. **Intermittent false positives flap status**: successful balance/checkin still revive `expired → active`. Prefer fixing classification over removing revive.
+6. **`ReportTokenExpired` DB `Exec` error is still unchecked** (pre-existing) — mark may silently fail while event/notify run.
+7. **Downstream API key `expires_at`** and sticky-session TTL cleanup are unrelated clocks; do not conflate with account token expiry.
+
+## Tests
+
+- `platform/error_classification_test.go` — matrix + non-auth never-mark table + positive auth signals
+- `service/alert` tests continue to cover historical `IsTokenExpiredError` surface via thin delegate
+- `proxy` failure toolkit tests cover mark-hook invocation only on expired class
+
+## Non-goals (R0)
+
+- Schema / UI changes
+- Replacing all string matching with typed upstream errors
+- Changing OAuth refresh policy or circuit-breaker penalties beyond classification guards

--- a/platform/error_classification.go
+++ b/platform/error_classification.go
@@ -1,0 +1,292 @@
+package platform
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// UpstreamErrorClass is the high-level class for upstream failure signals.
+// Used for account-status decisions, retry UX, and residual-risk documentation.
+type UpstreamErrorClass string
+
+const (
+	// ClassExpired means the upstream credential/session looks expired or invalid.
+	// Only this class may mark accounts.status = 'expired'.
+	ClassExpired UpstreamErrorClass = "expired"
+	// ClassAuth means an auth/session problem that is not clearly token expiry.
+	ClassAuth UpstreamErrorClass = "auth"
+	// ClassBilling means payment / quota / credit failures.
+	ClassBilling UpstreamErrorClass = "billing"
+	// ClassModel means model capability / unsupported-model failures.
+	ClassModel UpstreamErrorClass = "model"
+	// ClassValidation means request validation / argument errors.
+	ClassValidation UpstreamErrorClass = "validation"
+	// ClassTransient means rate-limit / timeout / 5xx / network-like failures.
+	ClassTransient UpstreamErrorClass = "transient"
+	// ClassUnknown is the residual bucket.
+	ClassUnknown UpstreamErrorClass = "unknown"
+)
+
+var (
+	endpointDispatchDeniedRe = regexp.MustCompile(`does\s+not\s+allow\s+/v1/[a-z0-9/_:-]+\s+dispatch`)
+	invalidAccessTokenRe     = regexp.MustCompile(`invalid\s+access\s+token`)
+	accessTokenIsInvalidRe   = regexp.MustCompile(`access\s+token\s+is\s+invalid`)
+	modelNotSupportedRe      = regexp.MustCompile(`model\s+.+\s+is\s+not\s+supported`)
+	// Auth-oriented token references. Intentionally avoids bare "token"
+	// so phrases like "input token limit" do not look like credential failures.
+	authTokenRefRe = regexp.MustCompile(
+		`access\s+token|api[_\s-]?key|jwt|访问令牌|令牌|\binvalid\s+token\b|\btoken\s+(?:is\s+)?(?:invalid|expired)\b|\btoken\s+expired\b`,
+	)
+	authFailureSignalRe = regexp.MustCompile(
+		`unauthorized|unauthenticated|authentication\s+(?:failed|required|error)|not\s+login|not\s+logged|未登录|未授权|无权|forbidden`,
+	)
+)
+
+// ClassifyUpstreamError maps an upstream HTTP status + message to a class.
+// Classification is intentionally conservative for ClassExpired: non-auth
+// 401/403 bodies (billing, model, validation, rate-limit) must not mark keys expired.
+func ClassifyUpstreamError(httpStatus int, message string) UpstreamErrorClass {
+	raw := message
+	text := strings.ToLower(strings.TrimSpace(message))
+
+	// Explicit non-auth exclusions first (even when status is 401).
+	if isEndpointDispatchDeniedMessage(raw) {
+		return ClassValidation
+	}
+	if text != "" && strings.Contains(text, "未登录且未提供 access token") {
+		// NewAPI probe noise: missing credential header, not a stored-token expiry.
+		return ClassAuth
+	}
+	if isRequestValidationFailure(text) {
+		return ClassValidation
+	}
+	if isCapabilityFailure(text) {
+		return ClassModel
+	}
+	if isBillingFailure(text) {
+		return ClassBilling
+	}
+
+	// Strong credential-expiry phrases beat mixed residual text such as
+	// "jwt expired, connection timeout" (checkin failure-reason priority 6 > 8).
+	if isStrongTokenExpiredSignal(text) {
+		return ClassExpired
+	}
+
+	if isTransientFailure(httpStatus, text) {
+		return ClassTransient
+	}
+	if isCloudflareChallengeMessage(text) {
+		return ClassTransient
+	}
+
+	// Bare HTTP 401 with empty body is treated as expired (legacy auto-relogin /
+	// mark path). Non-empty 401/403 without auth signal stay unknown/auth.
+	if httpStatus == 401 || containsHTTPStatus(raw, 401) {
+		if text == "" {
+			return ClassExpired
+		}
+		if hasAuthFailureSignal(text) || hasAuthTokenReference(text) {
+			// Unauthorized without an explicit expiry phrase is still auth, but
+			// historical IsTokenExpiredError treated 401 as expired once non-auth
+			// exclusions were ruled out. Keep that for empty-adjacent auth 401s.
+			if hasExplicitExpiryOrInvalidCredential(text) || text == "unauthorized" ||
+				strings.Contains(text, "http 401") || strings.Contains(text, "401 unauthorized") {
+				return ClassExpired
+			}
+			return ClassAuth
+		}
+		// 401 with an opaque/non-auth residual body must not mark expired.
+		return ClassUnknown
+	}
+
+	if httpStatus == 403 || containsHTTPStatus(raw, 403) {
+		if hasAuthFailureSignal(text) || hasAuthTokenReference(text) {
+			return ClassAuth
+		}
+		return ClassUnknown
+	}
+
+	if hasAuthFailureSignal(text) && hasAuthTokenReference(text) {
+		return ClassAuth
+	}
+
+	return ClassUnknown
+}
+
+// IsTokenExpiredError reports whether the signal should be treated as an
+// expired/invalid stored credential for auto-relogin and account marking.
+// Mirrors historical TS isTokenExpiredError() with tighter non-auth guards.
+func IsTokenExpiredError(httpStatus int, message string) bool {
+	switch ClassifyUpstreamError(httpStatus, message) {
+	case ClassExpired:
+		return true
+	case ClassAuth:
+		// Auth without clear expiry does not mark accounts expired, but some
+		// callers historically used IsTokenExpiredError for auto-relogin only.
+		// Keep auto-relogin-compatible true only for strong credential signals.
+		text := strings.ToLower(strings.TrimSpace(message))
+		return hasExplicitExpiryOrInvalidCredential(text)
+	default:
+		return false
+	}
+}
+
+// ShouldMarkAccountExpired is the guard used before writing accounts.status='expired'.
+// Today it matches IsTokenExpiredError; kept separate so mark policy can tighten later
+// without changing auto-relogin heuristics.
+func ShouldMarkAccountExpired(httpStatus int, message string) bool {
+	return ClassifyUpstreamError(httpStatus, message) == ClassExpired
+}
+
+// IsAuthRelatedUpstreamError is true for expired or other auth classes.
+func IsAuthRelatedUpstreamError(httpStatus int, message string) bool {
+	c := ClassifyUpstreamError(httpStatus, message)
+	return c == ClassExpired || c == ClassAuth
+}
+
+func isEndpointDispatchDeniedMessage(message string) bool {
+	text := strings.ToLower(message)
+	if text == "" {
+		return false
+	}
+	return endpointDispatchDeniedRe.MatchString(text) || strings.Contains(text, "dispatch denied")
+}
+
+func isRequestValidationFailure(text string) bool {
+	if text == "" {
+		return false
+	}
+	return strings.Contains(text, "invalid_argument") ||
+		strings.Contains(text, "invalid_request_error") ||
+		strings.Contains(text, "input token limit") ||
+		strings.Contains(text, "context length") ||
+		strings.Contains(text, "maximum context") ||
+		strings.Contains(text, "max_tokens") ||
+		strings.Contains(text, "max tokens") ||
+		strings.Contains(text, "string_above_max_length") ||
+		strings.Contains(text, "invalid request body") ||
+		strings.Contains(text, "validation error") ||
+		strings.Contains(text, "missing required")
+}
+
+func isCapabilityFailure(text string) bool {
+	if text == "" {
+		return false
+	}
+	return modelNotSupportedRe.MatchString(text) ||
+		strings.Contains(text, "not supported for format") ||
+		strings.Contains(text, "model not supported") ||
+		strings.Contains(text, "unsupported model") ||
+		strings.Contains(text, "does not support the model") ||
+		strings.Contains(text, "does not support model") ||
+		strings.Contains(text, "no such model") ||
+		strings.Contains(text, "unknown model") ||
+		strings.Contains(text, "model_not_found") ||
+		strings.Contains(text, "不支持所选模型") ||
+		(strings.Contains(text, "不支持") && strings.Contains(text, "模型"))
+}
+
+func isBillingFailure(text string) bool {
+	if text == "" {
+		return false
+	}
+	return strings.Contains(text, "no payment method") ||
+		strings.Contains(text, "payment method") ||
+		strings.Contains(text, "billing") ||
+		strings.Contains(text, "insufficient_quota") ||
+		strings.Contains(text, "insufficient quota") ||
+		strings.Contains(text, "quota exceeded") ||
+		strings.Contains(text, "exceeded your current quota") ||
+		strings.Contains(text, "credit balance") ||
+		strings.Contains(text, "out of credits") ||
+		strings.Contains(text, "余额不足") ||
+		strings.Contains(text, "额度不足") ||
+		strings.Contains(text, "配额不足") ||
+		strings.Contains(text, "充值")
+}
+
+func isTransientFailure(httpStatus int, text string) bool {
+	if httpStatus == 408 || httpStatus == 409 || httpStatus == 425 || httpStatus == 429 || httpStatus >= 500 {
+		return true
+	}
+	if text == "" {
+		return false
+	}
+	return strings.Contains(text, "rate limit") ||
+		strings.Contains(text, "rate_limit") ||
+		strings.Contains(text, "too many requests") ||
+		strings.Contains(text, "timeout") ||
+		strings.Contains(text, "timed out") ||
+		strings.Contains(text, "temporar") ||
+		strings.Contains(text, "service unavailable") ||
+		strings.Contains(text, "bad gateway") ||
+		strings.Contains(text, "gateway time") ||
+		strings.Contains(text, "connection reset") ||
+		strings.Contains(text, "connection refused") ||
+		strings.Contains(text, "econnreset") ||
+		strings.Contains(text, "econnrefused")
+}
+
+func isCloudflareChallengeMessage(text string) bool {
+	if text == "" {
+		return false
+	}
+	return strings.Contains(text, "cloudflare") ||
+		strings.Contains(text, "cf challenge") ||
+		strings.Contains(text, "challenge required")
+}
+
+func isStrongTokenExpiredSignal(text string) bool {
+	if text == "" {
+		return false
+	}
+	if strings.Contains(text, "jwt expired") ||
+		strings.Contains(text, "token expired") ||
+		strings.Contains(text, "access token expired") ||
+		invalidAccessTokenRe.MatchString(text) ||
+		accessTokenIsInvalidRe.MatchString(text) {
+		return true
+	}
+	return hasExplicitExpiryOrInvalidCredential(text)
+}
+
+func hasExplicitExpiryOrInvalidCredential(text string) bool {
+	if text == "" {
+		return false
+	}
+	if strings.Contains(text, "jwt expired") ||
+		strings.Contains(text, "token expired") ||
+		strings.Contains(text, "access token expired") ||
+		invalidAccessTokenRe.MatchString(text) ||
+		accessTokenIsInvalidRe.MatchString(text) {
+		return true
+	}
+	// Chinese credential expiry / invalidity.
+	if (strings.Contains(text, "令牌") || strings.Contains(text, "访问令牌")) &&
+		(strings.Contains(text, "过期") || strings.Contains(text, "无效")) {
+		return true
+	}
+	// Auth-oriented token ref + invalid/expired (not bare "token").
+	if hasAuthTokenReference(text) &&
+		(strings.Contains(text, "invalid") || strings.Contains(text, "expired") ||
+			strings.Contains(text, "无效") || strings.Contains(text, "过期")) {
+		return true
+	}
+	return false
+}
+
+func hasAuthTokenReference(text string) bool {
+	return authTokenRefRe.MatchString(text)
+}
+
+func hasAuthFailureSignal(text string) bool {
+	return authFailureSignalRe.MatchString(text)
+}
+
+func containsHTTPStatus(message string, status int) bool {
+	pattern := fmt.Sprintf(`(?:^|\b)(?:http\s*)?%d(?:\b|:)`, status)
+	re := regexp.MustCompile(pattern)
+	return re.MatchString(strings.ToLower(message))
+}

--- a/platform/error_classification_test.go
+++ b/platform/error_classification_test.go
@@ -1,0 +1,281 @@
+package platform
+
+import "testing"
+
+func TestClassifyUpstreamError_Matrix(t *testing.T) {
+	cases := []struct {
+		name       string
+		httpStatus int
+		message    string
+		wantClass  UpstreamErrorClass
+		wantMark   bool
+	}{
+		// expired / mark
+		{
+			name:       "jwt expired marks",
+			httpStatus: 0,
+			message:    "jwt expired",
+			wantClass:  ClassExpired,
+			wantMark:   true,
+		},
+		{
+			name:       "token expired marks",
+			httpStatus: 0,
+			message:    "token expired",
+			wantClass:  ClassExpired,
+			wantMark:   true,
+		},
+		{
+			name:       "invalid access token marks",
+			httpStatus: 0,
+			message:    "invalid access token",
+			wantClass:  ClassExpired,
+			wantMark:   true,
+		},
+		{
+			name:       "chinese token expired marks",
+			httpStatus: 0,
+			message:    "令牌已过期",
+			wantClass:  ClassExpired,
+			wantMark:   true,
+		},
+		{
+			name:       "bare 401 empty body marks (legacy)",
+			httpStatus: 401,
+			message:    "",
+			wantClass:  ClassExpired,
+			wantMark:   true,
+		},
+		{
+			name:       "HTTP 401 Unauthorized marks",
+			httpStatus: 0,
+			message:    "HTTP 401 Unauthorized",
+			wantClass:  ClassExpired,
+			wantMark:   true,
+		},
+
+		// validation — must NOT mark
+		{
+			name:       "invalid_argument input token limit is validation",
+			httpStatus: 400,
+			message:    "Error code: 400 - {'error': {'code': 'invalid_argument', 'message': 'input token limit is 202752', 'type': 'invalid_request_error'}}",
+			wantClass:  ClassValidation,
+			wantMark:   false,
+		},
+		{
+			name:       "401 body that is only validation must not mark",
+			httpStatus: 401,
+			message:    "invalid_request_error: max_tokens is too large",
+			wantClass:  ClassValidation,
+			wantMark:   false,
+		},
+		{
+			name:       "dispatch denied is validation",
+			httpStatus: 403,
+			message:    "does not allow /v1/chat/completions dispatch",
+			wantClass:  ClassValidation,
+			wantMark:   false,
+		},
+
+		// model — must NOT mark
+		{
+			name:       "401 model not supported is capability failure",
+			httpStatus: 401,
+			message:    "Model minimax-m3-free is not supported for format openai",
+			wantClass:  ClassModel,
+			wantMark:   false,
+		},
+		{
+			name:       "message with HTTP 401 model unsupported is not token expiry",
+			httpStatus: 0,
+			message:    "HTTP 401 - Model gemini-3.1-pro-preview is not supported",
+			wantClass:  ClassModel,
+			wantMark:   false,
+		},
+		{
+			name:       "chinese model unsupported is not token expiry",
+			httpStatus: 400,
+			message:    "当前API不支持所选模型",
+			wantClass:  ClassModel,
+			wantMark:   false,
+		},
+
+		// billing — must NOT mark
+		{
+			name:       "401 billing failure is not token expiry",
+			httpStatus: 401,
+			message:    "No payment method. Add a payment method here: https://example.com/billing",
+			wantClass:  ClassBilling,
+			wantMark:   false,
+		},
+		{
+			name:       "insufficient_quota is billing not expired",
+			httpStatus: 429,
+			message:    "You exceeded your current quota, please check your plan and billing details.",
+			wantClass:  ClassBilling,
+			wantMark:   false,
+		},
+		{
+			name:       "chinese balance insufficient is billing",
+			httpStatus: 403,
+			message:    "账户余额不足，请充值",
+			wantClass:  ClassBilling,
+			wantMark:   false,
+		},
+
+		// transient — must NOT mark
+		{
+			name:       "rate limit is transient",
+			httpStatus: 429,
+			message:    "rate limit exceeded",
+			wantClass:  ClassTransient,
+			wantMark:   false,
+		},
+		{
+			name:       "timeout is transient",
+			httpStatus: 0,
+			message:    "request timed out",
+			wantClass:  ClassTransient,
+			wantMark:   false,
+		},
+		{
+			name:       "5xx is transient",
+			httpStatus: 502,
+			message:    "bad gateway",
+			wantClass:  ClassTransient,
+			wantMark:   false,
+		},
+		{
+			name:       "cloudflare challenge is transient not expired",
+			httpStatus: 403,
+			message:    "Cloudflare challenge required",
+			wantClass:  ClassTransient,
+			wantMark:   false,
+		},
+
+		// auth residual / unknown — must NOT mark
+		{
+			name:       "newapi missing access token is auth not expired mark",
+			httpStatus: 401,
+			message:    "未登录且未提供 access token",
+			wantClass:  ClassAuth,
+			wantMark:   false,
+		},
+		{
+			name:       "opaque 401 body without auth signal does not mark",
+			httpStatus: 401,
+			message:    "upstream rejected the request",
+			wantClass:  ClassUnknown,
+			wantMark:   false,
+		},
+		{
+			name:       "input token alone is not credential expiry",
+			httpStatus: 0,
+			message:    "input token count too high for model",
+			wantClass:  ClassUnknown,
+			wantMark:   false,
+		},
+		{
+			name:       "connection timeout unknown/transient path",
+			httpStatus: 0,
+			message:    "connection timeout",
+			wantClass:  ClassTransient,
+			wantMark:   false,
+		},
+		{
+			name:       "empty message without status is unknown",
+			httpStatus: 0,
+			message:    "",
+			wantClass:  ClassUnknown,
+			wantMark:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotClass := ClassifyUpstreamError(tc.httpStatus, tc.message)
+			if gotClass != tc.wantClass {
+				t.Fatalf("ClassifyUpstreamError(%d, %q) = %q, want %q",
+					tc.httpStatus, tc.message, gotClass, tc.wantClass)
+			}
+			gotMark := ShouldMarkAccountExpired(tc.httpStatus, tc.message)
+			if gotMark != tc.wantMark {
+				t.Fatalf("ShouldMarkAccountExpired(%d, %q) = %v, want %v (class=%s)",
+					tc.httpStatus, tc.message, gotMark, tc.wantMark, gotClass)
+			}
+			// IsTokenExpiredError is the historical mark/relogin gate; keep aligned with mark.
+			if got := IsTokenExpiredError(tc.httpStatus, tc.message); got != tc.wantMark {
+				t.Fatalf("IsTokenExpiredError(%d, %q) = %v, want %v",
+					tc.httpStatus, tc.message, got, tc.wantMark)
+			}
+		})
+	}
+}
+
+func TestIsTokenExpiredError_NonAuthUpstreamNeverMarks(t *testing.T) {
+	// Table focused on the #24 false-positive guard: non-auth upstream errors
+	// must never be treated as token expiry for accounts.status='expired'.
+	cases := []struct {
+		name       string
+		httpStatus int
+		message    string
+	}{
+		{"validation invalid_argument", 400, "invalid_argument: input token limit is 202752"},
+		{"validation invalid_request_error", 400, "type: invalid_request_error"},
+		{"validation context length", 400, "This model's maximum context length is 128000 tokens"},
+		{"model unsupported openai format", 401, "Model foo is not supported for format openai"},
+		{"model unsupported generic", 401, "HTTP 401 - Model bar is not supported"},
+		{"model not found", 404, "model_not_found: no such model"},
+		{"billing payment method", 401, "No payment method. Add a payment method here: https://example.com/billing"},
+		{"billing insufficient quota", 429, "insufficient_quota: You exceeded your current quota"},
+		{"billing chinese balance", 403, "余额不足"},
+		{"rate limit", 429, "Rate limit reached for requests"},
+		{"too many requests", 429, "too many requests"},
+		{"dispatch denied", 403, "site does not allow /v1/chat/completions dispatch"},
+		{"dispatch denied phrase", 403, "A dispatch denied error occurred"},
+		{"newapi missing access token", 401, "未登录且未提供 access token"},
+		{"cloudflare", 403, "cf challenge detected"},
+		{"timeout", 0, "request timed out"},
+		{"5xx", 502, "bad gateway from upstream"},
+		{"opaque 401", 401, "upstream rejected the request"},
+		{"bare token word without auth", 0, "input token encoding failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if IsTokenExpiredError(tc.httpStatus, tc.message) {
+				t.Fatalf("IsTokenExpiredError(%d, %q) = true, want false", tc.httpStatus, tc.message)
+			}
+			if ShouldMarkAccountExpired(tc.httpStatus, tc.message) {
+				t.Fatalf("ShouldMarkAccountExpired(%d, %q) = true, want false", tc.httpStatus, tc.message)
+			}
+		})
+	}
+}
+
+func TestIsTokenExpiredError_PositiveAuthSignals(t *testing.T) {
+	cases := []struct {
+		name       string
+		httpStatus int
+		message    string
+	}{
+		{"jwt expired", 0, "jwt expired"},
+		{"token expired", 0, "token expired"},
+		{"invalid access token", 0, "invalid access token"},
+		{"access token is invalid", 0, "access token is invalid"},
+		{"access token chinese invalid", 0, "access token无效"},
+		{"访问令牌无效", 0, "访问令牌无效"},
+		{"令牌已过期", 0, "令牌已过期"},
+		{"bare 401", 401, ""},
+		{"HTTP 401 Unauthorized", 0, "HTTP 401 Unauthorized"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !IsTokenExpiredError(tc.httpStatus, tc.message) {
+				t.Fatalf("IsTokenExpiredError(%d, %q) = false, want true", tc.httpStatus, tc.message)
+			}
+			if !ShouldMarkAccountExpired(tc.httpStatus, tc.message) {
+				t.Fatalf("ShouldMarkAccountExpired(%d, %q) = false, want true", tc.httpStatus, tc.message)
+			}
+		})
+	}
+}

--- a/platform/newapi.go
+++ b/platform/newapi.go
@@ -792,6 +792,15 @@ func isMissingCheckinEndpointMessage(msg string) bool {
 }
 
 func isCookieSessionFailureMessage(msg string) bool {
+	// Session/cookie retry heuristic only — never marks accounts.status.
+	// Non-auth classes (billing/model/validation/transient) must not look like
+	// cookie session failures just because they mention "expired" or "token".
+	switch ClassifyUpstreamError(0, msg) {
+	case ClassExpired, ClassAuth:
+		return true
+	case ClassBilling, ClassModel, ClassValidation, ClassTransient:
+		return false
+	}
 	lower := strings.ToLower(msg)
 	return strings.Contains(lower, "access token") ||
 		strings.Contains(lower, "unauthorized") ||
@@ -799,7 +808,6 @@ func isCookieSessionFailureMessage(msg string) bool {
 		strings.Contains(lower, "new-api-user") ||
 		strings.Contains(lower, "user id") ||
 		strings.Contains(lower, "invalid token") ||
-		strings.Contains(lower, "expired") ||
 		strings.Contains(lower, "无权") ||
 		strings.Contains(lower, "未登录") ||
 		strings.Contains(lower, "未提供") ||

--- a/platform/newapi_test.go
+++ b/platform/newapi_test.go
@@ -378,8 +378,8 @@ func TestIsMissingCheckinEndpointMessage(t *testing.T) {
 
 func TestIsCookieSessionFailureMessage(t *testing.T) {
 	tests := []struct {
-		msg     string
-		isFail  bool
+		msg    string
+		isFail bool
 	}{
 		{"access token invalid", true},
 		{"unauthorized", true},
@@ -391,6 +391,11 @@ func TestIsCookieSessionFailureMessage(t *testing.T) {
 		{"not login", true},
 		{"success", false},
 		{"checkin completed", false},
+		// Non-auth residual: bare "expired" alone must not look like cookie session failure
+		// when the class is billing/model (R0).
+		{"No payment method. Add a payment method here: https://example.com/billing", false},
+		{"Model foo is not supported for format openai", false},
+		{"rate limit exceeded", false},
 	}
 	for _, tt := range tests {
 		if got := isCookieSessionFailureMessage(tt.msg); got != tt.isFail {

--- a/platform/oneapi.go
+++ b/platform/oneapi.go
@@ -256,17 +256,28 @@ func resolveGroupFetchErrorMessage(payload map[string]interface{}) string {
 	if msg == "" {
 		return "failed to fetch groups"
 	}
+	// UX rewrite only — does not mark accounts.status. Prefer auth-related
+	// classes; avoid rewriting pure billing/model/validation messages.
+	if IsAuthRelatedUpstreamError(0, msg) || IsTokenExpiredError(0, msg) {
+		return "账号会话可能已过期，请重新登录后再拉取分组"
+	}
+	// Keep a few historical session phrases that classify as auth residual.
 	lower := strings.ToLower(msg)
-	indicatesExpired := strings.Contains(lower, "expired") ||
-		strings.Contains(lower, "invalid token") ||
-		strings.Contains(lower, "access token") ||
+	if strings.Contains(lower, "未登录") ||
+		strings.Contains(lower, "not login") ||
+		strings.Contains(lower, "not logged") ||
 		strings.Contains(lower, "unauthorized") ||
 		strings.Contains(lower, "forbidden") ||
-		strings.Contains(lower, "未登录") ||
-		strings.Contains(lower, "登录") ||
-		strings.Contains(lower, "过期")
-	if indicatesExpired {
-		return "账号会话可能已过期，请重新登录后再拉取分组"
+		strings.Contains(lower, "invalid token") ||
+		strings.Contains(lower, "access token") {
+		// Exclude non-auth classes already handled by classifier above; if we
+		// still land here, rewrite only when not clearly billing/model/validation.
+		switch ClassifyUpstreamError(0, msg) {
+		case ClassBilling, ClassModel, ClassValidation, ClassTransient:
+			return msg
+		default:
+			return "账号会话可能已过期，请重新登录后再拉取分组"
+		}
 	}
 	return msg
 }

--- a/platform/oneapi_test.go
+++ b/platform/oneapi_test.go
@@ -196,6 +196,20 @@ func TestResolveGroupFetchErrorMessage(t *testing.T) {
 	if msg4 != "failed to fetch groups" {
 		t.Errorf("empty: %q", msg4)
 	}
+
+	// Non-auth messages must not be rewritten as session-expired UX (R0).
+	msg5 := resolveGroupFetchErrorMessage(map[string]interface{}{
+		"message": "No payment method. Add a payment method here: https://example.com/billing",
+	})
+	if msg5 != "No payment method. Add a payment method here: https://example.com/billing" {
+		t.Errorf("billing should not rewrite to session-expired: %q", msg5)
+	}
+	msg6 := resolveGroupFetchErrorMessage(map[string]interface{}{
+		"message": "Model foo is not supported for format openai",
+	})
+	if msg6 != "Model foo is not supported for format openai" {
+		t.Errorf("model unsupported should not rewrite to session-expired: %q", msg6)
+	}
 }
 
 func TestExtractGroupKeys(t *testing.T) {

--- a/proxy/surface.go
+++ b/proxy/surface.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
+	"github.com/tokendancelab/metapi-go/platform"
 	"github.com/tokendancelab/metapi-go/routing"
 )
 
@@ -273,6 +275,10 @@ func (ft *SurfaceFailureToolkit) HandleUpstreamFailure(
 		slog.Warn("LogProxy failed", "err", err, "channel_id", selected.Channel.ID, "model", modelName)
 	}
 
+	// Mark account expired only for ClassExpired (R0 guard). Non-auth 401s
+	// (billing/model/validation) must not flip accounts.status.
+	ft.maybeReportTokenExpired(selected, status, rawErrText, errText)
+
 	// Check retry
 	if ShouldRetryProxyRequest(status, errText) {
 		if retryCount < ft.MaxRetries {
@@ -295,6 +301,31 @@ func (ft *SurfaceFailureToolkit) HandleUpstreamFailure(
 			},
 		},
 	}
+}
+
+// maybeReportTokenExpired invokes ReportTokenExpired only when classification
+// says the credential is expired — never for billing/model/validation/transient.
+func (ft *SurfaceFailureToolkit) maybeReportTokenExpired(
+	selected SurfaceSelectedChannel,
+	status int,
+	rawErrText string,
+	errText string,
+) {
+	if ft.ReportTokenExpired == nil {
+		return
+	}
+	detail := strings.TrimSpace(rawErrText)
+	if detail == "" {
+		detail = strings.TrimSpace(errText)
+	}
+	if !platform.ShouldMarkAccountExpired(status, detail) {
+		return
+	}
+	var siteName *string
+	if selected.Site.Name != nil && strings.TrimSpace(*selected.Site.Name) != "" {
+		siteName = selected.Site.Name
+	}
+	ft.ReportTokenExpired(selected.Account.ID, selected.Account.Username, siteName, detail)
 }
 
 // HandleDetectedFailure handles a content-based failure detection.
@@ -341,6 +372,9 @@ func (ft *SurfaceFailureToolkit) HandleDetectedFailure(
 	}); err != nil {
 		slog.Warn("LogProxy failed", "err", err, "channel_id", selected.Channel.ID, "model", modelName)
 	}
+
+	// Content-based failures may still carry auth expiry text without HTTP 401.
+	ft.maybeReportTokenExpired(selected, failure.Status, failure.Reason, failure.Reason)
 
 	// Check retry
 	if ShouldRetryProxyRequest(failure.Status, failure.Reason) {

--- a/proxy/surface_test.go
+++ b/proxy/surface_test.go
@@ -105,6 +105,92 @@ func TestConvertToSurfaceSelectedChannel(t *testing.T) {
 	}
 }
 
+func TestHandleUpstreamFailure_TokenExpiredMarkGuard(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     int
+		errText    string
+		rawErrText string
+		wantMark   bool
+	}{
+		{
+			name:       "jwt expired marks",
+			status:     401,
+			errText:    "jwt expired",
+			rawErrText: "jwt expired",
+			wantMark:   true,
+		},
+		{
+			name:       "bare 401 empty body marks",
+			status:     401,
+			errText:    "",
+			rawErrText: "",
+			wantMark:   true,
+		},
+		{
+			name:       "billing 401 does not mark",
+			status:     401,
+			errText:    "No payment method. Add a payment method here: https://example.com/billing",
+			rawErrText: "No payment method. Add a payment method here: https://example.com/billing",
+			wantMark:   false,
+		},
+		{
+			name:       "model unsupported 401 does not mark",
+			status:     401,
+			errText:    "Model foo is not supported for format openai",
+			rawErrText: "Model foo is not supported for format openai",
+			wantMark:   false,
+		},
+		{
+			name:       "validation 400 does not mark",
+			status:     400,
+			errText:    "invalid_argument: input token limit is 202752",
+			rawErrText: "invalid_argument: input token limit is 202752",
+			wantMark:   false,
+		},
+		{
+			name:       "rate limit does not mark",
+			status:     429,
+			errText:    "rate limit exceeded",
+			rawErrText: "rate limit exceeded",
+			wantMark:   false,
+		},
+		{
+			name:       "opaque 401 does not mark",
+			status:     401,
+			errText:    "upstream rejected the request",
+			rawErrText: "upstream rejected the request",
+			wantMark:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var marked []string
+			toolkit, _ := makeToolkit(0)
+			toolkit.ReportTokenExpired = func(accountID int64, username *string, siteName *string, detail string) {
+				marked = append(marked, detail)
+			}
+			selected := makeSurfaceSelectedChannel(7)
+			username := "acct"
+			selected.Account.Username = &username
+
+			_ = toolkit.HandleUpstreamFailure(
+				context.Background(), selected, "gpt-4", "gpt-4",
+				tc.status, tc.errText, tc.rawErrText,
+				false, 100, 0,
+			)
+
+			if tc.wantMark && len(marked) != 1 {
+				t.Fatalf("expected mark, got %v", marked)
+			}
+			if !tc.wantMark && len(marked) != 0 {
+				t.Fatalf("expected no mark, got %v", marked)
+			}
+		})
+	}
+}
+
 func TestHandleUpstreamFailure(t *testing.T) {
 	t.Run("retryable failure within maxRetries", func(t *testing.T) {
 		toolkit, state := makeToolkit(2)

--- a/service/alert/alert_test.go
+++ b/service/alert/alert_test.go
@@ -146,11 +146,29 @@ func TestIsTokenExpiredError_ExcludesNonAuthUpstreamFailures(t *testing.T) {
 			httpStatus: 0,
 			message:    "HTTP 401 - Model gemini-3.1-pro-preview is not supported",
 		},
+		{
+			name:       "insufficient_quota is billing not expired",
+			httpStatus: 429,
+			message:    "You exceeded your current quota, please check your plan and billing details.",
+		},
+		{
+			name:       "rate limit is not expired",
+			httpStatus: 429,
+			message:    "rate limit exceeded",
+		},
+		{
+			name:       "opaque 401 without auth signal is not expired",
+			httpStatus: 401,
+			message:    "upstream rejected the request",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if IsTokenExpiredError(tc.httpStatus, tc.message) {
 				t.Fatalf("IsTokenExpiredError(%d, %q) = true, want false", tc.httpStatus, tc.message)
+			}
+			if ShouldMarkAccountExpired(tc.httpStatus, tc.message) {
+				t.Fatalf("ShouldMarkAccountExpired(%d, %q) = true, want false", tc.httpStatus, tc.message)
 			}
 		})
 	}
@@ -178,20 +196,6 @@ func TestIsTokenExpiredError_Negative(t *testing.T) {
 				t.Errorf("expected false for: %q", msg)
 			}
 		})
-	}
-}
-
-// ---- containsHTTPStatus Tests ----
-
-func TestContainsHTTPStatus(t *testing.T) {
-	if !containsHTTPStatus("HTTP 401 Unauthorized", 401) {
-		t.Error("expected true for HTTP 401 in message")
-	}
-	if containsHTTPStatus("HTTP 200 OK", 401) {
-		t.Error("expected false for HTTP 200")
-	}
-	if !containsHTTPStatus("401 error", 401) {
-		t.Error("expected true for bare 401")
 	}
 }
 

--- a/service/alert/rules.go
+++ b/service/alert/rules.go
@@ -1,20 +1,12 @@
 package alert
 
 import (
-	"fmt"
-	"regexp"
 	"strings"
+
+	"github.com/tokendancelab/metapi-go/platform"
 )
 
 const sessionTokenRebindHint = "请在中转站重新生成系统访问令牌后重新绑定账号"
-
-var (
-	endpointDispatchDeniedRe    = regexp.MustCompile(`does\s+not\s+allow\s+/v1/[a-z0-9/_:-]+\s+dispatch`)
-	invalidAccessTokenRe        = regexp.MustCompile(`invalid\s+access\s+token`)
-	accessTokenIsInvalidRe      = regexp.MustCompile(`access\s+token\s+is\s+invalid`)
-	modelNotSupportedRe         = regexp.MustCompile(`model\s+.+\s+is\s+not\s+supported`)
-	accessTokenChineseInvalidRe = regexp.MustCompile(`access\s+token.*无效`)
-)
 
 // IsCloudflareChallenge detects Cloudflare challenge messages.
 // Mirrors TS isCloudflareChallenge().
@@ -28,76 +20,16 @@ func IsCloudflareChallenge(message string) bool {
 		strings.Contains(text, "challenge required")
 }
 
-// isEndpointDispatchDeniedMessage detects dispatch denied messages (not token expired).
-func isEndpointDispatchDeniedMessage(message string) bool {
-	text := strings.ToLower(message)
-	if text == "" {
-		return false
-	}
-	return endpointDispatchDeniedRe.MatchString(text) || strings.Contains(text, "dispatch denied")
-}
-
 // IsTokenExpiredError detects if an error indicates an expired token.
-// Mirrors TS isTokenExpiredError().
+// Delegates to platform.ClassifyUpstreamError / IsTokenExpiredError (R0 SSOT).
+// Mirrors TS isTokenExpiredError() with tighter non-auth guards.
 func IsTokenExpiredError(httpStatus int, message string) bool {
-	rawMessage := message
-	text := strings.ToLower(strings.TrimSpace(message))
-
-	// Exclude dispatch denied messages
-	if isEndpointDispatchDeniedMessage(rawMessage) {
-		return false
-	}
-
-	if text == "" {
-		return httpStatus == 401
-	}
-
-	// NewAPI-specific: "未登录且未提供 access token" doesn't always mean token expired
-	if strings.Contains(text, "未登录且未提供 access token") {
-		return false
-	}
-
-	if isRequestValidationFailure(text) || isCapabilityOrBillingFailure(text) {
-		return false
-	}
-
-	// Check HTTP 401 after explicit non-auth failure exclusions.
-	if httpStatus == 401 || containsHTTPStatus(rawMessage, 401) {
-		return true
-	}
-
-	tokenPhrase := strings.Contains(text, "token") || strings.Contains(text, "令牌") || strings.Contains(text, "访问令牌")
-	hasInvalid := strings.Contains(text, "invalid") || strings.Contains(text, "无效")
-	hasExpired := strings.Contains(text, "expired") || strings.Contains(text, "过期")
-
-	return strings.Contains(text, "jwt expired") ||
-		strings.Contains(text, "token expired") ||
-		(tokenPhrase && (hasInvalid || hasExpired)) ||
-		invalidAccessTokenRe.MatchString(text) ||
-		accessTokenIsInvalidRe.MatchString(text)
+	return platform.IsTokenExpiredError(httpStatus, message)
 }
 
-func isRequestValidationFailure(text string) bool {
-	return strings.Contains(text, "invalid_argument") ||
-		strings.Contains(text, "invalid_request_error") ||
-		strings.Contains(text, "input token limit") ||
-		strings.Contains(text, "context length") ||
-		strings.Contains(text, "maximum context")
-}
-
-func isCapabilityOrBillingFailure(text string) bool {
-	return modelNotSupportedRe.MatchString(text) ||
-		strings.Contains(text, "not supported for format") ||
-		strings.Contains(text, "no payment method") ||
-		strings.Contains(text, "payment method") ||
-		strings.Contains(text, "billing")
-}
-
-// containsHTTPStatus checks if a message contains an HTTP status code.
-func containsHTTPStatus(message string, status int) bool {
-	pattern := fmt.Sprintf(`(?:^|\b)(?:http\s*)?%d(?:\b|:)`, status)
-	re := regexp.MustCompile(pattern)
-	return re.MatchString(strings.ToLower(message))
+// ShouldMarkAccountExpired is the guard before writing accounts.status='expired'.
+func ShouldMarkAccountExpired(httpStatus int, message string) bool {
+	return platform.ShouldMarkAccountExpired(httpStatus, message)
 }
 
 // AppendSessionTokenRebindHint appends rebind hint to invalid access token messages.
@@ -114,9 +46,9 @@ func AppendSessionTokenRebindHint(message string) string {
 	text := strings.ToLower(raw)
 	looksLikeInvalidAccessToken :=
 		strings.Contains(raw, "无权进行此操作，access token 无效") ||
-			invalidAccessTokenRe.MatchString(text) ||
-			accessTokenIsInvalidRe.MatchString(text) ||
-			accessTokenChineseInvalidRe.MatchString(raw)
+			strings.Contains(text, "invalid access token") ||
+			strings.Contains(text, "access token is invalid") ||
+			(strings.Contains(text, "access token") && strings.Contains(raw, "无效"))
 
 	if !looksLikeInvalidAccessToken {
 		return raw


### PR DESCRIPTION
Closes #24. Lane: lane-reliability. SSOT classification + tests; non-auth errors must not mark expired.