### PR TITLE
feat(admin): wire account token create/delete/sync to adapters

### DIFF
--- a/docs/analysis/p4-token-adapter-wiring.md
+++ b/docs/analysis/p4-token-adapter-wiring.md
@@ -1,0 +1,58 @@
+# P4 Token Adapter Wiring (#182)
+
+Last updated: 2026-07-17
+
+## Scope
+
+Wire admin account token create / delete / sync stubs to platform adapters:
+
+- `handler/admin/account_tokens.go`
+- `service/account_token_service.go` thin helpers
+- SQLite tests with httptest fake NewAPI upstream
+
+## Flows
+
+### Create (upstream path)
+
+When `POST /api/account-tokens` has no local `token` value:
+
+1. Reject API-key connections / disabled sites / missing access token
+2. Build `platform.CreateAPITokenOptions` from payload
+3. `platform.GetAdapter(site.Platform).CreateAPIToken(...)`
+4. Refresh local rows via `GetAPITokens` (+ `GetAPIToken` fallback) then `service.SyncTokensFromUpstream`
+5. Return synced token summary
+
+### Delete (upstream-first)
+
+For single and batch delete:
+
+1. Skip remote delete when token is `masked_pending` / masked value (key residual unknown)
+2. Skip remote delete when site disabled, access token empty, or adapter missing
+3. Otherwise call `adapter.DeleteAPIToken(url, accessToken, tokenKey, platformUserId, proxy)`
+4. On remote failure: abort local delete
+5. On success / skip: local `DeleteTokenByID` + default repair
+
+Residual note: masked tokens cannot be matched remotely because only redacted key material is stored.
+
+### Sync account / sync-all
+
+`POST /api/account-tokens/sync/{accountId}` and `sync-all`:
+
+1. Skip reasons: `site_disabled`, `apikey_connection`, `no_access_token`, `unsupported_platform`, `no_upstream_tokens`
+2. Otherwise: `FetchUpstreamAPITokens` → `SyncTokensFromUpstream`
+3. Real counts for created/updated/total
+4. `sync-all wait=true` runs in process (batch size 3)
+5. `sync-all wait=false` uses `StartBackgroundTask` with dedupe key `sync-all-account-tokens`
+
+## Helpers
+
+- `service.PlatformAPITokensToUpstream`
+- `service.FetchUpstreamAPITokens`
+- `service.ResolvePlatformUserIDPtr`
+- `service.BuildPlatformProxyConfig` (existing)
+
+## Verify
+
+```bash
+go test ./handler/admin ./service -count=1 -run Token
+```

--- a/handler/admin/account_tokens.go
+++ b/handler/admin/account_tokens.go
@@ -1,23 +1,33 @@
 package admin
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/config"
 	"github.com/tokendancelab/metapi-go/handler/admin/payloads"
