### PR TITLE
feat(scheduler): background channel health probing #114

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,9 @@ TELEGRAM_ENABLED=false
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=
 
+# Background channel health probing (#114). Off by default.
+# Interval floor 60s; timeout floor 3s; concurrency clamped to [1,16].
+# See docs/analysis/channel-health-probing.md
 MODEL_AVAILABILITY_PROBE_CONCURRENCY=1
 MODEL_AVAILABILITY_PROBE_ENABLED=false
 MODEL_AVAILABILITY_PROBE_INTERVAL_MS=1800000

--- a/docs/analysis/channel-health-probing.md
+++ b/docs/analysis/channel-health-probing.md
@@ -1,0 +1,135 @@
+# Background channel health probing (#114)
+
+**Date:** 2026-07-17  
+**Lane:** competitive learn / reliability  
+**SSOT code:** `scheduler/model_probe.go`, `routing/router.go` (`RecordProbeSuccess` / `RecordProbeFailure`), `routing/runtime_health.go` (probe stamps)  
+**Peers:** LiteLLM background `health_check` polling; AxonHub channel health probing
+
+## Goal
+
+Detect dead or flaky upstream channels **before** user traffic fails, then bias routing away from them via existing runtime health / cooldown machinery.
+
+This is **proactive** probing. Reactive Fibonacci cooldown still applies on real user traffic (`RecordFailure`).
+
+## Operator config (`MODEL_AVAILABILITY_PROBE_*`)
+
+| Env | Config field | Default | Notes |
+|:----|:-------------|:--------|:------|
+| `MODEL_AVAILABILITY_PROBE_ENABLED` | `ModelAvailabilityProbeEnabled` | `false` | Master gate. When false, scheduler does not start a timer. |
+| `MODEL_AVAILABILITY_PROBE_INTERVAL_MS` | `ModelAvailabilityProbeIntervalMs` | `1800000` (30m) | Hard floor **60s** (`max(60000, value)`). |
+| `MODEL_AVAILABILITY_PROBE_TIMEOUT_MS` | `ModelAvailabilityProbeTimeoutMs` | `15000` | Hard floor **3s**. Per-target probe timeout. |
+| `MODEL_AVAILABILITY_PROBE_CONCURRENCY` | `ModelAvailabilityProbeConcurrency` | `1` | Clamped to **[1, 16]**. |
+
+Also present in admin settings as `modelAvailabilityProbeEnabled` (DB setting key `model_availability_probe_enabled`) and listed in `.env.example`.
+
+### Recommended starting point
+
+```bash
+MODEL_AVAILABILITY_PROBE_ENABLED=true
+MODEL_AVAILABILITY_PROBE_INTERVAL_MS=300000   # 5 minutes
+MODEL_AVAILABILITY_PROBE_TIMEOUT_MS=10000
+MODEL_AVAILABILITY_PROBE_CONCURRENCY=2
+```
+
+Keep concurrency low and interval ≥ a few minutes in production so probe spend stays bounded. The scheduler caps each pass at **16** channel targets (cooling channels first, then least-recently-used active channels).
+
+## Architecture
+
+```
+ModelProbeScheduler (config-gated ticker, multi-instance lease)
+  loadProbeTargets(route_channels ∩ active accounts/sites, budget=16)
+  account lease (in-memory) per account
+  ChannelHealthProbe.ProbeChannel(target)     // injected; lightweight request
+       │
+       ├─ success  → ChannelHealthRecorder.RecordProbeSuccess
+       │                → TokenRouter.RecordProbeSuccess
+       │                     · clear credential-scoped cooldown
+       │                     · RecordSiteRuntimeSuccess
+       │                     · RecordSiteProbeOutcome(status=success)
+       │
+       ├─ failure  → ChannelHealthRecorder.RecordProbeFailure
+       │                → TokenRouter.RecordProbeFailure
+       │                     · cool ONLY the probed channel (no credential cascade)
+       │                     · RecordSiteRuntimeFailure (breaker streak)
+       │                     · RecordSiteProbeOutcome(status=failure)
+       │                     · NEVER mark account/key expired
+       │
+       └─ inconclusive / skipped → no health / cooldown mutation
+```
+
+### Package boundaries
+
+- `scheduler` must **not** import `routing` / `proxy` / `handler` (BACKEND.md).
+- Probe execution and health recording are **injected interfaces**:
+  - `scheduler.ChannelHealthProbe`
+  - `scheduler.ChannelHealthRecorder`
+- Composition root (`app` / `cmd/server`) wires a lightweight HTTP/protocol probe and a thin adapter over `routing.TokenRouter`.
+- When either dependency is missing, targets are **skipped** (safe no-op) so enabling the flag never panics.
+
+## Success / failure semantics
+
+| Outcome | Channel cooldown | Runtime health | Probe stamp | Account/key expired? |
+|:--------|:-----------------|:---------------|:------------|:---------------------|
+| success | Clear credential-scoped cooldowns | `RecordSiteRuntimeSuccess` | `lastProbeStatus=success` | No |
+| failure (transient 5xx/timeout) | Probed channel only (fib / RR tiers) | Failure + breaker streak | `lastProbeStatus=failure` | **No** |
+| failure (auth-looking 401/403) | Probed channel only | Failure penalty | `lastProbeStatus=failure` | **No** (probe must not expire keys) |
+| inconclusive / executor error | Unchanged | Unchanged | optional stamp only via direct helper | No |
+| skipped (no deps / lease) | Unchanged | Unchanged | Unchanged | No |
+
+### Why probe failure ≠ `RecordFailure`
+
+User-path `RecordFailure` may expand short-window usage-limit cooldowns across **credential-scoped siblings** and participates in proxy expiry classification. Background probes are synthetic: cascading siblings or marking keys expired on a bad probe would poison healthy capacity. `RecordProbeFailure` therefore:
+
+1. Always scopes channel cooldown to the **probed channel** (or OAuth member only).
+2. Still feeds site/model runtime health so breakers can open after a transient streak.
+3. Never writes account `status` / token `valueStatus`.
+
+## Operator visibility (last probe status)
+
+In-memory runtime health (`SiteRuntimeHealthState`) carries:
+
+| Field | Meaning |
+|:------|:--------|
+| `lastProbeAtMs` | When the last background probe for this site completed |
+| `lastProbeStatus` | `success` \| `failure` \| `inconclusive` |
+| `lastProbeLatencyMs` | Observed latency on success |
+| `lastProbeError` | Truncated error text on failure |
+| `lastProbeModel` | Model name used for the probe |
+| `lastProbeChannelId` | Channel id that was probed |
+
+Read via `routing.GetSiteProbeStatus(siteID)`. Persistence uses the existing `token_router_site_runtime_health_v1` settings payload (JSON tags). Admin UI surfacing can read this stamp; full admin REST expansion is optional follow-up (web/** out of scope for this issue).
+
+## Target selection budget
+
+Each pass:
+
+1. Enabled `route_channels` on **active** accounts + **active** sites with non-empty `source_model`.
+2. Prefer rows with `cooldown_until > now` (recovering channels).
+3. Fill remaining budget with non-cooling channels ordered by oldest `last_used_at`.
+4. Hard cap **16** targets per pass.
+5. Account-level in-memory lease prevents concurrent probes on the same account.
+6. Multi-instance scheduler lease (`runWithSchedulerLease`) avoids duplicate fleet-wide passes on Postgres.
+
+Out of scope for #114: paid full-size eval suites; probing every model on every site by default without budgets.
+
+## Tests
+
+- `routing/probe_health_test.go`
+  - success clears credential-scoped cooldown + stamps probe status
+  - failure cools only probed channel; updates health; no credential cascade
+  - auth-looking probe failure does not mark expired / does not cascade
+  - three transient probe failures open site breaker
+  - inconclusive stamp does not invent success/failure samples
+- `scheduler/model_probe_test.go`
+  - `ApplyProbeOutcome` success/failure/inconclusive transitions
+  - `probeOne` records via injected fakes
+  - executor errors → inconclusive
+  - missing deps → skipped
+  - disabled config does not start ticker
+
+## Non-goals
+
+- Redis multi-instance health state (#118)
+- Frontend admin pages (`web/**`)
+- Replacing reactive cooldown / user-path `RecordFailure`
+- Automatic route rebuild on every probe (availability-table rebuild remains a separate model-catalog concern)

--- a/routing/failure_isolation_test.go
+++ b/routing/failure_isolation_test.go
@@ -181,11 +181,16 @@ func (db *isolationDB) UpdateChannelCooldownFields(ctx context.Context, channelI
 		if v, ok := updates["failCount"].(int64); ok {
 			row.Channel.FailCount = v
 		}
-		if v, ok := updates["lastFailAt"].(*string); ok {
-			row.Channel.LastFailAt = v
-		} else if v, ok := updates["lastFailAt"].(string); ok {
-			s := v
-			row.Channel.LastFailAt = &s
+		if raw, exists := updates["lastFailAt"]; exists {
+			switch v := raw.(type) {
+			case nil:
+				row.Channel.LastFailAt = nil
+			case *string:
+				row.Channel.LastFailAt = v
+			case string:
+				s := v
+				row.Channel.LastFailAt = &s
+			}
 		}
 		if v, ok := updates["consecutiveFailCount"].(int64); ok {
 			row.Channel.ConsecutiveFailCount = v
@@ -193,11 +198,16 @@ func (db *isolationDB) UpdateChannelCooldownFields(ctx context.Context, channelI
 		if v, ok := updates["cooldownLevel"].(int64); ok {
 			row.Channel.CooldownLevel = v
 		}
-		if v, ok := updates["cooldownUntil"].(*string); ok {
-			row.Channel.CooldownUntil = v
-		} else if v, ok := updates["cooldownUntil"].(string); ok {
-			s := v
-			row.Channel.CooldownUntil = &s
+		if raw, exists := updates["cooldownUntil"]; exists {
+			switch v := raw.(type) {
+			case nil:
+				row.Channel.CooldownUntil = nil
+			case *string:
+				row.Channel.CooldownUntil = v
+			case string:
+				s := v
+				row.Channel.CooldownUntil = &s
+			}
 		}
 	}
 	return nil

--- a/routing/probe_health_test.go
+++ b/routing/probe_health_test.go
@@ -1,0 +1,239 @@
+package routing
+
+import (
+	"context"
+	"testing"
+)
+
+// =============================================================================
+// #114 — Background channel health probe success/failure transitions
+// =============================================================================
+
+func TestRecordProbeSuccess_ClearsCooldownAndStampsProbeStatus(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	db := newIsolationDB()
+	until := "2099-01-01T00:00:00Z"
+	lastFail := "2020-01-01T00:00:00Z"
+	ch := isolationChannel(101, 1, 11)
+	ch.FailCount = 3
+	ch.ConsecutiveFailCount = 2
+	ch.CooldownLevel = 1
+	ch.CooldownUntil = &until
+	ch.LastFailAt = &lastFail
+	account := isolationAccount(11, 7)
+	route := isolationRoute(1, "weighted")
+	db.seedChannel(ch, account, route)
+	db.credentialScope[101] = []int64{101, 102}
+
+	// Sibling also cooling — success should clear credential-scoped siblings.
+	sibling := isolationChannel(102, 1, 11)
+	sibling.CooldownUntil = &until
+	sibling.LastFailAt = &lastFail
+	sibling.ConsecutiveFailCount = 1
+	sibling.CooldownLevel = 1
+	db.seedChannel(sibling, account, route)
+
+	tr := newIsolationRouter(db)
+	model := "gpt-test"
+	if err := tr.RecordProbeSuccess(context.Background(), 101, 120.0, &model, nil); err != nil {
+		t.Fatalf("RecordProbeSuccess: %v", err)
+	}
+
+	got := db.getChannel(101)
+	if got == nil {
+		t.Fatal("channel 101 missing")
+	}
+	if got.CooldownUntil != nil || got.LastFailAt != nil || got.ConsecutiveFailCount != 0 || got.CooldownLevel != 0 {
+		t.Fatalf("probe success did not clear channel cooldown: %+v", got)
+	}
+	sib := db.getChannel(102)
+	if sib == nil || sib.CooldownUntil != nil || sib.ConsecutiveFailCount != 0 {
+		t.Fatalf("probe success did not clear credential sibling: %+v", sib)
+	}
+
+	// Runtime health success + probe stamp.
+	status := GetSiteProbeStatus(7)
+	if status.Status != "success" {
+		t.Fatalf("probe status = %q, want success", status.Status)
+	}
+	if status.AtMs <= 0 {
+		t.Fatal("expected LastProbeAtMs stamped")
+	}
+	if status.ModelName != "gpt-test" {
+		t.Fatalf("model = %q", status.ModelName)
+	}
+	if status.ChannelID == nil || *status.ChannelID != 101 {
+		t.Fatalf("channel id stamp = %v", status.ChannelID)
+	}
+	if status.LatencyMs == nil || *status.LatencyMs != 120 {
+		t.Fatalf("latency stamp = %v", status.LatencyMs)
+	}
+
+	// Success counter path reduced penalty / set last success.
+	details := GetSiteRuntimeHealthDetails(7, "gpt-test")
+	if details.RecentSuccessRate <= 0 {
+		t.Fatalf("expected positive recent success rate, got %+v", details)
+	}
+}
+
+func TestRecordProbeFailure_CoolsOnlyProbedChannelAndUpdatesHealth(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	db := newIsolationDB()
+	ch := isolationChannel(201, 2, 21)
+	sibling := isolationChannel(202, 2, 21)
+	account := isolationAccount(21, 8)
+	route := isolationRoute(2, "weighted")
+	db.seedChannel(ch, account, route)
+	db.seedChannel(sibling, account, route)
+	// Even if credential scope would expand for usage-limit traffic, probe
+	// failures must stay single-channel.
+	db.credentialScope[201] = []int64{201, 202}
+
+	tr := newIsolationRouter(db)
+	status502 := 502
+	errText := "bad gateway"
+	model := "gpt-test"
+	if err := tr.RecordProbeFailure(context.Background(), 201, SiteRuntimeFailureContext{
+		Status:    &status502,
+		ErrorText: &errText,
+		ModelName: &model,
+	}, nil); err != nil {
+		t.Fatalf("RecordProbeFailure: %v", err)
+	}
+
+	failed := db.getChannel(201)
+	if failed == nil {
+		t.Fatal("channel 201 missing")
+	}
+	if failed.FailCount != 1 {
+		t.Fatalf("failCount = %d, want 1", failed.FailCount)
+	}
+	if failed.CooldownUntil == nil {
+		t.Fatal("expected cooldownUntil set on probed channel")
+	}
+	if failed.LastFailAt == nil {
+		t.Fatal("expected lastFailAt set")
+	}
+
+	clean := db.getChannel(202)
+	if clean == nil {
+		t.Fatal("sibling missing")
+	}
+	if clean.FailCount != 0 || clean.CooldownUntil != nil || clean.LastFailAt != nil {
+		t.Fatalf("probe failure cascaded to sibling: %+v", clean)
+	}
+	if db.cooldownCalls != 1 || len(db.lastCooldownIDs) != 1 || db.lastCooldownIDs[0] != 201 {
+		t.Fatalf("cooldown write scope = ids %v calls %d", db.lastCooldownIDs, db.cooldownCalls)
+	}
+
+	probe := GetSiteProbeStatus(8)
+	if probe.Status != "failure" {
+		t.Fatalf("probe status = %q, want failure", probe.Status)
+	}
+	if probe.ErrorText == nil || *probe.ErrorText != "bad gateway" {
+		t.Fatalf("probe error = %v", probe.ErrorText)
+	}
+
+	// Transient failure feeds runtime health (penalty / streak) without expiry.
+	details := GetSiteRuntimeHealthDetails(8, "gpt-test")
+	if details.GlobalMultiplier >= 1 {
+		t.Fatalf("expected health penalty after probe failure, details=%+v", details)
+	}
+}
+
+func TestRecordProbeFailure_AuthLookingErrorDoesNotCascadeCredentialScope(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	db := newIsolationDB()
+	ch := isolationChannel(301, 3, 31)
+	sibling := isolationChannel(302, 3, 31)
+	account := isolationAccount(31, 9)
+	route := isolationRoute(3, "weighted")
+	db.seedChannel(ch, account, route)
+	db.seedChannel(sibling, account, route)
+	db.credentialScope[301] = []int64{301, 302}
+
+	tr := newIsolationRouter(db)
+	status401 := 401
+	errText := "invalid api key" // must NOT mark expired; probe path never touches account status
+	model := "gpt-test"
+	if err := tr.RecordProbeFailure(context.Background(), 301, SiteRuntimeFailureContext{
+		Status:    &status401,
+		ErrorText: &errText,
+		ModelName: &model,
+	}, nil); err != nil {
+		t.Fatalf("RecordProbeFailure: %v", err)
+	}
+
+	// Only probed channel cooled; no credential cascade (unlike short-window usage limit).
+	if got := db.getChannel(302); got.FailCount != 0 || got.CooldownUntil != nil {
+		t.Fatalf("auth-looking probe failure cascaded: %+v", got)
+	}
+	// Account row is not mutated by isolationDB (and production path never writes account.status).
+	if account.Status != "active" {
+		t.Fatalf("account status mutated to %q", account.Status)
+	}
+
+	probe := GetSiteProbeStatus(9)
+	if probe.Status != "failure" {
+		t.Fatalf("status=%q", probe.Status)
+	}
+}
+
+func TestRecordProbeFailure_OpensBreakerAfterTransientStreak(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	db := newIsolationDB()
+	ch := isolationChannel(401, 4, 41)
+	account := isolationAccount(41, 10)
+	route := isolationRoute(4, "weighted")
+	db.seedChannel(ch, account, route)
+
+	tr := newIsolationRouter(db)
+	status503 := 503
+	errText := "service unavailable"
+	model := "gpt-test"
+
+	for i := 0; i < 3; i++ {
+		if err := tr.RecordProbeFailure(context.Background(), 401, SiteRuntimeFailureContext{
+			Status:    &status503,
+			ErrorText: &errText,
+			ModelName: &model,
+		}, nil); err != nil {
+			t.Fatalf("RecordProbeFailure #%d: %v", i+1, err)
+		}
+	}
+
+	if !IsSiteRuntimeBreakerOpen(10) {
+		t.Fatal("expected site breaker open after 3 transient probe failures")
+	}
+	probe := GetSiteProbeStatus(10)
+	if probe.Status != "failure" || !probe.BreakerOpen {
+		t.Fatalf("probe status after streak: %+v", probe)
+	}
+}
+
+func TestRecordSiteProbeOutcome_InconclusiveDoesNotChangeSuccessRateAlone(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	model := "m"
+	channelID := int64(1)
+	// Stamp only — no success/failure counters.
+	RecordSiteProbeOutcome(55, "inconclusive", 0, &model, &channelID, nil)
+	status := GetSiteProbeStatus(55)
+	if status.Status != "inconclusive" {
+		t.Fatalf("status=%q", status.Status)
+	}
+	details := GetSiteRuntimeHealthDetails(55, "m")
+	// With no outcomes, prior is 0.5 success rate and low confidence.
+	if details.RecentSampleCount != 0 {
+		t.Fatalf("inconclusive stamp should not invent samples, got %v", details.RecentSampleCount)
+	}
+}

--- a/routing/router.go
+++ b/routing/router.go
@@ -527,7 +527,9 @@ func (tr *TokenRouter) RecordSuccess(ctx context.Context, channelID int64, laten
 	return nil
 }
 
-// RecordProbeSuccess clears cooldown for all credential-scoped channels.
+// RecordProbeSuccess records a successful background health probe.
+// It clears cooldown for credential-scoped channels, feeds runtime health
+// success, and stamps last probe status. It never marks credentials expired.
 func (tr *TokenRouter) RecordProbeSuccess(ctx context.Context, channelID int64, latencyMs float64, modelName *string, actualAccountID *int64) error {
 	if err := EnsureSiteRuntimeHealthStateLoaded(); err != nil {
 		return err
@@ -541,6 +543,7 @@ func (tr *TokenRouter) RecordProbeSuccess(ctx context.Context, channelID int64, 
 	ch := row.Channel
 	account := row.Account
 	nowISO := time.Now().UTC().Format(time.RFC3339)
+	channelIDCopy := channelID
 
 	if ch.OAuthRouteUnitID != nil && *ch.OAuthRouteUnitID > 0 {
 		targetAccountID := account.ID
@@ -551,22 +554,24 @@ func (tr *TokenRouter) RecordProbeSuccess(ctx context.Context, channelID int64, 
 		memberRow, err := tr.db.LoadRouteUnitMemberWithAccount(ctx, *ch.OAuthRouteUnitID, targetAccountID)
 		if err == nil && memberRow != nil {
 			_ = tr.db.UpdateRouteUnitMemberCooldownFields(ctx, memberRow.Member.ID, map[string]interface{}{
-				"cooldownUntil":  nil,
-				"lastFailAt":     nil,
+				"cooldownUntil":        nil,
+				"lastFailAt":           nil,
 				"consecutiveFailCount": int64(0),
-				"cooldownLevel":  int64(0),
-				"updatedAt":      nowISO,
+				"cooldownLevel":        int64(0),
+				"updatedAt":            nowISO,
 			})
 			RecordSiteRuntimeSuccess(memberRow.Account.SiteID, latencyMs, modelName)
+			RecordSiteProbeOutcome(memberRow.Account.SiteID, "success", latencyMs, modelName, &channelIDCopy, nil)
 		} else {
 			RecordSiteRuntimeSuccess(account.SiteID, latencyMs, modelName)
+			RecordSiteProbeOutcome(account.SiteID, "success", latencyMs, modelName, &channelIDCopy, nil)
 		}
 
 		_ = tr.db.UpdateChannelCooldownFields(ctx, []int64{channelID}, map[string]interface{}{
-			"cooldownUntil":  nil,
-			"lastFailAt":     nil,
+			"cooldownUntil":        nil,
+			"lastFailAt":           nil,
 			"consecutiveFailCount": int64(0),
-			"cooldownLevel":  int64(0),
+			"cooldownLevel":        int64(0),
 		})
 		tr.cache.PatchCachedChannel(channelID, func(ch *store.RouteChannel) {
 			ch.CooldownUntil = nil
@@ -586,10 +591,10 @@ func (tr *TokenRouter) RecordProbeSuccess(ctx context.Context, channelID int64, 
 	needsReset := ch.CooldownUntil != nil || ch.LastFailAt != nil || ch.ConsecutiveFailCount > 0 || ch.CooldownLevel > 0
 	if needsReset {
 		_ = tr.db.UpdateChannelCooldownFields(ctx, affectedChannelIDs, map[string]interface{}{
-			"cooldownUntil":  nil,
-			"lastFailAt":     nil,
+			"cooldownUntil":        nil,
+			"lastFailAt":           nil,
 			"consecutiveFailCount": int64(0),
-			"cooldownLevel":  int64(0),
+			"cooldownLevel":        int64(0),
 		})
 		for _, id := range affectedChannelIDs {
 			tr.cache.PatchCachedChannel(id, func(ch *store.RouteChannel) {
@@ -602,6 +607,130 @@ func (tr *TokenRouter) RecordProbeSuccess(ctx context.Context, channelID int64, 
 	}
 
 	RecordSiteRuntimeSuccess(account.SiteID, latencyMs, modelName)
+	RecordSiteProbeOutcome(account.SiteID, "success", latencyMs, modelName, &channelIDCopy, nil)
+	return nil
+}
+
+// RecordProbeFailure records a failed background health probe.
+//
+// Unlike RecordFailure (user traffic path), probe failures:
+//   - update site/model runtime health + breaker streak (so routing can avoid dead channels)
+//   - apply a short channel cooldown only for the probed channel (no credential cascade)
+//   - never mark accounts/keys expired
+//   - never treat auth-looking probe errors as credential expiry
+func (tr *TokenRouter) RecordProbeFailure(ctx context.Context, channelID int64, failureCtx SiteRuntimeFailureContext, actualAccountID *int64) error {
+	if err := EnsureSiteRuntimeHealthStateLoaded(); err != nil {
+		return err
+	}
+
+	row, err := tr.db.LoadChannelWithAccountAndRoute(ctx, channelID)
+	if err != nil || row == nil {
+		return err
+	}
+
+	ch := row.Channel
+	account := row.Account
+	route := row.Route
+	nowMs := time.Now().UnixMilli()
+	nowISO := time.Now().UTC().Format(time.RFC3339)
+	channelIDCopy := channelID
+
+	// Normalize model onto failure context for runtime health model-level state.
+	if failureCtx.ModelName == nil || *failureCtx.ModelName == "" {
+		if ch.SourceModel != nil && *ch.SourceModel != "" {
+			failureCtx.ModelName = ch.SourceModel
+		}
+	}
+
+	// OAuth unit: update member cooldown only; outer channel fields stay clean.
+	if ch.OAuthRouteUnitID != nil && *ch.OAuthRouteUnitID > 0 {
+		targetAccountID := account.ID
+		if actualAccountID != nil && *actualAccountID > 0 {
+			targetAccountID = *actualAccountID
+		}
+
+		memberRow, err := tr.db.LoadRouteUnitMemberWithAccount(ctx, *ch.OAuthRouteUnitID, targetAccountID)
+		if err == nil && memberRow != nil {
+			// Probe path intentionally ignores usage-limit credential cascade and
+			// never zeros failCount for short-window limits: probes are synthetic.
+			failCount := max64(0, memberRow.Member.FailCount) + 1
+			routeUnitStrategy := memberRow.Unit.Strategy
+			if routeUnitStrategy == "" {
+				routeUnitStrategy = "round_robin"
+			}
+
+			var cooldownUntil *string
+			consecutiveFailCount := max64(0, memberRow.Member.ConsecutiveFailCount) + 1
+			cooldownLevel := max64(0, memberRow.Member.CooldownLevel)
+
+			if routeUnitStrategy == "round_robin" {
+				nextCF, nextCL, cu := ApplyRoundRobinCooldown(consecutiveFailCount, cooldownLevel, nowMs, tr.configuredMaxSec)
+				consecutiveFailCount = nextCF
+				cooldownLevel = nextCL
+				cooldownUntil = cu
+			} else {
+				cu := ApplyFibonacciCooldown(failCount, nowMs, tr.configuredMaxSec)
+				consecutiveFailCount = 0
+				cooldownLevel = 0
+				cooldownUntil = cu
+			}
+
+			_ = tr.db.UpdateRouteUnitMemberCooldownFields(ctx, memberRow.Member.ID, map[string]interface{}{
+				"failCount":            failCount,
+				"lastFailAt":           nowISO,
+				"consecutiveFailCount": consecutiveFailCount,
+				"cooldownLevel":        cooldownLevel,
+				"cooldownUntil":        cooldownUntil,
+				"updatedAt":            nowISO,
+			})
+			RecordSiteRuntimeFailure(memberRow.Account.SiteID, failureCtx)
+			RecordSiteProbeOutcome(memberRow.Account.SiteID, "failure", 0, failureCtx.ModelName, &channelIDCopy, failureCtx.ErrorText)
+			tr.cache.InvalidateRouteScopedCache(route.ID)
+		}
+		return nil
+	}
+
+	// Regular channel: probe failure cools only the probed channel (no credential cascade).
+	failCount := max64(0, ch.FailCount) + 1
+	routeStrategy := NormalizeRouteRoutingStrategy(route.RoutingStrategy)
+	affectedChannelIDs := []int64{channelID}
+
+	var cooldownUntil *string
+	consecutiveFailCount := max64(0, ch.ConsecutiveFailCount) + 1
+	cooldownLevel := max64(0, ch.CooldownLevel)
+
+	if routeStrategy == StrategyRoundRobin {
+		nextCF, nextCL, cu := ApplyRoundRobinCooldown(consecutiveFailCount, cooldownLevel, nowMs, tr.configuredMaxSec)
+		consecutiveFailCount = nextCF
+		cooldownLevel = nextCL
+		cooldownUntil = cu
+	} else {
+		cu := ApplyFibonacciCooldown(failCount, nowMs, tr.configuredMaxSec)
+		consecutiveFailCount = 0
+		cooldownLevel = 0
+		cooldownUntil = cu
+	}
+
+	_ = tr.db.UpdateChannelCooldownFields(ctx, affectedChannelIDs, map[string]interface{}{
+		"failCount":            failCount,
+		"lastFailAt":           nowISO,
+		"consecutiveFailCount": consecutiveFailCount,
+		"cooldownLevel":        cooldownLevel,
+		"cooldownUntil":        cooldownUntil,
+	})
+
+	for _, id := range affectedChannelIDs {
+		tr.cache.PatchCachedChannel(id, func(ch *store.RouteChannel) {
+			ch.FailCount = failCount
+			ch.LastFailAt = &nowISO
+			ch.ConsecutiveFailCount = consecutiveFailCount
+			ch.CooldownLevel = cooldownLevel
+			ch.CooldownUntil = cooldownUntil
+		})
+	}
+
+	RecordSiteRuntimeFailure(account.SiteID, failureCtx)
+	RecordSiteProbeOutcome(account.SiteID, "failure", 0, failureCtx.ModelName, &channelIDCopy, failureCtx.ErrorText)
 	return nil
 }
 

--- a/routing/runtime_health.go
+++ b/routing/runtime_health.go
@@ -127,6 +127,13 @@ type SiteRuntimeHealthState struct {
 	LastUpdatedAtMs          int64    `json:"lastUpdatedAtMs"`
 	LastFailureAtMs          *int64   `json:"lastFailureAtMs,omitempty"`
 	LastSuccessAtMs          *int64   `json:"lastSuccessAtMs,omitempty"`
+	// Background probe status (issue #114). Soft operator signal; never marks keys expired.
+	LastProbeAtMs     *int64   `json:"lastProbeAtMs,omitempty"`
+	LastProbeStatus   string   `json:"lastProbeStatus,omitempty"` // success | failure | inconclusive
+	LastProbeLatencyMs *float64 `json:"lastProbeLatencyMs,omitempty"`
+	LastProbeError    *string  `json:"lastProbeError,omitempty"`
+	LastProbeModel    string   `json:"lastProbeModel,omitempty"`
+	LastProbeChannelID *int64  `json:"lastProbeChannelId,omitempty"`
 }
 
 // SiteRuntimeHealthDetails is the resolved health for selection.
@@ -776,6 +783,119 @@ func RecordSiteRuntimeSuccess(siteID int64, latencyMs float64, modelName *string
 	scheduleSiteRuntimeHealthPersistence()
 }
 
+// ProbeStatus is the operator-visible background probe outcome for a site.
+type ProbeStatus struct {
+	Status     string   // success | failure | inconclusive | ""
+	AtMs       int64
+	LatencyMs  *float64
+	ErrorText  *string
+	ModelName  string
+	ChannelID  *int64
+	BreakerOpen bool
+	Multiplier float64
+}
+
+// RecordSiteProbeOutcome stamps the last background probe result on site health
+// without treating the event as user traffic. Success/failure still go through
+// the normal runtime health counters via RecordSiteRuntime* helpers.
+func RecordSiteProbeOutcome(siteID int64, status string, latencyMs float64, modelName *string, channelID *int64, errText *string) {
+	if siteID <= 0 {
+		return
+	}
+	healthStateMu.Lock()
+	defer healthStateMu.Unlock()
+
+	n := nowMs()
+	state := getOrCreateSiteRuntimeHealthState(siteID)
+	state.LastProbeAtMs = &n
+	state.LastProbeStatus = status
+	state.LastUpdatedAtMs = n
+	if latencyMs > 0 {
+		v := latencyMs
+		state.LastProbeLatencyMs = &v
+	} else {
+		state.LastProbeLatencyMs = nil
+	}
+	if errText != nil && *errText != "" {
+		e := *errText
+		state.LastProbeError = &e
+	} else {
+		state.LastProbeError = nil
+	}
+	if modelName != nil {
+		state.LastProbeModel = *modelName
+	} else {
+		state.LastProbeModel = ""
+	}
+	if channelID != nil && *channelID > 0 {
+		id := *channelID
+		state.LastProbeChannelID = &id
+	} else {
+		state.LastProbeChannelID = nil
+	}
+
+	if modelName != nil && *modelName != "" {
+		if modelState := getOrCreateSiteModelRuntimeHealthState(siteID, *modelName); modelState != nil {
+			modelState.LastProbeAtMs = &n
+			modelState.LastProbeStatus = status
+			modelState.LastUpdatedAtMs = n
+			if latencyMs > 0 {
+				v := latencyMs
+				modelState.LastProbeLatencyMs = &v
+			} else {
+				modelState.LastProbeLatencyMs = nil
+			}
+			if errText != nil && *errText != "" {
+				e := *errText
+				modelState.LastProbeError = &e
+			} else {
+				modelState.LastProbeError = nil
+			}
+			modelState.LastProbeModel = *modelName
+			if channelID != nil && *channelID > 0 {
+				id := *channelID
+				modelState.LastProbeChannelID = &id
+			} else {
+				modelState.LastProbeChannelID = nil
+			}
+		}
+	}
+	scheduleSiteRuntimeHealthPersistence()
+}
+
+// GetSiteProbeStatus returns the last background probe stamp for a site.
+func GetSiteProbeStatus(siteID int64) ProbeStatus {
+	healthStateMu.RLock()
+	defer healthStateMu.RUnlock()
+
+	state := siteRuntimeHealthStates[siteID]
+	if state == nil {
+		return ProbeStatus{Multiplier: 1}
+	}
+	out := ProbeStatus{
+		Status:      state.LastProbeStatus,
+		ModelName:   state.LastProbeModel,
+		BreakerOpen: isRuntimeHealthBreakerOpen(state),
+		Multiplier:  GetRuntimeHealthMultiplier(state),
+	}
+	if state.LastProbeAtMs != nil {
+		out.AtMs = *state.LastProbeAtMs
+	}
+	if state.LastProbeLatencyMs != nil {
+		v := *state.LastProbeLatencyMs
+		out.LatencyMs = &v
+	}
+	if state.LastProbeError != nil {
+		e := *state.LastProbeError
+		out.ErrorText = &e
+	}
+	if state.LastProbeChannelID != nil {
+		id := *state.LastProbeChannelID
+		out.ChannelID = &id
+	}
+	return out
+}
+
 // ---- Breaker filter helpers ----
 
 // GetBreakerFilteredCandidatesByModel is public for use by selector.
@@ -909,10 +1029,16 @@ func cloneSiteRuntimeHealthState(state *SiteRuntimeHealthState) *SiteRuntimeHeal
 		RecentWindowUpdatedAtMs: state.RecentWindowUpdatedAtMs,
 		BreakerLevel:            state.BreakerLevel,
 		LastUpdatedAtMs:         state.LastUpdatedAtMs,
+		LastProbeStatus:         state.LastProbeStatus,
+		LastProbeModel:          state.LastProbeModel,
 	}
 	if state.LatencyEMAMs != nil {
 		v := *state.LatencyEMAMs
 		clone.LatencyEMAMs = &v
+	}
+	if state.FirstByteEMAMs != nil {
+		v := *state.FirstByteEMAMs
+		clone.FirstByteEMAMs = &v
 	}
 	if state.LastTransientFailureAtMs != nil {
 		v := *state.LastTransientFailureAtMs
@@ -929,6 +1055,22 @@ func cloneSiteRuntimeHealthState(state *SiteRuntimeHealthState) *SiteRuntimeHeal
 	if state.LastSuccessAtMs != nil {
 		v := *state.LastSuccessAtMs
 		clone.LastSuccessAtMs = &v
+	}
+	if state.LastProbeAtMs != nil {
+		v := *state.LastProbeAtMs
+		clone.LastProbeAtMs = &v
+	}
+	if state.LastProbeLatencyMs != nil {
+		v := *state.LastProbeLatencyMs
+		clone.LastProbeLatencyMs = &v
+	}
+	if state.LastProbeError != nil {
+		v := *state.LastProbeError
+		clone.LastProbeError = &v
+	}
+	if state.LastProbeChannelID != nil {
+		v := *state.LastProbeChannelID
+		clone.LastProbeChannelID = &v
 	}
 	return clone
 }

--- a/scheduler/model_probe.go
+++ b/scheduler/model_probe.go
@@ -10,9 +10,42 @@ import (
 	"github.com/tokendancelab/metapi-go/store"
 )
 
-// ModelProbeScheduler periodically probes model availability by queuing
-// background tasks. Supports account-level lease to prevent concurrent probes
-// on the same account.
+// ProbeTarget is one lightweight channel/model pair the background probe may hit.
+type ProbeTarget struct {
+	ChannelID int64
+	AccountID int64
+	SiteID    int64
+	ModelName string
+}
+
+// ProbeOutcome is the result of a single lightweight probe attempt.
+// Status is one of: success | failure | inconclusive | skipped.
+type ProbeOutcome struct {
+	Status    string
+	LatencyMs float64
+	// HTTPStatus is optional; 0 means unknown / transport error.
+	HTTPStatus int
+	ErrorText  string
+}
+
+// ChannelHealthProbe executes one lightweight request against a channel/model.
+// Implementations live outside scheduler (proxy/platform) and are injected at boot.
+// Returning an error is treated as an inconclusive outcome (no health mutation).
+type ChannelHealthProbe interface {
+	ProbeChannel(ctx context.Context, target ProbeTarget) (ProbeOutcome, error)
+}
+
+// ChannelHealthRecorder applies probe outcomes to routing health/cooldown.
+// Implementations wrap routing.TokenRouter.RecordProbeSuccess/RecordProbeFailure.
+// Must never mark credentials/accounts expired.
+type ChannelHealthRecorder interface {
+	RecordProbeSuccess(ctx context.Context, channelID int64, latencyMs float64, modelName *string, actualAccountID *int64) error
+	RecordProbeFailure(ctx context.Context, channelID int64, httpStatus *int, errorText *string, modelName *string, actualAccountID *int64) error
+}
+
+// ModelProbeScheduler periodically probes model/channel availability with a
+// lightweight request so routing can avoid dead channels before user traffic fails.
+// Supports account-level lease to prevent concurrent probes on the same account.
 type ModelProbeScheduler struct {
 	cfg           *config.Config
 	ticker        *time.Ticker
@@ -20,6 +53,24 @@ type ModelProbeScheduler struct {
 	running       bool
 	mu            sync.Mutex
 	accountLeases map[int64]bool
+
+	probe    ChannelHealthProbe
+	recorder ChannelHealthRecorder
+
+	// lastRunSummary is retained for tests / operator diagnostics.
+	lastRunSummary ProbeRunSummary
+}
+
+// ProbeRunSummary summarizes one background probe pass.
+type ProbeRunSummary struct {
+	AccountsConsidered int
+	AccountsProbed     int
+	TargetsScanned     int
+	Success            int
+	Failed             int
+	Inconclusive       int
+	Skipped            int
+	CompletedAtMs      int64
 }
 
 // NewModelProbeScheduler creates a new model availability probe scheduler.
@@ -28,6 +79,20 @@ func NewModelProbeScheduler(cfg *config.Config) *ModelProbeScheduler {
 		cfg:           cfg,
 		accountLeases: make(map[int64]bool),
 	}
+}
+
+// SetProbeExecutor injects the lightweight probe implementation.
+func (s *ModelProbeScheduler) SetProbeExecutor(probe ChannelHealthProbe) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.probe = probe
+}
+
+// SetHealthRecorder injects the routing health/cooldown recorder.
+func (s *ModelProbeScheduler) SetHealthRecorder(recorder ChannelHealthRecorder) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recorder = recorder
 }
 
 func (s *ModelProbeScheduler) Name() string { return "model-probe" }
@@ -64,6 +129,7 @@ func (s *ModelProbeScheduler) Start(ctx context.Context) error {
 
 	slog.Info("model-probe scheduler started",
 		"interval_ms", intervalMs,
+		"timeout_ms", s.cfg.ModelAvailabilityProbeTimeoutMs,
 		"concurrency", s.cfg.ModelAvailabilityProbeConcurrency,
 	)
 	return nil
@@ -111,6 +177,13 @@ func (s *ModelProbeScheduler) ResetLeases() {
 	s.accountLeases = make(map[int64]bool)
 }
 
+// LastRunSummary returns a copy of the most recent probe pass summary.
+func (s *ModelProbeScheduler) LastRunSummary() ProbeRunSummary {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastRunSummary
+}
+
 func (s *ModelProbeScheduler) runProbe() {
 	dbw := store.GetDB()
 	if dbw == nil {
@@ -124,41 +197,312 @@ func (s *ModelProbeScheduler) runProbe() {
 func (s *ModelProbeScheduler) runProbeLocked(dbw *store.DB) {
 	slog.Info("model-probe: starting availability probe")
 
-	// Query active accounts
-	rows, err := dbw.Query("SELECT id FROM accounts WHERE status = 'active'")
+	summary := ProbeRunSummary{}
+	defer func() {
+		summary.CompletedAtMs = time.Now().UnixMilli()
+		s.mu.Lock()
+		s.lastRunSummary = summary
+		s.mu.Unlock()
+	}()
+
+	targets, err := s.loadProbeTargets(dbw)
 	if err != nil {
-		slog.Error("model-probe: failed to query accounts", "error", err)
+		slog.Error("model-probe: failed to load probe targets", "error", err)
 		return
 	}
-	defer rows.Close()
-
-	var accountIDs []int64
-	for rows.Next() {
-		var id int64
-		if err := rows.Scan(&id); err != nil {
-			continue
-		}
-		accountIDs = append(accountIDs, id)
+	if len(targets) == 0 {
+		slog.Info("model-probe: no probe targets")
+		return
 	}
 
-	// Filter by account-level lease
-	var available []int64
-	for _, id := range accountIDs {
-		if s.TryAcquireAccountLease(id) {
-			available = append(available, id)
+	// Group by account so account leases still gate concurrent work.
+	byAccount := make(map[int64][]ProbeTarget)
+	for _, t := range targets {
+		byAccount[t.AccountID] = append(byAccount[t.AccountID], t)
+	}
+	summary.AccountsConsidered = len(byAccount)
+
+	var availableAccounts []int64
+	for accountID := range byAccount {
+		if s.TryAcquireAccountLease(accountID) {
+			availableAccounts = append(availableAccounts, accountID)
 		}
 	}
-
-	if len(available) == 0 {
+	if len(availableAccounts) == 0 {
 		slog.Info("model-probe: no accounts available (all leased)")
 		return
 	}
 
-	// TODO: Wire actual probe execution via background task system
-	// For now, probe is a stub that releases leases immediately
-	for _, id := range available {
-		s.ReleaseAccountLease(id)
+	timeoutMs := s.cfg.ModelAvailabilityProbeTimeoutMs
+	if timeoutMs < 3000 {
+		timeoutMs = 3000
+	}
+	concurrency := s.cfg.ModelAvailabilityProbeConcurrency
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	if concurrency > 16 {
+		concurrency = 16
 	}
 
-	slog.Info("model-probe: probe complete", "accounts", len(available))
+	// Flatten leased targets and run with bounded concurrency.
+	var work []ProbeTarget
+	for _, accountID := range availableAccounts {
+		work = append(work, byAccount[accountID]...)
+	}
+	summary.AccountsProbed = len(availableAccounts)
+	summary.TargetsScanned = len(work)
+
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	for _, target := range work {
+		target := target
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			outcome := s.probeOne(target, timeoutMs)
+			mu.Lock()
+			switch outcome {
+			case "success":
+				summary.Success++
+			case "failure":
+				summary.Failed++
+			case "inconclusive":
+				summary.Inconclusive++
+			default:
+				summary.Skipped++
+			}
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	for _, accountID := range availableAccounts {
+		s.ReleaseAccountLease(accountID)
+	}
+
+	slog.Info("model-probe: probe complete",
+		"accounts", summary.AccountsProbed,
+		"targets", summary.TargetsScanned,
+		"success", summary.Success,
+		"failed", summary.Failed,
+		"inconclusive", summary.Inconclusive,
+		"skipped", summary.Skipped,
+	)
+}
+
+func (s *ModelProbeScheduler) probeOne(target ProbeTarget, timeoutMs int) string {
+	s.mu.Lock()
+	probe := s.probe
+	recorder := s.recorder
+	s.mu.Unlock()
+
+	if probe == nil || recorder == nil {
+		// Without an injected executor/recorder we cannot safely touch health.
+		// Keep the pass no-op so operators can enable the flag without crash.
+		slog.Debug("model-probe: probe executor or recorder not configured; skipping target",
+			"channel_id", target.ChannelID,
+			"model", target.ModelName,
+		)
+		return "skipped"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutMs)*time.Millisecond)
+	defer cancel()
+
+	outcome, err := probe.ProbeChannel(ctx, target)
+	if err != nil {
+		slog.Warn("model-probe: probe executor error (inconclusive)",
+			"channel_id", target.ChannelID,
+			"model", target.ModelName,
+			"error", err,
+		)
+		return "inconclusive"
+	}
+
+	modelName := target.ModelName
+	var modelPtr *string
+	if modelName != "" {
+		modelPtr = &modelName
+	}
+	accountID := target.AccountID
+	accountPtr := &accountID
+
+	switch outcome.Status {
+	case "success":
+		if err := recorder.RecordProbeSuccess(ctx, target.ChannelID, outcome.LatencyMs, modelPtr, accountPtr); err != nil {
+			slog.Warn("model-probe: RecordProbeSuccess failed",
+				"channel_id", target.ChannelID,
+				"error", err,
+			)
+			return "inconclusive"
+		}
+		return "success"
+	case "failure":
+		var statusPtr *int
+		if outcome.HTTPStatus > 0 {
+			st := outcome.HTTPStatus
+			statusPtr = &st
+		}
+		var errPtr *string
+		if outcome.ErrorText != "" {
+			e := outcome.ErrorText
+			errPtr = &e
+		}
+		if err := recorder.RecordProbeFailure(ctx, target.ChannelID, statusPtr, errPtr, modelPtr, accountPtr); err != nil {
+			slog.Warn("model-probe: RecordProbeFailure failed",
+				"channel_id", target.ChannelID,
+				"error", err,
+			)
+			return "inconclusive"
+		}
+		return "failure"
+	case "skipped":
+		return "skipped"
+	default:
+		// inconclusive / unknown — do not mutate health or cooldown.
+		return "inconclusive"
+	}
+}
+
+// loadProbeTargets selects a budgeted set of active route channels for probing.
+// Prefers channels that are currently cooling down, then other enabled channels.
+// Caps the batch so default-on budgets stay small (issue #114 out of scope: every model).
+func (s *ModelProbeScheduler) loadProbeTargets(dbw *store.DB) ([]ProbeTarget, error) {
+	const maxBatch = 16
+	nowISO := time.Now().UTC().Format(time.RFC3339)
+
+	// Cooling channels first (proactive recovery signal).
+	cooling, err := queryProbeTargets(dbw, `
+		SELECT rc.id, rc.account_id, a.site_id, COALESCE(rc.source_model, '') AS source_model
+		FROM route_channels rc
+		INNER JOIN accounts a ON rc.account_id = a.id
+		INNER JOIN sites st ON a.site_id = st.id
+		WHERE rc.enabled = TRUE
+		  AND a.status = 'active'
+		  AND st.status = 'active'
+		  AND rc.cooldown_until IS NOT NULL
+		  AND rc.cooldown_until > ?
+		  AND COALESCE(rc.source_model, '') <> ''
+		ORDER BY rc.cooldown_until ASC
+		LIMIT ?
+	`, nowISO, maxBatch)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(cooling) >= maxBatch {
+		return cooling, nil
+	}
+
+	// Fill remaining budget with active (non-cooling) channels.
+	remaining := maxBatch - len(cooling)
+	active, err := queryProbeTargets(dbw, `
+		SELECT rc.id, rc.account_id, a.site_id, COALESCE(rc.source_model, '') AS source_model
+		FROM route_channels rc
+		INNER JOIN accounts a ON rc.account_id = a.id
+		INNER JOIN sites st ON a.site_id = st.id
+		WHERE rc.enabled = TRUE
+		  AND a.status = 'active'
+		  AND st.status = 'active'
+		  AND rc.cooldown_until IS NULL
+		  AND COALESCE(rc.source_model, '') <> ''
+		ORDER BY COALESCE(rc.last_used_at, '') ASC, rc.id ASC
+		LIMIT ?
+	`, remaining)
+	if err != nil {
+		return cooling, err
+	}
+
+	// De-dupe by channel id.
+	seen := make(map[int64]struct{}, len(cooling)+len(active))
+	out := make([]ProbeTarget, 0, len(cooling)+len(active))
+	for _, t := range cooling {
+		if _, ok := seen[t.ChannelID]; ok {
+			continue
+		}
+		seen[t.ChannelID] = struct{}{}
+		out = append(out, t)
+	}
+	for _, t := range active {
+		if _, ok := seen[t.ChannelID]; ok {
+			continue
+		}
+		seen[t.ChannelID] = struct{}{}
+		out = append(out, t)
+	}
+	return out, nil
+}
+
+func queryProbeTargets(dbw *store.DB, query string, args ...any) ([]ProbeTarget, error) {
+	rows, err := dbw.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []ProbeTarget
+	for rows.Next() {
+		var t ProbeTarget
+		if err := rows.Scan(&t.ChannelID, &t.AccountID, &t.SiteID, &t.ModelName); err != nil {
+			continue
+		}
+		if t.ChannelID <= 0 || t.ModelName == "" {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out, nil
+}
+
+// ApplyProbeOutcome is a pure helper used by tests and optional direct callers.
+// It maps a ProbeOutcome onto the recorder without requiring a live DB target load.
+func ApplyProbeOutcome(
+	ctx context.Context,
+	recorder ChannelHealthRecorder,
+	target ProbeTarget,
+	outcome ProbeOutcome,
+) (string, error) {
+	if recorder == nil {
+		return "skipped", nil
+	}
+	modelName := target.ModelName
+	var modelPtr *string
+	if modelName != "" {
+		modelPtr = &modelName
+	}
+	accountID := target.AccountID
+	accountPtr := &accountID
+
+	switch outcome.Status {
+	case "success":
+		if err := recorder.RecordProbeSuccess(ctx, target.ChannelID, outcome.LatencyMs, modelPtr, accountPtr); err != nil {
+			return "inconclusive", err
+		}
+		return "success", nil
+	case "failure":
+		var statusPtr *int
+		if outcome.HTTPStatus > 0 {
+			st := outcome.HTTPStatus
+			statusPtr = &st
+		}
+		var errPtr *string
+		if outcome.ErrorText != "" {
+			e := outcome.ErrorText
+			errPtr = &e
+		}
+		if err := recorder.RecordProbeFailure(ctx, target.ChannelID, statusPtr, errPtr, modelPtr, accountPtr); err != nil {
+			return "inconclusive", err
+		}
+		return "failure", nil
+	case "skipped":
+		return "skipped", nil
+	default:
+		return "inconclusive", nil
+	}
 }

--- a/scheduler/model_probe_test.go
+++ b/scheduler/model_probe_test.go
@@ -1,0 +1,209 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/config"
+)
+
+// ---- fakes for #114 probe recording ----
+
+type fakeProbe struct {
+	mu       sync.Mutex
+	outcomes map[int64]ProbeOutcome
+	err      error
+	calls    []ProbeTarget
+}
+
+func (f *fakeProbe) ProbeChannel(_ context.Context, target ProbeTarget) (ProbeOutcome, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, target)
+	if f.err != nil {
+		return ProbeOutcome{}, f.err
+	}
+	if out, ok := f.outcomes[target.ChannelID]; ok {
+		return out, nil
+	}
+	return ProbeOutcome{Status: "inconclusive"}, nil
+}
+
+type fakeRecorder struct {
+	mu            sync.Mutex
+	successCalls  []probeSuccessCall
+	failureCalls  []probeFailureCall
+	successErr    error
+	failureErr    error
+}
+
+type probeSuccessCall struct {
+	ChannelID int64
+	LatencyMs float64
+	Model     *string
+	AccountID *int64
+}
+
+type probeFailureCall struct {
+	ChannelID  int64
+	HTTPStatus *int
+	ErrorText  *string
+	Model      *string
+	AccountID  *int64
+}
+
+func (f *fakeRecorder) RecordProbeSuccess(_ context.Context, channelID int64, latencyMs float64, modelName *string, actualAccountID *int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.successCalls = append(f.successCalls, probeSuccessCall{
+		ChannelID: channelID,
+		LatencyMs: latencyMs,
+		Model:     modelName,
+		AccountID: actualAccountID,
+	})
+	return f.successErr
+}
+
+func (f *fakeRecorder) RecordProbeFailure(_ context.Context, channelID int64, httpStatus *int, errorText *string, modelName *string, actualAccountID *int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failureCalls = append(f.failureCalls, probeFailureCall{
+		ChannelID:  channelID,
+		HTTPStatus: httpStatus,
+		ErrorText:  errorText,
+		Model:      modelName,
+		AccountID:  actualAccountID,
+	})
+	return f.failureErr
+}
+
+func TestApplyProbeOutcome_SuccessAndFailureTransitions(t *testing.T) {
+	rec := &fakeRecorder{}
+	target := ProbeTarget{ChannelID: 9, AccountID: 3, SiteID: 1, ModelName: "gpt-x"}
+
+	status, err := ApplyProbeOutcome(context.Background(), rec, target, ProbeOutcome{
+		Status:    "success",
+		LatencyMs: 42,
+	})
+	if err != nil || status != "success" {
+		t.Fatalf("success: status=%s err=%v", status, err)
+	}
+	if len(rec.successCalls) != 1 || rec.successCalls[0].LatencyMs != 42 {
+		t.Fatalf("success calls: %+v", rec.successCalls)
+	}
+
+	status, err = ApplyProbeOutcome(context.Background(), rec, target, ProbeOutcome{
+		Status:     "failure",
+		HTTPStatus: 502,
+		ErrorText:  "bad gateway",
+	})
+	if err != nil || status != "failure" {
+		t.Fatalf("failure: status=%s err=%v", status, err)
+	}
+	if len(rec.failureCalls) != 1 {
+		t.Fatalf("failure calls: %+v", rec.failureCalls)
+	}
+	fc := rec.failureCalls[0]
+	if fc.HTTPStatus == nil || *fc.HTTPStatus != 502 {
+		t.Fatalf("http status = %v", fc.HTTPStatus)
+	}
+	if fc.ErrorText == nil || *fc.ErrorText != "bad gateway" {
+		t.Fatalf("error text = %v", fc.ErrorText)
+	}
+
+	status, err = ApplyProbeOutcome(context.Background(), rec, target, ProbeOutcome{Status: "inconclusive"})
+	if err != nil || status != "inconclusive" {
+		t.Fatalf("inconclusive: status=%s err=%v", status, err)
+	}
+	// No additional success/failure calls.
+	if len(rec.successCalls) != 1 || len(rec.failureCalls) != 1 {
+		t.Fatalf("inconclusive mutated recorder: success=%d failure=%d", len(rec.successCalls), len(rec.failureCalls))
+	}
+}
+
+func TestModelProbeScheduler_ProbeOne_RecordsSuccessAndFailure(t *testing.T) {
+	cfg := &config.Config{
+		ModelAvailabilityProbeEnabled:     true,
+		ModelAvailabilityProbeIntervalMs:  60_000,
+		ModelAvailabilityProbeTimeoutMs:   5000,
+		ModelAvailabilityProbeConcurrency: 2,
+	}
+	s := NewModelProbeScheduler(cfg)
+	probe := &fakeProbe{outcomes: map[int64]ProbeOutcome{
+		1: {Status: "success", LatencyMs: 11},
+		2: {Status: "failure", HTTPStatus: 503, ErrorText: "unavailable"},
+		3: {Status: "inconclusive"},
+	}}
+	rec := &fakeRecorder{}
+	s.SetProbeExecutor(probe)
+	s.SetHealthRecorder(rec)
+
+	if got := s.probeOne(ProbeTarget{ChannelID: 1, AccountID: 10, ModelName: "m1"}, 5000); got != "success" {
+		t.Fatalf("channel 1 => %s", got)
+	}
+	if got := s.probeOne(ProbeTarget{ChannelID: 2, AccountID: 10, ModelName: "m2"}, 5000); got != "failure" {
+		t.Fatalf("channel 2 => %s", got)
+	}
+	if got := s.probeOne(ProbeTarget{ChannelID: 3, AccountID: 10, ModelName: "m3"}, 5000); got != "inconclusive" {
+		t.Fatalf("channel 3 => %s", got)
+	}
+
+	if len(rec.successCalls) != 1 || rec.successCalls[0].ChannelID != 1 {
+		t.Fatalf("success calls: %+v", rec.successCalls)
+	}
+	if len(rec.failureCalls) != 1 || rec.failureCalls[0].ChannelID != 2 {
+		t.Fatalf("failure calls: %+v", rec.failureCalls)
+	}
+}
+
+func TestModelProbeScheduler_ProbeOne_ExecutorErrorIsInconclusive(t *testing.T) {
+	s := NewModelProbeScheduler(testConfig())
+	s.SetProbeExecutor(&fakeProbe{err: errors.New("dial boom")})
+	s.SetHealthRecorder(&fakeRecorder{})
+	if got := s.probeOne(ProbeTarget{ChannelID: 1, AccountID: 1, ModelName: "m"}, 1000); got != "inconclusive" {
+		t.Fatalf("got %s", got)
+	}
+}
+
+func TestModelProbeScheduler_ProbeOne_MissingDepsSkipped(t *testing.T) {
+	s := NewModelProbeScheduler(testConfig())
+	if got := s.probeOne(ProbeTarget{ChannelID: 1, AccountID: 1, ModelName: "m"}, 1000); got != "skipped" {
+		t.Fatalf("got %s, want skipped when deps missing", got)
+	}
+}
+
+func TestModelProbeScheduler_DisabledDoesNotStartTicker(t *testing.T) {
+	cfg := testConfig()
+	cfg.ModelAvailabilityProbeEnabled = false
+	s := NewModelProbeScheduler(cfg)
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// running stays false when disabled
+	s.mu.Lock()
+	running := s.running
+	s.mu.Unlock()
+	if running {
+		t.Fatal("disabled scheduler should not mark running")
+	}
+	_ = s.Stop()
+}
+
+func TestModelProbeScheduler_StartStopWithDeps(t *testing.T) {
+	cfg := testConfig()
+	cfg.ModelAvailabilityProbeEnabled = true
+	cfg.ModelAvailabilityProbeIntervalMs = 60_000
+	s := NewModelProbeScheduler(cfg)
+	s.SetProbeExecutor(&fakeProbe{outcomes: map[int64]ProbeOutcome{}})
+	s.SetHealthRecorder(&fakeRecorder{})
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	time.Sleep(30 * time.Millisecond)
+	if err := s.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Wire `ModelProbeScheduler` to load a budgeted set of active/cooling `route_channels` and run lightweight probes under `MODEL_AVAILABILITY_PROBE_*`.
- Add `TokenRouter.RecordProbeFailure` + probe stamps on runtime health so success/failure feed cooldown/breaker state without credential cascade or key expiry.
- Document operator config and semantics in `docs/analysis/channel-health-probing.md`; cover success/failure transitions with unit tests.

## Test plan
- [x] `go test ./routing/ -run 'Probe|RecordProbe' -count=1`
- [x] `go test ./scheduler/ -run 'Probe|ModelProbe' -count=1`
- [x] `go test ./routing/ ./scheduler/ -count=1`

Closes #114