### PR TITLE
docs: residual honesty refresh post v0.8.17 (#329)

### DIFF
--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,8 +1,8 @@
-# Residual next candidates (post v0.8.17)
+# Residual next candidates (post v0.8.17 → v0.8.18)
 
 **Date**: 2026-07-17  
-**Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); refresh trail #318 + v0.8.17 product  
-**Context**: After Enterprise residual **v0.8.17** (#318 residual honesty, #319 failed usage aggregates, #320 route `contextLength` admin surface).  
+**Issue**: [#329](https://github.com/TokenDanceLab/metapi-go/issues/329) (this refresh); inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); trail #318 + v0.8.17 product  
+**Context**: After Enterprise residual **v0.8.17** (#318 residual honesty, #319 failed usage aggregates, #320 route `contextLength` admin surface). Active Milestone **27 / v0.8.18** work: **#327–#329**.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 
@@ -26,7 +26,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | UC-1 | Update-center remote registry / deploy | residual | `scheduler/update_center.go` log-only; admin deploy/rollback/SSE **501**; `docs/analysis/residual-update-center.md` (#283) | Product Milestone with real registry client | Ops safety; no fake updateAvailable |
 | TEST-1 | Admin proxy/chat stream + job queue harness | residual | `handler/admin/test.go` stream/jobs **501** / job not-found; sync path aliases forced-channel harness; `docs/analysis/admin-channel-test-harness.md` (#291) | Optional UX polish; sync harness already present | Low if residual stays honest |
 | P0-568 | Relay keys force-marked expired | **present** (#298/#301) | `ShouldMarkAccountExpired` + `ReportTokenExpired` ClassExpired guard; bare/generic 401 no longer marks | Done for mark path; novel wording residual only | Residual wording gaps |
-| P0-585 | Channel failure cascade poison | **partial** (hardened #299/#302) | Channel-scoped exclude, 429 failover, same-channel timeout budget, isolation tests; residual site/model breaker + production multi-channel load proof | Optional load-test / breaker polish | Medium residual |
+| P0-585 | Channel failure cascade poison | **partial** (hardened #299/#302) | Channel-scoped exclude, 429 failover, same-channel timeout budget, isolation tests; residual site/model breaker + production multi-channel load proof | Optional load-test / breaker polish (not in #327–#329 ACs) | Medium residual |
 | P0-555 | Token usage statistics inaccurate | **present-with-residual** (#300/#311/#319) | Disconnect partial + failure proxy_logs with usage (#311); aggregation projects non-success tokens into `failed_calls` + `total_tokens` (#319 regression). Residual: stream_options policy, media zeros, multi-instance lag, orphan site join — not perfect billing | Residual polish only | Billing/ops trust residual |
 | P1-580 | Gemini thought_signature tool history | **present** (#86 transform + #309 proxy wire) | `NormalizeRequest` / OpenAI↔Gemini rebuild + `sanitizeUpstreamJSONBody` on gemini native/cli generateContent; residual: no multi-instance aggregate store | Done for request-side; session re-attach only if product needs | Residual multi-instance only |
 | P1-538 | Hermes/Codex multi-turn responses content | **present** (core; #50/#310) | `SanitizeResponsesInputItems` + `sanitizeUpstreamJSONBody` inject/preserve content; honest 400; residual: full Responses→chat conversion + no server store + no WS | Done for HTTP multi-turn content | Residual conversion/store/WS only |
@@ -36,16 +36,17 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | KEY-578 | Per-key outbound proxy | present | `proxy/key_proxy.go` + `downstream_api_keys.proxy_url` | Done (matrix #281) | — |
 | REBUILD-588 | Pattern/group rebuild | present | `service/route_rebuild.go` `RebuildRoutesBestEffort` | Done (matrix #281) | — |
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
-| CTX-520 | Route contextLength admin surface | **present-with-residual** (#320) | Admin CRUD + list/summary/lite; residual: `/v1/models` still heuristic-only; no proxy max-token enforce | Optional models wire / enforce Milestone | Metadata vs enforcement |
+| CTX-520 | Route contextLength admin + models wire | **present-with-residual** (#320; active **#327**) | Admin CRUD + list/summary/lite shipped (#320). Residual flip target: `/v1/models` still heuristic-only until #327; no proxy max-token enforce | **v0.8.18 #327** models metadata wire; enforce still out of scope | Metadata vs enforcement |
 
-## Recommended sequencing (v0.8.18+)
+## Recommended sequencing (v0.8.18)
 
-1. **Shipped in v0.8.17**: #318 docs honesty · #319 failed-status aggregate regression · #320 contextLength admin metadata.
-2. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
-3. **Optional**: wire `/v1/models` to route `contextLength`; P0-585 load-proof / breaker polish.
-4. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
-5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+1. **Active Milestone 27**: #327 `/v1/models` `context_length` from `token_routes.context_length` · #328 admin `RefreshBalance_NotFound` race flake · #329 this residual honesty refresh.
+2. **Shipped in v0.8.17**: #318 docs honesty · #319 failed-status aggregate regression · #320 contextLength admin metadata.
+3. **No residual status flip yet** from this wave until #327 lands; CTX-520 stays present-with-residual (admin done, models heuristic).
+4. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
+5. **Optional later**: P0-585 load-proof / site-model breaker; not claimed in #327–#329.
+6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+7. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -53,13 +54,15 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Claiming cluster-wide sticky while bindings remain process-local.
 - Inventing update-center deploy/rollback success without a registry.
 - Returning `success:true` for unimplemented admin stream/job queues.
-- Claiming perfect billing accuracy without aggregation proof after #311.
+- Claiming perfect billing accuracy without aggregation proof after #311/#319.
 - Claiming proxy max-token enforcement from `contextLength` without a dedicated product AC.
+- Skipping or weakening #328 permanently instead of isolating the race.
 
 ## Links
 
 - Release: [v0.8.17](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.17) · prior [v0.8.16](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.16)
+- Milestone: [27 — Enterprise residual v0.8.18](https://github.com/TokenDanceLab/metapi-go/milestone/27)
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`
-- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320
+- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | closed Milestone 26 (v0.8.17) — next residual wave TBD |
+| Active milestone | [Milestone 27 — Enterprise residual v0.8.18](https://github.com/TokenDanceLab/metapi-go/milestone/27) |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -30,13 +30,16 @@
 | M-FEATURE + competitive learn | ✅ | Gap #38–#56 · learn #110–#121 |
 | Enterprise residual **v0.8.15** | ✅ | #298–#300 · tag v0.8.15 |
 | Enterprise residual **v0.8.16** | ✅ | #309–#311 · tag v0.8.16 |
-| Enterprise residual **v0.8.17** | ✅ | #318–#320 (PRs #322/#323/#324); tag **v0.8.17** |
+| Enterprise residual **v0.8.17** | ✅ | #318–#320 · tag **v0.8.17** |
+| Enterprise residual **v0.8.18** | 🔄 | Milestone 27 · #327–#329 |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| — | — | Board clean after v0.8.17; next residual only with ACs |
+| [#327](https://github.com/TokenDanceLab/metapi-go/issues/327) | product | `/v1/models` context_length from token_routes.context_length (#520 residual) |
+| [#328](https://github.com/TokenDanceLab/metapi-go/issues/328) | test | fix handler/admin race flake RefreshBalance_NotFound under -race suite |
+| [#329](https://github.com/TokenDanceLab/metapi-go/issues/329) | docs | residual honesty refresh post v0.8.17 |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -67,7 +70,7 @@
 ## Quick status commands
 
 ```bash
-gh issue list --state open --limit 20
+gh issue list --milestone "Enterprise residual v0.8.18" --state open
 gh pr list --state open
 gh release view v0.8.17
 git log --oneline origin/master -10
@@ -75,8 +78,8 @@ git log --oneline origin/master -10
 
 ## Next Steps
 
-1. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
-2. Optional residual polish: P0-585 load-proof / site-model breaker; P0-555 policy/media/lag; `/v1/models` consume route `contextLength`.
+1. Land **v0.8.18** Milestone 27: #327 models context_length wire · #328 admin race flake · #329 residual honesty refresh.
+2. Product Milestones only with ACs after that: full Responses WS Codex; Redis sticky Option B; update-center registry.
 3. Keep MASTER slim; docs map at `docs/README.md`.
 
 


### PR DESCRIPTION
## Summary
- Refresh `docs/analysis/residual-next-candidates.md` for post-v0.8.17 residual honesty: active Milestone **27 / v0.8.18**, issues **#327–#329**.
- Point `docs/progress/MASTER.md` Active milestone + active work table at #327–#329; keep slim (no changelog dump).
- CTX-520 stays **present-with-residual** until #327 models wire lands; no fake WS/sticky/update-center claims.

## Test plan
- [x] `go test ./docs -run TestPublicMarkdownHygiene -count=1`

Closes #329.