### PR TITLE
feat(admin): recover expired API-key accounts on credential update

### DIFF
--- a/docs/analysis/expired-apikey-recovery.md
+++ b/docs/analysis/expired-apikey-recovery.md
@@ -1,0 +1,84 @@
+# Expired API-key account recovery (#205)
+
+**Date**: 2026-07-17  
+**Issue**: [#205](https://github.com/TokenDanceLab/metapi-go/issues/205)  
+**Spec**: `docs/specs/p3-sites-accounts.md` § Account Expired API Key Recovery (594-602)
+
+## Problem
+
+`PUT /api/accounts/{id}` still had a `TODO(P4)` for the TS parity path: when an
+operator updates credentials on an account that is already `status=expired` and
+credential-mode `apikey`, the backend should validate the new key via model
+refresh (`allowInactive=true`) and only then flip the account back to `active`.
+
+Without this, operators could write a new API key while the account stayed
+`expired` forever, or a naive status flip could claim `active` without proving
+the key works.
+
+## Detection (needs recovery)
+
+All of the following must hold on `updateAccount`:
+
+| Condition | Source |
+|-----------|--------|
+| Previous status is `expired` | stored `accounts.status` |
+| Next credential mode is `apikey` | `ResolveStoredCredentialMode(nextAccount)` after applying token/extraConfig projection |
+| Credential changed | `accessToken` and/or `apiToken` differs from previous values |
+| Next status is not forced `disabled` | request `status` (if present) |
+
+If the request also sends `status=active`, that activation is deferred
+(`preserveExpiredStatus`) until model refresh succeeds.
+
+## Behavior
+
+1. Persist the field updates first (tokens / extraConfig / non-status fields).
+2. Call shared `refreshAccountModels(..., allowInactive=true)`.
+3. **Success**:
+   - set `status=active`
+   - best-effort clear `extraConfig.runtimeHealth` when source is `auth`
+   - response includes `modelRefresh` success payload
+4. **Failure**:
+   - force `status=expired` (never false-active)
+   - response still 200 with updated credentials
+   - honest `message` + `modelRefresh` failure payload (`errorCode` / `errorMessage`)
+
+Disabled accounts remain rejected by the shared refresher regardless of
+`allowInactive`.
+
+## Shared helper
+
+`handler/admin/model_refresh.go` owns:
+
+- `refreshAccountModels(ctx, db, accountID, allowInactive)`
+- `persistAccountModelAvailability`
+- token / platform-user resolution and error classification
+
+Call sites:
+
+| Caller | `allowInactive` |
+|--------|-----------------|
+| `POST /api/models/check/{accountId}` (`stats.modelCheck`) | `true` (previous stats behavior only blocked `disabled`) |
+| `PUT /api/accounts/{id}` recovery path | `true` |
+
+Tests inject via package var `accountModelRefresher`.
+
+## Residuals / honest limits
+
+1. Recovery is **update-path only** — batch enable / health refresh / create do not auto-reactivate expired API keys.
+2. Runtime-health clear is **auth-source only**; balance/checkin health entries are left alone.
+3. Route rebuild after model refresh is best-effort (same as model-check); rebuild failure does not undo a successful model write or reactivation.
+4. OAuth session recovery remains on the OAuth rebind / workflow hooks path, not this API-key branch.
+
+## Tests
+
+```bash
+go test ./handler/admin -count=1 -run 'Account|Expired|Recovery|ModelRefresh'
+```
+
+Coverage:
+
+- success: expired apikey + new token → `active`, auth runtimeHealth cleared, models persisted
+- failure: expired apikey + bad token → stays `expired`, honest message, no false active
+- skip: forced `disabled` status does not enter recovery
+- skip: non-credential update on expired account does not refresh
+- unit: `shouldRecoverExpiredAPIKey` / `credentialFieldsChanged` detection edges

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -757,6 +757,95 @@ func normalizeAccountStatus(status string) string {
 	}
 }
 
