### PR TITLE
fix(service): wire RejectCrossOriginRedirect on ProxyAwareHTTPClient

### DIFF
--- a/service/proxy_util.go
+++ b/service/proxy_util.go
@@ -8,10 +8,16 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/tokendancelab/metapi-go/platform"
 )
 
 // ProxyAwareHTTPClient creates an *http.Client that optionally routes through a proxy.
 // If proxyURL is empty, returns a standard client.
+//
+// The client always wires platform.RejectCrossOriginRedirect so HTTPGet/HTTPPost
+// callers (and Telegram when it reuses this helper) cannot follow a public-origin
+// 302 onto a different host.
 func ProxyAwareHTTPClient(proxyURL string, timeout time.Duration) *http.Client {
 	transport := &http.Transport{
 		DialContext: (&net.Dialer{
@@ -31,8 +37,9 @@ func ProxyAwareHTTPClient(proxyURL string, timeout time.Duration) *http.Client {
 	}
 
 	return &http.Client{
-		Transport: transport,
-		Timeout:   timeout,
+		Transport:     transport,
+		Timeout:       timeout,
+		CheckRedirect: platform.RejectCrossOriginRedirect,
 	}
 }
 

--- a/service/proxy_util_test.go
+++ b/service/proxy_util_test.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProxyAwareHTTPClientWiresCheckRedirect(t *testing.T) {
+	client := ProxyAwareHTTPClient("", 5*time.Second)
+	if client.CheckRedirect == nil {
+		t.Fatal("ProxyAwareHTTPClient must set CheckRedirect")
+	}
+}
+
+func TestProxyAwareHTTPClientRejectsCrossOriginRedirect(t *testing.T) {
+	targetCalled := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(target.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/landing", http.StatusFound)
+	}))
+	t.Cleanup(source.Close)
+
+	client := ProxyAwareHTTPClient("", 5*time.Second)
+	resp, err := client.Get(source.URL + "/start")
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("cross-origin redirect was allowed")
+	}
+	if !strings.Contains(err.Error(), "cross-origin") {
+		t.Fatalf("error = %v, want cross-origin", err)
+	}
+	if targetCalled {
+		t.Fatal("cross-origin redirect target was called")
+	}
+}
+
+func TestHTTPGetRejectsCrossOriginRedirect(t *testing.T) {
+	targetCalled := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(target.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/landing", http.StatusFound)
+	}))
+	t.Cleanup(source.Close)
+
+	resp, err := HTTPGet(context.Background(), "", source.URL+"/start", nil)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("cross-origin redirect was allowed")
+	}
+	if !strings.Contains(err.Error(), "cross-origin") {
+		t.Fatalf("error = %v, want cross-origin", err)
+	}
+	if targetCalled {
+		t.Fatal("cross-origin redirect target was called")
+	}
+}


### PR DESCRIPTION
## Summary
- Wire `platform.RejectCrossOriginRedirect` on `service.ProxyAwareHTTPClient` so all `HTTPGet`/`HTTPPost`/`HTTPPostJSON` callers reject public-origin cross-host redirects by default.
- Add regression coverage: client rejects 302 to a different host and never dials the target.
- Telegram still assigns `CheckRedirect` after construction; that remains correct and now is idempotent with the helper default.

Closes #441

## Test plan
- [x] `go test ./service ./platform -count=1 -run 'ProxyAware|Redirect|CrossOrigin|HTTP|Client'`
- [x] `go test ./service -count=1 -run 'ProxyAware|HTTPGetRejects|CrossOrigin' -v`