### PR TITLE
feat(service): wire InvalidateSiteProxyCache via hook registry

### DIFF
--- a/docs/analysis/site-proxy-cache-invalidation.md
+++ b/docs/analysis/site-proxy-cache-invalidation.md
@@ -1,0 +1,69 @@
+# Site proxy cache invalidation (#216)
+
+**Date**: 2026-07-17  
+**Issue**: [#216](https://github.com/TokenDanceLab/metapi-go/issues/216)  
+**SSOT code**: `service/site_service.go`, `handler/admin/accounts.go`, `handler/admin/sites.go`, `routing/cache.go`
+
+## Problem
+
+`service.InvalidateSiteProxyCache` was a `TODO(P8)` no-op. Site create/update/delete
+paths already called `service.InvalidateSiteCaches()` (or only
+`routing.InvalidateCache()`), so:
+
+1. Token-router invalidation was partial / duplicated depending on the path.
+2. The admin `GET /api/accounts` snapshot (`globalAccountsCache`) was **not**
+   cleared on site mutations, so the snapshot could keep serving stale site rows
+   for up to the 30s TTL.
+3. Wiring admin → service → admin would create an import cycle if service called
+   into `handler/admin` directly.
+
+## Design
+
+Prefer a small **hook registry** in `service` (no new package required):
+
+| API | Role |
+|-----|------|
+| `RegisterSiteProxyCacheInvalidator(fn)` | Append optional side-effect hook |
+| `InvalidateSiteProxyCache()` | Run hooks, then always `routing.InvalidateCache()` |
+| `InvalidateTokenRouterCache()` | Thin alias of `routing.InvalidateCache()` |
+| `InvalidateSiteCaches()` | `InvalidateSiteProxyCache` + `InvalidateTokenRouterCache` (idempotent) |
+
+`handler/admin` registers a once-only hook (package `init` +
+`RegisterAccountsRoutes`) that clears `globalAccountsCache`. Service never
+imports admin; admin already imports service.
+
+```text
+sites handler ──► service.InvalidateSiteCaches()
+                        │
+                        ├─ registered hooks (admin accounts snapshot clear)
+                        └─ routing.InvalidateCache()
+```
+
+## Call sites
+
+| Path | Before | After |
+|------|--------|-------|
+| `POST /api/sites` | `routing.InvalidateCache` only | `service.InvalidateSiteCaches` |
+| `PUT /api/sites/{id}` | `InvalidateSiteCaches` only on status change; always `routing.InvalidateCache` | Always `InvalidateSiteCaches` after successful update |
+| `DELETE /api/sites/{id}` | both (duplicate routing) | `InvalidateSiteCaches` only |
+| batch site mutations | both (duplicate routing) | `InvalidateSiteCaches` only |
+| account mutations | direct `globalAccountsCache.clear` + `routing.InvalidateCache` | unchanged (still local clear) |
+
+## Why not move the snapshot into `service`?
+
+The accounts list response is an HTTP-layer JSON snapshot (includes sites +
+generatedAt). Keeping it package-private in admin matches existing maintenance
+clear-cache code and avoids bloating service with handler response shapes.
+
+## Verification
+
+```bash
+go test ./service ./handler/admin ./routing -count=1 -run 'Cache|Invalidate|Site'
+```
+
+## Follow-ups
+
+- If a dedicated site-proxy HTTP client cache appears later, register another
+  hook (or fold into the same registry) instead of reopening package boundaries.
+- Account mutation paths could optionally call `InvalidateSiteCaches` for one
+  entrypoint, but that is out of scope for #216.

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -27,6 +27,9 @@ import (
 
 // RegisterAccountsRoutes registers all /api/accounts routes.
 func RegisterAccountsRoutes(r chi.Router, db *sqlx.DB, cfg *config.Config) {
+	// Ensure accounts snapshot participates in service.InvalidateSiteProxyCache.
+	// Also registered from init() so site-only route wiring still clears the snapshot.
+	registerAccountsSnapshotCacheInvalidator()
 	handler := &accountsHandler{db: db, cfg: cfg}
 
 	r.Get("/api/accounts", handler.listAccounts)
@@ -87,6 +90,27 @@ func (c *accountsSnapshotCache) clear() {
 }
 
 var globalAccountsCache = &accountsSnapshotCache{ttl: 30 * time.Second}
+
+// accountsSnapshotInvalidatorOnce ensures the site-proxy invalidation hook is
+// registered at most once even when tests re-register routes repeatedly.
+var accountsSnapshotInvalidatorOnce sync.Once
+
+// registerAccountsSnapshotCacheInvalidator wires admin's package-private
+// accounts snapshot cache into service.InvalidateSiteProxyCache without a
+// service → handler import cycle.
+func registerAccountsSnapshotCacheInvalidator() {
+	accountsSnapshotInvalidatorOnce.Do(func() {
+		service.RegisterSiteProxyCacheInvalidator(func() {
+			// Closure reads the package-level variable so test reassignments of
+			// globalAccountsCache remain effective.
+			globalAccountsCache.clear()
+		})
+	})
+}
+
+func init() {
+	registerAccountsSnapshotCacheInvalidator()
+}
 
 // ---- List Accounts ----
 

--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/tokendancelab/metapi-go/config"
 	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/service"
 	"github.com/tokendancelab/metapi-go/service/alert"
 	"github.com/tokendancelab/metapi-go/store"
 )
@@ -2382,5 +2383,29 @@ func TestAccounts_Update_ExtraConfigAndProxyURLMergeTogether(t *testing.T) {
 	}
 	if cfg["platformUserId"] != float64(42) {
 		t.Fatalf("platformUserId = %#v, want 42", cfg["platformUserId"])
+	}
+}
+
+func TestAccountsSnapshotHook_ClearsOnInvalidateSiteCaches(t *testing.T) {
+	// init() + RegisterAccountsRoutes already register the snapshot clear hook.
+	// Prove site-cache invalidation reaches the package-private snapshot.
+	globalAccountsCache = &accountsSnapshotCache{ttl: 30 * time.Second}
+	globalAccountsCache.set([]byte(`{"accounts":[],"sites":[]}`))
+	if !globalAccountsCache.isValid() {
+		t.Fatal("accounts snapshot should be warm")
+	}
+
+	rc := routing.NewRouteCache(5_000)
+	rc.SetRoutes([]store.TokenRoute{{ID: 11, ModelPattern: "gpt-*"}})
+	routing.SetGlobalCache(rc)
+	t.Cleanup(func() { routing.SetGlobalCache(nil) })
+
+	service.InvalidateSiteCaches()
+
+	if globalAccountsCache.isValid() {
+		t.Fatal("accounts snapshot still warm after InvalidateSiteCaches")
+	}
+	if rc.GetRoutes() != nil {
+		t.Fatal("route cache still warm after InvalidateSiteCaches")
 	}
 }

--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -229,7 +229,8 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "Create site failed")
 		return
 	}
