### PR TITLE
fix(admin): redact secrets from routes channels + search (#375)

### DIFF
--- a/handler/admin/search.go
+++ b/handler/admin/search.go
@@ -116,6 +116,12 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 		 ORDER BY account_count DESC LIMIT ?`,
 		likePattern, perCategory)
 
+	for _, row := range accounts {
+		redactSearchAccountSecrets(row)
+	}
+	for _, row := range accountTokens {
+		redactSearchTokenSecrets(row)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"accounts":      normalizeSlice(accounts),
 		"accountTokens": normalizeSlice(accountTokens),
@@ -124,6 +130,32 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 		"proxyLogs":     normalizeSlice(proxyLogs),
 		"models":        normalizeSlice(modelRows),
 	})
+}
+
+// redactSearchAccountSecrets removes plaintext credentials from search account hits (#375).
+func redactSearchAccountSecrets(row map[string]any) {
+	if row == nil {
+		return
+	}
+	if s, ok := row["accessToken"].(string); ok && strings.TrimSpace(s) != "" {
+		row["accessTokenMasked"] = maskAdminSecret(s)
+	}
+	delete(row, "accessToken")
+	if s, ok := row["apiToken"].(string); ok && strings.TrimSpace(s) != "" {
+		row["apiTokenMasked"] = maskAdminSecret(s)
+	}
+	delete(row, "apiToken")
+}
+
+// redactSearchTokenSecrets removes plaintext token from search accountTokens hits (#375).
+func redactSearchTokenSecrets(row map[string]any) {
+	if row == nil {
+		return
+	}
+	if s, ok := row["token"].(string); ok && strings.TrimSpace(s) != "" {
+		row["tokenMasked"] = maskAdminSecret(s)
+	}
+	delete(row, "token")
 }
 
 func queryRows(db *sqlx.DB, query string, args ...any) []map[string]any {

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -184,14 +184,7 @@ func (h *tokenRoutesHandler) listRoutes(w http.ResponseWriter, r *http.Request) 
 				"weight":           ch["weight"],
 				"enabled":          ch["enabled"],
 				"manualOverride":   ch["manualOverride"],
-				"account": map[string]any{
-					"id":          ch["accountId"],
-					"username":    ch["username"],
-					"accessToken": ch["accessToken"],
-					"apiToken":    ch["apiToken"],
-					"balance":     ch["balance"],
-					"status":      ch["accountStatus"],
-				},
+				"account":          routeChannelAccountPublic(ch),
 				"site": map[string]any{
 					"id":       ch["siteId"],
 					"name":     ch["siteName"],
@@ -546,14 +539,7 @@ func (h *tokenRoutesHandler) getRouteChannels(w http.ResponseWriter, r *http.Req
 			"weight":           ch["weight"],
 			"enabled":          ch["enabled"],
 			"manualOverride":   ch["manualOverride"],
-			"account": map[string]any{
-				"id":          ch["accountId"],
-				"username":    ch["username"],
-				"accessToken": ch["accessToken"],
-				"apiToken":    ch["apiToken"],
-				"balance":     ch["balance"],
-				"status":      ch["accountStatus"],
-			},
+			"account":          routeChannelAccountPublic(ch),
 			"site": map[string]any{
 				"id":       ch["siteId"],
 				"name":     ch["siteName"],
@@ -1260,4 +1246,44 @@ func toInt64(v any) int64 {
 	default:
 		return 0
 	}
+}
+
+// routeChannelAccountPublic returns account fields for admin route channel lists
+// without plaintext credentials (#375).
+func routeChannelAccountPublic(ch map[string]any) map[string]any {
+	out := map[string]any{
+		"id":       ch["accountId"],
+		"username": ch["username"],
+		"balance":  ch["balance"],
+		"status":   ch["accountStatus"],
+	}
+	if v, ok := ch["accessToken"]; ok {
+		if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+			out["accessTokenMasked"] = maskAdminSecret(s)
+		}
+	}
+	if v, ok := ch["apiToken"]; ok {
+		switch tv := v.(type) {
+		case string:
+			if strings.TrimSpace(tv) != "" {
+				out["apiTokenMasked"] = maskAdminSecret(tv)
+			}
+		case *string:
+			if tv != nil && strings.TrimSpace(*tv) != "" {
+				out["apiTokenMasked"] = maskAdminSecret(*tv)
+			}
+		}
+	}
+	return out
+}
+
+func maskAdminSecret(secret string) string {
+	s := strings.TrimSpace(secret)
+	if s == "" {
+		return ""
+	}
+	if len(s) <= 8 {
+		return "****"
+	}
+	return s[:4] + "****" + s[len(s)-4:]
 }

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1187,5 +1188,48 @@ func TestRoutes_ReorderAndListOrder(t *testing.T) {
 	}
 	if resp["success"] != false {
 		t.Fatalf("expected success=false with failed item, got %#v", resp)
+	}
+}
+
+func TestRouteChannelAccountPublic_OmitsSecrets(t *testing.T) {
+	ch := map[string]any{
+		"accountId":     int64(7),
+		"username":      "u",
+		"accessToken":   "sk-access-secret-ABCDEF",
+		"apiToken":      "sk-api-secret-XYZ12345",
+		"balance":       1.5,
+		"accountStatus": "active",
+	}
+	got := routeChannelAccountPublic(ch)
+	if _, ok := got["accessToken"]; ok {
+		t.Fatalf("accessToken present: %#v", got["accessToken"])
+	}
+	if _, ok := got["apiToken"]; ok {
+		t.Fatalf("apiToken present: %#v", got["apiToken"])
+	}
+	if got["accessTokenMasked"] == nil || got["apiTokenMasked"] == nil {
+		t.Fatalf("expected masked fields: %#v", got)
+	}
+	if s, _ := got["accessTokenMasked"].(string); strings.Contains(s, "sk-access-secret") {
+		t.Fatalf("mask leaked secret: %q", s)
+	}
+}
+
+func TestRedactSearchSecrets(t *testing.T) {
+	acc := map[string]any{"accessToken": "sk-acc-ABCDEFGH", "apiToken": "sk-api-ABCDEFGH", "username": "x"}
+	redactSearchAccountSecrets(acc)
+	if _, ok := acc["accessToken"]; ok {
+		t.Fatal("accessToken not removed")
+	}
+	if _, ok := acc["apiToken"]; ok {
+		t.Fatal("apiToken not removed")
+	}
+	tok := map[string]any{"token": "sk-token-ABCDEFGH", "name": "n"}
+	redactSearchTokenSecrets(tok)
+	if _, ok := tok["token"]; ok {
+		t.Fatal("token not removed")
+	}
+	if tok["tokenMasked"] == nil {
+		t.Fatal("tokenMasked missing")
 	}
 }


### PR DESCRIPTION
## Summary
- `GET /api/routes` + `GET /api/routes/:id/channels` account blocks omit plaintext `accessToken`/`apiToken` (masked-only via `routeChannelAccountPublic`)
- `POST /api/search` accounts drop `accessToken`/`apiToken`; accountTokens drop `token` (masked-only)

## Test plan
- [x] `go test ./handler/admin -count=1`
- [x] pre-push race suite

Closes #375