### PR TITLE
fix(routing): RR consecutiveFailCount double-increment (#511)

### DIFF
--- a/routing/failure_isolation_test.go
+++ b/routing/failure_isolation_test.go
@@ -329,6 +329,85 @@ func isolationChannel(id, routeID, accountID int64) store.RouteChannel {
 	}
 }
 
+// TestRecordFailure_RoundRobinConsecutiveFailThreshold proves #511: callers pass raw
+// consecutiveFailCount into ApplyRoundRobinCooldown (helper alone does +1). After N=1,2
+// failures consecutive=1 then 2 with no cooldownUntil; after N=3 consecutive resets to 0,
+// cooldownLevel advances, and cooldownUntil is set.
+func TestRecordFailure_RoundRobinConsecutiveFailThreshold(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	siteRuntimeHealthLoaded = true
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	db := newIsolationDB()
+	route := isolationRoute(1, "round_robin")
+	ch := isolationChannel(501, 1, 5001)
+	acc := isolationAccount(5001, 50)
+	db.seedChannel(ch, acc, route)
+
+	tr := newIsolationRouter(db)
+	ctx := context.Background()
+	status := 500
+	errText := "upstream error"
+	model := "gpt-test"
+	failCtx := SiteRuntimeFailureContext{
+		Status:    &status,
+		ErrorText: &errText,
+		ModelName: &model,
+	}
+
+	// N=1: consecutive=1, no cooldown yet
+	if err := tr.RecordFailure(ctx, 501, failCtx, nil); err != nil {
+		t.Fatalf("RecordFailure #1: %v", err)
+	}
+	got := db.getChannel(501)
+	if got == nil {
+		t.Fatal("expected channel 501 present")
+	}
+	if got.ConsecutiveFailCount != 1 {
+		t.Fatalf("after 1 RR failure consecutive=%d, want 1", got.ConsecutiveFailCount)
+	}
+	if got.CooldownLevel != 0 {
+		t.Fatalf("after 1 RR failure cooldownLevel=%d, want 0", got.CooldownLevel)
+	}
+	if got.CooldownUntil != nil {
+		t.Fatalf("after 1 RR failure cooldownUntil=%v, want nil", *got.CooldownUntil)
+	}
+
+	// N=2: consecutive=2, still no cooldown
+	if err := tr.RecordFailure(ctx, 501, failCtx, nil); err != nil {
+		t.Fatalf("RecordFailure #2: %v", err)
+	}
+	got = db.getChannel(501)
+	if got.ConsecutiveFailCount != 2 {
+		t.Fatalf("after 2 RR failures consecutive=%d, want 2", got.ConsecutiveFailCount)
+	}
+	if got.CooldownLevel != 0 {
+		t.Fatalf("after 2 RR failures cooldownLevel=%d, want 0", got.CooldownLevel)
+	}
+	if got.CooldownUntil != nil {
+		t.Fatalf("after 2 RR failures cooldownUntil=%v, want nil", *got.CooldownUntil)
+	}
+
+	// N=3: threshold reached — consecutive resets, level advances, cooldownUntil set
+	if err := tr.RecordFailure(ctx, 501, failCtx, nil); err != nil {
+		t.Fatalf("RecordFailure #3: %v", err)
+	}
+	got = db.getChannel(501)
+	if got.ConsecutiveFailCount != 0 {
+		t.Fatalf("after 3 RR failures consecutive=%d, want 0 (reset)", got.ConsecutiveFailCount)
+	}
+	if got.CooldownLevel != 1 {
+		t.Fatalf("after 3 RR failures cooldownLevel=%d, want 1", got.CooldownLevel)
+	}
+	if got.CooldownUntil == nil || *got.CooldownUntil == "" {
+		t.Fatal("after 3 RR failures cooldownUntil should be set")
+	}
+	// failCount still accumulates independently of RR consecutive counter
+	if got.FailCount != 3 {
+		t.Fatalf("after 3 RR failures failCount=%d, want 3", got.FailCount)
+	}
+}
+
 // TestRecordFailure_DoesNotCascadeToSiblingChannels proves a single non-usage-limit
 // failure only mutates the failed channel's cooldown/failCount fields (channel-scoped
 // exclude — no credential expand). See also P0-585 credential usage-limit honesty

