### PR TITLE
feat(ui): tokenize residual monitor-hint / route-enable / stat-summary / topbar brand hex (#485)

### DIFF
--- a/web/index.css
+++ b/web/index.css
@@ -410,7 +410,7 @@ body {
 .topbar-logo-icon {
   width: 32px;
   height: 32px;
-  background: linear-gradient(135deg, #4f46e5, #06b6d4);
+  background: var(--color-brand-gradient);
   border-radius: 8px;
   display: flex;
   align-items: center;
@@ -2574,7 +2574,7 @@ body[data-tooltip-portal="true"] [data-tooltip]::before {
 
 [data-theme="dark"] .route-enable-toggle.is-disabled:hover {
   background: color-mix(in srgb, var(--color-primary) 18%, var(--color-bg-card));
-  color: #a5b4fc;
+  color: var(--color-primary-hover);
 }
 
 /* ===== Tabs ===== */
@@ -5520,19 +5520,35 @@ textarea:focus-visible {
 }
 
 .stat-summary-purple {
-  background: linear-gradient(135deg, #7c3aed, #a78bfa);
+  background: linear-gradient(
+    135deg,
+    var(--color-stat-purple-ink),
+    color-mix(in srgb, var(--color-stat-purple-ink) 45%, white)
+  );
 }
 
 .stat-summary-blue {
-  background: linear-gradient(135deg, #2563eb, #60a5fa);
+  background: linear-gradient(
+    135deg,
+    var(--color-stat-blue-ink),
+    color-mix(in srgb, var(--color-stat-blue-ink) 45%, white)
+  );
 }
 
 .stat-summary-green {
-  background: linear-gradient(135deg, #059669, #34d399);
+  background: linear-gradient(
+    135deg,
+    var(--color-stat-green-ink),
+    color-mix(in srgb, var(--color-stat-green-ink) 45%, white)
+  );
 }
 
 .stat-summary-orange {
-  background: linear-gradient(135deg, #ea580c, #fb923c);
+  background: linear-gradient(
+    135deg,
+    var(--color-stat-orange-ink),
+    color-mix(in srgb, var(--color-stat-orange-ink) 45%, white)
+  );
 }
 
 /* ===== Log Detail Row ===== */
@@ -5831,17 +5847,17 @@ textarea:focus-visible {
 
 .monitor-hint {
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(245, 158, 11, 0.45);
-  background: rgba(251, 191, 36, 0.16);
-  color: #92400e;
+  border: 1px solid color-mix(in srgb, var(--color-warning) 45%, transparent);
+  background: color-mix(in srgb, var(--color-warning) 16%, transparent);
+  color: color-mix(in srgb, var(--color-warning) 76%, black);
   padding: 8px 10px;
   font-size: 12px;
 }
 
 [data-theme="dark"] .monitor-hint {
-  border-color: rgba(250, 204, 21, 0.42);
-  background: rgba(161, 98, 7, 0.25);
-  color: #fbbf24;
+  border-color: color-mix(in srgb, var(--color-warning) 42%, transparent);
+  background: color-mix(in srgb, var(--color-warning-soft) 88%, transparent);
+  color: var(--color-warning);
 }
 
 .monitor-iframe {


### PR DESCRIPTION
## Summary
- Tokenize residual hard-coded hex clusters in `web/index.css` for monitor-hint (light/dark), dark disabled route-enable hover, topbar brand gradient, and stat-summary cards.
- Prefer existing tokens / `color-mix`; no `tokens.css` or package changes.
- Dual-theme visual intent preserved; marketing login gradients intentionally left bare.

Closes #485

## Hex before → after

| Cluster | Before | After |
|---|---|---|
| `.topbar-logo-icon` | `linear-gradient(135deg, #4f46e5, #06b6d4)` | `var(--color-brand-gradient)` |
| dark `.route-enable-toggle.is-disabled:hover` | `#a5b4fc` | `var(--color-primary-hover)` |
| `.stat-summary-purple` | `#7c3aed → #a78bfa` | `var(--color-stat-purple-ink)` + `color-mix(... 45%, white)` |
| `.stat-summary-blue` | `#2563eb → #60a5fa` | `var(--color-stat-blue-ink)` + `color-mix(... 45%, white)` |
| `.stat-summary-green` | `#059669 → #34d399` | `var(--color-stat-green-ink)` + `color-mix(... 45%, white)` |
| `.stat-summary-orange` | `#ea580c → #fb923c` | `var(--color-stat-orange-ink)` + `color-mix(... 45%, white)` |
| `.monitor-hint` color | `#92400e` | `color-mix(in srgb, var(--color-warning) 76%, black)` |
| `.monitor-hint` border/bg | `rgba(245,158,11,0.45)` / `rgba(251,191,36,0.16)` | `color-mix(... warning 45%/16%, transparent)` |
| dark `.monitor-hint` color | `#fbbf24` | `var(--color-warning)` |
| dark `.monitor-hint` border/bg | `rgba(250,204,21,0.42)` / `rgba(161,98,7,0.25)` | warning / warning-soft `color-mix` |

## Test plan
- [x] `go vet ./...` + `go test ./... -count=1 -race` (pre-push)
- [x] `rg` clusters show `var(--token)` / `color-mix` only
- [ ] Spot-check light/dark: topbar logo gradient, disabled route toggle hover, monitor hint, dashboard stat-summary cards