### PR TITLE
feat(admin): merge sub2api managed auth on update/rebind (#194)

### DIFF
--- a/docs/analysis/residual-sub2api-auth.md
+++ b/docs/analysis/residual-sub2api-auth.md
@@ -1,0 +1,36 @@
+# Residual: Sub2API Managed Auth (#194)
+
+Last updated: 2026-07-17
+
+## Scope
+
+Merge `extraConfig.sub2apiAuth` managed auth fields (`refreshToken`, `tokenExpiresAt`) on account update and rebind-session when the site platform is `sub2api`.
+
+## Behavior landed
+
+| Path | Behavior |
+|------|----------|
+| `PUT /api/accounts/:id` | When platform is `sub2api`, merge top-level `refreshToken` / `tokenExpiresAt` and nested `extraConfig.sub2apiAuth` into stored `extraConfig.sub2apiAuth`. Valid new values overwrite; missing/invalid values preserve existing keys. Unrelated `extraConfig` keys are preserved via `MergeExtraConfig`. Nested `sub2apiAuth` is stripped from the generic extraConfig merge so partial nested patches cannot wholesale-clobber auth. |
+| `POST /api/accounts/:id/rebind-session` | Same managed-auth merge for `sub2api` platforms while always setting `credentialMode=session`. Unrelated extraConfig keys remain intact. |
+| Non-sub2api platforms | Top-level refresh/expiry fields are ignored for managed auth (no invented platform behavior). |
+
+Helpers:
+
+- `service.NormalizeManagedRefreshToken` — non-empty trimmed string
+- `service.NormalizeManagedTokenExpiresAt` — positive epoch seconds (number or numeric string)
+- `service.MergeSub2ApiAuth` / `service.BuildMergedSub2ApiAuth` — preserve/overwrite merge
+
+## Residual / not in this PR
+
+1. **No dedicated Sub2API refresh endpoint in Go yet.** Balance refresh currently falls back through `refreshSub2ApiManagedSessionSingleflight` → auto-relogin style path when managed auth is due. A true `/api/v1/auth/refresh` (or platform-specific) adapter call is still residual.
+2. **Scheduler filter incomplete.** `scheduler/sub2api_refresh.go` still has a TODO to parse `extraConfig` and only refresh candidates with `refreshToken` + due `tokenExpiresAt`.
+3. **Create-path managed auth.** `POST /api/accounts` stores top-level `tokenExpiresAt` as a flat extraConfig key for session mode, but does not yet write nested `extraConfig.sub2apiAuth` for sub2api imports.
+4. **Due window.** `IsManagedSub2ApiTokenDue` currently returns true whenever `tokenExpiresAt` is present; a real expiry-window policy remains residual.
+5. **Subscription summary aggregation** from managed auth remains a stub in site service.
+
+## Verify
+
+```bash
+go test ./handler/admin -count=1 -run Account
+go test ./service -count=1 -run 'Sub2Api|Managed'
+```

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -790,10 +790,15 @@ func (h *accountsHandler) rebindSession(w http.ResponseWriter, r *http.Request) 
 
 	now := time.Now().UTC().Format(time.RFC3339)
 
-	// TODO(P4): handle sub2api managed auth (extraConfig.sub2apiAuth.refreshToken / tokenExpiresAt)
-	// Spec lines 528-542: when platform is sub2api, rebind-session must update sub2apiAuth fields.
+	// Sub2API managed auth: merge refreshToken/tokenExpiresAt into extraConfig.sub2apiAuth
+	// without clobbering unrelated keys (spec p3-sites-accounts lines 528-542).
 	extraConfigPatch := map[string]any{
 		"credentialMode": "session",
+	}
+	if service.IsSub2ApiPlatform(row.Site.Platform) {
+		if mergedAuth := service.BuildMergedSub2ApiAuth(row.Account.ExtraConfig, body.RefreshToken, body.TokenExpiresAt, nil); mergedAuth != nil {
+			extraConfigPatch["sub2apiAuth"] = mergedAuth
+		}
 	}
 	extraConfigStr := service.MergeExtraConfig(row.Account.ExtraConfig, extraConfigPatch)
 
@@ -900,9 +905,24 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 		updates["unitCost"] = *body.UnitCost
 	}
 	if body.ExtraConfig != nil {
-		// Merge with existing extraConfig to preserve keys not in the update
+		// Merge with existing extraConfig to preserve keys not in the update.
+		// For sub2api, strip nested sub2apiAuth here and merge it via managed-auth
+		// helpers later so partial patches cannot clobber unrelated auth keys.
 		if ecMap, ok := body.ExtraConfig.(map[string]any); ok {
-			mergeExtraConfigUpdate(ecMap)
+			if service.IsSub2ApiPlatform(row.Site.Platform) {
+				stripped := make(map[string]any, len(ecMap))
+				for k, v := range ecMap {
+					if k == "sub2apiAuth" {
+						continue
+					}
+					stripped[k] = v
+				}
+				if len(stripped) > 0 {
+					mergeExtraConfigUpdate(stripped)
+				}
+			} else {
+				mergeExtraConfigUpdate(ecMap)
+			}
 		}
 	}
 	nextAccount := row.Account
