### PR TITLE
fix(oauth): real CSRF state tokens for start/rebind (#196)

### DIFF
--- a/docs/analysis/residual-oauth-state.md
+++ b/docs/analysis/residual-oauth-state.md
@@ -1,0 +1,42 @@
+# Residual: OAuth state + rebind CSRF tokens (#196)
+
+**Date**: 2026-07-17  
+**Issue**: [#196](https://github.com/TokenDanceLab/metapi-go/issues/196)  
+**Lane**: residual OAuth security
+
+## Scope landed
+
+Admin OAuth start/rebind no longer returns fixed `stub-state` / `stub-rebind` strings.
+
+| Endpoint | Behavior |
+|----------|----------|
+| `POST /api/oauth/providers/{provider}/start` | `service/oauth.StartFlow` creates a cryptographically random base64url state (24 bytes) + PKCE verifier, stored in the in-memory session store with **10-minute TTL** |
+| `POST /api/oauth/connections/{accountId}/rebind` | `service/oauth.StartOauthRebindFlow` → same `StartFlow` path with `RebindAccountID` |
+| `GET /api/oauth/sessions/{state}` | Looks up server-stored session; **404** when missing/expired |
+| `POST /api/oauth/sessions/{state}/manual-callback` | Rejects unknown state (**404**); rejects callback URL whose `state` query ≠ path state (**400 state mismatch**) |
+
+State generation and TTL live in `service/oauth/session.go` (`MemoryOAuthSessionStore`, `sessionTTL = 10m`). Validation for manual callback lives in `service/oauth.SubmitManualCallback`.
+
+## Residuals / honest limits
+
+1. **In-memory session store only** — state is process-local. Multi-instance / restart loses pending flows. No Redis/shared store yet (see `docs/analysis/redis-shared-state.md` if/when multi-node is required).
+2. **Provider matrix still incomplete for production credentials** — Antigravity still uses placeholder client credentials in `service/oauth/antigravity.go`; Gemini CLI / Claude / Codex require env client IDs/secrets. State CSRF is fixed independently of provider credential completeness.
+3. **Admin loopback callback HTML** (`GET /api/oauth/callback/{provider}`) remains a browser close helper; real code exchange runs via provider loopback servers + `HandleCallback` / manual-callback, not this HTML route.
+4. **Other OAuth admin stubs** (proxy update, delete connection, quota refresh, import, route-units mutations) are out of scope for #196 and may still be stubs.
+5. **Token encryption at rest** remains an open shared gap (see `docs/specs/review/audits/audit-oauth.md`).
+
+## Tests
+
+`handler/admin/oauth_routes_test.go`:
+
+- start issues non-stub, distinct crypto-random states
+- getSession validates known vs unknown state
+- manual-callback rejects state mismatch and unknown state
+- rebind issues non-stub random state bound to an OAuth account
+- unknown provider → 404
+
+Verify:
+
+```bash
+go test ./handler/admin ./service/oauth -count=1 -run OAuth
+```

--- a/handler/admin/oauth_routes.go
+++ b/handler/admin/oauth_routes.go
@@ -3,13 +3,17 @@ package admin
 import (
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/service/oauth"
 )
 
 // RegisterOauthRoutes registers all /api/oauth routes.
-// These stub endpoints delegate to the P6 OAuth service implementation.
+// Start/rebind issue cryptographically random server-stored state tokens (TTL 10m);
+// session lookup and manual callback validate that state.
 func RegisterOauthRoutes(r chi.Router, db *sqlx.DB) {
 	handler := &oauthHandler{db: db}
 
@@ -36,31 +40,136 @@ type oauthHandler struct {
 
 // GET /api/oauth/providers
 func (h *oauthHandler) listProviders(w http.ResponseWriter, r *http.Request) {
+	providers := oauth.ListOauthProviders()
+	systemProxyConfigured := false
+	if cfg := oauthSafeConfig(); cfg != nil {
+		systemProxyConfigured = strings.TrimSpace(cfg.SystemProxyUrl) != ""
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"defaults":  []any{},
-		"providers": []any{},
+		"providers": providers,
+		"defaults": map[string]any{
+			"systemProxyConfigured": systemProxyConfigured,
+		},
 	})
+}
+
+type oauthStartBody struct {
+	AccountID      *int64  `json:"accountId,omitempty"`
+	ProjectID      *string `json:"projectId,omitempty"`
+	ProxyURL       *string `json:"proxyUrl,omitempty"`
+	UseSystemProxy *bool   `json:"useSystemProxy,omitempty"`
 }
 
 // POST /api/oauth/providers/:provider/start
 func (h *oauthHandler) startProviderFlow(w http.ResponseWriter, r *http.Request) {
-	provider := chi.URLParam(r, "provider")
+	provider := strings.TrimSpace(chi.URLParam(r, "provider"))
+	if provider == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"message": "provider is required"})
+		return
+	}
+
+	body, ok := decodeOptionalOAuthStartBody(w, r)
+	if !ok {
+		return
+	}
+
+	input := oauth.StartFlowInput{
+		Provider:      provider,
+		RequestOrigin: requestOrigin(r),
+	}
+	if body.AccountID != nil && *body.AccountID > 0 {
+		input.RebindAccountID = *body.AccountID
+	}
+	if body.ProjectID != nil {
+		input.ProjectID = strings.TrimSpace(*body.ProjectID)
+	}
+	if body.ProxyURL != nil {
+		input.ProxyURL = strings.TrimSpace(*body.ProxyURL)
+	}
+	if body.UseSystemProxy != nil {
+		input.UseSystemProxy = *body.UseSystemProxy
+	}
+
+	result, err := oauth.StartFlow(input)
+	if err != nil {
+		status := http.StatusBadRequest
+		msg := err.Error()
+		if strings.Contains(msg, "unsupported oauth provider") {
+			status = http.StatusNotFound
+		}
+		writeJSON(w, status, map[string]any{"message": msg})
+		return
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{
-		"state":     "stub-state",
-		"authUrl":   "",
-		"provider":  provider,
+		"provider":         result.Provider,
+		"state":            result.State,
+		"authorizationUrl": result.AuthorizationURL,
+		"instructions":     result.Instructions,
 	})
 }
 
 // GET /api/oauth/sessions/:state
 func (h *oauthHandler) getSession(w http.ResponseWriter, r *http.Request) {
-	state := chi.URLParam(r, "state")
-	_ = state
-	writeJSON(w, http.StatusNotFound, map[string]any{"message": "oauth session not found"})
+	state := strings.TrimSpace(chi.URLParam(r, "state"))
+	if state == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"message": "state is required"})
+		return
+	}
+
+	status := oauth.GetSessionStatus(state)
+	if status == nil {
+		writeJSON(w, http.StatusNotFound, map[string]any{"message": "oauth session not found"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, status)
 }
 
 // POST /api/oauth/sessions/:state/manual-callback
 func (h *oauthHandler) manualCallback(w http.ResponseWriter, r *http.Request) {
+	state := strings.TrimSpace(chi.URLParam(r, "state"))
+	if state == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"message": "state is required"})
+		return
+	}
+
+	var body struct {
+		CallbackURL string `json:"callbackUrl"`
+	}
+	if err := decodeJSONRequest(r, &body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"message": "invalid request body"})
+		return
+	}
+	callbackURL := strings.TrimSpace(body.CallbackURL)
+	if callbackURL == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"message": "callbackUrl is required"})
+		return
+	}
+
+	// Reject unknown / expired state before parsing callback content further.
+	if oauth.GetSession(state) == nil {
+		writeJSON(w, http.StatusNotFound, map[string]any{"message": "oauth session not found"})
+		return
+	}
+
+	err := oauth.SubmitManualCallback(oauth.ManualCallbackInput{
+		State:       state,
+		CallbackURL: callbackURL,
+	})
+	if err != nil {
+		msg := err.Error()
+		status := http.StatusBadRequest
+		switch {
+		case strings.Contains(msg, "oauth session not found"):
+			status = http.StatusNotFound
+		case strings.Contains(msg, "state mismatch"):
+			status = http.StatusBadRequest
+		}
+		writeJSON(w, status, map[string]any{"message": msg})
+		return
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})
 }
 
