### PR TITLE
feat(admin): cross-site model price comparison API #112

### DIFF
--- a/docs/analysis/cross-site-price-compare.md
+++ b/docs/analysis/cross-site-price-compare.md
@@ -1,0 +1,122 @@
+# Cross-site effective model price comparison (#112)
+
+**Date:** 2026-07-17  
+**Backlog:** [#112](https://github.com/TokenDanceLab/metapi-go/issues/112) · competitive learn L3  
+**Peers:** all-api-hub model price comparison (server-side, not extension)  
+**Code:** `routing/price_compare.go`, `handler/admin/model_price_compare.go`
+
+## Problem
+
+Operators run many relay sites/accounts. Picking a cheaper healthy channel requires
+comparing **effective** model prices across sites. all-api-hub does this in a
+browser extension; metapi-go already holds multi-site catalogs and proxy cost
+signals, so comparison belongs in the **admin API / SPA**, not an extension.
+
+## API
+
+Both paths share one handler:
+
+| Method | Path | Notes |
+|--------|------|-------|
+| GET | `/api/models/price-compare` | Canonical models-namespace path |
+| GET | `/api/stats/model-prices` | Alias under stats |
+
+### Query
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `model` | _(empty)_ | Model name or substring. Empty → top models by recent successful traffic (or availability). |
+| `days` | `30` | Observation window for proxy_logs averages (1–365). |
+| `limit` | `50` | Max rows returned (1–200). |
+| `topModels` | `12` | When `model` is empty, how many models to expand (1–50). |
+
+### Response shape
+
+```json
+{
+  "model": "gpt-4o",
+  "days": 30,
+  "limit": 50,
+  "sampleUsage": { "promptTokens": 1000, "completionTokens": 1000, "totalTokens": 2000 },
+  "items": [
+    {
+      "siteId": 1,
+      "siteName": "CheapSite",
+      "platform": "openai",
+      "model": "gpt-4o",
+      "accountId": 10,
+      "username": "ops",
+      "inputPerMillion": 1.0,
+      "outputPerMillion": 2.0,
+      "source": "billing_details",
+      "ratesSource": "billing_details",
+      "estimatedCostSample": 0.003,
+      "observedSamples": 12,
+      "configuredUnitCost": null,
+      "missingPrice": false
+    }
+  ],
+  "meta": {
+    "count": 1,
+    "modelsConsidered": 1,
+    "sources": ["billing_details", "observed", "configured", "fallback"],
+    "notes": "..."
+  }
+}
+```
+
+## Provenance (no unlabeled invented prices)
+
+`routing.BuildPriceCompareRow` resolves each candidate with explicit `source` /
+`ratesSource`:
+
+| Priority | `source` | Signal |
+|---------:|----------|--------|
+| 1 | `billing_details` | Rates/ratios recovered from `proxy_logs.billing_details` |
+| 2 | `observed` | `AVG(estimated_cost)` over successful proxy_logs in the window |
+| 3 | `configured` | `accounts.unit_cost` set by the operator |
+| 4 | `fallback` | Platform `FallbackTokenCost` + default model_ratio display rates |
+
+Rules:
+
+1. Fallback is **always labeled** (`source=fallback`, `ratesSource=fallback`).
+2. `missingPrice=true` when only fallback exists (no billing/observed/configured).
+3. UI must treat `missingPrice` as an empty/missing catalog state, not “real” list price.
+4. Sample cost uses 1k prompt + 1k completion tokens unless only unit/observed totals apply.
+
+Per-million rates:
+
+- Prefer explicit `inputPerMillion` / `outputPerMillion` from billing breakdown.
+- Else derive via `CacheAwarePerMillionRates` from recovered model/completion ratios.
+- Else default ratio rates with `ratesSource=fallback` (Claude cache defaults still apply only for cache fields, not base input).
+
+## Data sources (no new tables)
+
+| Source | Table / field |
+|--------|----------------|
+| Sites / platform | `sites` |
+| Accounts / unit cost | `accounts.unit_cost` |
+| Model presence | `model_availability` |
+| Observed cost | `proxy_logs.estimated_cost` (success only) |
+| Billing rates | `proxy_logs.billing_details` JSON |
+
+No remote scrape of vendor marketing pages. No browser extension architecture.
+
+## Admin UI
+
+Thin section on **Models** page: model query + compare table calling
+`GET /api/models/price-compare`. Empty/missing-price rows show a muted badge.
+
+Full marketplace pricing hydration (`includePricing`) remains a separate stub/gap.
+
+## Tests
+
+- `routing/price_compare_test.go` — pure aggregation provenance + sort order.
+- `handler/admin/model_price_compare_test.go` — SQLite fixtures for billing/observed/configured/fallback and both route aliases.
+
+## Out of scope
+
+- Browser extension product shape
+- Automatic re-pricing of upstream vendor contracts
+- Full remote `/api/pricing` catalog fetch / marketplace non-stub
+- Breaking existing stats APIs

--- a/docs/api.md
+++ b/docs/api.md
@@ -164,6 +164,18 @@ Trigger decision snapshot refresh.
 
 Available models by site.
 
+### GET /api/models/price-compare
+
+Cross-site effective model price comparison for operators.
+
+Query: `model` (optional name/substring), `days` (default 30), `limit` (default 50), `topModels` (default 12 when model empty).
+
+Returns `{ model, days, limit, sampleUsage, items: [{ siteId, siteName, platform, model, accountId, username, inputPerMillion, outputPerMillion, source, ratesSource, estimatedCostSample, observedSamples, configuredUnitCost, missingPrice }], meta }`.
+
+`source` is one of `billing_details` | `observed` | `configured` | `fallback`. Fallback is always labeled; `missingPrice=true` when no catalog/observed/configured signal exists.
+
+Alias: `GET /api/stats/model-prices` (same handler).
+
 ### GET /api/models/token-candidates
 
 Available token candidates for route configuration.

--- a/handler/admin/model_price_compare.go
+++ b/handler/admin/model_price_compare.go
@@ -1,0 +1,383 @@
+package admin
+
+import (
+	"encoding/json"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/routing"
+)
+
+// modelPriceCompare handles:
+//
+//	GET /api/models/price-compare?model=...&limit=...
+//	GET /api/stats/model-prices?model=...&limit=...
+//
+// Aggregates effective model prices across enabled sites/accounts using
+// billing_details rates, observed proxy_logs costs, configured unit_cost, and
+// labeled platform fallbacks. Does not invent unlabeled prices.
+func (h *statsHandler) modelPriceCompare(w http.ResponseWriter, r *http.Request) {
+	modelQ := strings.TrimSpace(r.URL.Query().Get("model"))
+	limit := clampInt(getQueryInt(r, "limit", 50), 1, 200)
+	days := clampInt(getQueryInt(r, "days", 30), 1, 365)
+	topModels := clampInt(getQueryInt(r, "topModels", 12), 1, 50)
+
+	since := time.Now().UTC().AddDate(0, 0, -(days - 1)).Format(time.RFC3339)
+
+	models := []string{}
+	if modelQ != "" {
+		models = []string{modelQ}
+	} else {
+		models = h.topModelsForPriceCompare(topModels, since)
+	}
+
+	candidates := make([]routing.PriceCompareRow, 0)
+	for _, modelName := range models {
+		inputs := h.loadPriceCompareInputs(modelName, since)
+		for _, in := range inputs {
+			row := routing.BuildPriceCompareRow(in, routing.DefaultPriceCompareSampleUsage)
+			candidates = append(candidates, row)
+		}
+	}
+
+	if modelQ != "" {
+		q := strings.ToLower(modelQ)
+		filtered := make([]routing.PriceCompareRow, 0, len(candidates))
+		for _, row := range candidates {
+			if strings.Contains(strings.ToLower(row.Model), q) {
+				filtered = append(filtered, row)
+			}
+		}
+		candidates = filtered
+	}
+
+	sorted := routing.AggregatePriceCompareRows(candidates)
+	if len(sorted) > limit {
+		sorted = sorted[:limit]
+	}
+	if sorted == nil {
+		sorted = []routing.PriceCompareRow{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"model": modelQ,
+		"days":  days,
+		"limit": limit,
+		"sampleUsage": map[string]any{
+			"promptTokens":     routing.DefaultPriceCompareSampleUsage.PromptTokens,
+			"completionTokens": routing.DefaultPriceCompareSampleUsage.CompletionTokens,
+			"totalTokens":      routing.DefaultPriceCompareSampleUsage.TotalTokens,
+		},
+		"items": sorted,
+		"meta": map[string]any{
+			"count":            len(sorted),
+			"modelsConsidered": len(models),
+			"sources": []string{
+				routing.PriceSourceBilling,
+				routing.PriceSourceObserved,
+				routing.PriceSourceConfigured,
+				routing.PriceSourceFallback,
+			},
+			"notes": "Rates/costs from billing_details, observed proxy_logs, account unit_cost, or labeled fallback. missingPrice=true means no catalog/observed/configured signal.",
+		},
+	})
+}
+
+func (h *statsHandler) topModelsForPriceCompare(limit int, since string) []string {
+	rows := queryRows(h.db, `
+		SELECT COALESCE(NULLIF(TRIM(pl.model_actual), ''), NULLIF(TRIM(pl.model_requested), ''), '') AS model,
+			COUNT(*) AS calls
+		FROM proxy_logs pl
+		WHERE pl.created_at >= ?
+			AND pl.status = 'success'
+			AND COALESCE(NULLIF(TRIM(pl.model_actual), ''), NULLIF(TRIM(pl.model_requested), ''), '') <> ''
+		GROUP BY COALESCE(NULLIF(TRIM(pl.model_actual), ''), NULLIF(TRIM(pl.model_requested), ''), '')
+		ORDER BY calls DESC
+		LIMIT ?
+	`, since, limit)
+
+	out := make([]string, 0, len(rows))
+	seen := map[string]struct{}{}
+	for _, row := range rows {
+		m := strings.TrimSpace(coerceString(row["model"]))
+		if m == "" {
+			continue
+		}
+		key := strings.ToLower(m)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, m)
+	}
+	if len(out) > 0 {
+		return out
+	}
+
+	avail := queryRows(h.db, `
+		SELECT model_name AS model, COUNT(*) AS cnt
+		FROM model_availability
+		GROUP BY model_name
+		ORDER BY cnt DESC
+		LIMIT ?
+	`, limit)
+	for _, row := range avail {
+		m := strings.TrimSpace(coerceString(row["model"]))
+		if m == "" {
+			continue
+		}
+		key := strings.ToLower(m)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, m)
+	}
+	return out
+}
+
+type observedPriceSignal struct {
+	AvgCost         float64
+	Samples         int
+	BillingDetails  string
+	ResolvedModel   string
+}
+
+func (h *statsHandler) loadPriceCompareInputs(modelName string, since string) []routing.PriceCompareInput {
+	modelName = strings.TrimSpace(modelName)
+	if modelName == "" {
+		return nil
+	}
+	like := "%" + strings.ToLower(modelName) + "%"
+
+	// Observed success costs + latest-ish billing_details for matching models.
+	obsRows := queryRows(h.db, `
+		SELECT
+			pl.account_id AS account_id,
+			COALESCE(NULLIF(TRIM(pl.model_actual), ''), NULLIF(TRIM(pl.model_requested), ''), '') AS model_name,
+			AVG(COALESCE(pl.estimated_cost, 0)) AS avg_cost,
+			COUNT(*) AS samples,
+			MAX(COALESCE(pl.billing_details, '')) AS billing_details
+		FROM proxy_logs pl
+		WHERE pl.created_at >= ?
+			AND pl.status = 'success'
+			AND COALESCE(pl.estimated_cost, 0) > 0
+			AND LOWER(COALESCE(NULLIF(TRIM(pl.model_actual), ''), NULLIF(TRIM(pl.model_requested), ''), '')) LIKE ?
+		GROUP BY pl.account_id, COALESCE(NULLIF(TRIM(pl.model_actual), ''), NULLIF(TRIM(pl.model_requested), ''), '')
+	`, since, like)
+
+	obsByAccount := map[int64]observedPriceSignal{}
+	for _, row := range obsRows {
+		accID := coerceInt64(row["accountId"])
+		if accID <= 0 {
+			continue
+		}
+		sig := observedPriceSignal{
+			AvgCost:        coerceFloat(row["avgCost"]),
+			Samples:        coerceInt(row["samples"]),
+			BillingDetails: coerceString(row["billingDetails"]),
+			ResolvedModel:  strings.TrimSpace(coerceString(row["modelName"])),
+		}
+		// Keep the highest-sample signal per account for this model filter.
+		if prev, ok := obsByAccount[accID]; ok && prev.Samples >= sig.Samples {
+			continue
+		}
+		obsByAccount[accID] = sig
+	}
+
+	// Accounts that advertise the model via availability.
+	availRows := queryRows(h.db, `
+		SELECT account_id, model_name
+		FROM model_availability
+		WHERE LOWER(model_name) LIKE ?
+	`, like)
+	availModelByAccount := map[int64]string{}
+	for _, row := range availRows {
+		accID := coerceInt64(row["accountId"])
+		if accID <= 0 {
+			continue
+		}
+		if _, ok := availModelByAccount[accID]; ok {
+			continue
+		}
+		availModelByAccount[accID] = strings.TrimSpace(coerceString(row["modelName"]))
+	}
+
+	// Active accounts on non-disabled sites.
+	accountRows := queryRows(h.db, `
+		SELECT
+			s.id AS site_id,
+			s.name AS site_name,
+			s.platform AS platform,
+			a.id AS account_id,
+			COALESCE(a.username, '') AS username,
+			a.unit_cost AS unit_cost,
+			COALESCE(a.status, '') AS account_status,
+			COALESCE(s.status, '') AS site_status
+		FROM accounts a
+		INNER JOIN sites s ON s.id = a.site_id
+		WHERE COALESCE(a.status, '') <> 'disabled'
+			AND COALESCE(s.status, '') <> 'disabled'
+		ORDER BY s.name ASC, a.id ASC
+	`)
+
+	out := make([]routing.PriceCompareInput, 0)
+	for _, row := range accountRows {
+		accID := coerceInt64(row["accountId"])
+		if accID <= 0 {
+			continue
+		}
+		obs, hasObs := obsByAccount[accID]
+		availModel, hasAvail := availModelByAccount[accID]
+		unitCost := coerceFloat(row["unitCost"])
+		hasUnit := unitCost > 0 && !math.IsNaN(unitCost)
+
+		// Include account if it has availability, observed traffic, or configured unit cost.
+		if !hasObs && !hasAvail && !hasUnit {
+			continue
+		}
+
+		resolvedModel := modelName
+		if hasAvail && availModel != "" {
+			resolvedModel = availModel
+		} else if hasObs && obs.ResolvedModel != "" {
+			resolvedModel = obs.ResolvedModel
+		}
+
+		in := routing.PriceCompareInput{
+			SiteID:    coerceInt64(row["siteId"]),
+			SiteName:  coerceString(row["siteName"]),
+			Platform:  coerceString(row["platform"]),
+			Model:     resolvedModel,
+			AccountID: accID,
+			Username:  coerceString(row["username"]),
+		}
+		if hasUnit {
+			v := unitCost
+			in.ConfiguredUnitCost = &v
+		}
+		if hasObs {
+			in.ObservedSamples = obs.Samples
+			if obs.AvgCost > 0 {
+				v := obs.AvgCost
+				in.ObservedAvgCost = &v
+			}
+			if strings.TrimSpace(obs.BillingDetails) != "" {
+				applyBillingDetailsToPriceInput(&in, obs.BillingDetails)
+			}
+		}
+		out = append(out, in)
+	}
+
+	// Empty-state: when no signals exist for this model, still return active
+	// accounts as labeled fallback rows so operators see missing-price sites.
+	if len(out) == 0 {
+		for _, row := range accountRows {
+			// Prefer active accounts for empty/missing UI.
+			if coerceString(row["accountStatus"]) != "active" {
+				continue
+			}
+			out = append(out, routing.PriceCompareInput{
+				SiteID:    coerceInt64(row["siteId"]),
+				SiteName:  coerceString(row["siteName"]),
+				Platform:  coerceString(row["platform"]),
+				Model:     modelName,
+				AccountID: coerceInt64(row["accountId"]),
+				Username:  coerceString(row["username"]),
+			})
+			if len(out) >= 50 {
+				break
+			}
+		}
+	}
+	return out
+}
+
+func applyBillingDetailsToPriceInput(in *routing.PriceCompareInput, raw string) {
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return
+	}
+	breakdown := firstMap(parsed, "breakdown", "Breakdown")
+	pricing := firstMap(parsed, "pricing", "Pricing")
+
+	if breakdown != nil {
+		if v, ok := floatFromAny(firstAny(breakdown, "inputPerMillion", "input_per_million", "InputPerMillion")); ok {
+			in.InputPerMillion = &v
+		}
+		if v, ok := floatFromAny(firstAny(breakdown, "outputPerMillion", "output_per_million", "OutputPerMillion")); ok {
+			in.OutputPerMillion = &v
+		}
+	}
+	if pricing != nil {
+		if v, ok := floatFromAny(firstAny(pricing, "modelRatio", "model_ratio", "ModelRatio")); ok {
+			in.ModelRatio = &v
+		}
+		if v, ok := floatFromAny(firstAny(pricing, "completionRatio", "completion_ratio", "CompletionRatio")); ok {
+			in.CompletionRatio = &v
+		}
+		if v, ok := floatFromAny(firstAny(pricing, "groupRatio", "group_ratio", "GroupRatio")); ok {
+			in.GroupRatio = &v
+		}
+	}
+}
+
+func firstMap(m map[string]any, keys ...string) map[string]any {
+	for _, k := range keys {
+		if v, ok := m[k]; ok {
+			if mm, ok2 := v.(map[string]any); ok2 {
+				return mm
+			}
+		}
+	}
+	return nil
+}
+
+func firstAny(m map[string]any, keys ...string) any {
+	for _, k := range keys {
+		if v, ok := m[k]; ok {
+			return v
+		}
+	}
+	return nil
+}
+
+func floatFromAny(v any) (float64, bool) {
+	if v == nil {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float64:
+		if math.IsNaN(n) || math.IsInf(n, 0) {
+			return 0, false
+		}
+		return n, true
+	case float32:
+		f := float64(n)
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return 0, false
+		}
+		return f, true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case json.Number:
+		f, err := n.Float64()
+		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
+			return 0, false
+		}
+		return f, true
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(n), 64)
+		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
+			return 0, false
+		}
+		return f, true
+	default:
+		return 0, false
+	}
+}

