### PR TITLE
docs: align README stack badges to Go 1.26.5 + React 19 + Vite 8 (#494)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/TokenDanceLab/metapi-go/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/TokenDanceLab/metapi-go/actions/workflows/ci.yml/badge.svg"></a>
-  <img alt="Go" src="https://img.shields.io/badge/Go-1.26.4-00ADD8?logo=go">
+  <img alt="Go" src="https://img.shields.io/badge/Go-1.26.5-00ADD8?logo=go">
   <a href="https://github.com/TokenDanceLab/metapi-go/pkgs/container/metapi-go"><img alt="Docker" src="https://img.shields.io/badge/ghcr-v0.6.5-blue?logo=docker"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-green"></a>
 </p>
@@ -197,11 +197,11 @@ Cron 定时执行（默认每日 08:00），智能解析奖励金额，签到失
 | 层 | 技术 |
 |----|------|
 | 后端 | [chi](https://github.com/go-chi/chi) 路由 + `net/http` |
-| 语言 | Go 1.26.4 |
+| 语言 | Go 1.26.5 |
 | 数据库 | SQLite / PostgreSQL + [sqlx](https://github.com/jmoiron/sqlx)，无 Redis 运行时依赖 |
 | 定时任务 | [robfig/cron](https://github.com/robfig/cron) |
 | 容器化 | Docker（Alpine，15MB 镜像） |
-| 前端 | React 18 + Vite + Tailwind CSS v4（内嵌） |
+| 前端 | React 19 + Vite 8 + Tailwind CSS v4（内嵌） |
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -12,7 +12,7 @@ Go rewrite of [MetAPI](https://github.com/cita-777/metapi). Single binary, no No
 </p>
 
 [![CI](https://github.com/TokenDanceLab/metapi-go/actions/workflows/ci.yml/badge.svg)](https://github.com/TokenDanceLab/metapi-go/actions/workflows/ci.yml)
-[![Go](https://img.shields.io/badge/Go-1.26.4-00ADD8?logo=go)](https://go.dev/)
+[![Go](https://img.shields.io/badge/Go-1.26.5-00ADD8?logo=go)](https://go.dev/)
 [![Docker](https://img.shields.io/badge/ghcr-v0.6.5-blue?logo=docker)](https://github.com/TokenDanceLab/metapi-go/pkgs/container/metapi-go)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 


### PR DESCRIPTION
## Summary
- Align `README.md` / `README_EN.md` Go badge to **1.26.5** (truth: `go.mod`, Dockerfile `golang:1.26.5-alpine`)
- Update README tech stack table: language Go 1.26.5; frontend React 19 + Vite 8 + Tailwind CSS v4
- Docs-only; no package bumps

Closes #494

## Test plan
- [x] `rg -n "1\.26\.|React |Vite" README.md README_EN.md` shows 1.26.5 / React 19 / Vite 8
- [x] No remaining 1.26.4 or React 18 claims in README files
- [x] Diff limited to README.md + README_EN.md