### PR TITLE
feat(proxy): add /v1/rerank endpoint

### DIFF
--- a/docs/analysis/rerank-endpoint.md
+++ b/docs/analysis/rerank-endpoint.md
@@ -1,0 +1,59 @@
+# Rerank Endpoint Contract
+
+Last updated: 2026-07-17
+
+## Surface
+
+| Item | Value |
+|------|--------|
+| Method / Path | `POST /v1/rerank` |
+| Handler | `handler/proxy/rerank.go` → `HandleRerank` |
+| Upstream path | `/v1/rerank` (passthrough) |
+| Template | Same thin surface as `POST /v1/embeddings` |
+
+## Auth / logging / errors
+
+Matches other proxy routes:
+
+- Proxy auth middleware (401 without token)
+- `PrepareCtx` + `dispatchUpstream` path
+- JSON error shape: `{"error":{"message":"...","type":"..."}}`
+
+## Request body
+
+OpenAI-compatible / Cohere-style JSON. MetAPI validates **model** only; remaining fields are forwarded raw (with standard model swap if routing rewrites the model name).
+
+```json
+{
+  "model": "rerank-english-v3.0",
+  "query": "What is the capital of France?",
+  "documents": [
+    "Paris is the capital of France.",
+    "Berlin is in Germany."
+  ]
+}
+```
+
+| Field | Required by MetAPI | Notes |
+|-------|--------------------|--------|
+| `model` | yes | Channel selection key; empty → 400 `model is required` |
+| `query` | no (upstream may require) | string |
+| `documents` | no (upstream may require) | array of strings **or** objects |
+| `top_n` / `return_documents` / etc. | no | passed through if present |
+| `stream` | must not be true | `stream: true` → 400 `rerank does not support streaming` |
+
+## Response
+
+Upstream response is returned as-is. No dedicated response transform layer.
+
+When proxy stub is enabled (tests / unconfigured upstream), the generic stub chat-style JSON is returned (same as embeddings).
+
+## Routing
+
+Channel selection uses the requested `model` only (no extra capability flag). Upstream platforms that expose rerank models typically name them with `rerank` in the model id; original MetAPI probed capability via model-name pattern `/(^|[-_/])rerank($|[-_/])/i` rather than a dedicated TS route.
+
+## Non-goals
+
+- No heavy Cohere ↔ OpenAI transform layer
+- No stream / SSE support
+- No dedicated capability matrix beyond model routing

--- a/handler/proxy/rerank.go
+++ b/handler/proxy/rerank.go
@@ -1,0 +1,37 @@
+package proxyhandler
+
+import (
+	"net/http"
+)
+
+// HandleRerank handles POST /v1/rerank.
+//
+// OpenAI-compatible / Cohere-style rerank surface. Request body is passed
+// through to upstream /v1/rerank after standard PrepareCtx model swap.
+// Expected body fields (validated only for model; rest is passthrough):
+//
+//	{
+//	  "model": "rerank-...",
+//	  "query": "...",
+//	  "documents": ["...", ...] // or array of objects
+//	}
+//
+// Streaming is not supported.
+func HandleRerank(w http.ResponseWriter, r *http.Request) {
+	ctx, errResp := PrepareCtx(r, SurfConfig{
+		Endpoint:       "rerank",
+		DownstreamPath: "/v1/rerank",
+		RequireModel:   true,
+	})
+	if errResp != nil {
+		writeJSONError(w, errResp.Status, errResp.Error, errResp.ErrorType)
+		return
+	}
+
+	if ctx.IsStream {
+		writeJSONError(w, 400, "rerank does not support streaming", "invalid_request_error")
+		return
+	}
+
+	dispatchUpstream(w, r, ctx)
+}

