### PR TITLE
fix(service): IsValidHTTPURL rejects metadata/link-local targets (#382)

### DIFF
--- a/service/site_endpoint_service.go
+++ b/service/site_endpoint_service.go
@@ -53,6 +53,9 @@ func IsValidProxyURL(raw string) bool {
 }
 
 // IsValidHTTPURL checks whether a string is a valid http/https URL (not socks).
+// Empty is valid (optional field). Also rejects cloud metadata / link-local
+// targets via IsForbiddenSiteTargetURL so externalCheckin and similar callers
+// cannot store first-hop SSRF URLs (#382 / extends #376).
 func IsValidHTTPURL(raw string) bool {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
@@ -62,7 +65,13 @@ func IsValidHTTPURL(raw string) bool {
 	if err != nil {
 		return false
 	}
-	return parsed.Scheme == "http" || parsed.Scheme == "https"
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return false
+	}
+	if IsForbiddenSiteTargetURL(trimmed) {
+		return false
+	}
+	return true
 }
 
 // IsForbiddenSiteTargetURL reports whether a site/endpoint URL must be rejected

--- a/service/site_service_test.go
+++ b/service/site_service_test.go
@@ -550,3 +550,25 @@ func TestIsForbiddenSiteTargetURL(t *testing.T) {
 		}
 	}
 }
+
+func TestIsValidHTTPURL_RejectsMetadata(t *testing.T) {
+	forbid := []string{
+		"http://169.254.169.254/latest/meta-data",
+		"https://metadata.google.internal/",
+		"http://[fe80::1]/",
+	}
+	for _, u := range forbid {
+		if IsValidHTTPURL(u) {
+			t.Errorf("expected invalid for metadata URL %q", u)
+		}
+	}
+	if !IsValidHTTPURL("https://example.com/checkin") {
+		t.Error("public URL should stay valid")
+	}
+	if !IsValidHTTPURL("") {
+		t.Error("empty should stay valid")
+	}
+	if !IsValidHTTPURL("http://10.0.0.5/checkin") {
+		t.Error("RFC1918 should remain valid for lab external checkin")
+	}
+}


### PR DESCRIPTION
## Summary
- `IsValidHTTPURL` now rejects cloud metadata / link-local via `IsForbiddenSiteTargetURL`
- Covers site `externalCheckinURL` create/update (scheme-only hole after #376)
- RFC1918 + empty still valid

Closes #382