### PR TITLE
fix(release): per-tag changelog release notes + fold Unreleased into v0.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Extract changelog section for this tag
+        run: |
+          awk -v ver="$GITHUB_REF_NAME" '
+            index($0, "## [" ver "]") == 1 {found=1; print; next}
+            found && index($0, "## [") == 1 {exit}
+            found {print}
+          ' CHANGELOG.md > release-body.md
+          if [ ! -s release-body.md ]; then
+            echo "no changelog section for $GITHUB_REF_NAME" >&2
+            exit 1
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
-          body_path: CHANGELOG.md
+          body_path: release-body.md
           make_latest: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,35 +5,7 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
-## [Unreleased]
-
-### Added — 品牌与国际化完善
-- 品牌名统一 **MetAPI**（identity-branding / locales / About / index title）
-- 透明 SVG LOGO：`logo.svg`（渐变圆角徽标 + 真 π 字形 U+03C0）+ `favicon.svg`，替换白底 PNG；router 根文件白名单 + 表驱动回归测试扩展 `image/svg+xml`
-- 顶栏语言切换 `LanguageSwitcher`（en/zh-CN）：浏览器语言自动跟随（localStorage → navigator）+ `documentElement.lang`/`dir` 同步（`toBcp47`）；locale 各 1381 key 双向 0 缺失
-- **主题定制面板**：顶栏 Palette 入口，4 轴（10 颜色预设 swatch / 字体 Auto-Sans-Serif / 圆角 6 档 / 缩放 4 档）+ 每轴独立重置 + 全局重置；**全部预设默认无衬线**（Anthropic 不再内联衬线，衬线仅显式选择）；移除遗留 FontProvider 双轨（html class → data-theme-font 单一机制）
-- **侧栏导航 i18n**：导航标题改为 i18n key（sidebar.groups/items/backToHome，en + zh-CN），侧栏随语言切换完整本地化
-
-### Fixed — URL 同步与滚动裁切
-- sites/models/oauth/site-announcements 表格状态经 `useLocation()` 订阅 router location（`searchStr`），排序/分页立即在页面内生效（此前同路径 search 导航不重渲染，表格滞后）
-- authenticated-layout 内容区 `overflow-hidden` 裁切超视口内容 → `overflow-y-auto`（长页面不可滚动）
-- **侧栏导航点击崩溃**：TanStack `Link` 经 Base UI `render` prop 渲染时 React children 泄漏进 `router.navigate`（"Converting circular structure to JSON"）→ `SidebarNavLink` 包装器只透传 DOM-safe props
-- **URL 同步表格参数噪声**：`searchParams.ts` parse/encode 分离，5 个 feature（sites/proxy-logs/models/oauth/site-announcements）search schema 以规范逗号字符串回写 URL，消除 `?sort=%5B%5D` / `?brand=%5B%5D` JSON 序列化噪声；proxy-logs schema 测试同步 encode 语义
-
-### Changed — 文案与视觉润色
-- 文案术语统一（启用/停用、额度、Check-in、通道）、内部计划编号（K1a/N9a 等）移出用户可见文案、tokenRoutes toast/链式横幅拼接 bug 修复、9 处硬编码 → t()（含移除公开设置页的 TokenDance 品牌泄漏）
-- 登录页真实 logo 徽标 + 品牌光晕 + lg CTA；Dashboard 统计卡骨架屏 + 渐变 id 唯一化 + 空/错状态图标化 + WS 连接脉冲指示；设置页移动端响应式 drill-in + sticky 侧栏
-
-### Chore — Git 工作流规范化（GitHub Flow）
-- **分支模型**：master 唯一长期分支（受保护），短命分支（`fix/*`/`feature/*`/`chore/*`/`docs/*`）→ PR → Squash merge；规则文档 `docs/git-workflow.md`
-- **master 分支保护**（GitHub 实际启用）：要求 PR + 11 个 CI 状态检查必选 + enforce admins + 禁强推/删除；不要求 approve（个人项目）
-- **Squash-only 合并**：仓库级关闭 merge commit / rebase merge
-- **PR 模板**：`.github/pull_request_template.md`（改动摘要/类型/测试验证/自查清单）
-- **CI**：ci.yml 移除 `paths-ignore`（必选状态检查与跳过互斥，纯文档 PR 会永久 pending 卡合并）；PR + master push 全量 11 job
-- **移除 update-center 幽灵前端**：`updateCenterReminder.ts`/`updateCenterPresentation.ts` 删除（update-center API 为 501 residual，前端不再渲染）
-
 ## [v0.9.0] — 2026-08-11
-
 ### Added — 前端整体重写（newapi 栈 100% 对齐）
 - 技术栈：Bun + Rsbuild 2 + TanStack Router（文件路由 + validateSearch）+ TanStack Query + Zustand + Tailwind 4（CSS-first 无 config）+ shadcn Base UI + OKLCH 语义 token + HugeIcons/lucide + Public Sans/Lora（@fontsource 本地）+ VChart + recharts + RHF + Zod + i18next + motion/sonner/vaul/cmdk
 - 设计系统：三层 CSS（theme.css + theme-presets.css + index.css）、OKLCH 语义 token、3 轴主题（preset/radius/scale）、10 套预设、圆角单点缩放、Tailwind 4 @theme inline 桥接、cookie 持久化暗色模式
