### PR TITLE
feat(proxy): honest Responses WebSocket residual + boot wire

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/tokendancelab/metapi-go/config"
+	proxyhandler "github.com/tokendancelab/metapi-go/handler/proxy"
 	"github.com/tokendancelab/metapi-go/store"
 )
 
@@ -60,6 +61,9 @@ func (a *App) OnClose() {
 func (a *App) Start() error {
 	addr := fmt.Sprintf("%s:%d", a.Config.ListenHost, a.Config.Port)
 	a.Server = newHTTPServer(addr, a.Router)
+	// Honest residual registration for Responses WS (#217). Noop transport is OK;
+	// must be called from boot so capability is not a silent uncalled stub.
+	a.WireResponsesWebsocketTransport()
 
 	// Channel to capture listen errors
 	errCh := make(chan error, 1)
@@ -106,6 +110,16 @@ func newHTTPServer(addr string, handler http.Handler) *http.Server {
 		IdleTimeout:       120 * time.Second,
 		MaxHeaderBytes:    1 << 20,
 	}
+}
+
+// WireResponsesWebsocketTransport registers the Responses WebSocket residual on
+// a.Server. Safe no-op when Server is nil. Called from Start; tests may call
+// directly after assigning Server.
+func (a *App) WireResponsesWebsocketTransport() {
+	if a == nil || a.Server == nil {
+		return
+	}
+	proxyhandler.EnsureResponsesWebsocketTransport(a.Server, proxyhandler.WebSocketConfig{})
 }
 
 // Shutdown performs a graceful shutdown of the HTTP server with the given context.

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/tokendancelab/metapi-go/config"
+	proxyhandler "github.com/tokendancelab/metapi-go/handler/proxy"
 	"github.com/tokendancelab/metapi-go/store"
 )
 
@@ -171,4 +172,26 @@ func TestNewHTTPServerUsesHardenedDefaults(t *testing.T) {
 	if server.MaxHeaderBytes != 1<<20 {
 		t.Fatalf("MaxHeaderBytes = %d, want %d", server.MaxHeaderBytes, 1<<20)
 	}
+}
+
+// TestWireResponsesWebsocketTransport_RegistersResidual covers #217 boot path:
+// App.Start calls WireResponsesWebsocketTransport so Ensure is not a silent uncalled stub.
+func TestWireResponsesWebsocketTransport_RegistersResidual(t *testing.T) {
+	proxyhandler.ResetResponsesWebsocketTransportForTest()
+	if proxyhandler.ResponsesWebsocketTransportRegistered() {
+		t.Fatal("expected unregistered before wire")
+	}
+
+	a := New(&config.Config{ListenHost: "127.0.0.1", Port: 0}, http.NewServeMux())
+	a.Server = newHTTPServer("127.0.0.1:0", a.Router)
+	a.WireResponsesWebsocketTransport()
+
+	if !proxyhandler.ResponsesWebsocketTransportRegistered() {
+		t.Fatal("WireResponsesWebsocketTransport must call EnsureResponsesWebsocketTransport")
+	}
+
+	// nil / missing server must not panic
+	(&App{}).WireResponsesWebsocketTransport()
+	var nilApp *App
+	nilApp.WireResponsesWebsocketTransport()
 }