--- a/handler/proxy/rerank_test.go
+++ b/handler/proxy/rerank_test.go
@@ -1,0 +1,69 @@
+package proxyhandler
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleRerank_NonStream(t *testing.T) {
+	req := makeProxyReq("POST", "/v1/rerank", `{
+		"model":"rerank-english-v3.0",
+		"query":"What is the capital of France?",
+		"documents":["Paris is the capital of France.","Berlin is in Germany."]
+	}`)
+	rec := httptest.NewRecorder()
+	HandleRerank(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// With upstream forwarding not wired, stub returns a generic response.
+	// Verify valid JSON and model echo.
+	m := unmarshalResponse(t, rec)
+	if m == nil {
+		t.Error("expected non-nil response")
+	}
+	if m["model"] != "rerank-english-v3.0" {
+		t.Errorf("model = %v", m["model"])
+	}
+}
+
+func TestHandleRerank_StreamNotSupported(t *testing.T) {
+	req := makeProxyReq("POST", "/v1/rerank", `{
+		"model":"rerank-english-v3.0",
+		"query":"q",
+		"documents":["a"],
+		"stream":true
+	}`)
+	rec := httptest.NewRecorder()
+	HandleRerank(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("expected 400 for streaming rerank, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleRerank_ModelRequired(t *testing.T) {
+	req := makeProxyReq("POST", "/v1/rerank", `{
+		"query":"q",
+		"documents":["a"]
+	}`)
+	rec := httptest.NewRecorder()
+	HandleRerank(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleRerank_Unauthorized(t *testing.T) {
+	req := httptest.NewRequest("POST", "/v1/rerank", nil)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	HandleRerank(rec, req)
+
+	if rec.Code != 401 {
+		t.Errorf("expected 401, got %d", rec.Code)
+	}
+}

--- a/handler/proxy/router.go
+++ b/handler/proxy/router.go
@@ -37,6 +37,9 @@ func RegisterProxyRoutes(r chi.Router) {
 	// Embeddings surface
 	r.Post("/embeddings", HandleEmbeddings)
 
+	// Rerank surface (OpenAI-compatible / Cohere-style)
+	r.Post("/rerank", HandleRerank)
+
 	// Images surface
 	r.Post("/images/generations", HandleImagesGenerations)
 	r.Post("/images/edits", HandleImagesEdits)

--- a/handler/proxy/router_test.go
+++ b/handler/proxy/router_test.go
@@ -72,6 +72,7 @@ func TestRegisterProxyRoutes_AllPathsExist(t *testing.T) {
 		{"POST", "/responses/compact", `{"model":"gpt-4o","input":"hi"}`},
 		{"GET", "/models", ``},
 		{"POST", "/embeddings", `{"model":"text-embedding","input":"hi"}`},
+		{"POST", "/rerank", `{"model":"rerank-english-v3.0","query":"q","documents":["a"]}`},
 		{"POST", "/images/generations", `{"prompt":"test"}`},
 		{"POST", "/images/edits", `{"image":"test","prompt":"edit"}`},
 		{"POST", "/images/variations", `{"image":"test"}`},
@@ -147,6 +148,20 @@ func TestEmbeddingsRoute_ModelMissing(t *testing.T) {
 	RegisterProxyRoutes(r)
 
 	req := makeProxyReq("POST", "/embeddings", `{"input":"test"}`)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != 400 {
+		t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRerankRoute_ModelMissing(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(injectAuth)
+	RegisterProxyRoutes(r)
+
+	req := makeProxyReq("POST", "/rerank", `{"query":"q","documents":["a"]}`)
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 


### PR DESCRIPTION
## Summary
- Add `POST /v1/rerank` proxy surface (OpenAI-compatible / Cohere-style) as thin passthrough like embeddings
- Register route, reject streaming, require model, dispatch upstream `/v1/rerank`
- Document request contract and add unit/route tests

Closes #48

## Test plan
- [x] `go test ./handler/proxy/ -count=1`
- [x] happy path stub response with model echo
- [x] stream rejected (400)
- [x] missing model (400)
- [x] unauthorized (401)
- [x] route registered in `RegisterProxyRoutes`