### PR TITLE
fix(proxy): enforce max_output_tokens vs context_length on /v1/responses

### DIFF
--- a/handler/proxy/max_tokens.go
+++ b/handler/proxy/max_tokens.go
@@ -6,28 +6,38 @@ import (
 	"strings"
 )
 
-// maxTokensOverContextError is returned when body max_tokens exceeds a positive
-// route context_length. Callers must surface an honest 400 (no silent clamp).
+// maxTokensOverContextError is returned when body max_tokens / max_output_tokens
+// exceeds a positive route context_length. Callers must surface an honest 400
+// (no silent clamp).
 type maxTokensOverContextError struct {
 	MaxTokens     int64
 	ContextLength int64
+	// Field is the body key that exceeded the limit ("max_tokens" or
+	// "max_output_tokens") so error text matches the request dialect.
+	Field string
 }
 
 func (e maxTokensOverContextError) Error() string {
+	field := e.Field
+	if field == "" {
+		field = "max_tokens"
+	}
 	return fmt.Sprintf(
-		"max_tokens (%d) exceeds route context_length (%d)",
+		"%s (%d) exceeds route context_length (%d)",
+		field,
 		e.MaxTokens,
 		e.ContextLength,
 	)
 }
 
-// enforceMaxTokensAgainstContextLength rejects max_tokens above a positive
-// route context_length for OpenAI chat/completions-style and Anthropic messages bodies.
+// enforceMaxTokensAgainstContextLength rejects max_tokens / max_output_tokens
+// above a positive route context_length for OpenAI chat/completions-style,
+// Anthropic messages, and OpenAI Responses bodies.
 //
-// Policy (issue #399 / #409 / CTX-520):
+// Policy (issue #399 / #409 / #450 / CTX-520 residual):
 //   - enforce only when context_length > 0
-//   - enforce only when max_tokens is present and parseable as an integer
-//   - skip when max_tokens is omitted, null, or unparseable
+//   - enforce when max_output_tokens or max_tokens is present and parseable
+//   - skip when both fields are omitted, null, or unparseable
 //   - never silent-clamp or invent tokens
 //
 // Returns maxTokensOverContextError when the request must be rejected with 400.
@@ -36,18 +46,25 @@ func enforceMaxTokensAgainstContextLength(body map[string]any, contextLength *in
 	if !ok {
 		return nil
 	}
-	maxTokens, present := bodyMaxTokens(body)
+	// Prefer OpenAI Responses max_output_tokens when both are present; otherwise
+	// accept chat/messages max_tokens for parity.
+	maxTokens, field, present := bodyOutputTokenLimit(body)
 	if !present {
 		return nil
 	}
 	if maxTokens > limit {
-		return maxTokensOverContextError{MaxTokens: maxTokens, ContextLength: limit}
+		return maxTokensOverContextError{
+			MaxTokens:     maxTokens,
+			ContextLength: limit,
+			Field:         field,
+		}
 	}
 	return nil
 }
 
