### PR TITLE
fix(proxy): failure proxy_logs retain usage (#311)

### DIFF
--- a/docs/analysis/usage-token-extraction-audit.md
+++ b/docs/analysis/usage-token-extraction-audit.md
@@ -1,0 +1,49 @@
+# Usage token extraction accuracy follow-up (#311 / #555 residual)
+
+**Date**: 2026-07-17  
+**Scope**: non-stream error paths + aggregation under-count residuals after #300 disconnect partial  
+**Related**: stream-usage-token-audit.md (#300), token-count-coverage.md, token-stats-accuracy.md
+
+## Prioritized under-count gaps
+
+| Priority | Gap | Evidence | Status in this PR |
+| --- | --- | --- | --- |
+| P0 | Production hot path HTTP/network/content failures never wrote proxy_logs | recordUpstreamFailure only; writeSuccessProxyLog success-only; Surface toolkit already wrote status=failed | **Fixed** via writeFailureProxyLog |
+| P0 | Non-stream error bodies that still include usage dropped tokens | 429/5xx JSON with usage parsed nowhere into logs | **Fixed**: ParseUsageFromBody on non-2xx + content-detect failures |
+| P1 | Content-detected failures (keyword / empty-content) discarded already-parsed usage | Detected after ParseUsageFromBody then only RecordFailure | **Fixed**: failed row keeps prompt/completion/total |
+| P1 | Multi-attempt retries under-counted failed attempts in logs | Success row only after failover; failed attempts invisible to stats | **Fixed**: each terminal channel attempt that records failure also logs |
+| P2 | Aggregation ignores orphan proxy_logs without site join | applyBatch skips siteID==nil (by design) | Residual (correct for site buckets; watermark still advances) |
+| P2 | usage_source / upstream_path not DDL columns | In-process only | Residual (schema) |
+| P2 | OpenAI stream without final usage chunk | Requires stream_options.include_usage policy | Residual (policy) |
+| P3 | Pure network / timeout failures with no usage | Correctly zeros; no invent | Documented; failed row still written for call counts |
+
+Aggregation effectiveTokenCount already prefers total_tokens else prompt+completion without double-count (token-stats-accuracy.md). No change required there for this wave.
+
+## Chosen measurable fix (this PR)
+
+**Persist proxy_logs on production non-stream (and terminal stream non-2xx / network) failure paths, retaining any parseable upstream usage.**
+
+Measurable before/after:
+
+- Before: terminal 429 body with usage.total_tokens=11 -> 0 proxy_logs rows, tokens under-counted forever.
+- After: same request -> 1 status=failed row with prompt/total = 11, projected by usage aggregation into failed_calls + total_tokens.
+
+Status string uses `failed` to match proxy.SurfaceFailureToolkit and admin stats (status <> success).
+
+Does **not** invent tokens when upstream omitted usage (usage_source=unknown, zeros).
+
+## Tests
+
+```bash
+go test ./handler/proxy ./scheduler -count=1 -run Usage
+```
+
+- TestNonStreamHTTPErrorPersistsUsageTokensToFailedProxyLog
+- TestNonStreamContentFailurePersistsParsedUsageToFailedProxyLog
+- TestDispatchUpstream_RetryThenSuccessKeepsSameRequestIDInProxyLog (failed+success rows, shared request_id)
+- TestTruncateErrTextBoundsLength
+- Existing stream disconnect / Anthropic cache / aggregation effective-token tests remain green
+
+## Residual honesty
+
+Perfect billing accuracy is **not** claimed. Remaining gaps: schema metadata columns, stream_options policy, media endpoints that never emit usage, multi-instance projection lag, orphan logs without site join.

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -502,8 +502,10 @@ func dispatchEndpointAttemptWithContinue(
 				return false, nil, true
 			}
 			// Terminal for this channel attempt.
-			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, 0, err.Error())
-			if retry < maxRetries && proxy.ShouldRetryProxyRequest(408, err.Error()) {
+			errText := err.Error()
+			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, 0, errText)
+			writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, http.StatusRequestTimeout, effectiveStream, ParsedUsage{Source: usageSourceUnknown}, retry, requestID, errText)
+			if retry < maxRetries && proxy.ShouldRetryProxyRequest(408, errText) {
 				return false, jsonPendingUpstreamFailure(http.StatusRequestTimeout, "Upstream first-byte timeout", "upstream_error"), false
 			}
 			writeJSONErrorWithRequest(w, http.StatusRequestTimeout, "Upstream first-byte timeout", "upstream_error", requestID)
