### PR TITLE
docs(release): v0.8.23 admin secret redact + soft-filter demotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.23] — 2026-07-17
+
+### Security
+- Admin account list/overview redacts `accessToken`/`apiToken` (masked only) and strips `passwordCipher` from list `extraConfig`; account-token list drops join credential fields (#367 / #372)
+- Credential export remains intentional product path (create/update may still echo once outside list enrichment)
+
+### Fixed
+- Round-robin / stable_first / least_* soft-filter priority demotion: soft-empty higher priority tries next layer (parity with weighted #358) (#368 / #370)
+
+### Docs / Honesty
+- Residual inventory + MASTER for Milestone 32 post v0.8.22; SEC-ADMIN + REL-SOFT-RR → present (#366 / #369)
+
 ## [v0.8.22] — 2026-07-17
 
 ### Security

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,8 +1,8 @@
-# Residual next candidates (post v0.8.22 → v0.8.23)
+# Residual next candidates (post v0.8.23)
 
 **Date**: 2026-07-17  
 **Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual  
-**Context**: **v0.8.22 shipped** (#355–#359). Active residual wave: **Milestone 32 / v0.8.23** (#366 residual honesty, #367 admin secret surface audit, #368 RR/stable soft-filter priority demotion).  
+**Context**: **v0.8.23 shipped** (#366 residual honesty, #367 admin account secret redact, #368 RR/stable soft-filter demotion). Prior **v0.8.22**: #355–#359.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 
@@ -41,27 +41,18 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | SEC-HDR | custom_headers deny-list | **present** (#356/#364) | Shared `platform.ApplyCustomHeaders` / deny-list; Bearer after custom on upstream path | Done | Residual novel header names only |
 | SEC-REDIR | RuntimeExecutor CheckRedirect SSRF | **present** (#357/#360) | `rejectCrossOriginRedirect` on RuntimeExecutor client | Done | Residual site-URL SSRF validation only if product AC |
 | REL-SOFT | Weighted soft-filter empty → next priority | **present** (#358/#362) | Weighted path skips soft-empty priority layer and tries next; failover-isolation note | Done for weighted soft-filter | P0-585 empty-filter fallback residual separate |
-| SEC-ADMIN | Remaining admin secret surfaces | residual → active | Downstream-keys list redacted (#355); account-tokens list/`tokenToMap`, credential export, other dumps may still expose secrets | Milestone 32 / #367 | Secret leakage via admin APIs |
-| REL-SOFT-RR | RR/stable_first soft-filter priority demotion | partial → active | #358 fixed weighted only; RR/stable_first still soft-filter full set with full-set fallback | Milestone 32 / #368 | Broken P0 can still starve healthy P≥1 under non-weighted algos |
+| SEC-ADMIN | Remaining admin secret surfaces | **present-with-residual** (#367/#372) | Account list redacts accessToken/apiToken + passwordCipher strip; token list drops join secrets. Residual: create/update/rebind may still echo once; intentional credential export | Done for list/overview | Residual intentional export / create-once |
+| REL-SOFT-RR | RR/stable_first soft-filter priority demotion | **present** (#368/#370) | RR/stable_first/least_* share priority-layer strict soft-filter demotion with weighted | Done | Global full-set fallback when all layers soft-empty (P0-585 residual) |
 
 
-## Active wave (Milestone 32 / v0.8.23)
+## Recommended sequencing (v0.8.24+)
 
-| Issue | Role | Notes |
-|------:|------|-------|
-| [#366](https://github.com/TokenDanceLab/metapi-go/issues/366) | docs | This residual + MASTER flip post v0.8.22 |
-| [#367](https://github.com/TokenDanceLab/metapi-go/issues/367) | security | audit/redact remaining admin secret surfaces beyond downstream-keys |
-| [#368](https://github.com/TokenDanceLab/metapi-go/issues/368) | reliability | RR + stable_first soft-filter priority demotion (parity with #358) |
-
-## Recommended sequencing (v0.8.23+)
-
-1. **Shipped in v0.8.22**: #355–#359 (PRs #360–#364/#365). **P0-555** stays **present-with-residual**. **CTX-520** / **P0-585** residual notes unchanged beyond weighted soft-filter priority.
-2. **v0.8.23 board (Milestone 32)**: #367 admin secret audit · #368 RR/stable soft-filter demotion · #366 residual honesty — no fake WS/sticky/update-center.
-3. **Observability residual only** on P0-555 (media/lag/multi-instance); not perfect billing.
-4. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
-5. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
-6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-7. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+1. **Shipped in v0.8.23**: #366–#368 (PRs #369/#370/#372) — residual honesty · admin account secret redact · RR/stable soft-filter demotion. Prior v0.8.22: #355–#359. **P0-555** stays **present-with-residual**. **CTX-520** / **P0-585** residual notes unchanged beyond soft-filter priority demotion.
+2. **Observability residual only** on P0-555 (media/lag/multi-instance); not perfect billing.
+3. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
+4. **Protocol partials** already **present** (P1-580 + P1-538 HTTP multi-turn); residual conversion/store/WS + multi-instance aggregate only.
+5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -77,7 +68,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 
 ## Links
 
-- Release: [v0.8.22](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.22) · prior [v0.8.21](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.21)
+- Release: [v0.8.23](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.23) · prior [v0.8.22](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.22)
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -3,7 +3,7 @@
 **Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery
 **Mode**: GitHub Issues + Milestones (SDD)
 **Repo**: https://github.com/TokenDanceLab/metapi-go
-**Latest release**: **[v0.8.22](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.22)** (2026-07-17)
+**Latest release**: **[v0.8.23](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.23)** (2026-07-17)
 
 > 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。
 > 文档地图：[`docs/README.md`](../README.md)
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | **[Milestone 32 — Enterprise residual v0.8.23](https://github.com/TokenDanceLab/metapi-go/milestone/32)** |
+| Active milestone | closed Milestone 32 (v0.8.23) — next residual wave TBD |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -33,15 +33,13 @@
 | Enterprise residual **v0.8.20** | ✅ | #345–#346 · tag v0.8.20 |
 | Enterprise residual **v0.8.21** | ✅ | #350–#351 (PRs #352/#353); tag **v0.8.21** |
 | Enterprise residual **v0.8.22** | ✅ | #355–#359 (PRs #360–#364); tag **v0.8.22** |
-| Enterprise residual **v0.8.23** | 🔄 | Milestone 32 · #366–#368 |
+| Enterprise residual **v0.8.23** | ✅ | #366–#368 (PRs #369/#370/#372); tag **v0.8.23** |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| [#366](https://github.com/TokenDanceLab/metapi-go/issues/366) | docs | residual honesty + M32 board post v0.8.22 |
-| [#367](https://github.com/TokenDanceLab/metapi-go/issues/367) | security | audit remaining admin secret surfaces |
-| [#368](https://github.com/TokenDanceLab/metapi-go/issues/368) | reliability | RR/stable_first soft-filter priority demotion |
+| — | — | Board clean after v0.8.23; next residual only with ACs |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -50,6 +48,7 @@
 
 | Tag | Milestone | Highlights |
 |:----|:----------|:-----------|
+| [v0.8.23](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.23) | 32 | admin account secret redact · RR/stable soft-filter demotion · residual honesty |
 | [v0.8.22](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.22) | 31 | admin key redact · custom_headers deny · CheckRedirect · soft-filter priority · residual honesty |
 | [v0.8.21](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.21) | 30 | completions include_usage · residual honesty |
 | [v0.8.20](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.20) | 29 | chat stream include_usage · residual honesty |
@@ -74,16 +73,15 @@
 ```bash
 gh issue list --state open --limit 20
 gh pr list --state open
-gh release view v0.8.22
+gh release view v0.8.23
 git log --oneline origin/master -10
 ```
 
 ## Next Steps
 
-1. Close Milestone 32: #367 admin secret audit · #368 RR/stable soft-filter · #366 residual honesty.
-2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
-3. Optional later: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
-4. Keep MASTER slim; docs map at `docs/README.md`.
+1. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
+2. Optional residual polish: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
+3. Keep MASTER slim; docs map at `docs/README.md`.
 
 
 ## Governance


### PR DESCRIPTION
## Summary
- CHANGELOG **v0.8.23**: admin account list secret redact (#367), RR/stable soft-filter demotion (#368), residual honesty (#366)
- MASTER flip: latest **v0.8.23**, Milestone 32 closed pointer, board clean
- residual-next-candidates post v0.8.23 sequencing

## Test plan
- [x] pre-push race suite
- [x] docs-only