### PR TITLE
feat(proxy): enforce max_tokens vs context_length on Claude /v1/messages (#409)

### DIFF
--- a/handler/proxy/max_tokens.go
+++ b/handler/proxy/max_tokens.go
@@ -22,9 +22,9 @@ func (e maxTokensOverContextError) Error() string {
 }
 
 // enforceMaxTokensAgainstContextLength rejects max_tokens above a positive
-// route context_length for OpenAI chat/completions-style bodies.
+// route context_length for OpenAI chat/completions-style and Anthropic messages bodies.
 //
-// Policy (issue #399 / CTX-520):
+// Policy (issue #399 / #409 / CTX-520):
 //   - enforce only when context_length > 0
 //   - enforce only when max_tokens is present and parseable as an integer
 //   - skip when max_tokens is omitted, null, or unparseable
@@ -46,15 +46,16 @@ func enforceMaxTokensAgainstContextLength(body map[string]any, contextLength *in
 	return nil
 }
 
-// shouldEnforceMaxTokensOnPath is true for OpenAI chat/completions (+ legacy completions).
-// Claude native messages keep optional residual (max_tokens is required there and often
-// means output budget only); this wave only enforces the OpenAI-shaped surfaces named in #399.
+// shouldEnforceMaxTokensOnPath is true for OpenAI chat/completions (+ legacy completions)
+// and Anthropic Claude /v1/messages (issue #409). count_tokens and other surfaces stay out.
 func shouldEnforceMaxTokensOnPath(downstreamPath string) bool {
 	p := strings.ToLower(strings.TrimSpace(downstreamPath))
 	switch {
 	case strings.HasSuffix(p, "/chat/completions"):
 		return true
 	case p == "/v1/completions" || p == "/completions" || strings.HasSuffix(p, "/v1/completions"):
+		return true
+	case p == "/v1/messages" || p == "/messages" || strings.HasSuffix(p, "/v1/messages"):
 		return true
 	default:
 		return false

--- a/handler/proxy/max_tokens_test.go
+++ b/handler/proxy/max_tokens_test.go
@@ -151,7 +151,9 @@ func TestShouldEnforceMaxTokensOnPath(t *testing.T) {
 		"/chat/completions":                true,
 		"/v1/completions":                  true,
 		"/completions":                     true,
-		"/v1/messages":                     false,
+		"/v1/messages":                     true,
+		"/messages":                        true,
+		"/v1/messages/count_tokens":        false,
 		"/v1/responses":                    false,
 		"/v1/embeddings":                   false,
 		"/v1beta/models/x:generateContent": false,
@@ -355,5 +357,206 @@ func TestCompletions_MaxTokensOverContextLengthReturns400(t *testing.T) {
 	}
 	if upstreamHits != 0 {
 		t.Fatalf("upstream was called; expected rejection before forward")
+	}
+}
+
+func TestClaudeMessages_MaxTokensOverContextLengthReturns400(t *testing.T) {
+	// Issue #409: Claude /v1/messages must reject max_tokens above positive route context_length.
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"should-not-reach"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(1024)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "claude-sonnet-4-20250514",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/messages",
+		`{"model":"claude-sonnet-4-20250514","max_tokens":2048,"messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleClaudeMessages(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "max_tokens") || !strings.Contains(body, "context_length") {
+		t.Fatalf("body = %q, want clear max_tokens/context_length error", body)
+	}
+	if !strings.Contains(body, "invalid_request_error") {
+		t.Fatalf("body = %q, want invalid_request_error", body)
+	}
+	if upstreamHits != 0 {
+		t.Fatalf("upstream was called %d times; expected 0 (must not silent-forward)", upstreamHits)
+	}
+}
+
+func TestClaudeMessages_MaxTokensAtContextLengthPassesThrough(t *testing.T) {
+	upstreamHits := 0
+	var sawMaxTokens any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		var payload map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		sawMaxTokens = payload["max_tokens"]
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_ok","type":"message","role":"assistant","content":[]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(2048)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "claude-sonnet-4-20250514",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/messages",
+		`{"model":"claude-sonnet-4-20250514","max_tokens":2048,"messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleClaudeMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
+	}
+	// No silent clamp: original max_tokens must be forwarded unchanged.
+	if sawMaxTokens != float64(2048) {
+		t.Fatalf("upstream max_tokens = %v (%T), want 2048 (no clamp)", sawMaxTokens, sawMaxTokens)
+	}
+}
+
+func TestClaudeMessages_MaxTokensUnderContextLengthPassesThrough(t *testing.T) {
+	upstreamHits := 0
+	var sawMaxTokens any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		var payload map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		sawMaxTokens = payload["max_tokens"]
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_ok","type":"message","role":"assistant","content":[]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(8192)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "claude-sonnet-4-20250514",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/messages",
+		`{"model":"claude-sonnet-4-20250514","max_tokens":100,"messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleClaudeMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
+	}
+	if sawMaxTokens != float64(100) {
+		t.Fatalf("upstream max_tokens = %v (%T), want 100 (no clamp)", sawMaxTokens, sawMaxTokens)
+	}
+}
+
+func TestClaudeMessages_NoContextLengthDoesNotEnforce(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_ok","type":"message","role":"assistant","content":[]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:     store.RouteChannel{ID: 1, Enabled: true},
+			Account:     store.Account{ID: 1, Status: "active"},
+			Site:        store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:  "upstream-token",
+			ActualModel: "claude-sonnet-4-20250514",
+			// ContextLength nil → no enforce
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/messages",
+		`{"model":"claude-sonnet-4-20250514","max_tokens":999999,"messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleClaudeMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
+	}
+}
+
+func TestClaudeMessages_ZeroContextLengthDoesNotEnforce(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_ok","type":"message","role":"assistant","content":[]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(0)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "claude-sonnet-4-20250514",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/messages",
+		`{"model":"claude-sonnet-4-20250514","max_tokens":999999,"messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleClaudeMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
 	}
 }

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -207,10 +207,10 @@ func dispatchSelectedUpstream(
 	if requestID == "" {
 		requestID = proxy.RequestIDFromContext(r.Context())
 	}
-	// Optional max_tokens vs route context_length (issue #399 / CTX-520).
-	// Enforce only on OpenAI chat/completions (+ legacy completions) when the
-	// selected route publishes a positive context_length and the body includes
-	// max_tokens above that limit. Never silent-clamp.
+	// Optional max_tokens vs route context_length (issue #399 / #409 / CTX-520).
+	// Enforce on OpenAI chat/completions (+ legacy completions) and Anthropic
+	// /v1/messages when the selected route publishes a positive context_length
+	// and the body includes max_tokens above that limit. Never silent-clamp.
 	if ctx != nil && selected != nil && shouldEnforceMaxTokensOnPath(upstreamPath) {
 		if err := enforceMaxTokensAgainstContextLength(ctx.Body, selected.ContextLength); err != nil {
 			writeJSONErrorWithRequest(w, http.StatusBadRequest, err.Error(), "invalid_request_error", requestID)


### PR DESCRIPTION
## Summary
- Extend `enforceMaxTokensAgainstContextLength` / path gate to Anthropic `POST /v1/messages` when selected route `context_length > 0` and body `max_tokens` exceeds it → honest `400 invalid_request_error`
- No silent clamp; skip when `context_length` is null/0; leave `/v1/messages/count_tokens` and other surfaces out of scope
- Integration tests: over-limit reject, under/equal pass-through, nil/zero context_length no-enforce

Closes #409

## Test plan
- [x] `go test ./handler/proxy -count=1 -run 'MaxToken|Messages|Context'`