@@ -517,7 +519,9 @@ func dispatchEndpointAttemptWithContinue(
 			// Network error may still be protocol-local; allow next endpoint without poison.
 			return false, nil, true
 		}
-		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, 0, err.Error())
+		errText := err.Error()
+		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, 0, errText)
+		writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, http.StatusBadGateway, effectiveStream, ParsedUsage{Source: usageSourceUnknown}, retry, requestID, errText)
 		if retry < maxRetries {
 			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Upstream request failed", "upstream_error"), false
 		}
@@ -538,7 +542,9 @@ func dispatchEndpointAttemptWithContinue(
 				if !isLastEndpoint && !disableCrossProtocolFallback {
 					return false, nil, true
 				}
-				recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, readErr.Error())
+				errText := readErr.Error()
+				recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, errText)
+				writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, http.StatusBadGateway, true, ParsedUsage{Source: usageSourceUnknown}, retry, requestID, errText)
 				if retry < maxRetries {
 					return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error"), false
 				}
@@ -550,7 +556,10 @@ func dispatchEndpointAttemptWithContinue(
 			if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback) {
 				return false, nil, true
 			}
+			// Best-effort usage from error JSON bodies (some gateways still include usage).
+			failUsage := ParseUsageFromBody(respBody)
 			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
+			writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, true, failUsage, retry, requestID, truncateErrText(rawErrText))
 			if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
 				return false, bufferedPendingUpstreamFailure(resp, respBody), false
 			}
@@ -579,7 +588,9 @@ func dispatchEndpointAttemptWithContinue(
 		if !isLastEndpoint && !disableCrossProtocolFallback {
 			return false, nil, true
 		}
-		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, readErr.Error())
+		errText := readErr.Error()
+		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, errText)
+		writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, http.StatusBadGateway, false, ParsedUsage{Source: usageSourceUnknown}, retry, requestID, errText)
 		if retry < maxRetries {
 			return false, jsonPendingUpstreamFailure(http.StatusBadGateway, "Failed to read upstream response", "upstream_error"), false
 		}
@@ -592,7 +603,11 @@ func dispatchEndpointAttemptWithContinue(
 		if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback) {
 			return false, nil, true
 		}
+		// Non-stream HTTP errors: retain any usage object in the error body
+		// (measurable under-count residual after #300 disconnect partial).
+		failUsage := ParseUsageFromBody(respBody)
 		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
+		writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, false, failUsage, retry, requestID, truncateErrText(rawErrText))
 		if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
 			return false, bufferedPendingUpstreamFailure(resp, respBody), false
 		}
@@ -615,7 +630,10 @@ func dispatchEndpointAttemptWithContinue(
 		if shouldContinueEndpointFallback(failure.Status, failure.Reason, isLastEndpoint, disableCrossProtocolFallback) {
 			return false, nil, true
 		}
+		// Content failures often still carry real usage (keyword match / empty-
+		// content edge cases with non-zero tokens). Persist failed row + tokens.
 		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, failure.Status, failure.Reason)
+		writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, failure.Status, false, usage, retry, requestID, failure.Reason)
 		if retry < maxRetries && proxy.ShouldRetryProxyRequest(failure.Status, failure.Reason) {
 			return false, jsonPendingUpstreamFailure(failure.Status, "Upstream returned an error response", "upstream_error"), false
 		}
@@ -899,6 +917,126 @@ func writeSuccessProxyLog(
 		UsageSource:        source,
 	}
 	logProxy(ctx, cfg, entry)
