### PR TITLE
docs(release): v0.8.19 residual honesty + healthPersist race + cascade honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.19] — 2026-07-17
+
+### Fixed
+- Race-harden `scheduleSiteRuntimeHealthPersistence` / `persistSiteRuntimeHealthState`: timer + in-flight flags under `healthStateMu`; concurrent success/failure regression (#335 / #339)
+
+### Docs / Honesty
+- Residual inventory + MASTER flip for Milestone 28 post v0.8.18 (#334 / #337)
+- P0-585 cascade residual honesty: shipped channel isolation vs site/model breaker + empty-filter fallback + no production multi-channel load proof (`failover-isolation.md`) (#336 / #343)
+
 ## [v0.8.18] — 2026-07-17
 
 ### Added

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,8 +1,8 @@
-# Residual next candidates (post v0.8.18 → v0.8.19)
+# Residual next candidates (post v0.8.19)
 
 **Date**: 2026-07-17  
-**Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product  
-**Context**: **v0.8.18 shipped** (#327 `/v1/models` contextLength wire, #328 admin race isolation, #329 residual honesty). Active residual wave: **Milestone 28 / v0.8.19** (#334 docs honesty, #335 race regression test, #336 P0-585 cascade residual docs).  
+**Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual  
+**Context**: After Enterprise residual **v0.8.19** (#334 residual honesty, #335 healthPersist race, #336 P0-585 cascade honesty). Prior **v0.8.18**: #327 models contextLength wire · #328 admin race isolation · #329 residual honesty.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 
@@ -38,23 +38,14 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
 | CTX-520 | Route contextLength admin + models wire | **present-with-residual** (#320 + #327) | Admin CRUD (#320) + OpenAI `/v1/models` prefers positive route `context_length` (max per exposed id) (#327). Residual: no proxy max-token enforce; Claude models path has no context_length field | Optional enforce Milestone only with ACs | Metadata vs enforcement |
 
-## Active wave (Milestone 28 / v0.8.19)
+## Recommended sequencing (v0.8.20+)
 
-| Issue | Role | Notes |
-|------:|------|-------|
-| [#334](https://github.com/TokenDanceLab/metapi-go/issues/334) | docs | This residual + MASTER flip post v0.8.18 |
-| [#335](https://github.com/TokenDanceLab/metapi-go/issues/335) | test | `scheduleSiteRuntimeHealthPersistence` race regression (follow-up to #328 path) |
-| [#336](https://github.com/TokenDanceLab/metapi-go/issues/336) | docs | P0-585 cascade residual honesty (site/model breaker + load-proof) |
-
-## Recommended sequencing (v0.8.19+)
-
-1. **Shipped in v0.8.18**: #327 models contextLength wire · #328 admin race isolation · #329 residual honesty. **CTX-520** stays **present-with-residual** (models metadata wire; no proxy max-token enforce).
-2. **v0.8.19 board**: #334 residual honesty · #335 race regression · #336 P0-585 residual docs — no fake WS/sticky/update-center.
-3. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
-4. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
-5. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
-6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-7. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+1. **Shipped in v0.8.19**: #334 residual honesty · #335 healthPersist race · #336 P0-585 cascade honesty. Prior v0.8.18: #327 models contextLength · #328 admin race · #329 residual honesty. **CTX-520** stays **present-with-residual** (models metadata wire; no proxy max-token enforce). **P0-585** stays **partial** (channel isolation present; breaker + load-proof residual).
+2. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
+3. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
+4. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
+5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -67,7 +58,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 
 ## Links
 
-- Release: [v0.8.18](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.18) · prior [v0.8.17](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.17)
+- Release: [v0.8.19](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.19) · prior [v0.8.18](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.18)
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -1,11 +1,11 @@
 # MASTER.md — MetAPI Go
 
-**Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery  
-**Mode**: GitHub Issues + Milestones (SDD)  
-**Repo**: https://github.com/TokenDanceLab/metapi-go  
-**Latest release**: **[v0.8.18](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.18)** (2026-07-17)
+**Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery
+**Mode**: GitHub Issues + Milestones (SDD)
+**Repo**: https://github.com/TokenDanceLab/metapi-go
+**Latest release**: **[v0.8.19](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.19)** (2026-07-17)
 
-> 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。  
+> 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。
 > 文档地图：[`docs/README.md`](../README.md)
 
 ## Tracking
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | **[Milestone 28 — Enterprise residual v0.8.19](https://github.com/TokenDanceLab/metapi-go/milestone/28)** |
+| Active milestone | closed Milestone 28 (v0.8.19) — next residual wave TBD |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -30,16 +30,14 @@
 | M-FEATURE + competitive learn | ✅ | Gap #38–#56 · learn #110–#121 |
 | Enterprise residual **v0.8.16** | ✅ | #309–#311 · tag v0.8.16 |
 | Enterprise residual **v0.8.17** | ✅ | #318–#320 · tag v0.8.17 |
-| Enterprise residual **v0.8.18** | ✅ | #327–#329 (PRs #330–#332); tag **v0.8.18** |
-| Enterprise residual **v0.8.19** | 🔄 | Milestone 28 · #334–#336 |
+| Enterprise residual **v0.8.18** | ✅ | #327–#329 · tag v0.8.18 |
+| Enterprise residual **v0.8.19** | ✅ | #334–#336 (PRs #337/#339/#343); tag **v0.8.19** |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| [#334](https://github.com/TokenDanceLab/metapi-go/issues/334) | docs | residual honesty refresh post v0.8.18 |
-| [#335](https://github.com/TokenDanceLab/metapi-go/issues/335) | test | harden scheduleSiteRuntimeHealthPersistence race |
-| [#336](https://github.com/TokenDanceLab/metapi-go/issues/336) | docs | P0-585 cascade residual honesty (site/model breaker + load-proof) |
+| — | — | Board clean after v0.8.19; next residual only with ACs |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -48,6 +46,7 @@
 
 | Tag | Milestone | Highlights |
 |:----|:----------|:-----------|
+| [v0.8.19](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.19) | 28 | residual honesty · healthPersist race · P0-585 cascade honesty |
 | [v0.8.18](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.18) | 27 | models contextLength wire · admin race isolation · residual honesty |
 | [v0.8.17](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.17) | 26 | Residual honesty · failed usage aggregates · route contextLength admin |
 | [v0.8.16](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.16) | 25 | Gemini thought_signature · Responses multi-turn · failure usage logs |
@@ -71,16 +70,15 @@
 ```bash
 gh issue list --state open --limit 20
 gh pr list --state open
-gh release view v0.8.18
+gh release view v0.8.19
 git log --oneline origin/master -10
 ```
 
 ## Next Steps
 
-1. Close Milestone 28 items: #334 residual honesty · #335 race regression · #336 P0-585 residual docs.
-2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
-3. Optional residual polish later: P0-585 product load-proof / site-model breaker; P0-555 policy/media/lag; proxy max-token enforce from contextLength.
-4. Keep MASTER slim; docs map at `docs/README.md`.
+1. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
+2. Optional residual polish: P0-585 load-proof / site-model breaker; P0-555 policy/media/lag; proxy max-token enforce from contextLength.
+3. Keep MASTER slim; docs map at `docs/README.md`.
 
 
 ## Governance


### PR DESCRIPTION
## Summary
- CHANGELOG **v0.8.19**: #335 healthPersist race · #334 residual honesty · #336 P0-585 cascade honesty
- MASTER: latest tag v0.8.19; Milestone 28 closed pointer; board clean
- residual-next-candidates: post v0.8.19 sequencing; Active wave removed

## Test plan
- [x] `go test ./docs -run TestPublicMarkdownHygiene`
- [x] pre-push vet + race suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health-state persistence reliability to prevent conflicting success and failure updates during concurrent activity.

* **Documentation**
  * Added release notes for v0.8.19.
  * Updated residual work, milestone status, release references, and planning guidance to reflect the latest completed work and remaining follow-ups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->