### PR TITLE
fix(proxy): ResolveInputFile honest residual error (#238)

### DIFF
--- a/docs/analysis/input-files-parse.md
+++ b/docs/analysis/input-files-parse.md
@@ -1,8 +1,8 @@
 # Input Files Parse (`ParseInputFiles`)
 
 **Date**: 2026-07-17  
-**Issue**: [#228](https://github.com/TokenDanceLab/metapi-go/issues/228)  
-**Lane**: p86 input_files parse
+**Issues**: [#228](https://github.com/TokenDanceLab/metapi-go/issues/228) (parse), [#238](https://github.com/TokenDanceLab/metapi-go/issues/238) (`ResolveInputFile` residual)  
+**Lane**: p86 input_files parse / p87 resolve residual
 
 ## Scope landed
 
@@ -29,11 +29,12 @@ proxy helpers stay dependency-light.
    owner-scoped input-file upload that inlined refs. Go does **not** add that
    route this wave. Durable file I/O goes through the existing **`/v1/files`**
    proxy surface (`docs/analysis/files-proxy.md`).
-2. **`ResolveInputFile` remains a residual stub** — returns `(nil, nil)`.
-   There is no multi-tenant local file vault, no disk dump of customer bytes,
-   and no automatic fetch of `file_url` / decode of `file_data`. Callers that
-   need content should use upstream `file_id` / `file_url` as-is or the
-   `/v1/files` proxy.
+2. **`ResolveInputFile` is an honest residual** (#238) — returns
+   `(nil, ErrInputFileResolveResidual)`, **not** silent `(nil, nil)` success
+   theater. There is no multi-tenant local file vault, no disk dump of
+   customer bytes, and no automatic fetch of `file_url` / decode of
+   `file_data`. Callers that need content should use upstream `file_id` /
+   `file_url` as-is or the `/v1/files` proxy.
 3. **`file_data` is not materialized into `InputFile.Data`** — parse only
    surfaces identity fields (`FileID` / `FileURL` / `Filename`). Base64
    payloads stay in the original body for transform/upstream paths.
@@ -52,7 +53,7 @@ proxy helpers stay dependency-light.
 - top-level `input` array (nested content + direct part)
 - nested `file` object identifiers
 - empty typed parts / image_url ignored
-- `ResolveInputFile` residual stub
+- `ResolveInputFile` → `ErrInputFileResolveResidual` (nil data)
 
 Verify:
 

--- a/handler/proxy/input_files.go
+++ b/handler/proxy/input_files.go
@@ -1,6 +1,7 @@
 package proxyhandler
 
 import (
+	"errors"
 	"strings"
 )
 
@@ -8,6 +9,13 @@ import (
 // Extract OpenAI-shaped input_file / file references from request bodies.
 // Resolution/upload remains residual: TS inlines local file refs; Go proxies
 // durable files via /v1/files and does not invent a local multi-tenant vault.
+
+// ErrInputFileResolveResidual is returned by ResolveInputFile to make the
+// residual explicit: no local multi-tenant vault, no silent empty success.
+// Use the /v1/files proxy or pass upstream-native file_id / file_url.
+var ErrInputFileResolveResidual = errors.New(
+	"input file resolve is residual: use /v1/files proxy or upstream file_id/file_url (no local vault)",
+)
 
 // InputFile represents an input file reference.
 type InputFile struct {
@@ -41,11 +49,12 @@ func ParseInputFiles(body map[string]any) []InputFile {
 }
 
 // ResolveInputFile resolves an input file to its content.
-// Residual stub — no local vault / no durable fetch in this wave.
+// Residual: there is no local vault / durable fetch. Returns
+// ErrInputFileResolveResidual so callers cannot mistake this for success.
 // Callers should use /v1/files proxy or upstream-native file_id/file_url.
 func ResolveInputFile(file InputFile) ([]byte, error) {
 	_ = file
-	return nil, nil
+	return nil, ErrInputFileResolveResidual
 }
 
 func collectInputFilesFromValue(out *[]InputFile, v any) {

--- a/handler/proxy/input_files_test.go
+++ b/handler/proxy/input_files_test.go
@@ -1,6 +1,7 @@
 package proxyhandler
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -138,11 +139,11 @@ func TestResolveInputFile_Stub(t *testing.T) {
 		Filename: "test.txt",
 	}
 	data, err := ResolveInputFile(file)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+	if !errors.Is(err, ErrInputFileResolveResidual) {
+		t.Errorf("expected ErrInputFileResolveResidual, got %v", err)
 	}
 	if data != nil {
-		t.Errorf("expected nil data (stub), got %d bytes", len(data))
+		t.Errorf("expected nil data (residual), got %d bytes", len(data))
 	}
 }
 


### PR DESCRIPTION
## Summary
- `ResolveInputFile` now returns explicit `ErrInputFileResolveResidual` instead of silent `(nil, nil)`.
- Tests assert residual error; docs residual section updated for #238.
- `ParseInputFiles` behavior unchanged.

## Test plan
- [x] `go test ./handler/proxy -count=1 -run InputFile`

Closes #238