### PR TITLE
feat(admin): real account health-refresh via balance probe (#195)

### DIFF
--- a/docs/analysis/residual-health-refresh.md
+++ b/docs/analysis/residual-health-refresh.md
@@ -1,0 +1,83 @@
+# Residual: account health refresh (#195)
+
+**Date**: 2026-07-17  
+**Issue**: [#195](https://github.com/TokenDanceLab/metapi-go/issues/195)  
+**Lane**: residual accounts health
+
+## Problem
+
+`POST /api/accounts/health/refresh` previously returned success theater:
+
+- `wait=true` → empty zeroed summary / empty results (no work)
+- `wait=false` → fake `jobId: "stub-health-refresh"` with no runner
+
+## Implemented behavior
+
+Health probe is implemented by reusing the real balance-refresh path
+(`service/balance.RefreshBalance`), which already writes `extraConfig.runtimeHealth`
+(`healthy` / `unhealthy` / `disabled`, source `balance`) and updates balance fields.
+
+| Mode | Behavior |
+|------|----------|
+| `wait=true` | Synchronously refresh target account(s); return `summary` + `results` + human `message` |
+| `wait=false` | Queue in-process `StartBackgroundTask` (`type=account-runtime-health-refresh`) with real `jobId`/`taskId` and dedupe keys |
+| `accountId` set | Single-account path; 404 if missing |
+| `accountId` omitted | Batch over all account ids (`ORDER BY id`) |
+
+### Per-account outcomes
+
+| Case | `status` | Notes |
+|------|----------|-------|
+| Session-capable balance refresh OK | `success` | State usually `healthy` (or preserved checkin `degraded`) |
+| Balance refresh error | `failed` | Runtime health set by balance service to `unhealthy` when applicable |
+| Account/site disabled | `skipped` | Balance service marks `disabled` runtime health |
+| Proxy-only / API-key / OAuth | `skipped` | Honest `reason=proxy_only` — no fake success, no upstream call |
+| Unsupported platform / missing row mid-run | `failed` | No stub success |
+
+### Async tracking
+
+- Uses the existing in-memory admin task registry (`handler/admin/tasks.go`).
+- Dedupe keys:
+  - single: `refresh-account-runtime-health-{id}`
+  - batch: `refresh-all-account-runtime-health`
+- Response shape mirrors token-sync async:
+
+```json
+{
+  "success": true,
+  "queued": true,
+  "reused": false,
+  "jobId": "<hex>",
+  "taskId": "<hex>",
+  "status": "pending",
+  "message": "已开始刷新账号运行健康状态，请稍后查看账号列表"
+}
+```
+
+Task result payload (via `GET /api/tasks/:id`):
+
+```json
+{ "summary": { "...": 0 }, "results": [ { "accountId": 1, "status": "success", "state": "healthy" } ] }
+```
+
+## Residuals / honest limits
+
+1. **No durable multi-instance job store.** Task registry is process-local; multi-replica deployments do not share `jobId` state. This is intentional and matches other admin background jobs (announcement sync, account-token sync).
+2. **Probe mechanism = balance refresh only.** Model-discovery / channel probe paths are not invoked here. Proxy-only accounts remain skipped (TS parity: no session balance probe).
+3. **No separate model-health probe for API keys.** If product later needs API-key runtime health via model list, that is a new residual outside #195.
+4. **Batch wait mode is sequential** per account (simple correctness over fan-out). Large fleets may prefer async mode.
+5. **UI currently calls without `wait`** (`api.refreshAccountHealth()`), so operators see toast + list reload; detailed summary is available when callers pass `wait: true` or poll `/api/tasks/:id`.
+
+## Tests
+
+```bash
+go test ./handler/admin -count=1 -run Health
+```
+
+Coverage:
+
+- sync batch: session success + apikey skip + persisted runtimeHealth/balance
+- single `accountId` wait path
+- missing `accountId` → 404
+- async real `jobId` (not `stub-health-refresh`) + runner completion
+- async dedupe reuse

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -1127,6 +1127,29 @@ func (h *accountsHandler) batchAccounts(w http.ResponseWriter, r *http.Request) 
 
 // ---- Health Refresh ----
 
+// healthRefreshResultItem is one account outcome from POST /api/accounts/health/refresh.
+type healthRefreshResultItem struct {
+	AccountID int64  `json:"accountId"`
+	Status    string `json:"status"` // success | failed | skipped
+	State     string `json:"state"`
+	Reason    string `json:"reason,omitempty"`
+	Message   string `json:"message,omitempty"`
+	ProxyOnly bool   `json:"proxyOnly,omitempty"`
+}
+
+// healthRefreshSummary aggregates wait-mode / background-task results.
+type healthRefreshSummary struct {
+	Total     int `json:"total"`
+	Healthy   int `json:"healthy"`
+	Unhealthy int `json:"unhealthy"`
+	Degraded  int `json:"degraded"`
+	Disabled  int `json:"disabled"`
+	Unknown   int `json:"unknown"`
+	Success   int `json:"success"`
+	Failed    int `json:"failed"`
+	Skipped   int `json:"skipped"`
+}
+
 func (h *accountsHandler) healthRefresh(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountHealthRefreshPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
@@ -1136,28 +1159,239 @@ func (h *accountsHandler) healthRefresh(w http.ResponseWriter, r *http.Request) 
 
 	wait := body.Wait != nil && *body.Wait
 
+	var accountIDs []int64
+	if body.AccountID != nil {
+		if *body.AccountID <= 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "error": "Invalid accountId. Expected positive number."})
+			return
+		}
+		accountID := int64(*body.AccountID)
+		if _, err := service.GetAccountWithSiteByID(h.db, accountID); err != nil {
+			writeJSON(w, http.StatusNotFound, map[string]any{"success": false, "message": "account not found"})
+			return
+		}
+		accountIDs = []int64{accountID}
+	} else {
+		ids, err := listAccountIDsForHealthRefresh(h.db)
+		if err != nil {
+			slog.Error("Failed to list accounts for health refresh", "err", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "error": "Failed to list accounts"})
+			return
+		}
+		accountIDs = ids
+	}
+
 	if wait {
-		// Stub: sync health refresh
+		summary, results := h.runAccountHealthRefresh(accountIDs)
+		globalAccountsCache.clear()
 		writeJSON(w, http.StatusOK, map[string]any{
 			"success": true,
-			"summary": map[string]int{
-				"total": 0, "healthy": 0, "unhealthy": 0,
-				"degraded": 0, "disabled": 0, "unknown": 0,
-				"success": 0, "failed": 0, "skipped": 0,
-			},
-			"results": []any{},
+			"summary": summary,
+			"results": results,
+			"message": formatHealthRefreshMessage(summary),
 		})
 		return
 	}
 
