### PR TITLE
fix(admin): redact account list secrets (#367)

### DIFF
--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/tokendancelab/metapi-go/config"
 	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/service"
 	"github.com/tokendancelab/metapi-go/service/alert"
 	"github.com/tokendancelab/metapi-go/store"
 )
@@ -2401,5 +2402,63 @@ func TestAccounts_Update_ExtraConfigAndProxyURLMergeTogether(t *testing.T) {
 	}
 	if cfg["platformUserId"] != float64(42) {
 		t.Fatalf("platformUserId = %#v, want 42", cfg["platformUserId"])
+	}
+}
+
+func TestListAccounts_RedactsAccessTokenAndAPIToken(t *testing.T) {
+	db, _, _ := setupAccountsTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	siteRes, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, sort_order, created_at, updated_at)
+		 VALUES (?, ?, ?, 'active', 0, ?, ?)`,
+		"redact-site", "https://example.com", "openai", now, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	siteID, _ := siteRes.LastInsertId()
+	secret := "sk-list-secret-ABCDEFGH"
+	apiTok := "sk-api-token-XYZ12345"
+	res, err := db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, api_token, balance, balance_used, quota, value_score, status, is_pinned, sort_order, checkin_enabled, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, 0, 0, 0, 0, 'active', 0, 0, 0, ?, ?)`,
+		siteID, "redact-user", secret, apiTok, now, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, _ := res.LastInsertId()
+
+	items, err := service.ListAccountsWithSites(db.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found map[string]any
+	for _, it := range items {
+		switch v := it["id"].(type) {
+		case int64:
+			if v == id {
+				found = it
+			}
+		case float64:
+			if int64(v) == id {
+				found = it
+			}
+		}
+	}
+	if found == nil {
+		t.Fatalf("account %d not in list (%d items)", id, len(items))
+	}
+	if v, ok := found["accessToken"]; ok && v != nil && v != "" {
+		t.Fatalf("list leaked accessToken: %#v", v)
+	}
+	if v, ok := found["apiToken"]; ok && v != nil && v != "" {
+		t.Fatalf("list leaked apiToken: %#v", v)
+	}
+	if got, _ := found["accessTokenMasked"].(string); got == "" || strings.Contains(got, secret) {
+		t.Fatalf("accessTokenMasked = %#v", found["accessTokenMasked"])
+	}
+	if got, _ := found["apiTokenMasked"].(string); got == "" || strings.Contains(got, apiTok) {
+		t.Fatalf("apiTokenMasked = %#v", found["apiTokenMasked"])
 	}
 }

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -548,7 +548,51 @@ func enrichAccountOverviewRow(account map[string]any) map[string]any {
 	delete(account, "siteUrl")
 	delete(account, "sitePlatform")
 	delete(account, "siteStatus")
+	// List/overview must not return plaintext secrets (#367). Create/update/rebind
+	// responses may still echo once; those paths build maps outside this helper.
+	redactAccountSecrets(account)
 	return account
+}
+
+// redactAccountSecrets removes plaintext credentials from admin list/overview rows.
+// Sets accessTokenMasked / apiTokenMasked when a value was present.
+func redactAccountSecrets(account map[string]any) {
+	if account == nil {
+		return
+	}
+	if v := asString(account["accessToken"]); strings.TrimSpace(v) != "" {
+		account["accessTokenMasked"] = maskSecretTail(v)
+	}
+	delete(account, "accessToken")
+	if v := asString(account["apiToken"]); strings.TrimSpace(v) != "" {
+		account["apiTokenMasked"] = maskSecretTail(v)
+	}
+	delete(account, "apiToken")
+	// Never leak passwordCipher from extraConfig on list surfaces.
+	if ec := asStringPtr(account["extraConfig"]); ec != nil && strings.Contains(*ec, "passwordCipher") {
+		var m map[string]any
+		if err := json.Unmarshal([]byte(*ec), &m); err == nil {
+			if auto, ok := m["autoRelogin"].(map[string]any); ok {
+				delete(auto, "passwordCipher")
+				m["autoRelogin"] = auto
+				if b, err := json.Marshal(m); err == nil {
+					s := string(b)
+					account["extraConfig"] = s
+				}
+			}
+		}
+	}
+}
+
+func maskSecretTail(secret string) string {
+	s := strings.TrimSpace(secret)
+	if s == "" {
+		return ""
+	}
+	if len(s) <= 8 {
+		return "****"
+	}
+	return s[:4] + "****" + s[len(s)-4:]
 }
 
 func normalizeMapScanValues(m map[string]any) {

--- a/service/account_token_service.go
+++ b/service/account_token_service.go
@@ -161,6 +161,9 @@ func ListTokensWithRelations(db *sqlx.DB, accountID *int64) ([]map[string]any, e
 			row["valueStatus"] = vs
 		}
 		delete(row, "token") // Remove plain token
+		// Drop account secrets that were only needed for API-key connection filter (#367).
+		delete(row, "access_token")
+		delete(row, "extra_config")
 		// Add account and site sub-objects
 		row["account"] = map[string]any{
 			"id":       row["account_id_val"],


### PR DESCRIPTION
## Summary
- `ListAccountsWithSites` redacts `accessToken`/`apiToken` (masked only) and strips `passwordCipher` from list `extraConfig`
- Account-token list drops `access_token`/`extra_config` join fields after API-key filter
- Credential **export** remains intentional product path; create/update may still echo once outside list enrichment

Closes #367

## Test plan
- [x] `go test ./service ./handler/admin -count=1`
- [x] pre-push race suite