### PR TITLE
docs: residual honesty refresh post v0.8.18 (#334)

### DIFF
--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,8 +1,8 @@
 # Residual next candidates (post v0.8.18)
 
 **Date**: 2026-07-17  
-**Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); refresh trail #318 / #329 + v0.8.18 product  
-**Context**: After Enterprise residual **v0.8.18** (#327 `/v1/models` contextLength wire, #328 admin race isolation, #329 residual honesty).  
+**Issue**: [#334](https://github.com/TokenDanceLab/metapi-go/issues/334) (this refresh); inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290)  
+**Context**: After Enterprise residual **v0.8.18**. Active Milestone **28 / v0.8.19** work: **#334-#336**.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 
@@ -40,12 +40,13 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 
 ## Recommended sequencing (v0.8.19+)
 
-1. **Shipped in v0.8.18**: #327 models contextLength wire · #328 admin race isolation · #329 residual honesty.
-2. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
-3. **Optional**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength.
-4. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
-5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+1. **Active Milestone 28**: #334 residual honesty · #335 healthPersistTimer race regression · #336 P0-585 cascade residual docs.
+2. **Shipped in v0.8.18**: #327 models contextLength wire · #328 admin race isolation · #329 residual honesty.
+3. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
+4. **Optional**: P0-585 load-proof / site-model breaker (docs #336); proxy max-token enforce from contextLength.
+5. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
+6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+7. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -62,4 +63,4 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`
-- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329
+- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | closed Milestone 27 (v0.8.18) — next residual wave TBD |
+| Active milestone | [Milestone 28 — Enterprise residual v0.8.19](https://github.com/TokenDanceLab/metapi-go/milestone/28) |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -28,15 +28,17 @@
 | M-GAP inventory | ✅ | Matrix + backlog; product via residual tags |
 | M-BACKEND / UI / SCHEMA / RELIABILITY | ✅ | Design SSOT in `docs/design/` |
 | M-FEATURE + competitive learn | ✅ | Gap #38–#56 · learn #110–#121 |
-| Enterprise residual **v0.8.16** | ✅ | #309–#311 · tag v0.8.16 |
 | Enterprise residual **v0.8.17** | ✅ | #318–#320 · tag v0.8.17 |
-| Enterprise residual **v0.8.18** | ✅ | #327–#329 (PRs #330–#332); tag **v0.8.18** |
+| Enterprise residual **v0.8.18** | ✅ | #327–#329 · tag **v0.8.18** |
+| Enterprise residual **v0.8.19** | 🔄 | Milestone 28 · #334–#336 |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| — | — | Board clean after v0.8.18; next residual only with ACs |
+| [#334](https://github.com/TokenDanceLab/metapi-go/issues/334) | docs | residual honesty refresh post v0.8.18 |
+| [#335](https://github.com/TokenDanceLab/metapi-go/issues/335) | test | harden scheduleSiteRuntimeHealthPersistence race regression |
+| [#336](https://github.com/TokenDanceLab/metapi-go/issues/336) | docs | P0-585 cascade residual honesty (site/model breaker + load-proof) |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -66,7 +68,7 @@
 ## Quick status commands
 
 ```bash
-gh issue list --state open --limit 20
+gh issue list --milestone "Enterprise residual v0.8.19" --state open
 gh pr list --state open
 gh release view v0.8.18
 git log --oneline origin/master -10
@@ -74,8 +76,8 @@ git log --oneline origin/master -10
 
 ## Next Steps
 
-1. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
-2. Optional residual polish: P0-585 load-proof / site-model breaker; P0-555 policy/media/lag; proxy max-token enforce from contextLength.
+1. Land **v0.8.19** Milestone 28: #334 residual honesty · #335 healthPersist race regression · #336 cascade residual docs.
+2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
 3. Keep MASTER slim; docs map at `docs/README.md`.
 
 


### PR DESCRIPTION
## Summary
- MASTER active milestone → Milestone 28 v0.8.19
- residual-next-candidates points at #334–#336
- Keep MASTER slim

Closes #334.

## Verify
`go test ./docs -run TestPublicMarkdownHygiene -count=1`