--- a/routing/round_robin.go
+++ b/routing/round_robin.go
@@ -42,7 +42,8 @@ func SelectRoundRobinCandidate(candidates []RouteChannelCandidate) *RouteChannel
 }
 
 // ApplyRoundRobinCooldown applies tiered cooldown to a failure-aware struct.
-// Increments consecutiveFailCount, and if threshold is reached, increments cooldownLevel and resets.
+// Callers must pass the raw consecutiveFailCount (no pre-increment); this helper alone does +1.
+// If the post-increment count reaches RoundRobinFailureThreshold, increments cooldownLevel and resets count.
 // Returns the updated values and cooldownUntil ISO string.
 func ApplyRoundRobinCooldown(
 	consecutiveFailCount int64,

--- a/routing/router.go
+++ b/routing/router.go
@@ -704,7 +704,8 @@ func (tr *TokenRouter) RecordProbeFailure(ctx context.Context, channelID int64, 
 			}
 
 			var cooldownUntil *string
-			consecutiveFailCount := max64(0, memberRow.Member.ConsecutiveFailCount) + 1
+			// Pass raw consecutiveFailCount; ApplyRoundRobinCooldown alone does +1.
+			consecutiveFailCount := max64(0, memberRow.Member.ConsecutiveFailCount)
 			cooldownLevel := max64(0, memberRow.Member.CooldownLevel)
 
 			if routeUnitStrategy == "round_robin" {
@@ -740,7 +741,8 @@ func (tr *TokenRouter) RecordProbeFailure(ctx context.Context, channelID int64, 
 	affectedChannelIDs := []int64{channelID}
 
 	var cooldownUntil *string
-	consecutiveFailCount := max64(0, ch.ConsecutiveFailCount) + 1
+	// Pass raw consecutiveFailCount; ApplyRoundRobinCooldown alone does +1.
+	consecutiveFailCount := max64(0, ch.ConsecutiveFailCount)
 	cooldownLevel := max64(0, ch.CooldownLevel)
 
 	if routeStrategy == StrategyRoundRobin {
@@ -818,7 +820,8 @@ func (tr *TokenRouter) RecordFailure(ctx context.Context, channelID int64, failu
 			}
 
 			var cooldownUntil *string
-			consecutiveFailCount := max64(0, memberRow.Member.ConsecutiveFailCount) + 1
+			// Pass raw consecutiveFailCount; ApplyRoundRobinCooldown alone does +1.
+			consecutiveFailCount := max64(0, memberRow.Member.ConsecutiveFailCount)
 			cooldownLevel := max64(0, memberRow.Member.CooldownLevel)
 
 			if shortWindowCooldown != nil {
@@ -876,7 +879,8 @@ func (tr *TokenRouter) RecordFailure(ctx context.Context, channelID int64, failu
 	}
 
 	var cooldownUntil *string
-	consecutiveFailCount := max64(0, ch.ConsecutiveFailCount) + 1
+	// Pass raw consecutiveFailCount; ApplyRoundRobinCooldown alone does +1.
+	consecutiveFailCount := max64(0, ch.ConsecutiveFailCount)
 	cooldownLevel := max64(0, ch.CooldownLevel)
 
 	if shortWindowCooldown != nil {


### PR DESCRIPTION
## Summary
- Round-robin failure path double-incremented `consecutiveFailCount` (caller `+1` then `ApplyRoundRobinCooldown` `+1`), so cooldown fired after 2 failures instead of 3.
- Pass **raw** `ConsecutiveFailCount` into `ApplyRoundRobinCooldown` at all 4 call sites in `routing/router.go` (RecordFailure channel/member + probe-failure channel/member).
- Helper alone performs the increment; existing `TestApplyRoundRobinCooldown` semantics unchanged.
- Add `TestRecordFailure_RoundRobinConsecutiveFailThreshold` on the RecordFailure path: N=1,2 → consecutive 1 then 2 (no cooldown); N=3 → reset 0, level advances, cooldownUntil set.

Closes #511

## Test plan
- [x] `go test ./routing -count=1`
- [x] `TestApplyRoundRobinCooldown` green
- [x] `TestRecordFailure_RoundRobinConsecutiveFailThreshold` green
- [x] pre-push `go vet ./...` + `go test ./... -count=1 -race`