### PR TITLE
feat(proxy): per-site max concurrency limit

### DIFF
--- a/handler/admin/payloads/sites.go
+++ b/handler/admin/payloads/sites.go
@@ -2,19 +2,21 @@ package payloads
 
 // SiteCreatePayload mirrors TS SiteCreatePayload (siteRoutePayloads.ts).
 type SiteCreatePayload struct {
-	Name                   string                 `json:"name"`
-	URL                    string                 `json:"url"`
-	Platform               *string                `json:"platform,omitempty"`
-	InitializationPresetID *string                `json:"initializationPresetId,omitempty"`
-	ProxyURL               *string                `json:"proxyUrl,omitempty"`
-	UseSystemProxy         *bool                  `json:"useSystemProxy,omitempty"`
-	CustomHeaders          *string                `json:"customHeaders,omitempty"`
-	ExternalCheckinURL     *string                `json:"externalCheckinUrl,omitempty"`
-	Status                 *string                `json:"status,omitempty"`
-	IsPinned               *bool                  `json:"isPinned,omitempty"`
-	SortOrder              *int                   `json:"sortOrder,omitempty"`
-	GlobalWeight           *float64               `json:"globalWeight,omitempty"`
-	APIEndpoints           []SiteAPIEndpointInput `json:"apiEndpoints,omitempty"`
+	Name                   string   `json:"name"`
+	URL                    string   `json:"url"`
+	Platform               *string  `json:"platform,omitempty"`
+	InitializationPresetID *string  `json:"initializationPresetId,omitempty"`
+	ProxyURL               *string  `json:"proxyUrl,omitempty"`
+	UseSystemProxy         *bool    `json:"useSystemProxy,omitempty"`
+	CustomHeaders          *string  `json:"customHeaders,omitempty"`
+	ExternalCheckinURL     *string  `json:"externalCheckinUrl,omitempty"`
+	Status                 *string  `json:"status,omitempty"`
+	IsPinned               *bool    `json:"isPinned,omitempty"`
+	SortOrder              *int     `json:"sortOrder,omitempty"`
+	GlobalWeight           *float64 `json:"globalWeight,omitempty"`
+	// MaxConcurrency caps concurrent upstream calls for this site (0 = unlimited).
+	MaxConcurrency *int64                 `json:"maxConcurrency,omitempty"`
+	APIEndpoints   []SiteAPIEndpointInput `json:"apiEndpoints,omitempty"`
 }
 
 // SiteAPIEndpointInput is an embedded sub-resource input for apiEndpoints.