@@ -77,7 +186,22 @@ func (h *oauthHandler) listConnections(w http.ResponseWriter, r *http.Request) {
 		offset = o
 	}
 
-	// Query accounts with oauth_provider set
+	// Prefer service implementation when the global DB is available; fall back to
+	// the handler's injected *sqlx.DB for tests that only wire the chi handler.
+	if result, err := oauth.ListOauthConnections(oauth.ListConnectionsInput{
+		Limit:  limit,
+		Offset: offset,
+	}); err == nil && result != nil {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"connections": result.Items,
+			"items":       result.Items,
+			"total":       result.Total,
+			"limit":       result.Limit,
+			"offset":      result.Offset,
+		})
+		return
+	}
+
 	rows := queryRows(h.db,
 		`SELECT a.*, s.name as site_name, s.platform as site_platform
 		 FROM accounts a
@@ -100,10 +224,29 @@ func (h *oauthHandler) rebindConnection(w http.ResponseWriter, r *http.Request) 
 		writeJSON(w, http.StatusBadRequest, map[string]any{"message": "invalid account id"})
 		return
 	}
+
+	body, ok := decodeOptionalOAuthStartBody(w, r)
+	if !ok {
+		return
+	}
+
+	result, err := oauth.StartOauthRebindFlow(id, requestOrigin(r), body.ProxyURL, body.UseSystemProxy)
+	if err != nil {
+		msg := err.Error()
+		status := http.StatusBadRequest
+		if strings.Contains(msg, "not found") || strings.Contains(msg, "not managed by oauth") {
+			status = http.StatusNotFound
+		}
+		writeJSON(w, status, map[string]any{"message": msg})
+		return
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{
-		"state":    "stub-rebind",
-		"authUrl":  "",
-		"accountId": id,
+		"provider":         result.Provider,
+		"state":            result.State,
+		"authorizationUrl": result.AuthorizationURL,
+		"instructions":     result.Instructions,
+		"accountId":        id,
 	})
 }
 
@@ -148,6 +291,9 @@ func (h *oauthHandler) deleteRouteUnit(w http.ResponseWriter, r *http.Request) {
 }
 
 // GET /api/oauth/callback/:provider
+// Loopback providers use their own callback servers; this admin callback surface
+// only acknowledges the browser redirect and relies on session state already
+// issued by start/rebind (validated on getSession / manual-callback).
 func (h *oauthHandler) callback(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
@@ -159,4 +305,45 @@ func (h *oauthHandler) callback(w http.ResponseWriter, r *http.Request) {
     OAuth authorization succeeded. You can close this window.
   </body>
 </html>`))
