### PR TITLE
fix(handler): B3 unify admin API error responses

### DIFF
--- a/docs/analysis/error-model.md
+++ b/docs/analysis/error-model.md
@@ -1,0 +1,71 @@
+# Admin API Error Model (B3 / #19)
+
+**Date:** 2026-07-17  
+**Lane:** backend-core  
+**SSOT code:** `handler/shared/errors.go`, admin wrappers in `handler/admin/response_errors.go`
+
+## Goal
+
+Unify admin mutation error responses so clients never need to treat **HTTP 200 + error body** as failure.
+
+## Wire format (camelCase JSON)
+
+```json
+{"error":"human-readable message"}
+```
+
+Optional classifier:
+
+```json
+{"error":"API key 已存在","detail":"duplicate_key"}
+```
+
+| Field | JSON key | Notes |
+|:------|:---------|:------|
+| Message | `error` | Safe public string |
+| Detail | `detail` | Optional subtype / machine hint |
+| HTTP status | response code | Always **≥ 400** for failures |
+| Internal | (not serialized) | Logged server-side only |
+
+Helpers: `shared.WriteError`, `shared.WriteErrorDetail`, `shared.WriteAPIError`, admin `writeError` / `writeErrorDetail`.
+
+## Classification boundaries
+
+| Class | Typical status | Examples |
+|:------|:---------------|:---------|
+| **validation** | 400 | Invalid payload, empty name/url/token, bad enums |
+| **auth (admin session)** | 401 / 403 | Missing/invalid admin bearer (auth middleware) |
+| **auth (upstream login/verify)** | 401 / 502 | Login rejected by upstream; verify transport failure |
+| **not found** | 404 | Site / account / key missing |
+| **conflict** | 409 | Duplicate site URL or downstream key |
+| **upstream** | 502 | Login/verify/create-token upstream adapter failure |
+| **internal** | 500 | DB / encryption / unexpected handler failure |
+
+Upstream **proxy** OpenAI-shaped errors remain nested (`{"error":{"message","type"}}`) in `handler/proxy` — that surface is for model clients, not the admin SPA. Admin uses the flat `{"error":"..."}` model above.
+
+Related: account-expired classification for upstream token health is documented in `docs/analysis/error-classification.md` (R0) and is orthogonal to HTTP response shaping.
+
+## High-traffic mutation paths covered
+
+| Resource | Create / update | Silent 200 forbidden |
+|:---------|:----------------|:---------------------|
+| Sites | `POST /api/sites`, `PUT /api/sites/{id}` | Yes — validation/conflict/internal use 4xx/5xx + `error` |
+| Accounts | `POST /api/accounts`, `PUT /api/accounts/{id}` | Yes |
+| Accounts login/verify | `POST /api/accounts/login`, `.../verify-token` | Yes — failures no longer return 200 + `success:false` |
+| Downstream keys | `POST /api/downstream-keys`, `PUT /api/downstream-keys/{id}` | Yes |
+
+Batch **partial** success responses may still return 200 with per-item results when at least one item succeeds. All-failed batch create returns **400** with structured items (not a silent success).
+
+## Client notes
+
+`web/api.ts` already:
+
+1. Throws on `!res.ok`, reading `json.error` or `json.message`.
+2. Uses try/catch for mutations — non-2xx failures surface as thrown `Error` messages.
+
+Login / verify UIs that previously branched on `result.success` still work: success stays 200 + `success:true`; failures throw into the existing `catch` path.
+
+## Tests
+
+- `handler/shared/errors_test.go` — status, camelCase body, no silent 200
+- `handler/admin/error_model_test.go` — sites / accounts / keys create-update status codes

--- a/handler/admin/account_tokens.go
+++ b/handler/admin/account_tokens.go
@@ -50,7 +50,7 @@ func (h *accountTokensHandler) listTokens(w http.ResponseWriter, r *http.Request
 	tokens, err := service.ListTokensWithRelations(h.db, accountID)
 	if err != nil {
 		slog.Error("Failed to load tokens", "err", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "Failed to load tokens"})
+		writeError(w, http.StatusInternalServerError, "Failed to load tokens")
 		return
 	}
 
@@ -65,24 +65,24 @@ func (h *accountTokensHandler) listTokens(w http.ResponseWriter, r *http.Request
 func (h *accountTokensHandler) createToken(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountTokenCreatePayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "Invalid account token payload."})
+		writeError(w, http.StatusBadRequest, "Invalid account token payload.")
 		return
 	}
 
 	if body.AccountID <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "Invalid accountId. Expected positive number."})
+		writeError(w, http.StatusBadRequest, "Invalid accountId. Expected positive number.")
 		return
 	}
 
 	// Get account with site
 	row, err := service.GetAccountWithSiteByID(h.db, int64(body.AccountID))
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "账号不存在"})
+		writeError(w, http.StatusNotFound, "账号不存在")
 		return
 	}
 
 	if service.IsAPIKeyConnection(&row.Account) {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "API Key 连接不支持创建账号令牌"})
+		writeError(w, http.StatusBadRequest, "API Key 连接不支持创建账号令牌")
 		return
 	}
 
@@ -96,7 +96,7 @@ func (h *accountTokensHandler) createToken(w http.ResponseWriter, r *http.Reques
 		result, err := h.createLocalToken(body, row, tokenValue)
 		if err != nil {
 			slog.Error("Token creation failed", "err", err)
-			writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "Token creation failed"})
+			writeError(w, http.StatusInternalServerError, "Token creation failed")
 			return
 		}
 		writeJSON(w, http.StatusOK, result)
@@ -105,16 +105,16 @@ func (h *accountTokensHandler) createToken(w http.ResponseWriter, r *http.Reques
 
 	// Upstream path: create token on the target site
 	if row.Site.Status == "disabled" || strings.TrimSpace(row.Site.Status) == "disabled" {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "站点已禁用，无法创建令牌"})
+		writeError(w, http.StatusBadRequest, "站点已禁用，无法创建令牌")
 		return
 	}
 	if strings.TrimSpace(row.Account.AccessToken) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "账号缺少访问令牌，无法创建站点令牌"})
+		writeError(w, http.StatusBadRequest, "账号缺少访问令牌，无法创建站点令牌")
 		return
 	}
 
 	// Stub: P4 adapter.createApiToken()
-	writeJSON(w, http.StatusBadGateway, map[string]any{"success": false, "message": "站点创建令牌失败（上游适配器未实现）"})
+	writeError(w, http.StatusBadGateway, "站点创建令牌失败（上游适配器未实现）")
 }
 
 func (h *accountTokensHandler) createLocalToken(body payloads.AccountTokenCreatePayload, row *service.AccountWithSite, tokenValue string) (map[string]any, error) {
@@ -216,19 +216,19 @@ func (h *accountTokensHandler) createLocalToken(body payloads.AccountTokenCreate
 func (h *accountTokensHandler) batchTokens(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountTokenBatchPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid account token batch payload."})
+		writeError(w, http.StatusBadRequest, "Invalid account token batch payload.")
 		return
 	}
 
 	if len(body.IDs) == 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "ids is required"})
+		writeError(w, http.StatusBadRequest, "ids is required")
 		return
 	}
 
 	action := strings.TrimSpace(body.Action)
 	validActions := map[string]bool{"enable": true, "disable": true, "delete": true}
 	if !validActions[action] {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid action"})
+		writeError(w, http.StatusBadRequest, "Invalid action")
 		return
 	}
 
@@ -301,33 +301,33 @@ func (h *accountTokensHandler) updateToken(w http.ResponseWriter, r *http.Reques
 	idStr := chi.URLParam(r, "id")
 	tokenID, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "令牌 ID 无效"})
+		writeError(w, http.StatusBadRequest, "令牌 ID 无效")
 		return
 	}
 
 	var body payloads.AccountTokenUpdatePayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "Invalid account token payload."})
+		writeError(w, http.StatusBadRequest, "Invalid account token payload.")
 		return
 	}
 
 	existing, err := service.GetTokenByID(h.db, tokenID)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "令牌不存在"})
+		writeError(w, http.StatusNotFound, "令牌不存在")
 		return
 	}
 
 	owner, err := service.GetAccountByID(h.db, existing.AccountID)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "账号不存在"})
+		writeError(w, http.StatusNotFound, "账号不存在")
 		return
 	}
 	if owner == nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "账号不存在"})
+		writeError(w, http.StatusNotFound, "账号不存在")
 		return
 	}
 	if service.IsAPIKeyConnection(owner) {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "API Key 连接不支持管理账号令牌"})
+		writeError(w, http.StatusBadRequest, "API Key 连接不支持管理账号令牌")
 		return
 	}
 
@@ -341,7 +341,7 @@ func (h *accountTokensHandler) updateToken(w http.ResponseWriter, r *http.Reques
 	if body.Token != nil {
 		tv := strings.TrimSpace(*body.Token)
 		if tv == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "令牌不能为空"})
+			writeError(w, http.StatusBadRequest, "令牌不能为空")
 			return
 		}
 		updates["token"] = tv
@@ -372,52 +372,52 @@ func (h *accountTokensHandler) updateToken(w http.ResponseWriter, r *http.Reques
 	}
 
 	if err := service.UpdateTokenFields(h.db, tokenID, updates); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "更新失败"})
