### PR TITLE
chore(ci): bump Go 1.26.5 and green vulncheck (#168)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: Run gitleaks
         run: go run github.com/zricethezav/gitleaks/v8@v8.28.0 detect --source . --no-git --redact --verbose
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
       - name: Run golangci-lint
@@ -40,17 +40,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - run: go vet ./...
 
   vulncheck:
     runs-on: ubuntu-latest
-    continue-on-error: true  # S1: stdlib go patch lag is not a product gate for this CI PR
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
   mod-verify:
@@ -59,7 +58,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - run: go mod download
       - run: go mod verify
 
@@ -71,7 +70,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: Run gitleaks
         run: go run github.com/zricethezav/gitleaks/v8@v8.28.0 detect --source . --no-git --redact --verbose
 
@@ -81,7 +80,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - run: go test ./docs -run TestPublicMarkdownHygiene -count=1
 
   frontend:
@@ -109,7 +108,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - run: go test ./... -count=1 -race
 
   test-pg:
@@ -131,7 +130,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - run: |
           dsn="${PG_SCHEME}://${PG_USER}:${PG_PASSWORD}@localhost:5432/${PG_DATABASE}?sslmode=disable"
           PG_TEST_DSN="$dsn" DATABASE_URL="$dsn" go test ./... -count=1 -tags=integration
@@ -147,7 +146,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - run: mkdir -p web/dist
       - run: go build -trimpath ./cmd/server
       - run: go build -trimpath ./cmd/migrate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [Unreleased]
+
+### Changed
+- Bump Go toolchain to 1.26.5 across go.mod, Dockerfile, and CI/CD workflows (#168).
+
+### Security
+- Resolve stdlib advisory GO-2026-5856 (crypto/tls ECH) by upgrading from Go 1.26.4 to 1.26.5; remove CI `vulncheck` continue-on-error gate once clean.
+
 ## [v0.8.0] — 2026-07-17
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY web ./
 RUN npm run build:web
 
 # Stage 2: Go build
-FROM golang:1.26.4-alpine AS build
+FROM golang:1.26.5-alpine AS build
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -75,8 +75,8 @@
 | Shipped infra | Site max concurrency · per-key `proxy_url` · group route rebuild |
 | Closed F1+P1 | Full gap backlog #38–#56 (PRs #74–#94) |
 | In flight WFs | none — ops residual #154–#158 landed; v0.8.0 tagged |
-| Next | Go 1.26.5 when available for vulncheck; optional v0.8.1 polish; deeper product backlog as needed |
-| Residual CI | `vulncheck` GO-2026-5856 (Go 1.26.4); frontend occasional `EnvironmentTeardownError` flake (tests pass) |
+| Next | optional v0.8.1 polish; deeper product backlog as needed |
+| Residual CI | frontend occasional `EnvironmentTeardownError` flake (tests pass); GO-2026-5856 closed via Go 1.26.5 (#168) |
 
 ### M-COMPETE notes (active)
 
@@ -173,4 +173,4 @@
 1. Continue **M-FEATURE** remaining P0 backlog: token stats (#42), cache_ratio (#43), key/whitelist correctness (#40/#41/#45/#46), expired-connection UX (#39), cross-protocol failover (#38)
 2. Protocol P1: `/v1/rerank` (#48), Gemini thought_signature residual (#47), Responses multi-turn (#50), Codex/OAuth model issues (#49/#55)
 3. Watch CI frontend unhandled-rejection flakiness (dashboard observability)
-4. Optional: Go stdlib vulncheck GO-2026-5856 via Go 1.26.5 when available
+4. Go stdlib vulncheck GO-2026-5856 addressed by Go 1.26.5 bump (#168)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tokendancelab/metapi-go
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/go-chi/chi/v5 v5.3.0


### PR DESCRIPTION
## Summary
- Bump Go toolchain from 1.26.4 → 1.26.5 in `go.mod`, `Dockerfile`, and CI/CD workflows.
- Remove `vulncheck` `continue-on-error` now that stdlib advisory GO-2026-5856 is fixed.
- Document under Unreleased in CHANGELOG and clear residual note in MASTER.

Closes #168

## Test plan
- [x] `go version` → go1.26.5
- [x] `go test ./handler/admin ./auth ./routing ./scheduler ./handler/shared -count=1`
- [x] `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` → No vulnerabilities found
- [x] local pre-push: `go vet ./...` + `go test ./... -count=1 -race`
- [ ] CI vulncheck job green without continue-on-error