### PR TITLE
feat(proxy): per-request cost attribution + token-type breakdown #111

### DIFF
--- a/docs/analysis/request-cost-attribution.md
+++ b/docs/analysis/request-cost-attribution.md
@@ -1,0 +1,91 @@
+# Per-request cost attribution + token-type breakdown
+
+**Date:** 2026-07-17  
+**Backlog:** [#111](https://github.com/TokenDanceLab/metapi-go/issues/111) · competitive matrix L2  
+**Peers:** LiteLLM spend logs + cost headers · AxonHub real-time cost · New API pricing visibility  
+**Code:** `routing/pricing_cost.go`, `handler/proxy/usage.go`, `handler/proxy/cost.go`, `handler/proxy/upstream.go`
+
+## Goal
+
+Persist a truthful per-request cost estimate and token-type breakdown on every
+successful proxy attempt:
+
+| Surface | Field / header | Notes |
+|---------|----------------|-------|
+| `proxy_logs.estimated_cost` | float | Used by usage aggregation spend |
+| `proxy_logs.billing_details` | JSON (`ProxyBillingDetails`) | input/output/cache split + ratios + provenance |
+| Response headers (non-stream) | `X-Metapi-Cost`, `X-Metapi-Cost-Source`, token headers | Best-effort; stream commits headers at first byte |
+
+## Token-type extraction
+
+`ParsedUsage` now carries optional:
+
+- `CacheReadTokens` / `CacheCreationTokens`
+- `ReasoningTokens` (operator-only; not billed separately)
+- `PromptTokensIncludeCache`
+
+Sources:
+
+| Protocol | Cache read | Cache creation | Reasoning |
+|----------|------------|----------------|-----------|
+| Anthropic messages | `cache_read_input_tokens` | `cache_creation_input_tokens` / `cache_creation.*` | — |
+| OpenAI chat/completions | `prompt_tokens_details.cached_tokens` | — | `completion_tokens_details.reasoning_tokens` |
+| OpenAI Responses | `input_tokens_details.cached_tokens` | — | `output_tokens_details.reasoning_tokens` |
+| Gemini | `cachedContentTokenCount` | — | `thoughtsTokenCount` |
+
+Missing fields stay **0** (never invented).
+
+## Cost policy
+
+`routing.EstimateRequestCost` chooses:
+
+1. **`pricing_model`** — when a `PricingModel` is supplied (catalog / override).  
+   Claude missing `cache_ratio` / `cache_creation_ratio` → **0.1 / 1.25**  
+   (see `docs/analysis/cache-ratio-pricing.md`). Explicit 0 is preserved.
+2. **`fallback`** — no pricing model. `FallbackTokenCost(total, platform)`  
+   (veloera `/1e6`, others `/5e5`). Billing details still record token breakdown;  
+   **ratios are zeroed** (not silent 1.0) so operators can tell “unknown pricing”
+   from “priced at input rate”.
+3. **`zero`** — empty usage; cost 0 with a zero shell `billing_details`.
+
+`billing_details.costSource` mirrors the provenance string.
+
+## Wire path
+
+```
+upstream success
+  → ParseUsageFromBody / ParseUsageFromSSEEvents
+  → buildRequestCostAttribution (model currently nil → fallback)
+  → writeSuccessProxyLog { EstimatedCost, BillingDetails }
+  → RecordSuccess(..., cost, ...)
+  → (non-stream only) X-Metapi-* headers before body write
+```
+
+Stream responses still persist cost on `proxy_logs`; headers are not rewritten
+after the SSE status line is committed.
+
+## Headers
+
+| Header | Example |
+|--------|---------|
+| `X-Metapi-Cost` | `0.003` |
+| `X-Metapi-Cost-Source` | `fallback` / `pricing_model` / `zero` |
+| `X-Metapi-Prompt-Tokens` | `1000` |
+| `X-Metapi-Completion-Tokens` | `500` |
+| `X-Metapi-Total-Tokens` | `1500` |
+| `X-Metapi-Cache-Read-Tokens` | present when > 0 |
+| `X-Metapi-Cache-Creation-Tokens` | present when > 0 |
+| `X-Metapi-Reasoning-Tokens` | present when > 0 |
+
+## Tests
+
+- `routing/pricing_cost_test.go` — `EstimateRequestCost` pricing / fallback / zero
+- `handler/proxy/usage_test.go` — Anthropic cache + OpenAI cached/reasoning + partial
+- `handler/proxy/cost_test.go` — attribution, headers, proxy log persistence
+
+## Out of scope
+
+- Full remote pricing catalog fetch into the hot path (model pointer is ready)
+- Multi-tenant virtual key wallet / Stripe
+- Web redesign of ProxyLogs UI (already displays `billingDetails` when present)
+- Stream response trailer headers

--- a/handler/proxy/cost.go
+++ b/handler/proxy/cost.go
@@ -1,0 +1,92 @@
+package proxyhandler
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/tokendancelab/metapi-go/routing"
+)
+
+// Cost attribution response headers (operator-facing, LiteLLM-inspired).
+// Set only when headers have not been written yet (cheap / best-effort).
+const (
+	headerMetapiCost              = "X-Metapi-Cost"
+	headerMetapiCostSource        = "X-Metapi-Cost-Source"
+	headerMetapiPromptTokens      = "X-Metapi-Prompt-Tokens"
+	headerMetapiCompletionTokens  = "X-Metapi-Completion-Tokens"
+	headerMetapiTotalTokens       = "X-Metapi-Total-Tokens"
+	headerMetapiCacheReadTokens   = "X-Metapi-Cache-Read-Tokens"
+	headerMetapiCacheCreateTokens = "X-Metapi-Cache-Creation-Tokens"
+	headerMetapiReasoningTokens   = "X-Metapi-Reasoning-Tokens"
+)
+
+// buildRequestCostAttribution estimates cost + billing_details for a proxy log.
+// Pricing catalog wiring is optional: when no PricingModel is available the
+// platform fallback divisor is used and ratios are zeroed (not 1.0). Claude
+// cache_ratio policy is applied only when a PricingModel is supplied.
+func buildRequestCostAttribution(
+	modelName string,
+	platform string,
+	usage ParsedUsage,
+	model *routing.PricingModel,
+	groupRatio map[string]float64,
+) routing.RequestCostAttribution {
+	attr := routing.EstimateRequestCost(modelName, platform, usage.ToUsageForCost(), model, groupRatio)
+	attr.ReasoningTokens = usage.ReasoningTokens
+	if attr.BillingDetails != nil && usage.ReasoningTokens > 0 {
+		attr.BillingDetails.Usage.ReasoningTokens = usage.ReasoningTokens
+	}
+	return attr
+}
+
+// applyCostAttributionHeaders sets optional operator cost/token headers when the
+// response writer has not yet written a status line. Safe no-op after WriteHeader.
+func applyCostAttributionHeaders(w http.ResponseWriter, usage ParsedUsage, attr routing.RequestCostAttribution) {
+	if w == nil {
+		return
+	}
+	// httptest.ResponseRecorder and real servers: check if headers were written.
+	if rw, ok := w.(interface{ Written() bool }); ok && rw.Written() {
+		return
+	}
+	// Standard library: after WriteHeader, Header map is still mutable on most
+	// ResponseWriters but clients may already have received headers. Prefer the
+	// Written() check above; fall through for plain ResponseWriter.
+	h := w.Header()
+	if attr.Source != "" {
+		h.Set(headerMetapiCost, formatCostHeader(attr.EstimatedCost))
+		h.Set(headerMetapiCostSource, attr.Source)
+	}
+	if usage.Found || usage.PromptTokens > 0 || usage.CompletionTokens > 0 || usage.TotalTokens > 0 {
+		h.Set(headerMetapiPromptTokens, strconv.FormatInt(usage.PromptTokens, 10))
+		h.Set(headerMetapiCompletionTokens, strconv.FormatInt(usage.CompletionTokens, 10))
+		h.Set(headerMetapiTotalTokens, strconv.FormatInt(usage.TotalTokens, 10))
+	}
+	if usage.CacheReadTokens > 0 {
+		h.Set(headerMetapiCacheReadTokens, strconv.FormatInt(usage.CacheReadTokens, 10))
+	}
+	if usage.CacheCreationTokens > 0 {
+		h.Set(headerMetapiCacheCreateTokens, strconv.FormatInt(usage.CacheCreationTokens, 10))
+	}
+	if usage.ReasoningTokens > 0 {
+		h.Set(headerMetapiReasoningTokens, strconv.FormatInt(usage.ReasoningTokens, 10))
+	}
+}
+
+func formatCostHeader(cost float64) string {
+	// Fixed precision without scientific notation; trim trailing zeros lightly.
+	s := strconv.FormatFloat(cost, 'f', 6, 64)
+	s = strings.TrimRight(s, "0")
+	s = strings.TrimRight(s, ".")
+	if s == "" || s == "-" {
+		return "0"
+	}
+	return s
+}
+
+// formatCostDebug is used only in tests / slog if needed.
+func formatCostDebug(attr routing.RequestCostAttribution) string {
+	return fmt.Sprintf("cost=%s source=%s", formatCostHeader(attr.EstimatedCost), attr.Source)
+}

