### PR TITLE
docs: residual honesty refresh post v0.8.16 (#318)

### DIFF
--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,9 +1,9 @@
-# Residual next candidates (post v0.8.15)
+# Residual next candidates (post v0.8.16)
 
 **Date**: 2026-07-17  
-**Issue**: [#290](https://github.com/TokenDanceLab/metapi-go/issues/290) (inventory origin); reliability wave **#298–#300**  
-**Context**: After Enterprise residual **v0.8.15** (expired-mark guard, cascade isolation, stream/partial usage).  
-**Scope**: inventory only — **no product code** in this document.
+**Issue**: [#318](https://github.com/TokenDanceLab/metapi-go/issues/318) (this refresh); inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290)  
+**Context**: After Enterprise residual **v0.8.16** (protocol + usage residual **#309–#311**: Gemini thought_signature wire, Responses multi-turn content sanitize, failure `proxy_logs` retain usage).  
+**Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 
 ## Purpose
@@ -27,7 +27,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | TEST-1 | Admin proxy/chat stream + job queue harness | residual | `handler/admin/test.go` stream/jobs **501** / job not-found; sync path aliases forced-channel harness; `docs/analysis/admin-channel-test-harness.md` (#291) | Optional UX polish; sync harness already present | Low if residual stays honest |
 | P0-568 | Relay keys force-marked expired | **present** (#298/#301) | `ShouldMarkAccountExpired` + `ReportTokenExpired` ClassExpired guard; bare/generic 401 no longer marks | Done for mark path; novel wording residual only | Residual wording gaps |
 | P0-585 | Channel failure cascade poison | **partial** (hardened #299/#302) | Channel-scoped exclude, 429 failover, same-channel timeout budget, isolation tests; residual site/model breaker + production multi-channel load proof | Optional load-test / breaker polish | Medium residual |
-| P0-555 | Token usage statistics inaccurate | **partial** (audit #300/#303) | Client disconnect keeps extracted stream usage; aggregation pipeline still needs broader error/partial coverage | Observability follow-up | Billing/ops trust |
+| P0-555 | Token usage statistics inaccurate | **partial** (#300/#303 stream partial; **#311** failure logs) | Client disconnect keeps extracted stream usage; **#311** failure `proxy_logs` retain usage on error paths; aggregation still needs to project failed-row tokens into aggregates — follow-up **#319** | Observability wave **#319** (v0.8.17) | Billing/ops trust |
 | P1-580 | Gemini thought_signature tool history | **present** (#86 transform + #309 proxy wire) | `NormalizeRequest` / OpenAI↔Gemini rebuild + `sanitizeUpstreamJSONBody` on gemini native/cli generateContent; residual: no multi-instance aggregate store | Done for request-side; session re-attach only if product needs | Residual multi-instance only |
 | P1-538 | Hermes/Codex multi-turn responses content | **present** (core; #50/#310) | `SanitizeResponsesInputItems` + `sanitizeUpstreamJSONBody` inject/preserve content; honest 400; residual: full Responses→chat conversion + no server store + no WS | Done for HTTP multi-turn content | Residual conversion/store/WS only |
 | ROUTE-590 | Route list drag reorder | **present** (v0.8.13) | `token_routes.sort_order` + `PUT /api/routes/reorder` (#284/#288); list `ORDER BY sort_order, id` | Done — matrix row should flip present on next refresh | — |
@@ -37,13 +37,14 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | REBUILD-588 | Pattern/group rebuild | present | `service/route_rebuild.go` `RebuildRoutesBestEffort` | Done (matrix #281) | — |
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
 
-## Recommended sequencing (v0.8.16+)
+## Recommended sequencing (v0.8.17+)
 
-1. **Docs honesty**: flip matrix #590 → present; keep residual inventory honest after v0.8.15.
-2. **Protocol partials** largely present (P1-580 request-side + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
-3. **Observability follow-up** on P0-555 aggregation / non-stream paths (beyond disconnect partial).
-4. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-5. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+1. **Docs honesty** (#318): residual inventory + MASTER pointers after v0.8.16 so inventory matches shipped **#309–#311**.
+2. **Observability** (#319 / P0-555): project failed `proxy_logs` usage into aggregation (`failed_calls` + tokens); do not invent tokens when unknown.
+3. **Product surface honesty** (#320): `token_routes.context_length` admin/API JSON round-trip; document non-goal if no runtime max-token enforcement.
+4. **Protocol partials** already **present** on master (P1-580 request-side + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
+5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -51,11 +52,12 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Claiming cluster-wide sticky while bindings remain process-local.
 - Inventing update-center deploy/rollback success without a registry.
 - Returning `success:true` for unimplemented admin stream/job queues.
+- Claiming perfect billing accuracy without aggregation proof after #311.
 
 ## Links
 
-- Release: [v0.8.15](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.15)
+- Release: [v0.8.16](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.16)
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`
-- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300
+- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | next residual wave after v0.8.16 (open when needed) |
+| Active milestone | [Milestone 26 — Enterprise residual v0.8.17](https://github.com/TokenDanceLab/metapi-go/milestone/26) |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -30,10 +30,15 @@
 | M-FEATURE + competitive learn | ✅ | Gap #38–#56 · learn #110–#121 |
 | Enterprise residual **v0.8.15** | ✅ | #298–#300 · tag v0.8.15 |
 | Enterprise residual **v0.8.16** | ✅ | #309–#311 (PRs #313/#314/#315); tag **v0.8.16** |
+| Enterprise residual **v0.8.17** | 🔄 | Milestone 26 · #318–#320 |
 
 ## Active work
 
-v0.8.16 product Issues **closed**. Next wave: residual-next-candidates partials (#585 load-proof residual, #555 aggregation deeper, multi-key #579) — open Issues only when starting work.
+| Issue | Track | Title |
+|------:|:------|:------|
+| [#318](https://github.com/TokenDanceLab/metapi-go/issues/318) | docs | residual honesty refresh post v0.8.16 |
+| [#319](https://github.com/TokenDanceLab/metapi-go/issues/319) | observability | project failed proxy_logs tokens into usage aggregates (#555) |
+| [#320](https://github.com/TokenDanceLab/metapi-go/issues/320) | product | token_routes.context_length admin/API surface honesty (#520) |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -64,18 +69,17 @@ v0.8.16 product Issues **closed**. Next wave: residual-next-candidates partials 
 ## Quick status commands
 
 ```bash
-gh issue list --milestone "Enterprise residual v0.8.16" --state open
+gh issue list --milestone "Enterprise residual v0.8.17" --state open
 gh pr list --state open
-gh release view v0.8.15
+gh release view v0.8.16
 git log --oneline origin/master -10
 ```
 
 ## Next Steps
 
-1. Tag **v0.8.16** (this release) — Milestone 25 closed.
-2. Next residual wave only with clear ACs: #585 load residual, #555 aggregation, optional #579 multi-key.
-3. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
-4. Keep MASTER slim; docs map at `docs/README.md`.
+1. Land **v0.8.17** Milestone 26: #318 docs honesty · #319 usage aggregation · #320 context_length surface.
+2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
+3. Keep MASTER slim; docs map at `docs/README.md`.
 
 
 ## Governance


### PR DESCRIPTION
## Summary
- Refresh residual inventory after v0.8.16 so docs match shipped #309–#311
- Note #311 failure `proxy_logs` retain usage; aggregation follow-up #319
- Point MASTER active milestone to v0.8.17 (#318/#319/#320)

Closes #318

## Changes
- `docs/analysis/residual-next-candidates.md` — post v0.8.16 honesty refresh
- `docs/progress/MASTER.md` — Milestone 26 v0.8.17 pointers only

## Test plan
- [x] `go test ./docs -run TestPublicMarkdownHygiene -count=1`
- [x] No product Go/web code touched