### PR TITLE
feat(admin): honest update-center residual + real clear-cache (#197)

### DIFF
--- a/docs/analysis/residual-update-center.md
+++ b/docs/analysis/residual-update-center.md
@@ -1,0 +1,87 @@
+# Residual: update-center deploy/rollback + maintenance clear-cache honesty (#197)
+
+**Date**: 2026-07-17  
+**Issue**: [#197](https://github.com/TokenDanceLab/metapi-go/issues/197)  
+**Lane**: residual honesty (admin ops)
+
+## Goal
+
+Stop success-theater for operations that are not implemented in-process:
+
+| Endpoint | Previous | New |
+|----------|----------|-----|
+| `POST /api/update-center/deploy` | `202` + fake `task.id: "stub-deploy"` | **501** residual (`success:false`, no task id) after validation |
+| `POST /api/update-center/rollback` | `202` + fake `task.id: "stub-rollback"` | **501** residual after validation |
+| `GET /api/update-center/tasks/:id/stream` | SSE with immediate fake `done/stub` | **501** residual (no fake SSE) |
+| `POST /api/settings/maintenance/clear-cache` | deleted rows + `jobId: "stub-clear-cache"` | delete rows + **real** in-process invalidation + **real** background task id |
+
+## Safe local clear-cache behavior
+
+1. Count + `DELETE` from shared tables:
+   - `model_availability`
+   - `route_channels`
+   - `token_routes`
+2. Invalidate **this process** caches immediately:
+   - `routing.InvalidateCache()` (route match / stable-first caches)
+   - `globalAccountsCache.clear()` (admin accounts list snapshot)
+3. Queue a real in-memory background task (`maintenance-clear-cache`) that:
+   - runs `service.RebuildRoutesBestEffort()`
+   - re-invalidates local caches after rebuild
+4. Return `202` with the real `jobId` / `taskId` (never `stub-clear-cache`)
+
+After wiping availability tables, rebuild is intentionally best-effort and may insert few/no channels until models are re-probed. That is still honest work, not a fake job id.
+
+## Deploy / rollback residual (out of scope)
+
+Remote binary/Helm deploy and release rollback require a helper service, credentials, and host orchestration. That is **not** implemented in the Go runtime.
+
+Honest residual shape (same helper as `#185` test routes):
+
+```json
+{
+  "success": false,
+  "message": "Update-center deploy is not implemented in Go",
+  "residual": "remote binary/Helm deploy via helper service is out of scope; use external deploy tooling (CI/CD or helper) instead of inventing task ids"
+}
+```
+
+Rules:
+
+- Never return `success:true` for unimplemented deploy/rollback.
+- Never invent `stub-deploy` / `stub-rollback` task ids.
+- Validation still runs first (`targetTag` / `targetRevision` required → `400`).
+
+## Multi-instance residual
+
+| Surface | Shared across instances? | Notes |
+|---------|--------------------------|-------|
+| DB row deletes (availability / routes / channels / usage) | **Yes** (shared DB) | All instances see empty tables |
+| `routing` in-process cache | **No** | Only the receiving process invalidates |
+| accounts snapshot cache | **No** | Only the receiving process clears |
+| background task registry (`jobId`) | **No** | Process-local; peer `/api/tasks/:id` will 404 |
+| remote deploy/rollback | **N/A** | Residual 501 everywhere until helper is wired |
+
+Operators running multi-instance should either:
+
+1. call clear-cache on each instance (or restart pods), and/or  
+2. rely on route-cache TTL + account-snapshot TTL for natural expiry.
+
+## Tests
+
+```bash
+go test ./handler/admin -count=1 -run 'Update|Maintenance|Cache'
+```
+
+Coverage:
+
+- deploy/rollback validation `400`
+- deploy/rollback/stream honest `501` without stub task ids
+- clear-cache wipes seeded `token_routes`, clears accounts + route caches, returns real `jobId`, task reaches `succeeded`
+
+## Files
+
+- `handler/admin/update_center.go`
+- `handler/admin/settings_maintenance.go`
+- `handler/admin/update_center_test.go`
+- `handler/admin/settings_maintenance_test.go`
+- `docs/analysis/residual-update-center.md`

--- a/handler/admin/settings_maintenance.go
+++ b/handler/admin/settings_maintenance.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
 	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/service"
 )
 
 // RegisterMaintenanceRoutes registers all /api/settings/maintenance routes.
@@ -22,46 +23,116 @@ type maintenanceHandler struct {
 	db *sqlx.DB
 }
 
+const (
+	clearCacheTaskType  = "maintenance-clear-cache"
+	clearCacheTaskTitle = "清理缓存并重建路由"
+	clearCacheDedupeKey = "maintenance-clear-cache"
+)
+
 // POST /api/settings/maintenance/clear-cache
+// Real local ops:
+//  1. Delete model_availability / route_channels / token_routes rows
+//  2. Invalidate in-process caches (routing + accounts snapshot)
+//  3. Queue a real background rebuild task (no fake stub job ids)
+//
+// Multi-instance residual: only this process's in-memory caches are cleared;
+// peer instances retain their own caches until TTL/local invalidation.
 func (h *maintenanceHandler) clearCache(w http.ResponseWriter, r *http.Request) {
 	// Count before deletion
 	var modelAvail, routeCh, tokenRoutes int64
-	h.db.Get(&modelAvail, "SELECT COUNT(*) FROM model_availability")
-	h.db.Get(&routeCh, "SELECT COUNT(*) FROM route_channels")
-	h.db.Get(&tokenRoutes, "SELECT COUNT(*) FROM token_routes")
+	_ = h.db.Get(&modelAvail, "SELECT COUNT(*) FROM model_availability")
+	_ = h.db.Get(&routeCh, "SELECT COUNT(*) FROM route_channels")
+	_ = h.db.Get(&tokenRoutes, "SELECT COUNT(*) FROM token_routes")
 
-	// Delete all
-	h.db.Exec("DELETE FROM model_availability")
-	h.db.Exec("DELETE FROM route_channels")
-	h.db.Exec("DELETE FROM token_routes")
+	// Delete all (shared DB — multi-instance safe for durable state)
+	if _, err := h.db.Exec("DELETE FROM model_availability"); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{
+			"success": false,
+			"message": fmt.Sprintf("清理 model_availability 失败：%v", err),
+		})
+		return
+	}
+	if _, err := h.db.Exec("DELETE FROM route_channels"); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{
+			"success": false,
+			"message": fmt.Sprintf("清理 route_channels 失败：%v", err),
+		})
+		return
+	}
+	if _, err := h.db.Exec("DELETE FROM token_routes"); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{
+			"success": false,
+			"message": fmt.Sprintf("清理 token_routes 失败：%v", err),
+		})
+		return
+	}
 