+	"github.com/tokendancelab/metapi-go/platform"
 	"github.com/tokendancelab/metapi-go/service"
 	"github.com/tokendancelab/metapi-go/store"
 )
 
 // RegisterAccountTokensRoutes registers all /api/account-tokens routes.
 func RegisterAccountTokensRoutes(r chi.Router, db *sqlx.DB) {
-	handler := &accountTokensHandler{db: db}
+	RegisterAccountTokensRoutesWithConfig(r, db, nil)
+}
+
+// RegisterAccountTokensRoutesWithConfig is like RegisterAccountTokensRoutes but
+// accepts optional runtime config for proxy-aware upstream calls.
+func RegisterAccountTokensRoutesWithConfig(r chi.Router, db *sqlx.DB, cfg *config.Config) {
+	handler := &accountTokensHandler{db: db, cfg: cfg}
 
 	r.Get("/api/account-tokens", handler.listTokens)
 	r.Post("/api/account-tokens", handler.createToken)
@@ -33,7 +43,8 @@ func RegisterAccountTokensRoutes(r chi.Router, db *sqlx.DB) {
 }
 
 type accountTokensHandler struct {
-	db *sqlx.DB
+	db  *sqlx.DB
+	cfg *config.Config
 }
 
 // ---- List Tokens ----
@@ -113,8 +124,78 @@ func (h *accountTokensHandler) createToken(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Stub: P4 adapter.createApiToken()
-	writeError(w, http.StatusBadGateway, "站点创建令牌失败（上游适配器未实现）")
+	options, optErr := buildCreateAPITokenOptions(body)
+	if optErr != nil {
+		writeError(w, http.StatusBadRequest, optErr.Error())
+		return
+	}
+
+	adapter := platform.GetAdapter(row.Site.Platform)
+	if adapter == nil {
+		writeError(w, http.StatusBadGateway, "不支持的平台，无法创建站点令牌: "+row.Site.Platform)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	proxyCfg := service.BuildPlatformProxyConfig(h.cfg, &row.Account, &row.Site)
+	platformUserID := service.ResolvePlatformUserIDPtr(&row.Account)
+
+	created, createErr := adapter.CreateAPIToken(
+		ctx,
+		row.Site.URL,
+		row.Account.AccessToken,
+		platformUserID,
+		options,
+		proxyCfg,
+	)
+	if createErr != nil {
+		slog.Warn("Upstream create API token failed", "err", createErr, "account_id", row.Account.ID, "platform", row.Site.Platform)
+		writeError(w, http.StatusBadGateway, "站点创建令牌失败: "+createErr.Error())
+		return
+	}
+	if !created {
+		writeError(w, http.StatusBadGateway, "站点创建令牌失败（上游返回失败）")
+		return
+	}
+
+	syncResult, syncErr := executeAccountTokenSync(ctx, h.db, h.cfg, row)
+	if syncErr != nil {
+		slog.Warn("Token sync after upstream create failed", "err", syncErr, "account_id", row.Account.ID)
+		writeError(w, http.StatusBadGateway, "站点令牌已创建，但同步本地令牌失败: "+syncErr.Error())
+		return
+	}
+
+	var token *store.AccountToken
+	if syncResult != nil {
+		if defaultID, ok := syncResult["defaultTokenId"].(int64); ok {
+			token, _ = service.GetTokenByID(h.db, defaultID)
+		}
+	}
+	if token == nil {
+		token, _ = service.GetDefaultTokenForAccount(h.db, row.Account.ID)
+	}
+	if token == nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"success": true,
+			"synced":  true,
+			"created": syncResult["created"],
+			"updated": syncResult["updated"],
+			"total":   syncResult["total"],
+			"message": "上游令牌已创建并完成同步",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"success": true,
+		"token":   tokenToMap(*token, row.Site.Platform),
+		"synced":  true,
+		"created": syncResult["created"],
+		"updated": syncResult["updated"],
+		"total":   syncResult["total"],
+	})
 }
 
 func (h *accountTokensHandler) createLocalToken(body payloads.AccountTokenCreatePayload, row *service.AccountWithSite, tokenValue string) (map[string]any, error) {
@@ -259,10 +340,9 @@ func (h *accountTokensHandler) batchTokens(w http.ResponseWriter, r *http.Reques
 		}
 
 		if action == "delete" {
-			// Upstream-first delete stub: just do local delete
-			if err := service.DeleteTokenByID(h.db, id); err != nil {
+			if err := h.deleteTokenWithUpstream(r.Context(), existing); err != nil {
 				slog.Error("Token deletion failed", "err", err, "token_id", id)
-				failedItems = append(failedItems, map[string]any{"id": id, "message": "Token deletion failed"})
+				failedItems = append(failedItems, map[string]any{"id": id, "message": err.Error()})
 				continue
 			}
 		} else {
@@ -559,13 +639,45 @@ func (h *accountTokensHandler) deleteToken(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Stub: upstream-first delete - just local delete for now
-	if err := service.DeleteTokenByID(h.db, tokenID); err != nil {
-		slog.Error("Token deletion failed", "err", err)
-		writeError(w, http.StatusBadGateway, "Token deletion failed")
+	if err := h.deleteTokenWithUpstream(r.Context(), token); err != nil {
+		slog.Error("Token deletion failed", "err", err, "token_id", tokenID)
+		writeError(w, http.StatusBadGateway, err.Error())
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})
+}
+
+func (h *accountTokensHandler) deleteTokenWithUpstream(ctx context.Context, token *store.AccountToken) error {
+	if token == nil {
+		return fmt.Errorf("令牌不存在")
+	}
+
+	// Residual: masked_pending tokens only store redacted key material, so remote
+	// delete cannot match a real upstream key and is intentionally skipped.
+	shouldSkipUpstream := service.IsMaskedPendingAccountToken(token) || IsMaskedTokenValue(token.Token)
+
+	row, err := service.GetAccountWithSiteByID(h.db, token.AccountID)
+	if err != nil {
+		return service.DeleteTokenByID(h.db, token.ID)
+	}
+
+	if !shouldSkipUpstream {
+		siteDisabled := strings.EqualFold(strings.TrimSpace(row.Site.Status), "disabled")
+		accessToken := strings.TrimSpace(row.Account.AccessToken)
+		adapter := platform.GetAdapter(row.Site.Platform)
+
+		if !siteDisabled && accessToken != "" && adapter != nil {
+			callCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+			defer cancel()
+			proxyCfg := service.BuildPlatformProxyConfig(h.cfg, &row.Account, &row.Site)
+			platformUserID := service.ResolvePlatformUserIDPtr(&row.Account)
+			if delErr := adapter.DeleteAPIToken(callCtx, row.Site.URL, accessToken, token.Token, platformUserID, proxyCfg); delErr != nil {
+				return fmt.Errorf("上游删除令牌失败: %w", delErr)
+			}
+		}
+	}
+
+	return service.DeleteTokenByID(h.db, token.ID)
 }
 
 // ---- Sync Account ----
@@ -584,19 +696,15 @@ func (h *accountTokensHandler) syncAccount(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Stub: P4 adapter sync
-	_ = row
-	writeJSON(w, http.StatusOK, map[string]any{
-		"success":   true,
-		"accountId": accountID,
-		"status":    "skipped",
-		"reason":    "no_upstream_tokens",
-		"message":   "upstream returned no api tokens (sync stub)",
-		"synced":    false,
-		"created":   0,
-		"updated":   0,
-		"total":     0,
-	})
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	result, syncErr := executeAccountTokenSync(ctx, h.db, h.cfg, row)
+	if syncErr != nil {
+		writeError(w, http.StatusBadGateway, syncErr.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
 }
 
 // ---- Sync All ----
@@ -604,30 +712,43 @@ func (h *accountTokensHandler) syncAccount(w http.ResponseWriter, r *http.Reques
 func (h *accountTokensHandler) syncAll(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountTokenSyncAllPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid request body")
-		return
+		// Empty body is allowed for background mode.
+		body = payloads.AccountTokenSyncAllPayload{}
 	}
 
 	wait := body.Wait != nil && *body.Wait
+	db := h.db
+	cfg := h.cfg
 
 	if wait {
+		summary, results := executeSyncAllAccountTokens(context.Background(), db, cfg)
 		writeJSON(w, http.StatusOK, map[string]any{
 			"success": true,
-			"summary": map[string]int{
-				"total": 0, "synced": 0, "skipped": 0, "failed": 0,
-				"created": 0, "updated": 0,
-			},
-			"results": []any{},
+			"summary": summary,
+			"results": results,
 		})
 		return
 	}
 
+	task, reused := StartBackgroundTask(BackgroundTaskStartOptions{
+		Type:      "sync-all-account-tokens",
+		Title:     "同步全部账号令牌",
+		DedupeKey: "sync-all-account-tokens",
+	}, func() (any, error) {
+		summary, results := executeSyncAllAccountTokens(context.Background(), db, cfg)
+		return map[string]any{
+			"summary": summary,
+			"results": results,
+		}, nil
+	})
+
 	writeJSON(w, http.StatusAccepted, map[string]any{
 		"success": true,
 		"queued":  true,
-		"reused":  false,
-		"jobId":   "stub-sync-all",
-		"status":  "pending",
+		"reused":  reused,
+		"jobId":   task.ID,
+		"taskId":  task.ID,
+		"status":  string(task.Status),
 		"message": "已开始全部账号令牌同步，请稍后查看程序日志",
 	})
 }
@@ -703,6 +824,350 @@ func (h *accountTokensHandler) getAccountDefault(w http.ResponseWriter, r *http.
 		"success": true,
 		"token":   tokenToMapMasked(*token, site.Platform),
 	})
+}
+
+// ---- Upstream helpers ----
+
+func buildCreateAPITokenOptions(body payloads.AccountTokenCreatePayload) (*platform.CreateAPITokenOptions, error) {
+	unlimitedQuota := true
+	if body.UnlimitedQuota != nil {
+		unlimitedQuota = *body.UnlimitedQuota
+	}
+
+	var remainQuota float64
+	if body.RemainQuota != nil {
+		parsed, ok := parseFlexibleFloat(body.RemainQuota)
+		if !ok {
+			return nil, fmt.Errorf("Invalid remainQuota. Expected number.")
+		}
+		remainQuota = parsed
+	} else if !unlimitedQuota {
+		return nil, fmt.Errorf("remainQuota is required when unlimitedQuota is false")
+	}
+
+	expiredTime := int64(-1)
+	if body.ExpiredTime != nil {
+		parsed, ok := parseFlexibleEpochSeconds(body.ExpiredTime)
+		if !ok {
+			return nil, fmt.Errorf("Invalid expiredTime. Expected unix seconds or ISO date string.")
+		}
+		expiredTime = parsed
+	}
+
+	name := ""
+	if body.Name != nil {
+		name = strings.TrimSpace(*body.Name)
+	}
+	group := ""
+	if body.Group != nil {
+		group = strings.TrimSpace(*body.Group)
+	}
+	allowIPs := ""
+	if body.AllowIPs != nil {
+		allowIPs = strings.TrimSpace(*body.AllowIPs)
+	}
+	modelLimits := ""
+	if body.ModelLimits != nil {
+		modelLimits = strings.TrimSpace(*body.ModelLimits)
+	}
+	modelLimitsEnabled := false
+	if body.ModelLimitsEnabled != nil {
+		modelLimitsEnabled = *body.ModelLimitsEnabled
+	}
+
+	return &platform.CreateAPITokenOptions{
+		Name:               name,
+		Group:              group,
+		UnlimitedQuota:     unlimitedQuota,
+		RemainQuota:        remainQuota,
+		ExpiredTime:        expiredTime,
+		AllowIPs:           allowIPs,
+		ModelLimitsEnabled: modelLimitsEnabled,
+		ModelLimits:        modelLimits,
+	}, nil
+}
+
+func parseFlexibleFloat(v any) (float64, bool) {
+	switch val := v.(type) {
+	case float64:
+		return val, true
+	case float32:
+		return float64(val), true
+	case int:
+		return float64(val), true
+	case int64:
+		return float64(val), true
+	case string:
+		s := strings.TrimSpace(val)
+		if s == "" {
+			return 0, false
+		}
+		n, err := strconv.ParseFloat(s, 64)
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func parseFlexibleEpochSeconds(v any) (int64, bool) {
+	switch val := v.(type) {
+	case float64:
+		return int64(val), true
+	case float32:
+		return int64(val), true
+	case int:
+		return int64(val), true
+	case int64:
+		return val, true
+	case string:
+		s := strings.TrimSpace(val)
+		if s == "" {
+			return 0, false
+		}
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return n, true
+		}
+		if t, err := time.Parse(time.RFC3339, s); err == nil {
+			return t.Unix(), true
+		}
+		if t, err := time.Parse("2006-01-02", s); err == nil {
+			return t.Unix(), true
+		}
+		return 0, false
+	default:
+		if n, ok := parseFlexibleFloat(v); ok {
+			return int64(n), true
+		}
+		return 0, false
+	}
+}
+
+func executeAccountTokenSync(ctx context.Context, db *sqlx.DB, cfg *config.Config, row *service.AccountWithSite) (map[string]any, error) {
+	if row == nil {
+		return nil, fmt.Errorf("账号不存在")
+	}
+	accountID := row.Account.ID
+
+	base := map[string]any{
+		"success":   true,
+		"accountId": accountID,
+		"synced":    false,
+		"created":   0,
+		"updated":   0,
+		"total":     0,
+	}
+
+	if strings.EqualFold(strings.TrimSpace(row.Site.Status), "disabled") {
+		base["status"] = "skipped"
+		base["reason"] = "site_disabled"
+		base["message"] = "站点已禁用，跳过令牌同步"
+		return base, nil
+	}
+	if service.IsAPIKeyConnection(&row.Account) {
+		base["status"] = "skipped"
+		base["reason"] = "apikey_connection"
+		base["message"] = "API Key 连接不支持同步账号令牌"
+		return base, nil
+	}
+
+	accessToken := strings.TrimSpace(row.Account.AccessToken)
+	if accessToken == "" {
+		if row.Account.APIToken != nil && strings.TrimSpace(*row.Account.APIToken) != "" {
+			if _, err := service.EnsureDefaultTokenForAccount(
+				db,
+				accountID,
+				strings.TrimSpace(*row.Account.APIToken),
+				"default",
+				"legacy",
+				"default",
+				true,
+			); err != nil {
+				return nil, err
+			}
+			base["status"] = "skipped"
+			base["reason"] = "no_access_token"
+			base["message"] = "账号缺少访问令牌，已保留本地默认令牌"
+			return base, nil
+		}
+		base["status"] = "skipped"
+		base["reason"] = "no_access_token"
+		base["message"] = "账号缺少访问令牌，无法同步站点令牌"
+		return base, nil
+	}
+
+	adapter := platform.GetAdapter(row.Site.Platform)
+	if adapter == nil {
+		base["status"] = "skipped"
+		base["reason"] = "unsupported_platform"
+		base["message"] = "不支持的平台，无法同步站点令牌: " + row.Site.Platform
+		return base, nil
+	}
+
+	callCtx := ctx
+	if callCtx == nil {
+		callCtx = context.Background()
+	}
+	if _, hasDeadline := callCtx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		callCtx, cancel = context.WithTimeout(callCtx, 15*time.Second)
+		defer cancel()
+	}
+
+	proxyCfg := service.BuildPlatformProxyConfig(cfg, &row.Account, &row.Site)
+	platformUserID := service.ResolvePlatformUserIDPtr(&row.Account)
+
+	upstreamTokens, err := service.FetchUpstreamAPITokens(
+		callCtx,
+		adapter,
+		row.Site.URL,
+		accessToken,
+		platformUserID,
+		proxyCfg,
+	)
+	if err != nil {
+		_ = service.CreateEvent(db, "token_sync", "账号令牌同步失败", err.Error(), "error", accountID, "account")
+		return nil, fmt.Errorf("同步上游令牌失败: %w", err)
+	}
+	if len(upstreamTokens) == 0 {
+		base["status"] = "skipped"
+		base["reason"] = "no_upstream_tokens"
+		base["message"] = "upstream returned no api tokens"
+		return base, nil
+	}
+
+	syncResult, syncErr := service.SyncTokensFromUpstream(db, accountID, upstreamTokens)
+	if syncErr != nil {
+		_ = service.CreateEvent(db, "token_sync", "账号令牌同步失败", syncErr.Error(), "error", accountID, "account")
+		return nil, syncErr
+	}
+
+	base["status"] = "synced"
+	base["synced"] = true
+	base["created"] = syncResult.Created
+	base["updated"] = syncResult.Updated
+	base["total"] = syncResult.Total
+	base["maskedPending"] = syncResult.MaskedPending
+	if syncResult.DefaultTokenID != nil {
+		base["defaultTokenId"] = *syncResult.DefaultTokenID
+	}
+	base["message"] = fmt.Sprintf("同步完成：新增 %d，更新 %d，合计 %d", syncResult.Created, syncResult.Updated, syncResult.Total)
+
+	_ = service.CreateEvent(
+		db,
+		"token_sync",
+		"账号令牌同步完成",
+		base["message"].(string),
+		"info",
+		accountID,
+		"account",
+	)
+	return base, nil
+}
+
+func executeSyncAllAccountTokens(ctx context.Context, db *sqlx.DB, cfg *config.Config) (map[string]int, []map[string]any) {
+	type accountIDRow struct {
+		ID int64 `db:"id"`
+	}
+	var ids []accountIDRow
+	if err := db.Select(&ids, `SELECT id FROM accounts WHERE status = 'active' ORDER BY id`); err != nil {
+		slog.Error("sync-all account tokens: list accounts failed", "err", err)
+		return map[string]int{
+			"total": 0, "synced": 0, "skipped": 0, "failed": 0, "created": 0, "updated": 0,
+		}, []map[string]any{}
+	}
+
+	summary := map[string]int{
+		"total": len(ids), "synced": 0, "skipped": 0, "failed": 0, "created": 0, "updated": 0,
+	}
+	results := make([]map[string]any, 0, len(ids))
+
+	const batchSize = 3
+	for i := 0; i < len(ids); i += batchSize {
+		end := i + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[i:end]
+
+		type batchItem struct {
+			result map[string]any
+		}
+		out := make([]batchItem, len(batch))
+		var wg sync.WaitGroup
+		for idx, item := range batch {
+			wg.Add(1)
+			go func(idx int, accountID int64) {
+				defer wg.Done()
+				row, err := service.GetAccountWithSiteByID(db, accountID)
+				if err != nil {
+					out[idx] = batchItem{result: map[string]any{
+						"success":   false,
+						"accountId": accountID,
+						"status":    "failed",
+						"reason":    "account_not_found",
+						"message":   "账号不存在",
+						"synced":    false,
+						"created":   0,
+						"updated":   0,
+						"total":     0,
+					}}
+					return
+				}
+				result, syncErr := executeAccountTokenSync(ctx, db, cfg, row)
+				if syncErr != nil {
+					out[idx] = batchItem{result: map[string]any{
+						"success":   false,
+						"accountId": accountID,
+						"status":    "failed",
+						"reason":    "sync_failed",
+						"message":   syncErr.Error(),
+						"synced":    false,
+						"created":   0,
+						"updated":   0,
+						"total":     0,
+					}}
+					return
+				}
+				out[idx] = batchItem{result: result}
+			}(idx, item.ID)
+		}
+		wg.Wait()
+
+		for _, item := range out {
+			result := item.result
+			results = append(results, result)
+			status, _ := result["status"].(string)
+			switch status {
+			case "synced":
+				summary["synced"]++
+			case "skipped":
+				summary["skipped"]++
+			default:
+				summary["failed"]++
+			}
+			if created, ok := asInt(result["created"]); ok {
+				summary["created"] += created
+			}
+			if updated, ok := asInt(result["updated"]); ok {
+				summary["updated"] += updated
+			}
+		}
+	}
+
+	return summary, results
+}
+
+func asInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	default:
+		return 0, false
+	}
 }
 
 // ---- Helper functions ----

--- a/handler/admin/account_tokens_adapter_test.go
+++ b/handler/admin/account_tokens_adapter_test.go
@@ -1,0 +1,324 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+// fakeNewAPIUpstream simulates NewAPI token endpoints used by platform.NewApiAdapter.
+type fakeNewAPIUpstream struct {
+	mu     sync.Mutex
+	tokens map[string]map[string]any // key -> item
+	nextID int
+}
+
+func newFakeNewAPIUpstream() *fakeNewAPIUpstream {
+	return &fakeNewAPIUpstream{
+		tokens: map[string]map[string]any{},
+		nextID: 1,
+	}
+}
+
+func (f *fakeNewAPIUpstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+	switch {
+	case path == "/api/status":
+		writeJSON(w, http.StatusOK, map[string]any{
+			"success": true,
+			"data":    map[string]any{"system_name": "New API"},
+		})
+		return
+	case strings.HasPrefix(path, "/api/token"):
+		f.mu.Lock()
+		defer f.mu.Unlock()
+
+		// /api/token or /api/token/ or /api/token/?p=0
+		trimmed := strings.TrimPrefix(path, "/api/token")
+		trimmed = strings.TrimPrefix(trimmed, "/")
+		if trimmed == "" {
+			switch r.Method {
+			case http.MethodGet:
+				items := make([]map[string]any, 0, len(f.tokens))
+				for _, item := range f.tokens {
+					items = append(items, item)
+				}
+				writeJSON(w, http.StatusOK, map[string]any{"success": true, "data": items})
+				return
+			case http.MethodPost:
+				var body map[string]any
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				name, _ := body["name"].(string)
+				if strings.TrimSpace(name) == "" {
+					name = "metapi"
+				}
+				group, _ := body["group"].(string)
+				key := "sk-newapi-" + strings.ReplaceAll(name, " ", "-") + "-" + itoa(int64(f.nextID))
+				item := map[string]any{
+					"id":     f.nextID,
+					"name":   name,
+					"key":    key,
+					"status": 1,
+					"group":  group,
+				}
+				f.tokens[key] = item
+				f.nextID++
+				writeJSON(w, http.StatusOK, map[string]any{"success": true, "data": item})
+				return
+			default:
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+		}
+
+		// DELETE /api/token/{id}
+		if r.Method == http.MethodDelete {
+			idStr := strings.Trim(trimmed, "/")
+			for key, item := range f.tokens {
+				if idToString(item["id"]) == idStr {
+					delete(f.tokens, key)
+					writeJSON(w, http.StatusOK, map[string]any{"success": true})
+					return
+				}
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"success": false, "message": "not found"})
+			return
+		}
+
+		// Fallback GET list for odd paths.
+		if r.Method == http.MethodGet {
+			items := make([]map[string]any, 0, len(f.tokens))
+			for _, item := range f.tokens {
+				items = append(items, item)
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"success": true, "data": items})
+			return
+		}
+		http.NotFound(w, r)
+		return
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func idToString(v any) string {
+	switch n := v.(type) {
+	case int:
+		return itoa(int64(n))
+	case int64:
+		return itoa(n)
+	case float64:
+		return itoa(int64(n))
+	default:
+		return ""
+	}
+}
+
+func tokenFixtureWithPlatform(t *testing.T, db *store.DB, name, siteURL, platform string) (int64, int64) {
+	t.Helper()
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, ?, 'active', ?, ?)`,
+		name, siteURL, platform, now, now,
+	)
+	if err != nil {
+		t.Fatalf("INSERT site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+	extraConfig := `{"credentialMode":"session","platformUserId":1}`
+	username := "42"
+	res, err = db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, status, is_pinned, sort_order,
+		 checkin_enabled, extra_config, created_at, updated_at)
+		 VALUES (?, ?, 'session-access-token', 'active', 0, 0, 1, ?, ?, ?)`,
+		siteID, &username, &extraConfig, now, now,
+	)
+	if err != nil {
+		t.Fatalf("INSERT account: %v", err)
+	}
+	accountID, _ := res.LastInsertId()
+	return siteID, accountID
+}
+
+func TestTokens_CreateUpstream_AndSync(t *testing.T) {
+	db, r := setupTokensTest(t)
+	fake := newFakeNewAPIUpstream()
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+
+	_, accountID := tokenFixtureWithPlatform(t, db, "NewAPI Site", srv.URL, "new-api")
+
+	resp := doPostJSON(t, r, "/api/account-tokens", map[string]any{
+		"accountId": accountID,
+		"name":      "from-admin",
+		"group":     "default",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("upstream create: %d %s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result["success"] != true {
+		t.Fatalf("expected success=true, got %#v", result)
+	}
+	if result["synced"] != true {
+		t.Fatalf("expected synced=true, got %#v", result)
+	}
+	if created, _ := result["created"].(float64); created < 1 {
+		t.Fatalf("expected created>=1, got %#v", result["created"])
+	}
+
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM account_tokens WHERE account_id = ?", accountID).Scan(&count); err != nil {
+		t.Fatalf("count tokens: %v", err)
+	}
+	if count < 1 {
+		t.Fatalf("expected local tokens after upstream create, got %d", count)
+	}
+}
+
+func TestTokens_SyncAccount_FromUpstream(t *testing.T) {
+	db, r := setupTokensTest(t)
+	fake := newFakeNewAPIUpstream()
+	fake.tokens["sk-remote-1"] = map[string]any{
+		"id": 1, "name": "remote-1", "key": "sk-remote-1", "status": 1, "group": "default",
+	}
+	fake.nextID = 2
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+
+	_, accountID := tokenFixtureWithPlatform(t, db, "NewAPI Sync Site", srv.URL, "new-api")
+
+	resp := doPostJSON(t, r, "/api/account-tokens/sync/"+itoa(accountID), nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("sync: %d %s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &result)
+	if result["status"] != "synced" {
+		t.Fatalf("expected status=synced, got %#v", result)
+	}
+	if created, _ := result["created"].(float64); created != 1 {
+		t.Fatalf("expected created=1, got %#v", result)
+	}
+
+	var tokenVal string
+	if err := db.QueryRow("SELECT token FROM account_tokens WHERE account_id = ? LIMIT 1", accountID).Scan(&tokenVal); err != nil {
+		t.Fatalf("read token: %v", err)
+	}
+	if tokenVal != "sk-remote-1" {
+		t.Fatalf("token = %q, want sk-remote-1", tokenVal)
+	}
+}
+
+func TestTokens_Delete_UpstreamFirst(t *testing.T) {
+	db, r := setupTokensTest(t)
+	fake := newFakeNewAPIUpstream()
+	fake.tokens["sk-delete-me"] = map[string]any{
+		"id": 9, "name": "delete-me", "key": "sk-delete-me", "status": 1, "group": "default",
+	}
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+
+	_, accountID := tokenFixtureWithPlatform(t, db, "NewAPI Delete Site", srv.URL, "new-api")
+	tokID := createTokenFixture(t, db, accountID, "delete-me", "sk-delete-me", "default", true, true)
+
+	resp := doDelete(t, r, "/api/account-tokens/"+itoa(tokID))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("delete: %d %s", resp.Code, resp.Body.String())
+	}
+
+	var count int
+	db.QueryRow("SELECT COUNT(*) FROM account_tokens WHERE id = ?", tokID).Scan(&count)
+	if count != 0 {
+		t.Fatalf("expected local token deleted, got %d", count)
+	}
+	fake.mu.Lock()
+	_, stillThere := fake.tokens["sk-delete-me"]
+	fake.mu.Unlock()
+	if stillThere {
+		t.Fatal("expected upstream token deleted")
+	}
+}
+
+func TestTokens_Delete_MaskedSkipsUpstream(t *testing.T) {
+	db, r := setupTokensTest(t)
+	fake := newFakeNewAPIUpstream()
+	fake.tokens["sk-real-but-local-masked"] = map[string]any{
+		"id": 3, "name": "masked", "key": "sk-real-but-local-masked", "status": 1,
+	}
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+
+	_, accountID := tokenFixtureWithPlatform(t, db, "NewAPI Masked Delete", srv.URL, "new-api")
+	tokID := createTokenFixture(t, db, accountID, "masked", "sk-abc***123", "", false, false)
+
+	resp := doDelete(t, r, "/api/account-tokens/"+itoa(tokID))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("delete masked: %d %s", resp.Code, resp.Body.String())
+	}
+	fake.mu.Lock()
+	if len(fake.tokens) != 1 {
+		t.Fatalf("upstream tokens should be untouched for masked local token, got %d", len(fake.tokens))
+	}
+	fake.mu.Unlock()
+}
+
+func TestTokens_SyncAll_WaitWithUpstream(t *testing.T) {
+	db, r := setupTokensTest(t)
+	fake := newFakeNewAPIUpstream()
+	fake.tokens["sk-all-1"] = map[string]any{
+		"id": 1, "name": "all-1", "key": "sk-all-1", "status": 1,
+	}
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+
+	_, _ = tokenFixtureWithPlatform(t, db, "NewAPI SyncAll", srv.URL, "new-api")
+
+	resp := doPostJSON(t, r, "/api/account-tokens/sync-all", map[string]any{"wait": true})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("sync-all: %d %s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &result)
+	summary, _ := result["summary"].(map[string]any)
+	if summary == nil {
+		t.Fatalf("missing summary: %#v", result)
+	}
+	if total, _ := summary["total"].(float64); total < 1 {
+		t.Fatalf("expected total>=1, got %#v", summary)
+	}
+	if synced, _ := summary["synced"].(float64); synced < 1 {
+		t.Fatalf("expected synced>=1, got %#v", summary)
+	}
+}
+
+func TestTokens_CreateUpstream_MissingAdapter(t *testing.T) {
+	db, r := setupTokensTest(t)
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	res, _ := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES ('NoAdapter', 'https://no-adapter.example.com', 'not-a-platform', 'active', ?, ?)`,
+		now, now,
+	)
+	siteID, _ := res.LastInsertId()
+	extra := `{"credentialMode":"session"}`
+	res, _ = db.Exec(
+		`INSERT INTO accounts (site_id, access_token, status, checkin_enabled, extra_config, created_at, updated_at)
+		 VALUES (?, 'session-token', 'active', 1, ?, ?, ?)`,
+		siteID, &extra, now, now,
+	)
+	accountID, _ := res.LastInsertId()
+
+	resp := doPostJSON(t, r, "/api/account-tokens", map[string]any{"accountId": accountID, "name": "x"})
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502 for missing adapter, got %d %s", resp.Code, resp.Body.String())
+	}
+}

--- a/handler/admin/account_tokens_test.go
+++ b/handler/admin/account_tokens_test.go
@@ -803,6 +803,7 @@ func TestTokens_SyncAccount(t *testing.T) {
 	db, r := setupTokensTest(t)
 	_, accountID := tokenFixture(t, db, r)
 
+	// Default fixture site platform is openai, which has no upstream token list.
 	resp := doPostJSON(t, r, "/api/account-tokens/sync/"+itoa(accountID), nil)
 	if resp.Code != http.StatusOK {
 		t.Fatalf("sync: %d %s", resp.Code, resp.Body.String())
@@ -814,7 +815,10 @@ func TestTokens_SyncAccount(t *testing.T) {
 		t.Error("expected success=true")
 	}
 	if result["status"] != "skipped" {
-		t.Errorf("expected status='skipped' (stub), got %v", result["status"])
+		t.Errorf("expected status='skipped', got %v", result["status"])
+	}
+	if result["reason"] != "no_upstream_tokens" && result["reason"] != "unsupported_platform" {
+		t.Errorf("expected skip reason no_upstream_tokens/unsupported_platform, got %v", result["reason"])
 	}
 }
 

--- a/service/account_token_adapter_helpers_test.go
+++ b/service/account_token_adapter_helpers_test.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tokendancelab/metapi-go/platform"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+type stubTokenAdapter struct {
+	platform.BaseAdapter
+	tokens []platform.ApiTokenInfo
+	single *string
+	err    error
+}
+
+func (s *stubTokenAdapter) PlatformName() string { return "stub-token" }
+
+func (s *stubTokenAdapter) GetAPITokens(ctx context.Context, url, accessToken string, platformUserId *int, proxy *platform.ProxyConfig) ([]platform.ApiTokenInfo, error) {
+	return s.tokens, s.err
+}
+
+func (s *stubTokenAdapter) GetAPIToken(ctx context.Context, url, accessToken string, platformUserId *int, proxy *platform.ProxyConfig) (*string, error) {
+	return s.single, s.err
+}
+
+func TestPlatformAPITokensToUpstream(t *testing.T) {
+	out := PlatformAPITokensToUpstream([]platform.ApiTokenInfo{
+		{Name: " a ", Key: " sk-1 ", Enabled: true, TokenGroup: " g "},
+		{Name: "empty", Key: "   ", Enabled: false},
+	})
+	if len(out) != 1 {
+		t.Fatalf("len=%d want 1", len(out))
+	}
+	if out[0].Key != "sk-1" || out[0].Name != "a" || out[0].TokenGroup != "g" || !out[0].Enabled {
+		t.Fatalf("unexpected conversion: %#v", out[0])
+	}
+}
+
+func TestFetchUpstreamAPITokens_FallbackToSingle(t *testing.T) {
+	single := "sk-single"
+	adp := &stubTokenAdapter{single: &single}
+	out, err := FetchUpstreamAPITokens(context.Background(), adp, "https://example.com", "session", nil, nil)
+	if err != nil {
+		t.Fatalf("FetchUpstreamAPITokens: %v", err)
+	}
+	if len(out) != 1 || out[0].Key != "sk-single" {
+		t.Fatalf("unexpected tokens: %#v", out)
+	}
+}
+
+func TestResolvePlatformUserIDPtr(t *testing.T) {
+	extra := `{"platformUserId": 99}`
+	username := "42"
+	acct := &store.Account{ExtraConfig: &extra, Username: &username}
+	id := ResolvePlatformUserIDPtr(acct)
+	if id == nil || *id != 99 {
+		t.Fatalf("expected 99 from extraConfig, got %#v", id)
+	}
+
+	acct2 := &store.Account{Username: &username}
+	id2 := ResolvePlatformUserIDPtr(acct2)
+	if id2 == nil || *id2 != 42 {
+		t.Fatalf("expected 42 from username, got %#v", id2)
+	}
+}
+
+func TestSyncTokensFromUpstream_CreatesAndUpdates(t *testing.T) {
+	db := openTestDB(t)
+	siteID := createTestSite(t, db, "SyncSite", "https://sync.example.com", "new-api")
+	accountID := createTestAccount(t, db, siteID, strPtr("u1"), "session")
+	// existing ready token should be updated, not duplicated
+	_ = createTestAccountToken(t, db, accountID, "old-name", "sk-keep", true)
+
+	result, err := SyncTokensFromUpstream(db.DB, accountID, []UpstreamAPIToken{
+		{Name: "upstream-name", Key: "sk-keep", Enabled: false, TokenGroup: "vip"},
+		{Name: "new-one", Key: "sk-new", Enabled: true, TokenGroup: "default"},
+	})
+	if err != nil {
+		t.Fatalf("SyncTokensFromUpstream: %v", err)
+	}
+	if result.Created != 1 {
+		t.Fatalf("created=%d want 1", result.Created)
+	}
+	if result.Updated != 1 {
+		t.Fatalf("updated=%d want 1", result.Updated)
+	}
+
+	var name string
+	var enabled bool
+	if err := db.QueryRow("SELECT name, enabled FROM account_tokens WHERE token = ?", "sk-keep").Scan(&name, &enabled); err != nil {
+		t.Fatalf("read kept token: %v", err)
+	}
+	// preserve operator-set name/enabled
+	if name != "old-name" {
+		t.Fatalf("name=%q want old-name", name)
+	}
+	if !enabled {
+		t.Fatalf("enabled should be preserved as true")
+	}
+}

--- a/service/account_token_service.go
+++ b/service/account_token_service.go
@@ -1,11 +1,13 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/platform"
 	"github.com/tokendancelab/metapi-go/store"
 )
 
@@ -461,6 +463,84 @@ type TokenSyncResult struct {
 	PendingTokenIDs []int64
 	Total           int
 	DefaultTokenID  *int64
+}
+
+// PlatformAPITokensToUpstream converts platform.ApiTokenInfo values to the
+// local UpstreamAPIToken shape used by SyncTokensFromUpstream.
+func PlatformAPITokensToUpstream(tokens []platform.ApiTokenInfo) []UpstreamAPIToken {
+	if len(tokens) == 0 {
+		return nil
+	}
+	out := make([]UpstreamAPIToken, 0, len(tokens))
+	for _, token := range tokens {
+		key := strings.TrimSpace(token.Key)
+		if key == "" {
+			continue
+		}
+		out = append(out, UpstreamAPIToken{
+			Name:       strings.TrimSpace(token.Name),
+			Key:        key,
+			Enabled:    token.Enabled,
+			TokenGroup: strings.TrimSpace(token.TokenGroup),
+		})
+	}
+	return out
+}
+
+// ResolvePlatformUserIDPtr returns a *int platform user id when one can be
+// resolved from account extraConfig or a numeric username.
+func ResolvePlatformUserIDPtr(account *store.Account) *int {
+	if account == nil {
+		return nil
+	}
+	if id, ok := GetPlatformUserIdFromExtraConfig(account.ExtraConfig); ok && id > 0 {
+		v := int(id)
+		return &v
+	}
+	if id := GuessPlatformUserIdFromUsername(account.Username); id > 0 {
+		v := int(id)
+		return &v
+	}
+	if id := ResolvePlatformUserID(account.ExtraConfig, account.Username); id > 0 {
+		v := int(id)
+		return &v
+	}
+	return nil
+}
+
+// FetchUpstreamAPITokens loads tokens via adapter.GetAPITokens, falling back to
+// adapter.GetAPIToken when the list endpoint returns nothing.
+func FetchUpstreamAPITokens(
+	ctx context.Context,
+	adapter platform.PlatformAdapter,
+	baseURL, accessToken string,
+	platformUserID *int,
+	proxy *platform.ProxyConfig,
+) ([]UpstreamAPIToken, error) {
+	if adapter == nil {
+		return nil, fmt.Errorf("platform adapter is nil")
+	}
+	tokens, err := adapter.GetAPITokens(ctx, baseURL, accessToken, platformUserID, proxy)
+	if err != nil {
+		return nil, err
+	}
+	if len(tokens) == 0 {
+		single, singleErr := adapter.GetAPIToken(ctx, baseURL, accessToken, platformUserID, proxy)
+		if singleErr != nil {
+			return nil, singleErr
+		}
+		if single != nil {
+			key := strings.TrimSpace(*single)
+			if key != "" {
+				tokens = []platform.ApiTokenInfo{{
+					Name:    "default",
+					Key:     key,
+					Enabled: true,
+				}}
+			}
+		}
+	}
+	return PlatformAPITokensToUpstream(tokens), nil
 }
 
 // SyncTokensFromUpstream upserts account tokens from upstream listings.


### PR DESCRIPTION
## Summary
- Wire `POST/DELETE /api/account-tokens` and sync endpoints to `platform.GetAdapter` create/list/delete APIs plus `service.SyncTokensFromUpstream`
- Upstream-first delete with documented residual for masked/redacted keys; clear skip/error paths for disabled sites, missing access tokens, and missing adapters
- Add SQLite + httptest NewAPI coverage and thin service helpers for token conversion / platform user id / fetch fallback

Closes #182

## Test plan
- [x] `go test ./handler/admin ./service -count=1 -run Token`
- [x] `go test ./handler/admin ./service -count=1`
- [x] pre-push `go vet ./...` + `go test ./... -race`