### PR TITLE
docs: residual honesty refresh post v0.8.20

### DIFF
--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,8 +1,8 @@
-# Residual next candidates (post v0.8.20)
+# Residual next candidates (post v0.8.20 → v0.8.21)
 
 **Date**: 2026-07-17  
 **Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual  
-**Context**: **v0.8.19 shipped** (#334 residual honesty, #335 healthPersist race, #336 P0-585 cascade honesty). Active residual wave: **Milestone 29 / v0.8.20** (#345 stream include_usage, #346 residual honesty).  
+**Context**: **v0.8.20 shipped** (#345 stream include_usage, #346 residual honesty). Active residual wave: **Milestone 30 / v0.8.21** (#350 completions include_usage, #351 residual honesty).  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 
@@ -38,14 +38,22 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
 | CTX-520 | Route contextLength admin + models wire | **present-with-residual** (#320 + #327) | Admin CRUD (#320) + OpenAI `/v1/models` prefers positive route `context_length` (max per exposed id) (#327). Residual: no proxy max-token enforce; Claude models path has no context_length field | Optional enforce Milestone only with ACs | Metadata vs enforcement |
 
+## Active wave (Milestone 30 / v0.8.21)
+
+| Issue | Role | Notes |
+|------:|------|-------|
+| [#350](https://github.com/TokenDanceLab/metapi-go/issues/350) | proxy | legacy `/v1/completions` stream `include_usage` |
+| [#351](https://github.com/TokenDanceLab/metapi-go/issues/351) | docs | This residual + MASTER flip post v0.8.20 |
+
 ## Recommended sequencing (v0.8.21+)
 
 1. **Shipped in v0.8.20**: #345 OpenAI chat stream `stream_options.include_usage` · #346 residual honesty. Prior v0.8.19: #334–#336. **P0-555** stays **present-with-residual** (chat stream policy wired; media/lag/orphan residual). **CTX-520** / **P0-585** unchanged residual notes.
-2. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
-3. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
-4. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
-5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+2. **v0.8.21 board**: #350 legacy completions include_usage · #351 residual honesty — no fake WS/sticky/update-center.
+3. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
+4. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
+5. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
+6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+7. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -62,4 +70,4 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`
-- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346
+- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346, #350, #351

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | closed Milestone 29 (v0.8.20) — next residual wave TBD |
+| Active milestone | **[Milestone 30 — Enterprise residual v0.8.21](https://github.com/TokenDanceLab/metapi-go/milestone/30)** |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -33,12 +33,14 @@
 | Enterprise residual **v0.8.18** | ✅ | #327–#329 · tag v0.8.18 |
 | Enterprise residual **v0.8.19** | ✅ | #334–#336 · tag v0.8.19 |
 | Enterprise residual **v0.8.20** | ✅ | #345–#346 (PRs #347/#348); tag **v0.8.20** |
+| Enterprise residual **v0.8.21** | 🔄 | Milestone 30 · #350–#351 |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| — | — | Board clean after v0.8.20; next residual only with ACs |
+| [#350](https://github.com/TokenDanceLab/metapi-go/issues/350) | proxy | legacy `/v1/completions` stream include_usage (P0-555 follow-up) |
+| [#351](https://github.com/TokenDanceLab/metapi-go/issues/351) | docs | residual honesty refresh post v0.8.20 |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -77,9 +79,10 @@ git log --oneline origin/master -10
 
 ## Next Steps
 
-1. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
-2. Optional residual polish: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
-3. Keep MASTER slim; docs map at `docs/README.md`.
+1. Close Milestone 30: #350 completions include_usage · #351 residual honesty.
+2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
+3. Optional later: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
+4. Keep MASTER slim; docs map at `docs/README.md`.
 
 
 ## Governance


### PR DESCRIPTION
## Summary
- MASTER: Active Milestone 30 (v0.8.21); latest release still v0.8.20; active work #350/#351; status table v0.8.20 ✅ / v0.8.21 🔄
- residual-next-candidates: post v0.8.20 → v0.8.21 context; active wave table; sequencing + related issues #350/#351
- Docs only — no product Go code

Closes #351

## Test plan
- [x] `go test ./docs -run TestPublicMarkdownHygiene -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release tracking to reflect the completion of v0.8.20 and the active v0.8.21 milestone.
  * Added current milestone status, sequencing guidance, and next steps.
  * Documented outstanding work related to legacy completion streaming and residual tracking updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->