### PR TITLE
docs: residual honesty post v0.8.26 (Milestone 37 board)

### DIFF
--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,11 +1,12 @@
-# Residual next candidates (post v0.8.26)
+# Residual next candidates (post v0.8.26 / M37)
 
 **Date**: 2026-07-18  
-**Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual; post-M35 honesty [#397](https://github.com/TokenDanceLab/metapi-go/issues/397)  
-**Context**: **v0.8.26 shipped** (#397 residual honesty, #398 IsValidAPIEndpointURL metadata parity, #399 CTX-520 max_tokens reject, #400 P0-555 missing-usage warn; PRs #401–#404). Prior **v0.8.25**: #382–#384. M35 closed: #388 review synthesis, **#389/#396** endpoint early reject, **#390/#395** multi-route list regression. Original P0 #405/#565/#515/#409 already-correct in code.  
+**Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual; post-M35 honesty [#397](https://github.com/TokenDanceLab/metapi-go/issues/397); post-v0.8.26 honesty [#410](https://github.com/TokenDanceLab/metapi-go/issues/410)  
+**Context**: **v0.8.26 shipped** (#397 residual honesty, #398 IsValidAPIEndpointURL metadata parity, #399 CTX-520 OpenAI max_tokens reject, #400 P0-555 missing-usage warn; PRs #401–#404/#406). Board was clean after M36. **Milestone 37 opened** with security/polish board **#407–#410**. Prior **v0.8.25**: #382–#384. M35 closed: #388 review synthesis, **#389/#396** endpoint early reject, **#390/#395** multi-route list regression. Original P0 #405/#565/#515/#409 already-correct in code.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)  
-**M35 review synthesis**: [`enterprise-review-m35.md`](./enterprise-review-m35.md) (#388) — ranked P0/P1/P2 backlog after multi-lane residual review (historical; #389/#390 done)
+**M35 review synthesis**: [`enterprise-review-m35.md`](./enterprise-review-m35.md) (#388) — ranked P0/P1/P2 backlog after multi-lane residual review (historical; #389/#390 done)  
+**Active wave**: Milestone 37 / **v0.8.27** board **#407–#410** (security polish; latest release remains **v0.8.26** until release gate)
 
 ## Purpose
 
@@ -37,7 +38,9 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | KEY-578 | Per-key outbound proxy | present | `proxy/key_proxy.go` + `downstream_api_keys.proxy_url` | Done (matrix #281) | — |
 | REBUILD-588 | Pattern/group rebuild | present | `service/route_rebuild.go` `RebuildRoutesBestEffort` | Done (matrix #281) | — |
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
-| CTX-520 | Route contextLength admin + models wire + max_tokens reject | **present-with-residual** (#320 + #327 + #399) | Admin CRUD (#320) + OpenAI `/v1/models` prefers positive route `context_length` (max per exposed id) (#327) + proxy rejects OpenAI chat/completions (and legacy completions) `max_tokens` above positive selected-route `context_length` with honest 400 (#399/#404). Residual: Claude messages path still out of scope; no clamp/rewrite of oversize requests; null/non-positive context_length still skips enforce | Residual dialect/scope polish only with ACs | Metadata + OpenAI enforce; Claude residual |
+| CTX-520 | Route contextLength admin + models wire + max_tokens reject | **present-with-residual** (OpenAI shipped #320/#327/#399; Claude residual **active** #409) | Admin CRUD (#320) + OpenAI `/v1/models` prefers positive route `context_length` (max per exposed id) (#327) + proxy rejects OpenAI chat/completions (and legacy completions) `max_tokens` above positive selected-route `context_length` with honest 400 (#399/#404). **Active residual:** Claude `/v1/messages` still out of scope → M37 **#409** (reject when positive context_length and max_tokens > limit; no silent clamp). null/non-positive context_length still skips enforce | M37 #409 Claude path; further dialects only with ACs | OpenAI enforce present; Claude residual active |
+| SEC-MONITOR | Monitor session cookie embeds live AUTH_TOKEN | **residual → active** (#407) | `handler/admin/monitor.go` createSession sets `meta_monitor_auth=<cfg.AuthToken>`; `ensureMonitorAuth` uses non-constant-time compare. Cookie capture yields full admin bearer for all `/api/*` | **M37 P0 #407** — opaque monitor session (or HMAC) + constant-time compare; never put raw AuthToken in cookie | **P0** — cookie theft = full admin token |
+| SEC-AUTH-TIMING | Admin token change OldToken compare | **residual → active** (#408) | `handler/admin/auth_settings.go` compares `OldToken` with `!=` while AdminAuth middleware already uses `subtle.ConstantTimeCompare` | **M37 P0 #408** — constant-time equal-length compare; reject mismatched lengths without leaking timing | Timing side-channel on token rotate path |
 | SEC-KEY | Admin downstream-keys plaintext redaction | **present** (#355/#361) | `redactDownstreamKeySecret` on list/summary/overview; `key` omitted, `keyMasked` only | Done for admin list surface | Residual: other admin dumps if any |
 | SEC-HDR | custom_headers deny-list | **present** (#356/#364) | Shared `platform.ApplyCustomHeaders` / deny-list; Bearer after custom on upstream path | Done | Residual novel header names only |
 | SEC-REDIR | RuntimeExecutor CheckRedirect SSRF | **present** (#357/#360) | `rejectCrossOriginRedirect` on RuntimeExecutor client | Done | Residual site-URL SSRF validation only if product AC |
@@ -53,12 +56,17 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 
 ## Recommended sequencing (v0.8.27+)
 
-1. **Shipped in v0.8.26**: #397–#400 (PRs #401–#404) — residual honesty · IsValidAPIEndpointURL metadata parity · CTX-520 max_tokens reject · P0-555 stream missing-usage warn. Prior v0.8.25: #382–#384. M35 closed: #388 + #389/#396 + #390/#395.
-2. **SEC-ENDPOINT** fully **present** (admin early-reject + base validator). **CTX-520** stays **present-with-residual** (OpenAI max_tokens reject shipped; Claude / null-context residual). **P0-555** stays **present-with-residual** (warn shipped; provider-ignore / media / lag / orphan join residual).
-3. **P0-585** residual notes unchanged until load-proof / breaker ACs land.
-4. **Optional product later**: P0-585 load-proof / site-model breaker; deeper billing polish; Claude context_length enforce (dedicated ACs only).
-5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+1. **Shipped in v0.8.26**: #397–#400 (PRs #401–#404/#406) — residual honesty · IsValidAPIEndpointURL metadata parity · CTX-520 OpenAI max_tokens reject · P0-555 stream missing-usage warn. Prior v0.8.25: #382–#384. M35/M36 closed.
+2. **Active M37 board (#407–#410)** — Enterprise residual security polish **v0.8.27** (latest tag stays **v0.8.26** until release gate):
+   1. **#407 SEC-MONITOR (P0)**: opaque monitor session cookie; never embed live `AUTH_TOKEN`; constant-time compare.
+   2. **#408 SEC-AUTH-TIMING (P0)**: constant-time `OldToken` compare on admin token change (parity with AdminAuth middleware).
+   3. **#409 CTX-520 Claude residual (P1)**: enforce max_tokens vs positive route `context_length` on Anthropic `/v1/messages` (honest 400; no silent clamp).
+   4. **#410 docs**: this residual honesty pass + MASTER M37 pointer (no product code).
+3. **SEC-ENDPOINT** fully **present**. **CTX-520** stays **present-with-residual** until #409 lands (OpenAI enforce shipped; Claude active). **P0-555** stays **present-with-residual** (warn shipped; provider-ignore / media / lag / orphan join residual).
+4. **P0-585** residual notes unchanged until load-proof / breaker ACs land.
+5. **Optional product later**: P0-585 load-proof / site-model breaker; deeper billing polish; further dialect context_length enforce (dedicated ACs only).
+6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+7. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -67,16 +75,19 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Inventing update-center deploy/rollback success without a registry.
 - Returning `success:true` for unimplemented admin stream/job queues.
 - Claiming perfect billing accuracy without aggregation proof after #311.
-- Claiming Claude / all-dialect proxy max-token enforcement from `contextLength` without a dedicated product AC (OpenAI chat/completions reject only after #399).
+- Claiming Claude / all-dialect proxy max-token enforcement from `contextLength` without a dedicated product AC (OpenAI chat/completions reject only after #399; Claude via #409).
 - Returning full downstream API keys on admin list/summary/overview after #355.
 - Allowing custom_headers to override Authorization/Host/hop-by-hop after #356.
 - Following cross-origin/private RuntimeExecutor redirects after #357.
+- Embedding live `AUTH_TOKEN` in monitor cookies (SEC-MONITOR / #407).
+- Non-constant-time compares on admin token-change paths after AdminAuth already uses constant-time (#408).
 
 ## Links
 
-- Release: [v0.8.26](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.26) · prior [v0.8.25](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.25) · next residual board **v0.8.27+**
+- Release: [v0.8.26](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.26) · prior [v0.8.25](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.25) · next residual board **v0.8.27+** (no tag until release gate)
+- Milestone: [Enterprise residual security polish v0.8.27](https://github.com/TokenDanceLab/metapi-go/milestone/37) · board **#407–#410**
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - M35 review synthesis: `docs/analysis/enterprise-review-m35.md` (#388)
 - MASTER: `docs/progress/MASTER.md`
-- Related issues: #397, #398, #399, #400, #401, #402, #403, #404, #382, #383, #384, #375, #376, #377, #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346, #350, #351, #355, #356, #357, #358, #359, #366, #367, #368, #388, #389, #390, #391, #395, #396
+- Related issues: #407, #408, #409, #410, #397, #398, #399, #400, #401, #402, #403, #404, #406, #382, #383, #384, #375, #376, #377, #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346, #350, #351, #355, #356, #357, #358, #359, #366, #367, #368, #388, #389, #390, #391, #395, #396

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -3,7 +3,7 @@
 **Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery
 **Mode**: GitHub Issues + Milestones (SDD)
 **Repo**: https://github.com/TokenDanceLab/metapi-go
-**Latest release**: **[v0.8.26](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.26)** (2026-07-18)
+**Latest release**: **[v0.8.26](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.26)** (2026-07-18) — remains latest until M37 release gate
 
 > 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。
 > 文档地图：[`docs/README.md`](../README.md)
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | closed Milestone 36 (v0.8.26) — next residual wave TBD |
+| Active milestone | [Milestone 37 — Enterprise residual security polish v0.8.27](https://github.com/TokenDanceLab/metapi-go/milestone/37) |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | M35 review synthesis | `docs/analysis/enterprise-review-m35.md` (#388; M35 closed) |
@@ -38,16 +38,21 @@
 | Enterprise residual **v0.8.24** | ✅ | #375–#377 (PRs #378/#379/#380); tag **v0.8.24** |
 | Enterprise residual **v0.8.25** | ✅ | #382–#384 (PRs #385/#386/#387); tag **v0.8.25** |
 | M35 residual review / follow-ons | ✅ closed | #388 synthesis · #389/#396 endpoint early reject · #390/#395 multi-route regression |
-| Enterprise residual polish **v0.8.26** | ✅ | #397–#400 (PRs #401–#404); tag **v0.8.26** |
+| Enterprise residual polish **v0.8.26** | ✅ closed | #397–#400 (PRs #401–#404/#406); tag **v0.8.26** |
+| Enterprise residual security polish **v0.8.27** | 🔄 active | Milestone 37 · board **#407–#410** |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| — | — | Board clean after v0.8.26; next residual only with ACs |
+| [#407](https://github.com/TokenDanceLab/metapi-go/issues/407) | security P0 | SEC-MONITOR: opaque monitor session (no live AUTH_TOKEN cookie) + constant-time compare |
+| [#408](https://github.com/TokenDanceLab/metapi-go/issues/408) | security P0 | Constant-time compare for admin token change OldToken |
+| [#409](https://github.com/TokenDanceLab/metapi-go/issues/409) | proxy P1 | CTX-520: enforce max_tokens vs context_length on Claude `/v1/messages` |
+| [#410](https://github.com/TokenDanceLab/metapi-go/issues/410) | docs | Residual honesty post v0.8.26 (M37 board) |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
-**M35/M36 closed**: do not re-list #388–#390 or #397–#400 as active work (landed on master).
+**M35/M36 closed**: do not re-list #388–#390 or #397–#400 as active work (landed on master with v0.8.26).
+**Latest release**: stays **v0.8.26** until M37 release gate; do not claim v0.8.27 until tag.
 
 
 ## Residual releases (pointer only)
@@ -88,7 +93,7 @@ git log --oneline origin/master -10
 
 ## Next Steps
 
-1. Close Milestone 36: #397 residual honesty · #398 endpoint validator parity · #399 CTX-520 max_tokens reject · #400 P0-555 missing-usage warn. Latest release **v0.8.26**.
+1. Land M37 board **#407–#410**: SEC-MONITOR opaque session (#407 P0) · OldToken constant-time (#408 P0) · CTX-520 Claude max_tokens (#409) · residual honesty (#410). Latest release stays **v0.8.26** until release gate.
 2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
 3. Optional later: P0-585 load-proof / site-model breaker; deeper P0-555 media/lag polish.
 4. Keep MASTER slim; docs map at `docs/README.md`.


### PR DESCRIPTION
## Summary
- Flip residual inventory for **Milestone 37 / v0.8.27** board after clean post-v0.8.26 state
- **SEC-MONITOR** residual→active (**#407** P0: monitor cookie embeds live AUTH_TOKEN)
- **SEC-AUTH-TIMING** active (**#408** P0: OldToken `!=` vs AdminAuth constant-time)
- **CTX-520** Claude residual active (**#409**); OpenAI max_tokens reject remains shipped
- MASTER: Active milestone M37; Active work **#407–#410**; latest release stays **v0.8.26** until release gate

## Allowed paths
- `docs/analysis/residual-next-candidates.md`
- `docs/progress/MASTER.md`

## Test plan
- [x] Docs-only change (no product code)
- [x] Pre-push vet + race tests green
- [ ] Review residual table status labels for #407–#409
- [ ] Confirm MASTER Active work matches open M37 issues

Closes #410