+		writeError(w, http.StatusInternalServerError, "更新失败")
 		return
 	}
 
 	// Refresh and handle default logic
 	latest, err := service.GetTokenByID(h.db, tokenID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "更新失败"})
+		writeError(w, http.StatusInternalServerError, "更新失败")
 		return
 	}
 	if latest == nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "更新失败"})
+		writeError(w, http.StatusInternalServerError, "更新失败")
 		return
 	}
 
 	if body.IsDefault != nil && *body.IsDefault && service.IsUsableAccountToken(latest) {
 		if ok, err := service.SetDefaultToken(h.db, tokenID); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "设置默认令牌失败"})
+			writeError(w, http.StatusInternalServerError, "设置默认令牌失败")
 			return
 		} else if !ok {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "令牌不能设为默认"})
+			writeError(w, http.StatusBadRequest, "令牌不能设为默认")
 			return
 		}
 	} else if latest.IsDefault && service.IsUsableAccountToken(latest) {
 		if ok, err := service.SetDefaultToken(h.db, tokenID); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "设置默认令牌失败"})
+			writeError(w, http.StatusInternalServerError, "设置默认令牌失败")
 			return
 		} else if !ok {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "令牌不能设为默认"})
+			writeError(w, http.StatusBadRequest, "令牌不能设为默认")
 			return
 		}
 	} else if existing.IsDefault && !service.IsUsableAccountToken(latest) {
 		if _, err := service.RepairDefaultToken(h.db, existing.AccountID); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "修复默认令牌失败"})
+			writeError(w, http.StatusInternalServerError, "修复默认令牌失败")
 			return
 		}
 	} else if body.IsDefault != nil && !(*body.IsDefault) && existing.IsDefault {
 		if _, err := service.RepairDefaultToken(h.db, existing.AccountID); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "修复默认令牌失败"})
+			writeError(w, http.StatusInternalServerError, "修复默认令牌失败")
 			return
 		}
 	}
 
 	latest, err = service.GetTokenByID(h.db, tokenID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "读取令牌失败"})
+		writeError(w, http.StatusInternalServerError, "读取令牌失败")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -432,41 +432,41 @@ func (h *accountTokensHandler) setDefault(w http.ResponseWriter, r *http.Request
 	idStr := chi.URLParam(r, "id")
 	tokenID, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "令牌 ID 无效"})
+		writeError(w, http.StatusBadRequest, "令牌 ID 无效")
 		return
 	}
 
 	token, err := service.GetTokenByID(h.db, tokenID)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "令牌不存在"})
+		writeError(w, http.StatusNotFound, "令牌不存在")
 		return
 	}
 
 	owner, err := service.GetAccountByID(h.db, token.AccountID)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "账号不存在"})
+		writeError(w, http.StatusNotFound, "账号不存在")
 		return
 	}
 	if owner == nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "账号不存在"})
+		writeError(w, http.StatusNotFound, "账号不存在")
 		return
 	}
 	if service.IsAPIKeyConnection(owner) {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "API Key 连接不支持管理账号令牌"})
+		writeError(w, http.StatusBadRequest, "API Key 连接不支持管理账号令牌")
 		return
 	}
 	if service.IsMaskedPendingAccountToken(token) {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "待补全令牌不能设为默认，请先补全明文 token"})
+		writeError(w, http.StatusBadRequest, "待补全令牌不能设为默认，请先补全明文 token")
 		return
 	}
 
 	ok, err := service.SetDefaultToken(h.db, tokenID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "设置默认令牌失败"})
+		writeError(w, http.StatusInternalServerError, "设置默认令牌失败")
 		return
 	}
 	if !ok {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "令牌不存在"})
+		writeError(w, http.StatusNotFound, "令牌不存在")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})
@@ -478,35 +478,32 @@ func (h *accountTokensHandler) getTokenValue(w http.ResponseWriter, r *http.Requ
 	idStr := chi.URLParam(r, "id")
 	tokenID, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "令牌 ID 无效"})
+		writeError(w, http.StatusBadRequest, "令牌 ID 无效")
 		return
 	}
 
 	token, err := service.GetTokenByID(h.db, tokenID)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "令牌不存在"})
+		writeError(w, http.StatusNotFound, "令牌不存在")
 		return
 	}
 
 	owner, err := service.GetAccountByID(h.db, token.AccountID)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "令牌不存在"})
+		writeError(w, http.StatusNotFound, "令牌不存在")
 		return
 	}
 	if owner == nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "令牌不存在"})
+		writeError(w, http.StatusNotFound, "令牌不存在")
 		return
 	}
 	if service.IsAPIKeyConnection(owner) {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "API Key 连接不支持管理账号令牌"})
+		writeError(w, http.StatusBadRequest, "API Key 连接不支持管理账号令牌")
 		return
 	}
 
 	if service.IsMaskedPendingAccountToken(token) || IsMaskedTokenValue(token.Token) {
-		writeJSON(w, http.StatusConflict, map[string]any{
-			"success": false,
-			"message": "当前仅保存了脱敏令牌，无法展开/复制。请在站点重新生成并同步，或手动更新为完整令牌。",
-		})
+		writeError(w, http.StatusConflict, "当前仅保存了脱敏令牌，无法展开/复制。请在站点重新生成并同步，或手动更新为完整令牌。")
 		return
 	}
 
@@ -514,11 +511,11 @@ func (h *accountTokensHandler) getTokenValue(w http.ResponseWriter, r *http.Requ
 	var site store.Site
 	var account store.Account
 	if err := h.db.Get(&account, h.db.Rebind("SELECT * FROM accounts WHERE id = ?"), token.AccountID); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "读取账号失败"})
+		writeError(w, http.StatusInternalServerError, "读取账号失败")
 		return
 	}
 	if err := h.db.Get(&site, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), account.SiteID); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "读取站点失败"})
+		writeError(w, http.StatusInternalServerError, "读取站点失败")
 		return
 	}
 
@@ -538,34 +535,34 @@ func (h *accountTokensHandler) deleteToken(w http.ResponseWriter, r *http.Reques
 	idStr := chi.URLParam(r, "id")
 	tokenID, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "令牌 ID 无效"})
+		writeError(w, http.StatusBadRequest, "令牌 ID 无效")
 		return
 	}
 
 	token, err := service.GetTokenByID(h.db, tokenID)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "令牌不存在"})
+		writeError(w, http.StatusNotFound, "令牌不存在")
 		return
 	}
 
 	owner, err := service.GetAccountByID(h.db, token.AccountID)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "令牌不存在"})
+		writeError(w, http.StatusNotFound, "令牌不存在")
 		return
 	}
 	if owner == nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "令牌不存在"})
+		writeError(w, http.StatusNotFound, "令牌不存在")
 		return
 	}
 	if service.IsAPIKeyConnection(owner) {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "API Key 连接不支持管理账号令牌"})
+		writeError(w, http.StatusBadRequest, "API Key 连接不支持管理账号令牌")
 		return
 	}
 
 	// Stub: upstream-first delete - just local delete for now
 	if err := service.DeleteTokenByID(h.db, tokenID); err != nil {
 		slog.Error("Token deletion failed", "err", err)
-		writeJSON(w, http.StatusBadGateway, map[string]any{"success": false, "message": "Token deletion failed"})
+		writeError(w, http.StatusBadGateway, "Token deletion failed")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})
@@ -577,13 +574,13 @@ func (h *accountTokensHandler) syncAccount(w http.ResponseWriter, r *http.Reques
 	accountIDStr := chi.URLParam(r, "accountId")
 	accountID, err := strconv.ParseInt(accountIDStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "账号 ID 无效"})
+		writeError(w, http.StatusBadRequest, "账号 ID 无效")
 		return
 	}
 
 	row, err := service.GetAccountWithSiteByID(h.db, accountID)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "账号不存在"})
+		writeError(w, http.StatusNotFound, "账号不存在")
 		return
 	}
 
@@ -607,7 +604,7 @@ func (h *accountTokensHandler) syncAccount(w http.ResponseWriter, r *http.Reques
 func (h *accountTokensHandler) syncAll(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountTokenSyncAllPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid request body"})
+		writeError(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
 
@@ -641,25 +638,25 @@ func (h *accountTokensHandler) getGroups(w http.ResponseWriter, r *http.Request)
 	accountIDStr := chi.URLParam(r, "accountId")
 	accountID, err := strconv.ParseInt(accountIDStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "账号 ID 无效"})
+		writeError(w, http.StatusBadRequest, "账号 ID 无效")
 		return
 	}
 
 	row, err := service.GetAccountWithSiteByID(h.db, accountID)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "账号不存在"})
+		writeError(w, http.StatusNotFound, "账号不存在")
 		return
 	}
 
 	if service.IsAPIKeyConnection(&row.Account) {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "API Key 连接不支持拉取账号令牌分组"})
+		writeError(w, http.StatusBadRequest, "API Key 连接不支持拉取账号令牌分组")
 		return
 	}
 
 	groups, err := service.GetTokenGroups(h.db, accountID)
 	if err != nil {
 		slog.Error("Failed to load token groups", "err", err, "account_id", accountID)
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "Failed to load token groups"})
+		writeError(w, http.StatusInternalServerError, "Failed to load token groups")
 		return
 	}
 
