### PR TITLE
feat(ui): wire DownstreamKeys proxyUrl create/edit/list (#466)

### DIFF
--- a/web/pages/DownstreamKeys.test.tsx
+++ b/web/pages/DownstreamKeys.test.tsx
@@ -906,4 +906,181 @@ describe('DownstreamKeys page', () => {
       root?.unmount();
     }
   });
+
+  it('hydrates custom proxyUrl into editor and shows compact list indicator', async () => {
+    apiMock.getDownstreamApiKeysSummary.mockResolvedValue({
+      success: true,
+      items: [buildSummaryItem({
+        proxyUrl: 'http://user:s3cret@proxy.example.com:8080',
+      })],
+    });
+    apiMock.getDownstreamApiKeys.mockResolvedValue({
+      success: true,
+      items: [buildRawItem({
+        proxyUrl: 'http://user:s3cret@proxy.example.com:8080',
+      })],
+    });
+
+    let root!: WebTestRenderer;
+    try {
+      await act(async () => {
+        root = create(
+          <MemoryRouter initialEntries={['/downstream-keys']}>
+            <ToastProvider>
+              <DownstreamKeys />
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+      });
+      await flushMicrotasks();
+
+      const pageText = collectText(root!.root);
+      expect(pageText).toContain('代理 · proxy.example.com:8080');
+      expect(pageText).not.toContain('s3cret');
+
+      const editBtn = root!.root.findAll((node) => node.type === 'button' && collectText(node) === '编辑')[0];
+      await act(async () => {
+        editBtn.props.onClick();
+      });
+      await flushMicrotasks();
+
+      const proxyInput = root!.root.findAllByType('input').find((node) =>
+        String(node.props.placeholder || '').includes('留空继承站点/系统代理'),
+      );
+      expect(proxyInput?.props.value).toBe('http://user:s3cret@proxy.example.com:8080');
+    } finally {
+      root?.unmount();
+    }
+  });
+
+  it('saves proxyUrl on create and clears it with empty string as null', async () => {
+    let root!: WebTestRenderer;
+    try {
+      await act(async () => {
+        root = create(
+          <MemoryRouter initialEntries={['/downstream-keys']}>
+            <ToastProvider>
+              <DownstreamKeys />
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+      });
+      await flushMicrotasks();
+
+      const createBtn = root!.root.findAll((node) => node.type === 'button' && collectText(node).includes('新增下游密钥'))[0];
+      await act(async () => {
+        createBtn.props.onClick();
+      });
+      await flushMicrotasks();
+
+      const inputs = root!.root.findAllByType('input');
+      const nameInput = inputs.find((node) => node.props.placeholder === '例如：项目 A / 移动端');
+      const keyInput = inputs.find((node) => node.props.placeholder === 'sk-...');
+      const proxyInput = inputs.find((node) =>
+        String(node.props.placeholder || '').includes('留空继承站点/系统代理'),
+      );
+      expect(proxyInput).toBeTruthy();
+      expect(proxyInput?.props.value).toBe('');
+
+      await act(async () => {
+        nameInput!.props.onChange({ target: { value: 'proxy-key' } });
+        keyInput!.props.onChange({ target: { value: 'sk-proxy-key-0466' } });
+        proxyInput!.props.onChange({ target: { value: '  socks5://127.0.0.1:1080  ' } });
+      });
+      await flushMicrotasks();
+
+      const saveBtn = root!.root.findAll((node) => node.type === 'button' && collectText(node).includes('创建密钥'))[0];
+      await act(async () => {
+        saveBtn.props.onClick();
+      });
+      await flushMicrotasks();
+
+      expect(apiMock.createDownstreamApiKey).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'proxy-key',
+        key: 'sk-proxy-key-0466',
+        proxyUrl: 'socks5://127.0.0.1:1080',
+      }));
+
+      // Re-open create form and save with empty proxy → null inherit.
+      apiMock.createDownstreamApiKey.mockClear();
+      const createBtn2 = root!.root.findAll((node) => node.type === 'button' && collectText(node).includes('新增下游密钥'))[0];
+      await act(async () => {
+        createBtn2.props.onClick();
+      });
+      await flushMicrotasks();
+
+      const inputs2 = root!.root.findAllByType('input');
+      const nameInput2 = inputs2.find((node) => node.props.placeholder === '例如：项目 A / 移动端');
+      const keyInput2 = inputs2.find((node) => node.props.placeholder === 'sk-...');
+      const proxyInput2 = inputs2.find((node) =>
+        String(node.props.placeholder || '').includes('留空继承站点/系统代理'),
+      );
+      await act(async () => {
+        nameInput2!.props.onChange({ target: { value: 'inherit-key' } });
+        keyInput2!.props.onChange({ target: { value: 'sk-inherit-key-0466' } });
+        proxyInput2!.props.onChange({ target: { value: '   ' } });
+      });
+      await flushMicrotasks();
+
+      const saveBtn2 = root!.root.findAll((node) => node.type === 'button' && collectText(node).includes('创建密钥'))[0];
+      await act(async () => {
+        saveBtn2.props.onClick();
+      });
+      await flushMicrotasks();
+
+      expect(apiMock.createDownstreamApiKey).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'inherit-key',
+        key: 'sk-inherit-key-0466',
+        proxyUrl: null,
+      }));
+    } finally {
+      root?.unmount();
+    }
+  });
+
+  it('rejects invalid proxyUrl scheme before calling create API', async () => {
+    let root!: WebTestRenderer;
+    try {
+      await act(async () => {
+        root = create(
+          <MemoryRouter initialEntries={['/downstream-keys']}>
+            <ToastProvider>
+              <DownstreamKeys />
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+      });
+      await flushMicrotasks();
+
+      const createBtn = root!.root.findAll((node) => node.type === 'button' && collectText(node).includes('新增下游密钥'))[0];
+      await act(async () => {
+        createBtn.props.onClick();
+      });
+      await flushMicrotasks();
+
+      const inputs = root!.root.findAllByType('input');
+      const nameInput = inputs.find((node) => node.props.placeholder === '例如：项目 A / 移动端');
+      const keyInput = inputs.find((node) => node.props.placeholder === 'sk-...');
+      const proxyInput = inputs.find((node) =>
+        String(node.props.placeholder || '').includes('留空继承站点/系统代理'),
+      );
+
+      await act(async () => {
+        nameInput!.props.onChange({ target: { value: 'bad-proxy-key' } });
+        keyInput!.props.onChange({ target: { value: 'sk-bad-proxy-0466' } });
+        proxyInput!.props.onChange({ target: { value: 'ftp://not-supported' } });
+      });
+      await flushMicrotasks();
+
+      const saveBtn = root!.root.findAll((node) => node.type === 'button' && collectText(node).includes('创建密钥'))[0];
+      await act(async () => {
+        saveBtn.props.onClick();
+      });
+      await flushMicrotasks();
+
+      expect(apiMock.createDownstreamApiKey).not.toHaveBeenCalled();
+    } finally {
+      root?.unmount();
+    }
+  });
 });

