### PR TITLE
fix(routing): RR/stable/least_* soft-filter priority demotion (#368)

### DIFF
--- a/routing/failure_isolation_test.go
+++ b/routing/failure_isolation_test.go
@@ -917,3 +917,77 @@ func TestWeightedSoftFilter_AllLayersSoftEmptyAllowsGlobalFallback(t *testing.T)
 		t.Fatalf("unexpected selected channel %d", selected.Channel.ID)
 	}
 }
+
+// TestRRSoftFilter_EmptyPriorityDemotesToNext covers #368: round-robin must
+// demote soft-empty priority-0 to healthy priority-1 (parity with weighted #358).
+func TestRRSoftFilter_EmptyPriorityDemotesToNext(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	siteRuntimeHealthLoaded = true
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	nowMs := time.Now().UnixMilli()
+	recentISO := time.UnixMilli(nowMs - 2_000).UTC().Format(time.RFC3339)
+	model := "gpt-test"
+	resolve := staticModel(model)
+
+	c0a := buildTestCandidate(1, 10, 101, 10, 0, 100, 1, 50.0, 1.0, nil, 50.0, &model)
+	c0a.Channel.FailCount = 2
+	c0a.Channel.LastFailAt = &recentISO
+	c0b := buildTestCandidate(2, 11, 102, 10, 0, 100, 1, 50.0, 1.0, nil, 50.0, &model)
+	c0b.Channel.FailCount = 3
+	c0b.Channel.LastFailAt = &recentISO
+	c1 := buildTestCandidate(3, 20, 201, 10, 1, 100, 0, 50.0, 1.0, nil, 50.0, &model)
+
+	available := []RouteChannelCandidate{c0a, c0b, c1}
+	selected := selectAcrossPriorityLayersStrict(available, resolve, nowMs, 3600,
+		func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+			return SelectRoundRobinCandidate(pool)
+		})
+	if selected == nil {
+		t.Fatal("expected selection from healthy priority-1 layer")
+	}
+	if selected.Channel.ID != 3 {
+		t.Fatalf("expected priority-1 channel 3, got channel %d priority %d",
+			selected.Channel.ID, selected.Channel.Priority)
+	}
+}
+
+// TestStableFirstSoftFilter_EmptyPriorityDemotesToNext covers #368: stable_first
+// demotes soft-empty priority-0 to healthy priority-1.
+func TestStableFirstSoftFilter_EmptyPriorityDemotesToNext(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	siteRuntimeHealthLoaded = true
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	nowMs := time.Now().UnixMilli()
+	recentISO := time.UnixMilli(nowMs - 2_000).UTC().Format(time.RFC3339)
+	model := "gpt-test"
+	resolve := staticModel(model)
+
+	c0 := buildTestCandidate(1, 10, 101, 10, 0, 100, 1, 50.0, 1.0, nil, 50.0, &model)
+	c0.Channel.FailCount = 2
+	c0.Channel.LastFailAt = &recentISO
+	c1 := buildTestCandidate(3, 20, 201, 10, 1, 100, 0, 50.0, 1.0, nil, 50.0, &model)
+
+	available := []RouteChannelCandidate{c0, c1}
+	selected := selectAcrossPriorityLayersStrict(available, resolve, nowMs, 3600,
+		func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+			if len(pool) == 0 {
+				return nil
+			}
+			// Deterministic: prefer lowest channel ID in the filtered layer.
+			best := &pool[0]
+			for i := range pool {
+				if pool[i].Channel.ID < best.Channel.ID {
+					best = &pool[i]
+				}
+			}
+			return best
+		})
+	if selected == nil {
+		t.Fatal("expected selection from healthy priority-1 layer")
+	}
+	if selected.Channel.ID != 3 {
+		t.Fatalf("expected priority-1 channel 3, got channel %d", selected.Channel.ID)
+	}
+}

