### PR TITLE
fix(gemini): inject/preserve tool-history thought_signature

### DIFF
--- a/docs/analysis/gemini-thought-signature.md
+++ b/docs/analysis/gemini-thought-signature.md
@@ -1,0 +1,70 @@
+# Gemini tool-history `thought_signature`
+
+Last updated: 2026-07-17
+
+Issue: TokenDanceLab/metapi-go#47  
+Upstream: cita-777/metapi#580 / #581
+
+## Problem
+
+Official Gemini (especially Gemini 3.x) rejects multi-turn tool history when model `functionCall` parts lack `thoughtSignature`:
+
+```text
+Function call is missing a thought_signature in functionCall parts.
+```
+
+OpenAI-compatible clients usually cannot carry Gemini provider metadata, so replaying `assistant.tool_calls` without a bridge causes HTTP 400 on official Gemini chat / native generateContent tool history.
+
+## Implementation (metapi-go)
+
+Primary surface: `transform/gemini/generate_content/compatibility.go`
+
+| Concern | Behavior |
+|--------|----------|
+| Dummy sentinel | `DummyThoughtSignature` = base64(`skip_thought_signature_validator`) = `c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I=` |
+| Safe models | `gemini-*` / `models/gemini-*` only |
+| Required models | Gemini 3.x (`gemini-3…`) always require signature on tool-history `functionCall` parts, even without explicit thinking config |
+| Thinking-enabled | For Gemini 2.5-class models, inject dummy only when thinking/reasoning is enabled |
+| Non-Gemini | Never inject dummy; if thinking would otherwise be enabled and signature is missing, drop derived `thinkingConfig` |
+| Preserve real sig | Prefer `provider_specific_fields.thought_signature` / part `thoughtSignature` over dummy |
+| Split contents | When a model turn has both text and signed `functionCall` parts, emit separate `contents` entries (text first, then functionCall) |
+| Native request | `NormalizeRequest` injects missing signatures into native Gemini `contents` for Gemini 3 / thinking-safe models |
+| Stream collect | `StreamBridge.NormalizeEvent` records unique `ThoughtSignatures` into `GeminiAggregateState` |
+| Next-turn inject | `ApplyThoughtSignaturesToFunctionCallParts` / `BuildSignedModelContentForToolHistory` re-attach aggregate signatures for follow-up requests |
+| OpenAI bridge | Gemini→OpenAI stores signature under `tool_calls[].provider_specific_fields.thought_signature`; OpenAI→Gemini restores it |
+
+## Round-trip
+
+1. Upstream stream/final Gemini parts may include `thoughtSignature` on `functionCall`.
+2. Aggregate state collects unique signatures (`GeminiAggregateState.ThoughtSignatures`).
+3. Gemini→OpenAI conversion preserves them on tool_calls provider fields.
+4. Next OpenAI→Gemini or native normalize re-attaches real signatures (or dummy when required and missing).
+
+## Models without signature support / caveats
+
+| Model class | Signature behavior |
+|-------------|--------------------|
+| `gemini-3*` (incl. 3.5) | Required on tool-history functionCall parts; dummy injected when real sig missing |
+| `gemini-2.5*` with thinking/reasoning | Dummy injected when thinking enabled and real sig missing |
+| `gemini-2.5*` without thinking | No injection (matches upstream #135 baseline) |
+| Non-`gemini-*` IDs routed through this bridge | No dummy; thinking config may be disabled if signature missing |
+| Third-party “Gemini-compatible” proxies | Dummy may be rejected; only official Gemini model IDs are treated as dummy-safe |
+
+## Tests
+
+`transform/gemini/generate_content/thought_signature_test.go` covers:
+
+- Preserve real provider signatures
+- Text/functionCall split for signed parts
+- Dummy inject for thinking-enabled and Gemini 3 without thinking
+- No dummy for Gemini 2.5 without thinking / non-Gemini
+- Multi-turn preservation
+- Native `NormalizeRequest` inject/preserve
+- Stream aggregate collection
+- Aggregate → next request round-trip
+- OpenAI↔Gemini tool-history signature round-trip
+
+## Out of scope (this issue)
+
+- Proxy executor routing (`gemini-native` path selection) — upstream #581 also touched request builders; this Go issue focuses on transform/request-side signature inject/preserve.
+- `web/**` and other protocol issues (#52/#53/#54).

--- a/transform/gemini/generate_content/compatibility.go
+++ b/transform/gemini/generate_content/compatibility.go
@@ -15,6 +15,10 @@ var AllowedGeminiKeys = map[string]bool{
 	"toolConfig": true, "labels": true, "model": true,
 }
 
+// DummyThoughtSignature is the base64 sentinel for "skip_thought_signature_validator".
+// Gemini accepts any non-empty base64 string when a real thought signature is unavailable.
+const DummyThoughtSignature = "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="
+
 // NormalizeRequest filters and normalizes an incoming Gemini request body.
 func NormalizeRequest(body map[string]any, modelName string) map[string]any {
 	next := map[string]any{}
@@ -68,6 +72,10 @@ func NormalizeRequest(body map[string]any, modelName string) map[string]any {
 		}
 		next[k] = cloneJSONValue(v)
 	}
+
+	// Official Gemini multi-turn tool history requires thoughtSignature on
+	// functionCall parts for Gemini 3.x (and thinking-enabled models).
+	injectThoughtSignaturesIntoContents(next, modelName)
 
 	return next
 }
@@ -125,10 +133,17 @@ func BuildOpenAiBodyFromGeminiRequest(body map[string]any, modelName string) map
 				if args == "" {
 					args = "{}"
 				}
-				toolCalls = append(toolCalls, map[string]any{
+				toolCall := map[string]any{
 					"id": id, "type": "function",
 					"function": map[string]any{"name": name, "arguments": args},
-				})
+				}
+				// Preserve thought_signature for OpenAI↔Gemini tool-history round-trips.
+				if sig := extractThoughtSignature(part); sig != "" {
+					toolCall["provider_specific_fields"] = map[string]any{
+						"thought_signature": sig,
+					}
+				}
+				toolCalls = append(toolCalls, toolCall)
 			} else if fr, ok := part["functionResponse"].(map[string]any); ok {
 				name := shared.AsTrimmedString(fr["name"])
 				id := shared.AsTrimmedString(fr["id"])
@@ -211,6 +226,51 @@ func BuildGeminiGenerateContentRequestFromOpenAi(openaiBody map[string]any, mode
 	var systemInstruction map[string]any
 
 	msgs, _ := openaiBody["messages"].([]any)
+
+	// Map tool_call_id -> function name for functionResponse.name when tool messages omit name.
+	toolNameByID := map[string]string{}
+	// Map tool_call_id -> thought_signature from provider_specific_fields (or top-level aliases).
+	thoughtSignatureByID := map[string]string{}
+	for _, item := range msgs {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if strings.ToLower(shared.AsTrimmedString(m["role"])) != "assistant" {
+			continue
+		}
+		tcs, ok := m["tool_calls"].([]any)
+		if !ok {
+			continue
+		}
+		for _, tc := range tcs {
+			tcm, ok := tc.(map[string]any)
+			if !ok {
+				continue
+			}
+			id := shared.AsTrimmedString(tcm["id"])
+			fn, _ := tcm["function"].(map[string]any)
+			if fn == nil {
+				fn = map[string]any{}
+			}
+			name := shared.AsTrimmedString(fn["name"])
+			if id != "" && name != "" {
+				toolNameByID[id] = name
+			}
+			if id == "" {
+				continue
+			}
+			if sig := extractThoughtSignatureFromToolCall(tcm); sig != "" {
+				thoughtSignatureByID[id] = sig
+			}
+		}
+	}
+
+	hasThinkingEnabled := requestHasThinkingEnabled(modelName, openaiBody)
+	allowsDummy := isDummyThoughtSafeModel(modelName)
+	requiresSig := requiresFunctionCallThoughtSignature(modelName)
+	shouldDisableThinkingConfig := false
+
 	for _, item := range msgs {
 		m, ok := item.(map[string]any)
 		if !ok {
@@ -233,18 +293,19 @@ func BuildGeminiGenerateContentRequestFromOpenAi(openaiBody map[string]any, mode
 			geminiRole = "model"
 		}
 
-		var parts []map[string]any
+		var textParts []map[string]any
+		var fcParts []map[string]any
 
 		// Reasoning content
 		if rc := shared.AsTrimmedString(m["reasoning_content"]); rc != "" {
-			parts = append(parts, map[string]any{"text": rc, "thought": true})
+			textParts = append(textParts, map[string]any{"text": rc, "thought": true})
 		}
 
 		// Content blocks
 		content := m["content"]
 		if s, ok := content.(string); ok {
 			if s != "" {
-				parts = append(parts, map[string]any{"text": s})
+				textParts = append(textParts, map[string]any{"text": s})
 			}
 		} else if arr, ok := content.([]any); ok {
 			for _, block := range arr {
@@ -255,15 +316,15 @@ func BuildGeminiGenerateContentRequestFromOpenAi(openaiBody map[string]any, mode
 				bt := shared.AsTrimmedString(bm["type"])
 				if bt == "text" {
 					if t := shared.AsTrimmedString(bm["text"]); t != "" {
-						parts = append(parts, map[string]any{"text": t})
+						textParts = append(textParts, map[string]any{"text": t})
 					}
 				} else if bt == "image_url" {
 					if iu, ok := bm["image_url"].(map[string]any); ok {
 						url := shared.AsTrimmedString(iu["url"])
 						if inline := parseDataURLToGeminiInline(url); inline != nil {
-							parts = append(parts, inline)
+							textParts = append(textParts, inline)
 						} else if url != "" {
-							parts = append(parts, map[string]any{
+							textParts = append(textParts, map[string]any{
 								"fileData": map[string]any{"fileUri": url, "mimeType": inferMimeFromURL(url)},
 							})
 						}
@@ -272,7 +333,7 @@ func BuildGeminiGenerateContentRequestFromOpenAi(openaiBody map[string]any, mode
 			}
 		}
 
-		// Tool calls
+		// Tool calls -> functionCall parts, with thoughtSignature when required/available.
 		if tcs, ok := m["tool_calls"].([]any); ok {
 			for _, tc := range tcs {
 				tcm, ok := tc.(map[string]any)
@@ -288,12 +349,31 @@ func BuildGeminiGenerateContentRequestFromOpenAi(openaiBody map[string]any, mode
 					continue
 				}
 				args := shared.ParseJSONLike(shared.AsTrimmedString(fn["arguments"]))
-				parts = append(parts, map[string]any{
+				fcPart := map[string]any{
 					"functionCall": map[string]any{
 						"name": name,
 						"args": args,
 					},
-				})
+				}
+				id := shared.AsTrimmedString(tcm["id"])
+				if id != "" {
+					if fc, ok := fcPart["functionCall"].(map[string]any); ok {
+						fc["id"] = id
+					}
+				}
+				sig := thoughtSignatureByID[id]
+				if sig == "" {
+					sig = extractThoughtSignatureFromToolCall(tcm)
+				}
+				if sig != "" {
+					fcPart["thoughtSignature"] = sig
+				} else if (hasThinkingEnabled || requiresSig) && allowsDummy {
+					fcPart["thoughtSignature"] = DummyThoughtSignature
+				} else if hasThinkingEnabled {
+					// Non-Gemini thinking targets cannot safely receive dummy signatures.
+					shouldDisableThinkingConfig = true
+				}
+				fcParts = append(fcParts, fcPart)
 			}
 		}
 
@@ -301,20 +381,47 @@ func BuildGeminiGenerateContentRequestFromOpenAi(openaiBody map[string]any, mode
 		if role == "tool" {
 			toolCallID := shared.AsTrimmedString(m["tool_call_id"])
 			name := shared.AsTrimmedString(m["name"])
+			if name == "" {
+				name = toolNameByID[toolCallID]
+			}
+			if name == "" {
+				name = "unknown"
+			}
 			response := m["content"]
-			parts = append(parts, map[string]any{
-				"functionResponse": map[string]any{
-					"name":     name,
-					"id":       toolCallID,
-					"response": response,
-				},
+			contents = append(contents, map[string]any{
+				"role": "user",
+				"parts": []map[string]any{{
+					"functionResponse": map[string]any{
+						"name":     name,
+						"id":       toolCallID,
+						"response": response,
+					},
+				}},
 			})
+			continue
 		}
 
-		if len(parts) > 0 {
+		// Official Gemini expects signed functionCall parts separated from sibling text parts.
+		hasSigned := false
+		for _, p := range fcParts {
+			if shared.AsTrimmedString(p["thoughtSignature"]) != "" {
+				hasSigned = true
+				break
+			}
+		}
+		if hasSigned && len(textParts) > 0 && len(fcParts) > 0 {
+			contents = append(contents,
+				map[string]any{"role": geminiRole, "parts": textParts},
+				map[string]any{"role": geminiRole, "parts": fcParts},
+			)
+			continue
+		}
+
+		allParts := append(append([]map[string]any{}, textParts...), fcParts...)
+		if len(allParts) > 0 {
 			contents = append(contents, map[string]any{
 				"role":  geminiRole,
-				"parts": parts,
+				"parts": allParts,
 			})
 		}
 	}
@@ -339,6 +446,10 @@ func BuildGeminiGenerateContentRequestFromOpenAi(openaiBody map[string]any, mode
 	if mt, ok := openaiBody["max_tokens"].(float64); ok {
 		gc["maxOutputTokens"] = int(mt)
 	}
+	thinkingConfig := ResolveGeminiThinkingConfigFromRequest(modelName, openaiBody)
+	if thinkingConfig != nil && !shouldDisableThinkingConfig {
+		gc["thinkingConfig"] = thinkingConfig
+	}
 	if len(gc) > 0 {
 		body["generationConfig"] = gc
 	}
@@ -356,7 +467,216 @@ func BuildGeminiGenerateContentRequestFromOpenAi(openaiBody map[string]any, mode
 	return body
 }
 
-// --- Helpers ---
+// --- Thought signature helpers ---
+
+// isDummyThoughtSafeModel reports whether dummy thought signatures are safe for this model.
+// Only official Gemini model IDs accept the sentinel; third-party "Gemini-compatible" models may not.
+func isDummyThoughtSafeModel(modelName string) bool {
+	normalized := strings.ToLower(shared.AsTrimmedString(modelName))
+	return strings.HasPrefix(normalized, "gemini-") || strings.HasPrefix(normalized, "models/gemini-")
+}
+
+// requiresFunctionCallThoughtSignature reports models that reject tool history without thoughtSignature
+// even when the client did not enable thinking/reasoning explicitly (Gemini 3.x).
+func requiresFunctionCallThoughtSignature(modelName string) bool {
+	normalized := strings.ToLower(shared.AsTrimmedString(modelName))
+	normalized = strings.TrimPrefix(normalized, "models/")
+	// gemini-3, gemini-3.5-flash, gemini-3-pro-preview, etc.
+	return strings.HasPrefix(normalized, "gemini-3")
+}
+
+// requestHasThinkingEnabled detects thinking either via derived reasoning params or explicit thinkingConfig.
+func requestHasThinkingEnabled(modelName string, body map[string]any) bool {
+	if ResolveGeminiThinkingConfigFromRequest(modelName, body) != nil {
+		return true
+	}
+	if body == nil {
+		return false
+	}
+	if gc, ok := body["generationConfig"].(map[string]any); ok && gc != nil {
+		if tc := gc["thinkingConfig"]; tc != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func extractThoughtSignature(part map[string]any) string {
+	if part == nil {
+		return ""
+	}
+	if sig := shared.AsTrimmedString(part["thoughtSignature"]); sig != "" {
+		return sig
+	}
+	if sig := shared.AsTrimmedString(part["thought_signature"]); sig != "" {
+		return sig
+	}
+	return ""
+}
+
+func extractThoughtSignatureFromToolCall(toolCall map[string]any) string {
+	if toolCall == nil {
+		return ""
+	}
+	if sig := shared.AsTrimmedString(toolCall["thoughtSignature"]); sig != "" {
+		return sig
+	}
+	if sig := shared.AsTrimmedString(toolCall["thought_signature"]); sig != "" {
+		return sig
+	}
+	if psf, ok := toolCall["provider_specific_fields"].(map[string]any); ok && psf != nil {
+		if sig := shared.AsTrimmedString(psf["thought_signature"]); sig != "" {
+			return sig
+		}
+		if sig := shared.AsTrimmedString(psf["thoughtSignature"]); sig != "" {
+			return sig
+		}
+	}
+	return ""
+}
+
+// injectThoughtSignaturesIntoContents ensures native Gemini contents with functionCall parts
+// carry thoughtSignature when official Gemini would reject unsigned tool history.
+// Existing real signatures are preserved; dummy is only injected when missing.
+func injectThoughtSignaturesIntoContents(body map[string]any, modelName string) {
+	if body == nil {
+		return
+	}
+	allowsDummy := isDummyThoughtSafeModel(modelName)
+	requiresSig := requiresFunctionCallThoughtSignature(modelName)
+	hasThinking := requestHasThinkingEnabled(modelName, body)
+	if !allowsDummy || (!requiresSig && !hasThinking) {
+		return
+	}
+
+	// contents may be []any (from clone) or []map[string]any in tests.
+	switch contents := body["contents"].(type) {
+	case []any:
+		for _, item := range contents {
+			m, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			injectThoughtSignaturesIntoParts(m)
+		}
+	case []map[string]any:
+		for _, m := range contents {
+			injectThoughtSignaturesIntoParts(m)
+		}
+	}
+}
+
+func injectThoughtSignaturesIntoParts(content map[string]any) {
+	if content == nil {
+		return
+	}
+	switch parts := content["parts"].(type) {
+	case []any:
+		for _, p := range parts {
+			pm, ok := p.(map[string]any)
+			if !ok {
+				continue
+			}
+			if _, hasFC := pm["functionCall"]; !hasFC {
+				continue
+			}
+			if extractThoughtSignature(pm) != "" {
+				continue
+			}
+			pm["thoughtSignature"] = DummyThoughtSignature
+		}
+	case []map[string]any:
+		for _, pm := range parts {
+			if pm == nil {
+				continue
+			}
+			if _, hasFC := pm["functionCall"]; !hasFC {
+				continue
+			}
+			if extractThoughtSignature(pm) != "" {
+				continue
+			}
+			pm["thoughtSignature"] = DummyThoughtSignature
+		}
+	}
+}
+
+// ApplyThoughtSignaturesToFunctionCallParts injects/preserves thought signatures on functionCall parts.
+// Prefer real signatures from priorAggregate or existing part fields; fall back to dummy when required.
+func ApplyThoughtSignaturesToFunctionCallParts(parts []map[string]any, modelName string, priorAggregate *GeminiAggregateState) []map[string]any {
+	if len(parts) == 0 {
+		return parts
+	}
+	allowsDummy := isDummyThoughtSafeModel(modelName)
+	requiresSig := requiresFunctionCallThoughtSignature(modelName)
+	// Without aggregate thinking flag, still inject for Gemini 3.x tool history.
+	shouldInject := allowsDummy && requiresSig
+	if !shouldInject && allowsDummy {
+		// Also inject when aggregate already collected signatures (multi-turn follow-up).
+		if priorAggregate != nil && len(priorAggregate.ThoughtSignatures) > 0 {
+			shouldInject = true
+		}
+	}
+	if !shouldInject && !allowsDummy {
+		return parts
+	}
+
+	aggIdx := 0
+	out := make([]map[string]any, 0, len(parts))
+	for _, part := range parts {
+		next := cloneMapSimple(part)
+		if _, hasFC := next["functionCall"]; hasFC {
+			if extractThoughtSignature(next) == "" {
+				var sig string
+				if priorAggregate != nil && aggIdx < len(priorAggregate.ThoughtSignatures) {
+					sig = priorAggregate.ThoughtSignatures[aggIdx]
+				}
+				if sig == "" && shouldInject {
+					sig = DummyThoughtSignature
+				}
+				if sig != "" {
+					next["thoughtSignature"] = sig
+				}
+			}
+			aggIdx++
+		}
+		out = append(out, next)
+	}
+	return out
+}
+
+// CollectThoughtSignaturesFromParts records unique thoughtSignature values from parts into state.
+func CollectThoughtSignaturesFromParts(state *GeminiAggregateState, parts []map[string]any) {
+	if state == nil {
+		return
+	}
+	for _, part := range parts {
+		sig := extractThoughtSignature(part)
+		if sig == "" {
+			continue
+		}
+		found := false
+		for _, existing := range state.ThoughtSignatures {
+			if existing == sig {
+				found = true
+				break
+			}
+		}
+		if !found {
+			state.ThoughtSignatures = append(state.ThoughtSignatures, sig)
+		}
+	}
+}
+
+// BuildSignedModelContentForToolHistory builds a model content entry for replaying tool calls
+// into the next Gemini request, attaching thought signatures from aggregate state when present.
+func BuildSignedModelContentForToolHistory(parts []map[string]any, modelName string, priorAggregate *GeminiAggregateState) map[string]any {
+	signed := ApplyThoughtSignaturesToFunctionCallParts(parts, modelName, priorAggregate)
+	return map[string]any{
+		"role":  "model",
+		"parts": signed,
+	}
+}
 
 func filterParts(parts []any) []map[string]any {
 	var out []map[string]any
@@ -812,11 +1132,15 @@ func (sb *StreamBridge) NormalizeEvent(payload any) shared.NormalizedStreamEvent
 				}
 				if cp, ok := c["content"].(map[string]any); ok {
 					if parts, ok := cp["parts"].([]any); ok {
+						var collected []map[string]any
 						for _, p := range parts {
 							if pm, ok := p.(map[string]any); ok {
 								sb.State.Parts = append(sb.State.Parts, pm)
+								collected = append(collected, pm)
 							}
 						}
+						// Stream collect thought signatures for next-turn tool-history injection.
+						CollectThoughtSignaturesFromParts(sb.State, collected)
 					}
 				}
 			}

--- a/transform/gemini/generate_content/thought_signature_test.go
+++ b/transform/gemini/generate_content/thought_signature_test.go
@@ -1,0 +1,588 @@
+package generate_content
+
+import (
+	"testing"
+)
+
+func collectFunctionCallParts(contents any) []map[string]any {
+	var out []map[string]any
+	switch arr := contents.(type) {
+	case []map[string]any:
+		for _, content := range arr {
+			switch parts := content["parts"].(type) {
+			case []map[string]any:
+				for _, p := range parts {
+					if _, ok := p["functionCall"]; ok {
+						out = append(out, p)
+					}
+				}
+			case []any:
+				for _, raw := range parts {
+					if p, ok := raw.(map[string]any); ok {
+						if _, ok := p["functionCall"]; ok {
+							out = append(out, p)
+						}
+					}
+				}
+			}
+		}
+	case []any:
+		for _, item := range arr {
+			content, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			switch parts := content["parts"].(type) {
+			case []map[string]any:
+				for _, p := range parts {
+					if _, ok := p["functionCall"]; ok {
+						out = append(out, p)
+					}
+				}
+			case []any:
+				for _, raw := range parts {
+					if p, ok := raw.(map[string]any); ok {
+						if _, ok := p["functionCall"]; ok {
+							out = append(out, p)
+						}
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+func TestBuildGeminiGenerateContentRequestFromOpenAi_PreservesProviderThoughtSignature(t *testing.T) {
+	oaiBody := map[string]any{
+		"model": "gemini-3-flash-preview",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "What is the weather?"},
+			map[string]any{
+				"role":    "assistant",
+				"content": "Let me check.",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_123",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "get_weather",
+							"arguments": `{"city":"Tokyo"}`,
+						},
+						"provider_specific_fields": map[string]any{
+							"thought_signature": "real_sig_abc",
+						},
+					},
+				},
+			},
+			map[string]any{"role": "tool", "tool_call_id": "call_123", "content": `{"temp":"22C"}`},
+		},
+	}
+
+	result := BuildGeminiGenerateContentRequestFromOpenAi(oaiBody, "gemini-3-flash-preview")
+	fcParts := collectFunctionCallParts(result["contents"])
+	if len(fcParts) != 1 {
+		t.Fatalf("expected 1 functionCall part, got %d", len(fcParts))
+	}
+	if fcParts[0]["thoughtSignature"] != "real_sig_abc" {
+		t.Fatalf("expected real thoughtSignature, got %v", fcParts[0]["thoughtSignature"])
+	}
+}
+
+func TestBuildGeminiGenerateContentRequestFromOpenAi_SplitsSignedFunctionCallFromText(t *testing.T) {
+	oaiBody := map[string]any{
+		"model": "gemini-3-flash-preview",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Read the file."},
+			map[string]any{
+				"role":    "assistant",
+				"content": "I will read it.",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_456",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "Read",
+							"arguments": `{"path":"/tmp/x"}`,
+						},
+						"provider_specific_fields": map[string]any{
+							"thought_signature": "sig_split_test",
+						},
+					},
+				},
+			},
+			map[string]any{"role": "tool", "tool_call_id": "call_456", "content": "file content here"},
+		},
+	}
+
+	result := BuildGeminiGenerateContentRequestFromOpenAi(oaiBody, "gemini-3-flash-preview")
+	contents, ok := result["contents"].([]map[string]any)
+	if !ok {
+		t.Fatalf("contents type = %T", result["contents"])
+	}
+	var modelMsgs []map[string]any
+	for _, c := range contents {
+		if c["role"] == "model" {
+			modelMsgs = append(modelMsgs, c)
+		}
+	}
+	if len(modelMsgs) != 2 {
+		t.Fatalf("expected 2 model messages (text + signed functionCall), got %d", len(modelMsgs))
+	}
+	firstParts, _ := modelMsgs[0]["parts"].([]map[string]any)
+	secondParts, _ := modelMsgs[1]["parts"].([]map[string]any)
+	if len(firstParts) == 0 || firstParts[0]["text"] == nil {
+		t.Fatalf("first model message should be text-only, got %#v", firstParts)
+	}
+	if _, ok := secondParts[0]["functionCall"]; !ok {
+		t.Fatalf("second model message should be functionCall, got %#v", secondParts)
+	}
+	if secondParts[0]["thoughtSignature"] != "sig_split_test" {
+		t.Fatalf("expected split signature, got %v", secondParts[0]["thoughtSignature"])
+	}
+}
+
+func TestBuildGeminiGenerateContentRequestFromOpenAi_InjectsDummyWhenThinkingEnabled(t *testing.T) {
+	oaiBody := map[string]any{
+		"model":            "gemini-3-flash-preview",
+		"reasoning_effort": "high",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Do something."},
+			map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_no_sig",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "Bash",
+							"arguments": `{"command":"ls"}`,
+						},
+					},
+				},
+			},
+			map[string]any{"role": "tool", "tool_call_id": "call_no_sig", "content": "file1\nfile2"},
+		},
+	}
+
+	result := BuildGeminiGenerateContentRequestFromOpenAi(oaiBody, "gemini-3-flash-preview")
+	fcParts := collectFunctionCallParts(result["contents"])
+	if len(fcParts) != 1 {
+		t.Fatalf("expected 1 functionCall part, got %d", len(fcParts))
+	}
+	sig, _ := fcParts[0]["thoughtSignature"].(string)
+	if sig == "" {
+		t.Fatal("expected dummy thoughtSignature when thinking enabled")
+	}
+	if sig != DummyThoughtSignature {
+		t.Fatalf("expected dummy sentinel, got %q", sig)
+	}
+}
+
+func TestBuildGeminiGenerateContentRequestFromOpenAi_InjectsDummyForGemini3WithoutThinking(t *testing.T) {
+	// Official Gemini 3.x rejects tool history without thought_signature even without explicit thinking.
+	oaiBody := map[string]any{
+		"model": "gemini-3.5-flash",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "List files."},
+			map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_ls",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "ls",
+							"arguments": `{"path":"/tmp"}`,
+						},
+					},
+				},
+			},
+			map[string]any{"role": "tool", "tool_call_id": "call_ls", "content": "file1\nfile2"},
+		},
+	}
+
+	result := BuildGeminiGenerateContentRequestFromOpenAi(oaiBody, "gemini-3.5-flash")
+	fcParts := collectFunctionCallParts(result["contents"])
+	if len(fcParts) != 1 {
+		t.Fatalf("expected 1 functionCall part, got %d", len(fcParts))
+	}
+	if fcParts[0]["thoughtSignature"] != DummyThoughtSignature {
+		t.Fatalf("expected dummy thoughtSignature for Gemini 3 tool history, got %v", fcParts[0]["thoughtSignature"])
+	}
+}
+
+func TestBuildGeminiGenerateContentRequestFromOpenAi_NoDummyWhenThinkingDisabledOnGemini25(t *testing.T) {
+	oaiBody := map[string]any{
+		"model": "gemini-2.5-flash",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Hello"},
+			map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_no_think",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "Read",
+							"arguments": `{"path":"/x"}`,
+						},
+					},
+				},
+			},
+			map[string]any{"role": "tool", "tool_call_id": "call_no_think", "content": "data"},
+		},
+	}
+
+	result := BuildGeminiGenerateContentRequestFromOpenAi(oaiBody, "gemini-2.5-flash")
+	fcParts := collectFunctionCallParts(result["contents"])
+	if len(fcParts) != 1 {
+		t.Fatalf("expected 1 functionCall part, got %d", len(fcParts))
+	}
+	if _, ok := fcParts[0]["thoughtSignature"]; ok {
+		t.Fatalf("did not expect thoughtSignature when thinking disabled on gemini-2.5, got %v", fcParts[0]["thoughtSignature"])
+	}
+}
+
+func TestBuildGeminiGenerateContentRequestFromOpenAi_NonGeminiNoDummyDisablesThinking(t *testing.T) {
+	oaiBody := map[string]any{
+		"model":            "claude-sonnet-4-5",
+		"reasoning_effort": "high",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Do something."},
+			map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_no_sig_non_gemini",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "Bash",
+							"arguments": `{"command":"ls"}`,
+						},
+					},
+				},
+			},
+			map[string]any{"role": "tool", "tool_call_id": "call_no_sig_non_gemini", "content": "file1\nfile2"},
+		},
+	}
+
+	result := BuildGeminiGenerateContentRequestFromOpenAi(oaiBody, "claude-sonnet-4-5")
+	fcParts := collectFunctionCallParts(result["contents"])
+	if len(fcParts) != 1 {
+		t.Fatalf("expected 1 functionCall part, got %d", len(fcParts))
+	}
+	if _, ok := fcParts[0]["thoughtSignature"]; ok {
+		t.Fatalf("did not expect dummy signature for non-gemini model, got %v", fcParts[0]["thoughtSignature"])
+	}
+	if gc, ok := result["generationConfig"].(map[string]any); ok {
+		if _, hasTC := gc["thinkingConfig"]; hasTC {
+			t.Fatalf("expected thinkingConfig disabled for non-gemini missing signature, got %#v", gc["thinkingConfig"])
+		}
+	}
+}
+
+func TestBuildGeminiGenerateContentRequestFromOpenAi_MultiTurnToolHistoryPreservesSignatures(t *testing.T) {
+	oaiBody := map[string]any{
+		"model": "gemini-3.5-flash",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Read two files."},
+			map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_a",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "Read",
+							"arguments": `{"path":"/a"}`,
+						},
+						"provider_specific_fields": map[string]any{"thought_signature": "sig_a"},
+					},
+					map[string]any{
+						"id":   "call_b",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "Read",
+							"arguments": `{"path":"/b"}`,
+						},
+						"provider_specific_fields": map[string]any{"thought_signature": "sig_b"},
+					},
+				},
+			},
+			map[string]any{"role": "tool", "tool_call_id": "call_a", "content": "content a"},
+			map[string]any{"role": "tool", "tool_call_id": "call_b", "content": "content b"},
+			map[string]any{"role": "user", "content": "Summarize them."},
+		},
+	}
+
+	result := BuildGeminiGenerateContentRequestFromOpenAi(oaiBody, "gemini-3.5-flash")
+	fcParts := collectFunctionCallParts(result["contents"])
+	if len(fcParts) != 2 {
+		t.Fatalf("expected 2 functionCall parts, got %d", len(fcParts))
+	}
+	sigs := map[string]bool{}
+	for _, p := range fcParts {
+		sig, _ := p["thoughtSignature"].(string)
+		sigs[sig] = true
+	}
+	if !sigs["sig_a"] || !sigs["sig_b"] {
+		t.Fatalf("expected multi-turn signatures preserved, got %#v", sigs)
+	}
+}
+
+func TestBuildOpenAiBodyFromGeminiRequest_PreservesThoughtSignatureInProviderFields(t *testing.T) {
+	geminiBody := map[string]any{
+		"model": "gemini-3.5-flash",
+		"contents": []any{
+			map[string]any{
+				"role": "user",
+				"parts": []any{
+					map[string]any{"text": "Get weather"},
+				},
+			},
+			map[string]any{
+				"role": "model",
+				"parts": []any{
+					map[string]any{
+						"functionCall": map[string]any{
+							"id":   "call_weather",
+							"name": "get_weather",
+							"args": map[string]any{"city": "SF"},
+						},
+						"thoughtSignature": "stream_sig_1",
+					},
+				},
+			},
+		},
+	}
+
+	oaiBody := BuildOpenAiBodyFromGeminiRequest(geminiBody, "")
+	msgs, ok := oaiBody["messages"].([]map[string]any)
+	if !ok {
+		t.Fatalf("messages type = %T", oaiBody["messages"])
+	}
+	var toolCalls []any
+	for _, msg := range msgs {
+		if tcs, ok := msg["tool_calls"].([]map[string]any); ok {
+			for _, tc := range tcs {
+				toolCalls = append(toolCalls, tc)
+			}
+		} else if tcs, ok := msg["tool_calls"].([]any); ok {
+			toolCalls = append(toolCalls, tcs...)
+		}
+	}
+	if len(toolCalls) != 1 {
+		// BuildOpenAiBody uses []map[string]any for tool_calls.
+		for _, msg := range msgs {
+			if tcs, ok := msg["tool_calls"].([]map[string]any); ok {
+				if len(tcs) != 1 {
+					t.Fatalf("expected 1 tool_call, got %d in %#v", len(tcs), msgs)
+				}
+				psf, _ := tcs[0]["provider_specific_fields"].(map[string]any)
+				if psf == nil || psf["thought_signature"] != "stream_sig_1" {
+					t.Fatalf("expected preserved thought_signature, got %#v", tcs[0])
+				}
+				return
+			}
+		}
+		t.Fatalf("tool_calls missing in %#v", msgs)
+	}
+}
+
+func TestNormalizeRequest_InjectsDummyThoughtSignatureForGemini3ToolHistory(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-3.5-flash",
+		"contents": []any{
+			map[string]any{
+				"role": "user",
+				"parts": []any{map[string]any{"text": "List files."}},
+			},
+			map[string]any{
+				"role": "model",
+				"parts": []any{
+					map[string]any{
+						"functionCall": map[string]any{
+							"name": "ls",
+							"args": map[string]any{"path": "/tmp"},
+						},
+					},
+				},
+			},
+			map[string]any{
+				"role": "user",
+				"parts": []any{
+					map[string]any{
+						"functionResponse": map[string]any{
+							"name":     "ls",
+							"response": map[string]any{"result": "a\nb"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	normalized := NormalizeRequest(body, "gemini-3.5-flash")
+	fcParts := collectFunctionCallParts(normalized["contents"])
+	if len(fcParts) != 1 {
+		t.Fatalf("expected 1 functionCall part, got %d", len(fcParts))
+	}
+	if fcParts[0]["thoughtSignature"] != DummyThoughtSignature {
+		t.Fatalf("expected dummy signature injected into native contents, got %v", fcParts[0]["thoughtSignature"])
+	}
+}
+
+func TestNormalizeRequest_PreservesExistingThoughtSignature(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-3.5-flash",
+		"contents": []any{
+			map[string]any{
+				"role": "model",
+				"parts": []any{
+					map[string]any{
+						"functionCall": map[string]any{
+							"name": "ls",
+							"args": map[string]any{},
+						},
+						"thoughtSignature": "keep_me",
+					},
+				},
+			},
+		},
+	}
+
+	normalized := NormalizeRequest(body, "gemini-3.5-flash")
+	fcParts := collectFunctionCallParts(normalized["contents"])
+	if len(fcParts) != 1 {
+		t.Fatalf("expected 1 functionCall part, got %d", len(fcParts))
+	}
+	if fcParts[0]["thoughtSignature"] != "keep_me" {
+		t.Fatalf("expected existing signature preserved, got %v", fcParts[0]["thoughtSignature"])
+	}
+}
+
+func TestStreamBridge_CollectsThoughtSignatures(t *testing.T) {
+	sb := NewStreamBridge("gemini-3.5-flash")
+	payload := map[string]any{
+		"responseId": "resp_sig",
+		"candidates": []any{
+			map[string]any{
+				"content": map[string]any{
+					"role": "model",
+					"parts": []any{
+						map[string]any{
+							"functionCall": map[string]any{
+								"id":   "call_1",
+								"name": "read",
+								"args": map[string]any{"path": "/tmp"},
+							},
+							"thoughtSignature": "stream_sig_xyz",
+						},
+					},
+				},
+			},
+		},
+	}
+	sb.NormalizeEvent(payload)
+	if len(sb.State.ThoughtSignatures) != 1 || sb.State.ThoughtSignatures[0] != "stream_sig_xyz" {
+		t.Fatalf("expected stream collected signature, got %#v", sb.State.ThoughtSignatures)
+	}
+}
+
+func TestApplyThoughtSignaturesToFunctionCallParts_RoundTripFromAggregate(t *testing.T) {
+	prior := &GeminiAggregateState{
+		ThoughtSignatures: []string{"agg_sig_1"},
+	}
+	parts := []map[string]any{
+		{
+			"functionCall": map[string]any{
+				"name": "read",
+				"args": map[string]any{"path": "/tmp"},
+			},
+		},
+	}
+	signed := ApplyThoughtSignaturesToFunctionCallParts(parts, "gemini-3.5-flash", prior)
+	if signed[0]["thoughtSignature"] != "agg_sig_1" {
+		t.Fatalf("expected aggregate signature applied, got %v", signed[0]["thoughtSignature"])
+	}
+
+	// Follow-up request content built from aggregate signatures should not be rejectable.
+	content := BuildSignedModelContentForToolHistory(parts, "gemini-3.5-flash", prior)
+	if content["role"] != "model" {
+		t.Fatalf("expected model role, got %v", content["role"])
+	}
+	contentParts, _ := content["parts"].([]map[string]any)
+	if contentParts[0]["thoughtSignature"] != "agg_sig_1" {
+		t.Fatalf("expected signed model content, got %#v", contentParts)
+	}
+}
+
+func TestOpenAiGeminiToolHistoryRoundTrip_PreservesThoughtSignature(t *testing.T) {
+	// Gemini response parts with signature -> OpenAI tool_calls provider fields -> next Gemini request.
+	geminiBody := map[string]any{
+		"model": "gemini-3.5-flash",
+		"contents": []any{
+			map[string]any{
+				"role":  "user",
+				"parts": []any{map[string]any{"text": "List files."}},
+			},
+			map[string]any{
+				"role": "model",
+				"parts": []any{
+					map[string]any{
+						"functionCall": map[string]any{
+							"id":   "call_read",
+							"name": "read",
+							"args": map[string]any{"path": "/tmp/a"},
+						},
+						"thoughtSignature": "roundtrip_sig",
+					},
+				},
+			},
+			map[string]any{
+				"role": "user",
+				"parts": []any{
+					map[string]any{
+						"functionResponse": map[string]any{
+							"id":       "call_read",
+							"name":     "read",
+							"response": map[string]any{"result": "file content"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	oai := BuildOpenAiBodyFromGeminiRequest(geminiBody, "gemini-3.5-flash")
+	// Ensure messages is []any for the reverse converter (which type-asserts []any).
+	msgs, ok := oai["messages"].([]map[string]any)
+	if !ok {
+		t.Fatalf("messages type = %T", oai["messages"])
+	}
+	asAny := make([]any, 0, len(msgs))
+	for _, m := range msgs {
+		// Normalize nested tool_calls to []any for reverse conversion.
+		if tcs, ok := m["tool_calls"].([]map[string]any); ok {
+			nested := make([]any, 0, len(tcs))
+			for _, tc := range tcs {
+				nested = append(nested, tc)
+			}
+			m["tool_calls"] = nested
+		}
+		asAny = append(asAny, m)
+	}
+	oai["messages"] = asAny
+	// Append a follow-up user turn so this looks like a multi-turn tool-history request.
+	oai["messages"] = append(asAny, map[string]any{"role": "user", "content": "Thanks, continue."})
+
+	nextGemini := BuildGeminiGenerateContentRequestFromOpenAi(oai, "gemini-3.5-flash")
+	fcParts := collectFunctionCallParts(nextGemini["contents"])
+	if len(fcParts) != 1 {
+		t.Fatalf("expected 1 functionCall on follow-up, got %d (%#v)", len(fcParts), nextGemini["contents"])
+	}
+	if fcParts[0]["thoughtSignature"] != "roundtrip_sig" {
+		t.Fatalf("expected round-trip thoughtSignature, got %v", fcParts[0]["thoughtSignature"])
+	}
+}


### PR DESCRIPTION
## Summary
- Inject/preserve Gemini `thoughtSignature` on multi-turn `functionCall` tool history so official Gemini (esp. 3.x) does not reject OpenAI-compatible or native generateContent follow-ups.
- Stream aggregate collects signatures; next-request helpers re-attach real or safe dummy signatures; Gemini↔OpenAI bridge preserves `provider_specific_fields.thought_signature`.
- Document model caveats in `docs/analysis/gemini-thought-signature.md`.

Closes #47

## Upstream
- cita-777/metapi#580 / #581

## Test plan
- [x] `go test ./transform/gemini/... -count=1`
- [x] Fixtures for Gemini 3 dummy inject, real signature preserve, text/functionCall split, multi-turn round-trip, stream collect, native NormalizeRequest inject