### PR TITLE
fix(responses): multi-turn content sanitize gate (#310)

### DIFF
--- a/docs/analysis/original-gap-matrix.md
+++ b/docs/analysis/original-gap-matrix.md
@@ -70,7 +70,7 @@
 | 555 | Token usage statistics inaccurate | bug-correctness | partial | Aggregation pipeline: `scheduler/usage_aggregation.go` → `site_day_usage` / `model_day_usage`; dashboard reads `handler/admin/stats.go` (`SUM(total_tokens)`, model day usage). Accuracy of stream/partial/error token extraction still needs runtime audit | P0 | yes |
 | 496 | Claude cache pricing wrong when cache_ratio missing (fallback 1.0) | bug-correctness | present | Cost builder: `routing/pricing_cost.go` `ResolveCacheRatio` / `DefaultCacheRatioForModel` — Claude missing → **0.1**, cache_creation → **1.25**; non-Claude keeps historical 1.0; explicit 0 preserved. Proxy path: `handler/proxy/billing_cost.go` `EstimateBillingCostFromUsage` → `CalculateModelUsageBreakdown`. Tests `routing/pricing_cost_test.go`, `handler/proxy/billing_cost_test.go`. Analysis `docs/analysis/cache-ratio-pricing.md`. UI still shows `billing_details.cacheRatio` on proxy logs | P0 | no |
 | 529 | Drag-and-drop reorder | feature-admin-ux | present | Route **channel** drag: `web/pages/TokenRoutes.tsx` + `@dnd-kit` (`web/pages/token-routes/RouteCard*.tsx`, `priorityRail.ts`) → `api.batchUpdateChannels` priorities. Import drag is file-drop only (`ImportExport.tsx`) | P4 | no |
-| 538 | Hermes/Codex multi-turn `/v1/responses` reasoning item needs content | feature-protocol | partial | Responses surface: `handler/proxy/router.go` `/responses`, transform reasoning parsers `transform/shared/chatFormatsCore.go` `parseResponsesReasoning` / `ResponsesReasoningByIndex`; compact sanitize `transform/openai/responses/compact.go`. No dedicated fix ensuring multi-turn reasoning items always carry required `content` for Hermes/Codex second turn | P1 | yes |
+| 538 | Hermes/Codex multi-turn `/v1/responses` reasoning item needs content | feature-protocol | present | `transform/openai/responses/reasoning_input.go` injects/preserves `content` + keeps `encrypted_content`/`summary`; `SanitizeResponsesRequestBody` + `handler/proxy/upstream.go` `sanitizeUpstreamJSONBody` (Responses path + input gate #310); honest `ReasoningInputError` 400; tests `reasoning_input_test.go`, `upstream_test.go`. Residual: full Responses→chat conversion, server store, WS (see `responses-multi-turn-reasoning.md`) | P1 | no |
 
 **Mandatory row count:** 29 (all listed numbers covered; #580/#581 and #588/#526/#559 expanded as separate rows).
 
@@ -134,15 +134,15 @@
 
 | status | mandatory (29) | all rows (64) |
 | --- | ---: | ---: |
-| present | 18 | 18 |
-| partial | 10 | 31 |
+| present | 19 | 18 |
+| partial | 9 | 31 |
 | missing | 0 | 3 |
 | unknown-needs-runtime | 1 | 6 |
 | n/a-upstream-only | 0 | 6 |
 
-Mandatory present (18): **#582, #568, #573, #583, #570, #549, #550, #586, #569, #529, #590, #594, #591, #578, #588, #526, #559, #496**.  
+Mandatory present (19): **#582, #568, #573, #583, #570, #549, #550, #586, #569, #529, #590, #594, #591, #578, #588, #526, #559, #496, #538**.  
 Mandatory missing (0): *(none — #594/#591/#578/#588/#526/#559 shipped)*.  
-Mandatory partial (10): **#585, #580, #581, #579, #547, #520, #584, #577, #555, #538**.  
+Mandatory partial (9): **#585, #580, #581, #579, #547, #520, #584, #577, #555**.  
 Mandatory unknown (1): **#571**.
 
 Remaining **all-rows missing** (3, additional product sample only): **#534** bulk account import · **#514** multi-tier ctx routing · **#292** auto priority orchestration.
@@ -167,7 +167,7 @@ Remaining **all-rows missing** (3, additional product sample only): **#534** bul
 
 1. G2 matrix was inventory-only; product fixes landed later under **M-FEATURE** / residual releases. This file tracks **current evidence**, not the original freeze.
 2. **2026-07-17 refresh:** mandatory missing set cleared for shipped surfaces — rebuild (**#588/#526/#559**), `/v1/rerank` (**#591**), per-site concurrency (**#594**), per-key proxy (**#578**), Claude `cache_ratio` (**#496**).
-3. Remaining high-leverage **partial** mandatory work: Gemini `thought_signature` depth (**#580/#581**), cascade residual load-proof (**#585**), multi-key binding (**#579**), usage/stats accuracy (**#555**), multi-turn responses content (**#538**).
+3. Remaining high-leverage **partial** mandatory work: Gemini `thought_signature` depth (**#580/#581**), cascade residual load-proof (**#585**), multi-key binding (**#579**), usage/stats accuracy (**#555**). Multi-turn responses content (**#538**) is **present** for HTTP content inject/preserve (#50/#310); residual is conversion/store/WS only.
 4. Prefer runtime verification for `unknown-needs-runtime` before opening large implementation issues.
 5. Architecture debt rows can be filed as metapi-go-native issues (not “upstream parity”).
 

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -29,7 +29,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | P0-585 | Channel failure cascade poison | **partial** (hardened #299/#302) | Channel-scoped exclude, 429 failover, same-channel timeout budget, isolation tests; residual site/model breaker + production multi-channel load proof | Optional load-test / breaker polish | Medium residual |
 | P0-555 | Token usage statistics inaccurate | **partial** (audit #300/#303) | Client disconnect keeps extracted stream usage; aggregation pipeline still needs broader error/partial coverage | Observability follow-up | Billing/ops trust |
 | P1-580 | Gemini thought_signature tool history | partial | Aggregate field only in `transform/gemini/generate_content/compatibility.go`; request-side preservation incomplete | Protocol wave | Official Gemini tool history rejects |
-| P1-538 | Hermes/Codex multi-turn responses content | partial | Responses surface + reasoning parsers; multi-turn required `content` not fully enforced | Protocol wave | Client second-turn failures |
+| P1-538 | Hermes/Codex multi-turn responses content | **present** (core; #50/#310) | `SanitizeResponsesInputItems` + `sanitizeUpstreamJSONBody` inject/preserve content; honest 400; residual: full Responses→chat conversion + no server store + no WS | Done for HTTP multi-turn content | Residual conversion/store/WS only |
 | ROUTE-590 | Route list drag reorder | **present** (v0.8.13) | `token_routes.sort_order` + `PUT /api/routes/reorder` (#284/#288); list `ORDER BY sort_order, id` | Done — matrix row should flip present on next refresh | — |
 | RERANK-591 | `/v1/rerank` | present | `handler/proxy/rerank.go` + router | Done (matrix #281) | — |
 | SITE-594 | Site max concurrency | present | `proxy/site_concurrency.go` + `sites.max_concurrency` | Done (matrix #281) | — |
@@ -40,7 +40,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 ## Recommended sequencing (v0.8.16+)
 
 1. **Docs honesty**: flip matrix #590 → present; keep residual inventory honest after v0.8.15.
-2. **Protocol partials** P1-580 / P1-538 when client repros available.
+2. **Protocol partials** P1-580 when client repros available (P1-538 HTTP multi-turn content present; residual conversion/store/WS only).
 3. **Observability follow-up** on P0-555 aggregation / non-stream paths (beyond disconnect partial).
 4. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
 5. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.

--- a/docs/analysis/responses-multi-turn-reasoning.md
+++ b/docs/analysis/responses-multi-turn-reasoning.md
@@ -1,8 +1,8 @@
-# Multi-turn `/v1/responses` reasoning content (#50 / upstream #538)
+# Multi-turn `/v1/responses` reasoning content (#50 / upstream #538 / #310)
 
 **Date:** 2026-07-17  
-**Lane:** feature / FE-PROTOCOL  
-**SSOT code:** `transform/openai/responses/reasoning_input.go`, `transform/openai/responses/compact.go`, `transform/openai/responses/previous_response_id.go` (`SanitizeResponsesRequestBody`), `transform/shared/chatFormatsCore.go` (`parseResponsesReasoning`)
+**Lane:** feature / FE-PROTOCOL / residual honesty  
+**SSOT code:** `transform/openai/responses/reasoning_input.go`, `transform/openai/responses/compact.go`, `transform/openai/responses/previous_response_id.go` (`SanitizeResponsesRequestBody`), `handler/proxy/upstream.go` (`sanitizeUpstreamJSONBody`), `transform/shared/chatFormatsCore.go` (`parseResponsesReasoning`)
 
 ## Problem
 
@@ -66,10 +66,13 @@ parseResponsesReasoning(m) // reads output[] or input[]; flattens summary/conten
 `handler/proxy/upstream.go` `sanitizeUpstreamJSONBody` cheap-gates on:
 
 - `"previous_response_id"`
-- compact path
+- compact path (`/responses/compact`)
 - `"type":"reasoning"` / `"type": "reasoning"` / `"encrypted_content"`
+- **Responses path + `"input"`** — catches pretty-printed / spaced JSON where type markers are not contiguous bytes (#310)
 
 then calls `SanitizeResponsesRequestBody` so second-turn reasoning bodies are rewritten even without continuity ids.
+
+`ReasoningInputError` / `ContinuityError` map to **HTTP 400** `invalid_request_error` (no silent accept).
 
 ## Acceptance mapping
 
@@ -77,16 +80,24 @@ then calls `SanitizeResponsesRequestBody` so second-turn reasoning bodies are re
 | --- | --- |
 | Multi-turn Hermes/Codex second turn accepts prior reasoning with required content | `SanitizeResponsesInputItems` injects/preserves `content`; keeps `encrypted_content` + `summary` |
 | Compact/sanitize does not drop required reasoning content | Compact only strips stream/store/previous_response_id; input sanitized before compact |
-| Fixture covers reasoning item round-trip | `reasoning_input_test.go`, shared parse fixtures |
-| Explicit error when client omits required fields | `ReasoningInputError` with `input[n]` index and required field list |
+| Fixture covers reasoning item round-trip | `reasoning_input_test.go`, shared parse fixtures, `upstream_test.go` wire tests |
+| Explicit error when client omits required fields | `ReasoningInputError` with `input[n]` index and required field list → 400 |
+| Pretty-printed / spaced type markers still sanitize | Responses path + `"input"` cheap gate (#310) |
 
-## Residual
+## Residual (honest)
 
-- Full Responses → chat conversion of reasoning items remains in original TS `convertResponsesBodyToOpenAiBody`; Go multi-protocol fallback still relies on passthrough + continuity strip (#54).
-- No server-side store of prior Responses payloads: clients must replay items or use `previous_response_id` on supported platforms.
+| Item | Status |
+|------|--------|
+| Inject `content` on reasoning items for strict gateway validators | **present** (`SanitizeResponsesInputItems` + wire tests) |
+| Preserve `encrypted_content` / `summary` through compact | **present** |
+| Explicit 400 when reasoning has no content/summary/encrypted | **present** (`ReasoningInputError` → 400) |
+| Pretty-printed / spaced JSON type markers | **present** (Responses path + `"input"` gate, #310) |
+| Full Responses → chat conversion of reasoning items | **residual** — Go multi-protocol fallback still relies on passthrough + continuity strip (#54); no invent of chat-shaped reasoning |
+| Server-side store of prior Responses payloads | **residual** — clients must replay items or use `previous_response_id` on supported platforms |
+| Full Responses WebSocket multi-turn Codex path | **residual** — 426/501 only; see `responses-websocket-residual.md` (not this issue) |
 
 ## Verification
 
 ```bash
-go test ./transform/openai/responses/ ./transform/shared/ -count=1
+go test ./transform/openai/responses/ ./transform/shared/ ./handler/proxy -count=1 -run 'Response|Sanitize|Reasoning'
 ```

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -1210,11 +1210,17 @@ func sanitizeUpstreamJSONBody(bodyBytes []byte, sitePlatform, upstreamPath strin
 	// input is involved. Avoid full JSON parse on hot path otherwise.
 	pathLower := strings.ToLower(upstreamPath)
 	needsCompact := strings.Contains(pathLower, "/responses/compact")
+	isResponsesPath := needsCompact || strings.Contains(pathLower, "/responses")
 	needsContinuity := bytes.Contains(bodyBytes, []byte(`"previous_response_id"`))
-	// Match both "type":"reasoning" and "type": "reasoning" (space after colon).
+	// Multi-turn Hermes/Codex (#50 / #538 / #310):
+	// 1) Exact compact markers (common client encoding).
+	// 2) Responses path + "input" always parse - covers pretty-printed /
+	//    spaced JSON where "type" : "reasoning" does not match contiguous bytes.
+	// 3) encrypted_content anywhere (continuity payload even without type key).
 	needsReasoningInput := bytes.Contains(bodyBytes, []byte(`"type":"reasoning"`)) ||
 		bytes.Contains(bodyBytes, []byte(`"type": "reasoning"`)) ||
-		bytes.Contains(bodyBytes, []byte(`"encrypted_content"`))
+		bytes.Contains(bodyBytes, []byte(`"encrypted_content"`)) ||
+		(isResponsesPath && bytes.Contains(bodyBytes, []byte(`"input"`)))
 	if !needsCompact && !needsContinuity && !needsReasoningInput {
 		return bodyBytes, nil
 	}

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 	"github.com/tokendancelab/metapi-go/proxy"
 	"github.com/tokendancelab/metapi-go/routing"
 	"github.com/tokendancelab/metapi-go/store"
+	"github.com/tokendancelab/metapi-go/transform/openai/responses"
 )
 
 type upstreamTestRouter struct {
@@ -625,7 +627,6 @@ func TestSiteConcurrencySaturateSkipsWithoutFailure(t *testing.T) {
 	}
 }
 
-
 func TestNonStreamSuccessPersistsUsageTokensToProxyLog(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -1031,5 +1032,140 @@ func TestHandleStreamUpstreamContextCancelPreservesPartialUsage(t *testing.T) {
 	}
 	if usage.Source != usageSourceUnknown {
 		t.Fatalf("source = %q, want unknown when no usage extracted", usage.Source)
+	}
+}
+
+func TestSanitizeUpstreamJSONBody_MultiTurnReasoningInjectsContent(t *testing.T) {
+	// Hermes/Codex second-turn: reasoning has encrypted_content + summary, no content.
+	body := []byte(`{
+  "model": "gpt-5.4",
+  "input": [
+    {"type": "message", "role": "user", "content": "continue"},
+    {
+      "type": "reasoning",
+      "id": "rs_1",
+      "encrypted_content": "enc_abc",
+      "summary": [{"type": "summary_text", "text": "step one"}]
+    },
+    {"type": "message", "role": "assistant", "content": ""},
+    {"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": "{}"}
+  ]
+}`)
+	out, err := sanitizeUpstreamJSONBody(body, "codex", "/v1/responses")
+	if err != nil {
+		t.Fatalf("sanitize: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal out: %v", err)
+	}
+	arr, ok := m["input"].([]any)
+	if !ok || len(arr) != 4 {
+		t.Fatalf("input = %#v", m["input"])
+	}
+	reasoning, _ := arr[1].(map[string]any)
+	if reasoning["encrypted_content"] != "enc_abc" {
+		t.Fatalf("encrypted_content dropped: %#v", reasoning["encrypted_content"])
+	}
+	if _, ok := reasoning["summary"]; !ok {
+		t.Fatal("summary dropped")
+	}
+	if reasoning["content"] != "step one" {
+		t.Fatalf("content = %#v, want summary text for strict gateways", reasoning["content"])
+	}
+}
+
+func TestSanitizeUpstreamJSONBody_PrettyPrintedReasoningTypeSpace(t *testing.T) {
+	// Pretty-printed "type" : "reasoning" (spaces around colon) must still sanitize.
+	body := []byte(`{
+  "model": "gpt-5.4",
+  "input": [
+    {
+      "type" : "reasoning",
+      "encrypted_content": "enc_pretty",
+      "summary": [{"type": "summary_text", "text": "think"}]
+    }
+  ]
+}`)
+	out, err := sanitizeUpstreamJSONBody(body, "openai", "/v1/responses")
+	if err != nil {
+		t.Fatalf("sanitize: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	arr := m["input"].([]any)
+	r := arr[0].(map[string]any)
+	if r["encrypted_content"] != "enc_pretty" {
+		t.Fatalf("encrypted_content = %#v", r["encrypted_content"])
+	}
+	if r["content"] != "think" {
+		t.Fatalf("content = %#v (pretty type key must still inject content)", r["content"])
+	}
+}
+
+func TestSanitizeUpstreamJSONBody_ReasoningMissingFieldsHonest400(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","input":[{"type":"reasoning","summary":[]}]}`)
+	out, err := sanitizeUpstreamJSONBody(body, "openai", "/v1/responses")
+	if err == nil {
+		t.Fatalf("expected ReasoningInputError, got body=%s", out)
+	}
+	if !strings.Contains(err.Error(), "input[0]") {
+		t.Fatalf("err = %q, want input index", err.Error())
+	}
+	if !strings.Contains(err.Error(), "encrypted_content") {
+		t.Fatalf("err = %q, want required field list", err.Error())
+	}
+	// Wire path maps this to 400 invalid_request_error (no silent accept).
+	var re *responses.ReasoningInputError
+	if !errors.As(err, &re) {
+		t.Fatalf("err type = %T, want *responses.ReasoningInputError", err)
+	}
+	if re.Index != 0 {
+		t.Fatalf("index = %d", re.Index)
+	}
+}
+
+func TestSanitizeUpstreamJSONBody_NonResponsesPathSkipsUnlessMarkers(t *testing.T) {
+	// Chat path without markers: no parse, body unchanged.
+	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hi"}]}`)
+	out, err := sanitizeUpstreamJSONBody(body, "openai", "/v1/chat/completions")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !bytes.Equal(out, body) {
+		t.Fatalf("chat body mutated without markers")
+	}
+}
+
+func TestSanitizeUpstreamJSONBody_CompactPreservesReasoningInput(t *testing.T) {
+	body := []byte(`{
+  "model":"gpt-5.4",
+  "stream":true,
+  "store":true,
+  "previous_response_id":"resp_1",
+  "input":[{"type":"reasoning","encrypted_content":"enc","summary":[{"type":"summary_text","text":"s"}]}]
+}`)
+	out, err := sanitizeUpstreamJSONBody(body, "codex", "/v1/responses/compact")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"stream", "previous_response_id"} {
+		if _, ok := m[k]; ok {
+			t.Fatalf("expected %q stripped on compact", k)
+		}
+	}
+	arr := m["input"].([]any)
+	r := arr[0].(map[string]any)
+	if r["encrypted_content"] != "enc" {
+		t.Fatalf("encrypted_content dropped: %#v", r)
+	}
+	if r["content"] != "s" {
+		t.Fatalf("content = %#v", r["content"])
 	}
 }

--- a/transform/openai/responses/reasoning_input_test.go
+++ b/transform/openai/responses/reasoning_input_test.go
@@ -280,3 +280,46 @@ func TestSanitizeCompactResponsesRequestBody_DoesNotDropInput(t *testing.T) {
 		t.Fatalf("input mutated: %#v", r)
 	}
 }
+
+func TestSanitizeResponsesInputItems_SummaryTextArrayContentKey(t *testing.T) {
+	// summary_text blocks with nested content field instead of text.
+	input := []any{
+		map[string]any{
+			"type":              "reasoning",
+			"encrypted_content": "enc_nested",
+			"summary": []any{
+				map[string]any{"type": "summary_text", "content": "from content key"},
+			},
+		},
+	}
+	got, err := SanitizeResponsesInputItems(input)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	r := got.([]any)[0].(map[string]any)
+	if r["content"] != "from content key" {
+		t.Fatalf("content = %#v", r["content"])
+	}
+	if r["encrypted_content"] != "enc_nested" {
+		t.Fatalf("encrypted dropped")
+	}
+}
+
+func TestSanitizeResponsesInputItems_EmptyStringContentWithEncrypted(t *testing.T) {
+	// content key present but empty string + encrypted -> keep key, do not reject.
+	input := []any{
+		map[string]any{
+			"type":              "reasoning",
+			"content":           "",
+			"encrypted_content": "enc",
+		},
+	}
+	got, err := SanitizeResponsesInputItems(input)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	r := got.([]any)[0].(map[string]any)
+	if c, ok := r["content"].(string); !ok || c != "" {
+		t.Fatalf("content = %#v", r["content"])
+	}
+}


### PR DESCRIPTION
## Summary
- Broaden `sanitizeUpstreamJSONBody` so Responses paths with `input` always run multi-turn reasoning sanitization (pretty-printed type keys).
- Wire tests + flip matrix #538 / residual P1-538 to present with honest residual notes.

## Issue
Closes #310

## Verify
```bash
go test ./transform/openai/responses/ ./handler/proxy -count=1 -run 'Response|Sanitize|Reasoning|MultiTurn|Content'
```