### PR TITLE
feat(admin): forced-channel API test harness #119

### DIFF
--- a/docs/analysis/admin-channel-test-harness.md
+++ b/docs/analysis/admin-channel-test-harness.md
@@ -1,0 +1,124 @@
+# Admin channel test harness (#119)
+
+**Date:** 2026-07-17  
+**Backlog:** [#119](https://github.com/TokenDanceLab/metapi-go/issues/119) · competitive learn L10  
+**Peers:** all-api-hub multi-dimensional API verification (in-page, not browser extension)  
+**Code:** `handler/admin/channel_test_harness.go`
+
+## Goal
+
+Give operators a **one-click, admin-auth** way to force a specific channel/site and verify that a model/key actually works — returning status, latency, and a **safe truncated** body/error summary. No browser extension, no end-user unauthenticated console, no storage of production prompt corpora.
+
+## API
+
+Both paths share one handler (admin auth via `/api/*` group):
+
+| Method | Path | Notes |
+|--------|------|-------|
+| POST | `/api/admin/test-channel` | Canonical admin path |
+| POST | `/api/debug/channel-probe` | Alias under debug namespace |
+
+### Request body
+
+```json
+{
+  "channelId": 12,
+  "siteId": 3,
+  "model": "gpt-4o-mini",
+  "prompt": "ping",
+  "mode": "chat",
+  "timeoutMs": 15000
+}
+```
+
+| Field | Required | Default | Notes |
+|-------|----------|---------|-------|
+| `channelId` | one of channel/site | — | Forces this `route_channels` row (preferred). |
+| `siteId` | one of channel/site | — | Picks best enabled channel on the site (model match preferred). |
+| `model` | no | channel `source_model` or `gpt-4o-mini` | Upstream model name. |
+| `prompt` | no | `ping` | Chat user content only; max 256 runes; **not stored**. |
+| `mode` | no | `chat` | `chat` → `POST /v1/chat/completions`; `models` → `GET /v1/models`. |
+| `timeoutMs` | no | `15000` | Clamped to **[1000, 60000]**. |
+
+### Response shape
+
+Always HTTP **200** for a completed probe attempt (including upstream 4xx/5xx/timeouts). Validation/auth/not-found use normal admin error status codes (400/401/404).
+
+```json
+{
+  "success": true,
+  "statusCode": 200,
+  "latencyMs": 142,
+  "truncatedBody": "{\"id\":\"chatcmpl-…\",\"choices\":[…]}",
+  "error": null,
+  "channelId": 12,
+  "routeId": 4,
+  "siteId": 3,
+  "siteName": "Relay-A",
+  "accountId": 9,
+  "model": "gpt-4o-mini",
+  "mode": "chat",
+  "upstreamPath": "/v1/chat/completions",
+  "upstreamHost": "relay.example.com",
+  "bodyTruncated": false
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `success` | Upstream HTTP status in **2xx**. |
+| `statusCode` | Upstream status (0 on transport error). |
+| `latencyMs` | Wall time for the forced attempt. |
+| `truncatedBody` | Response body capped ~**2 KiB**, secret-like substrings redacted. |
+| `error` | Safe summary when not successful (timeout / status / transport). |
+| `bodyTruncated` | True when the body was cut for size. |
+| `upstreamHost` | Host only (no credentials). |
+
+## Forced channel semantics
+
+1. Load channel → account → site (and optional `account_tokens` when `token_id` set).
+2. Resolve credential like routing (token row → oauth access token → api_token → access_token fallback for harness).
+3. Build **one** upstream request to that site URL (via `proxy.BuildUpstreamURL`).
+4. **Do not** call weighted selection / failover / sticky / multi-protocol fallback.
+5. Apply site custom headers / account-or-site proxy via `service.BuildPlatformProxyConfig` (Authorization never overwritten by site headers).
+6. Return status/latency/truncated body; **do not** mutate channel cooldown or mark keys expired.
+
+## Safety
+
+| Rule | Implementation |
+|------|----------------|
+| Admin-only | Registered under `auth.AdminAuth` group in `router/router.go` |
+| No full prompt storage | Prompt is request-scoped only; never written to DB/logs as corpus |
+| Body cap | Read at most ~2 KiB; mark `bodyTruncated` |
+| Secret redaction | `sk-…`, `Bearer …`, `api_key=…` patterns replaced with `[redacted]` |
+| No auth header echo | Response does not include request Authorization |
+| Timeout floor/ceiling | 1s–60s |
+
+## Out of scope
+
+- End-user unauthenticated console
+- Multi-model matrix fan-out UI (can call this API repeatedly)
+- Browser extension permissions / all-api-hub client shape
+- Background health probing (see #114 / `scheduler/model_probe.go`)
+- Large SPA redesign (optional thin button is a follow-up)
+
+## Tests
+
+`handler/admin/channel_test_harness_test.go`:
+
+- validation (missing ids, bad mode, bad JSON)
+- channel not found → 404
+- forced channel chat success via stub `RoundTripper`
+- debug alias + models mode
+- siteId resolution to enabled channel
+- upstream 401 + oversized body → truncated + redacted
+- transport timeout → safe error summary
+
+## Operator usage
+
+```bash
+curl -sS -X POST "http://localhost:4000/api/admin/test-channel" \
+  -H "Authorization: Bearer $AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channelId":12,"model":"gpt-4o-mini","prompt":"ping"}'
+```

--- a/docs/api.md
+++ b/docs/api.md
@@ -132,6 +132,14 @@ Update a single channel.
 
 Delete a channel.
 
+### POST /api/admin/test-channel
+
+Admin-only forced channel/site probe (competitive learn #119). Alias: `POST /api/debug/channel-probe`.
+
+Body: `{ "channelId"?: number, "siteId"?: number, "model"?: string, "prompt"?: string, "mode"?: "chat"|"models", "timeoutMs"?: number }`.
+
+Requires `channelId` or `siteId`. Forces one upstream request (no weighted selection). Returns `{ success, statusCode, latencyMs, truncatedBody, error, channelId, siteId, accountId, model, mode, bodyTruncated, ... }` with ~2 KiB redacted body summary. See `docs/analysis/admin-channel-test-harness.md`.
+
 ---
 
 ## Route Decision

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -28,7 +28,7 @@
 | **M-UI** | UI/UX design system | ✅ U0–U3 landed (DESIGN/tokens/components/pages/a11y) |
 | **M-SCHEMA** | Schema compat + upgrade | ✅ SC0–SC2 landed (parity + additive migrations + P0 columns) |
 | **M-RELIABILITY** | Reliability and boundaries | ✅ R0–R2 landed |
-| **M-FEATURE** | Feature completeness from gap matrix | ✅ Gap #38–#56 + learn #110–#117. Open #118–#121 |
+| **M-FEATURE** | Feature completeness from gap matrix | ✅ Gap #38–#56 + learn #110–#117 + #119. Open #118/#120–#121 |
 
 > **Program map**: `docs/plan/enterprise-program.md` + `docs/plan/lane-charters.md`  
 > **Scope**: product gap implementation only after F0; CRITICAL reliability (B2/R*) may ship earlier.
@@ -74,8 +74,8 @@
 | Milestone | https://github.com/TokenDanceLab/metapi-go/milestone/6 · Roadmap `docs/plan/feature-complete-roadmap.md` |
 | Shipped infra | Site max concurrency · per-key `proxy_url` · group route rebuild |
 | Closed F1+P1 | Full gap backlog #38–#56 (PRs #74–#94) |
-| In flight WFs | none — next P1 #118 Redis cooldown · #119 admin API harness |
-| Next | M-COMPETE P1 residual: #118 Redis cooldown · #119 admin API harness · P2 #120–#121 |
+| In flight WFs | none — next P1 #118 Redis cooldown |
+| Next | M-COMPETE P1 residual: #118 Redis cooldown · P2 #120–#121 |
 | Residual CI | `vulncheck` GO-2026-5856 (Go 1.26.4); frontend occasional `EnvironmentTeardownError` flake (tests pass) |
 
 ### M-COMPETE notes (active)

--- a/handler/admin/channel_test_harness.go
+++ b/handler/admin/channel_test_harness.go
@@ -1,0 +1,537 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/platform"
+	"github.com/tokendancelab/metapi-go/proxy"
+	"github.com/tokendancelab/metapi-go/service"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+const (
+	channelTestDefaultPrompt    = "ping"
+	channelTestDefaultTimeoutMs = 15_000
+	channelTestMinTimeoutMs     = 1_000
+	channelTestMaxTimeoutMs     = 60_000
+	channelTestMaxBodyBytes     = 2 << 10 // ~2 KiB safe summary
+	channelTestMaxPromptRunes   = 256
+	channelTestDefaultModel     = "gpt-4o-mini"
+	channelTestModeChat         = "chat"
+	channelTestModeModels       = "models"
+)
+
+// secretLikeRE redacts common secret-looking tokens from operator-visible bodies/errors.
+var secretLikeRE = regexp.MustCompile(`(?i)(sk-[a-z0-9_\-]{8,}|Bearer\s+[A-Za-z0-9\-._~+/]+=*|api[_-]?key["']?\s*[:=]\s*["']?[A-Za-z0-9\-._]{8,})`)
+
+// RegisterChannelTestRoutes registers admin-only forced-channel probe endpoints.
+//
+//	POST /api/admin/test-channel
+//	POST /api/debug/channel-probe   (alias)
+func RegisterChannelTestRoutes(r chi.Router, db *sqlx.DB, cfg *config.Config) {
+	h := &channelTestHandler{db: db, cfg: cfg}
+	r.Post("/api/admin/test-channel", h.testChannel)
+	r.Post("/api/debug/channel-probe", h.testChannel)
+}
+
+type channelTestHandler struct {
+	db  *sqlx.DB
+	cfg *config.Config
+
+	// transport is an optional override for tests (stub upstream).
+	// When nil, production uses platform.DoWithProxy / default client.
+	transport http.RoundTripper
+}
+
+type channelTestRequest struct {
+	ChannelID *int64 `json:"channelId"`
+	SiteID    *int64 `json:"siteId"`
+	Model     string `json:"model"`
+	Prompt    string `json:"prompt"`
+	Mode      string `json:"mode"`
+	TimeoutMs *int64 `json:"timeoutMs"`
+}
+
+type channelTestTarget struct {
+	ChannelID   int64
+	RouteID     int64
+	AccountID   int64
+	SiteID      int64
+	SourceModel string
+	SiteName    string
+	SiteURL     string
+	Platform    string
+	TokenValue  string
+	Account     store.Account
+	Site        store.Site
+}
+
+type harnessAccountRow struct {
+	ID            int64   `db:"id"`
+	SiteID        int64   `db:"site_id"`
+	AccessToken   string  `db:"access_token"`
+	APIToken      *string `db:"api_token"`
+	OAuthProvider *string `db:"oauth_provider"`
+	ExtraConfig   *string `db:"extra_config"`
+	Status        string  `db:"status"`
+}
+
+type harnessSiteRow struct {
+	ID             int64   `db:"id"`
+	Name           string  `db:"name"`
+	URL            string  `db:"url"`
+	Platform       string  `db:"platform"`
+	ProxyURL       *string `db:"proxy_url"`
+	UseSystemProxy bool    `db:"use_system_proxy"`
+	CustomHeaders  *string `db:"custom_headers"`
+	Status         string  `db:"status"`
+}
+
+type harnessChannelRow struct {
+	ID          int64   `db:"id"`
+	RouteID     int64   `db:"route_id"`
+	AccountID   int64   `db:"account_id"`
+	TokenID     *int64  `db:"token_id"`
+	SourceModel *string `db:"source_model"`
+	Enabled     bool    `db:"enabled"`
+}
+
+type harnessTokenRow struct {
+	ID      int64  `db:"id"`
+	Token   string `db:"token"`
+	Enabled bool   `db:"enabled"`
+}
+
+// POST /api/admin/test-channel
+// POST /api/debug/channel-probe
+func (h *channelTestHandler) testChannel(w http.ResponseWriter, r *http.Request) {
+	var body channelTestRequest
+	if err := decodeJSONRequest(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(body.Mode))
+	if mode == "" {
+		mode = channelTestModeChat
+	}
+	if mode != channelTestModeChat && mode != channelTestModeModels {
+		writeError(w, http.StatusBadRequest, "Invalid mode. Expected chat or models.")
+		return
+	}
+
+	if (body.ChannelID == nil || *body.ChannelID <= 0) && (body.SiteID == nil || *body.SiteID <= 0) {
+		writeError(w, http.StatusBadRequest, "channelId or siteId is required")
+		return
+	}
+
+	model := strings.TrimSpace(body.Model)
+	prompt := strings.TrimSpace(body.Prompt)
+	if prompt == "" {
+		prompt = channelTestDefaultPrompt
+	}
+	if utf8.RuneCountInString(prompt) > channelTestMaxPromptRunes {
+		// Bound operator input; never store prompt corpora.
+		runes := []rune(prompt)
+		prompt = string(runes[:channelTestMaxPromptRunes])
+	}
+
+	timeoutMs := int64(channelTestDefaultTimeoutMs)
+	if body.TimeoutMs != nil && *body.TimeoutMs > 0 {
+		timeoutMs = *body.TimeoutMs
+	}
+	if timeoutMs < channelTestMinTimeoutMs {
+		timeoutMs = channelTestMinTimeoutMs
+	}
+	if timeoutMs > channelTestMaxTimeoutMs {
+		timeoutMs = channelTestMaxTimeoutMs
+	}
+
+	target, err := h.resolveTarget(r.Context(), body.ChannelID, body.SiteID, model)
+	if err != nil {
+		if isHarnessNotFound(err) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if model == "" {
+		if target.SourceModel != "" {
+			model = target.SourceModel
+		} else {
+			model = channelTestDefaultModel
+		}
+	}
+
+	if target.TokenValue == "" {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"success":       false,
+			"statusCode":    0,
+			"latencyMs":     0,
+			"truncatedBody": "",
+			"error":         "No usable token on channel/account (api token / oauth access token required)",
+			"channelId":     target.ChannelID,
+			"siteId":        target.SiteID,
+			"accountId":     target.AccountID,
+			"model":         model,
+			"mode":          mode,
+			"bodyTruncated": false,
+		})
+		return
+	}
+
+	result := h.executeProbe(r.Context(), target, mode, model, prompt, timeoutMs)
+	writeJSON(w, http.StatusOK, result)
+}
+
+func isHarnessNotFound(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "not found")
+}
+
+func (h *channelTestHandler) resolveTarget(ctx context.Context, channelID, siteID *int64, modelHint string) (*channelTestTarget, error) {
+	if channelID != nil && *channelID > 0 {
+		return h.loadByChannelID(ctx, *channelID)
+	}
+	return h.loadBySiteID(ctx, *siteID, modelHint)
+}
+
+func (h *channelTestHandler) loadByChannelID(ctx context.Context, channelID int64) (*channelTestTarget, error) {
+	var ch harnessChannelRow
+	err := h.db.GetContext(ctx, &ch, h.db.Rebind(`
+		SELECT id, route_id, account_id, token_id, source_model, enabled
+		FROM route_channels WHERE id = ?`), channelID)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("channel not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load channel: %w", err)
+	}
+	return h.assembleTarget(ctx, ch)
+}
+
+func (h *channelTestHandler) loadBySiteID(ctx context.Context, siteID int64, modelHint string) (*channelTestTarget, error) {
+	// Prefer enabled channel whose source_model matches modelHint, else any enabled for the site.
+	var ch harnessChannelRow
+	modelHint = strings.TrimSpace(modelHint)
+	var err error
+	if modelHint != "" {
+		err = h.db.GetContext(ctx, &ch, h.db.Rebind(`
+			SELECT rc.id, rc.route_id, rc.account_id, rc.token_id, rc.source_model, rc.enabled
+			FROM route_channels rc
+			JOIN accounts a ON a.id = rc.account_id
+			WHERE a.site_id = ? AND rc.enabled = ?
+			  AND LOWER(COALESCE(rc.source_model, '')) = LOWER(?)
+			ORDER BY rc.priority DESC, rc.id ASC
+			LIMIT 1`), siteID, true, modelHint)
+		if err != nil && err != sql.ErrNoRows {
+			return nil, fmt.Errorf("load channel by site/model: %w", err)
+		}
+	}
+	if ch.ID == 0 {
+		err = h.db.GetContext(ctx, &ch, h.db.Rebind(`
+			SELECT rc.id, rc.route_id, rc.account_id, rc.token_id, rc.source_model, rc.enabled
+			FROM route_channels rc
+			JOIN accounts a ON a.id = rc.account_id
+			WHERE a.site_id = ? AND rc.enabled = ?
+			ORDER BY rc.priority DESC, rc.id ASC
+			LIMIT 1`), siteID, true)
+		if err == sql.ErrNoRows {
+			// Fall back to any channel on site even if disabled.
+			err = h.db.GetContext(ctx, &ch, h.db.Rebind(`
+				SELECT rc.id, rc.route_id, rc.account_id, rc.token_id, rc.source_model, rc.enabled
+				FROM route_channels rc
+				JOIN accounts a ON a.id = rc.account_id
+				WHERE a.site_id = ?
+				ORDER BY rc.priority DESC, rc.id ASC
+				LIMIT 1`), siteID)
+		}
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("no channel found for site")
+		}
+		if err != nil {
+			return nil, fmt.Errorf("load channel by site: %w", err)
+		}
+	}
+	return h.assembleTarget(ctx, ch)
+}
+
+func (h *channelTestHandler) assembleTarget(ctx context.Context, ch harnessChannelRow) (*channelTestTarget, error) {
+	var acc harnessAccountRow
+	if err := h.db.GetContext(ctx, &acc, h.db.Rebind(`
+		SELECT id, site_id, access_token, api_token, oauth_provider, extra_config, status
+		FROM accounts WHERE id = ?`), ch.AccountID); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("account not found")
+		}
+		return nil, fmt.Errorf("load account: %w", err)
+	}
+
+	var site harnessSiteRow
+	if err := h.db.GetContext(ctx, &site, h.db.Rebind(`
+		SELECT id, name, url, platform, proxy_url, use_system_proxy, custom_headers, status
+		FROM sites WHERE id = ?`), acc.SiteID); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("site not found")
+		}
+		return nil, fmt.Errorf("load site: %w", err)
+	}
+
+	var token *harnessTokenRow
+	if ch.TokenID != nil && *ch.TokenID > 0 {
+		var tr harnessTokenRow
+		if err := h.db.GetContext(ctx, &tr, h.db.Rebind(`
+			SELECT id, token, enabled FROM account_tokens WHERE id = ?`), *ch.TokenID); err == nil {
+			token = &tr
+		}
+	}
+
+	sourceModel := ""
+	if ch.SourceModel != nil {
+		sourceModel = strings.TrimSpace(*ch.SourceModel)
+	}
+
+	account := store.Account{
+		ID:            acc.ID,
+		SiteID:        acc.SiteID,
+		AccessToken:   acc.AccessToken,
+		APIToken:      acc.APIToken,
+		OAuthProvider: acc.OAuthProvider,
+		ExtraConfig:   acc.ExtraConfig,
+		Status:        acc.Status,
+	}
+	siteModel := store.Site{
+		ID:             site.ID,
+		Name:           site.Name,
+		URL:            site.URL,
+		Platform:       site.Platform,
+		ProxyURL:       site.ProxyURL,
+		UseSystemProxy: site.UseSystemProxy,
+		CustomHeaders:  site.CustomHeaders,
+		Status:         site.Status,
+	}
+
+	return &channelTestTarget{
+		ChannelID:   ch.ID,
+		RouteID:     ch.RouteID,
+		AccountID:   acc.ID,
+		SiteID:      site.ID,
+		SourceModel: sourceModel,
+		SiteName:    site.Name,
+		SiteURL:     site.URL,
+		Platform:    site.Platform,
+		TokenValue:  resolveHarnessToken(ch.TokenID, token, acc),
+		Account:     account,
+		Site:        siteModel,
+	}, nil
+}
+
+// resolveHarnessToken mirrors routing.ChannelSelector.resolveChannelTokenValue
+// without importing selector internals. Harness additionally falls back to
+// access_token for session-style accounts so operators can still probe.
+func resolveHarnessToken(tokenID *int64, token *harnessTokenRow, acc harnessAccountRow) string {
+	if tokenID != nil && *tokenID > 0 {
+		if token == nil || token.Token == "" || !token.Enabled {
+			return ""
+		}
+		return token.Token
+	}
+	if acc.OAuthProvider != nil && strings.TrimSpace(*acc.OAuthProvider) != "" {
+		return strings.TrimSpace(acc.AccessToken)
+	}
+	if acc.APIToken != nil && strings.TrimSpace(*acc.APIToken) != "" {
+		return strings.TrimSpace(*acc.APIToken)
+	}
+	return strings.TrimSpace(acc.AccessToken)
+}
+
+func (h *channelTestHandler) executeProbe(
+	ctx context.Context,
+	target *channelTestTarget,
+	mode, model, prompt string,
+	timeoutMs int64,
+) map[string]any {
+	upstreamPath := "/v1/models"
+	method := http.MethodGet
+	var bodyBytes []byte
+	if mode == channelTestModeChat {
+		upstreamPath = "/v1/chat/completions"
+		method = http.MethodPost
+		payload := map[string]any{
+			"model": model,
+			"messages": []map[string]string{
+				{"role": "user", "content": prompt},
+			},
+			"max_tokens": 8,
+			"stream":     false,
+		}
+		bodyBytes, _ = json.Marshal(payload)
+	}
+
+	upstreamURL := proxy.BuildUpstreamURL(target.SiteURL, upstreamPath)
+	host := safeHost(upstreamURL)
+
+	timeout := time.Duration(timeoutMs) * time.Millisecond
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var bodyReader io.Reader
+	if len(bodyBytes) > 0 {
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+	req, err := http.NewRequestWithContext(reqCtx, method, upstreamURL, bodyReader)
+	if err != nil {
+		return harnessFail(target, mode, model, upstreamPath, host, 0, 0, "", "build request: "+safeError(err))
+	}
+	if len(bodyBytes) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+target.TokenValue)
+	req.Header.Set("User-Agent", "metapi-go-admin-channel-test/1.0")
+
+	proxyCfg := service.BuildPlatformProxyConfig(h.cfg, &target.Account, &target.Site)
+	if proxyCfg != nil {
+		for k, v := range proxyCfg.CustomHeaders {
+			if proxy.IsMetapiControlHeader(k) {
+				continue
+			}
+			// Never let site headers clobber the harness Authorization.
+			if strings.EqualFold(k, "Authorization") {
+				continue
+			}
+			req.Header.Set(k, v)
+		}
+	}
+
+	started := time.Now()
+	resp, err := h.doRequest(reqCtx, req, proxyCfg)
+	latencyMs := time.Since(started).Milliseconds()
+	if err != nil {
+		return harnessFail(target, mode, model, upstreamPath, host, 0, latencyMs, "", safeError(err))
+	}
+	defer resp.Body.Close()
+
+	// Bound body read tightly for operator summary.
+	limited := io.LimitReader(resp.Body, channelTestMaxBodyBytes+1)
+	raw, readErr := io.ReadAll(limited)
+	if readErr != nil {
+		return harnessFail(target, mode, model, upstreamPath, host, resp.StatusCode, latencyMs, "", "read body: "+safeError(readErr))
+	}
+	truncated, wasTruncated := truncateAndRedact(raw, channelTestMaxBodyBytes)
+
+	success := resp.StatusCode >= 200 && resp.StatusCode < 300
+	out := map[string]any{
+		"success":       success,
+		"statusCode":    resp.StatusCode,
+		"latencyMs":     latencyMs,
+		"truncatedBody": truncated,
+		"error":         nil,
+		"channelId":     target.ChannelID,
+		"routeId":       target.RouteID,
+		"siteId":        target.SiteID,
+		"siteName":      target.SiteName,
+		"accountId":     target.AccountID,
+		"model":         model,
+		"mode":          mode,
+		"upstreamPath":  upstreamPath,
+		"upstreamHost":  host,
+		"bodyTruncated": wasTruncated,
+	}
+	if !success {
+		out["error"] = fmt.Sprintf("upstream status %d", resp.StatusCode)
+	}
+	return out
+}
+
+func harnessFail(target *channelTestTarget, mode, model, path, host string, status int, latencyMs int64, body, errMsg string) map[string]any {
+	return map[string]any{
+		"success":       false,
+		"statusCode":    status,
+		"latencyMs":     latencyMs,
+		"truncatedBody": body,
+		"error":         errMsg,
+		"channelId":     target.ChannelID,
+		"routeId":       target.RouteID,
+		"siteId":        target.SiteID,
+		"siteName":      target.SiteName,
+		"accountId":     target.AccountID,
+		"model":         model,
+		"mode":          mode,
+		"upstreamPath":  path,
+		"upstreamHost":  host,
+		"bodyTruncated": false,
+	}
+}
+
+func (h *channelTestHandler) doRequest(ctx context.Context, req *http.Request, proxyCfg *platform.ProxyConfig) (*http.Response, error) {
+	if h.transport != nil {
+		return h.transport.RoundTrip(req.WithContext(ctx))
+	}
+	if proxyCfg != nil && (proxyCfg.ProxyURL != "" || proxyCfg.InsecureSkipTLS) {
+		return platform.DoWithProxy(ctx, req, proxyCfg)
+	}
+	client := &http.Client{Timeout: 0} // context owns deadline
+	return client.Do(req.WithContext(ctx))
+}
+
+func safeHost(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return u.Host
+}
+
+func truncateAndRedact(raw []byte, maxBytes int) (string, bool) {
+	truncated := false
+	if len(raw) > maxBytes {
+		raw = raw[:maxBytes]
+		truncated = true
+	}
+	// Ensure valid UTF-8 after hard cut.
+	for !utf8.Valid(raw) && len(raw) > 0 {
+		raw = raw[:len(raw)-1]
+		truncated = true
+	}
+	s := string(raw)
+	s = secretLikeRE.ReplaceAllString(s, "[redacted]")
+	s = strings.ReplaceAll(s, "\r", "")
+	if truncated {
+		s += "…[truncated]"
+	}
+	return s, truncated
+}
+
+func safeError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	msg = secretLikeRE.ReplaceAllString(msg, "[redacted]")
+	if strings.Contains(msg, "context deadline exceeded") {
+		return "timeout waiting for upstream"
+	}
+	if strings.Contains(msg, "context canceled") {
+		return "request canceled"
+	}
+	if utf8.RuneCountInString(msg) > 400 {
+		runes := []rune(msg)
+		msg = string(runes[:400]) + "…"
+	}
+	return msg
+}