--- a/handler/proxy/cost_test.go
+++ b/handler/proxy/cost_test.go
@@ -1,0 +1,217 @@
+package proxyhandler
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tokendancelab/metapi-go/proxy"
+	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func TestBuildRequestCostAttribution_FallbackOpenAI(t *testing.T) {
+	usage := ParsedUsage{
+		PromptTokens:     1000,
+		CompletionTokens: 500,
+		TotalTokens:      1500,
+		Found:            true,
+		Source:           usageSourceUpstream,
+	}
+	attr := buildRequestCostAttribution("gpt-4o", "new-api", usage, nil, nil)
+	if attr.Source != routing.CostSourceFallback {
+		t.Fatalf("source = %q, want fallback", attr.Source)
+	}
+	// new-api fallback: tokens / 5e5
+	if math.Abs(attr.EstimatedCost-0.003) > 1e-9 {
+		t.Fatalf("cost = %v, want 0.003", attr.EstimatedCost)
+	}
+	if attr.BillingDetails == nil {
+		t.Fatal("expected billing details")
+	}
+	if attr.BillingDetails.Usage.PromptTokens != 1000 || attr.BillingDetails.Usage.CompletionTokens != 500 {
+		t.Fatalf("usage section = %+v", attr.BillingDetails.Usage)
+	}
+	// Fallback zeros ratios so operators can tell "unknown pricing" from 1.0.
+	if attr.BillingDetails.Pricing.CacheRatio != 0 || attr.BillingDetails.Pricing.ModelRatio != 0 {
+		t.Fatalf("fallback ratios should be 0, got %+v", attr.BillingDetails.Pricing)
+	}
+	if attr.BillingDetails.CostSource != routing.CostSourceFallback {
+		t.Fatalf("costSource = %q", attr.BillingDetails.CostSource)
+	}
+}
+
+func TestBuildRequestCostAttribution_AnthropicCacheWithPricingModel(t *testing.T) {
+	include := true
+	usage := ParsedUsage{
+		PromptTokens:             146638,
+		CompletionTokens:         172,
+		TotalTokens:              146810,
+		CacheReadTokens:          145692,
+		CacheCreationTokens:      945,
+		PromptTokensIncludeCache: &include,
+		Found:                    true,
+		Source:                   usageSourceUpstream,
+	}
+	// Missing cache ratios → Claude defaults 0.1 / 1.25 (not silent 1.0).
+	model := &routing.PricingModel{
+		ModelName:       "claude-opus-4-7",
+		QuotaType:       0,
+		ModelRatio:      2.5,
+		CompletionRatio: 5,
+		EnableGroups:    []string{"default"},
+	}
+	attr := buildRequestCostAttribution("claude-opus-4-7", "new-api", usage, model, map[string]float64{"default": 1})
+	if attr.Source != routing.CostSourcePricingModel {
+		t.Fatalf("source = %q, want pricing_model", attr.Source)
+	}
+	if attr.BillingDetails == nil {
+		t.Fatal("expected billing details")
+	}
+	if attr.BillingDetails.Pricing.CacheRatio != routing.ClaudeCacheRatio {
+		t.Fatalf("cacheRatio = %v, want %v", attr.BillingDetails.Pricing.CacheRatio, routing.ClaudeCacheRatio)
+	}
+	if attr.BillingDetails.Pricing.CacheCreationRatio != routing.ClaudeCacheCreationRatio {
+		t.Fatalf("cacheCreationRatio = %v, want %v", attr.BillingDetails.Pricing.CacheCreationRatio, routing.ClaudeCacheCreationRatio)
+	}
+	if math.Abs(attr.EstimatedCost-0.083057) > 1e-9 {
+		t.Fatalf("cost = %v, want 0.083057", attr.EstimatedCost)
+	}
+	if attr.BillingDetails.Usage.CacheReadTokens != 145692 {
+		t.Fatalf("cacheReadTokens = %d", attr.BillingDetails.Usage.CacheReadTokens)
+	}
+}
+
+func TestBuildRequestCostAttribution_ZeroUsage(t *testing.T) {
+	attr := buildRequestCostAttribution("gpt-4o", "new-api", ParsedUsage{}, nil, nil)
+	if attr.Source != routing.CostSourceZero {
+		t.Fatalf("source = %q, want zero", attr.Source)
+	}
+	if attr.EstimatedCost != 0 {
+		t.Fatalf("cost = %v, want 0", attr.EstimatedCost)
+	}
+	if attr.BillingDetails == nil {
+		t.Fatal("expected zero shell billing details")
+	}
+}
+
+func TestBuildRequestCostAttribution_ReasoningTokensOperatorOnly(t *testing.T) {
+	usage := ParsedUsage{
+		PromptTokens:     10,
+		CompletionTokens: 20,
+		TotalTokens:      30,
+		ReasoningTokens:  12,
+		Found:            true,
+	}
+	attr := buildRequestCostAttribution("gpt-4o", "new-api", usage, nil, nil)
+	if attr.ReasoningTokens != 12 {
+		t.Fatalf("reasoning = %d", attr.ReasoningTokens)
+	}
+	if attr.BillingDetails == nil || attr.BillingDetails.Usage.ReasoningTokens != 12 {
+		t.Fatalf("billing reasoning = %+v", attr.BillingDetails)
+	}
+}
+
+func TestApplyCostAttributionHeaders(t *testing.T) {
+	rec := httptest.NewRecorder()
+	usage := ParsedUsage{
+		PromptTokens:        11,
+		CompletionTokens:    22,
+		TotalTokens:         33,
+		CacheReadTokens:     5,
+		CacheCreationTokens: 2,
+		ReasoningTokens:     7,
+		Found:               true,
+	}
+	attr := routing.RequestCostAttribution{
+		EstimatedCost: 0.003,
+		Source:        routing.CostSourceFallback,
+	}
+	applyCostAttributionHeaders(rec, usage, attr)
+	if got := rec.Header().Get(headerMetapiCost); got != "0.003" {
+		t.Fatalf("X-Metapi-Cost = %q", got)
+	}
+	if got := rec.Header().Get(headerMetapiCostSource); got != routing.CostSourceFallback {
+		t.Fatalf("X-Metapi-Cost-Source = %q", got)
+	}
+	if got := rec.Header().Get(headerMetapiPromptTokens); got != "11" {
+		t.Fatalf("prompt header = %q", got)
+	}
+	if got := rec.Header().Get(headerMetapiCacheReadTokens); got != "5" {
+		t.Fatalf("cache read header = %q", got)
+	}
+	if got := rec.Header().Get(headerMetapiReasoningTokens); got != "7" {
+		t.Fatalf("reasoning header = %q", got)
+	}
+}
+
+func TestWriteSuccessProxyLogPersistsBillingDetails(t *testing.T) {
+	var got proxy.ProxyLogEntry
+	cfg := &UpstreamConfig{
+		LogProxy: func(_ context.Context, entry proxy.ProxyLogEntry) error {
+			got = entry
+			return nil
+		},
+	}
+	selected := &routing.SelectedChannel{
+		Channel: store.RouteChannel{ID: 9, RouteID: 3},
+		Account: store.Account{ID: 4},
+		Site:    store.Site{ID: 2, Platform: "new-api", Name: "demo"},
+	}
+	usage := ParsedUsage{
+		PromptTokens:     1000,
+		CompletionTokens: 500,
+		TotalTokens:      1500,
+		Found:            true,
+		Source:           usageSourceUpstream,
+	}
+	writeSuccessProxyLog(context.Background(), cfg, selected, nil, "gpt-4o", "/v1/chat/completions", 42, 200, false, usage, 0)
+
+	if math.Abs(got.EstimatedCost-0.003) > 1e-9 {
+		t.Fatalf("EstimatedCost = %v, want 0.003", got.EstimatedCost)
+	}
+	if got.BillingDetails == nil {
+		t.Fatal("BillingDetails is nil")
+	}
+	raw, err := json.Marshal(got.BillingDetails)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var details routing.ProxyBillingDetails
+	if err := json.Unmarshal(raw, &details); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if details.Usage.PromptTokens != 1000 || details.Usage.CompletionTokens != 500 {
+		t.Fatalf("details.usage = %+v", details.Usage)
+	}
+	if details.CostSource != routing.CostSourceFallback {
+		t.Fatalf("costSource = %q", details.CostSource)
+	}
+}
+
+func TestWriteSuccessProxyLogWithHeadersSetsResponseHeaders(t *testing.T) {
+	cfg := &UpstreamConfig{
+		LogProxy: func(_ context.Context, _ proxy.ProxyLogEntry) error { return nil },
+	}
+	selected := &routing.SelectedChannel{
+		Channel: store.RouteChannel{ID: 1},
+		Account: store.Account{ID: 1},
+		Site:    store.Site{Platform: "new-api"},
+	}
+	usage := ParsedUsage{
+		PromptTokens:     100,
+		CompletionTokens: 50,
+		TotalTokens:      150,
+		Found:            true,
+	}
+	rec := httptest.NewRecorder()
+	writeSuccessProxyLogWithHeaders(context.Background(), rec, cfg, selected, nil, "gpt-4o", "/v1/chat/completions", 10, 200, false, usage, 0)
+	if got := rec.Header().Get(headerMetapiCost); got == "" {
+		t.Fatal("expected X-Metapi-Cost header")
+	}
+	if got := rec.Header().Get(headerMetapiTotalTokens); got != "150" {
+		t.Fatalf("total tokens header = %q", got)
+	}
+}

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -76,7 +76,8 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 		unconfiguredUpstreamLogOnce.Do(func() {
 			slog.Error("proxy upstream dependencies are not configured")
 		})
