### PR TITLE
fix(routes): preserve in-route model config on rebuild #46

### DIFF
--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -235,11 +236,18 @@ func (h *tokenRoutesHandler) createRoute(w http.ResponseWriter, r *http.Request)
 
 	now := time.Now().UTC().Format(time.RFC3339)
 
+	var modelMapping any
+	if body.ModelMapping != nil {
+		if b, err := json.Marshal(body.ModelMapping); err == nil {
+			modelMapping = string(b)
+		}
+	}
+
 	id, err := execInsertID(h.db,
 		`INSERT INTO token_routes (model_pattern, display_name, display_icon, route_mode, model_mapping, routing_strategy, enabled, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		modelPattern, strOrNull(&displayName), strOrNull(body.DisplayIcon), routeMode,
-		nil, routingStrategy, enabled, now, now,
+		modelMapping, routingStrategy, enabled, now, now,
 	)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "创建路由失败"})
@@ -336,10 +344,14 @@ func (h *tokenRoutesHandler) updateRoute(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Pattern change: recompose automatic channels while preserving manual overrides.
+	// Unrelated field updates (displayName, routingStrategy, modelMapping, enabled)
+	// must not wipe intentional in-route channel configuration.
 	if v, ok := body["modelPattern"]; ok {
-		if _, ok2 := v.(string); ok2 {
+		if s, ok2 := v.(string); ok2 {
+			nextPattern := strings.TrimSpace(s)
+			prevPattern, _ := existing["modelPattern"].(string)
 			mode, _ := existing["routeMode"].(string)
-			if !routing.IsExplicitGroupRoute(mode) {
+			if nextPattern != prevPattern && !routing.IsExplicitGroupRoute(mode) {
 				if _, err := service.RebuildTokenRoutesFromAvailability(r.Context(), h.db); err != nil {
 					slog.Warn("route update: rebuild after modelPattern change failed", "routeId", id, "error", err)
 				}
@@ -552,9 +564,12 @@ func (h *tokenRoutesHandler) addChannel(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Operator-added channels are intentional configuration and must survive
+	// RebuildTokenRoutesFromAvailability (manual_override stays true unless
+	// the channel is explicitly deleted).
 	id, err := execInsertID(h.db,
 		"INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-		routeID, body.AccountID, body.TokenID, body.SourceModel, priority, weight, true, false,
+		routeID, body.AccountID, body.TokenID, body.SourceModel, priority, weight, true, true,
 	)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "创建通道失败"})
@@ -691,6 +706,8 @@ func (h *tokenRoutesHandler) updateChannel(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Any intentional channel edit marks manual_override so rebuild cannot
+	// wipe operator-tuned priority/weight/enabled/sourceModel.
 	if v, ok := body["priority"]; ok {
 		h.db.Exec(h.db.Rebind("UPDATE route_channels SET priority = ?, manual_override = ? WHERE id = ?"), toFloat64(v), true, channelID)
 	}
@@ -699,6 +716,23 @@ func (h *tokenRoutesHandler) updateChannel(w http.ResponseWriter, r *http.Reques
 	}
 	if v, ok := body["enabled"]; ok {
 		h.db.Exec(h.db.Rebind("UPDATE route_channels SET enabled = ?, manual_override = ? WHERE id = ?"), toBool(v), true, channelID)
+	}
+	if v, ok := body["sourceModel"]; ok {
+		var sourceModel any
+		switch s := v.(type) {
+		case nil:
+			sourceModel = nil
+		case string:
+			trimmed := strings.TrimSpace(s)
+			if trimmed == "" {
+				sourceModel = nil
+			} else {
+				sourceModel = trimmed
+			}
+		default:
+			sourceModel = fmt.Sprint(v)
+		}
+		h.db.Exec(h.db.Rebind("UPDATE route_channels SET source_model = ?, manual_override = ? WHERE id = ?"), sourceModel, true, channelID)
 	}
 
 	updated := queryRow(h.db, "SELECT * FROM route_channels WHERE id = ?", channelID)

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -289,3 +289,227 @@ func TestRouteChannelsBatchAllowsSameCredentialForDifferentSourceModels(t *testi
 		t.Fatalf("route channel count = %d, want 2; body=%s", count, resp.Body.String())
 	}
 }
+
+
+
+func isTruthyJSON(v any) bool {
+	switch t := v.(type) {
+	case bool:
+		return t
+	case float64:
+		return t != 0
+	case int:
+		return t != 0
+	case int64:
+		return t != 0
+	default:
+		return false
+	}
+}
+
+// TestTokenRoutes_ManualChannelSurvivesRebuild covers upstream #409 / backlog #46:
+// operator-added in-route models must keep manual_override and survive rebuild.
+func TestTokenRoutes_ManualChannelSurvivesRebuild(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Availability for a different model so rebuild still has auto work to do.
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		t.Fatalf("seed availability: %v", err)
+	}
+
+	// Operator manually attaches a non-discovered model to the route.
+	addResp := doPostJSON(t, r, "/api/routes/"+itoa(routeID)+"/channels", map[string]any{
+		"accountId":   accountID,
+		"tokenId":     tokenID,
+		"sourceModel": "Qwen/Qwen3-Embedding-8B",
+		"priority":    7,
+		"weight":      3,
+	})
+	if addResp.Code != http.StatusOK {
+		t.Fatalf("add manual channel: %d %s", addResp.Code, addResp.Body.String())
+	}
+	var added map[string]any
+	if err := json.Unmarshal(addResp.Body.Bytes(), &added); err != nil {
+		t.Fatalf("decode add response: %v", err)
+	}
+	if !isTruthyJSON(added["manualOverride"]) {
+		t.Fatalf("manualOverride = %v, want true for operator-added channel; body=%s", added["manualOverride"], addResp.Body.String())
+	}
+	channelID := int64(added["id"].(float64))
+
+	// Rebuild must not delete the intentional channel.
+	rebuildResp := doPostJSON(t, r, "/api/routes/rebuild", map[string]any{})
+	if rebuildResp.Code != http.StatusOK {
+		t.Fatalf("rebuild: %d %s", rebuildResp.Code, rebuildResp.Body.String())
+	}
+
+	var manualCount int
+	if err := db.Get(&manualCount,
+		`SELECT COUNT(*) FROM route_channels
+		 WHERE id = ? AND source_model = 'Qwen/Qwen3-Embedding-8B' AND manual_override = 1
+		   AND priority = 7 AND weight = 3`, channelID); err != nil {
+		t.Fatalf("count manual: %v", err)
+	}
+	if manualCount != 1 {
+		t.Fatalf("manual in-route model wiped or reset by rebuild")
+	}
+
+	// Auto channel for gpt-4o should also exist alongside the manual one.
+	var autoCount int
+	if err := db.Get(&autoCount,
+		`SELECT COUNT(*) FROM route_channels WHERE route_id = ? AND source_model = 'gpt-4o'`, routeID); err != nil {
+		t.Fatalf("count auto: %v", err)
+	}
+	if autoCount != 1 {
+		t.Fatalf("auto channel missing after rebuild, count=%d", autoCount)
+	}
+}
+
+// TestTokenRoutes_PartialUpdatePreservesModelMapping covers intentional modelMapping
+// updates and ensures unrelated partial updates do not clear mapping or channels.
+func TestTokenRoutes_PartialUpdatePreservesModelMapping(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+
+	// Seed an intentional mapping + a manual channel.
+	mapping := map[string]any{"gpt-*": "gpt-4o"}
+	createMapping := doPutJSON(t, r, "/api/routes/"+itoa(routeID), map[string]any{
+		"modelMapping": mapping,
+	})
+	if createMapping.Code != http.StatusOK {
+		t.Fatalf("set modelMapping: %d %s", createMapping.Code, createMapping.Body.String())
+	}
+
+	addResp := doPostJSON(t, r, "/api/routes/"+itoa(routeID)+"/channels", map[string]any{
+		"accountId":   accountID,
+		"tokenId":     tokenID,
+		"sourceModel": "manual-model-x",
+		"priority":    5,
+	})
+	if addResp.Code != http.StatusOK {
+		t.Fatalf("add channel: %d %s", addResp.Code, addResp.Body.String())
+	}
+
+	// Unrelated partial update: only displayName.
+	partial := doPutJSON(t, r, "/api/routes/"+itoa(routeID), map[string]any{
+		"displayName": "renamed-route",
+	})
+	if partial.Code != http.StatusOK {
+		t.Fatalf("partial update: %d %s", partial.Code, partial.Body.String())
+	}
+	var updated map[string]any
+	if err := json.Unmarshal(partial.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode partial: %v", err)
+	}
+	if updated["displayName"] != "renamed-route" {
+		t.Fatalf("displayName = %v, want renamed-route", updated["displayName"])
+	}
+
+	// modelMapping must still be present (not clobbered by omit).
+	var rawMapping *string
+	if err := db.Get(&rawMapping, `SELECT model_mapping FROM token_routes WHERE id = ?`, routeID); err != nil {
+		t.Fatalf("load model_mapping: %v", err)
+	}
+	if rawMapping == nil || *rawMapping == "" {
+		t.Fatalf("model_mapping cleared by partial update")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(*rawMapping), &parsed); err != nil {
+		t.Fatalf("parse model_mapping: %v raw=%s", err, *rawMapping)
+	}
+	if parsed["gpt-*"] != "gpt-4o" {
+		t.Fatalf("model_mapping content reset: %v", parsed)
+	}
+
+	// Manual channel still present.
+	var manualCount int
+	if err := db.Get(&manualCount,
+		`SELECT COUNT(*) FROM route_channels WHERE route_id = ? AND source_model = 'manual-model-x' AND manual_override = 1`,
+		routeID); err != nil {
+		t.Fatalf("count manual: %v", err)
+	}
+	if manualCount != 1 {
+		t.Fatalf("manual channel lost after partial route update")
+	}
+
+	// Intentional mapping change.
+	next := doPutJSON(t, r, "/api/routes/"+itoa(routeID), map[string]any{
+		"modelMapping": map[string]any{"gpt-*": "gpt-4o-mini"},
+	})
+	if next.Code != http.StatusOK {
+		t.Fatalf("intentional mapping update: %d %s", next.Code, next.Body.String())
+	}
+	if err := db.Get(&rawMapping, `SELECT model_mapping FROM token_routes WHERE id = ?`, routeID); err != nil {
+		t.Fatalf("reload mapping: %v", err)
+	}
+	if err := json.Unmarshal([]byte(*rawMapping), &parsed); err != nil {
+		t.Fatalf("parse next mapping: %v", err)
+	}
+	if parsed["gpt-*"] != "gpt-4o-mini" {
+		t.Fatalf("intentional mapping update not applied: %v", parsed)
+	}
+}
+
+// TestTokenRoutes_ChannelUpdatePreservesIntentionalConfig ensures channel edits set
+// manual_override and that rebuild keeps the operator-tuned sourceModel/priority.
+func TestTokenRoutes_ChannelUpdatePreservesIntentionalConfig(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Start as an auto-looking channel (simulate insert without override), then edit.
+	res, err := db.Exec(
+		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+		 VALUES (?, ?, ?, 'gpt-4o', 0, 10, 1, 0)`, routeID, accountID, tokenID)
+	if err != nil {
+		t.Fatalf("seed auto channel: %v", err)
+	}
+	channelID, _ := res.LastInsertId()
+
+	// Intentional edit of source model + priority.
+	upd := doPutJSON(t, r, "/api/channels/"+itoa(channelID), map[string]any{
+		"sourceModel": "MiMo-V2-Flash-Free",
+		"priority":    9,
+		"weight":      4,
+	})
+	if upd.Code != http.StatusOK {
+		t.Fatalf("update channel: %d %s", upd.Code, upd.Body.String())
+	}
+	var updated map[string]any
+	if err := json.Unmarshal(upd.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode update: %v", err)
+	}
+	if !isTruthyJSON(updated["manualOverride"]) {
+		t.Fatalf("manualOverride = %v after intentional edit, want true", updated["manualOverride"])
+	}
+	if updated["sourceModel"] != "MiMo-V2-Flash-Free" {
+		t.Fatalf("sourceModel = %v, want MiMo-V2-Flash-Free", updated["sourceModel"])
+	}
+
+	// Availability for gpt-4o (original auto model) - rebuild would prefer this if override ignored.
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		t.Fatalf("seed avail: %v", err)
+	}
+
+	rebuild := doPostJSON(t, r, "/api/routes/rebuild", map[string]any{})
+	if rebuild.Code != http.StatusOK {
+		t.Fatalf("rebuild: %d %s", rebuild.Code, rebuild.Body.String())
+	}
+
+	var kept int
+	if err := db.Get(&kept,
+		`SELECT COUNT(*) FROM route_channels
+		 WHERE id = ? AND source_model = 'MiMo-V2-Flash-Free' AND manual_override = 1
+		   AND priority = 9 AND weight = 4`, channelID); err != nil {
+		t.Fatalf("count kept: %v", err)
+	}
+	if kept != 1 {
+		t.Fatalf("intentional channel config reset by rebuild")
+	}
+}

