### PR TITLE
feat(routing): TTFT/first-byte soft scoring for channel selection (#113)

### DIFF
--- a/docs/analysis/ttft-channel-selection.md
+++ b/docs/analysis/ttft-channel-selection.md
@@ -1,0 +1,80 @@
+# TTFT / first-byte soft scoring for channel selection (#113)
+
+**Date:** 2026-07-17  
+**Lane:** M-COMPETE learn / L4  
+**SSOT code:** `routing/runtime_health.go`, `routing/weights.go`, `routing/router.go`, `handler/proxy/upstream.go`, `proxy/channel_selection.go`
+
+## Goal
+
+Use observed first-token / first-byte latency (TTFT) as a **soft scoring** signal in channel selection so slow-but-alive channels are deprioritized, without replacing Fibonacci cooldown / breakers.
+
+Peers: AxonHub FTTL/TTFT scoring, LiteLLM latency-based routing.
+
+## Units
+
+| Surface | Unit | Notes |
+| --- | --- | --- |
+| `PROXY_FIRST_BYTE_TIMEOUT_SEC` | seconds | Existing operator config (#38) |
+| Observed first-byte on success | **milliseconds** | Header-arrival delta from request start |
+| Runtime health EMA fields | **milliseconds** | `LatencyEMAMs` (E2E) + `FirstByteLatencyEMAMs` (TTFT) |
+| Soft penalty constants | dimensionless | Multiplier ∈ `[min, 1]` |
+
+## Signal path
+
+```
+upstream headers arrive
+  → firstByteLatencyMsObs (ms)
+  → recordUpstreamSuccess(..., latencyMs, &firstByteLatencyMsObs, ...)
+  → TokenRouter.RecordSuccess(..., firstByteLatencyMs *float64)
+  → RecordSiteRuntimeSuccess(site, e2eLatency, model, firstByte)
+  → SiteRuntimeHealthState.FirstByteLatencyEMAMs (EMA α=0.3)
+  → GetRuntimeHealthMultiplier() multiplies soft TTFT factor
+  → CalculateWeightedSelection contribution *= runtimeMultiplier
+```
+
+Streaming and non-streaming success paths both observe header arrival as TTFT. Probe success may omit TTFT (`nil`) so it does not invent samples.
+
+`proxy_logs.first_byte_latency_ms` stores the observed header latency separately from end-to-end `latency_ms`.
+
+## Soft weight (non-breaking default)
+
+```
+ttftPenaltyRatio = clamp((firstByteEMA - 800) / 10000, 0, 1)
+ttftFactor       = 1 - ttftPenaltyRatio * 0.12
+```
+
+Constants (`routing/runtime_health.go`):
+
+| Constant | Value | Role |
+| --- | --- | --- |
+| `SiteRuntimeFirstByteLatencyBaselineMs` | 800 | Below this → no TTFT penalty |
+| `SiteRuntimeFirstByteLatencyWindowMs` | 10000 | Span to full soft penalty |
+| `SiteRuntimeMaxFirstByteLatencyPenalty` | **0.12** | Max 12% weight reduction |
+| `SiteRuntimeFirstByteLatencyEMAAlpha` | 0.3 | Same EMA α as overall latency |
+
+Overall latency soft penalty remains independent (max 35%). Combined:
+
+```
+multiplier = clamp(failureFactor * e2eLatencyFactor * ttftFactor, 0.08, 1)
+```
+
+## Compatibility / non-goals
+
+- **No double-penalize with cooldown:** TTFT only updates on **success**. Failures still use penalty + breaker paths only.
+- **No breaker from TTFT:** Slow first-byte never opens site/model breakers.
+- **Missing samples neutral:** `nil` / non-positive first-byte EMA → factor `1.0`.
+- **Does not replace** Fibonacci channel cooldown, sticky sessions, load multipliers, or cost weights.
+- **Does not add** a new operator env flag in this slice; weight is a small fixed default. A future learn can expose config if operators need to disable/tune.
+
+## Tests
+
+- `TestResolveFirstByteLatencyFactor_*`
+- `TestGetRuntimeHealthMultiplier_TTFTSoftOnly`
+- `TestRecordSiteRuntimeSuccess_UpdatesFirstByteEMA`
+- `TestRecordSiteRuntimeSuccess_TTFTDoesNotOpenBreaker`
+- `TestCalculateWeightedSelection_PrefersLowerTTFT`
+
+## Residual
+
+- True first-**token** (SSE content) latency is not measured yet; header first-byte is the available production signal from #38.
+- Runtime health (including TTFT EMA) remains process-local; multi-instance shared state is a separate future concern, same as other site runtime health fields.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -123,7 +123,7 @@ func (m *mockRouter) SelectPreferredChannel(ctx context.Context, requestedModel 
 	return ch, nil
 }
 
-func (m *mockRouter) RecordSuccess(ctx context.Context, channelID int64, latencyMs float64, cost float64, modelName *string, actualAccountID *int64) error {
+func (m *mockRouter) RecordSuccess(ctx context.Context, channelID int64, latencyMs float64, cost float64, modelName *string, actualAccountID *int64, firstByteLatencyMs *float64) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.recordedSuccess = append(m.recordedSuccess, recordedSuccess{channelID, latencyMs})

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -76,7 +76,8 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 		unconfiguredUpstreamLogOnce.Do(func() {
 			slog.Error("proxy upstream dependencies are not configured")
 		})
-		shared.RecordProxyError(); writeJSONError(w, http.StatusServiceUnavailable, "Proxy upstream is not configured", "server_error")
+		shared.RecordProxyError()
+		writeJSONError(w, http.StatusServiceUnavailable, "Proxy upstream is not configured", "server_error")
 		return
 	}
 
@@ -432,7 +433,9 @@ func dispatchEndpointAttemptWithContinue(
 	applyProxyCustomHeaders(req, proxyConfig)
 
 	resp, err := sendUpstreamRequest(cfg, req, proxyConfig, firstByteTimeoutMs)
-	latencyMs := time.Since(startedAt).Milliseconds()
+	// Header arrival ≈ observed first-byte / TTFT (issue #38 executor semantics).
+	firstByteLatencyMsObs := time.Since(startedAt).Milliseconds()
+	latencyMs := firstByteLatencyMsObs
 
 	if err != nil {
 		// First-byte timeout: continue to next protocol when allowed; do not poison.
@@ -500,64 +503,66 @@ func dispatchEndpointAttemptWithContinue(
 		var streamUsage ParsedUsage
 		func() {
 			defer resp.Body.Close()
-			streamUsage = handleStreamUpstream(w, r, resp, latencyMs)
+			streamUsage = handleStreamUpstream(w, r, resp, firstByteLatencyMsObs)
 		}()
-			recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, streamUsage)
-			writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, true, streamUsage, retry)
-			return true, nil, false
-		}
+		latencyMs = time.Since(startedAt).Milliseconds()
+		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, &firstByteLatencyMsObs, streamUsage)
+		writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, firstByteLatencyMsObs, latencyMs, resp.StatusCode, true, streamUsage, retry)
+		return true, nil, false
+	}
 
