### PR TITLE
feat(ui): wire DownstreamKeys maxRpm/maxTpm create/edit/list (#475)

### DIFF
--- a/web/pages/DownstreamKeys.test.tsx
+++ b/web/pages/DownstreamKeys.test.tsx
@@ -1083,4 +1083,199 @@ describe('DownstreamKeys page', () => {
       root?.unmount();
     }
   });
+
+  it('hydrates maxRpm/maxTpm into editor and shows compact list indicators', async () => {
+    apiMock.getDownstreamApiKeysSummary.mockResolvedValue({
+      success: true,
+      items: [buildSummaryItem({
+        maxRpm: 60,
+        maxTpm: 100_000,
+      })],
+    });
+    apiMock.getDownstreamApiKeys.mockResolvedValue({
+      success: true,
+      items: [buildRawItem({
+        maxRpm: 60,
+        maxTpm: 100_000,
+      })],
+    });
+
+    let root!: WebTestRenderer;
+    try {
+      await act(async () => {
+        root = create(
+          <MemoryRouter initialEntries={['/downstream-keys']}>
+            <ToastProvider>
+              <DownstreamKeys />
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+      });
+      await flushMicrotasks();
+
+      const pageText = collectText(root!.root);
+      expect(pageText).toContain('RPM 60');
+      expect(pageText).toContain('TPM 100k');
+
+      const editBtn = root!.root.findAll((node) => node.type === 'button' && collectText(node) === '编辑')[0];
+      await act(async () => {
+        editBtn.props.onClick();
+      });
+      await flushMicrotasks();
+
+      const rpmInput = root!.root.findAllByType('input').find((node) =>
+        String(node.props.placeholder || '').includes('留空表示不限，例如 60'),
+      );
+      const tpmInput = root!.root.findAllByType('input').find((node) =>
+        String(node.props.placeholder || '').includes('留空表示不限，例如 100000'),
+      );
+      expect(rpmInput?.props.value).toBe('60');
+      expect(tpmInput?.props.value).toBe('100000');
+    } finally {
+      root?.unmount();
+    }
+  });
+
+  it('saves maxRpm/maxTpm on create and clears empty values as null', async () => {
+    let root!: WebTestRenderer;
+    try {
+      await act(async () => {
+        root = create(
+          <MemoryRouter initialEntries={['/downstream-keys']}>
+            <ToastProvider>
+              <DownstreamKeys />
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+      });
+      await flushMicrotasks();
+
+      const createBtn = root!.root.findAll((node) => node.type === 'button' && collectText(node).includes('新增下游密钥'))[0];
+      await act(async () => {
+        createBtn.props.onClick();
+      });
+      await flushMicrotasks();
+
+      const inputs = root!.root.findAllByType('input');
+      const nameInput = inputs.find((node) => node.props.placeholder === '例如：项目 A / 移动端');
+      const keyInput = inputs.find((node) => node.props.placeholder === 'sk-...');
+      const rpmInput = inputs.find((node) =>
+        String(node.props.placeholder || '').includes('留空表示不限，例如 60'),
+      );
+      const tpmInput = inputs.find((node) =>
+        String(node.props.placeholder || '').includes('留空表示不限，例如 100000'),
+      );
+      expect(rpmInput).toBeTruthy();
+      expect(tpmInput).toBeTruthy();
+      expect(rpmInput?.props.value).toBe('');
+      expect(tpmInput?.props.value).toBe('');
+
+      await act(async () => {
+        nameInput!.props.onChange({ target: { value: 'rate-key' } });
+        keyInput!.props.onChange({ target: { value: 'sk-rate-key-0475' } });
+        rpmInput!.props.onChange({ target: { value: '  60  ' } });
+        tpmInput!.props.onChange({ target: { value: '100000' } });
+      });
+      await flushMicrotasks();
+
+      const saveBtn = root!.root.findAll((node) => node.type === 'button' && collectText(node).includes('创建密钥'))[0];
+      await act(async () => {
+        saveBtn.props.onClick();
+      });
+      await flushMicrotasks();
+
+      expect(apiMock.createDownstreamApiKey).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'rate-key',
+        key: 'sk-rate-key-0475',
+        maxRpm: 60,
+        maxTpm: 100000,
+      }));
+
+      // Re-open create form and save with empty rate limits → null unlimited.
+      apiMock.createDownstreamApiKey.mockClear();
+      const createBtn2 = root!.root.findAll((node) => node.type === 'button' && collectText(node).includes('新增下游密钥'))[0];
+      await act(async () => {
+        createBtn2.props.onClick();
+      });
+      await flushMicrotasks();
+
+      const inputs2 = root!.root.findAllByType('input');
+      const nameInput2 = inputs2.find((node) => node.props.placeholder === '例如：项目 A / 移动端');
+      const keyInput2 = inputs2.find((node) => node.props.placeholder === 'sk-...');
+      const rpmInput2 = inputs2.find((node) =>
+        String(node.props.placeholder || '').includes('留空表示不限，例如 60'),
+      );
+      const tpmInput2 = inputs2.find((node) =>
+        String(node.props.placeholder || '').includes('留空表示不限，例如 100000'),
+      );
+      await act(async () => {
+        nameInput2!.props.onChange({ target: { value: 'unlimited-key' } });
+        keyInput2!.props.onChange({ target: { value: 'sk-unlimited-key-0475' } });
+        rpmInput2!.props.onChange({ target: { value: '   ' } });
+        tpmInput2!.props.onChange({ target: { value: '0' } });
+      });
+      await flushMicrotasks();
+
+      const saveBtn2 = root!.root.findAll((node) => node.type === 'button' && collectText(node).includes('创建密钥'))[0];
+      await act(async () => {
+        saveBtn2.props.onClick();
+      });
+      await flushMicrotasks();
+
+      expect(apiMock.createDownstreamApiKey).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'unlimited-key',
+        key: 'sk-unlimited-key-0475',
+        maxRpm: null,
+        maxTpm: null,
+      }));
+    } finally {
+      root?.unmount();
+    }
+  });
+
+  it('rejects invalid maxRpm before calling create API', async () => {
+    let root!: WebTestRenderer;
+    try {
+      await act(async () => {
+        root = create(
+          <MemoryRouter initialEntries={['/downstream-keys']}>
+            <ToastProvider>
+              <DownstreamKeys />
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+      });
+      await flushMicrotasks();
+
+      const createBtn = root!.root.findAll((node) => node.type === 'button' && collectText(node).includes('新增下游密钥'))[0];
+      await act(async () => {
+        createBtn.props.onClick();
+      });
+      await flushMicrotasks();
+
+      const inputs = root!.root.findAllByType('input');
+      const nameInput = inputs.find((node) => node.props.placeholder === '例如：项目 A / 移动端');
+      const keyInput = inputs.find((node) => node.props.placeholder === 'sk-...');
+      const rpmInput = inputs.find((node) =>
+        String(node.props.placeholder || '').includes('留空表示不限，例如 60'),
+      );
+
+      await act(async () => {
+        nameInput!.props.onChange({ target: { value: 'bad-rpm-key' } });
+        keyInput!.props.onChange({ target: { value: 'sk-bad-rpm-0475' } });
+        rpmInput!.props.onChange({ target: { value: '12.5' } });
+      });
+      await flushMicrotasks();
+
+      const saveBtn = root!.root.findAll((node) => node.type === 'button' && collectText(node).includes('创建密钥'))[0];
+      await act(async () => {
+        saveBtn.props.onClick();
+      });
+      await flushMicrotasks();
+
+      expect(apiMock.createDownstreamApiKey).not.toHaveBeenCalled();
+    } finally {
+      root?.unmount();
+    }
+  });
 });

