### PR TITLE
test(ui): axe smoke login+gallery (#546)

### DIFF
--- a/web/e2e/a11y-smoke.spec.ts
+++ b/web/e2e/a11y-smoke.spec.ts
@@ -1,0 +1,159 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * Minimal axe-core smoke (#546).
+ *
+ * Surfaces:
+ * - `/` login shell (preview without backend)
+ * - `/__design__` design gallery (requires metapi_design_gallery=1)
+ *
+ * Gate: fail only on impact serious|critical after allowlist filtering.
+ * Moderate/minor are logged but do not fail CI.
+ *
+ * Allowlist (gallery only — documented residuals, not product fixes in #546):
+ * - aria-hidden-focus: static drawer/modal mocks keep focusable form controls
+ *   while the mock chrome is aria-hidden (demo only; not a real open overlay).
+ * - color-contrast: shell/gallery token contrast residuals (checklist follow-ups;
+ *   do not redesign DesignSystemGallery in this smoke issue).
+ *
+ * Login surface has no allowlist.
+ */
+
+const GALLERY_PATH = '/__design__';
+
+/** Rule IDs allowed only on the design gallery surface. */
+const GALLERY_ALLOWLIST_RULE_IDS = new Set(['aria-hidden-focus', 'color-contrast']);
+
+type AxeImpact = 'minor' | 'moderate' | 'serious' | 'critical';
+
+function formatViolations(
+  violations: Array<{
+    id: string;
+    impact?: string | null;
+    help: string;
+    nodes: Array<{ target: unknown[]; failureSummary?: string }>;
+  }>,
+): string {
+  return violations
+    .map((v) => {
+      const targets = v.nodes
+        .slice(0, 5)
+        .map((n) => `    - ${JSON.stringify(n.target)}${n.failureSummary ? `: ${n.failureSummary}` : ''}`)
+        .join('\n');
+      return `[${v.impact ?? 'unknown'}] ${v.id}: ${v.help}\n${targets}`;
+    })
+    .join('\n\n');
+}
+
+async function runSeriousCriticalAxe(
+  page: Page,
+  label: string,
+  allowlist: ReadonlySet<string> = new Set(),
+) {
+  const results = await new AxeBuilder({ page })
+    // WCAG 2.1 A/AA is enough for a smoke gate.
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .analyze();
+
+  const seriousOrCritical = results.violations.filter((v) => {
+    const impact = (v.impact ?? '') as AxeImpact | '';
+    return impact === 'serious' || impact === 'critical';
+  });
+
+  const allowlisted = seriousOrCritical.filter((v) => allowlist.has(v.id));
+  const blocking = seriousOrCritical.filter((v) => !allowlist.has(v.id));
+
+  const soft = results.violations.filter((v) => {
+    const impact = (v.impact ?? '') as AxeImpact | '';
+    return impact === 'moderate' || impact === 'minor';
+  });
+
+  if (allowlisted.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[a11y-smoke] ${label}: ${allowlisted.length} allowlisted serious/critical rule(s):\n${formatViolations(allowlisted)}`,
+    );
+  }
+
+  if (soft.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[a11y-smoke] ${label}: ${soft.length} moderate/minor violation(s) (not failing):\n${formatViolations(soft)}`,
+    );
+  }
+
+  expect(
+    blocking,
+    `[a11y-smoke] ${label}: serious/critical violations:\n${formatViolations(blocking)}`,
+  ).toEqual([]);
+}
+
+async function galleryAvailable(page: Page): Promise<boolean> {
+  const response = await page.goto(GALLERY_PATH, { waitUntil: 'domcontentloaded' });
+  if (!response) return false;
+  // Vite SPA fallback serves index.html with 200 for unknown paths; treat a
+  // missing gallery as either real 404 or a non-gallery shell without marker.
+  if (response.status() === 404) return false;
+  const marker = page.locator(
+    '[data-testid="design-system-gallery"], [data-design-gallery], #design-gallery, [data-testid="design-gallery"]',
+  );
+  try {
+    await marker.first().waitFor({ state: 'visible', timeout: 8_000 });
+    return true;
+  } catch {
+    const bodyText = (await page.locator('body').innerText().catch(() => '')).toLowerCase();
+    if (bodyText.includes('design system') || bodyText.includes('design gallery')) {
+      return true;
+    }
+    return false;
+  }
+}
+
+test.describe('a11y smoke (axe)', () => {
+  test('login surface has no serious/critical axe violations', async ({ page }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('theme_mode', 'dark');
+        localStorage.setItem('theme', 'dark');
+      } catch {
+        /* ignore */
+      }
+    });
+
+    await page.goto('/', { waitUntil: 'networkidle' }).catch(async () => {
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+    });
+
+    await expect(page.locator('#root')).toBeAttached({ timeout: 15_000 });
+    // Give React a beat to paint the login shell before axe scans.
+    await page.waitForTimeout(300);
+
+    await runSeriousCriticalAxe(page, 'login /');
+  });
+
+  test('design gallery has no serious/critical axe violations (allowlisted residuals)', async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('theme_mode', 'light');
+        localStorage.setItem('theme', 'light');
+        // Production preview builds gate /__design__ behind this flag (#533).
+        localStorage.setItem('metapi_design_gallery', '1');
+      } catch {
+        /* ignore */
+      }
+    });
+
+    const available = await galleryAvailable(page);
+    test.skip(!available, 'design gallery route /__design__ not available (404 or not scaffolded)');
+
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'light', {
+      timeout: 15_000,
+    });
+    await page.waitForTimeout(300);
+
+    await runSeriousCriticalAxe(page, 'gallery /__design__', GALLERY_ALLOWLIST_RULE_IDS);
+  });
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,6 +16,7 @@
         "marked": "^18.0.3"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "^1.54.2",
         "@tailwindcss/vite": "^4.3.0",
         "@types/node": "^22.10.1",
@@ -88,6 +89,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmmirror.com/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -2542,6 +2556,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmmirror.com/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/bidi-js": {

--- a/web/package.json
+++ b/web/package.json
@@ -53,6 +53,7 @@
     "marked": "^18.0.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.54.2",
     "@tailwindcss/vite": "^4.3.0",
     "@types/node": "^22.10.1",


### PR DESCRIPTION
## Summary
Implements #546: minimal axe-core Playwright smoke on the login surface and design gallery.

## Changes
- Add `web/e2e/a11y-smoke.spec.ts` using `@axe-core/playwright`
- Scan `/` (login) and `/__design__` with `metapi_design_gallery=1`
- Fail only **serious/critical** after a documented gallery allowlist (`aria-hidden-focus`, `color-contrast` residuals)
- Soft-skip gallery when route is missing (same pattern as visual specs)
- Add `@axe-core/playwright` as a web devDependency (picked up by existing `npm run test:e2e`)
- Do **not** edit `docs/design/a11y-checklist.md` (owned by #547)

## Verify
```bash
cd web && npm install
npm run test:e2e -- e2e/a11y-smoke.spec.ts
```
Result: **2 passed** (login clean; gallery allowlisted residuals logged only).

## Notes
Gallery allowlist is intentional for CI stability; product contrast/focus mock cleanup is out of scope for this smoke issue.

Closes #546