### PR TITLE
fix(admission): roll back shared RPM/TPM on deny (#513)

### DIFF
--- a/auth/key_admission.go
+++ b/auth/key_admission.go
@@ -204,7 +204,6 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 					if _, rerr := l.sharedRPM.Decr(context.Background(), rpmKey, time.Minute); rerr != nil {
 						slog.Debug("redis admission: rpm rollback after tpm deny failed", "key_id", keyID, "error", rerr)
 					}
-					sharedRPMCounted = false
 				}
 				return AdmissionDecision{
 					Allowed:    false,

--- a/auth/key_admission.go
+++ b/auth/key_admission.go
@@ -149,15 +149,20 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 	usedTPM := sumTokens(w.tokenEvents)
 
 	// Optional multi-instance RPM (#118). Fail-open on errors.
+	// On deny, compensating Decr so denied requests do not occupy the window (#513).
 	sharedRPMCounted := false
+	rpmKey := rpmSharedKey(keyID)
 	if rpmLimit > 0 && l.sharedRPM != nil {
-		n, err := l.sharedRPM.Incr(context.Background(), rpmSharedKey(keyID), time.Minute)
+		n, err := l.sharedRPM.Incr(context.Background(), rpmKey, time.Minute)
 		if err != nil {
 			slog.Debug("redis admission: fail-open on error", "key_id", keyID, "error", err)
 		} else {
 			sharedRPMCounted = true
 			usedRPM = n
 			if n > rpmLimit {
+				if _, rerr := l.sharedRPM.Decr(context.Background(), rpmKey, time.Minute); rerr != nil {
+					slog.Debug("redis admission: rpm rollback failed", "key_id", keyID, "error", rerr)
+				}
 				return AdmissionDecision{
 					Allowed:    false,
 					Reason:     "over_rpm",
@@ -181,15 +186,26 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 	}
 
 	// Optional multi-instance TPM (#245). Fail-open on errors.
+	// On deny, roll back TPM (and RPM if already reserved) so the window stays free (#513).
 	sharedTPMCounted := false
+	tpmKey := tpmSharedKey(keyID)
 	if tpmLimit > 0 && estimatedTokens > 0 && l.sharedTPM != nil {
-		n, err := l.sharedTPM.IncrBy(context.Background(), tpmSharedKey(keyID), estimatedTokens, time.Minute)
+		n, err := l.sharedTPM.IncrBy(context.Background(), tpmKey, estimatedTokens, time.Minute)
 		if err != nil {
 			slog.Debug("redis admission tpm: fail-open on error", "key_id", keyID, "error", err)
 		} else {
 			sharedTPMCounted = true
 			usedTPM = n
 			if n > tpmLimit {
+				if _, rerr := l.sharedTPM.IncrBy(context.Background(), tpmKey, -estimatedTokens, time.Minute); rerr != nil {
+					slog.Debug("redis admission: tpm rollback failed", "key_id", keyID, "error", rerr)
+				}
+				if sharedRPMCounted {
+					if _, rerr := l.sharedRPM.Decr(context.Background(), rpmKey, time.Minute); rerr != nil {
+						slog.Debug("redis admission: rpm rollback after tpm deny failed", "key_id", keyID, "error", rerr)
+					}
+					sharedRPMCounted = false
+				}
 				return AdmissionDecision{
 					Allowed:    false,
 					Reason:     "over_tpm",

--- a/auth/key_admission_shared_test.go
+++ b/auth/key_admission_shared_test.go
@@ -5,32 +5,81 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/tokendancelab/metapi-go/internal/sharedcount"
 )
 
+// fakeWindow is a dual-key WindowCounter for shared RPM/TPM tests.
+// Keys containing "tpm" use the tokens field; others use the n field.
 type fakeWindow struct {
-	n   int64
-	err error
+	n      int64
+	tokens int64
+	err    error
+	// lastDelta records the most recent IncrBy delta (for rollback assertions).
+	lastDelta int64
+}
+
+func (f *fakeWindow) isTPM(key string) bool {
+	return len(key) >= 11 && key[:11] == "metapi:tpm:"
 }
 
 func (f *fakeWindow) Incr(ctx context.Context, key string, window time.Duration) (int64, error) {
+	_ = ctx
+	_ = window
 	if f.err != nil {
 		return 0, f.err
+	}
+	if f.isTPM(key) {
+		f.tokens++
+		return f.tokens, nil
 	}
 	f.n++
 	return f.n, nil
 }
 
-func (f *fakeWindow) IncrBy(ctx context.Context, key string, delta int64, window time.Duration) (int64, error) {
+func (f *fakeWindow) Decr(ctx context.Context, key string, window time.Duration) (int64, error) {
+	_ = ctx
+	_ = window
 	if f.err != nil {
 		return 0, f.err
 	}
-	if delta > 0 {
-		f.n += delta
+	if f.isTPM(key) {
+		if f.tokens > 0 {
+			f.tokens--
+		}
+		return f.tokens, nil
+	}
+	if f.n > 0 {
+		f.n--
+	}
+	return f.n, nil
+}
+
+func (f *fakeWindow) IncrBy(ctx context.Context, key string, delta int64, window time.Duration) (int64, error) {
+	_ = ctx
+	_ = window
+	if f.err != nil {
+		return 0, f.err
+	}
+	f.lastDelta = delta
+	if f.isTPM(key) {
+		f.tokens += delta
+		if f.tokens < 0 {
+			f.tokens = 0
+		}
+		return f.tokens, nil
+	}
+	f.n += delta
+	if f.n < 0 {
+		f.n = 0
 	}
 	return f.n, nil
 }
 
 func (f *fakeWindow) Get(ctx context.Context, key string) (int64, error) {
+	if f.isTPM(key) {
+		return f.tokens, f.err
+	}
 	return f.n, f.err
 }
 
@@ -47,6 +96,22 @@ func TestKeyAdmission_SharedRPM(t *testing.T) {
 	}
 	if d := l.Allow(1, &limit, nil, 0); d.Allowed || d.Reason != "over_rpm" {
 		t.Fatalf("3 should deny: %#v", d)
+	}
+	// #513: over_rpm rolls back the denied Incr so the window stays at the limit.
+	if fw.n != 2 {
+		t.Fatalf("after over_rpm deny want counter=2 got %d", fw.n)
+	}
+	// A subsequent allow should succeed once capacity frees — with rollback,
+	// counter remains at 2 so still deny; bump by rolling window is not simulated.
+	// Explicitly free one slot then admit.
+	if _, err := fw.Decr(context.Background(), "metapi:rpm:1", time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	if d := l.Allow(1, &limit, nil, 0); !d.Allowed {
+		t.Fatalf("after free slot should allow: %#v", d)
+	}
+	if fw.n != 2 {
+		t.Fatalf("after re-admit want counter=2 got %d", fw.n)
 	}
 }
 
@@ -80,6 +145,13 @@ func TestKeyAdmission_SharedTPM(t *testing.T) {
 	if d := l.Allow(11, nil, &tpm, 1); d.Allowed || d.Reason != "over_tpm" {
 		t.Fatalf("3 should deny over_tpm: %#v", d)
 	}
+	// #513: over_tpm rolls back the denied IncrBy.
+	if fw.tokens != 1000 {
+		t.Fatalf("after over_tpm deny want tokens=1000 got %d", fw.tokens)
+	}
+	if fw.lastDelta != -1 {
+		t.Fatalf("want lastDelta=-1 rollback got %d", fw.lastDelta)
+	}
 }
 
 func TestKeyAdmission_SharedTPM_FailOpen(t *testing.T) {
@@ -94,5 +166,82 @@ func TestKeyAdmission_SharedTPM_FailOpen(t *testing.T) {
 	// Local path still enforces after fail-open.
 	if d := l.Allow(12, nil, &tpm, 500); d.Allowed || d.Reason != "over_tpm" {
 		t.Fatalf("local over_tpm after fail-open: %#v", d)
+	}
+}
+
+func TestKeyAdmission_SharedRPM_ThenTPM_CompoundRollback(t *testing.T) {
+	// RPM ok + TPM deny must undo BOTH reservations (#513).
+	l := NewKeyAdmissionLimiter()
+	fw := &fakeWindow{}
+	l.SetSharedRPMCounter(fw)
+	l.SetSharedTPMCounter(fw)
+	rpm := int64(10)
+	tpm := int64(100)
+	// Fill TPM almost full.
+	if d := l.Allow(21, &rpm, &tpm, 90); !d.Allowed {
+		t.Fatalf("seed allow: %#v", d)
+	}
+	if fw.n != 1 || fw.tokens != 90 {
+		t.Fatalf("seed state n=%d tokens=%d", fw.n, fw.tokens)
+	}
+	// Next: RPM would succeed (2<=10) but TPM 90+20=110 > 100 → deny both.
+	if d := l.Allow(21, &rpm, &tpm, 20); d.Allowed || d.Reason != "over_tpm" {
+		t.Fatalf("compound deny expected over_tpm: %#v", d)
+	}
+	if fw.n != 1 {
+		t.Fatalf("RPM reservation must roll back: n=%d want 1", fw.n)
+	}
+	if fw.tokens != 90 {
+		t.Fatalf("TPM reservation must roll back: tokens=%d want 90", fw.tokens)
+	}
+	// Capacity remains usable for a fitting request.
+	if d := l.Allow(21, &rpm, &tpm, 10); !d.Allowed {
+		t.Fatalf("fitting request after compound deny: %#v", d)
+	}
+	if fw.n != 2 || fw.tokens != 100 {
+		t.Fatalf("after fit n=%d tokens=%d want 2/100", fw.n, fw.tokens)
+	}
+}
+
+func TestKeyAdmission_SharedMemoryCounter_Parity(t *testing.T) {
+	// MemoryCounter implements the same Decr/negative IncrBy rollback path.
+	// Use two separate counters because MemoryCounter keys share one map but
+	// RPM vs TPM use different key namespaces via the limiter.
+	rpmC := sharedcount.NewMemoryCounter()
+	tpmC := sharedcount.NewMemoryCounter()
+	l := NewKeyAdmissionLimiter()
+	l.SetSharedRPMCounter(rpmC)
+	l.SetSharedTPMCounter(tpmC)
+
+	rpm := int64(2)
+	tpm := int64(100)
+
+	if d := l.Allow(31, &rpm, &tpm, 40); !d.Allowed {
+		t.Fatalf("1: %#v", d)
+	}
+	if d := l.Allow(31, &rpm, &tpm, 40); !d.Allowed {
+		t.Fatalf("2: %#v", d)
+	}
+	// RPM deny: should roll back so used RPM stays 2.
+	if d := l.Allow(31, &rpm, &tpm, 1); d.Allowed || d.Reason != "over_rpm" {
+		t.Fatalf("over_rpm: %#v", d)
+	}
+	// Free one RPM via Decr directly on the counter, then hit TPM deny compound.
+	if _, err := rpmC.Decr(context.Background(), "metapi:rpm:31", time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	// tokens currently 80; request 30 → 110 > 100, both roll back.
+	if d := l.Allow(31, &rpm, &tpm, 30); d.Allowed || d.Reason != "over_tpm" {
+		t.Fatalf("over_tpm compound: %#v", d)
+	}
+	// After compound rollback, RPM should still be 1 (post-decr) and TPM 80.
+	n, err := rpmC.Get(context.Background(), "metapi:rpm:31")
+	if err != nil || n != 1 {
+		t.Fatalf("rpm after compound rollback n=%d err=%v", n, err)
+	}
+	// TPM uses IncrBy points; Get only returns unit times — read via IncrBy 0.
+	tok, err := tpmC.IncrBy(context.Background(), "metapi:tpm:31", 0, time.Minute)
+	if err != nil || tok != 80 {
+		t.Fatalf("tpm after compound rollback tok=%d err=%v", tok, err)
 	}
 }

--- a/internal/sharedcount/counter.go
+++ b/internal/sharedcount/counter.go
@@ -16,8 +16,12 @@ type WindowCounter interface {
 	// Incr increments key by 1 within window and returns the new count.
 	// Implementations may approximate sliding windows with fixed TTL buckets.
 	Incr(ctx context.Context, key string, window time.Duration) (count int64, err error)
+	// Decr decrements key by 1 (compensating rollback for a prior Incr, #513).
+	// Does not extend/refresh TTL. Count is floored at 0 for memory; Redis DECR may go negative.
+	Decr(ctx context.Context, key string, window time.Duration) (count int64, err error)
 	// IncrBy increments key by delta within window and returns the new total.
-	// Used for TPM token reservations (#245). delta<=0 returns the current total.
+	// Used for TPM token reservations (#245). delta==0 returns the current total.
+	// Negative delta is a compensating rollback (#513) and does not refresh TTL.
 	IncrBy(ctx context.Context, key string, delta int64, window time.Duration) (count int64, err error)
 	// Get returns the current count without incrementing.
 	Get(ctx context.Context, key string) (count int64, err error)
@@ -70,6 +74,34 @@ func (m *MemoryCounter) Incr(ctx context.Context, key string, window time.Durati
 	return int64(len(w.times)), nil
 }
 
+func (m *MemoryCounter) Decr(ctx context.Context, key string, window time.Duration) (int64, error) {
+	_ = ctx
+	if window <= 0 {
+		window = time.Minute
+	}
+	nowMs := m.now().UnixMilli()
+	start := nowMs - window.Milliseconds()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	w := m.keys[key]
+	if w == nil {
+		return 0, nil
+	}
+	// prune
+	i := 0
+	for i < len(w.times) && w.times[i] < start {
+		i++
+	}
+	if i > 0 {
+		w.times = append([]int64(nil), w.times[i:]...)
+	}
+	// Compensating rollback: drop the most recent unit event when present.
+	if len(w.times) > 0 {
+		w.times = w.times[:len(w.times)-1]
+	}
+	return int64(len(w.times)), nil
+}
+
 func (m *MemoryCounter) IncrBy(ctx context.Context, key string, delta int64, window time.Duration) (int64, error) {
 	_ = ctx
 	if window <= 0 {
@@ -92,12 +124,18 @@ func (m *MemoryCounter) IncrBy(ctx context.Context, key string, delta int64, win
 	if i > 0 {
 		w.points = append([]memPoint(nil), w.points[i:]...)
 	}
-	if delta > 0 {
+	// delta==0 is a read-only peek; positive reserves; negative rolls back (#513).
+	if delta != 0 {
 		w.points = append(w.points, memPoint{atMs: nowMs, delta: delta})
 	}
 	var sum int64
 	for _, p := range w.points {
 		sum += p.delta
+	}
+	if sum < 0 {
+		// Keep memory totals non-negative for admission math.
+		sum = 0
+		w.points = nil
 	}
 	return sum, nil
 }
@@ -241,24 +279,39 @@ func (r *RedisCounter) Incr(ctx context.Context, key string, window time.Duratio
 	return count, err
 }
 
+func (r *RedisCounter) Decr(ctx context.Context, key string, window time.Duration) (int64, error) {
+	_ = window // compensating rollback must not refresh TTL
+	var count int64
+	err := r.withConn(ctx, func(conn net.Conn) error {
+		n, err := redisDoInt(conn, "DECR", key)
+		if err != nil {
+			return err
+		}
+		count = n
+		return nil
+	})
+	return count, err
+}
+
 func (r *RedisCounter) IncrBy(ctx context.Context, key string, delta int64, window time.Duration) (int64, error) {
 	if window <= 0 {
 		window = time.Minute
 	}
-	if delta <= 0 {
+	if delta == 0 {
 		// No reservation — read current total without changing TTL.
 		return r.Get(ctx, key)
 	}
 	var count int64
 	err := r.withConn(ctx, func(conn net.Conn) error {
-		// Fixed-window approximation: INCRBY + PEXPIRE when this is the first write
+		// Fixed-window approximation: INCRBY + PEXPIRE when this is the first positive write
 		// in the window (post-increment equals delta ⇒ key was absent/0).
+		// Negative delta is a compensating rollback (#513) and must not refresh TTL.
 		n, err := redisDoInt(conn, "INCRBY", key, strconv.FormatInt(delta, 10))
 		if err != nil {
 			return err
 		}
 		count = n
-		if n == delta {
+		if delta > 0 && n == delta {
 			ms := strconv.FormatInt(window.Milliseconds(), 10)
 			if err := redisDo(conn, "PEXPIRE", key, ms); err != nil {
 				return err

--- a/internal/sharedcount/memory_test.go
+++ b/internal/sharedcount/memory_test.go
@@ -46,6 +46,54 @@ func TestMemoryCounter_IncrByWindow(t *testing.T) {
 	}
 }
 
+func TestMemoryCounter_DecrRollback(t *testing.T) {
+	m := NewMemoryCounter()
+	for i := 0; i < 3; i++ {
+		if _, err := m.Incr(context.Background(), "k", time.Minute); err != nil {
+			t.Fatal(err)
+		}
+	}
+	n, err := m.Decr(context.Background(), "k", time.Minute)
+	if err != nil || n != 2 {
+		t.Fatalf("decr: n=%d err=%v", n, err)
+	}
+	n, err = m.Decr(context.Background(), "k", time.Minute)
+	if err != nil || n != 1 {
+		t.Fatalf("decr2: n=%d err=%v", n, err)
+	}
+	// Extra Decr floors at 0.
+	n, err = m.Decr(context.Background(), "k", time.Minute)
+	if err != nil || n != 0 {
+		t.Fatalf("decr3: n=%d err=%v", n, err)
+	}
+	n, err = m.Decr(context.Background(), "k", time.Minute)
+	if err != nil || n != 0 {
+		t.Fatalf("decr floor: n=%d err=%v", n, err)
+	}
+}
+
+func TestMemoryCounter_IncrByNegativeRollback(t *testing.T) {
+	m := NewMemoryCounter()
+	n, err := m.IncrBy(context.Background(), "tpm", 100, time.Minute)
+	if err != nil || n != 100 {
+		t.Fatalf("seed: n=%d err=%v", n, err)
+	}
+	n, err = m.IncrBy(context.Background(), "tpm", -30, time.Minute)
+	if err != nil || n != 70 {
+		t.Fatalf("rollback: n=%d err=%v", n, err)
+	}
+	// Zero delta is a peek.
+	n, err = m.IncrBy(context.Background(), "tpm", 0, time.Minute)
+	if err != nil || n != 70 {
+		t.Fatalf("peek: n=%d err=%v", n, err)
+	}
+	// Over-rollback floors at 0.
+	n, err = m.IncrBy(context.Background(), "tpm", -1000, time.Minute)
+	if err != nil || n != 0 {
+		t.Fatalf("floor: n=%d err=%v", n, err)
+	}
+}
+
 func TestParseRedisURL(t *testing.T) {
 	addr, pass, db, err := ParseRedisURL("redis://:s3cret@localhost:6380/2")
 	if err != nil {


### PR DESCRIPTION
## Summary
- Shared Redis/memory admission previously did `Incr`/`IncrBy` then deny when `n > limit` **without** undoing the reservation, so denied traffic still filled the window.
- On `over_rpm`, compensating `Decr`; on `over_tpm`, compensating `IncrBy(-delta)`; if RPM already reserved then TPM denies, **both** are rolled back.
- `WindowCounter` gains `Decr` and allows negative `IncrBy` for rollback (no TTL refresh on compensate). Fail-open on Redis errors preserved; local path still enforces.

## Design note
Lua-less compensating rollback (not check-then-incr): after a successful shared `Incr`/`IncrBy`, if the post-count exceeds the limit we issue `Decr` / `IncrBy(-delta)` on the same key. Compound path undoes RPM after TPM deny so a TPM rejection cannot strand an RPM slot. MemoryCounter mirrors the same API for parity tests. Fail-open remains: counter errors skip shared path and fall back to process-local windows.

## Test plan
- [x] `go test ./auth ./internal/sharedcount -count=1`
- [x] Partial race suite: app/auth/cmd/server/config/docs/e2e ok (full `./... -race` slow on this host)
- [x] `TestKeyAdmission_SharedRPM` asserts counter stays at limit after deny
- [x] `TestKeyAdmission_SharedTPM` asserts token rollback after over_tpm
- [x] `TestKeyAdmission_SharedRPM_ThenTPM_CompoundRollback`
- [x] `TestKeyAdmission_SharedMemoryCounter_Parity`
- [x] MemoryCounter Decr / negative IncrBy unit tests

Closes #513