@@ -26,22 +28,24 @@ type SiteAPIEndpointInput struct {
 
 // SiteUpdatePayload mirrors TS SiteUpdatePayload.
 type SiteUpdatePayload struct {
-	Name                         *string                `json:"name,omitempty"`
-	URL                          *string                `json:"url,omitempty"`
-	Platform                     *string                `json:"platform,omitempty"`
-	ProxyURL                     *string                `json:"proxyUrl,omitempty"`
-	UseSystemProxy               *bool                  `json:"useSystemProxy,omitempty"`
-	CustomHeaders                *string                `json:"customHeaders,omitempty"`
-	ExternalCheckinURL           *string                `json:"externalCheckinUrl,omitempty"`
-	Status                       *string                `json:"status,omitempty"`
-	IsPinned                     *bool                  `json:"isPinned,omitempty"`
-	SortOrder                    *int                   `json:"sortOrder,omitempty"`
-	GlobalWeight                 *float64               `json:"globalWeight,omitempty"`
-	APIEndpoints                 []SiteAPIEndpointInput `json:"apiEndpoints,omitempty"`
-	PostRefreshProbeEnabled      *bool                  `json:"postRefreshProbeEnabled,omitempty"`
-	PostRefreshProbeModel        *string                `json:"postRefreshProbeModel,omitempty"`
-	PostRefreshProbeScope        *string                `json:"postRefreshProbeScope,omitempty"`
-	PostRefreshProbeLatencyThresholdMs *int             `json:"postRefreshProbeLatencyThresholdMs,omitempty"`
+	Name               *string  `json:"name,omitempty"`
+	URL                *string  `json:"url,omitempty"`
+	Platform           *string  `json:"platform,omitempty"`
+	ProxyURL           *string  `json:"proxyUrl,omitempty"`
+	UseSystemProxy     *bool    `json:"useSystemProxy,omitempty"`
+	CustomHeaders      *string  `json:"customHeaders,omitempty"`
+	ExternalCheckinURL *string  `json:"externalCheckinUrl,omitempty"`
+	Status             *string  `json:"status,omitempty"`
+	IsPinned           *bool    `json:"isPinned,omitempty"`
+	SortOrder          *int     `json:"sortOrder,omitempty"`
+	GlobalWeight       *float64 `json:"globalWeight,omitempty"`
+	// MaxConcurrency caps concurrent upstream calls for this site (0 = unlimited).
+	MaxConcurrency                     *int64                 `json:"maxConcurrency,omitempty"`
+	APIEndpoints                       []SiteAPIEndpointInput `json:"apiEndpoints,omitempty"`
+	PostRefreshProbeEnabled            *bool                  `json:"postRefreshProbeEnabled,omitempty"`
+	PostRefreshProbeModel              *string                `json:"postRefreshProbeModel,omitempty"`
+	PostRefreshProbeScope              *string                `json:"postRefreshProbeScope,omitempty"`
+	PostRefreshProbeLatencyThresholdMs *int                   `json:"postRefreshProbeLatencyThresholdMs,omitempty"`
 }
 
 // SiteBatchPayload mirrors TS SiteBatchPayload.
@@ -62,7 +66,7 @@ type SiteDisabledModelsPayload struct {
 
 // ProbeNowBody is the JSON body for POST /api/sites/:id/probe-now.
 type ProbeNowBody struct {
-	Scope               *string `json:"scope,omitempty"`
-	ModelName           *string `json:"modelName,omitempty"`
-	LatencyThresholdMs  *int    `json:"latencyThresholdMs,omitempty"`
+	Scope              *string `json:"scope,omitempty"`
+	ModelName          *string `json:"modelName,omitempty"`
+	LatencyThresholdMs *int    `json:"latencyThresholdMs,omitempty"`
 }

--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -107,6 +107,10 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid globalWeight value. Expected a positive number."})
 		return
 	}
+	if body.MaxConcurrency != nil && *body.MaxConcurrency < 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid maxConcurrency value. Expected non-negative integer (0 = unlimited)."})
+		return
+	}
 	if body.CustomHeaders != nil && *body.CustomHeaders != "" {
 		if !json.Valid([]byte(*body.CustomHeaders)) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid customHeaders."})
@@ -163,6 +167,7 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 		"status":                             coalesce(normalizedStatus, "active"),
 		"isPinned":                           coalesceBool(normalizedPinned, false),
 		"globalWeight":                       coalesceFloat64(normalizedWeight, 1.0),
+		"maxConcurrency":                     coalesceInt64(body.MaxConcurrency, 0),
 		"postRefreshProbeEnabled":            false,
 		"postRefreshProbeModel":              "",
 		"postRefreshProbeScope":              "single",
@@ -318,6 +323,13 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		updates["globalWeight"] = *gw
+	}
+	if body.MaxConcurrency != nil {
+		if *body.MaxConcurrency < 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid maxConcurrency value. Expected non-negative integer (0 = unlimited)."})
+			return
+		}
+		updates["maxConcurrency"] = *body.MaxConcurrency
 	}
 	if body.PostRefreshProbeEnabled != nil {
 		updates["postRefreshProbeEnabled"] = *body.PostRefreshProbeEnabled
@@ -741,6 +753,13 @@ func coalesceFloat64(f *float64, fallback float64) float64 {
 		return fallback
 	}
 	return *f
+}
+
+func coalesceInt64(v *int64, fallback int64) int64 {
+	if v == nil {
+		return fallback
+	}
+	return *v
 }
 
 func normalizeAPIEndpointsInput(input []payloads.SiteAPIEndpointInput) ([]payloads.SiteAPIEndpointInput, string) {

--- a/handler/admin/sites_test.go
+++ b/handler/admin/sites_test.go
@@ -927,3 +927,62 @@ func itoa(i int64) string {
 	}
 	return s
 }
