### PR TITLE
fix(routing): RR/stable_first soft-filter priority demotion (#368)

### DIFF
--- a/docs/analysis/failover-isolation.md
+++ b/docs/analysis/failover-isolation.md
@@ -23,7 +23,7 @@ Upstream gap **#585** (“one channel failure cascades to other channels”) is 
 | **Shipped — selection soft filters** | Recent-failure + breaker filters prefer healthy candidates (all strategies) | **present** (R1 RR parity) |
 | **Residual — site/model breaker** | Transient streak ≥3 opens site or site+model breaker → **all** channels on that scope soft-filtered | **intentional policy**, not a “sibling poison bug”; still a fleet-level cascade pressure |
 | **Residual — credential usage-limit scope** | Short-window usage limit cools **all channels sharing the credential** | **intentional** shared-key truth |
-| **Residual — empty-filter fallback** | Soft filters still return the **full set** when healthy is empty (**global** starvation guard). Weighted priority layers now use **strict** soft-filter demotion first (`softFilterCandidatesStrict` / `selectWeightedAcrossPriorityLayers`): a soft-empty higher priority skips to the next priority; full-set fallback applies only after **all** layers are soft-empty (**#358**) | Starvation prevention without pinning on a broken priority-0 layer; residual remains for global full-set re-exposure |
+| **Residual — empty-filter fallback** | Soft filters still return the **full set** when healthy is empty (**global** starvation guard). Weighted / round_robin / stable_first priority layers use **strict** soft-filter demotion first (`softFilterCandidatesStrict` / `selectAcrossPriorityLayers`): a soft-empty higher priority skips to the next priority; full-set fallback applies only after **all** layers are soft-empty (**#358**, **#368**) | Starvation prevention without pinning on a broken priority-0 layer; residual remains for global full-set re-exposure |
 | **Residual — production multi-channel load proof** | No e2e / production-shaped load evidence that systemic poison stays contained under failure storms | **open** — unit/integration only |
 
 **Do not claim:** “#585 is fully present” or “site-wide cascade is eliminated.”  
@@ -58,7 +58,7 @@ All three strategies now share the same isolation order after eligibility:
 
 > R1 fix: round-robin previously skipped step 3, so a single RR failure (no `cooldownUntil` yet) could be reselected immediately and starve healthy siblings. RR now applies the same recent-failure filter as weighted and stable-first.
 >
-> **#358 weighted priority layers:** per-layer soft filters are **strict** (no full-set pin). Soft-empty higher priority demotes to the next priority; only if every layer is soft-empty does the global full-set fallback apply.
+> **#358 / #368 priority layers (weighted, round_robin, stable_first):** per-layer soft filters are **strict** (no full-set pin) via `selectAcrossPriorityLayers`. Soft-empty higher priority demotes to the next priority; only if every layer is soft-empty does the global full-set fallback apply.
 
 ### `RecordFailure` write scope
 
@@ -106,7 +106,7 @@ These are **not** bugs of “mark sibling failed,” but residual fleet-level pr
 |:---------|:---------|:----|
 | Site/model breaker | 3 transient fails open breaker → **all** channels on that site/model filtered via `FilterSiteRuntimeBrokenCandidatesByModel*` | Intentional systemic protection; can look like cascade under multi-channel storms on one site |
 | Credential-scoped usage limit | Short window cools **all channels sharing the credential** | Shared quota / key truth — not peer-channel poison, still multi-channel impact |
-| Empty-filter fallback | Global filters return the **full set** when healthy is empty; weighted layers demote soft-empty priorities before that global fallback (**#358**) | Global starvation prevention still reselects cooled channels when the whole fleet is degraded |
+| Empty-filter fallback | Global filters return the **full set** when healthy is empty; weighted / RR / stable_first layers demote soft-empty priorities before that global fallback (**#358**, **#368**) | Global starvation prevention still reselects cooled channels when the whole fleet is degraded |
 | Production multi-channel load proof | Load-shaped systemic poison not proven e2e under production traffic | Unit/integration isolation proven only; gap matrix #585 residual / inventory P0-585 |
 
 ### What would close (or further shrink) residual
@@ -115,7 +115,7 @@ These are **not** bugs of “mark sibling failed,” but residual fleet-level pr
 |:--------------|:-----------------------------------------------|
 | Site/model breaker “cascade look” | Product AC if breaker thresholds / model scope need operator knobs or different policy — **not** docs-only |
 | Production multi-channel load proof | Load-test or production evidence plan with multi-channel same-site failure storms; metrics that sibling channels stay eligible while breakers stay closed for single-channel noise |
-| Empty-filter fallback (global) | Removing global full-set fallback risks hard outage when all candidates are dirty; weighted per-layer demotion is shipped (**#358**) |
+| Empty-filter fallback (global) | Removing global full-set fallback risks hard outage when all candidates are dirty; weighted / RR / stable_first per-layer demotion is shipped (**#358**, **#368**) |
 
 ## Tests
 
@@ -134,6 +134,9 @@ These are **not** bugs of “mark sibling failed,” but residual fleet-level pr
   - `TestRoundRobinFilterStack_MatchesWeightedRecentFailurePolicy`
   - `TestWeightedSoftFilter_EmptyPriorityDemotesToNext` (**#358**)
   - `TestWeightedSoftFilter_AllLayersSoftEmptyAllowsGlobalFallback` (**#358**)
+  - `TestRoundRobinSoftFilter_EmptyPriorityDemotesToNext` (**#368**)
+  - `TestStableFirstSoftFilter_EmptyPriorityDemotesToNext` (**#368**)
+  - `TestRoundRobinAndStableFirstSoftFilter_AllLayersSoftEmptyAllowsGlobalFallback` (**#368**)
 - Existing: `routing/cooldown_test.go`, `routing/runtime_health_test.go`, `routing/algorithm_test.go` (partial/all breaker open)
 
 ## Non-goals (R1 / #299 / #336)

--- a/routing/failure_isolation_test.go
+++ b/routing/failure_isolation_test.go
@@ -917,3 +917,194 @@ func TestWeightedSoftFilter_AllLayersSoftEmptyAllowsGlobalFallback(t *testing.T)
 		t.Fatalf("unexpected selected channel %d", selected.Channel.ID)
 	}
 }
+
+// TestRoundRobinSoftFilter_EmptyPriorityDemotesToNext covers #368:
+// when every priority-0 candidate is soft-unhealthy, round_robin must try the
+// next priority (strict soft-filter demotion) instead of pinning via the
+// global FilterRecentlyFailedCandidates full-set fallback. Healthy prio-1 wins.
+func TestRoundRobinSoftFilter_EmptyPriorityDemotesToNext(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	siteRuntimeHealthLoaded = true
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	nowMs := time.Now().UnixMilli()
+	recentISO := time.UnixMilli(nowMs - 2_000).UTC().Format(time.RFC3339)
+	model := "gpt-test"
+	resolve := staticModel(model)
+
+	// Priority 0: recently-failed channel (would previously pin via full-set fallback
+	// when RR applied FilterRecentlyFailedCandidates to the whole available set).
+	c0 := buildTestCandidate(1, 10, 101, 10, 0, 100, 1, 50.0, 1.0, nil, 50.0, &model)
+	c0.Channel.FailCount = 2
+	c0.Channel.LastFailAt = &recentISO
+	// Make prio-0 "earlier" in RR order so without demotion it would win.
+	old := time.UnixMilli(nowMs - 86_400_000).UTC().Format(time.RFC3339)
+	c0.Channel.LastSelectedAt = &old
+
+	// Priority 1: healthy channel
+	c1 := buildTestCandidate(2, 20, 201, 10, 1, 100, 0, 50.0, 1.0, nil, 50.0, &model)
+	recentSel := time.UnixMilli(nowMs - 1_000).UTC().Format(time.RFC3339)
+	c1.Channel.LastSelectedAt = &recentSel
+
+	available := []RouteChannelCandidate{c0, c1}
+
+	strict0 := softFilterCandidatesStrict([]RouteChannelCandidate{c0}, resolve, nowMs, 3600)
+	if len(strict0) != 0 {
+		t.Fatalf("expected strict soft-filter of failed prio-0 layer to be empty, got %d", len(strict0))
+	}
+
+	// Legacy FilterRecentlyFailedCandidates on prio-0 alone would return c0 via full-set fallback.
+	legacy0 := FilterRecentlyFailedCandidates([]RouteChannelCandidate{c0},
+		func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
+		nowMs, 3600)
+	if len(legacy0) != 1 || legacy0[0].Channel.ID != 1 {
+		t.Fatalf("expected legacy filter full-set fallback to pin prio-0 channel 1, got %v", healthyIDs(legacy0))
+	}
+
+	selected := selectAcrossPriorityLayers(available, resolve, nowMs, 3600,
+		func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+			return SelectRoundRobinCandidate(pool)
+		})
+	if selected == nil {
+		t.Fatal("expected selection from healthy priority-1 layer")
+	}
+	if selected.Channel.ID != 2 {
+		t.Fatalf("expected priority-1 channel 2, got channel %d priority %d",
+			selected.Channel.ID, selected.Channel.Priority)
+	}
+	if selected.Channel.Priority != 1 {
+		t.Fatalf("expected priority 1, got %d", selected.Channel.Priority)
+	}
+
+	// Alias used by #358 tests must share the same walk.
+	selectedAlias := selectWeightedAcrossPriorityLayers(available, resolve, nowMs, 3600,
+		func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+			return SelectRoundRobinCandidate(pool)
+		})
+	if selectedAlias == nil || selectedAlias.Channel.ID != 2 {
+		t.Fatalf("alias walk expected channel 2, got %v", channelIDOrNil(selectedAlias))
+	}
+}
+
+// TestStableFirstSoftFilter_EmptyPriorityDemotesToNext covers #368:
+// stable_first must demote a soft-failed prio-0 channel to healthy prio-1 via
+// priority-layer strict soft-filter walk (parity with weighted #358 / RR above).
+func TestStableFirstSoftFilter_EmptyPriorityDemotesToNext(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	siteRuntimeHealthLoaded = true
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	nowMs := time.Now().UnixMilli()
+	recentISO := time.UnixMilli(nowMs - 2_000).UTC().Format(time.RFC3339)
+	model := "gpt-test"
+	resolve := staticModel(model)
+
+	// Priority 0: soft-unhealthy (recent fail). Give it high success history so that
+	// if it leaked into the pool plan it would be primary material.
+	c0 := buildTestCandidate(1, 10, 101, 10, 0, 100, 1, 50.0, 1.0, nil, 50.0, &model)
+	c0.Channel.FailCount = 2
+	c0.Channel.LastFailAt = &recentISO
+	c0.Channel.SuccessCount = 50
+
+	// Priority 1: healthy channel with enough history for primary pool.
+	c1 := buildTestCandidate(2, 20, 201, 10, 1, 100, 0, 50.0, 1.0, nil, 50.0, &model)
+	c1.Channel.SuccessCount = 50
+
+	available := []RouteChannelCandidate{c0, c1}
+
+	strict0 := softFilterCandidatesStrict([]RouteChannelCandidate{c0}, resolve, nowMs, 3600)
+	if len(strict0) != 0 {
+		t.Fatalf("expected strict soft-filter of failed prio-0 layer to be empty, got %d", len(strict0))
+	}
+
+	selected := selectAcrossPriorityLayers(available, resolve, nowMs, 3600,
+		func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+			// Mirror selectFromMatch stable_first branch: plan primary/observation
+			// only on the soft-healthy layer, then pick a deterministic candidate.
+			poolPlan := BuildStableFirstPoolPlan(pool, resolve)
+			selectionPool := poolPlan.PrimaryCandidates
+			if len(selectionPool) == 0 {
+				selectionPool = poolPlan.ObservationCandidates
+			}
+			if len(selectionPool) == 0 {
+				// Fall back to the soft-healthy layer itself if pool plan is empty
+				// (e.g. untrusted sites still need demotion coverage).
+				if len(pool) == 0 {
+					return nil
+				}
+				best := &pool[0]
+				for i := range pool {
+					if pool[i].Channel.ID < best.Channel.ID {
+						best = &pool[i]
+					}
+				}
+				return best
+			}
+			best := &selectionPool[0]
+			for i := range selectionPool {
+				if selectionPool[i].Channel.ID < best.Channel.ID {
+					best = &selectionPool[i]
+				}
+			}
+			return best
+		})
+	if selected == nil {
+		t.Fatal("expected selection from healthy priority-1 layer")
+	}
+	if selected.Channel.ID != 2 {
+		t.Fatalf("expected priority-1 channel 2, got channel %d priority %d",
+			selected.Channel.ID, selected.Channel.Priority)
+	}
+	if selected.Channel.Priority != 1 {
+		t.Fatalf("expected priority 1, got %d", selected.Channel.Priority)
+	}
+}
+
+// TestRoundRobinAndStableFirstSoftFilter_AllLayersSoftEmptyAllowsGlobalFallback
+// covers #368 honesty: when every priority layer is soft-empty, RR and
+// stable_first still return a candidate via the shared global full-set fallback
+// (same starvation guard as weighted #358).
+func TestRoundRobinAndStableFirstSoftFilter_AllLayersSoftEmptyAllowsGlobalFallback(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	siteRuntimeHealthLoaded = true
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	nowMs := time.Now().UnixMilli()
+	recentISO := time.UnixMilli(nowMs - 1_000).UTC().Format(time.RFC3339)
+	model := "gpt-test"
+	resolve := staticModel(model)
+
+	c0 := buildTestCandidate(1, 10, 101, 10, 0, 100, 1, 50.0, 1.0, nil, 50.0, &model)
+	c0.Channel.FailCount = 2
+	c0.Channel.LastFailAt = &recentISO
+	c1 := buildTestCandidate(2, 20, 201, 10, 1, 100, 1, 50.0, 1.0, nil, 50.0, &model)
+	c1.Channel.FailCount = 2
+	c1.Channel.LastFailAt = &recentISO
+
+	available := []RouteChannelCandidate{c0, c1}
+
+	rr := selectAcrossPriorityLayers(available, resolve, nowMs, 3600,
+		func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+			return SelectRoundRobinCandidate(pool)
+		})
+	if rr == nil {
+		t.Fatal("expected RR global fallback selection when all layers soft-empty")
+	}
+	if rr.Channel.ID != 1 && rr.Channel.ID != 2 {
+		t.Fatalf("unexpected RR selected channel %d", rr.Channel.ID)
+	}
+
+	sf := selectAcrossPriorityLayers(available, resolve, nowMs, 3600,
+		func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+			if len(pool) == 0 {
+				return nil
+			}
+			return &pool[0]
+		})
+	if sf == nil {
+		t.Fatal("expected stable_first-style global fallback selection when all layers soft-empty")
+	}
+	if sf.Channel.ID != 1 && sf.Channel.ID != 2 {
+		t.Fatalf("unexpected stable_first selected channel %d", sf.Channel.ID)
+	}
+}

--- a/routing/selector.go
+++ b/routing/selector.go
@@ -278,15 +278,21 @@ func (s *ChannelSelector) selectFromMatch(
 	}
 
 	if strategy == StrategyRoundRobin {
-		// Align with weighted/stable_first: avoid recently-failed channels when healthy
-		// alternatives remain. Without this filter, RR only hard-excludes cooldownUntil
-		// (which starts after RoundRobinFailureThreshold consecutive fails), so a single
-		// failure can be reselected immediately and starve sibling healthy channels.
-		breakerHealthy, _ := GetBreakerFilteredCandidatesByModelResolver(available, resolveModel)
-		filteredCandidates := FilterRecentlyFailedCandidates(breakerHealthy,
-			func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
-			nowMs, s.configuredMaxSec)
-		selected := SelectRoundRobinCandidate(filteredCandidates)
+		// Priority-layer strict soft-filter demotion (#368), same walk as weighted (#358).
+		// Per-layer soft filters use softFilterCandidatesStrict (no full-set pin). Without
+		// the layer walk, a failed prio-0 channel + global FilterRecentlyFailedCandidates
+		// fallback could pin RR onto the broken layer and starve healthy lower-priority
+		// siblings. RR still only hard-excludes cooldownUntil after
+		// RoundRobinFailureThreshold consecutive fails — soft demotion is the early avoid.
+		selected := selectAcrossPriorityLayers(
+			available,
+			resolveModel,
+			nowMs,
+			s.configuredMaxSec,
+			func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+				return SelectRoundRobinCandidate(pool)
+			},
+		)
 		if selected == nil {
 			return nil, nil
 		}
@@ -295,40 +301,50 @@ func (s *ChannelSelector) selectFromMatch(
 	}
 
 	if strategy == StrategyStableFirst {
-		breakerHealthy, _ := GetBreakerFilteredCandidatesByModelResolver(available, resolveModel)
-		filteredCandidates := FilterRecentlyFailedCandidates(breakerHealthy,
-			func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
-			nowMs, s.configuredMaxSec)
-
+		// Priority-layer strict soft-filter demotion (#368). Primary/observation pool
+		// planning runs only on the chosen layer's soft-healthy set so a broken prio-0
+		// site does not pin stable_first when a healthy prio-1 alternative exists.
 		rotationKey := BuildStableFirstRotationKey(match.Route.ID, requestedModel)
-		poolPlan := BuildStableFirstPoolPlan(filteredCandidates, resolveModel)
+		usedObservation := false
+		selected := selectAcrossPriorityLayers(
+			available,
+			resolveModel,
+			nowMs,
+			s.configuredMaxSec,
+			func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+				poolPlan := BuildStableFirstPoolPlan(pool, resolveModel)
 
-		shouldUseObservation := len(poolPlan.ObservationCandidates) > 0 &&
-			(len(poolPlan.PrimaryCandidates) == 0 ||
-				(recordSelection && ShouldUseStableFirstObservationCandidate(rotationKey, poolPlan.ObservationCandidates)))
+				shouldUseObservation := len(poolPlan.ObservationCandidates) > 0 &&
+					(len(poolPlan.PrimaryCandidates) == 0 ||
+						(recordSelection && ShouldUseStableFirstObservationCandidate(rotationKey, poolPlan.ObservationCandidates)))
 
-		var selectionPool []RouteChannelCandidate
-		if shouldUseObservation {
-			selectionPool = poolPlan.ObservationCandidates
-		} else if len(poolPlan.PrimaryCandidates) > 0 {
-			selectionPool = poolPlan.PrimaryCandidates
-		} else {
-			selectionPool = poolPlan.ObservationCandidates
-		}
+				var selectionPool []RouteChannelCandidate
+				if shouldUseObservation {
+					selectionPool = poolPlan.ObservationCandidates
+				} else if len(poolPlan.PrimaryCandidates) > 0 {
+					selectionPool = poolPlan.PrimaryCandidates
+				} else {
+					selectionPool = poolPlan.ObservationCandidates
+				}
+				if len(selectionPool) == 0 {
+					return nil
+				}
 
-		if len(selectionPool) == 0 {
-			return nil, nil
-		}
-
-		selected := s.stableFirstSelect(selectionPool, resolveModel, policy,
-			shouldUseObservation, rotationKey)
+				picked := s.stableFirstSelect(selectionPool, resolveModel, policy,
+					shouldUseObservation, rotationKey)
+				if picked != nil {
+					usedObservation = shouldUseObservation
+				}
+				return picked
+			},
+		)
 		if selected == nil {
 			return nil, nil
 		}
 
 		obsKey := rotationKey + ":observe"
 		return s.finalizeDispatch(ctx, selected, match, requestedModel, mappedModel, policy,
-			recordSelection, rotationKey, obsKey, shouldUseObservation, excludeChannelIDs, nowISO, nowMs)
+			recordSelection, rotationKey, obsKey, usedObservation, excludeChannelIDs, nowISO, nowMs)
 	}
 
 	// Deterministic pluggable strategies (#115): least_busy / lowest_latency / lowest_cost.
@@ -354,8 +370,8 @@ func (s *ChannelSelector) selectFromMatch(
 			recordSelection, "", "", false, excludeChannelIDs, nowISO, nowMs)
 	}
 
-	// Weighted: priority layers (#358 soft-filter demotion).
-	selected := selectWeightedAcrossPriorityLayers(
+	// Weighted: priority layers (#358 soft-filter demotion; shared walk with #368).
+	selected := selectAcrossPriorityLayers(
 		available,
 		resolveModel,
 		nowMs,
@@ -371,12 +387,21 @@ func (s *ChannelSelector) selectFromMatch(
 		recordSelection, "", "", false, excludeChannelIDs, nowISO, nowMs)
 }
 
-// selectWeightedAcrossPriorityLayers walks priority layers low→high. Per-layer soft
-// filters use softFilterCandidatesStrict (no full-set pin). If a layer is entirely
-// soft-empty, try the next priority. Only when ALL layers are soft-empty does the
-// global FilterRecentlyFailed / breaker full-set fallback apply (starvation guard).
-// See #358.
-func selectWeightedAcrossPriorityLayers(
+// selectAcrossPriorityLayers walks priority layers low→high for weighted (#358),
+// round_robin and stable_first (#368). Per-layer soft filters use
+// softFilterCandidatesStrict (no full-set pin). If a layer is entirely soft-empty,
+// try the next priority. Only when ALL layers are soft-empty does the global
+// FilterRecentlyFailed / breaker full-set fallback apply (starvation guard).
+//
+// Algorithm-specific pick happens via selectFromPool on each non-empty layer.
+// Hard excludes (eligibility / excludeChannelIDs) remain upstream.
+//
+// Honest global fallback: when every layer is soft-empty we deliberately re-enter
+// FilterRecentlyFailedCandidates (full-set pin when soft-empty) so the request still
+// attempts something rather than returning nil. That pin is a last resort, not the
+// happy path — priority demotion above is what prevents a broken prio-0 layer from
+// starving healthy lower-priority siblings.
+func selectAcrossPriorityLayers(
 	available []RouteChannelCandidate,
 	resolveModel func(RouteChannelCandidate) string,
 	nowMs int64,
@@ -416,12 +441,27 @@ func selectWeightedAcrossPriorityLayers(
 		}
 	}
 
-	// All priority layers soft-empty → global fallback with existing full-set behavior.
+	// All priority layers soft-empty → honest global fallback with existing full-set
+	// pin behavior (FilterRecentlyFailedCandidates returns the input when soft-empty).
+	// Prefer this over returning nil when every candidate is in soft-failure state —
+	// request must still attempt something; hard excludes already ran upstream.
 	breakerHealthy, _ := GetBreakerFilteredCandidatesByModelResolver(available, resolveModel)
 	filteredGlobal := FilterRecentlyFailedCandidates(breakerHealthy,
 		func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
 		nowMs, configuredMaxSec)
 	return selectFromPool(filteredGlobal)
+}
+
+// selectWeightedAcrossPriorityLayers is retained as a thin alias for tests and
+// any external references to the #358 name.
+func selectWeightedAcrossPriorityLayers(
+	available []RouteChannelCandidate,
+	resolveModel func(RouteChannelCandidate) string,
+	nowMs int64,
+	configuredMaxSec int,
+	selectFromPool func([]RouteChannelCandidate) *RouteChannelCandidate,
+) *RouteChannelCandidate {
+	return selectAcrossPriorityLayers(available, resolveModel, nowMs, configuredMaxSec, selectFromPool)
 }
 
 // softFilterCandidatesStrict applies site/model breaker then recent-failure


### PR DESCRIPTION
## Summary
- Round_robin and stable_first now walk priority layers with `softFilterCandidatesStrict` (shared `selectAcrossPriorityLayers`), matching weighted soft-filter demotion from #358.
- Soft-empty higher-priority layers demote to the next priority instead of pinning via global `FilterRecentlyFailedCandidates` full-set fallback.
- When **all** layers are soft-empty, the honest global full-set fallback still applies (starvation guard). Documented in selector comments + minimal honesty update in `docs/analysis/failover-isolation.md`.

## Tests
- `TestRoundRobinSoftFilter_EmptyPriorityDemotesToNext`
- `TestStableFirstSoftFilter_EmptyPriorityDemotesToNext`
- `TestRoundRobinAndStableFirstSoftFilter_AllLayersSoftEmptyAllowsGlobalFallback`
- `go test ./routing -count=1`
- pre-push: `go vet ./...` + `go test ./... -count=1 -race`

Closes #368