### PR TITLE
feat(metrics): richer Prometheus + optional Observer export #117

### DIFF
--- a/app/prometheus.go
+++ b/app/prometheus.go
@@ -3,6 +3,7 @@ package app
 import (
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/tokendancelab/metapi-go/handler/shared"
 	"github.com/tokendancelab/metapi-go/store"
@@ -28,6 +29,22 @@ func SetDBConnections(n int64) { shared.SetDBConnections(n) }
 
 // RecordRouteRebuildCompleted increments successful route rebuild/cache-invalidate counter.
 func RecordRouteRebuildCompleted() { shared.RecordRouteRebuildCompleted() }
+
+// ObserveProxyOutcome records labeled outcomes, latency histograms, and the optional Observer hook.
+func ObserveProxyOutcome(obs shared.ProxyObservation) { shared.ObserveProxyOutcome(obs) }
+
+// SetMetricsObserver registers an optional OTEL/Langfuse-style export sink (nil = no-op).
+func SetMetricsObserver(o shared.Observer) { shared.SetObserver(o) }
+
+// ObserveProxySuccess is a convenience for success-path latency observation.
+func ObserveProxySuccess(endpoint string, stream bool, latency time.Duration) {
+	shared.ObserveProxyOutcome(shared.ProxyObservation{
+		Endpoint: endpoint,
+		Status:   shared.OutcomeSuccess,
+		Stream:   stream,
+		Latency:  latency,
+	})
+}
 
 func refreshRuntimeGauges() {
 	if db := store.GetDB(); db != nil && db.DB != nil && db.DB.DB != nil {

--- a/app/prometheus_test.go
+++ b/app/prometheus_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tokendancelab/metapi-go/handler/shared"
 )
@@ -17,6 +18,12 @@ func TestPrometheusHandler_FormatSmoke(t *testing.T) {
 	shared.RecordRouteRebuildCompleted()
 	shared.SetActiveChannels(2)
 	shared.SetDBConnections(3)
+	shared.ObserveProxyOutcome(shared.ProxyObservation{
+		Endpoint: shared.EndpointChat,
+		Status:   shared.OutcomeSuccess,
+		Stream:   false,
+		Latency:  100 * time.Millisecond,
+	})
 
 	rec := httptest.NewRecorder()
 	PrometheusHandler(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
@@ -38,6 +45,10 @@ func TestPrometheusHandler_FormatSmoke(t *testing.T) {
 		"metapi_db_connections_open 3",
 		`metapi_route_rebuild_total{result="completed"} 1`,
 		"# HELP metapi_uptime_seconds",
+		"# TYPE metapi_proxy_outcomes_total counter",
+		`metapi_proxy_outcomes_total{endpoint="chat",status="success",stream="false"} 1`,
+		"# TYPE metapi_proxy_request_duration_seconds histogram",
+		`metapi_proxy_request_duration_seconds_count{endpoint="chat",status="success"} 1`,
 	}
 	for _, want := range required {
 		if !strings.Contains(body, want) {
@@ -46,3 +57,27 @@ func TestPrometheusHandler_FormatSmoke(t *testing.T) {
 	}
 	shared.RecordStreamEnd()
 }
+
+func TestSetMetricsObserver_AppSurface(t *testing.T) {
+	shared.ResetMetricsForTest()
+	var called int
+	SetMetricsObserver(observerFunc(func(obs shared.ProxyObservation) {
+		called++
+		if obs.Endpoint != shared.EndpointEmbeddings {
+			t.Fatalf("endpoint = %q", obs.Endpoint)
+		}
+	}))
+	ObserveProxyOutcome(shared.ProxyObservation{
+		Endpoint: shared.EndpointEmbeddings,
+		Status:   shared.OutcomeSuccess,
+		Latency:  time.Millisecond,
+	})
+	if called != 1 {
+		t.Fatalf("called = %d, want 1", called)
+	}
+	SetMetricsObserver(nil)
+}
+
+type observerFunc func(shared.ProxyObservation)
+
+func (f observerFunc) ObserveProxy(obs shared.ProxyObservation) { f(obs) }

--- a/docs/analysis/observability-boundaries.md
+++ b/docs/analysis/observability-boundaries.md
@@ -34,8 +34,10 @@ Define the public semantics of liveness/readiness/metrics endpoints, document wh
 | `metapi_active_channels` | gauge | Optional setter (`SetActiveChannels`) |
 | `metapi_db_connections_open` | gauge | Refreshed from `sql.DB.Stats().OpenConnections` on scrape when DB is initialized |
 | `metapi_route_rebuild_total{result="completed"}` | counter | Successful `POST /api/routes/rebuild` cache invalidate |
+| `metapi_proxy_outcomes_total{endpoint,status,stream}` | counter | Terminal proxy outcomes (bounded labels; see `observability-export.md` #117) |
+| `metapi_proxy_request_duration_seconds` | histogram | Proxy terminal latency by endpoint/status |
 
-**Non-goals (R2):** histograms/P99, request-id propagation (separate), OpenTelemetry, auth on `/metrics`, lease gauges wired from coordinator.
+**R2 baseline non-goals (partially superseded by #117):** request-id propagation (landed #110), full OpenTelemetry SDK, auth on `/metrics`, lease gauges. Histograms + optional Observer export: `docs/analysis/observability-export.md`.
 
 ## Proxy hot-path recording
 

--- a/docs/analysis/observability-export.md
+++ b/docs/analysis/observability-export.md
@@ -1,0 +1,151 @@
+# Richer Prometheus + optional OTEL/Langfuse export (#117)
+
+**Date:** 2026-07-17  
+**Lane:** competitive learn / observability  
+**SSOT code:** `handler/shared/metrics.go`, `app/prometheus.go`, `handler/proxy/upstream.go`  
+**Peers:** LiteLLM `integrations/*` (Langfuse/OTEL/Prometheus), AxonHub observability surface
+
+## Goal
+
+Expand MetAPI beyond basic counters so operators can build SLOs (latency histograms, labeled outcomes) and optionally fan out privacy-safe terminal events to external APM/tracing backends **without** embedding a vendor SDK in the core binary.
+
+## Prometheus series (additive)
+
+Existing scrape series are preserved. New series are additive and only use **bounded** labels.
+
+| Metric | Type | Labels | Notes |
+|:-------|:-----|:-------|:------|
+| `metapi_uptime_seconds` | gauge | — | unchanged |
+| `metapi_proxy_requests_total` | counter | — | unchanged; +1 at `dispatchUpstream` entry |
+| `metapi_proxy_errors_total` | counter | — | still present; also increments on non-success **terminal** outcomes |
+| `metapi_proxy_streams_active` | gauge | — | unchanged |
+| `metapi_active_channels` | gauge | — | unchanged |
+| `metapi_db_connections_open` | gauge | — | unchanged |
+| `metapi_route_rebuild_total{result}` | counter | `result` | unchanged (`completed`) |
+| **`metapi_proxy_outcomes_total`** | counter | `endpoint`, `status`, `stream` | **new** terminal outcomes |
+| **`metapi_proxy_request_duration_seconds`** | histogram | `endpoint`, `status` | **new** latency distribution |
+
+### Label allowlists (cardinality policy)
+
+| Label | Allowed values | Forbidden |
+|:------|:---------------|:----------|
+| `endpoint` | `chat`, `messages`, `responses`, `embeddings`, `completions`, `images`, `rerank`, `search`, `gemini`, `models`, `other` | raw URL paths, model names, site ids |
+| `status` | `success`, `error`, `timeout`, `unavailable`, `upstream_error`, `client_error` | raw HTTP codes, free-text errors |
+| `stream` | `true`, `false` | — |
+
+Unknown endpoint/status strings collapse via `sanitizeEndpoint` / `sanitizeStatus`.
+
+### Latency buckets (seconds)
+
+`0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120` (+Inf)
+
+Covers first-byte-ish short calls through long streaming completions. Bucket choice is fixed in-process (no config yet) to keep scrape stable.
+
+## Hot-path recording
+
+```
+dispatchUpstream
+  RecordProxyRequest()
+  startedAt := now
+  ...
+  on terminal response (success or final error):
+    ObserveProxyOutcome({endpoint, status, stream, latency})
+      · outcomes counter
+      · duration histogram
+      · proxy_errors_total if status != success
+      · Observer.ObserveProxy (optional export hook)
+```
+
+Latency for successful upstream attempts uses the existing first-byte/total attempt timer (`latencyMs` around `sendUpstreamRequest`). Outer selection failures use wall time since `dispatchUpstream` entry.
+
+Auth/JSON validation failures that never enter `dispatchUpstream` still do **not** appear in proxy metrics.
+
+## Optional export hook (Observer)
+
+```go
+// handler/shared
+type ProxyObservation struct {
+    Endpoint string        // bounded
+    Status   string        // bounded
+    Stream   bool
+    Latency  time.Duration
+}
+
+type Observer interface {
+    ObserveProxy(obs ProxyObservation)
+}
+
+func SetObserver(o Observer) // nil => no-op
+func GetObserver() Observer  // never nil
+```
+
+App surface:
+
+```go
+app.SetMetricsObserver(mySink)
+app.ObserveProxyOutcome(shared.ProxyObservation{...})
+```
+
+### Design rules
+
+1. **No mandatory vendor dependency** — core stays zero-dep for Prometheus text exposition.
+2. **No-op default** — production is safe without registration.
+3. **Privacy-safe payload only** — no prompts, keys, cookies, upstream bodies, model names, site URLs.
+4. **Non-blocking sinks** — implementers should buffer/async; `ObserveProxyOutcome` recovers panics from sinks so a bad hook cannot crash the proxy path.
+5. **One event per terminal client response** — retries that later succeed emit a single success outcome for the winning attempt (not every intermediate soft fail).
+
+### Example sink sketches (not shipped)
+
+**OpenTelemetry-ish (metrics only):**
+
+```go
+type OTELSink struct{ hist metric.Float64Histogram }
+
+func (s OTELSink) ObserveProxy(obs shared.ProxyObservation) {
+    s.hist.Record(context.Background(), obs.Latency.Seconds(),
+        metric.WithAttributes(
+            attribute.String("endpoint", obs.Endpoint),
+            attribute.String("status", obs.Status),
+            attribute.Bool("stream", obs.Stream),
+        ))
+}
+```
+
+**Langfuse-style (metadata only, no prompts):**
+
+```go
+type LangfuseMetaSink struct{ enqueue func(map[string]any) }
+
+func (s LangfuseMetaSink) ObserveProxy(obs shared.ProxyObservation) {
+    s.enqueue(map[string]any{
+        "name": "metapi.proxy",
+        "endpoint": obs.Endpoint,
+        "status": obs.Status,
+        "stream": obs.Stream,
+        "latency_ms": obs.Latency.Milliseconds(),
+    })
+}
+```
+
+Register at composition root (`cmd/server` / `app`) only when env/config opts in. Credentials for SaaS stay out of this repo.
+
+## Privacy / non-goals
+
+| In scope | Out of scope |
+|:---------|:-------------|
+| Bounded labels + histograms | High-cardinality model/site labels without aggregation policy |
+| Optional Observer interface | Shipping Langfuse/OTEL SDKs or SaaS tokens in-repo |
+| Prometheus text at `GET /metrics` | Auth on `/metrics` (still network-policy based) |
+| Terminal outcome export | Full distributed traces with prompt payloads |
+
+## Tests
+
+- `handler/shared/metrics_test.go` — legacy counters, labeled outcomes, histogram buckets/count, sanitization of high-cardinality input, Observer hook.
+- `app/prometheus_test.go` — `/metrics` exposition includes new HELP/TYPE lines and sample series; `SetMetricsObserver` surface.
+
+## Residual risks
+
+1. **Cardinality growth** is bounded by the allowlists, but operators enabling custom sinks must not re-introduce raw model labels.
+2. **Error counter semantics expanded**: non-success terminal outcomes now increment `metapi_proxy_errors_total` (not only “unconfigured upstream”). Dashboards that treated that counter as “config errors only” need a one-time adjustment; prefer `metapi_proxy_outcomes_total{status=...}` going forward.
+3. Soft protocol fallbacks / intermediate retries do not emit outcomes until a terminal response is written to the client.
+4. Stream active gauge is still optional/manual; this issue does not re-plumb `RecordStreamStart/End` into every SSE path.

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -67,6 +67,7 @@ func getUpstreamConfig() *UpstreamConfig {
 // Implements the spec's 10-step Handler pattern.
 func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 	shared.RecordProxyRequest()
+	startedAt := time.Now()
 	// Parent request/trace id is stable across channel retries and endpoint fallbacks.
 	reqCtx, requestID := proxy.EnsureRequestID(r.Context(), "")
 	if requestID != "" && r.Context() != reqCtx {
@@ -81,8 +82,8 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 		unconfiguredUpstreamLogOnce.Do(func() {
 			slog.Error("proxy upstream dependencies are not configured", "request_id", requestID)
 		})
-		shared.RecordProxyError()
 		writeJSONErrorWithRequest(w, http.StatusServiceUnavailable, "Proxy upstream is not configured", "server_error", requestID)
+		observeProxyTerminal(ctx, shared.OutcomeUnavailable, ctx != nil && ctx.IsStream, time.Since(startedAt))
 		return
 	}
 
@@ -118,9 +119,11 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 			)
 			if pendingFailure != nil {
 				pendingFailure.write(w, requestID)
+				observeProxyTerminal(ctx, pendingFailure.outcomeStatus(), ctx != nil && ctx.IsStream, time.Since(startedAt))
 				return
 			}
 			writeJSONErrorWithRequest(w, 503, "No available channels", "server_error", requestID)
+			observeProxyTerminal(ctx, shared.OutcomeUnavailable, ctx != nil && ctx.IsStream, time.Since(startedAt))
 			return
 		}
 		excludeChannelIDs = append(excludeChannelIDs, selected.Channel.ID)
@@ -161,6 +164,22 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 	}
 
 	writeJSONErrorWithRequest(w, 503, "All channels exhausted", "server_error", requestID)
+	observeProxyTerminal(ctx, shared.OutcomeUnavailable, ctx != nil && ctx.IsStream, time.Since(startedAt))
+}
+
+// observeProxyTerminal records labeled counters, latency histogram, and optional export hook.
+// Labels are privacy-safe (endpoint family + outcome); never model/key/body.
+func observeProxyTerminal(ctx *Ctx, status string, stream bool, latency time.Duration) {
+	endpoint := shared.EndpointOther
+	if ctx != nil && ctx.DownstreamPath != "" {
+		endpoint = shared.EndpointLabelFromPath(ctx.DownstreamPath)
+	}
+	shared.ObserveProxyOutcome(shared.ProxyObservation{
+		Endpoint: endpoint,
+		Status:   status,
+		Stream:   stream,
+		Latency:  latency,
+	})
 }
 
 // dispatchSelectedUpstream runs steps 7-9 for one selected channel.
@@ -216,6 +235,7 @@ func dispatchSelectedUpstream(
 			slog.Warn("multipart upstream body construction failed",
 				"err", err, "path", upstreamPath, "model", upstreamModel, "request_id", requestID, "retry", retry)
 			writeJSONErrorWithRequest(w, 400, "Invalid multipart request body", "invalid_request_error", requestID)
+			observeProxyTerminal(ctx, shared.OutcomeClientError, false, 0)
 			return true, nil
 		}
 		if bodyReader != nil {
@@ -224,6 +244,7 @@ func dispatchSelectedUpstream(
 				slog.Warn("multipart upstream body read failed",
 					"err", err, "path", upstreamPath, "request_id", requestID, "retry", retry)
 				writeJSONErrorWithRequest(w, 400, "Invalid multipart request body", "invalid_request_error", requestID)
+				observeProxyTerminal(ctx, shared.OutcomeClientError, false, 0)
 				return true, nil
 			}
 		}
@@ -240,6 +261,7 @@ func dispatchSelectedUpstream(
 	if errMsg := responsesOnlyClientError(upstreamPath, bodyBytes, sitePref); errMsg != "" {
 		// Clear failure for chat/messages clients when site cannot serve without transform.
 		writeJSONErrorWithRequest(w, http.StatusBadRequest, errMsg, "invalid_request_error", requestID)
+		observeProxyTerminal(ctx, shared.OutcomeClientError, false, 0)
 		return true, nil
 	}
 
@@ -251,6 +273,7 @@ func dispatchSelectedUpstream(
 		if sanitizeErr != nil {
 			// Clear client-facing continuity error (issue #54 / upstream #504).
 			writeJSONErrorWithRequest(w, http.StatusBadRequest, sanitizeErr.Error(), "invalid_request_error", requestID)
+			observeProxyTerminal(ctx, shared.OutcomeClientError, false, 0)
 			return true, nil
 		}
 		// Force stream=true for responses-only / stream-preferring sites (and codex/sub2api).
@@ -281,6 +304,7 @@ func dispatchSelectedUpstream(
 		return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error")
 	}
 	writeJSONErrorWithRequest(w, 502, "Upstream request failed", "upstream_error", requestID)
+	observeProxyTerminal(ctx, shared.OutcomeUpstreamError, false, 0)
 	return true, nil
 }
 
@@ -448,6 +472,7 @@ func dispatchEndpointAttemptWithContinue(
 			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error"), false
 		}
 		writeJSONErrorWithRequest(w, 502, "Upstream request failed", "upstream_error", requestID)
+		observeProxyTerminal(ctx, shared.OutcomeUpstreamError, effectiveStream, time.Since(startedAt))
 		return true, nil, false
 	}
 	req.Header.Set("Content-Type", contentType)
@@ -480,6 +505,7 @@ func dispatchEndpointAttemptWithContinue(
 				return false, jsonPendingUpstreamFailure(http.StatusRequestTimeout, "Upstream first-byte timeout", "upstream_error"), false
 			}
 			writeJSONErrorWithRequest(w, http.StatusRequestTimeout, "Upstream first-byte timeout", "upstream_error", requestID)
+			observeProxyTerminal(ctx, shared.OutcomeTimeout, effectiveStream, time.Since(startedAt))
 			return true, nil, false
 		}
 		slog.Warn("upstream request failed",
@@ -494,6 +520,7 @@ func dispatchEndpointAttemptWithContinue(
 			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error"), false
 		}
 		writeJSONErrorWithRequest(w, 502, "Upstream request failed", "upstream_error", requestID)
+		observeProxyTerminal(ctx, shared.OutcomeUpstreamError, effectiveStream, time.Since(startedAt))
 		return true, nil, false
 	}
 
@@ -514,6 +541,7 @@ func dispatchEndpointAttemptWithContinue(
 					return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error"), false
 				}
 				writeJSONErrorWithRequest(w, 502, "Failed to read upstream response", "upstream_error", requestID)
+				observeProxyTerminal(ctx, shared.OutcomeUpstreamError, true, time.Duration(latencyMs)*time.Millisecond)
 				return true, nil, false
 			}
 			rawErrText := string(respBody)
@@ -525,6 +553,7 @@ func dispatchEndpointAttemptWithContinue(
 				return false, bufferedPendingUpstreamFailure(resp, respBody), false
 			}
 			relayBufferedUpstreamErrorResponse(w, resp, respBody)
+			observeProxyTerminal(ctx, shared.StatusFromHTTP(resp.StatusCode), true, time.Duration(latencyMs)*time.Millisecond)
 			return true, nil, false
 		}
 		// Always close the upstream body, including early client disconnects.
@@ -535,6 +564,7 @@ func dispatchEndpointAttemptWithContinue(
 		}()
 		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, streamUsage)
 		writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, true, streamUsage, retry, requestID)