+}
+
+func requestOrigin(r *http.Request) string {
+	if origin := strings.TrimSpace(r.Header.Get("Origin")); origin != "" {
+		return origin
+	}
+	if referer := strings.TrimSpace(r.Header.Get("Referer")); referer != "" {
+		return referer
+	}
+	return ""
+}
+
+func oauthSafeConfig() *config.Config {
+	defer func() { _ = recover() }()
+	return config.Get()
+}
+
+// decodeOptionalOAuthStartBody accepts missing/empty bodies as {}.
+// Malformed non-empty JSON is rejected with 400.
+func decodeOptionalOAuthStartBody(w http.ResponseWriter, r *http.Request) (oauthStartBody, bool) {
+	var body oauthStartBody
+	if r.Body == nil || r.Body == http.NoBody {
+		return body, true
+	}
+	if err := decodeJSONRequest(r, &body); err != nil {
+		if isEmptyJSONBodyError(err) {
+			return oauthStartBody{}, true
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]any{"message": "invalid request body"})
+		return oauthStartBody{}, false
+	}
+	return body, true
+}
+
+func isEmptyJSONBodyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "EOF") ||
+		strings.Contains(msg, "unexpected end of JSON input")
 }

--- a/handler/admin/oauth_routes_test.go
+++ b/handler/admin/oauth_routes_test.go
@@ -1,0 +1,285 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/service/oauth"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func setupOAuthRoutesTest(t *testing.T) (*store.DB, chi.Router) {
+	t.Helper()
+
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		store.OverrideDB(nil)
+		db.Close()
+	})
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	store.OverrideDB(db)
+
+	// Isolate session store per test so state cannot leak across cases.
+	sessionStore := oauth.NewMemoryOAuthSessionStore()
+	oauth.SetSessionStore(sessionStore)
+	t.Cleanup(func() {
+		oauth.SetSessionStore(oauth.NewMemoryOAuthSessionStore())
+	})
+
+	// Clear loopback callback failure state for codex so StartFlow succeeds.
+	// StartFlow only fails when Attempted && !Ready; absence is fine.
+	config.Set(&config.Config{
+		SystemProxyUrl: "",
+		// Provider client IDs are required by BuildAuthorizationURL for some providers.
+		// Codex/Claude may panic if missing; tests use codex which needs CODEX_CLIENT_ID.
+		// Provide a non-empty placeholder so URL construction can proceed.
+		CodexClientId:  "test-codex-client",
+		ClaudeClientId: "test-claude-client",
+	})
+
+	r := chi.NewRouter()
+	RegisterOauthRoutes(r, db.DB)
+	return db, r
+}
+
+func insertOAuthAccount(t *testing.T, db *store.DB, provider string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, use_system_proxy, is_pinned, global_weight, sort_order, created_at, updated_at)
+		 VALUES (?, ?, ?, 'active', 0, 0, 1, 0, ?, ?)`,
+		"Codex OAuth Test", "https://chatgpt.com/backend-api", provider, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+
+	extra := `{"oauth":{"provider":"` + provider + `","accountId":"acc-1","accountKey":"acc-1","email":"user@example.com","refreshToken":"rt-test"}}`
+	res, err = db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, checkin_enabled, status, oauth_provider, oauth_account_key, extra_config, is_pinned, sort_order, balance, balance_used, quota, value_score, created_at, updated_at)
+		 VALUES (?, ?, ?, 0, 'active', ?, ?, ?, 0, 0, 0, 0, 0, 0, ?, ?)`,
+		siteID, "user@example.com", "at-test", provider, "acc-1", extra, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("account id: %v", err)
+	}
+	return accountID
+}
+
+func TestOAuthStart_IssuesCryptoRandomState(t *testing.T) {
+	_, r := setupOAuthRoutesTest(t)
+
+	resp1 := doPostJSON(t, r, "/api/oauth/providers/codex/start", map[string]any{})
+	if resp1.Code != http.StatusOK {
+		t.Fatalf("start #1 status=%d body=%s", resp1.Code, resp1.Body.String())
+	}
+	var body1 map[string]any
+	if err := json.Unmarshal(resp1.Body.Bytes(), &body1); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	state1, _ := body1["state"].(string)
+	if state1 == "" || state1 == "stub-state" || state1 == "stub-rebind" {
+		t.Fatalf("expected crypto-random state, got %q", state1)
+	}
+	if len(state1) < 20 {
+		t.Fatalf("state too short for 24-byte entropy: %q", state1)
+	}
+	if body1["authorizationUrl"] == "" {
+		t.Fatalf("authorizationUrl should be non-empty: %v", body1)
+	}
+	if body1["provider"] != "codex" {
+		t.Fatalf("provider = %v, want codex", body1["provider"])
+	}
+
+	resp2 := doPostJSON(t, r, "/api/oauth/providers/codex/start", map[string]any{})
+	if resp2.Code != http.StatusOK {
+		t.Fatalf("start #2 status=%d body=%s", resp2.Code, resp2.Body.String())
+	}
+	var body2 map[string]any
+	if err := json.Unmarshal(resp2.Body.Bytes(), &body2); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	state2, _ := body2["state"].(string)
+	if state2 == "" || state2 == state1 {
+		t.Fatalf("successive starts must issue distinct states; got %q and %q", state1, state2)
+	}
+}
+
+func TestOAuthGetSession_ValidatesState(t *testing.T) {
+	_, r := setupOAuthRoutesTest(t)
+
+	start := doPostJSON(t, r, "/api/oauth/providers/codex/start", map[string]any{})
+	if start.Code != http.StatusOK {
+		t.Fatalf("start status=%d body=%s", start.Code, start.Body.String())
+	}
+	var started map[string]any
+	if err := json.Unmarshal(start.Body.Bytes(), &started); err != nil {
+		t.Fatalf("decode start: %v", err)
+	}
+	state, _ := started["state"].(string)
+
+	ok := doGet(t, r, "/api/oauth/sessions/"+state)
+	if ok.Code != http.StatusOK {
+		t.Fatalf("getSession status=%d body=%s", ok.Code, ok.Body.String())
+	}
+	var session map[string]any
+	if err := json.Unmarshal(ok.Body.Bytes(), &session); err != nil {
+		t.Fatalf("decode session: %v", err)
+	}
+	if session["state"] != state {
+		t.Fatalf("state = %v, want %q", session["state"], state)
+	}
+	if session["status"] != "pending" {
+		t.Fatalf("status = %v, want pending", session["status"])
+	}
+	if session["provider"] != "codex" {
+		t.Fatalf("provider = %v, want codex", session["provider"])
+	}
+
+	missing := doGet(t, r, "/api/oauth/sessions/not-a-real-state")
+	if missing.Code != http.StatusNotFound {
+		t.Fatalf("missing state status=%d body=%s, want 404", missing.Code, missing.Body.String())
+	}
+	var missingBody map[string]any
+	if err := json.Unmarshal(missing.Body.Bytes(), &missingBody); err != nil {
+		t.Fatalf("decode missing: %v", err)
+	}
+	msg, _ := missingBody["message"].(string)
+	if !strings.Contains(msg, "oauth session not found") {
+		t.Fatalf("message = %q, want session-not-found", msg)
+	}
+}
+
+func TestOAuthManualCallback_RejectsStateMismatch(t *testing.T) {
+	_, r := setupOAuthRoutesTest(t)
+
+	start := doPostJSON(t, r, "/api/oauth/providers/codex/start", map[string]any{})
+	if start.Code != http.StatusOK {
+		t.Fatalf("start status=%d body=%s", start.Code, start.Body.String())
+	}
+	var started map[string]any
+	if err := json.Unmarshal(start.Body.Bytes(), &started); err != nil {
+		t.Fatalf("decode start: %v", err)
+	}
+	state, _ := started["state"].(string)
+
+	// Callback URL carries a different state than the path parameter.
+	mismatch := doPostJSON(t, r, "/api/oauth/sessions/"+state+"/manual-callback", map[string]any{
+		"callbackUrl": "http://localhost:1455/auth/callback?state=attacker-forged-state&code=xyz",
+	})
+	if mismatch.Code != http.StatusBadRequest {
+		t.Fatalf("mismatch status=%d body=%s, want 400", mismatch.Code, mismatch.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(mismatch.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	msg, _ := body["message"].(string)
+	if !strings.Contains(msg, "state mismatch") {
+		t.Fatalf("message = %q, want state mismatch", msg)
+	}
+
+	// Unknown path state is rejected before callback processing.
+	unknown := doPostJSON(t, r, "/api/oauth/sessions/unknown-state/manual-callback", map[string]any{
+		"callbackUrl": "http://localhost:1455/auth/callback?state=unknown-state&code=xyz",
+	})
+	if unknown.Code != http.StatusNotFound {
+		t.Fatalf("unknown status=%d body=%s, want 404", unknown.Code, unknown.Body.String())
+	}
+}
+
+func TestOAuthRebind_IssuesCryptoRandomState(t *testing.T) {
+	db, r := setupOAuthRoutesTest(t)
+	accountID := insertOAuthAccount(t, db, "codex")
+
+	resp := doPostJSON(t, r, fmt.Sprintf("/api/oauth/connections/%d/rebind", accountID), map[string]any{})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("rebind status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	state, _ := body["state"].(string)
+	if state == "" || state == "stub-rebind" || state == "stub-state" {
+		t.Fatalf("expected crypto-random rebind state, got %q", state)
+	}
+	if body["provider"] != "codex" {
+		t.Fatalf("provider = %v, want codex", body["provider"])
+	}
+	if body["authorizationUrl"] == "" {
+		t.Fatalf("authorizationUrl should be non-empty: %v", body)
+	}
+
+	// State must be server-stored and retrievable.
+	sessionResp := doGet(t, r, "/api/oauth/sessions/"+state)
+	if sessionResp.Code != http.StatusOK {
+		t.Fatalf("getSession after rebind status=%d body=%s", sessionResp.Code, sessionResp.Body.String())
+	}
+}
+
+func TestOAuthStart_UnknownProvider(t *testing.T) {
+	_, r := setupOAuthRoutesTest(t)
+	resp := doPostJSON(t, r, "/api/oauth/providers/not-a-provider/start", map[string]any{})
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404", resp.Code, resp.Body.String())
+	}
+}
+
+func TestOAuthProviders_ListsRealProviders(t *testing.T) {
+	_, r := setupOAuthRoutesTest(t)
+	resp := doGet(t, r, "/api/oauth/providers")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	providers, ok := body["providers"].([]any)
+	if !ok || len(providers) == 0 {
+		t.Fatalf("expected non-empty providers, got %v", body["providers"])
+	}
+}
+
+// Ensure doGet is available even if sites_test helpers change; keep a local fallback.
+func TestOAuthManualCallback_RequiresCallbackURL(t *testing.T) {
+	_, r := setupOAuthRoutesTest(t)
+	start := doPostJSON(t, r, "/api/oauth/providers/codex/start", map[string]any{})
+	if start.Code != http.StatusOK {
+		t.Fatalf("start status=%d body=%s", start.Code, start.Body.String())
+	}
+	var started map[string]any
+	_ = json.Unmarshal(start.Body.Bytes(), &started)
+	state, _ := started["state"].(string)
+
+	resp := doPostJSON(t, r, "/api/oauth/sessions/"+state+"/manual-callback", map[string]any{
+		"callbackUrl": "",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+}
+
+// Silence unused import if httptest is only needed transitively via helpers.
+var _ = httptest.NewRecorder


### PR DESCRIPTION
## Summary
- Replace fixed `stub-state` / `stub-rebind` OAuth admin responses with cryptographically random, server-stored session state (TTL 10m) via `service/oauth` session store
- `GET /api/oauth/sessions/{state}` and `POST .../manual-callback` validate state; reject missing/mismatched tokens
- Add residual doc for remaining OAuth gaps (in-memory store, provider credential matrix)

Closes #196

## Test plan
- [x] `go test ./handler/admin ./service/oauth -count=1 -run OAuth`
- [x] Handler tests cover start/rebind random state, getSession mismatch 404, manual-callback state mismatch 400