### PR TITLE
docs(release): v0.8.12 Enterprise residual (#271–#274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.12] — 2026-07-17
+
+### Fixed
+- Admin BackgroundTask snapshot under mutex (DATA RACE on get/list vs runner Result write) (#271 / #275)
+
+### Added
+- Site-announcement scheduler wires to real `SyncSiteAnnouncements` via SyncFunc (#272 / #278)
+- Channel recovery active candidates via optional `ProxyChannelCoordinator` provider hook (#273 / #276)
+
+### Docs / Honesty
+- Responses WebSocket residual product path evaluation (stay 426/501 for v0.8.x) (#274 / #277)
+
 ## [v0.8.11] — 2026-07-17
 
 ### Added

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -85,6 +85,7 @@
 | Residual v0.8.9 | Milestone 18 closed · tag **[v0.8.9](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.9)** |
 | Residual v0.8.10 | Milestone 19 closed · tag **[v0.8.10](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.10)** |
 | Residual v0.8.11 | Milestone 20 closed · **#265–#266** (PRs #267/#268); tag **v0.8.11** |
+| Residual v0.8.12 | Milestone 21 closed · **#271–#274** (PRs #275/#276/#277/#278); tag **v0.8.12** |
 | Residual CI | vulncheck green on Go 1.26.5; frontend occasional EnvironmentTeardownError flake |
 
 ### M-COMPETE notes (active)
@@ -179,8 +180,6 @@
 - **M-SCHEMA**: additive `schema_migrations` + columns `proxy_url` / `max_concurrency` / `context_length`
 
 ## Next Steps
-1. Tag **v0.8.11** (durable admin task store + frontend CI flake)
-2. Optional deeper product: full Responses WS Codex path; channel recovery coordinator wiring; product backlog P0/P1 (Sub2API refresh + video task retention)
-2. Optional deeper product: full Responses WS Codex path; durable admin job store; product backlog P0/P1; frontend flake observability (videos sticky pin + retention residual honesty)
-2. Optional deeper product: full Responses WS Codex path; durable admin job store; Sub2API/channel-recovery product wiring; video task TTL/GC product
-3. Continue product backlog P0/P1; frontend flake observability
+1. Tag **v0.8.12** (admin task race + site-announcement wire + channel-recovery coordinator + WS residual eval)
+2. Optional deeper product: full Responses WS Codex path (see residual eval #274); update-center product; product backlog P0/P1
+3. Continue product backlog P0/P1; multi-instance sticky/session affinity product if needed


### PR DESCRIPTION
## Summary
- CHANGELOG **v0.8.12**: #271 race fix, #272 site-announcement wire, #273 channel-recovery coordinator, #274 WS residual eval
- MASTER residual row + Next Steps
- Milestone 21 closed (all issues merged)

## Test plan
- docs only