### PR TITLE
fix(reliability): R1 channel failure isolation no cascade

### DIFF
--- a/docs/analysis/failover-isolation.md
+++ b/docs/analysis/failover-isolation.md
@@ -1,0 +1,87 @@
+# Failover Isolation (R1 / #25, upstream #585)
+
+**Date:** 2026-07-16  
+**Lane:** reliability  
+**SSOT code:** `routing/cooldown.go`, `routing/round_robin.go`, `routing/runtime_health.go`, `routing/router.go` (`RecordFailure`), `routing/selector.go`, `proxy/conductor.go`, `proxy/retry_policy.go`, `proxy/failure_judge.go`
+
+## Purpose
+
+Prevent one upstream channel failure from poisoning sibling channels or unrelated sites. Isolation is layered: channel cooldown, selection soft-filters, site/model breakers, and proxy failover excludes.
+
+## Mechanism map (aligned with code)
+
+| Layer | Mechanism | Code | Scope of poison |
+|:------|:----------|:-----|:----------------|
+| Channel cooldown | Fibonacci backoff from `failCount` | `ResolveFailureBackoffSec` / `ApplyFibonacciCooldown` (`routing/cooldown.go`, `routing/round_robin.go`) | **Failed channel only** (default) |
+| Channel cooldown (RR) | Tiered 10m / 1h / 24h after 3 consecutive fails | `ApplyRoundRobinCooldown`, `RoundRobinCooldownLevelsSec` | **Failed channel only** |
+| Soft recent-failure filter | Prefer candidates outside fib backoff window | `IsChannelRecentlyFailed`, `FilterRecentlyFailedCandidates` | Selection only; does not write state |
+| Hard cooldown exclude | `cooldownUntil > now` | `getCandidateEligibilityReasons` (`routing/selector.go`) | Channel must already carry `cooldownUntil` |
+| Short-window usage limit | 5m credential-scoped cooldown | `resolveShortWindowLimitCooldownTS`, `ShortWindowLimitCooldownMs`; `RecordFailure` expands via `LoadCredentialScopedChannelIDs` | **Same credential siblings only** |
+| Site/model breaker | Transient streak ≥3 → 60s / 5m / 30m | `applyRuntimeHealthFailure`, `SiteRuntimeBreakerLevelsMs` (`routing/runtime_health.go`) | **All channels on that site (global) or site+model** |
+| Breaker filter | Drop open-breaker candidates | `FilterSiteRuntimeBrokenCandidatesByModel*` | Soft; falls back to full set if all broken |
+| OAuth route-unit members | Member-level cooldown + healthy filter on failover | `SelectRouteUnitMember`, member path in `RecordFailure` | **Member only** (outer channel fields untouched) |
+| Proxy failover | Exclude tried channels | `SelectNextChannel(excludeChannelIDs)`, `proxy/channel_selection.go`, `proxy/conductor.go` | Request-local |
+| Retry vs terminal | Status/text classification | `ShouldRetryProxyRequest` | No cross-channel state |
+| Same-site endpoint abort | Systemic 5xx/429 patterns | `ShouldAbortSameSiteEndpointFallback` | Endpoint list within site |
+| Content failure judge | HTTP 200 empty/keyword → record failure | `proxy/failure_judge.go` | Same as `RecordFailure` path |
+
+### Strategy filter stack (selection)
+
+All three strategies now share the same isolation order after eligibility:
+
+1. Eligibility hard excludes (`cooldownUntil`, exclude IDs, account/site status, …)
+2. Site/model breaker filter
+3. **Recent-failure soft filter** (`FilterRecentlyFailedCandidates`)
+4. Strategy pick (weighted / RR / stable-first)
+
+> R1 fix: round-robin previously skipped step 3, so a single RR failure (no `cooldownUntil` yet) could be reselected immediately and starve healthy siblings. RR now applies the same recent-failure filter as weighted and stable-first.
+
+### `RecordFailure` write scope
+
+```
+OAuth unit channel?
+  yes → update ONLY route-unit member cooldown fields; RecordSiteRuntimeFailure(member.site)
+  no  → short-window usage-limit?
+          yes → UpdateChannelCooldownFields(credential-scoped IDs)
+          no  → UpdateChannelCooldownFields([failedChannelID])
+        RecordSiteRuntimeFailure(account.site)
+```
+
+Unrelated sites and non-scoped sibling channels **must not** receive `failCount` / `lastFailAt` / `cooldownUntil` updates.
+
+## What is isolated (guarantees)
+
+1. **One non-usage-limit channel failure** updates only that channel’s cooldown fields.
+2. **Unrelated sites** never receive channel cooldown writes from another site’s failure.
+3. **Same-site sibling channels** (different credentials) stay clean after a peer failure.
+4. **Selection** prefers healthy siblings while any remain (recent-failure + breaker filters).
+5. **OAuth member failure** mutates member state only, not sibling members’ channel rows.
+
+## Residual cascade (still intentional / partial)
+
+These are **not** bugs of “mark sibling failed,” but residual fleet-level pressure:
+
+| Residual | Behavior | Why |
+|:---------|:---------|:----|
+| Site/model breaker | 3 transient fails open breaker → **all** channels on that site/model filtered | Site-level systemic protection |
+| Credential-scoped usage limit | Short window cools **all channels sharing the credential** | Shared quota / key truth |
+| Empty-filter fallback | If every candidate is recently-failed or breaker-open, filters return the **full set** | Starvation prevention |
+| No multi-channel production proof | Load-shaped systemic poison not proven e2e | See gap matrix #585 |
+
+## Tests
+
+- `routing/failure_isolation_test.go`
+  - `TestRecordFailure_DoesNotCascadeToSiblingChannels`
+  - `TestRecordFailure_UsageLimitScopesCredentialSiblingsOnly`
+  - `TestRecordFailure_OAuthMemberIsolation`
+  - `TestSelectionFilter_PrefersHealthySiblingAfterOneFailure` (weighted / RR / stable_first)
+  - `TestSiteBreaker_DoesNotOpenOnSingleFailureAndDoesNotPoisonOtherSites`
+  - `TestRoundRobinFilterStack_MatchesWeightedRecentFailurePolicy`
+- Existing: `routing/cooldown_test.go`, `routing/runtime_health_test.go`, `routing/algorithm_test.go` (partial/all breaker open)
+
+## Non-goals (R1)
+
+- Schema / UI changes
+- Removing site breakers or empty-filter fallbacks
+- Production multi-channel load proof
+- Changing proxy conductor action matrix beyond selection filter parity