--- a/web/pages/DownstreamKeys.tsx
+++ b/web/pages/DownstreamKeys.tsx
@@ -27,6 +27,11 @@ import {
   type Range,
   type SummaryItem,
 } from './downstream-keys/shared.js';
+import {
+  formatDownstreamKeyProxyIndicator,
+  hasCustomDownstreamKeyProxy,
+  parseDownstreamKeyProxyUrl,
+} from './helpers/downstreamKeyProxyUrl.js';
 
 type Status = 'all' | 'enabled' | 'disabled';
 
@@ -49,6 +54,8 @@ type DownstreamApiKeyItem = {
   siteWeightMultipliers: Record<number, number>;
   excludedSiteIds: number[];
   excludedCredentialRefs: DownstreamExcludedCredentialRef[];
+  /** Per-key egress proxy; null/empty inherits site/account/system. */
+  proxyUrl?: string | null;
   lastUsedAt: string | null;
 };
 
@@ -347,6 +354,7 @@ function buildEditorForm(
     maxRequests: item?.maxRequests === null || item?.maxRequests === undefined ? '' : String(item.maxRequests),
     expiresAt: toDateTimeLocal(item?.expiresAt),
     enabled: item?.enabled ?? true,
+    proxyUrl: item?.proxyUrl ?? '',
     selectedModels: uniqStrings(selectedModels),
     selectedGroupRouteIds: uniqIds(selectedGroupRouteIds),
     siteWeightMultipliersText: JSON.stringify(item?.siteWeightMultipliers || {}, null, 2),
@@ -628,6 +636,7 @@ export default function DownstreamKeys() {
         siteWeightMultipliers: raw?.siteWeightMultipliers ?? item.siteWeightMultipliers,
         excludedSiteIds: raw?.excludedSiteIds ?? item.excludedSiteIds,
         excludedCredentialRefs: raw?.excludedCredentialRefs ?? item.excludedCredentialRefs,
+        proxyUrl: raw?.proxyUrl ?? item.proxyUrl ?? null,
         lastUsedAt: raw?.lastUsedAt ?? item.lastUsedAt,
       };
     })
