### PR TITLE
feat(app): boot-wire ModelProbeScheduler probe executor + health recorder #170

### DIFF
--- a/app/probe_wire.go
+++ b/app/probe_wire.go
@@ -1,0 +1,97 @@
+package app
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/tokendancelab/metapi-go/config"
+	proxyhandler "github.com/tokendancelab/metapi-go/handler/proxy"
+	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/scheduler"
+)
+
+// activeProbeRouter is the TokenRouter built by ConfigureProxyUpstream.
+// ModelProbeScheduler health recording feeds this router at boot (#170).
+var (
+	probeWireMu       sync.RWMutex
+	activeProbeRouter *routing.TokenRouter
+	activeProbeCfg    *config.Config
+)
+
+// tokenRouterHealthRecorder adapts routing.TokenRouter to scheduler.ChannelHealthRecorder.
+// Probe failures never mark credentials expired (router.RecordProbeFailure contract).
+type tokenRouterHealthRecorder struct {
+	router *routing.TokenRouter
+}
+
+func (r *tokenRouterHealthRecorder) RecordProbeSuccess(
+	ctx context.Context,
+	channelID int64,
+	latencyMs float64,
+	modelName *string,
+	actualAccountID *int64,
+) error {
+	if r == nil || r.router == nil {
+		return nil
+	}
+	return r.router.RecordProbeSuccess(ctx, channelID, latencyMs, modelName, actualAccountID)
+}
+
+func (r *tokenRouterHealthRecorder) RecordProbeFailure(
+	ctx context.Context,
+	channelID int64,
+	httpStatus *int,
+	errorText *string,
+	modelName *string,
+	actualAccountID *int64,
+) error {
+	if r == nil || r.router == nil {
+		return nil
+	}
+	return r.router.RecordProbeFailure(ctx, channelID, routing.SiteRuntimeFailureContext{
+		Status:    httpStatus,
+		ErrorText: errorText,
+		ModelName: modelName,
+	}, actualAccountID)
+}
+
+// rememberProbeRouter stores the live TokenRouter for model-probe wiring.
+func rememberProbeRouter(cfg *config.Config, router *routing.TokenRouter) {
+	probeWireMu.Lock()
+	defer probeWireMu.Unlock()
+	activeProbeCfg = cfg
+	activeProbeRouter = router
+}
+
+// WireModelProbeScheduler injects ChannelHealthProbe + ChannelHealthRecorder
+// into a ModelProbeScheduler using the router from ConfigureProxyUpstream.
+// Safe no-op when the proxy router has not been configured yet.
+func WireModelProbeScheduler(s *scheduler.ModelProbeScheduler) {
+	if s == nil {
+		return
+	}
+	probeWireMu.RLock()
+	router := activeProbeRouter
+	cfg := activeProbeCfg
+	probeWireMu.RUnlock()
+
+	if router == nil {
+		slog.Debug("model-probe wire: TokenRouter not ready; probe executor deferred")
+		return
+	}
+	if cfg == nil {
+		cfg = config.Get()
+	}
+
+	probe := proxyhandler.NewChannelHealthProbeExecutor(cfg)
+	s.SetProbeExecutor(probe)
+	s.SetHealthRecorder(&tokenRouterHealthRecorder{router: router})
+	slog.Info("model-probe: probe executor and health recorder wired")
+}
+
+// WireGlobalModelProbeScheduler injects deps into the process-global scheduler
+// if one is already registered (admin / recovery paths).
+func WireGlobalModelProbeScheduler() {
+	WireModelProbeScheduler(scheduler.GetGlobalModelProbeScheduler())
+}

