### PR TITLE
feat(proxy): durable proxy_video_tasks store for publicId mapping (#244)

### DIFF
--- a/docs/analysis/videos-proxy-residual.md
+++ b/docs/analysis/videos-proxy-residual.md
@@ -1,72 +1,60 @@
-# Residual: Videos proxy publicId mapping (#225 / #235)
+# Residual: Videos proxy publicId mapping (#225 / #235 / #244)
 
 **Date**: 2026-07-17  
-**Issues**: [#225](https://github.com/TokenDanceLab/metapi-go/issues/225) (GET/DELETE passthrough), [#235](https://github.com/TokenDanceLab/metapi-go/issues/235) (create mapping)  
-**Lane**: p87 / videos create rewrite  
+**Issues**: [#225](https://github.com/TokenDanceLab/metapi-go/issues/225) (GET/DELETE passthrough), [#235](https://github.com/TokenDanceLab/metapi-go/issues/235) (create rewrite), [#244](https://github.com/TokenDanceLab/metapi-go/issues/244) (durable store)  
+**Lane**: p88 / videos durable mapping  
 **SSOT code**: `handler/proxy/videos.go`, success hook in `handler/proxy/upstream.go`
 
 ## Goal
 
 1. **#225** — Stop store-gated theater on video GET/DELETE (missing map ≠ hard 404).
-2. **#235** — On successful create, save process-local `ProxyVideoTask` and rewrite response `id` to opaque `publicId`.
+2. **#235** — On successful create, generate opaque `publicId`, rewrite response `id`, save mapping.
+3. **#244** — Dual-write mapping to `proxy_video_tasks` so multi-instance / restart can resolve publicId.
 
-## Behavior after #235
+## Behavior after #244
 
 | Surface | Behavior |
 |---------|----------|
-| `POST /v1/videos` | `PrepareCtx` + `dispatchUpstream`. On **non-stream buffered 2xx**, parse upstream JSON `id`, generate `video_<hex>`, `SaveProxyVideoTask`, rewrite body `id` → publicId. Parse miss / non-JSON → body unchanged (best-effort). |
-| `GET /v1/videos/{id}` | Always dispatch. If local mapping exists and `UpstreamVideoID` differs from `{id}`, path uses `UpstreamVideoID`; otherwise `{id}` passthrough. **Missing mapping is not a 404.** |
-| `DELETE /v1/videos/{id}` | Delete local mapping if present. Always dispatch DELETE with same path rewrite rule. Prefer upstream status over local-only 204. |
+| `POST /v1/videos` | On **non-stream buffered 2xx**, parse upstream JSON `id`, generate `video_<hex>`, rewrite body `id`, `SaveProxyVideoTask` → memory + `INSERT … ON CONFLICT(public_id) DO UPDATE` when `store.GetDB()` set. |
+| `GET /v1/videos/{id}` | Resolve via memory, then durable `proxy_video_tasks` cold load. Path rewrite if UpstreamVideoID differs. Missing map → passthrough (no hard 404). |
+| `DELETE /v1/videos/{id}` | Clear memory + `DELETE FROM proxy_video_tasks`, then always dispatch DELETE. |
+
+### Storage layers
+
+```
+Save:  memory map  +  best-effort DB upsert (log warn on DB failure; memory still set)
+Get:   memory hit  → return; miss → SELECT by public_id → warm memory
+Delete: memory delete + best-effort DB delete
+```
+
+When DB is nil (unit tests without OverrideDB / unbootstrapped process), behavior degrades to process-local memory only (#235).
 
 ### Create rewrite rule
 
 ```
-on success POST /v1/videos (path equal, ignore trailing slash):
-  upstreamID = JSON.body.id (string, non-empty)
+on success POST /v1/videos:
+  upstreamID = JSON.body.id
   publicID   = "video_" + hex(16 random bytes)
-  SaveProxyVideoTask({
-    PublicID, UpstreamVideoID: upstreamID,
-    SiteURL, TokenValue, RequestedModel, ActualModel,
-    ChannelID, AccountID
-  })
+  SaveProxyVideoTask({PublicID, UpstreamVideoID, SiteURL, TokenValue, models, channel, account})
   body.id = publicID
-```
-
-### Path rewrite rule (GET/DELETE)
-
-```
-upstreamPathID = publicID
-if mapping[publicID] exists
-  and UpstreamVideoID != ""
-  and UpstreamVideoID != publicID:
-    upstreamPathID = UpstreamVideoID
-
-DownstreamPath = "/v1/videos/" + upstreamPathID
 ```
 
 ## What is still residual (not claimed)
 
-1. **In-memory process-local store only** — no Redis / DB multi-instance video task store. Schema table `proxy_video_tasks` exists for future durability but is **not** written this wave.
-2. **No sticky site/token restore from mapping** — even when a mapping row has `SiteURL` / `TokenValue` / channel ids, GET/DELETE still go through normal channel selection (`PrepareCtx` + router). Sticky pin is future work.
-3. **Stub mode** — when upstream is unconfigured and proxy stub is enabled, create returns generic stub JSON without mapping rewrite (no selected channel). Production without upstream config still returns 503 from `dispatchUpstream`.
-4. **Response fields other than `id`** — only top-level `id` is rewritten; nested ids (if any) are left as upstream sent them.
-
-## TS parity note
-
-TS MetAPI saves mapping on create and rewrites `id` in the create response, then uses the mapping on GET/DELETE. Go now matches the create-side process-local mapping + id rewrite path; durable multi-instance store and sticky pin remain residual (same honesty bar as sticky/admin tasks).
+1. **No sticky site/token restore from mapping** — GET/DELETE still use normal channel selection; mapping fields SiteURL/TokenValue are stored for future pin work only.
+2. **Stub mode** — unconfigured upstream + stub does not rewrite publicId (no selected channel).
+3. **TTL / GC** — no retention job for stale `proxy_video_tasks` rows this wave.
+4. **TokenValue in DB** — same sensitivity as process memory mapping; operators must protect DB backups.
 
 ## Tests
 
 | Case | Expectation |
 |------|-------------|
-| Create with mock upstream | 200; body `id` is `video_*`; raw upstream id not present; mapping saved |
-| Multipart create forwards form | same rewrite + mapping |
-| GET with mapping | path may use UpstreamVideoID; no hard 404 |
-| GET without mapping | not hard 404; stub/upstream proceeds |
+| Create with mock upstream | rewritten publicId + mapping |
+| DB durable round-trip | save → clear memory → get loads from DB |
+| GET without mapping | not hard 404 |
 | Non-videos success body | rewrite helper no-ops |
 
-Verify:
-
 ```bash
-go test ./handler/proxy -count=1 -run 'Video|Videos'
+go test ./handler/proxy -count=1 -run 'Video|Videos|ProxyVideo'
 ```

--- a/handler/proxy/videos.go
+++ b/handler/proxy/videos.go
@@ -2,8 +2,11 @@ package proxyhandler
 
 import (
 	"crypto/rand"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -12,15 +15,17 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/store"
 )
 
 // ProxyVideoTask holds a video task mapping (publicId -> upstreamVideoId).
 //
-// Create (#235) saves a process-local mapping on successful POST /v1/videos and
-// rewrites the response `id` to publicId. GET/DELETE treat the local store as
-// an optional rewrite aid, not a hard gate — missing entries still pass the
-// client id through to upstream. Multi-instance durable DB store and sticky
-// site/token pin remain residual. See docs/analysis/videos-proxy-residual.md.
+// Create (#235/#244) saves a process-local cache entry and dual-writes to
+// `proxy_video_tasks` when store.GetDB() is available so multi-instance /
+// restart can resolve publicId. GET/DELETE treat the store as an optional
+// rewrite aid, not a hard gate — missing entries still pass the client id
+// through to upstream. Sticky site/token pin remains residual.
+// See docs/analysis/videos-proxy-residual.md.
 type ProxyVideoTask struct {
 	PublicID        string `json:"publicId"`
 	UpstreamVideoID string `json:"upstreamVideoId"`
@@ -133,35 +138,184 @@ func resolveVideoUpstreamID(publicID string) string {
 	return publicID
 }
 
-// SaveProxyVideoTask saves a video task mapping.
+// SaveProxyVideoTask saves a video task mapping to the process-local cache and
+// dual-writes to proxy_video_tasks when a runtime DB is available (#244).
 func SaveProxyVideoTask(task *ProxyVideoTask) {
 	if task == nil || strings.TrimSpace(task.PublicID) == "" {
 		return
 	}
-	videoTaskStoreMu.Lock()
-	defer videoTaskStoreMu.Unlock()
 	// Store a copy so callers cannot mutate the map entry after return.
 	cp := *task
+	cp.PublicID = strings.TrimSpace(cp.PublicID)
+	cp.UpstreamVideoID = strings.TrimSpace(cp.UpstreamVideoID)
+
+	videoTaskStoreMu.Lock()
 	videoTaskStore[cp.PublicID] = &cp
+	videoTaskStoreMu.Unlock()
+
+	if err := upsertProxyVideoTaskDB(&cp); err != nil {
+		slog.Warn("proxy video task: durable upsert failed (memory cache still set)",
+			"public_id", cp.PublicID, "error", err)
+	}
 }
 
 // GetProxyVideoTaskByPublicID retrieves a video task by publicId.
+// Memory cache first; cold miss falls back to proxy_video_tasks (#244).
 func GetProxyVideoTaskByPublicID(publicID string) *ProxyVideoTask {
-	videoTaskStoreMu.RLock()
-	defer videoTaskStoreMu.RUnlock()
-	task := videoTaskStore[publicID]
-	if task == nil {
+	publicID = strings.TrimSpace(publicID)
+	if publicID == "" {
 		return nil
 	}
-	cp := *task
+	videoTaskStoreMu.RLock()
+	task := videoTaskStore[publicID]
+	if task != nil {
+		cp := *task
+		videoTaskStoreMu.RUnlock()
+		return &cp
+	}
+	videoTaskStoreMu.RUnlock()
+
+	loaded, err := loadProxyVideoTaskDB(publicID)
+	if err != nil {
+		slog.Debug("proxy video task: durable load failed", "public_id", publicID, "error", err)
+		return nil
+	}
+	if loaded == nil {
+		return nil
+	}
+	// Warm process-local cache.
+	videoTaskStoreMu.Lock()
+	videoTaskStore[loaded.PublicID] = loaded
+	videoTaskStoreMu.Unlock()
+	cp := *loaded
 	return &cp
 }
 
-// DeleteProxyVideoTaskByPublicID deletes a video task by publicId.
+// DeleteProxyVideoTaskByPublicID deletes a video task by publicId (memory + DB).
 func DeleteProxyVideoTaskByPublicID(publicID string) {
+	publicID = strings.TrimSpace(publicID)
+	if publicID == "" {
+		return
+	}
 	videoTaskStoreMu.Lock()
-	defer videoTaskStoreMu.Unlock()
 	delete(videoTaskStore, publicID)
+	videoTaskStoreMu.Unlock()
+
+	if err := deleteProxyVideoTaskDB(publicID); err != nil {
+		slog.Warn("proxy video task: durable delete failed", "public_id", publicID, "error", err)
+	}
+}
+
+func upsertProxyVideoTaskDB(task *ProxyVideoTask) error {
+	db := store.GetDB()
+	if db == nil || task == nil {
+		return nil
+	}
+	if strings.TrimSpace(task.PublicID) == "" || strings.TrimSpace(task.UpstreamVideoID) == "" {
+		return nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	// store.DB rebinds ? → $N for postgres.
+	const q = `
+INSERT INTO proxy_video_tasks (
+	public_id, upstream_video_id, site_url, token_value,
+	requested_model, actual_model, channel_id, account_id,
+	created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(public_id) DO UPDATE SET
+	upstream_video_id = excluded.upstream_video_id,
+	site_url = excluded.site_url,
+	token_value = excluded.token_value,
+	requested_model = excluded.requested_model,
+	actual_model = excluded.actual_model,
+	channel_id = excluded.channel_id,
+	account_id = excluded.account_id,
+	updated_at = excluded.updated_at
+`
+	var reqModel, actModel any
+	if strings.TrimSpace(task.RequestedModel) != "" {
+		reqModel = task.RequestedModel
+	}
+	if strings.TrimSpace(task.ActualModel) != "" {
+		actModel = task.ActualModel
+	}
+	var channelID, accountID any
+	if task.ChannelID > 0 {
+		channelID = task.ChannelID
+	}
+	if task.AccountID > 0 {
+		accountID = task.AccountID
+	}
+	_, err := db.Exec(q,
+		task.PublicID,
+		task.UpstreamVideoID,
+		task.SiteURL,
+		task.TokenValue,
+		reqModel,
+		actModel,
+		channelID,
+		accountID,
+		now,
+		now,
+	)
+	return err
+}
+
+func loadProxyVideoTaskDB(publicID string) (*ProxyVideoTask, error) {
+	db := store.GetDB()
+	if db == nil {
+		return nil, nil
+	}
+	const q = `
+SELECT public_id, upstream_video_id, site_url, token_value,
+       requested_model, actual_model, channel_id, account_id
+FROM proxy_video_tasks
+WHERE public_id = ?
+LIMIT 1
+`
+	var (
+		rowPublic, upstream, siteURL, token string
+		reqModel, actModel                  *string
+		channelID, accountID                *int64
+	)
+	err := db.QueryRow(q, publicID).Scan(
+		&rowPublic, &upstream, &siteURL, &token,
+		&reqModel, &actModel, &channelID, &accountID,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	task := &ProxyVideoTask{
+		PublicID:        rowPublic,
+		UpstreamVideoID: upstream,
+		SiteURL:         siteURL,
+		TokenValue:      token,
+	}
+	if reqModel != nil {
+		task.RequestedModel = *reqModel
+	}
+	if actModel != nil {
+		task.ActualModel = *actModel
+	}
+	if channelID != nil {
+		task.ChannelID = *channelID
+	}
+	if accountID != nil {
+		task.AccountID = *accountID
+	}
+	return task, nil
+}
+
+func deleteProxyVideoTaskDB(publicID string) error {
+	db := store.GetDB()
+	if db == nil {
+		return nil
+	}
+	_, err := db.Exec(`DELETE FROM proxy_video_tasks WHERE public_id = ?`, publicID)
+	return err
 }
 
 // maybeRewriteVideosCreateResponse rewrites a successful POST /v1/videos body so

--- a/handler/proxy/videos_test.go
+++ b/handler/proxy/videos_test.go
@@ -415,3 +415,57 @@ func TestProxyVideoTask_SiteURLAndToken(t *testing.T) {
 
 var _ = json.Marshal
 var _ = http.MethodPost
+
+func TestProxyVideoTask_DBDurableRoundTrip(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	store.OverrideDB(db)
+	t.Cleanup(func() { store.OverrideDB(nil) })
+
+	publicID := "video_db_roundtrip_1"
+	// Ensure memory empty for cold load path after save+clear memory.
+	SaveProxyVideoTask(&ProxyVideoTask{
+		PublicID:        publicID,
+		UpstreamVideoID: "up_db_999",
+		SiteURL:         "https://upstream.example.test",
+		TokenValue:      "sk-db",
+		RequestedModel:  "sora-2",
+		ActualModel:     "sora-up",
+		ChannelID:       7,
+		AccountID:       8,
+	})
+	// Drop memory only (simulate other process / restart) without deleting DB.
+	videoTaskStoreMu.Lock()
+	delete(videoTaskStore, publicID)
+	videoTaskStoreMu.Unlock()
+
+	got := GetProxyVideoTaskByPublicID(publicID)
+	if got == nil {
+		t.Fatal("expected durable load from proxy_video_tasks")
+	}
+	if got.UpstreamVideoID != "up_db_999" {
+		t.Fatalf("UpstreamVideoID=%q", got.UpstreamVideoID)
+	}
+	if got.ChannelID != 7 || got.AccountID != 8 {
+		t.Fatalf("ids channel=%d account=%d", got.ChannelID, got.AccountID)
+	}
+	if got.TokenValue != "sk-db" {
+		t.Fatalf("token=%q", got.TokenValue)
+	}
+	// Second get hits warm cache.
+	got2 := GetProxyVideoTaskByPublicID(publicID)
+	if got2 == nil || got2.UpstreamVideoID != "up_db_999" {
+		t.Fatalf("cache warm failed: %+v", got2)
+	}
+
+	DeleteProxyVideoTaskByPublicID(publicID)
+	if GetProxyVideoTaskByPublicID(publicID) != nil {
+		t.Fatal("expected deleted from memory+db")
+	}
+}


### PR DESCRIPTION
## Summary
- Dual-write `SaveProxyVideoTask` to `proxy_video_tasks` (UPSERT on public_id)
- Cold `Get` falls back to DB and warms process cache
- Delete clears memory + DB
- Residual doc updated for #244

Closes #244

## Test plan
- [x] `go test ./handler/proxy -count=1 -run 'Video|Videos|ProxyVideo'`