### PR TITLE
feat(auth): best-effort TPM admission estimate when maxTPM set (#495)

### DIFF
--- a/auth/proxy.go
+++ b/auth/proxy.go
@@ -2,8 +2,8 @@ package auth
 
 import (
 	"net/http"
-	"strconv"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/tokendancelab/metapi-go/config"
@@ -57,7 +57,13 @@ func ProxyAuth(cfg *config.Config) func(http.Handler) http.Handler {
 					return
 				}
 				// Soft RPM/TPM admission (learn #116). Fail closed with 429 + Retry-After.
-				adm := GlobalKeyAdmission.Allow(result.Key.ID, result.Key.MaxRPM, result.Key.MaxTPM, 0)
+				// When maxTPM is set, reserve a best-effort estimate from the request
+				// body (#495). estimatedTokens=0 skips TPM accounting (no invent).
+				estimatedTokens := int64(0)
+				if result.Key.MaxTPM != nil && *result.Key.MaxTPM > 0 {
+					estimatedTokens = estimateAdmissionTokens(r)
+				}
+				adm := GlobalKeyAdmission.Allow(result.Key.ID, result.Key.MaxRPM, result.Key.MaxTPM, estimatedTokens)
 				if !adm.Allowed {
 					msg := "API key rate limit exceeded"
 					if adm.Reason == "over_tpm" {

--- a/auth/tpm_estimate.go
+++ b/auth/tpm_estimate.go
@@ -1,0 +1,133 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"unicode/utf8"
+)
+
+// Best-effort TPM admission estimate (#495 / learn #116).
+//
+// Strategy (documented intentionally; not a tokenizer):
+//  1. Prefer JSON body fields used by chat/completions & responses APIs:
+//     sum string rune lengths under "messages" and "input", then chars/4.
+//  2. Else fall back to Content-Length/4 when present (floor only).
+//  3. Clamp positive estimates to [1, 128000].
+//  4. Unreadable / empty / non-JSON with no Content-Length → 0 (skip TPM accounting).
+//
+// Never invent large defaults that false-block admission.
+const (
+	tpmEstimateMaxTokens int64 = 128_000
+	// Cap how much of the body we peek for estimation so huge uploads do not
+	// blow middleware memory. Content-Length floor still applies above the cap.
+	tpmEstimateMaxBodyBytes int64 = 256 << 10 // 256 KiB
+)
+
+// estimateAdmissionTokens returns a best-effort token estimate for TPM admission.
+// Safe to call on any request; restores r.Body when it was peeked.
+// Returns 0 when no reliable signal is available (caller should skip TPM reserve).
+func estimateAdmissionTokens(r *http.Request) int64 {
+	if r == nil {
+		return 0
+	}
+
+	chars := int64(0)
+	if r.Body != nil && r.Body != http.NoBody {
+		// Peek up to cap+1 so we can detect truncation without consuming the rest.
+		peek, err := io.ReadAll(io.LimitReader(r.Body, tpmEstimateMaxBodyBytes+1))
+		if err != nil {
+			// Re-chain whatever was read with the remaining body; skip JSON path.
+			r.Body = io.NopCloser(io.MultiReader(bytes.NewReader(peek), r.Body))
+		} else if int64(len(peek)) > tpmEstimateMaxBodyBytes {
+			// Partial peek only — re-attach full stream; do not parse partial JSON.
+			r.Body = io.NopCloser(io.MultiReader(bytes.NewReader(peek), r.Body))
+		} else {
+			// Full body (within cap) was consumed; restore from bytes.
+			r.Body = io.NopCloser(bytes.NewReader(peek))
+			if n := sumMessagesInputStringRunes(peek); n > 0 {
+				chars = n
+			}
+		}
+	}
+
+	if chars <= 0 {
+		// Content-Length floor when JSON path yielded nothing.
+		if r.ContentLength > 0 {
+			chars = r.ContentLength
+		} else {
+			return 0
+		}
+	}
+
+	// chars/4 ≈ tokens; clamp positive results to [1, 128000].
+	tokens := chars / 4
+	if tokens < 1 {
+		tokens = 1
+	}
+	if tokens > tpmEstimateMaxTokens {
+		tokens = tpmEstimateMaxTokens
+	}
+	return tokens
+}
+
+// sumMessagesInputStringRunes walks JSON "messages" / "input" and sums rune
+// lengths of string leaves. Returns 0 for non-JSON or missing fields.
+func sumMessagesInputStringRunes(raw []byte) int64 {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || raw[0] != '{' {
+		return 0
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return 0
+	}
+	var total int64
+	if m, ok := top["messages"]; ok {
+		total += sumJSONStringRunes(m)
+	}
+	if in, ok := top["input"]; ok {
+		total += sumJSONStringRunes(in)
+	}
+	return total
+}
+
+// sumJSONStringRunes recursively sums rune counts of all JSON string values.
+func sumJSONStringRunes(raw json.RawMessage) int64 {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return 0
+	}
+	switch raw[0] {
+	case '"':
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return 0
+		}
+		return int64(utf8.RuneCountInString(s))
+	case '[':
+		var arr []json.RawMessage
+		if err := json.Unmarshal(raw, &arr); err != nil {
+			return 0
+		}
+		var n int64
+		for _, el := range arr {
+			n += sumJSONStringRunes(el)
+		}
+		return n
+	case '{':
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			return 0
+		}
+		var n int64
+		for _, v := range obj {
+			n += sumJSONStringRunes(v)
+		}
+		return n
+	default:
+		// numbers, bools, null — ignore
+		return 0
+	}
+}