--- a/docs/analysis/responses-websocket-residual.md
+++ b/docs/analysis/responses-websocket-residual.md
@@ -1,0 +1,81 @@
+# Residual: Responses WebSocket transport (#217)
+
+**Date**: 2026-07-17  
+**Issue**: [#217](https://github.com/TokenDanceLab/metapi-go/issues/217)  
+**Lane**: p85 / honest residual  
+**SSOT code**: `handler/proxy/responses_ws.go`, `handler/proxy/responses.go`, `app/app.go`
+
+## Goal
+
+Stop silent capability theater around Responses WebSocket:
+
+- `EnsureResponsesWebsocketTransport` must be **called from app boot**, not only defined.
+- Do **not** invent a full Codex multi-turn WebSocket product or fake WS completions.
+- Prefer stdlib residual (no `gorilla/websocket` / `nhooyr` dependency) with clear HTTP status semantics.
+
+## Boot wiring
+
+```
+cmd/server
+  app.New(cfg, router)
+  a.Start()
+    · newHTTPServer(...)
+    · a.WireResponsesWebsocketTransport()
+        · proxyhandler.EnsureResponsesWebsocketTransport(server, WebSocketConfig{})
+```
+
+`WireResponsesWebsocketTransport` is a thin composition-root call on `*app.App`. Residual registration sets an in-process flag (`ResponsesWebsocketTransportRegistered`) and logs:
+
+| Field | Value |
+|-------|--------|
+| `status` | `not_implemented` |
+| plain GET | `426 Upgrade Required` |
+| upgrade attempt | `501 Not Implemented` |
+| `doc` | `docs/analysis/responses-websocket-residual.md` |
+
+## HTTP surface (honest)
+
+| Request | Status | Meaning |
+|---------|--------|---------|
+| `GET /v1/responses` (no Upgrade) | **426** | Client must use WebSocket upgrade for GET; HTTP GET is not a responses read API |
+| `GET /v1/responses` with `Upgrade: websocket` + `Connection: upgrade` | **501** | Residual: transport not implemented; no Hijack, no frames, no fake completions |
+| `GET /responses` / alias compact | same 426 / 501 after alias resolve | Unknown alias still **404** |
+| `POST /v1/responses` | existing HTTP responses path | Unchanged (not part of this residual) |
+
+JSON error shape remains OpenAI-ish:
+
+```json
+{"error":{"message":"...","type":"invalid_request_error"}}
+```
+
+## What is **not** claimed
+
+1. **No live WS server** — `EnsureResponsesWebsocketTransport` does not install `server.ConnState`, does not Hijack, and does not accept WebSocket handshakes.
+2. **No fake completions on wire** — helpers such as `SynthesizePrewarmResponsePayloads` / `ParseResponsesWSMessage` exist for a future runtime and unit tests only; residual handlers never emit them to a client socket.
+3. **Codex profile capability ≠ transport readiness** — `SupportsResponsesWebsocketIncremental` on the Codex CLI profile describes **client detection** (what Codex clients expect). It does **not** mean metapi-go currently serves incremental WS responses.
+4. **No new websocket module in go.mod** — residual stays stdlib-only.
+
+## Optional future scaffolding (out of scope for #217)
+
+When implementing a real transport:
+
+1. Keep boot call site: `App.WireResponsesWebsocketTransport` → `EnsureResponsesWebsocketTransport`.
+2. Prefer `http.Hijacker` on `GET /v1/responses` after auth, or a dedicated upgrade mux — still no silent success without a protocol.
+3. Message loop, turn-state echo, pre-warm `generate=false`, and HTTP fallback from an open socket are product work, not residual.
+
+## Tests
+
+| Area | Coverage |
+|------|----------|
+| Residual registration | `EnsureResponsesWebsocketTransport` sets registered flag |
+| App boot wire | `App.WireResponsesWebsocketTransport` marks registered |
+| Plain GET | `HandleResponsesGet426` → 426 |
+| Upgrade GET | residual → 501, message mentions residual doc |
+| Alias GET | 426 / 501 / 404 unchanged for unknown |
+| Upgrade detection | `IsWebsocketUpgradeRequest` |
+
+Verify:
+
+```bash
+go test ./handler/proxy ./app ./cmd/server -count=1 -run 'Responses|Websocket|WS'
+```

--- a/handler/proxy/responses.go
+++ b/handler/proxy/responses.go
@@ -27,8 +27,14 @@ func HandleResponses(w http.ResponseWriter, r *http.Request, downstreamPath stri
 	dispatchUpstream(w, r, ctx)
 }
 
-// HandleResponsesGet426 returns 426 WebSocket upgrade required for GET /v1/responses.
+// HandleResponsesGet426 handles GET /v1/responses.
+// Plain GET → 426 Upgrade Required. WebSocket upgrade attempt → 501 residual
+// (no Codex WS runtime; see EnsureResponsesWebsocketTransport).
 func HandleResponsesGet426(w http.ResponseWriter, r *http.Request) {
+	if IsWebsocketUpgradeRequest(r) {
+		HandleResponsesWebsocketUpgradeResidual(w, r)
+		return
+	}
 	path := r.URL.Path
 	writeJSONError(w, 426,
 		fmt.Sprintf("WebSocket upgrade required for GET %s", path),
@@ -45,11 +51,16 @@ func HandleResponsesAliasPost(w http.ResponseWriter, r *http.Request) {
 	HandleResponses(w, r, downstreamPath)
 }
 
-// HandleResponsesAliasGet426 returns 426 for GET /responses and /responses/*.
+// HandleResponsesAliasGet426 handles GET /responses and /responses/*.
+// Unknown alias → 404. Upgrade attempt → 501 residual. Plain GET → 426.
 func HandleResponsesAliasGet426(w http.ResponseWriter, r *http.Request) {
 	downstreamPath := resolveAliasedResponsesPath(r.URL.Path)
 	if downstreamPath == "" {
 		writeJSONError(w, 404, "Unknown /responses alias path", "invalid_request_error")
+		return
+	}
+	if IsWebsocketUpgradeRequest(r) {
+		HandleResponsesWebsocketUpgradeResidual(w, r)
 		return
 	}
 	writeJSONError(w, 426,

--- a/handler/proxy/responses_test.go
+++ b/handler/proxy/responses_test.go
@@ -102,6 +102,24 @@ func TestHandleResponsesGet426(t *testing.T) {
 	if rec.Code != 426 {
 		t.Errorf("expected 426, got %d: %s", rec.Code, rec.Body.String())
 	}
+	if !strings.Contains(rec.Body.String(), "WebSocket upgrade required") {
+		t.Errorf("body = %s", rec.Body.String())
+	}
+}
+
+func TestHandleResponsesGet426_WebsocketUpgradeIs501Residual(t *testing.T) {
+	req := httptest.NewRequest("GET", "/v1/responses", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "Upgrade")
+	rec := httptest.NewRecorder()
+	HandleResponsesGet426(rec, req)
+
+	if rec.Code != 501 {
+		t.Fatalf("expected 501 residual, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "response.completed") {
+		t.Error("must not invent WS completion payloads")
+	}
 }
 
 // ---- HandleResponsesAliasPost ----
@@ -145,6 +163,18 @@ func TestHandleResponsesAliasGet426_Valid(t *testing.T) {
 
 	if rec.Code != 426 {
 		t.Errorf("expected 426, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleResponsesAliasGet426_WebsocketUpgradeIs501Residual(t *testing.T) {
+	req := httptest.NewRequest("GET", "/responses", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "Upgrade")
+	rec := httptest.NewRecorder()
+	HandleResponsesAliasGet426(rec, req)
+
+	if rec.Code != 501 {
+		t.Fatalf("expected 501 residual, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/handler/proxy/responses_ws.go
+++ b/handler/proxy/responses_ws.go
@@ -5,32 +5,100 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync/atomic"
 
 	"github.com/tokendancelab/metapi-go/auth"
 )
 
-// EnsureResponsesWebsocketTransport registers the WebSocket upgrade handler
-// for /v1/responses on the given HTTP server.
-//
-// In the TS codebase, this is installed via server.on('upgrade') and only
-// handles pathname === '/v1/responses'. The Go implementation uses
-// the net/http Hijacker interface for WebSocket upgrades.
-//
-// For the initial P10 implementation, WebSocket support is stubbed.
-// The full implementation (Codex WS runtime, message serialization,
-// pre-warm synthesis, HTTP fallback) will be completed in a follow-up pass.
-func EnsureResponsesWebsocketTransport(srv *http.Server, cfg WebSocketConfig) {
-	slog.Info("registering responses WebSocket transport (stub)")
+// Residual status for Responses WebSocket transport (#217).
+// There is intentionally no gorilla/websocket (or other WS) dependency and no
+// Codex multi-turn WS runtime. Boot still calls EnsureResponsesWebsocketTransport
+// so registration is explicit rather than a silent stub that is never invoked.
+const (
+	ResponsesWebsocketResidualStatus = "not_implemented"
+	ResponsesWebsocketResidualDoc    = "docs/analysis/responses-websocket-residual.md"
+)
 
-	// Store the config for use during upgrade
-	_ = srv
-	_ = cfg
+// responsesWebsocketTransportRegistered is set by EnsureResponsesWebsocketTransport.
+// Tests assert the boot path actually registers the residual.
+var responsesWebsocketTransportRegistered atomic.Bool
+
+// ResponsesWebsocketTransportRegistered reports whether the residual transport
+// registration entrypoint has been called in this process.
+func ResponsesWebsocketTransportRegistered() bool {
+	return responsesWebsocketTransportRegistered.Load()
 }
 
-// WebSocketConfig holds configuration for the responses WebSocket transport.
+// ResetResponsesWebsocketTransportForTest clears residual registration state.
+// Test-only helper.
+func ResetResponsesWebsocketTransportForTest() {
+	responsesWebsocketTransportRegistered.Store(false)
+}
+
+// EnsureResponsesWebsocketTransport registers the Responses WebSocket residual
+// for /v1/responses on the given HTTP server.
+//
+// Honest residual behavior (no fake WS completions):
+//   - No net/http ConnState / Hijacker upgrade loop is installed.
+//   - Plain GET /v1/responses continues to return 426 (upgrade required).
+//   - GET with Upgrade: websocket is refused with 501 (not implemented).
+//   - Codex profile SupportsResponsesWebsocketIncremental describes client
+//     capability detection only — not server transport readiness.
+//
+// Full Codex WS runtime (message loop, pre-warm synthesis on wire, HTTP
+// fallback from an open socket) remains out of scope for this residual.
+func EnsureResponsesWebsocketTransport(srv *http.Server, cfg WebSocketConfig) {
+	responsesWebsocketTransportRegistered.Store(true)
+
+	// Keep cfg/srv referenced so future Hijacker scaffolding can plug in
+	// without changing the boot call site. No silent success theater.
+	_ = srv
+	_ = cfg
+
+	slog.Info("responses WebSocket transport residual registered",
+		"status", ResponsesWebsocketResidualStatus,
+		"http_get", "426 Upgrade Required (non-upgrade GET)",
+		"upgrade", "501 Not Implemented (no Codex WS runtime)",
+		"doc", ResponsesWebsocketResidualDoc,
+	)
+}
+
+// WebSocketConfig holds optional hooks for a future Responses WebSocket transport.
+// Residual registration accepts the config so boot wiring stays stable.
 type WebSocketConfig struct {
 	// AuthTokenValidation is used to validate tokens during WS upgrade.
+	// Unused while transport is residual-only.
 	AuthTokenValidation func(token string) (*auth.ProxyAuthContext, error)
+}
+
+// IsWebsocketUpgradeRequest reports whether r is a WebSocket upgrade attempt.
+// Used to distinguish plain GET 426 from residual 501 on upgrade.
+func IsWebsocketUpgradeRequest(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(r.Header.Get("Upgrade")), "websocket") {
+		return false
+	}
+	for _, part := range strings.Split(r.Header.Get("Connection"), ",") {
+		if strings.EqualFold(strings.TrimSpace(part), "upgrade") {
+			return true
+		}
+	}
+	return false
+}
+
+// HandleResponsesWebsocketUpgradeResidual refuses a WebSocket upgrade without
+// inventing frames or fake completions. Prefer 501 over Hijack+silent close so
+// clients get a clear residual JSON error on the HTTP path.
+func HandleResponsesWebsocketUpgradeResidual(w http.ResponseWriter, r *http.Request) {
+	path := "/v1/responses"
+	if r != nil && r.URL != nil && strings.TrimSpace(r.URL.Path) != "" {
+		path = r.URL.Path
+	}
+	writeJSONError(w, http.StatusNotImplemented,
+		"Responses WebSocket transport is not implemented for "+path+" (residual; see "+ResponsesWebsocketResidualDoc+")",
+		"invalid_request_error")
 }
 
 // extractWSHeaders extracts relevant headers for WebSocket context detection.
@@ -50,14 +118,15 @@ func extractWSTurnState(r *http.Request) string {
 }
 
 // ResponsesWSMessage is a WebSocket message from the downstream client.
+// Parsing helpers exist for a future runtime; residual path does not open sockets.
 type ResponsesWSMessage struct {
-	Type             string         `json:"type"`
-	Model            string         `json:"model,omitempty"`
-	Generate         *bool          `json:"generate,omitempty"`
-	Input            []any          `json:"input,omitempty"`
-	Instructions     any            `json:"instructions,omitempty"`
-	PreviousResponseID string       `json:"previous_response_id,omitempty"`
-	Raw              map[string]any `json:"-"`
+	Type               string         `json:"type"`
+	Model              string         `json:"model,omitempty"`
+	Generate           *bool          `json:"generate,omitempty"`
+	Input              []any          `json:"input,omitempty"`
+	Instructions       any            `json:"instructions,omitempty"`
+	PreviousResponseID string         `json:"previous_response_id,omitempty"`
+	Raw                map[string]any `json:"-"`
 }
 
 // ParseResponsesWSMessage parses a WebSocket JSON message.
@@ -67,14 +136,14 @@ func ParseResponsesWSMessage(raw []byte) (*ResponsesWSMessage, error) {
 		return nil, err
 	}
 	msg.Raw = make(map[string]any)
-	json.Unmarshal(raw, &msg.Raw)
+	_ = json.Unmarshal(raw, &msg.Raw)
 	return &msg, nil
 }
 
-// ResponsesWSError writes a WebSocket error frame.
+// ResponsesWSError builds a WebSocket-shaped error object (not written on residual path).
 func ResponsesWSError(status int, message string) map[string]any {
 	return map[string]any{
-		"type":  "error",
+		"type":   "error",
 		"status": status,
 		"error": map[string]any{
 			"type":    "invalid_request_error",
@@ -84,7 +153,8 @@ func ResponsesWSError(status int, message string) map[string]any {
 }
 
 // SynthesizePrewarmResponsePayloads generates pre-warm response.created + response.completed
-// for Codex file-search pre-warm mode (generate=false without incremental input).
+// for a future Codex file-search pre-warm mode (generate=false without incremental input).
+// Residual transport does not emit these on the wire.
 func SynthesizePrewarmResponsePayloads(model string, responseID string) []map[string]any {
 	if responseID == "" {
 		responseID = "resp_prewarm_metapi"
@@ -97,21 +167,21 @@ func SynthesizePrewarmResponsePayloads(model string, responseID string) []map[st
 		{
 			"type": "response.created",
 			"response": map[string]any{
-				"id":       responseID,
-				"object":   "response",
-				"status":   "in_progress",
-				"model":    modelName,
-				"output":   []any{},
+				"id":     responseID,
+				"object": "response",
+				"status": "in_progress",
+				"model":  modelName,
+				"output": []any{},
 			},
 		},
 		{
 			"type": "response.completed",
 			"response": map[string]any{
-				"id":       responseID,
-				"object":   "response",
-				"status":   "completed",
-				"model":    modelName,
-				"output":   []any{},
+				"id":     responseID,
+				"object": "response",
+				"status": "completed",
+				"model":  modelName,
+				"output": []any{},
 				"usage": map[string]any{
 					"input_tokens":  0,
 					"output_tokens": 0,

--- a/handler/proxy/responses_ws_test.go
+++ b/handler/proxy/responses_ws_test.go
@@ -2,9 +2,83 @@ package proxyhandler
 
 import (
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+// ---- EnsureResponsesWebsocketTransport residual registration ----
+
+func TestEnsureResponsesWebsocketTransport_RegistersResidual(t *testing.T) {
+	ResetResponsesWebsocketTransportForTest()
+	if ResponsesWebsocketTransportRegistered() {
+		t.Fatal("expected unregistered before Ensure")
+	}
+
+	srv := &http.Server{}
+	EnsureResponsesWebsocketTransport(srv, WebSocketConfig{})
+
+	if !ResponsesWebsocketTransportRegistered() {
+		t.Fatal("expected residual registration after EnsureResponsesWebsocketTransport")
+	}
+	if ResponsesWebsocketResidualStatus != "not_implemented" {
+		t.Errorf("status = %q, want not_implemented", ResponsesWebsocketResidualStatus)
+	}
+	if !strings.Contains(ResponsesWebsocketResidualDoc, "responses-websocket-residual") {
+		t.Errorf("doc pointer = %q", ResponsesWebsocketResidualDoc)
+	}
+}
+
+func TestIsWebsocketUpgradeRequest(t *testing.T) {
+	t.Parallel()
+
+	upgrade := httptest.NewRequest(http.MethodGet, "/v1/responses", nil)
+	upgrade.Header.Set("Upgrade", "websocket")
+	upgrade.Header.Set("Connection", "keep-alive, Upgrade")
+	if !IsWebsocketUpgradeRequest(upgrade) {
+		t.Error("expected upgrade request")
+	}
+
+	plain := httptest.NewRequest(http.MethodGet, "/v1/responses", nil)
+	if IsWebsocketUpgradeRequest(plain) {
+		t.Error("plain GET must not look like upgrade")
+	}
+
+	upgradeOnly := httptest.NewRequest(http.MethodGet, "/v1/responses", nil)
+	upgradeOnly.Header.Set("Upgrade", "websocket")
+	if IsWebsocketUpgradeRequest(upgradeOnly) {
+		t.Error("Upgrade without Connection: upgrade must not match")
+	}
+
+	if IsWebsocketUpgradeRequest(nil) {
+		t.Error("nil request must be false")
+	}
+}
+
+func TestHandleResponsesWebsocketUpgradeResidual_501(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/responses", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "Upgrade")
+	rec := httptest.NewRecorder()
+
+	HandleResponsesWebsocketUpgradeResidual(rec, req)
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501 body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "not implemented") {
+		t.Errorf("body should mention not implemented: %s", body)
+	}
+	if !strings.Contains(body, ResponsesWebsocketResidualDoc) {
+		t.Errorf("body should point at residual doc: %s", body)
+	}
+	// Must not invent fake completion payloads on residual path.
+	if strings.Contains(body, "response.completed") || strings.Contains(body, "chat.completion") {
+		t.Errorf("residual must not emit fake completions: %s", body)
+	}
+}
 
 // ---- ParseResponsesWSMessage ----
 


### PR DESCRIPTION
## Summary
- Wire `EnsureResponsesWebsocketTransport` from `app.Start` via `WireResponsesWebsocketTransport` so residual registration is not a silent uncalled stub (#217).
- Keep plain `GET /v1/responses` at **426**; WebSocket upgrade attempts return **501** residual JSON (no Hijack, no fake completions, no websocket dependency).
- Document residual in `docs/analysis/responses-websocket-residual.md`; clarify Codex `SupportsResponsesWebsocketIncremental` is client capability detection, not server transport readiness.

## Test plan
- [x] `go test ./handler/proxy ./app ./cmd/server -count=1 -run 'Responses|Websocket|WS'`
- [x] `go test ./handler/proxy ./app -count=1`
- [ ] Confirm boot log line mentions residual status + doc path when server starts

Closes #217