### PR TITLE
fix(settings): non-destructive model whitelist parse #45

### DIFF
--- a/docs/plan/feature-complete-roadmap.md
+++ b/docs/plan/feature-complete-roadmap.md
@@ -314,11 +314,19 @@ Global lane rules still apply (`docs/plan/lane-charters.md`). Below is the **fea
 
 ```markdown
 ## Acceptance criteria
-- [ ] Repro-or-refute recorded (failing test or closed as cannot-reproduce with evidence)
-- [ ] Concurrent or partial updates do not clobber unrelated settings/route model fields
-- [ ] Global model whitelist empty array is only saved when operator explicitly clears
-- [ ] Regression tests for update payloads that omit optional fields
+- [x] Repro-or-refute recorded (failing test or closed as cannot-reproduce with evidence)
+- [x] Concurrent or partial updates do not clobber unrelated settings/route model fields
+- [x] Global model whitelist empty array is only saved when operator explicitly clears
+- [x] Regression tests for update payloads that omit optional fields
 ```
+
+**#45 / upstream #515 status (2026-07-17):** fixed on save + load path.
+
+- PUT `/api/settings/runtime` rejects `null` / non-array `globalAllowedModels` instead of silently writing `[]`.
+- Explicit `[]` still clears (allow-all semantics).
+- Partial updates that omit the field never touch the whitelist.
+- `ApplyRuntimeSettings` hydrates JSON arrays, double-encoded legacy strings, and CSV; invalid values no longer wipe in-memory config.
+- Residual risk: process-level concurrent PUTs still race on shared `*config.Config` (no settings mutex). Last writer wins per-key via SQL upsert, but multi-field concurrent partial updates can interleave in-memory fields. Mitigate later with a settings write lock if multi-admin concurrency is required. UI still shows empty whitelist as `[]` text when loaded empty (display-only).
 
 ### FE-PROTOCOL — pack template (use per issue #47–#56 except #48)
 

--- a/handler/admin/settings.go
+++ b/handler/admin/settings.go
@@ -112,9 +112,9 @@ func (h *settingsHandler) getRuntime(w http.ResponseWriter, r *http.Request) {
 		"payloadRules":                 cfg.PayloadRules,
 		"proxyErrorKeywords":           cfg.ProxyErrorKeywords,
 		"proxyEmptyContentFailEnabled": cfg.ProxyEmptyContentFailEnabled,
-		// Global filters
-		"globalBlockedBrands": cfg.GlobalBlockedBrands,
-		"globalAllowedModels": cfg.GlobalAllowedModels,
+		// Global filters (always JSON arrays; never null)
+		"globalBlockedBrands": stringSliceOrEmpty(cfg.GlobalBlockedBrands),
+		"globalAllowedModels": stringSliceOrEmpty(cfg.GlobalAllowedModels),
 	})
 }
 
@@ -531,36 +531,32 @@ func (h *settingsHandler) updateRuntime(w http.ResponseWriter, r *http.Request) 
 
 	// Global blocked brands
 	if v, ok := body["globalBlockedBrands"]; ok {
-		var brands []string
-		if arr, ok2 := v.([]any); ok2 {
-			for _, item := range arr {
-				if s, ok3 := item.(string); ok3 {
-					s = strings.TrimSpace(s)
-					if s != "" {
-						brands = append(brands, s)
-					}
-				}
-			}
+		brands, err := parseStringArraySetting(v, "globalBlockedBrands")
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": err.Error()})
+			return
 		}
 		cfg.GlobalBlockedBrands = brands
-		upsertSettingDB(h.db, "global_blocked_brands", brands)
+		if err := upsertSettingDB(h.db, "global_blocked_brands", brands); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "保存品牌屏蔽失败"})
+			return
+		}
 	}
 
 	// Global allowed models
+	// Only an explicit array (including []) may mutate this setting. null /
+	// wrong types used to silently wipe the allowlist (upstream #515).
 	if v, ok := body["globalAllowedModels"]; ok {
-		var models []string
-		if arr, ok2 := v.([]any); ok2 {
-			for _, item := range arr {
-				if s, ok3 := item.(string); ok3 {
-					s = strings.TrimSpace(s)
-					if s != "" {
-						models = append(models, s)
-					}
-				}
-			}
+		models, err := parseStringArraySetting(v, "globalAllowedModels")
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": err.Error()})
+			return
 		}
 		cfg.GlobalAllowedModels = models
-		upsertSettingDB(h.db, "global_allowed_models", models)
+		if err := upsertSettingDB(h.db, "global_allowed_models", models); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "保存模型白名单失败"})
+			return
+		}
 	}
 
 	// Proxy error keywords
