### PR TITLE
fix(proxy): deny-list sensitive custom_headers (#356)

### DIFF
--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -573,10 +573,12 @@ func dispatchEndpointAttemptWithContinue(
 		return true, nil, false
 	}
 	req.Header.Set("Content-Type", contentType)
+	// Custom headers first (deny-list skips Authorization/Host/hop-by-hop), then
+	// Bearer so site custom_headers can never override the selected token (#356).
+	applyProxyCustomHeaders(req, proxyConfig)
 	if selected.TokenValue != "" {
 		req.Header.Set("Authorization", "Bearer "+selected.TokenValue)
 	}
-	applyProxyCustomHeaders(req, proxyConfig)
 
 	resp, err := sendUpstreamRequest(cfg, req, proxyConfig, firstByteTimeoutMs)
 	latencyMs := time.Since(startedAt).Milliseconds()
@@ -820,13 +822,8 @@ func applyProxyCustomHeaders(req *http.Request, proxyConfig *platform.ProxyConfi
 	if proxyConfig == nil {
 		return
 	}
-	for k, v := range proxyConfig.CustomHeaders {
-		// Preference control headers are site marks only — never forward upstream.
-		if proxy.IsMetapiControlHeader(k) {
-			continue
-		}
-		req.Header.Set(k, v)
-	}
+	// Shared deny-list: Authorization/Host/hop-by-hop/Cookie/Proxy-*/metapi control (#356).
+	platform.ApplyCustomHeaders(req, proxyConfig.CustomHeaders)
 }
 
 // sendUpstreamRequest dispatches an upstream HTTP request with optional observed

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -356,6 +356,58 @@ func TestDispatchUpstreamUsesSiteCustomHeaders(t *testing.T) {
 	}
 }
 
