### PR TITLE
docs(release): v0.8.38 Redis admission truth + docker badge + residual latest honesty residual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.38] — 2026-07-18
+
+### Docs / Honesty
+- Public Redis claims: optional REDIS_URL for multi-instance RPM/TPM admission (sharedcount fail-open); sticky still process-local residual (#503 / #507)
+- ghcr public badge bumped to v0.8.37 series; residual inventory latest-release sequencing (#504 / #505 / #508)
+- Residual inventory + MASTER for Milestone 48 post-product landings; DOCS-REDIS-TRUTH + DOCS-DOCKER-BADGE + DOCS-RESIDUAL-LATEST present · board #503–#506 closed (#506 / #509)
+
 ## [v0.8.37] — 2026-07-18
 
 ### Docs

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -2,11 +2,11 @@
 
 **Date**: 2026-07-18  
 **Issue**: inventory origin [#290](https://github.com/TokenDanceLab/metapi-go/issues/290); latest honesty [#487](https://github.com/TokenDanceLab/metapi-go/issues/487) (trail via MASTER / CHANGELOG)  
-**Context**: **v0.8.37 shipped** (Milestone 47 closed): #494-#497 present. **Milestone 48 product landed on master** (not tagged yet): #503 DOCS-REDIS-TRUTH (PR #507), #504 DOCS-DOCKER-BADGE + #505 DOCS-RESIDUAL-LATEST (PR #508); docs honesty #506 this pass. Prior **v0.8.36** (M46 closed): #484-#487 present. Residual train v0.8.18–v0.8.35 is in `CHANGELOG.md` / Releases — do not re-narrate here. Program foundations (STACK / UI / BACKEND / SCHEMA / FEATURE / RELIABILITY) are closed; residual polish only.  
+**Context**: **v0.8.37 shipped** (Milestone 47 closed): #494-#497 present. **v0.8.38 shipped** (Milestone 48 closed): #503 DOCS-REDIS-TRUTH (PR #507), #504/#505 docker badge + residual latest (PR #508), #506 residual honesty (PR #509) + release gate. Prior **v0.8.36** (M46 closed): #484-#487 present. Residual train v0.8.18–v0.8.35 is in `CHANGELOG.md` / Releases — do not re-narrate here. Program foundations (STACK / UI / BACKEND / SCHEMA / FEATURE / RELIABILITY) are closed; residual polish only.  
 **Scope**: inventory only — **no product code** in this document.  
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)  
 **M35 review synthesis**: [`enterprise-review-m35.md`](./enterprise-review-m35.md) (#388) — historical pointer only  
-**Active wave**: M48 product board empty after #506; next is **v0.8.38** release gate (latest tag still **v0.8.37**)
+**Active wave**: none (M48 closed; sequencing **v0.8.39+** optional residual with ACs only)
 
 ## Purpose
 
@@ -82,12 +82,12 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | SEC-ENDPOINT | Site API endpoint admin normalize + service validator | **present** (#389/#396 + #398/#403) | Admin `normalizeAPIEndpointsInput` rejects forbidden targets with clear 400 before upsert; `IsValidAPIEndpointURL` itself rejects metadata/link-local (parity with `IsValidHTTPURL` / `IsForbiddenSiteTargetURL`) so any caller is safe by default | Done for admin early-reject + base validator parity | RFC1918/localhost intentionally allowed |
 | M35-REVIEW | Multi-lane residual review synthesis | **present** (docs #388) | `docs/analysis/enterprise-review-m35.md` ranked P0/P1/P2; #389/#390 follow-ons closed on master | Historical M35 pointer | Synthesis only |
 
-## Recommended sequencing (v0.8.38 release gate + v0.8.39+)
+## Recommended sequencing (v0.8.39+)
 
 1. **Latest release**: **v0.8.37** (M47 closed).
-2. **M48 product landed on master (not tagged)**: #503 DOCS-REDIS-TRUTH (PR #507) · #504/#505 docker badge + residual latest (PR #508); docs honesty #506 this pass.
-3. **Active wave**: none after products. Next operator step is **v0.8.38** release gate. Optional residual **v0.8.39+** only with dedicated ACs.
-4. **DOCS-REDIS-TRUTH** (optional Redis admission honesty, not sticky product) / **DOCS-DOCKER-BADGE** / **DOCS-RESIDUAL-LATEST** fully **present**. **P0-555** stays **present-with-residual**. **P0-585** remains **partial** (load-proof still required). Sticky Redis remains **not** product (fail-open admission only).
+2. **M48 / v0.8.38 closed**: #503–#506 (PRs #507–#509) present on master with tag.
+3. **Active wave**: none. Optional residual **v0.8.39+** only with dedicated ACs.
+4. **DOCS-REDIS-TRUTH** (optional admission honesty, sticky **not** product / fail-open) / **DOCS-DOCKER-BADGE** / **DOCS-RESIDUAL-LATEST** fully **present**. **P0-555** stays **present-with-residual**. **P0-585** remains **partial** (load-proof still required).
 5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
 6. **Do not** invent shared sticky, WS completions, or updateAvailable without the matching Milestone.
 7. **Do not** re-open enterprise program foundations as greenfield modernization — residual polish only.
@@ -114,10 +114,10 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 - Claiming Redis is completely absent after #503/#507 (admission optional; sticky still residual).
 - Claiming public ghcr badge is still v0.6.5 after #504/#508.
 - Claiming residual inventory latest release is still v0.8.36 after #505/#508.
-- Claiming **v0.8.38** released before the release gate (products landed; tag is separate).
+- Claiming **v0.8.39** product without dedicated ACs.
 ## Links
 
-- Release: [v0.8.37](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.37) · prior [v0.8.36](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.36) · next **v0.8.38** release gate after this honesty pass (then optional residual **v0.8.39+** with ACs only)
+- Release: [v0.8.38](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.38) · prior [v0.8.37](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.37) · next optional residual **v0.8.39+** (with ACs only)
 - Milestone: [Enterprise residual polish v0.8.37](https://github.com/TokenDanceLab/metapi-go/milestone/47) · **closed** (#494–#497)
 - Prior milestone: [Enterprise security/UI residual polish v0.8.36](https://github.com/TokenDanceLab/metapi-go/milestone/46) · **closed** (#484–#487)
 - Matrix: `docs/analysis/original-gap-matrix.md`

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -3,7 +3,7 @@
 **Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery  
 **Mode**: GitHub Issues + Milestones (SDD)  
 **Repo**: https://github.com/TokenDanceLab/metapi-go  
-**Latest release**: **[v0.8.37](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.37)** (2026-07-18)
+**Latest release**: **[v0.8.38](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.38)** (2026-07-18)
 
 > 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。  
 > 文档地图：[`docs/README.md`](../README.md)
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | [Milestone 48](https://github.com/TokenDanceLab/metapi-go/milestone/48) open until **v0.8.38** release gate |
+| Active milestone | none (board clean; next residual only with ACs) |
 | Program map | `docs/plan/enterprise-program.md` (historical / closed foundations) |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | M35 review synthesis | `docs/analysis/enterprise-review-m35.md` (#388; historical) |
@@ -32,17 +32,16 @@
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| — | — | Product board empty after this PR closes #506; next is **v0.8.38** release gate |
+| — | — | Board clean (no open residual product board) |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
-**M35–M47 closed** with v0.8.37. **M48 product landed on master**: #503 DOCS-REDIS-TRUTH (PR #507) · #504/#505 docker badge + residual latest (PR #508). Docs honesty is #506 (this PR).
-**Milestone 48**: remains open until release gate / **v0.8.38** tag — do not claim v0.8.38 released.
-**Latest release**: stays **v0.8.37** until the M48 release gate.
+**M35–M48 closed** with v0.8.38. Latest release **v0.8.38** (published after this gate).
 
 ## Residual releases (pointer only)
 
 | Tag | Milestone | Highlights |
 |:----|:----------|:-----------|
+| [v0.8.38](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.38) | 48 | Redis admission truth · docker badge · residual latest sequencing · residual honesty |
 | [v0.8.37](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.37) | 47 | README stack truth · TPM admission estimate · P0-585 credential usage honesty · residual honesty |
 | [v0.8.36](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.36) | 46 | monitor cookie clear · CSS residual · P0-555 stream usage honesty · residual honesty |
 | [v0.8.35](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.35) | 45 | DownstreamKeys maxRpm/maxTpm UI · P0-585 empty-filter honesty · login token debt |
@@ -71,7 +70,7 @@ git log --oneline origin/master -10
 
 ## Next Steps
 
-1. After this docs PR closes #506: M48 product board is empty on master; run **v0.8.38** release gate (tag + milestone close). Latest release remains **v0.8.37** until then.
+1. Board clean after **v0.8.38**. Optional residual **v0.8.39+** only with dedicated ACs.
 2. Do **not** invent WS-1 / STICKY-B Redis sticky / UC-1 product without dedicated ACs.
 3. Optional later: P0-585 production load-proof; deeper P0-555 media/lag polish; further dialect context_length only if a new dialect needs ACs.
 


### PR DESCRIPTION
## Summary
Release gate for **v0.8.38** / Milestone 48.

### Product already on master
- #503/#507 Redis admission public truth (sticky still residual)
- #504/#505/#508 docker badge + residual latest sequencing
- #506/#509 residual honesty

Tag + milestone close follow merge.