@@ -675,7 +672,7 @@ func (h *accountTokensHandler) getAccountDefault(w http.ResponseWriter, r *http.
 	accountIDStr := chi.URLParam(r, "accountId")
 	accountID, err := strconv.ParseInt(accountIDStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "账号 ID 无效"})
+		writeError(w, http.StatusBadRequest, "账号 ID 无效")
 		return
 	}
 
@@ -698,7 +695,7 @@ func (h *accountTokensHandler) getAccountDefault(w http.ResponseWriter, r *http.
 
 	var site store.Site
 	if err := h.db.Get(&site, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), account.SiteID); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "读取站点失败"})
+		writeError(w, http.StatusInternalServerError, "读取站点失败")
 		return
 	}
 

--- a/handler/admin/account_tokens_test.go
+++ b/handler/admin/account_tokens_test.go
@@ -724,8 +724,9 @@ func TestTokens_GetValue_Masked(t *testing.T) {
 
 	var result map[string]any
 	json.Unmarshal(resp.Body.Bytes(), &result)
-	if !strings.Contains(result["message"].(string), "脱敏") {
-		t.Errorf("expected masked token error message, got %v", result["message"])
+	errMsg, _ := result["error"].(string)
+	if !strings.Contains(errMsg, "脱敏") {
+		t.Errorf("expected masked token error message, got %#v", result)
 	}
 }
 

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -107,7 +107,7 @@ func (h *accountsHandler) listAccounts(w http.ResponseWriter, r *http.Request) {
 	accounts, err := service.ListAccountsWithSites(h.db)
 	if err != nil {
 		slog.Error("Failed to load accounts", "err", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load accounts"})
+		writeError(w, http.StatusInternalServerError, "Failed to load accounts")
 		return
 	}
 
@@ -132,19 +132,19 @@ func (h *accountsHandler) listAccounts(w http.ResponseWriter, r *http.Request) {
 func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountCreatePayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "Invalid account payload."})
+		writeError(w, http.StatusBadRequest, "Invalid account payload.")
 		return
 	}
 
 	if body.SiteID <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid siteId. Expected positive number."})
+		writeError(w, http.StatusBadRequest, "Invalid siteId. Expected positive number.")
 		return
 	}
 
 	// Check site exists
 	var site store.Site
 	if err := h.db.Get(&site, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), body.SiteID); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "site not found"})
+		writeError(w, http.StatusBadRequest, "site not found")
 		return
 	}
 
@@ -177,7 +177,7 @@ func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if len(requestedTokens) == 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "请填写 Token"})
+		writeError(w, http.StatusBadRequest, "请填写 Token")
 		return
 	}
 
@@ -247,10 +247,7 @@ func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) 
 	accountID, err := h.createSingleAccount(body, site, credentialMode, requestedTokens[0], body.Username)
 	if err != nil {
 		slog.Error("Account creation failed", "err", err)
-		writeJSON(w, http.StatusBadRequest, map[string]any{
-			"success": false,
-			"message": "Account creation failed",
-		})
+		writeError(w, http.StatusBadRequest, "Account creation failed")
 		return
 	}
 
@@ -338,33 +335,33 @@ func (h *accountsHandler) createSingleAccount(body payloads.AccountCreatePayload
 func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountLoginPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid login payload."})
+		writeError(w, http.StatusBadRequest, "Invalid login payload.")
 		return
 	}
 
 	if body.SiteID <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid siteId. Expected positive number."})
+		writeError(w, http.StatusBadRequest, "Invalid siteId. Expected positive number.")
 		return
 	}
 	if strings.TrimSpace(body.Username) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid username. Expected string."})
+		writeError(w, http.StatusBadRequest, "Invalid username. Expected string.")
 		return
 	}
 	if strings.TrimSpace(body.Password) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid password. Expected string."})
+		writeError(w, http.StatusBadRequest, "Invalid password. Expected string.")
 		return
 	}
 
 	// Get site
 	var site store.Site
 	if err := h.db.Get(&site, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), body.SiteID); err != nil {
-		writeJSON(w, http.StatusOK, map[string]any{"success": false, "message": "site not found"})
+		writeError(w, http.StatusNotFound, "site not found")
 		return
 	}
 
 	adp := platform.GetAdapter(site.Platform)
 	if adp == nil {
-		writeJSON(w, http.StatusOK, map[string]any{"success": false, "message": "unsupported platform: " + site.Platform})
+		writeError(w, http.StatusBadRequest, "unsupported platform: "+site.Platform)
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
@@ -372,7 +369,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 	loginResult, err := adp.Login(ctx, site.URL, body.Username, body.Password, nil, service.BuildPlatformProxyConfig(h.cfg, nil, &site))
 	if err != nil {
 		slog.Warn("Account login failed", "err", err, "site_id", site.ID, "platform", site.Platform)
-		writeJSON(w, http.StatusOK, map[string]any{"success": false, "message": "login failed"})
+		writeError(w, http.StatusBadGateway, "login failed")
 		return
 	}
 	if loginResult == nil || !loginResult.Success || strings.TrimSpace(loginResult.AccessToken) == "" {
@@ -380,7 +377,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 		if loginResult != nil && strings.TrimSpace(loginResult.Message) != "" {
 			message = strings.TrimSpace(loginResult.Message)
 		}
-		writeJSON(w, http.StatusOK, map[string]any{"success": false, "message": message})
+		writeError(w, http.StatusUnauthorized, message)
 		return
 	}
 	loginAccessToken := strings.TrimSpace(loginResult.AccessToken)
@@ -401,7 +398,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 	// Encrypt password for autoRelogin
 	passwordCipher, encErr := service.EncryptPassword(h.cfg, body.Password)
 	if encErr != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "Failed to encrypt password."})
+		writeError(w, http.StatusInternalServerError, "Failed to encrypt password.")
 		return
 	}
 
@@ -424,7 +421,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 			loginAccessToken, true, extraConfigStr, now, existing.ID,
 		); err != nil {
 			slog.Error("Failed to update login account", "err", err, "account_id", existing.ID)
-			writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "Failed to save account."})
+			writeError(w, http.StatusInternalServerError, "Failed to save account.")
 			return
 		}
 	} else {
@@ -436,7 +433,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 			body.SiteID, body.Username, loginAccessToken, true, false, sortOrder, extraConfigStr, now, now,
 		); err != nil {
 			slog.Error("Failed to insert login account", "err", err, "site_id", body.SiteID)
-			writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "Failed to save account."})
+			writeError(w, http.StatusInternalServerError, "Failed to save account.")
 			return
 		}
 	}
@@ -445,7 +442,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 	var loginAcct store.Account
 	if err := h.db.Get(&loginAcct, h.db.Rebind("SELECT * FROM accounts WHERE site_id = ? AND username = ?"), body.SiteID, body.Username); err != nil {
 		slog.Error("Failed to load login account", "err", err, "site_id", body.SiteID)
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "Failed to load account."})
+		writeError(w, http.StatusInternalServerError, "Failed to load account.")
 		return
 	}
 	loginAcctMap := map[string]any{
@@ -479,12 +476,12 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountVerifyTokenPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid verify-token payload."})
+		writeError(w, http.StatusBadRequest, "Invalid verify-token payload.")
 		return
 	}
 
 	if body.SiteID <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid siteId. Expected positive number."})
+		writeError(w, http.StatusBadRequest, "Invalid siteId. Expected positive number.")
 		return
 	}
 
@@ -493,20 +490,20 @@ func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 		accessToken = strings.TrimSpace(*body.AccessToken)
 	}
 	if accessToken == "" {
-		writeJSON(w, http.StatusOK, map[string]any{"success": false, "error": "Token 不能为空"})
+		writeError(w, http.StatusBadRequest, "Token 不能为空")
 		return
 	}
 
 	// Get site
 	var site store.Site
 	if err := h.db.Get(&site, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), body.SiteID); err != nil {
-		writeJSON(w, http.StatusOK, map[string]any{"success": false, "message": "site not found"})
+		writeError(w, http.StatusNotFound, "site not found")
 		return
 	}
 
 	adp := platform.GetAdapter(site.Platform)
 	if adp == nil {
-		writeJSON(w, http.StatusOK, map[string]any{"success": false, "message": "unsupported platform: " + site.Platform})
+		writeError(w, http.StatusBadRequest, "unsupported platform: "+site.Platform)
 		return
 	}
 
@@ -514,15 +511,11 @@ func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	result, err := adp.VerifyToken(ctx, site.URL, accessToken, body.PlatformUserID, service.BuildPlatformProxyConfig(h.cfg, nil, &site))
 	if err != nil {
-		writeJSON(w, http.StatusOK, map[string]any{"success": false, "message": err.Error()})
+		writeError(w, http.StatusBadGateway, "token verification failed")
 		return
 	}
 	if result == nil || result.TokenType == "" || result.TokenType == "unknown" {
-		writeJSON(w, http.StatusOK, map[string]any{
-			"success":   false,
-			"tokenType": "unknown",
-			"message":   "token verification failed",
-		})
+		writeError(w, http.StatusBadRequest, "token verification failed")
 		return
 	}
 
