### PR TITLE
fix(ui): defer Sites weight banner when empty (#554)

### DIFF
--- a/web/pages/Sites.tsx
+++ b/web/pages/Sites.tsx
@@ -1280,9 +1280,17 @@ export default function Sites() {
         </ResponsiveBatchActionBar>
       )}
 
-      <div className="info-tip" style={{ marginBottom: 12 }}>
-        站点权重说明：最终站点倍率 = 站点全局权重 × 设置页中下游 API Key 的站点倍率。它会与路由策略因子（基础权重、价值分、成本、余额、使用频次）共同作用。数值越大，该站点在同优先级下越容易被选中。建议范围 0.5-3，默认 1；长期不建议超过 5。
-      </div>
+      {/* #554: defer weight-formula education until at least one site exists so EmptyState CTA stays primary */}
+      {sites.length > 0 ? (
+        <details className="info-tip sites-weight-tip" style={{ marginBottom: 12 }} data-testid="sites-weight-tip">
+          <summary style={{ cursor: 'pointer', fontWeight: 600, listStylePosition: 'outside' }}>
+            了解站点权重
+          </summary>
+          <div style={{ marginTop: 8 }}>
+            站点权重说明：最终站点倍率 = 站点全局权重 × 设置页中下游 API Key 的站点倍率。它会与路由策略因子（基础权重、价值分、成本、余额、使用频次）共同作用。数值越大，该站点在同优先级下越容易被选中。建议范围 0.5-3，默认 1；长期不建议超过 5。
+          </div>
+        </details>
+      ) : null}
 
       <DeleteConfirmModal
         open={Boolean(deleteConfirm)}

--- a/web/pages/sites.weight-banner.test.tsx
+++ b/web/pages/sites.weight-banner.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * #554 — Sites weight-formula banner is deferred until sites.length > 0.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
+import { ToastProvider } from '../components/Toast.js';
+import Sites from './Sites.js';
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    getSites: vi.fn(),
+  },
+}));
+
+vi.mock('../api.js', () => ({
+  api: apiMock,
+}));
+
+function collectText(node: any): string {
+  if (node == null) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join('');
+  const children = node?.children || node?.props?.children;
+  if (children == null) return '';
+  if (Array.isArray(children)) return children.map(collectText).join('');
+  return collectText(children);
+}
+
+async function flushMicrotasks() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('Sites weight banner (#554)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hides weight formula banner when sites list is empty', async () => {
+    apiMock.getSites.mockResolvedValue([]);
+
+    let root!: ReactTestRenderer;
+    try {
+      await act(async () => {
+        root = create(
+          <MemoryRouter initialEntries={['/sites']}>
+            <ToastProvider>
+              <Sites />
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+      });
+      await flushMicrotasks();
+
+      const serialized = JSON.stringify(root.toJSON());
+      expect(serialized).toContain('暂无站点');
+      expect(serialized).not.toContain('站点权重说明');
+      expect(serialized).not.toContain('了解站点权重');
+      expect(() => root.root.find((node) => node.props['data-testid'] === 'sites-weight-tip')).toThrow();
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it('shows collapsible 了解站点权重 after first site exists', async () => {
+    apiMock.getSites.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Site A',
+        url: 'https://a.example.com',
+        platform: 'new-api',
+        status: 'active',
+        globalWeight: 1,
+      },
+    ]);
+
+    let root!: ReactTestRenderer;
+    try {
+      await act(async () => {
+        root = create(
+          <MemoryRouter initialEntries={['/sites']}>
+            <ToastProvider>
+              <Sites />
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+      });
+      await flushMicrotasks();
+
+      const tip = root.root.find((node) => node.props['data-testid'] === 'sites-weight-tip');
+      expect(tip.type).toBe('details');
+      const serialized = JSON.stringify(root.toJSON());
+      expect(serialized).toContain('了解站点权重');
+      expect(serialized).toContain('站点权重说明');
+      expect(serialized).toContain('Site A');
+    } finally {
+      root.unmount();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Hide the always-on amber weight-formula banner when `sites.length === 0` so EmptyState primary CTA stays clear on first-run.
- After the first site exists, show a collapsed `details` tip with summary **了解站点权重** (expand for full formula text).
- Add unit coverage in `web/pages/sites.weight-banner.test.tsx`.

Closes #554

## Test plan
- [x] `npm run typecheck:web` (in `web/`)
- [x] `npx vitest run pages/sites.weight-banner.test.tsx`
- [x] Related Sites tests (create-redirect, system-proxy-bulk, mobile)
- [x] pre-push local CI (`go vet` + `go test -race`)
- [ ] Optional: recapture page-sites light/dark empty shots after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “站点权重说明” tip is now hidden when no sites exist, keeping the empty-state action prominent.
  * When sites are available, the tip appears as a collapsible section for improved clarity.

* **Tests**
  * Added coverage for the tip’s visibility and collapsible behavior in both empty and populated site states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->