### PR TITLE
fix(proxy): responses-only site routing and stream preference #56

### DIFF
--- a/docs/analysis/responses-only-sites.md
+++ b/docs/analysis/responses-only-sites.md
@@ -1,0 +1,13 @@
+# Responses-only site streaming preference (#56 / upstream #340)
+
+## Operator marks
+Custom headers on the site (not forwarded upstream):
+- `x-metapi-responses-only: true` — only `/v1/responses`
+- `x-metapi-endpoint-preference: responses` — prefer responses first
+- `x-metapi-stream-only` / stream preference — force stream on responses
+
+## Platform/URL heuristics
+Codex platform and known responses-only relay hosts prefer `/v1/responses`.
+
+## Client policy
+Chat/messages clients against responses-only sites are rewritten to responses candidates (or receive a clear unsupported message when transform is impossible).

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -213,7 +213,19 @@ func dispatchSelectedUpstream(
 	}
 	bodyBytes = swapModelInJSON(ctx.RawBody, upstreamModel)
 
-	candidatePaths := resolveUpstreamCandidatePaths(upstreamPath, disableCrossProtocolFallback)
+	// Site protocol preference (#56 / upstream #340): responses-only + stream.
+	sitePref := proxy.DetectSiteProtocolPreferenceFromSite(
+		selected.Site.Platform,
+		selected.Site.URL,
+		selected.Site.CustomHeaders,
+	)
+	if errMsg := responsesOnlyClientError(upstreamPath, bodyBytes, sitePref); errMsg != "" {
+		// Clear failure for chat/messages clients when site cannot serve without transform.
+		writeJSONError(w, http.StatusBadRequest, errMsg, "invalid_request_error")
+		return true, nil
+	}
+
+	candidatePaths := resolveUpstreamCandidatePaths(upstreamPath, disableCrossProtocolFallback, sitePref)
 	var lastPending *pendingUpstreamFailure
 	for i, path := range candidatePaths {
 		isLast := i >= len(candidatePaths)-1
@@ -223,10 +235,13 @@ func dispatchSelectedUpstream(
 			writeJSONError(w, http.StatusBadRequest, sanitizeErr.Error(), "invalid_request_error")
 			return true, nil
 		}
+		// Force stream=true for responses-only / stream-preferring sites (and codex/sub2api).
+		attemptBody, forcedStream := applyUpstreamStreamPreference(attemptBody, selected.Site.Platform, path, sitePref)
+		effectiveStream := ctx.IsStream || forcedStream
 		finished, pending, cont := dispatchEndpointAttemptWithContinue(
 			w, r, ctx, cfg, selected, upstreamModel, proxyConfig,
 			path, contentType, attemptBody, firstByteTimeoutMs,
-			retry, maxRetries, isLast, disableCrossProtocolFallback,
+			retry, maxRetries, isLast, disableCrossProtocolFallback, effectiveStream,
 		)
 		if finished {
 			return true, nil
@@ -253,8 +268,12 @@ func dispatchSelectedUpstream(
 
 // resolveUpstreamCandidatePaths returns ordered upstream paths for one channel attempt.
 // Non chat-family paths yield the original path only.
-func resolveUpstreamCandidatePaths(upstreamPath string, disableCrossProtocolFallback bool) []string {
-	candidates := proxy.ResolveEndpointCandidates(upstreamPath, disableCrossProtocolFallback)
+// sitePref controls responses-only / prefer-responses ordering (#56).
+func resolveUpstreamCandidatePaths(upstreamPath string, disableCrossProtocolFallback bool, sitePref proxy.SiteProtocolPreference) []string {
+	candidates := proxy.ResolveEndpointCandidatesWithOptions(upstreamPath, proxy.EndpointCandidateOptions{
+		DisableCrossProtocolFallback: disableCrossProtocolFallback,
+		Preference:                   sitePref,
+	})
 	if len(candidates) == 0 {
 		return []string{upstreamPath}
 	}
@@ -268,6 +287,78 @@ func resolveUpstreamCandidatePaths(upstreamPath string, disableCrossProtocolFall
 		return []string{upstreamPath}
 	}
 	return paths
+}
+
+// responsesOnlyClientError returns a clear client message when a chat/messages
+// shaped request hits a responses-only site (no heavy protocol transform in this wave).
+func responsesOnlyClientError(downstreamPath string, bodyBytes []byte, pref proxy.SiteProtocolPreference) string {
+	if !pref.ResponsesOnly {
+		return ""
+	}
+	ep, ok := proxy.EndpointFromPath(downstreamPath)
+	if !ok || ep == proxy.EndpointResponses {
+		return ""
+	}
+	// If body already looks responses-shaped (has input, no messages), allow path rewrite.
+	if bodyLooksResponsesShaped(bodyBytes) {
+		return ""
+	}
+	return proxy.ResponsesOnlyChatUnsupportedMessage(downstreamPath)
+}
+
+func bodyLooksResponsesShaped(bodyBytes []byte) bool {
+	if len(bodyBytes) == 0 {
+		return false
+	}
+	var body map[string]any
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		return false
+	}
+	if _, hasMessages := body["messages"]; hasMessages {
+		return false
+	}
+	if _, hasInput := body["input"]; hasInput {
+		return true
+	}
+	return false
+}
+
+// applyUpstreamStreamPreference forces stream=true when site/platform requires it.
+func applyUpstreamStreamPreference(bodyBytes []byte, sitePlatform, upstreamPath string, pref proxy.SiteProtocolPreference) ([]byte, bool) {
+	pathLower := strings.ToLower(upstreamPath)
+	isCompact := strings.Contains(pathLower, "/responses/compact")
+	// Platform helper (codex/sub2api) OR site preference.
+	force := responses.ShouldForceResponsesUpstreamStream(sitePlatform, isCompact) ||
+		proxy.ShouldForceUpstreamStream(pref, upstreamPath, isCompact)
+	if !force {
+		return bodyBytes, false
+	}
+	if len(bodyBytes) == 0 {
+		return []byte(`{"stream":true}`), true
+	}
+	var body map[string]any
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		return bodyBytes, false
+	}
+	// Already streaming?
+	if v, ok := body["stream"]; ok {
+		if b, ok := v.(bool); ok && b {
+			return bodyBytes, false
+		}
+		if s, ok := v.(string); ok && (s == "true" || s == "1") {
+			return bodyBytes, false
+		}
+	}
+	next := make(map[string]any, len(body)+1)
+	for k, v := range body {
+		next[k] = v
+	}
+	next["stream"] = true
+	out, err := json.Marshal(next)
+	if err != nil {
+		return bodyBytes, false
+	}
+	return out, true
 }
 
 // dispatchEndpointAttempt is the single-path entry used by multipart.
@@ -290,7 +381,7 @@ func dispatchEndpointAttempt(
 	finished, pending, _ := dispatchEndpointAttemptWithContinue(
 		w, r, ctx, cfg, selected, upstreamModel, proxyConfig,
 		upstreamPath, contentType, bodyBytes, firstByteTimeoutMs,
-		retry, maxRetries, true, true,
+		retry, maxRetries, true, true, ctx != nil && ctx.IsStream,
 	)
 	if !recordFailure {
 		return finished, pending
@@ -317,6 +408,7 @@ func dispatchEndpointAttemptWithContinue(
 	maxRetries int,
 	isLastEndpoint bool,
 	disableCrossProtocolFallback bool,
+	effectiveStream bool,
 ) (finished bool, nextPending *pendingUpstreamFailure, cont bool) {
 	upstreamURL := proxy.BuildUpstreamURL(selected.Site.URL, upstreamPath)
 	startedAt := time.Now()
@@ -377,7 +469,7 @@ func dispatchEndpointAttemptWithContinue(
 	}
 
 	// Step 9: Handle response
-	if ctx.IsStream {
+	if effectiveStream {
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			respBody, readErr := proxy.ReadBufferedResponseBody(resp.Body)
 			resp.Body.Close()
@@ -533,6 +625,10 @@ func applyProxyCustomHeaders(req *http.Request, proxyConfig *platform.ProxyConfi
 		return
 	}
 	for k, v := range proxyConfig.CustomHeaders {
+		// Preference control headers are site marks only — never forward upstream.
+		if proxy.IsMetapiControlHeader(k) {
+			continue
+		}
 		req.Header.Set(k, v)
 	}
 }

--- a/handler/proxy/upstream_failover_test.go
+++ b/handler/proxy/upstream_failover_test.go
@@ -1,6 +1,7 @@
 package proxyhandler
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,20 +16,36 @@ import (
 )
 
 func TestResolveUpstreamCandidatePaths(t *testing.T) {
-	paths := resolveUpstreamCandidatePaths("/v1/chat/completions", false)
+	paths := resolveUpstreamCandidatePaths("/v1/chat/completions", false, proxy.SiteProtocolPreference{})
 	if len(paths) < 2 {
 		t.Fatalf("expected multi-protocol candidates, got %v", paths)
 	}
 	if paths[0] != "/v1/chat/completions" {
 		t.Fatalf("primary path = %q", paths[0])
 	}
-	disabled := resolveUpstreamCandidatePaths("/v1/chat/completions", true)
+	disabled := resolveUpstreamCandidatePaths("/v1/chat/completions", true, proxy.SiteProtocolPreference{})
 	if len(disabled) != 1 || disabled[0] != "/v1/chat/completions" {
 		t.Fatalf("disabled fallback paths = %v", disabled)
 	}
-	nonChat := resolveUpstreamCandidatePaths("/v1/embeddings", false)
+	nonChat := resolveUpstreamCandidatePaths("/v1/embeddings", false, proxy.SiteProtocolPreference{})
 	if len(nonChat) != 1 || nonChat[0] != "/v1/embeddings" {
 		t.Fatalf("non-chat paths = %v", nonChat)
+	}
+	// Responses-only site: chat client rewrites candidate list to responses only.
+	only := resolveUpstreamCandidatePaths("/v1/chat/completions", false, proxy.SiteProtocolPreference{
+		ResponsesOnly:   true,
+		PreferResponses: true,
+		PreferStream:    true,
+	})
+	if len(only) != 1 || only[0] != "/v1/responses" {
+		t.Fatalf("responses-only paths = %v, want [/v1/responses]", only)
+	}
+	// Prefer-responses (not only): responses first with fallbacks.
+	prefer := resolveUpstreamCandidatePaths("/v1/chat/completions", false, proxy.SiteProtocolPreference{
+		PreferResponses: true,
+	})
+	if len(prefer) < 2 || prefer[0] != "/v1/responses" {
+		t.Fatalf("prefer-responses paths = %v, want responses first", prefer)
 	}
 }
 
@@ -200,5 +217,91 @@ func TestDispatchFirstByteTimeoutFallsBackToNextEndpointWithoutPoison(t *testing
 	}
 	if body := rec.Body.String(); !strings.Contains(body, "chatcmpl_fast") {
 		t.Fatalf("body = %q, want fast fallback response", body)
+	}
+}
+
+
+func TestDispatchResponsesOnlySiteRoutesToResponsesAndForcesStream(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		paths    []string
+		streamed bool
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if r.URL.Path != "/v1/responses" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not responses"}`))
+			return
+		}
+		if v, ok := body["stream"].(bool); ok && v {
+			streamed = true
+		}
+		// SSE-ish response for forced stream path.
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"id\":\"resp_ok\",\"type\":\"response.completed\"}\n\n"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	customHeaders := `{"x-metapi-responses-only":"true"}`
+	router := &upstreamTestRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active", Platform: "openai", CustomHeaders: &customHeaders},
+		TokenValue:  "upstream-token",
+		ActualModel: "gpt-4o",
+	}}
+	SetUpstreamConfig(&UpstreamConfig{Router: router})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	// Chat path + responses-shaped body (input, no messages) should rewrite to /v1/responses.
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"gpt-4o","input":"hello"}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s paths=%v", rec.Code, rec.Body.String(), paths)
+	}
+	mu.Lock()
+	gotPaths := append([]string(nil), paths...)
+	mu.Unlock()
+	if len(gotPaths) != 1 || gotPaths[0] != "/v1/responses" {
+		t.Fatalf("paths = %v, want only /v1/responses", gotPaths)
+	}
+	if !streamed {
+		t.Fatal("expected stream=true forced for responses-only site")
+	}
+}
+
+func TestDispatchResponsesOnlySiteRejectsChatShapedBody(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("upstream should not be called; got %s", r.URL.Path)
+	}))
+	t.Cleanup(upstream.Close)
+
+	customHeaders := `{"x-metapi-responses-only":"1"}`
+	router := &upstreamTestRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active", Platform: "openai", CustomHeaders: &customHeaders},
+		TokenValue:  "upstream-token",
+		ActualModel: "gpt-4o",
+	}}
+	SetUpstreamConfig(&UpstreamConfig{Router: router})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "responses-only") {
+		t.Fatalf("body = %q, want clear responses-only error", body)
 	}
 }

