### PR TITLE
fix(responses): previous_response_id forward/strip/reject policy #54

### DIFF
--- a/docs/analysis/previous-response-id.md
+++ b/docs/analysis/previous-response-id.md
@@ -1,0 +1,102 @@
+# `previous_response_id` continuity policy (#54 / upstream #504)
+
+**Date:** 2026-07-17  
+**Lane:** feature / FE-PROTOCOL  
+**SSOT code:** `transform/openai/responses/previous_response_id.go`, `transform/openai/responses/compact.go`, `transform/canonical/openai_bridge.go` (`ApplyOpenAICompatibleContinuation` / `ApplyOpenAIResponsesContinuation`)
+
+## Problem
+
+Clients (notably Codex / Responses clients) send:
+
+```json
+{ "model": "...", "input": "...", "previous_response_id": "resp_..." }
+```
+
+Some upstreams accept the field (official OpenAI Responses, Azure OpenAI Responses, Codex). Many OpenAI-compatible relays and chat-only endpoints reject it with:
+
+```text
+HTTP 400: Unsupported parameter: previous_response_id
+```
+
+Before this fix:
+
+1. Compact sanitize stripped `stream` / `stream_options` / conditional `store` but **not** `previous_response_id`.
+2. Canonical → OpenAI **chat** body re-emitted `previous_response_id` via `ApplyOpenAICompatibleContinuation`.
+3. Claude → OpenAI chat conversion copied `previous_response_id` onto chat payloads.
+4. Multi-protocol path fallback could reuse a Responses JSON body against `/v1/chat/completions` with the field still present.
+
+## Policy (forward / strip / reject)
+
+| Target | Platform examples | Action | Reason |
+| --- | --- | --- | --- |
+| Responses | `openai`, `openai-responses`, `azure`, `azure-openai`, `codex` | **forward** | Official / Codex Responses continuity |
+| Responses | `sub2api`, NewAPI-family, empty/unknown | **strip** (default) | Avoid opaque 400; field unsupported |
+| Responses compact (`/v1/responses/compact`) | any | **strip** | Compact is not a stored-response continuation |
+| Chat (`/v1/chat/completions`) | any | **strip** | Chat Completions has no Responses continuity |
+| Messages (`/v1/messages`) | any | **strip** | Anthropic Messages has no `previous_response_id` |
+| Any of the strip cases with `RequireContinuity=true` | — | **reject** | Clear client error instead of upstream 400 |
+
+Default is **fail-open strip** when the field cannot be forwarded safely. Callers that must preserve multi-turn Responses state can set `RequireContinuity` and surface `ContinuityError` (clear `invalid_request_error` text).
+
+### API surface (SSOT)
+
+```go
+// transform/openai/responses
+ResolvePreviousResponseIDPolicy(input ContinuityPolicyInput) ContinuityDecision
+ApplyPreviousResponseIDPolicy(body, input) (body, decision, error)
+SanitizeResponsesRequestBody(body, input) (body, decision, error) // + compact stream/store sanitize
+SupportsResponsesPreviousResponseID(sitePlatform string) bool
+IsUnsupportedPreviousResponseIDError(rawErrText string) bool
+StripPreviousResponseID(body) map[string]any
+```
+
+```go
+// transform/canonical
+ApplyOpenAICompatibleContinuation(...)  // chat-shaped: NO previous_response_id
+ApplyOpenAIResponsesContinuation(...)   // responses-shaped: writes previous_response_id
+```
+
+## Compact / sanitize field matrix
+
+| Field | Normal Responses | Compact Responses | Chat / Messages fallback |
+| --- | --- | --- | --- |
+| `stream` | pass-through (codex/sub2api may force stream outside compact) | **strip** | n/a (chat uses own stream) |
+| `stream_options` | pass-through | **strip** | n/a |
+| `store` | pass-through | **strip** for `codex` / `sub2api` only | n/a |
+| `previous_response_id` | forward **or** strip per platform table | **always strip** | **always strip** |
+| `prompt_cache_key` | pass-through | pass-through | pass-through (chat-compatible) |
+| `model` / `input` / tools | pass-through | pass-through | protocol transform (separate) |
+
+Helpers:
+
+- `SanitizeCompactResponsesRequestBody` — compact-only field strip (includes `previous_response_id`).
+- `SanitizeResponsesRequestBody` — continuity policy + optional compact strip in one call.
+
+## Integration guidance (dispatch)
+
+Per upstream attempt (after channel selection, once `site.platform` and target path are known):
+
+1. Build attempt body (model swap, etc.).
+2. Call `SanitizeResponsesRequestBody` with:
+   - `SitePlatform = selected.Site.Platform`
+   - `Protocol` / `UpstreamPath` for this candidate (`responses` / `chat` / `messages`)
+   - `IsCompactRequest` when path ends with `/responses/compact`
+3. On `ContinuityReject`, return **400** `invalid_request_error` with `ContinuityError.Message` (do not forward).
+4. Optionally: if an upstream still returns `IsUnsupportedPreviousResponseIDError`, strip and retry once or fall through to the next protocol candidate **without** poisoning the channel.
+
+Canonical chat builders must keep using `ApplyOpenAICompatibleContinuation` only; Responses builders use `ApplyOpenAIResponsesContinuation`.
+
+## Acceptance mapping
+
+| Criterion | Status |
+| --- | --- |
+| accepted / stripped / translated per upstream capabilities | Policy table + `ResolvePreviousResponseIDPolicy` / `ApplyPreviousResponseIDPolicy` |
+| clear errors instead of opaque 400s | `ContinuityReject` + `ContinuityError`; chat no longer emits the field |
+| compact/sanitize policy documented | This file + compact matrix |
+| tests for presence / absence / strip | `transform/openai/responses/previous_response_id_test.go`, compact tests, canonical continuation tests |
+
+## Residual
+
+- Production multi-protocol dispatch should call `SanitizeResponsesRequestBody` **per candidate path** (same residual as #38 body transform). Until wired, library SSOT + chat emission strip still remove the most common opaque 400 paths (chat conversion + compact).
+- No server-side store of prior Responses payloads: strip does not reconstruct history from `previous_response_id`.
+- Translation of `previous_response_id` into Anthropic/Gemini session state is out of scope.

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tokendancelab/metapi-go/proxy"
 	"github.com/tokendancelab/metapi-go/routing"
 	"github.com/tokendancelab/metapi-go/service"
+	"github.com/tokendancelab/metapi-go/transform/openai/responses"
 )
 
 // UpstreamConfig holds the dependencies needed for upstream forwarding.
