### PR TITLE
fix(frontend): CI EnvironmentTeardownError flake hardening (#266)

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -33,5 +33,11 @@ export default defineConfig({
       // Suppress vitest worker console RPC traffic that races teardown.
       return false;
     },
+    // #266: Longer teardown window avoids races when jsdom closes
+    // with pending microtasks/console RPC from React 19 async act().
+    teardownTimeout: 10_000,
+    // #266: Deterministic setup-file order prevents edge-case races
+    // when multiple setup files patch the same jsdom globals.
+    sequence: { setupFiles: 'list' as const },
   },
 });

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { afterAll, vi } from 'vitest';
 import type { ReactElement, ReactNode } from 'react';
 import type {
   ReactTestRenderer,
@@ -86,3 +86,16 @@ console.warn = (...args: unknown[]) => {
   if (head.includes('react-test-renderer is deprecated')) return;
   originalWarn(...args);
 };
+
+// #266: Global afterAll to drain mocks and pending microtasks after each
+// suite, reducing EnvironmentTeardownError from leftover console RPC.
+afterAll(async () => {
+  try {
+    vi.clearAllMocks();
+  } catch {
+    // Ignore mock cleanup races under single-worker vitest.
+  }
+  // Drain pending microtasks so worker teardown does not race console RPC.
+  await Promise.resolve();
+  await Promise.resolve();
+});


### PR DESCRIPTION
## Summary
- Added teardownTimeout: 10_000ms to vite config (avoids jsdom race)
- Added sequence.setupFiles: list for deterministic setup ordering
- Existing mitigations (maxWorkers:1, dangerouslyIgnoreUnhandledErrors, onConsoleLog suppress) remain

Closes #266

## Test plan
- Frontend CI should show fewer EnvironmentTeardownError flakes