### PR TITLE
docs(release): v0.8.13 Enterprise residual (#281–#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.13] — 2026-07-17
+
+### Added
+- token_routes.sort_order + PUT /api/routes/reorder bulk drag reorder (#284 / #288)
+
+### Docs / Honesty
+- original-gap-matrix refresh for shipped surfaces (rerank/site concurrency/key proxy/rebuild/cache_ratio) (#281 / #285)
+- sticky multi-instance affinity product-path evaluation (#282 / #286)
+- update-center residual honesty hardening (no remote registry) (#283 / #287)
+
 ## [v0.8.12] — 2026-07-17
 
 ### Fixed

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -86,6 +86,7 @@
 | Residual v0.8.10 | Milestone 19 closed · tag **[v0.8.10](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.10)** |
 | Residual v0.8.11 | Milestone 20 closed · **#265–#266** (PRs #267/#268); tag **v0.8.11** |
 | Residual v0.8.12 | Milestone 21 closed · **#271–#274** (PRs #275/#276/#277/#278); tag **v0.8.12** |
+| Residual v0.8.13 | Milestone 22 closed · **#281–#284** (PRs #285/#286/#287/#288); tag **v0.8.13** |
 | Residual CI | vulncheck green on Go 1.26.5; frontend occasional EnvironmentTeardownError flake |
 
 ### M-COMPETE notes (active)
@@ -180,6 +181,6 @@
 - **M-SCHEMA**: additive `schema_migrations` + columns `proxy_url` / `max_concurrency` / `context_length`
 
 ## Next Steps
-1. Tag **v0.8.12** (admin task race + site-announcement wire + channel-recovery coordinator + WS residual eval)
-2. Optional deeper product: full Responses WS Codex path (see residual eval #274); update-center product; product backlog P0/P1
-3. Continue product backlog P0/P1; multi-instance sticky/session affinity product if needed
+1. Tag **v0.8.13** (gap matrix refresh + sticky eval + update-center residual + route reorder)
+2. Optional deeper product: full Responses WS Codex path; Redis sticky (eval B); remaining P0/P1 backlog
+3. Continue product backlog P0/P1; frontend flake observability if CI noise returns


### PR DESCRIPTION
## Summary
- CHANGELOG **v0.8.13**: #281–#284 / PRs #285–#288
- MASTER residual row + Next Steps
- Milestone 22 closed

## Test plan
- docs only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.8.13, including route bulk-reorder sorting and drag-ordering updates.
  * Documented refreshed coverage matrices, multi-instance affinity evaluation, and improved transparency around update-center behavior.
  * Updated project progress documentation to reflect milestone completion and revised next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->