### PR TITLE
fix(admin): redact remaining secret surfaces on list/get (#367)

### DIFF
--- a/handler/admin/account_tokens.go
+++ b/handler/admin/account_tokens.go
@@ -500,9 +500,15 @@ func (h *accountTokensHandler) updateToken(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusInternalServerError, "读取令牌失败")
 		return
 	}
+	// Update response is a list/get-style surface: return masked token only (#367).
+	var site store.Site
+	var ownerAcct store.Account
+	if err := h.db.Get(&ownerAcct, h.db.Rebind("SELECT * FROM accounts WHERE id = ?"), latest.AccountID); err == nil {
+		_ = h.db.Get(&site, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), ownerAcct.SiteID)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success": true,
-		"token":   latest,
+		"token":   tokenToMap(*latest, site.Platform),
 	})
 }
 
@@ -599,6 +605,8 @@ func (h *accountTokensHandler) getTokenValue(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// Intentional export-secret path: full token returned only on explicit /value
+	// fetch after admin auth. List/create/update use tokenMasked instead (#367).
 	displayToken := service.NormalizeTokenForDisplay(token.Token, site.Platform)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success":     true,

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -118,6 +118,10 @@ func (h *accountsHandler) listAccounts(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load accounts"})
 		return
 	}
+	// List/get snapshot must not return plaintext credentials (#367).
+	for _, account := range accounts {
+		redactAccountSecrets(account)
+	}
 
 	// Also fetch sites for the response
 	var sites []store.Site
@@ -289,6 +293,8 @@ func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) 
 	caps := service.BuildCapabilitiesForAccount(&account)
 	routing.InvalidateCache()
 	globalAccountsCache.clear()
+	// Create-once: echo the credential just entered. No plaintext apiToken field;
+	// presence is indicated by apiTokenFound only (#367).
 	writeJSON(w, http.StatusOK, map[string]any{
 		"id":               account.ID,
 		"siteId":           account.SiteID,
@@ -636,18 +642,19 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "Failed to load account."})
 		return
 	}
+	// Login mutation: echo the session just obtained. Scrub nested extraConfig
+	// secrets and omit apiToken plaintext (use apiTokenFound) (#367).
 	loginAcctMap := map[string]any{
 		"id":             loginAcct.ID,
 		"siteId":         loginAcct.SiteID,
 		"username":       loginAcct.Username,
 		"accessToken":    loginAcct.AccessToken,
-		"apiToken":       loginAcct.APIToken,
 		"balance":        loginAcct.Balance,
 		"status":         loginAcct.Status,
 		"isPinned":       loginAcct.IsPinned,
 		"sortOrder":      loginAcct.SortOrder,
 		"checkinEnabled": loginAcct.CheckinEnabled,
-		"extraConfig":    loginAcct.ExtraConfig,
+		"extraConfig":    redactExtraConfigSecrets(loginAcct.ExtraConfig),
 		"createdAt":      loginAcct.CreatedAt,
 		"updatedAt":      loginAcct.UpdatedAt,
 	}
@@ -714,6 +721,11 @@ func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Probe response: mask any discovered API token; FE only needs presence/prefix (#367).
+	apiTokenPreview := ""
+	if result.APIToken != "" {
+		apiTokenPreview = maskAccountSecret(result.APIToken)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success":       true,
 		"tokenType":     result.TokenType,
@@ -721,7 +733,7 @@ func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 		"models":        result.Models,
 		"userInfo":      result.UserInfo,
 		"balance":       result.Balance,
-		"apiToken":      result.APIToken,
+		"apiToken":      apiTokenPreview,
 		"apiTokenFound": result.APIToken != "",
 	})
 }
@@ -911,18 +923,19 @@ func (h *accountsHandler) rebindSession(w http.ResponseWriter, r *http.Request) 
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "failed to read updated account"})
 		return
 	}