-	routing.InvalidateCache()
+	// Local in-process invalidation (this instance only).
+	invalidateLocalProcessCaches()
+
+	// Ensure rebuild path uses this request's DB handle (tests / non-global DB).
+	service.SetRouteRebuildDB(h.db)
+
+	task, reused := StartBackgroundTask(BackgroundTaskStartOptions{
+		Type:      clearCacheTaskType,
+		Title:     clearCacheTaskTitle,
+		DedupeKey: clearCacheDedupeKey,
+	}, func() (any, error) {
+		// Rebuild is best-effort: after wiping availability tables there may be
+		// little to rebuild until models are re-probed; still honest work.
+		service.RebuildRoutesBestEffort()
+		// Re-invalidate after rebuild so stale route matches cannot linger.
+		invalidateLocalProcessCaches()
+		return map[string]any{
+			"deletedModelAvailability": modelAvail,
+			"deletedRouteChannels":     routeCh,
+			"deletedTokenRoutes":       tokenRoutes,
+			"scope":                    "local-process-cache + shared-db-rows",
+		}, nil
+	})
+
 	writeJSON(w, http.StatusAccepted, map[string]any{
 		"success":                  true,
 		"queued":                   true,
-		"reused":                   false,
-		"jobId":                    "stub-clear-cache",
-		"message":                  "缓存已清理，重建路由已开始执行",
+		"reused":                   reused,
+		"jobId":                    task.ID,
+		"taskId":                   task.ID,
+		"status":                   string(task.Status),
+		"message":                  "缓存已清理，重建路由已开始执行（本进程内存缓存已失效；多实例需各自失效）",
 		"deletedModelAvailability": modelAvail,
 		"deletedRouteChannels":     routeCh,
 		"deletedTokenRoutes":       tokenRoutes,
 	})
 }
 
