### PR TITLE
docs: residual honesty refresh post v0.8.18 (#334)

### DIFF
--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,8 +1,8 @@
-# Residual next candidates (post v0.8.18)
+# Residual next candidates (post v0.8.18 → v0.8.19)
 
 **Date**: 2026-07-17  
-**Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); refresh trail #318 / #329 + v0.8.18 product  
-**Context**: After Enterprise residual **v0.8.18** (#327 `/v1/models` contextLength wire, #328 admin race isolation, #329 residual honesty).  
+**Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product  
+**Context**: **v0.8.18 shipped** (#327 `/v1/models` contextLength wire, #328 admin race isolation, #329 residual honesty). Active residual wave: **Milestone 28 / v0.8.19** (#334 docs honesty, #335 race regression test, #336 P0-585 cascade residual docs).  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 
@@ -38,14 +38,23 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
 | CTX-520 | Route contextLength admin + models wire | **present-with-residual** (#320 + #327) | Admin CRUD (#320) + OpenAI `/v1/models` prefers positive route `context_length` (max per exposed id) (#327). Residual: no proxy max-token enforce; Claude models path has no context_length field | Optional enforce Milestone only with ACs | Metadata vs enforcement |
 
+## Active wave (Milestone 28 / v0.8.19)
+
+| Issue | Role | Notes |
+|------:|------|-------|
+| [#334](https://github.com/TokenDanceLab/metapi-go/issues/334) | docs | This residual + MASTER flip post v0.8.18 |
+| [#335](https://github.com/TokenDanceLab/metapi-go/issues/335) | test | `scheduleSiteRuntimeHealthPersistence` race regression (follow-up to #328 path) |
+| [#336](https://github.com/TokenDanceLab/metapi-go/issues/336) | docs | P0-585 cascade residual honesty (site/model breaker + load-proof) |
+
 ## Recommended sequencing (v0.8.19+)
 
-1. **Shipped in v0.8.18**: #327 models contextLength wire · #328 admin race isolation · #329 residual honesty.
-2. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
-3. **Optional**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength.
-4. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
-5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+1. **Shipped in v0.8.18**: #327 models contextLength wire · #328 admin race isolation · #329 residual honesty. **CTX-520** stays **present-with-residual** (models metadata wire; no proxy max-token enforce).
+2. **v0.8.19 board**: #334 residual honesty · #335 race regression · #336 P0-585 residual docs — no fake WS/sticky/update-center.
+3. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
+4. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
+5. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
+6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+7. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -62,4 +71,4 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`
-- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329
+- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | closed Milestone 27 (v0.8.18) — next residual wave TBD |
+| Active milestone | **[Milestone 28 — Enterprise residual v0.8.19](https://github.com/TokenDanceLab/metapi-go/milestone/28)** |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -31,12 +31,15 @@
 | Enterprise residual **v0.8.16** | ✅ | #309–#311 · tag v0.8.16 |
 | Enterprise residual **v0.8.17** | ✅ | #318–#320 · tag v0.8.17 |
 | Enterprise residual **v0.8.18** | ✅ | #327–#329 (PRs #330–#332); tag **v0.8.18** |
+| Enterprise residual **v0.8.19** | 🔄 | Milestone 28 · #334–#336 |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| — | — | Board clean after v0.8.18; next residual only with ACs |
+| [#334](https://github.com/TokenDanceLab/metapi-go/issues/334) | docs | residual honesty refresh post v0.8.18 |
+| [#335](https://github.com/TokenDanceLab/metapi-go/issues/335) | test | harden scheduleSiteRuntimeHealthPersistence race |
+| [#336](https://github.com/TokenDanceLab/metapi-go/issues/336) | docs | P0-585 cascade residual honesty (site/model breaker + load-proof) |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -74,9 +77,10 @@ git log --oneline origin/master -10
 
 ## Next Steps
 
-1. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
-2. Optional residual polish: P0-585 load-proof / site-model breaker; P0-555 policy/media/lag; proxy max-token enforce from contextLength.
-3. Keep MASTER slim; docs map at `docs/README.md`.
+1. Close Milestone 28 items: #334 residual honesty · #335 race regression · #336 P0-585 residual docs.
+2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
+3. Optional residual polish later: P0-585 product load-proof / site-model breaker; P0-555 policy/media/lag; proxy max-token enforce from contextLength.
+4. Keep MASTER slim; docs map at `docs/README.md`.
 
 
 ## Governance


### PR DESCRIPTION
## Summary
- Flip residual inventory + MASTER to **Milestone 28 / v0.8.19** after v0.8.18 ship.
- Active board: #334 docs honesty · #335 race regression · #336 P0-585 cascade residual docs.
- Reaffirm **CTX-520** as present-with-residual (models wire #327; no max-token enforce).
- MASTER stays slim (no CHANGELOG dump).

Closes #334

## Test plan
- [x] `go test ./docs -run TestPublicMarkdownHygiene -count=1`