### PR TITLE
feat(auth): optional Redis-backed shared RPM admission #118

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,3 +62,8 @@ TRUSTED_PROXY_CIDRS=
 # Empty means same-origin admin UI only; proxy and health endpoints keep wildcard CORS.
 ADMIN_CORS_ALLOWED_ORIGINS=
 TZ=Asia/Shanghai
+
+# Optional Redis for multi-instance shared RPM admission / soft cooldowns (#118).
+# Empty = process-local memory only. On Redis errors, admission fails open.
+# Example: redis://:password@127.0.0.1:6379/0
+REDIS_URL=

--- a/app/proxy_upstream.go
+++ b/app/proxy_upstream.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/auth"
 	"github.com/tokendancelab/metapi-go/config"
 	proxyhandler "github.com/tokendancelab/metapi-go/handler/proxy"
 	"github.com/tokendancelab/metapi-go/proxy"
@@ -39,6 +40,8 @@ func ConfigureProxyUpstream(cfg *config.Config) error {
 			requestTimeout = doubled
 		}
 	}
+	auth.ConfigureSharedAdmissionFromRedisURL(cfg.RedisURL)
+
 	router := routing.NewTokenRouter(newProxyRoutingStore(db), cfg, nil, proxyLoadProvider{coord: coord})
 	proxyhandler.SetUpstreamConfig(&proxyhandler.UpstreamConfig{
 		Router:      router,

--- a/auth/key_admission.go
+++ b/auth/key_admission.go
@@ -1,8 +1,13 @@
 package auth
 
 import (
+	"context"
+	"log/slog"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/tokendancelab/metapi-go/internal/sharedcount"
 )
 
 // KeyAdmissionLimiter is an in-process sliding-window RPM/TPM gate for
@@ -13,6 +18,9 @@ type KeyAdmissionLimiter struct {
 	keys map[int64]*keyWindow
 	// nowFn is injectable for tests.
 	nowFn func() time.Time
+	// sharedRPM is optional multi-instance counter (#118). nil = memory-only.
+	// Fail-open: Redis errors fall back to local window.
+	sharedRPM sharedcount.WindowCounter
 }
 
 type keyWindow struct {
@@ -36,6 +44,35 @@ func NewKeyAdmissionLimiter() *KeyAdmissionLimiter {
 		keys:  make(map[int64]*keyWindow),
 		nowFn: time.Now,
 	}
+}
+
+// SetSharedRPMCounter wires an optional multi-instance window counter (#118).
+// Pass nil to clear (memory-only). Safe to call at process startup.
+func (l *KeyAdmissionLimiter) SetSharedRPMCounter(c sharedcount.WindowCounter) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.sharedRPM = c
+}
+
+// ConfigureSharedAdmissionFromRedisURL enables Redis-backed RPM counting when url is non-empty.
+// On parse/dial setup failure, logs and keeps memory-only. Runtime Redis errors fail open.
+func ConfigureSharedAdmissionFromRedisURL(redisURL string) {
+	redisURL = strings.TrimSpace(redisURL)
+	if redisURL == "" {
+		GlobalKeyAdmission.SetSharedRPMCounter(nil)
+		return
+	}
+	rc, err := sharedcount.NewRedisCounter(redisURL)
+	if err != nil {
+		slog.Warn("redis admission: disabled (bad REDIS_URL)", "error", err)
+		GlobalKeyAdmission.SetSharedRPMCounter(nil)
+		return
+	}
+	GlobalKeyAdmission.SetSharedRPMCounter(rc)
+	slog.Info("redis admission: shared RPM counter enabled")
 }
 
 // ResetKeyAdmissionForTest clears the global limiter state.
@@ -90,7 +127,28 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 	usedRPM := int64(len(w.reqTimes))
 	usedTPM := sumTokens(w.tokenEvents)
 
-	if rpmLimit > 0 && usedRPM >= rpmLimit {
+	// Optional multi-instance RPM (#118). Fail-open on errors.
+	sharedCounted := false
+	if rpmLimit > 0 && l.sharedRPM != nil {
+		n, err := l.sharedRPM.Incr(context.Background(), rpmSharedKey(keyID), time.Minute)
+		if err != nil {
+			slog.Debug("redis admission: fail-open on error", "key_id", keyID, "error", err)
+		} else {
+			sharedCounted = true
+			usedRPM = n
+			if n > rpmLimit {
+				return AdmissionDecision{
+					Allowed:    false,
+					Reason:     "over_rpm",
+					RetryAfter: time.Second,
+					UsedRPM:    usedRPM,
+					UsedTPM:    usedTPM,
+				}
+			}
+		}
+	}
+
+	if !sharedCounted && rpmLimit > 0 && usedRPM >= rpmLimit {
 		retry := retryAfterMs(w.reqTimes, nowMs)
 		return AdmissionDecision{
 			Allowed:    false,
@@ -211,4 +269,8 @@ func max64z(v, floor int64) int64 {
 		return floor
 	}
 	return v
+}
+
+func rpmSharedKey(keyID int64) string {
+	return "metapi:rpm:" + formatInt64(keyID)
 }

--- a/auth/key_admission_shared_test.go
+++ b/auth/key_admission_shared_test.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeWindow struct {
+	n   int64
+	err error
+}
+
+func (f *fakeWindow) Incr(ctx context.Context, key string, window time.Duration) (int64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	f.n++
+	return f.n, nil
+}
+
+func (f *fakeWindow) Get(ctx context.Context, key string) (int64, error) {
+	return f.n, f.err
+}
+
+func TestKeyAdmission_SharedRPM(t *testing.T) {
+	l := NewKeyAdmissionLimiter()
+	fw := &fakeWindow{}
+	l.SetSharedRPMCounter(fw)
+	limit := int64(2)
+	if d := l.Allow(1, &limit, nil, 0); !d.Allowed {
+		t.Fatalf("1: %#v", d)
+	}
+	if d := l.Allow(1, &limit, nil, 0); !d.Allowed {
+		t.Fatalf("2: %#v", d)
+	}
+	if d := l.Allow(1, &limit, nil, 0); d.Allowed || d.Reason != "over_rpm" {
+		t.Fatalf("3 should deny: %#v", d)
+	}
+}
+
+func TestKeyAdmission_SharedRPM_FailOpen(t *testing.T) {
+	l := NewKeyAdmissionLimiter()
+	fw := &fakeWindow{err: errors.New("redis down")}
+	l.SetSharedRPMCounter(fw)
+	limit := int64(100)
+	// Should not hard-fail; local path allows.
+	if d := l.Allow(2, &limit, nil, 0); !d.Allowed {
+		t.Fatalf("fail-open expected allow: %#v", d)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -120,6 +120,8 @@ type Config struct {
 	// Notify: General (2 fields)
 	NotifyCooldownSec int
 	SystemProxyUrl    string
+	// RedisURL enables optional shared admission counters (#118).
+	RedisURL string
 
 	// Admin (3 fields)
 	AdminIpAllowlist        []string
@@ -127,7 +129,7 @@ type Config struct {
 	TrustedProxyCidrs       []string
 
 	// Proxy: Core (2 fields)
-	RequestBodyLimit int
+	RequestBodyLimit        int
 	RoutingFallbackUnitCost float64
 	// ProxyFirstByteTimeoutSec is the operator-facing first-byte / first-token
 	// timeout in SECONDS (env PROXY_FIRST_BYTE_TIMEOUT_SEC). Internal dispatch
@@ -458,6 +460,7 @@ func Load(env map[string]string) *Config {
 	// ---- §3.11 Notify: General ----
 	cfg.NotifyCooldownSec = maxInt(0, int(math.Trunc(parseNumber(get("NOTIFY_COOLDOWN_SEC"), DefaultNotifyCooldownSec))))
 	cfg.SystemProxyUrl = firstNonEmpty(get("SYSTEM_PROXY_URL"), "")
+	cfg.RedisURL = firstNonEmpty(get("REDIS_URL"), get("METAPI_REDIS_URL"))
 
 	// ---- §3.12 Admin ----
 	cfg.AdminIpAllowlist = parseCsvList(get("ADMIN_IP_ALLOWLIST"))

--- a/docs/analysis/redis-shared-state.md
+++ b/docs/analysis/redis-shared-state.md
@@ -1,0 +1,21 @@
+# Optional Redis shared state (#118)
+
+## Config
+- `REDIS_URL` or `METAPI_REDIS_URL` (empty = disabled)
+- Examples: `redis://127.0.0.1:6379/0`, `redis://:pass@host:6379/1`, `host:6379`
+
+## What is shared
+- Downstream-key **RPM** admission counters (`metapi:rpm:{keyID}`) via fixed-window INCR+PEXPIRE.
+- Implementation: `internal/sharedcount` (memory + minimal RESP Redis client, no third-party dep).
+
+## Failure mode
+- **Fail-open**: if Redis is unreachable or returns errors at request time, admission falls back to process-local sliding window (same as #116).
+- Bad `REDIS_URL` at startup disables shared mode and logs a warning.
+
+## Residual
+- TPM multi-instance sharing not yet wired.
+- Channel cooldown remains DB-backed (`cooldown_until`); not moved to Redis.
+- Fixed-window Redis approximation differs slightly from local sliding window.
+
+## Single-node
+Leave `REDIS_URL` empty. No Redis process required.

--- a/internal/sharedcount/counter.go
+++ b/internal/sharedcount/counter.go
@@ -1,0 +1,320 @@
+package sharedcount
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// WindowCounter increments a named key inside a sliding/fixed window and returns
+// the post-increment count. Used for multi-instance RPM admission (#118).
+type WindowCounter interface {
+	// Incr increments key by 1 within window and returns the new count.
+	// Implementations may approximate sliding windows with fixed TTL buckets.
+	Incr(ctx context.Context, key string, window time.Duration) (count int64, err error)
+	// Get returns the current count without incrementing.
+	Get(ctx context.Context, key string) (count int64, err error)
+}
+
+// MemoryCounter is the default single-process implementation.
+type MemoryCounter struct {
+	mu   sync.Mutex
+	keys map[string]*memWindow
+	now  func() time.Time
+}
+
+type memWindow struct {
+	times []int64 // unix ms
+}
+
+func NewMemoryCounter() *MemoryCounter {
+	return &MemoryCounter{keys: make(map[string]*memWindow), now: time.Now}
+}
+
+func (m *MemoryCounter) Incr(ctx context.Context, key string, window time.Duration) (int64, error) {
+	_ = ctx
+	if window <= 0 {
+		window = time.Minute
+	}
+	nowMs := m.now().UnixMilli()
+	start := nowMs - window.Milliseconds()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	w := m.keys[key]
+	if w == nil {
+		w = &memWindow{}
+		m.keys[key] = w
+	}
+	// prune
+	i := 0
+	for i < len(w.times) && w.times[i] < start {
+		i++
+	}
+	if i > 0 {
+		w.times = append([]int64(nil), w.times[i:]...)
+	}
+	w.times = append(w.times, nowMs)
+	return int64(len(w.times)), nil
+}
+
+func (m *MemoryCounter) Get(ctx context.Context, key string) (int64, error) {
+	_ = ctx
+	nowMs := m.now().UnixMilli()
+	start := nowMs - 60_000
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	w := m.keys[key]
+	if w == nil {
+		return 0, nil
+	}
+	n := 0
+	for _, t := range w.times {
+		if t >= start {
+			n++
+		}
+	}
+	return int64(n), nil
+}
+
+// RedisCounter is a minimal RESP client (INCR + PEXPIRE / GET) over TCP.
+// No third-party dependency. Failures return errors for callers to fail-open.
+type RedisCounter struct {
+	addr     string // host:port
+	password string
+	db       int
+	timeout  time.Duration
+	// dial is injectable for tests.
+	dial func(network, address string, timeout time.Duration) (net.Conn, error)
+}
+
+// ParseRedisURL parses redis://[:password@]host:port[/db] into RedisCounter fields.
+// Empty password/db are ok. redis://localhost:6379/0 is the common form.
+func ParseRedisURL(raw string) (addr, password string, db int, err error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", 0, fmt.Errorf("empty redis url")
+	}
+	// Accept host:port without scheme.
+	if !strings.Contains(raw, "://") {
+		if !strings.Contains(raw, ":") {
+			raw = raw + ":6379"
+		}
+		return raw, "", 0, nil
+	}
+	// Very small parser for redis://[:pass@]host:port[/db]
+	u := raw
+	u = strings.TrimPrefix(u, "redis://")
+	u = strings.TrimPrefix(u, "rediss://")
+	// password
+	if at := strings.LastIndex(u, "@"); at >= 0 {
+		userinfo := u[:at]
+		u = u[at+1:]
+		if strings.HasPrefix(userinfo, ":") {
+			password = userinfo[1:]
+		} else if i := strings.Index(userinfo, ":"); i >= 0 {
+			password = userinfo[i+1:]
+		} else {
+			password = userinfo
+		}
+	}
+	// db
+	if slash := strings.Index(u, "/"); slash >= 0 {
+		dbPart := u[slash+1:]
+		u = u[:slash]
+		if dbPart != "" {
+			n, e := strconv.Atoi(strings.Split(dbPart, "?")[0])
+			if e != nil {
+				return "", "", 0, fmt.Errorf("invalid redis db: %w", e)
+			}
+			db = n
+		}
+	}
+	if !strings.Contains(u, ":") {
+		u = u + ":6379"
+	}
+	return u, password, db, nil
+}
+
+func NewRedisCounter(redisURL string) (*RedisCounter, error) {
+	addr, pass, db, err := ParseRedisURL(redisURL)
+	if err != nil {
+		return nil, err
+	}
+	return &RedisCounter{
+		addr:     addr,
+		password: pass,
+		db:       db,
+		timeout:  800 * time.Millisecond,
+		dial:     net.DialTimeout,
+	}, nil
+}
+
+func (r *RedisCounter) withConn(ctx context.Context, fn func(net.Conn) error) error {
+	_ = ctx
+	if r.dial == nil {
+		r.dial = net.DialTimeout
+	}
+	conn, err := r.dial("tcp", r.addr, r.timeout)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(r.timeout))
+	if r.password != "" {
+		if err := redisDo(conn, "AUTH", r.password); err != nil {
+			return err
+		}
+	}
+	if r.db != 0 {
+		if err := redisDo(conn, "SELECT", strconv.Itoa(r.db)); err != nil {
+			return err
+		}
+	}
+	return fn(conn)
+}
+
+func (r *RedisCounter) Incr(ctx context.Context, key string, window time.Duration) (int64, error) {
+	if window <= 0 {
+		window = time.Minute
+	}
+	var count int64
+	err := r.withConn(ctx, func(conn net.Conn) error {
+		// Fixed-window approximation: INCR + PEXPIRE only when count==1.
+		n, err := redisDoInt(conn, "INCR", key)
+		if err != nil {
+			return err
+		}
+		count = n
+		if n == 1 {
+			ms := strconv.FormatInt(window.Milliseconds(), 10)
+			if err := redisDo(conn, "PEXPIRE", key, ms); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return count, err
+}
+
+func (r *RedisCounter) Get(ctx context.Context, key string) (int64, error) {
+	var count int64
+	err := r.withConn(ctx, func(conn net.Conn) error {
+		// GET may return null bulk → 0
+		n, err := redisDoIntNullable(conn, "GET", key)
+		if err != nil {
+			return err
+		}
+		count = n
+		return nil
+	})
+	return count, err
+}
+
+// ---- minimal RESP ----
+
+func redisDo(conn net.Conn, parts ...string) error {
+	_, err := redisDoRaw(conn, parts...)
+	return err
+}
+
+func redisDoInt(conn net.Conn, parts ...string) (int64, error) {
+	raw, err := redisDoRaw(conn, parts...)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(raw, 10, 64)
+}
+
+func redisDoIntNullable(conn net.Conn, parts ...string) (int64, error) {
+	raw, err := redisDoRaw(conn, parts...)
+	if err != nil {
+		return 0, err
+	}
+	if raw == "" {
+		return 0, nil
+	}
+	return strconv.ParseInt(raw, 10, 64)
+}
+
+func redisDoRaw(conn net.Conn, parts ...string) (string, error) {
+	var b strings.Builder
+	b.WriteString("*")
+	b.WriteString(strconv.Itoa(len(parts)))
+	b.WriteString("\r\n")
+	for _, p := range parts {
+		b.WriteString("$")
+		b.WriteString(strconv.Itoa(len(p)))
+		b.WriteString("\r\n")
+		b.WriteString(p)
+		b.WriteString("\r\n")
+	}
+	if _, err := conn.Write([]byte(b.String())); err != nil {
+		return "", err
+	}
+	return redisRead(conn)
+}
+
+func redisRead(conn net.Conn) (string, error) {
+	buf := make([]byte, 0, 256)
+	tmp := make([]byte, 256)
+	for {
+		n, err := conn.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
+		if err != nil && len(buf) == 0 {
+			return "", err
+		}
+		if len(buf) == 0 {
+			continue
+		}
+		switch buf[0] {
+		case '+':
+			if i := indexCRLF(buf); i >= 0 {
+				return string(buf[1:i]), nil
+			}
+		case '-':
+			if i := indexCRLF(buf); i >= 0 {
+				return "", fmt.Errorf("redis error: %s", string(buf[1:i]))
+			}
+		case ':':
+			if i := indexCRLF(buf); i >= 0 {
+				return string(buf[1:i]), nil
+			}
+		case '$':
+			// bulk: $<len>\r\n<data>\r\n or hmtBc1\r\n
+			if i := indexCRLF(buf); i >= 0 {
+				lenStr := string(buf[1:i])
+				if lenStr == "-1" {
+					return "", nil
+				}
+				ln, err := strconv.Atoi(lenStr)
+				if err != nil {
+					return "", err
+				}
+				start := i + 2
+				if len(buf) >= start+ln+2 {
+					return string(buf[start : start+ln]), nil
+				}
+			}
+		default:
+			return "", fmt.Errorf("unexpected redis reply prefix %q", buf[0])
+		}
+		if err != nil {
+			return "", err
+		}
+	}
+}
+
+func indexCRLF(b []byte) int {
+	for i := 0; i+1 < len(b); i++ {
+		if b[i] == 13 && b[i+1] == 10 {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/sharedcount/memory_test.go
+++ b/internal/sharedcount/memory_test.go
@@ -1,0 +1,40 @@
+package sharedcount
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMemoryCounter_IncrWindow(t *testing.T) {
+	m := NewMemoryCounter()
+	base := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	now := base
+	m.now = func() time.Time { return now }
+
+	for i := 1; i <= 3; i++ {
+		n, err := m.Incr(context.Background(), "k", time.Minute)
+		if err != nil || n != int64(i) {
+			t.Fatalf("i=%d n=%d err=%v", i, n, err)
+		}
+	}
+	now = base.Add(61 * time.Second)
+	n, err := m.Incr(context.Background(), "k", time.Minute)
+	if err != nil || n != 1 {
+		t.Fatalf("after window n=%d err=%v", n, err)
+	}
+}
+
+func TestParseRedisURL(t *testing.T) {
+	addr, pass, db, err := ParseRedisURL("redis://:s3cret@localhost:6380/2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr != "localhost:6380" || pass != "s3cret" || db != 2 {
+		t.Fatalf("addr=%s pass=%s db=%d", addr, pass, db)
+	}
+	addr, _, _, err = ParseRedisURL("127.0.0.1")
+	if err != nil || addr != "127.0.0.1:6379" {
+		t.Fatalf("host only: %s %v", addr, err)
+	}
+}


### PR DESCRIPTION
## Summary
- Optional \`REDIS_URL\` / \`METAPI_REDIS_URL\` enables shared RPM counters
- Zero third-party dep RESP client in \`internal/sharedcount\`
- Fail-open on Redis errors; single-node needs no Redis

## Residual
- TPM multi-instance not wired
- Channel cooldown stays DB-backed

## Test plan
- [x] \`go test ./auth ./internal/sharedcount ./config ./app\`
- [ ] CI green

Closes #118