### PR TITLE
docs(release): v0.8.20 stream include_usage + residual honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.20] — 2026-07-17
+
+### Fixed
+- OpenAI-compatible chat/completions stream: inject/merge `stream_options.include_usage=true` on upstream body for final SSE usage chunks; skip codex/sub2api and non-chat paths (P0-555 residual) (#345 / #347)
+
+### Docs / Honesty
+- Residual inventory + MASTER for Milestone 29 post v0.8.19 (#346 / #348)
+- P0-555 evidence: stream_options policy addressed for chat stream; residual provider-ignore / media zeros / multi-instance lag / orphan site join
+
 ## [v0.8.19] — 2026-07-17
 
 ### Fixed

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,4 +1,4 @@
-# Residual next candidates (post v0.8.19 → v0.8.20)
+# Residual next candidates (post v0.8.20)
 
 **Date**: 2026-07-17  
 **Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual  
@@ -38,22 +38,14 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
 | CTX-520 | Route contextLength admin + models wire | **present-with-residual** (#320 + #327) | Admin CRUD (#320) + OpenAI `/v1/models` prefers positive route `context_length` (max per exposed id) (#327). Residual: no proxy max-token enforce; Claude models path has no context_length field | Optional enforce Milestone only with ACs | Metadata vs enforcement |
 
-## Active wave (Milestone 29 / v0.8.20)
+## Recommended sequencing (v0.8.21+)
 
-| Issue | Role | Notes |
-|------:|------|-------|
-| [#345](https://github.com/TokenDanceLab/metapi-go/issues/345) | proxy | OpenAI chat stream `stream_options.include_usage` inject (P0-555) |
-| [#346](https://github.com/TokenDanceLab/metapi-go/issues/346) | docs | This residual + MASTER flip post v0.8.19 |
-
-## Recommended sequencing (v0.8.20+)
-
-1. **Shipped in v0.8.19**: #334 residual honesty · #335 healthPersist race · #336 P0-585 cascade honesty. Prior v0.8.18: #327 models contextLength · #328 admin race · #329 residual honesty. **CTX-520** stays **present-with-residual** (models metadata wire; no proxy max-token enforce). **P0-585** stays **partial** (channel isolation present; breaker + load-proof residual).
-2. **v0.8.20 board**: #345 OpenAI chat stream include_usage · #346 residual honesty — no fake WS/sticky/update-center.
-3. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
-4. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
-5. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
-6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-7. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+1. **Shipped in v0.8.20**: #345 OpenAI chat stream `stream_options.include_usage` · #346 residual honesty. Prior v0.8.19: #334–#336. **P0-555** stays **present-with-residual** (chat stream policy wired; media/lag/orphan residual). **CTX-520** / **P0-585** unchanged residual notes.
+2. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
+3. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
+4. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
+5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -66,7 +58,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 
 ## Links
 
-- Release: [v0.8.19](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.19) · prior [v0.8.18](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.18)
+- Release: [v0.8.20](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.20) · prior [v0.8.19](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.19)
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -3,7 +3,7 @@
 **Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery
 **Mode**: GitHub Issues + Milestones (SDD)
 **Repo**: https://github.com/TokenDanceLab/metapi-go
-**Latest release**: **[v0.8.19](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.19)** (2026-07-17)
+**Latest release**: **[v0.8.20](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.20)** (2026-07-17)
 
 > 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。
 > 文档地图：[`docs/README.md`](../README.md)
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | **[Milestone 29 — Enterprise residual v0.8.20](https://github.com/TokenDanceLab/metapi-go/milestone/29)** |
+| Active milestone | closed Milestone 29 (v0.8.20) — next residual wave TBD |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -31,15 +31,14 @@
 | Enterprise residual **v0.8.16** | ✅ | #309–#311 · tag v0.8.16 |
 | Enterprise residual **v0.8.17** | ✅ | #318–#320 · tag v0.8.17 |
 | Enterprise residual **v0.8.18** | ✅ | #327–#329 · tag v0.8.18 |
-| Enterprise residual **v0.8.19** | ✅ | #334–#336 (PRs #337/#339/#343); tag **v0.8.19** |
-| Enterprise residual **v0.8.20** | 🔄 | Milestone 29 · #345–#346 |
+| Enterprise residual **v0.8.19** | ✅ | #334–#336 · tag v0.8.19 |
+| Enterprise residual **v0.8.20** | ✅ | #345–#346 (PRs #347/#348); tag **v0.8.20** |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| [#345](https://github.com/TokenDanceLab/metapi-go/issues/345) | proxy | OpenAI chat stream `stream_options.include_usage` inject (P0-555 residual) |
-| [#346](https://github.com/TokenDanceLab/metapi-go/issues/346) | docs | residual honesty refresh post v0.8.19 |
+| — | — | Board clean after v0.8.20; next residual only with ACs |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -48,12 +47,12 @@
 
 | Tag | Milestone | Highlights |
 |:----|:----------|:-----------|
+| [v0.8.20](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.20) | 29 | stream include_usage · residual honesty |
 | [v0.8.19](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.19) | 28 | residual honesty · healthPersist race · P0-585 cascade honesty |
 | [v0.8.18](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.18) | 27 | models contextLength wire · admin race isolation · residual honesty |
 | [v0.8.17](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.17) | 26 | Residual honesty · failed usage aggregates · route contextLength admin |
 | [v0.8.16](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.16) | 25 | Gemini thought_signature · Responses multi-turn · failure usage logs |
-| [v0.8.15](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.15) | 24 | Expired-mark guard · cascade isolation · stream usage partial |
-| older | 11–23 | See GitHub Releases / `CHANGELOG.md` |
+| older | 11–24 | See GitHub Releases / `CHANGELOG.md` |
 
 ## Architecture entry points
 
@@ -72,16 +71,15 @@
 ```bash
 gh issue list --state open --limit 20
 gh pr list --state open
-gh release view v0.8.19
+gh release view v0.8.20
 git log --oneline origin/master -10
 ```
 
 ## Next Steps
 
-1. Close Milestone 29: #345 stream include_usage · #346 residual honesty.
-2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
-3. Optional later: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
-4. Keep MASTER slim; docs map at `docs/README.md`.
+1. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
+2. Optional residual polish: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
+3. Keep MASTER slim; docs map at `docs/README.md`.
 
 
 ## Governance


### PR DESCRIPTION
## Summary
- CHANGELOG **v0.8.20**: #345 stream include_usage · #346 residual honesty
- MASTER: latest tag v0.8.20; Milestone 29 closed pointer
- residual-next-candidates: post v0.8.20 sequencing

## Test plan
- [x] docs hygiene + pre-push race suite