### PR TITLE
docs(release): v0.8.37 README stack truth + TPM estimate + credential usage honesty residual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.37] — 2026-07-18
+
+### Docs
+- Align README/README_EN stack badges to Go 1.26.5 + React 19 + Vite 8 (#494 / #498)
+
+### Reliability
+- Best-effort TPM admission estimate when maxTPM is set (no invent; empty body skips) (#495 / #500)
+
+### Tests / Honesty
+- P0-585 credential usage-limit multi-channel cool honesty tests (intentional shared-key scope; cascade still partial) (#496 / #499)
+
+### Docs / Honesty
+- Residual inventory + MASTER for Milestone 47 post-product landings; DOCS-STACK-TRUTH + REL-TPM-ESTIMATE + REL-CRED-USAGE-HONESTY present · board #494–#497 closed (#497 / #501)
+
 ## [v0.8.36] — 2026-07-18
 
 ### Security

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -2,11 +2,11 @@
 
 **Date**: 2026-07-18  
 **Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); latest honesty [#487](https://github.com/TokenDanceLab/metapi-go/issues/487) (trail via MASTER / CHANGELOG)  
-**Context**: **v0.8.36 shipped** (Milestone 46 closed): #484-#487 present. **Milestone 47 product landed on master** (not tagged yet): #494 DOCS-STACK-TRUTH (PR #498), #495 REL-TPM-ESTIMATE (PR #500), #496 REL-CRED-USAGE-HONESTY (PR #499); docs honesty #497 this pass. Prior residual train v0.8.18–v0.8.35 is in `CHANGELOG.md` / Releases — do not re-narrate here. Program foundations (STACK / UI / BACKEND / SCHEMA / FEATURE / RELIABILITY) are closed; residual polish only.  
+**Context**: **v0.8.36 shipped** (Milestone 46 closed): #484-#487 present. **v0.8.37 shipped** (Milestone 47 closed): #494 DOCS-STACK-TRUTH (PR #498), #495 REL-TPM-ESTIMATE (PR #500), #496 REL-CRED-USAGE-HONESTY (PR #499), #497 residual honesty (PR #501) + release gate. Prior residual train v0.8.18–v0.8.35 is in `CHANGELOG.md` / Releases — do not re-narrate here. Program foundations (STACK / UI / BACKEND / SCHEMA / FEATURE / RELIABILITY) are closed; residual polish only.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)  
 **M35 review synthesis**: [`enterprise-review-m35.md`](./enterprise-review-m35.md) (#388) — historical pointer only  
-**Active wave**: M47 product board empty after #497; next is **v0.8.37** release gate (latest tag still **v0.8.36**)
+**Active wave**: none (M47 closed; sequencing **v0.8.38+** optional residual with ACs only)
 
 ## Purpose
 
@@ -79,11 +79,11 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | SEC-ENDPOINT | Site API endpoint admin normalize + service validator | **present** (#389/#396 + #398/#403) | Admin `normalizeAPIEndpointsInput` rejects forbidden targets with clear 400 before upsert; `IsValidAPIEndpointURL` itself rejects metadata/link-local (parity with `IsValidHTTPURL` / `IsForbiddenSiteTargetURL`) so any caller is safe by default | Done for admin early-reject + base validator parity | RFC1918/localhost intentionally allowed |
 | M35-REVIEW | Multi-lane residual review synthesis | **present** (docs #388) | `docs/analysis/enterprise-review-m35.md` ranked P0/P1/P2; #389/#390 follow-ons closed on master | Historical M35 pointer | Synthesis only |
 
-## Recommended sequencing (v0.8.37 release gate + v0.8.38+)
+## Recommended sequencing (v0.8.38+)
 
 1. **Latest release**: **v0.8.36** (M46 closed).
-2. **M47 product landed on master (not tagged)**: #494 DOCS-STACK-TRUTH (PR #498) · #495 REL-TPM-ESTIMATE (PR #500) · #496 REL-CRED-USAGE-HONESTY (PR #499); docs honesty #497 this pass.
-3. **Active wave**: none after products. Next operator step is **v0.8.37** release gate. Optional residual **v0.8.38+** only with dedicated ACs.
+2. **M47 / v0.8.37 closed**: #494–#497 (PRs #498–#501) present on master with tag.
+3. **Active wave**: none. Optional residual **v0.8.38+** only with dedicated ACs.
 4. **DOCS-STACK-TRUTH** / **REL-TPM-ESTIMATE** / **REL-CRED-USAGE-HONESTY** fully **present**. **P0-555** stays **present-with-residual**. **P0-585** remains **partial** (load-proof still required).
 5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
 6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
@@ -107,10 +107,10 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Claiming README still shows Go 1.26.4 / React 18 after #494/#498.
 - Claiming maxTPM soft admission is a no-op after #495/#500 (estimate is best-effort, not perfect tokenizer).
 - Claiming P0-585 credential usage-limit honesty tests are missing after #496/#499 (cascade still partial).
-- Claiming **v0.8.37** released before the release gate (products landed; tag is separate).
+- Claiming **v0.8.38** product without dedicated ACs.
 ## Links
 
-- Release: [v0.8.36](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.36) · prior [v0.8.35](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.35) · next **v0.8.37** release gate after this honesty pass (then optional residual **v0.8.38+** with ACs only)
+- Release: [v0.8.37](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.37) · prior [v0.8.36](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.36) · next optional residual **v0.8.38+** (with ACs only)
 - Milestone: [Enterprise security/UI residual polish v0.8.36](https://github.com/TokenDanceLab/metapi-go/milestone/46) · **closed** (#484–#487)
 - Prior milestone: [Enterprise UI/reliability residual polish v0.8.35](https://github.com/TokenDanceLab/metapi-go/milestone/45) · **closed**
 - Matrix: `docs/analysis/original-gap-matrix.md`

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -3,7 +3,7 @@
 **Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery  
 **Mode**: GitHub Issues + Milestones (SDD)  
 **Repo**: https://github.com/TokenDanceLab/metapi-go  
-**Latest release**: **[v0.8.36](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.36)** (2026-07-18)
+**Latest release**: **[v0.8.37](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.37)** (2026-07-18)
 
 > 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。  
 > 文档地图：[`docs/README.md`](../README.md)
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | [Milestone 47](https://github.com/TokenDanceLab/metapi-go/milestone/47) open until **v0.8.37** release gate |
+| Active milestone | none (board clean; next residual only with ACs) |
 | Program map | `docs/plan/enterprise-program.md` (historical / closed foundations) |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | M35 review synthesis | `docs/analysis/enterprise-review-m35.md` (#388; historical) |
@@ -32,17 +32,16 @@
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| — | — | Product board empty after this PR closes #497; next is **v0.8.37** release gate |
+| — | — | Board clean (no open residual product board) |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
-**M35–M46 closed** with v0.8.36. **M47 product landed on master**: #494 DOCS-STACK-TRUTH (PR #498) · #495 REL-TPM-ESTIMATE (PR #500) · #496 REL-CRED-USAGE-HONESTY (PR #499). Docs honesty is #497 (this PR).
-**Milestone 47**: remains open until release gate / **v0.8.37** tag — do not claim v0.8.37 released.
-**Latest release**: stays **v0.8.36** until the M47 release gate.
+**M35–M47 closed** with v0.8.37. Latest release **v0.8.37** (published after this gate).
 
 ## Residual releases (pointer only)
 
 | Tag | Milestone | Highlights |
 |:----|:----------|:-----------|
+| [v0.8.37](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.37) | 47 | README stack truth · TPM admission estimate · P0-585 credential usage honesty · residual honesty |
 | [v0.8.36](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.36) | 46 | monitor cookie clear · CSS residual · P0-555 stream usage honesty · residual honesty |
 | [v0.8.35](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.35) | 45 | DownstreamKeys maxRpm/maxTpm UI · P0-585 empty-filter honesty · login token debt |
 | older | 11–44 | See GitHub Releases / `CHANGELOG.md` |
@@ -70,7 +69,7 @@ git log --oneline origin/master -10
 
 ## Next Steps
 
-1. After this docs PR closes #497: M47 product board is empty on master; run **v0.8.37** release gate (tag + milestone close). Latest release remains **v0.8.36** until then.
+1. Board clean after **v0.8.37**. Optional residual **v0.8.38+** only with dedicated ACs.
 2. Do **not** invent WS-1 / STICKY-B Redis / UC-1 product without dedicated ACs.
 3. Optional later: P0-585 production load-proof; deeper P0-555 media/lag polish; further dialect context_length only if a new dialect needs ACs.
 


### PR DESCRIPTION
## Summary
Release gate for **v0.8.37** / Milestone 47.

### Product already on master
- #494/#498 README stack truth
- #495/#500 TPM admission estimate
- #496/#499 P0-585 credential usage honesty tests
- #497/#501 residual honesty

Tag + milestone close follow merge.