### PR TITLE
fix(proxy): cross-protocol failover and first-byte timeout units #38

### DIFF
--- a/app/proxy_upstream.go
+++ b/app/proxy_upstream.go
@@ -25,9 +25,19 @@ func ConfigureProxyUpstream(cfg *config.Config) error {
 		return fmt.Errorf("proxy upstream: database is not initialized")
 	}
 	coord := proxy.NewProxyChannelCoordinator(cfg)
-	requestTimeout := time.Duration(cfg.ProxyFirstByteTimeoutSec) * time.Second
-	if requestTimeout <= 0 {
-		requestTimeout = 90 * time.Second
+	// Overall HTTP client timeout is a safety ceiling for full request lifetime.
+	// Observed first-byte timeout is separate: PROXY_FIRST_BYTE_TIMEOUT_SEC
+	// (seconds) is converted to milliseconds via proxy.FirstByteTimeoutMs and
+	// applied per attempt in handler/proxy sendUpstreamRequest.
+	// Keep client timeout at least as large as the first-byte window so the
+	// client does not pre-empt first-byte observation.
+	requestTimeout := 90 * time.Second
+	if firstByteMs := proxy.FirstByteTimeoutMs(cfg.ProxyFirstByteTimeoutSec); firstByteMs > 0 {
+		fb := time.Duration(firstByteMs) * time.Millisecond
+		// Ceiling: max(90s, first-byte*2) so multi-endpoint fallback can still complete.
+		if doubled := fb * 2; doubled > requestTimeout {
+			requestTimeout = doubled
+		}
 	}
 	router := routing.NewTokenRouter(newProxyRoutingStore(db), cfg, nil, proxyLoadProvider{coord: coord})
 	proxyhandler.SetUpstreamConfig(&proxyhandler.UpstreamConfig{

--- a/config/config.go
+++ b/config/config.go
@@ -127,8 +127,12 @@ type Config struct {
 	TrustedProxyCidrs       []string
 
 	// Proxy: Core (2 fields)
-	RequestBodyLimit         int
-	RoutingFallbackUnitCost  float64
+	RequestBodyLimit int
+	RoutingFallbackUnitCost float64
+	// ProxyFirstByteTimeoutSec is the operator-facing first-byte / first-token
+	// timeout in SECONDS (env PROXY_FIRST_BYTE_TIMEOUT_SEC). Internal dispatch
+	// converts to milliseconds via proxy.FirstByteTimeoutMs (sec * 1000).
+	// 0 disables observed first-byte timeout.
 	ProxyFirstByteTimeoutSec int
 
 	// Proxy: Token Router (2 fields)
@@ -463,6 +467,7 @@ func Load(env map[string]string) *Config {
 	// ---- §3.13 Proxy: Core ----
 	cfg.RequestBodyLimit = DefaultRequestBodyLimit
 	cfg.RoutingFallbackUnitCost = math.Max(1e-6, parseNumber(get("ROUTING_FALLBACK_UNIT_COST"), 1))
+	// Seconds; internal first-byte observation uses ms = sec * 1000.
 	cfg.ProxyFirstByteTimeoutSec = maxInt(0, int(math.Trunc(parseNumber(get("PROXY_FIRST_BYTE_TIMEOUT_SEC"), 0))))
 
 	// ---- §3.14 Proxy: Token Router ----

--- a/docs/analysis/failover-first-byte.md
+++ b/docs/analysis/failover-first-byte.md
@@ -1,0 +1,42 @@
+# Failover first-byte timeout units (#38 / upstream #387)
+
+**Date:** 2026-07-17  
+**Lane:** feature / FE-FAILOVER  
+**SSOT code:** `proxy/executor.go`, `proxy/endpoint_flow.go`, `handler/proxy/upstream.go`, `app/proxy_upstream.go`, `config/config.go`
+
+## Units
+
+| Surface | Unit | Notes |
+| --- | --- | --- |
+| Env / operator config `PROXY_FIRST_BYTE_TIMEOUT_SEC` | **seconds** | Parsed into `config.ProxyFirstByteTimeoutSec` |
+| Internal dispatch / observation | **milliseconds** | `proxy.FirstByteTimeoutMs(sec) = sec * 1000` when `sec > 0` |
+| `ExecuteEndpointFlowInput.FirstByteTimeoutMs` | **milliseconds** | Passed into `DispatchRequest(..., firstByteTimeoutMs)` |
+| `RuntimeExecutor.WithObservedFirstByte` / `DoWithObservedFirstByte` | **milliseconds** | Timer-based first-byte (response headers) observation |
+
+Original TS: `firstByteTimeoutMs = proxyFirstByteTimeoutSec * 1000` (`chatSurface.ts`).
+
+`0` disables observed first-byte timeout.
+
+## Production path (live wiring)
+
+Before #38, production `handler/proxy/upstream.go` single-shot `sendUpstreamRequest` and never:
+
+1. converted sec → ms for observed first-byte, or
+2. iterated multi-protocol endpoint candidates.
+
+Now:
+
+1. `PROXY_FIRST_BYTE_TIMEOUT_SEC` → `proxy.FirstByteTimeoutMs` → `sendUpstreamRequest(..., firstByteTimeoutMs)`.
+2. Chat-family paths use `proxy.ResolveEndpointCandidates` ordered list (`chat` / `messages` / `responses`).
+3. First-byte timeout or protocol-mismatch (`ShouldDowngradeToNextEndpoint`) continues to the next candidate when `DISABLE_CROSS_PROTOCOL_FALLBACK` is false.
+4. Intermediate protocol/timeout misses **do not** call `RecordFailure` so healthy siblings / the same channel are not poisoned by a single wrong protocol.
+5. Terminal failure on the last candidate (or when cross-protocol fallback is disabled) records failure and may channel-failover via existing retry loop.
+
+`DisableCrossProtocolFallback` (`DISABLE_CROSS_PROTOCOL_FALLBACK`) limits the candidate list to the primary endpoint only.
+
+## Residual
+
+- Full body transform between protocols (OpenAI chat ↔ Anthropic messages ↔ responses) is **not** part of this fix; path fallback reuses the same JSON body. Protocol transforms remain FE-PROTOCOL / transformer work.
+- Multipart surfaces stay single-path (no multi-protocol rewrite).
+- Site API endpoint pool / multi-base-URL iteration remains separate from this cross-protocol path list.
+- Overall HTTP client timeout in `app.ConfigureProxyUpstream` is a safety ceiling (`max(90s, first-byte*2)`), not the observed first-byte unit.

--- a/docs/plan/feature-complete-roadmap.md
+++ b/docs/plan/feature-complete-roadmap.md
@@ -295,10 +295,12 @@ Global lane rules still apply (`docs/plan/lane-charters.md`). Below is the **fea
 ## Acceptance criteria
 - [ ] Channel failure exclude/cooldown scope is channel-level unless policy says site-level (document)
 - [ ] One channel 5xx does not permanently poison other channels on same site without cooldown rules
-- [ ] Multi-protocol / multi-endpoint candidates attempted per policy; abort rules tested
-- [ ] First-byte / first-token timeout units documented and enforced consistently
+- [x] Multi-protocol / multi-endpoint candidates attempted per policy; abort rules tested (#38)
+- [x] First-byte / first-token timeout units documented and enforced consistently (#38; see docs/analysis/failover-first-byte.md)
 - [ ] Load/integration test with multi-channel fixture
 ```
+
+**#38 residual:** path-level multi-protocol fallback reuses the same request body (no chat↔messages transform); multipart stays single-path.
 
 ### FE-KEYS-CORR — sync + quota clear (#40/#41 · #565/#405)
 

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/tokendancelab/metapi-go/auth"
@@ -153,6 +154,11 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 // finished=true means the response was written (success or terminal error).
 // finished=false means the caller should continue the retry loop (optionally
 // with nextPending as the last soft failure to surface if selection ends).
+//
+// Chat-family surfaces iterate multi-protocol endpoint candidates with observed
+// first-byte timeout (issue #38 / upstream #387). Failures that fall through to
+// the next protocol candidate do not record channel failure so healthy siblings
+// are not poisoned by a single protocol miss.
 func dispatchSelectedUpstream(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -163,43 +169,162 @@ func dispatchSelectedUpstream(
 	retry int,
 	maxRetries int,
 ) (finished bool, nextPending *pendingUpstreamFailure) {
-	// Step 7: Build upstream request
+	// Step 7: Build upstream request materials
 	upstreamModel := selected.ActualModel
 	if upstreamModel == "" {
 		upstreamModel = ctx.RequestedModel
 	}
-	upstreamURL := proxy.BuildUpstreamURL(selected.Site.URL, upstreamPath)
+	runtimeCfg := config.Get()
 	// Proxy selection: key proxy > account > site > system > direct
 	// (FE-KEY-PROXY / upstream #578; see proxy.KeyProxyPrecedence).
-	proxyConfig := service.BuildPlatformProxyConfig(config.Get(), &selected.Account, &selected.Site)
+	proxyConfig := service.BuildPlatformProxyConfig(runtimeCfg, &selected.Account, &selected.Site)
 	if ctx != nil && ctx.Auth != nil {
 		proxyConfig = proxy.ApplyKeyProxyOverride(proxyConfig, ctx.Auth.ProxyURL)
 	}
+	firstByteTimeoutMs := int64(0)
+	disableCrossProtocolFallback := false
+	if runtimeCfg != nil {
+		firstByteTimeoutMs = proxy.FirstByteTimeoutMs(runtimeCfg.ProxyFirstByteTimeoutSec)
+		disableCrossProtocolFallback = runtimeCfg.DisableCrossProtocolFallback
+	}
 
-	// Step 8: Send upstream request
-	startedAt := time.Now()
 	contentType := "application/json"
-	var bodyReader io.Reader
+	var bodyBytes []byte
 	var err error
 	if ctx.Multipart {
+		// Multipart bodies are not multi-protocol rewritten; single-shot only.
+		var bodyReader io.Reader
 		bodyReader, contentType, err = CloneMultipartBody(r, map[string]string{"model": upstreamModel})
 		if err != nil {
-			slog.Warn("multipart upstream body construction failed", "err", err, "url", upstreamURL, "model", upstreamModel)
+			slog.Warn("multipart upstream body construction failed", "err", err, "path", upstreamPath, "model", upstreamModel)
 			writeJSONError(w, 400, "Invalid multipart request body", "invalid_request_error")
 			return true, nil
 		}
-	} else {
-		forwardBytes := swapModelInJSON(ctx.RawBody, upstreamModel)
-		bodyReader = bytesReader(forwardBytes)
+		if bodyReader != nil {
+			bodyBytes, err = io.ReadAll(bodyReader)
+			if err != nil {
+				slog.Warn("multipart upstream body read failed", "err", err, "path", upstreamPath)
+				writeJSONError(w, 400, "Invalid multipart request body", "invalid_request_error")
+				return true, nil
+			}
+		}
+		return dispatchEndpointAttempt(w, r, ctx, cfg, selected, upstreamModel, proxyConfig, upstreamPath, contentType, bodyBytes, firstByteTimeoutMs, retry, maxRetries, true)
 	}
-	req, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, bodyReader)
+	bodyBytes = swapModelInJSON(ctx.RawBody, upstreamModel)
+
+	candidatePaths := resolveUpstreamCandidatePaths(upstreamPath, disableCrossProtocolFallback)
+	var lastPending *pendingUpstreamFailure
+	for i, path := range candidatePaths {
+		isLast := i >= len(candidatePaths)-1
+		finished, pending, cont := dispatchEndpointAttemptWithContinue(
+			w, r, ctx, cfg, selected, upstreamModel, proxyConfig,
+			path, contentType, bodyBytes, firstByteTimeoutMs,
+			retry, maxRetries, isLast, disableCrossProtocolFallback,
+		)
+		if finished {
+			return true, nil
+		}
+		if pending != nil {
+			lastPending = pending
+		}
+		if cont {
+			// Soft protocol/timeout miss: try next candidate without channel poison.
+			continue
+		}
+		// Channel-level retry or terminal pending for outer loop.
+		return false, lastPending
+	}
+	if lastPending != nil {
+		return false, lastPending
+	}
+	if retry < maxRetries {
+		return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error")
+	}
+	writeJSONError(w, 502, "Upstream request failed", "upstream_error")
+	return true, nil
+}
+
+// resolveUpstreamCandidatePaths returns ordered upstream paths for one channel attempt.
+// Non chat-family paths yield the original path only.
+func resolveUpstreamCandidatePaths(upstreamPath string, disableCrossProtocolFallback bool) []string {
+	candidates := proxy.ResolveEndpointCandidates(upstreamPath, disableCrossProtocolFallback)
+	if len(candidates) == 0 {
+		return []string{upstreamPath}
+	}
+	paths := make([]string, 0, len(candidates))
+	for _, ep := range candidates {
+		if p := proxy.PathForEndpoint(ep); p != "" {
+			paths = append(paths, p)
+		}
+	}
+	if len(paths) == 0 {
+		return []string{upstreamPath}
+	}
+	return paths
+}
+
+// dispatchEndpointAttempt is the single-path entry used by multipart.
+func dispatchEndpointAttempt(
+	w http.ResponseWriter,
+	r *http.Request,
+	ctx *Ctx,
+	cfg *UpstreamConfig,
+	selected *routing.SelectedChannel,
+	upstreamModel string,
+	proxyConfig *platform.ProxyConfig,
+	upstreamPath string,
+	contentType string,
+	bodyBytes []byte,
+	firstByteTimeoutMs int64,
+	retry int,
+	maxRetries int,
+	recordFailure bool,
+) (finished bool, nextPending *pendingUpstreamFailure) {
+	finished, pending, _ := dispatchEndpointAttemptWithContinue(
+		w, r, ctx, cfg, selected, upstreamModel, proxyConfig,
+		upstreamPath, contentType, bodyBytes, firstByteTimeoutMs,
+		retry, maxRetries, true, true,
+	)
+	if !recordFailure {
+		return finished, pending
+	}
+	return finished, pending
+}
+
+// dispatchEndpointAttemptWithContinue runs one endpoint path.
+// cont=true means the caller should try the next protocol candidate without
+// recording channel failure / without writing a terminal response.
+func dispatchEndpointAttemptWithContinue(
+	w http.ResponseWriter,
+	r *http.Request,
+	ctx *Ctx,
+	cfg *UpstreamConfig,
+	selected *routing.SelectedChannel,
+	upstreamModel string,
+	proxyConfig *platform.ProxyConfig,
+	upstreamPath string,
+	contentType string,
+	bodyBytes []byte,
+	firstByteTimeoutMs int64,
+	retry int,
+	maxRetries int,
+	isLastEndpoint bool,
+	disableCrossProtocolFallback bool,
+) (finished bool, nextPending *pendingUpstreamFailure, cont bool) {
+	upstreamURL := proxy.BuildUpstreamURL(selected.Site.URL, upstreamPath)
+	startedAt := time.Now()
+
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, bytesReader(bodyBytes))
 	if err != nil {
 		slog.Warn("upstream request construction failed", "err", err, "url", upstreamURL, "model", upstreamModel)
+		if !isLastEndpoint && !disableCrossProtocolFallback {
+			return false, nil, true
+		}
 		if retry < maxRetries {
-			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error")
+			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error"), false
 		}
 		writeJSONError(w, 502, "Upstream request failed", "upstream_error")
-		return true, nil
+		return true, nil, false
 	}
 	req.Header.Set("Content-Type", contentType)
 	if selected.TokenValue != "" {
@@ -207,41 +332,70 @@ func dispatchSelectedUpstream(
 	}
 	applyProxyCustomHeaders(req, proxyConfig)
 
-	var resp *http.Response
-	resp, err = sendUpstreamRequest(cfg, req, proxyConfig)
+	resp, err := sendUpstreamRequest(cfg, req, proxyConfig, firstByteTimeoutMs)
 	latencyMs := time.Since(startedAt).Milliseconds()
 
 	if err != nil {
+		// First-byte timeout: continue to next protocol when allowed; do not poison.
+		if proxy.IsObservedFirstByteTimeoutError(err) {
+			slog.Info("upstream first-byte timeout",
+				"url", upstreamURL,
+				"model", upstreamModel,
+				"channel_id", selected.Channel.ID,
+				"first_byte_timeout_ms", firstByteTimeoutMs,
+				"is_last_endpoint", isLastEndpoint,
+			)
+			if !isLastEndpoint && !disableCrossProtocolFallback {
+				return false, nil, true
+			}
+			// Terminal for this channel attempt.
+			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, 0, err.Error())
+			if retry < maxRetries && proxy.ShouldRetryProxyRequest(408, err.Error()) {
+				return false, jsonPendingUpstreamFailure(http.StatusRequestTimeout, "Upstream first-byte timeout", "upstream_error"), false
+			}
+			writeJSONError(w, http.StatusRequestTimeout, "Upstream first-byte timeout", "upstream_error")
+			return true, nil, false
+		}
 		slog.Warn("upstream request failed", "err", err, "url", upstreamURL, "model", upstreamModel, "channel_id", selected.Channel.ID)
+		if !isLastEndpoint && !disableCrossProtocolFallback {
+			// Network error may still be protocol-local; allow next endpoint without poison.
+			return false, nil, true
+		}
 		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, 0, err.Error())
 		if retry < maxRetries {
-			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error")
+			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error"), false
 		}
 		writeJSONError(w, 502, "Upstream request failed", "upstream_error")
-		return true, nil
+		return true, nil, false
 	}
 
 	// Step 9: Handle response
 	if ctx.IsStream {
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			bodyBytes, readErr := proxy.ReadBufferedResponseBody(resp.Body)
+			respBody, readErr := proxy.ReadBufferedResponseBody(resp.Body)
 			resp.Body.Close()
 			if readErr != nil {
 				slog.Warn("failed to read upstream stream error response", "err", readErr, "latency_ms", latencyMs, "status", resp.StatusCode)
+				if !isLastEndpoint && !disableCrossProtocolFallback {
+					return false, nil, true
+				}
 				recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, readErr.Error())
 				if retry < maxRetries {
-					return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error")
+					return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error"), false
 				}
 				writeJSONError(w, 502, "Failed to read upstream response", "upstream_error")
-				return true, nil
+				return true, nil, false
 			}
-			rawErrText := string(bodyBytes)
+			rawErrText := string(respBody)
+			if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback) {
+				return false, nil, true
+			}
 			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
 			if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
-				return false, bufferedPendingUpstreamFailure(resp, bodyBytes)
+				return false, bufferedPendingUpstreamFailure(resp, respBody), false
 			}
-			relayBufferedUpstreamErrorResponse(w, resp, bodyBytes)
-			return true, nil
+			relayBufferedUpstreamErrorResponse(w, resp, respBody)
+			return true, nil, false
 		}
 		// Always close the upstream body, including early client disconnects.
 		var streamUsage ParsedUsage
@@ -249,31 +403,39 @@ func dispatchSelectedUpstream(
 			defer resp.Body.Close()
 			streamUsage = handleStreamUpstream(w, r, resp, latencyMs)
 		}()
-		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, streamUsage)
-		writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, true, streamUsage, retry)
-	} else {
-		bodyBytes, readErr := proxy.ReadBufferedResponseBody(resp.Body)
+			recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, streamUsage)
+			writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, true, streamUsage, retry)
+			return true, nil, false
+		}
+
+		respBody, readErr := proxy.ReadBufferedResponseBody(resp.Body)
 		resp.Body.Close()
 		if readErr != nil {
 			slog.Warn("failed to read upstream response", "err", readErr, "latency_ms", latencyMs, "channel_id", selected.Channel.ID)
+			if !isLastEndpoint && !disableCrossProtocolFallback {
+				return false, nil, true
+			}
 			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, readErr.Error())
 			if retry < maxRetries {
-				return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error")
+				return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error"), false
 			}
 			writeJSONError(w, 502, "Failed to read upstream response", "upstream_error")
-			return true, nil
+			return true, nil, false
 		}
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			rawErrText := string(bodyBytes)
+			rawErrText := string(respBody)
+			if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback) {
+				return false, nil, true
+			}
 			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
 			if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
-				return false, bufferedPendingUpstreamFailure(resp, bodyBytes)
+				return false, bufferedPendingUpstreamFailure(resp, respBody), false
 			}
-			relayBufferedUpstreamResponse(w, resp, bodyBytes)
-			return true, nil
+			relayBufferedUpstreamResponse(w, resp, respBody)
+			return true, nil, false
 		}
-		usage := ParseUsageFromBody(bodyBytes)
-		failure := proxy.DetectProxyFailure(string(bodyBytes), usage.ToUsageSummary())
+		usage := ParseUsageFromBody(respBody)
+		failure := proxy.DetectProxyFailure(string(respBody), usage.ToUsageSummary())
 		if failure != nil {
 			slog.Warn("content-based failure detected",
 				"reason", failure.Reason,
@@ -282,18 +444,37 @@ func dispatchSelectedUpstream(
 				"channel_id", selected.Channel.ID,
 				"latency_ms", latencyMs,
 			)
+			if shouldContinueEndpointFallback(failure.Status, failure.Reason, isLastEndpoint, disableCrossProtocolFallback) {
+				return false, nil, true
+			}
 			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, failure.Status, failure.Reason)
 			if retry < maxRetries && proxy.ShouldRetryProxyRequest(failure.Status, failure.Reason) {
-				return false, jsonPendingUpstreamFailure(failure.Status, "Upstream returned an error response", "upstream_error")
+				return false, jsonPendingUpstreamFailure(failure.Status, "Upstream returned an error response", "upstream_error"), false
 			}
 			writeJSONError(w, failure.Status, "Upstream returned an error response", "upstream_error")
-			return true, nil
+			return true, nil, false
 		}
 		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, usage)
 		writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, false, usage, retry)
-		relayBufferedUpstreamResponse(w, resp, bodyBytes)
+		relayBufferedUpstreamResponse(w, resp, respBody)
+		return true, nil, false
 	}
-	return true, nil
+
+func shouldContinueEndpointFallback(status int, rawErrText string, isLastEndpoint bool, disableCrossProtocolFallback bool) bool {
+	if isLastEndpoint || disableCrossProtocolFallback {
+		return false
+	}
+	if proxy.ShouldAbortSameSiteEndpointFallback(status, rawErrText) {
+		return false
+	}
+	if proxy.ShouldDowngradeToNextEndpoint(status, rawErrText) {
+		return true
+	}
+	// First-byte style status=0 should already be handled by error path; treat as continue.
+	if status == 0 {
+		return true
+	}
+	return false
 }
 
 type pendingUpstreamFailure struct {
@@ -349,14 +530,67 @@ func applyProxyCustomHeaders(req *http.Request, proxyConfig *platform.ProxyConfi
 	}
 }
 
-func sendUpstreamRequest(cfg *UpstreamConfig, req *http.Request, proxyConfig *platform.ProxyConfig) (*http.Response, error) {
+// sendUpstreamRequest dispatches an upstream HTTP request with optional observed
+// first-byte timeout. firstByteTimeoutMs is milliseconds (0 disables observation).
+// Config PROXY_FIRST_BYTE_TIMEOUT_SEC is seconds; convert via proxy.FirstByteTimeoutMs.
+func sendUpstreamRequest(cfg *UpstreamConfig, req *http.Request, proxyConfig *platform.ProxyConfig, firstByteTimeoutMs int64) (*http.Response, error) {
+	// Executor path: DoWithObservedFirstByte owns the first-byte deadline and
+	// does not cancel the body after headers arrive.
+	if (proxyConfig == nil || (proxyConfig.ProxyURL == "" && !proxyConfig.InsecureSkipTLS)) && cfg != nil && cfg.Executor != nil {
+		return cfg.Executor.DoWithObservedFirstByte(req.Context(), req, firstByteTimeoutMs)
+	}
+
+	if firstByteTimeoutMs <= 0 {
+		if proxyConfig != nil && (proxyConfig.ProxyURL != "" || proxyConfig.InsecureSkipTLS) {
+			return platform.DoWithProxy(req.Context(), req, proxyConfig)
+		}
+		return defaultUpstreamClient.Do(req)
+	}
+
+	// Proxy / fallback client: mirror DoWithObservedFirstByte timer semantics.
+	parent := req.Context()
+	reqCtx, cancelReq := context.WithCancel(parent)
+	req = req.WithContext(reqCtx)
+	var timedOut atomic.Bool
+	timer := time.AfterFunc(time.Duration(firstByteTimeoutMs)*time.Millisecond, func() {
+		timedOut.Store(true)
+		cancelReq()
+	})
+
+	var (
+		resp *http.Response
+		err  error
+	)
 	if proxyConfig != nil && (proxyConfig.ProxyURL != "" || proxyConfig.InsecureSkipTLS) {
-		return platform.DoWithProxy(req.Context(), req, proxyConfig)
+		resp, err = platform.DoWithProxy(reqCtx, req, proxyConfig)
+	} else {
+		resp, err = defaultUpstreamClient.Do(req)
 	}
-	if cfg.Executor != nil {
-		return cfg.Executor.Do(req)
+	if err != nil {
+		_ = timer.Stop()
+		cancelReq()
+		if timedOut.Load() && parent.Err() == nil {
+			return nil, proxy.ErrObservedFirstByteTimeout
+		}
+		return nil, err
 	}
-	return defaultUpstreamClient.Do(req)
+	_ = timer.Stop()
+	resp.Body = &cancelOnCloseBody{ReadCloser: resp.Body, cancel: cancelReq}
+	return resp, nil
+}
+
+// cancelOnCloseBody cancels the request context when the response body is closed.
+type cancelOnCloseBody struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (b *cancelOnCloseBody) Close() error {
+	err := b.ReadCloser.Close()
+	if b.cancel != nil {
+		b.cancel()
+	}
+	return err
 }
 
 func recordUpstreamFailure(ctx context.Context, cfg *UpstreamConfig, selected *routing.SelectedChannel, modelName string, status int, rawErrText string) {

--- a/handler/proxy/upstream_failover_test.go
+++ b/handler/proxy/upstream_failover_test.go
@@ -1,0 +1,204 @@
+package proxyhandler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/proxy"
+	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func TestResolveUpstreamCandidatePaths(t *testing.T) {
+	paths := resolveUpstreamCandidatePaths("/v1/chat/completions", false)
+	if len(paths) < 2 {
+		t.Fatalf("expected multi-protocol candidates, got %v", paths)
+	}
+	if paths[0] != "/v1/chat/completions" {
+		t.Fatalf("primary path = %q", paths[0])
+	}
+	disabled := resolveUpstreamCandidatePaths("/v1/chat/completions", true)
+	if len(disabled) != 1 || disabled[0] != "/v1/chat/completions" {
+		t.Fatalf("disabled fallback paths = %v", disabled)
+	}
+	nonChat := resolveUpstreamCandidatePaths("/v1/embeddings", false)
+	if len(nonChat) != 1 || nonChat[0] != "/v1/embeddings" {
+		t.Fatalf("non-chat paths = %v", nonChat)
+	}
+}
+
+func TestDispatchCrossProtocolFallbackOnProtocolHintWithoutPoison(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		paths []string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/chat/completions" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"please use /v1/messages"}}`))
+			return
+		}
+		if r.URL.Path == "/v1/messages" {
+			_, _ = w.Write([]byte(`{"id":"msg_ok","content":[{"type":"text","text":"ok"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"nope"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	prev := config.Get()
+	cfgCopy := *prev
+	cfgCopy.DisableCrossProtocolFallback = false
+	cfgCopy.ProxyFirstByteTimeoutSec = 0
+	config.Set(&cfgCopy)
+	t.Cleanup(func() { config.Set(prev) })
+
+	router := &upstreamTestRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active"},
+		TokenValue:  "upstream-token",
+		ActualModel: "claude-3",
+	}}
+	SetUpstreamConfig(&UpstreamConfig{Router: router})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"claude-3","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s paths=%v", rec.Code, rec.Body.String(), paths)
+	}
+	mu.Lock()
+	gotPaths := append([]string(nil), paths...)
+	mu.Unlock()
+	if len(gotPaths) < 2 || gotPaths[0] != "/v1/chat/completions" || gotPaths[1] != "/v1/messages" {
+		t.Fatalf("paths = %v, want chat then messages", gotPaths)
+	}
+	if len(router.failures) != 0 {
+		t.Fatalf("failures = %#v, want none (protocol miss must not poison channel)", router.failures)
+	}
+	if len(router.successes) != 1 || router.successes[0].channelID != 42 {
+		t.Fatalf("successes = %#v, want one success on channel 42", router.successes)
+	}
+}
+
+func TestDispatchDisableCrossProtocolFallbackStopsAfterPrimary(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		paths []string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"please use /v1/messages"}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	prev := config.Get()
+	cfgCopy := *prev
+	cfgCopy.DisableCrossProtocolFallback = true
+	config.Set(&cfgCopy)
+	t.Cleanup(func() { config.Set(prev) })
+
+	router := &upstreamTestRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active"},
+		TokenValue:  "upstream-token",
+		ActualModel: "claude-3",
+	}}
+	SetUpstreamConfig(&UpstreamConfig{Router: router})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"claude-3","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	mu.Lock()
+	gotPaths := append([]string(nil), paths...)
+	mu.Unlock()
+	if len(gotPaths) != 1 || gotPaths[0] != "/v1/chat/completions" {
+		t.Fatalf("paths = %v, want only primary chat path", gotPaths)
+	}
+}
+
+func TestDispatchFirstByteTimeoutFallsBackToNextEndpointWithoutPoison(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		paths []string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		if r.URL.Path == "/v1/chat/completions" {
+			// Exceed 1s first-byte timeout.
+			time.Sleep(1200 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"late"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_fast","choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	prev := config.Get()
+	cfgCopy := *prev
+	cfgCopy.DisableCrossProtocolFallback = false
+	// PROXY_FIRST_BYTE_TIMEOUT_SEC is seconds; convert to ms internally.
+	cfgCopy.ProxyFirstByteTimeoutSec = 1
+	config.Set(&cfgCopy)
+	t.Cleanup(func() { config.Set(prev) })
+
+	router := &upstreamTestRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active"},
+		TokenValue:  "upstream-token",
+		ActualModel: "gpt-4o",
+	}}
+	SetUpstreamConfig(&UpstreamConfig{
+		Router:   router,
+		Executor: proxy.NewRuntimeExecutor(5 * time.Second),
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	mu.Lock()
+	gotPaths := append([]string(nil), paths...)
+	mu.Unlock()
+	if len(gotPaths) < 2 || gotPaths[0] != "/v1/chat/completions" {
+		t.Fatalf("paths = %v, want timeout on chat then fallback", gotPaths)
+	}
+	if len(router.failures) != 0 {
+		t.Fatalf("failures = %#v, want none for intermediate first-byte timeout", router.failures)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "chatcmpl_fast") {
+		t.Fatalf("body = %q, want fast fallback response", body)
+	}
+}

--- a/proxy/endpoint_flow.go
+++ b/proxy/endpoint_flow.go
@@ -14,6 +14,110 @@ const (
 	EndpointResponses UpstreamEndpoint = "responses" // /v1/responses (Codex)
 )
 
+// PathForEndpoint returns the canonical upstream path for a known endpoint type.
+// Unknown endpoints return "".
+func PathForEndpoint(endpoint UpstreamEndpoint) string {
+	switch endpoint {
+	case EndpointChat:
+		return "/v1/chat/completions"
+	case EndpointMessages:
+		return "/v1/messages"
+	case EndpointResponses:
+		return "/v1/responses"
+	default:
+		return ""
+	}
+}
+
+// EndpointFromPath maps a downstream/upstream path to a known chat-family endpoint.
+// Non chat-family paths return ("", false).
+func EndpointFromPath(path string) (UpstreamEndpoint, bool) {
+	path = strings.TrimSpace(path)
+	if i := strings.IndexAny(path, "?#"); i >= 0 {
+		path = path[:i]
+	}
+	path = strings.TrimRight(path, "/")
+	switch {
+	case strings.HasSuffix(path, "/v1/chat/completions") || path == "/chat/completions" || path == "/v1/chat/completions":
+		return EndpointChat, true
+	case strings.HasSuffix(path, "/v1/messages") || path == "/messages" || path == "/v1/messages" ||
+		strings.HasSuffix(path, "/anthropic/v1/messages"):
+		return EndpointMessages, true
+	case strings.HasSuffix(path, "/v1/responses") || path == "/responses" || path == "/v1/responses":
+		return EndpointResponses, true
+	default:
+		return "", false
+	}
+}
+
+// ResolveEndpointCandidates builds the ordered multi-protocol candidate list for a
+// downstream path. Primary endpoint is first. When disableCrossProtocolFallback is
+// true, only the primary is returned. Non chat-family paths yield a single synthetic
+// candidate list of length 1 using the original path via PathForEndpoint fallbacks.
+//
+// Product policy (upstream #387 / issue #38):
+// - first-byte timeout or protocol-mismatch may continue to remaining candidates
+// - DISABLE_CROSS_PROTOCOL_FALLBACK stops after the primary attempt
+func ResolveEndpointCandidates(downstreamPath string, disableCrossProtocolFallback bool) []UpstreamEndpoint {
+	primary, ok := EndpointFromPath(downstreamPath)
+	if !ok {
+		// Non chat-family: no multi-protocol list. Caller should use the original path.
+		return nil
+	}
+	if disableCrossProtocolFallback {
+		return []UpstreamEndpoint{primary}
+	}
+	// Primary first, then remaining chat-family protocols in stable order.
+	order := []UpstreamEndpoint{EndpointChat, EndpointMessages, EndpointResponses}
+	// Prefer responses→chat→messages when primary is responses (common Codex downgrade).
+	switch primary {
+	case EndpointResponses:
+		order = []UpstreamEndpoint{EndpointResponses, EndpointChat, EndpointMessages}
+	case EndpointMessages:
+		order = []UpstreamEndpoint{EndpointMessages, EndpointChat, EndpointResponses}
+	case EndpointChat:
+		order = []UpstreamEndpoint{EndpointChat, EndpointMessages, EndpointResponses}
+	}
+	out := make([]UpstreamEndpoint, 0, len(order))
+	seen := map[UpstreamEndpoint]bool{}
+	for _, ep := range order {
+		if seen[ep] {
+			continue
+		}
+		seen[ep] = true
+		out = append(out, ep)
+	}
+	return out
+}
+
+// ShouldDowngradeToNextEndpoint reports whether an upstream error indicates the
+// current protocol/path is wrong and a different endpoint candidate should be tried.
+func ShouldDowngradeToNextEndpoint(status int, rawErrText string) bool {
+	if status <= 0 {
+		return false
+	}
+	text := strings.ToLower(strings.TrimSpace(rawErrText))
+	if text == "" {
+		return false
+	}
+	// Protocol redirect hints from upstream (also in retry_policy patterns).
+	if strings.Contains(text, "please use /v1/chat/completions") ||
+		strings.Contains(text, "please use /v1/messages") ||
+		strings.Contains(text, "please use /v1/responses") ||
+		strings.Contains(text, "unsupported endpoint") ||
+		strings.Contains(text, "unsupported path") ||
+		strings.Contains(text, "unknown endpoint") ||
+		strings.Contains(text, "unrecognized request url") ||
+		strings.Contains(text, "unsupported legacy protocol") {
+		return true
+	}
+	// 404 on a protocol path is a common wrong-endpoint signal.
+	if status == 404 {
+		return true
+	}
+	return false
+}
+
 // BuiltEndpointRequest is a built upstream request for a specific endpoint.
 type BuiltEndpointRequest struct {
 	Endpoint UpstreamEndpoint

--- a/proxy/endpoint_flow_test.go
+++ b/proxy/endpoint_flow_test.go
@@ -468,6 +468,109 @@ func TestExecuteEndpointFlow_DisableCrossProtocolFallback(t *testing.T) {
 	})
 }
 
+func TestResolveEndpointCandidates(t *testing.T) {
+	t.Run("chat primary includes multi-protocol order", func(t *testing.T) {
+		got := ResolveEndpointCandidates("/v1/chat/completions", false)
+		want := []UpstreamEndpoint{EndpointChat, EndpointMessages, EndpointResponses}
+		if len(got) != len(want) {
+			t.Fatalf("len=%d want %d (%v)", len(got), len(want), got)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("got %v want %v", got, want)
+			}
+		}
+	})
+	t.Run("disableCrossProtocolFallback returns primary only", func(t *testing.T) {
+		got := ResolveEndpointCandidates("/v1/messages", true)
+		if len(got) != 1 || got[0] != EndpointMessages {
+			t.Fatalf("got %v, want [messages]", got)
+		}
+	})
+	t.Run("non chat-family returns nil", func(t *testing.T) {
+		got := ResolveEndpointCandidates("/v1/embeddings", false)
+		if got != nil {
+			t.Fatalf("got %v, want nil", got)
+		}
+	})
+}
+
+func TestPathForEndpointAndFromPath(t *testing.T) {
+	if PathForEndpoint(EndpointChat) != "/v1/chat/completions" {
+		t.Fatalf("PathForEndpoint chat = %q", PathForEndpoint(EndpointChat))
+	}
+	ep, ok := EndpointFromPath("/v1/responses")
+	if !ok || ep != EndpointResponses {
+		t.Fatalf("EndpointFromPath responses = %v %v", ep, ok)
+	}
+}
+
+func TestShouldDowngradeToNextEndpoint(t *testing.T) {
+	if !ShouldDowngradeToNextEndpoint(400, "please use /v1/chat/completions") {
+		t.Fatal("expected protocol redirect to downgrade")
+	}
+	if !ShouldDowngradeToNextEndpoint(404, "not found") {
+		t.Fatal("expected 404 to downgrade")
+	}
+	if ShouldDowngradeToNextEndpoint(500, "internal") {
+		t.Fatal("generic 500 should not auto-downgrade")
+	}
+	if ShouldDowngradeToNextEndpoint(0, "first byte timeout") {
+		t.Fatal("status 0 is handled by timeout path, not downgrade helper")
+	}
+}
+
+func TestExecuteEndpointFlow_FirstByteTimeoutPassesMsToDispatch(t *testing.T) {
+	var gotTimeout int64 = -1
+	_ = ExecuteEndpointFlow(ExecuteEndpointFlowInput{
+		SiteURL:            "https://api.example.com",
+		EndpointCandidates: makeEndpointCandidates(EndpointChat),
+		FirstByteTimeoutMs: 1500,
+		BuildRequest: func(endpoint UpstreamEndpoint, index int) BuiltEndpointRequest {
+			return BuiltEndpointRequest{Endpoint: endpoint, Path: PathForEndpoint(endpoint)}
+		},
+		DispatchRequest: func(request BuiltEndpointRequest, targetURL string, firstByteTimeoutMs int64) (*ExecutorDispatchResult, error) {
+			gotTimeout = firstByteTimeoutMs
+			return makeSuccessResponse(200, "ok"), nil
+		},
+	})
+	if gotTimeout != 1500 {
+		t.Fatalf("firstByteTimeoutMs = %d, want 1500", gotTimeout)
+	}
+}
+
+func TestExecuteEndpointFlow_TimeoutDoesNotPoisonViaFailureHookSemantics(t *testing.T) {
+	// Soft timeout on non-last endpoint should call OnAttemptFailure but still
+	// continue; callers must not treat intermediate timeout as terminal poison.
+	failures := 0
+	result := ExecuteEndpointFlow(ExecuteEndpointFlowInput{
+		SiteURL:                      "https://api.example.com",
+		DisableCrossProtocolFallback: false,
+		EndpointCandidates:           makeEndpointCandidates(EndpointChat, EndpointMessages),
+		BuildRequest: func(endpoint UpstreamEndpoint, index int) BuiltEndpointRequest {
+			return BuiltEndpointRequest{Endpoint: endpoint, Path: PathForEndpoint(endpoint)}
+		},
+		DispatchRequest: func(request BuiltEndpointRequest, targetURL string, _ int64) (*ExecutorDispatchResult, error) {
+			if request.Endpoint == EndpointChat {
+				return makeTimeoutResponse(), nil
+			}
+			return makeSuccessResponse(200, "ok"), nil
+		},
+		OnAttemptFailure: func(ctx EndpointAttemptContext) {
+			failures++
+			if ctx.Response == nil || ctx.Response.Status != 0 {
+				t.Fatalf("expected timeout marker failure, got %+v", ctx.Response)
+			}
+		},
+	})
+	if !result.OK {
+		t.Fatal("expected success after timeout fallback")
+	}
+	if failures != 1 {
+		t.Fatalf("failures=%d, want 1 intermediate timeout failure", failures)
+	}
+}
+
 func TestExecuteEndpointFlow_ProxyURL(t *testing.T) {
 	t.Run("uses proxy URL when provided", func(t *testing.T) {
 		var capturedURL string

--- a/proxy/executor.go
+++ b/proxy/executor.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -90,8 +91,90 @@ func (e *RuntimeExecutor) Dispatch(ctx context.Context, input ExecutorDispatchIn
 	}, nil
 }
 
+// ErrObservedFirstByteTimeout is returned by DoWithObservedFirstByte when the
+// first-byte / response-header deadline fires before headers arrive.
+//
+// Unit note: firstByteTimeoutMs is milliseconds. Config field
+// PROXY_FIRST_BYTE_TIMEOUT_SEC is seconds; convert with FirstByteTimeoutMs.
+var ErrObservedFirstByteTimeout = errors.New("first byte timeout")
+
+// FirstByteTimeoutMs converts ProxyFirstByteTimeoutSec (seconds) to the
+// internal first-byte observation unit (milliseconds). Values <= 0 disable
+// first-byte observation (returns 0).
+//
+// Matches original TS: firstByteTimeoutMs = proxyFirstByteTimeoutSec * 1000.
+func FirstByteTimeoutMs(proxyFirstByteTimeoutSec int) int64 {
+	if proxyFirstByteTimeoutSec <= 0 {
+		return 0
+	}
+	return int64(proxyFirstByteTimeoutSec) * 1000
+}
+
+// DoWithObservedFirstByte sends req and observes first-byte (response header)
+// latency. Unlike WithObservedFirstByte it does NOT buffer the body, so callers
+// (including streaming handlers) must close resp.Body themselves.
+//
+// When firstByteTimeoutMs > 0 and the deadline fires before headers arrive,
+// it returns (nil, ErrObservedFirstByteTimeout).
+// firstByteTimeoutMs is milliseconds (see FirstByteTimeoutMs).
+//
+// After headers arrive the first-byte timer is stopped so the body stream is not
+// cancelled by the observation deadline.
+func (e *RuntimeExecutor) DoWithObservedFirstByte(
+	ctx context.Context,
+	req *http.Request,
+	firstByteTimeoutMs int64,
+) (*http.Response, error) {
+	if e == nil || e.client == nil {
+		return nil, fmt.Errorf("dispatch: executor is not configured")
+	}
+	if firstByteTimeoutMs <= 0 {
+		return e.client.Do(req)
+	}
+
+	reqCtx, cancelReq := context.WithCancel(ctx)
+	req = req.WithContext(reqCtx)
+
+	var timedOut atomic.Bool
+	timer := time.AfterFunc(time.Duration(firstByteTimeoutMs)*time.Millisecond, func() {
+		timedOut.Store(true)
+		cancelReq()
+	})
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		_ = timer.Stop()
+		cancelReq()
+		if timedOut.Load() && ctx.Err() == nil {
+			return nil, ErrObservedFirstByteTimeout
+		}
+		return nil, err
+	}
+
+	// Headers received: stop first-byte timer. Keep reqCtx alive for body reads;
+	// cancel when the body is closed.
+	_ = timer.Stop()
+	resp.Body = &cancelOnCloseBody{ReadCloser: resp.Body, cancel: cancelReq}
+	return resp, nil
+}
+
+// cancelOnCloseBody cancels the request context when the response body is closed.
+type cancelOnCloseBody struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (b *cancelOnCloseBody) Close() error {
+	err := b.ReadCloser.Close()
+	if b.cancel != nil {
+		b.cancel()
+	}
+	return err
+}
+
 // WithObservedFirstByte dispatches a request and observes the first-byte latency.
 // Returns a special result with status=0 if the first-byte timeout fires.
+// firstByteTimeoutMs is milliseconds (see FirstByteTimeoutMs).
 func (e *RuntimeExecutor) WithObservedFirstByte(
 	ctx context.Context,
 	input ExecutorDispatchInput,
@@ -113,20 +196,12 @@ func (e *RuntimeExecutor) WithObservedFirstByte(
 		req.Header.Set(k, v)
 	}
 
-	timeoutCtx := ctx
-	if firstByteTimeoutMs > 0 {
-		var cancel context.CancelFunc
-		timeoutCtx, cancel = context.WithTimeout(ctx, time.Duration(firstByteTimeoutMs)*time.Millisecond)
-		defer cancel()
-		req = req.WithContext(timeoutCtx)
-	}
-
-	resp, err := e.client.Do(req)
+	resp, err := e.DoWithObservedFirstByte(ctx, req, firstByteTimeoutMs)
 	firstByteLatencyMs := time.Since(startedAt).Milliseconds()
 
 	if err != nil {
 		// Check if this was a first-byte timeout
-		if firstByteTimeoutMs > 0 && errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
+		if errors.Is(err, ErrObservedFirstByteTimeout) {
 			return &ExecutorDispatchResult{
 				Status:  0, // timeout marker
 				Headers: map[string]string{},
@@ -157,4 +232,9 @@ func (e *RuntimeExecutor) WithObservedFirstByte(
 // IsObservedFirstByteTimeout checks if a result represents a first-byte timeout.
 func IsObservedFirstByteTimeout(result *ExecutorDispatchResult) bool {
 	return result != nil && result.Status == 0
+}
+
+// IsObservedFirstByteTimeoutError reports whether err is a first-byte timeout.
+func IsObservedFirstByteTimeoutError(err error) bool {
+	return errors.Is(err, ErrObservedFirstByteTimeout)
 }

--- a/proxy/executor_test.go
+++ b/proxy/executor_test.go
@@ -59,6 +59,78 @@ func TestWithObservedFirstByteReturnsTimeoutMarkerOnDeadline(t *testing.T) {
 	}
 }
 
+func TestFirstByteTimeoutMsSecToMs(t *testing.T) {
+	tests := []struct {
+		sec  int
+		want int64
+	}{
+		{0, 0},
+		{-1, 0},
+		{1, 1000},
+		{5, 5000},
+		{90, 90000},
+	}
+	for _, tt := range tests {
+		if got := FirstByteTimeoutMs(tt.sec); got != tt.want {
+			t.Errorf("FirstByteTimeoutMs(%d) = %d, want %d", tt.sec, got, tt.want)
+		}
+	}
+}
+
+func TestDoWithObservedFirstByteTimeoutError(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(80 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	executor := NewRuntimeExecutor(time.Second)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, upstream.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := executor.DoWithObservedFirstByte(context.Background(), req, 5)
+	if resp != nil {
+		resp.Body.Close()
+		t.Fatalf("expected nil response on first-byte timeout")
+	}
+	if !IsObservedFirstByteTimeoutError(err) {
+		t.Fatalf("err = %v, want ErrObservedFirstByteTimeout", err)
+	}
+}
+
+func TestDoWithObservedFirstByteDoesNotCancelBodyAfterHeaders(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		if flusher != nil {
+			flusher.Flush()
+		}
+		time.Sleep(40 * time.Millisecond)
+		_, _ = w.Write([]byte("body-after-headers"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	executor := NewRuntimeExecutor(time.Second)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, upstream.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	// first-byte window is short but headers arrive immediately; body should still complete.
+	resp, err := executor.DoWithObservedFirstByte(context.Background(), req, 10)
+	if err != nil {
+		t.Fatalf("DoWithObservedFirstByte: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(body) != "body-after-headers" {
+		t.Fatalf("body = %q, want body-after-headers", body)
+	}
+}
+
 func TestDispatchRejectsOversizedBufferedResponse(t *testing.T) {
 	t.Setenv("PROXY_MAX_BUFFERED_RESPONSE_BYTES", "8")
 


### PR DESCRIPTION
## Summary
- Wire observed first-byte timeout into production dispatch (`ProxyFirstByteTimeoutSec` → ms)
- On status=0 first-byte timeout, continue to next endpoint/protocol candidate
- Honor `DisableCrossProtocolFallback`; document units in `docs/analysis/failover-first-byte.md`
- Tests for failover continue, disable flag, and unit conversion

## Test plan
- [x] `go test ./handler/proxy/ ./proxy/ ./app/`
- [x] pre-push race suite green

Closes #38