### PR TITLE
fix(proxy): videos GET/DELETE honest passthrough (#225)

### DIFF
--- a/docs/analysis/videos-proxy-residual.md
+++ b/docs/analysis/videos-proxy-residual.md
@@ -1,0 +1,74 @@
+# Residual: Videos GET/DELETE honest passthrough (#225)
+
+**Date**: 2026-07-17  
+**Issue**: [#225](https://github.com/TokenDanceLab/metapi-go/issues/225)  
+**Lane**: p86 / honest residual  
+**SSOT code**: `handler/proxy/videos.go`
+
+## Goal
+
+Stop store-gated theater on video GET/DELETE:
+
+- `HandleVideosCreate` already dispatches upstream but **does not** save
+  `ProxyVideoTask` or rewrite the response `id` to a publicId.
+- Clients that hold a real upstream video id were still hard-404'd with
+  `"Video task not found"` solely because the in-memory map was empty.
+- Prefer honest upstream passthrough over local-only mapping theater.
+- Full multi-instance durable video store is **out of scope**.
+
+## Behavior after #225
+
+| Surface | Behavior |
+|---------|----------|
+| `POST /v1/videos` | `PrepareCtx` + `dispatchUpstream` (unchanged). No mapping save / publicId rewrite yet. |
+| `GET /v1/videos/{id}` | Always `PrepareCtx` + `dispatchUpstream`. If local mapping exists and `UpstreamVideoID` differs from `{id}`, path uses `UpstreamVideoID`; otherwise `{id}` is passed through. **Missing mapping is not a 404.** |
+| `DELETE /v1/videos/{id}` | Delete local mapping if present (idempotent). Always `PrepareCtx` + `dispatchUpstream` DELETE with the same path rewrite rule as GET. Prefer upstream status over a local-only 204 residual. |
+
+### Path rewrite rule
+
+```
+upstreamPathID = publicID
+if mapping[publicID] exists
+  and UpstreamVideoID != ""
+  and UpstreamVideoID != publicID:
+    upstreamPathID = UpstreamVideoID
+
+DownstreamPath = "/v1/videos/" + upstreamPathID
+```
+
+## What is still residual (not claimed)
+
+1. **Create does not save `ProxyVideoTask`** — response `id` is whatever upstream
+   returns (or stub). No publicId generation/rewrite on the write path.
+2. **In-memory process-local store only** — no Redis / DB multi-instance video
+   task store. Mapping is an optional rewrite aid when something else seeds it
+   (tests, future create wiring).
+3. **No sticky site/token restore from mapping** — even when a mapping row has
+   `SiteURL` / `TokenValue` / channel ids, GET/DELETE still go through normal
+   channel selection (`PrepareCtx` + router). Sticky pin is future work.
+4. **Stub mode** — when upstream is unconfigured and proxy stub is enabled,
+   GET/DELETE return the generic stub JSON (non-404), same as other surfaces.
+   Production without upstream config still returns 503 from `dispatchUpstream`.
+
+## TS parity note
+
+TS MetAPI saves mapping on create and rewrites `id` in the create response, then
+uses the mapping on GET/DELETE. Go currently only has the optional mapping
+helpers + passthrough path rewrite. Closing the create-side mapping + id rewrite
+is a separate follow-up, not required for honest GET/DELETE.
+
+## Tests
+
+| Case | Expectation |
+|------|-------------|
+| GET with mapping | 200 stub (or upstream); path may use UpstreamVideoID |
+| GET without mapping (auth ok) | **not** hard 404; stub/upstream path proceeds |
+| DELETE with mapping | local mapping cleared; dispatchUpstream (stub non-404) |
+| DELETE without mapping | **not** hard 404; dispatchUpstream proceeds |
+| Create model required / multipart | unchanged |
+
+Verify:
+
+```bash
+go test ./handler/proxy -count=1 -run Video
+```

--- a/handler/proxy/videos.go
+++ b/handler/proxy/videos.go
@@ -1,7 +1,6 @@
 package proxyhandler
 
 import (
-	"encoding/json"
 	"net/http"
 	"sync"
 
@@ -9,6 +8,11 @@ import (
 )
 
 // ProxyVideoTask holds a video task mapping (publicId -> upstreamVideoId).
+//
+// Residual (#225): Create currently dispatches upstream but does not save this
+// mapping or rewrite response id. GET/DELETE therefore treat the local store as
+// an optional rewrite aid, not a hard gate — missing entries pass the client id
+// through to upstream. See docs/analysis/videos-proxy-residual.md.
 type ProxyVideoTask struct {
 	PublicID        string `json:"publicId"`
 	UpstreamVideoID string `json:"upstreamVideoId"`
@@ -27,6 +31,10 @@ var (
 
 // HandleVideosCreate handles POST /v1/videos.
 // Supports multipart/form-data or JSON body. Model is required.
+//
+// Residual: does not yet persist ProxyVideoTask or rewrite upstream response id
+// to a publicId. Clients that receive an upstream id can still GET/DELETE it via
+// honest passthrough when the local mapping is absent.
 func HandleVideosCreate(w http.ResponseWriter, r *http.Request) {
 	EnsureMultipartBufferParser()
 
@@ -49,6 +57,10 @@ func HandleVideosCreate(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleVideosGet handles GET /v1/videos/{id}.
+//
+// If a local mapping exists and UpstreamVideoID differs from the public path id,
+// the upstream path uses UpstreamVideoID. When the mapping is missing, the
+// client-provided id is passed through — no store-gated 404 theater.
 func HandleVideosGet(w http.ResponseWriter, r *http.Request) {
 	publicID := chi.URLParam(r, "id")
 	if publicID == "" {
@@ -56,9 +68,11 @@ func HandleVideosGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	upstreamID := resolveVideoUpstreamID(publicID)
+
 	ctx, errResp := PrepareCtx(r, SurfConfig{
 		Endpoint:       "videos",
-		DownstreamPath: "/v1/videos/" + publicID,
+		DownstreamPath: "/v1/videos/" + upstreamID,
 		RequireModel:   false,
 	})
 	if errResp != nil {
@@ -66,21 +80,14 @@ func HandleVideosGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	videoTaskStoreMu.RLock()
-	task, ok := videoTaskStore[publicID]
-	videoTaskStoreMu.RUnlock()
-
-	if !ok {
-		writeJSONError(w, 404, "Video task not found", "not_found_error")
-		return
-	}
-
-	_ = task
-	_ = ctx
 	dispatchUpstream(w, r, ctx)
 }
 
 // HandleVideosDelete handles DELETE /v1/videos/{id}.
+//
+// Clears any local mapping for the public id, then always dispatches DELETE to
+// upstream (mapping is optional rewrite aid, not a hard gate). Prefer honest
+// upstream status over a local-only 204 residual.
 func HandleVideosDelete(w http.ResponseWriter, r *http.Request) {
 	publicID := chi.URLParam(r, "id")
 	if publicID == "" {
@@ -88,20 +95,35 @@ func HandleVideosDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	videoTaskStoreMu.RLock()
-	_, ok := videoTaskStore[publicID]
-	videoTaskStoreMu.RUnlock()
+	upstreamID := resolveVideoUpstreamID(publicID)
+	// Best-effort local cleanup whether or not a mapping existed.
+	DeleteProxyVideoTaskByPublicID(publicID)
 
-	if !ok {
-		writeJSONError(w, 404, "Video task not found", "not_found_error")
+	ctx, errResp := PrepareCtx(r, SurfConfig{
+		Endpoint:       "videos",
+		DownstreamPath: "/v1/videos/" + upstreamID,
+		RequireModel:   false,
+	})
+	if errResp != nil {
+		writeJSONError(w, errResp.Status, errResp.Error, errResp.ErrorType)
 		return
 	}
 
-	videoTaskStoreMu.Lock()
-	delete(videoTaskStore, publicID)
-	videoTaskStoreMu.Unlock()
+	dispatchUpstream(w, r, ctx)
+}
 
-	w.WriteHeader(204)
+// resolveVideoUpstreamID returns the upstream path id for a client-facing id.
+// When a mapping exists with a non-empty UpstreamVideoID different from publicID,
+// that upstream id is used; otherwise publicID is passed through unchanged.
+func resolveVideoUpstreamID(publicID string) string {
+	task := GetProxyVideoTaskByPublicID(publicID)
+	if task == nil {
+		return publicID
+	}
+	if task.UpstreamVideoID != "" && task.UpstreamVideoID != publicID {
+		return task.UpstreamVideoID
+	}
+	return publicID
 }
 
 // SaveProxyVideoTask saves a video task mapping.
@@ -124,6 +146,3 @@ func DeleteProxyVideoTaskByPublicID(publicID string) {
 	defer videoTaskStoreMu.Unlock()
 	delete(videoTaskStore, publicID)
 }
-
-// Ensure json import is used
-var _ = json.Marshal

--- a/handler/proxy/videos_test.go
+++ b/handler/proxy/videos_test.go
@@ -117,13 +117,14 @@ func TestHandleVideosCreate_InvalidMultipartReturnsBadRequest(t *testing.T) {
 	}
 }
 
-func TestHandleVideosGet_Found(t *testing.T) {
+func TestHandleVideosGet_WithMapping(t *testing.T) {
 	publicID := "video_test_get_123"
 	SaveProxyVideoTask(&ProxyVideoTask{
 		PublicID:        publicID,
 		UpstreamVideoID: "upstream_" + publicID,
 		RequestedModel:  "sora-2",
 	})
+	t.Cleanup(func() { DeleteProxyVideoTaskByPublicID(publicID) })
 
 	r := chiRouterForVideo()
 	req := makeProxyReqNoBody("GET", "/v1/videos/"+publicID)
@@ -141,18 +142,38 @@ func TestHandleVideosGet_Found(t *testing.T) {
 	}
 }
 
-func TestHandleVideosGet_NotFound(t *testing.T) {
+func TestHandleVideosGet_WithoutMapping_Passthrough(t *testing.T) {
+	// Missing local store entry must not hard-404; auth + stub/upstream path proceeds.
 	r := chiRouterForVideo()
 	req := makeProxyReqNoBody("GET", "/v1/videos/nonexistent_video_id")
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != 404 {
-		t.Errorf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code == http.StatusNotFound {
+		t.Fatalf("expected no store-gated 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected stub 200 when auth proceeds, got %d: %s", rec.Code, rec.Body.String())
+	}
+	m := unmarshalResponse(t, rec)
+	if m == nil {
+		t.Fatal("expected non-nil stub response")
 	}
 }
 
-func TestHandleVideosDelete_Found(t *testing.T) {
+func TestHandleVideosGet_Unauthorized(t *testing.T) {
+	r := chi.NewRouter()
+	r.Get("/v1/videos/{id}", HandleVideosGet)
+	req := httptest.NewRequest("GET", "/v1/videos/vid_no_auth", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleVideosDelete_WithMapping_ClearsAndPassthrough(t *testing.T) {
 	publicID := "video_test_delete_456"
 	SaveProxyVideoTask(&ProxyVideoTask{
 		PublicID:        publicID,
@@ -165,25 +186,69 @@ func TestHandleVideosDelete_Found(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != 204 {
-		t.Errorf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	// Prefer upstream/stub dispatch over local-only 204 residual.
+	if rec.Code == http.StatusNotFound {
+		t.Fatalf("expected no store-gated 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected stub 200 when auth proceeds, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	// Verify deleted
+	// Local mapping must be cleared even though we pass through upstream.
 	task := GetProxyVideoTaskByPublicID(publicID)
 	if task != nil {
 		t.Error("task should be deleted")
 	}
 }
 
-func TestHandleVideosDelete_NotFound(t *testing.T) {
+func TestHandleVideosDelete_WithoutMapping_Passthrough(t *testing.T) {
 	r := chiRouterForVideo()
 	req := makeProxyReqNoBody("DELETE", "/v1/videos/nonexistent_id")
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != 404 {
-		t.Errorf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code == http.StatusNotFound {
+		t.Fatalf("expected no store-gated 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected stub 200 when auth proceeds, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleVideosDelete_Unauthorized(t *testing.T) {
+	r := chi.NewRouter()
+	r.Delete("/v1/videos/{id}", HandleVideosDelete)
+	req := httptest.NewRequest("DELETE", "/v1/videos/vid_no_auth", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestResolveVideoUpstreamID(t *testing.T) {
+	publicID := "video_resolve_public"
+	if got := resolveVideoUpstreamID(publicID); got != publicID {
+		t.Errorf("missing mapping: got %q want %q", got, publicID)
+	}
+
+	SaveProxyVideoTask(&ProxyVideoTask{
+		PublicID:        publicID,
+		UpstreamVideoID: "upstream_video_xyz",
+	})
+	t.Cleanup(func() { DeleteProxyVideoTaskByPublicID(publicID) })
+
+	if got := resolveVideoUpstreamID(publicID); got != "upstream_video_xyz" {
+		t.Errorf("mapped id: got %q want upstream_video_xyz", got)
+	}
+
+	// Same public/upstream id should not force a different path segment.
+	same := "video_same_id"
+	SaveProxyVideoTask(&ProxyVideoTask{PublicID: same, UpstreamVideoID: same})
+	t.Cleanup(func() { DeleteProxyVideoTaskByPublicID(same) })
+	if got := resolveVideoUpstreamID(same); got != same {
+		t.Errorf("same id mapping: got %q want %q", got, same)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove store-gated 404 theater on `GET/DELETE /v1/videos/{id}` when `ProxyVideoTask` mapping is missing
- Always `PrepareCtx` + `dispatchUpstream`; rewrite path to `UpstreamVideoID` only when a local mapping exists and differs
- DELETE clears local mapping if present, then passes through upstream (prefer upstream status over residual 204)
- Document publicId rewrite residual in `docs/analysis/videos-proxy-residual.md`

Closes #225

## Test plan
- [x] `go test ./handler/proxy -count=1 -run Video`
- [x] `go vet ./... && go test ./... -count=1 -race` (local)
- [ ] CI green on PR
- [ ] Manual: GET/DELETE with real upstream id and empty process-local store should not 404 solely for missing mapping