--- a/app/probe_wire_test.go
+++ b/app/probe_wire_test.go
@@ -1,0 +1,142 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/config"
+	proxyhandler "github.com/tokendancelab/metapi-go/handler/proxy"
+	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/scheduler"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func TestWireModelProbeScheduler_ProbeMutatesHealth(t *testing.T) {
+	// Create temp dir first so its cleanup is registered early (runs last = after DB close).
+	dataDir := t.TempDir()
+
+	_ = store.CloseDatabase()
+	routing.ResetSiteRuntimeHealthState()
+	// Close DB before TempDir removal (LIFO: this runs before TempDir cleanup).
+	t.Cleanup(func() {
+		_ = store.CloseDatabase()
+		proxyhandler.SetUpstreamConfig(nil)
+		rememberProbeRouter(nil, nil)
+		scheduler.SetGlobalModelProbeScheduler(nil)
+		routing.ResetSiteRuntimeHealthState()
+	})
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-wire"}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	cfg := &config.Config{
+		AuthToken:                        "admin-token",
+		ProxyToken:                       "downstream-token",
+		DataDir:                          dataDir,
+		DbType:                           store.DialectSQLite,
+		DbUrl:                            filepath.Join(dataDir, "metapi.db"),
+		RequestBodyLimit:                 1 << 20,
+		ProxyMaxChannelAttempts:          3,
+		ProxyFirstByteTimeoutSec:         90,
+		TokenRouterCacheTtlMs:            60_000,
+		RoutingFallbackUnitCost:          1,
+		TokenRouterFailureCooldownMaxSec: 3600,
+		ModelAvailabilityProbeEnabled:    false, // ticker off; manual probe still works
+		ModelAvailabilityProbeTimeoutMs:  5000,
+		RoutingWeights: config.RoutingWeights{
+			BaseWeightFactor: 1,
+			ValueScoreFactor: 1,
+			CostWeight:       1,
+			BalanceWeight:    1,
+			UsageWeight:      1,
+		},
+	}
+	config.Set(cfg)
+
+	if err := store.EnsureRuntimeDatabase(cfg); err != nil {
+		t.Fatalf("EnsureRuntimeDatabase: %v", err)
+	}
+	db := store.GetDB()
+
+	// Seed cooling channel so success clears cooldown + stamps probe status.
+	now := time.Now().UTC().Format(time.RFC3339)
+	until := "2099-01-01T00:00:00Z"
+	res, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		"wire-site", upstream.URL, "anyrouter", "active", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO accounts (site_id, access_token, api_token, status, balance, quota, value_score, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		siteID, "wire-token", "wire-token", "active", 10.0, 100.0, 1.0, now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ := res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		"gpt-wire", "pattern", "weighted", true, now, now)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	routeID, _ := res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO route_channels (
+		route_id, account_id, source_model, priority, weight, enabled,
+		fail_count, consecutive_fail_count, cooldown_level, cooldown_until, last_fail_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		routeID, accountID, "gpt-wire", 0, 10, true,
+		2, 2, 1, until, now)
+	if err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+	channelID, _ := res.LastInsertId()
+
+	if err := ConfigureProxyUpstream(cfg); err != nil {
+		t.Fatalf("ConfigureProxyUpstream: %v", err)
+	}
+
+	s := scheduler.NewModelProbeScheduler(cfg)
+	WireModelProbeScheduler(s)
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Stop() })
+
+	results, available, unavailable := s.ProbeSite(siteID)
+	if available != 1 || unavailable != 0 {
+		t.Fatalf("ProbeSite available=%d unavailable=%d results=%+v", available, unavailable, results)
+	}
+	if len(results) != 1 || results[0].Status != "success" || results[0].ChannelID != channelID {
+		t.Fatalf("ProbeSite results = %+v", results)
+	}
+
+	var cooldown *string
+	var consecutive int64
+	if err := db.QueryRow(`SELECT cooldown_until, consecutive_fail_count FROM route_channels WHERE id = ?`, channelID).
+		Scan(&cooldown, &consecutive); err != nil {
+		t.Fatalf("read channel: %v", err)
+	}
+	if cooldown != nil {
+		t.Fatalf("cooldown_until still set after probe success: %v", *cooldown)
+	}
+	if consecutive != 0 {
+		t.Fatalf("consecutive_fail_count = %d, want 0", consecutive)
+	}
+
+	probeStatus := routing.GetSiteProbeStatus(siteID)
+	if probeStatus.Status != "success" {
+		t.Fatalf("site probe status = %q, want success", probeStatus.Status)
+	}
+	if probeStatus.ChannelID == nil || *probeStatus.ChannelID != channelID {
+		t.Fatalf("probe channel stamp = %v", probeStatus.ChannelID)
+	}
+}

