### PR TITLE
feat(service): wire site proxy cache invalidation hooks (#216)

### DIFF
--- a/docs/analysis/site-proxy-cache-invalidation.md
+++ b/docs/analysis/site-proxy-cache-invalidation.md
@@ -1,0 +1,33 @@
+# Site proxy cache invalidation (#216)
+
+Last updated: 2026-07-17
+
+## Problem
+
+`service.InvalidateSiteProxyCache` was a no-op TODO(P8). Site create/update/delete called `InvalidateSiteCaches()`, which only partially cleared routing state via `InvalidateTokenRouterCache`, and never cleared the admin `GET /api/accounts` snapshot cache.
+
+## Design
+
+Hook registry in `service` (no import cycle):
+
+- `RegisterSiteProxyCacheInvalidator(fn)`
+- `InvalidateSiteProxyCache()` always calls `routing.InvalidateCache()`, then runs hooks
+
+Admin registers in `handler/admin/accounts.go` `init()`:
+
+```go
+service.RegisterSiteProxyCacheInvalidator(func() { globalAccountsCache.clear() })
+```
+
+`InvalidateSiteCaches()` still calls both proxy + token-router invalidators (double routing clear is idempotent).
+
+## Residual
+
+- Multi-instance: process-local only (same as existing admin snapshot / route caches).
+- No separate HTTP client proxy-config cache layer yet; when one is added, register another hook.
+
+## Verify
+
+```bash
+go test ./service ./handler/admin -count=1 -run 'Invalidate|Cache|Site'
+```

--- a/docs/analysis/site-proxy-cache-invalidation.md
+++ b/docs/analysis/site-proxy-cache-invalidation.md
@@ -31,3 +31,7 @@ service.RegisterSiteProxyCacheInvalidator(func() { globalAccountsCache.clear() }
 ```bash
 go test ./service ./handler/admin -count=1 -run 'Invalidate|Cache|Site'
 ```
+
+## Related: sites SELECT * drift
+
+Shared CI Postgres may carry leftover columns (e.g. `sc1_test_probe_col`). All admin/service site loads should use `service.SiteSelectColumns` instead of `SELECT *`.

--- a/handler/admin/account_tokens.go
+++ b/handler/admin/account_tokens.go
@@ -594,7 +594,7 @@ func (h *accountTokensHandler) getTokenValue(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusInternalServerError, "读取账号失败")
 		return
 	}
-	if err := h.db.Get(&site, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), account.SiteID); err != nil {
+	if err := h.db.Get(&site, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), account.SiteID); err != nil {
 		writeError(w, http.StatusInternalServerError, "读取站点失败")
 		return
 	}
@@ -832,7 +832,7 @@ func (h *accountTokensHandler) getAccountDefault(w http.ResponseWriter, r *http.
 	}
 
 	var site store.Site
-	if err := h.db.Get(&site, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), account.SiteID); err != nil {
+	if err := h.db.Get(&site, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), account.SiteID); err != nil {
 		writeError(w, http.StatusInternalServerError, "读取站点失败")
 		return
 	}

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -88,6 +88,13 @@ func (c *accountsSnapshotCache) clear() {
 
 var globalAccountsCache = &accountsSnapshotCache{ttl: 30 * time.Second}
 
+func init() {
+	// Site mutations invalidate process-local admin list cache via service hook (#216).
+	service.RegisterSiteProxyCacheInvalidator(func() {
+		globalAccountsCache.clear()
+	})
+}
+
 // ---- List Accounts ----
 
 func (h *accountsHandler) listAccounts(w http.ResponseWriter, r *http.Request) {
@@ -844,7 +851,6 @@ func clearAccountAuthRuntimeHealth(db *sqlx.DB, accountID int64) error {
 	_, err = db.Exec(db.Rebind("UPDATE accounts SET extra_config = ?, updated_at = ? WHERE id = ?"), *merged, now, accountID)
 	return err
 }
-
 
 // ---- Rebind Session ----
 

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -121,7 +121,7 @@ func (h *accountsHandler) listAccounts(w http.ResponseWriter, r *http.Request) {
 
 	// Also fetch sites for the response
 	var sites []store.Site
-	h.db.Select(&sites, "SELECT * FROM sites ORDER BY sort_order, id")
+	h.db.Select(&sites, "SELECT "+service.SiteSelectColumns+" FROM sites ORDER BY sort_order, id")
 
 	resp := map[string]any{
 		"generatedAt": time.Now().UTC().Format(time.RFC3339),
@@ -151,7 +151,7 @@ func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) 
 
 	// Check site exists
 	var site store.Site
-	if err := h.db.Get(&site, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), body.SiteID); err != nil {
+	if err := h.db.Get(&site, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), body.SiteID); err != nil {
 		writeError(w, http.StatusBadRequest, "site not found")
 		return
 	}
@@ -545,7 +545,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 
 	// Get site
 	var site store.Site
-	if err := h.db.Get(&site, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), body.SiteID); err != nil {
+	if err := h.db.Get(&site, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), body.SiteID); err != nil {
 		writeError(w, http.StatusNotFound, "site not found")
 		return
 	}
@@ -687,7 +687,7 @@ func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 
 	// Get site
 	var site store.Site
-	if err := h.db.Get(&site, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), body.SiteID); err != nil {
+	if err := h.db.Get(&site, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), body.SiteID); err != nil {
 		writeError(w, http.StatusNotFound, "site not found")
 		return
 	}