-	// Background task (stub)
+	// Async path: in-process task registry (no durable multi-instance job store).
+	title := "刷新账号运行健康状态"
+	dedupeKey := "refresh-all-account-runtime-health"
+	if body.AccountID != nil {
+		title = fmt.Sprintf("刷新账号 #%d 运行健康状态", *body.AccountID)
+		dedupeKey = fmt.Sprintf("refresh-account-runtime-health-%d", *body.AccountID)
+	}
+
+	ids := append([]int64(nil), accountIDs...)
+	db := h.db
+	cfg := h.cfg
+	task, reused := StartBackgroundTask(BackgroundTaskStartOptions{
+		Type:      "account-runtime-health-refresh",
+		Title:     title,
+		DedupeKey: dedupeKey,
+	}, func() (any, error) {
+		handler := &accountsHandler{db: db, cfg: cfg}
+		summary, results := handler.runAccountHealthRefresh(ids)
+		globalAccountsCache.clear()
+		return map[string]any{
+			"summary": summary,
+			"results": results,
+		}, nil
+	})
+
 	writeJSON(w, http.StatusAccepted, map[string]any{
 		"success": true,
 		"queued":  true,
-		"jobId":   "stub-health-refresh",
-		"status":  "pending",
+		"reused":  reused,
+		"jobId":   task.ID,
+		"taskId":  task.ID,
+		"status":  string(task.Status),
 		"message": "已开始刷新账号运行健康状态，请稍后查看账号列表",
 	})
