### PR TITLE
fix(proxy): conductor hard attempt budget + nil RefreshAuth failover

### DIFF
--- a/proxy/conductor.go
+++ b/proxy/conductor.go
@@ -18,6 +18,10 @@ const (
 	ActionStop             AttemptFailureAction = "stop"
 )
 
+// DefaultMaxRefreshAuthSuccesses caps successful RefreshAuth calls per channel
+// before the conductor fails over with a channel-scoped exclude.
+const DefaultMaxRefreshAuthSuccesses = 1
+
 // AttemptResult is the result of an attempt callback.
 type AttemptResult struct {
 	OK           bool
@@ -37,20 +41,27 @@ type AttemptInput struct {
 
 // ConductorDependencies are the injected dependencies for DefaultProxyConductor.
 type ConductorDependencies struct {
-	SelectChannel     func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
-	SelectNextChannel func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
+	SelectChannel          func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
+	SelectNextChannel      func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
 	PreviewSelectedChannel func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
-	RefreshAuth       func(ctx context.Context, selected *routing.SelectedChannel, failureCtx struct {
+	RefreshAuth            func(ctx context.Context, selected *routing.SelectedChannel, failureCtx struct {
 		Status       int
 		RawErrorText string
 	}) (*routing.SelectedChannel, error)
+	// MaxAttempts is the hard total attempt budget covering same-channel retries,
+	// auth refresh retries, and cross-channel failover. Values <= 0 resolve via
+	// GetProxyMaxChannelAttempts (minimum 1). Prefer wiring config.ProxyMaxChannelAttempts.
+	MaxAttempts int
+	// MaxRefreshAuthSuccesses caps successful RefreshAuth calls per selected channel
+	// before failover. Values <= 0 use DefaultMaxRefreshAuthSuccesses.
+	MaxRefreshAuthSuccesses int
 }
 
 // ExecuteInput is the input for the Execute method.
 type ExecuteInput struct {
-	RequestedModel   string
-	DownstreamPolicy routing.DownstreamRoutingPolicy
-	Attempt          func(ctx context.Context, input AttemptInput) (AttemptResult, error)
+	RequestedModel    string
+	DownstreamPolicy  routing.DownstreamRoutingPolicy
+	Attempt           func(ctx context.Context, input AttemptInput) (AttemptResult, error)
 	OnTerminalFailure func(ctx context.Context, selected *routing.SelectedChannel, failureCtx struct {
 		Status       int
 		RawErrorText string
@@ -70,12 +81,22 @@ type ExecuteResult struct {
 
 // DefaultProxyConductor implements action-based retry for non-surface flows.
 type DefaultProxyConductor struct {
-	deps ConductorDependencies
+	deps                    ConductorDependencies
+	maxAttempts             int
+	maxRefreshAuthSuccesses int
 }
 
 // NewDefaultProxyConductor creates a new conductor.
 func NewDefaultProxyConductor(deps ConductorDependencies) *DefaultProxyConductor {
-	return &DefaultProxyConductor{deps: deps}
+	maxRefresh := deps.MaxRefreshAuthSuccesses
+	if maxRefresh <= 0 {
+		maxRefresh = DefaultMaxRefreshAuthSuccesses
+	}
+	return &DefaultProxyConductor{
+		deps:                    deps,
+		maxAttempts:             GetProxyMaxChannelAttempts(deps.MaxAttempts),
+		maxRefreshAuthSuccesses: maxRefresh,
+	}
 }
 
 // PreviewSelectedChannel returns the selected channel without executing a request.
@@ -102,11 +123,15 @@ const maxSameChannelRetries = 1
 // excluded and remain eligible for SelectNextChannel unless they are themselves
 // in the exclude list or filtered by routing policy (cooldown / breaker /
 // credential-scoped usage-limit). See docs/analysis/failover-isolation.md.
+//
+// Hard budget: attempts never exceed maxAttempts (same-channel + refresh + failover).
+// RefreshAuth successes are capped per channel; nil/error RefreshAuth fails over.
 func (c *DefaultProxyConductor) Execute(ctx context.Context, input ExecuteInput) (ExecuteResult, error) {
 	// Request-local exclude list: channel IDs only (never site-wide).
 	excludeChannelIDs := make([]int64, 0)
 	attempts := 0
 	sameChannelRetries := 0
+	refreshAuthSuccesses := 0
 
 	selected, err := c.deps.SelectChannel(ctx, input.RequestedModel, input.DownstreamPolicy)
 	if err != nil {
@@ -136,6 +161,18 @@ func (c *DefaultProxyConductor) Execute(ctx context.Context, input ExecuteInput)
 				Selected: selected,
 				Response: result.Response,
 				Attempts: attempts,
+			}, nil
+		}
+
+		// Budget covers every finished attempt (success already returned above).
+		if attempts >= c.maxAttempts {
+			return ExecuteResult{
+				OK:           false,
+				Reason:       "failed",
+				Selected:     selected,
+				Status:       result.Status,
+				RawErrorText: result.RawErrorText,
+				Attempts:     attempts,
 			}, nil
 		}
 
@@ -169,29 +206,27 @@ func (c *DefaultProxyConductor) Execute(ctx context.Context, input ExecuteInput)
 			action = ActionFailover
 		}
 
-		if shouldRefreshAuth(action) && c.deps.RefreshAuth != nil {
-			refreshed, refreshErr := c.deps.RefreshAuth(ctx, selected, struct {
-				Status       int
-				RawErrorText string
-			}{Status: result.Status, RawErrorText: result.RawErrorText})
-			if refreshErr == nil && refreshed != nil {
-				selected = refreshed
-				sameChannelRetries = 0
-				continue
+		if shouldRefreshAuth(action) {
+			canRefresh := c.deps.RefreshAuth != nil && refreshAuthSuccesses < c.maxRefreshAuthSuccesses
+			if canRefresh {
+				refreshed, refreshErr := c.deps.RefreshAuth(ctx, selected, struct {
+					Status       int
+					RawErrorText string
+				}{Status: result.Status, RawErrorText: result.RawErrorText})
+				if refreshErr == nil && refreshed != nil {
+					selected = refreshed
+					refreshAuthSuccesses++
+					sameChannelRetries = 0
+					continue
+				}
 			}
-			// Auth refresh failed → fall through to failover so siblings can absorb.
+			// nil RefreshAuth, refresh error/nil result, or refresh success cap → failover.
 			action = ActionFailover
 		}
 
 		if shouldFailover(action) {
-			// Channel-scoped only: never expand to site/account sibling IDs here.
-			excludeChannelIDs = appendExcludedChannelID(excludeChannelIDs, selected.Channel.ID)
-			next, nextErr := c.deps.SelectNextChannel(
-				ctx,
-				input.RequestedModel,
-				excludeChannelIDs,
-				input.DownstreamPolicy,
-			)
+			next, nextErr, nextExclude := c.failover(ctx, input, selected, excludeChannelIDs)
+			excludeChannelIDs = nextExclude
 			if nextErr != nil || next == nil {
 				return ExecuteResult{
 					OK:           false,
@@ -204,6 +239,7 @@ func (c *DefaultProxyConductor) Execute(ctx context.Context, input ExecuteInput)
 			}
 			selected = next
 			sameChannelRetries = 0
+			refreshAuthSuccesses = 0
 			continue
 		}
 
@@ -233,6 +269,26 @@ func appendExcludedChannelID(exclude []int64, channelID int64) []int64 {
 		}
 	}
 	return append(exclude, channelID)
+}
+
+func (c *DefaultProxyConductor) failover(
+	ctx context.Context,
+	input ExecuteInput,
+	selected *routing.SelectedChannel,
+	excludeChannelIDs []int64,
+) (*routing.SelectedChannel, error, []int64) {
+	// Channel-scoped only: never expand to site/account sibling IDs here.
+	excludeChannelIDs = appendExcludedChannelID(excludeChannelIDs, selected.Channel.ID)
+	if c.deps.SelectNextChannel == nil {
+		return nil, nil, excludeChannelIDs
+	}
+	next, nextErr := c.deps.SelectNextChannel(
+		ctx,
+		input.RequestedModel,
+		excludeChannelIDs,
+		input.DownstreamPolicy,
+	)
+	return next, nextErr, excludeChannelIDs
 }
 
 // failureActionOf determines the action for a failed attempt.

--- a/proxy/conductor_test.go
+++ b/proxy/conductor_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/tokendancelab/metapi-go/routing"
@@ -45,6 +46,7 @@ func TestConductor_FailoverExcludeIsChannelScopedNotSiteWide(t *testing.T) {
 	attemptChannels := make([]int64, 0, 2)
 
 	conductor := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: 5,
 		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
 			return failed, nil
 		},
@@ -113,6 +115,7 @@ func TestConductor_RateLimitFailsOverToSameSiteSibling(t *testing.T) {
 
 	var capturedExclude []int64
 	conductor := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: 5,
 		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
 			return failed, nil
 		},
@@ -160,6 +163,7 @@ func TestConductor_TimeoutRetriesSameChannelThenFailsOver(t *testing.T) {
 	var attemptOrder []int64
 	var excludeSeen []int64
 	conductor := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: 5,
 		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
 			return failed, nil
 		},
@@ -207,6 +211,7 @@ func TestConductor_MultiChannelSameSiteFailureIsolation(t *testing.T) {
 
 	var excludeSnapshots [][]int64
 	conductor := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: 5,
 		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
 			return ch1, nil
 		},
@@ -288,5 +293,380 @@ func TestFailureActionOf_DoesNotPinRateLimitOnSameChannel(t *testing.T) {
 	}
 	if got := failureActionOf(AttemptResult{Status: 400, RawErrorText: "invalid request body"}); got != ActionTerminal {
 		t.Fatalf("400 want terminal, got %s", got)
+	}
+}
+
+func conductorChannel(id int64) *routing.SelectedChannel {
+	ch := makeChannel(id, 1, 100+id)
+	return &ch
+}
+
+func TestConductor_NChannel5xxStormStopsAtBudget(t *testing.T) {
+	// Many channels available; every attempt is 5xx. Conductor must stop at MaxAttempts
+	// even though SelectNextChannel would keep returning siblings.
+	const budget = 3
+	const channelCount = 10
+
+	channels := make([]*routing.SelectedChannel, channelCount)
+	for i := 0; i < channelCount; i++ {
+		channels[i] = conductorChannel(int64(i + 1))
+	}
+
+	selectCalls := 0
+	nextCalls := 0
+	attemptCalls := 0
+	var seenChannelIDs []int64
+	var lastExclude []int64
+
+	c := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: budget,
+		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			selectCalls++
+			return channels[0], nil
+		},
+		SelectNextChannel: func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			nextCalls++
+			lastExclude = append([]int64(nil), excludeChannelIDs...)
+			excluded := map[int64]bool{}
+			for _, id := range excludeChannelIDs {
+				excluded[id] = true
+			}
+			for _, ch := range channels {
+				if !excluded[ch.Channel.ID] {
+					return ch, nil
+				}
+			}
+			return nil, nil
+		},
+	})
+
+	result, err := c.Execute(context.Background(), ExecuteInput{
+		RequestedModel: "gpt-4",
+		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
+			attemptCalls++
+			seenChannelIDs = append(seenChannelIDs, input.Selected.Channel.ID)
+			return AttemptResult{
+				OK:           false,
+				Status:       503,
+				RawErrorText: "service unavailable",
+			}, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.OK {
+		t.Fatal("expected failure under 5xx storm")
+	}
+	if result.Reason != "failed" {
+		t.Fatalf("reason = %q, want failed", result.Reason)
+	}
+	if result.Status != 503 {
+		t.Fatalf("status = %d, want 503", result.Status)
+	}
+	if result.Attempts != budget {
+		t.Fatalf("attempts = %d, want budget %d", result.Attempts, budget)
+	}
+	if attemptCalls != budget {
+		t.Fatalf("attempt callbacks = %d, want %d", attemptCalls, budget)
+	}
+	if selectCalls != 1 {
+		t.Fatalf("SelectChannel calls = %d, want 1", selectCalls)
+	}
+	// budget-1 failovers after failed attempts that still have budget remaining
+	if nextCalls != budget-1 {
+		t.Fatalf("SelectNextChannel calls = %d, want %d", nextCalls, budget-1)
+	}
+	if len(seenChannelIDs) != budget {
+		t.Fatalf("seen channels = %v, want %d entries", seenChannelIDs, budget)
+	}
+	// Failover must exclude prior channel IDs
+	if len(lastExclude) == 0 {
+		t.Fatal("expected non-empty exclude list on last failover")
+	}
+	// No infinite walk: never contacted more channels than the budget allows
+	if len(seenChannelIDs) > budget {
+		t.Fatalf("walked too many channels: %v", seenChannelIDs)
+	}
+}
+
+func TestConductor_401RefreshAuthNilTriesSibling(t *testing.T) {
+	ch1 := conductorChannel(1)
+	ch2 := conductorChannel(2)
+
+	var attemptChannelIDs []int64
+	var excludeOnNext []int64
+	refreshCalled := false
+
+	c := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: 3,
+		// RefreshAuth intentionally nil — 401 must still failover to sibling.
+		RefreshAuth: nil,
+		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			return ch1, nil
+		},
+		SelectNextChannel: func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			excludeOnNext = append([]int64(nil), excludeChannelIDs...)
+			return ch2, nil
+		},
+	})
+
+	result, err := c.Execute(context.Background(), ExecuteInput{
+		RequestedModel: "gpt-4",
+		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
+			attemptChannelIDs = append(attemptChannelIDs, input.Selected.Channel.ID)
+			if input.Selected.Channel.ID == 1 {
+				return AttemptResult{OK: false, Status: 401, RawErrorText: "unauthorized"}, nil
+			}
+			return AttemptResult{OK: true, Response: "ok-from-sibling"}, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.OK {
+		t.Fatalf("expected success on sibling, got reason=%s status=%d", result.Reason, result.Status)
+	}
+	if result.Response != "ok-from-sibling" {
+		t.Fatalf("response = %v", result.Response)
+	}
+	if refreshCalled {
+		t.Fatal("RefreshAuth should not have been called (nil)")
+	}
+	if len(attemptChannelIDs) != 2 || attemptChannelIDs[0] != 1 || attemptChannelIDs[1] != 2 {
+		t.Fatalf("attempt channels = %v, want [1 2]", attemptChannelIDs)
+	}
+	if len(excludeOnNext) != 1 || excludeOnNext[0] != 1 {
+		t.Fatalf("exclude on failover = %v, want [1]", excludeOnNext)
+	}
+	if result.Attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", result.Attempts)
+	}
+}
+
+func TestConductor_401RefreshAuthErrorFailsOver(t *testing.T) {
+	ch1 := conductorChannel(1)
+	ch2 := conductorChannel(2)
+	refreshCalls := 0
+
+	c := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: 3,
+		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			return ch1, nil
+		},
+		SelectNextChannel: func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			return ch2, nil
+		},
+		RefreshAuth: func(ctx context.Context, selected *routing.SelectedChannel, failureCtx struct {
+			Status       int
+			RawErrorText string
+		}) (*routing.SelectedChannel, error) {
+			refreshCalls++
+			return nil, errors.New("refresh failed")
+		},
+	})
+
+	var attemptIDs []int64
+	result, err := c.Execute(context.Background(), ExecuteInput{
+		RequestedModel: "gpt-4",
+		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
+			attemptIDs = append(attemptIDs, input.Selected.Channel.ID)
+			if input.Selected.Channel.ID == 1 {
+				return AttemptResult{OK: false, Status: 403, RawErrorText: "forbidden"}, nil
+			}
+			return AttemptResult{OK: true, Response: "sibling"}, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.OK {
+		t.Fatalf("expected sibling success, got %+v", result)
+	}
+	if refreshCalls != 1 {
+		t.Fatalf("refreshCalls = %d, want 1", refreshCalls)
+	}
+	if len(attemptIDs) != 2 || attemptIDs[0] != 1 || attemptIDs[1] != 2 {
+		t.Fatalf("attemptIDs = %v, want [1 2]", attemptIDs)
+	}
+}
+
+func TestConductor_RefreshAuthSuccessCappedThenFailover(t *testing.T) {
+	ch1 := conductorChannel(1)
+	ch2 := conductorChannel(2)
+	refreshCalls := 0
+	var attemptIDs []int64
+
+	c := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts:             5,
+		MaxRefreshAuthSuccesses: 1,
+		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			return ch1, nil
+		},
+		SelectNextChannel: func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			if len(excludeChannelIDs) == 0 || excludeChannelIDs[len(excludeChannelIDs)-1] != 1 {
+				t.Fatalf("expected channel 1 excluded, got %v", excludeChannelIDs)
+			}
+			return ch2, nil
+		},
+		RefreshAuth: func(ctx context.Context, selected *routing.SelectedChannel, failureCtx struct {
+			Status       int
+			RawErrorText string
+		}) (*routing.SelectedChannel, error) {
+			refreshCalls++
+			// Return same channel with "refreshed" token semantics.
+			return selected, nil
+		},
+	})
+
+	result, err := c.Execute(context.Background(), ExecuteInput{
+		RequestedModel: "gpt-4",
+		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
+			attemptIDs = append(attemptIDs, input.Selected.Channel.ID)
+			// Channel 1 always 401; channel 2 succeeds.
+			if input.Selected.Channel.ID == 1 {
+				return AttemptResult{OK: false, Status: 401, RawErrorText: "unauthorized"}, nil
+			}
+			return AttemptResult{OK: true, Response: "ok"}, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.OK {
+		t.Fatalf("expected success, got %+v", result)
+	}
+	// First 401 → refresh once → second 401 → refresh cap → failover to ch2 → success.
+	if refreshCalls != 1 {
+		t.Fatalf("refreshCalls = %d, want 1 (capped)", refreshCalls)
+	}
+	if len(attemptIDs) != 3 || attemptIDs[0] != 1 || attemptIDs[1] != 1 || attemptIDs[2] != 2 {
+		t.Fatalf("attemptIDs = %v, want [1 1 2]", attemptIDs)
+	}
+	if result.Attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", result.Attempts)
+	}
+}
+
+func TestConductor_SameChannelRetryRespectsBudget(t *testing.T) {
+	ch1 := conductorChannel(1)
+	nextCalls := 0
+	attemptCalls := 0
+
+	c := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: 2,
+		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			return ch1, nil
+		},
+		SelectNextChannel: func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			nextCalls++
+			return conductorChannel(2), nil
+		},
+	})
+
+	result, err := c.Execute(context.Background(), ExecuteInput{
+		RequestedModel: "gpt-4",
+		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
+			attemptCalls++
+			// 408 with retryable classification → same-channel retry until budget.
+			return AttemptResult{OK: false, Status: 408, RawErrorText: "request timed out"}, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.OK || result.Reason != "failed" {
+		t.Fatalf("expected budget-exhausted failure, got %+v", result)
+	}
+	if result.Attempts != 2 || attemptCalls != 2 {
+		t.Fatalf("attempts=%d attemptCalls=%d, want 2", result.Attempts, attemptCalls)
+	}
+	if nextCalls != 0 {
+		t.Fatalf("same-channel path should not failover before budget stop, nextCalls=%d", nextCalls)
+	}
+	if result.Status != 408 {
+		t.Fatalf("status = %d, want 408", result.Status)
+	}
+}
+
+func TestConductor_TerminalDoesNotFailover(t *testing.T) {
+	ch1 := conductorChannel(1)
+	nextCalls := 0
+
+	c := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: 5,
+		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			return ch1, nil
+		},
+		SelectNextChannel: func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			nextCalls++
+			return conductorChannel(2), nil
+		},
+	})
+
+	result, err := c.Execute(context.Background(), ExecuteInput{
+		RequestedModel: "gpt-4",
+		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
+			return AttemptResult{OK: false, Status: 400, RawErrorText: "bad request"}, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Reason != "terminal" {
+		t.Fatalf("reason = %q, want terminal", result.Reason)
+	}
+	if nextCalls != 0 {
+		t.Fatalf("terminal must not failover, nextCalls=%d", nextCalls)
+	}
+	if result.Attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", result.Attempts)
+	}
+}
+
+func TestConductor_NoChannel(t *testing.T) {
+	c := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: 3,
+		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			return nil, nil
+		},
+	})
+	result, err := c.Execute(context.Background(), ExecuteInput{
+		RequestedModel: "gpt-4",
+		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
+			t.Fatal("Attempt should not be called")
+			return AttemptResult{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Reason != "no_channel" || result.Attempts != 0 {
+		t.Fatalf("got %+v", result)
+	}
+}
+
+func TestNewDefaultProxyConductor_Defaults(t *testing.T) {
+	c := NewDefaultProxyConductor(ConductorDependencies{})
+	if c.maxAttempts != 1 {
+		// GetProxyMaxChannelAttempts(0) → 1
+		t.Fatalf("maxAttempts = %d, want 1", c.maxAttempts)
+	}
+	if c.maxRefreshAuthSuccesses != DefaultMaxRefreshAuthSuccesses {
+		t.Fatalf("maxRefreshAuthSuccesses = %d, want %d", c.maxRefreshAuthSuccesses, DefaultMaxRefreshAuthSuccesses)
+	}
+
+	c2 := NewDefaultProxyConductor(ConductorDependencies{MaxAttempts: 7, MaxRefreshAuthSuccesses: 2})
+	if c2.maxAttempts != 7 {
+		t.Fatalf("maxAttempts = %d, want 7", c2.maxAttempts)
+	}
+	if c2.maxRefreshAuthSuccesses != 2 {
+		t.Fatalf("maxRefreshAuthSuccesses = %d, want 2", c2.maxRefreshAuthSuccesses)
 	}
 }


### PR DESCRIPTION
## Summary
- Enforce a hard total attempt budget on `DefaultProxyConductor` via `MaxAttempts` / `GetProxyMaxChannelAttempts`, covering same-channel retries, RefreshAuth retries, and cross-channel failover so multi-channel 5xx storms cannot walk forever.
- Cap successful `RefreshAuth` calls per channel (default 1), then failover with channel-scoped exclude.
- When action is `refresh_auth` and `RefreshAuth` is nil or errors/returns nil, take the failover path instead of stopping without a sibling attempt.

## Test plan
- [x] `go test ./proxy -count=1 -run 'Conductor|Failover|Refresh|Budget'`
- [x] Full pre-push: `go vet ./...` + `go test ./... -count=1 -race`

Closes #425