### PR TITLE
feat(admin): client credential export adapters #120

### DIFF
--- a/docs/analysis/credential-export.md
+++ b/docs/analysis/credential-export.md
@@ -1,0 +1,82 @@
+# Client/tool credential export adapters (#120)
+
+**Date:** 2026-07-17  
+**Backlog:** [#120](https://github.com/TokenDanceLab/metapi-go/issues/120) · competitive learn L11  
+**Peers:** all-api-hub one-click export integrations (browser extension — not product shape)  
+**Code:** `handler/admin/downstream_keys_export.go`
+
+## Goal
+
+Give operators a **server-side, admin-auth** way to export a downstream key as ready-to-paste config snippets for common clients/tools (OpenAI-compatible env, Cherry Studio / CCR-style provider JSON, generic JSON). Reduces copy-paste errors without browser sniffing, WebDAV rewrites, or reverse-engineering proprietary client binaries.
+
+## API
+
+| Method | Path | Auth |
+|--------|------|------|
+| GET | `/api/downstream-keys/{id}/export` | Admin (`/api/*` group) |
+
+### Query params
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `profile` | no | `openai` · `cherry` · `generic`. Omit to return all profiles. |
+| `baseUrl` | no* | Explicit public origin for clients. Wins over env/settings/host. |
+
+\* If omitted, resolution order is:
+
+1. `?baseUrl=`
+2. `PUBLIC_BASE_URL` env
+3. settings table key `public_base_url` (plain or JSON-encoded string)
+4. request host (`X-Forwarded-Host` / `Host` + `X-Forwarded-Proto` / TLS)
+
+### Response shape
+
+```json
+{
+  "success": true,
+  "formatVersion": "1",
+  "keyId": 12,
+  "keyName": "ops-bot",
+  "keyMasked": "sk-e****cdef",
+  "baseUrl": "https://metapi.example.com",
+  "profiles": [
+    {
+      "id": "openai",
+      "label": "OpenAI-compatible env",
+      "format": "env",
+      "description": "…",
+      "content": {
+        "OPENAI_API_KEY": "sk-…",
+        "OPENAI_BASE_URL": "https://metapi.example.com/v1"
+      },
+      "snippet": "OPENAI_API_KEY=sk-…\nOPENAI_BASE_URL=https://metapi.example.com/v1\n"
+    }
+  ]
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `formatVersion` | Adapter contract version. Bump on non-compatible profile shape changes. |
+| `baseUrl` | Normalized origin (`http(s)://host[:port]`, no path). |
+| `profiles[]` | One or more export adapters. Each has structured `content` + copyable `snippet`. |
+| `keyMasked` | Display-safe mask; full key only in profile content (admin already can read it). |
+
+## Profiles (formatVersion `1`)
+
+| id | format | Payload |
+|----|--------|---------|
+| `openai` | `env` | `OPENAI_API_KEY` + `OPENAI_BASE_URL` (`baseUrl` + `/v1`) |
+| `cherry` | `json` | Cherry Studio / CCR-style OpenAI-compatible provider block (`apiKey`, `apiHost`/`baseUrl`) |
+| `generic` | `json` | Neutral JSON: `apiKey`, `baseUrl`, `openaiBaseUrl`, auth header hints |
+
+## Security / non-goals
+
+- **Only** re-emits the selected downstream key value that admin list/overview already expose.
+- Never invents upstream account tokens, OAuth secrets, or passwords.
+- No browser page sniffing, no WebDAV extension sync, no proprietary binary formats.
+- Export is admin-only; do not expose on unauthenticated proxy paths.
+
+## Future adapters
+
+Keep `formatVersion` stable while adding new profile `id`s. Breaking field renames inside an existing profile require a formatVersion bump and dual-read notes in this document.

--- a/docs/api.md
+++ b/docs/api.md
@@ -300,6 +300,14 @@ Usage overview for a specific key (24h, 7d, all-time).
 
 Usage trend data for a specific key.
 
+### GET /api/downstream-keys/:id/export
+
+Export client/tool config snippets for a downstream key (competitive learn #120).
+
+**Query params**: `profile` (`openai` | `cherry` | `generic`, omit for all), optional `baseUrl` (else `PUBLIC_BASE_URL` / settings `public_base_url` / request host).
+
+Response includes `formatVersion`, `baseUrl`, and `profiles[]` with structured `content` + copyable `snippet`. Secrets are limited to the key the admin can already read. See `docs/analysis/credential-export.md`.
+
 ### POST /api/downstream-keys
 
 Create a new downstream API key.

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -28,7 +28,7 @@
 | **M-UI** | UI/UX design system | ✅ U0–U3 landed (DESIGN/tokens/components/pages/a11y) |
 | **M-SCHEMA** | Schema compat + upgrade | ✅ SC0–SC2 landed (parity + additive migrations + P0 columns) |
 | **M-RELIABILITY** | Reliability and boundaries | ✅ R0–R2 landed |
-| **M-FEATURE** | Feature completeness from gap matrix | ✅ Gap #38–#56 + learn #110–#119. Open P2 #120–#121 |
+| **M-FEATURE** | Feature completeness from gap matrix | ✅ Gap #38–#56 + learn #110–#120. Open P2 #121 |
 
 > **Program map**: `docs/plan/enterprise-program.md` + `docs/plan/lane-charters.md`  
 > **Scope**: product gap implementation only after F0; CRITICAL reliability (B2/R*) may ship earlier.
@@ -75,7 +75,7 @@
 | Shipped infra | Site max concurrency · per-key `proxy_url` · group route rebuild |
 | Closed F1+P1 | Full gap backlog #38–#56 (PRs #74–#94) |
 | In flight WFs | none — next P1 #118 Redis cooldown |
-| Next | M-COMPETE P1 residual: #118 Redis cooldown · P2 #120–#121 |
+| Next | M-COMPETE P2 residual: #121 heatmaps |
 | Residual CI | `vulncheck` GO-2026-5856 (Go 1.26.4); frontend occasional `EnvironmentTeardownError` flake (tests pass) |
 
 ### M-COMPETE notes (active)
@@ -84,7 +84,7 @@
 |------|--------|
 | Milestone | https://github.com/TokenDanceLab/metapi-go/milestone/8 |
 | Local clones | operator-only checkouts under competitors/ (not product SSOT) |
-| Scope | Docs-first competitive learning; matrix `docs/analysis/competitive/`; `[learn]` **#110–#121** (open) |
+| Scope | Docs-first competitive learning; matrix `docs/analysis/competitive/`; `[learn]` **#110–#121** (#120 export landed; #121 open) |
 | Peers | [all-api-hub](https://github.com/qixing-jk/all-api-hub) · [axonhub](https://github.com/looplj/axonhub) · [new-api](https://github.com/QuantumNous/new-api) · [litellm](https://github.com/BerriAI/litellm) |
 | Matrix / backlog | `docs/analysis/competitive/matrix.md` · issues **#110–#121** |
 | Inventory | `docs/analysis/competitive/` — [README](../analysis/competitive/README.md) · [sources](../analysis/competitive/sources.md) · [matrix](../analysis/competitive/matrix.md) |

--- a/handler/admin/downstream_keys.go
+++ b/handler/admin/downstream_keys.go
@@ -24,6 +24,7 @@ func RegisterDownstreamKeysRoutes(r chi.Router, db *sqlx.DB) {
 	r.Post("/api/downstream-keys/batch", handler.batchKeys)
 	r.Get("/api/downstream-keys/{id}/overview", handler.overview)
 	r.Get("/api/downstream-keys/{id}/trend", handler.trend)
+	r.Get("/api/downstream-keys/{id}/export", handler.exportKey)
 	r.Put("/api/downstream-keys/{id}", handler.updateKey)
 	r.Post("/api/downstream-keys/{id}/reset-usage", handler.resetUsage)
 	r.Delete("/api/downstream-keys/{id}", handler.deleteKey)

--- a/handler/admin/downstream_keys_export.go
+++ b/handler/admin/downstream_keys_export.go
@@ -1,0 +1,310 @@
+package admin
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Credential export format version. Bump when profile payload shapes change
+// in a non-compatible way; adapters should pin against this field.
+const credentialExportFormatVersion = "1"
+
+// Known export profile IDs. Keep stable for clients and docs.
+const (
+	exportProfileOpenAI  = "openai"
+	exportProfileCherry  = "cherry"
+	exportProfileGeneric = "generic"
+)
+
+// GET /api/downstream-keys/{id}/export?profile=openai|cherry|generic&baseUrl=
+//
+// Admin-only (inherits /api/* auth group). Emits ready-to-copy client config
+// snippets for the selected downstream key. Secrets are limited to the key
+// value the admin list/overview APIs already expose — never invents upstream
+// tokens or other credentials.
+func (h *downstreamKeysHandler) exportKey(w http.ResponseWriter, r *http.Request) {
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || id <= 0 {
+		writeError(w, http.StatusBadRequest, "id 无效")
+		return
+	}
+
+	row := queryRow(h.db, "SELECT * FROM downstream_api_keys WHERE id = ?", id)
+	if row == nil {
+		writeError(w, http.StatusNotFound, "API key 不存在")
+		return
+	}
+
+	key := strings.TrimSpace(existingString(row, "key"))
+	if key == "" {
+		writeError(w, http.StatusInternalServerError, "API key 数据异常")
+		return
+	}
+	name := existingString(row, "name")
+
+	baseURL, baseErr := resolveExportBaseURL(r, h.lookupPublicBaseURLSetting)
+	if baseErr != "" {
+		writeError(w, http.StatusBadRequest, baseErr)
+		return
+	}
+
+	requested := normalizeExportProfileFilter(r.URL.Query().Get("profile"))
+	if requested != "" && !isKnownExportProfile(requested) {
+		writeError(w, http.StatusBadRequest, "profile 无效，支持: openai, cherry, generic")
+		return
+	}
+
+	profiles := buildCredentialExportProfiles(name, key, baseURL, requested)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"success":       true,
+		"formatVersion": credentialExportFormatVersion,
+		"keyId":         id,
+		"keyName":       name,
+		"keyMasked":     maskKey(key),
+		"baseUrl":       baseURL,
+		"profiles":      profiles,
+	})
+}
+
+// lookupPublicBaseURLSetting reads an optional settings-table override.
+// Empty when the table is missing the key or the DB is unavailable.
+func (h *downstreamKeysHandler) lookupPublicBaseURLSetting() string {
+	if h == nil || h.db == nil {
+		return ""
+	}
+	var value string
+	// Settings values may be JSON-encoded strings ("\"https://…\"") or plain text.
+	err := h.db.Get(&value, rebindAdminQuery(h.db, "SELECT value FROM settings WHERE key = ? LIMIT 1"), "public_base_url")
+	if err != nil {
+		return ""
+	}
+	return unwrapSettingString(value)
+}
+
+func unwrapSettingString(raw string) string {
+	v := strings.TrimSpace(raw)
+	if v == "" {
+		return ""
+	}
+	// JSON string encoding: "\"https://example.com\""
+	if strings.HasPrefix(v, "\"") {
+		if unquoted, err := strconv.Unquote(v); err == nil {
+			return strings.TrimSpace(unquoted)
+		}
+	}
+	return v
+}
+
+func normalizeExportProfileFilter(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func isKnownExportProfile(id string) bool {
+	switch id {
+	case exportProfileOpenAI, exportProfileCherry, exportProfileGeneric:
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveExportBaseURL picks a public base URL for client config snippets.
+//
+// Priority:
+//  1. ?baseUrl= query (explicit operator override)
+//  2. PUBLIC_BASE_URL environment variable
+//  3. settings.public_base_url (optional DB override, when lookup provided)
+//  4. Request host (+ X-Forwarded-* when present)
+func resolveExportBaseURL(r *http.Request, settingsLookup func() string) (string, string) {
+	if r != nil {
+		if q := strings.TrimSpace(r.URL.Query().Get("baseUrl")); q != "" {
+			normalized, errMsg := normalizeExportBaseURL(q)
+			if errMsg != "" {
+				return "", errMsg
+			}
+			return normalized, ""
+		}
+	}
+
+	if env := strings.TrimSpace(os.Getenv("PUBLIC_BASE_URL")); env != "" {
+		normalized, errMsg := normalizeExportBaseURL(env)
+		if errMsg != "" {
+			return "", "PUBLIC_BASE_URL 无效: " + errMsg
+		}
+		return normalized, ""
+	}
+
+	if settingsLookup != nil {
+		if s := strings.TrimSpace(settingsLookup()); s != "" {
+			normalized, errMsg := normalizeExportBaseURL(s)
+			if errMsg == "" {
+				return normalized, ""
+			}
+			// Fall through to request host when settings value is malformed.
+		}
+	}
+
+	if r != nil {
+		if hostDerived := deriveBaseURLFromRequest(r); hostDerived != "" {
+			return hostDerived, ""
+		}
+	}
+
+	return "", "无法确定 baseUrl：请传 ?baseUrl= 或配置 PUBLIC_BASE_URL"
+}
+
+func normalizeExportBaseURL(raw string) (string, string) {
+	v := strings.TrimSpace(raw)
+	if v == "" {
+		return "", "baseUrl 不能为空"
+	}
+	// Allow scheme-less hosts by assuming https.
+	if !strings.Contains(v, "://") {
+		v = "https://" + v
+	}
+	u, err := url.Parse(v)
+	if err != nil || u.Host == "" {
+		return "", "baseUrl 格式无效"
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", "baseUrl 必须以 http:// 或 https:// 开头"
+	}
+	// Strip path/query/fragment — clients append /v1 themselves when needed.
+	// Keep trailing-slash free origin.
+	normalized := scheme + "://" + u.Host
+	return normalized, ""
+}
+
+func deriveBaseURLFromRequest(r *http.Request) string {
+	host := strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))
+	if host == "" {
+		host = strings.TrimSpace(r.Host)
+	}
+	// X-Forwarded-Host may be a comma-separated list; take the first.
+	if i := strings.IndexByte(host, ','); i >= 0 {
+		host = strings.TrimSpace(host[:i])
+	}
+	if host == "" {
+		return ""
+	}
+	// Reject obviously unsafe hosts (empty port-only, etc.).
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		if strings.TrimSpace(h) == "" {
+			return ""
+		}
+	}
+
+	scheme := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto"))
+	if i := strings.IndexByte(scheme, ','); i >= 0 {
+		scheme = strings.TrimSpace(scheme[:i])
+	}
+	scheme = strings.ToLower(scheme)
+	if scheme != "http" && scheme != "https" {
+		if r.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+	normalized, errMsg := normalizeExportBaseURL(scheme + "://" + host)
+	if errMsg != "" {
+		return ""
+	}
+	return normalized
+}
+
+func buildCredentialExportProfiles(name, key, baseURL, filter string) []map[string]any {
+	openaiBase := strings.TrimRight(baseURL, "/") + "/v1"
+	all := []map[string]any{
+		buildOpenAIExportProfile(key, openaiBase),
+		buildCherryExportProfile(name, key, baseURL),
+		buildGenericExportProfile(name, key, baseURL, openaiBase),
+	}
+	if filter == "" {
+		return all
+	}
+	out := make([]map[string]any, 0, 1)
+	for _, p := range all {
+		if id, _ := p["id"].(string); id == filter {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func buildOpenAIExportProfile(key, openaiBaseURL string) map[string]any {
+	envBlock := "OPENAI_API_KEY=" + key + "\nOPENAI_BASE_URL=" + openaiBaseURL + "\n"
+	content := map[string]any{
+		"OPENAI_API_KEY":  key,
+		"OPENAI_BASE_URL": openaiBaseURL,
+	}
+	return map[string]any{
+		"id":          exportProfileOpenAI,
+		"label":       "OpenAI-compatible env",
+		"format":      "env",
+		"description": "Environment variables for OpenAI SDKs and CLI tools (base URL includes /v1).",
+		"content":     content,
+		"snippet":     envBlock,
+	}
+}
+
+func buildCherryExportProfile(name, key, baseURL string) map[string]any {
+	providerName := strings.TrimSpace(name)
+	if providerName == "" {
+		providerName = "MetAPI"
+	}
+	// Cherry Studio / CCR-style provider entry: OpenAI-compatible relay.
+	content := map[string]any{
+		"id":      "metapi",
+		"name":    providerName,
+		"type":    "openai",
+		"apiKey":  key,
+		"apiHost": baseURL,
+		"baseUrl": baseURL,
+		"enabled": true,
+	}
+	snippetBytes, _ := jsonMarshalPretty(content)
+	return map[string]any{
+		"id":          exportProfileCherry,
+		"label":       "Cherry Studio / CCR",
+		"format":      "json",
+		"description": "OpenAI-compatible provider block for Cherry Studio and similar clients.",
+		"content":     content,
+		"snippet":     string(snippetBytes),
+	}
+}
+
+func buildGenericExportProfile(name, key, baseURL, openaiBaseURL string) map[string]any {
+	content := map[string]any{
+		"name":             name,
+		"apiKey":           key,
+		"baseUrl":          baseURL,
+		"openaiBaseUrl":    openaiBaseURL,
+		"openaiCompatible": true,
+		"authHeader":       "Authorization",
+		"authScheme":       "Bearer",
+	}
+	snippetBytes, _ := jsonMarshalPretty(content)
+	return map[string]any{
+		"id":          exportProfileGeneric,
+		"label":       "Generic JSON",
+		"format":      "json",
+		"description": "Neutral JSON for custom clients and automation.",
+		"content":     content,
+		"snippet":     string(snippetBytes),
+	}
+}
+
+func jsonMarshalPretty(v any) ([]byte, error) {
+	return json.MarshalIndent(v, "", "  ")
+}

--- a/handler/admin/downstream_keys_export_test.go
+++ b/handler/admin/downstream_keys_export_test.go
@@ -1,0 +1,294 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func seedExportDownstreamKey(t *testing.T) (keyID int64, key, name string, r chi.Router) {
+	t.Helper()
+	db, router := setupDownstreamKeysTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	name = "export-client"
+	key = "sk-export-fixture-abcdef"
+	res, err := db.Exec(
+		`INSERT INTO downstream_api_keys
+		(name, key, description, enabled, used_cost, used_requests, created_at, updated_at)
+		VALUES (?, ?, 'export fixture', 1, 0, 0, ?, ?)`,
+		name, key, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert downstream key: %v", err)
+	}
+	keyID, err = res.LastInsertId()
+	if err != nil {
+		t.Fatalf("LastInsertId: %v", err)
+	}
+	return keyID, key, name, router
+}
+
+func TestDownstreamKeysExport_OpenAIProfile(t *testing.T) {
+	keyID, key, name, r := seedExportDownstreamKey(t)
+
+	resp := doGet(t, r, "/api/downstream-keys/"+itoa(keyID)+"/export?profile=openai&baseUrl=https://metapi.example.com")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("export returned %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["success"] != true {
+		t.Fatalf("success=%v", body["success"])
+	}
+	if body["formatVersion"] != credentialExportFormatVersion {
+		t.Fatalf("formatVersion=%v, want %s", body["formatVersion"], credentialExportFormatVersion)
+	}
+	if body["baseUrl"] != "https://metapi.example.com" {
+		t.Fatalf("baseUrl=%v", body["baseUrl"])
+	}
+	if body["keyName"] != name {
+		t.Fatalf("keyName=%v", body["keyName"])
+	}
+
+	profiles, ok := body["profiles"].([]any)
+	if !ok || len(profiles) != 1 {
+		t.Fatalf("profiles=%#v, want single openai profile", body["profiles"])
+	}
+	profile, _ := profiles[0].(map[string]any)
+	if profile["id"] != exportProfileOpenAI {
+		t.Fatalf("profile id=%v", profile["id"])
+	}
+	if profile["format"] != "env" {
+		t.Fatalf("format=%v", profile["format"])
+	}
+	content, _ := profile["content"].(map[string]any)
+	if content["OPENAI_API_KEY"] != key {
+		t.Fatalf("OPENAI_API_KEY=%v, want fixture key", content["OPENAI_API_KEY"])
+	}
+	if content["OPENAI_BASE_URL"] != "https://metapi.example.com/v1" {
+		t.Fatalf("OPENAI_BASE_URL=%v", content["OPENAI_BASE_URL"])
+	}
+	snippet, _ := profile["snippet"].(string)
+	if !strings.Contains(snippet, "OPENAI_API_KEY="+key) {
+		t.Fatalf("snippet missing key: %q", snippet)
+	}
+	if !strings.Contains(snippet, "OPENAI_BASE_URL=https://metapi.example.com/v1") {
+		t.Fatalf("snippet missing base: %q", snippet)
+	}
+}
+
+func TestDownstreamKeysExport_AllProfilesAndNoExtraSecrets(t *testing.T) {
+	keyID, key, _, r := seedExportDownstreamKey(t)
+
+	resp := doGet(t, r, "/api/downstream-keys/"+itoa(keyID)+"/export?baseUrl=https://gateway.example.org/")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("export returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["baseUrl"] != "https://gateway.example.org" {
+		t.Fatalf("baseUrl normalized=%v", body["baseUrl"])
+	}
+	profiles, ok := body["profiles"].([]any)
+	if !ok || len(profiles) != 3 {
+		t.Fatalf("want 3 profiles, got %#v", body["profiles"])
+	}
+
+	ids := map[string]bool{}
+	raw := resp.Body.String()
+	// Export must only surface the downstream key already readable by admin —
+	// never invent upstream tokens / passwords / other secrets.
+	forbidden := []string{"session-token", "sk-default-key", "sk-token-key", "password", "client_secret"}
+	for _, bad := range forbidden {
+		if strings.Contains(raw, bad) {
+			t.Fatalf("export leaked unexpected secret material %q", bad)
+		}
+	}
+	if !strings.Contains(raw, key) {
+		t.Fatal("export missing the downstream key value")
+	}
+
+	for _, p := range profiles {
+		m, _ := p.(map[string]any)
+		id, _ := m["id"].(string)
+		ids[id] = true
+		if m["snippet"] == nil || m["content"] == nil {
+			t.Fatalf("profile %s missing snippet/content: %#v", id, m)
+		}
+	}
+	for _, want := range []string{exportProfileOpenAI, exportProfileCherry, exportProfileGeneric} {
+		if !ids[want] {
+			t.Fatalf("missing profile %s in %#v", want, ids)
+		}
+	}
+}
+
+func TestDownstreamKeysExport_CherryAndGenericShapes(t *testing.T) {
+	keyID, key, name, r := seedExportDownstreamKey(t)
+
+	resp := doGet(t, r, "/api/downstream-keys/"+itoa(keyID)+"/export?profile=cherry&baseUrl=http://127.0.0.1:4000")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("cherry export %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &body)
+	profiles := body["profiles"].([]any)
+	p := profiles[0].(map[string]any)
+	content := p["content"].(map[string]any)
+	if content["apiKey"] != key || content["apiHost"] != "http://127.0.0.1:4000" {
+		t.Fatalf("cherry content=%#v", content)
+	}
+	if content["name"] != name {
+		t.Fatalf("cherry name=%v", content["name"])
+	}
+
+	resp = doGet(t, r, "/api/downstream-keys/"+itoa(keyID)+"/export?profile=generic&baseUrl=https://metapi.example.com")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("generic export %d: %s", resp.Code, resp.Body.String())
+	}
+	json.Unmarshal(resp.Body.Bytes(), &body)
+	profiles = body["profiles"].([]any)
+	p = profiles[0].(map[string]any)
+	content = p["content"].(map[string]any)
+	if content["apiKey"] != key {
+		t.Fatalf("generic apiKey=%v", content["apiKey"])
+	}
+	if content["openaiBaseUrl"] != "https://metapi.example.com/v1" {
+		t.Fatalf("generic openaiBaseUrl=%v", content["openaiBaseUrl"])
+	}
+	if content["openaiCompatible"] != true {
+		t.Fatalf("openaiCompatible=%v", content["openaiCompatible"])
+	}
+}
+
+func TestDownstreamKeysExport_InvalidProfileAndMissingKey(t *testing.T) {
+	keyID, _, _, r := seedExportDownstreamKey(t)
+
+	resp := doGet(t, r, "/api/downstream-keys/"+itoa(keyID)+"/export?profile=webdav&baseUrl=https://x.example")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("invalid profile returned %d, want 400: %s", resp.Code, resp.Body.String())
+	}
+
+	resp = doGet(t, r, "/api/downstream-keys/999999/export?baseUrl=https://x.example")
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("missing key returned %d, want 404: %s", resp.Code, resp.Body.String())
+	}
+
+	resp = doGet(t, r, "/api/downstream-keys/not-an-id/export?baseUrl=https://x.example")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("bad id returned %d, want 400: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestDownstreamKeysExport_PublicBaseURLEnv(t *testing.T) {
+	keyID, _, _, r := seedExportDownstreamKey(t)
+	t.Setenv("PUBLIC_BASE_URL", "https://from-env.example")
+	// Ensure query baseUrl still wins when present.
+	resp := doGet(t, r, "/api/downstream-keys/"+itoa(keyID)+"/export?profile=openai&baseUrl=https://from-query.example")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("export %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &body)
+	if body["baseUrl"] != "https://from-query.example" {
+		t.Fatalf("query override failed: %v", body["baseUrl"])
+	}
+
+	resp = doGet(t, r, "/api/downstream-keys/"+itoa(keyID)+"/export?profile=openai")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("env export %d: %s", resp.Code, resp.Body.String())
+	}
+	json.Unmarshal(resp.Body.Bytes(), &body)
+	if body["baseUrl"] != "https://from-env.example" {
+		t.Fatalf("env baseUrl=%v", body["baseUrl"])
+	}
+}
+
+func TestDownstreamKeysExport_RequestHostFallback(t *testing.T) {
+	keyID, _, _, r := seedExportDownstreamKey(t)
+	// Clear env so request host is used.
+	t.Setenv("PUBLIC_BASE_URL", "")
+	_ = os.Unsetenv("PUBLIC_BASE_URL")
+
+	req := httptest.NewRequest("GET", "/api/downstream-keys/"+itoa(keyID)+"/export?profile=generic", nil)
+	req.Host = "admin.metapi.local:4000"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("host export %d: %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["baseUrl"] != "https://admin.metapi.local:4000" {
+		t.Fatalf("host baseUrl=%v", body["baseUrl"])
+	}
+}
+
+func TestDownstreamKeysExport_SettingsPublicBaseURL(t *testing.T) {
+	db, r := setupDownstreamKeysTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		`INSERT INTO downstream_api_keys
+		(name, key, enabled, used_cost, used_requests, created_at, updated_at)
+		VALUES ('settings-export', 'sk-settings-export-key', 1, 0, 0, ?, ?)`,
+		now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert key: %v", err)
+	}
+	keyID, _ := res.LastInsertId()
+
+	if _, err := db.Exec(`INSERT INTO settings (key, value) VALUES (?, ?)`, "public_base_url", `"https://from-settings.example"`); err != nil {
+		t.Fatalf("insert settings: %v", err)
+	}
+	t.Setenv("PUBLIC_BASE_URL", "")
+	_ = os.Unsetenv("PUBLIC_BASE_URL")
+
+	resp := doGet(t, r, "/api/downstream-keys/"+itoa(keyID)+"/export?profile=openai")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("settings export %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &body)
+	if body["baseUrl"] != "https://from-settings.example" {
+		t.Fatalf("settings baseUrl=%v", body["baseUrl"])
+	}
+}
+
+func TestNormalizeExportBaseURL(t *testing.T) {
+	got, errMsg := normalizeExportBaseURL("https://a.example/v1/extra?x=1")
+	if errMsg != "" || got != "https://a.example" {
+		t.Fatalf("path strip => (%q, %q)", got, errMsg)
+	}
+	got, errMsg = normalizeExportBaseURL("metapi.example.com")
+	if errMsg != "" || got != "https://metapi.example.com" {
+		t.Fatalf("scheme-less => (%q, %q)", got, errMsg)
+	}
+	_, errMsg = normalizeExportBaseURL("ftp://bad")
+	if errMsg == "" {
+		t.Fatal("expected ftp reject")
+	}
+}
+
+func TestBuildCredentialExportProfilesFilter(t *testing.T) {
+	all := buildCredentialExportProfiles("n", "sk-abc123", "https://x.example", "")
+	if len(all) != 3 {
+		t.Fatalf("all len=%d", len(all))
+	}
+	one := buildCredentialExportProfiles("n", "sk-abc123", "https://x.example", "generic")
+	if len(one) != 1 || one[0]["id"] != exportProfileGeneric {
+		t.Fatalf("filter generic => %#v", one)
+	}
+}


### PR DESCRIPTION
## Summary
- Admin-only `GET /api/downstream-keys/{id}/export` emits versioned client config snippets (`openai` env, `cherry` JSON, `generic` JSON) from a downstream key + public base URL.
- Base URL resolution: `?baseUrl=` → `PUBLIC_BASE_URL` → settings `public_base_url` → request host; never invents secrets beyond the key admins can already read.
- Docs: `docs/analysis/credential-export.md` + brief `docs/api.md` note; MASTER progress update.

Closes #120

## Test plan
- [x] `go test ./handler/admin/ -count=1 -run DownstreamKeysExport`
- [x] pre-push local CI: `go vet ./... && go test ./... -count=1 -race`