### PR TITLE
fix(proxy): persist request usage tokens to proxy_logs #44

### DIFF
--- a/app/proxy_upstream.go
+++ b/app/proxy_upstream.go
@@ -34,6 +34,11 @@ func ConfigureProxyUpstream(cfg *config.Config) error {
 		Router:      router,
 		Coordinator: coord,
 		Executor:    proxy.NewRuntimeExecutor(requestTimeout),
+		// Persist successful/failed proxy attempts (token usage when available).
+		// Writer uses store.GetDB() so it follows runtime DB overrides in tests.
+		LogProxy: func(ctx context.Context, entry proxy.ProxyLogEntry) error {
+			return proxyhandler.InsertProxyLog(ctx, store.GetDB(), entry)
+		},
 	})
 	return nil
 }

--- a/docs/analysis/token-count-coverage.md
+++ b/docs/analysis/token-count-coverage.md
@@ -1,0 +1,36 @@
+# Token count coverage residual notes (FE-TOKEN / #44 / upstream #491)
+
+**Date**: 2026-07-17  
+**Scope**: production proxy path usage extraction + proxy_logs persistence  
+**Related**: `token-stats-accuracy.md` (aggregation correctness), issue #42 (stats reads)
+
+## What this wave fixed
+
+1. **Production non-stream success** (`handler/proxy/upstream.go`)
+   - Parses upstream JSON usage (OpenAI / Anthropic / Gemini / nested Responses).
+   - Passes real `UsageSummary` into `DetectProxyFailure`.
+   - Inserts `proxy_logs` with prompt/completion/total tokens, latency, channel/account/route ids, status `success`.
+
+2. **Production stream success**
+   - Incremental SSE analyzer extracts end-of-stream usage (chat completion chunk usage, Anthropic `message_delta`, Responses `response.completed`).
+   - Persists `proxy_logs` after stream end with best-effort usage (zeros + `usage_source=unknown` when absent).
+
+3. **Wiring**
+   - `UpstreamConfig.LogProxy` injected from `app/proxy_upstream.go` via `InsertProxyLog` → `store.GetDB()`.
+   - Stub path still returns zero usage (demo/tests only; not production when upstream is configured).
+
+## Residual gaps (not in this issue)
+
+| Gap | Notes |
+| --- | --- |
+| `usage_source` / `upstream_path` columns | Present on `proxy.ProxyLogEntry` but **not** in `proxy_logs` DDL yet; values are available in-process only. |
+| Failure-path proxy_logs | HTTP/network failures still record router health but do not always write `proxy_logs` from `dispatchSelectedUpstream` (surface toolkit path has LogProxy on failure; production dispatch is success-focused for #44). |
+| Pricing / `estimated_cost` | Still 0 on write; cache_ratio pricing is #43. |
+| Multipart / non-chat surfaces | Share the same dispatch path, so usage is counted when upstream returns a parseable usage object; media endpoints that omit usage remain zero. |
+| Aggregation lag | Projected stats still depend on the usage aggregation scheduler reading newly inserted rows. |
+
+## Tests
+
+- `handler/proxy/usage_test.go` — OpenAI / Anthropic / Gemini / SSE merge
+- `handler/proxy/upstream_test.go` — non-stream + stream success write non-zero tokens via LogProxy
+- `handler/proxy/sse_parser` incremental analyzer usage extraction

--- a/handler/proxy/proxy_log.go
+++ b/handler/proxy/proxy_log.go
@@ -1,0 +1,147 @@
+package proxyhandler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/proxy"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+// defaultLogProxyWriter inserts a proxy.ProxyLogEntry into proxy_logs.
+// Prefer injecting via UpstreamConfig.LogProxy so tests can capture writes.
+func defaultLogProxyWriter(ctx context.Context, entry proxy.ProxyLogEntry) error {
+	db := store.GetDB()
+	if db == nil {
+		return nil
+	}
+	return InsertProxyLog(ctx, db, entry)
+}
+
+// InsertProxyLog writes one proxy_logs row. Columns match store.ProxyLog / DDL.
+// Fields present only on ProxyLogEntry (usage_source, upstream_path) are not
+// persisted until the schema grows those columns; they remain on the entry for
+// in-process consumers and tests.
+func InsertProxyLog(ctx context.Context, db *store.DB, entry proxy.ProxyLogEntry) error {
+	if db == nil {
+		return nil
+	}
+	createdAt := time.Now().UTC().Format(time.RFC3339)
+	var billingDetails any
+	if entry.BillingDetails != nil {
+		switch v := entry.BillingDetails.(type) {
+		case string:
+			billingDetails = v
+		default:
+			if b, err := json.Marshal(v); err == nil {
+				billingDetails = string(b)
+			}
+		}
+	}
+
+	query := `
+		INSERT INTO proxy_logs (
+			route_id, channel_id, account_id, downstream_api_key_id,
+			model_requested, model_actual, status, http_status, is_stream,
+			first_byte_latency_ms, latency_ms,
+			prompt_tokens, completion_tokens, total_tokens,
+			estimated_cost, billing_details,
+			client_family, client_app_id, client_app_name, client_confidence,
+			error_message, retry_count, created_at
+		) VALUES (
+			?, ?, ?, ?,
+			?, ?, ?, ?, ?,
+			?, ?,
+			?, ?, ?,
+			?, ?,
+			?, ?, ?, ?,
+			?, ?, ?
+		)`
+
+	args := []any{
+		nullInt64(entry.RouteID),
+		nullInt64(entry.ChannelID),
+		nullInt64(entry.AccountID),
+		nullInt64(entry.DownstreamAPIKeyID),
+		nullString(strPtrOrEmpty(entry.ModelRequested)),
+		nullString(entry.ModelActual),
+		nullString(strPtrOrEmpty(entry.Status)),
+		entry.HTTPStatus,
+		nullBool(entry.IsStream),
+		nullInt64(entry.FirstByteLatencyMs),
+		entry.LatencyMs,
+		nullInt64(entry.PromptTokens),
+		nullInt64(entry.CompletionTokens),
+		nullInt64(entry.TotalTokens),
+		entry.EstimatedCost,
+		billingDetails,
+		nullString(strPtrOrEmpty(entry.ClientFamily)),
+		nullString(strPtrOrEmpty(entry.ClientAppID)),
+		nullString(strPtrOrEmpty(entry.ClientAppName)),
+		nullString(strPtrOrEmpty(entry.ClientConfidence)),
+		nullString(entry.ErrorMessage),
+		entry.RetryCount,
+		createdAt,
+	}
+
+	if ctx != nil {
+		if db.Dialect == store.DialectPostgres {
+			query = db.Rebind(query)
+		}
+		_, err := db.DB.ExecContext(ctx, query, args...)
+		return err
+	}
+	_, err := db.Exec(query, args...)
+	return err
+}
+
+func logProxy(ctx context.Context, cfg *UpstreamConfig, entry proxy.ProxyLogEntry) {
+	if cfg == nil {
+		return
+	}
+	writer := cfg.LogProxy
+	if writer == nil {
+		writer = defaultLogProxyWriter
+	}
+	if err := writer(ctx, entry); err != nil {
+		slog.Warn("LogProxy failed",
+			"err", err,
+			"status", entry.Status,
+			"model", entry.ModelRequested,
+		)
+	}
+}
+
+func nullInt64(v *int64) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+func nullBool(v *bool) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+func nullString(v *string) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+func strPtrOrEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func boolPtr(v bool) *bool { return &v }

--- a/handler/proxy/sse_parser.go
+++ b/handler/proxy/sse_parser.go
@@ -33,6 +33,8 @@ type incrementalSseAnalysisResult struct {
 	EventCount            int
 	PendingBytes          int
 	DroppedOversizedEvent bool
+	// Usage is the best-effort final usage extracted from SSE data events.
+	Usage ParsedUsage
 }
 
 type incrementalSseAnalyzer struct {
@@ -40,6 +42,7 @@ type incrementalSseAnalyzer struct {
 	skippingOversized     bool
 	droppedOversizedEvent bool
 	result                incrementalSseAnalysisResult
+	usage                 ParsedUsage
 }
 
 func newIncrementalSseAnalyzer() *incrementalSseAnalyzer {
@@ -83,6 +86,14 @@ func (a *incrementalSseAnalyzer) Result() incrementalSseAnalysisResult {
 	result := a.result
 	result.PendingBytes = len(a.pending)
 	result.DroppedOversizedEvent = a.droppedOversizedEvent
+	result.Usage = a.usage
+	if result.Usage.Source == "" {
+		if result.Usage.Found {
+			result.Usage.Source = usageSourceUpstream
+		} else {
+			result.Usage.Source = usageSourceUnknown
+		}
+	}
 	return result
 }
 
@@ -133,6 +144,14 @@ func (a *incrementalSseAnalyzer) recordEvent(ev SseEvent) {
 	a.result.EventCount++
 	if ev.Data != "" && ev.Data != "[DONE]" {
 		a.result.HasDataEvent = true
+		// Best-effort usage extraction without retaining full stream bodies.
+		// Later events with usage win (stream-end usage / message_delta / response.completed).
+		if looksLikeJSONObject(ev.Data) {
+			got := ParseUsageFromBody([]byte(ev.Data))
+			if got.Found {
+				a.usage = mergeUsagePreferLater(a.usage, got)
+			}
+		}
 	}
 	if IsSseErrorEvent(ev) {
 		a.result.HasErrorEvent = true

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -32,6 +32,9 @@ type UpstreamConfig struct {
 	// When nil, proxy.DefaultSiteConcurrencyLimiter is used.
 	// Orthogonal to Coordinator channel leases (FE-SITE-CONC / upstream #594).
 	SiteLimiter *proxy.SiteConcurrencyLimiter
+	// LogProxy persists successful/failed proxy attempts into proxy_logs.
+	// When nil, defaultLogProxyWriter uses store.GetDB() (no-op if DB unset).
+	LogProxy func(ctx context.Context, entry proxy.ProxyLogEntry) error
 }
 
 var upstreamCfg *UpstreamConfig
@@ -241,11 +244,13 @@ func dispatchSelectedUpstream(
 			return true, nil
 		}
 		// Always close the upstream body, including early client disconnects.
+		var streamUsage ParsedUsage
 		func() {
 			defer resp.Body.Close()
-			handleStreamUpstream(w, r, resp, latencyMs)
+			streamUsage = handleStreamUpstream(w, r, resp, latencyMs)
 		}()
-		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs)
+		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, streamUsage)
+		writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, true, streamUsage, retry)
 	} else {
 		bodyBytes, readErr := proxy.ReadBufferedResponseBody(resp.Body)
 		resp.Body.Close()
@@ -267,7 +272,8 @@ func dispatchSelectedUpstream(
 			relayBufferedUpstreamResponse(w, resp, bodyBytes)
 			return true, nil
 		}
-		failure := proxy.DetectProxyFailure(string(bodyBytes), &proxy.UsageSummary{})
+		usage := ParseUsageFromBody(bodyBytes)
+		failure := proxy.DetectProxyFailure(string(bodyBytes), usage.ToUsageSummary())
 		if failure != nil {
 			slog.Warn("content-based failure detected",
 				"reason", failure.Reason,
@@ -283,7 +289,8 @@ func dispatchSelectedUpstream(
 			writeJSONError(w, failure.Status, "Upstream returned an error response", "upstream_error")
 			return true, nil
 		}
-		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs)
+		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, usage)
+		writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, false, usage, retry)
 		relayBufferedUpstreamResponse(w, resp, bodyBytes)
 	}
 	return true, nil
