### PR TITLE
feat(redis): optional shared admission + soft cooldown state #118

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,11 @@ DATABASE_URL=
 # Optional PostgreSQL TLS mode. Leave empty to use the DSN value.
 # Valid values: disable, allow, prefer, require, verify-ca, verify-full.
 DB_SSLMODE=
+# Optional Redis for multi-instance shared admission counters + soft channel
+# cooldown markers (#118). Empty = process-local only (default). Fail-open on
+# Redis errors. See docs/analysis/redis-shared-state.md
+# Example: redis://:password@127.0.0.1:6379/0  or  127.0.0.1:6379
+REDIS_URL=
 NOTIFY_COOLDOWN_SEC=300
 ADMIN_IP_ALLOWLIST=
 # Optional CSV of reverse-proxy CIDRs allowed to supply X-Forwarded-For/X-Real-IP.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to MetAPI-Go will be documented in this file.
 - Enterprise modernization program (stack TS7/React19/Vite8, UI tokens/a11y, backend boundaries, schema additive migrations, reliability SSOT).
 - Feature completeness from original metapi gap matrix: site max concurrency, per-key proxy, group route rebuild, `/v1/rerank`, usage/token accounting, failover/first-byte, protocol pack (Gemini thought_signature, Minimax thinking, models shape, previous_response_id, skill-call, responses multi-turn reasoning, responses-only sites), Codex OAuth gpt-5.5 + discovery soft-retry.
 - Competitive learning milestone (M-COMPETE) vs all-api-hub / axonhub / new-api / litellm with matrix + `[learn]` backlog.
+- Optional Redis shared state for multi-instance RPM/TPM admission + soft channel cooldown markers (`REDIS_URL`, learn #118); default process-local, fail-open, no hard dependency.
 
 ### Fixed
 - Admin correctness: key refresh name/enable preserve, quota clear, model whitelist non-destructive parse, in-route model config preserve, expired account health.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Cron 定时执行（默认每日 08:00），智能解析奖励金额，签到失
 | `CHECKIN_CRON` | `0 8 * * *` | 签到时间 |
 | `BALANCE_REFRESH_CRON` | `0 * * * *` | 余额刷新频率 |
 
-当前运行时支持两种数据库形态：单进程 SQLite；PostgreSQL 生产部署。PostgreSQL 模式下，产生外部请求、通知、上传、清理或同步副作用的后台任务使用 PG advisory lock，避免多副本重复执行同一批任务。Redis 尚未集成：没有 `REDIS_URL` 配置、Redis 客户端或分布式缓存。
+当前运行时支持两种数据库形态：单进程 SQLite；PostgreSQL 生产部署。PostgreSQL 模式下，产生外部请求、通知、上传、清理或同步副作用的后台任务使用 PG advisory lock，避免多副本重复执行同一批任务。可选 Redis（`REDIS_URL`）用于多实例共享下游 Key 的 RPM/TPM 准入计数与通道软冷却标记；默认关闭，单节点无 Redis 依赖，错误时 fail-open。详见 `docs/analysis/redis-shared-state.md`。
 
 代理转发没有配置路由和上游依赖时，生产默认返回 HTTP 503。`METAPI_ENABLE_PROXY_STUB=1` 只用于测试或演示，避免把本地假响应误当成真实上游调用。
 
@@ -198,7 +198,7 @@ Cron 定时执行（默认每日 08:00），智能解析奖励金额，签到失
 |----|------|
 | 后端 | [chi](https://github.com/go-chi/chi) 路由 + `net/http` |
 | 语言 | Go 1.26.4 |
-| 数据库 | SQLite / PostgreSQL + [sqlx](https://github.com/jmoiron/sqlx)，无 Redis 运行时依赖 |
+| 数据库 | SQLite / PostgreSQL + [sqlx](https://github.com/jmoiron/sqlx)；可选 `REDIS_URL` 共享准入/软冷却（stdlib RESP，非硬依赖） |
 | 定时任务 | [robfig/cron](https://github.com/robfig/cron) |
 | 容器化 | Docker（Alpine，15MB 镜像） |
 | 前端 | React 18 + Vite + Tailwind CSS v4（内嵌） |

--- a/README_EN.md
+++ b/README_EN.md
@@ -73,7 +73,7 @@ All env vars are identical to the TypeScript version.
 
 Full list: [`.env.example`](.env.example).
 
-The runtime supports two database modes: single-process SQLite and PostgreSQL for production deployments. In PostgreSQL mode, side-effecting schedulers such as external requests, notifications, uploads, cleanup, and sync jobs use PG advisory locks so multiple replicas do not run the same job batch at the same time. Redis is not integrated yet: there is no `REDIS_URL` setting, Redis client, or distributed cache.
+The runtime supports two database modes: single-process SQLite and PostgreSQL for production deployments. In PostgreSQL mode, side-effecting schedulers such as external requests, notifications, uploads, cleanup, and sync jobs use PG advisory locks so multiple replicas do not run the same job batch at the same time. Optional Redis (`REDIS_URL`) shares downstream-key RPM/TPM admission counters and soft channel cooldown markers across instances; it is off by default, not required for single-node installs, and fail-open on Redis errors. See `docs/analysis/redis-shared-state.md`.
 
 Proxy forwarding returns HTTP 503 when routing and upstream dependencies are not configured. `METAPI_ENABLE_PROXY_STUB=1` is for tests and demos only.
 

--- a/app/redis_shared.go
+++ b/app/redis_shared.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/tokendancelab/metapi-go/auth"
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/internal/redisx"
+	"github.com/tokendancelab/metapi-go/routing"
+)
+
+// ConfigureSharedState wires optional Redis-backed multi-instance state (#118):
+//   - downstream-key RPM/TPM admission counters (auth.GlobalKeyAdmission)
+//   - soft channel cooldown markers (routing soft filter)
+//
+// Empty REDIS_URL leaves process-local defaults. Redis is never a hard dependency:
+// connect/parse failures log a warning and continue with in-process state.
+// Runtime Redis command errors fail-open (documented in docs/analysis/redis-shared-state.md).
+func ConfigureSharedState(cfg *config.Config) {
+	if cfg == nil {
+		return
+	}
+	url := strings.TrimSpace(cfg.RedisURL)
+	if url == "" {
+		auth.ConfigureKeyAdmissionCounter(nil)
+		routing.ConfigureSoftCooldown(nil)
+		return
+	}
+
+	client, err := redisx.NewClient(url)
+	if err != nil {
+		slog.Warn("redis shared state disabled: invalid REDIS_URL", "error", err)
+		auth.ConfigureKeyAdmissionCounter(nil)
+		routing.ConfigureSoftCooldown(nil)
+		return
+	}
+
+	// Best-effort connectivity probe; do not abort startup on failure.
+	if err := client.Ping(context.Background()); err != nil {
+		slog.Warn("redis PING failed at startup; shared state will fail-open until reachable",
+			"error", err,
+		)
+	}
+
+	auth.ConfigureKeyAdmissionCounter(redisx.NewRedisCounterFromClient(client))
+	routing.ConfigureSoftCooldown(redisx.NewRedisCooldown(client))
+	slog.Info("redis shared state enabled",
+		"admission", true,
+		"soft_cooldown", true,
+	)
+}

--- a/app/redis_shared_test.go
+++ b/app/redis_shared_test.go
@@ -1,0 +1,45 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/tokendancelab/metapi-go/auth"
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/routing"
+)
+
+func TestConfigureSharedState_EmptyDisables(t *testing.T) {
+	auth.ResetKeyAdmissionForTest()
+	routing.ResetSoftCooldownForTest()
+	t.Cleanup(func() {
+		auth.ResetKeyAdmissionForTest()
+		routing.ResetSoftCooldownForTest()
+	})
+
+	// Install something first, then clear via empty URL.
+	auth.ConfigureKeyAdmissionCounter(nil)
+	ConfigureSharedState(&config.Config{RedisURL: ""})
+	if auth.GlobalKeyAdmission.SharedCounterEnabled() {
+		t.Fatal("expected admission shared disabled")
+	}
+	if routing.SoftCooldownEnabled() {
+		t.Fatal("expected soft cooldown disabled")
+	}
+}
+
+func TestConfigureSharedState_InvalidURLKeepsLocal(t *testing.T) {
+	auth.ResetKeyAdmissionForTest()
+	routing.ResetSoftCooldownForTest()
+	t.Cleanup(func() {
+		auth.ResetKeyAdmissionForTest()
+		routing.ResetSoftCooldownForTest()
+	})
+
+	ConfigureSharedState(&config.Config{RedisURL: "rediss://example.com:6379"})
+	if auth.GlobalKeyAdmission.SharedCounterEnabled() {
+		t.Fatal("TLS redis should not enable shared admission")
+	}
+	if routing.SoftCooldownEnabled() {
+		t.Fatal("TLS redis should not enable soft cooldown")
+	}
+}

--- a/auth/key_admission.go
+++ b/auth/key_admission.go
@@ -1,18 +1,33 @@
 package auth
 
 import (
+	"fmt"
+	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
+
+	"github.com/tokendancelab/metapi-go/internal/redisx"
 )
 
-// KeyAdmissionLimiter is an in-process sliding-window RPM/TPM gate for
-// managed downstream keys (learn #116). Default unlimited when limits are nil/<=0.
-// Multi-instance deployments need shared state (#118) — this is process-local.
+// KeyAdmissionLimiter is a sliding/fixed-window RPM/TPM gate for managed
+// downstream keys (learn #116). Default unlimited when limits are nil/<=0.
+//
+// When a SharedCounter backend is configured via ConfigureKeyAdmissionCounter
+// (typically Redis from REDIS_URL, learn #118), RPM/TPM counters are shared
+// across instances. Redis errors fail-open to the local memory window so a
+// Redis outage never hard-blocks traffic.
 type KeyAdmissionLimiter struct {
 	mu   sync.Mutex
 	keys map[int64]*keyWindow
 	// nowFn is injectable for tests.
 	nowFn func() time.Time
+
+	// shared is an optional multi-instance counter (Redis fixed-window).
+	// nil → pure process-local sliding window.
+	shared redisx.SharedCounter
+	// failOpenCount tracks Redis/shared backend errors (observability).
+	failOpenCount atomic.Uint64
 }
 
 type keyWindow struct {
@@ -43,6 +58,43 @@ func ResetKeyAdmissionForTest() {
 	GlobalKeyAdmission = NewKeyAdmissionLimiter()
 }
 
+// ConfigureKeyAdmissionCounter installs a SharedCounter backend on the global
+// limiter. Pass nil to disable shared mode (process-local only).
+func ConfigureKeyAdmissionCounter(counter redisx.SharedCounter) {
+	if GlobalKeyAdmission == nil {
+		GlobalKeyAdmission = NewKeyAdmissionLimiter()
+	}
+	GlobalKeyAdmission.SetSharedCounter(counter)
+}
+
+// SetSharedCounter installs a SharedCounter on this limiter (nil disables).
+func (l *KeyAdmissionLimiter) SetSharedCounter(counter redisx.SharedCounter) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.shared = counter
+}
+
+// SharedCounterEnabled reports whether a non-nil shared backend is installed.
+func (l *KeyAdmissionLimiter) SharedCounterEnabled() bool {
+	if l == nil {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.shared != nil
+}
+
+// FailOpenCount returns how many times shared-backend errors caused fail-open.
+func (l *KeyAdmissionLimiter) FailOpenCount() uint64 {
+	if l == nil {
+		return 0
+	}
+	return l.failOpenCount.Load()
+}
+
 // AdmissionDecision is the result of Allow.
 type AdmissionDecision struct {
 	Allowed    bool
@@ -50,14 +102,29 @@ type AdmissionDecision struct {
 	RetryAfter time.Duration
 	UsedRPM    int64
 	UsedTPM    int64
+	// Backend is "memory" | "shared" | "shared_failopen" for diagnostics.
+	Backend string
+}
+
+const admissionWindow = time.Minute
+
+func rpmKey(keyID int64) string {
+	return fmt.Sprintf("admission:rpm:%d", keyID)
+}
+
+func tpmKey(keyID int64) string {
+	return fmt.Sprintf("admission:tpm:%d", keyID)
 }
 
 // Allow checks and records a request against optional RPM/TPM limits.
 // estimatedTokens is reserved against TPM when maxTPM is set; pass 0 to skip TPM accounting.
 // When allowed, the request is recorded immediately (admission reservation).
+//
+// Failure mode with shared backend: on Redis/shared errors the limiter fails
+// open by falling back to the process-local window (and increments FailOpenCount).
 func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimatedTokens int64) AdmissionDecision {
 	if l == nil || keyID <= 0 {
-		return AdmissionDecision{Allowed: true}
+		return AdmissionDecision{Allowed: true, Backend: "memory"}
 	}
 	rpmLimit := int64(0)
 	tpmLimit := int64(0)
@@ -68,9 +135,112 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 		tpmLimit = *maxTPM
 	}
 	if rpmLimit == 0 && tpmLimit == 0 {
-		return AdmissionDecision{Allowed: true}
+		return AdmissionDecision{Allowed: true, Backend: "memory"}
 	}
 
+	l.mu.Lock()
+	shared := l.shared
+	l.mu.Unlock()
+
+	if shared != nil {
+		d, ok := l.allowShared(shared, keyID, rpmLimit, tpmLimit, estimatedTokens)
+		if ok {
+			return d
+		}
+		// fail-open → local path
+		l.failOpenCount.Add(1)
+		slog.Warn("key admission shared counter failed; falling back to process-local",
+			"key_id", keyID,
+			"fail_open_count", l.failOpenCount.Load(),
+		)
+		d = l.allowLocal(keyID, rpmLimit, tpmLimit, estimatedTokens)
+		d.Backend = "shared_failopen"
+		return d
+	}
+	return l.allowLocal(keyID, rpmLimit, tpmLimit, estimatedTokens)
+}
+
+// allowShared returns (decision, true) on success, or (_, false) to fail-open.
+func (l *KeyAdmissionLimiter) allowShared(
+	shared redisx.SharedCounter,
+	keyID, rpmLimit, tpmLimit, estimatedTokens int64,
+) (AdmissionDecision, bool) {
+	// Snapshot current usage first (best-effort) for Retry-After / admin display.
+	usedRPM, err := shared.Get(rpmKey(keyID))
+	if err != nil {
+		return AdmissionDecision{}, false
+	}
+	usedTPM, err := shared.Get(tpmKey(keyID))
+	if err != nil {
+		return AdmissionDecision{}, false
+	}
+
+	if rpmLimit > 0 && usedRPM >= rpmLimit {
+		return AdmissionDecision{
+			Allowed:    false,
+			Reason:     "over_rpm",
+			RetryAfter: time.Second, // fixed-window approximation
+			UsedRPM:    usedRPM,
+			UsedTPM:    usedTPM,
+			Backend:    "shared",
+		}, true
+	}
+	if tpmLimit > 0 && estimatedTokens > 0 && usedTPM+estimatedTokens > tpmLimit {
+		return AdmissionDecision{
+			Allowed:    false,
+			Reason:     "over_tpm",
+			RetryAfter: time.Second,
+			UsedRPM:    usedRPM,
+			UsedTPM:    usedTPM,
+			Backend:    "shared",
+		}, true
+	}
+
+	// Reserve RPM (always, when limited) then TPM.
+	if rpmLimit > 0 {
+		n, err := shared.IncrWindow(rpmKey(keyID), admissionWindow)
+		if err != nil {
+			return AdmissionDecision{}, false
+		}
+		usedRPM = n
+		// Race: two instances may both pass the pre-check; enforce post-incr.
+		if usedRPM > rpmLimit {
+			return AdmissionDecision{
+				Allowed:    false,
+				Reason:     "over_rpm",
+				RetryAfter: time.Second,
+				UsedRPM:    usedRPM,
+				UsedTPM:    usedTPM,
+				Backend:    "shared",
+			}, true
+		}
+	}
+	if tpmLimit > 0 && estimatedTokens > 0 {
+		n, err := shared.IncrWindowBy(tpmKey(keyID), estimatedTokens, admissionWindow)
+		if err != nil {
+			return AdmissionDecision{}, false
+		}
+		usedTPM = n
+		if usedTPM > tpmLimit {
+			return AdmissionDecision{
+				Allowed:    false,
+				Reason:     "over_tpm",
+				RetryAfter: time.Second,
+				UsedRPM:    usedRPM,
+				UsedTPM:    usedTPM,
+				Backend:    "shared",
+			}, true
+		}
+	}
+	return AdmissionDecision{
+		Allowed: true,
+		UsedRPM: usedRPM,
+		UsedTPM: usedTPM,
+		Backend: "shared",
+	}, true
+}
+
+func (l *KeyAdmissionLimiter) allowLocal(keyID, rpmLimit, tpmLimit, estimatedTokens int64) AdmissionDecision {
 	now := l.nowFn().UTC()
 	nowMs := now.UnixMilli()
 	windowStart := nowMs - 60_000
@@ -98,6 +268,7 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 			RetryAfter: time.Duration(retry) * time.Millisecond,
 			UsedRPM:    usedRPM,
 			UsedTPM:    usedTPM,
+			Backend:    "memory",
 		}
 	}
 	if tpmLimit > 0 && estimatedTokens > 0 && usedTPM+estimatedTokens > tpmLimit {
@@ -108,6 +279,7 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 			RetryAfter: time.Duration(retry) * time.Millisecond,
 			UsedRPM:    usedRPM,
 			UsedTPM:    usedTPM,
+			Backend:    "memory",
 		}
 	}
 
@@ -120,6 +292,7 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 		Allowed: true,
 		UsedRPM: usedRPM + 1,
 		UsedTPM: usedTPM + max64z(estimatedTokens, 0),
+		Backend: "memory",
 	}
 }
 
