### PR TITLE
fix(security): wire RejectCrossOriginRedirect on OAuth + Telegram clients

### DIFF
--- a/service/notify/http_test.go
+++ b/service/notify/http_test.go
@@ -194,3 +194,36 @@ func TestTelegramRejectsOversizedResponseBody(t *testing.T) {
 		t.Fatalf("error = %q, want telegram response read failure", err)
 	}
 }
+
+func TestTelegramRejectsCrossOriginRedirect(t *testing.T) {
+	targetCalled := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(target.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/landing", http.StatusFound)
+	}))
+	t.Cleanup(source.Close)
+
+	err := (&TelegramChannel{}).Send(&config.Config{
+		TelegramEnabled:    true,
+		TelegramBotToken:   "bot-token",
+		TelegramChatId:     "123",
+		TelegramApiBaseUrl: source.URL,
+	}, "title", "message", "info", "time")
+	if err == nil {
+		t.Fatal("expected cross-origin telegram redirect to fail")
+	}
+	if !strings.Contains(err.Error(), "telegram request failed") {
+		t.Fatalf("error = %q, want telegram request failure", err)
+	}
+	if !strings.Contains(err.Error(), "cross-origin") {
+		t.Fatalf("error = %q, want cross-origin", err)
+	}
+	if targetCalled {
+		t.Fatal("cross-origin redirect target was called")
+	}
+}

--- a/service/notify/telegram.go
+++ b/service/notify/telegram.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/platform"
 	"github.com/tokendancelab/metapi-go/service"
 )
 
@@ -45,13 +46,15 @@ func (c *TelegramChannel) Send(cfg *config.Config, title, message, level, timeFo
 
 	body, _ := json.Marshal(bodyMap)
 
-	// Use system proxy if configured
+	// Use system proxy if configured. Always reject cross-origin redirects so a
+	// compromised/misconfigured Telegram API base cannot SSRF via 302.
 	var client *http.Client
 	if cfg.TelegramUseSystemProxy && cfg.SystemProxyUrl != "" {
 		client = service.ProxyAwareHTTPClient(cfg.SystemProxyUrl, 30*time.Second)
 	} else {
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
+	client.CheckRedirect = platform.RejectCrossOriginRedirect
 
 	resp, err := client.Post(reqURL, "application/json", strings.NewReader(string(body)))
 	if err != nil {

--- a/service/oauth/codex.go
+++ b/service/oauth/codex.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/tokendancelab/metapi-go/config"
+	"github.com/tokendancelab/metapi-go/platform"
 )
 
 const (
@@ -339,8 +340,9 @@ func doHTTP(req *http.Request, proxyURL *string, client *http.Client) (*http.Res
 
 func newOAuthHTTPClient(proxy func(*http.Request) (*url.URL, error)) *http.Client {
 	return &http.Client{
-		Transport: newOAuthHTTPTransport(proxy),
-		Timeout:   30 * time.Second,
+		Transport:     newOAuthHTTPTransport(proxy),
+		Timeout:       30 * time.Second,
+		CheckRedirect: platform.RejectCrossOriginRedirect,
 	}
 }
 

--- a/service/oauth/http_test.go
+++ b/service/oauth/http_test.go
@@ -92,3 +92,42 @@ func TestDoHTTPIgnoresEnvironmentProxyWithoutProxyURL(t *testing.T) {
 		t.Fatal("doHTTP without proxy URL used HTTP_PROXY from environment")
 	}
 }
+
+func TestOAuthHTTPClientRejectsCrossOriginRedirect(t *testing.T) {
+	targetCalled := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(target.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/landing", http.StatusFound)
+	}))
+	t.Cleanup(source.Close)
+
+	req, err := http.NewRequest(http.MethodGet, source.URL+"/oauth/token", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := doHTTP(req, nil, nil)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("cross-origin redirect was allowed")
+	}
+	if !strings.Contains(err.Error(), "cross-origin") {
+		t.Fatalf("error = %v, want cross-origin", err)
+	}
+	if targetCalled {
+		t.Fatal("cross-origin redirect target was called")
+	}
+}
+
+func TestNewOAuthHTTPClientWiresCheckRedirect(t *testing.T) {
+	client := newOAuthHTTPClient(nil)
+	if client.CheckRedirect == nil {
+		t.Fatal("newOAuthHTTPClient must set CheckRedirect")
+	}
+}


### PR DESCRIPTION
## Summary
- Wire `platform.RejectCrossOriginRedirect` on residual bare clients left after #357/#416:
  - `service/oauth/codex.go` `newOAuthHTTPClient`
  - `service/notify/telegram.go` direct/system-proxy Telegram HTTP clients
- Add regression tests that a public-origin 302 to a different host is rejected and the target is never dialed.

Closes #433

## Test plan
- [x] `go test ./service/oauth ./service/notify ./platform -count=1 -run 'Redirect|OAuth|Telegram|Client|CrossOrigin|HTTP'`