@@ -647,9 +643,13 @@ func (h *settingsHandler) updateRuntime(w http.ResponseWriter, r *http.Request) 
 	// Log the event
 	logSettingsEvent(h.db, "status", "运行时设置已更新", "运行时设置已更新", "info", now)
 
+	// Echo current filter lists so partial-update clients can re-sync without
+	// another GET, and so empty arrays serialize as [] rather than null.
 	writeJSON(w, http.StatusOK, map[string]any{
-		"success": true,
-		"message": "运行时设置已更新",
+		"success":             true,
+		"message":             "运行时设置已更新",
+		"globalAllowedModels": stringSliceOrEmpty(cfg.GlobalAllowedModels),
+		"globalBlockedBrands": stringSliceOrEmpty(cfg.GlobalBlockedBrands),
 	})
 }
 
@@ -801,6 +801,11 @@ func applyBoolSettingDB(db *sqlx.DB, body map[string]any, key string, target *bo
 }
 
 func upsertSettingDB(db *sqlx.DB, key string, value any) error {
+	// Normalize nil string slices to empty arrays so we never persist JSON null
+	// for list settings (null historically rehydrated as a wiped allowlist).
+	if value == nil {
+		value = []string{}
+	}
 	jsonValue, err := json.Marshal(value)
 	if err != nil {
 		return fmt.Errorf("settings: marshal %q: %w", key, err)
@@ -811,6 +816,44 @@ func upsertSettingDB(db *sqlx.DB, key string, value any) error {
 		return fmt.Errorf("settings: upsert %q: %w", key, err)
 	}
 	return nil
+}
+
+// parseStringArraySetting validates an explicit JSON array setting.
+// null / non-array values are rejected so accidental clients cannot wipe lists.
+// Empty arrays are allowed and mean "clear / allow all" for the model whitelist.
+func parseStringArraySetting(v any, field string) ([]string, error) {
+	if v == nil {
+		return nil, fmt.Errorf("%s must be an array of strings (use [] to clear)", field)
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array of strings", field)
+	}
+	out := make([]string, 0, len(arr))
+	seen := make(map[string]struct{}, len(arr))
+	for _, item := range arr {
+		s, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s must be an array of strings", field)
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, exists := seen[s]; exists {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+func stringSliceOrEmpty(in []string) []string {
+	if in == nil {
+		return []string{}
+	}
+	return in
 }
 
 func logSettingsEvent(db *sqlx.DB, eventType, title, message, level, createdAt string) {

--- a/handler/admin/settings_runtime_test.go
+++ b/handler/admin/settings_runtime_test.go
@@ -1,7 +1,9 @@
 package admin
 
 import (
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -68,5 +70,146 @@ func TestSettingsRuntimeUpdateCheckinScheduleRejectsFractionalInterval(t *testin
 	})
 	if resp.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+}
+
+func TestSettingsRuntimeGlobalAllowedModelsPersistsAndNormalizes(t *testing.T) {
+	db, r, cfg := setupEdgeTest(t)
+
+	resp := doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+		"globalAllowedModels": []any{"gpt-4o", " claude-3.7-sonnet ", "gpt-4o", "", "gemini-pro"},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update runtime: %d %s", resp.Code, resp.Body.String())
+	}
+
+	want := []string{"gpt-4o", "claude-3.7-sonnet", "gemini-pro"}
+	if len(cfg.GlobalAllowedModels) != len(want) {
+		t.Fatalf("cfg.GlobalAllowedModels = %#v, want %#v", cfg.GlobalAllowedModels, want)
+	}
+	for i := range want {
+		if cfg.GlobalAllowedModels[i] != want[i] {
+			t.Fatalf("cfg.GlobalAllowedModels = %#v, want %#v", cfg.GlobalAllowedModels, want)
+		}
+	}
+
+	var stored string
+	if err := db.Get(&stored, "SELECT value FROM settings WHERE key = ?", "global_allowed_models"); err != nil {
+		t.Fatalf("query stored whitelist: %v", err)
+	}
+	if stored != `["gpt-4o","claude-3.7-sonnet","gemini-pro"]` {
+		t.Fatalf("stored whitelist = %q, want normalized JSON array", stored)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	models, ok := body["globalAllowedModels"].([]any)
+	if !ok {
+		t.Fatalf("response globalAllowedModels type = %T, want []any", body["globalAllowedModels"])
+	}
+	if len(models) != len(want) {
+		t.Fatalf("response globalAllowedModels = %#v, want %#v", models, want)
+	}
+}
+
+func TestSettingsRuntimeGlobalAllowedModelsExplicitEmptyClears(t *testing.T) {
+	db, r, cfg := setupEdgeTest(t)
+
+	if resp := doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+		"globalAllowedModels": []any{"keep-me", "also-keep"},
+	}); resp.Code != http.StatusOK {
+		t.Fatalf("seed whitelist: %d %s", resp.Code, resp.Body.String())
+	}
+
+	resp := doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+		"globalAllowedModels": []any{},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("clear whitelist: %d %s", resp.Code, resp.Body.String())
+	}
+	if len(cfg.GlobalAllowedModels) != 0 {
+		t.Fatalf("cfg.GlobalAllowedModels = %#v, want empty after explicit clear", cfg.GlobalAllowedModels)
+	}
+	var stored string
+	if err := db.Get(&stored, "SELECT value FROM settings WHERE key = ?", "global_allowed_models"); err != nil {
+		t.Fatalf("query stored whitelist: %v", err)
+	}
+	if stored != `[]` {
+		t.Fatalf("stored whitelist = %q, want []", stored)
+	}
+}
+
+func TestSettingsRuntimeGlobalAllowedModelsRejectsNullAndNonArray(t *testing.T) {
+	db, r, cfg := setupEdgeTest(t)
+	cfg.GlobalAllowedModels = []string{"must-survive"}
+	if _, err := db.Exec(`INSERT INTO settings (key, value) VALUES (?, ?)`,
+		"global_allowed_models", `["must-survive"]`); err != nil {
+		t.Fatalf("seed db: %v", err)
+	}
+
+	for _, body := range []map[string]any{
+		{"globalAllowedModels": nil},
+		{"globalAllowedModels": "gpt-4o"},
+		{"globalAllowedModels": map[string]any{"model": "gpt-4o"}},
+		{"globalAllowedModels": []any{"ok", 1}},
+	} {
+		resp := doPutJSON(t, r, "/api/settings/runtime", body)
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("body=%v status=%d, want 400; resp=%s", body, resp.Code, resp.Body.String())
+		}
+	}
+
+	if len(cfg.GlobalAllowedModels) != 1 || cfg.GlobalAllowedModels[0] != "must-survive" {
+		t.Fatalf("cfg.GlobalAllowedModels clobbered to %#v", cfg.GlobalAllowedModels)
+	}
+	var stored string
+	if err := db.Get(&stored, "SELECT value FROM settings WHERE key = ?", "global_allowed_models"); err != nil {
+		t.Fatalf("query stored whitelist: %v", err)
+	}
+	if stored != `["must-survive"]` {
+		t.Fatalf("stored whitelist wiped to %q", stored)
+	}
+}
+
+func TestSettingsRuntimePartialUpdateDoesNotClobberWhitelist(t *testing.T) {
+	db, r, cfg := setupEdgeTest(t)
+	cfg.GlobalAllowedModels = []string{"alpha", "beta"}
+	if _, err := db.Exec(`INSERT INTO settings (key, value) VALUES (?, ?)`,
+		"global_allowed_models", `["alpha","beta"]`); err != nil {
+		t.Fatalf("seed db: %v", err)
+	}
+
+	resp := doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+		"proxyDebugTraceEnabled": true,
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("partial update: %d %s", resp.Code, resp.Body.String())
+	}
+	if len(cfg.GlobalAllowedModels) != 2 || cfg.GlobalAllowedModels[0] != "alpha" || cfg.GlobalAllowedModels[1] != "beta" {
+		t.Fatalf("whitelist clobbered by partial update: %#v", cfg.GlobalAllowedModels)
+	}
+	var stored string
+	if err := db.Get(&stored, "SELECT value FROM settings WHERE key = ?", "global_allowed_models"); err != nil {
+		t.Fatalf("query stored whitelist: %v", err)
+	}
+	if stored != `["alpha","beta"]` {
+		t.Fatalf("stored whitelist changed by partial update: %q", stored)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/settings/runtime", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET runtime: %d %s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode GET: %v", err)
+	}
+	models, ok := got["globalAllowedModels"].([]any)
+	if !ok || len(models) != 2 {
+		t.Fatalf("GET globalAllowedModels = %#v", got["globalAllowedModels"])
 	}
 }

