### PR TITLE
feat(admin): replace residual ops stubs (notify/monitor/tasks/announcements) #158

### DIFF
--- a/docs/analysis/ops-admin-stubs.md
+++ b/docs/analysis/ops-admin-stubs.md
@@ -1,0 +1,34 @@
+# Ops admin stubs residual (#158)
+
+**Date**: 2026-07-17  
+**Issue**: [#158](https://github.com/TokenDanceLab/metapi-go/issues/158)  
+**Lane**: `lane:ops-admin`
+
+## Scope
+
+Replace remaining admin ops stubs that previously returned fake success:
+
+| Endpoint | Previous stub | New behavior |
+|----------|---------------|--------------|
+| `POST /api/settings/notify/test` | Always `success:true` with `0/0` | Real `notify.SendNotification` with `bypassThrottle/requireChannel/throwOnFailure`; clear `400` when no channel configured or all sends fail |
+| `PUT /api/monitor/config` | Fake success, never persisted | Validates + persists `monitor_ldoh_cookie` setting; clear cookie supported |
+| `ALL /monitor-proxy/ldoh*` | Fake/partial 400 stub | Requires monitor session cookie + configured LDOH cookie; reverse-proxies `https://ldoh.105117.xyz` with HTML/JS/CSS/JSON rewrite |
+| `GET /api/tasks` / `GET /api/tasks/:id` | Always empty / not found | In-memory background task registry with camelCase schema; empty list is honest success |
+| `POST /api/site-announcements/sync` | Fake `taskId:"stub"` | Queues real background task (`site-announcements-sync`) that pulls announcements via platform adapters |
+
+## Residuals / honest limits
+
+1. **Notify test** depends on operator-configured channels (webhook/bark/serverchan/telegram/smtp). With none configured, response is `400` + `no notification channels configured` (not silent success).
+2. **LDOH reverse proxy** needs a valid operator-provided `ld_auth_session` cookie and a prior `POST /api/monitor/session`. Upstream network failures return `502`, never fake `success:true`.
+3. **Background task registry** is process-local (in-memory), matching the TS service model. Multi-instance deployments do not share task state.
+4. **Announcement sync** is best-effort per site: unsupported platforms increment `unsupported`; adapter/network failures are recorded in `failedSites` inside the task result rather than inventing a queued success without work.
+
+## Tests
+
+`handler/admin/ops_admin_stubs_test.go` covers:
+
+- notify test 400 when unconfigured
+- monitor config persist/mask + invalid cookie 400
+- LDOH proxy 401 (no session) / 400 (no cookie) without fake success
+- tasks empty schema + camelCase list/get after `StartBackgroundTask`
+- announcements sync returns real `taskId` and completes a registry task

--- a/handler/admin/monitor.go
+++ b/handler/admin/monitor.go
@@ -1,8 +1,12 @@
 package admin
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
@@ -17,7 +21,7 @@ func RegisterMonitorRoutes(r chi.Router, db *sqlx.DB, cfg *config.Config) {
 	r.Put("/api/monitor/config", handler.saveConfig)
 	r.Post("/api/monitor/session", handler.createSession)
 
-	// LDOH proxy routes - rate limited at 60 req/min
+	// LDOH proxy routes - rate limited at 60 req/min at the router layer when wired.
 	r.HandleFunc("/monitor-proxy/ldoh", handler.ldohProxy)
 	r.HandleFunc("/monitor-proxy/ldoh/", handler.ldohProxy)
 	r.HandleFunc("/monitor-proxy/ldoh/*", handler.ldohProxy)
@@ -30,6 +34,7 @@ type monitorHandler struct {
 
 const ldohCookieSettingKey = "monitor_ldoh_cookie"
 const monitorAuthCookie = "meta_monitor_auth"
+const ldohBaseURL = "https://ldoh.105117.xyz"
 
 // GET /api/monitor/config
 func (h *monitorHandler) getConfig(w http.ResponseWriter, r *http.Request) {
@@ -43,16 +48,77 @@ func (h *monitorHandler) getConfig(w http.ResponseWriter, r *http.Request) {
 // PUT /api/monitor/config
 func (h *monitorHandler) saveConfig(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		LdohCookie string `json:"ldohCookie"`
+		LdohCookie *string `json:"ldohCookie"`
 	}
-	// Read raw body
-	_ = body
+	rawBody, readErr := readAdminJSONBody(r.Body)
+	if readErr != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"success": false,
+			"message": "Invalid request body",
+		})
+		return
+	}
+	if len(strings.TrimSpace(string(rawBody))) > 0 {
+		if err := rejectDuplicateJSONKeys(rawBody); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{
+				"success": false,
+				"message": "Invalid request body",
+			})
+			return
+		}
+		if err := json.Unmarshal(rawBody, &body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{
+				"success": false,
+				"message": "Invalid request body",
+			})
+			return
+		}
+	}
 
-	// Stub: persist LDOH cookie setting
+	raw := ""
+	if body.LdohCookie != nil {
+		raw = strings.TrimSpace(*body.LdohCookie)
+	}
+
+	if raw == "" {
+		if err := upsertSettingDB(h.db, ldohCookieSettingKey, ""); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]any{
+				"success": false,
+				"message": "Failed to clear LDOH cookie",
+			})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"success":              true,
+			"message":              "LDOH Cookie 已清空",
+			"ldohCookieConfigured": false,
+			"ldohCookieMasked":     "",
+		})
+		return
+	}
+
+	normalized := normalizeLdohCookie(raw)
+	if !strings.HasPrefix(normalized, "ld_auth_session=") || len(normalized) < 24 {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"success": false,
+			"message": "Cookie 格式无效，请填写 ld_auth_session 或其值",
+		})
+		return
+	}
+
+	if err := upsertSettingDB(h.db, ldohCookieSettingKey, normalized); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{
+			"success": false,
+			"message": "Failed to save LDOH cookie",
+		})
+		return
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success":              true,
-		"message":              "LDOH config stub — not yet implemented",
-		"ldohCookieConfigured": false,
+		"message":              "LDOH Cookie 已保存",
+		"ldohCookieConfigured": true,
+		"ldohCookieMasked":     maskValue(normalized),
 	})
 }
 
