### PR TITLE
docs(release): v0.8.39 M49 adversarial bugfix residual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.8.39] — 2026-07-18
+
+### Fixed
+- Round-robin `consecutiveFailCount` no longer double-increments (threshold 3 restored) (#511 / #519)
+- Managed-key `used_requests` not burned on RPM/TPM admission 429 (`Allow` before consume) (#512 / #522)
+- Shared Redis RPM/TPM admission rolls back window counters on deny (fail-open preserved) (#513 / #518)
+- Wire `RecordManagedKeyCostUsage` on proxy success so `max_cost` advances (#514 / #520)
+- Gemini path model when body omits model; `streamGenerateContent` forces stream (#515 / #523)
+- Retention cutoffs use RFC3339 comparable to `created_at` (same-day prune fixed) (#516 / #521)
+
+### Docs / Honesty
+- Residual inventory + MASTER for Milestone 49 post-product landings; REL-RR-FAILCOUNT · REL-USED-REQ-429 · REL-REDIS-ADMIT-ROLLBACK · REL-MAX-COST-WIRE · REL-GEMINI-PATH-STREAM · REL-RETENTION-RFC3339 present · board #511–#517 closed (#517 / residual honesty PR)
+- Keep **P0-585 partial** (load-proof still required) and **P0-555 present-with-residual**; WS-1 / STICKY-B / UC-1 residual
+
 ## [v0.8.38] — 2026-07-18
 
 ### Docs / Honesty

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <a href="https://github.com/TokenDanceLab/metapi-go/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/TokenDanceLab/metapi-go/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="Go" src="https://img.shields.io/badge/Go-1.26.5-00ADD8?logo=go">
-  <a href="https://github.com/TokenDanceLab/metapi-go/pkgs/container/metapi-go"><img alt="Docker" src="https://img.shields.io/badge/ghcr-v0.8.37-blue?logo=docker"></a>
+  <a href="https://github.com/TokenDanceLab/metapi-go/pkgs/container/metapi-go"><img alt="Docker" src="https://img.shields.io/badge/ghcr-v0.8.39-blue?logo=docker"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-green"></a>
 </p>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -13,7 +13,7 @@ Go rewrite of [MetAPI](https://github.com/cita-777/metapi). Single binary, no No
 
 [![CI](https://github.com/TokenDanceLab/metapi-go/actions/workflows/ci.yml/badge.svg)](https://github.com/TokenDanceLab/metapi-go/actions/workflows/ci.yml)
 [![Go](https://img.shields.io/badge/Go-1.26.5-00ADD8?logo=go)](https://go.dev/)
-[![Docker](https://img.shields.io/badge/ghcr-v0.8.37-blue?logo=docker)](https://github.com/TokenDanceLab/metapi-go/pkgs/container/metapi-go)
+[![Docker](https://img.shields.io/badge/ghcr-v0.8.39-blue?logo=docker)](https://github.com/TokenDanceLab/metapi-go/pkgs/container/metapi-go)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
 </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,9 +46,9 @@ docs/
 4. **`docs/specs/` is heavy rewrite history** — do not treat as day-to-day runbook.
 5. **One Issue per topic**; close duplicates the same day.
 
-## Residual board (post v0.8.38 / M49 product)
+## Residual board (post v0.8.39 / M49 closed)
 
-- **Latest release**: [v0.8.38](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.38) · M48 closed · M49 product #511–#516 on master · release gate → **v0.8.39**.
+- **Latest release**: [v0.8.39](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.39) · M49 closed · active milestone **none**.
 - **Residual SSOT**: [`analysis/residual-next-candidates.md`](analysis/residual-next-candidates.md) (optional **v0.8.40+** only with dedicated ACs).
 - **Still not product without ACs**: full Responses WS (WS-1), Redis sticky (STICKY-B), update-center remote deploy (UC-1).
 - **Keep partial**: P0-585 cascade (load-proof required; honesty tests do not flip present).

--- a/docs/analysis/residual-next-candidates.md
+++ b/docs/analysis/residual-next-candidates.md
@@ -6,7 +6,7 @@
 **Scope**: inventory only — **no product code** in this document.
 **Map**: [`docs/README.md`](../README.md) · status [`docs/progress/MASTER.md`](../progress/MASTER.md)
 **M35 review synthesis**: [`enterprise-review-m35.md`](./enterprise-review-m35.md) (#388) — historical pointer only
-**Active wave**: none (M49 product closed on master; residual honesty #517 + release gate → **v0.8.39**; sequencing **v0.8.40+** optional residual with ACs only)
+**Active wave**: none (M49 / **v0.8.39** shipped; sequencing **v0.8.40+** optional residual with ACs only)
 
 ## Purpose
 
@@ -64,8 +64,8 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 | REL-P0555-STREAM-TESTS | P0-555 Anthropic stream message_delta usage merge honesty tests | **present** (#486/#488) | handler/proxy/usage_test.go locks early input + later output merge; no invent when usage absent | Done for honesty residual tests | P0-555 still present-with-residual (not perfect billing) |
 | DOCS-STACK-TRUTH | README/README_EN stack badge truth | **present** (#494/#498) | Go badge + tech stack table align to go.mod 1.26.5 and React 19 / Vite 8 | Done for public stack truth | Residual other marketing badges only with AC |
 | DOCS-REDIS-TRUTH | Public Redis admission truth (not sticky) | **present** (#503/#507) | README/README_EN/deployment: optional REDIS_URL for multi-instance RPM/TPM admission via sharedcount fail-open; sticky remains process-local | Done for public Redis honesty | STICKY-B still design-only |
-| DOCS-DOCKER-BADGE | ghcr public badge current release | **present** (#504/#508) | README ghcr badge v0.8.37 (was stale v0.6.5) | Done for badge truth | Residual other marketing badges only with AC |
-| DOCS-RESIDUAL-LATEST | residual inventory latest release line | **present** (#505/#508) | sequencing Latest release points at v0.8.37 | Done | residual inventory churn only |
+| DOCS-DOCKER-BADGE | ghcr public badge current release | **present** (#504/#508; release bump v0.8.39) | README ghcr badge tracks current release series | Done for badge truth | Residual other marketing badges only with AC |
+| DOCS-RESIDUAL-LATEST | residual inventory latest release line | **present** (#505/#508; release bump v0.8.39) | sequencing Latest release points at v0.8.39 | Done | residual inventory churn only |
 | REL-TPM-ESTIMATE | Best-effort TPM admission estimate when maxTPM set | **present** (#495/#500) | auth ProxyAuth passes best-effort estimatedTokens when maxTPM>0; empty body keeps 0; never invents large defaults | Done for TPM soft-limit not no-op | Residual perfect tokenizer only with AC |
 | REL-CRED-USAGE-HONESTY | P0-585 credential usage-limit multi-channel cool honesty tests | **present** (#496/#499) | routing tests document same-credential siblings cool only; non-usage-limit stays channel-scoped | Done for honesty residual tests | P0-585 still partial (load-proof) |
 | KEY-578 | Per-key outbound proxy | **present** (backend #281; admin UI #466/#471) | `proxy/key_proxy.go` + `downstream_api_keys.proxy_url`; DownstreamKeys create/edit/list wires `proxyUrl` (empty/null inherits site/system) via #466/#471 | Done for backend + DownstreamKeys admin UI | Residual novel key-proxy surfaces only with AC |
@@ -91,8 +91,8 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 
 ## Recommended sequencing (v0.8.40+)
 
-1. **Latest release**: **v0.8.38** (M48 closed). **M49 product** (#511–#516) merged on master (PRs #518–#523); residual honesty #517 + release gate ship **v0.8.39**.
-2. **Active wave**: none after #517 + v0.8.39 tag. Optional residual **v0.8.40+** only with dedicated ACs.
+1. **Latest release**: **v0.8.39** (M49 closed): #511–#517 present on master with tag.
+2. **Active wave**: none. Optional residual **v0.8.40+** only with dedicated ACs.
 3. **M49 reliability present**: REL-RR-FAILCOUNT · REL-USED-REQ-429 · REL-REDIS-ADMIT-ROLLBACK · REL-MAX-COST-WIRE · REL-GEMINI-PATH-STREAM · REL-RETENTION-RFC3339.
 4. **P0-555** stays **present-with-residual**. **P0-585** remains **partial** (load-proof still required). Redis admission is fail-open / **not** sticky (STICKY-B design-only).
 5. **Product Milestones only with ACs**: WS-1 Codex interop, STICKY-B Redis sticky, UC-1 update-center registry.
@@ -130,4 +130,4 @@ Give the next residual / product wave a single honest backlog of high-leverage l
 
 ## Links
 
-- Release: [v0.8.38](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.38) · prior [v0.8.37](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.37) · next **v0.8.39** (M49 release gate) · optional residual **v0.8.40+** (with ACs only)
+- Release: [v0.8.39](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.39) · prior [v0.8.38](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.38) · optional residual **v0.8.40+** (with ACs only)

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -3,7 +3,7 @@
 **Task**: MetAPI TypeScript → Go rewrite + enterprise residual delivery
 **Mode**: GitHub Issues + Milestones (SDD)
 **Repo**: https://github.com/TokenDanceLab/metapi-go
-**Latest release**: **[v0.8.38](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.38)** (2026-07-18)
+**Latest release**: **[v0.8.39](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.39)** (2026-07-18)
 
 > 本文件是**轻量导航索引**，不是变更日志。细节进 Issue / PR / CHANGELOG。
 > 文档地图：[`docs/README.md`](../README.md)
@@ -13,7 +13,7 @@
 | Item | URL |
 |:-----|:----|
 | Project | https://github.com/orgs/TokenDanceLab/projects/1 |
-| Active milestone | [49](https://github.com/TokenDanceLab/metapi-go/milestone/49) (product #511–#516 closed; #517 residual honesty + release gate → **v0.8.39**) |
+| Active milestone | none (board clean; next residual only with ACs) |
 | Program map | `docs/plan/enterprise-program.md` (historical / closed foundations) |
 | Residual backlog | `docs/analysis/residual-next-candidates.md` |
 | M35 review synthesis | `docs/analysis/enterprise-review-m35.md` (#388; historical) |
@@ -26,28 +26,26 @@
 |:------|:-------|:------|
 | Rewrite P0–P13 | ✅ | Single-binary Go + embed SPA |
 | Program foundations (STACK / GAP / BACKEND / UI / SCHEMA / RELIABILITY / FEATURE) | ✅ | Closed; residual polish only |
-| Enterprise residual train **v0.8.18–v0.8.38** (M27–M48) | ✅ closed | Latest **v0.8.38** / M48; full narrative → `CHANGELOG.md` + Releases |
-| M49 product adversarial bugfix (#511–#516) | ✅ on master | PRs #518–#523; residual honesty + tag remaining |
+| Enterprise residual train **v0.8.18–v0.8.39** (M27–M49) | ✅ closed | Latest **v0.8.39** / M49; full narrative → `CHANGELOG.md` + Releases |
 
 ## Active work
 
 | Issue | Track | Title |
 |------:|:------|:------|
-| #517 | docs | Residual honesty after M49 product landings (this wave) |
-| — | release | CHANGELOG + tag **v0.8.39** after #517 |
+| — | — | Board clean (no open residual product board) |
 
 **Board hygiene**: one Issue per topic; never leave conflict markers in squash merges.
-**M35–M48 closed** with v0.8.38. **M49 product merged**; do not invent WS-1 / STICKY-B / UC-1.
+**M35–M49 closed** with v0.8.39. Do not invent WS-1 / STICKY-B / UC-1.
 
 ## Residual releases (pointer only)
 
 | Tag | Milestone | Highlights |
 |:----|:----------|:-----------|
+| [v0.8.39](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.39) | 49 | RR fail-count · used_requests 429 order · Redis admit rollback · max_cost wire · Gemini path/stream · retention RFC3339 · residual honesty |
 | [v0.8.38](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.38) | 48 | Redis admission truth · docker badge · residual latest sequencing · residual honesty |
 | [v0.8.37](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.37) | 47 | README stack truth · TPM admission estimate · P0-585 credential usage honesty · residual honesty |
 | [v0.8.36](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.36) | 46 | monitor cookie clear · CSS residual · P0-555 stream usage honesty · residual honesty |
-| [v0.8.35](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.35) | 45 | DownstreamKeys maxRpm/maxTpm UI · P0-585 empty-filter honesty · login token debt |
-| older | 11–44 | See GitHub Releases / `CHANGELOG.md` |
+| older | 11–45 | See GitHub Releases / `CHANGELOG.md` |
 
 ## Architecture entry points
 
@@ -66,13 +64,13 @@
 ```bash
 gh issue list --state open --limit 20
 gh pr list --state open
-gh release view v0.8.38
+gh release view v0.8.39
 git log --oneline origin/master -10
 ```
 
 ## Next Steps
 
-1. Land **#517** residual honesty → release docs + tag **v0.8.39** → close Milestone 49.
+1. Board clean after **v0.8.39**. Optional residual **v0.8.40+** only with dedicated ACs.
 2. Do **not** invent WS-1 / STICKY-B Redis sticky / UC-1 product without dedicated ACs.
 3. Keep **P0-585 partial** and **P0-555 present-with-residual**; optional later load-proof / media polish only with ACs.
 


### PR DESCRIPTION
## Summary
- CHANGELOG **[v0.8.39]** records M49 product fixes #511–#516 + residual honesty #517
- MASTER / residual inventory / docs map point at **v0.8.39**; board clean → optional **v0.8.40+** with ACs
- ghcr badges → v0.8.39
- Keep **P0-585 partial**, **P0-555 present-with-residual**; no WS-1/STICKY-B/UC-1 invent

## Test plan
- [x] `go test ./docs -run TestPublicMarkdownHygiene -count=1`
- [ ] Merge → tag `v0.8.39` + GitHub Release → close Milestone 49