### PR TITLE
fix(admin): reject metadata/link-local site API endpoints early

### DIFF
--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -809,6 +809,12 @@ func normalizeAPIEndpointsInput(input []payloads.SiteAPIEndpointInput) ([]payloa
 		if normalizedURL == "" || !service.IsValidAPIEndpointURL(normalizedURL) {
 			return nil, "Invalid apiEndpoints url. Expected a valid http(s) URL."
 		}
+		// Reject cloud metadata / link-local early with a clear 400 (#389).
+		// UpsertSiteAPIEndpoints also guards, but without this the admin path
+		// surfaces a generic 500 when CreateSite/UpdateSite fails later.
+		if service.IsForbiddenSiteTargetURL(normalizedURL) {
+			return nil, "Invalid apiEndpoints url. Cloud metadata / link-local targets are not allowed."
+		}
 		if seen[normalizedURL] {
 			return nil, fmt.Sprintf("Duplicate apiEndpoints url: %s", normalizedURL)
 		}

--- a/handler/admin/sites_create_endpoints_test.go
+++ b/handler/admin/sites_create_endpoints_test.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/tokendancelab/metapi-go/handler/admin/payloads"
 )
 
 func TestSites_CreateWithAPIEndpoints_SQLite(t *testing.T) {
@@ -36,5 +39,127 @@ func TestSites_CreateWithAPIEndpoints_SQLite(t *testing.T) {
 	eps, _ := created["apiEndpoints"].([]any)
 	if len(eps) != 1 {
 		t.Fatalf("apiEndpoints=%v", created["apiEndpoints"])
+	}
+}
+
+func TestNormalizeAPIEndpointsInput_ForbiddenMetadata(t *testing.T) {
+	forbid := []string{
+		"http://169.254.169.254/latest/meta-data",
+		"https://169.254.169.254/",
+		"http://metadata.google.internal/computeMetadata/v1/",
+		"http://[fe80::1]/",
+	}
+	for _, u := range forbid {
+		_, errMsg := normalizeAPIEndpointsInput([]payloads.SiteAPIEndpointInput{
+			{URL: u, Enabled: true, SortOrder: 0},
+		})
+		if errMsg == "" {
+			t.Fatalf("expected forbid for %q", u)
+		}
+		if !strings.Contains(errMsg, "Cloud metadata / link-local") {
+			t.Fatalf("unexpected error for %q: %s", u, errMsg)
+		}
+	}
+}
+
+func TestNormalizeAPIEndpointsInput_AllowsRFC1918LocalhostPublic(t *testing.T) {
+	allow := []string{
+		"https://api.openai.com/v1",
+		"http://10.0.0.5:8080/v1",
+		"http://192.168.1.10/v1",
+		"http://127.0.0.1:4000/v1",
+		"http://localhost:8080/v1",
+	}
+	for _, u := range allow {
+		eps, errMsg := normalizeAPIEndpointsInput([]payloads.SiteAPIEndpointInput{
+			{URL: u, Enabled: true, SortOrder: 0},
+		})
+		if errMsg != "" {
+			t.Fatalf("expected allow for %q, got %s", u, errMsg)
+		}
+		if len(eps) != 1 || eps[0].URL == "" {
+			t.Fatalf("expected normalized endpoint for %q, got %+v", u, eps)
+		}
+	}
+}
+
+func TestSites_Create_APIEndpoints_RejectsForbiddenMetadata(t *testing.T) {
+	_, r := setupSitesTest(t)
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 36)
+	cases := []string{
+		"http://169.254.169.254/latest/meta-data",
+		"http://metadata.google.internal/",
+		"http://[fe80::1]/",
+	}
+	for i, epURL := range cases {
+		resp := doPostJSON(t, r, "/api/sites", map[string]any{
+			"name":     "Forbidden EP " + suffix + "-" + strconv.Itoa(i),
+			"url":      "https://forbid-ep-" + suffix + "-" + strconv.Itoa(i) + ".example.com",
+			"platform": "openai",
+			"apiEndpoints": []map[string]any{
+				{"url": epURL, "enabled": true, "sortOrder": 0},
+			},
+		})
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("create forbidden endpoint %q: expected 400, got %d %s", epURL, resp.Code, resp.Body.String())
+		}
+		if !strings.Contains(resp.Body.String(), "Cloud metadata / link-local") {
+			t.Fatalf("create forbidden endpoint %q: body=%s", epURL, resp.Body.String())
+		}
+	}
+}
+
+func TestSites_Create_APIEndpoints_AllowsRFC1918LocalhostPublic(t *testing.T) {
+	_, r := setupSitesTest(t)
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 36)
+	allow := []string{
+		"https://api.openai.com/v1",
+		"http://10.0.0.5:8080/v1",
+		"http://192.168.1.10/v1",
+		"http://127.0.0.1:4000/v1",
+		"http://localhost:8080/v1",
+	}
+	for i, epURL := range allow {
+		resp := doPostJSON(t, r, "/api/sites", map[string]any{
+			"name":     "Allow EP " + suffix + "-" + strconv.Itoa(i),
+			"url":      "https://allow-ep-" + suffix + "-" + strconv.Itoa(i) + ".example.com",
+			"platform": "openai",
+			"apiEndpoints": []map[string]any{
+				{"url": epURL, "enabled": true, "sortOrder": 0},
+			},
+		})
+		if resp.Code != http.StatusOK {
+			t.Fatalf("create allowed endpoint %q: expected 200, got %d %s", epURL, resp.Code, resp.Body.String())
+		}
+	}
+}
+
+func TestSites_Update_APIEndpoints_RejectsForbiddenMetadata(t *testing.T) {
+	_, r := setupSitesTest(t)
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 36)
+	createResp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "Update Forbid EP " + suffix,
+		"url":      "https://update-forbid-ep-" + suffix + ".example.com",
+		"platform": "openai",
+	})
+	if createResp.Code != http.StatusOK {
+		t.Fatalf("create site: %d %s", createResp.Code, createResp.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(createResp.Body.Bytes(), &created); err != nil {
+		t.Fatalf("json: %v", err)
+	}
+	siteID := int64(created["id"].(float64))
+
+	resp := doPutJSON(t, r, "/api/sites/"+itoa(siteID), map[string]any{
+		"apiEndpoints": []map[string]any{
+			{"url": "http://169.254.169.254/", "enabled": true, "sortOrder": 0},
+		},
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("update forbidden endpoint: expected 400, got %d %s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "Cloud metadata / link-local") {
+		t.Fatalf("update forbidden endpoint body=%s", resp.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary
- `normalizeAPIEndpointsInput` rejects `IsForbiddenSiteTargetURL` (169.254, metadata.google.internal, fe80) with a clear 400
- RFC1918 / localhost / public endpoint URLs remain allowed
- Handler + unit tests cover forbid + allow paths for create/update

Closes #389

## Test plan
- [x] `go test ./handler/admin ./service -count=1 -run 'Site|Endpoint|Forbidden|Valid'`
- [x] `go test ./... -count=1 -race -timeout 300s` (pre-push 120s budget is too tight for full race suite here)