### PR TITLE
fix(http): share RejectCrossOriginRedirect on residual bare clients (#416)

### DIFF
--- a/handler/admin/channel_test_harness.go
+++ b/handler/admin/channel_test_harness.go
@@ -490,7 +490,12 @@ func (h *channelTestHandler) doRequest(ctx context.Context, req *http.Request, p
 	if proxyCfg != nil && (proxyCfg.ProxyURL != "" || proxyCfg.InsecureSkipTLS) {
 		return platform.DoWithProxy(ctx, req, proxyCfg)
 	}
-	client := &http.Client{Timeout: 0} // context owns deadline
+	// Context owns the deadline; refuse cross-origin redirects so a public
+	// site URL cannot 302 into metadata/loopback (shared platform policy).
+	client := &http.Client{
+		Timeout:       0,
+		CheckRedirect: platform.RejectCrossOriginRedirect,
+	}
 	return client.Do(req.WithContext(ctx))
 }
 

--- a/handler/admin/channel_test_harness_test.go
+++ b/handler/admin/channel_test_harness_test.go
@@ -335,6 +335,89 @@ func TestChannelTest_TransportError(t *testing.T) {
 	}
 }
 
+func TestChannelTest_RejectsCrossOriginRedirect(t *testing.T) {
+	// SSRF residual (#416): bare harness client must refuse public-origin 302
+	// to a different host and must not return the redirect target body.
+	targetCalled := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetCalled = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ssrf":"payload-from-169"}`))
+	}))
+	t.Cleanup(target.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/latest/meta-data/", http.StatusFound)
+	}))
+	t.Cleanup(source.Close)
+
+	db, _, r := setupChannelTestHarness(t)
+	// Leave transport nil so doRequest uses the real bare http.Client path.
+	_, _, _, channelID := insertHarnessFixturesAtURL(t, db, source.URL)
+
+	resp := doPostJSON(t, r, "/api/admin/test-channel", map[string]any{
+		"channelId": channelID,
+		"mode":      "models",
+		"timeoutMs": 5000,
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", resp.Code, resp.Body.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out["success"] != false {
+		t.Fatalf("expected success=false on cross-origin redirect, got %v", out)
+	}
+	errMsg, _ := out["error"].(string)
+	if !strings.Contains(errMsg, "cross-origin") {
+		t.Fatalf("error = %q, want cross-origin redirect rejection", errMsg)
+	}
+	body, _ := out["truncatedBody"].(string)
+	if strings.Contains(body, "ssrf") || strings.Contains(body, "payload-from-169") {
+		t.Fatalf("redirect target body leaked: %q", body)
+	}
+	if targetCalled {
+		t.Fatal("cross-origin redirect target was called (SSRF)")
+	}
+}
+
+func insertHarnessFixturesAtURL(t *testing.T, db *store.DB, siteURL string) (siteID, accountID, routeID, channelID int64) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	res, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "HarnessRedirectSite", siteURL, "openai", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ = res.LastInsertId()
+
+	apiTok := "sk-harness-api-token-xyz"
+	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, ?, 'active', 0, ?, ?)`, siteID, "harness-user", "session-token", apiTok, now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ = res.LastInsertId()
+
+	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
+		VALUES (?, ?, 'standard', 'weighted', 1, ?, ?)`, "gpt-*", "Harness Redirect Route", now, now)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	routeID, _ = res.LastInsertId()
+
+	res, err = db.Exec(`INSERT INTO route_channels (route_id, account_id, source_model, priority, weight, enabled)
+		VALUES (?, ?, ?, 10, 10, 1)`, routeID, accountID, "gpt-4o-mini")
+	if err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+	channelID, _ = res.LastInsertId()
+	return siteID, accountID, routeID, channelID
+}
+
 type contextDeadlineErr struct{}
 
 func (contextDeadlineErr) Error() string { return "context deadline exceeded" }

--- a/handler/proxy/channel_health_probe.go
+++ b/handler/proxy/channel_health_probe.go
@@ -339,6 +339,11 @@ func (p *ChannelHealthProbeExecutor) doRequest(ctx context.Context, req *http.Re
 	if proxyCfg != nil && (proxyCfg.ProxyURL != "" || proxyCfg.InsecureSkipTLS) {
 		return platform.DoWithProxy(ctx, req, proxyCfg)
 	}
-	client := &http.Client{Timeout: 0} // context owns deadline
+	// Context owns the deadline; refuse cross-origin redirects so a public
+	// site URL cannot 302 into metadata/loopback (shared platform policy).
+	client := &http.Client{
+		Timeout:       0,
+		CheckRedirect: platform.RejectCrossOriginRedirect,
+	}
 	return client.Do(req.WithContext(ctx))
 }

--- a/handler/proxy/channel_health_probe_test.go
+++ b/handler/proxy/channel_health_probe_test.go
@@ -118,6 +118,49 @@ func TestChannelHealthProbeExecutor_Upstream5xxIsFailure(t *testing.T) {
 	}
 }
 
