### PR TITLE
fix(ui): shell mock Traffic trend chart well (#543)

### DIFF
--- a/web/design-system/styles.css
+++ b/web/design-system/styles.css
@@ -741,6 +741,64 @@ select.ds-input {
   }
 }
 
+/* Shell mock Traffic trend chart well (#543) — token-only sparkline surface */
+.ds-gallery__chart-well {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-height: 168px;
+  margin-top: var(--space-2);
+  padding: var(--space-4);
+  border-radius: var(--radius-card);
+  border: 1px solid var(--color-border-light);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-primary) 6%, var(--color-bg-card)) 0%,
+      var(--color-bg-secondary) 100%
+    );
+  /* dual soft shadow — intentional elevation vs empty grey box */
+  box-shadow:
+    var(--shadow-sm),
+    0 10px 28px color-mix(in srgb, var(--color-primary) 8%, transparent);
+  color: var(--color-primary);
+}
+
+.ds-gallery__chart-sparkline {
+  display: block;
+  width: 100%;
+  height: 120px;
+  min-height: 120px;
+  overflow: visible;
+}
+
+.ds-gallery__chart-grid {
+  stroke: color-mix(in srgb, var(--color-border) 70%, transparent);
+  stroke-width: 1;
+  stroke-dasharray: 3 5;
+}
+
+.ds-gallery__chart-line {
+  filter: drop-shadow(0 1px 1px color-mix(in srgb, var(--color-primary) 25%, transparent));
+}
+
+.ds-gallery__chart-dot {
+  fill: var(--color-bg-card);
+  stroke: var(--color-primary);
+  stroke-width: 2;
+}
+
+.ds-gallery__chart-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.02em;
+  color: var(--color-text-secondary);
+}
+
 .ds-gallery__fake-table {
   display: grid;
   grid-template-columns: 1.4fr 1fr 0.7fr;

--- a/web/pages/DesignSystemGallery.tsx
+++ b/web/pages/DesignSystemGallery.tsx
@@ -160,11 +160,47 @@ function ShellChromeMock({ activePage, onPageChange }: {
                   </article>
                 ))}
               </div>
-              <Card title="Traffic trend" description="Placeholder chart well for shell composition.">
-                <div className="ds-gallery__fake-table" aria-hidden="true">
-                  <div /><div /><div />
-                  <div /><div /><div />
-                  <div /><div /><div />
+              <Card title="Traffic trend" description="Token-only sparkline mock for shell composition (#543).">
+                <div className="ds-gallery__chart-well" aria-hidden="true">
+                  <svg
+                    className="ds-gallery__chart-sparkline"
+                    viewBox="0 0 320 120"
+                    preserveAspectRatio="none"
+                    role="presentation"
+                  >
+                    <defs>
+                      <linearGradient id="ds-gallery-spark-fill" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stopColor="var(--color-primary)" stopOpacity="0.28" />
+                        <stop offset="100%" stopColor="var(--color-primary)" stopOpacity="0.02" />
+                      </linearGradient>
+                    </defs>
+                    {/* soft baseline grid */}
+                    <line className="ds-gallery__chart-grid" x1="0" y1="30" x2="320" y2="30" />
+                    <line className="ds-gallery__chart-grid" x1="0" y1="60" x2="320" y2="60" />
+                    <line className="ds-gallery__chart-grid" x1="0" y1="90" x2="320" y2="90" />
+                    {/* area under sparkline */}
+                    <path
+                      className="ds-gallery__chart-area"
+                      d="M0 88 C28 84, 40 70, 56 66 C78 60, 92 78, 112 72 C136 64, 148 42, 172 46 C196 50, 208 74, 232 68 C256 62, 272 38, 292 34 C304 32, 312 36, 320 40 L320 120 L0 120 Z"
+                      fill="url(#ds-gallery-spark-fill)"
+                    />
+                    {/* stroke sparkline */}
+                    <path
+                      className="ds-gallery__chart-line"
+                      d="M0 88 C28 84, 40 70, 56 66 C78 60, 92 78, 112 72 C136 64, 148 42, 172 46 C196 50, 208 74, 232 68 C256 62, 272 38, 292 34 C304 32, 312 36, 320 40"
+                      fill="none"
+                      stroke="var(--color-primary)"
+                      strokeWidth="2.25"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <circle className="ds-gallery__chart-dot" cx="172" cy="46" r="3.5" />
+                    <circle className="ds-gallery__chart-dot" cx="292" cy="34" r="3.5" />
+                  </svg>
+                  <div className="ds-gallery__chart-meta">
+                    <span>7d · req/min</span>
+                    <span>peak 14.8k</span>
+                  </div>
                 </div>
               </Card>
             </div>


### PR DESCRIPTION
Closes #543

## Summary
- Replace shell mock Dashboard `Traffic trend` `ds-gallery__fake-table` 3×3 empty bars with a token-only SVG sparkline chart well
- Add `.ds-gallery__chart-well` gallery helper (min-height, dual soft shadow, primary-tinted fill) in `web/design-system/styles.css`
- Keep `data-testid="shell-chrome-mock"` / `shell-mock-dashboard` stable; no brand hex

## Test plan
- [x] `cd web && npm run typecheck`
- [ ] Recapture `docs/analysis/ui-shots/shell-dashboard-{light,dark}-win32.png` (optional follow-up)
- [ ] Visual check light + dark shell dashboard Traffic trend looks intentional