@@ -582,13 +575,13 @@ func (h *accountsHandler) rebindSession(w http.ResponseWriter, r *http.Request) 
 	idStr := chi.URLParam(r, "id")
 	accountID, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || accountID <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "账号 ID 无效"})
+		writeError(w, http.StatusBadRequest, "账号 ID 无效")
 		return
 	}
 
 	var body payloads.AccountRebindSessionPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid rebind payload."})
+		writeError(w, http.StatusBadRequest, "Invalid rebind payload.")
 		return
 	}
 
@@ -597,13 +590,13 @@ func (h *accountsHandler) rebindSession(w http.ResponseWriter, r *http.Request) 
 		nextAccessToken = strings.TrimSpace(*body.AccessToken)
 	}
 	if nextAccessToken == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "请提供新的 Session Token"})
+		writeError(w, http.StatusBadRequest, "请提供新的 Session Token")
 		return
 	}
 
 	row, err := service.GetAccountWithSiteByID(h.db, accountID)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "账号不存在"})
+		writeError(w, http.StatusNotFound, "账号不存在")
 		return
 	}
 
@@ -620,14 +613,14 @@ func (h *accountsHandler) rebindSession(w http.ResponseWriter, r *http.Request) 
 		h.db.Rebind("UPDATE accounts SET access_token = ?, status = 'active', extra_config = ?, updated_at = ? WHERE id = ?"),
 		nextAccessToken, extraConfigStr, now, accountID,
 	); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "failed to update account"})
+		writeError(w, http.StatusInternalServerError, "failed to update account")
 		return
 	}
 
 	// Fetch updated account for response
 	var rebindAcct store.Account
 	if err := h.db.Get(&rebindAcct, h.db.Rebind("SELECT * FROM accounts WHERE id = ?"), accountID); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "failed to read updated account"})
+		writeError(w, http.StatusInternalServerError, "failed to read updated account")
 		return
 	}
 	rebindAcctMap := map[string]any{
@@ -663,19 +656,19 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid account id"})
+		writeError(w, http.StatusBadRequest, "Invalid account id")
 		return
 	}
 
 	var body payloads.AccountUpdatePayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid account payload."})
+		writeError(w, http.StatusBadRequest, "Invalid account payload.")
 		return
 	}
 
 	row, err := service.GetAccountWithSiteByID(h.db, id)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"message": "account not found"})
+		writeError(w, http.StatusNotFound, "account not found")
 		return
 	}
 
@@ -706,14 +699,14 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 	if body.Status != nil {
 		status := normalizeAccountStatus(*body.Status)
 		if status == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid account status. Expected active, disabled, or expired."})
+			writeError(w, http.StatusBadRequest, "Invalid account status. Expected active, disabled, or expired.")
 			return
 		}
 		updates["status"] = status
 	}
 	if body.UnitCost != nil {
 		if *body.UnitCost <= 0 {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid unitCost value. Expected positive number."})
+			writeError(w, http.StatusBadRequest, "Invalid unitCost value. Expected positive number.")
 			return
 		}
 		updates["unitCost"] = *body.UnitCost
@@ -745,7 +738,7 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 	if body.SortOrder != nil {
 		so := service.NormalizeSortOrder(body.SortOrder)
 		if so == nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid sortOrder value. Expected non-negative integer."})
+			writeError(w, http.StatusBadRequest, "Invalid sortOrder value. Expected non-negative integer.")
 			return
 		}
 		updates["sortOrder"] = int64(*so)
@@ -763,7 +756,7 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 
 	if err := service.UpdateAccountFields(h.db, id, updates); err != nil {
 		slog.Error("Failed to update account", "err", err, "account_id", id)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Failed to update account"})
+		writeError(w, http.StatusInternalServerError, "Failed to update account")
 		return
 	}
 
@@ -780,12 +773,12 @@ func (h *accountsHandler) deleteAccount(w http.ResponseWriter, r *http.Request) 
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid account id"})
+		writeError(w, http.StatusBadRequest, "Invalid account id")
 		return
 	}
 	if err := service.DeleteAccount(h.db, id); err != nil {
 		slog.Error("Failed to delete account", "err", err, "account_id", id)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Failed to delete account"})
+		writeError(w, http.StatusInternalServerError, "Failed to delete account")
 		return
 	}
 	service.RebuildRoutesBestEffort()
@@ -798,19 +791,19 @@ func (h *accountsHandler) deleteAccount(w http.ResponseWriter, r *http.Request) 
 func (h *accountsHandler) batchAccounts(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountBatchPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Invalid account batch payload."})
+		writeError(w, http.StatusBadRequest, "Invalid account batch payload.")
 		return
 	}
 
 	if len(body.IDs) == 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "ids is required"})
+		writeError(w, http.StatusBadRequest, "ids is required")
 		return
 	}
 
 	action := strings.TrimSpace(body.Action)
 	validActions := map[string]bool{"enable": true, "disable": true, "delete": true, "refreshBalance": true}
 	if !validActions[action] {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Invalid action"})
+		writeError(w, http.StatusBadRequest, "Invalid action")
 		return
 	}
 
@@ -893,7 +886,7 @@ func (h *accountsHandler) batchAccounts(w http.ResponseWriter, r *http.Request) 
 func (h *accountsHandler) healthRefresh(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountHealthRefreshPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "Invalid health refresh payload."})
+		writeError(w, http.StatusBadRequest, "Invalid health refresh payload.")
 		return
 	}
 
@@ -929,22 +922,22 @@ func (h *accountsHandler) refreshBalance(w http.ResponseWriter, r *http.Request)
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"message": "account not found or platform not supported"})
+		writeError(w, http.StatusNotFound, "account not found or platform not supported")
 		return
 	}
 
 	result, err := balanceService.RefreshBalance(h.cfg, h.db, id)
 	if result == nil && err == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"message": "account not found or platform not supported"})
+		writeError(w, http.StatusNotFound, "account not found or platform not supported")
 		return
 	}
 	if err != nil {
 		if strings.Contains(err.Error(), "unsupported platform") {
-			writeJSON(w, http.StatusNotFound, map[string]string{"message": "account not found or platform not supported"})
+			writeError(w, http.StatusNotFound, "account not found or platform not supported")
 			return
 		}
 		slog.Warn("Balance refresh failed", "err", err, "account_id", id)
-		writeJSON(w, http.StatusBadGateway, map[string]string{"message": "balance refresh failed"})
+		writeError(w, http.StatusBadGateway, "balance refresh failed")
 		return
 	}
 
@@ -963,13 +956,13 @@ func (h *accountsHandler) getAccountModels(w http.ResponseWriter, r *http.Reques
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "账号 ID 无效"})
+		writeError(w, http.StatusBadRequest, "账号 ID 无效")
 		return
 	}
 
 	row, err := service.GetAccountWithSiteByID(h.db, id)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"message": "账号不存在"})
+		writeError(w, http.StatusNotFound, "账号不存在")
 		return
 	}
 
@@ -1018,18 +1011,18 @@ func (h *accountsHandler) manualModels(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "账号 ID 无效"})
+		writeError(w, http.StatusBadRequest, "账号 ID 无效")
 		return
 	}
 
 	var body payloads.AccountManualModelsPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid models. Expected string[]."})
+		writeError(w, http.StatusBadRequest, "Invalid models. Expected string[].")
 		return
 	}
 
 	if len(body.Models) == 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "模型列表不能为空"})
+		writeError(w, http.StatusBadRequest, "模型列表不能为空")
 		return
 	}
 
@@ -1044,20 +1037,20 @@ func (h *accountsHandler) manualModels(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if len(models) == 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "模型列表不能为空"})
+		writeError(w, http.StatusBadRequest, "模型列表不能为空")
 		return
 	}
 
 	var account store.Account
 	if err := h.db.Get(&account, h.db.Rebind("SELECT * FROM accounts WHERE id = ?"), id); err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"message": "账号不存在"})
+		writeError(w, http.StatusNotFound, "账号不存在")
 		return
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	tx, err := h.db.Beginx()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to start transaction"})
+		writeError(w, http.StatusInternalServerError, "failed to start transaction")
 		return
 	}
 	committed := false
@@ -1072,22 +1065,22 @@ func (h *accountsHandler) manualModels(w http.ResponseWriter, r *http.Request) {
 		err := tx.Get(&existingID, tx.Rebind("SELECT id FROM model_availability WHERE account_id = ? AND model_name = ?"), id, m)
 		if err == nil {
 			if _, err := tx.Exec(tx.Rebind("UPDATE model_availability SET available = ?, latency_ms = NULL, is_manual = ?, checked_at = ? WHERE id = ?"), true, true, now, existingID); err != nil {
-				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update manual model"})
+				writeError(w, http.StatusInternalServerError, "failed to update manual model")
 				return
 			}
 			continue
 		}
 		if !errors.Is(err, sql.ErrNoRows) {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to read manual model"})
+			writeError(w, http.StatusInternalServerError, "failed to read manual model")
 			return
 		}
 		if _, err := tx.Exec(tx.Rebind("INSERT INTO model_availability (account_id, model_name, available, is_manual, latency_ms, checked_at) VALUES (?, ?, ?, ?, NULL, ?)"), id, m, true, true, now); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to insert manual model"})
+			writeError(w, http.StatusInternalServerError, "failed to insert manual model")
 			return
 		}
 	}
 	if err := tx.Commit(); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to commit manual models"})
