### PR TITLE
docs: neat-freak hygiene after v0.8.36 / M46 board clean

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,14 +21,14 @@ Go rewrite of [MetAPI](https://github.com/cita-777/metapi). Feature parity with 
 cmd/server/main.go      Entry point
 cmd/migrate/main.go     SQLite→PG migration tool
 config/                 ~100 env vars from config.Load()
-store/                  DB layer (27 tables, sqlx)
+store/                  DB layer (28 tables, sqlx)
 auth/                   Admin + proxy auth + rate limiting
 routing/                TokenRouter (Fibonacci + weighted random)
 proxy/                  ProxyCore (dual-loop orchestration)
 platform/               14 upstream adapters
 transform/              4-protocol SSE conversion
 service/                Checkin, balance, notify, OAuth, backup
-scheduler/              15 background jobs
+scheduler/              16 background jobs
 handler/admin/          ~144 admin REST endpoints
 handler/proxy/           ~30 proxy routes (OpenAI, Gemini, Claude, Codex, Files)
 web/dist/               Pre-built React SPA (embedded)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # docs/ — MetAPI Go documentation map
 
-**Last updated**: 2026-07-17  
+**Last updated**: 2026-07-18  
 **Purpose**: one-screen orientation so humans and agents do not dig 180+ markdown files blindly.
 
 ## Start here
@@ -29,14 +29,13 @@ docs/
   migration.md              ← SQLite → PG / schema upgrade
   design/                   ← living design SSOT (BACKEND, DESIGN, a11y)
   analysis/                 ← evidence audits, residuals, gap matrix
-    residual-next-candidates.md   ← next residual queue (read often)
+    residual-next-candidates.md   ← residual honesty SSOT (read often)
     original-gap-matrix.md        ← parity evidence
     competitive/                  ← peer learning inventory
-  plan/                     ← program / lane / roadmap (historical OK)
+  plan/                     ← program / lane / roadmap (historical / closed)
   progress/                 ← MASTER index only (keep slim)
   specs/                    ← rewrite-era implementation specs (large; archival)
     review/                 ← historical audits/reviews
-  archives/                 ← (optional) completed program dumps
 ```
 
 ## Mental model (reduce load)
@@ -47,27 +46,25 @@ docs/
 4. **`docs/specs/` is heavy rewrite history** — do not treat as day-to-day runbook.
 5. **One Issue per topic**; close duplicates the same day.
 
-## Active residual lanes (v0.8.22)
+## Residual board (post v0.8.36)
 
-See Milestone [Enterprise residual v0.8.22](https://github.com/TokenDanceLab/metapi-go/milestone/31):
-
-- Security: admin key redaction (#355), custom_headers deny-list (#356), RuntimeExecutor redirect SSRF (#357)
-- Reliability: weighted soft-filter empty → next priority layer (#358)
-- Docs: residual honesty board (#359)
-- Explicit non-goals until dedicated Milestone: full Responses WS product, Redis sticky product, update-center remote deploy
+- **Latest release**: [v0.8.36](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.36) · M46 closed · active milestone **none**.
+- **Residual SSOT**: [`analysis/residual-next-candidates.md`](analysis/residual-next-candidates.md) (optional **v0.8.37+** only with dedicated ACs).
+- **Still not product without ACs**: full Responses WS (WS-1), Redis sticky (STICKY-B), update-center remote deploy (UC-1).
+- **Keep partial**: P0-585 cascade (load-proof required; honesty tests do not flip present).
 
 ## Hygiene rules (short)
 
 - Prefer **merge/update** over new parallel analysis files.
-- Absolute dates (`2026-07-17`), not “recently”.
+- Absolute dates (`2026-07-18`), not “recently”.
 - Cross-link residual docs from `residual-next-candidates.md`.
 - `docs/doc_hygiene_test.go` enforces public markdown hygiene (no local paths / false Redis sticky claims).
 
-## Related program docs
+## Related program docs (historical)
 
 | Doc | Role |
 |:----|:-----|
-| `plan/enterprise-program.md` | Multi-lane enterprise program |
-| `plan/lane-charters.md` | File ownership for parallel WFs |
-| `plan/feature-complete-roadmap.md` | Feature track (largely shipped) |
+| `plan/enterprise-program.md` | Closed enterprise program map |
+| `plan/lane-charters.md` | File ownership for parallel WFs (ownership rules still useful) |
+| `plan/feature-complete-roadmap.md` | F0 snapshot (closed / historical) |
 | `plan/gap-inventory-acceptance.md` | G4 acceptance (closed) |

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -1,12 +1,12 @@
-# Residual next candidates (post v0.8.35 / M46 product landed)
+# Residual next candidates (post v0.8.36 / M46 closed)
 
 **Date**: 2026-07-18  
-**Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); honesty refresh [#334](https://github.com/TokenDanceLab/metapi-go/issues/334); trail #318 / #329 + v0.8.18 product + v0.8.19 residual; post-M35 honesty [#397](https://github.com/TokenDanceLab/metapi-go/issues/397); post-v0.8.26 honesty [#410](https://github.com/TokenDanceLab/metapi-go/issues/410); post-v0.8.27 honesty [#418](https://github.com/TokenDanceLab/metapi-go/issues/418); post-v0.8.28 honesty [#426](https://github.com/TokenDanceLab/metapi-go/issues/426); post-v0.8.29 honesty [#435](https://github.com/TokenDanceLab/metapi-go/issues/435); post-v0.8.30 honesty [#443](https://github.com/TokenDanceLab/metapi-go/issues/443); post-v0.8.31 honesty [#451](https://github.com/TokenDanceLab/metapi-go/issues/451); post-v0.8.32 honesty [#459](https://github.com/TokenDanceLab/metapi-go/issues/459); post-M44 product honesty [#469](https://github.com/TokenDanceLab/metapi-go/issues/469); post-M45 product honesty [#478](https://github.com/TokenDanceLab/metapi-go/issues/478); post-M46 product honesty [#487](https://github.com/TokenDanceLab/metapi-go/issues/487)  
-**Context**: **v0.8.33 shipped** (Milestone 43 closed): #456 UI-STAT-TOKENS (PR #460), #457 UI-SITE-CONC (PR #461), #458 CTX-520-GEMINI (PR #462), #459 residual honesty (PR #464) + release gate. **v0.8.34 shipped** (Milestone 44 closed): #466 UI-KEY-PROXY DownstreamKeys proxyUrl UI (PR #471), #467 UI-ROUTE-CTX TokenRoutes contextLength UI (PR #472), #468 UI-TOKEN-DEBT high-value CSS hex clusters → design tokens (PR #470), #469 residual honesty (PR #473) + release gate. **v0.8.35 shipped** (Milestone 45 closed): #475–#478 (PRs #479–#483). **v0.8.36 shipped** (Milestone 46 closed): #484 SEC-MONITOR-TOKEN-CLEAR (PR #489), #485 UI-CSS-RESIDUAL (PR #490), #486 REL-P0555-STREAM-TESTS (PR #488), #487 residual honesty (PR #491) + release gate. Prior **v0.8.32**: #449–#451 (PRs #452/#454/#453). Prior **v0.8.31**: #440–#443 (PRs #444–#447). Prior **v0.8.30**: #433–#435 (PRs #436/#438/#437). Prior **v0.8.29**: #423–#426 (PRs #427/#428/#430/#431). Prior **v0.8.28**: #416–#418 (PRs #419–#421). Prior **v0.8.27**: #407–#410 (PRs #411–#414). Prior **v0.8.26**: #397–#400 (PRs #401–#404/#406). Prior **v0.8.25**: #382–#384. M35 closed: #388 review synthesis, **#389/#396** endpoint early reject, **#390/#395** multi-route list regression. Original P0 #405/#565/#515 already-correct in code. **Program foundations already closed** (M-STACK / M-UI / M-BACKEND / M-SCHEMA / M-FEATURE): M46 is residual polish, not greenfield modernization.  
+**Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); latest honesty [#487](https://github.com/TokenDanceLab/metapi-go/issues/487) (trail via MASTER / CHANGELOG)  
+**Context**: **v0.8.36 shipped** (Milestone 46 closed): #484 SEC-MONITOR-TOKEN-CLEAR, #485 UI-CSS-RESIDUAL, #486 REL-P0555-STREAM-TESTS, #487 residual honesty + release gate. Prior residual train v0.8.18–v0.8.35 is in `CHANGELOG.md` / Releases — do not re-narrate here. Program foundations (STACK / UI / BACKEND / SCHEMA / FEATURE / RELIABILITY) are closed; residual polish only.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)  
-**M35 review synthesis**: [`enterprise-review-m35.md`](./enterprise-review-m35.md) (#388) — ranked P0/P1/P2 backlog after multi-lane residual review (historical; #389/#390 done)  
-**Active wave**: none (M46 closed; sequencing **v0.8.37+** optional residual with ACs only)
+**M35 review synthesis**: [`enterprise-review-m35.md`](./enterprise-review-m35.md) (#388) — historical pointer only  
+**Active wave**: none (M46 closed; optional **v0.8.37+** residual only with dedicated ACs)
 
 ## Purpose
 
@@ -78,13 +78,13 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 
 ## Recommended sequencing (v0.8.37+)
 
-1. **Shipped in v0.8.35 (M45 closed)**: #475-#478 (PRs #479-#483). Latest release **v0.8.35**.
-2. **M46 / v0.8.36 closed**: #484–#487 (PRs #488–#491) present on master with tag.
-3. **Active wave**: none. Optional residual **v0.8.37+** only with dedicated ACs.
-4. **SEC-MONITOR-TOKEN-CLEAR** / **UI-CSS-RESIDUAL** / **REL-P0555-STREAM-TESTS** fully **present**. **P0-555** stays **present-with-residual**. **P0-585** remains **partial** (load-proof still required).
-5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
-6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
-7. **Do not** re-open enterprise program foundations as greenfield modernization — M46 is residual polish only.
+1. **Latest release**: **v0.8.36** (M46 closed; #484–#487 present on master with tag).
+2. **Active wave**: none. Optional residual **v0.8.37+** only with dedicated ACs.
+3. **Shipped M46**: SEC-MONITOR-TOKEN-CLEAR / UI-CSS-RESIDUAL / REL-P0555-STREAM-TESTS are **present**. **P0-555** stays **present-with-residual**. **P0-585** remains **partial** (load-proof still required — do not flip present from tests alone).
+4. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
+5. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
+6. **Do not** re-open enterprise program foundations as greenfield modernization — residual polish only.
+
 
 ## Explicit non-goals for residual waves
 
@@ -92,50 +92,22 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Claiming cluster-wide sticky while bindings remain process-local.
 - Inventing update-center deploy/rollback success without a registry.
 - Returning `success:true` for unimplemented admin stream/job queues.
-- Claiming perfect billing accuracy without aggregation proof after #311.
-- Claiming all-dialect proxy max-token enforcement from `contextLength` without a dedicated product AC (OpenAI chat/completions after #399; Claude `/v1/messages` after #409; OpenAI `/v1/responses` after #450; Gemini generationConfig after #458; further dialects need ACs).
-- Returning full downstream API keys on admin list/summary/overview after #355, or on update/reset-usage after #440.
-- Allowing custom_headers to override Authorization/Host/hop-by-hop after #356.
-- Following cross-origin/private RuntimeExecutor, bare probe/harness/defaultUpstreamClient, OAuth/notify, ProxyAwareHTTPClient, or SiteProxy constructor redirects after #357/#416/#433/#441/#442.
-- Embedding live `AUTH_TOKEN` in monitor cookies after #407; leaving `meta_monitor_auth` set after admin logout after #417.
-- Non-constant-time compares on admin token-change paths after #408.
-- Claiming preferred/sticky selection ignores open site/model breakers after #423.
-- Claiming CooldownUntil eligibility uses lex string compare after #424.
-- Claiming conductor lacks a hard cross-channel attempt budget or never fails over on nil RefreshAuth after #425.
-- Claiming Codex OAuth or Telegram notify clients still lack cross-origin redirect rejection after #433/#436.
-- Claiming `loadRouteMatch` still uses an always-empty source-model fallback stub after #434/#438.
-- Claiming `ProxyAwareHTTPClient` still lacks cross-origin redirect rejection after #441/#446.
-- Claiming SiteProxy `buildClients` / `doWithExplicitProxy` still lack cross-origin redirect rejection after #442/#444.
-- Claiming downstream-keys update + reset-usage still echo plaintext `key` after #440/#445.
-- Claiming system-proxy/test still accepts metadata/link-local `targetUrl` after #449/#452.
-- Claiming OpenAI `/v1/responses` still lacks `max_output_tokens` vs `context_length` enforce after #450/#454.
-- Claiming Gemini generateContent still lacks `generationConfig.maxOutputTokens` vs `context_length` enforce after #458/#462.
-- Claiming Sites admin UI still omits `maxConcurrency` after #457/#461 (backend was already present).
-- Claiming stat-icon colors still use hard-coded hex after #456/#460.
-- Claiming DownstreamKeys admin UI still omits `proxyUrl` after #466/#471 (backend KEY-578 was already present).
-- Claiming TokenRoutes admin UI still omits `contextLength` after #467/#472 (backend CTX-520 was already present).
-- Claiming listed high-value CSS clusters (checkin-toggle / route-enable / info-tip / model-tag / status-dot) still use hard-coded hex after #468/#470.
-- Claiming P0-585 cascade is fully present (stays partial; REL-SOURCE-MODEL is not a cascade close).
-- Claiming enterprise STACK/UI/BACKEND/SCHEMA/FEATURE foundations are still greenfield work (closed; M44 is residual polish only).
-- Claiming DownstreamKeys admin UI still omits `maxRpm`/`maxTpm` after #475/#481 (backend #116 was already present).
-- Claiming P0-585 empty-filter honesty tests are missing after #476/#479 (tests present; cascade still partial).
-- Claiming residual login-shell text/surface hex still hard-coded after #477/#480 (gradients may remain).
-- Claiming **v0.8.36** product without dedicated ACs.
-- Claiming **v0.8.36** product without dedicated ACs.
+- Claiming perfect billing accuracy without aggregation proof (P0-555 stays present-with-residual).
+- Claiming all-dialect proxy max-token enforcement from `contextLength` without a dedicated product AC (OpenAI chat/completions, Claude messages, Responses, Gemini generateContent present; further dialects need ACs).
+- Claiming P0-585 cascade is fully present (stays **partial**; honesty tests and selection mapping are not cascade-complete).
+- Claiming enterprise STACK/UI/BACKEND/SCHEMA/FEATURE foundations are still greenfield work (closed; residual polish only).
 - Inventing WS-1 / STICKY-B / UC-1 product without dedicated ACs.
+- Claiming **v0.8.37+** product without dedicated ACs.
+- Re-opening closed security/UI residual slices as active work when CHANGELOG/MASTER already cover them (monitor token clear, CSS residual, stream usage honesty tests, etc.).
 
-- Claiming admin AuthToken change still leaves meta_monitor_auth uncleared after #484/#489.
-- Claiming residual monitor-hint / stat-summary / topbar brand hex still hard-coded after #485/#490.
-- Claiming P0-555 Anthropic stream usage merge honesty tests are missing after #486/#488 (still not perfect billing).
-- Claiming **v0.8.37** product without dedicated ACs.
+
 ## Links
 
 - Release: [v0.8.36](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.36) · prior [v0.8.35](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.35) · next optional residual **v0.8.37+** (with ACs only)
-- Milestone: [Enterprise security/UI residual polish v0.8.36](https://github.com/TokenDanceLab/metapi-go/milestone/46) · **closed** (board #484–#487; issues closed; GH milestone close is operator step after tag)
+- Milestone: [Enterprise security/UI residual polish v0.8.36](https://github.com/TokenDanceLab/metapi-go/milestone/46) · **closed** (#484–#487)
 - Prior milestone: [Enterprise UI/reliability residual polish v0.8.35](https://github.com/TokenDanceLab/metapi-go/milestone/45) · **closed**
-- Prior milestone: [Enterprise UI schema-product residual polish v0.8.34](https://github.com/TokenDanceLab/metapi-go/milestone/44) · **closed**
 - Matrix: `docs/analysis/original-gap-matrix.md`
 - Failover: `docs/analysis/failover-isolation.md`
-- M35 review synthesis: `docs/analysis/enterprise-review-m35.md` (#388)
+- M35 review synthesis: `docs/analysis/enterprise-review-m35.md` (#388; historical)
 - MASTER: `docs/progress/MASTER.md`
-- Related issues: #466, #467, #468, #469, #470, #471, #472, #456, #457, #458, #459, #460, #461, #462, #449, #450, #451, #452, #453, #454, #440, #441, #442, #443, #444, #445, #446, #447, #433, #434, #435, #436, #437, #438, #423, #424, #425, #426, #427, #428, #430, #431, #416, #417, #418, #419, #420, #421, #407, #408, #409, #410, #411, #412, #413, #414, #397, #398, #399, #400, #401, #402, #403, #404, #406, #382, #383, #384, #375, #376, #377, #274, #282, #283, #290, #291, #292, #298, #299, #300, #309, #310, #311, #318, #319, #320, #327, #328, #329, #334, #335, #336, #345, #346, #350, #351, #355, #356, #357, #358, #359, #366, #367, #368, #388, #389, #390, #391, #395, #396
+- Related issues: see closed M45/M46 boards (#475–#478, #484–#487) and residual IDs in the table above; full PR trail in `CHANGELOG.md`.

--- a/docs/plan/audit-fix-plan.md
+++ b/docs/plan/audit-fix-plan.md
@@ -1,5 +1,7 @@
 # Audit Fix Plan
 
+> **Status: historical / superseded** (targets v0.4.0 / LOCAL_ONLY era). Not an open production plan.
+
 **Date**: 2026-07-04 | **Source**: 16-agent audit | **Findings**: 47 total (10 CRITICAL, 12 HIGH, 15 MEDIUM, 10 LOW)
 
 ## CRITICAL Fixes (must fix before v0.2.0)

--- a/docs/plan/dependency-graph-hardening.md
+++ b/docs/plan/dependency-graph-hardening.md
@@ -1,5 +1,7 @@
 # Dependency Graph — Production Hardening
 
+> **Status: historical / superseded** (pre-v0.4 hardening era). Not an open board.
+
 ```mermaid
 graph TD
     subgraph Phase1[Phase 1: Critical Fixes]

--- a/docs/plan/dependency-graph.md
+++ b/docs/plan/dependency-graph.md
@@ -1,5 +1,7 @@
 # Dependency Graph — MetAPI Go Rewrite
 
+> **Status: historical rewrite-era graph**. Counts and package names are archival; living map is `docs/architecture.md`.
+
 ```mermaid
 graph TD
   subgraph Phase0["Phase 0: Foundation"]

--- a/docs/plan/enterprise-ops-residual.md
+++ b/docs/plan/enterprise-ops-residual.md
@@ -1,5 +1,7 @@
 # Enterprise ops residual + v0.8.0
 
+> **Status: closed (M9 / v0.8.0 era)**. Not an open residual board. Next residual honesty: `docs/analysis/residual-next-candidates.md`.
+
 **Milestone**: https://github.com/TokenDanceLab/metapi-go/milestone/9  
 **Opened**: 2026-07-17
 

--- a/docs/plan/enterprise-program.md
+++ b/docs/plan/enterprise-program.md
@@ -1,5 +1,7 @@
 # MetAPI-Go Enterprise Modernization Program
 
+> **Status: closed / historical program map** (foundations closed through M46 / v0.8.36). Living residual queue: `docs/analysis/residual-next-candidates.md`. Do not schedule greenfield modernization from this file.
+
 **Goal**: 彻底完成 MetAPI 的现代化升级与企业级改造 — 前端风格统一与 UI/UX、后端理念与结构清晰、schema 兼容原版且可升级、功能全面、边界条件干净。
 
 **Project**: https://github.com/orgs/TokenDanceLab/projects/1  

--- a/docs/plan/feature-complete-roadmap.md
+++ b/docs/plan/feature-complete-roadmap.md
@@ -1,5 +1,7 @@
 # Feature-Complete Roadmap (F0)
 
+> **Status: historical F0 snapshot (M-FEATURE closed)**. Do not schedule implementation from this file. Living residual inventory: `docs/analysis/residual-next-candidates.md`.
+
 > Snapshot date: 2026-07-16  
 > Issue: [#23 F0](https://github.com/TokenDanceLab/metapi-go/issues/23)  
 > Milestone: [M-FEATURE](https://github.com/TokenDanceLab/metapi-go/milestone/6)  

--- a/docs/plan/lane-charters.md
+++ b/docs/plan/lane-charters.md
@@ -1,5 +1,7 @@
 # Lane Charters — 每条线独立小组 / Workflow
 
+> **Status: historical program ownership map** (enterprise foundations closed; residual board clean after v0.8.36). File-ownership rules still useful for parallel WFs; residual queue SSOT is `docs/analysis/residual-next-candidates.md` (optional v0.8.37+ with ACs only).
+
 **规则**：一条线 = 一个 Milestone + 一组 Issues + **一个专属 Workflow 舰队** + 硬文件所有权。  
 主 session 只编排，不跨线改代码。两条线不得写同一文件。
 

--- a/docs/plan/milestones-hardening.md
+++ b/docs/plan/milestones-hardening.md
@@ -1,5 +1,7 @@
 # Milestones — Production Hardening
 
+> **Status: closed / superseded** (original v0.4.0 target; product is **v0.8.36+**). Do not treat M1–M5 as open production board. Residual train: `docs/analysis/residual-next-candidates.md` + `CHANGELOG.md`.
+
 | # | Milestone | After | Criteria | Status |
 |:--|:----------|:------|:---------|:-------|
 | M1 | **Critical Fixes Done** | Phase 1 | `http.DefaultClient` 零引用；`panic(` 在 `service/oauth/` 零出现；默认密钥生产告警；SSE >60s 不断 | Pending |

--- a/docs/plan/milestones-stack-gap.md
+++ b/docs/plan/milestones-stack-gap.md
@@ -1,5 +1,7 @@
 # Milestones — Stack Modernization + Gap Inventory
 
+> **Status: closed / historical** (M-STACK + M-GAP closed; MASTER marks both ✅). Wave table below is archival. Living residual: `docs/analysis/residual-next-candidates.md`.
+
 **Program**: dual-track SDD for frontend stack modernization and original-metapi gap inventory  
 **Project**: https://github.com/orgs/TokenDanceLab/projects/1  
 **MASTER**: `docs/progress/MASTER.md`
@@ -23,9 +25,9 @@ This program **does not** implement original-gap product fixes.
 | Wave | Status | Stack lane | Gap lane | Goal |
 |:-----|:-------|:-----------|:---------|:-----|
 | **Wave 0** | ✅ Done | Branch hygiene; labels; project; milestones; issues #3–#11 | same | Tracking surface ready |
-| **Wave 1** | 🔄 Active | **S1** core lock (TS 7.0.2 + React 19.2.7 + Vite 8.1.5) | **G1** issue capture + taxonomy · **G2** gap matrix | Parallel stack bump + gap evidence base |
-| **Wave 2** | 🔄 Active | **S2** React 19 test adaptation · **S3** Vite 8 / vitepress-mermaid tooling | **G3** publish `[backlog]` issues from matrix | Tests + tooling green; backlog visible |
-| **Wave 3** | Pending | **S4** CI / Docker / embed regression gate + CHANGELOG | **G4** gap inventory acceptance (docs-only) | Ship stack gate; freeze inventory |
+| **Wave 1** | ✅ Done | **S1** core lock (TS 7.0.2 + React 19.2.7 + Vite 8.1.5) | **G1** issue capture + taxonomy · **G2** gap matrix | Parallel stack bump + gap evidence base |
+| **Wave 2** | ✅ Done | **S2** React 19 test adaptation · **S3** Vite 8 / vitepress-mermaid tooling | **G3** publish `[backlog]` issues from matrix | Tests + tooling green; backlog visible |
+| **Wave 3** | ✅ Done | **S4** CI / Docker / embed regression gate + CHANGELOG | **G4** gap inventory acceptance (docs-only) | Ship stack gate; freeze inventory |
 
 Parallelism notes:
 

--- a/docs/plan/milestones.md
+++ b/docs/plan/milestones.md
@@ -1,5 +1,7 @@
 # Milestones — MetAPI Go Rewrite
 
+> **Status: historical rewrite-era plan** (P0–P13). Not an open board; product is v0.8.36+. Use MASTER + residual-next-candidates.
+
 | Phase | Name | Tasks | Est. Effort | Key Deliverable |
 |:------|:-----|------:|:------------|:----------------|
 | P0 | Project Skeleton | 1 | 1d | Go binary boots, /health responds, Docker builds |

--- a/docs/plan/original-gap-backlog.md
+++ b/docs/plan/original-gap-backlog.md
@@ -1,5 +1,7 @@
 # Original MetAPI Gap Backlog (G3)
 
+> **Status: historical G3 backlog shells**. Do not schedule product work from this file; use `docs/analysis/residual-next-candidates.md` + MASTER.
+
 > Snapshot date: 2026-07-16  
 > **Matrix evidence refreshed: 2026-07-17** for shipped surfaces (post v0.8.12 / toward v0.8.13) — see `docs/analysis/original-gap-matrix.md` (#281). Historical G3 issue shells below are unchanged.  
 > Source matrix: `docs/analysis/original-gap-matrix.md` (G2 #9)  

--- a/docs/plan/task-breakdown-hardening.md
+++ b/docs/plan/task-breakdown-hardening.md
@@ -1,5 +1,7 @@
 # Task Breakdown — MetAPI-Go Production Hardening
 
+> **Status: historical / superseded** (v0.4.0 hardening). Residual train: `docs/analysis/residual-next-candidates.md`.
+
 **目标**: 消除所有审计发现的 CRITICAL/HIGH/MEDIUM 问题，达到生产就绪状态
 **跟踪模式**: LOCAL_ONLY
 **版本目标**: v0.4.0

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -1,11 +1,11 @@
 # MASTER.md — MetAPI Go
 
-**Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery
-**Mode**: GitHub Issues + Milestones (SDD)
-**Repo**: https://github.com/TokenDanceLab/metapi-go
+**Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery  
+**Mode**: GitHub Issues + Milestones (SDD)  
+**Repo**: https://github.com/TokenDanceLab/metapi-go  
 **Latest release**: **[v0.8.36](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.36)** (2026-07-18)
 
-> 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。
+> 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。  
 > 文档地图：[`docs/README.md`](../README.md)
 
 ## Tracking
@@ -14,9 +14,9 @@
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
 | Active milestone | none (board clean; next residual only with ACs) |
-| Program map | `docs/plan/enterprise-program.md` |
+| Program map | `docs/plan/enterprise-program.md` (historical / closed foundations) |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
-| M35 review synthesis | `docs/analysis/enterprise-review-m35.md` (#388; M35 closed) |
+| M35 review synthesis | `docs/analysis/enterprise-review-m35.md` (#388; historical) |
 | Gap matrix | `docs/analysis/original-gap-matrix.md` |
 | Architecture | `docs/architecture.md` · design `docs/design/BACKEND.md` |
 
@@ -25,30 +25,8 @@
 | Track | Status | Notes |
 |:------|:-------|:------|
 | Rewrite P0–P13 | ✅ | Single-binary Go + embed SPA |
-| M-STACK (TS7 / React19 / Vite8) | ✅ | CI frontend green path |
-| M-GAP inventory | ✅ | Matrix + backlog; product via residual tags |
-| M-BACKEND / UI / SCHEMA / RELIABILITY | ✅ | Design SSOT in `docs/design/` |
-| M-FEATURE + competitive learn | ✅ | Gap #38–#56 · learn #110–#121 |
-| Enterprise residual **v0.8.18** | ✅ | #327–#329 · tag v0.8.18 |
-| Enterprise residual **v0.8.19** | ✅ | #334–#336 · tag v0.8.19 |
-| Enterprise residual **v0.8.20** | ✅ | #345–#346 · tag v0.8.20 |
-| Enterprise residual **v0.8.21** | ✅ | #350–#351 (PRs #352/#353); tag **v0.8.21** |
-| Enterprise residual **v0.8.22** | ✅ | #355–#359 (PRs #360–#364); tag **v0.8.22** |
-| Enterprise residual **v0.8.23** | ✅ | #366–#368 (PRs #369/#370/#372); tag **v0.8.23** |
-| Enterprise residual **v0.8.24** | ✅ | #375–#377 (PRs #378/#379/#380); tag **v0.8.24** |
-| Enterprise residual **v0.8.25** | ✅ | #382–#384 (PRs #385/#386/#387); tag **v0.8.25** |
-| M35 residual review / follow-ons | ✅ closed | #388 synthesis · #389/#396 endpoint early reject · #390/#395 multi-route regression |
-| Enterprise residual polish **v0.8.26** | ✅ closed | #397–#400 (PRs #401–#404/#406); tag **v0.8.26** |
-| Enterprise residual security polish **v0.8.27** | ✅ closed | #407–#410 (PRs #411–#414); tag **v0.8.27** |
-| Enterprise residual SSRF/client harden **v0.8.28** | ✅ closed | #416–#418 (PRs #419–#421); tag **v0.8.28** |
-| Enterprise residual reliability harden **v0.8.29** | ✅ closed | #423–#426 (PRs #427/#428/#430/#431); tag **v0.8.29** |
-| Enterprise residual client/routing polish **v0.8.30** | ✅ closed | #433–#435 (PRs #436–#438); tag **v0.8.30** |
-| Enterprise residual security polish **v0.8.31** | ✅ closed | #440–#443 (PRs #444–#447); tag **v0.8.31** |
-| Enterprise residual security/product polish **v0.8.32** | ✅ closed | #449–#451 (PRs #452–#454); tag **v0.8.32** |
-| Enterprise UI/schema/product residual polish **v0.8.33** | ✅ closed | #456–#459 (PRs #460–#462 / #464); tag **v0.8.33** |
-| Enterprise UI schema-product residual polish **v0.8.34** | ✅ closed | #466–#469 (PRs #470–#473); tag **v0.8.34** |
-| Enterprise UI/reliability residual polish **v0.8.35** | ✅ closed | #475–#478 (PRs #479–#482); tag **v0.8.35** |
-| Enterprise security/UI residual polish **v0.8.36** | ✅ closed | #484–#487 (PRs #488–#491); tag **v0.8.36** |
+| Program foundations (STACK / GAP / BACKEND / UI / SCHEMA / RELIABILITY / FEATURE) | ✅ | Closed; residual polish only |
+| Enterprise residual train **v0.8.18–v0.8.36** (M27–M46) | ✅ closed | Latest **v0.8.36** / M46; full narrative → `CHANGELOG.md` + Releases |
 
 ## Active work
 
@@ -56,35 +34,17 @@
 |------:|:------|:------|
 | — | — | Board clean (no open residual product board) |
 
-**Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
-**M35–M46 closed**: do not re-list #388–#390, #397–#400, #407–#410, #416–#418, #423–#426, #433–#435, #440–#443, #449–#451, #456–#459, #466–#469, #475–#478, or #484–#487 as active work (landed on master with v0.8.36).
-**Latest release**: **v0.8.36** after this release gate (tag is a separate operator step if not yet published).
-
+**Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.  
+**Closed train**: M35–M46 (#388–#390, #397–#400, #407–#410, #416–#418, #423–#426, #433–#435, #440–#443, #449–#451, #456–#459, #466–#469, #475–#478, #484–#487) are **not** active work.  
+**Latest release**: **v0.8.36** (published).
 
 ## Residual releases (pointer only)
 
 | Tag | Milestone | Highlights |
 |:----|:----------|:-----------|
-| [v0.8.36](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.36) | 46 | monitor cookie clear on AuthToken change · CSS residual polish · P0-555 stream usage honesty tests · residual honesty |
-| [v0.8.35](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.35) | 45 | DownstreamKeys maxRpm/maxTpm UI · P0-585 empty-filter honesty tests · login token debt · residual honesty |
-| [v0.8.34](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.34) | 44 | DownstreamKeys proxyUrl UI · TokenRoutes contextLength UI · CSS token debt · residual honesty |
-| [v0.8.33](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.33) | 43 | stat-icon design tokens · Sites maxConcurrency UI · Gemini maxOutputTokens · residual honesty |
-| [v0.8.32](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.32) | 42 | system-proxy/test targetUrl guard · Responses max_output_tokens vs context_length · residual honesty |
-| [v0.8.31](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.31) | 41 | ProxyAware/SiteProxy CheckRedirect · key mutate redact · residual honesty |
-| [v0.8.30](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.30) | 40 | OAuth/Telegram CheckRedirect · source-model fallback · residual honesty |
-| [v0.8.29](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.29) | 39 | preferred breaker · cooldown timestamp parse · conductor attempt budget · residual honesty |
-| [v0.8.28](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.28) | 38 | SEC-REDIR bare clients · SEC-MONITOR logout clear · residual honesty |
-| [v0.8.27](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.27) | 37 | opaque monitor session · OldToken constant-time · Claude max_tokens vs context_length · residual honesty |
-| [v0.8.26](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.26) | 36 | IsValidAPIEndpointURL metadata parity · max_tokens vs context_length reject · stream missing-usage warn · residual honesty |
-| [v0.8.25](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.25) | 34 | IsValidHTTPURL metadata harden · routes N+1 batch · residual honesty |
-| [v0.8.24](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.24) | 33 | routes/search secret redact · site metadata URL guard · residual honesty |
-| [v0.8.23](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.23) | 32 | admin account secret redact · RR/stable soft-filter demotion · residual honesty |
-| [v0.8.22](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.22) | 31 | admin key redact · custom_headers deny · CheckRedirect · soft-filter priority · residual honesty |
-| [v0.8.21](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.21) | 30 | completions include_usage · residual honesty |
-| [v0.8.20](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.20) | 29 | chat stream include_usage · residual honesty |
-| [v0.8.19](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.19) | 28 | residual honesty · healthPersist race · P0-585 cascade honesty |
-| [v0.8.18](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.18) | 27 | models contextLength wire · admin race isolation · residual honesty |
-| older | 11–26 | See GitHub Releases / `CHANGELOG.md` |
+| [v0.8.36](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.36) | 46 | monitor cookie clear · CSS residual · P0-555 stream usage honesty · residual honesty |
+| [v0.8.35](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.35) | 45 | DownstreamKeys maxRpm/maxTpm UI · P0-585 empty-filter honesty · login token debt |
+| older | 11–44 | See GitHub Releases / `CHANGELOG.md` |
 
 ## Architecture entry points
 
@@ -103,7 +63,7 @@
 ```bash
 gh issue list --state open --limit 20
 gh pr list --state open
-gh release view v0.8.33
+gh release view v0.8.36
 git log --oneline origin/master -10
 ```
 
@@ -112,7 +72,6 @@ git log --oneline origin/master -10
 1. Board clean after **v0.8.36**. Optional residual **v0.8.37+** only with dedicated ACs.
 2. Do **not** invent WS-1 / STICKY-B Redis / UC-1 product without dedicated ACs.
 3. Optional later: P0-585 production load-proof; deeper P0-555 media/lag polish; further dialect context_length only if a new dialect needs ACs.
-
 
 ## Governance
 


### PR DESCRIPTION
## Summary

Post-M46 documentation hygiene only (no product code). Deduped finder reports and applied safe mental-load reductions so agents stop treating closed history as an open board.

### Cleanups applied
- **`docs/progress/MASTER.md`**: slimmed to navigation index — collapsed v0.8.18–v0.8.36 residual status rows + long release table into CHANGELOG/Releases pointers; `gh release view v0.8.36`; dropped unpublished-tag hedge.
- **`docs/analysis/residual-next-candidates.md`**: title/context/sequencing honesty → **latest v0.8.36**, **Active wave: none**; removed duplicate non-goals / long closed-slice anti-regression dump; **P0-585 stays partial**.
- **`docs/README.md`**: replaced stale **Active residual lanes (v0.8.22)** with post-v0.8.36 residual board pointer; dropped missing `archives/` layout line; date 2026-07-18.
- **`docs/plan/*`**: one-line **historical/closed/superseded** banners (enterprise-program, lane-charters, stack-gap waves Done, hardening, F0, G3 backlog, ops residual M9, rewrite-era milestones/dependency graphs/audit plans).
- **`AGENTS.md`**: structure counts **28 tables / 16 background jobs** (code-aligned).

### Explicit non-claims
- Does **not** claim P0-585 present or perfect billing.
- Does **not** invent WS-1 / STICKY-B Redis / UC-1 product.
- Does **not** rewrite CHANGELOG history.

## Remaining P2 (not done this PR)
- Root README / README_EN Docker badge drift (still older ghcr tag narrative) and EN docs map gap.
- `docs/analysis/original-gap-matrix.md` #520/#555 evidence refresh vs residual inventory.
- `docs/analysis/schema-parity.md` SC2 shipped reframe + remove host-local absolute paths.
- `docs/analysis/enterprise-review-m35.md` freeze as archive-only living-queue competition.
- DESIGN vs a11y hit-target / adoption matrix reconcile; AGENTS/BACKEND/architecture triple-restated Golden Rules slim.
- Root README entry-point parity with docs map; CHANGELOG compare-link footer lag beyond v0.6.3.
- Mass orphan inventory under `docs/specs/**` / analysis (keep archives; no mass delete).

## Test plan
- [x] `go vet ./... && go test ./... -count=1 -race` (pre-push)
- [x] `rg -n "Active wave|v0\.8\.36|P0-585" docs/progress/MASTER.md docs/analysis/residual-next-candidates.md docs/README.md`
- [ ] Human skim: MASTER + residual SSOT still point to optional v0.8.37+ only with ACs