### PR TITLE
fix(proxy): forward multipart /v1/images/edits (Closes #207)

### DIFF
--- a/docs/analysis/images-multipart-forward.md
+++ b/docs/analysis/images-multipart-forward.md
@@ -1,0 +1,59 @@
+# Images Multipart Forward (`POST /v1/images/edits`)
+
+**Date**: 2026-07-17  
+**Issue**: [#207](https://github.com/TokenDanceLab/metapi-go/issues/207)  
+**Lane**: p84 images multipart
+
+## Scope landed
+
+`HandleImagesEdits` no longer short-circuits multipart with a fake
+`https://example.com/edited-image.png` 200 body.
+
+| Path | Behavior |
+|------|----------|
+| `POST /v1/images/edits` (JSON) | `PrepareCtx` → `dispatchUpstream` (unchanged) |
+| `POST /v1/images/edits` (multipart) | `EnsureMultipartBufferParser` → `PrepareCtx` (sets `Ctx.Multipart`) → `dispatchUpstream` → `CloneMultipartBody` with `model` rewritten to selected channel `ActualModel` |
+| `POST /v1/images/generations` | JSON-only generations path (unchanged) |
+| `POST /v1/images/variations` | Still hard 400 unsupported |
+
+Shared machinery already used by videos/files:
+
+- `PrepareCtx` / `ParseMultipartFormData` for field extraction + model defaulting
+- `dispatchUpstream` multipart branch + `CloneMultipartBody`
+- Auth failure still returns 401 before dispatch; invalid multipart still 400
+
+## Residuals / honest limits
+
+1. **No image-specific response shaping** — upstream body is relayed as-is. Local
+   `METAPI_ENABLE_PROXY_STUB` still returns the generic chat.completion demo body
+   when upstream deps are unset (same as other surfaces); it is not an images
+   payload and is test/demo-only.
+2. **Mask / multi-file field contract** is whatever the selected upstream accepts
+   (`image`, optional `mask`, etc.). MetAPI clones the parsed multipart form; it
+   does not validate OpenAI image-edit field completeness beyond general multipart
+   size/count limits (`PROXY_MAX_MULTIPART_*`).
+3. **Platform support is uneven** — many non-OpenAI / chat-only sites will not
+   implement `/v1/images/edits`. Operators should bind image models only to
+   channels whose sites expose OpenAI-compatible image edits; failures surface as
+   real upstream errors after channel selection rather than fake local success.
+4. **`/v1/images/variations` remains unsupported** (explicit 400).
+5. **Streaming / progressive image APIs** are out of scope; edits remain a single
+   buffered multipart/JSON request.
+
+## Tests
+
+`handler/proxy/images_test.go`:
+
+- multipart unauthorized → 401, no example.com body
+- invalid multipart → 400, no example.com body
+- multipart + stub env + nil upstream → generic dispatchUpstream stub, not
+  example.com theater
+- multipart + wired upstream → path `/v1/images/edits`, model rewrite, file
+  payload preserved
+- multipart + stub disabled + nil upstream → 503 unavailable
+
+Verify:
+
+```bash
+go test ./handler/proxy -count=1 -run Image
+```

--- a/handler/proxy/images.go
+++ b/handler/proxy/images.go
@@ -23,6 +23,7 @@ func HandleImagesGenerations(w http.ResponseWriter, r *http.Request) {
 
 // HandleImagesEdits handles POST /v1/images/edits.
 // Supports multipart/form-data and JSON body. Model defaults to "gpt-image-1".
+// Multipart is parsed in PrepareCtx and forwarded via CloneMultipartBody in dispatchUpstream.
 func HandleImagesEdits(w http.ResponseWriter, r *http.Request) {
 	EnsureMultipartBufferParser()
 
@@ -34,21 +35,6 @@ func HandleImagesEdits(w http.ResponseWriter, r *http.Request) {
 	})
 	if errResp != nil {
 		writeJSONError(w, errResp.Status, errResp.Error, errResp.ErrorType)
-		return
-	}
-
-	// For multipart image edits, return stub until full image edit forwarding is implemented.
-	if IsMultipartRequest(r) {
-		_ = ctx.RequestedModel
-		stubResp := map[string]any{
-			"created": 0,
-			"data": []map[string]any{
-				{
-					"url": "https://example.com/edited-image.png",
-				},
-			},
-		}
-		writeJSON(w, 200, stubResp) // TODO: full multipart upstream forwarding
 		return
 	}
 

--- a/handler/proxy/images_test.go
+++ b/handler/proxy/images_test.go
@@ -8,6 +8,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/store"
 )
 
 // ---- HandleImagesGenerations ----
@@ -65,6 +68,10 @@ func TestHandleImagesEdits_JSONBody(t *testing.T) {
 	if m == nil {
 		t.Error("expected non-nil response")
 	}
+	// Must not be the retired multipart theater payload.
+	if body := rec.Body.String(); strings.Contains(body, "example.com/edited-image") {
+		t.Fatalf("unexpected retired stub payload: %s", body)
+	}
 }
 
 func TestHandleImagesEdits_Unauthorized(t *testing.T) {
@@ -95,6 +102,9 @@ func TestHandleImagesEdits_MultipartUnauthorized(t *testing.T) {
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401, got %d: %s", rec.Code, rec.Body.String())
 	}
+	if body := rec.Body.String(); strings.Contains(body, "example.com/edited-image") {
+		t.Fatalf("unexpected retired stub payload on unauthorized multipart: %s", body)
+	}
 }
 
 func TestHandleImagesEdits_InvalidMultipartReturnsBadRequest(t *testing.T) {
@@ -107,6 +117,197 @@ func TestHandleImagesEdits_InvalidMultipartReturnsBadRequest(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid multipart, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); strings.Contains(body, "example.com/edited-image") {
+		t.Fatalf("unexpected retired stub payload: %s", body)
+	}
+}
+
+func TestHandleImagesEdits_MultipartUsesDispatchUpstreamNotFakeImage(t *testing.T) {
+	// Default TestMain enables METAPI_ENABLE_PROXY_STUB with nil upstream config.
+	// Multipart edits must take the same dispatchUpstream path as JSON (generic
+	// proxy stub), never the retired example.com image theater.
+	SetUpstreamConfig(nil)
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	if err := writer.WriteField("model", "gpt-image-1"); err != nil {
+		t.Fatalf("write model field: %v", err)
+	}
+	if err := writer.WriteField("prompt", "add a hat"); err != nil {
+		t.Fatalf("write prompt field: %v", err)
+	}
+	part, err := writer.CreateFormFile("image", "source.png")
+	if err != nil {
+		t.Fatalf("create image field: %v", err)
+	}
+	if _, err := part.Write([]byte("fake-png-bytes")); err != nil {
+		t.Fatalf("write image field: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := makeProxyReqNoBody("POST", "/v1/images/edits")
+	req.Body = io.NopCloser(body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+	HandleImagesEdits(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 via proxy stub path, got %d: %s", rec.Code, rec.Body.String())
+	}
+	raw := rec.Body.String()
+	if strings.Contains(raw, "example.com/edited-image") || strings.Contains(raw, "https://example.com/") {
+		t.Fatalf("retired multipart theater payload still returned: %s", raw)
+	}
+	m := unmarshalResponse(t, rec)
+	// Generic METAPI_ENABLE_PROXY_STUB response (same family as JSON edits).
+	if m["object"] != "chat.completion" {
+		t.Fatalf("object = %v, want chat.completion from dispatchUpstream stub", m["object"])
+	}
+	if m["model"] != "gpt-image-1" {
+		t.Fatalf("model = %v, want gpt-image-1", m["model"])
+	}
+}
+
+func TestHandleImagesEdits_MultipartForwardsToUpstream(t *testing.T) {
+	var gotModel, gotPrompt, gotFilename string
+	var gotImageBody string
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer upstream-token" {
+			t.Errorf("Authorization = %q", got)
+		}
+		if got := r.Header.Get("Content-Type"); !strings.HasPrefix(got, "multipart/form-data;") {
+			t.Errorf("Content-Type = %q, want multipart/form-data", got)
+		}
+		if err := r.ParseMultipartForm(32 << 20); err != nil {
+			t.Errorf("parse upstream multipart: %v", err)
+			http.Error(w, "bad multipart", http.StatusBadRequest)
+			return
+		}
+		gotModel = r.FormValue("model")
+		gotPrompt = r.FormValue("prompt")
+		files := r.MultipartForm.File["image"]
+		if len(files) != 1 {
+			t.Errorf("image file count = %d, want 1", len(files))
+		} else {
+			gotFilename = files[0].Filename
+			f, err := files[0].Open()
+			if err != nil {
+				t.Errorf("open image: %v", err)
+			} else {
+				defer f.Close()
+				data, _ := io.ReadAll(f)
+				gotImageBody = string(data)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created":1710000000,"data":[{"b64_json":"ZmFrZQ=="}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:     store.RouteChannel{ID: 42, Enabled: true},
+			Account:     store.Account{ID: 7, Status: "active"},
+			Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active"},
+			TokenValue:  "upstream-token",
+			ActualModel: "gpt-image-1-upstream",
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	if err := writer.WriteField("model", "gpt-image-1"); err != nil {
+		t.Fatalf("write model field: %v", err)
+	}
+	if err := writer.WriteField("prompt", "add a hat"); err != nil {
+		t.Fatalf("write prompt field: %v", err)
+	}
+	part, err := writer.CreateFormFile("image", "source.png")
+	if err != nil {
+		t.Fatalf("create image field: %v", err)
+	}
+	if _, err := part.Write([]byte("fake-png-bytes")); err != nil {
+		t.Fatalf("write image field: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := makeProxyReqNoBody("POST", "/v1/images/edits")
+	req.Body = io.NopCloser(body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+	HandleImagesEdits(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if gotPath != "/v1/images/edits" {
+		t.Fatalf("upstream path = %q, want /v1/images/edits", gotPath)
+	}
+	if gotModel != "gpt-image-1-upstream" {
+		t.Fatalf("upstream model = %q, want gpt-image-1-upstream (ActualModel rewrite)", gotModel)
+	}
+	if gotPrompt != "add a hat" {
+		t.Fatalf("prompt = %q", gotPrompt)
+	}
+	if gotFilename != "source.png" {
+		t.Fatalf("filename = %q", gotFilename)
+	}
+	if gotImageBody != "fake-png-bytes" {
+		t.Fatalf("image body = %q", gotImageBody)
+	}
+	raw := rec.Body.String()
+	if strings.Contains(raw, "example.com/edited-image") {
+		t.Fatalf("retired stub payload mixed with upstream response: %s", raw)
+	}
+	if !strings.Contains(raw, "ZmFrZQ==") {
+		t.Fatalf("body = %q, want upstream edit payload", raw)
+	}
+}
+
+func TestHandleImagesEdits_MultipartNoUpstreamNoStubReturnsUnavailable(t *testing.T) {
+	t.Setenv("METAPI_ENABLE_PROXY_STUB", "0")
+	SetUpstreamConfig(nil)
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	if err := writer.WriteField("prompt", "add a hat"); err != nil {
+		t.Fatalf("write prompt field: %v", err)
+	}
+	part, err := writer.CreateFormFile("image", "source.png")
+	if err != nil {
+		t.Fatalf("create image field: %v", err)
+	}
+	if _, err := part.Write([]byte("fake-png-bytes")); err != nil {
+		t.Fatalf("write image field: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := makeProxyReqNoBody("POST", "/v1/images/edits")
+	req.Body = io.NopCloser(body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+	HandleImagesEdits(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when stub disabled and upstream unset, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); strings.Contains(body, "example.com/edited-image") {
+		t.Fatalf("unexpected retired stub payload: %s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove the multipart-only `example.com/edited-image.png` theater from `HandleImagesEdits`
- Multipart edits now take the same `PrepareCtx` → `dispatchUpstream` path as JSON (body rebuilt via `CloneMultipartBody` with `ActualModel` rewrite)
- Add tests for no-stub payload, auth failure, stub path, and real upstream multipart forward
- Document residuals in `docs/analysis/images-multipart-forward.md`

Closes #207

## Test plan
- [x] `go test ./handler/proxy -count=1 -run Image`
- [ ] CI green on PR