### PR TITLE
feat(proxy): OpenAI-compatible /v1/files pass-through #155

### DIFF
--- a/docs/analysis/files-proxy.md
+++ b/docs/analysis/files-proxy.md
@@ -1,0 +1,13 @@
+# Files proxy (#155)
+
+## Behavior
+OpenAI-compatible /v1/files routes use PrepareCtx + dispatchUpstream:
+- POST /v1/files (multipart supported)
+- GET /v1/files, GET /v1/files/{id}, GET /v1/files/{id}/content
+- DELETE /v1/files/{id}
+
+Default model for channel selection: gpt-4o-mini.
+
+## Residual
+- Upstream sites without a files API return upstream errors (not MetAPI 501).
+- No local durable file store; MetAPI is pass-through only.

--- a/docs/api.md
+++ b/docs/api.md
@@ -560,3 +560,8 @@ Forwarded client IP headers are ignored by default. Set `TRUSTED_PROXY_CIDRS` on
 ### GET /api/downstream-keys/:id/export
 
 Admin credential export adapters (openai/cherry/generic). See docs/analysis/credential-export.md.
+
+
+### /v1/files*
+
+OpenAI-compatible files proxy (upload/list/get/content/delete). Pass-through to selected upstream; residual platforms without files API return upstream errors. See docs/analysis/files-proxy.md.

--- a/handler/proxy/files.go
+++ b/handler/proxy/files.go
@@ -2,12 +2,12 @@ package proxyhandler
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 )
 
