### PR TITLE
fix(tokens): preserve name and enable state on refresh #40

### DIFF
--- a/service/account_mutation_test.go
+++ b/service/account_mutation_test.go
@@ -58,11 +58,16 @@ func createTestAccount(t *testing.T, db *store.DB, siteID int64, username *strin
 
 func createTestAccountToken(t *testing.T, db *store.DB, accountID int64, name, token string, isDefault bool) int64 {
 	t.Helper()
+	return createTestAccountTokenWithEnabled(t, db, accountID, name, token, true, isDefault)
+}
+
+func createTestAccountTokenWithEnabled(t *testing.T, db *store.DB, accountID int64, name, token string, enabled, isDefault bool) int64 {
+	t.Helper()
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	res, err := db.Exec(
 		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
-		 VALUES (?, ?, ?, 'ready', 'manual', 1, ?, ?, ?)`,
-		accountID, name, token, isDefault, now, now,
+		 VALUES (?, ?, ?, 'ready', 'manual', ?, ?, ?, ?)`,
+		accountID, name, token, enabled, isDefault, now, now,
 	)
 	if err != nil {
 		t.Fatalf("INSERT account token failed: %v", err)
@@ -167,6 +172,110 @@ func TestEnsureDefaultTokenForAccountRollsBackWhenAccountUpdateFails(t *testing.
 	}
 	if count != 0 {
 		t.Fatalf("account token rows = %d, want rollback to leave none", count)
+	}
+}
+
+// Upstream #565 / backlog #40: account refresh calls ensureDefault with name="default"
+// and must not rename an existing operator-named default key.
+func TestEnsureDefaultTokenForAccountPreservesNameAndEnabledOnRefresh(t *testing.T) {
+	db := openTestDB(t)
+	siteID := createTestSite(t, db, "PreserveNameSite", "https://preserve-name.example.com", "sub2api")
+	accountID := createTestAccount(t, db, siteID, strPtr("preserve-user"), "session-token")
+	tokenID := createTestAccountTokenWithEnabled(t, db, accountID, "prod-key", "sk-existing-key", false, true)
+
+	id, err := EnsureDefaultTokenForAccount(db.DB, accountID, "sk-existing-key", "default", "manual", "default", true)
+	if err != nil {
+		t.Fatalf("EnsureDefaultTokenForAccount: %v", err)
+	}
+	if id != tokenID {
+		t.Fatalf("token id = %d, want existing %d", id, tokenID)
+	}
+
+	var name string
+	var enabled, isDefault bool
+	if err := db.QueryRow(
+		"SELECT name, enabled, is_default FROM account_tokens WHERE id = ?", tokenID,
+	).Scan(&name, &enabled, &isDefault); err != nil {
+		t.Fatalf("read token: %v", err)
+	}
+	if name != "prod-key" {
+		t.Fatalf("name = %q, want preserved prod-key (not forced to default)", name)
+	}
+	if enabled {
+		t.Fatal("enabled = true, want preserved false")
+	}
+	if !isDefault {
+		t.Fatal("is_default = false, want true after ensure-default")
+	}
+}
+
+// Upstream #565 / backlog #40: sync must not re-enable operator-disabled keys when key is unchanged.
+func TestSyncTokensFromUpstreamPreservesEnabledAndName(t *testing.T) {
+	db := openTestDB(t)
+	siteID := createTestSite(t, db, "PreserveSyncSite", "https://preserve-sync.example.com", "new-api")
+	accountID := createTestAccount(t, db, siteID, strPtr("sync-user"), "session-token")
+	disabledID := createTestAccountTokenWithEnabled(t, db, accountID, "ops-disabled", "sk-disabled-key", false, false)
+	defaultID := createTestAccountTokenWithEnabled(t, db, accountID, "ops-default", "sk-default-key", true, true)
+
+	syncResult, err := SyncTokensFromUpstream(db.DB, accountID, []UpstreamAPIToken{
+		{Name: "upstream-renamed-disabled", Key: "sk-disabled-key", Enabled: true, TokenGroup: "default"},
+		{Name: "upstream-renamed-default", Key: "sk-default-key", Enabled: true, TokenGroup: "default"},
+		{Name: "brand-new", Key: "sk-new-key", Enabled: true, TokenGroup: "default"},
+	})
+	if err != nil {
+		t.Fatalf("SyncTokensFromUpstream: %v", err)
+	}
+	if syncResult == nil {
+		t.Fatal("sync result is nil")
+	}
+	if syncResult.Updated != 2 {
+		t.Fatalf("updated = %d, want 2", syncResult.Updated)
+	}
+	if syncResult.Created != 1 {
+		t.Fatalf("created = %d, want 1", syncResult.Created)
+	}
+
+	var disabledName string
+	var disabledEnabled bool
+	if err := db.QueryRow(
+		"SELECT name, enabled FROM account_tokens WHERE id = ?", disabledID,
+	).Scan(&disabledName, &disabledEnabled); err != nil {
+		t.Fatalf("read disabled token: %v", err)
+	}
+	if disabledName != "ops-disabled" {
+		t.Fatalf("disabled name = %q, want ops-disabled", disabledName)
+	}
+	if disabledEnabled {
+		t.Fatal("disabled token was re-enabled by sync; local enable must be preserved")
+	}
+
+	var defaultName string
+	var defaultEnabled bool
+	if err := db.QueryRow(
+		"SELECT name, enabled FROM account_tokens WHERE id = ?", defaultID,
+	).Scan(&defaultName, &defaultEnabled); err != nil {
+		t.Fatalf("read default token: %v", err)
+	}
+	if defaultName != "ops-default" {
+		t.Fatalf("default name = %q, want ops-default", defaultName)
+	}
+	if !defaultEnabled {
+		t.Fatal("default token enabled flipped off unexpectedly")
+	}
+
+	var newEnabled bool
+	var newName string
+	if err := db.QueryRow(
+		"SELECT name, enabled FROM account_tokens WHERE account_id = ? AND token = ?",
+		accountID, "sk-new-key",
+	).Scan(&newName, &newEnabled); err != nil {
+		t.Fatalf("read new token: %v", err)
+	}
+	if newName != "brand-new" {
+		t.Fatalf("new token name = %q, want brand-new", newName)
+	}
+	if !newEnabled {
+		t.Fatal("new upstream-enabled token should start enabled")
 	}
 }
 

--- a/service/account_token_service.go
+++ b/service/account_token_service.go
@@ -312,7 +312,9 @@ func RepairDefaultToken(db *sqlx.DB, accountID int64) (*store.AccountToken, erro
 }
 
 // EnsureDefaultTokenForAccount ensures a token exists and is default for a given account.
-// Mirrors TS ensureDefaultTokenForAccount().
+// Mirrors TS ensureDefaultTokenForAccount(), with #565 preserve semantics:
+// on an existing token match by value, operator-set name and enabled are kept
+// (callers often pass name="default"; that must not clobber a real key name).
 func EnsureDefaultTokenForAccount(db *sqlx.DB, accountID int64, tokenValue string, name, source, tokenGroup string, enabled bool) (int64, error) {
 	normalized := strings.TrimSpace(tokenValue)
 	if normalized == "" || IsMaskedTokenValue(normalized) {
@@ -397,19 +399,31 @@ func EnsureDefaultTokenForAccount(db *sqlx.DB, accountID int64, tokenValue strin
 		return targetID, nil
 	}
 
-	// Update existing
+	// Update existing: preserve operator-set name/enable (upstream #565 / backlog #40).
+	// Refresh/sync callers pass name="default" and enabled=true; those must not clobber.
 	updateName := target.Name
-	if name != "" {
-		updateName = name
+	if strings.TrimSpace(updateName) == "" {
+		if name != "" {
+			updateName = name
+		} else {
+			updateName = "default"
+		}
+	}
+	updateGroup := tokenGroup
+	if target.TokenGroup != nil && strings.TrimSpace(*target.TokenGroup) != "" {
+		updateGroup = *target.TokenGroup
 	}
 	src := source
 	if src == "" {
 		src = target.Source
 	}
+	if src == "" {
+		src = "manual"
+	}
 	_, err = tx.Exec(
 		tx.Rebind(`UPDATE account_tokens SET name = ?, token_group = ?, value_status = ?, source = ?, enabled = ?, is_default = ?, updated_at = ?
 		 WHERE id = ?`),
-		updateName, tokenGroup, TokenValueStatusReady, src, enabled, true, now, target.ID,
+		updateName, updateGroup, TokenValueStatusReady, src, target.Enabled, true, now, target.ID,
 	)
 	if err != nil {
 		return 0, err
@@ -429,6 +443,148 @@ func EnsureDefaultTokenForAccount(db *sqlx.DB, accountID int64, tokenValue strin
 	}
 	committed = true
 	return target.ID, nil
+}
+
+// UpstreamAPIToken is a token payload returned by platform adapters during sync.
+type UpstreamAPIToken struct {
+	Name       string
+	Key        string
+	Enabled    bool
+	TokenGroup string
+}
+
+// TokenSyncResult summarizes SyncTokensFromUpstream outcomes.
+type TokenSyncResult struct {
+	Created         int
+	Updated         int
+	MaskedPending   int
+	PendingTokenIDs []int64
+	Total           int
+	DefaultTokenID  *int64
+}
+
+// SyncTokensFromUpstream upserts account tokens from upstream listings.
+// When an existing ready token matches by key, local enabled (and non-empty
+// operator-set name) are preserved; upstream enable flags do not clobber
+// operator disable/enable choices (upstream #565 / backlog #40).
+func SyncTokensFromUpstream(db *sqlx.DB, accountID int64, upstreamTokens []UpstreamAPIToken) (*TokenSyncResult, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	var existing []store.AccountToken
+	if err := db.Select(&existing, db.Rebind("SELECT * FROM account_tokens WHERE account_id = ?"), accountID); err != nil {
+		return nil, err
+	}
+
+	result := &TokenSyncResult{Total: len(existing)}
+	index := len(existing) + 1
+
+	for _, upstream := range upstreamTokens {
+		tokenValue := strings.TrimSpace(upstream.Key)
+		if tokenValue == "" {
+			continue
+		}
+		tokenName := strings.TrimSpace(upstream.Name)
+		if tokenName == "" {
+			if index == 1 {
+				tokenName = "default"
+			} else {
+				tokenName = fmt.Sprintf("token-%d", index)
+			}
+		}
+		tokenGroup := strings.TrimSpace(upstream.TokenGroup)
+		if tokenGroup == "" {
+			tokenGroup = "default"
+		}
+		nextValueStatus := TokenValueStatusReady
+		if IsMaskedTokenValue(tokenValue) {
+			nextValueStatus = TokenValueStatusMaskedPending
+		}
+
+		// Match existing ready token by exact key value.
+		var byToken *store.AccountToken
+		for i := range existing {
+			if existing[i].Token == tokenValue && ResolveAccountTokenValueStatus(&existing[i]) == TokenValueStatusReady {
+				byToken = &existing[i]
+				break
+			}
+		}
+		if byToken != nil {
+			// Preserve local enable state; keep operator-set name when present.
+			preservedName := byToken.Name
+			if strings.TrimSpace(preservedName) == "" {
+				preservedName = tokenName
+			}
+			preservedEnabled := byToken.Enabled
+			if _, err := db.Exec(
+				db.Rebind(`UPDATE account_tokens SET name = ?, token_group = ?, value_status = ?, source = ?, enabled = ?, updated_at = ?
+				 WHERE id = ?`),
+				preservedName, tokenGroup, TokenValueStatusReady, "sync", preservedEnabled, now, byToken.ID,
+			); err != nil {
+				return nil, err
+			}
+			byToken.Name = preservedName
+			groupCopy := tokenGroup
+			byToken.TokenGroup = &groupCopy
+			byToken.ValueStatus = TokenValueStatusReady
+			byToken.Enabled = preservedEnabled
+			byToken.Source = "sync"
+			byToken.UpdatedAt = now
+			result.Updated++
+			continue
+		}
+
+		// New token from upstream.
+		nextEnabled := nextValueStatus == TokenValueStatusReady && upstream.Enabled
+		if nextValueStatus == TokenValueStatusMaskedPending {
+			nextEnabled = false
+		}
+		insertRes, err := db.Exec(
+			db.Rebind(`INSERT INTO account_tokens (account_id, name, token, token_group, value_status, source, enabled, is_default, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+			accountID, tokenName, tokenValue, tokenGroup, nextValueStatus, "sync", nextEnabled, false, now, now,
+		)
+		if err != nil {
+			return nil, err
+		}
+		id, err := insertRes.LastInsertId()
+		if err != nil {
+			if err := db.Get(&id, db.Rebind("SELECT id FROM account_tokens WHERE account_id = ? AND token = ? ORDER BY id DESC LIMIT 1"), accountID, tokenValue); err != nil {
+				return nil, err
+			}
+		}
+		groupCopy := tokenGroup
+		createdRow := store.AccountToken{
+			ID:          id,
+			AccountID:   accountID,
+			Name:        tokenName,
+			Token:       tokenValue,
+			TokenGroup:  &groupCopy,
+			ValueStatus: nextValueStatus,
+			Source:      "sync",
+			Enabled:     nextEnabled,
+			IsDefault:   false,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		existing = append(existing, createdRow)
+		result.Created++
+		index++
+		if nextValueStatus == TokenValueStatusMaskedPending {
+			result.MaskedPending++
+			result.PendingTokenIDs = append(result.PendingTokenIDs, id)
+		}
+	}
+
+	repaired, err := RepairDefaultToken(db, accountID)
+	if err != nil {
+		return nil, err
+	}
+	if repaired != nil {
+		id := repaired.ID
+		result.DefaultTokenID = &id
+	}
+	result.Total = len(existing)
+	return result, nil
 }
 
 // GetDefaultTokenForAccount returns the default token for an account.


### PR DESCRIPTION
## Summary
- `EnsureDefaultTokenForAccount`: on existing key match, preserve local name/enabled (and token_group when set)
- Add `SyncTokensFromUpstream` upsert-by-key that keeps operator name + enabled when key value unchanged
- Tests for refresh preserve + sync preserve paths

## Test plan
- [x] `go test ./service/ -run 'EnsureDefault|SyncTokens'`
- [x] pre-push race suite green

Closes #40