### PR TITLE
feat(proxy): Gemini /v1beta/models via owned catalog (#215)

### DIFF
--- a/docs/analysis/gemini-models-list.md
+++ b/docs/analysis/gemini-models-list.md
@@ -1,0 +1,93 @@
+# Gemini `/v1beta/models` list via owned catalog
+
+> Date: 2026-07-17  
+> Issue: TokenDanceLab/metapi-go #215  
+> Scope: proxy surface `handler/proxy/gemini.go` (`HandleGeminiModelsList`)
+
+## Purpose
+
+Document how MetAPI serves Gemini Generative Language **models.list** responses from the **MetAPI-owned model catalog**, instead of a hard-coded success stub or a live upstream scrape.
+
+## Endpoints
+
+| Item | Value |
+|------|--------|
+| Paths | `GET /v1beta/models`, `GET /gemini/{geminiApiVersion}/models` |
+| Auth | Proxy auth required (missing → **401**) |
+| Handler | `HandleGeminiModelsList` / `HandleGeminiModelsListDynamic` |
+| Generate paths | Unchanged: `POST …/models/*` and Gemini CLI still use `dispatchUpstream` |
+
+## Owned vs hard-coded vs upstream
+
+| Mode | Behavior | Status |
+|------|----------|--------|
+| **Owned listing** (current) | Resolve catalog via `getAvailableModels` → `resolveOwnedModelCatalog` / `AvailableModelsSource`, filter gemini-ish names when mixed, map to Gemini list JSON | **Implemented** (#215) |
+| **Hard-coded stub list** | Always returned `gemini-2.5-pro` + `gemini-2.5-flash` on success | **Removed** |
+| **Upstream Generative Language list** | Proxy vendor `models.list` body | **Not implemented** (not the default) |
+
+Catalog resolution is shared with `GET /v1/models` (see `docs/analysis/models-response-shape.md`):
+
+| Condition | Catalog source |
+|-----------|----------------|
+| Router implements `AvailableModelsSource` | `GetAvailableModels(ctx)` (normalized + sorted) |
+| Router listing error | Empty list + warn log |
+| Selection-only router (no listing method) | Last-resort stub catalog residual |
+| No router + `METAPI_ENABLE_PROXY_STUB=1` | Last-resort stub catalog residual (unit tests) |
+| No router + stub disabled | Empty list + one-shot warn (production safety) |
+
+Policy filtering (`SupportedModels`, `DenyAllWhenEmpty`, …) is applied by `getAvailableModels` before Gemini mapping.
+
+## Gemini response shape
+
+```json
+{
+  "models": [
+    {
+      "name": "models/gemini-2.5-pro",
+      "displayName": "Gemini 2.5 Pro",
+      "description": "Gemini 2.5 Pro model",
+      "supportedGenerationMethods": [
+        "generateContent",
+        "streamGenerateContent",
+        "countTokens"
+      ]
+    }
+  ]
+}
+```
+
+| Field | Notes |
+|-------|--------|
+| `models` | Always present; may be `[]` when catalog empty / deny-all / listing error |
+| `name` | Resource form `models/<id>`; optional input `models/` prefix is stripped then re-applied |
+| `displayName` | Lightweight humanization of the id (`gemini-2.5-flash` → `Gemini 2.5 Flash`) |
+| `description` | `{displayName} model` (stable client-facing filler; not scraped from vendor) |
+| `supportedGenerationMethods` | Fixed capability set for owned Gemini entries |
+
+## Gemini-ish filtering
+
+When the owned catalog is **mixed** (OpenAI + Claude + Gemini route names), list entries whose names contain `gemini` (case-insensitive) are preferred.
+
+If **no** gemini-ish names exist, **all** owned models are still mapped into the Gemini envelope. Empty `models` is reserved for truly empty catalogs (or policy denial / listing failure), not for “no gemini substring”.
+
+## Residual / stub fallback
+
+- Last-resort stub catalog remains a **shared residual** of `resolveOwnedModelCatalog` for unit tests and selection-only routers. It is not a Gemini-handler hard-code.
+- When that residual catalog is mixed, Gemini list still filters to gemini-ish names (`gemini-2.5-pro`, `gemini-2.5-flash` today).
+- Production with a wired `TokenRouter` that implements `AvailableModelsSource` never depends on the residual stub for success.
+
+## Auth
+
+Unauthorized callers (no proxy auth context) receive **401** with the standard JSON error envelope. Catalog resolution is not attempted.
+
+## Verify
+
+```bash
+go test ./handler/proxy -count=1 -run Gemini
+```
+
+## Non-goals
+
+- Live upstream Gemini `models.list` merge
+- Per-model method discovery from vendor metadata
+- Changing generateContent / Gemini CLI dispatch behavior

--- a/handler/proxy/gemini.go
+++ b/handler/proxy/gemini.go
@@ -24,7 +24,22 @@ func RegisterGeminiRoutes(r chi.Router) {
 	r.Post("/v1internal::countTokens", HandleGeminiCLICountTokens)
 }
 
+// geminiSupportedGenerationMethods is the fixed method set advertised for owned
+// Gemini list entries. Typed as []any so writeJSON/appendJSON encodes a JSON
+// array (the lightweight encoder does not special-case []string).
+// GenerateContent paths still route through dispatchUpstream; this list only
+// describes client-visible capabilities.
+var geminiSupportedGenerationMethods = []any{
+	"generateContent",
+	"streamGenerateContent",
+	"countTokens",
+}
+
 // HandleGeminiModelsList handles GET /v1beta/models.
+// Returns a Gemini-shaped models list built from the MetAPI-owned catalog
+// (resolveOwnedModelCatalog / AvailableModelsSource), not a hard-coded stub and
+// not a live upstream Generative Language models scrape. See
+// docs/analysis/gemini-models-list.md.
 func HandleGeminiModelsList(w http.ResponseWriter, r *http.Request) {
 	authCtx := GetProxyAuth(r)
 	if authCtx == nil {
@@ -32,26 +47,85 @@ func HandleGeminiModelsList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = authCtx
+	models := getAvailableModels(r.Context(), authCtx.Policy)
+	writeJSON(w, 200, buildGeminiModelsResponse(selectGeminiListModels(models)))
+}
 
-	// Gemini models list response
-	stubResp := map[string]any{
-		"models": []map[string]any{
-			{
-				"name":                       "models/gemini-2.5-pro",
-				"displayName":                "Gemini 2.5 Pro",
-				"description":                "Gemini 2.5 Pro model",
-				"supportedGenerationMethods": []string{"generateContent", "streamGenerateContent", "countTokens"},
-			},
-			{
-				"name":                       "models/gemini-2.5-flash",
-				"displayName":                "Gemini 2.5 Flash",
-				"description":                "Gemini 2.5 Flash model",
-				"supportedGenerationMethods": []string{"generateContent", "streamGenerateContent", "countTokens"},
-			},
-		},
+// selectGeminiListModels prefers catalog entries that look Gemini-related when
+// the owned catalog is mixed (OpenAI/Claude/Gemini). If no gemini-ish names are
+// present, the full owned catalog is returned so an empty list is reserved for
+// truly empty / deny-all / listing-error cases.
+func selectGeminiListModels(models []string) []string {
+	if len(models) == 0 {
+		return []string{}
 	}
-	writeJSON(w, 200, stubResp)
+	gemini := make([]string, 0, len(models))
+	for _, m := range models {
+		if isGeminiishModelName(m) {
+			gemini = append(gemini, m)
+		}
+	}
+	if len(gemini) > 0 {
+		return gemini
+	}
+	return models
+}
+
+func isGeminiishModelName(model string) bool {
+	return strings.Contains(strings.ToLower(strings.TrimSpace(model)), "gemini")
+}
+
+// buildGeminiModelsResponse maps owned model IDs into the Gemini models.list
+// envelope used by Generative Language API clients:
+//
+//	{ "models": [ { "name": "models/<id>", "displayName", "description?",
+//	               "supportedGenerationMethods": [...] } ] }
+func buildGeminiModelsResponse(models []string) map[string]any {
+	items := make([]map[string]any, 0, len(models))
+	for _, m := range models {
+		id := normalizeGeminiModelID(m)
+		if id == "" {
+			continue
+		}
+		display := geminiDisplayName(id)
+		items = append(items, map[string]any{
+			"name":                       "models/" + id,
+			"displayName":                display,
+			"description":                display + " model",
+			"supportedGenerationMethods": append([]any(nil), geminiSupportedGenerationMethods...),
+		})
+	}
+	return map[string]any{
+		"models": items,
+	}
+}
+
+// normalizeGeminiModelID strips optional "models/" resource prefixes and blanks.
+func normalizeGeminiModelID(model string) string {
+	id := strings.TrimSpace(model)
+	id = strings.TrimPrefix(id, "models/")
+	return strings.TrimSpace(id)
+}
+
+// geminiDisplayName produces a lightweight human label from a model id
+// (e.g. gemini-2.5-pro → "Gemini 2.5 Pro"). Non-hyphenated ids pass through.
+func geminiDisplayName(id string) string {
+	id = normalizeGeminiModelID(id)
+	if id == "" || !strings.Contains(id, "-") {
+		return id
+	}
+	parts := strings.Split(id, "-")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		// Keep purely numeric / dotted version tokens as-is (2.5, 1.5, …).
+		if p[0] >= '0' && p[0] <= '9' {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
 }
 
 // HandleGeminiModelsListDynamic handles GET /gemini/:geminiApiVersion/models.

--- a/handler/proxy/gemini_test.go
+++ b/handler/proxy/gemini_test.go
@@ -2,8 +2,10 @@ package proxyhandler
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -76,7 +78,10 @@ func TestGeminiRoutes_Registration(t *testing.T) {
 
 // ---- HandleGeminiModelsList ----
 
-func TestHandleGeminiModelsList(t *testing.T) {
+func TestHandleGeminiModelsList_StubFallbackCatalog(t *testing.T) {
+	// TestMain enables METAPI_ENABLE_PROXY_STUB; nil upstream uses last-resort
+	// owned catalog (mixed OpenAI/Claude/Gemini) then filters to gemini-ish.
+	SetUpstreamConfig(nil)
 	req := auth.ProxyAuthFromRequest(
 		httptest.NewRequest("GET", "/v1beta/models", nil),
 		&auth.ProxyAuthContext{Token: "test", Source: "global", Policy: auth.EmptyDownstreamRoutingPolicy},
@@ -91,14 +96,130 @@ func TestHandleGeminiModelsList(t *testing.T) {
 	m := unmarshalResponse(t, rec)
 	models, _ := m["models"].([]any)
 	if len(models) == 0 {
-		t.Error("expected non-empty models list")
+		t.Fatal("expected non-empty models list from stub fallback residual")
+	}
+	// Mixed stub catalog must filter to gemini-ish names only.
+	for _, item := range models {
+		entry := item.(map[string]any)
+		name, _ := entry["name"].(string)
+		if !strings.Contains(strings.ToLower(name), "gemini") {
+			t.Errorf("stub fallback should filter non-gemini entries, got %q", name)
+		}
+		if !strings.HasPrefix(name, "models/") {
+			t.Errorf("name must use models/ resource form, got %q", name)
+		}
+		if _, ok := entry["displayName"]; !ok {
+			t.Error("missing displayName")
+		}
+		if _, ok := entry["supportedGenerationMethods"]; !ok {
+			t.Error("missing supportedGenerationMethods")
+		}
+	}
+}
+
+func TestHandleGeminiModelsList_UsesOwnedRouterCatalog(t *testing.T) {
+	withModelsRouter(t, &modelsTestRouter{
+		models: []string{"gpt-4o", "gemini-2.5-flash", "claude-sonnet-4-20250514", "models/gemini-2.5-pro", "gemini-2.5-flash"},
+	})
+	req := auth.ProxyAuthFromRequest(
+		httptest.NewRequest("GET", "/v1beta/models", nil),
+		&auth.ProxyAuthContext{Token: "test", Source: "global", Policy: auth.EmptyDownstreamRoutingPolicy},
+	)
+	rec := httptest.NewRecorder()
+	HandleGeminiModelsList(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	m := unmarshalResponse(t, rec)
+	models, _ := m["models"].([]any)
+	if len(models) != 2 {
+		t.Fatalf("expected 2 gemini models after filter/dedupe/sort, got %d: %v", len(models), models)
+	}
+	// normalizeModelCatalog sorts: flash before pro
+	first := models[0].(map[string]any)
+	second := models[1].(map[string]any)
+	if first["name"] != "models/gemini-2.5-flash" {
+		t.Errorf("first name = %v, want models/gemini-2.5-flash", first["name"])
+	}
+	if second["name"] != "models/gemini-2.5-pro" {
+		t.Errorf("second name = %v, want models/gemini-2.5-pro", second["name"])
+	}
+	if first["displayName"] != "Gemini 2.5 Flash" {
+		t.Errorf("displayName = %v, want Gemini 2.5 Flash", first["displayName"])
+	}
+	methods, _ := first["supportedGenerationMethods"].([]any)
+	if len(methods) != 3 {
+		t.Errorf("supportedGenerationMethods = %v, want 3 entries", methods)
+	}
+}
+
+func TestHandleGeminiModelsList_EmptyCatalog(t *testing.T) {
+	// Production safety: no router + stub disabled → empty models array.
+	t.Setenv("METAPI_ENABLE_PROXY_STUB", "0")
+	SetUpstreamConfig(nil)
+	req := auth.ProxyAuthFromRequest(
+		httptest.NewRequest("GET", "/v1beta/models", nil),
+		&auth.ProxyAuthContext{Token: "test", Source: "global", Policy: auth.EmptyDownstreamRoutingPolicy},
+	)
+	rec := httptest.NewRecorder()
+	HandleGeminiModelsList(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	m := unmarshalResponse(t, rec)
+	models, ok := m["models"].([]any)
+	if !ok {
+		t.Fatalf("models field missing or wrong type: %T", m["models"])
+	}
+	if len(models) != 0 {
+		t.Fatalf("expected empty models list, got %v", models)
+	}
+}
+
+func TestHandleGeminiModelsList_RouterErrorEmpty(t *testing.T) {
+	withModelsRouter(t, &modelsTestRouter{err: errors.New("db down")})
+	req := auth.ProxyAuthFromRequest(
+		httptest.NewRequest("GET", "/v1beta/models", nil),
+		&auth.ProxyAuthContext{Token: "test", Source: "global", Policy: auth.EmptyDownstreamRoutingPolicy},
+	)
+	rec := httptest.NewRecorder()
+	HandleGeminiModelsList(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	m := unmarshalResponse(t, rec)
+	models, _ := m["models"].([]any)
+	if len(models) != 0 {
+		t.Fatalf("router listing error should yield empty models, got %v", models)
+	}
+}
+
+func TestHandleGeminiModelsList_AllOwnedWhenNoGeminiNames(t *testing.T) {
+	// AC: prefer gemini-ish OR map all owned when none match.
+	withModelsRouter(t, &modelsTestRouter{
+		models: []string{"gpt-4o", "claude-sonnet-4-20250514"},
+	})
+	req := auth.ProxyAuthFromRequest(
+		httptest.NewRequest("GET", "/v1beta/models", nil),
+		&auth.ProxyAuthContext{Token: "test", Source: "global", Policy: auth.EmptyDownstreamRoutingPolicy},
+	)
+	rec := httptest.NewRecorder()
+	HandleGeminiModelsList(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	m := unmarshalResponse(t, rec)
+	models, _ := m["models"].([]any)
+	if len(models) != 2 {
+		t.Fatalf("expected all owned models mapped when no gemini names, got %d", len(models))
 	}
 	first := models[0].(map[string]any)
-	if _, ok := first["name"]; !ok {
-		t.Error("missing name field")
-	}
-	if _, ok := first["supportedGenerationMethods"]; !ok {
-		t.Error("missing supportedGenerationMethods")
+	if first["name"] != "models/claude-sonnet-4-20250514" && first["name"] != "models/gpt-4o" {
+		t.Errorf("unexpected mapped name %v", first["name"])
 	}
 }
 
@@ -109,6 +230,37 @@ func TestHandleGeminiModelsList_Unauthorized(t *testing.T) {
 
 	if rec.Code != 401 {
 		t.Errorf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestBuildGeminiModelsResponse_Shape(t *testing.T) {
+	resp := buildGeminiModelsResponse([]string{"gemini-2.5-pro", "models/gemini-2.5-flash", "  "})
+	models, _ := resp["models"].([]map[string]any)
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models (blank dropped), got %d", len(models))
+	}
+	if models[0]["name"] != "models/gemini-2.5-pro" {
+		t.Errorf("name = %v", models[0]["name"])
+	}
+	if models[0]["displayName"] != "Gemini 2.5 Pro" {
+		t.Errorf("displayName = %v", models[0]["displayName"])
+	}
+	if models[1]["name"] != "models/gemini-2.5-flash" {
+		t.Errorf("name = %v", models[1]["name"])
+	}
+}
+
+func TestSelectGeminiListModels(t *testing.T) {
+	mixed := selectGeminiListModels([]string{"gpt-4o", "gemini-2.5-pro", "claude-x"})
+	if len(mixed) != 1 || mixed[0] != "gemini-2.5-pro" {
+		t.Fatalf("mixed filter = %v", mixed)
+	}
+	all := selectGeminiListModels([]string{"gpt-4o", "claude-x"})
+	if len(all) != 2 {
+		t.Fatalf("no-gemini should return all owned, got %v", all)
+	}
+	if len(selectGeminiListModels(nil)) != 0 {
+		t.Fatal("nil input should yield empty")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace hard-coded Gemini models list stub with MetAPI-owned catalog via `getAvailableModels` / `resolveOwnedModelCatalog` / `AvailableModelsSource`
- Map owned IDs to Gemini list shape (`name: models/<id>`, `displayName`, `supportedGenerationMethods`)
- Prefer gemini-ish names when catalog is mixed; return all owned mapped when none match; empty when catalog empty
- Unauthorized remains 401; residual last-resort stub documented

Closes #215

## Test plan
- [x] `go test ./handler/proxy -count=1 -run Gemini`
- [ ] Confirm dynamic path `/gemini/{version}/models` still delegates to list handler