### PR TITLE
feat(proxy): per-request cost attribution and token breakdown #111

### DIFF
--- a/docs/analysis/request-cost-attribution.md
+++ b/docs/analysis/request-cost-attribution.md
@@ -1,0 +1,3 @@
+# Per-request cost attribution (#111)
+
+EstimateBillingCostFromUsage fills proxy_logs estimated_cost + billing_details.

--- a/handler/proxy/billing_cost.go
+++ b/handler/proxy/billing_cost.go
@@ -1,0 +1,79 @@
+package proxyhandler
+
+import (
+	"strings"
+
+	"github.com/tokendancelab/metapi-go/routing"
+)
+
+// BillingCostResult is the cost estimate attached to a successful proxy log.
+type BillingCostResult struct {
+	EstimatedCost  float64
+	BillingDetails map[string]any
+}
+
+// EstimateBillingCostFromUsage builds estimated_cost + billing_details for proxy_logs.
+func EstimateBillingCostFromUsage(modelName, platform string, usage ParsedUsage) BillingCostResult {
+	total := usage.TotalTokens
+	if total <= 0 {
+		total = usage.PromptTokens + usage.CompletionTokens
+	}
+	cost := routing.FallbackTokenCost(total, platform)
+	details := map[string]any{
+		"quota_type": 0,
+		"usage": map[string]any{
+			"prompt_tokens":         usage.PromptTokens,
+			"completion_tokens":     usage.CompletionTokens,
+			"total_tokens":          total,
+			"cache_read_tokens":     usage.CacheReadTokens,
+			"cache_creation_tokens": usage.CacheCreationTokens,
+		},
+		"pricing": map[string]any{
+			"source":   "fallback_token_cost",
+			"platform": strings.TrimSpace(platform),
+			"model":    strings.TrimSpace(modelName),
+		},
+		"breakdown": map[string]any{
+			"total_cost": cost,
+		},
+		"usage_source": usage.Source,
+	}
+	if usage.Found {
+		pm := routing.PricingModel{
+			ModelName:       modelName,
+			QuotaType:       0,
+			ModelRatio:      1,
+			CompletionRatio: 1,
+		}
+		u := routing.UsageForCost{
+			PromptTokens:        usage.PromptTokens,
+			CompletionTokens:    usage.CompletionTokens,
+			TotalTokens:         total,
+			CacheReadTokens:     usage.CacheReadTokens,
+			CacheCreationTokens: usage.CacheCreationTokens,
+		}
+		if detail := routing.CalculateModelUsageBreakdown(pm, u, map[string]float64{"default": 1}); detail != nil {
+			details["breakdown"] = map[string]any{
+				"input_cost":          detail.Breakdown.InputCost,
+				"output_cost":         detail.Breakdown.OutputCost,
+				"cache_read_cost":     detail.Breakdown.CacheReadCost,
+				"cache_creation_cost": detail.Breakdown.CacheCreationCost,
+				"total_cost":          detail.Breakdown.TotalCost,
+				"fallback_total_cost": cost,
+			}
+			details["pricing"] = map[string]any{
+				"source":               "model_ratio_defaults",
+				"model_ratio":          detail.Pricing.ModelRatio,
+				"completion_ratio":     detail.Pricing.CompletionRatio,
+				"cache_ratio":          detail.Pricing.CacheRatio,
+				"cache_creation_ratio": detail.Pricing.CacheCreationRatio,
+				"platform":             strings.TrimSpace(platform),
+				"model":                strings.TrimSpace(modelName),
+			}
+			if detail.Breakdown.TotalCost > 0 {
+				cost = detail.Breakdown.TotalCost
+			}
+		}
+	}
+	return BillingCostResult{EstimatedCost: cost, BillingDetails: details}
+}