-// RegisterFilesRoutes registers file proxy routes.
-// Mounted under /v1, so paths omit the /v1 prefix.
+// RegisterFilesRoutes registers file proxy routes under /v1.
 func RegisterFilesRoutes(r chi.Router) {
 	r.Post("/files", HandleFilesUpload)
 	r.Get("/files/{fileId}/content", HandleFilesDownload)
@@ -16,30 +16,114 @@ func RegisterFilesRoutes(r chi.Router) {
 	r.Delete("/files/{fileId}", HandleFilesDelete)
 }
 
-// HandleFilesUpload handles POST /v1/files (file upload).
+// HandleFilesUpload handles POST /v1/files (multipart or JSON).
 func HandleFilesUpload(w http.ResponseWriter, r *http.Request) {
-	writeJSONError(w, 501, "files upload not yet implemented", "server_error")
+	EnsureMultipartBufferParser()
+	ctx, errResp := PrepareCtx(r, SurfConfig{
+		Endpoint:       "files",
+		DownstreamPath: "/v1/files",
+		RequireModel:   false,
+		DefaultModel:   "gpt-4o-mini",
+	})
+	if errResp != nil {
+		writeJSONError(w, errResp.Status, errResp.Error, errResp.ErrorType)
+		return
+	}
+	dispatchUpstream(w, r, ctx)
 }
 
 // HandleFilesDownload handles GET /v1/files/{fileId}/content.
 func HandleFilesDownload(w http.ResponseWriter, r *http.Request) {
-	writeJSONError(w, 501, "files download not yet implemented", "server_error")
+	fileID := strings.TrimSpace(filesPathID(r, "fileId"))
+	if fileID == "" {
+		writeJSONError(w, 400, "fileId is required", "invalid_request_error")
+		return
+	}
+	ctx, errResp := PrepareCtx(r, SurfConfig{
+		Endpoint:       "files",
+		DownstreamPath: "/v1/files/" + fileID + "/content",
+		RequireModel:   false,
+		DefaultModel:   "gpt-4o-mini",
+	})
+	if errResp != nil {
+		writeJSONError(w, errResp.Status, errResp.Error, errResp.ErrorType)
+		return
+	}
+	dispatchUpstream(w, r, ctx)
 }
 
 // HandleFilesInfo handles GET /v1/files/{fileId}.
 func HandleFilesInfo(w http.ResponseWriter, r *http.Request) {
-	writeJSONError(w, 501, "files info not yet implemented", "server_error")
+	fileID := strings.TrimSpace(filesPathID(r, "fileId"))
+	if fileID == "" {
+		writeJSONError(w, 400, "fileId is required", "invalid_request_error")
+		return
+	}
+	ctx, errResp := PrepareCtx(r, SurfConfig{
+		Endpoint:       "files",
+		DownstreamPath: "/v1/files/" + fileID,
+		RequireModel:   false,
+		DefaultModel:   "gpt-4o-mini",
+	})
+	if errResp != nil {
+		writeJSONError(w, errResp.Status, errResp.Error, errResp.ErrorType)
+		return
+	}
+	dispatchUpstream(w, r, ctx)
 }
 
 // HandleFilesList handles GET /v1/files.
 func HandleFilesList(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, 200, map[string]any{
-		"object": "list",
-		"data":   []any{},
+	ctx, errResp := PrepareCtx(r, SurfConfig{
+		Endpoint:       "files",
+		DownstreamPath: "/v1/files",
+		RequireModel:   false,
+		DefaultModel:   "gpt-4o-mini",
 	})
+	if errResp != nil {
+		writeJSONError(w, errResp.Status, errResp.Error, errResp.ErrorType)
+		return
+	}
+	// Preserve query string for purpose/limit filters when present.
+	if q := r.URL.RawQuery; q != "" {
+		ctx.DownstreamPath = ctx.DownstreamPath + "?" + q
+	}
+	dispatchUpstream(w, r, ctx)
 }
 
 // HandleFilesDelete handles DELETE /v1/files/{fileId}.
 func HandleFilesDelete(w http.ResponseWriter, r *http.Request) {
-	writeJSONError(w, 501, "files delete not yet implemented", "server_error")
+	fileID := strings.TrimSpace(filesPathID(r, "fileId"))
+	if fileID == "" {
+		writeJSONError(w, 400, "fileId is required", "invalid_request_error")
+		return
+	}
+	ctx, errResp := PrepareCtx(r, SurfConfig{
+		Endpoint:       "files",
+		DownstreamPath: "/v1/files/" + fileID,
+		RequireModel:   false,
+		DefaultModel:   "gpt-4o-mini",
+	})
+	if errResp != nil {
+		writeJSONError(w, errResp.Status, errResp.Error, errResp.ErrorType)
+		return
+	}
+	dispatchUpstream(w, r, ctx)
+}
+
+func filesPathID(r *http.Request, param string) string {
+	id := strings.TrimSpace(chi.URLParam(r, param))
+	if id != "" {
+		return id
+	}
+	// Fallback when handler is invoked without chi route context (unit tests).
+	path := strings.Trim(r.URL.Path, "/")
+	parts := strings.Split(path, "/")
+	// expect .../files/{id}[/content]
+	for i := 0; i < len(parts); i++ {
+		if parts[i] == "files" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return ""
 }

--- a/handler/proxy/files_test.go
+++ b/handler/proxy/files_test.go
@@ -5,61 +5,64 @@ import (
 	"testing"
 )
 
-func TestHandleFilesList_Empty(t *testing.T) {
+func TestHandleFilesList_Unauthorized(t *testing.T) {
+	SetUpstreamConfig(nil)
 	req := httptest.NewRequest("GET", "/v1/files", nil)
 	rec := httptest.NewRecorder()
 	HandleFilesList(rec, req)
-
-	if rec.Code != 200 {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	m := unmarshalResponse(t, rec)
-	if m["object"] != "list" {
-		t.Errorf("object = %v", m["object"])
-	}
-	data, _ := m["data"].([]any)
-	if len(data) != 0 {
-		t.Errorf("expected empty data, got %d items", len(data))
+	if rec.Code != 401 {
+		t.Fatalf("expected 401 without auth, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
-func TestHandleFilesUpload_Returns501(t *testing.T) {
+func TestHandleFilesUpload_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("POST", "/v1/files", nil)
 	rec := httptest.NewRecorder()
 	HandleFilesUpload(rec, req)
-
-	if rec.Code != 501 {
-		t.Errorf("expected 501, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != 401 {
+		t.Errorf("expected 401, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
-func TestHandleFilesDownload_Returns501(t *testing.T) {
+func TestHandleFilesDownload_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/v1/files/test/content", nil)
 	rec := httptest.NewRecorder()
 	HandleFilesDownload(rec, req)
-
-	if rec.Code != 501 {
-		t.Errorf("expected 501, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != 401 {
+		t.Errorf("expected 401, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
-func TestHandleFilesInfo_Returns501(t *testing.T) {
+func TestHandleFilesInfo_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", "/v1/files/test", nil)
 	rec := httptest.NewRecorder()
 	HandleFilesInfo(rec, req)
-
-	if rec.Code != 501 {
-		t.Errorf("expected 501, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != 401 {
+		t.Errorf("expected 401, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
-func TestHandleFilesDelete_Returns501(t *testing.T) {
+func TestHandleFilesDelete_Unauthorized(t *testing.T) {
 	req := httptest.NewRequest("DELETE", "/v1/files/test", nil)
 	rec := httptest.NewRecorder()
 	HandleFilesDelete(rec, req)
+	if rec.Code != 401 {
+		t.Errorf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
 
-	if rec.Code != 501 {
-		t.Errorf("expected 501, got %d: %s", rec.Code, rec.Body.String())
+func TestHandleFiles_NotHard501(t *testing.T) {
+	req := httptest.NewRequest("POST", "/v1/files", nil)
+	rec := httptest.NewRecorder()
+	HandleFilesUpload(rec, req)
+	if rec.Code == 501 {
+		t.Fatalf("unexpected hard 501 stub: %s", rec.Body.String())
+	}
+}
+
+func TestFilesPathID(t *testing.T) {
+	req := httptest.NewRequest("GET", "/v1/files/abc123/content", nil)
+	if got := filesPathID(req, "fileId"); got != "abc123" {
+		t.Fatalf("got %q", got)
 	}
 }

--- a/handler/proxy/router_test.go
+++ b/handler/proxy/router_test.go
@@ -225,7 +225,7 @@ func TestFilesListRoute_Returns200(t *testing.T) {
 	}
 }
 
-func TestFilesUploadRoute_501(t *testing.T) {
+func TestFilesUploadRoute_NotHard501(t *testing.T) {
 	r := chi.NewRouter()
 	r.Use(injectAuth)
 	RegisterProxyRoutes(r)
@@ -234,8 +234,8 @@ func TestFilesUploadRoute_501(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != 501 {
-		t.Errorf("expected 501, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code == 501 {
+		t.Errorf("unexpected hard 501 stub: %s", rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- /v1/files* uses shared proxy surface (auth + channel selection + upstream)
- No more hard 501 stubs
- Multipart upload supported via existing CloneMultipartBody path

## Test plan
- [x] go test ./handler/proxy -run Files
- [ ] CI green

Closes #155