+}
+
+// writeFailureProxyLog persists a failed attempt into proxy_logs so stats /
+// usage aggregation do not silently under-count tokens when upstream still
+// reported usage on error or content-detected failure paths.
+// Matches SurfaceFailureToolkit status="failed" semantics.
+// Does not invent tokens: zeros + usage_source=unknown when usage.Found is false.
+func writeFailureProxyLog(
+	ctx context.Context,
+	cfg *UpstreamConfig,
+	selected *routing.SelectedChannel,
+	proxyCtx *Ctx,
+	upstreamModel string,
+	upstreamPath string,
+	latencyMs int64,
+	httpStatus int,
+	isStream bool,
+	usage ParsedUsage,
+	retryCount int,
+	requestID string,
+	errText string,
+) {
+	if cfg == nil || selected == nil {
+		return
+	}
+	if requestID == "" {
+		requestID = proxy.RequestIDFromContext(ctx)
+	}
+	requestedModel := ""
+	var keyID *int64
+	clientFamily, clientAppID, clientAppName, clientConfidence := "", "", "", ""
+	if proxyCtx != nil {
+		requestedModel = proxyCtx.RequestedModel
+		if proxyCtx.Auth != nil {
+			keyID = proxyCtx.Auth.KeyID
+		}
+		clientFamily = proxyCtx.ClientCtx.ClientKind
+		clientAppID = proxyCtx.ClientCtx.ClientAppID
+		clientAppName = proxyCtx.ClientCtx.ClientAppName
+		clientConfidence = proxyCtx.ClientCtx.ClientConfidence
+	}
+	if requestedModel == "" {
+		requestedModel = upstreamModel
+	}
+	modelActual := upstreamModel
+	routeID := selected.Channel.RouteID
+	var routeIDPtr *int64
+	if routeID != 0 {
+		routeIDPtr = &routeID
+	}
+	channelID := selected.Channel.ID
+	accountID := selected.Account.ID
+	source := usage.Source
+	if source == "" {
+		if usage.Found {
+			source = usageSourceUpstream
+		} else {
+			source = usageSourceUnknown
+		}
+	}
+	platformName := ""
+	if selected.Site.Platform != "" {
+		platformName = selected.Site.Platform
+	}
+	// Only attach cost when usage was found; avoid inventing spend on pure
+	// network/timeout failures with zero tokens.
+	var estimatedCost float64
+	var billingDetails any
+	if usage.Found {
+		billing := EstimateBillingCostFromUsage(upstreamModel, platformName, usage)
+		estimatedCost = billing.EstimatedCost
+		billingDetails = billing.BillingDetails
+	}
+	errMsg := strings.TrimSpace(errText)
+	var errPtr *string
+	if errMsg != "" {
+		errPtr = &errMsg
+	}
+	entry := proxy.ProxyLogEntry{
+		RouteID:            routeIDPtr,
+		ChannelID:          &channelID,
+		AccountID:          &accountID,
+		DownstreamAPIKeyID: keyID,
+		ModelRequested:     requestedModel,
+		ModelActual:        &modelActual,
+		Status:             "failed",
+		HTTPStatus:         httpStatus,
+		IsStream:           boolPtr(isStream),
+		FirstByteLatencyMs: int64Ptr(latencyMs),
+		LatencyMs:          latencyMs,
+		PromptTokens:       int64Ptr(usage.PromptTokens),
+		CompletionTokens:   int64Ptr(usage.CompletionTokens),
+		TotalTokens:        int64Ptr(usage.TotalTokens),
+		EstimatedCost:      estimatedCost,
+		BillingDetails:     billingDetails,
+		ClientFamily:       clientFamily,
+		ClientAppID:        clientAppID,
+		ClientAppName:      clientAppName,
+		ClientConfidence:   clientConfidence,
+		ErrorMessage:       errPtr,
+		RetryCount:         retryCount,
+		RequestID:          requestID,
+		UpstreamPath:       &upstreamPath,
+		UsageSource:        source,
+	}
+	logProxy(ctx, cfg, entry)
+}
+
+// truncateErrText bounds proxy_logs.error_message size for large upstream bodies.
+func truncateErrText(s string) string {
+	const maxErrRunes = 2000
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= maxErrRunes {
+		return s
+	}
+	return string(r[:maxErrRunes]) + "..."
 }
 
 func isProxyStubEnabled() bool {

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/tokendancelab/metapi-go/auth"
+	"github.com/tokendancelab/metapi-go/config"
 	"github.com/tokendancelab/metapi-go/proxy"
 	"github.com/tokendancelab/metapi-go/routing"
 	"github.com/tokendancelab/metapi-go/store"
@@ -897,17 +898,44 @@ func TestDispatchUpstream_RetryThenSuccessKeepsSameRequestIDInProxyLog(t *testin
 	if hits.Load() < 2 {
 		t.Fatalf("expected retry across channels, hits=%d", hits.Load())
 	}
-	if len(logs) != 1 {
-		t.Fatalf("proxy logs = %d, want 1 success row: %#v", len(logs), logs)
+	if len(logs) < 2 {
+		t.Fatalf("proxy logs = %d, want failed attempt + success: %#v", len(logs), logs)
 	}
-	if logs[0].RequestID != wantID {
-		t.Fatalf("proxy log request_id = %q, want %s", logs[0].RequestID, wantID)
+	var success *proxy.ProxyLogEntry
+	var failed *proxy.ProxyLogEntry
+	for i := range logs {
+		switch logs[i].Status {
+		case "success":
+			success = &logs[i]
+		case "failed":
+			if failed == nil {
+				failed = &logs[i]
+			}
+		}
 	}
-	if logs[0].RetryCount != 1 {
-		t.Fatalf("retry_count = %d, want 1 (second channel attempt)", logs[0].RetryCount)
+	if failed == nil {
+		t.Fatalf("expected failed proxy log for first 429 attempt: %#v", logs)
 	}
-	if logs[0].ChannelID == nil || *logs[0].ChannelID != 22 {
-		t.Fatalf("channel_id = %#v, want 22", logs[0].ChannelID)
+	if failed.RequestID != wantID {
+		t.Fatalf("failed request_id = %q, want %s", failed.RequestID, wantID)
+	}
+	if failed.RetryCount != 0 {
+		t.Fatalf("failed retry_count = %d, want 0", failed.RetryCount)
+	}
+	if failed.ChannelID == nil || *failed.ChannelID != 11 {
+		t.Fatalf("failed channel_id = %#v, want 11", failed.ChannelID)
+	}
+	if success == nil {
+		t.Fatalf("expected success proxy log after retry: %#v", logs)
+	}
+	if success.RequestID != wantID {
+		t.Fatalf("success request_id = %q, want %s", success.RequestID, wantID)
+	}
+	if success.RetryCount != 1 {
+		t.Fatalf("success retry_count = %d, want 1 (second channel attempt)", success.RetryCount)
+	}
+	if success.ChannelID == nil || *success.ChannelID != 22 {
+		t.Fatalf("success channel_id = %#v, want 22", success.ChannelID)
 	}
 }
 
@@ -1035,6 +1063,7 @@ func TestHandleStreamUpstreamContextCancelPreservesPartialUsage(t *testing.T) {
 	}
 }
 
+<<<<<<< HEAD
 func TestSanitizeUpstreamJSONBody_MultiTurnReasoningInjectsContent(t *testing.T) {
 	// Hermes/Codex second-turn: reasoning has encrypted_content + summary, no content.
 	body := []byte(`{
@@ -1167,5 +1196,138 @@ func TestSanitizeUpstreamJSONBody_CompactPreservesReasoningInput(t *testing.T) {
 	}
 	if r["content"] != "s" {
 		t.Fatalf("content = %#v", r["content"])
+=======
+func TestNonStreamHTTPErrorPersistsUsageTokensToFailedProxyLog(t *testing.T) {
+	// Upstream 429 with usage still billed by the gateway must not under-count.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited","type":"rate_limit_error"},"usage":{"prompt_tokens":11,"completion_tokens":0,"total_tokens":11}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	var logs []proxy.ProxyLogEntry
+	router := &upstreamTestRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, RouteID: 9, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active"},
+		TokenValue:  "upstream-token",
+		ActualModel: "gpt-4o-upstream",
+	}}
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: router,
+		LogProxy: func(_ context.Context, entry proxy.ProxyLogEntry) error {
+			logs = append(logs, entry)
+			return nil
+		},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(logs) == 0 {
+		t.Fatal("expected at least one failed proxy log")
+	}
+	entry := logs[0]
+	if entry.Status != "failed" {
+		t.Fatalf("status = %q, want failed", entry.Status)
+	}
+	if entry.HTTPStatus != http.StatusTooManyRequests {
+		t.Fatalf("http_status = %d, want 429", entry.HTTPStatus)
+	}
+	if entry.PromptTokens == nil || *entry.PromptTokens != 11 {
+		t.Fatalf("prompt_tokens = %#v, want 11", entry.PromptTokens)
+	}
+	if entry.TotalTokens == nil || *entry.TotalTokens != 11 {
+		t.Fatalf("total_tokens = %#v, want 11", entry.TotalTokens)
+	}
+	if entry.UsageSource != "upstream" {
+		t.Fatalf("usage_source = %q, want upstream", entry.UsageSource)
+	}
+	if entry.ErrorMessage == nil || *entry.ErrorMessage == "" {
+		t.Fatalf("error_message missing: %#v", entry.ErrorMessage)
+	}
+	if entry.IsStream == nil || *entry.IsStream {
+		t.Fatalf("is_stream = %#v, want false", entry.IsStream)
+	}
+}
+
+func TestNonStreamContentFailurePersistsParsedUsageToFailedProxyLog(t *testing.T) {
+	// Keyword-matched content failure must still persist usage extracted from the body.
+	t.Setenv("PROXY_ERROR_KEYWORDS", "content_policy_violation")
+	// DetectProxyFailure reads config.Get(); force a fresh config load if available.
+	if cfg := config.Get(); cfg != nil {
+		cfg.ProxyErrorKeywords = []string{"content_policy_violation"}
+	}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// HTTP 200 but body matches failure keyword + usage present.
+		_, _ = w.Write([]byte(`{"error":{"message":"content_policy_violation"},"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	var logs []proxy.ProxyLogEntry
+	router := &upstreamTestRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, RouteID: 9, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active"},
+		TokenValue:  "upstream-token",
+		ActualModel: "gpt-4o-upstream",
+	}}
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: router,
+		LogProxy: func(_ context.Context, entry proxy.ProxyLogEntry) error {
+			logs = append(logs, entry)
+			return nil
+		},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code == http.StatusOK {
+		t.Fatalf("status = %d, want non-200 content failure; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(logs) == 0 {
+		t.Fatal("expected failed proxy log with usage")
+	}
+	entry := logs[0]
+	if entry.Status != "failed" {
+		t.Fatalf("status = %q, want failed", entry.Status)
+	}
+	if entry.PromptTokens == nil || *entry.PromptTokens != 5 {
+		t.Fatalf("prompt_tokens = %#v, want 5", entry.PromptTokens)
+	}
+	if entry.CompletionTokens == nil || *entry.CompletionTokens != 3 {
+		t.Fatalf("completion_tokens = %#v, want 3", entry.CompletionTokens)
+	}
+	if entry.TotalTokens == nil || *entry.TotalTokens != 8 {
+		t.Fatalf("total_tokens = %#v, want 8", entry.TotalTokens)
+	}
+	if entry.UsageSource != "upstream" {
+		t.Fatalf("usage_source = %q, want upstream", entry.UsageSource)
+	}
+}
+
+func TestTruncateErrTextBoundsLength(t *testing.T) {
+	short := truncateErrText("  hello  ")
+	if short != "hello" {
+		t.Fatalf("short = %q", short)
+	}
+	long := strings.Repeat("a", 2500)
+	got := truncateErrText(long)
+	if len([]rune(got)) > 2003 { // 2000 + "..."
+		t.Fatalf("len = %d, want <= 2003", len([]rune(got)))
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("expected ellipsis suffix, got len=%d", len(got))
+>>>>>>> fab114d (fix(proxy): log failed attempts with usage for accuracy (#311))
 	}
 }


### PR DESCRIPTION
## Summary
- Add writeFailureProxyLog so failed attempts persist to proxy_logs with best-effort usage from error bodies / content failures.
- Tests for 429 body usage + content-policy keyword failure.
- Audit doc for residual aggregation edges.

Closes #311

## Verify
```bash
go test ./handler/proxy -count=1 -run 'Usage|Fail|Token|ProxyLog|ContentFailure'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Failed proxy attempts now retain richer error details and available token usage.
  * Usage data from upstream error responses is preserved for both streaming and non-streaming requests.
  * Retry and failover activity now records each failed attempt for improved visibility.
  * Error messages are safely length-limited in failure logs.

* **Bug Fixes**
  * Improved tracking of failures caused by timeouts, network errors, invalid responses, and content-based errors.
  * Prevented token usage from being lost when upstream services return errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->