### PR TITLE
test(scheduler): project failed proxy_logs usage into aggregates (#319)

### DIFF
--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -27,7 +27,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | TEST-1 | Admin proxy/chat stream + job queue harness | residual | `handler/admin/test.go` stream/jobs **501** / job not-found; sync path aliases forced-channel harness; `docs/analysis/admin-channel-test-harness.md` (#291) | Optional UX polish; sync harness already present | Low if residual stays honest |
 | P0-568 | Relay keys force-marked expired | **present** (#298/#301) | `ShouldMarkAccountExpired` + `ReportTokenExpired` ClassExpired guard; bare/generic 401 no longer marks | Done for mark path; novel wording residual only | Residual wording gaps |
 | P0-585 | Channel failure cascade poison | **partial** (hardened #299/#302) | Channel-scoped exclude, 429 failover, same-channel timeout budget, isolation tests; residual site/model breaker + production multi-channel load proof | Optional load-test / breaker polish | Medium residual |
-| P0-555 | Token usage statistics inaccurate | **partial** (#300/#303 stream partial; **#311** failure logs) | Client disconnect keeps extracted stream usage; **#311** failure `proxy_logs` retain usage on error paths; aggregation still needs to project failed-row tokens into aggregates — follow-up **#319** | Observability wave **#319** (v0.8.17) | Billing/ops trust |
+| P0-555 | Token usage statistics inaccurate | **present-with-residual** (#300/#311/#319) | Disconnect partial + failure proxy_logs with usage (#311); aggregation projects non-success tokens into `failed_calls` + `total_tokens` (#319 regression). Residual: stream_options policy, media zeros, multi-instance lag, orphan site join — not perfect billing | Residual polish only | Billing/ops trust residual |
 | P1-580 | Gemini thought_signature tool history | **present** (#86 transform + #309 proxy wire) | `NormalizeRequest` / OpenAI↔Gemini rebuild + `sanitizeUpstreamJSONBody` on gemini native/cli generateContent; residual: no multi-instance aggregate store | Done for request-side; session re-attach only if product needs | Residual multi-instance only |
 | P1-538 | Hermes/Codex multi-turn responses content | **present** (core; #50/#310) | `SanitizeResponsesInputItems` + `sanitizeUpstreamJSONBody` inject/preserve content; honest 400; residual: full Responses→chat conversion + no server store + no WS | Done for HTTP multi-turn content | Residual conversion/store/WS only |
 | ROUTE-590 | Route list drag reorder | **present** (v0.8.13) | `token_routes.sort_order` + `PUT /api/routes/reorder` (#284/#288); list `ORDER BY sort_order, id` | Done — matrix row should flip present on next refresh | — |
@@ -39,10 +39,10 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 
 ## Recommended sequencing (v0.8.17+)
 
-1. **Docs honesty** (#318): residual inventory + MASTER pointers after v0.8.16 so inventory matches shipped **#309–#311**.
-2. **Observability** (#319 / P0-555): project failed `proxy_logs` usage into aggregation (`failed_calls` + tokens); do not invent tokens when unknown.
-3. **Product surface honesty** (#320): `token_routes.context_length` admin/API JSON round-trip; document non-goal if no runtime max-token enforcement.
-4. **Protocol partials** already **present** on master (P1-580 request-side + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
+1. **Docs honesty** (#318): residual inventory + MASTER after v0.8.16 — done on master.
+2. **Observability** (#319 / P0-555): failed `proxy_logs` tokens project into aggregates — this PR; residual only policy/media/lag.
+3. **Product surface honesty** (#320): `token_routes.context_length` admin/API round-trip — done on master (metadata-only; no proxy max-token enforce).
+4. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
 5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
 6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 

--- a/docs/analysis/usage-token-extraction-audit.md
+++ b/docs/analysis/usage-token-extraction-audit.md
@@ -42,8 +42,25 @@ go test ./handler/proxy ./scheduler -count=1 -run Usage
 - TestNonStreamContentFailurePersistsParsedUsageToFailedProxyLog
 - TestDispatchUpstream_RetryThenSuccessKeepsSameRequestIDInProxyLog (failed+success rows, shared request_id)
 - TestTruncateErrTextBoundsLength
+- TestUsageAggregationProjectsFailedStatusTokens (#319: `status=failed` → failed_calls + total_tokens)
 - Existing stream disconnect / Anthropic cache / aggregation effective-token tests remain green
 
 ## Residual honesty
 
 Perfect billing accuracy is **not** claimed. Remaining gaps: schema metadata columns, stream_options policy, media endpoints that never emit usage, multi-instance projection lag, orphan logs without site join.
+
+## Aggregation of failed `proxy_logs` (#319)
+
+**Verdict: present-with-residual** (no product code gap in `scheduler/usage_aggregation.go`).
+
+`applyBatch` is status-agnostic for tokens: every projected row adds `effectiveTokenCount(...)` to day/hour/model `total_tokens`. Call classification is exact-string only:
+
+| `proxy_logs.status` | `success_calls` | `failed_calls` | `total_tokens` |
+|---------------------|-----------------|----------------|----------------|
+| `"success"` | +1 | +0 | +tokens |
+| `"failed"` (#311 `writeFailureProxyLog`) | +0 | +1 | +tokens |
+| other / nil (incl. legacy `"error"`) | +0 | +1 | +tokens |
+
+Zero/unknown usage stays 0 (`effectiveTokenCount` does not invent; #311 cost only when `usage.Found`). This is **not** perfect billing — residuals above still apply (stream_options policy, media endpoints, multi-instance lag, orphans without site join).
+
+Regression: `TestUsageAggregationProjectsFailedStatusTokens` (success + `status=failed` → `failed_calls=1`, `total_tokens=T1+T2`). Lifecycle projection seeds also use `"failed"` for the non-success row.

--- a/scheduler/usage_aggregation_test.go
+++ b/scheduler/usage_aggregation_test.go
@@ -76,7 +76,8 @@ func runUsageAggregationProjectionLifecycle(t *testing.T, db *store.DB, suffix s
 		t.Fatalf("first ProcessedLogs = %d, want 1", first.ProcessedLogs)
 	}
 
-	insertProjectionProxyLog(t, db, accountID, "error", "gpt-4.1", 80, 0.11, 0, secondLogTime)
+	// #311 writeFailureProxyLog uses status="failed" (legacy "error" is also non-success).
+	insertProjectionProxyLog(t, db, accountID, "failed", "gpt-4.1", 80, 0.11, 0, secondLogTime)
 	second := s.RunProjectionPass()
 	if second == nil {
 		t.Fatal("second projection pass returned nil")
@@ -273,6 +274,70 @@ func insertProjectionProxyLogTokens(
 		t.Fatalf("sqlite proxy log LastInsertId: %v", err)
 	}
 	return id
+}
+
+func TestUsageAggregationProjectsFailedStatusTokens(t *testing.T) {
+	// #319 / #311: writeFailureProxyLog uses status="failed" (not "error").
+	// Aggregation must count non-success rows into failed_calls and still
+	// project effectiveTokenCount into total_tokens (no success-only gate).
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate sqlite: %v", err)
+	}
+
+	suffix := "failed-status-" + strings.ReplaceAll(t.Name(), "/", "-")
+	now := time.Now().UTC().Format(time.RFC3339)
+	seedProjectionCheckpoint(t, db, maxProxyLogID(t, db))
+	siteID := insertProjectionSite(t, db, suffix, now)
+	accountID := insertProjectionAccount(t, db, siteID, suffix, now)
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM proxy_logs WHERE account_id = ?", accountID)
+		_, _ = db.Exec("DELETE FROM model_day_usage WHERE site_id = ?", siteID)
+		_, _ = db.Exec("DELETE FROM site_hour_usage WHERE site_id = ?", siteID)
+		_, _ = db.Exec("DELETE FROM site_day_usage WHERE site_id = ?", siteID)
+		_, _ = db.Exec("DELETE FROM sites WHERE id = ?", siteID)
+		seedProjectionCheckpoint(t, db, maxProxyLogID(t, db))
+	})
+
+	successTime := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	failedTime := successTime.Add(5 * time.Minute)
+	const successTokens int64 = 120
+	const failedTokens int64 = 11
+	insertProjectionProxyLog(t, db, accountID, "success", "gpt-4o", successTokens, 0.42, 230, successTime)
+	insertProjectionProxyLog(t, db, accountID, "failed", "gpt-4o", failedTokens, 0.01, 50, failedTime)
+
+	previousDB := store.GetDB()
+	store.OverrideDB(db)
+	t.Cleanup(func() { store.OverrideDB(previousDB) })
+
+	s := NewUsageAggregationScheduler(testConfig())
+	pass := s.RunProjectionPass()
+	if pass == nil || pass.ProcessedLogs != 2 {
+		t.Fatalf("projection pass = %#v, want ProcessedLogs=2", pass)
+	}
+
+	day := successTime.Format("2006-01-02")
+	var dayUsage struct {
+		TotalCalls   int   `db:"total_calls"`
+		SuccessCalls int   `db:"success_calls"`
+		FailedCalls  int   `db:"failed_calls"`
+		TotalTokens  int64 `db:"total_tokens"`
+	}
+	if err := db.Get(&dayUsage, `SELECT total_calls, success_calls, failed_calls, total_tokens
+		FROM site_day_usage WHERE site_id = ? AND local_day = ?`, siteID, day); err != nil {
+		t.Fatalf("read site_day_usage: %v", err)
+	}
+	if dayUsage.TotalCalls != 2 || dayUsage.SuccessCalls != 1 || dayUsage.FailedCalls != 1 {
+		t.Fatalf("calls = %+v, want total=2 success=1 failed=1", dayUsage)
+	}
+	wantTokens := successTokens + failedTokens
+	if dayUsage.TotalTokens != wantTokens {
+		t.Fatalf("total_tokens = %d, want %d (success+failed usage)", dayUsage.TotalTokens, wantTokens)
+	}
 }
 
 func TestEffectiveTokenCount(t *testing.T) {


### PR DESCRIPTION
## Summary
- Aggregation already treats non-success (including `failed`) as failed_calls and still adds tokens.
- Add regression test for status=`failed` + usage after #311.
- Audit / residual notes for #319.

Closes #319

## Verify
```bash
go test ./scheduler -count=1 -run 'FailedStatus|Usage|Aggregat'
```