### PR TITLE
feat(scheduler): wire site-announcement sync (#272)

### DIFF
--- a/docs/analysis/scheduler-residual-todos.md
+++ b/docs/analysis/scheduler-residual-todos.md
@@ -14,8 +14,8 @@ Four background schedulers still carry TODOs that look like product work. Operat
 | Scheduler | File | Interval | What currently runs | Residual / silent gap | Multi-instance |
 |-----------|------|----------|---------------------|------------------------|----------------|
 | Sub2API refresh | `scheduler/sub2api_refresh.go` | 60s (min 60s) | Lease + SQL scan of active `sub2api` accounts; logs `scanned=N, refreshed=0, failed=0` | Does **not** parse `extraConfig.sub2apiAuth`; does **not** filter due tokens; does **not** call `refreshSub2ApiManagedSessionSingleflight` or any upstream refresh. Concurrency constant unused. | `runWithSchedulerLease` (PG advisory lock / process-local mutex). Only one instance runs the empty pass. |
-| Channel recovery | `scheduler/channel_recovery.go` | 30s (min 10s) | Lease + load cooling candidates (SQL) + load active candidates (coordinator provider when wired, else SQL stub) + merge/filter/prioritize + probe via global model-probe scheduler when registered | Active path prefers optional `SetActiveChannelIDsProvider` → `ProxyChannelCoordinator.GetActiveChannelIDs` (#273). Residual only when provider is **unset**: SQL `LIMIT 50` approximation. Probe is real only if model-probe is registered; otherwise probe is skipped with debug log. | Lease serializes sweeps across PG instances. In-flight / last-started maps and coordinator active set are **process-local**. |
-| Site announcement | `scheduler/site_announcement.go` | 15m (min 10s) | Lease + enumerate active sites + log count | **No** platform adapter calls, **no** `site_announcements` writes, **no** notifications/events. Admin `POST /api/site-announcements/sync` already has real `syncSiteAnnouncements`; this ticker does not call it. | Lease serializes residual scan. No shared announcement write from this path (because none occur). |
+| Channel recovery | `scheduler/channel_recovery.go` | 30s (min 10s) | Lease + cooling SQL + active candidates via optional `SetActiveChannelIDsProvider` (coordinator) or SQL LIMIT 50 residual + probe | Active path prefers provider (#273); residual SQL only when provider **unset**. Empty provider set does not fall back to residual SQL. Probe real only if model-probe registered. | Lease serializes sweeps; in-flight maps process-local. |
+| Site announcement | `scheduler/site_announcement.go` | 15m (min 10s) | Lease + optional `SyncFunc` (wired from admin `SyncSiteAnnouncements` via `SetDefaultSiteAnnouncementSyncFunc` on route register, #272) | When SyncFunc set: real platform adapter + DB writes. When nil: residual scan-only remains for tests/partial boots. | Lease serializes sync/scan. |
 | Update center | `scheduler/update_center.go` | 15m (min 10s) | Lease + log line | **No** remote registry/helper poll, **no** version persistence, **no** deploy/rollback. Admin status/check are local stubs (`0.0.0`); deploy/rollback are 501 residuals (`residual-update-center.md`). | Lease serializes residual log. No cluster-wide "last checked" state. |
 
 ## Per-scheduler detail
@@ -139,3 +139,11 @@ test -f docs/analysis/scheduler-residual-todos.md
 - `docs/analysis/residual-update-center.md` — admin deploy/rollback / clear-cache honesty
 - `docs/analysis/background-tasks-multi-instance-residual.md` — process-local admin task registry
 - `docs/specs/p12-schedulers.md` — intended TS parity (aspirational vs residual above)
+
+### Update (#272)
+
+Production path: `RegisterSiteAnnouncementsRoutes` installs `SetDefaultSiteAnnouncementSyncFunc` → `admin.SyncSiteAnnouncements`. Residual scan only when `SyncFunc` is nil.
+
+### Update (#273)
+
+Channel recovery active candidates prefer optional `SetActiveChannelIDsProvider` (wired from `ConfigureProxyUpstream` → `ProxyChannelCoordinator.GetActiveChannelIDs`). Nil provider keeps SQL `LIMIT 50` residual fallback. Empty provider set does **not** fall back to residual SQL.

--- a/handler/admin/site_announcements.go
+++ b/handler/admin/site_announcements.go
@@ -14,12 +14,18 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/tokendancelab/metapi-go/config"
 	"github.com/tokendancelab/metapi-go/platform"
+	"github.com/tokendancelab/metapi-go/scheduler"
 	"github.com/tokendancelab/metapi-go/service"
 	"github.com/tokendancelab/metapi-go/service/notify"
 )
 
 // RegisterSiteAnnouncementsRoutes registers all /api/site-announcements routes.
+// Also wires the background SiteAnnouncementScheduler to real SyncSiteAnnouncements
+// (#272). Routes register before StartBackgroundServices, so the package-level
+// default is installed for NewSiteAnnouncementScheduler to pick up.
 func RegisterSiteAnnouncementsRoutes(r chi.Router, db *sqlx.DB) {
+	wireSiteAnnouncementSchedulerSync()
+
 	handler := &siteAnnouncementsHandler{db: db}
 
 	r.Get("/api/site-announcements", handler.listAnnouncements)
@@ -29,12 +35,31 @@ func RegisterSiteAnnouncementsRoutes(r chi.Router, db *sqlx.DB) {
 	r.Post("/api/site-announcements/sync", handler.syncAnnouncements)
 }
 
+// wireSiteAnnouncementSchedulerSync injects admin SyncSiteAnnouncements into the
+// scheduler package without creating an app→admin import cycle (admin already
+// imports scheduler; app cannot import admin).
+func wireSiteAnnouncementSchedulerSync() {
+	scheduler.SetDefaultSiteAnnouncementSyncFunc(func(db *sqlx.DB) scheduler.SiteAnnouncementSyncResult {
+		result := SyncSiteAnnouncements(db, nil)
+		return scheduler.SiteAnnouncementSyncResult{
+			ScannedSites:  result.ScannedSites,
+			Inserted:      result.Inserted,
+			Updated:       result.Updated,
+			Unsupported:   result.Unsupported,
+			Notifications: result.Notifications,
+			Events:        result.Events,
+			Failed:        result.Failed,
+		}
+	})
+}
+
 type siteAnnouncementsHandler struct {
 	db *sqlx.DB
 }
 
-// siteAnnouncementSyncResult mirrors the TS syncSiteAnnouncements result shape.
-type siteAnnouncementSyncResult struct {
+// SiteAnnouncementSyncResult mirrors the TS syncSiteAnnouncements result shape.
+// Used by the admin HTTP task path and by SiteAnnouncementScheduler via SyncSiteAnnouncements.
+type SiteAnnouncementSyncResult struct {
 	ScannedSites  int                          `json:"scannedSites"`
 	Inserted      int                          `json:"inserted"`
 	Updated       int                          `json:"updated"`
@@ -42,10 +67,11 @@ type siteAnnouncementSyncResult struct {
 	Notifications int                          `json:"notifications"`
 	Events        int                          `json:"events"`
 	Failed        int                          `json:"failed"`
-	FailedSites   []siteAnnouncementFailedSite `json:"failedSites"`
+	FailedSites   []SiteAnnouncementFailedSite `json:"failedSites"`
 }
 
-type siteAnnouncementFailedSite struct {
+// SiteAnnouncementFailedSite is one site that failed during announcement sync.
+type SiteAnnouncementFailedSite struct {
 	SiteID   int64  `json:"siteId"`
 	SiteName string `json:"siteName"`
 	Message  string `json:"message"`
@@ -231,7 +257,7 @@ func (h *siteAnnouncementsHandler) syncAnnouncements(w http.ResponseWriter, r *h
 		Title:     title,
 		DedupeKey: dedupeKey,
 	}, func() (any, error) {
-		result := syncSiteAnnouncements(db, siteID)
+		result := SyncSiteAnnouncements(db, siteID)
 		return result, nil
 	})
 
@@ -243,9 +269,12 @@ func (h *siteAnnouncementsHandler) syncAnnouncements(w http.ResponseWriter, r *h
 	})
 }
 
-func syncSiteAnnouncements(db *sqlx.DB, siteID *int64) siteAnnouncementSyncResult {
-	result := siteAnnouncementSyncResult{
-		FailedSites: []siteAnnouncementFailedSite{},
+// SyncSiteAnnouncements fetches announcements for active sites (or one site)
+// via platform adapters and upserts site_announcements. Exported so the
+// background SiteAnnouncementScheduler can reuse this path without HTTP (#272).
+func SyncSiteAnnouncements(db *sqlx.DB, siteID *int64) SiteAnnouncementSyncResult {
+	result := SiteAnnouncementSyncResult{
+		FailedSites: []SiteAnnouncementFailedSite{},
 	}
 
 	type siteRow struct {
@@ -266,7 +295,7 @@ func syncSiteAnnouncements(db *sqlx.DB, siteID *int64) siteAnnouncementSyncResul
 	if err != nil {
 		slog.Error("site-announcement sync: failed to query sites", "error", err)
 		result.Failed++
-		result.FailedSites = append(result.FailedSites, siteAnnouncementFailedSite{
+		result.FailedSites = append(result.FailedSites, SiteAnnouncementFailedSite{
 			SiteID:   0,
 			SiteName: "",
 			Message:  err.Error(),
@@ -291,7 +320,7 @@ func syncSiteAnnouncements(db *sqlx.DB, siteID *int64) siteAnnouncementSyncResul
 		anns, annErr := adapter.GetSiteAnnouncements(ctx, site.URL, accessToken, nil, nil)
 		if annErr != nil {
 			result.Failed++
-			result.FailedSites = append(result.FailedSites, siteAnnouncementFailedSite{
+			result.FailedSites = append(result.FailedSites, SiteAnnouncementFailedSite{
 				SiteID:   site.ID,
 				SiteName: site.Name,
 				Message:  annErr.Error(),
@@ -365,7 +394,7 @@ func syncSiteAnnouncements(db *sqlx.DB, siteID *int64) siteAnnouncementSyncResul
 			)
 			if insertErr != nil {
 				result.Failed++
-				result.FailedSites = append(result.FailedSites, siteAnnouncementFailedSite{
+				result.FailedSites = append(result.FailedSites, SiteAnnouncementFailedSite{
 					SiteID:   site.ID,
 					SiteName: site.Name,
 					Message:  insertErr.Error(),

--- a/scheduler/site_announcement.go
+++ b/scheduler/site_announcement.go
@@ -6,11 +6,49 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/tokendancelab/metapi-go/config"
 	"github.com/tokendancelab/metapi-go/store"
 )
 
 const defaultSiteAnnouncementIntervalMs = 15 * 60 * 1000 // 15 minutes
+
+// SiteAnnouncementSyncResult is the honest outcome of a real announcement sync pass.
+// Field names mirror admin SyncSiteAnnouncements / TS syncSiteAnnouncements.
+type SiteAnnouncementSyncResult struct {
+	ScannedSites  int
+	Inserted      int
+	Updated       int
+	Unsupported   int
+	Notifications int
+	Events        int
+	Failed        int
+}
+
+// SiteAnnouncementSyncFunc runs a full announcement sync against the given DB.
+// Implementations must call real platform adapters (no invented success counts).
+// Injected from app/admin composition root so scheduler does not import handler/admin.
+type SiteAnnouncementSyncFunc func(db *sqlx.DB) SiteAnnouncementSyncResult
+
+var (
+	defaultSiteAnnouncementSyncMu sync.RWMutex
+	defaultSiteAnnouncementSync   SiteAnnouncementSyncFunc
+)
+
+// SetDefaultSiteAnnouncementSyncFunc installs the process-wide sync implementation
+// used by NewSiteAnnouncementScheduler when no per-instance SyncFunc is set.
+// Safe to call before StartBackgroundServices (routes register first).
+func SetDefaultSiteAnnouncementSyncFunc(fn SiteAnnouncementSyncFunc) {
+	defaultSiteAnnouncementSyncMu.Lock()
+	defer defaultSiteAnnouncementSyncMu.Unlock()
+	defaultSiteAnnouncementSync = fn
+}
+
+func getDefaultSiteAnnouncementSyncFunc() SiteAnnouncementSyncFunc {
+	defaultSiteAnnouncementSyncMu.RLock()
+	defer defaultSiteAnnouncementSyncMu.RUnlock()
+	return defaultSiteAnnouncementSync
+}
 
 // SiteAnnouncementScheduler polls site announcements periodically.
 type SiteAnnouncementScheduler struct {
@@ -20,11 +58,24 @@ type SiteAnnouncementScheduler struct {
 	running  bool
 	mu       sync.Mutex
 	inFlight bool
+	syncFunc SiteAnnouncementSyncFunc
 }
 
 // NewSiteAnnouncementScheduler creates a new site announcement poller.
+// Picks up any process-wide SyncFunc installed via SetDefaultSiteAnnouncementSyncFunc.
 func NewSiteAnnouncementScheduler(cfg *config.Config) *SiteAnnouncementScheduler {
-	return &SiteAnnouncementScheduler{cfg: cfg}
+	return &SiteAnnouncementScheduler{
+		cfg:      cfg,
+		syncFunc: getDefaultSiteAnnouncementSyncFunc(),
+	}
+}
+
+// SetSyncFunc injects (or clears) the real sync implementation for this instance.
+// When fn is nil, the scheduler keeps residual scan-only behavior.
+func (s *SiteAnnouncementScheduler) SetSyncFunc(fn SiteAnnouncementSyncFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.syncFunc = fn
 }
 
 func (s *SiteAnnouncementScheduler) Name() string { return "site-announcement" }
@@ -99,13 +150,34 @@ func (s *SiteAnnouncementScheduler) runSync() {
 }
 
 func (s *SiteAnnouncementScheduler) runSyncLocked(dbw *store.DB) {
-	// Residual honesty (#246): this scheduler pass is scan-only.
-	// What runs: enumerate active sites under the scheduler lease and log the
-	// count. What does NOT run: platform adapter GetSiteAnnouncements, DB
-	// insert/update into site_announcements, notifications, or events.
-	// Admin path POST /api/site-announcements/sync already implements real
-	// syncSiteAnnouncements; this ticker does not call it. "sync complete"
-	// means "enumeration complete", not that announcements were fetched.
+	s.mu.Lock()
+	fn := s.syncFunc
+	s.mu.Unlock()
+
+	if fn == nil {
+		// Residual honesty: no SyncFunc injected — scan-only, no platform calls.
+		// What runs: enumerate active sites under the scheduler lease and log the
+		// count. What does NOT run: platform adapter GetSiteAnnouncements, DB
+		// insert/update into site_announcements, notifications, or events.
+		// Production wires SyncFunc via admin.SyncSiteAnnouncements (#272).
+		s.runResidualScan(dbw)
+		return
+	}
+
+	slog.Info("site-announcement: running sync")
+	result := fn(dbw.DB)
+	slog.Info("site-announcement: sync complete",
+		"scanned", result.ScannedSites,
+		"inserted", result.Inserted,
+		"updated", result.Updated,
+		"unsupported", result.Unsupported,
+		"notifications", result.Notifications,
+		"events", result.Events,
+		"failed", result.Failed,
+	)
+}
+
+func (s *SiteAnnouncementScheduler) runResidualScan(dbw *store.DB) {
 	slog.Info("site-announcement: residual scan (no platform sync)")
 
 	rows, err := dbw.Query("SELECT id, platform, url FROM sites WHERE status = 'active'")
@@ -125,10 +197,7 @@ func (s *SiteAnnouncementScheduler) runSyncLocked(dbw *store.DB) {
 		_ = id
 		_ = platform
 		_ = url
-		// Residual (#246): site row is counted only.
-		// TODO residual (not wired): call platform-specific announcement sync
-		// (reuse admin syncSiteAnnouncements / adapter.GetSiteAnnouncements).
-		// Do not invent inserted/updated success without real upstream calls.
+		// Residual: site row is counted only. No adapter / DB write.
 		count++
 	}
 

--- a/scheduler/site_announcement_test.go
+++ b/scheduler/site_announcement_test.go
@@ -1,0 +1,42 @@
+package scheduler
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/config"
+)
+
+func TestSiteAnnouncementSyncFuncInvoked(t *testing.T) {
+	t.Cleanup(func() { SetDefaultSiteAnnouncementSyncFunc(nil) })
+
+	var called atomic.Int64
+	SetDefaultSiteAnnouncementSyncFunc(func(db *sqlx.DB) SiteAnnouncementSyncResult {
+		called.Add(1)
+		return SiteAnnouncementSyncResult{ScannedSites: 2, Inserted: 1}
+	})
+
+	s := NewSiteAnnouncementScheduler(&config.Config{})
+	if s.syncFunc == nil {
+		t.Fatal("expected default SyncFunc to be picked up")
+	}
+	// Direct locked path without DB/lease: call syncFunc shape
+	result := s.syncFunc(nil)
+	if result.ScannedSites != 2 || result.Inserted != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	if called.Load() != 1 {
+		t.Fatalf("called=%d", called.Load())
+	}
+}
+
+func TestSiteAnnouncementResidualWhenNil(t *testing.T) {
+	t.Cleanup(func() { SetDefaultSiteAnnouncementSyncFunc(nil) })
+	SetDefaultSiteAnnouncementSyncFunc(nil)
+	s := NewSiteAnnouncementScheduler(&config.Config{})
+	s.SetSyncFunc(nil)
+	if s.syncFunc != nil {
+		t.Fatal("expected nil SyncFunc")
+	}
+}


### PR DESCRIPTION
## Summary
- `SiteAnnouncementScheduler` accepts optional `SyncFunc`
- Admin route registration installs `SyncSiteAnnouncements` as process default
- Honest residual scan when SyncFunc nil
- Unit tests + residual doc update

Closes #272

## Test plan
- [x] `go test ./scheduler ./handler/admin -count=1`