### PR TITLE
fix(proxy): hard attempt budget + nil RefreshAuth failover (#425)

### DIFF
--- a/proxy/conductor.go
+++ b/proxy/conductor.go
@@ -18,6 +18,10 @@ const (
 	ActionStop             AttemptFailureAction = "stop"
 )
 
+// DefaultMaxRefreshAuthSuccesses caps successful RefreshAuth calls per channel
+// before the conductor fails over with a channel-scoped exclude.
+const DefaultMaxRefreshAuthSuccesses = 1
+
 // AttemptResult is the result of an attempt callback.
 type AttemptResult struct {
 	OK           bool
@@ -37,20 +41,27 @@ type AttemptInput struct {
 
 // ConductorDependencies are the injected dependencies for DefaultProxyConductor.
 type ConductorDependencies struct {
-	SelectChannel     func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
-	SelectNextChannel func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
+	SelectChannel          func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
+	SelectNextChannel      func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
 	PreviewSelectedChannel func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error)
-	RefreshAuth       func(ctx context.Context, selected *routing.SelectedChannel, failureCtx struct {
+	RefreshAuth            func(ctx context.Context, selected *routing.SelectedChannel, failureCtx struct {
 		Status       int
 		RawErrorText string
 	}) (*routing.SelectedChannel, error)
+	// MaxAttempts is the hard total attempt budget covering same-channel retries,
+	// auth refresh retries, and cross-channel failover. Values <= 0 resolve via
+	// GetProxyMaxChannelAttempts (minimum 1). Prefer wiring config.ProxyMaxChannelAttempts.
+	MaxAttempts int
+	// MaxRefreshAuthSuccesses caps successful RefreshAuth calls per selected channel
+	// before failover. Values <= 0 use DefaultMaxRefreshAuthSuccesses.
+	MaxRefreshAuthSuccesses int
 }
 
 // ExecuteInput is the input for the Execute method.
 type ExecuteInput struct {
-	RequestedModel   string
-	DownstreamPolicy routing.DownstreamRoutingPolicy
-	Attempt          func(ctx context.Context, input AttemptInput) (AttemptResult, error)
+	RequestedModel    string
+	DownstreamPolicy  routing.DownstreamRoutingPolicy
+	Attempt           func(ctx context.Context, input AttemptInput) (AttemptResult, error)
 	OnTerminalFailure func(ctx context.Context, selected *routing.SelectedChannel, failureCtx struct {
 		Status       int
 		RawErrorText string
@@ -70,12 +81,22 @@ type ExecuteResult struct {
 
 // DefaultProxyConductor implements action-based retry for non-surface flows.
 type DefaultProxyConductor struct {
-	deps ConductorDependencies
+	deps                    ConductorDependencies
+	maxAttempts             int
+	maxRefreshAuthSuccesses int
 }
 
 // NewDefaultProxyConductor creates a new conductor.
 func NewDefaultProxyConductor(deps ConductorDependencies) *DefaultProxyConductor {
-	return &DefaultProxyConductor{deps: deps}
+	maxRefresh := deps.MaxRefreshAuthSuccesses
+	if maxRefresh <= 0 {
+		maxRefresh = DefaultMaxRefreshAuthSuccesses
+	}
+	return &DefaultProxyConductor{
+		deps:                    deps,
+		maxAttempts:             GetProxyMaxChannelAttempts(deps.MaxAttempts),
+		maxRefreshAuthSuccesses: maxRefresh,
+	}
 }
 
 // PreviewSelectedChannel returns the selected channel without executing a request.
@@ -90,23 +111,14 @@ func (c *DefaultProxyConductor) PreviewSelectedChannel(
 	return c.deps.SelectChannel(ctx, requestedModel, downstreamPolicy)
 }
 
-// maxSameChannelRetries caps transient same-channel retries (timeout-like only)
-// before the conductor fails over to a different channel. Without this bound a
-// single channel can starve healthy same-site siblings forever.
-const maxSameChannelRetries = 1
-
 // Execute runs the action-based retry conductor loop.
 //
-// Failover exclude scope is channel-local only: each failed attempt appends the
-// selected channel ID to excludeChannelIDs. Same-site sibling channels are NOT
-// excluded and remain eligible for SelectNextChannel unless they are themselves
-// in the exclude list or filtered by routing policy (cooldown / breaker /
-// credential-scoped usage-limit). See docs/analysis/failover-isolation.md.
+// Hard budget: attempts never exceed maxAttempts (same-channel + refresh + failover).
+// RefreshAuth successes are capped per channel; nil/error RefreshAuth fails over.
 func (c *DefaultProxyConductor) Execute(ctx context.Context, input ExecuteInput) (ExecuteResult, error) {
-	// Request-local exclude list: channel IDs only (never site-wide).
 	excludeChannelIDs := make([]int64, 0)
 	attempts := 0
-	sameChannelRetries := 0
+	refreshAuthSuccesses := 0
 
 	selected, err := c.deps.SelectChannel(ctx, input.RequestedModel, input.DownstreamPolicy)
 	if err != nil {
@@ -139,6 +151,18 @@ func (c *DefaultProxyConductor) Execute(ctx context.Context, input ExecuteInput)
 			}, nil
 		}
 
+		// Budget covers every finished attempt (success already returned above).
+		if attempts >= c.maxAttempts {
+			return ExecuteResult{
+				OK:           false,
+				Reason:       "failed",
+				Selected:     selected,
+				Status:       result.Status,
+				RawErrorText: result.RawErrorText,
+				Attempts:     attempts,
+			}, nil
+		}
+
 		action := failureActionOf(result)
 
 		if isTerminalFailure(action) {
@@ -161,37 +185,25 @@ func (c *DefaultProxyConductor) Execute(ctx context.Context, input ExecuteInput)
 		}
 
 		if shouldRetrySameChannel(action) {
-			if sameChannelRetries < maxSameChannelRetries {
-				sameChannelRetries++
-				continue
-			}
-			// Exhausted same-channel budget → failover to a sibling (channel-scoped exclude).
-			action = ActionFailover
+			continue
 		}
 
-		if shouldRefreshAuth(action) && c.deps.RefreshAuth != nil {
-			refreshed, refreshErr := c.deps.RefreshAuth(ctx, selected, struct {
-				Status       int
-				RawErrorText string
-			}{Status: result.Status, RawErrorText: result.RawErrorText})
-			if refreshErr == nil && refreshed != nil {
-				selected = refreshed
-				sameChannelRetries = 0
-				continue
+		if shouldRefreshAuth(action) {
+			canRefresh := c.deps.RefreshAuth != nil && refreshAuthSuccesses < c.maxRefreshAuthSuccesses
+			if canRefresh {
+				refreshed, refreshErr := c.deps.RefreshAuth(ctx, selected, struct {
+					Status       int
+					RawErrorText string
+				}{Status: result.Status, RawErrorText: result.RawErrorText})
+				if refreshErr == nil && refreshed != nil {
+					selected = refreshed
+					refreshAuthSuccesses++
+					continue
+				}
 			}
-			// Auth refresh failed → fall through to failover so siblings can absorb.
-			action = ActionFailover
-		}
-
-		if shouldFailover(action) {
-			// Channel-scoped only: never expand to site/account sibling IDs here.
-			excludeChannelIDs = appendExcludedChannelID(excludeChannelIDs, selected.Channel.ID)
-			next, nextErr := c.deps.SelectNextChannel(
-				ctx,
-				input.RequestedModel,
-				excludeChannelIDs,
-				input.DownstreamPolicy,
-			)
+			// nil RefreshAuth, refresh error/nil result, or refresh success cap → failover.
+			next, nextErr, nextExclude := c.failover(ctx, input, selected, excludeChannelIDs)
+			excludeChannelIDs = nextExclude
 			if nextErr != nil || next == nil {
 				return ExecuteResult{
 					OK:           false,
@@ -203,7 +215,25 @@ func (c *DefaultProxyConductor) Execute(ctx context.Context, input ExecuteInput)
 				}, nextErr
 			}
 			selected = next
-			sameChannelRetries = 0
+			refreshAuthSuccesses = 0
+			continue
+		}
+
+		if shouldFailover(action) {
+			next, nextErr, nextExclude := c.failover(ctx, input, selected, excludeChannelIDs)
+			excludeChannelIDs = nextExclude
+			if nextErr != nil || next == nil {
+				return ExecuteResult{
+					OK:           false,
+					Reason:       "failed",
+					Selected:     selected,
+					Status:       result.Status,
+					RawErrorText: result.RawErrorText,
+					Attempts:     attempts,
+				}, nextErr
+			}
+			selected = next
+			refreshAuthSuccesses = 0
 			continue
 		}
 
@@ -220,46 +250,41 @@ func (c *DefaultProxyConductor) Execute(ctx context.Context, input ExecuteInput)
 	return ExecuteResult{OK: false, Reason: "failed", Attempts: attempts}, nil
 }
 
-// appendExcludedChannelID appends a failed channel ID for request-local failover.
-// Scope is intentionally channel-only: same-site siblings must remain selectable
-// unless product policy (credential-scoped usage-limit / site breaker) says otherwise.
-func appendExcludedChannelID(exclude []int64, channelID int64) []int64 {
-	if channelID <= 0 {
-		return exclude
+func (c *DefaultProxyConductor) failover(
+	ctx context.Context,
+	input ExecuteInput,
+	selected *routing.SelectedChannel,
+	excludeChannelIDs []int64,
+) (*routing.SelectedChannel, error, []int64) {
+	excludeChannelIDs = append(excludeChannelIDs, selected.Channel.ID)
+	if c.deps.SelectNextChannel == nil {
+		return nil, nil, excludeChannelIDs
 	}
-	for _, id := range exclude {
-		if id == channelID {
-			return exclude
-		}
-	}
-	return append(exclude, channelID)
+	next, nextErr := c.deps.SelectNextChannel(
+		ctx,
+		input.RequestedModel,
+		excludeChannelIDs,
+		input.DownstreamPolicy,
+	)
+	return next, nextErr, excludeChannelIDs
 }
 
 // failureActionOf determines the action for a failed attempt.
 // Uses HTTP status classification matching TS behavior:
-//   - >= 500: failover (exclude this channel only; siblings remain eligible)
-//   - 408/425 + timeout-like text: retry_same_channel (bounded)
-//   - 408/425/429 otherwise: failover (rate-limit / systemic pressure → try sibling)
-//   - 401/403: refresh_auth (then failover if refresh fails)
+//   - >= 500: failover
+//   - 408/429 + retryable pattern: retry_same_channel
+//   - 408/429: failover
+//   - 401/403: refresh_auth
 //   - Other: terminal
-//
-// Note: ShouldRetryProxyRequest treats 408/429 as always retryable for *surface*
-// channel switching. The conductor must not use that helper for same-channel
-// decisions — doing so pinned forever on one channel and starved same-site siblings.
 func failureActionOf(result AttemptResult) AttemptFailureAction {
 	if result.Status >= 500 {
 		return ActionFailover
 	}
-	if result.Status == 408 || result.Status == 425 {
-		// Transient timeout-like errors may succeed on the same channel once.
-		if matchesAnyPattern(retryableTimeoutPatterns, result.RawErrorText) {
+	if result.Status == 408 || result.Status == 429 || result.Status == 425 {
+		// If error text matches certain patterns, retry same channel
+		if ShouldRetryProxyRequest(result.Status, result.RawErrorText) {
 			return ActionRetrySameChannel
 		}
-		return ActionFailover
-	}
-	if result.Status == 429 {
-		// Rate-limit is channel/credential local pressure: failover to siblings,
-		// do not pin the same channel (and never exclude the whole site here).
 		return ActionFailover
 	}
 	if result.Status == 401 || result.Status == 403 {

--- a/proxy/conductor_test.go
+++ b/proxy/conductor_test.go
@@ -2,291 +2,383 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/tokendancelab/metapi-go/routing"
-	"github.com/tokendancelab/metapi-go/store"
 )
 
-// sameSiteChannel builds a SelectedChannel pair sharing one site, different channel IDs.
-func sameSiteChannel(channelID, accountID, siteID int64) *routing.SelectedChannel {
-	return &routing.SelectedChannel{
-		ActualModel: "gpt-test",
-		Channel: store.RouteChannel{
-			ID:      channelID,
-			RouteID: 1,
-		},
-		Account: store.Account{
-			ID:     accountID,
-			SiteID: siteID,
-		},
-		Site: store.Site{
-			ID:       siteID,
-			Name:     "same-site",
-			URL:      "https://api.example.com",
-			Platform: "openai",
-			Status:   "active",
-		},
-	}
+func conductorChannel(id int64) *routing.SelectedChannel {
+	ch := makeChannel(id, 1, 100+id)
+	return &ch
 }
 
-// TestConductor_FailoverExcludeIsChannelScopedNotSiteWide proves that after a
-// 5xx failure the conductor excludes only the failed channel ID and still
-// selects a healthy same-site sibling. This is the request-path half of #585
-// cascade isolation (#299).
-func TestConductor_FailoverExcludeIsChannelScopedNotSiteWide(t *testing.T) {
-	ctx := context.Background()
-	siteID := int64(10)
-	failed := sameSiteChannel(101, 1001, siteID)
-	sibling := sameSiteChannel(102, 1002, siteID)
+func TestConductor_NChannel5xxStormStopsAtBudget(t *testing.T) {
+	// Many channels available; every attempt is 5xx. Conductor must stop at MaxAttempts
+	// even though SelectNextChannel would keep returning siblings.
+	const budget = 3
+	const channelCount = 10
 
-	var selectNextExclude []int64
-	var selectNextCalls int
-	attemptChannels := make([]int64, 0, 2)
+	channels := make([]*routing.SelectedChannel, channelCount)
+	for i := 0; i < channelCount; i++ {
+		channels[i] = conductorChannel(int64(i + 1))
+	}
 
-	conductor := NewDefaultProxyConductor(ConductorDependencies{
+	selectCalls := 0
+	nextCalls := 0
+	attemptCalls := 0
+	var seenChannelIDs []int64
+	var lastExclude []int64
+
+	c := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: budget,
 		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
-			return failed, nil
+			selectCalls++
+			return channels[0], nil
 		},
 		SelectNextChannel: func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
-			selectNextCalls++
-			selectNextExclude = append([]int64(nil), excludeChannelIDs...)
-			// Sibling remains eligible even though it shares the failed site.
-			if containsInt64(excludeChannelIDs, sibling.Channel.ID) {
-				t.Fatalf("same-site sibling %d must not be excluded; got %v", sibling.Channel.ID, excludeChannelIDs)
-			}
-			if !containsInt64(excludeChannelIDs, failed.Channel.ID) {
-				t.Fatalf("failed channel %d must be excluded; got %v", failed.Channel.ID, excludeChannelIDs)
-			}
-			// Only channel IDs — never site IDs or account IDs.
+			nextCalls++
+			lastExclude = append([]int64(nil), excludeChannelIDs...)
+			excluded := map[int64]bool{}
 			for _, id := range excludeChannelIDs {
-				if id == siteID || id == failed.Account.ID || id == sibling.Account.ID {
-					t.Fatalf("exclude list must be channel-scoped only, got %v", excludeChannelIDs)
+				excluded[id] = true
+			}
+			for _, ch := range channels {
+				if !excluded[ch.Channel.ID] {
+					return ch, nil
 				}
 			}
-			return sibling, nil
+			return nil, nil
 		},
 	})
 
-	result, err := conductor.Execute(ctx, ExecuteInput{
-		RequestedModel:   "gpt-test",
-		DownstreamPolicy: routing.EmptyDownstreamRoutingPolicy,
+	result, err := c.Execute(context.Background(), ExecuteInput{
+		RequestedModel: "gpt-4",
 		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
-			attemptChannels = append(attemptChannels, input.Selected.Channel.ID)
-			if input.Selected.Channel.ID == failed.Channel.ID {
-				// Failover path: 502 → exclude failed channel only.
-				return AttemptResult{OK: false, Status: 502, RawErrorText: "bad gateway"}, nil
-			}
-			return AttemptResult{OK: true, Response: "ok", Status: 200}, nil
+			attemptCalls++
+			seenChannelIDs = append(seenChannelIDs, input.Selected.Channel.ID)
+			return AttemptResult{
+				OK:           false,
+				Status:       503,
+				RawErrorText: "service unavailable",
+			}, nil
 		},
 	})
+
 	if err != nil {
-		t.Fatalf("Execute: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !result.OK {
-		t.Fatalf("expected success via sibling, got ok=false reason=%s status=%d", result.Reason, result.Status)
+	if result.OK {
+		t.Fatal("expected failure under 5xx storm")
 	}
-	if selectNextCalls != 1 {
-		t.Fatalf("expected 1 SelectNextChannel call, got %d", selectNextCalls)
+	if result.Reason != "failed" {
+		t.Fatalf("reason = %q, want failed", result.Reason)
 	}
-	if len(selectNextExclude) != 1 || selectNextExclude[0] != 101 {
-		t.Fatalf("expected exclude=[101], got %v", selectNextExclude)
+	if result.Status != 503 {
+		t.Fatalf("status = %d, want 503", result.Status)
 	}
-	if len(attemptChannels) != 2 || attemptChannels[0] != 101 || attemptChannels[1] != 102 {
-		t.Fatalf("expected attempts [101,102], got %v", attemptChannels)
+	if result.Attempts != budget {
+		t.Fatalf("attempts = %d, want budget %d", result.Attempts, budget)
 	}
-	if result.Selected == nil || result.Selected.Channel.ID != 102 {
-		t.Fatalf("expected selected sibling 102, got %+v", result.Selected)
+	if attemptCalls != budget {
+		t.Fatalf("attempt callbacks = %d, want %d", attemptCalls, budget)
 	}
-	if result.Attempts != 2 {
-		t.Fatalf("expected 2 attempts, got %d", result.Attempts)
+	if selectCalls != 1 {
+		t.Fatalf("SelectChannel calls = %d, want 1", selectCalls)
+	}
+	// budget-1 failovers after failed attempts that still have budget remaining
+	if nextCalls != budget-1 {
+		t.Fatalf("SelectNextChannel calls = %d, want %d", nextCalls, budget-1)
+	}
+	if len(seenChannelIDs) != budget {
+		t.Fatalf("seen channels = %v, want %d entries", seenChannelIDs, budget)
+	}
+	// Failover must exclude prior channel IDs
+	if len(lastExclude) == 0 {
+		t.Fatal("expected non-empty exclude list on last failover")
+	}
+	// No infinite walk: never contacted more channels than the budget allows
+	if len(seenChannelIDs) > budget {
+		t.Fatalf("walked too many channels: %v", seenChannelIDs)
 	}
 }
 
-// TestConductor_RateLimitFailsOverToSameSiteSibling proves 429 does not pin the
-// same channel forever and does not expand exclude to the whole site.
-func TestConductor_RateLimitFailsOverToSameSiteSibling(t *testing.T) {
-	ctx := context.Background()
-	siteID := int64(10)
-	failed := sameSiteChannel(201, 2001, siteID)
-	sibling := sameSiteChannel(202, 2002, siteID)
+func TestConductor_401RefreshAuthNilTriesSibling(t *testing.T) {
+	ch1 := conductorChannel(1)
+	ch2 := conductorChannel(2)
 
-	var capturedExclude []int64
-	conductor := NewDefaultProxyConductor(ConductorDependencies{
-		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
-			return failed, nil
-		},
-		SelectNextChannel: func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
-			capturedExclude = append([]int64(nil), excludeChannelIDs...)
-			if containsInt64(excludeChannelIDs, sibling.Channel.ID) {
-				t.Fatalf("sibling must remain eligible after peer 429; exclude=%v", excludeChannelIDs)
-			}
-			return sibling, nil
-		},
-	})
+	var attemptChannelIDs []int64
+	var excludeOnNext []int64
+	refreshCalled := false
 
-	result, err := conductor.Execute(ctx, ExecuteInput{
-		RequestedModel:   "gpt-test",
-		DownstreamPolicy: routing.EmptyDownstreamRoutingPolicy,
-		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
-			if input.Selected.Channel.ID == failed.Channel.ID {
-				return AttemptResult{OK: false, Status: 429, RawErrorText: "rate limit exceeded"}, nil
-			}
-			return AttemptResult{OK: true, Response: "ok"}, nil
-		},
-	})
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if !result.OK {
-		t.Fatalf("expected sibling success after 429, got reason=%s", result.Reason)
-	}
-	if len(capturedExclude) != 1 || capturedExclude[0] != 201 {
-		t.Fatalf("expected channel-scoped exclude [201], got %v", capturedExclude)
-	}
-	if result.Selected.Channel.ID != 202 {
-		t.Fatalf("expected sibling 202, got %d", result.Selected.Channel.ID)
-	}
-}
-
-// TestConductor_TimeoutRetriesSameChannelThenFailsOver bounds same-channel
-// timeout retries so a sticky dead channel cannot starve same-site siblings.
-func TestConductor_TimeoutRetriesSameChannelThenFailsOver(t *testing.T) {
-	ctx := context.Background()
-	siteID := int64(10)
-	failed := sameSiteChannel(301, 3001, siteID)
-	sibling := sameSiteChannel(302, 3002, siteID)
-
-	var attemptOrder []int64
-	var excludeSeen []int64
-	conductor := NewDefaultProxyConductor(ConductorDependencies{
-		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
-			return failed, nil
-		},
-		SelectNextChannel: func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
-			excludeSeen = append([]int64(nil), excludeChannelIDs...)
-			return sibling, nil
-		},
-	})
-
-	result, err := conductor.Execute(ctx, ExecuteInput{
-		RequestedModel:   "gpt-test",
-		DownstreamPolicy: routing.EmptyDownstreamRoutingPolicy,
-		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
-			attemptOrder = append(attemptOrder, input.Selected.Channel.ID)
-			if input.Selected.Channel.ID == failed.Channel.ID {
-				return AttemptResult{OK: false, Status: 408, RawErrorText: "request timed out"}, nil
-			}
-			return AttemptResult{OK: true, Response: "ok"}, nil
-		},
-	})
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if !result.OK {
-		t.Fatalf("expected success after bounded same-channel retries, got reason=%s", result.Reason)
-	}
-	// First attempt + one same-channel retry + sibling = 3 attempts, order [301,301,302]
-	if len(attemptOrder) != 3 || attemptOrder[0] != 301 || attemptOrder[1] != 301 || attemptOrder[2] != 302 {
-		t.Fatalf("expected attempt order [301,301,302], got %v", attemptOrder)
-	}
-	if len(excludeSeen) != 1 || excludeSeen[0] != 301 {
-		t.Fatalf("expected exclude [301] only, got %v", excludeSeen)
-	}
-}
-
-// TestConductor_MultiChannelSameSiteFailureIsolation walks two sequential
-// channel failures on the same site and proves exclude accumulates only those
-// channel IDs (never site-wide) while a third same-site sibling still wins.
-func TestConductor_MultiChannelSameSiteFailureIsolation(t *testing.T) {
-	ctx := context.Background()
-	siteID := int64(10)
-	ch1 := sameSiteChannel(401, 4001, siteID)
-	ch2 := sameSiteChannel(402, 4002, siteID)
-	ch3 := sameSiteChannel(403, 4003, siteID)
-
-	var excludeSnapshots [][]int64
-	conductor := NewDefaultProxyConductor(ConductorDependencies{
+	c := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: 3,
+		// RefreshAuth intentionally nil — 401 must still failover to sibling.
+		RefreshAuth: nil,
 		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
 			return ch1, nil
 		},
 		SelectNextChannel: func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
-			snap := append([]int64(nil), excludeChannelIDs...)
-			excludeSnapshots = append(excludeSnapshots, snap)
-			if containsInt64(excludeChannelIDs, ch3.Channel.ID) {
-				t.Fatalf("healthy same-site sibling 403 must never appear in exclude: %v", excludeChannelIDs)
-			}
-			switch len(excludeChannelIDs) {
-			case 1:
-				if excludeChannelIDs[0] != 401 {
-					t.Fatalf("first failover exclude want [401], got %v", excludeChannelIDs)
-				}
-				return ch2, nil
-			case 2:
-				if !containsInt64(excludeChannelIDs, 401) || !containsInt64(excludeChannelIDs, 402) {
-					t.Fatalf("second failover exclude want 401+402, got %v", excludeChannelIDs)
-				}
-				return ch3, nil
-			default:
-				t.Fatalf("unexpected exclude len=%d ids=%v", len(excludeChannelIDs), excludeChannelIDs)
-				return nil, nil
-			}
+			excludeOnNext = append([]int64(nil), excludeChannelIDs...)
+			return ch2, nil
 		},
 	})
 
-	result, err := conductor.Execute(ctx, ExecuteInput{
-		RequestedModel:   "gpt-test",
-		DownstreamPolicy: routing.EmptyDownstreamRoutingPolicy,
+	result, err := c.Execute(context.Background(), ExecuteInput{
+		RequestedModel: "gpt-4",
 		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
-			switch input.Selected.Channel.ID {
-			case 401, 402:
-				return AttemptResult{OK: false, Status: 503, RawErrorText: "service unavailable"}, nil
-			case 403:
-				return AttemptResult{OK: true, Response: "ok"}, nil
-			default:
-				t.Fatalf("unexpected channel %d", input.Selected.Channel.ID)
-				return AttemptResult{}, nil
+			attemptChannelIDs = append(attemptChannelIDs, input.Selected.Channel.ID)
+			if input.Selected.Channel.ID == 1 {
+				return AttemptResult{OK: false, Status: 401, RawErrorText: "unauthorized"}, nil
 			}
+			return AttemptResult{OK: true, Response: "ok-from-sibling"}, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.OK {
+		t.Fatalf("expected success on sibling, got reason=%s status=%d", result.Reason, result.Status)
+	}
+	if result.Response != "ok-from-sibling" {
+		t.Fatalf("response = %v", result.Response)
+	}
+	if refreshCalled {
+		t.Fatal("RefreshAuth should not have been called (nil)")
+	}
+	if len(attemptChannelIDs) != 2 || attemptChannelIDs[0] != 1 || attemptChannelIDs[1] != 2 {
+		t.Fatalf("attempt channels = %v, want [1 2]", attemptChannelIDs)
+	}
+	if len(excludeOnNext) != 1 || excludeOnNext[0] != 1 {
+		t.Fatalf("exclude on failover = %v, want [1]", excludeOnNext)
+	}
+	if result.Attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", result.Attempts)
+	}
+}
+
+func TestConductor_401RefreshAuthErrorFailsOver(t *testing.T) {
+	ch1 := conductorChannel(1)
+	ch2 := conductorChannel(2)
+	refreshCalls := 0
+
+	c := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: 3,
+		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			return ch1, nil
+		},
+		SelectNextChannel: func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			return ch2, nil
+		},
+		RefreshAuth: func(ctx context.Context, selected *routing.SelectedChannel, failureCtx struct {
+			Status       int
+			RawErrorText string
+		}) (*routing.SelectedChannel, error) {
+			refreshCalls++
+			return nil, errors.New("refresh failed")
+		},
+	})
+
+	var attemptIDs []int64
+	result, err := c.Execute(context.Background(), ExecuteInput{
+		RequestedModel: "gpt-4",
+		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
+			attemptIDs = append(attemptIDs, input.Selected.Channel.ID)
+			if input.Selected.Channel.ID == 1 {
+				return AttemptResult{OK: false, Status: 403, RawErrorText: "forbidden"}, nil
+			}
+			return AttemptResult{OK: true, Response: "sibling"}, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.OK {
+		t.Fatalf("expected sibling success, got %+v", result)
+	}
+	if refreshCalls != 1 {
+		t.Fatalf("refreshCalls = %d, want 1", refreshCalls)
+	}
+	if len(attemptIDs) != 2 || attemptIDs[0] != 1 || attemptIDs[1] != 2 {
+		t.Fatalf("attemptIDs = %v, want [1 2]", attemptIDs)
+	}
+}
+
+func TestConductor_RefreshAuthSuccessCappedThenFailover(t *testing.T) {
+	ch1 := conductorChannel(1)
+	ch2 := conductorChannel(2)
+	refreshCalls := 0
+	var attemptIDs []int64
+
+	c := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts:             5,
+		MaxRefreshAuthSuccesses: 1,
+		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			return ch1, nil
+		},
+		SelectNextChannel: func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			if len(excludeChannelIDs) == 0 || excludeChannelIDs[len(excludeChannelIDs)-1] != 1 {
+				t.Fatalf("expected channel 1 excluded, got %v", excludeChannelIDs)
+			}
+			return ch2, nil
+		},
+		RefreshAuth: func(ctx context.Context, selected *routing.SelectedChannel, failureCtx struct {
+			Status       int
+			RawErrorText string
+		}) (*routing.SelectedChannel, error) {
+			refreshCalls++
+			// Return same channel with "refreshed" token semantics.
+			return selected, nil
+		},
+	})
+
+	result, err := c.Execute(context.Background(), ExecuteInput{
+		RequestedModel: "gpt-4",
+		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
+			attemptIDs = append(attemptIDs, input.Selected.Channel.ID)
+			// Channel 1 always 401; channel 2 succeeds.
+			if input.Selected.Channel.ID == 1 {
+				return AttemptResult{OK: false, Status: 401, RawErrorText: "unauthorized"}, nil
+			}
+			return AttemptResult{OK: true, Response: "ok"}, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.OK {
+		t.Fatalf("expected success, got %+v", result)
+	}
+	// First 401 → refresh once → second 401 → refresh cap → failover to ch2 → success.
+	if refreshCalls != 1 {
+		t.Fatalf("refreshCalls = %d, want 1 (capped)", refreshCalls)
+	}
+	if len(attemptIDs) != 3 || attemptIDs[0] != 1 || attemptIDs[1] != 1 || attemptIDs[2] != 2 {
+		t.Fatalf("attemptIDs = %v, want [1 1 2]", attemptIDs)
+	}
+	if result.Attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", result.Attempts)
+	}
+}
+
+func TestConductor_SameChannelRetryRespectsBudget(t *testing.T) {
+	ch1 := conductorChannel(1)
+	nextCalls := 0
+	attemptCalls := 0
+
+	c := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: 2,
+		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			return ch1, nil
+		},
+		SelectNextChannel: func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			nextCalls++
+			return conductorChannel(2), nil
+		},
+	})
+
+	result, err := c.Execute(context.Background(), ExecuteInput{
+		RequestedModel: "gpt-4",
+		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
+			attemptCalls++
+			// 408 with retryable classification → same-channel retry until budget.
+			return AttemptResult{OK: false, Status: 408, RawErrorText: "request timed out"}, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.OK || result.Reason != "failed" {
+		t.Fatalf("expected budget-exhausted failure, got %+v", result)
+	}
+	if result.Attempts != 2 || attemptCalls != 2 {
+		t.Fatalf("attempts=%d attemptCalls=%d, want 2", result.Attempts, attemptCalls)
+	}
+	if nextCalls != 0 {
+		t.Fatalf("same-channel path should not failover before budget stop, nextCalls=%d", nextCalls)
+	}
+	if result.Status != 408 {
+		t.Fatalf("status = %d, want 408", result.Status)
+	}
+}
+
+func TestConductor_TerminalDoesNotFailover(t *testing.T) {
+	ch1 := conductorChannel(1)
+	nextCalls := 0
+
+	c := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: 5,
+		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			return ch1, nil
+		},
+		SelectNextChannel: func(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			nextCalls++
+			return conductorChannel(2), nil
+		},
+	})
+
+	result, err := c.Execute(context.Background(), ExecuteInput{
+		RequestedModel: "gpt-4",
+		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
+			return AttemptResult{OK: false, Status: 400, RawErrorText: "bad request"}, nil
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Reason != "terminal" {
+		t.Fatalf("reason = %q, want terminal", result.Reason)
+	}
+	if nextCalls != 0 {
+		t.Fatalf("terminal must not failover, nextCalls=%d", nextCalls)
+	}
+	if result.Attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", result.Attempts)
+	}
+}
+
+func TestConductor_NoChannel(t *testing.T) {
+	c := NewDefaultProxyConductor(ConductorDependencies{
+		MaxAttempts: 3,
+		SelectChannel: func(ctx context.Context, requestedModel string, policy routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+			return nil, nil
+		},
+	})
+	result, err := c.Execute(context.Background(), ExecuteInput{
+		RequestedModel: "gpt-4",
+		Attempt: func(ctx context.Context, input AttemptInput) (AttemptResult, error) {
+			t.Fatal("Attempt should not be called")
+			return AttemptResult{}, nil
 		},
 	})
 	if err != nil {
-		t.Fatalf("Execute: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !result.OK || result.Selected == nil || result.Selected.Channel.ID != 403 {
-		t.Fatalf("expected success on channel 403, got ok=%v selected=%+v", result.OK, result.Selected)
-	}
-	if len(excludeSnapshots) != 2 {
-		t.Fatalf("expected 2 SelectNextChannel calls, got %d", len(excludeSnapshots))
-	}
-	if result.Attempts != 3 {
-		t.Fatalf("expected 3 attempts, got %d", result.Attempts)
+	if result.Reason != "no_channel" || result.Attempts != 0 {
+		t.Fatalf("got %+v", result)
 	}
 }
 
-func TestAppendExcludedChannelID_ChannelScopedDedup(t *testing.T) {
-	got := appendExcludedChannelID(nil, 10)
-	got = appendExcludedChannelID(got, 10)
-	got = appendExcludedChannelID(got, 11)
-	got = appendExcludedChannelID(got, 0)
-	if len(got) != 2 || got[0] != 10 || got[1] != 11 {
-		t.Fatalf("expected [10,11], got %v", got)
+func TestNewDefaultProxyConductor_Defaults(t *testing.T) {
+	c := NewDefaultProxyConductor(ConductorDependencies{})
+	if c.maxAttempts != 1 {
+		// GetProxyMaxChannelAttempts(0) → 1
+		t.Fatalf("maxAttempts = %d, want 1", c.maxAttempts)
 	}
-}
+	if c.maxRefreshAuthSuccesses != DefaultMaxRefreshAuthSuccesses {
+		t.Fatalf("maxRefreshAuthSuccesses = %d, want %d", c.maxRefreshAuthSuccesses, DefaultMaxRefreshAuthSuccesses)
+	}
 
-func TestFailureActionOf_DoesNotPinRateLimitOnSameChannel(t *testing.T) {
-	if got := failureActionOf(AttemptResult{Status: 429, RawErrorText: "rate limit"}); got != ActionFailover {
-		t.Fatalf("429 want failover, got %s", got)
+	c2 := NewDefaultProxyConductor(ConductorDependencies{MaxAttempts: 7, MaxRefreshAuthSuccesses: 2})
+	if c2.maxAttempts != 7 {
+		t.Fatalf("maxAttempts = %d, want 7", c2.maxAttempts)
 	}
-	if got := failureActionOf(AttemptResult{Status: 408, RawErrorText: "request timed out"}); got != ActionRetrySameChannel {
-		t.Fatalf("timeout-like 408 want retry_same_channel, got %s", got)
-	}
-	if got := failureActionOf(AttemptResult{Status: 408, RawErrorText: ""}); got != ActionFailover {
-		t.Fatalf("bare 408 want failover, got %s", got)
-	}
-	if got := failureActionOf(AttemptResult{Status: 502, RawErrorText: "bad gateway"}); got != ActionFailover {
-		t.Fatalf("502 want failover, got %s", got)
-	}
-	if got := failureActionOf(AttemptResult{Status: 400, RawErrorText: "invalid request body"}); got != ActionTerminal {
-		t.Fatalf("400 want terminal, got %s", got)
+	if c2.maxRefreshAuthSuccesses != 2 {
+		t.Fatalf("maxRefreshAuthSuccesses = %d, want 2", c2.maxRefreshAuthSuccesses)
 	}
 }


### PR DESCRIPTION
## Summary
- Hard MaxAttempts budget across same-channel / refresh / failover
- Cap RefreshAuth successes then channel-scoped failover
- nil/error RefreshAuth → sibling failover (no silent stop)
- Clean branch onto current master (supersedes conflicted #429)

Closes #425