### PR TITLE
feat(ui): wire TokenRoutes contextLength field (#467)

### DIFF
--- a/web/pages/TokenRoutes.tsx
+++ b/web/pages/TokenRoutes.tsx
@@ -57,6 +57,8 @@ import {
   normalizeRouteDisplayIconValue,
   inferEndpointTypesFromPlatform,
   getModelPatternError,
+  contextLengthFormValue,
+  parseRouteContextLength,
 } from './token-routes/utils.js';
 import { applyPriorityRailDrop, isPriorityRailNewLayerId } from './token-routes/priorityRail.js';
 import { useRouteChannels } from './token-routes/useRouteChannels.js';
@@ -82,6 +84,7 @@ type RouteEditorForm = {
   displayIcon: string;
   modelPattern: string;
   sourceRouteIds: number[];
+  contextLength: string;
   advancedOpen: boolean;
 };
 
@@ -91,6 +94,7 @@ const EMPTY_ROUTE_FORM: RouteEditorForm = {
   displayIcon: '',
   modelPattern: '',
   sourceRouteIds: [],
+  contextLength: '',
   advancedOpen: false,
 };
 const DESKTOP_DETAIL_ENTER_MS = 260;
@@ -494,6 +498,11 @@ export default function TokenRoutes() {
     const trimmedDisplayIcon = form.displayIcon.trim() ? form.displayIcon.trim() : undefined;
     const trimmedModelPattern = form.modelPattern.trim();
     const routeMode = normalizeRouteMode(form.routeMode);
+    const parsedContextLength = parseRouteContextLength(form.contextLength);
+    if (!parsedContextLength.valid) {
+      toast.error(parsedContextLength.error || tr('上下文长度无效'));
+      return;
+    }
     if (routeMode === 'explicit_group') {
       if (!trimmedDisplayName) {
         toast.error('请填写对外模型名');
@@ -522,6 +531,7 @@ export default function TokenRoutes() {
           ...(routeMode === 'pattern' ? { modelPattern: trimmedModelPattern } : {}),
           displayName: trimmedDisplayName,
           displayIcon: trimmedDisplayIcon,
+          contextLength: parsedContextLength.value,
           ...(routeMode === 'explicit_group' ? { sourceRouteIds: form.sourceRouteIds } : {}),
         });
         toast.success(routeMode === 'pattern' && modelPatternChanged ? tr('群组已更新并重新匹配通道') : tr('群组已更新'));
@@ -531,6 +541,7 @@ export default function TokenRoutes() {
           ...(routeMode === 'pattern' ? { modelPattern: trimmedModelPattern } : {}),
           displayName: trimmedDisplayName,
           displayIcon: trimmedDisplayIcon,
+          contextLength: parsedContextLength.value,
           ...(routeMode === 'explicit_group' ? { sourceRouteIds: form.sourceRouteIds } : {}),
         });
         toast.success(tr('群组已创建'));
@@ -555,6 +566,7 @@ export default function TokenRoutes() {
       displayName: route.displayName || '',
       displayIcon: normalizeRouteDisplayIconValue(route.displayIcon),
       sourceRouteIds: routeMode === 'explicit_group' ? [...(route.sourceRouteIds || [])] : [],
+      contextLength: contextLengthFormValue(route.contextLength),
       advancedOpen: routeMode === 'pattern',
     });
     setShowManual(true);

--- a/web/pages/token-routes/ManualRoutePanel.tsx
+++ b/web/pages/token-routes/ManualRoutePanel.tsx
@@ -12,6 +12,7 @@ import {
   matchesModelPattern,
   normalizeRouteDisplayIconValue,
   normalizeRouteMode,
+  parseRouteContextLength,
   resolveEndpointTypeIconModel,
   resolveRouteBrand,
   siteAvatarLetters,
@@ -23,6 +24,7 @@ type RouteEditorForm = {
   displayIcon: string;
   modelPattern: string;
   sourceRouteIds: number[];
+  contextLength: string;
   advancedOpen: boolean;
 };
 
@@ -150,6 +152,11 @@ export default function ManualRoutePanel({
     () => getModelPatternError(form.modelPattern),
     [form.modelPattern],
   );
+
+  const contextLengthError = useMemo(() => {
+    const parsed = parseRouteContextLength(form.contextLength);
+    return parsed.valid ? null : (parsed.error || tr('上下文长度无效'));
+  }, [form.contextLength]);
 
   const routeIconOptionValues = useMemo(
     () => new Set(routeIconSelectOptions.map((option) => option.value)),
@@ -602,6 +609,33 @@ export default function ManualRoutePanel({
                     )}
                   </div>
                 </label>
+
+                <label style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                  <span style={{ fontSize: 12, color: 'var(--color-text-secondary)' }}>{tr('上下文长度')}</span>
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    data-testid="route-context-length-input"
+                    placeholder={tr('可选，正整数 token（如 128000）；留空表示未知/不强制')}
+                    value={form.contextLength}
+                    onChange={(event) => setForm((current) => ({ ...current, contextLength: event.target.value }))}
+                    style={{
+                      width: '100%',
+                      padding: '10px 14px',
+                      border: `1px solid ${contextLengthError ? 'var(--color-danger)' : 'var(--color-border)'}`,
+                      borderRadius: 'var(--radius-sm)',
+                      fontSize: 13,
+                      outline: 'none',
+                      background: 'var(--color-bg)',
+                      color: 'var(--color-text-primary)',
+                      fontFamily: 'var(--font-mono)',
+                    }}
+                  />
+                  <span style={{ fontSize: 12, color: contextLengthError ? 'var(--color-danger)' : 'var(--color-text-muted)', lineHeight: 1.5 }}>
+                    {contextLengthError
+                      || tr('用于 max_tokens 上限校验；空 / 0 = 未知，不强制。')}
+                  </span>
+                </label>
               </div>
             </>
           ) : (
@@ -672,6 +706,33 @@ export default function ManualRoutePanel({
                     fontFamily: 'var(--font-mono)',
                   }}
                 />
+              </label>
+
+              <label style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                <span style={{ fontSize: 12, color: 'var(--color-text-secondary)' }}>{tr('上下文长度')}</span>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  data-testid="route-context-length-input"
+                  placeholder={tr('可选，正整数 token（如 128000）；留空表示未知/不强制')}
+                  value={form.contextLength}
+                  onChange={(event) => setForm((current) => ({ ...current, contextLength: event.target.value }))}
+                  style={{
+                    width: '100%',
+                    padding: '10px 14px',
+                    border: `1px solid ${contextLengthError ? 'var(--color-danger)' : 'var(--color-border)'}`,
+                    borderRadius: 'var(--radius-sm)',
+                    fontSize: 13,
+                    outline: 'none',
+                    background: 'var(--color-bg)',
+                    color: 'var(--color-text-primary)',
+                    fontFamily: 'var(--font-mono)',
+                  }}
+                />
+                <span style={{ fontSize: 12, color: contextLengthError ? 'var(--color-danger)' : 'var(--color-text-muted)', lineHeight: 1.5 }}>
+                  {contextLengthError
+                    || tr('用于 max_tokens 上限校验；空 / 0 = 未知，不强制。')}
+                </span>
               </label>
 
               <div style={{ fontSize: 12, color: 'var(--color-text-muted)', marginTop: -4 }}>

--- a/web/pages/token-routes/RouteCard.test.tsx
+++ b/web/pages/token-routes/RouteCard.test.tsx
@@ -145,6 +145,104 @@ describe('RouteCard', () => {
     expect(text).toContain('route-unit-third');
   });
 
+  it('shows contextLength badge when set and hides it for zero-channel rows', () => {
+    const withContext = create(
+      <RouteCard
+        route={buildRoute({
+          modelPattern: 'gpt-4o',
+          displayName: 'gpt-4o',
+          contextLength: 128000,
+        })}
+        brand={null}
+        expanded={false}
+        onToggleExpand={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onToggleEnabled={vi.fn()}
+        onClearCooldown={vi.fn()}
+        clearingCooldown={false}
+        onRoutingStrategyChange={vi.fn()}
+        updatingRoutingStrategy={false}
+        channels={undefined}
+        loadingChannels={false}
+        routeDecision={null}
+        loadingDecision={false}
+        candidateView={{ routeCandidates: [], accountOptions: [], tokenOptionsByAccountId: {} }}
+        channelTokenDraft={{}}
+        updatingChannel={{}}
+        savingPriority={false}
+        onTokenDraftChange={vi.fn()}
+        onSaveToken={vi.fn()}
+        onDeleteChannel={vi.fn()}
+        onToggleChannelEnabled={vi.fn()}
+        onChannelDragEnd={vi.fn()}
+        missingTokenSiteItems={[]}
+        missingTokenGroupItems={[]}
+        onCreateTokenForMissing={vi.fn()}
+        onAddChannel={vi.fn()}
+        onSiteBlockModel={vi.fn()}
+        expandedSourceGroupMap={{}}
+        onToggleSourceGroup={vi.fn()}
+      />,
+    );
+
+    const badge = withContext.root.find((node) => (
+      node.type === 'span'
+      && node.props['data-testid'] === 'route-context-length-badge'
+    ));
+    expect(collectText(badge)).toBe('128k');
+
+    const zeroChannel = create(
+      <RouteCard
+        route={buildRoute({
+          modelPattern: 'gpt-4o',
+          displayName: 'gpt-4o',
+          contextLength: 128000,
+          kind: 'zero_channel',
+          readOnly: true,
+          isVirtual: true,
+          channelCount: 0,
+          enabledChannelCount: 0,
+        })}
+        brand={null}
+        expanded={false}
+        onToggleExpand={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onToggleEnabled={vi.fn()}
+        onClearCooldown={vi.fn()}
+        clearingCooldown={false}
+        onRoutingStrategyChange={vi.fn()}
+        updatingRoutingStrategy={false}
+        channels={undefined}
+        loadingChannels={false}
+        routeDecision={null}
+        loadingDecision={false}
+        candidateView={{ routeCandidates: [], accountOptions: [], tokenOptionsByAccountId: {} }}
+        channelTokenDraft={{}}
+        updatingChannel={{}}
+        savingPriority={false}
+        onTokenDraftChange={vi.fn()}
+        onSaveToken={vi.fn()}
+        onDeleteChannel={vi.fn()}
+        onToggleChannelEnabled={vi.fn()}
+        onChannelDragEnd={vi.fn()}
+        missingTokenSiteItems={[]}
+        missingTokenGroupItems={[]}
+        onCreateTokenForMissing={vi.fn()}
+        onAddChannel={vi.fn()}
+        onSiteBlockModel={vi.fn()}
+        expandedSourceGroupMap={{}}
+        onToggleSourceGroup={vi.fn()}
+      />,
+    );
+
+    expect(() => zeroChannel.root.find((node) => (
+      node.type === 'span'
+      && node.props['data-testid'] === 'route-context-length-badge'
+    ))).toThrow();
+  });
+
   it('truncates the collapsed regex badge while keeping the group name primary', () => {
     const root = create(
       <RouteCard

--- a/web/pages/token-routes/RouteCard.tsx
+++ b/web/pages/token-routes/RouteCard.tsx
@@ -45,6 +45,7 @@ import {
   isExplicitGroupRoute,
   resolveRouteTitle,
   resolveRouteIcon,
+  formatRouteContextLength,
 } from './utils.js';
 import {
   buildPriorityBuckets,
@@ -583,6 +584,7 @@ function RouteCardInner({
   const cachedDecisionTooltip = route.decisionRefreshedAt
     ? `${tr('最近刷新')}: ${formatDateTimeMinuteLocal(route.decisionRefreshedAt)}`
     : undefined;
+  const contextLengthLabel = readOnlyRoute ? null : formatRouteContextLength(route.contextLength);
   const showAddChannelButton = !readOnlyRoute && !channelManagementDisabled;
   const showMissingTokenHints = !channelManagementDisabled && (missingTokenSiteItems.length > 0 || missingTokenGroupItems.length > 0);
   const routeUnits = collectRouteUnits(channels);
@@ -771,6 +773,16 @@ function RouteCardInner({
               {route.channelCount} {tr('通道')}
             </span>
           )}
+          {contextLengthLabel ? (
+            <span
+              className="badge badge-muted"
+              data-testid="route-context-length-badge"
+              data-tooltip={`${tr('上下文长度')}: ${contextLengthLabel} tokens`}
+              style={{ fontSize: 10, flexShrink: 0 }}
+            >
+              {contextLengthLabel}
+            </span>
+          ) : null}
           {hasCachedDecisionSnapshot ? (
             <span
               className="badge badge-success"
@@ -866,6 +878,16 @@ function RouteCardInner({
                 {route.channelCount} {tr('通道')}
               </span>
             )}
+            {contextLengthLabel ? (
+              <span
+                className="badge badge-muted"
+                data-testid="route-context-length-badge"
+                data-tooltip={`${tr('上下文长度')}: ${contextLengthLabel} tokens`}
+                style={{ fontSize: 10 }}
+              >
+                {contextLengthLabel}
+              </span>
+            ) : null}
             {hasCachedDecisionSnapshot ? (
               <span
                 className="badge badge-success"
@@ -947,6 +969,16 @@ function RouteCardInner({
               <span className="badge badge-info" style={{ fontSize: 10 }}>
                 {route.channelCount} {tr('通道')}
               </span>
+              {contextLengthLabel ? (
+                <span
+                  className="badge badge-muted"
+                  data-testid="route-context-length-badge"
+                  data-tooltip={`${tr('上下文长度')}: ${contextLengthLabel} tokens`}
+                  style={{ fontSize: 10 }}
+                >
+                  {contextLengthLabel}
+                </span>
+              ) : null}
               {hasCachedDecisionSnapshot ? (
                 <span
                   className="badge badge-success"

--- a/web/pages/token-routes/types.ts
+++ b/web/pages/token-routes/types.ts
@@ -73,6 +73,8 @@ export type RouteRow = {
   sourceRouteIds?: number[];
   modelMapping?: string | null;
   routingStrategy?: RouteRoutingStrategy | null;
+  /** Optional route context window (tokens). null/omit/0 = unknown, no enforce. */
+  contextLength?: number | null;
   decisionSnapshot?: RouteDecision | null;
   decisionRefreshedAt?: string | null;
   enabled: boolean;
@@ -88,6 +90,8 @@ export type RouteSummaryRow = {
   sourceRouteIds?: number[];
   modelMapping: string | null;
   routingStrategy?: RouteRoutingStrategy | null;
+  /** Optional route context window (tokens). null/omit/0 = unknown, no enforce. */
+  contextLength?: number | null;
   enabled: boolean;
   channelCount: number;
   enabledChannelCount: number;

--- a/web/pages/token-routes/utils.test.ts
+++ b/web/pages/token-routes/utils.test.ts
@@ -7,7 +7,10 @@ vi.mock('../../components/BrandIcon.js', () => ({
 
 import {
   ROUTE_ICON_NONE_VALUE,
+  contextLengthFormValue,
+  formatRouteContextLength,
   normalizeRouteDisplayIconValue,
+  parseRouteContextLength,
   resolveRouteIcon,
 } from './utils.js';
 
@@ -18,5 +21,35 @@ describe('token route icon helpers', () => {
 
   it('treats the explicit no-icon sentinel as no icon', () => {
     expect(resolveRouteIcon({ displayIcon: ROUTE_ICON_NONE_VALUE })).toEqual({ kind: 'none' });
+  });
+});
+
+describe('route contextLength helpers', () => {
+  it('hydrates positive contextLength into form string and clears unknown values', () => {
+    expect(contextLengthFormValue(128000)).toBe('128000');
+    expect(contextLengthFormValue(null)).toBe('');
+    expect(contextLengthFormValue(undefined)).toBe('');
+    expect(contextLengthFormValue(0)).toBe('');
+    expect(contextLengthFormValue(-1)).toBe('');
+  });
+
+  it('parses save payload: empty/0 → null, positive int accepted, rejects non-integer/negative', () => {
+    expect(parseRouteContextLength('')).toEqual({ valid: true, value: null });
+    expect(parseRouteContextLength('   ')).toEqual({ valid: true, value: null });
+    expect(parseRouteContextLength('0')).toEqual({ valid: true, value: null });
+    expect(parseRouteContextLength('128000')).toEqual({ valid: true, value: 128000 });
+    expect(parseRouteContextLength('-1').valid).toBe(false);
+    expect(parseRouteContextLength('1.5').valid).toBe(false);
+    expect(parseRouteContextLength('abc').valid).toBe(false);
+    expect(parseRouteContextLength('12e3').valid).toBe(false);
+  });
+
+  it('formats list/card labels only when set', () => {
+    expect(formatRouteContextLength(null)).toBeNull();
+    expect(formatRouteContextLength(0)).toBeNull();
+    expect(formatRouteContextLength(undefined)).toBeNull();
+    expect(formatRouteContextLength(128000)).toBe('128k');
+    expect(formatRouteContextLength(200000)).toBe('200k');
+    expect(formatRouteContextLength(8192)).toBe('8192');
   });
 });

--- a/web/pages/token-routes/utils.ts
+++ b/web/pages/token-routes/utils.ts
@@ -177,6 +177,64 @@ export function normalizeRoutes(routeRows: any[]): RouteRow[] {
   }));
 }
 
+/**
+ * Hydrate optional contextLength into a form string.
+ * null / omit / non-positive → empty (unknown / no enforce).
+ */
+export function contextLengthFormValue(value?: number | null): string {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return '';
+  return String(Math.trunc(n));
+}
+
+/**
+ * Parse contextLength from form input.
+ * empty / 0 → null (unknown, no enforce); rejects non-integers and negatives.
+ */
+export function parseRouteContextLength(raw: string): {
+  valid: boolean;
+  value: number | null;
+  error?: string;
+} {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { valid: true, value: null };
+  }
+  if (!/^\d+$/.test(trimmed)) {
+    return {
+      valid: false,
+      value: null,
+      error: '上下文长度必须是正整数 token 数（留空表示未知/不强制）',
+    };
+  }
+  const value = Number(trimmed);
+  if (!Number.isFinite(value) || value < 0) {
+    return {
+      valid: false,
+      value: null,
+      error: '上下文长度必须是正整数 token 数（留空表示未知/不强制）',
+    };
+  }
+  if (value === 0) {
+    return { valid: true, value: null };
+  }
+  return { valid: true, value: Math.trunc(value) };
+}
+
+/**
+ * Compact list/card label when set. null when unknown/unset.
+ * Multiples of 1000 → "128k"; otherwise raw count.
+ */
+export function formatRouteContextLength(value?: number | null): string | null {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const tokens = Math.trunc(n);
+  if (tokens % 1000 === 0) {
+    return `${tokens / 1000}k`;
+  }
+  return String(tokens);
+}
+
 export function buildSourceGroupKey(routeId: number, sourceModel: string): string {
   const normalizedSourceModel = sourceModel.trim() || '__ungrouped__';
   return `${routeId}::${normalizedSourceModel}`;

--- a/web/pages/tokenRoutes.context-length.test.tsx
+++ b/web/pages/tokenRoutes.context-length.test.tsx
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
+import { ToastProvider } from '../components/Toast.js';
+import TokenRoutes from './TokenRoutes.js';
+
+const { apiMock, getBrandMock } = vi.hoisted(() => ({
+  apiMock: {
+    getRoutesSummary: vi.fn(),
+    getRouteChannels: vi.fn(),
+    getModelTokenCandidates: vi.fn(),
+    getRouteDecisionsBatch: vi.fn(),
+    getRouteWideDecisionsBatch: vi.fn(),
+    updateRoute: vi.fn(),
+    addRoute: vi.fn(),
+  },
+  getBrandMock: vi.fn(),
+}));
+
+vi.mock('../api.js', () => ({
+  api: apiMock,
+}));
+
+vi.mock('../components/BrandIcon.js', () => ({
+  BrandGlyph: ({ brand, icon, model }: { brand?: { name?: string } | null; icon?: string | null; model?: string | null }) => (
+    <span>{brand?.name || icon || model || ''}</span>
+  ),
+  InlineBrandIcon: ({ model }: { model: string }) => model ? <span>{model}</span> : null,
+  getBrand: (...args: unknown[]) => getBrandMock(...args),
+  hashColor: () => 'linear-gradient(135deg,#4f46e5,#818cf8)',
+  normalizeBrandIconKey: (icon: string) => icon,
+}));
+
+function collectText(node: ReactTestInstance): string {
+  return (node.children || []).map((child) => {
+    if (typeof child === 'string') return child;
+    return collectText(child);
+  }).join('');
+}
+
+async function flushMicrotasks() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('TokenRoutes contextLength hydrate/save/clear', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getBrandMock.mockReset();
+    getBrandMock.mockReturnValue(null);
+    apiMock.getRoutesSummary.mockResolvedValue([
+      {
+        id: 21,
+        modelPattern: 'gpt-4o',
+        displayName: 'gpt-4o group',
+        displayIcon: null,
+        routeMode: 'explicit_group',
+        sourceRouteIds: [1],
+        modelMapping: null,
+        routingStrategy: 'weighted',
+        contextLength: 128000,
+        enabled: true,
+        channelCount: 2,
+        enabledChannelCount: 2,
+        siteNames: ['site-a'],
+        decisionSnapshot: null,
+        decisionRefreshedAt: null,
+      },
+    ]);
+    apiMock.getRouteChannels.mockResolvedValue([]);
+    apiMock.getModelTokenCandidates.mockResolvedValue({ models: {} });
+    apiMock.getRouteDecisionsBatch.mockResolvedValue({ decisions: {} });
+    apiMock.getRouteWideDecisionsBatch.mockResolvedValue({ decisions: {} });
+    apiMock.updateRoute.mockResolvedValue({});
+    apiMock.addRoute.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hydrates contextLength into the editor and saves null when cleared', async () => {
+    let root!: ReactTestRenderer;
+    await act(async () => {
+      root = create(
+        <MemoryRouter initialEntries={['/routes']}>
+          <ToastProvider>
+            <TokenRoutes />
+          </ToastProvider>
+        </MemoryRouter>,
+      );
+    });
+    await flushMicrotasks();
+
+    // Expand so edit button is available (expanded header has 编辑群组 for group routes).
+    const expandButton = root.root.find((node) => (
+      node.type === 'div'
+      && String(node.props.className || '').includes('route-card-collapsed')
+    ));
+    await act(async () => {
+      expandButton.props.onClick();
+    });
+    await flushMicrotasks();
+
+    const editButton = root.root.find((node) => (
+      node.type === 'button'
+      && collectText(node).includes('编辑群组')
+    ));
+    await act(async () => {
+      editButton.props.onClick();
+    });
+    await flushMicrotasks();
+
+    const input = root.root.find((node) => (
+      node.type === 'input'
+      && node.props['data-testid'] === 'route-context-length-input'
+    ));
+    expect(input.props.value).toBe('128000');
+
+    await act(async () => {
+      input.props.onChange({ target: { value: '' } });
+    });
+    await flushMicrotasks();
+
+    const saveButton = root.root.find((node) => (
+      node.type === 'button'
+      && collectText(node).includes('保存群组')
+    ));
+    await act(async () => {
+      saveButton.props.onClick();
+    });
+    await flushMicrotasks();
+
+    expect(apiMock.updateRoute).toHaveBeenCalledWith(
+      21,
+      expect.objectContaining({
+        contextLength: null,
+      }),
+    );
+  });
+
+  it('rejects non-integer contextLength before submit', async () => {
+    let root!: ReactTestRenderer;
+    await act(async () => {
+      root = create(
+        <MemoryRouter initialEntries={['/routes']}>
+          <ToastProvider>
+            <TokenRoutes />
+          </ToastProvider>
+        </MemoryRouter>,
+      );
+    });
+    await flushMicrotasks();
+
+    const expandButton = root.root.find((node) => (
+      node.type === 'div'
+      && String(node.props.className || '').includes('route-card-collapsed')
+    ));
+    await act(async () => {
+      expandButton.props.onClick();
+    });
+    await flushMicrotasks();
+
+    const editButton = root.root.find((node) => (
+      node.type === 'button'
+      && collectText(node).includes('编辑群组')
+    ));
+    await act(async () => {
+      editButton.props.onClick();
+    });
+    await flushMicrotasks();
+
+    const input = root.root.find((node) => (
+      node.type === 'input'
+      && node.props['data-testid'] === 'route-context-length-input'
+    ));
+    await act(async () => {
+      input.props.onChange({ target: { value: '-12' } });
+    });
+    await flushMicrotasks();
+
+    const saveButton = root.root.find((node) => (
+      node.type === 'button'
+      && collectText(node).includes('保存群组')
+    ));
+    await act(async () => {
+      saveButton.props.onClick();
+    });
+    await flushMicrotasks();
+
+    expect(apiMock.updateRoute).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Expose optional `contextLength` on TokenRoutes create/edit form (`ManualRoutePanel` / `RouteEditorForm`)
- Show compact badge on route cards when set (e.g. `128k`); skip clutter on zero-channel rows
- Include field on create/update payloads; empty/0 clears to `null` for backend no-enforce
- Client-side reject non-integer/negative values; pure helper + hydrate/save/clear tests

Closes #467

## Test plan
- [x] `cd web && npm run typecheck:web`
- [x] `cd web && npm test -- --run token-routes`
- [x] pre-push local CI (`go vet` + `go test -race`)