### PR TITLE
feat(ui): dashboard first-run getting-started strip (#553)

### DIFF
--- a/web/components/charts/SiteDistributionChart.tsx
+++ b/web/components/charts/SiteDistributionChart.tsx
@@ -1,6 +1,7 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, type ReactNode } from 'react';
 import { VChart } from '@visactor/react-vchart';
 import { useThemeLabelColor } from '../useThemeLabelColor.js';
+import { EmptyState as DsEmptyState } from '../../design-system/index.js';
 
 interface SiteDistributionData {
   siteName: string;
@@ -13,6 +14,8 @@ interface SiteDistributionData {
 interface SiteDistributionChartProps {
   data: SiteDistributionData[];
   loading?: boolean;
+  /** Shared next-step CTA for empty wells (#553). */
+  emptyAction?: ReactNode;
 }
 
 type ViewMode = 'balance' | 'spend';
@@ -56,40 +59,24 @@ function SkeletonCircle() {
   );
 }
 
-function EmptyState() {
+function ChartEmptyState({ action }: { action?: ReactNode }) {
   return (
-    <div className="empty-state" style={{ padding: 40 }}>
-      <div style={{ margin: '0 auto 16px', width: 64, height: 64, opacity: 0.35 }}>
-        <svg
-          width="64"
-          height="64"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="var(--color-text-muted)"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.2}
-            d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z"
-          />
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.2}
-            d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z"
-          />
-        </svg>
-      </div>
-      <div className="empty-state-title" style={{ marginBottom: 4 }}>
-        暂无站点数据
-      </div>
-      <div className="empty-state-desc">添加站点后将自动展示分布图表</div>
-    </div>
+    <DsEmptyState
+      className="dashboard-chart-empty"
+      tone="neutral"
+      icon="◇"
+      title="暂无站点数据"
+      description="添加站点后将自动展示分布图表"
+      action={action}
+    />
   );
 }
 
