### PR TITLE
feat(admin): usage heatmaps and slow-request ranking #121

### DIFF
--- a/docs/analysis/usage-heatmaps.md
+++ b/docs/analysis/usage-heatmaps.md
@@ -1,0 +1,138 @@
+# Usage heatmaps + slow-request ranking (#121)
+
+**Date:** 2026-07-17  
+**Lane:** competitive learn / observability  
+**SSOT code:** `handler/admin/stats.go` (`usageHeatmap`, `slowRequests`)  
+**Peers:** all-api-hub usage analytics heatmaps / slow-request analysis; New API performance views  
+**Matrix:** L12
+
+## Goal
+
+Give operators an admin-facing density view of traffic (hour × site/model) and a ranked list of the slowest proxy requests, without shipping personal chat content or unbounded SQL scans.
+
+## Endpoints
+
+### `GET /api/stats/usage-heatmap`
+
+| Query | Default | Clamp | Notes |
+|:------|:--------|:------|:------|
+| `days` | `7` | `[1, 31]` | Lookback window from now (UTC). |
+| `dimension` | `site` | `site` \| `model` | Anything else falls back to `site`. |
+
+**Response (camelCase):**
+
+```json
+{
+  "dimension": "site",
+  "days": 7,
+  "since": "2026-07-10T12:00:00Z",
+  "source": "site_hour_usage",
+  "cellLimit": 2000,
+  "count": 12,
+  "cells": [
+    {
+      "bucket": "2026-07-17T08:00:00Z",
+      "key": "3",
+      "label": "prod-openai",
+      "calls": 42,
+      "tokens": 12000,
+      "spend": 0.12
+    }
+  ]
+}
+```
+
+| Field | Meaning |
+|:------|:--------|
+| `bucket` | UTC hour start (RFC3339) |
+| `key` | site id (string) or model name |
+| `label` | site name or model name |
+| `calls` / `tokens` / `spend` | density metrics for the cell |
+| `source` | `site_hour_usage` when projection hits; otherwise `proxy_logs` |
+| `cellLimit` | hard max rows returned (`2000`) |
+
+### `GET /api/stats/slow-requests`
+
+| Query | Default | Clamp | Notes |
+|:------|:--------|:------|:------|
+| `limit` | `50` | `[1, 200]` | Max ranked rows. |
+| `minLatencyMs` | `1000` | `[0, 3600000]` | Minimum `proxy_logs.latency_ms`. |
+| `hours` | `24` | `[1, 168]` | Lookback window (max 7 days). |
+
+**Response (camelCase):**
+
+```json
+{
+  "hours": 24,
+  "minLatencyMs": 1000,
+  "limit": 50,
+  "since": "2026-07-16T12:00:00Z",
+  "count": 1,
+  "items": [
+    {
+      "id": 99,
+      "model": "gpt-4o",
+      "status": "success",
+      "latencyMs": 4500,
+      "firstByteLatencyMs": 1200,
+      "httpStatus": 200,
+      "requestId": "req-abc",
+      "accountId": 7,
+      "siteId": 3,
+      "siteName": "prod-openai",
+      "createdAt": "2026-07-17T11:22:33Z"
+    }
+  ]
+}
+```
+
+## Query bounds (AC)
+
+| Path | Bound | How |
+|:-----|:------|:----|
+| Heatmap site | `LIMIT 2000` + `bucket_start_utc >= since` | Prefer projected `site_hour_usage` (already hour-bucketed). Fallback live aggregate from `proxy_logs` also uses the same `LIMIT`. |
+| Heatmap model | `LIMIT 2000` + `created_at >= since` | Aggregate from `proxy_logs` only (no model_hour table). |
+| Slow requests | `LIMIT <= 200` + `created_at >= since` + `latency_ms >= min` | Indexed `proxy_logs_created_at_idx`; ordered by latency DESC. |
+
+No endpoint does a full-table scan without a time predicate and a hard `LIMIT`.
+
+## Privacy
+
+- Never selects request/response bodies, messages, prompts, or billing payload text.
+- Heatmap cells are aggregates only.
+- Slow-request ranking returns metadata + latency + request id (trace join key), not content.
+- Aligns with `docs/analysis/observability-export.md` privacy rules.
+
+## Sources of truth
+
+| Dimension | Preferred source | Fallback |
+|:----------|:-----------------|:---------|
+| `site` | `site_hour_usage` projected by `scheduler/usage_aggregation.go` | Live `proxy_logs ⋈ accounts ⋈ sites` hour aggregate |
+| `model` | Live `proxy_logs` hour × model aggregate | — |
+
+Token totals reuse `effectiveProxyTokensSQL` (prefer `total_tokens`, else prompt+completion; never double-count).
+
+## Dual dialect notes
+
+`created_at` / `bucket_start_utc` are stored as TEXT RFC3339.
+
+- **SQLite hour bucket:** `substr(created_at, 1, 13) || ':00:00Z'`
+- **PostgreSQL hour bucket:** `to_char(date_trunc('hour', created_at::timestamptz), ...)`
+
+Both paths go through `rebindAdminQuery` (`?` → `$n` on PG).
+
+## Out of scope
+
+- Real-time clickstream / product analytics
+- Exporting personal user chat content into heatmaps
+- Frontend chart polish (API-only MVP satisfies AC)
+- New projection tables for model×hour (optional later if live aggregate cost grows)
+
+## Tests
+
+- `handler/admin/stats_test.go`
+  - site heatmap from `site_hour_usage` fixtures + days filter
+  - model heatmap from `proxy_logs` fixtures
+  - slow-request ranking / threshold / hours window
+  - param clamps (`days`, `limit`, `hours`, `dimension` fallback)
+  - no content fields leaked

