### PR TITLE
feat(sites): validate initializationPresetId against registry

### DIFF
--- a/docs/analysis/site-init-presets.md
+++ b/docs/analysis/site-init-presets.md
@@ -1,0 +1,101 @@
+# Site initialization presets (#214)
+
+**Date**: 2026-07-17  
+**Issue**: [#214](https://github.com/TokenDanceLab/metapi-go/issues/214)  
+**Spec**: `docs/specs/p3-sites-accounts.md` — `SiteCreatePayload.initializationPresetId`, `POST /api/sites/detect`
+
+## Problem
+
+Frontend site creation can send `initializationPresetId` (from
+`web/shared/siteInitializationPresets.js`), but Go `createSite` ignored the
+field (`TODO(P4)`). Mismatched / unknown presets were accepted silently.
+`detectSite` also never returned `initializationPresetId`.
+
+## Solution
+
+Port the 13-preset registry to Go and validate on create:
+
+| API | Behavior |
+|-----|----------|
+| Registry | `service.List/Get/DetectSiteInitializationPreset` |
+| `POST /api/sites` | If `initializationPresetId` set → must exist, platform match, and URL match when host/path rules exist; else 400. Response includes `initializationPresetId` when known. |
+| `POST /api/sites/detect` | When URL matches a preset, return protocol-family `platform` (`openai`/`claude`) + `initializationPresetId`. |
+
+## Registry parity
+
+Source of truth for product labels/models remains the JS file; Go is a port for
+server-side validation/detection.
+
+| id | platform | defaultUrl host/path match |
+|----|----------|----------------------------|
+| codingplan-openai | openai | coding.dashscope.aliyuncs.com `/v1` |
+| codingplan-claude | claude | coding.dashscope.aliyuncs.com `/apps/anthropic` |
+| zhipu-coding-plan-openai | openai | open.bigmodel.cn `/api/coding/paas/v4` |
+| zhipu-coding-plan-claude | claude | **manual only** (no URL auto-match) |
+| deepseek-openai | openai | api.deepseek.com `/`, `/v1` |
+| deepseek-claude | claude | api.deepseek.com `/anthropic` |
+| moonshot-openai | openai | api.moonshot.cn `/`, `/v1` |
+| moonshot-claude | claude | api.moonshot.cn `/anthropic` |
+| minimax-openai | openai | api.minimaxi.com `/`, `/v1` |
+| minimax-claude | claude | api.minimaxi.com `/anthropic` |
+| modelscope-openai | openai | api-inference.modelscope.cn `/v1` |
+| modelscope-claude | claude | api-inference.modelscope.cn `/` |
+| doubao-coding-openai | openai | ark.cn-beijing.volces.com `/api/coding/v3` |
+
+Detection order (JS parity):
+
+1. First preset whose host+paths match (optional platform filter).
+2. If platform is set, fall back to `analyzePrimarySiteUrl` equality against
+   each preset `defaultUrl` (covers manual-only zhipu Claude when platform is
+   already `claude`).
+
+## createSite validation
+
+```text
+empty id                → allowed (optional)
+unknown id              → 400 Unknown initializationPresetId
+platform mismatch       → 400 does not match platform
+has match rules + bad URL → 400 does not match site URL
+manual-only + platform OK → allowed without URL check
+```
+
+When the client omits the id but the URL is a known preset entry, create
+auto-attaches the detected id on the response (not persisted as a DB column;
+sites still store protocol/vendor `platform` only).
+
+## DetectSite interaction
+
+`service.DetectSite` now prefers preset host/path matches **before** vendor
+hostname heuristics. That means:
+
+- `https://api.deepseek.com/v1` → platform `openai` + `deepseek-openai`
+  (not vendor tag `deepseek`)
+- `https://platform.deepseek.com` → still vendor heuristic `deepseek`
+- non-preset hosts keep previous heuristic platforms
+
+This matches the frontend create flow, which selects presets with protocol
+families `openai` / `claude`.
+
+## Files
+
+- `service/site_initialization_presets.go` (+ tests)
+- `service/site_detect.go`
+- `handler/admin/sites.go` (+ tests)
+- `docs/analysis/site-init-presets.md`
+
+## Residuals / honest limits
+
+1. Preset metadata (recommended models, docs) is not persisted on the `sites`
+   row; only echoed on create/detect responses.
+2. Vendor heuristics (`deepseek`, `moonshot`, `zhipu`, …) remain for non-preset
+   URLs; they are not rewritten to openai/claude unless a preset matches.
+3. JS and Go registries can drift if one side is updated alone — treat the JS
+   file as product UX SSOT and re-port when presets change.
+4. `updateSite` does not accept `initializationPresetId` (create-only, same as
+   payload schema).
+
+## Tests
+
+```bash
+go test ./service ./handler/admin -count=1 -run 'Preset|Detect|Site'
+```

--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -143,10 +143,23 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate initializationPresetId against detected platform
-	// TODO(P4): cross-reference with preset registry for full validation
-	if body.InitializationPresetID != nil && *body.InitializationPresetID != "" {
-		_ = body.InitializationPresetID // reserved for P4 preset validation
+	// Validate initializationPresetId against registry (platform + URL match rules).
+	var initializationPresetID string
+	if body.InitializationPresetID != nil {
+		initializationPresetID = strings.TrimSpace(*body.InitializationPresetID)
+	}
+	if initializationPresetID != "" {
+		if err := service.ValidateSiteInitializationPreset(initializationPresetID, platform, body.URL); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	} else {
+		// Auto-detect preset when client omitted it but URL is a known vendor entry.
+		if preset := service.DetectSiteInitializationPreset(body.URL, platform); preset != nil {
+			initializationPresetID = preset.ID
+		} else if preset := service.DetectSiteInitializationPreset(canonicalURL, platform); preset != nil {
+			initializationPresetID = preset.ID
+		}
 	}
 
 	// Check for duplicate (platform, url)
@@ -228,6 +241,9 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 		slog.Error("LoadSiteWithEndpoints returned nil after create", "site_id", createdID)
 		writeError(w, http.StatusInternalServerError, "Create site failed")
 		return
+	}
+	if initializationPresetID != "" {
+		result["initializationPresetId"] = initializationPresetID
 	}
 	routing.InvalidateCache()
 	writeJSON(w, http.StatusOK, result)

--- a/handler/admin/sites_test.go
+++ b/handler/admin/sites_test.go
@@ -872,6 +872,118 @@ func TestSites_BatchDisable_WithStatusSideEffects(t *testing.T) {
 	}
 }
 
