### PR TITLE
fix(routing): weighted soft-filter empty tries next priority (#358)

### DIFF
--- a/docs/analysis/failover-isolation.md
+++ b/docs/analysis/failover-isolation.md
@@ -23,7 +23,7 @@ Upstream gap **#585** (“one channel failure cascades to other channels”) is 
 | **Shipped — selection soft filters** | Recent-failure + breaker filters prefer healthy candidates (all strategies) | **present** (R1 RR parity) |
 | **Residual — site/model breaker** | Transient streak ≥3 opens site or site+model breaker → **all** channels on that scope soft-filtered | **intentional policy**, not a “sibling poison bug”; still a fleet-level cascade pressure |
 | **Residual — credential usage-limit scope** | Short-window usage limit cools **all channels sharing the credential** | **intentional** shared-key truth |
-| **Residual — empty-filter fallback** | If every candidate is filtered, filters return the **full set** | Starvation prevention; can re-expose recently failed channels |
+| **Residual — empty-filter fallback** | Soft filters still return the **full set** when healthy is empty (**global** starvation guard). Weighted priority layers now use **strict** soft-filter demotion first (`softFilterCandidatesStrict` / `selectWeightedAcrossPriorityLayers`): a soft-empty higher priority skips to the next priority; full-set fallback applies only after **all** layers are soft-empty (**#358**) | Starvation prevention without pinning on a broken priority-0 layer; residual remains for global full-set re-exposure |
 | **Residual — production multi-channel load proof** | No e2e / production-shaped load evidence that systemic poison stays contained under failure storms | **open** — unit/integration only |
 
 **Do not claim:** “#585 is fully present” or “site-wide cascade is eliminated.”  
@@ -57,6 +57,8 @@ All three strategies now share the same isolation order after eligibility:
 4. Strategy pick (weighted / RR / stable-first)
 
 > R1 fix: round-robin previously skipped step 3, so a single RR failure (no `cooldownUntil` yet) could be reselected immediately and starve healthy siblings. RR now applies the same recent-failure filter as weighted and stable-first.
+>
+> **#358 weighted priority layers:** per-layer soft filters are **strict** (no full-set pin). Soft-empty higher priority demotes to the next priority; only if every layer is soft-empty does the global full-set fallback apply.
 
 ### `RecordFailure` write scope
 
@@ -104,7 +106,7 @@ These are **not** bugs of “mark sibling failed,” but residual fleet-level pr
 |:---------|:---------|:----|
 | Site/model breaker | 3 transient fails open breaker → **all** channels on that site/model filtered via `FilterSiteRuntimeBrokenCandidatesByModel*` | Intentional systemic protection; can look like cascade under multi-channel storms on one site |
 | Credential-scoped usage limit | Short window cools **all channels sharing the credential** | Shared quota / key truth — not peer-channel poison, still multi-channel impact |
-| Empty-filter fallback | If every candidate is recently-failed or breaker-open, filters return the **full set** | Starvation prevention; may reselect cooled channels when the fleet is degraded |
+| Empty-filter fallback | Global filters return the **full set** when healthy is empty; weighted layers demote soft-empty priorities before that global fallback (**#358**) | Global starvation prevention still reselects cooled channels when the whole fleet is degraded |
 | Production multi-channel load proof | Load-shaped systemic poison not proven e2e under production traffic | Unit/integration isolation proven only; gap matrix #585 residual / inventory P0-585 |
 
 ### What would close (or further shrink) residual
@@ -113,7 +115,7 @@ These are **not** bugs of “mark sibling failed,” but residual fleet-level pr
 |:--------------|:-----------------------------------------------|
 | Site/model breaker “cascade look” | Product AC if breaker thresholds / model scope need operator knobs or different policy — **not** docs-only |
 | Production multi-channel load proof | Load-test or production evidence plan with multi-channel same-site failure storms; metrics that sibling channels stay eligible while breakers stay closed for single-channel noise |
-| Empty-filter fallback | Explicit product decision only — changing fallback risks hard outage when all candidates are dirty |
+| Empty-filter fallback (global) | Removing global full-set fallback risks hard outage when all candidates are dirty; weighted per-layer demotion is shipped (**#358**) |
 
 ## Tests
 
@@ -130,6 +132,8 @@ These are **not** bugs of “mark sibling failed,” but residual fleet-level pr
   - `TestSelectionFilter_PrefersHealthySiblingAfterOneFailure` (weighted / RR / stable_first)
   - `TestSiteBreaker_DoesNotOpenOnSingleFailureAndDoesNotPoisonOtherSites`
   - `TestRoundRobinFilterStack_MatchesWeightedRecentFailurePolicy`
+  - `TestWeightedSoftFilter_EmptyPriorityDemotesToNext` (**#358**)
+  - `TestWeightedSoftFilter_AllLayersSoftEmptyAllowsGlobalFallback` (**#358**)
 - Existing: `routing/cooldown_test.go`, `routing/runtime_health_test.go`, `routing/algorithm_test.go` (partial/all breaker open)
 
 ## Non-goals (R1 / #299 / #336)

--- a/routing/failure_isolation_test.go
+++ b/routing/failure_isolation_test.go
@@ -38,7 +38,7 @@ type isolationDB struct {
 	// lastCooldownUpdate records the most recent UpdateChannelCooldownFields call
 	lastCooldownIDs     []int64
 	lastCooldownUpdates map[string]interface{}
-	cooldownCalls        int
+	cooldownCalls       int
 
 	// lastMemberUpdate records OAuth member cooldown writes
 	lastMemberID      int64
@@ -48,7 +48,7 @@ type isolationDB struct {
 
 func newIsolationDB() *isolationDB {
 	return &isolationDB{
-		channels:        make(map[int64]*struct {
+		channels: make(map[int64]*struct {
 			Channel store.RouteChannel
 			Account store.Account
 			Route   store.TokenRoute
@@ -596,10 +596,10 @@ func TestSelectionFilter_PrefersHealthySiblingAfterOneFailure(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		strategy       RouteRoutingStrategy
-		rows           []cand
-		wantIDs        []int64
+		name            string
+		strategy        RouteRoutingStrategy
+		rows            []cand
+		wantIDs         []int64
 		wantFallbackAll bool
 	}{
 		{
@@ -816,4 +816,104 @@ func channelIDOrNil(c *RouteChannelCandidate) interface{} {
 		return nil
 	}
 	return c.Channel.ID
+}
+
+// TestWeightedSoftFilter_EmptyPriorityDemotesToNext covers #358:
+// when every priority-0 candidate is soft-unhealthy (recent-fail / breaker),
+// weighted selection must try the next priority instead of pinning on the
+// unfiltered full priority-0 layer. Healthy priority-1 wins.
+func TestWeightedSoftFilter_EmptyPriorityDemotesToNext(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	siteRuntimeHealthLoaded = true
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	nowMs := time.Now().UnixMilli()
+	recentISO := time.UnixMilli(nowMs - 2_000).UTC().Format(time.RFC3339)
+	model := "gpt-test"
+	resolve := staticModel(model)
+
+	// Priority 0: two recently-failed channels (would previously pin via full-set fallback)
+	c0a := buildTestCandidate(1, 10, 101, 10, 0, 100, 1, 50.0, 1.0, nil, 50.0, &model)
+	c0a.Channel.FailCount = 2
+	c0a.Channel.LastFailAt = &recentISO
+	c0b := buildTestCandidate(2, 11, 102, 10, 0, 100, 1, 50.0, 1.0, nil, 50.0, &model)
+	c0b.Channel.FailCount = 3
+	c0b.Channel.LastFailAt = &recentISO
+	// Priority 1: healthy channel
+	c1 := buildTestCandidate(3, 20, 201, 10, 1, 100, 0, 50.0, 1.0, nil, 50.0, &model)
+
+	available := []RouteChannelCandidate{c0a, c0b, c1}
+
+	// Strict filter on prio 0 alone must be empty (no full-set pin).
+	strict0 := softFilterCandidatesStrict([]RouteChannelCandidate{c0a, c0b}, resolve, nowMs, 3600)
+	if len(strict0) != 0 {
+		t.Fatalf("expected strict soft-filter of failed prio-0 layer to be empty, got %d", len(strict0))
+	}
+	// Legacy full-set filter would return both failed channels.
+	legacy0 := FilterRecentlyFailedCandidates([]RouteChannelCandidate{c0a, c0b},
+		func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
+		nowMs, 3600)
+	if len(legacy0) != 2 {
+		t.Fatalf("expected legacy filter full-set fallback size 2, got %d", len(legacy0))
+	}
+
+	selected := selectWeightedAcrossPriorityLayers(available, resolve, nowMs, 3600,
+		func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+			if len(pool) == 0 {
+				return nil
+			}
+			// Deterministic pick: lowest channel ID (avoids rand flakiness).
+			best := &pool[0]
+			for i := range pool {
+				if pool[i].Channel.ID < best.Channel.ID {
+					best = &pool[i]
+				}
+			}
+			return best
+		})
+	if selected == nil {
+		t.Fatal("expected selection from healthy priority-1 layer")
+	}
+	if selected.Channel.ID != 3 {
+		t.Fatalf("expected priority-1 channel 3, got channel %d priority %d",
+			selected.Channel.ID, selected.Channel.Priority)
+	}
+	if selected.Channel.Priority != 1 {
+		t.Fatalf("expected priority 1, got %d", selected.Channel.Priority)
+	}
+}
+
+// TestWeightedSoftFilter_AllLayersSoftEmptyAllowsGlobalFallback covers #358 AC2:
+// when every priority layer is soft-empty, selection still returns a candidate
+// via global full-set fallback instead of hard-failing.
+func TestWeightedSoftFilter_AllLayersSoftEmptyAllowsGlobalFallback(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	siteRuntimeHealthLoaded = true
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	nowMs := time.Now().UnixMilli()
+	recentISO := time.UnixMilli(nowMs - 1_000).UTC().Format(time.RFC3339)
+	model := "gpt-test"
+	resolve := staticModel(model)
+
+	c0 := buildTestCandidate(1, 10, 101, 10, 0, 100, 1, 50.0, 1.0, nil, 50.0, &model)
+	c0.Channel.FailCount = 2
+	c0.Channel.LastFailAt = &recentISO
+	c1 := buildTestCandidate(2, 20, 201, 10, 1, 100, 1, 50.0, 1.0, nil, 50.0, &model)
+	c1.Channel.FailCount = 2
+	c1.Channel.LastFailAt = &recentISO
+
+	selected := selectWeightedAcrossPriorityLayers([]RouteChannelCandidate{c0, c1}, resolve, nowMs, 3600,
+		func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+			if len(pool) == 0 {
+				return nil
+			}
+			return &pool[0]
+		})
+	if selected == nil {
+		t.Fatal("expected global fallback selection when all layers soft-empty")
+	}
+	if selected.Channel.ID != 1 && selected.Channel.ID != 2 {
+		t.Fatalf("unexpected selected channel %d", selected.Channel.ID)
+	}
 }

--- a/routing/selector.go
+++ b/routing/selector.go
@@ -73,9 +73,9 @@ type ChannelSelectorDB interface {
 
 	// Runtime health
 	LoadRuntimeHealthChannelRows(ctx context.Context, channelIDs []int64) ([]struct {
-		SiteID             int64
-		SourceModel        *string
-		RouteModelPattern  string
+		SiteID            int64
+		SourceModel       *string
+		RouteModelPattern string
 	}, error)
 
 	// Clear channel failure states
@@ -84,13 +84,13 @@ type ChannelSelectorDB interface {
 
 // ChannelSelector implements selectChannel, selectNextChannel, selectPreferredChannel.
 type ChannelSelector struct {
-	db                ChannelSelectorDB
-	cache             *RouteCache
-	configuredMaxSec   int
-	downstreamPolicy   DownstreamRoutingPolicy
-	routingWeights    RoutingWeightsConfig
-	pricingFn         func(siteID, accountID int64, modelName string) *float64
-	fallbackUnitCost  float64
+	db                  ChannelSelectorDB
+	cache               *RouteCache
+	configuredMaxSec    int
+	downstreamPolicy    DownstreamRoutingPolicy
+	routingWeights      RoutingWeightsConfig
+	pricingFn           func(siteID, accountID int64, modelName string) *float64
+	fallbackUnitCost    float64
 	channelLoadProvider ChannelLoadSnapshotProvider
 }
 
@@ -105,12 +105,12 @@ func NewChannelSelector(
 	channelLoadProvider ChannelLoadSnapshotProvider,
 ) *ChannelSelector {
 	return &ChannelSelector{
-		db:                db,
-		cache:             cache,
-		configuredMaxSec:   configuredMaxSec,
-		routingWeights:    routingWeights,
-		pricingFn:         pricingFn,
-		fallbackUnitCost:  fallbackUnitCost,
+		db:                  db,
+		cache:               cache,
+		configuredMaxSec:    configuredMaxSec,
+		routingWeights:      routingWeights,
+		pricingFn:           pricingFn,
+		fallbackUnitCost:    fallbackUnitCost,
 		channelLoadProvider: channelLoadProvider,
 	}
 }
@@ -354,17 +354,49 @@ func (s *ChannelSelector) selectFromMatch(
 			recordSelection, "", "", false, excludeChannelIDs, nowISO, nowMs)
 	}
 
-	// Weighted: priority layers
+	// Weighted: priority layers (#358 soft-filter demotion).
+	selected := selectWeightedAcrossPriorityLayers(
+		available,
+		resolveModel,
+		nowMs,
+		s.configuredMaxSec,
+		func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+			return s.weightedRandomSelect(pool, resolveModel, policy)
+		},
+	)
+	if selected == nil {
+		return nil, nil
+	}
+	return s.finalizeDispatch(ctx, selected, match, requestedModel, mappedModel, policy,
+		recordSelection, "", "", false, excludeChannelIDs, nowISO, nowMs)
+}
+
+// selectWeightedAcrossPriorityLayers walks priority layers low→high. Per-layer soft
+// filters use softFilterCandidatesStrict (no full-set pin). If a layer is entirely
+// soft-empty, try the next priority. Only when ALL layers are soft-empty does the
+// global FilterRecentlyFailed / breaker full-set fallback apply (starvation guard).
+// See #358.
+func selectWeightedAcrossPriorityLayers(
+	available []RouteChannelCandidate,
+	resolveModel func(RouteChannelCandidate) string,
+	nowMs int64,
+	configuredMaxSec int,
+	selectFromPool func([]RouteChannelCandidate) *RouteChannelCandidate,
+) *RouteChannelCandidate {
+	if len(available) == 0 || selectFromPool == nil {
+		return nil
+	}
+
 	layers := make(map[int64][]RouteChannelCandidate)
 	for _, c := range available {
 		layers[c.Channel.Priority] = append(layers[c.Channel.Priority], c)
 	}
 
-	var priorities []int64
+	priorities := make([]int64, 0, len(layers))
 	for p := range layers {
 		priorities = append(priorities, p)
 	}
-	// Sort ascending
+	// Sort ascending (lower number = higher priority)
 	for i := 0; i < len(priorities); i++ {
 		for j := i + 1; j < len(priorities); j++ {
 			if priorities[j] < priorities[i] {
@@ -375,20 +407,54 @@ func (s *ChannelSelector) selectFromMatch(
 
 	for _, priority := range priorities {
 		rawLayer := layers[priority]
-		breakerHealthy, _ := GetBreakerFilteredCandidatesByModelResolver(rawLayer, resolveModel)
-		filteredLayer := FilterRecentlyFailedCandidates(breakerHealthy,
-			func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
-			nowMs, s.configuredMaxSec)
-
-		selected := s.weightedRandomSelect(filteredLayer, resolveModel, policy)
-		if selected == nil {
+		filteredLayer := softFilterCandidatesStrict(rawLayer, resolveModel, nowMs, configuredMaxSec)
+		if len(filteredLayer) == 0 {
 			continue
 		}
-		return s.finalizeDispatch(ctx, selected, match, requestedModel, mappedModel, policy,
-			recordSelection, "", "", false, excludeChannelIDs, nowISO, nowMs)
+		if selected := selectFromPool(filteredLayer); selected != nil {
+			return selected
+		}
 	}
 
-	return nil, nil
+	// All priority layers soft-empty → global fallback with existing full-set behavior.
+	breakerHealthy, _ := GetBreakerFilteredCandidatesByModelResolver(available, resolveModel)
+	filteredGlobal := FilterRecentlyFailedCandidates(breakerHealthy,
+		func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
+		nowMs, configuredMaxSec)
+	return selectFromPool(filteredGlobal)
+}
+
+// softFilterCandidatesStrict applies site/model breaker then recent-failure
+// filters without full-set fallback. An empty result means every candidate is
+// soft-unhealthy and the caller should try the next priority layer (or global
+// fallback). Unlike FilterRecentlyFailedCandidates / FilterSiteRuntimeBroken*,
+// a single soft-unhealthy candidate still yields empty so a lone broken
+// priority-0 channel cannot block demotion to priority>=1.
+func softFilterCandidatesStrict(
+	candidates []RouteChannelCandidate,
+	resolveModel func(RouteChannelCandidate) string,
+	nowMs int64,
+	configuredMaxSec int,
+) []RouteChannelCandidate {
+	if len(candidates) == 0 {
+		return nil
+	}
+	healthy := make([]RouteChannelCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		modelName := ""
+		if resolveModel != nil {
+			modelName = resolveModel(c)
+		}
+		details := GetSiteRuntimeHealthDetails(c.Site.ID, modelName)
+		if details.GlobalBreakerOpen || details.ModelBreakerOpen {
+			continue
+		}
+		if IsChannelRecentlyFailed(&c.Channel.FailCount, c.Channel.LastFailAt, nowMs, configuredMaxSec) {
+			continue
+		}
+		healthy = append(healthy, c)
+	}
+	return healthy
 }
 
 func (s *ChannelSelector) findRoute(ctx context.Context, model string, policy DownstreamRoutingPolicy) (*RouteMatch, error) {
@@ -533,10 +599,10 @@ func (s *ChannelSelector) loadRouteMatch(ctx context.Context, route store.TokenR
 		}
 
 		candidate := RouteChannelCandidate{
-			Channel:  j.Channel,
-			Account:  j.Account,
-			Site:     j.Site,
-			Token:    j.Token,
+			Channel: j.Channel,
+			Account: j.Account,
+			Site:    j.Site,
+			Token:   j.Token,
 		}
 
 		if j.Channel.OAuthRouteUnitID != nil && *j.Channel.OAuthRouteUnitID > 0 {


### PR DESCRIPTION
## Summary
- Weighted priority layers use **strict** soft-filter demotion (`softFilterCandidatesStrict` / `selectWeightedAcrossPriorityLayers`): if breaker + recent-failure empty a priority layer, skip to the next priority instead of selecting from the unfiltered full-set pin.
- Global full-set fallback remains only when **all** layers are soft-empty (starvation guard).
- Docs honesty in `docs/analysis/failover-isolation.md` updated for weighted empty-filter residual (#358).

Closes #358

## Test plan
- [x] `go test ./routing -count=1 -race -run 'Weighted|Priority|Filter|Select|Cascade'`
- [x] pre-push full `go test ./... -race` clean
- [x] AC: all prio 0 recently failed, prio 1 healthy → select prio 1
- [x] AC: all layers soft-empty → global fallback still selects