### PR TITLE
feat(auth): TPM multi-instance Redis sharing (#245)

### DIFF
--- a/auth/key_admission.go
+++ b/auth/key_admission.go
@@ -12,7 +12,8 @@ import (
 
 // KeyAdmissionLimiter is an in-process sliding-window RPM/TPM gate for
 // managed downstream keys (learn #116). Default unlimited when limits are nil/<=0.
-// Multi-instance deployments need shared state (#118) — this is process-local.
+// Multi-instance deployments optionally share RPM/TPM via WindowCounter (#118, #245).
+// Snapshot() remains process-local (residual).
 type KeyAdmissionLimiter struct {
 	mu   sync.Mutex
 	keys map[int64]*keyWindow
@@ -21,6 +22,10 @@ type KeyAdmissionLimiter struct {
 	// sharedRPM is optional multi-instance counter (#118). nil = memory-only.
 	// Fail-open: Redis errors fall back to local window.
 	sharedRPM sharedcount.WindowCounter
+	// sharedTPM is optional multi-instance token counter (#245). nil = memory-only.
+	// Typically the same RedisCounter instance as sharedRPM.
+	// Fail-open: Redis errors fall back to local tokenEvents.
+	sharedTPM sharedcount.WindowCounter
 }
 
 type keyWindow struct {
@@ -57,22 +62,38 @@ func (l *KeyAdmissionLimiter) SetSharedRPMCounter(c sharedcount.WindowCounter) {
 	l.sharedRPM = c
 }
 
-// ConfigureSharedAdmissionFromRedisURL enables Redis-backed RPM counting when url is non-empty.
+// SetSharedTPMCounter wires an optional multi-instance token counter (#245).
+// Pass nil to clear (memory-only). Safe to call at process startup.
+// May reuse the same WindowCounter instance as SetSharedRPMCounter.
+func (l *KeyAdmissionLimiter) SetSharedTPMCounter(c sharedcount.WindowCounter) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.sharedTPM = c
+}
+
+// ConfigureSharedAdmissionFromRedisURL enables Redis-backed RPM+TPM counting when url is non-empty.
+// Both counters share one RedisCounter instance (distinct key namespaces).
 // On parse/dial setup failure, logs and keeps memory-only. Runtime Redis errors fail open.
 func ConfigureSharedAdmissionFromRedisURL(redisURL string) {
 	redisURL = strings.TrimSpace(redisURL)
 	if redisURL == "" {
 		GlobalKeyAdmission.SetSharedRPMCounter(nil)
+		GlobalKeyAdmission.SetSharedTPMCounter(nil)
 		return
 	}
 	rc, err := sharedcount.NewRedisCounter(redisURL)
 	if err != nil {
 		slog.Warn("redis admission: disabled (bad REDIS_URL)", "error", err)
 		GlobalKeyAdmission.SetSharedRPMCounter(nil)
+		GlobalKeyAdmission.SetSharedTPMCounter(nil)
 		return
 	}
 	GlobalKeyAdmission.SetSharedRPMCounter(rc)
-	slog.Info("redis admission: shared RPM counter enabled")
+	GlobalKeyAdmission.SetSharedTPMCounter(rc)
+	slog.Info("redis admission: shared RPM+TPM counters enabled")
 }
 
 // ResetKeyAdmissionForTest clears the global limiter state.
@@ -128,13 +149,13 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 	usedTPM := sumTokens(w.tokenEvents)
 
 	// Optional multi-instance RPM (#118). Fail-open on errors.
-	sharedCounted := false
+	sharedRPMCounted := false
 	if rpmLimit > 0 && l.sharedRPM != nil {
 		n, err := l.sharedRPM.Incr(context.Background(), rpmSharedKey(keyID), time.Minute)
 		if err != nil {
 			slog.Debug("redis admission: fail-open on error", "key_id", keyID, "error", err)
 		} else {
-			sharedCounted = true
+			sharedRPMCounted = true
 			usedRPM = n
 			if n > rpmLimit {
 				return AdmissionDecision{
@@ -148,7 +169,7 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 		}
 	}
 
-	if !sharedCounted && rpmLimit > 0 && usedRPM >= rpmLimit {
+	if !sharedRPMCounted && rpmLimit > 0 && usedRPM >= rpmLimit {
 		retry := retryAfterMs(w.reqTimes, nowMs)
 		return AdmissionDecision{
 			Allowed:    false,
@@ -158,7 +179,29 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 			UsedTPM:    usedTPM,
 		}
 	}
-	if tpmLimit > 0 && estimatedTokens > 0 && usedTPM+estimatedTokens > tpmLimit {
+
+	// Optional multi-instance TPM (#245). Fail-open on errors.
+	sharedTPMCounted := false
+	if tpmLimit > 0 && estimatedTokens > 0 && l.sharedTPM != nil {
+		n, err := l.sharedTPM.IncrBy(context.Background(), tpmSharedKey(keyID), estimatedTokens, time.Minute)
+		if err != nil {
+			slog.Debug("redis admission tpm: fail-open on error", "key_id", keyID, "error", err)
+		} else {
+			sharedTPMCounted = true
+			usedTPM = n
+			if n > tpmLimit {
+				return AdmissionDecision{
+					Allowed:    false,
+					Reason:     "over_tpm",
+					RetryAfter: time.Second,
+					UsedRPM:    usedRPM,
+					UsedTPM:    usedTPM,
+				}
+			}
+		}
+	}
+
+	if !sharedTPMCounted && tpmLimit > 0 && estimatedTokens > 0 && usedTPM+estimatedTokens > tpmLimit {
 		retry := retryAfterTokenMs(w.tokenEvents, nowMs)
 		return AdmissionDecision{
 			Allowed:    false,
@@ -169,15 +212,23 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 		}
 	}
 
-	// reserve
+	// reserve (process-local residual for Snapshot)
 	w.reqTimes = append(w.reqTimes, nowMs)
 	if estimatedTokens > 0 && tpmLimit > 0 {
 		w.tokenEvents = append(w.tokenEvents, tokenEvent{atMs: nowMs, tokens: estimatedTokens})
 	}
+	outRPM := usedRPM
+	if !sharedRPMCounted {
+		outRPM = usedRPM + 1
+	}
+	outTPM := usedTPM
+	if !sharedTPMCounted {
+		outTPM = usedTPM + max64z(estimatedTokens, 0)
+	}
 	return AdmissionDecision{
 		Allowed: true,
-		UsedRPM: usedRPM + 1,
-		UsedTPM: usedTPM + max64z(estimatedTokens, 0),
+		UsedRPM: outRPM,
+		UsedTPM: outTPM,
 	}
 }
 
@@ -273,4 +324,8 @@ func max64z(v, floor int64) int64 {
 
 func rpmSharedKey(keyID int64) string {
 	return "metapi:rpm:" + formatInt64(keyID)
+}
+
+func tpmSharedKey(keyID int64) string {
+	return "metapi:tpm:" + formatInt64(keyID)
 }

--- a/auth/key_admission_shared_test.go
+++ b/auth/key_admission_shared_test.go
@@ -20,6 +20,16 @@ func (f *fakeWindow) Incr(ctx context.Context, key string, window time.Duration)
 	return f.n, nil
 }
 
+func (f *fakeWindow) IncrBy(ctx context.Context, key string, delta int64, window time.Duration) (int64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	if delta > 0 {
+		f.n += delta
+	}
+	return f.n, nil
+}
+
 func (f *fakeWindow) Get(ctx context.Context, key string) (int64, error) {
 	return f.n, f.err
 }
@@ -48,5 +58,41 @@ func TestKeyAdmission_SharedRPM_FailOpen(t *testing.T) {
 	// Should not hard-fail; local path allows.
 	if d := l.Allow(2, &limit, nil, 0); !d.Allowed {
 		t.Fatalf("fail-open expected allow: %#v", d)
+	}
+}
+
+func TestKeyAdmission_SharedTPM(t *testing.T) {
+	l := NewKeyAdmissionLimiter()
+	fw := &fakeWindow{}
+	l.SetSharedTPMCounter(fw)
+	tpm := int64(1000)
+	d := l.Allow(11, nil, &tpm, 600)
+	if !d.Allowed {
+		t.Fatalf("1: %#v", d)
+	}
+	if d.UsedTPM != 600 {
+		t.Fatalf("used tpm want 600 got %d", d.UsedTPM)
+	}
+	// 400 fits (600+400=1000); shared IncrBy-before-check semantics (same as RPM).
+	if d := l.Allow(11, nil, &tpm, 400); !d.Allowed {
+		t.Fatalf("2 should allow 400 after 600: %#v", d)
+	}
+	if d := l.Allow(11, nil, &tpm, 1); d.Allowed || d.Reason != "over_tpm" {
+		t.Fatalf("3 should deny over_tpm: %#v", d)
+	}
+}
+
+func TestKeyAdmission_SharedTPM_FailOpen(t *testing.T) {
+	l := NewKeyAdmissionLimiter()
+	fw := &fakeWindow{err: errors.New("redis down")}
+	l.SetSharedTPMCounter(fw)
+	tpm := int64(1000)
+	// Fail-open to local tokenEvents — first 600 should allow.
+	if d := l.Allow(12, nil, &tpm, 600); !d.Allowed {
+		t.Fatalf("fail-open expected allow: %#v", d)
+	}
+	// Local path still enforces after fail-open.
+	if d := l.Allow(12, nil, &tpm, 500); d.Allowed || d.Reason != "over_tpm" {
+		t.Fatalf("local over_tpm after fail-open: %#v", d)
 	}
 }

--- a/docs/analysis/redis-shared-state.md
+++ b/docs/analysis/redis-shared-state.md
@@ -1,21 +1,23 @@
-# Optional Redis shared state (#118)
+# Optional Redis shared state (#118, #245)
 
 ## Config
 - `REDIS_URL` or `METAPI_REDIS_URL` (empty = disabled)
 - Examples: `redis://127.0.0.1:6379/0`, `redis://:pass@host:6379/1`, `host:6379`
 
 ## What is shared
-- Downstream-key **RPM** admission counters (`metapi:rpm:{keyID}`) via fixed-window INCR+PEXPIRE.
+- Downstream-key **RPM** admission counters (`metapi:rpm:{keyID}`) via fixed-window `INCR` + `PEXPIRE`.
+- Downstream-key **TPM** admission counters (`metapi:tpm:{keyID}`) via fixed-window `INCRBY` + `PEXPIRE` (#245).
 - Implementation: `internal/sharedcount` (memory + minimal RESP Redis client, no third-party dep).
+- `ConfigureSharedAdmissionFromRedisURL` wires **both** RPM and TPM on the same `RedisCounter` instance (distinct key namespaces).
 
 ## Failure mode
 - **Fail-open**: if Redis is unreachable or returns errors at request time, admission falls back to process-local sliding window (same as #116).
 - Bad `REDIS_URL` at startup disables shared mode and logs a warning.
 
 ## Residual
-- TPM multi-instance sharing not yet wired.
+- `Snapshot()` remains **process-local** for both RPM and TPM (admin display may under-report multi-instance usage).
 - Channel cooldown remains DB-backed (`cooldown_until`); not moved to Redis.
-- Fixed-window Redis approximation differs slightly from local sliding window.
+- Fixed-window Redis approximation differs slightly from local sliding window (both RPM and TPM).
 
 ## Single-node
 Leave `REDIS_URL` empty. No Redis process required.

--- a/internal/sharedcount/counter.go
+++ b/internal/sharedcount/counter.go
@@ -11,11 +11,14 @@ import (
 )
 
 // WindowCounter increments a named key inside a sliding/fixed window and returns
-// the post-increment count. Used for multi-instance RPM admission (#118).
+// the post-increment count. Used for multi-instance RPM/TPM admission (#118, #245).
 type WindowCounter interface {
 	// Incr increments key by 1 within window and returns the new count.
 	// Implementations may approximate sliding windows with fixed TTL buckets.
 	Incr(ctx context.Context, key string, window time.Duration) (count int64, err error)
+	// IncrBy increments key by delta within window and returns the new total.
+	// Used for TPM token reservations (#245). delta<=0 returns the current total.
+	IncrBy(ctx context.Context, key string, delta int64, window time.Duration) (count int64, err error)
 	// Get returns the current count without incrementing.
 	Get(ctx context.Context, key string) (count int64, err error)
 }
@@ -28,7 +31,13 @@ type MemoryCounter struct {
 }
 
 type memWindow struct {
-	times []int64 // unix ms
+	times  []int64    // unix ms — unit Incr events (RPM)
+	points []memPoint // weighted IncrBy events (TPM)
+}
+
+type memPoint struct {
+	atMs  int64
+	delta int64
 }
 
 func NewMemoryCounter() *MemoryCounter {
@@ -59,6 +68,38 @@ func (m *MemoryCounter) Incr(ctx context.Context, key string, window time.Durati
 	}
 	w.times = append(w.times, nowMs)
 	return int64(len(w.times)), nil
+}
+
+func (m *MemoryCounter) IncrBy(ctx context.Context, key string, delta int64, window time.Duration) (int64, error) {
+	_ = ctx
+	if window <= 0 {
+		window = time.Minute
+	}
+	nowMs := m.now().UnixMilli()
+	start := nowMs - window.Milliseconds()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	w := m.keys[key]
+	if w == nil {
+		w = &memWindow{}
+		m.keys[key] = w
+	}
+	// prune
+	i := 0
+	for i < len(w.points) && w.points[i].atMs < start {
+		i++
+	}
+	if i > 0 {
+		w.points = append([]memPoint(nil), w.points[i:]...)
+	}
+	if delta > 0 {
+		w.points = append(w.points, memPoint{atMs: nowMs, delta: delta})
+	}
+	var sum int64
+	for _, p := range w.points {
+		sum += p.delta
+	}
+	return sum, nil
 }
 
 func (m *MemoryCounter) Get(ctx context.Context, key string) (int64, error) {
@@ -190,6 +231,34 @@ func (r *RedisCounter) Incr(ctx context.Context, key string, window time.Duratio
 		}
 		count = n
 		if n == 1 {
+			ms := strconv.FormatInt(window.Milliseconds(), 10)
+			if err := redisDo(conn, "PEXPIRE", key, ms); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return count, err
+}
+
+func (r *RedisCounter) IncrBy(ctx context.Context, key string, delta int64, window time.Duration) (int64, error) {
+	if window <= 0 {
+		window = time.Minute
+	}
+	if delta <= 0 {
+		// No reservation — read current total without changing TTL.
+		return r.Get(ctx, key)
+	}
+	var count int64
+	err := r.withConn(ctx, func(conn net.Conn) error {
+		// Fixed-window approximation: INCRBY + PEXPIRE when this is the first write
+		// in the window (post-increment equals delta ⇒ key was absent/0).
+		n, err := redisDoInt(conn, "INCRBY", key, strconv.FormatInt(delta, 10))
+		if err != nil {
+			return err
+		}
+		count = n
+		if n == delta {
 			ms := strconv.FormatInt(window.Milliseconds(), 10)
 			if err := redisDo(conn, "PEXPIRE", key, ms); err != nil {
 				return err

--- a/internal/sharedcount/memory_test.go
+++ b/internal/sharedcount/memory_test.go
@@ -25,6 +25,27 @@ func TestMemoryCounter_IncrWindow(t *testing.T) {
 	}
 }
 
+func TestMemoryCounter_IncrByWindow(t *testing.T) {
+	m := NewMemoryCounter()
+	base := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	now := base
+	m.now = func() time.Time { return now }
+
+	n, err := m.IncrBy(context.Background(), "tpm", 600, time.Minute)
+	if err != nil || n != 600 {
+		t.Fatalf("first: n=%d err=%v", n, err)
+	}
+	n, err = m.IncrBy(context.Background(), "tpm", 400, time.Minute)
+	if err != nil || n != 1000 {
+		t.Fatalf("second: n=%d err=%v", n, err)
+	}
+	now = base.Add(61 * time.Second)
+	n, err = m.IncrBy(context.Background(), "tpm", 50, time.Minute)
+	if err != nil || n != 50 {
+		t.Fatalf("after window: n=%d err=%v", n, err)
+	}
+}
+
 func TestParseRedisURL(t *testing.T) {
 	addr, pass, db, err := ParseRedisURL("redis://:s3cret@localhost:6380/2")
 	if err != nil {


### PR DESCRIPTION
## Summary
- Extend `sharedcount.WindowCounter` with `IncrBy` (Memory + Redis `INCRBY`/`PEXPIRE` fixed-window)
- Wire optional shared TPM on `KeyAdmissionLimiter` (`metapi:tpm:{keyID}`), fail-open to local `tokenEvents`
- `ConfigureSharedAdmissionFromRedisURL` enables RPM+TPM on the same RedisCounter
- Tests for shared TPM deny/fail-open; docs residual notes Snapshot remains process-local

Closes #245

## Test plan
- [x] `go test ./auth ./internal/sharedcount -count=1 -run 'Admission|Shared|TPM|Redis|Window|Memory'`