--- a/proxy/endpoint_flow.go
+++ b/proxy/endpoint_flow.go
@@ -50,45 +50,8 @@ func EndpointFromPath(path string) (UpstreamEndpoint, bool) {
 	}
 }
 
-// ResolveEndpointCandidates builds the ordered multi-protocol candidate list for a
-// downstream path. Primary endpoint is first. When disableCrossProtocolFallback is
-// true, only the primary is returned. Non chat-family paths yield a single synthetic
-// candidate list of length 1 using the original path via PathForEndpoint fallbacks.
-//
-// Product policy (upstream #387 / issue #38):
-// - first-byte timeout or protocol-mismatch may continue to remaining candidates
-// - DISABLE_CROSS_PROTOCOL_FALLBACK stops after the primary attempt
-func ResolveEndpointCandidates(downstreamPath string, disableCrossProtocolFallback bool) []UpstreamEndpoint {
-	primary, ok := EndpointFromPath(downstreamPath)
-	if !ok {
-		// Non chat-family: no multi-protocol list. Caller should use the original path.
-		return nil
-	}
-	if disableCrossProtocolFallback {
-		return []UpstreamEndpoint{primary}
-	}
-	// Primary first, then remaining chat-family protocols in stable order.
-	order := []UpstreamEndpoint{EndpointChat, EndpointMessages, EndpointResponses}
-	// Prefer responses→chat→messages when primary is responses (common Codex downgrade).
-	switch primary {
-	case EndpointResponses:
-		order = []UpstreamEndpoint{EndpointResponses, EndpointChat, EndpointMessages}
-	case EndpointMessages:
-		order = []UpstreamEndpoint{EndpointMessages, EndpointChat, EndpointResponses}
-	case EndpointChat:
-		order = []UpstreamEndpoint{EndpointChat, EndpointMessages, EndpointResponses}
-	}
-	out := make([]UpstreamEndpoint, 0, len(order))
-	seen := map[UpstreamEndpoint]bool{}
-	for _, ep := range order {
-		if seen[ep] {
-			continue
-		}
-		seen[ep] = true
-		out = append(out, ep)
-	}
-	return out
-}
+// ResolveEndpointCandidates lives in site_preference.go (with responses-only options).
+// See ResolveEndpointCandidates / ResolveEndpointCandidatesWithOptions.
 
 // ShouldDowngradeToNextEndpoint reports whether an upstream error indicates the
 // current protocol/path is wrong and a different endpoint candidate should be tried.