--- a/auth/tpm_estimate_test.go
+++ b/auth/tpm_estimate_test.go
@@ -1,0 +1,160 @@
+package auth
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestEstimateAdmissionTokens_MessagesJSON(t *testing.T) {
+	// 40 ASCII chars in content → 40/4 = 10 tokens.
+	body := `{"model":"gpt","messages":[{"role":"user","content":"abcdefghijklmnopqrstuvwxyzabcdefghijkl"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = int64(len(body))
+
+	got := estimateAdmissionTokens(req)
+	if got != 10 {
+		t.Fatalf("estimate = %d, want 10", got)
+	}
+
+	// Body must still be fully readable by downstream.
+	restored, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if string(restored) != body {
+		t.Fatalf("body mutated: got %q want %q", restored, body)
+	}
+}
+
+func TestEstimateAdmissionTokens_InputJSON(t *testing.T) {
+	// responses-style: input is a plain string of 8 chars → 2 tokens.
+	body := `{"model":"gpt","input":"abcdefgh"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+
+	got := estimateAdmissionTokens(req)
+	if got != 2 {
+		t.Fatalf("estimate = %d, want 2", got)
+	}
+}
+
+func TestEstimateAdmissionTokens_ContentLengthFloor(t *testing.T) {
+	// Non-JSON body → Content-Length/4 floor.
+	body := "not-json-but-sixteen" // 20 chars → 5 tokens
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+
+	got := estimateAdmissionTokens(req)
+	want := int64(len(body)) / 4
+	if got != want {
+		t.Fatalf("estimate = %d, want %d", got, want)
+	}
+}
+
+func TestEstimateAdmissionTokens_EmptyBodySkips(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	got := estimateAdmissionTokens(req)
+	if got != 0 {
+		t.Fatalf("empty body estimate = %d, want 0 (skip TPM)", got)
+	}
+}
+
+func TestEstimateAdmissionTokens_NoContentLengthNonJSONSkips(t *testing.T) {
+	// Chunked-style: body present but ContentLength unknown and non-JSON → 0.
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("plain"))
+	req.ContentLength = -1
+	got := estimateAdmissionTokens(req)
+	if got != 0 {
+		t.Fatalf("non-json without content-length estimate = %d, want 0", got)
+	}
+}
+
+func TestEstimateAdmissionTokens_ClampMin(t *testing.T) {
+	// 1 char content → chars/4 = 0 → clamp to 1.
+	body := `{"messages":[{"content":"a"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+	got := estimateAdmissionTokens(req)
+	if got != 1 {
+		t.Fatalf("min clamp estimate = %d, want 1", got)
+	}
+}
+
+func TestEstimateAdmissionTokens_ClampMax(t *testing.T) {
+	// Content-Length huge → clamp to 128000.
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("x"))
+	req.ContentLength = 4 * (tpmEstimateMaxTokens + 50_000) // would be > max
+	got := estimateAdmissionTokens(req)
+	// Body is "x" (JSON path fails), Content-Length floor applies then clamp.
+	if got != tpmEstimateMaxTokens {
+		t.Fatalf("max clamp estimate = %d, want %d", got, tpmEstimateMaxTokens)
+	}
+}
+
+func TestEstimateAdmissionTokens_NilRequest(t *testing.T) {
+	if got := estimateAdmissionTokens(nil); got != 0 {
+		t.Fatalf("nil request estimate = %d, want 0", got)
+	}
+}
+
+func TestEstimateAdmissionTokens_UnicodeRunes(t *testing.T) {
+	// 4 CJK runes → rune count 4 → 1 token (not byte-based).
+	body := `{"messages":[{"content":"你好世界"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+	got := estimateAdmissionTokens(req)
+	if got != 1 {
+		t.Fatalf("unicode estimate = %d, want 1", got)
+	}
+}
+
+func TestKeyAdmissionLimiter_TPM_WithEstimateHelper(t *testing.T) {
+	// Wire helper → Allow: two estimates of 600 against maxTPM=1000.
+	l := NewKeyAdmissionLimiter()
+	tpm := int64(1000)
+
+	body1 := `{"messages":[{"content":"` + strings.Repeat("a", 2400) + `"}]}` // 2400/4=600
+	req1 := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body1))
+	req1.ContentLength = int64(len(body1))
+	est1 := estimateAdmissionTokens(req1)
+	if est1 != 600 {
+		t.Fatalf("est1 = %d, want 600", est1)
+	}
+	if d := l.Allow(42, nil, &tpm, est1); !d.Allowed {
+		t.Fatalf("first allow: %#v", d)
+	}
+
+	body2 := `{"messages":[{"content":"` + strings.Repeat("b", 2000) + `"}]}` // 2000/4=500
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body2))
+	req2.ContentLength = int64(len(body2))
+	est2 := estimateAdmissionTokens(req2)
+	if est2 != 500 {
+		t.Fatalf("est2 = %d, want 500", est2)
+	}
+	if d := l.Allow(42, nil, &tpm, est2); d.Allowed || d.Reason != "over_tpm" {
+		t.Fatalf("expected over_tpm: %#v (est2=%d)", d, est2)
+	}
+}
+
+func TestKeyAdmissionLimiter_MaxTPMNil_Unchanged(t *testing.T) {
+	// maxTPM nil: estimatedTokens ignored — unlimited TPM path.
+	l := NewKeyAdmissionLimiter()
+	for i := 0; i < 5; i++ {
+		if d := l.Allow(99, nil, nil, 100_000); !d.Allowed {
+			t.Fatalf("nil maxTPM should allow: %#v", d)
+		}
+	}
+	rpm, tpmUsed := l.Snapshot(99)
+	if tpmUsed != 0 {
+		t.Fatalf("nil maxTPM must not reserve tokens, usedTPM=%d", tpmUsed)
+	}
+	if rpm != 0 {
+		// RPM also unlimited (nil) — Allow returns early before recording.
+		// usedRPM stays 0 when both limits are 0.
+	}
+	_ = rpm
+}


### PR DESCRIPTION
## Summary
- Wire `ProxyAuth` to pass a best-effort `estimatedTokens` into `GlobalKeyAdmission.Allow` when managed key `maxTPM` is positive (was always `0`, so TPM never reserved).
- New pure helper `estimateAdmissionTokens`: JSON `messages`/`input` string rune lengths / 4, else Content-Length floor; clamp `1..128000`; unreadable/empty → `0` (skip TPM, never invent).
- Unit tests for estimate helper + Allow path with maxTPM; maxTPM nil/0 unchanged.

## Issue
Closes #495

## Test plan
- [x] `go test ./auth -count=1 -run 'Admission|TPM|Estimate'`
- [x] `go test ./auth -count=1`