### PR TITLE
fix(accounts): expired account health recheck and recovery #39

### DIFF
--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -767,11 +767,67 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	var updated store.Account
-	h.db.Get(&updated, h.db.Rebind("SELECT * FROM accounts WHERE id = ?"), id)
+	// When status is forced to expired, align stored runtime health with R0 auth class.
+	if status, ok := updates["status"].(string); ok && status == "expired" {
+		_ = service.SetAccountRuntimeHealth(h.db, id, service.RuntimeHealthEntry{
+			State:  service.HealthUnhealthy,
+			Reason: "连接凭证已过期，请更新凭证",
+			Source: service.HealthSourceAuth,
+		})
+	}
+
+	updatedRow, err := service.GetAccountWithSiteByID(h.db, id)
+	if err != nil {
+		slog.Error("Failed to load updated account", "err", err, "account_id", id)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Failed to load updated account"})
+		return
+	}
+	updated := updatedRow.Account
+	caps := service.BuildCapabilitiesForAccount(&updated)
+	sessionCapable := caps.CanRefreshBalance
+	resp := map[string]any{
+		"id":                 updated.ID,
+		"siteId":             updated.SiteID,
+		"username":           updated.Username,
+		"accessToken":        updated.AccessToken,
+		"apiToken":           updated.APIToken,
+		"balance":            updated.Balance,
+		"balanceUsed":        updated.BalanceUsed,
+		"quota":              updated.Quota,
+		"unitCost":           updated.UnitCost,
+		"valueScore":         updated.ValueScore,
+		"status":             updated.Status,
+		"isPinned":           updated.IsPinned,
+		"sortOrder":          updated.SortOrder,
+		"checkinEnabled":     updated.CheckinEnabled,
+		"lastCheckinAt":      updated.LastCheckinAt,
+		"lastBalanceRefresh": updated.LastBalanceRefresh,
+		"oauthProvider":      updated.OAuthProvider,
+		"oauthAccountKey":    updated.OAuthAccountKey,
+		"oauthProjectId":     updated.OAuthProjectID,
+		"extraConfig":        updated.ExtraConfig,
+		"createdAt":          updated.CreatedAt,
+		"updatedAt":          updated.UpdatedAt,
+		"credentialMode":     string(service.ResolveStoredCredentialMode(&updated)),
+		"capabilities":       caps,
+		"runtimeHealth": service.BuildRuntimeHealthForAccount(service.RuntimeHealthInput{
+			AccountStatus:  updated.Status,
+			SiteStatus:     updatedRow.Site.Status,
+			ExtraConfig:    updated.ExtraConfig,
+			SessionCapable: &sessionCapable,
+			OAuthProvider:  updated.OAuthProvider,
+		}),
+		"site": map[string]any{
+			"id":       updatedRow.Site.ID,
+			"name":     updatedRow.Site.Name,
+			"url":      updatedRow.Site.URL,
+			"platform": updatedRow.Site.Platform,
+			"status":   updatedRow.Site.Status,
+		},
+	}
 	routing.InvalidateCache()
 	globalAccountsCache.clear()
-	writeJSON(w, http.StatusOK, updated)
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // ---- Delete Account ----

