### PR TITLE
feat(schema): SC1 additive dual-dialect migration strategy

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -206,6 +206,158 @@ The SQLite database is never modified by the migration tool (it only reads). You
 | Container image | ~80MB+ | <25MB |
 | CI/CD | Manual / CD-only | Full CI (lint + test + build) |
 
+## Additive enterprise upgrades
+
+**Issue:** [SC1 #21](https://github.com/TokenDanceLab/metapi-go/issues/21)  
+**Depends on:** [SC0 #20](https://github.com/TokenDanceLab/metapi-go/issues/20) (`docs/analysis/schema-parity.md`)  
+**Implements product columns:** [SC2 #22](https://github.com/TokenDanceLab/metapi-go/issues/22)
+
+This section is the operator-facing contract for **forward-only schema upgrades**
+on existing SQLite and PostgreSQL installs. It complements the one-shot
+TS→Go / SQLite→PG data transfer tool above.
+
+### Why CREATE TABLE IF NOT EXISTS is not enough
+
+Startup already runs `store.AutoMigrate`:
+
+1. **Base bootstrap** — `CREATE TABLE IF NOT EXISTS` for all 27 product tables +
+   `CREATE INDEX IF NOT EXISTS` for non-unique indexes.
+2. **Additive upgrades** — ordered steps recorded in `schema_migrations`.
+
+`CREATE TABLE IF NOT EXISTS` only creates **missing tables**. It never adds
+columns to a table that already exists. Enterprise upgrades such as:
+
+| Column | Table | Default / meaning |
+|:-------|:------|:------------------|
+| `proxy_url` | `downstream_api_keys` | `NULL` → fall back to site / system proxy |
+| `max_concurrency` | `sites` | `NULL` or `0` → unlimited (current behavior) |
+| `context_length` | `token_routes` (or catalog) | `NULL` → unknown / no enforcement |
+
+must use **`ALTER TABLE … ADD COLUMN`** (or new tables) on live databases. SC1
+ships the dual-dialect machinery; SC2 registers the concrete steps.
+
+### Versioning model
+
+Bookkeeping table (created automatically on every startup):
+
+```sql
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  version     TEXT PRIMARY KEY,
+  applied_at  TEXT NOT NULL,   -- ISO-8601 UTC, app-filled
+  description TEXT
+);
+```
+
+| Rule | Detail |
+|:-----|:-------|
+| Version ID | Stable **string** primary key (e.g. `sc2_001_downstream_proxy_url`), not a dense integer sequence |
+| Ordering | Registry order in `store/additive.go` (`enterpriseAdditiveSteps`); append-only |
+| Applied set | `SELECT version FROM schema_migrations`; skip if already present |
+| Fresh install | Base DDL creates full current tables; additive steps that only `EnsureColumn` become no-ops if the column is already in CREATE TABLE, then still get a bookkeeping row when registered |
+| Old install | Missing columns are added; defaults preserve pre-upgrade behavior |
+| Concurrency | `INSERT OR IGNORE` (SQLite) / `ON CONFLICT DO NOTHING` (PG) when marking applied |
+
+**Do not** renumber, rename, or delete a shipped `version` string. New work is
+always a new ID appended to the registry.
+
+### How new columns get defaults
+
+Additive columns must leave **old rows and old clients** behaving as today:
+
+1. Prefer **nullable** columns with application-level fallback  
+   (`NULL` = “feature off / use previous resolver path”).
+2. Or **`DEFAULT`** values that encode the historical unlimited / empty behavior  
+   (e.g. `max_concurrency DEFAULT 0` meaning unlimited).
+3. Never add `NOT NULL` without a default on an existing table (blocks upgrade).
+4. Never change type, rename, or drop columns in an additive step.
+5. Dual-dialect type fragments:
+   - booleans: SQLite `INTEGER` + `DEFAULT 0/1`; PG `BOOLEAN` + `DEFAULT FALSE/TRUE`
+   - floats: SQLite `REAL`; PG **`DOUBLE PRECISION`** (never bare PG `REAL`)
+   - JSON: always `TEXT` (app marshal), not PG `JSONB`
+   - datetimes: `TEXT` ISO-8601 filled by the app
+
+Primitive used by SC2 steps:
+
+```go
+// store.EnsureColumn — inspects then ALTER TABLE ADD COLUMN if missing
+EnsureColumn(db, "downstream_api_keys", "proxy_url", "TEXT", "TEXT", "")
+EnsureColumn(db, "sites", "max_concurrency", "INTEGER", "INTEGER", "DEFAULT 0")
+```
+
+`columnExists` uses `PRAGMA table_info` on SQLite and
+`information_schema.columns` on PostgreSQL.
+
+### Dual-dialect notes
+
+| Concern | SQLite | PostgreSQL |
+|:--------|:-------|:-----------|
+| Base bootstrap | `INTEGER PRIMARY KEY AUTOINCREMENT`, bool as INTEGER | `SERIAL PRIMARY KEY`, native BOOLEAN, DOUBLE PRECISION |
+| Additive DDL | `ALTER TABLE … ADD COLUMN` | Same (PG also supports `IF NOT EXISTS` on newer versions; we use inspect-then-add for both) |
+| Index create | `CREATE INDEX IF NOT EXISTS` | Same |
+| Bookkeeping insert | `INSERT OR IGNORE` | `ON CONFLICT (version) DO NOTHING` |
+| Placeholders | `?` | `?` rebound to `$N` via `store.DB` |
+| Startup path | `EnsureRuntimeDatabase` → `AutoMigrate` → `ApplyAdditiveMigrations` | Same |
+
+The standalone `metapi-migrate` binary (**SQLite → PostgreSQL data copy**) is
+orthogonal: it transfers rows after the target schema exists. Additive upgrades
+run inside the **server** process on whatever dialect is configured. After a
+SQLite→PG transfer, start the Go server once so base + additive migrations run
+on the PG target (or rely on the migrator’s minimal `ensureTargetSchema` plus a
+server boot).
+
+### Safe upgrade path for existing deployments
+
+1. **Back up** the database (SQLite file copy or `pg_dump`).
+2. Deploy the new binary (or image). No separate migrate CLI is required for
+   additive column upgrades.
+3. On first start, logs should include:
+   - `store: running auto-migration`
+   - `store: applying additive migration` (only for pending versions)
+   - `store: auto-migration complete`
+4. Verify with health/ready endpoints and a spot-check of row counts.
+5. Optional: inspect bookkeeping  
+   `SELECT version, applied_at, description FROM schema_migrations ORDER BY applied_at;`
+
+Failed steps **do not** write a `schema_migrations` row. The next process start
+retries the same version. Steps should keep DDL idempotent (`EnsureColumn`) so a
+crash between `ALTER TABLE` and the bookkeeping insert recovers cleanly.
+
+### Rollback philosophy
+
+Additive migrations are **forward-only**:
+
+| Policy | Rationale |
+|:-------|:----------|
+| No automatic `DROP COLUMN` / down migrations | Dual-dialect drop semantics differ; dropping data is operator-dangerous |
+| Binary rollback | Older binaries ignore unknown columns; keep defaults so old code paths remain valid |
+| True rollback of data | Restore from pre-upgrade backup (SQLite file or `pg_dump`) |
+| Failed deploy | Fix forward (new additive step or hotfix); do not rewrite history in `schema_migrations` |
+| Column retirement (rare) | Stop writing the column in app code first; physical drop is a later, explicit ops task outside SC1 |
+
+**Compatibility invariant:** every additive column’s default / NULL semantics
+must preserve pre-upgrade behavior until a feature flag or UI explicitly opts in.
+
+### Code map (SC1)
+
+| Path | Role |
+|:-----|:-----|
+| `store/migrate.go` | Base 27-table DDL; `AutoMigrate` calls `ApplyAdditiveMigrations` |
+| `store/additive.go` | `schema_migrations`, `ApplyAdditiveMigrations`, `EnsureColumn`, `columnExists` |
+| `store/additive_test.go` | SQLite unit tests + optional PG (`PG_TEST_DSN`) dual-dialect smoke |
+| `docs/analysis/schema-parity.md` §5 | Product column proposals for SC2 |
+| `cmd/migrate/` | **Not** the additive engine — SQLite→PG **data** transfer only |
+
+### SC2 registration checklist
+
+When implementing enterprise columns:
+
+1. Add / update Go structs in `store/schema.go` and base `CREATE TABLE` builders
+   so **new** installs get the column from bootstrap.
+2. Append an `AdditiveStep` with a new `version` that calls `EnsureColumn` (and
+   optional `EnsureIndex`) so **old** installs converge.
+3. Keep defaults compatible; wire feature code to treat NULL/0 as “legacy”.
+4. Extend dual-dialect tests; run `go test ./store/ -count=1` (and PG if available).
+
 ## Troubleshooting
 
 ### "web/dist: no matching files found" at build time
@@ -223,3 +375,11 @@ Ensure you are using `--overwrite` (default). The migration tool deletes data in
 ### Server exits with "AUTH_TOKEN is required"
 
 Set the `AUTH_TOKEN` environment variable. Both `AUTH_TOKEN` and `PROXY_TOKEN` are required.
+
+### Additive migration fails on startup
+
+1. Read the log line `store: additive migration <version>: …` for the failing step.
+2. Confirm disk / DB permissions and that the dialect matches `DB_TYPE`.
+3. After fixing, restart — pending versions retry automatically.
+4. Do not manually delete rows from `schema_migrations` unless recovering from a
+   partial operator experiment; prefer re-running with idempotent steps.

--- a/store/additive.go
+++ b/store/additive.go
@@ -1,0 +1,260 @@
+package store
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// AdditiveStep is one forward-only schema change applied after the base
+// CREATE TABLE IF NOT EXISTS bootstrap. Steps must be additive (new tables,
+// columns, indexes) and safe to re-attempt if bookkeeping is incomplete.
+//
+// Version IDs are stable strings (not integers) so SC2+ can insert descriptive
+// IDs such as "sc2_001_downstream_proxy_url" without renumbering history.
+type AdditiveStep struct {
+	// Version is the primary key stored in schema_migrations.
+	Version string
+	// Description is a short human-readable note for operators and logs.
+	Description string
+	// Apply performs the DDL/DML for this step. It should be idempotent where
+	// practical (e.g. EnsureColumn) so a crash between DDL and bookkeeping
+	// does not break the next startup.
+	Apply func(db *DB) error
+}
+
+// enterpriseAdditiveSteps is the ordered registry of production additive
+// upgrades. SC1 ships the bookkeeping machinery only; SC2 registers the
+// enterprise columns documented in docs/analysis/schema-parity.md §5.
+//
+// Keep this list append-only. Never edit or remove a shipped Version string.
+var enterpriseAdditiveSteps = []AdditiveStep{
+	// SC2 candidates (not registered until product code lands):
+	//   sc2_001_downstream_proxy_url  — downstream_api_keys.proxy_url TEXT NULL
+	//   sc2_002_site_max_concurrency  — sites.max_concurrency INTEGER NULL / DEFAULT 0
+	//   sc2_003_route_context_length  — token_routes.context_length INTEGER NULL
+}
+
+// schemaMigrationsDDL creates the version bookkeeping table.
+// Dual-dialect identical: text PK + ISO-8601 applied_at filled by the app.
+const schemaMigrationsDDL = `CREATE TABLE IF NOT EXISTS schema_migrations (
+	version TEXT PRIMARY KEY,
+	applied_at TEXT NOT NULL,
+	description TEXT
+)`
+
+// ensureSchemaMigrationsTable creates the schema_migrations bookkeeping table.
+func ensureSchemaMigrationsTable(db *DB) error {
+	if _, err := db.Exec(schemaMigrationsDDL); err != nil {
+		return fmt.Errorf("store: create schema_migrations: %w", err)
+	}
+	return nil
+}
+
+// appliedVersions returns the set of Version strings already recorded.
+func appliedVersions(db *DB) (map[string]struct{}, error) {
+	rows, err := db.Query(`SELECT version FROM schema_migrations`)
+	if err != nil {
+		return nil, fmt.Errorf("store: list schema_migrations: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]struct{})
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return nil, fmt.Errorf("store: scan schema_migrations: %w", err)
+		}
+		out[v] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: iterate schema_migrations: %w", err)
+	}
+	return out, nil
+}
+
+// markMigrationApplied records a successful step. Uses INSERT OR IGNORE /
+// ON CONFLICT DO NOTHING so a concurrent or retried mark is safe.
+func markMigrationApplied(db *DB, version, description string) error {
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	var q string
+	if db.Dialect == DialectPostgres {
+		q = `INSERT INTO schema_migrations (version, applied_at, description)
+			VALUES (?, ?, ?)
+			ON CONFLICT (version) DO NOTHING`
+	} else {
+		q = `INSERT OR IGNORE INTO schema_migrations (version, applied_at, description)
+			VALUES (?, ?, ?)`
+	}
+	if _, err := db.Exec(q, version, now, description); err != nil {
+		return fmt.Errorf("store: mark migration %s: %w", version, err)
+	}
+	return nil
+}
+
+// ApplyAdditiveMigrations ensures the bookkeeping table exists, then runs any
+// pending enterpriseAdditiveSteps in registry order. Safe on fresh and old DBs.
+func ApplyAdditiveMigrations(db *DB) error {
+	return applyAdditiveMigrations(db, enterpriseAdditiveSteps)
+}
+
+// applyAdditiveMigrations is the testable core that accepts an explicit step list.
+func applyAdditiveMigrations(db *DB, steps []AdditiveStep) error {
+	if db == nil {
+		return fmt.Errorf("store: ApplyAdditiveMigrations: db is nil")
+	}
+
+	if err := ensureSchemaMigrationsTable(db); err != nil {
+		return err
+	}
+
+	applied, err := appliedVersions(db)
+	if err != nil {
+		return err
+	}
+
+	for _, step := range steps {
+		if step.Version == "" {
+			return fmt.Errorf("store: additive step missing version")
+		}
+		if _, ok := applied[step.Version]; ok {
+			continue
+		}
+		if step.Apply == nil {
+			return fmt.Errorf("store: additive step %s has nil Apply", step.Version)
+		}
+
+		slog.Info("store: applying additive migration",
+			"version", step.Version,
+			"description", step.Description,
+			"dialect", db.Dialect,
+		)
+		if err := step.Apply(db); err != nil {
+			return fmt.Errorf("store: additive migration %s: %w", step.Version, err)
+		}
+		if err := markMigrationApplied(db, step.Version, step.Description); err != nil {
+			return err
+		}
+		applied[step.Version] = struct{}{}
+	}
+
+	return nil
+}
+
+// columnExists reports whether table.column is present.
+// SQLite: PRAGMA table_info; PostgreSQL: information_schema.columns.
+func columnExists(db *DB, table, column string) (bool, error) {
+	table = strings.TrimSpace(table)
+	column = strings.TrimSpace(column)
+	if table == "" || column == "" {
+		return false, fmt.Errorf("store: columnExists: empty table or column")
+	}
+
+	if db.Dialect == DialectPostgres {
+		var n int
+		err := db.QueryRow(`
+			SELECT COUNT(*) FROM information_schema.columns
+			WHERE table_schema = current_schema()
+			  AND table_name = ?
+			  AND column_name = ?`, table, column).Scan(&n)
+		if err != nil {
+			return false, fmt.Errorf("store: columnExists(%s.%s) pg: %w", table, column, err)
+		}
+		return n > 0, nil
+	}
+
+	// SQLite — PRAGMA table_info does not accept bound parameters for the table name.
+	// Table names come only from our own registry / tests (not user input).
+	rows, err := db.Query(fmt.Sprintf(`PRAGMA table_info(%s)`, quoteIdentSQLite(table)))
+	if err != nil {
+		return false, fmt.Errorf("store: columnExists(%s.%s) sqlite: %w", table, column, err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid, notNull, pk int
+		var name, colType string
+		var dflt *string
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &dflt, &pk); err != nil {
+			return false, fmt.Errorf("store: columnExists scan: %w", err)
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+// quoteIdentSQLite double-quotes a simple identifier for PRAGMA use.
+// Rejects identifiers that are not alphanumeric/underscore to avoid injection.
+func quoteIdentSQLite(name string) string {
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+			continue
+		}
+		// Fall back to empty quoted form; callers validate names from registry.
+		return `""`
+	}
+	return `"` + name + `"`
+}
+
+// EnsureColumn adds table.column if missing. Types are dialect-specific
+// fragments (e.g. sqliteType="TEXT", pgType="TEXT", or INTEGER vs BOOLEAN).
+// defaultClause is optional SQL after the type (e.g. "DEFAULT 0" or "DEFAULT FALSE");
+// pass "" for nullable columns with no default (NULL → old behavior).
+//
+// This is the primary primitive SC2 uses for enterprise columns.
+func EnsureColumn(db *DB, table, column, sqliteType, pgType, defaultClause string) error {
+	exists, err := columnExists(db, table, column)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	colType := sqliteType
+	if db.Dialect == DialectPostgres {
+		colType = pgType
+	}
+	colType = strings.TrimSpace(colType)
+	if colType == "" {
+		return fmt.Errorf("store: EnsureColumn %s.%s: empty type for dialect %s", table, column, db.Dialect)
+	}
+
+	// Validate identifiers from registry only.
+	if quoteIdentSQLite(table) == `""` || quoteIdentSQLite(column) == `""` {
+		return fmt.Errorf("store: EnsureColumn: invalid identifier %q.%q", table, column)
+	}
+
+	def := strings.TrimSpace(defaultClause)
+	var ddl string
+	if def == "" {
+		ddl = fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s`, table, column, colType)
+	} else {
+		ddl = fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s %s`, table, column, colType, def)
+	}
+
+	if _, err := db.Exec(ddl); err != nil {
+		// Race / concurrent startup: column may already exist.
+		if existsNow, checkErr := columnExists(db, table, column); checkErr == nil && existsNow {
+			return nil
+		}
+		return fmt.Errorf("store: EnsureColumn %s.%s: %w", table, column, err)
+	}
+	slog.Info("store: added column", "table", table, "column", column, "dialect", db.Dialect)
+	return nil
+}
+
+// EnsureIndex creates a non-unique index if missing. Both dialects support
+// CREATE INDEX IF NOT EXISTS.
+func EnsureIndex(db *DB, name, createSQL string) error {
+	if strings.TrimSpace(name) == "" || strings.TrimSpace(createSQL) == "" {
+		return fmt.Errorf("store: EnsureIndex: empty name or SQL")
+	}
+	if _, err := db.Exec(createSQL); err != nil {
+		return fmt.Errorf("store: EnsureIndex %s: %w", name, err)
+	}
+	return nil
+}

--- a/store/additive_test.go
+++ b/store/additive_test.go
@@ -1,0 +1,344 @@
+package store
+
+import (
+	"testing"
+)
+
+// TestSchemaMigrationsTableCreated verifies AutoMigrate creates the
+// schema_migrations bookkeeping table even when no additive steps are registered.
+func TestSchemaMigrationsTableCreated(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+
+	var name string
+	err = db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'`).Scan(&name)
+	if err != nil {
+		t.Fatalf("schema_migrations table missing: %v", err)
+	}
+	if name != "schema_migrations" {
+		t.Errorf("unexpected table name %q", name)
+	}
+}
+
+// TestApplyAdditiveMigrationsEmptyRegistry is a no-op when no steps are registered.
+func TestApplyAdditiveMigrationsEmptyRegistry(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+
+	// Empty registry: still succeeds and leaves zero rows.
+	if err := ApplyAdditiveMigrations(db); err != nil {
+		t.Fatalf("ApplyAdditiveMigrations empty: %v", err)
+	}
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 applied migrations with empty registry, got %d", n)
+	}
+}
+
+// TestEnsureColumnSQLite adds a column to an existing table and is idempotent.
+func TestEnsureColumnSQLite(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+
+	// Column must not exist yet.
+	exists, err := columnExists(db, "sites", "max_concurrency")
+	if err != nil {
+		t.Fatalf("columnExists: %v", err)
+	}
+	if exists {
+		t.Fatal("expected sites.max_concurrency to be absent before EnsureColumn")
+	}
+
+	if err := EnsureColumn(db, "sites", "max_concurrency", "INTEGER", "INTEGER", "DEFAULT 0"); err != nil {
+		t.Fatalf("EnsureColumn first: %v", err)
+	}
+	exists, err = columnExists(db, "sites", "max_concurrency")
+	if err != nil {
+		t.Fatalf("columnExists after add: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected sites.max_concurrency after EnsureColumn")
+	}
+
+	// Second call must be a no-op (idempotent).
+	if err := EnsureColumn(db, "sites", "max_concurrency", "INTEGER", "INTEGER", "DEFAULT 0"); err != nil {
+		t.Fatalf("EnsureColumn second: %v", err)
+	}
+
+	// Existing rows get the default.
+	now := "2026-07-16T00:00:00.000Z"
+	_, err = db.Exec(`INSERT INTO sites (name, url, platform, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+		"s1", "https://example.com", "openai", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	var mc int
+	if err := db.QueryRow(`SELECT max_concurrency FROM sites WHERE name = ?`, "s1").Scan(&mc); err != nil {
+		t.Fatalf("select max_concurrency: %v", err)
+	}
+	if mc != 0 {
+		t.Errorf("expected default 0, got %d", mc)
+	}
+}
+
+// TestEnsureColumnNullableNoDefault models per-key proxy: NULL means fall back.
+func TestEnsureColumnNullableNoDefault(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+
+	if err := EnsureColumn(db, "downstream_api_keys", "proxy_url", "TEXT", "TEXT", ""); err != nil {
+		t.Fatalf("EnsureColumn proxy_url: %v", err)
+	}
+
+	now := "2026-07-16T00:00:00.000Z"
+	_, err = db.Exec(`INSERT INTO downstream_api_keys (name, key, created_at, updated_at) VALUES (?, ?, ?, ?)`,
+		"k1", "sk-test", now, now)
+	if err != nil {
+		t.Fatalf("insert key: %v", err)
+	}
+
+	var proxy *string
+	if err := db.QueryRow(`SELECT proxy_url FROM downstream_api_keys WHERE key = ?`, "sk-test").Scan(&proxy); err != nil {
+		t.Fatalf("select proxy_url: %v", err)
+	}
+	if proxy != nil {
+		t.Errorf("expected NULL proxy_url (old behavior), got %q", *proxy)
+	}
+}
+
+// TestAdditiveStepRegistryAppliesOnce exercises the version bookkeeping path
+// with an explicit step list (does not mutate the production registry).
+func TestAdditiveStepRegistryAppliesOnce(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+
+	var applyCount int
+	steps := []AdditiveStep{
+		{
+			Version:     "test_001_sites_context_probe",
+			Description: "test-only additive column",
+			Apply: func(db *DB) error {
+				applyCount++
+				return EnsureColumn(db, "token_routes", "context_length", "INTEGER", "INTEGER", "")
+			},
+		},
+	}
+
+	if err := applyAdditiveMigrations(db, steps); err != nil {
+		t.Fatalf("first ApplyAdditiveMigrations: %v", err)
+	}
+	if applyCount != 1 {
+		t.Fatalf("expected Apply once, got %d", applyCount)
+	}
+
+	// Second run must skip (bookkeeping hit).
+	if err := applyAdditiveMigrations(db, steps); err != nil {
+		t.Fatalf("second ApplyAdditiveMigrations: %v", err)
+	}
+	if applyCount != 1 {
+		t.Fatalf("expected Apply still once after re-run, got %d", applyCount)
+	}
+
+	var version, desc string
+	err = db.QueryRow(`SELECT version, description FROM schema_migrations WHERE version = ?`,
+		"test_001_sites_context_probe").Scan(&version, &desc)
+	if err != nil {
+		t.Fatalf("bookkeeping row missing: %v", err)
+	}
+	if version != "test_001_sites_context_probe" {
+		t.Errorf("version = %q", version)
+	}
+
+	exists, err := columnExists(db, "token_routes", "context_length")
+	if err != nil {
+		t.Fatalf("columnExists: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected token_routes.context_length after step")
+	}
+}
+
+// TestAdditiveStepIdempotentWithoutBookkeeping simulates a crash between DDL
+// and INSERT into schema_migrations: re-run must succeed because EnsureColumn
+// is idempotent, then bookkeeping is written.
+func TestAdditiveStepIdempotentWithoutBookkeeping(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+
+	// Pre-apply DDL without bookkeeping.
+	if err := EnsureColumn(db, "sites", "max_concurrency", "INTEGER", "INTEGER", "DEFAULT 0"); err != nil {
+		t.Fatalf("pre EnsureColumn: %v", err)
+	}
+
+	steps := []AdditiveStep{
+		{
+			Version:     "test_002_max_concurrency",
+			Description: "crash-recovery simulation",
+			Apply: func(db *DB) error {
+				return EnsureColumn(db, "sites", "max_concurrency", "INTEGER", "INTEGER", "DEFAULT 0")
+			},
+		},
+	}
+
+	if err := applyAdditiveMigrations(db, steps); err != nil {
+		t.Fatalf("Apply after partial DDL: %v", err)
+	}
+
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations WHERE version = ?`,
+		"test_002_max_concurrency").Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected bookkeeping row, got count %d", n)
+	}
+}
+
+// TestApplyAdditiveMigrationsNilDB returns an error instead of panicking.
+func TestApplyAdditiveMigrationsNilDB(t *testing.T) {
+	if err := ApplyAdditiveMigrations(nil); err == nil {
+		t.Fatal("expected error for nil db")
+	}
+}
+
+// TestEnsureColumnInvalidIdent rejects unsafe identifiers.
+func TestEnsureColumnInvalidIdent(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+
+	err = EnsureColumn(db, "sites;drop", "x", "TEXT", "TEXT", "")
+	if err == nil {
+		t.Fatal("expected error for invalid table name")
+	}
+}
+
+// TestColumnExistsUnknownTableSQLite returns false without fatal for empty result.
+func TestColumnExistsUnknownTableSQLite(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	// No AutoMigrate — table missing. PRAGMA table_info on missing table yields empty rows.
+	exists, err := columnExists(db, "no_such_table", "id")
+	if err != nil {
+		t.Fatalf("columnExists on missing table: %v", err)
+	}
+	if exists {
+		t.Error("expected false for missing table")
+	}
+}
+
+// TestPostgresEnsureColumnAndMigrations exercises dual-dialect helpers when
+// PG_TEST_DSN is available (skipped otherwise).
+func TestPostgresEnsureColumnAndMigrations(t *testing.T) {
+	skipIfNoPG(t)
+
+	db := openTestPG(t)
+
+	// Bookkeeping table must exist after AutoMigrate.
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&n); err != nil {
+		t.Fatalf("schema_migrations missing on PG: %v", err)
+	}
+
+	// Fixed name is fine — EnsureColumn is idempotent; leave column if present
+	// on shared PG test databases.
+	col := "sc1_test_probe_col"
+
+	if err := EnsureColumn(db, "sites", col, "INTEGER", "INTEGER", "DEFAULT 0"); err != nil {
+		t.Fatalf("PG EnsureColumn: %v", err)
+	}
+	exists, err := columnExists(db, "sites", col)
+	if err != nil {
+		t.Fatalf("PG columnExists: %v", err)
+	}
+	if !exists {
+		t.Fatal("PG column not found after EnsureColumn")
+	}
+	// Idempotent.
+	if err := EnsureColumn(db, "sites", col, "INTEGER", "INTEGER", "DEFAULT 0"); err != nil {
+		t.Fatalf("PG EnsureColumn second: %v", err)
+	}
+
+	steps := []AdditiveStep{
+		{
+			Version:     "test_pg_001_bookkeeping",
+			Description: "pg dual-dialect bookkeeping smoke",
+			Apply: func(db *DB) error {
+				// No-op DDL; only exercises mark path. Column already present.
+				return EnsureColumn(db, "sites", col, "INTEGER", "INTEGER", "DEFAULT 0")
+			},
+		},
+	}
+
+	if err := applyAdditiveMigrations(db, steps); err != nil {
+		t.Fatalf("PG ApplyAdditiveMigrations: %v", err)
+	}
+	if err := applyAdditiveMigrations(db, steps); err != nil {
+		t.Fatalf("PG ApplyAdditiveMigrations second: %v", err)
+	}
+
+	var cnt int
+	err = db.QueryRow(`SELECT COUNT(*) FROM schema_migrations WHERE version = ?`,
+		"test_pg_001_bookkeeping").Scan(&cnt)
+	if err != nil {
+		t.Fatalf("PG bookkeeping select: %v", err)
+	}
+	if cnt != 1 {
+		t.Errorf("expected 1 bookkeeping row, got %d", cnt)
+	}
+}

