### PR TITLE
feat(admin): client credential export adapters #120

### DIFF
--- a/docs/analysis/credential-export.md
+++ b/docs/analysis/credential-export.md
@@ -1,0 +1,15 @@
+# Credential export adapters (#120)
+
+## API
+GET /api/downstream-keys/{id}/export?profile=openai|cherry|generic|all
+
+Admin-only. Returns formatVersion, baseUrl, and profiles.
+
+## Profiles
+- openai: shell env for OPENAI_BASE_URL / OPENAI_API_KEY
+- cherry: JSON provider block (apiHost + apiKey)
+- generic: portable JSON with baseUrl/apiBase/headers
+
+## Security
+Only exports a key already readable by the authenticated admin.
+Bump formatVersion when profile schema changes.

--- a/docs/api.md
+++ b/docs/api.md
@@ -539,3 +539,8 @@ Admin routes under `/api/*` are same-origin by default. Set `ADMIN_CORS_ALLOWED_
 ## Trusted Client IPs
 
 Forwarded client IP headers are ignored by default. Set `TRUSTED_PROXY_CIDRS` only for reverse-proxy source ranges you control; admin IP allowlists and rate limits otherwise use the direct peer IP.
+
+
+### GET /api/downstream-keys/:id/export
+
+Admin credential export adapters (openai/cherry/generic). See docs/analysis/credential-export.md.

--- a/handler/admin/credential_export.go
+++ b/handler/admin/credential_export.go
@@ -1,0 +1,119 @@
+package admin
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const credentialExportFormatVersion = "1.0.0"
+
+func (h *downstreamKeysHandler) exportKey(w http.ResponseWriter, r *http.Request) {
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || id <= 0 {
+		writeError(w, http.StatusBadRequest, "id 无效")
+		return
+	}
+	row := queryRow(h.db, "SELECT * FROM downstream_api_keys WHERE id = ?", id)
+	if row == nil {
+		writeError(w, http.StatusNotFound, "API key 不存在")
+		return
+	}
+	key, _ := row["key"].(string)
+	name, _ := row["name"].(string)
+	if key == "" {
+		writeError(w, http.StatusInternalServerError, "key 缺失")
+		return
+	}
+	baseURL := resolveExportBaseURL(r)
+	profile := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("profile")))
+	if profile == "" {
+		profile = "all"
+	}
+	profiles := buildCredentialExportProfiles(name, key, baseURL)
+	if profile != "all" {
+		filtered := make([]map[string]any, 0, 1)
+		for _, p := range profiles {
+			if p["id"] == profile {
+				filtered = append(filtered, p)
+			}
+		}
+		if len(filtered) == 0 {
+			writeError(w, http.StatusBadRequest, "unknown profile: "+profile)
+			return
+		}
+		profiles = filtered
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"success":       true,
+		"formatVersion": credentialExportFormatVersion,
+		"keyId":         id,
+		"keyName":       name,
+		"baseUrl":       baseURL,
+		"profiles":      profiles,
+		"notes": []string{
+			"Export only includes the key already visible to this admin session",
+			"formatVersion is semver for adapter schema evolution",
+		},
+	})
+}
+
+func resolveExportBaseURL(r *http.Request) string {
+	proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto"))
+	if proto == "" {
+		if r.TLS != nil {
+			proto = "https"
+		} else {
+			proto = "http"
+		}
+	}
+	host := strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))
+	if host == "" {
+		host = strings.TrimSpace(r.Host)
+	}
+	if host == "" {
+		return "http://localhost:4000"
+	}
+	return strings.TrimRight(proto+"://"+host, "/")
+}
+
+func buildCredentialExportProfiles(name, key, baseURL string) []map[string]any {
+	v1 := strings.TrimRight(baseURL, "/") + "/v1"
+	env := "export OPENAI_BASE_URL=" + strconv.Quote(v1) + "\nexport OPENAI_API_KEY=" + strconv.Quote(key) + "\n"
+	return []map[string]any{
+		{
+			"id":          "openai",
+			"label":       "OpenAI-compatible env",
+			"description": "OPENAI_BASE_URL + OPENAI_API_KEY for CLI/SDKs",
+			"contentType": "text/plain",
+			"content":     env,
+		},
+		{
+			"id":          "cherry",
+			"label":       "Cherry Studio / generic OpenAI provider JSON",
+			"description": "Provider block for tools that accept OpenAI-compatible base URL + key",
+			"contentType": "application/json",
+			"content": map[string]any{
+				"name":    name,
+				"type":    "openai",
+				"apiHost": v1,
+				"apiKey":  key,
+			},
+		},
+		{
+			"id":          "generic",
+			"label":       "Generic JSON",
+			"description": "Minimal portable credential object",
+			"contentType": "application/json",
+			"content": map[string]any{
+				"baseUrl": baseURL,
+				"apiBase": v1,
+				"apiKey":  key,
+				"headers": map[string]string{"Authorization": "Bearer " + key},
+			},
+		},
+	}
+}

--- a/handler/admin/credential_export_test.go
+++ b/handler/admin/credential_export_test.go
@@ -1,0 +1,24 @@
+package admin
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildCredentialExportProfiles_Content(t *testing.T) {
+	ps := buildCredentialExportProfiles("n", "sk-abc", "https://gw.test")
+	if len(ps) != 3 {
+		t.Fatalf("len=%d", len(ps))
+	}
+	if ps[0]["id"] != "openai" {
+		t.Fatalf("%v", ps[0])
+	}
+	content, _ := ps[0]["content"].(string)
+	if !strings.Contains(content, "OPENAI_BASE_URL") || !strings.Contains(content, "sk-abc") {
+		t.Fatalf("content=%q", content)
+	}
+	cherry, _ := ps[1]["content"].(map[string]any)
+	if cherry["apiKey"] != "sk-abc" {
+		t.Fatalf("cherry=%v", cherry)
+	}
+}

--- a/handler/admin/downstream_keys.go
+++ b/handler/admin/downstream_keys.go
@@ -23,6 +23,7 @@ func RegisterDownstreamKeysRoutes(r chi.Router, db *sqlx.DB) {
 	r.Post("/api/downstream-keys", handler.createKey)
 	r.Post("/api/downstream-keys/batch", handler.batchKeys)
 	r.Get("/api/downstream-keys/{id}/overview", handler.overview)
+	r.Get("/api/downstream-keys/{id}/export", handler.exportKey)
 	r.Get("/api/downstream-keys/{id}/trend", handler.trend)
 	r.Put("/api/downstream-keys/{id}", handler.updateKey)
 	r.Post("/api/downstream-keys/{id}/reset-usage", handler.resetUsage)


### PR DESCRIPTION
## Summary
- GET /api/downstream-keys/{id}/export?profile=openai|cherry|generic|all
- formatVersioned profiles for common client tools

## Test plan
- [x] go test ./handler/admin -run TestBuildCredentialExportProfiles
- [ ] CI green

Closes #120