### PR TITLE
fix(proxy): enforce Gemini generationConfig.maxOutputTokens vs context_length

### DIFF
--- a/handler/proxy/max_tokens.go
+++ b/handler/proxy/max_tokens.go
@@ -7,13 +7,14 @@ import (
 )
 
 // maxTokensOverContextError is returned when body max_tokens / max_output_tokens
-// exceeds a positive route context_length. Callers must surface an honest 400
-// (no silent clamp).
+// / generationConfig.maxOutputTokens exceeds a positive route context_length.
+// Callers must surface an honest 400 (no silent clamp).
 type maxTokensOverContextError struct {
 	MaxTokens     int64
 	ContextLength int64
-	// Field is the body key that exceeded the limit ("max_tokens" or
-	// "max_output_tokens") so error text matches the request dialect.
+	// Field is the body key (or dotted nested path) that exceeded the limit
+	// ("max_tokens", "max_output_tokens", "generationConfig.maxOutputTokens", …)
+	// so error text matches the request dialect.
 	Field string
 }
 
@@ -30,14 +31,15 @@ func (e maxTokensOverContextError) Error() string {
 	)
 }
 
-// enforceMaxTokensAgainstContextLength rejects max_tokens / max_output_tokens
-// above a positive route context_length for OpenAI chat/completions-style,
-// Anthropic messages, and OpenAI Responses bodies.
+// enforceMaxTokensAgainstContextLength rejects max_tokens / max_output_tokens /
+// Gemini generationConfig.maxOutputTokens above a positive route context_length
+// for OpenAI chat/completions-style, Anthropic messages, OpenAI Responses, and
+// Gemini generateContent bodies.
 //
-// Policy (issue #399 / #409 / #450 / CTX-520 residual):
+// Policy (issue #399 / #409 / #450 / #458 / CTX-520 residual):
 //   - enforce only when context_length > 0
-//   - enforce when max_output_tokens or max_tokens is present and parseable
-//   - skip when both fields are omitted, null, or unparseable
+//   - enforce when a dialect-specific output-token field is present and parseable
+//   - skip when all candidate fields are omitted, null, or unparseable
 //   - never silent-clamp or invent tokens
 //
 // Returns maxTokensOverContextError when the request must be rejected with 400.
