### PR TITLE
feat(admin): wire /api/test proxy+chat to channel harness (#185)

### DIFF
--- a/docs/analysis/p4-admin-test-routes.md
+++ b/docs/analysis/p4-admin-test-routes.md
@@ -1,0 +1,75 @@
+# P4 admin test routes (#185)
+
+**Date:** 2026-07-17  
+**Issue:** [#185](https://github.com/TokenDanceLab/metapi-go/issues/185)  
+**Peers:** [#119](https://github.com/TokenDanceLab/metapi-go/issues/119) forced-channel harness  
+**Code:** `handler/admin/test.go`, reuses `handler/admin/channel_test_harness.go`
+
+## Goal
+
+Replace `handler/admin/test.go` fake `success:true` / stub-job responses with either:
+
+1. the real forced-channel harness path, or
+2. an honest **501** residual (never `success:true` with a not-implemented message).
+
+## Behavior matrix
+
+| Method | Path | Behavior |
+|--------|------|----------|
+| POST | `/api/test/proxy` | When `channelId` / `forcedChannelId` / `siteId` present → delegate to harness (`runChannelTest`). Otherwise **501** residual (full path/multipart matrix not ported). |
+| POST | `/api/test/chat` | Same alias as proxy when a forced channel/site is provided. |
+| POST | `/api/test/proxy/stream` | **501** residual (SSE matrix). |
+| POST | `/api/test/chat/stream` | **501** residual (SSE). |
+| POST | `/api/test/proxy/jobs` | **501** residual (no async job queue). |
+| POST | `/api/test/chat/jobs` | **501** residual (no async job queue). |
+| GET/DELETE | `/api/test/{proxy,chat}/jobs/{jobId}` | **404** `job not found` (no registry; no stub-job invent). |
+
+## Request mapping
+
+Frontend envelopes (`ProxyTestRequestEnvelope`, chat payloads) are accepted and projected onto harness fields:
+
+| Input | Harness field |
+|-------|---------------|
+| `channelId` or `forcedChannelId` | `channelId` (first positive) |
+| `siteId` | `siteId` |
+| top-level `model` or `jsonBody.model` | `model` |
+| top-level `prompt`, last user `messages[]`, or nested `jsonBody.messages/prompt/input` | `prompt` |
+| `mode`, else path containing `/models` | `mode` (`chat` default) |
+| `timeoutMs` | `timeoutMs` (clamped by harness) |
+
+Probe execution, redaction, timeout clamps, and token resolution are **not duplicated** — they live in `channelTestHandler.runChannelTest` / `executeProbe`.
+
+## Residual honesty
+
+501 body shape:
+
+```json
+{
+  "success": false,
+  "message": "… is not implemented in Go",
+  "residual": "… what is missing and which endpoint to use instead"
+}
+```
+
+Rules:
+
+- Never return HTTP 200 with `success:true` for unimplemented work.
+- Never invent `jobId: "stub-job"`.
+- Prefer pointing operators at `POST /api/admin/test-channel` for forced probes.
+
+## Router wiring
+
+`RegisterTestRoutes(r, db, cfg)` now requires DB + config so aliases can construct the shared harness handler. Called from `router/router.go` inside the admin-auth + DB-ready group.
+
+## Tests
+
+`handler/admin/test_routes_test.go`:
+
+- route mount + invalid JSON → 400
+- proxy/chat without forced id → 501 + residual, `success:false`
+- forced channel / siteId → real harness probe (transport stub)
+- stream + job create → 501; job get/delete → 404 without fake success
+
+```bash
+go test ./handler/admin -count=1 -run 'TestTest|TestRegisterTest|TestMapFlexible|TestChannelTest'
+```

--- a/handler/admin/channel_test_harness.go
+++ b/handler/admin/channel_test_harness.go
@@ -124,7 +124,12 @@ func (h *channelTestHandler) testChannel(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
+	h.runChannelTest(w, r, body)
+}
 
+// runChannelTest is the shared forced-channel probe implementation used by
+// /api/admin/test-channel and the /api/test/{proxy,chat} aliases (#185).
+func (h *channelTestHandler) runChannelTest(w http.ResponseWriter, r *http.Request, body channelTestRequest) {
 	mode := strings.ToLower(strings.TrimSpace(body.Mode))
 	if mode == "" {
 		mode = channelTestModeChat

--- a/handler/admin/test.go
+++ b/handler/admin/test.go
@@ -1,14 +1,22 @@
 package admin
 
 import (
+	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/config"
 )
 
 // RegisterTestRoutes registers all /api/test routes.
-func RegisterTestRoutes(r chi.Router) {
-	handler := &testHandler{}
+// Sync proxy/chat probes alias the forced-channel harness (#119 / #185).
+// Stream and async job surfaces return honest 501 residuals (no fake success).
+func RegisterTestRoutes(r chi.Router, db *sqlx.DB, cfg *config.Config) {
+	handler := &testHandler{
+		channel: &channelTestHandler{db: db, cfg: cfg},
+	}
 
 	// Proxy test endpoints
 	r.Post("/api/test/proxy", handler.proxyTest)
@@ -25,88 +33,237 @@ func RegisterTestRoutes(r chi.Router) {
 	r.Delete("/api/test/chat/jobs/{jobId}", handler.chatTestJobCancel)
 }
 
-type testHandler struct{}
+type testHandler struct {
+	channel *channelTestHandler
+}
+
+// flexibleTestBody accepts both harness-shaped fields and the richer frontend
+// proxy/chat envelopes (forcedChannelId, jsonBody, messages).
+type flexibleTestBody struct {
+	ChannelID       *int64          `json:"channelId"`
+	ForcedChannelID *int64          `json:"forcedChannelId"`
+	SiteID          *int64          `json:"siteId"`
+	Model           string          `json:"model"`
+	Prompt          string          `json:"prompt"`
+	Mode            string          `json:"mode"`
+	TimeoutMs       *int64          `json:"timeoutMs"`
+	Path            string          `json:"path"`
+	JSONBody        json.RawMessage `json:"jsonBody"`
+	Messages        []testMessage   `json:"messages"`
+}
+
+type testMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
 
 // POST /api/test/proxy
+// Accepts channelId/siteId/forcedChannelId + model and delegates to the
+// forced-channel harness. Full path/multipart matrix testing remains residual.
 func (h *testHandler) proxyTest(w http.ResponseWriter, r *http.Request) {
-	// Stub: proxy test not yet wired
-	writeJSON(w, http.StatusOK, map[string]any{
-		"success": true,
-		"message": "Proxy test is not yet implemented in Go",
-	})
+	h.handleSyncProbe(w, r, "proxy")
 }
 
 // POST /api/test/proxy/stream
 func (h *testHandler) proxyTestStream(w http.ResponseWriter, r *http.Request) {
-	// Stub
-	writeJSON(w, http.StatusOK, map[string]any{
-		"success": true,
-		"message": "Proxy stream test is not yet implemented in Go",
-	})
+	writeNotImplementedResidual(w,
+		"Proxy stream test is not implemented in Go",
+		"SSE /api/test/proxy/stream matrix; use non-stream POST /api/test/proxy with channelId/siteId or POST /api/admin/test-channel",
+	)
 }
 
 // POST /api/test/proxy/jobs
 func (h *testHandler) proxyTestJob(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusAccepted, map[string]any{
-		"jobId":     "stub-job",
-		"status":    "pending",
-		"createdAt": "",
-		"expiresAt": "",
-	})
+	writeNotImplementedResidual(w,
+		"Proxy test job queue is not implemented in Go",
+		"async /api/test/proxy/jobs; use sync POST /api/test/proxy or POST /api/admin/test-channel",
+	)
 }
 
 // GET /api/test/proxy/jobs/:jobId
 func (h *testHandler) proxyTestJobStatus(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusNotFound, map[string]any{
-		"error": map[string]any{
-			"message": "job not found",
-			"type":    "not_found",
-		},
-	})
+	writeJobNotFound(w)
 }
 
 // DELETE /api/test/proxy/jobs/:jobId
 func (h *testHandler) proxyTestJobCancel(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{"success": true})
+	writeJobNotFound(w)
 }
 
 // POST /api/test/chat
+// Alias of the forced-channel harness when channelId/siteId/forcedChannelId is set.
 func (h *testHandler) chatTest(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{
-		"success": true,
-		"message": "Chat test is not yet implemented in Go",
-	})
+	h.handleSyncProbe(w, r, "chat")
 }
 
 // POST /api/test/chat/stream
 func (h *testHandler) chatTestStream(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{
-		"success": true,
-		"message": "Chat stream test is not yet implemented in Go",
-	})
+	writeNotImplementedResidual(w,
+		"Chat stream test is not implemented in Go",
+		"SSE /api/test/chat/stream; use non-stream POST /api/test/chat with channelId/siteId or POST /api/admin/test-channel",
+	)
 }
 
 // POST /api/test/chat/jobs
 func (h *testHandler) chatTestJob(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusAccepted, map[string]any{
-		"jobId":     "stub-chat-job",
-		"status":    "pending",
-		"createdAt": "",
-		"expiresAt": "",
-	})
+	writeNotImplementedResidual(w,
+		"Chat test job queue is not implemented in Go",
+		"async /api/test/chat/jobs; use sync POST /api/test/chat or POST /api/admin/test-channel",
+	)
 }
 
 // GET /api/test/chat/jobs/:jobId
 func (h *testHandler) chatTestJobStatus(w http.ResponseWriter, r *http.Request) {
+	writeJobNotFound(w)
+}
+
+// DELETE /api/test/chat/jobs/:jobId
+func (h *testHandler) chatTestJobCancel(w http.ResponseWriter, r *http.Request) {
+	writeJobNotFound(w)
+}
+
+func (h *testHandler) handleSyncProbe(w http.ResponseWriter, r *http.Request, surface string) {
+	var body flexibleTestBody
+	if err := decodeJSONRequest(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	req, ok := mapFlexibleToChannelTest(body)
+	if !ok {
+		writeNotImplementedResidual(w,
+			strings.ToUpper(surface[:1])+surface[1:]+" test requires channelId, siteId, or forcedChannelId for the forced-channel harness",
+			"full /api/test/"+surface+" path/multipart/routing matrix without a forced channel; provide channelId/siteId/forcedChannelId or use POST /api/admin/test-channel",
+		)
+		return
+	}
+
+	h.channel.runChannelTest(w, r, req)
+}
+
+func mapFlexibleToChannelTest(body flexibleTestBody) (channelTestRequest, bool) {
+	channelID := firstPositiveID(body.ChannelID, body.ForcedChannelID)
+	siteID := body.SiteID
+	if (channelID == nil || *channelID <= 0) && (siteID == nil || *siteID <= 0) {
+		return channelTestRequest{}, false
+	}
+
+	model := strings.TrimSpace(body.Model)
+	if model == "" && len(body.JSONBody) > 0 {
+		var nested struct {
+			Model string `json:"model"`
+		}
+		if err := json.Unmarshal(body.JSONBody, &nested); err == nil {
+			model = strings.TrimSpace(nested.Model)
+		}
+	}
+
+	prompt := strings.TrimSpace(body.Prompt)
+	if prompt == "" {
+		prompt = lastUserPrompt(body.Messages)
+	}
+	if prompt == "" && len(body.JSONBody) > 0 {
+		var nested struct {
+			Messages []testMessage `json:"messages"`
+			Prompt   string        `json:"prompt"`
+			Input    string        `json:"input"`
+		}
+		if err := json.Unmarshal(body.JSONBody, &nested); err == nil {
+			if p := strings.TrimSpace(nested.Prompt); p != "" {
+				prompt = p
+			} else if p := strings.TrimSpace(nested.Input); p != "" {
+				prompt = p
+			} else {
+				prompt = lastUserPrompt(nested.Messages)
+			}
+		}
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(body.Mode))
+	if mode == "" {
+		path := strings.ToLower(strings.TrimSpace(body.Path))
+		if strings.Contains(path, "/models") && !strings.Contains(path, "chat") {
+			mode = channelTestModeModels
+		} else {
+			mode = channelTestModeChat
+		}
+	}
+
+	return channelTestRequest{
+		ChannelID: channelID,
+		SiteID:    siteID,
+		Model:     model,
+		Prompt:    prompt,
+		Mode:      mode,
+		TimeoutMs: body.TimeoutMs,
+	}, true
+}
+
+func firstPositiveID(ids ...*int64) *int64 {
+	for _, id := range ids {
+		if id != nil && *id > 0 {
+			return id
+		}
+	}
+	return nil
+}
+
+func lastUserPrompt(messages []testMessage) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		role := strings.ToLower(strings.TrimSpace(messages[i].Role))
+		if role != "" && role != "user" {
+			continue
+		}
+		if p := contentToPrompt(messages[i].Content); p != "" {
+			return p
+		}
+	}
+	return ""
+}
+
+func contentToPrompt(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return strings.TrimSpace(s)
+	}
+	// OpenAI-style multipart content: [{"type":"text","text":"..."}]
+	var parts []map[string]any
+	if err := json.Unmarshal(raw, &parts); err == nil {
+		var b strings.Builder
+		for _, part := range parts {
+			if t, _ := part["type"].(string); t != "" && t != "text" {
+				continue
+			}
+			if text, ok := part["text"].(string); ok {
+				if b.Len() > 0 {
+					b.WriteByte(' ')
+				}
+				b.WriteString(strings.TrimSpace(text))
+			}
+		}
+		return strings.TrimSpace(b.String())
+	}
+	return ""
+}
+
+func writeNotImplementedResidual(w http.ResponseWriter, message, residual string) {
+	writeJSON(w, http.StatusNotImplemented, map[string]any{
+		"success":  false,
+		"message":  message,
+		"residual": residual,
+	})
+}
+
+func writeJobNotFound(w http.ResponseWriter) {
+	// Honest empty job surface: no in-process job registry for /api/test/* yet.
 	writeJSON(w, http.StatusNotFound, map[string]any{
+		"success": false,
 		"error": map[string]any{
 			"message": "job not found",
 			"type":    "not_found",
 		},
 	})
-}
-
-// DELETE /api/test/chat/jobs/:jobId
-func (h *testHandler) chatTestJobCancel(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{"success": true})
 }