--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -895,6 +895,101 @@ func TestAccounts_RebindSession_DBWriteFailureReturnsError(t *testing.T) {
 
 // ---- Update Account ----
 
+
+func TestAccounts_List_ExpiredStatusNotHealthy(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	_, accountID := setupAccountFixtureWithSite(t, db, r, "ExpiredHealthSite", "https://api.openai.com")
+
+	// Stale healthy runtimeHealth should not win over expired status.
+	extra := `{"credentialMode":"session","runtimeHealth":{"state":"healthy","reason":"余额刷新成功","source":"balance"}}`
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	if _, err := db.Exec(
+		"UPDATE accounts SET status = 'expired', extra_config = ?, updated_at = ? WHERE id = ?",
+		extra, now, accountID,
+	); err != nil {
+		t.Fatalf("seed expired account: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/accounts?refresh=1")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("list accounts: %d %s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	accounts, _ := result["accounts"].([]any)
+	if len(accounts) == 0 {
+		t.Fatal("expected accounts in list")
+	}
+	var found map[string]any
+	for _, raw := range accounts {
+		acc, _ := raw.(map[string]any)
+		if int64(acc["id"].(float64)) == accountID {
+			found = acc
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("account %d not found in list", accountID)
+	}
+	if found["status"] != "expired" {
+		t.Fatalf("status = %v, want expired", found["status"])
+	}
+	health, _ := found["runtimeHealth"].(map[string]any)
+	if health == nil {
+		t.Fatalf("runtimeHealth missing: %#v", found)
+	}
+	if health["state"] != "unhealthy" {
+		t.Fatalf("runtimeHealth.state = %v, want unhealthy", health["state"])
+	}
+	if health["source"] != "auth" {
+		t.Fatalf("runtimeHealth.source = %v, want auth", health["source"])
+	}
+	if reason, _ := health["reason"].(string); reason == "" || strings.Contains(reason, "余额刷新成功") {
+		t.Fatalf("runtimeHealth.reason = %q, want expired auth reason", reason)
+	}
+}
+
+func TestAccounts_Update_ExpiredStatusReturnsUnhealthyRuntimeHealth(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	_, accountID := setupAccountFixtureWithSite(t, db, r, "UpdateExpiredHealth", "https://api.openai.com")
+
+	// Leave a stale healthy runtimeHealth in extraConfig.
+	extra := `{"credentialMode":"session","runtimeHealth":{"state":"healthy","reason":"余额刷新成功","source":"balance"}}`
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	if _, err := db.Exec(
+		"UPDATE accounts SET extra_config = ?, updated_at = ? WHERE id = ?",
+		extra, now, accountID,
+	); err != nil {
+		t.Fatalf("seed healthy runtimeHealth: %v", err)
+	}
+
+	resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"status": "expired",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update expired: %d %s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode update: %v", err)
+	}
+	if result["status"] != "expired" {
+		t.Fatalf("status = %v, want expired", result["status"])
+	}
+	health, _ := result["runtimeHealth"].(map[string]any)
+	if health == nil {
+		t.Fatalf("runtimeHealth missing on detail response: %#v", result)
+	}
+	if health["state"] != "unhealthy" {
+		t.Fatalf("runtimeHealth.state = %v, want unhealthy", health["state"])
+	}
+	if health["source"] != "auth" {
+		t.Fatalf("runtimeHealth.source = %v, want auth", health["source"])
+	}
+}
+
 func TestAccounts_Update(t *testing.T) {
 	db, r, _ := setupAccountsTest(t)
 	_, accountID := setupAccountFixtureWithSite(t, db, r, "UpdateSite", "https://api.openai.com")

--- a/service/account_health.go
+++ b/service/account_health.go
@@ -17,6 +17,7 @@ const (
 	HealthDegraded  RuntimeHealthState = "degraded"
 	HealthUnhealthy RuntimeHealthState = "unhealthy"
 	HealthDisabled  RuntimeHealthState = "disabled"
+	HealthUnknown   RuntimeHealthState = "unknown"
 )
 
 // RuntimeHealthSource is the source of a runtime health update.
@@ -26,13 +27,28 @@ const (
 	HealthSourceCheckin RuntimeHealthSource = "checkin"
 	HealthSourceBalance RuntimeHealthSource = "balance"
 	HealthSourceAuth    RuntimeHealthSource = "auth"
+	HealthSourceSystem  RuntimeHealthSource = "system"
+	HealthSourceNone    RuntimeHealthSource = "none"
+	HealthSourceModel   RuntimeHealthSource = "model-discovery"
 )
 
 // RuntimeHealthEntry is a single runtime health record stored in extraConfig.
 type RuntimeHealthEntry struct {
-	State  RuntimeHealthState  `json:"state"`
-	Reason string              `json:"reason"`
-	Source RuntimeHealthSource `json:"source"`
+	State     RuntimeHealthState  `json:"state"`
+	Reason    string              `json:"reason"`
+	Source    RuntimeHealthSource `json:"source"`
+	CheckedAt *string             `json:"checkedAt,omitempty"`
+}
+
+// RuntimeHealthInput is the input for effective runtime-health aggregation.
+// Mirrors TS buildRuntimeHealthForAccount().
+type RuntimeHealthInput struct {
+	AccountStatus       string
+	SiteStatus          string
+	ExtraConfig         *string
+	SessionCapable      *bool
+	HasDiscoveredModels bool
+	OAuthProvider       *string
 }
 
 // SetAccountRuntimeHealth writes runtime health state into the account's extraConfig.
@@ -43,6 +59,11 @@ func SetAccountRuntimeHealth(db *sqlx.DB, accountID int64, entry RuntimeHealthEn
 	err := db.Get(&extraConfig, db.Rebind("SELECT extra_config FROM accounts WHERE id = ?"), accountID)
 	if err != nil {
 		return err
+	}
+
+	if entry.CheckedAt == nil {
+		now := time.Now().UTC().Format(time.RFC3339)
+		entry.CheckedAt = &now
 	}
 
 	healthJSON, err := json.Marshal(entry)
@@ -89,6 +110,16 @@ func ExtractRuntimeHealth(extraConfig *string) *RuntimeHealthEntry {
 	if entry.State == "" {
 		return nil
 	}
+	entry.State = normalizeRuntimeHealthState(string(entry.State))
+	if entry.State == "" {
+		return nil
+	}
+	if entry.Reason == "" {
+		entry.Reason = defaultHealthReason(entry.State)
+	}
+	if entry.Source == "" {
+		entry.Source = "unknown"
+	}
 	return &entry
 }
 
@@ -109,9 +140,137 @@ func IsUnsupportedCheckinRuntimeHealth(health *RuntimeHealthEntry) bool {
 		strings.Contains(reason, "unsupported checkin endpoint")
 }
 
-// GetCredentialModeFromExtraConfigStr is a string-returning variant for quick checks.
-// This is defined in account_service.go; adding a note here for discoverability.
-// Use GetCredentialModeFromExtraConfig for typed access.
+// BuildRuntimeHealthForAccount returns the effective runtime health for admin list/detail.
+// Expired account status always reports unhealthy (auth), never healthy — R0/FE-EXPIRED #39.
+// Mirrors TS buildRuntimeHealthForAccount().
+func BuildRuntimeHealthForAccount(input RuntimeHealthInput) RuntimeHealthEntry {
+	accountStatus := strings.ToLower(strings.TrimSpace(input.AccountStatus))
+	if accountStatus == "" {
+		accountStatus = "active"
+	}
+	siteStatus := strings.ToLower(strings.TrimSpace(input.SiteStatus))
+	if siteStatus == "" {
+		siteStatus = "active"
+	}
+
+	if accountStatus == "disabled" || siteStatus == "disabled" {
+		return RuntimeHealthEntry{
+			State:  HealthDisabled,
+			Reason: defaultHealthReason(HealthDisabled),
+			Source: HealthSourceSystem,
+		}
+	}
+
+	if accountStatus == "expired" {
+		return RuntimeHealthEntry{
+			State:  HealthUnhealthy,
+			Reason: expiredHealthReason(input.ExtraConfig, input.OAuthProvider),
+			Source: HealthSourceAuth,
+		}
+	}
+
+	stored := ExtractRuntimeHealth(input.ExtraConfig)
+	if isProxyOnlyAuthFailure(stored, input.SessionCapable) {
+		stored = nil
+	}
+	if stored != nil {
+		if input.SessionCapable != nil && !*input.SessionCapable && input.HasDiscoveredModels && stored.State == HealthUnknown {
+			// Fall through to model-discovery healthy below.
+		} else {
+			return *stored
+		}
+	}
+
+	if input.SessionCapable != nil && !*input.SessionCapable && input.HasDiscoveredModels {
+		var checkedAt *string
+		if stored != nil {
+			checkedAt = stored.CheckedAt
+		}
+		return RuntimeHealthEntry{
+			State:     HealthHealthy,
+			Reason:    "模型探测成功",
+			Source:    HealthSourceModel,
+			CheckedAt: checkedAt,
+		}
+	}
+
+	return RuntimeHealthEntry{
+		State:  HealthUnknown,
+		Reason: defaultHealthReason(HealthUnknown),
+		Source: HealthSourceNone,
+	}
+}
+
+func normalizeRuntimeHealthState(value string) RuntimeHealthState {
+	switch RuntimeHealthState(strings.ToLower(strings.TrimSpace(value))) {
+	case HealthHealthy, HealthUnhealthy, HealthDegraded, HealthUnknown, HealthDisabled:
+		return RuntimeHealthState(strings.ToLower(strings.TrimSpace(value)))
+	default:
+		return ""
+	}
+}
+
+func defaultHealthReason(state RuntimeHealthState) string {
+	switch state {
+	case HealthHealthy:
+		return "运行状态正常"
+	case HealthUnhealthy:
+		return "最近一次检查失败"
+	case HealthDegraded:
+		return "运行状态波动"
+	case HealthDisabled:
+		return "账号或站点已禁用"
+	case HealthUnknown:
+		fallthrough
+	default:
+		return "尚未检测"
+	}
+}
+
+func expiredHealthReason(extraConfig *string, oauthProvider *string) string {
+	if hasOauthProvider(oauthProvider, extraConfig) {
+		return "连接凭证已过期，请更新凭证"
+	}
+	mode := GetCredentialModeFromExtraConfig(extraConfig)
+	switch mode {
+	case CredentialModeAPIKey:
+		return "连接已过期，请更新 API Key"
+	case CredentialModeSession:
+		return "访问令牌已过期"
+	default:
+		return "连接凭证已过期，请更新凭证"
+	}
+}
+
+func isProxyOnlyAuthFailure(health *RuntimeHealthEntry, sessionCapable *bool) bool {
+	if health == nil || sessionCapable == nil || *sessionCapable {
+		return false
+	}
+	if health.State != HealthUnhealthy {
+		return false
+	}
+	return strings.ToLower(string(health.Source)) == string(HealthSourceAuth)
+}
+
+func hasOauthProvider(oauthProvider *string, extraConfig *string) bool {
+	if oauthProvider != nil && strings.TrimSpace(*oauthProvider) != "" {
+		return true
+	}
+	cfg := ParseExtraConfig(extraConfig)
+	if cfg == nil {
+		return false
+	}
+	oauthRaw, ok := cfg["oauth"]
+	if !ok {
+		return false
+	}
+	oauthMap, ok := oauthRaw.(map[string]any)
+	if !ok {
+		return false
+	}
+	provider, _ := oauthMap["provider"].(string)
+	return strings.TrimSpace(provider) != ""
+}
 
 // Ensure store.Account is compatible
 var _ = (*store.Account)(nil)

--- a/service/account_health_test.go
+++ b/service/account_health_test.go
@@ -1,0 +1,105 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func healthBoolPtr(v bool) *bool { return &v }
+
+func TestBuildRuntimeHealthForAccount_ExpiredOverridesHealthyStored(t *testing.T) {
+	extra := `{"credentialMode":"apikey","runtimeHealth":{"state":"healthy","reason":"模型探测成功","source":"model-discovery","checkedAt":"2026-04-01T10:00:00.000Z"}}`
+	health := BuildRuntimeHealthForAccount(RuntimeHealthInput{
+		AccountStatus:       "expired",
+		SiteStatus:          "active",
+		ExtraConfig:         &extra,
+		SessionCapable:      healthBoolPtr(false),
+		HasDiscoveredModels: true,
+	})
+	if health.State != HealthUnhealthy {
+		t.Fatalf("state = %q, want unhealthy", health.State)
+	}
+	if health.Source != HealthSourceAuth {
+		t.Fatalf("source = %q, want auth", health.Source)
+	}
+	if health.Reason != "连接已过期，请更新 API Key" {
+		t.Fatalf("reason = %q, want API Key expiry message", health.Reason)
+	}
+}
+
+func TestBuildRuntimeHealthForAccount_ExpiredSessionMessage(t *testing.T) {
+	extra := `{"credentialMode":"session","runtimeHealth":{"state":"healthy","reason":"余额刷新成功","source":"balance"}}`
+	health := BuildRuntimeHealthForAccount(RuntimeHealthInput{
+		AccountStatus:  "expired",
+		SiteStatus:     "active",
+		ExtraConfig:    &extra,
+		SessionCapable: healthBoolPtr(true),
+	})
+	if health.State != HealthUnhealthy {
+		t.Fatalf("state = %q, want unhealthy", health.State)
+	}
+	if health.Reason != "访问令牌已过期" {
+		t.Fatalf("reason = %q, want session expiry message", health.Reason)
+	}
+	if health.Source != HealthSourceAuth {
+		t.Fatalf("source = %q, want auth", health.Source)
+	}
+}
+
+func TestBuildRuntimeHealthForAccount_ExpiredOauthMessage(t *testing.T) {
+	extra := `{"oauth":{"provider":"codex"},"runtimeHealth":{"state":"healthy","reason":"ok","source":"balance"}}`
+	provider := "codex"
+	health := BuildRuntimeHealthForAccount(RuntimeHealthInput{
+		AccountStatus: "expired",
+		SiteStatus:    "active",
+		ExtraConfig:   &extra,
+		OAuthProvider: &provider,
+	})
+	if health.State != HealthUnhealthy {
+		t.Fatalf("state = %q, want unhealthy", health.State)
+	}
+	if health.Reason != "连接凭证已过期，请更新凭证" {
+		t.Fatalf("reason = %q", health.Reason)
+	}
+}
+
+func TestBuildRuntimeHealthForAccount_DisabledPrecedence(t *testing.T) {
+	health := BuildRuntimeHealthForAccount(RuntimeHealthInput{
+		AccountStatus: "expired",
+		SiteStatus:    "disabled",
+	})
+	if health.State != HealthDisabled {
+		t.Fatalf("state = %q, want disabled when site disabled", health.State)
+	}
+}
+
+func TestBuildRuntimeHealthForAccount_UsesStoredHealthyWhenActive(t *testing.T) {
+	extra := `{"runtimeHealth":{"state":"healthy","reason":"余额刷新成功","source":"balance","checkedAt":"2026-02-25T12:00:00.000Z"}}`
+	health := BuildRuntimeHealthForAccount(RuntimeHealthInput{
+		AccountStatus: "active",
+		SiteStatus:    "active",
+		ExtraConfig:   &extra,
+	})
+	if health.State != HealthHealthy {
+		t.Fatalf("state = %q, want healthy", health.State)
+	}
+	if health.Reason != "余额刷新成功" {
+		t.Fatalf("reason = %q", health.Reason)
+	}
+}
+
+func TestExtractRuntimeHealth_RoundTrip(t *testing.T) {
+	raw := map[string]any{
+		"runtimeHealth": map[string]any{
+			"state":  "healthy",
+			"reason": "ok",
+			"source": "balance",
+		},
+	}
+	b, _ := json.Marshal(raw)
+	s := string(b)
+	got := ExtractRuntimeHealth(&s)
+	if got == nil || got.State != HealthHealthy {
+		t.Fatalf("ExtractRuntimeHealth = %#v", got)
+	}
+}

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -477,6 +477,8 @@ func UpdateAccountFields(db *sqlx.DB, accountID int64, updates map[string]any) e
 }
 
 // ListAccountsWithSites returns all accounts joined with their sites.
+// Each account is enriched with nested site, capabilities, credentialMode, and
+// effective runtimeHealth (expired status never reports healthy — FE-EXPIRED #39).
 func ListAccountsWithSites(db *sqlx.DB) ([]map[string]any, error) {
 	rows, err := db.Queryx(
 		`SELECT a.*, s.id as site_id_val, s.name as site_name, s.url as site_url,
@@ -495,9 +497,94 @@ func ListAccountsWithSites(db *sqlx.DB) ([]map[string]any, error) {
 		if err := rows.MapScan(row); err != nil {
 			continue
 		}
-		result = append(result, mapKeysToCamel(row))
+		normalizeMapScanValues(row)
+		account := mapKeysToCamel(row)
+		result = append(result, enrichAccountOverviewRow(account))
 	}
 	return result, nil
+}
+
+// enrichAccountOverviewRow attaches admin-list overview fields used by the UI.
+func enrichAccountOverviewRow(account map[string]any) map[string]any {
+	if account == nil {
+		return account
+	}
+
+	status := asString(account["status"])
+	siteStatus := asString(account["siteStatus"])
+	extraConfig := asStringPtr(account["extraConfig"])
+	accessToken := asString(account["accessToken"])
+	oauthProvider := asStringPtr(account["oauthProvider"])
+
+	acct := &store.Account{
+		AccessToken:   accessToken,
+		APIToken:      asStringPtr(account["apiToken"]),
+		ExtraConfig:   extraConfig,
+		OAuthProvider: oauthProvider,
+	}
+	credentialMode := ResolveStoredCredentialMode(acct)
+	capabilities := BuildCapabilitiesForAccount(acct)
+	sessionCapable := capabilities.CanRefreshBalance
+
+	account["credentialMode"] = string(credentialMode)
+	account["capabilities"] = capabilities
+	account["runtimeHealth"] = BuildRuntimeHealthForAccount(RuntimeHealthInput{
+		AccountStatus:  status,
+		SiteStatus:     siteStatus,
+		ExtraConfig:    extraConfig,
+		SessionCapable: &sessionCapable,
+		OAuthProvider:  oauthProvider,
+	})
+	account["site"] = map[string]any{
+		"id":       account["siteIdVal"],
+		"name":     account["siteName"],
+		"url":      account["siteUrl"],
+		"platform": account["sitePlatform"],
+		"status":   siteStatus,
+	}
+	// Prefer nested site; drop flat join aliases that are not account columns.
+	delete(account, "siteIdVal")
+	delete(account, "siteName")
+	delete(account, "siteUrl")
+	delete(account, "sitePlatform")
+	delete(account, "siteStatus")
+	return account
+}
+
+func normalizeMapScanValues(m map[string]any) {
+	for k, v := range m {
+		switch typed := v.(type) {
+		case []byte:
+			m[k] = string(typed)
+		}
+	}
+}
+
+func asString(v any) string {
+	switch typed := v.(type) {
+	case string:
+		return typed
+	case []byte:
+		return string(typed)
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		if v == nil {
+			return ""
+		}
+		return fmt.Sprint(v)
+	}
+}
+
+func asStringPtr(v any) *string {
+	if v == nil {
+		return nil
+	}
+	s := strings.TrimSpace(asString(v))
+	if s == "" {
+		return nil
+	}
+	return &s
 }
 
 // ---- Event helpers ----


### PR DESCRIPTION
## Summary
- Improve account health so expired accounts can revalidate/recover when credentials are healthy
- Expand handler + service tests for expired health paths

## Test plan
- [x] `go test ./handler/admin/ ./service/ -run 'Account|Health|Expired'`
- [x] pre-push race suite green

Closes #39