### PR TITLE
fix: make PostgreSQL pool budget explicit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,10 @@ DATABASE_URL=
 # Optional PostgreSQL TLS mode. Leave empty to use the DSN value.
 # Valid values: disable, allow, prefer, require, verify-ca, verify-full.
 DB_SSLMODE=
+DB_MAX_OPEN_CONNS=20
+DB_MAX_IDLE_CONNS=5
+DB_CONN_MAX_LIFETIME_SEC=1800
+DB_CONN_MAX_IDLE_TIME_SEC=300
 NOTIFY_COOLDOWN_SEC=300
 ADMIN_IP_ALLOWLIST=
 # Optional CSV of reverse-proxy CIDRs allowed to supply X-Forwarded-For/X-Real-IP.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Cron 定时执行（默认每日 08:00），智能解析奖励金额，签到失
 | `DB_TYPE` | `sqlite` | 数据库类型（`sqlite` / `postgres`）；提供 PostgreSQL URL 时可自动推断为 `postgres` |
 | `DATABASE_URL` / `DB_URL` | 空 | PostgreSQL 连接串或 SQLite 文件路径；`DB_URL` 优先，`DATABASE_URL` 用于兼容部署平台 |
 | `DB_SSLMODE` | 空 | PostgreSQL TLS 模式；支持 `disable`、`allow`、`prefer`、`require`、`verify-ca`、`verify-full`；非空时覆盖连接串中的 `sslmode` |
+| `DB_MAX_OPEN_CONNS` / `DB_MAX_IDLE_CONNS` | `20` / `5` | PostgreSQL 应用池预算；生产值不得超过数据库 role connection limit |
+| `DB_CONN_MAX_LIFETIME_SEC` / `DB_CONN_MAX_IDLE_TIME_SEC` | `1800` / `300` | PostgreSQL 连接寿命与空闲回收时间（秒） |
 | `TRUSTED_PROXY_CIDRS` | 空 | 允许提供 `X-Forwarded-For` / `X-Real-IP` 的反向代理 CIDR CSV；默认忽略 forwarded headers |
 | `ADMIN_CORS_ALLOWED_ORIGINS` | 空 | 允许跨域访问 `/api/*` 管理接口的精确 `http(s)` origin CSV；默认只支持同源管理 UI，禁止 `*` |
 | `CHECKIN_CRON` | `0 8 * * *` | 签到时间 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -68,6 +68,8 @@ All env vars are identical to the TypeScript version.
 | `DB_TYPE` | `sqlite`; `postgres` is inferred when a PostgreSQL URL is provided |
 | `DATABASE_URL` / `DB_URL` | empty; PostgreSQL connection string or SQLite file path. `DB_URL` takes precedence. |
 | `DB_SSLMODE` | empty; PostgreSQL TLS mode. Supports `disable`, `allow`, `prefer`, `require`, `verify-ca`, and `verify-full`; non-empty values override `sslmode` in the connection string. |
+| `DB_MAX_OPEN_CONNS` / `DB_MAX_IDLE_CONNS` | `20` / `5`; PostgreSQL application pool budget, bounded by the database role connection limit. |
+| `DB_CONN_MAX_LIFETIME_SEC` / `DB_CONN_MAX_IDLE_TIME_SEC` | `1800` / `300`; PostgreSQL connection lifetime and idle rotation in seconds. |
 | `TRUSTED_PROXY_CIDRS` | empty; comma-separated reverse-proxy CIDRs allowed to supply `X-Forwarded-For` / `X-Real-IP`; forwarded headers are ignored by default |
 | `ADMIN_CORS_ALLOWED_ORIGINS` | empty; comma-separated exact `http(s)` admin browser origins allowed to call `/api/*`; `*` is rejected |
 

