### PR TITLE
docs(release): v0.8.5 Enterprise residual complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.5] — 2026-07-17
+
+### Added
+- Site initialization preset registry + create/detect validation (#214 / #222)
+- Gemini `/v1beta/models` from owned model catalog (#215 / #221)
+- Site proxy cache invalidation hooks (routing + admin accounts snapshot) (#216 / #219)
+- Responses WebSocket honest residual + boot wire (#217 / #220)
+
+### Fixed
+- Shared PG CI: prefer `SiteSelectColumns` over `SELECT * FROM sites` (probe-column drift)
+
 ## [v0.8.4] — 2026-07-17
 
 ### Fixed

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -78,7 +78,7 @@
 | P4 adapters | Milestone 11 closed · **#182–#185** · tag **[v0.8.2](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.2)** |
 | Residual stubs | Milestone 12 closed · tag **[v0.8.3](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.3)** |
 | Polish v0.8.4 | Milestone 13 closed · tag **[v0.8.4](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.4)** |
-| Residual v0.8.5 | Milestone 14 · **#214–#217** (presets / gemini models / cache invalidate / responses WS) |
+| Residual v0.8.5 | Milestone 14 · **#214–#217 closed** (PRs #219–#222); tag **v0.8.5** |
 | Residual CI | vulncheck green on Go 1.26.5; frontend occasional EnvironmentTeardownError flake |
 
 ### M-COMPETE notes (active)
@@ -173,6 +173,6 @@
 - **M-SCHEMA**: additive `schema_migrations` + columns `proxy_url` / `max_concurrency` / `context_length`
 
 ## Next Steps
-1. **Enterprise residual v0.8.5** (milestone 14): #214 site init presets · #215 Gemini models list · #216 site cache invalidation · #217 Responses WS residual
-2. Optional multi-instance job coordination beyond in-process tasks
+1. Tag **v0.8.5** (Enterprise residual complete)
+2. Optional: multi-instance job coordination beyond in-process tasks; full Responses WS product
 3. Continue product backlog P0/P1; frontend flake observability


### PR DESCRIPTION
## Summary
- CHANGELOG + MASTER for v0.8.5 (#214–#217)

## Test plan
- [x] docs only