### PR TITLE
docs(analysis): residual next candidates post v0.8.13 (#290)

### DIFF
--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,0 +1,59 @@
+# Residual next candidates (post v0.8.13)
+
+**Date**: 2026-07-17  
+**Issue**: [#290](https://github.com/TokenDanceLab/metapi-go/issues/290)  
+**Context**: After Enterprise residual **v0.8.13** (gap matrix refresh, sticky eval, update-center residual honesty, token_routes reorder).  
+**Scope**: inventory only — **no product code** in this document.
+
+## Purpose
+
+Give the next residual / product wave a single honest backlog of high-leverage leftovers. Status labels:
+
+| Status | Meaning |
+|--------|---------|
+| residual | Explicit non-product or 501/log-only path |
+| partial | Related surface exists; upstream intent incomplete |
+| present | Shipped enough to drop from active residual queue |
+| design-only | Evaluation/spike docs exist; no runtime path |
+
+## Candidates
+
+| ID | Title | Status | Evidence | Recommended wave | Risk |
+|----|-------|--------|----------|------------------|------|
+| WS-1 | Full Responses WebSocket Codex path | residual | `handler/proxy/responses_ws.go` (426 plain GET / 501 upgrade); `docs/analysis/responses-websocket-residual.md` (#217/#274) | Dedicated Milestone after Codex interop ACs | High protocol + multi-instance sticky interaction |
+| STICKY-B | Redis sticky map (option B) | design-only | `proxy/session.go` process-local `stickyBindings`; `docs/analysis/sticky-session-multi-instance-residual.md` (#237/#282); design spike #292 | Only if multi-instance sticky is product-critical and LB pin is unavailable | Hot-path Redis; must fail-open like sharedcount |
+| UC-1 | Update-center remote registry / deploy | residual | `scheduler/update_center.go` log-only; admin deploy/rollback/SSE **501**; `docs/analysis/residual-update-center.md` (#283) | Product Milestone with real registry client | Ops safety; no fake updateAvailable |
+| TEST-1 | Admin proxy/chat stream + job queue harness | residual | `handler/admin/test.go` stream/jobs **501** / job not-found; sync path aliases forced-channel harness; `docs/analysis/admin-channel-test-harness.md` (#291) | Optional UX polish; sync harness already present | Low if residual stays honest |
+| P0-568 | Relay keys force-marked expired | partial | `service/alert/alert.go` `ReportTokenExpired` → `accounts.status='expired'`; callers checkin/balance | Reliability wave | Over-expiry false positives |
+| P0-585 | Channel failure cascade poison | partial | Retry/exclude in `proxy/channel_selection.go`, `proxy/conductor.go`, `proxy/retry_policy.go`; no full production proof vs site-wide poison | Reliability / load-test wave | High under multi-channel failure storms |
+| P0-555 | Token usage statistics inaccurate | partial | `scheduler/usage_aggregation.go` + admin stats; stream/partial/error token extraction still needs runtime audit | Observability wave | Billing/ops trust |
+| P1-580 | Gemini thought_signature tool history | partial | Aggregate field only in `transform/gemini/generate_content/compatibility.go`; request-side preservation incomplete | Protocol wave | Official Gemini tool history rejects |
+| P1-538 | Hermes/Codex multi-turn responses content | partial | Responses surface + reasoning parsers; multi-turn required `content` not fully enforced | Protocol wave | Client second-turn failures |
+| ROUTE-590 | Route list drag reorder | **present** (v0.8.13) | `token_routes.sort_order` + `PUT /api/routes/reorder` (#284/#288); list `ORDER BY sort_order, id` | Done — matrix row should flip present on next refresh | — |
+| RERANK-591 | `/v1/rerank` | present | `handler/proxy/rerank.go` + router | Done (matrix #281) | — |
+| SITE-594 | Site max concurrency | present | `proxy/site_concurrency.go` + `sites.max_concurrency` | Done (matrix #281) | — |
+| KEY-578 | Per-key outbound proxy | present | `proxy/key_proxy.go` + `downstream_api_keys.proxy_url` | Done (matrix #281) | — |
+| REBUILD-588 | Pattern/group rebuild | present | `service/route_rebuild.go` `RebuildRoutesBestEffort` | Done (matrix #281) | — |
+| PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
+
+## Recommended sequencing (v0.8.14+)
+
+1. **Docs hygiene** (this file + Redis sticky design spike #292 + admin test residual honesty #291) — no runtime risk.
+2. **Reliability partials** P0-568 / P0-585 with tests under multi-channel failure — highest operator pain.
+3. **Protocol partials** P1-580 / P1-538 when client repros available.
+4. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+5. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+
+## Explicit non-goals for residual waves
+
+- Fake WS frames or Hijack-then-silent-close.
+- Claiming cluster-wide sticky while bindings remain process-local.
+- Inventing update-center deploy/rollback success without a registry.
+- Returning `success:true` for unimplemented admin stream/job queues.
+
+## Links
+
+- Release: [v0.8.13](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.13)
+- Matrix: `docs/analysis/original-gap-matrix.md`
+- MASTER: `docs/progress/MASTER.md`
+- Related issues: #274, #282, #283, #290, #291, #292


### PR DESCRIPTION
## Summary
- Add `docs/analysis/residual-next-candidates.md` inventory after **v0.8.13**
- Covers: Responses WS Codex residual (426/501), Redis sticky Option B, remaining matrix partial P0s (#568/#585/#555; #590 present via #284), admin test harness 501s, update-center log-only residual
- Light MASTER Next Steps refresh to point at the inventory (tag step done)
- **No product code**

Closes #290

## Test plan
- [x] docs only (`docs/analysis/residual-next-candidates.md`, `docs/progress/MASTER.md`)
- [x] matrix verified post-#281/#284 for partial vs present