### PR TITLE
fix(proxy): wire Gemini tool-history thought_signature sanitize (#309)

### DIFF
--- a/docs/analysis/gemini-thought-signature.md
+++ b/docs/analysis/gemini-thought-signature.md
@@ -2,7 +2,7 @@
 
 Last updated: 2026-07-17
 
-Issue: TokenDanceLab/metapi-go#47  
+Issue: TokenDanceLab/metapi-go#47 / #309  
 Upstream: cita-777/metapi#580 / #581
 
 ## Problem
@@ -17,7 +17,9 @@ OpenAI-compatible clients usually cannot carry Gemini provider metadata, so repl
 
 ## Implementation (metapi-go)
 
-Primary surface: `transform/gemini/generate_content/compatibility.go`
+### Transform surface
+
+Primary: `transform/gemini/generate_content/compatibility.go`
 
 | Concern | Behavior |
 |--------|----------|
@@ -33,12 +35,28 @@ Primary surface: `transform/gemini/generate_content/compatibility.go`
 | Next-turn inject | `ApplyThoughtSignaturesToFunctionCallParts` / `BuildSignedModelContentForToolHistory` re-attach aggregate signatures for follow-up requests |
 | OpenAI bridge | Gemini→OpenAI stores signature under `tool_calls[].provider_specific_fields.thought_signature`; OpenAI→Gemini restores it |
 
+### Proxy runtime wire (#309)
+
+Live path: `handler/proxy/upstream.go` `sanitizeUpstreamJSONBody` (after model swap, per candidate path).
+
+| Gate | Behavior |
+|------|----------|
+| Platform | `gemini` / `gemini-cli` / `google` only |
+| Path | native `*generateContent*` / `*streamGenerateContent*` or `/v1internal*` (CLI) |
+| Body markers | only when `"functionCall"` / `"function_call"` / `"tool_calls"` present (cheap skip) |
+| Native `contents` | `generate_content.NormalizeRequest(body, model)` |
+| CLI envelope | `{ request: { contents… } }` — normalize inner request |
+| OpenAI `messages` on native path | `BuildGeminiGenerateContentRequestFromOpenAi` |
+| Model source | upstream actual model → body/request model → path-parsed model |
+
+OpenAI-compat `/v1/chat/completions` on Gemini OpenAI-compat bases is **not** rewritten (stays OpenAI-shaped; no native `thoughtSignature` field).
+
 ## Round-trip
 
 1. Upstream stream/final Gemini parts may include `thoughtSignature` on `functionCall`.
-2. Aggregate state collects unique signatures (`GeminiAggregateState.ThoughtSignatures`).
+2. Aggregate state collects unique signatures (`GeminiAggregateState.ThoughtSignatures`) inside the transform `StreamBridge` (test/helpers; not a multi-instance session store).
 3. Gemini→OpenAI conversion preserves them on tool_calls provider fields.
-4. Next OpenAI→Gemini or native normalize re-attaches real signatures (or dummy when required and missing).
+4. Next OpenAI→Gemini or native normalize (via proxy sanitize or direct transform) re-attaches real signatures (or dummy when required and missing).
 
 ## Models without signature support / caveats
 
@@ -49,6 +67,12 @@ Primary surface: `transform/gemini/generate_content/compatibility.go`
 | `gemini-2.5*` without thinking | No injection (matches upstream #135 baseline) |
 | Non-`gemini-*` IDs routed through this bridge | No dummy; thinking config may be disabled if signature missing |
 | Third-party “Gemini-compatible” proxies | Dummy may be rejected; only official Gemini model IDs are treated as dummy-safe |
+
+## Residual (honest)
+
+- **No multi-instance / Redis session store** for aggregate `ThoughtSignatures`. Process-local stream aggregate helpers exist for tests and future session glue; live proxy does **not** re-attach prior-turn aggregate state across requests. Clients must echo `provider_specific_fields.thought_signature` or send native contents that `NormalizeRequest` can patch (dummy for Gemini 3 when missing).
+- Full Responses WS and Redis sticky remain out of scope.
+- OpenAI-compat chat path on Gemini is passthrough (no native inject).
 
 ## Tests
 
@@ -64,7 +88,16 @@ Primary surface: `transform/gemini/generate_content/compatibility.go`
 - Aggregate → next request round-trip
 - OpenAI↔Gemini tool-history signature round-trip
 
-## Out of scope (this issue)
+`handler/proxy/gemini_thought_signature_test.go` covers:
 
-- Proxy executor routing (`gemini-native` path selection) — upstream #581 also touched request builders; this Go issue focuses on transform/request-side signature inject/preserve.
-- `web/**` and other protocol issues (#52/#53/#54).
+- Proxy sanitize injects dummy for Gemini 3 tool history on generateContent
+- Preserves real signatures
+- gemini-cli request envelope inject
+- OpenAI messages → native rebuild with provider sig
+- Non-gemini platform / no tool-history skip
+
+## Out of scope
+
+- Redis sticky / multi-instance aggregate re-attach
+- Full Responses WebSocket
+- `web/**` and unrelated protocol issues

--- a/docs/analysis/original-gap-matrix.md
+++ b/docs/analysis/original-gap-matrix.md
@@ -46,8 +46,8 @@
 | 568 | Relay-station API keys frequently force-marked expired | bug-failover | present | Hardened in #298: `platform.ShouldMarkAccountExpired` requires confirmed credential-expiry wording (no bare/generic 401 mark); `ReportTokenExpired` defense-in-depth no-ops unless ClassExpired; checkin/balance call sites use `ShouldMarkAccountExpired`; proxy surface uses same guard. Residual: novel provider wording may still need exclusion expansion | P0 | no |
 | 585 | One channel failure cascades to other channels | bug-failover | partial | Request-path exclude is **channel-scoped** (`proxy/conductor.go` `appendExcludedChannelID`; upstream loop appends `selected.Channel.ID` only). Hardened #299: 429 fails over (no same-channel pin), timeout same-channel budget, multi-channel same-site isolation tests in `proxy/conductor_test.go` + `routing/failure_isolation_test.go`. Residual: site/model breaker after 3 fails, credential-scoped usage-limit, empty-filter fallback, no production multi-channel load proof — see `docs/analysis/failover-isolation.md` | P0 | yes |
 | 573 | Add Site silent fail: HTTP 200 error body + UI success toast | bug-correctness | present | Backend: `handler/admin/sites.go` create path returns 400/409/500 with `error`/`message` (not 200-on-error); success only `writeJSON(..., StatusOK, result)`. Frontend: `web/pages/Sites.tsx` `api.addSite` then `toast.success`; failures `catch` → `toast.error` | P0 | no |
-| 580 | Gemini official chat rejects tool history without thought_signature | feature-protocol | partial | Only aggregate field `ThoughtSignatures []string` in `transform/gemini/generate_content/compatibility.go` `GeminiAggregateState`; no request-side injection/preservation of tool-history `thought_signature` for official Gemini chat found | P1 | yes |
-| 581 | PR: Fix Gemini official tool-history thought signatures | feature-protocol | partial | Same as #580 — stream state can collect signatures (`ThoughtSignatures`), but native bridge fix for official tool history is incomplete vs PR intent | P1 | yes |
+| 580 | Gemini official chat rejects tool history without thought_signature | feature-protocol | present | Transform (#86/`5dcaf76`): `NormalizeRequest` / OpenAI↔Gemini rebuild / dummy inject / stream `ThoughtSignatures` collect / aggregate re-attach helpers in `transform/gemini/generate_content/compatibility.go` + `thought_signature_test.go`. Runtime wire (#309): `handler/proxy/upstream.go` `sanitizeUpstreamJSONBody` calls normalize/rebuild for `gemini`/`gemini-cli`/`google` on generateContent / v1internal paths when tool-history markers present; tests `handler/proxy/gemini_thought_signature_test.go`. Residual: no multi-instance aggregate session store — clients must echo `provider_specific_fields` or native signed contents; OpenAI-compat chat/completions path not rewritten | P1 | no |
+| 581 | PR: Fix Gemini official tool-history thought signatures | feature-protocol | present | Same as #580 — request-side inject/preserve + proxy sanitize wire; residual is session aggregate re-attach across instances only | P1 | no |
 | 590 | Cannot adjust route order | feature-routing | present | `token_routes.sort_order` additive (`store/additive.go` `sc2_006_token_routes_sort_order`); `PUT /api/routes/reorder` + list `ORDER BY sort_order ASC, id ASC` in `handler/admin/token_routes.go` (#284/#288); channel priority reorder remains `PUT /api/channels/batch` | P2 | no |
 | 594 | Per-site max concurrency / request control | feature-routing | present | Schema: `sites.max_concurrency` (`store/schema.go` `Site.MaxConcurrency`, additive `store/additive.go` `sc2_002_site_max_concurrency`). Limiter: `proxy/site_concurrency.go` `SiteConcurrencyLimiter` (0 = unlimited; saturate → skip site, no cascade). Wired in `handler/proxy/upstream.go` + admin create/update `handler/admin/sites.go` / `handler/admin/payloads/sites.go`; tests `proxy/site_concurrency_test.go`, `handler/proxy/upstream_test.go` `TestSiteConcurrencySaturateSkipsWithoutFailure`, `handler/admin/sites_test.go` `TestSites_MaxConcurrencyRoundTrip`. Orthogonal to session channel leases in `proxy/session.go` | P2 | no |
 | 591 | Add `/v1/rerank` endpoint | feature-protocol | present | `handler/proxy/rerank.go` `HandleRerank` (`POST` passthrough `/v1/rerank`, model required, stream rejected); registered `handler/proxy/router.go` `RegisterProxyRoutes` → `r.Post("/rerank", HandleRerank)`; metrics path `handler/shared/metrics.go`; tests `handler/proxy/rerank_test.go` + router path coverage; contract `docs/analysis/rerank-endpoint.md` | P1 | no |
@@ -134,15 +134,15 @@
 
 | status | mandatory (29) | all rows (64) |
 | --- | ---: | ---: |
-| present | 19 | 18 |
-| partial | 9 | 31 |
+| present | 21 | 21 |
+| partial | 7 | 28 |
 | missing | 0 | 3 |
 | unknown-needs-runtime | 1 | 6 |
 | n/a-upstream-only | 0 | 6 |
 
-Mandatory present (19): **#582, #568, #573, #583, #570, #549, #550, #586, #569, #529, #590, #594, #591, #578, #588, #526, #559, #496, #538**.  
-Mandatory missing (0): *(none — #594/#591/#578/#588/#526/#559 shipped)*.  
-Mandatory partial (9): **#585, #580, #581, #579, #547, #520, #584, #577, #555**.  
+Mandatory present (21): **#582, #568, #573, #580, #581, #583, #570, #549, #550, #586, #569, #529, #590, #594, #591, #578, #588, #526, #559, #496, #538**.  
+Mandatory missing (0): *(none — #594/#591/#578/#588/#526/#559/#580/#581/#538 shipped)*.  
+Mandatory partial (7): **#585, #579, #547, #520, #584, #577, #555**.  
 Mandatory unknown (1): **#571**.
 
 Remaining **all-rows missing** (3, additional product sample only): **#534** bulk account import · **#514** multi-tier ctx routing · **#292** auto priority orchestration.
@@ -167,7 +167,7 @@ Remaining **all-rows missing** (3, additional product sample only): **#534** bul
 
 1. G2 matrix was inventory-only; product fixes landed later under **M-FEATURE** / residual releases. This file tracks **current evidence**, not the original freeze.
 2. **2026-07-17 refresh:** mandatory missing set cleared for shipped surfaces — rebuild (**#588/#526/#559**), `/v1/rerank` (**#591**), per-site concurrency (**#594**), per-key proxy (**#578**), Claude `cache_ratio` (**#496**).
-3. Remaining high-leverage **partial** mandatory work: Gemini `thought_signature` depth (**#580/#581**), cascade residual load-proof (**#585**), multi-key binding (**#579**), usage/stats accuracy (**#555**). Multi-turn responses content (**#538**) is **present** for HTTP content inject/preserve (#50/#310); residual is conversion/store/WS only.
+3. Remaining high-leverage **partial** mandatory work: cascade residual load-proof (**#585**), multi-key binding (**#579**), usage/stats accuracy (**#555**). Gemini `thought_signature` (**#580/#581**) request-side + proxy sanitize is **present** (#86/#309); multi-turn Responses content (**#538**) is **present** for HTTP (#50/#310); residuals are multi-instance aggregate re-attach and conversion/store/WS only.
 4. Prefer runtime verification for `unknown-needs-runtime` before opening large implementation issues.
 5. Architecture debt rows can be filed as metapi-go-native issues (not “upstream parity”).
 

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -28,7 +28,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | P0-568 | Relay keys force-marked expired | **present** (#298/#301) | `ShouldMarkAccountExpired` + `ReportTokenExpired` ClassExpired guard; bare/generic 401 no longer marks | Done for mark path; novel wording residual only | Residual wording gaps |
 | P0-585 | Channel failure cascade poison | **partial** (hardened #299/#302) | Channel-scoped exclude, 429 failover, same-channel timeout budget, isolation tests; residual site/model breaker + production multi-channel load proof | Optional load-test / breaker polish | Medium residual |
 | P0-555 | Token usage statistics inaccurate | **partial** (audit #300/#303) | Client disconnect keeps extracted stream usage; aggregation pipeline still needs broader error/partial coverage | Observability follow-up | Billing/ops trust |
-| P1-580 | Gemini thought_signature tool history | partial | Aggregate field only in `transform/gemini/generate_content/compatibility.go`; request-side preservation incomplete | Protocol wave | Official Gemini tool history rejects |
+| P1-580 | Gemini thought_signature tool history | **present** (#86 transform + #309 proxy wire) | `NormalizeRequest` / OpenAI↔Gemini rebuild + `sanitizeUpstreamJSONBody` on gemini native/cli generateContent; residual: no multi-instance aggregate store | Done for request-side; session re-attach only if product needs | Residual multi-instance only |
 | P1-538 | Hermes/Codex multi-turn responses content | **present** (core; #50/#310) | `SanitizeResponsesInputItems` + `sanitizeUpstreamJSONBody` inject/preserve content; honest 400; residual: full Responses→chat conversion + no server store + no WS | Done for HTTP multi-turn content | Residual conversion/store/WS only |
 | ROUTE-590 | Route list drag reorder | **present** (v0.8.13) | `token_routes.sort_order` + `PUT /api/routes/reorder` (#284/#288); list `ORDER BY sort_order, id` | Done — matrix row should flip present on next refresh | — |
 | RERANK-591 | `/v1/rerank` | present | `handler/proxy/rerank.go` + router | Done (matrix #281) | — |
@@ -40,7 +40,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 ## Recommended sequencing (v0.8.16+)
 
 1. **Docs honesty**: flip matrix #590 → present; keep residual inventory honest after v0.8.15.
-2. **Protocol partials** P1-580 when client repros available (P1-538 HTTP multi-turn content present; residual conversion/store/WS only).
+2. **Protocol partials** largely present (P1-580 request-side + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
 3. **Observability follow-up** on P0-555 aggregation / non-stream paths (beyond disconnect partial).
 4. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
 5. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.

--- a/handler/proxy/gemini_thought_signature_test.go
+++ b/handler/proxy/gemini_thought_signature_test.go
@@ -1,0 +1,274 @@
+package proxyhandler
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	generate_content "github.com/tokendancelab/metapi-go/transform/gemini/generate_content"
+)
+
+func TestSanitizeUpstreamJSONBody_InjectsGemini3ThoughtSignature(t *testing.T) {
+	body := map[string]any{
+		"contents": []any{
+			map[string]any{
+				"role":  "user",
+				"parts": []any{map[string]any{"text": "weather?"}},
+			},
+			map[string]any{
+				"role": "model",
+				"parts": []any{
+					map[string]any{
+						"functionCall": map[string]any{
+							"name": "get_weather",
+							"args": map[string]any{"city": "Tokyo"},
+						},
+					},
+				},
+			},
+			map[string]any{
+				"role": "user",
+				"parts": []any{
+					map[string]any{
+						"functionResponse": map[string]any{
+							"name":     "get_weather",
+							"response": map[string]any{"temp": "22C"},
+						},
+					},
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := sanitizeUpstreamJSONBody(
+		raw,
+		"gemini",
+		"/v1beta/models/gemini-3-flash-preview:generateContent",
+		"gemini-3-flash-preview",
+	)
+	if err != nil {
+		t.Fatalf("sanitize: %v", err)
+	}
+	var next map[string]any
+	if err := json.Unmarshal(out, &next); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	fcParts := collectSanitizeFunctionCallParts(next["contents"])
+	if len(fcParts) != 1 {
+		t.Fatalf("expected 1 functionCall part, got %d (%s)", len(fcParts), string(out))
+	}
+	if fcParts[0]["thoughtSignature"] != generate_content.DummyThoughtSignature {
+		t.Fatalf("expected dummy thoughtSignature, got %v", fcParts[0]["thoughtSignature"])
+	}
+}
+
+func TestSanitizeUpstreamJSONBody_PreservesRealThoughtSignature(t *testing.T) {
+	body := map[string]any{
+		"contents": []any{
+			map[string]any{
+				"role": "model",
+				"parts": []any{
+					map[string]any{
+						"functionCall": map[string]any{
+							"name": "read",
+							"args": map[string]any{"path": "/tmp"},
+						},
+						"thoughtSignature": "real_sig_preserve",
+					},
+				},
+			},
+		},
+	}
+	raw, _ := json.Marshal(body)
+	out, err := sanitizeUpstreamJSONBody(
+		raw,
+		"gemini",
+		"/v1beta/models/gemini-3.5-flash:generateContent",
+		"gemini-3.5-flash",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var next map[string]any
+	if err := json.Unmarshal(out, &next); err != nil {
+		t.Fatal(err)
+	}
+	fcParts := collectSanitizeFunctionCallParts(next["contents"])
+	if len(fcParts) != 1 || fcParts[0]["thoughtSignature"] != "real_sig_preserve" {
+		t.Fatalf("expected preserved real sig, got %#v", fcParts)
+	}
+}
+
+func TestSanitizeUpstreamJSONBody_GeminiCLIRequestEnvelope(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-3-pro-preview",
+		"request": map[string]any{
+			"contents": []any{
+				map[string]any{
+					"role": "model",
+					"parts": []any{
+						map[string]any{
+							"functionCall": map[string]any{
+								"name": "tool_a",
+								"args": map[string]any{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	raw, _ := json.Marshal(body)
+	out, err := sanitizeUpstreamJSONBody(raw, "gemini-cli", "/v1internal::generateContent", "gemini-3-pro-preview")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var next map[string]any
+	if err := json.Unmarshal(out, &next); err != nil {
+		t.Fatal(err)
+	}
+	req, ok := next["request"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected request envelope, got %T", next["request"])
+	}
+	fcParts := collectSanitizeFunctionCallParts(req["contents"])
+	if len(fcParts) != 1 || fcParts[0]["thoughtSignature"] != generate_content.DummyThoughtSignature {
+		t.Fatalf("expected CLI envelope inject, got %#v full=%s", fcParts, string(out))
+	}
+}
+
+func TestSanitizeUpstreamJSONBody_OpenAIMessagesOnNativePath(t *testing.T) {
+	body := map[string]any{
+		"model": "gemini-3-flash-preview",
+		"messages": []any{
+			map[string]any{"role": "user", "content": "hi"},
+			map[string]any{
+				"role": "assistant",
+				"tool_calls": []any{
+					map[string]any{
+						"id":   "call_1",
+						"type": "function",
+						"function": map[string]any{
+							"name":      "ping",
+							"arguments": `{}`,
+						},
+						"provider_specific_fields": map[string]any{
+							"thought_signature": "from_openai_psf",
+						},
+					},
+				},
+			},
+			map[string]any{"role": "tool", "tool_call_id": "call_1", "content": `{"ok":true}`},
+		},
+	}
+	raw, _ := json.Marshal(body)
+	out, err := sanitizeUpstreamJSONBody(
+		raw,
+		"gemini",
+		"/v1beta/models/gemini-3-flash-preview:generateContent",
+		"gemini-3-flash-preview",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var next map[string]any
+	if err := json.Unmarshal(out, &next); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := next["contents"]; !ok {
+		t.Fatalf("expected OpenAI→Gemini rebuild with contents, got keys %v", mapKeys(next))
+	}
+	fcParts := collectSanitizeFunctionCallParts(next["contents"])
+	if len(fcParts) != 1 || fcParts[0]["thoughtSignature"] != "from_openai_psf" {
+		t.Fatalf("expected preserved OpenAI provider sig, got %#v body=%s", fcParts, string(out))
+	}
+}
+
+func TestSanitizeUpstreamJSONBody_SkipsNonGeminiPlatform(t *testing.T) {
+	body := map[string]any{
+		"contents": []any{
+			map[string]any{
+				"role": "model",
+				"parts": []any{
+					map[string]any{
+						"functionCall": map[string]any{"name": "x", "args": map[string]any{}},
+					},
+				},
+			},
+		},
+	}
+	raw, _ := json.Marshal(body)
+	out, err := sanitizeUpstreamJSONBody(raw, "openai", "/v1beta/models/gemini-3:generateContent", "gemini-3-flash-preview")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(raw) {
+		// Non-gemini platform must not rewrite even on generateContent path.
+		t.Fatalf("expected passthrough for non-gemini platform")
+	}
+}
+
+func TestSanitizeUpstreamJSONBody_SkipsWithoutToolHistory(t *testing.T) {
+	body := []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+	out, err := sanitizeUpstreamJSONBody(body, "gemini", "/v1beta/models/gemini-3:generateContent", "gemini-3-flash-preview")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != string(body) {
+		t.Fatalf("expected no rewrite without functionCall/tool_calls")
+	}
+}
+
+func TestNeedsGeminiThoughtSignatureSanitize(t *testing.T) {
+	raw := []byte(`{"contents":[{"parts":[{"functionCall":{"name":"a"}}]}]}`)
+	if !needsGeminiThoughtSignatureSanitize("gemini", "/v1beta/models/x:generateContent", raw) {
+		t.Fatal("expected true for gemini generateContent + functionCall")
+	}
+	if needsGeminiThoughtSignatureSanitize("openai", "/v1beta/models/x:generateContent", raw) {
+		t.Fatal("expected false for non-gemini platform")
+	}
+	if needsGeminiThoughtSignatureSanitize("gemini", "/v1/chat/completions", raw) {
+		t.Fatal("expected false for OpenAI chat path")
+	}
+	if needsGeminiThoughtSignatureSanitize("gemini", "/v1beta/models/x:generateContent", []byte(`{"contents":[]}`)) {
+		t.Fatal("expected false without tool markers")
+	}
+}
+
+func collectSanitizeFunctionCallParts(contents any) []map[string]any {
+	var out []map[string]any
+	switch arr := contents.(type) {
+	case []any:
+		for _, item := range arr {
+			m, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			switch parts := m["parts"].(type) {
+			case []any:
+				for _, p := range parts {
+					pm, ok := p.(map[string]any)
+					if !ok {
+						continue
+					}
+					if _, ok := pm["functionCall"]; ok {
+						out = append(out, pm)
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+func mapKeys(m map[string]any) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return strings.Join(keys, ",")
+}

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tokendancelab/metapi-go/proxy"
 	"github.com/tokendancelab/metapi-go/routing"
 	"github.com/tokendancelab/metapi-go/service"
+	generate_content "github.com/tokendancelab/metapi-go/transform/gemini/generate_content"
 	"github.com/tokendancelab/metapi-go/transform/openai/responses"
 )
 
@@ -270,7 +271,7 @@ func dispatchSelectedUpstream(
 	var lastPending *pendingUpstreamFailure
 	for i, path := range candidatePaths {
 		isLast := i >= len(candidatePaths)-1
-		attemptBody, sanitizeErr := sanitizeUpstreamJSONBody(bodyBytes, selected.Site.Platform, path)
+		attemptBody, sanitizeErr := sanitizeUpstreamJSONBody(bodyBytes, selected.Site.Platform, path, upstreamModel)
 		if sanitizeErr != nil {
 			// Clear client-facing continuity error (issue #54 / upstream #504).
 			writeJSONErrorWithRequest(w, http.StatusBadRequest, sanitizeErr.Error(), "invalid_request_error", requestID)
@@ -1196,18 +1197,23 @@ func handleNonStreamUpstream(w http.ResponseWriter, resp *http.Response, latency
 }
 
 // sanitizeUpstreamJSONBody applies Responses continuity/compact/reasoning-input
-// sanitization for one upstream attempt. Chat/messages candidates strip
-// previous_response_id; Responses platforms forward or strip per
-// SupportsResponsesPreviousResponseID. Multi-turn reasoning items get required
-// content preserved/injected (#50 / upstream #538).
-// See docs/analysis/previous-response-id.md and
-// docs/analysis/responses-multi-turn-reasoning.md.
-func sanitizeUpstreamJSONBody(bodyBytes []byte, sitePlatform, upstreamPath string) ([]byte, error) {
+// sanitization and official Gemini tool-history thoughtSignature inject for one
+// upstream attempt. Chat/messages candidates strip previous_response_id;
+// Responses platforms forward or strip per SupportsResponsesPreviousResponseID.
+// Multi-turn reasoning items get required content preserved/injected
+// (#50 / upstream #538). Native Gemini generateContent bodies (and gemini-cli
+// request envelopes) get NormalizeRequest / OpenAI→Gemini rebuild so functionCall
+// parts carry thoughtSignature (#309 / upstream #580/#581).
+// See docs/analysis/previous-response-id.md,
+// docs/analysis/responses-multi-turn-reasoning.md, and
+// docs/analysis/gemini-thought-signature.md.
+func sanitizeUpstreamJSONBody(bodyBytes []byte, sitePlatform, upstreamPath, upstreamModel string) ([]byte, error) {
 	if len(bodyBytes) == 0 {
 		return bodyBytes, nil
 	}
-	// Cheap gate: only rewrite when continuity, compact, or multi-turn reasoning
-	// input is involved. Avoid full JSON parse on hot path otherwise.
+	// Cheap gate: only rewrite when continuity, compact, multi-turn reasoning
+	// input, or Gemini tool-history signature inject is involved. Avoid full
+	// JSON parse on hot path otherwise.
 	pathLower := strings.ToLower(upstreamPath)
 	needsCompact := strings.Contains(pathLower, "/responses/compact")
 	isResponsesPath := needsCompact || strings.Contains(pathLower, "/responses")
@@ -1221,38 +1227,174 @@ func sanitizeUpstreamJSONBody(bodyBytes []byte, sitePlatform, upstreamPath strin
 		bytes.Contains(bodyBytes, []byte(`"type": "reasoning"`)) ||
 		bytes.Contains(bodyBytes, []byte(`"encrypted_content"`)) ||
 		(isResponsesPath && bytes.Contains(bodyBytes, []byte(`"input"`)))
-	if !needsCompact && !needsContinuity && !needsReasoningInput {
+	needsGeminiThought := needsGeminiThoughtSignatureSanitize(sitePlatform, upstreamPath, bodyBytes)
+	if !needsCompact && !needsContinuity && !needsReasoningInput && !needsGeminiThought {
 		return bodyBytes, nil
 	}
 	var body map[string]any
 	if err := json.Unmarshal(bodyBytes, &body); err != nil {
 		return bodyBytes, nil
 	}
-	protocol := responses.ProtocolUnknown
-	switch ep, ok := proxy.EndpointFromPath(upstreamPath); {
-	case ok && ep == proxy.EndpointChat:
-		protocol = responses.ProtocolChat
-	case ok && ep == proxy.EndpointMessages:
-		protocol = responses.ProtocolMessages
-	case ok && ep == proxy.EndpointResponses:
-		protocol = responses.ProtocolResponses
-	case needsCompact || strings.Contains(pathLower, "/responses"):
-		protocol = responses.ProtocolResponses
+	next := body
+	if needsCompact || needsContinuity || needsReasoningInput {
+		protocol := responses.ProtocolUnknown
+		switch ep, ok := proxy.EndpointFromPath(upstreamPath); {
+		case ok && ep == proxy.EndpointChat:
+			protocol = responses.ProtocolChat
+		case ok && ep == proxy.EndpointMessages:
+			protocol = responses.ProtocolMessages
+		case ok && ep == proxy.EndpointResponses:
+			protocol = responses.ProtocolResponses
+		case needsCompact || strings.Contains(pathLower, "/responses"):
+			protocol = responses.ProtocolResponses
+		}
+		sanitized, _, err := responses.SanitizeResponsesRequestBody(next, responses.ContinuityPolicyInput{
+			SitePlatform:     sitePlatform,
+			Protocol:         protocol,
+			UpstreamPath:     upstreamPath,
+			IsCompactRequest: needsCompact,
+		})
+		if err != nil {
+			return nil, err
+		}
+		next = sanitized
 	}
-	next, _, err := responses.SanitizeResponsesRequestBody(body, responses.ContinuityPolicyInput{
-		SitePlatform:     sitePlatform,
-		Protocol:         protocol,
-		UpstreamPath:     upstreamPath,
-		IsCompactRequest: needsCompact,
-	})
-	if err != nil {
-		return nil, err
+	if needsGeminiThought {
+		next = applyGeminiThoughtSignatureSanitize(next, upstreamPath, upstreamModel)
 	}
 	out, marshalErr := json.Marshal(next)
 	if marshalErr != nil {
 		return bodyBytes, nil
 	}
 	return out, nil
+}
+
+// needsGeminiThoughtSignatureSanitize is a cheap byte/path gate for official
+// Gemini native generateContent / gemini-cli tool-history inject. Avoids parse
+// when the body clearly has no functionCall / tool_calls tool history.
+func needsGeminiThoughtSignatureSanitize(sitePlatform, upstreamPath string, bodyBytes []byte) bool {
+	if !isGeminiThoughtSignaturePlatform(sitePlatform) {
+		return false
+	}
+	if !isGeminiNativeGenerateContentPath(upstreamPath) {
+		return false
+	}
+	// Tool-history markers only (functionCall native or OpenAI tool_calls).
+	return bytes.Contains(bodyBytes, []byte(`"functionCall"`)) ||
+		bytes.Contains(bodyBytes, []byte(`"function_call"`)) ||
+		bytes.Contains(bodyBytes, []byte(`"tool_calls"`))
+}
+
+func isGeminiThoughtSignaturePlatform(sitePlatform string) bool {
+	switch strings.ToLower(strings.TrimSpace(sitePlatform)) {
+	case "gemini", "gemini-cli", "google":
+		return true
+	default:
+		return false
+	}
+}
+
+// isGeminiNativeGenerateContentPath reports paths that carry Gemini contents
+// (official generateContent / streamGenerateContent / gemini-cli v1internal).
+// OpenAI-compat chat/completions paths are intentionally excluded — they keep
+// OpenAI shape and do not accept native thoughtSignature inject.
+func isGeminiNativeGenerateContentPath(upstreamPath string) bool {
+	pathLower := strings.ToLower(strings.TrimSpace(upstreamPath))
+	if pathLower == "" {
+		return false
+	}
+	if strings.Contains(pathLower, "generatecontent") ||
+		strings.Contains(pathLower, "streamgeneratecontent") {
+		return true
+	}
+	// Gemini CLI internal: /v1internal::generateContent (double-colon in routes)
+	// and /v1internal:generateContent (single-colon detect form).
+	if strings.Contains(pathLower, "/v1internal") {
+		return true
+	}
+	return false
+}
+
+// applyGeminiThoughtSignatureSanitize rewrites a Gemini-shaped (or CLI-wrapped)
+// request so tool-history functionCall parts carry thoughtSignature.
+// Prefer real signatures already present; inject dummy for Gemini 3.x /
+// thinking-enabled models via generate_content.NormalizeRequest.
+// When the client posts OpenAI messages onto a native generateContent path,
+// rebuild via BuildGeminiGenerateContentRequestFromOpenAi.
+// Residual: process-local aggregate ThoughtSignatures are not re-attached here
+// (no multi-instance session store); clients must echo provider_specific_fields
+// or send native contents that NormalizeRequest can patch.
+func applyGeminiThoughtSignatureSanitize(body map[string]any, upstreamPath, upstreamModel string) map[string]any {
+	if body == nil {
+		return body
+	}
+	// gemini-cli envelope: { "model", "request": { contents... } }
+	if req, ok := body["request"].(map[string]any); ok && req != nil {
+		modelName := resolveGeminiSanitizeModel(body, req, upstreamPath, upstreamModel)
+		inner := applyGeminiThoughtSignatureSanitizeBody(req, modelName)
+		if inner != nil {
+			// Clone top-level map so we do not mutate the unmarshaled input in place
+			// when callers share maps (tests / retries).
+			out := cloneJSONMapShallow(body)
+			out["request"] = inner
+			if sharedModel := strings.TrimSpace(asJSONString(out["model"])); sharedModel == "" && modelName != "" {
+				out["model"] = modelName
+			}
+			return out
+		}
+		return body
+	}
+	modelName := resolveGeminiSanitizeModel(body, nil, upstreamPath, upstreamModel)
+	return applyGeminiThoughtSignatureSanitizeBody(body, modelName)
+}
+
+func applyGeminiThoughtSignatureSanitizeBody(body map[string]any, modelName string) map[string]any {
+	if body == nil {
+		return body
+	}
+	// Native Gemini: contents present → NormalizeRequest (inject/preserve).
+	if _, hasContents := body["contents"]; hasContents {
+		return generate_content.NormalizeRequest(body, modelName)
+	}
+	// OpenAI chat body posted on a native generateContent path (rare bridge).
+	if _, hasMessages := body["messages"]; hasMessages {
+		return generate_content.BuildGeminiGenerateContentRequestFromOpenAi(body, modelName)
+	}
+	return body
+}
+
+func resolveGeminiSanitizeModel(body, nested map[string]any, upstreamPath, upstreamModel string) string {
+	if m := strings.TrimSpace(upstreamModel); m != "" {
+		return m
+	}
+	if nested != nil {
+		if m := asJSONString(nested["model"]); m != "" {
+			return m
+		}
+	}
+	if body != nil {
+		if m := asJSONString(body["model"]); m != "" {
+			return m
+		}
+	}
+	_, model, _ := ParseGeminiPath(upstreamPath)
+	return strings.TrimSpace(model)
+}
+
+func asJSONString(v any) string {
+	s, _ := v.(string)
+	return strings.TrimSpace(s)
+}
+
+func cloneJSONMapShallow(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 // swapModelInJSON performs a shallow JSON re-encode to replace the "model" field.

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -1051,7 +1051,7 @@ func TestSanitizeUpstreamJSONBody_MultiTurnReasoningInjectsContent(t *testing.T)
     {"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": "{}"}
   ]
 }`)
-	out, err := sanitizeUpstreamJSONBody(body, "codex", "/v1/responses")
+	out, err := sanitizeUpstreamJSONBody(body, "codex", "/v1/responses", "")
 	if err != nil {
 		t.Fatalf("sanitize: %v", err)
 	}
@@ -1087,7 +1087,7 @@ func TestSanitizeUpstreamJSONBody_PrettyPrintedReasoningTypeSpace(t *testing.T) 
     }
   ]
 }`)
-	out, err := sanitizeUpstreamJSONBody(body, "openai", "/v1/responses")
+	out, err := sanitizeUpstreamJSONBody(body, "openai", "/v1/responses", "")
 	if err != nil {
 		t.Fatalf("sanitize: %v", err)
 	}
@@ -1107,7 +1107,7 @@ func TestSanitizeUpstreamJSONBody_PrettyPrintedReasoningTypeSpace(t *testing.T) 
 
 func TestSanitizeUpstreamJSONBody_ReasoningMissingFieldsHonest400(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.4","input":[{"type":"reasoning","summary":[]}]}`)
-	out, err := sanitizeUpstreamJSONBody(body, "openai", "/v1/responses")
+	out, err := sanitizeUpstreamJSONBody(body, "openai", "/v1/responses", "")
 	if err == nil {
 		t.Fatalf("expected ReasoningInputError, got body=%s", out)
 	}
@@ -1130,7 +1130,7 @@ func TestSanitizeUpstreamJSONBody_ReasoningMissingFieldsHonest400(t *testing.T) 
 func TestSanitizeUpstreamJSONBody_NonResponsesPathSkipsUnlessMarkers(t *testing.T) {
 	// Chat path without markers: no parse, body unchanged.
 	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hi"}]}`)
-	out, err := sanitizeUpstreamJSONBody(body, "openai", "/v1/chat/completions")
+	out, err := sanitizeUpstreamJSONBody(body, "openai", "/v1/chat/completions", "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1147,7 +1147,7 @@ func TestSanitizeUpstreamJSONBody_CompactPreservesReasoningInput(t *testing.T) {
   "previous_response_id":"resp_1",
   "input":[{"type":"reasoning","encrypted_content":"enc","summary":[{"type":"summary_text","text":"s"}]}]
 }`)
-	out, err := sanitizeUpstreamJSONBody(body, "codex", "/v1/responses/compact")
+	out, err := sanitizeUpstreamJSONBody(body, "codex", "/v1/responses/compact", "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Wire request-side Gemini `thoughtSignature` inject/preserve in `sanitizeUpstreamJSONBody` for `gemini` / `gemini-cli` / `google` on native `generateContent` / `streamGenerateContent` and gemini-cli `/v1internal` paths when tool-history markers (`functionCall` / `tool_calls`) are present.
- Native `contents` → `generate_content.NormalizeRequest`; CLI `{request:{...}}` envelope → normalize inner; OpenAI `messages` on native path → `BuildGeminiGenerateContentRequestFromOpenAi`.
- Prefer real signatures; inject dummy for Gemini 3 / thinking-enabled models when missing (transform helpers already landed in #86 / `5dcaf76`).
- Docs: matrix #580/#581 → **present**; residual honesty (no multi-instance aggregate store; OpenAI-compat chat path not rewritten).

## Issue
Closes #309

## Residual
- No multi-instance/Redis aggregate re-attach of process-local `ThoughtSignatures`.
- Clients must echo `provider_specific_fields.thought_signature` or native signed contents (dummy inject for Gemini 3 when missing).
- OpenAI-compat `/v1/chat/completions` on Gemini is passthrough (no native inject).

## Verify
```bash
go test ./transform/gemini/... -count=1
go test ./handler/proxy -count=1 -run 'Thought|Sanitize|Gemini'
go test ./handler/proxy -count=1
```

Local results:
```
ok  github.com/tokendancelab/metapi-go/transform/gemini/generate_content  0.021s
ok  github.com/tokendancelab/metapi-go/handler/proxy                      1.369s
```