### PR TITLE
docs(release): v0.8.28 SEC-REDIR bare clients + monitor logout residual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.28] — 2026-07-18
+
+### Security
+- Share `RejectCrossOriginRedirect` on residual bare clients: channel health probe, channel test harness, and `defaultUpstreamClient` (no longer follow public-origin 302 → private/metadata) (#416 / #420)
+- Admin logout / session clear sets `Max-Age=0` for `meta_monitor_auth` with matching `Path=/monitor-proxy/` (#417 / #421)
+
+### Fixed
+- Residual bare HTTP clients no longer inherit Go default redirect policy when site proxy is absent (#416 / #420)
+
+### Docs / Honesty
+- Residual inventory + MASTER for Milestone 38 post v0.8.27; SEC-REDIR bare clients + SEC-MONITOR logout residual shipped · board #416–#418 closed (#418 / #419)
+
 ## [v0.8.27] — 2026-07-18
 
 ### Security

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,12 +1,12 @@
-# Residual next candidates (post v0.8.27 / M38)
+# Residual next candidates (post v0.8.28)
 
 **Date**: 2026-07-18  
 **Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual; post-M35 honesty [#397](https://github.com/TokenDanceLab/metapi-go/issues/397); post-v0.8.26 honesty [#410](https://github.com/TokenDanceLab/metapi-go/issues/410); post-v0.8.27 honesty [#418](https://github.com/TokenDanceLab/metapi-go/issues/418)  
-**Context**: **v0.8.27 shipped** (#407 opaque monitor session, #408 OldToken constant-time, #409 CTX-520 Claude max_tokens reject, #410 residual honesty; PRs #411–#414). Board was clean after M37. **Milestone 38 opened** with SSRF/client harden board **#416–#418**. Prior **v0.8.26**: #397–#400 (PRs #401–#404/#406). Prior **v0.8.25**: #382–#384. M35 closed: #388 review synthesis, **#389/#396** endpoint early reject, **#390/#395** multi-route list regression. Original P0 #405/#565/#515 already-correct in code.  
+**Context**: **v0.8.28 shipped** (#416 SEC-REDIR bare clients share `RejectCrossOriginRedirect`, #417 SEC-MONITOR logout cookie clear, #418 residual honesty; PRs #419–#421). Board clean after M38. Prior **v0.8.27**: #407–#410 (PRs #411–#414). Prior **v0.8.26**: #397–#400 (PRs #401–#404/#406). Prior **v0.8.25**: #382–#384. M35 closed: #388 review synthesis, **#389/#396** endpoint early reject, **#390/#395** multi-route list regression. Original P0 #405/#565/#515 already-correct in code.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)  
 **M35 review synthesis**: [`enterprise-review-m35.md`](./enterprise-review-m35.md) (#388) — ranked P0/P1/P2 backlog after multi-lane residual review (historical; #389/#390 done)  
-**Active wave**: Milestone 38 / **v0.8.28** board **#416–#418** (SSRF/client harden; latest release remains **v0.8.27** until release gate)
+**Active wave**: board clean after **v0.8.28** / Milestone 38; next residual only with ACs (**v0.8.29+**)
 
 ## Purpose
 
@@ -39,11 +39,11 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | REBUILD-588 | Pattern/group rebuild | present | `service/route_rebuild.go` `RebuildRoutesBestEffort` | Done (matrix #281) | — |
 | PRICE-496 | Claude cache_ratio defaults | present | `routing/pricing_cost.go` Claude 0.1 / 1.25 | Done (matrix #281) | — |
 | CTX-520 | Route contextLength admin + models wire + max_tokens reject | **present-with-residual** (OpenAI #320/#327/#399; Claude #409) | Admin CRUD (#320) + OpenAI `/v1/models` prefers positive route `context_length` (max per exposed id) (#327) + proxy rejects OpenAI chat/completions (and legacy completions) `max_tokens` above positive selected-route `context_length` with honest 400 (#399/#404) + Claude `/v1/messages` same reject when positive context_length (#409/#412). Residual: further dialects only with ACs; null/non-positive context_length still skips enforce; no silent clamp | Further dialect polish only with ACs | OpenAI + Claude enforce present; other dialects residual |
-| SEC-MONITOR | Monitor session cookie embeds live AUTH_TOKEN | **present-with-residual** (opaque session #407/#414; logout residual **active** #417) | Opaque HMAC-SHA256 monitor session; `ensureMonitorAuth` constant-time compare; cookie scoped `Path=/monitor-proxy/` so capture cannot become full admin bearer. **Active residual:** admin logout / session clear may not set `Max-Age=0` for `meta_monitor_auth` with matching Path → M38 **#417** | M38 #417 logout cookie clear; rotate/invalidate on auth_token change only with product AC | Logout residual active; session token present |
+| SEC-MONITOR | Monitor session cookie embeds live AUTH_TOKEN | **present** (opaque session #407/#414; logout clear #417/#421) | Opaque HMAC-SHA256 monitor session; `ensureMonitorAuth` constant-time compare; cookie scoped `Path=/monitor-proxy/` so capture cannot become full admin bearer. Admin logout / session clear sets `Max-Age=0` for `meta_monitor_auth` with matching Path (#417/#421). Residual: rotate/invalidate on auth_token change only with product AC | Done for opaque session + logout clear | Residual rotate-on-token-change only with AC |
 | SEC-AUTH-TIMING | Admin token change OldToken compare | **present** (#408/#411) | `handler/admin/auth_settings.go` uses `subtle.ConstantTimeCompare` on equal-length normalized bytes; mismatched lengths rejected without leaking timing (parity with AdminAuth middleware) | Done for token-change path | Residual other non-constant compares only if product AC |
 | SEC-KEY | Admin downstream-keys plaintext redaction | **present** (#355/#361) | `redactDownstreamKeySecret` on list/summary/overview; `key` omitted, `keyMasked` only | Done for admin list surface | Residual: other admin dumps if any |
 | SEC-HDR | custom_headers deny-list | **present** (#356/#364) | Shared `platform.ApplyCustomHeaders` / deny-list; Bearer after custom on upstream path | Done | Residual novel header names only |
-| SEC-REDIR | RuntimeExecutor CheckRedirect SSRF | **present-with-residual** (RuntimeExecutor #357/#360; bare clients residual **active** #416) | `rejectCrossOriginRedirect` on RuntimeExecutor client + platform DoWithProxy. **Active residual after #357:** bare probe/harness/default clients still use Go default redirect policy — `channel_health_probe.go` / `channel_test_harness.go` bare `&http.Client{}` when no site proxy, and `defaultUpstreamClient` (90s, no CheckRedirect) → M38 **#416** share rejectCrossOriginRedirect (or stronger) + regression tests public origin 302 → 169.254/loopback | **M38 P0 #416** — share CheckRedirect on probe/harness/defaultUpstreamClient | **P0** bare-client redirect SSRF residual |
+| SEC-REDIR | RuntimeExecutor CheckRedirect SSRF | **present** (RuntimeExecutor #357/#360; bare clients #416/#420) | `rejectCrossOriginRedirect` / shared `RejectCrossOriginRedirect` on RuntimeExecutor client + platform DoWithProxy **and** residual bare clients: `channel_health_probe.go`, `channel_test_harness.go`, `defaultUpstreamClient` (#416/#420). Regression: public origin 302 → 169.254/loopback must error and not fetch target body | Done for RuntimeExecutor + bare probe/harness/defaultUpstreamClient | Residual novel client constructors only if product AC |
 | REL-SOFT | Weighted soft-filter empty → next priority | **present** (#358/#362) | Weighted path skips soft-empty priority layer and tries next; failover-isolation note | Done for weighted soft-filter | P0-585 empty-filter fallback residual separate |
 | SEC-ADMIN | Remaining admin secret surfaces | **present-with-residual** (#367/#372) | Account list redacts accessToken/apiToken + passwordCipher strip; token list drops join secrets. Residual: create/update/rebind may still echo once; intentional credential export | Done for list/overview | Residual intentional export / create-once |
 | REL-SOFT-RR | RR/stable_first soft-filter priority demotion | **present** (#368/#370) | RR/stable_first/least_* share priority-layer strict soft-filter demotion with weighted | Done | Global full-set fallback when all layers soft-empty (P0-585 residual) |
@@ -54,14 +54,11 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | SEC-ENDPOINT | Site API endpoint admin normalize + service validator | **present** (#389/#396 + #398/#403) | Admin `normalizeAPIEndpointsInput` rejects forbidden targets with clear 400 before upsert; `IsValidAPIEndpointURL` itself rejects metadata/link-local (parity with `IsValidHTTPURL` / `IsForbiddenSiteTargetURL`) so any caller is safe by default | Done for admin early-reject + base validator parity | RFC1918/localhost intentionally allowed |
 | M35-REVIEW | Multi-lane residual review synthesis | **present** (docs #388) | `docs/analysis/enterprise-review-m35.md` ranked P0/P1/P2; #389/#390 follow-ons closed on master | Historical M35 pointer | Synthesis only |
 
-## Recommended sequencing (v0.8.28+)
+## Recommended sequencing (v0.8.29+)
 
-1. **Shipped in v0.8.27**: #407–#410 (PRs #411–#414) — opaque monitor session · OldToken constant-time · CTX-520 Claude max_tokens reject · residual honesty. Prior v0.8.26: #397–#400. M35/M36/M37 closed.
-2. **Active M38 board (#416–#418)** — Enterprise residual SSRF/client harden **v0.8.28** (latest tag stays **v0.8.27** until release gate):
-   1. **#416 SEC-REDIR bare clients (P0)**: share `rejectCrossOriginRedirect` (or equivalent) on probe / harness / `defaultUpstreamClient`; regression tests for public-origin 302 → 169.254/loopback.
-   2. **#417 SEC-MONITOR logout residual (P1)**: clear `meta_monitor_auth` with matching `Path=/monitor-proxy/` on admin logout / session clear (`Max-Age=0`).
-   3. **#418 docs**: this residual honesty pass + MASTER M38 pointer (no product code).
-3. **SEC-AUTH-TIMING** fully **present**. **SEC-REDIR** stays **present-with-residual** until #416 lands (RuntimeExecutor shipped; bare clients active). **SEC-MONITOR** stays **present-with-residual** until #417 lands (opaque session shipped; logout cookie clear active). **CTX-520** stays **present-with-residual** (OpenAI + Claude max_tokens reject shipped; further dialects / null-context residual). **P0-555** stays **present-with-residual** (warn shipped; provider-ignore / media / lag / orphan join residual).
+1. **Shipped in v0.8.28**: #416–#418 (PRs #419–#421) — SEC-REDIR bare clients share `RejectCrossOriginRedirect` · SEC-MONITOR logout cookie clear · residual honesty. Prior v0.8.27: #407–#410. Prior v0.8.26: #397–#400. M35–M38 closed.
+2. **Board clean after M38** — next residual wave only with product ACs (**v0.8.29+**). Do not invent a board without Issue ACs.
+3. **SEC-REDIR** fully **present** (RuntimeExecutor + bare probe/harness/defaultUpstreamClient). **SEC-MONITOR** fully **present** for opaque session + logout clear (rotate/invalidate on auth_token change only with product AC). **SEC-AUTH-TIMING** fully **present**. **CTX-520** stays **present-with-residual** (OpenAI + Claude max_tokens reject shipped; further dialects / null-context residual). **P0-555** stays **present-with-residual** (warn shipped; provider-ignore / media / lag / orphan join residual).
 4. **P0-585** residual notes unchanged until load-proof / breaker ACs land.
 5. **Optional product later**: P0-585 load-proof / site-model breaker; deeper billing polish; further dialect context_length enforce (dedicated ACs only).
 6. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
@@ -77,16 +74,16 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Claiming all-dialect proxy max-token enforcement from `contextLength` without a dedicated product AC (OpenAI chat/completions after #399; Claude `/v1/messages` after #409; further dialects need ACs).
 - Returning full downstream API keys on admin list/summary/overview after #355.
 - Allowing custom_headers to override Authorization/Host/hop-by-hop after #356.
-- Following cross-origin/private RuntimeExecutor redirects after #357 (bare probe/harness/defaultUpstreamClient residual via #416).
-- Embedding live `AUTH_TOKEN` in monitor cookies after #407 (logout cookie clear residual via #417).
+- Following cross-origin/private RuntimeExecutor or bare probe/harness/defaultUpstreamClient redirects after #357/#416.
+- Embedding live `AUTH_TOKEN` in monitor cookies after #407; leaving `meta_monitor_auth` set after admin logout after #417.
 - Non-constant-time compares on admin token-change paths after #408.
 
 ## Links
 
-- Release: [v0.8.27](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.27) · prior [v0.8.26](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.26) · next residual board **v0.8.28+** (no tag until release gate)
-- Milestone: [Enterprise residual SSRF/client harden v0.8.28](https://github.com/TokenDanceLab/metapi-go/milestone/38) · board **#416–#418**
+- Release: [v0.8.28](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.28) · prior [v0.8.27](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.27) · next residual board **v0.8.29+** (no tag until release gate)
+- Milestone: [Enterprise residual SSRF/client harden v0.8.28](https://github.com/TokenDanceLab/metapi-go/milestone/38) · board **#416–#418** closed
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
 - M35 review synthesis: `docs/analysis/enterprise-review-m35.md` (#388)
 - MASTER: `docs/progress/MASTER.md`
-- Related issues: #416, #417, #418, #407, #408, #409, #410, #411, #412, #413, #414, #397, #398, #399, #400, #401, #402, #403, #404, #406, #382, #383, #384, #375, #376, #377, #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346, #350, #351, #355, #356, #357, #358, #359, #366, #367, #368, #388, #389, #390, #391, #395, #396
+- Related issues: #416, #417, #418, #419, #420, #421, #407, #408, #409, #410, #411, #412, #413, #414, #397, #398, #399, #400, #401, #402, #403, #404, #406, #382, #383, #384, #375, #376, #377, #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346, #350, #351, #355, #356, #357, #358, #359, #366, #367, #368, #388, #389, #390, #391, #395, #396

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -3,7 +3,7 @@
 **Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery
 **Mode**: GitHub Issues + Milestones (SDD)
 **Repo**: https://github.com/TokenDanceLab/metapi-go
-**Latest release**: **[v0.8.27](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.27)** (2026-07-18) — remains latest until M38 release gate
+**Latest release**: **[v0.8.28](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.28)** (2026-07-18)
 
 > 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。
 > 文档地图：[`docs/README.md`](../README.md)
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | [Milestone 38 — Enterprise residual SSRF/client harden v0.8.28](https://github.com/TokenDanceLab/metapi-go/milestone/38) |
+| Active milestone | closed Milestone 38 (v0.8.28) — next residual wave TBD |
 | Program map | `docs/plan/enterprise-program.md` |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | M35 review synthesis | `docs/analysis/enterprise-review-m35.md` (#388; M35 closed) |
@@ -40,25 +40,24 @@
 | M35 residual review / follow-ons | ✅ closed | #388 synthesis · #389/#396 endpoint early reject · #390/#395 multi-route regression |
 | Enterprise residual polish **v0.8.26** | ✅ closed | #397–#400 (PRs #401–#404/#406); tag **v0.8.26** |
 | Enterprise residual security polish **v0.8.27** | ✅ closed | #407–#410 (PRs #411–#414); tag **v0.8.27** |
-| Enterprise residual SSRF/client harden **v0.8.28** | 🔄 active | Milestone 38 · board **#416–#418** |
+| Enterprise residual SSRF/client harden **v0.8.28** | ✅ closed | #416–#418 (PRs #419–#421); tag **v0.8.28** |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| [#416](https://github.com/TokenDanceLab/metapi-go/issues/416) | security P0 | SEC-REDIR: share rejectCrossOriginRedirect on probe/harness/defaultUpstreamClient |
-| [#417](https://github.com/TokenDanceLab/metapi-go/issues/417) | security P1 | SEC-MONITOR: clear meta_monitor_auth cookie on admin logout / session clear |
-| [#418](https://github.com/TokenDanceLab/metapi-go/issues/418) | docs | Residual honesty post v0.8.27 (M38 board) |
+| — | — | Board clean after v0.8.28; next residual only with ACs |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
-**M35/M36/M37 closed**: do not re-list #388–#390, #397–#400, or #407–#410 as active work (landed on master with v0.8.27).
-**Latest release**: stays **v0.8.27** until M38 release gate; do not claim v0.8.28 until tag.
+**M35–M38 closed**: do not re-list #388–#390, #397–#400, #407–#410, or #416–#418 as active work (landed on master with v0.8.28).
+**Latest release**: **v0.8.28** after M38 release gate (docs gate only; do not claim next residual until new board + ACs).
 
 
 ## Residual releases (pointer only)
 
 | Tag | Milestone | Highlights |
 |:----|:----------|:-----------|
+| [v0.8.28](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.28) | 38 | SEC-REDIR bare clients · SEC-MONITOR logout clear · residual honesty |
 | [v0.8.27](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.27) | 37 | opaque monitor session · OldToken constant-time · Claude max_tokens vs context_length · residual honesty |
 | [v0.8.26](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.26) | 36 | IsValidAPIEndpointURL metadata parity · max_tokens vs context_length reject · stream missing-usage warn · residual honesty |
 | [v0.8.25](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.25) | 34 | IsValidHTTPURL metadata harden · routes N+1 batch · residual honesty |
@@ -88,13 +87,13 @@
 ```bash
 gh issue list --state open --limit 20
 gh pr list --state open
-gh release view v0.8.27
+gh release view v0.8.28
 git log --oneline origin/master -10
 ```
 
 ## Next Steps
 
-1. Land M38 board **#416–#418**: SEC-REDIR bare clients CheckRedirect (#416 P0) · SEC-MONITOR logout cookie clear (#417) · residual honesty (#418). Latest release stays **v0.8.27** until release gate.
+1. Close Milestone 38: #416 SEC-REDIR bare clients · #417 SEC-MONITOR logout cookie clear · #418 residual honesty. Latest release **v0.8.28**.
 2. Product Milestones only with ACs: full Responses WS Codex; Redis sticky Option B; update-center registry.
 3. Optional later: P0-585 load-proof / site-model breaker; deeper P0-555 media/lag polish; further dialect context_length enforce.
 4. Keep MASTER slim; docs map at `docs/README.md`.


### PR DESCRIPTION
## Summary
- Docs-only release gate for **v0.8.28** after M38 product landings on master (`c4fedfa`+): #416/#420 SEC-REDIR bare clients, #417/#421 SEC-MONITOR logout clear, #418/#419 residual honesty.
- `CHANGELOG.md`: `## [v0.8.28]` Security / Fixed / Docs for #416–#418.
- `docs/progress/MASTER.md`: latest **v0.8.28**, Milestone 38 closed, active board clean, residual releases row.
- `docs/analysis/residual-next-candidates.md`: post v0.8.28; **SEC-REDIR fully present** (RuntimeExecutor + bare probe/harness/defaultUpstreamClient); **SEC-MONITOR** logout residual closed; sequencing **v0.8.29+**.

## Shipped on master (verified)
- #418 residual honesty M38 (PR #419)
- #416 shared RejectCrossOriginRedirect on probe/harness/defaultUpstreamClient (PR #420)
- #417 clear meta_monitor_auth on logout (PR #421)
- tip ~c4fedfa or later

## Allowed paths
- CHANGELOG.md
- docs/progress/MASTER.md
- docs/analysis/residual-next-candidates.md

## Not in this PR
- No product code
- **Do not tag** here (release tag is a separate operator step)

## Test plan
- [ ] Diff limited to the three allowed docs files
- [ ] MASTER latest points at v0.8.28; M38 closed; active work empty
- [ ] residual-next-candidates marks SEC-REDIR/SEC-MONITOR present; sequencing is v0.8.29+
- [ ] CHANGELOG has v0.8.28 Security/Fixed/Docs entries for #416–#418