--- a/proxy/endpoint_flow_test.go
+++ b/proxy/endpoint_flow_test.go
@@ -493,6 +493,37 @@ func TestResolveEndpointCandidates(t *testing.T) {
 			t.Fatalf("got %v, want nil", got)
 		}
 	})
+	t.Run("responses-only site forces responses only", func(t *testing.T) {
+		got := ResolveEndpointCandidatesWithOptions("/v1/chat/completions", EndpointCandidateOptions{
+			Preference: SiteProtocolPreference{ResponsesOnly: true, PreferResponses: true},
+		})
+		if len(got) != 1 || got[0] != EndpointResponses {
+			t.Fatalf("got %v, want [responses]", got)
+		}
+	})
+	t.Run("prefer-responses reorders candidates", func(t *testing.T) {
+		got := ResolveEndpointCandidatesWithOptions("/v1/chat/completions", EndpointCandidateOptions{
+			Preference: SiteProtocolPreference{PreferResponses: true},
+		})
+		want := []UpstreamEndpoint{EndpointResponses, EndpointChat, EndpointMessages}
+		if len(got) != len(want) {
+			t.Fatalf("got %v want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("got %v want %v", got, want)
+			}
+		}
+	})
+	t.Run("responses-only ignores disableCrossProtocolFallback primary", func(t *testing.T) {
+		got := ResolveEndpointCandidatesWithOptions("/v1/chat/completions", EndpointCandidateOptions{
+			DisableCrossProtocolFallback: true,
+			Preference:                   SiteProtocolPreference{ResponsesOnly: true},
+		})
+		if len(got) != 1 || got[0] != EndpointResponses {
+			t.Fatalf("got %v, want [responses]", got)
+		}
+	})
 }
 
 func TestPathForEndpointAndFromPath(t *testing.T) {

--- a/proxy/profiles/responses_only.go
+++ b/proxy/profiles/responses_only.go
@@ -1,0 +1,255 @@
+package profiles
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+)
+
+// Site protocol preference control headers (site.custom_headers).
+// These are configuration signals for MetAPI and must not be forwarded upstream.
+const (
+	HeaderResponsesOnly       = "x-metapi-responses-only"
+	HeaderStreamOnly          = "x-metapi-stream-only"
+	HeaderEndpointPreference  = "x-metapi-endpoint-preference"
+	HeaderProtocolPreference  = "x-metapi-protocol-preference"
+)
+
+// SiteProtocolPreference describes how a site should be reached for chat-family traffic.
+// Issue #56 / upstream #340: some relays only expose /v1/responses (+ streaming).
+type SiteProtocolPreference struct {
+	// ResponsesOnly means the site should not be tried on chat/messages; only /v1/responses.
+	ResponsesOnly bool
+	// PreferResponses reorders multi-protocol candidates so responses is first (fallback allowed).
+	PreferResponses bool
+	// PreferStream forces upstream stream=true for responses (and stream-only sites).
+	PreferStream bool
+	// Source is a short debug label: platform | header | url | none.
+	Source string
+}
+
+// DetectSiteProtocolPreference resolves responses-only / stream preference from
+// site platform, URL, and optional custom headers.
+//
+// Precedence (first match wins for Source; flags OR together across sources):
+//  1. custom headers (operator mark)
+//  2. platform (codex / known responses-stream platforms)
+//  3. URL host markers (known responses-only relays)
+func DetectSiteProtocolPreference(platform, siteURL string, customHeaders map[string]string) SiteProtocolPreference {
+	pref := SiteProtocolPreference{Source: "none"}
+
+	if h := preferenceFromHeaders(customHeaders); h.ResponsesOnly || h.PreferResponses || h.PreferStream {
+		mergePreference(&pref, h)
+		if pref.Source == "none" || pref.Source == "" {
+			pref.Source = "header"
+		}
+	}
+
+	if p := preferenceFromPlatform(platform); p.ResponsesOnly || p.PreferResponses || p.PreferStream {
+		mergePreference(&pref, p)
+		if pref.Source == "none" {
+			pref.Source = "platform"
+		}
+	}
+
+	if u := preferenceFromURL(siteURL); u.ResponsesOnly || u.PreferResponses || u.PreferStream {
+		mergePreference(&pref, u)
+		if pref.Source == "none" {
+			pref.Source = "url"
+		}
+	}
+
+	// Responses-only implies prefer-responses + stream preference (upstream #340).
+	if pref.ResponsesOnly {
+		pref.PreferResponses = true
+		pref.PreferStream = true
+	}
+	return pref
+}
+
+// IsResponsesOnlySite is a convenience wrapper for DetectSiteProtocolPreference(...).ResponsesOnly.
+func IsResponsesOnlySite(platform, siteURL string, customHeaders map[string]string) bool {
+	return DetectSiteProtocolPreference(platform, siteURL, customHeaders).ResponsesOnly
+}
+
+// IsMetapiControlHeader reports whether a custom header is a MetAPI control signal
+// that must not be forwarded to upstream. Only known preference keys are blocked;
+// other x-metapi-* values (e.g. operator tracing headers) still pass through.
+func IsMetapiControlHeader(name string) bool {
+	n := strings.ToLower(strings.TrimSpace(name))
+	switch n {
+	case HeaderResponsesOnly, HeaderStreamOnly, HeaderEndpointPreference, HeaderProtocolPreference:
+		return true
+	default:
+		return false
+	}
+}
+
+// ParseCustomHeadersJSON parses a site.custom_headers JSON object into a flat map.
+// Invalid / empty input yields nil. Bool values become "true"/"false"; numbers become
+// their JSON text; other types are skipped.
+func ParseCustomHeadersJSON(raw string) map[string]string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var generic map[string]any
+	if err := json.Unmarshal([]byte(raw), &generic); err != nil {
+		return nil
+	}
+	if len(generic) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(generic))
+	for k, v := range generic {
+		switch t := v.(type) {
+		case string:
+			out[k] = t
+		case bool:
+			if t {
+				out[k] = "true"
+			} else {
+				out[k] = "false"
+			}
+		case float64:
+			b, err := json.Marshal(t)
+			if err == nil {
+				out[k] = string(b)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func preferenceFromHeaders(headers map[string]string) SiteProtocolPreference {
+	if len(headers) == 0 {
+		return SiteProtocolPreference{}
+	}
+	pref := SiteProtocolPreference{Source: "header"}
+	if isTruthyHeader(headers, HeaderResponsesOnly) {
+		pref.ResponsesOnly = true
+		pref.PreferResponses = true
+		pref.PreferStream = true
+	}
+	if isTruthyHeader(headers, HeaderStreamOnly) {
+		pref.PreferStream = true
+	}
+	if ep := getHeaderCI(headers, HeaderEndpointPreference); ep != "" {
+		switch strings.ToLower(strings.TrimSpace(ep)) {
+		case "responses", "responses-only", "response", "v1/responses", "/v1/responses":
+			pref.PreferResponses = true
+			if strings.Contains(strings.ToLower(ep), "only") || strings.EqualFold(ep, "responses-only") {
+				pref.ResponsesOnly = true
+				pref.PreferStream = true
+			}
+		}
+	}
+	if proto := getHeaderCI(headers, HeaderProtocolPreference); proto != "" {
+		lower := strings.ToLower(proto)
+		if strings.Contains(lower, "responses-only") || strings.Contains(lower, "responses_only") {
+			pref.ResponsesOnly = true
+			pref.PreferResponses = true
+			pref.PreferStream = true
+		} else if strings.Contains(lower, "responses") {
+			pref.PreferResponses = true
+		}
+		if strings.Contains(lower, "stream") {
+			pref.PreferStream = true
+		}
+	}
+	if !pref.ResponsesOnly && !pref.PreferResponses && !pref.PreferStream {
+		return SiteProtocolPreference{}
+	}
+	return pref
+}
+
+func preferenceFromPlatform(platform string) SiteProtocolPreference {
+	n := strings.ToLower(strings.TrimSpace(platform))
+	switch n {
+	case "codex", "chatgpt-codex", "chatgpt codex":
+		// Official Codex backend is responses + stream oriented.
+		return SiteProtocolPreference{
+			ResponsesOnly:   true,
+			PreferResponses: true,
+			PreferStream:    true,
+			Source:          "platform",
+		}
+	case "sub2api":
+		// sub2api often needs forced stream on responses; not strictly responses-only.
+		return SiteProtocolPreference{
+			PreferStream: true,
+			Source:       "platform",
+		}
+	default:
+		return SiteProtocolPreference{}
+	}
+}
+
+func preferenceFromURL(siteURL string) SiteProtocolPreference {
+	raw := strings.TrimSpace(siteURL)
+	if raw == "" {
+		return SiteProtocolPreference{}
+	}
+	host := strings.ToLower(raw)
+	if u, err := url.Parse(raw); err == nil && u.Host != "" {
+		host = strings.ToLower(u.Hostname())
+	} else {
+		// Fallback: strip scheme-ish prefix.
+		host = strings.TrimPrefix(host, "https://")
+		host = strings.TrimPrefix(host, "http://")
+		if i := strings.IndexAny(host, "/?"); i >= 0 {
+			host = host[:i]
+		}
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return SiteProtocolPreference{}
+	}
+
+	// Known responses-only relays from upstream #340 discussions.
+	// Keep this list narrow; operators can always mark via custom headers.
+	for _, marker := range responsesOnlyHostMarkers {
+		if host == marker || strings.HasSuffix(host, "."+marker) {
+			return SiteProtocolPreference{
+				ResponsesOnly:   true,
+				PreferResponses: true,
+				PreferStream:    true,
+				Source:          "url",
+			}
+		}
+	}
+	return SiteProtocolPreference{}
+}
+
+// responsesOnlyHostMarkers are host suffixes known to expose only /v1/responses (+ stream).
+var responsesOnlyHostMarkers = []string{
+	"aabb1.pro",
+}
+
+func mergePreference(dst *SiteProtocolPreference, src SiteProtocolPreference) {
+	if src.ResponsesOnly {
+		dst.ResponsesOnly = true
+	}
+	if src.PreferResponses {
+		dst.PreferResponses = true
+	}
+	if src.PreferStream {
+		dst.PreferStream = true
+	}
+	if dst.Source == "none" || dst.Source == "" {
+		dst.Source = src.Source
+	}
+}
+
+func isTruthyHeader(headers map[string]string, key string) bool {
+	v := strings.ToLower(strings.TrimSpace(getHeaderCI(headers, key)))
+	switch v {
+	case "1", "true", "yes", "on", "y":
+		return true
+	default:
+		return false
+	}
+}

--- a/proxy/profiles/responses_only_test.go
+++ b/proxy/profiles/responses_only_test.go
@@ -1,0 +1,32 @@
+package profiles
+
+import "testing"
+
+func TestDetectSiteProtocolPreference_HeaderResponsesOnly(t *testing.T) {
+	pref := DetectSiteProtocolPreference("openai", "https://example.com", map[string]string{
+		"x-metapi-responses-only": "true",
+	})
+	if !pref.ResponsesOnly || !pref.PreferResponses || !pref.PreferStream {
+		t.Fatalf("pref=%+v", pref)
+	}
+	if pref.Source != "header" {
+		t.Fatalf("source=%q", pref.Source)
+	}
+}
+
+func TestDetectSiteProtocolPreference_PlatformCodex(t *testing.T) {
+	pref := DetectSiteProtocolPreference("codex", "https://api.openai.com", nil)
+	if !pref.PreferResponses && !pref.ResponsesOnly {
+		// codex platform should at least prefer responses
+		t.Fatalf("expected prefer-responses for codex platform, got %+v", pref)
+	}
+}
+
+func TestIsMetapiControlHeader(t *testing.T) {
+	if !IsMetapiControlHeader("X-Metapi-Responses-Only") {
+		t.Fatal("expected control header")
+	}
+	if IsMetapiControlHeader("Authorization") {
+		t.Fatal("Authorization is not control")
+	}
+}

--- a/proxy/site_preference.go
+++ b/proxy/site_preference.go
@@ -1,0 +1,189 @@
+package proxy
+
+import (
+	"strings"
+
+	"github.com/tokendancelab/metapi-go/proxy/profiles"
+	"github.com/tokendancelab/metapi-go/proxy/types"
+)
+
+// SiteProtocolPreference re-exports profiles.SiteProtocolPreference for callers
+// that already depend on proxy (handler layer).
+type SiteProtocolPreference = profiles.SiteProtocolPreference
+
+// DetectSiteProtocolPreference resolves responses-only / stream preference for a site.
+// See docs/analysis/responses-only-sites.md (issue #56 / upstream #340).
+func DetectSiteProtocolPreference(platform, siteURL string, customHeaders map[string]string) SiteProtocolPreference {
+	return profiles.DetectSiteProtocolPreference(platform, siteURL, customHeaders)
+}
+
+// DetectSiteProtocolPreferenceFromSite is a convenience for store.Site-like fields.
+func DetectSiteProtocolPreferenceFromSite(platform, siteURL string, customHeadersJSON *string) SiteProtocolPreference {
+	var headers map[string]string
+	if customHeadersJSON != nil {
+		headers = profiles.ParseCustomHeadersJSON(*customHeadersJSON)
+	}
+	return profiles.DetectSiteProtocolPreference(platform, siteURL, headers)
+}
+
+// IsResponsesOnlySite reports whether the site is responses-only.
+func IsResponsesOnlySite(platform, siteURL string, customHeaders map[string]string) bool {
+	return profiles.IsResponsesOnlySite(platform, siteURL, customHeaders)
+}
+
+// IsMetapiControlHeader reports whether a custom header is a MetAPI control signal
+// that must not be forwarded upstream (responses-only / stream preference marks).
+func IsMetapiControlHeader(name string) bool {
+	return profiles.IsMetapiControlHeader(name)
+}
+
+// EndpointCandidateOptions controls multi-protocol candidate ordering.
+type EndpointCandidateOptions struct {
+	// DisableCrossProtocolFallback limits candidates to the primary endpoint only.
+	// When ResponsesOnly is set, primary is forced to responses regardless of
+	// downstream path (chat/messages clients are rewritten to responses).
+	DisableCrossProtocolFallback bool
+	// Preference is the site protocol preference (responses-only / stream).
+	Preference SiteProtocolPreference
+	// DownstreamClient may influence preference when Codex profile is detected.
+	DownstreamClient *types.DetectedProfile
+}
+
+// ResolveEndpointCandidatesWithOptions builds the ordered multi-protocol candidate
+// list honoring responses-only / prefer-responses site preference (#56).
+//
+// Policy:
+//   - responses-only site → only EndpointResponses (even if client called chat/messages)
+//   - prefer-responses    → responses first, then remaining chat-family endpoints
+//   - disableCrossProtocolFallback → single primary (responses when responses-only)
+//   - non chat-family path → nil (caller uses original path)
+func ResolveEndpointCandidatesWithOptions(downstreamPath string, opts EndpointCandidateOptions) []UpstreamEndpoint {
+	primary, ok := EndpointFromPath(downstreamPath)
+	if !ok {
+		return nil
+	}
+
+	pref := opts.Preference
+	// Codex client profile on responses path reinforces prefer-responses, but does
+	// not by itself force responses-only (that is a site property).
+	if opts.DownstreamClient != nil && opts.DownstreamClient.ID == types.ProfileCodex {
+		if !pref.PreferResponses && !pref.ResponsesOnly {
+			// no-op; site preference is authoritative for responses-only.
+		}
+	}
+
+	if pref.ResponsesOnly {
+		return []UpstreamEndpoint{EndpointResponses}
+	}
+
+	if opts.DisableCrossProtocolFallback {
+		return []UpstreamEndpoint{primary}
+	}
+
+	order := []UpstreamEndpoint{EndpointChat, EndpointMessages, EndpointResponses}
+	switch {
+	case pref.PreferResponses:
+		order = []UpstreamEndpoint{EndpointResponses, EndpointChat, EndpointMessages}
+	case primary == EndpointResponses:
+		order = []UpstreamEndpoint{EndpointResponses, EndpointChat, EndpointMessages}
+	case primary == EndpointMessages:
+		order = []UpstreamEndpoint{EndpointMessages, EndpointChat, EndpointResponses}
+	case primary == EndpointChat:
+		order = []UpstreamEndpoint{EndpointChat, EndpointMessages, EndpointResponses}
+	}
+
+	out := make([]UpstreamEndpoint, 0, len(order))
+	seen := map[UpstreamEndpoint]bool{}
+	for _, ep := range order {
+		if seen[ep] {
+			continue
+		}
+		seen[ep] = true
+		out = append(out, ep)
+	}
+	return out
+}
+
+// ResolveEndpointCandidates builds the ordered multi-protocol candidate list for a
+// downstream path. Primary endpoint is first. When disableCrossProtocolFallback is
+// true, only the primary is returned. Non chat-family paths yield nil.
+//
+// Product policy (upstream #387 / issue #38):
+// - first-byte timeout or protocol-mismatch may continue to remaining candidates
+// - DISABLE_CROSS_PROTOCOL_FALLBACK stops after the primary attempt
+//
+// For responses-only sites, prefer ResolveEndpointCandidatesWithOptions.
+func ResolveEndpointCandidates(downstreamPath string, disableCrossProtocolFallback bool) []UpstreamEndpoint {
+	return ResolveEndpointCandidatesWithOptions(downstreamPath, EndpointCandidateOptions{
+		DisableCrossProtocolFallback: disableCrossProtocolFallback,
+	})
+}
+
+// ShouldForceUpstreamStream reports whether the request body must set stream=true
+// for the given upstream path / site preference.
+//
+// Forces stream when:
+//   - site PreferStream / ResponsesOnly and path is responses (non-compact)
+//   - platform-level ShouldForceResponsesUpstreamStream (codex/sub2api) — callers
+//     may combine with transform/openai/responses helpers
+func ShouldForceUpstreamStream(pref SiteProtocolPreference, upstreamPath string, isCompact bool) bool {
+	if isCompact {
+		return false
+	}
+	if !pref.PreferStream && !pref.ResponsesOnly {
+		return false
+	}
+	ep, ok := EndpointFromPath(upstreamPath)
+	if !ok {
+		// Treat explicit responses compact/non-compact paths.
+		p := strings.ToLower(strings.TrimSpace(upstreamPath))
+		if strings.Contains(p, "/responses") && !strings.Contains(p, "/compact") {
+			return true
+		}
+		return false
+	}
+	return ep == EndpointResponses
+}
+
+// ApplyStreamPreference mutates a shallow copy of body to set stream=true when
+// ShouldForceUpstreamStream is true. Returns the (possibly same) body map and
+// whether stream was forced.
+func ApplyStreamPreference(body map[string]any, pref SiteProtocolPreference, upstreamPath string, isCompact bool) (map[string]any, bool) {
+	if !ShouldForceUpstreamStream(pref, upstreamPath, isCompact) {
+		return body, false
+	}
+	if body == nil {
+		body = map[string]any{}
+	}
+	// Already streaming?
+	if v, ok := body["stream"]; ok {
+		switch t := v.(type) {
+		case bool:
+			if t {
+				return body, false
+			}
+		case string:
+			if t == "true" || t == "1" {
+				return body, false
+			}
+		}
+	}
+	next := make(map[string]any, len(body)+1)
+	for k, v := range body {
+		next[k] = v
+	}
+	next["stream"] = true
+	return next, true
+}
+
+// ResponsesOnlyChatUnsupportedMessage is the clear client error when a chat/completions
+// (or messages) client hits a responses-only site and transform is not available.
+// Used when DISABLE_CROSS_PROTOCOL_FALLBACK is true and body cannot be rewritten.
+func ResponsesOnlyChatUnsupportedMessage(downstreamPath string) string {
+	path := strings.TrimSpace(downstreamPath)
+	if path == "" {
+		path = "this endpoint"
+	}
+	return "site is responses-only and only supports /v1/responses (streaming); " +
+		"client called " + path + " which cannot be served without protocol transform"
+}

--- a/proxy/site_preference.go
+++ b/proxy/site_preference.go
@@ -66,11 +66,9 @@ func ResolveEndpointCandidatesWithOptions(downstreamPath string, opts EndpointCa
 	pref := opts.Preference
 	// Codex client profile on responses path reinforces prefer-responses, but does
 	// not by itself force responses-only (that is a site property).
-	if opts.DownstreamClient != nil && opts.DownstreamClient.ID == types.ProfileCodex {
-		if !pref.PreferResponses && !pref.ResponsesOnly {
-			// no-op; site preference is authoritative for responses-only.
-		}
-	}
+	// Codex client profile is informational only; site preference remains authoritative
+	// for responses-only. DownstreamClient is accepted for future scoring hooks.
+	_ = opts.DownstreamClient
 
 	if pref.ResponsesOnly {
 		return []UpstreamEndpoint{EndpointResponses}

--- a/proxy/site_preference_test.go
+++ b/proxy/site_preference_test.go
@@ -1,0 +1,35 @@
+package proxy
+
+import "testing"
+
+func TestResolveEndpointCandidates_ResponsesOnly(t *testing.T) {
+	cands := ResolveEndpointCandidatesWithOptions("/v1/chat/completions", EndpointCandidateOptions{
+		Preference: SiteProtocolPreference{ResponsesOnly: true, PreferResponses: true, PreferStream: true},
+	})
+	if len(cands) != 1 || cands[0] != EndpointResponses {
+		t.Fatalf("cands=%v", cands)
+	}
+}
+
+func TestResolveEndpointCandidates_PreferResponsesOrder(t *testing.T) {
+	cands := ResolveEndpointCandidatesWithOptions("/v1/chat/completions", EndpointCandidateOptions{
+		Preference: SiteProtocolPreference{PreferResponses: true},
+	})
+	if len(cands) < 2 || cands[0] != EndpointResponses {
+		t.Fatalf("cands=%v", cands)
+	}
+}
+
+func TestResolveEndpointCandidates_DefaultChatPrimary(t *testing.T) {
+	cands := ResolveEndpointCandidates("/v1/chat/completions", false)
+	if len(cands) == 0 || cands[0] != EndpointChat {
+		t.Fatalf("cands=%v", cands)
+	}
+}
+
+func TestResponsesOnlyChatUnsupportedMessage(t *testing.T) {
+	msg := ResponsesOnlyChatUnsupportedMessage("/v1/chat/completions")
+	if msg == "" {
+		t.Fatal("empty message")
+	}
+}


### PR DESCRIPTION
## Summary
- Detect responses-only / stream-preferring sites from `custom_headers` (`x-metapi-responses-only`, stream/endpoint preference), platform (`codex`, `sub2api` stream), and known URL markers (`*.aabb1.pro`).
- Route chat-family traffic to `/v1/responses` (only, or first) and force `stream:true` for responses-only / stream-preferring sites; clear 400 when chat-shaped bodies cannot be transformed.
- Docs + unit/integration tests for preference selection, candidate order, stream force, and chat rejection.

## Test plan
- [x] `go test ./proxy/ ./proxy/profiles/ -count=1`
- [x] `go test ./handler/proxy/ -count=1`
- [x] pre-push full `go test ./... -race` passed locally
- [ ] Manual: mark a site with `{"x-metapi-responses-only":"true"}` and confirm chat client with responses-shaped body hits `/v1/responses` with stream; chat-shaped body returns 400.

Closes #56