### PR TITLE
feat(routing): custom group route rebuild after channel changes

### DIFF
--- a/docs/specs/p7-token-router.md
+++ b/docs/specs/p7-token-router.md
@@ -844,6 +844,13 @@ are hidden from `getAvailableModels()` output.
 
 Delegates to `modelService.rebuildTokenRoutesFromAvailability()`. The actual rebuild logic is in `modelService` (not in the token router files). The Go port should implement equivalent logic.
 
+**Go implementation (FE-GROUP-REBUILD / upstream #588/#526/#559):**
+- `service.RebuildTokenRoutesFromAvailability` recomposes **pattern/exact** route channels from dual sources (exact-model route channels + `token_model_availability` / `model_availability`).
+- `manual_override = true` channels are never deleted.
+- `explicit_group` routes are **not** materialised into `route_channels`; they expand `route_group_sources` at select time (`ChannelSelector.loadRouteMatch`). After rebuild, new matching accounts attach to **source** exact routes and therefore become visible through groups.
+- `POST /api/routes/rebuild` runs the same path **synchronously** and returns truthful `{ queued: false, status: "completed", channelsInserted, ... }` (no fake jobId).
+- `service.RebuildRoutesBestEffort` is no longer a no-op stub; account delete/batch hooks call it after mutations.
+
 ### 12.2 `refreshModelsAndRebuildRoutes()`
 
 1. Refresh models for all active accounts concurrently

--- a/handler/admin/edge_cases_test.go
+++ b/handler/admin/edge_cases_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/service"
 	"github.com/tokendancelab/metapi-go/store"
 )
 
@@ -830,21 +831,23 @@ func TestEdge_RouteCacheConcurrentReadWrite(t *testing.T) {
 	}
 }
 
-// TestEdge_RebuildRoutesStub verifies that RebuildRoutesBestEffort is a stub
-// that does not cause races when called concurrently.
+// TestEdge_RebuildRoutesConcurrent verifies concurrent rebuild calls do not panic.
+// RebuildRoutesBestEffort now performs real channel recompose under a process mutex.
 func TestEdge_RebuildRoutesConcurrent(t *testing.T) {
-	// Call the stub concurrently -- should not panic
+	db, _, _ := setupEdgeTest(t)
+	service.SetRouteRebuildDB(db.DB)
+	t.Cleanup(func() { service.SetRouteRebuildDB(nil) })
+
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			// RebuildRoutesBestEffort is not directly importable; structural test
-			// The stub writes nothing, so no race.
+			service.RebuildRoutesBestEffort()
 		}()
 	}
 	wg.Wait()
-	t.Log("RebuildRoutesBestEffort is a stub: no concurrent mutation risk")
+	t.Log("RebuildRoutesBestEffort concurrent: no panics")
 }
 
 // =============================================================================

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/tokendancelab/metapi-go/handler/shared"
 	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/service"
 )
 
 // RegisterTokenRoutes registers all /api/routes and /api/channels routes.
@@ -252,6 +253,13 @@ func (h *tokenRoutesHandler) createRoute(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
+	// Pattern routes: auto-populate channels from exact-model routes + model availability.
+	if routeMode != "explicit_group" && modelPattern != "" {
+		if _, err := service.PopulateRouteChannelsByModelPattern(r.Context(), h.db, id, modelPattern); err != nil {
+			slog.Warn("route create: channel auto-populate failed", "routeId", id, "error", err)
+		}
+	}
+
 	created := queryRow(h.db, "SELECT * FROM token_routes WHERE id = ?", id)
 	if created == nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "创建路由失败"})