-		respBody, readErr := proxy.ReadBufferedResponseBody(resp.Body)
-		resp.Body.Close()
-		if readErr != nil {
-			slog.Warn("failed to read upstream response", "err", readErr, "latency_ms", latencyMs, "channel_id", selected.Channel.ID)
-			if !isLastEndpoint && !disableCrossProtocolFallback {
-				return false, nil, true
-			}
-			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, readErr.Error())
-			if retry < maxRetries {
-				return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error"), false
-			}
-			writeJSONError(w, 502, "Failed to read upstream response", "upstream_error")
-			return true, nil, false
+	respBody, readErr := proxy.ReadBufferedResponseBody(resp.Body)
+	resp.Body.Close()
+	if readErr != nil {
+		slog.Warn("failed to read upstream response", "err", readErr, "latency_ms", latencyMs, "channel_id", selected.Channel.ID)
+		if !isLastEndpoint && !disableCrossProtocolFallback {
+			return false, nil, true
 		}
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			rawErrText := string(respBody)
-			if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback) {
-				return false, nil, true
-			}
-			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
-			if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
-				return false, bufferedPendingUpstreamFailure(resp, respBody), false
-			}
-			relayBufferedUpstreamResponse(w, resp, respBody)
-			return true, nil, false
+		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, readErr.Error())
+		if retry < maxRetries {
+			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error"), false
 		}
-		usage := ParseUsageFromBody(respBody)
-		failure := proxy.DetectProxyFailure(string(respBody), usage.ToUsageSummary())
-		if failure != nil {
-			slog.Warn("content-based failure detected",
-				"reason", failure.Reason,
-				"status", failure.Status,
-				"model", upstreamModel,
-				"channel_id", selected.Channel.ID,
-				"latency_ms", latencyMs,
-			)
-			if shouldContinueEndpointFallback(failure.Status, failure.Reason, isLastEndpoint, disableCrossProtocolFallback) {
-				return false, nil, true
-			}
-			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, failure.Status, failure.Reason)
-			if retry < maxRetries && proxy.ShouldRetryProxyRequest(failure.Status, failure.Reason) {
-				return false, jsonPendingUpstreamFailure(failure.Status, "Upstream returned an error response", "upstream_error"), false
-			}
-			writeJSONError(w, failure.Status, "Upstream returned an error response", "upstream_error")
-			return true, nil, false
+		writeJSONError(w, 502, "Failed to read upstream response", "upstream_error")
+		return true, nil, false
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		rawErrText := string(respBody)
+		if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback) {
+			return false, nil, true
 		}
-		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, usage)
-		writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, false, usage, retry)
+		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
+		if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
+			return false, bufferedPendingUpstreamFailure(resp, respBody), false
+		}
 		relayBufferedUpstreamResponse(w, resp, respBody)
 		return true, nil, false
 	}
