### PR TITLE
feat(admin): token_routes.contextLength create/update/list (#320)

### DIFF
--- a/docs/analysis/models-response-shape.md
+++ b/docs/analysis/models-response-shape.md
@@ -42,7 +42,8 @@ Implications:
 
 Residual / future hardening:
 
-- Prefer `token_routes.context_length` (SC2 additive column) over built-in defaults when set; today `knownModelContextLength` still supplies family defaults/heuristics only.
+- Admin CRUD for route metadata: `POST/PUT /api/routes` accept camelCase `contextLength`; list/summary/lite echo it when set (`#320`). Stored on `token_routes.context_length` (SC2). **Metadata only** — no proxy max-token truncation/enforcement is wired from this field yet.
+- Prefer `token_routes.context_length` over built-in defaults when set in `/v1/models`; today `knownModelContextLength` still supplies family defaults/heuristics only (route-level not consumed by models listing yet).
 - Optionally merge per-site discovered context metadata from platform model refresh.
 - Route-ID-aware listing when policy has only `AllowedRouteIDs` (currently empty until joined).
 

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -94,7 +94,7 @@ type tokenRoutesHandler struct {
 // ---- List Lite ----
 // GET /api/routes/lite
 func (h *tokenRoutesHandler) listLite(w http.ResponseWriter, r *http.Request) {
-	rows := queryRows(h.db, "SELECT id, model_pattern, display_name, display_icon, route_mode, routing_strategy, enabled FROM token_routes ORDER BY sort_order ASC, id ASC")
+	rows := queryRows(h.db, "SELECT id, model_pattern, display_name, display_icon, route_mode, routing_strategy, enabled, context_length FROM token_routes ORDER BY sort_order ASC, id ASC")
 	type srcRow struct {
 		GroupRouteID  int64 `db:"group_route_id"`
 		SourceRouteID int64 `db:"source_route_id"`
@@ -136,6 +136,7 @@ func (h *tokenRoutesHandler) listSummary(w http.ResponseWriter, r *http.Request)
 			"sourceRouteIds":      []int64{},
 			"modelMapping":        route["modelMapping"],
 			"routingStrategy":     route["routingStrategy"],
+			"contextLength":       route["contextLength"],
 			"enabled":             route["enabled"],
 			"channelCount":        channelCount,
 			"enabledChannelCount": enabledCount,
@@ -227,8 +228,11 @@ func (h *tokenRoutesHandler) createRoute(w http.ResponseWriter, r *http.Request)
 		DisplayIcon     *string `json:"displayIcon"`
 		SourceRouteIds  []int64 `json:"sourceRouteIds"`
 		RoutingStrategy *string `json:"routingStrategy"`
-		ModelMapping    any     `json:"modelMapping"`
-		Enabled         *bool   `json:"enabled"`
+		// ContextLength is optional route metadata (tokens). NULL/omit/0 means unknown;
+		// not enforced at proxy runtime in this wave (admin surface + /v1/models residual).
+		ContextLength any   `json:"contextLength"`
+		ModelMapping  any   `json:"modelMapping"`
+		Enabled       *bool `json:"enabled"`
 	}
 	if err := decodeJSONRequest(r, &body); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"success": false, "message": "Invalid request body"})
@@ -279,11 +283,13 @@ func (h *tokenRoutesHandler) createRoute(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
+	contextLength := normalizeContextLengthOrNull(body.ContextLength)
+
 	id, err := execInsertID(h.db,
-		`INSERT INTO token_routes (model_pattern, display_name, display_icon, route_mode, model_mapping, routing_strategy, enabled, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO token_routes (model_pattern, display_name, display_icon, route_mode, model_mapping, routing_strategy, context_length, enabled, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		modelPattern, strOrNull(&displayName), strOrNull(body.DisplayIcon), routeMode,
-		modelMapping, routingStrategy, enabled, now, now,
+		modelMapping, routingStrategy, contextLength, enabled, now, now,
 	)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "创建路由失败"})
@@ -364,6 +370,11 @@ func (h *tokenRoutesHandler) updateRoute(w http.ResponseWriter, r *http.Request)
 	if v, ok := body["modelMapping"]; ok {
 		mappingJSON, _ := json.Marshal(v)
 		h.db.Exec(h.db.Rebind("UPDATE token_routes SET model_mapping = ?, updated_at = ? WHERE id = ?"), string(mappingJSON), now, id)
+	}
+	// contextLength: present key updates (including explicit null/0 clear → NULL).
+	// Metadata only — no proxy max-token enforcement is wired from this field yet.
+	if v, ok := body["contextLength"]; ok {
+		h.db.Exec(h.db.Rebind("UPDATE token_routes SET context_length = ?, updated_at = ? WHERE id = ?"), normalizeContextLengthOrNull(v), now, id)
 	}
 
 	// Update source route IDs for explicit_group
@@ -1166,6 +1177,55 @@ func uniquePositiveInt64(values []int64) []int64 {
 		out = append(out, v)
 	}
 	return out
+}
+
+// normalizeContextLengthOrNull parses admin camelCase contextLength.
+// Contract: null / omit (caller) / "" / 0 / negative → NULL (unknown, no enforcement).
+// Positive integers (or numeric strings) are stored as token window metadata only.
+func normalizeContextLengthOrNull(input any) any {
+	if input == nil {
+		return nil
+	}
+	switch v := input.(type) {
+	case float64:
+		if v <= 0 {
+			return nil
+		}
+		return int64(v)
+	case float32:
+		if v <= 0 {
+			return nil
+		}
+		return int64(v)
+	case int:
+		if v <= 0 {
+			return nil
+		}
+		return int64(v)
+	case int64:
+		if v <= 0 {
+			return nil
+		}
+		return v
+	case json.Number:
+		i, err := v.Int64()
+		if err != nil || i <= 0 {
+			return nil
+		}
+		return i
+	case string:
+		s := strings.TrimSpace(v)
+		if s == "" {
+			return nil
+		}
+		i, err := strconv.ParseInt(s, 10, 64)
+		if err != nil || i <= 0 {
+			return nil
+		}
+		return i
+	default:
+		return nil
+	}
 }
 
 func strOrNull(s *string) any {

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -362,6 +362,155 @@ func TestTokenRoutes_ManualChannelSurvivesRebuild(t *testing.T) {
 
 // TestTokenRoutes_PartialUpdatePreservesModelMapping covers intentional modelMapping
 // updates and ensures unrelated partial updates do not clear mapping or channels.
+func TestTokenRoutes_ContextLengthCreateUpdateListRoundTrip(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+
+	// Create with positive contextLength metadata.
+	create := doPostJSON(t, r, "/api/routes", map[string]any{
+		"modelPattern":  "ctx-meta-*",
+		"displayName":   "Context Meta Route",
+		"contextLength": 128000,
+		"enabled":       true,
+	})
+	if create.Code != http.StatusOK {
+		t.Fatalf("create status = %d, want 200 body=%s", create.Code, create.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(create.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	routeID := int64(created["id"].(float64))
+	if got := int64(created["contextLength"].(float64)); got != 128000 {
+		t.Fatalf("create contextLength = %v, want 128000", created["contextLength"])
+	}
+
+	// Full list (SELECT *) echoes camelCase contextLength.
+	list := doGet(t, r, "/api/routes")
+	if list.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s", list.Code, list.Body.String())
+	}
+	var listItems []map[string]any
+	if err := json.Unmarshal(list.Body.Bytes(), &listItems); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	found := false
+	for _, item := range listItems {
+		if int64(item["id"].(float64)) == routeID {
+			found = true
+			if got := int64(item["contextLength"].(float64)); got != 128000 {
+				t.Fatalf("list contextLength = %v, want 128000", item["contextLength"])
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("route %d missing from /api/routes list", routeID)
+	}
+
+	// Summary + lite surfaces must also expose contextLength.
+	summary := doGet(t, r, "/api/routes/summary")
+	if summary.Code != http.StatusOK {
+		t.Fatalf("summary status = %d body=%s", summary.Code, summary.Body.String())
+	}
+	var summaryItems []map[string]any
+	if err := json.Unmarshal(summary.Body.Bytes(), &summaryItems); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	found = false
+	for _, item := range summaryItems {
+		if int64(item["id"].(float64)) == routeID {
+			found = true
+			if got := int64(item["contextLength"].(float64)); got != 128000 {
+				t.Fatalf("summary contextLength = %v, want 128000", item["contextLength"])
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("route %d missing from /api/routes/summary", routeID)
+	}
+
+	lite := doGet(t, r, "/api/routes/lite")
+	if lite.Code != http.StatusOK {
+		t.Fatalf("lite status = %d body=%s", lite.Code, lite.Body.String())
+	}
+	var liteItems []map[string]any
+	if err := json.Unmarshal(lite.Body.Bytes(), &liteItems); err != nil {
+		t.Fatalf("decode lite: %v", err)
+	}
+	found = false
+	for _, item := range liteItems {
+		if int64(item["id"].(float64)) == routeID {
+			found = true
+			if got := int64(item["contextLength"].(float64)); got != 128000 {
+				t.Fatalf("lite contextLength = %v, want 128000", item["contextLength"])
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("route %d missing from /api/routes/lite", routeID)
+	}
+
+	// Update to a different positive value.
+	upd := doPutJSON(t, r, "/api/routes/"+itoa(routeID), map[string]any{
+		"contextLength": 200000,
+	})
+	if upd.Code != http.StatusOK {
+		t.Fatalf("update status = %d body=%s", upd.Code, upd.Body.String())
+	}
+	var updated map[string]any
+	if err := json.Unmarshal(upd.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode update: %v", err)
+	}
+	if got := int64(updated["contextLength"].(float64)); got != 200000 {
+		t.Fatalf("update contextLength = %v, want 200000", updated["contextLength"])
+	}
+
+	var dbVal *int64
+	if err := db.Get(&dbVal, `SELECT context_length FROM token_routes WHERE id = ?`, routeID); err != nil {
+		t.Fatalf("db get context_length: %v", err)
+	}
+	if dbVal == nil || *dbVal != 200000 {
+		t.Fatalf("db context_length = %v, want 200000", dbVal)
+	}
+
+	// Explicit null clears to unknown (NULL) — metadata only, no runtime enforcement.
+	clear := doPutJSON(t, r, "/api/routes/"+itoa(routeID), map[string]any{
+		"contextLength": nil,
+	})
+	if clear.Code != http.StatusOK {
+		t.Fatalf("clear status = %d body=%s", clear.Code, clear.Body.String())
+	}
+	var cleared map[string]any
+	if err := json.Unmarshal(clear.Body.Bytes(), &cleared); err != nil {
+		t.Fatalf("decode clear: %v", err)
+	}
+	if cleared["contextLength"] != nil {
+		t.Fatalf("cleared contextLength = %#v, want null", cleared["contextLength"])
+	}
+	dbVal = nil
+	if err := db.Get(&dbVal, `SELECT context_length FROM token_routes WHERE id = ?`, routeID); err != nil {
+		t.Fatalf("db get cleared context_length: %v", err)
+	}
+	if dbVal != nil {
+		t.Fatalf("db context_length after clear = %v, want NULL", *dbVal)
+	}
+
+	// Create without field leaves NULL.
+	create2 := doPostJSON(t, r, "/api/routes", map[string]any{
+		"modelPattern": "ctx-omit-*",
+		"enabled":      true,
+	})
+	if create2.Code != http.StatusOK {
+		t.Fatalf("create2 status = %d body=%s", create2.Code, create2.Body.String())
+	}
+	var created2 map[string]any
+	if err := json.Unmarshal(create2.Body.Bytes(), &created2); err != nil {
+		t.Fatalf("decode create2: %v", err)
+	}
+	if created2["contextLength"] != nil {
+		t.Fatalf("omitted create contextLength = %#v, want null", created2["contextLength"])
+	}
+}
+
 func TestTokenRoutes_PartialUpdatePreservesModelMapping(t *testing.T) {
 	db, r := setupTokenRoutesTest(t)
 	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)


### PR DESCRIPTION
## Summary
- Wire `contextLength` on admin token route create/update/list (column already existed).
- Tests round-trip; residual: metadata only (no runtime max-token enforcement).

Closes #320

## Verify
```bash
go test ./handler/admin -count=1 -run 'Context|Route'
```