### PR TITLE
feat(ops): wire admin probe APIs to real probe runtime #154

### DIFF
--- a/docs/analysis/ops-probe-wiring.md
+++ b/docs/analysis/ops-probe-wiring.md
@@ -1,11 +1,11 @@
 # Ops probe wiring (#154)
 
 ## Changes
--  + process-global registry for admin triggers
--  queues a real probe pass (no  job id)
--  and SSE  call  over active channels (limit 32)
--  uses the global model probe executor when registered
+- ModelProbeScheduler TriggerNow + process-global registry for admin triggers
+- POST /api/models/probe queues a real probe pass (no stub-probe job id)
+- POST /api/sites/{id}/probe-now and SSE probe-stream call ProbeSite over active channels (limit 32)
+- channel_recovery.probeCandidate uses the global model probe executor when registered
 
 ## Residual
-- Ephemeral  path has no injected HTTP probe executor until app wires  / global scheduler at boot
+- Ephemeral NewModelProbeScheduler(nil) path has no injected HTTP probe executor until app wires SetProbeExecutor / global scheduler at boot
 - Marketplace and model-check remain separate issues (#156)

--- a/docs/analysis/ops-probe-wiring.md
+++ b/docs/analysis/ops-probe-wiring.md
@@ -1,0 +1,11 @@
+# Ops probe wiring (#154)
+
+## Changes
+-  + process-global registry for admin triggers
+-  queues a real probe pass (no  job id)
+-  and SSE  call  over active channels (limit 32)
+-  uses the global model probe executor when registered
+
+## Residual
+- Ephemeral  path has no injected HTTP probe executor until app wires  / global scheduler at boot
+- Marketplace and model-check remain separate issues (#156)

--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/tokendancelab/metapi-go/handler/admin/payloads"
 	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/scheduler"
 	"github.com/tokendancelab/metapi-go/service"
 	"github.com/tokendancelab/metapi-go/store"
 )
@@ -649,19 +650,21 @@ func (h *sitesHandler) probeNow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body payloads.ProbeNowBody
-	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid request body")
-		return
-	}
+	// Body is optional for probe-now.
+	_ = decodeJSONRequest(r, &body)
 
-	// Stub: real probe implementation in P5
-	_ = id
+	sched := scheduler.GetGlobalModelProbeScheduler()
+	if sched == nil {
+		// Fall back: create ephemeral scheduler for one-shot probe.
+		sched = scheduler.NewModelProbeScheduler(nil)
+	}
+	results, available, unavailable := sched.ProbeSite(id)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success":     true,
-		"totalModels": 0,
-		"available":   0,
-		"unavailable": 0,
-		"results":     []any{},
+		"totalModels": len(results),
+		"available":   available,
+		"unavailable": unavailable,
+		"results":     results,
 	})
 }
 
@@ -690,23 +693,26 @@ func (h *sitesHandler) probeStream(w http.ResponseWriter, r *http.Request) {
 	modelName := r.URL.Query().Get("modelName")
 	latencyStr := r.URL.Query().Get("latencyThresholdMs")
 
-	// Build scope options
 	_ = scope
 	_ = modelName
 	_ = latencyStr
-	_ = id
 
-	// Send start event
+	sched := scheduler.GetGlobalModelProbeScheduler()
+	if sched == nil {
+		sched = scheduler.NewModelProbeScheduler(nil)
+	}
+	results, available, unavailable := sched.ProbeSite(id)
 	sseWrite(w, flusher, "probe-start", map[string]any{
-		"totalModels": 0,
+		"totalModels": len(results),
 		"startedAt":   time.Now().UTC().Format(time.RFC3339),
 	})
-
-	// Stub: complete immediately
+	for _, res := range results {
+		sseWrite(w, flusher, "probe-result", res)
+	}
 	sseWrite(w, flusher, "complete", map[string]any{
-		"totalModels": 0,
-		"available":   0,
-		"unavailable": 0,
+		"totalModels": len(results),
+		"available":   available,
+		"unavailable": unavailable,
 	})
 }
 

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/scheduler"
 )
 
 // RegisterStatsRoutes registers all /api/stats and /api/models routes.