+func TestChannelHealthProbeExecutor_RejectsCrossOriginRedirect(t *testing.T) {
+	// SSRF residual (#416): public origin 302 → other host (e.g. 169.254) must not
+	// be followed by the bare probe client when site proxy is unset.
+	targetCalled := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetCalled = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ssrf":"payload"}`))
+	}))
+	t.Cleanup(target.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/latest/meta-data/", http.StatusFound)
+	}))
+	t.Cleanup(source.Close)
+
+	db := openProbeTestDB(t)
+	channelID := seedProbeChannel(t, db, source.URL, "gpt-probe", "probe-token")
+
+	probe := NewChannelHealthProbeExecutor(&config.Config{})
+	probe.SetDB(db)
+	// Leave transport nil so doRequest uses the real bare http.Client path.
+	out, err := probe.ProbeChannel(context.Background(), scheduler.ProbeTarget{
+		ChannelID: channelID,
+		ModelName: "gpt-probe",
+	})
+	if err != nil {
+		t.Fatalf("ProbeChannel: %v", err)
+	}
+	if out.Status != "failure" {
+		t.Fatalf("status = %q error=%q, want failure on cross-origin redirect", out.Status, out.ErrorText)
+	}
+	if out.HTTPStatus != 0 {
+		t.Fatalf("http status = %d, want 0 (transport/redirect error)", out.HTTPStatus)
+	}
+	if !strings.Contains(out.ErrorText, "cross-origin") {
+		t.Fatalf("error = %q, want cross-origin redirect rejection", out.ErrorText)
+	}
+	if targetCalled {
+		t.Fatal("cross-origin redirect target was called (SSRF)")
+	}
+}
+
 func openProbeTestDB(t *testing.T) *store.DB {
 	t.Helper()
 	db, err := store.Open(store.DialectSQLite, ":memory:", false)

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -47,10 +47,13 @@ const defaultMaxStreamResponseBytes int64 = 128 << 20
 
 // defaultUpstreamClient is used as a safety fallback when the RuntimeExecutor
 // has not been wired (e.g., during tests). It carries a 90s timeout so a hung
-// upstream never leaks a goroutine. Production deployments should always wire
-// the Executor field via SetUpstreamConfig.
+// upstream never leaks a goroutine, and the shared RejectCrossOriginRedirect
+// policy so a public origin cannot 302 into metadata/loopback when Executor is
+// nil. Production deployments should always wire the Executor field via
+// SetUpstreamConfig.
 var defaultUpstreamClient = &http.Client{
-	Timeout: 90 * time.Second,
+	Timeout:       90 * time.Second,
+	CheckRedirect: platform.RejectCrossOriginRedirect,
 }
 
 // SetUpstreamConfig sets the package-level upstream forwarding dependencies.

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -1546,3 +1546,49 @@ func TestParseUsageFromSSEEvents_FakeStreamWithoutUsage(t *testing.T) {
 		t.Fatal("expected warn from incremental path without usage")
 	}
 }
+
+func TestDefaultUpstreamClientRejectsCrossOriginRedirect(t *testing.T) {
+	// SSRF residual (#416): when RuntimeExecutor is nil, defaultUpstreamClient
+	// must refuse public-origin 302 to a different host (e.g. 169.254) and not
+	// return the target body.
+	targetCalled := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetCalled = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ssrf-payload"))
+	}))
+	t.Cleanup(target.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/latest/meta-data/", http.StatusFound)
+	}))
+	t.Cleanup(source.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, source.URL+"/start", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	// Executor nil → sendUpstreamRequest falls back to defaultUpstreamClient.
+	// net/http returns the last redirect Response (Body closed) together with
+	// CheckRedirect's error; treat any non-nil err as rejection and never follow.
+	resp, err := sendUpstreamRequest(&UpstreamConfig{}, req, nil, 0)
+	if err == nil {
+		if resp != nil {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 64))
+			_ = resp.Body.Close()
+			t.Fatalf("cross-origin redirect was allowed: status=%d body=%q", resp.StatusCode, body)
+		}
+		t.Fatal("cross-origin redirect was allowed on defaultUpstreamClient")
+	}
+	if !strings.Contains(err.Error(), "cross-origin") {
+		t.Fatalf("error = %v, want cross-origin redirect rejection", err)
+	}
+	if targetCalled {
+		t.Fatal("cross-origin redirect target was called (SSRF)")
+	}
+	// Even if a 302 response is returned alongside the error, never treat it as success body.
+	if resp != nil {
+		// Body is already closed by net/http on CheckRedirect error.
+		_ = resp.Body.Close()
+	}
+}

--- a/platform/site_proxy.go
+++ b/platform/site_proxy.go
@@ -188,11 +188,22 @@ func newProxyHTTPClient(proxy func(*http.Request) (*url.URL, error), insecureSki
 	return &http.Client{
 		Transport:     transport,
 		Timeout:       30 * time.Second,
-		CheckRedirect: rejectCrossOriginRedirect,
+		CheckRedirect: RejectCrossOriginRedirect,
 	}
 }
 
