### PR TITLE
fix(admin): isolate accounts cache from async health-refresh races

### DIFF
--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -18,7 +18,10 @@ import (
 
 func setupAccountsTest(t *testing.T) (*store.DB, chi.Router, *config.Config) {
 	t.Helper()
-	globalAccountsCache = &accountsSnapshotCache{ttl: 30 * time.Second}
+	// Keep the process-lifetime singleton; only clear contents.
+	// Reassigning the package pointer races with async health-refresh runners
+	// that call globalAccountsCache.clear() after StartBackgroundTask (#328).
+	globalAccountsCache.clear()
 
 	db, err := store.Open(store.DialectSQLite, ":memory:", false)
 	if err != nil {
@@ -43,7 +46,8 @@ func setupAccountsTest(t *testing.T) (*store.DB, chi.Router, *config.Config) {
 
 func setupAccountsPostgresTest(t *testing.T) (*store.DB, chi.Router, *config.Config) {
 	t.Helper()
-	globalAccountsCache = &accountsSnapshotCache{ttl: 30 * time.Second}
+	// Same isolation rule as setupAccountsTest: never reassign the global pointer (#328).
+	globalAccountsCache.clear()
 
 	db, r := setupSitesPostgresTest(t)
 	cfg := &config.Config{
@@ -2033,6 +2037,21 @@ func TestAccounts_HealthRefresh_BackgroundDedupe(t *testing.T) {
 	}
 	if secondResult["jobId"] != jobID {
 		t.Fatalf("second jobId = %v, want %q", secondResult["jobId"], jobID)
+	}
+
+	// Drain the shared runner before cleanup so it cannot race the next test's
+	// setupAccountsTest (or a closed fixture DB) while still calling package globals (#328).
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		task := getBackgroundTask(nil, jobID)
+		if task != nil && (task.Status == BackgroundTaskSucceeded || task.Status == BackgroundTaskFailed) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	task := getBackgroundTask(nil, jobID)
+	if task == nil || (task.Status != BackgroundTaskSucceeded && task.Status != BackgroundTaskFailed) {
+		t.Fatalf("background dedupe task did not reach terminal status: %#v", task)
 	}
 }
 

--- a/handler/admin/settings_maintenance_test.go
+++ b/handler/admin/settings_maintenance_test.go
@@ -15,7 +15,8 @@ import (
 func setupMaintenanceTest(t *testing.T) (*store.DB, chi.Router, *routing.RouteCache) {
 	t.Helper()
 	resetBackgroundTasksForTests()
-	globalAccountsCache = &accountsSnapshotCache{ttl: 30 * time.Second}
+	// Keep the process-lifetime singleton; only clear contents (#328).
+	globalAccountsCache.clear()
 
 	db, err := store.Open(store.DialectSQLite, ":memory:", false)
 	if err != nil {

--- a/handler/admin/tasks.go
+++ b/handler/admin/tasks.go
@@ -520,8 +520,35 @@ func newBackgroundTaskID() string {
 	return hex.EncodeToString(b[:])
 }
 
+// waitAllBackgroundTasksForTests polls until every in-memory task is terminal
+// or the timeout elapses. Used by tests so cleanup does not race runners that
+// still touch package globals (e.g. globalAccountsCache.clear) (#328).
+func waitAllBackgroundTasksForTests(timeout time.Duration) {
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		backgroundTasksMu.Lock()
+		pending := false
+		for _, task := range backgroundTasks {
+			if task.Status == BackgroundTaskPending || task.Status == BackgroundTaskRunning {
+				pending = true
+				break
+			}
+		}
+		backgroundTasksMu.Unlock()
+		if !pending {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // resetBackgroundTasksForTests clears the in-memory registry (tests only).
+// It first waits briefly for runners so map teardown does not race active work.
 func resetBackgroundTasksForTests() {
+	waitAllBackgroundTasksForTests(3 * time.Second)
 	backgroundTasksMu.Lock()
 	defer backgroundTasksMu.Unlock()
 	backgroundTasks = map[string]*BackgroundTask{}


### PR DESCRIPTION
## Summary
- Stop reassigning the process-lifetime `globalAccountsCache` pointer in admin test setups; clear contents instead so async health-refresh runners cannot race pointer writes.
- Drain `TestAccounts_HealthRefresh_BackgroundDedupe` until terminal status, and harden `resetBackgroundTasksForTests` to wait for runners before wiping the registry.
- Closes #328

## Root cause
Package-level DATA RACE on `globalAccountsCache`:
- Write: `setupAccountsTest` reassigned the global pointer.
- Concurrent read: leftover health-refresh background runners from earlier tests called `globalAccountsCache.clear()`.
- `t.Cleanup(resetBackgroundTasksForTests)` only cleared maps and did not wait for runners.

## Test plan
- [x] `go test ./handler/admin -run 'TestAccounts_RefreshBalance_NotFound|TestAccounts_HealthRefresh_Background' -count=10 -race -timeout 180s`
- [x] `go test ./handler/admin -count=3 -race -timeout 180s`
- [x] Pre-push hook: `go vet ./...` + `go test ./... -count=1 -race`