--- a/routing/selector.go
+++ b/routing/selector.go
@@ -278,15 +278,18 @@ func (s *ChannelSelector) selectFromMatch(
 	}
 
 	if strategy == StrategyRoundRobin {
-		// Align with weighted/stable_first: avoid recently-failed channels when healthy
-		// alternatives remain. Without this filter, RR only hard-excludes cooldownUntil
-		// (which starts after RoundRobinFailureThreshold consecutive fails), so a single
-		// failure can be reselected immediately and starve sibling healthy channels.
-		breakerHealthy, _ := GetBreakerFilteredCandidatesByModelResolver(available, resolveModel)
-		filteredCandidates := FilterRecentlyFailedCandidates(breakerHealthy,
-			func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
-			nowMs, s.configuredMaxSec)
-		selected := SelectRoundRobinCandidate(filteredCandidates)
+		// #368: same priority-layer strict soft-filter demotion as weighted (#358).
+		// Soft-empty higher priority demotes to next; global full-set fallback only
+		// when every layer is soft-empty (starvation guard).
+		selected := selectAcrossPriorityLayersStrict(
+			available,
+			resolveModel,
+			nowMs,
+			s.configuredMaxSec,
+			func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+				return SelectRoundRobinCandidate(pool)
+			},
+		)
 		if selected == nil {
 			return nil, nil
 		}
@@ -295,58 +298,65 @@ func (s *ChannelSelector) selectFromMatch(
 	}
 
 	if strategy == StrategyStableFirst {
-		breakerHealthy, _ := GetBreakerFilteredCandidatesByModelResolver(available, resolveModel)
-		filteredCandidates := FilterRecentlyFailedCandidates(breakerHealthy,
-			func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
-			nowMs, s.configuredMaxSec)
-
+		// #368: walk priority layers with strict soft-filter before stable_first pools.
 		rotationKey := BuildStableFirstRotationKey(match.Route.ID, requestedModel)
-		poolPlan := BuildStableFirstPoolPlan(filteredCandidates, resolveModel)
-
-		shouldUseObservation := len(poolPlan.ObservationCandidates) > 0 &&
-			(len(poolPlan.PrimaryCandidates) == 0 ||
-				(recordSelection && ShouldUseStableFirstObservationCandidate(rotationKey, poolPlan.ObservationCandidates)))
-
-		var selectionPool []RouteChannelCandidate
-		if shouldUseObservation {
-			selectionPool = poolPlan.ObservationCandidates
-		} else if len(poolPlan.PrimaryCandidates) > 0 {
-			selectionPool = poolPlan.PrimaryCandidates
-		} else {
-			selectionPool = poolPlan.ObservationCandidates
-		}
-
-		if len(selectionPool) == 0 {
-			return nil, nil
-		}
-
-		selected := s.stableFirstSelect(selectionPool, resolveModel, policy,
-			shouldUseObservation, rotationKey)
+		var usedObservation bool
+		selected := selectAcrossPriorityLayersStrict(
+			available,
+			resolveModel,
+			nowMs,
+			s.configuredMaxSec,
+			func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+				poolPlan := BuildStableFirstPoolPlan(pool, resolveModel)
+				shouldUseObservation := len(poolPlan.ObservationCandidates) > 0 &&
+					(len(poolPlan.PrimaryCandidates) == 0 ||
+						(recordSelection && ShouldUseStableFirstObservationCandidate(rotationKey, poolPlan.ObservationCandidates)))
+				var selectionPool []RouteChannelCandidate
+				if shouldUseObservation {
+					selectionPool = poolPlan.ObservationCandidates
+				} else if len(poolPlan.PrimaryCandidates) > 0 {
+					selectionPool = poolPlan.PrimaryCandidates
+				} else {
+					selectionPool = poolPlan.ObservationCandidates
+				}
+				if len(selectionPool) == 0 {
+					return nil
+				}
+				picked := s.stableFirstSelect(selectionPool, resolveModel, policy,
+					shouldUseObservation, rotationKey)
+				if picked != nil {
+					usedObservation = shouldUseObservation
+				}
+				return picked
+			},
+		)
 		if selected == nil {
 			return nil, nil
 		}
-
 		obsKey := rotationKey + ":observe"
 		return s.finalizeDispatch(ctx, selected, match, requestedModel, mappedModel, policy,
-			recordSelection, rotationKey, obsKey, shouldUseObservation, excludeChannelIDs, nowISO, nowMs)
+			recordSelection, rotationKey, obsKey, usedObservation, excludeChannelIDs, nowISO, nowMs)
 	}
 
 	// Deterministic pluggable strategies (#115): least_busy / lowest_latency / lowest_cost.