-		shared.RecordProxyError(); writeJSONError(w, http.StatusServiceUnavailable, "Proxy upstream is not configured", "server_error")
+		shared.RecordProxyError()
+		writeJSONError(w, http.StatusServiceUnavailable, "Proxy upstream is not configured", "server_error")
 		return
 	}
 
@@ -497,67 +498,71 @@ func dispatchEndpointAttemptWithContinue(
 			return true, nil, false
 		}
 		// Always close the upstream body, including early client disconnects.
+		// Stream responses commit headers at first byte, so cost headers cannot
+		// be attached after the stream ends. We still persist billing_details
+		// on the proxy log for operators (admin path).
 		var streamUsage ParsedUsage
 		func() {
 			defer resp.Body.Close()
 			streamUsage = handleStreamUpstream(w, r, resp, latencyMs)
 		}()
-			recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, streamUsage)
-			writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, true, streamUsage, retry)
-			return true, nil, false
-		}
+		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, streamUsage)
+		writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, true, streamUsage, retry)
+		return true, nil, false
+	}
 
-		respBody, readErr := proxy.ReadBufferedResponseBody(resp.Body)
-		resp.Body.Close()
-		if readErr != nil {
-			slog.Warn("failed to read upstream response", "err", readErr, "latency_ms", latencyMs, "channel_id", selected.Channel.ID)
-			if !isLastEndpoint && !disableCrossProtocolFallback {
-				return false, nil, true
-			}
-			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, readErr.Error())
-			if retry < maxRetries {
-				return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error"), false
-			}
-			writeJSONError(w, 502, "Failed to read upstream response", "upstream_error")
-			return true, nil, false
+	respBody, readErr := proxy.ReadBufferedResponseBody(resp.Body)
+	resp.Body.Close()
+	if readErr != nil {
+		slog.Warn("failed to read upstream response", "err", readErr, "latency_ms", latencyMs, "channel_id", selected.Channel.ID)
+		if !isLastEndpoint && !disableCrossProtocolFallback {
+			return false, nil, true
 		}
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			rawErrText := string(respBody)
-			if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback) {
-				return false, nil, true
-			}
-			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
-			if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
-				return false, bufferedPendingUpstreamFailure(resp, respBody), false
-			}
-			relayBufferedUpstreamResponse(w, resp, respBody)
-			return true, nil, false
+		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, readErr.Error())
+		if retry < maxRetries {
+			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error"), false
 		}