--- a/handler/admin/search.go
+++ b/handler/admin/search.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/service"
 )
 
 // RegisterSearchRoutes registers all /api/search routes.
@@ -67,7 +68,7 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 	likePattern := "%" + q + "%"
 
 	// Search sites
-	sites := queryRows(h.db, "SELECT * FROM sites WHERE name LIKE ? OR url LIKE ? OR platform LIKE ? LIMIT ?",
+	sites := queryRows(h.db, "SELECT "+service.SiteSelectColumns+" FROM sites WHERE name LIKE ? OR url LIKE ? OR platform LIKE ? LIMIT ?",
 		likePattern, likePattern, likePattern, perCategory)
 
 	// Search accounts

--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -244,7 +244,7 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var existing store.Site
-	err = h.db.Get(&existing, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), id)
+	err = h.db.Get(&existing, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), id)
 	if err == sql.ErrNoRows {
 		writeError(w, http.StatusNotFound, "Site not found")
 		return
@@ -466,7 +466,7 @@ func (h *sitesHandler) batchSites(w http.ResponseWriter, r *http.Request) {
 	for _, rawID := range body.IDs {
 		id := int64(rawID)
 		var existing store.Site
-		err := h.db.Get(&existing, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), id)
+		err := h.db.Get(&existing, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), id)
 		if err != nil {
 			failedItems = append(failedItems, map[string]any{"id": id, "message": "Site not found"})
 			continue
@@ -537,7 +537,7 @@ func (h *sitesHandler) getDisabledModels(w http.ResponseWriter, r *http.Request)
 	}
 
 	var existing store.Site
-	if err := h.db.Get(&existing, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), id); err != nil {
+	if err := h.db.Get(&existing, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), id); err != nil {
 		writeError(w, http.StatusNotFound, "Site not found")
 		return
 	}
@@ -566,7 +566,7 @@ func (h *sitesHandler) updateDisabledModels(w http.ResponseWriter, r *http.Reque
 	}
 
 	var existing store.Site
-	if err := h.db.Get(&existing, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), id); err != nil {
+	if err := h.db.Get(&existing, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), id); err != nil {
 		writeError(w, http.StatusNotFound, "Site not found")
 		return
 	}
@@ -608,7 +608,7 @@ func (h *sitesHandler) getAvailableModels(w http.ResponseWriter, r *http.Request
 	}
 
 	var existing store.Site
-	if err := h.db.Get(&existing, h.db.Rebind("SELECT * FROM sites WHERE id = ?"), id); err != nil {
+	if err := h.db.Get(&existing, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), id); err != nil {
 		writeError(w, http.StatusNotFound, "Site not found")
 		return
 	}

