### PR TITLE
fix(platform): make NewAPI user ID extraction RE2-safe

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -15,7 +15,7 @@
 |:-----|:------|
 | Latest release tag | **[v0.8.44](https://github.com/TokenDanceLab/metapi-go/releases/tag/v0.8.44)** (2026-07-19) |
 | Tip | `origin/master` @ v0.8.44 (#531 pool profiles + lease pressure) |
-| Production pin (ops) | server `projects/metapi/STATE.md` (hk3 **0.8.44** healthy; pool/role **1/1**; restart=no) |
+| Production pin (ops) | server `projects/metapi/STATE.md` (hk3 image **0.8.44**; small-pool experiment failed, container **Exited(2)**; pool/role remains **1/1**; restart=no; source fix is on `codex/metapi-regex-crash`, but no fixed image has been deployed) |
 | Standby us1 pin | compose **0.8.42** + image pulled (#528); cold stack not auto-started |
 | Active milestone | none (M50 closed) |
 | Open issues / PRs | board clean after M50 close |

--- a/platform/newapi.go
+++ b/platform/newapi.go
@@ -68,6 +68,11 @@ func (n *NewApiAdapter) authHeaders(accessToken string, userID *int) map[string]
 
 // --- User-ID discovery ---
 
+var (
+	underscoreUserIDRE = regexp.MustCompile(`_(\d{4,})`)
+	namedUserIDRE      = regexp.MustCompile(`(?i)(?:user(?:name)?|uid|id)[^\d]{0,16}(\d{4,})`)
+)
+
 func (n *NewApiAdapter) tryDecodeUserID(token string) *int {
 	t := strings.TrimSpace(token)
 	t = strings.TrimPrefix(t, "Bearer ")
@@ -181,15 +186,19 @@ func (n *NewApiAdapter) extractLikelyUserIDs(token string) []int {
 
 		for _, payload := range payloads {
 			// Pattern: _12345678
-			re := regexp.MustCompile(`_(\d{4,8})(?!\d)`)
-			for _, match := range re.FindAllStringSubmatch(payload, -1) {
+			for _, match := range underscoreUserIDRE.FindAllStringSubmatch(payload, -1) {
+				if len(match[1]) > 8 {
+					continue
+				}
 				if id, err := strconv.Atoi(match[1]); err == nil {
 					push(id)
 				}
 			}
 			// Pattern: user/id/uid near a number
-			re2 := regexp.MustCompile(`(?i)(?:user(?:name)?|uid|id)[^\d]{0,16}(\d{4,8})(?!\d)`)
-			for _, match := range re2.FindAllStringSubmatch(payload, -1) {
+			for _, match := range namedUserIDRE.FindAllStringSubmatch(payload, -1) {
+				if len(match[1]) > 8 {
+					continue
+				}
 				if id, err := strconv.Atoi(match[1]); err == nil {
 					push(id)
 				}

--- a/platform/newapi_test.go
+++ b/platform/newapi_test.go
@@ -2,6 +2,8 @@ package platform
 
 import (
 	"context"
+	"encoding/base64"
+	"reflect"
 	"testing"
 )
 
@@ -25,6 +27,33 @@ func TestNewApiAdapter_PlatformName(t *testing.T) {
 	n := &NewApiAdapter{BaseAdapter: NewBaseAdapter("new-api")}
 	if n.PlatformName() != "new-api" {
 		t.Errorf("PlatformName: %q", n.PlatformName())
+	}
+}
+
+func TestNewApiAdapter_ExtractLikelyUserIDs_RE2Boundaries(t *testing.T) {
+	n := &NewApiAdapter{BaseAdapter: NewBaseAdapter("new-api")}
+	tests := []struct {
+		name    string
+		payload string
+		want    []int
+	}{
+		{name: "underscore before delimiter", payload: `prefix_8765432|suffix`, want: []int{8765432}},
+		{name: "underscore at end", payload: `prefix_1234`, want: []int{1234}},
+		{name: "named user before delimiter", payload: `username: 567890;`, want: []int{567890}},
+		{name: "named id at end", payload: `uid=4321`, want: []int{4321}},
+		{name: "adjacent underscore ids", payload: `prefix_1234_5678`, want: []int{1234, 5678}},
+		{name: "reject underscore nine digits", payload: `prefix_123456789|suffix`, want: nil},
+		{name: "reject named nine digits", payload: `user_id=123456789;`, want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := "session=" + base64.RawStdEncoding.EncodeToString([]byte(tt.payload))
+			got := n.extractLikelyUserIDs(token)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("extractLikelyUserIDs() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary\n- replace the two unsupported Go RE2 negative lookaheads in NewAPI session user-ID extraction\n- preserve 4-8 digit and existing numeric bounds, including adjacent IDs\n- record the v0.8.44 small-pool experiment as Exited(2) in product STATE\n\n## Verification\n- focused regression and platform tests pass\n- clean clone: go build ./cmd/server passes\n- pre-push: go vet ./... and go test ./... -count=1 -race pass\n- no production image, container, database, or deployment changes\n\n## Follow-up\nAfter merge and image publication, run the separately gated 15-minute background-task soak before any MetAPI re-experiment.