@@ -66,37 +132,239 @@ func (h *monitorHandler) createSession(w http.ResponseWriter, r *http.Request) {
 
 // GET/POST/ALL /monitor-proxy/ldoh and /monitor-proxy/ldoh/*
 func (h *monitorHandler) ldohProxy(w http.ResponseWriter, r *http.Request) {
-	// Stub: LDOH reverse proxy not yet implemented
-	writeJSON(w, http.StatusBadRequest, map[string]any{
-		"error": "LDOH proxy not yet implemented",
-	})
+	if !h.ensureMonitorAuth(r) {
+		writeJSON(w, http.StatusUnauthorized, map[string]any{
+			"error": "Missing or invalid monitor session",
+		})
+		return
+	}
+
+	storedCookie := getSettingValue(h.db, ldohCookieSettingKey)
+	if storedCookie == "" {
+		// Keep plain-text 400 parity with TS for the unconfigured cookie path.
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("LDOH cookie not configured"))
+		return
+	}
+
+	wildcardPath := resolveLdohProxyPath(r)
+	targetURL, err := url.Parse(ldohBaseURL + "/" + wildcardPath)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid proxy path"})
+		return
+	}
+	q := targetURL.Query()
+	for key, values := range r.URL.Query() {
+		for _, value := range values {
+			q.Add(key, value)
+		}
+	}
+	targetURL.RawQuery = q.Encode()
+
+	method := strings.ToUpper(r.Method)
+	var body io.Reader
+	if method != http.MethodGet && method != http.MethodHead {
+		body = r.Body
+	}
+
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), method, targetURL.String(), body)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]any{"error": "failed to build upstream request"})
+		return
+	}
+	upstreamReq.Header.Set("Cookie", storedCookie)
+	upstreamReq.Header.Set("Accept", firstNonEmpty(r.Header.Get("Accept"), "*/*"))
+	upstreamReq.Header.Set("Accept-Language", firstNonEmpty(r.Header.Get("Accept-Language"), "zh-CN,zh;q=0.9,en;q=0.8"))
+	upstreamReq.Header.Set("User-Agent", firstNonEmpty(r.Header.Get("User-Agent"), "metapiMonitorProxy/1.0"))
+	if ct := r.Header.Get("Content-Type"); ct != "" {
+		upstreamReq.Header.Set("Content-Type", ct)
+	}
+	if referer := r.Header.Get("Referer"); referer != "" {
+		upstreamReq.Header.Set("Referer", strings.ReplaceAll(referer, "/monitor-proxy/ldoh", ""))
+	}
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	upstreamResp, err := client.Do(upstreamReq)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]any{
+			"error": "LDOH upstream request failed: " + err.Error(),
+		})
+		return
+	}
+	defer upstreamResp.Body.Close()
+
+	contentType := upstreamResp.Header.Get("Content-Type")
+	if location := rewriteLocationHeader(upstreamResp.Header.Get("Location")); location != "" {
+		w.Header().Set("Location", location)
+	}
+	if contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+	}
+	if cacheControl := upstreamResp.Header.Get("Cache-Control"); cacheControl != "" {
+		w.Header().Set("Cache-Control", cacheControl)
+	}
+
+	w.WriteHeader(upstreamResp.StatusCode)
+
+	if shouldRewriteProxyBody(contentType) {
+		raw, readErr := io.ReadAll(upstreamResp.Body)
+		if readErr != nil {
+			return
+		}
+		_, _ = w.Write([]byte(rewriteProxyText(string(raw))))
+		return
+	}
+
+	_, _ = io.Copy(w, upstreamResp.Body)
+}
+
+func (h *monitorHandler) ensureMonitorAuth(r *http.Request) bool {
+	cookies := parseCookieHeader(r.Header.Get("Cookie"))
+	return cookies[monitorAuthCookie] == h.cfg.AuthToken
+}
+
+func parseCookieHeader(raw string) map[string]string {
+	result := map[string]string{}
+	if raw == "" {
+		return result
+	}
+	for _, part := range strings.Split(raw, ";") {
+		entry := strings.TrimSpace(part)
+		if entry == "" {
+			continue
+		}
+		idx := strings.Index(entry, "=")
+		if idx <= 0 {
+			continue
+		}
+		key := strings.TrimSpace(entry[:idx])
+		value := strings.TrimSpace(entry[idx+1:])
+		if key == "" {
+			continue
+		}
+		result[key] = value
+	}
+	return result
+}
+
+func normalizeLdohCookie(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.Contains(trimmed, "ld_auth_session=") {
+		firstPair := strings.TrimSpace(strings.Split(trimmed, ";")[0])
+		if strings.HasPrefix(firstPair, "ld_auth_session=") {
+			return firstPair
+		}
+	}
+	return "ld_auth_session=" + trimmed
+}
+
+func resolveLdohProxyPath(r *http.Request) string {
+	cleanPath := r.URL.Path
+	prefix := "/monitor-proxy/ldoh"
+	if cleanPath == prefix || cleanPath == prefix+"/" {
+		return ""
+	}
+	if strings.HasPrefix(cleanPath, prefix+"/") {
+		return strings.TrimPrefix(cleanPath, prefix+"/")
+	}
+	if star := chi.URLParam(r, "*"); star != "" {
+		return strings.TrimPrefix(star, "/")
+	}
+	return ""
+}
+
+func rewriteProxyText(text string) string {
+	replacer := strings.NewReplacer(
+		"https://ldoh.105117.xyz/", "/monitor-proxy/ldoh/",
+		`https:\/\/ldoh.105117.xyz\/`, `\/monitor-proxy\/ldoh\/`,
+		`src="/`, `src="/monitor-proxy/ldoh/`,
+		`src='/`, `src='/monitor-proxy/ldoh/`,
+		`href="/`, `href="/monitor-proxy/ldoh/`,
+		`href='/`, `href='/monitor-proxy/ldoh/`,
+		`action="/`, `action="/monitor-proxy/ldoh/`,
+		`action='/`, `action='/monitor-proxy/ldoh/`,
+		`"/_next/`, `"/monitor-proxy/ldoh/_next/`,
+		`'/_next/`, `'/monitor-proxy/ldoh/_next/`,
+		`"\/api/`, `"\/monitor-proxy\/ldoh\/api/`,
+		`'/api/`, `'/monitor-proxy/ldoh/api/`,
+		`"/api/`, `"/monitor-proxy/ldoh/api/`,
+	)
+	return replacer.Replace(text)
+}
+
+func rewriteLocationHeader(location string) string {
+	if location == "" {
+		return ""
+	}
+	if strings.HasPrefix(location, ldohBaseURL+"/") {
+		return "/monitor-proxy/ldoh/" + strings.TrimPrefix(location, ldohBaseURL+"/")
+	}
+	if strings.HasPrefix(location, "/") {
+		return "/monitor-proxy/ldoh" + location
+	}
+	return location
+}
+
+func shouldRewriteProxyBody(contentType string) bool {
+	ct := strings.ToLower(contentType)
+	return strings.Contains(ct, "text/html") ||
+		strings.Contains(ct, "application/javascript") ||
+		strings.Contains(ct, "text/javascript") ||
+		strings.Contains(ct, "text/css") ||
+		strings.Contains(ct, "application/json")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func maskValue(value string) string {
 	if value == "" {
 		return ""
 	}
-	if len(value) <= 10 {
-		if len(value) < 2 {
+	// Prefer masking the cookie value portion after '=' when present.
+	raw := value
+	if idx := strings.Index(value, "="); idx >= 0 {
+		raw = value[idx+1:]
+	}
+	if len(raw) <= 10 {
+		if len(raw) < 2 {
 			return "****"
 		}
-		return value[:2] + "****"
+		return raw[:2] + "****"
 	}
-	return value[:6] + "****" + value[len(value)-4:]
+	return raw[:6] + "****" + raw[len(raw)-4:]
 }
 
 func getSettingValue(db *sqlx.DB, key string) string {
 	var row struct {
 		Value *string `db:"value"`
 	}
-	err := db.Get(&row, "SELECT value FROM settings WHERE key = ?", key)
+	err := db.Get(&row, db.Rebind("SELECT value FROM settings WHERE key = ?"), key)
 	if err != nil || row.Value == nil {
 		return ""
 	}
 	// Value is stored as JSON-encoded string
-	val := *row.Value
-	val = strings.TrimSpace(val)
+	val := strings.TrimSpace(*row.Value)
 	if strings.HasPrefix(val, `"`) && strings.HasSuffix(val, `"`) {
+		var unquoted string
+		if err := json.Unmarshal([]byte(val), &unquoted); err == nil {
+			return unquoted
+		}
 		val = val[1 : len(val)-1]
 	}
 	return val

--- a/handler/admin/ops_admin_stubs_test.go
+++ b/handler/admin/ops_admin_stubs_test.go
@@ -1,0 +1,313 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func setupOpsAdminStubsTest(t *testing.T) (*store.DB, chi.Router, *config.Config) {
+	t.Helper()
+	resetBackgroundTasksForTests()
+
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	cfg := &config.Config{
+		AuthToken: "ops-admin-test-token",
+	}
+	config.Set(cfg)
+
+	r := chi.NewRouter()
+	RegisterNotifyRoutes(r)
+	RegisterMonitorRoutes(r, db.DB, cfg)
+	RegisterTasksRoutes(r, db.DB)
+	RegisterSiteAnnouncementsRoutes(r, db.DB)
+	return db, r, cfg
+}
+
+func TestNotifyTest_NoChannelConfiguredReturns400(t *testing.T) {
+	_, r, _ := setupOpsAdminStubsTest(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/notify/test", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s, want 400", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != false {
+		t.Fatalf("success = %v, want false", body["success"])
+	}
+	msg, _ := body["message"].(string)
+	if !strings.Contains(msg, "no notification channels configured") {
+		t.Fatalf("message = %q, want clear channel configuration error", msg)
+	}
+}
+
+func TestMonitorConfig_SaveAndGetRoundTrip(t *testing.T) {
+	db, r, _ := setupOpsAdminStubsTest(t)
+
+	cookie := "ld_auth_session=" + strings.Repeat("a", 24)
+	putResp := doPutJSON(t, r, "/api/monitor/config", map[string]any{
+		"ldohCookie": cookie,
+	})
+	if putResp.Code != http.StatusOK {
+		t.Fatalf("save status = %d body=%s", putResp.Code, putResp.Body.String())
+	}
+	var putBody map[string]any
+	if err := json.Unmarshal(putResp.Body.Bytes(), &putBody); err != nil {
+		t.Fatalf("decode put: %v", err)
+	}
+	if putBody["success"] != true || putBody["ldohCookieConfigured"] != true {
+		t.Fatalf("unexpected put body: %v", putBody)
+	}
+	if putBody["message"] == "LDOH config stub — not yet implemented" {
+		t.Fatalf("still returning stub message: %v", putBody)
+	}
+
+	getResp := doGet(t, r, "/api/monitor/config")
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("get status = %d body=%s", getResp.Code, getResp.Body.String())
+	}
+	var getBody map[string]any
+	if err := json.Unmarshal(getResp.Body.Bytes(), &getBody); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if getBody["ldohCookieConfigured"] != true {
+		t.Fatalf("configured = %v, want true", getBody["ldohCookieConfigured"])
+	}
+	masked, _ := getBody["ldohCookieMasked"].(string)
+	if masked == "" || strings.Contains(masked, strings.Repeat("a", 24)) {
+		t.Fatalf("masked cookie not applied: %q", masked)
+	}
+
+	// Ensure value persisted in settings table.
+	stored := getSettingValue(db.DB, ldohCookieSettingKey)
+	if stored != cookie {
+		t.Fatalf("stored cookie = %q, want %q", stored, cookie)
+	}
+}
+
+func TestMonitorConfig_RejectsInvalidCookie(t *testing.T) {
+	_, r, _ := setupOpsAdminStubsTest(t)
+
+	resp := doPutJSON(t, r, "/api/monitor/config", map[string]any{
+		"ldohCookie": "short",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	_ = json.Unmarshal(resp.Body.Bytes(), &body)
+	if body["success"] != false {
+		t.Fatalf("success = %v, want false", body["success"])
+	}
+}
+
+func TestMonitorLdohProxy_RequiresSessionAndCookie(t *testing.T) {
+	_, r, cfg := setupOpsAdminStubsTest(t)
+
+	// No session cookie → 401
+	req := httptest.NewRequest(http.MethodGet, "/monitor-proxy/ldoh/", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("no session status = %d body=%s, want 401", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), `"success":true`) {
+		t.Fatalf("must not fake success for missing session: %s", rec.Body.String())
+	}
+
+	// Session present but cookie not configured → 400 plain text
+	req2 := httptest.NewRequest(http.MethodGet, "/monitor-proxy/ldoh/", nil)
+	req2.AddCookie(&http.Cookie{Name: monitorAuthCookie, Value: cfg.AuthToken})
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("no cookie status = %d body=%s, want 400", rec2.Code, rec2.Body.String())
+	}
+	if !strings.Contains(rec2.Body.String(), "LDOH cookie not configured") {
+		t.Fatalf("body = %q, want unconfigured cookie message", rec2.Body.String())
+	}
+}
+
+func TestTasks_ListEmptySchemaAndGetMissing(t *testing.T) {
+	_, r, _ := setupOpsAdminStubsTest(t)
+
+	listResp := doGet(t, r, "/api/tasks?limit=10")
+	if listResp.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s", listResp.Code, listResp.Body.String())
+	}
+	var listBody map[string]any
+	if err := json.Unmarshal(listResp.Body.Bytes(), &listBody); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if listBody["success"] != true {
+		t.Fatalf("success = %v, want true", listBody["success"])
+	}
+	tasks, ok := listBody["tasks"].([]any)
+	if !ok {
+		t.Fatalf("tasks field missing/invalid: %v", listBody["tasks"])
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("tasks len = %d, want 0", len(tasks))
+	}
+
+	missing := doGet(t, r, "/api/tasks/does-not-exist")
+	if missing.Code != http.StatusNotFound {
+		t.Fatalf("missing status = %d body=%s, want 404", missing.Code, missing.Body.String())
+	}
+}
+
+func TestTasks_StartAndListCamelCase(t *testing.T) {
+	_, r, _ := setupOpsAdminStubsTest(t)
+
+	var started sync.WaitGroup
+	started.Add(1)
+	task, reused := StartBackgroundTask(BackgroundTaskStartOptions{
+		Type:      "unit-test",
+		Title:     "单元测试任务",
+		DedupeKey: "unit-test-key",
+	}, func() (any, error) {
+		started.Done()
+		time.Sleep(20 * time.Millisecond)
+		return map[string]any{"ok": true}, nil
+	})
+	if reused {
+		t.Fatal("expected new task, got reused")
+	}
+	if task.ID == "" || task.Type != "unit-test" {
+		t.Fatalf("unexpected task: %+v", task)
+	}
+
+	// Wait until runner begins so list can observe it.
+	started.Wait()
+	// Allow a short window for completion.
+	deadline := time.Now().Add(2 * time.Second)
+	var found map[string]any
+	for time.Now().Before(deadline) {
+		listResp := doGet(t, r, "/api/tasks?limit=20")
+		var listBody map[string]any
+		if err := json.Unmarshal(listResp.Body.Bytes(), &listBody); err != nil {
+			t.Fatalf("decode list: %v", err)
+		}
+		tasks, _ := listBody["tasks"].([]any)
+		for _, item := range tasks {
+			m, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if m["id"] == task.ID {
+				found = m
+				break
+			}
+		}
+		if found != nil {
+			if found["status"] == "succeeded" || found["status"] == "failed" {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if found == nil {
+		t.Fatalf("task %s not found in list", task.ID)
+	}
+	for _, key := range []string{"id", "type", "title", "status", "message", "createdAt", "updatedAt", "dedupeKey"} {
+		if _, ok := found[key]; !ok {
+			t.Fatalf("missing camelCase field %q in %v", key, found)
+		}
+	}
+	if _, ok := found["created_at"]; ok {
+		t.Fatalf("unexpected snake_case created_at in task payload: %v", found)
+	}
+
+	getResp := doGet(t, r, "/api/tasks/"+task.ID)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("get status = %d body=%s", getResp.Code, getResp.Body.String())
+	}
+	var getBody map[string]any
+	if err := json.Unmarshal(getResp.Body.Bytes(), &getBody); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if getBody["success"] != true {
+		t.Fatalf("get success = %v", getBody["success"])
+	}
+}
+
+func TestSiteAnnouncementsSync_QueuesRealTask(t *testing.T) {
+	db, r, _ := setupOpsAdminStubsTest(t)
+
+	// Seed one active site with no adapter platform → unsupported counted by worker.
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES ('Sync Site', 'https://sync-site.example.com', 'unknown-platform-x', 'active', ?, ?)`, now, now)
+	if err != nil {
+		t.Fatalf("seed site: %v", err)
+	}
+
+	resp := doPostJSON(t, r, "/api/site-announcements/sync", map[string]any{})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("sync status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != true || body["queued"] != true {
+		t.Fatalf("unexpected body: %v", body)
+	}
+	if body["taskId"] == "stub" || body["taskId"] == "" || body["taskId"] == nil {
+		t.Fatalf("taskId still stub/empty: %v", body["taskId"])
+	}
+	taskID, _ := body["taskId"].(string)
+
+	// Wait for background completion.
+	deadline := time.Now().Add(2 * time.Second)
+	var task map[string]any
+	for time.Now().Before(deadline) {
+		getResp := doGet(t, r, "/api/tasks/"+taskID)
+		if getResp.Code != http.StatusOK {
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		var getBody map[string]any
+		if err := json.Unmarshal(getResp.Body.Bytes(), &getBody); err != nil {
+			t.Fatalf("decode task: %v", err)
+		}
+		task, _ = getBody["task"].(map[string]any)
+		if task != nil {
+			if task["status"] == "succeeded" || task["status"] == "failed" {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if task == nil {
+		t.Fatal("task not found after sync")
+	}
+	if task["status"] != "succeeded" {
+		t.Fatalf("task status = %v body=%v, want succeeded", task["status"], task)
+	}
+	if task["type"] != "site-announcements-sync" {
+		t.Fatalf("task type = %v", task["type"])
+	}
+}

--- a/handler/admin/settings_notify.go
+++ b/handler/admin/settings_notify.go
@@ -1,9 +1,12 @@
 package admin
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/service/notify"
 )
 
 // RegisterNotifyRoutes registers the /api/settings/notify/test route.
@@ -12,10 +15,33 @@ func RegisterNotifyRoutes(r chi.Router) {
 }
 
 // POST /api/settings/notify/test
+// Dispatches a real connectivity test through all configured notification channels.
+// Returns a clear 400 failure when no channel is configured or all sends fail.
 func testNotify(w http.ResponseWriter, r *http.Request) {
-	// Stub: notification test not yet implemented
+	cfg := config.Get()
+
+	result, err := notify.SendNotification(
+		cfg,
+		"测试通知",
+		"您好，这是一条来自系统设置的连通性测试通知，您的通知相关配置目前工作正常！",
+		"info",
+		&notify.SendNotificationOptions{
+			BypassThrottle: true,
+			RequireChannel: true,
+			ThrowOnFailure: true,
+		},
+	)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
+
+	message := fmt.Sprintf("测试通知已发送（成功 %d/%d）", result.Succeeded, result.Attempted)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success": true,
-		"message": "测试通知已发送（成功 0/0）",
+		"message": message,
 	})
 }

--- a/handler/admin/site_announcements.go
+++ b/handler/admin/site_announcements.go
@@ -1,6 +1,9 @@
 package admin
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -9,6 +12,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/platform"
+	"github.com/tokendancelab/metapi-go/service"
+	"github.com/tokendancelab/metapi-go/service/notify"
 )
 
 // RegisterSiteAnnouncementsRoutes registers all /api/site-announcements routes.
@@ -24,6 +31,24 @@ func RegisterSiteAnnouncementsRoutes(r chi.Router, db *sqlx.DB) {
 
 type siteAnnouncementsHandler struct {
 	db *sqlx.DB
+}
+
+// siteAnnouncementSyncResult mirrors the TS syncSiteAnnouncements result shape.
+type siteAnnouncementSyncResult struct {
+	ScannedSites  int                          `json:"scannedSites"`
+	Inserted      int                          `json:"inserted"`
+	Updated       int                          `json:"updated"`
+	Unsupported   int                          `json:"unsupported"`
+	Notifications int                          `json:"notifications"`
+	Events        int                          `json:"events"`
+	Failed        int                          `json:"failed"`
+	FailedSites   []siteAnnouncementFailedSite `json:"failedSites"`
+}
+
+type siteAnnouncementFailedSite struct {
+	SiteID   int64  `json:"siteId"`
+	SiteName string `json:"siteName"`
+	Message  string `json:"message"`
 }
 
 // GET /api/site-announcements?limit=&offset=&siteId=&platform=&read=&status=
@@ -166,14 +191,261 @@ func (h *siteAnnouncementsHandler) deleteAll(w http.ResponseWriter, r *http.Requ
 }
 
 // POST /api/site-announcements/sync
+// Queues a real background sync against active sites (or a single siteId).
 func (h *siteAnnouncementsHandler) syncAnnouncements(w http.ResponseWriter, r *http.Request) {
-	// Stub: sync not yet implemented
+	var body struct {
+		SiteID any `json:"siteId"`
+	}
+	// Body is optional; ignore decode errors for empty payloads.
+	_ = decodeJSONRequest(r, &body)
+
+	var siteID *int64
+	if body.SiteID != nil {
+		switch v := body.SiteID.(type) {
+		case float64:
+			if v > 0 {
+				id := int64(v)
+				siteID = &id
+			}
+		case string:
+			if parsed, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64); err == nil && parsed > 0 {
+				siteID = &parsed
+			}
+		case json.Number:
+			if parsed, err := v.Int64(); err == nil && parsed > 0 {
+				siteID = &parsed
+			}
+		}
+	}
+
+	title := "同步站点公告"
+	dedupeKey := "site-announcements:all"
+	if siteID != nil {
+		title = fmt.Sprintf("同步站点公告 #%d", *siteID)
+		dedupeKey = fmt.Sprintf("site-announcements:%d", *siteID)
+	}
+
+	db := h.db
+	task, reused := StartBackgroundTask(BackgroundTaskStartOptions{
+		Type:      "site-announcements-sync",
+		Title:     title,
+		DedupeKey: dedupeKey,
+	}, func() (any, error) {
+		result := syncSiteAnnouncements(db, siteID)
+		return result, nil
+	})
+
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success": true,
 		"queued":  true,
-		"reused":  false,
-		"taskId":  "stub",
+		"reused":  reused,
+		"taskId":  task.ID,
 	})
+}
+
+func syncSiteAnnouncements(db *sqlx.DB, siteID *int64) siteAnnouncementSyncResult {
+	result := siteAnnouncementSyncResult{
+		FailedSites: []siteAnnouncementFailedSite{},
+	}
+
+	type siteRow struct {
+		ID       int64   `db:"id"`
+		Name     string  `db:"name"`
+		URL      string  `db:"url"`
+		Platform string  `db:"platform"`
+		APIKey   *string `db:"api_key"`
+	}
+
+	var sites []siteRow
+	var err error
+	if siteID != nil && *siteID > 0 {
+		err = db.Select(&sites, db.Rebind(`SELECT id, name, url, platform, api_key FROM sites WHERE id = ?`), *siteID)
+	} else {
+		err = db.Select(&sites, `SELECT id, name, url, platform, api_key FROM sites WHERE status = 'active'`)
+	}
+	if err != nil {
+		slog.Error("site-announcement sync: failed to query sites", "error", err)
+		result.Failed++
+		result.FailedSites = append(result.FailedSites, siteAnnouncementFailedSite{
+			SiteID:   0,
+			SiteName: "",
+			Message:  err.Error(),
+		})
+		return result
+	}
+
+	ctx := context.Background()
+	for _, site := range sites {
+		result.ScannedSites++
+		adapter := platform.GetAdapter(site.Platform)
+		if adapter == nil {
+			result.Unsupported++
+			continue
+		}
+
+		accessToken := strings.TrimSpace(stringPtrValue(site.APIKey))
+		if accessToken == "" {
+			accessToken = resolveSiteAccessToken(db, site.ID)
+		}
+
+		anns, annErr := adapter.GetSiteAnnouncements(ctx, site.URL, accessToken, nil, nil)
+		if annErr != nil {
+			result.Failed++
+			result.FailedSites = append(result.FailedSites, siteAnnouncementFailedSite{
+				SiteID:   site.ID,
+				SiteName: site.Name,
+				Message:  annErr.Error(),
+			})
+			continue
+		}
+
+		seenAt := service.FormatUtcSqlDateTime(time.Now())
+		for _, announcement := range anns {
+			sourceKey := strings.TrimSpace(announcement.SourceKey)
+			if sourceKey == "" {
+				continue
+			}
+
+			var existingID int64
+			lookupErr := db.Get(&existingID, db.Rebind(`
+				SELECT id FROM site_announcements WHERE site_id = ? AND source_key = ? LIMIT 1
+			`), site.ID, sourceKey)
+
+			rawPayload := ""
+			if len(announcement.RawPayload) > 0 {
+				rawPayload = string(announcement.RawPayload)
+			}
+
+			if lookupErr == nil && existingID > 0 {
+				_, _ = db.Exec(db.Rebind(`
+					UPDATE site_announcements
+					SET platform = ?, title = ?, content = ?, level = ?, source_url = ?,
+					    starts_at = ?, ends_at = ?, upstream_created_at = ?, upstream_updated_at = ?,
+					    last_seen_at = ?, raw_payload = ?
+					WHERE id = ?
+				`),
+					site.Platform,
+					announcement.Title,
+					announcement.Content,
+					defaultLevel(announcement.Level),
+					emptyToNil(announcement.SourceURL),
+					emptyToNil(announcement.StartsAt),
+					emptyToNil(announcement.EndsAt),
+					emptyToNil(announcement.UpstreamCreatedAt),
+					emptyToNil(announcement.UpstreamUpdatedAt),
+					seenAt,
+					emptyToNil(rawPayload),
+					existingID,
+				)
+				result.Updated++
+				continue
+			}
+
+			insertRes, insertErr := db.Exec(db.Rebind(`
+				INSERT INTO site_announcements (
+					site_id, platform, source_key, title, content, level, source_url,
+					starts_at, ends_at, upstream_created_at, upstream_updated_at,
+					first_seen_at, last_seen_at, raw_payload
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			`),
+				site.ID,
+				site.Platform,
+				sourceKey,
+				announcement.Title,
+				announcement.Content,
+				defaultLevel(announcement.Level),
+				emptyToNil(announcement.SourceURL),
+				emptyToNil(announcement.StartsAt),
+				emptyToNil(announcement.EndsAt),
+				emptyToNil(announcement.UpstreamCreatedAt),
+				emptyToNil(announcement.UpstreamUpdatedAt),
+				seenAt,
+				seenAt,
+				emptyToNil(rawPayload),
+			)
+			if insertErr != nil {
+				result.Failed++
+				result.FailedSites = append(result.FailedSites, siteAnnouncementFailedSite{
+					SiteID:   site.ID,
+					SiteName: site.Name,
+					Message:  insertErr.Error(),
+				})
+				continue
+			}
+			announcementID, _ := insertRes.LastInsertId()
+			result.Inserted++
+
+			title := "站点公告：" + site.Name
+			message := buildAnnouncementMessage(announcement)
+			_, _ = db.Exec(db.Rebind(`
+				INSERT INTO events (type, title, message, level, related_id, related_type, created_at, read)
+				VALUES ('site_notice', ?, ?, ?, ?, 'site_announcement', ?, 0)
+			`), title, message, defaultLevel(announcement.Level), announcementID, seenAt)
+			result.Events++
+
+			// Best-effort notify; failures do not fail the whole sync.
+			cfg := safeConfig()
+			if cfg != nil {
+				_, _ = notify.SendNotification(cfg, title, message, defaultLevel(announcement.Level), nil)
+				result.Notifications++
+			}
+		}
+	}
+
+	return result
+}
+
+func resolveSiteAccessToken(db *sqlx.DB, siteID int64) string {
+	var token *string
+	err := db.Get(&token, db.Rebind(`
+		SELECT access_token FROM accounts
+		WHERE site_id = ? AND status = 'active'
+		ORDER BY id ASC
+		LIMIT 1
+	`), siteID)
+	if err != nil || token == nil {
+		return ""
+	}
+	return strings.TrimSpace(*token)
+}
+
+func buildAnnouncementMessage(row platform.SiteAnnouncement) string {
+	title := strings.TrimSpace(row.Title)
+	content := strings.TrimSpace(row.Content)
+	if title != "" && content != "" && title != content && strings.ToLower(title) != "site notice" {
+		return title + "\n" + content
+	}
+	if content != "" {
+		return content
+	}
+	return title
+}
+
+func defaultLevel(level string) string {
+	level = strings.TrimSpace(level)
+	if level == "" {
+		return "info"
+	}
+	return level
+}
+
+func emptyToNil(v string) any {
+	if strings.TrimSpace(v) == "" {
+		return nil
+	}
+	return v
+}
+
+func stringPtrValue(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+func safeConfig() *config.Config {
+	defer func() { _ = recover() }()
+	return config.Get()
 }
 
 func hasValue(v any) bool {

--- a/handler/admin/tasks.go
+++ b/handler/admin/tasks.go
@@ -1,11 +1,72 @@
 package admin
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"net/http"
-	"strconv"
+	"sort"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
+)
+
+// BackgroundTaskStatus mirrors the TS background task lifecycle.
+type BackgroundTaskStatus string
+
+const (
+	BackgroundTaskPending   BackgroundTaskStatus = "pending"
+	BackgroundTaskRunning   BackgroundTaskStatus = "running"
+	BackgroundTaskSucceeded BackgroundTaskStatus = "succeeded"
+	BackgroundTaskFailed    BackgroundTaskStatus = "failed"
+)
+
+// BackgroundTaskLogEntry is a single task log line.
+type BackgroundTaskLogEntry struct {
+	Seq       int    `json:"seq"`
+	Message   string `json:"message"`
+	CreatedAt string `json:"createdAt"`
+}
+
+// BackgroundTask is the in-memory admin task registry entry (camelCase JSON).
+type BackgroundTask struct {
+	ID         string                   `json:"id"`
+	Type       string                   `json:"type"`
+	Title      string                   `json:"title"`
+	Status     BackgroundTaskStatus     `json:"status"`
+	Message    string                   `json:"message"`
+	Error      *string                  `json:"error"`
+	Result     any                      `json:"result"`
+	DedupeKey  *string                  `json:"dedupeKey"`
+	CreatedAt  string                   `json:"createdAt"`
+	UpdatedAt  string                   `json:"updatedAt"`
+	StartedAt  *string                  `json:"startedAt"`
+	FinishedAt *string                  `json:"finishedAt"`
+	Logs       []BackgroundTaskLogEntry `json:"logs"`
+	expiresAt  time.Time
+}
+
+// BackgroundTaskStartOptions configures StartBackgroundTask.
+type BackgroundTaskStartOptions struct {
+	Type      string
+	Title     string
+	DedupeKey string
+	KeepMs    int64
+}
+
+const (
+	backgroundTaskTTLMs           = 6 * 60 * 60 * 1000
+	backgroundTaskCleanupInterval = 60 * time.Second
+	backgroundTaskLogLimit        = 200
+)
+
+var (
+	backgroundTasksMu     sync.Mutex
+	backgroundTasks       = map[string]*BackgroundTask{}
+	backgroundDedupeIDs   = map[string]string{}
+	backgroundCleanupOnce sync.Once
 )
 
 // RegisterTasksRoutes registers all /api/tasks routes.
@@ -21,21 +82,18 @@ type tasksHandler struct {
 
 // GET /api/tasks?limit=
 func (h *tasksHandler) listTasks(w http.ResponseWriter, r *http.Request) {
-	limit := clampInt(getQueryInt(r, "limit", 50), 0, 500)
-
-	// Background tasks are not stored in DB in the TS implementation;
-	// they live in an in-memory registry. Return empty stub for now.
+	limit := clampInt(getQueryInt(r, "limit", 50), 1, 200)
+	tasks := listBackgroundTasks(limit)
 	writeJSON(w, http.StatusOK, map[string]any{
-		"tasks": []any{},
+		"success": true,
+		"tasks":   tasks,
 	})
-	_ = limit
 }
 
 // GET /api/tasks/:id
 func (h *tasksHandler) getTask(w http.ResponseWriter, r *http.Request) {
-	idStr := chi.URLParam(r, "id")
-	id, err := strconv.ParseInt(idStr, 10, 64)
-	if err != nil || id <= 0 {
+	id := strings.TrimSpace(chi.URLParam(r, "id"))
+	if id == "" {
 		writeJSON(w, http.StatusNotFound, map[string]any{
 			"success": false,
 			"message": "task not found",
@@ -43,9 +101,205 @@ func (h *tasksHandler) getTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Stub: task registry not yet implemented
-	writeJSON(w, http.StatusNotFound, map[string]any{
-		"success": false,
-		"message": "task not found",
+	task := getBackgroundTask(id)
+	if task == nil {
+		writeJSON(w, http.StatusNotFound, map[string]any{
+			"success": false,
+			"message": "task not found",
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"success": true,
+		"task":    task,
 	})
+}
+
+// StartBackgroundTask queues a background job in the in-memory registry.
+// When dedupeKey matches a pending/running task, that task is reused.
+func StartBackgroundTask(opts BackgroundTaskStartOptions, runner func() (any, error)) (task *BackgroundTask, reused bool) {
+	ensureBackgroundTaskCleanup()
+	now := time.Now().UTC()
+	nowISO := now.Format(time.RFC3339Nano)
+
+	backgroundTasksMu.Lock()
+	defer backgroundTasksMu.Unlock()
+
+	dedupeKey := opts.DedupeKey
+	if dedupeKey != "" {
+		if existingID, ok := backgroundDedupeIDs[dedupeKey]; ok {
+			if existing := backgroundTasks[existingID]; existing != nil &&
+				(existing.Status == BackgroundTaskPending || existing.Status == BackgroundTaskRunning) {
+				cp := *existing
+				return &cp, true
+			}
+			delete(backgroundDedupeIDs, dedupeKey)
+		}
+	}
+
+	keepMs := opts.KeepMs
+	if keepMs < 60_000 {
+		keepMs = backgroundTaskTTLMs
+	}
+
+	var dedupePtr *string
+	if dedupeKey != "" {
+		key := dedupeKey
+		dedupePtr = &key
+	}
+
+	task = &BackgroundTask{
+		ID:        newBackgroundTaskID(),
+		Type:      opts.Type,
+		Title:     opts.Title,
+		Status:    BackgroundTaskPending,
+		Message:   opts.Title + " 已开始执行",
+		Error:     nil,
+		Result:    nil,
+		DedupeKey: dedupePtr,
+		CreatedAt: nowISO,
+		UpdatedAt: nowISO,
+		Logs:      []BackgroundTaskLogEntry{},
+		expiresAt: now.Add(time.Duration(keepMs) * time.Millisecond),
+	}
+	backgroundTasks[task.ID] = task
+	if dedupeKey != "" {
+		backgroundDedupeIDs[dedupeKey] = task.ID
+	}
+
+	// Snapshot id for goroutine
+	taskID := task.ID
+	title := opts.Title
+	go runBackgroundTask(taskID, title, dedupeKey, runner)
+
+	cp := *task
+	return &cp, false
+}
+
+func runBackgroundTask(taskID, title, dedupeKey string, runner func() (any, error)) {
+	started := time.Now().UTC().Format(time.RFC3339Nano)
+	backgroundTasksMu.Lock()
+	if task, ok := backgroundTasks[taskID]; ok {
+		task.Status = BackgroundTaskRunning
+		task.StartedAt = &started
+		task.Message = title + " 正在执行"
+		task.UpdatedAt = started
+	}
+	backgroundTasksMu.Unlock()
+
+	result, err := runner()
+	finished := time.Now().UTC().Format(time.RFC3339Nano)
+
+	backgroundTasksMu.Lock()
+	defer backgroundTasksMu.Unlock()
+	task, ok := backgroundTasks[taskID]
+	if !ok {
+		return
+	}
+	task.FinishedAt = &finished
+	task.UpdatedAt = finished
+	if err != nil {
+		msg := err.Error()
+		task.Status = BackgroundTaskFailed
+		task.Error = &msg
+		task.Message = title + " 失败：" + msg
+	} else {
+		task.Status = BackgroundTaskSucceeded
+		task.Error = nil
+		task.Result = result
+		task.Message = title + " 已完成"
+	}
+	if dedupeKey != "" && backgroundDedupeIDs[dedupeKey] == taskID {
+		delete(backgroundDedupeIDs, dedupeKey)
+	}
+}
+
+func getBackgroundTask(id string) *BackgroundTask {
+	backgroundTasksMu.Lock()
+	defer backgroundTasksMu.Unlock()
+	cleanupExpiredBackgroundTasksLocked(time.Now())
+	task, ok := backgroundTasks[id]
+	if !ok {
+		return nil
+	}
+	cp := *task
+	if cp.Logs == nil {
+		cp.Logs = []BackgroundTaskLogEntry{}
+	}
+	return &cp
+}
+
+func listBackgroundTasks(limit int) []BackgroundTask {
+	if limit < 1 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+
+	backgroundTasksMu.Lock()
+	defer backgroundTasksMu.Unlock()
+	cleanupExpiredBackgroundTasksLocked(time.Now())
+
+	all := make([]BackgroundTask, 0, len(backgroundTasks))
+	for _, task := range backgroundTasks {
+		cp := *task
+		if cp.Logs == nil {
+			cp.Logs = []BackgroundTaskLogEntry{}
+		}
+		all = append(all, cp)
+	}
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].CreatedAt > all[j].CreatedAt
+	})
+	if len(all) > limit {
+		all = all[:limit]
+	}
+	if all == nil {
+		all = []BackgroundTask{}
+	}
+	return all
+}
+
+func ensureBackgroundTaskCleanup() {
+	backgroundCleanupOnce.Do(func() {
+		go func() {
+			ticker := time.NewTicker(backgroundTaskCleanupInterval)
+			defer ticker.Stop()
+			for range ticker.C {
+				backgroundTasksMu.Lock()
+				cleanupExpiredBackgroundTasksLocked(time.Now())
+				backgroundTasksMu.Unlock()
+			}
+		}()
+	})
+}
+
+func cleanupExpiredBackgroundTasksLocked(now time.Time) {
+	for id, task := range backgroundTasks {
+		if !task.expiresAt.IsZero() && !task.expiresAt.After(now) {
+			if task.DedupeKey != nil && backgroundDedupeIDs[*task.DedupeKey] == id {
+				delete(backgroundDedupeIDs, *task.DedupeKey)
+			}
+			delete(backgroundTasks, id)
+		}
+	}
+}
+
+func newBackgroundTaskID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Extremely unlikely; fall back to timestamp-based id.
+		return hex.EncodeToString([]byte(time.Now().UTC().Format(time.RFC3339Nano)))
+	}
+	// UUID-ish hex (no dashes) is fine for admin task ids.
+	return hex.EncodeToString(b[:])
+}
+
+// resetBackgroundTasksForTests clears the in-memory registry (tests only).
+func resetBackgroundTasksForTests() {
+	backgroundTasksMu.Lock()
+	defer backgroundTasksMu.Unlock()
+	backgroundTasks = map[string]*BackgroundTask{}
+	backgroundDedupeIDs = map[string]string{}
 }


### PR DESCRIPTION
## Summary
- Wire real `POST /api/settings/notify/test` via `notify.SendNotification` with clear 400 when channels are missing/fail (no silent 0/0 success).
- Implement LDOH monitor config persist/validate + reverse proxy with session/cookie gates (401/400, never fake success).
- Add in-memory background task registry (`GET /api/tasks`, `GET /api/tasks/:id`) with camelCase schema and empty success list.
- Queue real site-announcement sync work through the task registry instead of `taskId: "stub"`.
- Document residuals in `docs/analysis/ops-admin-stubs.md` and cover status codes in tests.

Closes #158

## Test plan
- [x] `go test ./handler/admin/ -count=1 -run 'TestNotifyTest_|TestMonitor|TestTasks_|TestSiteAnnouncementsSync_'`
- [x] `go test ./handler/admin/ -count=1`
- [x] `go build ./cmd/server`
- [ ] Manual: configure a notify channel and confirm test message success path
- [ ] Manual: save LDOH cookie + create session, open `/monitor-proxy/ldoh/`