-		usage := ParseUsageFromBody(respBody)
-		failure := proxy.DetectProxyFailure(string(respBody), usage.ToUsageSummary())
-		if failure != nil {
-			slog.Warn("content-based failure detected",
-				"reason", failure.Reason,
-				"status", failure.Status,
-				"model", upstreamModel,
-				"channel_id", selected.Channel.ID,
-				"latency_ms", latencyMs,
-			)
-			if shouldContinueEndpointFallback(failure.Status, failure.Reason, isLastEndpoint, disableCrossProtocolFallback) {
-				return false, nil, true
-			}
-			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, failure.Status, failure.Reason)
-			if retry < maxRetries && proxy.ShouldRetryProxyRequest(failure.Status, failure.Reason) {
-				return false, jsonPendingUpstreamFailure(failure.Status, "Upstream returned an error response", "upstream_error"), false
-			}
-			writeJSONError(w, failure.Status, "Upstream returned an error response", "upstream_error")
-			return true, nil, false
+		writeJSONError(w, 502, "Failed to read upstream response", "upstream_error")
+		return true, nil, false
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		rawErrText := string(respBody)
+		if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback) {
+			return false, nil, true
 		}
-		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, usage)
-		writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, false, usage, retry)
+		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
+		if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
+			return false, bufferedPendingUpstreamFailure(resp, respBody), false
+		}
 		relayBufferedUpstreamResponse(w, resp, respBody)
 		return true, nil, false
 	}