-func rejectCrossOriginRedirect(req *http.Request, via []*http.Request) error {
+// RejectCrossOriginRedirect is the shared CheckRedirect policy for outbound
+// HTTP clients that talk to operator-configured upstream sites.
+//
+// It refuses:
+//   - more than 5 redirects
+//   - https → non-https scheme downgrades
+//   - any host change (blocks 302 to metadata / loopback / private SSRF targets)
+//
+// Same-origin redirects remain allowed so normal upstream path hops still work.
+// Used by platform.DoWithProxy, proxy.RuntimeExecutor, and residual bare clients
+// (health probe / admin harness / defaultUpstreamClient).
+func RejectCrossOriginRedirect(req *http.Request, via []*http.Request) error {
 	if len(via) >= 5 {
 		return fmt.Errorf("stopped after %d redirects", len(via))
 	}

--- a/platform/site_proxy_test.go
+++ b/platform/site_proxy_test.go
@@ -224,6 +224,33 @@ func TestDoWithProxy_RejectsCrossOriginRedirect(t *testing.T) {
 	}
 }
 
+func TestRejectCrossOriginRedirect_MetadataHost(t *testing.T) {
+	// Same scheme so we exercise the host check (not the https→http downgrade).
+	via, err := http.NewRequest(http.MethodGet, "http://api.example.com/v1/models", nil)
+	if err != nil {
+		t.Fatalf("via: %v", err)
+	}
+	toMeta, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data/", nil)
+	if err != nil {
+		t.Fatalf("toMeta: %v", err)
+	}
+	err = RejectCrossOriginRedirect(toMeta, []*http.Request{via})
+	if err == nil {
+		t.Fatal("expected 169.254 metadata redirect rejection")
+	}
+	if !strings.Contains(err.Error(), "cross-origin") {
+		t.Fatalf("error = %v, want cross-origin", err)
+	}
+
+	sameHost, err := http.NewRequest(http.MethodGet, "http://api.example.com/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatalf("sameHost: %v", err)
+	}
+	if err = RejectCrossOriginRedirect(sameHost, []*http.Request{via}); err != nil {
+		t.Fatalf("same-host redirect should be allowed: %v", err)
+	}
+}
+
 func TestSupportedProxySchemes(t *testing.T) {
 	schemes := []string{"http", "https", "socks", "socks4", "socks4a", "socks5", "socks5h"}
 	for _, s := range schemes {

--- a/proxy/executor.go
+++ b/proxy/executor.go
@@ -10,29 +10,15 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/tokendancelab/metapi-go/platform"
 )
 
-// rejectCrossOriginRedirect mirrors platform.rejectCrossOriginRedirect so the
-// RuntimeExecutor client cannot be tricked into following a 302 to a different
-// host (SSRF amplification to metadata / loopback / private networks).
-//
-// Kept local (not imported from platform) to avoid tightening package cycles;
-// behavior must stay in lockstep with platform/site_proxy.go.
+// rejectCrossOriginRedirect is a package-local alias of the shared SSOT in
+// platform.RejectCrossOriginRedirect so RuntimeExecutor and existing tests keep
+// a short name without diverging policy copies.
 func rejectCrossOriginRedirect(req *http.Request, via []*http.Request) error {
-	if len(via) >= 5 {
-		return fmt.Errorf("stopped after %d redirects", len(via))
-	}
-	if len(via) == 0 {
-		return nil
-	}
-	previous := via[len(via)-1].URL
-	if previous.Scheme == "https" && req.URL.Scheme != "https" {
-		return fmt.Errorf("refusing redirect from https to %s", req.URL.Scheme)
-	}
-	if !strings.EqualFold(previous.Host, req.URL.Host) {
-		return fmt.Errorf("refusing cross-origin redirect from %s to %s", previous.Host, req.URL.Host)
-	}
-	return nil
+	return platform.RejectCrossOriginRedirect(req, via)
 }
 
 // ExecutorDispatchInput is the input for dispatching an HTTP request.


### PR DESCRIPTION
## Summary
- Export `platform.RejectCrossOriginRedirect` as the shared CheckRedirect SSOT (was private `rejectCrossOriginRedirect`).
- Wire it on residual bare clients: channel health probe `doRequest`, admin channel test harness `doRequest`, and `defaultUpstreamClient` (Executor-nil fallback).
- Point `proxy.RuntimeExecutor` at the shared helper so policy no longer lives as a second divergent copy.
- Regression tests: public origin 302 → different host must error and not fetch target body (probe / harness / defaultUpstreamClient / platform policy).

## Test plan
- [x] `go test ./handler/proxy ./handler/admin ./proxy ./platform -count=1 -run 'Redirect|Probe|Harness|Upstream|CrossOrigin|CheckRedirect'`

Closes #416