### PR TITLE
fix(proxy): /v1/models response shape parity #53

### DIFF
--- a/docs/analysis/models-response-shape.md
+++ b/docs/analysis/models-response-shape.md
@@ -1,0 +1,131 @@
+# `/v1/models` response shape
+
+> Date: 2026-07-17  
+> Issue: TokenDanceLab/metapi-go #53 (upstream cita-777/metapi #507)  
+> Scope: proxy surface `handler/proxy/models.go`
+
+## Purpose
+
+Document the **owned MetAPI listing** returned by `GET /v1/models`, how it differs from **live upstream** model listing, and the client-facing fields required for OpenAI / Claude / Hermes-class clients.
+
+## Endpoint
+
+| Item | Value |
+|------|--------|
+| Path | `GET /v1/models` |
+| Auth | Proxy auth (`Authorization: Bearer …` or managed key middleware) |
+| Handler | `handler/proxy/models.go` → `HandleModels` |
+| Format selection | Claude when `anthropic-version` **or** `x-api-key` is present; otherwise OpenAI |
+
+## Owned vs upstream listing
+
+| Mode | What it is | Status in metapi-go |
+|------|------------|---------------------|
+| **Owned listing** (current) | MetAPI constructs the list itself from an owned catalog (stub today) filtered by downstream routing policy (`SupportedModels` / deny-all / route-id constraints). `owned_by` is always `"metapi"`. | **Implemented** |
+| **Upstream listing** | Proxy or merge of each site/account’s native `/v1/models` (or platform equivalent), including vendor `context_length` / `max_model_len` when present. | **Not implemented** on this surface. Route rebuild / platform model refresh populate routes elsewhere; this handler does **not** currently call `TokenRouter.GetAvailableModels` or pass through upstream payloads. |
+
+Implications:
+
+1. Clients always see a MetAPI-owned OpenAI/Claude envelope, not a raw vendor body.
+2. Model IDs are the names MetAPI is willing to route (catalog ∩ policy), not necessarily a complete dump of every upstream account’s models.
+3. `owned_by: "metapi"` intentionally avoids vendor-specific client branches (e.g. Hermes’ `owned_by == "llamacpp"` → `/v1/props` path).
+
+Future hardening (out of this issue’s code scope unless reopened):
+
+- Wire `TokenRouter.GetAvailableModels` + channel resolvability (upstream metapi `listModelsSurface` behavior).
+- Prefer `token_routes.context_length` (SC2 additive column) over built-in defaults when set.
+- Optionally merge per-site discovered context metadata from platform model refresh.
+
+## OpenAI-compatible shape (default)
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "gpt-4o",
+      "object": "model",
+      "created": 1710000000,
+      "owned_by": "metapi",
+      "context_length": 128000
+    }
+  ]
+}
+```
+
+### Required fields (product clients)
+
+| Field | Location | Notes |
+|-------|----------|--------|
+| `object` | top | always `"list"` (including empty `data`) |
+| `data` | top | array (may be empty under deny-all / filtered policy) |
+| `id` | item | model identifier |
+| `object` | item | always `"model"` |
+| `created` | item | Unix seconds (`int`); request-time stamp for owned catalog |
+| `owned_by` | item | always `"metapi"` for owned listing |
+
+### Optional fields
+
+| Field | Location | Notes |
+|-------|----------|--------|
+| `context_length` | item | Token window when known. Omitted for unknown/custom IDs so clients can fall back to their own defaults/probes. |
+
+`context_length` addresses upstream #507 / Hermes auto-detection: Hermes and similar agents scan `/v1/models` for keys such as `context_length`, `max_model_len`, `n_ctx`, etc. MetAPI emits the common OpenRouter-style key `context_length` for known catalog models.
+
+## Claude-compatible shape
+
+Triggered by either:
+
+- `anthropic-version: …`
+- `x-api-key: …` (without requiring Anthropic version)
+
+```json
+{
+  "data": [
+    {
+      "id": "claude-sonnet-4-20250514",
+      "type": "model",
+      "display_name": "claude-sonnet-4-20250514",
+      "created_at": "2026-03-19T00:00:00Z"
+    }
+  ],
+  "first_id": "claude-sonnet-4-20250514",
+  "last_id": "claude-sonnet-4-20250514",
+  "has_more": false
+}
+```
+
+Notes:
+
+- No top-level `object: "list"` (OpenAI-only).
+- Pagination fields mirror Anthropic Models API / upstream metapi `modelsSurface` (`first_id`, `last_id`, `has_more`).
+- Empty list: `data: []`, `first_id: null`, `last_id: null`, `has_more: false`.
+
+## Policy filtering
+
+| Policy | Listing behavior |
+|--------|------------------|
+| Empty allow-all | Full owned catalog |
+| `DenyAllWhenEmpty` with no supported models / routes | Empty `data` |
+| `SupportedModels` patterns | Catalog filtered by wildcard/exact match |
+| `AllowedRouteIDs` only (no supported models) | Empty until route-aware listing is wired |
+
+## Client quirks
+
+| Client / class | Quirk | MetAPI behavior |
+|----------------|-------|-----------------|
+| OpenAI SDKs / LiteLLM | Expect `object` + `data[].object` + `owned_by` | Always present on OpenAI path |
+| Hermes / similar agents | Read `context_length` (and aliases) from `/v1/models`; treat `owned_by: "llamacpp"` specially | Emit `context_length` when known; `owned_by` is `"metapi"` (not llamacpp) |
+| Claude Code / Anthropic SDKs | Prefer Models API fields (`type`, `display_name`, pagination) | Claude path when Anthropic headers present |
+| Empty catalog | Some UIs break on missing `data` | Always return `data` array |
+
+## Tests
+
+- Unit: `handler/proxy/models_test.go` (`TestBuildOpenAIModelsResponse*`, `TestBuildClaudeModelsResponse*`, `TestHandleModels_*`)
+- E2E: `e2e/e2e_flow_test.go` Phase 5 asserts OpenAI required fields including `owned_by` / `created`
+
+## References
+
+- Upstream issue: [cita-777/metapi#507](https://github.com/cita-777/metapi/issues/507)
+- Upstream surface: `src/server/proxy-core/surfaces/modelsSurface.ts`
+- Schema home for future route context: `store.TokenRoute.ContextLength` / `token_routes.context_length`

--- a/e2e/e2e_flow_test.go
+++ b/e2e/e2e_flow_test.go
@@ -251,7 +251,8 @@ func TestSiteCreateToProxyFlow(t *testing.T) {
 		t.Fatalf("GET /v1/models: failed to parse response: %v", err)
 	}
 
-	// Verify OpenAI models format.
+	// Verify OpenAI models format (id/object/created/owned_by; optional context_length).
+	// See docs/analysis/models-response-shape.md (#53 / upstream #507).
 	if obj, _ := modelsResp["object"].(string); obj != "list" {
 		t.Errorf("GET /v1/models: expected object='list', got %q", obj)
 	}
@@ -265,11 +266,21 @@ func TestSiteCreateToProxyFlow(t *testing.T) {
 				t.Errorf("GET /v1/models: data[%d] is not an object", i)
 				continue
 			}
-			if _, hasID := modelEntry["id"]; !hasID {
-				t.Errorf("GET /v1/models: data[%d] missing 'id' field", i)
+			if id, _ := modelEntry["id"].(string); id == "" {
+				t.Errorf("GET /v1/models: data[%d] missing non-empty 'id' field", i)
 			}
 			if obj, _ := modelEntry["object"].(string); obj != "model" {
 				t.Errorf("GET /v1/models: data[%d] expected object='model', got %q", i, obj)
+			}
+			if ownedBy, _ := modelEntry["owned_by"].(string); ownedBy != "metapi" {
+				t.Errorf("GET /v1/models: data[%d] expected owned_by='metapi', got %q", i, ownedBy)
+			}
+			if _, hasCreated := modelEntry["created"]; !hasCreated {
+				t.Errorf("GET /v1/models: data[%d] missing 'created' field", i)
+			}
+			// Owned catalog models should advertise context_length for Hermes-class clients.
+			if _, hasCtx := modelEntry["context_length"]; !hasCtx {
+				t.Errorf("GET /v1/models: data[%d] missing 'context_length' for owned catalog model %v", i, modelEntry["id"])
 			}
 		}
 		t.Logf("GET /v1/models: returned %d models", len(data))

--- a/handler/proxy/models.go
+++ b/handler/proxy/models.go
@@ -8,6 +8,11 @@ import (
 	"github.com/tokendancelab/metapi-go/auth"
 )
 
+// modelsOwnedBy is the OpenAI-compatible owned_by value for MetAPI-owned listings.
+// Clients that special-case owned_by (e.g. Hermes llama.cpp detection) treat this
+// as a generic OpenAI-compatible gateway, not llamacpp.
+const modelsOwnedBy = "metapi"
+
 // HandleModels handles GET /v1/models.
 // Returns model list in OpenAI or Claude format based on request headers.
 func HandleModels(w http.ResponseWriter, r *http.Request) {
@@ -20,27 +25,37 @@ func HandleModels(w http.ResponseWriter, r *http.Request) {
 	// Detect response format: if anthropic-version or x-api-key header present → Claude format
 	wantsClaude := r.Header.Get("anthropic-version") != "" || r.Header.Get("x-api-key") != ""
 
-	// Build model list
+	// Build model list (MetAPI-owned listing; see docs/analysis/models-response-shape.md)
 	models := getAvailableModels(authCtx.Policy)
+	now := time.Now().UTC()
 
 	if wantsClaude {
-		writeJSON(w, 200, buildClaudeModelsResponse(models))
+		writeJSON(w, 200, buildClaudeModelsResponse(models, now))
 	} else {
-		writeJSON(w, 200, buildOpenAIModelsResponse(models))
+		writeJSON(w, 200, buildOpenAIModelsResponse(models, now))
 	}
 }
 
-// buildOpenAIModelsResponse builds OpenAI-format models response.
-func buildOpenAIModelsResponse(models []string) map[string]any {
+// buildOpenAIModelsResponse builds OpenAI-format models response:
+//
+//	{ "object": "list", "data": [ { "id", "object":"model", "created", "owned_by", ... } ] }
+//
+// Optional context_length is included when known so OpenAI-compatible clients
+// (Hermes and similar) can auto-detect context windows from /v1/models.
+func buildOpenAIModelsResponse(models []string, now time.Time) map[string]any {
 	items := make([]map[string]any, 0, len(models))
-	now := time.Now().Unix()
+	created := now.Unix()
 	for _, m := range models {
-		items = append(items, map[string]any{
+		item := map[string]any{
 			"id":       m,
 			"object":   "model",
-			"created":  now,
-			"owned_by": "metapi",
-		})
+			"created":  created,
+			"owned_by": modelsOwnedBy,
+		}
+		if ctxLen, ok := knownModelContextLength(m); ok {
+			item["context_length"] = ctxLen
+		}
+		items = append(items, item)
 	}
 	return map[string]any{
 		"object": "list",
@@ -48,23 +63,45 @@ func buildOpenAIModelsResponse(models []string) map[string]any {
 	}
 }
 
-// buildClaudeModelsResponse builds Claude-format models response.
-func buildClaudeModelsResponse(models []string) map[string]any {
+// buildClaudeModelsResponse builds Claude-format models response matching
+// Anthropic Models API pagination fields used by upstream metapi:
+//
+//	{ "data": [...], "first_id", "last_id", "has_more": false }
+func buildClaudeModelsResponse(models []string, now time.Time) map[string]any {
 	items := make([]map[string]any, 0, len(models))
+	createdAt := now.UTC().Format(time.RFC3339Nano)
+	// Prefer millisecond precision like upstream ISO strings; trim trailing zeros noise
+	// by using RFC3339 when nanoseconds are zero.
+	if now.Nanosecond() == 0 {
+		createdAt = now.UTC().Format(time.RFC3339)
+	}
 	for _, m := range models {
 		items = append(items, map[string]any{
 			"id":           m,
 			"display_name": m,
 			"type":         "model",
+			"created_at":   createdAt,
 		})
 	}
+
+	var firstID any = nil
+	var lastID any = nil
+	if len(models) > 0 {
+		firstID = models[0]
+		lastID = models[len(models)-1]
+	}
+
 	return map[string]any{
-		"data": items,
+		"data":      items,
+		"first_id":  firstID,
+		"last_id":   lastID,
+		"has_more":  false,
 	}
 }
 
 // getAvailableModels returns the list of available model names.
-// Stub: returns common model names.
+// This is the MetAPI-owned listing path (not a live upstream /v1/models proxy).
+// Stub: returns common model names until tokenRouter-backed listing is wired here.
 func getAvailableModels(policy auth.DownstreamRoutingPolicy) []string {
 	// Stub model list. In production, this queries the tokenRouter.
 	models := []string{
@@ -94,6 +131,47 @@ func getAvailableModels(policy auth.DownstreamRoutingPolicy) []string {
 		}
 	}
 	return filtered
+}
+
+// knownModelContextLength returns a published context window for well-known models
+// in the owned listing. Unknown models omit the field (clients fall back to their
+// own defaults/probes). Values are token counts, not bytes.
+//
+// When route-level token_routes.context_length is wired into this handler, that
+// value should take precedence over these defaults.
+func knownModelContextLength(model string) (int64, bool) {
+	// Exact matches first for the owned stub catalog.
+	switch model {
+	case "gpt-4o", "gpt-4o-mini", "gpt-4-turbo":
+		return 128000, true
+	case "gpt-3.5-turbo":
+		return 16385, true
+	case "claude-sonnet-4-20250514", "claude-3-5-sonnet-latest":
+		return 200000, true
+	case "gemini-2.5-pro", "gemini-2.5-flash":
+		return 1048576, true
+	}
+
+	// Light prefix heuristics for common families so managed-key wildcards still
+	// surface a usable context_length for OpenAI-compatible clients.
+	lower := strings.ToLower(model)
+	switch {
+	case strings.HasPrefix(lower, "gpt-4o"),
+		strings.HasPrefix(lower, "gpt-4-turbo"),
+		strings.HasPrefix(lower, "gpt-4.1"),
+		strings.HasPrefix(lower, "o1"),
+		strings.HasPrefix(lower, "o3"),
+		strings.HasPrefix(lower, "o4"):
+		return 128000, true
+	case strings.HasPrefix(lower, "gpt-3.5"):
+		return 16385, true
+	case strings.HasPrefix(lower, "claude-"):
+		return 200000, true
+	case strings.HasPrefix(lower, "gemini-"):
+		return 1048576, true
+	default:
+		return 0, false
+	}
 }
 
 // IsModelAllowedByPolicy checks if a model is allowed by the downstream policy.

--- a/handler/proxy/models_test.go
+++ b/handler/proxy/models_test.go
@@ -3,6 +3,7 @@ package proxyhandler
 import (
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/tokendancelab/metapi-go/auth"
 )
@@ -83,7 +84,8 @@ func TestIsModelAllowedByPolicy(t *testing.T) {
 
 func TestBuildOpenAIModelsResponse(t *testing.T) {
 	models := []string{"gpt-4o", "gpt-3.5-turbo"}
-	resp := buildOpenAIModelsResponse(models)
+	fixed := time.Date(2026, 3, 19, 0, 0, 0, 0, time.UTC)
+	resp := buildOpenAIModelsResponse(models, fixed)
 
 	if resp["object"] != "list" {
 		t.Errorf("object = %v", resp["object"])
@@ -98,31 +100,69 @@ func TestBuildOpenAIModelsResponse(t *testing.T) {
 	if data[0]["object"] != "model" {
 		t.Errorf("object = %v", data[0]["object"])
 	}
-	if data[0]["owned_by"] != "metapi" {
-		t.Errorf("owned_by = %v", data[0]["owned_by"])
+	if data[0]["owned_by"] != modelsOwnedBy {
+		t.Errorf("owned_by = %v, want %q", data[0]["owned_by"], modelsOwnedBy)
 	}
-	if _, ok := data[0]["created"]; !ok {
-		t.Error("missing created field")
+	created, ok := data[0]["created"].(int64)
+	if !ok {
+		// JSON builder may keep int; accept both
+		if createdInt, okInt := data[0]["created"].(int); okInt {
+			created = int64(createdInt)
+			ok = true
+		}
+	}
+	if !ok {
+		t.Fatalf("created type = %T, want int/int64", data[0]["created"])
+	}
+	if created != fixed.Unix() {
+		t.Errorf("created = %d, want %d", created, fixed.Unix())
+	}
+	if data[0]["context_length"] != int64(128000) {
+		t.Errorf("gpt-4o context_length = %v, want 128000", data[0]["context_length"])
+	}
+	if data[1]["context_length"] != int64(16385) {
+		t.Errorf("gpt-3.5-turbo context_length = %v, want 16385", data[1]["context_length"])
 	}
 }
 
 func TestBuildOpenAIModelsResponse_Empty(t *testing.T) {
-	resp := buildOpenAIModelsResponse([]string{})
+	resp := buildOpenAIModelsResponse([]string{}, time.Unix(0, 0).UTC())
+	if resp["object"] != "list" {
+		t.Errorf("empty list must still set object=list, got %v", resp["object"])
+	}
 	data, _ := resp["data"].([]map[string]any)
 	if len(data) != 0 {
 		t.Errorf("expected 0 models, got %d", len(data))
 	}
 }
 
+func TestBuildOpenAIModelsResponse_UnknownModelOmitsContextLength(t *testing.T) {
+	resp := buildOpenAIModelsResponse([]string{"custom-vendor/my-model"}, time.Unix(1, 0).UTC())
+	data, _ := resp["data"].([]map[string]any)
+	if len(data) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(data))
+	}
+	if _, ok := data[0]["context_length"]; ok {
+		t.Errorf("unknown model should omit context_length, got %v", data[0]["context_length"])
+	}
+	if data[0]["owned_by"] != modelsOwnedBy {
+		t.Errorf("owned_by = %v", data[0]["owned_by"])
+	}
+	if data[0]["object"] != "model" {
+		t.Errorf("object = %v", data[0]["object"])
+	}
+}
+
 // ---- buildClaudeModelsResponse ----
 
 func TestBuildClaudeModelsResponse(t *testing.T) {
-	models := []string{"claude-sonnet-4-20250514"}
-	resp := buildClaudeModelsResponse(models)
+	models := []string{"claude-sonnet-4-20250514", "claude-3-5-sonnet-latest"}
+	fixed := time.Date(2026, 3, 19, 0, 0, 0, 0, time.UTC)
+	resp := buildClaudeModelsResponse(models, fixed)
 
 	data, _ := resp["data"].([]map[string]any)
-	if len(data) != 1 {
-		t.Errorf("expected 1 model, got %d", len(data))
+	if len(data) != 2 {
+		t.Errorf("expected 2 models, got %d", len(data))
 	}
 	if data[0]["id"] != "claude-sonnet-4-20250514" {
 		t.Errorf("id = %v", data[0]["id"])
@@ -132,6 +172,35 @@ func TestBuildClaudeModelsResponse(t *testing.T) {
 	}
 	if data[0]["type"] != "model" {
 		t.Errorf("type = %v", data[0]["type"])
+	}
+	if data[0]["created_at"] != "2026-03-19T00:00:00Z" {
+		t.Errorf("created_at = %v, want 2026-03-19T00:00:00Z", data[0]["created_at"])
+	}
+	if resp["first_id"] != "claude-sonnet-4-20250514" {
+		t.Errorf("first_id = %v", resp["first_id"])
+	}
+	if resp["last_id"] != "claude-3-5-sonnet-latest" {
+		t.Errorf("last_id = %v", resp["last_id"])
+	}
+	if resp["has_more"] != false {
+		t.Errorf("has_more = %v, want false", resp["has_more"])
+	}
+}
+
+func TestBuildClaudeModelsResponse_Empty(t *testing.T) {
+	resp := buildClaudeModelsResponse([]string{}, time.Unix(0, 0).UTC())
+	data, _ := resp["data"].([]map[string]any)
+	if len(data) != 0 {
+		t.Fatalf("expected empty data, got %v", data)
+	}
+	if resp["first_id"] != nil {
+		t.Errorf("first_id = %v, want nil", resp["first_id"])
+	}
+	if resp["last_id"] != nil {
+		t.Errorf("last_id = %v, want nil", resp["last_id"])
+	}
+	if resp["has_more"] != false {
+		t.Errorf("has_more = %v, want false", resp["has_more"])
 	}
 }
 
@@ -196,6 +265,21 @@ func TestGetAvailableModelsAppliesManagedPolicy(t *testing.T) {
 	}
 }
 
+func TestKnownModelContextLength(t *testing.T) {
+	if got, ok := knownModelContextLength("gpt-4o"); !ok || got != 128000 {
+		t.Fatalf("gpt-4o = (%d,%v), want (128000,true)", got, ok)
+	}
+	if got, ok := knownModelContextLength("claude-sonnet-4-20250514"); !ok || got != 200000 {
+		t.Fatalf("claude = (%d,%v), want (200000,true)", got, ok)
+	}
+	if got, ok := knownModelContextLength("gemini-2.5-flash"); !ok || got != 1048576 {
+		t.Fatalf("gemini = (%d,%v), want (1048576,true)", got, ok)
+	}
+	if _, ok := knownModelContextLength("vendor/unknown-model"); ok {
+		t.Fatal("unknown model should not report context_length")
+	}
+}
+
 // ---- HandleModels ----
 
 func TestHandleModels_OpenAIFormat(t *testing.T) {
@@ -218,7 +302,27 @@ func TestHandleModels_OpenAIFormat(t *testing.T) {
 	}
 	data, _ := m["data"].([]any)
 	if len(data) == 0 {
-		t.Error("expected non-empty model list")
+		t.Fatal("expected non-empty model list")
+	}
+	first := data[0].(map[string]any)
+	if first["id"] == nil || first["id"] == "" {
+		t.Errorf("missing id: %v", first)
+	}
+	if first["object"] != "model" {
+		t.Errorf("object = %v, want model", first["object"])
+	}
+	if first["owned_by"] != modelsOwnedBy {
+		t.Errorf("owned_by = %v, want %q", first["owned_by"], modelsOwnedBy)
+	}
+	if first["created"] == nil {
+		t.Error("missing created field")
+	}
+	// JSON numbers decode as float64
+	if _, ok := first["created"].(float64); !ok {
+		t.Errorf("created type = %T, want number", first["created"])
+	}
+	if first["context_length"] == nil {
+		t.Errorf("expected context_length on owned catalog model: %v", first)
 	}
 }
 
@@ -243,9 +347,24 @@ func TestHandleModels_ClaudeFormat(t *testing.T) {
 		t.Error("expected non-empty model list")
 	}
 	// Claude format: should have data array, no "object" field with "list"
+	if obj, ok := m["object"]; ok {
+		t.Errorf("Claude format should not set object=list, got object=%v", obj)
+	}
 	first := data[0].(map[string]any)
 	if first["type"] != "model" {
 		t.Errorf("Claude format missing 'type: model': %v", first)
+	}
+	if first["created_at"] == nil || first["created_at"] == "" {
+		t.Errorf("Claude format missing created_at: %v", first)
+	}
+	if m["has_more"] != false {
+		t.Errorf("has_more = %v, want false", m["has_more"])
+	}
+	if m["first_id"] == nil {
+		t.Error("missing first_id")
+	}
+	if m["last_id"] == nil {
+		t.Error("missing last_id")
 	}
 }
 
@@ -267,6 +386,12 @@ func TestHandleModels_XApiKeyFormat(t *testing.T) {
 	m := unmarshalResponse(t, rec)
 	if _, ok := m["data"]; !ok {
 		t.Error("Claude format should have data field")
+	}
+	if _, ok := m["has_more"]; !ok {
+		t.Error("Claude format should include has_more pagination field")
+	}
+	if _, ok := m["object"]; ok {
+		t.Error("x-api-key path should not return OpenAI object=list")
 	}
 }
 
@@ -296,6 +421,9 @@ func TestHandleModelsFiltersManagedKeyPolicy(t *testing.T) {
 	if first["id"] != "gpt-4o" {
 		t.Fatalf("model id = %v, want gpt-4o", first["id"])
 	}
+	if first["owned_by"] != modelsOwnedBy {
+		t.Fatalf("owned_by = %v, want %q", first["owned_by"], modelsOwnedBy)
+	}
 }
 
 func TestHandleModelsDenyAllManagedPolicyReturnsEmptyList(t *testing.T) {
@@ -315,6 +443,9 @@ func TestHandleModelsDenyAllManagedPolicyReturnsEmptyList(t *testing.T) {
 	}
 
 	m := unmarshalResponse(t, rec)
+	if m["object"] != "list" {
+		t.Errorf("object = %v, want list", m["object"])
+	}
 	data, _ := m["data"].([]any)
 	if len(data) != 0 {
 		t.Fatalf("expected empty model list, got %#v", data)


### PR DESCRIPTION
## Summary
- Align `GET /v1/models` OpenAI envelope with client expectations: `object:"list"`, `data[]` items with `id`, `object:"model"`, `created`, `owned_by:"metapi"`.
- Add optional `context_length` for known owned-catalog models so Hermes-class clients can auto-detect context windows (upstream #507).
- Complete Claude format pagination fields (`created_at`, `first_id`, `last_id`, `has_more`) while preserving header-based format selection.
- Document owned vs upstream listing and client quirks in `docs/analysis/models-response-shape.md`.

Closes #53

## Test plan
- [x] `go test ./handler/proxy/ -run Models -count=1`
- [x] `go test ./e2e/ -run SiteCreateToProxyFlow -count=1`
- [x] pre-push hook: `go vet ./...` + `go test ./... -count=1 -race`