-export default function SiteDistributionChart({ data, loading }: SiteDistributionChartProps) {
+export default function SiteDistributionChart({
+  data,
+  loading,
+  emptyAction,
+}: SiteDistributionChartProps) {
   const [viewMode, setViewMode] = useState<ViewMode>('balance');
   const labelColor = useThemeLabelColor();
 
@@ -263,7 +250,7 @@ export default function SiteDistributionChart({ data, loading }: SiteDistributio
       {loading ? (
         <SkeletonCircle />
       ) : !hasData ? (
-        <EmptyState />
+        <ChartEmptyState action={emptyAction} />
       ) : (
         <div>
           <div style={{ width: '100%', height: 300 }}>

--- a/web/components/charts/SiteTrendChart.tsx
+++ b/web/components/charts/SiteTrendChart.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, type ReactNode } from 'react';
 import { VChart } from '@visactor/react-vchart';
+import { EmptyState as DsEmptyState } from '../../design-system/index.js';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -13,6 +14,8 @@ interface SiteTrendData {
 interface SiteTrendChartProps {
   data: SiteTrendData[];
   loading?: boolean;
+  /** Shared next-step CTA for empty wells (#553). */
+  emptyAction?: ReactNode;
 }
 
 /* ------------------------------------------------------------------ */
@@ -41,7 +44,11 @@ const COLOR_PALETTE = [
 /*  Component                                                          */
 /* ------------------------------------------------------------------ */
 
-export default function SiteTrendChart({ data, loading }: SiteTrendChartProps) {
+export default function SiteTrendChart({
+  data,
+  loading,
+  emptyAction,
+}: SiteTrendChartProps) {
   const [metric, setMetric] = useState<Metric>('spend');
 
   /* ---------- data transform ---------- */
@@ -78,10 +85,14 @@ export default function SiteTrendChart({ data, loading }: SiteTrendChartProps) {
         <div style={headerStyle}>
           <MetricToggle metric={metric} onChange={setMetric} />
         </div>
-        <div className="empty-state" style={{ padding: 48 }}>
-          <div className="empty-state-title">暂无趋势数据</div>
-          <div className="empty-state-desc">数据加载后将自动展示趋势图表</div>
-        </div>
+        <DsEmptyState
+          className="dashboard-chart-empty"
+          tone="neutral"
+          icon="◇"
+          title="暂无趋势数据"
+          description="数据加载后将自动展示趋势图表"
+          action={emptyAction}
+        />
       </div>
     );
   }

--- a/web/index.css
+++ b/web/index.css
@@ -1869,6 +1869,179 @@ body {
   }
 }
 
+/* ===== Dashboard first-run (#553) ===== */
+.dashboard-getting-started {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: var(--space-4, 16px);
+  margin-bottom: 16px;
+  padding: var(--space-4, 16px) var(--space-5, 20px);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-light);
+  background: color-mix(in srgb, var(--color-info-soft) 55%, var(--color-bg-card));
+  box-shadow: var(--shadow-sm);
+}
+
+.dashboard-getting-started__intro {
+  flex: 1 1 220px;
+  min-width: 0;
+}
+
+.dashboard-getting-started__title {
+  font-size: var(--text-md, 14px);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  letter-spacing: -0.01em;
+  margin-bottom: 4px;
+}
+
+.dashboard-getting-started__desc {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+  max-width: 48ch;
+}
+
+.dashboard-getting-started__steps {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  flex: 2 1 360px;
+  min-width: 0;
+}
+
+.dashboard-getting-started__step {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+  flex: 1 1 140px;
+  min-width: 0;
+}
+
+.dashboard-getting-started__arrow {
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-text-muted);
+  font-size: 14px;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.dashboard-getting-started__link {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border-light);
+  background: var(--color-bg-card);
+  text-decoration: none;
+  color: inherit;
+  transition:
+    border-color var(--motion-swift, 0.15s ease),
+    box-shadow var(--motion-swift, 0.15s ease),
+    transform var(--motion-swift, 0.15s ease);
+}
+
+.dashboard-getting-started__link:hover {
+  border-color: color-mix(in srgb, var(--color-primary) 35%, var(--color-border-light));
+  box-shadow: var(--shadow-sm);
+}
+
+.dashboard-getting-started__link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.dashboard-getting-started__index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  margin-bottom: 4px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--color-primary-soft, var(--color-info-soft));
+  color: var(--color-primary);
+}
+
+.dashboard-getting-started__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.dashboard-getting-started__hint {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}
+
+.dashboard-zero-traffic {
+  margin-bottom: 24px;
+  padding: 8px 12px 16px;
+}
+
+.dashboard-chart-empty {
+  padding: var(--space-6, 24px) var(--space-4, 16px);
+}
+
+.dashboard-sites-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+}
+
+.dashboard-inline-code {
+  background: var(--color-bg);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+}
+
+.site-observability-empty .ds-empty {
+  padding-top: var(--space-6, 24px);
+  padding-bottom: var(--space-6, 24px);
+}
+
+a.ds-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  box-sizing: border-box;
+}
+
+@media (max-width: 720px) {
+  .dashboard-getting-started {
+    padding: 14px;
+  }
+
+  .dashboard-getting-started__arrow {
+    display: none;
+  }
+
+  .dashboard-getting-started__steps {
+    flex-direction: column;
+  }
+
+  .dashboard-getting-started__step {
+    flex: 1 1 auto;
+  }
+}
+
 /* ===== Nav ===== */
 .nav-transition {
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);

--- a/web/pages/Dashboard.tsx
+++ b/web/pages/Dashboard.tsx
@@ -1,8 +1,9 @@
-import { Suspense, lazy, useEffect, useState, useCallback } from "react";
+import { Suspense, lazy, useEffect, useState, useCallback, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { api } from "../api.js";
 import { useToast } from "../components/Toast.js";
 import { useIsMobile } from "../components/useIsMobile.js";
+import { EmptyState } from "../design-system/index.js";
 import { formatCompactTokenMetric } from "../numberFormat.js";
 import { safeExternalHref } from "../shared/sitePrimaryUrl.js";
 
@@ -49,6 +50,73 @@ function ChartFallback({ height = 280 }: { height?: number }) {
           height: Math.max(120, height - 46),
           borderRadius: 10,
         }}
