### PR TITLE
docs(release): v0.8.26 endpoint parity + max_tokens + stream warn residual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.26] — 2026-07-18
+
+### Security
+- `IsValidAPIEndpointURL` rejects cloud metadata / link-local targets (aligned with `IsForbiddenSiteTargetURL` / `IsValidHTTPURL`); any caller is safe by default (#398 / #403)
+
+### Fixed
+- OpenAI chat/completions (and legacy completions): reject `max_tokens` above positive selected-route `context_length` with honest 400 `invalid_request_error` (no silent clamp; Claude out of scope) (#399 / #404)
+- OpenAI chat/completions stream: `slog.Warn` once when stream ends without usable usage after `stream_options.include_usage` (injected or client-provided); never invent token counts (#400 / #401)
+
+### Docs / Honesty
+- Residual inventory + MASTER for Milestone 36 post M35 / v0.8.25; SEC-ENDPOINT fully present · CTX-520 max_tokens reject shipped · P0-555 missing-usage warn residual note (#397 / #402)
+
 ## [v0.8.25] — 2026-07-17
 
 ### Security

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,12 +1,11 @@
-# Residual next candidates (post M35 / v0.8.25)
+# Residual next candidates (post v0.8.26)
 
 **Date**: 2026-07-18  
 **Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual; post-M35 honesty [#397](https://github.com/TokenDanceLab/metapi-go/issues/397)  
-**Context**: **post-M35** — **v0.8.25 shipped** (#382 IsValidHTTPURL metadata harden, #383 routes N+1 batch, #384 residual honesty). M35 closed: #388 review synthesis, **#389/#396** endpoint early reject, **#390/#395** multi-route list regression. Prior **v0.8.24**: #375–#377. Original P0 #405/#565/#515/#409 already-correct in code.  
+**Context**: **v0.8.26 shipped** (#397 residual honesty, #398 IsValidAPIEndpointURL metadata parity, #399 CTX-520 max_tokens reject, #400 P0-555 missing-usage warn; PRs #401–#404). Prior **v0.8.25**: #382–#384. M35 closed: #388 review synthesis, **#389/#396** endpoint early reject, **#390/#395** multi-route list regression. Original P0 #405/#565/#515/#409 already-correct in code.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)  
-**M35 review synthesis**: [`enterprise-review-m35.md`](./enterprise-review-m35.md) (#388) — ranked P0/P1/P2 backlog after multi-lane residual review (historical; #389/#390 done)  
-**Active wave**: Milestone 36 / **v0.8.26** board **#397–#400**
+**M35 review synthesis**: [`enterprise-review-m35.md`](./enterprise-review-m35.md) (#388) — ranked P0/P1/P2 backlog after multi-lane residual review (historical; #389/#390 done)
 
 ## Purpose
 
@@ -29,7 +28,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | TEST-1 | Admin proxy/chat stream + job queue harness | residual | `handler/admin/test.go` stream/jobs **501** / job not-found; sync path aliases forced-channel harness; `docs/analysis/admin-channel-test-harness.md` (#291) | Optional UX polish; sync harness already present | Low if residual stays honest |
 | P0-568 | Relay keys force-marked expired | **present** (#298/#301) | `ShouldMarkAccountExpired` + `ReportTokenExpired` ClassExpired guard; bare/generic 401 no longer marks | Done for mark path; novel wording residual only | Residual wording gaps |
 | P0-585 | Channel failure cascade poison | **partial** (hardened #299/#302; honesty #336) | **Shipped:** channel-scoped `excludeChannelIDs`, non-usage-limit cooldown write isolation, 429 failover, same-channel timeout budget, multi-channel same-site conductor + routing isolation tests. **Still open:** site/model breaker after 3 transient fails (intentional fleet filter), credential-scoped usage-limit multi-channel cool, empty-filter fallback, **no production multi-channel load proof**. Detail: `docs/analysis/failover-isolation.md` §P0-585 honesty | Optional load-test / breaker product AC only; soft-filter next-priority present via #358 | Medium residual — do not claim #585 present |
-| P0-555 | Token usage statistics inaccurate | **present-with-residual** (#300/#311/#319/#345/#350) | Disconnect partial + failure proxy_logs with usage (#311); aggregation projects non-success tokens into `failed_calls` + `total_tokens` (#319 regression); OpenAI chat + legacy completions stream `stream_options.include_usage` inject (#345/#350). Residual: provider-ignored flag, media zeros, multi-instance lag, orphan site join — not perfect billing | Residual polish only | Billing/ops trust residual |
+| P0-555 | Token usage statistics inaccurate | **present-with-residual** (#300/#311/#319/#345/#350/#400) | Disconnect partial + failure proxy_logs with usage (#311); aggregation projects non-success tokens into `failed_calls` + `total_tokens` (#319 regression); OpenAI chat + legacy completions stream `stream_options.include_usage` inject (#345/#350); stream-end `slog.Warn` when include_usage requested but no usable tokens extracted (#400 — never invents counts). Residual: provider-ignored flag, media zeros, multi-instance lag, orphan site join — not perfect billing | Residual polish only | Billing/ops trust residual |
 | P1-580 | Gemini thought_signature tool history | **present** (#86 transform + #309 proxy wire) | `NormalizeRequest` / OpenAI↔Gemini rebuild + `sanitizeUpstreamJSONBody` on gemini native/cli generateContent; residual: no multi-instance aggregate store | Done for request-side; session re-attach only if product needs | Residual multi-instance only |
 | P1-538 | Hermes/Codex multi-turn responses content | **present** (core; #50/#310) | `SanitizeResponsesInputItems` + `sanitizeUpstreamJSONBody` inject/preserve content; honest 400; residual: full Responses→chat conversion + no server store + no WS | Done for HTTP multi-turn content | Residual conversion/store/WS only |
 | ROUTE-590 | Route list drag reorder | **present** (v0.8.13) | `token_routes.sort_order` + `PUT /api/routes/reorder` (#284/#288); list `ORDER BY sort_order, id` | Done | — |
@@ -38,7 +37,7 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | KEY-578 | Per-key outbound proxy | present | `proxy/key_proxy.go` + `downstream_api_keys.proxy_url` | Done (matrix #281) | — |
 | REBUILD-588 | Pattern/group rebuild | present | `service/route_rebuild.go` `RebuildRoutesBestEffort` | Done (matrix #281) | — |
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
-| CTX-520 | Route contextLength admin + models wire | **present-with-residual** (#320 + #327) | Admin CRUD (#320) + OpenAI `/v1/models` prefers positive route `context_length` (max per exposed id) (#327). Residual: no proxy max-token enforce; Claude models path has no context_length field | Optional enforce Milestone only with ACs | Metadata vs enforcement |
+| CTX-520 | Route contextLength admin + models wire + max_tokens reject | **present-with-residual** (#320 + #327 + #399) | Admin CRUD (#320) + OpenAI `/v1/models` prefers positive route `context_length` (max per exposed id) (#327) + proxy rejects OpenAI chat/completions (and legacy completions) `max_tokens` above positive selected-route `context_length` with honest 400 (#399/#404). Residual: Claude messages path still out of scope; no clamp/rewrite of oversize requests; null/non-positive context_length still skips enforce | Residual dialect/scope polish only with ACs | Metadata + OpenAI enforce; Claude residual |
 | SEC-KEY | Admin downstream-keys plaintext redaction | **present** (#355/#361) | `redactDownstreamKeySecret` on list/summary/overview; `key` omitted, `keyMasked` only | Done for admin list surface | Residual: other admin dumps if any |
 | SEC-HDR | custom_headers deny-list | **present** (#356/#364) | Shared `platform.ApplyCustomHeaders` / deny-list; Bearer after custom on upstream path | Done | Residual novel header names only |
 | SEC-REDIR | RuntimeExecutor CheckRedirect SSRF | **present** (#357/#360) | `rejectCrossOriginRedirect` on RuntimeExecutor client | Done | Residual site-URL SSRF validation only if product AC |
@@ -49,18 +48,17 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | SEC-SITEURL | Site URL metadata/link-local SSRF | **present** (#376/#379) | `IsForbiddenSiteTargetURL` blocks 169.254/16, IPv6 link-local, metadata hostnames on create/update/endpoint upsert | Done | RFC1918/localhost intentionally allowed |
 | SEC-HTTPURL | IsValidHTTPURL / externalCheckin metadata | **present** (#382/#385) | `IsValidHTTPURL` rejects metadata/link-local class via `IsForbiddenSiteTargetURL`; externalCheckin uses hardened check | Done | RFC1918/localhost intentionally allowed |
 | PERF-ROUTES | GET /api/routes N+1 channel queries | **present** (#383/#386; test residual closed #390/#395) | Single channels JOIN for listed routes, group in memory; response shape + #375 redact unchanged; multi-route list regression + secret redact covered by `TestListRoutes_MultiRouteBatchChannelLoadAndRedaction` | Done for routes list batch-load | Residual other admin list N+1 only if product AC |
-| SEC-ENDPOINT | Site API endpoint admin normalize vs service upsert | **present** (#389/#396) | Admin `normalizeAPIEndpointsInput` rejects `IsForbiddenSiteTargetURL` targets with clear 400 before upsert; service path still defense-in-depth | Done for admin early-reject parity | Residual: base `IsValidAPIEndpointURL` scheme-only → M36 #398 validator parity |
-| M35-REVIEW | Multi-lane residual review synthesis | **present** (docs #388) | `docs/analysis/enterprise-review-m35.md` ranked P0/P1/P2; #389/#390 follow-ons closed on master | Historical M35 pointer; active board M36 #397–#400 | Synthesis only |
+| SEC-ENDPOINT | Site API endpoint admin normalize + service validator | **present** (#389/#396 + #398/#403) | Admin `normalizeAPIEndpointsInput` rejects forbidden targets with clear 400 before upsert; `IsValidAPIEndpointURL` itself rejects metadata/link-local (parity with `IsValidHTTPURL` / `IsForbiddenSiteTargetURL`) so any caller is safe by default | Done for admin early-reject + base validator parity | RFC1918/localhost intentionally allowed |
+| M35-REVIEW | Multi-lane residual review synthesis | **present** (docs #388) | `docs/analysis/enterprise-review-m35.md` ranked P0/P1/P2; #389/#390 follow-ons closed on master | Historical M35 pointer | Synthesis only |
 
-## Recommended sequencing (v0.8.26+)
+## Recommended sequencing (v0.8.27+)
 
-1. **Shipped in v0.8.25**: #382–#384 (PRs #385/#386/#387) — IsValidHTTPURL metadata harden · routes N+1 batch · residual honesty. Prior v0.8.24: #375–#377. Release docs flip #391 closed with tag **v0.8.25**.
-2. **M35 closed**: #388 review synthesis; **#389/#396** endpoint early-reject present; **#390/#395** multi-route list regression present (test residual closed).
-3. **Active M36 board (#397–#400)**: residual honesty flip (#397); **#398** `IsValidAPIEndpointURL` metadata/link-local validator parity; **#399** CTX-520 optional max_tokens reject when route `context_length` set; **#400** P0-555 stream missing-usage warn after include_usage inject.
-4. **P0-555** stays **present-with-residual**. **CTX-520** / **P0-585** residual notes unchanged until #399 / load-proof ACs land.
-5. **Optional product later**: P0-585 load-proof / site-model breaker; deeper billing polish (dedicated ACs only).
-6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-7. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+1. **Shipped in v0.8.26**: #397–#400 (PRs #401–#404) — residual honesty · IsValidAPIEndpointURL metadata parity · CTX-520 max_tokens reject · P0-555 stream missing-usage warn. Prior v0.8.25: #382–#384. M35 closed: #388 + #389/#396 + #390/#395.
+2. **SEC-ENDPOINT** fully **present** (admin early-reject + base validator). **CTX-520** stays **present-with-residual** (OpenAI max_tokens reject shipped; Claude / null-context residual). **P0-555** stays **present-with-residual** (warn shipped; provider-ignore / media / lag / orphan join residual).
+3. **P0-585** residual notes unchanged until load-proof / breaker ACs land.
+4. **Optional product later**: P0-585 load-proof / site-model breaker; deeper billing polish; Claude context_length enforce (dedicated ACs only).
+5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -69,16 +67,16 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Inventing update-center deploy/rollback success without a registry.
 - Returning `success:true` for unimplemented admin stream/job queues.
 - Claiming perfect billing accuracy without aggregation proof after #311.
-- Claiming proxy max-token enforcement from `contextLength` without a dedicated product AC.
+- Claiming Claude / all-dialect proxy max-token enforcement from `contextLength` without a dedicated product AC (OpenAI chat/completions reject only after #399).
 - Returning full downstream API keys on admin list/summary/overview after #355.
 - Allowing custom_headers to override Authorization/Host/hop-by-hop after #356.
 - Following cross-origin/private RuntimeExecutor redirects after #357.
 
 ## Links
 
-- Release: [v0.8.25](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.25) · prior [v0.8.24](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.24) · next residual board **v0.8.26+** (no tag until release gate)
+- Release: [v0.8.26](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.26) · prior [v0.8.25](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.25) · next residual board **v0.8.27+**
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - M35 review synthesis: `docs/analysis/enterprise-review-m35.md` (#388)
 - MASTER: `docs/progress/MASTER.md`
-- Related issues: #382, #383, #384, #375, #376, #377, #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346, #350, #351, #355, #356, #357, #358, #359, #366, #367, #368, #388, #389, #390, #391, #395, #396, #397, #398, #399, #400
+- Related issues: #397, #398, #399, #400, #401, #402, #403, #404, #382, #383, #384, #375, #376, #377, #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346, #350, #351, #355, #356, #357, #358, #359, #366, #367, #368, #388, #389, #390, #391, #395, #396

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -3,7 +3,7 @@
 **Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery
 **Mode**: GitHub Issues + Milestones (SDD)
 **Repo**: https://github.com/TokenDanceLab/metapi-go
-**Latest release**: **[v0.8.25](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.25)** (2026-07-17) — remains until release gate for v0.8.26
+**Latest release**: **[v0.8.26](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.26)** (2026-07-18)
 
 > 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。
 > 文档地图：[`docs/README.md`](../README.md)
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | [Milestone 36 — Enterprise residual polish v0.8.26](https://github.com/TokenDanceLab/metapi-go/milestone/36) |
+| Active milestone | closed Milestone 36 (v0.8.26) — next residual wave TBD |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | M35 review synthesis | `docs/analysis/enterprise-review-m35.md` (#388; M35 closed) |
@@ -38,25 +38,23 @@
 | Enterprise residual **v0.8.24** | ✅ | #375–#377 (PRs #378/#379/#380); tag **v0.8.24** |
 | Enterprise residual **v0.8.25** | ✅ | #382–#384 (PRs #385/#386/#387); tag **v0.8.25** |
 | M35 residual review / follow-ons | ✅ closed | #388 synthesis · #389/#396 endpoint early reject · #390/#395 multi-route regression |
-| Enterprise residual polish **v0.8.26** | 🔄 active | Milestone 36 · board **#397–#400** |
+| Enterprise residual polish **v0.8.26** | ✅ | #397–#400 (PRs #401–#404); tag **v0.8.26** |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| [#397](https://github.com/TokenDanceLab/metapi-go/issues/397) | docs | Residual honesty post M35 + v0.8.26 board |
-| [#398](https://github.com/TokenDanceLab/metapi-go/issues/398) | security | `IsValidAPIEndpointURL` metadata/link-local validator parity |
-| [#399](https://github.com/TokenDanceLab/metapi-go/issues/399) | proxy | CTX-520 reject max_tokens above positive route context_length |
-| [#400](https://github.com/TokenDanceLab/metapi-go/issues/400) | observability | P0-555 warn when stream ends without usage after include_usage inject |
+| — | — | Board clean after v0.8.26; next residual only with ACs |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
-**M35 closed**: do not re-list #388–#390 as active work (landed on master with #395/#396).
+**M35/M36 closed**: do not re-list #388–#390 or #397–#400 as active work (landed on master).
 
 
 ## Residual releases (pointer only)
 
 | Tag | Milestone | Highlights |
 |:----|:----------|:-----------|
+| [v0.8.26](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.26) | 36 | IsValidAPIEndpointURL metadata parity · max_tokens vs context_length reject · stream missing-usage warn · residual honesty |
 | [v0.8.25](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.25) | 34 | IsValidHTTPURL metadata harden · routes N+1 batch · residual honesty |
 | [v0.8.24](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.24) | 33 | routes/search secret redact · site metadata URL guard · residual honesty |
 | [v0.8.23](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.23) | 32 | admin account secret redact · RR/stable soft-filter demotion · residual honesty |
@@ -84,13 +82,13 @@
 ```bash
 gh issue list --state open --limit 20
 gh pr list --state open
-gh release view v0.8.25
+gh release view v0.8.26
 git log --oneline origin/master -10
 ```
 
 ## Next Steps
 
-1. Land M36 board **#397–#400**: residual honesty (#397) · endpoint validator parity (#398) · CTX-520 max_tokens reject (#399) · P0-555 missing-usage warn (#400). Latest release stays **v0.8.25** until release gate.
+1. Close Milestone 36: #397 residual honesty · #398 endpoint validator parity · #399 CTX-520 max_tokens reject · #400 P0-555 missing-usage warn. Latest release **v0.8.26**.
 2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
 3. Optional later: P0-585 load-proof / site-model breaker; deeper P0-555 media/lag polish.
 4. Keep MASTER slim; docs map at `docs/README.md`.


### PR DESCRIPTION
## Summary
- Docs-only release gate for **v0.8.26** (Milestone 36 board #397–#400).
- CHANGELOG: Security / Fixed / Docs for #398 endpoint validator parity, #399 max_tokens vs context_length reject, #400 stream missing-usage warn, #397 residual honesty.
- MASTER: latest **v0.8.26**, Milestone 36 closed pointer, board clean, residual releases row.
- residual-next-candidates: SEC-ENDPOINT fully present; CTX-520 present-with-residual (max_tokens reject shipped); P0-555 present-with-residual (warn note); sequencing **v0.8.27+**.

## Shipped on master (documented only)
- #397 residual honesty M36 board (PR #402)
- #400 stream missing usage warn (PR #401)
- #398 IsValidAPIEndpointURL metadata reject (PR #403)
- #399 max_tokens vs context_length reject (PR #404)

## Allowed files
- `CHANGELOG.md`
- `docs/progress/MASTER.md`
- `docs/analysis/residual-next-candidates.md`

## Notes
- **Do not tag** in this PR; tag is a separate release step.
- No product code.

## Test plan
- [x] Pre-push `go vet` + `go test ./... -race` green (docs-only)
- [x] Diff limited to three allowed docs files
- [ ] Human skim CHANGELOG / MASTER / residual sequencing