+	usage := ParseUsageFromBody(respBody)
+	failure := proxy.DetectProxyFailure(string(respBody), usage.ToUsageSummary())
+	if failure != nil {
+		slog.Warn("content-based failure detected",
+			"reason", failure.Reason,
+			"status", failure.Status,
+			"model", upstreamModel,
+			"channel_id", selected.Channel.ID,
+			"latency_ms", latencyMs,
+		)
+		if shouldContinueEndpointFallback(failure.Status, failure.Reason, isLastEndpoint, disableCrossProtocolFallback) {
+			return false, nil, true
+		}
+		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, failure.Status, failure.Reason)
+		if retry < maxRetries && proxy.ShouldRetryProxyRequest(failure.Status, failure.Reason) {
+			return false, jsonPendingUpstreamFailure(failure.Status, "Upstream returned an error response", "upstream_error"), false
+		}
+		writeJSONError(w, failure.Status, "Upstream returned an error response", "upstream_error")
+		return true, nil, false
+	}
+	recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, usage)
+	// Cost headers must be applied before the body is written.
+	writeSuccessProxyLogWithHeaders(r.Context(), w, cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, false, usage, retry)
+	relayBufferedUpstreamResponse(w, resp, respBody)
+	return true, nil, false
+}
 
 func shouldContinueEndpointFallback(status int, rawErrText string, isLastEndpoint bool, disableCrossProtocolFallback bool) bool {
 	if isLastEndpoint || disableCrossProtocolFallback {
@@ -716,12 +721,14 @@ func recordUpstreamSuccess(ctx context.Context, cfg *UpstreamConfig, selected *r
 	if cfg == nil || cfg.Router == nil || selected == nil {
 		return
 	}
-	// Cost remains 0 here; pricing is a separate concern (#43). Token totals
-	// are persisted via writeSuccessProxyLog for aggregation.
-	if err := cfg.Router.RecordSuccess(ctx, selected.Channel.ID, float64(latencyMs), 0, &modelName, nil); err != nil {
+	platform := ""
+	if selected.Site.Platform != "" {
+		platform = selected.Site.Platform
+	}
+	attr := buildRequestCostAttribution(modelName, platform, usage, nil, nil)
+	if err := cfg.Router.RecordSuccess(ctx, selected.Channel.ID, float64(latencyMs), attr.EstimatedCost, &modelName, nil); err != nil {
 		slog.Warn("RecordSuccess failed", "err", err, "channel_id", selected.Channel.ID, "model", modelName)
 	}
-	_ = usage
 }
 
 func writeSuccessProxyLog(
@@ -772,6 +779,15 @@ func writeSuccessProxyLog(
 			source = usageSourceUnknown
 		}
 	}
+	platform := selected.Site.Platform
+	// Pricing catalog is not wired into the hot path yet; EstimateRequestCost
+	// falls back to platform token divisor with zeroed ratios (documented).
+	// When a PricingModel becomes available, pass it as the model pointer.
+	attr := buildRequestCostAttribution(modelActual, platform, usage, nil, nil)
+	var billing any
+	if attr.BillingDetails != nil {
+		billing = attr.BillingDetails
+	}
 	entry := proxy.ProxyLogEntry{
 		RouteID:            routeIDPtr,
 		ChannelID:          &channelID,
@@ -787,6 +803,8 @@ func writeSuccessProxyLog(
 		PromptTokens:       int64Ptr(usage.PromptTokens),
 		CompletionTokens:   int64Ptr(usage.CompletionTokens),
 		TotalTokens:        int64Ptr(usage.TotalTokens),
+		EstimatedCost:      attr.EstimatedCost,
+		BillingDetails:     billing,
 		ClientFamily:       clientFamily,
 		ClientAppID:        clientAppID,
 		ClientAppName:      clientAppName,
@@ -796,6 +814,31 @@ func writeSuccessProxyLog(
 		UsageSource:        source,
 	}
 	logProxy(ctx, cfg, entry)
+}
+
+// writeSuccessProxyLogWithHeaders is like writeSuccessProxyLog but also sets
+// optional X-Metapi-Cost / token headers when the response has not been committed.
+func writeSuccessProxyLogWithHeaders(
+	ctx context.Context,
+	w http.ResponseWriter,
+	cfg *UpstreamConfig,
+	selected *routing.SelectedChannel,
+	proxyCtx *Ctx,
+	upstreamModel string,
+	upstreamPath string,
+	latencyMs int64,
+	httpStatus int,
+	isStream bool,
+	usage ParsedUsage,
+	retryCount int,
+) {
+	platform := ""
+	if selected != nil {
+		platform = selected.Site.Platform
+	}
+	attr := buildRequestCostAttribution(upstreamModel, platform, usage, nil, nil)
+	applyCostAttributionHeaders(w, usage, attr)
+	writeSuccessProxyLog(ctx, cfg, selected, proxyCtx, upstreamModel, upstreamPath, latencyMs, httpStatus, isStream, usage, retryCount)
 }
 
 func isProxyStubEnabled() bool {

--- a/handler/proxy/usage.go
+++ b/handler/proxy/usage.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/tokendancelab/metapi-go/proxy"
+	"github.com/tokendancelab/metapi-go/routing"
 )
 
 const (
@@ -13,10 +14,23 @@ const (
 )
 
 // ParsedUsage is a normalized token usage snapshot extracted from an upstream body/SSE.
+//
+// Token-type breakdown fields (cache/reasoning) are best-effort: they are filled
+// only when the upstream payload exposes them (Anthropic cache_*, OpenAI
+// prompt_tokens_details.cached_tokens, OpenAI completion_tokens_details.reasoning_tokens,
+// Gemini cachedContentTokenCount / thoughtsTokenCount). Missing fields stay 0.
 type ParsedUsage struct {
-	PromptTokens     int64
-	CompletionTokens int64
-	TotalTokens      int64
+	PromptTokens        int64
+	CompletionTokens    int64
+	TotalTokens         int64
+	CacheReadTokens     int64
+	CacheCreationTokens int64
+	ReasoningTokens     int64
+	// PromptTokensIncludeCache:
+	//   true  → prompt/input tokens already include cache tokens (typical OpenAI/Anthropic)
+	//   false → prompt tokens exclude cache (rare; set only when upstream is known exclusive)
+	//   nil   → unknown; cost builder treats as include (conservative billable split)
+	PromptTokensIncludeCache *bool
 	// Source is "upstream" when any token field was present, otherwise "unknown".
 	Source string
 	Found  bool
@@ -28,6 +42,18 @@ func (u ParsedUsage) ToUsageSummary() *proxy.UsageSummary {
 		PromptTokens:     int(u.PromptTokens),
 		CompletionTokens: int(u.CompletionTokens),
 		TotalTokens:      int(u.TotalTokens),
+	}
+}
+
+// ToUsageForCost maps ParsedUsage into the routing cost calculator input.
+func (u ParsedUsage) ToUsageForCost() routing.UsageForCost {
+	return routing.UsageForCost{
+		PromptTokens:             u.PromptTokens,
+		CompletionTokens:         u.CompletionTokens,
+		TotalTokens:              u.TotalTokens,
+		CacheReadTokens:          u.CacheReadTokens,
+		CacheCreationTokens:      u.CacheCreationTokens,
+		PromptTokensIncludeCache: u.PromptTokensIncludeCache,
 	}
 }
 
@@ -86,6 +112,24 @@ func mergeUsagePreferLater(prev, next ParsedUsage) ParsedUsage {
 		out.CompletionTokens = next.CompletionTokens
 	} else if !prev.Found {
 		out.CompletionTokens = next.CompletionTokens
+	}
+	if next.CacheReadTokens > 0 {
+		out.CacheReadTokens = next.CacheReadTokens
+	} else if !prev.Found {
+		out.CacheReadTokens = next.CacheReadTokens
+	}
+	if next.CacheCreationTokens > 0 {
+		out.CacheCreationTokens = next.CacheCreationTokens
+	} else if !prev.Found {
+		out.CacheCreationTokens = next.CacheCreationTokens
+	}
+	if next.ReasoningTokens > 0 {
+		out.ReasoningTokens = next.ReasoningTokens
+	} else if !prev.Found {
+		out.ReasoningTokens = next.ReasoningTokens
+	}
+	if next.PromptTokensIncludeCache != nil {
+		out.PromptTokensIncludeCache = next.PromptTokensIncludeCache
 	}
 	// Recompute total from merged prompt+completion unless the later event
 	// provides an explicit total that covers both sides (total >= sum).
@@ -166,14 +210,89 @@ func applyUsageMap(out *ParsedUsage, usage map[string]any) {
 		out.CompletionTokens = n
 		out.Found = true
 	}
-	// Optional Anthropic cache fields roll into prompt when present.
-	cacheRead, hasCacheRead := asInt64(usage["cache_read_input_tokens"])
-	cacheCreate, hasCacheCreate := asInt64(usage["cache_creation_input_tokens"])
-	if hasCacheRead || hasCacheCreate {
+	// Optional Anthropic cache fields (also accepted as top-level usage fields).
+	// Anthropic input_tokens is exclusive of cache in some versions and inclusive
+	// in others; when both are present we keep input_tokens as-is and record
+	// cache separately so billing can apply cache ratios without double-count
+	// when PromptTokensIncludeCache is true (default for Anthropic/OpenAI).
+	if n, ok := asInt64(usage["cache_read_input_tokens"]); ok {
+		out.CacheReadTokens = n
 		// Prefer explicit input_tokens when set; otherwise sum cache fields.
 		if out.PromptTokens == 0 {
-			out.PromptTokens = cacheRead + cacheCreate
+			out.PromptTokens = n
 		}
+		// Anthropic reports cache tokens separately from billable input; treat
+		// prompt as inclusive only when we had to synthesize it from cache.
+		// Default include=true for explicit input_tokens (matches TS cost builder).
+		if out.PromptTokensIncludeCache == nil {
+			include := true
+			out.PromptTokensIncludeCache = &include
+		}
+		out.Found = true
+	}
+	if n, ok := asInt64(usage["cache_creation_input_tokens"]); ok {
+		out.CacheCreationTokens = n
+		if out.PromptTokens == 0 {
+			out.PromptTokens = n
+		}
+		if out.PromptTokensIncludeCache == nil {
+			include := true
+			out.PromptTokensIncludeCache = &include
+		}
+		out.Found = true
+	}
+	// Nested Anthropic cache_creation object (newer payloads).
+	if cc, ok := usage["cache_creation"].(map[string]any); ok {
+		var sum int64
+		if n, ok := asInt64(cc["ephemeral_5m_input_tokens"]); ok {
+			sum += n
+		}
+		if n, ok := asInt64(cc["ephemeral_1h_input_tokens"]); ok {
+			sum += n
+		}
+		if sum > 0 && out.CacheCreationTokens == 0 {
+			out.CacheCreationTokens = sum
+			out.Found = true
+		}
+	}
+
+	// OpenAI prompt_tokens_details.cached_tokens (and input_tokens_details).
+	if details, ok := usage["prompt_tokens_details"].(map[string]any); ok {
+		if n, ok := asInt64(details["cached_tokens"]); ok {
+			out.CacheReadTokens = n
+			if out.PromptTokensIncludeCache == nil {
+				include := true
+				out.PromptTokensIncludeCache = &include
+			}
+			out.Found = true
+		}
+	}
+	if details, ok := usage["input_tokens_details"].(map[string]any); ok {
+		if n, ok := asInt64(details["cached_tokens"]); ok && out.CacheReadTokens == 0 {
+			out.CacheReadTokens = n
+			if out.PromptTokensIncludeCache == nil {
+				include := true
+				out.PromptTokensIncludeCache = &include
+			}
+			out.Found = true
+		}
+	}
+	// OpenAI completion_tokens_details.reasoning_tokens / output_tokens_details.
+	if details, ok := usage["completion_tokens_details"].(map[string]any); ok {
+		if n, ok := asInt64(details["reasoning_tokens"]); ok {
+			out.ReasoningTokens = n
+			out.Found = true
+		}
+	}
+	if details, ok := usage["output_tokens_details"].(map[string]any); ok {
+		if n, ok := asInt64(details["reasoning_tokens"]); ok && out.ReasoningTokens == 0 {
+			out.ReasoningTokens = n
+			out.Found = true
+		}
+	}
+	// Top-level reasoning_tokens (some gateways flatten the field).
+	if n, ok := asInt64(usage["reasoning_tokens"]); ok && out.ReasoningTokens == 0 {
+		out.ReasoningTokens = n
 		out.Found = true
 	}
 
@@ -188,6 +307,18 @@ func applyUsageMap(out *ParsedUsage, usage map[string]any) {
 	}
 	if n, ok := asInt64(usage["totalTokenCount"]); ok {
 		out.TotalTokens = n
+		out.Found = true
+	}
+	if n, ok := asInt64(usage["cachedContentTokenCount"]); ok {
+		out.CacheReadTokens = n
+		if out.PromptTokensIncludeCache == nil {
+			include := true
+			out.PromptTokensIncludeCache = &include
+		}
+		out.Found = true
+	}
+	if n, ok := asInt64(usage["thoughtsTokenCount"]); ok {
+		out.ReasoningTokens = n
 		out.Found = true
 	}
 

--- a/handler/proxy/usage_test.go
+++ b/handler/proxy/usage_test.go
@@ -42,6 +42,52 @@ func TestParseUsageFromBodyAnthropic(t *testing.T) {
 	if got.TotalTokens != 150 {
 		t.Fatalf("total = %d, want 150", got.TotalTokens)
 	}
+	if got.CacheReadTokens != 10 || got.CacheCreationTokens != 5 {
+		t.Fatalf("cache tokens = %d/%d, want 10/5", got.CacheReadTokens, got.CacheCreationTokens)
+	}
+	if got.PromptTokensIncludeCache == nil || !*got.PromptTokensIncludeCache {
+		t.Fatalf("PromptTokensIncludeCache = %v, want true", got.PromptTokensIncludeCache)
+	}
+}
+
+func TestParseUsageFromBodyOpenAICachedAndReasoning(t *testing.T) {
+	body := []byte(`{
+		"usage":{
+			"prompt_tokens":200,
+			"completion_tokens":80,
+			"total_tokens":280,
+			"prompt_tokens_details":{"cached_tokens":120},
+			"completion_tokens_details":{"reasoning_tokens":40}
+		}
+	}`)
+	got := ParseUsageFromBody(body)
+	if !got.Found {
+		t.Fatal("expected usage found")
+	}
+	if got.PromptTokens != 200 || got.CompletionTokens != 80 || got.TotalTokens != 280 {
+		t.Fatalf("usage = %+v", got)
+	}
+	if got.CacheReadTokens != 120 {
+		t.Fatalf("cache read = %d, want 120", got.CacheReadTokens)
+	}
+	if got.ReasoningTokens != 40 {
+		t.Fatalf("reasoning = %d, want 40", got.ReasoningTokens)
+	}
+}
+
+func TestParseUsageFromBodyPartialMissingFields(t *testing.T) {
+	// Partial payload: only completion side — must not invent prompt/cache.
+	body := []byte(`{"usage":{"completion_tokens":3}}`)
+	got := ParseUsageFromBody(body)
+	if !got.Found {
+		t.Fatal("expected found")
+	}
+	if got.PromptTokens != 0 || got.CacheReadTokens != 0 || got.CompletionTokens != 3 {
+		t.Fatalf("partial usage = %+v", got)
+	}
+	if got.TotalTokens != 3 {
+		t.Fatalf("total = %d, want 3", got.TotalTokens)
+	}
 }
 
 func TestParseUsageFromBodyGemini(t *testing.T) {

--- a/routing/pricing_cost.go
+++ b/routing/pricing_cost.go
@@ -39,14 +39,14 @@ const (
 // PricingModel is a normalized upstream pricing row used for cost estimation.
 // Pointer ratios distinguish "missing" from an explicit zero.
 type PricingModel struct {
-	ModelName           string
-	QuotaType           int // 0 = token-based, 1 = per-call
-	ModelRatio          float64
-	CompletionRatio     float64
-	CacheRatio          *float64
-	CacheCreationRatio  *float64
-	ModelPrice          *ModelPrice
-	EnableGroups        []string
+	ModelName          string
+	QuotaType          int // 0 = token-based, 1 = per-call
+	ModelRatio         float64
+	CompletionRatio    float64
+	CacheRatio         *float64
+	CacheCreationRatio *float64
+	ModelPrice         *ModelPrice
+	EnableGroups       []string
 }
 
 // ModelPrice is either a flat per-call price or input/output pair.
@@ -61,11 +61,11 @@ type ModelPrice struct {
 
 // UsageForCost is token usage for a single request cost estimate.
 type UsageForCost struct {
-	PromptTokens             int64
-	CompletionTokens         int64
-	TotalTokens              int64
-	CacheReadTokens          int64
-	CacheCreationTokens      int64
+	PromptTokens        int64
+	CompletionTokens    int64
+	TotalTokens         int64
+	CacheReadTokens     int64
+	CacheCreationTokens int64
 	// PromptTokensIncludeCache:
 	//   true/nil → prompt tokens already include cache tokens (subtract for billable input)
 	//   false    → prompt tokens are exclusive of cache tokens
@@ -82,20 +82,26 @@ type ProxyBillingPricingOverride struct {
 }
 
 // ProxyBillingDetails mirrors the TS ProxyBillingDetails shape (camelCase JSON).
+// CostSource / ReasoningTokens are additive operator fields for #111 and are
+// omitted when empty so older UI consumers keep working.
 type ProxyBillingDetails struct {
-	QuotaType int                    `json:"quotaType"`
-	Usage     ProxyBillingUsage      `json:"usage"`
-	Pricing   ProxyBillingPricing    `json:"pricing"`
-	Breakdown ProxyBillingBreakdown  `json:"breakdown"`
+	QuotaType int                   `json:"quotaType"`
+	Usage     ProxyBillingUsage     `json:"usage"`
+	Pricing   ProxyBillingPricing   `json:"pricing"`
+	Breakdown ProxyBillingBreakdown `json:"breakdown"`
+	// CostSource is pricing_model | fallback | zero (see CostSource* constants).
+	CostSource string `json:"costSource,omitempty"`
 }
 
 // ProxyBillingUsage is the usage section of billing details.
 type ProxyBillingUsage struct {
-	PromptTokens             int64 `json:"promptTokens"`
-	CompletionTokens         int64 `json:"completionTokens"`
-	TotalTokens              int64 `json:"totalTokens"`
-	CacheReadTokens          int64 `json:"cacheReadTokens"`
-	CacheCreationTokens      int64 `json:"cacheCreationTokens"`
+	PromptTokens        int64 `json:"promptTokens"`
+	CompletionTokens    int64 `json:"completionTokens"`
+	TotalTokens         int64 `json:"totalTokens"`
+	CacheReadTokens     int64 `json:"cacheReadTokens"`
+	CacheCreationTokens int64 `json:"cacheCreationTokens"`
+	// ReasoningTokens is operator-only (not billed separately).
+	ReasoningTokens          int64 `json:"reasoningTokens,omitempty"`
 	BillablePromptTokens     int64 `json:"billablePromptTokens"`
 	PromptTokensIncludeCache *bool `json:"promptTokensIncludeCache"`
 }
@@ -312,6 +318,124 @@ func FallbackTokenCost(totalTokens int64, platform string) float64 {
 	}
 	tokens := float64(toPositiveInt64(totalTokens))
 	return roundCost(tokens / divisor)
+}
+
+// CostEstimateSource labels how a per-request cost was produced.
+const (
+	// CostSourcePricingModel means CalculateModelUsage* ran against an explicit
+	// PricingModel (catalog row or override). Cache ratios use Claude-aware
+	// defaults when omitted.
+	CostSourcePricingModel = "pricing_model"
+	// CostSourceFallback means no pricing model was available and FallbackTokenCost
+	// was used (platform divisor; zeros for ratio fields).
+	CostSourceFallback = "fallback"
+	// CostSourceZero means usage was empty / not found; cost is 0 with zeroed
+	// token breakdown still recorded when available.
+	CostSourceZero = "zero"
+)
+
+// RequestCostAttribution is the operator-facing cost attribution package for one
+// proxy request: estimated cost + billing_details JSON + provenance.
+type RequestCostAttribution struct {
+	EstimatedCost  float64
+	BillingDetails *ProxyBillingDetails
+	// Source is one of CostSourcePricingModel / CostSourceFallback / CostSourceZero.
+	Source string
+	// ReasoningTokens is recorded for operators when upstream exposes it; it is
+	// NOT billed separately (completion cost already covers reasoning output for
+	// token-quota models). Present on the attribution envelope for headers/logs.
+	ReasoningTokens int64
+}
+
+// EstimateRequestCost builds per-request cost attribution from usage + optional
+// pricing model. Policy:
+//
+//  1. When model != nil and quota is token-based, use CalculateModelUsageBreakdown
+//     (Claude-aware cache_ratio defaults apply inside that path).
+//  2. When model is nil (or per-call with no usable price), fall back to
+//     FallbackTokenCost(totalTokens, platform) and emit a zero-ratio
+//     billing_details shell so proxy_logs always store a token-type breakdown.
+//  3. Empty usage → cost 0, source "zero", billing_details still carries zeros.
+//
+// Missing cache ratios never silently become 1.0 for Claude — that policy lives
+// in ResolveCacheRatio (see docs/analysis/cache-ratio-pricing.md).
+func EstimateRequestCost(
+	modelName string,
+	platform string,
+	usage UsageForCost,
+	model *PricingModel,
+	groupRatio map[string]float64,
+) RequestCostAttribution {
+	attr := RequestCostAttribution{}
+	hasUsage := usage.PromptTokens > 0 || usage.CompletionTokens > 0 || usage.TotalTokens > 0 ||
+		usage.CacheReadTokens > 0 || usage.CacheCreationTokens > 0
+
+	if model != nil {
+		if model.QuotaType == 1 {
+			// Per-call: cost from model price; still emit usage shell for logs.
+			cost := CalculateModelUsageCost(*model, usage, groupRatio)
+			attr.EstimatedCost = cost
+			attr.BillingDetails = buildFallbackBillingDetails(usage, cost, CostSourcePricingModel)
+			attr.Source = CostSourcePricingModel
+			return attr
+		}
+		detail := CalculateModelUsageBreakdown(*model, usage, groupRatio)
+		if detail != nil {
+			detail.CostSource = CostSourcePricingModel
+			attr.EstimatedCost = detail.Breakdown.TotalCost
+			attr.BillingDetails = detail
+			attr.Source = CostSourcePricingModel
+			return attr
+		}
+	}
+
+	if !hasUsage {
+		attr.EstimatedCost = 0
+		attr.BillingDetails = buildFallbackBillingDetails(usage, 0, CostSourceZero)
+		attr.Source = CostSourceZero
+		return attr
+	}
+
+	total := usage.TotalTokens
+	if total <= 0 {
+		total = usage.PromptTokens + usage.CompletionTokens
+	}
+	cost := FallbackTokenCost(total, platform)
+	attr.EstimatedCost = cost
+	attr.BillingDetails = buildFallbackBillingDetails(usage, cost, CostSourceFallback)
+	attr.Source = CostSourceFallback
+	return attr
+}
+
+// buildFallbackBillingDetails materializes a ProxyBillingDetails shell when no
+// full pricing model breakdown is available. Ratios are zeroed (not 1.0) so
+// operators can distinguish "unknown pricing" from "priced at input rate".
+// TotalCost is set to the fallback estimate; per-component costs stay 0.
+func buildFallbackBillingDetails(usage UsageForCost, totalCost float64, source string) *ProxyBillingDetails {
+	normalized := normalizeUsageBreakdownInput(usage)
+	return &ProxyBillingDetails{
+		QuotaType:  0,
+		Usage:      normalized,
+		CostSource: source,
+		Pricing: ProxyBillingPricing{
+			ModelRatio:         0,
+			CompletionRatio:    0,
+			CacheRatio:         0,
+			CacheCreationRatio: 0,
+			GroupRatio:         1,
+		},
+		Breakdown: ProxyBillingBreakdown{
+			InputPerMillion:         0,
+			OutputPerMillion:        0,
+			CacheReadPerMillion:     0,
+			CacheCreationPerMillion: 0,
+			InputCost:               0,
+			OutputCost:              0,
+			CacheReadCost:           0,
+			CacheCreationCost:       0,
+			TotalCost:               roundCost(totalCost),
+		},
+	}
 }
 
 // CacheAwarePerMillionRates derives input/output/cache $/M rates for catalog

--- a/routing/pricing_cost_test.go
+++ b/routing/pricing_cost_test.go
@@ -11,8 +11,8 @@ func boolPtr(v bool) *bool { return &v }
 
 func TestIsClaudeModel(t *testing.T) {
 	cases := []struct {
-		name  string
-		want  bool
+		name string
+		want bool
 	}{
 		{"claude-opus-4-7", true},
 		{"Claude-Sonnet-4", true},
@@ -310,6 +310,63 @@ func TestFallbackTokenCost(t *testing.T) {
 	}
 	if got := FallbackTokenCost(1500, "veloera"); math.Abs(got-0.0015) > 1e-9 {
 		t.Fatalf("veloera fallback=%v want 0.0015", got)
+	}
+}
+
+func TestEstimateRequestCost_WithPricingModel(t *testing.T) {
+	model := PricingModel{
+		ModelName:          "gpt-4o",
+		QuotaType:          0,
+		ModelRatio:         2.5,
+		CompletionRatio:    5,
+		CacheRatio:         ptrF(0.1),
+		CacheCreationRatio: ptrF(1.25),
+		EnableGroups:       []string{"default"},
+	}
+	attr := EstimateRequestCost("gpt-4o", "new-api", UsageForCost{
+		PromptTokens:             146638,
+		CompletionTokens:         172,
+		TotalTokens:              146810,
+		CacheReadTokens:          145692,
+		CacheCreationTokens:      945,
+		PromptTokensIncludeCache: boolPtr(true),
+	}, &model, map[string]float64{"default": 1})
+	if attr.Source != CostSourcePricingModel {
+		t.Fatalf("source=%q", attr.Source)
+	}
+	if math.Abs(attr.EstimatedCost-0.083057) > 1e-9 {
+		t.Fatalf("cost=%v", attr.EstimatedCost)
+	}
+	if attr.BillingDetails == nil || attr.BillingDetails.CostSource != CostSourcePricingModel {
+		t.Fatalf("billing details costSource missing: %+v", attr.BillingDetails)
+	}
+}
+
+func TestEstimateRequestCost_MissingModelUsesFallbackZeros(t *testing.T) {
+	attr := EstimateRequestCost("gpt-4o", "new-api", UsageForCost{
+		PromptTokens:     1000,
+		CompletionTokens: 500,
+		TotalTokens:      1500,
+	}, nil, nil)
+	if attr.Source != CostSourceFallback {
+		t.Fatalf("source=%q want fallback", attr.Source)
+	}
+	if math.Abs(attr.EstimatedCost-0.003) > 1e-9 {
+		t.Fatalf("cost=%v want 0.003", attr.EstimatedCost)
+	}
+	// Ratios must be zero (not silent 1.0) when pricing is unknown.
+	if attr.BillingDetails.Pricing.CacheRatio != 0 || attr.BillingDetails.Pricing.ModelRatio != 0 {
+		t.Fatalf("fallback pricing should zero ratios: %+v", attr.BillingDetails.Pricing)
+	}
+	if attr.BillingDetails.Usage.PromptTokens != 1000 {
+		t.Fatalf("usage not preserved: %+v", attr.BillingDetails.Usage)
+	}
+}
+
+func TestEstimateRequestCost_EmptyUsageZero(t *testing.T) {
+	attr := EstimateRequestCost("gpt-4o", "new-api", UsageForCost{}, nil, nil)
+	if attr.Source != CostSourceZero || attr.EstimatedCost != 0 {
+		t.Fatalf("attr=%+v", attr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Parse token-type breakdown from OpenAI/Anthropic/Gemini usage (prompt/completion/cache/reasoning) into `ParsedUsage`
- Build `proxy_logs.estimated_cost` + camelCase `billing_details` via `routing.EstimateRequestCost` (pricing model / platform fallback / zero)
- Preserve Claude cache_ratio policy (0.1/1.25 when missing); fallback path zeros ratios instead of silent 1.0
- Optional non-stream response headers: `X-Metapi-Cost`, `X-Metapi-Cost-Source`, token headers
- Docs: `docs/analysis/request-cost-attribution.md`

Supersedes the thinner #128 (snake_case ad-hoc map + model_ratio=1 default cost).

## Test plan
- [x] `go vet ./...`
- [x] `go test ./... -count=1 -race`
- [x] Focused: `go test ./routing/ ./handler/proxy/ -count=1`

Closes #111