+		writeError(w, http.StatusInternalServerError, "failed to commit manual models")
 		return
 	}
 	committed = true

--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -690,15 +690,18 @@ func TestAccounts_Login_InvalidCredentialsDoNotCreateAccount(t *testing.T) {
 		"username": "baduser",
 		"password": "badpass",
 	})
-	if resp.Code != http.StatusOK {
+	if resp.Code == http.StatusOK {
+		t.Fatalf("login failure must not return HTTP 200, body=%s", resp.Body.String())
+	}
+	if resp.Code < 400 {
 		t.Fatalf("login failure response status = %d body=%s", resp.Code, resp.Body.String())
 	}
 	var result map[string]any
 	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if result["success"] != false {
-		t.Fatalf("success = %v, want false", result["success"])
+	if result["error"] == nil || result["error"] == "" {
+		t.Fatalf("expected error field, got %#v", result)
 	}
 	if loginCalls != 1 {
 		t.Fatalf("loginCalls = %d, want 1", loginCalls)
@@ -798,13 +801,13 @@ func TestAccounts_VerifyToken_EmptyToken(t *testing.T) {
 
 	body := map[string]any{"siteId": siteID, "accessToken": ""}
 	resp := doPostJSON(t, r, "/api/accounts/verify-token", body)
-	if resp.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.Code)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", resp.Code, resp.Body.String())
 	}
 	var result map[string]any
 	json.Unmarshal(resp.Body.Bytes(), &result)
-	if result["success"] != false {
-		t.Error("expected success=false for empty token")
+	if result["error"] == nil || result["error"] == "" {
+		t.Errorf("expected error field for empty token, got %#v", result)
 	}
 }
 
@@ -1605,13 +1608,13 @@ func TestAccounts_Login_SiteNotFound(t *testing.T) {
 	_, r, _ := setupAccountsTest(t)
 	body := map[string]any{"siteId": 99999, "username": "u", "password": "p"}
 	resp := doPostJSON(t, r, "/api/accounts/login", body)
-	if resp.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.Code)
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%s", resp.Code, resp.Body.String())
 	}
 	var result map[string]any
 	json.Unmarshal(resp.Body.Bytes(), &result)
-	if result["success"] != false {
-		t.Error("expected success=false for missing site")
+	if result["error"] == nil || result["error"] == "" {
+		t.Errorf("expected error field for missing site, got %#v", result)
 	}
 }
 
@@ -1675,16 +1678,14 @@ func TestAccounts_VerifyToken_SiteNotFound(t *testing.T) {
 	_, r, _ := setupAccountsTest(t)
 	body := map[string]any{"siteId": 99999, "accessToken": "missing-site-token"}
 	resp := doPostJSON(t, r, "/api/accounts/verify-token", body)
-	if resp.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.Code)
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%s", resp.Code, resp.Body.String())
 	}
 	var result map[string]any
 	json.Unmarshal(resp.Body.Bytes(), &result)
-	if result["success"] != false {
-		t.Error("expected success=false for missing site")
-	}
-	if !strings.Contains(result["message"].(string), "site not found") {
-		t.Errorf("expected 'site not found', got %v", result["message"])
+	errMsg, _ := result["error"].(string)
+	if !strings.Contains(errMsg, "site not found") {
+		t.Errorf("expected 'site not found', got %#v", result)
 	}
 }
 

--- a/handler/admin/downstream_keys.go
+++ b/handler/admin/downstream_keys.go
@@ -128,7 +128,7 @@ func (h *downstreamKeysHandler) createKey(w http.ResponseWriter, r *http.Request
 		ExcludedCredentialRefs []any    `json:"excludedCredentialRefs"`
 	}
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid request body"})
+		writeError(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
 
@@ -136,15 +136,15 @@ func (h *downstreamKeysHandler) createKey(w http.ResponseWriter, r *http.Request
 	body.Key = strings.TrimSpace(body.Key)
 
 	if body.Name == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "name 不能为空"})
+		writeError(w, http.StatusBadRequest, "name 不能为空")
 		return
 	}
 	if body.Key == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "key 不能为空"})
+		writeError(w, http.StatusBadRequest, "key 不能为空")
 		return
 	}
 	if !strings.HasPrefix(body.Key, "sk-") || len(body.Key) < 6 {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "key 必须以 sk- 开头且长度至少 6"})
+		writeError(w, http.StatusBadRequest, "key 必须以 sk- 开头且长度至少 6")
 		return
 	}
 
@@ -152,7 +152,7 @@ func (h *downstreamKeysHandler) createKey(w http.ResponseWriter, r *http.Request
 	var count int
 	h.db.Get(&count, rebindAdminQuery(h.db, "SELECT COUNT(*) FROM downstream_api_keys WHERE key = ?"), body.Key)
 	if count > 0 {
-		writeJSON(w, http.StatusConflict, map[string]any{"success": false, "message": "API key 已存在"})
+		writeError(w, http.StatusConflict, "API key 已存在")
 		return
 	}
 
@@ -166,7 +166,7 @@ func (h *downstreamKeysHandler) createKey(w http.ResponseWriter, r *http.Request
 
 	// Policy reference validation.
 	if refErr := h.validateDownstreamPolicyReferences(normalizedRouteIds, normalizedSWM, normalizedExcludedSites, normalizedCredRefs); refErr != "" {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": refErr})
+		writeError(w, http.StatusBadRequest, refErr)
 		return
 	}
 
@@ -204,10 +204,10 @@ func (h *downstreamKeysHandler) createKey(w http.ResponseWriter, r *http.Request
 	)
 	if err != nil {
 		if isUniqueConstraintError(err) {
-			writeJSON(w, http.StatusConflict, map[string]any{"success": false, "message": "API key 已存在"})
+			writeError(w, http.StatusConflict, "API key 已存在")
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "创建失败"})
+		writeError(w, http.StatusInternalServerError, "创建失败")
 		return
 	}
 	created := queryRow(h.db, "SELECT * FROM downstream_api_keys WHERE id = ?", id)
@@ -228,13 +228,13 @@ func (h *downstreamKeysHandler) updateKey(w http.ResponseWriter, r *http.Request
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "id 无效"})
+		writeError(w, http.StatusBadRequest, "id 无效")
 		return
 	}
 
 	existing := queryRow(h.db, "SELECT * FROM downstream_api_keys WHERE id = ?", id)
 	if existing == nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "API key 不存在"})
+		writeError(w, http.StatusNotFound, "API key 不存在")
 		return
 	}
 
@@ -259,14 +259,14 @@ func (h *downstreamKeysHandler) updateKey(w http.ResponseWriter, r *http.Request
 
 	bodyBytes, err := decodeJSONRequestRaw(r, &body)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid request body"})
+		writeError(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
 
 	// First unmarshal into map to detect which fields were present in JSON.
 	rawBody := map[string]any{}
 	if err := json.Unmarshal(bodyBytes, &rawBody); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid request body"})
+		writeError(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
 
@@ -399,15 +399,15 @@ func (h *downstreamKeysHandler) updateKey(w http.ResponseWriter, r *http.Request
 
 	// Validate.
 	if name == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "name 不能为空"})
+		writeError(w, http.StatusBadRequest, "name 不能为空")
 		return
 	}
 	if key == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "key 不能为空"})
+		writeError(w, http.StatusBadRequest, "key 不能为空")
 		return
 	}
 	if !strings.HasPrefix(key, "sk-") || len(key) < 6 {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "key 必须以 sk- 开头且长度至少 6"})
+		writeError(w, http.StatusBadRequest, "key 必须以 sk- 开头且长度至少 6")
 		return
 	}
 
@@ -416,14 +416,14 @@ func (h *downstreamKeysHandler) updateKey(w http.ResponseWriter, r *http.Request
 		var dupCount int
 		h.db.Get(&dupCount, rebindAdminQuery(h.db, "SELECT COUNT(*) FROM downstream_api_keys WHERE key = ? AND id != ?"), key, id)
 		if dupCount > 0 {
-			writeJSON(w, http.StatusConflict, map[string]any{"success": false, "message": "API key 已存在"})
+			writeError(w, http.StatusConflict, "API key 已存在")
 			return
 		}
 	}
 
 	// Policy reference validation.
 	if refErr := h.validateDownstreamPolicyReferences(allowedRouteIds, siteWeightMultipliers, excludedSiteIds, excludedCredentialRefs); refErr != "" {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": refErr})
+		writeError(w, http.StatusBadRequest, refErr)
 		return
 	}
 
@@ -450,10 +450,10 @@ func (h *downstreamKeysHandler) updateKey(w http.ResponseWriter, r *http.Request
 	)
 	if err != nil {
 		if isUniqueConstraintError(err) {
-			writeJSON(w, http.StatusConflict, map[string]any{"success": false, "message": "API key 已存在"})
+			writeError(w, http.StatusConflict, "API key 已存在")
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "更新失败"})
+		writeError(w, http.StatusInternalServerError, "更新失败")
 		return
 	}
 