@@ -327,6 +335,18 @@ func (h *tokenRoutesHandler) updateRoute(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
+	// Pattern change: recompose automatic channels while preserving manual overrides.
+	if v, ok := body["modelPattern"]; ok {
+		if _, ok2 := v.(string); ok2 {
+			mode, _ := existing["routeMode"].(string)
+			if !routing.IsExplicitGroupRoute(mode) {
+				if _, err := service.RebuildTokenRoutesFromAvailability(r.Context(), h.db); err != nil {
+					slog.Warn("route update: rebuild after modelPattern change failed", "routeId", id, "error", err)
+				}
+			}
+		}
+	}
+
 	updated := queryRow(h.db, "SELECT * FROM token_routes WHERE id = ?", id)
 	var srcIDs []int64
 	h.db.Select(&srcIDs, h.db.Rebind("SELECT source_route_id FROM route_group_sources WHERE group_route_id = ?"), id)
@@ -396,21 +416,44 @@ func (h *tokenRoutesHandler) batchRoutes(w http.ResponseWriter, r *http.Request)
 
 // ---- Rebuild Routes ----
 // POST /api/routes/rebuild
-// Currently only invalidates the in-process route cache. Response must stay
-// truthful: do not claim a background job was queued.
+// Synchronously recomposes pattern-route channels from model availability and
+// invalidates the in-process route cache. Response must stay truthful: do not
+// claim a background job was queued.
 func (h *tokenRoutesHandler) rebuildRoutes(w http.ResponseWriter, r *http.Request) {
-	routing.InvalidateCache()
+	stats, err := service.RebuildTokenRoutesFromAvailability(r.Context(), h.db)
+	if err != nil {
+		slog.Error("routes rebuild failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{
+			"success": false,
+			"queued":  false,
+			"reused":  false,
+			"status":  "failed",
+			"message": "路由重建失败",
+		})
+		return
+	}
 	shared.RecordRouteRebuildCompleted()
-	slog.Info("routes rebuild: route cache invalidated",
+	slog.Info("routes rebuild completed",
 		"queued", false,
 		"status", "completed",
+		"routesConsidered", stats.RoutesConsidered,
+		"patternRoutes", stats.PatternRoutes,
+		"groupRoutes", stats.GroupRoutes,
+		"channelsInserted", stats.ChannelsInserted,
+		"channelsRemoved", stats.ChannelsRemoved,
 	)
 	writeJSON(w, http.StatusOK, map[string]any{
-		"success": true,
-		"queued":  false,
-		"reused":  false,
-		"status":  "completed",
-		"message": "路由缓存已刷新",
+		"success":          true,
+		"queued":           false,
+		"reused":           false,
+		"status":           "completed",
+		"message":          "路由通道已重建并刷新缓存",
+		"routesConsidered": stats.RoutesConsidered,
+		"patternRoutes":    stats.PatternRoutes,
+		"groupRoutes":      stats.GroupRoutes,
+		"channelsInserted": stats.ChannelsInserted,
+		"channelsRemoved":  stats.ChannelsRemoved,
+		"channelsKept":     stats.ChannelsKept,
 	})
 }
 

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -81,7 +81,18 @@ func seedRouteChannelRefs(t *testing.T, db *store.DB) (routeID, accountID, token
 }
 
 func TestTokenRoutes_Rebuild_InvalidatesCacheTruthfully(t *testing.T) {
-	_, r := setupTokenRoutesTest(t)
+	db, r := setupTokenRoutesTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		t.Fatalf("seed availability: %v", err)
+	}
+	// Ensure pattern route exists (seed creates gpt-*)
+	_ = routeID
+	_ = accountID
+
 	resp := doPostJSON(t, r, "/api/routes/rebuild", map[string]any{})
 	if resp.Code != http.StatusOK {
 		t.Fatalf("rebuild status = %d, want 200 body=%s", resp.Code, resp.Body.String())
@@ -94,13 +105,28 @@ func TestTokenRoutes_Rebuild_InvalidatesCacheTruthfully(t *testing.T) {
 		t.Fatalf("success = %v, want true", result["success"])
 	}
 	if result["queued"] != false {
-		t.Fatalf("queued = %v, want false (cache invalidate is synchronous)", result["queued"])
+		t.Fatalf("queued = %v, want false (rebuild is synchronous)", result["queued"])
 	}
 	if result["status"] != "completed" {
 		t.Fatalf("status = %v, want completed", result["status"])
 	}
 	if _, ok := result["jobId"]; ok {
 		t.Fatalf("unexpected fake jobId in truthful rebuild response: %v", result["jobId"])
+	}
+	// Stats surface must be present for operators (not a silent cache-only no-op).
+	if _, ok := result["channelsInserted"]; !ok {
+		t.Fatalf("missing channelsInserted in rebuild response: %v", result)
+	}
+	if _, ok := result["patternRoutes"]; !ok {
+		t.Fatalf("missing patternRoutes in rebuild response: %v", result)
+	}
+
+	var chCount int
+	if err := db.Get(&chCount, `SELECT COUNT(*) FROM route_channels WHERE route_id = ?`, routeID); err != nil {
+		t.Fatalf("count channels: %v", err)
+	}
+	if chCount < 1 {
+		t.Fatalf("rebuild did not materialize matching channels, count=%d", chCount)
 	}
 }
 

--- a/routing/rebuilder_adapter.go
+++ b/routing/rebuilder_adapter.go
@@ -1,0 +1,23 @@
+package routing
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// SQLRouteRebuilder adapts a DB-backed rebuild function to RouteRebuilder.
+// The concrete recompose logic lives in service (avoids circular imports with
+// service packages that already depend on routing matchers).
+type SQLRouteRebuilder struct {
+	DB      *sqlx.DB
+	Rebuild func(ctx context.Context, db *sqlx.DB) error
+}
+
+// RebuildTokenRoutesFromAvailability implements RouteRebuilder.
+func (r *SQLRouteRebuilder) RebuildTokenRoutesFromAvailability(ctx context.Context) error {
+	if r == nil || r.Rebuild == nil {
+		return nil
+	}
+	return r.Rebuild(ctx, r.DB)
+}

--- a/service/route_rebuild.go
+++ b/service/route_rebuild.go
@@ -1,0 +1,411 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+// RouteRebuildStats summarizes a synchronous rebuild pass.
+// explicit_group routes do not materialize their own channels; they expand
+// source routes at selection time via route_group_sources.
+type RouteRebuildStats struct {
+	RoutesConsidered int `json:"routesConsidered"`
+	PatternRoutes    int `json:"patternRoutes"`
+	GroupRoutes      int `json:"groupRoutes"`
+	ChannelsInserted int `json:"channelsInserted"`
+	ChannelsRemoved  int `json:"channelsRemoved"`
+	ChannelsKept     int `json:"channelsKept"`
+}
+
+var (
+	routeRebuildMu sync.Mutex
+	// optional override for tests / injected SQL handles without store.GetDB
+	routeRebuildDBMu sync.RWMutex
+	routeRebuildDB   *sqlx.DB
+)
+
+// SetRouteRebuildDB sets the SQL handle used by RebuildRoutesBestEffort when
+// store.GetDB() is not initialized (tests). Pass nil to clear.
+func SetRouteRebuildDB(db *sqlx.DB) {
+	routeRebuildDBMu.Lock()
+	defer routeRebuildDBMu.Unlock()
+	routeRebuildDB = db
+}
+
+// RebuildRoutesBestEffort rebuilds pattern-route channels from current model
+// availability and invalidates the token-router cache. Failures are logged and
+// swallowed so account/site mutation paths stay best-effort.
+func RebuildRoutesBestEffort() {
+	db := resolveRebuildDB()
+	if db == nil {
+		slog.Debug("route rebuild skipped: database not available")
+		return
+	}
+	stats, err := RebuildTokenRoutesFromAvailability(context.Background(), db)
+	if err != nil {
+		slog.Warn("route rebuild best-effort failed", "error", err)
+		return
+	}
+	slog.Info("route rebuild best-effort completed",
+		"routesConsidered", stats.RoutesConsidered,
+		"patternRoutes", stats.PatternRoutes,
+		"groupRoutes", stats.GroupRoutes,
+		"channelsInserted", stats.ChannelsInserted,
+		"channelsRemoved", stats.ChannelsRemoved,
+	)
+}
+
+// RebuildTokenRoutesFromAvailability repopulates automatic (non-manual) channels
+// for every pattern/exact route from dual sources:
+//  1. channels on exact-model routes whose model_pattern matches the target pattern
+//  2. token_model_availability + model_availability rows whose model_name matches
+//
+// explicit_group routes are counted but not rewritten: their membership is
+// route_group_sources, and channel expansion happens at select time. Manual
+// override channels on pattern routes are never deleted.
+//
+// Concurrent rebuilds serialize on a process-wide mutex.
+func RebuildTokenRoutesFromAvailability(ctx context.Context, db *sqlx.DB) (RouteRebuildStats, error) {
+	var stats RouteRebuildStats
+	if db == nil {
+		return stats, fmt.Errorf("route rebuild: db is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return stats, err
+	}
+
+	routeRebuildMu.Lock()
+	defer routeRebuildMu.Unlock()
+
+	type routeRow struct {
+		ID           int64  `db:"id"`
+		ModelPattern string `db:"model_pattern"`
+		RouteMode    string `db:"route_mode"`
+		Enabled      bool   `db:"enabled"`
+	}
+	var routes []routeRow
+	if err := db.SelectContext(ctx, &routes,
+		`SELECT id, model_pattern, route_mode, enabled FROM token_routes ORDER BY id ASC`); err != nil {
+		return stats, fmt.Errorf("load token_routes: %w", err)
+	}
+
+	stats.RoutesConsidered = len(routes)
+	for _, route := range routes {
+		if routing.IsExplicitGroupRoute(route.RouteMode) {
+			stats.GroupRoutes++
+			continue
+		}
+		stats.PatternRoutes++
+		inserted, removed, kept, err := rebuildAutomaticRouteChannelsByModelPattern(ctx, db, route.ID, route.ModelPattern)
+		if err != nil {
+			return stats, fmt.Errorf("rebuild route %d (%s): %w", route.ID, route.ModelPattern, err)
+		}
+		stats.ChannelsInserted += inserted
+		stats.ChannelsRemoved += removed
+		stats.ChannelsKept += kept
+	}
+
+	// Always invalidate in-process cache after topology recompose.
+	routing.InvalidateCache()
+	return stats, nil
+}
+
+// PopulateRouteChannelsByModelPattern is the create-path helper: insert automatic
+// channels for a newly created pattern route without wiping existing rows.
+func PopulateRouteChannelsByModelPattern(ctx context.Context, db *sqlx.DB, routeID int64, modelPattern string) (inserted int, err error) {
+	if db == nil {
+		return 0, fmt.Errorf("populate channels: db is nil")
+	}
+	routeRebuildMu.Lock()
+	defer routeRebuildMu.Unlock()
+
+	desired, err := collectDesiredChannels(ctx, db, routeID, modelPattern)
+	if err != nil {
+		return 0, err
+	}
+	existing, err := loadRouteChannelKeys(ctx, db, routeID)
+	if err != nil {
+		return 0, err
+	}
+	for key, cand := range desired {
+		if _, ok := existing[key]; ok {
+			continue
+		}
+		if err := insertAutoChannel(ctx, db, routeID, cand); err != nil {
+			return inserted, err
+		}
+		inserted++
+	}
+	routing.InvalidateCache()
+	return inserted, nil
+}
+
+type channelIdentity struct {
+	AccountID   int64
+	TokenID     int64 // 0 means NULL
+	SourceModel string
+}
+
+type desiredChannel struct {
+	AccountID   int64
+	TokenID     *int64
+	SourceModel *string
+	Priority    int64
+	Weight      int64
+	Enabled     bool
+}
+
+func channelKey(accountID int64, tokenID *int64, sourceModel *string) channelIdentity {
+	var tid int64
+	if tokenID != nil {
+		tid = *tokenID
+	}
+	sm := ""
+	if sourceModel != nil {
+		sm = *sourceModel
+	}
+	return channelIdentity{AccountID: accountID, TokenID: tid, SourceModel: sm}
+}
+
+func rebuildAutomaticRouteChannelsByModelPattern(ctx context.Context, db *sqlx.DB, routeID int64, modelPattern string) (inserted, removed, kept int, err error) {
+	desired, err := collectDesiredChannels(ctx, db, routeID, modelPattern)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	type existingRow struct {
+		ID             int64   `db:"id"`
+		AccountID      int64   `db:"account_id"`
+		TokenID        *int64  `db:"token_id"`
+		SourceModel    *string `db:"source_model"`
+		ManualOverride bool    `db:"manual_override"`
+	}
+	var rows []existingRow
+	if err := db.SelectContext(ctx, &rows,
+		db.Rebind(`SELECT id, account_id, token_id, source_model, manual_override
+		 FROM route_channels WHERE route_id = ?`), routeID); err != nil {
+		return 0, 0, 0, fmt.Errorf("load route_channels: %w", err)
+	}
+
+	present := make(map[channelIdentity]struct{}, len(rows))
+	for _, row := range rows {
+		key := channelKey(row.AccountID, row.TokenID, row.SourceModel)
+		if row.ManualOverride {
+			// Manual attachments are never deleted by rebuild.
+			present[key] = struct{}{}
+			kept++
+			continue
+		}
+		if _, ok := desired[key]; ok {
+			present[key] = struct{}{}
+			kept++
+			continue
+		}
+		if _, err := db.ExecContext(ctx, db.Rebind(`DELETE FROM route_channels WHERE id = ?`), row.ID); err != nil {
+			return inserted, removed, kept, fmt.Errorf("delete stale channel %d: %w", row.ID, err)
+		}
+		removed++
+	}
+
+	for key, cand := range desired {
+		if _, ok := present[key]; ok {
+			continue
+		}
+		if err := insertAutoChannel(ctx, db, routeID, cand); err != nil {
+			return inserted, removed, kept, err
+		}
+		inserted++
+	}
+	return inserted, removed, kept, nil
+}
+
+func collectDesiredChannels(ctx context.Context, db *sqlx.DB, routeID int64, modelPattern string) (map[channelIdentity]desiredChannel, error) {
+	desired := make(map[channelIdentity]desiredChannel)
+	pattern := modelPattern
+
+	// Source 1: channels from exact-model routes whose pattern matches the target.
+	type exactRoute struct {
+		ID           int64  `db:"id"`
+		ModelPattern string `db:"model_pattern"`
+	}
+	var exactRoutes []exactRoute
+	if err := db.SelectContext(ctx, &exactRoutes,
+		db.Rebind(`SELECT id, model_pattern FROM token_routes
+		 WHERE enabled = ? AND route_mode != ?`), true, "explicit_group"); err != nil {
+		return nil, fmt.Errorf("load exact routes: %w", err)
+	}
+	for _, er := range exactRoutes {
+		if er.ID == routeID {
+			continue
+		}
+		if !routing.IsExactRouteModelPattern(er.ModelPattern) {
+			continue
+		}
+		if !routing.MatchesModelPattern(er.ModelPattern, pattern) {
+			continue
+		}
+		type chRow struct {
+			AccountID   int64   `db:"account_id"`
+			TokenID     *int64  `db:"token_id"`
+			SourceModel *string `db:"source_model"`
+			Priority    int64   `db:"priority"`
+			Weight      int64   `db:"weight"`
+			Enabled     bool    `db:"enabled"`
+		}
+		var channels []chRow
+		if err := db.SelectContext(ctx, &channels,
+			db.Rebind(`SELECT account_id, token_id, source_model, priority, weight, enabled
+			 FROM route_channels WHERE route_id = ? AND enabled = ?`), er.ID, true); err != nil {
+			return nil, fmt.Errorf("load channels for exact route %d: %w", er.ID, err)
+		}
+		for _, ch := range channels {
+			sm := ch.SourceModel
+			if sm == nil || *sm == "" {
+				// Fall back to the exact route's model name.
+				mp := er.ModelPattern
+				sm = &mp
+			}
+			key := channelKey(ch.AccountID, ch.TokenID, sm)
+			if _, exists := desired[key]; exists {
+				continue // first occurrence wins (exact-route channels first)
+			}
+			weight := ch.Weight
+			if weight <= 0 {
+				weight = 10
+			}
+			desired[key] = desiredChannel{
+				AccountID:   ch.AccountID,
+				TokenID:     ch.TokenID,
+				SourceModel: sm,
+				Priority:    ch.Priority,
+				Weight:      weight,
+				Enabled:     true,
+			}
+		}
+	}
+
+	// Source 2a: token_model_availability (token-scoped models).
+	type tokenAvail struct {
+		TokenID   int64  `db:"token_id"`
+		AccountID int64  `db:"account_id"`
+		ModelName string `db:"model_name"`
+	}
+	var tokenRows []tokenAvail
+	if err := db.SelectContext(ctx, &tokenRows,
+		db.Rebind(`SELECT tma.token_id, at.account_id, tma.model_name
+		 FROM token_model_availability tma
+		 JOIN account_tokens at ON at.id = tma.token_id
+		 JOIN accounts a ON a.id = at.account_id
+		 WHERE tma.available = ?
+		   AND at.enabled = ?
+		   AND a.status = ?
+		   AND (at.value_status IS NULL OR at.value_status != ?)`),
+		true, true, "active", "expired"); err != nil {
+		return nil, fmt.Errorf("load token_model_availability: %w", err)
+	}
+	for _, row := range tokenRows {
+		if !routing.MatchesModelPattern(row.ModelName, pattern) {
+			continue
+		}
+		tid := row.TokenID
+		sm := row.ModelName
+		key := channelKey(row.AccountID, &tid, &sm)
+		if _, exists := desired[key]; exists {
+			continue
+		}
+		desired[key] = desiredChannel{
+			AccountID:   row.AccountID,
+			TokenID:     &tid,
+			SourceModel: &sm,
+			Priority:    0,
+			Weight:      10,
+			Enabled:     true,
+		}
+	}
+
+	// Source 2b: model_availability (account-scoped models, no token).
+	type modelAvail struct {
+		AccountID int64  `db:"account_id"`
+		ModelName string `db:"model_name"`
+	}
+	var modelRows []modelAvail
+	if err := db.SelectContext(ctx, &modelRows,
+		db.Rebind(`SELECT ma.account_id, ma.model_name
+		 FROM model_availability ma
+		 JOIN accounts a ON a.id = ma.account_id
+		 WHERE ma.available = ?
+		   AND a.status = ?`), true, "active"); err != nil {
+		return nil, fmt.Errorf("load model_availability: %w", err)
+	}
+	for _, row := range modelRows {
+		if !routing.MatchesModelPattern(row.ModelName, pattern) {
+			continue
+		}
+		sm := row.ModelName
+		key := channelKey(row.AccountID, nil, &sm)
+		if _, exists := desired[key]; exists {
+			continue
+		}
+		desired[key] = desiredChannel{
+			AccountID:   row.AccountID,
+			TokenID:     nil,
+			SourceModel: &sm,
+			Priority:    0,
+			Weight:      10,
+			Enabled:     true,
+		}
+	}
+
+	return desired, nil
+}
+
+func loadRouteChannelKeys(ctx context.Context, db *sqlx.DB, routeID int64) (map[channelIdentity]struct{}, error) {
+	type row struct {
+		AccountID   int64   `db:"account_id"`
+		TokenID     *int64  `db:"token_id"`
+		SourceModel *string `db:"source_model"`
+	}
+	var rows []row
+	if err := db.SelectContext(ctx, &rows,
+		db.Rebind(`SELECT account_id, token_id, source_model FROM route_channels WHERE route_id = ?`), routeID); err != nil {
+		return nil, err
+	}
+	out := make(map[channelIdentity]struct{}, len(rows))
+	for _, r := range rows {
+		out[channelKey(r.AccountID, r.TokenID, r.SourceModel)] = struct{}{}
+	}
+	return out, nil
+}
+
+func insertAutoChannel(ctx context.Context, db *sqlx.DB, routeID int64, cand desiredChannel) error {
+	_, err := db.ExecContext(ctx,
+		db.Rebind(`INSERT INTO route_channels
+			(route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`),
+		routeID, cand.AccountID, cand.TokenID, cand.SourceModel,
+		cand.Priority, cand.Weight, cand.Enabled, false,
+	)
+	if err != nil {
+		return fmt.Errorf("insert auto channel route=%d account=%d: %w", routeID, cand.AccountID, err)
+	}
+	return nil
+}
+
+func resolveRebuildDB() *sqlx.DB {
+	routeRebuildDBMu.RLock()
+	override := routeRebuildDB
+	routeRebuildDBMu.RUnlock()
+	if override != nil {
+		return override
+	}
+	if dbw := store.GetDB(); dbw != nil {
+		return dbw.DB
+	}
+	return nil
+}

--- a/service/route_rebuild_test.go
+++ b/service/route_rebuild_test.go
@@ -1,0 +1,378 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func setupRouteRebuildDB(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func seedSiteAccountToken(t *testing.T, db *store.DB, name string) (siteID, accountID, tokenID int64) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		 VALUES (?, ?, 'openai', 'active', ?, ?)`,
+		name, "https://"+name+".example.com", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ = res.LastInsertId()
+	res, err = db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
+		 VALUES (?, ?, 'tok', 'active', 1, ?, ?)`,
+		siteID, name+"-user", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ = res.LastInsertId()
+	res, err = db.Exec(
+		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
+		 VALUES (?, 'default', 'sk-test', 'ready', 'manual', 1, 1, ?, ?)`,
+		accountID, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert token: %v", err)
+	}
+	tokenID, _ = res.LastInsertId()
+	return siteID, accountID, tokenID
+}
+
+func TestRebuildTokenRoutesFromAvailability_AddsMatchingChannels(t *testing.T) {
+	db := setupRouteRebuildDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	_, accountMatch, tokenMatch := seedSiteAccountToken(t, db, "match")
+	_, accountOther, tokenOther := seedSiteAccountToken(t, db, "other")
+
+	// Matching availability
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'gpt-4o', 1, ?)`, tokenMatch, now); err != nil {
+		t.Fatalf("token avail match: %v", err)
+	}
+	// Non-matching model
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'claude-3-opus', 1, ?)`, tokenOther, now); err != nil {
+		t.Fatalf("token avail other: %v", err)
+	}
+	// Account-level model availability that should also match
+	if _, err := db.Exec(
+		`INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at)
+		 VALUES (?, 'gpt-4o-mini', 1, 0, ?)`, accountMatch, now); err != nil {
+		t.Fatalf("model avail: %v", err)
+	}
+
+	res, err := db.Exec(
+		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
+		 VALUES ('gpt-*', 'pattern', 'weighted', 1, ?, ?)`, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert pattern route: %v", err)
+	}
+	patternRouteID, _ := res.LastInsertId()
+
+	// explicit_group referencing a future exact route — should not get materialised channels
+	res, err = db.Exec(
+		`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
+		 VALUES ('my-group', 'my-group', 'explicit_group', 'weighted', 1, ?, ?)`, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert group route: %v", err)
+	}
+	groupRouteID, _ := res.LastInsertId()
+
+	stats, err := RebuildTokenRoutesFromAvailability(context.Background(), db.DB)
+	if err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if stats.PatternRoutes != 1 {
+		t.Fatalf("patternRoutes = %d, want 1", stats.PatternRoutes)
+	}
+	if stats.GroupRoutes != 1 {
+		t.Fatalf("groupRoutes = %d, want 1", stats.GroupRoutes)
+	}
+	if stats.ChannelsInserted < 2 {
+		t.Fatalf("channelsInserted = %d, want >= 2 (token+account availability)", stats.ChannelsInserted)
+	}
+
+	var patternCount int
+	if err := db.Get(&patternCount, `SELECT COUNT(*) FROM route_channels WHERE route_id = ?`, patternRouteID); err != nil {
+		t.Fatalf("count pattern channels: %v", err)
+	}
+	if patternCount < 2 {
+		t.Fatalf("pattern route channels = %d, want >= 2", patternCount)
+	}
+
+	// Non-matching model must not appear under gpt-* route
+	var claudeCount int
+	if err := db.Get(&claudeCount,
+		`SELECT COUNT(*) FROM route_channels WHERE route_id = ? AND source_model = 'claude-3-opus'`, patternRouteID); err != nil {
+		t.Fatalf("count claude: %v", err)
+	}
+	if claudeCount != 0 {
+		t.Fatalf("non-matching model leaked into pattern route: %d", claudeCount)
+	}
+
+	var groupCount int
+	if err := db.Get(&groupCount, `SELECT COUNT(*) FROM route_channels WHERE route_id = ?`, groupRouteID); err != nil {
+		t.Fatalf("count group channels: %v", err)
+	}
+	if groupCount != 0 {
+		t.Fatalf("explicit_group must not materialize channels, got %d", groupCount)
+	}
+
+	// Unrelated account (claude only) should not be attached
+	var otherOnPattern int
+	if err := db.Get(&otherOnPattern,
+		`SELECT COUNT(*) FROM route_channels WHERE route_id = ? AND account_id = ?`, patternRouteID, accountOther); err != nil {
+		t.Fatalf("count other: %v", err)
+	}
+	if otherOnPattern != 0 {
+		t.Fatalf("non-matching account attached to pattern route")
+	}
+}
+
+func TestRebuildTokenRoutesFromAvailability_PreservesManualOverride(t *testing.T) {
+	db := setupRouteRebuildDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, accountID, tokenID := seedSiteAccountToken(t, db, "manual")
+
+	res, err := db.Exec(
+		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
+		 VALUES ('gpt-*', 'pattern', 'weighted', 1, ?, ?)`, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	routeID, _ := res.LastInsertId()
+
+	// Manual channel with a model that will NOT match after rebuild sources change
+	if _, err := db.Exec(
+		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+		 VALUES (?, ?, ?, 'manual-only-model', 5, 10, 1, 1)`, routeID, accountID, tokenID); err != nil {
+		t.Fatalf("insert manual channel: %v", err)
+	}
+	// Auto channel that becomes stale (no availability for it)
+	if _, err := db.Exec(
+		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+		 VALUES (?, ?, ?, 'stale-auto', 0, 10, 1, 0)`, routeID, accountID, tokenID); err != nil {
+		t.Fatalf("insert auto channel: %v", err)
+	}
+	// Fresh availability
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		t.Fatalf("token avail: %v", err)
+	}
+
+	stats, err := RebuildTokenRoutesFromAvailability(context.Background(), db.DB)
+	if err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if stats.ChannelsRemoved < 1 {
+		t.Fatalf("expected stale auto channel removed, stats=%+v", stats)
+	}
+
+	var manualCount int
+	if err := db.Get(&manualCount,
+		`SELECT COUNT(*) FROM route_channels WHERE route_id = ? AND source_model = 'manual-only-model' AND manual_override = 1`,
+		routeID); err != nil {
+		t.Fatalf("count manual: %v", err)
+	}
+	if manualCount != 1 {
+		t.Fatalf("manual channel wiped by rebuild")
+	}
+
+	var staleCount int
+	if err := db.Get(&staleCount,
+		`SELECT COUNT(*) FROM route_channels WHERE route_id = ? AND source_model = 'stale-auto'`, routeID); err != nil {
+		t.Fatalf("count stale: %v", err)
+	}
+	if staleCount != 0 {
+		t.Fatalf("stale auto channel still present")
+	}
+
+	var freshCount int
+	if err := db.Get(&freshCount,
+		`SELECT COUNT(*) FROM route_channels WHERE route_id = ? AND source_model = 'gpt-4o'`, routeID); err != nil {
+		t.Fatalf("count fresh: %v", err)
+	}
+	if freshCount != 1 {
+		t.Fatalf("fresh availability channel missing")
+	}
+}
+
+func TestRebuildTokenRoutesFromAvailability_GroupSourcesExpandAtSelectTime(t *testing.T) {
+	// Verifies the #526/#588 path: after rebuild adds channels to source exact routes,
+	// explicit_group membership (route_group_sources) remains intact and pattern sources grow.
+	db := setupRouteRebuildDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, accountID, tokenID := seedSiteAccountToken(t, db, "group-src")
+
+	res, err := db.Exec(
+		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
+		 VALUES ('gpt-4o', 'pattern', 'weighted', 1, ?, ?)`, now, now,
+	)
+	if err != nil {
+		t.Fatalf("exact route: %v", err)
+	}
+	exactID, _ := res.LastInsertId()
+
+	res, err = db.Exec(
+		`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
+		 VALUES ('bundle', 'bundle', 'explicit_group', 'weighted', 1, ?, ?)`, now, now,
+	)
+	if err != nil {
+		t.Fatalf("group route: %v", err)
+	}
+	groupID, _ := res.LastInsertId()
+
+	if _, err := db.Exec(
+		`INSERT INTO route_group_sources (group_route_id, source_route_id) VALUES (?, ?)`,
+		groupID, exactID); err != nil {
+		t.Fatalf("group source: %v", err)
+	}
+
+	// New site/model becomes available → rebuild should attach to exact source route
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		t.Fatalf("avail: %v", err)
+	}
+
+	if _, err := RebuildTokenRoutesFromAvailability(context.Background(), db.DB); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+
+	var exactChannels int
+	if err := db.Get(&exactChannels, `SELECT COUNT(*) FROM route_channels WHERE route_id = ?`, exactID); err != nil {
+		t.Fatalf("count exact: %v", err)
+	}
+	if exactChannels != 1 {
+		t.Fatalf("exact source route channels = %d, want 1 (new site auto-added)", exactChannels)
+	}
+
+	var groupChannels int
+	if err := db.Get(&groupChannels, `SELECT COUNT(*) FROM route_channels WHERE route_id = ?`, groupID); err != nil {
+		t.Fatalf("count group: %v", err)
+	}
+	if groupChannels != 0 {
+		t.Fatalf("group should not materialize channels; selector expands sources")
+	}
+
+	var sourceCount int
+	if err := db.Get(&sourceCount,
+		`SELECT COUNT(*) FROM route_group_sources WHERE group_route_id = ? AND source_route_id = ?`,
+		groupID, exactID); err != nil {
+		t.Fatalf("source link: %v", err)
+	}
+	if sourceCount != 1 {
+		t.Fatalf("group source membership lost")
+	}
+
+	// Sanity: channel is reachable via source route for this account
+	var accountOnSource int
+	if err := db.Get(&accountOnSource,
+		`SELECT COUNT(*) FROM route_channels WHERE route_id = ? AND account_id = ?`, exactID, accountID); err != nil {
+		t.Fatalf("account on source: %v", err)
+	}
+	if accountOnSource != 1 {
+		t.Fatalf("new account not on source route used by group")
+	}
+}
+
+func TestRebuildRoutesBestEffort_ConcurrentSafe(t *testing.T) {
+	db := setupRouteRebuildDB(t)
+	SetRouteRebuildDB(db.DB)
+	t.Cleanup(func() { SetRouteRebuildDB(nil) })
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, _, tokenID := seedSiteAccountToken(t, db, "conc")
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'gpt-4', 1, ?)`, tokenID, now); err != nil {
+		t.Fatalf("avail: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
+		 VALUES ('gpt-*', 'pattern', 'weighted', 1, ?, ?)`, now, now); err != nil {
+		t.Fatalf("route: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			RebuildRoutesBestEffort()
+		}()
+	}
+	wg.Wait()
+
+	var count int
+	if err := db.Get(&count, `SELECT COUNT(*) FROM route_channels`); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count == 0 {
+		t.Fatalf("expected channels after concurrent rebuild")
+	}
+}
+
+func TestPopulateRouteChannelsByModelPattern_InsertOnly(t *testing.T) {
+	db := setupRouteRebuildDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, accountID, tokenID := seedSiteAccountToken(t, db, "pop")
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		t.Fatalf("avail: %v", err)
+	}
+	res, err := db.Exec(
+		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
+		 VALUES ('gpt-*', 'pattern', 'weighted', 1, ?, ?)`, now, now,
+	)
+	if err != nil {
+		t.Fatalf("route: %v", err)
+	}
+	routeID, _ := res.LastInsertId()
+
+	// Pre-existing manual channel
+	if _, err := db.Exec(
+		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+		 VALUES (?, ?, ?, 'manual-x', 1, 10, 1, 1)`, routeID, accountID, tokenID); err != nil {
+		t.Fatalf("manual: %v", err)
+	}
+
+	inserted, err := PopulateRouteChannelsByModelPattern(context.Background(), db.DB, routeID, "gpt-*")
+	if err != nil {
+		t.Fatalf("populate: %v", err)
+	}
+	if inserted < 1 {
+		t.Fatalf("inserted = %d, want >= 1", inserted)
+	}
+
+	var manual int
+	_ = db.Get(&manual, `SELECT COUNT(*) FROM route_channels WHERE route_id = ? AND source_model = 'manual-x'`, routeID)
+	if manual != 1 {
+		t.Fatalf("populate must not remove manual channels")
+	}
+}