+}
+
+func listAccountIDsForHealthRefresh(db *sqlx.DB) ([]int64, error) {
+	var ids []int64
+	if err := db.Select(&ids, "SELECT id FROM accounts ORDER BY id"); err != nil {
+		return nil, err
+	}
+	if ids == nil {
+		ids = []int64{}
+	}
+	return ids, nil
+}
+
+func (h *accountsHandler) runAccountHealthRefresh(accountIDs []int64) (healthRefreshSummary, []healthRefreshResultItem) {
+	results := make([]healthRefreshResultItem, 0, len(accountIDs))
+	summary := healthRefreshSummary{}
+
+	for _, accountID := range accountIDs {
+		item := h.refreshOneAccountHealth(accountID)
+		results = append(results, item)
+		summary.Total++
+		switch item.Status {
+		case "success":
+			summary.Success++
+		case "failed":
+			summary.Failed++
+		default:
+			summary.Skipped++
+		}
+		switch service.RuntimeHealthState(item.State) {
+		case service.HealthHealthy:
+			summary.Healthy++
+		case service.HealthUnhealthy:
+			summary.Unhealthy++
+		case service.HealthDegraded:
+			summary.Degraded++
+		case service.HealthDisabled:
+			summary.Disabled++
+		default:
+			summary.Unknown++
+		}
+	}
+
+	if results == nil {
+		results = []healthRefreshResultItem{}
+	}
+	return summary, results
+}
+
+func (h *accountsHandler) refreshOneAccountHealth(accountID int64) healthRefreshResultItem {
+	row, err := service.GetAccountWithSiteByID(h.db, accountID)
+	if err != nil {
+		return healthRefreshResultItem{
+			AccountID: accountID,
+			Status:    "failed",
+			State:     string(service.HealthUnknown),
+			Reason:    "account not found",
+			Message:   "account not found",
+		}
+	}
+
+	caps := service.BuildCapabilitiesForAccount(&row.Account)
+	sessionCapable := caps.CanRefreshBalance
+
+	// proxy-only / OAuth / pure API-key: no balance probe path — honest skip.
+	if caps.ProxyOnly || !caps.CanRefreshBalance || service.IsAPIKeyConnection(&row.Account) {
+		health := service.BuildRuntimeHealthForAccount(service.RuntimeHealthInput{
+			AccountStatus:  row.Account.Status,
+			SiteStatus:     row.Site.Status,
+			ExtraConfig:    row.Account.ExtraConfig,
+			SessionCapable: &sessionCapable,
+			OAuthProvider:  row.Account.OAuthProvider,
+		})
+		return healthRefreshResultItem{
+			AccountID: accountID,
+			Status:    "skipped",
+			State:     string(health.State),
+			Reason:    "proxy_only",
+			Message:   "proxy-only account skipped runtime balance probe",
+			ProxyOnly: true,
+		}
+	}
+
+	result, refreshErr := balanceService.RefreshBalance(h.cfg, h.db, accountID)
+
+	// Re-read after refresh so state reflects persisted runtimeHealth / status.
+	if updated, loadErr := service.GetAccountWithSiteByID(h.db, accountID); loadErr == nil {
+		row = updated
+	}
+	sessionCapable = service.BuildCapabilitiesForAccount(&row.Account).CanRefreshBalance
+	health := service.BuildRuntimeHealthForAccount(service.RuntimeHealthInput{
+		AccountStatus:  row.Account.Status,
+		SiteStatus:     row.Site.Status,
+		ExtraConfig:    row.Account.ExtraConfig,
+		SessionCapable: &sessionCapable,
+		OAuthProvider:  row.Account.OAuthProvider,
+	})
+
+	if result == nil && refreshErr == nil {
+		return healthRefreshResultItem{
+			AccountID: accountID,
+			Status:    "failed",
+			State:     string(service.HealthUnknown),
+			Reason:    "account not found or platform not supported",
+			Message:   "account not found or platform not supported",
+		}
+	}
+	if refreshErr != nil {
+		state := string(health.State)
+		if state == "" || state == string(service.HealthUnknown) {
+			state = string(service.HealthUnhealthy)
+		}
+		reason := health.Reason
+		if reason == "" {
+			reason = refreshErr.Error()
+		}
+		return healthRefreshResultItem{
+			AccountID: accountID,
+			Status:    "failed",
+			State:     state,
+			Reason:    reason,
+			Message:   refreshErr.Error(),
+		}
+	}
+	if result.Skipped {
+		state := string(health.State)
+		if state == "" {
+			state = string(service.HealthUnknown)
+		}
+		reason := result.Reason
+		if reason == "" {
+			reason = health.Reason
+		}
+		return healthRefreshResultItem{
+			AccountID: accountID,
+			Status:    "skipped",
+			State:     state,
+			Reason:    reason,
+			Message:   reason,
+			ProxyOnly: reason == "proxy_only",
+		}
+	}
+
+	state := string(health.State)
+	if state == "" {
+		state = string(service.HealthHealthy)
+	}
+	reason := health.Reason
+	if reason == "" {
+		reason = "余额刷新成功"
+	}
+	return healthRefreshResultItem{
+		AccountID: accountID,
+		Status:    "success",
+		State:     state,
+		Reason:    reason,
+		Message:   reason,
+	}
+}
+
+func formatHealthRefreshMessage(summary healthRefreshSummary) string {
+	return fmt.Sprintf(
+		"账号健康刷新完成：成功 %d，失败 %d，跳过 %d（共 %d）",
+		summary.Success, summary.Failed, summary.Skipped, summary.Total,
+	)
 }
 
 // ---- Refresh Balance ----

