### PR TITLE
feat(admin): real system-proxy probe + registry brand list (#184)

### DIFF
--- a/docs/analysis/p4-settings-proxy-test.md
+++ b/docs/analysis/p4-settings-proxy-test.md
@@ -1,0 +1,46 @@
+# P4 #184 — Real system-proxy test + brand list from registry
+
+**Date**: 2026-07-17
+**Issue**: #184
+**Branch**: `feat/p4-settings-proxy-impl`
+
+## Problem
+
+- `POST /api/settings/system-proxy/test` always returned fake success (`reachable: true`, fixed `latencyMs: 100`, status 204) without performing an HTTP probe.
+- `GET /api/settings/brand-list` returned a hardcoded 5-name stub (`new-api`, `one-api`, `veloera`, `lobechat`, `openwebui`) instead of registered platforms.
+
+## Solution
+
+### System proxy test
+
+Aligned with the TypeScript reference (`metapi/src/server/routes/api/settings.ts`):
+
+| Field | Behavior |
+|-------|----------|
+| Probe URL | `https://www.gstatic.com/generate_204` |
+| Timeout | 15s |
+| Proxy source | request `proxyUrl` if present, else `config.SystemProxyUrl` |
+| Transport | `platform.DoWithProxy` with explicit `ProxyConfig.ProxyURL` |
+| Success body | `{ success, proxyUrl, probeUrl, finalUrl, reachable, ok, statusCode, latencyMs }` |
+| Failure | `400` missing/invalid proxy; `502` probe error with Chinese operator message |
+
+`reachable` means a response was received through the proxy. `ok` is HTTP 2xx. Non-2xx responses still return HTTP 200 with `ok: false` (connectivity worked; probe target rejected).
+
+Tests inject `systemProxyTestTransport` (fake `http.RoundTripper`) so unit tests do not hit the network.
+
+### Brand list
+
+`platform.ListRegisteredPlatformNames()` returns canonical adapter names from the platform registry, ordered by `orderedPlatformNames` (openai → … → one-api). The settings handler returns `{ brands: [...] }` from that helper.
+
+## Verify
+
+```bash
+go test ./handler/admin -count=1 -run 'Proxy|Brand'
+```
+
+## Files
+
+- `handler/admin/settings.go`
+- `handler/admin/settings_proxy_brand_test.go`
+- `platform/registry.go` (`ListRegisteredPlatformNames`)
+- `docs/analysis/p4-settings-proxy-test.md`

--- a/handler/admin/settings.go
+++ b/handler/admin/settings.go
@@ -1,16 +1,31 @@
 package admin
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
 	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/platform"
 )
