### PR TITLE
docs(release): v0.8.15 Enterprise residual (#298–#300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.15] — 2026-07-17
+
+### Fixed
+- Gate `ReportTokenExpired` / checkin-balance mark paths with `ShouldMarkAccountExpired` (no bare/generic 401 over-expiry) (#298 / #301)
+- Channel-scoped cascade isolation: 429 fails over, same-channel timeout budget, multi-channel same-site isolation tests (#299 / #302)
+- Preserve stream/partial usage on client disconnect when usage was already extracted (#300 / #303)
+
+### Docs / Honesty
+- Failover isolation residual notes for #585 (#299)
+- Gap matrix rows for #568 present + #585/#555 partial evidence refresh (via #301/#302/#303)
+
 ## [v0.8.14] — 2026-07-17
 
 ### Docs / Honesty

--- a/docs/analysis/original-gap-matrix.md
+++ b/docs/analysis/original-gap-matrix.md
@@ -1,7 +1,7 @@
 # Original MetAPI Gap Matrix (metapi-go evidence)
 
 > Snapshot date: 2026-07-16 (G2 inventory)  
-> **Matrix evidence refreshed: 2026-07-17** (post v0.8.12 / toward v0.8.13 — docs-only #281)  
+> **Matrix evidence refreshed: 2026-07-17** (post v0.8.15 — #568 present, #585/#555 partial evidence, #590 present)  
 > Branch base: `feat/gap-inventory` (G1 sources/taxonomy); refresh on `docs/p90-gap-matrix-refresh`  
 > Issue: [#9 G2](https://github.com/tokendancelab/metapi-go/issues/9) · refresh [#281](https://github.com/TokenDanceLab/metapi-go/issues/281)  
 > Sources: `docs/analysis/original-gap-sources.md`  
@@ -48,7 +48,7 @@
 | 573 | Add Site silent fail: HTTP 200 error body + UI success toast | bug-correctness | present | Backend: `handler/admin/sites.go` create path returns 400/409/500 with `error`/`message` (not 200-on-error); success only `writeJSON(..., StatusOK, result)`. Frontend: `web/pages/Sites.tsx` `api.addSite` then `toast.success`; failures `catch` → `toast.error` | P0 | no |
 | 580 | Gemini official chat rejects tool history without thought_signature | feature-protocol | partial | Only aggregate field `ThoughtSignatures []string` in `transform/gemini/generate_content/compatibility.go` `GeminiAggregateState`; no request-side injection/preservation of tool-history `thought_signature` for official Gemini chat found | P1 | yes |
 | 581 | PR: Fix Gemini official tool-history thought signatures | feature-protocol | partial | Same as #580 — stream state can collect signatures (`ThoughtSignatures`), but native bridge fix for official tool history is incomplete vs PR intent | P1 | yes |
-| 590 | Cannot adjust route order | feature-routing | partial | Routes listed `ORDER BY id ASC` in `handler/admin/token_routes.go` `listLite`/`listSummary` — no route-level order column/API. Channel priority reorder exists: `PUT /api/channels/batch` `batchUpdateChannels` updates `route_channels.priority` | P2 | yes |
+| 590 | Cannot adjust route order | feature-routing | present | `token_routes.sort_order` additive (`store/additive.go` `sc2_006_token_routes_sort_order`); `PUT /api/routes/reorder` + list `ORDER BY sort_order ASC, id ASC` in `handler/admin/token_routes.go` (#284/#288); channel priority reorder remains `PUT /api/channels/batch` | P2 | no |
 | 594 | Per-site max concurrency / request control | feature-routing | present | Schema: `sites.max_concurrency` (`store/schema.go` `Site.MaxConcurrency`, additive `store/additive.go` `sc2_002_site_max_concurrency`). Limiter: `proxy/site_concurrency.go` `SiteConcurrencyLimiter` (0 = unlimited; saturate → skip site, no cascade). Wired in `handler/proxy/upstream.go` + admin create/update `handler/admin/sites.go` / `handler/admin/payloads/sites.go`; tests `proxy/site_concurrency_test.go`, `handler/proxy/upstream_test.go` `TestSiteConcurrencySaturateSkipsWithoutFailure`, `handler/admin/sites_test.go` `TestSites_MaxConcurrencyRoundTrip`. Orthogonal to session channel leases in `proxy/session.go` | P2 | no |
 | 591 | Add `/v1/rerank` endpoint | feature-protocol | present | `handler/proxy/rerank.go` `HandleRerank` (`POST` passthrough `/v1/rerank`, model required, stream rejected); registered `handler/proxy/router.go` `RegisterProxyRoutes` → `r.Post("/rerank", HandleRerank)`; metrics path `handler/shared/metrics.go`; tests `handler/proxy/rerank_test.go` + router path coverage; contract `docs/analysis/rerank-endpoint.md` | P1 | no |
 | 583 | Key grouping / tags | feature-keys | present | `downstream_api_keys.group_name` CRUD: `handler/admin/downstream_keys.go` create/update/batch groupName; schema `store/schema.go` `DownstreamAPIKey`; tests `handler/admin/downstream_keys_test.go` | P2 | no |
@@ -134,15 +134,15 @@
 
 | status | mandatory (29) | all rows (64) |
 | --- | ---: | ---: |
-| present | 17 | 18 |
-| partial | 11 | 31 |
+| present | 18 | 18 |
+| partial | 10 | 31 |
 | missing | 0 | 3 |
 | unknown-needs-runtime | 1 | 6 |
 | n/a-upstream-only | 0 | 6 |
 
-Mandatory present (17): **#582, #568, #573, #583, #570, #549, #550, #586, #569, #529, #594, #591, #578, #588, #526, #559, #496**.  
+Mandatory present (18): **#582, #568, #573, #583, #570, #549, #550, #586, #569, #529, #590, #594, #591, #578, #588, #526, #559, #496**.  
 Mandatory missing (0): *(none — #594/#591/#578/#588/#526/#559 shipped)*.  
-Mandatory partial (11): **#585, #580, #581, #590, #579, #547, #520, #584, #577, #555, #538**.  
+Mandatory partial (10): **#585, #580, #581, #579, #547, #520, #584, #577, #555, #538**.  
 Mandatory unknown (1): **#571**.
 
 Remaining **all-rows missing** (3, additional product sample only): **#534** bulk account import · **#514** multi-tier ctx routing · **#292** auto priority orchestration.
@@ -167,7 +167,7 @@ Remaining **all-rows missing** (3, additional product sample only): **#534** bul
 
 1. G2 matrix was inventory-only; product fixes landed later under **M-FEATURE** / residual releases. This file tracks **current evidence**, not the original freeze.
 2. **2026-07-17 refresh:** mandatory missing set cleared for shipped surfaces — rebuild (**#588/#526/#559**), `/v1/rerank` (**#591**), per-site concurrency (**#594**), per-key proxy (**#578**), Claude `cache_ratio` (**#496**).
-3. Remaining high-leverage **partial** mandatory work: Gemini `thought_signature` depth (**#580/#581**), cascade/failover hardening (**#585/#568**), route **order** (**#590**), multi-key binding (**#579**), usage/stats accuracy (**#555**), multi-turn responses content (**#538**).
+3. Remaining high-leverage **partial** mandatory work: Gemini `thought_signature` depth (**#580/#581**), cascade residual load-proof (**#585**), multi-key binding (**#579**), usage/stats accuracy (**#555**), multi-turn responses content (**#538**).
 4. Prefer runtime verification for `unknown-needs-runtime` before opening large implementation issues.
 5. Architecture debt rows can be filed as metapi-go-native issues (not “upstream parity”).
 

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,8 +1,8 @@
-# Residual next candidates (post v0.8.13)
+# Residual next candidates (post v0.8.15)
 
 **Date**: 2026-07-17  
-**Issue**: [#290](https://github.com/TokenDanceLab/metapi-go/issues/290)  
-**Context**: After Enterprise residual **v0.8.13** (gap matrix refresh, sticky eval, update-center residual honesty, token_routes reorder).  
+**Issue**: [#290](https://github.com/TokenDanceLab/metapi-go/issues/290) (inventory origin); reliability wave **#298–#300**  
+**Context**: After Enterprise residual **v0.8.15** (expired-mark guard, cascade isolation, stream/partial usage).  
 **Scope**: inventory only — **no product code** in this document.
 
 ## Purpose
@@ -24,9 +24,9 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | STICKY-B | Redis sticky map (option B) | design-only | `proxy/session.go` process-local `stickyBindings`; `docs/analysis/sticky-session-multi-instance-residual.md` (#237/#282); design spike #292 | Only if multi-instance sticky is product-critical and LB pin is unavailable | Hot-path Redis; must fail-open like sharedcount |
 | UC-1 | Update-center remote registry / deploy | residual | `scheduler/update_center.go` log-only; admin deploy/rollback/SSE **501**; `docs/analysis/residual-update-center.md` (#283) | Product Milestone with real registry client | Ops safety; no fake updateAvailable |
 | TEST-1 | Admin proxy/chat stream + job queue harness | residual | `handler/admin/test.go` stream/jobs **501** / job not-found; sync path aliases forced-channel harness; `docs/analysis/admin-channel-test-harness.md` (#291) | Optional UX polish; sync harness already present | Low if residual stays honest |
-| P0-568 | Relay keys force-marked expired | **present** (#298) | `ShouldMarkAccountExpired` + `ReportTokenExpired` ClassExpired guard; bare/generic 401 no longer marks | Done for mark path; novel wording residual only | Residual wording gaps |
-| P0-585 | Channel failure cascade poison | partial | Retry/exclude in `proxy/channel_selection.go`, `proxy/conductor.go`, `proxy/retry_policy.go`; no full production proof vs site-wide poison | Reliability / load-test wave | High under multi-channel failure storms |
-| P0-555 | Token usage statistics inaccurate | partial | `scheduler/usage_aggregation.go` + admin stats; stream/partial/error token extraction still needs runtime audit | Observability wave | Billing/ops trust |
+| P0-568 | Relay keys force-marked expired | **present** (#298/#301) | `ShouldMarkAccountExpired` + `ReportTokenExpired` ClassExpired guard; bare/generic 401 no longer marks | Done for mark path; novel wording residual only | Residual wording gaps |
+| P0-585 | Channel failure cascade poison | **partial** (hardened #299/#302) | Channel-scoped exclude, 429 failover, same-channel timeout budget, isolation tests; residual site/model breaker + production multi-channel load proof | Optional load-test / breaker polish | Medium residual |
+| P0-555 | Token usage statistics inaccurate | **partial** (audit #300/#303) | Client disconnect keeps extracted stream usage; aggregation pipeline still needs broader error/partial coverage | Observability follow-up | Billing/ops trust |
 | P1-580 | Gemini thought_signature tool history | partial | Aggregate field only in `transform/gemini/generate_content/compatibility.go`; request-side preservation incomplete | Protocol wave | Official Gemini tool history rejects |
 | P1-538 | Hermes/Codex multi-turn responses content | partial | Responses surface + reasoning parsers; multi-turn required `content` not fully enforced | Protocol wave | Client second-turn failures |
 | ROUTE-590 | Route list drag reorder | **present** (v0.8.13) | `token_routes.sort_order` + `PUT /api/routes/reorder` (#284/#288); list `ORDER BY sort_order, id` | Done — matrix row should flip present on next refresh | — |
@@ -36,11 +36,11 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | REBUILD-588 | Pattern/group rebuild | present | `service/route_rebuild.go` `RebuildRoutesBestEffort` | Done (matrix #281) | — |
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
 
-## Recommended sequencing (v0.8.14+)
+## Recommended sequencing (v0.8.16+)
 
-1. **Docs hygiene** (this file + Redis sticky design spike #292 + admin test residual honesty #291) — no runtime risk.
-2. **Reliability partials** P0-568 / P0-585 with tests under multi-channel failure — highest operator pain.
-3. **Protocol partials** P1-580 / P1-538 when client repros available.
+1. **Docs honesty**: flip matrix #590 → present; keep residual inventory honest after v0.8.15.
+2. **Protocol partials** P1-580 / P1-538 when client repros available.
+3. **Observability follow-up** on P0-555 aggregation / non-stream paths (beyond disconnect partial).
 4. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
 5. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
@@ -53,7 +53,8 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 
 ## Links
 
-- Release: [v0.8.13](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.13)
+- Release: [v0.8.15](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.15)
 - Matrix: `docs/analysis/original-gap-matrix.md`
+- Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`
-- Related issues: #274, #282, #283, #290, #291, #292
+- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -88,6 +88,7 @@
 | Residual v0.8.12 | Milestone 21 closed · **#271–#274** (PRs #275/#276/#277/#278); tag **v0.8.12** |
 | Residual v0.8.13 | Milestone 22 closed · **#281–#284** (PRs #285/#286/#287/#288); tag **v0.8.13** |
 | Residual v0.8.14 | Milestone 23 closed · **#290–#292** (PRs #293/#294/#295); tag **v0.8.14** |
+| Residual v0.8.15 | Milestone 24 closed · **#298–#300** (PRs #301/#302/#303); tag **v0.8.15** |
 | Residual CI | vulncheck green on Go 1.26.5; frontend occasional EnvironmentTeardownError flake |
 
 ### M-COMPETE notes (active)
@@ -182,6 +183,6 @@
 - **M-SCHEMA**: additive `schema_migrations` + columns `proxy_url` / `max_concurrency` / `context_length`
 
 ## Next Steps
-1. Tag **v0.8.14** (next residual inventory + Redis sticky design + admin test residual honesty)
-2. Optional deeper product: full Responses WS Codex path; Redis sticky Option B Milestone; reliability partials #568/#585/#555
-3. Continue product backlog P0/P1 from residual-next-candidates.md
+1. Tag **v0.8.15** (reliability P0: expired-mark guard + cascade isolation + stream usage partial) — this release
+2. Open **v0.8.16**: matrix #590 present flip, residual-next-candidates refresh, protocol partials P1-580/P1-538, optional usage aggregation deeper audit
+3. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry


### PR DESCRIPTION
## Summary
- Document **v0.8.15** reliability wave: #298/#301 expired-mark guard, #299/#302 cascade isolation, #300/#303 stream usage partial.
- Flip matrix **#590 → present**; refresh residual-next-candidates post v0.8.15.
- Close Milestone 24 via release notes (issues already closed).

## Verify
- docs only
- `go test ./docs -run TestPublicMarkdownHygiene -count=1` (optional)

Closes release gate for Milestone **Enterprise residual v0.8.15**.