### PR TITLE
feat(ui): wire Sites maxConcurrency create/edit/list (#457)

### DIFF
--- a/web/pages/Sites.tsx
+++ b/web/pages/Sites.tsx
@@ -29,6 +29,8 @@ import {
   emptySiteApiEndpoint,
   emptySiteCustomHeader,
   emptySiteForm,
+  formatSiteMaxConcurrency,
+  parseSiteMaxConcurrency,
   serializeSiteApiEndpoints,
   serializeSiteCustomHeaders,
   siteFormFromSite,
@@ -64,6 +66,8 @@ type SiteRow = {
   useSystemProxy?: boolean;
   customHeaders?: string | null;
   globalWeight?: number;
+  /** Caps concurrent upstream calls (0 = unlimited). */
+  maxConcurrency?: number;
   isPinned?: boolean;
   sortOrder?: number;
   totalBalance?: number;
@@ -746,6 +750,11 @@ export default function Sites() {
       toast.error('全局权重必须是大于 0 的数字');
       return;
     }
+    const parsedMaxConcurrency = parseSiteMaxConcurrency(form.maxConcurrency);
+    if (!parsedMaxConcurrency.valid) {
+      toast.error(parsedMaxConcurrency.error || '最大并发必须是非负整数（0 = 不限制）');
+      return;
+    }
     const serializedCustomHeaders = serializeSiteCustomHeaders(form.customHeaders);
     if (!serializedCustomHeaders.valid) {
       toast.error(serializedCustomHeaders.error || '自定义请求头格式不正确');
@@ -779,6 +788,7 @@ export default function Sites() {
       apiEndpoints: serializedApiEndpoints.apiEndpoints,
       customHeaders: serializedCustomHeaders.customHeaders,
       globalWeight: Number(parsedGlobalWeight.toFixed(3)),
+      maxConcurrency: parsedMaxConcurrency.value,
       postRefreshProbeEnabled: probeEnabled,
       postRefreshProbeModel: probeModel.trim(),
       postRefreshProbeScope: probeScope,
@@ -1944,6 +1954,22 @@ export default function Sites() {
                 越大越容易被路由选中。建议 0.5-3，默认 1。
               </div>
             </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <input
+                type="number"
+                min={0}
+                step={1}
+                inputMode="numeric"
+                data-testid="site-max-concurrency-input"
+                placeholder="最大并发（0 = 不限制）"
+                value={form.maxConcurrency}
+                onChange={(e) => setForm((prev) => ({ ...prev, maxConcurrency: e.target.value }))}
+                style={formInputStyle}
+              />
+              <div style={{ fontSize: 12, color: 'var(--color-text-muted)' }}>
+                限制该站点同时进行的上游请求数。0 = 不限制；负数会被拒绝。
+              </div>
+            </div>
           </ResponsiveFormGrid>
         </CenteredModal>
       )}
@@ -2045,6 +2071,7 @@ export default function Sites() {
                       )}
                     />
                     <MobileField label="权重" value={(site.globalWeight || 1).toFixed(2)} />
+                    <MobileField label="最大并发" value={formatSiteMaxConcurrency(site.maxConcurrency)} />
                     {isExpanded ? (
                       <div className="mobile-card-extra">
                         <MobileField
@@ -2185,6 +2212,7 @@ export default function Sites() {
                   <th>状态</th>
                   <th>系统代理</th>
                   <th>权重</th>
+                  <th>最大并发</th>
                   <th>平台</th>
                   <th>创建时间</th>
                   <th className="sites-actions-col" style={{ textAlign: 'right' }}>操作</th>
@@ -2270,6 +2298,15 @@ export default function Sites() {
                     </td>
                     <td style={{ fontVariantNumeric: 'tabular-nums', fontWeight: 600 }}>
                       {(site.globalWeight || 1).toFixed(2)}
+                    </td>
+                    <td style={{ fontVariantNumeric: 'tabular-nums' }}>
+                      <span
+                        className={`badge ${!site.maxConcurrency || site.maxConcurrency <= 0 ? 'badge-muted' : 'badge-info'}`}
+                        style={{ fontSize: 11 }}
+                        title="0 = 不限制"
+                      >
+                        {formatSiteMaxConcurrency(site.maxConcurrency)}
+                      </span>
                     </td>
                     <td>
                       <a

--- a/web/pages/helpers/sitesEditor.test.ts
+++ b/web/pages/helpers/sitesEditor.test.ts
@@ -4,6 +4,8 @@ import {
   emptySiteApiEndpoint,
   emptySiteCustomHeader,
   emptySiteForm,
+  formatSiteMaxConcurrency,
+  parseSiteMaxConcurrency,
   serializeSiteApiEndpoints,
   serializeSiteCustomHeaders,
   siteFormFromSite,
@@ -26,6 +28,7 @@ describe('buildSiteSaveAction', () => {
         customHeaders: '{"x-site-token":"alpha"}',
         useSystemProxy: false,
         globalWeight: 1.2,
+        maxConcurrency: 0,
         postRefreshProbeEnabled: true,
         postRefreshProbeModel: 'gpt-4o',
         postRefreshProbeScope: 'single',
@@ -48,6 +51,7 @@ describe('buildSiteSaveAction', () => {
         customHeaders: '{"x-site-token":"alpha"}',
         useSystemProxy: false,
         globalWeight: 1.2,
+        maxConcurrency: 0,
         postRefreshProbeEnabled: true,
         postRefreshProbeModel: 'gpt-4o',
         postRefreshProbeScope: 'single',
@@ -69,6 +73,7 @@ describe('buildSiteSaveAction', () => {
         apiEndpoints: [],
         customHeaders: '',
         globalWeight: 0.8,
+        maxConcurrency: 8,
       },
     );
 
@@ -85,6 +90,7 @@ describe('buildSiteSaveAction', () => {
         apiEndpoints: [],
         customHeaders: '',
         globalWeight: 0.8,
+        maxConcurrency: 8,
       },
     });
   });
@@ -103,6 +109,7 @@ describe('buildSiteSaveAction', () => {
           apiEndpoints: [],
           customHeaders: '',
           globalWeight: 1,
+          maxConcurrency: 0,
         },
       ),
     ).toThrow('editingSiteId is required in edit mode');
@@ -125,14 +132,17 @@ describe('buildSiteSaveAction', () => {
       ],
       customHeaders: '{"x-site-token":"alpha"}',
       globalWeight: 1,
+      maxConcurrency: 4,
       apiKey: 'sk-legacy-site-key',
     } as unknown as Parameters<typeof siteFormFromSite>[0];
 
     expect(emptySiteForm()).not.toHaveProperty('apiKey');
+    expect(emptySiteForm().maxConcurrency).toBe('0');
     expect(emptySiteForm().customHeaders).toEqual([emptySiteCustomHeader()]);
     expect(emptySiteForm().apiEndpoints).toEqual([emptySiteApiEndpoint()]);
     expect(emptySiteForm().proxyUrl).toBe('');
     expect(siteFormFromSite(legacySite)).not.toHaveProperty('apiKey');
+    expect(siteFormFromSite(legacySite).maxConcurrency).toBe('4');
     expect(siteFormFromSite({
       proxyUrl: 'http://127.0.0.1:8080',
     }).proxyUrl).toBe('http://127.0.0.1:8080');
@@ -144,6 +154,31 @@ describe('buildSiteSaveAction', () => {
         lastFailureReason: 'HTTP 502',
       },
     ]);
+  });
+
+  it('defaults maxConcurrency to 0 when missing or invalid on hydrate', () => {
+    expect(siteFormFromSite({}).maxConcurrency).toBe('0');
+    expect(siteFormFromSite({ maxConcurrency: -3 }).maxConcurrency).toBe('0');
+    expect(siteFormFromSite({ maxConcurrency: '12.9' }).maxConcurrency).toBe('12');
+  });
+
+  it('parses and formats maxConcurrency for save/list', () => {
+    expect(parseSiteMaxConcurrency('0')).toEqual({ valid: true, value: 0 });
+    expect(parseSiteMaxConcurrency('')).toEqual({ valid: true, value: 0 });
+    expect(parseSiteMaxConcurrency('16')).toEqual({ valid: true, value: 16 });
+    expect(parseSiteMaxConcurrency('-1')).toEqual({
+      valid: false,
+      value: 0,
+      error: '最大并发必须是非负整数（0 = 不限制）',
+    });
+    expect(parseSiteMaxConcurrency('1.5')).toEqual({
+      valid: false,
+      value: 0,
+      error: '最大并发必须是非负整数（0 = 不限制）',
+    });
+    expect(formatSiteMaxConcurrency(0)).toBe('不限制');
+    expect(formatSiteMaxConcurrency(null)).toBe('不限制');
+    expect(formatSiteMaxConcurrency(8)).toBe('8');
   });
 
   it('parses custom headers json into key value rows', () => {

--- a/web/pages/helpers/sitesEditor.ts
+++ b/web/pages/helpers/sitesEditor.ts
@@ -21,6 +21,8 @@ export type SiteForm = {
   apiEndpoints: SiteApiEndpointField[];
   customHeaders: SiteCustomHeaderField[];
   globalWeight: string;
+  /** Site concurrent upstream cap; string for controlled input. 0 = unlimited. */
+  maxConcurrency: string;
 };
 
 export type SiteEditorState =
@@ -42,6 +44,8 @@ export type SiteSavePayload = {
   }>;
   customHeaders: string;
   globalWeight: number;
+  /** Caps concurrent upstream calls for this site (0 = unlimited). */
+  maxConcurrency: number;
   postRefreshProbeEnabled?: boolean;
   postRefreshProbeModel?: string;
   postRefreshProbeScope?: 'single' | 'all';
@@ -80,6 +84,7 @@ export function emptySiteForm(): SiteForm {
     apiEndpoints: [emptySiteApiEndpoint()],
     customHeaders: [emptySiteCustomHeader()],
     globalWeight: '1',
+    maxConcurrency: '0',
   };
 }
 
@@ -131,7 +136,7 @@ function parseApiEndpointsForEditor(raw: unknown): SiteApiEndpointField[] {
   return ensureSiteApiEndpointRows(rows);
 }
 
-export function siteFormFromSite(site: Partial<Omit<SiteForm, 'apiEndpoints' | 'customHeaders' | 'globalWeight' | 'externalCheckinUrl' | 'proxyUrl' | 'useSystemProxy'>> & {
+export function siteFormFromSite(site: Partial<Omit<SiteForm, 'apiEndpoints' | 'customHeaders' | 'globalWeight' | 'maxConcurrency' | 'externalCheckinUrl' | 'proxyUrl' | 'useSystemProxy'>> & {
   externalCheckinUrl?: string | null;
   proxyUrl?: string | null;
   useSystemProxy?: boolean | null;
@@ -143,9 +148,14 @@ export function siteFormFromSite(site: Partial<Omit<SiteForm, 'apiEndpoints' | '
   }> | null;
   customHeaders?: string | null;
   globalWeight?: number | string | null;
+  maxConcurrency?: number | string | null;
 }): SiteForm {
   const globalWeightRaw = Number(site.globalWeight);
   const globalWeight = Number.isFinite(globalWeightRaw) && globalWeightRaw > 0 ? String(globalWeightRaw) : '1';
+  const maxConcurrencyRaw = Number(site.maxConcurrency);
+  const maxConcurrency = Number.isFinite(maxConcurrencyRaw) && maxConcurrencyRaw >= 0
+    ? String(Math.trunc(maxConcurrencyRaw))
+    : '0';
   return {
     name: site.name ?? '',
     url: site.url ?? '',
@@ -156,7 +166,46 @@ export function siteFormFromSite(site: Partial<Omit<SiteForm, 'apiEndpoints' | '
     apiEndpoints: parseApiEndpointsForEditor(site.apiEndpoints),
     customHeaders: parseCustomHeadersForEditor(site.customHeaders),
     globalWeight,
+    maxConcurrency,
   };
+}
+
+/**
+ * Parse maxConcurrency from form input.
+ * 0 = unlimited; rejects non-integers and negatives (backend also 400s negatives).
+ */
+export function parseSiteMaxConcurrency(raw: string): {
+  valid: boolean;
+  value: number;
+  error?: string;
+} {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { valid: true, value: 0 };
+  }
+  if (!/^\d+$/.test(trimmed)) {
+    return {
+      valid: false,
+      value: 0,
+      error: '最大并发必须是非负整数（0 = 不限制）',
+    };
+  }
+  const value = Number(trimmed);
+  if (!Number.isFinite(value) || value < 0) {
+    return {
+      valid: false,
+      value: 0,
+      error: '最大并发必须是非负整数（0 = 不限制）',
+    };
+  }
+  return { valid: true, value: Math.trunc(value) };
+}
+
+/** Compact list/detail label: 0 → 不限制. */
+export function formatSiteMaxConcurrency(value?: number | null): string {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return '不限制';
+  return String(Math.trunc(n));
 }
 
 // Keep this in sync with normalizeSiteApiEndpointBaseUrl in


### PR DESCRIPTION
## Summary
- Expose `maxConcurrency` on Sites create/edit form (number input, default `0`)
- Include `maxConcurrency` in create/update payloads via `sitesEditor` helpers
- Show compact list/mobile badge (`不限制` when 0/unlimited)
- Client-side reject negatives/non-integers before submit (backend already 400s)

## Backend contract (unchanged)
- `sites.max_concurrency` / JSON camelCase `maxConcurrency`
- `0` = unlimited; negative → 400
- Admin create/update/list already return the field

## Test plan
- [x] `cd web && npm run typecheck:web`
- [x] `cd web && npm test -- --run Sites` (9 files / 38 tests green)

Closes #457