### PR TITLE
test(routing): race-harden healthPersistTimer schedule/persist (#335)

### DIFF
--- a/routing/runtime_health.go
+++ b/routing/runtime_health.go
@@ -128,12 +128,12 @@ type SiteRuntimeHealthState struct {
 	LastFailureAtMs          *int64   `json:"lastFailureAtMs,omitempty"`
 	LastSuccessAtMs          *int64   `json:"lastSuccessAtMs,omitempty"`
 	// Background probe status (issue #114). Soft operator signal; never marks keys expired.
-	LastProbeAtMs     *int64   `json:"lastProbeAtMs,omitempty"`
-	LastProbeStatus   string   `json:"lastProbeStatus,omitempty"` // success | failure | inconclusive
+	LastProbeAtMs      *int64   `json:"lastProbeAtMs,omitempty"`
+	LastProbeStatus    string   `json:"lastProbeStatus,omitempty"` // success | failure | inconclusive
 	LastProbeLatencyMs *float64 `json:"lastProbeLatencyMs,omitempty"`
-	LastProbeError    *string  `json:"lastProbeError,omitempty"`
-	LastProbeModel    string   `json:"lastProbeModel,omitempty"`
-	LastProbeChannelID *int64  `json:"lastProbeChannelId,omitempty"`
+	LastProbeError     *string  `json:"lastProbeError,omitempty"`
+	LastProbeModel     string   `json:"lastProbeModel,omitempty"`
+	LastProbeChannelID *int64   `json:"lastProbeChannelId,omitempty"`
 }
 
 // SiteRuntimeHealthDetails is the resolved health for selection.
@@ -197,6 +197,8 @@ var healthSettingsStore SettingsStore
 
 // SetHealthSettingsStore sets the settings store for health persistence.
 func SetHealthSettingsStore(store SettingsStore) {
+	healthStateMu.Lock()
+	defer healthStateMu.Unlock()
 	healthSettingsStore = store
 }
 
@@ -785,14 +787,14 @@ func RecordSiteRuntimeSuccess(siteID int64, latencyMs float64, modelName *string
 
 // ProbeStatus is the operator-visible background probe outcome for a site.
 type ProbeStatus struct {
-	Status     string   // success | failure | inconclusive | ""
-	AtMs       int64
-	LatencyMs  *float64
-	ErrorText  *string
-	ModelName  string
-	ChannelID  *int64
+	Status      string // success | failure | inconclusive | ""
+	AtMs        int64
+	LatencyMs   *float64
+	ErrorText   *string
+	ModelName   string
+	ChannelID   *int64
 	BreakerOpen bool
-	Multiplier float64
+	Multiplier  float64
 }
 
 // RecordSiteProbeOutcome stamps the last background probe result on site health
@@ -1077,7 +1079,7 @@ func cloneSiteRuntimeHealthState(state *SiteRuntimeHealthState) *SiteRuntimeHeal
 
 func scheduleSiteRuntimeHealthPersistence() {
 	// Caller must hold healthStateMu (write lock). The AfterFunc clears the timer
-	// under the same mutex so concurrent schedule/persist paths are -race clean.
+	// under the same mutex so concurrent schedule/persist/flush paths are -race clean.
 	if healthPersistTimer != nil {
 		return
 	}
@@ -1090,16 +1092,26 @@ func scheduleSiteRuntimeHealthPersistence() {
 }
 
 func persistSiteRuntimeHealthState() {
+	healthStateMu.Lock()
 	if healthSettingsStore == nil {
+		healthStateMu.Unlock()
 		return
 	}
 	if healthPersistInFlight {
+		healthStateMu.Unlock()
 		return
 	}
+	store := healthSettingsStore
 	healthPersistInFlight = true
-	defer func() { healthPersistInFlight = false }()
+	healthStateMu.Unlock()
 
-	// Build payload under read lock, then serialize
+	defer func() {
+		healthStateMu.Lock()
+		healthPersistInFlight = false
+		healthStateMu.Unlock()
+	}()
+
+	// Build payload under read lock, then serialize outside the critical section.
 	healthStateMu.RLock()
 	payload := buildSiteRuntimeHealthPersistencePayload()
 	healthStateMu.RUnlock()
@@ -1108,7 +1120,7 @@ func persistSiteRuntimeHealthState() {
 	if err != nil {
 		return
 	}
-	_ = healthSettingsStore.Set(SiteRuntimeHealthSettingKey, data)
+	_ = store.Set(SiteRuntimeHealthSettingKey, data)
 }
 
 func buildSiteRuntimeHealthPersistencePayload() SiteRuntimeHealthPersistencePayload {
@@ -1248,10 +1260,12 @@ func EnsureSiteRuntimeHealthStateLoaded() error {
 
 // FlushSiteRuntimeHealthPersistence flushes any pending persistence immediately.
 func FlushSiteRuntimeHealthPersistence() {
+	healthStateMu.Lock()
 	if healthPersistTimer != nil {
 		healthPersistTimer.Stop()
 		healthPersistTimer = nil
 	}
+	healthStateMu.Unlock()
 	persistSiteRuntimeHealthState()
 }
 

--- a/routing/runtime_health_test.go
+++ b/routing/runtime_health_test.go
@@ -3,7 +3,9 @@ package routing
 import (
 	"math"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // =============================================================================
@@ -691,6 +693,111 @@ func TestSiteRuntimeHealthConstants(t *testing.T) {
 	}
 	if SiteTransientStreakWindowMs != 5*60*1000 {
 		t.Errorf("expected transient streak window 300000, got %d", SiteTransientStreakWindowMs)
+	}
+}
+
+// memHealthSettingsStore is a tiny concurrent-safe SettingsStore for race tests.
+type memHealthSettingsStore struct {
+	mu   sync.Mutex
+	data map[string]string
+	sets atomic.Int64
+}
+
+func newMemHealthSettingsStore() *memHealthSettingsStore {
+	return &memHealthSettingsStore{data: make(map[string]string)}
+}
+
+func (s *memHealthSettingsStore) Get(key string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.data[key], nil
+}
+
+func (s *memHealthSettingsStore) Set(key, value string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] = value
+	s.sets.Add(1)
+	return nil
+}
+
+// TestScheduleSiteRuntimeHealthPersistenceConcurrentRace is a regression for the
+// healthPersistTimer path fixed under #327: concurrent RecordSiteRuntimeSuccess /
+// schedule + timer fire + Flush must stay -race clean.
+func TestScheduleSiteRuntimeHealthPersistenceConcurrentRace(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	store := newMemHealthSettingsStore()
+	SetHealthSettingsStore(store)
+	t.Cleanup(func() {
+		FlushSiteRuntimeHealthPersistence()
+		SetHealthSettingsStore(nil)
+		ResetSiteRuntimeHealthState()
+	})
+
+	const workers = 8
+	const iterations = 200
+	modelName := "gpt-4o"
+	status500 := 500
+	errText := "bad gateway"
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		siteID := int64(9200 + i)
+		wg.Add(1)
+		go func(siteID int64) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				if j%4 == 0 {
+					RecordSiteRuntimeFailure(siteID, SiteRuntimeFailureContext{
+						Status:    &status500,
+						ErrorText: &errText,
+						ModelName: &modelName,
+					})
+					continue
+				}
+				RecordSiteRuntimeSuccess(siteID, float64(80+j%40), &modelName)
+			}
+		}(siteID)
+	}
+
+	// Concurrent flushes exercise timer Stop/clear against AfterFunc.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			FlushSiteRuntimeHealthPersistence()
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	// Concurrent readers keep public paths hot while the timer fires.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+			for j := 0; j < iterations*2; j++ {
+				siteID := int64(9200 + ((j + offset) % workers))
+				_ = GetSiteRuntimeHealthDetails(siteID, modelName)
+				_ = GetSiteRuntimeHealthMultiplier(siteID)
+				_ = IsSiteRuntimeBreakerOpen(siteID)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	// Allow debounce timer to fire at least once under -race.
+	time.Sleep(time.Duration(SiteRuntimeHealthPersistDebounceMs+200) * time.Millisecond)
+	FlushSiteRuntimeHealthPersistence()
+
+	if store.sets.Load() == 0 {
+		t.Fatal("expected at least one health persistence Set under concurrent schedule")
+	}
+	raw, err := store.Get(SiteRuntimeHealthSettingKey)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if raw == "" {
+		t.Fatal("expected persisted health payload")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `TestScheduleSiteRuntimeHealthPersistenceConcurrentRace` covering concurrent `RecordSiteRuntimeSuccess` / schedule + timer fire + `Flush` under `-race`.
- Product timer clear from #327 is already on master; further harden `SetHealthSettingsStore`, `persistSiteRuntimeHealthState`, and `FlushSiteRuntimeHealthPersistence` so `healthSettingsStore` / `healthPersistInFlight` are mutex-guarded.

## Root cause status
- **#327 already shipped race-safe `healthPersistTimer` clear** under `healthStateMu` in `scheduleSiteRuntimeHealthPersistence` AfterFunc.
- Residual risk: unguarded `healthPersistInFlight` + `healthSettingsStore` reads/writes and `Flush` timer clear without the mutex — closed by this PR so the flake cannot regress silently.

## Verify
```bash
go test ./routing ./app -count=3 -race -timeout 120s
```

Closes #335.