-	// Same eligibility + recent-failure filters as weighted; exclude lists remain upstream.
+	// #368: same priority-layer strict soft-filter demotion as weighted.
 	if strategy == StrategyLeastBusy || strategy == StrategyLowestLatency || strategy == StrategyLowestCost {
-		breakerHealthy, _ := GetBreakerFilteredCandidatesByModelResolver(available, resolveModel)
-		filteredCandidates := FilterRecentlyFailedCandidates(breakerHealthy,
-			func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
-			nowMs, s.configuredMaxSec)
-		var selected *RouteChannelCandidate
-		switch strategy {
-		case StrategyLeastBusy:
-			selected = SelectLeastBusyCandidate(filteredCandidates, s.channelLoadProvider)
-		case StrategyLowestLatency:
-			selected = SelectLowestLatencyCandidate(filteredCandidates, resolveModel)
-		default:
-			selected = SelectLowestCostCandidate(filteredCandidates, resolveModel, s.pricingFn, s.fallbackUnitCost)
-		}
+		selected := selectAcrossPriorityLayersStrict(
+			available,
+			resolveModel,
+			nowMs,
+			s.configuredMaxSec,
+			func(pool []RouteChannelCandidate) *RouteChannelCandidate {
+				switch strategy {
+				case StrategyLeastBusy:
+					return SelectLeastBusyCandidate(pool, s.channelLoadProvider)
+				case StrategyLowestLatency:
+					return SelectLowestLatencyCandidate(pool, resolveModel)
+				default:
+					return SelectLowestCostCandidate(pool, resolveModel, s.pricingFn, s.fallbackUnitCost)
+				}
+			},
+		)
 		if selected == nil {
 			return nil, nil
 		}
@@ -355,7 +365,7 @@ func (s *ChannelSelector) selectFromMatch(
 	}
 
 	// Weighted: priority layers (#358 soft-filter demotion).
-	selected := selectWeightedAcrossPriorityLayers(
+	selected := selectAcrossPriorityLayersStrict(
 		available,
 		resolveModel,
 		nowMs,
@@ -371,12 +381,12 @@ func (s *ChannelSelector) selectFromMatch(
 		recordSelection, "", "", false, excludeChannelIDs, nowISO, nowMs)
 }
 
-// selectWeightedAcrossPriorityLayers walks priority layers low→high. Per-layer soft
+// selectAcrossPriorityLayersStrict walks priority layers low→high. Per-layer soft
 // filters use softFilterCandidatesStrict (no full-set pin). If a layer is entirely
 // soft-empty, try the next priority. Only when ALL layers are soft-empty does the
 // global FilterRecentlyFailed / breaker full-set fallback apply (starvation guard).
-// See #358.
-func selectWeightedAcrossPriorityLayers(
+// Used by weighted (#358) and RR/stable_first/least_* (#368).
+func selectAcrossPriorityLayersStrict(
 	available []RouteChannelCandidate,
 	resolveModel func(RouteChannelCandidate) string,
 	nowMs int64,
@@ -422,6 +432,17 @@ func selectWeightedAcrossPriorityLayers(
 		func(c RouteChannelCandidate) (*int64, *string) { return &c.Channel.FailCount, c.Channel.LastFailAt },
 		nowMs, configuredMaxSec)
 	return selectFromPool(filteredGlobal)
+}
+
+// selectWeightedAcrossPriorityLayers is the historical name for weighted callers/tests (#358).
+func selectWeightedAcrossPriorityLayers(
+	available []RouteChannelCandidate,
+	resolveModel func(RouteChannelCandidate) string,
+	nowMs int64,
+	configuredMaxSec int,
+	selectFromPool func([]RouteChannelCandidate) *RouteChannelCandidate,
+) *RouteChannelCandidate {
+	return selectAcrossPriorityLayersStrict(available, resolveModel, nowMs, configuredMaxSec, selectFromPool)
 }
 
 // softFilterCandidatesStrict applies site/model breaker then recent-failure


### PR DESCRIPTION
## Summary
- RR, stable_first, and least_* strategies walk priority layers with **strict** soft-filter demotion (parity with weighted #358)
- Soft-empty higher priority → next priority; global full-set fallback only when **all** layers soft-empty
- Tests for RR + stable_first demotion

Closes #368

## Test plan
- [x] `go test ./routing -count=1`
- [x] pre-push race suite