@@ -475,13 +475,13 @@ func (h *downstreamKeysHandler) resetUsage(w http.ResponseWriter, r *http.Reques
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "id 无效"})
+		writeError(w, http.StatusBadRequest, "id 无效")
 		return
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	if _, err := h.db.Exec(rebindAdminQuery(h.db, "UPDATE downstream_api_keys SET used_cost = 0, used_requests = 0, updated_at = ? WHERE id = ?"), now, id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "重置失败"})
+		writeError(w, http.StatusInternalServerError, "重置失败")
 		return
 	}
 
@@ -497,12 +497,12 @@ func (h *downstreamKeysHandler) deleteKey(w http.ResponseWriter, r *http.Request
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "id 无效"})
+		writeError(w, http.StatusBadRequest, "id 无效")
 		return
 	}
 
 	if _, err := h.db.Exec(rebindAdminQuery(h.db, "DELETE FROM downstream_api_keys WHERE id = ?"), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "删除失败"})
+		writeError(w, http.StatusInternalServerError, "删除失败")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})
@@ -513,13 +513,13 @@ func (h *downstreamKeysHandler) overview(w http.ResponseWriter, r *http.Request)
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "id 无效"})
+		writeError(w, http.StatusBadRequest, "id 无效")
 		return
 	}
 
 	row := queryRow(h.db, "SELECT * FROM downstream_api_keys WHERE id = ?", id)
 	if row == nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "API key 不存在"})
+		writeError(w, http.StatusNotFound, "API key 不存在")
 		return
 	}
 
@@ -543,13 +543,13 @@ func (h *downstreamKeysHandler) trend(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "id 无效"})
+		writeError(w, http.StatusBadRequest, "id 无效")
 		return
 	}
 
 	row := queryRow(h.db, "SELECT * FROM downstream_api_keys WHERE id = ?", id)
 	if row == nil {
-		writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "API key 不存在"})
+		writeError(w, http.StatusNotFound, "API key 不存在")
 		return
 	}
 
@@ -576,12 +576,12 @@ func (h *downstreamKeysHandler) batchKeys(w http.ResponseWriter, r *http.Request
 		TagOperation   *string  `json:"tagOperation"`
 	}
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid request body"})
+		writeError(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
 
 	if len(body.IDs) == 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "ids is required"})
+		writeError(w, http.StatusBadRequest, "ids is required")
 		return
 	}
 
@@ -591,7 +591,7 @@ func (h *downstreamKeysHandler) batchKeys(w http.ResponseWriter, r *http.Request
 		"resetUsage": true, "updateMetadata": true,
 	}
 	if !validActions[action] {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid action"})
+		writeError(w, http.StatusBadRequest, "Invalid action")
 		return
 	}
 

--- a/handler/admin/error_model_test.go
+++ b/handler/admin/error_model_test.go
@@ -1,0 +1,108 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// B3: high-traffic admin create/update mutation failures must use non-2xx
+// status codes with camelCase {"error":"..."} bodies (no silent HTTP 200).
+
+func TestB3_SitesCreate_InvalidPayload_StatusAndErrorJSON(t *testing.T) {
+	_, r := setupSitesTest(t)
+	resp := doPostJSON(t, r, "/api/sites", map[string]any{"name": "", "url": ""})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 body=%s", resp.Code, resp.Body.String())
+	}
+	assertUnifiedErrorBody(t, resp.Body.Bytes())
+}
+
+func TestB3_SitesCreate_MissingName_StatusAndErrorJSON(t *testing.T) {
+	_, r := setupSitesTest(t)
+	resp := doPostJSON(t, r, "/api/sites", map[string]any{"name": "  ", "url": "https://api.openai.com"})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 body=%s", resp.Code, resp.Body.String())
+	}
+	assertUnifiedErrorBody(t, resp.Body.Bytes())
+}
+
+func TestB3_SitesUpdate_InvalidID_StatusAndErrorJSON(t *testing.T) {
+	_, r := setupSitesTest(t)
+	resp := doPutJSON(t, r, "/api/sites/not-a-number", map[string]any{"name": "x"})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 body=%s", resp.Code, resp.Body.String())
+	}
+	assertUnifiedErrorBody(t, resp.Body.Bytes())
+}
+
+func TestB3_AccountsCreate_InvalidPayload_StatusAndErrorJSON(t *testing.T) {
+	_, r, _ := setupAccountsTest(t)
+	resp := doPostJSON(t, r, "/api/accounts", map[string]any{"siteId": 0})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 body=%s", resp.Code, resp.Body.String())
+	}
+	assertUnifiedErrorBody(t, resp.Body.Bytes())
+}
+
+func TestB3_AccountsUpdate_InvalidID_StatusAndErrorJSON(t *testing.T) {
+	_, r, _ := setupAccountsTest(t)
+	resp := doPutJSON(t, r, "/api/accounts/abc", map[string]any{"status": "active"})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 body=%s", resp.Code, resp.Body.String())
+	}
+	assertUnifiedErrorBody(t, resp.Body.Bytes())
+}
+
+func TestB3_AccountsLogin_SiteNotFound_NotSilent200(t *testing.T) {
+	_, r, _ := setupAccountsTest(t)
+	resp := doPostJSON(t, r, "/api/accounts/login", map[string]any{
+		"siteId":   99999,
+		"username": "u",
+		"password": "p",
+	})
+	if resp.Code == http.StatusOK {
+		t.Fatalf("login failure must not return HTTP 200, body=%s", resp.Body.String())
+	}
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 body=%s", resp.Code, resp.Body.String())
+	}
+	assertUnifiedErrorBody(t, resp.Body.Bytes())
+}
+
+func TestB3_DownstreamKeysCreate_InvalidKey_StatusAndErrorJSON(t *testing.T) {
+	_, r := setupDownstreamKeysTest(t)
+	resp := doPostJSON(t, r, "/api/downstream-keys", map[string]any{
+		"name": "demo",
+		"key":  "bad",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 body=%s", resp.Code, resp.Body.String())
+	}
+	assertUnifiedErrorBody(t, resp.Body.Bytes())
+}
+
+func TestB3_DownstreamKeysUpdate_InvalidID_StatusAndErrorJSON(t *testing.T) {
+	_, r := setupDownstreamKeysTest(t)
+	resp := doPutJSON(t, r, "/api/downstream-keys/0", map[string]any{"name": "x"})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 body=%s", resp.Code, resp.Body.String())
+	}
+	assertUnifiedErrorBody(t, resp.Body.Bytes())
+}
+
+func assertUnifiedErrorBody(t *testing.T, raw []byte) {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal error body: %v raw=%s", err, string(raw))
+	}
+	errVal, ok := body["error"].(string)
+	if !ok || errVal == "" {
+		t.Fatalf("expected non-empty camelCase error field, got %#v", body)
+	}
+	// Unified mutation errors should not rely on success:false under HTTP 200.
+	if success, has := body["success"]; has && success == true {
+		t.Fatalf("error body must not claim success=true: %#v", body)
+	}
+}

--- a/handler/admin/response_errors.go
+++ b/handler/admin/response_errors.go
@@ -1,0 +1,19 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/tokendancelab/metapi-go/handler/shared"
+)
+
+// writeError writes a unified admin API error: non-2xx status + camelCase JSON
+// {"error":"..."}. Prefer this over writeJSON(..., {"success":false,...}) for
+// mutation failure paths so clients never see HTTP 200 with an error body.
+func writeError(w http.ResponseWriter, code int, message string) {
+	shared.WriteError(w, code, message)
+}
+
+// writeErrorDetail writes {"error":"...","detail":"..."} with a non-2xx status.
+func writeErrorDetail(w http.ResponseWriter, code int, message, detail string) {
+	shared.WriteErrorDetail(w, code, message, detail)
+}

--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -47,7 +47,7 @@ func (h *sitesHandler) listSites(w http.ResponseWriter, r *http.Request) {
 	sites, err := service.ListSites(h.db)
 	if err != nil {
 		slog.Error("Failed to load sites", "err", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load sites"})
+		writeError(w, http.StatusInternalServerError, "Failed to load sites")
 		return
 	}
 	writeJSON(w, http.StatusOK, sites)
@@ -58,58 +58,58 @@ func (h *sitesHandler) listSites(w http.ResponseWriter, r *http.Request) {
 func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 	var body payloads.SiteCreatePayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Invalid site payload."})
+		writeError(w, http.StatusBadRequest, "Invalid site payload.")
 		return
 	}
 
 	// Validate name and url
 	if strings.TrimSpace(body.Name) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid name. Expected non-empty string."})
+		writeError(w, http.StatusBadRequest, "Invalid name. Expected non-empty string.")
 		return
 	}
 	if strings.TrimSpace(body.URL) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid url. Expected non-empty string."})
+		writeError(w, http.StatusBadRequest, "Invalid url. Expected non-empty string.")
 		return
 	}
 
 	// Normalize values
 	normalizedStatus := normalizeSiteStatusString(body.Status)
 	if body.Status != nil && normalizedStatus == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid site status. Expected active or disabled."})