@@ -936,9 +956,22 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 			"proxyUrl": service.NormalizeNullable(body.ProxyURL),
 		})
 	}
-	// TODO(P4): handle sub2api managed auth (extraConfig.sub2apiAuth.refreshToken / tokenExpiresAt)
-	// Spec lines 530-542: updateAccount for sub2api platform must merge sub2apiAuth fields.
-	// TODO(P4): expired API key recovery — when updating an expired API key account,
+	// Sub2API managed auth: merge top-level / nested refreshToken+tokenExpiresAt
+	// into extraConfig.sub2apiAuth without clobbering unrelated keys.
+	if service.IsSub2ApiPlatform(row.Site.Platform) {
+		var extraPatch map[string]any
+		if body.ExtraConfig != nil {
+			if ecMap, ok := body.ExtraConfig.(map[string]any); ok {
+				extraPatch = ecMap
+			}
+		}
+		// Merge against the original stored config so nested extraConfig.sub2apiAuth
+		// patches compose with top-level fields instead of overwriting wholesale.
+		if mergedAuth := service.BuildMergedSub2ApiAuth(row.Account.ExtraConfig, body.RefreshToken, body.TokenExpiresAt, extraPatch); mergedAuth != nil {
+			mergeExtraConfigUpdate(map[string]any{"sub2apiAuth": mergedAuth})
+		}
+	}
+	// TODO(P4): expired API key recovery - when updating an expired API key account,
 	// trigger model refresh with allowInactive:true and reactivateAfterSuccessfulModelRefresh:true
 	// (spec lines 594-602, TS accounts.ts:1550-1556)
 

