### PR TITLE
docs(release): v0.8.17 residual honesty + aggregation + contextLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.17] — 2026-07-17
+
+### Added
+- Admin `token_routes.contextLength` create/update + list/summary/lite surfaces (metadata-only; no proxy max-token enforcement) (#320 / #323)
+
+### Fixed / Verified
+- Usage aggregation projects `proxy_logs.status=failed` tokens into `failed_calls` + `total_tokens` (regression + audit note; aggregation logic already status-agnostic) (#319 / #324)
+
+### Docs / Honesty
+- Residual inventory + MASTER pointers post v0.8.16 (#318 / #322)
+- P0-555 → present-with-residual after #311/#319; residual policy/media/lag only
+
 ## [v0.8.16] — 2026-07-17
 
 ### Fixed

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,8 +1,8 @@
-# Residual next candidates (post v0.8.16)
+# Residual next candidates (post v0.8.17)
 
 **Date**: 2026-07-17  
-**Issue**: [#318](https://github.com/TokenDanceLab/metapi-go/issues/318) (this refresh); inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290)  
-**Context**: After Enterprise residual **v0.8.16** (protocol + usage residual **#309–#311**: Gemini thought_signature wire, Responses multi-turn content sanitize, failure `proxy_logs` retain usage).  
+**Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); refresh trail #318 + v0.8.17 product  
+**Context**: After Enterprise residual **v0.8.17** (#318 residual honesty, #319 failed usage aggregates, #320 route `contextLength` admin surface).  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 
@@ -36,12 +36,13 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | KEY-578 | Per-key outbound proxy | present | `proxy/key_proxy.go` + `downstream_api_keys.proxy_url` | Done (matrix #281) | — |
 | REBUILD-588 | Pattern/group rebuild | present | `service/route_rebuild.go` `RebuildRoutesBestEffort` | Done (matrix #281) | — |
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
+| CTX-520 | Route contextLength admin surface | **present-with-residual** (#320) | Admin CRUD + list/summary/lite; residual: `/v1/models` still heuristic-only; no proxy max-token enforce | Optional models wire / enforce Milestone | Metadata vs enforcement |
 
-## Recommended sequencing (v0.8.17+)
+## Recommended sequencing (v0.8.18+)
 
-1. **Docs honesty** (#318): residual inventory + MASTER after v0.8.16 — done on master.
-2. **Observability** (#319 / P0-555): failed `proxy_logs` tokens project into aggregates — this PR; residual only policy/media/lag.
-3. **Product surface honesty** (#320): `token_routes.context_length` admin/API round-trip — done on master (metadata-only; no proxy max-token enforce).
+1. **Shipped in v0.8.17**: #318 docs honesty · #319 failed-status aggregate regression · #320 contextLength admin metadata.
+2. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
+3. **Optional**: wire `/v1/models` to route `contextLength`; P0-585 load-proof / breaker polish.
 4. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
 5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
 6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
@@ -53,10 +54,11 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Inventing update-center deploy/rollback success without a registry.
 - Returning `success:true` for unimplemented admin stream/job queues.
 - Claiming perfect billing accuracy without aggregation proof after #311.
+- Claiming proxy max-token enforcement from `contextLength` without a dedicated product AC.
 
 ## Links
 
-- Release: [v0.8.16](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.16)
+- Release: [v0.8.17](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.17) · prior [v0.8.16](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.16)
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -3,7 +3,7 @@
 **Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery  
 **Mode**: GitHub Issues + Milestones (SDD)  
 **Repo**: https://github.com/TokenDanceLab/metapi-go  
-**Latest release**: **[v0.8.16](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.16)** (2026-07-17)
+**Latest release**: **[v0.8.17](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.17)** (2026-07-17)
 
 > 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。  
 > 文档地图：[`docs/README.md`](../README.md)
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | [Milestone 26 — Enterprise residual v0.8.17](https://github.com/TokenDanceLab/metapi-go/milestone/26) |
+| Active milestone | closed Milestone 26 (v0.8.17) — next residual wave TBD |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -29,16 +29,14 @@
 | M-BACKEND / UI / SCHEMA / RELIABILITY | ✅ | Design SSOT in `docs/design/` |
 | M-FEATURE + competitive learn | ✅ | Gap #38–#56 · learn #110–#121 |
 | Enterprise residual **v0.8.15** | ✅ | #298–#300 · tag v0.8.15 |
-| Enterprise residual **v0.8.16** | ✅ | #309–#311 (PRs #313/#314/#315); tag **v0.8.16** |
-| Enterprise residual **v0.8.17** | 🔄 | Milestone 26 · #318–#320 |
+| Enterprise residual **v0.8.16** | ✅ | #309–#311 · tag v0.8.16 |
+| Enterprise residual **v0.8.17** | ✅ | #318–#320 (PRs #322/#323/#324); tag **v0.8.17** |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| [#318](https://github.com/TokenDanceLab/metapi-go/issues/318) | docs | residual honesty refresh post v0.8.16 |
-| [#319](https://github.com/TokenDanceLab/metapi-go/issues/319) | observability | project failed proxy_logs tokens into usage aggregates (#555) |
-| [#320](https://github.com/TokenDanceLab/metapi-go/issues/320) | product | token_routes.context_length admin/API surface honesty (#520) |
+| — | — | Board clean after v0.8.17; next residual only with ACs |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -47,12 +45,12 @@
 
 | Tag | Milestone | Highlights |
 |:----|:----------|:-----------|
+| [v0.8.17](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.17) | 26 | Residual honesty · failed usage aggregates · route contextLength |
 | [v0.8.16](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.16) | 25 | Gemini thought_signature wire · Responses multi-turn · failure usage logs |
 | [v0.8.15](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.15) | 24 | Expired-mark guard · cascade isolation · stream usage partial |
 | [v0.8.14](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.14) | 23 | Residual inventory · Redis sticky design · admin test honesty |
 | [v0.8.13](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.13) | 22 | Gap matrix refresh · sticky eval · route reorder |
-| [v0.8.12](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.12) | 21 | Task race · announcement sync · recovery provider · WS residual |
-| older | 11–20 | See GitHub Releases / `CHANGELOG.md` |
+| older | 11–21 | See GitHub Releases / `CHANGELOG.md` |
 
 ## Architecture entry points
 
@@ -69,16 +67,16 @@
 ## Quick status commands
 
 ```bash
-gh issue list --milestone "Enterprise residual v0.8.17" --state open
+gh issue list --state open --limit 20
 gh pr list --state open
-gh release view v0.8.16
+gh release view v0.8.17
 git log --oneline origin/master -10
 ```
 
 ## Next Steps
 
-1. Land **v0.8.17** Milestone 26: #318 docs honesty · #319 usage aggregation · #320 context_length surface.
-2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
+1. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
+2. Optional residual polish: P0-585 load-proof / site-model breaker; P0-555 policy/media/lag; `/v1/models` consume route `contextLength`.
 3. Keep MASTER slim; docs map at `docs/README.md`.
 
 


### PR DESCRIPTION
## Summary
- CHANGELOG entry for **v0.8.17** (#318 residual honesty, #319 failed usage aggregates, #320 contextLength admin)
- Slim MASTER → latest release v0.8.17; Milestone 26 closed after merge/tag
- residual-next-candidates post v0.8.17 (P0-555 present-with-residual; CTX-520 present-with-residual)

## Verify
`go test ./docs -run TestPublicMarkdownHygiene -count=1`

## Forbidden
No product Go/web code.

After merge: tag `v0.8.17`, GitHub Release, close Milestone 26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `contextLength` metadata to Admin token route creation, updates, lists, summaries, and lightweight views.

- **Bug Fixes**
  - Improved usage reporting for failed proxy calls, including accurate failed-call counts and total token usage.

- **Documentation**
  - Updated release notes and project status documentation for v0.8.17.
  - Clarified residual inventory, release tracking, observability follow-ups, and future `/v1/models` context-length handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->