### PR TITLE
docs: residual honesty post v0.8.21 security wave (#359)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,12 +47,13 @@ docs/
 4. **`docs/specs/` is heavy rewrite history** — do not treat as day-to-day runbook.
 5. **One Issue per topic**; close duplicates the same day.
 
-## Active residual lanes (v0.8.16)
+## Active residual lanes (v0.8.22)
 
-See Milestone [Enterprise residual v0.8.16](https://github.com/TokenDanceLab/metapi-go/milestone/25):
+See Milestone [Enterprise residual v0.8.22](https://github.com/TokenDanceLab/metapi-go/milestone/31):
 
-- Protocol: Gemini `thought_signature`, multi-turn Responses content
-- Observability: usage accuracy follow-up
+- Security: admin key redaction (#355), custom_headers deny-list (#356), RuntimeExecutor redirect SSRF (#357)
+- Reliability: weighted soft-filter empty → next priority layer (#358)
+- Docs: residual honesty board (#359)
 - Explicit non-goals until dedicated Milestone: full Responses WS product, Redis sticky product, update-center remote deploy
 
 ## Hygiene rules (short)

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-07-17  
 **Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual  
-**Context**: **v0.8.21 shipped** (#350 completions include_usage, #351 residual honesty). Active residual wave: **Milestone 31 / v0.8.22** security residual (#355–#359).  
+**Context**: **v0.8.21 shipped** (#350 completions include_usage, #351 residual honesty). Milestone 31 product items **#355–#358 merged** to master; **#359** residual honesty for post-merge board; release gate **v0.8.22** pending.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 
@@ -26,7 +26,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | UC-1 | Update-center remote registry / deploy | residual | `scheduler/update_center.go` log-only; admin deploy/rollback/SSE **501**; `docs/analysis/residual-update-center.md` (#283) | Product Milestone with real registry client | Ops safety; no fake updateAvailable |
 | TEST-1 | Admin proxy/chat stream + job queue harness | residual | `handler/admin/test.go` stream/jobs **501** / job not-found; sync path aliases forced-channel harness; `docs/analysis/admin-channel-test-harness.md` (#291) | Optional UX polish; sync harness already present | Low if residual stays honest |
 | P0-568 | Relay keys force-marked expired | **present** (#298/#301) | `ShouldMarkAccountExpired` + `ReportTokenExpired` ClassExpired guard; bare/generic 401 no longer marks | Done for mark path; novel wording residual only | Residual wording gaps |
-| P0-585 | Channel failure cascade poison | **partial** (hardened #299/#302; honesty #336) | **Shipped:** channel-scoped `excludeChannelIDs`, non-usage-limit cooldown write isolation, 429 failover, same-channel timeout budget, multi-channel same-site conductor + routing isolation tests. **Still open:** site/model breaker after 3 transient fails (intentional fleet filter), credential-scoped usage-limit multi-channel cool, empty-filter fallback, **no production multi-channel load proof**. Detail: `docs/analysis/failover-isolation.md` §P0-585 honesty | Optional load-test / breaker product AC only; soft-filter priority layer #358 | Medium residual — do not claim #585 present |
+| P0-585 | Channel failure cascade poison | **partial** (hardened #299/#302; honesty #336) | **Shipped:** channel-scoped `excludeChannelIDs`, non-usage-limit cooldown write isolation, 429 failover, same-channel timeout budget, multi-channel same-site conductor + routing isolation tests. **Still open:** site/model breaker after 3 transient fails (intentional fleet filter), credential-scoped usage-limit multi-channel cool, empty-filter fallback, **no production multi-channel load proof**. Detail: `docs/analysis/failover-isolation.md` §P0-585 honesty | Optional load-test / breaker product AC only; soft-filter next-priority present via #358 | Medium residual — do not claim #585 present |
 | P0-555 | Token usage statistics inaccurate | **present-with-residual** (#300/#311/#319/#345/#350) | Disconnect partial + failure proxy_logs with usage (#311); aggregation projects non-success tokens into `failed_calls` + `total_tokens` (#319 regression); OpenAI chat + legacy completions stream `stream_options.include_usage` inject (#345/#350). Residual: provider-ignored flag, media zeros, multi-instance lag, orphan site join — not perfect billing | Residual polish only | Billing/ops trust residual |
 | P1-580 | Gemini thought_signature tool history | **present** (#86 transform + #309 proxy wire) | `NormalizeRequest` / OpenAI↔Gemini rebuild + `sanitizeUpstreamJSONBody` on gemini native/cli generateContent; residual: no multi-instance aggregate store | Done for request-side; session re-attach only if product needs | Residual multi-instance only |
 | P1-538 | Hermes/Codex multi-turn responses content | **present** (core; #50/#310) | `SanitizeResponsesInputItems` + `sanitizeUpstreamJSONBody` inject/preserve content; honest 400; residual: full Responses→chat conversion + no server store + no WS | Done for HTTP multi-turn content | Residual conversion/store/WS only |
@@ -37,27 +37,27 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | REBUILD-588 | Pattern/group rebuild | present | `service/route_rebuild.go` `RebuildRoutesBestEffort` | Done (matrix #281) | — |
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
 | CTX-520 | Route contextLength admin + models wire | **present-with-residual** (#320 + #327) | Admin CRUD (#320) + OpenAI `/v1/models` prefers positive route `context_length` (max per exposed id) (#327). Residual: no proxy max-token enforce; Claude models path has no context_length field | Optional enforce Milestone only with ACs | Metadata vs enforcement |
-| SEC-KEY | Admin downstream-keys plaintext redaction | residual → active | `handler/admin/downstream_keys.go` list/summary/overview may still expose full `key` alongside `keyMasked` | Milestone 31 / #355 | Secret leakage via admin list |
-| SEC-HDR | custom_headers deny-list | residual → active | `applyProxyCustomHeaders` can set Authorization/Host/hop-by-hop after Bearer | Milestone 31 / #356 | Identity override / SSRF assist |
-| SEC-REDIR | RuntimeExecutor CheckRedirect SSRF | residual → active | `proxy.NewRuntimeExecutor` default client has no CheckRedirect; platform has `rejectCrossOriginRedirect` | Milestone 31 / #357 | Redirect to private/metadata |
-| REL-SOFT | Weighted soft-filter empty → next priority | partial → active | Soft-filter empties priority-0 layer then still selects unfiltered full layer | Milestone 31 / #358 | Broken P0 starves healthy P≥1 |
+| SEC-KEY | Admin downstream-keys plaintext redaction | **present** (#355/#361) | `redactDownstreamKeySecret` on list/summary/overview; `key` omitted, `keyMasked` only | Done for admin list surface | Residual: other admin dumps if any |
+| SEC-HDR | custom_headers deny-list | **present** (#356/#364) | Shared `platform.ApplyCustomHeaders` / deny-list; Bearer after custom on upstream path | Done | Residual novel header names only |
+| SEC-REDIR | RuntimeExecutor CheckRedirect SSRF | **present** (#357/#360) | `rejectCrossOriginRedirect` on RuntimeExecutor client | Done | Residual site-URL SSRF validation only if product AC |
+| REL-SOFT | Weighted soft-filter empty → next priority | **present** (#358/#362) | Weighted path skips soft-empty priority layer and tries next; failover-isolation note | Done for weighted soft-filter | P0-585 empty-filter fallback residual separate |
 
 
 ## Active wave (Milestone 31 / v0.8.22)
 
 | Issue | Role | Notes |
 |------:|------|-------|
-| [#355](https://github.com/TokenDanceLab/metapi-go/issues/355) | security | redact plaintext key from admin downstream-keys list/summary/overview |
-| [#356](https://github.com/TokenDanceLab/metapi-go/issues/356) | security | deny-list sensitive custom_headers (Authorization/Host/hop-by-hop) |
-| [#357](https://github.com/TokenDanceLab/metapi-go/issues/357) | security | RuntimeExecutor CheckRedirect reject cross-origin/private SSRF |
-| [#358](https://github.com/TokenDanceLab/metapi-go/issues/358) | reliability | weighted soft-filter empty should try next priority layer |
-| [#359](https://github.com/TokenDanceLab/metapi-go/issues/359) | docs | This residual + MASTER flip post v0.8.21 |
+| [#355](https://github.com/TokenDanceLab/metapi-go/issues/355) | security | **merged** #361 — admin key redact |
+| [#356](https://github.com/TokenDanceLab/metapi-go/issues/356) | security | **merged** #364 — custom_headers deny-list |
+| [#357](https://github.com/TokenDanceLab/metapi-go/issues/357) | security | **merged** #360 — RuntimeExecutor CheckRedirect |
+| [#358](https://github.com/TokenDanceLab/metapi-go/issues/358) | reliability | **merged** #362 — weighted soft-filter next priority |
+| [#359](https://github.com/TokenDanceLab/metapi-go/issues/359) | docs | residual honesty + MASTER flip (this document) |
 
 ## Recommended sequencing (v0.8.22+)
 
-1. **Shipped in v0.8.21**: #350 legacy completions `stream_options.include_usage` · #351 residual honesty. Prior v0.8.20: #345 chat stream include_usage · #346 residual honesty. **P0-555** stays **present-with-residual** (chat+completions stream policy wired; media/lag/orphan residual). **CTX-520** / **P0-585** unchanged residual notes.
-2. **v0.8.22 board (Milestone 31)**: #355–#357 security residual · #358 weighted soft-filter priority skip · #359 residual honesty — no fake WS/sticky/update-center.
-3. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
+1. **Shipped on master for v0.8.22**: #355–#358 (PRs #360/#361/#362/#364). **#359** residual honesty closes the Milestone 31 board; release gate tags **v0.8.22**.
+2. **Shipped in v0.8.21**: #350 completions include_usage · #351 residual honesty. **P0-555** stays **present-with-residual** (chat+completions stream policy; media/lag/orphan residual). **CTX-520** / **P0-585** residual notes unchanged beyond soft-filter priority.
+3. **Observability residual only** on P0-555 (media/lag/multi-instance); not perfect billing.
 4. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
 5. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
 6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,8 +1,8 @@
-# Residual next candidates (post v0.8.21)
+# Residual next candidates (post v0.8.21 → v0.8.22)
 
 **Date**: 2026-07-17  
 **Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual  
-**Context**: After Enterprise residual **v0.8.21** (#350 completions include_usage, #351 residual honesty). Prior **v0.8.20**: #345 chat stream include_usage · #346 residual honesty.  
+**Context**: **v0.8.21 shipped** (#350 completions include_usage, #351 residual honesty). Active residual wave: **Milestone 31 / v0.8.22** security residual (#355–#359).  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 
@@ -26,7 +26,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | UC-1 | Update-center remote registry / deploy | residual | `scheduler/update_center.go` log-only; admin deploy/rollback/SSE **501**; `docs/analysis/residual-update-center.md` (#283) | Product Milestone with real registry client | Ops safety; no fake updateAvailable |
 | TEST-1 | Admin proxy/chat stream + job queue harness | residual | `handler/admin/test.go` stream/jobs **501** / job not-found; sync path aliases forced-channel harness; `docs/analysis/admin-channel-test-harness.md` (#291) | Optional UX polish; sync harness already present | Low if residual stays honest |
 | P0-568 | Relay keys force-marked expired | **present** (#298/#301) | `ShouldMarkAccountExpired` + `ReportTokenExpired` ClassExpired guard; bare/generic 401 no longer marks | Done for mark path; novel wording residual only | Residual wording gaps |
-| P0-585 | Channel failure cascade poison | **partial** (hardened #299/#302; honesty #336) | **Shipped:** channel-scoped `excludeChannelIDs`, non-usage-limit cooldown write isolation, 429 failover, same-channel timeout budget, multi-channel same-site conductor + routing isolation tests. **Still open:** site/model breaker after 3 transient fails (intentional fleet filter), credential-scoped usage-limit multi-channel cool, empty-filter fallback, **no production multi-channel load proof**. Detail: `docs/analysis/failover-isolation.md` §P0-585 honesty | Optional load-test / breaker product AC only | Medium residual — do not claim #585 present |
+| P0-585 | Channel failure cascade poison | **partial** (hardened #299/#302; honesty #336) | **Shipped:** channel-scoped `excludeChannelIDs`, non-usage-limit cooldown write isolation, 429 failover, same-channel timeout budget, multi-channel same-site conductor + routing isolation tests. **Still open:** site/model breaker after 3 transient fails (intentional fleet filter), credential-scoped usage-limit multi-channel cool, empty-filter fallback, **no production multi-channel load proof**. Detail: `docs/analysis/failover-isolation.md` §P0-585 honesty | Optional load-test / breaker product AC only; soft-filter priority layer #358 | Medium residual — do not claim #585 present |
 | P0-555 | Token usage statistics inaccurate | **present-with-residual** (#300/#311/#319/#345/#350) | Disconnect partial + failure proxy_logs with usage (#311); aggregation projects non-success tokens into `failed_calls` + `total_tokens` (#319 regression); OpenAI chat + legacy completions stream `stream_options.include_usage` inject (#345/#350). Residual: provider-ignored flag, media zeros, multi-instance lag, orphan site join — not perfect billing | Residual polish only | Billing/ops trust residual |
 | P1-580 | Gemini thought_signature tool history | **present** (#86 transform + #309 proxy wire) | `NormalizeRequest` / OpenAI↔Gemini rebuild + `sanitizeUpstreamJSONBody` on gemini native/cli generateContent; residual: no multi-instance aggregate store | Done for request-side; session re-attach only if product needs | Residual multi-instance only |
 | P1-538 | Hermes/Codex multi-turn responses content | **present** (core; #50/#310) | `SanitizeResponsesInputItems` + `sanitizeUpstreamJSONBody` inject/preserve content; honest 400; residual: full Responses→chat conversion + no server store + no WS | Done for HTTP multi-turn content | Residual conversion/store/WS only |
@@ -37,15 +37,31 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | REBUILD-588 | Pattern/group rebuild | present | `service/route_rebuild.go` `RebuildRoutesBestEffort` | Done (matrix #281) | — |
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
 | CTX-520 | Route contextLength admin + models wire | **present-with-residual** (#320 + #327) | Admin CRUD (#320) + OpenAI `/v1/models` prefers positive route `context_length` (max per exposed id) (#327). Residual: no proxy max-token enforce; Claude models path has no context_length field | Optional enforce Milestone only with ACs | Metadata vs enforcement |
+| SEC-KEY | Admin downstream-keys plaintext redaction | residual → active | `handler/admin/downstream_keys.go` list/summary/overview may still expose full `key` alongside `keyMasked` | Milestone 31 / #355 | Secret leakage via admin list |
+| SEC-HDR | custom_headers deny-list | residual → active | `applyProxyCustomHeaders` can set Authorization/Host/hop-by-hop after Bearer | Milestone 31 / #356 | Identity override / SSRF assist |
+| SEC-REDIR | RuntimeExecutor CheckRedirect SSRF | residual → active | `proxy.NewRuntimeExecutor` default client has no CheckRedirect; platform has `rejectCrossOriginRedirect` | Milestone 31 / #357 | Redirect to private/metadata |
+| REL-SOFT | Weighted soft-filter empty → next priority | partial → active | Soft-filter empties priority-0 layer then still selects unfiltered full layer | Milestone 31 / #358 | Broken P0 starves healthy P≥1 |
+
+
+## Active wave (Milestone 31 / v0.8.22)
+
+| Issue | Role | Notes |
+|------:|------|-------|
+| [#355](https://github.com/TokenDanceLab/metapi-go/issues/355) | security | redact plaintext key from admin downstream-keys list/summary/overview |
+| [#356](https://github.com/TokenDanceLab/metapi-go/issues/356) | security | deny-list sensitive custom_headers (Authorization/Host/hop-by-hop) |
+| [#357](https://github.com/TokenDanceLab/metapi-go/issues/357) | security | RuntimeExecutor CheckRedirect reject cross-origin/private SSRF |
+| [#358](https://github.com/TokenDanceLab/metapi-go/issues/358) | reliability | weighted soft-filter empty should try next priority layer |
+| [#359](https://github.com/TokenDanceLab/metapi-go/issues/359) | docs | This residual + MASTER flip post v0.8.21 |
 
 ## Recommended sequencing (v0.8.22+)
 
 1. **Shipped in v0.8.21**: #350 legacy completions `stream_options.include_usage` · #351 residual honesty. Prior v0.8.20: #345 chat stream include_usage · #346 residual honesty. **P0-555** stays **present-with-residual** (chat+completions stream policy wired; media/lag/orphan residual). **CTX-520** / **P0-585** unchanged residual notes.
-2. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
-3. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
-4. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
-5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+2. **v0.8.22 board (Milestone 31)**: #355–#357 security residual · #358 weighted soft-filter priority skip · #359 residual honesty — no fake WS/sticky/update-center.
+3. **Observability residual only** on P0-555 (policy/media/lag/multi-instance); not perfect billing.
+4. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
+5. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
+6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+7. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -55,6 +71,9 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Returning `success:true` for unimplemented admin stream/job queues.
 - Claiming perfect billing accuracy without aggregation proof after #311.
 - Claiming proxy max-token enforcement from `contextLength` without a dedicated product AC.
+- Returning full downstream API keys on admin list/summary/overview after #355.
+- Allowing custom_headers to override Authorization/Host/hop-by-hop after #356.
+- Following cross-origin/private RuntimeExecutor redirects after #357.
 
 ## Links
 
@@ -62,4 +81,4 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`
-- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346, #350, #351
+- Related issues: #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346, #350, #351, #355, #356, #357, #358, #359

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | closed Milestone 30 (v0.8.21) — next residual wave TBD |
+| Active milestone | **[Milestone 31 — Enterprise residual v0.8.22](https://github.com/TokenDanceLab/metapi-go/milestone/31)** |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -32,12 +32,17 @@
 | Enterprise residual **v0.8.19** | ✅ | #334–#336 · tag v0.8.19 |
 | Enterprise residual **v0.8.20** | ✅ | #345–#346 · tag v0.8.20 |
 | Enterprise residual **v0.8.21** | ✅ | #350–#351 (PRs #352/#353); tag **v0.8.21** |
+| Enterprise residual **v0.8.22** | 🔄 | Milestone 31 · #355–#359 |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| — | — | Board clean after v0.8.21; next residual only with ACs |
+| [#355](https://github.com/TokenDanceLab/metapi-go/issues/355) | security | redact plaintext key from admin downstream-keys list/summary/overview |
+| [#356](https://github.com/TokenDanceLab/metapi-go/issues/356) | security | deny-list sensitive custom_headers (Authorization/Host/hop-by-hop) |
+| [#357](https://github.com/TokenDanceLab/metapi-go/issues/357) | security | RuntimeExecutor CheckRedirect reject cross-origin/private SSRF |
+| [#358](https://github.com/TokenDanceLab/metapi-go/issues/358) | reliability | weighted soft-filter empty should try next priority layer |
+| [#359](https://github.com/TokenDanceLab/metapi-go/issues/359) | docs | residual honesty + security wave board post v0.8.21 |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -75,9 +80,10 @@ git log --oneline origin/master -10
 
 ## Next Steps
 
-1. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
-2. Optional residual polish: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
-3. Keep MASTER slim; docs map at `docs/README.md`.
+1. Close Milestone 31: #355–#357 security · #358 weighted soft-filter · #359 residual honesty.
+2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
+3. Optional later: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
+4. Keep MASTER slim; docs map at `docs/README.md`.
 
 
 ## Governance

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -32,17 +32,14 @@
 | Enterprise residual **v0.8.19** | ✅ | #334–#336 · tag v0.8.19 |
 | Enterprise residual **v0.8.20** | ✅ | #345–#346 · tag v0.8.20 |
 | Enterprise residual **v0.8.21** | ✅ | #350–#351 (PRs #352/#353); tag **v0.8.21** |
-| Enterprise residual **v0.8.22** | 🔄 | Milestone 31 · #355–#359 |
+| Enterprise residual **v0.8.22** | 🔄 | Milestone 31 · #355–#358 merged; #359 residual honesty → release gate |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| [#355](https://github.com/TokenDanceLab/metapi-go/issues/355) | security | redact plaintext key from admin downstream-keys list/summary/overview |
-| [#356](https://github.com/TokenDanceLab/metapi-go/issues/356) | security | deny-list sensitive custom_headers (Authorization/Host/hop-by-hop) |
-| [#357](https://github.com/TokenDanceLab/metapi-go/issues/357) | security | RuntimeExecutor CheckRedirect reject cross-origin/private SSRF |
-| [#358](https://github.com/TokenDanceLab/metapi-go/issues/358) | reliability | weighted soft-filter empty should try next priority layer |
-| [#359](https://github.com/TokenDanceLab/metapi-go/issues/359) | docs | residual honesty + security wave board post v0.8.21 |
+| [#359](https://github.com/TokenDanceLab/metapi-go/issues/359) | docs | residual honesty + security wave board post v0.8.21 (closes M31 docs) |
+| — | release | v0.8.22 CHANGELOG + tag after #359 |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -80,7 +77,7 @@ git log --oneline origin/master -10
 
 ## Next Steps
 
-1. Close Milestone 31: #355–#357 security · #358 weighted soft-filter · #359 residual honesty.
+1. Merge #359 residual honesty; release gate **v0.8.22** (CHANGELOG/MASTER tip/tag); close Milestone 31.
 2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
 3. Optional later: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
 4. Keep MASTER slim; docs map at `docs/README.md`.


### PR DESCRIPTION
## Summary
- MASTER: latest still v0.8.21; Active Milestone 31 (Enterprise residual v0.8.22); Active work #355–#359; status v0.8.22 🔄
- residual-next-candidates: Active wave Milestone 31 for security residual; sequencing v0.8.22 board
- docs/README active residual lanes pointer → v0.8.22
- Docs only — no product Go code

Closes #359

## Test plan
- [x] `go test ./docs -run TestPublicMarkdownHygiene -count=1`