@@ -368,13 +375,90 @@ func recordUpstreamFailure(ctx context.Context, cfg *UpstreamConfig, selected *r
 	}
 }
 
-func recordUpstreamSuccess(ctx context.Context, cfg *UpstreamConfig, selected *routing.SelectedChannel, modelName string, latencyMs int64) {
+func recordUpstreamSuccess(ctx context.Context, cfg *UpstreamConfig, selected *routing.SelectedChannel, modelName string, latencyMs int64, usage ParsedUsage) {
 	if cfg == nil || cfg.Router == nil || selected == nil {
 		return
 	}
+	// Cost remains 0 here; pricing is a separate concern (#43). Token totals
+	// are persisted via writeSuccessProxyLog for aggregation.
 	if err := cfg.Router.RecordSuccess(ctx, selected.Channel.ID, float64(latencyMs), 0, &modelName, nil); err != nil {
 		slog.Warn("RecordSuccess failed", "err", err, "channel_id", selected.Channel.ID, "model", modelName)
 	}
+	_ = usage
+}
+
+func writeSuccessProxyLog(
+	ctx context.Context,
+	cfg *UpstreamConfig,
+	selected *routing.SelectedChannel,
+	proxyCtx *Ctx,
+	upstreamModel string,
+	upstreamPath string,
+	latencyMs int64,
+	httpStatus int,
+	isStream bool,
+	usage ParsedUsage,
+	retryCount int,
+) {
+	if cfg == nil || selected == nil {
+		return
+	}
+	requestedModel := ""
+	var keyID *int64
+	clientFamily, clientAppID, clientAppName, clientConfidence := "", "", "", ""
+	if proxyCtx != nil {
+		requestedModel = proxyCtx.RequestedModel
+		if proxyCtx.Auth != nil {
+			keyID = proxyCtx.Auth.KeyID
+		}
+		clientFamily = proxyCtx.ClientCtx.ClientKind
+		clientAppID = proxyCtx.ClientCtx.ClientAppID
+		clientAppName = proxyCtx.ClientCtx.ClientAppName
+		clientConfidence = proxyCtx.ClientCtx.ClientConfidence
+	}
+	if requestedModel == "" {
+		requestedModel = upstreamModel
+	}
+	modelActual := upstreamModel
+	routeID := selected.Channel.RouteID
+	var routeIDPtr *int64
+	if routeID != 0 {
+		routeIDPtr = &routeID
+	}
+	channelID := selected.Channel.ID
+	accountID := selected.Account.ID
+	source := usage.Source
+	if source == "" {
+		if usage.Found {
+			source = usageSourceUpstream
+		} else {
+			source = usageSourceUnknown
+		}
+	}
+	entry := proxy.ProxyLogEntry{
+		RouteID:            routeIDPtr,
+		ChannelID:          &channelID,
+		AccountID:          &accountID,
+		DownstreamAPIKeyID: keyID,
+		ModelRequested:     requestedModel,
+		ModelActual:        &modelActual,
+		Status:             "success",
+		HTTPStatus:         httpStatus,
+		IsStream:           boolPtr(isStream),
+		FirstByteLatencyMs: int64Ptr(latencyMs),
+		LatencyMs:          latencyMs,
+		PromptTokens:       int64Ptr(usage.PromptTokens),
+		CompletionTokens:   int64Ptr(usage.CompletionTokens),
+		TotalTokens:        int64Ptr(usage.TotalTokens),
+		ClientFamily:       clientFamily,
+		ClientAppID:        clientAppID,
+		ClientAppName:      clientAppName,
+		ClientConfidence:   clientConfidence,
+		RetryCount:         retryCount,
+		UpstreamPath:       &upstreamPath,
+		UsageSource:        source,
+	}
+	logProxy(ctx, cfg, entry)
 }
 
 func isProxyStubEnabled() bool {
@@ -428,17 +512,21 @@ func writeStubResponse(w http.ResponseWriter, ctx *Ctx) {
 
 // handleStreamUpstream relays an SSE stream from upstream to the downstream client.
 // It performs raw byte passthrough for minimal latency while incrementally
-// analyzing bounded SSE event state for error and empty-content detection.
+// analyzing bounded SSE event state for error/empty-content detection and
+// end-of-stream usage extraction (OpenAI/Anthropic/Gemini/Responses shapes).
 //
 // Disables the server-level WriteTimeout via http.ResponseController so long-running
 // LLM streams (>60s) are not torn down mid-response.
-func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Response, latencyMs int64) {
+//
+// Returns best-effort ParsedUsage from SSE events (may be zero/unknown).
+func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Response, latencyMs int64) ParsedUsage {
+	empty := ParsedUsage{Source: usageSourceUnknown}
 	if resp == nil || resp.Body == nil {
-		return
+		return empty
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		relayUpstreamErrorResponse(w, resp, latencyMs)
-		return
+		return empty
 	}
 
 	writeSSEHeaders(w)
@@ -471,7 +559,7 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 				"latency_ms", latencyMs,
 				"streamed_bytes", streamedBytes,
 			)
-			return
+			return empty
 		default:
 		}
 
@@ -529,9 +617,8 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 
 	// Post-stream SSE analysis uses bounded incremental state instead of
 	// retaining the complete upstream body.
+	result := analyzer.Result()
 	if sawStreamBytes {
-		result := analyzer.Result()
-
 		if result.DroppedOversizedEvent {
 			slog.Warn("SSE stream event exceeded analysis buffer",
 				"latency_ms", latencyMs,
@@ -555,7 +642,11 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 				)
 			}
 		}
+		if result.Usage.Found {
+			return result.Usage
+		}
 	}
