### PR TITLE
feat(routing): pluggable least-busy/latency/cost strategies #115

### DIFF
--- a/docs/analysis/routing-strategies.md
+++ b/docs/analysis/routing-strategies.md
@@ -1,0 +1,25 @@
+# Pluggable routing strategies (#115)
+
+## Operator-selectable values (`token_routes.routing_strategy`)
+
+| Value | Behavior | Default |
+|-------|----------|---------|
+| `weighted` | Existing cost/balance/usage weighted random (default) | **yes** |
+| `round_robin` | Deterministic rotation among eligible channels | |
+| `stable_first` | Prefer recently healthy sites with observation rotation | |
+| `least_busy` | Lowest load pressure (lease ratio when available, else historical volume) | |
+| `lowest_latency` / `latency` | Lowest site runtime first-byte/total EMA (#113) | |
+| `lowest_cost` / `cost` | Lowest `EffectiveUnitCost` (observed → configured → catalog → fallback) | |
+
+Unknown values normalize to `weighted`.
+
+## Invariants
+
+- Sticky sessions / exclude lists / eligibility filters run **before** strategy ranking.
+- Recent-failure soft filters apply to least_busy / lowest_latency / lowest_cost (same as weighted).
+- Strategies are per-route (`token_routes.routing_strategy`), not global-only.
+
+## Residual
+
+- Multi-instance load snapshots still process-local (see #118 Redis cooldown).
+- No ML bandit / LAR1 copy.

--- a/routing/matcher_test.go
+++ b/routing/matcher_test.go
@@ -491,6 +491,11 @@ func TestNormalizeRouteRoutingStrategy(t *testing.T) {
 		{"weighted", StrategyWeighted},
 		{"round_robin", StrategyRoundRobin},
 		{"stable_first", StrategyStableFirst},
+		{"least_busy", StrategyLeastBusy},
+		{"lowest_latency", StrategyLowestLatency},
+		{"latency", StrategyLowestLatency},
+		{"lowest_cost", StrategyLowestCost},
+		{"cost", StrategyLowestCost},
 		{"", StrategyWeighted},           // unknown → weighted
 		{"unknown", StrategyWeighted},    // unknown → weighted
 		{"WEIGHTED", StrategyWeighted},   // case sensitive? Let's check

--- a/routing/ports.go
+++ b/routing/ports.go
@@ -128,10 +128,23 @@ type RouteDecisionCandidate struct {
 type RouteRoutingStrategy string
 
 const (
-	StrategyWeighted     RouteRoutingStrategy = "weighted"
-	StrategyRoundRobin   RouteRoutingStrategy = "round_robin"
-	StrategyStableFirst  RouteRoutingStrategy = "stable_first"
+	StrategyWeighted       RouteRoutingStrategy = "weighted"
+	StrategyRoundRobin     RouteRoutingStrategy = "round_robin"
+	StrategyStableFirst    RouteRoutingStrategy = "stable_first"
+	StrategyLeastBusy      RouteRoutingStrategy = "least_busy"
+	StrategyLowestLatency  RouteRoutingStrategy = "lowest_latency"
+	StrategyLowestCost     RouteRoutingStrategy = "lowest_cost"
 )
+
+// KnownRouteRoutingStrategies lists operator-selectable strategies (#115).
+var KnownRouteRoutingStrategies = []RouteRoutingStrategy{
+	StrategyWeighted,
+	StrategyRoundRobin,
+	StrategyStableFirst,
+	StrategyLeastBusy,
+	StrategyLowestLatency,
+	StrategyLowestCost,
+}
 
 // NormalizeRouteRoutingStrategy normalizes a strategy string.
 func NormalizeRouteRoutingStrategy(value string) RouteRoutingStrategy {
@@ -140,6 +153,12 @@ func NormalizeRouteRoutingStrategy(value string) RouteRoutingStrategy {
 		return StrategyRoundRobin
 	case "stable_first":
 		return StrategyStableFirst
+	case "least_busy":
+		return StrategyLeastBusy
+	case "lowest_latency", "latency":
+		return StrategyLowestLatency
+	case "lowest_cost", "cost":
+		return StrategyLowestCost
 	default:
 		return StrategyWeighted
 	}

--- a/routing/router.go
+++ b/routing/router.go
@@ -297,6 +297,12 @@ func explainSelectionFromMatch(match *RouteMatch, requestedModel string, exclude
 		summary = append(summary, "路由策略：轮询")
 	case StrategyStableFirst:
 		summary = append(summary, "路由策略：稳定优先")
+	case StrategyLeastBusy:
+		summary = append(summary, "路由策略：最少繁忙")
+	case StrategyLowestLatency:
+		summary = append(summary, "路由策略：最低延迟")
+	case StrategyLowestCost:
+		summary = append(summary, "路由策略：最低成本")
 	default:
 		summary = append(summary, "路由策略：按权重随机")
 	}

--- a/routing/selector.go
+++ b/routing/selector.go
@@ -331,6 +331,29 @@ func (s *ChannelSelector) selectFromMatch(
 			recordSelection, rotationKey, obsKey, shouldUseObservation, excludeChannelIDs, nowISO, nowMs)
 	}
 
+	// Deterministic pluggable strategies (#115): least_busy / lowest_latency / lowest_cost.
+	// Same eligibility + recent-failure filters as weighted; exclude lists remain upstream.
+	if strategy == StrategyLeastBusy || strategy == StrategyLowestLatency || strategy == StrategyLowestCost {
+		breakerHealthy, _ := GetBreakerFilteredCandidatesByModelResolver(available, resolveModel)
+		filteredCandidates := FilterRecentlyFailedCandidates(breakerHealthy,
+			func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
+			nowMs, s.configuredMaxSec)
+		var selected *RouteChannelCandidate
+		switch strategy {
+		case StrategyLeastBusy:
+			selected = SelectLeastBusyCandidate(filteredCandidates, s.channelLoadProvider)
+		case StrategyLowestLatency:
+			selected = SelectLowestLatencyCandidate(filteredCandidates, resolveModel)
+		default:
+			selected = SelectLowestCostCandidate(filteredCandidates, resolveModel, s.pricingFn, s.fallbackUnitCost)
+		}
+		if selected == nil {
+			return nil, nil
+		}
+		return s.finalizeDispatch(ctx, selected, match, requestedModel, mappedModel, policy,
+			recordSelection, "", "", false, excludeChannelIDs, nowISO, nowMs)
+	}
+
 	// Weighted: priority layers
 	layers := make(map[int64][]RouteChannelCandidate)
 	for _, c := range available {

--- a/routing/strategy_select.go
+++ b/routing/strategy_select.go
@@ -1,0 +1,164 @@
+package routing
+
+import (
+	"math"
+	"sort"
+)
+
+// SelectLeastBusyCandidate picks the candidate with the lowest load pressure.
+// Prefer providers that expose lease/concurrency data; fall back to historical
+// success/fail volume so the strategy still works without a load provider.
+// Sticky exclude lists are applied upstream — this only ranks the filtered pool.
+func SelectLeastBusyCandidate(
+	candidates []RouteChannelCandidate,
+	loadProvider ChannelLoadSnapshotProvider,
+) *RouteChannelCandidate {
+	if len(candidates) == 0 {
+		return nil
+	}
+	if len(candidates) == 1 {
+		return &candidates[0]
+	}
+
+	type scored struct {
+		idx   int
+		score float64
+	}
+	ranked := make([]scored, 0, len(candidates))
+	for i, c := range candidates {
+		score := leastBusyScore(c, loadProvider)
+		ranked = append(ranked, scored{idx: i, score: score})
+	}
+	sort.SliceStable(ranked, func(a, b int) bool {
+		if ranked[a].score != ranked[b].score {
+			return ranked[a].score < ranked[b].score
+		}
+		ca, cb := candidates[ranked[a].idx], candidates[ranked[b].idx]
+		if ca.Channel.Weight != cb.Channel.Weight {
+			return ca.Channel.Weight > cb.Channel.Weight
+		}
+		return ca.Channel.ID < cb.Channel.ID
+	})
+	return &candidates[ranked[0].idx]
+}
+
+func leastBusyScore(c RouteChannelCandidate, loadProvider ChannelLoadSnapshotProvider) float64 {
+	if loadProvider != nil {
+		snap := loadProvider.GetChannelLoadSnapshot(ChannelLoadParams{
+			ChannelID:            c.Channel.ID,
+			AccountExtraConfig:   c.Account.ExtraConfig,
+			AccountOAuthProvider: c.Account.OAuthProvider,
+		})
+		if snap.SessionScoped && snap.ConcurrencyLimit > 0 {
+			active := float64(snap.ActiveLeaseCount) / math.Max(1, float64(snap.ConcurrencyLimit))
+			waiting := float64(snap.WaitingCount) / math.Max(1, float64(snap.ConcurrencyLimit))
+			sat := 0.0
+			if snap.Saturated {
+				sat = 1.0
+			}
+			return active + 0.5*waiting + sat
+		}
+	}
+	total := float64(c.Channel.SuccessCount + c.Channel.FailCount)
+	return total
+}
+
+// SelectLowestLatencyCandidate ranks by site runtime first-byte/total latency EMA.
+func SelectLowestLatencyCandidate(
+	candidates []RouteChannelCandidate,
+	modelResolver func(RouteChannelCandidate) string,
+) *RouteChannelCandidate {
+	if len(candidates) == 0 {
+		return nil
+	}
+	if modelResolver == nil {
+		modelResolver = func(RouteChannelCandidate) string { return "" }
+	}
+	if len(candidates) == 1 {
+		return &candidates[0]
+	}
+
+	type scored struct {
+		idx     int
+		latency float64
+		known   bool
+	}
+	ranked := make([]scored, 0, len(candidates))
+	for i, c := range candidates {
+		lat, known := resolveStrategyLatencyMs(c.Site.ID, modelResolver(c))
+		ranked = append(ranked, scored{idx: i, latency: lat, known: known})
+	}
+	sort.SliceStable(ranked, func(a, b int) bool {
+		if ranked[a].known != ranked[b].known {
+			return ranked[a].known
+		}
+		if ranked[a].latency != ranked[b].latency {
+			return ranked[a].latency < ranked[b].latency
+		}
+		ca, cb := candidates[ranked[a].idx], candidates[ranked[b].idx]
+		return ca.Channel.ID < cb.Channel.ID
+	})
+	return &candidates[ranked[0].idx]
+}
+
+func resolveStrategyLatencyMs(siteID int64, model string) (float64, bool) {
+	healthStateMu.RLock()
+	defer healthStateMu.RUnlock()
+
+	if model != "" {
+		if byModel, ok := siteModelRuntimeHealthStates[siteID]; ok {
+			if ms := byModel[model]; ms != nil {
+				if ms.FirstByteEMAMs != nil && *ms.FirstByteEMAMs > 0 {
+					return *ms.FirstByteEMAMs, true
+				}
+				if ms.LatencyEMAMs != nil && *ms.LatencyEMAMs > 0 {
+					return *ms.LatencyEMAMs, true
+				}
+			}
+		}
+	}
+	if state := siteRuntimeHealthStates[siteID]; state != nil {
+		if state.FirstByteEMAMs != nil && *state.FirstByteEMAMs > 0 {
+			return *state.FirstByteEMAMs, true
+		}
+		if state.LatencyEMAMs != nil && *state.LatencyEMAMs > 0 {
+			return *state.LatencyEMAMs, true
+		}
+	}
+	return math.Inf(1), false
+}
+
+// SelectLowestCostCandidate picks the candidate with the lowest effective unit cost.
+func SelectLowestCostCandidate(
+	candidates []RouteChannelCandidate,
+	modelResolver func(RouteChannelCandidate) string,
+	pricingFn func(siteID, accountID int64, modelName string) *float64,
+	fallbackUnitCost float64,
+) *RouteChannelCandidate {
+	if len(candidates) == 0 {
+		return nil
+	}
+	if modelResolver == nil {
+		modelResolver = func(RouteChannelCandidate) string { return "" }
+	}
+	if len(candidates) == 1 {
+		return &candidates[0]
+	}
+
+	type scored struct {
+		idx  int
+		cost float64
+	}
+	ranked := make([]scored, 0, len(candidates))
+	for i, c := range candidates {
+		sig := EffectiveUnitCost(c, modelResolver(c), pricingFn, fallbackUnitCost)
+		ranked = append(ranked, scored{idx: i, cost: sig.UnitCost})
+	}
+	sort.SliceStable(ranked, func(a, b int) bool {
+		if ranked[a].cost != ranked[b].cost {
+			return ranked[a].cost < ranked[b].cost
+		}
+		return candidates[ranked[a].idx].Channel.ID < candidates[ranked[b].idx].Channel.ID
+	})
+	return &candidates[ranked[0].idx]
+}

--- a/routing/strategy_select_test.go
+++ b/routing/strategy_select_test.go
@@ -1,0 +1,88 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func mkStrategyCandidate(channelID, siteID, weight, success, fail int64, unitCost *float64) RouteChannelCandidate {
+	return RouteChannelCandidate{
+		Channel: store.RouteChannel{
+			ID:           channelID,
+			Weight:       weight,
+			SuccessCount: success,
+			FailCount:    fail,
+		},
+		Account: store.Account{ID: channelID, UnitCost: unitCost},
+		Site:    store.Site{ID: siteID, Name: "s"},
+	}
+}
+
+type fakeLoadProvider map[int64]ChannelLoadSnapshot
+
+func (f fakeLoadProvider) GetChannelLoadSnapshot(p ChannelLoadParams) ChannelLoadSnapshot {
+	if s, ok := f[p.ChannelID]; ok {
+		return s
+	}
+	return ChannelLoadSnapshot{}
+}
+
+func TestSelectLeastBusyCandidate_PrefersLowerLoad(t *testing.T) {
+	c1 := mkStrategyCandidate(1, 10, 1, 0, 0, nil)
+	c2 := mkStrategyCandidate(2, 20, 1, 0, 0, nil)
+	load := fakeLoadProvider{
+		1: {SessionScoped: true, ConcurrencyLimit: 10, ActiveLeaseCount: 8, WaitingCount: 2, Saturated: true},
+		2: {SessionScoped: true, ConcurrencyLimit: 10, ActiveLeaseCount: 1, WaitingCount: 0},
+	}
+	got := SelectLeastBusyCandidate([]RouteChannelCandidate{c1, c2}, load)
+	if got == nil || got.Channel.ID != 2 {
+		t.Fatalf("expected channel 2, got %#v", got)
+	}
+}
+
+func TestSelectLowestCostCandidate_PicksCheapest(t *testing.T) {
+	cheap := 0.1
+	expensive := 5.0
+	c1 := mkStrategyCandidate(1, 10, 1, 0, 0, &expensive)
+	c2 := mkStrategyCandidate(2, 20, 1, 0, 0, &cheap)
+	got := SelectLowestCostCandidate([]RouteChannelCandidate{c1, c2}, func(RouteChannelCandidate) string { return "gpt-4o" }, nil, 1.0)
+	if got == nil || got.Channel.ID != 2 {
+		t.Fatalf("expected channel 2, got %#v", got)
+	}
+}
+
+func TestSelectLowestLatencyCandidate_PrefersLowerEMA(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	c1 := mkStrategyCandidate(1, 11, 1, 0, 0, nil)
+	c2 := mkStrategyCandidate(2, 22, 1, 0, 0, nil)
+
+	// Seed site runtime latency EMAs via RecordSiteRuntimeSuccess.
+	// Site 11 slow, site 22 fast.
+	for i := 0; i < 5; i++ {
+		RecordSiteRuntimeSuccess(11, 2000, nil, 1500)
+		RecordSiteRuntimeSuccess(22, 200, nil, 80)
+	}
+
+	got := SelectLowestLatencyCandidate([]RouteChannelCandidate{c1, c2}, func(RouteChannelCandidate) string { return "gpt-4o" })
+	if got == nil || got.Channel.ID != 2 {
+		t.Fatalf("expected channel 2 (faster site), got %#v", got)
+	}
+}
+
+func TestNormalizeRouteRoutingStrategy_NewStrategies(t *testing.T) {
+	if NormalizeRouteRoutingStrategy("least_busy") != StrategyLeastBusy {
+		t.Fatal("least_busy")
+	}
+	if NormalizeRouteRoutingStrategy("lowest_latency") != StrategyLowestLatency {
+		t.Fatal("lowest_latency")
+	}
+	if NormalizeRouteRoutingStrategy("lowest_cost") != StrategyLowestCost {
+		t.Fatal("lowest_cost")
+	}
+	if len(KnownRouteRoutingStrategies) < 6 {
+		t.Fatalf("expected >=6 strategies, got %d", len(KnownRouteRoutingStrategies))
+	}
+}


### PR DESCRIPTION
## Summary
- Add `least_busy`, `lowest_latency`/`latency`, `lowest_cost`/`cost` routing strategies
- Preserve sticky exclude lists + eligibility filters upstream of ranking
- Document operator-selectable values in `docs/analysis/routing-strategies.md`

## Test plan
- [x] `go test ./routing -run 'TestSelectLeastBusy|TestSelectLowest|TestNormalizeRouteRoutingStrategy'`
- [ ] CI green

Closes #115