+// ---- Initialization preset validation / detect enrichment ----
+
+func TestSites_Create_ValidInitializationPreset(t *testing.T) {
+	_, r := setupSitesTest(t)
+	resp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":                   "DeepSeek Official",
+		"url":                    "https://api.deepseek.com/v1",
+		"platform":               "openai",
+		"initializationPresetId": "deepseek-openai",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &created); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if created["platform"] != "openai" {
+		t.Fatalf("platform=%v", created["platform"])
+	}
+	if created["initializationPresetId"] != "deepseek-openai" {
+		t.Fatalf("initializationPresetId=%v", created["initializationPresetId"])
+	}
+}
+
+func TestSites_Create_UnknownInitializationPreset(t *testing.T) {
+	_, r := setupSitesTest(t)
+	resp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":                   "Bad preset",
+		"url":                    "https://api.openai.com",
+		"platform":               "openai",
+		"initializationPresetId": "not-a-real-preset",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "Unknown initializationPresetId") {
+		t.Fatalf("unexpected body: %s", resp.Body.String())
+	}
+}
+
+func TestSites_Create_MismatchedInitializationPresetPlatform(t *testing.T) {
+	_, r := setupSitesTest(t)
+	resp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":                   "Mismatch platform",
+		"url":                    "https://api.deepseek.com/v1",
+		"platform":               "claude",
+		"initializationPresetId": "deepseek-openai",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "does not match platform") {
+		t.Fatalf("unexpected body: %s", resp.Body.String())
+	}
+}
+
+func TestSites_Create_MismatchedInitializationPresetURL(t *testing.T) {
+	_, r := setupSitesTest(t)
+	resp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":                   "Mismatch URL",
+		"url":                    "https://api.openai.com",
+		"platform":               "openai",
+		"initializationPresetId": "deepseek-openai",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "does not match site URL") {
+		t.Fatalf("unexpected body: %s", resp.Body.String())
+	}
+}
+
+func TestSites_Create_AutoDetectsInitializationPreset(t *testing.T) {
+	_, r := setupSitesTest(t)
+	resp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name": "CodingPlan auto",
+		"url":  "https://coding.dashscope.aliyuncs.com/v1",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	var created map[string]any
+	json.Unmarshal(resp.Body.Bytes(), &created)
+	if created["platform"] != "openai" {
+		t.Fatalf("platform=%v want openai", created["platform"])
+	}
+	if created["initializationPresetId"] != "codingplan-openai" {
+		t.Fatalf("initializationPresetId=%v", created["initializationPresetId"])
+	}
+}
+
+func TestSites_Detect_ReturnsInitializationPresetId(t *testing.T) {
+	_, r := setupSitesTest(t)
+	resp := doPostJSON(t, r, "/api/sites/detect", map[string]any{
+		"url": "https://api.moonshot.cn/anthropic",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result["platform"] != "claude" {
+		t.Fatalf("platform=%v want claude", result["platform"])
+	}
+	if result["initializationPresetId"] != "moonshot-claude" {
+		t.Fatalf("initializationPresetId=%v", result["initializationPresetId"])
+	}
+}
+
 // ---- HTTP Helpers ----
 
 func doGet(t *testing.T, r chi.Router, path string) *httptest.ResponseRecorder {

--- a/service/site_detect.go
+++ b/service/site_detect.go
@@ -13,8 +13,9 @@ type DetectResult struct {
 }
 
 // DetectSite attempts to detect the platform for a given URL.
-// Stub implementation: P4 platform adapters will provide real detection.
-// Currently returns nil (unknown platform) for all URLs.
+// When a site initialization preset matches the URL, the result uses the
+// preset protocol family (openai/claude) and includes initializationPresetId.
+// Otherwise falls back to hostname heuristics for vendor/platform tags.
 func DetectSite(rawURL string) *DetectResult {
 	trimmed := strings.TrimSpace(rawURL)
 	if trimmed == "" {
@@ -23,6 +24,13 @@ func DetectSite(rawURL string) *DetectResult {
 
 	parsed, err := url.Parse(trimmed)
 	if err != nil {
+		// Allow scheme-less inputs such as "api.deepseek.com/v1".
+		if withScheme, schemeErr := url.Parse("https://" + trimmed); schemeErr == nil {
+			parsed = withScheme
+			err = nil
+		}
+	}
+	if err != nil || parsed == nil || parsed.Host == "" {
 		return nil
 	}
 
@@ -30,70 +38,98 @@ func DetectSite(rawURL string) *DetectResult {
 	canonicalURL := parsed.String()
 	host := strings.ToLower(parsed.Hostname())
 
-	// Heuristic detection based on hostname patterns
-	// P4 will replace this with real adapter-based detection.
-	switch {
-	case strings.Contains(host, "api.openai.com") || strings.Contains(host, "openai.com"):
-		return &DetectResult{URL: canonicalURL, Platform: "openai"}
-	case strings.Contains(host, "api.anthropic.com") || strings.Contains(host, "anthropic.com"):
-		return &DetectResult{URL: canonicalURL, Platform: "anthropic"}
-	case strings.Contains(host, "generativelanguage.googleapis.com") || strings.Contains(host, "ai.google.dev"):
-		return &DetectResult{URL: canonicalURL, Platform: "gemini"}
-	case strings.Contains(host, "api.deepseek.com") || strings.Contains(host, "deepseek.com"):
-		return &DetectResult{URL: canonicalURL, Platform: "deepseek"}
-	case strings.Contains(host, "api.moonshot.cn") || strings.Contains(host, "moonshot.cn"):
-		return &DetectResult{URL: canonicalURL, Platform: "moonshot"}
-	case strings.Contains(host, "dashscope.aliyuncs.com") || strings.Contains(host, "dashscope"):
-		return &DetectResult{URL: canonicalURL, Platform: "dashscope"}
-	case strings.Contains(host, "api.baichuan-ai.com"):
-		return &DetectResult{URL: canonicalURL, Platform: "baichuan"}
-	case strings.Contains(host, "api.zhipuai.cn") || strings.Contains(host, "bigmodel.cn"):
-		return &DetectResult{URL: canonicalURL, Platform: "zhipu"}
-	case strings.Contains(host, "api.minimax.chat") || strings.Contains(host, "minimax"):
-		return &DetectResult{URL: canonicalURL, Platform: "minimax"}
-	case strings.Contains(host, "api.stepfun.com") || strings.Contains(host, "stepfun"):
-		return &DetectResult{URL: canonicalURL, Platform: "stepfun"}
-	case strings.Contains(host, "ark.cn-beijing.volces.com") || strings.Contains(host, "volcengine.com"):
-		return &DetectResult{URL: canonicalURL, Platform: "bytedance"}
-	case strings.Contains(host, "api.siliconflow.cn") || strings.Contains(host, "siliconflow"):
-		return &DetectResult{URL: canonicalURL, Platform: "siliconflow"}
-	case strings.Contains(host, "api-inference.modelscope.cn"):
-		return &DetectResult{URL: canonicalURL, Platform: "modelscope"}
-	case strings.Contains(host, "api.mistral.ai"):
-		return &DetectResult{URL: canonicalURL, Platform: "mistral"}
-	case strings.Contains(host, "api.cohere.ai") || strings.Contains(host, "cohere.com"):
-		return &DetectResult{URL: canonicalURL, Platform: "cohere"}
-	case strings.Contains(host, "api.together.xyz") || strings.Contains(host, "together.xyz"):
-		return &DetectResult{URL: canonicalURL, Platform: "together"}
-	case strings.Contains(host, "api.fireworks.ai"):
-		return &DetectResult{URL: canonicalURL, Platform: "fireworks"}
-	case strings.Contains(host, "api.groq.com"):
-		return &DetectResult{URL: canonicalURL, Platform: "groq"}
-	case strings.Contains(host, "api.perplexity.ai"):
-		return &DetectResult{URL: canonicalURL, Platform: "perplexity"}
-	case strings.Contains(host, "api.x.ai") || strings.Contains(host, "x.ai"):
-		return &DetectResult{URL: canonicalURL, Platform: "xai"}
-	case strings.Contains(host, "api-inference.huggingface.co") || strings.Contains(host, "hf.space"):
-		return &DetectResult{URL: canonicalURL, Platform: "huggingface"}
-	case strings.Contains(host, "azure.com") || strings.Contains(host, "openai.azure.com"):
-		return &DetectResult{URL: canonicalURL, Platform: "azure"}
-	case strings.Contains(host, ".github.com") && (strings.Contains(parsed.Path, "openai") || strings.Contains(parsed.Path, "copilot")):
-		return &DetectResult{URL: canonicalURL, Platform: "github-copilot"}
-	case strings.Contains(host, "claude.ai"):
-		return &DetectResult{URL: canonicalURL, Platform: "claude"}
-	case strings.Contains(host, "aistudio.google.com") || strings.Contains(host, "makersuite.google.com"):
-		return &DetectResult{URL: canonicalURL, Platform: "gemini"}
-	default:
-		// Check for common NewAPI/OneAPI patterns
-		if strings.Contains(host, "anyrouter") || strings.Contains(parsed.Path, "anyrouter") {
-			return &DetectResult{URL: canonicalURL, Platform: "anyrouter"}
-		}
-		if strings.Contains(host, "oneapi") || strings.Contains(host, "new-api") || strings.Contains(host, "newapi") {
-			return &DetectResult{URL: canonicalURL, Platform: "new-api"}
+	// Prefer initialization presets (protocol family + preset id) when the
+	// host/path rules match. This keeps createSite/detectSite aligned with the
+	// frontend siteInitializationPresets registry.
+	if preset := DetectSiteInitializationPreset(trimmed, ""); preset != nil {
+		id := preset.ID
+		return &DetectResult{
+			URL:                    canonicalURL,
+			Platform:               preset.Platform,
+			InitializationPresetID: &id,
 		}
 	}
 
-	return nil
+	// Heuristic detection based on hostname patterns
+	// P4 will replace this with real adapter-based detection.
+	var platform string
+	switch {
+	case strings.Contains(host, "api.openai.com") || strings.Contains(host, "openai.com"):
+		platform = "openai"
+	case strings.Contains(host, "api.anthropic.com") || strings.Contains(host, "anthropic.com"):
+		platform = "anthropic"
+	case strings.Contains(host, "generativelanguage.googleapis.com") || strings.Contains(host, "ai.google.dev"):
+		platform = "gemini"
+	case strings.Contains(host, "api.deepseek.com") || strings.Contains(host, "deepseek.com"):
+		platform = "deepseek"
+	case strings.Contains(host, "api.moonshot.cn") || strings.Contains(host, "moonshot.cn"):
+		platform = "moonshot"
+	case strings.Contains(host, "dashscope.aliyuncs.com") || strings.Contains(host, "dashscope"):
+		platform = "dashscope"
+	case strings.Contains(host, "api.baichuan-ai.com"):
+		platform = "baichuan"
+	case strings.Contains(host, "api.zhipuai.cn") || strings.Contains(host, "bigmodel.cn"):
+		platform = "zhipu"
+	case strings.Contains(host, "api.minimax.chat") || strings.Contains(host, "minimax"):
+		platform = "minimax"
+	case strings.Contains(host, "api.stepfun.com") || strings.Contains(host, "stepfun"):
+		platform = "stepfun"
+	case strings.Contains(host, "ark.cn-beijing.volces.com") || strings.Contains(host, "volcengine.com"):
+		platform = "bytedance"
+	case strings.Contains(host, "api.siliconflow.cn") || strings.Contains(host, "siliconflow"):
+		platform = "siliconflow"
+	case strings.Contains(host, "api-inference.modelscope.cn"):
+		platform = "modelscope"
+	case strings.Contains(host, "api.mistral.ai"):
+		platform = "mistral"
+	case strings.Contains(host, "api.cohere.ai") || strings.Contains(host, "cohere.com"):
+		platform = "cohere"
+	case strings.Contains(host, "api.together.xyz") || strings.Contains(host, "together.xyz"):
+		platform = "together"
+	case strings.Contains(host, "api.fireworks.ai"):
+		platform = "fireworks"
+	case strings.Contains(host, "api.groq.com"):
+		platform = "groq"
+	case strings.Contains(host, "api.perplexity.ai"):
+		platform = "perplexity"
+	case strings.Contains(host, "api.x.ai") || strings.Contains(host, "x.ai"):
+		platform = "xai"
+	case strings.Contains(host, "api-inference.huggingface.co") || strings.Contains(host, "hf.space"):
+		platform = "huggingface"
+	case strings.Contains(host, "azure.com") || strings.Contains(host, "openai.azure.com"):
+		platform = "azure"
+	case strings.Contains(host, ".github.com") && (strings.Contains(parsed.Path, "openai") || strings.Contains(parsed.Path, "copilot")):
+		platform = "github-copilot"
+	case strings.Contains(host, "claude.ai"):
+		platform = "claude"
+	case strings.Contains(host, "aistudio.google.com") || strings.Contains(host, "makersuite.google.com"):
+		platform = "gemini"
+	default:
+		// Check for common NewAPI/OneAPI patterns
+		if strings.Contains(host, "anyrouter") || strings.Contains(parsed.Path, "anyrouter") {
+			platform = "anyrouter"
+		} else if strings.Contains(host, "oneapi") || strings.Contains(host, "new-api") || strings.Contains(host, "newapi") {
+			platform = "new-api"
+		}
+	}
+
+	if platform == "" {
+		return nil
+	}
+
+	result := &DetectResult{URL: canonicalURL, Platform: platform}
+	// Optional: attach a preset when hostname heuristics already chose a vendor
+	// platform and a defaultUrl fallback matches under that protocol family.
+	// Prefer the detected protocol family when the heuristic platform itself is
+	// already openai/claude; otherwise leave preset empty (frontend can still
+	// call DetectSiteInitializationPreset client-side).
+	if platform == "openai" || platform == "claude" {
+		if preset := DetectSiteInitializationPreset(trimmed, platform); preset != nil {
+			id := preset.ID
+			result.InitializationPresetID = &id
+		}
+	}
+	return result
 }
 
 // CanonicalizeSiteURL returns a canonical URL for persistence.

--- a/service/site_initialization_presets.go
+++ b/service/site_initialization_presets.go
@@ -1,0 +1,528 @@
+package service
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// SiteInitializationPreset mirrors web/shared/siteInitializationPresets.js.
+// Platform values are protocol families (openai/claude), not vendor brand tags.
+type SiteInitializationPreset struct {
+	ID                         string
+	Label                      string
+	ProviderLabel              string
+	Description                string
+	Platform                   string
+	DefaultURL                 string
+	InitialSegment             string
+	RecommendedSkipModelFetch  bool
+	RecommendedModels          []string
+	DocsURL                    string
+	// MatchHost + MatchPaths define host/path auto-detect rules.
+	// Empty MatchHost means the preset is manual-only (matches always false).
+	MatchHost  string
+	MatchPaths []string
+}
+
+var codingPlanRecommendedModels = []string{
+	"qwen3-coder-plus",
+	"qwen3-coder-next",
+	"qwen3.5-plus",
+	"glm-5",
+}
+
+var zhipuCodingPlanRecommendedModels = []string{
+	"glm-4.7",
+	"glm-4.6",
+	"glm-4.5",
+	"glm-4.5-air",
+}
+
+var deepseekRecommendedModels = []string{
+	"deepseek-chat",
+	"deepseek-reasoner",
+}
+
+var moonshotRecommendedModels = []string{
+	"kimi-k2.5",
+	"kimi-k2",
+	"kimi-k2-thinking",
+}
+
+var minimaxRecommendedModels = []string{
+	"MiniMax-M2.7",
+	"MiniMax-M2.5",
+	"MiniMax-M2.1",
+}
+
+var modelscopeRecommendedModels = []string{
+	"Qwen/Qwen3-32B",
+	"Qwen/Qwen2.5-Coder-32B-Instruct",
+	"deepseek-ai/DeepSeek-V3.2",
+}
+
+var doubaoCodingRecommendedModels = []string{
+	"ark-code-latest",
+	"doubao-seed-2.0-code",
+	"doubao-seed-2.0-pro",
+}
+
+// siteInitializationPresets is the SSOT ported from siteInitializationPresets.js.
+// Order matters for DetectSiteInitializationPreset first-match behavior.
+var siteInitializationPresets = []SiteInitializationPreset{
+	{
+		ID:                        "codingplan-openai",
+		Label:                     "阿里云 CodingPlan / OpenAI",
+		ProviderLabel:             "阿里云 CodingPlan",
+		Description:               "适合阿里云 CodingPlan 的 OpenAI 兼容入口，建议先添加 API Key，再补入推荐模型完成初始化。",
+		Platform:                  "openai",
+		DefaultURL:                "https://coding.dashscope.aliyuncs.com/v1",
+		InitialSegment:            "apikey",
+		RecommendedSkipModelFetch: true,
+		RecommendedModels:         codingPlanRecommendedModels,
+		DocsURL:                   "https://help.aliyun.com/zh/model-studio/coding-plan-faq",
+		MatchHost:                 "coding.dashscope.aliyuncs.com",
+		MatchPaths:                []string{"/v1"},
+	},
+	{
+		ID:                        "codingplan-claude",
+		Label:                     "阿里云 CodingPlan / Claude",
+		ProviderLabel:             "阿里云 CodingPlan",
+		Description:               "适合阿里云 CodingPlan 的 Claude 兼容入口，建议先添加 API Key，再补入推荐模型完成初始化。",
+		Platform:                  "claude",
+		DefaultURL:                "https://coding.dashscope.aliyuncs.com/apps/anthropic",
+		InitialSegment:            "apikey",
+		RecommendedSkipModelFetch: true,
+		RecommendedModels:         codingPlanRecommendedModels,
+		DocsURL:                   "https://help.aliyun.com/zh/model-studio/coding-plan-faq",
+		MatchHost:                 "coding.dashscope.aliyuncs.com",
+		MatchPaths:                []string{"/apps/anthropic"},
+	},
+	{
+		ID:                        "zhipu-coding-plan-openai",
+		Label:                     "智谱 Coding Plan / OpenAI",
+		ProviderLabel:             "智谱 Coding Plan",
+		Description:               "适合智谱 Coding Plan 的 OpenAI 兼容入口，建议先添加 API Key，再补入常用 GLM 编程模型。",
+		Platform:                  "openai",
+		DefaultURL:                "https://open.bigmodel.cn/api/coding/paas/v4",
+		InitialSegment:            "apikey",
+		RecommendedSkipModelFetch: true,
+		RecommendedModels:         zhipuCodingPlanRecommendedModels,
+		DocsURL:                   "https://docs.bigmodel.cn/cn/coding-plan/faq",
+		MatchHost:                 "open.bigmodel.cn",
+		MatchPaths:                []string{"/api/coding/paas/v4"},
+	},
+	{
+		ID:                        "zhipu-coding-plan-claude",
+		Label:                     "智谱 Coding Plan / Claude",
+		ProviderLabel:             "智谱 Coding Plan",
+		Description:               "适合智谱 Coding Plan 的 Claude 兼容入口。由于该地址也可作为通用兼容入口，这里默认只提供手动预设，不按 URL 强制自动识别。",
+		Platform:                  "claude",
+		DefaultURL:                "https://open.bigmodel.cn/api/anthropic",
+		InitialSegment:            "apikey",
+		RecommendedSkipModelFetch: true,
+		RecommendedModels:         zhipuCodingPlanRecommendedModels,
+		DocsURL:                   "https://docs.bigmodel.cn/cn/coding-plan/faq",
+		// Manual-only: matches() always returns false in the JS registry.
+	},
+	{
+		ID:                        "deepseek-openai",
+		Label:                     "DeepSeek / OpenAI",
+		ProviderLabel:             "DeepSeek",
+		Description:               "适合 DeepSeek 官方 OpenAI 兼容入口，建议直接添加 API Key，并优先补入官方常用编程模型。",
+		Platform:                  "openai",
+		DefaultURL:                "https://api.deepseek.com/v1",
+		InitialSegment:            "apikey",
+		RecommendedSkipModelFetch: true,
+		RecommendedModels:         deepseekRecommendedModels,
+		DocsURL:                   "https://api-docs.deepseek.com/",
+		MatchHost:                 "api.deepseek.com",
+		MatchPaths:                []string{"/", "/v1"},
+	},
+	{
+		ID:                        "deepseek-claude",
+		Label:                     "DeepSeek / Claude",
+		ProviderLabel:             "DeepSeek",
+		Description:               "适合 DeepSeek 官方 Anthropic 兼容入口，便于 Claude Code 一类工具直接接入。",
+		Platform:                  "claude",
+		DefaultURL:                "https://api.deepseek.com/anthropic",
+		InitialSegment:            "apikey",
+		RecommendedSkipModelFetch: true,
+		RecommendedModels:         deepseekRecommendedModels,
+		DocsURL:                   "https://api-docs.deepseek.com/guides/anthropic_api",
+		MatchHost:                 "api.deepseek.com",
+		MatchPaths:                []string{"/anthropic"},
+	},
+	{
+		ID:                        "moonshot-openai",
+		Label:                     "Moonshot(Kimi) / OpenAI",
+		ProviderLabel:             "Moonshot / Kimi",
+		Description:               "适合 Moonshot 官方 OpenAI 兼容入口，推荐优先使用 Kimi 系列编程与 Agent 模型。",
+		Platform:                  "openai",
+		DefaultURL:                "https://api.moonshot.cn/v1",
+		InitialSegment:            "apikey",
+		RecommendedSkipModelFetch: true,
+		RecommendedModels:         moonshotRecommendedModels,
+		DocsURL:                   "https://platform.moonshot.cn/",
+		MatchHost:                 "api.moonshot.cn",
+		MatchPaths:                []string{"/", "/v1"},
+	},
+	{
+		ID:                        "moonshot-claude",
+		Label:                     "Moonshot(Kimi) / Claude",
+		ProviderLabel:             "Moonshot / Kimi",
+		Description:               "适合 Moonshot 官方 Anthropic 兼容入口，便于 Claude Code 与同类工具接入 Kimi。",
+		Platform:                  "claude",
+		DefaultURL:                "https://api.moonshot.cn/anthropic",
+		InitialSegment:            "apikey",
+		RecommendedSkipModelFetch: true,
+		RecommendedModels:         moonshotRecommendedModels,
+		DocsURL:                   "https://platform.moonshot.cn/blog/posts/kimi-k2-0905",
+		MatchHost:                 "api.moonshot.cn",
+		MatchPaths:                []string{"/anthropic"},
+	},
+	{
+		ID:                        "minimax-openai",
+		Label:                     "MiniMax / OpenAI",
+		ProviderLabel:             "MiniMax",
+		Description:               "适合 MiniMax 官方 OpenAI 兼容入口，建议直接添加 API Key 后补入常用 M2 编程模型。",
+		Platform:                  "openai",
+		DefaultURL:                "https://api.minimaxi.com/v1",
+		InitialSegment:            "apikey",
+		RecommendedSkipModelFetch: true,
+		RecommendedModels:         minimaxRecommendedModels,
+		DocsURL:                   "https://platform.minimaxi.com/docs/api-reference/api-overview",
+		MatchHost:                 "api.minimaxi.com",
+		MatchPaths:                []string{"/", "/v1"},
+	},
+	{
+		ID:                        "minimax-claude",
+		Label:                     "MiniMax / Claude",
+		ProviderLabel:             "MiniMax",
+		Description:               "适合 MiniMax 官方 Anthropic 兼容入口，适配 Claude Code 等编程工具场景。",
+		Platform:                  "claude",
+		DefaultURL:                "https://api.minimaxi.com/anthropic",
+		InitialSegment:            "apikey",
+		RecommendedSkipModelFetch: true,
+		RecommendedModels:         minimaxRecommendedModels,
+		DocsURL:                   "https://platform.minimaxi.com/docs/api-reference/text-anthropic-api",
+		MatchHost:                 "api.minimaxi.com",
+		MatchPaths:                []string{"/anthropic"},
+	},
+	{
+		ID:                        "modelscope-openai",
+		Label:                     "ModelScope / OpenAI",
+		ProviderLabel:             "ModelScope",
+		Description:               "适合 ModelScope API-Inference 的 OpenAI 兼容入口，适合直接接入常用开源编程模型。",
+		Platform:                  "openai",
+		DefaultURL:                "https://api-inference.modelscope.cn/v1",
+		InitialSegment:            "apikey",
+		RecommendedSkipModelFetch: true,
+		RecommendedModels:         modelscopeRecommendedModels,
+		DocsURL:                   "https://www.modelscope.cn/docs/model-service/API-Inference/intro",
+		MatchHost:                 "api-inference.modelscope.cn",
+		MatchPaths:                []string{"/v1"},
+	},
+	{
+		ID:                        "modelscope-claude",
+		Label:                     "ModelScope / Claude",
+		ProviderLabel:             "ModelScope",
+		Description:               "适合 ModelScope API-Inference 的 Claude 兼容入口，便于接入 Claude Code 一类工具。",
+		Platform:                  "claude",
+		DefaultURL:                "https://api-inference.modelscope.cn",
+		InitialSegment:            "apikey",
+		RecommendedSkipModelFetch: true,
+		RecommendedModels:         modelscopeRecommendedModels,
+		DocsURL:                   "https://www.modelscope.cn/docs/model-service/API-Inference/intro",
+		MatchHost:                 "api-inference.modelscope.cn",
+		MatchPaths:                []string{"/"},
+	},
+	{
+		ID:                        "doubao-coding-openai",
+		Label:                     "豆包 Coding Plan / OpenAI",
+		ProviderLabel:             "豆包 Coding Plan",
+		Description:               "适合火山方舟 Coding Plan 的 OpenAI 兼容入口，推荐优先使用 ark-code 与豆包编程模型。",
+		Platform:                  "openai",
+		DefaultURL:                "https://ark.cn-beijing.volces.com/api/coding/v3",
+		InitialSegment:            "apikey",
+		RecommendedSkipModelFetch: true,
+		RecommendedModels:         doubaoCodingRecommendedModels,
+		DocsURL:                   "https://www.volcengine.com/docs/82379/2205646?lang=zh",
+		MatchHost:                 "ark.cn-beijing.volces.com",
+		MatchPaths:                []string{"/api/coding/v3"},
+	},
+}
+
+func cloneSiteInitializationPreset(preset SiteInitializationPreset) SiteInitializationPreset {
+	out := preset
+	if len(preset.RecommendedModels) > 0 {
+		out.RecommendedModels = append([]string(nil), preset.RecommendedModels...)
+	}
+	if len(preset.MatchPaths) > 0 {
+		out.MatchPaths = append([]string(nil), preset.MatchPaths...)
+	}
+	return out
+}
+
+// ListSiteInitializationPresets returns a defensive copy of all known presets.
+func ListSiteInitializationPresets() []SiteInitializationPreset {
+	out := make([]SiteInitializationPreset, 0, len(siteInitializationPresets))
+	for _, preset := range siteInitializationPresets {
+		out = append(out, cloneSiteInitializationPreset(preset))
+	}
+	return out
+}
+
+// GetSiteInitializationPreset returns a preset by id, or nil when unknown.
+func GetSiteInitializationPreset(id string) *SiteInitializationPreset {
+	normalizedID := strings.TrimSpace(id)
+	if normalizedID == "" {
+		return nil
+	}
+	for _, preset := range siteInitializationPresets {
+		if preset.ID == normalizedID {
+			cloned := cloneSiteInitializationPreset(preset)
+			return &cloned
+		}
+	}
+	return nil
+}
+
+// DetectSiteInitializationPreset mirrors the JS detectSiteInitializationPreset(url, platform).
+// When platform is non-empty, only presets for that protocol family are considered.
+func DetectSiteInitializationPreset(rawURL, platform string) *SiteInitializationPreset {
+	normalizedPlatform := strings.TrimSpace(strings.ToLower(platform))
+
+	for _, preset := range siteInitializationPresets {
+		if normalizedPlatform != "" && preset.Platform != normalizedPlatform {
+			continue
+		}
+		if preset.MatchesURL(rawURL) {
+			cloned := cloneSiteInitializationPreset(preset)
+			return &cloned
+		}
+	}
+
+	if normalizedPlatform == "" {
+		return nil
+	}
+
+	analyzed := AnalyzePrimarySiteURL(rawURL)
+	if analyzed.PersistedURL == "" {
+		return nil
+	}
+	for _, preset := range siteInitializationPresets {
+		if preset.Platform != normalizedPlatform {
+			continue
+		}
+		if strings.TrimSpace(preset.DefaultURL) == "" {
+			continue
+		}
+		presetAnalyzed := AnalyzePrimarySiteURL(preset.DefaultURL)
+		if presetAnalyzed.PersistedURL == "" {
+			continue
+		}
+		if presetAnalyzed.PersistedURL == analyzed.PersistedURL {
+			cloned := cloneSiteInitializationPreset(preset)
+			return &cloned
+		}
+	}
+	return nil
+}
+
+// HasURLMatchRules reports whether the preset defines host/path auto-detect rules.
+func (p SiteInitializationPreset) HasURLMatchRules() bool {
+	return strings.TrimSpace(p.MatchHost) != "" && len(p.MatchPaths) > 0
+}
+
+// MatchesURL implements the JS preset.matches(url) host+paths check.
+func (p SiteInitializationPreset) MatchesURL(rawURL string) bool {
+	if !p.HasURLMatchRules() {
+		return false
+	}
+	parsed := parseURLCandidate(rawURL)
+	if parsed == nil {
+		return false
+	}
+	if !strings.EqualFold(parsed.Hostname(), p.MatchHost) {
+		return false
+	}
+	path := normalizePresetPathname(parsed.Path)
+	for _, allowed := range p.MatchPaths {
+		if path == normalizePresetPathname(allowed) {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateSiteInitializationPreset checks createSite initializationPresetId.
+// Empty id is allowed (optional field). When set:
+//  1. preset must exist
+//  2. preset.platform must equal the resolved site platform
+//  3. when the preset has host/path match rules, the URL must match those rules
+//     (or the defaultUrl persisted-url fallback when platform-filtered).
+func ValidateSiteInitializationPreset(presetID, platform, rawURL string) error {
+	normalizedID := strings.TrimSpace(presetID)
+	if normalizedID == "" {
+		return nil
+	}
+	preset := GetSiteInitializationPreset(normalizedID)
+	if preset == nil {
+		return fmt.Errorf("Unknown initializationPresetId %q.", normalizedID)
+	}
+
+	normalizedPlatform := strings.TrimSpace(strings.ToLower(platform))
+	if normalizedPlatform == "" || preset.Platform != normalizedPlatform {
+		return fmt.Errorf("initializationPresetId %q does not match platform %q.", normalizedID, normalizedPlatform)
+	}
+
+	if !preset.HasURLMatchRules() {
+		return nil
+	}
+
+	// Direct host/path match.
+	if preset.MatchesURL(rawURL) {
+		return nil
+	}
+
+	// Fallback: same persisted primary URL as the preset default (platform-filtered).
+	analyzed := AnalyzePrimarySiteURL(rawURL)
+	presetAnalyzed := AnalyzePrimarySiteURL(preset.DefaultURL)
+	if analyzed.PersistedURL != "" && presetAnalyzed.PersistedURL != "" && analyzed.PersistedURL == presetAnalyzed.PersistedURL {
+		return nil
+	}
+
+	return fmt.Errorf("initializationPresetId %q does not match site URL.", normalizedID)
+}
+
+func parseURLCandidate(rawURL string) *url.URL {
+	trimmed := strings.TrimSpace(rawURL)
+	if trimmed == "" {
+		return nil
+	}
+	candidates := []string{trimmed}
+	if !strings.Contains(trimmed, "://") {
+		candidates = []string{"https://" + trimmed}
+	}
+	for _, candidate := range candidates {
+		parsed, err := url.Parse(candidate)
+		if err != nil || parsed.Host == "" {
+			continue
+		}
+		scheme := strings.ToLower(parsed.Scheme)
+		if scheme != "http" && scheme != "https" {
+			continue
+		}
+		return parsed
+	}
+	return nil
+}
+
+func normalizePresetPathname(pathname string) string {
+	normalized := strings.TrimSpace(pathname)
+	if normalized == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(normalized, "/") {
+		normalized = "/" + normalized
+	}
+	for len(normalized) > 1 && strings.HasSuffix(normalized, "/") {
+		normalized = strings.TrimSuffix(normalized, "/")
+	}
+	return normalized
+}
+
+// PrimarySiteURLAnalysis mirrors web/shared/sitePrimaryUrl.js analyzePrimarySiteUrl.
+type PrimarySiteURLAnalysis struct {
+	CanonicalURL string
+	PersistedURL string
+	MatchedPath  string
+	Action       string
+}
+
+var autoStripPrimarySitePaths = map[string]struct{}{
+	"/v1":                   {},
+	"/v1beta":               {},
+	"/v1/models":            {},
+	"/v1/chat/completions":  {},
+	"/v1/responses":         {},
+	"/v1/messages":          {},
+	"/v1beta/models":        {},
+}
+
+var semanticPrimarySitePaths = map[string]struct{}{
+	"/backend-api/codex":    {},
+	"/anthropic":            {},
+	"/apps/anthropic":       {},
+	"/api/anthropic":        {},
+	"/api/coding/paas/v4":   {},
+	"/v1beta/openai":        {},
+}
+
+// AnalyzePrimarySiteURL ports analyzePrimarySiteUrl for preset fallback matching.
+func AnalyzePrimarySiteURL(rawURL string) PrimarySiteURLAnalysis {
+	parsed := parseURLCandidate(rawURL)
+	if parsed == nil {
+		return PrimarySiteURLAnalysis{Action: "invalid_url"}
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	matchedPath := normalizePresetPathname(parsed.Path)
+	origin := originFromURL(parsed)
+	canonicalURL := origin
+	if matchedPath != "/" {
+		canonicalURL = origin + matchedPath
+	}
+
+	if matchedPath == "/" {
+		return PrimarySiteURLAnalysis{
+			CanonicalURL: canonicalURL,
+			PersistedURL: canonicalURL,
+			MatchedPath:  matchedPath,
+			Action:       "unchanged",
+		}
+	}
+	if _, ok := semanticPrimarySitePaths[matchedPath]; ok {
+		return PrimarySiteURLAnalysis{
+			CanonicalURL: canonicalURL,
+			PersistedURL: canonicalURL,
+			MatchedPath:  matchedPath,
+			Action:       "preserve_semantic_path",
+		}
+	}
+	if _, ok := autoStripPrimarySitePaths[matchedPath]; ok {
+		return PrimarySiteURLAnalysis{
+			CanonicalURL: canonicalURL,
+			PersistedURL: origin,
+			MatchedPath:  matchedPath,
+			Action:       "auto_strip_known_api_suffix",
+		}
+	}
+	if strings.HasPrefix(matchedPath, "/api") {
+		return PrimarySiteURLAnalysis{
+			CanonicalURL: canonicalURL,
+			PersistedURL: canonicalURL,
+			MatchedPath:  matchedPath,
+			Action:       "preserve_api_path",
+		}
+	}
+	return PrimarySiteURLAnalysis{
+		CanonicalURL: canonicalURL,
+		PersistedURL: canonicalURL,
+		MatchedPath:  matchedPath,
+		Action:       "preserve_unknown_path",
+	}
+}
+
+func originFromURL(parsed *url.URL) string {
+	if parsed == nil {
+		return ""
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme == "" {
+		scheme = "https"
+	}
+	return scheme + "://" + parsed.Host
+}

--- a/service/site_initialization_presets_test.go
+++ b/service/site_initialization_presets_test.go
@@ -1,0 +1,146 @@
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestListSiteInitializationPresets_ParityCount(t *testing.T) {
+	presets := ListSiteInitializationPresets()
+	if len(presets) != 13 {
+		t.Fatalf("expected 13 presets, got %d", len(presets))
+	}
+
+	// Defensive copy: mutating returned slice must not affect registry.
+	presets[0].ID = "mutated"
+	if GetSiteInitializationPreset("mutated") != nil {
+		t.Fatal("ListSiteInitializationPresets should return clones")
+	}
+	if GetSiteInitializationPreset("codingplan-openai") == nil {
+		t.Fatal("expected codingplan-openai still present after list mutation")
+	}
+}
+
+func TestGetSiteInitializationPreset(t *testing.T) {
+	got := GetSiteInitializationPreset("  deepseek-openai ")
+	if got == nil {
+		t.Fatal("expected preset")
+	}
+	if got.Platform != "openai" {
+		t.Fatalf("platform=%q", got.Platform)
+	}
+	if got.DefaultURL != "https://api.deepseek.com/v1" {
+		t.Fatalf("defaultUrl=%q", got.DefaultURL)
+	}
+	if GetSiteInitializationPreset("no-such-preset") != nil {
+		t.Fatal("expected nil for unknown id")
+	}
+	if GetSiteInitializationPreset("") != nil {
+		t.Fatal("expected nil for empty id")
+	}
+}
+
+func TestDetectSiteInitializationPreset_HostPath(t *testing.T) {
+	cases := []struct {
+		url      string
+		platform string
+		wantID   string
+	}{
+		{"https://coding.dashscope.aliyuncs.com/v1", "", "codingplan-openai"},
+		{"https://coding.dashscope.aliyuncs.com/apps/anthropic", "", "codingplan-claude"},
+		{"https://open.bigmodel.cn/api/coding/paas/v4", "openai", "zhipu-coding-plan-openai"},
+		{"https://api.deepseek.com/v1", "", "deepseek-openai"},
+		{"https://api.deepseek.com/anthropic", "", "deepseek-claude"},
+		{"https://api.moonshot.cn", "", "moonshot-openai"},
+		{"https://api.moonshot.cn/anthropic", "claude", "moonshot-claude"},
+		{"https://api.minimaxi.com/v1", "", "minimax-openai"},
+		{"https://api-inference.modelscope.cn/v1", "", "modelscope-openai"},
+		{"https://api-inference.modelscope.cn", "", "modelscope-claude"},
+		{"https://ark.cn-beijing.volces.com/api/coding/v3", "", "doubao-coding-openai"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.wantID+"/"+tc.url, func(t *testing.T) {
+			got := DetectSiteInitializationPreset(tc.url, tc.platform)
+			if got == nil {
+				t.Fatalf("expected preset %s", tc.wantID)
+			}
+			if got.ID != tc.wantID {
+				t.Fatalf("got %q want %q", got.ID, tc.wantID)
+			}
+		})
+	}
+}
+
+func TestDetectSiteInitializationPreset_ManualOnlyZhipuClaude(t *testing.T) {
+	// zhipu-coding-plan-claude intentionally does not auto-match by URL.
+	if got := DetectSiteInitializationPreset("https://open.bigmodel.cn/api/anthropic", ""); got != nil {
+		t.Fatalf("expected no auto-detect without platform, got %q", got.ID)
+	}
+	// Platform-filtered defaultUrl fallback should still resolve it.
+	got := DetectSiteInitializationPreset("https://open.bigmodel.cn/api/anthropic", "claude")
+	if got == nil || got.ID != "zhipu-coding-plan-claude" {
+		t.Fatalf("expected zhipu-coding-plan-claude via defaultUrl fallback, got %#v", got)
+	}
+}
+
+func TestDetectSiteInitializationPreset_PlatformFilter(t *testing.T) {
+	// Same host, claude path should not match openai filter.
+	if got := DetectSiteInitializationPreset("https://api.deepseek.com/anthropic", "openai"); got != nil {
+		t.Fatalf("expected nil for openai filter on anthropic path, got %q", got.ID)
+	}
+	got := DetectSiteInitializationPreset("https://api.deepseek.com/anthropic", "claude")
+	if got == nil || got.ID != "deepseek-claude" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestValidateSiteInitializationPreset(t *testing.T) {
+	if err := ValidateSiteInitializationPreset("", "openai", "https://api.openai.com"); err != nil {
+		t.Fatalf("empty id should be optional: %v", err)
+	}
+
+	if err := ValidateSiteInitializationPreset("nope", "openai", "https://api.deepseek.com/v1"); err == nil {
+		t.Fatal("expected unknown preset error")
+	} else if !strings.Contains(err.Error(), "Unknown initializationPresetId") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := ValidateSiteInitializationPreset("deepseek-openai", "claude", "https://api.deepseek.com/v1"); err == nil {
+		t.Fatal("expected platform mismatch")
+	} else if !strings.Contains(err.Error(), "does not match platform") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := ValidateSiteInitializationPreset("deepseek-openai", "openai", "https://api.openai.com"); err == nil {
+		t.Fatal("expected URL mismatch")
+	} else if !strings.Contains(err.Error(), "does not match site URL") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := ValidateSiteInitializationPreset("deepseek-openai", "openai", "https://api.deepseek.com/v1"); err != nil {
+		t.Fatalf("valid preset: %v", err)
+	}
+
+	// Manual-only preset: platform match is enough; URL is not enforced.
+	if err := ValidateSiteInitializationPreset("zhipu-coding-plan-claude", "claude", "https://example.com"); err != nil {
+		t.Fatalf("manual-only preset should skip URL rules: %v", err)
+	}
+}
+
+func TestAnalyzePrimarySiteURL_StripAndSemantic(t *testing.T) {
+	stripped := AnalyzePrimarySiteURL("https://api.deepseek.com/v1")
+	if stripped.Action != "auto_strip_known_api_suffix" {
+		t.Fatalf("action=%q", stripped.Action)
+	}
+	if stripped.PersistedURL != "https://api.deepseek.com" {
+		t.Fatalf("persisted=%q", stripped.PersistedURL)
+	}
+
+	semantic := AnalyzePrimarySiteURL("https://coding.dashscope.aliyuncs.com/apps/anthropic")
+	if semantic.Action != "preserve_semantic_path" {
+		t.Fatalf("action=%q", semantic.Action)
+	}
+	if semantic.PersistedURL != "https://coding.dashscope.aliyuncs.com/apps/anthropic" {
+		t.Fatalf("persisted=%q", semantic.PersistedURL)
+	}
+}

--- a/service/site_service_test.go
+++ b/service/site_service_test.go
@@ -64,16 +64,29 @@ func TestDetectSite_Gemini(t *testing.T) {
 }
 
 func TestDetectSite_DeepSeek(t *testing.T) {
+	// Official OpenAI-compatible entry is covered by initialization presets.
 	result := DetectSite("https://api.deepseek.com")
+	if result == nil || result.Platform != "openai" {
+		t.Fatalf("expected preset platform 'openai', got %v", result)
+	}
+	if result.InitializationPresetID == nil || *result.InitializationPresetID != "deepseek-openai" {
+		t.Fatalf("expected initializationPresetId deepseek-openai, got %v", result.InitializationPresetID)
+	}
+
+	// Non-preset deepseek host still uses vendor heuristic.
+	result = DetectSite("https://platform.deepseek.com")
 	if result == nil || result.Platform != "deepseek" {
-		t.Fatalf("expected 'deepseek', got %v", result)
+		t.Fatalf("expected vendor heuristic 'deepseek', got %v", result)
 	}
 }
 
 func TestDetectSite_Moonshot(t *testing.T) {
 	result := DetectSite("https://api.moonshot.cn/v1")
-	if result == nil || result.Platform != "moonshot" {
-		t.Fatalf("expected 'moonshot', got %v", result)
+	if result == nil || result.Platform != "openai" {
+		t.Fatalf("expected preset platform 'openai', got %v", result)
+	}
+	if result.InitializationPresetID == nil || *result.InitializationPresetID != "moonshot-openai" {
+		t.Fatalf("expected initializationPresetId moonshot-openai, got %v", result.InitializationPresetID)
 	}
 }
 
@@ -142,9 +155,21 @@ func TestDetectSite_SiliconFlow(t *testing.T) {
 }
 
 func TestDetectSite_ModelScope(t *testing.T) {
+	// Bare modelscope inference root maps to the Claude-compatible preset.
 	result := DetectSite("https://api-inference.modelscope.cn")
-	if result == nil || result.Platform != "modelscope" {
-		t.Fatalf("expected 'modelscope', got %v", result)
+	if result == nil || result.Platform != "claude" {
+		t.Fatalf("expected preset platform 'claude', got %v", result)
+	}
+	if result.InitializationPresetID == nil || *result.InitializationPresetID != "modelscope-claude" {
+		t.Fatalf("expected initializationPresetId modelscope-claude, got %v", result.InitializationPresetID)
+	}
+
+	result = DetectSite("https://api-inference.modelscope.cn/v1")
+	if result == nil || result.Platform != "openai" {
+		t.Fatalf("expected preset platform 'openai', got %v", result)
+	}
+	if result.InitializationPresetID == nil || *result.InitializationPresetID != "modelscope-openai" {
+		t.Fatalf("expected initializationPresetId modelscope-openai, got %v", result.InitializationPresetID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Port `web/shared/siteInitializationPresets.js` (13 presets) to Go: `Get/List/DetectSiteInitializationPreset`
- `createSite` validates `initializationPresetId` (exists + platform match + URL match rules) and returns it on success
- `detectSite` returns `initializationPresetId` when host/path rules match (protocol family `openai`/`claude`)

Closes #214

## Test plan
- [x] `go test ./service ./handler/admin -count=1 -run 'Preset|Detect|Site'`
- [x] valid preset create returns 200 + `initializationPresetId`
- [x] unknown / platform-mismatch / URL-mismatch preset create returns 400
- [x] detect known vendor URL returns preset id