+	return empty
 }
 
 func maxStreamResponseBytes() int64 {
@@ -627,7 +718,8 @@ func handleNonStreamUpstream(w http.ResponseWriter, resp *http.Response, latency
 	}
 
 	// Detect proxy failure
-	failure := proxy.DetectProxyFailure(string(bodyBytes), &proxy.UsageSummary{})
+	usage := ParseUsageFromBody(bodyBytes)
+	failure := proxy.DetectProxyFailure(string(bodyBytes), usage.ToUsageSummary())
 	if failure != nil {
 		slog.Warn("content-based failure detected",
 			"reason", failure.Reason,

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -604,3 +604,157 @@ func TestSiteConcurrencySaturateSkipsWithoutFailure(t *testing.T) {
 		t.Fatalf("expected channel 202 success, got %d", router.successes[0].channelID)
 	}
 }
+
+
+func TestNonStreamSuccessPersistsUsageTokensToProxyLog(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_usage","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":12,"completion_tokens":34,"total_tokens":46}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	var logs []proxy.ProxyLogEntry
+	router := &upstreamTestRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, RouteID: 9, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active"},
+		TokenValue:  "upstream-token",
+		ActualModel: "gpt-4o-upstream",
+	}}
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: router,
+		LogProxy: func(_ context.Context, entry proxy.ProxyLogEntry) error {
+			logs = append(logs, entry)
+			return nil
+		},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(logs) != 1 {
+		t.Fatalf("proxy logs = %d, want 1: %#v", len(logs), logs)
+	}
+	entry := logs[0]
+	if entry.Status != "success" {
+		t.Fatalf("status = %q, want success", entry.Status)
+	}
+	if entry.PromptTokens == nil || *entry.PromptTokens != 12 {
+		t.Fatalf("prompt_tokens = %#v, want 12", entry.PromptTokens)
+	}
+	if entry.CompletionTokens == nil || *entry.CompletionTokens != 34 {
+		t.Fatalf("completion_tokens = %#v, want 34", entry.CompletionTokens)
+	}
+	if entry.TotalTokens == nil || *entry.TotalTokens != 46 {
+		t.Fatalf("total_tokens = %#v, want 46", entry.TotalTokens)
+	}
+	if entry.UsageSource != "upstream" {
+		t.Fatalf("usage_source = %q, want upstream", entry.UsageSource)
+	}
+	if entry.ChannelID == nil || *entry.ChannelID != 42 {
+		t.Fatalf("channel_id = %#v, want 42", entry.ChannelID)
+	}
+	if entry.AccountID == nil || *entry.AccountID != 7 {
+		t.Fatalf("account_id = %#v, want 7", entry.AccountID)
+	}
+	if entry.IsStream == nil || *entry.IsStream {
+		t.Fatalf("is_stream = %#v, want false", entry.IsStream)
+	}
+}
+
+func TestStreamSuccessExtractsFinalUsageAndPersistsProxyLog(t *testing.T) {
+	streamBody := strings.Join([]string{
+		`data: {"id":"chunk1","choices":[{"delta":{"content":"He"}}]}`,
+		`data: {"id":"chunk2","choices":[{"delta":{"content":"llo"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":9,"total_tokens":14}}`,
+		`data: [DONE]`,
+		``,
+	}, "\n\n")
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(streamBody))
+	}))
+	t.Cleanup(upstream.Close)
+
+	var logs []proxy.ProxyLogEntry
+	router := &upstreamTestRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, RouteID: 9, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active"},
+		TokenValue:  "upstream-token",
+		ActualModel: "gpt-4o-upstream",
+	}}
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: router,
+		LogProxy: func(_ context.Context, entry proxy.ProxyLogEntry) error {
+			logs = append(logs, entry)
+			return nil
+		},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(logs) != 1 {
+		t.Fatalf("proxy logs = %d, want 1: %#v", len(logs), logs)
+	}
+	entry := logs[0]
+	if entry.Status != "success" {
+		t.Fatalf("status = %q, want success", entry.Status)
+	}
+	if entry.IsStream == nil || !*entry.IsStream {
+		t.Fatalf("is_stream = %#v, want true", entry.IsStream)
+	}
+	if entry.PromptTokens == nil || *entry.PromptTokens != 5 {
+		t.Fatalf("prompt_tokens = %#v, want 5", entry.PromptTokens)
+	}
+	if entry.CompletionTokens == nil || *entry.CompletionTokens != 9 {
+		t.Fatalf("completion_tokens = %#v, want 9", entry.CompletionTokens)
+	}
+	if entry.TotalTokens == nil || *entry.TotalTokens != 14 {
+		t.Fatalf("total_tokens = %#v, want 14", entry.TotalTokens)
+	}
+	if entry.UsageSource != "upstream" {
+		t.Fatalf("usage_source = %q, want upstream", entry.UsageSource)
+	}
+}
+
+func TestDetectProxyFailureReceivesParsedUsageFromBody(t *testing.T) {
+	// When empty-content-fail is enabled and completion tokens are present,
+	// DetectProxyFailure must not treat the response as empty even without text.
+	t.Setenv("PROXY_EMPTY_CONTENT_FAIL", "1")
+	// config.Get() may already be loaded; DetectProxyFailure reads config singleton.
+	// Prefer direct unit path: ParseUsageFromBody -> ToUsageSummary.
+	body := []byte(`{"choices":[{"message":{"content":""}}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`)
+	usage := ParseUsageFromBody(body)
+	if !usage.Found || usage.CompletionTokens != 2 {
+		t.Fatalf("usage = %+v, want completion 2", usage)
+	}
+	sum := usage.ToUsageSummary()
+	if sum.CompletionTokens != 2 {
+		t.Fatalf("summary completion = %d", sum.CompletionTokens)
+	}
+}
+
+func TestIncrementalSseAnalyzerExtractsUsage(t *testing.T) {
+	analyzer := newIncrementalSseAnalyzer()
+	analyzer.Push([]byte(`data: {"choices":[{"delta":{"content":"x"}}]}` + "\n\n"))
+	analyzer.Push([]byte(`data: {"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}}` + "\n\n"))
+	analyzer.Push([]byte("data: [DONE]\n\n"))
+	result := analyzer.Result()
+	if !result.Usage.Found {
+		t.Fatal("expected usage found in analyzer result")
+	}
+	if result.Usage.TotalTokens != 5 {
+		t.Fatalf("total = %d, want 5", result.Usage.TotalTokens)
+	}
+}

