### PR TITLE
feat(admin): wire route decision APIs to ExplainSelection #171

### DIFF
--- a/docs/analysis/route-decision-api.md
+++ b/docs/analysis/route-decision-api.md
@@ -1,0 +1,10 @@
+# Route decision API (#171)
+
+## Endpoints
+- GET /api/routes/decision?model= -> TokenRouter.ExplainSelection
+- POST /api/routes/decision/batch {models:[]} (max 50)
+- by-route/route-wide batch currently alias model batch
+- POST /api/routes/decision/refresh queues async warm of up to 20 enabled patterns
+
+## Behavior
+Requires UpstreamConfig.Router (503 if not configured). No empty success stubs.

--- a/handler/admin/route_decision_test.go
+++ b/handler/admin/route_decision_test.go
@@ -1,0 +1,36 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	proxyhandler "github.com/tokendancelab/metapi-go/handler/proxy"
+)
+
+func TestRouteDecision_RequiresRouter(t *testing.T) {
+	proxyhandler.SetUpstreamConfig(nil)
+	_, r := setupTokenRoutesTest(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/routes/decision?model=gpt-4o", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["success"] != false {
+		t.Fatalf("body=%v", body)
+	}
+}
+
+func TestRouteDecision_RequiresModel(t *testing.T) {
+	_, r := setupTokenRoutesTest(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/routes/decision", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d", rec.Code)
+	}
+}

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
+	proxyhandler "github.com/tokendancelab/metapi-go/handler/proxy"
 	"github.com/tokendancelab/metapi-go/handler/shared"
 	"github.com/tokendancelab/metapi-go/routing"
 	"github.com/tokendancelab/metapi-go/service"
@@ -764,45 +766,90 @@ func (h *tokenRoutesHandler) routeDecision(w http.ResponseWriter, r *http.Reques
 		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "model 不能为空"})
 		return
 	}
-
-	// Stub: decision engine not yet wired
+	cfg := proxyhandler.GetUpstreamConfig()
+	if cfg == nil || cfg.Router == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"success": false, "message": "token router is not configured"})
+		return
+	}
+	decision, err := cfg.Router.ExplainSelection(r.Context(), model, nil, routing.EmptyDownstreamRoutingPolicy)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": err.Error()})
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success":  true,
-		"decision": map[string]any{},
+		"decision": decision,
 	})
 }
 
 // POST /api/routes/decision/batch
 func (h *tokenRoutesHandler) routeDecisionBatch(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Models []string `json:"models"`
+	}
+	if err := decodeJSONRequest(r, &body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid request body"})
+		return
+	}
+	cfg := proxyhandler.GetUpstreamConfig()
+	if cfg == nil || cfg.Router == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"success": false, "message": "token router is not configured"})
+		return
+	}
+	if len(body.Models) > 50 {
+		body.Models = body.Models[:50]
+	}
+	out := map[string]any{}
+	for _, model := range body.Models {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		decision, err := cfg.Router.ExplainSelection(r.Context(), model, nil, routing.EmptyDownstreamRoutingPolicy)
+		if err != nil {
+			out[model] = map[string]any{"error": err.Error()}
+			continue
+		}
+		out[model] = decision
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success":   true,
-		"decisions": map[string]any{},
+		"decisions": out,
 	})
 }
 
 // POST /api/routes/decision/by-route/batch
 func (h *tokenRoutesHandler) routeDecisionByRouteBatch(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{
-		"success":   true,
-		"decisions": map[string]any{},
-	})
+	h.routeDecisionBatch(w, r)
 }
 
 // POST /api/routes/decision/route-wide/batch
 func (h *tokenRoutesHandler) routeDecisionRouteWideBatch(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{
-		"success":   true,
-		"decisions": map[string]any{},
-	})
+	h.routeDecisionBatch(w, r)
 }
 
 // POST /api/routes/decision/refresh
 func (h *tokenRoutesHandler) routeDecisionRefresh(w http.ResponseWriter, r *http.Request) {
+	cfg := proxyhandler.GetUpstreamConfig()
+	if cfg == nil || cfg.Router == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"success": false, "message": "token router is not configured"})
+		return
+	}
+	jobID := fmt.Sprintf("decision-refresh-%d", time.Now().UTC().UnixNano())
+	router := cfg.Router
+	db := h.db
+	go func() {
+		var patterns []string
+		_ = db.Select(&patterns, "SELECT model_pattern FROM token_routes WHERE enabled = TRUE ORDER BY id ASC LIMIT 20")
+		for _, p := range patterns {
+			_, _ = router.ExplainSelection(context.Background(), strings.TrimSpace(p), nil, routing.EmptyDownstreamRoutingPolicy)
+		}
+	}()
 	writeJSON(w, http.StatusAccepted, map[string]any{
 		"success": true,
 		"queued":  true,
 		"reused":  false,
-		"jobId":   "stub-decision-refresh",
+		"jobId":   jobID,
 		"status":  "pending",
 		"message": "已开始后台刷新路由选中概率，可稍后返回查看",
 	})

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -63,6 +63,11 @@ func getUpstreamConfig() *UpstreamConfig {
 	return upstreamCfg
 }
 
+// GetUpstreamConfig returns the package-level upstream config for admin/tooling.
+func GetUpstreamConfig() *UpstreamConfig {
+	return getUpstreamConfig()
+}
+
 // dispatchUpstream forwards a proxy request to the selected upstream channel.
 // Implements the spec's 10-step Handler pattern.
 func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -39,6 +39,10 @@ type upstreamTestSuccess struct {
 	modelName *string
 }
 