--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -1764,7 +1764,38 @@ func TestAccounts_Batch_PartialFailure(t *testing.T) {
 // ---- Health Refresh ----
 
 func TestAccounts_HealthRefresh_Sync(t *testing.T) {
-	_, r, _ := setupAccountsTest(t)
+	db, r, _ := setupAccountsTest(t)
+	calls := 0
+	server := newAnyRouterBalanceServer(t, &calls)
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	siteID := insertAnyRouterBalanceSite(t, db, server.URL, now)
+
+	// Session-capable account (balance probe path).
+	accRes, err := db.Exec(
+		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, ?, 'active', 1, ?, ?)",
+		siteID, "anyrouter-user", "session-token", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert session account: %v", err)
+	}
+	accountID, err := accRes.LastInsertId()
+	if err != nil {
+		t.Fatalf("session account LastInsertId: %v", err)
+	}
+
+	// proxy-only apikey on same site should be skipped honestly
+	apiKeyRes, err := db.Exec(
+		"INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, ?, 'active', 0, ?, ?, ?)",
+		siteID, nil, "anyrouter-api-key-token", "anyrouter-api-key-token", `{"credentialMode":"apikey"}`, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert apikey account: %v", err)
+	}
+	apiKeyAccountID, err := apiKeyRes.LastInsertId()
+	if err != nil {
+		t.Fatalf("apikey account LastInsertId: %v", err)
+	}
+
 	body := map[string]any{"wait": true}
 	resp := doPostJSON(t, r, "/api/accounts/health/refresh", body)
 	if resp.Code != http.StatusOK {
@@ -1772,27 +1803,236 @@ func TestAccounts_HealthRefresh_Sync(t *testing.T) {
 	}
 
 	var result map[string]any
-	json.Unmarshal(resp.Body.Bytes(), &result)
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
 	if result["success"] != true {
 		t.Error("expected success=true")
+	}
+	summary, _ := result["summary"].(map[string]any)
+	if summary == nil {
+		t.Fatalf("summary missing: %#v", result)
+	}
+	if summary["total"] != float64(2) {
+		t.Fatalf("summary.total = %v, want 2", summary["total"])
+	}
+	if summary["success"] != float64(1) {
+		t.Fatalf("summary.success = %v, want 1", summary["success"])
+	}
+	if summary["skipped"] != float64(1) {
+		t.Fatalf("summary.skipped = %v, want 1", summary["skipped"])
+	}
+	if summary["healthy"] != float64(1) {
+		t.Fatalf("summary.healthy = %v, want 1", summary["healthy"])
+	}
+	if calls < 2 {
+		t.Fatalf("upstream calls = %d, want discovery plus balance fetch", calls)
+	}
+
+	results, _ := result["results"].([]any)
+	if len(results) != 2 {
+		t.Fatalf("results len = %d, want 2", len(results))
+	}
+	byID := map[int64]map[string]any{}
+	for _, raw := range results {
+		item, _ := raw.(map[string]any)
+		byID[int64(item["accountId"].(float64))] = item
+	}
+	sessionItem := byID[accountID]
+	if sessionItem == nil || sessionItem["status"] != "success" {
+		t.Fatalf("session item = %#v, want success", sessionItem)
+	}
+	if sessionItem["state"] != "healthy" {
+		t.Fatalf("session state = %v, want healthy", sessionItem["state"])
+	}
+	apiKeyItem := byID[apiKeyAccountID]
+	if apiKeyItem == nil || apiKeyItem["status"] != "skipped" {
+		t.Fatalf("apikey item = %#v, want skipped", apiKeyItem)
+	}
+	if apiKeyItem["reason"] != "proxy_only" {
+		t.Fatalf("apikey reason = %v, want proxy_only", apiKeyItem["reason"])
+	}
+
+	// Balance + runtimeHealth should be persisted for the session account.
+	var balance float64
+	var extraConfig *string
+	if err := db.QueryRow("SELECT balance, extra_config FROM accounts WHERE id = ?", accountID).Scan(&balance, &extraConfig); err != nil {
+		t.Fatalf("read refreshed account: %v", err)
+	}
+	if balance != 2 {
+		t.Fatalf("balance = %v, want 2", balance)
+	}
+	if extraConfig == nil || !strings.Contains(*extraConfig, `"state":"healthy"`) {
+		t.Fatalf("extra_config = %v, want healthy runtimeHealth", extraConfig)
+	}
+}
+
+func TestAccounts_HealthRefresh_SingleAccountID(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	calls := 0
+	server := newAnyRouterBalanceServer(t, &calls)
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	siteID := insertAnyRouterBalanceSite(t, db, server.URL, now)
+
+	accRes, err := db.Exec(
+		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, ?, 'active', 1, ?, ?)",
+		siteID, "anyrouter-user", "session-token", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert session account: %v", err)
+	}
+	accountID, err := accRes.LastInsertId()
+	if err != nil {
+		t.Fatalf("session account LastInsertId: %v", err)
+	}
+	// Second account on same site is intentionally not targeted by accountId.
+	if _, err := db.Exec(
+		"INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, ?, 'active', 0, ?, ?, ?)",
+		siteID, nil, "anyrouter-api-key-token", "anyrouter-api-key-token", `{"credentialMode":"apikey"}`, now, now,
+	); err != nil {
+		t.Fatalf("insert other apikey account: %v", err)
+	}
+
+	body := map[string]any{"wait": true, "accountId": accountID}
+	resp := doPostJSON(t, r, "/api/accounts/health/refresh", body)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("health refresh single: %d %s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	summary, _ := result["summary"].(map[string]any)
+	if summary["total"] != float64(1) {
+		t.Fatalf("summary.total = %v, want 1", summary["total"])
+	}
+	if summary["success"] != float64(1) {
+		t.Fatalf("summary.success = %v, want 1", summary["success"])
+	}
+	results, _ := result["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	item, _ := results[0].(map[string]any)
+	if int64(item["accountId"].(float64)) != accountID {
+		t.Fatalf("accountId = %v, want %d", item["accountId"], accountID)
+	}
+	if item["status"] != "success" {
+		t.Fatalf("status = %v, want success", item["status"])
+	}
+	if calls < 2 {
+		t.Fatalf("upstream calls = %d, want discovery plus balance fetch", calls)
+	}
+}
+
+func TestAccounts_HealthRefresh_SingleAccountNotFound(t *testing.T) {
+	_, r, _ := setupAccountsTest(t)
+	resp := doPostJSON(t, r, "/api/accounts/health/refresh", map[string]any{
+		"wait":      true,
+		"accountId": 99999,
+	})
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%s", resp.Code, resp.Body.String())
 	}
 }
 
 func TestAccounts_HealthRefresh_Background(t *testing.T) {
-	_, r, _ := setupAccountsTest(t)
-	body := map[string]any{"wait": false}
+	resetBackgroundTasksForTests()
+	t.Cleanup(resetBackgroundTasksForTests)
+
+	db, r, _ := setupAccountsTest(t)
+	calls := 0
+	server := newAnyRouterBalanceServer(t, &calls)
+	_, accountID := setupAnyRouterBalanceAccount(t, db, server.URL)
+
+	body := map[string]any{"wait": false, "accountId": accountID}
 	resp := doPostJSON(t, r, "/api/accounts/health/refresh", body)
 	if resp.Code != http.StatusAccepted {
-		t.Fatalf("health refresh bg: expected 202, got %d", resp.Code)
+		t.Fatalf("health refresh bg: expected 202, got %d body=%s", resp.Code, resp.Body.String())
 	}
 
 	var result map[string]any
-	json.Unmarshal(resp.Body.Bytes(), &result)
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
 	if result["queued"] != true {
 		t.Error("expected queued=true")
 	}
-	if result["jobId"] == nil {
-		t.Error("expected jobId")
+	jobID, _ := result["jobId"].(string)
+	if jobID == "" || jobID == "stub-health-refresh" {
+		t.Fatalf("jobId = %q, want real in-process task id", jobID)
+	}
+	if result["taskId"] != jobID {
+		t.Fatalf("taskId = %v, want same as jobId %q", result["taskId"], jobID)
+	}
+
+	// Wait for background runner to finish and persist runtime health.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		task := getBackgroundTask(jobID)
+		if task != nil && (task.Status == BackgroundTaskSucceeded || task.Status == BackgroundTaskFailed) {
+			if task.Status != BackgroundTaskSucceeded {
+				t.Fatalf("background task status = %s error=%v", task.Status, task.Error)
+			}
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	task := getBackgroundTask(jobID)
+	if task == nil || task.Status != BackgroundTaskSucceeded {
+		t.Fatalf("background task did not succeed: %#v", task)
+	}
+
+	var balance float64
+	var extraConfig *string
+	if err := db.QueryRow("SELECT balance, extra_config FROM accounts WHERE id = ?", accountID).Scan(&balance, &extraConfig); err != nil {
+		t.Fatalf("read refreshed account: %v", err)
+	}
+	if balance != 2 {
+		t.Fatalf("balance = %v, want 2 after async health refresh", balance)
+	}
+	if extraConfig == nil || !strings.Contains(*extraConfig, `"state":"healthy"`) {
+		t.Fatalf("extra_config = %v, want healthy runtimeHealth after async refresh", extraConfig)
+	}
+	if calls < 2 {
+		t.Fatalf("upstream calls = %d, want discovery plus balance fetch", calls)
+	}
+}
+
+func TestAccounts_HealthRefresh_BackgroundDedupe(t *testing.T) {
+	resetBackgroundTasksForTests()
+	t.Cleanup(resetBackgroundTasksForTests)
+
+	db, r, _ := setupAccountsTest(t)
+	// Slow-ish upstream is unnecessary; empty batch still exercises registry.
+	// Use a session account so the runner has real work if it runs twice.
+	calls := 0
+	server := newAnyRouterBalanceServer(t, &calls)
+	_, accountID := setupAnyRouterBalanceAccount(t, db, server.URL)
+
+	body := map[string]any{"wait": false, "accountId": accountID}
+	first := doPostJSON(t, r, "/api/accounts/health/refresh", body)
+	if first.Code != http.StatusAccepted {
+		t.Fatalf("first bg refresh: %d %s", first.Code, first.Body.String())
+	}
+	var firstResult map[string]any
+	json.Unmarshal(first.Body.Bytes(), &firstResult)
+	jobID, _ := firstResult["jobId"].(string)
+	if jobID == "" {
+		t.Fatal("first jobId empty")
+	}
+
+	second := doPostJSON(t, r, "/api/accounts/health/refresh", body)
+	if second.Code != http.StatusAccepted {
+		t.Fatalf("second bg refresh: %d %s", second.Code, second.Body.String())
+	}
+	var secondResult map[string]any
+	json.Unmarshal(second.Body.Bytes(), &secondResult)
+	if secondResult["reused"] != true {
+		t.Fatalf("reused = %v, want true for concurrent dedupe", secondResult["reused"])
+	}
+	if secondResult["jobId"] != jobID {
+		t.Fatalf("second jobId = %v, want %q", secondResult["jobId"], jobID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace `POST /api/accounts/health/refresh` stub (`jobId: stub-health-refresh` / empty wait summary) with real balance-based runtime health refresh.
- Single-account and batch paths; wait mode returns summary+results; async uses in-process task registry with real `jobId`/`taskId` and dedupe keys.
- Proxy-only / API-key accounts are honestly skipped (`reason=proxy_only`); residual documented in `docs/analysis/residual-health-refresh.md`.

## Test plan
- [x] `go test ./handler/admin -count=1 -run HealthRefresh`
- [ ] Manual: wait=true on session account updates balance + runtimeHealth
- [ ] Manual: wait=false returns non-stub jobId; `GET /api/tasks/:id` shows result

Closes #195