### PR TITLE
feat(admin): wire route decision APIs to ExplainSelection (#171)

### DIFF
--- a/app/proxy_upstream.go
+++ b/app/proxy_upstream.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -19,10 +20,12 @@ import (
 
 // ConfigureProxyUpstream wires the /v1 data plane to the runtime database.
 // Without this, proxy handlers can parse requests but cannot select real channels.
+// Also publishes the TokenRouter / RouteDecisionService for admin decision APIs.
 func ConfigureProxyUpstream(cfg *config.Config) error {
 	db := store.GetDB()
 	if db == nil {
 		proxyhandler.SetUpstreamConfig(nil)
+		setTokenRouteDecisionRuntime(nil, nil)
 		return fmt.Errorf("proxy upstream: database is not initialized")
 	}
 	coord := proxy.NewProxyChannelCoordinator(cfg)
@@ -42,7 +45,10 @@ func ConfigureProxyUpstream(cfg *config.Config) error {
 	}
 	auth.ConfigureSharedAdmissionFromRedisURL(cfg.RedisURL)
 
-	router := routing.NewTokenRouter(newProxyRoutingStore(db), cfg, nil, proxyLoadProvider{coord: coord})
+	routingStore := newProxyRoutingStore(db)
+	router := routing.NewTokenRouter(routingStore, cfg, nil, proxyLoadProvider{coord: coord})
+	decisionService := routing.NewRouteDecisionService(router, routingStore)
+	setTokenRouteDecisionRuntime(router, decisionService)
 	proxyhandler.SetUpstreamConfig(&proxyhandler.UpstreamConfig{
 		Router:      router,
 		Coordinator: coord,
@@ -54,6 +60,28 @@ func ConfigureProxyUpstream(cfg *config.Config) error {
 		},
 	})
 	return nil
+}
+
+var (
+	tokenRouteDecisionMu      sync.RWMutex
+	tokenRouteDecisionRouter  *routing.TokenRouter
+	tokenRouteDecisionService *routing.RouteDecisionService
+)
+
+func setTokenRouteDecisionRuntime(router *routing.TokenRouter, decisions *routing.RouteDecisionService) {
+	tokenRouteDecisionMu.Lock()
+	defer tokenRouteDecisionMu.Unlock()
+	tokenRouteDecisionRouter = router
+	tokenRouteDecisionService = decisions
+}
+
+// TokenRouteDecisionRuntime returns the TokenRouter and RouteDecisionService
+// published by ConfigureProxyUpstream. Both may be nil when upstream is not wired.
+// Used by router/admin registration without creating an app↔admin import cycle.
+func TokenRouteDecisionRuntime() (*routing.TokenRouter, *routing.RouteDecisionService) {
+	tokenRouteDecisionMu.RLock()
+	defer tokenRouteDecisionMu.RUnlock()
+	return tokenRouteDecisionRouter, tokenRouteDecisionService
 }
 
 type proxyLoadProvider struct {
@@ -452,6 +480,52 @@ func (s *proxyRoutingStore) ClearChannelFailureStates(ctx context.Context, chann
 		return err
 	}
 	_, err = s.execContext(ctx, query, args...)
+	return err
+}
+
+// UpdateRouteDecisionSnapshot persists a route decision explanation snapshot.
+func (s *proxyRoutingStore) UpdateRouteDecisionSnapshot(ctx context.Context, routeID int64, snapshot string, refreshedAt string) error {
+	if strings.TrimSpace(refreshedAt) == "" {
+		refreshedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	_, err := s.execContext(ctx, `
+		UPDATE token_routes
+		SET decision_snapshot = ?, decision_refreshed_at = ?, updated_at = ?
+		WHERE id = ?`, snapshot, refreshedAt, refreshedAt, routeID)
+	return err
+}
+
+// ClearRouteDecisionSnapshot clears one route decision snapshot.
+func (s *proxyRoutingStore) ClearRouteDecisionSnapshot(ctx context.Context, routeID int64) error {
+	_, err := s.execContext(ctx, `
+		UPDATE token_routes
+		SET decision_snapshot = NULL, decision_refreshed_at = NULL
+		WHERE id = ?`, routeID)
+	return err
+}
+
+// ClearRouteDecisionSnapshots clears decision snapshots for the given route IDs.
+func (s *proxyRoutingStore) ClearRouteDecisionSnapshots(ctx context.Context, routeIDs []int64) error {
+	if len(routeIDs) == 0 {
+		return nil
+	}
+	query, args, err := sqlx.In(`
+		UPDATE token_routes
+		SET decision_snapshot = NULL, decision_refreshed_at = NULL
+		WHERE id IN (?)`, routeIDs)
+	if err != nil {
+		return err
+	}
+	_, err = s.execContext(ctx, query, args...)
+	return err
+}
+
+// ClearAllRouteDecisionSnapshots clears every route decision snapshot.
+func (s *proxyRoutingStore) ClearAllRouteDecisionSnapshots(ctx context.Context) error {
+	_, err := s.execContext(ctx, `
+		UPDATE token_routes
+		SET decision_snapshot = NULL, decision_refreshed_at = NULL
+		WHERE decision_snapshot IS NOT NULL OR decision_refreshed_at IS NOT NULL`)
 	return err
 }
 

--- a/docs/analysis/route-decision-api.md
+++ b/docs/analysis/route-decision-api.md
@@ -1,0 +1,46 @@
+# Route Decision Admin APIs (#171)
+
+**Date**: 2026-07-17  
+**Issue**: [#171](https://github.com/TokenDanceLab/metapi-go/issues/171)  
+**Lane**: `lane:decision`
+
+## Summary
+
+Wire `handler/admin/token_routes.go` route-decision endpoints to the real routing
+engine instead of empty maps / `stub-decision-refresh`.
+
+| Endpoint | Behavior |
+|----------|----------|
+| `GET /api/routes/decision?model=` | `TokenRouter.ExplainSelection` → `{ success, decision }` with candidates/strategy summary |
+| `POST /api/routes/decision/batch` | Bounded model list (max 500, deduped) → `{ success, decisions: { [model]: decision } }` |
+| `POST /api/routes/decision/by-route/batch` | Bounded `items[{routeId,model}]` (max 500) → nested `{ [routeId]: { [model]: decision } }` |
+| `POST /api/routes/decision/route-wide/batch` | Bounded `routeIds` (max 500, deduped) → `{ [routeId]: decision }` |
+| `POST /api/routes/decision/refresh` | Background task via `StartBackgroundTask` that calls `RouteDecisionService.RefreshAllRouteDecisionSnapshots`; returns real `jobId`/`taskId`, never `stub-decision-refresh` |
+
+## Wiring
+
+1. `app.ConfigureProxyUpstream` builds one `routing.TokenRouter` +
+   `routing.RouteDecisionService` on the proxy routing store and publishes them
+   via `app.TokenRouteDecisionRuntime()`.
+2. `router.New` registers `admin.RegisterTokenRoutesWithDeps` with deps from
+   `app.TokenRouteDecisionRuntime()` (router package bridges to avoid import cycles).
+3. When upstream is not configured, deps are nil and decision endpoints return
+   **503** with a clear Chinese message (`路由决策引擎未配置`) — no silent empty success.
+4. `DecisionDB.FindAllEnabledRoutes` reuses `[]store.TokenRoute` so the same
+   `proxyRoutingStore` adapter satisfies both selector + snapshot refresh.
+
+## Honest limits
+
+1. Live explain endpoints do not currently persist snapshots unless the refresh
+   job runs (`persistSnapshots` request flags are accepted for API compatibility
+   but not yet applied on batch paths).
+2. `refreshPricingCatalog` is accepted and forwarded into the refresh service
+   signature; pricing catalog refresh itself remains a no-op inside
+   `RouteDecisionService` today.
+3. Background task registry is process-local (same as other admin tasks).
+
+## Verify
+
+```bash
+go test ./handler/admin ./routing -count=1 -run Decision
+```

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -16,9 +17,41 @@ import (
 	"github.com/tokendancelab/metapi-go/service"
 )
 
+const (
+	routeDecisionBatchMaxItems      = 500
+	routeDecisionRefreshTaskType    = "route-decision.refresh"
+	routeDecisionRefreshTaskTitle   = "刷新路由选中概率"
+	routeDecisionRefreshDedupeKey   = "route-decision-refresh"
+	routeDecisionRouterUnavailable  = "路由决策引擎未配置"
+)
+
+// RouteDecisionExplainer is the router surface used by decision admin APIs.
+// Tests inject fakes; production wires routing.TokenRouter.
+type RouteDecisionExplainer interface {
+	ExplainSelection(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (routing.RouteDecisionExplanation, error)
+	ExplainSelectionForRoute(ctx context.Context, routeID int64, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (routing.RouteDecisionExplanation, error)
+	ExplainSelectionRouteWide(ctx context.Context, routeID int64, policy routing.DownstreamRoutingPolicy) (routing.RouteDecisionExplanation, error)
+}
+
+// RouteDecisionRefresher refreshes persisted route decision snapshots.
+type RouteDecisionRefresher interface {
+	RefreshAllRouteDecisionSnapshots(ctx context.Context, refreshPricingCatalog bool) (exactModelCount int, wildcardRouteCount int, err error)
+}
+
+// TokenRoutesDeps are optional dependencies for route decision endpoints.
+type TokenRoutesDeps struct {
+	Router    RouteDecisionExplainer
+	Decisions RouteDecisionRefresher
+}
+
 // RegisterTokenRoutes registers all /api/routes and /api/channels routes.
 func RegisterTokenRoutes(r chi.Router, db *sqlx.DB) {
-	handler := &tokenRoutesHandler{db: db}
+	RegisterTokenRoutesWithDeps(r, db, TokenRoutesDeps{})
+}
+
+// RegisterTokenRoutesWithDeps registers routes with optional decision engine deps.
+func RegisterTokenRoutesWithDeps(r chi.Router, db *sqlx.DB, deps TokenRoutesDeps) {
+	handler := &tokenRoutesHandler{db: db, router: deps.Router, decisions: deps.Decisions}
 
 	// Route list
 	r.Get("/api/routes/lite", handler.listLite)
@@ -52,7 +85,9 @@ func RegisterTokenRoutes(r chi.Router, db *sqlx.DB) {
 }
 
 type tokenRoutesHandler struct {
-	db *sqlx.DB
+	db        *sqlx.DB
+	router    RouteDecisionExplainer
+	decisions RouteDecisionRefresher
 }
 
 // ---- List Lite ----
@@ -764,48 +799,306 @@ func (h *tokenRoutesHandler) routeDecision(w http.ResponseWriter, r *http.Reques
 		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "model 不能为空"})
 		return
 	}
+	if h.router == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"success": false,
+			"message": routeDecisionRouterUnavailable,
+		})
+		return
+	}
 
-	// Stub: decision engine not yet wired
+	decision, err := h.router.ExplainSelection(r.Context(), model, nil, routing.EmptyDownstreamRoutingPolicy)
+	if err != nil {
+		slog.Error("route decision explain failed", "model", model, "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{
+			"success": false,
+			"message": "路由决策查询失败",
+		})
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success":  true,
-		"decision": map[string]any{},
+		"decision": routeDecisionToMap(decision),
 	})
 }
 
 // POST /api/routes/decision/batch
 func (h *tokenRoutesHandler) routeDecisionBatch(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Models                []string `json:"models"`
+		RefreshPricingCatalog bool     `json:"refreshPricingCatalog"`
+		PersistSnapshots      bool     `json:"persistSnapshots"`
+	}
+	if err := decodeJSONRequest(r, &body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid request body"})
+		return
+	}
+	models := uniqueNonEmptyStrings(body.Models)
+	if len(models) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "models 必须是非空数组"})
+		return
+	}
+	if len(models) > routeDecisionBatchMaxItems {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"success": false,
+			"message": fmt.Sprintf("models 最多 %d 项", routeDecisionBatchMaxItems),
+		})
+		return
+	}
+	if h.router == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"success": false,
+			"message": routeDecisionRouterUnavailable,
+		})
+		return
+	}
+
+	_ = body.RefreshPricingCatalog
+	_ = body.PersistSnapshots
+
+	decisions := make(map[string]any, len(models))
+	for _, model := range models {
+		decision, err := h.router.ExplainSelection(r.Context(), model, nil, routing.EmptyDownstreamRoutingPolicy)
+		if err != nil {
+			slog.Warn("route decision batch item failed", "model", model, "error", err)
+			continue
+		}
+		decisions[model] = routeDecisionToMap(decision)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success":   true,
-		"decisions": map[string]any{},
+		"decisions": decisions,
 	})
 }
 
 // POST /api/routes/decision/by-route/batch
 func (h *tokenRoutesHandler) routeDecisionByRouteBatch(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Items []struct {
+			RouteID int64  `json:"routeId"`
+			Model   string `json:"model"`
+		} `json:"items"`
+		RefreshPricingCatalog bool `json:"refreshPricingCatalog"`
+		PersistSnapshots      bool `json:"persistSnapshots"`
+	}
+	if err := decodeJSONRequest(r, &body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid request body"})
+		return
+	}
+	if len(body.Items) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "items 必须是非空数组"})
+		return
+	}
+	if len(body.Items) > routeDecisionBatchMaxItems {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"success": false,
+			"message": fmt.Sprintf("items 最多 %d 项", routeDecisionBatchMaxItems),
+		})
+		return
+	}
+	if h.router == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"success": false,
+			"message": routeDecisionRouterUnavailable,
+		})
+		return
+	}
+
+	_ = body.RefreshPricingCatalog
+	_ = body.PersistSnapshots
+
+	// Nested map: routeId -> model -> decision
+	decisions := map[string]map[string]any{}
+	for _, item := range body.Items {
+		model := strings.TrimSpace(item.Model)
+		if item.RouteID <= 0 || model == "" {
+			continue
+		}
+		decision, err := h.router.ExplainSelectionForRoute(r.Context(), item.RouteID, model, nil, routing.EmptyDownstreamRoutingPolicy)
+		if err != nil {
+			slog.Warn("route decision by-route item failed", "routeId", item.RouteID, "model", model, "error", err)
+			continue
+		}
+		routeKey := strconv.FormatInt(item.RouteID, 10)
+		if decisions[routeKey] == nil {
+			decisions[routeKey] = map[string]any{}
+		}
+		decisions[routeKey][model] = routeDecisionToMap(decision)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success":   true,
-		"decisions": map[string]any{},
+		"decisions": decisions,
 	})
 }
 
 // POST /api/routes/decision/route-wide/batch
 func (h *tokenRoutesHandler) routeDecisionRouteWideBatch(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		RouteIDs              []int64 `json:"routeIds"`
+		RefreshPricingCatalog bool    `json:"refreshPricingCatalog"`
+		PersistSnapshots      bool    `json:"persistSnapshots"`
+	}
+	if err := decodeJSONRequest(r, &body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid request body"})
+		return
+	}
+	routeIDs := uniquePositiveInt64(body.RouteIDs)
+	if len(routeIDs) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "routeIds 必须是非空数组"})
+		return
+	}
+	if len(routeIDs) > routeDecisionBatchMaxItems {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"success": false,
+			"message": fmt.Sprintf("routeIds 最多 %d 项", routeDecisionBatchMaxItems),
+		})
+		return
+	}
+	if h.router == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"success": false,
+			"message": routeDecisionRouterUnavailable,
+		})
+		return
+	}
+
+	_ = body.RefreshPricingCatalog
+	_ = body.PersistSnapshots
+
+	decisions := make(map[string]any, len(routeIDs))
+	for _, routeID := range routeIDs {
+		decision, err := h.router.ExplainSelectionRouteWide(r.Context(), routeID, routing.EmptyDownstreamRoutingPolicy)
+		if err != nil {
+			slog.Warn("route decision route-wide item failed", "routeId", routeID, "error", err)
+			continue
+		}
+		decisions[strconv.FormatInt(routeID, 10)] = routeDecisionToMap(decision)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success":   true,
-		"decisions": map[string]any{},
+		"decisions": decisions,
 	})
 }
 
 // POST /api/routes/decision/refresh
 func (h *tokenRoutesHandler) routeDecisionRefresh(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		RefreshPricingCatalog bool `json:"refreshPricingCatalog"`
+	}
+	// Empty body is allowed; ignore decode errors for {}.
+	_ = decodeJSONRequest(r, &body)
+
+	if h.decisions == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"success": false,
+			"queued":  false,
+			"message": routeDecisionRouterUnavailable,
+		})
+		return
+	}
+
+	refresher := h.decisions
+	refreshPricing := body.RefreshPricingCatalog
+	task, reused := StartBackgroundTask(BackgroundTaskStartOptions{
+		Type:      routeDecisionRefreshTaskType,
+		Title:     routeDecisionRefreshTaskTitle,
+		DedupeKey: routeDecisionRefreshDedupeKey,
+	}, func() (any, error) {
+		exact, wildcard, err := refresher.RefreshAllRouteDecisionSnapshots(context.Background(), refreshPricing)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"exactModelCount":     exact,
+			"wildcardRouteCount":  wildcard,
+			"refreshPricingCatalog": refreshPricing,
+		}, nil
+	})
+
 	writeJSON(w, http.StatusAccepted, map[string]any{
 		"success": true,
 		"queued":  true,
-		"reused":  false,
-		"jobId":   "stub-decision-refresh",
-		"status":  "pending",
+		"reused":  reused,
+		"jobId":   task.ID,
+		"taskId":  task.ID,
+		"status":  string(task.Status),
 		"message": "已开始后台刷新路由选中概率，可稍后返回查看",
 	})
