### PR TITLE
feat(admin): verify account credentials on create (#183)

### DIFF
--- a/docs/analysis/p4-account-verify.md
+++ b/docs/analysis/p4-account-verify.md
@@ -1,0 +1,59 @@
+# P4 Account Verify (#183)
+
+Last updated: 2026-07-17
+
+## Scope
+
+Wire `POST /api/accounts` create path (`createSingleAccount`) to platform adapters so credentials are verified before the account row is written.
+
+## Behavior
+
+### Credential modes
+
+| Requested mode | Verify path | Fail closed when | Explicit skip |
+|---|---|---|---|
+| `auto` / `session` | `platform.VerifyToken(site.url, token, platformUserId, proxy)` | error, nil result, or `tokenType=unknown` | not available |
+| `apikey` | `adapter.GetModels(...)` | error or zero models | `skipModelFetch=true` accepts without upstream call |
+| batch `accessTokens` | each token uses `apikey` path | per-item failure; all-fail => HTTP 400 | `skipModelFetch=true` preserved |
+
+### Success enrichment (best effort)
+
+- `session`: fill username from `UserInfo` when request omitted it; copy discovered `apiToken` when missing.
+- `apikey`: store secret on `api_token`, clear `access_token` (proxy-only connection), report `modelCount`.
+- `credentialMode` stored as resolved type (`session` / `apikey`), not request `auto`.
+- `skipModelFetch=true` stored in `extraConfig` for residual/init consumers.
+
+### Failure response
+
+HTTP **400**:
+
+```json
+{
+  "success": false,
+  "requiresVerification": true,
+  "message": "Token 验证失败，请先点击“验证 Token”，验证成功后再绑定账号"
+}
+```
+
+Non-apikey failures also pass through `alert.AppendSessionTokenRebindHint` for invalid access-token phrasing.
+
+## Residual / unknown verify platforms
+
+- Platforms without a registered adapter: create fails with `platform not supported: <name>` (no silent create).
+- Platforms whose `VerifyToken` always returns `unknown` (weak defaults / no usable session or models endpoints) cannot create unless the UI uses `credentialMode=apikey` + `skipModelFetch=true` for proxy-only import.
+- **Standard adapters (openai/claude/gemini/cliproxyapi)**: `BaseAdapter.VerifyToken` calls methods on the embedded `*BaseAdapter` receiver, so `GetModels` overrides on the outer adapter are not used. Auto/session create via `VerifyToken` therefore often returns `unknown`. Prefer explicit `credentialMode=apikey` (handler calls `adapter.GetModels` through the interface) or `skipModelFetch=true` for proxy-only import. Fixing VerifyToken dispatch is adapter-layer work outside #183.
+- Background account init / model refresh after create remains out of scope for #183 (TS queues `account-init`; Go still returns `queued=false`).
+
+## Tests
+
+```bash
+go test ./handler/admin -count=1 -run 'Account'
+```
+
+Coverage includes:
+
+- successful OpenAI-style apikey create via `/v1/models`
+- reject unknown/invalid token (no row written)
+- session username enrichment
+- apikey `skipModelFetch` no upstream call
+- invalid access-token rebind hint

--- a/e2e/e2e_flow_test.go
+++ b/e2e/e2e_flow_test.go
@@ -36,19 +36,19 @@ func TestSiteCreateToProxyFlow(t *testing.T) {
 
 	// 1a. Build config first - EnsureRuntimeDatabase reads DbType and DbUrl.
 	cfg := &config.Config{
-		AuthToken:                    adminToken,
-		ProxyToken:                   proxyToken,
-		AccountCredentialSecret:      "test-cred-secret",
-		DbType:                       "sqlite",
-		DbUrl:                        ":memory:",
-		DataDir:                      t.TempDir(),
-		ProxyMaxChannelAttempts:      3,
-		ProxyStickySessionEnabled:    false,
-		ProxyStickySessionTtlMs:      30000,
-		TokenRouterCacheTtlMs:        1500,
+		AuthToken:                        adminToken,
+		ProxyToken:                       proxyToken,
+		AccountCredentialSecret:          "test-cred-secret",
+		DbType:                           "sqlite",
+		DbUrl:                            ":memory:",
+		DataDir:                          t.TempDir(),
+		ProxyMaxChannelAttempts:          3,
+		ProxyStickySessionEnabled:        false,
+		ProxyStickySessionTtlMs:          30000,
+		TokenRouterCacheTtlMs:            1500,
 		TokenRouterFailureCooldownMaxSec: 60,
-		RoutingFallbackUnitCost:      1,
-		RequestBodyLimit:             20 * 1024 * 1024,
+		RoutingFallbackUnitCost:          1,
+		RequestBodyLimit:                 20 * 1024 * 1024,
 	}
 	config.Set(cfg)
 
@@ -178,8 +178,10 @@ func TestSiteCreateToProxyFlow(t *testing.T) {
 	upstreamToken := "sk-test-upstream-token-abc123"
 
 	createAccountBody := map[string]any{
-		"siteId":      siteID,
-		"accessToken": upstreamToken,
+		"siteId":         siteID,
+		"accessToken":    upstreamToken,
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
 	}
 	accountRec := doAdminPost(t, r, "/api/accounts", adminToken, createAccountBody)
 
@@ -200,38 +202,10 @@ func TestSiteCreateToProxyFlow(t *testing.T) {
 	t.Logf("created account: id=%d for site %d", accountID, siteID)
 
 	// ══════════════════════════════════════════════════════════════════════════
-	// Phase 4: Create account_token for the account via admin API
+	// Phase 4: API-key accounts store credentials on the account row itself.
+	// /api/account-tokens is session-only, so skip token CRUD for this path.
 	// ══════════════════════════════════════════════════════════════════════════
-
-	tokenName := "default-token"
-	createTokenBody := map[string]any{
-		"accountId": int(accountID),
-		"name":      tokenName,
-		"token":     upstreamToken,
-	}
-	tokenRec := doAdminPost(t, r, "/api/account-tokens", adminToken, createTokenBody)
-
-	if tokenRec.Code != 200 && tokenRec.Code != 201 {
-		t.Fatalf("create account_token: expected 200/201, got %d: %s", tokenRec.Code, tokenRec.Body.String())
-	}
-
-	var tokenResp map[string]any
-	if err := json.Unmarshal(tokenRec.Body.Bytes(), &tokenResp); err != nil {
-		t.Fatalf("create account_token: failed to parse response: %v", err)
-	}
-
-	// The account_token response may nest the token under a "token" key.
-	// Handle both flat and nested response shapes.
-	tokenData, ok := tokenResp["token"].(map[string]any)
-	if !ok {
-		// Flat response: id is at top level.
-		tokenData = tokenResp
-	}
-	tokenID := mapGetInt64(tokenData, "id")
-	if tokenID == 0 {
-		t.Fatalf("create account_token: expected numeric id in response, got %v", tokenResp)
-	}
-	t.Logf("created account_token: id=%d for account %d", tokenID, accountID)
+	t.Logf("apikey account %d uses account.apiToken (skip account-tokens create)", accountID)
 
 	// ══════════════════════════════════════════════════════════════════════════
 	// Phase 5: Query /v1/models via proxy
@@ -555,18 +529,18 @@ func TestSiteCreateToProxyFlow_Streaming(t *testing.T) {
 	// Create account.
 	accountRec := doAdminPost(t, r, "/api/accounts", adminToken, map[string]any{
 		"siteId": siteID, "accessToken": "sk-stream-token",
+		"credentialMode": "apikey", "skipModelFetch": true,
 	})
 	if accountRec.Code < 200 || accountRec.Code > 299 {
 		t.Fatalf("create account failed: %d: %s", accountRec.Code, accountRec.Body.String())
 	}
 	var accountResp map[string]any
 	json.Unmarshal(accountRec.Body.Bytes(), &accountResp)
-	accountID := int64(accountResp["id"].(float64))
+	if _, ok := accountResp["id"].(float64); !ok {
+		t.Fatalf("create account: missing id: %v", accountResp)
+	}
 
-	// Create account_token.
-	doAdminPost(t, r, "/api/account-tokens", adminToken, map[string]any{
-		"accountId": int(accountID), "name": "default", "token": "sk-stream-token",
-	})
+	// API-key accounts do not support /api/account-tokens management.
 
 	// Streaming chat request.
 	streamBody := map[string]any{

--- a/e2e/e2e_shutdown_test.go
+++ b/e2e/e2e_shutdown_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/tokendancelab/metapi-go/auth"
 	"github.com/tokendancelab/metapi-go/config"
-	proxyhandler "github.com/tokendancelab/metapi-go/handler/proxy"
 	"github.com/tokendancelab/metapi-go/handler/admin"
+	proxyhandler "github.com/tokendancelab/metapi-go/handler/proxy"
 	"github.com/tokendancelab/metapi-go/proxy"
 	"github.com/tokendancelab/metapi-go/store"
 )
@@ -58,21 +58,21 @@ func TestShutdownUnderStreamingLoad(t *testing.T) {
 	dbPath := dataDir + "/shutdown_test.db"
 
 	cfg := &config.Config{
-		AuthToken:                    adminToken,
-		ProxyToken:                   proxyToken,
-		AccountCredentialSecret:      "test-cred-secret-shutdown",
-		DbType:                       "sqlite",
-		DbUrl:                        dbPath,
-		DataDir:                      dataDir,
-		ProxyMaxChannelAttempts:      3,
-		ProxyStickySessionEnabled:    false,
-		ProxyStickySessionTtlMs:      30000,
-		TokenRouterCacheTtlMs:        1500,
+		AuthToken:                        adminToken,
+		ProxyToken:                       proxyToken,
+		AccountCredentialSecret:          "test-cred-secret-shutdown",
+		DbType:                           "sqlite",
+		DbUrl:                            dbPath,
+		DataDir:                          dataDir,
+		ProxyMaxChannelAttempts:          3,
+		ProxyStickySessionEnabled:        false,
+		ProxyStickySessionTtlMs:          30000,
+		TokenRouterCacheTtlMs:            1500,
 		TokenRouterFailureCooldownMaxSec: 60,
-		RoutingFallbackUnitCost:      1,
-		RequestBodyLimit:             20 * 1024 * 1024,
-		ListenHost:                   "127.0.0.1",
-		Port:                         0, // OS-assigned port
+		RoutingFallbackUnitCost:          1,
+		RequestBodyLimit:                 20 * 1024 * 1024,
+		ListenHost:                       "127.0.0.1",
+		Port:                             0, // OS-assigned port
 	}
 	config.Set(cfg)
 
@@ -214,8 +214,10 @@ func TestShutdownUnderStreamingLoad(t *testing.T) {
 	siteID := int64(siteResp["id"].(float64))
 
 	accountRec := doAdminPost(t, r, "/api/accounts", adminToken, map[string]any{
-		"siteId":      siteID,
-		"accessToken": "sk-shutdown-upstream-token",
+		"siteId":         siteID,
+		"accessToken":    "sk-shutdown-upstream-token",
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
 	})
 	if accountRec.Code < 200 || accountRec.Code > 299 {
 		t.Fatalf("create account: expected 200/201, got %d: %s", accountRec.Code, accountRec.Body.String())
@@ -223,16 +225,11 @@ func TestShutdownUnderStreamingLoad(t *testing.T) {
 
 	var accountResp map[string]any
 	json.Unmarshal(accountRec.Body.Bytes(), &accountResp)
-	accountID := int64(accountResp["id"].(float64))
-
-	tokenRec := doAdminPost(t, r, "/api/account-tokens", adminToken, map[string]any{
-		"accountId": int(accountID),
-		"name":      "shutdown-token",
-		"token":     "sk-shutdown-upstream-token",
-	})
-	if tokenRec.Code < 200 || tokenRec.Code > 299 {
-		t.Fatalf("create account_token: expected 200/201, got %d: %s", tokenRec.Code, tokenRec.Body.String())
+	if _, ok := accountResp["id"].(float64); !ok {
+		t.Fatalf("create account: missing id: %v", accountResp)
 	}
+
+	// API-key accounts store credentials on the account row; skip account-tokens.
 
 	// ══════════════════════════════════════════════════════════════════════════
 	// Phase 4: Send 10 concurrent streaming requests
@@ -524,17 +521,18 @@ func TestShutdownRejectsNewConnections(t *testing.T) {
 
 	accountRec := doAdminPost(t, r, "/api/accounts", "admin-reject-token", map[string]any{
 		"siteId": siteID, "accessToken": "sk-reject",
+		"credentialMode": "apikey", "skipModelFetch": true,
 	})
 	if accountRec.Code < 200 || accountRec.Code > 299 {
 		t.Fatalf("create account failed: %d", accountRec.Code)
 	}
 	var accountResp map[string]any
 	json.Unmarshal(accountRec.Body.Bytes(), &accountResp)
-	accountID := int64(accountResp["id"].(float64))
+	if _, ok := accountResp["id"].(float64); !ok {
+		t.Fatalf("create account: missing id: %v", accountResp)
+	}
 
-	doAdminPost(t, r, "/api/account-tokens", "admin-reject-token", map[string]any{
-		"accountId": int(accountID), "name": "reject-token", "token": "sk-reject",
-	})
+	// API-key accounts store credentials on the account row; skip account-tokens.
 
 	// Start real HTTP server.
 	ts := httptest.NewUnstartedServer(r)

--- a/handler/admin/account_tokens_test.go
+++ b/handler/admin/account_tokens_test.go
@@ -243,7 +243,7 @@ func TestTokens_Postgres_CreateListUpdateDefaultValueAndDelete(t *testing.T) {
 	err := db.QueryRow(
 		db.Rebind(`INSERT INTO accounts (site_id, username, access_token, status, is_pinned, sort_order,
 		 checkin_enabled, extra_config, created_at, updated_at)
-		 VALUES (?, ?, ?, 'active', 0, 0, 1, ?, ?, ?) RETURNING id`),
+		 VALUES (?, ?, ?, 'active', FALSE, 0, TRUE, ?, ?, ?) RETURNING id`),
 		siteID, username, "pg-session-token-"+suffix, extraConfig, now, now,
 	).Scan(&accountID)
 	if err != nil {

--- a/handler/admin/account_tokens_test.go
+++ b/handler/admin/account_tokens_test.go
@@ -235,9 +235,11 @@ func TestTokens_Postgres_CreateListUpdateDefaultValueAndDelete(t *testing.T) {
 	siteID := int64(site["id"].(float64))
 
 	accountResp := doPostJSON(t, r, "/api/accounts", map[string]any{
-		"siteId":      siteID,
-		"accessToken": "pg-session-token-" + suffix,
-		"username":    "pg-token-user-" + suffix,
+		"siteId":         siteID,
+		"accessToken":    "pg-session-token-" + suffix,
+		"username":       "pg-token-user-" + suffix,
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
 	})
 	if accountResp.Code != http.StatusOK {
 		t.Fatalf("postgres create account: %d %s", accountResp.Code, accountResp.Body.String())

--- a/handler/admin/account_tokens_test.go
+++ b/handler/admin/account_tokens_test.go
@@ -234,21 +234,21 @@ func TestTokens_Postgres_CreateListUpdateDefaultValueAndDelete(t *testing.T) {
 	}
 	siteID := int64(site["id"].(float64))
 
-	accountResp := doPostJSON(t, r, "/api/accounts", map[string]any{
-		"siteId":         siteID,
-		"accessToken":    "pg-session-token-" + suffix,
-		"username":       "pg-token-user-" + suffix,
-		"credentialMode": "apikey",
-		"skipModelFetch": true,
-	})
-	if accountResp.Code != http.StatusOK {
-		t.Fatalf("postgres create account: %d %s", accountResp.Code, accountResp.Body.String())
+	// Insert session-mode account directly so token management APIs remain available
+	// without depending on live upstream VerifyToken.
+	now := time.Now().UTC().Format(time.RFC3339)
+	extraConfig := `{"credentialMode":"session"}`
+	username := "pg-token-user-" + suffix
+	var accountID int64
+	err := db.QueryRow(
+		db.Rebind(`INSERT INTO accounts (site_id, username, access_token, status, is_pinned, sort_order,
+		 checkin_enabled, extra_config, created_at, updated_at)
+		 VALUES (?, ?, ?, 'active', 0, 0, 1, ?, ?, ?) RETURNING id`),
+		siteID, username, "pg-session-token-"+suffix, extraConfig, now, now,
+	).Scan(&accountID)
+	if err != nil {
+		t.Fatalf("postgres insert session account: %v", err)
 	}
-	var account map[string]any
-	if err := json.Unmarshal(accountResp.Body.Bytes(), &account); err != nil {
-		t.Fatalf("unmarshal account: %v", err)
-	}
-	accountID := int64(account["id"].(float64))
 
 	createResp := doPostJSON(t, r, "/api/account-tokens", map[string]any{
 		"accountId": accountID,

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -346,7 +346,7 @@ func (h *accountsHandler) createSingleAccount(ctx context.Context, body payloads
 	if body.APIToken != nil {
 		apiTokenVal = strings.TrimSpace(*body.APIToken)
 	}
-	tokenType := "unknown"
+	var tokenType string
 	verifiedModels := []string{}
 
 	verifyCtx, cancel := context.WithTimeout(ctx, 10*time.Second)

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tokendancelab/metapi-go/platform"
 	"github.com/tokendancelab/metapi-go/routing"
 	"github.com/tokendancelab/metapi-go/service"
+	"github.com/tokendancelab/metapi-go/service/alert"
 	balanceService "github.com/tokendancelab/metapi-go/service/balance"
 	"github.com/tokendancelab/metapi-go/store"
 )
@@ -195,23 +196,30 @@ func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) 
 				}
 			}
 
-			accountID, err := h.createSingleAccount(body, site, credentialMode, token, username)
+			created, err := h.createSingleAccount(r.Context(), body, site, credentialMode, token, username)
 			if err != nil {
 				slog.Error("Batch account creation failed", "err", err, "index", i)
-				items = append(items, map[string]any{
+				item := map[string]any{
 					"index":   i,
 					"status":  "failed",
-					"message": "Account creation failed",
-				})
+					"message": err.Error(),
+				}
+				var verifyErr *accountCreateError
+				if errors.As(err, &verifyErr) {
+					item["message"] = verifyErr.Message
+					item["requiresVerification"] = verifyErr.RequiresVerification
+				}
+				items = append(items, item)
 			} else {
 				createdCount++
 				items = append(items, map[string]any{
-					"index":    i,
-					"status":   "created",
-					"id":       accountID,
-					"username": coalesceStr(username, ""),
-					"queued":   false,
-					"message":  nil,
+					"index":      i,
+					"status":     "created",
+					"id":         created.ID,
+					"username":   coalesceStr(created.Username, ""),
+					"queued":     false,
+					"message":    nil,
+					"modelCount": created.ModelCount,
 				})
 			}
 		}
@@ -244,19 +252,32 @@ func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Single token creation
-	accountID, err := h.createSingleAccount(body, site, credentialMode, requestedTokens[0], body.Username)
+	created, err := h.createSingleAccount(r.Context(), body, site, credentialMode, requestedTokens[0], body.Username)
 	if err != nil {
 		slog.Error("Account creation failed", "err", err)
+		message := err.Error()
+		requiresVerification := false
+		var verifyErr *accountCreateError
+		if errors.As(err, &verifyErr) {
+			message = verifyErr.Message
+			requiresVerification = verifyErr.RequiresVerification
+			if credentialMode != service.CredentialModeAPIKey {
+				message = alert.AppendSessionTokenRebindHint(message)
+			}
+		} else if credentialMode != service.CredentialModeAPIKey {
+			message = alert.AppendSessionTokenRebindHint(message)
+		}
 		writeJSON(w, http.StatusBadRequest, map[string]any{
-			"success": false,
-			"message": "Account creation failed",
+			"success":              false,
+			"requiresVerification": requiresVerification,
+			"message":              message,
 		})
 		return
 	}
 
 	// Fetch created account
 	var account store.Account
-	h.db.Get(&account, h.db.Rebind("SELECT * FROM accounts WHERE id = ?"), accountID)
+	h.db.Get(&account, h.db.Rebind("SELECT * FROM accounts WHERE id = ?"), created.ID)
 
 	caps := service.BuildCapabilitiesForAccount(&account)
 	routing.InvalidateCache()
@@ -267,56 +288,208 @@ func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) 
 		"username":         account.Username,
 		"accessToken":      account.AccessToken,
 		"status":           account.Status,
-		"tokenType":        string(credentialMode),
+		"tokenType":        created.TokenType,
 		"credentialMode":   string(service.ResolveStoredCredentialMode(&account)),
 		"capabilities":     caps,
-		"modelCount":       0,
-		"apiTokenFound":    account.APIToken != nil,
-		"usernameDetected": false,
+		"modelCount":       created.ModelCount,
+		"apiTokenFound":    created.APITokenFound,
+		"usernameDetected": created.UsernameDetected,
 		"queued":           false,
 	})
 }
 
-func (h *accountsHandler) createSingleAccount(body payloads.AccountCreatePayload, site store.Site, credentialMode service.AccountCredentialMode, accessToken string, username *string) (int64, error) {
+// accountCreateError is returned when create fails closed on token verification.
+type accountCreateError struct {
+	Message              string
+	RequiresVerification bool
+}
+
+func (e *accountCreateError) Error() string {
+	if e == nil {
+		return "account create failed"
+	}
+	return e.Message
+}
+
+// createAccountOutcome holds metadata from a successful createSingleAccount call.
+type createAccountOutcome struct {
+	ID               int64
+	Username         *string
+	TokenType        string
+	ModelCount       int
+	APITokenFound    bool
+	UsernameDetected bool
+}
+
+func (h *accountsHandler) createSingleAccount(ctx context.Context, body payloads.AccountCreatePayload, site store.Site, credentialMode service.AccountCredentialMode, rawAccessToken string, username *string) (*createAccountOutcome, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
-
-	sortOrder, _ := service.GetNextAccountSortOrder(h.db)
-
-	checkinEnabled := true
-	if credentialMode == service.CredentialModeAPIKey {
-		checkinEnabled = false
-	} else if body.CheckinEnabled != nil {
-		checkinEnabled = *body.CheckinEnabled
+	rawAccessToken = strings.TrimSpace(rawAccessToken)
+	if rawAccessToken == "" {
+		return nil, &accountCreateError{Message: "请填写 Token", RequiresVerification: false}
 	}
 
-	accessTokenVal := accessToken
-	apiTokenVal := body.APIToken
-	if credentialMode == service.CredentialModeAPIKey && (apiTokenVal == nil || strings.TrimSpace(*apiTokenVal) == "") {
-		apiTokenVal = &accessTokenVal
+	adp := platform.GetAdapter(site.Platform)
+	if adp == nil {
+		return nil, &accountCreateError{
+			Message:              "platform not supported: " + site.Platform,
+			RequiresVerification: false,
+		}
 	}
 
-	// Stub: Verify token against upstream (P4 adapter)
-	// For now, just create the account row
+	skipModelFetch := body.SkipModelFetch != nil && *body.SkipModelFetch
+	proxyCfg := service.BuildPlatformProxyConfig(h.cfg, nil, &site)
+
+	resolvedUsername := strings.TrimSpace(coalesceStr(username, ""))
+	usernameProvided := resolvedUsername != ""
+	accessTokenVal := rawAccessToken
+	apiTokenVal := ""
+	if body.APIToken != nil {
+		apiTokenVal = strings.TrimSpace(*body.APIToken)
+	}
+	tokenType := "unknown"
+	verifiedModels := []string{}
+
+	verifyCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	switch credentialMode {
+	case service.CredentialModeAPIKey:
+		if skipModelFetch {
+			// Explicit skip: accept as API-key without upstream model verify.
+			tokenType = "apikey"
+			accessTokenVal = ""
+			if apiTokenVal == "" {
+				apiTokenVal = rawAccessToken
+			}
+		} else {
+			models, err := adp.GetModels(verifyCtx, site.URL, rawAccessToken, body.PlatformUserID, proxyCfg)
+			if err != nil {
+				return nil, &accountCreateError{
+					Message:              "API Key 验证失败：" + err.Error(),
+					RequiresVerification: true,
+				}
+			}
+			for _, m := range models {
+				m = strings.TrimSpace(m)
+				if m != "" {
+					verifiedModels = append(verifiedModels, m)
+				}
+			}
+			if len(verifiedModels) == 0 {
+				return nil, &accountCreateError{
+					Message:              "API Key 验证失败：未获取到可用模型",
+					RequiresVerification: true,
+				}
+			}
+			tokenType = "apikey"
+			accessTokenVal = ""
+			if apiTokenVal == "" {
+				apiTokenVal = rawAccessToken
+			}
+		}
+	default:
+		// auto / session: require platform.VerifyToken success (fail closed).
+		result, err := adp.VerifyToken(verifyCtx, site.URL, rawAccessToken, body.PlatformUserID, proxyCfg)
+		if err != nil {
+			return nil, &accountCreateError{
+				Message:              err.Error(),
+				RequiresVerification: true,
+			}
+		}
+		if result == nil || result.TokenType == "" || result.TokenType == "unknown" {
+			return nil, &accountCreateError{
+				Message:              "Token 验证失败，请先点击“验证 Token”，验证成功后再绑定账号",
+				RequiresVerification: true,
+			}
+		}
+		tokenType = result.TokenType
+
+		if credentialMode == service.CredentialModeSession && tokenType != "session" {
+			return nil, &accountCreateError{
+				Message:              "当前凭证是 API Key，请切换到 API Key 模式，或改用 Session Token",
+				RequiresVerification: false,
+			}
+		}
+
+		if tokenType == "session" {
+			if resolvedUsername == "" && result.UserInfo != nil {
+				if u := strings.TrimSpace(result.UserInfo.Username); u != "" {
+					resolvedUsername = u
+				} else if u := strings.TrimSpace(result.UserInfo.DisplayName); u != "" {
+					resolvedUsername = u
+				}
+			}
+			if apiTokenVal == "" && strings.TrimSpace(result.APIToken) != "" {
+				apiTokenVal = strings.TrimSpace(result.APIToken)
+			}
+			accessTokenVal = rawAccessToken
+		} else if tokenType == "apikey" {
+			accessTokenVal = ""
+			if apiTokenVal == "" {
+				apiTokenVal = rawAccessToken
+			}
+			for _, m := range result.Models {
+				m = strings.TrimSpace(m)
+				if m != "" {
+					verifiedModels = append(verifiedModels, m)
+				}
+			}
+		}
+	}
+
+	// Resolve platform user id (explicit body wins; else guess from username).
+	var resolvedPlatformUserID *int
+	if body.PlatformUserID != nil {
+		resolvedPlatformUserID = body.PlatformUserID
+	} else if guessed := service.GuessPlatformUserIdFromUsername(&resolvedUsername); guessed > 0 {
+		id := int(guessed)
+		resolvedPlatformUserID = &id
+	}
+
+	resolvedCredentialMode := service.CredentialModeSession
+	if tokenType == "apikey" {
+		resolvedCredentialMode = service.CredentialModeAPIKey
+	}
+
+	checkinEnabled := false
+	if tokenType == "session" {
+		checkinEnabled = true
+		if body.CheckinEnabled != nil {
+			checkinEnabled = *body.CheckinEnabled
+		}
+	}
 
 	extraConfig := map[string]any{
-		"credentialMode": string(credentialMode),
+		"credentialMode": string(resolvedCredentialMode),
 	}
-	if body.PlatformUserID != nil {
-		extraConfig["platformUserId"] = *body.PlatformUserID
+	if resolvedPlatformUserID != nil {
+		extraConfig["platformUserId"] = *resolvedPlatformUserID
 	}
 	// Store tokenExpiresAt for session-mode accounts
-	if body.TokenExpiresAt != nil && credentialMode == service.CredentialModeSession {
+	if body.TokenExpiresAt != nil && resolvedCredentialMode == service.CredentialModeSession {
 		extraConfig["tokenExpiresAt"] = *body.TokenExpiresAt
 	}
-
-	status := "active"
+	// Preserve skipModelFetch intent for residual docs / future init queues.
+	if skipModelFetch {
+		extraConfig["skipModelFetch"] = true
+	}
 
 	extraConfigStr := service.MarshalExtraConfig(extraConfig)
 
-	isPinned := false
-	if body.SkipModelFetch != nil {
-		_ = *body.SkipModelFetch
+	var usernameVal *string
+	if resolvedUsername != "" {
+		u := resolvedUsername
+		usernameVal = &u
 	}
+	var apiTokenPtr *string
+	if apiTokenVal != "" {
+		t := apiTokenVal
+		apiTokenPtr = &t
+	}
+
+	sortOrder, _ := service.GetNextAccountSortOrder(h.db)
+	status := "active"
+	isPinned := false
 
 	var id int64
 	err := h.db.QueryRowx(
@@ -324,13 +497,21 @@ func (h *accountsHandler) createSingleAccount(body payloads.AccountCreatePayload
 		 checkin_enabled, extra_config, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 RETURNING id`),
-		site.ID, username, accessTokenVal, apiTokenVal, status, isPinned, sortOrder,
+		site.ID, usernameVal, accessTokenVal, apiTokenPtr, status, isPinned, sortOrder,
 		checkinEnabled, extraConfigStr, now, now,
 	).Scan(&id)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	return id, nil
+
+	return &createAccountOutcome{
+		ID:               id,
+		Username:         usernameVal,
+		TokenType:        tokenType,
+		ModelCount:       len(verifiedModels),
+		APITokenFound:    apiTokenPtr != nil,
+		UsernameDetected: !usernameProvided && usernameVal != nil,
+	}, nil
 }
 
 // ---- Login Account ----

--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/tokendancelab/metapi-go/config"
 	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/service/alert"
 	"github.com/tokendancelab/metapi-go/store"
 )
 
@@ -58,10 +59,12 @@ func setupAccountFixture(t *testing.T, r chi.Router) (int64, int64) {
 	site := newSiteFixture(t, r, "Fixture Site", "https://api.openai.com")
 	siteID := int64(site["id"].(float64))
 
-	// Create an account
+	// Create an account (skip upstream verify for generic fixtures).
 	body := map[string]any{
-		"siteId":      siteID,
-		"accessToken": "sk-fixture-token",
+		"siteId":         siteID,
+		"accessToken":    "sk-fixture-token",
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
 	}
 	resp := doPostJSON(t, r, "/api/accounts", body)
 	if resp.Code != http.StatusOK {
@@ -71,6 +74,62 @@ func setupAccountFixture(t *testing.T, r chi.Router) (int64, int64) {
 	json.Unmarshal(resp.Body.Bytes(), &m)
 	accountID := int64(m["id"].(float64))
 	return siteID, accountID
+}
+
+func newOpenAIModelsServer(t *testing.T, expectedToken string, models []string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			http.NotFound(w, r)
+			return
+		}
+		if expectedToken != "" && r.Header.Get("Authorization") != "Bearer "+expectedToken {
+			http.Error(w, `{"error":"bad token"}`, http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		items := make([]map[string]any, 0, len(models))
+		for _, m := range models {
+			items = append(items, map[string]any{"id": m})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": items})
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newSessionVerifyServer(t *testing.T, expectedToken, username string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/user/self":
+			if r.Header.Get("Authorization") != "Bearer "+expectedToken {
+				http.Error(w, `{"success":false,"message":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"id":         7,
+					"username":   username,
+					"quota":      1_000_000,
+					"used_quota": 0,
+				},
+			})
+		case "/api/user/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"success": true,
+				"data":    []any{},
+			})
+		case "/v1/models":
+			http.Error(w, `{"error":"not an apikey"}`, http.StatusUnauthorized)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
 }
 
 func setupAccountFixtureWithSite(t *testing.T, db *store.DB, r chi.Router, siteName, url string) (int64, int64) {
@@ -268,13 +327,24 @@ func TestAccounts_UpdateClearsSnapshotCache(t *testing.T) {
 
 func TestAccounts_Create(t *testing.T) {
 	_, r, _ := setupAccountsTest(t)
-	site := newSiteFixture(t, r, "CreateSite", "https://api.openai.com")
+	server := newOpenAIModelsServer(t, "sk-test-create-token-12345", []string{"gpt-4o-mini"})
+	siteResp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "CreateSite",
+		"url":      server.URL,
+		"platform": "openai",
+	})
+	if siteResp.Code != http.StatusOK {
+		t.Fatalf("create site: %d %s", siteResp.Code, siteResp.Body.String())
+	}
+	var site map[string]any
+	json.Unmarshal(siteResp.Body.Bytes(), &site)
 	siteID := int64(site["id"].(float64))
 
 	body := map[string]any{
-		"siteId":      siteID,
-		"accessToken": "sk-test-create-token-12345",
-		"username":    "testuser",
+		"siteId":         siteID,
+		"accessToken":    "sk-test-create-token-12345",
+		"username":       "testuser",
+		"credentialMode": "apikey",
 	}
 	resp := doPostJSON(t, r, "/api/accounts", body)
 	if resp.Code != http.StatusOK {
@@ -286,8 +356,221 @@ func TestAccounts_Create(t *testing.T) {
 	if created["id"] == nil {
 		t.Error("expected id in response")
 	}
-	if created["tokenType"] != "auto" {
-		t.Errorf("expected tokenType='auto', got %v", created["tokenType"])
+	if created["tokenType"] != "apikey" {
+		t.Errorf("expected tokenType='apikey', got %v", created["tokenType"])
+	}
+	if created["apiTokenFound"] != true {
+		t.Errorf("expected apiTokenFound=true, got %v", created["apiTokenFound"])
+	}
+	if created["modelCount"] != float64(1) {
+		t.Errorf("expected modelCount=1, got %v", created["modelCount"])
+	}
+}
+
+func TestAccounts_Create_RejectsUnknownToken(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Force VerifyToken unknown: no usable session/user and no models.
+		if r.URL.Path == "/api/user/self" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"success": false, "message": "nope"})
+			return
+		}
+		if r.URL.Path == "/v1/models" {
+			http.Error(w, `{"error":"bad token"}`, http.StatusUnauthorized)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(upstream.Close)
+
+	siteResp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "Reject Unknown",
+		"url":      upstream.URL,
+		"platform": "anyrouter",
+	})
+	if siteResp.Code != http.StatusOK {
+		t.Fatalf("create site: %d %s", siteResp.Code, siteResp.Body.String())
+	}
+	var site map[string]any
+	json.Unmarshal(siteResp.Body.Bytes(), &site)
+	siteID := int64(site["id"].(float64))
+
+	resp := doPostJSON(t, r, "/api/accounts", map[string]any{
+		"siteId":      siteID,
+		"accessToken": "invalid-token",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &result)
+	if result["success"] != false {
+		t.Fatalf("success = %v, want false", result["success"])
+	}
+	if result["requiresVerification"] != true {
+		t.Fatalf("requiresVerification = %v, want true", result["requiresVerification"])
+	}
+	msg, _ := result["message"].(string)
+	if !strings.Contains(msg, "Token 验证失败") {
+		t.Fatalf("message = %q, want verify failure", msg)
+	}
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM accounts WHERE site_id = ?", siteID).Scan(&count); err != nil {
+		t.Fatalf("count accounts: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("created %d accounts, want 0", count)
+	}
+}
+
+func TestAccounts_Create_EnrichesUsernameFromUserInfo(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	server := newSessionVerifyServer(t, "session-token-xyz", "detected-user")
+	siteResp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "Session Enrich",
+		"url":      server.URL,
+		"platform": "anyrouter",
+	})
+	if siteResp.Code != http.StatusOK {
+		t.Fatalf("create site: %d %s", siteResp.Code, siteResp.Body.String())
+	}
+	var site map[string]any
+	json.Unmarshal(siteResp.Body.Bytes(), &site)
+	siteID := int64(site["id"].(float64))
+
+	resp := doPostJSON(t, r, "/api/accounts", map[string]any{
+		"siteId":      siteID,
+		"accessToken": "session-token-xyz",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("create account: %d %s", resp.Code, resp.Body.String())
+	}
+	var created map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &created)
+	if created["tokenType"] != "session" {
+		t.Fatalf("tokenType = %v, want session", created["tokenType"])
+	}
+	if created["usernameDetected"] != true {
+		t.Fatalf("usernameDetected = %v, want true", created["usernameDetected"])
+	}
+	if created["username"] != "detected-user" {
+		t.Fatalf("username = %v, want detected-user", created["username"])
+	}
+
+	var username string
+	if err := db.QueryRow("SELECT username FROM accounts WHERE id = ?", int64(created["id"].(float64))).Scan(&username); err != nil {
+		t.Fatalf("read username: %v", err)
+	}
+	if username != "detected-user" {
+		t.Fatalf("stored username = %q, want detected-user", username)
+	}
+}
+
+func TestAccounts_Create_APIKeySkipModelFetch(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	upstreamCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	siteResp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "Skip Model Fetch",
+		"url":      server.URL,
+		"platform": "openai",
+	})
+	if siteResp.Code != http.StatusOK {
+		t.Fatalf("create site: %d %s", siteResp.Code, siteResp.Body.String())
+	}
+	var site map[string]any
+	json.Unmarshal(siteResp.Body.Bytes(), &site)
+	siteID := int64(site["id"].(float64))
+
+	resp := doPostJSON(t, r, "/api/accounts", map[string]any{
+		"siteId":         siteID,
+		"accessToken":    "sk-skip-verify",
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("create account: %d %s", resp.Code, resp.Body.String())
+	}
+	if upstreamCalls != 0 {
+		t.Fatalf("upstreamCalls = %d, want 0", upstreamCalls)
+	}
+	var created map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &created)
+	if created["tokenType"] != "apikey" {
+		t.Fatalf("tokenType = %v, want apikey", created["tokenType"])
+	}
+
+	var accessToken string
+	var apiToken *string
+	if err := db.QueryRow("SELECT access_token, api_token FROM accounts WHERE id = ?", int64(created["id"].(float64))).Scan(&accessToken, &apiToken); err != nil {
+		t.Fatalf("read tokens: %v", err)
+	}
+	if accessToken != "" {
+		t.Fatalf("access_token = %q, want empty for apikey", accessToken)
+	}
+	if apiToken == nil || *apiToken != "sk-skip-verify" {
+		t.Fatalf("api_token = %v, want sk-skip-verify", apiToken)
+	}
+}
+
+func TestAccounts_Create_InvalidAccessTokenFailClosed(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	// NewAPI-style adapters treat HTTP failures as "unknown" rather than
+	// propagating the body message; create must still fail closed.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"success":false,"message":"无权进行此操作，access token 无效"}`, http.StatusForbidden)
+	}))
+	t.Cleanup(upstream.Close)
+
+	siteResp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "Fail Closed",
+		"url":      upstream.URL,
+		"platform": "anyrouter",
+	})
+	if siteResp.Code != http.StatusOK {
+		t.Fatalf("create site: %d %s", siteResp.Code, siteResp.Body.String())
+	}
+	var site map[string]any
+	json.Unmarshal(siteResp.Body.Bytes(), &site)
+	siteID := int64(site["id"].(float64))
+
+	resp := doPostJSON(t, r, "/api/accounts", map[string]any{
+		"siteId":      siteID,
+		"accessToken": "bad-session",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &result)
+	if result["requiresVerification"] != true {
+		t.Fatalf("requiresVerification = %v, want true", result["requiresVerification"])
+	}
+	msg, _ := result["message"].(string)
+	if !strings.Contains(msg, "Token 验证失败") && !strings.Contains(msg, "重新绑定账号") {
+		t.Fatalf("message = %q, want verify failure or rebind hint", msg)
+	}
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM accounts WHERE site_id = ?", siteID).Scan(&count); err != nil {
+		t.Fatalf("count accounts: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("created %d accounts, want 0", count)
+	}
+}
+
+func TestAccounts_Create_AppendsRebindHintOnVerifyError(t *testing.T) {
+	// Directly exercise the response path used when VerifyToken returns a
+	// concrete invalid-access-token error (TS parity).
+	msg := alert.AppendSessionTokenRebindHint("无权进行此操作，access token 无效")
+	if !strings.Contains(msg, "重新绑定账号") {
+		t.Fatalf("message = %q, want rebind hint", msg)
 	}
 }
 
@@ -314,9 +597,11 @@ func TestAccounts_Postgres_CreateUpdateManualModelsAndBatch(t *testing.T) {
 	siteID := int64(site["id"].(float64))
 
 	createResp := doPostJSON(t, r, "/api/accounts", map[string]any{
-		"siteId":      siteID,
-		"accessToken": "pg-account-token",
-		"username":    "pg-user-" + suffix,
+		"siteId":         siteID,
+		"accessToken":    "pg-account-token",
+		"username":       "pg-user-" + suffix,
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
 	})
 	if createResp.Code != http.StatusOK {
 		t.Fatalf("postgres create account: expected 200, got %d: %s", createResp.Code, createResp.Body.String())
@@ -377,6 +662,7 @@ func TestAccounts_Postgres_CreateAnyRouterAPIKeyWithoutUsernameReturnsID(t *test
 		"accessToken":    "pg-anyrouter-api-key-" + suffix,
 		"credentialMode": "apikey",
 		"checkinEnabled": true,
+		"skipModelFetch": true,
 	})
 	if createResp.Code != http.StatusOK {
 		t.Fatalf("postgres create AnyRouter API-key account: %d %s", createResp.Code, createResp.Body.String())
@@ -437,9 +723,11 @@ func TestAccounts_Create_BatchAPIKeys(t *testing.T) {
 	siteID := int64(site["id"].(float64))
 
 	body := map[string]any{
-		"siteId":       siteID,
-		"accessTokens": []string{"batch-key-1", "batch-key-2", "batch-key-3"},
-		"username":     "batchuser",
+		"siteId":         siteID,
+		"accessTokens":   []string{"batch-key-1", "batch-key-2", "batch-key-3"},
+		"username":       "batchuser",
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
 	}
 	resp := doPostJSON(t, r, "/api/accounts", body)
 	if resp.Code != http.StatusOK {
@@ -469,9 +757,11 @@ func TestAccounts_Create_BatchAPIKeysTrimsAndFiltersBlankTokens(t *testing.T) {
 	siteID := int64(site["id"].(float64))
 
 	body := map[string]any{
-		"siteId":       siteID,
-		"accessTokens": []string{" batch-key-1 ", "   ", "\t", "batch-key-2"},
-		"username":     "batchuser",
+		"siteId":         siteID,
+		"accessTokens":   []string{" batch-key-1 ", "   ", "\t", "batch-key-2"},
+		"username":       "batchuser",
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
 	}
 	resp := doPostJSON(t, r, "/api/accounts", body)
 	if resp.Code != http.StatusOK {
@@ -488,7 +778,8 @@ func TestAccounts_Create_BatchAPIKeysTrimsAndFiltersBlankTokens(t *testing.T) {
 	}
 
 	var tokens []string
-	if err := db.Select(&tokens, "SELECT access_token FROM accounts WHERE site_id = ? ORDER BY id", siteID); err != nil {
+	// API-key create stores the secret on api_token and clears access_token.
+	if err := db.Select(&tokens, "SELECT api_token FROM accounts WHERE site_id = ? ORDER BY id", siteID); err != nil {
 		t.Fatalf("read created tokens: %v", err)
 	}
 	if len(tokens) != 2 || tokens[0] != "batch-key-1" || tokens[1] != "batch-key-2" {
@@ -520,6 +811,7 @@ func TestAccounts_Create_WithCredentialMode(t *testing.T) {
 		"siteId":         siteID,
 		"accessToken":    "anyrouter-api-token-test",
 		"credentialMode": "apikey",
+		"skipModelFetch": true,
 	}
 	resp := doPostJSON(t, r, "/api/accounts", body)
 	if resp.Code != http.StatusOK {
@@ -553,6 +845,7 @@ func TestAccounts_Create_APIKeyCannotEnableCheckin(t *testing.T) {
 		"accessToken":    "anyrouter-api-token-create-checkin",
 		"credentialMode": "apikey",
 		"checkinEnabled": true,
+		"skipModelFetch": true,
 	}
 	resp := doPostJSON(t, r, "/api/accounts", body)
 	if resp.Code != http.StatusOK {
@@ -895,7 +1188,6 @@ func TestAccounts_RebindSession_DBWriteFailureReturnsError(t *testing.T) {
 
 // ---- Update Account ----
 
-
 func TestAccounts_List_ExpiredStatusNotHealthy(t *testing.T) {
 	db, r, _ := setupAccountsTest(t)
 	_, accountID := setupAccountFixtureWithSite(t, db, r, "ExpiredHealthSite", "https://api.openai.com")
@@ -1082,6 +1374,7 @@ func TestAccounts_UpdateAPIKeyMirrorsAccessTokenWhenAPITokenUnchanged(t *testing
 		"siteId":         siteID,
 		"accessToken":    "old-anyrouter-api-key",
 		"credentialMode": "apikey",
+		"skipModelFetch": true,
 	})
 	if createResp.Code != http.StatusOK {
 		t.Fatalf("create apikey account: %d %s", createResp.Code, createResp.Body.String())
@@ -1122,6 +1415,7 @@ func TestAccounts_UpdateAPIKeyPreservesExplicitDifferentAPIToken(t *testing.T) {
 		"siteId":         siteID,
 		"accessToken":    "old-anyrouter-api-key",
 		"credentialMode": "apikey",
+		"skipModelFetch": true,
 	})
 	if createResp.Code != http.StatusOK {
 		t.Fatalf("create apikey account: %d %s", createResp.Code, createResp.Body.String())
@@ -1162,6 +1456,7 @@ func TestAccounts_UpdateAPIKeyCannotEnableCheckin(t *testing.T) {
 		"siteId":         siteID,
 		"accessToken":    "anyrouter-api-key-checkin",
 		"credentialMode": "apikey",
+		"skipModelFetch": true,
 	})
 	if createResp.Code != http.StatusOK {
 		t.Fatalf("create apikey account: %d %s", createResp.Code, createResp.Body.String())

--- a/handler/admin/edge_cases_test.go
+++ b/handler/admin/edge_cases_test.go
@@ -520,12 +520,14 @@ func TestEdge_DuplicateAccountCreation(t *testing.T) {
 	// So duplicate accounts with same accessToken will succeed.
 	// This is a potential data integrity issue for credential import.
 	body := map[string]any{
-		"siteId":      siteID,
-		"accessToken": "dup-token-test",
+		"siteId":         siteID,
+		"accessToken":    "dup-token-test",
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
 	}
 	rec1 := doPostJSON(t, r, "/api/accounts", body)
 	if rec1.Code != http.StatusOK {
-		t.Fatalf("first account: %d", rec1.Code)
+		t.Fatalf("first account: %d %s", rec1.Code, rec1.Body.String())
 	}
 
 	rec2 := doPostJSON(t, r, "/api/accounts", body)

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -165,48 +165,37 @@ func TestTokenRoutes_Postgres_CreateUpdateChannelAndDelete(t *testing.T) {
 		_, _ = db.Exec("DELETE FROM sites WHERE url = ?", siteURL)
 	})
 
-	siteResp := doPostJSON(t, r, "/api/sites", map[string]any{
-		"name":     "PG Routes " + suffix,
-		"url":      siteURL,
-		"platform": "openai",
-	})
-	if siteResp.Code != http.StatusOK {
-		t.Fatalf("postgres create site: %d %s", siteResp.Code, siteResp.Body.String())
-	}
-	var site map[string]any
-	if err := json.Unmarshal(siteResp.Body.Bytes(), &site); err != nil {
-		t.Fatalf("unmarshal site: %v", err)
-	}
-	siteID := int64(site["id"].(float64))
-
 	now := time.Now().UTC().Format(time.RFC3339)
+	// Seed site/account/token via SQL to avoid shared-PG /api/sites flake and VerifyToken.
+	var siteID int64
+	if err := db.QueryRow(
+		db.Rebind(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		 VALUES (?, ?, 'openai', 'active', ?, ?) RETURNING id`),
+		"PG Routes "+suffix, siteURL, now, now,
+	).Scan(&siteID); err != nil {
+		t.Fatalf("postgres insert site: %v", err)
+	}
+
 	extraConfig := `{"credentialMode":"session"}`
 	username := "pg-route-user-" + suffix
 	var accountID int64
-	err := db.QueryRow(
+	if err := db.QueryRow(
 		db.Rebind(`INSERT INTO accounts (site_id, username, access_token, status, is_pinned, sort_order,
 		 checkin_enabled, extra_config, created_at, updated_at)
 		 VALUES (?, ?, ?, 'active', FALSE, 0, TRUE, ?, ?, ?) RETURNING id`),
 		siteID, username, "pg-route-session-"+suffix, extraConfig, now, now,
-	).Scan(&accountID)
-	if err != nil {
+	).Scan(&accountID); err != nil {
 		t.Fatalf("postgres insert session account: %v", err)
 	}
 
-	tokenResp := doPostJSON(t, r, "/api/account-tokens", map[string]any{
-		"accountId": accountID,
-		"token":     "sk-pg-route-token-" + suffix,
-		"isDefault": true,
-	})
-	if tokenResp.Code != http.StatusOK {
-		t.Fatalf("postgres create token: %d %s", tokenResp.Code, tokenResp.Body.String())
+	var tokenID int64
+	if err := db.QueryRow(
+		db.Rebind(`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
+		 VALUES (?, 'default', ?, 'ready', 'manual', TRUE, TRUE, ?, ?) RETURNING id`),
+		accountID, "sk-pg-route-token-"+suffix, now, now,
+	).Scan(&tokenID); err != nil {
+		t.Fatalf("postgres insert token: %v", err)
 	}
-	var tokenResult map[string]any
-	if err := json.Unmarshal(tokenResp.Body.Bytes(), &tokenResult); err != nil {
-		t.Fatalf("unmarshal token: %v", err)
-	}
-	token := tokenResult["token"].(map[string]any)
-	tokenID := int64(token["id"].(float64))
 
 	routeResp := doPostJSON(t, r, "/api/routes", map[string]any{
 		"modelPattern": "pg-route-" + suffix + "-*",

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -186,7 +186,7 @@ func TestTokenRoutes_Postgres_CreateUpdateChannelAndDelete(t *testing.T) {
 	err := db.QueryRow(
 		db.Rebind(`INSERT INTO accounts (site_id, username, access_token, status, is_pinned, sort_order,
 		 checkin_enabled, extra_config, created_at, updated_at)
-		 VALUES (?, ?, ?, 'active', 0, 0, 1, ?, ?, ?) RETURNING id`),
+		 VALUES (?, ?, ?, 'active', FALSE, 0, TRUE, ?, ?, ?) RETURNING id`),
 		siteID, username, "pg-route-session-"+suffix, extraConfig, now, now,
 	).Scan(&accountID)
 	if err != nil {

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -179,21 +179,19 @@ func TestTokenRoutes_Postgres_CreateUpdateChannelAndDelete(t *testing.T) {
 	}
 	siteID := int64(site["id"].(float64))
 
-	accountResp := doPostJSON(t, r, "/api/accounts", map[string]any{
-		"siteId":         siteID,
-		"accessToken":    "pg-route-session-" + suffix,
-		"username":       "pg-route-user-" + suffix,
-		"credentialMode": "apikey",
-		"skipModelFetch": true,
-	})
-	if accountResp.Code != http.StatusOK {
-		t.Fatalf("postgres create account: %d %s", accountResp.Code, accountResp.Body.String())
+	now := time.Now().UTC().Format(time.RFC3339)
+	extraConfig := `{"credentialMode":"session"}`
+	username := "pg-route-user-" + suffix
+	var accountID int64
+	err := db.QueryRow(
+		db.Rebind(`INSERT INTO accounts (site_id, username, access_token, status, is_pinned, sort_order,
+		 checkin_enabled, extra_config, created_at, updated_at)
+		 VALUES (?, ?, ?, 'active', 0, 0, 1, ?, ?, ?) RETURNING id`),
+		siteID, username, "pg-route-session-"+suffix, extraConfig, now, now,
+	).Scan(&accountID)
+	if err != nil {
+		t.Fatalf("postgres insert session account: %v", err)
 	}
-	var account map[string]any
-	if err := json.Unmarshal(accountResp.Body.Bytes(), &account); err != nil {
-		t.Fatalf("unmarshal account: %v", err)
-	}
-	accountID := int64(account["id"].(float64))
 
 	tokenResp := doPostJSON(t, r, "/api/account-tokens", map[string]any{
 		"accountId": accountID,

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -180,9 +180,11 @@ func TestTokenRoutes_Postgres_CreateUpdateChannelAndDelete(t *testing.T) {
 	siteID := int64(site["id"].(float64))
 
 	accountResp := doPostJSON(t, r, "/api/accounts", map[string]any{
-		"siteId":      siteID,
-		"accessToken": "pg-route-session-" + suffix,
-		"username":    "pg-route-user-" + suffix,
+		"siteId":         siteID,
+		"accessToken":    "pg-route-session-" + suffix,
+		"username":       "pg-route-user-" + suffix,
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
 	})
 	if accountResp.Code != http.StatusOK {
 		t.Fatalf("postgres create account: %d %s", accountResp.Code, accountResp.Body.String())


### PR DESCRIPTION
## Summary
- Wire `createSingleAccount` to `platform.VerifyToken` / `GetModels` with fail-closed create
- Preserve `skipModelFetch` for apikey proxy-only import; enrich username from UserInfo on session verify
- Update e2e fixtures for verified apikey create path; document residual standard-adapter VerifyToken dispatch gap

## Test plan
- [x] `go test ./handler/admin -count=1 -run Account`
- [x] `go test ./e2e -count=1`
- [x] local pre-push CI (vet + race)

Closes #183