--- a/app/proxy_upstream.go
+++ b/app/proxy_upstream.go
@@ -53,6 +53,10 @@ func ConfigureProxyUpstream(cfg *config.Config) error {
 			return proxyhandler.InsertProxyLog(ctx, store.GetDB(), entry)
 		},
 	})
+	// Remember router for ModelProbeScheduler health recording (#170).
+	// Wire global scheduler if already started (reconfigure / test paths).
+	rememberProbeRouter(cfg, router)
+	WireGlobalModelProbeScheduler()
 	return nil
 }
 

--- a/app/services.go
+++ b/app/services.go
@@ -46,7 +46,11 @@ func StartBackgroundServices() {
 	newRegistry.Register(scheduler.NewSiteAnnouncementScheduler(cfg))
 
 	// ---- Scheduler 7: Model Probe ----
-	newRegistry.Register(scheduler.NewModelProbeScheduler(cfg))
+	// Inject live ChannelHealthProbe + TokenRouter health recorder when the
+	// proxy upstream router is already configured (#170).
+	modelProbe := scheduler.NewModelProbeScheduler(cfg)
+	WireModelProbeScheduler(modelProbe)
+	newRegistry.Register(modelProbe)
 
 	// ---- Scheduler 8: Channel Recovery ----
 	newRegistry.Register(scheduler.NewChannelRecoveryScheduler(cfg))

--- a/docs/analysis/ops-probe-wiring.md
+++ b/docs/analysis/ops-probe-wiring.md
@@ -7,5 +7,6 @@
 - channel_recovery.probeCandidate uses the global model probe executor when registered
 
 ## Residual
-- Ephemeral NewModelProbeScheduler(nil) path has no injected HTTP probe executor until app wires SetProbeExecutor / global scheduler at boot
+- Boot wiring of SetProbeExecutor + health recorder is #170 (`docs/analysis/probe-boot-wiring.md`)
+- Ephemeral `NewModelProbeScheduler(nil)` admin fallbacks still lack HTTP executor until `StartBackgroundServices` registers the global scheduler
 - Marketplace and model-check remain separate issues (#156)

--- a/docs/analysis/probe-boot-wiring.md
+++ b/docs/analysis/probe-boot-wiring.md
@@ -1,0 +1,53 @@
+# Probe boot wiring (#170)
+
+**Date:** 2026-07-17  
+**Lane:** enterprise polish / probe-boot  
+**SSOT code:** `app/probe_wire.go`, `app/services.go`, `app/proxy_upstream.go`, `handler/proxy/channel_health_probe.go`  
+**Peers:** #114 channel health probing, #119 admin channel test harness, #154 ops probe APIs
+
+## Goal
+
+Admin probe paths and background `ModelProbeScheduler` must hit **live upstream** and feed routing health — not skip every target because `SetProbeExecutor` / `SetHealthRecorder` were never injected at boot.
+
+## Boot sequence
+
+```
+cmd/server
+  ConfigureProxyUpstream(cfg)
+    · build routing.TokenRouter
+    · rememberProbeRouter(cfg, router)
+    · WireGlobalModelProbeScheduler()   // no-op if scheduler not started yet
+  StartBackgroundServices()
+    · modelProbe := NewModelProbeScheduler(cfg)
+    · WireModelProbeScheduler(modelProbe)   // inject probe + recorder
+    · Register + StartAll
+    · Start always SetGlobalModelProbeScheduler (enabled or disabled)
+```
+
+Admin `probe-now` / `probe-stream` / `POST /api/models/probe` and channel-recovery then use `GetGlobalModelProbeScheduler()` with a real executor.
+
+## Components
+
+| Piece | Package | Role |
+|-------|---------|------|
+| `ChannelHealthProbeExecutor` | `handler/proxy` | `GET /v1/models` (fallback `POST /v1/chat/completions` on 404/405) via `platform.DoWithProxy` |
+| `tokenRouterHealthRecorder` | `app` | Adapts `TokenRouter.RecordProbeSuccess/Failure` |
+| `WireModelProbeScheduler` | `app` | Composition-root inject into scheduler |
+
+### Success / failure
+
+- **2xx** → `RecordProbeSuccess` (clear credential-scoped cooldown + probe stamp)
+- **Transport error / non-2xx** → `RecordProbeFailure` (cool **probed channel only**; never expire keys)
+- **Missing token / channel load error** → inconclusive (no health mutation)
+
+## Residual
+
+- Platforms that expose neither OpenAI-style `/v1/models` nor `/v1/chat/completions` still probe as failure after both attempts (or after models-only when model name is empty). Native Anthropic/Gemini path-shaped sites may need a later adapter mode.
+- OAuth-only accounts without a resolvable bearer token stay inconclusive.
+- Ephemeral `NewModelProbeScheduler(nil)` fallbacks in admin handlers still have no HTTP executor until the global scheduler is started via `StartBackgroundServices`.
+
+## Verify
+
+```bash
+go test ./app ./scheduler ./handler/proxy ./handler/admin -count=1
+```

--- a/handler/proxy/channel_health_probe.go
+++ b/handler/proxy/channel_health_probe.go
@@ -1,0 +1,344 @@
+package proxyhandler
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/platform"
+	"github.com/tokendancelab/metapi-go/proxy"
+	"github.com/tokendancelab/metapi-go/scheduler"
+	"github.com/tokendancelab/metapi-go/service"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+// ChannelHealthProbeExecutor is a thin boot-wired probe that hits live upstream
+// for ModelProbeScheduler / admin probe-now paths (#170).
+//
+// It prefers a lightweight GET /v1/models check. Platforms without a models
+// catalog endpoint may return non-2xx; those outcomes are recorded as failure
+// (not credential expiry). See docs/analysis/probe-boot-wiring.md residual.
+type ChannelHealthProbeExecutor struct {
+	cfg *config.Config
+
+	// transport is an optional override for tests (fake upstream).
+	// When nil, production uses platform.DoWithProxy / default client.
+	transport http.RoundTripper
+
+	// db is an optional override for tests. When nil, production uses store.GetDB().
+	db *store.DB
+}
+
+// NewChannelHealthProbeExecutor builds the production probe executor.
+func NewChannelHealthProbeExecutor(cfg *config.Config) *ChannelHealthProbeExecutor {
+	return &ChannelHealthProbeExecutor{cfg: cfg}
+}
+
+// SetTransport injects a RoundTripper (tests).
+func (p *ChannelHealthProbeExecutor) SetTransport(rt http.RoundTripper) {
+	if p == nil {
+		return
+	}
+	p.transport = rt
+}
+
+// SetDB injects a database handle (tests). Production leaves this nil.
+func (p *ChannelHealthProbeExecutor) SetDB(db *store.DB) {
+	if p == nil {
+		return
+	}
+	p.db = db
+}
+
+// ProbeChannel implements scheduler.ChannelHealthProbe.
+func (p *ChannelHealthProbeExecutor) ProbeChannel(ctx context.Context, target scheduler.ProbeTarget) (scheduler.ProbeOutcome, error) {
+	if p == nil {
+		return scheduler.ProbeOutcome{Status: "inconclusive", ErrorText: "probe executor nil"}, nil
+	}
+	if target.ChannelID <= 0 {
+		return scheduler.ProbeOutcome{Status: "skipped", ErrorText: "invalid channel id"}, nil
+	}
+
+	dbw := p.db
+	if dbw == nil {
+		dbw = store.GetDB()
+	}
+	if dbw == nil {
+		return scheduler.ProbeOutcome{}, fmt.Errorf("database not initialized")
+	}
+
+	loaded, err := loadProbeChannel(ctx, dbw, target.ChannelID)
+	if err != nil {
+		// Missing channel is inconclusive (no health mutation).
+		return scheduler.ProbeOutcome{Status: "inconclusive", ErrorText: err.Error()}, nil
+	}
+	if loaded.TokenValue == "" {
+		return scheduler.ProbeOutcome{
+			Status:    "inconclusive",
+			ErrorText: "no usable token on channel/account",
+		}, nil
+	}
+
+	model := strings.TrimSpace(target.ModelName)
+	if model == "" {
+		model = loaded.SourceModel
+	}
+
+	// Prefer lightweight models listing. Fall back to a tiny chat completion
+	// when the operator/target model is known and models endpoint is absent
+	// is documented as residual — we still try models first for cost.
+	return p.executeModelsProbe(ctx, loaded, model)
+}
+
+type probeChannelTarget struct {
+	ChannelID   int64
+	AccountID   int64
+	SiteID      int64
+	SourceModel string
+	SiteURL     string
+	TokenValue  string
+	Account     store.Account
+	Site        store.Site
+}
+
+func loadProbeChannel(ctx context.Context, dbw *store.DB, channelID int64) (*probeChannelTarget, error) {
+	var ch struct {
+		ID          int64   `db:"id"`
+		AccountID   int64   `db:"account_id"`
+		TokenID     *int64  `db:"token_id"`
+		SourceModel *string `db:"source_model"`
+		Enabled     bool    `db:"enabled"`
+	}
+	err := dbw.GetContext(ctx, &ch, dbw.Rebind(`
+		SELECT id, account_id, token_id, source_model, enabled
+		FROM route_channels WHERE id = ?`), channelID)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("channel not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load channel: %w", err)
+	}
+
+	var acc store.Account
+	if err := dbw.GetContext(ctx, &acc, dbw.Rebind(`
+		SELECT id, site_id, username, access_token, api_token, balance, balance_used,
+		       quota, unit_cost, value_score, status, is_pinned, sort_order,
+		       checkin_enabled, last_checkin_at, last_balance_refresh, oauth_provider,
+		       oauth_account_key, oauth_project_id, extra_config, created_at, updated_at
+		FROM accounts WHERE id = ?`), ch.AccountID); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("account not found")
+		}
+		return nil, fmt.Errorf("load account: %w", err)
+	}
+
+	var site store.Site
+	if err := dbw.GetContext(ctx, &site, dbw.Rebind(`
+		SELECT id, name, url, external_checkin_url, platform, proxy_url, use_system_proxy,
+		       custom_headers, status, is_pinned, sort_order, global_weight, api_key,
+		       max_concurrency,
+		       post_refresh_probe_enabled, post_refresh_probe_model, post_refresh_probe_scope,
+		       post_refresh_probe_latency_threshold_ms, created_at, updated_at
+		FROM sites WHERE id = ?`), acc.SiteID); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("site not found")
+		}
+		return nil, fmt.Errorf("load site: %w", err)
+	}
+
+	var token *store.AccountToken
+	if ch.TokenID != nil && *ch.TokenID > 0 {
+		var tr store.AccountToken
+		if err := dbw.GetContext(ctx, &tr, dbw.Rebind(`
+			SELECT id, account_id, name, token, token_group, value_status, source,
+			       enabled, is_default, created_at, updated_at
+			FROM account_tokens WHERE id = ?`), *ch.TokenID); err == nil {
+			token = &tr
+		}
+	}
+
+	sourceModel := ""
+	if ch.SourceModel != nil {
+		sourceModel = strings.TrimSpace(*ch.SourceModel)
+	}
+
+	return &probeChannelTarget{
+		ChannelID:   ch.ID,
+		AccountID:   acc.ID,
+		SiteID:      site.ID,
+		SourceModel: sourceModel,
+		SiteURL:     site.URL,
+		TokenValue:  resolveProbeToken(ch.TokenID, token, acc),
+		Account:     acc,
+		Site:        site,
+	}, nil
+}
+
+// resolveProbeToken mirrors harness/routing token resolution without importing
+// selector internals. Falls back to access_token for session-style accounts.
+func resolveProbeToken(tokenID *int64, token *store.AccountToken, acc store.Account) string {
+	if tokenID != nil && *tokenID > 0 {
+		if token == nil || strings.TrimSpace(token.Token) == "" || !token.Enabled {
+			return ""
+		}
+		return strings.TrimSpace(token.Token)
+	}
+	if acc.OAuthProvider != nil && strings.TrimSpace(*acc.OAuthProvider) != "" {
+		return strings.TrimSpace(acc.AccessToken)
+	}
+	if acc.APIToken != nil && strings.TrimSpace(*acc.APIToken) != "" {
+		return strings.TrimSpace(*acc.APIToken)
+	}
+	return strings.TrimSpace(acc.AccessToken)
+}
+
+func (p *ChannelHealthProbeExecutor) executeModelsProbe(ctx context.Context, target *probeChannelTarget, model string) (scheduler.ProbeOutcome, error) {
+	upstreamPath := "/v1/models"
+	upstreamURL := proxy.BuildUpstreamURL(target.SiteURL, upstreamPath)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, upstreamURL, nil)
+	if err != nil {
+		return scheduler.ProbeOutcome{Status: "inconclusive", ErrorText: "build request: " + err.Error()}, nil
+	}
+	req.Header.Set("Authorization", "Bearer "+target.TokenValue)
+	req.Header.Set("User-Agent", "metapi-go-model-probe/1.0")
+
+	proxyCfg := service.BuildPlatformProxyConfig(p.cfg, &target.Account, &target.Site)
+	if proxyCfg != nil {
+		for k, v := range proxyCfg.CustomHeaders {
+			if proxy.IsMetapiControlHeader(k) {
+				continue
+			}
+			if strings.EqualFold(k, "Authorization") {
+				continue
+			}
+			req.Header.Set(k, v)
+		}
+	}
+
+	started := time.Now()
+	resp, err := p.doRequest(ctx, req, proxyCfg)
+	latencyMs := float64(time.Since(started).Milliseconds())
+	if err != nil {
+		// Transport / timeout: treat as failure so recovery can cool flaky channels.
+		msg := err.Error()
+		if strings.Contains(msg, "context deadline exceeded") {
+			msg = "timeout waiting for upstream"
+		}
+		return scheduler.ProbeOutcome{
+			Status:     "failure",
+			LatencyMs:  latencyMs,
+			ErrorText:  msg,
+			HTTPStatus: 0,
+		}, nil
+	}
+	defer resp.Body.Close()
+	// Drain a small amount so keep-alive connections can be reused; discard body.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 8<<10))
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return scheduler.ProbeOutcome{
+			Status:     "success",
+			LatencyMs:  latencyMs,
+			HTTPStatus: resp.StatusCode,
+		}, nil
+	}
+
+	// Non-2xx models listing: some gateways lack /v1/models. Retry once with a
+	// tiny chat completion when we have a model name (better signal, still cheap).
+	if model != "" && (resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed) {
+		return p.executeChatProbe(ctx, target, model)
+	}
+
+	return scheduler.ProbeOutcome{
+		Status:     "failure",
+		LatencyMs:  latencyMs,
+		HTTPStatus: resp.StatusCode,
+		ErrorText:  fmt.Sprintf("upstream status %d", resp.StatusCode),
+	}, nil
+}
+
+func (p *ChannelHealthProbeExecutor) executeChatProbe(ctx context.Context, target *probeChannelTarget, model string) (scheduler.ProbeOutcome, error) {
+	upstreamPath := "/v1/chat/completions"
+	upstreamURL := proxy.BuildUpstreamURL(target.SiteURL, upstreamPath)
+	payload := map[string]any{
+		"model": model,
+		"messages": []map[string]string{
+			{"role": "user", "content": "ping"},
+		},
+		"max_tokens": 1,
+		"stream":     false,
+	}
+	bodyBytes, _ := json.Marshal(payload)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, upstreamURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return scheduler.ProbeOutcome{Status: "inconclusive", ErrorText: "build chat request: " + err.Error()}, nil
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+target.TokenValue)
+	req.Header.Set("User-Agent", "metapi-go-model-probe/1.0")
+
+	proxyCfg := service.BuildPlatformProxyConfig(p.cfg, &target.Account, &target.Site)
+	if proxyCfg != nil {
+		for k, v := range proxyCfg.CustomHeaders {
+			if proxy.IsMetapiControlHeader(k) {
+				continue
+			}
+			if strings.EqualFold(k, "Authorization") {
+				continue
+			}
+			req.Header.Set(k, v)
+		}
+	}
+
+	started := time.Now()
+	resp, err := p.doRequest(ctx, req, proxyCfg)
+	latencyMs := float64(time.Since(started).Milliseconds())
+	if err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "context deadline exceeded") {
+			msg = "timeout waiting for upstream"
+		}
+		return scheduler.ProbeOutcome{
+			Status:     "failure",
+			LatencyMs:  latencyMs,
+			ErrorText:  msg,
+			HTTPStatus: 0,
+		}, nil
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 8<<10))
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return scheduler.ProbeOutcome{
+			Status:     "success",
+			LatencyMs:  latencyMs,
+			HTTPStatus: resp.StatusCode,
+		}, nil
+	}
+	return scheduler.ProbeOutcome{
+		Status:     "failure",
+		LatencyMs:  latencyMs,
+		HTTPStatus: resp.StatusCode,
+		ErrorText:  fmt.Sprintf("upstream status %d", resp.StatusCode),
+	}, nil
+}
+
+func (p *ChannelHealthProbeExecutor) doRequest(ctx context.Context, req *http.Request, proxyCfg *platform.ProxyConfig) (*http.Response, error) {
+	if p.transport != nil {
+		return p.transport.RoundTrip(req.WithContext(ctx))
+	}
+	if proxyCfg != nil && (proxyCfg.ProxyURL != "" || proxyCfg.InsecureSkipTLS) {
+		return platform.DoWithProxy(ctx, req, proxyCfg)
+	}
+	client := &http.Client{Timeout: 0} // context owns deadline
+	return client.Do(req.WithContext(ctx))
+}

