### PR TITLE
feat(proxy): per-key proxy_url override

### DIFF
--- a/auth/context.go
+++ b/auth/context.go
@@ -28,6 +28,12 @@ type ProxyAuthContext struct {
 	KeyID   *int64                  // Managed key row ID; nil for global
 	KeyName string                  // Managed key name; "global" for global
 	Policy  DownstreamRoutingPolicy // Resolved routing policy
+	// ProxyURL is an optional per-key egress proxy override from
+	// downstream_api_keys.proxy_url (FE-KEY-PROXY / upstream #578).
+	// nil/empty means inherit account → site → system proxy.
+	// When set, it takes precedence over site/account proxy for that key's
+	// upstream requests (product intent: multi-tenant key isolation).
+	ProxyURL *string
 }
 
 // ---------------------------------------------------------------------------

--- a/auth/downstream.go
+++ b/auth/downstream.go
@@ -43,6 +43,9 @@ type managedKeyView struct {
 	UsedCost     float64
 	MaxRequests  *int64
 	UsedRequests int64
+	// ProxyURL is the optional per-key egress proxy (downstream_api_keys.proxy_url).
+	// nil/empty means inherit site/account/system proxy (FE-KEY-PROXY / #578).
+	ProxyURL *string
 	// Policy fields — parsed from JSON TEXT columns
 	SupportedModels        []string
 	AllowedRouteIDs        []int64
@@ -177,7 +180,7 @@ func getManagedKeyByToken(token string) (*managedKeyView, error) {
 
 	row := db.QueryRowx(
 		`SELECT id, name, enabled, expires_at, max_cost, used_cost,
-		        max_requests, used_requests,
+		        max_requests, used_requests, proxy_url,
 		        supported_models, allowed_route_ids,
 		        site_weight_multipliers, excluded_site_ids,
 		        excluded_credential_refs
@@ -186,13 +189,14 @@ func getManagedKeyByToken(token string) (*managedKeyView, error) {
 	)
 
 	var v managedKeyView
+	var proxyURL *string
 	var supportedModelsJSON, allowedRouteIDsJSON *string
 	var siteWeightMultiJSON, excludedSiteIDsJSON *string
 	var excludedCredRefsJSON *string
 
 	err := row.Scan(
 		&v.ID, &v.Name, &v.Enabled, &v.ExpiresAt, &v.MaxCost, &v.UsedCost,
-		&v.MaxRequests, &v.UsedRequests,
+		&v.MaxRequests, &v.UsedRequests, &proxyURL,
 		&supportedModelsJSON, &allowedRouteIDsJSON,
 		&siteWeightMultiJSON, &excludedSiteIDsJSON,
 		&excludedCredRefsJSON,
@@ -203,6 +207,14 @@ func getManagedKeyByToken(token string) (*managedKeyView, error) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("query downstream_api_keys: %w", err)
+	}
+
+	// Normalize proxy_url: whitespace-only → nil (inherit site/system).
+	if proxyURL != nil {
+		trimmed := strings.TrimSpace(*proxyURL)
+		if trimmed != "" {
+			v.ProxyURL = &trimmed
+		}
 	}
 
 	// Parse JSON columns into typed slices/maps

--- a/auth/proxy.go
+++ b/auth/proxy.go
@@ -66,6 +66,13 @@ func ProxyAuth(cfg *config.Config) func(http.Handler) http.Handler {
 			if result.Key != nil {
 				pac.KeyID = &result.Key.ID
 				pac.KeyName = result.Key.Name
+				// Per-key egress proxy override (FE-KEY-PROXY / #578).
+				// Prefer over site/account proxy when non-empty; nil inherits.
+				if result.Key.ProxyURL != nil {
+					if trimmed := strings.TrimSpace(*result.Key.ProxyURL); trimmed != "" {
+						pac.ProxyURL = &trimmed
+					}
+				}
 			} else {
 				pac.KeyName = "global"
 			}

--- a/auth/proxy_test.go
+++ b/auth/proxy_test.go
@@ -613,3 +613,94 @@ func TestProxyAuthMiddleware_ResponseContentType(t *testing.T) {
 		t.Errorf("expected application/json Content-Type, got %q", ct)
 	}
 }
+
+func TestAuthorizeDownstreamToken_ManagedKeyProxyURL(t *testing.T) {
+	setupTestDB(t)
+	db := testDB(t)
+	now := "2026-07-04T00:00:00Z"
+	proxyURL := "http://key-proxy:9090"
+	_, err := db.Exec(
+		`INSERT INTO downstream_api_keys
+		 (name, key, enabled, expires_at, max_cost, used_cost, max_requests, used_requests, proxy_url,
+		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
+		  created_at, updated_at)
+		 VALUES (?, ?, 1, NULL, NULL, 0, NULL, 0, ?, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		"proxy-key", "sk-with-proxy", proxyURL, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	result := AuthorizeDownstreamToken("sk-with-proxy", proxyCfg("global-secret"))
+	if !result.OK {
+		t.Fatalf("expected OK, got %s", result.Error)
+	}
+	if result.Key == nil || result.Key.ProxyURL == nil || *result.Key.ProxyURL != proxyURL {
+		t.Fatalf("Key.ProxyURL = %#v, want %q", result.Key, proxyURL)
+	}
+}
+
+func TestAuthorizeDownstreamToken_ManagedKeyProxyURLWhitespaceInherits(t *testing.T) {
+	setupTestDB(t)
+	db := testDB(t)
+	now := "2026-07-04T00:00:00Z"
+	_, err := db.Exec(
+		`INSERT INTO downstream_api_keys
+		 (name, key, enabled, expires_at, max_cost, used_cost, max_requests, used_requests, proxy_url,
+		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
+		  created_at, updated_at)
+		 VALUES (?, ?, 1, NULL, NULL, 0, NULL, 0, '   ', '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		"proxy-blank", "sk-blank-proxy", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	result := AuthorizeDownstreamToken("sk-blank-proxy", proxyCfg("global-secret"))
+	if !result.OK {
+		t.Fatalf("expected OK, got %s", result.Error)
+	}
+	if result.Key == nil {
+		t.Fatal("expected key")
+	}
+	if result.Key.ProxyURL != nil {
+		t.Fatalf("whitespace proxy_url should inherit (nil), got %#v", *result.Key.ProxyURL)
+	}
+}
+
+func TestProxyAuthMiddleware_PropagatesKeyProxyURL(t *testing.T) {
+	setupTestDB(t)
+	db := testDB(t)
+	now := "2026-07-04T00:00:00Z"
+	proxyURL := "socks5://key-proxy:1080"
+	_, err := db.Exec(
+		`INSERT INTO downstream_api_keys
+		 (name, key, enabled, expires_at, max_cost, used_cost, max_requests, used_requests, proxy_url,
+		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
+		  created_at, updated_at)
+		 VALUES (?, ?, 1, NULL, NULL, 0, NULL, 0, ?, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		"mw-proxy", "sk-mw-proxy", proxyURL, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	cfg := proxyCfg("global-secret")
+	middleware := ProxyAuth(cfg)
+	var captured *ProxyAuthContext
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = GetProxyAuth(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := newProxyRequest("POST", "/v1/chat/completions", map[string]string{
+		"Authorization": "Bearer sk-mw-proxy",
+	}, "")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	if captured == nil || captured.ProxyURL == nil || *captured.ProxyURL != proxyURL {
+		t.Fatalf("captured ProxyURL = %#v, want %q", captured, proxyURL)
+	}
+}

--- a/handler/admin/downstream_keys.go
+++ b/handler/admin/downstream_keys.go
@@ -126,6 +126,7 @@ func (h *downstreamKeysHandler) createKey(w http.ResponseWriter, r *http.Request
 		SiteWeightMultipliers  any      `json:"siteWeightMultipliers"`
 		ExcludedSiteIds        []int64  `json:"excludedSiteIds"`
 		ExcludedCredentialRefs []any    `json:"excludedCredentialRefs"`
+		ProxyURL               *string  `json:"proxyUrl"`
 	}
 	if err := decodeJSONRequest(r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, "Invalid request body")
@@ -191,16 +192,23 @@ func (h *downstreamKeysHandler) createKey(w http.ResponseWriter, r *http.Request
 		desc = &s
 	}
 
+	// Per-key egress proxy (FE-KEY-PROXY / #578). NULL/empty inherits site/system.
+	proxyURL, proxyErr := normalizeDownstreamProxyURL(body.ProxyURL)
+	if proxyErr != "" {
+		writeError(w, http.StatusBadRequest, proxyErr)
+		return
+	}
+
 	id, err := execInsertID(h.db,
 		`INSERT INTO downstream_api_keys
 		(name, key, description, group_name, tags, enabled, expires_at, max_cost, used_cost, max_requests, used_requests,
 		 supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
-		 created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 0, ?, ?, ?, ?, ?, ?, ?)`,
+		 proxy_url, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		body.Name, body.Key, desc, normalizedGroupName, tagsJSON, enabled, body.ExpiresAt,
 		body.MaxCost, body.MaxRequests,
 		modelsJSON, routeIdsJSON, swmJSON, excludedSitesJSON, credRefsJSON,
-		now, now,
+		proxyURL, now, now,
 	)
 	if err != nil {
 		if isUniqueConstraintError(err) {
@@ -255,6 +263,7 @@ func (h *downstreamKeysHandler) updateKey(w http.ResponseWriter, r *http.Request
 		SiteWeightMultipliers  any      `json:"siteWeightMultipliers"`
 		ExcludedSiteIds        []int64  `json:"excludedSiteIds"`
 		ExcludedCredentialRefs []any    `json:"excludedCredentialRefs"`
+		ProxyURL               *string  `json:"proxyUrl"`
 	}
 
 	bodyBytes, err := decodeJSONRequestRaw(r, &body)
@@ -312,6 +321,9 @@ func (h *downstreamKeysHandler) updateKey(w http.ResponseWriter, r *http.Request
 	}
 	if _, ok := rawBody["excludedCredentialRefs"]; ok {
 		hasField["excludedCredentialRefs"] = true
+	}
+	if _, ok := rawBody["proxyUrl"]; ok {
+		hasField["proxyUrl"] = true
 	}
 
 	// Merge: present fields from body, missing fields from existing record.
@@ -397,6 +409,17 @@ func (h *downstreamKeysHandler) updateKey(w http.ResponseWriter, r *http.Request
 		excludedCredentialRefs = normalizeExcludedCredentialRefsInput(body.ExcludedCredentialRefs)
 	}
 
+	// proxyUrl: absent keeps existing; present empty/null clears to inherit site/system.
+	proxyURL := existingStringPtr(existing, "proxy_url")
+	if hasField["proxyUrl"] {
+		normalized, proxyErr := normalizeDownstreamProxyURL(body.ProxyURL)
+		if proxyErr != "" {
+			writeError(w, http.StatusBadRequest, proxyErr)
+			return
+		}
+		proxyURL = normalized
+	}
+
 	// Validate.
 	if name == "" {
 		writeError(w, http.StatusBadRequest, "name 不能为空")
@@ -441,12 +464,12 @@ func (h *downstreamKeysHandler) updateKey(w http.ResponseWriter, r *http.Request
 			name = ?, key = ?, description = ?, group_name = ?, tags = ?,
 			enabled = ?, expires_at = ?, max_cost = ?, max_requests = ?,
 			supported_models = ?, allowed_route_ids = ?, site_weight_multipliers = ?,
-			excluded_site_ids = ?, excluded_credential_refs = ?, updated_at = ?
+			excluded_site_ids = ?, excluded_credential_refs = ?, proxy_url = ?, updated_at = ?
 		WHERE id = ?`),
 		name, key, description, groupName, tagsJSON,
 		enabled, expiresAt, maxCost, maxRequests,
 		modelsJSON, routeIdsJSON, swmJSON,
-		excludedSitesJSON, credRefsJSON, now, id,
+		excludedSitesJSON, credRefsJSON, proxyURL, now, id,
 	)
 	if err != nil {
 		if isUniqueConstraintError(err) {
@@ -1069,6 +1092,31 @@ func int64FromAny(v any) int64 {
 		return int64(val)
 	}
 	return 0
+}
+
+// normalizeDownstreamProxyURL trims proxyUrl for create/update.
+// Empty / whitespace / null -> nil (inherit site/account/system proxy).
+// Non-empty values must include a supported scheme (http/https/socks*).
+func normalizeDownstreamProxyURL(input *string) (*string, string) {
+	if input == nil {
+		return nil, ""
+	}
+	v := strings.TrimSpace(*input)
+	if v == "" {
+		return nil, ""
+	}
+	lower := strings.ToLower(v)
+	supported := false
+	for _, scheme := range []string{"http://", "https://", "socks://", "socks4://", "socks4a://", "socks5://", "socks5h://"} {
+		if strings.HasPrefix(lower, scheme) {
+			supported = true
+			break
+		}
+	}
+	if !supported {
+		return nil, "proxyUrl 必须以 http://、https:// 或 socks 代理 scheme 开头"
+	}
+	return &v, ""
 }
 
 func normalizeExpiresAt(input *string) *string {

--- a/handler/admin/downstream_keys_test.go
+++ b/handler/admin/downstream_keys_test.go
@@ -326,3 +326,119 @@ func assertNullString(t *testing.T, name string, got sql.NullString, want string
 		t.Fatalf("%s = %#v, want %q", name, got, want)
 	}
 }
+
+func TestDownstreamKeysProxyURLCreateUpdateGetAndClear(t *testing.T) {
+	_, r := setupDownstreamKeysTest(t)
+
+	// Create with proxyUrl
+	resp := doPostJSON(t, r, "/api/downstream-keys", map[string]any{
+		"name":     "proxy-client",
+		"key":      "sk-proxy-client-1",
+		"proxyUrl": "http://key-proxy.example:8080",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("create returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var createBody map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &createBody); err != nil {
+		t.Fatalf("unmarshal create: %v", err)
+	}
+	item, ok := createBody["item"].(map[string]any)
+	if !ok {
+		t.Fatalf("create missing item: %#v", createBody)
+	}
+	if item["proxyUrl"] != "http://key-proxy.example:8080" {
+		t.Fatalf("create proxyUrl = %#v, want key proxy", item["proxyUrl"])
+	}
+	keyID := int64(item["id"].(float64))
+
+	// List/get should include proxyUrl (camelCase via SELECT *)
+	resp = doGet(t, r, "/api/downstream-keys")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("list returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var listBody map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &listBody); err != nil {
+		t.Fatalf("unmarshal list: %v", err)
+	}
+	items, _ := listBody["items"].([]any)
+	found := false
+	for _, raw := range items {
+		row, _ := raw.(map[string]any)
+		if int64(row["id"].(float64)) == keyID {
+			found = true
+			if row["proxyUrl"] != "http://key-proxy.example:8080" {
+				t.Fatalf("list proxyUrl = %#v", row["proxyUrl"])
+			}
+		}
+	}
+	if !found {
+		t.Fatal("created key not in list")
+	}
+
+	// Partial update without proxyUrl preserves it
+	resp = doPutJSON(t, r, "/api/downstream-keys/"+itoa(keyID), map[string]any{
+		"name": "proxy-client-renamed",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("partial update returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var updateBody map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &updateBody); err != nil {
+		t.Fatalf("unmarshal update: %v", err)
+	}
+	item = updateBody["item"].(map[string]any)
+	if item["proxyUrl"] != "http://key-proxy.example:8080" {
+		t.Fatalf("partial update dropped proxyUrl: %#v", item["proxyUrl"])
+	}
+	if item["name"] != "proxy-client-renamed" {
+		t.Fatalf("name not updated: %#v", item["name"])
+	}
+
+	// Clear proxyUrl with empty string → inherit (null)
+	resp = doPutJSON(t, r, "/api/downstream-keys/"+itoa(keyID), map[string]any{
+		"proxyUrl": "",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("clear proxyUrl returned %d: %s", resp.Code, resp.Body.String())
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &updateBody); err != nil {
+		t.Fatalf("unmarshal clear: %v", err)
+	}
+	item = updateBody["item"].(map[string]any)
+	if item["proxyUrl"] != nil {
+		t.Fatalf("cleared proxyUrl should be null, got %#v", item["proxyUrl"])
+	}
+
+	// Invalid scheme rejected
+	resp = doPostJSON(t, r, "/api/downstream-keys", map[string]any{
+		"name":     "bad-proxy",
+		"key":      "sk-bad-proxy-1",
+		"proxyUrl": "ftp://not-supported",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("invalid proxyUrl create returned %d, want 400: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestNormalizeDownstreamProxyURL(t *testing.T) {
+	got, errMsg := normalizeDownstreamProxyURL(nil)
+	if got != nil || errMsg != "" {
+		t.Fatalf("nil => (%v, %q)", got, errMsg)
+	}
+	empty := "  "
+	got, errMsg = normalizeDownstreamProxyURL(&empty)
+	if got != nil || errMsg != "" {
+		t.Fatalf("empty => (%v, %q)", got, errMsg)
+	}
+	ok := " http://proxy:1 "
+	got, errMsg = normalizeDownstreamProxyURL(&ok)
+	if errMsg != "" || got == nil || *got != "http://proxy:1" {
+		t.Fatalf("ok => (%v, %q)", got, errMsg)
+	}
+	bad := "notaurl"
+	got, errMsg = normalizeDownstreamProxyURL(&bad)
+	if got != nil || errMsg == "" {
+		t.Fatalf("bad => (%v, %q)", got, errMsg)
+	}
+}

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -166,7 +166,12 @@ func dispatchSelectedUpstream(
 		upstreamModel = ctx.RequestedModel
 	}
 	upstreamURL := proxy.BuildUpstreamURL(selected.Site.URL, upstreamPath)
+	// Proxy selection: key proxy > account > site > system > direct
+	// (FE-KEY-PROXY / upstream #578; see proxy.KeyProxyPrecedence).
 	proxyConfig := service.BuildPlatformProxyConfig(config.Get(), &selected.Account, &selected.Site)
+	if ctx != nil && ctx.Auth != nil {
+		proxyConfig = proxy.ApplyKeyProxyOverride(proxyConfig, ctx.Auth.ProxyURL)
+	}
 
 	// Step 8: Send upstream request
 	startedAt := time.Now()

--- a/proxy/key_proxy.go
+++ b/proxy/key_proxy.go
@@ -1,0 +1,71 @@
+package proxy
+
+import (
+	"strings"
+
+	"github.com/tokendancelab/metapi-go/platform"
+)
+
+// KeyProxyPrecedence documents the egress proxy selection order for
+// FE-KEY-PROXY / upstream #578:
+//
+//	1. downstream_api_keys.proxy_url  (per-key override; this package)
+//	2. account extraConfig.proxyUrl / useSystemProxy
+//	3. sites.proxy_url / sites.use_system_proxy
+//	4. config.SystemProxyUrl when site/account opt into system proxy
+//	5. direct (no proxy)
+//
+// Product intent: multi-tenant downstream keys may need distinct egress even
+// when they share the same upstream site/account channel. A non-empty key
+// proxy therefore wins over site and account proxies. NULL / empty key proxy
+// preserves pre-SC2 behavior (inherit site/account/system).
+const KeyProxyPrecedence = "key > account > site > system > direct"
+
+// ApplyKeyProxyOverride returns a ProxyConfig with ProxyURL replaced by the
+// per-key egress proxy when keyProxyURL is non-empty after trim.
+//
+// base may be nil (no site/account proxy). Custom headers and other fields
+// from base are preserved so site custom headers still apply under a key
+// proxy override.
+//
+// Empty / whitespace keyProxyURL returns base unchanged (inherit).
+func ApplyKeyProxyOverride(base *platform.ProxyConfig, keyProxyURL *string) *platform.ProxyConfig {
+	if keyProxyURL == nil {
+		return base
+	}
+	trimmed := strings.TrimSpace(*keyProxyURL)
+	if trimmed == "" {
+		return base
+	}
+
+	if base == nil {
+		return &platform.ProxyConfig{ProxyURL: trimmed}
+	}
+
+	// Clone so callers can share base configs safely.
+	out := *base
+	out.ProxyURL = trimmed
+	// Explicit key proxy is not the system proxy path.
+	out.UseSystemProxy = false
+	if base.CustomHeaders != nil {
+		headers := make(map[string]string, len(base.CustomHeaders))
+		for k, v := range base.CustomHeaders {
+			headers[k] = v
+		}
+		out.CustomHeaders = headers
+	}
+	return &out
+}
+
+// ResolveKeyProxyURL normalizes a nullable proxy URL pointer.
+// Whitespace-only and empty values become nil (inherit).
+func ResolveKeyProxyURL(proxyURL *string) *string {
+	if proxyURL == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*proxyURL)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}

--- a/proxy/key_proxy_test.go
+++ b/proxy/key_proxy_test.go
@@ -1,0 +1,101 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/tokendancelab/metapi-go/platform"
+)
+
+func TestApplyKeyProxyOverride_PreferKeyOverSite(t *testing.T) {
+	site := "http://site-proxy:8080"
+	key := "http://key-proxy:9090"
+	base := &platform.ProxyConfig{
+		ProxyURL: site,
+		CustomHeaders: map[string]string{
+			"X-Metapi-Site": "site-header",
+		},
+	}
+
+	got := ApplyKeyProxyOverride(base, &key)
+	if got == nil {
+		t.Fatal("expected non-nil proxy config")
+	}
+	if got.ProxyURL != key {
+		t.Fatalf("ProxyURL = %q, want key proxy %q", got.ProxyURL, key)
+	}
+	if got.UseSystemProxy {
+		t.Fatal("UseSystemProxy should be false after key override")
+	}
+	if got.CustomHeaders["X-Metapi-Site"] != "site-header" {
+		t.Fatalf("custom headers lost: %#v", got.CustomHeaders)
+	}
+	// base must not be mutated
+	if base.ProxyURL != site {
+		t.Fatalf("base mutated: ProxyURL = %q", base.ProxyURL)
+	}
+}
+
+func TestApplyKeyProxyOverride_NilKeyFallsBackToSite(t *testing.T) {
+	site := "http://site-proxy:8080"
+	base := &platform.ProxyConfig{ProxyURL: site, UseSystemProxy: false}
+
+	got := ApplyKeyProxyOverride(base, nil)
+	if got != base {
+		t.Fatalf("expected same base pointer on nil key, got %#v", got)
+	}
+	if got.ProxyURL != site {
+		t.Fatalf("ProxyURL = %q, want site", got.ProxyURL)
+	}
+}
+
+func TestApplyKeyProxyOverride_EmptyKeyFallsBackToSite(t *testing.T) {
+	site := "http://site-proxy:8080"
+	empty := "   "
+	base := &platform.ProxyConfig{ProxyURL: site}
+
+	got := ApplyKeyProxyOverride(base, &empty)
+	if got != base {
+		t.Fatalf("expected base on empty key, got %#v", got)
+	}
+}
+
+func TestApplyKeyProxyOverride_KeyOnlyWhenNoSite(t *testing.T) {
+	key := "socks5://key-proxy:1080"
+	got := ApplyKeyProxyOverride(nil, &key)
+	if got == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if got.ProxyURL != key {
+		t.Fatalf("ProxyURL = %q, want %q", got.ProxyURL, key)
+	}
+}
+
+func TestApplyKeyProxyOverride_KeyOverridesSystemProxyFlag(t *testing.T) {
+	key := "http://key-proxy:1"
+	base := &platform.ProxyConfig{
+		ProxyURL:       "http://system-proxy:8080",
+		UseSystemProxy: true,
+	}
+	got := ApplyKeyProxyOverride(base, &key)
+	if got.ProxyURL != key {
+		t.Fatalf("ProxyURL = %q, want key", got.ProxyURL)
+	}
+	if got.UseSystemProxy {
+		t.Fatal("UseSystemProxy should be cleared by key override")
+	}
+}
+
+func TestResolveKeyProxyURL(t *testing.T) {
+	if ResolveKeyProxyURL(nil) != nil {
+		t.Fatal("nil in → nil out")
+	}
+	empty := "  "
+	if ResolveKeyProxyURL(&empty) != nil {
+		t.Fatal("whitespace → nil")
+	}
+	v := " http://p:1 "
+	got := ResolveKeyProxyURL(&v)
+	if got == nil || *got != "http://p:1" {
+		t.Fatalf("got %#v", got)
+	}
+}


### PR DESCRIPTION
Implements FE-KEY-PROXY / upstream #578 using SC2 proxy_url. Auth context → egress selection with site/system fallback; admin proxyUrl field.