--- a/handler/admin/accounts_sub2api_auth_test.go
+++ b/handler/admin/accounts_sub2api_auth_test.go
@@ -1,0 +1,228 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+// ---- Sub2API managed auth merge (#194) ----
+
+func setupSub2ApiAccountFixture(t *testing.T, db *store.DB, r chi.Router, extraConfig string) (int64, int64) {
+	t.Helper()
+	siteResp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "Sub2API Auth Site",
+		"url":      "https://sub2api.example.com",
+		"platform": "sub2api",
+	})
+	if siteResp.Code != http.StatusOK {
+		t.Fatalf("create sub2api site: %d %s", siteResp.Code, siteResp.Body.String())
+	}
+	var site map[string]any
+	if err := json.Unmarshal(siteResp.Body.Bytes(), &site); err != nil {
+		t.Fatalf("decode site: %v", err)
+	}
+	siteID := int64(site["id"].(float64))
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	res, err := db.Exec(
+		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, 'active', 1, ?, ?, ?)",
+		siteID, "sub2api-user", "session-old", extraConfig, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert sub2api account: %v", err)
+	}
+	accountID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("account LastInsertId: %v", err)
+	}
+	return siteID, accountID
+}
+
+func parseExtraConfigMap(t *testing.T, raw *string) map[string]any {
+	t.Helper()
+	if raw == nil {
+		t.Fatal("extra_config is nil")
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(*raw), &cfg); err != nil {
+		t.Fatalf("decode extra_config: %v body=%s", err, *raw)
+	}
+	return cfg
+}
+
+func TestAccounts_Update_Sub2ApiAuthMergePreserveAndOverwrite(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	seed := `{"credentialMode":"session","proxyUrl":"http://proxy.local","sub2apiAuth":{"refreshToken":"rt_old","tokenExpiresAt":100,"custom":"keep-me"}}`
+	_, accountID := setupSub2ApiAccountFixture(t, db, r, seed)
+
+	// Partial top-level refreshToken update should preserve tokenExpiresAt + custom + proxyUrl.
+	resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"refreshToken": "rt_new",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update refreshToken: %d %s", resp.Code, resp.Body.String())
+	}
+
+	var extra *string
+	if err := db.QueryRow("SELECT extra_config FROM accounts WHERE id = ?", accountID).Scan(&extra); err != nil {
+		t.Fatalf("read extra_config: %v", err)
+	}
+	cfg := parseExtraConfigMap(t, extra)
+	if cfg["proxyUrl"] != "http://proxy.local" {
+		t.Fatalf("proxyUrl = %#v, want preserved", cfg["proxyUrl"])
+	}
+	auth, _ := cfg["sub2apiAuth"].(map[string]any)
+	if auth == nil {
+		t.Fatalf("sub2apiAuth missing: %#v", cfg)
+	}
+	if auth["refreshToken"] != "rt_new" {
+		t.Fatalf("refreshToken = %#v, want rt_new", auth["refreshToken"])
+	}
+	if auth["tokenExpiresAt"] != float64(100) {
+		t.Fatalf("tokenExpiresAt = %#v, want preserved 100", auth["tokenExpiresAt"])
+	}
+	if auth["custom"] != "keep-me" {
+		t.Fatalf("custom = %#v, want keep-me", auth["custom"])
+	}
+
+	// Nested partial tokenExpiresAt patch should preserve refreshToken.
+	resp = doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"extraConfig": map[string]any{
+			"sub2apiAuth": map[string]any{
+				"tokenExpiresAt": float64(999),
+			},
+			"note": "still-here",
+		},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update nested expires: %d %s", resp.Code, resp.Body.String())
+	}
+	if err := db.QueryRow("SELECT extra_config FROM accounts WHERE id = ?", accountID).Scan(&extra); err != nil {
+		t.Fatalf("read extra_config after nested: %v", err)
+	}
+	cfg = parseExtraConfigMap(t, extra)
+	if cfg["note"] != "still-here" {
+		t.Fatalf("note = %#v, want still-here", cfg["note"])
+	}
+	if cfg["proxyUrl"] != "http://proxy.local" {
+		t.Fatalf("proxyUrl lost after nested update: %#v", cfg["proxyUrl"])
+	}
+	auth, _ = cfg["sub2apiAuth"].(map[string]any)
+	if auth["refreshToken"] != "rt_new" {
+		t.Fatalf("refreshToken = %#v, want preserved rt_new", auth["refreshToken"])
+	}
+	if auth["tokenExpiresAt"] != float64(999) {
+		t.Fatalf("tokenExpiresAt = %#v, want 999", auth["tokenExpiresAt"])
+	}
+	if auth["custom"] != "keep-me" {
+		t.Fatalf("custom = %#v, want keep-me", auth["custom"])
+	}
+}
+
+func TestAccounts_Update_Sub2ApiAuthTopLevelWinsOverNested(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	seed := `{"credentialMode":"session","sub2apiAuth":{"refreshToken":"rt_old","tokenExpiresAt":100}}`
+	_, accountID := setupSub2ApiAccountFixture(t, db, r, seed)
+
+	resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"refreshToken":   "rt_top",
+		"tokenExpiresAt": int64(777),
+		"extraConfig": map[string]any{
+			"sub2apiAuth": map[string]any{
+				"refreshToken":   "rt_nested",
+				"tokenExpiresAt": float64(555),
+			},
+		},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update: %d %s", resp.Code, resp.Body.String())
+	}
+	var extra *string
+	if err := db.QueryRow("SELECT extra_config FROM accounts WHERE id = ?", accountID).Scan(&extra); err != nil {
+		t.Fatalf("read extra_config: %v", err)
+	}
+	cfg := parseExtraConfigMap(t, extra)
+	auth, _ := cfg["sub2apiAuth"].(map[string]any)
+	if auth["refreshToken"] != "rt_top" {
+		t.Fatalf("refreshToken = %#v, want top-level rt_top", auth["refreshToken"])
+	}
+	if auth["tokenExpiresAt"] != float64(777) {
+		t.Fatalf("tokenExpiresAt = %#v, want top-level 777", auth["tokenExpiresAt"])
+	}
+}
+
+func TestAccounts_RebindSession_Sub2ApiAuthMerge(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	seed := `{"credentialMode":"session","proxyUrl":"http://proxy.local","sub2apiAuth":{"refreshToken":"rt_old","tokenExpiresAt":100,"custom":"keep-me"}}`
+	_, accountID := setupSub2ApiAccountFixture(t, db, r, seed)
+
+	resp := doPostJSON(t, r, "/api/accounts/"+itoa(accountID)+"/rebind-session", map[string]any{
+		"accessToken":    "session-new",
+		"refreshToken":   "rt_rebind",
+		"tokenExpiresAt": int64(12345),
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("rebind: %d %s", resp.Code, resp.Body.String())
+	}
+
+	var accessToken string
+	var extra *string
+	if err := db.QueryRow("SELECT access_token, extra_config FROM accounts WHERE id = ?", accountID).Scan(&accessToken, &extra); err != nil {
+		t.Fatalf("read account: %v", err)
+	}
+	if accessToken != "session-new" {
+		t.Fatalf("access_token = %q, want session-new", accessToken)
+	}
+	cfg := parseExtraConfigMap(t, extra)
+	if cfg["proxyUrl"] != "http://proxy.local" {
+		t.Fatalf("proxyUrl = %#v, want preserved", cfg["proxyUrl"])
+	}
+	if cfg["credentialMode"] != "session" {
+		t.Fatalf("credentialMode = %#v, want session", cfg["credentialMode"])
+	}
+	auth, _ := cfg["sub2apiAuth"].(map[string]any)
+	if auth["refreshToken"] != "rt_rebind" {
+		t.Fatalf("refreshToken = %#v, want rt_rebind", auth["refreshToken"])
+	}
+	if auth["tokenExpiresAt"] != float64(12345) {
+		t.Fatalf("tokenExpiresAt = %#v, want 12345", auth["tokenExpiresAt"])
+	}
+	if auth["custom"] != "keep-me" {
+		t.Fatalf("custom = %#v, want keep-me", auth["custom"])
+	}
+}
+
+func TestAccounts_Update_NonSub2ApiIgnoresManagedAuthFields(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	_, accountID := setupAccountFixtureWithSite(t, db, r, "NonSub2", "https://api.openai.com")
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	if _, err := db.Exec(
+		"UPDATE accounts SET extra_config = ?, updated_at = ? WHERE id = ?",
+		`{"credentialMode":"session","proxyUrl":"http://proxy.local"}`, now, accountID,
+	); err != nil {
+		t.Fatalf("seed extra_config: %v", err)
+	}
+
+	resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"refreshToken":   "rt_should_ignore",
+		"tokenExpiresAt": int64(999),
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update non-sub2api: %d %s", resp.Code, resp.Body.String())
+	}
+	var extra *string
+	if err := db.QueryRow("SELECT extra_config FROM accounts WHERE id = ?", accountID).Scan(&extra); err != nil {
+		t.Fatalf("read extra_config: %v", err)
+	}
+	cfg := parseExtraConfigMap(t, extra)
+	if _, ok := cfg["sub2apiAuth"]; ok {
+		t.Fatalf("non-sub2api update should not write sub2apiAuth: %#v", cfg)
+	}
+	if cfg["proxyUrl"] != "http://proxy.local" {
+		t.Fatalf("proxyUrl = %#v, want preserved", cfg["proxyUrl"])
+	}
+}

