### PR TITLE
docs(progress): residual stubs milestone 12 (#194–#197)

### DIFF
--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -75,7 +75,8 @@
 | Shipped infra | Site max concurrency · per-key `proxy_url` · group route rebuild |
 | Closed F1+P1 | Full gap backlog #38–#56 (PRs #74–#94) |
 | Polish | v0.8.1 #168–#171 landed |
-| P4 adapters | Milestone 11 · **#182–#185 closed** (PRs #186/#187/#189/#190); tag **v0.8.2** |
+| P4 adapters | Milestone 11 closed · **#182–#185** · tag **[v0.8.2](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.2)** |
+| Residual stubs | Milestone 12 · issues **#194–#197** (sub2api auth / health-refresh / OAuth state / update-center) |
 | Residual CI | vulncheck green on Go 1.26.5; frontend occasional EnvironmentTeardownError flake |
 
 ### M-COMPETE notes (active)
@@ -170,7 +171,6 @@
 - **M-SCHEMA**: additive `schema_migrations` + columns `proxy_url` / `max_concurrency` / `context_length`
 
 ## Next Steps
-1. Tag **v0.8.2** (P4 adapter wave complete)
-2. Residual admin stubs: sub2api auth merge, expired API-key recovery, health-refresh job, OAuth state, update-center deploy/rollback
-3. Shared-Postgres site create flake hardening if still observed on master
-4. Continue product backlog P0/P1; frontend flake observability
+1. **Admin residual stubs v0.8.3** (milestone 12): #194 sub2api auth · #195 health-refresh · #196 OAuth state · #197 update-center/clear-cache (WFs in flight)
+2. Shared-Postgres site create flake hardening if still observed on master
+3. Continue product backlog P0/P1; frontend flake observability


### PR DESCRIPTION
## Summary
- MASTER: v0.8.2 tagged; open residual stubs wave #194–#197 under milestone 12

## Test plan
- [x] docs only