### PR TITLE
feat(scheduler): Sub2API refresh wire + video task retention (#261 #262)

### DIFF
--- a/app/services.go
+++ b/app/services.go
@@ -67,6 +67,9 @@ func StartBackgroundServices() {
 	// ---- Scheduler 13: Proxy File Retention ----
 	newRegistry.Register(scheduler.NewProxyFileRetentionScheduler(cfg))
 
+	// ---- Scheduler 13b: Proxy Video Task Retention (#262) ----
+	newRegistry.Register(scheduler.NewProxyVideoTaskRetentionScheduler(cfg))
+
 	// ---- Scheduler 14: Proxy Log Retention (legacy fallback) ----
 	newRegistry.Register(scheduler.NewProxyLogRetentionScheduler(cfg))
 

--- a/config/config.go
+++ b/config/config.go
@@ -182,11 +182,13 @@ type Config struct {
 	ModelAvailabilityProbeTimeoutMs   int
 	ModelAvailabilityProbeConcurrency int
 
-	// Retention (4 fields)
-	ProxyLogRetentionDays                  int
-	ProxyLogRetentionPruneIntervalMinutes  int
-	ProxyFileRetentionDays                 int
-	ProxyFileRetentionPruneIntervalMinutes int
+	// Retention (6 fields)
+	ProxyLogRetentionDays                       int
+	ProxyLogRetentionPruneIntervalMinutes       int
+	ProxyFileRetentionDays                      int
+	ProxyFileRetentionPruneIntervalMinutes      int
+	ProxyVideoTaskRetentionDays                 int
+	ProxyVideoTaskRetentionPruneIntervalMinutes int
 
 	// Routing Weights (5 fields)
 	RoutingWeights RoutingWeights
@@ -537,6 +539,8 @@ func Load(env map[string]string) *Config {
 	cfg.ProxyLogRetentionPruneIntervalMinutes = maxInt(1, int(math.Trunc(parseNumber(get("PROXY_LOG_RETENTION_PRUNE_INTERVAL_MINUTES"), float64(DefaultProxyLogRetentionPruneIntervalMinutes)))))
 	cfg.ProxyFileRetentionDays = maxInt(0, int(math.Trunc(parseNumber(get("PROXY_FILE_RETENTION_DAYS"), DefaultProxyFileRetentionDays))))
 	cfg.ProxyFileRetentionPruneIntervalMinutes = maxInt(1, int(math.Trunc(parseNumber(get("PROXY_FILE_RETENTION_PRUNE_INTERVAL_MINUTES"), float64(DefaultProxyFileRetentionPruneIntervalMinutes)))))
+	cfg.ProxyVideoTaskRetentionDays = maxInt(0, int(math.Trunc(parseNumber(get("PROXY_VIDEO_TASK_RETENTION_DAYS"), float64(DefaultProxyVideoTaskRetentionDays)))))
+	cfg.ProxyVideoTaskRetentionPruneIntervalMinutes = maxInt(1, int(math.Trunc(parseNumber(get("PROXY_VIDEO_TASK_RETENTION_PRUNE_INTERVAL_MINUTES"), float64(DefaultProxyVideoTaskRetentionPruneIntervalMinutes)))))
 
 	// ---- §3.22 Routing Weights ----
 	cfg.RoutingWeights = RoutingWeights{

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -43,6 +43,9 @@ const (
 	DefaultProxyLogRetentionPruneIntervalMinutes  = 30
 	DefaultProxyFileRetentionDays                 = 30
 	DefaultProxyFileRetentionPruneIntervalMinutes = 60
+	// Video task mappings: default 0 = retention disabled (no silent mass delete).
+	DefaultProxyVideoTaskRetentionDays                 = 0
+	DefaultProxyVideoTaskRetentionPruneIntervalMinutes = 60
 
 	DefaultProxyDebugRetentionHours = 24
 	DefaultProxyDebugMaxBodyBytes   = 262144

--- a/scheduler/sub2api_refresh.go
+++ b/scheduler/sub2api_refresh.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/service"
+	"github.com/tokendancelab/metapi-go/service/balance"
 	"github.com/tokendancelab/metapi-go/store"
 )
 
@@ -17,7 +20,7 @@ const (
 )
 
 // Sub2APIRefreshScheduler periodically refreshes Sub2API managed authentication
-// tokens for eligible accounts.
+// tokens for eligible accounts via balance.RefreshBalance (#261).
 type Sub2APIRefreshScheduler struct {
 	cfg          *config.Config
 	ticker       *time.Ticker
@@ -84,6 +87,7 @@ func (s *Sub2APIRefreshScheduler) Stop() error {
 // Sub2ApiRefreshResult is the result of a refresh pass.
 type Sub2ApiRefreshResult struct {
 	Scanned             int
+	Eligible            int
 	Refreshed           int
 	Failed              int
 	Skipped             int
@@ -118,13 +122,6 @@ func (s *Sub2APIRefreshScheduler) runPass() {
 func (s *Sub2APIRefreshScheduler) runPassLocked(dbw *store.DB) {
 	slog.Info("sub2api-refresh: running pass")
 
-	// Residual honesty (#246): this pass is scaffolding only.
-	// What runs: SQL scan of active sub2api accounts (id + extra_config) under
-	// the scheduler lease. What does NOT run: extraConfig.sub2apiAuth parsing,
-	// due-window filter (refreshToken + tokenExpiresAt), concurrency pool, or
-	// any call into balance.refreshSub2ApiManagedSessionSingleflight.
-	// Logs always report refreshed=0 / failed=0 — not fake success, just no work.
-	// Full managed-auth product is out of scope here; see residual-sub2api-auth.md.
 	rows, err := dbw.Query(`
 		SELECT a.id, a.extra_config
 		FROM accounts a
@@ -140,32 +137,80 @@ func (s *Sub2APIRefreshScheduler) runPassLocked(dbw *store.DB) {
 	defer rows.Close()
 
 	type candidate struct {
-		id          int64
-		extraConfig *string
+		id int64
 	}
 
-	var candidates []candidate
+	var scanned int
+	var eligible []candidate
 	for rows.Next() {
-		var c candidate
-		if err := rows.Scan(&c.id, &c.extraConfig); err != nil {
+		var id int64
+		var extraConfig *string
+		if err := rows.Scan(&id, &extraConfig); err != nil {
 			continue
 		}
-		// Residual (#246): extraConfig is loaded but not parsed.
-		// TODO residual (not wired): parse extraConfig.sub2apiAuth and keep only
-		// candidates with non-empty refreshToken + due tokenExpiresAt.
-		// Until then every active sub2api account is treated as a scan candidate
-		// and none are refreshed.
-		_ = c.extraConfig
-		candidates = append(candidates, c)
+		scanned++
+		if !isSub2APIRefreshCandidate(extraConfig) {
+			continue
+		}
+		eligible = append(eligible, candidate{id: id})
 	}
 
-	// Residual (#246): no refresh side effects. singleflight helper lives in
-	// service/balance but is not invoked from this scheduler.
-	// TODO residual (not wired): call refreshSub2ApiManagedSessionSingleflight
-	// with concurrency=sub2apiRefreshConcurrency; do not invent success counts.
-	slog.Info("sub2api-refresh: pass complete (scan-only residual; no tokens refreshed)",
-		"scanned", len(candidates),
-		"refreshed", 0,
-		"failed", 0,
+	if len(eligible) == 0 {
+		slog.Info("sub2api-refresh: pass complete",
+			"scanned", scanned,
+			"eligible", 0,
+			"refreshed", 0,
+			"failed", 0,
+		)
+		return
+	}
+
+	concurrency := sub2apiRefreshConcurrency
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	var refreshed atomic.Int64
+	var failed atomic.Int64
+
+	for _, c := range eligible {
+		c := c
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			_, err := balance.RefreshBalance(s.cfg, dbw.DB, c.id)
+			if err != nil {
+				failed.Add(1)
+				slog.Warn("sub2api-refresh: RefreshBalance failed",
+					"account_id", c.id, "error", err)
+				return
+			}
+			refreshed.Add(1)
+		}()
+	}
+	wg.Wait()
+
+	slog.Info("sub2api-refresh: pass complete",
+		"scanned", scanned,
+		"eligible", len(eligible),
+		"refreshed", refreshed.Load(),
+		"failed", failed.Load(),
 	)
+}
+
+// isSub2APIRefreshCandidate reports whether extraConfig carries managed Sub2API
+// auth that is due for refresh (#261).
+func isSub2APIRefreshCandidate(extraConfig *string) bool {
+	auth := service.GetSub2ApiAuthFromExtraConfig(extraConfig)
+	if auth == nil {
+		return false
+	}
+	rt, ok := service.NormalizeManagedRefreshToken(auth["refreshToken"])
+	if !ok || rt == "" {
+		return false
+	}
+	return service.IsManagedSub2ApiTokenDue(auth["tokenExpiresAt"])
 }

--- a/scheduler/video_task_retention.go
+++ b/scheduler/video_task_retention.go
@@ -1,0 +1,117 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+const defaultProxyVideoTaskRetentionIntervalMin = 60
+
+// ProxyVideoTaskRetentionScheduler periodically prunes aged proxy_video_tasks rows (#262).
+// Disabled when ProxyVideoTaskRetentionDays <= 0 (default).
+type ProxyVideoTaskRetentionScheduler struct {
+	cfg     *config.Config
+	ticker  *time.Ticker
+	stopCh  chan struct{}
+	running bool
+	mu      sync.Mutex
+}
+
+// NewProxyVideoTaskRetentionScheduler creates a video task retention scheduler.
+func NewProxyVideoTaskRetentionScheduler(cfg *config.Config) *ProxyVideoTaskRetentionScheduler {
+	return &ProxyVideoTaskRetentionScheduler{cfg: cfg}
+}
+
+func (s *ProxyVideoTaskRetentionScheduler) Name() string { return "proxy-video-task-retention" }
+
+func (s *ProxyVideoTaskRetentionScheduler) Start(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.cfg.ProxyVideoTaskRetentionDays <= 0 {
+		slog.Info("proxy-video-task-retention: disabled (retention_days=0)")
+		return nil
+	}
+
+	intervalMin := maxInt(s.cfg.ProxyVideoTaskRetentionPruneIntervalMinutes, 1)
+	if intervalMin == 0 {
+		intervalMin = defaultProxyVideoTaskRetentionIntervalMin
+	}
+	interval := time.Duration(intervalMin) * time.Minute
+
+	s.ticker = time.NewTicker(interval)
+	s.stopCh = make(chan struct{})
+	s.running = true
+
+	go s.runCleanup()
+
+	go func() {
+		for {
+			select {
+			case <-s.ticker.C:
+				go s.runCleanup()
+			case <-s.stopCh:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	slog.Info("proxy-video-task-retention scheduler started",
+		"interval_min", intervalMin,
+		"retention_days", s.cfg.ProxyVideoTaskRetentionDays,
+	)
+	return nil
+}
+
+func (s *ProxyVideoTaskRetentionScheduler) Stop() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.running {
+		return nil
+	}
+	s.running = false
+	if s.ticker != nil {
+		s.ticker.Stop()
+	}
+	if s.stopCh != nil {
+		close(s.stopCh)
+	}
+	return nil
+}
+
+func (s *ProxyVideoTaskRetentionScheduler) runCleanup() {
+	dbw := store.GetDB()
+	if dbw == nil {
+		return
+	}
+	retentionDays := s.cfg.ProxyVideoTaskRetentionDays
+	if retentionDays <= 0 {
+		return
+	}
+	runWithSchedulerLease(context.Background(), dbw, s.Name(), func() {
+		s.runCleanupLocked(dbw, retentionDays)
+	})
+}
+
+func (s *ProxyVideoTaskRetentionScheduler) runCleanupLocked(dbw *store.DB, retentionDays int) {
+	cutoff := time.Now().UTC().Add(-time.Duration(retentionDays) * 24 * time.Hour)
+	cutoffStr := formatTimeToSQL(cutoff)
+
+	result, err := dbw.Exec("DELETE FROM proxy_video_tasks WHERE created_at < ?", cutoffStr)
+	if err != nil {
+		slog.Warn("proxy-video-task-retention: cleanup failed", "error", err)
+		return
+	}
+	deleted, _ := result.RowsAffected()
+	if deleted > 0 {
+		slog.Info("proxy-video-task-retention: cleanup complete",
+			"deleted", deleted, "cutoff", cutoffStr, "retention_days", retentionDays)
+	}
+}


### PR DESCRIPTION
## Summary
- **#261**: Sub2API refresh scheduler now parses extraConfig.sub2apiAuth, filters candidates with refreshToken+due tokenExpiresAt, and calls balance.RefreshBalance with bounded concurrency
- **#262**: Age-based proxy_video_tasks retention scheduler (PROXY_VIDEO_TASK_RETENTION_DAYS config, default 0=disabled); registered in app/services.go

Closes #261, closes #262

## Test plan
- [x] go build ./scheduler
- [x] go test ./scheduler -count=1 -run Sub2