### PR TITLE
test(proxy): assert Claude cache_ratio defaults in billing details

### DIFF
--- a/docs/analysis/cache-ratio-pricing.md
+++ b/docs/analysis/cache-ratio-pricing.md
@@ -55,6 +55,14 @@ Pure helpers in `routing` (no network, no DB):
 - Full cache-split cost golden (0.083057) with and without Claude fallback
 - Platform fallback token divisor
 
+`handler/proxy/billing_cost_test.go` locks the proxy_logs path
+(`EstimateBillingCostFromUsage` → `CalculateModelUsageBreakdown`):
+
+- Claude model with missing ratios → `billing_details.pricing.cache_ratio == 0.1`
+  and `cache_creation_ratio == 1.25`
+- Non-Claude missing → both ratios stay `1.0`
+- `cache_read_cost` / `cache_creation_cost` present when cache tokens > 0
+
 ## Out of scope (this change)
 
 - Full remote pricing catalog fetch / AnyRouter shield cookie path

--- a/handler/proxy/billing_cost_test.go
+++ b/handler/proxy/billing_cost_test.go
@@ -22,7 +22,85 @@ func TestEstimateBillingCostFromUsage_ClaudeCacheFields(t *testing.T) {
 	if got.BillingDetails == nil {
 		t.Fatal("nil details")
 	}
-	if _, ok := got.BillingDetails["breakdown"].(map[string]any); !ok {
+
+	breakdown, ok := got.BillingDetails["breakdown"].(map[string]any)
+	if !ok {
 		t.Fatalf("breakdown missing: %#v", got.BillingDetails)
+	}
+
+	pricing, ok := got.BillingDetails["pricing"].(map[string]any)
+	if !ok {
+		t.Fatalf("pricing missing: %#v", got.BillingDetails)
+	}
+
+	// EstimateBillingCostFromUsage builds PricingModel without CacheRatio pointers.
+	// CalculateModelUsageBreakdown must surface Claude Anthropic defaults via
+	// ResolveCacheRatio / ResolveCacheCreationRatio (0.1 / 1.25).
+	if got := asFloat(t, pricing["cache_ratio"]); got != 0.1 {
+		t.Fatalf("claude pricing.cache_ratio=%v want 0.1", got)
+	}
+	if got := asFloat(t, pricing["cache_creation_ratio"]); got != 1.25 {
+		t.Fatalf("claude pricing.cache_creation_ratio=%v want 1.25", got)
+	}
+
+	// Cache token costs must be present and positive when cache tokens > 0.
+	cacheReadCost := asFloat(t, breakdown["cache_read_cost"])
+	if cacheReadCost <= 0 {
+		t.Fatalf("cache_read_cost should be > 0 when cache_read_tokens > 0, got %v", cacheReadCost)
+	}
+	cacheCreationCost := asFloat(t, breakdown["cache_creation_cost"])
+	if cacheCreationCost <= 0 {
+		t.Fatalf("cache_creation_cost should be > 0 when cache_creation_tokens > 0, got %v", cacheCreationCost)
+	}
+}
+
+func TestEstimateBillingCostFromUsage_NonClaudeMissingCacheRatiosStayOne(t *testing.T) {
+	got := EstimateBillingCostFromUsage("gpt-4o", "openai", ParsedUsage{
+		PromptTokens: 100, CompletionTokens: 50, CacheReadTokens: 20, CacheCreationTokens: 10,
+		Found: true, Source: "upstream",
+	})
+	if got.BillingDetails == nil {
+		t.Fatal("nil details")
+	}
+
+	pricing, ok := got.BillingDetails["pricing"].(map[string]any)
+	if !ok {
+		t.Fatalf("pricing missing: %#v", got.BillingDetails)
+	}
+
+	// Non-Claude models keep historical MetAPI fallback of 1.0 when ratios are missing.
+	if got := asFloat(t, pricing["cache_ratio"]); got != 1.0 {
+		t.Fatalf("non-claude pricing.cache_ratio=%v want 1.0", got)
+	}
+	if got := asFloat(t, pricing["cache_creation_ratio"]); got != 1.0 {
+		t.Fatalf("non-claude pricing.cache_creation_ratio=%v want 1.0", got)
+	}
+
+	breakdown, ok := got.BillingDetails["breakdown"].(map[string]any)
+	if !ok {
+		t.Fatalf("breakdown missing: %#v", got.BillingDetails)
+	}
+	if asFloat(t, breakdown["cache_read_cost"]) <= 0 {
+		t.Fatalf("cache_read_cost should be present and > 0 when tokens > 0: %#v", breakdown)
+	}
+	if asFloat(t, breakdown["cache_creation_cost"]) <= 0 {
+		t.Fatalf("cache_creation_cost should be present and > 0 when tokens > 0: %#v", breakdown)
+	}
+}
+
+func asFloat(t *testing.T, v any) float64 {
+	t.Helper()
+	switch n := v.(type) {
+	case float64:
+		return n
+	case float32:
+		return float64(n)
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	default:
+		t.Fatalf("expected numeric value, got %T (%#v)", v, v)
+		return 0
 	}
 }


### PR DESCRIPTION
## Summary
- Strengthen `EstimateBillingCostFromUsage` tests so Claude missing cache ratios surface as `0.1` / `1.25` in `billing_details.pricing`
- Assert non-Claude missing ratios stay `1.0`
- Assert `cache_read_cost` / `cache_creation_cost` are present and positive when cache tokens > 0
- Document the proxy_logs assertion path in `docs/analysis/cache-ratio-pricing.md`
- No production code change required: `CalculateModelUsageBreakdown` already applies Claude defaults via nil `CacheRatio` pointers

Closes #227

## Test plan
- [x] `go test ./handler/proxy ./routing -count=1 -run 'Billing|CacheRatio|Claude'`
- [ ] Confirm CI green on PR