### PR TITLE
feat(tokens): GetUserGroups with local fallback (#206)

### DIFF
--- a/docs/analysis/token-groups-upstream.md
+++ b/docs/analysis/token-groups-upstream.md
@@ -1,0 +1,78 @@
+# Token Groups from Upstream (#206)
+
+Last updated: 2026-07-17
+
+## Problem
+
+`GET /api/account-tokens/groups/{accountId}` previously returned only local
+`SELECT DISTINCT COALESCE(token_group, 'default')` from `account_tokens`.
+
+TS `accountTokens.ts` calls `adapter.getUserGroups()` so the UI can offer
+server-managed groups that may not yet exist as local token rows.
+
+## Design
+
+### Handler (`handler/admin/account_tokens.go`)
+
+`getGroups` still:
+
+1. Loads account + site
+2. Rejects API-key connections (`IsAPIKeyConnection`)
+
+Then builds proxy config via `BuildPlatformProxyConfig(h.cfg, ...)` (cfg may be
+nil — already supported by `RegisterAccountTokensRoutesWithConfig`) and calls:
+
+```text
+service.GetTokenGroups(ctx, db, accountID, adapter, siteURL, accessToken, platformUserID, proxy)
+```
+
+### Service (`service/account_token_service.go`)
+
+| Helper | Role |
+|--------|------|
+| `NormalizeTokenGroups` | trim + dedupe; empty → `["default"]` |
+| `GetLocalTokenGroups` | local DISTINCT + normalize |
+| `GetTokenGroups` | upstream-first with local fallback |
+
+Upstream path is used only when:
+
+- `adapter != nil`
+- `accessToken` is non-empty after trim
+
+Fallback to local when:
+
+- adapter is nil
+- access token missing
+- `GetUserGroups` returns error
+- upstream returns only blank strings / empty slice
+
+Upstream errors are **not** surfaced as HTTP 5xx for groups: local rows remain a
+usable picker source. Only local DB failures return 500.
+
+## Platform coverage
+
+`platform.PlatformAdapter.GetUserGroups` already exists:
+
+| Platform | Behavior |
+|----------|----------|
+| NewAPI / AnyRouter | `/api/user/self/groups` then `/api/user_group_map` (+ cookie fallback) |
+| OneAPI | `/api/user_group_map` then `/api/user/self/groups` |
+| OneHub / DoneHub | `/api/user_group_map` then OneAPI |
+| Sub2API | key/group endpoints + key inference; else `default` |
+| Base / OpenAI-style | `["default"]` |
+
+## Tests
+
+```bash
+go test ./service ./handler/admin -count=1 -run 'Group|Token'
+```
+
+- Service: fake `stubTokenAdapter` covers prefer-upstream, error/empty/nil
+  adapter fallback, missing access token skip, default when empty.
+- Handler: httptest NewAPI fake serves group endpoints; unsupported platform
+  falls back to local DISTINCT groups. Existing API-key reject test retained.
+
+## Residual
+
+- Groups are not persisted into local rows by this endpoint (read-only picker).
+- Masked / apikey connections remain out of scope for group listing.

--- a/handler/admin/account_tokens.go
+++ b/handler/admin/account_tokens.go
@@ -774,7 +774,24 @@ func (h *accountTokensHandler) getGroups(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	groups, err := service.GetTokenGroups(h.db, accountID)
+	accessToken := strings.TrimSpace(row.Account.AccessToken)
+	adapter := platform.GetAdapter(row.Site.Platform)
+	proxyCfg := service.BuildPlatformProxyConfig(h.cfg, &row.Account, &row.Site)
+	platformUserID := service.ResolvePlatformUserIDPtr(&row.Account)
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	groups, err := service.GetTokenGroups(
+		ctx,
+		h.db,
+		accountID,
+		adapter,
+		row.Site.URL,
+		accessToken,
+		platformUserID,
+		proxyCfg,
+	)
 	if err != nil {
 		slog.Error("Failed to load token groups", "err", err, "account_id", accountID)
 		writeError(w, http.StatusInternalServerError, "Failed to load token groups")

--- a/handler/admin/account_tokens_adapter_test.go
+++ b/handler/admin/account_tokens_adapter_test.go
@@ -35,6 +35,17 @@ func (f *fakeNewAPIUpstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"data":    map[string]any{"system_name": "New API"},
 		})
 		return
+	case path == "/api/user/self/groups" || path == "/api/user_group_map":
+		// NewApi GetUserGroups tries self/groups then user_group_map.
+		// Return map keys as group names for extractGroupKeys.
+		writeJSON(w, http.StatusOK, map[string]any{
+			"success": true,
+			"data": map[string]any{
+				"vip":     map[string]any{"desc": "VIP"},
+				"default": map[string]any{"desc": "Default"},
+			},
+		})
+		return
 	case strings.HasPrefix(path, "/api/token"):
 		f.mu.Lock()
 		defer f.mu.Unlock()
@@ -320,5 +331,78 @@ func TestTokens_CreateUpstream_MissingAdapter(t *testing.T) {
 	resp := doPostJSON(t, r, "/api/account-tokens", map[string]any{"accountId": accountID, "name": "x"})
 	if resp.Code != http.StatusBadGateway {
 		t.Fatalf("expected 502 for missing adapter, got %d %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestTokens_GetGroups_FromUpstream(t *testing.T) {
+	db, r := setupTokensTest(t)
+	fake := newFakeNewAPIUpstream()
+	srv := httptest.NewServer(fake)
+	t.Cleanup(srv.Close)
+
+	_, accountID := tokenFixtureWithPlatform(t, db, "NewAPI Groups Site", srv.URL, "new-api")
+	// Local only has group-a; upstream returns vip + default and should win.
+	createTokenFixture(t, db, accountID, "local", "sk-local-group", "group-a", true, true)
+
+	resp := doGet(t, r, "/api/account-tokens/groups/"+itoa(accountID))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("get groups: %d %s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result["success"] != true {
+		t.Fatalf("expected success=true, got %#v", result)
+	}
+	groups, _ := result["groups"].([]any)
+	set := map[string]bool{}
+	for _, g := range groups {
+		if s, ok := g.(string); ok {
+			set[s] = true
+		}
+	}
+	if !set["vip"] || !set["default"] {
+		t.Fatalf("expected upstream vip+default, got %#v", groups)
+	}
+	if set["group-a"] {
+		t.Fatalf("local-only group should not replace upstream groups: %#v", groups)
+	}
+}
+
+func TestTokens_GetGroups_LocalFallbackWhenUpstreamMissing(t *testing.T) {
+	db, r := setupTokensTest(t)
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	// Unsupported platform → adapter nil → local DISTINCT groups.
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, ?, 'active', ?, ?)`,
+		"No Groups Adapter", "https://no-groups.example.com", "not-a-platform", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+	extra := `{"credentialMode":"session"}`
+	res, err = db.Exec(
+		`INSERT INTO accounts (site_id, access_token, status, checkin_enabled, extra_config, created_at, updated_at)
+		 VALUES (?, 'session-token', 'active', 1, ?, ?, ?)`,
+		siteID, &extra, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ := res.LastInsertId()
+	createTokenFixture(t, db, accountID, "t1", "sk-t1", "group-a", true, true)
+	createTokenFixture(t, db, accountID, "t2", "sk-t2", "group-b", true, false)
+
+	resp := doGet(t, r, "/api/account-tokens/groups/"+itoa(accountID))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("get groups fallback: %d %s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &result)
+	groups, _ := result["groups"].([]any)
+	if len(groups) < 2 {
+		t.Fatalf("expected local groups, got %#v", result)
 	}
 }

--- a/handler/admin/account_tokens_test.go
+++ b/handler/admin/account_tokens_test.go
@@ -868,7 +868,26 @@ func TestTokens_SyncAll_Background(t *testing.T) {
 
 func TestTokens_GetGroups(t *testing.T) {
 	db, r := setupTokensTest(t)
-	_, accountID := tokenFixture(t, db, r)
+	// Unsupported platform keeps adapter nil so this path exercises local DISTINCT groups.
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, ?, 'active', ?, ?)`,
+		"Local Groups Site", "https://local-groups.example.com", "not-a-platform", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+	extra := `{"credentialMode":"session"}`
+	res, err = db.Exec(
+		`INSERT INTO accounts (site_id, access_token, status, checkin_enabled, extra_config, created_at, updated_at)
+		 VALUES (?, 'session-token', 'active', 1, ?, ?, ?)`,
+		siteID, &extra, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ := res.LastInsertId()
 	createTokenFixture(t, db, accountID, "t1", "sk-t1", "group-a", true, false)
 	createTokenFixture(t, db, accountID, "t2", "sk-t2", "group-b", true, false)
 

--- a/service/account_token_adapter_helpers_test.go
+++ b/service/account_token_adapter_helpers_test.go
@@ -13,6 +13,10 @@ type stubTokenAdapter struct {
 	tokens []platform.ApiTokenInfo
 	single *string
 	err    error
+
+	groups       []string
+	groupsErr    error
+	groupsCalled int
 }
 
 func (s *stubTokenAdapter) PlatformName() string { return "stub-token" }
@@ -23,6 +27,11 @@ func (s *stubTokenAdapter) GetAPITokens(ctx context.Context, url, accessToken st
 
 func (s *stubTokenAdapter) GetAPIToken(ctx context.Context, url, accessToken string, platformUserId *int, proxy *platform.ProxyConfig) (*string, error) {
 	return s.single, s.err
+}
+
+func (s *stubTokenAdapter) GetUserGroups(ctx context.Context, url, accessToken string, platformUserId *int, proxy *platform.ProxyConfig) ([]string, error) {
+	s.groupsCalled++
+	return s.groups, s.groupsErr
 }
 
 func TestPlatformAPITokensToUpstream(t *testing.T) {
@@ -99,4 +108,123 @@ func TestSyncTokensFromUpstream_CreatesAndUpdates(t *testing.T) {
 	if !enabled {
 		t.Fatalf("enabled should be preserved as true")
 	}
+}
+
+func TestNormalizeTokenGroups(t *testing.T) {
+	got := NormalizeTokenGroups([]string{" vip ", "", "vip", "default", "  "})
+	if len(got) != 2 || got[0] != "vip" || got[1] != "default" {
+		t.Fatalf("unexpected groups: %#v", got)
+	}
+	got = NormalizeTokenGroups(nil)
+	if len(got) != 1 || got[0] != "default" {
+		t.Fatalf("empty should become default, got %#v", got)
+	}
+}
+
+func TestGetTokenGroups_PrefersUpstream(t *testing.T) {
+	db := openTestDB(t)
+	siteID := createTestSite(t, db, "GroupSite", "https://groups.example.com", "new-api")
+	accountID := createTestAccount(t, db, siteID, strPtr("u1"), "session-token")
+	_ = createTestAccountToken(t, db, accountID, "local", "sk-local", true)
+	// local group default only; upstream should win
+	if _, err := db.Exec(`UPDATE account_tokens SET token_group = ? WHERE account_id = ?`, "local-only", accountID); err != nil {
+		t.Fatalf("set local group: %v", err)
+	}
+
+	adp := &stubTokenAdapter{groups: []string{" vip ", "vip", "default", " "}}
+	got, err := GetTokenGroups(context.Background(), db.DB, accountID, adp, "https://groups.example.com", "session-token", nil, nil)
+	if err != nil {
+		t.Fatalf("GetTokenGroups: %v", err)
+	}
+	if adp.groupsCalled != 1 {
+		t.Fatalf("groupsCalled=%d want 1", adp.groupsCalled)
+	}
+	if len(got) != 2 || got[0] != "vip" || got[1] != "default" {
+		t.Fatalf("unexpected upstream groups: %#v", got)
+	}
+}
+
+func TestGetTokenGroups_FallbackOnErrorEmptyNilAdapter(t *testing.T) {
+	db := openTestDB(t)
+	siteID := createTestSite(t, db, "GroupFallback", "https://groups-fallback.example.com", "new-api")
+	accountID := createTestAccount(t, db, siteID, strPtr("u1"), "session-token")
+	if _, err := db.Exec(
+		`INSERT INTO account_tokens (account_id, name, token, token_group, value_status, source, enabled, is_default, created_at, updated_at)
+		 VALUES (?, 'a', 'sk-a', 'group-a', 'ready', 'manual', 1, 1, datetime('now'), datetime('now'))`,
+		accountID,
+	); err != nil {
+		t.Fatalf("insert local token: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO account_tokens (account_id, name, token, token_group, value_status, source, enabled, is_default, created_at, updated_at)
+		 VALUES (?, 'b', 'sk-b', 'group-b', 'ready', 'manual', 1, 0, datetime('now'), datetime('now'))`,
+		accountID,
+	); err != nil {
+		t.Fatalf("insert local token b: %v", err)
+	}
+
+	// adapter error → local
+	errAdp := &stubTokenAdapter{groupsErr: context.DeadlineExceeded}
+	got, err := GetTokenGroups(context.Background(), db.DB, accountID, errAdp, "https://x", "session-token", nil, nil)
+	if err != nil {
+		t.Fatalf("error path: %v", err)
+	}
+	if !containsAllStrings(got, "group-a", "group-b") {
+		t.Fatalf("error fallback groups=%#v", got)
+	}
+
+	// empty upstream → local
+	emptyAdp := &stubTokenAdapter{groups: []string{"", "  "}}
+	got, err = GetTokenGroups(context.Background(), db.DB, accountID, emptyAdp, "https://x", "session-token", nil, nil)
+	if err != nil {
+		t.Fatalf("empty path: %v", err)
+	}
+	if !containsAllStrings(got, "group-a", "group-b") {
+		t.Fatalf("empty fallback groups=%#v", got)
+	}
+
+	// nil adapter → local, no panic
+	got, err = GetTokenGroups(context.Background(), db.DB, accountID, nil, "https://x", "session-token", nil, nil)
+	if err != nil {
+		t.Fatalf("nil adapter path: %v", err)
+	}
+	if !containsAllStrings(got, "group-a", "group-b") {
+		t.Fatalf("nil adapter groups=%#v", got)
+	}
+
+	// missing access token → local without calling adapter
+	skipAdp := &stubTokenAdapter{groups: []string{"should-not-use"}}
+	got, err = GetTokenGroups(context.Background(), db.DB, accountID, skipAdp, "https://x", "  ", nil, nil)
+	if err != nil {
+		t.Fatalf("no access token path: %v", err)
+	}
+	if skipAdp.groupsCalled != 0 {
+		t.Fatalf("adapter should not be called without access token")
+	}
+	if !containsAllStrings(got, "group-a", "group-b") {
+		t.Fatalf("no-token groups=%#v", got)
+	}
+
+	// no local rows → default
+	emptyAccount := createTestAccount(t, db, siteID, strPtr("u2"), "session-token")
+	got, err = GetTokenGroups(context.Background(), db.DB, emptyAccount, nil, "https://x", "", nil, nil)
+	if err != nil {
+		t.Fatalf("empty local path: %v", err)
+	}
+	if len(got) != 1 || got[0] != "default" {
+		t.Fatalf("expected default, got %#v", got)
+	}
+}
+
+func containsAllStrings(haystack []string, needles ...string) bool {
+	set := make(map[string]struct{}, len(haystack))
+	for _, h := range haystack {
+		set[h] = struct{}{}
+	}
+	for _, n := range needles {
+		if _, ok := set[n]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/service/account_token_service.go
+++ b/service/account_token_service.go
@@ -681,11 +681,30 @@ func GetDefaultTokenForAccount(db *sqlx.DB, accountID int64) (*store.AccountToke
 	return &token, nil
 }
 
-// GetTokenGroups fetches token groups from the database.
-// TODO(P4): call adapter.getUserGroups() on the upstream site instead of querying local DB.
-// TS accountTokens.ts:939-944 calls adapter.getUserGroups() — the Go version currently returns
-// what is locally cached, which may differ from server-side group management on some platforms.
-func GetTokenGroups(db *sqlx.DB, accountID int64) ([]string, error) {
+// NormalizeTokenGroups trims, de-duplicates, and ensures a non-empty result.
+// When every input is blank, returns ["default"].
+func NormalizeTokenGroups(groups []string) []string {
+	seen := make(map[string]struct{}, len(groups))
+	out := make([]string, 0, len(groups))
+	for _, group := range groups {
+		trimmed := strings.TrimSpace(group)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	if len(out) == 0 {
+		return []string{"default"}
+	}
+	return out
+}
+
+// GetLocalTokenGroups returns distinct token groups stored for the account.
+func GetLocalTokenGroups(db *sqlx.DB, accountID int64) ([]string, error) {
 	var groups []string
 	err := db.Select(&groups,
 		db.Rebind("SELECT DISTINCT COALESCE(token_group, 'default') FROM account_tokens WHERE account_id = ?"),
@@ -694,10 +713,43 @@ func GetTokenGroups(db *sqlx.DB, accountID int64) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(groups) == 0 {
-		return []string{"default"}, nil
+	return NormalizeTokenGroups(groups), nil
+}
+
+// GetTokenGroups prefers platform.GetUserGroups for session accounts when an
+// adapter and access token are available. Falls back to local DISTINCT
+// token_group on adapter nil, missing access token, upstream error, or empty
+// upstream result. Upstream errors are swallowed so local groups remain usable.
+func GetTokenGroups(
+	ctx context.Context,
+	db *sqlx.DB,
+	accountID int64,
+	adapter platform.PlatformAdapter,
+	baseURL, accessToken string,
+	platformUserID *int,
+	proxy *platform.ProxyConfig,
+) ([]string, error) {
+	accessToken = strings.TrimSpace(accessToken)
+	if adapter != nil && accessToken != "" {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		upstream, err := adapter.GetUserGroups(ctx, baseURL, accessToken, platformUserID, proxy)
+		if err == nil {
+			hasValue := false
+			for _, group := range upstream {
+				if strings.TrimSpace(group) != "" {
+					hasValue = true
+					break
+				}
+			}
+			if hasValue {
+				return NormalizeTokenGroups(upstream), nil
+			}
+		}
+		// nil adapter path is handled below; upstream error/empty → local fallback
 	}
-	return groups, nil
+	return GetLocalTokenGroups(db, accountID)
 }
 
 // DeleteTokenByID deletes a token by ID with upstream-first strategy.


### PR DESCRIPTION
## Summary
- Wire `GET /api/account-tokens/groups/{accountId}` to `platform.GetUserGroups` for session accounts (proxy-aware via existing `cfg`).
- Fall back to local `DISTINCT token_group` on adapter nil / missing access token / upstream error / empty result.
- Dedupe/trim groups; return `["default"]` when empty. API-key connections still rejected.
- Add service fake-adapter tests, handler httptest NewAPI groups coverage, and `docs/analysis/token-groups-upstream.md`.

Closes #206

## Test plan
- [x] `go test ./service ./handler/admin -count=1 -run 'Group|Token'`
- [ ] Manual: session NewAPI account shows upstream groups in UI picker
- [ ] Manual: unsupported/local-only account still lists stored token groups