### PR TITLE
feat(admin): token_routes sort_order + bulk reorder API (#284)

### DIFF
--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -18,11 +18,11 @@ import (
 )
 
 const (
-	routeDecisionBatchMaxItems      = 500
-	routeDecisionRefreshTaskType    = "route-decision.refresh"
-	routeDecisionRefreshTaskTitle   = "刷新路由选中概率"
-	routeDecisionRefreshDedupeKey   = "route-decision-refresh"
-	routeDecisionRouterUnavailable  = "路由决策引擎未配置"
+	routeDecisionBatchMaxItems     = 500
+	routeDecisionRefreshTaskType   = "route-decision.refresh"
+	routeDecisionRefreshTaskTitle  = "刷新路由选中概率"
+	routeDecisionRefreshDedupeKey  = "route-decision-refresh"
+	routeDecisionRouterUnavailable = "路由决策引擎未配置"
 )
 
 // RouteDecisionExplainer is the router surface used by decision admin APIs.
@@ -60,10 +60,11 @@ func RegisterTokenRoutesWithDeps(r chi.Router, db *sqlx.DB, deps TokenRoutesDeps
 
 	// Route CRUD
 	r.Post("/api/routes", handler.createRoute)
+	r.Post("/api/routes/batch", handler.batchRoutes)
+	r.Put("/api/routes/reorder", handler.reorderRoutes) // static path before /{id}
+	r.Post("/api/routes/rebuild", handler.rebuildRoutes)
 	r.Put("/api/routes/{id}", handler.updateRoute)
 	r.Delete("/api/routes/{id}", handler.deleteRoute)
-	r.Post("/api/routes/batch", handler.batchRoutes)
-	r.Post("/api/routes/rebuild", handler.rebuildRoutes)
 
 	// Route channels
 	r.Get("/api/routes/{id}/channels", handler.getRouteChannels)
@@ -93,7 +94,7 @@ type tokenRoutesHandler struct {
 // ---- List Lite ----
 // GET /api/routes/lite
 func (h *tokenRoutesHandler) listLite(w http.ResponseWriter, r *http.Request) {
-	rows := queryRows(h.db, "SELECT id, model_pattern, display_name, display_icon, route_mode, routing_strategy, enabled FROM token_routes ORDER BY id ASC")
+	rows := queryRows(h.db, "SELECT id, model_pattern, display_name, display_icon, route_mode, routing_strategy, enabled FROM token_routes ORDER BY sort_order ASC, id ASC")
 	type srcRow struct {
 		GroupRouteID  int64 `db:"group_route_id"`
 		SourceRouteID int64 `db:"source_route_id"`
@@ -118,7 +119,7 @@ func (h *tokenRoutesHandler) listLite(w http.ResponseWriter, r *http.Request) {
 // ---- List Summary ----
 // GET /api/routes/summary
 func (h *tokenRoutesHandler) listSummary(w http.ResponseWriter, r *http.Request) {
-	rows := queryRows(h.db, "SELECT * FROM token_routes ORDER BY id ASC")
+	rows := queryRows(h.db, "SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC")
 	result := make([]map[string]any, 0)
 	for _, route := range rows {
 		routeID := toInt64(route["id"])
@@ -157,7 +158,7 @@ func (h *tokenRoutesHandler) listSummary(w http.ResponseWriter, r *http.Request)
 // ---- List Routes ----
 // GET /api/routes
 func (h *tokenRoutesHandler) listRoutes(w http.ResponseWriter, r *http.Request) {
-	rows := queryRows(h.db, "SELECT * FROM token_routes ORDER BY id ASC")
+	rows := queryRows(h.db, "SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC")
 	result := make([]map[string]any, 0)
 	for _, route := range rows {
 		routeID := toInt64(route["id"])
@@ -727,6 +728,72 @@ func (h *tokenRoutesHandler) batchUpdateChannels(w http.ResponseWriter, r *http.
 
 // ---- Update Channel ----
 // PUT /api/channels/:channelId
+
+// PUT /api/routes/reorder
+// Body: { "items": [ { "id": 1, "sortOrder": 0 }, ... ] }
+// Assigns explicit sort_order for admin drag-and-drop route lists (#590/#284).
+func (h *tokenRoutesHandler) reorderRoutes(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Items []struct {
+			ID        int64 `json:"id"`
+			SortOrder int64 `json:"sortOrder"`
+		} `json:"items"`
+	}
+	if err := decodeJSONRequest(r, &body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "invalid payload"})
+		return
+	}
+	if len(body.Items) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "items is required"})
+		return
+	}
+	if len(body.Items) > 1000 {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "too many items (max 1000)"})
+		return
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	var successIDs []int64
+	var failedItems []map[string]any
+	seen := map[int64]bool{}
+
+	for _, item := range body.Items {
+		if item.ID <= 0 {
+			failedItems = append(failedItems, map[string]any{"id": item.ID, "message": "invalid id"})
+			continue
+		}
+		if item.SortOrder < 0 {
+			failedItems = append(failedItems, map[string]any{"id": item.ID, "message": "sortOrder must be >= 0"})
+			continue
+		}
+		if seen[item.ID] {
+			failedItems = append(failedItems, map[string]any{"id": item.ID, "message": "duplicate id in payload"})
+			continue
+		}
+		seen[item.ID] = true
+
+		res, err := h.db.Exec(h.db.Rebind(`
+			UPDATE token_routes SET sort_order = ?, updated_at = ? WHERE id = ?
+		`), item.SortOrder, now, item.ID)
+		if err != nil {
+			failedItems = append(failedItems, map[string]any{"id": item.ID, "message": err.Error()})
+			continue
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			failedItems = append(failedItems, map[string]any{"id": item.ID, "message": "route not found"})
+			continue
+		}
+		successIDs = append(successIDs, item.ID)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"success":     len(failedItems) == 0,
+		"successIds":  successIDs,
+		"failedItems": failedItems,
+	})
+}
+
 func (h *tokenRoutesHandler) updateChannel(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "channelId")
 	channelID, err := strconv.ParseInt(idStr, 10, 64)
@@ -1009,8 +1076,8 @@ func (h *tokenRoutesHandler) routeDecisionRefresh(w http.ResponseWriter, r *http
 			return nil, err
 		}
 		return map[string]any{
-			"exactModelCount":     exact,
-			"wildcardRouteCount":  wildcard,
+			"exactModelCount":       exact,
+			"wildcardRouteCount":    wildcard,
 			"refreshPricingCatalog": refreshPricing,
 		}, nil
 	})

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -283,8 +283,6 @@ func TestRouteChannelsBatchAllowsSameCredentialForDifferentSourceModels(t *testi
 	}
 }
 