+
+const (
+	systemProxyTestProbeURL = "https://www.gstatic.com/generate_204"
+	systemProxyTestTimeout  = 15 * time.Second
+)
+
+// systemProxyTestTransport lets tests inject a fake RoundTripper so the
+// system-proxy probe can be exercised without a real network or proxy.
+// Production code leaves this nil and uses platform.DoWithProxy.
+var systemProxyTestTransport http.RoundTripper
 
 // RegisterSettingsRoutes registers all /api/settings routes (runtime, brand-list, system-proxy/test).
 func RegisterSettingsRoutes(r chi.Router, db *sqlx.DB, cfg *config.Config) {
@@ -655,12 +670,11 @@ func (h *settingsHandler) updateRuntime(w http.ResponseWriter, r *http.Request) 
 
 // GET /api/settings/brand-list
 func (h *settingsHandler) brandList(w http.ResponseWriter, r *http.Request) {
-	// Stub: return known brands
-	brands := []string{"new-api", "one-api", "veloera", "lobechat", "openwebui"}
-	writeJSON(w, http.StatusOK, map[string]any{"brands": brands})
+	writeJSON(w, http.StatusOK, map[string]any{"brands": platform.ListRegisteredPlatformNames()})
 }
 
 // POST /api/settings/system-proxy/test
+// Probes https://www.gstatic.com/generate_204 through the given (or saved) proxy.
 func (h *settingsHandler) testSystemProxy(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		ProxyUrl *string `json:"proxyUrl"`
@@ -670,12 +684,14 @@ func (h *settingsHandler) testSystemProxy(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	proxyURL := h.cfg.SystemProxyUrl
+	rawProxyURL := h.cfg.SystemProxyUrl
 	if body.ProxyUrl != nil {
-		proxyURL = strings.TrimSpace(*body.ProxyUrl)
+		rawProxyURL = strings.TrimSpace(*body.ProxyUrl)
+	} else {
+		rawProxyURL = strings.TrimSpace(rawProxyURL)
 	}
 
-	if proxyURL == "" {
+	if rawProxyURL == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]any{
 			"success": false,
 			"message": "请先填写系统代理地址",
@@ -683,15 +699,173 @@ func (h *settingsHandler) testSystemProxy(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Stub: actual proxy testing would require HTTP client
+	normalizedProxyURL := normalizeSystemProxyURL(rawProxyURL)
+	if normalizedProxyURL == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"success": false,
+			"message": "系统代理地址无效，请填写合法的 http(s)/socks 代理 URL",
+		})
+		return
+	}
+
+	result, err := probeSystemProxy(r.Context(), normalizedProxyURL)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]any{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success":    true,
-		"proxyUrl":   proxyURL,
-		"reachable":  true,
-		"ok":         true,
-		"statusCode": 204,
-		"latencyMs":  100,
+		"proxyUrl":   normalizedProxyURL,
+		"probeUrl":   result.probeURL,
+		"finalUrl":   result.finalURL,
+		"reachable":  result.reachable,
+		"ok":         result.ok,
+		"statusCode": result.statusCode,
+		"latencyMs":  result.latencyMs,
 	})
