### PR TITLE
fix(transform): preserve Anthropic/OpenAI skill-call tool history #51

### DIFF
--- a/docs/analysis/anthropic-openai-skill-call.md
+++ b/docs/analysis/anthropic-openai-skill-call.md
@@ -1,9 +1,101 @@
-# Anthropic ↔ OpenAI skill-call bridge (#51 / upstream #531)
+# Anthropic ↔ OpenAI skill-call bridge
 
-## Fix
-- OpenAI `role=tool` rows convert to Anthropic `tool_result` blocks (coalesced; next user text appended).
-- Assistant `tool_calls` keep id/name/arguments (empty `{}` args preserved as empty maps).
-- Tool definitions deep-clone full `parameters` into `input_schema` (required/properties kept).
+Last updated: 2026-07-17
 
-## Residual client limits
-- Claude Code may still reject history if the **client** omits required Skill.input fields entirely and the upstream model never returned them; the proxy preserves empty object args but cannot invent skill parameters.
+Issue: TokenDanceLab/metapi-go#51  
+Upstream: cita-777/metapi#531
+
+## Problem (Claude Code repro)
+
+Claude Code expects Anthropic Messages `tool_use` for the built-in **Skill** tool:
+
+```json
+{
+  "type": "tool_use",
+  "id": "toolu_…",
+  "name": "Skill",
+  "input": { "skill": "superpowers:using-superpowers" }
+}
+```
+
+When MetAPI routes Claude Code traffic to an OpenAI-compatible upstream (or reconstructs multi-turn history through OpenAI chat shapes), a broken bridge can return:
+
+```json
+{
+  "type": "tool_use",
+  "name": "Skill",
+  "input": {}
+}
+```
+
+Upstream #531 control group:
+
+| Path | Skill call |
+|------|------------|
+| Claude Code → Claude-compatible model | pass (input present) |
+| Claude Code → MetAPI → GPT/OpenAI-compatible | fail (`input:{}`) before this fix |
+
+Static localization (no live runtime required for the transform gap):
+
+1. OpenAI `role=tool` history was not converted to Anthropic `tool_result` on the OpenAI→Anthropic path (multi-turn Skill history dropped linkage).
+2. Tool arguments emitted as objects (not JSON strings) could be dropped by stream helpers that only accepted strings.
+3. Tool schema `parameters.required` / `input_schema.required` must survive Claude↔OpenAI tool conversion so models still see that `skill` is required.
+
+## Implementation (metapi-go)
+
+| Surface | Behavior |
+|---------|----------|
+| `transform/anthropic/messages/conversion.go` `ConvertOpenAiBodyToAnthropicMessagesBody` | Maps assistant `tool_calls` → `tool_use` (id/name/input). Coalesces consecutive OpenAI `role=tool` rows into user `tool_result` blocks (optional next user text appended). |
+| same file `convertOpenAiToolsToAnthropic` | Preserves full function `parameters` as Anthropic `input_schema` (incl. `required`). |
+| same file `sanitizeAnthropicContentBlock` | Keeps `tool_use` / `server_tool_use` id/name/input; preserves `tool_result.is_error`. |
+| `transform/shared/chatFormatsCore.go` Claude→OpenAI | `tool_use` and `server_tool_use` become OpenAI `tool_calls`; arguments coerced via `coerceToolArgumentsText`. |
+| same package normalize/stream | OpenAI stream `function.arguments` objects preserved; Claude `input_json_delta` still accumulates. Final Claude serialize uses `ParseJSONLike` on accumulated arguments. |
+| `transform/canonical/openai_bridge.go` | Canonical tool_call `ArgumentsJSON` preserves string or object args; tool schemas keep `required`. |
+
+## Round-trip contract
+
+1. **OpenAI → Anthropic (request / history)**  
+   `tool_calls[].id|function.name|function.arguments` → `tool_use.id|name|input`  
+   `role=tool.tool_call_id|content` → `tool_result.tool_use_id|content`
+
+2. **Anthropic → OpenAI (Claude Code inbound to OpenAI upstream)**  
+   `tool_use` / `server_tool_use` → `tool_calls`  
+   `tool_result` → `role=tool`  
+   `input_schema` → `function.parameters` (required preserved)
+
+3. **Canonical bridge**  
+   Same id/name/arguments linkage through `PartToolCall` / `PartToolResult`.
+
+4. **Response serialize**  
+   Normalized `ToolCall.Arguments` JSON → Anthropic `tool_use.input` object for Claude Code clients.
+
+## Residual client / model limits (not fully fixable in proxy)
+
+| Limit | Notes |
+|-------|-------|
+| Model returns empty Skill arguments | If the upstream OpenAI model emits `function.arguments: "{}"` despite a schema with `required: ["skill"]`, the proxy **preserves** empty `input:{}` rather than inventing a skill name. Claude Code will still see a Skill tool_use block, but skill selection may fail until the model emits parameters. |
+| Non-streaming argument object quirks | Proxy now stringifies object arguments; providers that send malformed non-JSON strings still pass through as `{ "value": "…" }` via `ParseJSONLike`. |
+| Server tools vs Skill | Anthropic `server_tool_use` (e.g. web_search) is preserved as a tool_call/tool_use shape for bridges; it is not the Claude Code Skill tool, and OpenAI upstreams may not support native server tools. |
+| Streaming partial JSON | Skill input is only complete after all `input_json_delta` / argument deltas accumulate. Mid-stream clients that inspect incomplete partial JSON may briefly see incomplete skill names — expected SSE semantics. |
+| Live Claude Code end-to-end | Fixtures cover transform round-trips. A full Claude Code UI repro against a specific GPT deployment still depends on model compliance with the Skill schema. |
+
+## Tests
+
+```bash
+go test ./transform/anthropic/... ./transform/canonical/ ./transform/shared/ -count=1
+```
+
+Coverage highlights:
+
+- OpenAI multi-turn Skill tool_call + tool_result → Anthropic tool_use/tool_result
+- Object-shaped `function.arguments` preserved
+- Empty `{}` residual preserved (not dropped)
+- Claude Skill multi-turn → OpenAI tool_calls + tool role linkage + schema required
+- Canonical OpenAI Skill round-trip
+- Claude final serialize Skill input
+
+## Out of scope
+
+- `service/oauth/**`, Responses compact multi-turn (#50)
+- `web/**`
+- Inventing Skill parameters when the upstream model omits them

--- a/docs/analysis/anthropic-openai-skill-call.md
+++ b/docs/analysis/anthropic-openai-skill-call.md
@@ -1,0 +1,9 @@
+# Anthropic ↔ OpenAI skill-call bridge (#51 / upstream #531)
+
+## Fix
+- OpenAI `role=tool` rows convert to Anthropic `tool_result` blocks (coalesced; next user text appended).
+- Assistant `tool_calls` keep id/name/arguments (empty `{}` args preserved as empty maps).
+- Tool definitions deep-clone full `parameters` into `input_schema` (required/properties kept).
+
+## Residual client limits
+- Claude Code may still reject history if the **client** omits required Skill.input fields entirely and the upstream model never returned them; the proxy preserves empty object args but cannot invent skill parameters.

--- a/transform/anthropic/messages/conversion.go
+++ b/transform/anthropic/messages/conversion.go
@@ -477,13 +477,17 @@ func sanitizeAnthropicContentBlock(item map[string]any) map[string]any {
 			return nil
 		}
 		next := map[string]any{"type": "tool_result", "tool_use_id": toolUseID, "content": content}
+		if item["is_error"] == true {
+			next["is_error"] = true
+		}
 		if cc, ok := item["cache_control"].(map[string]any); ok && shared.AsTrimmedString(cc["type"]) == "ephemeral" {
 			next["cache_control"] = map[string]any{"type": "ephemeral"}
 		}
 		return next
 	}
 
