### PR TITLE
fix(admin): clear meta_monitor_auth on AuthToken change (#484)

### DIFF
--- a/handler/admin/auth_settings.go
+++ b/handler/admin/auth_settings.go
@@ -94,6 +94,11 @@ func (h *authSettingsHandler) changeToken(w http.ResponseWriter, r *http.Request
 	// Update runtime config
 	h.cfg.AuthToken = body.NewToken
 
+	// Defense-in-depth: expire HttpOnly meta_monitor_auth so browsers drop the
+	// dead cookie after AuthToken rotation (HMAC already invalidates server-side).
+	// Only on success — failed change must not clear a still-valid session cookie.
+	clearMonitorAuthCookies(w, r)
+
 	// Log the change event
 	h.db.Exec(`INSERT INTO events (type, title, message, level, related_type, created_at, read)
 		VALUES ('token', '管理员登录令牌已更新', '管理员登录 Token 已被修改，请使用新 Token 登录。', 'warning', 'settings', ?, 0)`, now)

--- a/handler/admin/auth_settings_test.go
+++ b/handler/admin/auth_settings_test.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -92,6 +93,105 @@ func TestAuthSettingsChange_SuccessUpdatesToken(t *testing.T) {
 	}
 	if stored != `"rotated-admin-token"` {
 		t.Fatalf("stored auth_token = %q, want JSON-quoted rotated-admin-token", stored)
+	}
+}
+
+func TestAuthSettingsChange_SuccessClearsMonitorAuthCookies(t *testing.T) {
+	_, r, _ := setupAuthSettingsTest(t)
+
+	resp := doPostJSON(t, r, "/api/settings/auth/change", map[string]any{
+		"oldToken": "admin-auth-settings-token",
+		"newToken": "rotated-admin-token-clear",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", resp.Code, resp.Body.String())
+	}
+
+	// Wire headers must expire both scoped and legacy paths (Max-Age=0).
+	headers := resp.Header().Values("Set-Cookie")
+	if len(headers) < 2 {
+		t.Fatalf("Set-Cookie count = %d, want >= 2 (scoped + legacy); headers=%v", len(headers), headers)
+	}
+	joined := strings.Join(headers, " | ")
+	if !strings.Contains(joined, monitorAuthCookie+"=") {
+		t.Fatalf("Set-Cookie missing %s: %s", monitorAuthCookie, joined)
+	}
+	if !strings.Contains(joined, "Max-Age=0") {
+		t.Fatalf("Set-Cookie missing Max-Age=0: %s", joined)
+	}
+
+	var scoped *http.Cookie
+	var legacyRoot *http.Cookie
+	for _, c := range resp.Result().Cookies() {
+		if c.Name != monitorAuthCookie {
+			continue
+		}
+		switch c.Path {
+		case monitorCookiePath:
+			scoped = c
+		case "/":
+			legacyRoot = c
+		}
+	}
+	if scoped == nil {
+		t.Fatalf("missing clear cookie for Path=%q; cookies=%v", monitorCookiePath, resp.Result().Cookies())
+	}
+	if scoped.MaxAge >= 0 {
+		t.Fatalf("scoped clear MaxAge = %d, want < 0 (Max-Age=0 on wire)", scoped.MaxAge)
+	}
+	if scoped.Value != "" {
+		t.Fatalf("scoped clear Value = %q, want empty", scoped.Value)
+	}
+	if !scoped.HttpOnly {
+		t.Fatal("scoped clear cookie must remain HttpOnly")
+	}
+	if legacyRoot == nil {
+		t.Fatal("missing legacy Path=/ clear cookie")
+	}
+	if legacyRoot.MaxAge >= 0 {
+		t.Fatalf("legacy clear MaxAge = %d, want < 0", legacyRoot.MaxAge)
+	}
+}
+
+func TestAuthSettingsChange_WrongOldTokenDoesNotClearMonitorAuthCookies(t *testing.T) {
+	_, r, cfg := setupAuthSettingsTest(t)
+
+	resp := doPostJSON(t, r, "/api/settings/auth/change", map[string]any{
+		"oldToken": "wrong-old-token-value",
+		"newToken": "brand-new-token-no-clear",
+	})
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body=%s, want 403", resp.Code, resp.Body.String())
+	}
+	if cfg.AuthToken != "admin-auth-settings-token" {
+		t.Fatalf("AuthToken mutated to %q", cfg.AuthToken)
+	}
+	assertNoMonitorAuthClearCookies(t, resp)
+}
+
+func TestAuthSettingsChange_ShortNewTokenDoesNotClearMonitorAuthCookies(t *testing.T) {
+	_, r, cfg := setupAuthSettingsTest(t)
+
+	resp := doPostJSON(t, r, "/api/settings/auth/change", map[string]any{
+		"oldToken": "admin-auth-settings-token",
+		"newToken": "short",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+	if cfg.AuthToken != "admin-auth-settings-token" {
+		t.Fatalf("AuthToken mutated to %q", cfg.AuthToken)
+	}
+	assertNoMonitorAuthClearCookies(t, resp)
+}
+
+func assertNoMonitorAuthClearCookies(t *testing.T, resp interface{ Header() http.Header }) {
+	t.Helper()
+	headers := resp.Header().Values("Set-Cookie")
+	for _, h := range headers {
+		if strings.Contains(h, monitorAuthCookie) {
+			t.Fatalf("failed auth change must not clear %s; Set-Cookie=%v", monitorAuthCookie, headers)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Successful `POST /api/settings/auth/change` now calls `clearMonitorAuthCookies` so browsers drop HttpOnly `meta_monitor_auth` for `Path=/monitor-proxy/` and legacy `Path=/` (`Max-Age=0`).
- Failed change paths (wrong old token / short new token) do **not** clear the cookie.
- HMAC monitor session scheme unchanged (server-side invalidation on AuthToken rotation already present; this is client cookie hygiene / defense-in-depth).

Closes #484

## Test plan
- [x] `go test ./handler/admin -count=1 -run 'AuthSettings|Monitor'`
- [x] Success path asserts Set-Cookie Max-Age=0 for both paths
- [x] Failure paths assert no `meta_monitor_auth` Set-Cookie
- [x] pre-push: `go vet ./...` + `go test ./... -race` clean