### PR TITLE
docs: residual honesty post v0.8.27 (Milestone 38 board)

### DIFF
--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,11 +1,12 @@
-# Residual next candidates (post v0.8.27)
+# Residual next candidates (post v0.8.27 / M38)
 
 **Date**: 2026-07-18  
-**Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual; post-M35 honesty [#397](https://github.com/TokenDanceLab/metapi-go/issues/397); post-v0.8.26 honesty [#410](https://github.com/TokenDanceLab/metapi-go/issues/410)  
-**Context**: **v0.8.27 shipped** (#407 opaque monitor session, #408 OldToken constant-time, #409 CTX-520 Claude max_tokens reject, #410 residual honesty; PRs #411–#414). Prior **v0.8.26**: #397–#400 (PRs #401–#404/#406). Board clean after M37. Prior **v0.8.25**: #382–#384. M35 closed: #388 review synthesis, **#389/#396** endpoint early reject, **#390/#395** multi-route list regression. Original P0 #405/#565/#515 already-correct in code.  
+**Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual; post-M35 honesty [#397](https://github.com/TokenDanceLab/metapi-go/issues/397); post-v0.8.26 honesty [#410](https://github.com/TokenDanceLab/metapi-go/issues/410); post-v0.8.27 honesty [#418](https://github.com/TokenDanceLab/metapi-go/issues/418)  
+**Context**: **v0.8.27 shipped** (#407 opaque monitor session, #408 OldToken constant-time, #409 CTX-520 Claude max_tokens reject, #410 residual honesty; PRs #411–#414). Board was clean after M37. **Milestone 38 opened** with SSRF/client harden board **#416–#418**. Prior **v0.8.26**: #397–#400 (PRs #401–#404/#406). Prior **v0.8.25**: #382–#384. M35 closed: #388 review synthesis, **#389/#396** endpoint early reject, **#390/#395** multi-route list regression. Original P0 #405/#565/#515 already-correct in code.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)  
-**M35 review synthesis**: [`enterprise-review-m35.md`](./enterprise-review-m35.md) (#388) — ranked P0/P1/P2 backlog after multi-lane residual review (historical; #389/#390 done)
+**M35 review synthesis**: [`enterprise-review-m35.md`](./enterprise-review-m35.md) (#388) — ranked P0/P1/P2 backlog after multi-lane residual review (historical; #389/#390 done)  
+**Active wave**: Milestone 38 / **v0.8.28** board **#416–#418** (SSRF/client harden; latest release remains **v0.8.27** until release gate)
 
 ## Purpose
 
@@ -38,11 +39,11 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | REBUILD-588 | Pattern/group rebuild | present | `service/route_rebuild.go` `RebuildRoutesBestEffort` | Done (matrix #281) | — |
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
 | CTX-520 | Route contextLength admin + models wire + max_tokens reject | **present-with-residual** (OpenAI #320/#327/#399; Claude #409) | Admin CRUD (#320) + OpenAI `/v1/models` prefers positive route `context_length` (max per exposed id) (#327) + proxy rejects OpenAI chat/completions (and legacy completions) `max_tokens` above positive selected-route `context_length` with honest 400 (#399/#404) + Claude `/v1/messages` same reject when positive context_length (#409/#412). Residual: further dialects only with ACs; null/non-positive context_length still skips enforce; no silent clamp | Further dialect polish only with ACs | OpenAI + Claude enforce present; other dialects residual |
-| SEC-MONITOR | Monitor session cookie embeds live AUTH_TOKEN | **present** (#407/#414) | Opaque HMAC-SHA256 monitor session; `ensureMonitorAuth` constant-time compare; cookie scoped `Path=/monitor-proxy/` so capture cannot become full admin bearer | Done for monitor session | Residual: rotate/invalidate on auth_token change if product AC |
+| SEC-MONITOR | Monitor session cookie embeds live AUTH_TOKEN | **present-with-residual** (opaque session #407/#414; logout residual **active** #417) | Opaque HMAC-SHA256 monitor session; `ensureMonitorAuth` constant-time compare; cookie scoped `Path=/monitor-proxy/` so capture cannot become full admin bearer. **Active residual:** admin logout / session clear may not set `Max-Age=0` for `meta_monitor_auth` with matching Path → M38 **#417** | M38 #417 logout cookie clear; rotate/invalidate on auth_token change only with product AC | Logout residual active; session token present |
 | SEC-AUTH-TIMING | Admin token change OldToken compare | **present** (#408/#411) | `handler/admin/auth_settings.go` uses `subtle.ConstantTimeCompare` on equal-length normalized bytes; mismatched lengths rejected without leaking timing (parity with AdminAuth middleware) | Done for token-change path | Residual other non-constant compares only if product AC |
 | SEC-KEY | Admin downstream-keys plaintext redaction | **present** (#355/#361) | `redactDownstreamKeySecret` on list/summary/overview; `key` omitted, `keyMasked` only | Done for admin list surface | Residual: other admin dumps if any |
 | SEC-HDR | custom_headers deny-list | **present** (#356/#364) | Shared `platform.ApplyCustomHeaders` / deny-list; Bearer after custom on upstream path | Done | Residual novel header names only |
-| SEC-REDIR | RuntimeExecutor CheckRedirect SSRF | **present** (#357/#360) | `rejectCrossOriginRedirect` on RuntimeExecutor client | Done | Residual site-URL SSRF validation only if product AC |
+| SEC-REDIR | RuntimeExecutor CheckRedirect SSRF | **present-with-residual** (RuntimeExecutor #357/#360; bare clients residual **active** #416) | `rejectCrossOriginRedirect` on RuntimeExecutor client + platform DoWithProxy. **Active residual after #357:** bare probe/harness/default clients still use Go default redirect policy — `channel_health_probe.go` / `channel_test_harness.go` bare `&http.Client{}` when no site proxy, and `defaultUpstreamClient` (90s, no CheckRedirect) → M38 **#416** share rejectCrossOriginRedirect (or stronger) + regression tests public origin 302 → 169.254/loopback | **M38 P0 #416** — share CheckRedirect on probe/harness/defaultUpstreamClient | **P0** bare-client redirect SSRF residual |
 | REL-SOFT | Weighted soft-filter empty → next priority | **present** (#358/#362) | Weighted path skips soft-empty priority layer and tries next; failover-isolation note | Done for weighted soft-filter | P0-585 empty-filter fallback residual separate |
 | SEC-ADMIN | Remaining admin secret surfaces | **present-with-residual** (#367/#372) | Account list redacts accessToken/apiToken + passwordCipher strip; token list drops join secrets. Residual: create/update/rebind may still echo once; intentional credential export | Done for list/overview | Residual intentional export / create-once |
 | REL-SOFT-RR | RR/stable_first soft-filter priority demotion | **present** (#368/#370) | RR/stable_first/least_* share priority-layer strict soft-filter demotion with weighted | Done | Global full-set fallback when all layers soft-empty (P0-585 residual) |
@@ -56,11 +57,15 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 ## Recommended sequencing (v0.8.28+)
 
 1. **Shipped in v0.8.27**: #407–#410 (PRs #411–#414) — opaque monitor session · OldToken constant-time · CTX-520 Claude max_tokens reject · residual honesty. Prior v0.8.26: #397–#400. M35/M36/M37 closed.
-2. **SEC-MONITOR** fully **present**. **SEC-AUTH-TIMING** fully **present**. **CTX-520** stays **present-with-residual** (OpenAI + Claude max_tokens reject shipped; further dialects / null-context residual). **P0-555** stays **present-with-residual** (warn shipped; provider-ignore / media / lag / orphan join residual).
-3. **P0-585** residual notes unchanged until load-proof / breaker ACs land.
-4. **Optional product later**: P0-585 load-proof / site-model breaker; deeper billing polish; further dialect context_length enforce (dedicated ACs only).
-5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+2. **Active M38 board (#416–#418)** — Enterprise residual SSRF/client harden **v0.8.28** (latest tag stays **v0.8.27** until release gate):
+   1. **#416 SEC-REDIR bare clients (P0)**: share `rejectCrossOriginRedirect` (or equivalent) on probe / harness / `defaultUpstreamClient`; regression tests for public-origin 302 → 169.254/loopback.
+   2. **#417 SEC-MONITOR logout residual (P1)**: clear `meta_monitor_auth` with matching `Path=/monitor-proxy/` on admin logout / session clear (`Max-Age=0`).
+   3. **#418 docs**: this residual honesty pass + MASTER M38 pointer (no product code).
+3. **SEC-AUTH-TIMING** fully **present**. **SEC-REDIR** stays **present-with-residual** until #416 lands (RuntimeExecutor shipped; bare clients active). **SEC-MONITOR** stays **present-with-residual** until #417 lands (opaque session shipped; logout cookie clear active). **CTX-520** stays **present-with-residual** (OpenAI + Claude max_tokens reject shipped; further dialects / null-context residual). **P0-555** stays **present-with-residual** (warn shipped; provider-ignore / media / lag / orphan join residual).
+4. **P0-585** residual notes unchanged until load-proof / breaker ACs land.
+5. **Optional product later**: P0-585 load-proof / site-model breaker; deeper billing polish; further dialect context_length enforce (dedicated ACs only).
+6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+7. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 
 ## Explicit non-goals for residual waves
 
@@ -72,16 +77,16 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Claiming all-dialect proxy max-token enforcement from `contextLength` without a dedicated product AC (OpenAI chat/completions after #399; Claude `/v1/messages` after #409; further dialects need ACs).
 - Returning full downstream API keys on admin list/summary/overview after #355.
 - Allowing custom_headers to override Authorization/Host/hop-by-hop after #356.
-- Following cross-origin/private RuntimeExecutor redirects after #357.
-- Embedding live `AUTH_TOKEN` in monitor cookies after #407.
+- Following cross-origin/private RuntimeExecutor redirects after #357 (bare probe/harness/defaultUpstreamClient residual via #416).
+- Embedding live `AUTH_TOKEN` in monitor cookies after #407 (logout cookie clear residual via #417).
 - Non-constant-time compares on admin token-change paths after #408.
 
 ## Links
 
-- Release: [v0.8.27](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.27) · prior [v0.8.26](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.26) · next residual board **v0.8.28+**
-- Milestone: [Enterprise residual security polish v0.8.27](https://github.com/TokenDanceLab/metapi-go/milestone/37) · board **#407–#410** closed
+- Release: [v0.8.27](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.27) · prior [v0.8.26](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.26) · next residual board **v0.8.28+** (no tag until release gate)
+- Milestone: [Enterprise residual SSRF/client harden v0.8.28](https://github.com/TokenDanceLab/metapi-go/milestone/38) · board **#416–#418**
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - M35 review synthesis: `docs/analysis/enterprise-review-m35.md` (#388)
 - MASTER: `docs/progress/MASTER.md`
-- Related issues: #407, #408, #409, #410, #411, #412, #413, #414, #397, #398, #399, #400, #401, #402, #403, #404, #406, #382, #383, #384, #375, #376, #377, #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346, #350, #351, #355, #356, #357, #358, #359, #366, #367, #368, #388, #389, #390, #391, #395, #396
+- Related issues: #416, #417, #418, #407, #408, #409, #410, #411, #412, #413, #414, #397, #398, #399, #400, #401, #402, #403, #404, #406, #382, #383, #384, #375, #376, #377, #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346, #350, #351, #355, #356, #357, #358, #359, #366, #367, #368, #388, #389, #390, #391, #395, #396

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -3,7 +3,7 @@
 **Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery
 **Mode**: GitHub Issues + Milestones (SDD)
 **Repo**: https://github.com/TokenDanceLab/metapi-go
-**Latest release**: **[v0.8.27](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.27)** (2026-07-18)
+**Latest release**: **[v0.8.27](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.27)** (2026-07-18) — remains latest until M38 release gate
 
 > 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。
 > 文档地图：[`docs/README.md`](../README.md)
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | closed Milestone 37 (v0.8.27) — next residual wave TBD |
+| Active milestone | [Milestone 38 — Enterprise residual SSRF/client harden v0.8.28](https://github.com/TokenDanceLab/metapi-go/milestone/38) |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | M35 review synthesis | `docs/analysis/enterprise-review-m35.md` (#388; M35 closed) |
@@ -39,16 +39,20 @@
 | Enterprise residual **v0.8.25** | ✅ | #382–#384 (PRs #385/#386/#387); tag **v0.8.25** |
 | M35 residual review / follow-ons | ✅ closed | #388 synthesis · #389/#396 endpoint early reject · #390/#395 multi-route regression |
 | Enterprise residual polish **v0.8.26** | ✅ closed | #397–#400 (PRs #401–#404/#406); tag **v0.8.26** |
-| Enterprise residual security polish **v0.8.27** | ✅ | #407–#410 (PRs #411–#414); tag **v0.8.27** |
+| Enterprise residual security polish **v0.8.27** | ✅ closed | #407–#410 (PRs #411–#414); tag **v0.8.27** |
+| Enterprise residual SSRF/client harden **v0.8.28** | 🔄 active | Milestone 38 · board **#416–#418** |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| — | — | Board clean after v0.8.27; next residual only with ACs |
+| [#416](https://github.com/TokenDanceLab/metapi-go/issues/416) | security P0 | SEC-REDIR: share rejectCrossOriginRedirect on probe/harness/defaultUpstreamClient |
+| [#417](https://github.com/TokenDanceLab/metapi-go/issues/417) | security P1 | SEC-MONITOR: clear meta_monitor_auth cookie on admin logout / session clear |
+| [#418](https://github.com/TokenDanceLab/metapi-go/issues/418) | docs | Residual honesty post v0.8.27 (M38 board) |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
 **M35/M36/M37 closed**: do not re-list #388–#390, #397–#400, or #407–#410 as active work (landed on master with v0.8.27).
+**Latest release**: stays **v0.8.27** until M38 release gate; do not claim v0.8.28 until tag.
 
 
 ## Residual releases (pointer only)
@@ -90,7 +94,7 @@ git log --oneline origin/master -10
 
 ## Next Steps
 
-1. Close Milestone 37: #407 opaque monitor session · #408 OldToken constant-time · #409 Claude max_tokens · #410 residual honesty. Latest release **v0.8.27**.
+1. Land M38 board **#416–#418**: SEC-REDIR bare clients CheckRedirect (#416 P0) · SEC-MONITOR logout cookie clear (#417) · residual honesty (#418). Latest release stays **v0.8.27** until release gate.
 2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
 3. Optional later: P0-585 load-proof / site-model breaker; deeper P0-555 media/lag polish; further dialect context_length enforce.
 4. Keep MASTER slim; docs map at `docs/README.md`.


### PR DESCRIPTION
## Summary
- Flip residual inventory for M38 SSRF/client harden board after v0.8.27
- SEC-REDIR residual→active for bare probe/harness/defaultUpstreamClient (#416)
- SEC-MONITOR logout residual active (#417); opaque session remains present-with-residual
- MASTER active milestone M38; active work #416–#418; latest release stays v0.8.27 until release gate
- Sequencing remains v0.8.28+

## Allowed files
- `docs/analysis/residual-next-candidates.md`
- `docs/progress/MASTER.md`

## Test plan
- [x] Docs-only diff (no product code)
- [x] Pre-push vet + `go test ./... -race` green
- [x] MASTER latest remains v0.8.27 (no claim of v0.8.28 tag)
- [x] Residual sequencing points at M38 board #416–#418

Closes #418