### PR TITLE
fix(routing): source route model_pattern fallback for blank SourceModel

### DIFF
--- a/routing/selector.go
+++ b/routing/selector.go
@@ -623,27 +623,32 @@ func (s *ChannelSelector) loadRouteMatch(ctx context.Context, route store.TokenR
 		}
 	}
 
-	// Resolve source model fallback
-	fallbackSourceModelByRouteID := make(map[int64]string)
-	for _, rID := range routeIDs {
-		// We'd need route details here; for simplicity, use model pattern
-		// In a real implementation, load the source route's model pattern
-		fallbackSourceModelByRouteID[rID] = "" // Will be resolved from the route
+	// Resolve source-model fallback from each channel's route model_pattern.
+	// Group routes expand to source route IDs; blank channel SourceModel
+	// must inherit that source route's pattern for eligibility/resolveModel.
+	fallbackSourceModelByRouteID, err := s.loadFallbackSourceModelByRouteID(ctx, route, routeIDs)
+	if err != nil {
+		return nil, err
 	}
 
 	candidates := make([]RouteChannelCandidate, 0, len(joined))
 	for _, j := range joined {
-		sourceModel := j.Channel.SourceModel
-		// Fallback source model resolution
-		resolvedSourceModel := NormalizeChannelSourceModel(sourceModel)
+		channel := j.Channel
+		resolvedSourceModel := NormalizeChannelSourceModel(channel.SourceModel)
 		if resolvedSourceModel == "" {
-			if fb, ok := fallbackSourceModelByRouteID[j.Channel.RouteID]; ok && fb != "" {
+			if fb, ok := fallbackSourceModelByRouteID[channel.RouteID]; ok && fb != "" {
 				resolvedSourceModel = fb
 			}
 		}
+		if resolvedSourceModel != "" {
+			sm := resolvedSourceModel
+			channel.SourceModel = &sm
+		} else {
+			channel.SourceModel = nil
+		}
 
 		candidate := RouteChannelCandidate{
-			Channel: j.Channel,
+			Channel: channel,
 			Account: j.Account,
 			Site:    j.Site,
 			Token:   j.Token,
@@ -659,7 +664,6 @@ func (s *ChannelSelector) loadRouteMatch(ctx context.Context, route store.TokenR
 			}
 		}
 
-		_ = resolvedSourceModel
 		candidates = append(candidates, candidate)
 	}
 
@@ -669,6 +673,47 @@ func (s *ChannelSelector) loadRouteMatch(ctx context.Context, route store.TokenR
 	}
 	s.cache.SetMatch(route.ID, match)
 	return match, nil
+}
+
+// loadFallbackSourceModelByRouteID maps route IDs to model_pattern values used when
+// a channel's SourceModel is nil/empty. For group routes this is each source route's
+// pattern; for normal routes it is the matched route itself.
+func (s *ChannelSelector) loadFallbackSourceModelByRouteID(ctx context.Context, route store.TokenRoute, routeIDs []int64) (map[int64]string, error) {
+	fallback := make(map[int64]string, len(routeIDs))
+	if len(routeIDs) == 0 {
+		return fallback, nil
+	}
+
+	// Fast path: non-group routes only expand to themselves.
+	if len(routeIDs) == 1 && routeIDs[0] == route.ID {
+		pattern := strings.TrimSpace(route.ModelPattern)
+		if pattern != "" {
+			fallback[route.ID] = pattern
+		}
+		return fallback, nil
+	}
+
+	// Load enabled routes and map model patterns for every source route ID.
+	routes, err := s.db.LoadEnabledRoutes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loadRouteMatch: load source route patterns: %w", err)
+	}
+	byID := make(map[int64]store.TokenRoute, len(routes)+1)
+	for _, r := range routes {
+		byID[r.ID] = r
+	}
+	// Always include the matched route in case it is a group or not in the enabled list shape used above.
+	byID[route.ID] = route
+
+	for _, rID := range routeIDs {
+		if r, ok := byID[rID]; ok {
+			pattern := strings.TrimSpace(r.ModelPattern)
+			if pattern != "" {
+				fallback[rID] = pattern
+			}
+		}
+	}
+	return fallback, nil
 }
 
 func (s *ChannelSelector) getCandidateEligibilityReasons(

--- a/routing/selector_source_model_fallback_test.go
+++ b/routing/selector_source_model_fallback_test.go
@@ -1,0 +1,260 @@
+package routing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tokendancelab/metapi-go/store"
+)
+
+// sourceModelFallbackDB is a minimal ChannelSelectorDB for loadRouteMatch source-model fallback.
+type sourceModelFallbackDB struct {
+	routes   []store.TokenRoute
+	sources  map[int64][]int64
+	channels []struct {
+		Channel store.RouteChannel
+		Account store.Account
+		Site    store.Site
+		Token   *store.AccountToken
+	}
+}
+
+func (db *sourceModelFallbackDB) LoadEnabledRoutes(ctx context.Context) ([]store.TokenRoute, error) {
+	out := make([]store.TokenRoute, 0, len(db.routes))
+	for _, r := range db.routes {
+		if r.Enabled {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func (db *sourceModelFallbackDB) LoadRouteGroupSources(ctx context.Context, groupRouteIDs []int64) (map[int64][]int64, error) {
+	result := make(map[int64][]int64)
+	for _, id := range groupRouteIDs {
+		if ids, ok := db.sources[id]; ok {
+			cp := append([]int64(nil), ids...)
+			result[id] = cp
+		}
+	}
+	return result, nil
+}
+
+func (db *sourceModelFallbackDB) LoadRouteChannels(ctx context.Context, routeIDs []int64) ([]struct {
+	Channel store.RouteChannel
+	Account store.Account
+	Site    store.Site
+	Token   *store.AccountToken
+}, error) {
+	allow := make(map[int64]bool, len(routeIDs))
+	for _, id := range routeIDs {
+		allow[id] = true
+	}
+	var out []struct {
+		Channel store.RouteChannel
+		Account store.Account
+		Site    store.Site
+		Token   *store.AccountToken
+	}
+	for _, row := range db.channels {
+		if allow[row.Channel.RouteID] {
+			out = append(out, row)
+		}
+	}
+	return out, nil
+}
+
+func (db *sourceModelFallbackDB) LoadOAuthRouteUnitSummaries(ctx context.Context, unitIDs []int64) (map[int64]OAuthRouteUnitSummary, error) {
+	return map[int64]OAuthRouteUnitSummary{}, nil
+}
+func (db *sourceModelFallbackDB) LoadOAuthRouteUnitMembers(ctx context.Context, unitIDs []int64) (map[int64][]OAuthRouteUnitMemberCandidate, error) {
+	return map[int64][]OAuthRouteUnitMemberCandidate{}, nil
+}
+func (db *sourceModelFallbackDB) UpdateChannelLastSelectedAt(ctx context.Context, channelID int64, lastSelectedAt string) error {
+	return nil
+}
+func (db *sourceModelFallbackDB) UpdateRouteUnitMemberLastSelectedAt(ctx context.Context, unitID, accountID int64, lastSelectedAt string) error {
+	return nil
+}
+func (db *sourceModelFallbackDB) FindRouteIDsByOAuthRouteUnitID(ctx context.Context, unitID int64) ([]int64, error) {
+	return nil, nil
+}
+func (db *sourceModelFallbackDB) LoadCredentialScopedChannelIDs(ctx context.Context, channel store.RouteChannel, accountID int64) ([]int64, error) {
+	return []int64{channel.ID}, nil
+}
+func (db *sourceModelFallbackDB) LoadChannelWithAccount(ctx context.Context, channelID int64) (*struct {
+	Channel store.RouteChannel
+	Account store.Account
+}, error) {
+	return nil, nil
+}
+func (db *sourceModelFallbackDB) LoadChannelWithAccountAndRoute(ctx context.Context, channelID int64) (*struct {
+	Channel store.RouteChannel
+	Account store.Account
+	Route   store.TokenRoute
+}, error) {
+	return nil, nil
+}
+func (db *sourceModelFallbackDB) UpdateChannelCooldownFields(ctx context.Context, channelIDs []int64, updates map[string]interface{}) error {
+	return nil
+}
+func (db *sourceModelFallbackDB) UpdateChannelSuccessFields(ctx context.Context, channelID int64, updates map[string]interface{}) error {
+	return nil
+}
+func (db *sourceModelFallbackDB) UpdateRouteUnitMemberCooldownFields(ctx context.Context, memberID int64, updates map[string]interface{}) error {
+	return nil
+}
+func (db *sourceModelFallbackDB) UpdateRouteUnitMemberSuccessFields(ctx context.Context, memberID int64, updates map[string]interface{}) error {
+	return nil
+}
+func (db *sourceModelFallbackDB) LoadRouteUnitMemberWithAccount(ctx context.Context, unitID, accountID int64) (*struct {
+	Member  store.OAuthRouteUnitMember
+	Account store.Account
+	Unit    store.OAuthRouteUnit
+}, error) {
+	return nil, nil
+}
+func (db *sourceModelFallbackDB) FindAllEnabledRoutes(ctx context.Context) ([]store.TokenRoute, error) {
+	return db.LoadEnabledRoutes(ctx)
+}
+func (db *sourceModelFallbackDB) LoadChannelsByTokenID(ctx context.Context, tokenID int64) ([]store.RouteChannel, error) {
+	return nil, nil
+}
+func (db *sourceModelFallbackDB) LoadChannelsByAccountIDWithoutToken(ctx context.Context, accountID int64) ([]store.RouteChannel, error) {
+	return nil, nil
+}
+func (db *sourceModelFallbackDB) LoadRuntimeHealthChannelRows(ctx context.Context, channelIDs []int64) ([]struct {
+	SiteID            int64
+	SourceModel       *string
+	RouteModelPattern string
+}, error) {
+	return nil, nil
+}
+func (db *sourceModelFallbackDB) ClearChannelFailureStates(ctx context.Context, channelIDs []int64) error {
+	return nil
+}
+
+func TestLoadRouteMatch_GroupRouteNilSourceModelGetsSourceRoutePattern(t *testing.T) {
+	displayName := "group-claude"
+	emptySource := ""
+	explicitSource := "claude-3-haiku"
+
+	groupRoute := store.TokenRoute{
+		ID:              100,
+		ModelPattern:    "group-claude",
+		DisplayName:     &displayName,
+		RouteMode:       "explicit_group",
+		RoutingStrategy: "weighted",
+		Enabled:         true,
+	}
+	sourceRouteA := store.TokenRoute{
+		ID:              10,
+		ModelPattern:    "claude-3-opus",
+		RouteMode:       "pattern",
+		RoutingStrategy: "weighted",
+		Enabled:         true,
+	}
+	sourceRouteB := store.TokenRoute{
+		ID:              20,
+		ModelPattern:    "claude-3-sonnet",
+		RouteMode:       "pattern",
+		RoutingStrategy: "weighted",
+		Enabled:         true,
+	}
+
+	token := store.AccountToken{ID: 1, AccountID: 1, Name: "default", Token: "tok-a", Enabled: true, IsDefault: true}
+	apiToken := "api-token-a"
+
+	db := &sourceModelFallbackDB{
+		routes: []store.TokenRoute{groupRoute, sourceRouteA, sourceRouteB},
+		sources: map[int64][]int64{
+			100: {10, 20},
+		},
+		channels: []struct {
+			Channel store.RouteChannel
+			Account store.Account
+			Site    store.Site
+			Token   *store.AccountToken
+		}{
+			{
+				// nil SourceModel → should fall back to source route pattern
+				Channel: store.RouteChannel{
+					ID: 1, RouteID: 10, AccountID: 1, TokenID: &token.ID,
+					SourceModel: nil, Priority: 0, Weight: 10, Enabled: true,
+				},
+				Account: store.Account{ID: 1, SiteID: 1, Status: "active", APIToken: &apiToken},
+				Site:    store.Site{ID: 1, Name: "site-a", Status: "active", GlobalWeight: 1},
+				Token:   &token,
+			},
+			{
+				// empty SourceModel → same fallback
+				Channel: store.RouteChannel{
+					ID: 2, RouteID: 20, AccountID: 2, TokenID: &token.ID,
+					SourceModel: &emptySource, Priority: 0, Weight: 10, Enabled: true,
+				},
+				Account: store.Account{ID: 2, SiteID: 1, Status: "active", APIToken: &apiToken},
+				Site:    store.Site{ID: 1, Name: "site-a", Status: "active", GlobalWeight: 1},
+				Token:   &token,
+			},
+			{
+				// explicit SourceModel must be preserved
+				Channel: store.RouteChannel{
+					ID: 3, RouteID: 10, AccountID: 3, TokenID: &token.ID,
+					SourceModel: &explicitSource, Priority: 0, Weight: 10, Enabled: true,
+				},
+				Account: store.Account{ID: 3, SiteID: 1, Status: "active", APIToken: &apiToken},
+				Site:    store.Site{ID: 1, Name: "site-a", Status: "active", GlobalWeight: 1},
+				Token:   &token,
+			},
+		},
+	}
+
+	selector := NewChannelSelector(db, NewRouteCache(60_000), 3600, defaultRoutingWeights(), nil, 1, nil)
+	match, err := selector.loadRouteMatch(context.Background(), groupRoute)
+	if err != nil {
+		t.Fatalf("loadRouteMatch: %v", err)
+	}
+	if match == nil {
+		t.Fatal("expected non-nil RouteMatch")
+	}
+	if len(match.Channels) != 3 {
+		t.Fatalf("expected 3 channels, got %d", len(match.Channels))
+	}
+
+	byID := make(map[int64]RouteChannelCandidate, len(match.Channels))
+	for _, c := range match.Channels {
+		byID[c.Channel.ID] = c
+	}
+
+	gotA := NormalizeChannelSourceModel(byID[1].Channel.SourceModel)
+	if gotA != "claude-3-opus" {
+		t.Fatalf("nil SourceModel channel: got %q, want source route pattern claude-3-opus", gotA)
+	}
+	gotB := NormalizeChannelSourceModel(byID[2].Channel.SourceModel)
+	if gotB != "claude-3-sonnet" {
+		t.Fatalf("empty SourceModel channel: got %q, want source route pattern claude-3-sonnet", gotB)
+	}
+	gotC := NormalizeChannelSourceModel(byID[3].Channel.SourceModel)
+	if gotC != "claude-3-haiku" {
+		t.Fatalf("explicit SourceModel channel: got %q, want claude-3-haiku (no overwrite)", gotC)
+	}
+}
+
+func TestLoadFallbackSourceModelByRouteID_NonGroupUsesRoutePattern(t *testing.T) {
+	route := store.TokenRoute{
+		ID:           7,
+		ModelPattern: "gpt-4o",
+		RouteMode:    "pattern",
+		Enabled:      true,
+	}
+	db := &sourceModelFallbackDB{routes: []store.TokenRoute{route}}
+	selector := NewChannelSelector(db, NewRouteCache(60_000), 3600, defaultRoutingWeights(), nil, 1, nil)
+
+	fallback, err := selector.loadFallbackSourceModelByRouteID(context.Background(), route, []int64{7})
+	if err != nil {
+		t.Fatalf("loadFallbackSourceModelByRouteID: %v", err)
+	}
+	if got := fallback[7]; got != "gpt-4o" {
+		t.Fatalf("fallback[7]=%q, want gpt-4o", got)
+	}
+}


### PR DESCRIPTION
## Summary
- `loadRouteMatch` now loads each expanded route ID's `model_pattern` into `fallbackSourceModelByRouteID` (group source routes + normal routes)
- Blank/nil channel `SourceModel` inherits that pattern so eligibility and resolveModel see the source model
- Explicit non-empty `SourceModel` is preserved

## Test plan
- [x] `go test ./routing -count=1 -run 'SourceModel|Fallback|Group|loadRoute|Match|Selector'`
- [x] `go test ./routing -count=1`
- [ ] CI

Closes #434