### PR TITLE
fix(admin): reject site URL cloud metadata / link-local targets (#376)

### DIFF
--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -72,6 +72,10 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "Invalid url. Expected non-empty string.")
 		return
 	}
+	if service.IsForbiddenSiteTargetURL(body.URL) {
+		writeError(w, http.StatusBadRequest, "Invalid url. Cloud metadata / link-local targets are not allowed.")
+		return
+	}
 
 	// Normalize values
 	normalizedStatus := normalizeSiteStatusString(body.Status)
@@ -289,6 +293,10 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	if body.URL != nil {
 		if strings.TrimSpace(*body.URL) == "" {
 			writeError(w, http.StatusBadRequest, "Invalid url. Expected non-empty string.")
+			return
+		}
+		if service.IsForbiddenSiteTargetURL(*body.URL) {
+			writeError(w, http.StatusBadRequest, "Invalid url. Cloud metadata / link-local targets are not allowed.")
 			return
 		}
 		updates["url"] = service.CanonicalizeSiteURL(*body.URL)

--- a/service/site_endpoint_service.go
+++ b/service/site_endpoint_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"net"
 	"net/url"
 	"strings"
 )
@@ -62,4 +63,44 @@ func IsValidHTTPURL(raw string) bool {
 		return false
 	}
 	return parsed.Scheme == "http" || parsed.Scheme == "https"
+}
+
+// IsForbiddenSiteTargetURL reports whether a site/endpoint URL must be rejected
+// as a first-hop SSRF risk to cloud metadata / link-local targets (#376).
+// RFC1918 private and localhost remain allowed for lab/docker operators.
+func IsForbiddenSiteTargetURL(raw string) bool {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return false
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return false
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		return false
+	}
+	lower := strings.ToLower(host)
+	switch lower {
+	case "metadata.google.internal", "metadata", "instance-data":
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// Hostname: only block well-known metadata names above.
+		return false
+	}
+	// Link-local IPv4 169.254.0.0/16 (includes AWS/GCP/Azure metadata 169.254.169.254).
+	if ip4 := ip.To4(); ip4 != nil {
+		if ip4[0] == 169 && ip4[1] == 254 {
+			return true
+		}
+		return false
+	}
+	// Link-local IPv6 fe80::/10
+	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return true
+	}
+	return false
 }

--- a/service/site_service.go
+++ b/service/site_service.go
@@ -100,6 +100,9 @@ func UpsertSiteAPIEndpoints(tx *sqlx.Tx, siteID int64, endpoints []store.SiteAPI
 		if normalizedURL == "" {
 			continue
 		}
+		if IsForbiddenSiteTargetURL(normalizedURL) {
+			return fmt.Errorf("site api endpoint url rejects cloud metadata / link-local targets")
+		}
 		enabled := true
 		if !ep.Enabled {
 			enabled = false

--- a/service/site_service_test.go
+++ b/service/site_service_test.go
@@ -523,3 +523,30 @@ func TestNormalizeNullable_Nil(t *testing.T) {
 		t.Errorf("expected nil for nil input, got %v", result)
 	}
 }
+
+func TestIsForbiddenSiteTargetURL(t *testing.T) {
+	forbid := []string{
+		"http://169.254.169.254/latest/meta-data",
+		"https://169.254.169.254/",
+		"http://metadata.google.internal/",
+		"http://[fe80::1]/",
+	}
+	allow := []string{
+		"https://api.openai.com/v1",
+		"http://10.0.0.5:8080",
+		"http://192.168.1.10",
+		"http://127.0.0.1:4000",
+		"http://localhost:8080",
+		"",
+	}
+	for _, u := range forbid {
+		if !IsForbiddenSiteTargetURL(u) {
+			t.Errorf("expected forbidden: %q", u)
+		}
+	}
+	for _, u := range allow {
+		if IsForbiddenSiteTargetURL(u) {
+			t.Errorf("expected allowed: %q", u)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `service.IsForbiddenSiteTargetURL` blocks `169.254.0.0/16`, IPv6 link-local, and metadata hostnames (`metadata.google.internal` etc.)
- Wired on site create/update + site API endpoint upsert
- RFC1918 private + localhost stay allowed for lab/docker

## Test plan
- [x] `go test ./service ./handler/admin -count=1`
- [x] pre-push race suite

Closes #376