@@ -79,6 +51,31 @@ All notable changes to MetAPI-Go will be documented in this file.
 - 前后端集成：bun build + go:embed 单二进制 + SPA HTML 200
 - sc2_012 dual-dialect 幂等三重保护（schema_migrations 簿记 + columnExists 预检 + ALTER 后再检）
 - 静态门禁：tsgo 0 error + oxlint 0 error + bun run build pass（4462.4 kB / 1385.8 kB gzip）+ vitest 351/351
+
+### Added — 品牌与国际化完善
+- 品牌名统一 **MetAPI**（identity-branding / locales / About / index title）
+- 透明 SVG LOGO：`logo.svg`（渐变圆角徽标 + 真 π 字形 U+03C0）+ `favicon.svg`，替换白底 PNG；router 根文件白名单 + 表驱动回归测试扩展 `image/svg+xml`
+- 顶栏语言切换 `LanguageSwitcher`（en/zh-CN）：浏览器语言自动跟随（localStorage → navigator）+ `documentElement.lang`/`dir` 同步（`toBcp47`）；locale 各 1381 key 双向 0 缺失
+- **主题定制面板**：顶栏 Palette 入口，4 轴（10 颜色预设 swatch / 字体 Auto-Sans-Serif / 圆角 6 档 / 缩放 4 档）+ 每轴独立重置 + 全局重置；**全部预设默认无衬线**（Anthropic 不再内联衬线，衬线仅显式选择）；移除遗留 FontProvider 双轨（html class → data-theme-font 单一机制）
+- **侧栏导航 i18n**：导航标题改为 i18n key（sidebar.groups/items/backToHome，en + zh-CN），侧栏随语言切换完整本地化
+
+### Fixed — URL 同步与滚动裁切
+- sites/models/oauth/site-announcements 表格状态经 `useLocation()` 订阅 router location（`searchStr`），排序/分页立即在页面内生效（此前同路径 search 导航不重渲染，表格滞后）
+- authenticated-layout 内容区 `overflow-hidden` 裁切超视口内容 → `overflow-y-auto`（长页面不可滚动）
+- **侧栏导航点击崩溃**：TanStack `Link` 经 Base UI `render` prop 渲染时 React children 泄漏进 `router.navigate`（"Converting circular structure to JSON"）→ `SidebarNavLink` 包装器只透传 DOM-safe props
+- **URL 同步表格参数噪声**：`searchParams.ts` parse/encode 分离，5 个 feature（sites/proxy-logs/models/oauth/site-announcements）search schema 以规范逗号字符串回写 URL，消除 `?sort=%5B%5D` / `?brand=%5B%5D` JSON 序列化噪声；proxy-logs schema 测试同步 encode 语义
+
+### Changed — 文案与视觉润色
+- 文案术语统一（启用/停用、额度、Check-in、通道）、内部计划编号（K1a/N9a 等）移出用户可见文案、tokenRoutes toast/链式横幅拼接 bug 修复、9 处硬编码 → t()（含移除公开设置页的 TokenDance 品牌泄漏）
+- 登录页真实 logo 徽标 + 品牌光晕 + lg CTA；Dashboard 统计卡骨架屏 + 渐变 id 唯一化 + 空/错状态图标化 + WS 连接脉冲指示；设置页移动端响应式 drill-in + sticky 侧栏
+
+### Chore — Git 工作流规范化（GitHub Flow）
+- **分支模型**：master 唯一长期分支（受保护），短命分支（`fix/*`/`feature/*`/`chore/*`/`docs/*`）→ PR → Squash merge；规则文档 `docs/git-workflow.md`
+- **master 分支保护**（GitHub 实际启用）：要求 PR + 11 个 CI 状态检查必选 + enforce admins + 禁强推/删除；不要求 approve（个人项目）
+- **Squash-only 合并**：仓库级关闭 merge commit / rebase merge
+- **PR 模板**：`.github/pull_request_template.md`（改动摘要/类型/测试验证/自查清单）
+- **CI**：ci.yml 移除 `paths-ignore`（必选状态检查与跳过互斥，纯文档 PR 会永久 pending 卡合并）；PR + master push 全量 11 job
+- **移除 update-center 幽灵前端**：`updateCenterReminder.ts`/`updateCenterPresentation.ts` 删除（update-center API 为 501 residual，前端不再渲染）
 
 ## [v0.8.54] — 2026-08-11
 


### PR DESCRIPTION
Release 页面之前 body 是整个 CHANGELOG.md（含 Unreleased 和全部历史版本），乱。修复：release.yml 提取当前 tag 对应的 changelog 节作为 body；CHANGELOG 的 Unreleased 内容并入 v0.9.0（该 tag 实际已包含这些提交）。