+	// Rebind mutation: echo the new session token just written. Scrub nested
+	// extraConfig secrets; omit apiToken plaintext (#367).
 	rebindAcctMap := map[string]any{
 		"id":             rebindAcct.ID,
 		"siteId":         rebindAcct.SiteID,
 		"username":       rebindAcct.Username,
 		"accessToken":    rebindAcct.AccessToken,
-		"apiToken":       rebindAcct.APIToken,
 		"balance":        rebindAcct.Balance,
 		"status":         rebindAcct.Status,
 		"isPinned":       rebindAcct.IsPinned,
 		"sortOrder":      rebindAcct.SortOrder,
 		"checkinEnabled": rebindAcct.CheckinEnabled,
-		"extraConfig":    rebindAcct.ExtraConfig,
+		"extraConfig":    redactExtraConfigSecrets(rebindAcct.ExtraConfig),
 		"createdAt":      rebindAcct.CreatedAt,
 		"updatedAt":      rebindAcct.UpdatedAt,
 	}
@@ -1132,12 +1145,13 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 	if recovery && modelRefreshSucceeded(modelRefresh) {
 		hasDiscoveredModels = true
 	}
+	// Update/get-style response: never return plaintext credentials (#367).
 	resp := map[string]any{
 		"id":                 updated.ID,
 		"siteId":             updated.SiteID,
 		"username":           updated.Username,
-		"accessToken":        updated.AccessToken,
-		"apiToken":           updated.APIToken,
+		"accessToken":        maskAccountSecret(updated.AccessToken),
+		"apiToken":           maskOptionalAccountSecret(updated.APIToken),
 		"balance":            updated.Balance,
 		"balanceUsed":        updated.BalanceUsed,
 		"quota":              updated.Quota,
@@ -1152,7 +1166,7 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 		"oauthProvider":      updated.OAuthProvider,
 		"oauthAccountKey":    updated.OAuthAccountKey,
 		"oauthProjectId":     updated.OAuthProjectID,
-		"extraConfig":        updated.ExtraConfig,
+		"extraConfig":        redactExtraConfigSecrets(updated.ExtraConfig),
 		"createdAt":          updated.CreatedAt,
 		"updatedAt":          updated.UpdatedAt,
 		"credentialMode":     string(service.ResolveStoredCredentialMode(&updated)),

--- a/handler/admin/credential_export.go
+++ b/handler/admin/credential_export.go
@@ -10,6 +10,9 @@ import (
 
 const credentialExportFormatVersion = "1.0.0"
 
+// exportKey is an intentional export-secret product path: it returns the full
+// downstream key inside adapter profiles for operator copy/export. List/summary/
+// overview redaction (#355/#367) intentionally does not apply here.
 func (h *downstreamKeysHandler) exportKey(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseInt(idStr, 10, 64)

--- a/handler/admin/oauth_routes.go
+++ b/handler/admin/oauth_routes.go
@@ -209,6 +209,10 @@ func (h *oauthHandler) listConnections(w http.ResponseWriter, r *http.Request) {
 		 WHERE a.oauth_provider IS NOT NULL
 		 ORDER BY a.id ASC LIMIT ? OFFSET ?`,
 		limit, offset)
+	// Fallback list path (tests / no oauth service DB): redact secrets (#367).
+	for _, row := range rows {
+		redactAccountSecrets(row)
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"connections": normalizeSlice(rows),

--- a/handler/admin/search.go
+++ b/handler/admin/search.go
@@ -116,6 +116,13 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 		 ORDER BY account_count DESC LIMIT ?`,
 		likePattern, perCategory)
 
+	// Search is a list/summary surface: redact account + token secrets (#367).
+	for _, row := range accounts {
+		redactAccountSecrets(row)
+	}
+	for _, row := range accountTokens {
+		redactAccountTokenSecrets(row)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"accounts":      normalizeSlice(accounts),
 		"accountTokens": normalizeSlice(accountTokens),

--- a/handler/admin/secret_redact.go
+++ b/handler/admin/secret_redact.go
@@ -1,0 +1,234 @@
+package admin
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/tokendancelab/metapi-go/service"
+)
+
+// maskAccountSecret masks account-level credential material for list/get/summary
+// responses. Prefer this over returning plaintext accessToken/apiToken (#367).
+// Empty input stays empty so absence remains distinguishable from presence.
+func maskAccountSecret(secret string) string {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return ""
+	}
+	return service.MaskToken(secret, "")
+}
+
+// maskOptionalAccountSecret masks a nullable account secret pointer for JSON.
+func maskOptionalAccountSecret(secret *string) any {
+	if secret == nil {
+		return nil
+	}
+	masked := maskAccountSecret(*secret)
+	if masked == "" {
+		return nil
+	}
+	return masked
+}
+
+// redactAccountSecrets rewrites account-shaped admin JSON maps so list/get/summary
+// never return plaintext accessToken/apiToken. Masked values stay under the same
+// field names so existing clients that only need presence/prefix keep working.
+// Nested extraConfig secrets (refreshToken, passwordCipher, oauth tokens) are
+// also scrubbed when present as JSON text or nested maps.
+//
+// Intentional create-once / rebind / verify / export paths must not call this.
+func redactAccountSecrets(row map[string]any) {
+	if row == nil {
+		return
+	}
+	if v, ok := row["accessToken"].(string); ok {
+		row["accessToken"] = maskAccountSecret(v)
+	}
+	switch v := row["apiToken"].(type) {
+	case string:
+		row["apiToken"] = maskAccountSecret(v)
+	case *string:
+		if v == nil {
+			row["apiToken"] = nil
+		} else {
+			masked := maskAccountSecret(*v)
+			if masked == "" {
+				row["apiToken"] = nil
+			} else {
+				row["apiToken"] = masked
+			}
+		}
+	}
+	if ec, ok := row["extraConfig"]; ok {
+		row["extraConfig"] = redactExtraConfigSecrets(ec)
+	}
+}
+
+// redactAccountTokenSecrets removes plaintext token material from account-token
+// list/search/default maps. Prefer tokenMasked (set by callers when known).
+func redactAccountTokenSecrets(row map[string]any) {
+	if row == nil {
+		return
+	}
+	if token, ok := row["token"].(string); ok && token != "" {
+		if _, hasMasked := row["tokenMasked"]; !hasMasked {
+			platform := ""
+			if site, ok := row["site"].(map[string]any); ok {
+				if p, ok := site["platform"].(string); ok {
+					platform = p
+				}
+			}
+			if p, ok := row["sitePlatform"].(string); ok && platform == "" {
+				platform = p
+			}
+			row["tokenMasked"] = service.MaskToken(token, platform)
+		}
+	}
+	delete(row, "token")
+	// Nested account join fields from search must not leak session secrets.
+	if account, ok := row["account"].(map[string]any); ok {
+		redactAccountSecrets(account)
+	}
+	// Flat join columns from SELECT at.*, a.access_token ...
+	if v, ok := row["accessToken"].(string); ok {
+		row["accessToken"] = maskAccountSecret(v)
+	}
+	if v, ok := row["apiToken"].(string); ok {
+		row["apiToken"] = maskAccountSecret(v)
+	}
+}
+
+// redactExtraConfigSecrets scrubs nested secret fields while preserving non-secret
+// config used by the admin UI (credentialMode, proxyUrl, platformUserId, etc.).
+func redactExtraConfigSecrets(extra any) any {
+	switch typed := extra.(type) {
+	case nil:
+		return nil
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if trimmed == "" {
+			return typed
+		}
+		var parsed any
+		if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+			return typed
+		}
+		redacted := scrubExtraConfigValue(parsed)
+		b, err := json.Marshal(redacted)
+		if err != nil {
+			return typed
+		}
+		return string(b)
+	case *string:
+		if typed == nil {
+			return nil
+		}
+		out := redactExtraConfigSecrets(*typed)
+		if s, ok := out.(string); ok {
+			return s
+		}
+		return out
+	case map[string]any:
+		return scrubExtraConfigValue(typed)
+	default:
+		return extra
+	}
+}
+
+func scrubExtraConfigValue(v any) any {
+	switch typed := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for k, child := range typed {
+			switch k {
+			case "refreshToken", "passwordCipher", "accessToken", "apiToken",
+				"idToken", "access_token", "refresh_token", "api_token":
+				if s, ok := child.(string); ok {
+					out[k] = maskAccountSecret(s)
+				} else if child == nil {
+					out[k] = nil
+				} else {
+					out[k] = "****"
+				}
+			case "oauth":
+				out[k] = scrubOAuthConfig(child)
+			case "sub2apiAuth", "autoRelogin":
+				out[k] = scrubExtraConfigValue(child)
+			default:
+				out[k] = scrubExtraConfigValue(child)
+			}
+		}
+		return out
+	case []any:
+		out := make([]any, len(typed))
+		for i, child := range typed {
+			out[i] = scrubExtraConfigValue(child)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func scrubOAuthConfig(v any) any {
+	m, ok := v.(map[string]any)
+	if !ok || m == nil {
+		return v
+	}
+	out := make(map[string]any, len(m))
+	for k, child := range m {
+		switch k {
+		case "refreshToken", "accessToken", "idToken", "access_token", "refresh_token", "token":
+			if s, ok := child.(string); ok {
+				out[k] = maskAccountSecret(s)
+			} else if child == nil {
+				out[k] = nil
+			} else {
+				out[k] = "****"
+			}
+		default:
+			out[k] = scrubExtraConfigValue(child)
+		}
+	}
+	return out
+}
+
+// enrichRouteChannelAccount builds a redacted account summary for route channel
+// list/get surfaces. Presence of accessToken/apiToken is preserved via masks so
+// FE connection-mode heuristics remain usable without plaintext secrets (#367).
+func enrichRouteChannelAccount(ch map[string]any) map[string]any {
+	access, _ := ch["accessToken"].(string)
+	apiRaw := ch["apiToken"]
+	var apiMasked any
+	switch v := apiRaw.(type) {
+	case string:
+		if strings.TrimSpace(v) == "" {
+			apiMasked = nil
+		} else {
+			apiMasked = maskAccountSecret(v)
+		}
+	case []byte:
+		s := string(v)
+		if strings.TrimSpace(s) == "" {
+			apiMasked = nil
+		} else {
+			apiMasked = maskAccountSecret(s)
+		}
+	default:
+		if apiRaw == nil {
+			apiMasked = nil
+		} else if s, ok := apiRaw.(string); ok {
+			apiMasked = maskAccountSecret(s)
+		} else {
+			apiMasked = nil
+		}
+	}
+	return map[string]any{
+		"id":          ch["accountId"],
+		"username":    ch["username"],
+		"accessToken": maskAccountSecret(access),
+		"apiToken":    apiMasked,
+		"balance":     ch["balance"],
+		"status":      ch["accountStatus"],
+	}
+}

--- a/handler/admin/secret_redact_test.go
+++ b/handler/admin/secret_redact_test.go
@@ -1,0 +1,493 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func TestRedactAccountSecretsHelper(t *testing.T) {
+	t.Parallel()
+	secret := "sk-account-list-secret-abcdef"
+	api := "sk-api-token-secret-xyz"
+	extra := `{"credentialMode":"session","sub2apiAuth":{"refreshToken":"rt-super-secret","tokenExpiresAt":123},"autoRelogin":{"passwordCipher":"cipher-secret"},"proxyUrl":"http://127.0.0.1:7890"}`
+	row := map[string]any{
+		"id":          int64(1),
+		"accessToken": secret,
+		"apiToken":    api,
+		"extraConfig": extra,
+		"username":    "u1",
+	}
+	redactAccountSecrets(row)
+	if row["accessToken"] == secret {
+		t.Fatalf("accessToken not redacted: %#v", row["accessToken"])
+	}
+	if row["apiToken"] == api {
+		t.Fatalf("apiToken not redacted: %#v", row["apiToken"])
+	}
+	if !strings.Contains(row["accessToken"].(string), "***") && !strings.Contains(row["accessToken"].(string), "****") {
+		t.Fatalf("accessToken mask unexpected: %#v", row["accessToken"])
+	}
+	ec, _ := row["extraConfig"].(string)
+	if strings.Contains(ec, "rt-super-secret") || strings.Contains(ec, "cipher-secret") {
+		t.Fatalf("extraConfig leaked secret: %s", ec)
+	}
+	if !strings.Contains(ec, "proxyUrl") || !strings.Contains(ec, "credentialMode") {
+		t.Fatalf("extraConfig lost non-secret fields: %s", ec)
+	}
+	redactAccountSecrets(nil) // must not panic
+}
+
+func TestRedactAccountTokenSecretsHelper(t *testing.T) {
+	t.Parallel()
+	secret := "sk-token-list-secret-123456"
+	row := map[string]any{
+		"id":    int64(9),
+		"token": secret,
+		"name":  "t1",
+		"site":  map[string]any{"platform": "newapi"},
+	}
+	redactAccountTokenSecrets(row)
+	if _, ok := row["token"]; ok {
+		t.Fatalf("token still present: %#v", row["token"])
+	}
+	masked, _ := row["tokenMasked"].(string)
+	if masked == "" || masked == secret {
+		t.Fatalf("tokenMasked = %#v", masked)
+	}
+}
+
+func TestAccountsListRedactsPlaintextSecrets(t *testing.T) {
+	secretAccess := "sk-list-access-token-secret-aaa"
+	secretAPI := "sk-list-api-token-secret-bbb"
+	db, r, _ := setupAccountsTest(t)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		 VALUES (?, ?, 'newapi', 'active', ?, ?)`,
+		"Secret List Site", "https://secret-list.example.com", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+	extra := `{"credentialMode":"session","sub2apiAuth":{"refreshToken":"rt-list-secret-should-not-leak"}}`
+	_, err = db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, extra_config, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, 'active', 1, ?, ?, ?)`,
+		siteID, "secret-user", secretAccess, secretAPI, extra, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+
+	// Force miss so we exercise the redaction path, not a stale empty cache.
+	globalAccountsCache.clear()
+	resp := doGet(t, r, "/api/accounts?refresh=1")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("list accounts: %d %s", resp.Code, resp.Body.String())
+	}
+	body := resp.Body.String()
+	if strings.Contains(body, secretAccess) {
+		t.Fatalf("list leaked accessToken secret")
+	}
+	if strings.Contains(body, secretAPI) {
+		t.Fatalf("list leaked apiToken secret")
+	}
+	if strings.Contains(body, "rt-list-secret-should-not-leak") {
+		t.Fatalf("list leaked refreshToken secret")
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	accounts, _ := result["accounts"].([]any)
+	if len(accounts) == 0 {
+		t.Fatal("expected accounts")
+	}
+	found := false
+	for _, raw := range accounts {
+		acc, _ := raw.(map[string]any)
+		if acc["username"] != "secret-user" {
+			continue
+		}
+		found = true
+		at, _ := acc["accessToken"].(string)
+		if at == "" || at == secretAccess {
+			t.Fatalf("accessToken not masked: %#v", at)
+		}
+		api, _ := acc["apiToken"].(string)
+		if api == "" || api == secretAPI {
+			t.Fatalf("apiToken not masked: %#v", api)
+		}
+	}
+	if !found {
+		t.Fatal("secret-user missing from list")
+	}
+}
+
+func TestAccountsUpdateResponseRedactsSecrets(t *testing.T) {
+	secretAccess := "sk-update-access-token-secret"
+	secretAPI := "sk-update-api-token-secret"
+	db, r, _ := setupAccountsTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		 VALUES (?, ?, 'newapi', 'active', ?, ?)`,
+		"Secret Update Site", "https://secret-update.example.com", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+	res, err = db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, 'active', 1, ?, ?)`,
+		siteID, "upd-user", secretAccess, secretAPI, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ := res.LastInsertId()
+
+	resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"status": "active",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update: %d %s", resp.Code, resp.Body.String())
+	}
+	if strings.Contains(resp.Body.String(), secretAccess) || strings.Contains(resp.Body.String(), secretAPI) {
+		t.Fatalf("update response leaked secret: %s", resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["accessToken"] == secretAccess {
+		t.Fatalf("update accessToken plaintext: %#v", body["accessToken"])
+	}
+	if body["apiToken"] == secretAPI {
+		t.Fatalf("update apiToken plaintext: %#v", body["apiToken"])
+	}
+}
+
+func TestAccountTokenUpdateResponseOmitsPlaintextToken(t *testing.T) {
+	secret := "sk-update-token-value-secret-zzz"
+	db, r := setupTokensTest(t)
+	_, accountID := tokenFixture(t, db, r)
+	tokID := createTokenFixture(t, db, accountID, "upd", secret, "", true, false)
+
+	resp := doPutJSON(t, r, "/api/account-tokens/"+itoa(tokID), map[string]any{
+		"name": "upd-renamed",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update token: %d %s", resp.Code, resp.Body.String())
+	}
+	if strings.Contains(resp.Body.String(), secret) {
+		t.Fatalf("update token response leaked plaintext secret")
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	tok, _ := result["token"].(map[string]any)
+	if tok == nil {
+		t.Fatalf("missing token object: %#v", result)
+	}
+	if v, ok := tok["token"]; ok && v != nil && v != "" {
+		t.Fatalf("token field present: %#v", v)
+	}
+	if tok["tokenMasked"] == nil || tok["tokenMasked"] == "" {
+		t.Fatalf("tokenMasked missing: %#v", tok)
+	}
+	if tok["name"] != "upd-renamed" {
+		t.Fatalf("name = %#v", tok["name"])
+	}
+}
+
+func TestAccountTokenValueExportKeepsFullSecret(t *testing.T) {
+	// Intentional export-secret contract: GET /api/account-tokens/:id/value returns full token (#367).
+	secret := "sk-export-value-token-secret-keep"
+	db, r := setupTokensTest(t)
+	_, accountID := tokenFixture(t, db, r)
+	tokID := createTokenFixture(t, db, accountID, "export-me", secret, "", true, true)
+
+	resp := doGet(t, r, "/api/account-tokens/"+itoa(tokID)+"/value")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("get value: %d %s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result["token"] != secret {
+		t.Fatalf("export /value must return full token, got %#v", result["token"])
+	}
+	if result["tokenMasked"] == nil || result["tokenMasked"] == "" {
+		t.Fatalf("tokenMasked missing on export path")
+	}
+}
+
+func TestRouteChannelsListRedactsAccountSecrets(t *testing.T) {
+	secretAccess := "sk-route-access-secret-1111"
+	secretAPI := "sk-route-api-secret-2222"
+	db, r := setupTokenRoutesTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		 VALUES ('Route Secret Site', 'https://route-secret.example.com', 'newapi', 'active', ?, ?)`,
+		now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+	res, err = db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
+		 VALUES (?, 'route-user', ?, ?, 'active', 0, ?, ?)`,
+		siteID, secretAccess, secretAPI, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ := res.LastInsertId()
+	res, err = db.Exec(
+		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
+		 VALUES (?, 'rt', 'sk-route-token-only', 'ready', 'manual', 1, 1, ?, ?)`,
+		accountID, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert token: %v", err)
+	}
+	tokenID, _ := res.LastInsertId()
+	res, err = db.Exec(
+		`INSERT INTO token_routes (model_pattern, enabled, sort_order, created_at, updated_at)
+		 VALUES ('secret-model', 1, 0, ?, ?)`,
+		now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	routeID, _ := res.LastInsertId()
+	_, err = db.Exec(
+		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+		 VALUES (?, ?, ?, 'secret-model', 1, 1, 1, 0)`,
+		routeID, accountID, tokenID,
+	)
+	if err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+
+	// List routes embeds channels.
+	resp := doGet(t, r, "/api/routes")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("list routes: %d %s", resp.Code, resp.Body.String())
+	}
+	if strings.Contains(resp.Body.String(), secretAccess) || strings.Contains(resp.Body.String(), secretAPI) {
+		t.Fatalf("routes list leaked account secret")
+	}
+
+	// Explicit channels endpoint.
+	resp = doGet(t, r, "/api/routes/"+itoa(routeID)+"/channels")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("get channels: %d %s", resp.Code, resp.Body.String())
+	}
+	if strings.Contains(resp.Body.String(), secretAccess) || strings.Contains(resp.Body.String(), secretAPI) {
+		t.Fatalf("channels list leaked account secret")
+	}
+	var channels []map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &channels); err != nil {
+		t.Fatalf("unmarshal channels: %v body=%s", err, resp.Body.String())
+	}
+	if len(channels) == 0 {
+		t.Fatal("expected channel")
+	}
+	acc, _ := channels[0]["account"].(map[string]any)
+	if acc == nil {
+		t.Fatalf("missing account: %#v", channels[0])
+	}
+	if acc["accessToken"] == secretAccess {
+		t.Fatalf("channel accessToken plaintext")
+	}
+	if acc["apiToken"] == secretAPI {
+		t.Fatalf("channel apiToken plaintext")
+	}
+	// Presence preserved via non-empty mask for FE heuristics.
+	if s, _ := acc["accessToken"].(string); s == "" {
+		t.Fatalf("accessToken mask empty; presence should be preserved")
+	}
+}
+
+func TestSearchRedactsAccountAndTokenSecrets(t *testing.T) {
+	secretAccess := "sk-search-access-secret-xyz"
+	secretToken := "sk-search-token-secret-xyz"
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	r := chi.NewRouter()
+	RegisterSearchRoutes(r, db.DB)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		 VALUES ('Search Secret Site', 'https://search-secret.example.com', 'newapi', 'active', ?, ?)`,
+		now, now,
+	)
+	if err != nil {
+		t.Fatalf("site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+	res, err = db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
+		 VALUES (?, 'search-secret-user', ?, 'active', 0, ?, ?)`,
+		siteID, secretAccess, now, now,
+	)
+	if err != nil {
+		t.Fatalf("account: %v", err)
+	}
+	accountID, _ := res.LastInsertId()
+	_, err = db.Exec(
+		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
+		 VALUES (?, 'search-token', ?, 'ready', 'manual', 1, 1, ?, ?)`,
+		accountID, secretToken, now, now,
+	)
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+
+	resp := doPostJSON(t, r, "/api/search", map[string]any{"query": "search-secret", "limit": 20})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("search: %d %s", resp.Code, resp.Body.String())
+	}
+	body := resp.Body.String()
+	if strings.Contains(body, secretAccess) {
+		t.Fatalf("search leaked accessToken")
+	}
+	if strings.Contains(body, secretToken) {
+		t.Fatalf("search leaked account token")
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	tokens, _ := result["accountTokens"].([]any)
+	if len(tokens) == 0 {
+		t.Fatal("expected accountTokens hit")
+	}
+	tok := tokens[0].(map[string]any)
+	if _, ok := tok["token"]; ok {
+		t.Fatalf("search token field present: %#v", tok["token"])
+	}
+	if tok["tokenMasked"] == nil || tok["tokenMasked"] == "" {
+		t.Fatalf("search missing tokenMasked: %#v", tok)
+	}
+}
+
+func TestDownstreamKeyExportKeepsFullSecret(t *testing.T) {
+	// Intentional export-secret contract: GET /api/downstream-keys/:id/export returns full key (#367).
+	secret := "sk-export-credential-secret-keep"
+	_, r := setupDownstreamKeysTest(t)
+	create := doPostJSON(t, r, "/api/downstream-keys", map[string]any{
+		"name": "export-client",
+		"key":  secret,
+	})
+	if create.Code != http.StatusOK {
+		t.Fatalf("create: %d %s", create.Code, create.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(create.Body.Bytes(), &created); err != nil {
+		t.Fatalf("unmarshal create: %v", err)
+	}
+	item := created["item"].(map[string]any)
+	keyID := int64(item["id"].(float64))
+
+	resp := doGet(t, r, "/api/downstream-keys/"+itoa(keyID)+"/export")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("export: %d %s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), secret) {
+		t.Fatalf("export must include full secret for operator copy")
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal export: %v", err)
+	}
+	profiles, _ := body["profiles"].([]any)
+	if len(profiles) == 0 {
+		t.Fatal("expected export profiles")
+	}
+}
+
+func TestOAuthConnectionsFallbackRedactsSecrets(t *testing.T) {
+	// Force the sql fallback list path by not wiring oauth.ListOauthConnections success
+	// through a global store that returns items — use handler DB only and break service by
+	// leaving store.DB nil / empty oauth provider query via direct handler registration.
+	secretAccess := "sk-oauth-conn-access-secret"
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() {
+		store.OverrideDB(nil)
+		db.Close()
+	})
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	// Ensure service list path fails so handler uses queryRows fallback.
+	store.OverrideDB(nil)
+
+	r := chi.NewRouter()
+	RegisterOauthRoutes(r, db.DB)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		 VALUES ('OAuth Secret Site', 'https://oauth-secret.example.com', 'newapi', 'active', ?, ?)`,
+		now, now,
+	)
+	if err != nil {
+		t.Fatalf("site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+	extra := `{"oauth":{"provider":"codex","refreshToken":"rt-oauth-secret-leak"}}`
+	_, err = db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, oauth_provider, extra_config, created_at, updated_at)
+		 VALUES (?, 'oauth-user', ?, 'active', 0, 'codex', ?, ?, ?)`,
+		siteID, secretAccess, extra, now, now,
+	)
+	if err != nil {
+		t.Fatalf("account: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/oauth/connections")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("connections: %d %s", resp.Code, resp.Body.String())
+	}
+	body := resp.Body.String()
+	if strings.Contains(body, secretAccess) {
+		t.Fatalf("oauth connections leaked accessToken")
+	}
+	if strings.Contains(body, "rt-oauth-secret-leak") {
+		t.Fatalf("oauth connections leaked refreshToken")
+	}
+}
+
+// silence unused import guards for packages only used in this file's local setups.
+var (
+	_ = chi.NewRouter
+	_ = store.DialectSQLite
+)

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -184,14 +184,7 @@ func (h *tokenRoutesHandler) listRoutes(w http.ResponseWriter, r *http.Request) 
 				"weight":           ch["weight"],
 				"enabled":          ch["enabled"],
 				"manualOverride":   ch["manualOverride"],
-				"account": map[string]any{
-					"id":          ch["accountId"],
-					"username":    ch["username"],
-					"accessToken": ch["accessToken"],
-					"apiToken":    ch["apiToken"],
-					"balance":     ch["balance"],
-					"status":      ch["accountStatus"],
-				},
+				"account": enrichRouteChannelAccount(ch),
 				"site": map[string]any{
 					"id":       ch["siteId"],
 					"name":     ch["siteName"],
@@ -546,14 +539,7 @@ func (h *tokenRoutesHandler) getRouteChannels(w http.ResponseWriter, r *http.Req
 			"weight":           ch["weight"],
 			"enabled":          ch["enabled"],
 			"manualOverride":   ch["manualOverride"],
-			"account": map[string]any{
-				"id":          ch["accountId"],
-				"username":    ch["username"],
-				"accessToken": ch["accessToken"],
-				"apiToken":    ch["apiToken"],
-				"balance":     ch["balance"],
-				"status":      ch["accountStatus"],
-			},
+			"account": enrichRouteChannelAccount(ch),
 			"site": map[string]any{
 				"id":       ch["siteId"],
 				"name":     ch["siteName"],


### PR DESCRIPTION
## Summary
Post-#355 residual audit of admin secret surfaces beyond downstream-keys.

- Redact/mask `accessToken` / `apiToken` and nested `extraConfig` secrets on accounts list/update responses
- Route channel list/get no longer embeds plaintext account credentials
- Search redacts account + account-token secrets; oauth connections fallback list redacted
- Account-token update returns `tokenToMap` (masked only)
- Keep intentional create-once / export paths honest with contract tests:
  - `GET /api/account-tokens/:id/value` full token
  - `GET /api/downstream-keys/:id/export` full key
  - create/login/rebind still echo the just-entered session token (no plaintext apiToken dump)

## Surfaces
**Redacted:** accounts list, accounts update response, route channels (list + by-route), search accounts/tokens, oauth connections fallback, account-token update response, verify-token discovered apiToken (masked)

**Intentional export/create-once:** account create accessToken echo, login/rebind session echo, account-token `/value`, downstream-key create full key, downstream-key `/export`

## Test plan
- [x] `go test ./handler/admin -count=1`
- [x] pre-push `go test ./... -count=1 -race`

Closes #367