+      />
+    </div>
+  );
+}
+
+/** Shared first-run / empty-well next step (#553). */
+function DashboardNextStepCta({
+  to = "/sites",
+  label = "添加站点",
+}: {
+  to?: string;
+  label?: string;
+}) {
+  return (
+    <Link to={to} className="ds-btn ds-btn--primary ds-btn--sm">
+      {label}
+    </Link>
+  );
+}
+
+const FIRST_RUN_STEPS: { to: string; label: string; hint: string }[] = [
+  { to: "/sites", label: "添加站点", hint: "配置上游 API 站点" },
+  { to: "/accounts", label: "连接账号", hint: "绑定站点账号与凭证" },
+  { to: "/tokens", label: "同步令牌", hint: "同步或生成访问令牌" },
+];
+
+function DashboardGettingStartedStrip() {
+  return (
+    <section
+      className="dashboard-getting-started"
+      aria-label="首次使用引导"
+    >
+      <div className="dashboard-getting-started__intro">
+        <div className="dashboard-getting-started__title">开始使用</div>
+        <p className="dashboard-getting-started__desc">
+          按顺序完成站点、账号与令牌配置后，仪表盘将自动展示余额与流量。
+        </p>
+      </div>
+      <ol className="dashboard-getting-started__steps">
+        {FIRST_RUN_STEPS.map((step, index) => (
+          <li key={step.to} className="dashboard-getting-started__step">
+            {index > 0 && (
+              <span className="dashboard-getting-started__arrow" aria-hidden="true">
+                →
+              </span>
+            )}
+            <Link to={step.to} className="dashboard-getting-started__link">
+              <span className="dashboard-getting-started__index">{index + 1}</span>
+              <span className="dashboard-getting-started__label">{step.label}</span>
+              <span className="dashboard-getting-started__hint">{step.hint}</span>
+            </Link>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function DashboardZeroTrafficSummary({ action }: { action?: ReactNode }) {
+  return (
+    <div className="dashboard-zero-traffic card animate-slide-up stagger-1">
+      <EmptyState
+        tone="info"
+        icon="◇"
+        title="尚未产生流量"
+        description="添加站点并完成账号连接后，余额、请求与签到指标会显示在这里。"
+        action={action ?? <DashboardNextStepCta />}
       />
     </div>
   );
@@ -528,6 +596,19 @@ export default function Dashboard({
     ? [...activeSites, ...inactiveSites]
     : activeSites;
 
+  // First-run: no sites yet (or site list still empty after load) and no traffic noise.
+  const sitesReady = !siteLoading;
+  const hasSites = sites.length > 0;
+  const hasTrafficSignal =
+    proxy24hTotal > 0 ||
+    totalTokens > 0 ||
+    totalUsed > 0 ||
+    todaySpend > 0 ||
+    siteDistribution.length > 0 ||
+    siteTrend.length > 0 ||
+    activeSites.length > 0;
+  const isFirstRunBootstrap = sitesReady && !hasSites && !hasTrafficSignal;
+
   const getLatencyColor = (ms: number) =>
     ms <= 500
       ? "var(--color-success)"
@@ -622,6 +703,13 @@ export default function Dashboard({
         </div>
       </div>
 
+      {isFirstRunBootstrap && <DashboardGettingStartedStrip />}
+
+      {isFirstRunBootstrap ? (
+        <DashboardZeroTrafficSummary
+          action={<DashboardNextStepCta to="/sites" label="添加站点" />}
+        />
+      ) : (
       <div className="dashboard-stat-grid">
         <div className="stat-card animate-slide-up stagger-1">
           <div className="stat-card-header">
@@ -968,6 +1056,7 @@ export default function Dashboard({
           </div>
         </div>
       </div>
+      )}
 
       {/* 站点级分析 */}
       <div
@@ -1043,12 +1132,25 @@ export default function Dashboard({
             <SiteDistributionChart
               data={siteDistribution}
               loading={siteLoading}
+              emptyAction={
+                isFirstRunBootstrap || (!siteLoading && !hasSites) ? (
+                  <DashboardNextStepCta />
+                ) : undefined
+              }
             />
           </Suspense>
         </div>
         <div className="chart-panel-enter animate-slide-up stagger-7">
           <Suspense fallback={<ChartFallback height={320} />}>
-            <SiteTrendChart data={siteTrend} loading={siteLoading} />
+            <SiteTrendChart
+              data={siteTrend}
+              loading={siteLoading}
+              emptyAction={
+                isFirstRunBootstrap || (!siteLoading && !hasSites) ? (
+                  <DashboardNextStepCta />
+                ) : undefined
+              }
+            />
           </Suspense>
         </div>
       </div>
@@ -1239,12 +1341,21 @@ export default function Dashboard({
           </div>
         ) : (
           <div className="site-observability-empty">
-            <div className="site-observability-empty-title">
-              暂无站点观测数据
-            </div>
-            <div className="site-observability-empty-note">
-              有代理请求后，这里会自动生成每个站点的可用性条和平均响应速度。
-            </div>
+            <EmptyState
+              tone="neutral"
+              icon="◇"
+              title="暂无站点观测数据"
+              description={
+                isFirstRunBootstrap
+                  ? "添加站点并产生代理请求后，这里会自动生成每个站点的可用性条和平均响应速度。"
+                  : "有代理请求后，这里会自动生成每个站点的可用性条和平均响应速度。"
+              }
+              action={
+                isFirstRunBootstrap || !hasSites ? (
+                  <DashboardNextStepCta />
+                ) : undefined
+              }
+            />
           </div>
         )}
       </div>
@@ -1508,63 +1619,30 @@ export default function Dashboard({
                 </div>
               ))
             ) : (
-              <div
-                style={{
-                  flex: 1,
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  gap: 8,
-                  padding: 20,
-                }}
-              >
-                <div style={{ width: 60, height: 60, opacity: 0.25 }}>
-                  <svg
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="var(--color-text-muted)"
-                    width="60"
-                    height="60"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={0.6}
-                      d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  style={{
-                    fontSize: 13,
-                    fontWeight: 600,
-                    color: "var(--color-text-secondary)",
-                  }}
-                >
-                  代理端点可用
-                </div>
-                <div
-                  style={{
-                    fontSize: 11,
-                    color: "var(--color-text-muted)",
-                    textAlign: "center",
-                    lineHeight: 1.6,
-                  }}
-                >
-                  使用{" "}
-                  <code
-                    style={{
-                      background: "var(--color-bg)",
-                      padding: "2px 6px",
-                      borderRadius: 4,
-                      fontSize: 10,
-                    }}
-                  >
-                    /v1/chat/completions
-                  </code>{" "}
-                  访问
-                </div>
+              <div className="dashboard-sites-empty">
+                <EmptyState
+                  tone="neutral"
+                  icon="◇"
+                  title={isFirstRunBootstrap ? "尚未配置站点" : "代理端点可用"}
+                  description={
+                    isFirstRunBootstrap ? (
+                      "先添加上游站点，再连接账号并同步令牌。"
+                    ) : (
+                      <>
+                        使用{" "}
+                        <code className="dashboard-inline-code">
+                          /v1/chat/completions
+                        </code>{" "}
+                        访问
+                      </>
+                    )
+                  }
+                  action={
+                    isFirstRunBootstrap || !hasSites ? (
+                      <DashboardNextStepCta />
+                    ) : undefined
+                  }
+                />
               </div>
             )}
             <div

--- a/web/pages/dashboard.performance-card.test.tsx
+++ b/web/pages/dashboard.performance-card.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, create, type ReactTestInstance } from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
 import { ToastProvider } from '../components/Toast.js';
 import Dashboard from './Dashboard.js';
 import { installDashboardSnapshotCompat } from './testApiCompat.js';
@@ -84,9 +85,11 @@ describe('Dashboard performance stat card', () => {
     try {
       await act(async () => {
         root = create(
-          <ToastProvider>
-            <Dashboard />
-          </ToastProvider>,
+          <MemoryRouter initialEntries={['/']}>
+            <ToastProvider>
+              <Dashboard />
+            </ToastProvider>
+          </MemoryRouter>,
         );
       });
       await flushMicrotasks();
@@ -124,9 +127,11 @@ describe('Dashboard performance stat card', () => {
     try {
       await act(async () => {
         root = create(
-          <ToastProvider>
-            <Dashboard />
-          </ToastProvider>,
+          <MemoryRouter initialEntries={['/']}>
+            <ToastProvider>
+              <Dashboard />
+            </ToastProvider>
+          </MemoryRouter>,
         );
       });
 

--- a/web/pages/dashboardHookOrder.test.tsx
+++ b/web/pages/dashboardHookOrder.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, create } from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
 import { ToastProvider } from '../components/Toast.js';
 import Dashboard from './Dashboard.js';
 import { installDashboardSnapshotCompat } from './testApiCompat.js';
@@ -72,9 +73,11 @@ describe('Dashboard hook order', () => {
     try {
       await act(async () => {
         root = create(
-          <ToastProvider>
-            <Dashboard />
-          </ToastProvider>,
+          <MemoryRouter initialEntries={['/']}>
+            <ToastProvider>
+              <Dashboard />
+            </ToastProvider>
+          </MemoryRouter>,
         );
       });
 


### PR DESCRIPTION
## Summary
- When sites/traffic are empty, show a **Getting started** strip: 添加站点 → 连接账号 → 同步令牌 with deep links to `/sites`, `/accounts`, `/tokens`.
- Collapse pure-zero KPI noise into a single **尚未产生流量** summary (EmptyState + next-step CTA) until first site/traffic.
- Unify empty chart wells (distribution / trend / observability / sites list) with a shared next-step CTA pattern; token-only styles; reuse EmptyState / ds-btn.

## Test plan
- [x] `npm run typecheck:web` (via worktree-linked node_modules)
- [x] pre-push `go vet` + `go test -race` green
- [ ] Manual: empty DB dashboard shows strip + collapsed KPI + CTAs
- [ ] Manual: with sites/traffic, normal KPI grid restored

Closes #553