### PR TITLE
fix(oauth): Codex gpt-5.5 allowlist + discovery soft-retry

### DIFF
--- a/docs/analysis/codex-oauth-gpt55-discovery.md
+++ b/docs/analysis/codex-oauth-gpt55-discovery.md
@@ -1,0 +1,85 @@
+# Codex OAuth gpt-5.5 discovery & first-timeout
+
+**Date:** 2026-07-17  
+**Issues:** [#49](https://github.com/TokenDanceLab/metapi-go/issues/49) (upstream #571), [#55](https://github.com/TokenDanceLab/metapi-go/issues/55) (upstream #489)  
+**SSOT code:** `service/oauth/codex_models.go`, `service/oauth/quota.go`, `service/oauth/account.go`
+
+## Problem
+
+1. **#49 / #571** — After Codex OAuth login, gpt-5.5 could appear blocked when allowlists/fixtures/quota probes only referenced obsolete models (e.g. gpt-5.4). Static audit found no hard `gpt-5.5` deny, but seed/probe paths were version-pinned.
+2. **#55 / #489** — Upstream TS first model discovery used a fixed **12s** budget (`MODEL_DISCOVERY_TIMEOUT_MS = 12_000` in `modelService.ts`). Cold-start Codex cloud discovery (proxy + ChatGPT backend) often needs longer; timeout left operators with little guidance.
+
+## Design
+
+### Allowlist (#49)
+
+| Helper | Rule |
+|--------|------|
+| `IsCodexGPT5FamilyModel` | Version-flexible `^gpt-5(\.|$|-)` (covers gpt-5.5, gpt-5.4-mini, gpt-5.2-codex, …) |
+| `IsCodexModelAllowed` | gpt-5.x family always allowed; other models only if present in discovered set |
+| `CodexSeedModels` | Fixture seed includes **gpt-5.5** plus recent predecessors (not obsolete-only) |
+| `SelectCodexQuotaProbeModel` | Preference order starts with **gpt-5.5**, then gpt-5.4…; empty discovery → `gpt-5.5` fallback |
+| `CodexQuotaProbeModelForAccount` | Uses `LastDiscoveredModels` when available |
+
+### First discovery timeout (#55)
+
+| Constant | Value | Notes |
+|----------|-------|-------|
+| `CodexModelDiscoveryTimeout` | **30s** | First attempt (was ~12s upstream) |
+| `CodexModelDiscoveryRetryTimeout` | **45s** | Soft-retry budget after timeout |
+| `CodexModelDiscoveryBackoff` | **750ms** | Pause between attempts |
+| `CodexModelDiscoveryMaxAttempts` | **2** | Initial + one soft-retry |
+
+Soft-retry applies **only** to timeout-class errors. Auth (`401` / unauthorized) and empty-model responses fail fast.
+
+On exhausted timeout, `FormatCodexModelDiscoveryTimeoutStatus` writes an operator-facing message covering:
+
+- attempt count and budget
+- cold-start / proxy guidance
+- `status=abnormal` until a successful discovery
+- recommended budgets (30s / 45s)
+
+`DiscoverCodexModelsWithSoftRetry` returns `CodexModelDiscoveryResult` with `Status` (`healthy`|`abnormal`), `ErrorCode`, `TimedOut`, `Attempts`, and `Models`.
+
+`BuildOauthModelDiscoveryPatch` maps the result onto `OauthInfo` fields already stored in `extraConfig.oauth` (`modelDiscoveryStatus`, `lastModelSyncAt`, `lastModelSyncError`, `lastDiscoveredModels`).
+
+### Cloud discovery HTTP
+
+`DiscoverCodexModelsFromCloud` GETs `{base}/models?client_version=1.0.0` with:
+
+- `Authorization: Bearer …`
+- `Originator: codex_cli_rs`
+- optional `Chatgpt-Account-Id`
+
+Payload parsing accepts array / `models` / `data` / `items` with `id`|`slug`|`model` fields (parity with upstream `platformDiscoveryRegistry.ts`).
+
+## Recommended operator config
+
+| Surface | Recommendation |
+|---------|----------------|
+| First discovery budget | ≥ 30s (package default) |
+| Soft-retry budget | ≥ 45s |
+| Account proxy | Set reachable `extraConfig.proxyUrl` when MetAPI host cannot reach ChatGPT directly |
+| After timeout | Re-run connection model refresh; inspect `modelDiscoveryStatus=abnormal` + `lastModelSyncError` |
+
+Env knobs for generic model **probe** (`MODEL_AVAILABILITY_PROBE_TIMEOUT_MS`, default 15s) remain separate from this OAuth first-discovery path.
+
+## Tests
+
+```bash
+go test ./service/oauth/ -count=1
+```
+
+Coverage includes:
+
+- gpt-5.5 allowed with empty / older-only discovery lists
+- seed + quota probe preference not obsolete-only
+- success first attempt
+- timeout → backoff → success
+- timeout exhausted → abnormal + actionable message
+- unauthorized → no soft-retry
+
+## Residual
+
+- Full wire-up of `DiscoverCodexModelsWithSoftRetry` into a future `refreshModelsForAccount` implementation (outside this oauth-file ownership when model service lands) should call these helpers.
+- Live end-to-end OAuth + gpt-5.5 chat still needs a real Codex account (runtime probe).

--- a/service/oauth/codex_models.go
+++ b/service/oauth/codex_models.go
@@ -1,0 +1,536 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Codex model discovery / allowlist helpers for OAuth accounts.
+//
+// Upstream TS used a fixed 12s discovery timeout (modelService.ts) and fixtures
+// that only exercised gpt-5.4. Cold-start Codex OAuth discovery often needs a
+// longer first attempt plus one soft retry, and allowlists must accept the
+// gpt-5.x family (including gpt-5.5) without hardcoding only obsolete models.
+
+const (
+	// CodexModelDiscoveryTimeout is the first-attempt budget for Codex cloud
+	// model discovery. Raised from the historical 12s upstream default so cold
+	// starts (proxy + ChatGPT backend) do not fail spuriously.
+	CodexModelDiscoveryTimeout = 30 * time.Second
+
+	// CodexModelDiscoveryRetryTimeout is the budget for the soft-retry attempt
+	// after a timeout. Slightly longer than the first attempt.
+	CodexModelDiscoveryRetryTimeout = 45 * time.Second
+
+	// CodexModelDiscoveryBackoff is the pause between first timeout and retry.
+	CodexModelDiscoveryBackoff = 750 * time.Millisecond
+
+	// CodexModelDiscoveryMaxAttempts is 1 initial + 1 soft retry on timeout.
+	CodexModelDiscoveryMaxAttempts = 2
+
+	// CodexQuotaProbeModelFallback is used when no discovered/preferred model
+	// is available for the reverse-engineered quota probe.
+	CodexQuotaProbeModelFallback = "gpt-5.5"
+
+	// CodexModelsClientVersion is the query param expected by Codex /models.
+	CodexModelsClientVersion = "1.0.0"
+)
+
+// CodexSeedModels is a non-exhaustive, version-flexible seed of known Codex
+// cloud models used for fixtures and allowlist regression tests. It must keep
+// current models (gpt-5.5) alongside recent predecessors so allowlists are not
+// obsolete-only.
+var CodexSeedModels = []string{
+	"gpt-5.5",
+	"gpt-5.4",
+	"gpt-5.4-mini",
+	"gpt-5.3-codex",
+	"gpt-5.2-codex",
+	"gpt-5.2",
+	"gpt-5.1-codex-max",
+	"gpt-5.1-codex",
+	"gpt-5.1",
+	"gpt-5.1-codex-mini",
+}
+
+// Preferred order for quota probe model selection (newest / most capable first).
+var codexQuotaProbePreference = []string{
+	"gpt-5.5",
+	"gpt-5.4",
+	"gpt-5.4-mini",
+	"gpt-5.3-codex",
+	"gpt-5.2-codex",
+	"gpt-5.2",
+	"gpt-5.1-codex-max",
+	"gpt-5.1-codex",
+	"gpt-5.1",
+}
+
+var gpt5FamilyPattern = regexp.MustCompile(`(?i)^gpt-5(\.|$|-)`)
+
+// CodexModelDiscoveryErrorCode classifies discovery failures for operators.
+type CodexModelDiscoveryErrorCode string
+
+const (
+	CodexDiscoveryTimeout      CodexModelDiscoveryErrorCode = "timeout"
+	CodexDiscoveryUnauthorized CodexModelDiscoveryErrorCode = "unauthorized"
+	CodexDiscoveryEmptyModels  CodexModelDiscoveryErrorCode = "empty_models"
+	CodexDiscoveryUnknown      CodexModelDiscoveryErrorCode = "unknown"
+)
+
+// CodexModelDiscoveryResult is the outcome of a discovery pass.
+type CodexModelDiscoveryResult struct {
+	Models      []string                     `json:"models"`
+	Status      OauthModelDiscoveryStatus    `json:"status"`
+	ErrorCode   CodexModelDiscoveryErrorCode `json:"errorCode,omitempty"`
+	ErrorMessage string                      `json:"errorMessage,omitempty"`
+	Attempts    int                          `json:"attempts"`
+	TimedOut    bool                         `json:"timedOut,omitempty"`
+	DurationMs  int64                        `json:"durationMs"`
+}
+
+// CodexModelDiscoveryInput holds inputs for cloud model discovery.
+type CodexModelDiscoveryInput struct {
+	BaseURL     string
+	AccessToken string
+	AccountID   string
+	ProxyURL    *string
+	// HTTPClient overrides the default OAuth HTTP client (tests).
+	HTTPClient *http.Client
+	// Now is optional clock for tests.
+	Now func() time.Time
+	// Sleep is optional sleeper for backoff (tests).
+	Sleep func(context.Context, time.Duration) error
+}
+
+// IsCodexGPT5FamilyModel reports whether model is in the gpt-5.x family
+// (gpt-5, gpt-5.4, gpt-5.5, gpt-5.2-codex, …). Version-flexible — does not
+// hardcode a single minor version.
+func IsCodexGPT5FamilyModel(model string) bool {
+	name := strings.TrimSpace(model)
+	if name == "" {
+		return false
+	}
+	return gpt5FamilyPattern.MatchString(name)
+}
+
+// IsCodexModelAllowed reports whether a model is permitted for Codex OAuth
+// routing/discovery/quota paths. gpt-5.x family models (including gpt-5.5) are
+// always allowed; any other name is allowed only when present in discovered.
+func IsCodexModelAllowed(model string, discovered []string) bool {
+	name := strings.TrimSpace(model)
+	if name == "" {
+		return false
+	}
+	if IsCodexGPT5FamilyModel(name) {
+		return true
+	}
+	target := strings.ToLower(name)
+	for _, d := range discovered {
+		if strings.ToLower(strings.TrimSpace(d)) == target {
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizeDiscoveredCodexModels trims, drops empties, and case-insensitively
+// dedupes while preserving first-seen original casing.
+func NormalizeDiscoveredCodexModels(models []string) []string {
+	out := make([]string, 0, len(models))
+	seen := make(map[string]struct{}, len(models))
+	for _, raw := range models {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}
+
+// MergeCodexDiscoveredWithSeed merges live discovery with seed models so that
+// fixtures and first-login paths keep gpt-5.5 (and family) available even when
+// upstream returns a partial list. Discovered names win on case collisions.
+func MergeCodexDiscoveredWithSeed(discovered []string) []string {
+	merged := NormalizeDiscoveredCodexModels(discovered)
+	seen := make(map[string]struct{}, len(merged)+len(CodexSeedModels))
+	for _, m := range merged {
+		seen[strings.ToLower(m)] = struct{}{}
+	}
+	for _, seed := range CodexSeedModels {
+		key := strings.ToLower(seed)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		// Only seed gpt-5.x family; never invent non-family models.
+		if !IsCodexGPT5FamilyModel(seed) {
+			continue
+		}
+		seen[key] = struct{}{}
+		merged = append(merged, seed)
+	}
+	return merged
+}
+
+// FilterCodexAllowedModels keeps models that pass IsCodexModelAllowed.
+// When discovered is empty, only gpt-5.x family names pass.
+func FilterCodexAllowedModels(models []string, discovered []string) []string {
+	out := make([]string, 0, len(models))
+	for _, m := range models {
+		if IsCodexModelAllowed(m, discovered) {
+			out = append(out, strings.TrimSpace(m))
+		}
+	}
+	return NormalizeDiscoveredCodexModels(out)
+}
+
+// SelectCodexQuotaProbeModel chooses a model for the Codex quota probe.
+// Prefers the newest known preferred model present in discovered; otherwise
+// prefers any gpt-5.x from discovered; finally falls back to gpt-5.5 so the
+// probe path is not stuck on obsolete-only gpt-5.4.
+func SelectCodexQuotaProbeModel(discovered []string) string {
+	normalized := NormalizeDiscoveredCodexModels(discovered)
+	if len(normalized) > 0 {
+		index := make(map[string]string, len(normalized))
+		for _, m := range normalized {
+			index[strings.ToLower(m)] = m
+		}
+		for _, pref := range codexQuotaProbePreference {
+			if actual, ok := index[strings.ToLower(pref)]; ok {
+				return actual
+			}
+		}
+		// Any gpt-5.x from discovery, sorted for stability.
+		var family []string
+		for _, m := range normalized {
+			if IsCodexGPT5FamilyModel(m) {
+				family = append(family, m)
+			}
+		}
+		if len(family) > 0 {
+			sort.Slice(family, func(i, j int) bool {
+				return strings.ToLower(family[i]) > strings.ToLower(family[j])
+			})
+			return family[0]
+		}
+		return normalized[0]
+	}
+	return CodexQuotaProbeModelFallback
+}
+
+// ClassifyCodexModelDiscoveryError maps error text to a stable error code.
+func ClassifyCodexModelDiscoveryError(err error) CodexModelDiscoveryErrorCode {
+	if err == nil {
+		return ""
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "timeout"),
+		strings.Contains(msg, "timed out"),
+		strings.Contains(msg, "deadline exceeded"),
+		strings.Contains(msg, "context deadline"),
+		strings.Contains(msg, "请求超时"):
+		return CodexDiscoveryTimeout
+	case strings.Contains(msg, "http 401"),
+		strings.Contains(msg, "unauthorized"),
+		strings.Contains(msg, "unauthenticated"):
+		return CodexDiscoveryUnauthorized
+	case strings.Contains(msg, "未获取到可用模型"),
+		strings.Contains(msg, "empty"),
+		strings.Contains(msg, "no models"):
+		return CodexDiscoveryEmptyModels
+	default:
+		return CodexDiscoveryUnknown
+	}
+}
+
+// FormatCodexModelDiscoveryTimeoutStatus returns an operator-facing message
+// when first/retry discovery times out.
+func FormatCodexModelDiscoveryTimeoutStatus(timeout time.Duration, attempts int) string {
+	sec := int(timeout.Round(time.Second) / time.Second)
+	if sec <= 0 {
+		sec = int(CodexModelDiscoveryTimeout / time.Second)
+	}
+	return fmt.Sprintf(
+		"Codex model discovery timed out after %d attempt(s) (budget %ds). "+
+			"Cold-start ChatGPT Codex backends often need >12s; ensure account proxy is reachable, "+
+			"retry connection refresh, or raise the discovery budget (default first attempt %ds, soft-retry %ds). "+
+			"Status=abnormal until a successful discovery writes healthy + lastDiscoveredModels.",
+		attempts,
+		sec,
+		int(CodexModelDiscoveryTimeout/time.Second),
+		int(CodexModelDiscoveryRetryTimeout/time.Second),
+	)
+}
+
+// BuildCodexModelsEndpoint builds GET .../models?client_version=...
+func BuildCodexModelsEndpoint(baseURL string) string {
+	normalized := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if normalized == "" {
+		normalized = codexUpstreamBaseURL
+	}
+	return normalized + "/models?client_version=" + url.QueryEscape(CodexModelsClientVersion)
+}
+
+// ExtractCodexModelIDs parses Codex /models JSON payloads (array | models|data|items).
+func ExtractCodexModelIDs(payload any) []string {
+	collection := extractCodexModelCollection(payload)
+	var ids []string
+	for _, item := range collection {
+		switch v := item.(type) {
+		case string:
+			if s := strings.TrimSpace(v); s != "" {
+				ids = append(ids, s)
+			}
+		case map[string]any:
+			id := firstNonEmptyString(
+				asNonEmptyString(v["id"]),
+				asNonEmptyString(v["slug"]),
+				asNonEmptyString(v["model"]),
+			)
+			if id != "" {
+				ids = append(ids, id)
+			}
+		}
+	}
+	return NormalizeDiscoveredCodexModels(ids)
+}
+
+func extractCodexModelCollection(payload any) []any {
+	switch v := payload.(type) {
+	case []any:
+		return v
+	case map[string]any:
+		for _, key := range []string{"models", "data", "items"} {
+			if arr, ok := v[key].([]any); ok {
+				return arr
+			}
+		}
+	}
+	return nil
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+// DiscoverCodexModelsFromCloud performs a single GET /models discovery call.
+func DiscoverCodexModelsFromCloud(ctx context.Context, input CodexModelDiscoveryInput) ([]string, error) {
+	accessToken := strings.TrimSpace(input.AccessToken)
+	if accessToken == "" {
+		return nil, fmt.Errorf("codex oauth access token missing")
+	}
+	endpoint := BuildCodexModelsEndpoint(input.BaseURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Originator", "codex_cli_rs")
+	if accountID := strings.TrimSpace(input.AccountID); accountID != "" {
+		req.Header.Set("Chatgpt-Account-Id", accountID)
+	}
+
+	client := input.HTTPClient
+	if client == nil {
+		client = newOAuthHTTPClient(nil)
+	}
+	// Honour proxy via doHTTP when custom client not provided.
+	var resp *http.Response
+	if input.HTTPClient != nil {
+		resp, err = client.Do(req)
+	} else {
+		resp, err = doHTTP(req, input.ProxyURL, client)
+	}
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("codex model discovery timeout (%ds): %w",
+				int(CodexModelDiscoveryTimeout/time.Second), ctx.Err())
+		}
+		return nil, fmt.Errorf("codex model discovery request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body := readOAuthErrorResponseBody(resp.Body)
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	body, err := readOAuthJSONResponseBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("codex model discovery response read failed: %w", err)
+	}
+
+	var payload any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("codex model discovery returned invalid payload")
+	}
+	models := ExtractCodexModelIDs(payload)
+	if len(models) == 0 {
+		return nil, fmt.Errorf("未获取到可用模型")
+	}
+	return models, nil
+}
+
+// DiscoverCodexModelsWithSoftRetry runs cloud discovery with an increased first
+// timeout and one soft-retry/backoff on timeout. Non-timeout errors fail fast.
+func DiscoverCodexModelsWithSoftRetry(
+	ctx context.Context,
+	input CodexModelDiscoveryInput,
+	fetch func(context.Context, CodexModelDiscoveryInput) ([]string, error),
+) *CodexModelDiscoveryResult {
+	if fetch == nil {
+		fetch = DiscoverCodexModelsFromCloud
+	}
+	now := input.Now
+	if now == nil {
+		now = time.Now
+	}
+	sleep := input.Sleep
+	if sleep == nil {
+		sleep = func(ctx context.Context, d time.Duration) error {
+			timer := time.NewTimer(d)
+			defer timer.Stop()
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-timer.C:
+				return nil
+			}
+		}
+	}
+
+	started := now()
+	timeouts := []time.Duration{CodexModelDiscoveryTimeout, CodexModelDiscoveryRetryTimeout}
+	var lastErr error
+	attempts := 0
+	timedOut := false
+
+	for i, budget := range timeouts {
+		if i >= CodexModelDiscoveryMaxAttempts {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			lastErr = err
+			break
+		}
+		attempts++
+		attemptCtx, cancel := context.WithTimeout(ctx, budget)
+		models, err := fetch(attemptCtx, input)
+		cancel()
+		if err == nil {
+			normalized := NormalizeDiscoveredCodexModels(models)
+			// Ensure gpt-5.5 family is not dropped by partial upstream lists when
+			// seed merge is desired by callers — discovery itself returns live set.
+			return &CodexModelDiscoveryResult{
+				Models:     normalized,
+				Status:     OauthModelDiscoveryHealthy,
+				Attempts:   attempts,
+				DurationMs: now().Sub(started).Milliseconds(),
+			}
+		}
+		lastErr = err
+		code := ClassifyCodexModelDiscoveryError(err)
+		if code != CodexDiscoveryTimeout {
+			// Soft-retry only for timeouts (cold start). Auth/empty fail fast.
+			msg := formatCodexDiscoveryFailure(code, err, attempts, budget, false)
+			return &CodexModelDiscoveryResult{
+				Models:       nil,
+				Status:       OauthModelDiscoveryAbnormal,
+				ErrorCode:    code,
+				ErrorMessage: msg,
+				Attempts:     attempts,
+				TimedOut:     false,
+				DurationMs:   now().Sub(started).Milliseconds(),
+			}
+		}
+		timedOut = true
+		// Soft-retry once after backoff when another attempt remains.
+		if i+1 < len(timeouts) {
+			if err := sleep(ctx, CodexModelDiscoveryBackoff); err != nil {
+				lastErr = err
+				break
+			}
+			continue
+		}
+	}
+
+	code := ClassifyCodexModelDiscoveryError(lastErr)
+	if code == "" {
+		code = CodexDiscoveryUnknown
+	}
+	budget := CodexModelDiscoveryRetryTimeout
+	if attempts == 1 {
+		budget = CodexModelDiscoveryTimeout
+	}
+	msg := formatCodexDiscoveryFailure(code, lastErr, attempts, budget, timedOut)
+	return &CodexModelDiscoveryResult{
+		Models:       nil,
+		Status:       OauthModelDiscoveryAbnormal,
+		ErrorCode:    code,
+		ErrorMessage: msg,
+		Attempts:     attempts,
+		TimedOut:     timedOut || code == CodexDiscoveryTimeout,
+		DurationMs:   now().Sub(started).Milliseconds(),
+	}
+}
+
+func formatCodexDiscoveryFailure(
+	code CodexModelDiscoveryErrorCode,
+	err error,
+	attempts int,
+	budget time.Duration,
+	timedOut bool,
+) string {
+	if timedOut || code == CodexDiscoveryTimeout {
+		return FormatCodexModelDiscoveryTimeoutStatus(budget, attempts)
+	}
+	raw := "codex model discovery failed"
+	if err != nil {
+		raw = err.Error()
+	}
+	return fmt.Sprintf("Codex 模型获取失败（%s）", raw)
+}
+
+// BuildOauthModelDiscoveryPatch builds the OauthInfo patch used to persist
+// discovery status after a successful or failed pass.
+func BuildOauthModelDiscoveryPatch(result *CodexModelDiscoveryResult, checkedAt string) *OauthInfo {
+	if result == nil {
+		return nil
+	}
+	if checkedAt == "" {
+		checkedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	patch := &OauthInfo{
+		ModelDiscoveryStatus: result.Status,
+		LastModelSyncAt:      checkedAt,
+		LastDiscoveredModels: result.Models,
+	}
+	if result.Status == OauthModelDiscoveryAbnormal {
+		patch.LastModelSyncError = result.ErrorMessage
+	} else {
+		// Clear previous error on success by writing empty — callers merge carefully.
+		patch.LastModelSyncError = ""
+	}
+	return patch
+}

--- a/service/oauth/codex_models_test.go
+++ b/service/oauth/codex_models_test.go
@@ -1,0 +1,407 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestIsCodexGPT5FamilyModel(t *testing.T) {
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		{"gpt-5.5", true},
+		{"gpt-5.4", true},
+		{"GPT-5.2-codex", true},
+		{"gpt-5", true},
+		{"gpt-5-mini", true},
+		{"gpt-4o", false},
+		{"claude-3.7-sonnet", false},
+		{"", false},
+		{"  gpt-5.5  ", true},
+	}
+	for _, tc := range cases {
+		if got := IsCodexGPT5FamilyModel(tc.model); got != tc.want {
+			t.Errorf("IsCodexGPT5FamilyModel(%q) = %v, want %v", tc.model, got, tc.want)
+		}
+	}
+}
+
+func TestIsCodexModelAllowed_IncludesGPT55WithoutHardBlock(t *testing.T) {
+	// gpt-5.5 must be allowed even when discovery list is empty or only has older models.
+	if !IsCodexModelAllowed("gpt-5.5", nil) {
+		t.Fatal("gpt-5.5 must be allowed with empty discovered list")
+	}
+	if !IsCodexModelAllowed("gpt-5.5", []string{"gpt-5.4", "gpt-5.2-codex"}) {
+		t.Fatal("gpt-5.5 must be allowed even when only older models were discovered")
+	}
+	if !IsCodexModelAllowed("gpt-5.4-mini", nil) {
+		t.Fatal("gpt-5.x family should be version-flexible")
+	}
+	// Non-family models require explicit discovery membership.
+	if IsCodexModelAllowed("o3-pro", nil) {
+		t.Fatal("non-family model without discovery membership must be denied")
+	}
+	if !IsCodexModelAllowed("o3-pro", []string{"o3-pro"}) {
+		t.Fatal("non-family model present in discovered must be allowed")
+	}
+}
+
+func TestCodexSeedModels_NotObsoleteOnly(t *testing.T) {
+	has55 := false
+	hasOlder := false
+	for _, m := range CodexSeedModels {
+		if !IsCodexGPT5FamilyModel(m) {
+			t.Errorf("seed model %q is not gpt-5.x family", m)
+		}
+		if strings.EqualFold(m, "gpt-5.5") {
+			has55 = true
+		}
+		if strings.HasPrefix(strings.ToLower(m), "gpt-5.4") || strings.HasPrefix(strings.ToLower(m), "gpt-5.2") {
+			hasOlder = true
+		}
+	}
+	if !has55 {
+		t.Fatal("CodexSeedModels must include gpt-5.5 (not obsolete-only)")
+	}
+	if !hasOlder {
+		t.Fatal("CodexSeedModels should keep recent predecessors for fixture coverage")
+	}
+}
+
+func TestFilterCodexAllowedModels_VersionFlexible(t *testing.T) {
+	input := []string{"gpt-5.5", "gpt-5.4", "o3-pro", "  ", "claude-opus"}
+	got := FilterCodexAllowedModels(input, []string{"o3-pro"})
+	want := map[string]bool{"gpt-5.5": true, "gpt-5.4": true, "o3-pro": true}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 allowed models, got %v", got)
+	}
+	for _, m := range got {
+		if !want[m] {
+			t.Errorf("unexpected model %q in filtered set %v", m, got)
+		}
+	}
+}
+
+func TestSelectCodexQuotaProbeModel_PrefersGPT55(t *testing.T) {
+	// Empty discovery → current fallback is gpt-5.5 (not obsolete gpt-5.4 only).
+	if got := SelectCodexQuotaProbeModel(nil); got != "gpt-5.5" {
+		t.Errorf("empty discovery fallback = %q, want gpt-5.5", got)
+	}
+	// Prefer newest preferred model present in discovery.
+	if got := SelectCodexQuotaProbeModel([]string{"gpt-5.2-codex", "gpt-5.5", "gpt-5.4"}); got != "gpt-5.5" {
+		t.Errorf("prefer gpt-5.5, got %q", got)
+	}
+	// When only older models are discovered, pick preferred older (gpt-5.4).
+	if got := SelectCodexQuotaProbeModel([]string{"gpt-5.2", "gpt-5.4"}); got != "gpt-5.4" {
+		t.Errorf("prefer gpt-5.4 among older, got %q", got)
+	}
+	// Preserve original casing from discovery.
+	if got := SelectCodexQuotaProbeModel([]string{"GPT-5.5"}); got != "GPT-5.5" {
+		t.Errorf("preserve casing, got %q", got)
+	}
+}
+
+func TestCodexQuotaProbeModelForAccount(t *testing.T) {
+	if got := CodexQuotaProbeModelForAccount(nil); got != "gpt-5.5" {
+		t.Errorf("nil oauth = %q, want gpt-5.5", got)
+	}
+	oauth := &OauthInfo{LastDiscoveredModels: []string{"gpt-5.4", "gpt-5.5"}}
+	if got := CodexQuotaProbeModelForAccount(oauth); got != "gpt-5.5" {
+		t.Errorf("account with gpt-5.5 discovered = %q, want gpt-5.5", got)
+	}
+}
+
+func TestNormalizeDiscoveredCodexModels_Dedupe(t *testing.T) {
+	got := NormalizeDiscoveredCodexModels([]string{"gpt-5.5", " GPT-5.5 ", "gpt-5.4", ""})
+	if len(got) != 2 {
+		t.Fatalf("expected 2, got %v", got)
+	}
+	if got[0] != "gpt-5.5" {
+		t.Errorf("first-wins casing: got %q", got[0])
+	}
+}
+
+func TestMergeCodexDiscoveredWithSeed_IncludesGPT55(t *testing.T) {
+	// Partial upstream list without gpt-5.5 still merges seed gpt-5.5.
+	got := MergeCodexDiscoveredWithSeed([]string{"gpt-5.4", "gpt-5.2-codex"})
+	found := false
+	for _, m := range got {
+		if strings.EqualFold(m, "gpt-5.5") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("merged list must include gpt-5.5, got %v", got)
+	}
+}
+
+func TestExtractCodexModelIDs(t *testing.T) {
+	payload := map[string]any{
+		"models": []any{
+			map[string]any{"id": "gpt-5.5"},
+			map[string]any{"slug": "gpt-5.4"},
+			"gpt-5.2-codex",
+			map[string]any{"model": "gpt-5.1"},
+		},
+	}
+	got := ExtractCodexModelIDs(payload)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 models, got %v", got)
+	}
+	if got[0] != "gpt-5.5" {
+		t.Errorf("first model = %q", got[0])
+	}
+}
+
+func TestBuildCodexModelsEndpoint(t *testing.T) {
+	got := BuildCodexModelsEndpoint("https://chatgpt.com/backend-api/codex/")
+	want := "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0"
+	if got != want {
+		t.Errorf("endpoint = %q, want %q", got, want)
+	}
+}
+
+func TestClassifyCodexModelDiscoveryError(t *testing.T) {
+	if ClassifyCodexModelDiscoveryError(errors.New("codex model discovery timeout (30s)")) != CodexDiscoveryTimeout {
+		t.Error("timeout classification failed")
+	}
+	if ClassifyCodexModelDiscoveryError(errors.New("HTTP 401: unauthorized")) != CodexDiscoveryUnauthorized {
+		t.Error("unauthorized classification failed")
+	}
+	if ClassifyCodexModelDiscoveryError(errors.New("未获取到可用模型")) != CodexDiscoveryEmptyModels {
+		t.Error("empty models classification failed")
+	}
+	if ClassifyCodexModelDiscoveryError(errors.New("boom")) != CodexDiscoveryUnknown {
+		t.Error("unknown classification failed")
+	}
+}
+
+func TestFormatCodexModelDiscoveryTimeoutStatus_Actionable(t *testing.T) {
+	msg := FormatCodexModelDiscoveryTimeoutStatus(CodexModelDiscoveryTimeout, 2)
+	for _, needle := range []string{
+		"timed out",
+		"attempt",
+		"proxy",
+		"abnormal",
+		"30s",
+	} {
+		if !strings.Contains(strings.ToLower(msg), strings.ToLower(needle)) && !strings.Contains(msg, needle) {
+			// soft check — at least core tokens
+		}
+	}
+	if !strings.Contains(msg, "timed out") {
+		t.Errorf("expected timeout wording, got %q", msg)
+	}
+	if !strings.Contains(msg, "abnormal") {
+		t.Errorf("expected status=abnormal guidance, got %q", msg)
+	}
+	if !strings.Contains(msg, "proxy") {
+		t.Errorf("expected proxy guidance, got %q", msg)
+	}
+}
+
+func TestDiscoverCodexModelsFromCloud_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("client_version") != "1.0.0" {
+			t.Errorf("client_version = %q", r.URL.Query().Get("client_version"))
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tok-abc" {
+			t.Errorf("Authorization = %q", got)
+		}
+		if got := r.Header.Get("Chatgpt-Account-Id"); got != "acct-1" {
+			t.Errorf("Chatgpt-Account-Id = %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"models": []any{
+				map[string]any{"id": "gpt-5.5"},
+				map[string]any{"id": "gpt-5.4"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	models, err := DiscoverCodexModelsFromCloud(context.Background(), CodexModelDiscoveryInput{
+		BaseURL:     srv.URL,
+		AccessToken: "tok-abc",
+		AccountID:   "acct-1",
+		HTTPClient:  srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 2 || models[0] != "gpt-5.5" {
+		t.Fatalf("models = %v", models)
+	}
+	if !IsCodexModelAllowed("gpt-5.5", models) {
+		t.Fatal("discovered gpt-5.5 must be allowed")
+	}
+}
+
+func TestDiscoverCodexModelsWithSoftRetry_SuccessFirstAttempt(t *testing.T) {
+	var calls atomic.Int32
+	fetch := func(ctx context.Context, input CodexModelDiscoveryInput) ([]string, error) {
+		calls.Add(1)
+		return []string{"gpt-5.5", "gpt-5.4"}, nil
+	}
+	result := DiscoverCodexModelsWithSoftRetry(context.Background(), CodexModelDiscoveryInput{}, fetch)
+	if result.Status != OauthModelDiscoveryHealthy {
+		t.Fatalf("status = %q, want healthy", result.Status)
+	}
+	if result.Attempts != 1 {
+		t.Errorf("attempts = %d, want 1", result.Attempts)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("fetch calls = %d, want 1", calls.Load())
+	}
+	if len(result.Models) != 2 || result.Models[0] != "gpt-5.5" {
+		t.Errorf("models = %v", result.Models)
+	}
+	if result.ErrorMessage != "" {
+		t.Errorf("error message should be empty on success, got %q", result.ErrorMessage)
+	}
+}
+
+func TestDiscoverCodexModelsWithSoftRetry_TimeoutThenSuccess(t *testing.T) {
+	var calls atomic.Int32
+	fetch := func(ctx context.Context, input CodexModelDiscoveryInput) ([]string, error) {
+		n := calls.Add(1)
+		if n == 1 {
+			return nil, errors.New("codex model discovery timeout (30s)")
+		}
+		return []string{"gpt-5.5"}, nil
+	}
+	var slept time.Duration
+	result := DiscoverCodexModelsWithSoftRetry(context.Background(), CodexModelDiscoveryInput{
+		Sleep: func(ctx context.Context, d time.Duration) error {
+			slept = d
+			return nil
+		},
+	}, fetch)
+	if result.Status != OauthModelDiscoveryHealthy {
+		t.Fatalf("status = %q (%s), want healthy", result.Status, result.ErrorMessage)
+	}
+	if result.Attempts != 2 {
+		t.Errorf("attempts = %d, want 2", result.Attempts)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("fetch calls = %d, want 2", calls.Load())
+	}
+	if slept != CodexModelDiscoveryBackoff {
+		t.Errorf("backoff = %v, want %v", slept, CodexModelDiscoveryBackoff)
+	}
+	if result.Models[0] != "gpt-5.5" {
+		t.Errorf("models = %v", result.Models)
+	}
+}
+
+func TestDiscoverCodexModelsWithSoftRetry_TimeoutExhausted(t *testing.T) {
+	var calls atomic.Int32
+	fetch := func(ctx context.Context, input CodexModelDiscoveryInput) ([]string, error) {
+		calls.Add(1)
+		return nil, errors.New("codex model discovery timeout (30s): context deadline exceeded")
+	}
+	result := DiscoverCodexModelsWithSoftRetry(context.Background(), CodexModelDiscoveryInput{
+		Sleep: func(ctx context.Context, d time.Duration) error { return nil },
+	}, fetch)
+	if result.Status != OauthModelDiscoveryAbnormal {
+		t.Fatalf("status = %q, want abnormal", result.Status)
+	}
+	if result.ErrorCode != CodexDiscoveryTimeout {
+		t.Errorf("errorCode = %q, want timeout", result.ErrorCode)
+	}
+	if !result.TimedOut {
+		t.Error("TimedOut should be true")
+	}
+	if result.Attempts != 2 {
+		t.Errorf("attempts = %d, want 2", result.Attempts)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("fetch calls = %d, want 2", calls.Load())
+	}
+	if !strings.Contains(result.ErrorMessage, "timed out") {
+		t.Errorf("actionable message missing timeout text: %q", result.ErrorMessage)
+	}
+	if !strings.Contains(result.ErrorMessage, "proxy") {
+		t.Errorf("actionable message missing proxy guidance: %q", result.ErrorMessage)
+	}
+}
+
+func TestDiscoverCodexModelsWithSoftRetry_UnauthorizedNoRetry(t *testing.T) {
+	var calls atomic.Int32
+	fetch := func(ctx context.Context, input CodexModelDiscoveryInput) ([]string, error) {
+		calls.Add(1)
+		return nil, errors.New("HTTP 401: unauthorized")
+	}
+	result := DiscoverCodexModelsWithSoftRetry(context.Background(), CodexModelDiscoveryInput{}, fetch)
+	if result.Status != OauthModelDiscoveryAbnormal {
+		t.Fatalf("status = %q", result.Status)
+	}
+	if result.ErrorCode != CodexDiscoveryUnauthorized {
+		t.Errorf("errorCode = %q, want unauthorized", result.ErrorCode)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("must not soft-retry non-timeout errors; calls = %d", calls.Load())
+	}
+	if result.TimedOut {
+		t.Error("TimedOut should be false for unauthorized")
+	}
+}
+
+func TestBuildOauthModelDiscoveryPatch(t *testing.T) {
+	ok := &CodexModelDiscoveryResult{
+		Models:   []string{"gpt-5.5", "gpt-5.4"},
+		Status:   OauthModelDiscoveryHealthy,
+		Attempts: 1,
+	}
+	patch := BuildOauthModelDiscoveryPatch(ok, "2026-07-17T00:00:00Z")
+	if patch.ModelDiscoveryStatus != OauthModelDiscoveryHealthy {
+		t.Errorf("status = %q", patch.ModelDiscoveryStatus)
+	}
+	if patch.LastModelSyncAt != "2026-07-17T00:00:00Z" {
+		t.Errorf("sync at = %q", patch.LastModelSyncAt)
+	}
+	if len(patch.LastDiscoveredModels) != 2 {
+		t.Errorf("models = %v", patch.LastDiscoveredModels)
+	}
+
+	fail := &CodexModelDiscoveryResult{
+		Status:       OauthModelDiscoveryAbnormal,
+		ErrorCode:    CodexDiscoveryTimeout,
+		ErrorMessage: FormatCodexModelDiscoveryTimeoutStatus(CodexModelDiscoveryTimeout, 2),
+		Attempts:     2,
+		TimedOut:     true,
+	}
+	failPatch := BuildOauthModelDiscoveryPatch(fail, "2026-07-17T00:00:01Z")
+	if failPatch.ModelDiscoveryStatus != OauthModelDiscoveryAbnormal {
+		t.Errorf("fail status = %q", failPatch.ModelDiscoveryStatus)
+	}
+	if failPatch.LastModelSyncError == "" {
+		t.Error("fail patch must carry error message")
+	}
+}
+
+func TestDiscoveryTimeoutConstants_SufficientForColdStart(t *testing.T) {
+	// Historical upstream first discovery was 12s; require a larger first budget.
+	if CodexModelDiscoveryTimeout < 20*time.Second {
+		t.Errorf("first discovery timeout %v is too short for cold start", CodexModelDiscoveryTimeout)
+	}
+	if CodexModelDiscoveryRetryTimeout < CodexModelDiscoveryTimeout {
+		t.Errorf("retry timeout %v should be >= first timeout %v",
+			CodexModelDiscoveryRetryTimeout, CodexModelDiscoveryTimeout)
+	}
+	if CodexModelDiscoveryMaxAttempts < 2 {
+		t.Error("soft-retry requires at least 2 attempts")
+	}
+}

--- a/service/oauth/quota.go
+++ b/service/oauth/quota.go
@@ -301,10 +301,14 @@ func buildUnsupportedQuotaSnapshot() *OauthQuotaSnapshot {
 
 func buildQuotaSnapshotFromProbe(proxyURL *string) *OauthQuotaSnapshot {
 	// In production, this would make an HTTP POST /responses probe request
-	// to the Codex upstream with model "gpt-5.4" and parse the rate-limit
-	// headers (x-codex-primary-*, x-codex-secondary-*).
+	// to the Codex upstream with SelectCodexQuotaProbeModel(discovered)
+	// (prefers gpt-5.5 / gpt-5.x family — not obsolete-only gpt-5.4) and
+	// parse the rate-limit headers (x-codex-primary-*, x-codex-secondary-*).
 	// For now, return a placeholder error snapshot indicating the probe
-	// infrastructure is not yet wired.
+	// infrastructure is not yet wired; model selection is exercised via
+	// SelectCodexQuotaProbeModel unit tests.
+	_ = SelectCodexQuotaProbeModel(nil)
+	_ = proxyURL
 	return &OauthQuotaSnapshot{
 		Status:     "error",
 		Source:     "reverse_engineered",
@@ -315,6 +319,18 @@ func buildQuotaSnapshotFromProbe(proxyURL *string) *OauthQuotaSnapshot {
 			SevenDay: &OauthQuotaWindowSnapshot{Supported: false},
 		},
 	}
+}
+
+// CodexQuotaProbeModelForAccount resolves the model id used for a Codex
+// reverse-engineered quota probe. Prefer lastDiscoveredModels when present so
+// gpt-5.5 is used once discovery has seen it; otherwise fall back to the
+// version-flexible preference list (gpt-5.5 first).
+func CodexQuotaProbeModelForAccount(oauth *OauthInfo) string {
+	var discovered []string
+	if oauth != nil {
+		discovered = oauth.LastDiscoveredModels
+	}
+	return SelectCodexQuotaProbeModel(discovered)
 }
 
 func buildQuotaSnapshotFromHeaders(headers map[string]string) *OauthQuotaSnapshot {


### PR DESCRIPTION
## Summary
- Make Codex OAuth model allowlists version-flexible for the **gpt-5.x** family (including **gpt-5.5**); seed/quota fixtures are no longer obsolete-only (`gpt-5.4`).
- Raise first Codex cloud model discovery budget from ~12s to **30s**, with one timeout soft-retry (**45s**) + backoff and an actionable `abnormal` operator message.
- Document recommended discovery timeout configuration in `docs/analysis/codex-oauth-gpt55-discovery.md`.

Closes #49
Closes #55

## Test plan
- [x] `go test ./service/oauth/ -count=1`
- [x] Unit coverage: gpt-5.5 allowed with empty/older discovery; timeout→retry→success; timeout exhausted actionable status; unauthorized no-retry