+	usage := ParseUsageFromBody(respBody)
+	failure := proxy.DetectProxyFailure(string(respBody), usage.ToUsageSummary())
+	if failure != nil {
+		slog.Warn("content-based failure detected",
+			"reason", failure.Reason,
+			"status", failure.Status,
+			"model", upstreamModel,
+			"channel_id", selected.Channel.ID,
+			"latency_ms", latencyMs,
+		)
+		if shouldContinueEndpointFallback(failure.Status, failure.Reason, isLastEndpoint, disableCrossProtocolFallback) {
+			return false, nil, true
+		}
+		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, failure.Status, failure.Reason)
+		if retry < maxRetries && proxy.ShouldRetryProxyRequest(failure.Status, failure.Reason) {
+			return false, jsonPendingUpstreamFailure(failure.Status, "Upstream returned an error response", "upstream_error"), false
+		}
+		writeJSONError(w, failure.Status, "Upstream returned an error response", "upstream_error")
+		return true, nil, false
+	}
+	latencyMs = time.Since(startedAt).Milliseconds()
+	recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, &firstByteLatencyMsObs, usage)
+	writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, firstByteLatencyMsObs, latencyMs, resp.StatusCode, false, usage, retry)
+	relayBufferedUpstreamResponse(w, resp, respBody)
+	return true, nil, false
+}
 
 func shouldContinueEndpointFallback(status int, rawErrText string, isLastEndpoint bool, disableCrossProtocolFallback bool) bool {
 	if isLastEndpoint || disableCrossProtocolFallback {
@@ -712,13 +717,19 @@ func recordUpstreamFailure(ctx context.Context, cfg *UpstreamConfig, selected *r
 	}
 }
 
-func recordUpstreamSuccess(ctx context.Context, cfg *UpstreamConfig, selected *routing.SelectedChannel, modelName string, latencyMs int64, usage ParsedUsage) {
+func recordUpstreamSuccess(ctx context.Context, cfg *UpstreamConfig, selected *routing.SelectedChannel, modelName string, latencyMs int64, firstByteLatencyMs *int64, usage ParsedUsage) {
 	if cfg == nil || cfg.Router == nil || selected == nil {
 		return
 	}
 	// Cost remains 0 here; pricing is a separate concern (#43). Token totals
 	// are persisted via writeSuccessProxyLog for aggregation.
-	if err := cfg.Router.RecordSuccess(ctx, selected.Channel.ID, float64(latencyMs), 0, &modelName, nil); err != nil {
+	// firstByteLatencyMs feeds soft TTFT scoring in runtime health (#113).
+	var firstByteFloat *float64
+	if firstByteLatencyMs != nil && *firstByteLatencyMs > 0 {
+		v := float64(*firstByteLatencyMs)
+		firstByteFloat = &v
+	}
+	if err := cfg.Router.RecordSuccess(ctx, selected.Channel.ID, float64(latencyMs), 0, &modelName, nil, firstByteFloat); err != nil {
 		slog.Warn("RecordSuccess failed", "err", err, "channel_id", selected.Channel.ID, "model", modelName)
 	}
 	_ = usage
@@ -731,6 +742,7 @@ func writeSuccessProxyLog(
 	proxyCtx *Ctx,
 	upstreamModel string,
 	upstreamPath string,
+	firstByteLatencyMs int64,
 	latencyMs int64,
 	httpStatus int,
 	isStream bool,
@@ -772,6 +784,10 @@ func writeSuccessProxyLog(
 			source = usageSourceUnknown
 		}
 	}
+	var firstBytePtr *int64
+	if firstByteLatencyMs > 0 {
+		firstBytePtr = int64Ptr(firstByteLatencyMs)
+	}
 	entry := proxy.ProxyLogEntry{
 		RouteID:            routeIDPtr,
 		ChannelID:          &channelID,
@@ -782,7 +798,7 @@ func writeSuccessProxyLog(
 		Status:             "success",
 		HTTPStatus:         httpStatus,
 		IsStream:           boolPtr(isStream),
-		FirstByteLatencyMs: int64Ptr(latencyMs),
+		FirstByteLatencyMs: firstBytePtr,
 		LatencyMs:          latencyMs,
 		PromptTokens:       int64Ptr(usage.PromptTokens),
 		CompletionTokens:   int64Ptr(usage.CompletionTokens),

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -32,10 +32,11 @@ type upstreamTestFailure struct {
 }
 
 type upstreamTestSuccess struct {
-	channelID int64
-	latencyMs float64
-	cost      float64
-	modelName *string
+	channelID          int64
+	latencyMs          float64
+	cost               float64
+	modelName          *string
+	firstByteLatencyMs *float64
 }
 
 func (r *upstreamTestRouter) SelectChannel(_ context.Context, _ string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
@@ -53,14 +54,23 @@ func (r *upstreamTestRouter) SelectPreferredChannel(_ context.Context, _ string,
 	return nil, nil
 }
 
-func (r *upstreamTestRouter) RecordSuccess(_ context.Context, channelID int64, latencyMs float64, cost float64, modelName *string, _ *int64) error {
+func (r *upstreamTestRouter) RecordSuccess(_ context.Context, channelID int64, latencyMs float64, cost float64, modelName *string, _ *int64, firstByteLatencyMs *float64) error {
 	r.successes = append(r.successes, upstreamTestSuccess{
-		channelID: channelID,
-		latencyMs: latencyMs,
-		cost:      cost,
-		modelName: cloneStringPtr(modelName),
+		channelID:          channelID,
+		latencyMs:          latencyMs,
+		cost:               cost,
+		modelName:          cloneStringPtr(modelName),
+		firstByteLatencyMs: cloneFloat64Ptr(firstByteLatencyMs),
 	})
 	return nil
+}
+
+func cloneFloat64Ptr(v *float64) *float64 {
+	if v == nil {
+		return nil
+	}
+	cloned := *v
+	return &cloned
 }
 
 func (r *upstreamTestRouter) RecordFailure(_ context.Context, channelID int64, failureCtx routing.SiteRuntimeFailureContext, _ *int64) error {
@@ -604,7 +614,6 @@ func TestSiteConcurrencySaturateSkipsWithoutFailure(t *testing.T) {
 		t.Fatalf("expected channel 202 success, got %d", router.successes[0].channelID)
 	}
 }
-
 
 func TestNonStreamSuccessPersistsUsageTokensToProxyLog(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/proxy/channel_selection.go
+++ b/proxy/channel_selection.go
@@ -15,7 +15,9 @@ type TokenRouterInterface interface {
 	SelectChannel(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
 	SelectNextChannel(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
 	SelectPreferredChannel(ctx context.Context, requestedModel string, preferredChannelID int64, policy routing.DownstreamRoutingPolicy, excludeChannelIDs []int64) (*routing.SelectedChannel, error)
-	RecordSuccess(ctx context.Context, channelID int64, latencyMs float64, cost float64, modelName *string, actualAccountID *int64) error
+	// RecordSuccess records a successful attempt. firstByteLatencyMs is optional TTFT
+	// (nil when unobserved). Soft-scored by runtime health (issue #113).
+	RecordSuccess(ctx context.Context, channelID int64, latencyMs float64, cost float64, modelName *string, actualAccountID *int64, firstByteLatencyMs *float64) error
 	RecordFailure(ctx context.Context, channelID int64, failureCtx routing.SiteRuntimeFailureContext, actualAccountID *int64) error
 }
 
@@ -36,7 +38,7 @@ type ChannelSelectionInput struct {
 
 // Tester header constants.
 const (
-	TesterRequestHeader     = "x-metapi-tester-request"
+	TesterRequestHeader       = "x-metapi-tester-request"
 	TesterForcedChannelHeader = "x-metapi-tester-forced-channel-id"
 )
 

--- a/proxy/channel_selection_test.go
+++ b/proxy/channel_selection_test.go
@@ -39,7 +39,7 @@ func (m *mockRouter) SelectPreferredChannel(ctx context.Context, requestedModel 
 	return nil, nil
 }
 
-func (m *mockRouter) RecordSuccess(ctx context.Context, channelID int64, latencyMs float64, cost float64, modelName *string, actualAccountID *int64) error {
+func (m *mockRouter) RecordSuccess(ctx context.Context, channelID int64, latencyMs float64, cost float64, modelName *string, actualAccountID *int64, firstByteLatencyMs *float64) error {
 	return nil
 }
 func (m *mockRouter) RecordFailure(ctx context.Context, channelID int64, failureCtx routing.SiteRuntimeFailureContext, actualAccountID *int64) error {

--- a/routing/router.go
+++ b/routing/router.go
@@ -454,7 +454,8 @@ func stringsTrimSpaceImpl(s string) string {
 }
 
 // RecordSuccess records a successful channel usage.
-func (tr *TokenRouter) RecordSuccess(ctx context.Context, channelID int64, latencyMs float64, cost float64, modelName *string, actualAccountID *int64) error {
+// firstByteLatencyMs is optional TTFT/first-byte observation (ms); nil skips TTFT scoring.
+func (tr *TokenRouter) RecordSuccess(ctx context.Context, channelID int64, latencyMs float64, cost float64, modelName *string, actualAccountID *int64, firstByteLatencyMs *float64) error {
 	if err := EnsureSiteRuntimeHealthStateLoaded(); err != nil {
 		return err
 	}
@@ -493,13 +494,13 @@ func (tr *TokenRouter) RecordSuccess(ctx context.Context, channelID int64, laten
 				"cooldownLevel":  int64(0),
 				"updatedAt":      nowISO,
 			})
-			RecordSiteRuntimeSuccess(memberRow.Account.SiteID, latencyMs, modelName)
+			RecordSiteRuntimeSuccess(memberRow.Account.SiteID, latencyMs, modelName, firstByteLatencyMs)
 		} else {
-			RecordSiteRuntimeSuccess(account.SiteID, latencyMs, modelName)
+			RecordSiteRuntimeSuccess(account.SiteID, latencyMs, modelName, firstByteLatencyMs)
 		}
 		tr.cache.InvalidateRouteScopedCache(ch.RouteID)
 	} else {
-		RecordSiteRuntimeSuccess(account.SiteID, latencyMs, modelName)
+		RecordSiteRuntimeSuccess(account.SiteID, latencyMs, modelName, firstByteLatencyMs)
 	}
 
 	_ = tr.db.UpdateChannelSuccessFields(ctx, channelID, map[string]interface{}{
@@ -557,9 +558,9 @@ func (tr *TokenRouter) RecordProbeSuccess(ctx context.Context, channelID int64, 
 				"cooldownLevel":  int64(0),
 				"updatedAt":      nowISO,
 			})
-			RecordSiteRuntimeSuccess(memberRow.Account.SiteID, latencyMs, modelName)
+			RecordSiteRuntimeSuccess(memberRow.Account.SiteID, latencyMs, modelName, nil)
 		} else {
-			RecordSiteRuntimeSuccess(account.SiteID, latencyMs, modelName)
+			RecordSiteRuntimeSuccess(account.SiteID, latencyMs, modelName, nil)
 		}
 
 		_ = tr.db.UpdateChannelCooldownFields(ctx, []int64{channelID}, map[string]interface{}{
@@ -601,7 +602,7 @@ func (tr *TokenRouter) RecordProbeSuccess(ctx context.Context, channelID int64, 
 		}
 	}
 
-	RecordSiteRuntimeSuccess(account.SiteID, latencyMs, modelName)
+	RecordSiteRuntimeSuccess(account.SiteID, latencyMs, modelName, nil)
 	return nil
 }
 

--- a/routing/runtime_health.go
+++ b/routing/runtime_health.go
@@ -11,20 +11,26 @@ import (
 // ---- Site runtime health constants ----
 
 const (
-	SiteRuntimeHealthDecayHalfLifeMs   = 10 * 60 * 1000
-	SiteRuntimeMinMultiplier           = 0.08
-	SiteRuntimeLatencyBaselineMs       = 2500
-	SiteRuntimeLatencyWindowMs         = 30000
-	SiteRuntimeMaxLatencyPenalty       = 0.35
-	SiteRuntimeLatencyEMAAlpha         = 0.3
-	SiteRuntimeBreakerStreakThreshold  = 3
-	SiteTransientStreakWindowMs        = 5 * 60 * 1000
-	SiteRecentOutcomeHalfLifeMs        = 30 * 60 * 1000
-	SiteRecentSuccessConfidenceSamples = 12
-	SiteRecentSuccessPriorSuccesses    = 1
-	SiteRecentSuccessPriorFailures     = 1
-	SiteRecentSuccessFallbackRate      = 0.5
-	SiteRecentModelWeight              = 0.65
+	SiteRuntimeHealthDecayHalfLifeMs = 10 * 60 * 1000
+	SiteRuntimeMinMultiplier         = 0.08
+	SiteRuntimeLatencyBaselineMs     = 2500
+	SiteRuntimeLatencyWindowMs       = 30000
+	SiteRuntimeMaxLatencyPenalty     = 0.35
+	SiteRuntimeLatencyEMAAlpha       = 0.3
+	// TTFT / first-byte soft scoring (issue #113). Small max penalty keeps the
+	// signal non-breaking relative to failure + overall latency multipliers.
+	SiteRuntimeFirstByteLatencyBaselineMs = 800
+	SiteRuntimeFirstByteLatencyWindowMs   = 10000
+	SiteRuntimeMaxFirstByteLatencyPenalty = 0.12
+	SiteRuntimeFirstByteLatencyEMAAlpha   = 0.3
+	SiteRuntimeBreakerStreakThreshold     = 3
+	SiteTransientStreakWindowMs           = 5 * 60 * 1000
+	SiteRecentOutcomeHalfLifeMs           = 30 * 60 * 1000
+	SiteRecentSuccessConfidenceSamples    = 12
+	SiteRecentSuccessPriorSuccesses       = 1
+	SiteRecentSuccessPriorFailures        = 1
+	SiteRecentSuccessFallbackRate         = 0.5
+	SiteRecentModelWeight                 = 0.65
 
 	SiteHistoricalHealthMinMultiplier = 0.45
 	SiteHistoricalHealthMaxSample     = 24
@@ -114,8 +120,11 @@ var usageLimitRateLimitPatterns = []*regexp.Regexp{
 
 // SiteRuntimeHealthState tracks runtime health for a site or (site, model).
 type SiteRuntimeHealthState struct {
-	PenaltyScore             float64  `json:"penaltyScore"`
-	LatencyEMAMs             *float64 `json:"latencyEmaMs,omitempty"`
+	PenaltyScore float64  `json:"penaltyScore"`
+	LatencyEMAMs *float64 `json:"latencyEmaMs,omitempty"`
+	// FirstByteLatencyEMAMs is the EMA of observed first-byte / TTFT latency (ms).
+	// Soft-scored separately from end-to-end LatencyEMAMs (issue #113).
+	FirstByteLatencyEMAMs    *float64 `json:"firstByteLatencyEmaMs,omitempty"`
 	TransientFailureStreak   int64    `json:"transientFailureStreak"`
 	LastTransientFailureAtMs *int64   `json:"lastTransientFailureAtMs,omitempty"`
 	RecentSuccessCount       float64  `json:"recentSuccessCount"`
@@ -431,6 +440,8 @@ func resolveSiteRuntimeBreakerMs(level int64) int64 {
 }
 
 // GetRuntimeHealthMultiplier returns the health multiplier for a state.
+// Soft signals (overall latency + optional TTFT/first-byte) only reduce weight;
+// they never open breakers and never double-count as failures.
 func GetRuntimeHealthMultiplier(state *SiteRuntimeHealthState) float64 {
 	if state == nil {
 		return 1
@@ -449,7 +460,22 @@ func GetRuntimeHealthMultiplier(state *SiteRuntimeHealthState) float64 {
 		)
 	}
 	latencyFactor := 1.0 - (latencyPenaltyRatio * SiteRuntimeMaxLatencyPenalty)
-	return ClampNumber(failurePenaltyFactor*latencyFactor, SiteRuntimeMinMultiplier, 1)
+	ttftFactor := resolveFirstByteLatencyFactor(state.FirstByteLatencyEMAMs)
+	return ClampNumber(failurePenaltyFactor*latencyFactor*ttftFactor, SiteRuntimeMinMultiplier, 1)
+}
+
+// resolveFirstByteLatencyFactor maps observed TTFT EMA into a soft multiplier.
+// Missing samples return 1 (no bias). Slow first-byte reduces weight by at most
+// SiteRuntimeMaxFirstByteLatencyPenalty (default 12%).
+func resolveFirstByteLatencyFactor(firstByteEMAMs *float64) float64 {
+	if firstByteEMAMs == nil || !isFiniteFloat(*firstByteEMAMs) || *firstByteEMAMs <= 0 {
+		return 1
+	}
+	penaltyRatio := ClampNumber(
+		(*firstByteEMAMs-SiteRuntimeFirstByteLatencyBaselineMs)/SiteRuntimeFirstByteLatencyWindowMs,
+		0, 1,
+	)
+	return 1.0 - (penaltyRatio * SiteRuntimeMaxFirstByteLatencyPenalty)
 }
 
 // GetSiteRuntimeHealthDetails returns combined health details for a site and model.
@@ -706,7 +732,7 @@ func applyRuntimeHealthFailure(state *SiteRuntimeHealthState, ctx SiteRuntimeFai
 	state.LastFailureAtMs = &n
 }
 
-func applyRuntimeHealthSuccess(state *SiteRuntimeHealthState, latencyMs float64) {
+func applyRuntimeHealthSuccess(state *SiteRuntimeHealthState, latencyMs float64, firstByteLatencyMs *float64) {
 	n := nowMs()
 	refreshRecentOutcomeWindow(state)
 	state.RecentSuccessCount += 1
@@ -717,11 +743,26 @@ func applyRuntimeHealthSuccess(state *SiteRuntimeHealthState, latencyMs float64)
 	state.BreakerUntilMs = nil
 	state.LastSuccessAtMs = &n
 
-	if state.LatencyEMAMs == nil {
-		state.LatencyEMAMs = &latencyMs
-	} else {
-		ema := (*state.LatencyEMAMs)*(1-SiteRuntimeLatencyEMAAlpha) + latencyMs*SiteRuntimeLatencyEMAAlpha
-		state.LatencyEMAMs = &ema
+	if isFiniteFloat(latencyMs) && latencyMs >= 0 {
+		if state.LatencyEMAMs == nil {
+			v := latencyMs
+			state.LatencyEMAMs = &v
+		} else {
+			ema := (*state.LatencyEMAMs)*(1-SiteRuntimeLatencyEMAAlpha) + latencyMs*SiteRuntimeLatencyEMAAlpha
+			state.LatencyEMAMs = &ema
+		}
+	}
+
+	// TTFT is optional: only update when a positive observation is available so
+	// non-streaming / untimed paths do not invent first-byte samples.
+	if firstByteLatencyMs != nil && isFiniteFloat(*firstByteLatencyMs) && *firstByteLatencyMs > 0 {
+		fb := *firstByteLatencyMs
+		if state.FirstByteLatencyEMAMs == nil {
+			state.FirstByteLatencyEMAMs = &fb
+		} else {
+			ema := (*state.FirstByteLatencyEMAMs)*(1-SiteRuntimeFirstByteLatencyEMAAlpha) + fb*SiteRuntimeFirstByteLatencyEMAAlpha
+			state.FirstByteLatencyEMAMs = &ema
+		}
 	}
 }
 
@@ -743,17 +784,18 @@ func RecordSiteRuntimeFailure(siteID int64, ctx SiteRuntimeFailureContext) {
 }
 
 // RecordSiteRuntimeSuccess records a success against a site and model.
-func RecordSiteRuntimeSuccess(siteID int64, latencyMs float64, modelName *string) {
+// firstByteLatencyMs is optional TTFT/first-byte observation in milliseconds.
+func RecordSiteRuntimeSuccess(siteID int64, latencyMs float64, modelName *string, firstByteLatencyMs *float64) {
 	healthStateMu.Lock()
 	defer healthStateMu.Unlock()
 
 	globalState := getOrCreateSiteRuntimeHealthState(siteID)
-	applyRuntimeHealthSuccess(globalState, latencyMs)
+	applyRuntimeHealthSuccess(globalState, latencyMs, firstByteLatencyMs)
 
 	if modelName != nil && *modelName != "" {
 		modelState := getOrCreateSiteModelRuntimeHealthState(siteID, *modelName)
 		if modelState != nil {
-			applyRuntimeHealthSuccess(modelState, latencyMs)
+			applyRuntimeHealthSuccess(modelState, latencyMs, firstByteLatencyMs)
 		}
 	}
 	scheduleSiteRuntimeHealthPersistence()
@@ -880,6 +922,9 @@ func shouldPersistSiteRuntimeHealthState(state *SiteRuntimeHealthState) bool {
 	if state.LatencyEMAMs != nil && *state.LatencyEMAMs > 0 {
 		return true
 	}
+	if state.FirstByteLatencyEMAMs != nil && *state.FirstByteLatencyEMAMs > 0 {
+		return true
+	}
 	return n-lastTouchedAtMs <= SiteRuntimeHealthPersistIdleTTLMs
 }
 
@@ -896,6 +941,10 @@ func cloneSiteRuntimeHealthState(state *SiteRuntimeHealthState) *SiteRuntimeHeal
 	if state.LatencyEMAMs != nil {
 		v := *state.LatencyEMAMs
 		clone.LatencyEMAMs = &v
+	}
+	if state.FirstByteLatencyEMAMs != nil {
+		v := *state.FirstByteLatencyEMAMs
+		clone.FirstByteLatencyEMAMs = &v
 	}
 	if state.LastTransientFailureAtMs != nil {
 		v := *state.LastTransientFailureAtMs
@@ -1221,6 +1270,12 @@ func marshalState(s *SiteRuntimeHealthState) []byte {
 		buf = append(buf, fmtFloat(*s.LatencyEMAMs)...)
 	} else {
 		buf = append(buf, `,"latencyEmaMs":null`...)
+	}
+	if s.FirstByteLatencyEMAMs != nil {
+		buf = append(buf, `,"firstByteLatencyEmaMs":`...)
+		buf = append(buf, fmtFloat(*s.FirstByteLatencyEMAMs)...)
+	} else {
+		buf = append(buf, `,"firstByteLatencyEmaMs":null`...)
 	}
 	buf = append(buf, `,"transientFailureStreak":`...)
 	buf = append(buf, fmtInt(s.TransientFailureStreak)...)

--- a/routing/runtime_health_test.go
+++ b/routing/runtime_health_test.go
@@ -441,7 +441,7 @@ func TestRecordSiteRuntimeSuccess_ClearsBreaker(t *testing.T) {
 
 	// Record success → clears breaker
 	modelName := "gpt-4"
-	RecordSiteRuntimeSuccess(siteID, 500.0, &modelName)
+	RecordSiteRuntimeSuccess(siteID, 500.0, &modelName, nil)
 
 	state = siteRuntimeHealthStates[siteID]
 	if state.BreakerLevel != 0 {
@@ -461,7 +461,7 @@ func TestRecordSiteRuntimeSuccess_ReducesPenalty(t *testing.T) {
 	// Record an auth failure (penalty 1.8) then success
 	RecordSiteRuntimeFailure(siteID, SiteRuntimeFailureContext{Status: &status401})
 	modelName := "gpt-4"
-	RecordSiteRuntimeSuccess(siteID, 800.0, &modelName)
+	RecordSiteRuntimeSuccess(siteID, 800.0, &modelName, nil)
 
 	state := siteRuntimeHealthStates[siteID]
 	// max(0, 1.8*0.2 - 0.3) = max(0, 0.36-0.3) = max(0, 0.06) = 0.06
@@ -475,7 +475,7 @@ func TestRecordSiteRuntimeSuccess_UpdatesLatencyEMA(t *testing.T) {
 
 	siteID := int64(9994)
 	modelName := "gpt-4"
-	RecordSiteRuntimeSuccess(siteID, 1000.0, &modelName)
+	RecordSiteRuntimeSuccess(siteID, 1000.0, &modelName, nil)
 
 	state := siteRuntimeHealthStates[siteID]
 	if state.LatencyEMAMs == nil {
@@ -486,7 +486,7 @@ func TestRecordSiteRuntimeSuccess_UpdatesLatencyEMA(t *testing.T) {
 	}
 
 	// Second call: EMA = 1000*0.7 + 500*0.3 = 850
-	RecordSiteRuntimeSuccess(siteID, 500.0, &modelName)
+	RecordSiteRuntimeSuccess(siteID, 500.0, &modelName, nil)
 	state = siteRuntimeHealthStates[siteID]
 	if math.Abs(*state.LatencyEMAMs-850.0) > 0.001 {
 		t.Errorf("expected EMA = 850, got %.2f", *state.LatencyEMAMs)
@@ -651,7 +651,7 @@ func TestRuntimeHealthPublicReadersConcurrentWithUpdates(t *testing.T) {
 					})
 					continue
 				}
-				RecordSiteRuntimeSuccess(siteID, float64(100+j), &modelName)
+				RecordSiteRuntimeSuccess(siteID, float64(100+j), &modelName, nil)
 			}
 		}()
 	}
@@ -698,7 +698,7 @@ func TestResetSiteRuntimeHealthState(t *testing.T) {
 	// Seed some state
 	siteID := int64(9991)
 	modelName := "gpt-4"
-	RecordSiteRuntimeSuccess(siteID, 100.0, &modelName)
+	RecordSiteRuntimeSuccess(siteID, 100.0, &modelName, nil)
 
 	if len(siteRuntimeHealthStates) == 0 {
 		t.Fatal("expected state to exist before reset")
@@ -732,5 +732,113 @@ func TestBuildRuntimeBreakerReason(t *testing.T) {
 	modelOnly := buildRuntimeBreakerReason(SiteRuntimeHealthDetails{GlobalBreakerOpen: false, ModelBreakerOpen: true})
 	if modelOnly == "" {
 		t.Error("expected non-empty reason")
+	}
+}
+
+// =============================================================================
+// TTFT / first-byte soft scoring (#113)
+// =============================================================================
+
+func TestResolveFirstByteLatencyFactor_MissingIsNeutral(t *testing.T) {
+	if got := resolveFirstByteLatencyFactor(nil); math.Abs(got-1.0) > 0.001 {
+		t.Errorf("nil EMA should be neutral 1.0, got %.4f", got)
+	}
+	zero := 0.0
+	if got := resolveFirstByteLatencyFactor(&zero); math.Abs(got-1.0) > 0.001 {
+		t.Errorf("zero EMA should be neutral 1.0, got %.4f", got)
+	}
+	fast := 200.0
+	if got := resolveFirstByteLatencyFactor(&fast); math.Abs(got-1.0) > 0.001 {
+		t.Errorf("sub-baseline TTFT should not penalize, got %.4f", got)
+	}
+}
+
+func TestResolveFirstByteLatencyFactor_SlowSoftPenalty(t *testing.T) {
+	// Exactly at baseline+window → full soft penalty.
+	slow := float64(SiteRuntimeFirstByteLatencyBaselineMs + SiteRuntimeFirstByteLatencyWindowMs)
+	got := resolveFirstByteLatencyFactor(&slow)
+	expected := 1.0 - SiteRuntimeMaxFirstByteLatencyPenalty
+	if math.Abs(got-expected) > 0.001 {
+		t.Errorf("expected %.4f, got %.4f", expected, got)
+	}
+	// Mid-window partial penalty.
+	mid := float64(SiteRuntimeFirstByteLatencyBaselineMs) + float64(SiteRuntimeFirstByteLatencyWindowMs)/2
+	got = resolveFirstByteLatencyFactor(&mid)
+	expected = 1.0 - (0.5 * SiteRuntimeMaxFirstByteLatencyPenalty)
+	if math.Abs(got-expected) > 0.001 {
+		t.Errorf("mid-window expected %.4f, got %.4f", expected, got)
+	}
+}
+
+func TestGetRuntimeHealthMultiplier_TTFTSoftOnly(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	n := nowMs()
+	// Same overall latency, different TTFT.
+	overall := 2000.0 // below overall latency baseline
+	fastTTFT := 300.0
+	slowTTFT := float64(SiteRuntimeFirstByteLatencyBaselineMs + SiteRuntimeFirstByteLatencyWindowMs)
+	fastState := &SiteRuntimeHealthState{
+		LatencyEMAMs:          &overall,
+		FirstByteLatencyEMAMs: &fastTTFT,
+		LastUpdatedAtMs:       n,
+	}
+	slowState := &SiteRuntimeHealthState{
+		LatencyEMAMs:          &overall,
+		FirstByteLatencyEMAMs: &slowTTFT,
+		LastUpdatedAtMs:       n,
+	}
+	fastM := GetRuntimeHealthMultiplier(fastState)
+	slowM := GetRuntimeHealthMultiplier(slowState)
+	if !(fastM > slowM) {
+		t.Fatalf("expected faster TTFT to score higher: fast=%.4f slow=%.4f", fastM, slowM)
+	}
+	// Soft bound: max TTFT penalty is 12%.
+	if slowM < 1.0-SiteRuntimeMaxFirstByteLatencyPenalty-0.001 {
+		t.Fatalf("TTFT penalty should be soft (max 12%%), got %.4f", slowM)
+	}
+}
+
+func TestRecordSiteRuntimeSuccess_UpdatesFirstByteEMA(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	siteID := int64(11301)
+	modelName := "gpt-4"
+	fb1 := 1000.0
+	RecordSiteRuntimeSuccess(siteID, 3000.0, &modelName, &fb1)
+	state := siteRuntimeHealthStates[siteID]
+	if state == nil || state.FirstByteLatencyEMAMs == nil {
+		t.Fatal("expected first-byte EMA after success with observation")
+	}
+	if math.Abs(*state.FirstByteLatencyEMAMs-1000.0) > 0.001 {
+		t.Errorf("first EMA want 1000, got %.2f", *state.FirstByteLatencyEMAMs)
+	}
+	// Nil observation must not invent/overwrite TTFT samples.
+	RecordSiteRuntimeSuccess(siteID, 2500.0, &modelName, nil)
+	if math.Abs(*state.FirstByteLatencyEMAMs-1000.0) > 0.001 {
+		t.Errorf("nil observation should preserve EMA, got %.2f", *state.FirstByteLatencyEMAMs)
+	}
+	// Second observation: EMA = 1000*0.7 + 400*0.3 = 820
+	fb2 := 400.0
+	RecordSiteRuntimeSuccess(siteID, 2000.0, &modelName, &fb2)
+	if math.Abs(*state.FirstByteLatencyEMAMs-820.0) > 0.001 {
+		t.Errorf("expected EMA 820, got %.2f", *state.FirstByteLatencyEMAMs)
+	}
+}
+
+func TestRecordSiteRuntimeSuccess_TTFTDoesNotOpenBreaker(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	siteID := int64(11302)
+	modelName := "gpt-4"
+	// Extremely slow TTFT should only soft-score, never trip breaker.
+	slow := 60000.0
+	for i := 0; i < 5; i++ {
+		RecordSiteRuntimeSuccess(siteID, 5000.0, &modelName, &slow)
+	}
+	if IsSiteRuntimeBreakerOpen(siteID) {
+		t.Fatal("TTFT soft scoring must not open breaker")
+	}
+	state := siteRuntimeHealthStates[siteID]
+	if state.PenaltyScore != 0 {
+		// Success path reduces penalty; should remain 0 without failures.
+		t.Errorf("expected zero failure penalty, got %.4f", state.PenaltyScore)
 	}
 }

--- a/routing/weights_test.go
+++ b/routing/weights_test.go
@@ -557,7 +557,6 @@ func BenchmarkMakeCandidate(b *testing.B) {
 	}
 }
 
-
 // TestStableFirstStateMaps_ConcurrentRace exercises concurrent select + update + clear
 // against the shared stable-first maps. Run with -race.
 func TestStableFirstStateMaps_ConcurrentRace(t *testing.T) {
@@ -602,4 +601,56 @@ func TestStableFirstStateMaps_ConcurrentRace(t *testing.T) {
 		}(w)
 	}
 	wg.Wait()
+}
+
+// =============================================================================
+// TTFT soft scoring preference in weighted selection (#113)
+// =============================================================================
+
+func TestCalculateWeightedSelection_PrefersLowerTTFT(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+
+	// Two otherwise equal candidates on different sites.
+	// Seed identical success/cost history so value scores match.
+	candidates := []RouteChannelCandidate{
+		makeCandidate(11, 501, 5001, 10, 0, 20, 0, 2.0, 1.0, ptrFloat(0.01), 1.0, nil),
+		makeCandidate(12, 502, 5002, 10, 0, 20, 0, 2.0, 1.0, ptrFloat(0.01), 1.0, nil),
+	}
+	model := "gpt-4"
+	// Fast TTFT site 501, slow TTFT site 502; same overall latency.
+	fast := 200.0
+	slow := float64(SiteRuntimeFirstByteLatencyBaselineMs + SiteRuntimeFirstByteLatencyWindowMs)
+	overall := 2000.0
+	RecordSiteRuntimeSuccess(501, overall, &model, &fast)
+	RecordSiteRuntimeSuccess(502, overall, &model, &slow)
+
+	routingWeights := RoutingWeightsConfig{
+		BaseWeightFactor: 0.5,
+		ValueScoreFactor: 0.5,
+		CostWeight:       0.4,
+		BalanceWeight:    0.3,
+		UsageWeight:      0.3,
+	}
+
+	// Deterministic ranking via contributions / probabilities (not rand pick).
+	// Use many trials and inspect probabilities directly.
+	result := CalculateWeightedSelection(
+		candidates, staticModel(model), routingWeights,
+		nil, nil, 0, WeightedMode, "", nil, 1.0,
+	)
+	if len(result.Details) != 2 {
+		t.Fatalf("expected 2 details, got %d", len(result.Details))
+	}
+	var fastProb, slowProb float64
+	for _, d := range result.Details {
+		switch d.Candidate.Site.ID {
+		case 501:
+			fastProb = d.Probability
+		case 502:
+			slowProb = d.Probability
+		}
+	}
+	if !(fastProb > slowProb) {
+		t.Fatalf("expected lower-TTFT site higher probability: fast=%.6f slow=%.6f", fastProb, slowProb)
+	}
 }


### PR DESCRIPTION
## Summary
- Record observed first-byte / TTFT on proxy success (header arrival) and persist it separately from end-to-end latency.
- Soft-score channel selection via runtime health EMA (`FirstByteLatencyEMAMs`) with a small non-breaking max penalty (12%).
- Keep cooldown/breakers failure-only so TTFT never double-penalizes or opens breakers.

## Closes
Closes #113

## Design notes
See `docs/analysis/ttft-channel-selection.md`.

- Baseline 800ms / window 10s / max penalty 0.12
- Missing first-byte samples are neutral
- Probe success may omit TTFT (`nil`)

## Test plan
- [x] `go test ./routing/ ./proxy/ ./handler/proxy/ ./e2e/ ./docs/`
- [x] pre-push `go vet ./...` + `go test ./... -race`
- [x] Unit: lower TTFT preferred when other factors equal
- [x] Unit: TTFT soft-only (no breaker)
- [x] Unit: first-byte EMA update + nil observation preserve