### PR TITLE
docs(scheduler): residual honesty for TODO no-ops (#246)

### DIFF
--- a/docs/analysis/scheduler-residual-todos.md
+++ b/docs/analysis/scheduler-residual-todos.md
@@ -1,0 +1,139 @@
+# Residual: scheduler silent TODO no-ops (#246)
+
+**Date**: 2026-07-17  
+**Issue**: [#246](https://github.com/TokenDanceLab/metapi-go/issues/246)  
+**Lane**: residual honesty (scheduler scaffolding)  
+**Scope**: document + strengthen comments only. No invented Sub2API refresh product, no fake sync success.
+
+## Goal
+
+Four background schedulers still carry TODOs that look like product work. Operators reading logs or code should see **honest residual** language: what actually runs, what is a no-op, and multi-instance behavior. This wave does **not** implement the missing product paths.
+
+## Inventory
+
+| Scheduler | File | Interval | What currently runs | Residual / silent gap | Multi-instance |
+|-----------|------|----------|---------------------|------------------------|----------------|
+| Sub2API refresh | `scheduler/sub2api_refresh.go` | 60s (min 60s) | Lease + SQL scan of active `sub2api` accounts; logs `scanned=N, refreshed=0, failed=0` | Does **not** parse `extraConfig.sub2apiAuth`; does **not** filter due tokens; does **not** call `refreshSub2ApiManagedSessionSingleflight` or any upstream refresh. Concurrency constant unused. | `runWithSchedulerLease` (PG advisory lock / process-local mutex). Only one instance runs the empty pass. |
+| Channel recovery | `scheduler/channel_recovery.go` | 30s (min 10s) | Lease + load cooling candidates (SQL) + load active candidates (SQL stub) + merge/filter/prioritize + probe via global model-probe scheduler when registered | Active path is **not** wired through `proxyChannelCoordinator.getActiveChannelIds()` (TS). SQL `LIMIT 50` approximation may differ from coordinator-active set. Probe is real only if model-probe is registered; otherwise probe is skipped with debug log. | Lease serializes sweeps across PG instances. In-flight / last-started maps are **process-local**. |
+| Site announcement | `scheduler/site_announcement.go` | 15m (min 10s) | Lease + enumerate active sites + log count | **No** platform adapter calls, **no** `site_announcements` writes, **no** notifications/events. Admin `POST /api/site-announcements/sync` already has real `syncSiteAnnouncements`; this ticker does not call it. | Lease serializes residual scan. No shared announcement write from this path (because none occur). |
+| Update center | `scheduler/update_center.go` | 15m (min 10s) | Lease + log line | **No** remote registry/helper poll, **no** version persistence, **no** deploy/rollback. Admin status/check are local stubs (`0.0.0`); deploy/rollback are 501 residuals (`residual-update-center.md`). | Lease serializes residual log. No cluster-wide "last checked" state. |
+
+## Per-scheduler detail
+
+### 1. `Sub2APIRefreshScheduler` (`sub2api_refresh.go`)
+
+**Runs today**
+
+1. Start ticker; immediate first `runPass`.
+2. Process-local `passInFlight` skip if previous pass still open.
+3. Acquire scheduler lease; on miss, skip.
+4. Query:
+
+   ```sql
+   SELECT a.id, a.extra_config
+   FROM accounts a
+   INNER JOIN sites s ON a.site_id = s.id
+   WHERE LOWER(TRIM(COALESCE(s.platform, ''))) = 'sub2api'
+     AND a.status = 'active'
+     AND s.status = 'active'
+   ```
+
+5. Append every scanned row as a "candidate" without parsing `extra_config`.
+6. Log `pass complete (scan-only residual; no tokens refreshed)` with `refreshed=0`, `failed=0`.
+
+**Residual**
+
+| TODO site | Honest status |
+|-----------|---------------|
+| parse `extraConfig` for `refreshToken` + `tokenExpiresAt` | **Not wired** — `extraConfig` is loaded and discarded |
+| wire Sub2API refresh via singleflight | **Not wired** — balance package has `refreshSub2ApiManagedSessionSingleflight` (auto-relogin style), but scheduler never calls it |
+| concurrency = 4 | Constant only; no worker pool |
+
+**Do not invent** a full managed-auth refresh product in this residual wave. Related account-merge residual: `docs/analysis/residual-sub2api-auth.md`.
+
+### 2. `ChannelRecoveryScheduler` (`channel_recovery.go`)
+
+**Runs today**
+
+1. Ticker + immediate first sweep; `sweepInFlight` serialization; scheduler lease.
+2. `loadCoolingCandidates`: real SQL over `route_channels` with non-null future `cooldown_until`.
+3. `loadActiveCandidates`: SQL of enabled channels with null cooldown (`LIMIT 50`) — **not** coordinator-backed.
+4. Merge (cooling wins), due-filter via process-local maps, prioritize, cap batch=4.
+5. `probeCandidate`: if global model-probe scheduler is registered, call `probeOne`; else debug-skip (no fake success).
+
+**Residual**
+
+| TODO site | Honest status |
+|-----------|---------------|
+| wire active candidate loading via `proxyChannelCoordinator` | **Partial / not TS-parity** — SQL stub runs and can feed probes, but ignores process-local coordinator active set |
+
+**Not a pure no-op**: cooling load + optional model probes can perform real work. The residual is **active-candidate source fidelity**, not "entire scheduler is dead".
+
+### 3. `SiteAnnouncementScheduler` (`site_announcement.go`)
+
+**Runs today**
+
+1. Ticker + immediate first run; `inFlight` + lease.
+2. `SELECT id, platform, url FROM sites WHERE status = 'active'`.
+3. Count rows; log residual scan complete. No adapter, no DB writes.
+
+**Residual**
+
+| TODO site | Honest status |
+|-----------|---------------|
+| platform-specific announcement sync | **Not wired** from this scheduler. Prefer reusing admin `syncSiteAnnouncements` rather than inventing a second path. |
+
+Log language is intentionally "residual scan", not "sync success".
+
+### 4. `UpdateCenterScheduler` (`update_center.go`)
+
+**Runs today**
+
+1. Ticker + immediate first run; `inFlight` + lease.
+2. Single info log: residual check, no remote polling.
+
+**Residual**
+
+| TODO site | Honest status |
+|-----------|---------------|
+| wire actual update-center polling | **Not wired** — pure log-only no-op for product purposes |
+
+Related admin residuals (deploy/rollback 501, local status stubs): `docs/analysis/residual-update-center.md`.
+
+## Multi-instance notes (shared)
+
+All four use `runWithSchedulerLease` (`scheduler/lease.go`):
+
+| Dialect | Behavior |
+|---------|----------|
+| PostgreSQL | `pg_try_advisory_lock` per scheduler name hash; non-holder skips the run |
+| SQLite / non-PG | Process-local map mutex only (single-process coordination) |
+
+Implications:
+
+1. Duplicate empty passes are suppressed across PG replicas (good for noise).
+2. Lease does **not** create product behavior that is missing inside the pass.
+3. Channel-recovery probe bookkeeping (`inFlightKeys`, `lastStartedAtByKey`) remains process-local even when the lease is shared — only the lease holder mutates its own maps.
+4. No durable job bus / cross-instance task registry is implied (see also `background-tasks-multi-instance-residual.md`).
+
+## Explicit non-goals (#246)
+
+- Implementing full Sub2API scheduled refresh product
+- Calling admin announcement sync from the ticker without a deliberate product decision
+- Remote update-center helper client / deploy orchestration
+- Fake `refreshed>0`, fake announcement inserts, fake `updateAvailable=true`
+- Multi-instance durable job coordination
+
+## Verify
+
+```bash
+go test ./scheduler -count=1
+test -f docs/analysis/scheduler-residual-todos.md
+```
+
+## Related docs
+
+- `docs/analysis/residual-sub2api-auth.md` — account-path managed auth merge residual
+- `docs/analysis/residual-update-center.md` — admin deploy/rollback / clear-cache honesty
+- `docs/analysis/background-tasks-multi-instance-residual.md` — process-local admin task registry
+- `docs/specs/p12-schedulers.md` — intended TS parity (aspirational vs residual above)

--- a/scheduler/channel_recovery.go
+++ b/scheduler/channel_recovery.go
@@ -122,9 +122,16 @@ func (s *ChannelRecoveryScheduler) runSweep() {
 func (s *ChannelRecoveryScheduler) runSweepLocked(dbw *store.DB) {
 	nowMs := time.Now().UnixMilli()
 
-	// Query cooling channels
+	// Query cooling channels (SQL-backed; real candidate list).
 	coolingCandidates := s.loadCoolingCandidates(dbw)
-	// TODO: wire active candidate loading via proxyChannelCoordinator
+	// Residual honesty (#246): active candidates are loaded via a simplified SQL
+	// stub (enabled route_channels with null cooldown), NOT via
+	// proxyChannelCoordinator.getActiveChannelIds() as the TS path does.
+	// That means process-local routing/coordinator state is ignored; the SQL
+	// list is an approximation and may include channels the coordinator would
+	// not treat as "active for recovery".
+	// TODO residual (partial): wire active candidate loading via
+	// proxyChannelCoordinator when that surface is shared with this package.
 	activeCandidates := s.loadActiveCandidates(dbw)
 
 	merged := s.mergeCandidates(coolingCandidates, activeCandidates)
@@ -194,7 +201,10 @@ func (s *ChannelRecoveryScheduler) loadCoolingCandidates(dbw *store.DB) []recove
 }
 
 func (s *ChannelRecoveryScheduler) loadActiveCandidates(dbw *store.DB) []recoveryCandidate {
-	// Stub: queries active channels
+	// Residual (#246): SQL approximation of "active" channels (enabled + no
+	// cooldown + active account/site). Not wired to proxyChannelCoordinator.
+	// LIMIT 50 is a local guard, not TS coordinator semantics. Not a silent
+	// no-op — rows are returned and may be probed — but selection is residual.
 	var candidates []recoveryCandidate
 
 	rows, err := dbw.Query(`

--- a/scheduler/site_announcement.go
+++ b/scheduler/site_announcement.go
@@ -99,12 +99,15 @@ func (s *SiteAnnouncementScheduler) runSync() {
 }
 
 func (s *SiteAnnouncementScheduler) runSyncLocked(dbw *store.DB) {
-	slog.Info("site-announcement: syncing announcements")
-	// Stub: calls sync function on active sites
-	// The TS version calls syncSiteAnnouncements() which iterates over sites
-	// and pulls announcements from each site's API.
+	// Residual honesty (#246): this scheduler pass is scan-only.
+	// What runs: enumerate active sites under the scheduler lease and log the
+	// count. What does NOT run: platform adapter GetSiteAnnouncements, DB
+	// insert/update into site_announcements, notifications, or events.
+	// Admin path POST /api/site-announcements/sync already implements real
+	// syncSiteAnnouncements; this ticker does not call it. "sync complete"
+	// means "enumeration complete", not that announcements were fetched.
+	slog.Info("site-announcement: residual scan (no platform sync)")
 
-	// For now we enumerate active sites and log
 	rows, err := dbw.Query("SELECT id, platform, url FROM sites WHERE status = 'active'")
 	if err != nil {
 		slog.Error("site-announcement: failed to query sites", "error", err)
@@ -120,12 +123,16 @@ func (s *SiteAnnouncementScheduler) runSyncLocked(dbw *store.DB) {
 			continue
 		}
 		_ = id
+		_ = platform
 		_ = url
-		// TODO: wire actual platform-specific announcement sync
+		// Residual (#246): site row is counted only.
+		// TODO residual (not wired): call platform-specific announcement sync
+		// (reuse admin syncSiteAnnouncements / adapter.GetSiteAnnouncements).
+		// Do not invent inserted/updated success without real upstream calls.
 		count++
 	}
 
-	slog.Info("site-announcement: sync complete", "sites", count)
+	slog.Info("site-announcement: residual scan complete (no announcements written)", "sites", count)
 }
 
 func maxInt64(a, b int64) int64 {

--- a/scheduler/sub2api_refresh.go
+++ b/scheduler/sub2api_refresh.go
@@ -118,7 +118,13 @@ func (s *Sub2APIRefreshScheduler) runPass() {
 func (s *Sub2APIRefreshScheduler) runPassLocked(dbw *store.DB) {
 	slog.Info("sub2api-refresh: running pass")
 
-	// Query Sub2API platform active accounts
+	// Residual honesty (#246): this pass is scaffolding only.
+	// What runs: SQL scan of active sub2api accounts (id + extra_config) under
+	// the scheduler lease. What does NOT run: extraConfig.sub2apiAuth parsing,
+	// due-window filter (refreshToken + tokenExpiresAt), concurrency pool, or
+	// any call into balance.refreshSub2ApiManagedSessionSingleflight.
+	// Logs always report refreshed=0 / failed=0 — not fake success, just no work.
+	// Full managed-auth product is out of scope here; see residual-sub2api-auth.md.
 	rows, err := dbw.Query(`
 		SELECT a.id, a.extra_config
 		FROM accounts a
@@ -144,13 +150,20 @@ func (s *Sub2APIRefreshScheduler) runPassLocked(dbw *store.DB) {
 		if err := rows.Scan(&c.id, &c.extraConfig); err != nil {
 			continue
 		}
-		// Filter: must have sub2apiAuth in extraConfig
-		// TODO: parse extraConfig and check for refreshToken+tokenExpiresAt
+		// Residual (#246): extraConfig is loaded but not parsed.
+		// TODO residual (not wired): parse extraConfig.sub2apiAuth and keep only
+		// candidates with non-empty refreshToken + due tokenExpiresAt.
+		// Until then every active sub2api account is treated as a scan candidate
+		// and none are refreshed.
+		_ = c.extraConfig
 		candidates = append(candidates, c)
 	}
 
-	// TODO: Wire actual Sub2API refresh via singleflight
-	slog.Info("sub2api-refresh: pass complete",
+	// Residual (#246): no refresh side effects. singleflight helper lives in
+	// service/balance but is not invoked from this scheduler.
+	// TODO residual (not wired): call refreshSub2ApiManagedSessionSingleflight
+	// with concurrency=sub2apiRefreshConcurrency; do not invent success counts.
+	slog.Info("sub2api-refresh: pass complete (scan-only residual; no tokens refreshed)",
 		"scanned", len(candidates),
 		"refreshed", 0,
 		"failed", 0,

--- a/scheduler/update_center.go
+++ b/scheduler/update_center.go
@@ -100,7 +100,15 @@ func (s *UpdateCenterScheduler) runSync() {
 
 func (s *UpdateCenterScheduler) runSyncLocked(dbw *store.DB) {
 	_ = dbw
-	slog.Info("update-center: checking for updates")
-	// Stub: calls update center API
-	// TODO: wire actual update center polling logic
+	// Residual honesty (#246): silent no-op for product purposes.
+	// What runs: ticker + in-flight guard + scheduler lease + this log line.
+	// What does NOT run: remote registry/helper polling, version compare,
+	// persistence of lastCheckedAt, or any deploy/rollback side effect.
+	// Admin update-center status/check endpoints are also local stubs
+	// (0.0.0 / updateAvailable=false); deploy/rollback are honest 501 residuals
+	// (see residual-update-center.md). This scheduler must not invent
+	// "update available" or fake task completion.
+	// TODO residual (not wired): wire actual update-center polling when a real
+	// helper/registry client exists — until then this is scan-free log-only.
+	slog.Info("update-center: residual check (no remote polling; no version discovery)")
 }


### PR DESCRIPTION
## Summary
- Inventory silent scheduler TODO no-ops in `docs/analysis/scheduler-residual-todos.md` (sub2api refresh, channel recovery active candidates, site announcement sync, update-center polling).
- Strengthen residual comments at each TODO site: honest no-op / not wired / not fake success; no invented Sub2API refresh product.
- Multi-instance notes via existing `runWithSchedulerLease` documented without claiming product work.

## Test plan
- [x] `go test ./scheduler -count=1`
- [x] `test -f docs/analysis/scheduler-residual-todos.md`

Closes #246