### PR TITLE
fix(admin): clear meta_monitor_auth cookie on logout (#417)

### DIFF
--- a/handler/admin/monitor.go
+++ b/handler/admin/monitor.go
@@ -24,6 +24,9 @@ func RegisterMonitorRoutes(r chi.Router, db *sqlx.DB, cfg *config.Config) {
 	r.Get("/api/monitor/config", handler.getConfig)
 	r.Put("/api/monitor/config", handler.saveConfig)
 	r.Post("/api/monitor/session", handler.createSession)
+	// DELETE clears the HttpOnly meta_monitor_auth cookie on admin logout.
+	// Frontend JS cannot clear HttpOnly cookies; this is the honest clear path.
+	r.Delete("/api/monitor/session", handler.clearSession)
 
 	// LDOH proxy routes - rate limited at 60 req/min at the router layer when wired.
 	r.HandleFunc("/monitor-proxy/ldoh", handler.ldohProxy)
@@ -145,17 +148,53 @@ func (h *monitorHandler) saveConfig(w http.ResponseWriter, r *http.Request) {
 // must not yield a usable admin Bearer credential for /api/*.
 func (h *monitorHandler) createSession(w http.ResponseWriter, r *http.Request) {
 	session := deriveMonitorSessionToken(h.cfg.AuthToken)
-	cookie := &http.Cookie{
+	http.SetCookie(w, newMonitorAuthCookie(session, monitorSessionMaxAge, isMonitorHTTPS(r)))
+	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+}
+
+// DELETE /api/monitor/session
+// Clears the HttpOnly meta_monitor_auth cookie with Path matching createSession.
+// Admin logout must call this while the Bearer is still valid: after frontend
+// clears localStorage, the opaque cookie would otherwise remain usable for
+// /monitor-proxy/* until Max-Age (AuthToken is unchanged on logout).
+func (h *monitorHandler) clearSession(w http.ResponseWriter, r *http.Request) {
+	clearMonitorAuthCookies(w, r)
+	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+}
+
+// newMonitorAuthCookie builds the shared cookie attributes for mint + clear so
+// Path/HttpOnly/SameSite/Secure stay in lockstep (browsers only clear when the
+// Path matches the cookie that was originally set).
+func newMonitorAuthCookie(value string, maxAge int, secure bool) *http.Cookie {
+	return &http.Cookie{
 		Name:     monitorAuthCookie,
-		Value:    session,
+		Value:    value,
 		Path:     monitorCookiePath,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
-		MaxAge:   monitorSessionMaxAge,
-		Secure:   isMonitorHTTPS(r),
+		MaxAge:   maxAge,
+		Secure:   secure,
 	}
-	http.SetCookie(w, cookie)
-	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+}
+
+// clearMonitorAuthCookies expires meta_monitor_auth for the scoped path used
+// by createSession. Also expires a legacy Path=/ cookie in case an older
+// release minted one before the /monitor-proxy/ scope landed (#407).
+//
+// net/http serializes MaxAge < 0 as Max-Age=0 (immediate expiry).
+func clearMonitorAuthCookies(w http.ResponseWriter, r *http.Request) {
+	secure := isMonitorHTTPS(r)
+	http.SetCookie(w, newMonitorAuthCookie("", -1, secure))
+	// Legacy Path=/ residual from pre-#407 createSession.
+	http.SetCookie(w, &http.Cookie{
+		Name:     monitorAuthCookie,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+		Secure:   secure,
+	})
 }
 
 // GET/POST/ALL /monitor-proxy/ldoh and /monitor-proxy/ldoh/*

--- a/handler/admin/monitor_session_test.go
+++ b/handler/admin/monitor_session_test.go
@@ -167,3 +167,104 @@ func TestMonitorAuth_AuthTokenRotationInvalidatesCookie(t *testing.T) {
 		t.Fatalf("post-rotation status = %d body=%s, want 401", recDenied.Code, recDenied.Body.String())
 	}
 }
+
+func TestMonitorSession_ClearCookieOnLogout(t *testing.T) {
+	_, r, _ := setupOpsAdminStubsTest(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/monitor/session", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != true {
+		t.Fatalf("success = %v, want true", body["success"])
+	}
+
+	cookies := rec.Result().Cookies()
+	var scoped *http.Cookie
+	var legacyRoot *http.Cookie
+	for _, c := range cookies {
+		if c.Name != monitorAuthCookie {
+			continue
+		}
+		switch c.Path {
+		case monitorCookiePath:
+			scoped = c
+		case "/":
+			legacyRoot = c
+		}
+	}
+	if scoped == nil {
+		t.Fatalf("missing clear cookie for Path=%q; cookies=%v", monitorCookiePath, cookies)
+	}
+	if scoped.MaxAge >= 0 {
+		t.Fatalf("scoped clear MaxAge = %d, want < 0 (Max-Age=0 on wire)", scoped.MaxAge)
+	}
+	if scoped.Value != "" {
+		t.Fatalf("scoped clear Value = %q, want empty", scoped.Value)
+	}
+	if !scoped.HttpOnly {
+		t.Fatal("scoped clear cookie must remain HttpOnly")
+	}
+	if scoped.SameSite != http.SameSiteLaxMode {
+		t.Fatalf("scoped clear SameSite = %v, want Lax", scoped.SameSite)
+	}
+	// Legacy Path=/ residual clear keeps older pre-#407 cookies from surviving logout.
+	if legacyRoot == nil {
+		t.Fatal("missing legacy Path=/ clear cookie")
+	}
+	if legacyRoot.MaxAge >= 0 {
+		t.Fatalf("legacy clear MaxAge = %d, want < 0", legacyRoot.MaxAge)
+	}
+}
+
+func TestMonitorSession_ClearCookieSecureWhenHTTPS(t *testing.T) {
+	_, r, _ := setupOpsAdminStubsTest(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/monitor/session", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	var scoped *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == monitorAuthCookie && c.Path == monitorCookiePath {
+			scoped = c
+			break
+		}
+	}
+	if scoped == nil {
+		t.Fatal("missing scoped clear cookie")
+	}
+	if !scoped.Secure {
+		t.Fatal("clear cookie Secure must match createSession when X-Forwarded-Proto=https")
+	}
+}
+
+func TestClearMonitorAuthCookies_HelperContract(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/monitor/session", nil)
+	clearMonitorAuthCookies(rec, req)
+
+	headers := rec.Header().Values("Set-Cookie")
+	if len(headers) < 2 {
+		t.Fatalf("Set-Cookie count = %d, want >= 2 (scoped + legacy)", len(headers))
+	}
+	joined := strings.Join(headers, " | ")
+	if !strings.Contains(joined, monitorAuthCookie+"=") {
+		t.Fatalf("Set-Cookie missing %s: %s", monitorAuthCookie, joined)
+	}
+	if !strings.Contains(joined, "Path="+monitorCookiePath) && !strings.Contains(joined, "Path=/monitor-proxy/") {
+		t.Fatalf("Set-Cookie missing scoped Path: %s", joined)
+	}
+	// net/http renders MaxAge < 0 as Max-Age=0.
+	if !strings.Contains(joined, "Max-Age=0") {
+		t.Fatalf("Set-Cookie missing Max-Age=0: %s", joined)
+	}
+}

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -813,8 +813,16 @@ function AppShell() {
                   {t('个人信息')}
                 </button>
                 <button onClick={() => {
-                  clearAuthSession(localStorage);
-                  setAuthed(false);
+                  // Clear HttpOnly monitor cookie while Bearer is still valid,
+                  // then drop localStorage auth. Fire-and-forget is fine: the
+                  // browser applies Set-Cookie from the DELETE response even
+                  // after setAuthed(false) re-renders the login screen.
+                  void api.clearMonitorSession()
+                    .catch(() => {})
+                    .finally(() => {
+                      clearAuthSession(localStorage);
+                      setAuthed(false);
+                    });
                 }} className="user-dropdown-item danger">
                   <svg width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" /></svg>
                   {t('退出登录')}

--- a/web/api.ts
+++ b/web/api.ts
@@ -1445,6 +1445,10 @@ export const api = {
       body: JSON.stringify(data),
     }),
   initMonitorSession: () => request("/api/monitor/session", { method: "POST" }),
+  // Clears HttpOnly meta_monitor_auth (Path=/monitor-proxy/). Call while
+  // Bearer auth is still valid — before clearAuthSession wipes localStorage.
+  clearMonitorSession: () =>
+    request("/api/monitor/session", { method: "DELETE" }),
 
   // Models marketplace
   getModelsMarketplace: (options?: {

--- a/web/authSession.test.ts
+++ b/web/authSession.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   AUTH_SESSION_DURATION_MS,
   clearAuthSession,
+  clearMonitorAuthCookie,
   getAuthToken,
   hasValidAuthSession,
+  MONITOR_AUTH_COOKIE_NAME,
+  MONITOR_AUTH_COOKIE_PATH,
   persistAuthSession,
 } from './authSession.js';
 
@@ -46,5 +49,28 @@ describe('authSession', () => {
     clearAuthSession(storage);
 
     expect(getAuthToken(storage, 2_000)).toBeNull();
+  });
+
+  it('clearMonitorAuthCookie expires meta_monitor_auth with Path=/monitor-proxy/', () => {
+    const written: string[] = [];
+    const doc = {
+      set cookie(value: string) {
+        written.push(value);
+      },
+      get cookie() {
+        return written.join('; ');
+      },
+    };
+
+    clearMonitorAuthCookie(doc);
+
+    expect(written.length).toBe(2);
+    expect(written[0]).toContain(`${MONITOR_AUTH_COOKIE_NAME}=`);
+    expect(written[0]).toContain(`Path=${MONITOR_AUTH_COOKIE_PATH}`);
+    expect(written[0]).toContain('Max-Age=0');
+    expect(written[1]).toContain('Path=/');
+    expect(written[1]).toContain('Max-Age=0');
+    // Contract with handler/admin/monitor.go after #407.
+    expect(MONITOR_AUTH_COOKIE_PATH).toBe('/monitor-proxy/');
   });
 });

--- a/web/authSession.ts
+++ b/web/authSession.ts
@@ -2,10 +2,26 @@ const AUTH_TOKEN_STORAGE_KEY = 'auth_token';
 const AUTH_TOKEN_EXPIRES_AT_STORAGE_KEY = 'auth_token_expires_at';
 export const AUTH_SESSION_DURATION_MS = 12 * 60 * 60 * 1000;
 
+/** Must match handler/admin/monitor.go monitorAuthCookie. */
+export const MONITOR_AUTH_COOKIE_NAME = 'meta_monitor_auth';
+
+/**
+ * Must match handler/admin/monitor.go monitorCookiePath (#407).
+ * document.cookie can only clear non-HttpOnly cookies; HttpOnly is cleared
+ * via DELETE /api/monitor/session. This helper is a best-effort residual
+ * clear for any non-HttpOnly twin and documents the Path contract in tests.
+ */
+export const MONITOR_AUTH_COOKIE_PATH = '/monitor-proxy/';
+
 type StorageLike = {
   getItem: (key: string) => string | null;
   setItem: (key: string, value: string) => void;
   removeItem: (key: string) => void;
+};
+
+type CookieWriter = {
+  /** Assign to document.cookie (or a test double). */
+  cookie?: string;
 };
 
 function resolveStorage(storage?: StorageLike | null): StorageLike | null {
@@ -14,11 +30,33 @@ function resolveStorage(storage?: StorageLike | null): StorageLike | null {
   return null;
 }
 
+/**
+ * Best-effort document.cookie clear for meta_monitor_auth.
+ * Path must match createSession (/monitor-proxy/) or the browser ignores it.
+ * Also clears legacy Path=/ in case an older mint used it.
+ * Prefer DELETE /api/monitor/session for the HttpOnly cookie.
+ */
+export function clearMonitorAuthCookie(
+  doc: CookieWriter | null | undefined = typeof document !== 'undefined' ? document : null,
+): void {
+  if (!doc) return;
+  try {
+    const expire = 'Max-Age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+    doc.cookie = `${MONITOR_AUTH_COOKIE_NAME}=; Path=${MONITOR_AUTH_COOKIE_PATH}; ${expire}`;
+    // Legacy Path=/ residual from pre-#407.
+    doc.cookie = `${MONITOR_AUTH_COOKIE_NAME}=; Path=/; ${expire}`;
+  } catch {
+    // document may be restricted (sandboxed); ignore.
+  }
+}
+
 export function clearAuthSession(storage?: StorageLike | null): void {
   const target = resolveStorage(storage);
   if (!target) return;
   target.removeItem(AUTH_TOKEN_STORAGE_KEY);
   target.removeItem(AUTH_TOKEN_EXPIRES_AT_STORAGE_KEY);
+  // Residual non-HttpOnly clear; HttpOnly still needs backend DELETE.
+  clearMonitorAuthCookie();
 }
 
 export function persistAuthSession(

--- a/web/pages/Settings.tsx
+++ b/web/pages/Settings.tsx
@@ -2578,8 +2578,14 @@ export default function Settings() {
             </button>
             <button
               onClick={() => {
-                clearAuthSession(localStorage);
-                window.location.reload();
+                // Await DELETE so Set-Cookie Max-Age=0 is applied before reload
+                // aborts in-flight requests.
+                void api.clearMonitorSession()
+                  .catch(() => {})
+                  .finally(() => {
+                    clearAuthSession(localStorage);
+                    window.location.reload();
+                  });
               }}
               className="btn btn-danger"
             >


### PR DESCRIPTION
## Summary
- Add `DELETE /api/monitor/session` that expires `meta_monitor_auth` with `Path=/monitor-proxy/` and `Max-Age=0` (HttpOnly cannot be cleared from JS).
- Wire admin logout in `App.tsx` / `Settings.tsx` to call clear **before** wiping localStorage Bearer auth.
- Best-effort `clearMonitorAuthCookie` helper documents Path contract; also expires legacy `Path=/` residual from pre-#407.

Closes #417

## Test plan
- [x] `go test ./handler/admin -count=1 -run 'Monitor|Logout|Cookie|Session'`
- [x] `cd web && npm test -- --run authSession` (4 passed)
- [ ] Manual: open Monitors (mints cookie) → logout → DevTools Application cookies shows `meta_monitor_auth` gone / Max-Age=0 for Path=/monitor-proxy/