+
+func TestSites_MaxConcurrencyRoundTrip(t *testing.T) {
+	_, r := setupSitesTest(t)
+
+	// Create with maxConcurrency
+	resp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":           "Conc Site",
+		"url":            "https://conc.example.com",
+		"platform":       "openai",
+		"maxConcurrency": 3,
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("create: expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &created); err != nil {
+		t.Fatalf("unmarshal create: %v", err)
+	}
+	if got := int64(created["maxConcurrency"].(float64)); got != 3 {
+		t.Fatalf("create maxConcurrency=%v, want 3", created["maxConcurrency"])
+	}
+	id := int64(created["id"].(float64))
+
+	// List should include field
+	resp = doGet(t, r, "/api/sites")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("list: %d", resp.Code)
+	}
+	var sites []map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &sites); err != nil {
+		t.Fatalf("unmarshal list: %v", err)
+	}
+	if len(sites) != 1 || int64(sites[0]["maxConcurrency"].(float64)) != 3 {
+		t.Fatalf("list maxConcurrency missing/wrong: %+v", sites)
+	}
+
+	// Update to unlimited (0)
+	resp = doPutJSON(t, r, "/api/sites/"+strconv.FormatInt(id, 10), map[string]any{
+		"maxConcurrency": 0,
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	var updated map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("unmarshal update: %v", err)
+	}
+	if got := int64(updated["maxConcurrency"].(float64)); got != 0 {
+		t.Fatalf("update maxConcurrency=%v, want 0", updated["maxConcurrency"])
+	}
+
+	// Negative rejected
+	resp = doPutJSON(t, r, "/api/sites/"+strconv.FormatInt(id, 10), map[string]any{
+		"maxConcurrency": -1,
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("negative maxConcurrency: expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+}

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -27,6 +27,10 @@ type UpstreamConfig struct {
 	RouteRefresher proxy.RouteRefreshWorkflow
 	Coordinator    *proxy.ProxyChannelCoordinator
 	Executor       *proxy.RuntimeExecutor
+	// SiteLimiter caps concurrent dispatches per site (sites.max_concurrency).
+	// When nil, proxy.DefaultSiteConcurrencyLimiter is used.
+	// Orthogonal to Coordinator channel leases (FE-SITE-CONC / upstream #594).
+	SiteLimiter *proxy.SiteConcurrencyLimiter
 }
 
 var upstreamCfg *UpstreamConfig
@@ -103,137 +107,179 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 		}
 		excludeChannelIDs = append(excludeChannelIDs, selected.Channel.ID)
 
-		// Step 7: Build upstream request
-		upstreamModel := selected.ActualModel
-		if upstreamModel == "" {
-			upstreamModel = ctx.RequestedModel
+		// Site-scoped concurrency (orthogonal to channel leases).
+		// On saturate: skip to next channel/site — do NOT mark expired/cascade.
+		// FE-SITE-CONC / upstream #594 / SC2 sites.max_concurrency.
+		siteLimiter := cfg.SiteLimiter
+		if siteLimiter == nil {
+			siteLimiter = proxy.DefaultSiteConcurrencyLimiter
 		}
-		upstreamURL := proxy.BuildUpstreamURL(selected.Site.URL, upstreamPath)
-		proxyConfig := service.BuildPlatformProxyConfig(config.Get(), &selected.Account, &selected.Site)
+		siteSlot, acquired := siteLimiter.TryAcquire(selected.Site.ID, selected.Site.MaxConcurrency)
+		if !acquired {
+			slog.Info("site concurrency saturated; skipping channel without failure cascade",
+				"site_id", selected.Site.ID,
+				"channel_id", selected.Channel.ID,
+				"max_concurrency", selected.Site.MaxConcurrency,
+				"model", ctx.RequestedModel,
+				"retry", retry,
+			)
+			continue
+		}
 
-		// Step 8: Send upstream request
-		startedAt := time.Now()
-		contentType := "application/json"
-		var bodyReader io.Reader
-		if ctx.Multipart {
-			bodyReader, contentType, err = CloneMultipartBody(r, map[string]string{"model": upstreamModel})
-			if err != nil {
-				slog.Warn("multipart upstream body construction failed", "err", err, "url", upstreamURL, "model", upstreamModel)
-				writeJSONError(w, 400, "Invalid multipart request body", "invalid_request_error")
-				return
-			}
-		} else {
-			forwardBytes := swapModelInJSON(ctx.RawBody, upstreamModel)
-			bodyReader = bytesReader(forwardBytes)
-		}
-		req, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, bodyReader)
-		if err != nil {
-			slog.Warn("upstream request construction failed", "err", err, "url", upstreamURL, "model", upstreamModel)
-			if retry < maxRetries {
-				pendingFailure = jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error")
-				continue
-			}
-			writeJSONError(w, 502, "Upstream request failed", "upstream_error")
+		// Hold the site slot for the full attempt; always release (even on panic path).
+		var finished bool
+		var nextPending *pendingUpstreamFailure
+		func() {
+			defer siteSlot.Release()
+			finished, nextPending = dispatchSelectedUpstream(w, r, ctx, cfg, selected, upstreamPath, retry, maxRetries)
+		}()
+		if finished {
 			return
 		}
-		req.Header.Set("Content-Type", contentType)
-		if selected.TokenValue != "" {
-			req.Header.Set("Authorization", "Bearer "+selected.TokenValue)
+		if nextPending != nil {
+			pendingFailure = nextPending
 		}
-		applyProxyCustomHeaders(req, proxyConfig)
-
-		var resp *http.Response
-		resp, err = sendUpstreamRequest(cfg, req, proxyConfig)
-		latencyMs := time.Since(startedAt).Milliseconds()
-
-		if err != nil {
-			slog.Warn("upstream request failed", "err", err, "url", upstreamURL, "model", upstreamModel, "channel_id", selected.Channel.ID)
-			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, 0, err.Error())
-			if retry < maxRetries {
-				pendingFailure = jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error")
-				continue
-			}
-			writeJSONError(w, 502, "Upstream request failed", "upstream_error")
-			return
-		}
-
-		// Step 9: Handle response
-		if ctx.IsStream {
-			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-				bodyBytes, readErr := proxy.ReadBufferedResponseBody(resp.Body)
-				resp.Body.Close()
-				if readErr != nil {
-					slog.Warn("failed to read upstream stream error response", "err", readErr, "latency_ms", latencyMs, "status", resp.StatusCode)
-					recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, readErr.Error())
-					if retry < maxRetries {
-						pendingFailure = jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error")
-						continue
-					}
-					writeJSONError(w, 502, "Failed to read upstream response", "upstream_error")
-					return
-				}
-				rawErrText := string(bodyBytes)
-				recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
-				if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
-					pendingFailure = bufferedPendingUpstreamFailure(resp, bodyBytes)
-					continue
-				}
-				relayBufferedUpstreamErrorResponse(w, resp, bodyBytes)
-				return
-			}
-			// Always close the upstream body, including early client disconnects.
-			func() {
-				defer resp.Body.Close()
-				handleStreamUpstream(w, r, resp, latencyMs)
-			}()
-			recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs)
-		} else {
-			bodyBytes, readErr := proxy.ReadBufferedResponseBody(resp.Body)
-			resp.Body.Close()
-			if readErr != nil {
-				slog.Warn("failed to read upstream response", "err", readErr, "latency_ms", latencyMs, "channel_id", selected.Channel.ID)
-				recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, readErr.Error())
-				if retry < maxRetries {
-					pendingFailure = jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error")
-					continue
-				}
-				writeJSONError(w, 502, "Failed to read upstream response", "upstream_error")
-				return
-			}
-			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-				rawErrText := string(bodyBytes)
-				recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
-				if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
-					pendingFailure = bufferedPendingUpstreamFailure(resp, bodyBytes)
-					continue
-				}
-				relayBufferedUpstreamResponse(w, resp, bodyBytes)
-				return
-			}
-			failure := proxy.DetectProxyFailure(string(bodyBytes), &proxy.UsageSummary{})
-			if failure != nil {
-				slog.Warn("content-based failure detected",
-					"reason", failure.Reason,
-					"status", failure.Status,
-					"model", upstreamModel,
-					"channel_id", selected.Channel.ID,
-					"latency_ms", latencyMs,
-				)
-				recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, failure.Status, failure.Reason)
-				if retry < maxRetries && proxy.ShouldRetryProxyRequest(failure.Status, failure.Reason) {
-					pendingFailure = jsonPendingUpstreamFailure(failure.Status, "Upstream returned an error response", "upstream_error")
-					continue
-				}
-				writeJSONError(w, failure.Status, "Upstream returned an error response", "upstream_error")
-				return
-			}
-			recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs)
-			relayBufferedUpstreamResponse(w, resp, bodyBytes)
-		}
-		return
 	}
 
 	writeJSONError(w, 503, "All channels exhausted", "server_error")
