### PR TITLE
docs: residual honesty refresh post v0.8.19 (#346)

### DIFF
--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,8 +1,8 @@
-# Residual next candidates (post v0.8.19)
+# Residual next candidates (post v0.8.19 → v0.8.20)
 
 **Date**: 2026-07-17  
 **Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual  
-**Context**: After Enterprise residual **v0.8.19** (#334 residual honesty, #335 healthPersist race, #336 P0-585 cascade honesty). Prior **v0.8.18**: #327 models contextLength wire · #328 admin race isolation · #329 residual honesty.  
+**Context**: **v0.8.19 shipped** (#334 residual honesty, #335 healthPersist race, #336 P0-585 cascade honesty). Active residual wave: **Milestone 29 / v0.8.20** (#345 stream include_usage, #346 residual honesty).  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 
@@ -38,14 +38,22 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
 | CTX-520 | Route contextLength admin + models wire | **present-with-residual** (#320 + #327) | Admin CRUD (#320) + OpenAI `/v1/models` prefers positive route `context_length` (max per exposed id) (#327). Residual: no proxy max-token enforce; Claude models path has no context_length field | Optional enforce Milestone only with ACs | Metadata vs enforcement |
 
+## Active wave (Milestone 29 / v0.8.20)
+
+| Issue | Role | Notes |
+|------:|------|-------|
+| [#345](https://github.com/TokenDanceLab/metapi-go/issues/345) | proxy | OpenAI chat stream `stream_options.include_usage` inject (P0-555) |
+| [#346](https://github.com/TokenDanceLab/metapi-go/issues/346) | docs | This residual + MASTER flip post v0.8.19 |
+
 ## Recommended sequencing (v0.8.20+)
 
 1. **Shipped in v0.8.19**: #334 residual honesty · #335 healthPersist race · #336 P0-585 cascade honesty. Prior v0.8.18: #327 models contextLength · #328 admin race · #329 residual honesty. **CTX-520** stays **present-with-residual** (models metadata wire; no proxy max-token enforce). **P0-585** stays **partial** (channel isolation present; breaker + load-proof residual).
-2. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
-3. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
-4. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
-5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+2. **v0.8.20 board**: #345 OpenAI chat stream include_usage · #346 residual honesty — no fake WS/sticky/update-center.
+3. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
+4. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
+5. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
+6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+7. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -62,4 +70,4 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`
-- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336
+- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | closed Milestone 28 (v0.8.19) — next residual wave TBD |
+| Active milestone | **[Milestone 29 — Enterprise residual v0.8.20](https://github.com/TokenDanceLab/metapi-go/milestone/29)** |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -32,12 +32,14 @@
 | Enterprise residual **v0.8.17** | ✅ | #318–#320 · tag v0.8.17 |
 | Enterprise residual **v0.8.18** | ✅ | #327–#329 · tag v0.8.18 |
 | Enterprise residual **v0.8.19** | ✅ | #334–#336 (PRs #337/#339/#343); tag **v0.8.19** |
+| Enterprise residual **v0.8.20** | 🔄 | Milestone 29 · #345–#346 |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| — | — | Board clean after v0.8.19; next residual only with ACs |
+| [#345](https://github.com/TokenDanceLab/metapi-go/issues/345) | proxy | OpenAI chat stream `stream_options.include_usage` inject (P0-555 residual) |
+| [#346](https://github.com/TokenDanceLab/metapi-go/issues/346) | docs | residual honesty refresh post v0.8.19 |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -76,9 +78,10 @@ git log --oneline origin/master -10
 
 ## Next Steps
 
-1. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
-2. Optional residual polish: P0-585 load-proof / site-model breaker; P0-555 policy/media/lag; proxy max-token enforce from contextLength.
-3. Keep MASTER slim; docs map at `docs/README.md`.
+1. Close Milestone 29: #345 stream include_usage · #346 residual honesty.
+2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
+3. Optional later: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
+4. Keep MASTER slim; docs map at `docs/README.md`.
 
 
 ## Governance


### PR DESCRIPTION
## Summary
- MASTER: active Milestone 29 (v0.8.20); Active work #345–#346
- residual-next-candidates: Active wave + sequencing for v0.8.20

Closes #346

## Test plan
- [x] `go test ./docs -run TestPublicMarkdownHygiene`
- [x] pre-push vet + race suite