### PR TITLE
feat(proxy): end-to-end request trace IDs across retries (#110)

### DIFF
--- a/docs/analysis/request-trace-ids.md
+++ b/docs/analysis/request-trace-ids.md
@@ -1,0 +1,97 @@
+# Request / Trace IDs across retries & failovers (#110)
+
+**Date:** 2026-07-17  
+**Lane:** competitive learn / observability  
+**SSOT code:** `router/request_id.go`, `proxy/request_id.go`, `handler/proxy/upstream.go`, `handler/proxy/proxy_log.go`, `handler/shared/errors.go`
+
+## Goal
+
+Give operators one stable identifier for a single client proxy call even when MetAPI retries across channels or protocol endpoints. Correlate:
+
+1. ingress access logs (`RequestLogger`)
+2. per-attempt `slog` lines on the proxy hot path
+3. `proxy_logs` rows (success path today)
+4. client-facing JSON error bodies / `X-Request-Id` header
+
+This is **not** OpenTelemetry / Langfuse. It reuses chi's `middleware.RequestID`.
+
+## Ingress
+
+| Layer | Behavior |
+|:------|:---------|
+| `router.WithRequestID` | Wraps chi `middleware.RequestID`. Accepts inbound `X-Request-Id` or generates one. Writes `X-Request-Id` on the response. Stores id in request context. |
+| `router.RequestLogger` | Emits `request_id` on every access log line. |
+| CORS | Exposes `X-Request-Id` so browsers can read the correlation header. |
+
+## Proxy hot path
+
+```
+dispatchUpstream
+  EnsureRequestID(r.Context())          // parent id for whole call
+  for retry := 0..MaxRetries:
+      SelectProxyChannelForAttempt(...)
+      dispatchSelectedUpstream(..., requestID)
+          dispatchEndpointAttemptWithContinue(..., requestID)
+              slog fields: request_id, retry, channel_id, ...
+              writeSuccessProxyLog(..., requestID)  // proxy_logs.request_id
+  on terminal MetAPI JSON error:
+      writeJSONErrorWithRequest(..., requestID)
+```
+
+Rules:
+
+- **Parent id is immutable** for the client call. Channel retries and cross-protocol endpoint fallbacks share the same id.
+- **`retry` / `retry_count`** is the channel-attempt index (0 = first selected channel).
+- Endpoint-protocol fallbacks inside one channel do **not** mint a new request id.
+- When the response is a **relayed upstream body**, MetAPI may not rewrite the body; operators still have the response `X-Request-Id` from ingress middleware and server logs.
+
+## Persistence
+
+| Surface | Field | Notes |
+|:--------|:------|:------|
+| `proxy_logs.request_id` | TEXT NULL | Additive migration `sc2_004_proxy_logs_request_id` + base DDL for fresh installs. Index `(request_id, created_at)`. |
+| `proxy.ProxyLogEntry.RequestID` | string | In-memory / writer path; filled from context if empty. |
+| Admin JSON error (`handler/shared`) | `request_id` | Optional; helpers `WriteErrorWithRequestID` / `WriteErrorDetailWithRequestID`. |
+| Proxy OpenAI-shaped JSON error | `error.request_id` | From `writeJSONErrorWithRequest`. |
+
+### Operator query examples
+
+```sql
+-- All success rows for one client call (after retries landed on a healthy channel)
+SELECT id, channel_id, account_id, status, http_status, retry_count, created_at
+FROM proxy_logs
+WHERE request_id = 'req-...'
+ORDER BY created_at;
+
+-- Grep process logs
+-- request_id=req-... retry=0|1 channel_id=...
+```
+
+## Client contract
+
+| Artifact | Value |
+|:---------|:------|
+| Response header | `X-Request-Id: <id>` (ingress middleware; error helpers fill if still empty) |
+| MetAPI JSON error body (proxy) | `{"error":{"message":"...","type":"...","request_id":"..."}}` |
+| MetAPI JSON error body (admin shared) | `{"error":"...","detail":"...","request_id":"..."}` |
+| Inbound override | Client may send `X-Request-Id`; chi reuses it when present. |
+
+## Tests
+
+- `proxy/request_id_test.go` — context helpers preserve parent id across attempts.
+- `handler/shared/errors_test.go` — `request_id` on unified admin errors.
+- `handler/proxy/helpers_test.go` — OpenAI-shaped error body includes `request_id`.
+- `handler/proxy/upstream_test.go` — multi-channel retry then success keeps the same `proxy_logs.request_id` with `retry_count=1`.
+
+## Out of scope
+
+- Full OpenTelemetry exporter / vendor UI
+- Storing raw prompts/responses in external APM
+- Per-attempt failure rows in `proxy_logs` (still success-centric; use slog + optional `proxy_debug_*` for deep traces)
+- Frontend log browser filters (future)
+
+## Residual risks
+
+1. Failed attempts that only appear in slog (no `proxy_logs` row yet) still share the request id in logs, not SQL.
+2. Upstream-relayed error bodies may omit `request_id` JSON field; header + logs remain authoritative.
+3. Existing DBs need additive migration; fresh installs get the column from base DDL.

--- a/handler/proxy/helpers_test.go
+++ b/handler/proxy/helpers_test.go
@@ -103,6 +103,26 @@ func TestWriteJSONError_SpecialChars(t *testing.T) {
 	}
 }
 