+// shouldRecoverExpiredAPIKey detects the expired API-key credential recovery path:
+// previous status expired, next mode apikey, credentials changed, next status not forced disabled.
+func shouldRecoverExpiredAPIKey(prev, next store.Account, updates map[string]any) bool {
+	if !strings.EqualFold(strings.TrimSpace(prev.Status), "expired") {
+		return false
+	}
+	nextStatus := strings.TrimSpace(prev.Status)
+	if status, ok := updates["status"].(string); ok && strings.TrimSpace(status) != "" {
+		nextStatus = strings.TrimSpace(status)
+	}
+	if strings.EqualFold(nextStatus, "disabled") {
+		return false
+	}
+	mode := service.ResolveStoredCredentialMode(&next)
+	if mode != service.CredentialModeAPIKey {
+		return false
+	}
+	return credentialFieldsChanged(prev, updates)
+}
+
+func credentialFieldsChanged(prev store.Account, updates map[string]any) bool {
+	if accessToken, ok := updates["accessToken"].(string); ok {
+		if strings.TrimSpace(accessToken) != strings.TrimSpace(prev.AccessToken) {
+			return true
+		}
+	}
+	if apiTokenRaw, ok := updates["apiToken"]; ok {
+		prevAPI := ""
+		if prev.APIToken != nil {
+			prevAPI = strings.TrimSpace(*prev.APIToken)
+		}
+		switch v := apiTokenRaw.(type) {
+		case string:
+			if strings.TrimSpace(v) != prevAPI {
+				return true
+			}
+		case *string:
+			nextAPI := ""
+			if v != nil {
+				nextAPI = strings.TrimSpace(*v)
+			}
+			if nextAPI != prevAPI {
+				return true
+			}
+		default:
+			if v != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// clearAccountAuthRuntimeHealth removes auth-sourced runtimeHealth best-effort after recovery.
+func clearAccountAuthRuntimeHealth(db *sqlx.DB, accountID int64) error {
+	var extraConfig *string
+	if err := db.Get(&extraConfig, db.Rebind("SELECT extra_config FROM accounts WHERE id = ?"), accountID); err != nil {
+		return err
+	}
+	cfg := service.ParseExtraConfig(extraConfig)
+	if cfg == nil {
+		return nil
+	}
+	healthRaw, ok := cfg["runtimeHealth"]
+	if !ok || healthRaw == nil {
+		return nil
+	}
+	b, err := json.Marshal(healthRaw)
+	if err != nil {
+		return nil
+	}
+	var entry service.RuntimeHealthEntry
+	if err := json.Unmarshal(b, &entry); err != nil {
+		return nil
+	}
+	if strings.ToLower(strings.TrimSpace(string(entry.Source))) != string(service.HealthSourceAuth) {
+		return nil
+	}
+	merged := service.MergeExtraConfig(extraConfig, map[string]any{"runtimeHealth": nil})
+	now := time.Now().UTC().Format(time.RFC3339)
+	if merged == nil {
+		_, err = db.Exec(db.Rebind("UPDATE accounts SET extra_config = NULL, updated_at = ? WHERE id = ?"), now, accountID)
+		return err
+	}
+	_, err = db.Exec(db.Rebind("UPDATE accounts SET extra_config = ?, updated_at = ? WHERE id = ?"), *merged, now, accountID)
+	return err
+}
+
+
 // ---- Rebind Session ----
 
 func (h *accountsHandler) rebindSession(w http.ResponseWriter, r *http.Request) {
@@ -932,6 +1021,12 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 	}
 	if apiToken, ok := updates["apiToken"].(*string); ok {
 		nextAccount.APIToken = apiToken
+	} else if apiTokenStr, ok := updates["apiToken"].(string); ok {
+		token := apiTokenStr
+		nextAccount.APIToken = &token
+	}
+	if status, ok := updates["status"].(string); ok {
+		nextAccount.Status = status
 	}
 	if service.BuildCapabilitiesForAccount(&nextAccount).CanCheckin {
 		if body.CheckinEnabled != nil {
@@ -971,9 +1066,16 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 			mergeExtraConfigUpdate(map[string]any{"sub2apiAuth": mergedAuth})
 		}
 	}
-	// TODO(P4): expired API key recovery - when updating an expired API key account,
-	// trigger model refresh with allowInactive:true and reactivateAfterSuccessfulModelRefresh:true
-	// (spec lines 594-602, TS accounts.ts:1550-1556)
+	// Expired API-key recovery (p3-sites-accounts.md 594-602 / TS accounts.ts):
+	// when credentials change on an expired apikey account and status is not forced
+	// disabled, refresh models with allowInactive and reactivate only on success.
+	recovery := shouldRecoverExpiredAPIKey(row.Account, nextAccount, updates)
+	if recovery {
+		// preserveExpiredStatus: do not activate until model refresh succeeds.
+		if status, ok := updates["status"].(string); ok && status == "active" {
+			delete(updates, "status")
+		}
+	}
 
 	if err := service.UpdateAccountFields(h.db, id, updates); err != nil {
 		slog.Error("Failed to update account", "err", err, "account_id", id)
@@ -990,6 +1092,27 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 		})
 	}
 
+	var modelRefresh map[string]any
+	if recovery {
+		modelRefresh = accountModelRefresher(r.Context(), h.db, id, true)
+		if modelRefreshSucceeded(modelRefresh) {
+			if err := service.UpdateAccountFields(h.db, id, map[string]any{"status": "active"}); err != nil {
+				slog.Error("Failed to reactivate account after model refresh", "err", err, "account_id", id)
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "模型刷新成功但账号激活失败"})
+				return
+			}
+			// Best-effort: clear stale auth-unhealthy runtime health after successful recovery.
+			_ = clearAccountAuthRuntimeHealth(h.db, id)
+		} else {
+			// Keep expired; never claim active on failed model refresh.
+			msg := modelRefreshErrorMessage(modelRefresh)
+			slog.Warn("expired API-key recovery model refresh failed", "account_id", id, "message", msg)
+			if err := service.UpdateAccountFields(h.db, id, map[string]any{"status": "expired"}); err != nil {
+				slog.Warn("failed to preserve expired status after recovery failure", "account_id", id, "err", err)
+			}
+		}
+	}
+
 	updatedRow, err := service.GetAccountWithSiteByID(h.db, id)
 	if err != nil {
 		slog.Error("Failed to load updated account", "err", err, "account_id", id)
@@ -999,6 +1122,10 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 	updated := updatedRow.Account
 	caps := service.BuildCapabilitiesForAccount(&updated)
 	sessionCapable := caps.CanRefreshBalance
+	hasDiscoveredModels := false
+	if recovery && modelRefreshSucceeded(modelRefresh) {
+		hasDiscoveredModels = true
+	}
 	resp := map[string]any{
 		"id":                 updated.ID,
 		"siteId":             updated.SiteID,
@@ -1025,11 +1152,12 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 		"credentialMode":     string(service.ResolveStoredCredentialMode(&updated)),
 		"capabilities":       caps,
 		"runtimeHealth": service.BuildRuntimeHealthForAccount(service.RuntimeHealthInput{
-			AccountStatus:  updated.Status,
-			SiteStatus:     updatedRow.Site.Status,
-			ExtraConfig:    updated.ExtraConfig,
-			SessionCapable: &sessionCapable,
-			OAuthProvider:  updated.OAuthProvider,
+			AccountStatus:       updated.Status,
+			SiteStatus:          updatedRow.Site.Status,
+			ExtraConfig:         updated.ExtraConfig,
+			SessionCapable:      &sessionCapable,
+			HasDiscoveredModels: hasDiscoveredModels,
+			OAuthProvider:       updated.OAuthProvider,
 		}),
 		"site": map[string]any{
 			"id":       updatedRow.Site.ID,
@@ -1038,6 +1166,12 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 			"platform": updatedRow.Site.Platform,
 			"status":   updatedRow.Site.Status,
 		},
+	}
+	if recovery {
+		resp["modelRefresh"] = modelRefresh
+		if !modelRefreshSucceeded(modelRefresh) {
+			resp["message"] = "凭证已更新，但模型刷新失败，账号仍为 expired: " + modelRefreshErrorMessage(modelRefresh)
+		}
 	}
 	routing.InvalidateCache()
 	globalAccountsCache.clear()

--- a/handler/admin/accounts_expired_recovery_test.go
+++ b/handler/admin/accounts_expired_recovery_test.go
@@ -1,0 +1,380 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/service"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func withAccountModelRefresher(
+	t *testing.T,
+	fn func(ctx context.Context, db *sqlx.DB, accountID int64, allowInactive bool) map[string]any,
+) {
+	t.Helper()
+	prev := accountModelRefresher
+	accountModelRefresher = fn
+	t.Cleanup(func() { accountModelRefresher = prev })
+}
+
+func TestShouldRecoverExpiredAPIKey(t *testing.T) {
+	api := "sk-new"
+	old := "sk-old"
+	prev := store.Account{
+		Status:      "expired",
+		AccessToken: old,
+		APIToken:    &old,
+		ExtraConfig: strPtr(`{"credentialMode":"apikey","runtimeHealth":{"state":"unhealthy","source":"auth","reason":"连接已过期，请更新 API Key"}}`),
+	}
+	next := prev
+	next.AccessToken = api
+	next.APIToken = &api
+
+	if !shouldRecoverExpiredAPIKey(prev, next, map[string]any{"accessToken": api, "apiToken": api}) {
+		t.Fatal("expected recovery when expired apikey credentials change")
+	}
+	if shouldRecoverExpiredAPIKey(prev, next, map[string]any{"accessToken": api, "apiToken": api, "status": "disabled"}) {
+		t.Fatal("disabled status must not recover")
+	}
+	if shouldRecoverExpiredAPIKey(prev, next, map[string]any{"username": "x"}) {
+		t.Fatal("non-credential update must not recover")
+	}
+	active := prev
+	active.Status = "active"
+	if shouldRecoverExpiredAPIKey(active, next, map[string]any{"accessToken": api}) {
+		t.Fatal("non-expired account must not recover")
+	}
+	sessionPrev := prev
+	sessionNext := next
+	sessionNext.ExtraConfig = strPtr(`{"credentialMode":"session"}`)
+	sessionNext.AccessToken = "sess"
+	if shouldRecoverExpiredAPIKey(sessionPrev, sessionNext, map[string]any{"accessToken": "sess"}) {
+		t.Fatal("session mode must not use apikey recovery path")
+	}
+}
+
+func TestAccounts_Update_ExpiredAPIKeyRecovery_Success(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	server := newOpenAIModelsServer(t, "sk-recovered", []string{"gpt-4o-mini", "gpt-4o"})
+	siteResp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "ExpiredRecoveryOK",
+		"url":      server.URL,
+		"platform": "openai",
+	})
+	if siteResp.Code != http.StatusOK {
+		t.Fatalf("create site: %d %s", siteResp.Code, siteResp.Body.String())
+	}
+	var site map[string]any
+	_ = json.Unmarshal(siteResp.Body.Bytes(), &site)
+	siteID := int64(site["id"].(float64))
+
+	createResp := doPostJSON(t, r, "/api/accounts", map[string]any{
+		"siteId":         siteID,
+		"accessToken":    "sk-old-expired",
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
+	})
+	if createResp.Code != http.StatusOK {
+		t.Fatalf("create: %d %s", createResp.Code, createResp.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(createResp.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	accountID := int64(created["id"].(float64))
+
+	extra := `{"credentialMode":"apikey","runtimeHealth":{"state":"unhealthy","reason":"连接已过期，请更新 API Key","source":"auth"}}`
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(
+		"UPDATE accounts SET status = 'expired', extra_config = ?, updated_at = ? WHERE id = ?",
+		extra, now, accountID,
+	); err != nil {
+		t.Fatalf("seed expired: %v", err)
+	}
+
+	// Prefer real adapter path (httptest OpenAI models) — no fake needed for success.
+	resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"accessToken": "sk-recovered",
+		// mirrored apikey path: same value as current stored api token triggers mirror,
+		// so omit apiToken to mirror new access token into apiToken.
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update: %d %s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode update: %v", err)
+	}
+	if result["status"] != "active" {
+		t.Fatalf("status = %v, want active; body=%s", result["status"], resp.Body.String())
+	}
+	mr, _ := result["modelRefresh"].(map[string]any)
+	if mr == nil || mr["success"] != true {
+		t.Fatalf("modelRefresh success missing: %#v", result["modelRefresh"])
+	}
+
+	var status string
+	var extraConfig *string
+	if err := db.QueryRow("SELECT status, extra_config FROM accounts WHERE id = ?", accountID).Scan(&status, &extraConfig); err != nil {
+		t.Fatalf("read account: %v", err)
+	}
+	if status != "active" {
+		t.Fatalf("db status = %q, want active", status)
+	}
+	if extraConfig != nil && strings.Contains(*extraConfig, `"source":"auth"`) {
+		t.Fatalf("auth runtimeHealth should be cleared, extra_config=%s", *extraConfig)
+	}
+
+	var modelCount int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND available = 1",
+		accountID,
+	).Scan(&modelCount); err != nil {
+		t.Fatalf("count models: %v", err)
+	}
+	if modelCount < 2 {
+		t.Fatalf("available models = %d, want >= 2", modelCount)
+	}
+}
+
+func TestAccounts_Update_ExpiredAPIKeyRecovery_FailureKeepsExpired(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	// Models endpoint always 401 for any token.
+	server := newOpenAIModelsServer(t, "never-matches", []string{"gpt-4o"})
+	siteResp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "ExpiredRecoveryFail",
+		"url":      server.URL,
+		"platform": "openai",
+	})
+	if siteResp.Code != http.StatusOK {
+		t.Fatalf("create site: %d %s", siteResp.Code, siteResp.Body.String())
+	}
+	var site map[string]any
+	_ = json.Unmarshal(siteResp.Body.Bytes(), &site)
+	siteID := int64(site["id"].(float64))
+
+	createResp := doPostJSON(t, r, "/api/accounts", map[string]any{
+		"siteId":         siteID,
+		"accessToken":    "sk-old-expired",
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
+	})
+	if createResp.Code != http.StatusOK {
+		t.Fatalf("create: %d %s", createResp.Code, createResp.Body.String())
+	}
+	var created map[string]any
+	_ = json.Unmarshal(createResp.Body.Bytes(), &created)
+	accountID := int64(created["id"].(float64))
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(
+		"UPDATE accounts SET status = 'expired', extra_config = ?, updated_at = ? WHERE id = ?",
+		`{"credentialMode":"apikey"}`, now, accountID,
+	); err != nil {
+		t.Fatalf("seed expired: %v", err)
+	}
+
+	resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"accessToken": "sk-still-bad",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update: %d %s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result["status"] != "expired" {
+		t.Fatalf("status = %v, want expired", result["status"])
+	}
+	msg, _ := result["message"].(string)
+	if !strings.Contains(msg, "expired") && !strings.Contains(msg, "模型") {
+		t.Fatalf("expected honest failure message, got %q", msg)
+	}
+	mr, _ := result["modelRefresh"].(map[string]any)
+	if mr == nil || mr["success"] == true {
+		t.Fatalf("expected failed modelRefresh, got %#v", result["modelRefresh"])
+	}
+
+	var status string
+	if err := db.QueryRow("SELECT status FROM accounts WHERE id = ?", accountID).Scan(&status); err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if status != "expired" {
+		t.Fatalf("db status = %q, want expired", status)
+	}
+}
+
+func TestAccounts_Update_ExpiredAPIKeyRecovery_DisabledSkips(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	site := newSiteFixture(t, r, "ExpiredRecoveryDisabled", "https://api.openai.com")
+	siteID := int64(site["id"].(float64))
+
+	createResp := doPostJSON(t, r, "/api/accounts", map[string]any{
+		"siteId":         siteID,
+		"accessToken":    "sk-old",
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
+	})
+	if createResp.Code != http.StatusOK {
+		t.Fatalf("create: %d %s", createResp.Code, createResp.Body.String())
+	}
+	var created map[string]any
+	_ = json.Unmarshal(createResp.Body.Bytes(), &created)
+	accountID := int64(created["id"].(float64))
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(
+		"UPDATE accounts SET status = 'expired', extra_config = ?, updated_at = ? WHERE id = ?",
+		`{"credentialMode":"apikey"}`, now, accountID,
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	called := false
+	withAccountModelRefresher(t, func(ctx context.Context, db *sqlx.DB, accountID int64, allowInactive bool) map[string]any {
+		called = true
+		return map[string]any{"success": true}
+	})
+
+	resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"accessToken": "sk-new",
+		"status":      "disabled",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update: %d %s", resp.Code, resp.Body.String())
+	}
+	if called {
+		t.Fatal("model refresh must not run when status forced disabled")
+	}
+	var result map[string]any
+	_ = json.Unmarshal(resp.Body.Bytes(), &result)
+	if result["status"] != "disabled" {
+		t.Fatalf("status = %v, want disabled", result["status"])
+	}
+	if _, ok := result["modelRefresh"]; ok {
+		t.Fatalf("modelRefresh should be absent, got %#v", result["modelRefresh"])
+	}
+}
+
+func TestAccounts_Update_ExpiredAPIKeyRecovery_NoCredentialChangeSkips(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	site := newSiteFixture(t, r, "ExpiredRecoveryNoCred", "https://api.openai.com")
+	siteID := int64(site["id"].(float64))
+
+	createResp := doPostJSON(t, r, "/api/accounts", map[string]any{
+		"siteId":         siteID,
+		"accessToken":    "sk-same",
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
+	})
+	if createResp.Code != http.StatusOK {
+		t.Fatalf("create: %d %s", createResp.Code, createResp.Body.String())
+	}
+	var created map[string]any
+	_ = json.Unmarshal(createResp.Body.Bytes(), &created)
+	accountID := int64(created["id"].(float64))
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(
+		"UPDATE accounts SET status = 'expired', extra_config = ?, updated_at = ? WHERE id = ?",
+		`{"credentialMode":"apikey"}`, now, accountID,
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	called := false
+	withAccountModelRefresher(t, func(ctx context.Context, db *sqlx.DB, accountID int64, allowInactive bool) map[string]any {
+		called = true
+		return map[string]any{"success": true}
+	})
+
+	resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"username": "only-name",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update: %d %s", resp.Code, resp.Body.String())
+	}
+	if called {
+		t.Fatal("model refresh must not run without credential change")
+	}
+	var status string
+	if err := db.QueryRow("SELECT status FROM accounts WHERE id = ?", accountID).Scan(&status); err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if status != "expired" {
+		t.Fatalf("status = %q, want expired", status)
+	}
+}
+
+func TestAccounts_Update_ExpiredAPIKeyRecovery_InjectableRefresh(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	site := newSiteFixture(t, r, "ExpiredRecoveryInject", "https://api.openai.com")
+	siteID := int64(site["id"].(float64))
+
+	createResp := doPostJSON(t, r, "/api/accounts", map[string]any{
+		"siteId":         siteID,
+		"accessToken":    "sk-old",
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
+	})
+	if createResp.Code != http.StatusOK {
+		t.Fatalf("create: %d %s", createResp.Code, createResp.Body.String())
+	}
+	var created map[string]any
+	_ = json.Unmarshal(createResp.Body.Bytes(), &created)
+	accountID := int64(created["id"].(float64))
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(
+		"UPDATE accounts SET status = 'expired', extra_config = ?, updated_at = ? WHERE id = ?",
+		`{"credentialMode":"apikey","runtimeHealth":{"state":"unhealthy","source":"auth","reason":"连接已过期，请更新 API Key"}}`,
+		now, accountID,
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var sawAllowInactive bool
+	withAccountModelRefresher(t, func(ctx context.Context, dbx *sqlx.DB, id int64, allowInactive bool) map[string]any {
+		if id != accountID {
+			t.Fatalf("accountID = %d, want %d", id, accountID)
+		}
+		sawAllowInactive = allowInactive
+		// Simulate successful model write without upstream.
+		_ = persistAccountModelAvailability(dbx, id, []string{"inject-model"}, time.Now().UTC().Format(time.RFC3339))
+		return map[string]any{
+			"success": true,
+			"refresh": map[string]any{"id": id, "status": "success", "modelCount": 1, "models": []string{"inject-model"}},
+			"rebuild": map[string]any{"success": true},
+		}
+	})
+
+	resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"accessToken": "sk-injected",
+		"status":      "active", // deferred until refresh succeeds
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update: %d %s", resp.Code, resp.Body.String())
+	}
+	if !sawAllowInactive {
+		t.Fatal("expected allowInactive=true on recovery refresh")
+	}
+	var result map[string]any
+	_ = json.Unmarshal(resp.Body.Bytes(), &result)
+	if result["status"] != "active" {
+		t.Fatalf("status = %v, want active", result["status"])
+	}
+
+	// Ensure auth health cleared via service helper path.
+	var extra *string
+	_ = db.QueryRow("SELECT extra_config FROM accounts WHERE id = ?", accountID).Scan(&extra)
+	stored := service.ExtractRuntimeHealth(extra)
+	if stored != nil && strings.EqualFold(string(stored.Source), string(service.HealthSourceAuth)) {
+		t.Fatalf("auth runtime health still present: %#v", stored)
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/handler/admin/model_refresh.go
+++ b/handler/admin/model_refresh.go
@@ -1,0 +1,342 @@
+package admin
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/platform"
+	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/service"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+// accountModelRefresher is the package-level model refresh entrypoint.
+// Tests may inject a fake implementation; production uses refreshAccountModels.
+var accountModelRefresher = refreshAccountModels
+
+// refreshAccountModels performs a real platform.GetModels refresh and persists
+// results into model_availability. Returns the operator-facing check payload.
+//
+// allowInactive=true permits non-active accounts (e.g. expired) to refresh so
+// recovery workflows can validate new credentials before reactivation.
+// Disabled accounts are always rejected.
+func refreshAccountModels(ctx context.Context, db *sqlx.DB, accountID int64, allowInactive bool) map[string]any {
+	if db == nil {
+		return map[string]any{
+			"success": false,
+			"error":   "database not configured",
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    "db_unavailable",
+				"errorMessage": "database not configured",
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	row, err := service.GetAccountWithSiteByID(db, accountID)
+	if err != nil || row == nil {
+		return map[string]any{
+			"success": false,
+			"error":   "account not found",
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    "not_found",
+				"errorMessage": "账号不存在",
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	account := row.Account
+	site := row.Site
+	status := strings.TrimSpace(account.Status)
+	if strings.EqualFold(status, "disabled") {
+		return map[string]any{
+			"success": false,
+			"message": "账号已禁用，无法刷新模型",
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    "disabled",
+				"errorMessage": "账号已禁用",
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+	if !allowInactive && !strings.EqualFold(status, "active") && status != "" {
+		return map[string]any{
+			"success": false,
+			"message": "账号未激活，无法刷新模型",
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    "inactive",
+				"errorMessage": "账号未激活",
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	adapter := platform.GetAdapter(site.Platform)
+	if adapter == nil {
+		return map[string]any{
+			"success": false,
+			"message": "unsupported platform: " + site.Platform,
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    "unsupported_platform",
+				"errorMessage": "不支持的平台: " + site.Platform,
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	token := resolveAccountModelToken(&account)
+	if token == "" {
+		return map[string]any{
+			"success": false,
+			"message": "账号缺少可用凭证",
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    "missing_credential",
+				"errorMessage": "账号缺少 access_token / api_token",
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	platformUserID := resolvePlatformUserIDPtr(account.ExtraConfig, account.Username)
+	proxyCfg := service.BuildPlatformProxyConfig(nil, &account, &site)
+
+	callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	models, getErr := adapter.GetModels(callCtx, site.URL, token, platformUserID, proxyCfg)
+	if getErr != nil {
+		code, msg := classifyModelRefreshError(getErr, callCtx)
+		return map[string]any{
+			"success": false,
+			"message": msg,
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    code,
+				"errorMessage": msg,
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	// Deduplicate / trim.
+	seen := map[string]struct{}{}
+	clean := make([]string, 0, len(models))
+	for _, m := range models {
+		m = strings.TrimSpace(m)
+		if m == "" {
+			continue
+		}
+		key := strings.ToLower(m)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		clean = append(clean, m)
+	}
+	if len(clean) == 0 {
+		return map[string]any{
+			"success": false,
+			"message": "未获取到可用模型",
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    "empty_models",
+				"errorMessage": "未获取到可用模型",
+				"modelCount":   0,
+				"models":       []string{},
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := persistAccountModelAvailability(db, accountID, clean, now); err != nil {
+		return map[string]any{
+			"success": false,
+			"message": "模型写入失败: " + err.Error(),
+			"refresh": map[string]any{
+				"id":           accountID,
+				"status":       "failed",
+				"errorCode":    "persist_failed",
+				"errorMessage": err.Error(),
+				"modelCount":   len(clean),
+				"models":       clean,
+			},
+			"rebuild": map[string]any{},
+		}
+	}
+
+	// Best-effort route rebuild from updated availability.
+	rebuildStats, rebuildErr := service.RebuildTokenRoutesFromAvailability(context.Background(), db)
+	rebuildPayload := map[string]any{
+		"routesConsidered": rebuildStats.RoutesConsidered,
+		"patternRoutes":    rebuildStats.PatternRoutes,
+		"groupRoutes":      rebuildStats.GroupRoutes,
+		"channelsInserted": rebuildStats.ChannelsInserted,
+		"channelsRemoved":  rebuildStats.ChannelsRemoved,
+		"channelsKept":     rebuildStats.ChannelsKept,
+	}
+	if rebuildErr != nil {
+		rebuildPayload["success"] = false
+		rebuildPayload["error"] = rebuildErr.Error()
+	} else {
+		rebuildPayload["success"] = true
+	}
+	routing.InvalidateCache()
+
+	return map[string]any{
+		"success": true,
+		"refresh": map[string]any{
+			"id":         accountID,
+			"status":     "success",
+			"modelCount": len(clean),
+			"models":     clean,
+			"checkedAt":  now,
+		},
+		"rebuild": rebuildPayload,
+	}
+}
+
+func resolveAccountModelToken(account *store.Account) string {
+	if account == nil {
+		return ""
+	}
+	if account.APIToken != nil && strings.TrimSpace(*account.APIToken) != "" {
+		return strings.TrimSpace(*account.APIToken)
+	}
+	return strings.TrimSpace(account.AccessToken)
+}
+
+func resolvePlatformUserIDPtr(extraConfig *string, username *string) *int {
+	id := service.ResolvePlatformUserID(extraConfig, username)
+	if id <= 0 {
+		return nil
+	}
+	v := int(id)
+	return &v
+}
+
+func classifyModelRefreshError(err error, ctx context.Context) (code, message string) {
+	if err == nil {
+		return "unknown", "模型获取失败"
+	}
+	msg := strings.TrimSpace(err.Error())
+	lower := strings.ToLower(msg)
+	timedOut := (ctx != nil && ctx.Err() == context.DeadlineExceeded) ||
+		strings.Contains(lower, "timeout") ||
+		strings.Contains(lower, "deadline exceeded")
+	if timedOut {
+		return "timeout", "模型获取失败（请求超时）"
+	}
+	if strings.Contains(lower, "unauthorized") || strings.Contains(lower, "401") || strings.Contains(lower, "invalid api key") || strings.Contains(lower, "authentication") {
+		return "unauthorized", "模型获取失败，API Key 已无效"
+	}
+	if msg == "" {
+		msg = "模型获取失败"
+	}
+	return "upstream_error", msg
+}
+
+func persistAccountModelAvailability(db *sqlx.DB, accountID int64, models []string, now string) error {
+	tx, err := db.Beginx()
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Preserve manual rows; mark non-manual previous rows unavailable then upsert.
+	if _, err := tx.Exec(tx.Rebind(`
+		UPDATE model_availability
+		SET available = ?, checked_at = ?
+		WHERE account_id = ? AND COALESCE(is_manual, 0) = 0
+	`), false, now, accountID); err != nil {
+		return err
+	}
+
+	for _, model := range models {
+		var existingID int64
+		err := tx.Get(&existingID, tx.Rebind(`
+			SELECT id FROM model_availability WHERE account_id = ? AND model_name = ?
+		`), accountID, model)
+		if err == nil {
+			if _, err := tx.Exec(tx.Rebind(`
+				UPDATE model_availability
+				SET available = ?, latency_ms = NULL, checked_at = ?
+				WHERE id = ?
+			`), true, now, existingID); err != nil {
+				return err
+			}
+			continue
+		}
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		if _, err := tx.Exec(tx.Rebind(`
+			INSERT INTO model_availability (account_id, model_name, available, is_manual, latency_ms, checked_at)
+			VALUES (?, ?, ?, ?, NULL, ?)
+		`), accountID, model, true, false, now); err != nil {
+			if _, err2 := tx.Exec(tx.Rebind(`
+				UPDATE model_availability
+				SET available = ?, latency_ms = NULL, checked_at = ?
+				WHERE account_id = ? AND model_name = ?
+			`), true, now, accountID, model); err2 != nil {
+				return err
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+func modelRefreshSucceeded(result map[string]any) bool {
+	if result == nil {
+		return false
+	}
+	ok, _ := result["success"].(bool)
+	return ok
+}
+
+func modelRefreshErrorMessage(result map[string]any) string {
+	if result == nil {
+		return "模型刷新失败"
+	}
+	if msg, ok := result["message"].(string); ok && strings.TrimSpace(msg) != "" {
+		return strings.TrimSpace(msg)
+	}
+	if errMsg, ok := result["error"].(string); ok && strings.TrimSpace(errMsg) != "" {
+		return strings.TrimSpace(errMsg)
+	}
+	if refresh, ok := result["refresh"].(map[string]any); ok {
+		if msg, ok := refresh["errorMessage"].(string); ok && strings.TrimSpace(msg) != "" {
+			return strings.TrimSpace(msg)
+		}
+	}
+	return "模型刷新失败"
+}

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -1,10 +1,7 @@
 package admin
 
 import (
-	"context"
-	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -15,11 +12,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
-	"github.com/tokendancelab/metapi-go/platform"
-	"github.com/tokendancelab/metapi-go/routing"
 	"github.com/tokendancelab/metapi-go/scheduler"
-	"github.com/tokendancelab/metapi-go/service"
-	"github.com/tokendancelab/metapi-go/store"
 )
 
 // RegisterStatsRoutes registers all /api/stats and /api/models routes.
@@ -801,7 +794,7 @@ func (h *statsHandler) modelCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result := h.refreshAccountModels(r.Context(), id)
+	result := accountModelRefresher(r.Context(), h.db, id, true)
 	writeJSON(w, http.StatusOK, result)
 }
 
@@ -1459,271 +1452,6 @@ func modelAllowed(model string, allowed map[string]struct{}) bool {
 func parseTruthyQuery(v string) bool {
 	v = strings.TrimSpace(strings.ToLower(v))
 	return v == "1" || v == "true" || v == "yes" || v == "on"
-}
-
-// refreshAccountModels performs a real platform.GetModels refresh and persists
-// results into model_availability. Returns the operator-facing check payload.
-func (h *statsHandler) refreshAccountModels(ctx context.Context, accountID int64) map[string]any {
-	row, err := service.GetAccountWithSiteByID(h.db, accountID)
-	if err != nil || row == nil {
-		return map[string]any{
-			"success": false,
-			"error":   "account not found",
-			"refresh": map[string]any{
-				"id":           accountID,
-				"status":       "failed",
-				"errorCode":    "not_found",
-				"errorMessage": "账号不存在",
-			},
-			"rebuild": map[string]any{},
-		}
-	}
-
-	account := row.Account
-	site := row.Site
-	if strings.EqualFold(strings.TrimSpace(account.Status), "disabled") {
-		return map[string]any{
-			"success": false,
-			"message": "账号已禁用，无法刷新模型",
-			"refresh": map[string]any{
-				"id":           accountID,
-				"status":       "failed",
-				"errorCode":    "disabled",
-				"errorMessage": "账号已禁用",
-			},
-			"rebuild": map[string]any{},
-		}
-	}
-
-	adapter := platform.GetAdapter(site.Platform)
-	if adapter == nil {
-		return map[string]any{
-			"success": false,
-			"message": "unsupported platform: " + site.Platform,
-			"refresh": map[string]any{
-				"id":           accountID,
-				"status":       "failed",
-				"errorCode":    "unsupported_platform",
-				"errorMessage": "不支持的平台: " + site.Platform,
-			},
-			"rebuild": map[string]any{},
-		}
-	}
-
-	token := resolveAccountModelToken(&account)
-	if token == "" {
-		return map[string]any{
-			"success": false,
-			"message": "账号缺少可用凭证",
-			"refresh": map[string]any{
-				"id":           accountID,
-				"status":       "failed",
-				"errorCode":    "missing_credential",
-				"errorMessage": "账号缺少 access_token / api_token",
-			},
-			"rebuild": map[string]any{},
-		}
-	}
-
-	platformUserID := resolvePlatformUserIDPtr(account.ExtraConfig, account.Username)
-	proxyCfg := service.BuildPlatformProxyConfig(nil, &account, &site)
-
-	callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	models, getErr := adapter.GetModels(callCtx, site.URL, token, platformUserID, proxyCfg)
-	if getErr != nil {
-		code, msg := classifyModelRefreshError(getErr, callCtx)
-		return map[string]any{
-			"success": false,
-			"message": msg,
-			"refresh": map[string]any{
-				"id":           accountID,
-				"status":       "failed",
-				"errorCode":    code,
-				"errorMessage": msg,
-			},
-			"rebuild": map[string]any{},
-		}
-	}
-
-	// Deduplicate / trim.
-	seen := map[string]struct{}{}
-	clean := make([]string, 0, len(models))
-	for _, m := range models {
-		m = strings.TrimSpace(m)
-		if m == "" {
-			continue
-		}
-		key := strings.ToLower(m)
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		clean = append(clean, m)
-	}
-	if len(clean) == 0 {
-		return map[string]any{
-			"success": false,
-			"message": "未获取到可用模型",
-			"refresh": map[string]any{
-				"id":           accountID,
-				"status":       "failed",
-				"errorCode":    "empty_models",
-				"errorMessage": "未获取到可用模型",
-				"modelCount":   0,
-				"models":       []string{},
-			},
-			"rebuild": map[string]any{},
-		}
-	}
-
-	now := time.Now().UTC().Format(time.RFC3339)
-	if err := h.persistAccountModelAvailability(accountID, clean, now); err != nil {
-		return map[string]any{
-			"success": false,
-			"message": "模型写入失败: " + err.Error(),
-			"refresh": map[string]any{
-				"id":           accountID,
-				"status":       "failed",
-				"errorCode":    "persist_failed",
-				"errorMessage": err.Error(),
-				"modelCount":   len(clean),
-				"models":       clean,
-			},
-			"rebuild": map[string]any{},
-		}
-	}
-
-	// Best-effort route rebuild from updated availability.
-	rebuildStats, rebuildErr := service.RebuildTokenRoutesFromAvailability(context.Background(), h.db)
-	rebuildPayload := map[string]any{
-		"routesConsidered": rebuildStats.RoutesConsidered,
-		"patternRoutes":    rebuildStats.PatternRoutes,
-		"groupRoutes":      rebuildStats.GroupRoutes,
-		"channelsInserted": rebuildStats.ChannelsInserted,
-		"channelsRemoved":  rebuildStats.ChannelsRemoved,
-		"channelsKept":     rebuildStats.ChannelsKept,
-	}
-	if rebuildErr != nil {
-		rebuildPayload["success"] = false
-		rebuildPayload["error"] = rebuildErr.Error()
-	} else {
-		rebuildPayload["success"] = true
-	}
-	routing.InvalidateCache()
-
-	return map[string]any{
-		"success": true,
-		"refresh": map[string]any{
-			"id":         accountID,
-			"status":     "success",
-			"modelCount": len(clean),
-			"models":     clean,
-			"checkedAt":  now,
-		},
-		"rebuild": rebuildPayload,
-	}
-}
-
-func resolveAccountModelToken(account *store.Account) string {
-	if account == nil {
-		return ""
-	}
-	if account.APIToken != nil && strings.TrimSpace(*account.APIToken) != "" {
-		return strings.TrimSpace(*account.APIToken)
-	}
-	return strings.TrimSpace(account.AccessToken)
-}
-
-func resolvePlatformUserIDPtr(extraConfig *string, username *string) *int {
-	id := service.ResolvePlatformUserID(extraConfig, username)
-	if id <= 0 {
-		return nil
-	}
-	v := int(id)
-	return &v
-}
-
-func classifyModelRefreshError(err error, ctx context.Context) (code, message string) {
-	if err == nil {
-		return "unknown", "模型获取失败"
-	}
-	msg := strings.TrimSpace(err.Error())
-	lower := strings.ToLower(msg)
-	timedOut := (ctx != nil && ctx.Err() == context.DeadlineExceeded) ||
-		strings.Contains(lower, "timeout") ||
-		strings.Contains(lower, "deadline exceeded")
-	if timedOut {
-		return "timeout", "模型获取失败（请求超时）"
-	}
-	if strings.Contains(lower, "unauthorized") || strings.Contains(lower, "401") || strings.Contains(lower, "invalid api key") || strings.Contains(lower, "authentication") {
-		return "unauthorized", "模型获取失败，API Key 已无效"
-	}
-	if msg == "" {
-		msg = "模型获取失败"
-	}
-	return "upstream_error", msg
-}
-
-func (h *statsHandler) persistAccountModelAvailability(accountID int64, models []string, now string) error {
-	tx, err := h.db.Beginx()
-	if err != nil {
-		return err
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-
-	// Preserve manual rows; mark non-manual previous rows unavailable then upsert.
-	if _, err := tx.Exec(tx.Rebind(`
-		UPDATE model_availability
-		SET available = ?, checked_at = ?
-		WHERE account_id = ? AND COALESCE(is_manual, 0) = 0
-	`), false, now, accountID); err != nil {
-		return err
-	}
-
-	for _, model := range models {
-		var existingID int64
-		err := tx.Get(&existingID, tx.Rebind(`
-			SELECT id FROM model_availability WHERE account_id = ? AND model_name = ?
-		`), accountID, model)
-		if err == nil {
-			if _, err := tx.Exec(tx.Rebind(`
-				UPDATE model_availability
-				SET available = ?, latency_ms = NULL, checked_at = ?
-				WHERE id = ?
-			`), true, now, existingID); err != nil {
-				return err
-			}
-			continue
-		}
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return err
-		}
-		if _, err := tx.Exec(tx.Rebind(`
-			INSERT INTO model_availability (account_id, model_name, available, is_manual, latency_ms, checked_at)
-			VALUES (?, ?, ?, ?, NULL, ?)
-		`), accountID, model, true, false, now); err != nil {
-			if _, err2 := tx.Exec(tx.Rebind(`
-				UPDATE model_availability
-				SET available = ?, latency_ms = NULL, checked_at = ?
-				WHERE account_id = ? AND model_name = ?
-			`), true, now, accountID, model); err2 != nil {
-				return err
-			}
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	committed = true
-	return nil
 }
 
 func queryRow(db *sqlx.DB, query string, args ...any) map[string]any {


### PR DESCRIPTION
## Summary
- Detect expired API-key accounts on `PUT /api/accounts/{id}` when credentials change and status is not forced disabled
- Refresh models via shared `refreshAccountModels(..., allowInactive=true)`; reactivate + clear auth-unhealthy runtime health only on success
- Keep `expired` and return an honest `modelRefresh`/`message` payload on failure
- Extract model refresh + availability persist helpers from `stats.go` for reuse
- Add httptest/injectable-refresh tests and `docs/analysis/expired-apikey-recovery.md`

Closes #205

## Test plan
- [x] `go test ./handler/admin -count=1 -run 'Account|Expired|Recovery|ModelRefresh'`
- [x] Recovery success path: expired apikey + valid token → `active` + models persisted
- [x] Recovery failure path: expired apikey + invalid token → stays `expired` with honest message
- [x] Forced `disabled` / non-credential updates skip recovery