### PR TITLE
fix(proxy): Gemini path model + streamGenerateContent IsStream (#515)

### DIFF
--- a/handler/proxy/gemini.go
+++ b/handler/proxy/gemini.go
@@ -141,11 +141,17 @@ func HandleGeminiModelsListDynamic(w http.ResponseWriter, r *http.Request) {
 
 // HandleGeminiGenerateContent handles POST /v1beta/models/*.
 // Parses {apiVersion}/models/{model}:{action} from the path.
+// Official Gemini clients put the model in the path (not body) and imply
+// streaming via the :streamGenerateContent action (issue #515).
 func HandleGeminiGenerateContent(w http.ResponseWriter, r *http.Request) {
+	pathModel, forceStream := geminiPathModelAndStream(r.URL.Path)
 	ctx, errResp := PrepareCtx(r, SurfConfig{
 		Endpoint:       "gemini",
 		DownstreamPath: r.URL.Path,
 		RequireModel:   false,
+		// Path model fills RequestedModel when body omits model (channel selection).
+		DefaultModel: pathModel,
+		ForceStream:  forceStream,
 	})
 	if errResp != nil {
 		writeJSONError(w, errResp.Status, errResp.Error, errResp.ErrorType)
@@ -182,11 +188,13 @@ func HandleGeminiCLIGenerateContent(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleGeminiCLIStreamGenerateContent handles POST /v1internal::streamGenerateContent.
+// Path action forces stream even when body omits stream:true (issue #515).
 func HandleGeminiCLIStreamGenerateContent(w http.ResponseWriter, r *http.Request) {
 	ctx, errResp := PrepareCtx(r, SurfConfig{
 		Endpoint:       "gemini-cli",
 		DownstreamPath: "/v1internal::streamGenerateContent",
 		RequireModel:   true,
+		ForceStream:    true,
 	})
 	if errResp != nil {
 		writeJSONError(w, errResp.Status, errResp.Error, errResp.ErrorType)
@@ -194,6 +202,20 @@ func HandleGeminiCLIStreamGenerateContent(w http.ResponseWriter, r *http.Request
 	}
 
 	dispatchUpstream(w, r, ctx)
+}
+
+// geminiPathModelAndStream extracts path model + stream-action force for native
+// Gemini generateContent paths. Body model still wins via PrepareCtx DefaultModel.
+func geminiPathModelAndStream(path string) (model string, forceStream bool) {
+	_, rawModel, action := ParseGeminiPath(path)
+	model = normalizeGeminiModelID(rawModel)
+	forceStream = isGeminiStreamAction(action)
+	return model, forceStream
+}
+
+// isGeminiStreamAction reports whether a Gemini path/CLI action is streaming.
+func isGeminiStreamAction(action string) bool {
+	return strings.EqualFold(strings.TrimSpace(action), "streamGenerateContent")
 }
 
 // HandleGeminiCLICountTokens handles POST /v1internal::countTokens.
@@ -214,8 +236,13 @@ func HandleGeminiCLICountTokens(w http.ResponseWriter, r *http.Request) {
 // ParseGeminiPath parses a Gemini path into apiVersion, model, action.
 // E.g., "/v1beta/models/gemini-2.5-pro:generateContent"
 //   -> apiVersion="v1beta", model="gemini-2.5-pro", action="generateContent"
+// Also accepts the dynamic surface "/gemini/{apiVersion}/models/{model}:{action}".
 func ParseGeminiPath(path string) (apiVersion, model, action string) {
 	path = strings.TrimPrefix(path, "/")
+	// Strip optional /gemini/ prefix used by HandleGeminiGenerateContentDynamic.
+	if strings.HasPrefix(path, "gemini/") {
+		path = strings.TrimPrefix(path, "gemini/")
+	}
 	parts := strings.SplitN(path, "/", 4)
 
 	if len(parts) >= 1 {

--- a/handler/proxy/gemini_test.go
+++ b/handler/proxy/gemini_test.go
@@ -28,6 +28,9 @@ func TestParseGeminiPath(t *testing.T) {
 		{"/v1beta/not-models/gemini-pro", "v1beta", "", ""},
 		{"/", "", "", ""},
 		{"v1beta/models/gemini-2.5-pro:generateContent", "v1beta", "gemini-2.5-pro", "generateContent"},
+		// Dynamic surface /gemini/{apiVersion}/models/...
+		{"/gemini/v1alpha/models/gemini-2.5-pro:generateContent", "v1alpha", "gemini-2.5-pro", "generateContent"},
+		{"/gemini/v1/models/gemini-2.5-flash:streamGenerateContent", "v1", "gemini-2.5-flash", "streamGenerateContent"},
 	}
 	for _, tt := range tests {
 		ver, model, action := ParseGeminiPath(tt.path)
@@ -293,15 +296,61 @@ func TestHandleGeminiGenerateContent_NonStream(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	// With upstream forwarding not wired, stub returns generic chat.completion response.
-	// Verify valid JSON response was received.
+	// Path-only model must populate RequestedModel for channel selection / stub.
 	m := unmarshalResponse(t, rec)
-	if m["model"] == nil && m["object"] == nil {
-		t.Error("expected valid response with model/object fields")
+	if m["model"] != "gemini-2.5-pro" {
+		t.Errorf("model = %v, want path model gemini-2.5-pro", m["model"])
+	}
+	if m["object"] == nil {
+		t.Error("expected valid response with object field")
+	}
+	// generateContent stays non-stream without body stream flag.
+	ct := rec.Header().Get("Content-Type")
+	if ct == "text/event-stream" {
+		t.Errorf("generateContent without body stream must not be SSE, Content-Type = %q", ct)
+	}
+}
+
+func TestHandleGeminiGenerateContent_PathOnlyModel(t *testing.T) {
+	// AC #515: body omits model; path model becomes RequestedModel.
+	req := makeProxyReq("POST", "/v1beta/models/gemini-2.5-flash:generateContent", `{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+	pathModel, forceStream := geminiPathModelAndStream(req.URL.Path)
+	ctx, errResp := PrepareCtx(req, SurfConfig{
+		Endpoint:       "gemini",
+		DownstreamPath: req.URL.Path,
+		RequireModel:   false,
+		DefaultModel:   pathModel,
+		ForceStream:    forceStream,
+	})
+	if errResp != nil {
+		t.Fatalf("PrepareCtx error: %+v", errResp)
+	}
+	if ctx.RequestedModel != "gemini-2.5-flash" {
+		t.Errorf("RequestedModel = %q, want gemini-2.5-flash from path", ctx.RequestedModel)
+	}
+	if ctx.IsStream {
+		t.Error("generateContent path action must not force IsStream")
+	}
+}
+
+func TestHandleGeminiGenerateContent_StreamActionForcesStream(t *testing.T) {
+	// AC #515: :streamGenerateContent forces IsStream without body.stream.
+	req := makeProxyReq("POST", "/v1beta/models/gemini-2.5-pro:streamGenerateContent", `{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`)
+	rec := httptest.NewRecorder()
+	HandleGeminiGenerateContent(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	ct := rec.Header().Get("Content-Type")
+	if ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream for path stream action", ct)
 	}
 }
 
 func TestHandleGeminiGenerateContent_Stream(t *testing.T) {
+	// Body stream:true still works alongside path stream action.
 	req := makeProxyReq("POST", "/v1beta/models/gemini-2.5-pro:streamGenerateContent", `{"contents":[{"role":"user","parts":[{"text":"hello"}]}],"stream":true}`)
 	rec := httptest.NewRecorder()
 	HandleGeminiGenerateContent(rec, req)
@@ -313,6 +362,25 @@ func TestHandleGeminiGenerateContent_Stream(t *testing.T) {
 	ct := rec.Header().Get("Content-Type")
 	if ct != "text/event-stream" {
 		t.Errorf("Content-Type = %q", ct)
+	}
+}
+
+func TestHandleGeminiGenerateContentDynamic_PathModelAndStream(t *testing.T) {
+	r := chi.NewRouter()
+	r.Post("/gemini/{geminiApiVersion}/models/*", func(w http.ResponseWriter, r *http.Request) {
+		HandleGeminiGenerateContentDynamic(w, r)
+	})
+
+	// Path-only model + stream action on dynamic surface.
+	req := makeProxyReq("POST", "/gemini/v1alpha/models/gemini-2.5-flash:streamGenerateContent", `{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("Content-Type") != "text/event-stream" {
+		t.Errorf("dynamic streamGenerateContent Content-Type = %q", rec.Header().Get("Content-Type"))
 	}
 }
 
@@ -358,6 +426,7 @@ func TestHandleGeminiCLIGenerateContent_ModelRequired(t *testing.T) {
 // ---- HandleGeminiCLIStreamGenerateContent ----
 
 func TestHandleGeminiCLIStreamGenerateContent(t *testing.T) {
+	// AC #515: CLI streamGenerateContent forces stream without body.stream.
 	req := makeProxyReq("POST", "/v1internal::streamGenerateContent", `{"model":"gemini-2.5-pro","contents":[{"role":"user","parts":[{"text":"hello"}]}]}`)
 	rec := httptest.NewRecorder()
 	HandleGeminiCLIStreamGenerateContent(rec, req)
@@ -366,11 +435,23 @@ func TestHandleGeminiCLIStreamGenerateContent(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	// With upstream forwarding not wired, stub returns generic response.
-	// Stream flag not set in body, so non-stream response is expected.
-	m := unmarshalResponse(t, rec)
-	if m == nil {
-		t.Error("expected non-nil response")
+	ct := rec.Header().Get("Content-Type")
+	if ct != "text/event-stream" {
+		t.Errorf("CLI streamGenerateContent Content-Type = %q, want text/event-stream", ct)
+	}
+}
+
+func TestHandleGeminiCLIGenerateContent_NonStream(t *testing.T) {
+	// generateContent CLI path stays non-stream without body stream flag.
+	req := makeProxyReq("POST", "/v1internal::generateContent", `{"model":"gemini-2.5-pro","contents":[{"role":"user","parts":[{"text":"hello"}]}]}`)
+	rec := httptest.NewRecorder()
+	HandleGeminiCLIGenerateContent(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("Content-Type") == "text/event-stream" {
+		t.Error("CLI generateContent without body stream must not be SSE")
 	}
 }
 

--- a/handler/proxy/surface.go
+++ b/handler/proxy/surface.go
@@ -18,10 +18,14 @@ type SurfConfig struct {
 	DownstreamPath string
 	RequireModel   bool
 	DefaultModel   string
-	Method         string
-	ExtraHeaders   map[string]string
-	MaxRetries     int
-	SurfaceFormat  string // "openai", "claude", or empty
+	// ForceStream forces IsStream=true even when the body omits stream:true.
+	// Used by Gemini path action streamGenerateContent and CLI
+	// /v1internal::streamGenerateContent where streaming is path-implied.
+	ForceStream   bool
+	Method        string
+	ExtraHeaders  map[string]string
+	MaxRetries    int
+	SurfaceFormat string // "openai", "claude", or empty
 }
 
 // SurfResult is the result of processing a proxy surface request.
@@ -121,8 +125,11 @@ func PrepareCtx(r *http.Request, cfg SurfConfig) (*Ctx, *SurfResult) {
 		return nil, &SurfResult{OK: false, Status: 403, Error: "model not allowed by downstream policy", ErrorType: "invalid_request_error"}
 	}
 
-	// Check stream flag
+	// Check stream flag (body and optional path/surface force).
 	isStream := isStreamFromBody(body)
+	if cfg.ForceStream {
+		isStream = true
+	}
 
 	// Client detection
 	headers := HeaderMapFromRequest(r.Header)

--- a/handler/proxy/surface_test.go
+++ b/handler/proxy/surface_test.go
@@ -288,6 +288,27 @@ func TestPrepareCtx_StreamDetection(t *testing.T) {
 	}
 }
 
+func TestPrepareCtx_ForceStream(t *testing.T) {
+	// Path-implied stream (Gemini streamGenerateContent / CLI) without body.stream.
+	req := authRequest("POST", "/v1beta/models/gemini-2.5-pro:streamGenerateContent", []byte(`{"contents":[]}`))
+	ctx, errResp := PrepareCtx(req, SurfConfig{
+		Endpoint:       "gemini",
+		DownstreamPath: "/v1beta/models/gemini-2.5-pro:streamGenerateContent",
+		RequireModel:   false,
+		DefaultModel:   "gemini-2.5-pro",
+		ForceStream:    true,
+	})
+	if errResp != nil {
+		t.Fatalf("unexpected error: %+v", errResp)
+	}
+	if !ctx.IsStream {
+		t.Error("ForceStream must set IsStream=true when body omits stream")
+	}
+	if ctx.RequestedModel != "gemini-2.5-pro" {
+		t.Errorf("RequestedModel = %q, want DefaultModel gemini-2.5-pro", ctx.RequestedModel)
+	}
+}
+
 func TestPrepareCtx_InvalidJSON(t *testing.T) {
 	req := authRequest("POST", "/v1/chat/completions", []byte(`{invalid`))
 


### PR DESCRIPTION
## Summary
- ParseGeminiPath sets RequestedModel when body omits model
- streamGenerateContent path action forces IsStream=true
- CLI /v1internal::streamGenerateContent also forces stream
- Tests lock path-only model + stream action

Closes #515

## Test plan
- [x] `go test ./handler/proxy -count=1`
- [ ] CI green