--- a/store/settings.go
+++ b/store/settings.go
@@ -183,9 +183,19 @@ func ApplyRuntimeSettings(cfg *config.Config, settingsMap map[string]string) {
 
 		// Generic JSON settings
 		case "global_blocked_brands":
-			_ = json.Unmarshal([]byte(value), &cfg.GlobalBlockedBrands)
+			if list, ok := parseStringListSetting(value); ok {
+				cfg.GlobalBlockedBrands = list
+			} else {
+				slog.Warn("settings: ignoring invalid global_blocked_brands value")
+			}
 		case "global_allowed_models":
-			_ = json.Unmarshal([]byte(value), &cfg.GlobalAllowedModels)
+			// Non-destructive: invalid / unparseable values must not wipe a
+			// previously configured allowlist (upstream #515 / backlog #45).
+			if list, ok := parseStringListSetting(value); ok {
+				cfg.GlobalAllowedModels = list
+			} else {
+				slog.Warn("settings: ignoring invalid global_allowed_models value")
+			}
 		case "payload_rules":
 			cfg.PayloadRules = config.ParseJsonValue(value)
 		case "openai_service_tier_rules":
@@ -196,6 +206,101 @@ func ApplyRuntimeSettings(cfg *config.Config, settingsMap map[string]string) {
 			// Future: system_proxy_url, routing weights, admin_ip_allowlist, etc.
 		}
 	}
