### PR TITLE
feat(scheduler): channel recovery active candidates via coordinator (#273)

### DIFF
--- a/app/proxy_upstream.go
+++ b/app/proxy_upstream.go
@@ -15,6 +15,7 @@ import (
 	proxyhandler "github.com/tokendancelab/metapi-go/handler/proxy"
 	"github.com/tokendancelab/metapi-go/proxy"
 	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/scheduler"
 	"github.com/tokendancelab/metapi-go/store"
 )
 
@@ -26,6 +27,8 @@ func ConfigureProxyUpstream(cfg *config.Config) error {
 	if db == nil {
 		proxyhandler.SetUpstreamConfig(nil)
 		setTokenRouteDecisionRuntime(nil, nil)
+		// Clear channel-recovery active-ID hook on failed/cleared reconfigure (#273).
+		scheduler.SetActiveChannelIDsProvider(nil)
 		return fmt.Errorf("proxy upstream: database is not initialized")
 	}
 	coord := proxy.NewProxyChannelCoordinator(cfg)
@@ -58,6 +61,15 @@ func ConfigureProxyUpstream(cfg *config.Config) error {
 		LogProxy: func(ctx context.Context, entry proxy.ProxyLogEntry) error {
 			return proxyhandler.InsertProxyLog(ctx, store.GetDB(), entry)
 		},
+	})
+	// Channel recovery active candidates follow coordinator leases (#273).
+	// Normalize nil→empty so an empty lease set does not look "unset".
+	scheduler.SetActiveChannelIDsProvider(func() []int64 {
+		ids := coord.GetActiveChannelIDs()
+		if ids == nil {
+			return []int64{}
+		}
+		return ids
 	})
 	// Remember router for ModelProbeScheduler health recording (#170).
 	// Wire global scheduler if already started (reconfigure / test paths).

--- a/app/proxy_upstream_test.go
+++ b/app/proxy_upstream_test.go
@@ -15,6 +15,7 @@ import (
 	proxyhandler "github.com/tokendancelab/metapi-go/handler/proxy"
 	"github.com/tokendancelab/metapi-go/proxy"
 	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/scheduler"
 	"github.com/tokendancelab/metapi-go/store"
 )
 
@@ -40,6 +41,7 @@ func TestConfigureProxyUpstreamWiresRealSQLiteRouter(t *testing.T) {
 	cfg := testProxyConfig(t)
 	t.Cleanup(func() {
 		proxyhandler.SetUpstreamConfig(nil)
+		scheduler.SetActiveChannelIDsProvider(nil)
 		_ = store.CloseDatabase()
 	})
 	config.Set(cfg)
@@ -171,5 +173,42 @@ func TestProxyRoutingStoreSelectsSeededChannel(t *testing.T) {
 	}
 	if selected.Channel.ID != channelID || selected.TokenValue != "seed-token" || selected.Site.URL != "https://example.invalid" {
 		t.Fatalf("selected = %+v", selected)
+	}
+}
+
+func TestConfigureProxyUpstreamWiresActiveChannelIDsProvider(t *testing.T) {
+	_ = store.CloseDatabase()
+	scheduler.SetActiveChannelIDsProvider(nil)
+
+	// Unset path / failed reconfigure clears the provider.
+	if err := ConfigureProxyUpstream(testProxyConfig(t)); err == nil {
+		t.Fatal("expected ConfigureProxyUpstream to fail without DB")
+	}
+	if got := scheduler.GetActiveChannelIDsFromProvider(); got != nil {
+		t.Fatalf("provider should be cleared when DB missing, got %v", got)
+	}
+
+	cfg := testProxyConfig(t)
+	// Register after TempDir so CloseDatabase runs before TempDir cleanup (Windows file lock).
+	t.Cleanup(func() {
+		proxyhandler.SetUpstreamConfig(nil)
+		scheduler.SetActiveChannelIDsProvider(nil)
+		_ = store.CloseDatabase()
+	})
+	config.Set(cfg)
+	if err := store.EnsureRuntimeDatabase(cfg); err != nil {
+		t.Fatalf("EnsureRuntimeDatabase: %v", err)
+	}
+	if err := ConfigureProxyUpstream(cfg); err != nil {
+		t.Fatalf("ConfigureProxyUpstream: %v", err)
+	}
+
+	// Provider is registered and returns a non-nil empty slice when no leases exist.
+	ids := scheduler.GetActiveChannelIDsFromProvider()
+	if ids == nil {
+		t.Fatal("expected non-nil provider after ConfigureProxyUpstream")
+	}
+	if len(ids) != 0 {
+		t.Fatalf("expected empty active IDs with no leases, got %v", ids)
 	}
 }

--- a/docs/analysis/scheduler-residual-todos.md
+++ b/docs/analysis/scheduler-residual-todos.md
@@ -14,7 +14,7 @@ Four background schedulers still carry TODOs that look like product work. Operat
 | Scheduler | File | Interval | What currently runs | Residual / silent gap | Multi-instance |
 |-----------|------|----------|---------------------|------------------------|----------------|
 | Sub2API refresh | `scheduler/sub2api_refresh.go` | 60s (min 60s) | Lease + SQL scan of active `sub2api` accounts; logs `scanned=N, refreshed=0, failed=0` | Does **not** parse `extraConfig.sub2apiAuth`; does **not** filter due tokens; does **not** call `refreshSub2ApiManagedSessionSingleflight` or any upstream refresh. Concurrency constant unused. | `runWithSchedulerLease` (PG advisory lock / process-local mutex). Only one instance runs the empty pass. |
-| Channel recovery | `scheduler/channel_recovery.go` | 30s (min 10s) | Lease + load cooling candidates (SQL) + load active candidates (SQL stub) + merge/filter/prioritize + probe via global model-probe scheduler when registered | Active path is **not** wired through `proxyChannelCoordinator.getActiveChannelIds()` (TS). SQL `LIMIT 50` approximation may differ from coordinator-active set. Probe is real only if model-probe is registered; otherwise probe is skipped with debug log. | Lease serializes sweeps across PG instances. In-flight / last-started maps are **process-local**. |
+| Channel recovery | `scheduler/channel_recovery.go` | 30s (min 10s) | Lease + load cooling candidates (SQL) + load active candidates (coordinator provider when wired, else SQL stub) + merge/filter/prioritize + probe via global model-probe scheduler when registered | Active path prefers optional `SetActiveChannelIDsProvider` → `ProxyChannelCoordinator.GetActiveChannelIDs` (#273). Residual only when provider is **unset**: SQL `LIMIT 50` approximation. Probe is real only if model-probe is registered; otherwise probe is skipped with debug log. | Lease serializes sweeps across PG instances. In-flight / last-started maps and coordinator active set are **process-local**. |
 | Site announcement | `scheduler/site_announcement.go` | 15m (min 10s) | Lease + enumerate active sites + log count | **No** platform adapter calls, **no** `site_announcements` writes, **no** notifications/events. Admin `POST /api/site-announcements/sync` already has real `syncSiteAnnouncements`; this ticker does not call it. | Lease serializes residual scan. No shared announcement write from this path (because none occur). |
 | Update center | `scheduler/update_center.go` | 15m (min 10s) | Lease + log line | **No** remote registry/helper poll, **no** version persistence, **no** deploy/rollback. Admin status/check are local stubs (`0.0.0`); deploy/rollback are 501 residuals (`residual-update-center.md`). | Lease serializes residual log. No cluster-wide "last checked" state. |
 
@@ -57,7 +57,9 @@ Four background schedulers still carry TODOs that look like product work. Operat
 
 1. Ticker + immediate first sweep; `sweepInFlight` serialization; scheduler lease.
 2. `loadCoolingCandidates`: real SQL over `route_channels` with non-null future `cooldown_until`.
-3. `loadActiveCandidates`: SQL of enabled channels with null cooldown (`LIMIT 50`) — **not** coordinator-backed.
+3. `loadActiveCandidates` (#273):
+   - If `SetActiveChannelIDsProvider` is registered (boot wires `ProxyChannelCoordinator.GetActiveChannelIDs` from `app.ConfigureProxyUpstream`), resolve model names for those IDs via SQL (`enabled` + active account/site; null cooldown preferred, source_model channels still included).
+   - If provider is **nil**, residual SQL of enabled channels with null cooldown (`LIMIT 50`).
 4. Merge (cooling wins), due-filter via process-local maps, prioritize, cap batch=4.
 5. `probeCandidate`: if global model-probe scheduler is registered, call `probeOne`; else debug-skip (no fake success).
 
@@ -65,9 +67,9 @@ Four background schedulers still carry TODOs that look like product work. Operat
 
 | TODO site | Honest status |
 |-----------|---------------|
-| wire active candidate loading via `proxyChannelCoordinator` | **Partial / not TS-parity** — SQL stub runs and can feed probes, but ignores process-local coordinator active set |
+| wire active candidate loading via `proxyChannelCoordinator` | **Wired when proxy upstream boots** (`scheduler.SetActiveChannelIDsProvider` → `coord.GetActiveChannelIDs`, #273). Residual SQL `LIMIT 50` remains only when provider is unset (tests / pre-boot). Process-local leases still mean multi-instance active sets are not shared. |
 
-**Not a pure no-op**: cooling load + optional model probes can perform real work. The residual is **active-candidate source fidelity**, not "entire scheduler is dead".
+**Not a pure no-op**: cooling load + optional model probes can perform real work. Remaining honesty gap is multi-instance coordinator state, not missing boot wiring.
 
 ### 3. `SiteAnnouncementScheduler` (`site_announcement.go`)
 

--- a/scheduler/channel_recovery.go
+++ b/scheduler/channel_recovery.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/tokendancelab/metapi-go/config"
 	"github.com/tokendancelab/metapi-go/store"
 )
@@ -18,6 +20,38 @@ const (
 	channelRecoveryCooldownRecheckMs = 30_000     // 30s for cooldown
 	channelRecoveryActiveRecheckMs   = 5 * 60_000 // 5min for active
 )
+
+// Optional process-local provider of coordinator-active channel IDs.
+// Wired from app.ConfigureProxyUpstream to ProxyChannelCoordinator.GetActiveChannelIDs
+// without importing proxy (avoids scheduler↔proxy cycles). #273
+var (
+	activeChannelIDsProviderMu sync.RWMutex
+	activeChannelIDsProvider   func() []int64
+)
+
+// SetActiveChannelIDsProvider registers (or clears with nil) the active-channel ID source
+// used by ChannelRecoveryScheduler.loadActiveCandidates.
+func SetActiveChannelIDsProvider(fn func() []int64) {
+	activeChannelIDsProviderMu.Lock()
+	defer activeChannelIDsProviderMu.Unlock()
+	activeChannelIDsProvider = fn
+}
+
+// GetActiveChannelIDsFromProvider returns IDs from the registered provider.
+// Returns nil when no provider is registered.
+func GetActiveChannelIDsFromProvider() []int64 {
+	fn := getActiveChannelIDsProvider()
+	if fn == nil {
+		return nil
+	}
+	return fn()
+}
+
+func getActiveChannelIDsProvider() func() []int64 {
+	activeChannelIDsProviderMu.RLock()
+	defer activeChannelIDsProviderMu.RUnlock()
+	return activeChannelIDsProvider
+}
 
 // ChannelRecoveryScheduler periodically sweeps channels that are in cooldown
 // or active to probe if they have recovered.
@@ -124,14 +158,8 @@ func (s *ChannelRecoveryScheduler) runSweepLocked(dbw *store.DB) {
 
 	// Query cooling channels (SQL-backed; real candidate list).
 	coolingCandidates := s.loadCoolingCandidates(dbw)
-	// Residual honesty (#246): active candidates are loaded via a simplified SQL
-	// stub (enabled route_channels with null cooldown), NOT via
-	// proxyChannelCoordinator.getActiveChannelIds() as the TS path does.
-	// That means process-local routing/coordinator state is ignored; the SQL
-	// list is an approximation and may include channels the coordinator would
-	// not treat as "active for recovery".
-	// TODO residual (partial): wire active candidate loading via
-	// proxyChannelCoordinator when that surface is shared with this package.
+	// Active candidates prefer ProxyChannelCoordinator via optional provider
+	// hook (#273). When unset, residual SQL LIMIT 50 approximation remains.
 	activeCandidates := s.loadActiveCandidates(dbw)
 
 	merged := s.mergeCandidates(coolingCandidates, activeCandidates)
@@ -201,10 +229,17 @@ func (s *ChannelRecoveryScheduler) loadCoolingCandidates(dbw *store.DB) []recove
 }
 
 func (s *ChannelRecoveryScheduler) loadActiveCandidates(dbw *store.DB) []recoveryCandidate {
-	// Residual (#246): SQL approximation of "active" channels (enabled + no
-	// cooldown + active account/site). Not wired to proxyChannelCoordinator.
-	// LIMIT 50 is a local guard, not TS coordinator semantics. Not a silent
-	// no-op — rows are returned and may be probed — but selection is residual.
+	// Prefer coordinator-active IDs when app has wired the optional provider (#273).
+	// Presence of the provider (not the slice contents) selects this path so an
+	// empty active-lease set does not fall back to the residual SQL scan.
+	if fn := getActiveChannelIDsProvider(); fn != nil {
+		return s.loadActiveCandidatesFromIDs(dbw, fn())
+	}
+
+	// Residual fallback (#246/#273): SQL approximation of "active" channels
+	// (enabled + no cooldown + active account/site) when no coordinator
+	// provider is registered. LIMIT 50 is a local guard, not coordinator
+	// semantics. Honest residual only when the optional hook is unset.
 	var candidates []recoveryCandidate
 
 	rows, err := dbw.Query(`
@@ -231,6 +266,65 @@ func (s *ChannelRecoveryScheduler) loadActiveCandidates(dbw *store.DB) []recover
 		}
 		if c.modelName != "" {
 			candidates = append(candidates, c)
+		}
+	}
+	return candidates
+}
+
+// loadActiveCandidatesFromIDs resolves model names for coordinator-provided channel IDs.
+// Includes enabled channels with active account/site. Null cooldown is preferred;
+// channels that still have a source_model are included even when cooldown is set.
+func (s *ChannelRecoveryScheduler) loadActiveCandidatesFromIDs(dbw *store.DB, ids []int64) []recoveryCandidate {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	query, args, err := sqlx.In(`
+		SELECT rc.id, COALESCE(rc.source_model, '') as source_model
+		FROM route_channels rc
+		INNER JOIN accounts a ON rc.account_id = a.id
+		INNER JOIN sites st ON a.site_id = st.id
+		WHERE rc.id IN (?)
+		  AND rc.enabled = TRUE
+		  AND a.status = 'active'
+		  AND st.status = 'active'
+		  AND (
+		    rc.cooldown_until IS NULL
+		    OR (rc.source_model IS NOT NULL AND TRIM(rc.source_model) != '')
+		  )
+	`, ids)
+	if err != nil {
+		slog.Error("channel-recovery: failed to build active candidate query", "error", err)
+		return nil
+	}
+
+	rows, err := dbw.Query(query, args...)
+	if err != nil {
+		slog.Error("channel-recovery: failed to load active candidates from provider IDs", "error", err)
+		return nil
+	}
+	defer rows.Close()
+
+	// Preserve provider order where possible.
+	byID := make(map[int64]recoveryCandidate, len(ids))
+	for rows.Next() {
+		var c recoveryCandidate
+		c.source = "active"
+		if err := rows.Scan(&c.channelID, &c.modelName); err != nil {
+			continue
+		}
+		c.modelName = strings.TrimSpace(c.modelName)
+		if c.modelName != "" {
+			byID[c.channelID] = c
+		}
+	}
+
+	candidates := make([]recoveryCandidate, 0, len(byID))
+	seen := make(map[int64]bool, len(byID))
+	for _, id := range ids {
+		if c, ok := byID[id]; ok && !seen[id] {
+			candidates = append(candidates, c)
+			seen[id] = true
 		}
 	}
 	return candidates

--- a/scheduler/channel_recovery_test.go
+++ b/scheduler/channel_recovery_test.go
@@ -1,0 +1,158 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func TestSetActiveChannelIDsProvider(t *testing.T) {
+	t.Cleanup(func() { SetActiveChannelIDsProvider(nil) })
+
+	if GetActiveChannelIDsFromProvider() != nil {
+		t.Fatal("expected nil IDs when provider unset")
+	}
+
+	SetActiveChannelIDsProvider(func() []int64 { return []int64{7, 9} })
+	got := GetActiveChannelIDsFromProvider()
+	if len(got) != 2 || got[0] != 7 || got[1] != 9 {
+		t.Fatalf("provider IDs = %v, want [7 9]", got)
+	}
+
+	SetActiveChannelIDsProvider(nil)
+	if GetActiveChannelIDsFromProvider() != nil {
+		t.Fatal("expected nil after clearing provider")
+	}
+}
+
+func TestLoadActiveCandidates_ProviderUsesIDs(t *testing.T) {
+	db := openChannelRecoveryTestDB(t)
+	s := NewChannelRecoveryScheduler(testConfig())
+
+	now := time.Now().UTC()
+	idA := seedRecoveryChannel(t, db, "provider-a", "gpt-a", true, nil)
+	idB := seedRecoveryChannel(t, db, "provider-b", "gpt-b", true, nil)
+	idC := seedRecoveryChannel(t, db, "provider-c", "gpt-c", true, nil)
+	// Cooldown channel with source_model should still resolve from provider IDs.
+	cooldownUntil := now.Add(10 * time.Minute).Format(time.RFC3339)
+	idCooldown := seedRecoveryChannel(t, db, "provider-cd", "gpt-cd", true, &cooldownUntil)
+	// Disabled channel should be ignored even if provider lists it.
+	idDisabled := seedRecoveryChannel(t, db, "provider-off", "gpt-off", false, nil)
+
+	t.Cleanup(func() { SetActiveChannelIDsProvider(nil) })
+	SetActiveChannelIDsProvider(func() []int64 {
+		return []int64{idB, idA, idCooldown, idDisabled, idC + 999}
+	})
+
+	got := s.loadActiveCandidates(db)
+	if len(got) != 3 {
+		t.Fatalf("candidates = %+v, want 3 (B,A,cooldown)", got)
+	}
+	if got[0].channelID != idB || got[0].modelName != "gpt-b" || got[0].source != "active" {
+		t.Fatalf("first candidate = %+v, want channel %d gpt-b active", got[0], idB)
+	}
+	if got[1].channelID != idA || got[1].modelName != "gpt-a" {
+		t.Fatalf("second candidate = %+v, want channel %d gpt-a", got[1], idA)
+	}
+	if got[2].channelID != idCooldown || got[2].modelName != "gpt-cd" {
+		t.Fatalf("third candidate = %+v, want cooldown channel %d gpt-cd", got[2], idCooldown)
+	}
+
+	// Empty provider result must not fall through to residual SQL LIMIT 50.
+	SetActiveChannelIDsProvider(func() []int64 { return []int64{} })
+	if got := s.loadActiveCandidates(db); len(got) != 0 {
+		t.Fatalf("empty provider should yield 0 candidates, got %+v", got)
+	}
+	_ = idC
+}
+
+func TestLoadActiveCandidates_NilProviderSQLFallback(t *testing.T) {
+	db := openChannelRecoveryTestDB(t)
+	s := NewChannelRecoveryScheduler(testConfig())
+	t.Cleanup(func() { SetActiveChannelIDsProvider(nil) })
+	SetActiveChannelIDsProvider(nil)
+
+	now := time.Now().UTC()
+	idActive := seedRecoveryChannel(t, db, "sql-active", "gpt-sql", true, nil)
+	cooldownUntil := now.Add(5 * time.Minute).Format(time.RFC3339)
+	_ = seedRecoveryChannel(t, db, "sql-cd", "gpt-cd", true, &cooldownUntil)
+	_ = seedRecoveryChannel(t, db, "sql-off", "gpt-off", false, nil)
+
+	got := s.loadActiveCandidates(db)
+	if len(got) != 1 {
+		t.Fatalf("SQL fallback candidates = %+v, want only null-cooldown enabled channel", got)
+	}
+	if got[0].channelID != idActive || got[0].modelName != "gpt-sql" || got[0].source != "active" {
+		t.Fatalf("SQL fallback candidate = %+v, want channel %d gpt-sql active", got[0], idActive)
+	}
+}
+
+func openChannelRecoveryTestDB(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func seedRecoveryChannel(t *testing.T, db *store.DB, suffix, model string, enabled bool, cooldownUntil *string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		"site-"+suffix, "https://example.invalid/"+suffix, "anyrouter", "active", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+	res, err = db.Exec(
+		`INSERT INTO accounts (site_id, access_token, api_token, status, balance, quota, value_score, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		siteID, "tok-"+suffix, "tok-"+suffix, "active", 10.0, 100.0, 1.0, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("account id: %v", err)
+	}
+	res, err = db.Exec(
+		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		model, "pattern", "weighted", true, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	routeID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("route id: %v", err)
+	}
+	res, err = db.Exec(
+		`INSERT INTO route_channels (route_id, account_id, source_model, priority, weight, enabled, cooldown_until)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		routeID, accountID, model, 0, 10, enabled, cooldownUntil,
+	)
+	if err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+	channelID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("channel id: %v", err)
+	}
+	if channelID <= 0 {
+		t.Fatalf("unexpected channel id %d for %s", channelID, suffix)
+	}
+	return channelID
+}


### PR DESCRIPTION
## Summary
- Add optional `scheduler.SetActiveChannelIDsProvider` / `GetActiveChannelIDsFromProvider` hook so channel recovery can consume coordinator-active channel IDs without importing `proxy`.
- Wire the hook in `app.ConfigureProxyUpstream` to `ProxyChannelCoordinator.GetActiveChannelIDs`; clear it on failed/cleared reconfigure.
- `loadActiveCandidates` prefers provider IDs (empty set does not fall through); nil provider keeps residual SQL `LIMIT 50` fallback.
- Update residual honesty doc and add scheduler/app tests.

Closes #273

## Test plan
- [x] `go test ./scheduler ./proxy ./app -count=1`
- [x] Provider set uses provider IDs + SQL model lookup
- [x] Empty provider set does not fall back to residual SQL
- [x] Nil provider keeps SQL LIMIT 50 fallback