+}
+
+type systemProxyProbeResult struct {
+	reachable  bool
+	ok         bool
+	statusCode int
+	latencyMs  int
+	probeURL   string
+	finalURL   string
+}
+
+func probeSystemProxy(ctx context.Context, proxyURL string) (systemProxyProbeResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, systemProxyTestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, systemProxyTestProbeURL, nil)
+	if err != nil {
+		return systemProxyProbeResult{}, fmt.Errorf("系统代理测试失败：%v", err)
+	}
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("User-Agent", "metapi-system-proxy-tester/1.0")
+
+	started := time.Now()
+	resp, err := doSystemProxyProbe(ctx, req, proxyURL)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return systemProxyProbeResult{}, fmt.Errorf("系统代理测试超时（%ds）", int(systemProxyTestTimeout.Seconds()))
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+			return systemProxyProbeResult{}, fmt.Errorf("系统代理测试超时（%ds）", int(systemProxyTestTimeout.Seconds()))
+		}
+		return systemProxyProbeResult{}, errors.New(describeSystemProxyTestFailure(err))
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+
+	latencyMs := int(time.Since(started).Milliseconds())
+	if latencyMs < 1 {
+		latencyMs = 1
+	}
+
+	finalURL := systemProxyTestProbeURL
+	if resp.Request != nil && resp.Request.URL != nil {
+		finalURL = resp.Request.URL.String()
+	}
+
+	return systemProxyProbeResult{
+		reachable:  true,
+		ok:         resp.StatusCode >= 200 && resp.StatusCode < 300,
+		statusCode: resp.StatusCode,
+		latencyMs:  latencyMs,
+		probeURL:   systemProxyTestProbeURL,
+		finalURL:   finalURL,
+	}, nil
+}
+
+func doSystemProxyProbe(ctx context.Context, req *http.Request, proxyURL string) (*http.Response, error) {
+	if systemProxyTestTransport != nil {
+		// Tests inject a RoundTripper; still honor the request context.
+		return systemProxyTestTransport.RoundTrip(req.WithContext(ctx))
+	}
+	return platform.DoWithProxy(ctx, req, &platform.ProxyConfig{ProxyURL: proxyURL})
+}
+
+// normalizeSystemProxyURL validates and normalizes http(s)/socks proxy URLs.
+// Returns "" when the value is empty or not a supported proxy URL.
+func normalizeSystemProxyURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return ""
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	switch scheme {
+	case "http", "https", "socks", "socks4", "socks4a", "socks5", "socks5h":
+	default:
+		return ""
+	}
+	// Drop default trailing slash so stored/returned values stay stable.
+	out := parsed.String()
+	for strings.HasSuffix(out, "/") {
+		out = strings.TrimSuffix(out, "/")
+	}
+	return out
+}
+
+func describeSystemProxyTestFailure(err error) string {
+	if err == nil {
+		return "系统代理测试失败：未知错误"
+	}
+
+	// Walk nested causes (matches TS extractNestedErrorMessages) and prefer a
+	// concrete detail over a generic outer "fetch failed".
+	messages := make([]string, 0, 4)
+	seen := make(map[string]struct{}, 4)
+	for current := err; current != nil; current = errors.Unwrap(current) {
+		msg := strings.TrimSpace(current.Error())
+		if msg == "" {
+			continue
+		}
+		if _, ok := seen[msg]; ok {
+			continue
+		}
+		seen[msg] = struct{}{}
+		messages = append(messages, msg)
+	}
+	detail := "未知错误"
+	for _, msg := range messages {
+		if msg != "fetch failed" {
+			detail = msg
+			break
+		}
+	}
+	if detail == "未知错误" && len(messages) > 0 {
+		detail = messages[0]
+	}
+
+	lower := strings.ToLower(detail)
+	switch {
+	case strings.Contains(lower, "connection refused") || strings.Contains(detail, "ECONNREFUSED"):
+		return "系统代理测试失败：连接被拒绝，请检查代理地址、端口和本地代理程序是否已启动"
+	case strings.Contains(lower, "timeout") || strings.Contains(lower, "deadline exceeded") ||
+		strings.Contains(detail, "ETIMEDOUT") || strings.Contains(lower, "i/o timeout"):
+		return "系统代理测试失败：连接超时，请检查代理服务或当前网络是否可用"
+	case strings.Contains(detail, "ENOTFOUND") || strings.Contains(detail, "EAI_AGAIN") ||
+		strings.Contains(lower, "no such host") || strings.Contains(lower, "server misbehaving"):
+		return "系统代理测试失败：域名解析失败，请检查网络或代理的 DNS 配置"
+	case strings.Contains(detail, "ECONNRESET") || strings.Contains(lower, "connection reset"):
+		return "系统代理测试失败：连接被对端重置，请检查代理链路是否稳定"
+	case strings.Contains(detail, "407") || strings.Contains(lower, "proxy authentication"):
+		return "系统代理测试失败：代理要求认证，请检查用户名、密码或代理配置"
+	case strings.Contains(lower, "unsupported proxy scheme") || strings.Contains(lower, "invalid proxy url"):
+		return "系统代理测试失败：代理地址无效，请填写合法的 http(s)/socks 代理 URL"
+	default:
+		return "系统代理测试失败：" + detail
+	}
 }
 
 func extractClientIP(r *http.Request) string {

--- a/handler/admin/settings_proxy_brand_test.go
+++ b/handler/admin/settings_proxy_brand_test.go
@@ -1,0 +1,322 @@
+package admin
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/platform"
+)
+
+type systemProxyRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f systemProxyRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func withSystemProxyTestTransport(t *testing.T, rt http.RoundTripper) {
+	t.Helper()
+	prev := systemProxyTestTransport
+	systemProxyTestTransport = rt
+	t.Cleanup(func() { systemProxyTestTransport = prev })
+}
+
+func TestBrandListFromPlatformRegistry(t *testing.T) {
+	platform.InitRegistry()
+	_, r, _ := setupEdgeTest(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/settings/brand-list", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Brands []string `json:"brands"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	want := platform.ListRegisteredPlatformNames()
+	if len(body.Brands) != len(want) {
+		t.Fatalf("brands len = %d, want %d (%v)", len(body.Brands), len(want), body.Brands)
+	}
+	for i := range want {
+		if body.Brands[i] != want[i] {
+			t.Fatalf("brands[%d] = %q, want %q (full=%v)", i, body.Brands[i], want[i], body.Brands)
+		}
+	}
+
+	// Must not be the old hardcoded 5-name stub.
+	if len(body.Brands) <= 5 {
+		t.Fatalf("brand list still looks stub-sized: %v", body.Brands)
+	}
+	// Registry platforms must include known adapters.
+	joined := strings.Join(body.Brands, ",")
+	for _, name := range []string{"openai", "new-api", "one-api", "veloera", "claude"} {
+		if !strings.Contains(joined, name) {
+			t.Fatalf("brand list missing %q: %v", name, body.Brands)
+		}
+	}
+}
+
+func TestSystemProxyTest_SuccessWithFakeTransport(t *testing.T) {
+	_, r, _ := setupEdgeTest(t)
+
+	var sawURL string
+	var sawMethod string
+	var sawUA string
+	withSystemProxyTestTransport(t, systemProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		sawURL = req.URL.String()
+		sawMethod = req.Method
+		sawUA = req.Header.Get("User-Agent")
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+			Request:    req,
+		}, nil
+	}))
+
+	resp := doPostJSON(t, r, "/api/settings/system-proxy/test", map[string]any{
+		"proxyUrl": "http://127.0.0.1:7890",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", resp.Code, resp.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != true {
+		t.Fatalf("success = %v, want true", body["success"])
+	}
+	if body["proxyUrl"] != "http://127.0.0.1:7890" {
+		t.Fatalf("proxyUrl = %v", body["proxyUrl"])
+	}
+	if body["probeUrl"] != systemProxyTestProbeURL {
+		t.Fatalf("probeUrl = %v, want %s", body["probeUrl"], systemProxyTestProbeURL)
+	}
+	if body["finalUrl"] != systemProxyTestProbeURL {
+		t.Fatalf("finalUrl = %v, want %s", body["finalUrl"], systemProxyTestProbeURL)
+	}
+	if body["reachable"] != true {
+		t.Fatalf("reachable = %v, want true", body["reachable"])
+	}
+	if body["ok"] != true {
+		t.Fatalf("ok = %v, want true", body["ok"])
+	}
+	if body["statusCode"] != float64(204) {
+		t.Fatalf("statusCode = %v, want 204", body["statusCode"])
+	}
+	latency, ok := body["latencyMs"].(float64)
+	if !ok || latency < 1 {
+		t.Fatalf("latencyMs = %v, want >= 1", body["latencyMs"])
+	}
+	if sawURL != systemProxyTestProbeURL {
+		t.Fatalf("probe target = %q, want %s", sawURL, systemProxyTestProbeURL)
+	}
+	if sawMethod != http.MethodGet {
+		t.Fatalf("method = %q, want GET", sawMethod)
+	}
+	if sawUA != "metapi-system-proxy-tester/1.0" {
+		t.Fatalf("user-agent = %q", sawUA)
+	}
+}
+
+func TestSystemProxyTest_UsesSavedConfigWhenBodyEmpty(t *testing.T) {
+	_, r, cfg := setupEdgeTest(t)
+	cfg.SystemProxyUrl = "socks5://127.0.0.1:1080"
+
+	withSystemProxyTestTransport(t, systemProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+			Request:    req,
+		}, nil
+	}))
+
+	resp := doPostJSON(t, r, "/api/settings/system-proxy/test", map[string]any{})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["proxyUrl"] != "socks5://127.0.0.1:1080" {
+		t.Fatalf("proxyUrl = %v, want saved socks5 url", body["proxyUrl"])
+	}
+}
+
+func TestSystemProxyTest_RejectsMissingProxyURL(t *testing.T) {
+	_, r, cfg := setupEdgeTest(t)
+	cfg.SystemProxyUrl = ""
+
+	called := false
+	withSystemProxyTestTransport(t, systemProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return nil, errors.New("should not be called")
+	}))
+
+	resp := doPostJSON(t, r, "/api/settings/system-proxy/test", map[string]any{})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+	if called {
+		t.Fatal("probe transport was called despite missing proxy URL")
+	}
+	if !strings.Contains(resp.Body.String(), "请先填写系统代理地址") {
+		t.Fatalf("body = %s, want missing-proxy message", resp.Body.String())
+	}
+}
+
+func TestSystemProxyTest_RejectsInvalidProxyURL(t *testing.T) {
+	_, r, _ := setupEdgeTest(t)
+
+	called := false
+	withSystemProxyTestTransport(t, systemProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return nil, errors.New("should not be called")
+	}))
+
+	resp := doPostJSON(t, r, "/api/settings/system-proxy/test", map[string]any{
+		"proxyUrl": "ftp://proxy.example:21",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+	if called {
+		t.Fatal("probe transport was called despite invalid proxy URL")
+	}
+	if !strings.Contains(resp.Body.String(), "系统代理地址无效") {
+		t.Fatalf("body = %s, want invalid-proxy message", resp.Body.String())
+	}
+}
+
+func TestSystemProxyTest_Returns502OnProbeFailure(t *testing.T) {
+	_, r, _ := setupEdgeTest(t)
+
+	withSystemProxyTestTransport(t, systemProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("connect ECONNREFUSED 127.0.0.1:7890")
+	}))
+
+	resp := doPostJSON(t, r, "/api/settings/system-proxy/test", map[string]any{
+		"proxyUrl": "http://127.0.0.1:7890",
+	})
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d body=%s, want 502", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != false {
+		t.Fatalf("success = %v, want false", body["success"])
+	}
+	msg, _ := body["message"].(string)
+	if !strings.Contains(msg, "连接被拒绝") {
+		t.Fatalf("message = %q, want connection-refused wording", msg)
+	}
+}
+
+func TestSystemProxyTest_Non2xxStillReachable(t *testing.T) {
+	_, r, _ := setupEdgeTest(t)
+
+	withSystemProxyTestTransport(t, systemProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("blocked")),
+			Request:    req,
+		}, nil
+	}))
+
+	resp := doPostJSON(t, r, "/api/settings/system-proxy/test", map[string]any{
+		"proxyUrl": "http://127.0.0.1:7890",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["reachable"] != true {
+		t.Fatalf("reachable = %v, want true (got a response)", body["reachable"])
+	}
+	if body["ok"] != false {
+		t.Fatalf("ok = %v, want false for 403", body["ok"])
+	}
+	if body["statusCode"] != float64(403) {
+		t.Fatalf("statusCode = %v, want 403", body["statusCode"])
+	}
+}
+
+func TestNormalizeSystemProxyURL(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"   ", ""},
+		{"http://127.0.0.1:7890", "http://127.0.0.1:7890"},
+		{"http://127.0.0.1:7890/", "http://127.0.0.1:7890"},
+		{"socks5://user:pass@127.0.0.1:1080", "socks5://user:pass@127.0.0.1:1080"},
+		{"ftp://bad", ""},
+		{"not-a-url", ""},
+		{"://invalid", ""},
+	}
+	for _, tt := range tests {
+		if got := normalizeSystemProxyURL(tt.in); got != tt.want {
+			t.Fatalf("normalizeSystemProxyURL(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestDescribeSystemProxyTestFailure(t *testing.T) {
+	msg := describeSystemProxyTestFailure(errors.New("connect ECONNREFUSED 127.0.0.1:1"))
+	if !strings.Contains(msg, "连接被拒绝") {
+		t.Fatalf("refused msg = %q", msg)
+	}
+	msg = describeSystemProxyTestFailure(errors.New("i/o timeout"))
+	if !strings.Contains(msg, "连接超时") {
+		t.Fatalf("timeout msg = %q", msg)
+	}
+	// Nested cause preferred over outer generic.
+	outer := errors.New("fetch failed")
+	_ = outer
+	nested := &wrappedError{msg: "fetch failed", cause: errors.New("proxy authentication required")}
+	msg = describeSystemProxyTestFailure(nested)
+	if !strings.Contains(msg, "代理要求认证") {
+		t.Fatalf("auth msg = %q", msg)
+	}
+}
+
+type wrappedError struct {
+	msg   string
+	cause error
+}
+
+func (e *wrappedError) Error() string { return e.msg }
+func (e *wrappedError) Unwrap() error { return e.cause }
+
+func TestSystemProxyTest_TimeoutBounded(t *testing.T) {
+	// Guard against accidental timeout regression: constant must stay bounded.
+	if systemProxyTestTimeout <= 0 || systemProxyTestTimeout > 30*time.Second {
+		t.Fatalf("systemProxyTestTimeout = %s, want (0, 30s]", systemProxyTestTimeout)
+	}
+	if systemProxyTestProbeURL == "" {
+		t.Fatal("probe URL empty")
+	}
+}

--- a/platform/registry.go
+++ b/platform/registry.go
@@ -7,38 +7,38 @@ import (
 
 // PLATFORM_ALIASES maps user-facing platform names to canonical identifiers.
 var PlatformAliases = map[string]string{
-	"anyrouter":      "anyrouter",
-	"wong-gongyi":    "new-api",
-	"vo-api":         "new-api",
-	"super-api":      "new-api",
-	"rix-api":        "new-api",
-	"neo-api":        "new-api",
-	"newapi":         "new-api",
-	"new api":        "new-api",
-	"new-api":        "new-api",
-	"oneapi":         "one-api",
-	"one api":        "one-api",
-	"one-api":        "one-api",
-	"onehub":         "one-hub",
-	"one-hub":        "one-hub",
-	"donehub":        "done-hub",
-	"done-hub":       "done-hub",
-	"veloera":        "veloera",
-	"sub2api":        "sub2api",
-	"openai":         "openai",
-	"codex":          "codex",
-	"chatgpt-codex":  "codex",
-	"chatgpt codex":  "codex",
-	"anthropic":      "claude",
-	"claude":         "claude",
-	"gemini":         "gemini",
-	"gemini-cli":     "gemini-cli",
-	"antigravity":    "antigravity",
-	"anti-gravity":   "antigravity",
-	"google":         "gemini",
-	"cliproxyapi":    "cliproxyapi",
-	"cpa":            "cliproxyapi",
-	"cli-proxy-api":  "cliproxyapi",
+	"anyrouter":     "anyrouter",
+	"wong-gongyi":   "new-api",
+	"vo-api":        "new-api",
+	"super-api":     "new-api",
+	"rix-api":       "new-api",
+	"neo-api":       "new-api",
+	"newapi":        "new-api",
+	"new api":       "new-api",
+	"new-api":       "new-api",
+	"oneapi":        "one-api",
+	"one api":       "one-api",
+	"one-api":       "one-api",
+	"onehub":        "one-hub",
+	"one-hub":       "one-hub",
+	"donehub":       "done-hub",
+	"done-hub":      "done-hub",
+	"veloera":       "veloera",
+	"sub2api":       "sub2api",
+	"openai":        "openai",
+	"codex":         "codex",
+	"chatgpt-codex": "codex",
+	"chatgpt codex": "codex",
+	"anthropic":     "claude",
+	"claude":        "claude",
+	"gemini":        "gemini",
+	"gemini-cli":    "gemini-cli",
+	"antigravity":   "antigravity",
+	"anti-gravity":  "antigravity",
+	"google":        "gemini",
+	"cliproxyapi":   "cliproxyapi",
+	"cpa":           "cliproxyapi",
+	"cli-proxy-api": "cliproxyapi",
 }
 
 // registry holds all platform adapters in detection order.
@@ -154,4 +154,42 @@ func DetectPlatform(rawURL string) PlatformAdapter {
 // ListAdapters returns all registered adapters (for diagnostics).
 func ListAdapters() []PlatformAdapter {
 	return append([]PlatformAdapter{}, registry...)
+}
+
+// ListRegisteredPlatformNames returns the canonical platform names currently
+// present in the adapter registry. Names follow orderedPlatformNames when
+// possible so callers (e.g. settings brand-list) get a stable order.
+func ListRegisteredPlatformNames() []string {
+	byName := make(map[string]struct{}, len(registry))
+	for _, a := range registry {
+		if a == nil {
+			continue
+		}
+		name := strings.TrimSpace(a.PlatformName())
+		if name == "" {
+			continue
+		}
+		byName[name] = struct{}{}
+	}
+
+	names := make([]string, 0, len(byName))
+	seen := make(map[string]struct{}, len(byName))
+	for _, name := range orderedPlatformNames {
+		if _, ok := byName[name]; !ok {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	// Include any adapters not listed in orderedPlatformNames (future-proof).
+	for name := range byName {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		names = append(names, name)
+	}
+	return names
 }

--- a/platform/registry_test.go
+++ b/platform/registry_test.go
@@ -416,6 +416,35 @@ func TestListAdapters_Copy(t *testing.T) {
 	}
 }
 
+func TestListRegisteredPlatformNames(t *testing.T) {
+	InitRegistry()
+
+	names := ListRegisteredPlatformNames()
+	if len(names) < 14 {
+		t.Fatalf("expected at least 14 registered platform names, got %d: %v", len(names), names)
+	}
+
+	// Stable order matches orderedPlatformNames for known adapters.
+	expectedPrefix := []string{"openai", "codex", "claude", "gemini"}
+	for i, want := range expectedPrefix {
+		if i >= len(names) || names[i] != want {
+			t.Fatalf("names[%d] = %q, want %q (full=%v)", i, names[i], want, names)
+		}
+	}
+
+	// No duplicates.
+	seen := make(map[string]bool, len(names))
+	for _, name := range names {
+		if name == "" {
+			t.Fatal("empty platform name in list")
+		}
+		if seen[name] {
+			t.Fatalf("duplicate platform name %q", name)
+		}
+		seen[name] = true
+	}
+}
+
 // --- Helper ---
 
 func indexOfString(slice []string, target string) int {


### PR DESCRIPTION
## Summary
- `POST /api/settings/system-proxy/test` now probes `https://www.gstatic.com/generate_204` through the provided/saved proxy via `platform.DoWithProxy` (15s timeout) and returns honest `reachable` / `ok` / `statusCode` / `latencyMs` / `probeUrl` / `finalUrl`.
- `GET /api/settings/brand-list` returns canonical platform names from `platform.ListRegisteredPlatformNames()` instead of a hardcoded 5-name stub.
- Unit tests cover success, saved-config fallback, validation, 502 failure mapping, non-2xx reachability, and registry brand list using a fake RoundTripper.

Closes #184

## Test plan
- [x] `go test ./handler/admin -count=1 -run 'Proxy|Brand'`
- [x] `go test ./platform -count=1 -run 'ListRegistered|Registry'`
- [ ] Manual: set system proxy URL in Settings UI and click 测试系统代理
- [ ] Manual: confirm brand-list UI shows registered platforms