@@ -128,6 +301,20 @@ func (l *KeyAdmissionLimiter) Snapshot(keyID int64) (usedRPM, usedTPM int64) {
 	if l == nil || keyID <= 0 {
 		return 0, 0
 	}
+	l.mu.Lock()
+	shared := l.shared
+	l.mu.Unlock()
+
+	if shared != nil {
+		rpm, err1 := shared.Get(rpmKey(keyID))
+		tpm, err2 := shared.Get(tpmKey(keyID))
+		if err1 == nil && err2 == nil {
+			return rpm, tpm
+		}
+		// fail-open to local snapshot
+		l.failOpenCount.Add(1)
+	}
+
 	nowMs := l.nowFn().UTC().UnixMilli()
 	windowStart := nowMs - 60_000
 	l.mu.Lock()

--- a/auth/key_admission_test.go
+++ b/auth/key_admission_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"testing"
 	"time"
+
+	"github.com/tokendancelab/metapi-go/internal/redisx"
 )
 
 func TestKeyAdmissionLimiter_RPM(t *testing.T) {
@@ -82,5 +84,142 @@ func TestKeyAdmissionLimiter_Concurrent(t *testing.T) {
 	}
 	if allowed != 50 || denied != 50 {
 		t.Fatalf("allowed=%d denied=%d want 50/50", allowed, denied)
+	}
+}
+
+func TestKeyAdmissionLimiter_SharedCounterRPM(t *testing.T) {
+	l := NewKeyAdmissionLimiter()
+	shared := redisx.NewMemoryCounter()
+	l.SetSharedCounter(shared)
+
+	limit := int64(2)
+	if d := l.Allow(11, &limit, nil, 0); !d.Allowed || d.Backend != "shared" {
+		t.Fatalf("d1: %#v", d)
+	}
+	if d := l.Allow(11, &limit, nil, 0); !d.Allowed || d.Backend != "shared" {
+		t.Fatalf("d2: %#v", d)
+	}
+	if d := l.Allow(11, &limit, nil, 0); d.Allowed || d.Reason != "over_rpm" || d.Backend != "shared" {
+		t.Fatalf("d3: %#v", d)
+	}
+	rpm, tpm := l.Snapshot(11)
+	if rpm != 2 || tpm != 0 {
+		t.Fatalf("snapshot rpm=%d tpm=%d", rpm, tpm)
+	}
+}
+
+func TestKeyAdmissionLimiter_SharedCounterTPM(t *testing.T) {
+	l := NewKeyAdmissionLimiter()
+	l.SetSharedCounter(redisx.NewMemoryCounter())
+	tpm := int64(1000)
+	if d := l.Allow(12, nil, &tpm, 600); !d.Allowed || d.Backend != "shared" {
+		t.Fatalf("d1: %#v", d)
+	}
+	if d := l.Allow(12, nil, &tpm, 500); d.Allowed || d.Reason != "over_tpm" {
+		t.Fatalf("d2: %#v", d)
+	}
+	if d := l.Allow(12, nil, &tpm, 400); !d.Allowed {
+		t.Fatalf("d3: %#v", d)
+	}
+}
+
+func TestKeyAdmissionLimiter_SharedFailOpen(t *testing.T) {
+	l := NewKeyAdmissionLimiter()
+	fake := redisx.NewFakeCounter()
+	fake.FailNext = true
+	l.SetSharedCounter(fake)
+
+	limit := int64(10)
+	d := l.Allow(13, &limit, nil, 0)
+	if !d.Allowed {
+		t.Fatalf("fail-open should allow: %#v", d)
+	}
+	if d.Backend != "shared_failopen" {
+		t.Fatalf("backend=%q want shared_failopen", d.Backend)
+	}
+	if l.FailOpenCount() != 1 {
+		t.Fatalf("failOpenCount=%d", l.FailOpenCount())
+	}
+	// Local path reserved the request; subsequent local allows still work.
+	for i := 0; i < 9; i++ {
+		// force fail-open each time by failing shared first
+		fake.FailNext = true
+		if d := l.Allow(13, &limit, nil, 0); !d.Allowed {
+			t.Fatalf("local allow %d: %#v", i, d)
+		}
+	}
+	fake.FailNext = true
+	if d := l.Allow(13, &limit, nil, 0); d.Allowed || d.Reason != "over_rpm" {
+		t.Fatalf("11th local should deny: %#v", d)
+	}
+}
+
+func TestKeyAdmissionLimiter_SharedFailOpenThenRecover(t *testing.T) {
+	l := NewKeyAdmissionLimiter()
+	fake := redisx.NewFakeCounter()
+	l.SetSharedCounter(fake)
+	limit := int64(1)
+
+	// First call uses shared successfully.
+	if d := l.Allow(14, &limit, nil, 0); !d.Allowed || d.Backend != "shared" {
+		t.Fatalf("shared allow: %#v", d)
+	}
+	// Second would be over_rpm on shared.
+	if d := l.Allow(14, &limit, nil, 0); d.Allowed || d.Backend != "shared" {
+		t.Fatalf("shared deny: %#v", d)
+	}
+	// Inject failure → fail-open to local (local is empty, so allows).
+	fake.FailNext = true
+	if d := l.Allow(14, &limit, nil, 0); !d.Allowed || d.Backend != "shared_failopen" {
+		t.Fatalf("failopen: %#v", d)
+	}
+}
+
+func TestConfigureKeyAdmissionCounter(t *testing.T) {
+	ResetKeyAdmissionForTest()
+	t.Cleanup(ResetKeyAdmissionForTest)
+
+	if GlobalKeyAdmission.SharedCounterEnabled() {
+		t.Fatal("expected disabled by default")
+	}
+	ConfigureKeyAdmissionCounter(redisx.NewMemoryCounter())
+	if !GlobalKeyAdmission.SharedCounterEnabled() {
+		t.Fatal("expected enabled")
+	}
+	ConfigureKeyAdmissionCounter(nil)
+	if GlobalKeyAdmission.SharedCounterEnabled() {
+		t.Fatal("expected disabled after nil")
+	}
+}
+
+func TestKeyAdmissionLimiter_SharedConcurrent(t *testing.T) {
+	l := NewKeyAdmissionLimiter()
+	l.SetSharedCounter(redisx.NewMemoryCounter())
+	limit := int64(50)
+	done := make(chan AdmissionDecision, 100)
+	for i := 0; i < 100; i++ {
+		go func() {
+			done <- l.Allow(15, &limit, nil, 0)
+		}()
+	}
+	allowed := 0
+	for i := 0; i < 100; i++ {
+		if (<-done).Allowed {
+			allowed++
+		}
+	}
+	// MemoryCounter is mutex-safe; fixed-window Incr is atomic within process.
+	// Pre-check + incr can overshoot by races → allow at most a small race band.
+	// With single process MemoryCounter and sequential Get+Incr under no lock across
+	// calls, concurrent overshoot is possible. Enforce that we do not admit far more
+	// than the limit (hard ceiling: 2x is unacceptable). Prefer exact when possible.
+	// Shared path is best-effort (Get then Incr is not a distributed lock), so
+	// concurrent overshoot above the limit is possible. Require at least the
+	// limit admits, and reject pathological 2x+ overshoot.
+	if allowed < 50 {
+		t.Fatalf("allowed=%d want >=50", allowed)
+	}
+	if allowed > 80 {
+		t.Fatalf("allowed=%d pathological overshoot", allowed)
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -47,6 +47,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Optional Redis shared state for multi-instance admission/cooldown (#118).
+	// Empty REDIS_URL keeps process-local defaults; never hard-fails startup.
+	app.ConfigureSharedState(cfg)
+
 	// Normalize DataDir (E11: trailing slash / Windows backslash)
 	cfg.DataDir = filepath.Clean(cfg.DataDir)
 

--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,12 @@ type Config struct {
 	DbSslMode  string
 	Tz         string
 
+	// RedisURL enables optional multi-instance shared state for key admission
+	// counters and soft channel cooldown markers (learn #118). Empty = disabled
+	// (default process-local). redis://host:port[/db] or host:port.
+	// No hard dependency: single-node installs leave this empty.
+	RedisURL string
+
 	// Cron (5 fields)
 	CheckinCron          string
 	CheckinScheduleMode  string
@@ -403,6 +409,8 @@ func Load(env map[string]string) *Config {
 	cfg.DbSsl = parseBoolean(get("DB_SSL"), false)
 	cfg.DbSslMode = normalizeDbSslMode(get("DB_SSLMODE"))
 	cfg.Tz = get("TZ")
+	// Optional shared state backend (admission counters + soft cooldown). Empty disables.
+	cfg.RedisURL = strings.TrimSpace(firstNonEmpty(get("REDIS_URL"), get("RedisURL")))
 
 	// ---- §3.4 Cron ----
 	cfg.CheckinCron = firstNonEmpty(get("CHECKIN_CRON"), DefaultCheckinCron)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,22 @@ import (
 	"testing"
 )
 
+func TestLoadParsesRedisURL(t *testing.T) {
+	cfg := Load(map[string]string{
+		"REDIS_URL": "redis://:secret@127.0.0.1:6379/1",
+	})
+	if cfg.RedisURL != "redis://:secret@127.0.0.1:6379/1" {
+		t.Fatalf("RedisURL = %q", cfg.RedisURL)
+	}
+}
+
+func TestLoadRedisURLEmptyByDefault(t *testing.T) {
+	cfg := Load(map[string]string{})
+	if cfg.RedisURL != "" {
+		t.Fatalf("RedisURL default = %q, want empty", cfg.RedisURL)
+	}
+}
+
 func TestLoadParsesAdminCorsAllowedOrigins(t *testing.T) {
 	cfg := Load(map[string]string{
 		"ADMIN_CORS_ALLOWED_ORIGINS": " https://admin.example.com,https://ops.example.com ,, ",

--- a/docs/analysis/downstream-key-admission.md
+++ b/docs/analysis/downstream-key-admission.md
@@ -22,5 +22,5 @@ List/summary rows include `windowUsedRpm` / `windowUsedTpm` from the local windo
 
 ## Residual
 
-- Multi-instance shared admission needs Redis (#118).
+- ~~Multi-instance shared admission needs Redis (#118).~~ Landed: set `REDIS_URL` for shared fixed-window RPM/TPM counters (`docs/analysis/redis-shared-state.md`). Default remains process-local; Redis errors fail-open to local.
 - TPM currently reserved at 0 tokens on auth (request-count RPM is primary); token estimate hook can feed later.

--- a/docs/analysis/redis-shared-state.md
+++ b/docs/analysis/redis-shared-state.md
@@ -1,0 +1,106 @@
+# Optional Redis shared state (#118)
+
+**Date:** 2026-07-17  
+**Lane:** competitive learn / multi-instance  
+**SSOT code:** `internal/redisx/*`, `auth/key_admission.go`, `routing/soft_cooldown.go`, `app/redis_shared.go`  
+**Peers:** LiteLLM Redis dual-cache cooldown/rate limits; New API Redis usage
+
+## Goal
+
+Optional Redis backend so multiple metapi-go instances behind a load balancer share:
+
+1. Downstream-key RPM/TPM admission counters (#116)
+2. Soft channel cooldown markers (accelerate peer awareness of DB-backed cooldowns)
+
+Default remains **in-process**. Redis is **never** a hard dependency for single-node installs.
+
+## Config
+
+| Env | Default | Meaning |
+|-----|---------|---------|
+| `REDIS_URL` | empty | `redis://[:password@]host:port[/db]` or `host:port`. Empty disables shared state. |
+
+Parsed into `config.Config.RedisURL`. Wired at startup by `app.ConfigureSharedState`.
+
+**TLS note:** the minimal client supports `redis://` only. `rediss://` is rejected with a startup warning and shared state stays process-local.
+
+## Architecture
+
+```
+REDIS_URL empty
+  └─ auth.GlobalKeyAdmission → process-local sliding 60s window
+  └─ routing soft cooldown → NoopCooldown
+
+REDIS_URL set
+  └─ internal/redisx.Client (stdlib net, RESP, connection-per-command)
+       ├─ RedisCounter → SharedCounter for admission RPM/TPM
+       └─ RedisCooldown → soft markers metapi:cooldown:channel:{id}
+```
+
+No third-party Redis SDK is added to `go.mod`.
+
+### Key layout
+
+| Key | Purpose | TTL |
+|-----|---------|-----|
+| `metapi:admission:rpm:{keyID}` | fixed-window request counter | 60s (PEXPIRE on first INCR) |
+| `metapi:admission:tpm:{keyID}` | fixed-window token counter | 60s |
+| `metapi:cooldown:channel:{id}` | soft cooldown marker (`"1"`) | remaining DB cooldown TTL |
+
+### Admission algorithm
+
+- **Memory (default):** sliding 60s window of event timestamps (unchanged from #116).
+- **Redis:** fixed-window approximation — `INCR`/`INCRBY` + `PEXPIRE` when the counter is first created in the window. Slightly coarser than sliding but cheap and multi-instance safe enough for soft admission.
+- Over limit → **429** + `Retry-After` (same as process-local).
+
+### Soft cooldown
+
+- **Source of truth remains DB** `route_channels.cooldown_until` (and OAuth member cooldown).
+- On `RecordFailure` / probe failure, instances also `SET PX` a soft marker so peers can filter the channel before their local route cache reloads from DB.
+- Eligibility checks: `isChannelCoolingDown` = DB until in future **OR** soft marker active.
+- On success / clear failure state, soft markers are deleted best-effort.
+
+## Failure mode: fail-open
+
+| Failure | Behavior |
+|---------|----------|
+| Invalid / empty `REDIS_URL` | Shared state disabled; process-local only |
+| Startup `PING` failure | Shared backends still installed; runtime commands fail-open until Redis recovers |
+| Runtime Redis error on admission | Fall back to **process-local** window for that request; increment `FailOpenCount`; log warn |
+| Runtime Redis error on soft cooldown Active/Mark | Treat as **not cooling** / skip mark; never force cooldown; log debug |
+
+**Rationale:** availability over strict global rate limits. Soft admission and soft cooldown stay optional — Redis outages must not black-hole traffic.
+
+**Not fail-closed:** we deliberately do **not** reject requests when Redis is down.
+
+## Tests
+
+| Area | Coverage |
+|------|----------|
+| `internal/redisx` | URL parse, memory counter/cooldown, fake RESP server INCR/SET/EXISTS, dial failure |
+| `auth` | shared RPM/TPM, fail-open to local, configure/nil |
+| `routing` | soft marker enable/disable, fail-open Active, `isChannelCoolingDown` |
+| `config` | `REDIS_URL` parse / default empty |
+
+No live Redis required in CI.
+
+## Residuals (out of scope for #118)
+
+- Full session/sticky binding store in Redis
+- Runtime health map dual-write
+- Route cache invalidation bus
+- `rediss://` TLS client
+- Cluster mesh / service discovery
+- Admin UI for Redis status
+
+## Operator notes
+
+```bash
+# single node (default)
+# REDIS_URL=
+
+# multi-instance behind LB
+REDIS_URL=redis://:password@redis:6379/0
+```
+
+Single-node operators can ignore Redis entirely. Multi-instance operators should still use PostgreSQL for durable cooldown and scheduler leases; Redis only tightens the admission/cooldown race window between cache reloads.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -136,7 +136,7 @@ Schema migrations run automatically at startup. Use `metapi-migrate` to transfer
 
 Use PostgreSQL for multi-instance deployments. Side-effecting schedulers use PostgreSQL advisory locks, so only one replica runs each job batch at a time. `admin-snapshot` remains process-local cache warming; `usage-aggregation` uses its own checkpoint lease.
 
-Redis is not part of the current runtime. There is no `REDIS_URL` setting, Redis client, or distributed cache in this build.
+Optional Redis (`REDIS_URL`) shares downstream-key RPM/TPM admission counters and soft channel cooldown markers across replicas. Leave it empty for process-local state (default). Redis is never a hard dependency: parse/connect errors keep in-process defaults, and runtime command errors fail-open. See `docs/analysis/redis-shared-state.md`.
 
 ### Proxy Forwarding
 

--- a/docs/doc_hygiene_test.go
+++ b/docs/doc_hygiene_test.go
@@ -51,8 +51,8 @@ func TestPublicMarkdownHygiene(t *testing.T) {
 				findings = append(findings, formatFinding(rel, lineNo, "AI citation or tracking artifact", line))
 			case dsnWithPasswordRE.MatchString(line) && !isAllowedExampleDSN(line):
 				findings = append(findings, formatFinding(rel, lineNo, "credential-bearing DSN without placeholders", line))
-			case looksLikeRedisSupportedClaim(line):
-				findings = append(findings, formatFinding(rel, lineNo, "unsupported Redis runtime claim", line))
+			case looksLikeRedisHardDependencyClaim(line):
+				findings = append(findings, formatFinding(rel, lineNo, "Redis hard-dependency claim (Redis is optional)", line))
 			}
 		}
 		return nil
@@ -129,30 +129,47 @@ func hasDisallowedUnixHomePath(line string) bool {
 	return false
 }
 
-func looksLikeRedisSupportedClaim(line string) bool {
+// looksLikeRedisHardDependencyClaim flags docs that claim Redis is mandatory.
+// Optional Redis (#118) is supported via REDIS_URL; single-node installs may
+// leave it empty. Claims that Redis is a hard/required runtime dependency are
+// incorrect. Optional / fail-open language is allowed.
+func looksLikeRedisHardDependencyClaim(line string) bool {
 	lower := strings.ToLower(line)
 	if !strings.Contains(lower, "redis") {
 		return false
 	}
-	hasClaim := strings.Contains(lower, "supported") ||
-		strings.Contains(lower, "integrated") ||
-		strings.Contains(lower, "required") ||
-		strings.Contains(lower, "dependency") ||
-		strings.Contains(lower, "runtime") ||
-		strings.Contains(lower, "兼容") ||
-		strings.Contains(lower, "支持") ||
-		strings.Contains(lower, "集成")
-	if !hasClaim {
-		return false
-	}
-	hasNegation := strings.Contains(lower, "not ") ||
-		strings.Contains(lower, " no ") ||
-		strings.Contains(lower, "no `redis_url`") ||
-		strings.Contains(lower, "without redis") ||
+	// Explicitly optional / disabled-by-default wording is fine.
+	if strings.Contains(lower, "optional") ||
+		strings.Contains(lower, "可选") ||
+		strings.Contains(lower, "fail-open") ||
+		strings.Contains(lower, "fail open") ||
+		strings.Contains(lower, "never a hard") ||
+		strings.Contains(lower, "not a hard") ||
+		strings.Contains(lower, "no hard") ||
+		strings.Contains(lower, "not required") ||
+		strings.Contains(lower, "not mandatory") ||
+		strings.Contains(lower, "empty =") ||
+		strings.Contains(lower, "empty disables") ||
+		strings.Contains(lower, "leave it empty") ||
+		strings.Contains(lower, "default remains") ||
+		strings.Contains(lower, "process-local") ||
+		strings.Contains(lower, "process local") ||
+		strings.Contains(lower, "off by default") ||
+		strings.Contains(lower, "by default") ||
+		strings.Contains(lower, "redis_url") ||
 		strings.Contains(lower, "尚未") ||
 		strings.Contains(lower, "没有") ||
-		strings.Contains(lower, "无 redis")
-	return !hasNegation
+		strings.Contains(lower, "无 redis") {
+		return false
+	}
+	// Ban only hard-requirement wording.
+	return strings.Contains(lower, "hard dependency") ||
+		strings.Contains(lower, "hard-dependency") ||
+		strings.Contains(lower, "required dependency") ||
+		strings.Contains(lower, "redis is required") ||
+		strings.Contains(lower, "must set redis") ||
+		strings.Contains(lower, "requires redis") ||
+		strings.Contains(lower, "必须") && strings.Contains(lower, "redis")
 }
 
 func itoa(n int) string {

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -28,7 +28,7 @@
 | **M-UI** | UI/UX design system | ✅ U0–U3 landed (DESIGN/tokens/components/pages/a11y) |
 | **M-SCHEMA** | Schema compat + upgrade | ✅ SC0–SC2 landed (parity + additive migrations + P0 columns) |
 | **M-RELIABILITY** | Reliability and boundaries | ✅ R0–R2 landed |
-| **M-FEATURE** | Feature completeness from gap matrix | ✅ Gap #38–#56 + learn #110–#117. Open #118–#121 |
+| **M-FEATURE** | Feature completeness from gap matrix | ✅ Gap #38–#56 + learn #110–#118. Open #119–#121 |
 
 > **Program map**: `docs/plan/enterprise-program.md` + `docs/plan/lane-charters.md`  
 > **Scope**: product gap implementation only after F0; CRITICAL reliability (B2/R*) may ship earlier.
@@ -74,8 +74,8 @@
 | Milestone | https://github.com/TokenDanceLab/metapi-go/milestone/6 · Roadmap `docs/plan/feature-complete-roadmap.md` |
 | Shipped infra | Site max concurrency · per-key `proxy_url` · group route rebuild |
 | Closed F1+P1 | Full gap backlog #38–#56 (PRs #74–#94) |
-| In flight WFs | none — next P1 #118 Redis cooldown · #119 admin API harness |
-| Next | M-COMPETE P1 residual: #118 Redis cooldown · #119 admin API harness · P2 #120–#121 |
+| In flight WFs | none — next P1 #119 admin API harness |
+| Next | M-COMPETE P1 residual: #119 admin API harness · P2 #120–#121 |
 | Residual CI | `vulncheck` GO-2026-5856 (Go 1.26.4); frontend occasional `EnvironmentTeardownError` flake (tests pass) |
 
 ### M-COMPETE notes (active)

--- a/internal/redisx/client.go
+++ b/internal/redisx/client.go
@@ -1,0 +1,308 @@
+// Package redisx provides a minimal optional Redis RESP client for shared
+// multi-instance counters and soft cooldown markers (learn #118).
+//
+// It intentionally uses only the Go standard library (net) so single-node
+// installs have no Redis dependency. When REDIS_URL is empty, callers keep
+// process-local state.
+package redisx
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Client is a tiny connection-per-command Redis RESP client.
+// It is safe for concurrent use; each command opens its own short-lived TCP conn.
+type Client struct {
+	addr     string
+	password string
+	db       int
+	timeout  time.Duration
+	// dial is injectable for tests.
+	dial func(network, address string, timeout time.Duration) (net.Conn, error)
+}
+
+// ParseURL parses redis://[:password@]host:port[/db] or host:port.
+// rediss:// is accepted but TLS is NOT implemented — returns an error.
+func ParseURL(raw string) (addr, password string, db int, err error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", 0, fmt.Errorf("empty redis url")
+	}
+	if strings.HasPrefix(strings.ToLower(raw), "rediss://") {
+		return "", "", 0, fmt.Errorf("rediss:// (TLS) is not supported by the minimal redisx client")
+	}
+	if !strings.Contains(raw, "://") {
+		if !strings.Contains(raw, ":") {
+			raw = raw + ":6379"
+		}
+		return raw, "", 0, nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("invalid redis url: %w", err)
+	}
+	if u.Scheme != "" && u.Scheme != "redis" {
+		return "", "", 0, fmt.Errorf("unsupported redis scheme %q", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", "", 0, fmt.Errorf("redis url missing host")
+	}
+	port := u.Port()
+	if port == "" {
+		port = "6379"
+	}
+	addr = net.JoinHostPort(host, port)
+	if u.User != nil {
+		if p, ok := u.User.Password(); ok {
+			password = p
+		} else if name := u.User.Username(); name != "" {
+			// redis://:pass@host form stores pass as username in some parsers;
+			// also accept username-only as password for redis://pass@host.
+			password = name
+		}
+	}
+	if path := strings.TrimPrefix(u.Path, "/"); path != "" {
+		// strip query leftovers if any
+		path = strings.Split(path, "?")[0]
+		n, e := strconv.Atoi(path)
+		if e != nil {
+			return "", "", 0, fmt.Errorf("invalid redis db: %w", e)
+		}
+		db = n
+	}
+	return addr, password, db, nil
+}
+
+// NewClient builds a Client from a REDIS_URL-style string.
+func NewClient(redisURL string) (*Client, error) {
+	addr, pass, db, err := ParseURL(redisURL)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		addr:     addr,
+		password: pass,
+		db:       db,
+		timeout:  800 * time.Millisecond,
+		dial:     net.DialTimeout,
+	}, nil
+}
+
+// Ping issues PING; useful at startup (non-fatal).
+func (c *Client) Ping(ctx context.Context) error {
+	_, err := c.Do(ctx, "PING")
+	return err
+}
+
+// Do runs a Redis command and returns a simplified string payload.
+// Integer replies are decimal strings; bulk null is "".
+func (c *Client) Do(ctx context.Context, parts ...string) (string, error) {
+	if len(parts) == 0 {
+		return "", fmt.Errorf("empty redis command")
+	}
+	return c.withConn(ctx, func(conn net.Conn) (string, error) {
+		return redisDoRaw(conn, parts...)
+	})
+}
+
+// Incr increments key by 1.
+func (c *Client) Incr(ctx context.Context, key string) (int64, error) {
+	raw, err := c.Do(ctx, "INCR", key)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(raw, 10, 64)
+}
+
+// IncrBy increments key by delta (may be negative).
+func (c *Client) IncrBy(ctx context.Context, key string, delta int64) (int64, error) {
+	raw, err := c.Do(ctx, "INCRBY", key, strconv.FormatInt(delta, 10))
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(raw, 10, 64)
+}
+
+// GetInt returns 0 when the key is missing.
+func (c *Client) GetInt(ctx context.Context, key string) (int64, error) {
+	raw, err := c.Do(ctx, "GET", key)
+	if err != nil {
+		return 0, err
+	}
+	if raw == "" {
+		return 0, nil
+	}
+	return strconv.ParseInt(raw, 10, 64)
+}
+
+// PExpire sets a millisecond TTL.
+func (c *Client) PExpire(ctx context.Context, key string, window time.Duration) error {
+	if window <= 0 {
+		window = time.Minute
+	}
+	ms := window.Milliseconds()
+	if ms < 1 {
+		ms = 1
+	}
+	_, err := c.Do(ctx, "PEXPIRE", key, strconv.FormatInt(ms, 10))
+	return err
+}
+
+// SetPX sets key to value with millisecond TTL (overwrites).
+func (c *Client) SetPX(ctx context.Context, key, value string, ttl time.Duration) error {
+	if ttl <= 0 {
+		ttl = time.Second
+	}
+	ms := ttl.Milliseconds()
+	if ms < 1 {
+		ms = 1
+	}
+	_, err := c.Do(ctx, "SET", key, value, "PX", strconv.FormatInt(ms, 10))
+	return err
+}
+
+// Exists returns whether key is present.
+func (c *Client) Exists(ctx context.Context, key string) (bool, error) {
+	raw, err := c.Do(ctx, "EXISTS", key)
+	if err != nil {
+		return false, err
+	}
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// Del deletes a key (best-effort).
+func (c *Client) Del(ctx context.Context, key string) error {
+	_, err := c.Do(ctx, "DEL", key)
+	return err
+}
+
+func (c *Client) withConn(ctx context.Context, fn func(net.Conn) (string, error)) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("nil redis client")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	dial := c.dial
+	if dial == nil {
+		dial = net.DialTimeout
+	}
+	timeout := c.timeout
+	if timeout <= 0 {
+		timeout = 800 * time.Millisecond
+	}
+	// Honor context deadline if tighter.
+	if dl, ok := ctx.Deadline(); ok {
+		if remain := time.Until(dl); remain > 0 && remain < timeout {
+			timeout = remain
+		}
+	}
+	conn, err := dial("tcp", c.addr, timeout)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+	if c.password != "" {
+		if _, err := redisDoRaw(conn, "AUTH", c.password); err != nil {
+			return "", err
+		}
+	}
+	if c.db != 0 {
+		if _, err := redisDoRaw(conn, "SELECT", strconv.Itoa(c.db)); err != nil {
+			return "", err
+		}
+	}
+	return fn(conn)
+}
+
+// ---- minimal RESP ----
+
+func redisDoRaw(conn net.Conn, parts ...string) (string, error) {
+	var b strings.Builder
+	b.WriteString("*")
+	b.WriteString(strconv.Itoa(len(parts)))
+	b.WriteString("\r\n")
+	for _, p := range parts {
+		b.WriteString("$")
+		b.WriteString(strconv.Itoa(len(p)))
+		b.WriteString("\r\n")
+		b.WriteString(p)
+		b.WriteString("\r\n")
+	}
+	if _, err := conn.Write([]byte(b.String())); err != nil {
+		return "", err
+	}
+	return redisRead(conn)
+}
+
+func redisRead(conn net.Conn) (string, error) {
+	buf := make([]byte, 0, 256)
+	tmp := make([]byte, 256)
+	for {
+		n, err := conn.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
+		if err != nil && len(buf) == 0 {
+			return "", err
+		}
+		if len(buf) == 0 {
+			continue
+		}
+		switch buf[0] {
+		case '+':
+			if i := indexCRLF(buf); i >= 0 {
+				return string(buf[1:i]), nil
+			}
+		case '-':
+			if i := indexCRLF(buf); i >= 0 {
+				return "", fmt.Errorf("redis error: %s", string(buf[1:i]))
+			}
+		case ':':
+			if i := indexCRLF(buf); i >= 0 {
+				return string(buf[1:i]), nil
+			}
+		case '$':
+			if i := indexCRLF(buf); i >= 0 {
+				lenStr := string(buf[1:i])
+				if lenStr == "-1" {
+					return "", nil
+				}
+				ln, err := strconv.Atoi(lenStr)
+				if err != nil {
+					return "", err
+				}
+				start := i + 2
+				if len(buf) >= start+ln+2 {
+					return string(buf[start : start+ln]), nil
+				}
+			}
+		default:
+			return "", fmt.Errorf("unexpected redis reply prefix %q", buf[0])
+		}
+		if err != nil {
+			return "", err
+		}
+	}
+}
+
+func indexCRLF(b []byte) int {
+	for i := 0; i+1 < len(b); i++ {
+		if b[i] == '\r' && b[i+1] == '\n' {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/redisx/cooldown.go
+++ b/internal/redisx/cooldown.go
@@ -1,0 +1,211 @@
+package redisx
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// ChannelCooldownKey returns the shared soft-cooldown key for a route channel.
+// Format: metapi:cooldown:channel:{id}
+func ChannelCooldownKey(channelID int64) string {
+	return "metapi:cooldown:channel:" + strconv.FormatInt(channelID, 10)
+}
+
+// CooldownMarker is an optional multi-instance soft filter for channel cooldowns.
+// DB-backed cooldown_until remains the source of truth; this marker accelerates
+// cross-instance awareness when Redis is configured.
+//
+// Failure mode: fail-open — Redis errors never force a channel into cooldown.
+type CooldownMarker interface {
+	// Mark sets a soft cooldown for channelID lasting ttl.
+	Mark(channelID int64, ttl time.Duration) error
+	// Active reports whether a soft cooldown marker is present.
+	// On error or when disabled, returns (false, err) / (false, nil).
+	Active(channelID int64) (bool, error)
+	// Clear removes a soft marker (best-effort).
+	Clear(channelID int64) error
+}
+
+// NoopCooldown never marks channels and never reports active.
+type NoopCooldown struct{}
+
+func (NoopCooldown) Mark(int64, time.Duration) error { return nil }
+func (NoopCooldown) Active(int64) (bool, error)     { return false, nil }
+func (NoopCooldown) Clear(int64) error               { return nil }
+
+// MemoryCooldown is a process-local soft marker (useful for tests / single-node).
+type MemoryCooldown struct {
+	mu   sync.Mutex
+	keys map[int64]int64 // channelID -> untilMs
+	now  func() time.Time
+}
+
+// NewMemoryCooldown creates an empty process-local marker store.
+func NewMemoryCooldown() *MemoryCooldown {
+	return &MemoryCooldown{keys: make(map[int64]int64), now: time.Now}
+}
+
+// SetNowFunc overrides the clock (tests only).
+func (m *MemoryCooldown) SetNowFunc(fn func() time.Time) {
+	if m == nil || fn == nil {
+		return
+	}
+	m.now = fn
+}
+
+func (m *MemoryCooldown) Mark(channelID int64, ttl time.Duration) error {
+	if channelID <= 0 || ttl <= 0 {
+		return nil
+	}
+	until := m.now().UTC().UnixMilli() + ttl.Milliseconds()
+	m.mu.Lock()
+	m.keys[channelID] = until
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *MemoryCooldown) Active(channelID int64) (bool, error) {
+	if channelID <= 0 {
+		return false, nil
+	}
+	now := m.now().UTC().UnixMilli()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	until, ok := m.keys[channelID]
+	if !ok {
+		return false, nil
+	}
+	if until <= now {
+		delete(m.keys, channelID)
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *MemoryCooldown) Clear(channelID int64) error {
+	m.mu.Lock()
+	delete(m.keys, channelID)
+	m.mu.Unlock()
+	return nil
+}
+
+// RedisCooldown stores soft markers under metapi:cooldown:channel:{id}.
+type RedisCooldown struct {
+	client *Client
+}
+
+// NewRedisCooldown wraps a Client.
+func NewRedisCooldown(c *Client) *RedisCooldown {
+	return &RedisCooldown{client: c}
+}
+
+// NewRedisCooldownFromURL parses REDIS_URL and builds a marker store.
+func NewRedisCooldownFromURL(redisURL string) (*RedisCooldown, error) {
+	c, err := NewClient(redisURL)
+	if err != nil {
+		return nil, err
+	}
+	return NewRedisCooldown(c), nil
+}
+
+func (r *RedisCooldown) Mark(channelID int64, ttl time.Duration) error {
+	if r == nil || r.client == nil || channelID <= 0 {
+		return nil
+	}
+	if ttl <= 0 {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), r.client.timeout+200*time.Millisecond)
+	defer cancel()
+	return r.client.SetPX(ctx, ChannelCooldownKey(channelID), "1", ttl)
+}
+
+func (r *RedisCooldown) Active(channelID int64) (bool, error) {
+	if r == nil || r.client == nil || channelID <= 0 {
+		return false, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), r.client.timeout+200*time.Millisecond)
+	defer cancel()
+	ok, err := r.client.Exists(ctx, ChannelCooldownKey(channelID))
+	if err != nil {
+		return false, err
+	}
+	return ok, nil
+}
+
+func (r *RedisCooldown) Clear(channelID int64) error {
+	if r == nil || r.client == nil || channelID <= 0 {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), r.client.timeout+200*time.Millisecond)
+	defer cancel()
+	return r.client.Del(ctx, ChannelCooldownKey(channelID))
+}
+
+// FakeCooldown is a CooldownMarker with injectable failures for fail-open tests.
+type FakeCooldown struct {
+	inner    *MemoryCooldown
+	FailNext bool
+	Err      error
+}
+
+// NewFakeCooldown returns a controllable CooldownMarker.
+func NewFakeCooldown() *FakeCooldown {
+	return &FakeCooldown{inner: NewMemoryCooldown()}
+}
+
+func (f *FakeCooldown) Mark(channelID int64, ttl time.Duration) error {
+	if f.FailNext {
+		f.FailNext = false
+		if f.Err != nil {
+			return f.Err
+		}
+		return fmt.Errorf("fake cooldown mark failed")
+	}
+	return f.inner.Mark(channelID, ttl)
+}
+
+func (f *FakeCooldown) Active(channelID int64) (bool, error) {
+	if f.FailNext {
+		f.FailNext = false
+		if f.Err != nil {
+			return false, f.Err
+		}
+		return false, fmt.Errorf("fake cooldown active failed")
+	}
+	return f.inner.Active(channelID)
+}
+
+func (f *FakeCooldown) Clear(channelID int64) error {
+	if f.FailNext {
+		f.FailNext = false
+		if f.Err != nil {
+			return f.Err
+		}
+		return fmt.Errorf("fake cooldown clear failed")
+	}
+	return f.inner.Clear(channelID)
+}
+
+// TTLFromUntilISO computes remaining TTL from an RFC3339 cooldownUntil vs now.
+// Returns 0 when the timestamp is missing/invalid/already past.
+func TTLFromUntilISO(cooldownUntil *string, now time.Time) time.Duration {
+	if cooldownUntil == nil || *cooldownUntil == "" {
+		return 0
+	}
+	t, err := time.Parse(time.RFC3339, *cooldownUntil)
+	if err != nil {
+		t, err = time.Parse("2006-01-02 15:04:05", *cooldownUntil)
+		if err != nil {
+			return 0
+		}
+	}
+	remain := t.Sub(now.UTC())
+	if remain <= 0 {
+		return 0
+	}
+	return remain
+}

--- a/internal/redisx/counter.go
+++ b/internal/redisx/counter.go
@@ -1,0 +1,220 @@
+package redisx
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// SharedCounter increments a named key inside a time window and returns the
+// post-increment count. Used for multi-instance RPM/TPM admission (#118).
+//
+// Memory implementation uses a sliding window of event timestamps.
+// Redis implementation uses a fixed-window approximation (INCR + PEXPIRE on first hit).
+type SharedCounter interface {
+	// IncrWindow increments key by 1 within window and returns the new count.
+	IncrWindow(key string, window time.Duration) (count int64, err error)
+	// IncrWindowBy increments key by delta within window and returns the new count.
+	// delta <= 0 is a no-op that returns the current count (best-effort).
+	IncrWindowBy(key string, delta int64, window time.Duration) (count int64, err error)
+	// Get returns the current count without incrementing.
+	Get(key string) (count int64, err error)
+}
+
+// MemoryCounter is the default single-process implementation.
+type MemoryCounter struct {
+	mu   sync.Mutex
+	keys map[string]*memWindow
+	now  func() time.Time
+}
+
+type memWindow struct {
+	// events are unix-ms timestamps; for token deltas we store repeated stamps
+	// only for unit increments. For multi-token we store weighted events.
+	events []memEvent
+}
+
+type memEvent struct {
+	atMs  int64
+	delta int64
+}
+
+// NewMemoryCounter creates an empty in-process counter.
+func NewMemoryCounter() *MemoryCounter {
+	return &MemoryCounter{
+		keys: make(map[string]*memWindow),
+		now:  time.Now,
+	}
+}
+
+func (m *MemoryCounter) IncrWindow(key string, window time.Duration) (int64, error) {
+	return m.IncrWindowBy(key, 1, window)
+}
+
+func (m *MemoryCounter) IncrWindowBy(key string, delta int64, window time.Duration) (int64, error) {
+	if window <= 0 {
+		window = time.Minute
+	}
+	nowMs := m.now().UTC().UnixMilli()
+	start := nowMs - window.Milliseconds()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	w := m.keys[key]
+	if w == nil {
+		w = &memWindow{}
+		m.keys[key] = w
+	}
+	// prune
+	i := 0
+	for i < len(w.events) && w.events[i].atMs < start {
+		i++
+	}
+	if i > 0 {
+		w.events = append([]memEvent(nil), w.events[i:]...)
+	}
+	if delta > 0 {
+		w.events = append(w.events, memEvent{atMs: nowMs, delta: delta})
+	}
+	return sumMemEvents(w.events), nil
+}
+
+func (m *MemoryCounter) Get(key string) (int64, error) {
+	nowMs := m.now().UTC().UnixMilli()
+	start := nowMs - 60_000
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	w := m.keys[key]
+	if w == nil {
+		return 0, nil
+	}
+	var n int64
+	for _, e := range w.events {
+		if e.atMs >= start {
+			n += e.delta
+		}
+	}
+	return n, nil
+}
+
+func sumMemEvents(in []memEvent) int64 {
+	var s int64
+	for _, e := range in {
+		s += e.delta
+	}
+	return s
+}
+
+// RedisCounter implements SharedCounter via fixed-window INCR/INCRBY + PEXPIRE.
+// Callers must treat errors as fail-open opportunities.
+type RedisCounter struct {
+	client *Client
+	// keyPrefix is prepended to all keys (default "metapi:").
+	keyPrefix string
+}
+
+// NewRedisCounter wraps a Client. redisURL is parsed via NewClient.
+func NewRedisCounter(redisURL string) (*RedisCounter, error) {
+	c, err := NewClient(redisURL)
+	if err != nil {
+		return nil, err
+	}
+	return &RedisCounter{client: c, keyPrefix: "metapi:"}, nil
+}
+
+// NewRedisCounterFromClient wraps an existing Client (for tests/fakes).
+func NewRedisCounterFromClient(c *Client) *RedisCounter {
+	return &RedisCounter{client: c, keyPrefix: "metapi:"}
+}
+
+func (r *RedisCounter) fullKey(key string) string {
+	if r.keyPrefix == "" {
+		return key
+	}
+	return r.keyPrefix + key
+}
+
+func (r *RedisCounter) IncrWindow(key string, window time.Duration) (int64, error) {
+	return r.IncrWindowBy(key, 1, window)
+}
+
+func (r *RedisCounter) IncrWindowBy(key string, delta int64, window time.Duration) (int64, error) {
+	if r == nil || r.client == nil {
+		return 0, errNilClient
+	}
+	if window <= 0 {
+		window = time.Minute
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), r.client.timeout+200*time.Millisecond)
+	defer cancel()
+	fk := r.fullKey(key)
+	var (
+		count int64
+		err   error
+	)
+	if delta <= 0 {
+		return r.Get(key)
+	}
+	if delta == 1 {
+		count, err = r.client.Incr(ctx, fk)
+	} else {
+		count, err = r.client.IncrBy(ctx, fk, delta)
+	}
+	if err != nil {
+		return 0, err
+	}
+	// Fixed window: set TTL only when the counter is first created in this window.
+	// For INCRBY of large deltas the first write also lands at count==delta.
+	if count == delta {
+		if err := r.client.PExpire(ctx, fk, window); err != nil {
+			return count, err
+		}
+	}
+	return count, nil
+}
+
+func (r *RedisCounter) Get(key string) (int64, error) {
+	if r == nil || r.client == nil {
+		return 0, errNilClient
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), r.client.timeout+200*time.Millisecond)
+	defer cancel()
+	return r.client.GetInt(ctx, r.fullKey(key))
+}
+
+// FakeCounter is an in-memory SharedCounter with injectable error for fail-open tests.
+type FakeCounter struct {
+	inner    *MemoryCounter
+	FailNext bool
+	Err      error
+}
+
+// NewFakeCounter returns a controllable SharedCounter for tests.
+func NewFakeCounter() *FakeCounter {
+	return &FakeCounter{inner: NewMemoryCounter()}
+}
+
+func (f *FakeCounter) IncrWindow(key string, window time.Duration) (int64, error) {
+	return f.IncrWindowBy(key, 1, window)
+}
+
+func (f *FakeCounter) IncrWindowBy(key string, delta int64, window time.Duration) (int64, error) {
+	if f.FailNext {
+		f.FailNext = false
+		if f.Err != nil {
+			return 0, f.Err
+		}
+		return 0, context.DeadlineExceeded
+	}
+	return f.inner.IncrWindowBy(key, delta, window)
+}
+
+func (f *FakeCounter) Get(key string) (int64, error) {
+	if f.FailNext {
+		f.FailNext = false
+		if f.Err != nil {
+			return 0, f.Err
+		}
+		return 0, context.DeadlineExceeded
+	}
+	return f.inner.Get(key)
+}

--- a/internal/redisx/errors.go
+++ b/internal/redisx/errors.go
@@ -1,0 +1,5 @@
+package redisx
+
+import "errors"
+
+var errNilClient = errors.New("redisx: nil client")

--- a/internal/redisx/redisx_test.go
+++ b/internal/redisx/redisx_test.go
@@ -1,0 +1,347 @@
+package redisx
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestParseURL(t *testing.T) {
+	addr, pass, db, err := ParseURL("redis://:s3cret@127.0.0.1:6380/2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr != "127.0.0.1:6380" || pass != "s3cret" || db != 2 {
+		t.Fatalf("got addr=%q pass=%q db=%d", addr, pass, db)
+	}
+	addr, pass, db, err = ParseURL("localhost:6379")
+	if err != nil || addr != "localhost:6379" || pass != "" || db != 0 {
+		t.Fatalf("hostport got addr=%q pass=%q db=%d err=%v", addr, pass, db, err)
+	}
+	if _, _, _, err := ParseURL("rediss://example.com:6379"); err == nil {
+		t.Fatal("expected rediss rejection")
+	}
+}
+
+func TestMemoryCounter_IncrWindow(t *testing.T) {
+	m := NewMemoryCounter()
+	base := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	now := base
+	m.now = func() time.Time { return now }
+
+	n1, err := m.IncrWindow("k", time.Minute)
+	if err != nil || n1 != 1 {
+		t.Fatalf("n1=%d err=%v", n1, err)
+	}
+	n2, _ := m.IncrWindow("k", time.Minute)
+	if n2 != 2 {
+		t.Fatalf("n2=%d", n2)
+	}
+	now = base.Add(61 * time.Second)
+	n3, _ := m.IncrWindow("k", time.Minute)
+	if n3 != 1 {
+		t.Fatalf("after window n3=%d", n3)
+	}
+}
+
+func TestMemoryCounter_IncrWindowBy(t *testing.T) {
+	m := NewMemoryCounter()
+	n, err := m.IncrWindowBy("tok", 500, time.Minute)
+	if err != nil || n != 500 {
+		t.Fatalf("n=%d err=%v", n, err)
+	}
+	n, _ = m.IncrWindowBy("tok", 400, time.Minute)
+	if n != 900 {
+		t.Fatalf("n=%d", n)
+	}
+}
+
+func TestFakeCounter_FailOpenSignal(t *testing.T) {
+	f := NewFakeCounter()
+	f.FailNext = true
+	if _, err := f.IncrWindow("x", time.Minute); err == nil {
+		t.Fatal("expected error")
+	}
+	// next call succeeds
+	n, err := f.IncrWindow("x", time.Minute)
+	if err != nil || n != 1 {
+		t.Fatalf("n=%d err=%v", n, err)
+	}
+}
+
+func TestMemoryCooldown(t *testing.T) {
+	c := NewMemoryCooldown()
+	base := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	now := base
+	c.SetNowFunc(func() time.Time { return now })
+
+	if err := c.Mark(42, 30*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	ok, err := c.Active(42)
+	if err != nil || !ok {
+		t.Fatalf("active=%v err=%v", ok, err)
+	}
+	now = base.Add(31 * time.Second)
+	ok, err = c.Active(42)
+	if err != nil || ok {
+		t.Fatalf("expired active=%v err=%v", ok, err)
+	}
+}
+
+func TestTTLFromUntilISO(t *testing.T) {
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	future := now.Add(45 * time.Second).Format(time.RFC3339)
+	ttl := TTLFromUntilISO(&future, now)
+	if ttl < 44*time.Second || ttl > 46*time.Second {
+		t.Fatalf("ttl=%v", ttl)
+	}
+	past := now.Add(-5 * time.Second).Format(time.RFC3339)
+	if TTLFromUntilISO(&past, now) != 0 {
+		t.Fatal("past should be 0")
+	}
+}
+
+// fakeRedis is a minimal in-process RESP server for unit tests.
+type fakeRedis struct {
+	ln   net.Listener
+	mu   sync.Mutex
+	data map[string]string
+	ttl  map[string]time.Time
+}
+
+func startFakeRedis(t *testing.T) (*fakeRedis, string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fr := &fakeRedis{
+		ln:   ln,
+		data: make(map[string]string),
+		ttl:  make(map[string]time.Time),
+	}
+	go fr.serve()
+	return fr, ln.Addr().String()
+}
+
+func (fr *fakeRedis) Close() { _ = fr.ln.Close() }
+
+func (fr *fakeRedis) serve() {
+	for {
+		conn, err := fr.ln.Accept()
+		if err != nil {
+			return
+		}
+		go fr.handle(conn)
+	}
+}
+
+func (fr *fakeRedis) handle(conn net.Conn) {
+	defer conn.Close()
+	r := bufio.NewReader(conn)
+	for {
+		args, err := readRESPArray(r)
+		if err != nil {
+			return
+		}
+		if len(args) == 0 {
+			return
+		}
+		cmd := strings.ToUpper(args[0])
+		var reply string
+		fr.mu.Lock()
+		fr.expireLocked()
+		switch cmd {
+		case "PING":
+			reply = "+PONG\r\n"
+		case "AUTH", "SELECT":
+			reply = "+OK\r\n"
+		case "INCR":
+			key := args[1]
+			n := fr.getIntLocked(key) + 1
+			fr.data[key] = strconv.FormatInt(n, 10)
+			reply = fmt.Sprintf(":%d\r\n", n)
+		case "INCRBY":
+			key := args[1]
+			delta, _ := strconv.ParseInt(args[2], 10, 64)
+			n := fr.getIntLocked(key) + delta
+			fr.data[key] = strconv.FormatInt(n, 10)
+			reply = fmt.Sprintf(":%d\r\n", n)
+		case "GET":
+			key := args[1]
+			v, ok := fr.data[key]
+			if !ok {
+				reply = "$-1\r\n"
+			} else {
+				reply = fmt.Sprintf("$%d\r\n%s\r\n", len(v), v)
+			}
+		case "PEXPIRE":
+			key := args[1]
+			ms, _ := strconv.ParseInt(args[2], 10, 64)
+			fr.ttl[key] = time.Now().Add(time.Duration(ms) * time.Millisecond)
+			reply = ":1\r\n"
+		case "SET":
+			// SET key value [PX ms]
+			key, val := args[1], args[2]
+			fr.data[key] = val
+			if len(args) >= 5 && strings.EqualFold(args[3], "PX") {
+				ms, _ := strconv.ParseInt(args[4], 10, 64)
+				fr.ttl[key] = time.Now().Add(time.Duration(ms) * time.Millisecond)
+			}
+			reply = "+OK\r\n"
+		case "EXISTS":
+			_, ok := fr.data[args[1]]
+			if ok {
+				reply = ":1\r\n"
+			} else {
+				reply = ":0\r\n"
+			}
+		case "DEL":
+			delete(fr.data, args[1])
+			delete(fr.ttl, args[1])
+			reply = ":1\r\n"
+		default:
+			reply = "-ERR unknown\r\n"
+		}
+		fr.mu.Unlock()
+		if _, err := conn.Write([]byte(reply)); err != nil {
+			return
+		}
+	}
+}
+
+func (fr *fakeRedis) expireLocked() {
+	now := time.Now()
+	for k, until := range fr.ttl {
+		if !until.After(now) {
+			delete(fr.data, k)
+			delete(fr.ttl, k)
+		}
+	}
+}
+
+func (fr *fakeRedis) getIntLocked(key string) int64 {
+	v, ok := fr.data[key]
+	if !ok {
+		return 0
+	}
+	n, _ := strconv.ParseInt(v, 10, 64)
+	return n
+}
+
+func readRESPArray(r *bufio.Reader) ([]string, error) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	line = strings.TrimRight(line, "\r\n")
+	if !strings.HasPrefix(line, "*") {
+		return nil, fmt.Errorf("want array, got %q", line)
+	}
+	n, err := strconv.Atoi(line[1:])
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		hlen, err := r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		hlen = strings.TrimRight(hlen, "\r\n")
+		if !strings.HasPrefix(hlen, "$") {
+			return nil, fmt.Errorf("want bulk, got %q", hlen)
+		}
+		ln, err := strconv.Atoi(hlen[1:])
+		if err != nil {
+			return nil, err
+		}
+		buf := make([]byte, ln+2)
+		if _, err := readFull(r, buf); err != nil {
+			return nil, err
+		}
+		out = append(out, string(buf[:ln]))
+	}
+	return out, nil
+}
+
+func readFull(r *bufio.Reader, buf []byte) (int, error) {
+	total := 0
+	for total < len(buf) {
+		n, err := r.Read(buf[total:])
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}
+
+func TestRedisCounter_AgainstFakeServer(t *testing.T) {
+	fr, addr := startFakeRedis(t)
+	defer fr.Close()
+
+	rc, err := NewRedisCounter(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n1, err := rc.IncrWindow("rpm:1", time.Minute)
+	if err != nil || n1 != 1 {
+		t.Fatalf("n1=%d err=%v", n1, err)
+	}
+	n2, err := rc.IncrWindow("rpm:1", time.Minute)
+	if err != nil || n2 != 2 {
+		t.Fatalf("n2=%d err=%v", n2, err)
+	}
+	n3, err := rc.IncrWindowBy("tpm:1", 500, time.Minute)
+	if err != nil || n3 != 500 {
+		t.Fatalf("n3=%d err=%v", n3, err)
+	}
+	got, err := rc.Get("rpm:1")
+	if err != nil || got != 2 {
+		t.Fatalf("get=%d err=%v", got, err)
+	}
+}
+
+func TestRedisCooldown_AgainstFakeServer(t *testing.T) {
+	fr, addr := startFakeRedis(t)
+	defer fr.Close()
+
+	c, err := NewClient(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cd := NewRedisCooldown(c)
+	if err := cd.Mark(99, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	ok, err := cd.Active(99)
+	if err != nil || !ok {
+		t.Fatalf("active=%v err=%v", ok, err)
+	}
+	if err := cd.Clear(99); err != nil {
+		t.Fatal(err)
+	}
+	ok, err = cd.Active(99)
+	if err != nil || ok {
+		t.Fatalf("cleared active=%v err=%v", ok, err)
+	}
+}
+
+func TestRedisCounter_DialFailure(t *testing.T) {
+	rc, err := NewRedisCounter("127.0.0.1:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Force very short timeout.
+	rc.client.timeout = 50 * time.Millisecond
+	if _, err := rc.IncrWindow("x", time.Minute); err == nil {
+		t.Fatal("expected dial error")
+	}
+}

--- a/routing/router.go
+++ b/routing/router.go
@@ -401,7 +401,7 @@ func getCandidateEligibilityReasonsExplain(
 			break
 		}
 	}
-	if candidate.Channel.CooldownUntil != nil && *candidate.Channel.CooldownUntil > nowISO {
+	if isChannelCoolingDown(candidate.Channel.ID, candidate.Channel.CooldownUntil, nowISO) {
 		reasons = append(reasons, "冷却中")
 	}
 	return reasons
@@ -529,6 +529,7 @@ func (tr *TokenRouter) RecordSuccess(ctx context.Context, channelID int64, laten
 		ch.ConsecutiveFailCount = 0
 		ch.CooldownLevel = 0
 	})
+	ClearSoftChannelCooldown(channelID)
 
 	return nil
 }
@@ -585,6 +586,7 @@ func (tr *TokenRouter) RecordProbeSuccess(ctx context.Context, channelID int64, 
 			ch.ConsecutiveFailCount = 0
 			ch.CooldownLevel = 0
 		})
+		ClearSoftChannelCooldown(channelID)
 		tr.cache.InvalidateRouteScopedCache(ch.RouteID)
 		return nil
 	}
@@ -609,6 +611,7 @@ func (tr *TokenRouter) RecordProbeSuccess(ctx context.Context, channelID int64, 
 				ch.ConsecutiveFailCount = 0
 				ch.CooldownLevel = 0
 			})
+			ClearSoftChannelCooldown(id)
 		}
 	}
 
@@ -733,6 +736,7 @@ func (tr *TokenRouter) RecordProbeFailure(ctx context.Context, channelID int64, 
 			ch.CooldownLevel = cooldownLevel
 			ch.CooldownUntil = cooldownUntil
 		})
+		MarkSoftChannelCooldownFromUntil(id, cooldownUntil)
 	}
 
 	RecordSiteRuntimeFailure(account.SiteID, failureCtx)
@@ -870,6 +874,7 @@ func (tr *TokenRouter) RecordFailure(ctx context.Context, channelID int64, failu
 			ch.CooldownLevel = cooldownLevel
 			ch.CooldownUntil = cooldownUntil
 		})
+		MarkSoftChannelCooldownFromUntil(id, cooldownUntil)
 	}
 
 	RecordSiteRuntimeFailure(account.SiteID, failureCtx)
@@ -904,6 +909,10 @@ func (tr *TokenRouter) ClearChannelFailureState(ctx context.Context, channelIDs 
 
 	if err := tr.db.ClearChannelFailureStates(ctx, channelIDs); err != nil {
 		return 0, err
+	}
+
+	for _, id := range channelIDs {
+		ClearSoftChannelCooldown(id)
 	}
 
 	tr.cache.InvalidateAll()

--- a/routing/selector.go
+++ b/routing/selector.go
@@ -629,8 +629,8 @@ func (s *ChannelSelector) getCandidateEligibilityReasons(
 		reasons = append(reasons, "令牌不可用")
 	}
 
-	// Cooldown
-	if candidate.Channel.CooldownUntil != nil && *candidate.Channel.CooldownUntil > nowISO {
+	// Cooldown (DB cooldown_until + optional shared soft marker #118)
+	if isChannelCoolingDown(candidate.Channel.ID, candidate.Channel.CooldownUntil, nowISO) {
 		reasons = append(reasons, "冷却中")
 	}
 

--- a/routing/soft_cooldown.go
+++ b/routing/soft_cooldown.go
@@ -1,0 +1,139 @@
+package routing
+
+import (
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/internal/redisx"
+)
+
+// Soft channel cooldown markers (learn #118).
+//
+// DB-backed route_channels.cooldown_until remains the source of truth for
+// durable cooldown. When REDIS_URL is configured, instances also publish a
+// short-lived Redis key metapi:cooldown:channel:{id} so peer replicas can
+// soft-filter a channel before their local cache reloads from DB.
+//
+// Failure mode: fail-open — Redis errors never force a channel into cooldown
+// and never block selection.
+
+var (
+	softCooldownMu     sync.RWMutex
+	softCooldownMarker  redisx.CooldownMarker = redisx.NoopCooldown{}
+	softCooldownFailOpen atomic.Uint64
+)
+
+// ConfigureSoftCooldown installs an optional multi-instance cooldown marker.
+// Pass nil or redisx.NoopCooldown{} to disable (default).
+func ConfigureSoftCooldown(marker redisx.CooldownMarker) {
+	softCooldownMu.Lock()
+	defer softCooldownMu.Unlock()
+	if marker == nil {
+		softCooldownMarker = redisx.NoopCooldown{}
+		return
+	}
+	softCooldownMarker = marker
+}
+
+// SoftCooldownEnabled reports whether a non-noop marker is installed.
+func SoftCooldownEnabled() bool {
+	softCooldownMu.RLock()
+	defer softCooldownMu.RUnlock()
+	_, noop := softCooldownMarker.(redisx.NoopCooldown)
+	return softCooldownMarker != nil && !noop
+}
+
+// MarkSoftChannelCooldown publishes a soft marker for channelID lasting ttl.
+// Best-effort; errors are logged and counted (fail-open).
+func MarkSoftChannelCooldown(channelID int64, ttl time.Duration) {
+	if channelID <= 0 || ttl <= 0 {
+		return
+	}
+	softCooldownMu.RLock()
+	m := softCooldownMarker
+	softCooldownMu.RUnlock()
+	if m == nil {
+		return
+	}
+	if _, ok := m.(redisx.NoopCooldown); ok {
+		return
+	}
+	if err := m.Mark(channelID, ttl); err != nil {
+		softCooldownFailOpen.Add(1)
+		slog.Debug("soft channel cooldown mark failed (fail-open)",
+			"channel_id", channelID,
+			"error", err,
+		)
+	}
+}
+
+// ClearSoftChannelCooldown removes a soft marker (best-effort).
+func ClearSoftChannelCooldown(channelID int64) {
+	if channelID <= 0 {
+		return
+	}
+	softCooldownMu.RLock()
+	m := softCooldownMarker
+	softCooldownMu.RUnlock()
+	if m == nil {
+		return
+	}
+	if err := m.Clear(channelID); err != nil {
+		softCooldownFailOpen.Add(1)
+		slog.Debug("soft channel cooldown clear failed (fail-open)",
+			"channel_id", channelID,
+			"error", err,
+		)
+	}
+}
+
+// IsSoftChannelCooldownActive reports whether a soft marker is present.
+// On Redis/backend error returns false (fail-open).
+func IsSoftChannelCooldownActive(channelID int64) bool {
+	if channelID <= 0 {
+		return false
+	}
+	softCooldownMu.RLock()
+	m := softCooldownMarker
+	softCooldownMu.RUnlock()
+	if m == nil {
+		return false
+	}
+	ok, err := m.Active(channelID)
+	if err != nil {
+		softCooldownFailOpen.Add(1)
+		return false
+	}
+	return ok
+}
+
+// SoftCooldownFailOpenCount returns how many soft-marker backend errors occurred.
+func SoftCooldownFailOpenCount() uint64 {
+	return softCooldownFailOpen.Load()
+}
+
+// ResetSoftCooldownForTest restores the noop marker and counters.
+func ResetSoftCooldownForTest() {
+	ConfigureSoftCooldown(redisx.NoopCooldown{})
+	softCooldownFailOpen.Store(0)
+}
+
+// MarkSoftChannelCooldownFromUntil publishes a soft marker using remaining TTL from
+// an RFC3339 cooldownUntil timestamp. No-op when until is nil/past.
+func MarkSoftChannelCooldownFromUntil(channelID int64, cooldownUntil *string) {
+	ttl := redisx.TTLFromUntilISO(cooldownUntil, time.Now().UTC())
+	if ttl <= 0 {
+		return
+	}
+	MarkSoftChannelCooldown(channelID, ttl)
+}
+
+// isChannelCoolingDown combines DB cooldown_until with optional soft Redis marker.
+func isChannelCoolingDown(channelID int64, cooldownUntil *string, nowISO string) bool {
+	if cooldownUntil != nil && *cooldownUntil != "" && *cooldownUntil > nowISO {
+		return true
+	}
+	return IsSoftChannelCooldownActive(channelID)
+}

--- a/routing/soft_cooldown_test.go
+++ b/routing/soft_cooldown_test.go
@@ -1,0 +1,89 @@
+package routing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/internal/redisx"
+)
+
+func TestSoftCooldown_NoopDefault(t *testing.T) {
+	ResetSoftCooldownForTest()
+	if SoftCooldownEnabled() {
+		t.Fatal("expected disabled")
+	}
+	if IsSoftChannelCooldownActive(1) {
+		t.Fatal("noop should not be active")
+	}
+	MarkSoftChannelCooldown(1, time.Minute) // no-op
+	if IsSoftChannelCooldownActive(1) {
+		t.Fatal("still inactive")
+	}
+}
+
+func TestSoftCooldown_MemoryMarker(t *testing.T) {
+	ResetSoftCooldownForTest()
+	t.Cleanup(ResetSoftCooldownForTest)
+
+	mem := redisx.NewMemoryCooldown()
+	base := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	now := base
+	mem.SetNowFunc(func() time.Time { return now })
+	ConfigureSoftCooldown(mem)
+
+	if !SoftCooldownEnabled() {
+		t.Fatal("expected enabled")
+	}
+	MarkSoftChannelCooldown(7, 30*time.Second)
+	if !IsSoftChannelCooldownActive(7) {
+		t.Fatal("expected active")
+	}
+	now = base.Add(31 * time.Second)
+	if IsSoftChannelCooldownActive(7) {
+		t.Fatal("expected expired")
+	}
+}
+
+func TestSoftCooldown_FailOpenOnError(t *testing.T) {
+	ResetSoftCooldownForTest()
+	t.Cleanup(ResetSoftCooldownForTest)
+
+	fake := redisx.NewFakeCooldown()
+	ConfigureSoftCooldown(fake)
+	fake.FailNext = true
+	// Mark error is fail-open (logged, counted)
+	MarkSoftChannelCooldown(3, time.Minute)
+	if SoftCooldownFailOpenCount() != 1 {
+		t.Fatalf("failopen=%d", SoftCooldownFailOpenCount())
+	}
+	// Active error → false
+	fake.FailNext = true
+	if IsSoftChannelCooldownActive(3) {
+		t.Fatal("fail-open Active must return false")
+	}
+	if SoftCooldownFailOpenCount() != 2 {
+		t.Fatalf("failopen=%d", SoftCooldownFailOpenCount())
+	}
+}
+
+func TestIsChannelCoolingDown(t *testing.T) {
+	ResetSoftCooldownForTest()
+	t.Cleanup(ResetSoftCooldownForTest)
+
+	nowISO := "2026-07-17T12:00:00Z"
+	future := "2026-07-17T12:05:00Z"
+	if !isChannelCoolingDown(1, &future, nowISO) {
+		t.Fatal("DB future cooldown should cool")
+	}
+	past := "2026-07-17T11:00:00Z"
+	if isChannelCoolingDown(1, &past, nowISO) {
+		t.Fatal("past DB cooldown should not cool without soft marker")
+	}
+
+	mem := redisx.NewMemoryCooldown()
+	ConfigureSoftCooldown(mem)
+	_ = mem.Mark(2, time.Minute)
+	if !isChannelCoolingDown(2, nil, nowISO) {
+		t.Fatal("soft marker alone should cool")
+	}
+}


### PR DESCRIPTION
## Summary
- Optional `REDIS_URL` enables multi-instance shared state for downstream-key RPM/TPM admission counters and soft channel cooldown markers.
- Minimal stdlib RESP client (`internal/redisx`) — no go-redis dependency; empty URL keeps process-local defaults.
- Fail-open on Redis errors (documented + tested); single-node installs have no hard Redis dependency.
- DB `cooldown_until` remains source of truth; Redis soft markers only accelerate peer filtering.

## AC (#118)
- [x] Config flag/URL enables Redis; default remains in-process
- [x] Cooldown (soft marker) and admission counters can use Redis
- [x] Failure mode documented (fail-open) and tested
- [x] No hard dependency on Redis for single-node installs

## Test plan
- [x] `go test ./... -count=1`
- [x] `go test ./internal/redisx ./auth ./routing ./app ./config ./docs -count=1 -race`
- [x] Fake RESP server tests (no live Redis)
- [x] Fail-open paths for admission + soft cooldown

Closes #118