--- a/service/account_extra_config.go
+++ b/service/account_extra_config.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"encoding/json"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -74,6 +76,148 @@ func GetSub2ApiAuthFromExtraConfig(extraConfig *string) map[string]any {
 	return auth
 }
 
+// NormalizeManagedRefreshToken accepts a non-empty trimmed string refresh token.
+// Returns ok=false for nil/empty/invalid values so callers preserve existing auth.
+func NormalizeManagedRefreshToken(value any) (string, bool) {
+	if value == nil {
+		return "", false
+	}
+	s, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return "", false
+	}
+	return trimmed, true
+}
+
+// NormalizeManagedTokenExpiresAt accepts a positive epoch-seconds value
+// (number or numeric string). Returns ok=false when missing/invalid.
+func NormalizeManagedTokenExpiresAt(value any) (int64, bool) {
+	if value == nil {
+		return 0, false
+	}
+	switch v := value.(type) {
+	case int64:
+		if v > 0 {
+			return v, true
+		}
+	case int:
+		if v > 0 {
+			return int64(v), true
+		}
+	case int32:
+		if v > 0 {
+			return int64(v), true
+		}
+	case float64:
+		if v > 0 && !math.IsNaN(v) && !math.IsInf(v, 0) {
+			return int64(v), true
+		}
+	case float32:
+		if v > 0 && !math.IsNaN(float64(v)) && !math.IsInf(float64(v), 0) {
+			return int64(v), true
+		}
+	case json.Number:
+		i, err := v.Int64()
+		if err == nil && i > 0 {
+			return i, true
+		}
+		f, err := v.Float64()
+		if err == nil && f > 0 && !math.IsNaN(f) && !math.IsInf(f, 0) {
+			return int64(f), true
+		}
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return 0, false
+		}
+		if i, err := strconv.ParseInt(trimmed, 10, 64); err == nil && i > 0 {
+			return i, true
+		}
+		if f, err := strconv.ParseFloat(trimmed, 64); err == nil && f > 0 && !math.IsNaN(f) && !math.IsInf(f, 0) {
+			return int64(f), true
+		}
+	}
+	return 0, false
+}
+
+// MergeSub2ApiAuth merges managed auth fields onto an existing sub2apiAuth map.
+// Valid new values overwrite; invalid/missing values preserve existing keys.
+// Unrelated keys on existing are always preserved. Returns nil when empty.
+func MergeSub2ApiAuth(existing map[string]any, refreshToken any, tokenExpiresAt any) map[string]any {
+	out := map[string]any{}
+	if existing != nil {
+		for k, v := range existing {
+			out[k] = v
+		}
+	}
+	if rt, ok := NormalizeManagedRefreshToken(refreshToken); ok {
+		out["refreshToken"] = rt
+	}
+	if exp, ok := NormalizeManagedTokenExpiresAt(tokenExpiresAt); ok {
+		out["tokenExpiresAt"] = exp
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// BuildMergedSub2ApiAuth builds the next sub2apiAuth object for a sub2api account.
+// Sources (later wins for the same field):
+//  1. existing extraConfig.sub2apiAuth
+//  2. optional nested extraConfigPatch["sub2apiAuth"]
+//  3. top-level refreshToken / tokenExpiresAt pointers
+//
+// Returns nil when there are no valid fields to write (caller should leave extraConfig alone).
+func BuildMergedSub2ApiAuth(existingExtraConfig *string, refreshToken *string, tokenExpiresAt *int64, extraConfigPatch map[string]any) map[string]any {
+	var patchRT any
+	var patchExp any
+	if extraConfigPatch != nil {
+		if auth, ok := extraConfigPatch["sub2apiAuth"].(map[string]any); ok && auth != nil {
+			if v, ok := auth["refreshToken"]; ok {
+				patchRT = v
+			}
+			if v, ok := auth["tokenExpiresAt"]; ok {
+				patchExp = v
+			}
+		}
+	}
+
+	hasIncoming := false
+	var rt any = patchRT
+	var exp any = patchExp
+	if refreshToken != nil {
+		rt = *refreshToken
+		hasIncoming = true
+	} else if patchRT != nil {
+		hasIncoming = true
+	}
+	if tokenExpiresAt != nil {
+		exp = *tokenExpiresAt
+		hasIncoming = true
+	} else if patchExp != nil {
+		hasIncoming = true
+	}
+	if !hasIncoming {
+		return nil
+	}
+
+	// Only produce a write when at least one incoming field normalizes successfully,
+	// otherwise leave existing managed auth untouched.
+	_, rtOK := NormalizeManagedRefreshToken(rt)
+	_, expOK := NormalizeManagedTokenExpiresAt(exp)
+	if !rtOK && !expOK {
+		return nil
+	}
+
+	existing := GetSub2ApiAuthFromExtraConfig(existingExtraConfig)
+	return MergeSub2ApiAuth(existing, rt, exp)
+}
+
 // BuildStoredSub2ApiSubscriptionSummary builds a storable subscription summary.
 func BuildStoredSub2ApiSubscriptionSummary(summary any) map[string]any {
 	return map[string]any{
@@ -88,7 +232,7 @@ func BuildStoredSub2ApiSubscriptionSummary(summary any) map[string]any {
 
 // IsSub2ApiPlatform checks if a platform is Sub2Api.
 func IsSub2ApiPlatform(platform string) bool {
-	return strings.ToLower(platform) == "sub2api"
+	return strings.EqualFold(strings.TrimSpace(platform), "sub2api")
 }
 
 // IsManagedSub2ApiTokenDue checks if a managed Sub2Api token needs refresh.

--- a/service/account_extra_config_test.go
+++ b/service/account_extra_config_test.go
@@ -1,0 +1,140 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeManagedRefreshToken(t *testing.T) {
+	t.Parallel()
+	if _, ok := NormalizeManagedRefreshToken(nil); ok {
+		t.Fatal("nil should be invalid")
+	}
+	if _, ok := NormalizeManagedRefreshToken("  "); ok {
+		t.Fatal("blank should be invalid")
+	}
+	if _, ok := NormalizeManagedRefreshToken(123); ok {
+		t.Fatal("non-string should be invalid")
+	}
+	got, ok := NormalizeManagedRefreshToken("  rt_abc  ")
+	if !ok || got != "rt_abc" {
+		t.Fatalf("got (%q, %v), want (rt_abc, true)", got, ok)
+	}
+}
+
+func TestNormalizeManagedTokenExpiresAt(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   any
+		want int64
+		ok   bool
+	}{
+		{"nil", nil, 0, false},
+		{"zero", 0, 0, false},
+		{"negative", -1, 0, false},
+		{"int", 1712345678, 1712345678, true},
+		{"float", float64(1712345678), 1712345678, true},
+		{"string", "1712345678", 1712345678, true},
+		{"jsonNumber", json.Number("1712345678"), 1712345678, true},
+		{"blank", "  ", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := NormalizeManagedTokenExpiresAt(tc.in)
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("got (%d, %v), want (%d, %v)", got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestMergeSub2ApiAuth_PreserveAndOverwrite(t *testing.T) {
+	t.Parallel()
+	existing := map[string]any{
+		"refreshToken":   "rt_old",
+		"tokenExpiresAt": int64(100),
+		"custom":         "keep-me",
+	}
+
+	// Partial overwrite of refreshToken only.
+	merged := MergeSub2ApiAuth(existing, "rt_new", nil)
+	if merged["refreshToken"] != "rt_new" {
+		t.Fatalf("refreshToken = %v, want rt_new", merged["refreshToken"])
+	}
+	if merged["tokenExpiresAt"] != int64(100) {
+		t.Fatalf("tokenExpiresAt = %v, want preserved 100", merged["tokenExpiresAt"])
+	}
+	if merged["custom"] != "keep-me" {
+		t.Fatalf("custom = %v, want keep-me", merged["custom"])
+	}
+
+	// Invalid incoming values preserve existing.
+	merged = MergeSub2ApiAuth(existing, "  ", -5)
+	if merged["refreshToken"] != "rt_old" {
+		t.Fatalf("invalid refresh should preserve old, got %v", merged["refreshToken"])
+	}
+	if merged["tokenExpiresAt"] != int64(100) {
+		t.Fatalf("invalid expires should preserve old, got %v", merged["tokenExpiresAt"])
+	}
+}
+
+func TestBuildMergedSub2ApiAuth_TopLevelAndNested(t *testing.T) {
+	t.Parallel()
+	existing := `{"credentialMode":"session","proxyUrl":"http://proxy","sub2apiAuth":{"refreshToken":"rt_old","tokenExpiresAt":100,"custom":"keep-me"}}`
+	rt := "rt_top"
+	exp := int64(200)
+	patch := map[string]any{
+		"sub2apiAuth": map[string]any{
+			"refreshToken":   "rt_nested",
+			"tokenExpiresAt": int64(150),
+		},
+	}
+
+	// Top-level wins over nested patch.
+	merged := BuildMergedSub2ApiAuth(&existing, &rt, &exp, patch)
+	if merged == nil {
+		t.Fatal("expected merged auth")
+	}
+	if merged["refreshToken"] != "rt_top" {
+		t.Fatalf("refreshToken = %v, want rt_top", merged["refreshToken"])
+	}
+	if merged["tokenExpiresAt"] != int64(200) {
+		t.Fatalf("tokenExpiresAt = %v, want 200", merged["tokenExpiresAt"])
+	}
+	if merged["custom"] != "keep-me" {
+		t.Fatalf("custom = %v, want keep-me", merged["custom"])
+	}
+
+	// Nested-only partial update preserves other auth fields.
+	merged = BuildMergedSub2ApiAuth(&existing, nil, nil, map[string]any{
+		"sub2apiAuth": map[string]any{"tokenExpiresAt": int64(333)},
+	})
+	if merged["refreshToken"] != "rt_old" {
+		t.Fatalf("refreshToken = %v, want rt_old", merged["refreshToken"])
+	}
+	if merged["tokenExpiresAt"] != int64(333) {
+		t.Fatalf("tokenExpiresAt = %v, want 333", merged["tokenExpiresAt"])
+	}
+
+	// No incoming fields => nil (leave alone).
+	if got := BuildMergedSub2ApiAuth(&existing, nil, nil, nil); got != nil {
+		t.Fatalf("expected nil when no incoming fields, got %#v", got)
+	}
+
+	// Invalid blank top-level should not write.
+	blank := "  "
+	if got := BuildMergedSub2ApiAuth(&existing, &blank, nil, nil); got != nil {
+		t.Fatalf("expected nil for blank refresh, got %#v", got)
+	}
+}
+
+func TestIsSub2ApiPlatform(t *testing.T) {
+	t.Parallel()
+	if !IsSub2ApiPlatform("sub2api") || !IsSub2ApiPlatform(" Sub2API ") {
+		t.Fatal("expected sub2api platform match")
+	}
+	if IsSub2ApiPlatform("anyrouter") {
+		t.Fatal("anyrouter should not match")
+	}
+}


### PR DESCRIPTION
## Summary
- Merge `extraConfig.sub2apiAuth` refreshToken / tokenExpiresAt on account update and rebind-session for sub2api platforms
- Preserve unrelated extraConfig keys
- Tests + residual analysis doc

Closes #194

## Test plan
- [x] `go test ./handler/admin ./service -count=1`