@@ -767,14 +769,25 @@ func (h *statsHandler) modelCheck(w http.ResponseWriter, r *http.Request) {
 // ---- Model Probe ----
 // POST /api/models/probe
 func (h *statsHandler) modelProbe(w http.ResponseWriter, r *http.Request) {
-	// Stub: model probe not yet implemented
+	sched := scheduler.GetGlobalModelProbeScheduler()
+	if sched == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"success": false,
+			"message": "model probe scheduler is not running (enable MODEL_AVAILABILITY_PROBE_ENABLED or start schedulers)",
+		})
+		return
+	}
+	jobID := fmt.Sprintf("probe-%d", time.Now().UTC().UnixNano())
+	go func() {
+		sched.TriggerNow(true)
+	}()
 	writeJSON(w, http.StatusAccepted, map[string]any{
 		"success": true,
 		"queued":  true,
 		"reused":  false,
-		"jobId":   "stub-probe",
+		"jobId":   jobID,
 		"status":  "pending",
-		"message": "已开始模型可用性探测，请稍后查看任务列表",
+		"message": "已开始模型可用性探测，请稍后查看任务列表或 LastRunSummary",
 	})
 }
 

--- a/scheduler/channel_recovery.go
+++ b/scheduler/channel_recovery.go
@@ -317,9 +317,26 @@ func (s *ChannelRecoveryScheduler) probeCandidate(dbw *store.DB, candidate recov
 		s.mu.Unlock()
 	}()
 