+}
+
+// dispatchSelectedUpstream runs steps 7-9 for one selected channel.
+// finished=true means the response was written (success or terminal error).
+// finished=false means the caller should continue the retry loop (optionally
+// with nextPending as the last soft failure to surface if selection ends).
+func dispatchSelectedUpstream(
+	w http.ResponseWriter,
+	r *http.Request,
+	ctx *Ctx,
+	cfg *UpstreamConfig,
+	selected *routing.SelectedChannel,
+	upstreamPath string,
+	retry int,
+	maxRetries int,
+) (finished bool, nextPending *pendingUpstreamFailure) {
+	// Step 7: Build upstream request
+	upstreamModel := selected.ActualModel
+	if upstreamModel == "" {
+		upstreamModel = ctx.RequestedModel
+	}
+	upstreamURL := proxy.BuildUpstreamURL(selected.Site.URL, upstreamPath)
+	proxyConfig := service.BuildPlatformProxyConfig(config.Get(), &selected.Account, &selected.Site)
+
+	// Step 8: Send upstream request
+	startedAt := time.Now()
+	contentType := "application/json"
+	var bodyReader io.Reader
+	var err error
+	if ctx.Multipart {
+		bodyReader, contentType, err = CloneMultipartBody(r, map[string]string{"model": upstreamModel})
+		if err != nil {
+			slog.Warn("multipart upstream body construction failed", "err", err, "url", upstreamURL, "model", upstreamModel)
+			writeJSONError(w, 400, "Invalid multipart request body", "invalid_request_error")
+			return true, nil
+		}
+	} else {
+		forwardBytes := swapModelInJSON(ctx.RawBody, upstreamModel)
+		bodyReader = bytesReader(forwardBytes)
+	}
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, bodyReader)
+	if err != nil {
+		slog.Warn("upstream request construction failed", "err", err, "url", upstreamURL, "model", upstreamModel)
+		if retry < maxRetries {
+			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error")
+		}
+		writeJSONError(w, 502, "Upstream request failed", "upstream_error")
+		return true, nil
+	}
+	req.Header.Set("Content-Type", contentType)
+	if selected.TokenValue != "" {
+		req.Header.Set("Authorization", "Bearer "+selected.TokenValue)
+	}
+	applyProxyCustomHeaders(req, proxyConfig)
+
+	var resp *http.Response
+	resp, err = sendUpstreamRequest(cfg, req, proxyConfig)
+	latencyMs := time.Since(startedAt).Milliseconds()
+
+	if err != nil {
+		slog.Warn("upstream request failed", "err", err, "url", upstreamURL, "model", upstreamModel, "channel_id", selected.Channel.ID)
+		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, 0, err.Error())
+		if retry < maxRetries {
+			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error")
+		}
+		writeJSONError(w, 502, "Upstream request failed", "upstream_error")
+		return true, nil
+	}
+
+	// Step 9: Handle response
+	if ctx.IsStream {
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			bodyBytes, readErr := proxy.ReadBufferedResponseBody(resp.Body)
+			resp.Body.Close()
+			if readErr != nil {
+				slog.Warn("failed to read upstream stream error response", "err", readErr, "latency_ms", latencyMs, "status", resp.StatusCode)
+				recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, readErr.Error())
+				if retry < maxRetries {
+					return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error")
+				}
+				writeJSONError(w, 502, "Failed to read upstream response", "upstream_error")
+				return true, nil
+			}
+			rawErrText := string(bodyBytes)
+			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
+			if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
+				return false, bufferedPendingUpstreamFailure(resp, bodyBytes)
+			}
+			relayBufferedUpstreamErrorResponse(w, resp, bodyBytes)
+			return true, nil
+		}
+		// Always close the upstream body, including early client disconnects.
+		func() {
+			defer resp.Body.Close()
+			handleStreamUpstream(w, r, resp, latencyMs)
+		}()
+		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs)
+	} else {
+		bodyBytes, readErr := proxy.ReadBufferedResponseBody(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			slog.Warn("failed to read upstream response", "err", readErr, "latency_ms", latencyMs, "channel_id", selected.Channel.ID)
+			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, readErr.Error())
+			if retry < maxRetries {
+				return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error")
+			}
+			writeJSONError(w, 502, "Failed to read upstream response", "upstream_error")
+			return true, nil
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			rawErrText := string(bodyBytes)
+			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
+			if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
+				return false, bufferedPendingUpstreamFailure(resp, bodyBytes)
+			}
+			relayBufferedUpstreamResponse(w, resp, bodyBytes)
+			return true, nil
+		}
+		failure := proxy.DetectProxyFailure(string(bodyBytes), &proxy.UsageSummary{})
+		if failure != nil {
+			slog.Warn("content-based failure detected",
+				"reason", failure.Reason,
+				"status", failure.Status,
+				"model", upstreamModel,
+				"channel_id", selected.Channel.ID,
+				"latency_ms", latencyMs,
+			)
+			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, failure.Status, failure.Reason)
+			if retry < maxRetries && proxy.ShouldRetryProxyRequest(failure.Status, failure.Reason) {
+				return false, jsonPendingUpstreamFailure(failure.Status, "Upstream returned an error response", "upstream_error")
+			}
+			writeJSONError(w, failure.Status, "Upstream returned an error response", "upstream_error")
+			return true, nil
+		}
+		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs)
+		relayBufferedUpstreamResponse(w, resp, bodyBytes)
+	}
+	return true, nil
 }
 
 type pendingUpstreamFailure struct {

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/tokendancelab/metapi-go/auth"
+	"github.com/tokendancelab/metapi-go/proxy"
 	"github.com/tokendancelab/metapi-go/routing"
 	"github.com/tokendancelab/metapi-go/store"
 )