--- a/handler/admin/model_price_compare.go
+++ b/handler/admin/model_price_compare.go
@@ -27,7 +27,7 @@ func (h *statsHandler) modelPriceCompare(w http.ResponseWriter, r *http.Request)
 
 	since := time.Now().UTC().AddDate(0, 0, -(days - 1)).Format(time.RFC3339)
 
-	models := []string{}
+	var models []string
 	if modelQ != "" {
 		models = []string{modelQ}
 	} else {

--- a/handler/admin/model_price_compare_test.go
+++ b/handler/admin/model_price_compare_test.go
@@ -1,0 +1,225 @@
+package admin
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestStats_SQLiteModelPriceCompare_ObservedAndConfigured(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Two sites / accounts for the same model with different signals.
+	_, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "CheapSite", "https://cheap.example.test", "openai", now, now)
+	if err != nil {
+		t.Fatalf("insert site1: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "ConfiguredSite", "https://cfg.example.test", "newapi", now, now)
+	if err != nil {
+		t.Fatalf("insert site2: %v", err)
+	}
+
+	var cheapSiteID, cfgSiteID int64
+	if err := db.Get(&cheapSiteID, "SELECT id FROM sites WHERE name = ?", "CheapSite"); err != nil {
+		t.Fatalf("cheap site id: %v", err)
+	}
+	if err := db.Get(&cfgSiteID, "SELECT id FROM sites WHERE name = ?", "ConfiguredSite"); err != nil {
+		t.Fatalf("cfg site id: %v", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, balance, unit_cost, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, NULL, 0, ?, ?)`, cheapSiteID, "cheap-user", "sk-cheap", 10.0, now, now)
+	if err != nil {
+		t.Fatalf("insert account1: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, balance, unit_cost, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?, 0, ?, ?)`, cfgSiteID, "cfg-user", "sk-cfg", 10.0, 0.55, now, now)
+	if err != nil {
+		t.Fatalf("insert account2: %v", err)
+	}
+
+	var cheapAccID, cfgAccID int64
+	if err := db.Get(&cheapAccID, "SELECT id FROM accounts WHERE username = ?", "cheap-user"); err != nil {
+		t.Fatalf("cheap acc: %v", err)
+	}
+	if err := db.Get(&cfgAccID, "SELECT id FROM accounts WHERE username = ?", "cfg-user"); err != nil {
+		t.Fatalf("cfg acc: %v", err)
+	}
+
+	// Availability for both accounts.
+	_, err = db.Exec(`INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at)
+		VALUES (?, ?, 1, 0, ?)`, cheapAccID, "gpt-price-compare", now)
+	if err != nil {
+		t.Fatalf("avail1: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at)
+		VALUES (?, ?, 1, 0, ?)`, cfgAccID, "gpt-price-compare", now)
+	if err != nil {
+		t.Fatalf("avail2: %v", err)
+	}
+
+	// Observed cheaper cost on CheapSite.
+	billing := `{"breakdown":{"inputPerMillion":1.0,"outputPerMillion":2.0},"pricing":{"model_ratio":0.5,"completion_ratio":2,"source":"test"}}`
+	_, err = db.Exec(`INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, total_tokens, estimated_cost, billing_details, created_at)
+		VALUES (?, ?, ?, 'success', ?, ?, ?, ?)`, cheapAccID, "gpt-price-compare", "gpt-price-compare", 2000, 0.12, billing, now)
+	if err != nil {
+		t.Fatalf("proxy log: %v", err)
+	}
+
+	// Primary path.
+	resp := doGet(t, r, "/api/models/price-compare?model=gpt-price-compare")
+	if resp.Code != 200 {
+		t.Fatalf("price-compare status %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	items, ok := body["items"].([]any)
+	if !ok || len(items) < 2 {
+		t.Fatalf("items=%#v, want >=2", body["items"])
+	}
+
+	// Alias path should work too.
+	resp2 := doGet(t, r, "/api/stats/model-prices?model=gpt-price-compare")
+	if resp2.Code != 200 {
+		t.Fatalf("model-prices status %d: %s", resp2.Code, resp2.Body.String())
+	}
+
+	// First item should prefer billing-derived rates on CheapSite.
+	first := items[0].(map[string]any)
+	if first["siteName"] != "CheapSite" {
+		// Sort is by estimatedCostSample; billing sample is tiny (1k/1k * rates).
+		// Accept either CheapSite first if cheaper, else check both present.
+		t.Logf("first site=%v source=%v sample=%v", first["siteName"], first["source"], first["estimatedCostSample"])
+	}
+
+	bySite := map[string]map[string]any{}
+	for _, raw := range items {
+		item := raw.(map[string]any)
+		bySite[item["siteName"].(string)] = item
+	}
+	cheap, ok := bySite["CheapSite"]
+	if !ok {
+		t.Fatalf("CheapSite missing: %#v", bySite)
+	}
+	cfg, ok := bySite["ConfiguredSite"]
+	if !ok {
+		t.Fatalf("ConfiguredSite missing: %#v", bySite)
+	}
+
+	if cheap["source"] != "billing_details" {
+		t.Fatalf("CheapSite source=%v want billing_details", cheap["source"])
+	}
+	if cheap["inputPerMillion"].(float64) != 1.0 || cheap["outputPerMillion"].(float64) != 2.0 {
+		t.Fatalf("CheapSite rates=%v/%v", cheap["inputPerMillion"], cheap["outputPerMillion"])
+	}
+	if cheap["missingPrice"] == true {
+		t.Fatal("CheapSite should not be missingPrice")
+	}
+
+	if cfg["source"] != "configured" {
+		t.Fatalf("ConfiguredSite source=%v want configured", cfg["source"])
+	}
+	if cfg["estimatedCostSample"].(float64) != 0.55 {
+		t.Fatalf("ConfiguredSite sample=%v want 0.55", cfg["estimatedCostSample"])
+	}
+	if cfg["missingPrice"] == true {
+		t.Fatal("ConfiguredSite should not be missingPrice")
+	}
+}
+
+func TestStats_SQLiteModelPriceCompare_EmptyModelUsesTopTraffic(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	_, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "TopSite", "https://top.example.test", "openai", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	var siteID int64
+	if err := db.Get(&siteID, "SELECT id FROM sites WHERE name = ?", "TopSite"); err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, balance, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, 0, ?, ?)`, siteID, "top-user", "sk-top", 1.0, now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	var accID int64
+	if err := db.Get(&accID, "SELECT id FROM accounts WHERE username = ?", "top-user"); err != nil {
+		t.Fatalf("acc id: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, total_tokens, estimated_cost, created_at)
+		VALUES (?, ?, ?, 'success', ?, ?, ?)`, accID, "top-model-a", "top-model-a", 100, 0.2, now)
+	if err != nil {
+		t.Fatalf("log: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/models/price-compare?limit=10")
+	if resp.Code != 200 {
+		t.Fatalf("status %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	items, ok := body["items"].([]any)
+	if !ok || len(items) == 0 {
+		t.Fatalf("items empty: %#v", body)
+	}
+	first := items[0].(map[string]any)
+	if first["model"] != "top-model-a" {
+		t.Fatalf("model=%v want top-model-a", first["model"])
+	}
+	if first["source"] != "observed" {
+		t.Fatalf("source=%v want observed", first["source"])
+	}
+}
+
+func TestStats_SQLiteModelPriceCompare_FallbackLabeledMissing(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	_, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "EmptySite", "https://empty.example.test", "openai", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	var siteID int64
+	if err := db.Get(&siteID, "SELECT id FROM sites WHERE name = ?", "EmptySite"); err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, balance, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, 0, ?, ?)`, siteID, "empty-user", "sk-empty", 1.0, now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/models/price-compare?model=never-seen-model")
+	if resp.Code != 200 {
+		t.Fatalf("status %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	items, ok := body["items"].([]any)
+	if !ok || len(items) == 0 {
+		t.Fatalf("expected fallback rows for empty state, got %#v", body["items"])
+	}
+	item := items[0].(map[string]any)
+	if item["source"] != "fallback" {
+		t.Fatalf("source=%v want fallback", item["source"])
+	}
+	if item["missingPrice"] != true {
+		t.Fatalf("missingPrice=%v want true", item["missingPrice"])
+	}
+	if item["ratesSource"] != "fallback" {
+		t.Fatalf("ratesSource=%v want fallback", item["ratesSource"])
+	}
+}

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -23,9 +23,13 @@ func RegisterStatsRoutes(r chi.Router, db *sqlx.DB) {
 	r.Get("/api/stats/site-distribution", handler.siteDistribution)
 	r.Get("/api/stats/site-trend", handler.siteTrend)
 	r.Get("/api/stats/model-by-site", handler.modelBySite)
+	// Cross-site effective model price comparison (admin).
+	// Both paths are registered for discoverability; they share one handler.
+	r.Get("/api/stats/model-prices", handler.modelPriceCompare)
 
 	// Model routes under /api/models
 	r.Get("/api/models/marketplace", handler.marketplace)
+	r.Get("/api/models/price-compare", handler.modelPriceCompare)
 	r.Get("/api/models/token-candidates", handler.tokenCandidates)
 	r.Post("/api/models/check/{accountId}", handler.modelCheck)
 	r.Post("/api/models/probe", handler.modelProbe)

--- a/routing/price_compare.go
+++ b/routing/price_compare.go
@@ -1,7 +1,6 @@
 package routing
 
 import (
-	"math"
 	"strings"
 )
 
@@ -275,7 +274,7 @@ func clonePositiveFloat(v *float64) *float64 {
 }
 
 func maxIntNonNeg(v int) int {
-	if v < 0 || math.IsNaN(float64(v)) {
+	if v < 0 {
 		return 0
 	}
 	return v

--- a/routing/price_compare.go
+++ b/routing/price_compare.go
@@ -1,0 +1,282 @@
+package routing
+
+import (
+	"math"
+	"strings"
+)
+
+// Price comparison provenance labels. Callers must not invent unlabeled prices.
+const (
+	// PriceSourceObserved uses successful proxy_logs estimated_cost averages.
+	PriceSourceObserved = "observed"
+	// PriceSourceConfigured uses accounts.unit_cost set by operators.
+	PriceSourceConfigured = "configured"
+	// PriceSourceBilling uses rates/ratios recovered from proxy_logs.billing_details.
+	PriceSourceBilling = "billing_details"
+	// PriceSourceFallback uses platform FallbackTokenCost / default model ratios.
+	// Always label invented defaults with this source (or ratesSource).
+	PriceSourceFallback = "fallback"
+)
+
+// DefaultPriceCompareSampleUsage is the sample window used for estimatedCostSample
+// when the operator does not supply custom usage (1k in + 1k out).
+var DefaultPriceCompareSampleUsage = UsageForCost{
+	PromptTokens:     1000,
+	CompletionTokens: 1000,
+	TotalTokens:      2000,
+}
+
+// PriceCompareInput is one site/account/model candidate for aggregation.
+// Pointers distinguish missing values from explicit zeros.
+type PriceCompareInput struct {
+	SiteID    int64
+	SiteName  string
+	Platform  string
+	Model     string
+	AccountID int64
+	Username  string
+
+	// ObservedAvgCost is AVG(estimated_cost) over successful proxy logs.
+	ObservedAvgCost *float64
+	ObservedSamples int
+
+	// ConfiguredUnitCost is accounts.unit_cost when set by the operator.
+	ConfiguredUnitCost *float64
+
+	// Optional rates recovered from billing_details breakdown.
+	InputPerMillion  *float64
+	OutputPerMillion *float64
+
+	// Optional ratios recovered from billing_details pricing section.
+	ModelRatio      *float64
+	CompletionRatio *float64
+	GroupRatio      *float64
+}
+
+// PriceCompareRow is one cross-site effective price candidate for admin UX.
+type PriceCompareRow struct {
+	SiteID               int64   `json:"siteId"`
+	SiteName             string  `json:"siteName"`
+	Platform             string  `json:"platform"`
+	Model                string  `json:"model"`
+	AccountID            int64   `json:"accountId"`
+	Username             string  `json:"username,omitempty"`
+	InputPerMillion      float64 `json:"inputPerMillion"`
+	OutputPerMillion     float64 `json:"outputPerMillion"`
+	Source               string  `json:"source"`
+	RatesSource          string  `json:"ratesSource"`
+	EstimatedCostSample  float64 `json:"estimatedCostSample"`
+	ObservedSamples      int     `json:"observedSamples,omitempty"`
+	ConfiguredUnitCost   *float64 `json:"configuredUnitCost,omitempty"`
+	MissingPrice         bool    `json:"missingPrice"`
+}
+
+// BuildPriceCompareRow resolves effective rates + sample cost without inventing
+// unlabeled prices. Provenance priority for estimatedCostSample:
+//
+//  1. billing_details rates/ratios → source=billing_details
+//  2. observed avg estimated_cost → source=observed
+//  3. configured account unit_cost → source=configured
+//  4. platform FallbackTokenCost + default ratios → source=fallback
+//
+// Per-million rates prefer explicit billing rates, then derived ratios, then
+// CacheAwarePerMillionRates defaults (ratesSource=fallback).
+func BuildPriceCompareRow(in PriceCompareInput, sample UsageForCost) PriceCompareRow {
+	model := strings.TrimSpace(in.Model)
+	platform := strings.TrimSpace(in.Platform)
+	if sample.TotalTokens <= 0 && sample.PromptTokens <= 0 && sample.CompletionTokens <= 0 {
+		sample = DefaultPriceCompareSampleUsage
+	}
+
+	row := PriceCompareRow{
+		SiteID:             in.SiteID,
+		SiteName:           strings.TrimSpace(in.SiteName),
+		Platform:           platform,
+		Model:              model,
+		AccountID:          in.AccountID,
+		Username:           strings.TrimSpace(in.Username),
+		ObservedSamples:    maxIntNonNeg(in.ObservedSamples),
+		ConfiguredUnitCost: clonePositiveFloat(in.ConfiguredUnitCost),
+		Source:             PriceSourceFallback,
+		RatesSource:        PriceSourceFallback,
+		MissingPrice:       true,
+	}
+
+	inputPerM, outputPerM, ratesSource := resolvePriceCompareRates(in, model)
+	row.InputPerMillion = inputPerM
+	row.OutputPerMillion = outputPerM
+	row.RatesSource = ratesSource
+
+	// Prefer billing-derived sample cost when rates/ratios exist.
+	if ratesSource == PriceSourceBilling {
+		pm := PricingModel{
+			ModelName:       model,
+			QuotaType:       0,
+			ModelRatio:      1,
+			CompletionRatio: 1,
+		}
+		if in.ModelRatio != nil && isFiniteFloat(*in.ModelRatio) && *in.ModelRatio > 0 {
+			pm.ModelRatio = *in.ModelRatio
+		}
+		if in.CompletionRatio != nil && isFiniteFloat(*in.CompletionRatio) && *in.CompletionRatio > 0 {
+			pm.CompletionRatio = *in.CompletionRatio
+		}
+		group := map[string]float64{"default": 1}
+		if in.GroupRatio != nil && isFiniteFloat(*in.GroupRatio) && *in.GroupRatio > 0 {
+			group["default"] = *in.GroupRatio
+		}
+		// When only absolute $/M rates are known, rebuild cost from rates directly.
+		if in.InputPerMillion != nil || in.OutputPerMillion != nil {
+			row.EstimatedCostSample = estimateCostFromPerMillion(inputPerM, outputPerM, sample)
+		} else {
+			row.EstimatedCostSample = CalculateModelUsageCost(pm, sample, group)
+		}
+		row.Source = PriceSourceBilling
+		row.MissingPrice = false
+		return row
+	}
+
+	if in.ObservedAvgCost != nil && isFiniteFloat(*in.ObservedAvgCost) && *in.ObservedAvgCost > 0 {
+		row.EstimatedCostSample = roundCost(*in.ObservedAvgCost)
+		row.Source = PriceSourceObserved
+		row.MissingPrice = false
+		return row
+	}
+
+	if in.ConfiguredUnitCost != nil && isFiniteFloat(*in.ConfiguredUnitCost) && *in.ConfiguredUnitCost > 0 {
+		row.EstimatedCostSample = roundCost(*in.ConfiguredUnitCost)
+		row.Source = PriceSourceConfigured
+		row.MissingPrice = false
+		return row
+	}
+
+	// Last resort: platform token divisor + default ratio rates (already filled).
+	total := sample.TotalTokens
+	if total <= 0 {
+		total = sample.PromptTokens + sample.CompletionTokens
+	}
+	fallback := FallbackTokenCost(total, platform)
+	// Prefer ratio-based sample when defaults produce a positive cost.
+	pm := PricingModel{ModelName: model, QuotaType: 0, ModelRatio: 1, CompletionRatio: 1}
+	ratioCost := CalculateModelUsageCost(pm, sample, map[string]float64{"default": 1})
+	if ratioCost > 0 {
+		row.EstimatedCostSample = ratioCost
+	} else {
+		row.EstimatedCostSample = fallback
+	}
+	row.Source = PriceSourceFallback
+	// Fallback is always "known" as an estimate, but operators must treat it as
+	// non-catalog. missingPrice stays true so UI can mark empty/missing states.
+	row.MissingPrice = true
+	return row
+}
+
+// AggregatePriceCompareRows sorts cheaper first, then by site name / account id.
+// Rows with missingPrice sort after priced rows with the same cost.
+func AggregatePriceCompareRows(rows []PriceCompareRow) []PriceCompareRow {
+	if len(rows) == 0 {
+		return []PriceCompareRow{}
+	}
+	out := make([]PriceCompareRow, len(rows))
+	copy(out, rows)
+	// Stable hand-rolled sort keeps the routing package free of sort.Slice
+	// allocation patterns in tiny unit tests; for N site rows this is fine.
+	for i := 0; i < len(out); i++ {
+		for j := i + 1; j < len(out); j++ {
+			if priceCompareLess(out[j], out[i]) {
+				out[i], out[j] = out[j], out[i]
+			}
+		}
+	}
+	return out
+}
+
+func priceCompareLess(a, b PriceCompareRow) bool {
+	if a.MissingPrice != b.MissingPrice {
+		return !a.MissingPrice && b.MissingPrice
+	}
+	if a.EstimatedCostSample != b.EstimatedCostSample {
+		return a.EstimatedCostSample < b.EstimatedCostSample
+	}
+	if a.SiteName != b.SiteName {
+		return strings.ToLower(a.SiteName) < strings.ToLower(b.SiteName)
+	}
+	if a.AccountID != b.AccountID {
+		return a.AccountID < b.AccountID
+	}
+	return a.Model < b.Model
+}
+
+func resolvePriceCompareRates(in PriceCompareInput, model string) (inputPerM, outputPerM float64, ratesSource string) {
+	if in.InputPerMillion != nil && in.OutputPerMillion != nil &&
+		isFiniteFloat(*in.InputPerMillion) && isFiniteFloat(*in.OutputPerMillion) &&
+		*in.InputPerMillion >= 0 && *in.OutputPerMillion >= 0 {
+		return roundCost(*in.InputPerMillion), roundCost(*in.OutputPerMillion), PriceSourceBilling
+	}
+
+	if (in.ModelRatio != nil && isFiniteFloat(*in.ModelRatio) && *in.ModelRatio > 0) ||
+		(in.CompletionRatio != nil && isFiniteFloat(*in.CompletionRatio) && *in.CompletionRatio > 0) {
+		pm := PricingModel{
+			ModelName:       model,
+			QuotaType:       0,
+			ModelRatio:      1,
+			CompletionRatio: 1,
+		}
+		if in.ModelRatio != nil && isFiniteFloat(*in.ModelRatio) && *in.ModelRatio > 0 {
+			pm.ModelRatio = *in.ModelRatio
+		}
+		if in.CompletionRatio != nil && isFiniteFloat(*in.CompletionRatio) && *in.CompletionRatio > 0 {
+			pm.CompletionRatio = *in.CompletionRatio
+		}
+		groupMul := 1.0
+		if in.GroupRatio != nil && isFiniteFloat(*in.GroupRatio) && *in.GroupRatio > 0 {
+			groupMul = *in.GroupRatio
+		}
+		inM, outM, _, _ := CacheAwarePerMillionRates(pm, groupMul)
+		return inM, outM, PriceSourceBilling
+	}
+
+	// Explicit single-sided rates still count as billing when one side is known.
+	if in.InputPerMillion != nil && isFiniteFloat(*in.InputPerMillion) && *in.InputPerMillion >= 0 {
+		out := 0.0
+		if in.OutputPerMillion != nil && isFiniteFloat(*in.OutputPerMillion) && *in.OutputPerMillion >= 0 {
+			out = *in.OutputPerMillion
+		}
+		return roundCost(*in.InputPerMillion), roundCost(out), PriceSourceBilling
+	}
+	if in.OutputPerMillion != nil && isFiniteFloat(*in.OutputPerMillion) && *in.OutputPerMillion >= 0 {
+		return 0, roundCost(*in.OutputPerMillion), PriceSourceBilling
+	}
+
+	pm := PricingModel{ModelName: model, QuotaType: 0, ModelRatio: 1, CompletionRatio: 1}
+	inM, outM, _, _ := CacheAwarePerMillionRates(pm, 1)
+	return inM, outM, PriceSourceFallback
+}
+
+func estimateCostFromPerMillion(inputPerM, outputPerM float64, sample UsageForCost) float64 {
+	prompt := float64(toPositiveInt64(sample.PromptTokens))
+	completion := float64(toPositiveInt64(sample.CompletionTokens))
+	if prompt == 0 && completion == 0 {
+		total := float64(toPositiveInt64(sample.TotalTokens))
+		// Split unknown totals evenly so sample remains non-zero.
+		prompt = total / 2
+		completion = total / 2
+	}
+	cost := (prompt/1_000_000)*inputPerM + (completion/1_000_000)*outputPerM
+	return roundCost(cost)
+}
+
+func clonePositiveFloat(v *float64) *float64 {
+	if v == nil || !isFiniteFloat(*v) || *v <= 0 {
+		return nil
+	}
+	x := *v
+	return &x
+}
+
+func maxIntNonNeg(v int) int {
+	if v < 0 || math.IsNaN(float64(v)) {
+		return 0
+	}
+	return v
+}

--- a/routing/price_compare_test.go
+++ b/routing/price_compare_test.go
@@ -1,0 +1,171 @@
+package routing
+
+import (
+	"math"
+	"testing"
+)
+
+func TestBuildPriceCompareRow_BillingRatesPreferred(t *testing.T) {
+	inRate := 3.0
+	outRate := 15.0
+	in := PriceCompareInput{
+		SiteID:           1,
+		SiteName:         "Alpha",
+		Platform:         "newapi",
+		Model:            "gpt-4o",
+		AccountID:        10,
+		Username:         "ops",
+		InputPerMillion:  &inRate,
+		OutputPerMillion: &outRate,
+	}
+	// Also supply observed/configured so we prove billing wins.
+	obs := 9.9
+	cfg := 8.8
+	in.ObservedAvgCost = &obs
+	in.ConfiguredUnitCost = &cfg
+
+	row := BuildPriceCompareRow(in, DefaultPriceCompareSampleUsage)
+	if row.Source != PriceSourceBilling {
+		t.Fatalf("source=%q want %q", row.Source, PriceSourceBilling)
+	}
+	if row.RatesSource != PriceSourceBilling {
+		t.Fatalf("ratesSource=%q want %q", row.RatesSource, PriceSourceBilling)
+	}
+	if row.MissingPrice {
+		t.Fatal("billing rates should not be missingPrice")
+	}
+	// 1000/1e6 * 3 + 1000/1e6 * 15 = 0.018
+	if math.Abs(row.EstimatedCostSample-0.018) > 1e-9 {
+		t.Fatalf("estimatedCostSample=%v want 0.018", row.EstimatedCostSample)
+	}
+	if row.InputPerMillion != 3 || row.OutputPerMillion != 15 {
+		t.Fatalf("rates = %v/%v", row.InputPerMillion, row.OutputPerMillion)
+	}
+}
+
+func TestBuildPriceCompareRow_ObservedBeforeConfiguredAndFallback(t *testing.T) {
+	obs := 0.42
+	cfg := 0.11
+	in := PriceCompareInput{
+		SiteID:             2,
+		SiteName:           "Beta",
+		Platform:           "openai",
+		Model:              "claude-sonnet-4",
+		AccountID:          20,
+		ObservedAvgCost:    &obs,
+		ObservedSamples:    7,
+		ConfiguredUnitCost: &cfg,
+	}
+	row := BuildPriceCompareRow(in, DefaultPriceCompareSampleUsage)
+	if row.Source != PriceSourceObserved {
+		t.Fatalf("source=%q want observed", row.Source)
+	}
+	if row.EstimatedCostSample != 0.42 {
+		t.Fatalf("sample=%v want 0.42", row.EstimatedCostSample)
+	}
+	if row.ObservedSamples != 7 {
+		t.Fatalf("samples=%d", row.ObservedSamples)
+	}
+	if row.MissingPrice {
+		t.Fatal("observed should not be missing")
+	}
+	// Rates still fall back to default model_ratio=1 display rates.
+	if row.RatesSource != PriceSourceFallback {
+		t.Fatalf("ratesSource=%q want fallback", row.RatesSource)
+	}
+}
+
+func TestBuildPriceCompareRow_ConfiguredThenFallback(t *testing.T) {
+	cfg := 0.25
+	in := PriceCompareInput{
+		SiteID:             3,
+		SiteName:           "Gamma",
+		Platform:           "openai",
+		Model:              "gpt-4o-mini",
+		AccountID:          30,
+		ConfiguredUnitCost: &cfg,
+	}
+	row := BuildPriceCompareRow(in, DefaultPriceCompareSampleUsage)
+	if row.Source != PriceSourceConfigured {
+		t.Fatalf("source=%q want configured", row.Source)
+	}
+	if row.EstimatedCostSample != 0.25 {
+		t.Fatalf("sample=%v", row.EstimatedCostSample)
+	}
+	if row.MissingPrice {
+		t.Fatal("configured should not be missing")
+	}
+
+	// No signals → labeled fallback + missingPrice=true.
+	empty := PriceCompareInput{
+		SiteID:   4,
+		SiteName: "Delta",
+		Platform: "openai",
+		Model:    "gpt-4o-mini",
+	}
+	fb := BuildPriceCompareRow(empty, DefaultPriceCompareSampleUsage)
+	if fb.Source != PriceSourceFallback {
+		t.Fatalf("source=%q want fallback", fb.Source)
+	}
+	if !fb.MissingPrice {
+		t.Fatal("fallback must set missingPrice so UI can flag empty catalog data")
+	}
+	if fb.EstimatedCostSample <= 0 {
+		t.Fatalf("fallback sample should still be positive estimate, got %v", fb.EstimatedCostSample)
+	}
+	if fb.RatesSource != PriceSourceFallback {
+		t.Fatalf("ratesSource=%q", fb.RatesSource)
+	}
+}
+
+func TestBuildPriceCompareRow_BillingRatiosDeriveRates(t *testing.T) {
+	mr := 2.5
+	cr := 4.0
+	in := PriceCompareInput{
+		SiteID:          5,
+		SiteName:        "RatioSite",
+		Platform:        "newapi",
+		Model:           "gpt-x",
+		AccountID:       50,
+		ModelRatio:      &mr,
+		CompletionRatio: &cr,
+	}
+	row := BuildPriceCompareRow(in, DefaultPriceCompareSampleUsage)
+	if row.Source != PriceSourceBilling || row.RatesSource != PriceSourceBilling {
+		t.Fatalf("source=%q ratesSource=%q", row.Source, row.RatesSource)
+	}
+	// input = 2.5*2=5; output=2.5*4*2=20
+	if row.InputPerMillion != 5 || row.OutputPerMillion != 20 {
+		t.Fatalf("rates=%v/%v want 5/20", row.InputPerMillion, row.OutputPerMillion)
+	}
+	// sample 1k/1k → 0.005 + 0.02 = 0.025
+	if math.Abs(row.EstimatedCostSample-0.025) > 1e-9 {
+		t.Fatalf("sample=%v want 0.025", row.EstimatedCostSample)
+	}
+}
+
+func TestAggregatePriceCompareRows_SortCheapestFirstMissingLast(t *testing.T) {
+	rows := []PriceCompareRow{
+		{SiteName: "B", EstimatedCostSample: 0.5, MissingPrice: false, AccountID: 2},
+		{SiteName: "A", EstimatedCostSample: 0.1, MissingPrice: true, AccountID: 1},
+		{SiteName: "C", EstimatedCostSample: 0.2, MissingPrice: false, AccountID: 3},
+		{SiteName: "A", EstimatedCostSample: 0.2, MissingPrice: false, AccountID: 4},
+	}
+	got := AggregatePriceCompareRows(rows)
+	if len(got) != 4 {
+		t.Fatalf("len=%d", len(got))
+	}
+	// Priced first by cost: A/0.2, C/0.2, B/0.5, then missing A/0.1
+	if got[0].SiteName != "A" || got[0].AccountID != 4 {
+		t.Fatalf("first=%+v", got[0])
+	}
+	if got[1].SiteName != "C" {
+		t.Fatalf("second=%+v", got[1])
+	}
+	if got[2].SiteName != "B" {
+		t.Fatalf("third=%+v", got[2])
+	}
+	if !got[3].MissingPrice || got[3].SiteName != "A" {
+		t.Fatalf("last should be missing A, got %+v", got[3])
+	}
+}

--- a/web/api.ts
+++ b/web/api.ts
@@ -1459,6 +1459,23 @@ export const api = {
       timeoutMs: options?.refresh ? 45_000 : 15_000,
     });
   },
+  /** Cross-site effective model price comparison (#112). */
+  getModelPriceCompare: (options?: {
+    model?: string;
+    days?: number;
+    limit?: number;
+    topModels?: number;
+  }) => {
+    const params = new URLSearchParams();
+    if (options?.model) params.set("model", options.model);
+    if (options?.days != null) params.set("days", String(options.days));
+    if (options?.limit != null) params.set("limit", String(options.limit));
+    if (options?.topModels != null) params.set("topModels", String(options.topModels));
+    const query = params.toString();
+    return request(`/api/models/price-compare${query ? `?${query}` : ""}`, {
+      timeoutMs: 20_000,
+    });
+  },
   getModelTokenCandidates: () => request("/api/models/token-candidates"),
 
   // Simple chat test from admin panel

--- a/web/pages/Models.tsx
+++ b/web/pages/Models.tsx
@@ -706,6 +706,111 @@ export default function Models() {
           </div>
         </div>
 
+        {/* Cross-site price compare (#112) */}
+        <div className="card" style={{ padding: 14, marginBottom: 16 }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap', marginBottom: 10 }}>
+            <div>
+              <div style={{ fontSize: 14, fontWeight: 600 }}>{tr('跨站有效价格对比')}</div>
+              <div style={{ fontSize: 12, color: 'var(--color-text-muted)', marginTop: 2 }}>
+                {tr('基于账单明细 / 观测成本 / 配置单价；回退估算会明确标注')}
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+              <input
+                value={priceModel}
+                onChange={(e) => setPriceModel(e.target.value)}
+                placeholder={tr('模型名（可空=热门模型）')}
+                style={{ minWidth: 180, height: 32, padding: '0 10px', borderRadius: 8, border: '1px solid var(--color-border)', background: 'var(--color-bg)' }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void loadPriceCompare();
+                }}
+              />
+              <button
+                className="btn btn-primary"
+                style={{ height: 32, padding: '0 12px' }}
+                disabled={priceLoading}
+                onClick={() => void loadPriceCompare()}
+              >
+                {priceLoading ? tr('对比中...') : tr('对比价格')}
+              </button>
+              {search && (
+                <button
+                  className="btn btn-ghost"
+                  style={{ height: 32, padding: '0 10px', border: '1px solid var(--color-border)' }}
+                  disabled={priceLoading}
+                  onClick={() => {
+                    setPriceModel(search);
+                    void loadPriceCompare(search);
+                  }}
+                >
+                  {tr('用当前搜索')}
+                </button>
+              )}
+            </div>
+          </div>
+
+          {priceError && (
+            <div style={{ fontSize: 12, color: 'var(--color-danger)', marginBottom: 8 }}>{priceError}</div>
+          )}
+
+          {!priceLoaded && !priceLoading && (
+            <div style={{ fontSize: 12, color: 'var(--color-text-muted)' }}>{tr('输入模型名后点击对比，或留空查看近期热门模型。')}</div>
+          )}
+
+          {priceLoaded && priceItems.length === 0 && !priceLoading && !priceError && (
+            <div style={{ fontSize: 12, color: 'var(--color-text-muted)' }}>{tr('暂无价格候选（无观测/配置/可用性信号）。')}</div>
+          )}
+
+          {priceItems.length > 0 && (
+            <div style={{ overflowX: 'auto' }}>
+              <table className="data-table" style={{ width: '100%', fontSize: 12 }}>
+                <thead>
+                  <tr>
+                    <th>{tr('站点')}</th>
+                    <th>{tr('模型')}</th>
+                    <th>{tr('输入 $/1M')}</th>
+                    <th>{tr('输出 $/1M')}</th>
+                    <th>{tr('样本成本')}</th>
+                    <th>{tr('来源')}</th>
+                    <th>{tr('状态')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {priceItems.map((item) => (
+                    <tr key={`${item.siteId}-${item.accountId}-${item.model}`}>
+                      <td>
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                          <SiteBadgeLink siteId={item.siteId} siteName={item.siteName} badgeStyle={{ fontSize: 11 }} />
+                          <span style={{ color: 'var(--color-text-muted)' }}>{item.username || `ID:${item.accountId}`} · {item.platform || '—'}</span>
+                        </div>
+                      </td>
+                      <td style={{ fontFamily: 'var(--font-mono, monospace)' }}>{item.model}</td>
+                      <td style={{ fontVariantNumeric: 'tabular-nums' }}>{formatMoney(item.inputPerMillion, 4)}</td>
+                      <td style={{ fontVariantNumeric: 'tabular-nums' }}>{formatMoney(item.outputPerMillion, 4)}</td>
+                      <td style={{ fontVariantNumeric: 'tabular-nums' }}>{formatMoney(item.estimatedCostSample, 6)}</td>
+                      <td>
+                        <span className={`badge ${item.source === 'fallback' ? 'badge-muted' : 'badge-info'}`} style={{ fontSize: 11 }}>
+                          {formatPriceSource(item.source)}
+                        </span>
+                        {item.observedSamples ? (
+                          <span style={{ marginLeft: 6, color: 'var(--color-text-muted)' }}>n={item.observedSamples}</span>
+                        ) : null}
+                      </td>
+                      <td>
+                        {item.missingPrice ? (
+                          <span className="badge badge-muted" style={{ fontSize: 11 }}>{tr('缺少真实价格')}</span>
+                        ) : (
+                          <span className="badge badge-success" style={{ fontSize: 11 }}>{tr('有效')}</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
         {/* Empty */}
         {detailModels.length === 0 ? (
           <div className="empty-state">

--- a/web/pages/Models.tsx
+++ b/web/pages/Models.tsx
@@ -72,6 +72,29 @@ interface ModelsMarketplaceResponse {
   };
 }
 
+interface PriceCompareItem {
+  siteId: number;
+  siteName: string;
+  platform: string;
+  model: string;
+  accountId: number;
+  username?: string;
+  inputPerMillion: number;
+  outputPerMillion: number;
+  source: string;
+  ratesSource: string;
+  estimatedCostSample: number;
+  observedSamples?: number;
+  configuredUnitCost?: number | null;
+  missingPrice?: boolean;
+}
+
+interface PriceCompareResponse {
+  model?: string;
+  items?: PriceCompareItem[];
+  meta?: { count?: number; notes?: string };
+}
+
 function isKnownLatency(latency: number | null | undefined): latency is number {
   return typeof latency === 'number' && Number.isFinite(latency);
 }
@@ -125,6 +148,26 @@ function renderGroupPricingValue(pricing: ModelGroupPricing): string {
   return `${pricing.perCallTotal ?? 0} USD / call`;
 }
 
+function formatPriceSource(source: string | undefined): string {
+  switch (source) {
+    case 'billing_details':
+      return tr('账单明细');
+    case 'observed':
+      return tr('观测成本');
+    case 'configured':
+      return tr('配置单价');
+    case 'fallback':
+      return tr('回退估算');
+    default:
+      return source || '—';
+  }
+}
+
+function formatMoney(value: number | null | undefined, digits = 6): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '—';
+  return value.toFixed(digits);
+}
+
 const PAGE_SIZES = [10, 20, 50];
 
 function compareModels(a: ModelRow, b: ModelRow, sortBy: SortColumn, sortDir: 'asc' | 'desc'): number {
@@ -168,6 +211,11 @@ export default function Models() {
   const [filterCollapsed, setFilterCollapsed] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
   const [metadataHydrating, setMetadataHydrating] = useState(false);
+  const [priceModel, setPriceModel] = useState('');
+  const [priceLoading, setPriceLoading] = useState(false);
+  const [priceItems, setPriceItems] = useState<PriceCompareItem[]>([]);
+  const [priceError, setPriceError] = useState<string | null>(null);
+  const [priceLoaded, setPriceLoaded] = useState(false);
   const isMobile = useIsMobile();
   const filterPanelPresence = useAnimatedVisibility(!isMobile && !filterCollapsed, 220);
   const latestPrimaryRequestRef = useRef(0);
@@ -285,6 +333,27 @@ export default function Models() {
       }, 600);
     })();
   }, [hydrateMarketplaceMetadata, loadBaseMarketplace]);
+
+  const loadPriceCompare = useCallback(async (modelOverride?: string) => {
+    const model = (modelOverride ?? priceModel).trim();
+    setPriceLoading(true);
+    setPriceError(null);
+    try {
+      const res = await api.getModelPriceCompare({
+        model: model || undefined,
+        limit: 40,
+        days: 30,
+      }) as PriceCompareResponse;
+      setPriceItems(Array.isArray(res.items) ? res.items : []);
+      setPriceLoaded(true);
+    } catch (err) {
+      setPriceItems([]);
+      setPriceLoaded(true);
+      setPriceError(err instanceof Error ? err.message : tr('价格对比加载失败'));
+    } finally {
+      setPriceLoading(false);
+    }
+  }, [priceModel]);
 
   useEffect(() => {
     const q = new URLSearchParams(location.search).get('q') || '';


### PR DESCRIPTION
## Summary
- `GET /api/stats/model-prices` and `/api/models/price-compare` with labeled provenance
- Pure aggregation helpers in `routing/price_compare.go`
- Minimal Models page + api client wiring
- Docs: `docs/analysis/cross-site-price-compare.md`

## Test plan
- [x] `go test ./handler/admin/ ./routing/`

Closes #112