### PR TITLE
docs(release): prepare v0.8.0 changelog + ops residual plan #157

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.0] — 2026-07-17
+
+### Added
+- Competitive learn program (M-COMPETE) fully implemented for [learn] issues #110–#121:
+  - Request trace IDs across retries/failovers (#110)
+  - Per-request cost attribution + cache token types (#111)
+  - TTFT/first-byte signals in routing health (#113)
+  - Cross-site model price comparison APIs (#112)
+  - Background channel health probing (#114)
+  - Pluggable routing strategies: least_busy / lowest_latency / lowest_cost (#115)
+  - Downstream-key RPM/TPM soft admission + Retry-After (#116)
+  - Richer Prometheus histograms/labels + MetricsObserver export hook (#117)
+  - Optional Redis-backed shared RPM admission (fail-open, zero third-party dep) (#118)
+  - Admin forced-channel test harness (#119)
+  - Client credential export adapters (openai/cherry/generic) (#120)
+  - Usage heatmaps + slow-request ranking stats (#121)
+- Enterprise ops residual milestone opened for remaining admin/proxy stubs (#154–#158).
+
+### Changed
+- MASTER progress: M-COMPETE learn #110–#121 marked complete; stack remains TS 7.0.2 + React 19.2.7 + Vite 8.1.5 + Go 1.26.4.
+
+### Notes
+- `vulncheck` may still fail on Go 1.26.4 stdlib advisory GO-2026-5856; CI continues with continue-on-error until a Go patch is available.
+- Residual operator stubs (site probe-now stream, /v1/files 501, marketplace/token-candidates, notify/LDOH/tasks) tracked under milestone Enterprise ops residual + v0.8.0.
+
 ## [v0.7.0] — 2026-07-17
 
 ### Added

--- a/docs/plan/enterprise-ops-residual.md
+++ b/docs/plan/enterprise-ops-residual.md
@@ -1,0 +1,20 @@
+# Enterprise ops residual + v0.8.0
+
+**Milestone**: https://github.com/TokenDanceLab/metapi-go/milestone/9  
+**Opened**: 2026-07-17
+
+## Why
+After stack modernization, gap pack, and M-COMPETE learn #110–#121, remaining enterprise friction is mostly **operator-facing stubs** (probe admin APIs, files proxy, models marketplace surfaces, notify/LDOH/tasks).
+
+## Issues
+| # | Title | Priority | Lane |
+|--:|:------|:---------|:-----|
+| 154 | Wire site/model probe admin APIs | P0 | ops-probe |
+| 155 | /v1/files proxy | P1 | ops-files |
+| 156 | marketplace / token-candidates / model-check | P1 | ops-admin |
+| 157 | Release v0.8.0 | P0 | ops-release |
+| 158 | notify / LDOH / tasks / announcements stubs | P1 | ops-admin |
+
+## Release policy
+- **v0.8.0** documents completed stack + feature + compete learn on master.
+- Ops residual may land in the same train if green before tag, else **v0.8.1**.

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -84,11 +84,11 @@
 |------|--------|
 | Milestone | https://github.com/TokenDanceLab/metapi-go/milestone/8 |
 | Local clones | operator-only checkouts under competitors/ (not product SSOT) |
-| Scope | Docs-first competitive learning; matrix `docs/analysis/competitive/`; `[learn]` **#110–#121** (open) |
+| Scope | Competitive learning matrix + implemented `[learn]` **#110–#121** (closed) |
 | Peers | [all-api-hub](https://github.com/qixing-jk/all-api-hub) · [axonhub](https://github.com/looplj/axonhub) · [new-api](https://github.com/QuantumNous/new-api) · [litellm](https://github.com/BerriAI/litellm) |
 | Matrix / backlog | `docs/analysis/competitive/matrix.md` · issues **#110–#121** |
 | Inventory | `docs/analysis/competitive/` — [README](../analysis/competitive/README.md) · [sources](../analysis/competitive/sources.md) · [matrix](../analysis/competitive/matrix.md) |
-| Status | Matrix L1–L12 published; `[learn]` backlog issues created under M-COMPETE. No product code until scheduled |
+| Status | Matrix L1–L12 published; `[learn]` #110–#121 implemented and closed |
 
 
 ## Hardening Results

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -74,8 +74,8 @@
 | Milestone | https://github.com/TokenDanceLab/metapi-go/milestone/6 · Roadmap `docs/plan/feature-complete-roadmap.md` |
 | Shipped infra | Site max concurrency · per-key `proxy_url` · group route rebuild |
 | Closed F1+P1 | Full gap backlog #38–#56 (PRs #74–#94) |
-| In flight WFs | none — M-COMPETE learn #110–#121 complete |
-| Next | Optional: v0.8.0 tag; Go 1.26.5 when available for vulncheck; original gap product backlog as needed |
+| In flight WFs | Enterprise ops residual #154–#158 (probe/files/models/admin stubs) + release #157 |
+| Next | Land ops residual #154–#158; tag v0.8.0; Go 1.26.5 when available for vulncheck |
 | Residual CI | `vulncheck` GO-2026-5856 (Go 1.26.4); frontend occasional `EnvironmentTeardownError` flake (tests pass) |
 
 ### M-COMPETE notes (active)


### PR DESCRIPTION
## Summary
- CHANGELOG [v0.8.0] for stack + gap + M-COMPETE #110–#121
- MASTER in-flight points at ops residual #154–#158
- Plan: docs/plan/enterprise-ops-residual.md

Tag `v0.8.0` after merge (or after ops PRs if they land first).

Refs #157 (tag step remains after merge)