--- a/store/migrate.go
+++ b/store/migrate.go
@@ -9,7 +9,8 @@ import (
 
 // AutoMigrate creates all 27 tables with indexes, unique constraints, foreign keys,
 // and check constraints. Uses CREATE TABLE IF NOT EXISTS for idempotency.
-// Run on startup after Open().
+// After the base bootstrap it runs ApplyAdditiveMigrations (schema_migrations
+// bookkeeping + ordered enterprise steps). Run on startup after Open().
 func AutoMigrate(db *DB) error {
 	dialect := db.Dialect
 	slog.Info("store: running auto-migration", "dialect", dialect)
@@ -83,6 +84,12 @@ func AutoMigrate(db *DB) error {
 		if _, err := db.Exec(m.sql); err != nil {
 			return fmt.Errorf("store: migrate %s: %w", m.name, err)
 		}
+	}
+
+	// Additive upgrades for existing installs (ALTER TABLE ADD COLUMN, etc.).
+	// CREATE TABLE IF NOT EXISTS alone never mutates an already-created table.
+	if err := ApplyAdditiveMigrations(db); err != nil {
+		return err
 	}
 
 	slog.Info("store: auto-migration complete", "dialect", dialect)
@@ -1243,9 +1250,10 @@ func buildIndexes() []struct {
 }
 
 // Migrate is a backward-compatible entry point for the P0 stub API.
-// It runs additional runtime schema migrations beyond the core CREATE TABLE
-// statements. AutoMigrate (called from EnsureRuntimeDatabase) already handles
-// the 27-table bootstrap. This function handles incremental compat checks.
+// AutoMigrate (called from EnsureRuntimeDatabase) already runs the 27-table
+// bootstrap plus ApplyAdditiveMigrations. This entry point re-runs additive
+// steps only — useful when GetDB() is already open and callers want an
+// explicit compatibility pass without re-executing full CREATE TABLE DDL.
 func Migrate(cfg *config.Config) error {
 	db := GetDB()
 	if db == nil {
@@ -1253,14 +1261,12 @@ func Migrate(cfg *config.Config) error {
 		return nil
 	}
 
+	_ = cfg // reserved for future config-gated migration features
 	slog.Info("migrate: running runtime schema compatibility checks", "dialect", db.Dialect)
 
-	// P1: Core tables already created by AutoMigrate.
-	// Future P2+ work will add incremental schema checks here:
-	//   - ensure columns exist, add missing via ALTER TABLE ADD COLUMN
-	//   - ensure indexes exist, add missing via CREATE INDEX IF NOT EXISTS
-	//   - deduplicate stale sites before creating unique index
-	// These map to the TS compatibility functions in index.ts.
+	if err := ApplyAdditiveMigrations(db); err != nil {
+		return err
+	}
 
 	slog.Info("migrate: runtime schema compatibility complete")
 	return nil


### PR DESCRIPTION
Closes #21. Lane: lane-schema. store/additive.go schema_migrations + EnsureColumn/Index; docs/migration.md enterprise upgrades; SC2 columns deferred empty steps.