### PR TITLE
fix(proxy): warn when stream ends without usage after include_usage

### DIFF
--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -282,11 +282,11 @@ func dispatchSelectedUpstream(
 		attemptBody, forcedStream := applyUpstreamStreamPreference(attemptBody, selected.Site.Platform, path, sitePref)
 		effectiveStream := ctx.IsStream || forcedStream
 		// OpenAI chat stream: ensure final SSE usage chunk via stream_options.include_usage (#345 / P0-555 residual).
-		attemptBody = applyUpstreamStreamIncludeUsage(attemptBody, selected.Site.Platform, path, effectiveStream)
+		attemptBody, expectStreamUsage := applyUpstreamStreamIncludeUsage(attemptBody, selected.Site.Platform, path, effectiveStream)
 		finished, pending, cont := dispatchEndpointAttemptWithContinue(
 			w, r, ctx, cfg, selected, upstreamModel, proxyConfig,
 			path, contentType, attemptBody, firstByteTimeoutMs,
-			retry, maxRetries, isLast, disableCrossProtocolFallback, effectiveStream, requestID,
+			retry, maxRetries, isLast, disableCrossProtocolFallback, effectiveStream, expectStreamUsage, requestID,
 		)
 		if finished {
 			return true, nil
@@ -411,23 +411,27 @@ func applyUpstreamStreamPreference(bodyBytes []byte, sitePlatform, upstreamPath 
 // chat/completions and legacy /v1/completions stream bodies so upstream SSE emits a final usage chunk (P0-555 residual / #345/#350).
 // Platform-safe: skips non-chat endpoints and platforms known to reject stream_options (codex/sub2api).
 // Does not invent tokens; only asks the provider to include usage when streaming.
-func applyUpstreamStreamIncludeUsage(bodyBytes []byte, sitePlatform, upstreamPath string, isStream bool) []byte {
+//
+// The bool is true when the outbound stream body is expected to carry usage via include_usage
+// (we injected it, or the client already set include_usage=true on an accepting path). Callers
+// use that flag to warn once if the stream ends without extracted usage (#400 / P0-555 residual).
+func applyUpstreamStreamIncludeUsage(bodyBytes []byte, sitePlatform, upstreamPath string, isStream bool) ([]byte, bool) {
 	if !isStream || len(bodyBytes) == 0 {
-		return bodyBytes
+		return bodyBytes, false
 	}
 	if !acceptsOpenAIStreamIncludeUsagePath(upstreamPath) {
-		return bodyBytes
+		return bodyBytes, false
 	}
 	if rejectsOpenAIStreamOptions(sitePlatform) {
-		return bodyBytes
+		return bodyBytes, false
 	}
 	var body map[string]any
 	if err := json.Unmarshal(bodyBytes, &body); err != nil {
-		return bodyBytes
+		return bodyBytes, false
 	}
 	// Only when this attempt is streaming (client or forced).
 	if !jsonTruthyBool(body["stream"]) && !isStream {
-		return bodyBytes
+		return bodyBytes, false
 	}
 	opts, _ := body["stream_options"].(map[string]any)
 	if opts == nil {
@@ -442,7 +446,8 @@ func applyUpstreamStreamIncludeUsage(bodyBytes []byte, sitePlatform, upstreamPat
 	}
 	if jsonTruthyBool(opts["include_usage"]) {
 		// Already requested; leave other stream_options keys intact without rewrite.
-		return bodyBytes
+		// Still expect a final usage chunk from upstream.
+		return bodyBytes, true
 	}
 	opts["include_usage"] = true
 	next := make(map[string]any, len(body)+1)
@@ -452,9 +457,39 @@ func applyUpstreamStreamIncludeUsage(bodyBytes []byte, sitePlatform, upstreamPat
 	next["stream_options"] = opts
 	out, err := json.Marshal(next)
 	if err != nil {
-		return bodyBytes
+		return bodyBytes, false
 	}
-	return out
+	return out, true
+}
+
+// shouldWarnMissingStreamUsage reports whether a completed/partial stream that requested
+// include_usage still lacks usable token counts. Never invents tokens — only detects absence.
+func shouldWarnMissingStreamUsage(expectIncludeUsage bool, usage ParsedUsage) bool {
+	if !expectIncludeUsage {
+		return false
+	}
+	if !usage.Found {
+		return true
+	}
+	// Found but all zero: provider emitted a usage object without counts (still residual).
+	return usage.PromptTokens == 0 && usage.CompletionTokens == 0 && usage.TotalTokens == 0 &&
+		usage.CacheReadTokens == 0 && usage.CacheCreationTokens == 0 && usage.ReasoningTokens == 0
+}
+
+// warnMissingStreamUsageAfterIncludeUsage logs once per call site (one success/partial end path).
+// model/path identify the request; tokens are never invented here.
+func warnMissingStreamUsageAfterIncludeUsage(model, path string, usage ParsedUsage) {
+	if !shouldWarnMissingStreamUsage(true, usage) {
+		return
+	}
+	slog.Warn("stream ended without usage after include_usage",
+		"model", model,
+		"path", path,
+		"usage_found", usage.Found,
+		"prompt_tokens", usage.PromptTokens,
+		"completion_tokens", usage.CompletionTokens,
+		"total_tokens", usage.TotalTokens,
+	)
 }
 
 // acceptsOpenAIStreamIncludeUsagePath reports OpenAI-compatible paths that honor
@@ -521,7 +556,7 @@ func dispatchEndpointAttempt(
 	finished, pending, _ := dispatchEndpointAttemptWithContinue(
 		w, r, ctx, cfg, selected, upstreamModel, proxyConfig,
 		upstreamPath, contentType, bodyBytes, firstByteTimeoutMs,
-		retry, maxRetries, true, true, ctx != nil && ctx.IsStream, requestID,
+		retry, maxRetries, true, true, ctx != nil && ctx.IsStream, false, requestID,
 	)
 	if !recordFailure {
 		return finished, pending
@@ -549,6 +584,7 @@ func dispatchEndpointAttemptWithContinue(
 	isLastEndpoint bool,
 	disableCrossProtocolFallback bool,
 	effectiveStream bool,
+	expectStreamUsage bool,
 	requestID string,
 ) (finished bool, nextPending *pendingUpstreamFailure, cont bool) {
 	if requestID == "" {
@@ -670,6 +706,11 @@ func dispatchEndpointAttemptWithContinue(
 			defer resp.Body.Close()
 			streamUsage = handleStreamUpstream(w, r, resp, latencyMs)
 		}()
+		// Observability only: include_usage was on the outbound body but SSE had no usable tokens (#400).
+		// Still record zeros / unknown — never invent tokens.
+		if expectStreamUsage {
+			warnMissingStreamUsageAfterIncludeUsage(upstreamModel, upstreamPath, streamUsage)
+		}
 		recordUpstreamSuccess(r.Context(), cfg, selected, upstreamModel, latencyMs, streamUsage)
 		writeSuccessProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, true, streamUsage, retry, requestID)
 		observeProxyTerminal(ctx, shared.OutcomeSuccess, true, time.Duration(latencyMs)*time.Millisecond)

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -1387,7 +1387,10 @@ func TestTruncateErrTextBoundsLength(t *testing.T) {
 func TestApplyUpstreamStreamIncludeUsage_InjectsWhenMissing(t *testing.T) {
 	t.Parallel()
 	in := []byte(`{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
-	out := applyUpstreamStreamIncludeUsage(in, "openai", "/v1/chat/completions", true)
+	out, expect := applyUpstreamStreamIncludeUsage(in, "openai", "/v1/chat/completions", true)
+	if !expect {
+		t.Fatal("expected expectStreamUsage=true after inject")
+	}
 	var body map[string]any
 	if err := json.Unmarshal(out, &body); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -1404,7 +1407,10 @@ func TestApplyUpstreamStreamIncludeUsage_InjectsWhenMissing(t *testing.T) {
 func TestApplyUpstreamStreamIncludeUsage_ForcesFalseToTrueAndPreservesKeys(t *testing.T) {
 	t.Parallel()
 	in := []byte(`{"model":"gpt-4o","stream":true,"stream_options":{"include_usage":false,"foo":"bar"}}`)
-	out := applyUpstreamStreamIncludeUsage(in, "new-api", "/v1/chat/completions", true)
+	out, expect := applyUpstreamStreamIncludeUsage(in, "new-api", "/v1/chat/completions", true)
+	if !expect {
+		t.Fatal("expected expectStreamUsage=true after force inject")
+	}
 	var body map[string]any
 	if err := json.Unmarshal(out, &body); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -1421,7 +1427,10 @@ func TestApplyUpstreamStreamIncludeUsage_ForcesFalseToTrueAndPreservesKeys(t *te
 func TestApplyUpstreamStreamIncludeUsage_NoopWhenAlreadyTrue(t *testing.T) {
 	t.Parallel()
 	in := []byte(`{"stream":true,"stream_options":{"include_usage":true,"foo":1}}`)
-	out := applyUpstreamStreamIncludeUsage(in, "openai", "/v1/chat/completions", true)
+	out, expect := applyUpstreamStreamIncludeUsage(in, "openai", "/v1/chat/completions", true)
+	if !expect {
+		t.Fatal("already-true include_usage still expects stream usage")
+	}
 	if string(out) != string(in) {
 		t.Fatalf("expected identical bytes when already true, got %s want %s", out, in)
 	}
@@ -1430,15 +1439,15 @@ func TestApplyUpstreamStreamIncludeUsage_NoopWhenAlreadyTrue(t *testing.T) {
 func TestApplyUpstreamStreamIncludeUsage_SkipNonChatAndNonStream(t *testing.T) {
 	t.Parallel()
 	in := []byte(`{"stream":true,"input":"hi"}`)
-	if got := applyUpstreamStreamIncludeUsage(in, "openai", "/v1/responses", true); string(got) != string(in) {
-		t.Fatalf("responses path should skip: %s", got)
+	if got, expect := applyUpstreamStreamIncludeUsage(in, "openai", "/v1/responses", true); string(got) != string(in) || expect {
+		t.Fatalf("responses path should skip: body=%s expect=%v", got, expect)
 	}
-	if got := applyUpstreamStreamIncludeUsage(in, "openai", "/v1/messages", true); string(got) != string(in) {
-		t.Fatalf("messages path should skip: %s", got)
+	if got, expect := applyUpstreamStreamIncludeUsage(in, "openai", "/v1/messages", true); string(got) != string(in) || expect {
+		t.Fatalf("messages path should skip: body=%s expect=%v", got, expect)
 	}
 	chat := []byte(`{"stream":false,"messages":[]}`)
-	if got := applyUpstreamStreamIncludeUsage(chat, "openai", "/v1/chat/completions", false); string(got) != string(chat) {
-		t.Fatalf("non-stream should skip: %s", got)
+	if got, expect := applyUpstreamStreamIncludeUsage(chat, "openai", "/v1/chat/completions", false); string(got) != string(chat) || expect {
+		t.Fatalf("non-stream should skip: body=%s expect=%v", got, expect)
 	}
 }
 
@@ -1446,8 +1455,8 @@ func TestApplyUpstreamStreamIncludeUsage_SkipCodexSub2API(t *testing.T) {
 	t.Parallel()
 	in := []byte(`{"stream":true,"messages":[{"role":"user","content":"x"}]}`)
 	for _, plat := range []string{"codex", "CODEX", "sub2api", "chatgpt-codex"} {
-		if got := applyUpstreamStreamIncludeUsage(in, plat, "/v1/chat/completions", true); string(got) != string(in) {
-			t.Fatalf("platform %q should skip stream_options inject: %s", plat, got)
+		if got, expect := applyUpstreamStreamIncludeUsage(in, plat, "/v1/chat/completions", true); string(got) != string(in) || expect {
+			t.Fatalf("platform %q should skip stream_options inject: body=%s expect=%v", plat, got, expect)
 		}
 	}
 }
@@ -1455,7 +1464,10 @@ func TestApplyUpstreamStreamIncludeUsage_SkipCodexSub2API(t *testing.T) {
 func TestApplyUpstreamStreamIncludeUsage_CompletionsPath(t *testing.T) {
 	t.Parallel()
 	in := []byte(`{"model":"gpt-3.5-turbo-instruct","stream":true,"prompt":"hi"}`)
-	out := applyUpstreamStreamIncludeUsage(in, "openai", "/v1/completions", true)
+	out, expect := applyUpstreamStreamIncludeUsage(in, "openai", "/v1/completions", true)
+	if !expect {
+		t.Fatal("completions path should expect stream usage")
+	}
 	var body map[string]any
 	if err := json.Unmarshal(out, &body); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -1468,11 +1480,69 @@ func TestApplyUpstreamStreamIncludeUsage_CompletionsPath(t *testing.T) {
 		t.Fatalf("include_usage = %#v", opts["include_usage"])
 	}
 	// nested suffix
-	out2 := applyUpstreamStreamIncludeUsage(in, "openai", "/proxy/v1/completions", true)
+	out2, expect2 := applyUpstreamStreamIncludeUsage(in, "openai", "/proxy/v1/completions", true)
+	if !expect2 {
+		t.Fatal("suffix completions path should expect stream usage")
+	}
 	if err := json.Unmarshal(out2, &body); err != nil {
 		t.Fatalf("unmarshal2: %v", err)
 	}
 	if body["stream_options"].(map[string]any)["include_usage"] != true {
 		t.Fatalf("suffix path failed: %#v", body)
+	}
+}
+
+func TestShouldWarnMissingStreamUsage(t *testing.T) {
+	t.Parallel()
+	if shouldWarnMissingStreamUsage(false, ParsedUsage{Source: usageSourceUnknown}) {
+		t.Fatal("no warn when include_usage was not expected")
+	}
+	if !shouldWarnMissingStreamUsage(true, ParsedUsage{Source: usageSourceUnknown}) {
+		t.Fatal("warn when expected and usage not found")
+	}
+	if !shouldWarnMissingStreamUsage(true, ParsedUsage{Found: true, Source: usageSourceUpstream}) {
+		t.Fatal("warn when expected and usage is all zeros")
+	}
+	if shouldWarnMissingStreamUsage(true, ParsedUsage{
+		Found:            true,
+		Source:           usageSourceUpstream,
+		PromptTokens:     11,
+		CompletionTokens: 22,
+		TotalTokens:      33,
+	}) {
+		t.Fatal("no warn when usable tokens present")
+	}
+}
+
+func TestParseUsageFromSSEEvents_FakeStreamWithoutUsage(t *testing.T) {
+	t.Parallel()
+	// Fake OpenAI chat stream that never emits a usage-bearing chunk (provider ignored include_usage).
+	events := []SseEvent{
+		{Data: `{"id":"chatcmpl-x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}`},
+		{Data: `{"id":"chatcmpl-x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`},
+		{Data: "[DONE]"},
+	}
+	got := ParseUsageFromSSEEvents(events)
+	if got.Found {
+		t.Fatalf("fake stream without usage must not invent tokens: %+v", got)
+	}
+	if !shouldWarnMissingStreamUsage(true, got) {
+		t.Fatal("expected warn when include_usage path ends without usage")
+	}
+	// Incremental analyzer path (production stream relay).
+	a := newIncrementalSseAnalyzer()
+	for _, ev := range events {
+		if ev.Data == "[DONE]" {
+			a.Push([]byte("data: [DONE]\n\n"))
+			continue
+		}
+		a.Push([]byte("data: " + ev.Data + "\n\n"))
+	}
+	result := a.Result()
+	if result.Usage.Found {
+		t.Fatalf("incremental analyzer must not invent tokens: %+v", result.Usage)
+	}
+	if !shouldWarnMissingStreamUsage(true, result.Usage) {
+		t.Fatal("expected warn from incremental path without usage")
 	}
 }


### PR DESCRIPTION
## Summary
- Track when OpenAI chat/completions streams carry `stream_options.include_usage` (injected or client-provided) via `applyUpstreamStreamIncludeUsage` bool return.
- On successful/partial stream end, `slog.Warn` once with `model`/`path` if usage is missing or all-zero tokens.
- Never invent tokens; residual remains zeros/`usage_source=unknown`.

Closes #400

## Test plan
- [x] `go test ./handler/proxy -count=1 -run 'IncludeUsage|Usage|Stream'`
- [x] pre-push `go vet ./... && go test ./... -count=1 -race`