@@ -216,9 +217,15 @@ func dispatchSelectedUpstream(
 	var lastPending *pendingUpstreamFailure
 	for i, path := range candidatePaths {
 		isLast := i >= len(candidatePaths)-1
+		attemptBody, sanitizeErr := sanitizeUpstreamJSONBody(bodyBytes, selected.Site.Platform, path)
+		if sanitizeErr != nil {
+			// Clear client-facing continuity error (issue #54 / upstream #504).
+			writeJSONError(w, http.StatusBadRequest, sanitizeErr.Error(), "invalid_request_error")
+			return true, nil
+		}
 		finished, pending, cont := dispatchEndpointAttemptWithContinue(
 			w, r, ctx, cfg, selected, upstreamModel, proxyConfig,
-			path, contentType, bodyBytes, firstByteTimeoutMs,
+			path, contentType, attemptBody, firstByteTimeoutMs,
 			retry, maxRetries, isLast, disableCrossProtocolFallback,
 		)
 		if finished {
@@ -975,6 +982,52 @@ func handleNonStreamUpstream(w http.ResponseWriter, resp *http.Response, latency
 	}
 	w.WriteHeader(resp.StatusCode)
 	w.Write(bodyBytes)
+}
+
+// sanitizeUpstreamJSONBody applies Responses continuity/compact sanitization for one
+// upstream attempt. Chat/messages candidates strip previous_response_id; Responses
+// platforms forward or strip per SupportsResponsesPreviousResponseID.
+// See docs/analysis/previous-response-id.md (issue #54 / upstream #504).
+func sanitizeUpstreamJSONBody(bodyBytes []byte, sitePlatform, upstreamPath string) ([]byte, error) {
+	if len(bodyBytes) == 0 {
+		return bodyBytes, nil
+	}
+	// Cheap gate: only rewrite when continuity field or compact path is involved.
+	pathLower := strings.ToLower(upstreamPath)
+	needsCompact := strings.Contains(pathLower, "/responses/compact")
+	needsContinuity := bytes.Contains(bodyBytes, []byte(`"previous_response_id"`))
+	if !needsCompact && !needsContinuity {
+		return bodyBytes, nil
+	}
+	var body map[string]any
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		return bodyBytes, nil
+	}
+	protocol := responses.ProtocolUnknown
+	switch ep, ok := proxy.EndpointFromPath(upstreamPath); {
+	case ok && ep == proxy.EndpointChat:
+		protocol = responses.ProtocolChat
+	case ok && ep == proxy.EndpointMessages:
+		protocol = responses.ProtocolMessages
+	case ok && ep == proxy.EndpointResponses:
+		protocol = responses.ProtocolResponses
+	case needsCompact || strings.Contains(pathLower, "/responses"):
+		protocol = responses.ProtocolResponses
+	}
+	next, _, err := responses.SanitizeResponsesRequestBody(body, responses.ContinuityPolicyInput{
+		SitePlatform:     sitePlatform,
+		Protocol:         protocol,
+		UpstreamPath:     upstreamPath,
+		IsCompactRequest: needsCompact,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out, marshalErr := json.Marshal(next)
+	if marshalErr != nil {
+		return bodyBytes, nil
+	}
+	return out, nil
 }
 
 // swapModelInJSON performs a shallow JSON re-encode to replace the "model" field.

--- a/transform/canonical/openai_bridge.go
+++ b/transform/canonical/openai_bridge.go
@@ -939,6 +939,14 @@ func canonicalToolChoiceToOpenAI(tc *CanonicalToolChoice) any {
 }
 
 // ApplyOpenAICompatibleContinuation writes continuation fields into the body/metadata.
+//
+// previous_response_id is a Responses-API field. Chat Completions (and other
+// non-Responses OpenAI-compatible surfaces built by CanonicalRequestToOpenAiChatBody)
+// must not receive it — many upstreams return HTTP 400
+// "Unsupported parameter: previous_response_id". Continuity is still preserved
+// on the canonical envelope (ReadOpenAICompatibleContinuation /
+// CanonicalContinuation.PreviousResponseID) and re-emitted only when building a
+// Responses body via ApplyOpenAIResponsesContinuation.
 func ApplyOpenAICompatibleContinuation(body map[string]any, cont *CanonicalContinuation, metadata map[string]any) {
 	if cont == nil {
 		return
@@ -946,14 +954,24 @@ func ApplyOpenAICompatibleContinuation(body map[string]any, cont *CanonicalConti
 	if cont.PromptCacheKey != "" {
 		body["prompt_cache_key"] = cont.PromptCacheKey
 	}
-	if cont.PreviousResponseID != "" {
-		body["previous_response_id"] = cont.PreviousResponseID
-	}
+	// Intentionally do NOT write previous_response_id onto chat-shaped bodies.
 	if cont.TurnState != "" {
 		if metadata == nil {
 			metadata = map[string]any{}
 		}
 		metadata["metapi_turn_state"] = cont.TurnState
+	}
+}
+
+// ApplyOpenAIResponsesContinuation writes Responses-protocol continuation
+// fields (including previous_response_id) into a Responses request body.
+func ApplyOpenAIResponsesContinuation(body map[string]any, cont *CanonicalContinuation, metadata map[string]any) {
+	if cont == nil {
+		return
+	}
+	ApplyOpenAICompatibleContinuation(body, cont, metadata)
+	if cont.PreviousResponseID != "" {
+		body["previous_response_id"] = cont.PreviousResponseID
 	}
 }
 

--- a/transform/canonical/openai_bridge_test.go
+++ b/transform/canonical/openai_bridge_test.go
@@ -432,13 +432,24 @@ func TestOpenAIBody_Continuation_Roundtrip(t *testing.T) {
 		t.Errorf("expected previousResponseId resp_prev_1, got %q", env.Continuation.PreviousResponseID)
 	}
 
-	// Reconstruct
+	// Reconstruct chat body: prompt_cache_key is OpenAI-compatible; previous_response_id
+	// is Responses-only and must NOT be re-emitted onto chat (upstream #504 / #54).
 	reconstructed := CanonicalRequestToOpenAiChatBody(env)
 	if reconstructed["prompt_cache_key"] != "cache_key_1" {
 		t.Errorf("expected prompt_cache_key, got %v", reconstructed["prompt_cache_key"])
 	}
-	if reconstructed["previous_response_id"] != "resp_prev_1" {
-		t.Errorf("expected previous_response_id, got %v", reconstructed["previous_response_id"])
+	if _, ok := reconstructed["previous_response_id"]; ok {
+		t.Errorf("chat body must not include previous_response_id, got %v", reconstructed["previous_response_id"])
+	}
+
+	// Responses body re-emits previous_response_id via ApplyOpenAIResponsesContinuation.
+	responsesBody := map[string]any{"model": "gpt-4"}
+	ApplyOpenAIResponsesContinuation(responsesBody, env.Continuation, nil)
+	if responsesBody["previous_response_id"] != "resp_prev_1" {
+		t.Errorf("expected previous_response_id on responses body, got %v", responsesBody["previous_response_id"])
+	}
+	if responsesBody["prompt_cache_key"] != "cache_key_1" {
+		t.Errorf("expected prompt_cache_key on responses body, got %v", responsesBody["prompt_cache_key"])
 	}
 }
 

--- a/transform/openai/responses/compact.go
+++ b/transform/openai/responses/compact.go
@@ -20,7 +20,9 @@ func ShouldForceResponsesUpstreamStream(sitePlatform string, isCompactRequest bo
 	return n == "codex" || n == "sub2api"
 }
 
-// SanitizeCompactResponsesRequestBody removes stream/stream_options and conditionally store.
+// SanitizeCompactResponsesRequestBody removes stream/stream_options and
+// conditionally store. Compact never continues a prior stored response, so
+// previous_response_id is always stripped here (see previous_response_id.go).
 func SanitizeCompactResponsesRequestBody(body map[string]any, sitePlatform string) map[string]any {
 	next := map[string]any{}
 	for k, v := range body {
@@ -28,6 +30,7 @@ func SanitizeCompactResponsesRequestBody(body map[string]any, sitePlatform strin
 	}
 	delete(next, "stream")
 	delete(next, "stream_options")
+	delete(next, PreviousResponseIDField)
 	if ShouldStripCompactResponsesStore(sitePlatform) {
 		delete(next, "store")
 	}

--- a/transform/openai/responses/previous_response_id.go
+++ b/transform/openai/responses/previous_response_id.go
@@ -1,0 +1,316 @@
+package responses
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PreviousResponseIDField is the OpenAI Responses continuity field name.
+const PreviousResponseIDField = "previous_response_id"
+
+// ContinuityAction describes how previous_response_id should be handled for an
+// upstream attempt.
+type ContinuityAction string
+
+const (
+	// ContinuityForward keeps previous_response_id on the upstream body.
+	// Use when the target protocol is Responses and the platform is known to
+	// accept continuity ids.
+	ContinuityForward ContinuityAction = "forward"
+
+	// ContinuityStrip removes previous_response_id without failing the request.
+	// Use for chat/messages fallback, compact paths that cannot continue a
+	// stored response, or Responses-shaped platforms that reject the field.
+	ContinuityStrip ContinuityAction = "strip"
+
+	// ContinuityReject returns a clear client error instead of forwarding a
+	// body that would produce an opaque upstream 400.
+	// Reserved for cases where the client requires continuity and no safe
+	// strip/forward path exists.
+	ContinuityReject ContinuityAction = "reject"
+)
+
+// UpstreamProtocol is the chat-family protocol used for one upstream attempt.
+type UpstreamProtocol string
+
+const (
+	ProtocolResponses UpstreamProtocol = "responses"
+	ProtocolChat      UpstreamProtocol = "chat"
+	ProtocolMessages  UpstreamProtocol = "messages"
+	ProtocolUnknown   UpstreamProtocol = "unknown"
+)
+
+// ContinuityPolicyInput selects how previous_response_id is handled.
+type ContinuityPolicyInput struct {
+	// SitePlatform is the selected site platform id (e.g. "openai", "codex").
+	SitePlatform string
+	// Protocol is the target upstream protocol for this attempt.
+	Protocol UpstreamProtocol
+	// UpstreamPath is optional; used when Protocol is empty to infer protocol.
+	UpstreamPath string
+	// IsCompactRequest is true for /v1/responses/compact (and aliases).
+	IsCompactRequest bool
+	// RequireContinuity forces ContinuityReject when the field cannot be
+	// forwarded safely. Default false → strip instead of reject.
+	RequireContinuity bool
+}
+
+// ContinuityDecision is the resolved action for previous_response_id.
+type ContinuityDecision struct {
+	Action ContinuityAction
+	// Reason is a short machine-oriented explanation for logs/tests/docs.
+	Reason string
+	// ClientMessage is a clear error message when Action == ContinuityReject.
+	ClientMessage string
+}
+
+// NormalizeUpstreamProtocol maps free-form protocol/path hints to a protocol.
+func NormalizeUpstreamProtocol(protocol UpstreamProtocol, upstreamPath string) UpstreamProtocol {
+	switch protocol {
+	case ProtocolResponses, ProtocolChat, ProtocolMessages:
+		return protocol
+	}
+	path := strings.ToLower(strings.TrimSpace(upstreamPath))
+	if i := strings.IndexAny(path, "?#"); i >= 0 {
+		path = path[:i]
+	}
+	path = strings.TrimRight(path, "/")
+	switch {
+	case strings.HasSuffix(path, "/responses/compact") || path == "/responses/compact":
+		return ProtocolResponses
+	case strings.HasSuffix(path, "/v1/responses") || path == "/responses" || path == "/v1/responses" ||
+		strings.Contains(path, "/responses/"):
+		return ProtocolResponses
+	case strings.HasSuffix(path, "/v1/chat/completions") || path == "/chat/completions" ||
+		path == "/v1/chat/completions" || strings.Contains(path, "/chat/completions"):
+		return ProtocolChat
+	case strings.HasSuffix(path, "/v1/messages") || path == "/messages" || path == "/v1/messages" ||
+		strings.Contains(path, "/messages"):
+		return ProtocolMessages
+	default:
+		return ProtocolUnknown
+	}
+}
+
+// SupportsResponsesPreviousResponseID reports whether a Responses-protocol
+// upstream is expected to accept previous_response_id.
+//
+// Known-support (forward):
+//   - openai / openai-responses / azure / azure-openai: official Responses API
+//   - codex: Codex Responses surface uses continuity when store is available
+//
+// Known-reject / unknown (strip on Responses):
+//   - sub2api and most NewAPI-family relays often proxy a reduced Responses
+//     schema and return HTTP 400 "Unsupported parameter: previous_response_id"
+//   - empty / unknown platforms: fail-open by stripping to avoid opaque 400s
+//
+// Chat and Messages never support the field (strip).
+func SupportsResponsesPreviousResponseID(sitePlatform string) bool {
+	n := strings.ToLower(strings.TrimSpace(sitePlatform))
+	switch n {
+	case "openai", "openai-responses", "azure", "azure-openai", "codex":
+		return true
+	default:
+		return false
+	}
+}
+
+// ResolvePreviousResponseIDPolicy decides forward / strip / reject.
+func ResolvePreviousResponseIDPolicy(input ContinuityPolicyInput) ContinuityDecision {
+	protocol := NormalizeUpstreamProtocol(input.Protocol, input.UpstreamPath)
+
+	// Compact is a specialized Responses request. Continuity ids refer to a
+	// prior stored response and are not meaningful on compact; strip cleanly.
+	if input.IsCompactRequest || isCompactPath(input.UpstreamPath) {
+		return ContinuityDecision{
+			Action: ContinuityStrip,
+			Reason: "compact_request_strips_previous_response_id",
+		}
+	}
+
+	switch protocol {
+	case ProtocolChat, ProtocolMessages:
+		if input.RequireContinuity {
+			return ContinuityDecision{
+				Action: ContinuityReject,
+				Reason: "chat_family_lacks_previous_response_id",
+				ClientMessage: fmt.Sprintf(
+					"previous_response_id is not supported on %s upstreams; use /v1/responses on a Responses-capable platform, or omit previous_response_id",
+					protocol,
+				),
+			}
+		}
+		return ContinuityDecision{
+			Action: ContinuityStrip,
+			Reason: "chat_family_strips_previous_response_id",
+		}
+	case ProtocolResponses:
+		if SupportsResponsesPreviousResponseID(input.SitePlatform) {
+			return ContinuityDecision{
+				Action: ContinuityForward,
+				Reason: "responses_platform_supports_previous_response_id",
+			}
+		}
+		if input.RequireContinuity {
+			return ContinuityDecision{
+				Action: ContinuityReject,
+				Reason: "responses_platform_rejects_previous_response_id",
+				ClientMessage: fmt.Sprintf(
+					"previous_response_id is not supported by platform %q; omit previous_response_id or route to a Responses-capable platform (openai/azure/codex)",
+					strings.TrimSpace(input.SitePlatform),
+				),
+			}
+		}
+		return ContinuityDecision{
+			Action: ContinuityStrip,
+			Reason: "responses_platform_strips_unsupported_previous_response_id",
+		}
+	default:
+		// Unknown protocol: strip to avoid opaque upstream 400s.
+		if input.RequireContinuity {
+			return ContinuityDecision{
+				Action:        ContinuityReject,
+				Reason:        "unknown_protocol_previous_response_id",
+				ClientMessage: "previous_response_id cannot be forwarded on this upstream protocol; use /v1/responses on a supported platform or omit previous_response_id",
+			}
+		}
+		return ContinuityDecision{
+			Action: ContinuityStrip,
+			Reason: "unknown_protocol_strips_previous_response_id",
+		}
+	}
+}
+
+// ApplyPreviousResponseIDPolicy mutates a shallow copy of body according to
+// the continuity policy. Returns the next body, the decision, and a non-nil
+// error only when Action == ContinuityReject and the field was present.
+func ApplyPreviousResponseIDPolicy(body map[string]any, input ContinuityPolicyInput) (map[string]any, ContinuityDecision, error) {
+	decision := ResolvePreviousResponseIDPolicy(input)
+	next := cloneBodyMap(body)
+	id := previousResponseIDValue(next)
+	// Absent or whitespace-only: never forward an empty continuity id.
+	if id == "" {
+		delete(next, PreviousResponseIDField)
+		return next, decision, nil
+	}
+	switch decision.Action {
+	case ContinuityForward:
+		next[PreviousResponseIDField] = id
+		return next, decision, nil
+	case ContinuityStrip:
+		delete(next, PreviousResponseIDField)
+		return next, decision, nil
+	case ContinuityReject:
+		msg := decision.ClientMessage
+		if msg == "" {
+			msg = "previous_response_id is not supported on this upstream"
+		}
+		return next, decision, &ContinuityError{Message: msg, Reason: decision.Reason}
+	default:
+		delete(next, PreviousResponseIDField)
+		return next, decision, nil
+	}
+}
+
+// SanitizeResponsesRequestBody applies Responses request sanitization for one
+// upstream attempt:
+//  1. previous_response_id forward/strip/reject policy
+//  2. when isCompact: also remove stream / stream_options / conditional store
+//
+// Callers that fall back from Responses → chat/messages should pass
+// ProtocolChat or ProtocolMessages so continuity is stripped cleanly.
+func SanitizeResponsesRequestBody(body map[string]any, input ContinuityPolicyInput) (map[string]any, ContinuityDecision, error) {
+	next, decision, err := ApplyPreviousResponseIDPolicy(body, input)
+	if err != nil {
+		return next, decision, err
+	}
+	if input.IsCompactRequest || isCompactPath(input.UpstreamPath) {
+		next = SanitizeCompactResponsesRequestBody(next, input.SitePlatform)
+	}
+	return next, decision, nil
+}
+
+// ContinuityError is a clear client-facing validation error for continuity
+// policy rejects (avoids opaque upstream 400 "Unsupported parameter").
+type ContinuityError struct {
+	Message string
+	Reason  string
+}
+
+func (e *ContinuityError) Error() string {
+	if e == nil {
+		return "continuity error"
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	return "previous_response_id is not supported on this upstream"
+}
+
+// IsUnsupportedPreviousResponseIDError reports whether an upstream error text
+// indicates rejection of previous_response_id (for retry/strip helpers).
+func IsUnsupportedPreviousResponseIDError(rawErrText string) bool {
+	text := strings.ToLower(strings.TrimSpace(rawErrText))
+	if text == "" {
+		return false
+	}
+	if !strings.Contains(text, "previous_response_id") {
+		return false
+	}
+	return strings.Contains(text, "unsupported parameter") ||
+		strings.Contains(text, "unknown parameter") ||
+		strings.Contains(text, "unexpected keyword") ||
+		strings.Contains(text, "not supported") ||
+		strings.Contains(text, "unrecognized") ||
+		strings.Contains(text, "invalid parameter")
+}
+
+// StripPreviousResponseID removes previous_response_id from a body copy.
+func StripPreviousResponseID(body map[string]any) map[string]any {
+	next := cloneBodyMap(body)
+	delete(next, PreviousResponseIDField)
+	return next
+}
+
+// HasPreviousResponseID reports whether body carries a non-empty id.
+func HasPreviousResponseID(body map[string]any) bool {
+	return hasPreviousResponseID(body)
+}
+
+func hasPreviousResponseID(body map[string]any) bool {
+	return previousResponseIDValue(body) != ""
+}
+
+func previousResponseIDValue(body map[string]any) string {
+	if body == nil {
+		return ""
+	}
+	v, ok := body[PreviousResponseIDField]
+	if !ok || v == nil {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(s)
+}
+
+func isCompactPath(path string) bool {
+	p := strings.ToLower(strings.TrimSpace(path))
+	if i := strings.IndexAny(p, "?#"); i >= 0 {
+		p = p[:i]
+	}
+	return strings.HasSuffix(p, "/responses/compact") || p == "/responses/compact"
+}
+
+func cloneBodyMap(body map[string]any) map[string]any {
+	next := map[string]any{}
+	if body == nil {
+		return next
+	}
+	for k, v := range body {
+		next[k] = v
+	}
+	return next
+}

--- a/transform/openai/responses/previous_response_id_test.go
+++ b/transform/openai/responses/previous_response_id_test.go
@@ -1,0 +1,395 @@
+package responses
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSupportsResponsesPreviousResponseID(t *testing.T) {
+	tests := []struct {
+		platform string
+		want     bool
+	}{
+		{"openai", true},
+		{"OpenAI", true},
+		{"  azure-openai  ", true},
+		{"azure", true},
+		{"codex", true},
+		{"openai-responses", true},
+		{"sub2api", false},
+		{"newapi", false},
+		{"anyrouter", false},
+		{"", false},
+		{"unknown", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			if got := SupportsResponsesPreviousResponseID(tt.platform); got != tt.want {
+				t.Fatalf("SupportsResponsesPreviousResponseID(%q) = %v, want %v", tt.platform, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeUpstreamProtocol(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol UpstreamProtocol
+		path     string
+		want     UpstreamProtocol
+	}{
+		{"explicit chat", ProtocolChat, "", ProtocolChat},
+		{"explicit responses", ProtocolResponses, "/v1/chat/completions", ProtocolResponses},
+		{"path responses", "", "/v1/responses", ProtocolResponses},
+		{"path compact", "", "/v1/responses/compact", ProtocolResponses},
+		{"path chat", "", "/v1/chat/completions", ProtocolChat},
+		{"path messages", "", "/v1/messages", ProtocolMessages},
+		{"unknown", "", "/v1/embeddings", ProtocolUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeUpstreamProtocol(tt.protocol, tt.path); got != tt.want {
+				t.Fatalf("NormalizeUpstreamProtocol(%q, %q) = %q, want %q", tt.protocol, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolvePreviousResponseIDPolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  ContinuityPolicyInput
+		action ContinuityAction
+		reason string
+	}{
+		{
+			name: "openai responses forwards",
+			input: ContinuityPolicyInput{
+				SitePlatform: "openai",
+				Protocol:     ProtocolResponses,
+			},
+			action: ContinuityForward,
+			reason: "responses_platform_supports_previous_response_id",
+		},
+		{
+			name: "codex responses forwards",
+			input: ContinuityPolicyInput{
+				SitePlatform: "codex",
+				Protocol:     ProtocolResponses,
+			},
+			action: ContinuityForward,
+			reason: "responses_platform_supports_previous_response_id",
+		},
+		{
+			name: "sub2api responses strips",
+			input: ContinuityPolicyInput{
+				SitePlatform: "sub2api",
+				Protocol:     ProtocolResponses,
+			},
+			action: ContinuityStrip,
+			reason: "responses_platform_strips_unsupported_previous_response_id",
+		},
+		{
+			name: "chat strips",
+			input: ContinuityPolicyInput{
+				SitePlatform: "openai",
+				Protocol:     ProtocolChat,
+			},
+			action: ContinuityStrip,
+			reason: "chat_family_strips_previous_response_id",
+		},
+		{
+			name: "messages strips",
+			input: ContinuityPolicyInput{
+				SitePlatform: "openai",
+				Protocol:     ProtocolMessages,
+			},
+			action: ContinuityStrip,
+			reason: "chat_family_strips_previous_response_id",
+		},
+		{
+			name: "compact strips even on openai",
+			input: ContinuityPolicyInput{
+				SitePlatform:     "openai",
+				Protocol:         ProtocolResponses,
+				IsCompactRequest: true,
+			},
+			action: ContinuityStrip,
+			reason: "compact_request_strips_previous_response_id",
+		},
+		{
+			name: "compact path strips",
+			input: ContinuityPolicyInput{
+				SitePlatform: "codex",
+				UpstreamPath: "/v1/responses/compact",
+			},
+			action: ContinuityStrip,
+			reason: "compact_request_strips_previous_response_id",
+		},
+		{
+			name: "chat require continuity rejects",
+			input: ContinuityPolicyInput{
+				SitePlatform:      "openai",
+				Protocol:          ProtocolChat,
+				RequireContinuity: true,
+			},
+			action: ContinuityReject,
+			reason: "chat_family_lacks_previous_response_id",
+		},
+		{
+			name: "unsupported platform require continuity rejects",
+			input: ContinuityPolicyInput{
+				SitePlatform:      "sub2api",
+				Protocol:          ProtocolResponses,
+				RequireContinuity: true,
+			},
+			action: ContinuityReject,
+			reason: "responses_platform_rejects_previous_response_id",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolvePreviousResponseIDPolicy(tt.input)
+			if got.Action != tt.action {
+				t.Fatalf("action = %q, want %q (decision=%+v)", got.Action, tt.action, got)
+			}
+			if got.Reason != tt.reason {
+				t.Fatalf("reason = %q, want %q", got.Reason, tt.reason)
+			}
+			if got.Action == ContinuityReject && strings.TrimSpace(got.ClientMessage) == "" {
+				t.Fatal("reject decision missing ClientMessage")
+			}
+		})
+	}
+}
+
+func TestApplyPreviousResponseIDPolicy_PresenceAbsenceStrip(t *testing.T) {
+	t.Run("absent field is no-op", func(t *testing.T) {
+		body := map[string]any{"model": "gpt-4", "input": "hi"}
+		next, decision, err := ApplyPreviousResponseIDPolicy(body, ContinuityPolicyInput{
+			SitePlatform: "openai",
+			Protocol:     ProtocolResponses,
+		})
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if decision.Action != ContinuityForward {
+			t.Fatalf("action = %q", decision.Action)
+		}
+		if _, ok := next[PreviousResponseIDField]; ok {
+			t.Fatal("did not expect previous_response_id key")
+		}
+		if next["model"] != "gpt-4" {
+			t.Fatalf("model = %v", next["model"])
+		}
+		// original not mutated
+		if _, ok := body[PreviousResponseIDField]; ok {
+			t.Fatal("original body mutated")
+		}
+	})
+
+	t.Run("forward preserves id", func(t *testing.T) {
+		body := map[string]any{"model": "gpt-4", "previous_response_id": "  resp_abc  "}
+		next, decision, err := ApplyPreviousResponseIDPolicy(body, ContinuityPolicyInput{
+			SitePlatform: "openai",
+			Protocol:     ProtocolResponses,
+		})
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if decision.Action != ContinuityForward {
+			t.Fatalf("action = %q", decision.Action)
+		}
+		if next[PreviousResponseIDField] != "resp_abc" {
+			t.Fatalf("previous_response_id = %v", next[PreviousResponseIDField])
+		}
+	})
+
+	t.Run("chat strips id", func(t *testing.T) {
+		body := map[string]any{"model": "gpt-4", "previous_response_id": "resp_abc"}
+		next, decision, err := ApplyPreviousResponseIDPolicy(body, ContinuityPolicyInput{
+			SitePlatform: "openai",
+			Protocol:     ProtocolChat,
+		})
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if decision.Action != ContinuityStrip {
+			t.Fatalf("action = %q", decision.Action)
+		}
+		if _, ok := next[PreviousResponseIDField]; ok {
+			t.Fatal("expected previous_response_id stripped")
+		}
+		if body[PreviousResponseIDField] != "resp_abc" {
+			t.Fatal("original body should keep field")
+		}
+	})
+
+	t.Run("sub2api responses strips id", func(t *testing.T) {
+		body := map[string]any{"model": "gpt-4", "previous_response_id": "resp_abc"}
+		next, decision, err := ApplyPreviousResponseIDPolicy(body, ContinuityPolicyInput{
+			SitePlatform: "sub2api",
+			Protocol:     ProtocolResponses,
+			UpstreamPath: "/v1/responses",
+		})
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if decision.Action != ContinuityStrip {
+			t.Fatalf("action = %q", decision.Action)
+		}
+		if _, ok := next[PreviousResponseIDField]; ok {
+			t.Fatal("expected previous_response_id stripped")
+		}
+	})
+
+	t.Run("reject returns clear error", func(t *testing.T) {
+		body := map[string]any{"model": "gpt-4", "previous_response_id": "resp_abc"}
+		_, decision, err := ApplyPreviousResponseIDPolicy(body, ContinuityPolicyInput{
+			SitePlatform:      "sub2api",
+			Protocol:          ProtocolResponses,
+			RequireContinuity: true,
+		})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if decision.Action != ContinuityReject {
+			t.Fatalf("action = %q", decision.Action)
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "previous_response_id") {
+			t.Fatalf("error should mention previous_response_id: %q", msg)
+		}
+		if strings.Contains(strings.ToLower(msg), "unsupported parameter") && !strings.Contains(msg, "platform") {
+			t.Fatalf("error looks like opaque upstream 400: %q", msg)
+		}
+	})
+
+	t.Run("whitespace-only id treated as absent on forward", func(t *testing.T) {
+		body := map[string]any{"model": "gpt-4", "previous_response_id": "   "}
+		next, _, err := ApplyPreviousResponseIDPolicy(body, ContinuityPolicyInput{
+			SitePlatform: "openai",
+			Protocol:     ProtocolResponses,
+		})
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if _, ok := next[PreviousResponseIDField]; ok {
+			t.Fatal("whitespace-only id should be deleted")
+		}
+	})
+}
+
+func TestSanitizeResponsesRequestBody(t *testing.T) {
+	t.Run("openai responses keeps continuity", func(t *testing.T) {
+		body := map[string]any{
+			"model":                "gpt-4",
+			"previous_response_id": "resp_1",
+			"input":                "hi",
+		}
+		next, decision, err := SanitizeResponsesRequestBody(body, ContinuityPolicyInput{
+			SitePlatform: "openai",
+			Protocol:     ProtocolResponses,
+			UpstreamPath: "/v1/responses",
+		})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if decision.Action != ContinuityForward {
+			t.Fatalf("action = %q", decision.Action)
+		}
+		if next["previous_response_id"] != "resp_1" {
+			t.Fatalf("id = %v", next["previous_response_id"])
+		}
+	})
+
+	t.Run("chat fallback strips continuity", func(t *testing.T) {
+		body := map[string]any{
+			"model":                "gpt-4",
+			"previous_response_id": "resp_1",
+			"input":                "hi",
+		}
+		next, decision, err := SanitizeResponsesRequestBody(body, ContinuityPolicyInput{
+			SitePlatform: "openai",
+			Protocol:     ProtocolChat,
+			UpstreamPath: "/v1/chat/completions",
+		})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if decision.Action != ContinuityStrip {
+			t.Fatalf("action = %q", decision.Action)
+		}
+		if _, ok := next["previous_response_id"]; ok {
+			t.Fatal("expected strip")
+		}
+	})
+
+	t.Run("compact also strips stream fields", func(t *testing.T) {
+		body := map[string]any{
+			"model":                "gpt-4",
+			"stream":               true,
+			"stream_options":       map[string]any{"include_usage": true},
+			"store":                true,
+			"previous_response_id": "resp_1",
+		}
+		next, decision, err := SanitizeResponsesRequestBody(body, ContinuityPolicyInput{
+			SitePlatform:     "codex",
+			Protocol:         ProtocolResponses,
+			IsCompactRequest: true,
+		})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if decision.Action != ContinuityStrip {
+			t.Fatalf("action = %q", decision.Action)
+		}
+		for _, k := range []string{"stream", "stream_options", "store", "previous_response_id"} {
+			if _, ok := next[k]; ok {
+				t.Fatalf("expected %q stripped", k)
+			}
+		}
+		if next["model"] != "gpt-4" {
+			t.Fatalf("model = %v", next["model"])
+		}
+	})
+}
+
+func TestIsUnsupportedPreviousResponseIDError(t *testing.T) {
+	tests := []struct {
+		text string
+		want bool
+	}{
+		{`{"detail":"Unsupported parameter: previous_response_id"}`, true},
+		{`unknown parameter: 'previous_response_id'`, true},
+		{`previous_response_id is not supported`, true},
+		{`bad request`, false},
+		{`unsupported parameter: stream`, false},
+		{``, false},
+	}
+	for _, tt := range tests {
+		if got := IsUnsupportedPreviousResponseIDError(tt.text); got != tt.want {
+			t.Errorf("IsUnsupportedPreviousResponseIDError(%q) = %v, want %v", tt.text, got, tt.want)
+		}
+	}
+}
+
+func TestHasAndStripPreviousResponseID(t *testing.T) {
+	if HasPreviousResponseID(nil) {
+		t.Fatal("nil body")
+	}
+	if HasPreviousResponseID(map[string]any{"previous_response_id": "  "}) {
+		t.Fatal("whitespace-only should be absent")
+	}
+	body := map[string]any{"previous_response_id": "resp_1", "model": "x"}
+	if !HasPreviousResponseID(body) {
+		t.Fatal("expected present")
+	}
+	stripped := StripPreviousResponseID(body)
+	if HasPreviousResponseID(stripped) {
+		t.Fatal("expected stripped")
+	}
+	if body["previous_response_id"] != "resp_1" {
+		t.Fatal("strip must copy")
+	}
+}

--- a/transform/openai/responses/responses_test.go
+++ b/transform/openai/responses/responses_test.go
@@ -67,20 +67,20 @@ func TestSanitizeCompactResponsesRequestBody(t *testing.T) {
 		want         map[string]any
 	}{
 		{
-			name:         "codex strips stream, stream_options, store",
-			body:         map[string]any{"model": "gpt-4", "stream": true, "stream_options": map[string]any{}, "store": true, "input": "hello"},
+			name:         "codex strips stream, stream_options, store, previous_response_id",
+			body:         map[string]any{"model": "gpt-4", "stream": true, "stream_options": map[string]any{}, "store": true, "previous_response_id": "resp_1", "input": "hello"},
 			sitePlatform: "codex",
 			want:         map[string]any{"model": "gpt-4", "input": "hello"},
 		},
 		{
-			name:         "sub2api strips stream, stream_options, store",
-			body:         map[string]any{"model": "gpt-4", "stream": true, "stream_options": map[string]any{}, "store": true},
+			name:         "sub2api strips stream, stream_options, store, previous_response_id",
+			body:         map[string]any{"model": "gpt-4", "stream": true, "stream_options": map[string]any{}, "store": true, "previous_response_id": "resp_1"},
 			sitePlatform: "sub2api",
 			want:         map[string]any{"model": "gpt-4"},
 		},
 		{
-			name:         "openai strips only stream and stream_options",
-			body:         map[string]any{"model": "gpt-4", "stream": true, "stream_options": map[string]any{}, "store": true},
+			name:         "openai strips stream, stream_options, previous_response_id; keeps store",
+			body:         map[string]any{"model": "gpt-4", "stream": true, "stream_options": map[string]any{}, "store": true, "previous_response_id": "resp_1"},
 			sitePlatform: "openai",
 			want:         map[string]any{"model": "gpt-4", "store": true},
 		},

--- a/transform/shared/chatFormatsCore.go
+++ b/transform/shared/chatFormatsCore.go
@@ -316,9 +316,10 @@ func convertClaudeRequestToOpenAiBody(body map[string]any) claudeConvertResult {
 	if pck := AsTrimmedString(body["prompt_cache_key"]); pck != "" {
 		payload["prompt_cache_key"] = pck
 	}
-	if pri := AsTrimmedString(body["previous_response_id"]); pri != "" {
-		payload["previous_response_id"] = pri
-	}
+	// previous_response_id is Responses-only. Never copy it onto chat bodies
+	// (avoids opaque upstream 400 "Unsupported parameter: previous_response_id").
+	// Continuity for Responses is handled in transform/openai/responses and
+	// canonical.ApplyOpenAIResponsesContinuation.
 
 	return claudeConvertResult{
 		model:    model,


### PR DESCRIPTION
## Summary
- Add SSOT continuity policy for `previous_response_id` (forward on openai/azure/codex Responses; strip on chat/messages, compact, and unsupported relays; optional clear reject).
- Stop re-emitting `previous_response_id` onto chat-shaped bodies (`ApplyOpenAICompatibleContinuation`); Responses builders use `ApplyOpenAIResponsesContinuation`.
- Wire per-candidate sanitize in `handler/proxy/upstream.go`; document compact/sanitize matrix in `docs/analysis/previous-response-id.md`.

Closes #54

## Test plan
- [x] `go test ./transform/openai/responses/ ./transform/canonical/ -count=1`
- [x] `go test ./handler/proxy/ -count=1`
- [ ] Manual: Responses client with `previous_response_id` against openai/codex keeps field; against sub2api/chat fallback strips without opaque 400.