+func (r *upstreamTestRouter) ExplainSelection(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (routing.RouteDecisionExplanation, error) {
+	return routing.RouteDecisionExplanation{}, nil
+}
+
 func (r *upstreamTestRouter) SelectChannel(_ context.Context, _ string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
 	r.policies = append(r.policies, policy)
 	return &r.selected, nil
@@ -605,7 +609,6 @@ func TestSiteConcurrencySaturateSkipsWithoutFailure(t *testing.T) {
 		t.Fatalf("expected channel 202 success, got %d", router.successes[0].channelID)
 	}
 }
-
 
 func TestNonStreamSuccessPersistsUsageTokensToProxyLog(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/proxy/channel_selection.go
+++ b/proxy/channel_selection.go
@@ -15,6 +15,7 @@ type TokenRouterInterface interface {
 	SelectChannel(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
 	SelectNextChannel(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
 	SelectPreferredChannel(ctx context.Context, requestedModel string, preferredChannelID int64, policy routing.DownstreamRoutingPolicy, excludeChannelIDs []int64) (*routing.SelectedChannel, error)
+	ExplainSelection(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (routing.RouteDecisionExplanation, error)
 	RecordSuccess(ctx context.Context, channelID int64, latencyMs float64, cost float64, modelName *string, actualAccountID *int64) error
 	RecordFailure(ctx context.Context, channelID int64, failureCtx routing.SiteRuntimeFailureContext, actualAccountID *int64) error
 }
@@ -36,7 +37,7 @@ type ChannelSelectionInput struct {
 
 // Tester header constants.
 const (
-	TesterRequestHeader     = "x-metapi-tester-request"
+	TesterRequestHeader       = "x-metapi-tester-request"
 	TesterForcedChannelHeader = "x-metapi-tester-forced-channel-id"
 )
 

--- a/proxy/channel_selection_test.go
+++ b/proxy/channel_selection_test.go
@@ -18,6 +18,10 @@ type mockRouter struct {
 	selectPreferredChannel func(ctx context.Context, requestedModel string, preferredChannelID int64, policy routing.DownstreamRoutingPolicy, excludeChannelIDs []int64) (*routing.SelectedChannel, error)
 }
 
+func (m *mockRouter) ExplainSelection(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (routing.RouteDecisionExplanation, error) {
+	return routing.RouteDecisionExplanation{}, nil
+}
+
 func (m *mockRouter) SelectChannel(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
 	if m.selectChannel != nil {
 		return m.selectChannel(ctx, requestedModel, policy)
@@ -47,8 +51,8 @@ func (m *mockRouter) RecordFailure(ctx context.Context, channelID int64, failure
 }
 
 type mockRouteRefresher struct {
-	called   bool
-	refresh  func(ctx context.Context) error
+	called  bool
+	refresh func(ctx context.Context) error
 }
 
 func (m *mockRouteRefresher) RefreshModelsAndRebuildRoutes(ctx context.Context) error {
@@ -154,7 +158,7 @@ func TestTesterHelpers(t *testing.T) {
 	t.Run("GetTesterForcedChannelID", func(t *testing.T) {
 		t.Run("valid forced channel", func(t *testing.T) {
 			headers := map[string]string{
-				"x-metapi-tester-request":        "1",
+				"x-metapi-tester-request":           "1",
 				"x-metapi-tester-forced-channel-id": "42",
 			}
 			id := GetTesterForcedChannelID(headers, "127.0.0.1")
@@ -165,7 +169,7 @@ func TestTesterHelpers(t *testing.T) {
 
 		t.Run("invalid channel ID", func(t *testing.T) {
 			headers := map[string]string{
-				"x-metapi-tester-request":        "1",
+				"x-metapi-tester-request":           "1",
 				"x-metapi-tester-forced-channel-id": "abc",
 			}
 			id := GetTesterForcedChannelID(headers, "127.0.0.1")
@@ -176,7 +180,7 @@ func TestTesterHelpers(t *testing.T) {
 
 		t.Run("zero channel ID", func(t *testing.T) {
 			headers := map[string]string{
-				"x-metapi-tester-request":        "1",
+				"x-metapi-tester-request":           "1",
 				"x-metapi-tester-forced-channel-id": "0",
 			}
 			id := GetTesterForcedChannelID(headers, "127.0.0.1")
@@ -187,7 +191,7 @@ func TestTesterHelpers(t *testing.T) {
 
 		t.Run("negative channel ID", func(t *testing.T) {
 			headers := map[string]string{
-				"x-metapi-tester-request":        "1",
+				"x-metapi-tester-request":           "1",
 				"x-metapi-tester-forced-channel-id": "-1",
 			}
 			id := GetTesterForcedChannelID(headers, "127.0.0.1")
@@ -198,7 +202,7 @@ func TestTesterHelpers(t *testing.T) {
 
 		t.Run("non-loopback", func(t *testing.T) {
 			headers := map[string]string{
-				"x-metapi-tester-request":        "1",
+				"x-metapi-tester-request":           "1",
 				"x-metapi-tester-forced-channel-id": "42",
 			}
 			id := GetTesterForcedChannelID(headers, "192.168.1.1")


### PR DESCRIPTION
## Summary
- GET /api/routes/decision uses ExplainSelection
- batch endpoints bounded; 503 when router missing
- refresh no longer stub-decision-refresh

Closes #171