+}
+
+func routeDecisionToMap(d routing.RouteDecisionExplanation) map[string]any {
+	candidates := make([]map[string]any, 0, len(d.Candidates))
+	for _, c := range d.Candidates {
+		candidates = append(candidates, map[string]any{
+			"channelId":              c.ChannelID,
+			"accountId":              c.AccountID,
+			"username":               c.Username,
+			"siteName":               c.SiteName,
+			"tokenName":              c.TokenName,
+			"priority":               c.Priority,
+			"weight":                 c.Weight,
+			"eligible":               c.Eligible,
+			"recentlyFailed":         c.RecentlyFailed,
+			"avoidedByRecentFailure": c.AvoidedByRecentFailure,
+			"probability":            c.Probability,
+			"reason":                 c.Reason,
+		})
+	}
+	out := map[string]any{
+		"requestedModel": d.RequestedModel,
+		"actualModel":    d.ActualModel,
+		"matched":        d.Matched,
+		"modelPattern":   d.ModelPattern,
+		"selectedLabel":  d.SelectedLabel,
+		"summary":        d.Summary,
+		"candidates":     candidates,
+	}
+	if d.RouteID != nil {
+		out["routeId"] = *d.RouteID
+	}
+	if d.SelectedChannelID != nil {
+		out["selectedChannelId"] = *d.SelectedChannelID
+	}
+	if d.SelectedAccountID != nil {
+		out["selectedAccountId"] = *d.SelectedAccountID
+	}
+	if d.Summary == nil {
+		out["summary"] = []string{}
+	}
+	return out
+}
+
+func uniqueNonEmptyStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, raw := range values {
+		v := strings.TrimSpace(raw)
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+func uniquePositiveInt64(values []int64) []int64 {
+	seen := make(map[int64]struct{}, len(values))
+	out := make([]int64, 0, len(values))
+	for _, v := range values {
+		if v <= 0 {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
 }
 
 func strOrNull(s *string) any {

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -509,6 +510,7 @@ func (f *fakeDecisionRouter) ExplainSelectionRouteWide(_ context.Context, routeI
 }
 
 type fakeDecisionRefresher struct {
+	mu                 sync.Mutex
 	calls              int
 	exact              int
 	wildcard           int
@@ -517,9 +519,17 @@ type fakeDecisionRefresher struct {
 }
 
 func (f *fakeDecisionRefresher) RefreshAllRouteDecisionSnapshots(_ context.Context, refreshPricingCatalog bool) (int, int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.calls++
 	f.refreshPricingSeen = append(f.refreshPricingSeen, refreshPricingCatalog)
 	return f.exact, f.wildcard, f.err
+}
+
+func (f *fakeDecisionRefresher) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
 }
 
 func setupTokenRoutesDecisionTest(t *testing.T, deps TokenRoutesDeps) (*store.DB, chi.Router) {
@@ -753,12 +763,12 @@ func TestRouteDecisionRefresh_RealTaskNotStub(t *testing.T) {
 	// Wait for background task completion.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if refresher.calls >= 1 {
+		if refresher.callCount() >= 1 {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if refresher.calls < 1 {
+	if refresher.callCount() < 1 {
 		t.Fatalf("refresher never called")
 	}
 
@@ -904,7 +914,7 @@ func TestRouteDecision_WithSQLiteRouterFixture(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("refresh task did not succeed in time, refresher.calls=%d", refresher.calls)
+	t.Fatalf("refresh task did not succeed in time, refresher.calls=%d", refresher.callCount())
 }
 
 // TestTokenRoutes_ChannelUpdatePreservesIntentionalConfig ensures channel edits set

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -1,13 +1,16 @@
 package admin
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/tokendancelab/metapi-go/routing"
 	"github.com/tokendancelab/metapi-go/store"
 )
 
@@ -452,6 +455,456 @@ func TestTokenRoutes_PartialUpdatePreservesModelMapping(t *testing.T) {
 	if parsed["gpt-*"] != "gpt-4o-mini" {
 		t.Fatalf("intentional mapping update not applied: %v", parsed)
 	}
+}
+
+// ---- Route Decision APIs (#171) ----
+
+type fakeDecisionRouter struct {
+	explainCalls       []string
+	explainForRoute    []string
+	explainRouteWide   []int64
+	decision           routing.RouteDecisionExplanation
+	err                error
+}
+
+func (f *fakeDecisionRouter) ExplainSelection(_ context.Context, requestedModel string, _ []int64, _ routing.DownstreamRoutingPolicy) (routing.RouteDecisionExplanation, error) {
+	f.explainCalls = append(f.explainCalls, requestedModel)
+	if f.err != nil {
+		return routing.RouteDecisionExplanation{}, f.err
+	}
+	d := f.decision
+	if d.RequestedModel == "" {
+		d.RequestedModel = requestedModel
+	}
+	if d.ActualModel == "" {
+		d.ActualModel = requestedModel
+	}
+	return d, nil
+}
+
+func (f *fakeDecisionRouter) ExplainSelectionForRoute(_ context.Context, routeID int64, requestedModel string, _ []int64, _ routing.DownstreamRoutingPolicy) (routing.RouteDecisionExplanation, error) {
+	f.explainForRoute = append(f.explainForRoute, fmt.Sprintf("%d:%s", routeID, requestedModel))
+	if f.err != nil {
+		return routing.RouteDecisionExplanation{}, f.err
+	}
+	d := f.decision
+	d.RequestedModel = requestedModel
+	id := routeID
+	d.RouteID = &id
+	d.Matched = true
+	return d, nil
+}
+
+func (f *fakeDecisionRouter) ExplainSelectionRouteWide(_ context.Context, routeID int64, _ routing.DownstreamRoutingPolicy) (routing.RouteDecisionExplanation, error) {
+	f.explainRouteWide = append(f.explainRouteWide, routeID)
+	if f.err != nil {
+		return routing.RouteDecisionExplanation{}, f.err
+	}
+	d := f.decision
+	id := routeID
+	d.RouteID = &id
+	d.Matched = true
+	d.RequestedModel = fmt.Sprintf("route:%d", routeID)
+	return d, nil
+}
+
+type fakeDecisionRefresher struct {
+	calls              int
+	exact              int
+	wildcard           int
+	err                error
+	refreshPricingSeen []bool
+}
+
+func (f *fakeDecisionRefresher) RefreshAllRouteDecisionSnapshots(_ context.Context, refreshPricingCatalog bool) (int, int, error) {
+	f.calls++
+	f.refreshPricingSeen = append(f.refreshPricingSeen, refreshPricingCatalog)
+	return f.exact, f.wildcard, f.err
+}
+
+func setupTokenRoutesDecisionTest(t *testing.T, deps TokenRoutesDeps) (*store.DB, chi.Router) {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("failed to open SQLite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+	r := chi.NewRouter()
+	RegisterTokenRoutesWithDeps(r, db.DB, deps)
+	return db, r
+}
+
+func TestRouteDecision_MissingModel(t *testing.T) {
+	_, r := setupTokenRoutesDecisionTest(t, TokenRoutesDeps{Router: &fakeDecisionRouter{}})
+	resp := doGet(t, r, "/api/routes/decision")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestRouteDecision_RouterUnavailable(t *testing.T) {
+	_, r := setupTokenRoutesDecisionTest(t, TokenRoutesDeps{})
+	resp := doGet(t, r, "/api/routes/decision?model=gpt-4o")
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != false {
+		t.Fatalf("success = %v, want false", body["success"])
+	}
+	if msg, _ := body["message"].(string); msg == "" {
+		t.Fatalf("expected clear error message, body=%v", body)
+	}
+}
+
+func TestRouteDecision_ExplainSelection(t *testing.T) {
+	routeID := int64(7)
+	channelID := int64(11)
+	fake := &fakeDecisionRouter{
+		decision: routing.RouteDecisionExplanation{
+			RequestedModel:    "gpt-4o",
+			ActualModel:       "gpt-4o",
+			Matched:           true,
+			RouteID:           &routeID,
+			ModelPattern:      "gpt-4o",
+			SelectedChannelID: &channelID,
+			Summary:           []string{"命中路由：gpt-4o", "路由策略：按权重随机"},
+			Candidates: []routing.RouteDecisionCandidate{
+				{
+					ChannelID:  channelID,
+					AccountID:  3,
+					Username:   "u1",
+					SiteName:   "s1",
+					Priority:   0,
+					Weight:     10,
+					Eligible:   true,
+					Probability: 1,
+				},
+			},
+		},
+	}
+	_, r := setupTokenRoutesDecisionTest(t, TokenRoutesDeps{Router: fake})
+	resp := doGet(t, r, "/api/routes/decision?model=gpt-4o")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != true {
+		t.Fatalf("success = %v", body["success"])
+	}
+	decision, ok := body["decision"].(map[string]any)
+	if !ok {
+		t.Fatalf("decision missing: %v", body)
+	}
+	if decision["matched"] != true {
+		t.Fatalf("matched = %v", decision["matched"])
+	}
+	if decision["modelPattern"] != "gpt-4o" {
+		t.Fatalf("modelPattern = %v", decision["modelPattern"])
+	}
+	summary, ok := decision["summary"].([]any)
+	if !ok || len(summary) == 0 {
+		t.Fatalf("summary missing: %v", decision["summary"])
+	}
+	candidates, ok := decision["candidates"].([]any)
+	if !ok || len(candidates) != 1 {
+		t.Fatalf("candidates = %v", decision["candidates"])
+	}
+	if len(fake.explainCalls) != 1 || fake.explainCalls[0] != "gpt-4o" {
+		t.Fatalf("explainCalls = %v", fake.explainCalls)
+	}
+}
+
+func TestRouteDecisionBatch_BoundedAndMapped(t *testing.T) {
+	fake := &fakeDecisionRouter{
+		decision: routing.RouteDecisionExplanation{
+			Matched: true,
+			Summary: []string{"ok"},
+		},
+	}
+	_, r := setupTokenRoutesDecisionTest(t, TokenRoutesDeps{Router: fake})
+
+	// empty models
+	empty := doPostJSON(t, r, "/api/routes/decision/batch", map[string]any{"models": []string{}})
+	if empty.Code != http.StatusBadRequest {
+		t.Fatalf("empty models status = %d body=%s", empty.Code, empty.Body.String())
+	}
+
+	// over bound
+	tooMany := make([]string, routeDecisionBatchMaxItems+1)
+	for i := range tooMany {
+		tooMany[i] = "m-" + strconv.Itoa(i)
+	}
+	bound := doPostJSON(t, r, "/api/routes/decision/batch", map[string]any{"models": tooMany})
+	if bound.Code != http.StatusBadRequest {
+		t.Fatalf("bound status = %d body=%s", bound.Code, bound.Body.String())
+	}
+
+	okResp := doPostJSON(t, r, "/api/routes/decision/batch", map[string]any{
+		"models": []string{"gpt-4o", "gpt-4o", " claude-4 "},
+	})
+	if okResp.Code != http.StatusOK {
+		t.Fatalf("batch status = %d body=%s", okResp.Code, okResp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(okResp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	decisions := body["decisions"].(map[string]any)
+	if len(decisions) != 2 {
+		t.Fatalf("decisions keys = %v, want 2 unique", decisions)
+	}
+	if _, ok := decisions["gpt-4o"]; !ok {
+		t.Fatalf("missing gpt-4o: %v", decisions)
+	}
+	if _, ok := decisions["claude-4"]; !ok {
+		t.Fatalf("missing claude-4: %v", decisions)
+	}
+	if len(fake.explainCalls) != 2 {
+		t.Fatalf("explainCalls = %v, want 2 after dedupe", fake.explainCalls)
+	}
+}
+
+func TestRouteDecisionByRouteAndRouteWideBatch(t *testing.T) {
+	fake := &fakeDecisionRouter{
+		decision: routing.RouteDecisionExplanation{
+			Matched: true,
+			Summary: []string{"route"},
+			Candidates: []routing.RouteDecisionCandidate{
+				{ChannelID: 1, Eligible: true, Probability: 0.5},
+			},
+		},
+	}
+	_, r := setupTokenRoutesDecisionTest(t, TokenRoutesDeps{Router: fake})
+
+	byRoute := doPostJSON(t, r, "/api/routes/decision/by-route/batch", map[string]any{
+		"items": []map[string]any{
+			{"routeId": 1, "model": "gpt-4o"},
+			{"routeId": 2, "model": "claude-4"},
+		},
+	})
+	if byRoute.Code != http.StatusOK {
+		t.Fatalf("by-route status = %d body=%s", byRoute.Code, byRoute.Body.String())
+	}
+	var byRouteBody map[string]any
+	if err := json.Unmarshal(byRoute.Body.Bytes(), &byRouteBody); err != nil {
+		t.Fatalf("decode by-route: %v", err)
+	}
+	decisions := byRouteBody["decisions"].(map[string]any)
+	if _, ok := decisions["1"]; !ok {
+		t.Fatalf("missing route 1: %v", decisions)
+	}
+	route1 := decisions["1"].(map[string]any)
+	if _, ok := route1["gpt-4o"]; !ok {
+		t.Fatalf("missing model under route 1: %v", route1)
+	}
+
+	wide := doPostJSON(t, r, "/api/routes/decision/route-wide/batch", map[string]any{
+		"routeIds": []int64{9, 9, 10},
+	})
+	if wide.Code != http.StatusOK {
+		t.Fatalf("route-wide status = %d body=%s", wide.Code, wide.Body.String())
+	}
+	var wideBody map[string]any
+	if err := json.Unmarshal(wide.Body.Bytes(), &wideBody); err != nil {
+		t.Fatalf("decode wide: %v", err)
+	}
+	wideDecisions := wideBody["decisions"].(map[string]any)
+	if len(wideDecisions) != 2 {
+		t.Fatalf("wide decisions = %v", wideDecisions)
+	}
+	if len(fake.explainRouteWide) != 2 {
+		t.Fatalf("explainRouteWide calls = %v", fake.explainRouteWide)
+	}
+}
+
+func TestRouteDecisionRefresh_RealTaskNotStub(t *testing.T) {
+	refresher := &fakeDecisionRefresher{exact: 2, wildcard: 1}
+	_, r := setupTokenRoutesDecisionTest(t, TokenRoutesDeps{
+		Router:    &fakeDecisionRouter{},
+		Decisions: refresher,
+	})
+
+	resp := doPostJSON(t, r, "/api/routes/decision/refresh", map[string]any{})
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("refresh status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != true || body["queued"] != true {
+		t.Fatalf("unexpected body: %v", body)
+	}
+	jobID, _ := body["jobId"].(string)
+	if jobID == "" || jobID == "stub-decision-refresh" {
+		t.Fatalf("jobId = %q, want real background task id", jobID)
+	}
+
+	// Wait for background task completion.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if refresher.calls >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if refresher.calls < 1 {
+		t.Fatalf("refresher never called")
+	}
+
+	taskResp := doGet(t, r, "/api/tasks/"+jobID)
+	// tasks routes not registered on this router — just assert task registry entry.
+	task := getBackgroundTask(jobID)
+	if task == nil {
+		t.Fatalf("background task %s not found", jobID)
+	}
+	// Allow a short wait for status transition.
+	for i := 0; i < 50 && task.Status != BackgroundTaskSucceeded && task.Status != BackgroundTaskFailed; i++ {
+		time.Sleep(10 * time.Millisecond)
+		task = getBackgroundTask(jobID)
+	}
+	if task.Status != BackgroundTaskSucceeded {
+		t.Fatalf("task status = %s error=%v", task.Status, task.Error)
+	}
+	if task.Type != routeDecisionRefreshTaskType {
+		t.Fatalf("task type = %s", task.Type)
+	}
+	_ = taskResp
+}
+
+func TestRouteDecisionRefresh_Unavailable(t *testing.T) {
+	_, r := setupTokenRoutesDecisionTest(t, TokenRoutesDeps{})
+	resp := doPostJSON(t, r, "/api/routes/decision/refresh", map[string]any{})
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["queued"] == true {
+		t.Fatalf("must not claim queued when unavailable: %v", body)
+	}
+}
+
+func TestRouteDecision_WithSQLiteRouterFixture(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	siteRes, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES ('Decision Site', 'https://decision.example.com', 'openai', 'active', ?, ?)`, now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := siteRes.LastInsertId()
+	accRes, err := db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
+		VALUES (?, 'dec-user', 'sk-dec', 'active', 1, ?, ?)`, siteID, now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ := accRes.LastInsertId()
+	tokRes, err := db.Exec(`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
+		VALUES (?, 'dec-token', 'sk-dec-token', 'ready', 'manual', 1, 1, ?, ?)`, accountID, now, now)
+	if err != nil {
+		t.Fatalf("insert token: %v", err)
+	}
+	tokenID, _ := tokRes.LastInsertId()
+	routeRes, err := db.Exec(`INSERT INTO token_routes (model_pattern, routing_strategy, enabled, created_at, updated_at)
+		VALUES ('gpt-4o', 'weighted', 1, ?, ?)`, now, now)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	routeID, _ := routeRes.LastInsertId()
+	if _, err := db.Exec(`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+		VALUES (?, ?, ?, 'gpt-4o', 0, 10, 1, 0)`, routeID, accountID, tokenID); err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+
+	// Lightweight in-package fixture router: use fake that mirrors real explain shape.
+	// Full TokenRouter needs ChannelSelectorDB; fake + sqlite fixture covers handler path.
+	fake := &fakeDecisionRouter{
+		decision: routing.RouteDecisionExplanation{
+			Matched:      true,
+			ModelPattern: "gpt-4o",
+			RouteID:      &routeID,
+			Summary:      []string{"命中路由：gpt-4o"},
+			Candidates: []routing.RouteDecisionCandidate{
+				{ChannelID: 1, AccountID: accountID, Eligible: true, Probability: 1, Weight: 10},
+			},
+		},
+	}
+	refresher := &fakeDecisionRefresher{exact: 1}
+	r := chi.NewRouter()
+	RegisterTokenRoutesWithDeps(r, db.DB, TokenRoutesDeps{Router: fake, Decisions: refresher})
+	RegisterTasksRoutes(r, db.DB)
+
+	resp := doGet(t, r, "/api/routes/decision?model=gpt-4o")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	decision := body["decision"].(map[string]any)
+	if decision["matched"] != true {
+		t.Fatalf("expected matched decision, got %v", decision)
+	}
+	if float64(routeID) != decision["routeId"] {
+		// routeId may be number; tolerate
+		if decision["routeId"] == nil {
+			t.Fatalf("routeId missing: %v", decision)
+		}
+	}
+
+	// Refresh should not use stub job id and should complete.
+	refresh := doPostJSON(t, r, "/api/routes/decision/refresh", map[string]any{"refreshPricingCatalog": false})
+	if refresh.Code != http.StatusAccepted {
+		t.Fatalf("refresh status = %d body=%s", refresh.Code, refresh.Body.String())
+	}
+	var refreshBody map[string]any
+	if err := json.Unmarshal(refresh.Body.Bytes(), &refreshBody); err != nil {
+		t.Fatalf("decode refresh: %v", err)
+	}
+	jobID, _ := refreshBody["jobId"].(string)
+	if jobID == "stub-decision-refresh" || jobID == "" {
+		t.Fatalf("unexpected jobId %q", jobID)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		taskResp := doGet(t, r, "/api/tasks/"+jobID)
+		if taskResp.Code == http.StatusOK {
+			var taskBody map[string]any
+			_ = json.Unmarshal(taskResp.Body.Bytes(), &taskBody)
+			if task, ok := taskBody["task"].(map[string]any); ok {
+				if task["status"] == "succeeded" {
+					return
+				}
+				if task["status"] == "failed" {
+					t.Fatalf("refresh task failed: %v", task)
+				}
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("refresh task did not succeed in time, refresher.calls=%d", refresher.calls)
 }
 
 // TestTokenRoutes_ChannelUpdatePreservesIntentionalConfig ensures channel edits set

--- a/router/router.go
+++ b/router/router.go
@@ -75,7 +75,7 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 			admin.RegisterSiteAnnouncementsRoutes(r, db.DB)
 			admin.RegisterAuthSettingsRoutes(r, db.DB, cfg)
 			admin.RegisterCheckinRoutes(r, db.DB, cfg)
-			admin.RegisterTokenRoutes(r, db.DB)
+			admin.RegisterTokenRoutesWithDeps(r, db.DB, tokenRoutesDeps())
 			admin.RegisterChannelTestRoutes(r, db.DB, cfg)
 			admin.RegisterUpdateCenterRoutes(r)
 			admin.RegisterOauthRoutes(r, db.DB)
@@ -115,6 +115,22 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 	setupSPAFallback(r, webFS)
 
 	return r
+}
+
+// tokenRoutesDeps bridges app-published TokenRouter/RouteDecisionService into
+// admin handlers without creating an app↔admin import cycle.
+// Only assign non-nil concrete pointers so interface fields stay truly nil
+// (avoid typed-nil interface traps).
+func tokenRoutesDeps() admin.TokenRoutesDeps {
+	router, decisions := app.TokenRouteDecisionRuntime()
+	deps := admin.TokenRoutesDeps{}
+	if router != nil {
+		deps.Router = router
+	}
+	if decisions != nil {
+		deps.Decisions = decisions
+	}
+	return deps
 }
 
 // setupSPAFallback configures static asset serving and SPA fallback.

--- a/routing/decision.go
+++ b/routing/decision.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/tokendancelab/metapi-go/store"
 )
 
 // RouteDecisionService handles route decision snapshots.
@@ -13,11 +15,10 @@ type RouteDecisionService struct {
 }
 
 // DecisionDB defines the DB operations for decision snapshots.
+// FindAllEnabledRoutes reuses the TokenRoute shape so the same store
+// adapter that backs TokenRouter can also back snapshot refresh.
 type DecisionDB interface {
-	FindAllEnabledRoutes(ctx context.Context) ([]struct {
-		ID           int64
-		ModelPattern string
-	}, error)
+	FindAllEnabledRoutes(ctx context.Context) ([]store.TokenRoute, error)
 	UpdateRouteDecisionSnapshot(ctx context.Context, routeID int64, snapshot string, refreshedAt string) error
 	ClearRouteDecisionSnapshot(ctx context.Context, routeID int64) error
 	ClearRouteDecisionSnapshots(ctx context.Context, routeIDs []int64) error


### PR DESCRIPTION
## Summary
- Wire `GET/POST /api/routes/decision*` to `TokenRouter.ExplainSelection*` with bounded batch inputs (max 500) and camelCase decision payloads (candidates, strategy summary).
- Replace `stub-decision-refresh` with a real background task that runs `RouteDecisionService.RefreshAllRouteDecisionSnapshots`.
- Return clear **503** when router/decision service is unavailable; publish runtime from `ConfigureProxyUpstream` without app↔admin import cycles.

## Test plan
- [x] `go test ./handler/admin ./routing -count=1 -run Decision`
- [x] `go test ./handler/admin -count=1 -race -run Decision`
- [x] pre-push local CI (`go vet ./...` + `go test ./... -count=1 -race`)

Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live route-decision explanations for individual models, routes, and batches.
  * Added route-wide decision analysis with validated, deduplicated, and size-limited requests.
  * Added a refresh endpoint that starts a background task and returns real task details.
  * Route decisions now use the active routing engine instead of placeholder responses.

* **Bug Fixes**
  * Requests now return clear validation or service-unavailable errors when required routing services are unavailable.

* **Documentation**
  * Added API documentation covering request limits, response formats, refresh behavior, and current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->