@@ -801,6 +810,12 @@ export default function DownstreamKeys() {
       return;
     }
 
+    const parsedProxy = parseDownstreamKeyProxyUrl(editorForm.proxyUrl);
+    if (!parsedProxy.valid) {
+      toast.info(parsedProxy.error || '代理地址格式无效');
+      return;
+    }
+
     let siteWeightMultipliers: Record<number, number> = {};
     const rawWeights = editorForm.siteWeightMultipliersText.trim();
     if (rawWeights && rawWeights !== '{}') {
@@ -833,6 +848,7 @@ export default function DownstreamKeys() {
         expiresAt: editorForm.expiresAt ? new Date(editorForm.expiresAt).toISOString() : null,
         maxCost: editorForm.maxCost.trim() ? Number(editorForm.maxCost.trim()) : null,
         maxRequests: editorForm.maxRequests.trim() ? Number(editorForm.maxRequests.trim()) : null,
+        proxyUrl: parsedProxy.value,
         supportedModels: uniqStrings(editorForm.selectedModels),
         allowedRouteIds: uniqIds(editorForm.selectedGroupRouteIds).filter((id) => routeMap.has(id) && isGroupRouteOption(routeMap.get(id)!)),
         siteWeightMultipliers,
@@ -1177,6 +1193,13 @@ export default function DownstreamKeys() {
                   {row.description ? <MobileField label="备注" value={row.description} stacked /> : null}
                   <MobileField label="主分组" value={row.groupName || '未分组'} />
                   <MobileField label="标签" value={summarizeTags(row.tags || [])} stacked />
+                  {hasCustomDownstreamKeyProxy(row.proxyUrl) ? (
+                    <MobileField
+                      label="出口代理"
+                      value={formatDownstreamKeyProxyIndicator(row.proxyUrl) || '已设置'}
+                      stacked
+                    />
+                  ) : null}
                   <MobileField label="模型" value={summarizeModelLimit(row.supportedModels || [])} stacked />
                   <MobileField label="群组" value={summarizeRouteLimit(row.allowedRouteIds || [], routeMap)} stacked />
                   <MobileField label="倍率" value={summarizeSiteWeightMultipliers(row.siteWeightMultipliers || {})} stacked />
@@ -1229,6 +1252,15 @@ export default function DownstreamKeys() {
                             {row.groupName ? `主分组 · ${row.groupName}` : '未分组'}
                           </span>
                           <TagChips tags={row.tags || []} maxVisible={3} />
+                          {hasCustomDownstreamKeyProxy(row.proxyUrl) ? (
+                            <span
+                              className="badge badge-info"
+                              style={{ fontSize: 11 }}
+                              title={formatDownstreamKeyProxyIndicator(row.proxyUrl) || '已设置'}
+                            >
+                              代理 · {formatDownstreamKeyProxyIndicator(row.proxyUrl) || '已设置'}
+                            </span>
+                          ) : null}
                         </div>
                       </td>
                       <td>

--- a/web/pages/downstream-keys/DownstreamKeyDrawer.tsx
+++ b/web/pages/downstream-keys/DownstreamKeyDrawer.tsx
@@ -17,6 +17,10 @@ import {
   type Range,
   type SummaryItem,
 } from './shared.js';
+import {
+  formatDownstreamKeyProxyIndicator,
+  hasCustomDownstreamKeyProxy,
+} from '../helpers/downstreamKeyProxyUrl.js';
 
 const DownstreamKeyTrendChart = lazy(() => import('../../components/charts/DownstreamKeyTrendChart.js'));
 type DownstreamKeyTrendBucket = import('../../components/charts/DownstreamKeyTrendChart.js').DownstreamKeyTrendBucket;
@@ -188,6 +192,14 @@ export default function DownstreamKeyDrawer({
                 <div>
                   <div style={{ color: 'var(--color-text-muted)', marginBottom: 4 }}>主分组</div>
                   <div style={{ color: 'var(--color-text-primary)', fontWeight: 600 }}>{item?.groupName || '未分组'}</div>
+                </div>
+                <div>
+                  <div style={{ color: 'var(--color-text-muted)', marginBottom: 4 }}>出口代理</div>
+                  <div style={{ color: 'var(--color-text-primary)', fontWeight: 600 }}>
+                    {hasCustomDownstreamKeyProxy(item?.proxyUrl)
+                      ? (formatDownstreamKeyProxyIndicator(item?.proxyUrl) || '已设置')
+                      : '继承站点/系统'}
+                  </div>
                 </div>
                 <div style={{ gridColumn: '1 / -1' }}>
                   <div style={{ color: 'var(--color-text-muted)', marginBottom: 6 }}>标签</div>

--- a/web/pages/downstream-keys/DownstreamKeyEditorModal.tsx
+++ b/web/pages/downstream-keys/DownstreamKeyEditorModal.tsx
@@ -27,6 +27,8 @@ export type DownstreamKeyEditorForm = {
   maxRequests: string;
   expiresAt: string;
   enabled: boolean;
+  /** Per-key egress proxy; empty = inherit site/account/system. */
+  proxyUrl: string;
   selectedModels: string[];
   selectedGroupRouteIds: number[];
   siteWeightMultipliersText: string;
@@ -412,6 +414,20 @@ export default function DownstreamKeyEditorModal({
         <div className="downstream-key-modal-field">
           <div className="downstream-key-modal-label">过期时间</div>
           <input type="datetime-local" value={form.expiresAt} onChange={(e) => onChange((prev) => ({ ...prev, expiresAt: e.target.value }))} style={inputStyle} />
+        </div>
+        <div className="downstream-key-modal-field downstream-key-modal-field-full">
+          <div className="downstream-key-modal-label">出口代理（可选）</div>
+          <input
+            value={form.proxyUrl}
+            onChange={(e) => onChange((prev) => ({ ...prev, proxyUrl: e.target.value }))}
+            placeholder="留空继承站点/系统代理，如 http://127.0.0.1:7890 或 socks5://127.0.0.1:1080"
+            style={inputStyle}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <div className="downstream-key-modal-help">
+            仅影响此密钥的上游出口。填写后优先使用密钥代理；留空则继承站点 / 账号 / 系统代理链路。
+          </div>
         </div>
         <label className="downstream-key-modal-toggle">
           <input type="checkbox" checked={form.enabled} onChange={(e) => onChange((prev) => ({ ...prev, enabled: e.target.checked }))} />

--- a/web/pages/downstream-keys/shared.tsx
+++ b/web/pages/downstream-keys/shared.tsx
@@ -23,6 +23,8 @@ export type SummaryItem = {
     | { kind: 'account_token'; siteId: number; accountId: number; tokenId: number }
     | { kind: 'default_api_key'; siteId: number; accountId: number }
   >;
+  /** Per-key egress proxy; null/empty inherits site/account/system. */
+  proxyUrl?: string | null;
   lastUsedAt: string | null;
   createdAt: string | null;
   updatedAt: string | null;

--- a/web/pages/helpers/downstreamKeyProxyUrl.test.ts
+++ b/web/pages/helpers/downstreamKeyProxyUrl.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatDownstreamKeyProxyIndicator,
+  hasCustomDownstreamKeyProxy,
+  normalizeDownstreamKeyProxyUrl,
+  parseDownstreamKeyProxyUrl,
+} from './downstreamKeyProxyUrl.js';
+
+describe('downstreamKeyProxyUrl', () => {
+  it('trims and treats empty as inherit', () => {
+    expect(normalizeDownstreamKeyProxyUrl(null)).toBe('');
+    expect(normalizeDownstreamKeyProxyUrl(undefined)).toBe('');
+    expect(normalizeDownstreamKeyProxyUrl('  ')).toBe('');
+    expect(normalizeDownstreamKeyProxyUrl('  http://127.0.0.1:7890  ')).toBe('http://127.0.0.1:7890');
+
+    expect(parseDownstreamKeyProxyUrl('')).toEqual({ valid: true, value: null });
+    expect(parseDownstreamKeyProxyUrl('   ')).toEqual({ valid: true, value: null });
+    expect(parseDownstreamKeyProxyUrl(null)).toEqual({ valid: true, value: null });
+    expect(hasCustomDownstreamKeyProxy(null)).toBe(false);
+    expect(hasCustomDownstreamKeyProxy('')).toBe(false);
+    expect(hasCustomDownstreamKeyProxy('  ')).toBe(false);
+  });
+
+  it('accepts http/https/socks schemes and rejects others', () => {
+    expect(parseDownstreamKeyProxyUrl('http://proxy.example:8080')).toEqual({
+      valid: true,
+      value: 'http://proxy.example:8080',
+    });
+    expect(parseDownstreamKeyProxyUrl('HTTPS://proxy.example:443')).toEqual({
+      valid: true,
+      value: 'HTTPS://proxy.example:443',
+    });
+    expect(parseDownstreamKeyProxyUrl('socks5://127.0.0.1:1080')).toEqual({
+      valid: true,
+      value: 'socks5://127.0.0.1:1080',
+    });
+    expect(parseDownstreamKeyProxyUrl('socks5h://user:pass@10.0.0.1:1080')).toEqual({
+      valid: true,
+      value: 'socks5h://user:pass@10.0.0.1:1080',
+    });
+    expect(parseDownstreamKeyProxyUrl('ftp://bad.example')).toEqual({
+      valid: false,
+      value: null,
+      error: '代理地址必须以 http://、https:// 或 socks 代理 scheme 开头',
+    });
+    expect(parseDownstreamKeyProxyUrl('proxy.example:8080')).toEqual({
+      valid: false,
+      value: null,
+      error: '代理地址必须以 http://、https:// 或 socks 代理 scheme 开头',
+    });
+    expect(hasCustomDownstreamKeyProxy('http://127.0.0.1:7890')).toBe(true);
+  });
+
+  it('formats compact indicator and redacts userinfo passwords', () => {
+    expect(formatDownstreamKeyProxyIndicator(null)).toBeNull();
+    expect(formatDownstreamKeyProxyIndicator('')).toBeNull();
+    expect(formatDownstreamKeyProxyIndicator('http://127.0.0.1:7890')).toBe('127.0.0.1:7890');
+    expect(formatDownstreamKeyProxyIndicator('socks5://proxy.example.com:1080')).toBe('proxy.example.com:1080');
+    expect(formatDownstreamKeyProxyIndicator('http://user:s3cret@proxy.example.com:8080')).toBe('proxy.example.com:8080');
+    expect(formatDownstreamKeyProxyIndicator('socks5h://alice:hunter2@10.0.0.9:1080')).toBe('10.0.0.9:1080');
+    // Unparseable values still must not leak credentials.
+    expect(formatDownstreamKeyProxyIndicator('not-a-url://user:pass@host')).toBe('host');
+    expect(formatDownstreamKeyProxyIndicator('not-a-url://user:pass@host')).not.toContain('pass');
+    expect(formatDownstreamKeyProxyIndicator('garbage')).toBe('已设置');
+  });
+});

--- a/web/pages/helpers/downstreamKeyProxyUrl.ts
+++ b/web/pages/helpers/downstreamKeyProxyUrl.ts
@@ -1,0 +1,74 @@
+/**
+ * Downstream key per-key egress proxy helpers (KEY-578 / #466).
+ * Empty/null = inherit site/account/system proxy chain.
+ */
+
+const SUPPORTED_PROXY_SCHEMES = [
+  'http://',
+  'https://',
+  'socks://',
+  'socks4://',
+  'socks4a://',
+  'socks5://',
+  'socks5h://',
+] as const;
+
+export function normalizeDownstreamKeyProxyUrl(raw: string | null | undefined): string {
+  return String(raw ?? '').trim();
+}
+
+export function hasCustomDownstreamKeyProxy(value?: string | null): boolean {
+  return normalizeDownstreamKeyProxyUrl(value).length > 0;
+}
+
+/**
+ * Client-side validate + normalize for create/update payloads.
+ * Empty/whitespace → null (inherit). Non-empty must use a supported scheme.
+ */
+export function parseDownstreamKeyProxyUrl(raw: string | null | undefined): {
+  valid: boolean;
+  value: string | null;
+  error?: string;
+} {
+  const trimmed = normalizeDownstreamKeyProxyUrl(raw);
+  if (!trimmed) {
+    return { valid: true, value: null };
+  }
+  const lower = trimmed.toLowerCase();
+  const supported = SUPPORTED_PROXY_SCHEMES.some((scheme) => lower.startsWith(scheme));
+  if (!supported) {
+    return {
+      valid: false,
+      value: null,
+      error: '代理地址必须以 http://、https:// 或 socks 代理 scheme 开头',
+    };
+  }
+  return { valid: true, value: trimmed };
+}
+
+/**
+ * Compact list/detail indicator when a custom proxy is set.
+ * Redacts userinfo; prefers `hostname:port`, falls back to `已设置`.
+ * Returns null when inheriting (empty/null).
+ */
+export function formatDownstreamKeyProxyIndicator(value?: string | null): string | null {
+  const text = normalizeDownstreamKeyProxyUrl(value);
+  if (!text) return null;
+
+  try {
+    const parsed = new URL(text);
+    const host = (parsed.hostname || '').trim();
+    if (!host) return '已设置';
+    const port = parsed.port ? `:${parsed.port}` : '';
+    return `${host}${port}`;
+  } catch {
+    // Strip credentials-ish segments without relying on URL parser.
+    const withoutUserinfo = text.replace(/\/\/[^/@\s]+@/, '//');
+    const hostPortMatch = withoutUserinfo.match(/\/\/([^/?#]+)/);
+    if (hostPortMatch?.[1]) {
+      const candidate = hostPortMatch[1].trim();
+      if (candidate && !candidate.includes('@')) return candidate;
+    }
+    return '已设置';
+  }
+}


### PR DESCRIPTION
## Summary
Wire the already-shipped backend `downstream_api_keys.proxy_url` field into DownstreamKeys admin UI (#466 / KEY-578).

- Create/edit form hydrates and writes `proxyUrl` (empty/null inherits site/system)
- List/detail show a compact custom-proxy indicator; userinfo passwords are redacted (`hostname:port` / `已设置`)
- Create/update payloads include `proxyUrl`; empty clears to inherit
- Client validation: trim; non-empty must start with `http://`, `https://`, or `socks*`
- Pure helper + page tests cover hydrate / save / clear / invalid scheme

## Test plan
- [x] `npx vitest run --root . pages/helpers/downstreamKeyProxyUrl.test.ts pages/DownstreamKeys.test.tsx` (17 passed)
- [ ] Manual: create key with custom proxy → list badge shows host:port without credentials
- [ ] Manual: edit key, clear proxy → payload `proxyUrl: null`, indicator disappears
- [ ] Manual: invalid scheme blocked client-side before API call

Closes #466