+func TestWriteJSONErrorWithRequest_IncludesRequestID(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeJSONErrorWithRequest(rec, 503, "All channels exhausted", "server_error", "req-trace-9")
+
+	if rec.Code != 503 {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	if got := rec.Header().Get("X-Request-Id"); got != "req-trace-9" {
+		t.Fatalf("X-Request-Id = %q", got)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatalf("invalid JSON: %v body=%s", err, rec.Body.String())
+	}
+	errObj := m["error"].(map[string]any)
+	if errObj["request_id"] != "req-trace-9" {
+		t.Fatalf("request_id = %v", errObj["request_id"])
+	}
+}
+
 // ---- writeJSON ----
 
 func TestWriteJSON(t *testing.T) {

--- a/handler/proxy/proxy_log.go
+++ b/handler/proxy/proxy_log.go
@@ -49,7 +49,7 @@ func InsertProxyLog(ctx context.Context, db *store.DB, entry proxy.ProxyLogEntry
 			prompt_tokens, completion_tokens, total_tokens,
 			estimated_cost, billing_details,
 			client_family, client_app_id, client_app_name, client_confidence,
-			error_message, retry_count, created_at
+			error_message, retry_count, request_id, created_at
 		) VALUES (
 			?, ?, ?, ?,
 			?, ?, ?, ?, ?,
@@ -57,7 +57,7 @@ func InsertProxyLog(ctx context.Context, db *store.DB, entry proxy.ProxyLogEntry
 			?, ?, ?,
 			?, ?,
 			?, ?, ?, ?,
-			?, ?, ?
+			?, ?, ?, ?
 		)`
 
 	args := []any{
@@ -83,6 +83,7 @@ func InsertProxyLog(ctx context.Context, db *store.DB, entry proxy.ProxyLogEntry
 		nullString(strPtrOrEmpty(entry.ClientConfidence)),
 		nullString(entry.ErrorMessage),
 		entry.RetryCount,
+		nullString(strPtrOrEmpty(entry.RequestID)),
 		createdAt,
 	}
 
@@ -101,6 +102,10 @@ func logProxy(ctx context.Context, cfg *UpstreamConfig, entry proxy.ProxyLogEntr
 	if cfg == nil {
 		return
 	}
+	// Prefer explicit entry.RequestID; otherwise inherit chi/MetAPI request id.
+	if entry.RequestID == "" {
+		entry.RequestID = proxy.RequestIDFromContext(ctx)
+	}
 	writer := cfg.LogProxy
 	if writer == nil {
 		writer = defaultLogProxyWriter
@@ -110,6 +115,8 @@ func logProxy(ctx context.Context, cfg *UpstreamConfig, entry proxy.ProxyLogEntr
 			"err", err,
 			"status", entry.Status,
 			"model", entry.ModelRequested,
+			"request_id", entry.RequestID,
+			"retry_count", entry.RetryCount,
 		)
 	}
 }

--- a/handler/proxy/router.go
+++ b/handler/proxy/router.go
@@ -80,11 +80,26 @@ func RegisterNonV1ProxyRoutes(r chi.Router) {
 // In Go/chi, `net/http` natively parses multipart forms, so this is a no-op.
 func EnsureMultipartBufferParser() {}
 
-// writeJSONError writes a JSON error response.
+// writeJSONError writes a JSON error response without a request id.
+// Prefer writeJSONErrorWithRequest when the ingress request/trace id is known.
 func writeJSONError(w http.ResponseWriter, status int, message, typ string) {
+	writeJSONErrorWithRequest(w, status, message, typ, "")
+}
+
+// writeJSONErrorWithRequest writes an OpenAI-shaped JSON error and, when
+// requestID is non-empty, attaches it both in the body and as X-Request-Id
+// when the response header is still unset.
+func writeJSONErrorWithRequest(w http.ResponseWriter, status int, message, typ, requestID string) {
+	if requestID != "" && w.Header().Get("X-Request-Id") == "" {
+		w.Header().Set("X-Request-Id", requestID)
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	body := `{"error":{"message":"` + jsonEscape(message) + `","type":"` + jsonEscape(typ) + `"}}`
+	body := `{"error":{"message":"` + jsonEscape(message) + `","type":"` + jsonEscape(typ) + `"`
+	if requestID != "" {
+		body += `,"request_id":"` + jsonEscape(requestID) + `"`
+	}
+	body += `}}`
 	w.Write([]byte(body))
 }
 

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -67,6 +67,11 @@ func getUpstreamConfig() *UpstreamConfig {
 // Implements the spec's 10-step Handler pattern.
 func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 	shared.RecordProxyRequest()
+	// Parent request/trace id is stable across channel retries and endpoint fallbacks.
+	reqCtx, requestID := proxy.EnsureRequestID(r.Context(), "")
+	if requestID != "" && r.Context() != reqCtx {
+		r = r.WithContext(reqCtx)
+	}
 	cfg := getUpstreamConfig()
 	if cfg == nil {
 		if isProxyStubEnabled() {
@@ -74,9 +79,10 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 			return
 		}
 		unconfiguredUpstreamLogOnce.Do(func() {
-			slog.Error("proxy upstream dependencies are not configured")
+			slog.Error("proxy upstream dependencies are not configured", "request_id", requestID)
 		})
-		shared.RecordProxyError(); writeJSONError(w, http.StatusServiceUnavailable, "Proxy upstream is not configured", "server_error")
+		shared.RecordProxyError()
+		writeJSONErrorWithRequest(w, http.StatusServiceUnavailable, "Proxy upstream is not configured", "server_error", requestID)
 		return
 	}
 
@@ -104,12 +110,17 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 			},
 		)
 		if err != nil || selected == nil {
-			slog.Warn("channel selection failed", "err", err, "model", ctx.RequestedModel, "retry", retry)
+			slog.Warn("channel selection failed",
+				"err", err,
+				"model", ctx.RequestedModel,
+				"retry", retry,
+				"request_id", requestID,
+			)
 			if pendingFailure != nil {
-				pendingFailure.write(w)
+				pendingFailure.write(w, requestID)
 				return
 			}
-			writeJSONError(w, 503, "No available channels", "server_error")
+			writeJSONErrorWithRequest(w, 503, "No available channels", "server_error", requestID)
 			return
 		}
 		excludeChannelIDs = append(excludeChannelIDs, selected.Channel.ID)
@@ -129,6 +140,7 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 				"max_concurrency", selected.Site.MaxConcurrency,
 				"model", ctx.RequestedModel,
 				"retry", retry,
+				"request_id", requestID,
 			)
 			continue
 		}
@@ -138,7 +150,7 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 		var nextPending *pendingUpstreamFailure
 		func() {
 			defer siteSlot.Release()
-			finished, nextPending = dispatchSelectedUpstream(w, r, ctx, cfg, selected, upstreamPath, retry, maxRetries)
+			finished, nextPending = dispatchSelectedUpstream(w, r, ctx, cfg, selected, upstreamPath, retry, maxRetries, requestID)
 		}()
 		if finished {
 			return
@@ -148,7 +160,7 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 		}
 	}
 
-	writeJSONError(w, 503, "All channels exhausted", "server_error")
+	writeJSONErrorWithRequest(w, 503, "All channels exhausted", "server_error", requestID)
 }
 
 // dispatchSelectedUpstream runs steps 7-9 for one selected channel.
@@ -169,7 +181,11 @@ func dispatchSelectedUpstream(
 	upstreamPath string,
 	retry int,
 	maxRetries int,
+	requestID string,
 ) (finished bool, nextPending *pendingUpstreamFailure) {
+	if requestID == "" {
+		requestID = proxy.RequestIDFromContext(r.Context())
+	}
 	// Step 7: Build upstream request materials
 	upstreamModel := selected.ActualModel
 	if upstreamModel == "" {
@@ -197,19 +213,21 @@ func dispatchSelectedUpstream(
 		var bodyReader io.Reader
 		bodyReader, contentType, err = CloneMultipartBody(r, map[string]string{"model": upstreamModel})
 		if err != nil {
-			slog.Warn("multipart upstream body construction failed", "err", err, "path", upstreamPath, "model", upstreamModel)
-			writeJSONError(w, 400, "Invalid multipart request body", "invalid_request_error")
+			slog.Warn("multipart upstream body construction failed",
+				"err", err, "path", upstreamPath, "model", upstreamModel, "request_id", requestID, "retry", retry)
+			writeJSONErrorWithRequest(w, 400, "Invalid multipart request body", "invalid_request_error", requestID)
 			return true, nil
 		}
 		if bodyReader != nil {
 			bodyBytes, err = io.ReadAll(bodyReader)
 			if err != nil {
-				slog.Warn("multipart upstream body read failed", "err", err, "path", upstreamPath)
-				writeJSONError(w, 400, "Invalid multipart request body", "invalid_request_error")
+				slog.Warn("multipart upstream body read failed",
+					"err", err, "path", upstreamPath, "request_id", requestID, "retry", retry)
+				writeJSONErrorWithRequest(w, 400, "Invalid multipart request body", "invalid_request_error", requestID)
 				return true, nil
 			}
 		}
-		return dispatchEndpointAttempt(w, r, ctx, cfg, selected, upstreamModel, proxyConfig, upstreamPath, contentType, bodyBytes, firstByteTimeoutMs, retry, maxRetries, true)
+		return dispatchEndpointAttempt(w, r, ctx, cfg, selected, upstreamModel, proxyConfig, upstreamPath, contentType, bodyBytes, firstByteTimeoutMs, retry, maxRetries, true, requestID)
 	}
 	bodyBytes = swapModelInJSON(ctx.RawBody, upstreamModel)
 
@@ -221,7 +239,7 @@ func dispatchSelectedUpstream(
 	)
 	if errMsg := responsesOnlyClientError(upstreamPath, bodyBytes, sitePref); errMsg != "" {
 		// Clear failure for chat/messages clients when site cannot serve without transform.
-		writeJSONError(w, http.StatusBadRequest, errMsg, "invalid_request_error")
+		writeJSONErrorWithRequest(w, http.StatusBadRequest, errMsg, "invalid_request_error", requestID)
 		return true, nil
 	}
 
@@ -232,7 +250,7 @@ func dispatchSelectedUpstream(
 		attemptBody, sanitizeErr := sanitizeUpstreamJSONBody(bodyBytes, selected.Site.Platform, path)
 		if sanitizeErr != nil {
 			// Clear client-facing continuity error (issue #54 / upstream #504).
-			writeJSONError(w, http.StatusBadRequest, sanitizeErr.Error(), "invalid_request_error")
+			writeJSONErrorWithRequest(w, http.StatusBadRequest, sanitizeErr.Error(), "invalid_request_error", requestID)
 			return true, nil
 		}
 		// Force stream=true for responses-only / stream-preferring sites (and codex/sub2api).
@@ -241,7 +259,7 @@ func dispatchSelectedUpstream(
 		finished, pending, cont := dispatchEndpointAttemptWithContinue(
 			w, r, ctx, cfg, selected, upstreamModel, proxyConfig,
 			path, contentType, attemptBody, firstByteTimeoutMs,
-			retry, maxRetries, isLast, disableCrossProtocolFallback, effectiveStream,
+			retry, maxRetries, isLast, disableCrossProtocolFallback, effectiveStream, requestID,
 		)
 		if finished {
 			return true, nil
@@ -262,7 +280,7 @@ func dispatchSelectedUpstream(
 	if retry < maxRetries {
 		return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error")
 	}
-	writeJSONError(w, 502, "Upstream request failed", "upstream_error")
+	writeJSONErrorWithRequest(w, 502, "Upstream request failed", "upstream_error", requestID)
 	return true, nil
 }
 
@@ -377,11 +395,12 @@ func dispatchEndpointAttempt(
 	retry int,
 	maxRetries int,
 	recordFailure bool,
+	requestID string,
 ) (finished bool, nextPending *pendingUpstreamFailure) {
 	finished, pending, _ := dispatchEndpointAttemptWithContinue(
 		w, r, ctx, cfg, selected, upstreamModel, proxyConfig,
 		upstreamPath, contentType, bodyBytes, firstByteTimeoutMs,
-		retry, maxRetries, true, true, ctx != nil && ctx.IsStream,
+		retry, maxRetries, true, true, ctx != nil && ctx.IsStream, requestID,
 	)
 	if !recordFailure {
 		return finished, pending
@@ -409,20 +428,26 @@ func dispatchEndpointAttemptWithContinue(
 	isLastEndpoint bool,
 	disableCrossProtocolFallback bool,
 	effectiveStream bool,
+	requestID string,
 ) (finished bool, nextPending *pendingUpstreamFailure, cont bool) {
+	if requestID == "" {
+		requestID = proxy.RequestIDFromContext(r.Context())
+	}
 	upstreamURL := proxy.BuildUpstreamURL(selected.Site.URL, upstreamPath)
 	startedAt := time.Now()
 
 	req, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, bytesReader(bodyBytes))
 	if err != nil {
-		slog.Warn("upstream request construction failed", "err", err, "url", upstreamURL, "model", upstreamModel)
+		slog.Warn("upstream request construction failed",
+			"err", err, "url", upstreamURL, "model", upstreamModel,
+			"request_id", requestID, "retry", retry)
 		if !isLastEndpoint && !disableCrossProtocolFallback {
 			return false, nil, true
 		}
 		if retry < maxRetries {
 			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error"), false
 		}
-		writeJSONError(w, 502, "Upstream request failed", "upstream_error")
+		writeJSONErrorWithRequest(w, 502, "Upstream request failed", "upstream_error", requestID)
 		return true, nil, false
 	}
 	req.Header.Set("Content-Type", contentType)
@@ -443,6 +468,8 @@ func dispatchEndpointAttemptWithContinue(
 				"channel_id", selected.Channel.ID,
 				"first_byte_timeout_ms", firstByteTimeoutMs,
 				"is_last_endpoint", isLastEndpoint,
+				"request_id", requestID,
+				"retry", retry,
 			)
 			if !isLastEndpoint && !disableCrossProtocolFallback {
 				return false, nil, true
@@ -452,10 +479,12 @@ func dispatchEndpointAttemptWithContinue(
 			if retry < maxRetries && proxy.ShouldRetryProxyRequest(408, err.Error()) {
 				return false, jsonPendingUpstreamFailure(http.StatusRequestTimeout, "Upstream first-byte timeout", "upstream_error"), false
 			}
-			writeJSONError(w, http.StatusRequestTimeout, "Upstream first-byte timeout", "upstream_error")
+			writeJSONErrorWithRequest(w, http.StatusRequestTimeout, "Upstream first-byte timeout", "upstream_error", requestID)
 			return true, nil, false
 		}
-		slog.Warn("upstream request failed", "err", err, "url", upstreamURL, "model", upstreamModel, "channel_id", selected.Channel.ID)
+		slog.Warn("upstream request failed",
+			"err", err, "url", upstreamURL, "model", upstreamModel,
+			"channel_id", selected.Channel.ID, "request_id", requestID, "retry", retry)
 		if !isLastEndpoint && !disableCrossProtocolFallback {
 			// Network error may still be protocol-local; allow next endpoint without poison.
 			return false, nil, true
@@ -464,7 +493,7 @@ func dispatchEndpointAttemptWithContinue(
 		if retry < maxRetries {
 			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error"), false
 		}
-		writeJSONError(w, 502, "Upstream request failed", "upstream_error")
+		writeJSONErrorWithRequest(w, 502, "Upstream request failed", "upstream_error", requestID)
 		return true, nil, false
 	}
 
@@ -474,7 +503,9 @@ func dispatchEndpointAttemptWithContinue(
 			respBody, readErr := proxy.ReadBufferedResponseBody(resp.Body)
 			resp.Body.Close()
 			if readErr != nil {
-				slog.Warn("failed to read upstream stream error response", "err", readErr, "latency_ms", latencyMs, "status", resp.StatusCode)
+				slog.Warn("failed to read upstream stream error response",
+					"err", readErr, "latency_ms", latencyMs, "status", resp.StatusCode,
+					"request_id", requestID, "retry", retry)
 				if !isLastEndpoint && !disableCrossProtocolFallback {
 					return false, nil, true
 				}
@@ -482,7 +513,7 @@ func dispatchEndpointAttemptWithContinue(
 				if retry < maxRetries {
 					return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error"), false
 				}
-				writeJSONError(w, 502, "Failed to read upstream response", "upstream_error")
+				writeJSONErrorWithRequest(w, 502, "Failed to read upstream response", "upstream_error", requestID)
 				return true, nil, false
 			}
 			rawErrText := string(respBody)
@@ -502,62 +533,66 @@ func dispatchEndpointAttemptWithContinue(
 			defer resp.Body.Close()
 			streamUsage = handleStreamUpstream(w, r, resp, latencyMs)
 		}()
-			recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, streamUsage)
-			writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, true, streamUsage, retry)
-			return true, nil, false
-		}
+		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, streamUsage)
+		writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, true, streamUsage, retry, requestID)
+		return true, nil, false
+	}
 
-		respBody, readErr := proxy.ReadBufferedResponseBody(resp.Body)
-		resp.Body.Close()
-		if readErr != nil {
-			slog.Warn("failed to read upstream response", "err", readErr, "latency_ms", latencyMs, "channel_id", selected.Channel.ID)
-			if !isLastEndpoint && !disableCrossProtocolFallback {
-				return false, nil, true
-			}
-			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, readErr.Error())
-			if retry < maxRetries {
-				return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error"), false
-			}
-			writeJSONError(w, 502, "Failed to read upstream response", "upstream_error")
-			return true, nil, false
+	respBody, readErr := proxy.ReadBufferedResponseBody(resp.Body)
+	resp.Body.Close()
+	if readErr != nil {
+		slog.Warn("failed to read upstream response",
+			"err", readErr, "latency_ms", latencyMs, "channel_id", selected.Channel.ID,
+			"request_id", requestID, "retry", retry)
+		if !isLastEndpoint && !disableCrossProtocolFallback {
+			return false, nil, true
 		}
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			rawErrText := string(respBody)
-			if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback) {
-				return false, nil, true
-			}
-			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
-			if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
-				return false, bufferedPendingUpstreamFailure(resp, respBody), false
-			}
-			relayBufferedUpstreamResponse(w, resp, respBody)
-			return true, nil, false
+		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, readErr.Error())
+		if retry < maxRetries {
+			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error"), false
 		}
-		usage := ParseUsageFromBody(respBody)
-		failure := proxy.DetectProxyFailure(string(respBody), usage.ToUsageSummary())
-		if failure != nil {
-			slog.Warn("content-based failure detected",
-				"reason", failure.Reason,
-				"status", failure.Status,
-				"model", upstreamModel,
-				"channel_id", selected.Channel.ID,
-				"latency_ms", latencyMs,
-			)
-			if shouldContinueEndpointFallback(failure.Status, failure.Reason, isLastEndpoint, disableCrossProtocolFallback) {
-				return false, nil, true
-			}
-			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, failure.Status, failure.Reason)
-			if retry < maxRetries && proxy.ShouldRetryProxyRequest(failure.Status, failure.Reason) {
-				return false, jsonPendingUpstreamFailure(failure.Status, "Upstream returned an error response", "upstream_error"), false
-			}
-			writeJSONError(w, failure.Status, "Upstream returned an error response", "upstream_error")
-			return true, nil, false
+		writeJSONErrorWithRequest(w, 502, "Failed to read upstream response", "upstream_error", requestID)
+		return true, nil, false
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		rawErrText := string(respBody)
+		if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback) {
+			return false, nil, true
 		}
-		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, usage)
-		writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, false, usage, retry)
+		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
+		if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
+			return false, bufferedPendingUpstreamFailure(resp, respBody), false
+		}
 		relayBufferedUpstreamResponse(w, resp, respBody)
 		return true, nil, false
 	}
+	usage := ParseUsageFromBody(respBody)
+	failure := proxy.DetectProxyFailure(string(respBody), usage.ToUsageSummary())
+	if failure != nil {
+		slog.Warn("content-based failure detected",
+			"reason", failure.Reason,
+			"status", failure.Status,
+			"model", upstreamModel,
+			"channel_id", selected.Channel.ID,
+			"latency_ms", latencyMs,
+			"request_id", requestID,
+			"retry", retry,
+		)
+		if shouldContinueEndpointFallback(failure.Status, failure.Reason, isLastEndpoint, disableCrossProtocolFallback) {
+			return false, nil, true
+		}
+		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, failure.Status, failure.Reason)
+		if retry < maxRetries && proxy.ShouldRetryProxyRequest(failure.Status, failure.Reason) {
+			return false, jsonPendingUpstreamFailure(failure.Status, "Upstream returned an error response", "upstream_error"), false
+		}
+		writeJSONErrorWithRequest(w, failure.Status, "Upstream returned an error response", "upstream_error", requestID)
+		return true, nil, false
+	}
+	recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, usage)
+	writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, false, usage, retry, requestID)
+	relayBufferedUpstreamResponse(w, resp, respBody)
+	return true, nil, false
+}
 
 func shouldContinueEndpointFallback(status int, rawErrText string, isLastEndpoint bool, disableCrossProtocolFallback bool) bool {
 	if isLastEndpoint || disableCrossProtocolFallback {
@@ -596,9 +631,9 @@ func jsonPendingUpstreamFailure(status int, message, typ string) *pendingUpstrea
 	}
 }
 
-func (p *pendingUpstreamFailure) write(w http.ResponseWriter) {
+func (p *pendingUpstreamFailure) write(w http.ResponseWriter, requestID string) {
 	if p == nil {
-		writeJSONError(w, http.StatusServiceUnavailable, "No available channels", "server_error")
+		writeJSONErrorWithRequest(w, http.StatusServiceUnavailable, "No available channels", "server_error", requestID)
 		return
 	}
 	if p.resp != nil {
@@ -617,7 +652,7 @@ func (p *pendingUpstreamFailure) write(w http.ResponseWriter) {
 	if typ == "" {
 		typ = "upstream_error"
 	}
-	writeJSONError(w, status, message, typ)
+	writeJSONErrorWithRequest(w, status, message, typ, requestID)
 }
 
 func applyProxyCustomHeaders(req *http.Request, proxyConfig *platform.ProxyConfig) {
@@ -736,9 +771,13 @@ func writeSuccessProxyLog(
 	isStream bool,
 	usage ParsedUsage,
 	retryCount int,
+	requestID string,
 ) {
 	if cfg == nil || selected == nil {
 		return
+	}
+	if requestID == "" {
+		requestID = proxy.RequestIDFromContext(ctx)
 	}
 	requestedModel := ""
 	var keyID *int64
@@ -792,6 +831,7 @@ func writeSuccessProxyLog(
 		ClientAppName:      clientAppName,
 		ClientConfidence:   clientConfidence,
 		RetryCount:         retryCount,
+		RequestID:          requestID,
 		UpstreamPath:       &upstreamPath,
 		UsageSource:        source,
 	}

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/tokendancelab/metapi-go/auth"
@@ -742,6 +743,151 @@ func TestDetectProxyFailureReceivesParsedUsageFromBody(t *testing.T) {
 	sum := usage.ToUsageSummary()
 	if sum.CompletionTokens != 2 {
 		t.Fatalf("summary completion = %d", sum.CompletionTokens)
+	}
+}
+
+func TestDispatchUpstream_MultiRetrySharesRequestIDInProxyLogsAndError(t *testing.T) {
+	// Channel A always 429 (retryable); channel B also 429 → terminal after retries.
+	// Same parent request_id must appear on success-path logs if B later succeeds,
+	// and on the final client error body / header when all attempts fail.
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited","type":"rate_limit_error"}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	selectedA := routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 11, RouteID: 1, Enabled: true},
+		Account:     store.Account{ID: 1, Status: "active"},
+		Site:        store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+		TokenValue:  "tok-a",
+		ActualModel: "gpt-4o-upstream",
+	}
+	selectedB := routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 22, RouteID: 1, Enabled: true},
+		Account:     store.Account{ID: 2, Status: "active"},
+		Site:        store.Site{ID: 2, URL: upstream.URL, Status: "active"},
+		TokenValue:  "tok-b",
+		ActualModel: "gpt-4o-upstream",
+	}
+	router := &upstreamTestRouter{selected: selectedA, next: &selectedB}
+
+	var logs []proxy.ProxyLogEntry
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: router,
+		LogProxy: func(_ context.Context, entry proxy.ProxyLogEntry) error {
+			logs = append(logs, entry)
+			return nil
+		},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	const wantID = "trace-multi-retry-42"
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	req = req.WithContext(proxy.WithRequestID(req.Context(), wantID))
+	rec := httptest.NewRecorder()
+	dispatchUpstream(rec, req, &Ctx{
+		RequestedModel: "gpt-4o",
+		DownstreamPath: "/v1/chat/completions",
+		RawBody:        []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`),
+		MaxRetries:     1,
+	})
+
+	if hits.Load() < 2 {
+		t.Fatalf("expected multi-channel attempts, hits=%d", hits.Load())
+	}
+	if rec.Code != http.StatusTooManyRequests && rec.Code != http.StatusServiceUnavailable && rec.Code != http.StatusBadGateway {
+		// Terminal may be relayed upstream 429 or synthetic exhausted JSON depending on retry policy.
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	// When we emit MetAPI JSON errors, request_id is present; when we relay upstream
+	// body, X-Request-Id may still be set if write path used writeJSONErrorWithRequest.
+	body := rec.Body.String()
+	if strings.Contains(body, `"request_id"`) && !strings.Contains(body, wantID) {
+		t.Fatalf("body has request_id field but missing %s: %s", wantID, body)
+	}
+	if hdr := rec.Header().Get("X-Request-Id"); hdr != "" && hdr != wantID {
+		t.Fatalf("X-Request-Id = %q, want %s", hdr, wantID)
+	}
+	// proxy_logs currently only write on success in the hot path; ensure the
+	// parent id is still recoverable from the request context after multi-attempt.
+	if got := proxy.RequestIDFromContext(req.Context()); got != wantID {
+		t.Fatalf("request context lost id: %q", got)
+	}
+	_ = logs
+}
+
+func TestDispatchUpstream_RetryThenSuccessKeepsSameRequestIDInProxyLog(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"message":"rate limited","type":"rate_limit_error"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"ok","choices":[{"message":{"content":"hi"}}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	selectedA := routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 11, RouteID: 1, Enabled: true},
+		Account:     store.Account{ID: 1, Status: "active"},
+		Site:        store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+		TokenValue:  "tok-a",
+		ActualModel: "gpt-4o-upstream",
+	}
+	selectedB := routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 22, RouteID: 1, Enabled: true},
+		Account:     store.Account{ID: 2, Status: "active"},
+		Site:        store.Site{ID: 2, URL: upstream.URL, Status: "active"},
+		TokenValue:  "tok-b",
+		ActualModel: "gpt-4o-upstream",
+	}
+	router := &upstreamTestRouter{selected: selectedA, next: &selectedB}
+
+	var logs []proxy.ProxyLogEntry
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: router,
+		LogProxy: func(_ context.Context, entry proxy.ProxyLogEntry) error {
+			logs = append(logs, entry)
+			return nil
+		},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	const wantID = "trace-success-after-retry"
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	req = req.WithContext(proxy.WithRequestID(req.Context(), wantID))
+	rec := httptest.NewRecorder()
+	dispatchUpstream(rec, req, &Ctx{
+		RequestedModel: "gpt-4o",
+		DownstreamPath: "/v1/chat/completions",
+		RawBody:        []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`),
+		MaxRetries:     1,
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s hits=%d", rec.Code, rec.Body.String(), hits.Load())
+	}
+	if hits.Load() < 2 {
+		t.Fatalf("expected retry across channels, hits=%d", hits.Load())
+	}
+	if len(logs) != 1 {
+		t.Fatalf("proxy logs = %d, want 1 success row: %#v", len(logs), logs)
+	}
+	if logs[0].RequestID != wantID {
+		t.Fatalf("proxy log request_id = %q, want %s", logs[0].RequestID, wantID)
+	}
+	if logs[0].RetryCount != 1 {
+		t.Fatalf("retry_count = %d, want 1 (second channel attempt)", logs[0].RetryCount)
+	}
+	if logs[0].ChannelID == nil || *logs[0].ChannelID != 22 {
+		t.Fatalf("channel_id = %#v, want 22", logs[0].ChannelID)
 	}
 }
 

--- a/handler/shared/errors.go
+++ b/handler/shared/errors.go
@@ -3,9 +3,12 @@
 package shared
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
+
+	"github.com/go-chi/chi/v5/middleware"
 )
 
 // APIError represents a structured JSON error response.
@@ -13,11 +16,13 @@ import (
 // JSON field names are camelCase-compatible public keys used by the admin UI:
 //   - error  (string message)
 //   - detail (optional classifier / subtype)
+//   - request_id (optional ingress correlation id, snake_case for log/ops tools)
 type APIError struct {
-	Code     int    `json:"-"`
-	Message  string `json:"error"`
-	Detail   string `json:"detail,omitempty"`
-	Internal error  `json:"-"`
+	Code      int    `json:"-"`
+	Message   string `json:"error"`
+	Detail    string `json:"detail,omitempty"`
+	RequestID string `json:"request_id,omitempty"`
+	Internal  error  `json:"-"`
 }
 
 // Error implements the error interface.
@@ -29,6 +34,22 @@ func (e *APIError) Error() string {
 		return e.Message + ": " + e.Internal.Error()
 	}
 	return e.Message
+}
+
+// RequestIDFromContext returns the chi RequestID middleware value when present.
+func RequestIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	return middleware.GetReqID(ctx)
+}
+
+// RequestIDFromRequest returns the ingress request/trace id for r.
+func RequestIDFromRequest(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	return RequestIDFromContext(r.Context())
 }
 
 // WriteError writes a structured JSON error response to the client.
@@ -44,8 +65,20 @@ func WriteErrorDetail(w http.ResponseWriter, code int, message, detail string) {
 	WriteAPIError(w, &APIError{Code: code, Message: message, Detail: detail})
 }
 
+// WriteErrorWithRequestID is WriteError plus an optional request/trace id field.
+func WriteErrorWithRequestID(w http.ResponseWriter, code int, message, requestID string) {
+	WriteAPIError(w, &APIError{Code: code, Message: message, RequestID: requestID})
+}
+
+// WriteErrorDetailWithRequestID is WriteErrorDetail plus an optional request/trace id.
+func WriteErrorDetailWithRequestID(w http.ResponseWriter, code int, message, detail, requestID string) {
+	WriteAPIError(w, &APIError{Code: code, Message: message, Detail: detail, RequestID: requestID})
+}
+
 // WriteAPIError writes the public fields of APIError with the given status.
 // Status defaults to Code when Code > 0; otherwise 500.
+// When RequestID is set, also mirrors it on the X-Request-Id response header
+// if that header is still empty (ingress middleware usually sets it first).
 func WriteAPIError(w http.ResponseWriter, err *APIError) {
 	if err == nil {
 		err = &APIError{Code: http.StatusInternalServerError, Message: "internal error"}
@@ -59,12 +92,16 @@ func WriteAPIError(w http.ResponseWriter, err *APIError) {
 			code = http.StatusBadRequest
 		}
 	}
+	if err.RequestID != "" && w.Header().Get("X-Request-Id") == "" {
+		w.Header().Set("X-Request-Id", err.RequestID)
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	if encErr := json.NewEncoder(w).Encode(APIError{
-		Message: err.Message,
-		Detail:  err.Detail,
+		Message:   err.Message,
+		Detail:    err.Detail,
+		RequestID: err.RequestID,
 	}); encErr != nil {
-		slog.Warn("shared: failed to write error response", "error", encErr)
+		slog.Warn("shared: failed to write error response", "error", encErr, "request_id", err.RequestID)
 	}
 }

--- a/handler/shared/errors_test.go
+++ b/handler/shared/errors_test.go
@@ -64,3 +64,45 @@ func TestWriteAPIError_RejectsSilent200(t *testing.T) {
 		t.Fatalf("status = %d, want 400 fallback", rec.Code)
 	}
 }
+
+func TestWriteErrorWithRequestID_IncludesRequestID(t *testing.T) {
+	rec := httptest.NewRecorder()
+	WriteErrorWithRequestID(rec, http.StatusServiceUnavailable, "upstream exhausted", "req-abc-123")
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	if got := rec.Header().Get("X-Request-Id"); got != "req-abc-123" {
+		t.Fatalf("X-Request-Id = %q, want req-abc-123", got)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, rec.Body.String())
+	}
+	if body["error"] != "upstream exhausted" {
+		t.Fatalf("error = %v", body["error"])
+	}
+	if body["request_id"] != "req-abc-123" {
+		t.Fatalf("request_id = %v", body["request_id"])
+	}
+}
+
+func TestWriteAPIError_DoesNotOverrideExistingRequestHeader(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("X-Request-Id", "ingress-id")
+	WriteAPIError(rec, &APIError{
+		Code:      http.StatusBadGateway,
+		Message:   "boom",
+		RequestID: "body-id",
+	})
+	if got := rec.Header().Get("X-Request-Id"); got != "ingress-id" {
+		t.Fatalf("header overwritten: %q", got)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["request_id"] != "body-id" {
+		t.Fatalf("request_id = %v, want body-id", body["request_id"])
+	}
+}

--- a/proxy/request_id.go
+++ b/proxy/request_id.go
@@ -1,0 +1,50 @@
+package proxy
+
+import (
+	"context"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// requestIDCtxKey is a private context key for MetAPI request/trace IDs.
+// Values mirror chi middleware.RequestID so retries and proxy_logs share one id.
+type requestIDCtxKey struct{}
+
+// WithRequestID stores requestID on ctx. Empty ids are ignored.
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	if ctx == nil || requestID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, requestIDCtxKey{}, requestID)
+}
+
+// RequestIDFromContext returns the MetAPI request/trace id when present.
+// Falls back to chi's middleware.GetReqID so ingress middleware and
+// attempt loops share the same correlation value without extra wiring.
+func RequestIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if id, ok := ctx.Value(requestIDCtxKey{}).(string); ok {
+		if id != "" {
+			return id
+		}
+	}
+	return middleware.GetReqID(ctx)
+}
+
+// EnsureRequestID returns ctx carrying a non-empty request id when possible.
+// Prefer the existing chi/MetAPI id; only copies an explicit fallback when
+// neither context source already has a value.
+func EnsureRequestID(ctx context.Context, fallback string) (context.Context, string) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if id := RequestIDFromContext(ctx); id != "" {
+		return ctx, id
+	}
+	if fallback == "" {
+		return ctx, ""
+	}
+	return WithRequestID(ctx, fallback), fallback
+}

--- a/proxy/request_id_test.go
+++ b/proxy/request_id_test.go
@@ -1,0 +1,45 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+func TestRequestIDFromContext_MetAPIKey(t *testing.T) {
+	ctx := WithRequestID(context.Background(), "req-metapi-1")
+	if got := RequestIDFromContext(ctx); got != "req-metapi-1" {
+		t.Fatalf("RequestIDFromContext = %q, want req-metapi-1", got)
+	}
+}
+
+func TestRequestIDFromContext_ChiFallback(t *testing.T) {
+	ctx := context.WithValue(context.Background(), middleware.RequestIDKey, "req-chi-1")
+	if got := RequestIDFromContext(ctx); got != "req-chi-1" {
+		t.Fatalf("RequestIDFromContext chi fallback = %q, want req-chi-1", got)
+	}
+}
+
+func TestEnsureRequestID_PreservesExistingAcrossAttempts(t *testing.T) {
+	base := WithRequestID(context.Background(), "parent-trace")
+	// Simulate channel attempt #0 and #1: same parent id, no overwrite.
+	ctx0, id0 := EnsureRequestID(base, "should-not-win")
+	ctx1, id1 := EnsureRequestID(ctx0, "also-ignored")
+	if id0 != "parent-trace" || id1 != "parent-trace" {
+		t.Fatalf("ids = %q / %q, want parent-trace for both attempts", id0, id1)
+	}
+	if RequestIDFromContext(ctx1) != "parent-trace" {
+		t.Fatalf("ctx lost request id: %q", RequestIDFromContext(ctx1))
+	}
+}
+
+func TestEnsureRequestID_UsesFallbackWhenMissing(t *testing.T) {
+	ctx, id := EnsureRequestID(context.Background(), "fallback-1")
+	if id != "fallback-1" {
+		t.Fatalf("id = %q, want fallback-1", id)
+	}
+	if RequestIDFromContext(ctx) != "fallback-1" {
+		t.Fatalf("ctx id = %q", RequestIDFromContext(ctx))
+	}
+}

--- a/proxy/surface.go
+++ b/proxy/surface.go
@@ -130,8 +130,11 @@ type ProxyLogEntry struct {
 	ClientConfidence    string
 	ErrorMessage        *string
 	RetryCount          int
-	UpstreamPath        *string
-	UsageSource         string
+	// RequestID correlates multi-channel retry/failover attempts for one client call.
+	// Same value as chi X-Request-Id / middleware.GetReqID for the ingress request.
+	RequestID    string
+	UpstreamPath *string
+	UsageSource  string
 }
 
 // SurfaceUsageSummary is a usage summary for surface operations.

--- a/store/additive.go
+++ b/store/additive.go
@@ -54,6 +54,18 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 			return EnsureColumn(db, "token_routes", "context_length", "INTEGER", "INTEGER", "")
 		},
 	},
+	{
+		// Learn #110: end-to-end request/trace ids across channel retries.
+		Version:     "sc2_004_proxy_logs_request_id",
+		Description: "proxy_logs.request_id TEXT NULL — ingress X-Request-Id shared across retry/failover attempts",
+		Apply: func(db *DB) error {
+			if err := EnsureColumn(db, "proxy_logs", "request_id", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			return EnsureIndex(db, "proxy_logs_request_id_created_at_idx",
+				`CREATE INDEX IF NOT EXISTS proxy_logs_request_id_created_at_idx ON proxy_logs (request_id, created_at)`)
+		},
+	},
 }
 
 // schemaMigrationsDDL creates the version bookkeeping table.

--- a/store/migrate.go
+++ b/store/migrate.go
@@ -602,6 +602,7 @@ func buildProxyLogsDDL(d string) string {
 			client_confidence TEXT,
 			error_message TEXT,
 			retry_count INTEGER DEFAULT 0,
+			request_id TEXT,
 			created_at TEXT
 		)`
 	}
@@ -629,6 +630,7 @@ func buildProxyLogsDDL(d string) string {
 		client_confidence TEXT,
 		error_message TEXT,
 		retry_count INTEGER DEFAULT 0,
+		request_id TEXT,
 		created_at TEXT
 	)`
 }
@@ -1213,6 +1215,7 @@ func buildIndexes() []struct {
 		{"proxy_logs_downstream_api_key_created_at_idx", `CREATE INDEX IF NOT EXISTS proxy_logs_downstream_api_key_created_at_idx ON proxy_logs (downstream_api_key_id, created_at)`},
 		{"proxy_logs_client_app_id_created_at_idx", `CREATE INDEX IF NOT EXISTS proxy_logs_client_app_id_created_at_idx ON proxy_logs (client_app_id, created_at)`},
 		{"proxy_logs_client_family_created_at_idx", `CREATE INDEX IF NOT EXISTS proxy_logs_client_family_created_at_idx ON proxy_logs (client_family, created_at)`},
+		{"proxy_logs_request_id_created_at_idx", `CREATE INDEX IF NOT EXISTS proxy_logs_request_id_created_at_idx ON proxy_logs (request_id, created_at)`},
 		// proxy_debug_traces
 		{"proxy_debug_traces_created_at_idx", `CREATE INDEX IF NOT EXISTS proxy_debug_traces_created_at_idx ON proxy_debug_traces (created_at)`},
 		{"proxy_debug_traces_session_created_at_idx", `CREATE INDEX IF NOT EXISTS proxy_debug_traces_session_created_at_idx ON proxy_debug_traces (session_id, created_at)`},

--- a/store/schema.go
+++ b/store/schema.go
@@ -229,6 +229,8 @@ type ProxyLog struct {
 	ClientConfidence     *string  `db:"client_confidence" json:"clientConfidence"`
 	ErrorMessage         *string  `db:"error_message" json:"errorMessage"`
 	RetryCount           int64    `db:"retry_count" json:"retryCount"`
+	// RequestID is the ingress X-Request-Id / chi RequestID shared across retries.
+	RequestID            *string  `db:"request_id" json:"requestId"`
 	CreatedAt            string   `db:"created_at" json:"createdAt"`
 }
 

--- a/store/schema_test.go
+++ b/store/schema_test.go
@@ -22,7 +22,7 @@ var tableColumnCount = map[string]int{
 	"OAuthRouteUnit":                 8,
 	"OAuthRouteUnitMember":           16,
 	"RouteChannel":                   20,
-	"ProxyLog":                       24,
+	"ProxyLog":                       25,
 	"ProxyDebugTrace":                26,
 	"ProxyDebugAttempt":              18,
 	"ProxyVideoTask":                 15,


### PR DESCRIPTION
## Summary
- Thread chi/MetAPI request ids through proxy retry/failover so multi-attempt logs share one parent id.
- Persist `proxy_logs.request_id` (additive + base DDL) and expose `request_id` on MetAPI JSON error bodies / `X-Request-Id`.
- Document operator correlation in `docs/analysis/request-trace-ids.md`.

## Test plan
- [x] `go test ./proxy ./handler/shared ./handler/proxy ./store -count=1`
- [x] Multi-retry success keeps same `proxy_logs.request_id` with `retry_count=1`
- [x] Shared/proxy error helpers include `request_id`

Closes #110