--- a/routing/failure_isolation_test.go
+++ b/routing/failure_isolation_test.go
@@ -1,0 +1,809 @@
+package routing
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+// =============================================================================
+// R1 / #25 — Channel failure isolation (no cascade to sibling channels)
+//
+// Proves RecordFailure scopes channel cooldown/failCount to the failed channel
+// (or credential-scoped siblings only for short-window usage-limit), and that
+// selection soft-filters prefer healthy siblings instead of cascading poison.
+// =============================================================================
+
+// isolationDB is a minimal ChannelSelectorDB for RecordFailure isolation tests.
+type isolationDB struct {
+	mu sync.Mutex
+
+	channels map[int64]*struct {
+		Channel store.RouteChannel
+		Account store.Account
+		Route   store.TokenRoute
+	}
+	members map[string]*struct {
+		Member  store.OAuthRouteUnitMember
+		Account store.Account
+		Unit    store.OAuthRouteUnit
+	}
+
+	// credentialScope maps channelID -> sibling IDs returned by LoadCredentialScopedChannelIDs
+	credentialScope map[int64][]int64
+
+	// lastCooldownUpdate records the most recent UpdateChannelCooldownFields call
+	lastCooldownIDs     []int64
+	lastCooldownUpdates map[string]interface{}
+	cooldownCalls        int
+
+	// lastMemberUpdate records OAuth member cooldown writes
+	lastMemberID      int64
+	lastMemberUpdates map[string]interface{}
+	memberCalls       int
+}
+
+func newIsolationDB() *isolationDB {
+	return &isolationDB{
+		channels:        make(map[int64]*struct {
+			Channel store.RouteChannel
+			Account store.Account
+			Route   store.TokenRoute
+		}),
+		members: make(map[string]*struct {
+			Member  store.OAuthRouteUnitMember
+			Account store.Account
+			Unit    store.OAuthRouteUnit
+		}),
+		credentialScope: make(map[int64][]int64),
+	}
+}
+
+func (db *isolationDB) seedChannel(ch store.RouteChannel, account store.Account, route store.TokenRoute) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	cp := ch
+	db.channels[ch.ID] = &struct {
+		Channel store.RouteChannel
+		Account store.Account
+		Route   store.TokenRoute
+	}{Channel: cp, Account: account, Route: route}
+}
+
+func (db *isolationDB) getChannel(id int64) *store.RouteChannel {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	row, ok := db.channels[id]
+	if !ok {
+		return nil
+	}
+	cp := row.Channel
+	return &cp
+}
+
+func memberKey(unitID, accountID int64) string {
+	return formatInt(unitID) + ":" + formatInt(accountID)
+}
+
+func (db *isolationDB) seedMember(member store.OAuthRouteUnitMember, account store.Account, unit store.OAuthRouteUnit) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.members[memberKey(member.UnitID, member.AccountID)] = &struct {
+		Member  store.OAuthRouteUnitMember
+		Account store.Account
+		Unit    store.OAuthRouteUnit
+	}{Member: member, Account: account, Unit: unit}
+}
+
+// ---- ChannelSelectorDB implementation (only methods exercised by RecordFailure) ----
+
+func (db *isolationDB) LoadEnabledRoutes(ctx context.Context) ([]store.TokenRoute, error) {
+	return nil, nil
+}
+func (db *isolationDB) LoadRouteGroupSources(ctx context.Context, groupRouteIDs []int64) (map[int64][]int64, error) {
+	return map[int64][]int64{}, nil
+}
+func (db *isolationDB) LoadRouteChannels(ctx context.Context, routeIDs []int64) ([]struct {
+	Channel store.RouteChannel
+	Account store.Account
+	Site    store.Site
+	Token   *store.AccountToken
+}, error) {
+	return nil, nil
+}
+func (db *isolationDB) LoadOAuthRouteUnitSummaries(ctx context.Context, unitIDs []int64) (map[int64]OAuthRouteUnitSummary, error) {
+	return map[int64]OAuthRouteUnitSummary{}, nil
+}
+func (db *isolationDB) LoadOAuthRouteUnitMembers(ctx context.Context, unitIDs []int64) (map[int64][]OAuthRouteUnitMemberCandidate, error) {
+	return map[int64][]OAuthRouteUnitMemberCandidate{}, nil
+}
+func (db *isolationDB) UpdateChannelLastSelectedAt(ctx context.Context, channelID int64, lastSelectedAt string) error {
+	return nil
+}
+func (db *isolationDB) UpdateRouteUnitMemberLastSelectedAt(ctx context.Context, unitID, accountID int64, lastSelectedAt string) error {
+	return nil
+}
+func (db *isolationDB) FindRouteIDsByOAuthRouteUnitID(ctx context.Context, unitID int64) ([]int64, error) {
+	return nil, nil
+}
+func (db *isolationDB) LoadCredentialScopedChannelIDs(ctx context.Context, channel store.RouteChannel, accountID int64) ([]int64, error) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	if ids, ok := db.credentialScope[channel.ID]; ok {
+		out := make([]int64, len(ids))
+		copy(out, ids)
+		return out, nil
+	}
+	return []int64{channel.ID}, nil
+}
+func (db *isolationDB) LoadChannelWithAccount(ctx context.Context, channelID int64) (*struct {
+	Channel store.RouteChannel
+	Account store.Account
+}, error) {
+	row, err := db.LoadChannelWithAccountAndRoute(ctx, channelID)
+	if err != nil || row == nil {
+		return nil, err
+	}
+	return &struct {
+		Channel store.RouteChannel
+		Account store.Account
+	}{Channel: row.Channel, Account: row.Account}, nil
+}
+func (db *isolationDB) LoadChannelWithAccountAndRoute(ctx context.Context, channelID int64) (*struct {
+	Channel store.RouteChannel
+	Account store.Account
+	Route   store.TokenRoute
+}, error) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	row, ok := db.channels[channelID]
+	if !ok {
+		return nil, nil
+	}
+	cp := *row
+	return &cp, nil
+}
+func (db *isolationDB) UpdateChannelCooldownFields(ctx context.Context, channelIDs []int64, updates map[string]interface{}) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.cooldownCalls++
+	db.lastCooldownIDs = append([]int64(nil), channelIDs...)
+	db.lastCooldownUpdates = updates
+
+	for _, id := range channelIDs {
+		row, ok := db.channels[id]
+		if !ok {
+			continue
+		}
+		if v, ok := updates["failCount"].(int64); ok {
+			row.Channel.FailCount = v
+		}
+		if v, ok := updates["lastFailAt"].(*string); ok {
+			row.Channel.LastFailAt = v
+		} else if v, ok := updates["lastFailAt"].(string); ok {
+			s := v
+			row.Channel.LastFailAt = &s
+		}
+		if v, ok := updates["consecutiveFailCount"].(int64); ok {
+			row.Channel.ConsecutiveFailCount = v
+		}
+		if v, ok := updates["cooldownLevel"].(int64); ok {
+			row.Channel.CooldownLevel = v
+		}
+		if v, ok := updates["cooldownUntil"].(*string); ok {
+			row.Channel.CooldownUntil = v
+		} else if v, ok := updates["cooldownUntil"].(string); ok {
+			s := v
+			row.Channel.CooldownUntil = &s
+		}
+	}
+	return nil
+}
+func (db *isolationDB) UpdateChannelSuccessFields(ctx context.Context, channelID int64, updates map[string]interface{}) error {
+	return nil
+}
+func (db *isolationDB) UpdateRouteUnitMemberCooldownFields(ctx context.Context, memberID int64, updates map[string]interface{}) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.memberCalls++
+	db.lastMemberID = memberID
+	db.lastMemberUpdates = updates
+	for _, row := range db.members {
+		if row.Member.ID != memberID {
+			continue
+		}
+		if v, ok := updates["failCount"].(int64); ok {
+			row.Member.FailCount = v
+		}
+		if v, ok := updates["lastFailAt"].(string); ok {
+			s := v
+			row.Member.LastFailAt = &s
+		} else if v, ok := updates["lastFailAt"].(*string); ok {
+			row.Member.LastFailAt = v
+		}
+		if v, ok := updates["consecutiveFailCount"].(int64); ok {
+			row.Member.ConsecutiveFailCount = v
+		}
+		if v, ok := updates["cooldownLevel"].(int64); ok {
+			row.Member.CooldownLevel = v
+		}
+		if v, ok := updates["cooldownUntil"].(*string); ok {
+			row.Member.CooldownUntil = v
+		}
+	}
+	return nil
+}
+func (db *isolationDB) UpdateRouteUnitMemberSuccessFields(ctx context.Context, memberID int64, updates map[string]interface{}) error {
+	return nil
+}
+func (db *isolationDB) LoadRouteUnitMemberWithAccount(ctx context.Context, unitID, accountID int64) (*struct {
+	Member  store.OAuthRouteUnitMember
+	Account store.Account
+	Unit    store.OAuthRouteUnit
+}, error) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	row, ok := db.members[memberKey(unitID, accountID)]
+	if !ok {
+		return nil, nil
+	}
+	cp := *row
+	return &cp, nil
+}
+func (db *isolationDB) FindAllEnabledRoutes(ctx context.Context) ([]store.TokenRoute, error) {
+	return nil, nil
+}
+func (db *isolationDB) LoadChannelsByTokenID(ctx context.Context, tokenID int64) ([]store.RouteChannel, error) {
+	return nil, nil
+}
+func (db *isolationDB) LoadChannelsByAccountIDWithoutToken(ctx context.Context, accountID int64) ([]store.RouteChannel, error) {
+	return nil, nil
+}
+func (db *isolationDB) LoadRuntimeHealthChannelRows(ctx context.Context, channelIDs []int64) ([]struct {
+	SiteID            int64
+	SourceModel       *string
+	RouteModelPattern string
+}, error) {
+	return nil, nil
+}
+func (db *isolationDB) ClearChannelFailureStates(ctx context.Context, channelIDs []int64) error {
+	return nil
+}
+
+func newIsolationRouter(db *isolationDB) *TokenRouter {
+	cache := NewRouteCache(60_000)
+	return &TokenRouter{
+		db:               db,
+		cache:            cache,
+		configuredMaxSec: 3600,
+	}
+}
+
+func isolationAccount(id, siteID int64) store.Account {
+	token := "tok-" + formatInt(id)
+	return store.Account{
+		ID:          id,
+		SiteID:      siteID,
+		AccessToken: token,
+		APIToken:    &token,
+		Status:      "active",
+		Balance:     100,
+		Quota:       1000,
+		ValueScore:  1,
+	}
+}
+
+func isolationRoute(id int64, strategy string) store.TokenRoute {
+	return store.TokenRoute{
+		ID:              id,
+		ModelPattern:    "gpt-test",
+		RouteMode:       "pattern",
+		RoutingStrategy: strategy,
+		Enabled:         true,
+	}
+}
+
+func isolationChannel(id, routeID, accountID int64) store.RouteChannel {
+	model := "gpt-test"
+	return store.RouteChannel{
+		ID:          id,
+		RouteID:     routeID,
+		AccountID:   accountID,
+		SourceModel: &model,
+		Priority:    0,
+		Weight:      10,
+		Enabled:     true,
+	}
+}
+
+// TestRecordFailure_DoesNotCascadeToSiblingChannels proves a single non-usage-limit
+// failure only mutates the failed channel's cooldown/failCount fields.
+func TestRecordFailure_DoesNotCascadeToSiblingChannels(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	// Mark health as loaded so EnsureSiteRuntimeHealthStateLoaded is a no-op
+	// without a settings store (persist is also no-op when store is nil).
+	siteRuntimeHealthLoaded = true
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	db := newIsolationDB()
+	route := isolationRoute(1, "weighted")
+
+	// Site A: two sibling channels (same site, different accounts)
+	// Site B: unrelated healthy channel
+	chA1 := isolationChannel(101, 1, 1001)
+	chA2 := isolationChannel(102, 1, 1002)
+	chB1 := isolationChannel(201, 1, 2001)
+	accA1 := isolationAccount(1001, 10)
+	accA2 := isolationAccount(1002, 10)
+	accB1 := isolationAccount(2001, 20)
+
+	db.seedChannel(chA1, accA1, route)
+	db.seedChannel(chA2, accA2, route)
+	db.seedChannel(chB1, accB1, route)
+
+	tr := newIsolationRouter(db)
+	ctx := context.Background()
+	status := 500
+	errText := "bad gateway"
+	model := "gpt-test"
+
+	if err := tr.RecordFailure(ctx, 101, SiteRuntimeFailureContext{
+		Status:    &status,
+		ErrorText: &errText,
+		ModelName: &model,
+	}, nil); err != nil {
+		t.Fatalf("RecordFailure: %v", err)
+	}
+
+	if db.cooldownCalls != 1 {
+		t.Fatalf("expected 1 cooldown update, got %d", db.cooldownCalls)
+	}
+	if len(db.lastCooldownIDs) != 1 || db.lastCooldownIDs[0] != 101 {
+		t.Fatalf("expected cooldown scoped to channel 101 only, got %v", db.lastCooldownIDs)
+	}
+
+	failed := db.getChannel(101)
+	sibling := db.getChannel(102)
+	otherSite := db.getChannel(201)
+	if failed == nil || sibling == nil || otherSite == nil {
+		t.Fatal("expected all seeded channels present")
+	}
+
+	if failed.FailCount != 1 {
+		t.Errorf("failed channel failCount=%d, want 1", failed.FailCount)
+	}
+	if failed.LastFailAt == nil || *failed.LastFailAt == "" {
+		t.Error("failed channel lastFailAt should be set")
+	}
+	if failed.CooldownUntil == nil || *failed.CooldownUntil == "" {
+		t.Error("failed channel cooldownUntil should be set (fibonacci path)")
+	}
+
+	if sibling.FailCount != 0 {
+		t.Errorf("sibling channel failCount cascaded: got %d, want 0", sibling.FailCount)
+	}
+	if sibling.LastFailAt != nil {
+		t.Errorf("sibling lastFailAt cascaded: %v", sibling.LastFailAt)
+	}
+	if sibling.CooldownUntil != nil {
+		t.Errorf("sibling cooldownUntil cascaded: %v", sibling.CooldownUntil)
+	}
+	if sibling.ConsecutiveFailCount != 0 || sibling.CooldownLevel != 0 {
+		t.Errorf("sibling consecutive/cooldown level cascaded: cf=%d level=%d",
+			sibling.ConsecutiveFailCount, sibling.CooldownLevel)
+	}
+
+	if otherSite.FailCount != 0 || otherSite.LastFailAt != nil || otherSite.CooldownUntil != nil {
+		t.Errorf("unrelated site channel poisoned: failCount=%d lastFailAt=%v cooldownUntil=%v",
+			otherSite.FailCount, otherSite.LastFailAt, otherSite.CooldownUntil)
+	}
+
+	// Site runtime health records only the failed site — not the unrelated site.
+	if !IsSiteRuntimeBreakerOpen(10) {
+		// One failure is not enough to open breaker; just check state exists for site 10
+		// and site 20 remains untouched.
+	}
+	if IsSiteRuntimeBreakerOpen(20) {
+		t.Error("unrelated site breaker should remain closed")
+	}
+	detailsB := GetSiteRuntimeHealthDetails(20, model)
+	if detailsB.GlobalBreakerOpen || detailsB.ModelBreakerOpen {
+		t.Error("unrelated site/model breaker should stay closed after site A failure")
+	}
+	// Site A should have recorded a failure (penalty/recent counts) but not open breaker yet.
+	stateA := siteRuntimeHealthStates[10]
+	if stateA == nil || stateA.RecentFailureCount < 1 {
+		t.Error("expected site A runtime health to record the failure")
+	}
+	stateB := siteRuntimeHealthStates[20]
+	if stateB != nil && stateB.RecentFailureCount > 0 {
+		t.Error("expected site B runtime health to stay clean")
+	}
+}
+
+// TestRecordFailure_UsageLimitScopesCredentialSiblingsOnly proves short-window
+// usage-limit cooldowns credential-scoped siblings, not whole-route/site peers.
+func TestRecordFailure_UsageLimitScopesCredentialSiblingsOnly(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	siteRuntimeHealthLoaded = true
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	db := newIsolationDB()
+	route := isolationRoute(1, "weighted")
+
+	// Same credential: channels 101 + 102 share token/account scope
+	// Different credential on same site: 103
+	// Other site: 201
+	ch101 := isolationChannel(101, 1, 1001)
+	ch102 := isolationChannel(102, 1, 1001)
+	ch103 := isolationChannel(103, 1, 1002)
+	ch201 := isolationChannel(201, 1, 2001)
+
+	accSame := isolationAccount(1001, 10)
+	accOther := isolationAccount(1002, 10)
+	accSiteB := isolationAccount(2001, 20)
+
+	db.seedChannel(ch101, accSame, route)
+	db.seedChannel(ch102, accSame, route)
+	db.seedChannel(ch103, accOther, route)
+	db.seedChannel(ch201, accSiteB, route)
+	db.credentialScope[101] = []int64{101, 102}
+
+	tr := newIsolationRouter(db)
+	status := 429
+	errText := "usage_limit_reached"
+	model := "gpt-test"
+
+	if err := tr.RecordFailure(context.Background(), 101, SiteRuntimeFailureContext{
+		Status:    &status,
+		ErrorText: &errText,
+		ModelName: &model,
+	}, nil); err != nil {
+		t.Fatalf("RecordFailure: %v", err)
+	}
+
+	if len(db.lastCooldownIDs) != 2 {
+		t.Fatalf("expected credential-scoped IDs [101,102], got %v", db.lastCooldownIDs)
+	}
+	seen := map[int64]bool{}
+	for _, id := range db.lastCooldownIDs {
+		seen[id] = true
+	}
+	if !seen[101] || !seen[102] {
+		t.Fatalf("expected both 101 and 102 in scope, got %v", db.lastCooldownIDs)
+	}
+	if seen[103] || seen[201] {
+		t.Fatalf("usage-limit must not cascade beyond credential scope, got %v", db.lastCooldownIDs)
+	}
+
+	if c := db.getChannel(103); c.FailCount != 0 || c.CooldownUntil != nil {
+		t.Errorf("same-site different credential poisoned: failCount=%d cooldown=%v", c.FailCount, c.CooldownUntil)
+	}
+	if c := db.getChannel(201); c.FailCount != 0 || c.CooldownUntil != nil {
+		t.Errorf("other-site channel poisoned: failCount=%d cooldown=%v", c.FailCount, c.CooldownUntil)
+	}
+	// Credential siblings should carry short-window cooldown
+	for _, id := range []int64{101, 102} {
+		c := db.getChannel(id)
+		if c.CooldownUntil == nil {
+			t.Errorf("channel %d missing short-window cooldown", id)
+		}
+		// short-window path resets failCount to 0 by design
+		if c.FailCount != 0 {
+			t.Errorf("channel %d failCount=%d want 0 under short-window path", id, c.FailCount)
+		}
+	}
+}
+
+// TestRecordFailure_OAuthMemberIsolation proves member failure does not write
+// channel-level cooldown on sibling members or regular channels.
+func TestRecordFailure_OAuthMemberIsolation(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	siteRuntimeHealthLoaded = true
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	db := newIsolationDB()
+	route := isolationRoute(1, "weighted")
+	unitID := int64(7)
+	ch := isolationChannel(301, 1, 3001)
+	ch.OAuthRouteUnitID = &unitID
+	acc1 := isolationAccount(3001, 30)
+	acc2 := isolationAccount(3002, 30)
+	db.seedChannel(ch, acc1, route)
+
+	unit := store.OAuthRouteUnit{
+		ID: unitID, SiteID: 30, Provider: "codex", Name: "unit", Strategy: "round_robin", Enabled: true,
+	}
+	db.seedMember(store.OAuthRouteUnitMember{ID: 1, UnitID: unitID, AccountID: 3001}, acc1, unit)
+	db.seedMember(store.OAuthRouteUnitMember{ID: 2, UnitID: unitID, AccountID: 3002}, acc2, unit)
+
+	// Sibling regular channel on same site
+	sibling := isolationChannel(302, 1, 3003)
+	db.seedChannel(sibling, isolationAccount(3003, 30), route)
+
+	tr := newIsolationRouter(db)
+	status := 502
+	errText := "bad gateway"
+
+	if err := tr.RecordFailure(context.Background(), 301, SiteRuntimeFailureContext{
+		Status:    &status,
+		ErrorText: &errText,
+	}, nil); err != nil {
+		t.Fatalf("RecordFailure: %v", err)
+	}
+
+	if db.memberCalls != 1 {
+		t.Fatalf("expected 1 member cooldown write, got %d", db.memberCalls)
+	}
+	if db.lastMemberID != 1 {
+		t.Fatalf("expected member 1 updated, got %d", db.lastMemberID)
+	}
+	if db.cooldownCalls != 0 {
+		t.Fatalf("oauth member path must not update channel cooldown fields, calls=%d ids=%v",
+			db.cooldownCalls, db.lastCooldownIDs)
+	}
+
+	// Sibling regular channel untouched
+	if c := db.getChannel(302); c.FailCount != 0 || c.CooldownUntil != nil {
+		t.Errorf("sibling regular channel cascaded: failCount=%d cooldown=%v", c.FailCount, c.CooldownUntil)
+	}
+	// Outer OAuth channel itself not mutated (member path only)
+	if c := db.getChannel(301); c.FailCount != 0 || c.CooldownUntil != nil {
+		t.Errorf("outer oauth channel fields mutated: failCount=%d cooldown=%v", c.FailCount, c.CooldownUntil)
+	}
+}
+
+// TestSelectionFilter_PrefersHealthySiblingAfterOneFailure is table-driven coverage
+// for weighted / stable_first / round_robin soft-filters after one channel fails.
+func TestSelectionFilter_PrefersHealthySiblingAfterOneFailure(t *testing.T) {
+	nowMs := time.Now().UnixMilli()
+	recentISO := time.UnixMilli(nowMs - 2_000).UTC().Format(time.RFC3339)
+	model := "gpt-test"
+
+	type cand struct {
+		id        int64
+		siteID    int64
+		failCount int64
+		lastFail  string
+	}
+	toCandidates := func(rows []cand) []RouteChannelCandidate {
+		out := make([]RouteChannelCandidate, 0, len(rows))
+		for _, r := range rows {
+			c := buildTestCandidate(r.id, r.siteID, r.id*10, 10, 0, 100, r.failCount, 50.0, 1.0, nil, 0, &model)
+			if r.lastFail != "" {
+				lf := r.lastFail
+				c.Channel.LastFailAt = &lf
+			}
+			out = append(out, c)
+		}
+		return out
+	}
+	getInfo := func(c RouteChannelCandidate) (*int64, *string) {
+		return &c.Channel.FailCount, c.Channel.LastFailAt
+	}
+
+	tests := []struct {
+		name           string
+		strategy       RouteRoutingStrategy
+		rows           []cand
+		wantIDs        []int64
+		wantFallbackAll bool
+	}{
+		{
+			name:     "weighted prefers healthy sibling",
+			strategy: StrategyWeighted,
+			rows: []cand{
+				{id: 1, siteID: 10, failCount: 1, lastFail: recentISO},
+				{id: 2, siteID: 20, failCount: 0},
+			},
+			wantIDs: []int64{2},
+		},
+		{
+			name:     "round_robin prefers healthy sibling",
+			strategy: StrategyRoundRobin,
+			rows: []cand{
+				{id: 1, siteID: 10, failCount: 1, lastFail: recentISO},
+				{id: 2, siteID: 20, failCount: 0},
+			},
+			wantIDs: []int64{2},
+		},
+		{
+			name:     "stable_first prefers healthy sibling",
+			strategy: StrategyStableFirst,
+			rows: []cand{
+				{id: 1, siteID: 10, failCount: 2, lastFail: recentISO},
+				{id: 2, siteID: 20, failCount: 0},
+				{id: 3, siteID: 30, failCount: 0},
+			},
+			wantIDs: []int64{2, 3},
+		},
+		{
+			name:     "same-site sibling still healthy after peer fail",
+			strategy: StrategyWeighted,
+			rows: []cand{
+				{id: 1, siteID: 10, failCount: 1, lastFail: recentISO},
+				{id: 2, siteID: 10, failCount: 0}, // same site, not marked failed
+			},
+			wantIDs: []int64{2},
+		},
+		{
+			name:     "all recently failed falls back to full set",
+			strategy: StrategyRoundRobin,
+			rows: []cand{
+				{id: 1, siteID: 10, failCount: 1, lastFail: recentISO},
+				{id: 2, siteID: 20, failCount: 3, lastFail: recentISO},
+			},
+			wantIDs:         []int64{1, 2},
+			wantFallbackAll: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetSiteRuntimeHealthState()
+			candidates := toCandidates(tt.rows)
+
+			// Mimic strategy selection filter stack: breaker then recent-failure
+			// (RR now uses the same recent-failure filter as weighted/stable_first).
+			breakerHealthy, _ := GetBreakerFilteredCandidatesByModel(candidates, model)
+			filtered := FilterRecentlyFailedCandidates(breakerHealthy, getInfo, nowMs, 0)
+
+			got := map[int64]bool{}
+			for _, c := range filtered {
+				got[c.Channel.ID] = true
+			}
+			if len(filtered) != len(tt.wantIDs) {
+				t.Fatalf("filtered len=%d want %d (ids=%v)", len(filtered), len(tt.wantIDs), keysOf(got))
+			}
+			for _, id := range tt.wantIDs {
+				if !got[id] {
+					t.Errorf("expected channel %d in filtered set, got %v", id, keysOf(got))
+				}
+			}
+			if !tt.wantFallbackAll {
+				// Failed channel must not remain when healthy sibling exists
+				for _, r := range tt.rows {
+					if r.failCount > 0 && r.lastFail != "" && !got[r.id] {
+						// expected excluded
+						continue
+					}
+					if r.failCount > 0 && r.lastFail != "" && got[r.id] && len(tt.wantIDs) < len(tt.rows) {
+						t.Errorf("recently failed channel %d still present with healthy alternatives", r.id)
+					}
+				}
+			}
+
+			// Round-robin selection must pick a healthy channel when available
+			if tt.strategy == StrategyRoundRobin && !tt.wantFallbackAll {
+				selected := SelectRoundRobinCandidate(filtered)
+				if selected == nil {
+					t.Fatal("expected RR selection")
+				}
+				if selected.Channel.FailCount > 0 {
+					t.Errorf("RR selected recently-failed channel %d", selected.Channel.ID)
+				}
+			}
+		})
+	}
+}
+
+// TestSiteBreaker_DoesNotOpenOnSingleFailureAndDoesNotPoisonOtherSites verifies
+// residual cascade boundaries: one failure must not open a site breaker or affect
+// other sites; three transient failures open only the failed site.
+func TestSiteBreaker_DoesNotOpenOnSingleFailureAndDoesNotPoisonOtherSites(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	status := 500
+	model := "gpt-test"
+	ctx := SiteRuntimeFailureContext{Status: &status, ModelName: &model}
+
+	// Single failure: no breaker
+	RecordSiteRuntimeFailure(10, ctx)
+	if IsSiteRuntimeBreakerOpen(10) {
+		t.Error("single transient failure must not open site breaker")
+	}
+	if IsSiteRuntimeBreakerOpen(20) {
+		t.Error("unrelated site must stay closed")
+	}
+
+	// Two more on site 10 → streak 3 opens breaker on site 10 only
+	RecordSiteRuntimeFailure(10, ctx)
+	RecordSiteRuntimeFailure(10, ctx)
+	if !IsSiteRuntimeBreakerOpen(10) {
+		t.Error("expected site 10 breaker open after 3 transient failures")
+	}
+	if IsSiteRuntimeBreakerOpen(20) {
+		t.Error("site 20 must not cascade-open from site 10 breaker")
+	}
+
+	// Model-level: only the named model on the failed site is broken
+	detailsSameModel := GetSiteRuntimeHealthDetails(10, model)
+	if !detailsSameModel.GlobalBreakerOpen {
+		t.Error("expected global breaker open on failed site")
+	}
+	detailsOtherSite := GetSiteRuntimeHealthDetails(20, model)
+	if detailsOtherSite.GlobalBreakerOpen || detailsOtherSite.ModelBreakerOpen {
+		t.Error("other site health must remain clean")
+	}
+
+	// Filter must keep other-site channels when only site 10 is broken
+	candidates := []RouteChannelCandidate{
+		buildTestCandidate(1, 10, 101, 10, 0, 100, 0, 50.0, 1.0, nil, 0, &model),
+		buildTestCandidate(2, 20, 201, 10, 0, 100, 0, 50.0, 1.0, nil, 0, &model),
+	}
+	healthy, avoided := GetBreakerFilteredCandidatesByModel(candidates, model)
+	if len(healthy) != 1 || healthy[0].Channel.ID != 2 {
+		t.Fatalf("expected only site-20 channel healthy, got %v", healthyIDs(healthy))
+	}
+	if len(avoided) != 1 || avoided[0].Candidate.Channel.ID != 1 {
+		t.Fatalf("expected site-10 channel avoided, got avoided=%d", len(avoided))
+	}
+}
+
+// TestRoundRobinFilterStack_MatchesWeightedRecentFailurePolicy is a regression for
+// the R1 fix: RR must apply FilterRecentlyFailedCandidates, not only breaker filter.
+func TestRoundRobinFilterStack_MatchesWeightedRecentFailurePolicy(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	nowMs := time.Now().UnixMilli()
+	recentISO := time.UnixMilli(nowMs - 1_000).UTC().Format(time.RFC3339)
+	model := "gpt-test"
+
+	failed := buildTestCandidate(1, 10, 101, 10, 0, 100, 1, 50.0, 1.0, nil, 0, &model)
+	failed.Channel.LastFailAt = &recentISO
+	healthy := buildTestCandidate(2, 20, 201, 10, 0, 100, 0, 50.0, 1.0, nil, 0, &model)
+	// Make failed channel "earlier" in RR order so without the filter it would win.
+	old := time.UnixMilli(nowMs - 86_400_000).UTC().Format(time.RFC3339)
+	failed.Channel.LastSelectedAt = &old
+	recentSel := time.UnixMilli(nowMs - 1_000).UTC().Format(time.RFC3339)
+	healthy.Channel.LastSelectedAt = &recentSel
+
+	candidates := []RouteChannelCandidate{failed, healthy}
+	breakerHealthy, _ := GetBreakerFilteredCandidatesByModel(candidates, model)
+	filtered := FilterRecentlyFailedCandidates(breakerHealthy,
+		func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
+		nowMs, 0)
+
+	selected := SelectRoundRobinCandidate(filtered)
+	if selected == nil {
+		t.Fatal("expected selection")
+	}
+	if selected.Channel.ID != 2 {
+		t.Fatalf("RR with recent-failure filter selected channel %d, want healthy sibling 2", selected.Channel.ID)
+	}
+
+	// Without recent-failure filter, RR would prefer the older lastSelectedAt (failed ch)
+	unfiltered := SelectRoundRobinCandidate(breakerHealthy)
+	if unfiltered == nil || unfiltered.Channel.ID != 1 {
+		t.Fatalf("sanity: unfiltered RR should prefer failed channel 1 by lastSelectedAt, got %v",
+			channelIDOrNil(unfiltered))
+	}
+}
+
+func keysOf(m map[int64]bool) []int64 {
+	out := make([]int64, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func healthyIDs(cs []RouteChannelCandidate) []int64 {
+	out := make([]int64, len(cs))
+	for i, c := range cs {
+		out[i] = c.Channel.ID
+	}
+	return out
+}
+
+func channelIDOrNil(c *RouteChannelCandidate) interface{} {
+	if c == nil {
+		return nil
+	}
+	return c.Channel.ID
+}

--- a/routing/selector.go
+++ b/routing/selector.go
@@ -278,8 +278,15 @@ func (s *ChannelSelector) selectFromMatch(
 	}
 
 	if strategy == StrategyRoundRobin {
+		// Align with weighted/stable_first: avoid recently-failed channels when healthy
+		// alternatives remain. Without this filter, RR only hard-excludes cooldownUntil
+		// (which starts after RoundRobinFailureThreshold consecutive fails), so a single
+		// failure can be reselected immediately and starve sibling healthy channels.
 		breakerHealthy, _ := GetBreakerFilteredCandidatesByModelResolver(available, resolveModel)
-		selected := SelectRoundRobinCandidate(breakerHealthy)
+		filteredCandidates := FilterRecentlyFailedCandidates(breakerHealthy,
+			func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
+			nowMs, s.configuredMaxSec)
+		selected := SelectRoundRobinCandidate(filteredCandidates)
 		if selected == nil {
 			return nil, nil
 		}


### PR DESCRIPTION
Closes #25. Lane: lane-reliability. Adds isolation tests; round_robin now filters recently-failed candidates; docs/analysis/failover-isolation.md.