--- a/handler/proxy/usage.go
+++ b/handler/proxy/usage.go
@@ -1,0 +1,240 @@
+package proxyhandler
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/tokendancelab/metapi-go/proxy"
+)
+
+const (
+	usageSourceUpstream = "upstream"
+	usageSourceUnknown  = "unknown"
+)
+
+// ParsedUsage is a normalized token usage snapshot extracted from an upstream body/SSE.
+type ParsedUsage struct {
+	PromptTokens     int64
+	CompletionTokens int64
+	TotalTokens      int64
+	// Source is "upstream" when any token field was present, otherwise "unknown".
+	Source string
+	Found  bool
+}
+
+// ToUsageSummary converts ParsedUsage into the lightweight failure-detection summary.
+func (u ParsedUsage) ToUsageSummary() *proxy.UsageSummary {
+	return &proxy.UsageSummary{
+		PromptTokens:     int(u.PromptTokens),
+		CompletionTokens: int(u.CompletionTokens),
+		TotalTokens:      int(u.TotalTokens),
+	}
+}
+
+// ParseUsageFromBody extracts token usage from a non-stream JSON response body.
+// Supports OpenAI (prompt_tokens/completion_tokens/total_tokens), Anthropic
+// (input_tokens/output_tokens), and Gemini (usageMetadata.*TokenCount).
+func ParseUsageFromBody(body []byte) ParsedUsage {
+	body = trimJSONNoise(body)
+	if len(body) == 0 {
+		return ParsedUsage{Source: usageSourceUnknown}
+	}
+	var payload any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return ParsedUsage{Source: usageSourceUnknown}
+	}
+	return extractUsageFromValue(payload)
+}
+
+// ParseUsageFromSSEEvents extracts the best-effort final usage from SSE data events.
+// Later events win when they carry usage so stream-end payloads (message_delta,
+// response.completed, final chat.completion.chunk) override partial early values.
+func ParseUsageFromSSEEvents(events []SseEvent) ParsedUsage {
+	var best ParsedUsage
+	best.Source = usageSourceUnknown
+	for _, ev := range events {
+		if ev.Data == "" || ev.Data == "[DONE]" {
+			continue
+		}
+		if !looksLikeJSONObject(ev.Data) {
+			continue
+		}
+		got := ParseUsageFromBody([]byte(ev.Data))
+		if !got.Found {
+			continue
+		}
+		best = mergeUsagePreferLater(best, got)
+	}
+	return best
+}
+
+func mergeUsagePreferLater(prev, next ParsedUsage) ParsedUsage {
+	if !next.Found {
+		return prev
+	}
+	out := prev
+	out.Found = true
+	out.Source = usageSourceUpstream
+	// Prefer non-zero fields from the later event; retain earlier values when
+	// the later payload is partial (e.g. Anthropic message_delta output only).
+	if next.PromptTokens > 0 {
+		out.PromptTokens = next.PromptTokens
+	} else if !prev.Found {
+		out.PromptTokens = next.PromptTokens
+	}
+	if next.CompletionTokens > 0 {
+		out.CompletionTokens = next.CompletionTokens
+	} else if !prev.Found {
+		out.CompletionTokens = next.CompletionTokens
+	}
+	// Recompute total from merged prompt+completion unless the later event
+	// provides an explicit total that covers both sides (total >= sum).
+	sum := out.PromptTokens + out.CompletionTokens
+	if next.TotalTokens > 0 && next.TotalTokens >= sum {
+		out.TotalTokens = next.TotalTokens
+	} else if sum > 0 {
+		out.TotalTokens = sum
+	} else if next.TotalTokens > 0 {
+		out.TotalTokens = next.TotalTokens
+	} else if !prev.Found {
+		out.TotalTokens = next.TotalTokens
+	}
+	return out
+}
+
+func extractUsageFromValue(v any) ParsedUsage {
+	out := ParsedUsage{Source: usageSourceUnknown}
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return out
+	}
+
+	// Direct usage object (OpenAI / Anthropic / Responses).
+	if usage, ok := obj["usage"].(map[string]any); ok {
+		applyUsageMap(&out, usage)
+	}
+	// Gemini-style usageMetadata.
+	if meta, ok := obj["usageMetadata"].(map[string]any); ok {
+		applyUsageMap(&out, meta)
+	}
+	// Nested response.usage (OpenAI Responses API stream events).
+	if resp, ok := obj["response"].(map[string]any); ok {
+		if usage, ok := resp["usage"].(map[string]any); ok {
+			applyUsageMap(&out, usage)
+		}
+	}
+	// Nested message.usage (Anthropic message_start).
+	if msg, ok := obj["message"].(map[string]any); ok {
+		if usage, ok := msg["usage"].(map[string]any); ok {
+			applyUsageMap(&out, usage)
+		}
+	}
+
+	if out.Found && out.TotalTokens == 0 && (out.PromptTokens > 0 || out.CompletionTokens > 0) {
+		out.TotalTokens = out.PromptTokens + out.CompletionTokens
+	}
+	if out.Found {
+		out.Source = usageSourceUpstream
+	}
+	return out
+}
+
+func applyUsageMap(out *ParsedUsage, usage map[string]any) {
+	if out == nil || usage == nil {
+		return
+	}
+	// OpenAI-style
+	if n, ok := asInt64(usage["prompt_tokens"]); ok {
+		out.PromptTokens = n
+		out.Found = true
+	}
+	if n, ok := asInt64(usage["completion_tokens"]); ok {
+		out.CompletionTokens = n
+		out.Found = true
+	}
+	if n, ok := asInt64(usage["total_tokens"]); ok {
+		out.TotalTokens = n
+		out.Found = true
+	}
+
+	// Anthropic-style
+	if n, ok := asInt64(usage["input_tokens"]); ok {
+		out.PromptTokens = n
+		out.Found = true
+	}
+	if n, ok := asInt64(usage["output_tokens"]); ok {
+		out.CompletionTokens = n
+		out.Found = true
+	}
+	// Optional Anthropic cache fields roll into prompt when present.
+	cacheRead, hasCacheRead := asInt64(usage["cache_read_input_tokens"])
+	cacheCreate, hasCacheCreate := asInt64(usage["cache_creation_input_tokens"])
+	if hasCacheRead || hasCacheCreate {
+		// Prefer explicit input_tokens when set; otherwise sum cache fields.
+		if out.PromptTokens == 0 {
+			out.PromptTokens = cacheRead + cacheCreate
+		}
+		out.Found = true
+	}
+
+	// Gemini-style
+	if n, ok := asInt64(usage["promptTokenCount"]); ok {
+		out.PromptTokens = n
+		out.Found = true
+	}
+	if n, ok := asInt64(usage["candidatesTokenCount"]); ok {
+		out.CompletionTokens = n
+		out.Found = true
+	}
+	if n, ok := asInt64(usage["totalTokenCount"]); ok {
+		out.TotalTokens = n
+		out.Found = true
+	}
+
+	// OpenAI Responses API sometimes uses input_tokens/output_tokens inside usage.
+	// Already covered by Anthropic keys above.
+}
+
+func asInt64(v any) (int64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int64(n), true
+	case float32:
+		return int64(n), true
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	case int32:
+		return int64(n), true
+	case json.Number:
+		i, err := n.Int64()
+		if err != nil {
+			f, err2 := n.Float64()
+			if err2 != nil {
+				return 0, false
+			}
+			return int64(f), true
+		}
+		return i, true
+	case string:
+		s := strings.TrimSpace(n)
+		if s == "" {
+			return 0, false
+		}
+		var parsed int64
+		for _, ch := range s {
+			if ch < '0' || ch > '9' {
+				return 0, false
+			}
+			parsed = parsed*10 + int64(ch-'0')
+		}
+		return parsed, true
+	default:
+		return 0, false
+	}
+}
+
+func trimJSONNoise(body []byte) []byte {
+	return []byte(strings.TrimSpace(string(body)))
+}

