### PR TITLE
feat(proxy): wire /v1/models to TokenRouter.GetAvailableModels #169

### DIFF
--- a/handler/proxy/models.go
+++ b/handler/proxy/models.go
@@ -1,6 +1,8 @@
 package proxyhandler
 
 import (
+	"context"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -26,7 +28,7 @@ func HandleModels(w http.ResponseWriter, r *http.Request) {
 	wantsClaude := r.Header.Get("anthropic-version") != "" || r.Header.Get("x-api-key") != ""
 
 	// Build model list (MetAPI-owned listing; see docs/analysis/models-response-shape.md)
-	models := getAvailableModels(authCtx.Policy)
+	models := getAvailableModels(r.Context(), authCtx.Policy)
 	now := time.Now().UTC()
 
 	if wantsClaude {
@@ -92,28 +94,30 @@ func buildClaudeModelsResponse(models []string, now time.Time) map[string]any {
 	}
 
 	return map[string]any{
-		"data":      items,
-		"first_id":  firstID,
-		"last_id":   lastID,
-		"has_more":  false,
+		"data":     items,
+		"first_id": firstID,
+		"last_id":  lastID,
+		"has_more": false,
 	}
 }
 
 // getAvailableModels returns the list of available model names.
-// This is the MetAPI-owned listing path (not a live upstream /v1/models proxy).
-// Stub: returns common model names until tokenRouter-backed listing is wired here.
-func getAvailableModels(policy auth.DownstreamRoutingPolicy) []string {
-	// Stub model list. In production, this queries the tokenRouter.
-	models := []string{
-		"gpt-4o",
-		"gpt-4o-mini",
-		"gpt-4-turbo",
-		"gpt-3.5-turbo",
-		"claude-sonnet-4-20250514",
-		"claude-3-5-sonnet-latest",
-		"gemini-2.5-pro",
-		"gemini-2.5-flash",
+// Prefer TokenRouter-backed listing when UpstreamConfig is wired; otherwise fall back
+// to a small owned catalog for tests/unconfigured process (#169).
+func getAvailableModels(ctx context.Context, policy auth.DownstreamRoutingPolicy) []string {
+	var models []string
+	if cfg := getUpstreamConfig(); cfg != nil && cfg.Router != nil {
+		live, err := cfg.Router.GetAvailableModels(ctx)
+		if err != nil {
+			slog.Warn("models: GetAvailableModels failed; using empty list", "error", err)
+		} else {
+			models = live
+		}
+	} else {
+		// Last-resort owned catalog when router is not wired (unit tests / early boot).
+		models = append([]string(nil), fallbackOwnedModelCatalog...)
 	}
+
 	if len(policy.SupportedModels) == 0 && len(policy.AllowedRouteIDs) == 0 {
 		if policy.DenyAllWhenEmpty {
 			return []string{}
@@ -121,6 +125,8 @@ func getAvailableModels(policy auth.DownstreamRoutingPolicy) []string {
 		return models
 	}
 	if len(policy.SupportedModels) == 0 {
+		// Route-id allowlists without supportedModels: return empty at listing layer
+		// (selection still enforces AllowedRouteIDs at dispatch time).
 		return []string{}
 	}
 
@@ -131,6 +137,18 @@ func getAvailableModels(policy auth.DownstreamRoutingPolicy) []string {
 		}
 	}
 	return filtered
+}
+
+// fallbackOwnedModelCatalog is only used when TokenRouter is not configured.
+var fallbackOwnedModelCatalog = []string{
+	"gpt-4o",
+	"gpt-4o-mini",
+	"gpt-4-turbo",
+	"gpt-3.5-turbo",
+	"claude-sonnet-4-20250514",
+	"claude-3-5-sonnet-latest",
+	"gemini-2.5-pro",
+	"gemini-2.5-flash",
 }
 
 // knownModelContextLength returns a published context window for well-known models

--- a/handler/proxy/models_test.go
+++ b/handler/proxy/models_test.go
@@ -1,11 +1,14 @@
 package proxyhandler
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/tokendancelab/metapi-go/auth"
+	"github.com/tokendancelab/metapi-go/proxy"
+	"github.com/tokendancelab/metapi-go/routing"
 )
 
 // ---- matchModelPattern ----
@@ -207,7 +210,7 @@ func TestBuildClaudeModelsResponse_Empty(t *testing.T) {
 // ---- getAvailableModels ----
 
 func TestGetAvailableModels(t *testing.T) {
-	models := getAvailableModels(auth.EmptyDownstreamRoutingPolicy)
+	models := getAvailableModels(context.Background(), auth.EmptyDownstreamRoutingPolicy)
 	if len(models) == 0 {
 		t.Error("expected non-empty model list")
 	}
@@ -229,7 +232,7 @@ func TestGetAvailableModels(t *testing.T) {
 
 func TestGetAvailableModelsAppliesManagedPolicy(t *testing.T) {
 	denyAll := auth.DownstreamRoutingPolicy{DenyAllWhenEmpty: true}
-	if got := getAvailableModels(denyAll); len(got) != 0 {
+	if got := getAvailableModels(context.Background(), denyAll); len(got) != 0 {
 		t.Fatalf("deny-all policy returned %v, want empty", got)
 	}
 
@@ -237,7 +240,7 @@ func TestGetAvailableModelsAppliesManagedPolicy(t *testing.T) {
 		SupportedModels:  []string{"gpt-4o"},
 		DenyAllWhenEmpty: true,
 	}
-	got := getAvailableModels(supported)
+	got := getAvailableModels(context.Background(), supported)
 	if len(got) != 1 || got[0] != "gpt-4o" {
 		t.Fatalf("supported policy returned %v, want [gpt-4o]", got)
 	}
@@ -246,7 +249,7 @@ func TestGetAvailableModelsAppliesManagedPolicy(t *testing.T) {
 		SupportedModels:  []string{"claude-*"},
 		DenyAllWhenEmpty: true,
 	}
-	got = getAvailableModels(wildcard)
+	got = getAvailableModels(context.Background(), wildcard)
 	if len(got) == 0 {
 		t.Fatal("wildcard supported policy returned empty, want Claude models")
 	}
@@ -260,7 +263,7 @@ func TestGetAvailableModelsAppliesManagedPolicy(t *testing.T) {
 		AllowedRouteIDs:  []int64{1},
 		DenyAllWhenEmpty: true,
 	}
-	if got := getAvailableModels(routeOnly); len(got) != 0 {
+	if got := getAvailableModels(context.Background(), routeOnly); len(got) != 0 {
 		t.Fatalf("route-only policy returned %v, want empty until route-aware model listing is available", got)
 	}
 }
@@ -459,5 +462,45 @@ func TestHandleModels_Unauthorized(t *testing.T) {
 
 	if rec.Code != 401 {
 		t.Errorf("expected 401, got %d", rec.Code)
+	}
+}
+
+type fakeModelsRouter struct {
+	proxy.TokenRouterInterface
+	models []string
+	err    error
+}
+
+func (f *fakeModelsRouter) GetAvailableModels(ctx context.Context) ([]string, error) {
+	return f.models, f.err
+}
+
+func (f *fakeModelsRouter) SelectChannel(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+	return nil, nil
+}
+func (f *fakeModelsRouter) SelectNextChannel(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+	return nil, nil
+}
+func (f *fakeModelsRouter) SelectPreferredChannel(ctx context.Context, requestedModel string, preferredChannelID int64, policy routing.DownstreamRoutingPolicy, excludeChannelIDs []int64) (*routing.SelectedChannel, error) {
+	return nil, nil
+}
+func (f *fakeModelsRouter) RecordSuccess(ctx context.Context, channelID int64, latencyMs float64, cost float64, modelName *string, actualAccountID *int64) error {
+	return nil
+}
+func (f *fakeModelsRouter) RecordFailure(ctx context.Context, channelID int64, failureCtx routing.SiteRuntimeFailureContext, actualAccountID *int64) error {
+	return nil
+}
+
+func TestGetAvailableModels_RouterBacked(t *testing.T) {
+	SetUpstreamConfig(&UpstreamConfig{Router: &fakeModelsRouter{models: []string{"alpha-model", "beta-model"}}})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+	got := getAvailableModels(context.Background(), auth.EmptyDownstreamRoutingPolicy)
+	if len(got) != 2 {
+		t.Fatalf("got=%v", got)
+	}
+	policy := auth.DownstreamRoutingPolicy{SupportedModels: []string{"alpha*"}}
+	got = getAvailableModels(context.Background(), policy)
+	if len(got) != 1 || got[0] != "alpha-model" {
+		t.Fatalf("filtered=%v", got)
 	}
 }

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -39,6 +39,10 @@ type upstreamTestSuccess struct {
 	modelName *string
 }
 
+func (r *upstreamTestRouter) GetAvailableModels(ctx context.Context) ([]string, error) {
+	return nil, nil
+}
+
 func (r *upstreamTestRouter) SelectChannel(_ context.Context, _ string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
 	r.policies = append(r.policies, policy)
 	return &r.selected, nil
@@ -605,7 +609,6 @@ func TestSiteConcurrencySaturateSkipsWithoutFailure(t *testing.T) {
 		t.Fatalf("expected channel 202 success, got %d", router.successes[0].channelID)
 	}
 }
-
 
 func TestNonStreamSuccessPersistsUsageTokensToProxyLog(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/proxy/channel_selection.go
+++ b/proxy/channel_selection.go
@@ -15,6 +15,7 @@ type TokenRouterInterface interface {
 	SelectChannel(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
 	SelectNextChannel(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
 	SelectPreferredChannel(ctx context.Context, requestedModel string, preferredChannelID int64, policy routing.DownstreamRoutingPolicy, excludeChannelIDs []int64) (*routing.SelectedChannel, error)
+	GetAvailableModels(ctx context.Context) ([]string, error)
 	RecordSuccess(ctx context.Context, channelID int64, latencyMs float64, cost float64, modelName *string, actualAccountID *int64) error
 	RecordFailure(ctx context.Context, channelID int64, failureCtx routing.SiteRuntimeFailureContext, actualAccountID *int64) error
 }
@@ -36,7 +37,7 @@ type ChannelSelectionInput struct {
 
 // Tester header constants.
 const (
-	TesterRequestHeader     = "x-metapi-tester-request"
+	TesterRequestHeader       = "x-metapi-tester-request"
 	TesterForcedChannelHeader = "x-metapi-tester-forced-channel-id"
 )
 

--- a/proxy/channel_selection_test.go
+++ b/proxy/channel_selection_test.go
@@ -18,6 +18,9 @@ type mockRouter struct {
 	selectPreferredChannel func(ctx context.Context, requestedModel string, preferredChannelID int64, policy routing.DownstreamRoutingPolicy, excludeChannelIDs []int64) (*routing.SelectedChannel, error)
 }
 
+func (m *mockRouter) GetAvailableModels(ctx context.Context) ([]string, error) {
+	return nil, nil
+}
 func (m *mockRouter) SelectChannel(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
 	if m.selectChannel != nil {
 		return m.selectChannel(ctx, requestedModel, policy)
@@ -47,8 +50,8 @@ func (m *mockRouter) RecordFailure(ctx context.Context, channelID int64, failure
 }
 
 type mockRouteRefresher struct {
-	called   bool
-	refresh  func(ctx context.Context) error
+	called  bool
+	refresh func(ctx context.Context) error
 }
 
 func (m *mockRouteRefresher) RefreshModelsAndRebuildRoutes(ctx context.Context) error {
@@ -154,7 +157,7 @@ func TestTesterHelpers(t *testing.T) {
 	t.Run("GetTesterForcedChannelID", func(t *testing.T) {
 		t.Run("valid forced channel", func(t *testing.T) {
 			headers := map[string]string{
-				"x-metapi-tester-request":        "1",
+				"x-metapi-tester-request":           "1",
 				"x-metapi-tester-forced-channel-id": "42",
 			}
 			id := GetTesterForcedChannelID(headers, "127.0.0.1")
@@ -165,7 +168,7 @@ func TestTesterHelpers(t *testing.T) {
 
 		t.Run("invalid channel ID", func(t *testing.T) {
 			headers := map[string]string{
-				"x-metapi-tester-request":        "1",
+				"x-metapi-tester-request":           "1",
 				"x-metapi-tester-forced-channel-id": "abc",
 			}
 			id := GetTesterForcedChannelID(headers, "127.0.0.1")
@@ -176,7 +179,7 @@ func TestTesterHelpers(t *testing.T) {
 
 		t.Run("zero channel ID", func(t *testing.T) {
 			headers := map[string]string{
-				"x-metapi-tester-request":        "1",
+				"x-metapi-tester-request":           "1",
 				"x-metapi-tester-forced-channel-id": "0",
 			}
 			id := GetTesterForcedChannelID(headers, "127.0.0.1")
@@ -187,7 +190,7 @@ func TestTesterHelpers(t *testing.T) {
 
 		t.Run("negative channel ID", func(t *testing.T) {
 			headers := map[string]string{
-				"x-metapi-tester-request":        "1",
+				"x-metapi-tester-request":           "1",
 				"x-metapi-tester-forced-channel-id": "-1",
 			}
 			id := GetTesterForcedChannelID(headers, "127.0.0.1")
@@ -198,7 +201,7 @@ func TestTesterHelpers(t *testing.T) {
 
 		t.Run("non-loopback", func(t *testing.T) {
 			headers := map[string]string{
-				"x-metapi-tester-request":        "1",
+				"x-metapi-tester-request":           "1",
 				"x-metapi-tester-forced-channel-id": "42",
 			}
 			id := GetTesterForcedChannelID(headers, "192.168.1.1")


### PR DESCRIPTION
## Summary
- TokenRouterInterface gains GetAvailableModels
- /v1/models uses live route listing when router wired
- Policy filters preserved; fallback catalog only when router nil

Closes #169