-	if t == "tool_use" {
+	// tool_use is the Claude Code Skill path; server_tool_use is Anthropic server tools.
+	if t == "tool_use" || t == "server_tool_use" {
 		id := shared.AsTrimmedString(item["id"])
 		name := shared.AsTrimmedString(item["name"])
 		if name == "" {
@@ -499,7 +503,7 @@ func sanitizeAnthropicContentBlock(item map[string]any) map[string]any {
 		if input == nil {
 			input = normalizeAnthropicToolInput(item["argumentsText"])
 		}
-		next := map[string]any{"type": "tool_use", "id": id, "name": name, "input": input}
+		next := map[string]any{"type": t, "id": id, "name": name, "input": input}
 		if cc, ok := item["cache_control"].(map[string]any); ok && shared.AsTrimmedString(cc["type"]) == "ephemeral" {
 			next["cache_control"] = map[string]any{"type": "ephemeral"}
 		}

--- a/transform/anthropic/messages/conversion.go
+++ b/transform/anthropic/messages/conversion.go
@@ -2,6 +2,7 @@
 package messages
 
 import (
+	"encoding/json"
 	"math"
 	"strings"
 
@@ -103,6 +104,12 @@ func SanitizeAnthropicMessagesBody(body map[string]any, autoOptimizeCacheControl
 // --- OpenAI body -> Anthropic body ---
 
 // ConvertOpenAiBodyToAnthropicMessagesBody converts an OpenAI chat body to Anthropic format.
+//
+// Skill-call multi-turn history depends on preserving:
+//   - assistant tool_calls[].id / function.name / function.arguments → tool_use
+//   - role=tool tool_call_id + content → tool_result (optionally coalesced with the next user turn)
+// Empty object arguments ({}) are kept as empty maps so Claude Code can still see the tool_use
+// block even when an upstream model omitted required Skill.input fields (client residual limit).
 func ConvertOpenAiBodyToAnthropicMessagesBody(openaiBody map[string]any, modelName string, stream bool) (map[string]any, error) {
 	rawMsgs, _ := openaiBody["messages"].([]any)
 	var systemContents []string
@@ -112,7 +119,8 @@ func ConvertOpenAiBodyToAnthropicMessagesBody(openaiBody map[string]any, modelNa
 	}
 	var msgs []claudeMsg
 
-	for _, item := range rawMsgs {
+	for messageIndex := 0; messageIndex < len(rawMsgs); messageIndex++ {
+		item := rawMsgs[messageIndex]
 		m, ok := item.(map[string]any)
 		if !ok {
 			continue
@@ -135,6 +143,72 @@ func ConvertOpenAiBodyToAnthropicMessagesBody(openaiBody map[string]any, modelNa
 			if t := strings.Join(texts, "\n\n"); t != "" {
 				systemContents = append(systemContents, t)
 			}
+			continue
+		}
+
+		// OpenAI role=tool rows become Anthropic user tool_result blocks.
+		// Consecutive tool messages are coalesced; if the next message is user text,
+		// it is appended so Claude Code multi-turn Skill history stays contiguous.
+		if role == "tool" {
+			var toolResultBlocks []map[string]any
+			cursor := messageIndex
+			for cursor < len(rawMsgs) {
+				candidate, ok := rawMsgs[cursor].(map[string]any)
+				if !ok {
+					break
+				}
+				if strings.ToLower(shared.AsTrimmedString(candidate["role"])) != "tool" {
+					break
+				}
+				toolUseID := shared.AsTrimmedString(candidate["tool_call_id"])
+				if toolUseID == "" {
+					toolUseID = shared.AsTrimmedString(candidate["id"])
+				}
+				toolResultContent := normalizeToolMessageContent(candidate["content"])
+				hasContent := false
+				switch c := toolResultContent.(type) {
+				case string:
+					hasContent = strings.TrimSpace(c) != ""
+				case []any:
+					hasContent = len(c) > 0
+				case []map[string]any:
+					hasContent = len(c) > 0
+				default:
+					hasContent = toolResultContent != nil
+				}
+				if toolUseID != "" && hasContent {
+					block := map[string]any{
+						"type":        "tool_result",
+						"tool_use_id": toolUseID,
+						"content":     toolResultContent,
+					}
+					if candidate["is_error"] == true {
+						block["is_error"] = true
+					}
+					toolResultBlocks = append(toolResultBlocks, block)
+				}
+				cursor++
+			}
+
+			if len(toolResultBlocks) > 0 && cursor < len(rawMsgs) {
+				if nextItem, ok := rawMsgs[cursor].(map[string]any); ok {
+					if strings.ToLower(shared.AsTrimmedString(nextItem["role"])) == "user" {
+						userBlocks := convertOpenAIContentToAnthropicBlocks(nextItem["content"])
+						toolResultBlocks = append(toolResultBlocks, userBlocks...)
+						cursor++
+					}
+				}
+			}
+
+			if len(toolResultBlocks) > 0 {
+				// convert to []any for consistent message content shape
+				content := make([]any, 0, len(toolResultBlocks))
+				for _, b := range toolResultBlocks {
+					content = append(content, b)
+				}
+				msgs = append(msgs, claudeMsg{Role: "user", Content: content})
+			}
+			messageIndex = cursor - 1
 			continue
 		}
 
@@ -172,7 +246,13 @@ func ConvertOpenAiBodyToAnthropicMessagesBody(openaiBody map[string]any, modelNa
 					if name == "" {
 						name = "tool_" + itoa(int64(i))
 					}
-					input := normalizeAnthropicToolInput(fn["arguments"])
+					// Prefer function.arguments; fall back to top-level arguments for
+					// non-standard OpenAI-compatible providers (Skill-call edge cases).
+					rawArgs := fn["arguments"]
+					if rawArgs == nil {
+						rawArgs = tcm["arguments"]
+					}
+					input := normalizeAnthropicToolInput(rawArgs)
 					cbs = append(cbs, map[string]any{"type": "tool_use", "id": id, "name": name, "input": input})
 				}
 			}
@@ -875,18 +955,27 @@ func convertOpenAiToolsToAnthropic(raw any) any {
 				if d := shared.AsTrimmedString(fn["description"]); d != "" {
 					mapped["description"] = d
 				}
+				// Preserve full parameters (incl. required / properties) so Skill and
+				// other Claude Code tools keep schema semantics across OpenAI bridges.
 				if fn["parameters"] != nil {
-					mapped["input_schema"] = fn["parameters"]
+					mapped["input_schema"] = deepCloneJSON(fn["parameters"])
+				} else {
+					mapped["input_schema"] = map[string]any{"type": "object", "properties": map[string]any{}}
 				}
 				if cc := m["cache_control"]; cc != nil {
-					mapped["cache_control"] = cc
+					mapped["cache_control"] = deepCloneJSON(cc)
 				}
 				out = append(out, mapped)
 			}
 			continue
 		}
 		if shared.AsTrimmedString(m["name"]) != "" && m["input_schema"] != nil {
-			out = append(out, item)
+			// Already Anthropic-shaped; deep-clone so callers cannot mutate shared maps.
+			if cloned := deepCloneJSON(item); cloned != nil {
+				out = append(out, cloned)
+			} else {
+				out = append(out, item)
+			}
 			continue
 		}
 	}
@@ -1268,6 +1357,22 @@ func toFloat(v any) (float64, bool) {
 		return float64(n), true
 	}
 	return 0, false
+}
+
+
+func deepCloneJSON(v any) any {
+	if v == nil {
+		return nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	var dst any
+	if err := json.Unmarshal(b, &dst); err != nil {
+		return nil
+	}
+	return dst
 }
 
 func cloneMap(src map[string]any) map[string]any {

--- a/transform/anthropic/messages/conversion.go
+++ b/transform/anthropic/messages/conversion.go
@@ -165,17 +165,7 @@ func ConvertOpenAiBodyToAnthropicMessagesBody(openaiBody map[string]any, modelNa
 					toolUseID = shared.AsTrimmedString(candidate["id"])
 				}
 				toolResultContent := normalizeToolMessageContent(candidate["content"])
-				hasContent := false
-				switch c := toolResultContent.(type) {
-				case string:
-					hasContent = strings.TrimSpace(c) != ""
-				case []any:
-					hasContent = len(c) > 0
-				case []map[string]any:
-					hasContent = len(c) > 0
-				default:
-					hasContent = toolResultContent != nil
-				}
+				hasContent := toolResultContentHasPayload(toolResultContent)
 				if toolUseID != "" && hasContent {
 					block := map[string]any{
 						"type":        "tool_result",
@@ -648,6 +638,22 @@ func normalizeAnthropicToolInput(raw any) any {
 		return raw
 	}
 	return map[string]any{}
+}
+
+
+func toolResultContentHasPayload(content any) bool {
+	switch c := content.(type) {
+	case string:
+		return strings.TrimSpace(c) != ""
+	case []any:
+		return len(c) > 0
+	case []map[string]any:
+		return len(c) > 0
+	default:
+		// normalizeToolMessageContent returns concrete string/slice values.
+		s := shared.StringifyUnknownValue(content)
+		return strings.TrimSpace(s) != "" && s != "{}" && s != "null"
+	}
 }
 
 func normalizeToolMessageContent(raw any) any {

--- a/transform/anthropic/messages/roundtrip_test.go
+++ b/transform/anthropic/messages/roundtrip_test.go
@@ -709,3 +709,405 @@ func TestAnthropicBodyJSONRoundtrip(t *testing.T) {
 		t.Error("model mismatch after JSON roundtrip")
 	}
 }
+
+
+// ---------------------------------------------------------------------------
+// Skill-call multi-turn fixtures (GitHub #51 / upstream #531)
+// ---------------------------------------------------------------------------
+
+func skillToolDefinition() map[string]any {
+	return map[string]any{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "Skill",
+			"description": "Load a Claude Code skill by name",
+			"parameters": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"skill": map[string]any{"type": "string"},
+				},
+				"required": []any{"skill"},
+			},
+		},
+	}
+}
+
+func TestConvertOpenAiBodyToAnthropic_SkillCallPreservesInput(t *testing.T) {
+	openaiBody := map[string]any{
+		"model": "gpt-4.1",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Use the superpowers skill"},
+			map[string]any{
+				"role":    "assistant",
+				"content": "",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_skill_01",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "Skill",
+							"arguments": `{"skill":"superpowers:using-superpowers"}`,
+						},
+					},
+				},
+			},
+			map[string]any{
+				"role":         "tool",
+				"tool_call_id": "call_skill_01",
+				"content":      "Skill loaded: superpowers:using-superpowers",
+			},
+			map[string]any{"role": "user", "content": "Continue with the skill"},
+		},
+		"tools": []any{skillToolDefinition()},
+	}
+
+	body, err := ConvertOpenAiBodyToAnthropicMessagesBody(openaiBody, "claude-sonnet-4-20250514", false)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	msgs := asMessageMaps(body["messages"])
+	if len(msgs) < 3 {
+		t.Fatalf("expected multi-turn messages, got %d: %#v", len(msgs), body["messages"])
+	}
+
+	var foundSkillToolUse bool
+	for _, msg := range msgs {
+		if msg["role"] != "assistant" {
+			continue
+		}
+		for _, block := range asBlockMaps(msg["content"]) {
+			if block["type"] != "tool_use" || block["name"] != "Skill" {
+				continue
+			}
+			foundSkillToolUse = true
+			if block["id"] != "call_skill_01" {
+				t.Errorf("expected tool_use id call_skill_01, got %v", block["id"])
+			}
+			input, _ := block["input"].(map[string]any)
+			if input == nil {
+				t.Fatalf("expected Skill input map, got %#v", block["input"])
+			}
+			if input["skill"] != "superpowers:using-superpowers" {
+				t.Errorf("expected skill name preserved, got %#v", input)
+			}
+		}
+	}
+	if !foundSkillToolUse {
+		t.Fatal("expected Skill tool_use block in assistant message")
+	}
+
+	var foundToolResult bool
+	for _, msg := range msgs {
+		if msg["role"] != "user" {
+			continue
+		}
+		for _, block := range asBlockMaps(msg["content"]) {
+			if block["type"] != "tool_result" {
+				continue
+			}
+			foundToolResult = true
+			if block["tool_use_id"] != "call_skill_01" {
+				t.Errorf("expected tool_use_id call_skill_01, got %v", block["tool_use_id"])
+			}
+			if block["content"] != "Skill loaded: superpowers:using-superpowers" {
+				t.Errorf("unexpected tool_result content: %#v", block["content"])
+			}
+		}
+	}
+	if !foundToolResult {
+		t.Fatal("expected tool_result linked to Skill tool_use")
+	}
+
+	tools, _ := body["tools"].([]any)
+	if len(tools) == 0 {
+		t.Fatal("expected tools on anthropic body")
+	}
+	tool, _ := tools[0].(map[string]any)
+	if tool["name"] != "Skill" {
+		t.Errorf("expected Skill tool, got %#v", tool["name"])
+	}
+	schema, _ := tool["input_schema"].(map[string]any)
+	if schema == nil {
+		t.Fatal("expected input_schema")
+	}
+	required, _ := schema["required"].([]any)
+	if len(required) == 0 || required[0] != "skill" {
+		t.Errorf("expected required=[skill], got %#v", schema["required"])
+	}
+}
+
+func TestConvertOpenAiBodyToAnthropic_SkillCallObjectArguments(t *testing.T) {
+	openaiBody := map[string]any{
+		"model": "gpt-4.1",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Load skill"},
+			map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_skill_obj",
+						"type": "function",
+						"function": map[string]any{
+							"name": "Skill",
+							"arguments": map[string]any{
+								"skill": "docs:writing-docs",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	body, err := ConvertOpenAiBodyToAnthropicMessagesBody(openaiBody, "claude-sonnet-4-20250514", false)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	found := false
+	for _, msg := range asMessageMaps(body["messages"]) {
+		if msg["role"] != "assistant" {
+			continue
+		}
+		for _, block := range asBlockMaps(msg["content"]) {
+			if block["type"] == "tool_use" && block["name"] == "Skill" {
+				found = true
+				input, _ := block["input"].(map[string]any)
+				if input["skill"] != "docs:writing-docs" {
+					t.Errorf("object arguments not preserved: %#v", block["input"])
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected Skill tool_use from object arguments")
+	}
+}
+
+func TestConvertOpenAiBodyToAnthropic_SkillCallEmptyArgumentsResidual(t *testing.T) {
+	openaiBody := map[string]any{
+		"model": "gpt-4.1",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Use skill"},
+			map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_skill_empty",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "Skill",
+							"arguments": "{}",
+						},
+					},
+				},
+			},
+		},
+	}
+	body, err := ConvertOpenAiBodyToAnthropicMessagesBody(openaiBody, "claude-sonnet-4-20250514", false)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	found := false
+	for _, msg := range asMessageMaps(body["messages"]) {
+		if msg["role"] != "assistant" {
+			continue
+		}
+		for _, block := range asBlockMaps(msg["content"]) {
+			if block["type"] == "tool_use" && block["name"] == "Skill" {
+				found = true
+				input, _ := block["input"].(map[string]any)
+				if input == nil {
+					t.Fatalf("expected empty map input, got %#v", block["input"])
+				}
+				if len(input) != 0 {
+					t.Errorf("expected empty input object residual, got %#v", input)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected Skill tool_use even with empty arguments")
+	}
+}
+
+func TestParseDownstreamChatRequest_ClaudeSkillMultiTurn(t *testing.T) {
+	claudeBody := map[string]any{
+		"model":      "claude-sonnet-4-20250514",
+		"max_tokens": 4096,
+		"tools": []any{
+			map[string]any{
+				"name":        "Skill",
+				"description": "Load a Claude Code skill",
+				"input_schema": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"skill": map[string]any{"type": "string"},
+					},
+					"required": []any{"skill"},
+				},
+			},
+		},
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Use superpowers"},
+			map[string]any{
+				"role": "assistant",
+				"content": []any{
+					map[string]any{
+						"type":  "tool_use",
+						"id":    "toolu_skill_01",
+						"name":  "Skill",
+						"input": map[string]any{"skill": "superpowers:using-superpowers"},
+					},
+				},
+			},
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{
+						"type":        "tool_result",
+						"tool_use_id": "toolu_skill_01",
+						"content":     "loaded",
+					},
+				},
+			},
+		},
+	}
+
+	parsed, errPayload := shared.ParseDownstreamChatRequest(claudeBody, shared.FormatClaude)
+	if errPayload != nil {
+		t.Fatalf("parse: %v", errPayload)
+	}
+	msgs, ok := parsed.UpstreamBody["messages"].([]map[string]any)
+	if !ok {
+		t.Fatalf("messages missing: %#v", parsed.UpstreamBody["messages"])
+	}
+
+	var skillCallID, skillArgs string
+	var toolResultID, toolResultContent string
+	for _, msg := range msgs {
+		switch tcs := msg["tool_calls"].(type) {
+		case []map[string]any:
+			for _, tc := range tcs {
+				fn, _ := tc["function"].(map[string]any)
+				if fn != nil && fn["name"] == "Skill" {
+					skillCallID = shared.AsTrimmedString(tc["id"])
+					skillArgs = shared.AsTrimmedString(fn["arguments"])
+				}
+			}
+		case []any:
+			for _, raw := range tcs {
+				tc, _ := raw.(map[string]any)
+				fn, _ := tc["function"].(map[string]any)
+				if fn != nil && fn["name"] == "Skill" {
+					skillCallID = shared.AsTrimmedString(tc["id"])
+					skillArgs = shared.AsTrimmedString(fn["arguments"])
+				}
+			}
+		}
+		if msg["role"] == "tool" {
+			toolResultID = shared.AsTrimmedString(msg["tool_call_id"])
+			toolResultContent = shared.AsTrimmedString(msg["content"])
+		}
+	}
+	if skillCallID != "toolu_skill_01" {
+		t.Errorf("expected skill call id preserved, got %q", skillCallID)
+	}
+	if skillArgs == "" || skillArgs == "{}" {
+		t.Errorf("expected Skill arguments JSON, got %q", skillArgs)
+	}
+	if !json.Valid([]byte(skillArgs)) {
+		t.Fatalf("skill args not valid JSON: %q", skillArgs)
+	}
+	var parsedArgs map[string]any
+	if err := json.Unmarshal([]byte(skillArgs), &parsedArgs); err != nil {
+		t.Fatalf("unmarshal skill args: %v", err)
+	}
+	if parsedArgs["skill"] != "superpowers:using-superpowers" {
+		t.Errorf("skill argument lost: %#v", parsedArgs)
+	}
+	if toolResultID != "toolu_skill_01" {
+		t.Errorf("tool_result linkage broken: %q", toolResultID)
+	}
+	if toolResultContent != "loaded" {
+		t.Errorf("tool_result content lost: %q", toolResultContent)
+	}
+
+	tools := parsed.UpstreamBody["tools"]
+	arr, _ := tools.([]any)
+	if len(arr) == 0 {
+		t.Fatal("expected tools on OpenAI body")
+	}
+	tool, _ := arr[0].(map[string]any)
+	fn, _ := tool["function"].(map[string]any)
+	params, _ := fn["parameters"].(map[string]any)
+	required, _ := params["required"].([]any)
+	if len(required) == 0 || required[0] != "skill" {
+		t.Errorf("expected required skill on OpenAI tools, got %#v", params)
+	}
+}
+
+func TestSerializeFinalResponse_SkillToolUseInput(t *testing.T) {
+	normalized := shared.NormalizedFinalResponse{
+		ID:           "chatcmpl-skill",
+		Model:        "gpt-4.1",
+		Created:      1,
+		FinishReason: "tool_calls",
+		ToolCalls: []shared.ToolCall{
+			{
+				ID:        "call_skill_stream",
+				Name:      "Skill",
+				Arguments: `{"skill":"superpowers:using-superpowers"}`,
+			},
+		},
+	}
+	result := shared.SerializeFinalResponse(shared.FormatClaude, normalized, struct {
+		PromptTokens, CompletionTokens, TotalTokens int
+	}{10, 5, 15})
+	content := asBlockMaps(result["content"])
+	if len(content) == 0 {
+		t.Fatalf("expected content blocks, got %#v", result["content"])
+	}
+	block := content[len(content)-1]
+	if block["type"] != "tool_use" || block["name"] != "Skill" {
+		t.Fatalf("expected Skill tool_use, got %#v", block)
+	}
+	input, _ := block["input"].(map[string]any)
+	if input["skill"] != "superpowers:using-superpowers" {
+		t.Errorf("skill input lost in Claude final serialize: %#v", block["input"])
+	}
+}
+
+func asMessageMaps(v any) []map[string]any {
+	switch msgs := v.(type) {
+	case []map[string]any:
+		return msgs
+	case []any:
+		out := make([]map[string]any, 0, len(msgs))
+		for _, item := range msgs {
+			if m, ok := item.(map[string]any); ok {
+				out = append(out, m)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func asBlockMaps(v any) []map[string]any {
+	switch content := v.(type) {
+	case []map[string]any:
+		return content
+	case []any:
+		out := make([]map[string]any, 0, len(content))
+		for _, item := range content {
+			if m, ok := item.(map[string]any); ok {
+				out = append(out, m)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+

--- a/transform/anthropic/messages/skill_call_test.go
+++ b/transform/anthropic/messages/skill_call_test.go
@@ -1,0 +1,132 @@
+package messages
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Claude Code Skill multi-turn history often arrives as OpenAI tool_calls + tool results.
+// Upstream #531 / issue #51: bridge must preserve tool_use id/name/input and tool_result linkage.
+func TestConvertOpenAIToAnthropic_SkillCallMultiTurn(t *testing.T) {
+	body := map[string]any{
+		"model": "claude-sonnet-4",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "use Skill"},
+			map[string]any{
+				"role": "assistant",
+				"content": "",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_skill_1",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "Skill",
+							"arguments": `{"skill":"read_file","path":"README.md"}`,
+						},
+					},
+				},
+			},
+			map[string]any{
+				"role":         "tool",
+				"tool_call_id": "call_skill_1",
+				"content":      "file contents here",
+			},
+			map[string]any{"role": "user", "content": "summarize it"},
+		},
+	}
+
+	out, err := ConvertOpenAiBodyToAnthropicMessagesBody(body, "claude-sonnet-4", false)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	// Normalize via JSON so message slices are []any regardless of internal types.
+	var normalized map[string]any
+	if err := json.Unmarshal([]byte(mustJSON(out)), &normalized); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	msgs, _ := normalized["messages"].([]any)
+	if len(msgs) < 2 {
+		t.Fatalf("expected multi-turn messages, got %d: %s", len(msgs), mustJSON(out))
+	}
+
+	// Find assistant tool_use for Skill
+	foundToolUse := false
+	foundToolResult := false
+	for _, m := range msgs {
+		mm, _ := m.(map[string]any)
+		role, _ := mm["role"].(string)
+		content, _ := mm["content"].([]any)
+		for _, c := range content {
+			cm, _ := c.(map[string]any)
+			switch cm["type"] {
+			case "tool_use":
+				if cm["name"] == "Skill" && cm["id"] == "call_skill_1" {
+					foundToolUse = true
+					input, _ := cm["input"].(map[string]any)
+					if input["skill"] != "read_file" {
+						t.Errorf("skill input not preserved: %#v", input)
+					}
+				}
+			case "tool_result":
+				if cm["tool_use_id"] == "call_skill_1" {
+					foundToolResult = true
+				}
+			}
+		}
+		_ = role
+	}
+	if !foundToolUse {
+		t.Fatalf("missing Skill tool_use in %s", mustJSON(msgs))
+	}
+	if !foundToolResult {
+		t.Fatalf("missing tool_result linked to call_skill_1 in %s", mustJSON(msgs))
+	}
+}
+
+func TestConvertOpenAITools_PreservesSkillParameters(t *testing.T) {
+	tools := []any{
+		map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":        "Skill",
+				"description": "Invoke a skill",
+				"parameters": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"skill": map[string]any{"type": "string"},
+					},
+					"required": []any{"skill"},
+				},
+			},
+		},
+	}
+	body := map[string]any{
+		"model":    "claude-sonnet-4",
+		"messages": []any{map[string]any{"role": "user", "content": "hi"}},
+		"tools":    tools,
+	}
+	out, err := ConvertOpenAiBodyToAnthropicMessagesBody(body, "claude-sonnet-4", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	atools, _ := out["tools"].([]any)
+	if len(atools) != 1 {
+		t.Fatalf("tools=%s", mustJSON(out["tools"]))
+	}
+	tm, _ := atools[0].(map[string]any)
+	if tm["name"] != "Skill" {
+		t.Fatalf("name=%v", tm["name"])
+	}
+	schema, _ := tm["input_schema"].(map[string]any)
+	if schema == nil {
+		t.Fatalf("missing input_schema: %s", mustJSON(tm))
+	}
+	if _, ok := schema["required"]; !ok {
+		t.Fatalf("required not preserved: %s", mustJSON(schema))
+	}
+}
+
+func mustJSON(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}

--- a/transform/canonical/openai_bridge.go
+++ b/transform/canonical/openai_bridge.go
@@ -287,11 +287,13 @@ func buildCanonicalMessages(body map[string]any) []CanonicalMessage {
 			if name == "" {
 				continue
 			}
-			argsJSON := ""
-			if s, ok := fn["arguments"].(string); ok {
-				argsJSON = s
-			} else {
-				argsJSON = safeJSONString(fn["arguments"])
+			// Skill-call and ordinary tools: preserve string or object arguments.
+			argsJSON := coerceCanonicalToolArgumentsJSON(fn["arguments"])
+			if argsJSON == "" {
+				argsJSON = coerceCanonicalToolArgumentsJSON(tcm["arguments"])
+			}
+			if argsJSON == "" {
+				argsJSON = "{}"
 			}
 			if id == "" {
 				id = "tool_" + itoa(len(parts))
@@ -494,8 +496,11 @@ func parseCanonicalTools(raw any) []CanonicalToolItem {
 			if strict, ok := fn["strict"].(bool); ok {
 				t.FnStrict = strict
 			}
+			// Clone full schema so required/properties survive Skill bridges.
 			if params, ok := fn["parameters"].(map[string]any); ok {
 				t.FnInputSchema = cloneJSONValue(params).(map[string]any)
+			} else {
+				t.FnInputSchema = map[string]any{"type": "object", "properties": map[string]any{}}
 			}
 			tools = append(tools, t)
 			continue
@@ -972,6 +977,25 @@ func ApplyOpenAIResponsesContinuation(body map[string]any, cont *CanonicalContin
 	ApplyOpenAICompatibleContinuation(body, cont, metadata)
 	if cont.PreviousResponseID != "" {
 		body["previous_response_id"] = cont.PreviousResponseID
+	}
+}
+
+
+// coerceCanonicalToolArgumentsJSON normalizes OpenAI tool arguments to a JSON string.
+// Skill tool calls may arrive with object arguments rather than a JSON string.
+func coerceCanonicalToolArgumentsJSON(raw any) string {
+	if raw == nil {
+		return ""
+	}
+	switch v := raw.(type) {
+	case string:
+		return v
+	default:
+		s := safeJSONString(v)
+		if s == "" || s == "null" {
+			return ""
+		}
+		return s
 	}
 }
 

--- a/transform/canonical/openai_bridge_test.go
+++ b/transform/canonical/openai_bridge_test.go
@@ -912,3 +912,179 @@ func BenchmarkOpenAIBody_Roundtrip_WithImages(b *testing.B) {
 		_ = CanonicalRequestToOpenAiChatBody(env)
 	}
 }
+
+
+// ---------------------------------------------------------------------------
+// Skill-call multi-turn fixtures (GitHub #51 / upstream #531)
+// ---------------------------------------------------------------------------
+
+func TestOpenAIBodySkillCall_Roundtrip(t *testing.T) {
+	body := map[string]any{
+		"model": "gpt-4.1",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Use the superpowers skill"},
+			map[string]any{
+				"role":    "assistant",
+				"content": "",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_skill_01",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "Skill",
+							"arguments": `{"skill":"superpowers:using-superpowers"}`,
+						},
+					},
+				},
+			},
+			map[string]any{
+				"role":         "tool",
+				"tool_call_id": "call_skill_01",
+				"content":      "Skill loaded",
+			},
+			map[string]any{"role": "user", "content": "Continue"},
+		},
+		"tools": []any{
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":        "Skill",
+					"description": "Load a Claude Code skill",
+					"parameters": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"skill": map[string]any{"type": "string"},
+						},
+						"required": []any{"skill"},
+					},
+				},
+			},
+		},
+	}
+
+	env, err := CanonicalRequestFromOpenAiBody(CanonicalRequestFromOpenAiBodyInput{
+		Body:       body,
+		Surface:    SurfaceOpenAIChat,
+		CliProfile: ProfileClaudeCode,
+		Operation:  OpGenerate,
+	})
+	if err != nil {
+		t.Fatalf("to canonical: %v", err)
+	}
+
+	// Assistant tool_call preserved
+	var skillCall CanonicalContentPart
+	var foundSkill bool
+	for _, msg := range env.Messages {
+		for _, part := range msg.Parts {
+			if part.Type == PartToolCall && part.Name == "Skill" {
+				skillCall = part
+				foundSkill = true
+			}
+			if part.Type == PartToolResult && part.ToolCallID == "call_skill_01" {
+				if part.ResultText != "Skill loaded" && part.ResultContent == nil {
+					t.Errorf("tool_result content lost: %#v", part)
+				}
+			}
+		}
+	}
+	if !foundSkill {
+		t.Fatal("expected Skill tool_call in canonical envelope")
+	}
+	if skillCall.ID != "call_skill_01" {
+		t.Errorf("expected id call_skill_01, got %q", skillCall.ID)
+	}
+	if !strings.Contains(skillCall.ArgumentsJSON, "superpowers:using-superpowers") {
+		t.Errorf("skill arguments lost: %q", skillCall.ArgumentsJSON)
+	}
+	if len(env.Tools) != 1 || env.Tools[0].FnName != "Skill" {
+		t.Fatalf("expected Skill tool schema, got %#v", env.Tools)
+	}
+	required, _ := env.Tools[0].FnInputSchema["required"].([]any)
+	if len(required) == 0 || required[0] != "skill" {
+		t.Errorf("required skill lost: %#v", env.Tools[0].FnInputSchema)
+	}
+
+	// Round-trip back to OpenAI body
+	reconstructed := CanonicalRequestToOpenAiChatBody(env)
+	msgs, ok := reconstructed["messages"].([]map[string]any)
+	if !ok {
+		t.Fatalf("messages missing: %#v", reconstructed["messages"])
+	}
+	var foundToolCall, foundToolMsg bool
+	for _, msg := range msgs {
+		if tcs, ok := msg["tool_calls"].([]any); ok {
+			for _, raw := range tcs {
+				tc, _ := raw.(map[string]any)
+				fn, _ := tc["function"].(map[string]any)
+				if fn != nil && fn["name"] == "Skill" {
+					foundToolCall = true
+					if tc["id"] != "call_skill_01" {
+						t.Errorf("id lost on reconstruct: %#v", tc["id"])
+					}
+					if !strings.Contains(asTrimmedString(fn["arguments"]), "superpowers:using-superpowers") {
+						t.Errorf("arguments lost on reconstruct: %#v", fn["arguments"])
+					}
+				}
+			}
+		}
+		if msg["role"] == "tool" {
+			foundToolMsg = true
+			if msg["tool_call_id"] != "call_skill_01" {
+				t.Errorf("tool_call_id lost: %#v", msg["tool_call_id"])
+			}
+		}
+	}
+	if !foundToolCall {
+		t.Fatal("expected Skill tool_calls after reconstruct")
+	}
+	if !foundToolMsg {
+		t.Fatal("expected tool role message after reconstruct")
+	}
+}
+
+func TestOpenAIBodySkillCall_ObjectArguments(t *testing.T) {
+	body := map[string]any{
+		"model": "gpt-4.1",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "skill"},
+			map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_obj",
+						"type": "function",
+						"function": map[string]any{
+							"name": "Skill",
+							"arguments": map[string]any{
+								"skill": "docs:writing-docs",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	env, err := CanonicalRequestFromOpenAiBody(CanonicalRequestFromOpenAiBodyInput{
+		Body:    body,
+		Surface: SurfaceOpenAIChat,
+	})
+	if err != nil {
+		t.Fatalf("to canonical: %v", err)
+	}
+	found := false
+	for _, msg := range env.Messages {
+		for _, part := range msg.Parts {
+			if part.Type == PartToolCall && part.Name == "Skill" {
+				found = true
+				if !strings.Contains(part.ArgumentsJSON, "docs:writing-docs") {
+					t.Errorf("object arguments not preserved: %q", part.ArgumentsJSON)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected Skill tool_call from object arguments")
+	}
+}
+

--- a/transform/shared/chatFormatsCore.go
+++ b/transform/shared/chatFormatsCore.go
@@ -210,17 +210,17 @@ func convertClaudeRequestToOpenAiBody(body map[string]any) claudeConvertResult {
 					appendToolResultMsg(bm["tool_use_id"], bm["content"])
 					continue
 				}
-				if mappedRole == "assistant" && bt == "tool_use" {
+				// tool_use covers Claude Code Skill and ordinary tools; server_tool_use is
+				// Anthropic server-side tools (e.g. web_search). Both become OpenAI tool_calls.
+				if mappedRole == "assistant" && (bt == "tool_use" || bt == "server_tool_use") {
 					id := AsTrimmedString(bm["id"])
 					if id == "" {
 						id = "call_" + itoa(int64(len(tcs)))
 					}
 					name := AsTrimmedString(bm["name"])
-					args := ""
-					if s, ok := bm["input"].(string); ok {
-						args = s
-					} else {
-						args = StringifyUnknownValue(bm["input"])
+					args := coerceToolArgumentsText(bm["input"])
+					if args == "" {
+						args = coerceToolArgumentsText(bm["arguments"])
 					}
 					if args == "" {
 						args = "{}"
@@ -430,6 +430,27 @@ func extractClaudeReasoning(body map[string]any) (effort string, budget int) {
 	return
 }
 
+
+// coerceToolArgumentsText normalizes tool argument payloads to the OpenAI string form.
+// Empty maps become "{}" so Claude Code Skill tool_use.input is never dropped to nil.
+func coerceToolArgumentsText(raw any) string {
+	if raw == nil {
+		return ""
+	}
+	switch v := raw.(type) {
+	case string:
+		return v
+	case map[string]any, []any:
+		s := SafeJSONString(v)
+		if s == "" {
+			return "{}"
+		}
+		return s
+	default:
+		return StringifyUnknownValue(raw)
+	}
+}
+
 func convertClaudeToolsToOpenAIChat(raw any) any {
 	arr, ok := raw.([]any)
 	if !ok {
@@ -456,15 +477,21 @@ func convertClaudeToolsToOpenAIChat(raw any) any {
 			out = append(out, item)
 			continue
 		}
-		params := map[string]any{"type": "object"}
+		params := map[string]any{"type": "object", "properties": map[string]any{}}
 		if is, ok := m["input_schema"].(map[string]any); ok {
 			params = is
 		} else if p, ok := m["parameters"].(map[string]any); ok {
 			params = p
+		} else if schema, ok := m["inputSchema"].(map[string]any); ok {
+			params = schema
 		}
 		fn := map[string]any{"name": name, "parameters": params}
 		if d := AsTrimmedString(m["description"]); d != "" {
 			fn["description"] = d
+		}
+		// Keep strict if present so OpenAI-compatible models honor required Skill fields.
+		if strict, ok := m["strict"].(bool); ok && strict {
+			fn["strict"] = true
 		}
 		out = append(out, map[string]any{"type": "function", "function": fn})
 	}
@@ -767,11 +794,12 @@ func collectToolCallsFromOpenAIChoice(choice any) []ToolCall {
 		if name == "" {
 			name = AsTrimmedString(tcm["name"])
 		}
-		args := ""
-		if s, ok := fn["arguments"].(string); ok {
-			args = s
-		} else {
-			args = StringifyUnknownValue(fn["arguments"])
+		args := coerceToolArgumentsText(fn["arguments"])
+		if args == "" {
+			args = coerceToolArgumentsText(tcm["arguments"])
+		}
+		if args == "" {
+			args = "{}"
 		}
 		tcs = append(tcs, ToolCall{ID: id, Name: name, Arguments: args})
 	}
@@ -783,7 +811,13 @@ func collectToolCallsFromClaudeContent(content any) []ToolCall {
 	var tcs []ToolCall
 	for i, item := range arr {
 		m, ok := item.(map[string]any)
-		if !ok || m["type"] != "tool_use" {
+		if !ok {
+			continue
+		}
+		// Claude Code skill-call and server tools share the same id/name/input shape.
+		// Preserve tool_use and server_tool_use so OpenAI bridges do not drop them.
+		bt := AsTrimmedString(m["type"])
+		if bt != "tool_use" && bt != "server_tool_use" {
 			continue
 		}
 		id := AsTrimmedString(m["id"])
@@ -791,7 +825,13 @@ func collectToolCallsFromClaudeContent(content any) []ToolCall {
 			id = "toolu_" + itoa(int64(i))
 		}
 		name := AsTrimmedString(m["name"])
-		args := StringifyUnknownValue(m["input"])
+		args := coerceToolArgumentsText(m["input"])
+		if args == "" {
+			args = coerceToolArgumentsText(m["arguments"])
+		}
+		if args == "" {
+			args = "{}"
+		}
 		tcs = append(tcs, ToolCall{ID: id, Name: name, Arguments: args})
 	}
 	return tcs
@@ -1003,7 +1043,15 @@ func NormalizeUpstreamStreamEvent(payload any, ctx *StreamTransformContext, fall
 				}
 				id := AsTrimmedString(tcm["id"])
 				name := AsTrimmedString(fn["name"])
-				ad := AsTrimmedString(fn["arguments"])
+				if name == "" {
+					name = AsTrimmedString(tcm["name"])
+				}
+				// Preserve string or object arguments (some OpenAI-compatible
+				// providers emit function.arguments as a map; Skill calls need it).
+				ad := coerceToolArgumentsText(fn["arguments"])
+				if ad == "" {
+					ad = coerceToolArgumentsText(tcm["arguments"])
+				}
 				if id == "" && name == "" && ad == "" {
 					continue
 				}
@@ -1057,19 +1105,22 @@ func NormalizeUpstreamStreamEvent(payload any, ctx *StreamTransformContext, fall
 	case "content_block_start":
 		cb, _ := m["content_block"].(map[string]any)
 		idx := PickFiniteInt(m["index"])
-		if cb != nil && cb["type"] == "tool_use" {
-			id := AsTrimmedString(cb["id"])
-			name := AsTrimmedString(cb["name"])
-			var ad string
-			if s, ok := cb["input"].(string); ok {
-				ad = s
-			} else {
-				ad = SafeJSONString(cb["input"])
+		if cb != nil {
+			cbType := AsTrimmedString(cb["type"])
+			if cbType == "tool_use" || cbType == "server_tool_use" {
+				id := AsTrimmedString(cb["id"])
+				name := AsTrimmedString(cb["name"])
+				ad := coerceToolArgumentsText(cb["input"])
+				if ad == "" {
+					ad = coerceToolArgumentsText(cb["arguments"])
+				}
+				// Empty object is a valid initial input for streaming tool_use starts
+				// (arguments arrive via input_json_delta). Do not invent fake args.
+				if ad == "{}" || ad == "[]" {
+					ad = ""
+				}
+				return NormalizedStreamEvent{ToolCallDeltas: []ToolCallDelta{{Index: idx, ID: id, Name: name, ArgumentsDelta: ad}}}
 			}
-			if ad == "{}" || ad == "[]" {
-				ad = ""
-			}
-			return NormalizedStreamEvent{ToolCallDeltas: []ToolCallDelta{{Index: idx, ID: id, Name: name, ArgumentsDelta: ad}}}
 		}
 		cd, cr := ConsumeThinkTaggedText(ctx.ThinkTagParser, StringifyUnknownValue(cb))
 		return NormalizedStreamEvent{ContentDelta: cd, ReasoningDelta: cr}


### PR DESCRIPTION
## Summary
- Preserve Claude Code Skill tool_use/tool_result linkage across Anthropic ↔ OpenAI bridges
- OpenAI `role=tool` history coalesces into Anthropic `tool_result` (optional next user text appended)
- Shared/canonical bridges keep Skill id/name/arguments, including object-shaped `function.arguments`
- Tool schema `required`/`properties` survive Claude↔OpenAI conversion
- Document residual client/model limits (`input:{}` when upstream model omits skill params)

## Test plan
- [x] `go test ./transform/anthropic/... ./transform/canonical/ ./transform/shared/ -count=1`
- [x] pre-push `go vet` + `go test ./... -race` green

Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved compatibility between Anthropic and OpenAI tool calls, including Skill and server-side tool invocations.
  * Preserved tool arguments, call IDs, results, and multi-turn conversation history more reliably.
  * Added support for object- or string-based arguments, with sensible defaults for missing values.
  * Preserved tool parameter schemas, including required fields and strict settings.
  * Improved handling of tool calls in streaming responses and final message serialization.

* **Documentation**
  * Added documentation covering supported conversions, round-trip behavior, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->