+}
+
+// parseStringListSetting decodes a settings-table value into a trimmed,
+// de-duplicated string list. It accepts:
+//   - JSON arrays: ["a","b"]
+//   - JSON null → empty list
+//   - legacy double-encoded JSON arrays: "[\"a\",\"b\"]"
+//   - comma-separated plain strings: "a, b"
+//
+// ok=false means the value is present but unusable; callers must not overwrite
+// the in-memory setting with an empty default in that case.
+func parseStringListSetting(raw string) ([]string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, false
+	}
+
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		// Non-JSON legacy plain string (comma-separated).
+		return normalizeStringList(raw), true
+	}
+
+	switch v := decoded.(type) {
+	case nil:
+		return []string{}, true
+	case []any:
+		return normalizeStringListAny(v), true
+	case []string:
+		return normalizeStringList(v...), true
+	case string:
+		// Double-encoded JSON array/string, or comma-separated plain string.
+		inner := strings.TrimSpace(v)
+		if inner == "" {
+			return []string{}, true
+		}
+		var nested any
+		if err := json.Unmarshal([]byte(inner), &nested); err == nil {
+			switch nv := nested.(type) {
+			case nil:
+				return []string{}, true
+			case []any:
+				return normalizeStringListAny(nv), true
+			case []string:
+				return normalizeStringList(nv...), true
+			case string:
+				return normalizeStringList(nv), true
+			default:
+				return nil, false
+			}
+		}
+		return normalizeStringList(inner), true
+	default:
+		return nil, false
+	}
+}
+
+func normalizeStringListAny(items []any) []string {
+	out := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok {
+			continue
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, exists := seen[s]; exists {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+func normalizeStringList(parts ...string) []string {
+	out := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		for _, item := range strings.Split(part, ",") {
+			s := strings.TrimSpace(item)
+			if s == "" {
+				continue
+			}
+			if _, exists := seen[s]; exists {
+				continue
+			}
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // parseBoolSetting parses a boolean setting value.

--- a/store/settings_runtime_test.go
+++ b/store/settings_runtime_test.go
@@ -45,3 +45,78 @@ func TestApplyRuntimeSettingsIgnoresInvalidCheckinInterval(t *testing.T) {
 		t.Fatalf("CheckinIntervalHours = %d, want fallback %d", cfg.CheckinIntervalHours, config.DefaultCheckinIntervalHours)
 	}
 }
+
+func TestApplyRuntimeSettingsGlobalAllowedModelsJSONArray(t *testing.T) {
+	cfg := &config.Config{GlobalAllowedModels: []string{"stale"}}
+	ApplyRuntimeSettings(cfg, map[string]string{
+		"global_allowed_models": `["gpt-4o"," claude-3.7-sonnet ","gpt-4o"]`,
+	})
+	want := []string{"gpt-4o", "claude-3.7-sonnet"}
+	if len(cfg.GlobalAllowedModels) != len(want) {
+		t.Fatalf("GlobalAllowedModels = %#v, want %#v", cfg.GlobalAllowedModels, want)
+	}
+	for i := range want {
+		if cfg.GlobalAllowedModels[i] != want[i] {
+			t.Fatalf("GlobalAllowedModels = %#v, want %#v", cfg.GlobalAllowedModels, want)
+		}
+	}
+}
+
+func TestApplyRuntimeSettingsGlobalAllowedModelsDoubleEncodedExact(t *testing.T) {
+	cfg := &config.Config{GlobalAllowedModels: []string{"stale"}}
+	// Value as stored after JSON.stringify(JSON.stringify([...]))
+	ApplyRuntimeSettings(cfg, map[string]string{
+		"global_allowed_models": `"[\"model-alpha\",\" model-beta \",\"model-gamma\"]"`,
+	})
+	want := []string{"model-alpha", "model-beta", "model-gamma"}
+	if len(cfg.GlobalAllowedModels) != len(want) {
+		t.Fatalf("GlobalAllowedModels = %#v, want %#v", cfg.GlobalAllowedModels, want)
+	}
+	for i := range want {
+		if cfg.GlobalAllowedModels[i] != want[i] {
+			t.Fatalf("GlobalAllowedModels = %#v, want %#v", cfg.GlobalAllowedModels, want)
+		}
+	}
+}
+
+func TestApplyRuntimeSettingsGlobalAllowedModelsExplicitEmpty(t *testing.T) {
+	cfg := &config.Config{GlobalAllowedModels: []string{"stale"}}
+	ApplyRuntimeSettings(cfg, map[string]string{
+		"global_allowed_models": `[]`,
+	})
+	if cfg.GlobalAllowedModels == nil || len(cfg.GlobalAllowedModels) != 0 {
+		t.Fatalf("GlobalAllowedModels = %#v, want empty non-nil slice", cfg.GlobalAllowedModels)
+	}
+}
+
+func TestApplyRuntimeSettingsGlobalAllowedModelsInvalidDoesNotWipe(t *testing.T) {
+	cfg := &config.Config{GlobalAllowedModels: []string{"keep-me", "also"}}
+	ApplyRuntimeSettings(cfg, map[string]string{
+		"global_allowed_models": `{"oops":true}`,
+	})
+	if len(cfg.GlobalAllowedModels) != 2 || cfg.GlobalAllowedModels[0] != "keep-me" {
+		t.Fatalf("invalid value wiped allowlist: %#v", cfg.GlobalAllowedModels)
+	}
+}
+
+func TestApplyRuntimeSettingsGlobalAllowedModelsCommaSeparatedLegacy(t *testing.T) {
+	cfg := &config.Config{GlobalAllowedModels: []string{}}
+	ApplyRuntimeSettings(cfg, map[string]string{
+		"global_allowed_models": `gpt-4o, claude-3, gemini-pro`,
+	})
+	want := []string{"gpt-4o", "claude-3", "gemini-pro"}
+	if len(cfg.GlobalAllowedModels) != len(want) {
+		t.Fatalf("GlobalAllowedModels = %#v, want %#v", cfg.GlobalAllowedModels, want)
+	}
+	for i := range want {
+		if cfg.GlobalAllowedModels[i] != want[i] {
+			t.Fatalf("GlobalAllowedModels = %#v, want %#v", cfg.GlobalAllowedModels, want)
+		}
+	}
+}
+
+func TestParseStringListSettingEmptyRawRejected(t *testing.T) {
+	if list, ok := parseStringListSetting(""); ok || list != nil {
+		t.Fatalf("empty raw should be rejected, got %#v ok=%v", list, ok)
+	}
+}


### PR DESCRIPTION
## Summary
- Invalid `global_allowed_models` / `global_blocked_brands` no longer wipe runtime lists
- Accept JSON arrays, double-encoded JSON, and comma-separated lists with trim/dedupe
- Tests for preserve-on-invalid paths

## Test plan
- [x] `go test ./handler/admin/ ./store/`
- [x] pre-push race suite green

Closes #45