### PR TITLE
feat(proxy): reject max_tokens above route context_length (#399)

### DIFF
--- a/handler/proxy/max_tokens.go
+++ b/handler/proxy/max_tokens.go
@@ -1,0 +1,122 @@
+package proxyhandler
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// maxTokensOverContextError is returned when body max_tokens exceeds a positive
+// route context_length. Callers must surface an honest 400 (no silent clamp).
+type maxTokensOverContextError struct {
+	MaxTokens     int64
+	ContextLength int64
+}
+
+func (e maxTokensOverContextError) Error() string {
+	return fmt.Sprintf(
+		"max_tokens (%d) exceeds route context_length (%d)",
+		e.MaxTokens,
+		e.ContextLength,
+	)
+}
+
+// enforceMaxTokensAgainstContextLength rejects max_tokens above a positive
+// route context_length for OpenAI chat/completions-style bodies.
+//
+// Policy (issue #399 / CTX-520):
+//   - enforce only when context_length > 0
+//   - enforce only when max_tokens is present and parseable as an integer
+//   - skip when max_tokens is omitted, null, or unparseable
+//   - never silent-clamp or invent tokens
+//
+// Returns maxTokensOverContextError when the request must be rejected with 400.
+func enforceMaxTokensAgainstContextLength(body map[string]any, contextLength *int64) error {
+	limit, ok := positiveContextLength(contextLength)
+	if !ok {
+		return nil
+	}
+	maxTokens, present := bodyMaxTokens(body)
+	if !present {
+		return nil
+	}
+	if maxTokens > limit {
+		return maxTokensOverContextError{MaxTokens: maxTokens, ContextLength: limit}
+	}
+	return nil
+}
+
+// shouldEnforceMaxTokensOnPath is true for OpenAI chat/completions (+ legacy completions).
+// Claude native messages keep optional residual (max_tokens is required there and often
+// means output budget only); this wave only enforces the OpenAI-shaped surfaces named in #399.
+func shouldEnforceMaxTokensOnPath(downstreamPath string) bool {
+	p := strings.ToLower(strings.TrimSpace(downstreamPath))
+	switch {
+	case strings.HasSuffix(p, "/chat/completions"):
+		return true
+	case p == "/v1/completions" || p == "/completions" || strings.HasSuffix(p, "/v1/completions"):
+		return true
+	default:
+		return false
+	}
+}
+
+func positiveContextLength(contextLength *int64) (int64, bool) {
+	if contextLength == nil || *contextLength <= 0 {
+		return 0, false
+	}
+	return *contextLength, true
+}
+
+// bodyMaxTokens extracts body["max_tokens"] when present as a finite whole number
+// or numeric string. Missing / null / empty / non-numeric → not present.
+func bodyMaxTokens(body map[string]any) (int64, bool) {
+	if body == nil {
+		return 0, false
+	}
+	raw, ok := body["max_tokens"]
+	if !ok || raw == nil {
+		return 0, false
+	}
+	switch v := raw.(type) {
+	case float64:
+		// JSON numbers unmarshal as float64.
+		if v != v { // NaN
+			return 0, false
+		}
+		if v > float64(^uint64(0)>>1) || v < float64(int64(-1<<63)) {
+			return 0, false
+		}
+		// Only accept whole-number values (no fractional tokens).
+		n := int64(v)
+		if v != float64(n) {
+			return 0, false
+		}
+		return n, true
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	case int32:
+		return int64(v), true
+	case string:
+		s := strings.TrimSpace(v)
+		if s == "" {
+			return 0, false
+		}
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return n, true
+	default:
+		// encoding/json.Number is a string under the hood.
+		if s, ok := raw.(fmt.Stringer); ok {
+			n, err := strconv.ParseInt(strings.TrimSpace(s.String()), 10, 64)
+			if err == nil {
+				return n, true
+			}
+		}
+		return 0, false
+	}
+}

--- a/handler/proxy/max_tokens_test.go
+++ b/handler/proxy/max_tokens_test.go
@@ -1,0 +1,359 @@
+package proxyhandler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tokendancelab/metapi-go/routing"
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+func ptrInt64(v int64) *int64 { return &v }
+
+func TestEnforceMaxTokensAgainstContextLength(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		body          map[string]any
+		contextLength *int64
+		wantErr       bool
+		wantMax       int64
+		wantLimit     int64
+	}{
+		{
+			name:          "over limit rejects",
+			body:          map[string]any{"max_tokens": float64(9000)},
+			contextLength: ptrInt64(8192),
+			wantErr:       true,
+			wantMax:       9000,
+			wantLimit:     8192,
+		},
+		{
+			name:          "equal limit passes",
+			body:          map[string]any{"max_tokens": float64(8192)},
+			contextLength: ptrInt64(8192),
+			wantErr:       false,
+		},
+		{
+			name:          "under limit passes",
+			body:          map[string]any{"max_tokens": float64(100)},
+			contextLength: ptrInt64(8192),
+			wantErr:       false,
+		},
+		{
+			name:          "omitted max_tokens skips",
+			body:          map[string]any{"model": "gpt-4o"},
+			contextLength: ptrInt64(8192),
+			wantErr:       false,
+		},
+		{
+			name:          "nil context_length skips",
+			body:          map[string]any{"max_tokens": float64(999999)},
+			contextLength: nil,
+			wantErr:       false,
+		},
+		{
+			name:          "zero context_length skips",
+			body:          map[string]any{"max_tokens": float64(999999)},
+			contextLength: ptrInt64(0),
+			wantErr:       false,
+		},
+		{
+			name:          "negative context_length skips",
+			body:          map[string]any{"max_tokens": float64(100)},
+			contextLength: ptrInt64(-1),
+			wantErr:       false,
+		},
+		{
+			name:          "null max_tokens skips",
+			body:          map[string]any{"max_tokens": nil},
+			contextLength: ptrInt64(100),
+			wantErr:       false,
+		},
+		{
+			name:          "string max_tokens over limit rejects",
+			body:          map[string]any{"max_tokens": "200"},
+			contextLength: ptrInt64(100),
+			wantErr:       true,
+			wantMax:       200,
+			wantLimit:     100,
+		},
+		{
+			name:          "json.Number over limit rejects",
+			body:          map[string]any{"max_tokens": json.Number("4097")},
+			contextLength: ptrInt64(4096),
+			wantErr:       true,
+			wantMax:       4097,
+			wantLimit:     4096,
+		},
+		{
+			name:          "unparseable max_tokens skips",
+			body:          map[string]any{"max_tokens": "lots"},
+			contextLength: ptrInt64(100),
+			wantErr:       false,
+		},
+		{
+			name:          "fractional max_tokens skips",
+			body:          map[string]any{"max_tokens": 12.5},
+			contextLength: ptrInt64(10),
+			wantErr:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := enforceMaxTokensAgainstContextLength(tt.body, tt.contextLength)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				var mtErr maxTokensOverContextError
+				if !asMaxTokensErr(err, &mtErr) {
+					t.Fatalf("error type = %T (%v), want maxTokensOverContextError", err, err)
+				}
+				if mtErr.MaxTokens != tt.wantMax || mtErr.ContextLength != tt.wantLimit {
+					t.Fatalf("err fields = %+v, want max=%d limit=%d", mtErr, tt.wantMax, tt.wantLimit)
+				}
+				if !strings.Contains(err.Error(), "max_tokens") || !strings.Contains(err.Error(), "context_length") {
+					t.Fatalf("error message = %q, want clear max_tokens/context_length wording", err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func asMaxTokensErr(err error, out *maxTokensOverContextError) bool {
+	if err == nil || out == nil {
+		return false
+	}
+	e, ok := err.(maxTokensOverContextError)
+	if !ok {
+		return false
+	}
+	*out = e
+	return true
+}
+
+func TestShouldEnforceMaxTokensOnPath(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"/v1/chat/completions":             true,
+		"/chat/completions":                true,
+		"/v1/completions":                  true,
+		"/completions":                     true,
+		"/v1/messages":                     false,
+		"/v1/responses":                    false,
+		"/v1/embeddings":                   false,
+		"/v1beta/models/x:generateContent": false,
+		"":                                 false,
+	}
+	for path, want := range cases {
+		if got := shouldEnforceMaxTokensOnPath(path); got != want {
+			t.Errorf("shouldEnforceMaxTokensOnPath(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestChatCompletions_MaxTokensOverContextLengthReturns400(t *testing.T) {
+	// Integration: selected route has positive context_length and body max_tokens exceeds it.
+	// Must return honest 400 without calling upstream.
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"should-not-reach"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(1024)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gpt-4o",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions",
+		`{"model":"gpt-4o","max_tokens":2048,"messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "max_tokens") || !strings.Contains(body, "context_length") {
+		t.Fatalf("body = %q, want clear max_tokens/context_length error", body)
+	}
+	if !strings.Contains(body, "invalid_request_error") {
+		t.Fatalf("body = %q, want invalid_request_error", body)
+	}
+	if upstreamHits != 0 {
+		t.Fatalf("upstream was called %d times; expected 0 (must not silent-forward)", upstreamHits)
+	}
+}
+
+func TestChatCompletions_MaxTokensAtContextLengthPassesThrough(t *testing.T) {
+	upstreamHits := 0
+	var sawMaxTokens any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		var payload map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		sawMaxTokens = payload["max_tokens"]
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"ok","choices":[]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(2048)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gpt-4o",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions",
+		`{"model":"gpt-4o","max_tokens":2048,"messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
+	}
+	// No silent clamp: original max_tokens must be forwarded unchanged.
+	if sawMaxTokens != float64(2048) {
+		t.Fatalf("upstream max_tokens = %v (%T), want 2048 (no clamp)", sawMaxTokens, sawMaxTokens)
+	}
+}
+
+func TestChatCompletions_NoContextLengthDoesNotEnforce(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"ok","choices":[]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:     store.RouteChannel{ID: 1, Enabled: true},
+			Account:     store.Account{ID: 1, Status: "active"},
+			Site:        store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:  "upstream-token",
+			ActualModel: "gpt-4o",
+			// ContextLength nil → no enforce
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions",
+		`{"model":"gpt-4o","max_tokens":999999,"messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
+	}
+}
+
+func TestChatCompletions_OmittedMaxTokensDoesNotEnforce(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"ok","choices":[]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(128)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gpt-4o",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions",
+		`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
+	}
+}
+
+func TestCompletions_MaxTokensOverContextLengthReturns400(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"nope"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(512)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gpt-3.5-turbo-instruct",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/completions",
+		`{"model":"gpt-3.5-turbo-instruct","prompt":"hi","max_tokens":1024}`)
+	rec := httptest.NewRecorder()
+	HandleCompletions(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 0 {
+		t.Fatalf("upstream was called; expected rejection before forward")
+	}
+}

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -207,6 +207,17 @@ func dispatchSelectedUpstream(
 	if requestID == "" {
 		requestID = proxy.RequestIDFromContext(r.Context())
 	}
+	// Optional max_tokens vs route context_length (issue #399 / CTX-520).
+	// Enforce only on OpenAI chat/completions (+ legacy completions) when the
+	// selected route publishes a positive context_length and the body includes
+	// max_tokens above that limit. Never silent-clamp.
+	if ctx != nil && selected != nil && shouldEnforceMaxTokensOnPath(upstreamPath) {
+		if err := enforceMaxTokensAgainstContextLength(ctx.Body, selected.ContextLength); err != nil {
+			writeJSONErrorWithRequest(w, http.StatusBadRequest, err.Error(), "invalid_request_error", requestID)
+			observeProxyTerminal(ctx, shared.OutcomeClientError, false, 0)
+			return true, nil
+		}
+	}
 	// Step 7: Build upstream request materials
 	upstreamModel := selected.ActualModel
 	if upstreamModel == "" {

--- a/routing/ports.go
+++ b/routing/ports.go
@@ -41,8 +41,8 @@ type ChannelLoadSnapshotProvider interface {
 
 // ChannelLoadParams are the parameters for resolving a channel's load snapshot.
 type ChannelLoadParams struct {
-	ChannelID           int64
-	AccountExtraConfig  *string
+	ChannelID            int64
+	AccountExtraConfig   *string
 	AccountOAuthProvider *string
 }
 
@@ -85,13 +85,16 @@ var EmptyDownstreamRoutingPolicy = DownstreamRoutingPolicy{
 
 // SelectedChannel is the result of a successful channel selection.
 type SelectedChannel struct {
-	Channel    store.RouteChannel
-	Account    store.Account
-	Site       store.Site
-	Token      *store.AccountToken
-	TokenValue string
-	TokenName  string
+	Channel     store.RouteChannel
+	Account     store.Account
+	Site        store.Site
+	Token       *store.AccountToken
+	TokenValue  string
+	TokenName   string
 	ActualModel string
+	// ContextLength is the matched token_routes.context_length (tokens).
+	// nil or <=0 means unknown / no max_tokens enforcement on the proxy path.
+	ContextLength *int64
 }
 
 // RouteDecisionExplanation mirrors TS RouteDecisionExplanation.
@@ -110,30 +113,30 @@ type RouteDecisionExplanation struct {
 
 // RouteDecisionCandidate mirrors TS RouteDecisionCandidate.
 type RouteDecisionCandidate struct {
-	ChannelID             int64
-	AccountID             int64
-	Username              string
-	SiteName              string
-	TokenName             string
-	Priority              int64
-	Weight                int64
-	Eligible              bool
-	RecentlyFailed        bool
+	ChannelID              int64
+	AccountID              int64
+	Username               string
+	SiteName               string
+	TokenName              string
+	Priority               int64
+	Weight                 int64
+	Eligible               bool
+	RecentlyFailed         bool
 	AvoidedByRecentFailure bool
-	Probability           float64
-	Reason                string
+	Probability            float64
+	Reason                 string
 }
 
 // RouteRoutingStrategy is the strategy for a route.
 type RouteRoutingStrategy string
 
 const (
-	StrategyWeighted       RouteRoutingStrategy = "weighted"
-	StrategyRoundRobin     RouteRoutingStrategy = "round_robin"
-	StrategyStableFirst    RouteRoutingStrategy = "stable_first"
-	StrategyLeastBusy      RouteRoutingStrategy = "least_busy"
-	StrategyLowestLatency  RouteRoutingStrategy = "lowest_latency"
-	StrategyLowestCost     RouteRoutingStrategy = "lowest_cost"
+	StrategyWeighted      RouteRoutingStrategy = "weighted"
+	StrategyRoundRobin    RouteRoutingStrategy = "round_robin"
+	StrategyStableFirst   RouteRoutingStrategy = "stable_first"
+	StrategyLeastBusy     RouteRoutingStrategy = "least_busy"
+	StrategyLowestLatency RouteRoutingStrategy = "lowest_latency"
+	StrategyLowestCost    RouteRoutingStrategy = "lowest_cost"
 )
 
 // KnownRouteRoutingStrategies lists operator-selectable strategies (#115).
@@ -224,8 +227,8 @@ type PricingReferenceRefreshOptions struct {
 
 // ExplainSelectionOptions configures explain-selection behavior.
 type ExplainSelectionOptions struct {
-	ExcludeChannelIDs           []int64
-	BypassSourceModelCheck      bool
+	ExcludeChannelIDs            []int64
+	BypassSourceModelCheck       bool
 	UseChannelSourceModelForCost bool
 	DownstreamPolicy             DownstreamRoutingPolicy
 }

--- a/routing/selector.go
+++ b/routing/selector.go
@@ -928,12 +928,13 @@ func (s *ChannelSelector) finalizeDispatch(
 	}
 
 	return &SelectedChannel{
-		Channel:     selected.Channel,
-		Account:     dispatchCandidate.Account,
-		Site:        dispatchCandidate.Site,
-		Token:       dispatchCandidate.Token,
-		TokenValue:  tokenValue,
-		TokenName:   tokenName,
-		ActualModel: actualModel,
+		Channel:       selected.Channel,
+		Account:       dispatchCandidate.Account,
+		Site:          dispatchCandidate.Site,
+		Token:         dispatchCandidate.Token,
+		TokenValue:    tokenValue,
+		TokenName:     tokenName,
+		ActualModel:   actualModel,
+		ContextLength: match.Route.ContextLength,
 	}, nil
 }


### PR DESCRIPTION
## Summary
- When route.context_length > 0 and OpenAI chat/completions max_tokens exceeds it → honest 400
- No silent clamp; skip if max_tokens omitted or context_length unset
- Clean cherry-pick onto current master (avoids stale worktree base)

Closes #399