### PR TITLE
docs(release): record v0.8.1 polish #168–#171

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
-## [Unreleased]
+## [v0.8.1] — 2026-07-17
 
 ### Fixed
-- Bump Go toolchain to 1.26.5 to clear GO-2026-5856 (crypto/tls ECH) vulncheck.
+- Go 1.26.5 toolchain; vulncheck green (GO-2026-5856) (#168)
+
+### Added
+- Live  listing via TokenRouter.GetAvailableModels (#169)
+- Boot-wired ModelProbeScheduler probe executor + health recorder (#170)
+- Route decision admin APIs wired to ExplainSelection (#171)
 
 ## [v0.8.0] — 2026-07-17
 

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -74,9 +74,9 @@
 | Milestone | https://github.com/TokenDanceLab/metapi-go/milestone/6 · Roadmap `docs/plan/feature-complete-roadmap.md` |
 | Shipped infra | Site max concurrency · per-key `proxy_url` · group route rebuild |
 | Closed F1+P1 | Full gap backlog #38–#56 (PRs #74–#94) |
-| In flight WFs | none — ops residual #154–#158 landed; v0.8.0 tagged |
-| Next | v0.8.1 polish waves (#169 models list, #170 probe boot, #171 decision API); deeper product backlog as needed |
-| Residual CI | Go 1.26.5 clears GO-2026-5856; frontend occasional EnvironmentTeardownError flake (tests pass) |
+| In flight WFs | none — v0.8.1 polish #168–#171 landed |
+| Next | Optional tag v0.8.1; deeper product backlog / P4 adapter stubs as needed |
+| Residual CI | vulncheck green on Go 1.26.5; frontend occasional EnvironmentTeardownError flake (tests pass) |
 
 ### M-COMPETE notes (active)
 


### PR DESCRIPTION
Go 1.26.5 + models list + probe boot + decision API landed. Ready for v0.8.1 tag.