### PR TITLE
feat(proxy): videos GET/DELETE sticky pin via ForcedChannelID (#253)

### DIFF
--- a/docs/analysis/videos-proxy-residual.md
+++ b/docs/analysis/videos-proxy-residual.md
@@ -39,11 +39,22 @@ on success POST /v1/videos:
   body.id = publicID
 ```
 
+## Sticky pin (#253)
+
+When a mapping has `ChannelID > 0`, GET/DELETE set `Ctx.ForcedChannelID` so
+`SelectProxyChannelForAttempt` uses `SelectPreferredChannel` (no cross-channel
+fallback). `RequestedModel` is seeded from the mapping when the client omits
+`model` (typical for GET/DELETE). Path rewrite still uses `UpstreamVideoID`.
+
+`SiteURL` / `TokenValue` on the mapping remain informational — selection still
+goes through the router preferred-channel path (token/site come from channel
+resolution), not a raw URL override.
+
 ## What is still residual (not claimed)
 
-1. **No sticky site/token restore from mapping** — GET/DELETE still use normal channel selection; mapping fields SiteURL/TokenValue are stored for future pin work only.
+1. **Raw site URL / token override** — mapping stores SiteURL/TokenValue but does not bypass router with a direct HTTP client pin.
 2. **Stub mode** — unconfigured upstream + stub does not rewrite publicId (no selected channel).
-3. **TTL / GC** — no retention job for stale `proxy_video_tasks` rows this wave.
+3. **TTL / GC** — no retention job for stale `proxy_video_tasks` rows this wave (see `videos-proxy-retention-residual.md`).
 4. **TokenValue in DB** — same sensitivity as process memory mapping; operators must protect DB backups.
 
 ## Tests

--- a/handler/proxy/surface.go
+++ b/handler/proxy/surface.go
@@ -54,6 +54,11 @@ type Ctx struct {
 	Multipart      bool
 	Retries        int
 	MaxRetries     int
+	// ForcedChannelID pins channel selection to a specific route channel when set
+	// (videos sticky pin from mapping #253; tester forced channel paths).
+	// When non-nil and >0, SelectProxyChannelForAttempt uses SelectPreferredChannel
+	// and does not fall back to other channels on retry.
+	ForcedChannelID *int64
 }
 
 // PrepareCtx extracts all context needed for proxy request handling.

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -108,6 +108,7 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 				DownstreamPolicy:  downstreamPolicy,
 				ExcludeChannelIDs: excludeChannelIDs,
 				RetryCount:        retry,
+				ForcedChannelID:   ctx.ForcedChannelID,
 			},
 		)
 		if err != nil || selected == nil {

--- a/handler/proxy/videos.go
+++ b/handler/proxy/videos.go
@@ -73,6 +73,9 @@ func HandleVideosCreate(w http.ResponseWriter, r *http.Request) {
 // If a local mapping exists and UpstreamVideoID differs from the public path id,
 // the upstream path uses UpstreamVideoID. When the mapping is missing, the
 // client-provided id is passed through — no store-gated 404 theater.
+//
+// Sticky pin (#253): when the mapping has ChannelID > 0, force preferred channel
+// selection so the request hits the same upstream account/site as create.
 func HandleVideosGet(w http.ResponseWriter, r *http.Request) {
 	publicID := chi.URLParam(r, "id")
 	if publicID == "" {
@@ -80,7 +83,8 @@ func HandleVideosGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	upstreamID := resolveVideoUpstreamID(publicID)
+	task := GetProxyVideoTaskByPublicID(publicID)
+	upstreamID := resolveVideoUpstreamIDFromTask(publicID, task)
 
 	ctx, errResp := PrepareCtx(r, SurfConfig{
 		Endpoint:       "videos",
@@ -91,6 +95,7 @@ func HandleVideosGet(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, errResp.Status, errResp.Error, errResp.ErrorType)
 		return
 	}
+	applyVideoTaskStickyPin(ctx, task)
 
 	dispatchUpstream(w, r, ctx)
 }
@@ -100,6 +105,9 @@ func HandleVideosGet(w http.ResponseWriter, r *http.Request) {
 // Clears any local mapping for the public id, then always dispatches DELETE to
 // upstream (mapping is optional rewrite aid, not a hard gate). Prefer honest
 // upstream status over a local-only 204 residual.
+//
+// Sticky pin (#253): resolve mapping before delete so channel preference and
+// path rewrite still apply for this request.
 func HandleVideosDelete(w http.ResponseWriter, r *http.Request) {
 	publicID := chi.URLParam(r, "id")
 	if publicID == "" {
@@ -107,7 +115,8 @@ func HandleVideosDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	upstreamID := resolveVideoUpstreamID(publicID)
+	task := GetProxyVideoTaskByPublicID(publicID)
+	upstreamID := resolveVideoUpstreamIDFromTask(publicID, task)
 	// Best-effort local cleanup whether or not a mapping existed.
 	DeleteProxyVideoTaskByPublicID(publicID)
 
@@ -120,6 +129,7 @@ func HandleVideosDelete(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, errResp.Status, errResp.Error, errResp.ErrorType)
 		return
 	}
+	applyVideoTaskStickyPin(ctx, task)
 
 	dispatchUpstream(w, r, ctx)
 }
@@ -128,7 +138,10 @@ func HandleVideosDelete(w http.ResponseWriter, r *http.Request) {
 // When a mapping exists with a non-empty UpstreamVideoID different from publicID,
 // that upstream id is used; otherwise publicID is passed through unchanged.
 func resolveVideoUpstreamID(publicID string) string {
-	task := GetProxyVideoTaskByPublicID(publicID)
+	return resolveVideoUpstreamIDFromTask(publicID, GetProxyVideoTaskByPublicID(publicID))
+}
+
+func resolveVideoUpstreamIDFromTask(publicID string, task *ProxyVideoTask) string {
 	if task == nil {
 		return publicID
 	}
@@ -136,6 +149,26 @@ func resolveVideoUpstreamID(publicID string) string {
 		return task.UpstreamVideoID
 	}
 	return publicID
+}
+
+// applyVideoTaskStickyPin forces preferred channel selection when the mapping
+// recorded a channel at create time (#253). Also seeds RequestedModel from the
+// mapping when the client omitted model (typical for GET/DELETE).
+func applyVideoTaskStickyPin(ctx *Ctx, task *ProxyVideoTask) {
+	if ctx == nil || task == nil {
+		return
+	}
+	if ctx.RequestedModel == "" {
+		if task.RequestedModel != "" {
+			ctx.RequestedModel = task.RequestedModel
+		} else if task.ActualModel != "" {
+			ctx.RequestedModel = task.ActualModel
+		}
+	}
+	if task.ChannelID > 0 {
+		ch := task.ChannelID
+		ctx.ForcedChannelID = &ch
+	}
 }
 
 // SaveProxyVideoTask saves a video task mapping to the process-local cache and

--- a/handler/proxy/videos_test.go
+++ b/handler/proxy/videos_test.go
@@ -2,6 +2,7 @@ package proxyhandler
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"mime/multipart"
@@ -467,5 +468,96 @@ func TestProxyVideoTask_DBDurableRoundTrip(t *testing.T) {
 	DeleteProxyVideoTaskByPublicID(publicID)
 	if GetProxyVideoTaskByPublicID(publicID) != nil {
 		t.Fatal("expected deleted from memory+db")
+	}
+}
+
+
+// preferredTrackRouter records SelectPreferredChannel invocations.
+type preferredTrackRouter struct {
+	selected routing.SelectedChannel
+	lastPreferred int64
+	preferredCalls int
+}
+
+func (r *preferredTrackRouter) SelectChannel(context.Context, string, routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+	tcopy := r.selected
+	return &tcopy, nil
+}
+func (r *preferredTrackRouter) SelectNextChannel(context.Context, string, []int64, routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+	return nil, nil
+}
+func (r *preferredTrackRouter) SelectPreferredChannel(_ context.Context, _ string, preferredChannelID int64, _ routing.DownstreamRoutingPolicy, _ []int64) (*routing.SelectedChannel, error) {
+	r.preferredCalls++
+	r.lastPreferred = preferredChannelID
+	if preferredChannelID != r.selected.Channel.ID {
+		return nil, nil
+	}
+	cp := r.selected
+	return &cp, nil
+}
+func (r *preferredTrackRouter) RecordSuccess(context.Context, int64, float64, float64, *string, *int64) error {
+	return nil
+}
+func (r *preferredTrackRouter) RecordFailure(context.Context, int64, routing.SiteRuntimeFailureContext, *int64) error {
+	return nil
+}
+
+func TestHandleVideosGet_StickyPinForcesPreferredChannel(t *testing.T) {
+	publicID := "video_sticky_pin_pref"
+	SaveProxyVideoTask(&ProxyVideoTask{
+		PublicID:        publicID,
+		UpstreamVideoID: "upstream_sticky_vid",
+		RequestedModel:  "sora-2",
+		ChannelID:       42,
+		AccountID:       7,
+	})
+	t.Cleanup(func() { DeleteProxyVideoTaskByPublicID(publicID) })
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/videos/upstream_sticky_vid" {
+			t.Fatalf("path=%s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"upstream_sticky_vid","status":"completed"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	router := &preferredTrackRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active"},
+		TokenValue:  "upstream-token",
+		ActualModel: "sora-up",
+	}}
+	SetUpstreamConfig(&UpstreamConfig{Router: router})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	r := chiRouterForVideo()
+	req := makeProxyReqNoBody("GET", "/v1/videos/"+publicID)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if router.preferredCalls < 1 {
+		t.Fatalf("expected SelectPreferredChannel, calls=%d", router.preferredCalls)
+	}
+	if router.lastPreferred != 42 {
+		t.Fatalf("preferred=%d want 42", router.lastPreferred)
+	}
+}
+
+func TestApplyVideoTaskStickyPin(t *testing.T) {
+	ctx := &Ctx{}
+	applyVideoTaskStickyPin(ctx, nil)
+	if ctx.ForcedChannelID != nil {
+		t.Fatal("nil task should not force")
+	}
+	applyVideoTaskStickyPin(ctx, &ProxyVideoTask{ChannelID: 9, RequestedModel: "m1"})
+	if ctx.ForcedChannelID == nil || *ctx.ForcedChannelID != 9 {
+		t.Fatalf("ForcedChannelID=%v", ctx.ForcedChannelID)
+	}
+	if ctx.RequestedModel != "m1" {
+		t.Fatalf("model=%q", ctx.RequestedModel)
 	}
 }


### PR DESCRIPTION
## Summary
- `Ctx.ForcedChannelID` wired into SelectProxyChannelForAttempt
- Videos GET/DELETE apply sticky pin from mapping ChannelID
- Seed RequestedModel from mapping when omitted
- Residual doc updated (#253)

Closes #253

## Test plan
- [x] go test ./handler/proxy -count=1 -run 'Video|Videos|Sticky|ApplyVideo'