--- a/service/site_service.go
+++ b/service/site_service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/routing"
 	"github.com/tokendancelab/metapi-go/store"
 )
 
@@ -374,9 +375,9 @@ func InvalidateSiteProxyCache() {
 }
 
 // InvalidateTokenRouterCache signals that cached token-router state should be invalidated.
-// TODO(P7): integrate with the token router cache when implemented.
+// Implemented in route_rebuild.go (delegates to routing.InvalidateCache).
 func InvalidateTokenRouterCache() {
-	// Stub: P7 token router cache invalidation
+	routing.InvalidateCache()
 }
 
 // InvalidateSiteCaches invalidates both site proxy and token router caches.
@@ -385,11 +386,7 @@ func InvalidateSiteCaches() {
 	InvalidateTokenRouterCache()
 }
 
-// RebuildRoutesBestEffort triggers a best-effort route rebuild after account/token mutations.
-// TODO(P4): integrate with the route-building pipeline when implemented.
-func RebuildRoutesBestEffort() {
-	// Stub: P4 route rebuild — the actual rebuild will be queued in a future phase.
-}
+// RebuildRoutesBestEffort is implemented in route_rebuild.go.
 
 // ApplySiteStatusSideEffects handles status change side effects for sites.
 func ApplySiteStatusSideEffects(db *sqlx.DB, siteID int64, siteName string, newStatus string) error {


### PR DESCRIPTION
Implements FE-GROUP-REBUILD / upstream #526/#588/#559. Real RebuildTokenRoutesFromAvailability; truthful rebuild API; tests.