### PR TITLE
docs: correct public Redis claims for admission sharedcount (#503)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Cron 定时执行（默认每日 08:00），智能解析奖励金额，签到失
 | `CHECKIN_CRON` | `0 8 * * *` | 签到时间 |
 | `BALANCE_REFRESH_CRON` | `0 * * * *` | 余额刷新频率 |
 
-当前运行时支持两种数据库形态：单进程 SQLite；PostgreSQL 生产部署。PostgreSQL 模式下，产生外部请求、通知、上传、清理或同步副作用的后台任务使用 PG advisory lock，避免多副本重复执行同一批任务。Redis 尚未集成：没有 `REDIS_URL` 配置、Redis 客户端或分布式缓存。
+当前运行时支持两种数据库形态：单进程 SQLite；PostgreSQL 生产部署。PostgreSQL 模式下，产生外部请求、通知、上传、清理或同步副作用的后台任务使用 PG advisory lock，避免多副本重复执行同一批任务。可选 `REDIS_URL` / `METAPI_REDIS_URL` 仅用于多实例下游 Key 的 **RPM/TPM admission** 共享计数（`auth.ConfigureSharedAdmissionFromRedisURL` + `internal/sharedcount`，不可达时 fail-open 回退进程内窗口）；留空则无需 Redis 进程。Sticky session 仍是进程内绑定，**不会**因配置 Redis 而跨实例共享（STICKY-B 仍为 residual，非产品）。详见 [`docs/analysis/redis-shared-state.md`](docs/analysis/redis-shared-state.md)。
 
 代理转发没有配置路由和上游依赖时，生产默认返回 HTTP 503。`METAPI_ENABLE_PROXY_STUB=1` 只用于测试或演示，避免把本地假响应误当成真实上游调用。
 
@@ -198,7 +198,7 @@ Cron 定时执行（默认每日 08:00），智能解析奖励金额，签到失
 |----|------|
 | 后端 | [chi](https://github.com/go-chi/chi) 路由 + `net/http` |
 | 语言 | Go 1.26.5 |
-| 数据库 | SQLite / PostgreSQL + [sqlx](https://github.com/jmoiron/sqlx)，无 Redis 运行时依赖 |
+| 数据库 | SQLite / PostgreSQL + [sqlx](https://github.com/jmoiron/sqlx)；可选 Redis 仅用于 RPM/TPM admission（非必需） |
 | 定时任务 | [robfig/cron](https://github.com/robfig/cron) |
 | 容器化 | Docker（Alpine，15MB 镜像） |
 | 前端 | React 19 + Vite 8 + Tailwind CSS v4（内嵌） |

--- a/README_EN.md
+++ b/README_EN.md
@@ -73,7 +73,7 @@ All env vars are identical to the TypeScript version.
 
 Full list: [`.env.example`](.env.example).
 
-The runtime supports two database modes: single-process SQLite and PostgreSQL for production deployments. In PostgreSQL mode, side-effecting schedulers such as external requests, notifications, uploads, cleanup, and sync jobs use PG advisory locks so multiple replicas do not run the same job batch at the same time. Redis is not integrated yet: there is no `REDIS_URL` setting, Redis client, or distributed cache.
+The runtime supports two database modes: single-process SQLite and PostgreSQL for production deployments. In PostgreSQL mode, side-effecting schedulers such as external requests, notifications, uploads, cleanup, and sync jobs use PG advisory locks so multiple replicas do not run the same job batch at the same time. Optional `REDIS_URL` / `METAPI_REDIS_URL` enables multi-instance shared **RPM/TPM admission** counters only (`auth.ConfigureSharedAdmissionFromRedisURL` + `internal/sharedcount`; fail-open to process-local windows if Redis is unreachable). Leave empty for single-node — no Redis process required. Sticky sessions remain process-local and are **not** shared across instances via Redis today (STICKY-B is residual, not product). See [`docs/analysis/redis-shared-state.md`](docs/analysis/redis-shared-state.md).
 
 Proxy forwarding returns HTTP 503 when routing and upstream dependencies are not configured. `METAPI_ENABLE_PROXY_STUB=1` is for tests and demos only.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,6 +34,7 @@
 | `METAPI_ENABLE_PROXY_STUB` | _(empty)_ | Test/demo-only local proxy stub. Leave empty in production; unconfigured upstream forwarding returns 503 |
 | `TRUSTED_PROXY_CIDRS` | _(empty)_ | Comma-separated reverse-proxy CIDRs allowed to supply `X-Forwarded-For` / `X-Real-IP`; forwarded headers are ignored when empty |
 | `ADMIN_CORS_ALLOWED_ORIGINS` | _(empty)_ | Comma-separated exact `http(s)` browser origins allowed to call `/api/*`; empty keeps admin API same-origin only, and `*` is rejected |
+| `REDIS_URL` / `METAPI_REDIS_URL` | _(empty)_ | Optional Redis for multi-instance shared downstream-key **RPM/TPM admission** only (`internal/sharedcount`; fail-open). Empty = process-local counters; no Redis process required. Does **not** enable sticky session multi-instance sharing |
 
 ## Docker Compose (Production)
 
@@ -136,7 +137,7 @@ Schema migrations run automatically at startup. Use `metapi-migrate` to transfer
 
 Use PostgreSQL for multi-instance deployments. Side-effecting schedulers use PostgreSQL advisory locks, so only one replica runs each job batch at a time. `admin-snapshot` remains process-local cache warming; `usage-aggregation` uses its own checkpoint lease.
 
-Redis is not part of the current runtime. There is no `REDIS_URL` setting, Redis client, or distributed cache in this build.
+Optional Redis (`REDIS_URL` / `METAPI_REDIS_URL`) is used only for multi-instance shared downstream-key **RPM/TPM admission** via `auth.ConfigureSharedAdmissionFromRedisURL` and `internal/sharedcount`. Admission is fail-open: if Redis is unreachable, counters fall back to process-local windows. Leave empty for single-node deployments — no Redis process is required. Sticky session bindings remain process-local; Redis does **not** share sticky maps across instances (STICKY-B is residual, not product). Details: [`docs/analysis/redis-shared-state.md`](analysis/redis-shared-state.md).
 
 ### Proxy Forwarding
 


### PR DESCRIPTION
## Summary
- Correct README.md / README_EN.md / docs/deployment.md: optional `REDIS_URL` / `METAPI_REDIS_URL` for multi-instance downstream-key **RPM/TPM admission** only (`auth.ConfigureSharedAdmissionFromRedisURL` + `internal/sharedcount`, fail-open).
- Explicitly state sticky sessions remain process-local (STICKY-B residual, not product).
- Point operators to `docs/analysis/redis-shared-state.md`.
- No product code.

Closes #503

## Test plan
- [x] `rg -n "REDIS|Redis|sticky" README.md README_EN.md docs/deployment.md` — no “Redis completely absent”; no sticky multi-instance product claim
- [x] Diff limited to allowed files only