### PR TITLE
feat(routing): pluggable named strategies least_busy/latency/cost #115

### DIFF
--- a/docs/analysis/routing-strategies.md
+++ b/docs/analysis/routing-strategies.md
@@ -1,0 +1,104 @@
+# Pluggable routing strategies (#115)
+
+**Date:** 2026-07-17  
+**Lane:** competitive learn / routing  
+**SSOT code:** `routing/ports.go` (`RouteRoutingStrategy`), `routing/strategies.go`, `routing/selector.go`  
+**Peers:** LiteLLM `RoutingStrategy` catalog; AxonHub load-balance strategies
+
+## Goal
+
+Expose **named, operator-selectable** channel selection strategies beyond the historical hard-coded weighted blend, without breaking sticky sessions, exclude lists, cooldown, or Fibonacci failure isolation.
+
+## Strategy catalog
+
+| Name | Constant | Selection rule | Priority (P) | Random? | Default? |
+|:-----|:---------|:---------------|:-------------|:--------|:---------|
+| `weighted` | `StrategyWeighted` | Multi-signal contribution (weight, cost, balance, usage, health, load) then weighted random | Hard layer gate | Yes | **Yes** |
+| `round_robin` | `StrategyRoundRobin` | Least-recently-selected among healthy candidates | Ignored | No | No |
+| `stable_first` | `StrategyStableFirst` | Primary/observation site pools + site rotation | Site order (soft) | No | No |
+| `least_busy` | `StrategyLeastBusy` | Argmin concurrency load score | Hard layer gate | No | No |
+| `lowest_latency` | `StrategyLowestLatency` | Argmin TTFT/first-byte EMA, else latency EMA | Hard layer gate | No | No |
+| `lowest_cost` | `StrategyLowestCost` | Argmin effective unit cost | Hard layer gate | No | No |
+
+### Normalization
+
+`NormalizeRouteRoutingStrategy` accepts:
+
+- Canonical snake_case: `weighted`, `round_robin`, `stable_first`, `least_busy`, `lowest_latency`, `lowest_cost`
+- Hyphen aliases: `least-busy`, `lowest-latency`, `lowest-cost`, `round-robin`, `stable-first`
+- Short aliases: `latency` → `lowest_latency`, `cost` → `lowest_cost`
+- Unknown / empty → **`weighted`** (documented default; preserves historical routes)
+
+Storage field: `token_routes.routing_strategy` (per-route). There is no separate global env switch in this wave; unset routes stay weighted via DB default `'weighted'`.
+
+## Score signals (new pure strategies)
+
+### `least_busy`
+
+Uses `ChannelLoadSnapshot` (same lease/concurrency telemetry already feeding weighted load multipliers):
+
+```
+score = active/limit + 2 * waiting/limit + (1 if saturated else 0)
+```
+
+Channels without session-scoped concurrency telemetry score `0` (treated idle). Lower score wins; ties break by ascending `channel.id`.
+
+### `lowest_latency`
+
+Reads in-memory site runtime health (#113 TTFT work):
+
+1. Model-scoped `FirstByteEMAMs` if present
+2. Model-scoped `LatencyEMAMs`
+3. Site-global first-byte / latency EMA
+4. Unknown → `+Inf` (sorted last so observed channels win)
+
+### `lowest_cost`
+
+Uses existing `EffectiveUnitCost` provenance chain:
+
+`observed (totalCost/successCount)` → `account.unitCost` → pricing catalog → fallback unit cost.
+
+## Shared invariants (must not break)
+
+These apply to **all** strategies, including the new pure ones:
+
+1. **Exclude lists** — `SelectNextChannel` / failover still remove already-tried channel IDs before strategy scoring.
+2. **Sticky / preferred** — `SelectPreferredChannel` still eligibility-checks the preferred ID first; strategy only affects free selection when preferred is unavailable.
+3. **Cooldown / breaker / recent-failure soft filter** — eligibility and breaker filtering run **before** strategy pick; named strategies never re-admit cooled channels.
+4. **Priority layers** — `weighted`, `least_busy`, `lowest_latency`, `lowest_cost` only compete inside the lowest available priority layer (same hard-P gate as historical weighted).
+5. **OAuth route units** — member selection inside a unit remains unit-local; unit presence is still eligibility-gated.
+
+## Residual multi-instance limits
+
+| State | Scope today | Multi-instance impact |
+|:------|:------------|:----------------------|
+| Runtime latency EMA / TTFT | In-process memory (+ optional settings persist) | Each replica scores from its own samples; cross-replica sharing is future work (#118) |
+| Channel load snapshots | In-process leases | Least-busy is **per-process**; load is not cluster-global |
+| Stable-first rotation keys | In-process maps | Rotation not shared across replicas |
+| Channel cooldown / failCount | DB | Shared across instances |
+| Route strategy setting | DB `routing_strategy` | Shared |
+
+Operators running multiple replicas should treat pure latency/busy strategies as **best-effort local signals**, not cluster-perfect LB. Weighted remains the safest default when signals are sparse.
+
+## Operator guidance
+
+| Goal | Recommended strategy |
+|:-----|:---------------------|
+| Balanced multi-signal production default | `weighted` |
+| Drain load from saturated session-scoped accounts | `least_busy` |
+| Prefer snappy TTFT after warm traffic | `lowest_latency` |
+| Strict cheapest-first (catalog/observed cost) | `lowest_cost` |
+| Even exploration / testing | `round_robin` |
+| Prefer proven healthy sites | `stable_first` |
+
+## Out of scope (this issue)
+
+- ML / bandit routers
+- Copying LiteLLM LAR1 verbatim
+- Frontend redesign of strategy labels (admin can already set `routingStrategy` string)
+- Shared multi-instance load/latency store (#118)
+
+## Tests
+
+- `routing/strategies_test.go` — normalization, pure-strategy invariants, deterministic tie-break
+- Existing weighted / RR / stable_first golden + algorithm tests remain authoritative for legacy strategies

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -229,9 +229,9 @@ func (h *tokenRoutesHandler) createRoute(w http.ResponseWriter, r *http.Request)
 		enabled = *body.Enabled
 	}
 
-	routingStrategy := "weighted"
+	routingStrategy := string(routing.StrategyWeighted)
 	if body.RoutingStrategy != nil {
-		routingStrategy = *body.RoutingStrategy
+		routingStrategy = string(routing.NormalizeRouteRoutingStrategy(*body.RoutingStrategy))
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -322,7 +322,8 @@ func (h *tokenRoutesHandler) updateRoute(w http.ResponseWriter, r *http.Request)
 	}
 	if v, ok := body["routingStrategy"]; ok {
 		if s, ok2 := v.(string); ok2 {
-			h.db.Exec(h.db.Rebind("UPDATE token_routes SET routing_strategy = ?, updated_at = ? WHERE id = ?"), s, now, id)
+			normalized := string(routing.NormalizeRouteRoutingStrategy(s))
+			h.db.Exec(h.db.Rebind("UPDATE token_routes SET routing_strategy = ?, updated_at = ? WHERE id = ?"), normalized, now, id)
 		}
 	}
 	if v, ok := body["modelMapping"]; ok {

--- a/routing/doc.go
+++ b/routing/doc.go
@@ -1,3 +1,4 @@
 // Package routing implements the token-based channel selection engine with Fibonacci
-// backoff cooldown and weighted random distribution.
+// backoff cooldown and pluggable routing strategies (weighted default, round_robin,
+// stable_first, least_busy, lowest_latency, lowest_cost).
 package routing

--- a/routing/ports.go
+++ b/routing/ports.go
@@ -5,6 +5,7 @@ package routing
 
 import (
 	"context"
+	"strings"
 
 	"github.com/tokendancelab/metapi-go/store"
 )
@@ -125,21 +126,46 @@ type RouteDecisionCandidate struct {
 }
 
 // RouteRoutingStrategy is the strategy for a route.
+// Named strategies are operator-selectable per route (token_routes.routing_strategy).
+// Default remains weighted for parity with historical MetAPI behavior.
 type RouteRoutingStrategy string
 
 const (
-	StrategyWeighted     RouteRoutingStrategy = "weighted"
-	StrategyRoundRobin   RouteRoutingStrategy = "round_robin"
-	StrategyStableFirst  RouteRoutingStrategy = "stable_first"
+	StrategyWeighted       RouteRoutingStrategy = "weighted"
+	StrategyRoundRobin     RouteRoutingStrategy = "round_robin"
+	StrategyStableFirst    RouteRoutingStrategy = "stable_first"
+	StrategyLeastBusy      RouteRoutingStrategy = "least_busy"
+	StrategyLowestLatency  RouteRoutingStrategy = "lowest_latency"
+	StrategyLowestCost     RouteRoutingStrategy = "lowest_cost"
 )
 
+// KnownRouteRoutingStrategies lists accepted strategy names (excluding aliases).
+var KnownRouteRoutingStrategies = []RouteRoutingStrategy{
+	StrategyWeighted,
+	StrategyRoundRobin,
+	StrategyStableFirst,
+	StrategyLeastBusy,
+	StrategyLowestLatency,
+	StrategyLowestCost,
+}
+
 // NormalizeRouteRoutingStrategy normalizes a strategy string.
+// Unknown / empty values fall back to weighted (documented default).
+// Accepts hyphen aliases (least-busy, lowest-latency, lowest-cost) for operator convenience.
 func NormalizeRouteRoutingStrategy(value string) RouteRoutingStrategy {
-	switch value {
-	case "round_robin":
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "round_robin", "round-robin":
 		return StrategyRoundRobin
-	case "stable_first":
+	case "stable_first", "stable-first":
 		return StrategyStableFirst
+	case "least_busy", "least-busy":
+		return StrategyLeastBusy
+	case "lowest_latency", "lowest-latency", "latency":
+		return StrategyLowestLatency
+	case "lowest_cost", "lowest-cost", "cost":
+		return StrategyLowestCost
+	case "weighted", "":
+		return StrategyWeighted
 	default:
 		return StrategyWeighted
 	}
@@ -148,6 +174,27 @@ func NormalizeRouteRoutingStrategy(value string) RouteRoutingStrategy {
 // IsRoundRobinRouteRoutingStrategy checks if a strategy is round_robin.
 func IsRoundRobinRouteRoutingStrategy(value string) bool {
 	return NormalizeRouteRoutingStrategy(value) == StrategyRoundRobin
+}
+
+// IsPriorityLayerRoutingStrategy reports strategies that walk priority layers
+// (P is a hard gate) then pick inside the first non-empty layer.
+func IsPriorityLayerRoutingStrategy(strategy RouteRoutingStrategy) bool {
+	switch strategy {
+	case StrategyWeighted, StrategyLeastBusy, StrategyLowestLatency, StrategyLowestCost:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsDeterministicNamedStrategy reports pure argmin strategies (no random blend).
+func IsDeterministicNamedStrategy(strategy RouteRoutingStrategy) bool {
+	switch strategy {
+	case StrategyLeastBusy, StrategyLowestLatency, StrategyLowestCost:
+		return true
+	default:
+		return false
+	}
 }
 
 // RouteMatch holds a matched route with its resolved channels.

--- a/routing/selector.go
+++ b/routing/selector.go
@@ -331,38 +331,49 @@ func (s *ChannelSelector) selectFromMatch(
 			recordSelection, rotationKey, obsKey, shouldUseObservation, excludeChannelIDs, nowISO, nowMs)
 	}
 
-	// Weighted: priority layers
-	layers := make(map[int64][]RouteChannelCandidate)
-	for _, c := range available {
-		layers[c.Channel.Priority] = append(layers[c.Channel.Priority], c)
-	}
+	// Priority-layer strategies: weighted (default) + named pure strategies
+	// (least_busy / lowest_latency / lowest_cost). P is a hard gate; selection
+	// only happens inside the first priority layer that still has healthy candidates.
+	if IsPriorityLayerRoutingStrategy(strategy) {
+		layers := make(map[int64][]RouteChannelCandidate)
+		for _, c := range available {
+			layers[c.Channel.Priority] = append(layers[c.Channel.Priority], c)
+		}
 
-	var priorities []int64
-	for p := range layers {
-		priorities = append(priorities, p)
-	}
-	// Sort ascending
-	for i := 0; i < len(priorities); i++ {
-		for j := i + 1; j < len(priorities); j++ {
-			if priorities[j] < priorities[i] {
-				priorities[i], priorities[j] = priorities[j], priorities[i]
+		var priorities []int64
+		for p := range layers {
+			priorities = append(priorities, p)
+		}
+		// Sort ascending
+		for i := 0; i < len(priorities); i++ {
+			for j := i + 1; j < len(priorities); j++ {
+				if priorities[j] < priorities[i] {
+					priorities[i], priorities[j] = priorities[j], priorities[i]
+				}
 			}
 		}
-	}
 
-	for _, priority := range priorities {
-		rawLayer := layers[priority]
-		breakerHealthy, _ := GetBreakerFilteredCandidatesByModelResolver(rawLayer, resolveModel)
-		filteredLayer := FilterRecentlyFailedCandidates(breakerHealthy,
-			func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
-			nowMs, s.configuredMaxSec)
+		for _, priority := range priorities {
+			rawLayer := layers[priority]
+			breakerHealthy, _ := GetBreakerFilteredCandidatesByModelResolver(rawLayer, resolveModel)
+			filteredLayer := FilterRecentlyFailedCandidates(breakerHealthy,
+				func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
+				nowMs, s.configuredMaxSec)
 
-		selected := s.weightedRandomSelect(filteredLayer, resolveModel, policy)
-		if selected == nil {
-			continue
+			var selected *RouteChannelCandidate
+			if IsDeterministicNamedStrategy(strategy) {
+				selected = s.namedStrategySelect(strategy, filteredLayer, resolveModel)
+			} else {
+				selected = s.weightedRandomSelect(filteredLayer, resolveModel, policy)
+			}
+			if selected == nil {
+				continue
+			}
+			return s.finalizeDispatch(ctx, selected, match, requestedModel, mappedModel, policy,
+				recordSelection, "", "", false, excludeChannelIDs, nowISO, nowMs)
 		}
-		return s.finalizeDispatch(ctx, selected, match, requestedModel, mappedModel, policy,
-			recordSelection, "", "", false, excludeChannelIDs, nowISO, nowMs)
+
+		return nil, nil
 	}
 
 	return nil, nil
@@ -694,6 +705,23 @@ func (s *ChannelSelector) weightedRandomSelect(
 		time.Now().UnixMilli(),
 		WeightedMode,
 		"",
+		s.pricingFn,
+		s.fallbackUnitCost,
+	)
+	return result.Selected
+}
+
+// namedStrategySelect runs least_busy / lowest_latency / lowest_cost inside a priority layer.
+func (s *ChannelSelector) namedStrategySelect(
+	strategy RouteRoutingStrategy,
+	candidates []RouteChannelCandidate,
+	modelResolver func(RouteChannelCandidate) string,
+) *RouteChannelCandidate {
+	result := SelectByNamedStrategy(
+		strategy,
+		candidates,
+		modelResolver,
+		s.channelLoadProvider,
 		s.pricingFn,
 		s.fallbackUnitCost,
 	)

--- a/routing/strategies.go
+++ b/routing/strategies.go
@@ -1,0 +1,186 @@
+package routing
+
+import (
+	"math"
+	"sort"
+)
+
+// StrategySelectionResult is the outcome of a named deterministic strategy.
+type StrategySelectionResult struct {
+	Selected *RouteChannelCandidate
+	Details  []StrategySelectionDetail
+}
+
+// StrategySelectionDetail explains one candidate under a named strategy.
+type StrategySelectionDetail struct {
+	Candidate RouteChannelCandidate
+	Score     float64
+	Reason    string
+}
+
+// SelectByNamedStrategy picks a channel under a pure named strategy
+// (least_busy / lowest_latency / lowest_cost). Unknown strategies return nil.
+//
+// All three keep priority-layer filtering outside this function (caller walks P).
+// Sticky preferred-channel and exclude lists are also applied by the caller
+// before candidates reach this function.
+func SelectByNamedStrategy(
+	strategy RouteRoutingStrategy,
+	candidates []RouteChannelCandidate,
+	modelResolver func(RouteChannelCandidate) string,
+	channelLoadProvider ChannelLoadSnapshotProvider,
+	pricingFn func(siteID, accountID int64, modelName string) *float64,
+	fallbackUnitCost float64,
+) StrategySelectionResult {
+	if len(candidates) == 0 {
+		return StrategySelectionResult{}
+	}
+	if modelResolver == nil {
+		modelResolver = func(RouteChannelCandidate) string { return "" }
+	}
+	switch NormalizeRouteRoutingStrategy(string(strategy)) {
+	case StrategyLeastBusy:
+		return selectLeastBusy(candidates, channelLoadProvider)
+	case StrategyLowestLatency:
+		return selectLowestLatency(candidates, modelResolver)
+	case StrategyLowestCost:
+		return selectLowestCost(candidates, modelResolver, pricingFn, fallbackUnitCost)
+	default:
+		return StrategySelectionResult{}
+	}
+}
+
+type strategyRank struct {
+	idx    int
+	score  float64 // lower is better
+	reason string
+}
+
+func selectLeastBusy(candidates []RouteChannelCandidate, loadProvider ChannelLoadSnapshotProvider) StrategySelectionResult {
+	ranks := make([]strategyRank, 0, len(candidates))
+	for i, c := range candidates {
+		snap := ChannelLoadSnapshot{}
+		if loadProvider != nil {
+			snap = loadProvider.GetChannelLoadSnapshot(ChannelLoadParams{
+				ChannelID:            c.Channel.ID,
+				AccountExtraConfig:   c.Account.ExtraConfig,
+				AccountOAuthProvider: c.Account.OAuthProvider,
+			})
+		}
+		score, reason := leastBusyScore(snap)
+		ranks = append(ranks, strategyRank{idx: i, score: score, reason: reason})
+	}
+	return pickLowestScore(candidates, ranks)
+}
+
+func leastBusyScore(snap ChannelLoadSnapshot) (float64, string) {
+	// Without session/concurrency telemetry, treat as idle (score 0).
+	if !snap.SessionScoped || snap.ConcurrencyLimit <= 0 {
+		return 0, "least_busy: no concurrency telemetry (treated idle)"
+	}
+	active := float64(snap.ActiveLeaseCount)
+	waiting := float64(snap.WaitingCount)
+	limit := math.Max(1, float64(snap.ConcurrencyLimit))
+	// Prefer free capacity; waiting queue is more expensive than an active lease.
+	score := active/limit + 2.0*(waiting/limit)
+	if snap.Saturated {
+		score += 1.0
+	}
+	return score, "least_busy: active/limit + 2*waiting/limit (+1 if saturated)"
+}
+
+func selectLowestLatency(candidates []RouteChannelCandidate, modelResolver func(RouteChannelCandidate) string) StrategySelectionResult {
+	ranks := make([]strategyRank, 0, len(candidates))
+	for i, c := range candidates {
+		model := modelResolver(c)
+		score, reason := lowestLatencyScore(c.Site.ID, model)
+		ranks = append(ranks, strategyRank{idx: i, score: score, reason: reason})
+	}
+	return pickLowestScore(candidates, ranks)
+}
+
+func lowestLatencyScore(siteID int64, modelName string) (float64, string) {
+	// Prefer TTFT/first-byte EMA (#113), then total latency EMA.
+	// Unknown latency sorts last (math.MaxFloat64) so observed channels win.
+	const unknown = math.MaxFloat64
+
+	healthStateMu.RLock()
+	defer healthStateMu.RUnlock()
+
+	// Model-scoped first, then global site state.
+	if state := peekRuntimeLatencyState(siteID, modelName); state != nil {
+		if state.FirstByteEMAMs != nil && *state.FirstByteEMAMs > 0 {
+			return *state.FirstByteEMAMs, "lowest_latency: first-byte EMA (model)"
+		}
+		if state.LatencyEMAMs != nil && *state.LatencyEMAMs > 0 {
+			return *state.LatencyEMAMs, "lowest_latency: latency EMA (model)"
+		}
+	}
+	if state := siteRuntimeHealthStates[siteID]; state != nil {
+		if state.FirstByteEMAMs != nil && *state.FirstByteEMAMs > 0 {
+			return *state.FirstByteEMAMs, "lowest_latency: first-byte EMA (site)"
+		}
+		if state.LatencyEMAMs != nil && *state.LatencyEMAMs > 0 {
+			return *state.LatencyEMAMs, "lowest_latency: latency EMA (site)"
+		}
+	}
+	return unknown, "lowest_latency: no latency sample (sorted last)"
+}
+
+func peekRuntimeLatencyState(siteID int64, modelName string) *SiteRuntimeHealthState {
+	modelKey := NormalizeModelAlias(modelName)
+	if modelKey == "" {
+		return nil
+	}
+	if modelStates, ok := siteModelRuntimeHealthStates[siteID]; ok {
+		return modelStates[modelKey]
+	}
+	return nil
+}
+
+func selectLowestCost(
+	candidates []RouteChannelCandidate,
+	modelResolver func(RouteChannelCandidate) string,
+	pricingFn func(siteID, accountID int64, modelName string) *float64,
+	fallbackUnitCost float64,
+) StrategySelectionResult {
+	ranks := make([]strategyRank, 0, len(candidates))
+	for i, c := range candidates {
+		model := modelResolver(c)
+		signal := EffectiveUnitCost(c, model, pricingFn, fallbackUnitCost)
+		ranks = append(ranks, strategyRank{
+			idx:    i,
+			score:  signal.UnitCost,
+			reason: "lowest_cost: unit_cost source=" + signal.Source,
+		})
+	}
+	return pickLowestScore(candidates, ranks)
+}
+
+func pickLowestScore(candidates []RouteChannelCandidate, ranks []strategyRank) StrategySelectionResult {
+	if len(ranks) == 0 {
+		return StrategySelectionResult{}
+	}
+	// Stable sort: score ASC, then channel ID ASC for determinism.
+	sort.SliceStable(ranks, func(a, b int) bool {
+		da := ranks[a].score - ranks[b].score
+		if math.Abs(da) > 1e-12 {
+			return da < 0
+		}
+		return candidates[ranks[a].idx].Channel.ID < candidates[ranks[b].idx].Channel.ID
+	})
+
+	details := make([]StrategySelectionDetail, 0, len(ranks))
+	for _, r := range ranks {
+		details = append(details, StrategySelectionDetail{
+			Candidate: candidates[r.idx],
+			Score:     r.score,
+			Reason:    r.reason,
+		})
+	}
+	selected := candidates[ranks[0].idx]
+	return StrategySelectionResult{
+		Selected: &selected,
+		Details:  details,
+	}
+}

--- a/routing/strategies_test.go
+++ b/routing/strategies_test.go
@@ -1,0 +1,185 @@
+package routing
+
+import (
+	"math"
+	"testing"
+)
+
+// mockLoadProvider implements ChannelLoadSnapshotProvider for strategy tests.
+type mockLoadProvider map[int64]ChannelLoadSnapshot
+
+func (m mockLoadProvider) GetChannelLoadSnapshot(params ChannelLoadParams) ChannelLoadSnapshot {
+	if snap, ok := m[params.ChannelID]; ok {
+		return snap
+	}
+	return ChannelLoadSnapshot{}
+}
+
+func strategyCandidates() []RouteChannelCandidate {
+	// Same priority so named strategies compare purely on their score signal.
+	// successCount=0 so EffectiveUnitCost uses configured unitCost (not observed avg).
+	return []RouteChannelCandidate{
+		makeCandidate(1, 10, 101, 100, 0, 0, 0, 0, 1.0, ptrFloat(0.05), 100.0, nil), // expensive
+		makeCandidate(2, 20, 201, 10, 0, 0, 0, 0, 1.0, ptrFloat(0.01), 100.0, nil),  // cheap
+		makeCandidate(3, 30, 301, 50, 0, 0, 0, 0, 1.0, ptrFloat(0.02), 100.0, nil),  // mid
+	}
+}
+
+func TestNormalizeRouteRoutingStrategy_NamedAndAliases(t *testing.T) {
+	cases := []struct {
+		in   string
+		want RouteRoutingStrategy
+	}{
+		{"", StrategyWeighted},
+		{"weighted", StrategyWeighted},
+		{"unknown", StrategyWeighted},
+		{"round_robin", StrategyRoundRobin},
+		{"round-robin", StrategyRoundRobin},
+		{"stable_first", StrategyStableFirst},
+		{"stable-first", StrategyStableFirst},
+		{"least_busy", StrategyLeastBusy},
+		{"least-busy", StrategyLeastBusy},
+		{"LEAST_BUSY", StrategyLeastBusy},
+		{"lowest_latency", StrategyLowestLatency},
+		{"lowest-latency", StrategyLowestLatency},
+		{"latency", StrategyLowestLatency},
+		{"lowest_cost", StrategyLowestCost},
+		{"lowest-cost", StrategyLowestCost},
+		{"cost", StrategyLowestCost},
+	}
+	for _, tc := range cases {
+		got := NormalizeRouteRoutingStrategy(tc.in)
+		if got != tc.want {
+			t.Errorf("NormalizeRouteRoutingStrategy(%q)=%q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestIsPriorityLayerRoutingStrategy(t *testing.T) {
+	if !IsPriorityLayerRoutingStrategy(StrategyWeighted) {
+		t.Fatal("weighted should use priority layers")
+	}
+	if !IsPriorityLayerRoutingStrategy(StrategyLeastBusy) {
+		t.Fatal("least_busy should use priority layers")
+	}
+	if !IsPriorityLayerRoutingStrategy(StrategyLowestLatency) {
+		t.Fatal("lowest_latency should use priority layers")
+	}
+	if !IsPriorityLayerRoutingStrategy(StrategyLowestCost) {
+		t.Fatal("lowest_cost should use priority layers")
+	}
+	if IsPriorityLayerRoutingStrategy(StrategyRoundRobin) {
+		t.Fatal("round_robin must not walk priority layers")
+	}
+	if IsPriorityLayerRoutingStrategy(StrategyStableFirst) {
+		t.Fatal("stable_first must not walk priority layers")
+	}
+}
+
+func TestSelectByNamedStrategy_LeastBusy(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	candidates := strategyCandidates()
+	load := mockLoadProvider{
+		1: {SessionScoped: true, ConcurrencyLimit: 10, ActiveLeaseCount: 9, WaitingCount: 2, Saturated: true},
+		2: {SessionScoped: true, ConcurrencyLimit: 10, ActiveLeaseCount: 1, WaitingCount: 0, Saturated: false},
+		3: {SessionScoped: true, ConcurrencyLimit: 10, ActiveLeaseCount: 5, WaitingCount: 1, Saturated: false},
+	}
+	result := SelectByNamedStrategy(StrategyLeastBusy, candidates, staticModel("gpt-4"), load, nil, 1.0)
+	if result.Selected == nil {
+		t.Fatal("expected selection")
+	}
+	if result.Selected.Channel.ID != 2 {
+		t.Fatalf("least_busy selected ch=%d want 2 (lowest load)", result.Selected.Channel.ID)
+	}
+	// Invariant: selected score is min among details.
+	if len(result.Details) != 3 {
+		t.Fatalf("details=%d want 3", len(result.Details))
+	}
+	min := result.Details[0].Score
+	for _, d := range result.Details[1:] {
+		if d.Score < min-1e-12 {
+			t.Fatalf("details not sorted by ascending score: first=%v later=%v", min, d.Score)
+		}
+	}
+}
+
+func TestSelectByNamedStrategy_LowestLatency(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	// Seed site latency: site 10 slow, site 20 fast, site 30 mid.
+	// Use package-private helpers via RecordSiteRuntimeSuccess.
+	// firstByte optional.
+	RecordSiteRuntimeSuccess(10, 5000, strPtr("gpt-4"), 4000)
+	RecordSiteRuntimeSuccess(20, 800, strPtr("gpt-4"), 120)
+	RecordSiteRuntimeSuccess(30, 2000, strPtr("gpt-4"), 900)
+
+	candidates := strategyCandidates()
+	result := SelectByNamedStrategy(StrategyLowestLatency, candidates, staticModel("gpt-4"), nil, nil, 1.0)
+	if result.Selected == nil {
+		t.Fatal("expected selection")
+	}
+	if result.Selected.Channel.ID != 2 {
+		t.Fatalf("lowest_latency selected ch=%d want 2 (site 20 TTFT=120)", result.Selected.Channel.ID)
+	}
+	// Prefer TTFT over total latency: site 10 has slow TTFT.
+	if result.Details[0].Score >= 4000 {
+		t.Fatalf("expected TTFT-based score < 4000, got %v", result.Details[0].Score)
+	}
+}
+
+func TestSelectByNamedStrategy_LowestCost(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	candidates := strategyCandidates()
+	// Channel 2 has configured unitCost 0.01 (cheapest).
+	result := SelectByNamedStrategy(StrategyLowestCost, candidates, staticModel("gpt-4"), nil, nil, 1.0)
+	if result.Selected == nil {
+		t.Fatal("expected selection")
+	}
+	if result.Selected.Channel.ID != 2 {
+		t.Fatalf("lowest_cost selected ch=%d want 2 (unitCost=0.01)", result.Selected.Channel.ID)
+	}
+	// Score equals EffectiveUnitCost of selected.
+	signal := EffectiveUnitCost(*result.Selected, "gpt-4", nil, 1.0)
+	if math.Abs(result.Details[0].Score-signal.UnitCost) > 1e-9 {
+		t.Fatalf("score=%v want unitCost=%v", result.Details[0].Score, signal.UnitCost)
+	}
+}
+
+func TestSelectByNamedStrategy_PriorityDoesNotChangeArgminInsideLayer(t *testing.T) {
+	// Named strategies are pure argmin; priority layering is selector responsibility.
+	// With mixed priorities still passed in, pure function still picks global min cost.
+	// successCount=0 so EffectiveUnitCost uses configured unitCost (not observed).
+	ResetSiteRuntimeHealthState()
+	candidates := []RouteChannelCandidate{
+		makeCandidate(10, 1, 1, 10, 0, 0, 0, 0, 1.0, ptrFloat(0.10), 1, nil),
+		makeCandidate(11, 2, 2, 10, 1, 0, 0, 0, 1.0, ptrFloat(0.01), 1, nil), // cheaper but lower priority
+	}
+	result := SelectByNamedStrategy(StrategyLowestCost, candidates, staticModel("gpt-4"), nil, nil, 1.0)
+	if result.Selected == nil || result.Selected.Channel.ID != 11 {
+		t.Fatalf("pure lowest_cost should pick cheapest regardless of priority, got %#v", result.Selected)
+	}
+}
+
+func TestSelectByNamedStrategy_EmptyAndUnknown(t *testing.T) {
+	if res := SelectByNamedStrategy(StrategyLeastBusy, nil, nil, nil, nil, 1); res.Selected != nil {
+		t.Fatal("empty candidates should not select")
+	}
+	if res := SelectByNamedStrategy(StrategyWeighted, strategyCandidates(), staticModel("gpt-4"), nil, nil, 1); res.Selected != nil {
+		t.Fatal("weighted is not a pure named strategy path")
+	}
+}
+
+func TestSelectByNamedStrategy_DeterministicTieBreakByChannelID(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	// Identical costs → lower channel ID wins.
+	candidates := []RouteChannelCandidate{
+		makeCandidate(30, 1, 1, 10, 0, 0, 0, 0, 1.0, ptrFloat(0.02), 1, nil),
+		makeCandidate(20, 2, 2, 10, 0, 0, 0, 0, 1.0, ptrFloat(0.02), 1, nil),
+		makeCandidate(10, 3, 3, 10, 0, 0, 0, 0, 1.0, ptrFloat(0.02), 1, nil),
+	}
+	result := SelectByNamedStrategy(StrategyLowestCost, candidates, staticModel("gpt-4"), nil, nil, 1.0)
+	if result.Selected == nil || result.Selected.Channel.ID != 10 {
+		t.Fatalf("tie-break want channel 10, got %#v", result.Selected)
+	}
+}
+
+func strPtr(s string) *string { return &s }


### PR DESCRIPTION
## Summary
- Add named pure routing strategies `least_busy`, `lowest_latency`, `lowest_cost` alongside existing `weighted` (default), `round_robin`, `stable_first`.
- Wire selector priority-layer path to honor strategy; normalize strategy names on admin create/update.
- Document defaults, score signals, sticky/exclude invariants, and multi-instance residual limits.

## Test plan
- [x] `go test ./routing/ -count=1`
- [x] `go test ./handler/admin/ -count=1 -run 'Route|Token'`
- [x] `go vet ./routing/ ./handler/admin/`
- [x] `go test ./docs/ -run TestPublicMarkdownHygiene`
- [ ] Manual: set route `routingStrategy` to each named strategy and confirm selection still respects exclude lists / preferred channel.

Closes #115