### PR TITLE
docs(release): v0.8.6 Enterprise residual complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.6] — 2026-07-17
+
+### Fixed
+- Videos GET/DELETE honest upstream passthrough without empty local-store 404 theater (#225 / #231)
+
+### Added / Tests
+- Downstream key maxCost/maxRequests clear-to-NULL API tests (#226 / #233)
+- Claude cache_ratio 0.1 / cache_creation_ratio 1.25 assertions on proxy billing details (#227 / #230)
+- ParseInputFiles extracts OpenAI input_file/file body refs (#228 / #232)
+
 ## [v0.8.5] — 2026-07-17
 
 ### Added

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -79,7 +79,7 @@
 | Residual stubs | Milestone 12 closed · tag **[v0.8.3](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.3)** |
 | Polish v0.8.4 | Milestone 13 closed · tag **[v0.8.4](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.4)** |
 | Residual v0.8.5 | Milestone 14 closed · tag **[v0.8.5](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.5)** |
-| Residual v0.8.6 | Milestone 15 · **#225–#228** (videos / quota clear tests / Claude billing / input_files parse) |
+| Residual v0.8.6 | Milestone 15 · **#225–#228 closed** (PRs #229–#233); tag **v0.8.6** |
 | Residual CI | vulncheck green on Go 1.26.5; frontend occasional EnvironmentTeardownError flake |
 
 ### M-COMPETE notes (active)
@@ -174,6 +174,6 @@
 - **M-SCHEMA**: additive `schema_migrations` + columns `proxy_url` / `max_concurrency` / `context_length`
 
 ## Next Steps
-1. **Enterprise residual v0.8.6** (milestone 15): #225 videos passthrough · #226 quota clear tests · #227 Claude billing assert · #228 input_files parse
-2. Optional: multi-instance job coordination; full Responses WS product
+1. Tag **v0.8.6** (Enterprise residual complete)
+2. Optional: multi-instance job coordination; full Responses WS product; video publicId rewrite mapping
 3. Continue product backlog P0/P1; frontend flake observability


### PR DESCRIPTION
## Summary
- CHANGELOG + MASTER for v0.8.6 (#225–#228)

## Test plan
- [x] docs only