### PR TITLE
feat(proxy): wire /v1/models to TokenRouter.GetAvailableModels

### DIFF
--- a/docs/analysis/models-response-shape.md
+++ b/docs/analysis/models-response-shape.md
@@ -21,20 +21,30 @@ Document the **owned MetAPI listing** returned by `GET /v1/models`, how it diffe
 
 | Mode | What it is | Status in metapi-go |
 |------|------------|---------------------|
-| **Owned listing** (current) | MetAPI constructs the list itself from an owned catalog (stub today) filtered by downstream routing policy (`SupportedModels` / deny-all / route-id constraints). `owned_by` is always `"metapi"`. | **Implemented** |
-| **Upstream listing** | Proxy or merge of each site/account’s native `/v1/models` (or platform equivalent), including vendor `context_length` / `max_model_len` when present. | **Not implemented** on this surface. Route rebuild / platform model refresh populate routes elsewhere; this handler does **not** currently call `TokenRouter.GetAvailableModels` or pass through upstream payloads. |
+| **Owned listing** (current) | MetAPI constructs the list itself from enabled `token_routes` via `TokenRouter.GetAvailableModels`, then filters by downstream routing policy (`SupportedModels` / deny-all / route-id constraints). `owned_by` is always `"metapi"`. | **Implemented** (#169) |
+| **Upstream listing** | Proxy or merge of each site/account’s native `/v1/models` (or platform equivalent), including vendor `context_length` / `max_model_len` when present. | **Not implemented** (and not the default). This surface never scrapes live upstream `/v1/models`. |
+
+### Catalog resolution (`resolveOwnedModelCatalog`)
+
+| Condition | Catalog source |
+|-----------|----------------|
+| `UpstreamConfig.Router` implements `AvailableModelsSource` (production `routing.TokenRouter`) | `GetAvailableModels(ctx)` over enabled/visible routes |
+| Router listing returns an error | Empty list + warn log (no silent stub) |
+| Router is present but selection-only (no listing method) | Last-resort stub catalog (keeps e2e / selection mocks shape-compatible) |
+| `UpstreamConfig` nil **and** `METAPI_ENABLE_PROXY_STUB` on | Last-resort stub catalog (unit-test default) |
+| `UpstreamConfig` nil **and** stub disabled | Empty list + one-shot warn (production safety) |
 
 Implications:
 
 1. Clients always see a MetAPI-owned OpenAI/Claude envelope, not a raw vendor body.
-2. Model IDs are the names MetAPI is willing to route (catalog ∩ policy), not necessarily a complete dump of every upstream account’s models.
+2. Model IDs are the names MetAPI is willing to route (route catalog ∩ policy), not necessarily a complete dump of every upstream account’s models.
 3. `owned_by: "metapi"` intentionally avoids vendor-specific client branches (e.g. Hermes’ `owned_by == "llamacpp"` → `/v1/props` path).
 
-Future hardening (out of this issue’s code scope unless reopened):
+Residual / future hardening:
 
-- Wire `TokenRouter.GetAvailableModels` + channel resolvability (upstream metapi `listModelsSurface` behavior).
-- Prefer `token_routes.context_length` (SC2 additive column) over built-in defaults when set.
+- Prefer `token_routes.context_length` (SC2 additive column) over built-in defaults when set; today `knownModelContextLength` still supplies family defaults/heuristics only.
 - Optionally merge per-site discovered context metadata from platform model refresh.
+- Route-ID-aware listing when policy has only `AllowedRouteIDs` (currently empty until joined).
 
 ## OpenAI-compatible shape (default)
 
@@ -105,10 +115,10 @@ Notes:
 
 | Policy | Listing behavior |
 |--------|------------------|
-| Empty allow-all | Full owned catalog |
+| Empty allow-all | Full owned catalog (route-backed or last-resort fallback) |
 | `DenyAllWhenEmpty` with no supported models / routes | Empty `data` |
 | `SupportedModels` patterns | Catalog filtered by wildcard/exact match |
-| `AllowedRouteIDs` only (no supported models) | Empty until route-aware listing is wired |
+| `AllowedRouteIDs` only (no supported models) | Empty until route-aware listing is wired (`AllowedRouteIDs` still enforced at channel selection) |
 
 ## Client quirks
 
@@ -121,11 +131,13 @@ Notes:
 
 ## Tests
 
-- Unit: `handler/proxy/models_test.go` (`TestBuildOpenAIModelsResponse*`, `TestBuildClaudeModelsResponse*`, `TestHandleModels_*`)
-- E2E: `e2e/e2e_flow_test.go` Phase 5 asserts OpenAI required fields including `owned_by` / `created`
+- Unit: `handler/proxy/models_test.go` (`TestGetAvailableModels_*`, `TestBuildOpenAIModelsResponse*`, `TestBuildClaudeModelsResponse*`, `TestHandleModels_*`)
+- E2E: `e2e/e2e_flow_test.go` Phase 5 asserts OpenAI required fields including `owned_by` / `created` (selection-only mock router still uses last-resort catalog)
 
 ## References
 
+- Issue: TokenDanceLab/metapi-go #169 (route-backed listing), #53 (shape / `context_length`)
 - Upstream issue: [cita-777/metapi#507](https://github.com/cita-777/metapi/issues/507)
 - Upstream surface: `src/server/proxy-core/surfaces/modelsSurface.ts`
 - Schema home for future route context: `store.TokenRoute.ContextLength` / `token_routes.context_length`
+- Router API: `routing.TokenRouter.GetAvailableModels`

--- a/handler/proxy/models.go
+++ b/handler/proxy/models.go
@@ -1,8 +1,12 @@
 package proxyhandler
 
 import (
+	"context"
+	"log/slog"
 	"net/http"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/tokendancelab/metapi-go/auth"
@@ -12,6 +16,16 @@ import (
 // Clients that special-case owned_by (e.g. Hermes llama.cpp detection) treat this
 // as a generic OpenAI-compatible gateway, not llamacpp.
 const modelsOwnedBy = "metapi"
+
+// AvailableModelsSource is implemented by routers that can list MetAPI-owned models
+// from enabled token_routes (notably routing.TokenRouter.GetAvailableModels).
+// Channel-selection-only mocks may omit this method; listing then uses the
+// documented last-resort catalog (see resolveOwnedModelCatalog).
+type AvailableModelsSource interface {
+	GetAvailableModels(ctx context.Context) ([]string, error)
+}
+
+var emptyModelsCatalogLogOnce sync.Once
 
 // HandleModels handles GET /v1/models.
 // Returns model list in OpenAI or Claude format based on request headers.
@@ -26,7 +40,7 @@ func HandleModels(w http.ResponseWriter, r *http.Request) {
 	wantsClaude := r.Header.Get("anthropic-version") != "" || r.Header.Get("x-api-key") != ""
 
 	// Build model list (MetAPI-owned listing; see docs/analysis/models-response-shape.md)
-	models := getAvailableModels(authCtx.Policy)
+	models := getAvailableModels(r.Context(), authCtx.Policy)
 	now := time.Now().UTC()
 
 	if wantsClaude {
@@ -99,27 +113,20 @@ func buildClaudeModelsResponse(models []string, now time.Time) map[string]any {
 	}
 }
 
-// getAvailableModels returns the list of available model names.
-// This is the MetAPI-owned listing path (not a live upstream /v1/models proxy).
-// Stub: returns common model names until tokenRouter-backed listing is wired here.
-func getAvailableModels(policy auth.DownstreamRoutingPolicy) []string {
-	// Stub model list. In production, this queries the tokenRouter.
-	models := []string{
-		"gpt-4o",
-		"gpt-4o-mini",
-		"gpt-4-turbo",
-		"gpt-3.5-turbo",
-		"claude-sonnet-4-20250514",
-		"claude-3-5-sonnet-latest",
-		"gemini-2.5-pro",
-		"gemini-2.5-flash",
-	}
+// getAvailableModels returns the list of available model names for this caller.
+// This is the MetAPI-owned listing path (not a live upstream /v1/models proxy):
+// resolveOwnedModelCatalog loads route-backed names when TokenRouter is wired,
+// then downstream routing policy filters the catalog.
+func getAvailableModels(ctx context.Context, policy auth.DownstreamRoutingPolicy) []string {
+	models := resolveOwnedModelCatalog(ctx)
 	if len(policy.SupportedModels) == 0 && len(policy.AllowedRouteIDs) == 0 {
 		if policy.DenyAllWhenEmpty {
 			return []string{}
 		}
 		return models
 	}
+	// SupportedModels empty but AllowedRouteIDs set: keep empty until listing can
+	// join route IDs (AllowedRouteIDs is enforced at channel selection today).
 	if len(policy.SupportedModels) == 0 {
 		return []string{}
 	}
@@ -131,6 +138,93 @@ func getAvailableModels(policy auth.DownstreamRoutingPolicy) []string {
 		}
 	}
 	return filtered
+}
+
+// resolveOwnedModelCatalog loads the MetAPI-owned model name catalog.
+//
+// Priority:
+//  1. UpstreamConfig.Router implementing AvailableModelsSource (TokenRouter.GetAvailableModels)
+//  2. Last-resort stub catalog when METAPI_ENABLE_PROXY_STUB is on (unit tests),
+//     or when a channel-selection router is present but does not implement listing
+//     (e2e / selection mocks that only wire SelectChannel*)
+//  3. Empty list with a one-shot warning when no router is configured in production
+//
+// This never scrapes live upstream /v1/models.
+func resolveOwnedModelCatalog(ctx context.Context) []string {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg := getUpstreamConfig()
+	if src := availableModelsSourceFromConfig(cfg); src != nil {
+		models, err := src.GetAvailableModels(ctx)
+		if err != nil {
+			slog.Warn("getAvailableModels: router listing failed; returning empty catalog", "err", err)
+			return []string{}
+		}
+		return normalizeModelCatalog(models)
+	}
+	// Router is wired for channel selection but does not expose listing (common in
+	// selection-only test doubles). Prefer a stable last-resort catalog over empty
+	// so OpenAI clients still receive a shape-compatible owned list.
+	if cfg != nil && cfg.Router != nil {
+		return lastResortStubCatalog()
+	}
+	if isProxyStubEnabled() {
+		return lastResortStubCatalog()
+	}
+	emptyModelsCatalogLogOnce.Do(func() {
+		slog.Warn("getAvailableModels: no AvailableModelsSource wired; returning empty model list")
+	})
+	return []string{}
+}
+
+// availableModelsSourceFromConfig returns the optional listing capability on the
+// configured TokenRouter. Kept as a thin UpstreamConfig accessor so models listing
+// does not require expanding proxy.TokenRouterInterface (channel-selection surface).
+func availableModelsSourceFromConfig(cfg *UpstreamConfig) AvailableModelsSource {
+	if cfg == nil || cfg.Router == nil {
+		return nil
+	}
+	src, _ := cfg.Router.(AvailableModelsSource)
+	return src
+}
+
+// lastResortStubCatalog is used only when route-backed listing is unavailable
+// (proxy stub tests / selection-only mocks). Production with TokenRouter uses
+// GetAvailableModels instead.
+func lastResortStubCatalog() []string {
+	return []string{
+		"gpt-4o",
+		"gpt-4o-mini",
+		"gpt-4-turbo",
+		"gpt-3.5-turbo",
+		"claude-sonnet-4-20250514",
+		"claude-3-5-sonnet-latest",
+		"gemini-2.5-pro",
+		"gemini-2.5-flash",
+	}
+}
+
+// normalizeModelCatalog drops blanks, de-duplicates, and sorts for stable responses.
+func normalizeModelCatalog(models []string) []string {
+	if len(models) == 0 {
+		return []string{}
+	}
+	seen := make(map[string]struct{}, len(models))
+	out := make([]string, 0, len(models))
+	for _, m := range models {
+		name := strings.TrimSpace(m)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // knownModelContextLength returns a published context window for well-known models

--- a/handler/proxy/models_test.go
+++ b/handler/proxy/models_test.go
@@ -1,12 +1,83 @@
 package proxyhandler
 
 import (
+	"context"
+	"errors"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/tokendancelab/metapi-go/auth"
+	"github.com/tokendancelab/metapi-go/proxy"
+	"github.com/tokendancelab/metapi-go/routing"
 )
+
+// modelsTestRouter is a channel-selection router that implements
+// AvailableModelsSource for /v1/models unit tests.
+type modelsTestRouter struct {
+	models []string
+	err    error
+}
+
+func (r *modelsTestRouter) SelectChannel(context.Context, string, routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+	return nil, nil
+}
+func (r *modelsTestRouter) SelectNextChannel(context.Context, string, []int64, routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+	return nil, nil
+}
+func (r *modelsTestRouter) SelectPreferredChannel(context.Context, string, int64, routing.DownstreamRoutingPolicy, []int64) (*routing.SelectedChannel, error) {
+	return nil, nil
+}
+func (r *modelsTestRouter) RecordSuccess(context.Context, int64, float64, float64, *string, *int64) error {
+	return nil
+}
+func (r *modelsTestRouter) RecordFailure(context.Context, int64, routing.SiteRuntimeFailureContext, *int64) error {
+	return nil
+}
+
+func (r *modelsTestRouter) GetAvailableModels(context.Context) ([]string, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	out := make([]string, len(r.models))
+	copy(out, r.models)
+	return out, nil
+}
+
+// selectionOnlyRouter satisfies TokenRouterInterface without AvailableModelsSource.
+type selectionOnlyRouter struct{}
+
+func (r *selectionOnlyRouter) SelectChannel(context.Context, string, routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+	return nil, nil
+}
+func (r *selectionOnlyRouter) SelectNextChannel(context.Context, string, []int64, routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+	return nil, nil
+}
+func (r *selectionOnlyRouter) SelectPreferredChannel(context.Context, string, int64, routing.DownstreamRoutingPolicy, []int64) (*routing.SelectedChannel, error) {
+	return nil, nil
+}
+func (r *selectionOnlyRouter) RecordSuccess(context.Context, int64, float64, float64, *string, *int64) error {
+	return nil
+}
+func (r *selectionOnlyRouter) RecordFailure(context.Context, int64, routing.SiteRuntimeFailureContext, *int64) error {
+	return nil
+}
+
+// Ensure compile-time interface compliance.
+var (
+	_ proxy.TokenRouterInterface = (*modelsTestRouter)(nil)
+	_ AvailableModelsSource      = (*modelsTestRouter)(nil)
+	_ proxy.TokenRouterInterface = (*selectionOnlyRouter)(nil)
+)
+
+func withModelsRouter(t *testing.T, router proxy.TokenRouterInterface) {
+	t.Helper()
+	prev := getUpstreamConfig()
+	SetUpstreamConfig(&UpstreamConfig{Router: router})
+	t.Cleanup(func() {
+		SetUpstreamConfig(prev)
+	})
+}
 
 // ---- matchModelPattern ----
 
@@ -206,10 +277,12 @@ func TestBuildClaudeModelsResponse_Empty(t *testing.T) {
 
 // ---- getAvailableModels ----
 
-func TestGetAvailableModels(t *testing.T) {
-	models := getAvailableModels(auth.EmptyDownstreamRoutingPolicy)
+func TestGetAvailableModels_LastResortStubWhenUnwired(t *testing.T) {
+	// TestMain enables METAPI_ENABLE_PROXY_STUB; nil upstream uses last-resort catalog.
+	SetUpstreamConfig(nil)
+	models := getAvailableModels(context.Background(), auth.EmptyDownstreamRoutingPolicy)
 	if len(models) == 0 {
-		t.Error("expected non-empty model list")
+		t.Error("expected non-empty model list from last-resort stub catalog")
 	}
 	// Check known models
 	known := map[string]bool{}
@@ -227,9 +300,62 @@ func TestGetAvailableModels(t *testing.T) {
 	}
 }
 
+func TestGetAvailableModels_UsesRouterCatalog(t *testing.T) {
+	withModelsRouter(t, &modelsTestRouter{
+		models: []string{"router-model-b", "router-model-a", "router-model-a", "  "},
+	})
+	got := getAvailableModels(context.Background(), auth.EmptyDownstreamRoutingPolicy)
+	if len(got) != 2 {
+		t.Fatalf("router catalog = %v, want 2 unique sorted models", got)
+	}
+	if got[0] != "router-model-a" || got[1] != "router-model-b" {
+		t.Fatalf("router catalog = %v, want sorted [router-model-a router-model-b]", got)
+	}
+}
+
+func TestGetAvailableModels_RouterErrorReturnsEmpty(t *testing.T) {
+	withModelsRouter(t, &modelsTestRouter{err: errors.New("db down")})
+	got := getAvailableModels(context.Background(), auth.EmptyDownstreamRoutingPolicy)
+	if len(got) != 0 {
+		t.Fatalf("router error should yield empty catalog, got %v", got)
+	}
+}
+
+func TestGetAvailableModels_SelectionOnlyRouterFallsBackToStub(t *testing.T) {
+	// selectionOnlyRouter does not implement AvailableModelsSource.
+	withModelsRouter(t, &selectionOnlyRouter{})
+	got := getAvailableModels(context.Background(), auth.EmptyDownstreamRoutingPolicy)
+	if len(got) == 0 {
+		t.Fatal("selection-only router should fall back to last-resort stub catalog")
+	}
+	known := false
+	for _, m := range got {
+		if m == "gpt-4o" {
+			known = true
+			break
+		}
+	}
+	if !known {
+		t.Fatalf("expected stub gpt-4o in selection-only fallback, got %v", got)
+	}
+}
+
+func TestGetAvailableModels_EmptyWhenNoRouterAndStubDisabled(t *testing.T) {
+	t.Setenv("METAPI_ENABLE_PROXY_STUB", "0")
+	SetUpstreamConfig(nil)
+	got := getAvailableModels(context.Background(), auth.EmptyDownstreamRoutingPolicy)
+	if len(got) != 0 {
+		t.Fatalf("production nil-router without stub should return empty, got %v", got)
+	}
+}
+
 func TestGetAvailableModelsAppliesManagedPolicy(t *testing.T) {
+	withModelsRouter(t, &modelsTestRouter{
+		models: []string{"gpt-4o", "claude-sonnet-4-20250514", "gemini-2.5-pro"},
+	})
+
 	denyAll := auth.DownstreamRoutingPolicy{DenyAllWhenEmpty: true}
-	if got := getAvailableModels(denyAll); len(got) != 0 {
+	if got := getAvailableModels(context.Background(), denyAll); len(got) != 0 {
 		t.Fatalf("deny-all policy returned %v, want empty", got)
 	}
 
@@ -237,7 +363,7 @@ func TestGetAvailableModelsAppliesManagedPolicy(t *testing.T) {
 		SupportedModels:  []string{"gpt-4o"},
 		DenyAllWhenEmpty: true,
 	}
-	got := getAvailableModels(supported)
+	got := getAvailableModels(context.Background(), supported)
 	if len(got) != 1 || got[0] != "gpt-4o" {
 		t.Fatalf("supported policy returned %v, want [gpt-4o]", got)
 	}
@@ -246,7 +372,7 @@ func TestGetAvailableModelsAppliesManagedPolicy(t *testing.T) {
 		SupportedModels:  []string{"claude-*"},
 		DenyAllWhenEmpty: true,
 	}
-	got = getAvailableModels(wildcard)
+	got = getAvailableModels(context.Background(), wildcard)
 	if len(got) == 0 {
 		t.Fatal("wildcard supported policy returned empty, want Claude models")
 	}
@@ -260,8 +386,36 @@ func TestGetAvailableModelsAppliesManagedPolicy(t *testing.T) {
 		AllowedRouteIDs:  []int64{1},
 		DenyAllWhenEmpty: true,
 	}
-	if got := getAvailableModels(routeOnly); len(got) != 0 {
+	if got := getAvailableModels(context.Background(), routeOnly); len(got) != 0 {
 		t.Fatalf("route-only policy returned %v, want empty until route-aware model listing is available", got)
+	}
+}
+
+func TestHandleModels_UsesRouterCatalog(t *testing.T) {
+	withModelsRouter(t, &modelsTestRouter{models: []string{"custom-route-model"}})
+
+	req := httptest.NewRequest("GET", "/v1/models", nil)
+	req = auth.ProxyAuthFromRequest(req, &auth.ProxyAuthContext{
+		Token:  "test",
+		Source: "global",
+		Policy: auth.EmptyDownstreamRoutingPolicy,
+	})
+	rec := httptest.NewRecorder()
+	HandleModels(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	m := unmarshalResponse(t, rec)
+	data, _ := m["data"].([]any)
+	if len(data) != 1 {
+		t.Fatalf("expected 1 model from router, got %#v", data)
+	}
+	first := data[0].(map[string]any)
+	if first["id"] != "custom-route-model" {
+		t.Fatalf("id = %v, want custom-route-model", first["id"])
+	}
+	if first["owned_by"] != modelsOwnedBy {
+		t.Fatalf("owned_by = %v", first["owned_by"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Wire `GET /v1/models` owned catalog to `TokenRouter.GetAvailableModels` via optional `AvailableModelsSource` on `UpstreamConfig.Router`
- Preserve `SupportedModels` / `DenyAllWhenEmpty` / `AllowedRouteIDs`-only policy behavior
- Document last-resort stub only for selection-only mocks and `METAPI_ENABLE_PROXY_STUB` unit tests (no live upstream scrape)

## Test plan
- [x] `go test ./handler/proxy -count=1 -run Models`
- [x] `go test ./handler/proxy -count=1`
- [x] pre-push: `go vet ./...` + `go test ./... -count=1 -race`

Closes #169