### PR TITLE
docs(release): v0.8.21 completions include_usage + residual honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.21] — 2026-07-17
+
+### Fixed
+- OpenAI legacy `/v1/completions` stream: same `stream_options.include_usage=true` inject as chat (path helper; still skips codex/sub2api and non-OpenAI stream_options paths) (#350 / #352)
+
+### Docs / Honesty
+- Residual inventory + MASTER for Milestone 30 post v0.8.20 (#351 / #353)
+- P0-555: chat + legacy completions stream policy wired; residual provider-ignore / media zeros / multi-instance lag / orphan site join
+
 ## [v0.8.20] — 2026-07-17
 
 ### Fixed

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,8 +1,8 @@
-# Residual next candidates (post v0.8.20 → v0.8.21)
+# Residual next candidates (post v0.8.21)
 
 **Date**: 2026-07-17  
 **Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual  
-**Context**: **v0.8.20 shipped** (#345 stream include_usage, #346 residual honesty). Active residual wave: **Milestone 30 / v0.8.21** (#350 completions include_usage, #351 residual honesty).  
+**Context**: After Enterprise residual **v0.8.21** (#350 completions include_usage, #351 residual honesty). Prior **v0.8.20**: #345 chat stream include_usage · #346 residual honesty.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 
@@ -38,22 +38,14 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
 | CTX-520 | Route contextLength admin + models wire | **present-with-residual** (#320 + #327) | Admin CRUD (#320) + OpenAI `/v1/models` prefers positive route `context_length` (max per exposed id) (#327). Residual: no proxy max-token enforce; Claude models path has no context_length field | Optional enforce Milestone only with ACs | Metadata vs enforcement |
 
-## Active wave (Milestone 30 / v0.8.21)
+## Recommended sequencing (v0.8.22+)
 
-| Issue | Role | Notes |
-|------:|------|-------|
-| [#350](https://github.com/TokenDanceLab/metapi-go/issues/350) | proxy | legacy `/v1/completions` stream `include_usage` |
-| [#351](https://github.com/TokenDanceLab/metapi-go/issues/351) | docs | This residual + MASTER flip post v0.8.20 |
-
-## Recommended sequencing (v0.8.21+)
-
-1. **Shipped in v0.8.20**: #345 OpenAI chat stream `stream_options.include_usage` · #346 residual honesty. Prior v0.8.19: #334–#336. **P0-555** stays **present-with-residual** (chat stream policy wired; media/lag/orphan residual). **CTX-520** / **P0-585** unchanged residual notes.
-2. **v0.8.21 board**: #350 legacy completions include_usage · #351 residual honesty — no fake WS/sticky/update-center.
-3. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
-4. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
-5. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
-6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-7. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+1. **Shipped in v0.8.21**: #350 legacy completions `stream_options.include_usage` · #351 residual honesty. Prior v0.8.20: #345 chat stream include_usage · #346 residual honesty. **P0-555** stays **present-with-residual** (chat+completions stream policy wired; media/lag/orphan residual). **CTX-520** / **P0-585** unchanged residual notes.
+2. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
+3. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
+4. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
+5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -66,7 +58,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 
 ## Links
 
-- Release: [v0.8.20](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.20) · prior [v0.8.19](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.19)
+- Release: [v0.8.21](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.21) · prior [v0.8.20](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.20)
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -3,7 +3,7 @@
 **Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery
 **Mode**: GitHub Issues + Milestones (SDD)
 **Repo**: https://github.com/TokenDanceLab/metapi-go
-**Latest release**: **[v0.8.20](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.20)** (2026-07-17)
+**Latest release**: **[v0.8.21](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.21)** (2026-07-17)
 
 > 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。
 > 文档地图：[`docs/README.md`](../README.md)
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | **[Milestone 30 — Enterprise residual v0.8.21](https://github.com/TokenDanceLab/metapi-go/milestone/30)** |
+| Active milestone | closed Milestone 30 (v0.8.21) — next residual wave TBD |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -28,19 +28,16 @@
 | M-GAP inventory | ✅ | Matrix + backlog; product via residual tags |
 | M-BACKEND / UI / SCHEMA / RELIABILITY | ✅ | Design SSOT in `docs/design/` |
 | M-FEATURE + competitive learn | ✅ | Gap #38–#56 · learn #110–#121 |
-| Enterprise residual **v0.8.16** | ✅ | #309–#311 · tag v0.8.16 |
-| Enterprise residual **v0.8.17** | ✅ | #318–#320 · tag v0.8.17 |
 | Enterprise residual **v0.8.18** | ✅ | #327–#329 · tag v0.8.18 |
 | Enterprise residual **v0.8.19** | ✅ | #334–#336 · tag v0.8.19 |
-| Enterprise residual **v0.8.20** | ✅ | #345–#346 (PRs #347/#348); tag **v0.8.20** |
-| Enterprise residual **v0.8.21** | 🔄 | Milestone 30 · #350–#351 |
+| Enterprise residual **v0.8.20** | ✅ | #345–#346 · tag v0.8.20 |
+| Enterprise residual **v0.8.21** | ✅ | #350–#351 (PRs #352/#353); tag **v0.8.21** |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| [#350](https://github.com/TokenDanceLab/metapi-go/issues/350) | proxy | legacy `/v1/completions` stream include_usage (P0-555 follow-up) |
-| [#351](https://github.com/TokenDanceLab/metapi-go/issues/351) | docs | residual honesty refresh post v0.8.20 |
+| — | — | Board clean after v0.8.21; next residual only with ACs |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -49,12 +46,11 @@
 
 | Tag | Milestone | Highlights |
 |:----|:----------|:-----------|
-| [v0.8.20](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.20) | 29 | stream include_usage · residual honesty |
+| [v0.8.21](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.21) | 30 | completions include_usage · residual honesty |
+| [v0.8.20](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.20) | 29 | chat stream include_usage · residual honesty |
 | [v0.8.19](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.19) | 28 | residual honesty · healthPersist race · P0-585 cascade honesty |
 | [v0.8.18](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.18) | 27 | models contextLength wire · admin race isolation · residual honesty |
-| [v0.8.17](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.17) | 26 | Residual honesty · failed usage aggregates · route contextLength admin |
-| [v0.8.16](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.16) | 25 | Gemini thought_signature · Responses multi-turn · failure usage logs |
-| older | 11–24 | See GitHub Releases / `CHANGELOG.md` |
+| older | 11–26 | See GitHub Releases / `CHANGELOG.md` |
 
 ## Architecture entry points
 
@@ -73,16 +69,15 @@
 ```bash
 gh issue list --state open --limit 20
 gh pr list --state open
-gh release view v0.8.20
+gh release view v0.8.21
 git log --oneline origin/master -10
 ```
 
 ## Next Steps
 
-1. Close Milestone 30: #350 completions include_usage · #351 residual honesty.
-2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
-3. Optional later: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
-4. Keep MASTER slim; docs map at `docs/README.md`.
+1. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
+2. Optional residual polish: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
+3. Keep MASTER slim; docs map at `docs/README.md`.
 
 
 ## Governance


### PR DESCRIPTION
## Summary
- CHANGELOG **v0.8.21**: #350 completions include_usage · #351 residual honesty
- MASTER: latest tag v0.8.21; Milestone 30 closed pointer
- residual-next-candidates: post v0.8.21 sequencing

## Test plan
- [x] docs hygiene + pre-push race suite