### PR TITLE
fix(routing): parse CooldownUntil for eligibility (#424)

### DIFF
--- a/routing/cooldown.go
+++ b/routing/cooldown.go
@@ -179,12 +179,29 @@ func CompareNullableTimeDesc(left, right *string) int {
 	return CompareNullableTimeAsc(right, left)
 }
 
-// IsOAuthRouteUnitMemberCoolingDown checks if a route unit member is in cooldown.
-func IsOAuthRouteUnitMemberCoolingDown(cooldownUntil *string, nowISO string) bool {
+// IsCooldownActive reports whether cooldownUntil is still in the future relative to nowISO.
+// Both timestamps are parsed to milliseconds before comparison so millis-bearing writer
+// formats (timeMsToISO) cannot lose to second-precision RFC3339 nowISO via lexical order.
+// Example bug: "…T15:04:05.500Z" > "…T15:04:05Z" is false as strings ('.' < 'Z') but true by time.
+func IsCooldownActive(cooldownUntil *string, nowISO string) bool {
 	if cooldownUntil == nil || *cooldownUntil == "" {
 		return false
 	}
-	return *cooldownUntil > nowISO
+	untilMs := ParseISOTimeMs(cooldownUntil)
+	if untilMs == nil {
+		return false
+	}
+	now := nowISO
+	nowMs := ParseISOTimeMs(&now)
+	if nowMs == nil {
+		return false
+	}
+	return *untilMs > *nowMs
+}
+
+// IsOAuthRouteUnitMemberCoolingDown checks if a route unit member is in cooldown.
+func IsOAuthRouteUnitMemberCoolingDown(cooldownUntil *string, nowISO string) bool {
+	return IsCooldownActive(cooldownUntil, nowISO)
 }
 
 // ClampNumber clamps a float64 to [lo, hi].

--- a/routing/cooldown_test.go
+++ b/routing/cooldown_test.go
@@ -355,6 +355,38 @@ func TestIsOAuthRouteUnitMemberCoolingDown(t *testing.T) {
 	}
 }
 
+// Regression #424: writers emit millis via timeMsToISO; readers used RFC3339 without millis.
+// Lexical compare of "…T15:04:05.500Z" vs "…T15:04:05Z" treats still-cooling channels as eligible.
+func TestIsCooldownActive_MillisVsSecondPrecision(t *testing.T) {
+	now := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	nowISO := now.UTC().Format(time.RFC3339) // no fractional seconds
+	cooldownUntil := timeMsToISO(now.UnixMilli() + 500) // always-present millis
+
+	// Document the lexical trap the parse path must avoid.
+	if cooldownUntil > nowISO {
+		t.Fatalf("precondition failed: expected lexical cool>now to be false; cool=%q now=%q", cooldownUntil, nowISO)
+	}
+
+	if !IsCooldownActive(&cooldownUntil, nowISO) {
+		t.Fatalf("cooldownUntil=now+500ms must still be active; cool=%q now=%q", cooldownUntil, nowISO)
+	}
+	if !IsOAuthRouteUnitMemberCoolingDown(&cooldownUntil, nowISO) {
+		t.Fatalf("OAuth member cool path must treat now+500ms as cooling; cool=%q now=%q", cooldownUntil, nowISO)
+	}
+
+	// Expired (past) millis cooldown must be inactive against second-precision now.
+	pastCool := timeMsToISO(now.UnixMilli() - 500)
+	if IsCooldownActive(&pastCool, nowISO) {
+		t.Fatalf("past cooldown must be inactive; cool=%q now=%q", pastCool, nowISO)
+	}
+
+	// Equal second boundary (no remaining cool window) is not active.
+	exact := timeMsToISO(now.UnixMilli())
+	if IsCooldownActive(&exact, nowISO) {
+		t.Fatalf("cooldownUntil==now must not be active; cool=%q now=%q", exact, nowISO)
+	}
+}
+
 // =============================================================================
 // ParseISOTimeMs tests
 // =============================================================================

--- a/routing/router.go
+++ b/routing/router.go
@@ -438,7 +438,8 @@ func getCandidateEligibilityReasonsExplain(
 			break
 		}
 	}
-	if candidate.Channel.CooldownUntil != nil && *candidate.Channel.CooldownUntil > nowISO {
+	// Cooldown — parse timestamps (millis-aware); do not lex-compare ISO strings.
+	if IsCooldownActive(candidate.Channel.CooldownUntil, nowISO) {
 		reasons = append(reasons, "冷却中")
 	}
 	return reasons

--- a/routing/selector.go
+++ b/routing/selector.go
@@ -735,8 +735,8 @@ func (s *ChannelSelector) getCandidateEligibilityReasons(
 		reasons = append(reasons, "令牌不可用")
 	}
 
-	// Cooldown
-	if candidate.Channel.CooldownUntil != nil && *candidate.Channel.CooldownUntil > nowISO {
+	// Cooldown — parse timestamps (millis-aware); do not lex-compare ISO strings.
+	if IsCooldownActive(candidate.Channel.CooldownUntil, nowISO) {
 		reasons = append(reasons, "冷却中")
 	}
 


### PR DESCRIPTION
## Summary
- Writers emit `CooldownUntil` with always-present millis (`timeMsToISO`); eligibility compared with second-precision RFC3339 `nowISO` via lexical `>`.
- Lex order can treat still-cooling channels as eligible within the same wall second (`…T15:04:05.500Z` is not `>` `…T15:04:05Z`).
- Add `IsCooldownActive` (parse both timestamps to ms) and use it in `getCandidateEligibilityReasons`, explain path, and OAuth member cool checks.

## Test plan
- [x] `go test ./routing -count=1 -run 'Cooldown|Eligibility|RecentFail|ISO|Parse'`
- [x] Regression: cooldownUntil = now+500ms still ineligible (`TestIsCooldownActive_MillisVsSecondPrecision`)

Closes #424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cooldown detection by accurately comparing timestamps, including sub-second precision.
  * Fixed cases where active cooldowns could be incorrectly treated as expired.
  * Applied consistent cooldown handling across routing and channel eligibility checks.

* **Tests**
  * Added regression coverage for millisecond-level cooldown timing and expiration boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->