-
-
 func isTruthyJSON(v any) bool {
 	switch t := v.(type) {
 	case bool:
@@ -450,11 +448,11 @@ func TestTokenRoutes_PartialUpdatePreservesModelMapping(t *testing.T) {
 // ---- Route Decision APIs (#171) ----
 
 type fakeDecisionRouter struct {
-	explainCalls       []string
-	explainForRoute    []string
-	explainRouteWide   []int64
-	decision           routing.RouteDecisionExplanation
-	err                error
+	explainCalls     []string
+	explainForRoute  []string
+	explainRouteWide []int64
+	decision         routing.RouteDecisionExplanation
+	err              error
 }
 
 func (f *fakeDecisionRouter) ExplainSelection(_ context.Context, requestedModel string, _ []int64, _ routing.DownstreamRoutingPolicy) (routing.RouteDecisionExplanation, error) {
@@ -576,13 +574,13 @@ func TestRouteDecision_ExplainSelection(t *testing.T) {
 			Summary:           []string{"命中路由：gpt-4o", "路由策略：按权重随机"},
 			Candidates: []routing.RouteDecisionCandidate{
 				{
-					ChannelID:  channelID,
-					AccountID:  3,
-					Username:   "u1",
-					SiteName:   "s1",
-					Priority:   0,
-					Weight:     10,
-					Eligible:   true,
+					ChannelID:   channelID,
+					AccountID:   3,
+					Username:    "u1",
+					SiteName:    "s1",
+					Priority:    0,
+					Weight:      10,
+					Eligible:    true,
 					Probability: 1,
 				},
 			},
@@ -963,5 +961,82 @@ func TestTokenRoutes_ChannelUpdatePreservesIntentionalConfig(t *testing.T) {
 	}
 	if kept != 1 {
 		t.Fatalf("intentional channel config reset by rebuild")
+	}
+}
+
+func TestRoutes_ReorderAndListOrder(t *testing.T) {
+	_, r := setupTokenRoutesTest(t)
+
+	// Create three pattern routes.
+	for _, pattern := range []string{"model-a", "model-b", "model-c"} {
+		body := map[string]any{"modelPattern": pattern, "routeMode": "pattern", "enabled": true}
+		rec := doPostJSON(t, r, "/api/routes", body)
+		if rec.Code != 200 {
+			t.Fatalf("create %s: %d %s", pattern, rec.Code, rec.Body.String())
+		}
+	}
+
+	rec := doGet(t, r, "/api/routes/lite")
+	if rec.Code != 200 {
+		t.Fatalf("list lite: %d %s", rec.Code, rec.Body.String())
+	}
+	var listed []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 3 {
+		t.Fatalf("expected 3 routes, got %d: %#v", len(listed), listed)
+	}
+	ids := make([]int64, 3)
+	for i, row := range listed {
+		ids[i] = int64(row["id"].(float64))
+	}
+
+	// Reverse order via sortOrder (lower first).
+	items := []map[string]any{
+		{"id": ids[0], "sortOrder": 2},
+		{"id": ids[1], "sortOrder": 1},
+		{"id": ids[2], "sortOrder": 0},
+	}
+	rec = doPutJSON(t, r, "/api/routes/reorder", map[string]any{"items": items})
+	if rec.Code != 200 {
+		t.Fatalf("reorder: %d %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["success"] != true {
+		t.Fatalf("reorder response: %#v", resp)
+	}
+
+	rec = doGet(t, r, "/api/routes/lite")
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]int64, len(listed))
+	for i, row := range listed {
+		got[i] = int64(row["id"].(float64))
+	}
+	want := []int64{ids[2], ids[1], ids[0]}
+	if len(got) != 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Fatalf("list order after reorder = %v, want %v", got, want)
+	}
+
+	// Unknown id is reported in failedItems without aborting others.
+	rec = doPutJSON(t, r, "/api/routes/reorder", map[string]any{
+		"items": []map[string]any{
+			{"id": ids[0], "sortOrder": 0},
+			{"id": int64(999999), "sortOrder": 1},
+		},
+	})
+	if rec.Code != 200 {
+		t.Fatalf("reorder partial: %d %s", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["success"] != false {
+		t.Fatalf("expected success=false with failed item, got %#v", resp)
 	}
 }

--- a/store/additive.go
+++ b/store/additive.go
@@ -69,7 +69,7 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 	{
 		// Learn #116: downstream-key RPM/TPM soft admission fields.
 		Version:     "sc2_005_downstream_key_rate_limits",
-		Description: "downstream_api_keys.max_rpm / max_tpm INTEGER NULL — optional per-key rate windows; NULL means unlimited",
+		Description: "downstream_api_keys.max_rpm / max_tpm INTEGER NULL - optional per-key rate windows; NULL means unlimited",
 		Apply: func(db *DB) error {
 			if err := EnsureColumn(db, "downstream_api_keys", "max_rpm", "INTEGER", "INTEGER", ""); err != nil {
 				return err
@@ -77,7 +77,18 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 			return EnsureColumn(db, "downstream_api_keys", "max_tpm", "INTEGER", "INTEGER", "")
 		},
 	},
-
+	{
+		// Upstream #590 / #284: admin drag reorder of token routes (list order).
+		Version:     "sc2_006_token_routes_sort_order",
+		Description: "token_routes.sort_order INTEGER DEFAULT 0 - list/admin drag reorder; lower first, then id",
+		Apply: func(db *DB) error {
+			if err := EnsureColumn(db, "token_routes", "sort_order", "INTEGER", "INTEGER", "DEFAULT 0"); err != nil {
+				return err
+			}
+			return EnsureIndex(db, "token_routes_sort_order_id_idx",
+				`CREATE INDEX IF NOT EXISTS token_routes_sort_order_id_idx ON token_routes (sort_order, id)`)
+		},
+	},
 }
 
 // schemaMigrationsDDL creates the version bookkeeping table.

--- a/store/migrate.go
+++ b/store/migrate.go
@@ -410,6 +410,7 @@ func buildTokenRoutesDDL(d string) string {
 			decision_refreshed_at TEXT,
 			routing_strategy TEXT DEFAULT 'weighted',
 			context_length INTEGER,
+			sort_order INTEGER DEFAULT 0,
 			enabled BOOLEAN DEFAULT TRUE,
 			created_at TEXT,
 			updated_at TEXT
@@ -426,6 +427,7 @@ func buildTokenRoutesDDL(d string) string {
 		decision_refreshed_at TEXT,
 		routing_strategy TEXT DEFAULT 'weighted',
 		context_length INTEGER,
+		sort_order INTEGER DEFAULT 0,
 		enabled INTEGER DEFAULT 1,
 		created_at TEXT,
 		updated_at TEXT
@@ -1128,7 +1130,6 @@ func buildSiteAnnouncementsDDL(d string) string {
 		FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE CASCADE
 	)`
 }
-
 
 func buildAdminBackgroundTasksDDL(d string) string {
 	if isPG(d) {

--- a/store/schema.go
+++ b/store/schema.go
@@ -2,43 +2,43 @@ package store
 
 // ---- Table 1: sites ----
 type Site struct {
-	ID                               int64   `db:"id" json:"id"`
-	Name                             string  `db:"name" json:"name"`
-	URL                              string  `db:"url" json:"url"`
-	ExternalCheckinURL               *string `db:"external_checkin_url" json:"externalCheckinUrl"`
-	Platform                         string  `db:"platform" json:"platform"`
-	ProxyURL                         *string `db:"proxy_url" json:"proxyUrl"`
-	UseSystemProxy                   bool    `db:"use_system_proxy" json:"useSystemProxy"`
-	CustomHeaders                    *string `db:"custom_headers" json:"customHeaders"`
-	Status                           string  `db:"status" json:"status"`
-	IsPinned                         bool    `db:"is_pinned" json:"isPinned"`
-	SortOrder                        int64   `db:"sort_order" json:"sortOrder"`
-	GlobalWeight                     float64 `db:"global_weight" json:"globalWeight"`
-	APIKey                           *string `db:"api_key" json:"apiKey"`
+	ID                 int64   `db:"id" json:"id"`
+	Name               string  `db:"name" json:"name"`
+	URL                string  `db:"url" json:"url"`
+	ExternalCheckinURL *string `db:"external_checkin_url" json:"externalCheckinUrl"`
+	Platform           string  `db:"platform" json:"platform"`
+	ProxyURL           *string `db:"proxy_url" json:"proxyUrl"`
+	UseSystemProxy     bool    `db:"use_system_proxy" json:"useSystemProxy"`
+	CustomHeaders      *string `db:"custom_headers" json:"customHeaders"`
+	Status             string  `db:"status" json:"status"`
+	IsPinned           bool    `db:"is_pinned" json:"isPinned"`
+	SortOrder          int64   `db:"sort_order" json:"sortOrder"`
+	GlobalWeight       float64 `db:"global_weight" json:"globalWeight"`
+	APIKey             *string `db:"api_key" json:"apiKey"`
 	// MaxConcurrency caps concurrent upstream calls for this site.
 	// 0 (default) means unlimited — preserves pre-SC2 behavior.
-	MaxConcurrency                   int64   `db:"max_concurrency" json:"maxConcurrency"`
-	PostRefreshProbeEnabled          bool    `db:"post_refresh_probe_enabled" json:"postRefreshProbeEnabled"`
-	PostRefreshProbeModel            string  `db:"post_refresh_probe_model" json:"postRefreshProbeModel"`
-	PostRefreshProbeScope            string  `db:"post_refresh_probe_scope" json:"postRefreshProbeScope"`
+	MaxConcurrency                     int64  `db:"max_concurrency" json:"maxConcurrency"`
+	PostRefreshProbeEnabled            bool   `db:"post_refresh_probe_enabled" json:"postRefreshProbeEnabled"`
+	PostRefreshProbeModel              string `db:"post_refresh_probe_model" json:"postRefreshProbeModel"`
+	PostRefreshProbeScope              string `db:"post_refresh_probe_scope" json:"postRefreshProbeScope"`
 	PostRefreshProbeLatencyThresholdMs int64  `db:"post_refresh_probe_latency_threshold_ms" json:"postRefreshProbeLatencyThresholdMs"`
-	CreatedAt                        string  `db:"created_at" json:"createdAt"`
-	UpdatedAt                        string  `db:"updated_at" json:"updatedAt"`
+	CreatedAt                          string `db:"created_at" json:"createdAt"`
+	UpdatedAt                          string `db:"updated_at" json:"updatedAt"`
 }
 
 // ---- Table 2: site_api_endpoints ----
 type SiteAPIEndpoint struct {
-	ID                 int64   `db:"id" json:"id"`
-	SiteID             int64   `db:"site_id" json:"siteId"`
-	URL                string  `db:"url" json:"url"`
-	Enabled            bool    `db:"enabled" json:"enabled"`
-	SortOrder          int64   `db:"sort_order" json:"sortOrder"`
-	CooldownUntil      *string `db:"cooldown_until" json:"cooldownUntil"`
-	LastSelectedAt     *string `db:"last_selected_at" json:"lastSelectedAt"`
-	LastFailedAt       *string `db:"last_failed_at" json:"lastFailedAt"`
-	LastFailureReason  *string `db:"last_failure_reason" json:"lastFailureReason"`
-	CreatedAt          string  `db:"created_at" json:"createdAt"`
-	UpdatedAt          string  `db:"updated_at" json:"updatedAt"`
+	ID                int64   `db:"id" json:"id"`
+	SiteID            int64   `db:"site_id" json:"siteId"`
+	URL               string  `db:"url" json:"url"`
+	Enabled           bool    `db:"enabled" json:"enabled"`
+	SortOrder         int64   `db:"sort_order" json:"sortOrder"`
+	CooldownUntil     *string `db:"cooldown_until" json:"cooldownUntil"`
+	LastSelectedAt    *string `db:"last_selected_at" json:"lastSelectedAt"`
+	LastFailedAt      *string `db:"last_failed_at" json:"lastFailedAt"`
+	LastFailureReason *string `db:"last_failure_reason" json:"lastFailureReason"`
+	CreatedAt         string  `db:"created_at" json:"createdAt"`
+	UpdatedAt         string  `db:"updated_at" json:"updatedAt"`
 }
 
 // ---- Table 3: site_disabled_models ----
@@ -51,28 +51,28 @@ type SiteDisabledModel struct {
 
 // ---- Table 4: accounts ----
 type Account struct {
-	ID                  int64   `db:"id" json:"id"`
-	SiteID              int64   `db:"site_id" json:"siteId"`
-	Username            *string `db:"username" json:"username"`
-	AccessToken         string  `db:"access_token" json:"accessToken"`
-	APIToken            *string `db:"api_token" json:"apiToken"`
-	Balance             float64 `db:"balance" json:"balance"`
-	BalanceUsed         float64 `db:"balance_used" json:"balanceUsed"`
-	Quota               float64 `db:"quota" json:"quota"`
-	UnitCost            *float64 `db:"unit_cost" json:"unitCost"`
-	ValueScore          float64 `db:"value_score" json:"valueScore"`
-	Status              string  `db:"status" json:"status"`
-	IsPinned            bool    `db:"is_pinned" json:"isPinned"`
-	SortOrder           int64   `db:"sort_order" json:"sortOrder"`
-	CheckinEnabled      bool    `db:"checkin_enabled" json:"checkinEnabled"`
-	LastCheckinAt       *string `db:"last_checkin_at" json:"lastCheckinAt"`
-	LastBalanceRefresh  *string `db:"last_balance_refresh" json:"lastBalanceRefresh"`
-	OAuthProvider       *string `db:"oauth_provider" json:"oauthProvider"`
-	OAuthAccountKey     *string `db:"oauth_account_key" json:"oauthAccountKey"`
-	OAuthProjectID      *string `db:"oauth_project_id" json:"oauthProjectId"`
-	ExtraConfig         *string `db:"extra_config" json:"extraConfig"`
-	CreatedAt           string  `db:"created_at" json:"createdAt"`
-	UpdatedAt           string  `db:"updated_at" json:"updatedAt"`
+	ID                 int64    `db:"id" json:"id"`
+	SiteID             int64    `db:"site_id" json:"siteId"`
+	Username           *string  `db:"username" json:"username"`
+	AccessToken        string   `db:"access_token" json:"accessToken"`
+	APIToken           *string  `db:"api_token" json:"apiToken"`
+	Balance            float64  `db:"balance" json:"balance"`
+	BalanceUsed        float64  `db:"balance_used" json:"balanceUsed"`
+	Quota              float64  `db:"quota" json:"quota"`
+	UnitCost           *float64 `db:"unit_cost" json:"unitCost"`
+	ValueScore         float64  `db:"value_score" json:"valueScore"`
+	Status             string   `db:"status" json:"status"`
+	IsPinned           bool     `db:"is_pinned" json:"isPinned"`
+	SortOrder          int64    `db:"sort_order" json:"sortOrder"`
+	CheckinEnabled     bool     `db:"checkin_enabled" json:"checkinEnabled"`
+	LastCheckinAt      *string  `db:"last_checkin_at" json:"lastCheckinAt"`
+	LastBalanceRefresh *string  `db:"last_balance_refresh" json:"lastBalanceRefresh"`
+	OAuthProvider      *string  `db:"oauth_provider" json:"oauthProvider"`
+	OAuthAccountKey    *string  `db:"oauth_account_key" json:"oauthAccountKey"`
+	OAuthProjectID     *string  `db:"oauth_project_id" json:"oauthProjectId"`
+	ExtraConfig        *string  `db:"extra_config" json:"extraConfig"`
+	CreatedAt          string   `db:"created_at" json:"createdAt"`
+	UpdatedAt          string   `db:"updated_at" json:"updatedAt"`
 }
 
 // ---- Table 5: account_tokens ----
@@ -102,13 +102,13 @@ type CheckinLog struct {
 
 // ---- Table 7: model_availability ----
 type ModelAvailability struct {
-	ID         int64   `db:"id" json:"id"`
-	AccountID  int64   `db:"account_id" json:"accountId"`
-	ModelName  string  `db:"model_name" json:"modelName"`
-	Available  *bool   `db:"available" json:"available"`
-	IsManual   bool    `db:"is_manual" json:"isManual"`
-	LatencyMs  *int64  `db:"latency_ms" json:"latencyMs"`
-	CheckedAt  string  `db:"checked_at" json:"checkedAt"`
+	ID        int64  `db:"id" json:"id"`
+	AccountID int64  `db:"account_id" json:"accountId"`
+	ModelName string `db:"model_name" json:"modelName"`
+	Available *bool  `db:"available" json:"available"`
+	IsManual  bool   `db:"is_manual" json:"isManual"`
+	LatencyMs *int64 `db:"latency_ms" json:"latencyMs"`
+	CheckedAt string `db:"checked_at" json:"checkedAt"`
 }
 
 // ---- Table 8: token_model_availability ----
@@ -135,10 +135,12 @@ type TokenRoute struct {
 	// ContextLength is optional route-level context window metadata (tokens).
 	// NULL means unknown / no enforcement — preserves pre-SC2 behavior.
 	// No dedicated model_catalog table exists; token_routes is the SC0 Option A home.
-	ContextLength       *int64  `db:"context_length" json:"contextLength"`
-	Enabled             bool    `db:"enabled" json:"enabled"`
-	CreatedAt           string  `db:"created_at" json:"createdAt"`
-	UpdatedAt           string  `db:"updated_at" json:"updatedAt"`
+	ContextLength *int64 `db:"context_length" json:"contextLength"`
+	// SortOrder controls admin list order (lower first, then id). Default 0.
+	SortOrder int64  `db:"sort_order" json:"sortOrder"`
+	Enabled   bool   `db:"enabled" json:"enabled"`
+	CreatedAt string `db:"created_at" json:"createdAt"`
+	UpdatedAt string `db:"updated_at" json:"updatedAt"`
 }
 
 // ---- Table 10: route_group_sources ----
@@ -182,86 +184,86 @@ type OAuthRouteUnitMember struct {
 
 // ---- Table 13: route_channels ----
 type RouteChannel struct {
-	ID                  int64    `db:"id" json:"id"`
-	RouteID             int64    `db:"route_id" json:"routeId"`
-	AccountID           int64    `db:"account_id" json:"accountId"`
-	TokenID             *int64   `db:"token_id" json:"tokenId"`
-	OAuthRouteUnitID    *int64   `db:"oauth_route_unit_id" json:"oauthRouteUnitId"`
-	SourceModel         *string  `db:"source_model" json:"sourceModel"`
-	Priority            int64    `db:"priority" json:"priority"`
-	Weight              int64    `db:"weight" json:"weight"`
-	Enabled             bool     `db:"enabled" json:"enabled"`
-	ManualOverride      bool     `db:"manual_override" json:"manualOverride"`
-	SuccessCount        int64    `db:"success_count" json:"successCount"`
-	FailCount           int64    `db:"fail_count" json:"failCount"`
-	TotalLatencyMs      int64    `db:"total_latency_ms" json:"totalLatencyMs"`
-	TotalCost           float64  `db:"total_cost" json:"totalCost"`
-	LastUsedAt          *string  `db:"last_used_at" json:"lastUsedAt"`
-	LastSelectedAt      *string  `db:"last_selected_at" json:"lastSelectedAt"`
-	LastFailAt          *string  `db:"last_fail_at" json:"lastFailAt"`
+	ID                   int64   `db:"id" json:"id"`
+	RouteID              int64   `db:"route_id" json:"routeId"`
+	AccountID            int64   `db:"account_id" json:"accountId"`
+	TokenID              *int64  `db:"token_id" json:"tokenId"`
+	OAuthRouteUnitID     *int64  `db:"oauth_route_unit_id" json:"oauthRouteUnitId"`
+	SourceModel          *string `db:"source_model" json:"sourceModel"`
+	Priority             int64   `db:"priority" json:"priority"`
+	Weight               int64   `db:"weight" json:"weight"`
+	Enabled              bool    `db:"enabled" json:"enabled"`
+	ManualOverride       bool    `db:"manual_override" json:"manualOverride"`
+	SuccessCount         int64   `db:"success_count" json:"successCount"`
+	FailCount            int64   `db:"fail_count" json:"failCount"`
+	TotalLatencyMs       int64   `db:"total_latency_ms" json:"totalLatencyMs"`
+	TotalCost            float64 `db:"total_cost" json:"totalCost"`
+	LastUsedAt           *string `db:"last_used_at" json:"lastUsedAt"`
+	LastSelectedAt       *string `db:"last_selected_at" json:"lastSelectedAt"`
+	LastFailAt           *string `db:"last_fail_at" json:"lastFailAt"`
 	ConsecutiveFailCount int64   `db:"consecutive_fail_count" json:"consecutiveFailCount"`
-	CooldownLevel       int64    `db:"cooldown_level" json:"cooldownLevel"`
-	CooldownUntil       *string  `db:"cooldown_until" json:"cooldownUntil"`
+	CooldownLevel        int64   `db:"cooldown_level" json:"cooldownLevel"`
+	CooldownUntil        *string `db:"cooldown_until" json:"cooldownUntil"`
 }
 
 // ---- Table 14: proxy_logs ----
 type ProxyLog struct {
-	ID                   int64    `db:"id" json:"id"`
-	RouteID              *int64   `db:"route_id" json:"routeId"`
-	ChannelID            *int64   `db:"channel_id" json:"channelId"`
-	AccountID            *int64   `db:"account_id" json:"accountId"`
-	DownstreamAPIKeyID   *int64   `db:"downstream_api_key_id" json:"downstreamApiKeyId"`
-	ModelRequested       *string  `db:"model_requested" json:"modelRequested"`
-	ModelActual          *string  `db:"model_actual" json:"modelActual"`
-	Status               *string  `db:"status" json:"status"`
-	HTTPStatus           *int64   `db:"http_status" json:"httpStatus"`
-	IsStream             *bool    `db:"is_stream" json:"isStream"`
-	FirstByteLatencyMs   *int64   `db:"first_byte_latency_ms" json:"firstByteLatencyMs"`
-	LatencyMs            *int64   `db:"latency_ms" json:"latencyMs"`
-	PromptTokens         *int64   `db:"prompt_tokens" json:"promptTokens"`
-	CompletionTokens     *int64   `db:"completion_tokens" json:"completionTokens"`
-	TotalTokens          *int64   `db:"total_tokens" json:"totalTokens"`
-	EstimatedCost        *float64 `db:"estimated_cost" json:"estimatedCost"`
-	BillingDetails       *string  `db:"billing_details" json:"billingDetails"`
-	ClientFamily         *string  `db:"client_family" json:"clientFamily"`
-	ClientAppID          *string  `db:"client_app_id" json:"clientAppId"`
-	ClientAppName        *string  `db:"client_app_name" json:"clientAppName"`
-	ClientConfidence     *string  `db:"client_confidence" json:"clientConfidence"`
-	ErrorMessage         *string  `db:"error_message" json:"errorMessage"`
-	RetryCount           int64    `db:"retry_count" json:"retryCount"`
+	ID                 int64    `db:"id" json:"id"`
+	RouteID            *int64   `db:"route_id" json:"routeId"`
+	ChannelID          *int64   `db:"channel_id" json:"channelId"`
+	AccountID          *int64   `db:"account_id" json:"accountId"`
+	DownstreamAPIKeyID *int64   `db:"downstream_api_key_id" json:"downstreamApiKeyId"`
+	ModelRequested     *string  `db:"model_requested" json:"modelRequested"`
+	ModelActual        *string  `db:"model_actual" json:"modelActual"`
+	Status             *string  `db:"status" json:"status"`
+	HTTPStatus         *int64   `db:"http_status" json:"httpStatus"`
+	IsStream           *bool    `db:"is_stream" json:"isStream"`
+	FirstByteLatencyMs *int64   `db:"first_byte_latency_ms" json:"firstByteLatencyMs"`
+	LatencyMs          *int64   `db:"latency_ms" json:"latencyMs"`
+	PromptTokens       *int64   `db:"prompt_tokens" json:"promptTokens"`
+	CompletionTokens   *int64   `db:"completion_tokens" json:"completionTokens"`
+	TotalTokens        *int64   `db:"total_tokens" json:"totalTokens"`
+	EstimatedCost      *float64 `db:"estimated_cost" json:"estimatedCost"`
+	BillingDetails     *string  `db:"billing_details" json:"billingDetails"`
+	ClientFamily       *string  `db:"client_family" json:"clientFamily"`
+	ClientAppID        *string  `db:"client_app_id" json:"clientAppId"`
+	ClientAppName      *string  `db:"client_app_name" json:"clientAppName"`
+	ClientConfidence   *string  `db:"client_confidence" json:"clientConfidence"`
+	ErrorMessage       *string  `db:"error_message" json:"errorMessage"`
+	RetryCount         int64    `db:"retry_count" json:"retryCount"`
 	// RequestID is the ingress X-Request-Id / chi RequestID shared across retries.
-	RequestID            *string  `db:"request_id" json:"requestId"`
-	CreatedAt            string   `db:"created_at" json:"createdAt"`
+	RequestID *string `db:"request_id" json:"requestId"`
+	CreatedAt string  `db:"created_at" json:"createdAt"`
 }
 
 // ---- Table 15: proxy_debug_traces ----
 type ProxyDebugTrace struct {
-	ID                         int64   `db:"id" json:"id"`
-	DownstreamPath             string  `db:"downstream_path" json:"downstreamPath"`
-	ClientKind                 *string `db:"client_kind" json:"clientKind"`
-	SessionID                  *string `db:"session_id" json:"sessionId"`
-	TraceHint                  *string `db:"trace_hint" json:"traceHint"`
-	RequestedModel             *string `db:"requested_model" json:"requestedModel"`
-	DownstreamAPIKeyID         *int64  `db:"downstream_api_key_id" json:"downstreamApiKeyId"`
-	RequestHeadersJSON         *string `db:"request_headers_json" json:"requestHeadersJson"`
-	RequestBodyJSON            *string `db:"request_body_json" json:"requestBodyJson"`
-	StickySessionKey           *string `db:"sticky_session_key" json:"stickySessionKey"`
-	StickyHitChannelID         *int64  `db:"sticky_hit_channel_id" json:"stickyHitChannelId"`
-	SelectedChannelID          *int64  `db:"selected_channel_id" json:"selectedChannelId"`
-	SelectedRouteID            *int64  `db:"selected_route_id" json:"selectedRouteId"`
-	SelectedAccountID          *int64  `db:"selected_account_id" json:"selectedAccountId"`
-	SelectedSiteID             *int64  `db:"selected_site_id" json:"selectedSiteId"`
-	SelectedSitePlatform       *string `db:"selected_site_platform" json:"selectedSitePlatform"`
-	EndpointCandidatesJSON     *string `db:"endpoint_candidates_json" json:"endpointCandidatesJson"`
-	EndpointRuntimeStateJSON   *string `db:"endpoint_runtime_state_json" json:"endpointRuntimeStateJson"`
-	DecisionSummaryJSON        *string `db:"decision_summary_json" json:"decisionSummaryJson"`
-	FinalStatus                *string `db:"final_status" json:"finalStatus"`
-	FinalHTTPStatus            *int64  `db:"final_http_status" json:"finalHttpStatus"`
-	FinalUpstreamPath          *string `db:"final_upstream_path" json:"finalUpstreamPath"`
-	FinalResponseHeadersJSON   *string `db:"final_response_headers_json" json:"finalResponseHeadersJson"`
-	FinalResponseBodyJSON      *string `db:"final_response_body_json" json:"finalResponseBodyJson"`
-	CreatedAt                  string  `db:"created_at" json:"createdAt"`
-	UpdatedAt                  string  `db:"updated_at" json:"updatedAt"`
+	ID                       int64   `db:"id" json:"id"`
+	DownstreamPath           string  `db:"downstream_path" json:"downstreamPath"`
+	ClientKind               *string `db:"client_kind" json:"clientKind"`
+	SessionID                *string `db:"session_id" json:"sessionId"`
+	TraceHint                *string `db:"trace_hint" json:"traceHint"`
+	RequestedModel           *string `db:"requested_model" json:"requestedModel"`
+	DownstreamAPIKeyID       *int64  `db:"downstream_api_key_id" json:"downstreamApiKeyId"`
+	RequestHeadersJSON       *string `db:"request_headers_json" json:"requestHeadersJson"`
+	RequestBodyJSON          *string `db:"request_body_json" json:"requestBodyJson"`
+	StickySessionKey         *string `db:"sticky_session_key" json:"stickySessionKey"`
+	StickyHitChannelID       *int64  `db:"sticky_hit_channel_id" json:"stickyHitChannelId"`
+	SelectedChannelID        *int64  `db:"selected_channel_id" json:"selectedChannelId"`
+	SelectedRouteID          *int64  `db:"selected_route_id" json:"selectedRouteId"`
+	SelectedAccountID        *int64  `db:"selected_account_id" json:"selectedAccountId"`
+	SelectedSiteID           *int64  `db:"selected_site_id" json:"selectedSiteId"`
+	SelectedSitePlatform     *string `db:"selected_site_platform" json:"selectedSitePlatform"`
+	EndpointCandidatesJSON   *string `db:"endpoint_candidates_json" json:"endpointCandidatesJson"`
+	EndpointRuntimeStateJSON *string `db:"endpoint_runtime_state_json" json:"endpointRuntimeStateJson"`
+	DecisionSummaryJSON      *string `db:"decision_summary_json" json:"decisionSummaryJson"`
+	FinalStatus              *string `db:"final_status" json:"finalStatus"`
+	FinalHTTPStatus          *int64  `db:"final_http_status" json:"finalHttpStatus"`
+	FinalUpstreamPath        *string `db:"final_upstream_path" json:"finalUpstreamPath"`
+	FinalResponseHeadersJSON *string `db:"final_response_headers_json" json:"finalResponseHeadersJson"`
+	FinalResponseBodyJSON    *string `db:"final_response_body_json" json:"finalResponseBodyJson"`
+	CreatedAt                string  `db:"created_at" json:"createdAt"`
+	UpdatedAt                string  `db:"updated_at" json:"updatedAt"`
 }
 
 // ---- Table 16: proxy_debug_attempts ----
@@ -288,21 +290,21 @@ type ProxyDebugAttempt struct {
 
 // ---- Table 17: proxy_video_tasks ----
 type ProxyVideoTask struct {
-	ID                    int64   `db:"id" json:"id"`
-	PublicID              string  `db:"public_id" json:"publicId"`
-	UpstreamVideoID       string  `db:"upstream_video_id" json:"upstreamVideoId"`
-	SiteURL               string  `db:"site_url" json:"siteUrl"`
-	TokenValue            string  `db:"token_value" json:"tokenValue"`
-	RequestedModel        *string `db:"requested_model" json:"requestedModel"`
-	ActualModel           *string `db:"actual_model" json:"actualModel"`
-	ChannelID             *int64  `db:"channel_id" json:"channelId"`
-	AccountID             *int64  `db:"account_id" json:"accountId"`
-	StatusSnapshot        *string `db:"status_snapshot" json:"statusSnapshot"`
-	UpstreamResponseMeta  *string `db:"upstream_response_meta" json:"upstreamResponseMeta"`
-	LastUpstreamStatus    *int64  `db:"last_upstream_status" json:"lastUpstreamStatus"`
-	LastPolledAt          *string `db:"last_polled_at" json:"lastPolledAt"`
-	CreatedAt             string  `db:"created_at" json:"createdAt"`
-	UpdatedAt             string  `db:"updated_at" json:"updatedAt"`
+	ID                   int64   `db:"id" json:"id"`
+	PublicID             string  `db:"public_id" json:"publicId"`
+	UpstreamVideoID      string  `db:"upstream_video_id" json:"upstreamVideoId"`
+	SiteURL              string  `db:"site_url" json:"siteUrl"`
+	TokenValue           string  `db:"token_value" json:"tokenValue"`
+	RequestedModel       *string `db:"requested_model" json:"requestedModel"`
+	ActualModel          *string `db:"actual_model" json:"actualModel"`
+	ChannelID            *int64  `db:"channel_id" json:"channelId"`
+	AccountID            *int64  `db:"account_id" json:"accountId"`
+	StatusSnapshot       *string `db:"status_snapshot" json:"statusSnapshot"`
+	UpstreamResponseMeta *string `db:"upstream_response_meta" json:"upstreamResponseMeta"`
+	LastUpstreamStatus   *int64  `db:"last_upstream_status" json:"lastUpstreamStatus"`
+	LastPolledAt         *string `db:"last_polled_at" json:"lastPolledAt"`
+	CreatedAt            string  `db:"created_at" json:"createdAt"`
+	UpdatedAt            string  `db:"updated_at" json:"updatedAt"`
 }
 
 // ---- Table 18: proxy_files ----
@@ -350,7 +352,7 @@ type AnalyticsProjectionCheckpoint struct {
 	LeaseOwner           *string `db:"lease_owner" json:"leaseOwner"`
 	LeaseToken           *string `db:"lease_token" json:"leaseToken"`
 	LeaseExpiresAt       *string `db:"lease_expires_at" json:"leaseExpiresAt"`
-	RecomputeFromID       *int64  `db:"recompute_from_id" json:"recomputeFromId"`
+	RecomputeFromID      *int64  `db:"recompute_from_id" json:"recomputeFromId"`
 	RecomputeRequestedAt *string `db:"recompute_requested_at" json:"recomputeRequestedAt"`
 	RecomputeReason      *string `db:"recompute_reason" json:"recomputeReason"`
 	RecomputeStartedAt   *string `db:"recompute_started_at" json:"recomputeStartedAt"`
@@ -415,53 +417,53 @@ type ModelDayUsage struct {
 
 // ---- Table 25: downstream_api_keys ----
 type DownstreamAPIKey struct {
-	ID                      int64    `db:"id" json:"id"`
-	Name                    string   `db:"name" json:"name"`
-	Key                     string   `db:"key" json:"key"`
-	Description             *string  `db:"description" json:"description"`
-	GroupName               *string  `db:"group_name" json:"groupName"`
-	Tags                    *string  `db:"tags" json:"tags"`
-	Enabled                 bool     `db:"enabled" json:"enabled"`
-	ExpiresAt               *string  `db:"expires_at" json:"expiresAt"`
-	MaxCost                 *float64 `db:"max_cost" json:"maxCost"`
-	UsedCost                float64  `db:"used_cost" json:"usedCost"`
-	MaxRequests             *int64   `db:"max_requests" json:"maxRequests"`
-	UsedRequests            int64    `db:"used_requests" json:"usedRequests"`
+	ID           int64    `db:"id" json:"id"`
+	Name         string   `db:"name" json:"name"`
+	Key          string   `db:"key" json:"key"`
+	Description  *string  `db:"description" json:"description"`
+	GroupName    *string  `db:"group_name" json:"groupName"`
+	Tags         *string  `db:"tags" json:"tags"`
+	Enabled      bool     `db:"enabled" json:"enabled"`
+	ExpiresAt    *string  `db:"expires_at" json:"expiresAt"`
+	MaxCost      *float64 `db:"max_cost" json:"maxCost"`
+	UsedCost     float64  `db:"used_cost" json:"usedCost"`
+	MaxRequests  *int64   `db:"max_requests" json:"maxRequests"`
+	UsedRequests int64    `db:"used_requests" json:"usedRequests"`
 	// MaxRPM / MaxTPM optional soft rate windows (learn #116). nil = unlimited.
-	MaxRPM                  *int64   `db:"max_rpm" json:"maxRpm"`
-	MaxTPM                  *int64   `db:"max_tpm" json:"maxTpm"`
-	SupportedModels         *string  `db:"supported_models" json:"supportedModels"`
-	AllowedRouteIDs         *string  `db:"allowed_route_ids" json:"allowedRouteIds"`
-	SiteWeightMultipliers   *string  `db:"site_weight_multipliers" json:"siteWeightMultipliers"`
-	ExcludedSiteIDs         *string  `db:"excluded_site_ids" json:"excludedSiteIds"`
-	ExcludedCredentialRefs  *string  `db:"excluded_credential_refs" json:"excludedCredentialRefs"`
+	MaxRPM                 *int64  `db:"max_rpm" json:"maxRpm"`
+	MaxTPM                 *int64  `db:"max_tpm" json:"maxTpm"`
+	SupportedModels        *string `db:"supported_models" json:"supportedModels"`
+	AllowedRouteIDs        *string `db:"allowed_route_ids" json:"allowedRouteIds"`
+	SiteWeightMultipliers  *string `db:"site_weight_multipliers" json:"siteWeightMultipliers"`
+	ExcludedSiteIDs        *string `db:"excluded_site_ids" json:"excludedSiteIds"`
+	ExcludedCredentialRefs *string `db:"excluded_credential_refs" json:"excludedCredentialRefs"`
 	// ProxyURL is an optional per-key egress proxy override.
 	// NULL falls back to site / system proxy — preserves pre-SC2 behavior.
-	ProxyURL                *string  `db:"proxy_url" json:"proxyUrl"`
-	LastUsedAt              *string  `db:"last_used_at" json:"lastUsedAt"`
-	CreatedAt               string   `db:"created_at" json:"createdAt"`
-	UpdatedAt               string   `db:"updated_at" json:"updatedAt"`
+	ProxyURL   *string `db:"proxy_url" json:"proxyUrl"`
+	LastUsedAt *string `db:"last_used_at" json:"lastUsedAt"`
+	CreatedAt  string  `db:"created_at" json:"createdAt"`
+	UpdatedAt  string  `db:"updated_at" json:"updatedAt"`
 }
 
 // ---- Table 26: site_announcements ----
 type SiteAnnouncement struct {
-	ID                 int64   `db:"id" json:"id"`
-	SiteID             int64   `db:"site_id" json:"siteId"`
-	Platform           string  `db:"platform" json:"platform"`
-	SourceKey          string  `db:"source_key" json:"sourceKey"`
-	Title              string  `db:"title" json:"title"`
-	Content            string  `db:"content" json:"content"`
-	Level              string  `db:"level" json:"level"`
-	SourceURL          *string `db:"source_url" json:"sourceUrl"`
-	StartsAt           *string `db:"starts_at" json:"startsAt"`
-	EndsAt             *string `db:"ends_at" json:"endsAt"`
-	UpstreamCreatedAt  *string `db:"upstream_created_at" json:"upstreamCreatedAt"`
-	UpstreamUpdatedAt  *string `db:"upstream_updated_at" json:"upstreamUpdatedAt"`
-	FirstSeenAt        string  `db:"first_seen_at" json:"firstSeenAt"`
-	LastSeenAt         string  `db:"last_seen_at" json:"lastSeenAt"`
-	ReadAt             *string `db:"read_at" json:"readAt"`
-	DismissedAt        *string `db:"dismissed_at" json:"dismissedAt"`
-	RawPayload         *string `db:"raw_payload" json:"rawPayload"`
+	ID                int64   `db:"id" json:"id"`
+	SiteID            int64   `db:"site_id" json:"siteId"`
+	Platform          string  `db:"platform" json:"platform"`
+	SourceKey         string  `db:"source_key" json:"sourceKey"`
+	Title             string  `db:"title" json:"title"`
+	Content           string  `db:"content" json:"content"`
+	Level             string  `db:"level" json:"level"`
+	SourceURL         *string `db:"source_url" json:"sourceUrl"`
+	StartsAt          *string `db:"starts_at" json:"startsAt"`
+	EndsAt            *string `db:"ends_at" json:"endsAt"`
+	UpstreamCreatedAt *string `db:"upstream_created_at" json:"upstreamCreatedAt"`
+	UpstreamUpdatedAt *string `db:"upstream_updated_at" json:"upstreamUpdatedAt"`
+	FirstSeenAt       string  `db:"first_seen_at" json:"firstSeenAt"`
+	LastSeenAt        string  `db:"last_seen_at" json:"lastSeenAt"`
+	ReadAt            *string `db:"read_at" json:"readAt"`
+	DismissedAt       *string `db:"dismissed_at" json:"dismissedAt"`
+	RawPayload        *string `db:"raw_payload" json:"rawPayload"`
 }
 
 // ---- Table 27: events ----

--- a/store/schema_test.go
+++ b/store/schema_test.go
@@ -17,7 +17,7 @@ var tableColumnCount = map[string]int{
 	"CheckinLog":                     6,
 	"ModelAvailability":              7,
 	"TokenModelAvailability":         6,
-	"TokenRoute":                     13,
+	"TokenRoute":                     14,
 	"RouteGroupSource":               3,
 	"OAuthRouteUnit":                 8,
 	"OAuthRouteUnitMember":           16,


### PR DESCRIPTION
## Summary
- Additive migration `sc2_006_token_routes_sort_order`
- List lite/summary/routes ordered by `sort_order ASC, id ASC`
- `PUT /api/routes/reorder` bulk assign sortOrder
- Tests for reorder + list order; schema column count updated

Closes #284

## Test plan
- [x] `go test ./handler/admin ./store -count=1`