### PR TITLE
feat(update-center): residual honesty hardening (#283)

### DIFF
--- a/docs/analysis/residual-update-center.md
+++ b/docs/analysis/residual-update-center.md
@@ -1,12 +1,32 @@
-# Residual: update-center deploy/rollback + maintenance clear-cache honesty (#197)
+# Residual: update-center honesty (admin + scheduler)
 
 **Date**: 2026-07-17  
-**Issue**: [#197](https://github.com/TokenDanceLab/metapi-go/issues/197)  
-**Lane**: residual honesty (admin ops)
+**Issues**: [#197](https://github.com/TokenDanceLab/metapi-go/issues/197), [#283](https://github.com/TokenDanceLab/metapi-go/issues/283)  
+**Lane**: residual honesty (admin ops + scheduler scaffolding)  
+**Scope**: honest 501 / local stubs only. **No remote registry product.**
 
 ## Goal
 
-Stop success-theater for operations that are not implemented in-process:
+Stop success-theater for operations that are not implemented in-process, and keep status/check from inventing `updateAvailable=true` without a real helper/registry client.
+
+## Current endpoint table (#283)
+
+| Method | Endpoint | Status | Behavior | Invents? |
+|--------|----------|--------|----------|----------|
+| `GET` | `/api/update-center/status` | **200** | Local stub: `currentVersion`/`latestVersion`=`0.0.0`, `updateAvailable=false`, `lastCheckedAt=null`, plus `residual` string | **No** remote poll, **no** fake available update |
+| `POST` | `/api/update-center/check` | **200** | Same payload as status (local-only; no remote registry check) | **No** remote poll, **no** fake available update |
+| `PUT` | `/api/update-center/config` | **200** | Echo request body for UI round-trip; `residual` notes echo-only (not a durable product config store) | **No** deploy side effects |
+| `POST` | `/api/update-center/deploy` | **400** / **501** | Validates `targetTag` (or `targetVersion` alias); then honest residual | **No** `stub-deploy` task id |
+| `POST` | `/api/update-center/rollback` | **400** / **501** | Validates `targetRevision`; then honest residual | **No** `stub-rollback` task id |
+| `GET` | `/api/update-center/tasks/:id/stream` | **501** | No in-process update-center task registry / SSE log stream | **No** fake SSE `done/stub` |
+
+Related (same residual wave historically, implemented work — not residual):
+
+| Method | Endpoint | Status | Behavior |
+|--------|----------|--------|----------|
+| `POST` | `/api/settings/maintenance/clear-cache` | **202** | Real DB wipe + process-local cache invalidation + real background rebuild `jobId` (never `stub-clear-cache`) |
+
+## Previous success-theater → current honesty (#197)
 
 | Endpoint | Previous | New |
 |----------|----------|-----|
@@ -15,21 +35,23 @@ Stop success-theater for operations that are not implemented in-process:
 | `GET /api/update-center/tasks/:id/stream` | SSE with immediate fake `done/stub` | **501** residual (no fake SSE) |
 | `POST /api/settings/maintenance/clear-cache` | deleted rows + `jobId: "stub-clear-cache"` | delete rows + **real** in-process invalidation + **real** background task id |
 
-## Safe local clear-cache behavior
+## Status / check payload (local stub)
 
-1. Count + `DELETE` from shared tables:
-   - `model_availability`
-   - `route_channels`
-   - `token_routes`
-2. Invalidate **this process** caches immediately:
-   - `routing.InvalidateCache()` (route match / stable-first caches)
-   - `globalAccountsCache.clear()` (admin accounts list snapshot)
-3. Queue a real in-memory background task (`maintenance-clear-cache`) that:
-   - runs `service.RebuildRoutesBestEffort()`
-   - re-invalidates local caches after rebuild
-4. Return `202` with the real `jobId` / `taskId` (never `stub-clear-cache`)
+```json
+{
+  "currentVersion": "0.0.0",
+  "latestVersion": "0.0.0",
+  "updateAvailable": false,
+  "lastCheckedAt": null,
+  "residual": "local stub only; no remote registry/helper polling or version discovery in Go"
+}
+```
 
-After wiping availability tables, rebuild is intentionally best-effort and may insert few/no channels until models are re-probed. That is still honest work, not a fake job id.
+Rules:
+
+- Never invent `updateAvailable=true` without a real remote registry/helper client.
+- Never invent a non-null `lastCheckedAt` from a fake poll.
+- `0.0.0` is an explicit local placeholder, not a discovered latest release.
 
 ## Deploy / rollback residual (out of scope)
 
@@ -51,6 +73,38 @@ Rules:
 - Never invent `stub-deploy` / `stub-rollback` task ids.
 - Validation still runs first (`targetTag` / `targetRevision` required → `400`).
 
+## Scheduler: log-only residual (#246 / #283)
+
+`scheduler/update_center.go` (`UpdateCenterScheduler`):
+
+| Aspect | Honest status |
+|--------|---------------|
+| Interval | 15m (min 10s) |
+| What runs | Ticker + process-local in-flight guard + `runWithSchedulerLease` + **one info log line** |
+| What does **not** run | Remote registry/helper HTTP, version compare, `lastCheckedAt` persistence, deploy/rollback, SSE task completion |
+| Product effect | **None** — residual scaffolding only |
+| Multi-instance | Lease serializes the residual log; no cluster-wide "last checked" state |
+
+Log language is intentionally residual (`no remote polling; no version discovery; no updateAvailable invention`), not "update check success".
+
+Do **not** add fake polling stubs that invent `updateAvailable=true`. Wire real helper/registry client only when product path exists.
+
+## Safe local clear-cache behavior
+
+1. Count + `DELETE` from shared tables:
+   - `model_availability`
+   - `route_channels`
+   - `token_routes`
+2. Invalidate **this process** caches immediately:
+   - `routing.InvalidateCache()` (route match / stable-first caches)
+   - `globalAccountsCache.clear()` (admin accounts list snapshot)
+3. Queue a real in-memory background task (`maintenance-clear-cache`) that:
+   - runs `service.RebuildRoutesBestEffort()`
+   - re-invalidates local caches after rebuild
+4. Return `202` with the real `jobId` / `taskId` (never `stub-clear-cache`)
+
+After wiping availability tables, rebuild is intentionally best-effort and may insert few/no channels until models are re-probed. That is still honest work, not a fake job id.
+
 ## Multi-instance residual
 
 | Surface | Shared across instances? | Notes |
@@ -59,29 +113,43 @@ Rules:
 | `routing` in-process cache | **No** | Only the receiving process invalidates |
 | accounts snapshot cache | **No** | Only the receiving process clears |
 | background task registry (`jobId`) | **No** | Process-local; peer `/api/tasks/:id` will 404 |
-| remote deploy/rollback | **N/A** | Residual 501 everywhere until helper is wired |
+| update-center status/check | **N/A** | Local stub; no shared last-checked state |
+| remote deploy/rollback / task SSE | **N/A** | Residual 501 everywhere until helper is wired |
+| update-center scheduler | Lease only | Serializes residual log; no product state |
 
 Operators running multi-instance should either:
 
 1. call clear-cache on each instance (or restart pods), and/or  
 2. rely on route-cache TTL + account-snapshot TTL for natural expiry.
 
+## Explicit non-goals (#283)
+
+- Remote update-center helper client / registry polling product
+- Inventing `updateAvailable=true` or fake `lastCheckedAt`
+- Fake deploy/rollback task ids or SSE completion
+- Durable update-center config store from `PUT /config`
+- Multi-instance durable deploy job bus
+
 ## Tests
 
 ```bash
-go test ./handler/admin -count=1 -run 'Update|Maintenance|Cache'
+go test ./handler/admin ./scheduler -count=1 -run 'Update|update'
 ```
 
 Coverage:
 
+- status/check local stub: `updateAvailable=false`, residual field present, no invented available update
 - deploy/rollback validation `400`
 - deploy/rollback/stream honest `501` without stub task ids
-- clear-cache wipes seeded `token_routes`, clears accounts + route caches, returns real `jobId`, task reaches `succeeded`
+- clear-cache (related) wipes seeded `token_routes`, clears accounts + route caches, returns real `jobId`, task reaches `succeeded`
+- scheduler construct/stop residual ticker
 
 ## Files
 
 - `handler/admin/update_center.go`
-- `handler/admin/settings_maintenance.go`
 - `handler/admin/update_center_test.go`
+- `handler/admin/settings_maintenance.go`
 - `handler/admin/settings_maintenance_test.go`
+- `scheduler/update_center.go`
 - `docs/analysis/residual-update-center.md`
+- `docs/analysis/scheduler-residual-todos.md` (update-center inventory row)

--- a/docs/analysis/scheduler-residual-todos.md
+++ b/docs/analysis/scheduler-residual-todos.md
@@ -16,7 +16,7 @@ Four background schedulers still carry TODOs that look like product work. Operat
 | Sub2API refresh | `scheduler/sub2api_refresh.go` | 60s (min 60s) | Lease + SQL scan of active `sub2api` accounts; logs `scanned=N, refreshed=0, failed=0` | Does **not** parse `extraConfig.sub2apiAuth`; does **not** filter due tokens; does **not** call `refreshSub2ApiManagedSessionSingleflight` or any upstream refresh. Concurrency constant unused. | `runWithSchedulerLease` (PG advisory lock / process-local mutex). Only one instance runs the empty pass. |
 | Channel recovery | `scheduler/channel_recovery.go` | 30s (min 10s) | Lease + cooling SQL + active candidates via optional `SetActiveChannelIDsProvider` (coordinator) or SQL LIMIT 50 residual + probe | Active path prefers provider (#273); residual SQL only when provider **unset**. Empty provider set does not fall back to residual SQL. Probe real only if model-probe registered. | Lease serializes sweeps; in-flight maps process-local. |
 | Site announcement | `scheduler/site_announcement.go` | 15m (min 10s) | Lease + optional `SyncFunc` (wired from admin `SyncSiteAnnouncements` via `SetDefaultSiteAnnouncementSyncFunc` on route register, #272) | When SyncFunc set: real platform adapter + DB writes. When nil: residual scan-only remains for tests/partial boots. | Lease serializes sync/scan. |
-| Update center | `scheduler/update_center.go` | 15m (min 10s) | Lease + log line | **No** remote registry/helper poll, **no** version persistence, **no** deploy/rollback. Admin status/check are local stubs (`0.0.0`); deploy/rollback are 501 residuals (`residual-update-center.md`). | Lease serializes residual log. No cluster-wide "last checked" state. |
+| Update center | `scheduler/update_center.go` | 15m (min 10s) | Lease + residual log line only (#283) | **No** remote registry/helper poll, **no** version persistence, **no** deploy/rollback, **no** `updateAvailable` invention. Admin status/check are local stubs (`0.0.0` / `updateAvailable=false` + `residual`); deploy/rollback/SSE are 501 residuals (`residual-update-center.md`). | Lease serializes residual log. No cluster-wide "last checked" state. |
 
 ## Per-scheduler detail
 
@@ -89,18 +89,19 @@ Log language is intentionally "residual scan", not "sync success".
 
 ### 4. `UpdateCenterScheduler` (`update_center.go`)
 
-**Runs today**
+**Runs today** (#283)
 
-1. Ticker + immediate first run; `inFlight` + lease.
-2. Single info log: residual check, no remote polling.
+1. Ticker + immediate first residual pass; `inFlight` + lease.
+2. Single info log: residual check, no remote polling, no `updateAvailable` invention.
+3. **No** HTTP client, **no** version compare, **no** DB write of last-checked.
 
 **Residual**
 
 | TODO site | Honest status |
 |-----------|---------------|
-| wire actual update-center polling | **Not wired** — pure log-only no-op for product purposes |
+| wire actual update-center polling | **Not wired** — pure log-only no-op for product purposes. Do not add fake poll stubs. |
 
-Related admin residuals (deploy/rollback 501, local status stubs): `docs/analysis/residual-update-center.md`.
+Related admin residuals (status/check local stubs with residual field; deploy/rollback/SSE 501): `docs/analysis/residual-update-center.md` (#197 / #283).
 
 ## Multi-instance notes (shared)
 
@@ -136,7 +137,7 @@ test -f docs/analysis/scheduler-residual-todos.md
 ## Related docs
 
 - `docs/analysis/residual-sub2api-auth.md` — account-path managed auth merge residual
-- `docs/analysis/residual-update-center.md` — admin deploy/rollback / clear-cache honesty
+- `docs/analysis/residual-update-center.md` — admin status/check stubs + deploy/rollback 501 + scheduler log-only (#197 / #283)
 - `docs/analysis/background-tasks-multi-instance-residual.md` — process-local admin task registry
 - `docs/specs/p12-schedulers.md` — intended TS parity (aspirational vs residual above)
 
@@ -147,3 +148,7 @@ Production path: `RegisterSiteAnnouncementsRoutes` installs `SetDefaultSiteAnnou
 ### Update (#273)
 
 Channel recovery active candidates prefer optional `SetActiveChannelIDsProvider` (wired from `ConfigureProxyUpstream` → `ProxyChannelCoordinator.GetActiveChannelIDs`). Nil provider keeps SQL `LIMIT 50` residual fallback. Empty provider set does **not** fall back to residual SQL.
+
+### Update (#283)
+
+Update-center residual honesty hardening: scheduler remains log-only (no remote registry product). Admin status/check expose explicit `residual` and never invent `updateAvailable=true`. Deploy/rollback/SSE stay honest 501. Endpoint table + scheduler behavior documented in `residual-update-center.md`.

--- a/handler/admin/update_center.go
+++ b/handler/admin/update_center.go
@@ -8,6 +8,12 @@ import (
 )
 
 // RegisterUpdateCenterRoutes registers all /api/update-center routes.
+//
+// Residual honesty (#197 / #283):
+//   - status/check are local stubs (never invent updateAvailable=true)
+//   - config is echo-only (no durable helper registry config product)
+//   - deploy/rollback/task stream are honest 501 residuals (no stub task ids / fake SSE)
+// See docs/analysis/residual-update-center.md.
 func RegisterUpdateCenterRoutes(r chi.Router) {
 	handler := &updateCenterHandler{}
 
@@ -21,30 +27,36 @@ func RegisterUpdateCenterRoutes(r chi.Router) {
 
 type updateCenterHandler struct{}
 
-// GET /api/update-center/status
-// Local status only — remote version discovery is residual.
-func (h *updateCenterHandler) status(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{
+// localUpdateCenterStatus is the honest local-only payload for status/check.
+// Never set updateAvailable=true without a real remote registry/helper client.
+func localUpdateCenterStatus() map[string]any {
+	return map[string]any{
 		"currentVersion":  "0.0.0",
 		"latestVersion":   "0.0.0",
 		"updateAvailable": false,
 		"lastCheckedAt":   nil,
-	})
+		// residual field makes the stub explicit for operators/UI (#283).
+		"residual": "local stub only; no remote registry/helper polling or version discovery in Go",
+	}
+}
+
+// GET /api/update-center/status
+// Local status only — remote version discovery is residual (#283).
+// Never invents updateAvailable=true or a fake lastCheckedAt.
+func (h *updateCenterHandler) status(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, localUpdateCenterStatus())
 }
 
 // POST /api/update-center/check
-// Local check only — no remote registry polling yet.
+// Local check only — no remote registry polling (#283).
+// Same payload as status; does not start deploy tasks or invent "update available".
 func (h *updateCenterHandler) check(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{
-		"currentVersion":  "0.0.0",
-		"latestVersion":   "0.0.0",
-		"updateAvailable": false,
-		"lastCheckedAt":   nil,
-	})
+	writeJSON(w, http.StatusOK, localUpdateCenterStatus())
 }
 
 // PUT /api/update-center/config
-// Accepts and echoes config for UI round-trip; deploy/rollback remain residual.
+// Accepts and echoes config for UI round-trip; not persisted as a product config store.
+// Deploy/rollback remain residual 501 regardless of echoed values.
 func (h *updateCenterHandler) saveConfig(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Enabled             *bool   `json:"enabled"`
@@ -76,6 +88,8 @@ func (h *updateCenterHandler) saveConfig(w http.ResponseWriter, r *http.Request)
 			"imageRepository":     coalesceStr(body.ImageRepository, ""),
 			"defaultDeploySource": coalesceStr(body.DefaultDeploySource, "docker-hub-tag"),
 		},
+		// Echo-only: this handler does not persist helper/registry product config (#283).
+		"residual": "config echo only; not persisted as update-center product config; deploy/rollback remain residual",
 	})
 }
 

--- a/handler/admin/update_center_test.go
+++ b/handler/admin/update_center_test.go
@@ -145,12 +145,64 @@ func TestUpdateCenterTaskStream_Honest501(t *testing.T) {
 func TestUpdateCenterStatusAndCheck_LocalOnly(t *testing.T) {
 	r := setupUpdateCenterTest(t)
 
-	statusResp := doGet(t, r, "/api/update-center/status")
-	if statusResp.Code != http.StatusOK {
-		t.Fatalf("status endpoint=%d body=%s", statusResp.Code, statusResp.Body.String())
+	assertLocalUpdateStatus := func(t *testing.T, label string, rec *httptest.ResponseRecorder) {
+		t.Helper()
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s status=%d body=%s, want 200", label, rec.Code, rec.Body.String())
+		}
+		var body map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("%s decode: %v body=%s", label, err, rec.Body.String())
+		}
+		if body["updateAvailable"] != false {
+			t.Fatalf("%s updateAvailable=%v, must stay false (no invented remote update)", label, body["updateAvailable"])
+		}
+		if body["currentVersion"] != "0.0.0" || body["latestVersion"] != "0.0.0" {
+			t.Fatalf("%s versions=%v/%v, want local 0.0.0 placeholders", label, body["currentVersion"], body["latestVersion"])
+		}
+		if body["lastCheckedAt"] != nil {
+			t.Fatalf("%s lastCheckedAt=%v, want nil (no fake poll timestamp)", label, body["lastCheckedAt"])
+		}
+		residual, _ := body["residual"].(string)
+		if residual == "" {
+			t.Fatalf("%s expected residual field for local stub honesty: %v", label, body)
+		}
 	}
+
+	statusResp := doGet(t, r, "/api/update-center/status")
+	assertLocalUpdateStatus(t, "status", statusResp)
+
 	checkResp := doPostJSON(t, r, "/api/update-center/check", map[string]any{})
-	if checkResp.Code != http.StatusOK {
-		t.Fatalf("check endpoint=%d body=%s", checkResp.Code, checkResp.Body.String())
+	assertLocalUpdateStatus(t, "check", checkResp)
+}
+
+func TestUpdateCenterConfig_EchoOnlyResidual(t *testing.T) {
+	r := setupUpdateCenterTest(t)
+
+	resp := doPutJSON(t, r, "/api/update-center/config", map[string]any{
+		"enabled":       true,
+		"helperBaseUrl": "http://helper.example",
+		"namespace":     "metapi",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s, want 200", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != true {
+		t.Fatalf("success=%v, want true (echo path)", body["success"])
+	}
+	residual, _ := body["residual"].(string)
+	if residual == "" {
+		t.Fatalf("expected residual field for echo-only config: %v", body)
+	}
+	cfg, _ := body["config"].(map[string]any)
+	if cfg == nil {
+		t.Fatalf("expected config echo: %v", body)
+	}
+	if cfg["enabled"] != true || cfg["helperBaseUrl"] != "http://helper.example" {
+		t.Fatalf("config echo mismatch: %v", cfg)
 	}
 }

--- a/scheduler/update_center.go
+++ b/scheduler/update_center.go
@@ -12,7 +12,11 @@ import (
 
 const defaultUpdateCenterIntervalMs = 15 * 60 * 1000 // 15 minutes
 
-// UpdateCenterScheduler polls the update center for new versions.
+// UpdateCenterScheduler is a residual ticker for update-center honesty.
+//
+// It does NOT poll a remote registry/helper, invent updateAvailable, or
+// trigger deploy/rollback. Product path remains external CI/CD / helper.
+// See docs/analysis/residual-update-center.md and #283 / #246.
 type UpdateCenterScheduler struct {
 	cfg      *config.Config
 	ticker   *time.Ticker
@@ -22,7 +26,7 @@ type UpdateCenterScheduler struct {
 	inFlight bool
 }
 
-// NewUpdateCenterScheduler creates a new update center poller.
+// NewUpdateCenterScheduler creates the residual update-center ticker.
 func NewUpdateCenterScheduler(cfg *config.Config) *UpdateCenterScheduler {
 	return &UpdateCenterScheduler{cfg: cfg}
 }
@@ -38,7 +42,7 @@ func (s *UpdateCenterScheduler) Start(ctx context.Context) error {
 	s.stopCh = make(chan struct{})
 	s.running = true
 
-	// Immediate first run
+	// Immediate first residual pass (log-only; no remote polling).
 	go s.runSync()
 
 	go func() {
@@ -54,7 +58,7 @@ func (s *UpdateCenterScheduler) Start(ctx context.Context) error {
 		}
 	}()
 
-	slog.Info("update-center scheduler started", "interval_ms", interval.Milliseconds())
+	slog.Info("update-center residual scheduler started (log-only; no remote registry)", "interval_ms", interval.Milliseconds())
 	return nil
 }
 
@@ -100,15 +104,16 @@ func (s *UpdateCenterScheduler) runSync() {
 
 func (s *UpdateCenterScheduler) runSyncLocked(dbw *store.DB) {
 	_ = dbw
-	// Residual honesty (#246): silent no-op for product purposes.
+	// Residual honesty (#246 / #283): log-only no-op for product purposes.
 	// What runs: ticker + in-flight guard + scheduler lease + this log line.
 	// What does NOT run: remote registry/helper polling, version compare,
 	// persistence of lastCheckedAt, or any deploy/rollback side effect.
-	// Admin update-center status/check endpoints are also local stubs
-	// (0.0.0 / updateAvailable=false); deploy/rollback are honest 501 residuals
-	// (see residual-update-center.md). This scheduler must not invent
-	// "update available" or fake task completion.
-	// TODO residual (not wired): wire actual update-center polling when a real
-	// helper/registry client exists — until then this is scan-free log-only.
-	slog.Info("update-center: residual check (no remote polling; no version discovery)")
+	// Admin update-center status/check are local stubs (0.0.0 /
+	// updateAvailable=false + residual field); deploy/rollback/SSE are honest
+	// 501 residuals (see residual-update-center.md). This scheduler must not
+	// invent "update available", fake lastCheckedAt, or fake task completion.
+	// TODO residual (not wired): wire actual update-center polling only when a
+	// real helper/registry client exists — until then this is scan-free log-only.
+	// Do not add fake HTTP polling stubs that invent updateAvailable=true.
+	slog.Info("update-center: residual check (no remote polling; no version discovery; no updateAvailable invention)")
 }


### PR DESCRIPTION
## Summary
- Harden update-center residual honesty for admin status/check (local stub + explicit `residual`, never invent `updateAvailable=true`)
- Keep deploy/rollback/task SSE as honest 501 residuals (no stub task ids / fake SSE)
- Keep scheduler as log-only residual (no remote registry product / no fake polling)
- Refresh residual docs: full endpoint table + scheduler log-only behavior; update-center inventory row for #283

## Test plan
- [x] `go test ./scheduler ./handler/admin -count=1 -run 'Update|update'`
- [x] Status/check assert `updateAvailable=false`, residual field, nil `lastCheckedAt`
- [x] Deploy/rollback/stream still 501 without stub task ids
- [x] Full pre-push `go vet ./...` + `go test ./... -race` clean

Closes #283