+		observeProxyTerminal(ctx, shared.OutcomeSuccess, true, time.Duration(latencyMs)*time.Millisecond)
 		return true, nil, false
 	}
 
@@ -552,6 +582,7 @@ func dispatchEndpointAttemptWithContinue(
 			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error"), false
 		}
 		writeJSONErrorWithRequest(w, 502, "Failed to read upstream response", "upstream_error", requestID)
+		observeProxyTerminal(ctx, shared.OutcomeUpstreamError, false, time.Duration(latencyMs)*time.Millisecond)
 		return true, nil, false
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -564,6 +595,7 @@ func dispatchEndpointAttemptWithContinue(
 			return false, bufferedPendingUpstreamFailure(resp, respBody), false
 		}
 		relayBufferedUpstreamResponse(w, resp, respBody)
+		observeProxyTerminal(ctx, shared.StatusFromHTTP(resp.StatusCode), false, time.Duration(latencyMs)*time.Millisecond)
 		return true, nil, false
 	}
 	usage := ParseUsageFromBody(respBody)
@@ -586,11 +618,13 @@ func dispatchEndpointAttemptWithContinue(
 			return false, jsonPendingUpstreamFailure(failure.Status, "Upstream returned an error response", "upstream_error"), false
 		}
 		writeJSONErrorWithRequest(w, failure.Status, "Upstream returned an error response", "upstream_error", requestID)