+		writeError(w, http.StatusBadRequest, "Invalid site status. Expected active or disabled.")
 		return
 	}
 	if body.UseSystemProxy != nil {
 		if !boolPtrValid(body.UseSystemProxy) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid useSystemProxy value. Expected boolean."})
+			writeError(w, http.StatusBadRequest, "Invalid useSystemProxy value. Expected boolean.")
 			return
 		}
 	}
 	if body.ProxyURL != nil && *body.ProxyURL != "" && !service.IsValidProxyURL(*body.ProxyURL) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid proxyUrl. Expected a valid http(s)/socks proxy URL."})
+		writeError(w, http.StatusBadRequest, "Invalid proxyUrl. Expected a valid http(s)/socks proxy URL.")
 		return
 	}
 	if body.ExternalCheckinURL != nil && *body.ExternalCheckinURL != "" && !service.IsValidHTTPURL(*body.ExternalCheckinURL) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid externalCheckinUrl. Expected a valid http(s) URL."})
+		writeError(w, http.StatusBadRequest, "Invalid externalCheckinUrl. Expected a valid http(s) URL.")
 		return
 	}
 	normalizedPinned := body.IsPinned
 	if body.IsPinned != nil && !boolPtrValid(body.IsPinned) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid isPinned value. Expected boolean."})
+		writeError(w, http.StatusBadRequest, "Invalid isPinned value. Expected boolean.")
 		return
 	}
 	normalizedSortOrder := service.NormalizeSortOrder(body.SortOrder)
 	if body.SortOrder != nil && normalizedSortOrder == nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid sortOrder value. Expected non-negative integer."})
+		writeError(w, http.StatusBadRequest, "Invalid sortOrder value. Expected non-negative integer.")
 		return
 	}
 	normalizedWeight := service.NormalizeGlobalWeight(body.GlobalWeight)
 	if body.GlobalWeight != nil && normalizedWeight == nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid globalWeight value. Expected a positive number."})
+		writeError(w, http.StatusBadRequest, "Invalid globalWeight value. Expected a positive number.")
 		return
 	}
 	if body.CustomHeaders != nil && *body.CustomHeaders != "" {
 		if !json.Valid([]byte(*body.CustomHeaders)) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid customHeaders."})
+			writeError(w, http.StatusBadRequest, "Invalid customHeaders.")
 			return
 		}
 	}
@@ -117,7 +117,7 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 	// Normalize API endpoints
 	eps, err := normalizeAPIEndpointsInput(body.APIEndpoints)
 	if err != "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err})
+		writeError(w, http.StatusBadRequest, err)
 		return
 	}
 
@@ -134,7 +134,7 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if platform == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Could not detect platform. Please specify manually."})
+		writeError(w, http.StatusBadRequest, "Could not detect platform. Please specify manually.")
 		return
 	}
 
@@ -148,9 +148,7 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 	var existingCount int
 	h.db.Get(&existingCount, h.db.Rebind("SELECT COUNT(*) FROM sites WHERE platform = ? AND url = ?"), platform, canonicalURL)
 	if existingCount > 0 {
-		writeJSON(w, http.StatusConflict, map[string]string{
-			"error": fmt.Sprintf("A %s site with URL %s already exists.", platform, canonicalURL),
-		})
+		writeError(w, http.StatusConflict, fmt.Sprintf("A %s site with URL %s already exists.", platform, canonicalURL))
 		return
 	}
 
@@ -202,18 +200,16 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 	if createErr != nil {
 		// Check for unique constraint violation
 		if isUniqueConstraintError(createErr) {
-			writeJSON(w, http.StatusConflict, map[string]string{
-				"error": fmt.Sprintf("A %s site with URL %s already exists.", platform, canonicalURL),
-			})
+			writeError(w, http.StatusConflict, fmt.Sprintf("A %s site with URL %s already exists.", platform, canonicalURL))
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Create site failed"})
+		writeError(w, http.StatusInternalServerError, "Create site failed")
 		return
 	}
 
 	result, _ := service.LoadSiteWithEndpoints(h.db, createdID)
 	if result == nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Create site failed"})
+		writeError(w, http.StatusInternalServerError, "Create site failed")
 		return
 	}
 	routing.InvalidateCache()
@@ -226,24 +222,24 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid site id"})
+		writeError(w, http.StatusBadRequest, "Invalid site id")
 		return
 	}
 
 	var existing store.Site
 	err = h.db.Get(&existing, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), id)
 	if err == sql.ErrNoRows {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "Site not found"})
+		writeError(w, http.StatusNotFound, "Site not found")
 		return
 	} else if err != nil {
 		slog.Error("Failed to load site for update", "err", err, "site_id", id)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load site"})
+		writeError(w, http.StatusInternalServerError, "Failed to load site")
 		return
 	}
 
 	var body payloads.SiteUpdatePayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid site payload."})
+		writeError(w, http.StatusBadRequest, "Invalid site payload.")
 		return
 	}
 
@@ -252,14 +248,14 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	// Validate each field
 	if body.Name != nil {
 		if strings.TrimSpace(*body.Name) == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid name. Expected non-empty string."})
+			writeError(w, http.StatusBadRequest, "Invalid name. Expected non-empty string.")
 			return
 		}
 		updates["name"] = *body.Name
 	}
 	if body.URL != nil {
 		if strings.TrimSpace(*body.URL) == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid url. Expected non-empty string."})
+			writeError(w, http.StatusBadRequest, "Invalid url. Expected non-empty string.")
 			return
 		}
 		updates["url"] = service.CanonicalizeSiteURL(*body.URL)
@@ -267,14 +263,14 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	if body.Platform != nil {
 		p := strings.TrimSpace(strings.ToLower(*body.Platform))
 		if p == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid platform. Expected non-empty string."})
+			writeError(w, http.StatusBadRequest, "Invalid platform. Expected non-empty string.")
 			return
 		}
 		updates["platform"] = p
 	}
 	if body.ProxyURL != nil {
 		if *body.ProxyURL != "" && !service.IsValidProxyURL(*body.ProxyURL) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid proxyUrl. Expected a valid http(s)/socks proxy URL."})
+			writeError(w, http.StatusBadRequest, "Invalid proxyUrl. Expected a valid http(s)/socks proxy URL.")
 			return
 		}
 		updates["proxyUrl"] = service.NormalizeNullable(body.ProxyURL)
@@ -287,7 +283,7 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.ExternalCheckinURL != nil {
 		if *body.ExternalCheckinURL != "" && !service.IsValidHTTPURL(*body.ExternalCheckinURL) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid externalCheckinUrl. Expected a valid http(s) URL."})
+			writeError(w, http.StatusBadRequest, "Invalid externalCheckinUrl. Expected a valid http(s) URL.")
 			return
 		}
 		updates["externalCheckinUrl"] = service.NormalizeNullable(body.ExternalCheckinURL)
@@ -295,7 +291,7 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	if body.Status != nil {
 		ns := normalizeSiteStatusString(body.Status)
 		if ns == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid site status. Expected active or disabled."})
+			writeError(w, http.StatusBadRequest, "Invalid site status. Expected active or disabled.")
 			return
 		}
 		updates["status"] = ns
@@ -306,7 +302,7 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	if body.SortOrder != nil {
 		so := service.NormalizeSortOrder(body.SortOrder)
 		if so == nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid sortOrder value. Expected non-negative integer."})
+			writeError(w, http.StatusBadRequest, "Invalid sortOrder value. Expected non-negative integer.")
 			return
 		}
 		updates["sortOrder"] = int64(*so)
@@ -314,7 +310,7 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	if body.GlobalWeight != nil {
 		gw := service.NormalizeGlobalWeight(body.GlobalWeight)
 		if gw == nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid globalWeight value. Expected a positive number."})
+			writeError(w, http.StatusBadRequest, "Invalid globalWeight value. Expected a positive number.")
 			return
 		}
 		updates["globalWeight"] = *gw
@@ -344,7 +340,7 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	if body.APIEndpoints != nil {
 		eps, errMsg := normalizeAPIEndpointsInput(body.APIEndpoints)
 		if errMsg != "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": errMsg})
+			writeError(w, http.StatusBadRequest, errMsg)
 			return
 		}
 		now := time.Now().UTC().Format(time.RFC3339)
@@ -371,22 +367,18 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 		var conflictCount int
 		h.db.Get(&conflictCount, h.db.Rebind("SELECT COUNT(*) FROM sites WHERE platform = ? AND url = ? AND id != ?"), nextPlatform, nextURL, id)
 		if conflictCount > 0 {
-			writeJSON(w, http.StatusConflict, map[string]string{
-				"error": fmt.Sprintf("A %s site with URL %s already exists.", nextPlatform, nextURL),
-			})
+			writeError(w, http.StatusConflict, fmt.Sprintf("A %s site with URL %s already exists.", nextPlatform, nextURL))
 			return
 		}
 	}
 
 	if err := service.UpdateSite(h.db, id, updates); err != nil {
 		if isUniqueConstraintError(err) {
-			writeJSON(w, http.StatusConflict, map[string]string{
-				"error": fmt.Sprintf("A %s site with URL %s already exists.", nextPlatform, nextURL),
-			})
+			writeError(w, http.StatusConflict, fmt.Sprintf("A %s site with URL %s already exists.", nextPlatform, nextURL))
 			return
 		}
 		slog.Error("Failed to update site", "err", err, "site_id", id)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to update site"})
+		writeError(w, http.StatusInternalServerError, "Failed to update site")
 		return
 	}
 
