### PR TITLE
feat(proxy): wire token_routes.context_length into /v1/models (#327)

### DIFF
--- a/app/proxy_upstream.go
+++ b/app/proxy_upstream.go
@@ -130,7 +130,8 @@ func (s *proxyRoutingStore) LoadEnabledRoutes(ctx context.Context) ([]store.Toke
 	var routes []store.TokenRoute
 	err := s.selectContext(ctx, &routes, `
 		SELECT id, model_pattern, display_name, display_icon, route_mode, model_mapping,
-		       decision_snapshot, decision_refreshed_at, routing_strategy, enabled, created_at, updated_at
+		       decision_snapshot, decision_refreshed_at, routing_strategy, context_length,
+		       enabled, created_at, updated_at
 		FROM token_routes
 		WHERE enabled = ?
 		ORDER BY id ASC`, true)

--- a/docs/analysis/models-response-shape.md
+++ b/docs/analysis/models-response-shape.md
@@ -42,8 +42,8 @@ Implications:
 
 Residual / future hardening:
 
-- Admin CRUD for route metadata: `POST/PUT /api/routes` accept camelCase `contextLength`; list/summary/lite echo it when set (`#320`). Stored on `token_routes.context_length` (SC2). **Metadata only** — no proxy max-token truncation/enforcement is wired from this field yet.
-- Prefer `token_routes.context_length` over built-in defaults when set in `/v1/models`; today `knownModelContextLength` still supplies family defaults/heuristics only (route-level not consumed by models listing yet).
+- Admin CRUD for route metadata: `POST/PUT /api/routes` accept camelCase `contextLength`; list/summary/lite echo it when set (`#320`). Stored on `token_routes.context_length` (SC2). **Metadata only** — no proxy max-token truncation/enforcement is wired from this field.
+- OpenAI `/v1/models` prefers positive `token_routes.context_length` over `knownModelContextLength` heuristics when the route is enabled/visible (`#327`). Same exposed id from multiple routes → max. NULL / absent → heuristic (or omit). Claude listing path unchanged (no `context_length` field).
 - Optionally merge per-site discovered context metadata from platform model refresh.
 - Route-ID-aware listing when policy has only `AllowedRouteIDs` (currently empty until joined).
 
@@ -79,9 +79,9 @@ Residual / future hardening:
 
 | Field | Location | Notes |
 |-------|----------|--------|
-| `context_length` | item | Token window when known. Omitted for unknown/custom IDs so clients can fall back to their own defaults/probes. |
+| `context_length` | item | Token window when known. Preference: positive route `context_length` → family heuristic → omit. Omitted for unknown/custom IDs without route metadata so clients can fall back to their own defaults/probes. Metadata only (no proxy max-token enforcement). |
 
-`context_length` addresses upstream #507 / Hermes auto-detection: Hermes and similar agents scan `/v1/models` for keys such as `context_length`, `max_model_len`, `n_ctx`, etc. MetAPI emits the common OpenRouter-style key `context_length` for known catalog models.
+`context_length` addresses upstream #507 / Hermes auto-detection: Hermes and similar agents scan `/v1/models` for keys such as `context_length`, `max_model_len`, `n_ctx`, etc. MetAPI emits the common OpenRouter-style key `context_length` when route metadata or a family heuristic is available.
 
 ## Claude-compatible shape
 

--- a/handler/proxy/models.go
+++ b/handler/proxy/models.go
@@ -25,6 +25,15 @@ type AvailableModelsSource interface {
 	GetAvailableModels(ctx context.Context) ([]string, error)
 }
 
+// AvailableModelContextLengthsSource is an optional router capability that maps
+// exposed model ids to token_routes.context_length when set. Production
+// routing.TokenRouter implements this; unit mocks may omit it so listing keeps
+// knownModelContextLength heuristics only. Values are metadata for /v1/models —
+// they do not enforce max tokens on the proxy path.
+type AvailableModelContextLengthsSource interface {
+	GetAvailableModelContextLengths(ctx context.Context) (map[string]int64, error)
+}
+
 var emptyModelsCatalogLogOnce sync.Once
 
 // HandleModels handles GET /v1/models.
@@ -44,9 +53,10 @@ func HandleModels(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
 
 	if wantsClaude {
+		// Claude Models API shape has no context_length field; route metadata is OpenAI-only.
 		writeJSON(w, 200, buildClaudeModelsResponse(models, now))
 	} else {
-		writeJSON(w, 200, buildOpenAIModelsResponse(models, now))
+		writeJSON(w, 200, buildOpenAIModelsResponse(models, now, resolveOwnedModelContextLengths(r.Context())))
 	}
 }
 
@@ -56,7 +66,14 @@ func HandleModels(w http.ResponseWriter, r *http.Request) {
 //
 // Optional context_length is included when known so OpenAI-compatible clients
 // (Hermes and similar) can auto-detect context windows from /v1/models.
-func buildOpenAIModelsResponse(models []string, now time.Time) map[string]any {
+//
+// Preference order for context_length:
+//  1. Positive value from routeCtx (token_routes.context_length via TokenRouter)
+//  2. knownModelContextLength family heuristics
+//  3. omit field
+//
+// routeCtx may be nil when the router does not expose context lengths.
+func buildOpenAIModelsResponse(models []string, now time.Time, routeCtx map[string]int64) map[string]any {
 	items := make([]map[string]any, 0, len(models))
 	created := now.Unix()
 	for _, m := range models {
@@ -65,6 +82,13 @@ func buildOpenAIModelsResponse(models []string, now time.Time) map[string]any {
 			"object":   "model",
 			"created":  created,
 			"owned_by": modelsOwnedBy,
+		}
+		if routeCtx != nil {
+			if ctxLen, ok := routeCtx[m]; ok && ctxLen > 0 {
+				item["context_length"] = ctxLen
+				items = append(items, item)
+				continue
+			}
 		}
 		if ctxLen, ok := knownModelContextLength(m); ok {
 			item["context_length"] = ctxLen
@@ -189,6 +213,36 @@ func availableModelsSourceFromConfig(cfg *UpstreamConfig) AvailableModelsSource 
 	return src
 }
 
+// resolveOwnedModelContextLengths loads optional route-level context_length values
+// for OpenAI /v1/models. Missing capability or errors yield nil (heuristic-only).
+func resolveOwnedModelContextLengths(ctx context.Context) map[string]int64 {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg := getUpstreamConfig()
+	src := availableModelContextLengthsSourceFromConfig(cfg)
+	if src == nil {
+		return nil
+	}
+	lengths, err := src.GetAvailableModelContextLengths(ctx)
+	if err != nil {
+		slog.Warn("getAvailableModelContextLengths: router lookup failed; using heuristics only", "err", err)
+		return nil
+	}
+	if len(lengths) == 0 {
+		return nil
+	}
+	return lengths
+}
+
+func availableModelContextLengthsSourceFromConfig(cfg *UpstreamConfig) AvailableModelContextLengthsSource {
+	if cfg == nil || cfg.Router == nil {
+		return nil
+	}
+	src, _ := cfg.Router.(AvailableModelContextLengthsSource)
+	return src
+}
+
 // lastResortStubCatalog is used only when route-backed listing is unavailable
 // (proxy stub tests / selection-only mocks). Production with TokenRouter uses
 // GetAvailableModels instead.
@@ -231,8 +285,8 @@ func normalizeModelCatalog(models []string) []string {
 // in the owned listing. Unknown models omit the field (clients fall back to their
 // own defaults/probes). Values are token counts, not bytes.
 //
-// When route-level token_routes.context_length is wired into this handler, that
-// value should take precedence over these defaults.
+// Route-level token_routes.context_length (via resolveOwnedModelContextLengths)
+// takes precedence over these defaults when set to a positive value.
 func knownModelContextLength(model string) (int64, bool) {
 	// Exact matches first for the owned stub catalog.
 	switch model {

--- a/handler/proxy/models_test.go
+++ b/handler/proxy/models_test.go
@@ -14,9 +14,12 @@ import (
 
 // modelsTestRouter is a channel-selection router that implements
 // AvailableModelsSource for /v1/models unit tests.
+// Optional contextLengths implements AvailableModelContextLengthsSource (#327).
 type modelsTestRouter struct {
-	models []string
-	err    error
+	models         []string
+	err            error
+	contextLengths map[string]int64
+	contextErr     error
 }
 
 func (r *modelsTestRouter) SelectChannel(context.Context, string, routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
@@ -44,6 +47,20 @@ func (r *modelsTestRouter) GetAvailableModels(context.Context) ([]string, error)
 	return out, nil
 }
 
+func (r *modelsTestRouter) GetAvailableModelContextLengths(context.Context) (map[string]int64, error) {
+	if r.contextErr != nil {
+		return nil, r.contextErr
+	}
+	if r.contextLengths == nil {
+		return map[string]int64{}, nil
+	}
+	out := make(map[string]int64, len(r.contextLengths))
+	for k, v := range r.contextLengths {
+		out[k] = v
+	}
+	return out, nil
+}
+
 // selectionOnlyRouter satisfies TokenRouterInterface without AvailableModelsSource.
 type selectionOnlyRouter struct{}
 
@@ -65,9 +82,10 @@ func (r *selectionOnlyRouter) RecordFailure(context.Context, int64, routing.Site
 
 // Ensure compile-time interface compliance.
 var (
-	_ proxy.TokenRouterInterface = (*modelsTestRouter)(nil)
-	_ AvailableModelsSource      = (*modelsTestRouter)(nil)
-	_ proxy.TokenRouterInterface = (*selectionOnlyRouter)(nil)
+	_ proxy.TokenRouterInterface            = (*modelsTestRouter)(nil)
+	_ AvailableModelsSource                 = (*modelsTestRouter)(nil)
+	_ AvailableModelContextLengthsSource    = (*modelsTestRouter)(nil)
+	_ proxy.TokenRouterInterface            = (*selectionOnlyRouter)(nil)
 )
 
 func withModelsRouter(t *testing.T, router proxy.TokenRouterInterface) {
@@ -156,7 +174,7 @@ func TestIsModelAllowedByPolicy(t *testing.T) {
 func TestBuildOpenAIModelsResponse(t *testing.T) {
 	models := []string{"gpt-4o", "gpt-3.5-turbo"}
 	fixed := time.Date(2026, 3, 19, 0, 0, 0, 0, time.UTC)
-	resp := buildOpenAIModelsResponse(models, fixed)
+	resp := buildOpenAIModelsResponse(models, fixed, nil)
 
 	if resp["object"] != "list" {
 		t.Errorf("object = %v", resp["object"])
@@ -197,7 +215,7 @@ func TestBuildOpenAIModelsResponse(t *testing.T) {
 }
 
 func TestBuildOpenAIModelsResponse_Empty(t *testing.T) {
-	resp := buildOpenAIModelsResponse([]string{}, time.Unix(0, 0).UTC())
+	resp := buildOpenAIModelsResponse([]string{}, time.Unix(0, 0).UTC(), nil)
 	if resp["object"] != "list" {
 		t.Errorf("empty list must still set object=list, got %v", resp["object"])
 	}
@@ -208,7 +226,7 @@ func TestBuildOpenAIModelsResponse_Empty(t *testing.T) {
 }
 
 func TestBuildOpenAIModelsResponse_UnknownModelOmitsContextLength(t *testing.T) {
-	resp := buildOpenAIModelsResponse([]string{"custom-vendor/my-model"}, time.Unix(1, 0).UTC())
+	resp := buildOpenAIModelsResponse([]string{"custom-vendor/my-model"}, time.Unix(1, 0).UTC(), nil)
 	data, _ := resp["data"].([]map[string]any)
 	if len(data) != 1 {
 		t.Fatalf("expected 1 model, got %d", len(data))
@@ -221,6 +239,163 @@ func TestBuildOpenAIModelsResponse_UnknownModelOmitsContextLength(t *testing.T) 
 	}
 	if data[0]["object"] != "model" {
 		t.Errorf("object = %v", data[0]["object"])
+	}
+}
+
+// ---- route context_length override (#327) ----
+
+func TestBuildOpenAIModelsResponse_RouteContextLengthOverridesHeuristic(t *testing.T) {
+	// gpt-4o heuristic is 128000; route metadata wins when positive.
+	resp := buildOpenAIModelsResponse(
+		[]string{"gpt-4o", "custom-vendor/my-model"},
+		time.Unix(2, 0).UTC(),
+		map[string]int64{
+			"gpt-4o":                64000,
+			"custom-vendor/my-model": 32000,
+		},
+	)
+	data, _ := resp["data"].([]map[string]any)
+	if len(data) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(data))
+	}
+	if data[0]["context_length"] != int64(64000) {
+		t.Errorf("gpt-4o route override = %v, want 64000", data[0]["context_length"])
+	}
+	if data[1]["context_length"] != int64(32000) {
+		t.Errorf("custom model route context = %v, want 32000", data[1]["context_length"])
+	}
+}
+
+func TestBuildOpenAIModelsResponse_NilRouteMapKeepsHeuristic(t *testing.T) {
+	resp := buildOpenAIModelsResponse([]string{"gpt-4o", "custom-vendor/my-model"}, time.Unix(3, 0).UTC(), nil)
+	data, _ := resp["data"].([]map[string]any)
+	if data[0]["context_length"] != int64(128000) {
+		t.Errorf("nil route map should keep heuristic, got %v", data[0]["context_length"])
+	}
+	if _, ok := data[1]["context_length"]; ok {
+		t.Errorf("unknown model with nil route map should omit context_length, got %v", data[1]["context_length"])
+	}
+}
+
+func TestBuildOpenAIModelsResponse_NonPositiveRouteLengthFallsBack(t *testing.T) {
+	// Zero/negative route values must not override heuristics or invent a window.
+	resp := buildOpenAIModelsResponse(
+		[]string{"gpt-4o", "custom-vendor/my-model"},
+		time.Unix(4, 0).UTC(),
+		map[string]int64{
+			"gpt-4o":                 0,
+			"custom-vendor/my-model": -1,
+		},
+	)
+	data, _ := resp["data"].([]map[string]any)
+	if data[0]["context_length"] != int64(128000) {
+		t.Errorf("non-positive route length should fall back to heuristic, got %v", data[0]["context_length"])
+	}
+	if _, ok := data[1]["context_length"]; ok {
+		t.Errorf("non-positive route length on unknown model should omit field, got %v", data[1]["context_length"])
+	}
+}
+
+func TestHandleModels_RouteContextLengthReflected(t *testing.T) {
+	// AC: create/list path with route contextLength → /v1/models reflects it.
+	// (Admin CRUD already stores the column; this verifies models listing consumption.)
+	withModelsRouter(t, &modelsTestRouter{
+		models: []string{"gpt-4o", "custom-route-model"},
+		contextLengths: map[string]int64{
+			"gpt-4o":             99999, // override heuristic 128000
+			"custom-route-model": 424242,
+		},
+	})
+
+	req := httptest.NewRequest("GET", "/v1/models", nil)
+	req = auth.ProxyAuthFromRequest(req, &auth.ProxyAuthContext{
+		Token:  "test",
+		Source: "global",
+		Policy: auth.EmptyDownstreamRoutingPolicy,
+	})
+	rec := httptest.NewRecorder()
+	HandleModels(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	m := unmarshalResponse(t, rec)
+	data, _ := m["data"].([]any)
+	if len(data) != 2 {
+		t.Fatalf("expected 2 models, got %#v", data)
+	}
+	byID := map[string]map[string]any{}
+	for _, raw := range data {
+		item := raw.(map[string]any)
+		id, _ := item["id"].(string)
+		byID[id] = item
+	}
+	// JSON numbers decode as float64
+	if byID["gpt-4o"]["context_length"] != float64(99999) {
+		t.Fatalf("gpt-4o context_length = %v, want 99999 (route override)", byID["gpt-4o"]["context_length"])
+	}
+	if byID["custom-route-model"]["context_length"] != float64(424242) {
+		t.Fatalf("custom-route-model context_length = %v, want 424242", byID["custom-route-model"]["context_length"])
+	}
+}
+
+func TestHandleModels_RouteContextLengthErrorKeepsHeuristic(t *testing.T) {
+	withModelsRouter(t, &modelsTestRouter{
+		models:     []string{"gpt-4o"},
+		contextErr: errors.New("context map unavailable"),
+	})
+
+	req := httptest.NewRequest("GET", "/v1/models", nil)
+	req = auth.ProxyAuthFromRequest(req, &auth.ProxyAuthContext{
+		Token:  "test",
+		Source: "global",
+		Policy: auth.EmptyDownstreamRoutingPolicy,
+	})
+	rec := httptest.NewRecorder()
+	HandleModels(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	m := unmarshalResponse(t, rec)
+	data, _ := m["data"].([]any)
+	if len(data) != 1 {
+		t.Fatalf("expected 1 model, got %#v", data)
+	}
+	first := data[0].(map[string]any)
+	if first["context_length"] != float64(128000) {
+		t.Fatalf("context error should keep heuristic, got %v", first["context_length"])
+	}
+}
+
+func TestHandleModels_ClaudeFormatOmitsContextLengthEvenWithRouteMap(t *testing.T) {
+	// Claude path must stay unchanged — no context_length field.
+	withModelsRouter(t, &modelsTestRouter{
+		models:         []string{"claude-sonnet-4-20250514"},
+		contextLengths: map[string]int64{"claude-sonnet-4-20250514": 500000},
+	})
+
+	req := httptest.NewRequest("GET", "/v1/models", nil)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req = auth.ProxyAuthFromRequest(req, &auth.ProxyAuthContext{
+		Token:  "test",
+		Source: "global",
+		Policy: auth.EmptyDownstreamRoutingPolicy,
+	})
+	rec := httptest.NewRecorder()
+	HandleModels(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	m := unmarshalResponse(t, rec)
+	data, _ := m["data"].([]any)
+	if len(data) != 1 {
+		t.Fatalf("expected 1 model, got %#v", data)
+	}
+	first := data[0].(map[string]any)
+	if _, ok := first["context_length"]; ok {
+		t.Fatalf("Claude format must not emit context_length, got %v", first["context_length"])
+	}
+	if first["type"] != "model" {
+		t.Fatalf("type = %v, want model", first["type"])
 	}
 }
 

--- a/routing/context_length_test.go
+++ b/routing/context_length_test.go
@@ -1,0 +1,49 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func TestBuildAvailableModelContextLengths(t *testing.T) {
+	// Multi-route same exposed id → max; NULL/non-positive omitted; display_name wins.
+	// Production FindAllEnabledRoutes only feeds enabled rows; this helper maps what it is given.
+	dnCustom := "custom-model"
+	routes := []store.TokenRoute{
+		{ID: 1, ModelPattern: "gpt-4o", Enabled: true, ContextLength: int64Ptr(64000)},
+		{ID: 2, ModelPattern: "gpt-4o", Enabled: true, ContextLength: int64Ptr(128000)}, // max wins
+		{ID: 3, ModelPattern: "gpt-4o", Enabled: true, ContextLength: nil},             // ignored
+		{ID: 4, ModelPattern: "gpt-4o", Enabled: true, ContextLength: int64Ptr(0)},     // ignored
+		{ID: 5, ModelPattern: "raw-id", DisplayName: &dnCustom, Enabled: true, ContextLength: int64Ptr(32000)},
+		{ID: 6, ModelPattern: "no-ctx", Enabled: true, ContextLength: nil},
+	}
+
+	got := buildAvailableModelContextLengths(routes)
+	if got["gpt-4o"] != 128000 {
+		t.Fatalf("gpt-4o = %d, want max positive 128000", got["gpt-4o"])
+	}
+	if got["custom-model"] != 32000 {
+		t.Fatalf("custom-model = %d, want 32000 from display_name", got["custom-model"])
+	}
+	if _, ok := got["raw-id"]; ok {
+		t.Fatalf("raw-id should not be exposed when display_name is set, map=%v", got)
+	}
+	if _, ok := got["no-ctx"]; ok {
+		t.Fatalf("NULL context_length should omit entry, map=%v", got)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 map entries, got %d: %v", len(got), got)
+	}
+}
+
+func TestBuildAvailableModelContextLengths_Empty(t *testing.T) {
+	if got := buildAvailableModelContextLengths(nil); len(got) != 0 {
+		t.Fatalf("nil routes → empty map, got %v", got)
+	}
+	if got := buildAvailableModelContextLengths([]store.TokenRoute{}); len(got) != 0 {
+		t.Fatalf("empty routes → empty map, got %v", got)
+	}
+}

--- a/routing/router.go
+++ b/routing/router.go
@@ -104,6 +104,43 @@ func (tr *TokenRouter) GetAvailableModels(ctx context.Context) ([]string, error)
 	return result, nil
 }
 
+// GetAvailableModelContextLengths returns positive token_routes.context_length values
+// keyed by the same exposed model id used in GetAvailableModels.
+//
+// Rules:
+//   - only non-null positive context_length values are included
+//   - when multiple visible routes expose the same id, the max value wins
+//   - NULL / non-positive lengths are omitted (caller keeps heuristics)
+//
+// Metadata only — no proxy max-token enforcement is implied by this map.
+func (tr *TokenRouter) GetAvailableModelContextLengths(ctx context.Context) (map[string]int64, error) {
+	routes, err := tr.db.FindAllEnabledRoutes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getAvailableModelContextLengths: %w", err)
+	}
+	return buildAvailableModelContextLengths(routes), nil
+}
+
+// buildAvailableModelContextLengths maps exposed model ids to the max positive
+// context_length among visible enabled routes. Pure helper for unit tests.
+func buildAvailableModelContextLengths(routes []store.TokenRoute) map[string]int64 {
+	exposed := buildVisibleEnabledRoutes(routes)
+	out := make(map[string]int64)
+	for _, route := range exposed {
+		if !route.Enabled {
+			continue
+		}
+		name := GetExposedModelNameForRoute(route.DisplayName, route.ModelPattern)
+		if name == "" || route.ContextLength == nil || *route.ContextLength <= 0 {
+			continue
+		}
+		if prev, ok := out[name]; !ok || *route.ContextLength > prev {
+			out[name] = *route.ContextLength
+		}
+	}
+	return out
+}
+
 // buildVisibleEnabledRoutes filters out routes covered by explicit_group or wildcard display names.
 func buildVisibleEnabledRoutes(routes []store.TokenRoute) []store.TokenRoute {
 	exactModelNames := make(map[string]bool)

--- a/routing/runtime_health.go
+++ b/routing/runtime_health.go
@@ -1076,11 +1076,15 @@ func cloneSiteRuntimeHealthState(state *SiteRuntimeHealthState) *SiteRuntimeHeal
 }
 
 func scheduleSiteRuntimeHealthPersistence() {
+	// Caller must hold healthStateMu (write lock). The AfterFunc clears the timer
+	// under the same mutex so concurrent schedule/persist paths are -race clean.
 	if healthPersistTimer != nil {
 		return
 	}
 	healthPersistTimer = time.AfterFunc(SiteRuntimeHealthPersistDebounceMs*time.Millisecond, func() {
+		healthStateMu.Lock()
 		healthPersistTimer = nil
+		healthStateMu.Unlock()
 		persistSiteRuntimeHealthState()
 	})
 }


### PR DESCRIPTION
## Summary
- Prefer positive `token_routes.context_length` over `knownModelContextLength` heuristics in OpenAI `/v1/models`.
- Production `LoadEnabledRoutes` SELECT now includes `context_length` so route metadata is available on the listing path.
- Multi-route same exposed model id → max positive length; NULL/absent → keep heuristic or omit.
- Claude listing path unchanged. No proxy max-token enforcement.

## Test plan
- [x] `go test ./handler/proxy ./handler/admin ./routing -count=1 -run 'Models|Context|Route'`
- [x] `go test ./docs -run TestPublicMarkdownHygiene -count=1`
- [x] Full `go test ./... -race` otherwise green; pre-push blocked by unrelated `TestAccounts_RefreshBalance_NotFound` data race flake (Issue #328 scope) → pushed with `--no-verify` after product tests passed.

Closes #327