--- a/handler/admin/test_routes_test.go
+++ b/handler/admin/test_routes_test.go
@@ -1,0 +1,321 @@
+package admin
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func setupTestRoutes(t *testing.T) (*store.DB, *channelTestHandler, chi.Router) {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	cfg := &config.Config{AuthToken: "test-routes-token"}
+	channel := &channelTestHandler{db: db.DB, cfg: cfg}
+	r := chi.NewRouter()
+	// Register via the public registrar, then re-bind the shared channel instance
+	// so tests can inject transport.
+	RegisterTestRoutes(r, db.DB, cfg)
+	// Replace the channel pointer used by handlers by re-registering with shared handler.
+	// Chi last-match wins for identical method+path when we mount a second router group.
+	// Instead, construct routes with the injectable handler directly.
+	r = chi.NewRouter()
+	h := &testHandler{channel: channel}
+	r.Post("/api/test/proxy", h.proxyTest)
+	r.Post("/api/test/proxy/stream", h.proxyTestStream)
+	r.Post("/api/test/proxy/jobs", h.proxyTestJob)
+	r.Get("/api/test/proxy/jobs/{jobId}", h.proxyTestJobStatus)
+	r.Delete("/api/test/proxy/jobs/{jobId}", h.proxyTestJobCancel)
+	r.Post("/api/test/chat", h.chatTest)
+	r.Post("/api/test/chat/stream", h.chatTestStream)
+	r.Post("/api/test/chat/jobs", h.chatTestJob)
+	r.Get("/api/test/chat/jobs/{jobId}", h.chatTestJobStatus)
+	r.Delete("/api/test/chat/jobs/{jobId}", h.chatTestJobCancel)
+	return db, channel, r
+}
+
+func TestRegisterTestRoutes_WiresPaths(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	r := chi.NewRouter()
+	RegisterTestRoutes(r, db.DB, &config.Config{})
+
+	// Missing body → 400 (validation), proves route is mounted.
+	req := httptest.NewRequest(http.MethodPost, "/api/test/proxy", strings.NewReader(`{`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("proxy mount status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestTestProxy_RequiresForcedChannelOrSite(t *testing.T) {
+	_, _, r := setupTestRoutes(t)
+
+	resp := doPostJSON(t, r, "/api/test/proxy", map[string]any{
+		"method": "POST",
+		"path":   "/v1/chat/completions",
+		"model":  "gpt-4o-mini",
+	})
+	if resp.Code != http.StatusNotImplemented {
+		t.Fatalf("status=%d body=%s, want 501", resp.Code, resp.Body.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out["success"] != false {
+		t.Fatalf("success=%v, want false (no fake success stub)", out["success"])
+	}
+	if msg, _ := out["message"].(string); msg == "" {
+		t.Fatalf("expected residual message: %v", out)
+	}
+	if residual, _ := out["residual"].(string); residual == "" {
+		t.Fatalf("expected residual field: %v", out)
+	}
+}
+
+func TestTestProxy_ForcedChannelDelegatesToHarness(t *testing.T) {
+	db, channel, r := setupTestRoutes(t)
+	_, _, _, channelID := insertHarnessFixtures(t, db)
+
+	var hits atomic.Int32
+	var seenAuth string
+	channel.transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		hits.Add(1)
+		seenAuth = req.Header.Get("Authorization")
+		body := `{"id":"chatcmpl-proxy","choices":[{"message":{"role":"assistant","content":"proxy-ok"}}]}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+
+	resp := doPostJSON(t, r, "/api/test/proxy", map[string]any{
+		"forcedChannelId": channelID,
+		"method":          "POST",
+		"path":            "/v1/chat/completions",
+		"requestKind":     "json",
+		"jsonBody": map[string]any{
+			"model": "gpt-4o-mini",
+			"messages": []map[string]string{
+				{"role": "user", "content": "hello proxy harness"},
+			},
+		},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out["success"] != true {
+		t.Fatalf("out=%v", out)
+	}
+	if out["channelId"].(float64) != float64(channelID) {
+		t.Fatalf("channelId=%v want %d", out["channelId"], channelID)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("hits=%d", hits.Load())
+	}
+	if seenAuth != "Bearer sk-harness-api-token-xyz" {
+		t.Fatalf("auth=%q", seenAuth)
+	}
+	if !strings.Contains(out["truncatedBody"].(string), "proxy-ok") {
+		t.Fatalf("truncatedBody=%v", out["truncatedBody"])
+	}
+}
+
+func TestTestChat_ChannelIDAliasHarness(t *testing.T) {
+	db, channel, r := setupTestRoutes(t)
+	_, _, _, channelID := insertHarnessFixtures(t, db)
+
+	channel.transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			Request:    req,
+		}, nil
+	})
+
+	resp := doPostJSON(t, r, "/api/test/chat", map[string]any{
+		"channelId": channelID,
+		"model":     "gpt-4o-mini",
+		"messages": []map[string]string{
+			{"role": "user", "content": "ping chat"},
+		},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var out map[string]any
+	_ = json.Unmarshal(resp.Body.Bytes(), &out)
+	if out["success"] != true {
+		t.Fatalf("out=%v", out)
+	}
+	if out["mode"] != "chat" {
+		t.Fatalf("mode=%v", out["mode"])
+	}
+}
+
+func TestTestChat_SiteIDAndValidation(t *testing.T) {
+	db, channel, r := setupTestRoutes(t)
+	siteID, _, _, channelID := insertHarnessFixtures(t, db)
+
+	channel.transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	// Invalid JSON
+	req := httptest.NewRequest(http.MethodPost, "/api/test/chat", strings.NewReader(`{`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid json status=%d", rec.Code)
+	}
+
+	// siteId resolution
+	resp := doPostJSON(t, r, "/api/test/chat", map[string]any{
+		"siteId": siteID,
+		"model":  "gpt-4o-mini",
+		"prompt": "from site",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var out map[string]any
+	_ = json.Unmarshal(resp.Body.Bytes(), &out)
+	if out["channelId"].(float64) != float64(channelID) {
+		t.Fatalf("channelId=%v want %d", out["channelId"], channelID)
+	}
+
+	// unknown channel
+	resp = doPostJSON(t, r, "/api/test/chat", map[string]any{
+		"channelId": 999999,
+		"model":     "gpt-4o-mini",
+	})
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("missing channel status=%d body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestTestRoutes_StreamAndJobsHonest501(t *testing.T) {
+	_, _, r := setupTestRoutes(t)
+
+	cases := []struct {
+		method string
+		path   string
+		body   any
+		want   int
+	}{
+		{http.MethodPost, "/api/test/proxy/stream", map[string]any{"forcedChannelId": 1}, http.StatusNotImplemented},
+		{http.MethodPost, "/api/test/chat/stream", map[string]any{"channelId": 1}, http.StatusNotImplemented},
+		{http.MethodPost, "/api/test/proxy/jobs", map[string]any{"forcedChannelId": 1}, http.StatusNotImplemented},
+		{http.MethodPost, "/api/test/chat/jobs", map[string]any{"channelId": 1}, http.StatusNotImplemented},
+		{http.MethodGet, "/api/test/proxy/jobs/any", nil, http.StatusNotFound},
+		{http.MethodGet, "/api/test/chat/jobs/any", nil, http.StatusNotFound},
+		{http.MethodDelete, "/api/test/proxy/jobs/any", nil, http.StatusNotFound},
+		{http.MethodDelete, "/api/test/chat/jobs/any", nil, http.StatusNotFound},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			var rec *httptest.ResponseRecorder
+			switch tc.method {
+			case http.MethodPost:
+				rec = doPostJSON(t, r, tc.path, tc.body)
+			case http.MethodGet:
+				rec = doGet(t, r, tc.path)
+			case http.MethodDelete:
+				rec = doDelete(t, r, tc.path)
+			default:
+				t.Fatalf("unsupported method %s", tc.method)
+			}
+			if rec.Code != tc.want {
+				t.Fatalf("status=%d body=%s want %d", rec.Code, rec.Body.String(), tc.want)
+			}
+			var out map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			// Never return success:true for unimplemented residual surfaces.
+			if out["success"] == true {
+				t.Fatalf("fake success on residual path: %v", out)
+			}
+			if tc.want == http.StatusNotImplemented {
+				if residual, _ := out["residual"].(string); residual == "" {
+					t.Fatalf("expected residual: %v", out)
+				}
+			}
+		})
+	}
+}
+
+func TestMapFlexibleToChannelTest_ExtractsNestedFields(t *testing.T) {
+	ch := int64(12)
+	body := flexibleTestBody{
+		ForcedChannelID: &ch,
+		Path:            "/v1/chat/completions",
+		JSONBody:        json.RawMessage(`{"model":"gpt-4o","messages":[{"role":"user","content":"nested hello"}]}`),
+	}
+	req, ok := mapFlexibleToChannelTest(body)
+	if !ok {
+		t.Fatal("expected mapping ok")
+	}
+	if req.ChannelID == nil || *req.ChannelID != 12 {
+		t.Fatalf("channelId=%v", req.ChannelID)
+	}
+	if req.Model != "gpt-4o" {
+		t.Fatalf("model=%q", req.Model)
+	}
+	if req.Prompt != "nested hello" {
+		t.Fatalf("prompt=%q", req.Prompt)
+	}
+	if req.Mode != channelTestModeChat {
+		t.Fatalf("mode=%q", req.Mode)
+	}
+
+	// models path detection
+	site := int64(3)
+	body2 := flexibleTestBody{SiteID: &site, Path: "/v1/models"}
+	req2, ok := mapFlexibleToChannelTest(body2)
+	if !ok {
+		t.Fatal("expected site mapping")
+	}
+	if req2.Mode != channelTestModeModels {
+		t.Fatalf("mode=%q want models", req2.Mode)
+	}
+}

--- a/router/router.go
+++ b/router/router.go
@@ -71,7 +71,7 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 			admin.RegisterEventsRoutes(r, db.DB)
 			admin.RegisterSearchRoutes(r, db.DB)
 			admin.RegisterTasksRoutes(r, db.DB)
-			admin.RegisterTestRoutes(r)
+			admin.RegisterTestRoutes(r, db.DB, cfg)
 			admin.RegisterSiteAnnouncementsRoutes(r, db.DB)
 			admin.RegisterAuthSettingsRoutes(r, db.DB, cfg)
 			admin.RegisterCheckinRoutes(r, db.DB, cfg)


### PR DESCRIPTION
## Summary
- Wire `POST /api/test/proxy` and `POST /api/test/chat` to the forced-channel harness when `channelId` / `forcedChannelId` / `siteId` is provided (reuses `runChannelTest`, no network duplication).
- Stream + async job endpoints return honest **501** residuals with `success:false` (no fake success / stub-job invent); job get/delete return honest 404.
- Update `RegisterTestRoutes(r, db, cfg)` wiring and document residuals in `docs/analysis/p4-admin-test-routes.md`.

Closes #185

## Test plan
- [x] `go test ./handler/admin -count=1 -run 'TestTest|TestRegisterTest|TestMapFlexible|TestChannelTest'`
- [x] `go test ./handler/admin ./router -count=1`