@@ -407,12 +399,12 @@ func (h *sitesHandler) deleteSite(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid site id"})
+		writeError(w, http.StatusBadRequest, "Invalid site id")
 		return
 	}
 	if err := service.DeleteSite(h.db, id); err != nil {
 		slog.Error("Failed to delete site", "err", err, "site_id", id)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to delete site"})
+		writeError(w, http.StatusInternalServerError, "Failed to delete site")
 		return
 	}
 	service.InvalidateSiteCaches()
@@ -425,12 +417,12 @@ func (h *sitesHandler) deleteSite(w http.ResponseWriter, r *http.Request) {
 func (h *sitesHandler) batchSites(w http.ResponseWriter, r *http.Request) {
 	var body payloads.SiteBatchPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid site payload."})
+		writeError(w, http.StatusBadRequest, "Invalid site payload.")
 		return
 	}
 
 	if len(body.IDs) == 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "ids is required"})
+		writeError(w, http.StatusBadRequest, "ids is required")
 		return
 	}
 
@@ -440,7 +432,7 @@ func (h *sitesHandler) batchSites(w http.ResponseWriter, r *http.Request) {
 		"enableSystemProxy": true, "disableSystemProxy": true,
 	}
 	if !validActions[action] {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "Invalid action"})
+		writeError(w, http.StatusBadRequest, "Invalid action")
 		return
 	}
 
@@ -493,20 +485,21 @@ func (h *sitesHandler) batchSites(w http.ResponseWriter, r *http.Request) {
 func (h *sitesHandler) detectSite(w http.ResponseWriter, r *http.Request) {
 	var body payloads.SiteDetectPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid url. Expected non-empty string."})
+		writeError(w, http.StatusBadRequest, "Invalid url. Expected non-empty string.")
 		return
 	}
 	if strings.TrimSpace(body.URL) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid url. Expected non-empty string."})
+		writeError(w, http.StatusBadRequest, "Invalid url. Expected non-empty string.")
 		return
 	}
 
 	result := service.DetectSite(body.URL)
 	if result != nil {
 		writeJSON(w, http.StatusOK, result)
-	} else {
-		writeJSON(w, http.StatusOK, map[string]string{"error": "Could not detect platform"})
+		return
 	}
+	// Failure must not use HTTP 200 with an error body (B3).
+	writeError(w, http.StatusBadRequest, "Could not detect platform")
 }
 
 // ---- Disabled Models ----
@@ -515,13 +508,13 @@ func (h *sitesHandler) getDisabledModels(w http.ResponseWriter, r *http.Request)
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid site id"})
+		writeError(w, http.StatusBadRequest, "Invalid site id")
 		return
 	}
 
 	var existing store.Site
 	if err := h.db.Get(&existing, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), id); err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "Site not found"})
+		writeError(w, http.StatusNotFound, "Site not found")
 		return
 	}
 
@@ -537,20 +530,20 @@ func (h *sitesHandler) getDisabledModels(w http.ResponseWriter, r *http.Request)
 func (h *sitesHandler) updateDisabledModels(w http.ResponseWriter, r *http.Request) {
 	var body payloads.SiteDisabledModelsPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid models. Expected string[]."})
+		writeError(w, http.StatusBadRequest, "Invalid models. Expected string[].")
 		return
 	}
 
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid site id"})
+		writeError(w, http.StatusBadRequest, "Invalid site id")
 		return
 	}
 
 	var existing store.Site
 	if err := h.db.Get(&existing, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), id); err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "Site not found"})
+		writeError(w, http.StatusNotFound, "Site not found")
 		return
 	}
 
@@ -586,13 +579,13 @@ func (h *sitesHandler) getAvailableModels(w http.ResponseWriter, r *http.Request
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid site id"})
+		writeError(w, http.StatusBadRequest, "Invalid site id")
 		return
 	}
 
 	var existing store.Site
 	if err := h.db.Get(&existing, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), id); err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "Site not found"})
+		writeError(w, http.StatusNotFound, "Site not found")
 		return
 	}
 
@@ -639,13 +632,13 @@ func (h *sitesHandler) probeNow(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid site id"})
+		writeError(w, http.StatusBadRequest, "Invalid site id")
 		return
 	}
 
 	var body payloads.ProbeNowBody
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		writeError(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
 
@@ -666,7 +659,7 @@ func (h *sitesHandler) probeStream(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid site id"})
+		writeError(w, http.StatusBadRequest, "Invalid site id")
 		return
 	}
 

--- a/handler/admin/sites_test.go
+++ b/handler/admin/sites_test.go
@@ -455,8 +455,8 @@ func TestSites_Detect_Unknown(t *testing.T) {
 	_, r := setupSitesTest(t)
 	body := map[string]string{"url": "https://unknown.example.com"}
 	resp := doPostJSON(t, r, "/api/sites/detect", body)
-	if resp.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.Code)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", resp.Code, resp.Body.String())
 	}
 	var result map[string]any
 	json.Unmarshal(resp.Body.Bytes(), &result)

--- a/handler/shared/errors.go
+++ b/handler/shared/errors.go
@@ -9,6 +9,9 @@ import (
 
 // APIError represents a structured JSON error response.
 // Message is safe for public consumption; Internal is logged but never sent.
+// JSON field names are camelCase-compatible public keys used by the admin UI:
+//   - error  (string message)
+//   - detail (optional classifier / subtype)
 type APIError struct {
 	Code     int    `json:"-"`
 	Message  string `json:"error"`
@@ -18,6 +21,9 @@ type APIError struct {
 
 // Error implements the error interface.
 func (e *APIError) Error() string {
+	if e == nil {
+		return ""
+	}
 	if e.Internal != nil {
 		return e.Message + ": " + e.Internal.Error()
 	}
@@ -26,16 +32,36 @@ func (e *APIError) Error() string {
 
 // WriteError writes a structured JSON error response to the client.
 // It sets Content-Type: application/json and the given HTTP status code.
+// Callers must use a non-2xx status for failures — never HTTP 200 with an error body.
 func WriteError(w http.ResponseWriter, code int, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(code)
-	json.NewEncoder(w).Encode(APIError{Code: code, Message: message})
+	WriteAPIError(w, &APIError{Code: code, Message: message})
 }
 
 // WriteErrorDetail writes a structured JSON error response with
 // additional detail field (e.g., "invalid_request" error type).
 func WriteErrorDetail(w http.ResponseWriter, code int, message, detail string) {
+	WriteAPIError(w, &APIError{Code: code, Message: message, Detail: detail})
+}
+
+// WriteAPIError writes the public fields of APIError with the given status.
+// Status defaults to Code when Code > 0; otherwise 500.
+func WriteAPIError(w http.ResponseWriter, err *APIError) {
+	if err == nil {
+		err = &APIError{Code: http.StatusInternalServerError, Message: "internal error"}
+	}
+	code := err.Code
+	if code < 400 {
+		// Guard against accidental silent success statuses for error bodies.
+		if code == 0 {
+			code = http.StatusInternalServerError
+		} else {
+			code = http.StatusBadRequest
+		}
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	json.NewEncoder(w).Encode(APIError{Code: code, Message: message, Detail: detail})
+	_ = json.NewEncoder(w).Encode(APIError{
+		Message: err.Message,
+		Detail:  err.Detail,
+	})
 }

--- a/handler/shared/errors_test.go
+++ b/handler/shared/errors_test.go
@@ -1,0 +1,66 @@
+package shared
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteError_StatusAndCamelCaseJSON(t *testing.T) {
+	rec := httptest.NewRecorder()
+	WriteError(rec, http.StatusBadRequest, "Invalid site payload.")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, rec.Body.String())
+	}
+	if body["error"] != "Invalid site payload." {
+		t.Fatalf("error field = %v", body["error"])
+	}
+	if _, ok := body["message"]; ok {
+		t.Fatalf("unexpected message field in unified error body: %#v", body)
+	}
+	if _, ok := body["success"]; ok {
+		t.Fatalf("unexpected success field in unified error body: %#v", body)
+	}
+}
+
+func TestWriteErrorDetail_IncludesDetail(t *testing.T) {
+	rec := httptest.NewRecorder()
+	WriteErrorDetail(rec, http.StatusConflict, "API key 已存在", "duplicate_key")
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["error"] != "API key 已存在" {
+		t.Fatalf("error = %v", body["error"])
+	}
+	if body["detail"] != "duplicate_key" {
+		t.Fatalf("detail = %v", body["detail"])
+	}
+}
+
+func TestWriteAPIError_RejectsSilent200(t *testing.T) {
+	rec := httptest.NewRecorder()
+	// Code 200 must not produce a silent success with error body.
+	WriteAPIError(rec, &APIError{Code: http.StatusOK, Message: "should not be 200"})
+
+	if rec.Code == http.StatusOK {
+		t.Fatalf("WriteAPIError must not emit HTTP 200 for error bodies, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 fallback", rec.Code)
+	}
+}


### PR DESCRIPTION
Closes #19. Lane: lane-backend. shared WriteError/WriteAPIError; sites/accounts/keys no silent HTTP 200; docs/analysis/error-model.md; tests pass.