@@ -46,8 +48,8 @@ func enforceMaxTokensAgainstContextLength(body map[string]any, contextLength *in
 	if !ok {
 		return nil
 	}
-	// Prefer OpenAI Responses max_output_tokens when both are present; otherwise
-	// accept chat/messages max_tokens for parity.
+	// Prefer nested Gemini generationConfig / OpenAI Responses max_output_tokens
+	// when present; otherwise accept chat/messages max_tokens for parity.
 	maxTokens, field, present := bodyOutputTokenLimit(body)
 	if !present {
 		return nil
@@ -63,8 +65,10 @@ func enforceMaxTokensAgainstContextLength(body map[string]any, contextLength *in
 }
 
 // shouldEnforceMaxTokensOnPath is true for OpenAI chat/completions (+ legacy
-// completions), Anthropic Claude /v1/messages (issue #409), and OpenAI
-// /v1/responses (+ /compact) (issue #450). count_tokens and other surfaces stay out.
+// completions), Anthropic Claude /v1/messages (issue #409), OpenAI
+// /v1/responses (+ /compact) (issue #450), and Gemini generateContent /
+// streamGenerateContent (issue #458). count_tokens / countTokens and other
+// surfaces stay out.
 func shouldEnforceMaxTokensOnPath(downstreamPath string) bool {
 	p := strings.ToLower(strings.TrimSpace(downstreamPath))
 	switch {
@@ -80,6 +84,12 @@ func shouldEnforceMaxTokensOnPath(downstreamPath string) bool {
 		return true
 	case p == "/v1/responses/compact" || p == "/responses/compact" || strings.HasSuffix(p, "/v1/responses/compact") || strings.HasSuffix(p, "/responses/compact"):
 		return true
+	// Gemini native generateContent / streamGenerateContent (v1beta models/*:action
+	// and CLI /v1internal::generateContent). Substring match is action-safe:
+	// "streamgeneratecontent" and "generatecontent" both contain "generatecontent";
+	// countTokens does not and stays out.
+	case strings.Contains(p, "generatecontent"):
+		return true
 	default:
 		return false
 	}
@@ -93,18 +103,56 @@ func positiveContextLength(contextLength *int64) (int64, bool) {
 }
 
 // bodyOutputTokenLimit extracts a parseable output-token cap from the body.
-// OpenAI Responses uses max_output_tokens; chat/completions and Claude messages
-// use max_tokens. When both are present, max_output_tokens wins (Responses dialect).
+// Preference order (first present + parseable wins):
+//  1. Gemini nested generationConfig.maxOutputTokens (camel/snake variants)
+//  2. Gemini CLI envelope request.generationConfig.*
+//  3. OpenAI Responses top-level max_output_tokens
+//  4. chat/completions + Claude messages top-level max_tokens
+//
 // Missing / null / empty / non-numeric → not present.
 func bodyOutputTokenLimit(body map[string]any) (value int64, field string, present bool) {
 	if body == nil {
 		return 0, "", false
+	}
+	if n, field, ok := bodyGeminiMaxOutputTokens(body); ok {
+		return n, field, true
+	}
+	// Gemini CLI internal envelope: { "model", "request": { generationConfig... } }
+	if req, ok := body["request"].(map[string]any); ok && req != nil {
+		if n, field, ok := bodyGeminiMaxOutputTokens(req); ok {
+			return n, field, true
+		}
 	}
 	if n, ok := parseBodyTokenField(body, "max_output_tokens"); ok {
 		return n, "max_output_tokens", true
 	}
 	if n, ok := parseBodyTokenField(body, "max_tokens"); ok {
 		return n, "max_tokens", true
+	}
+	return 0, "", false
+}
+
+// bodyGeminiMaxOutputTokens reads nested generationConfig.maxOutputTokens
+// (and cheap camel/snake variants). Field is returned as a dotted path for
+// honest error text. Missing / null / non-object / unparseable → not present.
+func bodyGeminiMaxOutputTokens(body map[string]any) (value int64, field string, present bool) {
+	if body == nil {
+		return 0, "", false
+	}
+	for _, configKey := range []string{"generationConfig", "generation_config"} {
+		raw, ok := body[configKey]
+		if !ok || raw == nil {
+			continue
+		}
+		gc, ok := raw.(map[string]any)
+		if !ok || gc == nil {
+			continue
+		}
+		for _, tokenKey := range []string{"maxOutputTokens", "max_output_tokens"} {
+			if n, ok := parseBodyTokenField(gc, tokenKey); ok {
+				return n, configKey + "." + tokenKey, true
+			}
+		}
 	}
 	return 0, "", false
 }

--- a/handler/proxy/max_tokens_test.go
+++ b/handler/proxy/max_tokens_test.go
@@ -181,6 +181,132 @@ func TestEnforceMaxTokensAgainstContextLength(t *testing.T) {
 			wantLimit:     100,
 			wantField:     "max_tokens",
 		},
+		// Gemini generationConfig.maxOutputTokens (issue #458)
+		{
+			name: "generationConfig.maxOutputTokens over limit rejects",
+			body: map[string]any{
+				"generationConfig": map[string]any{
+					"maxOutputTokens": float64(9000),
+				},
+			},
+			contextLength: ptrInt64(8192),
+			wantErr:       true,
+			wantMax:       9000,
+			wantLimit:     8192,
+			wantField:     "generationConfig.maxOutputTokens",
+		},
+		{
+			name: "generationConfig.maxOutputTokens equal limit passes",
+			body: map[string]any{
+				"generationConfig": map[string]any{
+					"maxOutputTokens": float64(8192),
+				},
+			},
+			contextLength: ptrInt64(8192),
+			wantErr:       false,
+		},
+		{
+			name: "generationConfig.maxOutputTokens under limit passes",
+			body: map[string]any{
+				"generationConfig": map[string]any{
+					"maxOutputTokens": float64(100),
+				},
+			},
+			contextLength: ptrInt64(8192),
+			wantErr:       false,
+		},
+		{
+			name: "null generationConfig.maxOutputTokens skips",
+			body: map[string]any{
+				"generationConfig": map[string]any{
+					"maxOutputTokens": nil,
+				},
+			},
+			contextLength: ptrInt64(100),
+			wantErr:       false,
+		},
+		{
+			name: "unparseable generationConfig.maxOutputTokens skips",
+			body: map[string]any{
+				"generationConfig": map[string]any{
+					"maxOutputTokens": "lots",
+				},
+			},
+			contextLength: ptrInt64(100),
+			wantErr:       false,
+		},
+		{
+			name: "snake generation_config.max_output_tokens over limit rejects",
+			body: map[string]any{
+				"generation_config": map[string]any{
+					"max_output_tokens": float64(4097),
+				},
+			},
+			contextLength: ptrInt64(4096),
+			wantErr:       true,
+			wantMax:       4097,
+			wantLimit:     4096,
+			wantField:     "generation_config.max_output_tokens",
+		},
+		{
+			name: "string generationConfig.maxOutputTokens over limit rejects",
+			body: map[string]any{
+				"generationConfig": map[string]any{
+					"maxOutputTokens": "200",
+				},
+			},
+			contextLength: ptrInt64(100),
+			wantErr:       true,
+			wantMax:       200,
+			wantLimit:     100,
+			wantField:     "generationConfig.maxOutputTokens",
+		},
+		{
+			name: "gemini CLI request.generationConfig.maxOutputTokens over limit rejects",
+			body: map[string]any{
+				"model": "gemini-2.5-pro",
+				"request": map[string]any{
+					"generationConfig": map[string]any{
+						"maxOutputTokens": float64(2048),
+					},
+				},
+			},
+			contextLength: ptrInt64(1024),
+			wantErr:       true,
+			wantMax:       2048,
+			wantLimit:     1024,
+			wantField:     "generationConfig.maxOutputTokens",
+		},
+		{
+			name: "nested generationConfig preferred over top-level max_tokens",
+			body: map[string]any{
+				"generationConfig": map[string]any{
+					"maxOutputTokens": float64(9000),
+				},
+				"max_tokens": float64(50), // under limit; must not mask nested over-limit
+			},
+			contextLength: ptrInt64(8192),
+			wantErr:       true,
+			wantMax:       9000,
+			wantLimit:     8192,
+			wantField:     "generationConfig.maxOutputTokens",
+		},
+		{
+			name: "omitted generationConfig skips",
+			body: map[string]any{
+				"contents": []any{},
+			},
+			contextLength: ptrInt64(8192),
+			wantErr:       false,
+		},
+		{
+			name: "non-object generationConfig skips",
+			body: map[string]any{
+				"generationConfig": "nope",
+			},
+			contextLength: ptrInt64(100),
+			wantErr:       false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -233,22 +359,32 @@ func asMaxTokensErr(err error, out *maxTokensOverContextError) bool {
 func TestShouldEnforceMaxTokensOnPath(t *testing.T) {
 	t.Parallel()
 	cases := map[string]bool{
-		"/v1/chat/completions":             true,
-		"/chat/completions":                true,
-		"/v1/completions":                  true,
-		"/completions":                     true,
-		"/v1/messages":                     true,
-		"/messages":                        true,
-		"/v1/messages/count_tokens":        false,
-		"/v1/responses":                    true,
-		"/responses":                       true,
-		"/v1/responses/compact":            true,
-		"/responses/compact":               true,
-		"/openai/v1/responses":             true,
-		"/openai/v1/responses/compact":     true,
-		"/v1/embeddings":                   false,
-		"/v1beta/models/x:generateContent": false,
-		"":                                 false,
+		"/v1/chat/completions":                      true,
+		"/chat/completions":                         true,
+		"/v1/completions":                           true,
+		"/completions":                              true,
+		"/v1/messages":                              true,
+		"/messages":                                 true,
+		"/v1/messages/count_tokens":                 false,
+		"/v1/responses":                             true,
+		"/responses":                                true,
+		"/v1/responses/compact":                     true,
+		"/responses/compact":                        true,
+		"/openai/v1/responses":                      true,
+		"/openai/v1/responses/compact":              true,
+		"/v1/embeddings":                            false,
+		// Gemini generateContent / streamGenerateContent (issue #458)
+		"/v1beta/models/x:generateContent":          true,
+		"/v1beta/models/gemini-2.5-pro:generateContent": true,
+		"/v1beta/models/x:streamGenerateContent":    true,
+		"/gemini/v1alpha/models/x:generateContent":  true,
+		"/v1internal::generateContent":              true,
+		"/v1internal::streamGenerateContent":        true,
+		"/v1internal:generateContent":               true,
+		// countTokens must not enforce
+		"/v1beta/models/x:countTokens":              false,
+		"/v1internal::countTokens":                  false,
+		"":                                          false,
 	}
 	for path, want := range cases {
 		if got := shouldEnforceMaxTokensOnPath(path); got != want {
@@ -710,6 +846,80 @@ func TestBodyOutputTokenLimit(t *testing.T) {
 			wantField:   "max_tokens",
 			wantPresent: true,
 		},
+		// Gemini nested generationConfig (issue #458)
+		{
+			name: "generationConfig.maxOutputTokens present",
+			body: map[string]any{
+				"generationConfig": map[string]any{
+					"maxOutputTokens": float64(256),
+				},
+			},
+			wantValue:   256,
+			wantField:   "generationConfig.maxOutputTokens",
+			wantPresent: true,
+		},
+		{
+			name: "snake generation_config.max_output_tokens present",
+			body: map[string]any{
+				"generation_config": map[string]any{
+					"max_output_tokens": float64(128),
+				},
+			},
+			wantValue:   128,
+			wantField:   "generation_config.max_output_tokens",
+			wantPresent: true,
+		},
+		{
+			name: "prefer nested generationConfig over top-level max_tokens",
+			body: map[string]any{
+				"generationConfig": map[string]any{
+					"maxOutputTokens": float64(10),
+				},
+				"max_tokens": float64(99),
+			},
+			wantValue:   10,
+			wantField:   "generationConfig.maxOutputTokens",
+			wantPresent: true,
+		},
+		{
+			name: "gemini CLI request.generationConfig.maxOutputTokens present",
+			body: map[string]any{
+				"model": "gemini-2.5-pro",
+				"request": map[string]any{
+					"generationConfig": map[string]any{
+						"maxOutputTokens": float64(512),
+					},
+				},
+			},
+			wantValue:   512,
+			wantField:   "generationConfig.maxOutputTokens",
+			wantPresent: true,
+		},
+		{
+			name: "null nested maxOutputTokens skips",
+			body: map[string]any{
+				"generationConfig": map[string]any{
+					"maxOutputTokens": nil,
+				},
+			},
+			wantPresent: false,
+		},
+		{
+			name: "unparseable nested maxOutputTokens skips",
+			body: map[string]any{
+				"generationConfig": map[string]any{
+					"maxOutputTokens": "nope",
+				},
+			},
+			wantPresent: false,
+		},
+		{
+			name: "non-object generationConfig skips",
+			body: map[string]any{
+				"generationConfig": "nope",
+			},
+			wantPresent: false,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -718,6 +928,62 @@ func TestBodyOutputTokenLimit(t *testing.T) {
 			got, field, present := bodyOutputTokenLimit(tt.body)
 			if present != tt.wantPresent {
 				t.Fatalf("present = %v, want %v (got=%d field=%q)", present, tt.wantPresent, got, field)
+			}
+			if !tt.wantPresent {
+				return
+			}
+			if got != tt.wantValue || field != tt.wantField {
+				t.Fatalf("got (%d, %q), want (%d, %q)", got, field, tt.wantValue, tt.wantField)
+			}
+		})
+	}
+}
+
+func TestBodyGeminiMaxOutputTokens(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		body        map[string]any
+		wantValue   int64
+		wantField   string
+		wantPresent bool
+	}{
+		{
+			name: "camel nested present",
+			body: map[string]any{
+				"generationConfig": map[string]any{"maxOutputTokens": float64(77)},
+			},
+			wantValue:   77,
+			wantField:   "generationConfig.maxOutputTokens",
+			wantPresent: true,
+		},
+		{
+			name: "mixed camel config + snake token key",
+			body: map[string]any{
+				"generationConfig": map[string]any{"max_output_tokens": float64(88)},
+			},
+			wantValue:   88,
+			wantField:   "generationConfig.max_output_tokens",
+			wantPresent: true,
+		},
+		{
+			name:        "empty body",
+			body:        map[string]any{},
+			wantPresent: false,
+		},
+		{
+			name:        "nil body",
+			body:        nil,
+			wantPresent: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, field, present := bodyGeminiMaxOutputTokens(tt.body)
+			if present != tt.wantPresent {
+				t.Fatalf("present = %v, want %v", present, tt.wantPresent)
 			}
 			if !tt.wantPresent {
 				return
@@ -961,5 +1227,285 @@ func TestResponses_NoContextLengthDoesNotEnforce(t *testing.T) {
 	}
 	if upstreamHits != 1 {
 		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
+	}
+}
+
+func TestGeminiGenerateContent_MaxOutputTokensOverContextLengthReturns400(t *testing.T) {
+	// Issue #458: Gemini generateContent must reject generationConfig.maxOutputTokens
+	// above positive route context_length with honest 400 (no silent clamp).
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"candidates":[]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(1024)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active", Platform: "gemini"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gemini-2.5-pro",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1beta/models/gemini-2.5-pro:generateContent",
+		`{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"generationConfig":{"maxOutputTokens":2048}}`)
+	rec := httptest.NewRecorder()
+	HandleGeminiGenerateContent(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "maxOutputTokens") || !strings.Contains(body, "context_length") {
+		t.Fatalf("body = %q, want clear maxOutputTokens/context_length error", body)
+	}
+	if !strings.Contains(body, "invalid_request_error") {
+		t.Fatalf("body = %q, want invalid_request_error", body)
+	}
+	if upstreamHits != 0 {
+		t.Fatalf("upstream was called %d times; expected 0 (must not silent-forward)", upstreamHits)
+	}
+}
+
+func TestGeminiStreamGenerateContent_MaxOutputTokensOverContextLengthReturns400(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"candidates":[]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(512)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active", Platform: "gemini"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gemini-2.5-flash",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1beta/models/gemini-2.5-flash:streamGenerateContent",
+		`{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"generationConfig":{"maxOutputTokens":1024}}`)
+	rec := httptest.NewRecorder()
+	HandleGeminiGenerateContent(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "maxOutputTokens") {
+		t.Fatalf("body = %q, want maxOutputTokens wording", rec.Body.String())
+	}
+	if upstreamHits != 0 {
+		t.Fatalf("upstream was called; expected rejection before forward")
+	}
+}
+
+func TestGeminiCLIGenerateContent_MaxOutputTokensOverContextLengthReturns400(t *testing.T) {
+	// Gemini CLI internal path (/v1internal::generateContent). Nested may live
+	// at top-level or under request{} envelope.
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"candidates":[]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(256)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active", Platform: "gemini-cli"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gemini-2.5-pro",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1internal::generateContent",
+		`{"model":"gemini-2.5-pro","request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"generationConfig":{"maxOutputTokens":512}}}`)
+	rec := httptest.NewRecorder()
+	HandleGeminiCLIGenerateContent(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "maxOutputTokens") || !strings.Contains(rec.Body.String(), "context_length") {
+		t.Fatalf("body = %q, want nested maxOutputTokens/context_length wording", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid_request_error") {
+		t.Fatalf("body = %q, want invalid_request_error", rec.Body.String())
+	}
+	if upstreamHits != 0 {
+		t.Fatalf("upstream was called; expected rejection before forward")
+	}
+}
+
+func TestGeminiGenerateContent_MaxOutputTokensAtContextLengthPassesThrough(t *testing.T) {
+	upstreamHits := 0
+	var sawMaxOutput any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		var payload map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		if gc, ok := payload["generationConfig"].(map[string]any); ok {
+			sawMaxOutput = gc["maxOutputTokens"]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(2048)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active", Platform: "gemini"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gemini-2.5-pro",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1beta/models/gemini-2.5-pro:generateContent",
+		`{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"generationConfig":{"maxOutputTokens":2048}}`)
+	rec := httptest.NewRecorder()
+	HandleGeminiGenerateContent(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
+	}
+	// No silent clamp: original maxOutputTokens must be forwarded unchanged.
+	if sawMaxOutput != float64(2048) {
+		t.Fatalf("upstream maxOutputTokens = %v (%T), want 2048 (no clamp)", sawMaxOutput, sawMaxOutput)
+	}
+}
+
+func TestGeminiGenerateContent_OmittedMaxOutputTokensDoesNotEnforce(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"candidates":[]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(128)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active", Platform: "gemini"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gemini-2.5-pro",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1beta/models/gemini-2.5-pro:generateContent",
+		`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+	rec := httptest.NewRecorder()
+	HandleGeminiGenerateContent(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
+	}
+}
+
+func TestGeminiGenerateContent_NoContextLengthDoesNotEnforce(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"candidates":[]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:     store.RouteChannel{ID: 1, Enabled: true},
+			Account:     store.Account{ID: 1, Status: "active"},
+			Site:        store.Site{ID: 1, URL: upstream.URL, Status: "active", Platform: "gemini"},
+			TokenValue:  "upstream-token",
+			ActualModel: "gemini-2.5-pro",
+			// ContextLength nil → no enforce
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1beta/models/gemini-2.5-pro:generateContent",
+		`{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"generationConfig":{"maxOutputTokens":999999}}`)
+	rec := httptest.NewRecorder()
+	HandleGeminiGenerateContent(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1", upstreamHits)
+	}
+}
+
+func TestGeminiCountTokens_DoesNotEnforceMaxOutputTokens(t *testing.T) {
+	// countTokens path must not apply the generateContent maxOutputTokens gate.
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"totalTokens":3}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	limit := int64(64)
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:       store.RouteChannel{ID: 1, Enabled: true},
+			Account:       store.Account{ID: 1, Status: "active"},
+			Site:          store.Site{ID: 1, URL: upstream.URL, Status: "active", Platform: "gemini"},
+			TokenValue:    "upstream-token",
+			ActualModel:   "gemini-2.5-pro",
+			ContextLength: &limit,
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	// Even if a client oddly includes generationConfig, countTokens path must skip enforce.
+	req := makeProxyReq("POST", "/v1internal::countTokens",
+		`{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"generationConfig":{"maxOutputTokens":999999}}`)
+	rec := httptest.NewRecorder()
+	HandleGeminiCLICountTokens(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("upstream hits = %d, want 1 (countTokens must not enforce)", upstreamHits)
 	}
 }

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -210,11 +210,12 @@ func dispatchSelectedUpstream(
 	if requestID == "" {
 		requestID = proxy.RequestIDFromContext(r.Context())
 	}
-	// Optional max_tokens / max_output_tokens vs route context_length
-	// (issue #399 / #409 / #450 / CTX-520 residual). Enforce on OpenAI
-	// chat/completions (+ legacy completions), Anthropic /v1/messages, and
-	// OpenAI /v1/responses (+ /compact) when the selected route publishes a
-	// positive context_length and the body includes a parseable token cap
+	// Optional max_tokens / max_output_tokens / generationConfig.maxOutputTokens
+	// vs route context_length (issue #399 / #409 / #450 / #458 / CTX-520 residual).
+	// Enforce on OpenAI chat/completions (+ legacy completions), Anthropic
+	// /v1/messages, OpenAI /v1/responses (+ /compact), and Gemini
+	// generateContent / streamGenerateContent when the selected route publishes
+	// a positive context_length and the body includes a parseable token cap
 	// above that limit. Never silent-clamp.
 	if ctx != nil && selected != nil && shouldEnforceMaxTokensOnPath(upstreamPath) {
 		if err := enforceMaxTokensAgainstContextLength(ctx.Body, selected.ContextLength); err != nil {


### PR DESCRIPTION
## Summary
- Extend `shouldEnforceMaxTokensOnPath` to Gemini `generateContent` / `streamGenerateContent` surfaces (v1beta `models/*:action`, dynamic `/gemini/...`, CLI `/v1internal::generateContent` / `streamGenerateContent`; action/suffix-safe via `generatecontent` substring).
- Parse nested `generationConfig.maxOutputTokens` (also `generation_config` / `max_output_tokens` variants) and Gemini CLI `request{}` envelope; over positive route `context_length` → honest **400** `invalid_request_error` via `maxTokensOverContextError` (no silent clamp).
- Omitted / null / unparseable / non-object nested fields skip (parity with chat/messages/Responses policy). `countTokens` stays out.
- Unit + integration tests for path match, nested extract, reject/skip/pass-through.

Closes #458

## Notes / residual honesty
- This is a **CTX-520 residual slice** only: Gemini generateContent dialect.
- Does **not** claim all-dialect CTX-520 fully closed if other dialects remain.
- Does not invent WS product; does not change thought_signature sanitize behavior.

## Test plan
- [x] `go test ./handler/proxy -count=1 -run 'MaxTokens|Gemini|Context|OutputTokens|GenerateContent'`
- [ ] CI green on PR