@@ -538,5 +539,68 @@ func TestVideosCreateMultipartForwardsFormToUpstream(t *testing.T) {
 	}
 	if body := rec.Body.String(); !strings.Contains(body, "vid_123") {
 		t.Fatalf("body = %q, want upstream response", body)
+	}
+}
+
+func TestSiteConcurrencySaturateSkipsWithoutFailure(t *testing.T) {
+	// Site A is saturated (limit 1 already held). Fallback channel on site B must
+	// still dispatch. Saturation must NOT RecordFailure (no cascade/expired).
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"ok","choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limiter := proxy.NewSiteConcurrencyLimiter()
+	held, ok := limiter.TryAcquire(1, 1)
+	if !ok {
+		t.Fatal("pre-hold site 1 failed")
+	}
+	t.Cleanup(held.Release)
+
+	selectedA := routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 101, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 1, URL: upstream.URL, Status: "active", MaxConcurrency: 1},
+		TokenValue:  "tok-a",
+		ActualModel: "gpt-4o-upstream",
+	}
+	selectedB := routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 202, Enabled: true},
+		Account:     store.Account{ID: 8, Status: "active"},
+		Site:        store.Site{ID: 2, URL: upstream.URL, Status: "active", MaxConcurrency: 1},
+		TokenValue:  "tok-b",
+		ActualModel: "gpt-4o-upstream",
+	}
+	router := &upstreamTestRouter{
+		selected: selectedA,
+		next:     &selectedB,
+	}
+	SetUpstreamConfig(&UpstreamConfig{
+		Router:      router,
+		SiteLimiter: limiter,
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	dispatchUpstream(rec, req, &Ctx{
+		RequestedModel: "gpt-4o",
+		DownstreamPath: "/v1/chat/completions",
+		RawBody:        []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`),
+		MaxRetries:     1,
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(router.failures) != 0 {
+		t.Fatalf("saturated site must not cascade RecordFailure, got %+v", router.failures)
+	}
+	if len(router.successes) != 1 {
+		t.Fatalf("expected 1 success on fallback channel, got %+v", router.successes)
+	}
+	if router.successes[0].channelID != 202 {
+		t.Fatalf("expected channel 202 success, got %d", router.successes[0].channelID)
 	}
 }

--- a/proxy/site_concurrency.go
+++ b/proxy/site_concurrency.go
@@ -1,0 +1,105 @@
+package proxy
+
+import "sync"
+
+// SiteConcurrencyLimiter caps concurrent upstream dispatches per site.
+// It is orthogonal to ProxyChannelCoordinator channel leases: a request may
+// hold both a site slot and a channel lease independently.
+//
+// Semantics (sites.max_concurrency / Site.MaxConcurrency):
+//   - limit <= 0  → unlimited (always acquire; no tracking)
+//   - limit > 0   → at most that many concurrent held slots per siteID
+//
+// On saturation callers must skip to the next channel/site and must NOT mark
+// the channel expired or record a routing failure cascade (FE-SITE-CONC / #594).
+type SiteConcurrencyLimiter struct {
+	mu    sync.Mutex
+	sites map[int64]*siteConcurrencyState
+}
+
+type siteConcurrencyState struct {
+	active int
+}
+
+// SiteSlot is a held (or no-op) site concurrency permit.
+// Always call Release exactly once when the upstream attempt finishes.
+type SiteSlot struct {
+	siteID  int64
+	limiter *SiteConcurrencyLimiter
+	held    bool
+}
+
+// DefaultSiteConcurrencyLimiter is the process-global site limiter used by the
+// proxy data plane when UpstreamConfig does not inject a custom instance.
+var DefaultSiteConcurrencyLimiter = NewSiteConcurrencyLimiter()
+
+// NewSiteConcurrencyLimiter creates an empty site-scoped limiter.
+func NewSiteConcurrencyLimiter() *SiteConcurrencyLimiter {
+	return &SiteConcurrencyLimiter{
+		sites: make(map[int64]*siteConcurrencyState),
+	}
+}
+
+// TryAcquire attempts to take one concurrency slot for siteID.
+//
+// Returns (slot, true) when the call may proceed. slot is never nil on success;
+// for unlimited sites the slot is a no-op (Release is still safe).
+// Returns (nil, false) when the site is saturated — caller should skip this
+// site/channel without recording failure.
+func (l *SiteConcurrencyLimiter) TryAcquire(siteID int64, maxConcurrency int64) (*SiteSlot, bool) {
+	if l == nil || siteID <= 0 || maxConcurrency <= 0 {
+		return &SiteSlot{siteID: siteID, limiter: l, held: false}, true
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	state := l.sites[siteID]
+	if state == nil {
+		state = &siteConcurrencyState{}
+		l.sites[siteID] = state
+	}
+	if state.active >= int(maxConcurrency) {
+		return nil, false
+	}
+	state.active++
+	return &SiteSlot{siteID: siteID, limiter: l, held: true}, true
+}
+
+// ActiveCount returns the number of currently held slots for siteID.
+// Unlimited / unknown sites report 0.
+func (l *SiteConcurrencyLimiter) ActiveCount(siteID int64) int {
+	if l == nil || siteID <= 0 {
+		return 0
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	state := l.sites[siteID]
+	if state == nil {
+		return 0
+	}
+	return state.active
+}
+
+// Release frees the slot. Idempotent and safe on no-op / nil slots.
+func (s *SiteSlot) Release() {
+	if s == nil || !s.held || s.limiter == nil {
+		if s != nil {
+			s.held = false
+		}
+		return
+	}
+
+	s.limiter.mu.Lock()
+	state := s.limiter.sites[s.siteID]
+	if state != nil {
+		if state.active > 0 {
+			state.active--
+		}
+		if state.active == 0 {
+			delete(s.limiter.sites, s.siteID)
+		}
+	}
+	s.limiter.mu.Unlock()
+	s.held = false
+}

--- a/proxy/site_concurrency_test.go
+++ b/proxy/site_concurrency_test.go
@@ -1,0 +1,150 @@
+package proxy
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSiteConcurrencyLimiter_Unlimited(t *testing.T) {
+	lim := NewSiteConcurrencyLimiter()
+
+	for _, limit := range []int64{0, -1} {
+		slots := make([]*SiteSlot, 0, 8)
+		for i := 0; i < 8; i++ {
+			slot, ok := lim.TryAcquire(11, limit)
+			if !ok || slot == nil {
+				t.Fatalf("limit=%d attempt=%d: expected acquire", limit, i)
+			}
+			slots = append(slots, slot)
+		}
+		if got := lim.ActiveCount(11); got != 0 {
+			t.Fatalf("limit=%d ActiveCount=%d, want 0 (unlimited tracks nothing)", limit, got)
+		}
+		for _, s := range slots {
+			s.Release()
+		}
+	}
+}
+
+func TestSiteConcurrencyLimiter_SaturateAndRelease(t *testing.T) {
+	lim := NewSiteConcurrencyLimiter()
+	const siteID int64 = 42
+
+	s1, ok := lim.TryAcquire(siteID, 2)
+	if !ok {
+		t.Fatal("first acquire failed")
+	}
+	s2, ok := lim.TryAcquire(siteID, 2)
+	if !ok {
+		t.Fatal("second acquire failed")
+	}
+	if got := lim.ActiveCount(siteID); got != 2 {
+		t.Fatalf("ActiveCount=%d, want 2", got)
+	}
+
+	if slot, ok := lim.TryAcquire(siteID, 2); ok || slot != nil {
+		t.Fatalf("expected saturate, got ok=%v slot=%v", ok, slot)
+	}
+
+	s1.Release()
+	if got := lim.ActiveCount(siteID); got != 1 {
+		t.Fatalf("after release ActiveCount=%d, want 1", got)
+	}
+
+	s3, ok := lim.TryAcquire(siteID, 2)
+	if !ok {
+		t.Fatal("re-acquire after release failed")
+	}
+	s2.Release()
+	s3.Release()
+	// Double-release is idempotent.
+	s3.Release()
+
+	if got := lim.ActiveCount(siteID); got != 0 {
+		t.Fatalf("final ActiveCount=%d, want 0", got)
+	}
+}
+
+func TestSiteConcurrencyLimiter_SitesIndependent(t *testing.T) {
+	lim := NewSiteConcurrencyLimiter()
+
+	a, ok := lim.TryAcquire(1, 1)
+	if !ok {
+		t.Fatal("site1 acquire failed")
+	}
+	if _, ok := lim.TryAcquire(1, 1); ok {
+		t.Fatal("site1 should be saturated")
+	}
+	b, ok := lim.TryAcquire(2, 1)
+	if !ok {
+		t.Fatal("site2 must remain independent")
+	}
+	a.Release()
+	b.Release()
+}
+
+func TestSiteConcurrencyLimiter_ConcurrentRace(t *testing.T) {
+	lim := NewSiteConcurrencyLimiter()
+	const (
+		siteID  int64 = 7
+		limit   int64 = 4
+		workers       = 32
+	)
+
+	var acquired atomic.Int64
+	var rejected atomic.Int64
+	var maxSeen atomic.Int64
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				slot, ok := lim.TryAcquire(siteID, limit)
+				if !ok {
+					rejected.Add(1)
+					continue
+				}
+				acquired.Add(1)
+				cur := int64(lim.ActiveCount(siteID))
+				for {
+					prev := maxSeen.Load()
+					if cur <= prev || maxSeen.CompareAndSwap(prev, cur) {
+						break
+					}
+				}
+				time.Sleep(time.Microsecond)
+				slot.Release()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := lim.ActiveCount(siteID); got != 0 {
+		t.Fatalf("leaked ActiveCount=%d", got)
+	}
+	if max := maxSeen.Load(); max > limit {
+		t.Fatalf("observed concurrent holders=%d > limit=%d", max, limit)
+	}
+	if acquired.Load() == 0 {
+		t.Fatal("expected some acquires")
+	}
+	if rejected.Load() == 0 {
+		t.Fatal("expected some rejections under contention")
+	}
+}
+
+func TestSiteSlot_NilSafe(t *testing.T) {
+	var slot *SiteSlot
+	slot.Release() // must not panic
+
+	lim := NewSiteConcurrencyLimiter()
+	s, ok := lim.TryAcquire(0, 5)
+	if !ok || s == nil {
+		t.Fatal("invalid siteID should no-op acquire")
+	}
+	s.Release()
+}

--- a/service/site_service.go
+++ b/service/site_service.go
@@ -183,6 +183,7 @@ func siteToMap(site store.Site, endpoints []store.SiteAPIEndpoint) map[string]an
 		"sortOrder":                          site.SortOrder,
 		"globalWeight":                       site.GlobalWeight,
 		"apiKey":                             site.APIKey,
+		"maxConcurrency":                     site.MaxConcurrency,
 		"postRefreshProbeEnabled":            site.PostRefreshProbeEnabled,
 		"postRefreshProbeModel":              site.PostRefreshProbeModel,
 		"postRefreshProbeScope":              site.PostRefreshProbeScope,
@@ -263,16 +264,31 @@ func CreateSite(db *sqlx.DB, siteData map[string]any) (int64, error) {
 	urlStr := CanonicalizeSiteURL(siteData["url"].(string))
 	platform := siteData["platform"].(string)
 
+	maxConcurrency := int64(0)
+	if v, ok := siteData["maxConcurrency"]; ok && v != nil {
+		switch n := v.(type) {
+		case int64:
+			maxConcurrency = n
+		case int:
+			maxConcurrency = int64(n)
+		case float64:
+			maxConcurrency = int64(n)
+		}
+		if maxConcurrency < 0 {
+			maxConcurrency = 0
+		}
+	}
+
 	result, err := tx.Exec(
 		tx.Rebind(`INSERT INTO sites (name, url, platform, proxy_url, use_system_proxy, custom_headers,
-		 external_checkin_url, status, is_pinned, sort_order, global_weight,
+		 external_checkin_url, status, is_pinned, sort_order, global_weight, max_concurrency,
 		 post_refresh_probe_enabled, post_refresh_probe_model, post_refresh_probe_scope,
 		 post_refresh_probe_latency_threshold_ms, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
 		name, urlStr, platform,
 		siteData["proxyUrl"], siteData["useSystemProxy"], siteData["customHeaders"],
 		siteData["externalCheckinUrl"], siteData["status"], siteData["isPinned"],
-		sortOrder, siteData["globalWeight"],
+		sortOrder, siteData["globalWeight"], maxConcurrency,
 		siteData["postRefreshProbeEnabled"], siteData["postRefreshProbeModel"],
 		siteData["postRefreshProbeScope"], siteData["postRefreshProbeLatencyThresholdMs"],
 		now, now,
@@ -422,6 +438,7 @@ func jsonKeyToColumn(key string) string {
 		"sortOrder":                          "sort_order",
 		"globalWeight":                       "global_weight",
 		"apiKey":                             "api_key",
+		"maxConcurrency":                     "max_concurrency",
 		"postRefreshProbeEnabled":            "post_refresh_probe_enabled",
 		"postRefreshProbeModel":              "post_refresh_probe_model",
 		"postRefreshProbeScope":              "post_refresh_probe_scope",


### PR DESCRIPTION
Implements FE-SITE-CONC / upstream #594 using SC2 sites.max_concurrency. Site-scoped limiter orthogonal to channel leases; admin maxConcurrency field; tests.