--- a/service/oauth/flow.go
+++ b/service/oauth/flow.go
@@ -624,7 +624,7 @@ func revertPersistedOauthAccount(db *store.DB, accountID int64, created bool, sn
 func ensureOAuthProviderSite(db *store.DB, def *OAuthProviderDefinition) (*store.Site, error) {
 	var site store.Site
 	err := db.Get(&site,
-		"SELECT * FROM sites WHERE platform = ? AND url = ? LIMIT 1",
+		"SELECT id, name, url, external_checkin_url, platform, proxy_url, use_system_proxy, custom_headers, status, is_pinned, sort_order, global_weight, api_key, max_concurrency, post_refresh_probe_enabled, post_refresh_probe_model, post_refresh_probe_scope, post_refresh_probe_latency_threshold_ms, created_at, updated_at FROM sites WHERE platform = ? AND url = ? LIMIT 1",
 		def.Site.Platform, def.Site.URL)
 	if err == nil {
 		return &site, nil
@@ -644,7 +644,7 @@ func ensureOAuthProviderSite(db *store.DB, def *OAuthProviderDefinition) (*store
 	if err != nil {
 		// Try reading again in case of race.
 		err2 := db.Get(&site,
-			"SELECT * FROM sites WHERE platform = ? AND url = ? LIMIT 1",
+			"SELECT id, name, url, external_checkin_url, platform, proxy_url, use_system_proxy, custom_headers, status, is_pinned, sort_order, global_weight, api_key, max_concurrency, post_refresh_probe_enabled, post_refresh_probe_model, post_refresh_probe_scope, post_refresh_probe_latency_threshold_ms, created_at, updated_at FROM sites WHERE platform = ? AND url = ? LIMIT 1",
 			def.Site.Platform, def.Site.URL)
 		if err2 == nil {
 			return &site, nil

--- a/service/site_cache_invalidation_test.go
+++ b/service/site_cache_invalidation_test.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func TestInvalidateSiteProxyCache_RunsHooksAndRouting(t *testing.T) {
+	var calls atomic.Int32
+	RegisterSiteProxyCacheInvalidator(func() {
+		calls.Add(1)
+	})
+
+	cache := routing.NewRouteCache(1000)
+	routing.SetGlobalCache(cache)
+	cache.SetRoutes([]store.TokenRoute{{ID: 1}})
+	if cache.GetRoutes() == nil {
+		t.Fatal("expected routes before invalidate")
+	}
+
+	InvalidateSiteProxyCache()
+	if calls.Load() < 1 {
+		t.Fatalf("hook calls=%d want >=1", calls.Load())
+	}
+	if cache.GetRoutes() != nil {
+		t.Fatal("expected routes cleared after InvalidateSiteProxyCache")
+	}
+}
+
+func TestInvalidateSiteCaches_Delegates(t *testing.T) {
+	var calls atomic.Int32
+	RegisterSiteProxyCacheInvalidator(func() { calls.Add(1) })
+	cache := routing.NewRouteCache(1000)
+	routing.SetGlobalCache(cache)
+	cache.SetRoutes([]store.TokenRoute{{ID: 2}})
+	InvalidateSiteCaches()
+	if calls.Load() < 1 {
+		t.Fatalf("hook calls=%d", calls.Load())
+	}
+	if cache.GetRoutes() != nil {
+		t.Fatal("routes not cleared")
+	}
+}
+
+func TestRegisterSiteProxyCacheInvalidator_NilNoop(t *testing.T) {
+	RegisterSiteProxyCacheInvalidator(nil) // must not panic
+}

--- a/service/site_service.go
+++ b/service/site_service.go
@@ -151,10 +151,10 @@ func LoadSiteAPIEndpoints(db *sqlx.DB, siteIDs []int64) (map[int64][]store.SiteA
 	return result, nil
 }
 
-// siteSelectColumns lists known sites columns for SELECT (never SELECT *).
+// SiteSelectColumns lists known sites columns for SELECT (never SELECT *).
 // Shared PG CI DBs may have leftover probe columns from schema experiments;
 // SELECT * would fail struct scan with "missing destination name ...".
-const siteSelectColumns = `id, name, url, external_checkin_url, platform, proxy_url, use_system_proxy,
+const SiteSelectColumns = `id, name, url, external_checkin_url, platform, proxy_url, use_system_proxy,
 	custom_headers, status, is_pinned, sort_order, global_weight, api_key, max_concurrency,
 	post_refresh_probe_enabled, post_refresh_probe_model, post_refresh_probe_scope,
 	post_refresh_probe_latency_threshold_ms, created_at, updated_at`
@@ -162,7 +162,7 @@ const siteSelectColumns = `id, name, url, external_checkin_url, platform, proxy_
 // LoadSiteWithEndpoints loads a single site with its apiEndpoints attached.
 func LoadSiteWithEndpoints(db *sqlx.DB, siteID int64) (map[string]any, error) {
 	var site store.Site
-	err := db.Get(&site, db.Rebind("SELECT "+siteSelectColumns+" FROM sites WHERE id = ?"), siteID)
+	err := db.Get(&site, db.Rebind("SELECT "+SiteSelectColumns+" FROM sites WHERE id = ?"), siteID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -209,7 +209,7 @@ func siteToMap(site store.Site, endpoints []store.SiteAPIEndpoint) map[string]an
 // ListSites returns all sites with apiEndpoints, totalBalance, and subscriptionSummary.
 func ListSites(db *sqlx.DB) ([]map[string]any, error) {
 	var sites []store.Site
-	if err := db.Select(&sites, "SELECT "+siteSelectColumns+" FROM sites ORDER BY sort_order, id"); err != nil {
+	if err := db.Select(&sites, "SELECT "+SiteSelectColumns+" FROM sites ORDER BY sort_order, id"); err != nil {
 		return nil, err
 	}
 

--- a/service/site_service.go
+++ b/service/site_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -409,10 +410,43 @@ func DeleteSite(db *sqlx.DB, siteID int64) error {
 	return err
 }
 
-// InvalidateSiteProxyCache signals that cached site proxy configurations should be refreshed.
-// TODO(P8): integrate with the proxy cache layer when implemented.
+// siteProxyCacheInvalidators are optional hooks (e.g. admin accounts snapshot cache).
+// Registered from other packages to avoid import cycles.
+var (
+	siteProxyCacheInvalidatorsMu sync.RWMutex
+	siteProxyCacheInvalidators   []func()
+)
+
+// RegisterSiteProxyCacheInvalidator appends a hook invoked by InvalidateSiteProxyCache.
+// Safe for concurrent registration; hooks should be idempotent and non-blocking.
+func RegisterSiteProxyCacheInvalidator(fn func()) {
+	if fn == nil {
+		return
+	}
+	siteProxyCacheInvalidatorsMu.Lock()
+	siteProxyCacheInvalidators = append(siteProxyCacheInvalidators, fn)
+	siteProxyCacheInvalidatorsMu.Unlock()
+}
+
+// InvalidateSiteProxyCache refreshes process-local caches that depend on site/proxy config.
+// Always invalidates the token-router route cache; then runs registered hooks
+// (admin accounts snapshot, future proxy config caches).
 func InvalidateSiteProxyCache() {
-	// Stub: P8 proxy cache invalidation
+	routing.InvalidateCache()
+	siteProxyCacheInvalidatorsMu.RLock()
+	hooks := append([]func(){}, siteProxyCacheInvalidators...)
+	siteProxyCacheInvalidatorsMu.RUnlock()
+	for _, fn := range hooks {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					// never let a hook panic abort site mutations
+					_ = r
+				}
+			}()
+			fn()
+		}()
+	}
 }
 
 // InvalidateTokenRouterCache signals that cached token-router state should be invalidated.


### PR DESCRIPTION
## Summary
- `InvalidateSiteProxyCache` clears `routing.InvalidateCache` + hook registry
- Admin accounts snapshot cache registers clear hook in `init`
- Tests + residual docs

Closes #216

## Test plan
- [x] `go test ./service -count=1 -run Invalidate`
- [x] `go test ./handler/admin -count=1 -run 'Account|Site'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Site and account caches now refresh after site changes, helping ensure updated information appears promptly.
  * Cache invalidation is more resilient, so individual cache errors do not interrupt site updates.
  * Site lookups use defined fields to improve consistency and reliability.

* **Documentation**
  * Added design notes covering site proxy cache invalidation and related operational considerations.

* **Tests**
  * Added coverage for cache invalidation, hook execution, and safe handling of empty hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->