### PR TITLE
feat(proxy): videos create publicId mapping + response rewrite (#235)

### DIFF
--- a/docs/analysis/videos-proxy-residual.md
+++ b/docs/analysis/videos-proxy-residual.md
@@ -1,30 +1,38 @@
-# Residual: Videos GET/DELETE honest passthrough (#225)
+# Residual: Videos proxy publicId mapping (#225 / #235)
 
 **Date**: 2026-07-17  
-**Issue**: [#225](https://github.com/TokenDanceLab/metapi-go/issues/225)  
-**Lane**: p86 / honest residual  
-**SSOT code**: `handler/proxy/videos.go`
+**Issues**: [#225](https://github.com/TokenDanceLab/metapi-go/issues/225) (GET/DELETE passthrough), [#235](https://github.com/TokenDanceLab/metapi-go/issues/235) (create mapping)  
+**Lane**: p87 / videos create rewrite  
+**SSOT code**: `handler/proxy/videos.go`, success hook in `handler/proxy/upstream.go`
 
 ## Goal
 
-Stop store-gated theater on video GET/DELETE:
+1. **#225** — Stop store-gated theater on video GET/DELETE (missing map ≠ hard 404).
+2. **#235** — On successful create, save process-local `ProxyVideoTask` and rewrite response `id` to opaque `publicId`.
 
-- `HandleVideosCreate` already dispatches upstream but **does not** save
-  `ProxyVideoTask` or rewrite the response `id` to a publicId.
-- Clients that hold a real upstream video id were still hard-404'd with
-  `"Video task not found"` solely because the in-memory map was empty.
-- Prefer honest upstream passthrough over local-only mapping theater.
-- Full multi-instance durable video store is **out of scope**.
-
-## Behavior after #225
+## Behavior after #235
 
 | Surface | Behavior |
 |---------|----------|
-| `POST /v1/videos` | `PrepareCtx` + `dispatchUpstream` (unchanged). No mapping save / publicId rewrite yet. |
-| `GET /v1/videos/{id}` | Always `PrepareCtx` + `dispatchUpstream`. If local mapping exists and `UpstreamVideoID` differs from `{id}`, path uses `UpstreamVideoID`; otherwise `{id}` is passed through. **Missing mapping is not a 404.** |
-| `DELETE /v1/videos/{id}` | Delete local mapping if present (idempotent). Always `PrepareCtx` + `dispatchUpstream` DELETE with the same path rewrite rule as GET. Prefer upstream status over a local-only 204 residual. |
+| `POST /v1/videos` | `PrepareCtx` + `dispatchUpstream`. On **non-stream buffered 2xx**, parse upstream JSON `id`, generate `video_<hex>`, `SaveProxyVideoTask`, rewrite body `id` → publicId. Parse miss / non-JSON → body unchanged (best-effort). |
+| `GET /v1/videos/{id}` | Always dispatch. If local mapping exists and `UpstreamVideoID` differs from `{id}`, path uses `UpstreamVideoID`; otherwise `{id}` passthrough. **Missing mapping is not a 404.** |
+| `DELETE /v1/videos/{id}` | Delete local mapping if present. Always dispatch DELETE with same path rewrite rule. Prefer upstream status over local-only 204. |
 
-### Path rewrite rule
+### Create rewrite rule
+
+```
+on success POST /v1/videos (path equal, ignore trailing slash):
+  upstreamID = JSON.body.id (string, non-empty)
+  publicID   = "video_" + hex(16 random bytes)
+  SaveProxyVideoTask({
+    PublicID, UpstreamVideoID: upstreamID,
+    SiteURL, TokenValue, RequestedModel, ActualModel,
+    ChannelID, AccountID
+  })
+  body.id = publicID
+```
+
+### Path rewrite rule (GET/DELETE)
 
 ```
 upstreamPathID = publicID
@@ -38,37 +46,27 @@ DownstreamPath = "/v1/videos/" + upstreamPathID
 
 ## What is still residual (not claimed)
 
-1. **Create does not save `ProxyVideoTask`** — response `id` is whatever upstream
-   returns (or stub). No publicId generation/rewrite on the write path.
-2. **In-memory process-local store only** — no Redis / DB multi-instance video
-   task store. Mapping is an optional rewrite aid when something else seeds it
-   (tests, future create wiring).
-3. **No sticky site/token restore from mapping** — even when a mapping row has
-   `SiteURL` / `TokenValue` / channel ids, GET/DELETE still go through normal
-   channel selection (`PrepareCtx` + router). Sticky pin is future work.
-4. **Stub mode** — when upstream is unconfigured and proxy stub is enabled,
-   GET/DELETE return the generic stub JSON (non-404), same as other surfaces.
-   Production without upstream config still returns 503 from `dispatchUpstream`.
+1. **In-memory process-local store only** — no Redis / DB multi-instance video task store. Schema table `proxy_video_tasks` exists for future durability but is **not** written this wave.
+2. **No sticky site/token restore from mapping** — even when a mapping row has `SiteURL` / `TokenValue` / channel ids, GET/DELETE still go through normal channel selection (`PrepareCtx` + router). Sticky pin is future work.
+3. **Stub mode** — when upstream is unconfigured and proxy stub is enabled, create returns generic stub JSON without mapping rewrite (no selected channel). Production without upstream config still returns 503 from `dispatchUpstream`.
+4. **Response fields other than `id`** — only top-level `id` is rewritten; nested ids (if any) are left as upstream sent them.
 
 ## TS parity note
 
-TS MetAPI saves mapping on create and rewrites `id` in the create response, then
-uses the mapping on GET/DELETE. Go currently only has the optional mapping
-helpers + passthrough path rewrite. Closing the create-side mapping + id rewrite
-is a separate follow-up, not required for honest GET/DELETE.
+TS MetAPI saves mapping on create and rewrites `id` in the create response, then uses the mapping on GET/DELETE. Go now matches the create-side process-local mapping + id rewrite path; durable multi-instance store and sticky pin remain residual (same honesty bar as sticky/admin tasks).
 
 ## Tests
 
 | Case | Expectation |
 |------|-------------|
-| GET with mapping | 200 stub (or upstream); path may use UpstreamVideoID |
-| GET without mapping (auth ok) | **not** hard 404; stub/upstream path proceeds |
-| DELETE with mapping | local mapping cleared; dispatchUpstream (stub non-404) |
-| DELETE without mapping | **not** hard 404; dispatchUpstream proceeds |
-| Create model required / multipart | unchanged |
+| Create with mock upstream | 200; body `id` is `video_*`; raw upstream id not present; mapping saved |
+| Multipart create forwards form | same rewrite + mapping |
+| GET with mapping | path may use UpstreamVideoID; no hard 404 |
+| GET without mapping | not hard 404; stub/upstream proceeds |
+| Non-videos success body | rewrite helper no-ops |
 
 Verify:
 
 ```bash
-go test ./handler/proxy -count=1 -run Video
+go test ./handler/proxy -count=1 -run 'Video|Videos'
 ```

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -623,6 +623,8 @@ func dispatchEndpointAttemptWithContinue(
 	}
 	recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, usage)
 	writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, false, usage, retry, requestID)
+	// Videos create (#235): map upstream id → publicId before the client sees the body.
+	respBody = maybeRewriteVideosCreateResponse(ctx, selected, upstreamPath, respBody)
 	relayBufferedUpstreamResponse(w, resp, respBody)
 	observeProxyTerminal(ctx, shared.OutcomeSuccess, false, time.Duration(latencyMs)*time.Millisecond)
 	return true, nil, false

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -3,6 +3,7 @@ package proxyhandler
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -538,9 +539,27 @@ func TestVideosCreateMultipartForwardsFormToUpstream(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
-	if body := rec.Body.String(); !strings.Contains(body, "vid_123") {
-		t.Fatalf("body = %q, want upstream response", body)
+	// Create rewrites upstream id → publicId (#235); raw upstream id must not leak.
+	bodyStr := rec.Body.String()
+	if strings.Contains(bodyStr, "vid_123") {
+		t.Fatalf("body = %q, must not expose raw upstream id after publicId rewrite", bodyStr)
 	}
+	var out map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, bodyStr)
+	}
+	publicID, _ := out["id"].(string)
+	if publicID == "" || !strings.HasPrefix(publicID, "video_") {
+		t.Fatalf("public id = %q, want video_*", publicID)
+	}
+	task := GetProxyVideoTaskByPublicID(publicID)
+	if task == nil {
+		t.Fatalf("expected mapping for publicId %q", publicID)
+	}
+	if task.UpstreamVideoID != "vid_123" {
+		t.Fatalf("UpstreamVideoID = %q, want vid_123", task.UpstreamVideoID)
+	}
+	t.Cleanup(func() { DeleteProxyVideoTaskByPublicID(publicID) })
 }
 
 func TestSiteConcurrencySaturateSkipsWithoutFailure(t *testing.T) {

--- a/handler/proxy/videos.go
+++ b/handler/proxy/videos.go
@@ -1,18 +1,26 @@
 package proxyhandler
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/tokendancelab/metapi-go/routing"
 )
 
 // ProxyVideoTask holds a video task mapping (publicId -> upstreamVideoId).
 //
-// Residual (#225): Create currently dispatches upstream but does not save this
-// mapping or rewrite response id. GET/DELETE therefore treat the local store as
-// an optional rewrite aid, not a hard gate — missing entries pass the client id
-// through to upstream. See docs/analysis/videos-proxy-residual.md.
+// Create (#235) saves a process-local mapping on successful POST /v1/videos and
+// rewrites the response `id` to publicId. GET/DELETE treat the local store as
+// an optional rewrite aid, not a hard gate — missing entries still pass the
+// client id through to upstream. Multi-instance durable DB store and sticky
+// site/token pin remain residual. See docs/analysis/videos-proxy-residual.md.
 type ProxyVideoTask struct {
 	PublicID        string `json:"publicId"`
 	UpstreamVideoID string `json:"upstreamVideoId"`
@@ -32,9 +40,8 @@ var (
 // HandleVideosCreate handles POST /v1/videos.
 // Supports multipart/form-data or JSON body. Model is required.
 //
-// Residual: does not yet persist ProxyVideoTask or rewrite upstream response id
-// to a publicId. Clients that receive an upstream id can still GET/DELETE it via
-// honest passthrough when the local mapping is absent.
+// On successful non-stream upstream 2xx, dispatch rewrites response `id` to a
+// generated publicId and SaveProxyVideoTask (process-local). See #235.
 func HandleVideosCreate(w http.ResponseWriter, r *http.Request) {
 	EnsureMultipartBufferParser()
 
@@ -128,16 +135,26 @@ func resolveVideoUpstreamID(publicID string) string {
 
 // SaveProxyVideoTask saves a video task mapping.
 func SaveProxyVideoTask(task *ProxyVideoTask) {
+	if task == nil || strings.TrimSpace(task.PublicID) == "" {
+		return
+	}
 	videoTaskStoreMu.Lock()
 	defer videoTaskStoreMu.Unlock()
-	videoTaskStore[task.PublicID] = task
+	// Store a copy so callers cannot mutate the map entry after return.
+	cp := *task
+	videoTaskStore[cp.PublicID] = &cp
 }
 
 // GetProxyVideoTaskByPublicID retrieves a video task by publicId.
 func GetProxyVideoTaskByPublicID(publicID string) *ProxyVideoTask {
 	videoTaskStoreMu.RLock()
 	defer videoTaskStoreMu.RUnlock()
-	return videoTaskStore[publicID]
+	task := videoTaskStore[publicID]
+	if task == nil {
+		return nil
+	}
+	cp := *task
+	return &cp
 }
 
 // DeleteProxyVideoTaskByPublicID deletes a video task by publicId.
@@ -145,4 +162,69 @@ func DeleteProxyVideoTaskByPublicID(publicID string) {
 	videoTaskStoreMu.Lock()
 	defer videoTaskStoreMu.Unlock()
 	delete(videoTaskStore, publicID)
+}
+
+// maybeRewriteVideosCreateResponse rewrites a successful POST /v1/videos body so
+// clients see an opaque publicId, and seeds the process-local mapping used by
+// GET/DELETE path rewrite. Best-effort: any parse/shape miss returns body unchanged.
+//
+// Multi-instance durable store and sticky site pin are residual (#235 follow-ups).
+func maybeRewriteVideosCreateResponse(
+	ctx *Ctx,
+	selected *routing.SelectedChannel,
+	upstreamPath string,
+	body []byte,
+) []byte {
+	if ctx == nil || selected == nil || len(body) == 0 {
+		return body
+	}
+	path := strings.TrimSpace(upstreamPath)
+	if path == "" {
+		path = strings.TrimSpace(ctx.DownstreamPath)
+	}
+	path = strings.TrimSuffix(path, "/")
+	if !strings.EqualFold(path, "/v1/videos") {
+		return body
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return body
+	}
+	upstreamID, _ := payload["id"].(string)
+	upstreamID = strings.TrimSpace(upstreamID)
+	if upstreamID == "" {
+		return body
+	}
+
+	publicID := newPublicVideoID()
+	actualModel := selected.ActualModel
+	if actualModel == "" {
+		actualModel = ctx.RequestedModel
+	}
+	SaveProxyVideoTask(&ProxyVideoTask{
+		PublicID:        publicID,
+		UpstreamVideoID: upstreamID,
+		SiteURL:         selected.Site.URL,
+		TokenValue:      selected.TokenValue,
+		RequestedModel:  ctx.RequestedModel,
+		ActualModel:     actualModel,
+		ChannelID:       selected.Channel.ID,
+		AccountID:       selected.Account.ID,
+	})
+
+	payload["id"] = publicID
+	out, err := json.Marshal(payload)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+func newPublicVideoID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "video_" + strconv.FormatInt(time.Now().UnixNano(), 16)
+	}
+	return "video_" + hex.EncodeToString(b[:])
 }

--- a/handler/proxy/videos_test.go
+++ b/handler/proxy/videos_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/store"
 )
 
 // chiRouterForVideo creates a chi router that registers video routes with auth injection.
@@ -35,12 +37,95 @@ func TestHandleVideosCreate_JSONBody(t *testing.T) {
 	}
 
 	// With upstream forwarding not wired, stub returns generic response.
+	// Stub path does not rewrite publicId (no selected channel).
 	m := unmarshalResponse(t, rec)
 	if m == nil {
 		t.Fatal("expected non-nil response")
 	}
 	if m["model"] != "sora-2" {
 		t.Errorf("model = %v", m["model"])
+	}
+}
+
+func TestHandleVideosCreate_RewritesPublicIDAndSavesMapping(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/videos" {
+			t.Fatalf("upstream path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"upstream_vid_abc","object":"video","status":"queued"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:     store.RouteChannel{ID: 99, Enabled: true},
+			Account:     store.Account{ID: 11, Status: "active"},
+			Site:        store.Site{ID: 5, URL: upstream.URL, Status: "active"},
+			TokenValue:  "sk-video-create",
+			ActualModel: "sora-upstream",
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	r := chiRouterForVideo()
+	req := makeProxyReq("POST", "/v1/videos", `{"model":"sora-2","prompt":"a cat"}`)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	m := unmarshalResponse(t, rec)
+	publicID, _ := m["id"].(string)
+	if publicID == "" || publicID == "upstream_vid_abc" {
+		t.Fatalf("expected rewritten publicId, got %q body=%v", publicID, m)
+	}
+	if !strings.HasPrefix(publicID, "video_") {
+		t.Fatalf("publicId prefix: %q", publicID)
+	}
+	if m["object"] != "video" {
+		t.Fatalf("object = %v", m["object"])
+	}
+
+	task := GetProxyVideoTaskByPublicID(publicID)
+	if task == nil {
+		t.Fatal("expected mapping saved")
+	}
+	t.Cleanup(func() { DeleteProxyVideoTaskByPublicID(publicID) })
+	if task.UpstreamVideoID != "upstream_vid_abc" {
+		t.Fatalf("UpstreamVideoID = %q", task.UpstreamVideoID)
+	}
+	if task.ChannelID != 99 || task.AccountID != 11 {
+		t.Fatalf("channel/account = %d/%d", task.ChannelID, task.AccountID)
+	}
+	if task.TokenValue != "sk-video-create" {
+		t.Fatalf("TokenValue = %q", task.TokenValue)
+	}
+	if task.RequestedModel != "sora-2" || task.ActualModel != "sora-upstream" {
+		t.Fatalf("models requested=%q actual=%q", task.RequestedModel, task.ActualModel)
+	}
+
+	// resolve path uses UpstreamVideoID for subsequent GET.
+	if got := resolveVideoUpstreamID(publicID); got != "upstream_vid_abc" {
+		t.Fatalf("resolve = %q", got)
+	}
+}
+
+func TestMaybeRewriteVideosCreateResponse_NonVideosPathUnchanged(t *testing.T) {
+	body := []byte(`{"id":"chatcmpl-1"}`)
+	out := maybeRewriteVideosCreateResponse(
+		&Ctx{DownstreamPath: "/v1/chat/completions", RequestedModel: "gpt"},
+		&routing.SelectedChannel{
+			Channel: store.RouteChannel{ID: 1},
+			Account: store.Account{ID: 2},
+			Site:    store.Site{URL: "https://example.test"},
+		},
+		"/v1/chat/completions",
+		body,
+	)
+	if string(out) != string(body) {
+		t.Fatalf("chat body rewritten unexpectedly: %s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Successful POST /v1/videos rewrites response id to opaque video_<hex> publicId
- Saves process-local ProxyVideoTask (upstream id + site/token/channel/account/model)
- GET/DELETE continue optional mapping rewrite; missing map still passthrough
- Residual doc updated (docs/analysis/videos-proxy-residual.md)

Closes #235

## Test plan
- [x] go test ./handler/proxy -count=1 -run 'Video|Videos'