### PR TITLE
fix(admin): opaque monitor session cookie (#407)

### DIFF
--- a/handler/admin/monitor.go
+++ b/handler/admin/monitor.go
@@ -1,6 +1,10 @@
 package admin
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -35,6 +39,19 @@ type monitorHandler struct {
 const ldohCookieSettingKey = "monitor_ldoh_cookie"
 const monitorAuthCookie = "meta_monitor_auth"
 const ldohBaseURL = "https://ldoh.105117.xyz"
+
+// monitorCookiePath is scoped to the iframe proxy surface only.
+// Path=/ is intentionally avoided so a stolen cookie cannot be presented
+// to other same-origin endpoints. Iframe + "open proxy" targets are both
+// under /monitor-proxy/, so this does not break the embed flow.
+const monitorCookiePath = "/monitor-proxy/"
+
+// monitorSessionMaxAge matches the previous 2h cookie lifetime.
+const monitorSessionMaxAge = 7200
+
+// monitorSessionPurpose is the fixed HMAC message. Changing it rotates all
+// outstanding monitor cookies without touching AuthToken itself.
+const monitorSessionPurpose = "metapi-monitor-session-v1"
 
 // GET /api/monitor/config
 func (h *monitorHandler) getConfig(w http.ResponseWriter, r *http.Request) {
@@ -123,10 +140,21 @@ func (h *monitorHandler) saveConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 // POST /api/monitor/session
+// Mints an opaque monitor-proxy cookie derived from AuthToken via HMAC.
+// The raw AUTH_TOKEN is never written into the cookie value: cookie theft
+// must not yield a usable admin Bearer credential for /api/*.
 func (h *monitorHandler) createSession(w http.ResponseWriter, r *http.Request) {
-	// Set HttpOnly cookie for iframe proxy auth
-	w.Header().Set("Set-Cookie",
-		monitorAuthCookie+"="+h.cfg.AuthToken+"; Path=/; HttpOnly; SameSite=Lax; Max-Age=7200")
+	session := deriveMonitorSessionToken(h.cfg.AuthToken)
+	cookie := &http.Cookie{
+		Name:     monitorAuthCookie,
+		Value:    session,
+		Path:     monitorCookiePath,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   monitorSessionMaxAge,
+		Secure:   isMonitorHTTPS(r),
+	}
+	http.SetCookie(w, cookie)
 	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
 }
 
@@ -226,7 +254,44 @@ func (h *monitorHandler) ldohProxy(w http.ResponseWriter, r *http.Request) {
 
 func (h *monitorHandler) ensureMonitorAuth(r *http.Request) bool {
 	cookies := parseCookieHeader(r.Header.Get("Cookie"))
-	return cookies[monitorAuthCookie] == h.cfg.AuthToken
+	got := cookies[monitorAuthCookie]
+	if got == "" {
+		return false
+	}
+	// Never accept the raw AuthToken as a monitor session.
+	if subtle.ConstantTimeCompare([]byte(got), []byte(h.cfg.AuthToken)) == 1 {
+		return false
+	}
+	expected := deriveMonitorSessionToken(h.cfg.AuthToken)
+	if len(got) != len(expected) {
+		// Length mismatch: still run a dummy compare to keep timing flat-ish,
+		// then deny.
+		_ = subtle.ConstantTimeCompare([]byte(expected), []byte(expected))
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(expected)) == 1
+}
+
+// deriveMonitorSessionToken returns an opaque, AuthToken-bound session value.
+// HMAC-SHA256(key=AuthToken, msg=purpose) means:
+//   - cookie value is never the live AUTH_TOKEN
+//   - AuthToken rotation automatically invalidates outstanding cookies
+//   - no server-side session store is required
+func deriveMonitorSessionToken(authToken string) string {
+	mac := hmac.New(sha256.New, []byte(authToken))
+	_, _ = mac.Write([]byte(monitorSessionPurpose))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// isMonitorHTTPS reports whether the request arrived over TLS (directly or
+// via a reverse proxy that sets X-Forwarded-Proto). Cookie.Secure is set
+// when true; deployments that terminate TLS elsewhere should forward that
+// header so the Secure flag is applied.
+func isMonitorHTTPS(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	return strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
 }
 
 func parseCookieHeader(raw string) map[string]string {

--- a/handler/admin/monitor_session_test.go
+++ b/handler/admin/monitor_session_test.go
@@ -1,0 +1,169 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestMonitorSession_CookieIsOpaqueNotAuthToken(t *testing.T) {
+	_, r, cfg := setupOpsAdminStubsTest(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/monitor/session", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != true {
+		t.Fatalf("success = %v, want true", body["success"])
+	}
+
+	cookies := rec.Result().Cookies()
+	var sessionCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == monitorAuthCookie {
+			sessionCookie = c
+			break
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatalf("Set-Cookie missing %s; headers=%v", monitorAuthCookie, rec.Header().Values("Set-Cookie"))
+	}
+	if sessionCookie.Value == "" {
+		t.Fatal("monitor session cookie value is empty")
+	}
+	if sessionCookie.Value == cfg.AuthToken {
+		t.Fatalf("cookie value must not equal AuthToken (cookie theft must not yield admin bearer)")
+	}
+	if !sessionCookie.HttpOnly {
+		t.Fatal("monitor session cookie must be HttpOnly")
+	}
+	if sessionCookie.Path != monitorCookiePath {
+		t.Fatalf("cookie Path = %q, want %q (scoped to proxy surface)", sessionCookie.Path, monitorCookiePath)
+	}
+	if sessionCookie.MaxAge != monitorSessionMaxAge {
+		t.Fatalf("cookie MaxAge = %d, want %d", sessionCookie.MaxAge, monitorSessionMaxAge)
+	}
+	if sessionCookie.SameSite != http.SameSiteLaxMode {
+		t.Fatalf("cookie SameSite = %v, want Lax", sessionCookie.SameSite)
+	}
+	expected := deriveMonitorSessionToken(cfg.AuthToken)
+	if sessionCookie.Value != expected {
+		t.Fatalf("cookie value = %q, want derived session %q", sessionCookie.Value, expected)
+	}
+}
+
+func TestMonitorSession_CookieSecureWhenHTTPS(t *testing.T) {
+	_, r, _ := setupOpsAdminStubsTest(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/monitor/session", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	var sessionCookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == monitorAuthCookie {
+			sessionCookie = c
+			break
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("missing monitor session cookie")
+	}
+	if !sessionCookie.Secure {
+		t.Fatal("cookie Secure must be set when X-Forwarded-Proto=https")
+	}
+}
+
+func TestMonitorAuth_ValidOpaqueCookieAccepted(t *testing.T) {
+	_, r, cfg := setupOpsAdminStubsTest(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/monitor-proxy/ldoh/", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  monitorAuthCookie,
+		Value: deriveMonitorSessionToken(cfg.AuthToken),
+	})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	// Auth ok; LDOH cookie not configured → 400 plain text (not 401).
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s, want 400 after valid session", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "LDOH cookie not configured") {
+		t.Fatalf("body = %q, want unconfigured cookie message", rec.Body.String())
+	}
+}
+
+func TestMonitorAuth_InvalidCookieDenied(t *testing.T) {
+	_, r, cfg := setupOpsAdminStubsTest(t)
+
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{name: "empty", value: ""},
+		{name: "garbage", value: "not-a-valid-session"},
+		{name: "raw-auth-token", value: cfg.AuthToken},
+		{name: "wrong-hmac", value: deriveMonitorSessionToken(cfg.AuthToken + "-other")},
+		{name: "truncated", value: deriveMonitorSessionToken(cfg.AuthToken)[:8]},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/monitor-proxy/ldoh/", nil)
+			if tc.value != "" {
+				req.AddCookie(&http.Cookie{Name: monitorAuthCookie, Value: tc.value})
+			}
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d body=%s, want 401", rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), "Missing or invalid monitor session") {
+				t.Fatalf("body = %q, want invalid session message", rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestMonitorAuth_AuthTokenRotationInvalidatesCookie(t *testing.T) {
+	_, r, cfg := setupOpsAdminStubsTest(t)
+
+	oldToken := "old-admin-token"
+	newToken := "new-admin-token"
+	if deriveMonitorSessionToken(oldToken) == deriveMonitorSessionToken(newToken) {
+		t.Fatal("session must change when AuthToken rotates")
+	}
+
+	cfg.AuthToken = oldToken
+	minted := deriveMonitorSessionToken(cfg.AuthToken)
+
+	// Valid under current token.
+	reqOK := httptest.NewRequest(http.MethodGet, "/monitor-proxy/ldoh/", nil)
+	reqOK.AddCookie(&http.Cookie{Name: monitorAuthCookie, Value: minted})
+	recOK := httptest.NewRecorder()
+	r.ServeHTTP(recOK, reqOK)
+	if recOK.Code == http.StatusUnauthorized {
+		t.Fatalf("pre-rotation cookie should be accepted; body=%s", recOK.Body.String())
+	}
+
+	// Rotate AuthToken: previous cookie must be rejected.
+	cfg.AuthToken = newToken
+	reqDenied := httptest.NewRequest(http.MethodGet, "/monitor-proxy/ldoh/", nil)
+	reqDenied.AddCookie(&http.Cookie{Name: monitorAuthCookie, Value: minted})
+	recDenied := httptest.NewRecorder()
+	r.ServeHTTP(recDenied, reqDenied)
+	if recDenied.Code != http.StatusUnauthorized {
+		t.Fatalf("post-rotation status = %d body=%s, want 401", recDenied.Code, recDenied.Body.String())
+	}
+}

--- a/handler/admin/ops_admin_stubs_test.go
+++ b/handler/admin/ops_admin_stubs_test.go
@@ -137,9 +137,9 @@ func TestMonitorLdohProxy_RequiresSessionAndCookie(t *testing.T) {
 		t.Fatalf("must not fake success for missing session: %s", rec.Body.String())
 	}
 
-	// Session present but cookie not configured → 400 plain text
+	// Session present but LDOH cookie not configured → 400 plain text
 	req2 := httptest.NewRequest(http.MethodGet, "/monitor-proxy/ldoh/", nil)
-	req2.AddCookie(&http.Cookie{Name: monitorAuthCookie, Value: cfg.AuthToken})
+	req2.AddCookie(&http.Cookie{Name: monitorAuthCookie, Value: deriveMonitorSessionToken(cfg.AuthToken)})
 	rec2 := httptest.NewRecorder()
 	r.ServeHTTP(rec2, req2)
 	if rec2.Code != http.StatusBadRequest {


### PR DESCRIPTION
## Summary
- Stop embedding live `AUTH_TOKEN` in the `meta_monitor_auth` cookie
- Mint an HMAC-SHA256 opaque session (`key=AuthToken`, purpose-bound) and compare with `crypto/subtle`
- Scope cookie to `Path=/monitor-proxy/` (iframe + open-proxy targets already live under that path; Path=/ is not required)
- Set `Secure` when the request is TLS / `X-Forwarded-Proto: https`
- AuthToken rotation invalidates outstanding monitor cookies without a server-side store

## Test plan
- [x] `go test ./handler/admin -count=1 -run 'Monitor|Session|Cookie|Ldoh'`
- [x] pre-push `go vet ./...` + `go test ./... -count=1 -race`
- [x] cookie value != AuthToken
- [x] raw AuthToken / garbage / wrong-HMAC / truncated cookies → 401
- [x] valid opaque cookie accepted (reaches LDOH unconfigured path)
- [x] AuthToken rotation invalidates prior cookie

Closes #407