### PR TITLE
fix(admin): reject metadata/link-local targetUrl on system-proxy/test

### DIFF
--- a/handler/admin/settings.go
+++ b/handler/admin/settings.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/tokendancelab/metapi-go/config"
 	"github.com/tokendancelab/metapi-go/platform"
+	"github.com/tokendancelab/metapi-go/service"
 )
 
 // RegisterSettingsRoutes registers all /api/settings routes (runtime, brand-list, system-proxy/test).
@@ -704,6 +705,15 @@ func (h *settingsHandler) testSystemProxy(w http.ResponseWriter, r *http.Request
 	target := "https://www.gstatic.com/generate_204"
 	if body.TargetUrl != nil && strings.TrimSpace(*body.TargetUrl) != "" {
 		target = strings.TrimSpace(*body.TargetUrl)
+		// Guard operator-supplied probe targets against non-http(s) and
+		// cloud metadata / link-local SSRF first-hops (#449).
+		if service.IsForbiddenSiteTargetURL(target) || !service.IsValidHTTPURL(target) {
+			writeJSON(w, http.StatusBadRequest, map[string]any{
+				"success": false,
+				"message": "Invalid targetUrl. Cloud metadata / link-local targets are not allowed; expected a valid http(s) URL.",
+			})
+			return
+		}
 	}
 
 	result := probeSystemProxy(r.Context(), proxyURL, target)

--- a/handler/admin/settings_proxy_test.go
+++ b/handler/admin/settings_proxy_test.go
@@ -28,7 +28,9 @@ func TestBrandList_FromRegistry(t *testing.T) {
 func TestSystemProxyTest_UsesProbe(t *testing.T) {
 	old := systemProxyProbeFn
 	t.Cleanup(func() { systemProxyProbeFn = old })
+	var gotTarget string
 	systemProxyProbeFn = func(ctx context.Context, proxyURL, target string) map[string]any {
+		gotTarget = target
 		return map[string]any{
 			"success": true, "proxyUrl": proxyURL, "targetUrl": target,
 			"reachable": true, "ok": true, "statusCode": 204, "latencyMs": 12,
@@ -48,5 +50,134 @@ func TestSystemProxyTest_UsesProbe(t *testing.T) {
 	_ = json.Unmarshal(rec.Body.Bytes(), &body)
 	if body["reachable"] != true {
 		t.Fatalf("body=%v", body)
+	}
+	if gotTarget != "https://www.gstatic.com/generate_204" {
+		t.Fatalf("default targetUrl=%q, want gstatic generate_204", gotTarget)
+	}
+}
+
+func TestSystemProxyTest_EmptyProxyURL(t *testing.T) {
+	old := systemProxyProbeFn
+	t.Cleanup(func() { systemProxyProbeFn = old })
+	called := false
+	systemProxyProbeFn = func(ctx context.Context, proxyURL, target string) map[string]any {
+		called = true
+		return map[string]any{"success": true}
+	}
+	_, r, cfg := setupEdgeTest(t)
+	cfg.SystemProxyUrl = ""
+	b, _ := json.Marshal(map[string]any{"proxyUrl": "  "})
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/system-proxy/test", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if called {
+		t.Fatal("probe must not run when proxy URL is empty")
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("请先填写系统代理地址")) {
+		t.Fatalf("body=%s", rec.Body.String())
+	}
+}
+
+func TestSystemProxyTest_RejectsForbiddenTargetURL(t *testing.T) {
+	old := systemProxyProbeFn
+	t.Cleanup(func() { systemProxyProbeFn = old })
+	called := false
+	systemProxyProbeFn = func(ctx context.Context, proxyURL, target string) map[string]any {
+		called = true
+		return map[string]any{"success": true, "targetUrl": target}
+	}
+
+	cases := []string{
+		"http://169.254.169.254/latest/meta-data",
+		"https://169.254.169.254/",
+		"http://metadata.google.internal/computeMetadata/v1/",
+		"not-a-url",
+		"ftp://example.com/",
+	}
+	_, r, cfg := setupEdgeTest(t)
+	cfg.SystemProxyUrl = "http://127.0.0.1:9"
+	for _, target := range cases {
+		called = false
+		b, _ := json.Marshal(map[string]any{
+			"proxyUrl":  "http://127.0.0.1:9",
+			"targetUrl": target,
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/settings/system-proxy/test", bytes.NewReader(b))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("target %q: status=%d body=%s", target, rec.Code, rec.Body.String())
+		}
+		if called {
+			t.Fatalf("target %q: probe must not be called", target)
+		}
+		if !bytes.Contains(rec.Body.Bytes(), []byte("Invalid targetUrl")) {
+			t.Fatalf("target %q: body=%s", target, rec.Body.String())
+		}
+	}
+}
+
+func TestSystemProxyTest_CustomSafeTargetURL(t *testing.T) {
+	old := systemProxyProbeFn
+	t.Cleanup(func() { systemProxyProbeFn = old })
+	var gotTarget string
+	systemProxyProbeFn = func(ctx context.Context, proxyURL, target string) map[string]any {
+		gotTarget = target
+		return map[string]any{
+			"success": true, "proxyUrl": proxyURL, "targetUrl": target,
+			"reachable": true, "ok": true, "statusCode": 204, "latencyMs": 3,
+		}
+	}
+	_, r, cfg := setupEdgeTest(t)
+	cfg.SystemProxyUrl = "http://127.0.0.1:9"
+	want := "https://example.com/healthz"
+	b, _ := json.Marshal(map[string]any{
+		"proxyUrl":  "http://127.0.0.1:9",
+		"targetUrl": want,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/system-proxy/test", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if gotTarget != want {
+		t.Fatalf("targetUrl=%q, want %q", gotTarget, want)
+	}
+}
+
+func TestSystemProxyTest_OmittedTargetUsesDefault(t *testing.T) {
+	old := systemProxyProbeFn
+	t.Cleanup(func() { systemProxyProbeFn = old })
+	var gotTarget string
+	systemProxyProbeFn = func(ctx context.Context, proxyURL, target string) map[string]any {
+		gotTarget = target
+		return map[string]any{
+			"success": true, "proxyUrl": proxyURL, "targetUrl": target,
+			"reachable": true, "ok": true, "statusCode": 204, "latencyMs": 1,
+		}
+	}
+	_, r, cfg := setupEdgeTest(t)
+	cfg.SystemProxyUrl = "http://127.0.0.1:9"
+	// Empty targetUrl must keep the default gstatic probe target.
+	b, _ := json.Marshal(map[string]any{
+		"proxyUrl":  "http://127.0.0.1:9",
+		"targetUrl": "   ",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/system-proxy/test", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if gotTarget != "https://www.gstatic.com/generate_204" {
+		t.Fatalf("empty targetUrl got %q", gotTarget)
 	}
 }


### PR DESCRIPTION
## Summary
- Guard `POST /api/settings/system-proxy/test` so non-empty `targetUrl` failing `service.IsValidHTTPURL` or matching `service.IsForbiddenSiteTargetURL` returns HTTP 400 and never calls the probe
- Keep empty/omitted `targetUrl` on the default `https://www.gstatic.com/generate_204` path
- Preserve existing empty proxy URL error path (`请先填写系统代理地址`)
- Regression coverage for `169.254.169.254`, `metadata.google.internal`, invalid schemes, happy-path mock probe, and default target

Closes #449

## Test plan
- [x] `go test ./handler/admin -count=1 -run 'SystemProxy|ProxyTest|Target|Settings'`
- [x] Forbidden metadata/link-local targets return 400 without probe
- [x] Empty/omitted target keeps gstatic default
- [x] Empty proxy URL still returns existing Chinese error message