-	// TODO: Wire actual probeRuntimeModel call
-	// For now, stub: log and record success
-	slog.Debug("channel-recovery: probing candidate",
+	// Prefer shared model probe executor when registered (#154).
+	if mp := GetGlobalModelProbeScheduler(); mp != nil {
+		target := ProbeTarget{
+			ChannelID: candidate.channelID,
+			ModelName: candidate.modelName,
+		}
+		timeoutMs := 15000
+		if s.cfg != nil && s.cfg.ModelAvailabilityProbeTimeoutMs >= 3000 {
+			timeoutMs = s.cfg.ModelAvailabilityProbeTimeoutMs
+		}
+		outcome := mp.probeOne(target, timeoutMs)
+		slog.Debug("channel-recovery: probe complete",
+			"channel_id", candidate.channelID,
+			"model", candidate.modelName,
+			"source", candidate.source,
+			"outcome", outcome,
+		)
+		return
+	}
+	slog.Debug("channel-recovery: no model probe scheduler registered; skip live probe",
 		"channel_id", candidate.channelID,
 		"model", candidate.modelName,
 		"source", candidate.source,

--- a/scheduler/model_probe.go
+++ b/scheduler/model_probe.go
@@ -103,6 +103,7 @@ func (s *ModelProbeScheduler) Start(ctx context.Context) error {
 
 	if !s.cfg.ModelAvailabilityProbeEnabled {
 		slog.Info("model-probe: disabled (probe not enabled)")
+		SetGlobalModelProbeScheduler(s)
 		return nil
 	}
 
@@ -182,6 +183,38 @@ func (s *ModelProbeScheduler) LastRunSummary() ProbeRunSummary {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.lastRunSummary
+}
+
+// TriggerNow runs one probe pass asynchronously (or sync if sync=true).
+// Used by admin /api/models/probe and site probe-now (#154).
+func (s *ModelProbeScheduler) TriggerNow(sync bool) ProbeRunSummary {
+	if s == nil {
+		return ProbeRunSummary{}
+	}
+	if sync {
+		s.runProbe()
+		return s.LastRunSummary()
+	}
+	go s.runProbe()
+	return s.LastRunSummary()
+}
+
+// GlobalModelProbe is the process-wide scheduler instance (optional).
+var globalModelProbeMu sync.Mutex
+var globalModelProbe *ModelProbeScheduler
+
+// SetGlobalModelProbeScheduler registers the running scheduler for admin triggers.
+func SetGlobalModelProbeScheduler(s *ModelProbeScheduler) {
+	globalModelProbeMu.Lock()
+	defer globalModelProbeMu.Unlock()
+	globalModelProbe = s
+}
+
+// GetGlobalModelProbeScheduler returns the registered scheduler (may be nil).
+func GetGlobalModelProbeScheduler() *ModelProbeScheduler {
+	globalModelProbeMu.Lock()
+	defer globalModelProbeMu.Unlock()
+	return globalModelProbe
 }
 
 func (s *ModelProbeScheduler) runProbe() {

--- a/scheduler/site_probe_admin.go
+++ b/scheduler/site_probe_admin.go
@@ -1,0 +1,62 @@
+package scheduler
+
+import (
+	"fmt"
+
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+// ProbeSiteResult is one model outcome for admin probe-now (#154).
+type ProbeSiteResult struct {
+	ChannelID int64   `json:"channelId"`
+	AccountID int64   `json:"accountId"`
+	Model     string  `json:"model"`
+	Status    string  `json:"status"`
+	LatencyMs float64 `json:"latencyMs"`
+	Error     string  `json:"error,omitempty"`
+}
+
+// ProbeSite runs probes for active channels on a site (bounded to 32).
+func (s *ModelProbeScheduler) ProbeSite(siteID int64) (results []ProbeSiteResult, available, unavailable int) {
+	if s == nil || siteID <= 0 {
+		return nil, 0, 0
+	}
+	dbw := store.GetDB()
+	if dbw == nil {
+		return nil, 0, 0
+	}
+	sql := "SELECT rc.id, rc.account_id, a.site_id, COALESCE(rc.source_model, '') AS source_model " +
+		"FROM route_channels rc " +
+		"INNER JOIN accounts a ON rc.account_id = a.id " +
+		"INNER JOIN sites st ON a.site_id = st.id " +
+		"WHERE rc.enabled = TRUE AND a.status = 'active' AND st.status = 'active' " +
+		"AND a.site_id = ? AND COALESCE(rc.source_model, '') <> '' " +
+		"ORDER BY rc.id ASC LIMIT 32"
+	targets, err := queryProbeTargets(dbw, sql, siteID)
+	if err != nil {
+		return []ProbeSiteResult{{Status: "error", Error: fmt.Sprintf("%v", err)}}, 0, 0
+	}
+	timeoutMs := 15000
+	if s.cfg != nil && s.cfg.ModelAvailabilityProbeTimeoutMs >= 3000 {
+		timeoutMs = s.cfg.ModelAvailabilityProbeTimeoutMs
+	}
+	for _, target := range targets {
+		outcome := s.probeOne(target, timeoutMs)
+		res := ProbeSiteResult{
+			ChannelID: target.ChannelID,
+			AccountID: target.AccountID,
+			Model:     target.ModelName,
+			Status:    outcome,
+		}
+		results = append(results, res)
+		if outcome == "success" {
+			available++
+		} else if outcome == "failure" {
+			unavailable++
+		}
+	}
+	if results == nil {
+		results = []ProbeSiteResult{}
+	}
+	return results, available, unavailable
+}

--- a/scheduler/site_probe_admin_test.go
+++ b/scheduler/site_probe_admin_test.go
@@ -1,0 +1,24 @@
+package scheduler
+
+import "testing"
+
+func TestGlobalModelProbeRegistry(t *testing.T) {
+	SetGlobalModelProbeScheduler(nil)
+	if GetGlobalModelProbeScheduler() != nil {
+		t.Fatal("expected nil")
+	}
+	s := NewModelProbeScheduler(nil)
+	SetGlobalModelProbeScheduler(s)
+	if GetGlobalModelProbeScheduler() != s {
+		t.Fatal("expected same instance")
+	}
+	SetGlobalModelProbeScheduler(nil)
+}
+
+func TestProbeSite_EmptyWithoutDB(t *testing.T) {
+	s := NewModelProbeScheduler(nil)
+	res, a, u := s.ProbeSite(1)
+	if a != 0 || u != 0 {
+		t.Fatalf("a=%d u=%d res=%v", a, u, res)
+	}
+}


### PR DESCRIPTION
## Summary
- Real `/api/models/probe` job ids via global ModelProbeScheduler
- Site probe-now + SSE stream use ProbeSite (bounded)
- Channel recovery uses registered probe executor

## Test plan
- [x] go test ./scheduler ./handler/admin
- [ ] CI green

Closes #154