### PR TITLE
feat(admin): marketplace/token-candidates/model-check non-stub (#156)

### DIFF
--- a/docs/analysis/admin-models-surfaces.md
+++ b/docs/analysis/admin-models-surfaces.md
@@ -1,0 +1,192 @@
+# Admin model surfaces (marketplace / token-candidates / model-check)
+
+**Date:** 2026-07-17  
+**Issue:** #156  
+**SSOT code:** `handler/admin/stats.go`  
+**Related:** `docs/analysis/cross-site-price-compare.md`, `docs/specs/p11-admin-api.md`
+
+## Goal
+
+Replace empty stubs for:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /api/models/marketplace` | Operator model plaza derived from local availability |
+| `GET /api/models/token-candidates` | Route-config candidate / missing-token maps |
+| `POST /api/models/check/{accountId}` | Per-account availability refresh |
+
+with **DB-derived real data**. No unbounded upstream marketplace scrape.
+
+## Data sources
+
+| Surface | Tables |
+|---------|--------|
+| Marketplace models | `model_availability`, `token_model_availability`, `account_tokens`, `accounts`, `sites`, exact `token_routes.model_pattern`, optional 7d `proxy_logs` success-rate |
+| Token candidates | `token_model_availability` ⨝ `account_tokens` ⨝ `accounts` ⨝ `sites` |
+| Models without token | `model_availability` accounts that have **no** enabled token coverage for that model |
+| Missing token groups | Accounts with managed tokens but no resolvable `token_group` / group-like name |
+| Model check | `platform.GetAdapter(site.Platform).GetModels` → persist `model_availability` → `service.RebuildTokenRoutesFromAvailability` |
+
+Optional filter: settings key `global_allowed_models` (JSON array). Empty / missing = allow all.
+
+## Response contracts
+
+### Marketplace
+
+```json
+{
+  "models": [{
+    "name": "gpt-4o",
+    "accountCount": 1,
+    "tokenCount": 1,
+    "avgLatency": 320,
+    "successRate": 50.0,
+    "description": null,
+    "tags": [],
+    "supportedEndpointTypes": ["openai"],
+    "pricingSources": [],
+    "accounts": [{
+      "id": 1,
+      "site": "Demo",
+      "username": "u",
+      "latency": 320,
+      "balance": 1.0,
+      "tokens": [{ "id": 1, "name": "default", "isDefault": true }]
+    }]
+  }],
+  "meta": {
+    "refreshRequested": false,
+    "refreshQueued": false,
+    "refreshReused": false,
+    "refreshRunning": false,
+    "refreshJobId": null,
+    "includePricing": true,
+    "source": "db_availability",
+    "pricingStatus": "unavailable",
+    "pricingNote": "..."
+  }
+}
+```
+
+Notes:
+
+- `pricingSources` is always empty in this wave.
+- When `includePricing=1|true`, `meta.pricingStatus=unavailable` labels the residual (no fake prices).
+- `refresh=true` rebuilds from DB only; it does **not** queue a remote catalog job (`refreshQueued=false`).
+
+### Token candidates
+
+```json
+{
+  "models": {
+    "gpt-4o": [{
+      "accountId": 1,
+      "tokenId": 2,
+      "tokenName": "default",
+      "isDefault": true,
+      "username": "u",
+      "siteId": 1,
+      "siteName": "Demo"
+    }]
+  },
+  "modelsWithoutToken": {
+    "claude-3-5-sonnet": [{
+      "accountId": 3,
+      "username": "bare",
+      "siteId": 1,
+      "siteName": "Demo"
+    }]
+  },
+  "modelsMissingTokenGroups": {
+    "gpt-4o-mini": [{
+      "accountId": 1,
+      "username": "u",
+      "siteId": 1,
+      "siteName": "Demo",
+      "missingGroups": [],
+      "requiredGroups": [],
+      "availableGroups": [],
+      "groupCoverageUncertain": true
+    }]
+  },
+  "endpointTypesByModel": {
+    "gpt-4o": ["openai"],
+    "claude-3-5-sonnet": ["anthropic"]
+  }
+}
+```
+
+`modelsMissingTokenGroups` is conservative: without a remote pricing catalog of **required** enableGroups, we only flag accounts whose managed tokens have no resolvable group label (`groupCoverageUncertain=true`). Full group-vs-catalog diff remains residual.
+
+### Model check
+
+Success:
+
+```json
+{
+  "success": true,
+  "refresh": {
+    "id": 1,
+    "status": "success",
+    "modelCount": 2,
+    "models": ["gpt-4o", "gpt-4o-mini"],
+    "checkedAt": "2026-07-17T00:00:00Z"
+  },
+  "rebuild": {
+    "success": true,
+    "routesConsidered": 1,
+    "patternRoutes": 1,
+    "groupRoutes": 0,
+    "channelsInserted": 0,
+    "channelsRemoved": 0,
+    "channelsKept": 0
+  }
+}
+```
+
+Failure (never fake success):
+
+```json
+{
+  "success": false,
+  "message": "...",
+  "refresh": {
+    "id": 1,
+    "status": "failed",
+    "errorCode": "timeout|unauthorized|empty_models|unsupported_platform|missing_credential|not_found|upstream_error|persist_failed",
+    "errorMessage": "..."
+  },
+  "rebuild": {}
+}
+```
+
+Invalid path id still uses Pattern C: `{ "success": false, "error": "Invalid account id" }`.
+
+## Residual: pricing refresh job
+
+Full marketplace pricing hydration (`includePricing` two-tier cache, remote `/api/pricing` catalog, background rebuild task, 15s/90s cache keys from p11 spec) is **not** implemented here.
+
+Operators should use:
+
+- `GET /api/models/price-compare` — effective cross-site rates from billing_details / observed / unit_cost / labeled fallback (#112)
+- Future job (out of scope for #156): bounded, cached remote pricing catalog with timeout + reuse policy
+
+Forbidden for this residual:
+
+- Unbounded multi-site marketplace scrapes without timeout/cache
+- Inventing unlabeled prices in `pricingSources`
+
+## Tests
+
+SQLite fixtures in `handler/admin/stats_test.go`:
+
+- `TestStats_SQLiteMarketplaceFromAvailability`
+- `TestStats_SQLiteTokenCandidatesMaps`
+- `TestStats_SQLiteModelCheckNoFakeSuccess`
+
+## Out of scope
+
+- `POST /api/models/probe` job queue (still stub)
+- Full p11 two-tier marketplace cache + refresh job
+- Remote pricing catalog scrape
+- 30 req/min dedicated token-candidates limiter (global admin rate limit still applies)

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -1,14 +1,23 @@
 package admin
 
 import (
+	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
+	"math"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/platform"
+	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/service"
+	"github.com/tokendancelab/metapi-go/store"
 )
 
 // RegisterStatsRoutes registers all /api/stats and /api/models routes.
@@ -716,35 +725,69 @@ func makeUsageHeatmapCells(rows []map[string]any) []map[string]any {
 
 // ---- Model Marketplace ----
 // GET /api/models/marketplace?refresh=&includePricing=
+//
+// Builds the operator marketplace view from local DB availability / routes.
+// Does not scrape remote marketplace/pricing catalogs. When includePricing=1,
+// pricingSources remain empty and meta.pricingStatus labels the residual gap
+// (see docs/analysis/admin-models-surfaces.md).
 func (h *statsHandler) marketplace(w http.ResponseWriter, r *http.Request) {
-	// Stub: market place not yet implemented
+	refreshRequested := parseTruthyQuery(r.URL.Query().Get("refresh"))
+	includePricing := parseTruthyQuery(r.URL.Query().Get("includePricing"))
+
+	models := h.buildMarketplaceModels()
+	meta := map[string]any{
+		"refreshRequested": refreshRequested,
+		// No background pricing/catalog job in this surface — DB-derived only.
+		"refreshQueued":  false,
+		"refreshReused":  false,
+		"refreshRunning": false,
+		"refreshJobId":   nil,
+		"includePricing": includePricing,
+		"source":         "db_availability",
+	}
+	if includePricing {
+		// Explicit residual: full remote /api/pricing hydration is out of scope.
+		meta["pricingStatus"] = "unavailable"
+		meta["pricingNote"] = "Remote marketplace pricing catalog is not hydrated; use /api/models/price-compare for effective rates. pricingSources intentionally empty."
+	}
+	if refreshRequested {
+		meta["refreshNote"] = "refresh=true acknowledged but no remote marketplace scrape is performed; response is rebuilt from local model_availability / token_model_availability / token_routes."
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{
-		"models": []any{},
-		"meta": map[string]any{
-			"refreshRequested": false,
-			"refreshQueued":    false,
-			"refreshReused":    false,
-			"refreshRunning":   false,
-			"refreshJobId":     nil,
-			"includePricing":   false,
-		},
+		"models": models,
+		"meta":   meta,
 	})
 }
 
 // ---- Token Candidates ----
 // GET /api/models/token-candidates
+//
+// Structured maps for route configuration:
+//   - models: token-scoped availability (token_model_availability)
+//   - modelsWithoutToken: account-level availability with no matching token coverage
+//   - modelsMissingTokenGroups: accounts whose tokens lack group labels when groups are required
+//   - endpointTypesByModel: inferred endpoint types from site platforms
 func (h *statsHandler) tokenCandidates(w http.ResponseWriter, r *http.Request) {
-	// Stub: token candidates not yet implemented
+	allowed := h.loadGlobalAllowedModels()
+	models := h.buildTokenCandidateModels(allowed)
+	withoutToken := h.buildModelsWithoutToken(allowed)
+	missingGroups := h.buildModelsMissingTokenGroups(allowed)
+	endpointTypes := h.buildEndpointTypesByModel(allowed)
+
 	writeJSON(w, http.StatusOK, map[string]any{
-		"models":                   map[string]any{},
-		"modelsWithoutToken":       map[string]any{},
-		"modelsMissingTokenGroups": map[string]any{},
-		"endpointTypesByModel":     map[string]any{},
+		"models":                   models,
+		"modelsWithoutToken":       withoutToken,
+		"modelsMissingTokenGroups": missingGroups,
+		"endpointTypesByModel":     endpointTypes,
 	})
 }
 
 // ---- Model Check ----
 // POST /api/models/check/:accountId
+//
+// Real availability refresh for one account via platform.GetModels, then
+// best-effort route rebuild. Never returns fake success when refresh fails.
 func (h *statsHandler) modelCheck(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "accountId")
 	id, err := strconv.ParseInt(idStr, 10, 64)
@@ -756,12 +799,8 @@ func (h *statsHandler) modelCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Stub: model refresh not yet implemented
-	writeJSON(w, http.StatusOK, map[string]any{
-		"success": true,
-		"refresh": map[string]any{"id": id},
-		"rebuild": map[string]any{},
-	})
+	result := h.refreshAccountModels(r.Context(), id)
+	writeJSON(w, http.StatusOK, result)
 }
 
 // ---- Model Probe ----
@@ -776,6 +815,902 @@ func (h *statsHandler) modelProbe(w http.ResponseWriter, r *http.Request) {
 		"status":  "pending",
 		"message": "已开始模型可用性探测，请稍后查看任务列表",
 	})
+}
+
+// marketplaceAccount aggregates per-account marketplace detail for one model.
+type marketplaceAccountAgg struct {
+	ID       int64
+	Site     string
+	Username *string
+	Latency  *float64
+	Balance  float64
+	Tokens   []map[string]any
+	tokenIDs map[int64]struct{}
+}
+
+func (h *statsHandler) buildMarketplaceModels() []map[string]any {
+	// Collect model names from availability tables + exact token_routes patterns.
+	type modelKey = string
+	type modelAgg struct {
+		accounts map[int64]*marketplaceAccountAgg
+		latSum   float64
+		latCount int
+	}
+	byModel := map[modelKey]*modelAgg{}
+
+	ensure := func(model string) *modelAgg {
+		if agg, ok := byModel[model]; ok {
+			return agg
+		}
+		agg := &modelAgg{accounts: map[int64]*marketplaceAccountAgg{}}
+		byModel[model] = agg
+		return agg
+	}
+	ensureAccount := func(agg *modelAgg, accountID int64, site, username string, balance float64, latency *float64) *marketplaceAccountAgg {
+		acc, ok := agg.accounts[accountID]
+		if !ok {
+			var userPtr *string
+			if strings.TrimSpace(username) != "" {
+				u := username
+				userPtr = &u
+			}
+			acc = &marketplaceAccountAgg{
+				ID:       accountID,
+				Site:     site,
+				Username: userPtr,
+				Balance:  balance,
+				Tokens:   []map[string]any{},
+				tokenIDs: map[int64]struct{}{},
+			}
+			agg.accounts[accountID] = acc
+		}
+		if latency != nil {
+			if acc.Latency == nil || *latency < *acc.Latency {
+				v := *latency
+				acc.Latency = &v
+			}
+			agg.latSum += *latency
+			agg.latCount++
+		}
+		return acc
+	}
+
+	// Account-level availability.
+	accountRows := queryRows(h.db, `
+		SELECT
+			ma.model_name AS model_name,
+			ma.latency_ms AS latency_ms,
+			a.id AS account_id,
+			COALESCE(a.username, '') AS username,
+			COALESCE(a.balance, 0) AS balance,
+			COALESCE(s.name, '') AS site_name,
+			COALESCE(s.platform, '') AS platform
+		FROM model_availability ma
+		INNER JOIN accounts a ON a.id = ma.account_id
+		INNER JOIN sites s ON s.id = a.site_id
+		WHERE COALESCE(ma.available, 0) = 1
+			AND COALESCE(a.status, '') <> 'disabled'
+			AND COALESCE(s.status, '') <> 'disabled'
+		ORDER BY ma.model_name ASC, a.id ASC
+	`)
+	for _, row := range accountRows {
+		model := strings.TrimSpace(coerceString(row["modelName"]))
+		if model == "" {
+			continue
+		}
+		agg := ensure(model)
+		var latency *float64
+		if row["latencyMs"] != nil && coerceString(row["latencyMs"]) != "" {
+			v := coerceFloat(row["latencyMs"])
+			latency = &v
+		}
+		acc := ensureAccount(agg,
+			coerceInt64(row["accountId"]),
+			coerceString(row["siteName"]),
+			coerceString(row["username"]),
+			coerceFloat(row["balance"]),
+			latency,
+		)
+		// Attach enabled tokens for this account (may also appear via token availability).
+		tokenRows := queryRows(h.db, `
+			SELECT id, name, is_default
+			FROM account_tokens
+			WHERE account_id = ?
+				AND enabled = 1
+				AND (value_status IS NULL OR value_status <> 'expired')
+			ORDER BY is_default DESC, id ASC
+		`, acc.ID)
+		for _, tr := range tokenRows {
+			tid := coerceInt64(tr["id"])
+			if tid <= 0 {
+				continue
+			}
+			if _, exists := acc.tokenIDs[tid]; exists {
+				continue
+			}
+			acc.tokenIDs[tid] = struct{}{}
+			acc.Tokens = append(acc.Tokens, map[string]any{
+				"id":        tid,
+				"name":      coerceString(tr["name"]),
+				"isDefault": coerceInt(tr["isDefault"]) == 1 || coerceString(tr["isDefault"]) == "true" || coerceString(tr["isDefault"]) == "1",
+			})
+		}
+	}
+
+	// Token-level availability.
+	tokenAvailRows := queryRows(h.db, `
+		SELECT
+			tma.model_name AS model_name,
+			tma.latency_ms AS latency_ms,
+			at.id AS token_id,
+			COALESCE(at.name, '') AS token_name,
+			at.is_default AS is_default,
+			a.id AS account_id,
+			COALESCE(a.username, '') AS username,
+			COALESCE(a.balance, 0) AS balance,
+			COALESCE(s.name, '') AS site_name
+		FROM token_model_availability tma
+		INNER JOIN account_tokens at ON at.id = tma.token_id
+		INNER JOIN accounts a ON a.id = at.account_id
+		INNER JOIN sites s ON s.id = a.site_id
+		WHERE COALESCE(tma.available, 0) = 1
+			AND at.enabled = 1
+			AND (at.value_status IS NULL OR at.value_status <> 'expired')
+			AND COALESCE(a.status, '') <> 'disabled'
+			AND COALESCE(s.status, '') <> 'disabled'
+		ORDER BY tma.model_name ASC, a.id ASC, at.id ASC
+	`)
+	for _, row := range tokenAvailRows {
+		model := strings.TrimSpace(coerceString(row["modelName"]))
+		if model == "" {
+			continue
+		}
+		agg := ensure(model)
+		var latency *float64
+		if row["latencyMs"] != nil && coerceString(row["latencyMs"]) != "" {
+			v := coerceFloat(row["latencyMs"])
+			latency = &v
+		}
+		acc := ensureAccount(agg,
+			coerceInt64(row["accountId"]),
+			coerceString(row["siteName"]),
+			coerceString(row["username"]),
+			coerceFloat(row["balance"]),
+			latency,
+		)
+		tid := coerceInt64(row["tokenId"])
+		if tid <= 0 {
+			continue
+		}
+		if _, exists := acc.tokenIDs[tid]; exists {
+			continue
+		}
+		acc.tokenIDs[tid] = struct{}{}
+		acc.Tokens = append(acc.Tokens, map[string]any{
+			"id":        tid,
+			"name":      coerceString(row["tokenName"]),
+			"isDefault": coerceInt(row["isDefault"]) == 1 || coerceString(row["isDefault"]) == "true" || coerceString(row["isDefault"]) == "1",
+		})
+	}
+
+	// Exact-model token_routes contribute model names even when availability is empty
+	// so operators still see configured routes in the marketplace list.
+	routeRows := queryRows(h.db, `
+		SELECT model_pattern
+		FROM token_routes
+		WHERE enabled = 1
+			AND route_mode <> 'explicit_group'
+	`)
+	for _, row := range routeRows {
+		pattern := strings.TrimSpace(coerceString(row["modelPattern"]))
+		if pattern == "" {
+			continue
+		}
+		// Only exact patterns (no wildcards / regex markers) become marketplace models.
+		if strings.ContainsAny(pattern, "*?^$[]()|\\+") {
+			continue
+		}
+		if _, ok := byModel[pattern]; !ok {
+			byModel[pattern] = &modelAgg{accounts: map[int64]*marketplaceAccountAgg{}}
+		}
+	}
+
+	// Optional success-rate from recent proxy_logs (bounded 7d window).
+	since := time.Now().UTC().Add(-7 * 24 * time.Hour).Format(time.RFC3339)
+	successByModel := map[string]struct {
+		total   int
+		success int
+	}{}
+	logRows := queryRows(h.db, `
+		SELECT
+			COALESCE(NULLIF(TRIM(model_actual), ''), NULLIF(TRIM(model_requested), ''), '') AS model,
+			COUNT(*) AS total,
+			COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) AS success
+		FROM proxy_logs
+		WHERE created_at >= ?
+			AND COALESCE(NULLIF(TRIM(model_actual), ''), NULLIF(TRIM(model_requested), ''), '') <> ''
+		GROUP BY COALESCE(NULLIF(TRIM(model_actual), ''), NULLIF(TRIM(model_requested), ''), '')
+	`, since)
+	for _, row := range logRows {
+		model := strings.TrimSpace(coerceString(row["model"]))
+		if model == "" {
+			continue
+		}
+		successByModel[model] = struct {
+			total   int
+			success int
+		}{total: coerceInt(row["total"]), success: coerceInt(row["success"])}
+	}
+
+	names := make([]string, 0, len(byModel))
+	for name := range byModel {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	out := make([]map[string]any, 0, len(names))
+	for _, name := range names {
+		agg := byModel[name]
+		accounts := make([]map[string]any, 0, len(agg.accounts))
+		accountIDs := make([]int64, 0, len(agg.accounts))
+		for id := range agg.accounts {
+			accountIDs = append(accountIDs, id)
+		}
+		sort.Slice(accountIDs, func(i, j int) bool { return accountIDs[i] < accountIDs[j] })
+		tokenCount := 0
+		for _, id := range accountIDs {
+			acc := agg.accounts[id]
+			tokenCount += len(acc.Tokens)
+			var latency any
+			if acc.Latency != nil {
+				latency = int64(math.Round(*acc.Latency))
+			} else {
+				latency = nil
+			}
+			accounts = append(accounts, map[string]any{
+				"id":       acc.ID,
+				"site":     acc.Site,
+				"username": acc.Username,
+				"latency":  latency,
+				"balance":  roundMicro(acc.Balance),
+				"tokens":   acc.Tokens,
+			})
+		}
+		var avgLatency any
+		if agg.latCount > 0 {
+			avgLatency = int64(math.Round(agg.latSum / float64(agg.latCount)))
+		} else {
+			avgLatency = nil
+		}
+		var successRate any
+		if stats, ok := successByModel[name]; ok && stats.total > 0 {
+			successRate = math.Round(1000.0*float64(stats.success)/float64(stats.total)) / 10.0
+		} else {
+			successRate = nil
+		}
+		out = append(out, map[string]any{
+			"name":                   name,
+			"accountCount":           len(accounts),
+			"tokenCount":             tokenCount,
+			"avgLatency":             avgLatency,
+			"successRate":            successRate,
+			"description":            nil,
+			"tags":                   []string{},
+			"supportedEndpointTypes": inferEndpointTypesForModel(name, accounts),
+			// Pricing intentionally empty — labeled residual; use price-compare for rates.
+			"pricingSources": []any{},
+			"accounts":       accounts,
+		})
+	}
+	return out
+}
+
+func inferEndpointTypesForModel(modelName string, accounts []map[string]any) []string {
+	// Prefer model-name heuristics; fall back to empty when unknown.
+	lower := strings.ToLower(modelName)
+	switch {
+	case strings.Contains(lower, "claude") || strings.HasPrefix(lower, "anthropic"):
+		return []string{"anthropic"}
+	case strings.Contains(lower, "gemini"):
+		return []string{"gemini"}
+	case strings.Contains(lower, "gpt") || strings.Contains(lower, "o1") || strings.Contains(lower, "o3") || strings.Contains(lower, "o4"):
+		return []string{"openai"}
+	default:
+		return []string{}
+	}
+}
+
+func (h *statsHandler) buildTokenCandidateModels(allowed map[string]struct{}) map[string][]map[string]any {
+	rows := queryRows(h.db, `
+		SELECT
+			tma.model_name AS model_name,
+			a.id AS account_id,
+			at.id AS token_id,
+			COALESCE(at.name, '') AS token_name,
+			at.is_default AS is_default,
+			COALESCE(a.username, '') AS username,
+			s.id AS site_id,
+			COALESCE(s.name, '') AS site_name
+		FROM token_model_availability tma
+		INNER JOIN account_tokens at ON at.id = tma.token_id
+		INNER JOIN accounts a ON a.id = at.account_id
+		INNER JOIN sites s ON s.id = a.site_id
+		WHERE COALESCE(tma.available, 0) = 1
+			AND at.enabled = 1
+			AND (at.value_status IS NULL OR at.value_status <> 'expired')
+			AND COALESCE(a.status, '') <> 'disabled'
+			AND COALESCE(s.status, '') <> 'disabled'
+		ORDER BY tma.model_name ASC, a.id ASC, at.id ASC
+	`)
+
+	out := map[string][]map[string]any{}
+	seen := map[string]map[int64]struct{}{} // model -> tokenIDs
+	for _, row := range rows {
+		model := strings.TrimSpace(coerceString(row["modelName"]))
+		if model == "" || !modelAllowed(model, allowed) {
+			continue
+		}
+		tokenID := coerceInt64(row["tokenId"])
+		if tokenID <= 0 {
+			continue
+		}
+		if _, ok := seen[model]; !ok {
+			seen[model] = map[int64]struct{}{}
+		}
+		if _, dup := seen[model][tokenID]; dup {
+			continue
+		}
+		seen[model][tokenID] = struct{}{}
+		var username any
+		if u := strings.TrimSpace(coerceString(row["username"])); u != "" {
+			username = u
+		} else {
+			username = nil
+		}
+		out[model] = append(out[model], map[string]any{
+			"accountId": coerceInt64(row["accountId"]),
+			"tokenId":   tokenID,
+			"tokenName": coerceString(row["tokenName"]),
+			"isDefault": coerceInt(row["isDefault"]) == 1 || coerceString(row["isDefault"]) == "true" || coerceString(row["isDefault"]) == "1",
+			"username":  username,
+			"siteId":    coerceInt64(row["siteId"]),
+			"siteName":  coerceString(row["siteName"]),
+		})
+	}
+	return out
+}
+
+func (h *statsHandler) buildModelsWithoutToken(allowed map[string]struct{}) map[string][]map[string]any {
+	// Accounts with available model_availability but no token_model_availability
+	// coverage for that model AND no enabled account_tokens at all (or none that
+	// list the model). Operators use this for zero-channel route hints.
+	rows := queryRows(h.db, `
+		SELECT
+			ma.model_name AS model_name,
+			a.id AS account_id,
+			COALESCE(a.username, '') AS username,
+			s.id AS site_id,
+			COALESCE(s.name, '') AS site_name
+		FROM model_availability ma
+		INNER JOIN accounts a ON a.id = ma.account_id
+		INNER JOIN sites s ON s.id = a.site_id
+		WHERE COALESCE(ma.available, 0) = 1
+			AND COALESCE(a.status, '') <> 'disabled'
+			AND COALESCE(s.status, '') <> 'disabled'
+			AND NOT EXISTS (
+				SELECT 1
+				FROM account_tokens at
+				INNER JOIN token_model_availability tma ON tma.token_id = at.id
+				WHERE at.account_id = a.id
+					AND at.enabled = 1
+					AND (at.value_status IS NULL OR at.value_status <> 'expired')
+					AND COALESCE(tma.available, 0) = 1
+					AND tma.model_name = ma.model_name
+			)
+			AND NOT EXISTS (
+				-- API-key style accounts that store a single key without managed tokens
+				-- are still "without token" for route channel binding when no account_tokens rows exist.
+				SELECT 1 FROM account_tokens at
+				WHERE at.account_id = a.id
+					AND at.enabled = 1
+					AND (at.value_status IS NULL OR at.value_status <> 'expired')
+			)
+		ORDER BY ma.model_name ASC, a.id ASC
+	`)
+
+	out := map[string][]map[string]any{}
+	seen := map[string]map[int64]struct{}{}
+	for _, row := range rows {
+		model := strings.TrimSpace(coerceString(row["modelName"]))
+		if model == "" || !modelAllowed(model, allowed) {
+			continue
+		}
+		accountID := coerceInt64(row["accountId"])
+		if accountID <= 0 {
+			continue
+		}
+		if _, ok := seen[model]; !ok {
+			seen[model] = map[int64]struct{}{}
+		}
+		if _, dup := seen[model][accountID]; dup {
+			continue
+		}
+		seen[model][accountID] = struct{}{}
+		var username any
+		if u := strings.TrimSpace(coerceString(row["username"])); u != "" {
+			username = u
+		} else {
+			username = nil
+		}
+		out[model] = append(out[model], map[string]any{
+			"accountId": accountID,
+			"username":  username,
+			"siteId":    coerceInt64(row["siteId"]),
+			"siteName":  coerceString(row["siteName"]),
+		})
+	}
+	return out
+}
+
+func (h *statsHandler) buildModelsMissingTokenGroups(allowed map[string]struct{}) map[string][]map[string]any {
+	// When an account has model availability and managed tokens, but none of the
+	// enabled tokens have a resolvable token_group label, group coverage is uncertain
+	// / missing. We do not invent required groups from a remote pricing catalog.
+	rows := queryRows(h.db, `
+		SELECT
+			ma.model_name AS model_name,
+			a.id AS account_id,
+			COALESCE(a.username, '') AS username,
+			s.id AS site_id,
+			COALESCE(s.name, '') AS site_name,
+			COALESCE(at.token_group, '') AS token_group,
+			COALESCE(at.name, '') AS token_name
+		FROM model_availability ma
+		INNER JOIN accounts a ON a.id = ma.account_id
+		INNER JOIN sites s ON s.id = a.site_id
+		INNER JOIN account_tokens at ON at.account_id = a.id
+		WHERE COALESCE(ma.available, 0) = 1
+			AND COALESCE(a.status, '') <> 'disabled'
+			AND COALESCE(s.status, '') <> 'disabled'
+			AND at.enabled = 1
+			AND (at.value_status IS NULL OR at.value_status <> 'expired')
+		ORDER BY ma.model_name ASC, a.id ASC, at.id ASC
+	`)
+
+	type accGroups struct {
+		accountID int64
+		username  string
+		siteID    int64
+		siteName  string
+		available []string
+		uncertain bool
+	}
+	// model -> accountID -> groups
+	byModel := map[string]map[int64]*accGroups{}
+	for _, row := range rows {
+		model := strings.TrimSpace(coerceString(row["modelName"]))
+		if model == "" || !modelAllowed(model, allowed) {
+			continue
+		}
+		accountID := coerceInt64(row["accountId"])
+		if accountID <= 0 {
+			continue
+		}
+		if _, ok := byModel[model]; !ok {
+			byModel[model] = map[int64]*accGroups{}
+		}
+		ag, ok := byModel[model][accountID]
+		if !ok {
+			ag = &accGroups{
+				accountID: accountID,
+				username:  coerceString(row["username"]),
+				siteID:    coerceInt64(row["siteId"]),
+				siteName:  coerceString(row["siteName"]),
+			}
+			byModel[model][accountID] = ag
+		}
+		group := resolveTokenGroupLabel(coerceString(row["tokenGroup"]), coerceString(row["tokenName"]))
+		if group == "" {
+			ag.uncertain = true
+			continue
+		}
+		// de-dupe
+		found := false
+		for _, g := range ag.available {
+			if strings.EqualFold(g, group) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			ag.available = append(ag.available, group)
+		}
+	}
+
+	out := map[string][]map[string]any{}
+	for model, accounts := range byModel {
+		for _, ag := range accounts {
+			// Only surface accounts where no token has a resolvable group label.
+			if len(ag.available) > 0 {
+				continue
+			}
+			var username any
+			if strings.TrimSpace(ag.username) != "" {
+				username = ag.username
+			} else {
+				username = nil
+			}
+			item := map[string]any{
+				"accountId":              ag.accountID,
+				"username":               username,
+				"siteId":                 ag.siteID,
+				"siteName":               ag.siteName,
+				"missingGroups":          []string{},
+				"requiredGroups":         []string{},
+				"availableGroups":        []string{},
+				"groupCoverageUncertain": true,
+			}
+			out[model] = append(out[model], item)
+		}
+	}
+	return out
+}
+
+func resolveTokenGroupLabel(tokenGroup, tokenName string) string {
+	group := strings.TrimSpace(tokenGroup)
+	if group != "" {
+		return group
+	}
+	name := strings.TrimSpace(tokenName)
+	if name == "" {
+		return ""
+	}
+	lower := strings.ToLower(name)
+	if lower == "default" || name == "默认" {
+		return ""
+	}
+	// Names like token-1 / token-N are not group labels.
+	if strings.HasPrefix(lower, "token-") {
+		return ""
+	}
+	return name
+}
+
+func (h *statsHandler) buildEndpointTypesByModel(allowed map[string]struct{}) map[string][]string {
+	// Union of endpoint types inferred from model names present in availability.
+	models := map[string]struct{}{}
+	for _, row := range queryRows(h.db, `
+		SELECT DISTINCT model_name AS model_name FROM model_availability WHERE COALESCE(available, 0) = 1
+		UNION
+		SELECT DISTINCT model_name AS model_name FROM token_model_availability WHERE COALESCE(available, 0) = 1
+	`) {
+		model := strings.TrimSpace(coerceString(row["modelName"]))
+		if model == "" || !modelAllowed(model, allowed) {
+			continue
+		}
+		models[model] = struct{}{}
+	}
+	out := map[string][]string{}
+	for model := range models {
+		types := inferEndpointTypesForModel(model, nil)
+		if len(types) == 0 {
+			// default OpenAI-compatible when unknown
+			types = []string{"openai"}
+		}
+		out[model] = types
+	}
+	return out
+}
+
+func (h *statsHandler) loadGlobalAllowedModels() map[string]struct{} {
+	// Optional whitelist from settings table. Empty / missing → allow all.
+	var raw string
+	err := h.db.Get(&raw, rebindAdminQuery(h.db, `SELECT value FROM settings WHERE key = ?`), "global_allowed_models")
+	if err != nil || strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var list []string
+	if err := json.Unmarshal([]byte(raw), &list); err != nil {
+		// also accept CSV
+		for _, part := range strings.Split(raw, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				list = append(list, part)
+			}
+		}
+	}
+	if len(list) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(list))
+	for _, m := range list {
+		m = strings.TrimSpace(m)
+		if m != "" {
+			out[strings.ToLower(m)] = struct{}{}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func modelAllowed(model string, allowed map[string]struct{}) bool {
+	if allowed == nil || len(allowed) == 0 {
+		return true
+	}
+	_, ok := allowed[strings.ToLower(strings.TrimSpace(model))]
+	return ok
+}
+
+func parseTruthyQuery(v string) bool {
+	v = strings.TrimSpace(strings.ToLower(v))
+	return v == "1" || v == "true" || v == "yes" || v == "on"
+}
+
+// refreshAccountModels performs a real platform.GetModels refresh and persists
+// results into model_availability. Returns the operator-facing check payload.
+func (h *statsHandler) refreshAccountModels(ctx context.Context, accountID int64) map[string]any {
+	row, err := service.GetAccountWithSiteByID(h.db, accountID)
+	if err != nil || row == nil {
+		return map[string]any{
+			"success": false,
+			"error":   "account not found",
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    "not_found",
+				"errorMessage": "账号不存在",
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	account := row.Account
+	site := row.Site
+	if strings.EqualFold(strings.TrimSpace(account.Status), "disabled") {
+		return map[string]any{
+			"success": false,
+			"message": "账号已禁用，无法刷新模型",
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    "disabled",
+				"errorMessage": "账号已禁用",
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	adapter := platform.GetAdapter(site.Platform)
+	if adapter == nil {
+		return map[string]any{
+			"success": false,
+			"message": "unsupported platform: " + site.Platform,
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    "unsupported_platform",
+				"errorMessage": "不支持的平台: " + site.Platform,
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	token := resolveAccountModelToken(&account)
+	if token == "" {
+		return map[string]any{
+			"success": false,
+			"message": "账号缺少可用凭证",
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    "missing_credential",
+				"errorMessage": "账号缺少 access_token / api_token",
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	platformUserID := resolvePlatformUserIDPtr(account.ExtraConfig, account.Username)
+	proxyCfg := service.BuildPlatformProxyConfig(nil, &account, &site)
+
+	callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	models, getErr := adapter.GetModels(callCtx, site.URL, token, platformUserID, proxyCfg)
+	if getErr != nil {
+		code, msg := classifyModelRefreshError(getErr, callCtx)
+		return map[string]any{
+			"success": false,
+			"message": msg,
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    code,
+				"errorMessage": msg,
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	// Deduplicate / trim.
+	seen := map[string]struct{}{}
+	clean := make([]string, 0, len(models))
+	for _, m := range models {
+		m = strings.TrimSpace(m)
+		if m == "" {
+			continue
+		}
+		key := strings.ToLower(m)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		clean = append(clean, m)
+	}
+	if len(clean) == 0 {
+		return map[string]any{
+			"success": false,
+			"message": "未获取到可用模型",
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    "empty_models",
+				"errorMessage": "未获取到可用模型",
+				"modelCount":   0,
+				"models":       []string{},
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := h.persistAccountModelAvailability(accountID, clean, now); err != nil {
+		return map[string]any{
+			"success": false,
+			"message": "模型写入失败: " + err.Error(),
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    "persist_failed",
+				"errorMessage": err.Error(),
+				"modelCount":   len(clean),
+				"models":       clean,
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	// Best-effort route rebuild from updated availability.
+	rebuildStats, rebuildErr := service.RebuildTokenRoutesFromAvailability(context.Background(), h.db)
+	rebuildPayload := map[string]any{
+		"routesConsidered": rebuildStats.RoutesConsidered,
+		"patternRoutes":    rebuildStats.PatternRoutes,
+		"groupRoutes":      rebuildStats.GroupRoutes,
+		"channelsInserted": rebuildStats.ChannelsInserted,
+		"channelsRemoved":  rebuildStats.ChannelsRemoved,
+		"channelsKept":     rebuildStats.ChannelsKept,
+	}
+	if rebuildErr != nil {
+		rebuildPayload["success"] = false
+		rebuildPayload["error"] = rebuildErr.Error()
+	} else {
+		rebuildPayload["success"] = true
+	}
+	routing.InvalidateCache()
+
+	return map[string]any{
+		"success": true,
+		"refresh": map[string]any{
+			"id":         accountID,
+			"status":     "success",
+			"modelCount": len(clean),
+			"models":     clean,
+			"checkedAt":  now,
+		},
+		"rebuild": rebuildPayload,
+	}
+}
+
+func resolveAccountModelToken(account *store.Account) string {
+	if account == nil {
+		return ""
+	}
+	if account.APIToken != nil && strings.TrimSpace(*account.APIToken) != "" {
+		return strings.TrimSpace(*account.APIToken)
+	}
+	return strings.TrimSpace(account.AccessToken)
+}
+
+func resolvePlatformUserIDPtr(extraConfig *string, username *string) *int {
+	id := service.ResolvePlatformUserID(extraConfig, username)
+	if id <= 0 {
+		return nil
+	}
+	v := int(id)
+	return &v
+}
+
+func classifyModelRefreshError(err error, ctx context.Context) (code, message string) {
+	if err == nil {
+		return "unknown", "模型获取失败"
+	}
+	msg := strings.TrimSpace(err.Error())
+	lower := strings.ToLower(msg)
+	timedOut := (ctx != nil && ctx.Err() == context.DeadlineExceeded) ||
+		strings.Contains(lower, "timeout") ||
+		strings.Contains(lower, "deadline exceeded")
+	if timedOut {
+		return "timeout", "模型获取失败（请求超时）"
+	}
+	if strings.Contains(lower, "unauthorized") || strings.Contains(lower, "401") || strings.Contains(lower, "invalid api key") || strings.Contains(lower, "authentication") {
+		return "unauthorized", "模型获取失败，API Key 已无效"
+	}
+	if msg == "" {
+		msg = "模型获取失败"
+	}
+	return "upstream_error", msg
+}
+
+func (h *statsHandler) persistAccountModelAvailability(accountID int64, models []string, now string) error {
+	tx, err := h.db.Beginx()
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Preserve manual rows; mark non-manual previous rows unavailable then upsert.
+	if _, err := tx.Exec(tx.Rebind(`
+		UPDATE model_availability
+		SET available = ?, checked_at = ?
+		WHERE account_id = ? AND COALESCE(is_manual, 0) = 0
+	`), false, now, accountID); err != nil {
+		return err
+	}
+
+	for _, model := range models {
+		var existingID int64
+		err := tx.Get(&existingID, tx.Rebind(`
+			SELECT id FROM model_availability WHERE account_id = ? AND model_name = ?
+		`), accountID, model)
+		if err == nil {
+			if _, err := tx.Exec(tx.Rebind(`
+				UPDATE model_availability
+				SET available = ?, latency_ms = NULL, checked_at = ?
+				WHERE id = ?
+			`), true, now, existingID); err != nil {
+				return err
+			}
+			continue
+		}
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		if _, err := tx.Exec(tx.Rebind(`
+			INSERT INTO model_availability (account_id, model_name, available, is_manual, latency_ms, checked_at)
+			VALUES (?, ?, ?, ?, NULL, ?)
+		`), accountID, model, true, false, now); err != nil {
+			if _, err2 := tx.Exec(tx.Rebind(`
+				UPDATE model_availability
+				SET available = ?, latency_ms = NULL, checked_at = ?
+				WHERE account_id = ? AND model_name = ?
+			`), true, now, accountID, model); err2 != nil {
+				return err
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }
 
 func queryRow(db *sqlx.DB, query string, args ...any) map[string]any {

--- a/handler/admin/stats_test.go
+++ b/handler/admin/stats_test.go
@@ -543,3 +543,313 @@ func TestStats_UsageHeatmapAndSlowRequestsClampParams(t *testing.T) {
 		t.Fatalf("empty fixtures should yield empty items, got %#v", slow["items"])
 	}
 }
+
+func seedModelsSurfacesFixture(t *testing.T, db *store.DB) (siteID, accountWithToken, accountWithoutToken, tokenID int64) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	_, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "ms-site", "https://ms.example.test", "openai", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	if err := db.Get(&siteID, "SELECT id FROM sites WHERE name = ?", "ms-site"); err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, balance, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, 0, ?, ?)`, siteID, "ms-token-user", "sk-ms-token", 9.5, now, now)
+	if err != nil {
+		t.Fatalf("insert account with token: %v", err)
+	}
+	if err := db.Get(&accountWithToken, "SELECT id FROM accounts WHERE username = ?", "ms-token-user"); err != nil {
+		t.Fatalf("account with token id: %v", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, balance, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, 0, ?, ?)`, siteID, "ms-bare-user", "sk-ms-bare", 1.25, now, now)
+	if err != nil {
+		t.Fatalf("insert bare account: %v", err)
+	}
+	if err := db.Get(&accountWithoutToken, "SELECT id FROM accounts WHERE username = ?", "ms-bare-user"); err != nil {
+		t.Fatalf("bare account id: %v", err)
+	}
+
+	_, err = db.Exec(`INSERT INTO account_tokens (account_id, name, token, token_group, value_status, source, enabled, is_default, created_at, updated_at)
+		VALUES (?, ?, ?, NULL, 'ready', 'manual', 1, 1, ?, ?)`, accountWithToken, "default", "sk-ms-default", now, now)
+	if err != nil {
+		t.Fatalf("insert account token: %v", err)
+	}
+	if err := db.Get(&tokenID, "SELECT id FROM account_tokens WHERE account_id = ?", accountWithToken); err != nil {
+		t.Fatalf("token id: %v", err)
+	}
+
+	// Token-scoped availability for gpt-4o.
+	_, err = db.Exec(`INSERT INTO token_model_availability (token_id, model_name, available, latency_ms, checked_at)
+		VALUES (?, ?, 1, ?, ?)`, tokenID, "gpt-4o", 320, now)
+	if err != nil {
+		t.Fatalf("insert token model availability: %v", err)
+	}
+
+	// Account-level availability on bare account (no managed tokens).
+	_, err = db.Exec(`INSERT INTO model_availability (account_id, model_name, available, is_manual, latency_ms, checked_at)
+		VALUES (?, ?, 1, 0, ?, ?)`, accountWithoutToken, "claude-3-5-sonnet", 410, now)
+	if err != nil {
+		t.Fatalf("insert bare model availability: %v", err)
+	}
+
+	// Account-level availability on token account whose tokens lack group labels.
+	_, err = db.Exec(`INSERT INTO model_availability (account_id, model_name, available, is_manual, latency_ms, checked_at)
+		VALUES (?, ?, 1, 0, ?, ?)`, accountWithToken, "gpt-4o-mini", 280, now)
+	if err != nil {
+		t.Fatalf("insert grouped model availability: %v", err)
+	}
+
+	// Exact route so marketplace still lists a route-only model name.
+	_, err = db.Exec(`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
+		VALUES ('route-only-model', 'exact', 'weighted', 1, ?, ?)`, now, now)
+	if err != nil {
+		t.Fatalf("insert exact route: %v", err)
+	}
+
+	// Success-rate signal for gpt-4o.
+	_, err = db.Exec(`INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, total_tokens, estimated_cost, latency_ms, created_at)
+		VALUES (?, ?, ?, 'success', 10, 0.01, 300, ?)`, accountWithToken, "gpt-4o", "gpt-4o", now)
+	if err != nil {
+		t.Fatalf("insert success proxy log: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, total_tokens, estimated_cost, latency_ms, created_at)
+		VALUES (?, ?, ?, 'failed', 5, 0, 900, ?)`, accountWithToken, "gpt-4o", "gpt-4o", now)
+	if err != nil {
+		t.Fatalf("insert failed proxy log: %v", err)
+	}
+
+	return siteID, accountWithToken, accountWithoutToken, tokenID
+}
+
+func TestStats_SQLiteMarketplaceFromAvailability(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	_, accountWithToken, accountWithoutToken, tokenID := seedModelsSurfacesFixture(t, db)
+
+	resp := doGet(t, r, "/api/models/marketplace?includePricing=1")
+	if resp.Code != 200 {
+		t.Fatalf("marketplace returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	models, ok := body["models"].([]any)
+	if !ok || len(models) < 3 {
+		t.Fatalf("models = %#v, want non-empty fixture models", body["models"])
+	}
+	meta, ok := body["meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("meta missing: %#v", body)
+	}
+	if meta["includePricing"] != true {
+		t.Fatalf("includePricing = %v, want true", meta["includePricing"])
+	}
+	if meta["pricingStatus"] != "unavailable" {
+		t.Fatalf("pricingStatus = %v, want unavailable residual label", meta["pricingStatus"])
+	}
+	if meta["source"] != "db_availability" {
+		t.Fatalf("source = %v, want db_availability", meta["source"])
+	}
+
+	byName := map[string]map[string]any{}
+	for _, raw := range models {
+		m := raw.(map[string]any)
+		byName[m["name"].(string)] = m
+	}
+	gpt, ok := byName["gpt-4o"]
+	if !ok {
+		t.Fatalf("missing gpt-4o in marketplace: %#v", byName)
+	}
+	if int(gpt["accountCount"].(float64)) < 1 {
+		t.Fatalf("gpt-4o accountCount = %v, want >=1", gpt["accountCount"])
+	}
+	if int(gpt["tokenCount"].(float64)) < 1 {
+		t.Fatalf("gpt-4o tokenCount = %v, want >=1", gpt["tokenCount"])
+	}
+	if gpt["successRate"] == nil {
+		t.Fatalf("gpt-4o successRate missing: %#v", gpt)
+	}
+	if pricing, ok := gpt["pricingSources"].([]any); !ok || len(pricing) != 0 {
+		t.Fatalf("pricingSources must be empty residual, got %#v", gpt["pricingSources"])
+	}
+	accounts, ok := gpt["accounts"].([]any)
+	if !ok || len(accounts) == 0 {
+		t.Fatalf("gpt-4o accounts empty: %#v", gpt["accounts"])
+	}
+	acc0 := accounts[0].(map[string]any)
+	if int64(acc0["id"].(float64)) != accountWithToken {
+		t.Fatalf("account id = %v, want %d", acc0["id"], accountWithToken)
+	}
+	tokens, ok := acc0["tokens"].([]any)
+	if !ok || len(tokens) == 0 {
+		t.Fatalf("account tokens empty: %#v", acc0["tokens"])
+	}
+	if int64(tokens[0].(map[string]any)["id"].(float64)) != tokenID {
+		t.Fatalf("token id = %v, want %d", tokens[0].(map[string]any)["id"], tokenID)
+	}
+
+	if _, ok := byName["claude-3-5-sonnet"]; !ok {
+		t.Fatalf("missing bare-account model claude-3-5-sonnet: %#v", byName)
+	}
+	if _, ok := byName["route-only-model"]; !ok {
+		t.Fatalf("missing exact route model route-only-model: %#v", byName)
+	}
+	claude := byName["claude-3-5-sonnet"]
+	foundBare := false
+	for _, raw := range claude["accounts"].([]any) {
+		if int64(raw.(map[string]any)["id"].(float64)) == accountWithoutToken {
+			foundBare = true
+		}
+	}
+	if !foundBare {
+		t.Fatalf("bare account %d missing from claude accounts: %#v", accountWithoutToken, claude["accounts"])
+	}
+}
+
+func TestStats_SQLiteTokenCandidatesMaps(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	_, accountWithToken, accountWithoutToken, tokenID := seedModelsSurfacesFixture(t, db)
+
+	resp := doGet(t, r, "/api/models/token-candidates")
+	if resp.Code != 200 {
+		t.Fatalf("token-candidates returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	models, ok := body["models"].(map[string]any)
+	if !ok {
+		t.Fatalf("models map missing: %#v", body["models"])
+	}
+	gptCandidates, ok := models["gpt-4o"].([]any)
+	if !ok || len(gptCandidates) != 1 {
+		t.Fatalf("gpt-4o candidates = %#v, want one token candidate", models["gpt-4o"])
+	}
+	c0 := gptCandidates[0].(map[string]any)
+	if int64(c0["tokenId"].(float64)) != tokenID {
+		t.Fatalf("tokenId = %v, want %d", c0["tokenId"], tokenID)
+	}
+	if int64(c0["accountId"].(float64)) != accountWithToken {
+		t.Fatalf("accountId = %v, want %d", c0["accountId"], accountWithToken)
+	}
+
+	without, ok := body["modelsWithoutToken"].(map[string]any)
+	if !ok {
+		t.Fatalf("modelsWithoutToken missing: %#v", body["modelsWithoutToken"])
+	}
+	bare, ok := without["claude-3-5-sonnet"].([]any)
+	if !ok || len(bare) != 1 {
+		t.Fatalf("modelsWithoutToken claude = %#v, want bare account", without["claude-3-5-sonnet"])
+	}
+	if int64(bare[0].(map[string]any)["accountId"].(float64)) != accountWithoutToken {
+		t.Fatalf("bare accountId = %v, want %d", bare[0].(map[string]any)["accountId"], accountWithoutToken)
+	}
+
+	missingGroups, ok := body["modelsMissingTokenGroups"].(map[string]any)
+	if !ok {
+		t.Fatalf("modelsMissingTokenGroups missing: %#v", body["modelsMissingTokenGroups"])
+	}
+	groupRows, ok := missingGroups["gpt-4o-mini"].([]any)
+	if !ok || len(groupRows) != 1 {
+		t.Fatalf("modelsMissingTokenGroups gpt-4o-mini = %#v", missingGroups["gpt-4o-mini"])
+	}
+	g0 := groupRows[0].(map[string]any)
+	if g0["groupCoverageUncertain"] != true {
+		t.Fatalf("groupCoverageUncertain = %v, want true", g0["groupCoverageUncertain"])
+	}
+
+	endpointTypes, ok := body["endpointTypesByModel"].(map[string]any)
+	if !ok {
+		t.Fatalf("endpointTypesByModel missing: %#v", body["endpointTypesByModel"])
+	}
+	if types, ok := endpointTypes["gpt-4o"].([]any); !ok || len(types) == 0 {
+		t.Fatalf("endpointTypes gpt-4o = %#v", endpointTypes["gpt-4o"])
+	}
+	if types, ok := endpointTypes["claude-3-5-sonnet"].([]any); !ok || len(types) == 0 || types[0] != "anthropic" {
+		t.Fatalf("endpointTypes claude = %#v, want anthropic", endpointTypes["claude-3-5-sonnet"])
+	}
+}
+
+func TestStats_SQLiteModelCheckNoFakeSuccess(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	_, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "check-site", "https://check.example.test", "openai", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	var siteID int64
+	if err := db.Get(&siteID, "SELECT id FROM sites WHERE name = ?", "check-site"); err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', 0, ?, ?)`, siteID, "check-user", "sk-check", now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	var accountID int64
+	if err := db.Get(&accountID, "SELECT id FROM accounts WHERE username = ?", "check-user"); err != nil {
+		t.Fatalf("account id: %v", err)
+	}
+
+	// Invalid id → Pattern C error, no fake success.
+	resp := doPostJSON(t, r, "/api/models/check/not-a-number", map[string]any{})
+	if resp.Code != 200 {
+		t.Fatalf("invalid id status = %d, want 200 with body error", resp.Code)
+	}
+	var invalidBody map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &invalidBody); err != nil {
+		t.Fatalf("unmarshal invalid: %v", err)
+	}
+	if invalidBody["success"] != false {
+		t.Fatalf("invalid id success = %v, want false", invalidBody["success"])
+	}
+	if invalidBody["error"] != "Invalid account id" {
+		t.Fatalf("invalid id error = %v", invalidBody["error"])
+	}
+
+	// Missing account → success=false.
+	resp = doPostJSON(t, r, "/api/models/check/999999", map[string]any{})
+	if resp.Code != 200 {
+		t.Fatalf("missing account status = %d", resp.Code)
+	}
+	var missingBody map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &missingBody); err != nil {
+		t.Fatalf("unmarshal missing: %v", err)
+	}
+	if missingBody["success"] != false {
+		t.Fatalf("missing account success = %v, want false (no fake success)", missingBody["success"])
+	}
+
+	// Real account against unreachable upstream URL: must not return success=true.
+	resp = doPostJSON(t, r, "/api/models/check/"+strconv.FormatInt(accountID, 10), map[string]any{})
+	if resp.Code != 200 {
+		t.Fatalf("model check status = %d: %s", resp.Code, resp.Body.String())
+	}
+	var checkBody map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &checkBody); err != nil {
+		t.Fatalf("unmarshal check: %v", err)
+	}
+	if checkBody["success"] != false {
+		t.Fatalf("unreachable upstream success = %v, want false (no fake success); body=%#v", checkBody["success"], checkBody)
+	}
+	refresh, ok := checkBody["refresh"].(map[string]any)
+	if !ok {
+		t.Fatalf("refresh missing: %#v", checkBody)
+	}
+	if refresh["status"] == "success" {
+		t.Fatalf("refresh.status must not be success for unreachable upstream: %#v", refresh)
+	}
+	if refresh["errorCode"] == nil || refresh["errorCode"] == "" {
+		t.Fatalf("refresh.errorCode required on failure: %#v", refresh)
+	}
+}


### PR DESCRIPTION
## Summary
- `GET /api/models/marketplace` now returns models derived from `model_availability`, `token_model_availability`, accounts/tokens, and exact `token_routes` (pricing residual labeled empty).
- `GET /api/models/token-candidates` returns structured maps for route candidates, accounts without token coverage, uncertain group coverage, and endpoint types.
- `POST /api/models/check/{accountId}` performs real `platform.GetModels` refresh + route rebuild, and never returns fake success.

Closes #156

## Test plan
- [x] `go test ./handler/admin/ -run 'TestStats_SQLite(Marketplace|TokenCandidates|ModelCheck)'`
- [x] SQLite fixtures cover non-empty marketplace/token-candidates paths and model-check failure shapes