-// shouldEnforceMaxTokensOnPath is true for OpenAI chat/completions (+ legacy completions)
-// and Anthropic Claude /v1/messages (issue #409). count_tokens and other surfaces stay out.
+// shouldEnforceMaxTokensOnPath is true for OpenAI chat/completions (+ legacy
+// completions), Anthropic Claude /v1/messages (issue #409), and OpenAI
+// /v1/responses (+ /compact) (issue #450). count_tokens and other surfaces stay out.
 func shouldEnforceMaxTokensOnPath(downstreamPath string) bool {
 	p := strings.ToLower(strings.TrimSpace(downstreamPath))
 	switch {
@@ -56,6 +73,12 @@ func shouldEnforceMaxTokensOnPath(downstreamPath string) bool {
 	case p == "/v1/completions" || p == "/completions" || strings.HasSuffix(p, "/v1/completions"):
 		return true
 	case p == "/v1/messages" || p == "/messages" || strings.HasSuffix(p, "/v1/messages"):
+		return true
+	// OpenAI Responses (+ compact). Alias /responses is resolved to /v1/responses*
+	// before enforce; still accept suffix/alias-safe forms like the other matchers.
+	case p == "/v1/responses" || p == "/responses" || strings.HasSuffix(p, "/v1/responses"):
+		return true
+	case p == "/v1/responses/compact" || p == "/responses/compact" || strings.HasSuffix(p, "/v1/responses/compact") || strings.HasSuffix(p, "/responses/compact"):
 		return true
 	default:
 		return false
@@ -69,13 +92,36 @@ func positiveContextLength(contextLength *int64) (int64, bool) {
 	return *contextLength, true
 }
 
+// bodyOutputTokenLimit extracts a parseable output-token cap from the body.
+// OpenAI Responses uses max_output_tokens; chat/completions and Claude messages
+// use max_tokens. When both are present, max_output_tokens wins (Responses dialect).
+// Missing / null / empty / non-numeric → not present.
+func bodyOutputTokenLimit(body map[string]any) (value int64, field string, present bool) {
+	if body == nil {
+		return 0, "", false
+	}
+	if n, ok := parseBodyTokenField(body, "max_output_tokens"); ok {
+		return n, "max_output_tokens", true
+	}
+	if n, ok := parseBodyTokenField(body, "max_tokens"); ok {
+		return n, "max_tokens", true
+	}
+	return 0, "", false
+}
+
 // bodyMaxTokens extracts body["max_tokens"] when present as a finite whole number
 // or numeric string. Missing / null / empty / non-numeric → not present.
+// Kept for callers/tests that only care about the chat/messages field.
 func bodyMaxTokens(body map[string]any) (int64, bool) {
+	return parseBodyTokenField(body, "max_tokens")
+}
+
+// parseBodyTokenField reads body[key] as a finite whole number or numeric string.
+func parseBodyTokenField(body map[string]any, key string) (int64, bool) {
 	if body == nil {
 		return 0, false
 	}
-	raw, ok := body["max_tokens"]
+	raw, ok := body[key]
 	if !ok || raw == nil {
 		return 0, false
 	}

--- a/handler/proxy/max_tokens_test.go
+++ b/handler/proxy/max_tokens_test.go
@@ -23,6 +23,7 @@ func TestEnforceMaxTokensAgainstContextLength(t *testing.T) {
 		wantErr       bool
 		wantMax       int64
 		wantLimit     int64
+		wantField     string
 	}{
 		{
 			name:          "over limit rejects",
@@ -102,6 +103,84 @@ func TestEnforceMaxTokensAgainstContextLength(t *testing.T) {
 			contextLength: ptrInt64(10),
 			wantErr:       false,
 		},
+		// OpenAI Responses max_output_tokens (issue #450)
+		{
+			name:          "max_output_tokens over limit rejects",
+			body:          map[string]any{"max_output_tokens": float64(9000)},
+			contextLength: ptrInt64(8192),
+			wantErr:       true,
+			wantMax:       9000,
+			wantLimit:     8192,
+			wantField:     "max_output_tokens",
+		},
+		{
+			name:          "max_output_tokens equal limit passes",
+			body:          map[string]any{"max_output_tokens": float64(8192)},
+			contextLength: ptrInt64(8192),
+			wantErr:       false,
+		},
+		{
+			name:          "max_output_tokens under limit passes",
+			body:          map[string]any{"max_output_tokens": float64(100)},
+			contextLength: ptrInt64(8192),
+			wantErr:       false,
+		},
+		{
+			name:          "null max_output_tokens skips",
+			body:          map[string]any{"max_output_tokens": nil},
+			contextLength: ptrInt64(100),
+			wantErr:       false,
+		},
+		{
+			name:          "unparseable max_output_tokens skips",
+			body:          map[string]any{"max_output_tokens": "lots"},
+			contextLength: ptrInt64(100),
+			wantErr:       false,
+		},
+		{
+			name:          "string max_output_tokens over limit rejects",
+			body:          map[string]any{"max_output_tokens": "200"},
+			contextLength: ptrInt64(100),
+			wantErr:       true,
+			wantMax:       200,
+			wantLimit:     100,
+			wantField:     "max_output_tokens",
+		},
+		{
+			name: "max_output_tokens preferred when both present",
+			body: map[string]any{
+				"max_output_tokens": float64(9000),
+				"max_tokens":        float64(50), // under limit; must not mask over-limit output tokens
+			},
+			contextLength: ptrInt64(8192),
+			wantErr:       true,
+			wantMax:       9000,
+			wantLimit:     8192,
+			wantField:     "max_output_tokens",
+		},
+		{
+			name: "max_tokens used when max_output_tokens omitted",
+			body: map[string]any{
+				"max_tokens": float64(9000),
+			},
+			contextLength: ptrInt64(8192),
+			wantErr:       true,
+			wantMax:       9000,
+			wantLimit:     8192,
+			wantField:     "max_tokens",
+		},
+		{
+			name: "unparseable max_output_tokens falls back to max_tokens",
+			body: map[string]any{
+				"max_output_tokens": "nope",
+				"max_tokens":        float64(200),
+			},
+			contextLength: ptrInt64(100),
+			wantErr:       true,
+			wantMax:       200,
+			wantLimit:     100,
+			wantField:     "max_tokens",
+		},
 	}
 
 	for _, tt := range tests {
@@ -120,8 +199,15 @@ func TestEnforceMaxTokensAgainstContextLength(t *testing.T) {
 				if mtErr.MaxTokens != tt.wantMax || mtErr.ContextLength != tt.wantLimit {
 					t.Fatalf("err fields = %+v, want max=%d limit=%d", mtErr, tt.wantMax, tt.wantLimit)
 				}
-				if !strings.Contains(err.Error(), "max_tokens") || !strings.Contains(err.Error(), "context_length") {
-					t.Fatalf("error message = %q, want clear max_tokens/context_length wording", err.Error())
+				wantField := tt.wantField
+				if wantField == "" {
+					wantField = "max_tokens"
+				}
+				if !strings.Contains(err.Error(), wantField) || !strings.Contains(err.Error(), "context_length") {
+					t.Fatalf("error message = %q, want clear %s/context_length wording", err.Error(), wantField)
+				}
+				if mtErr.Field != "" && mtErr.Field != wantField {
+					t.Fatalf("err.Field = %q, want %q", mtErr.Field, wantField)
 				}
 				return
 			}
@@ -154,7 +240,12 @@ func TestShouldEnforceMaxTokensOnPath(t *testing.T) {
 		"/v1/messages":                     true,
 		"/messages":                        true,
 		"/v1/messages/count_tokens":        false,
-		"/v1/responses":                    false,
+		"/v1/responses":                    true,
+		"/responses":                       true,
+		"/v1/responses/compact":            true,
+		"/responses/compact":               true,
+		"/openai/v1/responses":             true,
+		"/openai/v1/responses/compact":     true,
 		"/v1/embeddings":                   false,
 		"/v1beta/models/x:generateContent": false,
 		"":                                 false,
@@ -552,6 +643,318 @@ func TestClaudeMessages_ZeroContextLengthDoesNotEnforce(t *testing.T) {
 		`{"model":"claude-sonnet-4-20250514","max_tokens":999999,"messages":[{"role":"user","content":"hi"}]}`)
 	rec := httptest.NewRecorder()
 	HandleClaudeMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
+	}
+}
+
+func TestBodyOutputTokenLimit(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		body        map[string]any
+		wantValue   int64
+		wantField   string
+		wantPresent bool
+	}{
+		{
+			name:        "max_output_tokens present",
+			body:        map[string]any{"max_output_tokens": float64(128)},
+			wantValue:   128,
+			wantField:   "max_output_tokens",
+			wantPresent: true,
+		},
+		{
+			name:        "max_tokens present",
+			body:        map[string]any{"max_tokens": float64(64)},
+			wantValue:   64,
+			wantField:   "max_tokens",
+			wantPresent: true,
+		},
+		{
+			name: "prefer max_output_tokens",
+			body: map[string]any{
+				"max_output_tokens": float64(10),
+				"max_tokens":        float64(99),
+			},
+			wantValue:   10,
+			wantField:   "max_output_tokens",
+			wantPresent: true,
+		},
+		{
+			name:        "omitted skips",
+			body:        map[string]any{"model": "gpt-4o"},
+			wantPresent: false,
+		},
+		{
+			name:        "null max_output_tokens skips",
+			body:        map[string]any{"max_output_tokens": nil},
+			wantPresent: false,
+		},
+		{
+			name:        "unparseable max_output_tokens skips",
+			body:        map[string]any{"max_output_tokens": "nope"},
+			wantPresent: false,
+		},
+		{
+			name: "fallback to max_tokens when max_output_tokens unparseable",
+			body: map[string]any{
+				"max_output_tokens": "nope",
+				"max_tokens":        float64(42),
+			},
+			wantValue:   42,
+			wantField:   "max_tokens",
+			wantPresent: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, field, present := bodyOutputTokenLimit(tt.body)
+			if present != tt.wantPresent {
+				t.Fatalf("present = %v, want %v (got=%d field=%q)", present, tt.wantPresent, got, field)
+			}
+			if !tt.wantPresent {
+				return
+			}
+			if got != tt.wantValue || field != tt.wantField {
+				t.Fatalf("got (%d, %q), want (%d, %q)", got, field, tt.wantValue, tt.wantField)
+			}
+		})
+	}
+}
+
+func TestResponses_MaxOutputTokensOverContextLengthReturns400(t *testing.T) {
+	// Issue #450: OpenAI /v1/responses must reject max_output_tokens above positive route context_length.
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"should-not-reach"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(1024)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gpt-4o",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/responses",
+		`{"model":"gpt-4o","max_output_tokens":2048,"input":"hi"}`)
+	rec := httptest.NewRecorder()
+	HandleResponses(rec, req, "/v1/responses")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "max_output_tokens") || !strings.Contains(body, "context_length") {
+		t.Fatalf("body = %q, want clear max_output_tokens/context_length error", body)
+	}
+	if !strings.Contains(body, "invalid_request_error") {
+		t.Fatalf("body = %q, want invalid_request_error", body)
+	}
+	if upstreamHits != 0 {
+		t.Fatalf("upstream was called %d times; expected 0 (must not silent-forward)", upstreamHits)
+	}
+}
+
+func TestResponses_MaxTokensOverContextLengthReturns400(t *testing.T) {
+	// Parity: accept max_tokens on /v1/responses as well.
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"should-not-reach"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(512)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gpt-4o",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/responses",
+		`{"model":"gpt-4o","max_tokens":1024,"input":"hi"}`)
+	rec := httptest.NewRecorder()
+	HandleResponses(rec, req, "/v1/responses")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "max_tokens") {
+		t.Fatalf("body = %q, want max_tokens field in error", rec.Body.String())
+	}
+	if upstreamHits != 0 {
+		t.Fatalf("upstream was called; expected rejection before forward")
+	}
+}
+
+func TestResponsesCompact_MaxOutputTokensOverContextLengthReturns400(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"should-not-reach"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(256)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gpt-4o",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/responses/compact",
+		`{"model":"gpt-4o","max_output_tokens":512,"input":"hi"}`)
+	rec := httptest.NewRecorder()
+	HandleResponses(rec, req, "/v1/responses/compact")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "max_output_tokens") {
+		t.Fatalf("body = %q, want max_output_tokens wording", rec.Body.String())
+	}
+	if upstreamHits != 0 {
+		t.Fatalf("upstream was called; expected rejection before forward")
+	}
+}
+
+func TestResponses_MaxOutputTokensAtContextLengthPassesThrough(t *testing.T) {
+	upstreamHits := 0
+	var sawMaxOutput any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		var payload map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		sawMaxOutput = payload["max_output_tokens"]
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"resp_ok","object":"response","status":"completed"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(2048)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gpt-4o",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/responses",
+		`{"model":"gpt-4o","max_output_tokens":2048,"input":"hi"}`)
+	rec := httptest.NewRecorder()
+	HandleResponses(rec, req, "/v1/responses")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
+	}
+	// No silent clamp: original max_output_tokens must be forwarded unchanged.
+	if sawMaxOutput != float64(2048) {
+		t.Fatalf("upstream max_output_tokens = %v (%T), want 2048 (no clamp)", sawMaxOutput, sawMaxOutput)
+	}
+}
+
+func TestResponses_OmittedMaxOutputTokensDoesNotEnforce(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"resp_ok","object":"response","status":"completed"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(128)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gpt-4o",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/responses",
+		`{"model":"gpt-4o","input":"hi"}`)
+	rec := httptest.NewRecorder()
+	HandleResponses(rec, req, "/v1/responses")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
+	}
+}
+
+func TestResponses_NoContextLengthDoesNotEnforce(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"resp_ok","object":"response","status":"completed"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:     store.RouteChannel{ID: 1, Enabled: true},
+			Account:     store.Account{ID: 1, Status: "active"},
+			Site:        store.Site{ID: 1, URL: upstream.URL, Status: "active"},
+			TokenValue:  "upstream-token",
+			ActualModel: "gpt-4o",
+			// ContextLength nil → no enforce
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/responses",
+		`{"model":"gpt-4o","max_output_tokens":999999,"input":"hi"}`)
+	rec := httptest.NewRecorder()
+	HandleResponses(rec, req, "/v1/responses")
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -210,10 +210,12 @@ func dispatchSelectedUpstream(
 	if requestID == "" {
 		requestID = proxy.RequestIDFromContext(r.Context())
 	}
-	// Optional max_tokens vs route context_length (issue #399 / #409 / CTX-520).
-	// Enforce on OpenAI chat/completions (+ legacy completions) and Anthropic
-	// /v1/messages when the selected route publishes a positive context_length
-	// and the body includes max_tokens above that limit. Never silent-clamp.
+	// Optional max_tokens / max_output_tokens vs route context_length
+	// (issue #399 / #409 / #450 / CTX-520 residual). Enforce on OpenAI
+	// chat/completions (+ legacy completions), Anthropic /v1/messages, and
+	// OpenAI /v1/responses (+ /compact) when the selected route publishes a
+	// positive context_length and the body includes a parseable token cap
+	// above that limit. Never silent-clamp.
 	if ctx != nil && selected != nil && shouldEnforceMaxTokensOnPath(upstreamPath) {
 		if err := enforceMaxTokensAgainstContextLength(ctx.Body, selected.ContextLength); err != nil {
 			writeJSONErrorWithRequest(w, http.StatusBadRequest, err.Error(), "invalid_request_error", requestID)


### PR DESCRIPTION
## Summary
- Extend `shouldEnforceMaxTokensOnPath` to OpenAI `/v1/responses` and `/v1/responses/compact` (suffix/alias-safe, same style as existing matchers).
- Enforce parseable body `max_output_tokens` **or** `max_tokens` against positive route `context_length`; over-limit returns honest `400 invalid_request_error` via `maxTokensOverContextError` (no silent clamp).
- Omitted / null / unparseable fields skip (parity with chat/messages policy). Prefer `max_output_tokens` when both are present.
- Unit + integration tests for path match, field extract, reject/skip/pass-through.

Closes #450

## Notes / residual honesty
- This is a **CTX-520 residual slice** only: Responses dialect.
- Does **not** claim all-dialect CTX-520 done (Gemini `generationConfig` residual stays open).
- Does not invent Responses WS product.

## Test plan
- [x] `go test ./handler/proxy -count=1 -run 'MaxTokens|Responses|Context|OutputTokens'`
- [ ] CI green on PR