--- a/handler/proxy/channel_health_probe_test.go
+++ b/handler/proxy/channel_health_probe_test.go
@@ -1,0 +1,174 @@
+package proxyhandler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/scheduler"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func TestChannelHealthProbeExecutor_ModelsSuccess(t *testing.T) {
+	var hits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/models" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer probe-token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-probe"}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	db := openProbeTestDB(t)
+	channelID := seedProbeChannel(t, db, upstream.URL, "gpt-probe", "probe-token")
+
+	probe := NewChannelHealthProbeExecutor(&config.Config{})
+	probe.SetDB(db)
+	out, err := probe.ProbeChannel(context.Background(), scheduler.ProbeTarget{
+		ChannelID: channelID,
+		ModelName: "gpt-probe",
+	})
+	if err != nil {
+		t.Fatalf("ProbeChannel: %v", err)
+	}
+	if out.Status != "success" {
+		t.Fatalf("status = %q error=%q", out.Status, out.ErrorText)
+	}
+	if out.HTTPStatus != 200 {
+		t.Fatalf("http status = %d", out.HTTPStatus)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("hits = %d", hits.Load())
+	}
+}
+
+func TestChannelHealthProbeExecutor_Models404FallsBackToChat(t *testing.T) {
+	var modelsHits, chatHits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/models":
+			modelsHits.Add(1)
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/chat/completions":
+			chatHits.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"chatcmpl_probe","choices":[{"message":{"content":"ok"}}]}`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	db := openProbeTestDB(t)
+	channelID := seedProbeChannel(t, db, upstream.URL, "gpt-probe", "probe-token")
+
+	probe := NewChannelHealthProbeExecutor(&config.Config{})
+	probe.SetDB(db)
+	out, err := probe.ProbeChannel(context.Background(), scheduler.ProbeTarget{
+		ChannelID: channelID,
+		ModelName: "gpt-probe",
+	})
+	if err != nil {
+		t.Fatalf("ProbeChannel: %v", err)
+	}
+	if out.Status != "success" {
+		t.Fatalf("status = %q error=%q", out.Status, out.ErrorText)
+	}
+	if modelsHits.Load() != 1 || chatHits.Load() != 1 {
+		t.Fatalf("models=%d chat=%d", modelsHits.Load(), chatHits.Load())
+	}
+}
+
+func TestChannelHealthProbeExecutor_Upstream5xxIsFailure(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+	}))
+	t.Cleanup(upstream.Close)
+
+	db := openProbeTestDB(t)
+	channelID := seedProbeChannel(t, db, upstream.URL, "gpt-probe", "probe-token")
+
+	probe := NewChannelHealthProbeExecutor(&config.Config{})
+	probe.SetDB(db)
+	out, err := probe.ProbeChannel(context.Background(), scheduler.ProbeTarget{
+		ChannelID: channelID,
+		ModelName: "gpt-probe",
+	})
+	if err != nil {
+		t.Fatalf("ProbeChannel: %v", err)
+	}
+	if out.Status != "failure" {
+		t.Fatalf("status = %q, want failure", out.Status)
+	}
+	if out.HTTPStatus != 502 {
+		t.Fatalf("http status = %d", out.HTTPStatus)
+	}
+	if !strings.Contains(out.ErrorText, "502") {
+		t.Fatalf("error = %q", out.ErrorText)
+	}
+}
+
+func openProbeTestDB(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open SQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	return db
+}
+
+func seedProbeChannel(t *testing.T, db *store.DB, upstreamURL, model, token string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		"probe-site", upstreamURL, "anyrouter", "active", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("site LastInsertId: %v", err)
+	}
+	res, err = db.Exec(`INSERT INTO accounts (site_id, access_token, api_token, status, balance, quota, value_score, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		siteID, token, token, "active", 10.0, 100.0, 1.0, now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("account LastInsertId: %v", err)
+	}
+	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		model, "pattern", "weighted", true, now, now)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	routeID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("route LastInsertId: %v", err)
+	}
+	res, err = db.Exec(`INSERT INTO route_channels (route_id, account_id, source_model, priority, weight, enabled) VALUES (?, ?, ?, ?, ?, ?)`,
+		routeID, accountID, model, 0, 10, true)
+	if err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+	channelID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("channel LastInsertId: %v", err)
+	}
+	return channelID
+}

--- a/scheduler/model_probe.go
+++ b/scheduler/model_probe.go
@@ -101,9 +101,12 @@ func (s *ModelProbeScheduler) Start(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// Always register for admin probe-now / recovery paths (#154/#170),
+	// even when the background ticker is disabled.
+	SetGlobalModelProbeScheduler(s)
+
 	if !s.cfg.ModelAvailabilityProbeEnabled {
 		slog.Info("model-probe: disabled (probe not enabled)")
-		SetGlobalModelProbeScheduler(s)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- Wire `ChannelHealthProbe` (`GET /v1/models`, chat fallback on 404/405) and `TokenRouter` health recorder into `ModelProbeScheduler` at boot
- Inject after `ConfigureProxyUpstream` and in `StartBackgroundServices` so admin probe-now/stream/recovery hit live upstream
- Always register global model-probe scheduler on Start (even when ticker disabled)
- Docs residual for platforms lacking models endpoint

## Test plan
- [x] `go test ./app ./scheduler ./handler/proxy ./handler/admin -count=1`
- [x] pre-push `go vet` + `go test ./... -race`
- [x] Fake upstream: one probe clears cooldown + stamps site probe status

Closes #170