--- a/handler/proxy/usage_test.go
+++ b/handler/proxy/usage_test.go
@@ -1,0 +1,132 @@
+package proxyhandler
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseUsageFromBodyOpenAI(t *testing.T) {
+	body := []byte(`{"id":"x","choices":[{"message":{"content":"hi"}}],"usage":{"prompt_tokens":11,"completion_tokens":22,"total_tokens":33}}`)
+	got := ParseUsageFromBody(body)
+	if !got.Found {
+		t.Fatal("expected usage found")
+	}
+	if got.PromptTokens != 11 || got.CompletionTokens != 22 || got.TotalTokens != 33 {
+		t.Fatalf("usage = %+v, want 11/22/33", got)
+	}
+	if got.Source != usageSourceUpstream {
+		t.Fatalf("source = %q, want upstream", got.Source)
+	}
+}
+
+func TestParseUsageFromBodyOpenAIMissingTotal(t *testing.T) {
+	body := []byte(`{"usage":{"prompt_tokens":5,"completion_tokens":7}}`)
+	got := ParseUsageFromBody(body)
+	if !got.Found {
+		t.Fatal("expected usage found")
+	}
+	if got.TotalTokens != 12 {
+		t.Fatalf("total = %d, want 12 (prompt+completion)", got.TotalTokens)
+	}
+}
+
+func TestParseUsageFromBodyAnthropic(t *testing.T) {
+	body := []byte(`{"type":"message","usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":10,"cache_creation_input_tokens":5}}`)
+	got := ParseUsageFromBody(body)
+	if !got.Found {
+		t.Fatal("expected usage found")
+	}
+	if got.PromptTokens != 100 || got.CompletionTokens != 50 {
+		t.Fatalf("usage = %+v, want prompt=100 completion=50", got)
+	}
+	if got.TotalTokens != 150 {
+		t.Fatalf("total = %d, want 150", got.TotalTokens)
+	}
+}
+
+func TestParseUsageFromBodyGemini(t *testing.T) {
+	body := []byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]}}],"usageMetadata":{"promptTokenCount":9,"candidatesTokenCount":4,"totalTokenCount":13}}`)
+	got := ParseUsageFromBody(body)
+	if !got.Found {
+		t.Fatal("expected usage found")
+	}
+	if got.PromptTokens != 9 || got.CompletionTokens != 4 || got.TotalTokens != 13 {
+		t.Fatalf("usage = %+v, want 9/4/13", got)
+	}
+}
+
+func TestParseUsageFromBodyNestedResponseUsage(t *testing.T) {
+	body := []byte(`{"type":"response.completed","response":{"usage":{"input_tokens":3,"output_tokens":8,"total_tokens":11}}}`)
+	got := ParseUsageFromBody(body)
+	if !got.Found {
+		t.Fatal("expected usage found")
+	}
+	if got.PromptTokens != 3 || got.CompletionTokens != 8 || got.TotalTokens != 11 {
+		t.Fatalf("usage = %+v, want 3/8/11", got)
+	}
+}
+
+func TestParseUsageFromBodyEmpty(t *testing.T) {
+	got := ParseUsageFromBody(nil)
+	if got.Found {
+		t.Fatal("expected not found")
+	}
+	if got.Source != usageSourceUnknown {
+		t.Fatalf("source = %q", got.Source)
+	}
+}
+
+func TestParseUsageFromSSEEventsPrefersFinalUsage(t *testing.T) {
+	events := []SseEvent{
+		{Data: `{"choices":[{"delta":{"content":"a"}}]}`},
+		{Data: `{"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`},
+		{Data: `{"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}`},
+		{Data: "[DONE]"},
+	}
+	got := ParseUsageFromSSEEvents(events)
+	if !got.Found {
+		t.Fatal("expected usage found")
+	}
+	if got.PromptTokens != 10 || got.CompletionTokens != 20 || got.TotalTokens != 30 {
+		t.Fatalf("usage = %+v, want final 10/20/30", got)
+	}
+}
+
+func TestParseUsageFromSSEEventsAnthropicMessageDelta(t *testing.T) {
+	events := []SseEvent{
+		{Event: "message_start", Data: `{"type":"message_start","message":{"usage":{"input_tokens":40,"output_tokens":0}}}`},
+		{Event: "content_block_delta", Data: `{"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}`},
+		{Event: "message_delta", Data: `{"type":"message_delta","usage":{"output_tokens":12}}`},
+		{Data: "[DONE]"},
+	}
+	got := ParseUsageFromSSEEvents(events)
+	if !got.Found {
+		t.Fatal("expected usage found")
+	}
+	if got.PromptTokens != 40 {
+		t.Fatalf("prompt = %d, want 40 retained from message_start", got.PromptTokens)
+	}
+	if got.CompletionTokens != 12 {
+		t.Fatalf("completion = %d, want 12 from message_delta", got.CompletionTokens)
+	}
+	if got.TotalTokens != 52 {
+		t.Fatalf("total = %d, want 52", got.TotalTokens)
+	}
+}
+
+func TestToUsageSummary(t *testing.T) {
+	u := ParsedUsage{PromptTokens: 1, CompletionTokens: 2, TotalTokens: 3, Found: true}
+	s := u.ToUsageSummary()
+	if s.PromptTokens != 1 || s.CompletionTokens != 2 || s.TotalTokens != 3 {
+		t.Fatalf("summary = %+v", s)
+	}
+}
+
+func TestParseUsageFromBodyJSONNumberSafety(t *testing.T) {
+	// Ensure non-usage bodies do not panic / falsely report found.
+	body, _ := json.Marshal(map[string]any{"choices": []any{map[string]any{"message": map[string]any{"content": "x"}}}})
+	got := ParseUsageFromBody(body)
+	if got.Found {
+		t.Fatalf("unexpected found usage: %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Parse upstream token usage for OpenAI / Anthropic / Gemini (and nested Responses) on the production proxy path
- Extract end-of-stream SSE usage via the incremental analyzer and persist success `proxy_logs` with non-zero tokens when available
- Wire `UpstreamConfig.LogProxy` from app startup so production no longer relies on stub zero usage

## Test plan
- [x] `go test ./handler/proxy/ ./proxy/ -count=1`
- [x] Unit tests for OpenAI/Anthropic/Gemini usage parsing + SSE merge
- [x] Non-stream success writes non-zero tokens via LogProxy
- [x] Stream final usage extraction + proxy_log write

Closes #44