### PR TITLE
docs(release): v0.8.25 CHANGELOG + MASTER + residual flip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.25] — 2026-07-17
+
+### Security
+- `IsValidHTTPURL` rejects cloud metadata / link-local targets (aligned with `IsForbiddenSiteTargetURL`); site externalCheckin URL uses the hardened check (#382 / #385)
+
+### Fixed
+- Admin `GET /api/routes` batch-loads route channels in one query and groups in memory (kills per-route N+1; response shape + #375 redact unchanged) (#383 / #386)
+
+### Docs / Honesty
+- Residual inventory + MASTER for Milestone 34 post v0.8.24; SEC-HTTPURL + PERF-ROUTES → present (#384 / #387)
+
 ## [v0.8.24] — 2026-07-17
 
 ### Security

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,8 +1,8 @@
-# Residual next candidates (post v0.8.24 → v0.8.25)
+# Residual next candidates (post v0.8.25)
 
 **Date**: 2026-07-17  
 **Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual  
-**Context**: **v0.8.24 shipped** (#375–#377). Active residual wave: **Milestone 34 / v0.8.25** (#382 IsValidHTTPURL metadata harden, #383 routes N+1 batch, #384 residual honesty). Original P0 #405/#565/#515/#409 already-correct in code.  
+**Context**: **v0.8.25 shipped** (#382 IsValidHTTPURL metadata harden, #383 routes N+1 batch, #384 residual honesty). Prior **v0.8.24**: #375–#377. Original P0 #405/#565/#515/#409 already-correct in code.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 
@@ -45,21 +45,13 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | REL-SOFT-RR | RR/stable_first soft-filter priority demotion | **present** (#368/#370) | RR/stable_first/least_* share priority-layer strict soft-filter demotion with weighted | Done | Global full-set fallback when all layers soft-empty (P0-585 residual) |
 | SEC-ROUTE | Routes/search admin secret dumps | **present** (#375/#378) | Route channel `account` uses `routeChannelAccountPublic` (masked); search accounts/tokens redacted | Done | Residual: create-once / export paths intentional |
 | SEC-SITEURL | Site URL metadata/link-local SSRF | **present** (#376/#379) | `IsForbiddenSiteTargetURL` blocks 169.254/16, IPv6 link-local, metadata hostnames on create/update/endpoint upsert | Done | RFC1918/localhost intentionally allowed |
-| SEC-HTTPURL | IsValidHTTPURL / externalCheckin metadata | residual → active | `IsValidHTTPURL` scheme-only; externalCheckin can store 169.254 | Milestone 34 / #382 | First-hop SSRF via checkin URL |
-| PERF-ROUTES | GET /api/routes N+1 channel queries | residual → active | listRoutes per-route channel JOIN | Milestone 34 / #383 | Admin board latency |
+| SEC-HTTPURL | IsValidHTTPURL / externalCheckin metadata | **present** (#382/#385) | `IsValidHTTPURL` rejects metadata/link-local class via `IsForbiddenSiteTargetURL`; externalCheckin uses hardened check | Done | RFC1918/localhost intentionally allowed |
+| PERF-ROUTES | GET /api/routes N+1 channel queries | **present** (#383/#386) | Single channels JOIN for listed routes, group in memory; response shape + #375 redact unchanged | Done | Residual other admin list N+1 only if product AC |
 
 
-## Active wave (Milestone 34 / v0.8.25)
+## Recommended sequencing (v0.8.26+)
 
-| Issue | Role | Notes |
-|------:|------|-------|
-| [#382](https://github.com/TokenDanceLab/metapi-go/issues/382) | security | IsValidHTTPURL + externalCheckin metadata harden |
-| [#383](https://github.com/TokenDanceLab/metapi-go/issues/383) | perf | batch-load route channels on GET /api/routes |
-| [#384](https://github.com/TokenDanceLab/metapi-go/issues/384) | docs | residual honesty + MASTER flip post v0.8.24 |
-
-## Recommended sequencing (v0.8.25+)
-
-1. **Shipped in v0.8.24**: #375–#377. **v0.8.25 board**: #382–#384. Original gap P0 #405/#565/#515/#409 already-correct (quota clear, token sync preserve, whitelist array-only, modelMapping partial update).
+1. **Shipped in v0.8.25**: #382–#384 (PRs #385/#386/#387) — IsValidHTTPURL metadata harden · routes N+1 batch · residual honesty. Prior v0.8.24: #375–#377.
 2. **P0-555** stays **present-with-residual**. **CTX-520** / **P0-585** residual notes unchanged.
 3. **Optional product later**: P0-585 load-proof / site-model breaker; proxy max-token enforce from contextLength (dedicated ACs only).
 4. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
@@ -79,8 +71,8 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 
 ## Links
 
-- Release: [v0.8.24](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.24) · prior [v0.8.23](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.23)
+- Release: [v0.8.25](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.25) · prior [v0.8.24](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.24)
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - MASTER: `docs/progress/MASTER.md`
-- Related issues: #366, #367, #368, #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346, #350, #351, #355, #356, #357, #358, #359
+- Related issues: #382, #383, #384, #375, #376, #377, #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346, #350, #351, #355, #356, #357, #358, #359

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -3,7 +3,7 @@
 **Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery
 **Mode**: GitHub Issues + Milestones (SDD)
 **Repo**: https://github.com/TokenDanceLab/metapi-go
-**Latest release**: **[v0.8.24](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.24)** (2026-07-17)
+**Latest release**: **[v0.8.25](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.25)** (2026-07-17)
 
 > 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。
 > 文档地图：[`docs/README.md`](../README.md)
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | **[Milestone 34 — Enterprise residual v0.8.25](https://github.com/TokenDanceLab/metapi-go/milestone/34)** |
+| Active milestone | closed Milestone 34 (v0.8.25) — next residual wave TBD |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
@@ -35,15 +35,13 @@
 | Enterprise residual **v0.8.22** | ✅ | #355–#359 (PRs #360–#364); tag **v0.8.22** |
 | Enterprise residual **v0.8.23** | ✅ | #366–#368 (PRs #369/#370/#372); tag **v0.8.23** |
 | Enterprise residual **v0.8.24** | ✅ | #375–#377 (PRs #378/#379/#380); tag **v0.8.24** |
-| Enterprise residual **v0.8.25** | 🔄 | Milestone 34 · #382–#384 |
+| Enterprise residual **v0.8.25** | ✅ | #382–#384 (PRs #385/#386/#387); tag **v0.8.25** |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| [#382](https://github.com/TokenDanceLab/metapi-go/issues/382) | security | IsValidHTTPURL / externalCheckin metadata harden |
-| [#383](https://github.com/TokenDanceLab/metapi-go/issues/383) | perf | routes list N+1 batch channel load |
-| [#384](https://github.com/TokenDanceLab/metapi-go/issues/384) | docs | residual honesty post v0.8.24 |
+| — | — | Board clean after v0.8.25; next residual only with ACs |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 
@@ -52,6 +50,7 @@
 
 | Tag | Milestone | Highlights |
 |:----|:----------|:-----------|
+| [v0.8.25](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.25) | 34 | IsValidHTTPURL metadata harden · routes N+1 batch · residual honesty |
 | [v0.8.24](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.24) | 33 | routes/search secret redact · site metadata URL guard · residual honesty |
 | [v0.8.23](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.23) | 32 | admin account secret redact · RR/stable soft-filter demotion · residual honesty |
 | [v0.8.22](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.22) | 31 | admin key redact · custom_headers deny · CheckRedirect · soft-filter priority · residual honesty |
@@ -78,13 +77,13 @@
 ```bash
 gh issue list --state open --limit 20
 gh pr list --state open
-gh release view v0.8.24
+gh release view v0.8.25
 git log --oneline origin/master -10
 ```
 
 ## Next Steps
 
-1. Close Milestone 33: #375 routes/search secret redact · #376 site metadata URL · #377 residual honesty.
+1. Close Milestone 34: #382 IsValidHTTPURL metadata · #383 routes N+1 batch · #384 residual honesty.
 2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
 3. Optional later: P0-585 load-proof / site-model breaker; P0-555 media/lag; proxy max-token enforce from contextLength.
 4. Keep MASTER slim; docs map at `docs/README.md`.


### PR DESCRIPTION
## Summary
Docs-only release gate for **v0.8.25** (Milestone 34).

- **CHANGELOG**: Security IsValidHTTPURL metadata/link-local (#382/#385); Fixed routes N+1 batch (#383/#386); Docs residual honesty (#384/#387)
- **MASTER**: latest release v0.8.25; Milestone 34 closed pointer; board clean; residual releases row; `gh release view v0.8.25`
- **residual-next-candidates**: post v0.8.25; SEC-HTTPURL + PERF-ROUTES present; remove active M34 wave; sequencing v0.8.26+

## Allowed paths
- `CHANGELOG.md`
- `docs/progress/MASTER.md`
- `docs/analysis/residual-next-candidates.md`

## Notes
- Product PRs already on master: #385 / #386 / #387
- Do **not** tag in this PR — main session tags after merge

Closes #391