--- a/service/route_rebuild_test.go
+++ b/service/route_rebuild_test.go
@@ -376,3 +376,51 @@ func TestPopulateRouteChannelsByModelPattern_InsertOnly(t *testing.T) {
 		t.Fatalf("populate must not remove manual channels")
 	}
 }
+
+
+func TestRebuildTokenRoutesFromAvailability_PreservesManualPriorityWeight(t *testing.T) {
+	// #46: rebuild must keep operator-tuned priority/weight on manual channels
+	// even when the source model is no longer in availability.
+	db := setupRouteRebuildDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, accountID, tokenID := seedSiteAccountToken(t, db, "prio")
+
+	res, err := db.Exec(
+		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
+		 VALUES ('gpt-*', 'pattern', 'weighted', 1, ?, ?)`, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	routeID, _ := res.LastInsertId()
+
+	if _, err := db.Exec(
+		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+		 VALUES (?, ?, ?, 'manual-tuned', 11, 22, 1, 1)`, routeID, accountID, tokenID); err != nil {
+		t.Fatalf("manual channel: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		t.Fatalf("avail: %v", err)
+	}
+
+	if _, err := RebuildTokenRoutesFromAvailability(context.Background(), db.DB); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+
+	var priority, weight int64
+	var manual int
+	if err := db.QueryRow(
+		`SELECT priority, weight, manual_override FROM route_channels
+		 WHERE route_id = ? AND source_model = 'manual-tuned'`, routeID,
+	).Scan(&priority, &weight, &manual); err != nil {
+		t.Fatalf("load manual: %v", err)
+	}
+	if manual != 1 {
+		t.Fatalf("manual_override lost")
+	}
+	if priority != 11 || weight != 22 {
+		t.Fatalf("priority/weight reset: got %d/%d want 11/22", priority, weight)
+	}
+}


### PR DESCRIPTION
## Summary
- POST channel add sets `manual_override=true` (aligned with batch add)
- Channel/route updates preserve intentional config; partial updates do not wipe modelMapping
- Rebuild never deletes manual_override channels; tests cover preserve paths

## Test plan
- [x] handler: ManualChannelSurvivesRebuild, PartialUpdatePreservesModelMapping, ChannelUpdatePreservesIntentionalConfig
- [x] service: PreservesManualPriorityWeight (+ existing PreservesManualOverride)
- [x] pre-push race suite green

Closes #46