--- a/handler/proxy/billing_cost_test.go
+++ b/handler/proxy/billing_cost_test.go
@@ -1,0 +1,28 @@
+package proxyhandler
+
+import "testing"
+
+func TestEstimateBillingCostFromUsage_FallbackPositive(t *testing.T) {
+	got := EstimateBillingCostFromUsage("gpt-4o", "openai", ParsedUsage{
+		PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500, Found: true, Source: "upstream",
+	})
+	if got.EstimatedCost <= 0 {
+		t.Fatalf("expected positive cost, got %v", got.EstimatedCost)
+	}
+	if got.BillingDetails == nil {
+		t.Fatal("nil details")
+	}
+}
+
+func TestEstimateBillingCostFromUsage_ClaudeCacheFields(t *testing.T) {
+	got := EstimateBillingCostFromUsage("claude-sonnet-4", "anthropic", ParsedUsage{
+		PromptTokens: 100, CompletionTokens: 50, CacheReadTokens: 20, CacheCreationTokens: 10,
+		Found: true, Source: "upstream",
+	})
+	if got.BillingDetails == nil {
+		t.Fatal("nil details")
+	}
+	if _, ok := got.BillingDetails["breakdown"].(map[string]any); !ok {
+		t.Fatalf("breakdown missing: %#v", got.BillingDetails)
+	}
+}

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -751,9 +751,12 @@ func recordUpstreamSuccess(ctx context.Context, cfg *UpstreamConfig, selected *r
 	if cfg == nil || cfg.Router == nil || selected == nil {
 		return
 	}
-	// Cost remains 0 here; pricing is a separate concern (#43). Token totals
-	// are persisted via writeSuccessProxyLog for aggregation.
-	if err := cfg.Router.RecordSuccess(ctx, selected.Channel.ID, float64(latencyMs), 0, &modelName, nil); err != nil {
+	platformName := ""
+	if selected.Site.Platform != "" {
+		platformName = selected.Site.Platform
+	}
+	billing := EstimateBillingCostFromUsage(modelName, platformName, usage)
+	if err := cfg.Router.RecordSuccess(ctx, selected.Channel.ID, float64(latencyMs), billing.EstimatedCost, &modelName, nil); err != nil {
 		slog.Warn("RecordSuccess failed", "err", err, "channel_id", selected.Channel.ID, "model", modelName)
 	}
 	// Soft-feed first-byte EMA: until header timing is plumbed separately, use
@@ -762,7 +765,6 @@ func recordUpstreamSuccess(ctx context.Context, cfg *UpstreamConfig, selected *r
 	if siteID != 0 {
 		routing.RecordSiteRuntimeSuccess(siteID, float64(latencyMs), &modelName, float64(latencyMs))
 	}
-	_ = usage
 }
 
 func writeSuccessProxyLog(
@@ -817,6 +819,11 @@ func writeSuccessProxyLog(
 			source = usageSourceUnknown
 		}
 	}
+	platformName := ""
+	if selected.Site.Platform != "" {
+		platformName = selected.Site.Platform
+	}
+	billing := EstimateBillingCostFromUsage(upstreamModel, platformName, usage)
 	entry := proxy.ProxyLogEntry{
 		RouteID:            routeIDPtr,
 		ChannelID:          &channelID,
@@ -832,6 +839,8 @@ func writeSuccessProxyLog(
 		PromptTokens:       int64Ptr(usage.PromptTokens),
 		CompletionTokens:   int64Ptr(usage.CompletionTokens),
 		TotalTokens:        int64Ptr(usage.TotalTokens),
+		EstimatedCost:      billing.EstimatedCost,
+		BillingDetails:     billing.BillingDetails,
 		ClientFamily:       clientFamily,
 		ClientAppID:        clientAppID,
 		ClientAppName:      clientAppName,

--- a/handler/proxy/usage.go
+++ b/handler/proxy/usage.go
@@ -14,9 +14,11 @@ const (
 
 // ParsedUsage is a normalized token usage snapshot extracted from an upstream body/SSE.
 type ParsedUsage struct {
-	PromptTokens     int64
-	CompletionTokens int64
-	TotalTokens      int64
+	PromptTokens        int64
+	CompletionTokens    int64
+	TotalTokens         int64
+	CacheReadTokens     int64
+	CacheCreationTokens int64
 	// Source is "upstream" when any token field was present, otherwise "unknown".
 	Source string
 	Found  bool
@@ -166,15 +168,17 @@ func applyUsageMap(out *ParsedUsage, usage map[string]any) {
 		out.CompletionTokens = n
 		out.Found = true
 	}
-	// Optional Anthropic cache fields roll into prompt when present.
-	cacheRead, hasCacheRead := asInt64(usage["cache_read_input_tokens"])
-	cacheCreate, hasCacheCreate := asInt64(usage["cache_creation_input_tokens"])
-	if hasCacheRead || hasCacheCreate {
-		// Prefer explicit input_tokens when set; otherwise sum cache fields.
-		if out.PromptTokens == 0 {
-			out.PromptTokens = cacheRead + cacheCreate
-		}
+	// Optional Anthropic cache fields.
+	if cacheRead, ok := asInt64(usage["cache_read_input_tokens"]); ok {
+		out.CacheReadTokens = cacheRead
 		out.Found = true
+	}
+	if cacheCreate, ok := asInt64(usage["cache_creation_input_tokens"]); ok {
+		out.CacheCreationTokens = cacheCreate
+		out.Found = true
+	}
+	if out.PromptTokens == 0 && (out.CacheReadTokens > 0 || out.CacheCreationTokens > 0) {
+		out.PromptTokens = out.CacheReadTokens + out.CacheCreationTokens
 	}
 
 	// Gemini-style


### PR DESCRIPTION
## Summary
- Fill `proxy_logs.estimated_cost` + `billing_details` from parsed usage
- Anthropic cache token fields + Claude-aware ratio breakdown
- Feed cost into `RecordSuccess`

## Test plan
- [x] `go test ./handler/proxy/ ./routing/`

Closes #111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added estimated billing costs and detailed billing information to successful proxy records.
  * Added support for token-based cost estimates across supported models and platforms.
  * Added Anthropic cache token tracking for more accurate usage and cost reporting.

* **Documentation**
  * Documented per-request cost attribution and estimated billing details.

* **Bug Fixes**
  * Improved handling of cache token usage when calculating prompt totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->