### PR TITLE
fix(responses): multi-turn reasoning content for Hermes/Codex #50

### DIFF
--- a/docs/analysis/responses-multi-turn-reasoning.md
+++ b/docs/analysis/responses-multi-turn-reasoning.md
@@ -1,0 +1,92 @@
+# Multi-turn `/v1/responses` reasoning content (#50 / upstream #538)
+
+**Date:** 2026-07-17  
+**Lane:** feature / FE-PROTOCOL  
+**SSOT code:** `transform/openai/responses/reasoning_input.go`, `transform/openai/responses/compact.go`, `transform/openai/responses/previous_response_id.go` (`SanitizeResponsesRequestBody`), `transform/shared/chatFormatsCore.go` (`parseResponsesReasoning`)
+
+## Problem
+
+Hermes/Codex clients (`api_mode: codex_responses`) replay prior Responses `output` into the next turn's `input`:
+
+```json
+{
+  "model": "gpt-5.4",
+  "input": [
+    { "type": "message", "role": "user", "content": [...] },
+    {
+      "type": "reasoning",
+      "id": "rs_...",
+      "encrypted_content": "...",
+      "summary": [{ "type": "summary_text", "text": "..." }]
+    },
+    { "type": "message", "role": "assistant", "content": "" },
+    { "type": "function_call", "call_id": "...", "name": "...", "arguments": "..." },
+    { "type": "function_call_output", "call_id": "...", "output": "..." }
+  ]
+}
+```
+
+Official OpenAI Responses accepts reasoning items with `encrypted_content` / `summary` and **no** top-level `content`. Some OpenAI-compatible gateways (and intermediate normalizers) validate every `input[n]` as if it were a message and return:
+
+```text
+Missing required parameter: 'input[1].content'
+```
+
+Upstream issue: [cita-777/metapi#538](https://github.com/cita-777/metapi/issues/538). Direct Hermes → upstream works; the proxy path must not drop reasoning payload fields and must make strict validators happy.
+
+## Policy
+
+| Item type | Action |
+| --- | --- |
+| `reasoning` with `encrypted_content` and/or non-empty summary/content | **preserve** all fields; ensure top-level `content` is present (`summary` text, else existing content, else `""` when only encrypted) |
+| `reasoning` with empty summary, no content, no encrypted_content | **reject** with `ReasoningInputError` (explicit client message, not opaque upstream 400) |
+| `message` with empty `content` | **preserve** empty string/array (tool-call assistant turns) |
+| `function_call` / `function_call_output` / custom tool items | **pass-through** (no invented `content`) |
+| Compact sanitize (`stream` / `store` / `previous_response_id`) | **must not touch** `input` / reasoning fields |
+
+### API surface (SSOT)
+
+```go
+// transform/openai/responses
+SanitizeResponsesInputItems(input any) (any, error)
+SanitizeResponsesRequestBody(body, ContinuityPolicyInput) (body, ContinuityDecision, error)
+//  → continuity policy + input reasoning sanitize + optional compact strip
+HasReasoningInputItems(body map[string]any) bool
+
+type ReasoningInputError struct { Message string; Index int; Reason string }
+```
+
+```go
+// transform/shared
+parseResponsesReasoning(m) // reads output[] or input[]; flattens summary/content; keeps encrypted_content as signature
+```
+
+### Dispatch wiring
+
+`handler/proxy/upstream.go` `sanitizeUpstreamJSONBody` cheap-gates on:
+
+- `"previous_response_id"`
+- compact path
+- `"type":"reasoning"` / `"type": "reasoning"` / `"encrypted_content"`
+
+then calls `SanitizeResponsesRequestBody` so second-turn reasoning bodies are rewritten even without continuity ids.
+
+## Acceptance mapping
+
+| Criterion | Status |
+| --- | --- |
+| Multi-turn Hermes/Codex second turn accepts prior reasoning with required content | `SanitizeResponsesInputItems` injects/preserves `content`; keeps `encrypted_content` + `summary` |
+| Compact/sanitize does not drop required reasoning content | Compact only strips stream/store/previous_response_id; input sanitized before compact |
+| Fixture covers reasoning item round-trip | `reasoning_input_test.go`, shared parse fixtures |
+| Explicit error when client omits required fields | `ReasoningInputError` with `input[n]` index and required field list |
+
+## Residual
+
+- Full Responses → chat conversion of reasoning items remains in original TS `convertResponsesBodyToOpenAiBody`; Go multi-protocol fallback still relies on passthrough + continuity strip (#54).
+- No server-side store of prior Responses payloads: clients must replay items or use `previous_response_id` on supported platforms.
+
+## Verification
+
+```bash
+go test ./transform/openai/responses/ ./transform/shared/ -count=1
+```

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -984,19 +984,27 @@ func handleNonStreamUpstream(w http.ResponseWriter, resp *http.Response, latency
 	w.Write(bodyBytes)
 }
 
-// sanitizeUpstreamJSONBody applies Responses continuity/compact sanitization for one
-// upstream attempt. Chat/messages candidates strip previous_response_id; Responses
-// platforms forward or strip per SupportsResponsesPreviousResponseID.
-// See docs/analysis/previous-response-id.md (issue #54 / upstream #504).
+// sanitizeUpstreamJSONBody applies Responses continuity/compact/reasoning-input
+// sanitization for one upstream attempt. Chat/messages candidates strip
+// previous_response_id; Responses platforms forward or strip per
+// SupportsResponsesPreviousResponseID. Multi-turn reasoning items get required
+// content preserved/injected (#50 / upstream #538).
+// See docs/analysis/previous-response-id.md and
+// docs/analysis/responses-multi-turn-reasoning.md.
 func sanitizeUpstreamJSONBody(bodyBytes []byte, sitePlatform, upstreamPath string) ([]byte, error) {
 	if len(bodyBytes) == 0 {
 		return bodyBytes, nil
 	}
-	// Cheap gate: only rewrite when continuity field or compact path is involved.
+	// Cheap gate: only rewrite when continuity, compact, or multi-turn reasoning
+	// input is involved. Avoid full JSON parse on hot path otherwise.
 	pathLower := strings.ToLower(upstreamPath)
 	needsCompact := strings.Contains(pathLower, "/responses/compact")
 	needsContinuity := bytes.Contains(bodyBytes, []byte(`"previous_response_id"`))
-	if !needsCompact && !needsContinuity {
+	// Match both "type":"reasoning" and "type": "reasoning" (space after colon).
+	needsReasoningInput := bytes.Contains(bodyBytes, []byte(`"type":"reasoning"`)) ||
+		bytes.Contains(bodyBytes, []byte(`"type": "reasoning"`)) ||
+		bytes.Contains(bodyBytes, []byte(`"encrypted_content"`))
+	if !needsCompact && !needsContinuity && !needsReasoningInput {
 		return bodyBytes, nil
 	}
 	var body map[string]any

--- a/transform/openai/responses/compact.go
+++ b/transform/openai/responses/compact.go
@@ -23,6 +23,10 @@ func ShouldForceResponsesUpstreamStream(sitePlatform string, isCompactRequest bo
 // SanitizeCompactResponsesRequestBody removes stream/stream_options and
 // conditionally store. Compact never continues a prior stored response, so
 // previous_response_id is always stripped here (see previous_response_id.go).
+//
+// Input items (including multi-turn reasoning with encrypted_content / summary /
+// content) are preserved verbatim — compact must not drop required reasoning
+// content needed for Hermes/Codex second-turn replay (#50 / upstream #538).
 func SanitizeCompactResponsesRequestBody(body map[string]any, sitePlatform string) map[string]any {
 	next := map[string]any{}
 	for k, v := range body {
@@ -34,6 +38,7 @@ func SanitizeCompactResponsesRequestBody(body map[string]any, sitePlatform strin
 	if ShouldStripCompactResponsesStore(sitePlatform) {
 		delete(next, "store")
 	}
+	// Explicit: never touch "input" / reasoning item fields here.
 	return next
 }
 

--- a/transform/openai/responses/previous_response_id.go
+++ b/transform/openai/responses/previous_response_id.go
@@ -215,12 +215,23 @@ func ApplyPreviousResponseIDPolicy(body map[string]any, input ContinuityPolicyIn
 // SanitizeResponsesRequestBody applies Responses request sanitization for one
 // upstream attempt:
 //  1. previous_response_id forward/strip/reject policy
-//  2. when isCompact: also remove stream / stream_options / conditional store
+//  2. multi-turn input reasoning items: preserve required content fields
+//     (encrypted_content / summary) and ensure top-level content is present
+//     (#50 / upstream #538)
+//  3. when isCompact: also remove stream / stream_options / conditional store
 //
 // Callers that fall back from Responses → chat/messages should pass
 // ProtocolChat or ProtocolMessages so continuity is stripped cleanly.
+//
+// Reasoning input sanitization runs for every protocol: chat/messages fallback
+// still benefits from explicit missing-content errors and content preservation
+// before any later protocol conversion.
 func SanitizeResponsesRequestBody(body map[string]any, input ContinuityPolicyInput) (map[string]any, ContinuityDecision, error) {
 	next, decision, err := ApplyPreviousResponseIDPolicy(body, input)
+	if err != nil {
+		return next, decision, err
+	}
+	next, err = applyResponsesInputSanitization(next)
 	if err != nil {
 		return next, decision, err
 	}
@@ -228,6 +239,28 @@ func SanitizeResponsesRequestBody(body map[string]any, input ContinuityPolicyInp
 		next = SanitizeCompactResponsesRequestBody(next, input.SitePlatform)
 	}
 	return next, decision, nil
+}
+
+// applyResponsesInputSanitization rewrites body["input"] on a shallow body copy.
+// Compact field stripping must not drop reasoning content; this runs before
+// compact sanitize so stream/store cleanup cannot touch input items.
+func applyResponsesInputSanitization(body map[string]any) (map[string]any, error) {
+	if body == nil {
+		return map[string]any{}, nil
+	}
+	raw, ok := body["input"]
+	if !ok {
+		return body, nil
+	}
+	sanitized, err := SanitizeResponsesInputItems(raw)
+	if err != nil {
+		return body, err
+	}
+	// Always write sanitized input via a shallow body copy. Do not compare
+	// sanitized == raw: []any is not comparable and panics.
+	next := cloneBodyMap(body)
+	next["input"] = sanitized
+	return next, nil
 }
 
 // ContinuityError is a clear client-facing validation error for continuity

--- a/transform/openai/responses/reasoning_input.go
+++ b/transform/openai/responses/reasoning_input.go
@@ -1,0 +1,283 @@
+package responses
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Reasoning item types that must carry required multi-turn content fields
+// (summary / content / encrypted_content) when replayed into input.
+const (
+	ResponsesInputTypeReasoning = "reasoning"
+	ResponsesInputTypeMessage   = "message"
+)
+
+// ReasoningInputError is a clear client-facing validation error when a
+// multi-turn reasoning item omits every required content field.
+// Avoids opaque upstream 400 "Missing required parameter: 'input[n].content'".
+type ReasoningInputError struct {
+	Message string
+	Index   int
+	Reason  string
+}
+
+func (e *ReasoningInputError) Error() string {
+	if e == nil {
+		return "reasoning input error"
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	return "reasoning input item is missing required content"
+}
+
+// SanitizeResponsesInputItems normalizes the Responses `input` field for
+// multi-turn Hermes/Codex traffic:
+//
+//  1. Reasoning items keep encrypted_content / summary (never dropped).
+//  2. Reasoning items always expose a top-level `content` key derived from
+//     summary text (or "" when only encrypted_content is present) so strict
+//     OpenAI-compatible gateways that validate input[n].content do not 400.
+//  3. Message items keep empty content as "" rather than omitting the key.
+//  4. Returns ReasoningInputError when a reasoning item has no summary text,
+//     no content, and no encrypted_content.
+//
+// String / non-array inputs are returned unchanged.
+func SanitizeResponsesInputItems(input any) (any, error) {
+	switch v := input.(type) {
+	case nil:
+		return input, nil
+	case string:
+		return input, nil
+	case []any:
+		return sanitizeResponsesInputArray(v)
+	case map[string]any:
+		// Single-item object form (rare); normalize as a one-element array then unwrap.
+		arr, err := sanitizeResponsesInputArray([]any{v})
+		if err != nil {
+			return nil, err
+		}
+		if len(arr) == 1 {
+			return arr[0], nil
+		}
+		return arr, nil
+	default:
+		return input, nil
+	}
+}
+
+func sanitizeResponsesInputArray(items []any) ([]any, error) {
+	if items == nil {
+		return nil, nil
+	}
+	out := make([]any, 0, len(items))
+	for i, raw := range items {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			out = append(out, raw)
+			continue
+		}
+		next, err := sanitizeResponsesInputItem(item, i)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, next)
+	}
+	return out, nil
+}
+
+func sanitizeResponsesInputItem(item map[string]any, index int) (map[string]any, error) {
+	if item == nil {
+		return item, nil
+	}
+	typ := strings.ToLower(asTrimmedString(item["type"]))
+	switch typ {
+	case ResponsesInputTypeReasoning:
+		return sanitizeReasoningInputItem(item, index)
+	case ResponsesInputTypeMessage, "":
+		// Role-bearing items without type are treated as messages by Responses clients.
+		if typ == ResponsesInputTypeMessage || asTrimmedString(item["role"]) != "" {
+			return preserveMessageContent(item), nil
+		}
+		return cloneMapShallow(item), nil
+	default:
+		// function_call / function_call_output / custom_tool_call* / etc.
+		// Pass through without inventing a content field (schema differs by type).
+		return cloneMapShallow(item), nil
+	}
+}
+
+func sanitizeReasoningInputItem(item map[string]any, index int) (map[string]any, error) {
+	next := cloneMapShallow(item)
+	next["type"] = ResponsesInputTypeReasoning
+
+	// Never drop encrypted_content / summary — these are the real multi-turn
+	// continuity payload for reasoning models (stateless + tool loops).
+	encrypted := asTrimmedString(next["encrypted_content"])
+	if encrypted != "" {
+		next["encrypted_content"] = encrypted
+	}
+
+	summaryText := extractReasoningSummaryText(next["summary"])
+	// Also accept plain-string summary or content blocks already present.
+	existingContent := extractReasoningContentText(next["content"])
+	if existingContent == "" {
+		existingContent = extractReasoningContentText(next["text"])
+	}
+
+	hasEncrypted := encrypted != ""
+	hasSummaryText := summaryText != ""
+	hasContentText := existingContent != ""
+
+	if !hasEncrypted && !hasSummaryText && !hasContentText {
+		return nil, &ReasoningInputError{
+			Index:  index,
+			Reason: "reasoning_item_missing_required_content",
+			Message: fmt.Sprintf(
+				"input[%d] type=reasoning is missing required content: provide non-empty summary text, content, or encrypted_content for multi-turn /v1/responses (Hermes/Codex)",
+				index,
+			),
+		}
+	}
+
+	// Strict gateways validate input[n].content on every item. Prefer real text
+	// (summary/content); fall back to empty string when only encrypted_content
+	// is present so the key exists without fabricating reasoning prose.
+	if !hasContentKey(next) || !hasContentText {
+		if hasContentText {
+			next["content"] = existingContent
+		} else if hasSummaryText {
+			next["content"] = summaryText
+		} else {
+			next["content"] = ""
+		}
+	}
+
+	// Normalize empty summary arrays: keep as [] so clients that require the
+	// key still see it, without inventing summary_text blocks.
+	if _, ok := next["summary"]; ok {
+		if arr, ok := next["summary"].([]any); ok && len(arr) == 0 {
+			next["summary"] = arr
+		}
+	}
+
+	return next, nil
+}
+
+func preserveMessageContent(item map[string]any) map[string]any {
+	next := cloneMapShallow(item)
+	if typ := asTrimmedString(next["type"]); typ == "" {
+		next["type"] = ResponsesInputTypeMessage
+	}
+	// Empty assistant content is valid for tool-call turns. Do not delete the
+	// key — some clients send content:"" / content:[] and upstream expects it.
+	if _, ok := next["content"]; !ok {
+		// Only inject when role is present and content is completely absent.
+		// Leave non-message shapes alone.
+		if asTrimmedString(next["role"]) != "" {
+			next["content"] = ""
+		}
+	}
+	return next
+}
+
+func hasContentKey(item map[string]any) bool {
+	if item == nil {
+		return false
+	}
+	_, ok := item["content"]
+	return ok
+}
+
+// extractReasoningSummaryText flattens Responses summary arrays / strings into text.
+// Accepts:
+//   - string
+//   - []any of {type:summary_text|text, text: "..."} or plain strings
+//   - map with text / content
+func extractReasoningSummaryText(summary any) string {
+	switch s := summary.(type) {
+	case string:
+		return strings.TrimSpace(s)
+	case []any:
+		var parts []string
+		for _, item := range s {
+			if t := extractReasoningContentText(item); t != "" {
+				parts = append(parts, t)
+			}
+		}
+		return strings.Join(parts, "\n")
+	case map[string]any:
+		return extractReasoningContentText(s)
+	default:
+		return ""
+	}
+}
+
+// extractReasoningContentText pulls human-readable text from content-ish values.
+func extractReasoningContentText(content any) string {
+	switch c := content.(type) {
+	case string:
+		return strings.TrimSpace(c)
+	case []any:
+		var parts []string
+		for _, item := range c {
+			if t := extractReasoningContentText(item); t != "" {
+				parts = append(parts, t)
+			}
+		}
+		return strings.Join(parts, "\n")
+	case map[string]any:
+		for _, key := range []string{"text", "content", "summary_text", "output_text", "input_text", "reasoning", "reasoning_content"} {
+			if t := asTrimmedString(c[key]); t != "" {
+				return t
+			}
+		}
+		// Nested summary array inside a content object.
+		if t := extractReasoningSummaryText(c["summary"]); t != "" {
+			return t
+		}
+		return ""
+	default:
+		return ""
+	}
+}
+
+// HasReasoningInputItems reports whether body.input contains any reasoning items.
+func HasReasoningInputItems(body map[string]any) bool {
+	if body == nil {
+		return false
+	}
+	arr, ok := body["input"].([]any)
+	if !ok {
+		return false
+	}
+	for _, raw := range arr {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if strings.ToLower(asTrimmedString(item["type"])) == ResponsesInputTypeReasoning {
+			return true
+		}
+	}
+	return false
+}
+
+func asTrimmedString(v any) string {
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(s)
+}
+
+func cloneMapShallow(body map[string]any) map[string]any {
+	next := map[string]any{}
+	if body == nil {
+		return next
+	}
+	for k, v := range body {
+		next[k] = v
+	}
+	return next
+}

--- a/transform/openai/responses/reasoning_input_test.go
+++ b/transform/openai/responses/reasoning_input_test.go
@@ -1,0 +1,282 @@
+package responses
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeResponsesInputItems_ReasoningRoundTrip(t *testing.T) {
+	// Hermes/Codex second-turn shape from upstream #538:
+	// reasoning has encrypted_content + summary, no content.
+	input := []any{
+		map[string]any{
+			"type":    "message",
+			"role":    "user",
+			"content": []any{map[string]any{"type": "input_text", "text": "continue"}},
+		},
+		map[string]any{
+			"type":              "reasoning",
+			"id":                "rs_1",
+			"encrypted_content": "enc_abc",
+			"summary": []any{
+				map[string]any{"type": "summary_text", "text": "step one"},
+			},
+		},
+		map[string]any{
+			"type":    "message",
+			"role":    "assistant",
+			"content": "",
+		},
+		map[string]any{
+			"type":      "function_call",
+			"call_id":   "call_1",
+			"name":      "lookup",
+			"arguments": `{"q":"x"}`,
+		},
+		map[string]any{
+			"type":    "function_call_output",
+			"call_id": "call_1",
+			"output":  `{"ok":true}`,
+		},
+	}
+
+	got, err := SanitizeResponsesInputItems(input)
+	if err != nil {
+		t.Fatalf("SanitizeResponsesInputItems: %v", err)
+	}
+	arr, ok := got.([]any)
+	if !ok || len(arr) != 5 {
+		t.Fatalf("len = %d type=%T", len(arr), got)
+	}
+
+	// User message preserved.
+	user, _ := arr[0].(map[string]any)
+	if user["role"] != "user" {
+		t.Fatalf("user role = %v", user["role"])
+	}
+
+	// Reasoning: encrypted_content + summary kept; content injected from summary.
+	reasoning, _ := arr[1].(map[string]any)
+	if reasoning["type"] != "reasoning" {
+		t.Fatalf("type = %v", reasoning["type"])
+	}
+	if reasoning["encrypted_content"] != "enc_abc" {
+		t.Fatalf("encrypted_content dropped: %v", reasoning["encrypted_content"])
+	}
+	if _, ok := reasoning["summary"]; !ok {
+		t.Fatal("summary dropped")
+	}
+	content, ok := reasoning["content"].(string)
+	if !ok || content != "step one" {
+		t.Fatalf("content = %#v, want summary text", reasoning["content"])
+	}
+	if reasoning["id"] != "rs_1" {
+		t.Fatalf("id = %v", reasoning["id"])
+	}
+
+	// Empty assistant content preserved (not deleted).
+	asst, _ := arr[2].(map[string]any)
+	if asst["content"] != "" {
+		t.Fatalf("assistant content = %#v", asst["content"])
+	}
+
+	// Tool lifecycle pass-through.
+	fc, _ := arr[3].(map[string]any)
+	if fc["type"] != "function_call" || fc["call_id"] != "call_1" {
+		t.Fatalf("function_call = %#v", fc)
+	}
+	fco, _ := arr[4].(map[string]any)
+	if fco["type"] != "function_call_output" {
+		t.Fatalf("function_call_output = %#v", fco)
+	}
+}
+
+func TestSanitizeResponsesInputItems_EncryptedOnlyInjectsEmptyContent(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"type":              "reasoning",
+			"encrypted_content": "enc_only",
+			"summary":           []any{},
+		},
+	}
+	got, err := SanitizeResponsesInputItems(input)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	arr := got.([]any)
+	r := arr[0].(map[string]any)
+	if r["encrypted_content"] != "enc_only" {
+		t.Fatalf("encrypted_content = %v", r["encrypted_content"])
+	}
+	if c, ok := r["content"].(string); !ok || c != "" {
+		t.Fatalf("content = %#v, want empty string key present", r["content"])
+	}
+}
+
+func TestSanitizeResponsesInputItems_MissingRequiredFieldsError(t *testing.T) {
+	input := []any{
+		map[string]any{"type": "message", "role": "user", "content": "hi"},
+		map[string]any{
+			"type":    "reasoning",
+			"summary": []any{},
+			// no encrypted_content, no content, empty summary
+		},
+	}
+	_, err := SanitizeResponsesInputItems(input)
+	if err == nil {
+		t.Fatal("expected ReasoningInputError")
+	}
+	re, ok := err.(*ReasoningInputError)
+	if !ok {
+		t.Fatalf("err type = %T", err)
+	}
+	if re.Index != 1 {
+		t.Fatalf("index = %d", re.Index)
+	}
+	if !strings.Contains(re.Error(), "input[1]") {
+		t.Fatalf("message = %q", re.Error())
+	}
+	if !strings.Contains(re.Error(), "encrypted_content") {
+		t.Fatalf("message should list required fields: %q", re.Error())
+	}
+}
+
+func TestSanitizeResponsesInputItems_PreservesExistingContent(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"type":              "reasoning",
+			"content":           "already here",
+			"encrypted_content": "enc",
+			"summary": []any{
+				map[string]any{"type": "summary_text", "text": "sum"},
+			},
+		},
+	}
+	got, err := SanitizeResponsesInputItems(input)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	r := got.([]any)[0].(map[string]any)
+	if r["content"] != "already here" {
+		t.Fatalf("content overwritten: %v", r["content"])
+	}
+}
+
+func TestSanitizeResponsesInputItems_StringPassthrough(t *testing.T) {
+	got, err := SanitizeResponsesInputItems("hello")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != "hello" {
+		t.Fatalf("got = %v", got)
+	}
+}
+
+func TestSanitizeResponsesRequestBody_ReasoningAndCompact(t *testing.T) {
+	body := map[string]any{
+		"model":                "gpt-5.4",
+		"stream":               true,
+		"stream_options":       map[string]any{"include_usage": true},
+		"store":                true,
+		"previous_response_id": "resp_1",
+		"input": []any{
+			map[string]any{
+				"type":              "reasoning",
+				"encrypted_content": "enc_xyz",
+				"summary": []any{
+					map[string]any{"type": "summary_text", "text": "think"},
+				},
+			},
+			map[string]any{
+				"type":    "message",
+				"role":    "user",
+				"content": "next turn",
+			},
+		},
+	}
+
+	next, decision, err := SanitizeResponsesRequestBody(body, ContinuityPolicyInput{
+		SitePlatform:     "codex",
+		Protocol:         ProtocolResponses,
+		IsCompactRequest: true,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if decision.Action != ContinuityStrip {
+		t.Fatalf("action = %q", decision.Action)
+	}
+	for _, k := range []string{"stream", "stream_options", "store", "previous_response_id"} {
+		if _, ok := next[k]; ok {
+			t.Fatalf("expected %q stripped", k)
+		}
+	}
+
+	arr, ok := next["input"].([]any)
+	if !ok || len(arr) != 2 {
+		t.Fatalf("input = %#v", next["input"])
+	}
+	r := arr[0].(map[string]any)
+	if r["encrypted_content"] != "enc_xyz" {
+		t.Fatalf("encrypted_content dropped by compact: %v", r["encrypted_content"])
+	}
+	if r["content"] != "think" {
+		t.Fatalf("content = %v", r["content"])
+	}
+	if _, ok := r["summary"]; !ok {
+		t.Fatal("summary dropped by compact")
+	}
+}
+
+func TestSanitizeResponsesRequestBody_ReasoningMissingError(t *testing.T) {
+	body := map[string]any{
+		"model": "gpt-5.4",
+		"input": []any{
+			map[string]any{"type": "reasoning"},
+		},
+	}
+	_, _, err := SanitizeResponsesRequestBody(body, ContinuityPolicyInput{
+		SitePlatform: "openai",
+		Protocol:     ProtocolResponses,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if _, ok := err.(*ReasoningInputError); !ok {
+		t.Fatalf("err type = %T (%v)", err, err)
+	}
+}
+
+func TestHasReasoningInputItems(t *testing.T) {
+	if HasReasoningInputItems(nil) {
+		t.Fatal("nil")
+	}
+	if HasReasoningInputItems(map[string]any{"input": "hi"}) {
+		t.Fatal("string input")
+	}
+	if !HasReasoningInputItems(map[string]any{
+		"input": []any{map[string]any{"type": "reasoning", "encrypted_content": "x"}},
+	}) {
+		t.Fatal("expected true")
+	}
+}
+
+func TestSanitizeCompactResponsesRequestBody_DoesNotDropInput(t *testing.T) {
+	body := map[string]any{
+		"stream": true,
+		"input": []any{
+			map[string]any{
+				"type":              "reasoning",
+				"encrypted_content": "enc",
+				"content":           "kept",
+				"summary":           []any{map[string]any{"type": "summary_text", "text": "kept"}},
+			},
+		},
+	}
+	next := SanitizeCompactResponsesRequestBody(body, "codex")
+	arr := next["input"].([]any)
+	r := arr[0].(map[string]any)
+	if r["encrypted_content"] != "enc" || r["content"] != "kept" {
+		t.Fatalf("input mutated: %#v", r)
+	}
+}

--- a/transform/shared/chatFormatsCore.go
+++ b/transform/shared/chatFormatsCore.go
@@ -858,18 +858,24 @@ type responsesReasoningResult struct {
 }
 
 func parseResponsesReasoning(m map[string]any) responsesReasoningResult {
-	output, _ := m["output"].([]any)
+	// Prefer output[] (final response). Also accept input[] so multi-turn
+	// reasoning items replayed by Hermes/Codex can be parsed for round-trip
+	// fixtures and stream/final normalize (#50 / upstream #538).
+	items := firstResponsesItemArray(m, "output", "input")
 	var parts []string
 	var sig string
-	for _, item := range output {
+	for _, item := range items {
 		om, ok := item.(map[string]any)
 		if !ok || strings.ToLower(AsTrimmedString(om["type"])) != "reasoning" {
 			continue
 		}
-		tr := ExtractInlineThinkTags(StringifyUnknownValue(om["summary"]))
-		t := JoinNonEmpty([]string{tr.Content, tr.Reasoning})
-		if t != "" {
-			parts = append(parts, t)
+		// Required content sources (do not drop any):
+		//   summary (array of summary_text / string)
+		//   content / text (some gateways / clients)
+		// encrypted_content is the continuity signature, not visible text.
+		text := extractResponsesReasoningItemText(om)
+		if text != "" {
+			parts = append(parts, text)
 		}
 		if sig == "" {
 			if ec := AsTrimmedString(om["encrypted_content"]); ec != "" {
@@ -880,6 +886,72 @@ func parseResponsesReasoning(m map[string]any) responsesReasoningResult {
 	return responsesReasoningResult{
 		reasoningContent:   JoinNonEmpty(parts),
 		reasoningSignature: sig,
+	}
+}
+
+// firstResponsesItemArray returns the first present []any among keys.
+func firstResponsesItemArray(m map[string]any, keys ...string) []any {
+	if m == nil {
+		return nil
+	}
+	for _, k := range keys {
+		if arr, ok := m[k].([]any); ok && len(arr) > 0 {
+			return arr
+		}
+	}
+	// Still return empty slice if key exists as empty array (caller iterates).
+	for _, k := range keys {
+		if arr, ok := m[k].([]any); ok {
+			return arr
+		}
+	}
+	return nil
+}
+
+// extractResponsesReasoningItemText flattens summary/content/text on a
+// type=reasoning item into visible reasoning text. Prefers summary, then
+// content, then text — without double-counting identical values. Never uses
+// encrypted_content as text.
+func extractResponsesReasoningItemText(om map[string]any) string {
+	if om == nil {
+		return ""
+	}
+	// Prefer summary (Responses native), then content/text fallbacks.
+	for _, key := range []string{"summary", "content", "text"} {
+		if t := flattenResponsesReasoningText(om[key]); t != "" {
+			tr := ExtractInlineThinkTags(t)
+			return JoinNonEmpty([]string{tr.Content, tr.Reasoning})
+		}
+	}
+	return ""
+}
+
+func flattenResponsesReasoningText(v any) string {
+	switch x := v.(type) {
+	case string:
+		return strings.TrimSpace(x)
+	case []any:
+		var parts []string
+		for _, item := range x {
+			if t := flattenResponsesReasoningText(item); t != "" {
+				parts = append(parts, t)
+			}
+		}
+		return JoinNonEmpty(parts)
+	case map[string]any:
+		// summary_text / text / content blocks
+		for _, key := range []string{"text", "content", "summary_text", "output_text", "reasoning", "reasoning_content"} {
+			if t := AsTrimmedString(x[key]); t != "" {
+				return t
+			}
+		}
+		if s, ok := x["summary"]; ok {
+			return flattenResponsesReasoningText(s)
+		}
+		// Fallback: stringify only if it looks like a leaf text container.
+		return ""
+	default:
+		return ""
 	}
 }
 

--- a/transform/shared/shared_test.go
+++ b/transform/shared/shared_test.go
@@ -951,3 +951,95 @@ func TestBuildSyntheticOpenAiChunks(t *testing.T) {
 		t.Errorf("expected finish_reason in second chunk, got %v", c2[0]["finish_reason"])
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Responses multi-turn reasoning (#50 / upstream #538)
+// ---------------------------------------------------------------------------
+
+func TestParseResponsesReasoning_OutputAndInputRoundTrip(t *testing.T) {
+	// Final response shape: output[] with reasoning item.
+	final := map[string]any{
+		"object": "response",
+		"id":     "resp_1",
+		"model":  "gpt-5.4",
+		"output": []any{
+			map[string]any{
+				"type":              "reasoning",
+				"id":                "rs_1",
+				"encrypted_content": "enc_sig",
+				"summary": []any{
+					map[string]any{"type": "summary_text", "text": "plan A"},
+				},
+			},
+			map[string]any{
+				"type":    "message",
+				"role":    "assistant",
+				"content": []any{map[string]any{"type": "output_text", "text": "done"}},
+			},
+		},
+	}
+	rr := parseResponsesReasoning(final)
+	if rr.reasoningContent != "plan A" {
+		t.Fatalf("output reasoningContent = %q", rr.reasoningContent)
+	}
+	if rr.reasoningSignature != "enc_sig" {
+		t.Fatalf("output signature = %q", rr.reasoningSignature)
+	}
+
+	// Second-turn request shape: same item replayed into input[].
+	// parseResponsesReasoning must not drop required content when reading input.
+	secondTurn := map[string]any{
+		"input": []any{
+			map[string]any{
+				"type":              "reasoning",
+				"encrypted_content": "enc_sig",
+				"content":           "plan A",
+				"summary": []any{
+					map[string]any{"type": "summary_text", "text": "plan A"},
+				},
+			},
+		},
+	}
+	rr2 := parseResponsesReasoning(secondTurn)
+	if rr2.reasoningContent != "plan A" {
+		t.Fatalf("input reasoningContent = %q", rr2.reasoningContent)
+	}
+	if rr2.reasoningSignature != "enc_sig" {
+		t.Fatalf("input signature = %q", rr2.reasoningSignature)
+	}
+}
+
+func TestNormalizeUpstreamFinalResponse_ResponsesReasoning(t *testing.T) {
+	payload := map[string]any{
+		"object": "response",
+		"id":     "resp_rt",
+		"model":  "gpt-5.4",
+		"status": "completed",
+		"output": []any{
+			map[string]any{
+				"type":              "reasoning",
+				"encrypted_content": "enc_rt",
+				"summary": []any{
+					map[string]any{"type": "summary_text", "text": "think step"},
+				},
+			},
+			map[string]any{
+				"type": "message",
+				"role": "assistant",
+				// String content path is stable across parseResponsesOutputText shapes.
+				"content": "answer",
+			},
+		},
+	}
+	result := NormalizeUpstreamFinalResponse(payload, "gpt-5.4", "")
+	if result.ReasoningContent != "think step" {
+		t.Fatalf("ReasoningContent = %q", result.ReasoningContent)
+	}
+	if result.ReasoningSignature != "enc_rt" {
+		t.Fatalf("ReasoningSignature = %q", result.ReasoningSignature)
+	}
+	// Assert reasoning was separated from visible content path (signature retained).
+	if result.ID != "resp_rt" {
+		t.Fatalf("ID = %q", result.ID)
+	}
+}


### PR DESCRIPTION
## Summary
- Sanitize multi-turn `/v1/responses` `input` reasoning items so Hermes/Codex second-turn replay keeps `encrypted_content` / `summary` and always exposes top-level `content` (or returns an explicit `ReasoningInputError`).
- Compact / continuity sanitize no longer drops required reasoning fields; dispatch cheap-gate also rewrites bodies that carry reasoning items without `previous_response_id`.
- `parseResponsesReasoning` accepts `output[]` or `input[]` and flattens summary/content without using encrypted blobs as text.

Closes #50

## Test plan
- [x] `go test ./transform/openai/responses/ ./transform/shared/ -count=1`
- [x] `go test ./handler/proxy/ -count=1 -run 'Sanitize|Previous|Responses'`
- [ ] Manual Hermes/Codex multi-turn `/v1/responses` with tool loop against Responses-capable upstream (when available)