### PR TITLE
fix(stats): accurate token usage aggregation #42

### DIFF
--- a/docs/analysis/token-stats-accuracy.md
+++ b/docs/analysis/token-stats-accuracy.md
@@ -1,0 +1,55 @@
+# Token usage statistics accuracy (FE-STATS / #42 / upstream #555)
+
+**Date**: 2026-07-17  
+**Scope**: single-instance correctness of usage aggregation + admin stats reads  
+**Out of scope**: multi-instance Redis coordination, cache_ratio pricing (#43), web redesign
+
+## Summary of fixes
+
+1. **Effective token accounting** (proxy_logs → aggregates / admin reads)
+   - Prefer `total_tokens` when `> 0`.
+   - Otherwise fall back to `prompt_tokens + completion_tokens`.
+   - Never sum prompt+completion *on top of* total_tokens (avoids double count).
+   - Applied in:
+     - `scheduler/usage_aggregation.go` (`effectiveTokenCount`)
+     - `handler/admin/stats.go` (`effectiveProxyTokensSQL` for dashboard / proxy-log meta)
+
+2. **Spend resolution on projection**
+   - Explicit `estimated_cost > 0` wins.
+   - Otherwise fallback: Veloera → `tokens/1e6`, other platforms → `tokens/5e5` (model always `/5e5`).
+   - Aligns site_day / site_hour / model_day spend with the documented TS rules.
+
+3. **Projection batch correctness**
+   - Aggregate deltas by day/hour/model key inside a batch before upsert.
+   - Orphan proxy logs (no site join) still advance the watermark so they are not re-fetched forever, but do not inflate site/model aggregates.
+   - `RequestRecompute` keeps the earliest pending `recompute_from_id` (min) so rewind windows do not shrink.
+
+4. **Stats endpoints no longer stub empty charts**
+   - `/api/stats/site-distribution` reads account balances + `site_day_usage` spend windowed by `days`.
+   - `/api/stats/site-trend` returns `{date, sites:{[name]:{spend,calls}}}` from `site_day_usage`.
+   - `/api/stats/model-by-site` filters by `days` (was ignored) and optional `siteId`.
+   - Dashboard summary now exposes `proxy24h.totalTokens` with effective token math.
+
+## Residual multi-instance limitations
+
+| Area | Single-instance | Multi-instance (shared PostgreSQL, no Redis) |
+|------|-----------------|-----------------------------------------------|
+| Usage aggregation projector | Correct incremental watermark + DB lease | **SAFE**: DB CAS lease in `analytics_projection_checkpoints` prevents double projection while the lease holder is alive. Dead lease holder pauses projection up to ~10 minutes until expiry. |
+| Sticky sessions / route cache / other schedulers | N/A for token totals | Still **not** multi-instance safe (in-memory sticky bindings, local route cache invalidation, non-leased schedulers). See `docs/specs/review/audits/audit-multi-instance.md`. |
+| Admin stats live `SUM(proxy_logs)` paths | Correct | Safe (read-only SQL). |
+| Projected tables lag | Up to one projection interval (5s) | Same, plus lease wait if another instance holds the lease. |
+
+**Documented decision**: Redis / distributed sticky / shared cache invalidation remain out of scope for #42. Operators running multiple MetAPI instances against one database should treat usage aggregation as lease-serialized (correct but delayed on crash) and treat sticky routing as best-effort until a shared store exists.
+
+## Tests
+
+- `scheduler/usage_aggregation_test.go`
+  - existing incremental accumulation
+  - partial token field fallback
+  - orphan watermark without double count
+  - unit tests for effective tokens + spend fallbacks
+- `handler/admin/stats_test.go`
+  - proxy-log meta effective tokens (no double count)
+  - dashboard `proxy24h` tokens
+  - model-by-site `days` filter
+  - site-trend projection shape

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -35,6 +35,14 @@ type statsHandler struct {
 	db *sqlx.DB
 }
 
+// effectiveProxyTokensSQL returns a SQL expression that prefers total_tokens
+// and falls back to prompt_tokens + completion_tokens. Avoids under-counting
+// partial upstream usage payloads and avoids double-counting when both are set.
+const effectiveProxyTokensSQL = `CASE
+	WHEN COALESCE(pl.total_tokens, 0) > 0 THEN COALESCE(pl.total_tokens, 0)
+	ELSE COALESCE(pl.prompt_tokens, 0) + COALESCE(pl.completion_tokens, 0)
+END`
+
 // ---- Dashboard ----
 // GET /api/stats/dashboard?refresh=&view=
 func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
@@ -47,33 +55,146 @@ func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("x-dashboard-summary-cache", "miss")
 	w.Header().Set("x-dashboard-insights-cache", "miss")
 
-	// Stub: return basic stats
 	generatedAt := nowUTC()
-
-	var siteCount, accountCount int
-	h.db.Get(&siteCount, "SELECT COUNT(*) FROM sites")
-	h.db.Get(&accountCount, "SELECT COUNT(*) FROM accounts")
-
 	result := map[string]any{
-		"generatedAt":  generatedAt,
-		"siteCount":    siteCount,
-		"accountCount": accountCount,
+		"generatedAt": generatedAt,
 	}
 
 	if view == "summary" || view == "full" {
+		var siteCount, accountCount, activeAccounts int
+		_ = h.db.Get(&siteCount, "SELECT COUNT(*) FROM sites")
+		_ = h.db.Get(&accountCount, "SELECT COUNT(*) FROM accounts")
+		_ = h.db.Get(&activeAccounts, "SELECT COUNT(*) FROM accounts WHERE status = 'active'")
+
+		var totalBalance, totalUsed float64
+		_ = h.db.Get(&totalBalance, "SELECT COALESCE(SUM(COALESCE(balance, 0)), 0) FROM accounts")
+		_ = h.db.Get(&totalUsed, "SELECT COALESCE(SUM(COALESCE(balance_used, 0)), 0) FROM accounts")
+
+		// 24h proxy window (UTC) — single-pass aggregate with effective tokens.
+		since24h := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
+		var proxy24h struct {
+			Total       int     `db:"total"`
+			Success     int     `db:"success"`
+			TotalTokens int64   `db:"total_tokens"`
+			TotalCost   float64 `db:"total_cost"`
+		}
+		_ = h.db.Get(&proxy24h, rebindAdminQuery(h.db, `
+			SELECT
+				COUNT(*) AS total,
+				COALESCE(SUM(CASE WHEN pl.status = 'success' THEN 1 ELSE 0 END), 0) AS success,
+				COALESCE(SUM(`+effectiveProxyTokensSQL+`), 0) AS total_tokens,
+				COALESCE(SUM(COALESCE(pl.estimated_cost, 0)), 0) AS total_cost
+			FROM proxy_logs pl
+			WHERE pl.created_at >= ?
+		`), since24h)
+
+		// Today spend uses UTC day start for single-instance correctness
+		// (matches aggregation local_day = UTC day).
+		todayStart := time.Now().UTC().Truncate(24 * time.Hour).Format(time.RFC3339)
+		var todaySpend float64
+		_ = h.db.Get(&todaySpend, rebindAdminQuery(h.db, `
+			SELECT COALESCE(SUM(COALESCE(estimated_cost, 0)), 0)
+			FROM proxy_logs
+			WHERE created_at >= ?
+		`), todayStart)
+
+		// Performance window: last 60s request/token rate from proxy_logs.
+		windowSeconds := 60
+		sincePerf := time.Now().UTC().Add(-time.Duration(windowSeconds) * time.Second).Format(time.RFC3339)
+		var perf struct {
+			Requests int64 `db:"requests"`
+			Tokens   int64 `db:"tokens"`
+		}
+		_ = h.db.Get(&perf, rebindAdminQuery(h.db, `
+			SELECT
+				COUNT(*) AS requests,
+				COALESCE(SUM(`+effectiveProxyTokensSQL+`), 0) AS tokens
+			FROM proxy_logs pl
+			WHERE pl.created_at >= ?
+		`), sincePerf)
+
+		rpm := float64(perf.Requests) * 60 / float64(windowSeconds)
+		tpm := float64(perf.Tokens) * 60 / float64(windowSeconds)
+
 		result["siteCount"] = siteCount
 		result["accountCount"] = accountCount
+		result["totalAccounts"] = accountCount
+		result["activeAccounts"] = activeAccounts
+		result["totalBalance"] = roundMicro(totalBalance)
+		result["totalUsed"] = roundMicro(totalUsed)
+		result["todaySpend"] = roundMicro(todaySpend)
+		result["todayReward"] = 0.0
+		result["proxy24h"] = map[string]any{
+			"total":       proxy24h.Total,
+			"success":     proxy24h.Success,
+			"totalTokens": proxy24h.TotalTokens,
+			"totalCost":   roundMicro(proxy24h.TotalCost),
+		}
+		result["performance"] = map[string]any{
+			"windowSeconds":     windowSeconds,
+			"requestsPerMinute": rpm,
+			"tokensPerMinute":   tpm,
+		}
+		// Legacy flat fields kept for older clients / tests.
+		result["totalTokens"] = proxy24h.TotalTokens
+		result["totalCost"] = roundMicro(proxy24h.TotalCost)
 	}
 
 	if view == "insights" || view == "full" {
-		// Add insights fields
-		var totalTokens float64
-		h.db.Get(&totalTokens, "SELECT COALESCE(SUM(COALESCE(total_tokens, 0)), 0) FROM proxy_logs")
-		result["totalTokens"] = totalTokens
-
+		// All-time totals with effective token expression (no double count).
+		var totalTokens int64
+		_ = h.db.Get(&totalTokens, rebindAdminQuery(h.db, `
+			SELECT COALESCE(SUM(`+effectiveProxyTokensSQL+`), 0) FROM proxy_logs pl
+		`))
 		var totalCost float64
-		h.db.Get(&totalCost, "SELECT COALESCE(SUM(COALESCE(estimated_cost, 0)), 0) FROM proxy_logs")
-		result["totalCost"] = totalCost
+		_ = h.db.Get(&totalCost, "SELECT COALESCE(SUM(COALESCE(estimated_cost, 0)), 0) FROM proxy_logs")
+		result["totalTokens"] = totalTokens
+		result["totalCost"] = roundMicro(totalCost)
+
+		// Site availability over last 24h from proxy_logs join path.
+		since24h := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
+		rows := queryRows(h.db, `
+			SELECT
+				s.id AS site_id,
+				s.name AS site_name,
+				s.url AS site_url,
+				s.platform AS platform,
+				COUNT(pl.id) AS total_requests,
+				COALESCE(SUM(CASE WHEN pl.status = 'success' THEN 1 ELSE 0 END), 0) AS success_count,
+				COALESCE(SUM(CASE WHEN COALESCE(pl.status, '') <> 'success' THEN 1 ELSE 0 END), 0) AS failed_count,
+				CASE
+					WHEN COUNT(pl.id) = 0 THEN NULL
+					ELSE ROUND(100.0 * SUM(CASE WHEN pl.status = 'success' THEN 1 ELSE 0 END) / COUNT(pl.id), 2)
+				END AS availability_percent,
+				CASE
+					WHEN SUM(CASE WHEN COALESCE(pl.latency_ms, 0) > 0 THEN 1 ELSE 0 END) = 0 THEN NULL
+					ELSE ROUND(1.0 * SUM(CASE WHEN COALESCE(pl.latency_ms, 0) > 0 THEN pl.latency_ms ELSE 0 END)
+						/ SUM(CASE WHEN COALESCE(pl.latency_ms, 0) > 0 THEN 1 ELSE 0 END), 2)
+				END AS average_latency_ms
+			FROM sites s
+			LEFT JOIN accounts a ON a.site_id = s.id
+			LEFT JOIN proxy_logs pl ON pl.account_id = a.id AND pl.created_at >= ?
+			GROUP BY s.id, s.name, s.url, s.platform
+			ORDER BY total_requests DESC, s.name ASC
+		`, since24h)
+
+		siteAvailability := make([]map[string]any, 0, len(rows))
+		for _, row := range rows {
+			item := map[string]any{
+				"siteId":              row["siteId"],
+				"siteName":            row["siteName"],
+				"siteUrl":             row["siteUrl"],
+				"platform":            row["platform"],
+				"totalRequests":       row["totalRequests"],
+				"successCount":        row["successCount"],
+				"failedCount":         row["failedCount"],
+				"availabilityPercent": row["availabilityPercent"],
+				"averageLatencyMs":    row["averageLatencyMs"],
+				"buckets":             []any{},
+			}
+			siteAvailability = append(siteAvailability, item)
+		}
+		result["siteAvailability"] = siteAvailability
 	}
 
 	writeJSON(w, http.StatusOK, result)
@@ -153,11 +274,13 @@ func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if view == "meta" || view == "full" {
+		// Use effective token expression so partial logs are not under-counted,
+		// and never sum prompt+completion on top of total_tokens.
 		summaryQuery := `SELECT COUNT(*) as total_count,
 			COALESCE(SUM(CASE WHEN pl.status = 'success' THEN 1 ELSE 0 END), 0) as success_count,
 			COALESCE(SUM(CASE WHEN COALESCE(pl.status, '') <> 'success' THEN 1 ELSE 0 END), 0) as failed_count,
 			COALESCE(SUM(COALESCE(pl.estimated_cost, 0)), 0) as total_cost,
-			COALESCE(SUM(COALESCE(pl.total_tokens, 0)), 0) as total_tokens_all
+			COALESCE(SUM(` + effectiveProxyTokensSQL + `), 0) as total_tokens_all
 			FROM proxy_logs pl
 			LEFT JOIN accounts a ON pl.account_id = a.id
 			LEFT JOIN sites s ON a.site_id = s.id` + where
@@ -266,43 +389,126 @@ func (h *statsHandler) debugTraceDetail(w http.ResponseWriter, r *http.Request) 
 // ---- Site Distribution ----
 // GET /api/stats/site-distribution?days=&refresh=
 func (h *statsHandler) siteDistribution(w http.ResponseWriter, r *http.Request) {
-	days := getQueryInt(r, "days", 7)
-	_ = days // validated below, defaults to 7
+	days := clampInt(getQueryInt(r, "days", 7), 1, 365)
+	fromDay := time.Now().UTC().AddDate(0, 0, -(days - 1)).Format("2006-01-02")
 
-	// Stub: return empty distribution
-	_ = days
-	writeJSON(w, http.StatusOK, map[string]any{"distribution": []any{}})
+	// Prefer projected site_day_usage spend; include live account balances.
+	rows := queryRows(h.db, `
+		SELECT
+			s.id AS site_id,
+			s.name AS site_name,
+			s.platform AS platform,
+			COALESCE(bal.total_balance, 0) AS total_balance,
+			COALESCE(usage.total_spend, 0) AS total_spend,
+			COALESCE(bal.account_count, 0) AS account_count
+		FROM sites s
+		LEFT JOIN (
+			SELECT site_id, COALESCE(SUM(COALESCE(balance, 0)), 0) AS total_balance, COUNT(*) AS account_count
+			FROM accounts
+			GROUP BY site_id
+		) bal ON bal.site_id = s.id
+		LEFT JOIN (
+			SELECT site_id, COALESCE(SUM(COALESCE(total_summary_spend, 0)), 0) AS total_spend
+			FROM site_day_usage
+			WHERE local_day >= ?
+			GROUP BY site_id
+		) usage ON usage.site_id = s.id
+		ORDER BY total_spend DESC, s.name ASC
+	`, fromDay)
+
+	distribution := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		distribution = append(distribution, map[string]any{
+			"siteId":       row["siteId"],
+			"siteName":     row["siteName"],
+			"platform":     row["platform"],
+			"totalBalance": coerceFloat(row["totalBalance"]),
+			"totalSpend":   coerceFloat(row["totalSpend"]),
+			"accountCount": coerceInt(row["accountCount"]),
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"distribution": distribution})
 }
 
 // ---- Site Trend ----
 // GET /api/stats/site-trend?days=&refresh=
 func (h *statsHandler) siteTrend(w http.ResponseWriter, r *http.Request) {
-	days := getQueryInt(r, "days", 7)
-	_ = days // validated below, defaults to 7
+	days := clampInt(getQueryInt(r, "days", 7), 1, 365)
+	fromDay := time.Now().UTC().AddDate(0, 0, -(days - 1)).Format("2006-01-02")
 
-	// Stub: return empty trend
-	_ = days
-	writeJSON(w, http.StatusOK, map[string]any{"trend": []any{}})
+	rows := queryRows(h.db, `
+		SELECT
+			u.local_day AS local_day,
+			s.name AS site_name,
+			COALESCE(SUM(u.total_summary_spend), 0) AS spend,
+			COALESCE(SUM(u.total_calls), 0) AS calls
+		FROM site_day_usage u
+		INNER JOIN sites s ON s.id = u.site_id
+		WHERE u.local_day >= ?
+		GROUP BY u.local_day, s.name
+		ORDER BY u.local_day ASC, s.name ASC
+	`, fromDay)
+
+	// Shape: [{ date, sites: { [siteName]: { spend, calls } } }]
+	byDate := make(map[string]map[string]map[string]any)
+	order := make([]string, 0)
+	for _, row := range rows {
+		day := coerceString(row["localDay"])
+		siteName := coerceString(row["siteName"])
+		if day == "" || siteName == "" {
+			continue
+		}
+		if _, ok := byDate[day]; !ok {
+			byDate[day] = make(map[string]map[string]any)
+			order = append(order, day)
+		}
+		byDate[day][siteName] = map[string]any{
+			"spend": coerceFloat(row["spend"]),
+			"calls": coerceInt(row["calls"]),
+		}
+	}
+
+	trend := make([]map[string]any, 0, len(order))
+	for _, day := range order {
+		trend = append(trend, map[string]any{
+			"date":  day,
+			"sites": byDate[day],
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"trend": trend})
 }
 
 // ---- Model by Site ----
 // GET /api/stats/model-by-site?siteId=&days=
 func (h *statsHandler) modelBySite(w http.ResponseWriter, r *http.Request) {
-	days := getQueryInt(r, "days", 7)
-	_ = days // validated below, defaults to 7
+	days := clampInt(getQueryInt(r, "days", 7), 1, 365)
 	siteID := getQueryInt(r, "siteId", 0)
+	fromDay := time.Now().UTC().AddDate(0, 0, -(days - 1)).Format("2006-01-02")
 
-	// Stub: query model_day_usage
-	query := "SELECT model, SUM(total_calls) as calls, SUM(total_spend) as spend, SUM(total_tokens) as tokens FROM model_day_usage"
-	var args []any
+	query := `SELECT model,
+		COALESCE(SUM(total_calls), 0) AS calls,
+		COALESCE(SUM(total_spend), 0) AS spend,
+		COALESCE(SUM(total_tokens), 0) AS tokens
+		FROM model_day_usage
+		WHERE local_day >= ?`
+	args := []any{fromDay}
 	if siteID > 0 {
-		query += " WHERE site_id = ?"
+		query += " AND site_id = ?"
 		args = append(args, siteID)
 	}
 	query += " GROUP BY model ORDER BY calls DESC"
 
 	rows := queryRows(h.db, query, args...)
-	writeJSON(w, http.StatusOK, map[string]any{"models": normalizeSlice(rows)})
+	models := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		models = append(models, map[string]any{
+			"model":  coerceString(row["model"]),
+			"calls":  coerceInt(row["calls"]),
+			"spend":  coerceFloat(row["spend"]),
+			"tokens": coerceInt64(row["tokens"]),
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"models": models})
 }
 
 // ---- Model Marketplace ----
@@ -392,4 +598,68 @@ func nowUTC() string {
 
 func roundMicro(v float64) float64 {
 	return float64(int64(v*1_000_000)) / 1_000_000
+}
+
+func coerceFloat(v any) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case float32:
+		return float64(n)
+	case int64:
+		return float64(n)
+	case int:
+		return float64(n)
+	case int32:
+		return float64(n)
+	case []byte:
+		f, _ := strconv.ParseFloat(string(n), 64)
+		return f
+	case string:
+		f, _ := strconv.ParseFloat(n, 64)
+		return f
+	default:
+		return 0
+	}
+}
+
+func coerceInt(v any) int {
+	return int(coerceInt64(v))
+}
+
+func coerceInt64(v any) int64 {
+	switch n := v.(type) {
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	case int32:
+		return int64(n)
+	case float64:
+		return int64(n)
+	case float32:
+		return int64(n)
+	case []byte:
+		i, _ := strconv.ParseInt(string(n), 10, 64)
+		return i
+	case string:
+		i, _ := strconv.ParseInt(n, 10, 64)
+		return i
+	default:
+		return 0
+	}
+}
+
+func coerceString(v any) string {
+	switch s := v.(type) {
+	case string:
+		return s
+	case []byte:
+		return string(s)
+	default:
+		if v == nil {
+			return ""
+		}
+		return strings.TrimSpace(strconv.FormatInt(coerceInt64(v), 10))
+	}
 }

--- a/handler/admin/stats_test.go
+++ b/handler/admin/stats_test.go
@@ -35,6 +35,21 @@ func setupStatsPostgresTest(t *testing.T) (*store.DB, chi.Router) {
 	return db, r
 }
 
+func setupStatsSQLiteTest(t *testing.T) (*store.DB, chi.Router) {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate sqlite: %v", err)
+	}
+	r := chi.NewRouter()
+	RegisterStatsRoutes(r, db.DB)
+	return db, r
+}
+
 func TestStats_PostgresProxyLogsFilteredTotals(t *testing.T) {
 	db, r := setupStatsPostgresTest(t)
 
@@ -103,5 +118,193 @@ func TestStats_PostgresProxyLogsFilteredTotals(t *testing.T) {
 	}
 	if got := int(summary["failedCount"].(float64)); got != 0 {
 		t.Fatalf("summary.failedCount = %d, want 0", got)
+	}
+}
+
+func TestStats_SQLiteProxyLogsEffectiveTokenTotals(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// total_tokens present → use it (do not also add prompt+completion).
+	_, err := db.Exec(`INSERT INTO proxy_logs (model_requested, model_actual, status, prompt_tokens, completion_tokens, total_tokens, estimated_cost, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, "full-total", "full-total", "success", 40, 60, 100, 0.1, now)
+	if err != nil {
+		t.Fatalf("insert full-total log: %v", err)
+	}
+	// total_tokens missing → fallback prompt+completion.
+	_, err = db.Exec(`INSERT INTO proxy_logs (model_requested, model_actual, status, prompt_tokens, completion_tokens, estimated_cost, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`, "partial-tokens", "partial-tokens", "success", 25, 15, 0.05, now)
+	if err != nil {
+		t.Fatalf("insert partial log: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/stats/proxy-logs?view=meta")
+	if resp.Code != 200 {
+		t.Fatalf("proxy logs meta returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	summary := body["summary"].(map[string]any)
+	// 100 (prefer total) + 40 (25+15 fallback) = 140; never 100+40+60=200.
+	if got := int64(summary["totalTokensAll"].(float64)); got != 140 {
+		t.Fatalf("summary.totalTokensAll = %d, want 140 (no double count)", got)
+	}
+	if got := int(summary["totalCount"].(float64)); got != 2 {
+		t.Fatalf("summary.totalCount = %d, want 2", got)
+	}
+}
+
+func TestStats_SQLiteDashboardProxy24hTokens(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	_, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "stats-site", "https://stats.example.test", "openai", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	var siteID int64
+	if err := db.Get(&siteID, "SELECT id FROM sites WHERE name = ?", "stats-site"); err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, balance, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, 0, ?, ?)`, siteID, "stats-user", "sk-stats", 12.5, now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	var accountID int64
+	if err := db.Get(&accountID, "SELECT id FROM accounts WHERE username = ?", "stats-user"); err != nil {
+		t.Fatalf("account id: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, prompt_tokens, completion_tokens, total_tokens, estimated_cost, latency_ms, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, accountID, "gpt-x", "gpt-x", "success", 10, 20, 0, 0.2, 100, now)
+	if err != nil {
+		t.Fatalf("insert proxy log: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/stats/dashboard?view=full")
+	if resp.Code != 200 {
+		t.Fatalf("dashboard returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	proxy24h, ok := body["proxy24h"].(map[string]any)
+	if !ok {
+		t.Fatalf("proxy24h missing: %#v", body)
+	}
+	if got := int64(proxy24h["totalTokens"].(float64)); got != 30 {
+		t.Fatalf("proxy24h.totalTokens = %d, want 30 from prompt+completion", got)
+	}
+	if got := int(proxy24h["total"].(float64)); got != 1 {
+		t.Fatalf("proxy24h.total = %d, want 1", got)
+	}
+	if got := int(proxy24h["success"].(float64)); got != 1 {
+		t.Fatalf("proxy24h.success = %d, want 1", got)
+	}
+}
+
+func TestStats_SQLiteModelBySiteRespectsDaysFilter(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC()
+	nowStr := now.Format(time.RFC3339)
+	today := now.Format("2006-01-02")
+	oldDay := now.AddDate(0, 0, -30).Format("2006-01-02")
+
+	_, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "model-site", "https://model.example.test", "openai", nowStr, nowStr)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	var siteID int64
+	if err := db.Get(&siteID, "SELECT id FROM sites WHERE name = ?", "model-site"); err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO model_day_usage
+		(local_day, site_id, model, total_calls, success_calls, failed_calls, total_tokens, total_spend, total_latency_ms, latency_count, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		today, siteID, "recent-model", 3, 3, 0, 300, 0.3, 0, 0, nowStr, nowStr)
+	if err != nil {
+		t.Fatalf("insert recent model usage: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO model_day_usage
+		(local_day, site_id, model, total_calls, success_calls, failed_calls, total_tokens, total_spend, total_latency_ms, latency_count, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		oldDay, siteID, "old-model", 9, 9, 0, 900, 0.9, 0, 0, nowStr, nowStr)
+	if err != nil {
+		t.Fatalf("insert old model usage: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/stats/model-by-site?days=7&siteId="+strconv.FormatInt(siteID, 10))
+	if resp.Code != 200 {
+		t.Fatalf("model-by-site returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	models, ok := body["models"].([]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %#v, want only recent-model", body["models"])
+	}
+	item := models[0].(map[string]any)
+	if item["model"] != "recent-model" {
+		t.Fatalf("model = %v, want recent-model", item["model"])
+	}
+	if int(item["tokens"].(float64)) != 300 {
+		t.Fatalf("tokens = %v, want 300", item["tokens"])
+	}
+}
+
+func TestStats_SQLiteSiteTrendFromProjectedUsage(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC()
+	nowStr := now.Format(time.RFC3339)
+	today := now.Format("2006-01-02")
+
+	_, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "trend-site", "https://trend.example.test", "openai", nowStr, nowStr)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	var siteID int64
+	if err := db.Get(&siteID, "SELECT id FROM sites WHERE name = ?", "trend-site"); err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO site_day_usage
+		(local_day, site_id, total_calls, success_calls, failed_calls, total_tokens, total_summary_spend, total_site_spend, total_latency_ms, latency_count, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		today, siteID, 4, 3, 1, 400, 1.25, 1.25, 100, 1, nowStr, nowStr)
+	if err != nil {
+		t.Fatalf("insert site day usage: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/stats/site-trend?days=7")
+	if resp.Code != 200 {
+		t.Fatalf("site-trend returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	trend, ok := body["trend"].([]any)
+	if !ok || len(trend) != 1 {
+		t.Fatalf("trend = %#v, want one day", body["trend"])
+	}
+	entry := trend[0].(map[string]any)
+	if entry["date"] != today {
+		t.Fatalf("date = %v, want %s", entry["date"], today)
+	}
+	sites := entry["sites"].(map[string]any)
+	site := sites["trend-site"].(map[string]any)
+	if site["calls"].(float64) != 4 {
+		t.Fatalf("calls = %v, want 4", site["calls"])
+	}
+	if site["spend"].(float64) != 1.25 {
+		t.Fatalf("spend = %v, want 1.25", site["spend"])
 	}
 }

--- a/scheduler/usage_aggregation.go
+++ b/scheduler/usage_aggregation.go
@@ -221,14 +221,17 @@ type projectionCheckpoint struct {
 
 // projectionRow is a lightweight projection row from proxy_logs.
 type projectionRow struct {
-	id        int64
-	status    *string
-	tokens    *int64
-	cost      *float64
-	siteID    *int64
-	model     *string
-	latencyMs *int64
-	createdAt *string
+	id               int64
+	status           *string
+	promptTokens     *int64
+	completionTokens *int64
+	tokens           *int64
+	cost             *float64
+	siteID           *int64
+	platform         *string
+	model            *string
+	latencyMs        *int64
+	createdAt        *string
 }
 
 func (s *UsageAggregationScheduler) buildLeaseOwner() string {
@@ -336,8 +339,8 @@ func (s *UsageAggregationScheduler) readCheckpoint(dbw *store.DB) projectionChec
 
 func (s *UsageAggregationScheduler) fetchBatch(dbw *store.DB, afterID int64, limit int) ([]projectionRow, error) {
 	rows, err := dbw.Query(`
-		SELECT pl.id, pl.status, pl.total_tokens, pl.estimated_cost, s.id as site_id,
-		       pl.model_actual, pl.latency_ms, pl.created_at
+		SELECT pl.id, pl.status, pl.prompt_tokens, pl.completion_tokens, pl.total_tokens, pl.estimated_cost,
+		       s.id as site_id, s.platform, pl.model_actual, pl.latency_ms, pl.created_at
 		FROM proxy_logs pl
 		LEFT JOIN accounts a ON pl.account_id = a.id
 		LEFT JOIN sites s ON a.site_id = s.id
@@ -353,7 +356,10 @@ func (s *UsageAggregationScheduler) fetchBatch(dbw *store.DB, afterID int64, lim
 	var result []projectionRow
 	for rows.Next() {
 		var r projectionRow
-		if err := rows.Scan(&r.id, &r.status, &r.tokens, &r.cost, &r.siteID, &r.model, &r.latencyMs, &r.createdAt); err != nil {
+		if err := rows.Scan(
+			&r.id, &r.status, &r.promptTokens, &r.completionTokens, &r.tokens, &r.cost,
+			&r.siteID, &r.platform, &r.model, &r.latencyMs, &r.createdAt,
+		); err != nil {
 			return nil, fmt.Errorf("failed to scan projection row: %w", err)
 		}
 		result = append(result, r)
@@ -365,23 +371,41 @@ func (s *UsageAggregationScheduler) fetchBatch(dbw *store.DB, afterID int64, lim
 }
 
 func (s *UsageAggregationScheduler) applyBatch(dbw *store.DB, cp projectionCheckpoint, rows []projectionRow) error {
-	// Build deltas from projection rows
-	type delta struct {
-		siteID    int64
-		day       string
-		hour      string
-		model     string
-		calls     int
-		successes int
-		failures  int
-		tokens    int64
-		cost      float64
-		latencyMs int64
+	// Aggregate deltas by key so one batch never multiplies the same bucket
+	// with repeated single-row upserts (correctness + fewer writes).
+	type dayKey struct {
+		day    string
+		siteID int64
+	}
+	type hourKey struct {
+		hour   string
+		siteID int64
+	}
+	type modelKey struct {
+		day    string
+		siteID int64
+		model  string
+	}
+	type bucketDelta struct {
+		calls         int
+		successes     int
+		failures      int
+		tokens        int64
+		summarySpend  float64
+		siteSpend     float64
+		modelSpend    float64
+		latencyMs     int64
+		latencyCount  int
 	}
 
-	deltas := make([]delta, 0, len(rows))
+	dayDeltas := make(map[dayKey]*bucketDelta)
+	hourDeltas := make(map[hourKey]*bucketDelta)
+	modelDeltas := make(map[modelKey]*bucketDelta)
+
 	for _, r := range rows {
 		if r.siteID == nil {
+			// Orphan logs without a site join still advance the watermark below;
+			// they cannot contribute to site/model aggregates.
 			continue
 		}
 		logTime := projectionTimestamp(r.createdAt)
@@ -391,29 +415,72 @@ func (s *UsageAggregationScheduler) applyBatch(dbw *store.DB, cp projectionCheck
 		if r.model != nil && strings.TrimSpace(*r.model) != "" {
 			model = strings.TrimSpace(*r.model)
 		}
+		platform := ""
+		if r.platform != nil {
+			platform = *r.platform
+		}
 
-		d := delta{
-			siteID: *r.siteID,
-			day:    day,
-			hour:   hour,
-			model:  model,
-			calls:  1,
-		}
+		tokens := effectiveTokenCount(r.tokens, r.promptTokens, r.completionTokens)
+		summarySpend := resolveSummarySpend(r.cost, tokens, platform)
+		siteSpend := resolveSiteSpend(r.cost, tokens, platform)
+		modelSpend := resolveModelSpend(r.cost, tokens)
+
+		successes := 0
+		failures := 1
 		if r.status != nil && *r.status == "success" {
-			d.successes = 1
-		} else {
-			d.failures = 1
+			successes = 1
+			failures = 0
 		}
-		if r.tokens != nil {
-			d.tokens = *r.tokens
-		}
-		if r.cost != nil {
-			d.cost = *r.cost
-		}
+		latencyMs := int64(0)
+		latencyCount := 0
 		if r.latencyMs != nil && *r.latencyMs > 0 {
-			d.latencyMs = *r.latencyMs
+			latencyMs = *r.latencyMs
+			latencyCount = 1
 		}
-		deltas = append(deltas, d)
+
+		dk := dayKey{day: day, siteID: *r.siteID}
+		dd := dayDeltas[dk]
+		if dd == nil {
+			dd = &bucketDelta{}
+			dayDeltas[dk] = dd
+		}
+		dd.calls++
+		dd.successes += successes
+		dd.failures += failures
+		dd.tokens += tokens
+		dd.summarySpend += summarySpend
+		dd.siteSpend += siteSpend
+		dd.latencyMs += latencyMs
+		dd.latencyCount += latencyCount
+
+		hk := hourKey{hour: hour, siteID: *r.siteID}
+		hd := hourDeltas[hk]
+		if hd == nil {
+			hd = &bucketDelta{}
+			hourDeltas[hk] = hd
+		}
+		hd.calls++
+		hd.successes += successes
+		hd.failures += failures
+		hd.tokens += tokens
+		hd.summarySpend += summarySpend
+		hd.siteSpend += siteSpend
+		hd.latencyMs += latencyMs
+		hd.latencyCount += latencyCount
+
+		mk := modelKey{day: day, siteID: *r.siteID, model: model}
+		md := modelDeltas[mk]
+		if md == nil {
+			md = &bucketDelta{}
+			modelDeltas[mk] = md
+		}
+		md.calls++
+		md.successes += successes
+		md.failures += failures
+		md.tokens += tokens
+		md.modelSpend += modelSpend
+		md.latencyMs += latencyMs
+		md.latencyCount += latencyCount
 	}
 
 	// Apply to usage tables within a transaction for atomicity
@@ -462,35 +529,33 @@ func (s *UsageAggregationScheduler) applyBatch(dbw *store.DB, cp projectionCheck
 			latency_count = model_day_usage.latency_count + excluded.latency_count,
 			updated_at = excluded.updated_at`
 
-	for _, d := range deltas {
-		latencyCount := 0
-		if d.latencyMs > 0 {
-			latencyCount = 1
-		}
-
-		// site_day_usage upsert
+	for k, d := range dayDeltas {
 		if _, err := tx.Exec(tx.Rebind(siteDaySQL),
-			d.day, d.siteID, d.calls, d.successes, d.failures, d.tokens, d.cost, d.cost, d.latencyMs, latencyCount, now, now); err != nil {
+			k.day, k.siteID, d.calls, d.successes, d.failures, d.tokens, d.summarySpend, d.siteSpend, d.latencyMs, d.latencyCount, now, now); err != nil {
 			return fmt.Errorf("failed to upsert site_day_usage: %w", err)
 		}
-
-		// site_hour_usage upsert
+	}
+	for k, d := range hourDeltas {
 		if _, err := tx.Exec(tx.Rebind(siteHourSQL),
-			d.hour, d.siteID, d.calls, d.successes, d.failures, d.tokens, d.cost, d.cost, d.latencyMs, latencyCount, now, now); err != nil {
+			k.hour, k.siteID, d.calls, d.successes, d.failures, d.tokens, d.summarySpend, d.siteSpend, d.latencyMs, d.latencyCount, now, now); err != nil {
 			return fmt.Errorf("failed to upsert site_hour_usage: %w", err)
 		}
-
-		// model_day_usage upsert
+	}
+	for k, d := range modelDeltas {
 		if _, err := tx.Exec(tx.Rebind(modelDaySQL),
-			d.day, d.siteID, d.model, d.calls, d.successes, d.failures, d.tokens, d.cost, d.latencyMs, latencyCount, now, now); err != nil {
+			k.day, k.siteID, k.model, d.calls, d.successes, d.failures, d.tokens, d.modelSpend, d.latencyMs, d.latencyCount, now, now); err != nil {
 			return fmt.Errorf("failed to upsert model_day_usage: %w", err)
 		}
 	}
 
-	// Write checkpoint
+	// Write checkpoint for every fetched row (including orphans) so the
+	// watermark never re-projects the same proxy_log id range.
 	if len(rows) > 0 {
 		lastID := rows[len(rows)-1].id
 		lastCreatedAt := time.Now().UTC().Format(time.RFC3339)
+		if rows[len(rows)-1].createdAt != nil && strings.TrimSpace(*rows[len(rows)-1].createdAt) != "" {
+			lastCreatedAt = strings.TrimSpace(*rows[len(rows)-1].createdAt)
+		}
 		if _, err := tx.Exec(tx.Rebind(`UPDATE analytics_projection_checkpoints
 			SET last_proxy_log_id = ?, watermark_created_at = ?, last_projected_at = ?, last_successful_at = ?, updated_at = ?
 			WHERE projector_key = ?`),
@@ -500,6 +565,65 @@ func (s *UsageAggregationScheduler) applyBatch(dbw *store.DB, cp projectionCheck
 	}
 
 	return tx.Commit()
+}
+
+// effectiveTokenCount prefers total_tokens when present and positive; otherwise
+// falls back to prompt+completion so partial upstream payloads still count.
+func effectiveTokenCount(total, prompt, completion *int64) int64 {
+	var totalVal, promptVal, completionVal int64
+	if total != nil && *total > 0 {
+		totalVal = *total
+	}
+	if prompt != nil && *prompt > 0 {
+		promptVal = *prompt
+	}
+	if completion != nil && *completion > 0 {
+		completionVal = *completion
+	}
+	if totalVal > 0 {
+		return totalVal
+	}
+	sum := promptVal + completionVal
+	if sum > 0 {
+		return sum
+	}
+	return 0
+}
+
+func fallbackTokenCost(tokens int64, platform string) float64 {
+	if tokens <= 0 {
+		return 0
+	}
+	// Veloera-style platforms bill roughly tokens/1e6; other NewAPI-like
+	// platforms use the historical tokens/5e5 fallback from the TS service.
+	if strings.EqualFold(strings.TrimSpace(platform), "veloera") {
+		return float64(tokens) / 1_000_000
+	}
+	return float64(tokens) / 500_000
+}
+
+func resolveSummarySpend(explicit *float64, tokens int64, platform string) float64 {
+	if explicit != nil && *explicit > 0 {
+		return *explicit
+	}
+	return fallbackTokenCost(tokens, platform)
+}
+
+func resolveSiteSpend(explicit *float64, tokens int64, platform string) float64 {
+	if explicit != nil && *explicit > 0 {
+		return *explicit
+	}
+	return fallbackTokenCost(tokens, platform)
+}
+
+func resolveModelSpend(explicit *float64, tokens int64) float64 {
+	if explicit != nil && *explicit > 0 {
+		return *explicit
+	}
+	if tokens <= 0 {
+		return 0
+	}
+	return float64(tokens) / 500_000
 }
 
 func projectionTimestamp(raw *string) time.Time {
@@ -584,6 +708,8 @@ func (s *UsageAggregationScheduler) applyRecompute(dbw *store.DB, cp projectionC
 }
 
 // RequestRecompute requests a recompute of usage aggregates starting from fromLogID.
+// When a recompute is already pending, the earlier (smaller) log id is kept so the
+// rewind window is never silently reduced.
 func (s *UsageAggregationScheduler) RequestRecompute(fromLogID int64) {
 	dbw := store.GetDB()
 	if dbw == nil {
@@ -593,6 +719,10 @@ func (s *UsageAggregationScheduler) RequestRecompute(fromLogID int64) {
 	fromID := fromLogID
 	if fromID < 1 {
 		fromID = 1
+	}
+	cp := s.readCheckpoint(dbw)
+	if cp.RecomputeFromID != nil && *cp.RecomputeFromID > 0 && *cp.RecomputeFromID < fromID {
+		fromID = *cp.RecomputeFromID
 	}
 	dbw.Exec(`UPDATE analytics_projection_checkpoints
 		SET recompute_from_id = ?, recompute_requested_at = ?, updated_at = ?

--- a/scheduler/usage_aggregation_test.go
+++ b/scheduler/usage_aggregation_test.go
@@ -236,9 +236,27 @@ func insertProjectionAccount(t *testing.T, db *store.DB, siteID int64, suffix, n
 
 func insertProjectionProxyLog(t *testing.T, db *store.DB, accountID int64, status, model string, tokens int64, cost float64, latencyMs int64, createdAt time.Time) int64 {
 	t.Helper()
-	query := `INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, total_tokens, estimated_cost, latency_ms, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-	args := []any{accountID, model, model, status, tokens, cost, latencyMs, createdAt.UTC().Format(time.RFC3339)}
+	return insertProjectionProxyLogTokens(t, db, accountID, status, model, nil, nil, &tokens, &cost, latencyMs, createdAt)
+}
+
+func insertProjectionProxyLogTokens(
+	t *testing.T,
+	db *store.DB,
+	accountID int64,
+	status, model string,
+	promptTokens, completionTokens, totalTokens *int64,
+	cost *float64,
+	latencyMs int64,
+	createdAt time.Time,
+) int64 {
+	t.Helper()
+	query := `INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, prompt_tokens, completion_tokens, total_tokens, estimated_cost, latency_ms, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	args := []any{
+		accountID, model, model, status,
+		promptTokens, completionTokens, totalTokens, cost, latencyMs,
+		createdAt.UTC().Format(time.RFC3339),
+	}
 	if db.Dialect == store.DialectPostgres {
 		var id int64
 		if err := db.QueryRow(query+" RETURNING id", args...).Scan(&id); err != nil {
@@ -255,4 +273,142 @@ func insertProjectionProxyLog(t *testing.T, db *store.DB, accountID int64, statu
 		t.Fatalf("sqlite proxy log LastInsertId: %v", err)
 	}
 	return id
+}
+
+func TestEffectiveTokenCount(t *testing.T) {
+	ptr := func(v int64) *int64 { return &v }
+
+	if got := effectiveTokenCount(ptr(120), ptr(50), ptr(70)); got != 120 {
+		t.Fatalf("prefer total_tokens: got %d", got)
+	}
+	if got := effectiveTokenCount(ptr(0), ptr(40), ptr(60)); got != 100 {
+		t.Fatalf("fallback prompt+completion: got %d", got)
+	}
+	if got := effectiveTokenCount(nil, ptr(25), nil); got != 25 {
+		t.Fatalf("prompt-only fallback: got %d", got)
+	}
+	if got := effectiveTokenCount(nil, nil, nil); got != 0 {
+		t.Fatalf("empty tokens: got %d", got)
+	}
+}
+
+func TestResolveSpendFallbacks(t *testing.T) {
+	explicit := 1.25
+	if got := resolveSummarySpend(&explicit, 1000, "openai"); got != 1.25 {
+		t.Fatalf("explicit cost: got %v", got)
+	}
+	if got := resolveSummarySpend(nil, 1_000_000, "veloera"); math.Abs(got-1.0) > 1e-9 {
+		t.Fatalf("veloera fallback: got %v", got)
+	}
+	if got := resolveSummarySpend(nil, 500_000, "openai"); math.Abs(got-1.0) > 1e-9 {
+		t.Fatalf("default fallback: got %v", got)
+	}
+	if got := resolveModelSpend(nil, 500_000); math.Abs(got-1.0) > 1e-9 {
+		t.Fatalf("model fallback: got %v", got)
+	}
+}
+
+func TestUsageAggregationProjection_PartialTokenFieldsAccumulate(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate sqlite: %v", err)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	baseWatermark := maxProxyLogID(t, db)
+	seedProjectionCheckpoint(t, db, baseWatermark)
+	suffix := "partial-" + strings.ReplaceAll(t.Name(), "/", "-")
+	siteID := insertProjectionSite(t, db, suffix, now)
+	accountID := insertProjectionAccount(t, db, siteID, suffix, now)
+
+	prompt := int64(40)
+	completion := int64(60)
+	logTime := time.Date(2026, 7, 6, 11, 0, 0, 0, time.UTC)
+	// total_tokens missing/zero, but prompt+completion present.
+	insertProjectionProxyLogTokens(t, db, accountID, "success", "gpt-4.1", &prompt, &completion, nil, nil, 120, logTime)
+
+	previousDB := store.GetDB()
+	store.OverrideDB(db)
+	t.Cleanup(func() { store.OverrideDB(previousDB) })
+
+	s := NewUsageAggregationScheduler(testConfig())
+	result := s.RunProjectionPass()
+	if result == nil || result.ProcessedLogs != 1 {
+		t.Fatalf("projection result = %+v, want processed 1", result)
+	}
+
+	day := logTime.Format("2006-01-02")
+	var totalTokens int64
+	var spend float64
+	if err := db.Get(&totalTokens, `SELECT total_tokens FROM site_day_usage WHERE site_id = ? AND local_day = ?`, siteID, day); err != nil {
+		t.Fatalf("read tokens: %v", err)
+	}
+	if totalTokens != 100 {
+		t.Fatalf("site_day_usage total_tokens = %d, want 100 from prompt+completion", totalTokens)
+	}
+	if err := db.Get(&spend, `SELECT total_summary_spend FROM site_day_usage WHERE site_id = ? AND local_day = ?`, siteID, day); err != nil {
+		t.Fatalf("read spend: %v", err)
+	}
+	// No explicit cost → tokens/500k fallback = 100/500000 = 0.0002
+	if math.Abs(spend-0.0002) > 1e-9 {
+		t.Fatalf("site_day_usage spend = %.8f, want 0.0002", spend)
+	}
+}
+
+func TestUsageAggregationProjection_OrphanLogAdvancesWatermarkWithoutDoubleCount(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate sqlite: %v", err)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	seedProjectionCheckpoint(t, db, 0)
+	suffix := "orphan-" + strings.ReplaceAll(t.Name(), "/", "-")
+	siteID := insertProjectionSite(t, db, suffix, now)
+	accountID := insertProjectionAccount(t, db, siteID, suffix, now)
+
+	// Orphan proxy log (no account / site join) must still move watermark.
+	orphanTime := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	if _, err := db.Exec(`INSERT INTO proxy_logs (model_requested, model_actual, status, total_tokens, estimated_cost, latency_ms, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`, "orphan-model", "orphan-model", "success", 999, 9.99, 10, orphanTime.Format(time.RFC3339)); err != nil {
+		t.Fatalf("insert orphan log: %v", err)
+	}
+	goodTime := orphanTime.Add(time.Minute)
+	insertProjectionProxyLog(t, db, accountID, "success", "gpt-4.1", 50, 0.05, 10, goodTime)
+
+	previousDB := store.GetDB()
+	store.OverrideDB(db)
+	t.Cleanup(func() { store.OverrideDB(previousDB) })
+
+	s := NewUsageAggregationScheduler(testConfig())
+	first := s.RunProjectionPass()
+	if first == nil || first.ProcessedLogs != 2 {
+		t.Fatalf("first pass = %+v, want processed 2", first)
+	}
+	// Re-running must not re-project already watermarked rows.
+	second := s.RunProjectionPass()
+	if second == nil || second.ProcessedLogs != 0 {
+		t.Fatalf("second pass = %+v, want processed 0 (no double count)", second)
+	}
+
+	day := goodTime.Format("2006-01-02")
+	var totalTokens int64
+	var totalCalls int
+	if err := db.Get(&totalTokens, `SELECT total_tokens FROM site_day_usage WHERE site_id = ? AND local_day = ?`, siteID, day); err != nil {
+		t.Fatalf("read tokens: %v", err)
+	}
+	if err := db.Get(&totalCalls, `SELECT total_calls FROM site_day_usage WHERE site_id = ? AND local_day = ?`, siteID, day); err != nil {
+		t.Fatalf("read calls: %v", err)
+	}
+	if totalCalls != 1 || totalTokens != 50 {
+		t.Fatalf("site_day_usage calls/tokens = %d/%d, want 1/50 (orphan excluded, good log once)", totalCalls, totalTokens)
+	}
 }

--- a/service/daily/daily_summary.go
+++ b/service/daily/daily_summary.go
@@ -128,7 +128,12 @@ func CollectDailySummaryMetrics(cfg *config.Config, db *sqlx.DB, now time.Time) 
 			COUNT(*) AS count,
 			COALESCE(SUM(CASE WHEN status = 'success' OR status IS NULL THEN 1 ELSE 0 END), 0) AS success_count,
 			COALESCE(SUM(CASE WHEN status != 'success' AND status IS NOT NULL THEN 1 ELSE 0 END), 0) AS failed_count,
-			COALESCE(SUM(total_tokens), 0) AS total_tokens,
+			COALESCE(SUM(
+					CASE
+						WHEN COALESCE(total_tokens, 0) > 0 THEN COALESCE(total_tokens, 0)
+						ELSE COALESCE(prompt_tokens, 0) + COALESCE(completion_tokens, 0)
+					END
+				), 0) AS total_tokens,
 			COALESCE(SUM(estimated_cost), 0.0) AS total_cost
 		FROM proxy_logs
 		WHERE created_at >= ? AND created_at < ?


### PR DESCRIPTION
## Summary
- Effective token accounting: prefer `total_tokens`, else prompt+completion
- Spend fallbacks for Veloera/other; orphan logs advance watermark without inflating site/model totals
- Dashboard/proxy-log SQL uses effective tokens; docs residual multi-instance limits

## Test plan
- [x] `go test ./scheduler/ -run 'UsageAggregation|EffectiveToken|ResolveSpend'`
- [x] `go test ./handler/admin/ -run 'Stats_'`
- [x] pre-push race suite green

Closes #42