+		observeProxyTerminal(ctx, shared.StatusFromHTTP(failure.Status), false, time.Duration(latencyMs)*time.Millisecond)
 		return true, nil, false
 	}
 	recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, usage)
 	writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, false, usage, retry, requestID)
 	relayBufferedUpstreamResponse(w, resp, respBody)
+	observeProxyTerminal(ctx, shared.OutcomeSuccess, false, time.Duration(latencyMs)*time.Millisecond)
 	return true, nil, false
 }
 
@@ -629,6 +663,16 @@ func jsonPendingUpstreamFailure(status int, message, typ string) *pendingUpstrea
 		jsonMessage: message,
 		jsonType:    typ,
 	}
+}
+
+func (p *pendingUpstreamFailure) outcomeStatus() string {
+	if p == nil {
+		return shared.OutcomeUnavailable
+	}
+	if p.resp != nil {
+		return shared.StatusFromHTTP(p.resp.StatusCode)
+	}
+	return shared.StatusFromHTTP(p.jsonStatus)
 }
 
 func (p *pendingUpstreamFailure) write(w http.ResponseWriter, requestID string) {

--- a/handler/shared/metrics.go
+++ b/handler/shared/metrics.go
@@ -3,6 +3,8 @@ package shared
 import (
 	"fmt"
 	"net/http"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -20,10 +22,111 @@ type MetricsCollector struct {
 	dbConnectionsOpen  atomic.Int64
 	routeRebuildOK     atomic.Int64
 	startTime          time.Time
-	mu                 sync.RWMutex
+
+	// Labeled outcomes + latency histograms (low-cardinality only).
+	outcomesMu sync.Mutex
+	outcomes   map[outcomeKey]int64
+	histMu     sync.Mutex
+	histograms map[histKey]*latencyHistogram
 }
 
-var globalMetrics = &MetricsCollector{startTime: time.Now()}
+// Bounded outcome status labels (never raw HTTP codes or error strings).
+const (
+	OutcomeSuccess       = "success"
+	OutcomeError         = "error"
+	OutcomeTimeout       = "timeout"
+	OutcomeUnavailable   = "unavailable"
+	OutcomeUpstreamError = "upstream_error"
+	OutcomeClientError   = "client_error"
+)
+
+// Bounded endpoint labels derived from path suffixes (never full URLs/models).
+const (
+	EndpointChat        = "chat"
+	EndpointMessages    = "messages"
+	EndpointResponses   = "responses"
+	EndpointEmbeddings  = "embeddings"
+	EndpointCompletions = "completions"
+	EndpointImages      = "images"
+	EndpointRerank      = "rerank"
+	EndpointSearch      = "search"
+	EndpointGemini      = "gemini"
+	EndpointModels      = "models"
+	EndpointOther       = "other"
+)
+
+// Default latency histogram buckets in seconds (TTFT-ish to long completions).
+var defaultLatencyBuckets = []float64{
+	0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120,
+}
+
+type outcomeKey struct {
+	endpoint string
+	status   string
+	stream   string
+}
+
+type histKey struct {
+	endpoint string
+	status   string
+}
+
+type latencyHistogram struct {
+	buckets []float64
+	counts  []uint64 // len = len(buckets)+1 (+Inf)
+	sum     float64
+	count   uint64
+}
+
+var globalMetrics = &MetricsCollector{
+	startTime:  time.Now(),
+	outcomes:   make(map[outcomeKey]int64),
+	histograms: make(map[histKey]*latencyHistogram),
+}
+
+// ProxyObservation is a privacy-safe, low-cardinality proxy terminal event.
+// It must never carry prompts, keys, cookies, model names, or upstream bodies.
+type ProxyObservation struct {
+	Endpoint string        // bounded label from EndpointLabelFromPath
+	Status   string        // Outcome* constants
+	Stream   bool          // stream vs non-stream
+	Latency  time.Duration // total observed latency for the attempt/request
+}
+
+// Observer is an optional export hook for OTEL/Langfuse-style sinks.
+// Implementations must not block; drop or buffer on backpressure.
+// The default is a no-op.
+type Observer interface {
+	ObserveProxy(obs ProxyObservation)
+}
+
+type noopObserver struct{}
+
+func (noopObserver) ObserveProxy(ProxyObservation) {}
+
+var (
+	observerMu sync.RWMutex
+	observer   Observer = noopObserver{}
+)
+
+// SetObserver registers an optional export sink. Pass nil to reset to no-op.
+// Safe for concurrent use; hot path reads under RLock.
+func SetObserver(o Observer) {
+	observerMu.Lock()
+	defer observerMu.Unlock()
+	if o == nil {
+		observer = noopObserver{}
+		return
+	}
+	observer = o
+}
+
+// GetObserver returns the currently registered Observer (never nil).
+func GetObserver() Observer {
+	observerMu.RLock()
+	defer observerMu.RUnlock()
+	return observer
+}
 
 // RecordProxyRequest increments the proxy request counter.
 func RecordProxyRequest() { globalMetrics.proxyRequestsTotal.Add(1) }
@@ -46,6 +149,160 @@ func SetDBConnections(n int64) { globalMetrics.dbConnectionsOpen.Store(n) }
 // RecordRouteRebuildCompleted increments successful route rebuild/cache-invalidate counter.
 func RecordRouteRebuildCompleted() { globalMetrics.routeRebuildOK.Add(1) }
 
+// ObserveProxyOutcome records a terminal proxy outcome: labeled counter, latency
+// histogram, legacy error counter (when not success), and optional Observer hook.
+// Labels are sanitized to a fixed allowlist; unknown values collapse to safe defaults.
+func ObserveProxyOutcome(obs ProxyObservation) {
+	endpoint := sanitizeEndpoint(obs.Endpoint)
+	status := sanitizeStatus(obs.Status)
+	stream := "false"
+	if obs.Stream {
+		stream = "true"
+	}
+	if latency := obs.Latency; latency < 0 {
+		obs.Latency = 0
+	}
+
+	key := outcomeKey{endpoint: endpoint, status: status, stream: stream}
+	globalMetrics.outcomesMu.Lock()
+	globalMetrics.outcomes[key]++
+	globalMetrics.outcomesMu.Unlock()
+
+	observeLatency(endpoint, status, obs.Latency)
+
+	if status != OutcomeSuccess {
+		globalMetrics.proxyErrorsTotal.Add(1)
+	}
+
+	// Export hook last so metric state is consistent even if the sink panics
+	// (recover so a bad sink cannot break the proxy hot path).
+	func() {
+		defer func() { _ = recover() }()
+		GetObserver().ObserveProxy(ProxyObservation{
+			Endpoint: endpoint,
+			Status:   status,
+			Stream:   obs.Stream,
+			Latency:  obs.Latency,
+		})
+	}()
+}
+
+func observeLatency(endpoint, status string, d time.Duration) {
+	seconds := d.Seconds()
+	if seconds < 0 {
+		seconds = 0
+	}
+	hk := histKey{endpoint: endpoint, status: status}
+	globalMetrics.histMu.Lock()
+	h := globalMetrics.histograms[hk]
+	if h == nil {
+		h = newLatencyHistogram(defaultLatencyBuckets)
+		globalMetrics.histograms[hk] = h
+	}
+	h.observe(seconds)
+	globalMetrics.histMu.Unlock()
+}
+
+func newLatencyHistogram(buckets []float64) *latencyHistogram {
+	cp := append([]float64(nil), buckets...)
+	return &latencyHistogram{
+		buckets: cp,
+		counts:  make([]uint64, len(cp)+1),
+	}
+}
+
+func (h *latencyHistogram) observe(seconds float64) {
+	h.count++
+	h.sum += seconds
+	idx := len(h.buckets) // +Inf
+	for i, b := range h.buckets {
+		if seconds <= b {
+			idx = i
+			break
+		}
+	}
+	h.counts[idx]++
+}
+
+// EndpointLabelFromPath maps a request path to a low-cardinality endpoint label.
+// Never returns raw paths; unknown paths become "other".
+func EndpointLabelFromPath(path string) string {
+	path = strings.TrimSpace(path)
+	if i := strings.IndexAny(path, "?#"); i >= 0 {
+		path = path[:i]
+	}
+	path = strings.ToLower(strings.TrimRight(path, "/"))
+	switch {
+	case strings.HasSuffix(path, "/v1/chat/completions") || path == "/chat/completions" || path == "/v1/chat/completions":
+		return EndpointChat
+	case strings.HasSuffix(path, "/v1/messages") || path == "/messages" || path == "/v1/messages" ||
+		strings.HasSuffix(path, "/anthropic/v1/messages") || strings.HasSuffix(path, "/messages/count_tokens"):
+		return EndpointMessages
+	case strings.Contains(path, "/v1/responses") || path == "/responses":
+		return EndpointResponses
+	case strings.HasSuffix(path, "/v1/embeddings") || path == "/embeddings":
+		return EndpointEmbeddings
+	case strings.HasSuffix(path, "/v1/completions") || path == "/completions":
+		return EndpointCompletions
+	case strings.Contains(path, "/v1/images"):
+		return EndpointImages
+	case strings.HasSuffix(path, "/v1/rerank") || path == "/rerank":
+		return EndpointRerank
+	case strings.HasSuffix(path, "/v1/search") || path == "/search":
+		return EndpointSearch
+	case strings.Contains(path, "generatecontent") || strings.Contains(path, "counttokens") ||
+		strings.Contains(path, "/v1beta/") || strings.Contains(path, "/v1internal"):
+		return EndpointGemini
+	case strings.HasSuffix(path, "/v1/models") || path == "/models" || strings.HasSuffix(path, "/models"):
+		return EndpointModels
+	default:
+		return EndpointOther
+	}
+}
+
+// StatusFromHTTP maps an HTTP status to a bounded outcome label.
+func StatusFromHTTP(code int) string {
+	switch {
+	case code >= 200 && code < 300:
+		return OutcomeSuccess
+	case code == http.StatusRequestTimeout || code == 408:
+		return OutcomeTimeout
+	case code == http.StatusServiceUnavailable || code == http.StatusTooManyRequests:
+		return OutcomeUnavailable
+	case code >= 400 && code < 500:
+		return OutcomeClientError
+	case code >= 500:
+		return OutcomeUpstreamError
+	default:
+		return OutcomeError
+	}
+}
+
+func sanitizeEndpoint(v string) string {
+	switch strings.TrimSpace(strings.ToLower(v)) {
+	case EndpointChat, EndpointMessages, EndpointResponses, EndpointEmbeddings,
+		EndpointCompletions, EndpointImages, EndpointRerank, EndpointSearch,
+		EndpointGemini, EndpointModels, EndpointOther:
+		return strings.TrimSpace(strings.ToLower(v))
+	case "":
+		return EndpointOther
+	default:
+		return EndpointOther
+	}
+}
+
+func sanitizeStatus(v string) string {
+	switch strings.TrimSpace(strings.ToLower(v)) {
+	case OutcomeSuccess, OutcomeError, OutcomeTimeout, OutcomeUnavailable,
+		OutcomeUpstreamError, OutcomeClientError:
+		return strings.TrimSpace(strings.ToLower(v))
+	case "":
+		return OutcomeError
+	default:
+		return OutcomeError
+	}
+}
+
 // ResetMetricsForTest clears counters/gauges for deterministic tests.
 func ResetMetricsForTest() {
 	globalMetrics.proxyRequestsTotal.Store(0)
@@ -55,6 +312,13 @@ func ResetMetricsForTest() {
 	globalMetrics.dbConnectionsOpen.Store(0)
 	globalMetrics.routeRebuildOK.Store(0)
 	globalMetrics.startTime = time.Now()
+	globalMetrics.outcomesMu.Lock()
+	globalMetrics.outcomes = make(map[outcomeKey]int64)
+	globalMetrics.outcomesMu.Unlock()
+	globalMetrics.histMu.Lock()
+	globalMetrics.histograms = make(map[histKey]*latencyHistogram)
+	globalMetrics.histMu.Unlock()
+	SetObserver(nil)
 }
 
 // SnapshotForTest returns current counter values for assertions.
@@ -63,6 +327,30 @@ func SnapshotForTest() (requests, errors, streams, rebuilds int64) {
 		globalMetrics.proxyErrorsTotal.Load(),
 		globalMetrics.proxyStreamsActive.Load(),
 		globalMetrics.routeRebuildOK.Load()
+}
+
+// OutcomeSnapshotForTest returns labeled outcome counts for assertions.
+func OutcomeSnapshotForTest() map[string]int64 {
+	globalMetrics.outcomesMu.Lock()
+	defer globalMetrics.outcomesMu.Unlock()
+	out := make(map[string]int64, len(globalMetrics.outcomes))
+	for k, v := range globalMetrics.outcomes {
+		out[fmt.Sprintf("%s|%s|%s", k.endpoint, k.status, k.stream)] = v
+	}
+	return out
+}
+
+// HistogramCountForTest returns sample count for one labeled histogram series.
+func HistogramCountForTest(endpoint, status string) uint64 {
+	endpoint = sanitizeEndpoint(endpoint)
+	status = sanitizeStatus(status)
+	globalMetrics.histMu.Lock()
+	defer globalMetrics.histMu.Unlock()
+	h := globalMetrics.histograms[histKey{endpoint: endpoint, status: status}]
+	if h == nil {
+		return 0
+	}
+	return h.count
 }
 
 // WritePrometheusMetrics writes Prometheus text-format metrics to w.
@@ -103,6 +391,66 @@ func WritePrometheusMetrics(w http.ResponseWriter) error {
 	appendLine("# HELP metapi_route_rebuild_total Total route cache rebuild/invalidate operations\n")
 	appendLine("# TYPE metapi_route_rebuild_total counter\n")
 	appendLine("metapi_route_rebuild_total{result=\"completed\"} %d\n", m.routeRebuildOK.Load())
+
+	// Labeled terminal outcomes (privacy-safe, bounded labels).
+	appendLine("# HELP metapi_proxy_outcomes_total Terminal proxy outcomes by endpoint/status/stream\n")
+	appendLine("# TYPE metapi_proxy_outcomes_total counter\n")
+	m.outcomesMu.Lock()
+	outcomeKeys := make([]outcomeKey, 0, len(m.outcomes))
+	for k := range m.outcomes {
+		outcomeKeys = append(outcomeKeys, k)
+	}
+	sort.Slice(outcomeKeys, func(i, j int) bool {
+		a, b := outcomeKeys[i], outcomeKeys[j]
+		if a.endpoint != b.endpoint {
+			return a.endpoint < b.endpoint
+		}
+		if a.status != b.status {
+			return a.status < b.status
+		}
+		return a.stream < b.stream
+	})
+	for _, k := range outcomeKeys {
+		appendLine("metapi_proxy_outcomes_total{endpoint=%q,status=%q,stream=%q} %d\n",
+			k.endpoint, k.status, k.stream, m.outcomes[k])
+	}
+	m.outcomesMu.Unlock()
+
+	// Latency histogram (cumulative buckets).
+	appendLine("# HELP metapi_proxy_request_duration_seconds Proxy request duration in seconds\n")
+	appendLine("# TYPE metapi_proxy_request_duration_seconds histogram\n")
+	m.histMu.Lock()
+	histKeys := make([]histKey, 0, len(m.histograms))
+	for k := range m.histograms {
+		histKeys = append(histKeys, k)
+	}
+	sort.Slice(histKeys, func(i, j int) bool {
+		a, b := histKeys[i], histKeys[j]
+		if a.endpoint != b.endpoint {
+			return a.endpoint < b.endpoint
+		}
+		return a.status < b.status
+	})
+	for _, k := range histKeys {
+		h := m.histograms[k]
+		if h == nil || h.count == 0 {
+			continue
+		}
+		var cum uint64
+		for i, bound := range h.buckets {
+			cum += h.counts[i]
+			appendLine("metapi_proxy_request_duration_seconds_bucket{endpoint=%q,status=%q,le=\"%g\"} %d\n",
+				k.endpoint, k.status, bound, cum)
+		}
+		cum += h.counts[len(h.buckets)]
+		appendLine("metapi_proxy_request_duration_seconds_bucket{endpoint=%q,status=%q,le=\"+Inf\"} %d\n",
+			k.endpoint, k.status, cum)
+		appendLine("metapi_proxy_request_duration_seconds_sum{endpoint=%q,status=%q} %g\n",
+			k.endpoint, k.status, h.sum)
+		appendLine("metapi_proxy_request_duration_seconds_count{endpoint=%q,status=%q} %d\n",
+			k.endpoint, k.status, h.count)
+	}
+	m.histMu.Unlock()
 
 	_, err := w.Write(b)
 	return err

--- a/handler/shared/metrics_test.go
+++ b/handler/shared/metrics_test.go
@@ -3,7 +3,9 @@ package shared
 import (
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestMetricsCollector_RecordAndExpose(t *testing.T) {
@@ -34,5 +36,169 @@ func TestMetricsCollector_RecordAndExpose(t *testing.T) {
 	_, _, streams, _ = SnapshotForTest()
 	if streams != 0 {
 		t.Fatalf("streams after end = %d, want 0", streams)
+	}
+}
+
+func TestObserveProxyOutcome_HistogramAndLabels(t *testing.T) {
+	ResetMetricsForTest()
+
+	ObserveProxyOutcome(ProxyObservation{
+		Endpoint: EndpointChat,
+		Status:   OutcomeSuccess,
+		Stream:   false,
+		Latency:  120 * time.Millisecond,
+	})
+	ObserveProxyOutcome(ProxyObservation{
+		Endpoint: EndpointChat,
+		Status:   OutcomeSuccess,
+		Stream:   true,
+		Latency:  2 * time.Second,
+	})
+	ObserveProxyOutcome(ProxyObservation{
+		Endpoint: EndpointMessages,
+		Status:   OutcomeTimeout,
+		Stream:   false,
+		Latency:  15 * time.Second,
+	})
+
+	outcomes := OutcomeSnapshotForTest()
+	if outcomes["chat|success|false"] != 1 {
+		t.Fatalf("chat success non-stream = %d, want 1; all=%v", outcomes["chat|success|false"], outcomes)
+	}
+	if outcomes["chat|success|true"] != 1 {
+		t.Fatalf("chat success stream = %d, want 1", outcomes["chat|success|true"])
+	}
+	if outcomes["messages|timeout|false"] != 1 {
+		t.Fatalf("messages timeout = %d, want 1", outcomes["messages|timeout|false"])
+	}
+
+	if got := HistogramCountForTest(EndpointChat, OutcomeSuccess); got != 2 {
+		t.Fatalf("chat success hist count = %d, want 2", got)
+	}
+	if got := HistogramCountForTest(EndpointMessages, OutcomeTimeout); got != 1 {
+		t.Fatalf("messages timeout hist count = %d, want 1", got)
+	}
+
+	// Non-success outcomes also bump legacy error counter.
+	_, errors, _, _ := SnapshotForTest()
+	if errors != 1 {
+		t.Fatalf("proxy_errors_total = %d, want 1 (timeout only)", errors)
+	}
+
+	rec := httptest.NewRecorder()
+	if err := WritePrometheusMetrics(rec); err != nil {
+		t.Fatalf("WritePrometheusMetrics: %v", err)
+	}
+	body := rec.Body.String()
+	required := []string{
+		`metapi_proxy_outcomes_total{endpoint="chat",status="success",stream="false"} 1`,
+		`metapi_proxy_outcomes_total{endpoint="chat",status="success",stream="true"} 1`,
+		`metapi_proxy_outcomes_total{endpoint="messages",status="timeout",stream="false"} 1`,
+		`# TYPE metapi_proxy_request_duration_seconds histogram`,
+		`metapi_proxy_request_duration_seconds_count{endpoint="chat",status="success"} 2`,
+		`metapi_proxy_request_duration_seconds_bucket{endpoint="chat",status="success",le="+Inf"} 2`,
+		// existing scrape series must remain
+		"metapi_proxy_requests_total 0",
+		"metapi_proxy_errors_total 1",
+	}
+	for _, want := range required {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metrics body missing %q\n%s", want, body)
+		}
+	}
+	// Cumulative bucket: 120ms should fall into le="0.25"
+	if !strings.Contains(body, `metapi_proxy_request_duration_seconds_bucket{endpoint="chat",status="success",le="0.25"}`) {
+		t.Fatalf("missing 0.25s bucket for chat success:\n%s", body)
+	}
+}
+
+func TestEndpointLabelFromPath_Bounded(t *testing.T) {
+	cases := map[string]string{
+		"/v1/chat/completions":             EndpointChat,
+		"/v1/messages":                     EndpointMessages,
+		"/v1/responses":                    EndpointResponses,
+		"/v1/embeddings":                   EndpointEmbeddings,
+		"/v1/images/generations":           EndpointImages,
+		"/v1/rerank":                       EndpointRerank,
+		"/v1beta/models/x:generateContent": EndpointGemini,
+		"/secret/raw/path?key=abc":         EndpointOther,
+		"":                                 EndpointOther,
+	}
+	for path, want := range cases {
+		if got := EndpointLabelFromPath(path); got != want {
+			t.Fatalf("EndpointLabelFromPath(%q)=%q, want %q", path, got, want)
+		}
+	}
+}
+
+func TestObserveProxyOutcome_SanitizesHighCardinality(t *testing.T) {
+	ResetMetricsForTest()
+	// Attempt to inject model names / free text — must collapse.
+	ObserveProxyOutcome(ProxyObservation{
+		Endpoint: "gpt-4o-mini",
+		Status:   "HTTP 502 bad gateway from site-42",
+		Stream:   false,
+		Latency:  time.Millisecond,
+	})
+	outcomes := OutcomeSnapshotForTest()
+	if _, ok := outcomes["other|error|false"]; !ok {
+		t.Fatalf("expected sanitized other|error|false, got %v", outcomes)
+	}
+	for k := range outcomes {
+		if strings.Contains(k, "gpt") || strings.Contains(k, "502") || strings.Contains(k, "site") {
+			t.Fatalf("high-cardinality label leaked: %q", k)
+		}
+	}
+}
+
+type countingObserver struct {
+	n    atomic.Int64
+	last ProxyObservation
+}
+
+func (c *countingObserver) ObserveProxy(obs ProxyObservation) {
+	c.n.Add(1)
+	c.last = obs
+}
+
+func TestObserverHook_ReceivesSanitizedObservation(t *testing.T) {
+	ResetMetricsForTest()
+	obs := &countingObserver{}
+	SetObserver(obs)
+	ObserveProxyOutcome(ProxyObservation{
+		Endpoint: EndpointResponses,
+		Status:   OutcomeSuccess,
+		Stream:   true,
+		Latency:  50 * time.Millisecond,
+	})
+	if obs.n.Load() != 1 {
+		t.Fatalf("observer calls = %d, want 1", obs.n.Load())
+	}
+	if obs.last.Endpoint != EndpointResponses || obs.last.Status != OutcomeSuccess || !obs.last.Stream {
+		t.Fatalf("observer last = %+v", obs.last)
+	}
+	// Reset clears observer to no-op.
+	ResetMetricsForTest()
+	ObserveProxyOutcome(ProxyObservation{Endpoint: EndpointChat, Status: OutcomeSuccess})
+	if obs.n.Load() != 1 {
+		t.Fatalf("after reset observer still called: %d", obs.n.Load())
+	}
+}
+
+func TestStatusFromHTTP(t *testing.T) {
+	if StatusFromHTTP(200) != OutcomeSuccess {
+		t.Fatal("200")
+	}
+	if StatusFromHTTP(408) != OutcomeTimeout {
+		t.Fatal("408")
+	}
+	if StatusFromHTTP(429) != OutcomeUnavailable {
+		t.Fatal("429")
+	}
+	if StatusFromHTTP(400) != OutcomeClientError {
+		t.Fatal("400")
+	}
+	if StatusFromHTTP(502) != OutcomeUpstreamError {
+		t.Fatal("502")
 	}
 }


### PR DESCRIPTION
## Summary
- Add privacy-safe labeled terminal outcomes (`metapi_proxy_outcomes_total{endpoint,status,stream}`) and latency histogram (`metapi_proxy_request_duration_seconds`) without breaking existing scrape series.
- Wire cheap terminal observations on proxy success/failure paths in `handler/proxy/upstream.go`.
- Introduce optional `shared.Observer` / `app.SetMetricsObserver` export hook (no-op default; no vendor SDK) for OTEL/Langfuse-style sinks.
- Document surfaces in `docs/analysis/observability-export.md` (and update R2 boundaries).

Closes #117

## Test plan
- [x] `go test ./handler/shared/ ./app/ ./handler/proxy/ -count=1 -race`
- [x] pre-push full `go vet ./... && go test ./... -count=1 -race`
- [ ] Confirm `/metrics` still exposes legacy counters plus new histogram/outcome series after a proxy call