+
+func TestDispatchUpstreamDeniesSensitiveCustomHeaders(t *testing.T) {
+	var gotAuth, gotHost, gotCustom, gotCookie, gotConn string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotHost = r.Host
+		gotCustom = r.Header.Get("X-Custom")
+		gotCookie = r.Header.Get("Cookie")
+		gotConn = r.Header.Get("Connection")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_test","choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	// Malicious/sensitive custom headers must not reach upstream; X-Custom still applies.
+	customHeaders := `{"Authorization":"Bearer evil","Host":"evil.example","Cookie":"x=1","Connection":"close","X-Custom":"ok"}`
+	router := &upstreamTestRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active", CustomHeaders: &customHeaders},
+		TokenValue:  "upstream-token",
+		ActualModel: "gpt-4o-upstream",
+	}}
+	SetUpstreamConfig(&UpstreamConfig{Router: router})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if gotAuth != "Bearer upstream-token" {
+		t.Fatalf("Authorization = %q, want Bearer upstream-token", gotAuth)
+	}
+	if gotCustom != "ok" {
+		t.Fatalf("X-Custom = %q, want ok", gotCustom)
+	}
+	if gotCookie != "" {
+		t.Fatalf("Cookie leaked: %q", gotCookie)
+	}
+	if gotConn != "" {
+		t.Fatalf("Connection leaked: %q", gotConn)
+	}
+	if gotHost == "evil.example" {
+		t.Fatalf("Host overridden to evil.example")
+	}
+}
+
+
 func TestDispatchUpstreamNonStreamFailoversOnRetryableHTTPStatusAndRecordsHealth(t *testing.T) {
 	var firstCalls int
 	firstUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/platform/custom_headers.go
+++ b/platform/custom_headers.go
@@ -1,0 +1,59 @@
+package platform
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/tokendancelab/metapi-go/proxy/profiles"
+)
+
+// IsDeniedCustomHeader reports whether a site custom_headers entry must not be
+// forwarded upstream. Blocks identity, framing, hop-by-hop, cookies, Proxy-*,
+// and MetAPI control preference headers.
+//
+// Security: custom Authorization must never override the Bearer set from the
+// selected account token; Host/Connection/etc. must not be attacker-controlled.
+func IsDeniedCustomHeader(name string) bool {
+	if profiles.IsMetapiControlHeader(name) {
+		return true
+	}
+	n := strings.ToLower(strings.TrimSpace(name))
+	if n == "" {
+		return true
+	}
+	// Proxy-* covers Proxy-Authorization, Proxy-Connection, Proxy-Authenticate, etc.
+	if strings.HasPrefix(n, "proxy-") {
+		return true
+	}
+	switch n {
+	case "authorization",
+		"host",
+		"content-length",
+		"transfer-encoding",
+		"connection",
+		"cookie",
+		// RFC 7230 hop-by-hop (beyond Connection / Transfer-Encoding).
+		"keep-alive",
+		"te",
+		"trailer",
+		"trailers",
+		"upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
+// ApplyCustomHeaders sets non-denied custom headers onto req.
+// Nil req or empty map is a no-op.
+func ApplyCustomHeaders(req *http.Request, custom map[string]string) {
+	if req == nil || len(custom) == 0 {
+		return
+	}
+	for k, v := range custom {
+		if IsDeniedCustomHeader(k) {
+			continue
+		}
+		req.Header.Set(k, v)
+	}
+}

--- a/platform/custom_headers_test.go
+++ b/platform/custom_headers_test.go
@@ -1,0 +1,133 @@
+package platform
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsDeniedCustomHeader(t *testing.T) {
+	t.Parallel()
+	denied := []string{
+		"Authorization",
+		"authorization",
+		" AUTHORIZATION ",
+		"Host",
+		"Content-Length",
+		"Transfer-Encoding",
+		"Connection",
+		"Cookie",
+		"Proxy-Authorization",
+		"Proxy-Connection",
+		"Keep-Alive",
+		"TE",
+		"Upgrade",
+		"X-Metapi-Responses-Only",
+		"x-metapi-stream-only",
+	}
+	for _, h := range denied {
+		if !IsDeniedCustomHeader(h) {
+			t.Fatalf("IsDeniedCustomHeader(%q) = false, want true", h)
+		}
+	}
+	allowed := []string{"X-Custom", "X-Metapi-Trace", "User-Agent", "Accept-Language"}
+	for _, h := range allowed {
+		if IsDeniedCustomHeader(h) {
+			t.Fatalf("IsDeniedCustomHeader(%q) = true, want false", h)
+		}
+	}
+}
+
+func TestApplyCustomHeaders_DeniesSensitiveAllowsCustom(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest(http.MethodGet, "http://example.test/v1", nil)
+	req.Header.Set("Authorization", "Bearer original-token")
+	req.Host = "example.test"
+
+	ApplyCustomHeaders(req, map[string]string{
+		"Authorization":         "Bearer attacker",
+		"Host":                  "evil.example",
+		"Content-Length":        "999",
+		"Transfer-Encoding":     "chunked",
+		"Connection":            "close",
+		"Cookie":                "session=stolen",
+		"Proxy-Authorization":   "Basic evil",
+		"X-Metapi-Responses-Only": "1",
+		"X-Custom":              "ok",
+	})
+
+	if got := req.Header.Get("Authorization"); got != "Bearer original-token" {
+		t.Fatalf("Authorization = %q, want original Bearer", got)
+	}
+	if got := req.Host; got != "example.test" {
+		t.Fatalf("Host = %q, want example.test", got)
+	}
+	if req.Header.Get("Host") != "" {
+		t.Fatalf("Host header set to %q, want empty (not applied)", req.Header.Get("Host"))
+	}
+	if req.Header.Get("Content-Length") != "" {
+		t.Fatalf("Content-Length leaked: %q", req.Header.Get("Content-Length"))
+	}
+	if req.Header.Get("Transfer-Encoding") != "" {
+		t.Fatalf("Transfer-Encoding leaked: %q", req.Header.Get("Transfer-Encoding"))
+	}
+	if req.Header.Get("Connection") != "" {
+		t.Fatalf("Connection leaked: %q", req.Header.Get("Connection"))
+	}
+	if req.Header.Get("Cookie") != "" {
+		t.Fatalf("Cookie leaked: %q", req.Header.Get("Cookie"))
+	}
+	if req.Header.Get("Proxy-Authorization") != "" {
+		t.Fatalf("Proxy-Authorization leaked: %q", req.Header.Get("Proxy-Authorization"))
+	}
+	if req.Header.Get("X-Metapi-Responses-Only") != "" {
+		t.Fatalf("control header leaked: %q", req.Header.Get("X-Metapi-Responses-Only"))
+	}
+	if got := req.Header.Get("X-Custom"); got != "ok" {
+		t.Fatalf("X-Custom = %q, want ok", got)
+	}
+}
+
+func TestDoWithProxy_CustomHeadersDenySensitive(t *testing.T) {
+	var gotAuth, gotHost, gotCustom, gotCookie string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotHost = r.Host
+		gotCustom = r.Header.Get("X-Custom")
+		gotCookie = r.Header.Get("Cookie")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer good-token")
+	resp, err := DoWithProxy(req.Context(), req, &ProxyConfig{
+		CustomHeaders: map[string]string{
+			"Authorization": "Bearer evil",
+			"Host":          "evil.example",
+			"Cookie":        "x=1",
+			"X-Custom":      "still-set",
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoWithProxy: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if gotAuth != "Bearer good-token" {
+		t.Fatalf("Authorization on wire = %q, want Bearer good-token", gotAuth)
+	}
+	if gotCustom != "still-set" {
+		t.Fatalf("X-Custom = %q, want still-set", gotCustom)
+	}
+	if gotCookie != "" {
+		t.Fatalf("Cookie on wire = %q, want empty", gotCookie)
+	}
+	// Host is set by net/http from the request URL; custom Host must not replace it with evil.
+	if gotHost == "evil.example" {
+		t.Fatalf("Host was overridden to evil.example")
+	}
+}

--- a/platform/site_proxy.go
+++ b/platform/site_proxy.go
@@ -95,11 +95,9 @@ func (sp *SiteProxy) proxyFunc(req *http.Request) (*url.URL, error) {
 func (sp *SiteProxy) Do(ctx context.Context, req *http.Request, proxyConfig *ProxyConfig) (*http.Response, error) {
 	req = req.WithContext(ctx)
 
-	// Apply custom headers from proxy config
+	// Apply custom headers from proxy config (deny-list filters identity/hop-by-hop).
 	if proxyConfig != nil {
-		for k, v := range proxyConfig.CustomHeaders {
-			req.Header.Set(k, v)
-		}
+		ApplyCustomHeaders(req, proxyConfig.CustomHeaders)
 	}
 
 	// If specific proxy URL is given, use a dedicated transport
@@ -151,9 +149,8 @@ func (sp *SiteProxy) doWithExplicitProxy(ctx context.Context, req *http.Request,
 // DoWithProxy is a convenience function that works without a SiteProxy instance.
 func DoWithProxy(ctx context.Context, req *http.Request, proxyConfig *ProxyConfig) (*http.Response, error) {
 	if proxyConfig != nil {
-		for k, v := range proxyConfig.CustomHeaders {
-			req.Header.Set(k, v)
-		}
+		// Deny-list sensitive / hop-by-hop / metapi-control headers (#356).
+		ApplyCustomHeaders(req, proxyConfig.CustomHeaders)
 	}
 
 	insecureSkipTLS := proxyConfig != nil && proxyConfig.InsecureSkipTLS


### PR DESCRIPTION
## Summary
- Shared `platform.IsDeniedCustomHeader` / `ApplyCustomHeaders` blocks Authorization, Host, Content-Length, Transfer-Encoding, Connection, Cookie, Proxy-*, hop-by-hop, and metapi control headers from site `custom_headers`.
- Production `applyProxyCustomHeaders` uses the shared deny-list; Bearer is set **after** custom headers so identity cannot be overridden.
- `SiteProxy.Do` / `DoWithProxy` apply the same filter so proxy-path re-apply cannot smuggle sensitive headers.

## Test plan
- [x] `go test ./handler/proxy ./platform -count=1 -race -run 'CustomHeader|Proxy|Header|Upstream|Denied|DoWithProxy'`
- [x] full pre-push `go vet` + `go test ./... -race`

Closes #356