### PR TITLE
fix(admin): /api/test stream/job residual honesty (#291)

### DIFF
--- a/docs/analysis/admin-channel-test-harness.md
+++ b/docs/analysis/admin-channel-test-harness.md
@@ -94,6 +94,22 @@ Always HTTP **200** for a completed probe attempt (including upstream 4xx/5xx/ti
 | No auth header echo | Response does not include request Authorization |
 | Timeout floor/ceiling | 1s–60s |
 
+## Related `/api/test/*` aliases (#185 / #291)
+
+Sync admin test routes reuse this harness when a channel/site is forced. Stream and async job surfaces stay residual.
+
+| Method | Path | Status | Behavior | Invents? |
+|--------|------|--------|----------|----------|
+| POST | `/api/test/proxy` | **200** / **400** / **404** / **501** | Forced id → harness; else **501** residual matrix | **No** fake probe without forced channel |
+| POST | `/api/test/chat` | **200** / **400** / **404** / **501** | Same as proxy | **No** fake chat success without forced channel |
+| POST | `/api/test/proxy/stream` | **501** | SSE matrix residual | **No** fake stream chunks |
+| POST | `/api/test/chat/stream` | **501** | SSE residual | **No** fake stream chunks |
+| POST | `/api/test/proxy/jobs` | **501** | Async job queue residual | **No** `stub-job` |
+| POST | `/api/test/chat/jobs` | **501** | Async job queue residual | **No** `stub-job` |
+| GET/DELETE | `/api/test/{proxy,chat}/jobs/{jobId}` | **404** | No in-process job registry | **No** fake complete/cancel |
+
+Details: `docs/analysis/p4-admin-test-routes.md` · code: `handler/admin/test.go`.
+
 ## Out of scope
 
 - End-user unauthenticated console
@@ -101,6 +117,7 @@ Always HTTP **200** for a completed probe attempt (including upstream 4xx/5xx/ti
 - Browser extension permissions / all-api-hub client shape
 - Background health probing (see #114 / `scheduler/model_probe.go`)
 - Large SPA redesign (optional thin button is a follow-up)
+- Working `/api/test/*/stream` SSE matrix or `/api/test/*/jobs` async queues (honest 501/404 residuals only; see #291)
 
 ## Tests
 

--- a/docs/analysis/ops-admin-stubs.md
+++ b/docs/analysis/ops-admin-stubs.md
@@ -22,6 +22,7 @@ Replace remaining admin ops stubs that previously returned fake success:
 2. **LDOH reverse proxy** needs a valid operator-provided `ld_auth_session` cookie and a prior `POST /api/monitor/session`. Upstream network failures return `502`, never fake `success:true`.
 3. **Background task registry** is process-local (in-memory), matching the TS service model. Multi-instance deployments do not share task state.
 4. **Announcement sync** is best-effort per site: unsupported platforms increment `unsupported`; adapter/network failures are recorded in `failedSites` inside the task result rather than inventing a queued success without work.
+5. **Admin test harness residuals (#291)** — `/api/test/{proxy,chat}/stream` and `/api/test/{proxy,chat}/jobs` stay honest **501**; job get/cancel stay **404** with no stub-job registry. See `docs/analysis/admin-channel-test-harness.md` and `docs/analysis/p4-admin-test-routes.md`.
 
 ## Tests
 

--- a/docs/analysis/p4-admin-test-routes.md
+++ b/docs/analysis/p4-admin-test-routes.md
@@ -1,9 +1,10 @@
-# P4 admin test routes (#185)
+# P4 admin test routes (#185 / #291)
 
 **Date:** 2026-07-17  
-**Issue:** [#185](https://github.com/TokenDanceLab/metapi-go/issues/185)  
+**Issues:** [#185](https://github.com/TokenDanceLab/metapi-go/issues/185), [#291](https://github.com/TokenDanceLab/metapi-go/issues/291)  
 **Peers:** [#119](https://github.com/TokenDanceLab/metapi-go/issues/119) forced-channel harness  
-**Code:** `handler/admin/test.go`, reuses `handler/admin/channel_test_harness.go`
+**Code:** `handler/admin/test.go`, reuses `handler/admin/channel_test_harness.go`  
+**Related residual docs:** `docs/analysis/admin-channel-test-harness.md`, `docs/analysis/ops-admin-stubs.md`
 
 ## Goal
 
@@ -12,17 +13,29 @@ Replace `handler/admin/test.go` fake `success:true` / stub-job responses with ei
 1. the real forced-channel harness path, or
 2. an honest **501** residual (never `success:true` with a not-implemented message).
 
-## Behavior matrix
+#291 is a residual honesty pass only: keep stream/job surfaces residual, strengthen residual wording, and keep docs accurate. **Do not invent working SSE streams or job queues.**
 
-| Method | Path | Behavior |
-|--------|------|----------|
-| POST | `/api/test/proxy` | When `channelId` / `forcedChannelId` / `siteId` present → delegate to harness (`runChannelTest`). Otherwise **501** residual (full path/multipart matrix not ported). |
-| POST | `/api/test/chat` | Same alias as proxy when a forced channel/site is provided. |
-| POST | `/api/test/proxy/stream` | **501** residual (SSE matrix). |
-| POST | `/api/test/chat/stream` | **501** residual (SSE). |
-| POST | `/api/test/proxy/jobs` | **501** residual (no async job queue). |
-| POST | `/api/test/chat/jobs` | **501** residual (no async job queue). |
-| GET/DELETE | `/api/test/{proxy,chat}/jobs/{jobId}` | **404** `job not found` (no registry; no stub-job invent). |
+## Current endpoint table (#291)
+
+| Method | Path | Status | Behavior | Invents? |
+|--------|------|--------|----------|----------|
+| POST | `/api/test/proxy` | **200** / **400** / **404** / **501** | With `channelId` / `forcedChannelId` / `siteId` → forced-channel harness. Without forced id → **501** residual (full path/multipart matrix not ported). Bad JSON → **400**. Missing channel → **404**. | **No** fake probe success without a forced channel |
+| POST | `/api/test/chat` | **200** / **400** / **404** / **501** | Same alias as proxy when a forced channel/site is provided. | **No** fake chat success without a forced channel |
+| POST | `/api/test/proxy/stream` | **501** | SSE proxy stream matrix residual | **No** fake SSE chunks / stream success theater |
+| POST | `/api/test/chat/stream` | **501** | SSE chat stream residual | **No** fake SSE chunks / stream success theater |
+| POST | `/api/test/proxy/jobs` | **501** | Async proxy job queue residual | **No** `stub-job` / fake queued success |
+| POST | `/api/test/chat/jobs` | **501** | Async chat job queue residual | **No** `stub-job` / fake queued success |
+| GET | `/api/test/proxy/jobs/{jobId}` | **404** | No in-process job registry | **No** fake completed job |
+| DELETE | `/api/test/proxy/jobs/{jobId}` | **404** | No in-process job registry | **No** fake cancel success |
+| GET | `/api/test/chat/jobs/{jobId}` | **404** | No in-process job registry | **No** fake completed job |
+| DELETE | `/api/test/chat/jobs/{jobId}` | **404** | No in-process job registry | **No** fake cancel success |
+
+Canonical forced probe (implemented, not residual):
+
+| Method | Path | Status | Behavior |
+|--------|------|--------|----------|
+| POST | `/api/admin/test-channel` | **200** / **400** / **404** | Forced-channel harness (`channel_test_harness.go`) |
+| POST | `/api/debug/channel-probe` | **200** / **400** / **404** | Alias of the same harness |
 
 ## Request mapping
 
@@ -51,15 +64,30 @@ Probe execution, redaction, timeout clamps, and token resolution are **not dupli
 }
 ```
 
+404 job body shape (no registry):
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": "job not found",
+    "type": "not_found"
+  },
+  "residual": "no in-process /api/test/{proxy|chat} job queue or job registry; POST jobs returns 501; use sync POST /api/test/{proxy|chat} or POST /api/admin/test-channel"
+}
+```
+
 Rules:
 
 - Never return HTTP 200 with `success:true` for unimplemented work.
 - Never invent `jobId: "stub-job"`.
+- Never invent fake SSE stream chunks or async job completion theater.
 - Prefer pointing operators at `POST /api/admin/test-channel` for forced probes.
+- Job GET/DELETE stay **404** (empty registry), not **200** success or fake cancel.
 
 ## Router wiring
 
-`RegisterTestRoutes(r, db, cfg)` now requires DB + config so aliases can construct the shared harness handler. Called from `router/router.go` inside the admin-auth + DB-ready group.
+`RegisterTestRoutes(r, db, cfg)` requires DB + config so aliases can construct the shared harness handler. Called from `router/router.go` inside the admin-auth + DB-ready group.
 
 ## Tests
 
@@ -69,6 +97,7 @@ Rules:
 - proxy/chat without forced id → 501 + residual, `success:false`
 - forced channel / siteId → real harness probe (transport stub)
 - stream + job create → 501; job get/delete → 404 without fake success
+- residual field present on 501 and job 404 surfaces
 
 ```bash
 go test ./handler/admin -count=1 -run 'TestTest|TestRegisterTest|TestMapFlexible|TestChannelTest'

--- a/handler/admin/test.go
+++ b/handler/admin/test.go
@@ -11,8 +11,12 @@ import (
 )
 
 // RegisterTestRoutes registers all /api/test routes.
-// Sync proxy/chat probes alias the forced-channel harness (#119 / #185).
-// Stream and async job surfaces return honest 501 residuals (no fake success).
+//
+// Residual honesty (#185 / #291):
+//   - sync proxy/chat probes alias the forced-channel harness when a channel/site is forced
+//   - stream + async job create surfaces return honest 501 residuals (no fake SSE/job success)
+//   - job status/cancel return 404 (no in-process /api/test job registry; never invent stub-job ids)
+// See docs/analysis/admin-channel-test-harness.md and docs/analysis/p4-admin-test-routes.md.
 func RegisterTestRoutes(r chi.Router, db *sqlx.DB, cfg *config.Config) {
 	handler := &testHandler{
 		channel: &channelTestHandler{db: db, cfg: cfg},
@@ -65,29 +69,33 @@ func (h *testHandler) proxyTest(w http.ResponseWriter, r *http.Request) {
 }
 
 // POST /api/test/proxy/stream
+// SSE proxy stream matrix is residual — honest 501 (never invents fake stream chunks).
 func (h *testHandler) proxyTestStream(w http.ResponseWriter, r *http.Request) {
 	writeNotImplementedResidual(w,
 		"Proxy stream test is not implemented in Go",
-		"SSE /api/test/proxy/stream matrix; use non-stream POST /api/test/proxy with channelId/siteId or POST /api/admin/test-channel",
+		"SSE /api/test/proxy/stream matrix is residual; no fake stream success theater; use non-stream POST /api/test/proxy with channelId/siteId/forcedChannelId or POST /api/admin/test-channel",
 	)
 }
 
 // POST /api/test/proxy/jobs
+// Async proxy job queue is residual — honest 501 (never invents stub-job ids).
 func (h *testHandler) proxyTestJob(w http.ResponseWriter, r *http.Request) {
 	writeNotImplementedResidual(w,
 		"Proxy test job queue is not implemented in Go",
-		"async /api/test/proxy/jobs; use sync POST /api/test/proxy or POST /api/admin/test-channel",
+		"async /api/test/proxy/jobs queue is residual; no job registry or stub-job ids; use sync POST /api/test/proxy or POST /api/admin/test-channel",
 	)
 }
 
 // GET /api/test/proxy/jobs/:jobId
+// No in-process proxy test job registry — honest 404 (not a fake completed job).
 func (h *testHandler) proxyTestJobStatus(w http.ResponseWriter, r *http.Request) {
-	writeJobNotFound(w)
+	writeJobNotFound(w, "proxy")
 }
 
 // DELETE /api/test/proxy/jobs/:jobId
+// No in-process proxy test job registry — honest 404 (not a fake cancel success).
 func (h *testHandler) proxyTestJobCancel(w http.ResponseWriter, r *http.Request) {
-	writeJobNotFound(w)
+	writeJobNotFound(w, "proxy")
 }
 
 // POST /api/test/chat
@@ -97,29 +105,33 @@ func (h *testHandler) chatTest(w http.ResponseWriter, r *http.Request) {
 }
 
 // POST /api/test/chat/stream
+// SSE chat stream is residual — honest 501 (never invents fake stream chunks).
 func (h *testHandler) chatTestStream(w http.ResponseWriter, r *http.Request) {
 	writeNotImplementedResidual(w,
 		"Chat stream test is not implemented in Go",
-		"SSE /api/test/chat/stream; use non-stream POST /api/test/chat with channelId/siteId or POST /api/admin/test-channel",
+		"SSE /api/test/chat/stream is residual; no fake stream success theater; use non-stream POST /api/test/chat with channelId/siteId/forcedChannelId or POST /api/admin/test-channel",
 	)
 }
 
 // POST /api/test/chat/jobs
+// Async chat job queue is residual — honest 501 (never invents stub-job ids).
 func (h *testHandler) chatTestJob(w http.ResponseWriter, r *http.Request) {
 	writeNotImplementedResidual(w,
 		"Chat test job queue is not implemented in Go",
-		"async /api/test/chat/jobs; use sync POST /api/test/chat or POST /api/admin/test-channel",
+		"async /api/test/chat/jobs queue is residual; no job registry or stub-job ids; use sync POST /api/test/chat or POST /api/admin/test-channel",
 	)
 }
 
 // GET /api/test/chat/jobs/:jobId
+// No in-process chat test job registry — honest 404 (not a fake completed job).
 func (h *testHandler) chatTestJobStatus(w http.ResponseWriter, r *http.Request) {
-	writeJobNotFound(w)
+	writeJobNotFound(w, "chat")
 }
 
 // DELETE /api/test/chat/jobs/:jobId
+// No in-process chat test job registry — honest 404 (not a fake cancel success).
 func (h *testHandler) chatTestJobCancel(w http.ResponseWriter, r *http.Request) {
-	writeJobNotFound(w)
+	writeJobNotFound(w, "chat")
 }
 
 func (h *testHandler) handleSyncProbe(w http.ResponseWriter, r *http.Request, surface string) {
@@ -131,9 +143,11 @@ func (h *testHandler) handleSyncProbe(w http.ResponseWriter, r *http.Request, su
 
 	req, ok := mapFlexibleToChannelTest(body)
 	if !ok {
+		// Full path/multipart/routing matrix without a forced channel is residual.
+		// Do not invent a successful probe when no channel/site is forced.
 		writeNotImplementedResidual(w,
 			strings.ToUpper(surface[:1])+surface[1:]+" test requires channelId, siteId, or forcedChannelId for the forced-channel harness",
-			"full /api/test/"+surface+" path/multipart/routing matrix without a forced channel; provide channelId/siteId/forcedChannelId or use POST /api/admin/test-channel",
+			"full /api/test/"+surface+" path/multipart/routing matrix without a forced channel is residual; provide channelId/siteId/forcedChannelId or use POST /api/admin/test-channel",
 		)
 		return
 	}
@@ -249,6 +263,8 @@ func contentToPrompt(raw json.RawMessage) string {
 	return ""
 }
 
+// writeNotImplementedResidual returns HTTP 501 with success:false.
+// Never use this helper to invent fake success, stream chunks, or job ids (#291).
 func writeNotImplementedResidual(w http.ResponseWriter, message, residual string) {
 	writeJSON(w, http.StatusNotImplemented, map[string]any{
 		"success":  false,
@@ -257,13 +273,15 @@ func writeNotImplementedResidual(w http.ResponseWriter, message, residual string
 	})
 }
 
-func writeJobNotFound(w http.ResponseWriter) {
-	// Honest empty job surface: no in-process job registry for /api/test/* yet.
+// writeJobNotFound is the honest empty job surface for /api/test/*/jobs/:jobId.
+// There is no in-process job registry for these routes; never invent stub-job success (#291).
+func writeJobNotFound(w http.ResponseWriter, surface string) {
 	writeJSON(w, http.StatusNotFound, map[string]any{
 		"success": false,
 		"error": map[string]any{
 			"message": "job not found",
 			"type":    "not_found",
 		},
+		"residual": "no in-process /api/test/" + surface + " job queue or job registry; POST jobs returns 501; use sync POST /api/test/" + surface + " or POST /api/admin/test-channel",
 	})
 }

--- a/handler/admin/test_routes_test.go
+++ b/handler/admin/test_routes_test.go
@@ -236,19 +236,20 @@ func TestTestRoutes_StreamAndJobsHonest501(t *testing.T) {
 	_, _, r := setupTestRoutes(t)
 
 	cases := []struct {
-		method string
-		path   string
-		body   any
-		want   int
+		method          string
+		path            string
+		body            any
+		want            int
+		residualSnippet string
 	}{
-		{http.MethodPost, "/api/test/proxy/stream", map[string]any{"forcedChannelId": 1}, http.StatusNotImplemented},
-		{http.MethodPost, "/api/test/chat/stream", map[string]any{"channelId": 1}, http.StatusNotImplemented},
-		{http.MethodPost, "/api/test/proxy/jobs", map[string]any{"forcedChannelId": 1}, http.StatusNotImplemented},
-		{http.MethodPost, "/api/test/chat/jobs", map[string]any{"channelId": 1}, http.StatusNotImplemented},
-		{http.MethodGet, "/api/test/proxy/jobs/any", nil, http.StatusNotFound},
-		{http.MethodGet, "/api/test/chat/jobs/any", nil, http.StatusNotFound},
-		{http.MethodDelete, "/api/test/proxy/jobs/any", nil, http.StatusNotFound},
-		{http.MethodDelete, "/api/test/chat/jobs/any", nil, http.StatusNotFound},
+		{http.MethodPost, "/api/test/proxy/stream", map[string]any{"forcedChannelId": 1}, http.StatusNotImplemented, "no fake stream success theater"},
+		{http.MethodPost, "/api/test/chat/stream", map[string]any{"channelId": 1}, http.StatusNotImplemented, "no fake stream success theater"},
+		{http.MethodPost, "/api/test/proxy/jobs", map[string]any{"forcedChannelId": 1}, http.StatusNotImplemented, "no job registry or stub-job ids"},
+		{http.MethodPost, "/api/test/chat/jobs", map[string]any{"channelId": 1}, http.StatusNotImplemented, "no job registry or stub-job ids"},
+		{http.MethodGet, "/api/test/proxy/jobs/any", nil, http.StatusNotFound, "no in-process /api/test/proxy job queue"},
+		{http.MethodGet, "/api/test/chat/jobs/any", nil, http.StatusNotFound, "no in-process /api/test/chat job queue"},
+		{http.MethodDelete, "/api/test/proxy/jobs/any", nil, http.StatusNotFound, "no in-process /api/test/proxy job queue"},
+		{http.MethodDelete, "/api/test/chat/jobs/any", nil, http.StatusNotFound, "no in-process /api/test/chat job queue"},
 	}
 
 	for _, tc := range cases {
@@ -275,9 +276,22 @@ func TestTestRoutes_StreamAndJobsHonest501(t *testing.T) {
 			if out["success"] == true {
 				t.Fatalf("fake success on residual path: %v", out)
 			}
-			if tc.want == http.StatusNotImplemented {
-				if residual, _ := out["residual"].(string); residual == "" {
-					t.Fatalf("expected residual: %v", out)
+			// Never invent stub job ids on residual job surfaces.
+			if _, ok := out["jobId"]; ok {
+				t.Fatalf("invented jobId on residual path: %v", out)
+			}
+			if residual, _ := out["residual"].(string); residual == "" {
+				t.Fatalf("expected residual: %v", out)
+			} else if !strings.Contains(residual, tc.residualSnippet) {
+				t.Fatalf("residual=%q missing %q", residual, tc.residualSnippet)
+			}
+			if tc.want == http.StatusNotFound {
+				errObj, _ := out["error"].(map[string]any)
+				if errObj == nil {
+					t.Fatalf("expected error object on job 404: %v", out)
+				}
+				if msg, _ := errObj["message"].(string); msg != "job not found" {
+					t.Fatalf("error.message=%v", errObj["message"])
 				}
 			}
 		})


### PR DESCRIPTION
## Summary
- Residual honesty for proxy/chat stream (501) and jobs (501 create / 404 status-cancel)
- Docs endpoint table in admin-channel-test-harness
- No fake stream chunks or stub-job ids

Closes #291

## Test plan
- [x] go test ./handler/admin