--- a/docs/api.md
+++ b/docs/api.md
@@ -68,6 +68,22 @@ Usage trend data by site.
 
 Model usage breakdown by site.
 
+### GET /api/stats/usage-heatmap
+
+Hour × site/model usage density for admin analytics (learn #121).
+
+**Query params**: `days` (1–31, default 7), `dimension` (`site`|`model`, default `site`)
+
+**Response**: `{ dimension, days, since, source, cellLimit, count, cells:[{bucket,key,label,calls,tokens,spend}] }`. Bounded with hard `LIMIT` (2000). Prefers `site_hour_usage` for site dimension; model dimension aggregates `proxy_logs`. Never includes chat content.
+
+### GET /api/stats/slow-requests
+
+Top slow proxy requests by `latency_ms` within a time window (learn #121).
+
+**Query params**: `limit` (1–200, default 50), `minLatencyMs` (default 1000), `hours` (1–168, default 24)
+
+**Response**: `{ hours, minLatencyMs, limit, since, count, items:[{id,model,status,latencyMs,firstByteLatencyMs,httpStatus,requestId,accountId,siteId,siteName,createdAt}] }`. Metadata only — no request/response bodies.
+
 ---
 
 ## Models & Routes

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -23,6 +23,9 @@ func RegisterStatsRoutes(r chi.Router, db *sqlx.DB) {
 	r.Get("/api/stats/site-distribution", handler.siteDistribution)
 	r.Get("/api/stats/site-trend", handler.siteTrend)
 	r.Get("/api/stats/model-by-site", handler.modelBySite)
+	// Usage density heatmap + slow-request ranking (learn #121).
+	r.Get("/api/stats/usage-heatmap", handler.usageHeatmap)
+	r.Get("/api/stats/slow-requests", handler.slowRequests)
 	// Cross-site effective model price comparison (admin).
 	// Both paths are registered for discoverability; they share one handler.
 	r.Get("/api/stats/model-prices", handler.modelPriceCompare)
@@ -513,6 +516,202 @@ func (h *statsHandler) modelBySite(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"models": models})
+}
+
+// usageHeatmapCellLimit caps density rows returned to admin clients.
+// 31d * 24h * ~50 keys is more than enough for a dense operator view.
+const usageHeatmapCellLimit = 2000
+
+// ---- Usage Heatmap ----
+// GET /api/stats/usage-heatmap?days=7&dimension=site|model
+//
+// Returns bounded hour-bucket density cells for admin analytics (#121).
+// Site dimension prefers projected site_hour_usage; model dimension aggregates
+// proxy_logs with a hard LIMIT (no unbounded scans, no chat content).
+func (h *statsHandler) usageHeatmap(w http.ResponseWriter, r *http.Request) {
+	days := clampInt(getQueryInt(r, "days", 7), 1, 31)
+	dimension := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("dimension")))
+	if dimension != "model" {
+		dimension = "site"
+	}
+
+	since := time.Now().UTC().Add(-time.Duration(days) * 24 * time.Hour).Truncate(time.Hour).Format(time.RFC3339)
+	source := "proxy_logs"
+	var cells []map[string]any
+
+	if dimension == "site" {
+		// Prefer projected hour aggregates (cheap, already limited by projector).
+		rows := queryRows(h.db, `
+			SELECT
+				u.bucket_start_utc AS bucket,
+				CAST(u.site_id AS TEXT) AS key,
+				COALESCE(s.name, '') AS label,
+				COALESCE(u.total_calls, 0) AS calls,
+				COALESCE(u.total_tokens, 0) AS tokens,
+				COALESCE(u.total_summary_spend, 0) AS spend
+			FROM site_hour_usage u
+			LEFT JOIN sites s ON s.id = u.site_id
+			WHERE u.bucket_start_utc >= ?
+			ORDER BY u.bucket_start_utc ASC, u.total_calls DESC
+			LIMIT ?
+		`, since, usageHeatmapCellLimit)
+		if len(rows) > 0 {
+			source = "site_hour_usage"
+			cells = makeUsageHeatmapCells(rows)
+		} else {
+			// Fallback: bounded live aggregate from proxy_logs when projection is empty.
+			hourExpr := hourBucketSQLExpr(h.db, "pl.created_at")
+			rows = queryRows(h.db, `
+				SELECT
+					`+hourExpr+` AS bucket,
+					CAST(s.id AS TEXT) AS key,
+					COALESCE(s.name, '') AS label,
+					COUNT(*) AS calls,
+					COALESCE(SUM(`+effectiveProxyTokensSQL+`), 0) AS tokens,
+					COALESCE(SUM(COALESCE(pl.estimated_cost, 0)), 0) AS spend
+				FROM proxy_logs pl
+				INNER JOIN accounts a ON a.id = pl.account_id
+				INNER JOIN sites s ON s.id = a.site_id
+				WHERE pl.created_at >= ?
+				GROUP BY `+hourExpr+`, s.id, s.name
+				ORDER BY bucket ASC, calls DESC
+				LIMIT ?
+			`, since, usageHeatmapCellLimit)
+			cells = makeUsageHeatmapCells(rows)
+		}
+	} else {
+		// Model density: no model_hour_usage table; aggregate proxy_logs with LIMIT.
+		hourExpr := hourBucketSQLExpr(h.db, "pl.created_at")
+		modelExpr := `COALESCE(NULLIF(pl.model_actual, ''), NULLIF(pl.model_requested, ''), 'unknown')`
+		rows := queryRows(h.db, `
+			SELECT
+				`+hourExpr+` AS bucket,
+				`+modelExpr+` AS key,
+				`+modelExpr+` AS label,
+				COUNT(*) AS calls,
+				COALESCE(SUM(`+effectiveProxyTokensSQL+`), 0) AS tokens,
+				COALESCE(SUM(COALESCE(pl.estimated_cost, 0)), 0) AS spend
+			FROM proxy_logs pl
+			WHERE pl.created_at >= ?
+			GROUP BY `+hourExpr+`, `+modelExpr+`
+			ORDER BY bucket ASC, calls DESC
+			LIMIT ?
+		`, since, usageHeatmapCellLimit)
+		cells = makeUsageHeatmapCells(rows)
+	}
+
+	if cells == nil {
+		cells = []map[string]any{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"dimension": dimension,
+		"days":      days,
+		"since":     since,
+		"source":    source,
+		"cellLimit": usageHeatmapCellLimit,
+		"count":     len(cells),
+		"cells":     cells,
+	})
+}
+
+// ---- Slow Requests ----
+// GET /api/stats/slow-requests?limit=50&minLatencyMs=1000&hours=24
+//
+// Top proxy_logs by latency_ms within a bounded time window (#121).
+// Never returns request/response bodies or chat content.
+func (h *statsHandler) slowRequests(w http.ResponseWriter, r *http.Request) {
+	limit := clampInt(getQueryInt(r, "limit", 50), 1, 200)
+	minLatencyMs := clampInt(getQueryInt(r, "minLatencyMs", 1000), 0, 3_600_000)
+	hours := clampInt(getQueryInt(r, "hours", 24), 1, 168)
+	since := time.Now().UTC().Add(-time.Duration(hours) * time.Hour).Format(time.RFC3339)
+
+	rows := queryRows(h.db, `
+		SELECT
+			pl.id AS id,
+			COALESCE(NULLIF(pl.model_actual, ''), NULLIF(pl.model_requested, ''), '') AS model,
+			COALESCE(pl.status, '') AS status,
+			COALESCE(pl.latency_ms, 0) AS latency_ms,
+			COALESCE(pl.first_byte_latency_ms, 0) AS first_byte_latency_ms,
+			COALESCE(pl.http_status, 0) AS http_status,
+			COALESCE(pl.request_id, '') AS request_id,
+			pl.account_id AS account_id,
+			s.id AS site_id,
+			COALESCE(s.name, '') AS site_name,
+			pl.created_at AS created_at
+		FROM proxy_logs pl
+		LEFT JOIN accounts a ON a.id = pl.account_id
+		LEFT JOIN sites s ON s.id = a.site_id
+		WHERE pl.created_at >= ?
+			AND COALESCE(pl.latency_ms, 0) >= ?
+		ORDER BY pl.latency_ms DESC, pl.created_at DESC
+		LIMIT ?
+	`, since, minLatencyMs, limit)
+
+	items := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, map[string]any{
+			"id":                 coerceInt64(row["id"]),
+			"model":              coerceString(row["model"]),
+			"status":             coerceString(row["status"]),
+			"latencyMs":          coerceInt64(row["latencyMs"]),
+			"firstByteLatencyMs": coerceInt64(row["firstByteLatencyMs"]),
+			"httpStatus":         coerceInt(row["httpStatus"]),
+			"requestId":          coerceString(row["requestId"]),
+			"accountId":          row["accountId"],
+			"siteId":             row["siteId"],
+			"siteName":           coerceString(row["siteName"]),
+			"createdAt":          coerceString(row["createdAt"]),
+		})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"hours":        hours,
+		"minLatencyMs": minLatencyMs,
+		"limit":        limit,
+		"since":        since,
+		"count":        len(items),
+		"items":        items,
+	})
+}
+
+// hourBucketSQLExpr returns a dual-dialect SQL expression that truncates a
+// TEXT RFC3339 timestamp column to an hour bucket string (…T%H:00:00Z).
+func hourBucketSQLExpr(db *sqlx.DB, column string) string {
+	driver := ""
+	if db != nil {
+		driver = strings.ToLower(strings.TrimSpace(db.DriverName()))
+	}
+	switch driver {
+	case "pgx", "postgres", "postgresql":
+		// created_at is stored as TEXT RFC3339; cast for date_trunc then re-format.
+		return `to_char(date_trunc('hour', (` + column + `)::timestamptz), 'YYYY-MM-DD"T"HH24:00:00"Z"')`
+	default:
+		// SQLite stores UTC RFC3339 without fractional seconds in our writers.
+		// substr keeps the query portable and avoids full-table function scans
+		// beyond the created_at range predicate + LIMIT.
+		return `substr(` + column + `, 1, 13) || ':00:00Z'`
+	}
+}
+
+func makeUsageHeatmapCells(rows []map[string]any) []map[string]any {
+	cells := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		bucket := coerceString(row["bucket"])
+		key := coerceString(row["key"])
+		if bucket == "" || key == "" {
+			continue
+		}
+		cells = append(cells, map[string]any{
+			"bucket": bucket,
+			"key":    key,
+			"label":  coerceString(row["label"]),
+			"calls":  coerceInt64(row["calls"]),
+			"tokens": coerceInt64(row["tokens"]),
+			"spend":  roundMicro(coerceFloat(row["spend"])),
+		})
+	}
+	return cells
 }
 
 // ---- Model Marketplace ----