+// invalidateLocalProcessCaches clears known process-local caches.
+// Safe no-ops when caches are uninitialized.
+func invalidateLocalProcessCaches() {
+	routing.InvalidateCache()
+	if globalAccountsCache != nil {
+		globalAccountsCache.clear()
+	}
+}
+
 // POST /api/settings/maintenance/clear-usage
 func (h *maintenanceHandler) clearUsage(w http.ResponseWriter, r *http.Request) {
 	var deletedProxyLogs int64
-	h.db.Get(&deletedProxyLogs, "SELECT COUNT(*) FROM proxy_logs")
-	h.db.Exec("DELETE FROM proxy_logs")
+	_ = h.db.Get(&deletedProxyLogs, "SELECT COUNT(*) FROM proxy_logs")
+	_, _ = h.db.Exec("DELETE FROM proxy_logs")
 
 	// Reset route channel stats
-	h.db.Exec(`UPDATE route_channels SET
+	_, _ = h.db.Exec(`UPDATE route_channels SET
 		success_count = 0, fail_count = 0, total_latency_ms = 0, total_cost = 0,
 		last_used_at = NULL, last_selected_at = NULL, last_fail_at = NULL,
 		consecutive_fail_count = 0, cooldown_level = 0, cooldown_until = NULL`)
 
 	// Reset account balanceUsed
-	h.db.Exec("UPDATE accounts SET balance_used = 0")
+	_, _ = h.db.Exec("UPDATE accounts SET balance_used = 0")
+
+	// Accounts list snapshot may still show old balanceUsed until cleared.
+	if globalAccountsCache != nil {
+		globalAccountsCache.clear()
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success":          true,
@@ -136,11 +207,11 @@ func (h *maintenanceHandler) factoryReset(w http.ResponseWriter, r *http.Request
 	driverName := h.db.DriverName()
 	switch driverName {
 	case "sqlite", "sqlite3":
-		tx.Exec("DELETE FROM sqlite_sequence")
+		_, _ = tx.Exec("DELETE FROM sqlite_sequence")
 	case "pgx", "postgres":
 		for _, table := range allTables {
 			seqName := table + "_id_seq"
-			tx.Exec(fmt.Sprintf("ALTER SEQUENCE IF EXISTS %s RESTART WITH 1", seqName))
+			_, _ = tx.Exec(fmt.Sprintf("ALTER SEQUENCE IF EXISTS %s RESTART WITH 1", seqName))
 		}
 	}
 	// For other drivers, skip sequence reset (no-op).
@@ -153,7 +224,7 @@ func (h *maintenanceHandler) factoryReset(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	routing.InvalidateCache()
+	invalidateLocalProcessCaches()
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success": true,
 		"message": "工厂重置完成",

--- a/handler/admin/settings_maintenance_test.go
+++ b/handler/admin/settings_maintenance_test.go
@@ -1,0 +1,152 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func setupMaintenanceTest(t *testing.T) (*store.DB, chi.Router, *routing.RouteCache) {
+	t.Helper()
+	resetBackgroundTasksForTests()
+	globalAccountsCache = &accountsSnapshotCache{ttl: 30 * time.Second}
+
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Seed a warm accounts snapshot so clear-cache can prove invalidation.
+	globalAccountsCache.set([]byte(`{"accounts":[],"sites":[]}`))
+
+	// Seed a warm route cache so clear-cache can prove invalidation.
+	rc := routing.NewRouteCache(5_000)
+	rc.SetRoutes([]store.TokenRoute{{ID: 1, ModelPattern: "gpt-*"}})
+	routing.SetGlobalCache(rc)
+	t.Cleanup(func() { routing.SetGlobalCache(nil) })
+
+	r := chi.NewRouter()
+	RegisterMaintenanceRoutes(r, db.DB)
+	RegisterTasksRoutes(r, db.DB)
+	return db, r, rc
+}
+
+func TestMaintenanceClearCache_RealInvalidationAndRealJob(t *testing.T) {
+	db, r, rc := setupMaintenanceTest(t)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(`INSERT INTO token_routes (model_pattern, enabled, created_at, updated_at)
+		VALUES ('gpt-*', 1, ?, ?)`, now, now); err != nil {
+		t.Fatalf("seed token_routes: %v", err)
+	}
+
+	if !globalAccountsCache.isValid() {
+		t.Fatal("accounts snapshot cache should be warm before clear-cache")
+	}
+	if rc.GetRoutes() == nil {
+		t.Fatal("route cache should be warm before clear-cache")
+	}
+
+	resp := doPostJSON(t, r, "/api/settings/maintenance/clear-cache", map[string]any{})
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("status=%d body=%s, want 202", resp.Code, resp.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != true {
+		t.Fatalf("success=%v, want true", body["success"])
+	}
+	if body["queued"] != true {
+		t.Fatalf("queued=%v, want true", body["queued"])
+	}
+
+	deletedRoutes, _ := body["deletedTokenRoutes"].(float64)
+	if deletedRoutes < 1 {
+		t.Fatalf("deletedTokenRoutes=%v, want >= 1", body["deletedTokenRoutes"])
+	}
+
+	jobID, _ := body["jobId"].(string)
+	if jobID == "" || jobID == "stub-clear-cache" {
+		t.Fatalf("jobId still stub/empty: %v", body["jobId"])
+	}
+	if taskID, _ := body["taskId"].(string); taskID != jobID {
+		t.Fatalf("taskId=%v jobId=%v, want match", body["taskId"], jobID)
+	}
+
+	// In-process caches must be invalidated immediately.
+	if globalAccountsCache.isValid() {
+		t.Fatal("accounts snapshot cache should be cleared")
+	}
+	if routes := rc.GetRoutes(); routes != nil {
+		t.Fatalf("route cache should be invalidated, got %d routes", len(routes))
+	}
+
+	// Durable rows wiped.
+	var routeCount int64
+	if err := db.Get(&routeCount, "SELECT COUNT(*) FROM token_routes"); err != nil {
+		t.Fatalf("count token_routes: %v", err)
+	}
+	if routeCount != 0 {
+		t.Fatalf("token_routes count=%d, want 0", routeCount)
+	}
+
+	// Real background task completes.
+	deadline := time.Now().Add(2 * time.Second)
+	var task map[string]any
+	for time.Now().Before(deadline) {
+		getResp := doGet(t, r, "/api/tasks/"+jobID)
+		if getResp.Code != http.StatusOK {
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		var getBody map[string]any
+		if err := json.Unmarshal(getResp.Body.Bytes(), &getBody); err != nil {
+			t.Fatalf("decode task: %v", err)
+		}
+		task, _ = getBody["task"].(map[string]any)
+		if task != nil {
+			if task["status"] == "succeeded" || task["status"] == "failed" {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if task == nil {
+		t.Fatal("clear-cache task not found in registry")
+	}
+	if task["status"] != "succeeded" {
+		t.Fatalf("task status=%v body=%v, want succeeded", task["status"], task)
+	}
+	if task["type"] != clearCacheTaskType {
+		t.Fatalf("task type=%v, want %s", task["type"], clearCacheTaskType)
+	}
+}
+
+func TestMaintenanceClearCache_NoFakeStubJobID(t *testing.T) {
+	_, r, _ := setupMaintenanceTest(t)
+
+	resp := doPostJSON(t, r, "/api/settings/maintenance/clear-cache", nil)
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	raw := resp.Body.String()
+	if strings.Contains(raw, "stub-clear-cache") {
+		t.Fatalf("response still contains stub job id: %s", raw)
+	}
+	if strings.Contains(raw, `"success":false`) {
+		t.Fatalf("unexpected failure: %s", raw)
+	}
+}

--- a/handler/admin/update_center.go
+++ b/handler/admin/update_center.go
@@ -22,6 +22,7 @@ func RegisterUpdateCenterRoutes(r chi.Router) {
 type updateCenterHandler struct{}
 
 // GET /api/update-center/status
+// Local status only — remote version discovery is residual.
 func (h *updateCenterHandler) status(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"currentVersion":  "0.0.0",
@@ -32,6 +33,7 @@ func (h *updateCenterHandler) status(w http.ResponseWriter, r *http.Request) {
 }
 
 // POST /api/update-center/check
+// Local check only — no remote registry polling yet.
 func (h *updateCenterHandler) check(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"currentVersion":  "0.0.0",
@@ -42,6 +44,7 @@ func (h *updateCenterHandler) check(w http.ResponseWriter, r *http.Request) {
 }
 
 // PUT /api/update-center/config
+// Accepts and echoes config for UI round-trip; deploy/rollback remain residual.
 func (h *updateCenterHandler) saveConfig(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Enabled             *bool   `json:"enabled"`
@@ -77,6 +80,8 @@ func (h *updateCenterHandler) saveConfig(w http.ResponseWriter, r *http.Request)
 }
 
 // POST /api/update-center/deploy
+// Remote binary/Helm deploy is out of process scope — honest 501 residual.
+// Never invent stub-deploy task ids.
 func (h *updateCenterHandler) deploy(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Source        *string `json:"source"`
@@ -104,17 +109,15 @@ func (h *updateCenterHandler) deploy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusAccepted, map[string]any{
-		"success": true,
-		"reused":  false,
-		"task": map[string]any{
-			"id":     "stub-deploy",
-			"status": "pending",
-		},
-	})
+	writeNotImplementedResidual(w,
+		"Update-center deploy is not implemented in Go",
+		"remote binary/Helm deploy via helper service is out of scope; use external deploy tooling (CI/CD or helper) instead of inventing task ids",
+	)
 }
 
 // POST /api/update-center/rollback
+// Remote rollback is out of process scope — honest 501 residual.
+// Never invent stub-rollback task ids.
 func (h *updateCenterHandler) rollback(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		TargetRevision *string `json:"targetRevision"`
@@ -136,32 +139,20 @@ func (h *updateCenterHandler) rollback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusAccepted, map[string]any{
-		"success": true,
-		"reused":  false,
-		"task": map[string]any{
-			"id":     "stub-rollback",
-			"status": "pending",
-		},
-	})
+	writeNotImplementedResidual(w,
+		"Update-center rollback is not implemented in Go",
+		"remote Helm/release rollback via helper service is out of scope; use external deploy tooling instead of inventing task ids",
+	)
 }
 
 // GET /api/update-center/tasks/:id/stream
+// No deploy/rollback task registry exists — honest 501 residual (no fake SSE done).
 func (h *updateCenterHandler) taskStream(w http.ResponseWriter, r *http.Request) {
-	// SSE stream for task logs
-	idStr := chi.URLParam(r, "id")
+	idStr := strings.TrimSpace(chi.URLParam(r, "id"))
 	_ = idStr
 
-	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
-	w.Header().Set("Cache-Control", "no-cache, no-transform")
-	w.Header().Set("Connection", "keep-alive")
-	w.WriteHeader(http.StatusOK)
-
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		return
-	}
-
-	// Send done event immediately (stub)
-	sseWrite(w, flusher, "done", map[string]any{"status": "stub"})
+	writeNotImplementedResidual(w,
+		"Update-center task SSE stream is not implemented in Go",
+		"deploy/rollback tasks are residual; no in-process update-center task registry or SSE log stream exists",
+	)
 }

--- a/handler/admin/update_center_test.go
+++ b/handler/admin/update_center_test.go
@@ -1,0 +1,156 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func setupUpdateCenterTest(t *testing.T) chi.Router {
+	t.Helper()
+	r := chi.NewRouter()
+	RegisterUpdateCenterRoutes(r)
+	return r
+}
+
+func TestUpdateCenterDeploy_RequiresTargetTag(t *testing.T) {
+	r := setupUpdateCenterTest(t)
+
+	resp := doPostJSON(t, r, "/api/update-center/deploy", map[string]any{
+		"source": "docker-hub-tag",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != false {
+		t.Fatalf("success=%v, want false", body["success"])
+	}
+	if msg, _ := body["message"].(string); !strings.Contains(msg, "targetTag") {
+		t.Fatalf("message=%q, want targetTag required", msg)
+	}
+}
+
+func TestUpdateCenterDeploy_Honest501NoStubTask(t *testing.T) {
+	r := setupUpdateCenterTest(t)
+
+	resp := doPostJSON(t, r, "/api/update-center/deploy", map[string]any{
+		"targetTag": "v1.2.3",
+	})
+	if resp.Code != http.StatusNotImplemented {
+		t.Fatalf("status=%d body=%s, want 501", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != false {
+		t.Fatalf("success=%v, want false (no fake success theater)", body["success"])
+	}
+	if msg, _ := body["message"].(string); msg == "" {
+		t.Fatalf("expected residual message: %v", body)
+	}
+	if residual, _ := body["residual"].(string); residual == "" {
+		t.Fatalf("expected residual field: %v", body)
+	}
+	raw := resp.Body.String()
+	if strings.Contains(raw, "stub-deploy") {
+		t.Fatalf("must not invent stub-deploy task id: %s", raw)
+	}
+	if strings.Contains(raw, `"task"`) {
+		t.Fatalf("must not return fake task object: %s", raw)
+	}
+}
+
+func TestUpdateCenterDeploy_AcceptsTargetVersionAlias(t *testing.T) {
+	r := setupUpdateCenterTest(t)
+
+	// targetVersion alone is enough to pass validation, then residual 501.
+	resp := doPostJSON(t, r, "/api/update-center/deploy", map[string]any{
+		"targetVersion": "1.0.0",
+	})
+	if resp.Code != http.StatusNotImplemented {
+		t.Fatalf("status=%d body=%s, want 501", resp.Code, resp.Body.String())
+	}
+}
+
+func TestUpdateCenterRollback_RequiresTargetRevision(t *testing.T) {
+	r := setupUpdateCenterTest(t)
+
+	resp := doPostJSON(t, r, "/api/update-center/rollback", map[string]any{})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	_ = json.Unmarshal(resp.Body.Bytes(), &body)
+	if body["success"] != false {
+		t.Fatalf("success=%v, want false", body["success"])
+	}
+}
+
+func TestUpdateCenterRollback_Honest501NoStubTask(t *testing.T) {
+	r := setupUpdateCenterTest(t)
+
+	resp := doPostJSON(t, r, "/api/update-center/rollback", map[string]any{
+		"targetRevision": "42",
+	})
+	if resp.Code != http.StatusNotImplemented {
+		t.Fatalf("status=%d body=%s, want 501", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != false {
+		t.Fatalf("success=%v, want false", body["success"])
+	}
+	if residual, _ := body["residual"].(string); residual == "" {
+		t.Fatalf("expected residual field: %v", body)
+	}
+	raw := resp.Body.String()
+	if strings.Contains(raw, "stub-rollback") {
+		t.Fatalf("must not invent stub-rollback task id: %s", raw)
+	}
+}
+
+func TestUpdateCenterTaskStream_Honest501(t *testing.T) {
+	r := setupUpdateCenterTest(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/update-center/tasks/any-id/stream", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status=%d body=%s, want 501", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), `"status":"stub"`) {
+		t.Fatalf("must not emit fake SSE stub done: %s", rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != false {
+		t.Fatalf("success=%v, want false", body["success"])
+	}
+}
+
+func TestUpdateCenterStatusAndCheck_LocalOnly(t *testing.T) {
+	r := setupUpdateCenterTest(t)
+
+	statusResp := doGet(t, r, "/api/update-center/status")
+	if statusResp.Code != http.StatusOK {
+		t.Fatalf("status endpoint=%d body=%s", statusResp.Code, statusResp.Body.String())
+	}
+	checkResp := doPostJSON(t, r, "/api/update-center/check", map[string]any{})
+	if checkResp.Code != http.StatusOK {
+		t.Fatalf("check endpoint=%d body=%s", checkResp.Code, checkResp.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Replace update-center deploy/rollback/task-stream success theater with honest **501** residuals (no `stub-deploy` / `stub-rollback` task ids).
- Make `POST /api/settings/maintenance/clear-cache` perform real local ops: wipe shared availability/route tables, invalidate `routing` + accounts snapshot caches, queue a real background rebuild job.
- Document multi-instance residual in `docs/analysis/residual-update-center.md`.

Closes #197

## Test plan
- [x] `go test ./handler/admin -count=1 -run 'Update|Maintenance|Cache'`
- [ ] Confirm deploy/rollback return 501 with `success:false` and residual field
- [ ] Confirm clear-cache returns real `jobId` (not `stub-clear-cache`) and task reaches succeeded