### PR TITLE
feat(proxy): end-to-end request trace IDs across retries #110

### DIFF
--- a/docs/analysis/request-trace-ids.md
+++ b/docs/analysis/request-trace-ids.md
@@ -1,0 +1,11 @@
+# Request trace IDs across retries (#110)
+
+## Behavior
+- Chi `RequestID` middleware continues to set `X-Request-Id` on responses.
+- Proxy JSON errors echo `error.request_id` when the header is present so clients can correlate without relying solely on headers.
+- Successful `proxy_logs` rows store `request_id` inside `billing_details` (until a dedicated column is added).
+- Success/failure slog lines include `request_id` when available so multi-channel retries share one correlation key.
+
+## Residual
+- No dedicated `proxy_logs.request_id` column yet (schema additive change deferred).
+- Full OTEL/Langfuse export remains a separate learn item (#117).

--- a/handler/proxy/request_id_test.go
+++ b/handler/proxy/request_id_test.go
@@ -1,0 +1,50 @@
+package proxyhandler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+func TestWriteJSONErrorIncludesRequestIDWhenHeaderSet(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("X-Request-Id", "req-test-123")
+	writeJSONError(rec, 502, "Upstream request failed", "upstream_error")
+	if rec.Code != 502 {
+		t.Fatalf("status=%d", rec.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	errObj, _ := body["error"].(map[string]any)
+	if errObj["request_id"] != "req-test-123" {
+		t.Fatalf("body=%s", rec.Body.String())
+	}
+}
+
+func TestWriteJSONErrorOmitsRequestIDWhenMissing(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeJSONError(rec, 400, "bad", "invalid_request_error")
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	errObj, _ := body["error"].(map[string]any)
+	if _, ok := errObj["request_id"]; ok {
+		t.Fatalf("unexpected request_id in %s", rec.Body.String())
+	}
+}
+
+func TestRequestIDFromCtx(t *testing.T) {
+	ctx := context.WithValue(context.Background(), middleware.RequestIDKey, "abc-xyz")
+	if got := requestIDFromCtx(ctx); got != "abc-xyz" {
+		t.Fatalf("got %q", got)
+	}
+	if got := requestIDFromCtx(context.Background()); got != "" {
+		t.Fatalf("empty ctx got %q", got)
+	}
+}

--- a/handler/proxy/router.go
+++ b/handler/proxy/router.go
@@ -4,6 +4,7 @@ package proxyhandler
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/tokendancelab/metapi-go/auth"
@@ -81,11 +82,19 @@ func RegisterNonV1ProxyRoutes(r chi.Router) {
 func EnsureMultipartBufferParser() {}
 
 // writeJSONError writes a JSON error response.
+// When X-Request-Id is already on the response (RequestID middleware), it is
+// also echoed inside the error payload for client-side correlation across retries.
 func writeJSONError(w http.ResponseWriter, status int, message, typ string) {
 	w.Header().Set("Content-Type", "application/json")
+	reqID := strings.TrimSpace(w.Header().Get("X-Request-Id"))
 	w.WriteHeader(status)
+	if reqID != "" {
+		body := `{"error":{"message":"` + jsonEscape(message) + `","type":"` + jsonEscape(typ) + `","request_id":"` + jsonEscape(reqID) + `"}}`
+		_, _ = w.Write([]byte(body))
+		return
+	}
 	body := `{"error":{"message":"` + jsonEscape(message) + `","type":"` + jsonEscape(typ) + `"}}`
-	w.Write([]byte(body))
+	_, _ = w.Write([]byte(body))
 }
 
 // jsonEscape performs full JSON string escaping per RFC 8259 Section 7.

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/tokendancelab/metapi-go/auth"
 	"github.com/tokendancelab/metapi-go/config"
 	"github.com/tokendancelab/metapi-go/handler/shared"
@@ -23,6 +24,14 @@ import (
 	"github.com/tokendancelab/metapi-go/service"
 	"github.com/tokendancelab/metapi-go/transform/openai/responses"
 )
+
+// requestIDFromCtx returns the chi RequestID middleware value when present.
+func requestIDFromCtx(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	return strings.TrimSpace(middleware.GetReqID(ctx))
+}
 
 // UpstreamConfig holds the dependencies needed for upstream forwarding.
 type UpstreamConfig struct {
@@ -708,7 +717,14 @@ func recordUpstreamFailure(ctx context.Context, cfg *UpstreamConfig, selected *r
 		failureCtx.Status = &status
 	}
 	if err := cfg.Router.RecordFailure(ctx, selected.Channel.ID, failureCtx, nil); err != nil {
-		slog.Warn("RecordFailure failed", "err", err, "channel_id", selected.Channel.ID, "model", modelName)
+		slog.Warn("RecordFailure failed", "err", err, "channel_id", selected.Channel.ID, "model", modelName, "request_id", requestIDFromCtx(ctx))
+	} else if rid := requestIDFromCtx(ctx); rid != "" {
+		slog.Info("proxy request failure recorded",
+			"request_id", rid,
+			"channel_id", selected.Channel.ID,
+			"model", modelName,
+			"status", status,
+		)
 	}
 }
 
@@ -772,6 +788,7 @@ func writeSuccessProxyLog(
 			source = usageSourceUnknown
 		}
 	}
+	reqID := requestIDFromCtx(ctx)
 	entry := proxy.ProxyLogEntry{
 		RouteID:            routeIDPtr,
 		ChannelID:          &channelID,
@@ -794,8 +811,26 @@ func writeSuccessProxyLog(
 		RetryCount:         retryCount,
 		UpstreamPath:       &upstreamPath,
 		UsageSource:        source,
+		RequestID:          reqID,
+	}
+	// Persist request_id inside billing_details until a dedicated column exists.
+	if reqID != "" {
+		entry.BillingDetails = map[string]any{
+			"request_id":   reqID,
+			"usage_source": source,
+			"retry_count":  retryCount,
+		}
 	}
 	logProxy(ctx, cfg, entry)
+	if reqID != "" {
+		slog.Info("proxy request success",
+			"request_id", reqID,
+			"channel_id", channelID,
+			"model", requestedModel,
+			"retry", retryCount,
+			"latency_ms", latencyMs,
+		)
+	}
 }
 
 func isProxyStubEnabled() bool {

--- a/proxy/surface.go
+++ b/proxy/surface.go
@@ -132,6 +132,8 @@ type ProxyLogEntry struct {
 	RetryCount          int
 	UpstreamPath        *string
 	UsageSource         string
+	// RequestID correlates multi-attempt logs for one downstream request (#110).
+	RequestID string
 }
 
 // SurfaceUsageSummary is a usage summary for surface operations.


### PR DESCRIPTION
## Summary
- Echo `error.request_id` in proxy JSON errors when `X-Request-Id` is set
- Persist request_id in proxy_logs billing_details; slog success/failure correlation
- Docs: `docs/analysis/request-trace-ids.md`

## Test plan
- [x] `go test ./handler/proxy/ ./proxy/`

Closes #110