--- a/config/config.go
+++ b/config/config.go
@@ -72,7 +72,13 @@ type Config struct {
 	DbUrl      string
 	DbSsl      bool
 	DbSslMode  string
-	Tz         string
+	// PostgreSQL pool budget. Production operators must size MaxOpenConns no
+	// higher than the database role CONNECTION LIMIT.
+	DbMaxOpenConns       int
+	DbMaxIdleConns       int
+	DbConnMaxLifetimeSec int
+	DbConnMaxIdleTimeSec int
+	Tz                   string
 
 	// Cron (5 fields)
 	CheckinCron          string
@@ -406,6 +412,10 @@ func Load(env map[string]string) *Config {
 	cfg.DbType = inferDbType(get("DB_TYPE"), cfg.DbUrl)
 	cfg.DbSsl = parseBoolean(get("DB_SSL"), false)
 	cfg.DbSslMode = normalizeDbSslMode(get("DB_SSLMODE"))
+	cfg.DbMaxOpenConns = int(math.Trunc(parseNumber(get("DB_MAX_OPEN_CONNS"), 20)))
+	cfg.DbMaxIdleConns = int(math.Trunc(parseNumber(get("DB_MAX_IDLE_CONNS"), 5)))
+	cfg.DbConnMaxLifetimeSec = int(math.Trunc(parseNumber(get("DB_CONN_MAX_LIFETIME_SEC"), 1800)))
+	cfg.DbConnMaxIdleTimeSec = int(math.Trunc(parseNumber(get("DB_CONN_MAX_IDLE_TIME_SEC"), 300)))
 	cfg.Tz = get("TZ")
 
 	// ---- §3.4 Cron ----

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -88,6 +88,46 @@ func TestPostgresSSLModePreservesLegacyDBSSL(t *testing.T) {
 	}
 }
 
+func TestLoadParsesPostgresPoolBudget(t *testing.T) {
+	cfg := Load(map[string]string{
+		"DB_MAX_OPEN_CONNS":         "2",
+		"DB_MAX_IDLE_CONNS":         "1",
+		"DB_CONN_MAX_LIFETIME_SEC":  "1800",
+		"DB_CONN_MAX_IDLE_TIME_SEC": "300",
+	})
+
+	if cfg.DbMaxOpenConns != 2 || cfg.DbMaxIdleConns != 1 {
+		t.Fatalf("pool = %d/%d, want 2/1", cfg.DbMaxOpenConns, cfg.DbMaxIdleConns)
+	}
+	if cfg.DbConnMaxLifetimeSec != 1800 || cfg.DbConnMaxIdleTimeSec != 300 {
+		t.Fatalf(
+			"lifetime/idle = %d/%d, want 1800/300",
+			cfg.DbConnMaxLifetimeSec,
+			cfg.DbConnMaxIdleTimeSec,
+		)
+	}
+}
+
+func TestValidateRejectsPostgresPoolAboveOpenBudget(t *testing.T) {
+	cfg := Load(map[string]string{
+		"AUTH_TOKEN":                "admin-token",
+		"PROXY_TOKEN":               "proxy-token",
+		"ACCOUNT_CREDENTIAL_SECRET": "credential-secret",
+		"CLAUDE_CLIENT_ID":          "claude-client",
+		"CODEX_CLIENT_ID":           "codex-client",
+		"GEMINI_CLI_CLIENT_ID":      "gemini-client",
+		"DB_MAX_OPEN_CONNS":         "2",
+		"DB_MAX_IDLE_CONNS":         "3",
+	})
+
+	for _, err := range cfg.Validate() {
+		if strings.Contains(err.Error(), "db_max_idle_conns") && IsCritical(err) {
+			return
+		}
+	}
+	t.Fatal("Validate did not return critical db_max_idle_conns error")
+}
+
 func TestValidateRejectsInvalidPostgresSSLMode(t *testing.T) {
 	cfg := Load(map[string]string{
 		"AUTH_TOKEN":                "admin-token",

--- a/config/validate.go
+++ b/config/validate.go
@@ -54,6 +54,38 @@ func (c *Config) Validate() []error {
 			critical: true,
 		})
 	}
+	if c.DbMaxOpenConns < 1 {
+		errs = append(errs, &configError{
+			field:    "db_max_open_conns",
+			value:    fmt.Sprintf("%d", c.DbMaxOpenConns),
+			msg:      "must be >= 1",
+			critical: true,
+		})
+	}
+	if c.DbMaxIdleConns < 0 || c.DbMaxIdleConns > c.DbMaxOpenConns {
+		errs = append(errs, &configError{
+			field:    "db_max_idle_conns",
+			value:    fmt.Sprintf("%d", c.DbMaxIdleConns),
+			msg:      "must be between 0 and db_max_open_conns",
+			critical: true,
+		})
+	}
+	if c.DbConnMaxLifetimeSec < 0 {
+		errs = append(errs, &configError{
+			field:    "db_conn_max_lifetime_sec",
+			value:    fmt.Sprintf("%d", c.DbConnMaxLifetimeSec),
+			msg:      "must be >= 0",
+			critical: true,
+		})
+	}
+	if c.DbConnMaxIdleTimeSec < 0 {
+		errs = append(errs, &configError{
+			field:    "db_conn_max_idle_time_sec",
+			value:    fmt.Sprintf("%d", c.DbConnMaxIdleTimeSec),
+			msg:      "must be >= 0",
+			critical: true,
+		})
+	}
 
 	// --- Warning: Cron expressions must be parseable ---
 	if !validateCronExpr(c.CheckinCron) {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,4 +27,8 @@ services:
       TZ: ${TZ:-Asia/Shanghai}
       # Database config (for PG mode; leave empty for SQLite)
       DATABASE_URL: ${DATABASE_URL:-}
+      DB_MAX_OPEN_CONNS: ${DB_MAX_OPEN_CONNS:-20}
+      DB_MAX_IDLE_CONNS: ${DB_MAX_IDLE_CONNS:-5}
+      DB_CONN_MAX_LIFETIME_SEC: ${DB_CONN_MAX_LIFETIME_SEC:-1800}
+      DB_CONN_MAX_IDLE_TIME_SEC: ${DB_CONN_MAX_IDLE_TIME_SEC:-300}
     restart: unless-stopped

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -30,6 +30,10 @@
 | `DATABASE_URL` | _(empty)_ | PostgreSQL connection string; alias of `DB_URL`; when set to `postgres://` or `postgresql://`, uses PG instead of SQLite |
 | `DB_URL` | _(empty)_ | Database URL or SQLite file path; takes precedence over `DATABASE_URL` |
 | `DB_SSLMODE` | _(empty)_ | PostgreSQL TLS mode. Supports `disable`, `allow`, `prefer`, `require`, `verify-ca`, and `verify-full`; non-empty values override `sslmode` in the connection string |
+| `DB_MAX_OPEN_CONNS` | `20` | PostgreSQL application pool ceiling; must not exceed the database role connection limit |
+| `DB_MAX_IDLE_CONNS` | `5` | PostgreSQL idle pool ceiling; must not exceed `DB_MAX_OPEN_CONNS` |
+| `DB_CONN_MAX_LIFETIME_SEC` | `1800` | Maximum PostgreSQL connection lifetime; `0` disables rotation |
+| `DB_CONN_MAX_IDLE_TIME_SEC` | `300` | Maximum PostgreSQL idle time; `0` disables idle rotation |
 | `PROXY_MAX_BUFFERED_RESPONSE_BYTES` | `20971520` | Maximum buffered non-streaming upstream response size; responses above the limit return 502 |
 | `METAPI_ENABLE_PROXY_STUB` | _(empty)_ | Test/demo-only local proxy stub. Leave empty in production; unconfigured upstream forwarding returns 503 |
 | `TRUSTED_PROXY_CIDRS` | _(empty)_ | Comma-separated reverse-proxy CIDRs allowed to supply `X-Forwarded-For` / `X-Real-IP`; forwarded headers are ignored when empty |

--- a/store/bootstrap.go
+++ b/store/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/tokendancelab/metapi-go/config"
 )
@@ -66,7 +67,13 @@ func EnsureRuntimeDatabase(cfg *config.Config) error {
 	}
 
 	// Open database connection.
-	db, err := OpenWithPostgresSSLMode(dialect, dsn, cfg.PostgresSSLMode())
+	pool := PostgresPoolConfig{
+		MaxOpenConns:    cfg.DbMaxOpenConns,
+		MaxIdleConns:    cfg.DbMaxIdleConns,
+		ConnMaxLifetime: time.Duration(cfg.DbConnMaxLifetimeSec) * time.Second,
+		ConnMaxIdleTime: time.Duration(cfg.DbConnMaxIdleTimeSec) * time.Second,
+	}
+	db, err := OpenWithPostgresSSLModeAndPool(dialect, dsn, cfg.PostgresSSLMode(), pool)
 	if err != nil {
 		return fmt.Errorf("bootstrap: failed to open database: %w", err)
 	}
@@ -80,7 +87,16 @@ func EnsureRuntimeDatabase(cfg *config.Config) error {
 	activeDB = db
 	initialized = true
 
-	slog.Info("bootstrap: database ready", "dialect", dialect)
+	logAttrs := []any{"dialect", dialect}
+	if dialect == DialectPostgres {
+		logAttrs = append(logAttrs,
+			"max_open_conns", pool.MaxOpenConns,
+			"max_idle_conns", pool.MaxIdleConns,
+			"conn_max_lifetime_sec", cfg.DbConnMaxLifetimeSec,
+			"conn_max_idle_time_sec", cfg.DbConnMaxIdleTimeSec,
+		)
+	}
+	slog.Info("bootstrap: database ready", logAttrs...)
 	return nil
 }
 

--- a/store/bootstrap.go
+++ b/store/bootstrap.go
@@ -67,12 +67,7 @@ func EnsureRuntimeDatabase(cfg *config.Config) error {
 	}
 
 	// Open database connection.
-	pool := PostgresPoolConfig{
-		MaxOpenConns:    cfg.DbMaxOpenConns,
-		MaxIdleConns:    cfg.DbMaxIdleConns,
-		ConnMaxLifetime: time.Duration(cfg.DbConnMaxLifetimeSec) * time.Second,
-		ConnMaxIdleTime: time.Duration(cfg.DbConnMaxIdleTimeSec) * time.Second,
-	}
+	pool := postgresPoolConfigFromRuntimeConfig(cfg)
 	db, err := OpenWithPostgresSSLModeAndPool(dialect, dsn, cfg.PostgresSSLMode(), pool)
 	if err != nil {
 		return fmt.Errorf("bootstrap: failed to open database: %w", err)
@@ -98,6 +93,23 @@ func EnsureRuntimeDatabase(cfg *config.Config) error {
 	}
 	slog.Info("bootstrap: database ready", logAttrs...)
 	return nil
+}
+
+func postgresPoolConfigFromRuntimeConfig(cfg *config.Config) PostgresPoolConfig {
+	// Preserve compatibility for tests and embedders that construct Config
+	// directly instead of using config.Load, which populates all four defaults.
+	if cfg.DbMaxOpenConns == 0 &&
+		cfg.DbMaxIdleConns == 0 &&
+		cfg.DbConnMaxLifetimeSec == 0 &&
+		cfg.DbConnMaxIdleTimeSec == 0 {
+		return DefaultPostgresPoolConfig()
+	}
+	return PostgresPoolConfig{
+		MaxOpenConns:    cfg.DbMaxOpenConns,
+		MaxIdleConns:    cfg.DbMaxIdleConns,
+		ConnMaxLifetime: time.Duration(cfg.DbConnMaxLifetimeSec) * time.Second,
+		ConnMaxIdleTime: time.Duration(cfg.DbConnMaxIdleTimeSec) * time.Second,
+	}
 }
 
 // CloseDatabase closes the active database connection and resets the

--- a/store/open.go
+++ b/store/open.go
@@ -34,6 +34,24 @@ type DB struct {
 	Dialect string
 }
 
+// PostgresPoolConfig is the application-side connection budget. MaxOpenConns
+// must not exceed the production role CONNECTION LIMIT.
+type PostgresPoolConfig struct {
+	MaxOpenConns    int
+	MaxIdleConns    int
+	ConnMaxLifetime time.Duration
+	ConnMaxIdleTime time.Duration
+}
+
+func DefaultPostgresPoolConfig() PostgresPoolConfig {
+	return PostgresPoolConfig{
+		MaxOpenConns:    20,
+		MaxIdleConns:    5,
+		ConnMaxLifetime: 30 * time.Minute,
+		ConnMaxIdleTime: 5 * time.Minute,
+	}
+}
+
 // Exec executes a query that does not return rows. For PostgreSQL, the query
 // string is rebound from ? to $N placeholders before execution.
 func (db *DB) Exec(query string, args ...any) (sql.Result, error) {
@@ -170,6 +188,17 @@ func Open(dialect string, dsn string, sslMode bool) (*DB, error) {
 // OpenWithPostgresSSLMode opens a database connection pool and, for PostgreSQL,
 // applies an explicit sslmode without duplicating existing DSN parameters.
 func OpenWithPostgresSSLMode(dialect string, dsn string, sslMode string) (*DB, error) {
+	return OpenWithPostgresSSLModeAndPool(dialect, dsn, sslMode, DefaultPostgresPoolConfig())
+}
+
+// OpenWithPostgresSSLModeAndPool opens a database connection pool and applies
+// an explicit PostgreSQL budget. SQLite ignores the PostgreSQL pool settings.
+func OpenWithPostgresSSLModeAndPool(
+	dialect string,
+	dsn string,
+	sslMode string,
+	pool PostgresPoolConfig,
+) (*DB, error) {
 	var driverName string
 	var connStr string
 
@@ -211,7 +240,7 @@ func OpenWithPostgresSSLMode(dialect string, dsn string, sslMode string) (*DB, e
 			return nil, fmt.Errorf("store: failed to apply SQLite pragmas: %w", err)
 		}
 	case DialectPostgres:
-		if err := configurePostgresPool(db); err != nil {
+		if err := configurePostgresPool(db, pool); err != nil {
 			db.Close()
 			return nil, fmt.Errorf("store: failed to configure Postgres pool: %w", err)
 		}
@@ -279,11 +308,20 @@ func applySQLitePragmas(db *DB) error {
 }
 
 // configurePostgresPool sets connection pool defaults for PostgreSQL.
-func configurePostgresPool(db *DB) error {
-	db.SetMaxOpenConns(20)
-	db.SetMaxIdleConns(5)
-	db.SetConnMaxLifetime(5 * time.Minute)
-	db.SetConnMaxIdleTime(2 * time.Minute)
+func configurePostgresPool(db *DB, pool PostgresPoolConfig) error {
+	if pool.MaxOpenConns < 1 {
+		return fmt.Errorf("max open connections must be >= 1")
+	}
+	if pool.MaxIdleConns < 0 || pool.MaxIdleConns > pool.MaxOpenConns {
+		return fmt.Errorf("max idle connections must be between 0 and max open connections")
+	}
+	if pool.ConnMaxLifetime < 0 || pool.ConnMaxIdleTime < 0 {
+		return fmt.Errorf("connection lifetimes must be >= 0")
+	}
+	db.SetMaxOpenConns(pool.MaxOpenConns)
+	db.SetMaxIdleConns(pool.MaxIdleConns)
+	db.SetConnMaxLifetime(pool.ConnMaxLifetime)
+	db.SetConnMaxIdleTime(pool.ConnMaxIdleTime)
 	return nil
 }
 

--- a/store/pool_test.go
+++ b/store/pool_test.go
@@ -1,0 +1,51 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func TestConfigurePostgresPoolAppliesBudget(t *testing.T) {
+	raw, err := sqlx.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = raw.Close()
+	})
+
+	db := &DB{DB: raw, Dialect: DialectPostgres}
+	err = configurePostgresPool(db, PostgresPoolConfig{
+		MaxOpenConns:    2,
+		MaxIdleConns:    1,
+		ConnMaxLifetime: 30 * time.Minute,
+		ConnMaxIdleTime: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("configurePostgresPool() error = %v", err)
+	}
+	if got := db.Stats().MaxOpenConnections; got != 2 {
+		t.Fatalf("MaxOpenConnections = %d, want 2", got)
+	}
+}
+
+func TestConfigurePostgresPoolRejectsBudgetAboveOpen(t *testing.T) {
+	raw, err := sqlx.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = raw.Close()
+	})
+
+	db := &DB{DB: raw, Dialect: DialectPostgres}
+	err = configurePostgresPool(db, PostgresPoolConfig{
+		MaxOpenConns: 2,
+		MaxIdleConns: 3,
+	})
+	if err == nil {
+		t.Fatal("configurePostgresPool() error = nil, want invalid budget")
+	}
+}

--- a/store/pool_test.go
+++ b/store/pool_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/tokendancelab/metapi-go/config"
 )
 
 func TestConfigurePostgresPoolAppliesBudget(t *testing.T) {
@@ -47,5 +48,13 @@ func TestConfigurePostgresPoolRejectsBudgetAboveOpen(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("configurePostgresPool() error = nil, want invalid budget")
+	}
+}
+
+func TestPostgresPoolConfigFromZeroValueRuntimeConfigUsesLegacyDefaults(t *testing.T) {
+	got := postgresPoolConfigFromRuntimeConfig(&config.Config{})
+	want := DefaultPostgresPoolConfig()
+	if got != want {
+		t.Fatalf("pool = %#v, want %#v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- expose PostgreSQL pool limits and connection lifetimes through validated environment configuration
- apply the configured budget only to the runtime PostgreSQL pool and log the effective non-secret values
- document the settings in env, compose, deployment, and bilingual READMEs

## Production intent
TokenDance production will use `2/1`, `1800s/300s` so the application pool stays within role `metapi` LIMIT 2. This PR does not deploy or change production runtime.

## Validation
- `go build ./cmd/server`
- `go vet ./...`
- `go test ./... -count=1 -timeout=300s`
- `golangci-lint run --timeout=3m`
- WSL/Linux: `go test ./config ./store -count=1 -race -timeout=180s`

Full local Linux race reached only the pre-existing network-dependent `platform.TestAnyRouterAdapter_InheritsNewApiMethods`, which timed out dialing `proxy.local`; all changed packages passed race. Windows race cannot initialize ThreadSanitizer (error 87). GitHub CI remains the full race gate.