### PR TITLE
docs(release): v0.8.22 security residual + soft-filter priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.22] — 2026-07-17
+
+### Security
+- Redact plaintext `key` from admin downstream-keys list/summary/overview (`keyMasked` only) (#355 / #361)
+- Deny-list sensitive site `custom_headers` (Authorization/Host/Cookie/hop-by-hop/Proxy-*/Content-Type); shared `platform.ApplyCustomHeaders`; Bearer set after custom so identity cannot be overridden (#356 / #364)
+- RuntimeExecutor `CheckRedirect` rejects cross-origin and private/metadata redirect targets (#357 / #360)
+
+### Fixed
+- Weighted routing: when soft-filter empties a priority layer, try the next priority instead of reselecting the unfiltered broken layer (#358 / #362)
+
+### Docs / Honesty
+- Residual inventory + MASTER for Milestone 31 post v0.8.21; SEC-KEY/HDR/REDIR + REL-SOFT → present (#359 / #363)
+
 ## [v0.8.21] — 2026-07-17
 
 ### Fixed

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,8 +1,8 @@
-# Residual next candidates (post v0.8.21 → v0.8.22)
+# Residual next candidates (post v0.8.22)
 
 **Date**: 2026-07-17  
 **Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual  
-**Context**: **v0.8.21 shipped** (#350 completions include_usage, #351 residual honesty). Milestone 31 product items **#355–#358 merged** to master; **#359** residual honesty for post-merge board; release gate **v0.8.22** pending.  
+**Context**: **v0.8.22 shipped** (#355 admin key redact, #356 custom_headers deny, #357 CheckRedirect, #358 weighted soft-filter next priority, #359 residual honesty). Prior **v0.8.21**: #350–#351.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 
@@ -43,25 +43,14 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | REL-SOFT | Weighted soft-filter empty → next priority | **present** (#358/#362) | Weighted path skips soft-empty priority layer and tries next; failover-isolation note | Done for weighted soft-filter | P0-585 empty-filter fallback residual separate |
 
 
-## Active wave (Milestone 31 / v0.8.22)
+## Recommended sequencing (v0.8.23+)
 
-| Issue | Role | Notes |
-|------:|------|-------|
-| [#355](https://github.com/TokenDanceLab/metapi-go/issues/355) | security | **merged** #361 — admin key redact |
-| [#356](https://github.com/TokenDanceLab/metapi-go/issues/356) | security | **merged** #364 — custom_headers deny-list |
-| [#357](https://github.com/TokenDanceLab/metapi-go/issues/357) | security | **merged** #360 — RuntimeExecutor CheckRedirect |
-| [#358](https://github.com/TokenDanceLab/metapi-go/issues/358) | reliability | **merged** #362 — weighted soft-filter next priority |
-| [#359](https://github.com/TokenDanceLab/metapi-go/issues/359) | docs | residual honesty + MASTER flip (this document) |
-
-## Recommended sequencing (v0.8.22+)
-
-1. **Shipped on master for v0.8.22**: #355–#358 (PRs #360/#361/#362/#364). **#359** residual honesty closes the Milestone 31 board; release gate tags **v0.8.22**.
-2. **Shipped in v0.8.21**: #350 completions include_usage · #351 residual honesty. **P0-555** stays **present-with-residual** (chat+completions stream policy; media/lag/orphan residual). **CTX-520** / **P0-585** residual notes unchanged beyond soft-filter priority.
-3. **Observability residual only** on P0-555 (media/lag/multi-instance); not perfect billing.
-4. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
-5. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
-6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-7. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+1. **Shipped in v0.8.22**: #355–#359 (PRs #360–#364) — admin key redact · custom_headers deny · CheckRedirect · weighted soft-filter next priority · residual honesty. Prior v0.8.21: #350–#351. **P0-555** stays **present-with-residual**. **CTX-520** / **P0-585** residual notes unchanged beyond soft-filter priority.
+2. **Observability residual only** on P0-555 (media/lag/multi-instance); not perfect billing.
+3. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
+4. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
+5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -77,7 +66,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 
 ## Links
 
-- Release: [v0.8.21](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.21) · prior [v0.8.20](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.20)
+- Release: [v0.8.22](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.22) · prior [v0.8.21](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.21)
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -3,7 +3,7 @@
 **Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery
 **Mode**: GitHub Issues + Milestones (SDD)
 **Repo**: https://github.com/TokenDanceLab/metapi-go
-**Latest release**: **[v0.8.21](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.21)** (2026-07-17)
+**Latest release**: **[v0.8.22](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.22)** (2026-07-17)
 
 > 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。
 > 文档地图：[`docs/README.md`](../README.md)
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | **[Milestone 31 — Enterprise residual v0.8.22](https://github.com/TokenDanceLab/metapi-go/milestone/31)** |
+| Active milestone | closed Milestone 31 (v0.8.22) — next residual wave TBD |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -32,14 +32,13 @@
 | Enterprise residual **v0.8.19** | ✅ | #334–#336 · tag v0.8.19 |
 | Enterprise residual **v0.8.20** | ✅ | #345–#346 · tag v0.8.20 |
 | Enterprise residual **v0.8.21** | ✅ | #350–#351 (PRs #352/#353); tag **v0.8.21** |
-| Enterprise residual **v0.8.22** | 🔄 | Milestone 31 · #355–#358 merged; #359 residual honesty → release gate |
+| Enterprise residual **v0.8.22** | ✅ | #355–#359 (PRs #360–#364); tag **v0.8.22** |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| [#359](https://github.com/TokenDanceLab/metapi-go/issues/359) | docs | residual honesty + security wave board post v0.8.21 (closes M31 docs) |
-| — | release | v0.8.22 CHANGELOG + tag after #359 |
+| — | — | Board clean after v0.8.22; next residual only with ACs |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -48,6 +47,7 @@
 
 | Tag | Milestone | Highlights |
 |:----|:----------|:-----------|
+| [v0.8.22](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.22) | 31 | admin key redact · custom_headers deny · CheckRedirect · soft-filter priority · residual honesty |
 | [v0.8.21](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.21) | 30 | completions include_usage · residual honesty |
 | [v0.8.20](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.20) | 29 | chat stream include_usage · residual honesty |
 | [v0.8.19](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.19) | 28 | residual honesty · healthPersist race · P0-585 cascade honesty |
@@ -71,16 +71,15 @@
 ```bash
 gh issue list --state open --limit 20
 gh pr list --state open
-gh release view v0.8.21
+gh release view v0.8.22
 git log --oneline origin/master -10
 ```
 
 ## Next Steps
 
-1. Merge #359 residual honesty; release gate **v0.8.22** (CHANGELOG/MASTER tip/tag); close Milestone 31.
-2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
-3. Optional later: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
-4. Keep MASTER slim; docs map at `docs/README.md`.
+1. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
+2. Optional residual polish: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
+3. Keep MASTER slim; docs map at `docs/README.md`.
 
 
 ## Governance


### PR DESCRIPTION
## Summary
- CHANGELOG **v0.8.22**: admin key redact (#355), custom_headers deny (#356), RuntimeExecutor CheckRedirect (#357), weighted soft-filter next priority (#358), residual honesty (#359).
- MASTER flip: latest **v0.8.22**, Milestone 31 closed pointer, board clean.
- residual-next-candidates post v0.8.22 sequencing (SEC-* / REL-SOFT present).

## Test plan
- [x] pre-push vet + race suite
- [x] docs-only PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Sensitive administrator keys are now redacted from plaintext output.
  * Protected header values are blocked, and identity overrides through headers are prevented.
  * Redirects to external, private, or metadata destinations are rejected.

* **Bug Fixes**
  * Improved weighted routing fallback when filtering removes all options from a priority tier.

* **Documentation**
  * Updated release status, residual work tracking, and milestone documentation for v0.8.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->