### PR TITLE
docs(release): v0.8.16 protocol + usage residual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.16] — 2026-07-17
+
+### Fixed
+- Wire Gemini official tool-history `thought_signature` inject/preserve on generateContent / gemini-cli paths (#309 / #314)
+- Harden multi-turn Responses reasoning content sanitize (pretty-printed type keys + input gate) (#310 / #313)
+- Persist failed upstream attempts to proxy_logs with best-effort usage from error bodies (#311 / #315)
+
+### Docs / Honesty
+- Gap matrix #580/#581/#538 → present (with residual notes)
+- usage-token-extraction-audit follow-up (#311)
+- Hot-fix conflict markers in upstream_test after squash (#316)
+
 ## [v0.8.15] — 2026-07-17
 
 ### Fixed

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -3,7 +3,7 @@
 **Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery  
 **Mode**: GitHub Issues + Milestones (SDD)  
 **Repo**: https://github.com/TokenDanceLab/metapi-go  
-**Latest release**: **[v0.8.15](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.15)** (2026-07-17)
+**Latest release**: **[v0.8.16](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.16)** (2026-07-17)
 
 > 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。  
 > 文档地图：[`docs/README.md`](../README.md)
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | [v0.8.16](https://github.com/TokenDanceLab/metapi-go/milestone/25) |
+| Active milestone | next residual wave after v0.8.16 (open when needed) |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -29,22 +29,20 @@
 | M-BACKEND / UI / SCHEMA / RELIABILITY | ✅ | Design SSOT in `docs/design/` |
 | M-FEATURE + competitive learn | ✅ | Gap #38–#56 · learn #110–#121 |
 | Enterprise residual **v0.8.15** | ✅ | #298–#300 · tag v0.8.15 |
-| Enterprise residual **v0.8.16** | 🔄 | #309 Gemini signature · #310 Responses multi-turn · #311 usage follow-up |
+| Enterprise residual **v0.8.16** | ✅ | #309–#311 (PRs #313/#314/#315); tag **v0.8.16** |
 
-## Active work (v0.8.16)
+## Active work
 
-| Issue | Title | Lane |
-|------:|:------|:-----|
-| [#309](https://github.com/TokenDanceLab/metapi-go/issues/309) | Gemini tool-history `thought_signature` | protocol |
-| [#310](https://github.com/TokenDanceLab/metapi-go/issues/310) | Multi-turn Responses content honesty | protocol |
-| [#311](https://github.com/TokenDanceLab/metapi-go/issues/311) | Usage aggregation / non-stream accuracy | observability |
+v0.8.16 product Issues **closed**. Next wave: residual-next-candidates partials (#585 load-proof residual, #555 aggregation deeper, multi-key #579) — open Issues only when starting work.
 
-**Closed as duplicate**: #308 → #309. **Superseded PR**: #306 → already merged via #302.
+**Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
+
 
 ## Residual releases (pointer only)
 
 | Tag | Milestone | Highlights |
 |:----|:----------|:-----------|
+| [v0.8.16](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.16) | 25 | Gemini thought_signature wire · Responses multi-turn · failure usage logs |
 | [v0.8.15](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.15) | 24 | Expired-mark guard · cascade isolation · stream usage partial |
 | [v0.8.14](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.14) | 23 | Residual inventory · Redis sticky design · admin test honesty |
 | [v0.8.13](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.13) | 22 | Gap matrix refresh · sticky eval · route reorder |
@@ -74,10 +72,11 @@ git log --oneline origin/master -10
 
 ## Next Steps
 
-1. Land **v0.8.16** product PRs for #309 / #310 / #311 (parallel WFs).
-2. Keep residuals honest: no fake WS / no Redis sticky product without dedicated ACs.
-3. Prefer board hygiene: one Issue per topic; close duplicates immediately.
-4. MASTER stays slim — release notes go to `CHANGELOG.md` + GitHub Release only.
+1. Tag **v0.8.16** (this release) — Milestone 25 closed.
+2. Next residual wave only with clear ACs: #585 load residual, #555 aggregation, optional #579 multi-key.
+3. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
+4. Keep MASTER slim; docs map at `docs/README.md`.
+
 
 ## Governance
 


### PR DESCRIPTION
## Summary
Release notes for **v0.8.16**:
- #309/#314 Gemini thought_signature
- #310/#313 multi-turn Responses content
- #311/#315 failure proxy_logs usage
- #316 conflict-marker hot-fix

Closes Milestone 25 via release gate.