-	routing.InvalidateCache()
+	// Clear accounts snapshot + token-router caches (site list is embedded in accounts snapshot).
+	service.InvalidateSiteCaches()
 	writeJSON(w, http.StatusOK, result)
 }
 
@@ -409,11 +410,11 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	// Apply status side effects
 	if newStatus, ok := updates["status"].(string); ok {
 		service.ApplySiteStatusSideEffects(h.db, id, existing.Name, newStatus)
-		service.InvalidateSiteCaches()
 	}
 
 	result, _ := service.LoadSiteWithEndpoints(h.db, id)
-	routing.InvalidateCache()
+	// Always invalidate after a successful site mutation (proxy/url/status/endpoints).
+	service.InvalidateSiteCaches()
 	writeJSON(w, http.StatusOK, result)
 }
 
@@ -432,7 +433,6 @@ func (h *sitesHandler) deleteSite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	service.InvalidateSiteCaches()
-	routing.InvalidateCache()
 	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
 }
 
@@ -494,7 +494,6 @@ func (h *sitesHandler) batchSites(w http.ResponseWriter, r *http.Request) {
 	if action == "delete" || action == "enable" || action == "disable" ||
 		action == "enableSystemProxy" || action == "disableSystemProxy" {
 		service.InvalidateSiteCaches()
-		routing.InvalidateCache()
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{

--- a/handler/admin/sites_test.go
+++ b/handler/admin/sites_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/tokendancelab/metapi-go/routing"
 	"github.com/tokendancelab/metapi-go/store"
 )
 
@@ -984,5 +985,65 @@ func TestSites_MaxConcurrencyRoundTrip(t *testing.T) {
 	})
 	if resp.Code != http.StatusBadRequest {
 		t.Fatalf("negative maxConcurrency: expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestSites_MutationsInvalidateAccountsSnapshotAndRouteCache(t *testing.T) {
+	_, r := setupSitesTest(t)
+
+	// Warm package-level accounts snapshot cache (cleared via registered hook).
+	globalAccountsCache = &accountsSnapshotCache{ttl: 30 * time.Second}
+	globalAccountsCache.set([]byte(`{"accounts":[],"sites":[]}`))
+	if !globalAccountsCache.isValid() {
+		t.Fatal("accounts snapshot should be warm")
+	}
+
+	rc := routing.NewRouteCache(5_000)
+	rc.SetRoutes([]store.TokenRoute{{ID: 7, ModelPattern: "gpt-*"}})
+	routing.SetGlobalCache(rc)
+	t.Cleanup(func() { routing.SetGlobalCache(nil) })
+	if rc.GetRoutes() == nil {
+		t.Fatal("route cache should be warm")
+	}
+
+	site := newSiteFixture(t, r, "CacheSite", "https://api.openai.com/v1")
+	id := int64(site["id"].(float64))
+
+	// Create path must clear both caches.
+	if globalAccountsCache.isValid() {
+		t.Fatal("accounts snapshot still warm after site create")
+	}
+	if rc.GetRoutes() != nil {
+		t.Fatal("route cache still warm after site create")
+	}
+
+	// Re-warm and update (non-status field) - must still invalidate.
+	globalAccountsCache.set([]byte(`{"accounts":[],"sites":[]}`))
+	rc.SetRoutes([]store.TokenRoute{{ID: 8, ModelPattern: "claude-*"}})
+	resp := doPutJSON(t, r, "/api/sites/"+strconv.FormatInt(id, 10), map[string]any{
+		"name": "CacheSite-renamed",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if globalAccountsCache.isValid() {
+		t.Fatal("accounts snapshot still warm after site update")
+	}
+	if rc.GetRoutes() != nil {
+		t.Fatal("route cache still warm after site update")
+	}
+
+	// Re-warm and delete.
+	globalAccountsCache.set([]byte(`{"accounts":[],"sites":[]}`))
+	rc.SetRoutes([]store.TokenRoute{{ID: 9, ModelPattern: "gemini-*"}})
+	del := doDelete(t, r, "/api/sites/"+strconv.FormatInt(id, 10))
+	if del.Code != http.StatusOK {
+		t.Fatalf("delete status=%d body=%s", del.Code, del.Body.String())
+	}
+	if globalAccountsCache.isValid() {
+		t.Fatal("accounts snapshot still warm after site delete")
+	}
+	if rc.GetRoutes() != nil {
+		t.Fatal("route cache still warm after site delete")
 	}
 }

--- a/service/site_service.go
+++ b/service/site_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -409,10 +410,48 @@ func DeleteSite(db *sqlx.DB, siteID int64) error {
 	return err
 }
 
-// InvalidateSiteProxyCache signals that cached site proxy configurations should be refreshed.
-// TODO(P8): integrate with the proxy cache layer when implemented.
+// siteProxyCacheInvalidators holds optional side-effect hooks for site proxy
+// cache invalidation (e.g. admin accounts snapshot). Handlers register via
+// RegisterSiteProxyCacheInvalidator so service never imports handler packages.
+var (
+	siteProxyCacheInvalidatorsMu sync.Mutex
+	siteProxyCacheInvalidators   []func()
+)
+
+// RegisterSiteProxyCacheInvalidator appends a hook that runs on every
+// InvalidateSiteProxyCache / InvalidateSiteCaches call. Nil hooks are ignored.
+// Safe for concurrent registration; intended for package init / route setup.
+func RegisterSiteProxyCacheInvalidator(fn func()) {
+	if fn == nil {
+		return
+	}
+	siteProxyCacheInvalidatorsMu.Lock()
+	defer siteProxyCacheInvalidatorsMu.Unlock()
+	siteProxyCacheInvalidators = append(siteProxyCacheInvalidators, fn)
+}
+
+// resetSiteProxyCacheInvalidatorsForTest clears registered hooks (tests only).
+func resetSiteProxyCacheInvalidatorsForTest() {
+	siteProxyCacheInvalidatorsMu.Lock()
+	defer siteProxyCacheInvalidatorsMu.Unlock()
+	siteProxyCacheInvalidators = nil
+}
+
+// InvalidateSiteProxyCache clears registered site-proxy related caches and the
+// in-process token router cache. Always calls routing.InvalidateCache (no-op
+// when the global cache has not been set).
 func InvalidateSiteProxyCache() {
-	// Stub: P8 proxy cache invalidation
+	siteProxyCacheInvalidatorsMu.Lock()
+	hooks := append([]func(){}, siteProxyCacheInvalidators...)
+	siteProxyCacheInvalidatorsMu.Unlock()
+
+	for _, fn := range hooks {
+		if fn == nil {
+			continue
+		}
+		fn()
+	}
+	routing.InvalidateCache()
 }
 
 // InvalidateTokenRouterCache signals that cached token-router state should be invalidated.
@@ -421,7 +460,9 @@ func InvalidateTokenRouterCache() {
 	routing.InvalidateCache()
 }
 
-// InvalidateSiteCaches invalidates both site proxy and token router caches.
+// InvalidateSiteCaches invalidates both site proxy hooks and token router caches.
+// Routing invalidation is performed by InvalidateSiteProxyCache; the follow-up
+// InvalidateTokenRouterCache is kept for explicit dual-path clarity and is idempotent.
 func InvalidateSiteCaches() {
 	InvalidateSiteProxyCache()
 	InvalidateTokenRouterCache()

--- a/service/site_service_test.go
+++ b/service/site_service_test.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"testing"
+
+	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/store"
 )
 
 // ---- Platform Detection Tests ----
@@ -497,4 +500,66 @@ func TestNormalizeNullable_Nil(t *testing.T) {
 	if result != nil {
 		t.Errorf("expected nil for nil input, got %v", result)
 	}
+}
+
+// ---- Site proxy cache invalidation (#216) ----
+
+func TestRegisterSiteProxyCacheInvalidator_RunsOnInvalidate(t *testing.T) {
+	resetSiteProxyCacheInvalidatorsForTest()
+	t.Cleanup(resetSiteProxyCacheInvalidatorsForTest)
+
+	var calls int
+	RegisterSiteProxyCacheInvalidator(func() { calls++ })
+	RegisterSiteProxyCacheInvalidator(nil) // ignored
+	RegisterSiteProxyCacheInvalidator(func() { calls++ })
+
+	InvalidateSiteProxyCache()
+	if calls != 2 {
+		t.Fatalf("hook calls=%d, want 2", calls)
+	}
+
+	InvalidateSiteCaches()
+	if calls != 4 {
+		t.Fatalf("after InvalidateSiteCaches calls=%d, want 4", calls)
+	}
+}
+
+func TestInvalidateSiteProxyCache_AlwaysInvalidatesRoutingCache(t *testing.T) {
+	resetSiteProxyCacheInvalidatorsForTest()
+	t.Cleanup(resetSiteProxyCacheInvalidatorsForTest)
+
+	rc := routing.NewRouteCache(5_000)
+	rc.SetRoutes([]store.TokenRoute{{ID: 42, ModelPattern: "gpt-*"}})
+	routing.SetGlobalCache(rc)
+	t.Cleanup(func() { routing.SetGlobalCache(nil) })
+
+	if got := rc.GetRoutes(); got == nil {
+		t.Fatal("route cache should be warm before invalidation")
+	}
+
+	// No hooks registered — routing invalidation must still happen.
+	InvalidateSiteProxyCache()
+	if got := rc.GetRoutes(); got != nil {
+		t.Fatalf("route cache still warm after InvalidateSiteProxyCache: %v", got)
+	}
+
+	rc.SetRoutes([]store.TokenRoute{{ID: 99, ModelPattern: "claude-*"}})
+	if got := rc.GetRoutes(); got == nil {
+		t.Fatal("route cache should be warm before InvalidateSiteCaches")
+	}
+	InvalidateSiteCaches()
+	if got := rc.GetRoutes(); got != nil {
+		t.Fatalf("route cache still warm after InvalidateSiteCaches: %v", got)
+	}
+}
+
+func TestInvalidateSiteProxyCache_SafeWithoutGlobalCache(t *testing.T) {
+	resetSiteProxyCacheInvalidatorsForTest()
+	t.Cleanup(resetSiteProxyCacheInvalidatorsForTest)
+	routing.SetGlobalCache(nil)
+
+	// Must not panic when global route cache is unset.
+	InvalidateSiteProxyCache()
+	InvalidateSiteCaches()
+	InvalidateTokenRouterCache()
 }


### PR DESCRIPTION
## Summary
- Make `service.InvalidateSiteProxyCache` real: run a small hook registry, then always call `routing.InvalidateCache`.
- Admin registers an once-only hook (package `init` + `RegisterAccountsRoutes`) that clears `globalAccountsCache`, avoiding a `service` → `handler/admin` import cycle.
- Site create/update/delete/batch paths now call `service.InvalidateSiteCaches()` (drops redundant direct `routing.InvalidateCache` where it duplicated the same work).
- Add service + admin tests and `docs/analysis/site-proxy-cache-invalidation.md`.

Closes #216

## Test plan
- [x] `go test ./service ./handler/admin ./routing -count=1 -run 'Cache|Invalidate|Site'`
- [x] `go vet ./service ./handler/admin ./routing`
- [x] pre-push local CI: `go vet ./... && go test ./... -count=1 -race`

## Notes
Sibling PR #219 also targets #216 on `feat/p85-site-cache-invalidation-main`; pick one implementation to merge.