### PR TITLE
fix(routing): Claude cache_ratio pricing fallback #43

### DIFF
--- a/docs/analysis/cache-ratio-pricing.md
+++ b/docs/analysis/cache-ratio-pricing.md
@@ -1,0 +1,62 @@
+# Claude `cache_ratio` pricing fallback
+
+**Date:** 2026-07-17  
+**Backlog:** [#43](https://github.com/TokenDanceLab/metapi-go/issues/43) · upstream cita-777/metapi **#496**  
+**Code:** `routing/pricing_cost.go`
+
+## Problem
+
+Upstream NewAPI-family `/api/pricing` payloads (notably AnyRouter) often omit
+`cache_ratio` / `cache_creation_ratio`. Original MetAPI normalized missing ratios
+with `normalizeRatio(undefined, 1)` → **1.0**, so for Claude models:
+
+| Rate | Wrong (fallback 1.0) | Correct (Anthropic) |
+|------|----------------------|---------------------|
+| `cacheReadPerMillion` | input × 1.0 | input × **0.1** |
+| `cacheCreationPerMillion` | input × 1.0 | input × **1.25** |
+
+That inflated estimated cost / billing_details for cache-heavy Claude traffic
+and polluted cost signals used by routing weight scoring when catalog costs
+are derived from the same ratios.
+
+## Default choice (documented, intentional)
+
+| Model family | Missing `cache_ratio` | Missing `cache_creation_ratio` |
+|--------------|----------------------|--------------------------------|
+| Claude (`*claude*` in name, case-insensitive) | **0.1** | **1.25** |
+| All other models | **1.0** (historical MetAPI) | **1.0** |
+
+Rationale:
+
+1. Anthropic public prompt-cache multipliers relative to input price.
+2. Matches upstream issue #496 recommended Scheme A (display/estimate layer).
+3. Does **not** invent non-Claude vendor ratios; keeps prior MetAPI 1.0 fallback.
+4. Explicit ratios (including **0**) always win over defaults.
+5. NaN / negative values are treated as missing.
+
+## API surface
+
+Pure helpers in `routing` (no network, no DB):
+
+- `ResolveCacheRatio` / `ResolveCacheCreationRatio`
+- `NormalizePricingRatio` (catalog JSON field normalization)
+- `CalculateModelUsageBreakdown` / `CalculateModelUsageCost`
+- `BuildPricingOverrideModel` (self-log billing metadata)
+- `CacheAwarePerMillionRates` (catalog / routing reference rates)
+- `FallbackTokenCost` (last resort when no catalog)
+
+## Tests
+
+`routing/pricing_cost_test.go` covers:
+
+- Claude missing → 0.1 / 1.25 (not equal to input $/M)
+- Non-Claude missing → 1.0
+- Explicit present / explicit zero / NaN
+- Full cache-split cost golden (0.083057) with and without Claude fallback
+- Platform fallback token divisor
+
+## Out of scope (this change)
+
+- Full remote pricing catalog fetch / AnyRouter shield cookie path
+- Admin UI for per-site ratio overrides (upstream Scheme B)
+- Wiring every proxy log write path (helpers are ready for that wave)

--- a/routing/pricing_cost.go
+++ b/routing/pricing_cost.go
@@ -1,0 +1,479 @@
+package routing
+
+import (
+	"math"
+	"strings"
+)
+
+// Claude / Anthropic official prompt-cache multipliers used when an upstream
+// pricing payload omits cache_ratio / cache_creation_ratio for Claude models.
+//
+// Source of intent: cita-777/metapi#496 (AnyRouter /api/pricing often lacks
+// these fields and the historical normalizeRatio(undefined, 1) fallback made
+// cache_read == input and cache_creation == input). Anthropic public pricing
+// ratios relative to input are:
+//
+//	cache read     = 0.10 × input
+//	cache creation = 1.25 × input
+//
+// Non-Claude models keep the original MetAPI fallback of 1.0 so we do not
+// invent vendor-specific multipliers without evidence.
+const (
+	// DefaultCacheRatio is the historical MetAPI fallback when cache_ratio is
+	// missing for non-Claude models (input × 1.0).
+	DefaultCacheRatio = 1.0
+	// DefaultCacheCreationRatio is the historical MetAPI fallback when
+	// cache_creation_ratio is missing for non-Claude models.
+	DefaultCacheCreationRatio = 1.0
+
+	// ClaudeCacheRatio is Anthropic's cache-read multiplier (input × 0.1).
+	ClaudeCacheRatio = 0.1
+	// ClaudeCacheCreationRatio is Anthropic's cache-write / creation
+	// multiplier (input × 1.25).
+	ClaudeCacheCreationRatio = 1.25
+
+	// oneHubPerCallRatio mirrors TS ONE_HUB_PER_CALL_RATIO for times pricing.
+	oneHubPerCallRatio = 0.002
+)
+
+// PricingModel is a normalized upstream pricing row used for cost estimation.
+// Pointer ratios distinguish "missing" from an explicit zero.
+type PricingModel struct {
+	ModelName           string
+	QuotaType           int // 0 = token-based, 1 = per-call
+	ModelRatio          float64
+	CompletionRatio     float64
+	CacheRatio          *float64
+	CacheCreationRatio  *float64
+	ModelPrice          *ModelPrice
+	EnableGroups        []string
+}
+
+// ModelPrice is either a flat per-call price or input/output pair.
+type ModelPrice struct {
+	// Flat is set for scalar model_price values.
+	Flat *float64
+	// Input/Output are set for object model_price values (one-hub times).
+	Input  float64
+	Output float64
+	IsPair bool
+}
+
+// UsageForCost is token usage for a single request cost estimate.
+type UsageForCost struct {
+	PromptTokens             int64
+	CompletionTokens         int64
+	TotalTokens              int64
+	CacheReadTokens          int64
+	CacheCreationTokens      int64
+	// PromptTokensIncludeCache:
+	//   true/nil → prompt tokens already include cache tokens (subtract for billable input)
+	//   false    → prompt tokens are exclusive of cache tokens
+	PromptTokensIncludeCache *bool
+}
+
+// ProxyBillingPricingOverride supplies ratios from self-log metadata.
+type ProxyBillingPricingOverride struct {
+	ModelRatio         float64
+	CompletionRatio    float64
+	CacheRatio         *float64
+	CacheCreationRatio *float64
+	GroupRatio         *float64
+}
+
+// ProxyBillingDetails mirrors the TS ProxyBillingDetails shape (camelCase JSON).
+type ProxyBillingDetails struct {
+	QuotaType int                    `json:"quotaType"`
+	Usage     ProxyBillingUsage      `json:"usage"`
+	Pricing   ProxyBillingPricing    `json:"pricing"`
+	Breakdown ProxyBillingBreakdown  `json:"breakdown"`
+}
+
+// ProxyBillingUsage is the usage section of billing details.
+type ProxyBillingUsage struct {
+	PromptTokens             int64 `json:"promptTokens"`
+	CompletionTokens         int64 `json:"completionTokens"`
+	TotalTokens              int64 `json:"totalTokens"`
+	CacheReadTokens          int64 `json:"cacheReadTokens"`
+	CacheCreationTokens      int64 `json:"cacheCreationTokens"`
+	BillablePromptTokens     int64 `json:"billablePromptTokens"`
+	PromptTokensIncludeCache *bool `json:"promptTokensIncludeCache"`
+}
+
+// ProxyBillingPricing is the ratio section of billing details.
+type ProxyBillingPricing struct {
+	ModelRatio         float64 `json:"modelRatio"`
+	CompletionRatio    float64 `json:"completionRatio"`
+	CacheRatio         float64 `json:"cacheRatio"`
+	CacheCreationRatio float64 `json:"cacheCreationRatio"`
+	GroupRatio         float64 `json:"groupRatio"`
+}
+
+// ProxyBillingBreakdown is the money breakdown of billing details.
+type ProxyBillingBreakdown struct {
+	InputPerMillion         float64 `json:"inputPerMillion"`
+	OutputPerMillion        float64 `json:"outputPerMillion"`
+	CacheReadPerMillion     float64 `json:"cacheReadPerMillion"`
+	CacheCreationPerMillion float64 `json:"cacheCreationPerMillion"`
+	InputCost               float64 `json:"inputCost"`
+	OutputCost              float64 `json:"outputCost"`
+	CacheReadCost           float64 `json:"cacheReadCost"`
+	CacheCreationCost       float64 `json:"cacheCreationCost"`
+	TotalCost               float64 `json:"totalCost"`
+}
+
+// IsClaudeModel reports whether modelName belongs to the Claude / Anthropic
+// family. Matching is case-insensitive substring on "claude".
+func IsClaudeModel(modelName string) bool {
+	return strings.Contains(strings.ToLower(strings.TrimSpace(modelName)), "claude")
+}
+
+// DefaultCacheRatioForModel returns the intentional cache_ratio fallback when
+// an upstream pricing row omits the field. Claude models use Anthropic public
+// ratios; everything else keeps the historical MetAPI 1.0 fallback.
+func DefaultCacheRatioForModel(modelName string) float64 {
+	if IsClaudeModel(modelName) {
+		return ClaudeCacheRatio
+	}
+	return DefaultCacheRatio
+}
+
+// DefaultCacheCreationRatioForModel returns the intentional
+// cache_creation_ratio fallback when the field is missing.
+func DefaultCacheCreationRatioForModel(modelName string) float64 {
+	if IsClaudeModel(modelName) {
+		return ClaudeCacheCreationRatio
+	}
+	return DefaultCacheCreationRatio
+}
+
+// ResolveCacheRatio picks an explicit ratio when present and finite (>= 0),
+// otherwise the model-family default. Explicit 0 is preserved (free cache read).
+func ResolveCacheRatio(modelName string, cacheRatio *float64) float64 {
+	if cacheRatio != nil && isFiniteNonNeg(*cacheRatio) {
+		return *cacheRatio
+	}
+	return DefaultCacheRatioForModel(modelName)
+}
+
+// ResolveCacheCreationRatio picks an explicit creation ratio when present,
+// otherwise the model-family default. Explicit 0 is preserved.
+func ResolveCacheCreationRatio(modelName string, cacheCreationRatio *float64) float64 {
+	if cacheCreationRatio != nil && isFiniteNonNeg(*cacheCreationRatio) {
+		return *cacheCreationRatio
+	}
+	return DefaultCacheCreationRatioForModel(modelName)
+}
+
+// NormalizePricingRatio normalizes a raw ratio from an upstream pricing JSON
+// field. Missing/NaN/negative values fall back using the model-family default
+// selected by kind ("cache" | "cache_creation" | other→fallback).
+func NormalizePricingRatio(value any, modelName, kind string, fallback float64) float64 {
+	if n, ok := asFiniteNumber(value); ok && n >= 0 {
+		return n
+	}
+	switch kind {
+	case "cache":
+		return DefaultCacheRatioForModel(modelName)
+	case "cache_creation":
+		return DefaultCacheCreationRatioForModel(modelName)
+	default:
+		if isFiniteNonNeg(fallback) {
+			return fallback
+		}
+		return 1
+	}
+}
+
+// CalculateModelUsageBreakdown computes token-based billing details.
+// Returns nil for per-call quotaType (1), matching TS behavior.
+func CalculateModelUsageBreakdown(
+	model PricingModel,
+	usage UsageForCost,
+	groupRatio map[string]float64,
+) *ProxyBillingDetails {
+	if model.QuotaType == 1 {
+		return nil
+	}
+
+	multiplier := resolveGroupMultiplier(model, groupRatio)
+	normalized := normalizeUsageBreakdownInput(usage)
+
+	cacheRatio := ResolveCacheRatio(model.ModelName, model.CacheRatio)
+	cacheCreationRatio := ResolveCacheCreationRatio(model.ModelName, model.CacheCreationRatio)
+
+	modelRatio := model.ModelRatio
+	if modelRatio <= 0 || !isFiniteFloat(modelRatio) {
+		modelRatio = 1
+	}
+	completionRatio := model.CompletionRatio
+	if completionRatio <= 0 || !isFiniteFloat(completionRatio) {
+		completionRatio = 1
+	}
+
+	inputPerMillion := roundCost(modelRatio * 2 * multiplier)
+	outputPerMillion := roundCost(modelRatio * completionRatio * 2 * multiplier)
+	cacheReadPerMillion := roundCost(modelRatio * cacheRatio * 2 * multiplier)
+	cacheCreationPerMillion := roundCost(modelRatio * cacheCreationRatio * 2 * multiplier)
+
+	inputCost := roundCost((float64(normalized.BillablePromptTokens) / 1_000_000) * inputPerMillion)
+	outputCost := roundCost((float64(normalized.CompletionTokens) / 1_000_000) * outputPerMillion)
+	cacheReadCost := roundCost((float64(normalized.CacheReadTokens) / 1_000_000) * cacheReadPerMillion)
+	cacheCreationCost := roundCost((float64(normalized.CacheCreationTokens) / 1_000_000) * cacheCreationPerMillion)
+	totalCost := roundCost(inputCost + outputCost + cacheReadCost + cacheCreationCost)
+
+	return &ProxyBillingDetails{
+		QuotaType: model.QuotaType,
+		Usage:     normalized,
+		Pricing: ProxyBillingPricing{
+			ModelRatio:         modelRatio,
+			CompletionRatio:    completionRatio,
+			CacheRatio:         cacheRatio,
+			CacheCreationRatio: cacheCreationRatio,
+			GroupRatio:         multiplier,
+		},
+		Breakdown: ProxyBillingBreakdown{
+			InputPerMillion:         inputPerMillion,
+			OutputPerMillion:        outputPerMillion,
+			CacheReadPerMillion:     cacheReadPerMillion,
+			CacheCreationPerMillion: cacheCreationPerMillion,
+			InputCost:               inputCost,
+			OutputCost:              outputCost,
+			CacheReadCost:           cacheReadCost,
+			CacheCreationCost:       cacheCreationCost,
+			TotalCost:               totalCost,
+		},
+	}
+}
+
+// CalculateModelUsageCost returns the estimated cost for a model + usage.
+func CalculateModelUsageCost(
+	model PricingModel,
+	usage UsageForCost,
+	groupRatio map[string]float64,
+) float64 {
+	multiplier := resolveGroupMultiplier(model, groupRatio)
+	if model.QuotaType == 1 {
+		return roundCost(calculatePerCallCost(model.ModelPrice, multiplier))
+	}
+	detail := CalculateModelUsageBreakdown(model, usage, groupRatio)
+	if detail == nil {
+		return 0
+	}
+	return detail.Breakdown.TotalCost
+}
+
+// EstimateProxyCostFromModel is a pure cost estimate given an already-resolved
+// pricing model (catalog row or self-log override). Prefer this over inventing
+// prices when the catalog is unavailable — callers should use FallbackTokenCost.
+func EstimateProxyCostFromModel(model PricingModel, usage UsageForCost, groupRatio map[string]float64) float64 {
+	return CalculateModelUsageCost(model, usage, groupRatio)
+}
+
+// BuildPricingOverrideModel builds a token-quota PricingModel from self-log
+// billing metadata. Missing Claude cache ratios receive Anthropic defaults.
+func BuildPricingOverrideModel(modelName string, override ProxyBillingPricingOverride) (PricingModel, map[string]float64) {
+	group := 1.0
+	if override.GroupRatio != nil && isFiniteNonNeg(*override.GroupRatio) && *override.GroupRatio > 0 {
+		group = *override.GroupRatio
+	}
+
+	modelRatio := override.ModelRatio
+	if modelRatio <= 0 || !isFiniteFloat(modelRatio) {
+		modelRatio = 1
+	}
+	completionRatio := override.CompletionRatio
+	if completionRatio <= 0 || !isFiniteFloat(completionRatio) {
+		completionRatio = 1
+	}
+
+	// Materialize resolved ratios so billing_details always shows the applied
+	// values (including Claude-aware fallbacks when the override omitted them).
+	cacheRatio := ResolveCacheRatio(modelName, override.CacheRatio)
+	cacheCreationRatio := ResolveCacheCreationRatio(modelName, override.CacheCreationRatio)
+
+	return PricingModel{
+		ModelName:          modelName,
+		QuotaType:          0,
+		ModelRatio:         modelRatio,
+		CompletionRatio:    completionRatio,
+		CacheRatio:         &cacheRatio,
+		CacheCreationRatio: &cacheCreationRatio,
+		EnableGroups:       []string{"default"},
+	}, map[string]float64{"default": group}
+}
+
+// FallbackTokenCost is the last-resort estimate when no pricing catalog is
+// available. Mirrors TS fallbackTokenCost (veloera uses 1e6 divisor, others 5e5).
+func FallbackTokenCost(totalTokens int64, platform string) float64 {
+	divisor := 500_000.0
+	if strings.EqualFold(strings.TrimSpace(platform), "veloera") {
+		divisor = 1_000_000.0
+	}
+	tokens := float64(toPositiveInt64(totalTokens))
+	return roundCost(tokens / divisor)
+}
+
+// CacheAwarePerMillionRates derives input/output/cache $/M rates for catalog
+// display and routing reference helpers. Uses Claude-aware cache defaults.
+func CacheAwarePerMillionRates(model PricingModel, groupMultiplier float64) (input, output, cacheRead, cacheCreation float64) {
+	if groupMultiplier <= 0 || !isFiniteFloat(groupMultiplier) {
+		groupMultiplier = 1
+	}
+	modelRatio := model.ModelRatio
+	if modelRatio <= 0 || !isFiniteFloat(modelRatio) {
+		modelRatio = 1
+	}
+	completionRatio := model.CompletionRatio
+	if completionRatio <= 0 || !isFiniteFloat(completionRatio) {
+		completionRatio = 1
+	}
+	cacheRatio := ResolveCacheRatio(model.ModelName, model.CacheRatio)
+	cacheCreationRatio := ResolveCacheCreationRatio(model.ModelName, model.CacheCreationRatio)
+
+	input = roundCost(modelRatio * 2 * groupMultiplier)
+	output = roundCost(modelRatio * completionRatio * 2 * groupMultiplier)
+	cacheRead = roundCost(modelRatio * cacheRatio * 2 * groupMultiplier)
+	cacheCreation = roundCost(modelRatio * cacheCreationRatio * 2 * groupMultiplier)
+	return
+}
+
+func normalizeUsageBreakdownInput(usage UsageForCost) ProxyBillingUsage {
+	promptTokens := toPositiveInt64(usage.PromptTokens)
+	completionTokens := toPositiveInt64(usage.CompletionTokens)
+	totalTokensRaw := toPositiveInt64(usage.TotalTokens)
+	totalTokens := totalTokensRaw
+	if promptTokens+completionTokens > totalTokens {
+		totalTokens = promptTokens + completionTokens
+	}
+	cacheReadTokens := toPositiveInt64(usage.CacheReadTokens)
+	cacheCreationTokens := toPositiveInt64(usage.CacheCreationTokens)
+	promptTokensIncludeCache := usage.PromptTokensIncludeCache
+
+	hasSplit := promptTokens > 0 || completionTokens > 0
+	effectivePromptTokens := promptTokens
+	if !hasSplit {
+		effectivePromptTokens = totalTokens
+	}
+
+	var billablePromptTokens int64
+	if promptTokensIncludeCache != nil && !*promptTokensIncludeCache {
+		billablePromptTokens = effectivePromptTokens
+	} else {
+		billable := effectivePromptTokens - cacheReadTokens - cacheCreationTokens
+		if billable < 0 {
+			billable = 0
+		}
+		billablePromptTokens = billable
+	}
+
+	return ProxyBillingUsage{
+		PromptTokens:             promptTokens,
+		CompletionTokens:         completionTokens,
+		TotalTokens:              totalTokens,
+		CacheReadTokens:          cacheReadTokens,
+		CacheCreationTokens:      cacheCreationTokens,
+		BillablePromptTokens:     billablePromptTokens,
+		PromptTokensIncludeCache: promptTokensIncludeCache,
+	}
+}
+
+func resolveGroupMultiplier(model PricingModel, groupRatio map[string]float64) float64 {
+	if groupRatio == nil {
+		groupRatio = map[string]float64{}
+	}
+	groups := model.EnableGroups
+	if len(groups) == 0 {
+		groups = []string{"default"}
+	}
+
+	if containsString(groups, "default") {
+		if r, ok := groupRatio["default"]; ok && r > 0 && isFiniteFloat(r) {
+			return r
+		}
+	}
+	for _, g := range groups {
+		if r, ok := groupRatio[g]; ok && r > 0 && isFiniteFloat(r) {
+			return r
+		}
+	}
+	for _, r := range groupRatio {
+		if r > 0 && isFiniteFloat(r) {
+			return r
+		}
+	}
+	return 1
+}
+
+func calculatePerCallCost(price *ModelPrice, multiplier float64) float64 {
+	if price == nil {
+		return 0
+	}
+	if price.Flat != nil {
+		return *price.Flat * multiplier
+	}
+	if price.IsPair {
+		// done-hub/one-hub times pricing follows input ratio only.
+		return price.Input * multiplier * oneHubPerCallRatio
+	}
+	return 0
+}
+
+func roundCost(value float64) float64 {
+	if value < 0 || !isFiniteFloat(value) {
+		return 0
+	}
+	return math.Round(value*1_000_000) / 1_000_000
+}
+
+func toPositiveInt64(v int64) int64 {
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+func isFiniteNonNeg(v float64) bool {
+	return isFiniteFloat(v) && v >= 0
+}
+
+func asFiniteNumber(value any) (float64, bool) {
+	switch n := value.(type) {
+	case float64:
+		if isFiniteFloat(n) {
+			return n, true
+		}
+	case float32:
+		f := float64(n)
+		if isFiniteFloat(f) {
+			return f, true
+		}
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case jsonNumber:
+		f, err := n.Float64()
+		if err == nil && isFiniteFloat(f) {
+			return f, true
+		}
+	}
+	return 0, false
+}
+
+// jsonNumber is satisfied by encoding/json.Number without importing encoding/json
+// into every call site of asFiniteNumber.
+type jsonNumber interface {
+	Float64() (float64, error)
+}
+
+func containsString(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}

--- a/routing/pricing_cost_test.go
+++ b/routing/pricing_cost_test.go
@@ -1,0 +1,333 @@
+package routing
+
+import (
+	"math"
+	"testing"
+)
+
+func ptrF(v float64) *float64 { return &v }
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestIsClaudeModel(t *testing.T) {
+	cases := []struct {
+		name  string
+		want  bool
+	}{
+		{"claude-opus-4-7", true},
+		{"Claude-Sonnet-4", true},
+		{"anthropic/claude-3-5-sonnet", true},
+		{"gpt-4o", false},
+		{"gemini-2.0-flash", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := IsClaudeModel(tc.name); got != tc.want {
+			t.Errorf("IsClaudeModel(%q)=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestResolveCacheRatio_ClaudeMissingFallsBackToAnthropic(t *testing.T) {
+	got := ResolveCacheRatio("claude-haiku-4-5-20251001", nil)
+	if got != ClaudeCacheRatio {
+		t.Fatalf("missing Claude cache_ratio: got %v want %v", got, ClaudeCacheRatio)
+	}
+	got = ResolveCacheCreationRatio("claude-haiku-4-5-20251001", nil)
+	if got != ClaudeCacheCreationRatio {
+		t.Fatalf("missing Claude cache_creation_ratio: got %v want %v", got, ClaudeCacheCreationRatio)
+	}
+}
+
+func TestResolveCacheRatio_NonClaudeMissingFallsBackToOne(t *testing.T) {
+	got := ResolveCacheRatio("gpt-4o", nil)
+	if got != DefaultCacheRatio {
+		t.Fatalf("missing non-Claude cache_ratio: got %v want %v", got, DefaultCacheRatio)
+	}
+	got = ResolveCacheCreationRatio("gpt-4o", nil)
+	if got != DefaultCacheCreationRatio {
+		t.Fatalf("missing non-Claude cache_creation_ratio: got %v want %v", got, DefaultCacheCreationRatio)
+	}
+}
+
+func TestResolveCacheRatio_ExplicitPresentWins(t *testing.T) {
+	// Explicit ratios always win — even for Claude, even if "odd".
+	got := ResolveCacheRatio("claude-sonnet", ptrF(0.3))
+	if got != 0.3 {
+		t.Fatalf("explicit cache_ratio ignored: got %v", got)
+	}
+	// Explicit zero is free cache read, not "missing".
+	got = ResolveCacheRatio("claude-sonnet", ptrF(0))
+	if got != 0 {
+		t.Fatalf("explicit zero cache_ratio should stay 0, got %v", got)
+	}
+	// NaN / negative treated as missing → Claude default.
+	nan := math.NaN()
+	got = ResolveCacheRatio("claude-sonnet", &nan)
+	if got != ClaudeCacheRatio {
+		t.Fatalf("NaN should fall back to Claude default, got %v", got)
+	}
+	got = ResolveCacheRatio("claude-sonnet", ptrF(-1))
+	if got != ClaudeCacheRatio {
+		t.Fatalf("negative should fall back to Claude default, got %v", got)
+	}
+}
+
+func TestNormalizePricingRatio_KindAware(t *testing.T) {
+	// Missing cache fields on Claude → Anthropic defaults.
+	if got := NormalizePricingRatio(nil, "claude-opus-4-7", "cache", 1); got != ClaudeCacheRatio {
+		t.Fatalf("cache kind: got %v", got)
+	}
+	if got := NormalizePricingRatio(nil, "claude-opus-4-7", "cache_creation", 1); got != ClaudeCacheCreationRatio {
+		t.Fatalf("cache_creation kind: got %v", got)
+	}
+	// Present value wins.
+	if got := NormalizePricingRatio(0.05, "claude-opus-4-7", "cache", 1); got != 0.05 {
+		t.Fatalf("present cache ratio: got %v", got)
+	}
+	// Non-Claude missing → 1.0
+	if got := NormalizePricingRatio(nil, "gpt-4o", "cache", 1); got != 1 {
+		t.Fatalf("non-claude missing: got %v", got)
+	}
+}
+
+func TestCalculateModelUsageBreakdown_WithExplicitCacheRatio(t *testing.T) {
+	// Mirrors TS modelPricingService.test.ts "splits cache read and cache creation"
+	model := PricingModel{
+		ModelName:          "gpt-4o",
+		QuotaType:          0,
+		ModelRatio:         2.5,
+		CompletionRatio:    5,
+		CacheRatio:         ptrF(0.1),
+		CacheCreationRatio: ptrF(1.25),
+		EnableGroups:       []string{"default"},
+	}
+	detail := CalculateModelUsageBreakdown(model, UsageForCost{
+		PromptTokens:             146638,
+		CompletionTokens:         172,
+		TotalTokens:              146810,
+		CacheReadTokens:          145692,
+		CacheCreationTokens:      945,
+		PromptTokensIncludeCache: boolPtr(true),
+	}, map[string]float64{"default": 1})
+
+	if detail == nil {
+		t.Fatal("expected billing details")
+	}
+	if detail.Usage.BillablePromptTokens != 1 {
+		t.Errorf("billablePromptTokens=%d want 1", detail.Usage.BillablePromptTokens)
+	}
+	if detail.Pricing.CacheRatio != 0.1 || detail.Pricing.CacheCreationRatio != 1.25 {
+		t.Errorf("pricing ratios = %+v", detail.Pricing)
+	}
+	if math.Abs(detail.Breakdown.InputPerMillion-5) > 1e-9 {
+		t.Errorf("inputPerMillion=%v want 5", detail.Breakdown.InputPerMillion)
+	}
+	if math.Abs(detail.Breakdown.OutputPerMillion-25) > 1e-9 {
+		t.Errorf("outputPerMillion=%v want 25", detail.Breakdown.OutputPerMillion)
+	}
+	if math.Abs(detail.Breakdown.CacheReadPerMillion-0.5) > 1e-9 {
+		t.Errorf("cacheReadPerMillion=%v want 0.5", detail.Breakdown.CacheReadPerMillion)
+	}
+	if math.Abs(detail.Breakdown.CacheCreationPerMillion-6.25) > 1e-9 {
+		t.Errorf("cacheCreationPerMillion=%v want 6.25", detail.Breakdown.CacheCreationPerMillion)
+	}
+	if math.Abs(detail.Breakdown.TotalCost-0.083057) > 1e-9 {
+		t.Errorf("totalCost=%v want 0.083057", detail.Breakdown.TotalCost)
+	}
+}
+
+func TestCalculateModelUsageBreakdown_ClaudeMissingCacheRatioUsesAnthropicDefaults(t *testing.T) {
+	// Upstream #496 signature: missing cache_ratio used to force 1.0 so
+	// cacheReadPerMillion == inputPerMillion. With the fix, Claude defaults to
+	// 0.1 / 1.25 → cacheRead = input×0.1, cacheCreation = input×1.25.
+	model := PricingModel{
+		ModelName:       "claude-opus-4-7",
+		QuotaType:       0,
+		ModelRatio:      2.5, // input $/M = 5
+		CompletionRatio: 5,   // output $/M = 25
+		// CacheRatio / CacheCreationRatio intentionally nil
+		EnableGroups: []string{"default"},
+	}
+	detail := CalculateModelUsageBreakdown(model, UsageForCost{
+		PromptTokens:             146638,
+		CompletionTokens:         172,
+		TotalTokens:              146810,
+		CacheReadTokens:          145692,
+		CacheCreationTokens:      945,
+		PromptTokensIncludeCache: boolPtr(true),
+	}, map[string]float64{"default": 1})
+
+	if detail == nil {
+		t.Fatal("expected billing details")
+	}
+	if detail.Pricing.CacheRatio != ClaudeCacheRatio {
+		t.Fatalf("cacheRatio=%v want %v", detail.Pricing.CacheRatio, ClaudeCacheRatio)
+	}
+	if detail.Pricing.CacheCreationRatio != ClaudeCacheCreationRatio {
+		t.Fatalf("cacheCreationRatio=%v want %v", detail.Pricing.CacheCreationRatio, ClaudeCacheCreationRatio)
+	}
+	// input=5, cacheRead=0.5, cacheCreation=6.25 — NOT equal to input.
+	if math.Abs(detail.Breakdown.InputPerMillion-5) > 1e-9 {
+		t.Errorf("inputPerMillion=%v want 5", detail.Breakdown.InputPerMillion)
+	}
+	if math.Abs(detail.Breakdown.CacheReadPerMillion-0.5) > 1e-9 {
+		t.Errorf("cacheReadPerMillion=%v want 0.5 (was wrongly 5.0 with fallback 1.0)", detail.Breakdown.CacheReadPerMillion)
+	}
+	if math.Abs(detail.Breakdown.CacheCreationPerMillion-6.25) > 1e-9 {
+		t.Errorf("cacheCreationPerMillion=%v want 6.25 (was wrongly 5.0 with fallback 1.0)", detail.Breakdown.CacheCreationPerMillion)
+	}
+	if math.Abs(detail.Breakdown.CacheReadPerMillion-detail.Breakdown.InputPerMillion) < 1e-9 {
+		t.Fatal("cacheReadPerMillion must not equal inputPerMillion for Claude missing cache_ratio")
+	}
+	if math.Abs(detail.Breakdown.TotalCost-0.083057) > 1e-9 {
+		t.Errorf("totalCost=%v want 0.083057", detail.Breakdown.TotalCost)
+	}
+}
+
+func TestCalculateModelUsageBreakdown_NonClaudeMissingCacheRatioStaysOne(t *testing.T) {
+	model := PricingModel{
+		ModelName:       "gpt-4o",
+		QuotaType:       0,
+		ModelRatio:      2.5,
+		CompletionRatio: 5,
+		EnableGroups:    []string{"default"},
+	}
+	detail := CalculateModelUsageBreakdown(model, UsageForCost{
+		PromptTokens:             1000,
+		CompletionTokens:         0,
+		TotalTokens:              1000,
+		CacheReadTokens:          500,
+		PromptTokensIncludeCache: boolPtr(true),
+	}, map[string]float64{"default": 1})
+
+	if detail == nil {
+		t.Fatal("expected billing details")
+	}
+	if detail.Pricing.CacheRatio != 1.0 {
+		t.Fatalf("non-Claude missing cache_ratio should stay 1.0, got %v", detail.Pricing.CacheRatio)
+	}
+	// inputPerMillion = 5; cacheReadPerMillion with ratio 1.0 also 5
+	if math.Abs(detail.Breakdown.CacheReadPerMillion-5) > 1e-9 {
+		t.Errorf("cacheReadPerMillion=%v want 5", detail.Breakdown.CacheReadPerMillion)
+	}
+}
+
+func TestCalculateModelUsageCost_PromptTokensExcludeCache(t *testing.T) {
+	// Mirrors TS "keeps prompt tokens intact when upstream reports cache tokens separately"
+	model := PricingModel{
+		ModelName:          "claude-sonnet",
+		QuotaType:          0,
+		ModelRatio:         3,
+		CompletionRatio:    5,
+		CacheRatio:         ptrF(0.3),
+		CacheCreationRatio: ptrF(1.25),
+		EnableGroups:       []string{"default"},
+	}
+	cost := CalculateModelUsageCost(model, UsageForCost{
+		PromptTokens:             120,
+		CompletionTokens:         30,
+		TotalTokens:              150,
+		CacheReadTokens:          1000,
+		CacheCreationTokens:      40,
+		PromptTokensIncludeCache: boolPtr(false),
+	}, map[string]float64{"default": 1})
+	if math.Abs(cost-0.00372) > 1e-9 {
+		t.Fatalf("cost=%v want 0.00372", cost)
+	}
+}
+
+func TestCalculateModelUsageCost_ZeroCacheRatio(t *testing.T) {
+	model := PricingModel{
+		ModelName:       "claude-sonnet",
+		QuotaType:       0,
+		ModelRatio:      1,
+		CompletionRatio: 1,
+		CacheRatio:      ptrF(0), // free cache reads
+		EnableGroups:    []string{"default"},
+	}
+	detail := CalculateModelUsageBreakdown(model, UsageForCost{
+		PromptTokens:             1000,
+		CompletionTokens:         0,
+		TotalTokens:              1000,
+		CacheReadTokens:          1000,
+		PromptTokensIncludeCache: boolPtr(true),
+	}, map[string]float64{"default": 1})
+	if detail == nil {
+		t.Fatal("expected details")
+	}
+	if detail.Pricing.CacheRatio != 0 {
+		t.Fatalf("cacheRatio=%v want 0", detail.Pricing.CacheRatio)
+	}
+	if detail.Breakdown.CacheReadCost != 0 {
+		t.Fatalf("cacheReadCost=%v want 0", detail.Breakdown.CacheReadCost)
+	}
+	if detail.Breakdown.TotalCost != 0 {
+		// billable prompt = 0, cache cost = 0
+		t.Fatalf("totalCost=%v want 0", detail.Breakdown.TotalCost)
+	}
+}
+
+func TestBuildPricingOverrideModel_ClaudeMissingCache(t *testing.T) {
+	model, groups := BuildPricingOverrideModel("claude-haiku-4-5", ProxyBillingPricingOverride{
+		ModelRatio:      2.5,
+		CompletionRatio: 5,
+		// CacheRatio / CacheCreationRatio omitted
+	})
+	if model.CacheRatio == nil || *model.CacheRatio != ClaudeCacheRatio {
+		t.Fatalf("override cacheRatio=%v want %v", model.CacheRatio, ClaudeCacheRatio)
+	}
+	if model.CacheCreationRatio == nil || *model.CacheCreationRatio != ClaudeCacheCreationRatio {
+		t.Fatalf("override cacheCreationRatio=%v want %v", model.CacheCreationRatio, ClaudeCacheCreationRatio)
+	}
+	cost := CalculateModelUsageCost(model, UsageForCost{
+		PromptTokens:             146638,
+		CompletionTokens:         172,
+		TotalTokens:              146810,
+		CacheReadTokens:          145692,
+		CacheCreationTokens:      945,
+		PromptTokensIncludeCache: boolPtr(true),
+	}, groups)
+	if math.Abs(cost-0.083057) > 1e-9 {
+		t.Fatalf("override cost=%v want 0.083057", cost)
+	}
+}
+
+func TestCacheAwarePerMillionRates_ClaudeMissing(t *testing.T) {
+	in, out, cr, cc := CacheAwarePerMillionRates(PricingModel{
+		ModelName:       "claude-opus-4-7",
+		ModelRatio:      2.5,
+		CompletionRatio: 5,
+	}, 1)
+	if in != 5 || out != 25 || cr != 0.5 || cc != 6.25 {
+		t.Fatalf("rates in=%v out=%v cr=%v cc=%v", in, out, cr, cc)
+	}
+}
+
+func TestFallbackTokenCost(t *testing.T) {
+	if got := FallbackTokenCost(1500, "new-api"); math.Abs(got-0.003) > 1e-9 {
+		t.Fatalf("new-api fallback=%v want 0.003", got)
+	}
+	if got := FallbackTokenCost(1500, "veloera"); math.Abs(got-0.0015) > 1e-9 {
+		t.Fatalf("veloera fallback=%v want 0.0015", got)
+	}
+}
+
+func TestCalculateModelUsageCost_TokenBasedNoCache(t *testing.T) {
+	// Mirrors TS first unit test without cache fields.
+	model := PricingModel{
+		ModelName:       "gpt-4o",
+		QuotaType:       0,
+		ModelRatio:      2,
+		CompletionRatio: 1.5,
+		EnableGroups:    []string{"vip"},
+	}
+	cost := CalculateModelUsageCost(model, UsageForCost{
+		PromptTokens:     1000,
+		CompletionTokens: 500,
+		TotalTokens:      1500,
+	}, map[string]float64{"default": 1, "vip": 2})
+	if math.Abs(cost-0.014) > 1e-9 {
+		t.Fatalf("cost=%v want 0.014", cost)
+	}
+}


### PR DESCRIPTION
## Summary
- Add pure Claude-aware `cache_ratio` / `cache_creation_ratio` cost helpers in `routing/pricing_cost.go`
- Claude defaults: cache read 0.1×, cache creation 1.25×; non-Claude stays 1.0×
- Document gap analysis for upstream #496 / backlog #43

## Test plan
- [x] `go test ./routing -count=1`
- [x] pre-push race suite green

Closes #43