--- a/handler/admin/stats_test.go
+++ b/handler/admin/stats_test.go
@@ -308,3 +308,238 @@ func TestStats_SQLiteSiteTrendFromProjectedUsage(t *testing.T) {
 		t.Fatalf("spend = %v, want 1.25", site["spend"])
 	}
 }
+
+func TestStats_SQLiteUsageHeatmapFromSiteHourUsage(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Truncate(time.Hour)
+	nowStr := now.Format(time.RFC3339)
+	bucket := now.Format(time.RFC3339)
+	oldBucket := now.Add(-48 * time.Hour).Format(time.RFC3339)
+
+	_, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "heat-site", "https://heat.example.test", "openai", nowStr, nowStr)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	var siteID int64
+	if err := db.Get(&siteID, "SELECT id FROM sites WHERE name = ?", "heat-site"); err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO site_hour_usage
+		(bucket_start_utc, site_id, total_calls, success_calls, failed_calls, total_tokens, total_summary_spend, total_site_spend, total_latency_ms, latency_count, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		bucket, siteID, 7, 6, 1, 700, 0.7, 0.7, 1000, 1, nowStr, nowStr)
+	if err != nil {
+		t.Fatalf("insert recent hour usage: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO site_hour_usage
+		(bucket_start_utc, site_id, total_calls, success_calls, failed_calls, total_tokens, total_summary_spend, total_site_spend, total_latency_ms, latency_count, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		oldBucket, siteID, 99, 99, 0, 9900, 9.9, 9.9, 100, 1, nowStr, nowStr)
+	if err != nil {
+		t.Fatalf("insert old hour usage: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/stats/usage-heatmap?days=1&dimension=site")
+	if resp.Code != 200 {
+		t.Fatalf("usage-heatmap returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["dimension"] != "site" {
+		t.Fatalf("dimension = %v, want site", body["dimension"])
+	}
+	if body["source"] != "site_hour_usage" {
+		t.Fatalf("source = %v, want site_hour_usage", body["source"])
+	}
+	cells, ok := body["cells"].([]any)
+	if !ok || len(cells) != 1 {
+		t.Fatalf("cells = %#v, want one recent cell", body["cells"])
+	}
+	cell := cells[0].(map[string]any)
+	if cell["label"] != "heat-site" {
+		t.Fatalf("label = %v, want heat-site", cell["label"])
+	}
+	if int64(cell["calls"].(float64)) != 7 {
+		t.Fatalf("calls = %v, want 7", cell["calls"])
+	}
+	if int64(cell["tokens"].(float64)) != 700 {
+		t.Fatalf("tokens = %v, want 700", cell["tokens"])
+	}
+	if _, hasContent := cell["content"]; hasContent {
+		t.Fatalf("cells must not include chat content: %#v", cell)
+	}
+}
+
+func TestStats_SQLiteUsageHeatmapModelFromProxyLogs(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC()
+	nowStr := now.Format(time.RFC3339)
+	oldStr := now.Add(-72 * time.Hour).Format(time.RFC3339)
+
+	_, err := db.Exec(`INSERT INTO proxy_logs (model_requested, model_actual, status, prompt_tokens, completion_tokens, total_tokens, estimated_cost, latency_ms, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, "gpt-hot", "gpt-hot", "success", 10, 20, 30, 0.03, 120, nowStr)
+	if err != nil {
+		t.Fatalf("insert recent model log: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO proxy_logs (model_requested, model_actual, status, prompt_tokens, completion_tokens, total_tokens, estimated_cost, latency_ms, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, "gpt-cold", "gpt-cold", "success", 1, 1, 2, 0.01, 50, oldStr)
+	if err != nil {
+		t.Fatalf("insert old model log: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/stats/usage-heatmap?days=1&dimension=model")
+	if resp.Code != 200 {
+		t.Fatalf("usage-heatmap model returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["dimension"] != "model" {
+		t.Fatalf("dimension = %v, want model", body["dimension"])
+	}
+	if body["source"] != "proxy_logs" {
+		t.Fatalf("source = %v, want proxy_logs", body["source"])
+	}
+	cells, ok := body["cells"].([]any)
+	if !ok || len(cells) != 1 {
+		t.Fatalf("cells = %#v, want only gpt-hot", body["cells"])
+	}
+	cell := cells[0].(map[string]any)
+	if cell["key"] != "gpt-hot" {
+		t.Fatalf("key = %v, want gpt-hot", cell["key"])
+	}
+	if int64(cell["calls"].(float64)) != 1 {
+		t.Fatalf("calls = %v, want 1", cell["calls"])
+	}
+	if int64(cell["tokens"].(float64)) != 30 {
+		t.Fatalf("tokens = %v, want 30", cell["tokens"])
+	}
+}
+
+func TestStats_SQLiteSlowRequestsRanking(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC()
+	nowStr := now.Format(time.RFC3339)
+	oldStr := now.Add(-48 * time.Hour).Format(time.RFC3339)
+
+	_, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "slow-site", "https://slow.example.test", "openai", nowStr, nowStr)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	var siteID int64
+	if err := db.Get(&siteID, "SELECT id FROM sites WHERE name = ?", "slow-site"); err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, balance, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, 0, ?, ?)`, siteID, "slow-user", "sk-slow", 1.0, nowStr, nowStr)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	var accountID int64
+	if err := db.Get(&accountID, "SELECT id FROM accounts WHERE username = ?", "slow-user"); err != nil {
+		t.Fatalf("account id: %v", err)
+	}
+
+	// Fast request (below threshold) — must be excluded.
+	_, err = db.Exec(`INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, latency_ms, first_byte_latency_ms, http_status, request_id, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, accountID, "gpt-fast", "gpt-fast", "success", 200, 50, 200, "req-fast", nowStr)
+	if err != nil {
+		t.Fatalf("insert fast log: %v", err)
+	}
+	// Slow request (ranked).
+	_, err = db.Exec(`INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, latency_ms, first_byte_latency_ms, http_status, request_id, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, accountID, "gpt-slow", "gpt-slow", "success", 4500, 1200, 200, "req-slow", nowStr)
+	if err != nil {
+		t.Fatalf("insert slow log: %v", err)
+	}
+	// Even slower but outside hours window — excluded.
+	_, err = db.Exec(`INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, latency_ms, first_byte_latency_ms, http_status, request_id, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, accountID, "gpt-ancient", "gpt-ancient", "success", 9000, 3000, 200, "req-old", oldStr)
+	if err != nil {
+		t.Fatalf("insert old slow log: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/stats/slow-requests?limit=10&minLatencyMs=1000&hours=24")
+	if resp.Code != 200 {
+		t.Fatalf("slow-requests returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if int(body["minLatencyMs"].(float64)) != 1000 {
+		t.Fatalf("minLatencyMs = %v, want 1000", body["minLatencyMs"])
+	}
+	items, ok := body["items"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("items = %#v, want only in-window slow request", body["items"])
+	}
+	item := items[0].(map[string]any)
+	if item["model"] != "gpt-slow" {
+		t.Fatalf("model = %v, want gpt-slow", item["model"])
+	}
+	if int64(item["latencyMs"].(float64)) != 4500 {
+		t.Fatalf("latencyMs = %v, want 4500", item["latencyMs"])
+	}
+	if item["siteName"] != "slow-site" {
+		t.Fatalf("siteName = %v, want slow-site", item["siteName"])
+	}
+	if item["requestId"] != "req-slow" {
+		t.Fatalf("requestId = %v, want req-slow", item["requestId"])
+	}
+	// Privacy: never surface bodies / chat content.
+	for _, forbidden := range []string{"requestBody", "responseBody", "content", "messages", "prompt"} {
+		if _, ok := item[forbidden]; ok {
+			t.Fatalf("slow request item leaked %s: %#v", forbidden, item)
+		}
+	}
+}
+
+func TestStats_UsageHeatmapAndSlowRequestsClampParams(t *testing.T) {
+	_, r := setupStatsSQLiteTest(t)
+
+	resp := doGet(t, r, "/api/stats/usage-heatmap?days=999&dimension=weird")
+	if resp.Code != 200 {
+		t.Fatalf("usage-heatmap clamp returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var heat map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &heat); err != nil {
+		t.Fatalf("unmarshal heatmap: %v", err)
+	}
+	if int(heat["days"].(float64)) != 31 {
+		t.Fatalf("days clamp = %v, want 31", heat["days"])
+	}
+	if heat["dimension"] != "site" {
+		t.Fatalf("dimension fallback = %v, want site", heat["dimension"])
+	}
+	if int(heat["cellLimit"].(float64)) != usageHeatmapCellLimit {
+		t.Fatalf("cellLimit = %v, want %d", heat["cellLimit"], usageHeatmapCellLimit)
+	}
+
+	resp = doGet(t, r, "/api/stats/slow-requests?limit=9999&minLatencyMs=-5&hours=999")
+	if resp.Code != 200 {
+		t.Fatalf("slow-requests clamp returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var slow map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &slow); err != nil {
+		t.Fatalf("unmarshal slow: %v", err)
+	}
+	if int(slow["limit"].(float64)) != 200 {
+		t.Fatalf("limit clamp = %v, want 200", slow["limit"])
+	}
+	if int(slow["minLatencyMs"].(float64)) != 0 {
+		t.Fatalf("minLatencyMs clamp = %v, want 0", slow["minLatencyMs"])
+	}
+	if int(slow["hours"].(float64)) != 168 {
+		t.Fatalf("hours clamp = %v, want 168", slow["hours"])
+	}
+	if items, ok := slow["items"].([]any); !ok || len(items) != 0 {
+		t.Fatalf("empty fixtures should yield empty items, got %#v", slow["items"])
+	}
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/stats/usage-heatmap?days=&dimension=site|model` with hard cell LIMIT (2000); site dimension prefers projected `site_hour_usage`, model dimension aggregates bounded `proxy_logs`.
- Add `GET /api/stats/slow-requests?limit=&minLatencyMs=&hours=` ranking `proxy_logs` by `latency_ms` within a time window (metadata only, no chat content).
- Document AC + privacy bounds in `docs/analysis/usage-heatmaps.md` and brief API entries.

## Test plan
- [x] `go test ./handler/admin/ -count=1`
- [x] SQLite fixtures: site heatmap from `site_hour_usage`, model heatmap from `proxy_logs`, slow ranking + param clamps
- [ ] Optional: smoke against admin SPA once UI wires the endpoints

Closes #121