### PR TITLE
fix(service): IsValidAPIEndpointURL rejects metadata/link-local (#398)

### DIFF
--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -806,14 +806,17 @@ func normalizeAPIEndpointsInput(input []payloads.SiteAPIEndpointInput) ([]payloa
 
 	for i, ep := range input {
 		normalizedURL := service.NormalizeSiteAPIEndpointBaseUrl(ep.URL)
-		if normalizedURL == "" || !service.IsValidAPIEndpointURL(normalizedURL) {
+		if normalizedURL == "" {
 			return nil, "Invalid apiEndpoints url. Expected a valid http(s) URL."
 		}
-		// Reject cloud metadata / link-local early with a clear 400 (#389).
-		// UpsertSiteAPIEndpoints also guards, but without this the admin path
-		// surfaces a generic 500 when CreateSite/UpdateSite fails later.
+		// Prefer the specific metadata/link-local 400 (#389) before the generic
+		// scheme check. IsValidAPIEndpointURL also rejects these targets (#398),
+		// so order only affects the error message (double-safe).
 		if service.IsForbiddenSiteTargetURL(normalizedURL) {
 			return nil, "Invalid apiEndpoints url. Cloud metadata / link-local targets are not allowed."
+		}
+		if !service.IsValidAPIEndpointURL(normalizedURL) {
+			return nil, "Invalid apiEndpoints url. Expected a valid http(s) URL."
 		}
 		if seen[normalizedURL] {
 			return nil, fmt.Sprintf("Duplicate apiEndpoints url: %s", normalizedURL)

--- a/service/site_endpoint_service.go
+++ b/service/site_endpoint_service.go
@@ -23,6 +23,8 @@ func NormalizeSiteAPIEndpointBaseUrl(raw string) string {
 }
 
 // IsValidAPIEndpointURL checks whether a normalized URL is a valid http(s) URL.
+// Also rejects cloud metadata / link-local targets via IsForbiddenSiteTargetURL
+// so any future caller is safe by default (#398 / parity with #382).
 func IsValidAPIEndpointURL(raw string) bool {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
@@ -32,7 +34,13 @@ func IsValidAPIEndpointURL(raw string) bool {
 	if err != nil {
 		return false
 	}
-	return parsed.Scheme == "http" || parsed.Scheme == "https"
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return false
+	}
+	if IsForbiddenSiteTargetURL(trimmed) {
+		return false
+	}
+	return true
 }
 
 // IsValidProxyURL checks whether a string is a valid http(s)/socks proxy URL.

--- a/service/site_service_test.go
+++ b/service/site_service_test.go
@@ -396,6 +396,32 @@ func TestIsValidAPIEndpointURL_Invalid(t *testing.T) {
 	}
 }
 
+func TestIsValidAPIEndpointURL_RejectsMetadata(t *testing.T) {
+	forbid := []string{
+		"http://169.254.169.254/latest/meta-data",
+		"https://169.254.169.254/",
+		"http://metadata.google.internal/",
+		"http://[fe80::1]/",
+	}
+	for _, u := range forbid {
+		if IsValidAPIEndpointURL(u) {
+			t.Errorf("expected invalid for metadata URL %q", u)
+		}
+	}
+	allow := []string{
+		"https://api.openai.com/v1",
+		"http://10.0.0.5:8080",
+		"http://192.168.1.10",
+		"http://127.0.0.1:4000",
+		"http://localhost:8080",
+	}
+	for _, u := range allow {
+		if !IsValidAPIEndpointURL(u) {
+			t.Errorf("expected valid for %q", u)
+		}
+	}
+}
+
 func TestIsValidProxyURL_Valid(t *testing.T) {
 	tests := []string{"http://proxy:8080", "https://proxy:8443", "socks5://proxy:1080", "socks5h://proxy:1080"}
 	for _, url := range tests {


### PR DESCRIPTION
## Summary
- IsValidAPIEndpointURL also rejects IsForbiddenSiteTargetURL targets
- Tests for reject + allow cases

Closes #398