### PR TITLE
fix(store): CreateSite RETURNING id for PostgreSQL (#204)

### DIFF
--- a/docs/analysis/pg-create-site-fix.md
+++ b/docs/analysis/pg-create-site-fix.md
@@ -34,3 +34,15 @@ go test ./service ./handler/admin -count=1 -run 'Site|CreateSite'
 # with PG_TEST_DSN set:
 go test ./handler/admin -count=1 -run 'Sites_Postgres'
 ```
+
+
+## Follow-up root cause (shared PG CI)
+
+Even after RETURNING id, LoadSiteWithEndpoints used `SELECT * FROM sites`. Shared CI Postgres had a leftover column `sc1_test_probe_col` from schema experiments, so sqlx failed:
+
+```
+missing destination name sc1_test_probe_col in *store.Site
+```
+
+### Fix
+Use explicit `siteSelectColumns` for LoadSiteWithEndpoints / ListSites (never SELECT *).

--- a/docs/analysis/pg-create-site-fix.md
+++ b/docs/analysis/pg-create-site-fix.md
@@ -1,0 +1,36 @@
+# PostgreSQL CreateSite LastInsertId flake (#204)
+
+Last updated: 2026-07-17
+
+## Symptom
+
+CI `test-pg` / release-gate intermittently (often always under shared PG) failed:
+
+```
+TestSites_Postgres_CreateUpdateAndDisabledModels
+postgres create site: expected 200, got 500: {"error":"Create site failed"}
+```
+
+Also hit token-routes PG tests that create sites with endpoints via API.
+
+## Root cause
+
+`service.CreateSite` used `tx.Exec` + `LastInsertId()`:
+
+- **SQLite**: LastInsertId works.
+- **PostgreSQL (lib/pq / pgx)**: LastInsertId is unsupported; the code fell back to a post-insert `SELECT id ... ORDER BY id DESC` **without checking Get error**, so a failed/empty select left `siteID=0`.
+- Subsequent `UpsertSiteAPIEndpoints` then inserted `site_api_endpoints.site_id = 0`, violating FK → transaction error → handler maps to `"Create site failed"`.
+
+Race with concurrent site creates could also make the SELECT-by-name/url/platform ambiguous under shared DBs.
+
+## Fix
+
+Insert with `RETURNING id` scanned via `QueryRowx` inside the open transaction so both dialects return the real PK before endpoint rows are written. Reject `siteID <= 0` explicitly.
+
+## Verify
+
+```bash
+go test ./service ./handler/admin -count=1 -run 'Site|CreateSite'
+# with PG_TEST_DSN set:
+go test ./handler/admin -count=1 -run 'Sites_Postgres'
+```

--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -185,9 +185,13 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.CustomHeaders != nil {
 		siteData["customHeaders"] = *body.CustomHeaders
+	} else {
+		siteData["customHeaders"] = nil
 	}
 	if body.ExternalCheckinURL != nil {
 		siteData["externalCheckinUrl"] = service.NormalizeNullable(body.ExternalCheckinURL)
+	} else {
+		siteData["externalCheckinUrl"] = nil
 	}
 
 	// Convert apiEndpoints
@@ -209,12 +213,19 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusConflict, fmt.Sprintf("A %s site with URL %s already exists.", platform, canonicalURL))
 			return
 		}
+		slog.Error("CreateSite failed", "err", createErr, "platform", platform, "url", canonicalURL)
 		writeError(w, http.StatusInternalServerError, "Create site failed")
 		return
 	}
 
-	result, _ := service.LoadSiteWithEndpoints(h.db, createdID)
+	result, loadErr := service.LoadSiteWithEndpoints(h.db, createdID)
+	if loadErr != nil {
+		slog.Error("LoadSiteWithEndpoints after create failed", "err", loadErr, "site_id", createdID)
+		writeError(w, http.StatusInternalServerError, "Create site failed")
+		return
+	}
 	if result == nil {
+		slog.Error("LoadSiteWithEndpoints returned nil after create", "site_id", createdID)
 		writeError(w, http.StatusInternalServerError, "Create site failed")
 		return
 	}

--- a/handler/admin/sites_create_endpoints_test.go
+++ b/handler/admin/sites_create_endpoints_test.go
@@ -1,0 +1,40 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestSites_CreateWithAPIEndpoints_SQLite(t *testing.T) {
+	_, r := setupSitesTest(t)
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 36)
+	siteURL := "https://sqlite-sites-ep-" + suffix + ".example.com"
+	endpointURL := siteURL + "/v1"
+
+	resp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "SQLite Sites EP " + suffix,
+		"url":      siteURL,
+		"platform": "openai",
+		"apiEndpoints": []map[string]any{
+			{"url": endpointURL, "enabled": true, "sortOrder": 0},
+		},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("create site with endpoints: %d %s", resp.Code, resp.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &created); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	id, ok := created["id"].(float64)
+	if !ok || id <= 0 {
+		t.Fatalf("id=%v", created["id"])
+	}
+	eps, _ := created["apiEndpoints"].([]any)
+	if len(eps) != 1 {
+		t.Fatalf("apiEndpoints=%v", created["apiEndpoints"])
+	}
+}

--- a/service/site_create_test.go
+++ b/service/site_create_test.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func TestCreateSite_WithAPIEndpointsSQLite(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	id, err := CreateSite(db.DB, map[string]any{
+		"name":         "CreateSite Endpoints",
+		"url":          "https://create-site-endpoints.example.com",
+		"platform":     "openai",
+		"status":       "active",
+		"isPinned":     false,
+		"globalWeight": 1.0,
+		"maxConcurrency": int64(0),
+		"proxyUrl":     nil,
+		"useSystemProxy": false,
+		"customHeaders": nil,
+		"externalCheckinUrl": nil,
+		"postRefreshProbeEnabled": false,
+		"postRefreshProbeModel": "",
+		"postRefreshProbeScope": "single",
+		"postRefreshProbeLatencyThresholdMs": 0,
+		"apiEndpoints": []store.SiteAPIEndpoint{
+			{URL: "https://create-site-endpoints.example.com/v1", Enabled: true, SortOrder: 0},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("id=%d", id)
+	}
+
+	eps, err := LoadSiteAPIEndpoints(db.DB, []int64{id})
+	if err != nil {
+		t.Fatalf("LoadSiteAPIEndpoints: %v", err)
+	}
+	list := eps[id]
+	if len(list) != 1 {
+		t.Fatalf("endpoints=%d want 1", len(list))
+	}
+	if list[0].SiteID != id {
+		t.Fatalf("endpoint site_id=%d want %d", list[0].SiteID, id)
+	}
+}

--- a/service/site_service.go
+++ b/service/site_service.go
@@ -150,10 +150,18 @@ func LoadSiteAPIEndpoints(db *sqlx.DB, siteIDs []int64) (map[int64][]store.SiteA
 	return result, nil
 }
 
+// siteSelectColumns lists known sites columns for SELECT (never SELECT *).
+// Shared PG CI DBs may have leftover probe columns from schema experiments;
+// SELECT * would fail struct scan with "missing destination name ...".
+const siteSelectColumns = `id, name, url, external_checkin_url, platform, proxy_url, use_system_proxy,
+	custom_headers, status, is_pinned, sort_order, global_weight, api_key, max_concurrency,
+	post_refresh_probe_enabled, post_refresh_probe_model, post_refresh_probe_scope,
+	post_refresh_probe_latency_threshold_ms, created_at, updated_at`
+
 // LoadSiteWithEndpoints loads a single site with its apiEndpoints attached.
 func LoadSiteWithEndpoints(db *sqlx.DB, siteID int64) (map[string]any, error) {
 	var site store.Site
-	err := db.Get(&site, db.Rebind("SELECT * FROM sites WHERE id = ?"), siteID)
+	err := db.Get(&site, db.Rebind("SELECT "+siteSelectColumns+" FROM sites WHERE id = ?"), siteID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -200,7 +208,7 @@ func siteToMap(site store.Site, endpoints []store.SiteAPIEndpoint) map[string]an
 // ListSites returns all sites with apiEndpoints, totalBalance, and subscriptionSummary.
 func ListSites(db *sqlx.DB) ([]map[string]any, error) {
 	var sites []store.Site
-	if err := db.Select(&sites, "SELECT * FROM sites ORDER BY sort_order, id"); err != nil {
+	if err := db.Select(&sites, "SELECT "+siteSelectColumns+" FROM sites ORDER BY sort_order, id"); err != nil {
 		return nil, err
 	}
 

--- a/service/site_service.go
+++ b/service/site_service.go
@@ -280,12 +280,16 @@ func CreateSite(db *sqlx.DB, siteData map[string]any) (int64, error) {
 		}
 	}
 
-	result, err := tx.Exec(
+	// Use RETURNING so PostgreSQL (no LastInsertId) and SQLite both get a real id
+	// inside the open transaction before apiEndpoints FK inserts.
+	var siteID int64
+	err = tx.QueryRowx(
 		tx.Rebind(`INSERT INTO sites (name, url, platform, proxy_url, use_system_proxy, custom_headers,
 		 external_checkin_url, status, is_pinned, sort_order, global_weight, max_concurrency,
 		 post_refresh_probe_enabled, post_refresh_probe_model, post_refresh_probe_scope,
 		 post_refresh_probe_latency_threshold_ms, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 RETURNING id`),
 		name, urlStr, platform,
 		siteData["proxyUrl"], siteData["useSystemProxy"], siteData["customHeaders"],
 		siteData["externalCheckinUrl"], siteData["status"], siteData["isPinned"],
@@ -293,16 +297,12 @@ func CreateSite(db *sqlx.DB, siteData map[string]any) (int64, error) {
 		siteData["postRefreshProbeEnabled"], siteData["postRefreshProbeModel"],
 		siteData["postRefreshProbeScope"], siteData["postRefreshProbeLatencyThresholdMs"],
 		now, now,
-	)
+	).Scan(&siteID)
 	if err != nil {
 		return 0, err
 	}
-
-	siteID, err := result.LastInsertId()
-	if err != nil {
-		var id int64
-		tx.Get(&id, tx.Rebind("SELECT id FROM sites WHERE name = ? AND url = ? AND platform = ? ORDER BY id DESC LIMIT 1"), name, urlStr, platform)
-		siteID = id
+	if siteID <= 0 {
+		return 0, fmt.Errorf("create site: invalid id %d", siteID)
 	}
 
 	// Insert apiEndpoints if present

--- a/service/site_service.go
+++ b/service/site_service.go
@@ -280,6 +280,39 @@ func CreateSite(db *sqlx.DB, siteData map[string]any) (int64, error) {
 		}
 	}
 
+	useSystemProxy, _ := siteData["useSystemProxy"].(bool)
+	isPinned, _ := siteData["isPinned"].(bool)
+	postRefreshProbeEnabled, _ := siteData["postRefreshProbeEnabled"].(bool)
+	postRefreshProbeModel, _ := siteData["postRefreshProbeModel"].(string)
+	postRefreshProbeScope, _ := siteData["postRefreshProbeScope"].(string)
+	if postRefreshProbeScope == "" {
+		postRefreshProbeScope = "single"
+	}
+	postRefreshProbeLatencyThresholdMs := int64(0)
+	switch v := siteData["postRefreshProbeLatencyThresholdMs"].(type) {
+	case int64:
+		postRefreshProbeLatencyThresholdMs = v
+	case int:
+		postRefreshProbeLatencyThresholdMs = int64(v)
+	case float64:
+		postRefreshProbeLatencyThresholdMs = int64(v)
+	}
+	status, _ := siteData["status"].(string)
+	if status == "" {
+		status = "active"
+	}
+	globalWeight := 1.0
+	switch v := siteData["globalWeight"].(type) {
+	case float64:
+		globalWeight = v
+	case float32:
+		globalWeight = float64(v)
+	case int:
+		globalWeight = float64(v)
+	case int64:
+		globalWeight = float64(v)
+	}
+
 	// Use RETURNING so PostgreSQL (no LastInsertId) and SQLite both get a real id
 	// inside the open transaction before apiEndpoints FK inserts.
 	var siteID int64
@@ -291,11 +324,11 @@ func CreateSite(db *sqlx.DB, siteData map[string]any) (int64, error) {
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 RETURNING id`),
 		name, urlStr, platform,
-		siteData["proxyUrl"], siteData["useSystemProxy"], siteData["customHeaders"],
-		siteData["externalCheckinUrl"], siteData["status"], siteData["isPinned"],
-		sortOrder, siteData["globalWeight"], maxConcurrency,
-		siteData["postRefreshProbeEnabled"], siteData["postRefreshProbeModel"],
-		siteData["postRefreshProbeScope"], siteData["postRefreshProbeLatencyThresholdMs"],
+		siteData["proxyUrl"], useSystemProxy, siteData["customHeaders"],
+		siteData["externalCheckinUrl"], status, isPinned,
+		sortOrder, globalWeight, maxConcurrency,
+		postRefreshProbeEnabled, postRefreshProbeModel,
+		postRefreshProbeScope, postRefreshProbeLatencyThresholdMs,
 		now, now,
 	).Scan(&siteID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `service.CreateSite` uses `RETURNING id` so PostgreSQL gets a real PK before `site_api_endpoints` inserts
- Fixes release-gate / test-pg `Create site failed` flake
- SQLite unit test + analysis doc

Closes #204

## Test plan
- [x] `go test ./service -count=1 -run CreateSite`
- [ ] CI test-pg