### PR TITLE
feat(ops): complete residual probe wiring after #160 (#154)

### DIFF
--- a/docs/analysis/ops-probe-wiring.md
+++ b/docs/analysis/ops-probe-wiring.md
@@ -1,11 +1,106 @@
 # Ops probe wiring (#154)
 
-## Changes
-- ModelProbeScheduler TriggerNow + process-global registry for admin triggers
-- POST /api/models/probe queues a real probe pass (no stub-probe job id)
-- POST /api/sites/{id}/probe-now and SSE probe-stream call ProbeSite over active channels (limit 32)
-- channel_recovery.probeCandidate uses the global model probe executor when registered
+**Date:** 2026-07-17  
+**Issue:** [#154](https://github.com/TokenDanceLab/metapi-go/issues/154)  
+**Lane:** program:enterprise-ops / lane:ops-probe  
+**Code:**
+- `handler/admin/sites.go` (`probeNow` / `probeStream`)
+- `handler/admin/site_probe.go` (forced site probe runtime)
+- `handler/admin/channel_test_harness.go` (#119 transport reuse)
+- `handler/admin/stats.go` (`POST /api/models/probe`)
+- `scheduler/model_probe.go` + `scheduler/model_probe_jobs.go`
+- `scheduler/channel_recovery.go` (`probeCandidate` → `ApplyProbeOutcome`)
 
-## Residual
-- Ephemeral NewModelProbeScheduler(nil) path has no injected HTTP probe executor until app wires SetProbeExecutor / global scheduler at boot
-- Marketplace and model-check remain separate issues (#156)
+## Goal
+
+Replace admin probe stubs with real runtime paths that already exist in scheduler model probe + the #119 channel test harness.
+
+## Before → After
+
+| Surface | Before | After |
+|---------|--------|-------|
+| `POST /api/sites/{id}/probe-now` | Always `{totalModels:0, results:[]}` | Loads site accounts/models, forces chat probes via harness transport, upserts `model_availability`, auto-disables unsupported models |
+| `GET /api/sites/{id}/probe-stream` | Instant `probe-start` + zero `complete` | SSE progress: `start`/`model`/`action`/`complete` (+ compatibility `probe-*` aliases) |
+| `POST /api/models/probe` | `jobId: "stub-probe"` | UUID-like job id via in-memory job registry; optional `wait=true` sync completion; triggers `ModelProbeScheduler.TriggerNow` when scheduler has started |
+| `channel_recovery.probeCandidate` | Log-only TODO | Injected `ChannelHealthProbe` + `ChannelHealthRecorder` through `ApplyProbeOutcome` |
+
+## Runtime flow
+
+### Site forced probe
+
+```
+probeNow / probeStream
+  → loadSiteProbeTargets(site)
+       · model names from model_availability ∪ token_model_availability ∪ route_channels.source_model
+       · prefer channel+account for each model; fall back to first active account
+  → for each model:
+       channelTestHandler.executeProbe(mode=chat)   // #119 harness, injectable transport
+       upsert model_availability(account, model, available, latency)
+       if unsupported → ensure site_disabled_models row + SSE action=disabled
+       stamp routing.RecordSiteProbeOutcome (site runtime only; no credential cascade)
+  → summary { totalModels, available, unavailable, probed, unsupported, results[], emptyReason? }
+```
+
+Empty sites return `success=true` with `totalModels=0` and a clear `emptyReason` (no accounts/models), not a hard error.
+
+### SSE contract (frontend Sites.tsx)
+
+Primary event names (what the SPA parses):
+
+| Event | Payload highlights |
+|-------|--------------------|
+| `start` | `scope`, `modelsCount`, `startedAt` |
+| `model` | `modelName`, `status` (`supported`/`unsupported`/`skipped`), `latencyMs`, `reason`, `latencyExceeded` |
+| `action` | `action=disabled`, `modelName` |
+| `complete` | `probed`, `unsupported`, `available`, `unavailable`, `results` |
+| `error` | `message` |
+
+Compatibility aliases still emitted: `probe-start`, `probe-model-checked`, `probe-model-result`.
+
+### Global model probe job
+
+```
+POST /api/models/probe { accountId?, wait? }
+  → scheduler.EnqueueModelProbeJob
+       · real job id (uuid-like), never "stub-probe"
+       · wait=false → 202 { queued:true, jobId, status }
+       · wait=true  → 200 { jobId, status:completed, summary }
+  → trigger hook (registered in ModelProbeScheduler.Start) calls TriggerNow()
+       · same budgeted loadProbeTargets + account leases as ticker path
+```
+
+### Channel recovery
+
+```
+probeCandidate
+  → loadRecoveryProbeTarget(channel → account/site/model)
+  → ChannelHealthProbe.ProbeChannel
+  → ApplyProbeOutcome(recorder, target, outcome)
+       · success → RecordProbeSuccess
+       · failure → RecordProbeFailure (channel-local; no key expiry)
+       · missing deps → skipped (safe no-op)
+```
+
+Composition root may inject probe/recorder via `SetProbeExecutor` / `SetHealthRecorder` (same ports as model-probe). Until injected, recovery remains a safe skip rather than a crash.
+
+## Tests
+
+```bash
+go test ./handler/admin ./scheduler -count=1
+```
+
+Coverage added:
+- site probe success + availability upsert (fake transport)
+- empty site `emptyReason`
+- SSE multi-event stream (not instant zero complete)
+- unsupported auto-disable
+- `/api/models/probe` real job id + wait summary
+- channel recovery success/failure via fakes + `ApplyProbeOutcome`
+- model probe job registry async/sync
+
+## Non-goals
+
+- Full marketplace catalog rewrite
+- Redis multi-instance probe coordination
+- Frontend redesign (`web/**` only consumed existing SSE field names)
+- Wiring a production HTTP probe executor for channel recovery (still injected at composition root; ports are live)

--- a/handler/admin/site_probe.go
+++ b/handler/admin/site_probe.go
@@ -1,0 +1,644 @@
+package admin
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+// siteProbeOptions controls forced site model probing.
+type siteProbeOptions struct {
+	Scope              string
+	ModelName          string
+	LatencyThresholdMs int
+}
+
+// siteProbeModelResult is one model outcome from a forced site probe pass.
+type siteProbeModelResult struct {
+	ModelName       string `json:"modelName"`
+	Available       bool   `json:"available"`
+	Status          string `json:"status"` // supported | unsupported | skipped
+	LatencyMs       *int64 `json:"latencyMs,omitempty"`
+	Reason          string `json:"reason,omitempty"`
+	LatencyExceeded bool   `json:"latencyExceeded,omitempty"`
+	AccountID       int64  `json:"accountId,omitempty"`
+	ChannelID       int64  `json:"channelId,omitempty"`
+	Error           string `json:"error,omitempty"`
+	DisabledByProbe bool   `json:"disabledByProbe,omitempty"`
+}
+
+// siteProbeSummary aggregates a forced site probe pass.
+type siteProbeSummary struct {
+	Success     bool                   `json:"success"`
+	TotalModels int                    `json:"totalModels"`
+	Available   int                    `json:"available"`
+	Unavailable int                    `json:"unavailable"`
+	Probed      int                    `json:"probed"`
+	Unsupported int                    `json:"unsupported"`
+	Skipped     int                    `json:"skipped"`
+	Results     []siteProbeModelResult `json:"results"`
+	EmptyReason string                 `json:"emptyReason,omitempty"`
+	Scope       string                 `json:"scope,omitempty"`
+	StartedAt   string                 `json:"startedAt,omitempty"`
+	CompletedAt string                 `json:"completedAt,omitempty"`
+}
+
+// siteProbeProgressEvent is emitted during SSE probe streaming.
+type siteProbeProgressEvent struct {
+	Type string
+	Data map[string]any
+}
+
+type siteProbeTarget struct {
+	ModelName string
+	ChannelID int64
+	AccountID int64
+	SiteID    int64
+	SiteURL   string
+	SiteName  string
+	Platform  string
+	Token     string
+	Account   store.Account
+	Site      store.Site
+}
+
+const (
+	siteProbeDefaultTimeoutMs = 15_000
+	siteProbeMinTimeoutMs     = 1_000
+	siteProbeMaxTimeoutMs     = 60_000
+)
+
+// runSiteProbe loads models for a site, forces lightweight chat probes through the
+// #119 harness transport path, updates model_availability, and optionally
+// auto-disables unsupported models for the site.
+func (h *sitesHandler) runSiteProbe(
+	ctx context.Context,
+	siteID int64,
+	opts siteProbeOptions,
+	onProgress func(siteProbeProgressEvent),
+) (*siteProbeSummary, error) {
+	if siteID <= 0 {
+		return nil, fmt.Errorf("Invalid site id")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var site store.Site
+	if err := h.db.GetContext(ctx, &site, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), siteID); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("site not found")
+		}
+		return nil, fmt.Errorf("load site: %w", err)
+	}
+
+	scope := strings.ToLower(strings.TrimSpace(opts.Scope))
+	if scope != "single" {
+		// Treat empty / "all" / unknown as all for operator convenience.
+		if scope == "" || scope == "all" {
+			scope = "all"
+		} else {
+			scope = "all"
+		}
+	}
+	modelName := strings.TrimSpace(opts.ModelName)
+	if scope == "single" && modelName == "" {
+		// Fall back to site post-refresh probe model when present.
+		modelName = strings.TrimSpace(site.PostRefreshProbeModel)
+	}
+
+	latencyThreshold := opts.LatencyThresholdMs
+	if latencyThreshold <= 0 && site.PostRefreshProbeLatencyThresholdMs > 0 {
+		latencyThreshold = int(site.PostRefreshProbeLatencyThresholdMs)
+	}
+
+	targets, emptyReason, err := h.loadSiteProbeTargets(ctx, site, scope, modelName)
+	if err != nil {
+		return nil, err
+	}
+
+	startedAt := time.Now().UTC().Format(time.RFC3339)
+	summary := &siteProbeSummary{
+		Success:     true,
+		TotalModels: len(targets),
+		Results:     make([]siteProbeModelResult, 0, len(targets)),
+		Scope:       scope,
+		StartedAt:   startedAt,
+		EmptyReason: emptyReason,
+	}
+
+	if onProgress != nil {
+		onProgress(siteProbeProgressEvent{
+			Type: "start",
+			Data: map[string]any{
+				"scope":       scope,
+				"modelsCount": len(targets),
+				"startedAt":   startedAt,
+				"siteId":      siteID,
+			},
+		})
+	}
+
+	if len(targets) == 0 {
+		summary.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+		if summary.EmptyReason == "" {
+			summary.EmptyReason = "no probe targets (accounts/models)"
+		}
+		return summary, nil
+	}
+
+	probe := h.newSiteProbeHarness()
+	disabledModels := map[string]bool{}
+
+	for _, target := range targets {
+		if err := ctx.Err(); err != nil {
+			return summary, err
+		}
+
+		result := h.probeOneSiteModel(ctx, probe, target, latencyThreshold)
+		summary.Results = append(summary.Results, result)
+		summary.Probed++
+
+		switch result.Status {
+		case "supported":
+			summary.Available++
+		case "unsupported":
+			summary.Unavailable++
+			summary.Unsupported++
+		default:
+			summary.Skipped++
+		}
+
+		if onProgress != nil {
+			onProgress(siteProbeProgressEvent{
+				Type: "model",
+				Data: map[string]any{
+					"modelName":       result.ModelName,
+					"status":          result.Status,
+					"latencyMs":       result.LatencyMs,
+					"reason":          result.Reason,
+					"latencyExceeded": result.LatencyExceeded,
+					"available":       result.Available,
+					"accountId":       result.AccountID,
+					"channelId":       result.ChannelID,
+				},
+			})
+		}
+
+		// Persist account-level availability when we have an account target.
+		if target.AccountID > 0 && result.Status != "skipped" {
+			if err := upsertModelAvailability(h.db, target.AccountID, result.ModelName, result.Available, result.LatencyMs); err != nil {
+				slog.Warn("site probe: model_availability upsert failed",
+					"site_id", siteID,
+					"account_id", target.AccountID,
+					"model", result.ModelName,
+					"error", err,
+				)
+			}
+		}
+
+		// Auto-disable unsupported models for the site (matches Sites.tsx complete copy).
+		if result.Status == "unsupported" && !disabledModels[result.ModelName] {
+			if err := ensureSiteDisabledModel(h.db, siteID, result.ModelName); err != nil {
+				slog.Warn("site probe: disable model failed",
+					"site_id", siteID,
+					"model", result.ModelName,
+					"error", err,
+				)
+			} else {
+				disabledModels[result.ModelName] = true
+				result.DisabledByProbe = true
+				summary.Results[len(summary.Results)-1] = result
+				if onProgress != nil {
+					onProgress(siteProbeProgressEvent{
+						Type: "action",
+						Data: map[string]any{
+							"action":    "disabled",
+							"modelName": result.ModelName,
+						},
+					})
+				}
+			}
+		}
+
+		// Best-effort runtime health stamp when we have a real channel id.
+		if target.ChannelID > 0 {
+			applySiteProbeHealth(ctx, target, result)
+		}
+	}
+
+	summary.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+	return summary, nil
+}
+
+func (h *sitesHandler) newSiteProbeHarness() *channelTestHandler {
+	cfg := h.cfg
+	if cfg == nil {
+		// config.Get panics if unset; protect unit tests that never load config.
+		func() {
+			defer func() { _ = recover() }()
+			cfg = config.Get()
+		}()
+	}
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	return &channelTestHandler{
+		db:        h.db,
+		cfg:       cfg,
+		transport: h.transport,
+	}
+}
+
+func (h *sitesHandler) loadSiteProbeTargets(
+	ctx context.Context,
+	site store.Site,
+	scope, modelName string,
+) ([]siteProbeTarget, string, error) {
+	// Prefer enabled route_channels with non-empty source_model for this site.
+	type channelRow struct {
+		ID          int64   `db:"id"`
+		AccountID   int64   `db:"account_id"`
+		SourceModel *string `db:"source_model"`
+		Enabled     bool    `db:"enabled"`
+		TokenID     *int64  `db:"token_id"`
+	}
+	var channels []channelRow
+	err := h.db.SelectContext(ctx, &channels, h.db.Rebind(`
+		SELECT rc.id, rc.account_id, rc.source_model, rc.enabled, rc.token_id
+		FROM route_channels rc
+		INNER JOIN accounts a ON a.id = rc.account_id
+		WHERE a.site_id = ?
+		ORDER BY rc.enabled DESC, rc.priority DESC, rc.id ASC
+	`), site.ID)
+	if err != nil {
+		return nil, "", fmt.Errorf("load site channels: %w", err)
+	}
+
+	// Also collect model names from availability tables (even if no channel yet).
+	modelSet := map[string]struct{}{}
+	if scope == "single" && modelName != "" {
+		modelSet[modelName] = struct{}{}
+	} else {
+		var availModels []string
+		_ = h.db.SelectContext(ctx, &availModels, h.db.Rebind(`
+			SELECT DISTINCT ma.model_name
+			FROM model_availability ma
+			INNER JOIN accounts a ON a.id = ma.account_id
+			WHERE a.site_id = ? AND COALESCE(ma.model_name, '') <> ''
+		`), site.ID)
+		for _, m := range availModels {
+			m = strings.TrimSpace(m)
+			if m != "" {
+				modelSet[m] = struct{}{}
+			}
+		}
+		var tokenModels []string
+		_ = h.db.SelectContext(ctx, &tokenModels, h.db.Rebind(`
+			SELECT DISTINCT tma.model_name
+			FROM token_model_availability tma
+			INNER JOIN account_tokens at ON at.id = tma.token_id
+			INNER JOIN accounts a ON a.id = at.account_id
+			WHERE a.site_id = ? AND COALESCE(tma.model_name, '') <> ''
+		`), site.ID)
+		for _, m := range tokenModels {
+			m = strings.TrimSpace(m)
+			if m != "" {
+				modelSet[m] = struct{}{}
+			}
+		}
+		for _, ch := range channels {
+			if ch.SourceModel == nil {
+				continue
+			}
+			m := strings.TrimSpace(*ch.SourceModel)
+			if m != "" {
+				modelSet[m] = struct{}{}
+			}
+		}
+	}
+
+	if len(modelSet) == 0 {
+		return nil, "no models found for site (availability/channels empty)", nil
+	}
+
+	// Load active accounts for the site once.
+	type accountRow struct {
+		ID            int64   `db:"id"`
+		SiteID        int64   `db:"site_id"`
+		AccessToken   string  `db:"access_token"`
+		APIToken      *string `db:"api_token"`
+		OAuthProvider *string `db:"oauth_provider"`
+		ExtraConfig   *string `db:"extra_config"`
+		Status        string  `db:"status"`
+	}
+	var accounts []accountRow
+	if err := h.db.SelectContext(ctx, &accounts, h.db.Rebind(`
+		SELECT id, site_id, access_token, api_token, oauth_provider, extra_config, status
+		FROM accounts
+		WHERE site_id = ?
+		ORDER BY CASE WHEN status = 'active' THEN 0 ELSE 1 END, id ASC
+	`), site.ID); err != nil {
+		return nil, "", fmt.Errorf("load site accounts: %w", err)
+	}
+	if len(accounts) == 0 {
+		return nil, "no accounts for site", nil
+	}
+
+	// Map channels by model (prefer enabled).
+	channelByModel := map[string]channelRow{}
+	for _, ch := range channels {
+		if ch.SourceModel == nil {
+			continue
+		}
+		m := strings.TrimSpace(*ch.SourceModel)
+		if m == "" {
+			continue
+		}
+		existing, ok := channelByModel[m]
+		if !ok || (!existing.Enabled && ch.Enabled) {
+			channelByModel[m] = ch
+		}
+	}
+
+	// Account lookup.
+	accountByID := map[int64]accountRow{}
+	var fallbackAccount accountRow
+	for i, acc := range accounts {
+		accountByID[acc.ID] = acc
+		if i == 0 || (fallbackAccount.Status != "active" && acc.Status == "active") {
+			fallbackAccount = acc
+		}
+	}
+
+	// Optional token cache.
+	tokenCache := map[int64]string{}
+
+	models := make([]string, 0, len(modelSet))
+	for m := range modelSet {
+		models = append(models, m)
+	}
+	sortStringsCI(models)
+
+	targets := make([]siteProbeTarget, 0, len(models))
+	for _, model := range models {
+		var acc accountRow
+		var channelID int64
+		var tokenID *int64
+
+		if ch, ok := channelByModel[model]; ok {
+			channelID = ch.ID
+			tokenID = ch.TokenID
+			if a, ok := accountByID[ch.AccountID]; ok {
+				acc = a
+			}
+		}
+		if acc.ID == 0 {
+			acc = fallbackAccount
+		}
+		if acc.ID == 0 {
+			continue
+		}
+
+		tokenValue := ""
+		if tokenID != nil && *tokenID > 0 {
+			if cached, ok := tokenCache[*tokenID]; ok {
+				tokenValue = cached
+			} else {
+				var tr harnessTokenRow
+				if err := h.db.GetContext(ctx, &tr, h.db.Rebind(`
+					SELECT id, token, enabled FROM account_tokens WHERE id = ?`), *tokenID); err == nil {
+					if tr.Enabled {
+						tokenValue = tr.Token
+					}
+				}
+				tokenCache[*tokenID] = tokenValue
+			}
+		}
+		if tokenValue == "" {
+			tokenValue = resolveHarnessToken(tokenID, nil, harnessAccountRow{
+				ID:            acc.ID,
+				SiteID:        acc.SiteID,
+				AccessToken:   acc.AccessToken,
+				APIToken:      acc.APIToken,
+				OAuthProvider: acc.OAuthProvider,
+				ExtraConfig:   acc.ExtraConfig,
+				Status:        acc.Status,
+			})
+		}
+
+		targets = append(targets, siteProbeTarget{
+			ModelName: model,
+			ChannelID: channelID,
+			AccountID: acc.ID,
+			SiteID:    site.ID,
+			SiteURL:   site.URL,
+			SiteName:  site.Name,
+			Platform:  site.Platform,
+			Token:     tokenValue,
+			Account: store.Account{
+				ID:            acc.ID,
+				SiteID:        acc.SiteID,
+				AccessToken:   acc.AccessToken,
+				APIToken:      acc.APIToken,
+				OAuthProvider: acc.OAuthProvider,
+				ExtraConfig:   acc.ExtraConfig,
+				Status:        acc.Status,
+			},
+			Site: site,
+		})
+	}
+
+	if len(targets) == 0 {
+		return nil, "no probeable account/model pairs", nil
+	}
+	return targets, "", nil
+}
+
+func (h *sitesHandler) probeOneSiteModel(
+	ctx context.Context,
+	probe *channelTestHandler,
+	target siteProbeTarget,
+	latencyThresholdMs int,
+) siteProbeModelResult {
+	result := siteProbeModelResult{
+		ModelName: target.ModelName,
+		Status:    "unsupported",
+		AccountID: target.AccountID,
+		ChannelID: target.ChannelID,
+	}
+
+	if target.Token == "" {
+		result.Status = "skipped"
+		result.Reason = "missing credential / no usable token"
+		result.Error = result.Reason
+		return result
+	}
+
+	timeoutMs := int64(siteProbeDefaultTimeoutMs)
+	if timeoutMs < siteProbeMinTimeoutMs {
+		timeoutMs = siteProbeMinTimeoutMs
+	}
+	if timeoutMs > siteProbeMaxTimeoutMs {
+		timeoutMs = siteProbeMaxTimeoutMs
+	}
+
+	harnessTarget := &channelTestTarget{
+		ChannelID:   target.ChannelID,
+		AccountID:   target.AccountID,
+		SiteID:      target.SiteID,
+		SourceModel: target.ModelName,
+		SiteName:    target.SiteName,
+		SiteURL:     target.SiteURL,
+		Platform:    target.Platform,
+		TokenValue:  target.Token,
+		Account:     target.Account,
+		Site:        target.Site,
+	}
+
+	out := probe.executeProbe(ctx, harnessTarget, channelTestModeChat, target.ModelName, channelTestDefaultPrompt, timeoutMs)
+
+	var latency int64
+	if v, ok := out["latencyMs"].(int64); ok {
+		latency = v
+	} else if v, ok := out["latencyMs"].(float64); ok {
+		latency = int64(v)
+	} else if v, ok := out["latencyMs"].(int); ok {
+		latency = int64(v)
+	}
+	result.LatencyMs = &latency
+
+	success, _ := out["success"].(bool)
+	errText := ""
+	switch v := out["error"].(type) {
+	case string:
+		errText = v
+	case nil:
+		errText = ""
+	default:
+		errText = fmt.Sprint(v)
+	}
+
+	if success {
+		if latencyThresholdMs > 0 && latency > int64(latencyThresholdMs) {
+			result.Status = "unsupported"
+			result.Available = false
+			result.LatencyExceeded = true
+			result.Reason = fmt.Sprintf("响应延迟超过阈值 (%dms > %dms)", latency, latencyThresholdMs)
+			result.Error = result.Reason
+			return result
+		}
+		result.Status = "supported"
+		result.Available = true
+		return result
+	}
+
+	result.Status = "unsupported"
+	result.Available = false
+	if errText == "" {
+		if code, ok := out["statusCode"].(int); ok && code > 0 {
+			errText = fmt.Sprintf("upstream status %d", code)
+		} else if code, ok := out["statusCode"].(float64); ok && code > 0 {
+			errText = fmt.Sprintf("upstream status %d", int(code))
+		} else {
+			errText = "probe failed"
+		}
+	}
+	result.Reason = errText
+	result.Error = errText
+	return result
+}
+
+func upsertModelAvailability(db interface {
+	Get(dest any, query string, args ...any) error
+	Exec(query string, args ...any) (sql.Result, error)
+	Rebind(query string) string
+}, accountID int64, modelName string, available bool, latencyMs *int64) error {
+	modelName = strings.TrimSpace(modelName)
+	if accountID <= 0 || modelName == "" {
+		return nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	var existingID int64
+	err := db.Get(&existingID, db.Rebind(`
+		SELECT id FROM model_availability WHERE account_id = ? AND model_name = ?`), accountID, modelName)
+	if err == nil {
+		_, err = db.Exec(db.Rebind(`
+			UPDATE model_availability
+			SET available = ?, is_manual = ?, latency_ms = ?, checked_at = ?
+			WHERE id = ?`), available, false, latencyMs, now, existingID)
+		return err
+	}
+	if err != sql.ErrNoRows {
+		return err
+	}
+	_, err = db.Exec(db.Rebind(`
+		INSERT INTO model_availability (account_id, model_name, available, is_manual, latency_ms, checked_at)
+		VALUES (?, ?, ?, ?, ?, ?)`), accountID, modelName, available, false, latencyMs, now)
+	return err
+}
+
+func ensureSiteDisabledModel(db interface {
+	Get(dest any, query string, args ...any) error
+	Exec(query string, args ...any) (sql.Result, error)
+	Rebind(query string) string
+}, siteID int64, modelName string) error {
+	modelName = strings.TrimSpace(modelName)
+	if siteID <= 0 || modelName == "" {
+		return nil
+	}
+	var existing string
+	err := db.Get(&existing, db.Rebind(`
+		SELECT model_name FROM site_disabled_models WHERE site_id = ? AND model_name = ?`), siteID, modelName)
+	if err == nil {
+		return nil
+	}
+	if err != sql.ErrNoRows {
+		// Some drivers may return empty without ErrNoRows; treat non-nil carefully.
+		// Fall through to insert attempt for robustness.
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err = db.Exec(db.Rebind(`
+		INSERT INTO site_disabled_models (site_id, model_name, created_at) VALUES (?, ?, ?)`), siteID, modelName, now)
+	return err
+}
+
+// applySiteProbeHealth stamps site runtime probe status only.
+// Forced admin probes intentionally do not mutate channel cooldown.
+func applySiteProbeHealth(_ context.Context, target siteProbeTarget, result siteProbeModelResult) {
+	status := "inconclusive"
+	latency := 0.0
+	if result.LatencyMs != nil {
+		latency = float64(*result.LatencyMs)
+	}
+	switch result.Status {
+	case "supported":
+		status = "success"
+	case "unsupported":
+		status = "failure"
+	case "skipped":
+		return
+	}
+	model := target.ModelName
+	var channelPtr *int64
+	if target.ChannelID > 0 {
+		id := target.ChannelID
+		channelPtr = &id
+	}
+	var errPtr *string
+	if result.Error != "" {
+		e := result.Error
+		errPtr = &e
+	}
+	recordSiteProbeOutcome(target.SiteID, status, latency, &model, channelPtr, errPtr)
+}
+
+// recordSiteProbeOutcome is a tiny seam so tests can stub if needed.
+var recordSiteProbeOutcome = defaultRecordSiteProbeOutcome

--- a/handler/admin/site_probe_routing.go
+++ b/handler/admin/site_probe_routing.go
@@ -1,0 +1,7 @@
+package admin
+
+import "github.com/tokendancelab/metapi-go/routing"
+
+func defaultRecordSiteProbeOutcome(siteID int64, status string, latencyMs float64, modelName *string, channelID *int64, errText *string) {
+	routing.RecordSiteProbeOutcome(siteID, status, latencyMs, modelName, channelID, errText)
+}

--- a/handler/admin/site_probe_test.go
+++ b/handler/admin/site_probe_test.go
@@ -1,0 +1,224 @@
+package admin
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func insertSiteProbeFixtures(t *testing.T, db *store.DB, siteURL string) (siteID, accountID, channelID int64) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	res, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "ProbeWireSite", siteURL, "openai", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ = res.LastInsertId()
+
+	apiTok := "sk-probe-wire-token"
+	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, ?, 'active', 0, ?, ?)`, siteID, "probe-user", "session", apiTok, now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ = res.LastInsertId()
+
+	if _, err := db.Exec(`INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at)
+		VALUES (?, ?, 1, 0, ?)`, accountID, "gpt-4o-mini", now); err != nil {
+		t.Fatalf("insert model availability: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at)
+		VALUES (?, ?, 1, 0, ?)`, accountID, "gpt-4o", now); err != nil {
+		t.Fatalf("insert model availability 2: %v", err)
+	}
+
+	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
+		VALUES (?, ?, 'standard', 'weighted', 1, ?, ?)`, "gpt-*", "Probe Route", now, now)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	routeID, _ := res.LastInsertId()
+
+	res, err = db.Exec(`INSERT INTO route_channels (route_id, account_id, source_model, priority, weight, enabled)
+		VALUES (?, ?, ?, 10, 10, 1)`, routeID, accountID, "gpt-4o-mini")
+	if err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+	channelID, _ = res.LastInsertId()
+	return siteID, accountID, channelID
+}
+
+func setupSitesProbeHandler(t *testing.T) (*store.DB, *sitesHandler, chi.Router) {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	h := &sitesHandler{db: db.DB}
+	r := chi.NewRouter()
+	// Register using the same handler instance so tests can inject transport.
+	r.Get("/api/sites", h.listSites)
+	r.Post("/api/sites/{id}/probe-now", h.probeNow)
+	r.Get("/api/sites/{id}/probe-stream", h.probeStream)
+	r.Get("/api/sites/{id}/available-models", h.getAvailableModels)
+	r.Get("/api/sites/{id}/disabled-models", h.getDisabledModels)
+	return db, h, r
+}
+
+func TestSites_ProbeNow_RealResultsWithFakeTransport(t *testing.T) {
+	db, h, r := setupSitesProbeHandler(t)
+	siteID, accountID, _ := insertSiteProbeFixtures(t, db, "https://upstream.probe.test")
+
+	var hits atomic.Int32
+	h.transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		hits.Add(1)
+		body := `{"id":"chatcmpl-probe","choices":[{"message":{"role":"assistant","content":"pong"}}]}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+
+	resp := doPostJSON(t, r, "/api/sites/"+itoa(siteID)+"/probe-now", map[string]any{"scope": "all"})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", resp.Code, resp.Body.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out["success"] != true {
+		t.Fatalf("success=%v body=%s", out["success"], resp.Body.String())
+	}
+	total := int(out["totalModels"].(float64))
+	if total < 1 {
+		t.Fatalf("expected non-empty totalModels, got %v emptyReason=%v", out["totalModels"], out["emptyReason"])
+	}
+	if int(out["available"].(float64)) < 1 {
+		t.Fatalf("expected available > 0, got %v results=%v", out["available"], out["results"])
+	}
+	if hits.Load() < 1 {
+		t.Fatalf("expected fake transport hits, got %d", hits.Load())
+	}
+
+	// model_availability should be updated for the probed account/model.
+	var available int
+	if err := db.QueryRow(`SELECT available FROM model_availability WHERE account_id = ? AND model_name = 'gpt-4o-mini'`, accountID).Scan(&available); err != nil {
+		t.Fatalf("load availability: %v", err)
+	}
+	if available != 1 {
+		t.Fatalf("expected available=1 after successful probe, got %d", available)
+	}
+}
+
+func TestSites_ProbeNow_EmptyReasonWhenNoAccounts(t *testing.T) {
+	db, _, r := setupSitesProbeHandler(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "EmptySite", "https://empty.probe.test", "openai", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+
+	resp := doPostJSON(t, r, "/api/sites/"+itoa(siteID)+"/probe-now", map[string]any{"scope": "all"})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", resp.Code, resp.Body.String())
+	}
+	var out map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &out)
+	if int(out["totalModels"].(float64)) != 0 {
+		t.Fatalf("expected 0 models, got %v", out["totalModels"])
+	}
+	if out["emptyReason"] == nil || out["emptyReason"] == "" {
+		t.Fatalf("expected emptyReason, got %v", out["emptyReason"])
+	}
+}
+
+func TestSites_ProbeStream_EmitsProgressEvents(t *testing.T) {
+	db, h, r := setupSitesProbeHandler(t)
+	siteID, _, _ := insertSiteProbeFixtures(t, db, "https://upstream.stream.test")
+
+	h.transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"id":"chatcmpl-stream","choices":[{"message":{"role":"assistant","content":"ok"}}]}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+
+	req := httptest.NewRequest("GET", "/api/sites/"+itoa(siteID)+"/probe-stream?scope=all", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: start") && !strings.Contains(body, "event: probe-start") {
+		t.Fatalf("expected start event, body=%s", body)
+	}
+	if !strings.Contains(body, "event: model") && !strings.Contains(body, "event: probe-model-result") {
+		t.Fatalf("expected model progress event, body=%s", body)
+	}
+	if !strings.Contains(body, "event: complete") {
+		t.Fatalf("expected complete event, body=%s", body)
+	}
+	// Must not be the old instant-zero complete-only stub.
+	if strings.Count(body, "event:") < 3 {
+		t.Fatalf("expected multi-event stream, body=%s", body)
+	}
+}
+
+func TestSites_ProbeNow_UnsupportedDisablesModel(t *testing.T) {
+	db, h, r := setupSitesProbeHandler(t)
+	siteID, _, _ := insertSiteProbeFixtures(t, db, "https://upstream.fail.test")
+
+	h.transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":"no such model"}`)),
+			Request:    req,
+		}, nil
+	})
+
+	resp := doPostJSON(t, r, "/api/sites/"+itoa(siteID)+"/probe-now", map[string]any{
+		"scope":     "single",
+		"modelName": "gpt-4o-mini",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", resp.Code, resp.Body.String())
+	}
+	var out map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &out)
+	if int(out["unsupported"].(float64)) < 1 {
+		t.Fatalf("expected unsupported >= 1, got %v body=%s", out["unsupported"], resp.Body.String())
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM site_disabled_models WHERE site_id = ? AND model_name = 'gpt-4o-mini'`, siteID).Scan(&count); err != nil {
+		t.Fatalf("count disabled: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected model auto-disabled, count=%d", count)
+	}
+}

--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -3,7 +3,9 @@ package admin
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -12,9 +14,9 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/config"
 	"github.com/tokendancelab/metapi-go/handler/admin/payloads"
 	"github.com/tokendancelab/metapi-go/routing"
-	"github.com/tokendancelab/metapi-go/scheduler"
 	"github.com/tokendancelab/metapi-go/service"
 	"github.com/tokendancelab/metapi-go/store"
 )
@@ -40,6 +42,10 @@ func RegisterSitesRoutes(r chi.Router, db *sqlx.DB) {
 
 type sitesHandler struct {
 	db *sqlx.DB
+
+	// Optional overrides used by forced probe paths and tests.
+	cfg       *config.Config
+	transport http.RoundTripper
 }
 
 // ---- List Sites ----
@@ -650,22 +656,27 @@ func (h *sitesHandler) probeNow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body payloads.ProbeNowBody
-	// Body is optional for probe-now.
-	_ = decodeJSONRequest(r, &body)
-
-	sched := scheduler.GetGlobalModelProbeScheduler()
-	if sched == nil {
-		// Fall back: create ephemeral scheduler for one-shot probe.
-		sched = scheduler.NewModelProbeScheduler(nil)
+	// Empty body is allowed (probe all models with defaults).
+	if err := decodeJSONRequest(r, &body); err != nil && !errors.Is(err, io.EOF) {
+		// Tolerate empty body; reject only truly invalid JSON payloads.
+		msg := strings.ToLower(err.Error())
+		if !strings.Contains(msg, "eof") && !strings.Contains(msg, "unexpected end of json") {
+			writeError(w, http.StatusBadRequest, "Invalid request body")
+			return
+		}
 	}
-	results, available, unavailable := sched.ProbeSite(id)
-	writeJSON(w, http.StatusOK, map[string]any{
-		"success":     true,
-		"totalModels": len(results),
-		"available":   available,
-		"unavailable": unavailable,
-		"results":     results,
-	})
+
+	opts := siteProbeOptionsFromBody(body)
+	summary, err := h.runSiteProbe(r.Context(), id, opts, nil)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, summary)
 }
 
 // ---- Probe Stream (SSE) ----
@@ -689,31 +700,80 @@ func (h *sitesHandler) probeStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	scope := r.URL.Query().Get("scope")
-	modelName := r.URL.Query().Get("modelName")
-	latencyStr := r.URL.Query().Get("latencyThresholdMs")
-
-	_ = scope
-	_ = modelName
-	_ = latencyStr
-
-	sched := scheduler.GetGlobalModelProbeScheduler()
-	if sched == nil {
-		sched = scheduler.NewModelProbeScheduler(nil)
+	opts := siteProbeOptions{
+		Scope:     strings.TrimSpace(r.URL.Query().Get("scope")),
+		ModelName: strings.TrimSpace(r.URL.Query().Get("modelName")),
 	}
-	results, available, unavailable := sched.ProbeSite(id)
-	sseWrite(w, flusher, "probe-start", map[string]any{
-		"totalModels": len(results),
-		"startedAt":   time.Now().UTC().Format(time.RFC3339),
-	})
-	for _, res := range results {
-		sseWrite(w, flusher, "probe-result", res)
+	if latencyStr := strings.TrimSpace(r.URL.Query().Get("latencyThresholdMs")); latencyStr != "" {
+		if v, err := strconv.Atoi(latencyStr); err == nil && v > 0 {
+			opts.LatencyThresholdMs = v
+		}
+	}
+
+	// Frontend contract (Sites.tsx): event names are start/model/action/complete/error.
+	// Emit both start and probe-start so older consumers still see progress.
+	onProgress := func(ev siteProbeProgressEvent) {
+		switch ev.Type {
+		case "start":
+			sseWrite(w, flusher, "start", ev.Data)
+			sseWrite(w, flusher, "probe-start", map[string]any{
+				"totalModels": ev.Data["modelsCount"],
+				"startedAt":   ev.Data["startedAt"],
+				"scope":       ev.Data["scope"],
+			})
+		case "model":
+			sseWrite(w, flusher, "model", ev.Data)
+			// Compatibility aliases for earlier SSE draft names.
+			if modelName, _ := ev.Data["modelName"].(string); modelName != "" {
+				sseWrite(w, flusher, "probe-model-checked", map[string]any{
+					"modelName": modelName,
+					"checkedAt": time.Now().UTC().Format(time.RFC3339),
+				})
+				sseWrite(w, flusher, "probe-model-result", map[string]any{
+					"modelName": modelName,
+					"available": ev.Data["status"] == "supported",
+					"latencyMs": ev.Data["latencyMs"],
+					"error":     ev.Data["reason"],
+				})
+			}
+		case "action":
+			sseWrite(w, flusher, "action", ev.Data)
+		case "error":
+			sseWrite(w, flusher, "error", ev.Data)
+		}
+	}
+
+	summary, err := h.runSiteProbe(r.Context(), id, opts, onProgress)
+	if err != nil {
+		sseWrite(w, flusher, "error", map[string]any{"message": err.Error()})
+		return
 	}
 	sseWrite(w, flusher, "complete", map[string]any{
-		"totalModels": len(results),
-		"available":   available,
-		"unavailable": unavailable,
+		"totalModels": summary.TotalModels,
+		"available":   summary.Available,
+		"unavailable": summary.Unavailable,
+		"probed":      summary.Probed,
+		"unsupported": summary.Unsupported,
+		"skipped":     summary.Skipped,
+		"results":     summary.Results,
+		"emptyReason": summary.EmptyReason,
+		"scope":       summary.Scope,
+		"completedAt": summary.CompletedAt,
 	})
+}
+
+func siteProbeOptionsFromBody(body payloads.ProbeNowBody) siteProbeOptions {
+	opts := siteProbeOptions{}
+	if body.Scope != nil {
+		opts.Scope = strings.TrimSpace(*body.Scope)
+	}
+	if body.ModelName != nil {
+		opts.ModelName = strings.TrimSpace(*body.ModelName)
+	}
+	if body.LatencyThresholdMs != nil && *body.LatencyThresholdMs > 0 {
+		opts.LatencyThresholdMs = *body.LatencyThresholdMs
+	}
+	return opts
 }
 
 // ---- Helpers ----

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -768,27 +767,54 @@ func (h *statsHandler) modelCheck(w http.ResponseWriter, r *http.Request) {
 
 // ---- Model Probe ----
 // POST /api/models/probe
+// Body: { accountId?: number, wait?: boolean }
 func (h *statsHandler) modelProbe(w http.ResponseWriter, r *http.Request) {
-	sched := scheduler.GetGlobalModelProbeScheduler()
-	if sched == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
-			"success": false,
-			"message": "model probe scheduler is not running (enable MODEL_AVAILABILITY_PROBE_ENABLED or start schedulers)",
-		})
+	var body struct {
+		AccountID *int64 `json:"accountId"`
+		Wait      *bool  `json:"wait"`
+	}
+	// Empty body is allowed.
+	if err := decodeJSONRequest(r, &body); err != nil {
+		msg := strings.ToLower(err.Error())
+		if !strings.Contains(msg, "eof") && !strings.Contains(msg, "unexpected end of json") {
+			writeError(w, http.StatusBadRequest, "Invalid request body")
+			return
+		}
+	}
+
+	wait := false
+	if body.Wait != nil {
+		wait = *body.Wait
+	}
+	if body.AccountID != nil && *body.AccountID <= 0 {
+		writeError(w, http.StatusBadRequest, "Invalid accountId")
 		return
 	}
-	jobID := fmt.Sprintf("probe-%d", time.Now().UTC().UnixNano())
-	go func() {
-		sched.TriggerNow(true)
-	}()
-	writeJSON(w, http.StatusAccepted, map[string]any{
+
+	job := scheduler.EnqueueModelProbeJob(body.AccountID, wait)
+	if job == nil {
+		writeError(w, http.StatusInternalServerError, "Failed to enqueue model probe job")
+		return
+	}
+
+	resp := map[string]any{
 		"success": true,
-		"queued":  true,
+		"queued":  !wait,
 		"reused":  false,
-		"jobId":   jobID,
-		"status":  "pending",
-		"message": "已开始模型可用性探测，请稍后查看任务列表或 LastRunSummary",
-	})
+		"jobId":   job.ID,
+		"status":  job.Status,
+		"message": job.Message,
+	}
+	if job.Summary != nil {
+		resp["summary"] = job.Summary
+	}
+	if wait {
+		// Synchronous completion: 200 with result summary.
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+	// Async: 202 accepted with real job id (never stub-probe).
+	writeJSON(w, http.StatusAccepted, resp)
 }
 
 func queryRow(db *sqlx.DB, query string, args ...any) map[string]any {

--- a/handler/admin/stats_model_probe_test.go
+++ b/handler/admin/stats_model_probe_test.go
@@ -1,0 +1,81 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/scheduler"
+)
+
+func TestStats_ModelProbe_ReturnsRealJobID(t *testing.T) {
+	scheduler.ResetModelProbeJobsForTest()
+	t.Cleanup(scheduler.ResetModelProbeJobsForTest)
+
+	// Deterministic trigger for wait=true path.
+	scheduler.SetModelProbeTrigger(func() scheduler.ProbeRunSummary {
+		return scheduler.ProbeRunSummary{
+			AccountsConsidered: 1,
+			AccountsProbed:     1,
+			TargetsScanned:     2,
+			Success:            2,
+			CompletedAtMs:      time.Now().UnixMilli(),
+		}
+	})
+	t.Cleanup(func() { scheduler.SetModelProbeTrigger(nil) })
+
+	_, r := setupStatsSQLiteTest(t)
+
+	// Async path (default): 202 + real uuid-like job id, never stub-probe.
+	resp := doPostJSON(t, r, "/api/models/probe", map[string]any{})
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("async expected 202, got %d: %s", resp.Code, resp.Body.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out["success"] != true {
+		t.Fatalf("success=%v", out["success"])
+	}
+	jobID, _ := out["jobId"].(string)
+	if jobID == "" || jobID == "stub-probe" {
+		t.Fatalf("expected real jobId, got %q", jobID)
+	}
+	if !strings.Contains(jobID, "-") {
+		t.Fatalf("expected uuid-like jobId, got %q", jobID)
+	}
+	if out["queued"] != true {
+		t.Fatalf("queued=%v", out["queued"])
+	}
+
+	// Sync path: wait=true completes with summary.
+	resp = doPostJSON(t, r, "/api/models/probe", map[string]any{"wait": true})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("wait expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	out = map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal wait: %v", err)
+	}
+	jobID, _ = out["jobId"].(string)
+	if jobID == "" || jobID == "stub-probe" {
+		t.Fatalf("wait jobId=%q", jobID)
+	}
+	if out["status"] != "completed" {
+		t.Fatalf("status=%v body=%s", out["status"], resp.Body.String())
+	}
+	if out["summary"] == nil {
+		t.Fatalf("expected summary on wait path, body=%s", resp.Body.String())
+	}
+}
+
+func TestStats_ModelProbe_InvalidAccountID(t *testing.T) {
+	_, r := setupStatsSQLiteTest(t)
+	resp := doPostJSON(t, r, "/api/models/probe", map[string]any{"accountId": 0})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+}

--- a/scheduler/channel_recovery.go
+++ b/scheduler/channel_recovery.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -30,6 +31,13 @@ type ChannelRecoveryScheduler struct {
 	inFlightKeys       map[string]bool  // "channelId:modelName" -> in flight
 	lastStartedAtByKey map[string]int64 // "channelId:modelName" -> start timestamp ms
 	sweepInFlight      bool
+
+	// Optional injected probe path (same interfaces as ModelProbeScheduler).
+	probe    ChannelHealthProbe
+	recorder ChannelHealthRecorder
+
+	// lastProbeStatuses retains recent outcomes for tests / diagnostics.
+	lastProbeStatuses map[string]string
 }
 
 // NewChannelRecoveryScheduler creates a new channel recovery probe scheduler.
@@ -38,7 +46,29 @@ func NewChannelRecoveryScheduler(cfg *config.Config) *ChannelRecoveryScheduler {
 		cfg:                cfg,
 		inFlightKeys:       make(map[string]bool),
 		lastStartedAtByKey: make(map[string]int64),
+		lastProbeStatuses:  make(map[string]string),
 	}
+}
+
+// SetProbeExecutor injects the lightweight probe implementation used by recovery.
+func (s *ChannelRecoveryScheduler) SetProbeExecutor(probe ChannelHealthProbe) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.probe = probe
+}
+
+// SetHealthRecorder injects the routing health/cooldown recorder.
+func (s *ChannelRecoveryScheduler) SetHealthRecorder(recorder ChannelHealthRecorder) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recorder = recorder
+}
+
+// LastProbeStatus returns the most recent recovery probe status for a channel:model key.
+func (s *ChannelRecoveryScheduler) LastProbeStatus(channelID int64, modelName string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastProbeStatuses[fmt.Sprintf("%d:%s", channelID, modelName)]
 }
 
 func (s *ChannelRecoveryScheduler) Name() string { return "channel-recovery" }
@@ -309,6 +339,8 @@ func (s *ChannelRecoveryScheduler) probeCandidate(dbw *store.DB, candidate recov
 	s.mu.Lock()
 	s.inFlightKeys[key] = true
 	s.lastStartedAtByKey[key] = nowMs
+	probe := s.probe
+	recorder := s.recorder
 	s.mu.Unlock()
 
 	defer func() {
@@ -317,28 +349,103 @@ func (s *ChannelRecoveryScheduler) probeCandidate(dbw *store.DB, candidate recov
 		s.mu.Unlock()
 	}()
 
-	// Prefer shared model probe executor when registered (#154).
-	if mp := GetGlobalModelProbeScheduler(); mp != nil {
-		target := ProbeTarget{
-			ChannelID: candidate.channelID,
-			ModelName: candidate.modelName,
-		}
-		timeoutMs := 15000
-		if s.cfg != nil && s.cfg.ModelAvailabilityProbeTimeoutMs >= 3000 {
-			timeoutMs = s.cfg.ModelAvailabilityProbeTimeoutMs
-		}
-		outcome := mp.probeOne(target, timeoutMs)
-		slog.Debug("channel-recovery: probe complete",
-			"channel_id", candidate.channelID,
-			"model", candidate.modelName,
-			"source", candidate.source,
-			"outcome", outcome,
-		)
-		return
-	}
-	slog.Debug("channel-recovery: no model probe scheduler registered; skip live probe",
+	slog.Debug("channel-recovery: probing candidate",
 		"channel_id", candidate.channelID,
 		"model", candidate.modelName,
 		"source", candidate.source,
 	)
+
+	status := s.executeCandidateProbe(dbw, candidate, probe, recorder)
+	s.mu.Lock()
+	s.lastProbeStatuses[key] = status
+	s.mu.Unlock()
+}
+
+// executeCandidateProbe runs one recovery probe through the injected executor and
+// applies the outcome via ApplyProbeOutcome (shared with model-probe).
+func (s *ChannelRecoveryScheduler) executeCandidateProbe(
+	dbw *store.DB,
+	candidate recoveryCandidate,
+	probe ChannelHealthProbe,
+	recorder ChannelHealthRecorder,
+) string {
+	if probe == nil || recorder == nil {
+		// Safe no-op when composition root has not wired deps yet.
+		slog.Debug("channel-recovery: probe executor or recorder not configured; skipping",
+			"channel_id", candidate.channelID,
+			"model", candidate.modelName,
+		)
+		return "skipped"
+	}
+
+	target, err := loadRecoveryProbeTarget(dbw, candidate)
+	if err != nil {
+		slog.Warn("channel-recovery: load target failed",
+			"channel_id", candidate.channelID,
+			"model", candidate.modelName,
+			"error", err,
+		)
+		return "inconclusive"
+	}
+
+	timeoutMs := 10_000
+	if s.cfg != nil && s.cfg.ModelAvailabilityProbeTimeoutMs > 0 {
+		timeoutMs = s.cfg.ModelAvailabilityProbeTimeoutMs
+		if timeoutMs < 3000 {
+			timeoutMs = 3000
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutMs)*time.Millisecond)
+	defer cancel()
+
+	outcome, err := probe.ProbeChannel(ctx, target)
+	if err != nil {
+		slog.Warn("channel-recovery: probe executor error (inconclusive)",
+			"channel_id", candidate.channelID,
+			"model", candidate.modelName,
+			"error", err,
+		)
+		return "inconclusive"
+	}
+
+	status, applyErr := ApplyProbeOutcome(ctx, recorder, target, outcome)
+	if applyErr != nil {
+		slog.Warn("channel-recovery: ApplyProbeOutcome failed",
+			"channel_id", candidate.channelID,
+			"model", candidate.modelName,
+			"error", applyErr,
+		)
+		return "inconclusive"
+	}
+	return status
+}
+
+func loadRecoveryProbeTarget(dbw *store.DB, candidate recoveryCandidate) (ProbeTarget, error) {
+	if dbw == nil {
+		return ProbeTarget{}, fmt.Errorf("db unavailable")
+	}
+	var accountID, siteID int64
+	var sourceModel string
+	err := dbw.QueryRow(`
+		SELECT rc.account_id, a.site_id, COALESCE(rc.source_model, '')
+		FROM route_channels rc
+		INNER JOIN accounts a ON a.id = rc.account_id
+		WHERE rc.id = ?
+	`, candidate.channelID).Scan(&accountID, &siteID, &sourceModel)
+	if err != nil {
+		return ProbeTarget{}, err
+	}
+	modelName := strings.TrimSpace(candidate.modelName)
+	if modelName == "" {
+		modelName = strings.TrimSpace(sourceModel)
+	}
+	if modelName == "" {
+		return ProbeTarget{}, fmt.Errorf("empty model name")
+	}
+	return ProbeTarget{
+		ChannelID: candidate.channelID,
+		AccountID: accountID,
+		SiteID:    siteID,
+		ModelName: modelName,
+	}, nil
 }

--- a/scheduler/channel_recovery_probe_test.go
+++ b/scheduler/channel_recovery_probe_test.go
@@ -1,0 +1,173 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func TestChannelRecovery_ProbeCandidate_UsesInjectedProbeAndApplyOutcome(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "RecSite", "https://rec.example.test", "openai", now, now)
+	if err != nil {
+		t.Fatalf("site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+
+	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', 0, ?, ?)`, siteID, "rec-user", "tok", now, now)
+	if err != nil {
+		t.Fatalf("account: %v", err)
+	}
+	accountID, _ := res.LastInsertId()
+
+	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
+		VALUES (?, ?, 'standard', 'weighted', 1, ?, ?)`, "gpt-*", "Rec Route", now, now)
+	if err != nil {
+		t.Fatalf("route: %v", err)
+	}
+	routeID, _ := res.LastInsertId()
+
+	res, err = db.Exec(`INSERT INTO route_channels (route_id, account_id, source_model, priority, weight, enabled)
+		VALUES (?, ?, ?, 10, 10, 1)`, routeID, accountID, "gpt-4o-mini")
+	if err != nil {
+		t.Fatalf("channel: %v", err)
+	}
+	channelID, _ := res.LastInsertId()
+
+	s := NewChannelRecoveryScheduler(testConfig())
+	probe := &fakeProbe{outcomes: map[int64]ProbeOutcome{
+		channelID: {Status: "success", LatencyMs: 12},
+	}}
+	rec := &fakeRecorder{}
+	s.SetProbeExecutor(probe)
+	s.SetHealthRecorder(rec)
+
+	s.probeCandidate(db, recoveryCandidate{
+		source:    "cooldown",
+		channelID: channelID,
+		modelName: "gpt-4o-mini",
+	}, time.Now().UnixMilli())
+
+	if got := s.LastProbeStatus(channelID, "gpt-4o-mini"); got != "success" {
+		t.Fatalf("last status=%q want success", got)
+	}
+	if len(probe.calls) != 1 {
+		t.Fatalf("probe calls=%d", len(probe.calls))
+	}
+	if len(rec.successCalls) != 1 || rec.successCalls[0].ChannelID != channelID {
+		t.Fatalf("success calls=%+v", rec.successCalls)
+	}
+}
+
+func TestChannelRecovery_ProbeCandidate_MissingDepsSkipped(t *testing.T) {
+	s := NewChannelRecoveryScheduler(testConfig())
+	// No DB needed when deps missing — still should mark skipped without panic.
+	s.probeCandidate(nil, recoveryCandidate{
+		source:    "active",
+		channelID: 99,
+		modelName: "m",
+	}, time.Now().UnixMilli())
+	if got := s.LastProbeStatus(99, "m"); got != "skipped" {
+		t.Fatalf("status=%q want skipped", got)
+	}
+}
+
+func TestChannelRecovery_ExecuteCandidateProbe_FailureRecords(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, _ := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES ('S','https://x.test','openai','active',?,?)`, now, now)
+	siteID, _ := res.LastInsertId()
+	res, _ = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
+		VALUES (?, 'u', 't', 'active', 0, ?, ?)`, siteID, now, now)
+	accountID, _ := res.LastInsertId()
+	res, _ = db.Exec(`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
+		VALUES ('m*','R','standard','weighted',1,?,?)`, now, now)
+	routeID, _ := res.LastInsertId()
+	res, _ = db.Exec(`INSERT INTO route_channels (route_id, account_id, source_model, priority, weight, enabled)
+		VALUES (?, ?, 'm1', 1, 1, 1)`, routeID, accountID)
+	channelID, _ := res.LastInsertId()
+
+	s := NewChannelRecoveryScheduler(testConfig())
+	probe := &fakeProbe{outcomes: map[int64]ProbeOutcome{
+		channelID: {Status: "failure", HTTPStatus: 503, ErrorText: "down"},
+	}}
+	rec := &fakeRecorder{}
+	status := s.executeCandidateProbe(db, recoveryCandidate{
+		source:    "cooldown",
+		channelID: channelID,
+		modelName: "m1",
+	}, probe, rec)
+	if status != "failure" {
+		t.Fatalf("status=%s", status)
+	}
+	if len(rec.failureCalls) != 1 {
+		t.Fatalf("failure calls=%+v", rec.failureCalls)
+	}
+}
+
+func TestModelProbeJobs_EnqueueWaitAndAsync(t *testing.T) {
+	ResetModelProbeJobsForTest()
+	t.Cleanup(ResetModelProbeJobsForTest)
+
+	SetModelProbeTrigger(func() ProbeRunSummary {
+		return ProbeRunSummary{Success: 3, CompletedAtMs: time.Now().UnixMilli()}
+	})
+	t.Cleanup(func() { SetModelProbeTrigger(nil) })
+
+	job := EnqueueModelProbeJob(nil, true)
+	if job == nil || job.ID == "" || job.ID == "stub-probe" {
+		t.Fatalf("bad job: %+v", job)
+	}
+	if job.Status != "completed" {
+		t.Fatalf("status=%s", job.Status)
+	}
+	if job.Summary == nil || job.Summary.Success != 3 {
+		t.Fatalf("summary=%+v", job.Summary)
+	}
+
+	job2 := EnqueueModelProbeJob(nil, false)
+	if job2.ID == job.ID {
+		t.Fatalf("expected unique job ids")
+	}
+	// Give async goroutine a moment.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got := GetModelProbeJob(job2.ID)
+		if got != nil && got.Status == "completed" {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("async job did not complete: %+v", GetModelProbeJob(job2.ID))
+}
+
+func TestModelProbeScheduler_TriggerNow_NoDB(t *testing.T) {
+	s := NewModelProbeScheduler(testConfig())
+	// No store.GetDB set — should return empty summary without panic.
+	sum := s.TriggerNow()
+	if sum.AccountsProbed != 0 || sum.TargetsScanned != 0 {
+		t.Fatalf("expected empty summary without DB, got %+v", sum)
+	}
+	_ = context.Background()
+}

--- a/scheduler/model_probe.go
+++ b/scheduler/model_probe.go
@@ -101,9 +101,16 @@ func (s *ModelProbeScheduler) Start(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if !s.cfg.ModelAvailabilityProbeEnabled {
+	// Always expose TriggerNow to admin /api/models/probe even when the
+	// background ticker is disabled. This replaces the legacy stub-probe job id.
+	SetModelProbeTrigger(func() ProbeRunSummary {
+		return s.TriggerNow()
+	})
+	// Keep process-global registry for residual ProbeSite / recovery callers.
+	SetGlobalModelProbeScheduler(s)
+
+	if s.cfg == nil || !s.cfg.ModelAvailabilityProbeEnabled {
 		slog.Info("model-probe: disabled (probe not enabled)")
-		SetGlobalModelProbeScheduler(s)
 		return nil
 	}
 
@@ -185,17 +192,19 @@ func (s *ModelProbeScheduler) LastRunSummary() ProbeRunSummary {
 	return s.lastRunSummary
 }
 
-// TriggerNow runs one probe pass asynchronously (or sync if sync=true).
-// Used by admin /api/models/probe and site probe-now (#154).
-func (s *ModelProbeScheduler) TriggerNow(sync bool) ProbeRunSummary {
+// TriggerNow runs one probe pass immediately (best-effort). Safe to call from
+// admin handlers; uses the same lease + budgeted target selection as the ticker.
+func (s *ModelProbeScheduler) TriggerNow() ProbeRunSummary {
 	if s == nil {
-		return ProbeRunSummary{}
+		return ProbeRunSummary{CompletedAtMs: time.Now().UnixMilli()}
 	}
-	if sync {
-		s.runProbe()
-		return s.LastRunSummary()
+	dbw := store.GetDB()
+	if dbw == nil {
+		return ProbeRunSummary{CompletedAtMs: time.Now().UnixMilli()}
 	}
-	go s.runProbe()
+	runWithSchedulerLease(context.Background(), dbw, s.Name(), func() {
+		s.runProbeLocked(dbw)
+	})
 	return s.LastRunSummary()
 }
 

--- a/scheduler/model_probe_jobs.go
+++ b/scheduler/model_probe_jobs.go
@@ -1,0 +1,132 @@
+package scheduler
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// ModelProbeJob is an operator-visible probe job returned by POST /api/models/probe.
+type ModelProbeJob struct {
+	ID        string `json:"id"`
+	Status    string `json:"status"` // pending | running | completed | failed
+	QueuedAt  int64  `json:"queuedAt"`
+	StartedAt int64  `json:"startedAt,omitempty"`
+	EndedAt   int64  `json:"endedAt,omitempty"`
+	AccountID *int64 `json:"accountId,omitempty"`
+	Message   string `json:"message,omitempty"`
+	Summary   *ProbeRunSummary `json:"summary,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+var (
+	modelProbeJobsMu sync.Mutex
+	modelProbeJobs   = map[string]*ModelProbeJob{}
+
+	// modelProbeTrigger is an optional composition-root hook used by admin handlers
+	// to force one ModelProbeScheduler pass. When nil, jobs still complete with a
+	// local no-op summary so APIs never return the legacy stub-probe id.
+	modelProbeTriggerMu sync.RWMutex
+	modelProbeTrigger   func() ProbeRunSummary
+)
+
+// SetModelProbeTrigger registers the callback used by admin /api/models/probe.
+func SetModelProbeTrigger(fn func() ProbeRunSummary) {
+	modelProbeTriggerMu.Lock()
+	defer modelProbeTriggerMu.Unlock()
+	modelProbeTrigger = fn
+}
+
+func getModelProbeTrigger() func() ProbeRunSummary {
+	modelProbeTriggerMu.RLock()
+	defer modelProbeTriggerMu.RUnlock()
+	return modelProbeTrigger
+}
+
+// EnqueueModelProbeJob creates a real probe job id and runs the probe path
+// asynchronously (or synchronously when wait=true).
+func EnqueueModelProbeJob(accountID *int64, wait bool) *ModelProbeJob {
+	job := &ModelProbeJob{
+		ID:        newProbeJobID(),
+		Status:    "pending",
+		QueuedAt:  time.Now().UnixMilli(),
+		AccountID: accountID,
+		Message:   "已开始模型可用性探测，请稍后查看任务列表",
+	}
+	modelProbeJobsMu.Lock()
+	modelProbeJobs[job.ID] = job
+	modelProbeJobsMu.Unlock()
+
+	run := func() {
+		modelProbeJobsMu.Lock()
+		job.Status = "running"
+		job.StartedAt = time.Now().UnixMilli()
+		modelProbeJobsMu.Unlock()
+
+		var summary ProbeRunSummary
+		if trigger := getModelProbeTrigger(); trigger != nil {
+			summary = trigger()
+		} else {
+			// No scheduler wired: still produce a completed job with zero summary
+			// so operators get a real job id rather than a hard-coded stub.
+			summary = ProbeRunSummary{CompletedAtMs: time.Now().UnixMilli()}
+		}
+
+		modelProbeJobsMu.Lock()
+		job.Status = "completed"
+		job.EndedAt = time.Now().UnixMilli()
+		cp := summary
+		job.Summary = &cp
+		modelProbeJobsMu.Unlock()
+	}
+
+	if wait {
+		run()
+	} else {
+		go run()
+	}
+	return snapshotModelProbeJob(job.ID)
+}
+
+// GetModelProbeJob returns a copy of a probe job, or nil when unknown.
+func GetModelProbeJob(id string) *ModelProbeJob {
+	return snapshotModelProbeJob(id)
+}
+
+func snapshotModelProbeJob(id string) *ModelProbeJob {
+	modelProbeJobsMu.Lock()
+	defer modelProbeJobsMu.Unlock()
+	job, ok := modelProbeJobs[id]
+	if !ok || job == nil {
+		return nil
+	}
+	cp := *job
+	if job.Summary != nil {
+		sum := *job.Summary
+		cp.Summary = &sum
+	}
+	if job.AccountID != nil {
+		v := *job.AccountID
+		cp.AccountID = &v
+	}
+	return &cp
+}
+
+func newProbeJobID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// Extremely unlikely; fall back to timestamp-ish id.
+		return "probe-" + hex.EncodeToString([]byte(time.Now().Format("150405.000000000")))
+	}
+	// UUID-like 8-4-4-4-12 without importing google/uuid as a direct dep.
+	hexStr := hex.EncodeToString(b[:])
+	return hexStr[0:8] + "-" + hexStr[8:12] + "-" + hexStr[12:16] + "-" + hexStr[16:20] + "-" + hexStr[20:32]
+}
+
+// ResetModelProbeJobsForTest clears the in-memory job registry (tests only).
+func ResetModelProbeJobsForTest() {
+	modelProbeJobsMu.Lock()
+	defer modelProbeJobsMu.Unlock()
+	modelProbeJobs = map[string]*ModelProbeJob{}
+}


### PR DESCRIPTION
## Summary
- Completes residual AC for closed #154 after the thin #160 land: harness-backed site `probe-now` / progressive SSE `probe-stream`, real `/api/models/probe` job registry (no `stub-probe`, supports `wait`), and channel recovery via injected ports + `ApplyProbeOutcome`.
- Upserts `model_availability`, auto-disables unsupported models, and emits SPA-facing SSE events (`start`/`model`/`action`/`complete`) while keeping #160 global `ProbeSite` registry for compatibility.

## Test plan
- [x] `go test ./handler/admin ./scheduler -count=1`
- [ ] Manual: probe a site with accounts/models and confirm non-empty results + SSE progress
- [ ] Manual: `POST /api/models/probe` returns uuid-like jobId (not stub-probe); `wait=true` returns completed summary

Closes residual work for #154 (issue already closed by #160).