--- a/handler/admin/channel_test_harness_test.go
+++ b/handler/admin/channel_test_harness_test.go
@@ -1,0 +1,366 @@
+package admin
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func setupChannelTestHarness(t *testing.T) (*store.DB, *channelTestHandler, chi.Router) {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	cfg := &config.Config{}
+	h := &channelTestHandler{db: db.DB, cfg: cfg}
+	r := chi.NewRouter()
+	// Register using the same handler instance so tests can inject transport.
+	r.Post("/api/admin/test-channel", h.testChannel)
+	r.Post("/api/debug/channel-probe", h.testChannel)
+	return db, h, r
+}
+
+func insertHarnessFixtures(t *testing.T, db *store.DB) (siteID, accountID, routeID, channelID int64) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	res, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "HarnessSite", "https://upstream.example.test", "openai", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ = res.LastInsertId()
+
+	apiTok := "sk-harness-api-token-xyz"
+	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, ?, 'active', 0, ?, ?)`, siteID, "harness-user", "session-token", apiTok, now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ = res.LastInsertId()
+
+	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
+		VALUES (?, ?, 'standard', 'weighted', 1, ?, ?)`, "gpt-*", "Harness Route", now, now)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	routeID, _ = res.LastInsertId()
+
+	res, err = db.Exec(`INSERT INTO route_channels (route_id, account_id, source_model, priority, weight, enabled)
+		VALUES (?, ?, ?, 10, 10, 1)`, routeID, accountID, "gpt-4o-mini")
+	if err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+	channelID, _ = res.LastInsertId()
+	return siteID, accountID, routeID, channelID
+}
+
+func TestChannelTest_Validation(t *testing.T) {
+	_, _, r := setupChannelTestHarness(t)
+
+	// Missing both ids
+	resp := doPostJSON(t, r, "/api/admin/test-channel", map[string]any{"model": "gpt-4o"})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	// Invalid mode
+	resp = doPostJSON(t, r, "/api/admin/test-channel", map[string]any{
+		"channelId": 1,
+		"mode":      "stream",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("mode expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	// Invalid JSON
+	req := httptest.NewRequest("POST", "/api/admin/test-channel", strings.NewReader(`{`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid json expected 400, got %d", rec.Code)
+	}
+}
+
+func TestChannelTest_ChannelNotFound(t *testing.T) {
+	_, _, r := setupChannelTestHarness(t)
+	resp := doPostJSON(t, r, "/api/admin/test-channel", map[string]any{
+		"channelId": 99999,
+		"model":     "gpt-4o-mini",
+	})
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestChannelTest_ForcedChannelChatSuccess(t *testing.T) {
+	db, h, r := setupChannelTestHarness(t)
+	siteID, accountID, routeID, channelID := insertHarnessFixtures(t, db)
+
+	var seenAuth string
+	var seenPath string
+	var seenBody string
+	var hits atomic.Int32
+	h.transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		hits.Add(1)
+		seenAuth = req.Header.Get("Authorization")
+		seenPath = req.URL.Path
+		if req.Body != nil {
+			b, _ := io.ReadAll(req.Body)
+			seenBody = string(b)
+		}
+		body := `{"id":"chatcmpl-test","choices":[{"message":{"role":"assistant","content":"pong"}}]}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+
+	resp := doPostJSON(t, r, "/api/admin/test-channel", map[string]any{
+		"channelId": channelID,
+		"model":     "gpt-4o-mini",
+		"prompt":    "hello harness",
+		"mode":      "chat",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", resp.Code, resp.Body.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out["success"] != true {
+		t.Fatalf("success=%v error=%v body=%v", out["success"], out["error"], out["truncatedBody"])
+	}
+	if int(out["statusCode"].(float64)) != 200 {
+		t.Fatalf("statusCode=%v", out["statusCode"])
+	}
+	if out["channelId"].(float64) != float64(channelID) {
+		t.Fatalf("channelId=%v want %d", out["channelId"], channelID)
+	}
+	if out["siteId"].(float64) != float64(siteID) {
+		t.Fatalf("siteId=%v want %d", out["siteId"], siteID)
+	}
+	if out["accountId"].(float64) != float64(accountID) {
+		t.Fatalf("accountId=%v", out["accountId"])
+	}
+	if out["routeId"].(float64) != float64(routeID) {
+		t.Fatalf("routeId=%v", out["routeId"])
+	}
+	if out["upstreamPath"] != "/v1/chat/completions" {
+		t.Fatalf("upstreamPath=%v", out["upstreamPath"])
+	}
+	if !strings.Contains(out["truncatedBody"].(string), "pong") {
+		t.Fatalf("truncatedBody=%v", out["truncatedBody"])
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("hits=%d", hits.Load())
+	}
+	if seenAuth != "Bearer sk-harness-api-token-xyz" {
+		t.Fatalf("auth=%q", seenAuth)
+	}
+	if !strings.Contains(seenPath, "/chat/completions") {
+		t.Fatalf("path=%q", seenPath)
+	}
+	if !strings.Contains(seenBody, "hello harness") {
+		t.Fatalf("request body missing prompt: %s", seenBody)
+	}
+}
+
+func TestChannelTest_DebugAliasAndModelsMode(t *testing.T) {
+	db, h, r := setupChannelTestHarness(t)
+	_, _, _, channelID := insertHarnessFixtures(t, db)
+
+	h.transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("models mode method=%s", req.Method)
+		}
+		if !strings.HasSuffix(req.URL.Path, "/models") {
+			t.Fatalf("path=%s", req.URL.Path)
+		}
+		body := `{"data":[{"id":"gpt-4o-mini"}]}`
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+
+	resp := doPostJSON(t, r, "/api/debug/channel-probe", map[string]any{
+		"channelId": channelID,
+		"mode":      "models",
+	})
+	if resp.Code != 200 {
+		t.Fatalf("status %d: %s", resp.Code, resp.Body.String())
+	}
+	var out map[string]any
+	_ = json.Unmarshal(resp.Body.Bytes(), &out)
+	if out["success"] != true {
+		t.Fatalf("out=%v", out)
+	}
+	if out["mode"] != "models" {
+		t.Fatalf("mode=%v", out["mode"])
+	}
+	if out["upstreamPath"] != "/v1/models" {
+		t.Fatalf("path=%v", out["upstreamPath"])
+	}
+}
+
+func TestChannelTest_SiteIDResolution(t *testing.T) {
+	db, h, r := setupChannelTestHarness(t)
+	siteID, _, _, channelID := insertHarnessFixtures(t, db)
+
+	var forcedChannelPath string
+	h.transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		forcedChannelPath = req.URL.String()
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	resp := doPostJSON(t, r, "/api/admin/test-channel", map[string]any{
+		"siteId": siteID,
+		"model":  "gpt-4o-mini",
+		"mode":   "chat",
+	})
+	if resp.Code != 200 {
+		t.Fatalf("status %d: %s", resp.Code, resp.Body.String())
+	}
+	var out map[string]any
+	_ = json.Unmarshal(resp.Body.Bytes(), &out)
+	if out["channelId"].(float64) != float64(channelID) {
+		t.Fatalf("resolved channelId=%v want %d", out["channelId"], channelID)
+	}
+	if !strings.Contains(forcedChannelPath, "upstream.example.test") {
+		t.Fatalf("url=%s", forcedChannelPath)
+	}
+}
+
+func TestChannelTest_UpstreamErrorAndRedaction(t *testing.T) {
+	db, h, r := setupChannelTestHarness(t)
+	_, _, _, channelID := insertHarnessFixtures(t, db)
+
+	// Oversized body with secret-like token near the start (still truncated later).
+	big := "error unauthorized sk-abcdefghijklmnopqrstuvwxyz012345 " + strings.Repeat("A", 3000)
+	h.transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 401,
+			Body:       io.NopCloser(strings.NewReader(big)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	resp := doPostJSON(t, r, "/api/admin/test-channel", map[string]any{
+		"channelId": channelID,
+		"model":     "gpt-4o-mini",
+	})
+	if resp.Code != 200 {
+		t.Fatalf("status %d: %s", resp.Code, resp.Body.String())
+	}
+	var out map[string]any
+	_ = json.Unmarshal(resp.Body.Bytes(), &out)
+	if out["success"] != false {
+		t.Fatalf("expected success=false, got %v", out)
+	}
+	if int(out["statusCode"].(float64)) != 401 {
+		t.Fatalf("statusCode=%v", out["statusCode"])
+	}
+	body := out["truncatedBody"].(string)
+	if strings.Contains(body, "sk-abcdefghijklmnopqrstuvwxyz012345") {
+		t.Fatalf("secret leaked in truncatedBody: %s", body)
+	}
+	if !strings.Contains(body, "[redacted]") {
+		t.Fatalf("expected redaction marker: %s", body)
+	}
+	if out["bodyTruncated"] != true {
+		t.Fatalf("expected bodyTruncated=true")
+	}
+	if len(body) > channelTestMaxBodyBytes+40 { // room for suffix/redaction
+		t.Fatalf("body too large: %d", len(body))
+	}
+}
+
+func TestChannelTest_TransportError(t *testing.T) {
+	db, h, r := setupChannelTestHarness(t)
+	_, _, _, channelID := insertHarnessFixtures(t, db)
+
+	h.transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, contextDeadlineErr{}
+	})
+
+	resp := doPostJSON(t, r, "/api/admin/test-channel", map[string]any{
+		"channelId": channelID,
+		"timeoutMs": 1000,
+	})
+	if resp.Code != 200 {
+		t.Fatalf("status %d: %s", resp.Code, resp.Body.String())
+	}
+	var out map[string]any
+	_ = json.Unmarshal(resp.Body.Bytes(), &out)
+	if out["success"] != false {
+		t.Fatalf("out=%v", out)
+	}
+	if out["error"] == nil || out["error"] == "" {
+		t.Fatalf("expected error summary: %v", out)
+	}
+}
+
+type contextDeadlineErr struct{}
+
+func (contextDeadlineErr) Error() string { return "context deadline exceeded" }
+func (contextDeadlineErr) Timeout() bool { return true }
+
+func TestTruncateAndRedact(t *testing.T) {
+	s, trunc := truncateAndRedact([]byte(`ok Bearer sk-abc123456789 and more`), 100)
+	if trunc {
+		t.Fatalf("should not truncate short body")
+	}
+	if strings.Contains(s, "sk-abc") || strings.Contains(s, "Bearer sk-") {
+		t.Fatalf("not redacted: %s", s)
+	}
+	if !strings.Contains(s, "[redacted]") {
+		t.Fatalf("missing marker: %s", s)
+	}
+
+	big := bytes.Repeat([]byte("x"), 5000)
+	s2, trunc2 := truncateAndRedact(big, channelTestMaxBodyBytes)
+	if !trunc2 {
+		t.Fatalf("expected truncate")
+	}
+	if !strings.Contains(s2, "[truncated]") {
+		t.Fatalf("missing truncated marker: %s", s2)
+	}
+	if len(s2) > channelTestMaxBodyBytes+20 {
+		t.Fatalf("len=%d", len(s2))
+	}
+}

--- a/router/router.go
+++ b/router/router.go
@@ -76,6 +76,7 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 			admin.RegisterAuthSettingsRoutes(r, db.DB, cfg)
 			admin.RegisterCheckinRoutes(r, db.DB, cfg)
 			admin.RegisterTokenRoutes(r, db.DB)
+			admin.RegisterChannelTestRoutes(r, db.DB, cfg)
 			admin.RegisterUpdateCenterRoutes(r)
 			admin.RegisterOauthRoutes(r, db.DB)
 		} else {


### PR DESCRIPTION
## Summary
- Admin-only forced channel/site probe: `POST /api/admin/test-channel` (+ alias `POST /api/debug/channel-probe`)
- Loads channel→account→site, forces one upstream chat/models request (no weighted selection)
- Returns `success`, `statusCode`, `latencyMs`, ~2KiB redacted `truncatedBody`, safe `error`
- Docs: `docs/analysis/admin-channel-test-harness.md`; API index + MASTER progress updated

Closes #119

## Test plan
- [x] `go test ./handler/admin/ -run 'ChannelTest|TruncateAndRedact'`
- [x] `go test ./router/`
- [x] Local pre-push CI retry after unrelated routing flake (`TestFallbackCostPenalty`)
- [ ] Manual: call with admin token against a real channel and confirm latency/status summary