--- a/web/pages/DownstreamKeys.tsx
+++ b/web/pages/DownstreamKeys.tsx
@@ -32,6 +32,13 @@ import {
   hasCustomDownstreamKeyProxy,
   parseDownstreamKeyProxyUrl,
 } from './helpers/downstreamKeyProxyUrl.js';
+import {
+  formatDownstreamKeyMaxRpm,
+  formatDownstreamKeyMaxTpm,
+  formatDownstreamKeyRateLimits,
+  hasDownstreamKeyRateLimit,
+  parseQuotaIntOrNull,
+} from './helpers/downstreamKeyRateLimit.js';
 
 type Status = 'all' | 'enabled' | 'disabled';
 
@@ -49,6 +56,10 @@ type DownstreamApiKeyItem = {
   usedCost: number;
   maxRequests: number | null;
   usedRequests: number;
+  /** Optional soft RPM window (learn #116); null = unlimited. */
+  maxRpm?: number | null;
+  /** Optional soft TPM window (learn #116); null = unlimited. */
+  maxTpm?: number | null;
   supportedModels: string[];
   allowedRouteIds: number[];
   siteWeightMultipliers: Record<number, number>;
@@ -352,6 +363,8 @@ function buildEditorForm(
     tags: normalizeTags(Array.isArray(item?.tags) ? item!.tags : []),
     maxCost: item?.maxCost === null || item?.maxCost === undefined ? '' : String(item.maxCost),
     maxRequests: item?.maxRequests === null || item?.maxRequests === undefined ? '' : String(item.maxRequests),
+    maxRpm: item?.maxRpm === null || item?.maxRpm === undefined ? '' : String(item.maxRpm),
+    maxTpm: item?.maxTpm === null || item?.maxTpm === undefined ? '' : String(item.maxTpm),
     expiresAt: toDateTimeLocal(item?.expiresAt),
     enabled: item?.enabled ?? true,
     proxyUrl: item?.proxyUrl ?? '',
@@ -631,6 +644,8 @@ export default function DownstreamKeys() {
         usedCost: raw?.usedCost ?? item.usedCost,
         maxRequests: raw?.maxRequests ?? item.maxRequests,
         usedRequests: raw?.usedRequests ?? item.usedRequests,
+        maxRpm: raw?.maxRpm ?? item.maxRpm ?? null,
+        maxTpm: raw?.maxTpm ?? item.maxTpm ?? null,
         supportedModels: raw?.supportedModels ?? item.supportedModels,
         allowedRouteIds: raw?.allowedRouteIds ?? item.allowedRouteIds,
         siteWeightMultipliers: raw?.siteWeightMultipliers ?? item.siteWeightMultipliers,
@@ -816,6 +831,17 @@ export default function DownstreamKeys() {
       return;
     }
 
+    const parsedMaxRpm = parseQuotaIntOrNull(editorForm.maxRpm, 'RPM 上限');
+    if (!parsedMaxRpm.valid) {
+      toast.info(parsedMaxRpm.error || 'RPM 上限格式无效');
+      return;
+    }
+    const parsedMaxTpm = parseQuotaIntOrNull(editorForm.maxTpm, 'TPM 上限');
+    if (!parsedMaxTpm.valid) {
+      toast.info(parsedMaxTpm.error || 'TPM 上限格式无效');
+      return;
+    }
+
     let siteWeightMultipliers: Record<number, number> = {};
     const rawWeights = editorForm.siteWeightMultipliersText.trim();
     if (rawWeights && rawWeights !== '{}') {
@@ -848,6 +874,8 @@ export default function DownstreamKeys() {
         expiresAt: editorForm.expiresAt ? new Date(editorForm.expiresAt).toISOString() : null,
         maxCost: editorForm.maxCost.trim() ? Number(editorForm.maxCost.trim()) : null,
         maxRequests: editorForm.maxRequests.trim() ? Number(editorForm.maxRequests.trim()) : null,
+        maxRpm: parsedMaxRpm.value,
+        maxTpm: parsedMaxTpm.value,
         proxyUrl: parsedProxy.value,
         supportedModels: uniqStrings(editorForm.selectedModels),
         allowedRouteIds: uniqIds(editorForm.selectedGroupRouteIds).filter((id) => routeMap.has(id) && isGroupRouteOption(routeMap.get(id)!)),
@@ -1200,6 +1228,13 @@ export default function DownstreamKeys() {
                       stacked
                     />
                   ) : null}
+                  {hasDownstreamKeyRateLimit(row.maxRpm) || hasDownstreamKeyRateLimit(row.maxTpm) ? (
+                    <MobileField
+                      label="速率"
+                      value={formatDownstreamKeyRateLimits(row.maxRpm, row.maxTpm) || '--'}
+                      stacked
+                    />
+                  ) : null}
                   <MobileField label="模型" value={summarizeModelLimit(row.supportedModels || [])} stacked />
                   <MobileField label="群组" value={summarizeRouteLimit(row.allowedRouteIds || [], routeMap)} stacked />
                   <MobileField label="倍率" value={summarizeSiteWeightMultipliers(row.siteWeightMultipliers || {})} stacked />
@@ -1261,6 +1296,16 @@ export default function DownstreamKeys() {
                               代理 · {formatDownstreamKeyProxyIndicator(row.proxyUrl) || '已设置'}
                             </span>
                           ) : null}
+                          {hasDownstreamKeyRateLimit(row.maxRpm) ? (
+                            <span className="badge badge-info" style={{ fontSize: 11 }}>
+                              {formatDownstreamKeyMaxRpm(row.maxRpm)}
+                            </span>
+                          ) : null}
+                          {hasDownstreamKeyRateLimit(row.maxTpm) ? (
+                            <span className="badge badge-info" style={{ fontSize: 11 }}>
+                              {formatDownstreamKeyMaxTpm(row.maxTpm)}
+                            </span>
+                          ) : null}
                         </div>
                       </td>
                       <td>
@@ -1274,6 +1319,11 @@ export default function DownstreamKeys() {
                       <td style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
                         <div style={{ color: 'var(--color-text-primary)', fontWeight: 700 }}>{row.maxRequests == null ? '不限' : row.maxRequests.toLocaleString()}</div>
                         <div style={{ fontSize: 12, color: 'var(--color-text-muted)', marginTop: 4 }}>{row.maxCost == null ? '成本不限' : `成本 ${formatMoney(row.maxCost)}`}</div>
+                        {formatDownstreamKeyRateLimits(row.maxRpm, row.maxTpm) ? (
+                          <div style={{ fontSize: 12, color: 'var(--color-text-muted)', marginTop: 4 }}>
+                            {formatDownstreamKeyRateLimits(row.maxRpm, row.maxTpm)}
+                          </div>
+                        ) : null}
                         <div style={{ fontSize: 12, color: 'var(--color-text-muted)', marginTop: 4 }}>{row.expiresAt ? `到期 ${formatIso(row.expiresAt)}` : '永久有效'}</div>
                       </td>
                       <td style={{ textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>

--- a/web/pages/downstream-keys/DownstreamKeyDrawer.tsx
+++ b/web/pages/downstream-keys/DownstreamKeyDrawer.tsx
@@ -21,6 +21,11 @@ import {
   formatDownstreamKeyProxyIndicator,
   hasCustomDownstreamKeyProxy,
 } from '../helpers/downstreamKeyProxyUrl.js';
+import {
+  formatDownstreamKeyMaxRpm,
+  formatDownstreamKeyMaxTpm,
+  hasDownstreamKeyRateLimit,
+} from '../helpers/downstreamKeyRateLimit.js';
 
 const DownstreamKeyTrendChart = lazy(() => import('../../components/charts/DownstreamKeyTrendChart.js'));
 type DownstreamKeyTrendBucket = import('../../components/charts/DownstreamKeyTrendChart.js').DownstreamKeyTrendBucket;
@@ -201,6 +206,22 @@ export default function DownstreamKeyDrawer({
                       : '继承站点/系统'}
                   </div>
                 </div>
+                {hasDownstreamKeyRateLimit(item?.maxRpm) ? (
+                  <div>
+                    <div style={{ color: 'var(--color-text-muted)', marginBottom: 4 }}>RPM 上限</div>
+                    <div style={{ color: 'var(--color-text-primary)', fontWeight: 600 }}>
+                      {formatDownstreamKeyMaxRpm(item?.maxRpm)}
+                    </div>
+                  </div>
+                ) : null}
+                {hasDownstreamKeyRateLimit(item?.maxTpm) ? (
+                  <div>
+                    <div style={{ color: 'var(--color-text-muted)', marginBottom: 4 }}>TPM 上限</div>
+                    <div style={{ color: 'var(--color-text-primary)', fontWeight: 600 }}>
+                      {formatDownstreamKeyMaxTpm(item?.maxTpm)}
+                    </div>
+                  </div>
+                ) : null}
                 <div style={{ gridColumn: '1 / -1' }}>
                   <div style={{ color: 'var(--color-text-muted)', marginBottom: 6 }}>标签</div>
                   <TagChips tags={item?.tags || []} accent maxVisible={6} />

--- a/web/pages/downstream-keys/DownstreamKeyEditorModal.tsx
+++ b/web/pages/downstream-keys/DownstreamKeyEditorModal.tsx
@@ -25,6 +25,10 @@ export type DownstreamKeyEditorForm = {
   tags: string[];
   maxCost: string;
   maxRequests: string;
+  /** Optional soft RPM; empty = unlimited. */
+  maxRpm: string;
+  /** Optional soft TPM; empty = unlimited. */
+  maxTpm: string;
   expiresAt: string;
   enabled: boolean;
   /** Per-key egress proxy; empty = inherit site/account/system. */
@@ -412,6 +416,28 @@ export default function DownstreamKeyEditorModal({
           <input value={form.maxCost} onChange={(e) => onChange((prev) => ({ ...prev, maxCost: e.target.value }))} placeholder="留空表示不限" style={inputStyle} />
         </div>
         <div className="downstream-key-modal-field">
+          <div className="downstream-key-modal-label">RPM 上限</div>
+          <input
+            value={form.maxRpm}
+            onChange={(e) => onChange((prev) => ({ ...prev, maxRpm: e.target.value }))}
+            placeholder="留空表示不限，例如 60"
+            style={inputStyle}
+            inputMode="numeric"
+            autoComplete="off"
+          />
+        </div>
+        <div className="downstream-key-modal-field">
+          <div className="downstream-key-modal-label">TPM 上限</div>
+          <input
+            value={form.maxTpm}
+            onChange={(e) => onChange((prev) => ({ ...prev, maxTpm: e.target.value }))}
+            placeholder="留空表示不限，例如 100000"
+            style={inputStyle}
+            inputMode="numeric"
+            autoComplete="off"
+          />
+        </div>
+        <div className="downstream-key-modal-field">
           <div className="downstream-key-modal-label">过期时间</div>
           <input type="datetime-local" value={form.expiresAt} onChange={(e) => onChange((prev) => ({ ...prev, expiresAt: e.target.value }))} style={inputStyle} />
         </div>
@@ -427,6 +453,11 @@ export default function DownstreamKeyEditorModal({
           />
           <div className="downstream-key-modal-help">
             仅影响此密钥的上游出口。填写后优先使用密钥代理；留空则继承站点 / 账号 / 系统代理链路。
+          </div>
+        </div>
+        <div className="downstream-key-modal-field downstream-key-modal-field-full">
+          <div className="downstream-key-modal-help">
+            RPM / TPM 为每分钟软准入窗口（learn #116）。留空或 0 表示不限；正整数生效。
           </div>
         </div>
         <label className="downstream-key-modal-toggle">

--- a/web/pages/downstream-keys/shared.tsx
+++ b/web/pages/downstream-keys/shared.tsx
@@ -15,6 +15,10 @@ export type SummaryItem = {
   usedCost: number;
   maxRequests: number | null;
   usedRequests: number;
+  /** Optional soft RPM window (learn #116); null = unlimited. */
+  maxRpm?: number | null;
+  /** Optional soft TPM window (learn #116); null = unlimited. */
+  maxTpm?: number | null;
   supportedModels: string[];
   allowedRouteIds: number[];
   siteWeightMultipliers: Record<number, number>;

--- a/web/pages/helpers/downstreamKeyRateLimit.test.ts
+++ b/web/pages/helpers/downstreamKeyRateLimit.test.ts
@@ -34,11 +34,14 @@ describe('downstreamKeyRateLimit', () => {
   });
 
   it('rejects non-integer garbage instead of silently clearing', () => {
-    expect(parseQuotaIntOrNull('abc').valid).toBe(false);
+    const invalid = parseQuotaIntOrNull('abc');
+    expect(invalid.valid).toBe(false);
+    if (!invalid.valid) {
+      expect(invalid.error).toContain('正整数');
+    }
     expect(parseQuotaIntOrNull('12.5').valid).toBe(false);
     expect(parseQuotaIntOrNull('1e3').valid).toBe(false);
     expect(parseQuotaIntOrNull('60rpm').valid).toBe(false);
-    expect(parseQuotaIntOrNull('abc').error).toContain('正整数');
   });
 
   it('formats compact RPM/TPM badges only when set', () => {

--- a/web/pages/helpers/downstreamKeyRateLimit.test.ts
+++ b/web/pages/helpers/downstreamKeyRateLimit.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatDownstreamKeyMaxRpm,
+  formatDownstreamKeyMaxTpm,
+  formatDownstreamKeyRateLimits,
+  hasDownstreamKeyRateLimit,
+  normalizeQuotaIntInput,
+  parseQuotaIntOrNull,
+} from './downstreamKeyRateLimit.js';
+
+describe('downstreamKeyRateLimit', () => {
+  it('normalizes empty / null input', () => {
+    expect(normalizeQuotaIntInput(null)).toBe('');
+    expect(normalizeQuotaIntInput(undefined)).toBe('');
+    expect(normalizeQuotaIntInput('  ')).toBe('');
+    expect(normalizeQuotaIntInput(60)).toBe('60');
+    expect(normalizeQuotaIntInput('  100  ')).toBe('100');
+  });
+
+  it('parses empty/0/negative as unlimited null (backend clear contract)', () => {
+    expect(parseQuotaIntOrNull('')).toEqual({ valid: true, value: null });
+    expect(parseQuotaIntOrNull('   ')).toEqual({ valid: true, value: null });
+    expect(parseQuotaIntOrNull(null)).toEqual({ valid: true, value: null });
+    expect(parseQuotaIntOrNull('0')).toEqual({ valid: true, value: null });
+    expect(parseQuotaIntOrNull('00')).toEqual({ valid: true, value: null });
+    expect(parseQuotaIntOrNull('-1')).toEqual({ valid: true, value: null });
+    expect(parseQuotaIntOrNull(-5)).toEqual({ valid: true, value: null });
+  });
+
+  it('accepts positive integers', () => {
+    expect(parseQuotaIntOrNull('60')).toEqual({ valid: true, value: 60 });
+    expect(parseQuotaIntOrNull('  100000  ')).toEqual({ valid: true, value: 100000 });
+    expect(parseQuotaIntOrNull(42)).toEqual({ valid: true, value: 42 });
+  });
+
+  it('rejects non-integer garbage instead of silently clearing', () => {
+    expect(parseQuotaIntOrNull('abc').valid).toBe(false);
+    expect(parseQuotaIntOrNull('12.5').valid).toBe(false);
+    expect(parseQuotaIntOrNull('1e3').valid).toBe(false);
+    expect(parseQuotaIntOrNull('60rpm').valid).toBe(false);
+    expect(parseQuotaIntOrNull('abc').error).toContain('正整数');
+  });
+
+  it('formats compact RPM/TPM badges only when set', () => {
+    expect(hasDownstreamKeyRateLimit(null)).toBe(false);
+    expect(hasDownstreamKeyRateLimit(0)).toBe(false);
+    expect(hasDownstreamKeyRateLimit(60)).toBe(true);
+
+    expect(formatDownstreamKeyMaxRpm(null)).toBeNull();
+    expect(formatDownstreamKeyMaxRpm(0)).toBeNull();
+    expect(formatDownstreamKeyMaxRpm(60)).toBe('RPM 60');
+    expect(formatDownstreamKeyMaxRpm(1500)).toBe('RPM 1.5k');
+
+    expect(formatDownstreamKeyMaxTpm(null)).toBeNull();
+    expect(formatDownstreamKeyMaxTpm(100_000)).toBe('TPM 100k');
+    expect(formatDownstreamKeyMaxTpm(1_500_000)).toBe('TPM 1.5M');
+
+    expect(formatDownstreamKeyRateLimits(null, null)).toBeNull();
+    expect(formatDownstreamKeyRateLimits(60, null)).toBe('RPM 60');
+    expect(formatDownstreamKeyRateLimits(null, 100_000)).toBe('TPM 100k');
+    expect(formatDownstreamKeyRateLimits(60, 100_000)).toBe('RPM 60 · TPM 100k');
+  });
+});

--- a/web/pages/helpers/downstreamKeyRateLimit.ts
+++ b/web/pages/helpers/downstreamKeyRateLimit.ts
@@ -1,0 +1,118 @@
+/**
+ * Downstream key maxRpm / maxTpm helpers (learn #116 / #475).
+ * Matches backend normalizeQuotaIntOrNull:
+ *   empty/null/0/negative → null (unlimited)
+ *   positive integer → stored value
+ * Client rejects non-integer garbage so operators get a clear error
+ * instead of a silent clear.
+ */
+
+export type QuotaIntParseResult =
+  | { valid: true; value: number | null }
+  | { valid: false; value: null; error: string };
+
+const INVALID_QUOTA_INT_ERROR = '速率上限必须是正整数；留空或 0 表示不限';
+
+export function normalizeQuotaIntInput(raw: string | number | null | undefined): string {
+  if (raw === null || raw === undefined) return '';
+  return String(raw).trim();
+}
+
+/**
+ * Parse optional rate-limit field for create/update payloads.
+ * Empty / 0 / negative → null (unlimited, same as backend clear contract).
+ * Positive whole numbers → value. Non-integers / non-numeric → invalid.
+ */
+export function parseQuotaIntOrNull(
+  raw: string | number | null | undefined,
+  fieldLabel = '速率上限',
+): QuotaIntParseResult {
+  const trimmed = normalizeQuotaIntInput(raw);
+  if (!trimmed) {
+    return { valid: true, value: null };
+  }
+
+  // Explicit signed zero / negative: clear to unlimited (backend <=0 → NULL).
+  if (/^-\d+$/.test(trimmed) || trimmed === '0' || /^0+$/.test(trimmed)) {
+    return { valid: true, value: null };
+  }
+
+  // Positive integer only — reject decimals / scientific / garbage.
+  if (!/^\d+$/.test(trimmed)) {
+    return {
+      valid: false,
+      value: null,
+      error: `${fieldLabel}必须是正整数；留空或 0 表示不限`,
+    };
+  }
+
+  const value = Number(trimmed);
+  if (!Number.isFinite(value) || value <= 0) {
+    return { valid: true, value: null };
+  }
+
+  // Guard against values that overflow safe integer range for JSON.
+  if (value > Number.MAX_SAFE_INTEGER) {
+    return {
+      valid: false,
+      value: null,
+      error: INVALID_QUOTA_INT_ERROR,
+    };
+  }
+
+  return { valid: true, value: Math.trunc(value) };
+}
+
+export function hasDownstreamKeyRateLimit(value?: number | null): boolean {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0;
+}
+
+/** Compact token-style suffix: 1000 → 1k, 100000 → 100k, 1_500_000 → 1.5M */
+function formatCompactCount(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return '0';
+  const n = Math.trunc(value);
+  if (n >= 1_000_000_000) {
+    const scaled = n / 1_000_000_000;
+    return `${Number.isInteger(scaled) ? scaled.toFixed(0) : scaled.toFixed(1).replace(/\.0$/, '')}B`;
+  }
+  if (n >= 1_000_000) {
+    const scaled = n / 1_000_000;
+    return `${Number.isInteger(scaled) ? scaled.toFixed(0) : scaled.toFixed(1).replace(/\.0$/, '')}M`;
+  }
+  if (n >= 1_000) {
+    const scaled = n / 1_000;
+    return `${Number.isInteger(scaled) ? scaled.toFixed(0) : scaled.toFixed(1).replace(/\.0$/, '')}k`;
+  }
+  return String(n);
+}
+
+/**
+ * Compact list/detail badge when maxRpm is set.
+ * Returns null when unlimited.
+ */
+export function formatDownstreamKeyMaxRpm(value?: number | null): string | null {
+  if (!hasDownstreamKeyRateLimit(value)) return null;
+  return `RPM ${formatCompactCount(Number(value))}`;
+}
+
+/**
+ * Compact list/detail badge when maxTpm is set.
+ * Returns null when unlimited. Example: TPM 100k
+ */
+export function formatDownstreamKeyMaxTpm(value?: number | null): string | null {
+  if (!hasDownstreamKeyRateLimit(value)) return null;
+  return `TPM ${formatCompactCount(Number(value))}`;
+}
+
+/** Join set rate badges for list cells; empty when both unlimited. */
+export function formatDownstreamKeyRateLimits(
+  maxRpm?: number | null,
+  maxTpm?: number | null,
+): string | null {
+  const parts = [
+    formatDownstreamKeyMaxRpm(maxRpm),
+    formatDownstreamKeyMaxTpm(maxTpm),
+  ].filter(Boolean) as string[];
+  return parts.length > 0 ? parts.join(' · ') : null;
+}


### PR DESCRIPTION
## Summary
- Wire optional DownstreamKeys `maxRpm` / `maxTpm` into create/edit form, list badges, and detail drawer (backend admission already present from #116).
- Empty / 0 / negative clear to `null` unlimited; client rejects non-integers before submit to match `normalizeQuotaIntOrNull` without silent clear.
- Pure helper + page tests cover hydrate / save / clear / invalid input.

## Client rule (matches backend)
- omitted/null/""/0/negative → `null` (unlimited)
- positive integer → stored
- non-integer garbage → client reject (backend would also null it; we surface an error instead)

## Test plan
- [x] `cd web && npm test -- --run DownstreamKeys downstreamKeyRateLimit`
- [x] `cd web && npm run typecheck:web`
- [ ] Manual: create key with RPM 60 / TPM 100000 → list shows badges; edit clear fields → null unlimited

Closes #475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-key RPM and TPM rate limits for downstream keys.
  * Display configured limits in key lists, detail views, and compact mobile indicators.
  * Added validation and clear handling: blank, zero, or negative values mean unlimited.
  * Added user guidance explaining soft rate-limit behavior.

* **Bug Fixes**
  * Prevented saving when rate-limit values are invalid or non-integer.

* **Tests**
  * Added coverage for rate-limit parsing, formatting, validation, hydration, and save behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->