### PR TITLE
chore(repo): community health + repo hygiene for public productization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+
+[*.{ts,tsx,js,jsx,css,scss,json,yml,yaml,md,html,svg}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Normalize line endings for all text files (LF in the repository index)
+* text=auto eol=lf
+
+# Shell scripts must stay LF even on Windows checkouts
+*.sh text eol=lf
+*.ps1 text eol=crlf
+*.bat text eol=crlf
+
+# Binary assets — never treat as text
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -22,18 +22,24 @@ if [ "${delete_only:-0}" = "1" ]; then
 fi
 
 echo "=============================================="
-echo "pre-push: running local CI (vet + frontend + test -race)"
+echo "pre-push: running local CI (build + vet + frontend + test -race)"
 echo "=============================================="
 
-# 1. go vet — fast static analysis
+# 1. go build — compile the server binary first (AGENTS.md gate)
 echo ""
-echo "[1/3] go vet ./..."
+echo "[1/4] go build ./cmd/server"
+go build ./cmd/server
+echo "  ✓ build passed"
+
+# 2. go vet — fast static analysis
+echo ""
+echo "[2/4] go vet ./..."
 go vet ./...
 echo "  ✓ vet passed"
 
-# 2. frontend gate — typecheck + lint + unit tests (skipped when Bun is unavailable)
+# 3. frontend gate — typecheck + lint + unit tests (skipped when Bun is unavailable)
 echo ""
-echo "[2/3] frontend gate (cd web && bun run typecheck && bun run lint && bun run test)"
+echo "[3/4] frontend gate (cd web && bun run typecheck && bun run lint && bun run test)"
 if command -v bun >/dev/null 2>&1; then
 	(cd web && bun run typecheck && bun run lint && bun run test)
 	echo "  ✓ frontend passed"
@@ -41,9 +47,9 @@ else
 	echo "  ⚠ bun not found — skipping frontend gate (CI will cover it)"
 fi
 
-# 3. full test suite with race detector
+# 4. full test suite with race detector
 echo ""
-echo "[3/3] race gate (native Unix, WSL-backed on Windows)"
+echo "[4/4] race gate (native Unix, WSL-backed on Windows)"
 bash ./scripts/go-race.sh
 echo "  ✓ tests passed (-race clean)"
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: 提交缺陷报告（安全问题请走 Security Advisory，不要用此模板）
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: 感谢报告问题。请尽量完整填写，帮助快速定位。
+  - type: input
+    id: version
+    attributes:
+      label: 版本
+      description: 运行版本（镜像 tag、`metapi --version` 输出；源码运行请贴 commit）
+      placeholder: v0.9.0
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: 部署方式
+      options:
+        - Docker 镜像（ghcr.io/deliciousbuding/metapi-go）
+        - docker-compose
+        - 源码构建（go build）
+        - 其他
+    validations:
+      required: true
+  - type: dropdown
+    id: database
+    attributes:
+      label: 数据库
+      options:
+        - SQLite
+        - PostgreSQL
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: 复现步骤
+      description: 触发问题的完整步骤。日志请附在下方并涂抹密钥/Token。
+      placeholder: |
+        1. 打开「站点」页面
+        2. 点击「添加站点」
+        3. 看到报错：……
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 预期行为
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: 实际行为
+      description: 错误信息、截图或日志片段（记得涂抹凭证）
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: 相关日志
+      description: 服务端日志关键片段（无日志可留空）
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/DeliciousBuding/metapi-go/blob/master/README.md
+    about: 先查阅 README 与 docs/ 目录，大部分部署问题在那里有答案
+  - name: Security vulnerability
+    url: https://github.com/DeliciousBuding/metapi-go/security/advisories/new
+    about: 安全问题请通过 Security Advisory 私密报告，勿开公开 issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: 提出新功能或改进建议
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: 功能建议请说明使用场景与期望行为，方便评估优先级。
+  - type: textarea
+    id: problem
+    attributes:
+      label: 要解决什么问题
+      description: 你遇到了什么场景/痛点？
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: 期望的解决方案
+      description: 你希望的行为或 UI 是什么样的？
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 替代方案
+      description: 是否尝试过其他方式解决？

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot — automated dependency updates (Go / npm / Actions / Docker)
+# Each update opens a PR that goes through the same 11-check CI as any other PR.
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      go-modules:
+        patterns: ["*"]
+        update-types: ["patch", "minor"]
+
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      frontend-deps:
+        patterns: ["*"]
+        update-types: ["patch", "minor"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,13 @@ web/dist/
 /dist/
 /metapi-go
 /metapi-go.exe
+*.exe
+
+# Certificates & private keys (never commit)
+*.pem
+*.key
+*.crt
+*.p12
 
 # IDE
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [Unreleased]
+
+### Added — 仓库产品化（社区健康 + CI/CD 硬化 + 多平台发布）
+- 社区文件补齐：CONTRIBUTING.md / SECURITY.md / CODE_OF_CONDUCT.md / issue 模板（bug + feature + config）/ dependabot（Go/npm/Actions/Docker 四通道）
+- 仓库规范化：.gitattributes（LF 统一 + 二进制声明）、.editorconfig、.gitignore 补密钥/证书/通用 exe 规则
+- README（中/英）修正过时数据（369 tests / 1434 i18n keys）、移除私有仓链接、下沉 Windows 防火墙细节、补 star/fork badge 与贡献/安全导航
+- CI 硬化：全 job 超时上限、cd 最小权限、Go 版本单一来源（go-version-file）、bun/govulncheck 版本钉扎、gitleaks 扫全历史、前端 dist 产物跨 job 复用、tag 匹配收紧为 SemVer
+- 发布产品化：Release 并入 CD 流程（镜像推送成功后才建 Release）、多平台二进制附件 + checksums、Docker 镜像 amd64+arm64 双架构、`--version` 版本注入
+- 文档：docs/api.md Update Center 标注 501 residual、docs/README.md 补 responses-websocket-residual.md、CHANGELOG 链接只引用真实 tag
+
 ## [v0.9.0] — 2026-08-11
 ### Added — 前端整体重写（newapi 栈 100% 对齐）
 - 技术栈：Bun + Rsbuild 2 + TanStack Router（文件路由 + validateSearch）+ TanStack Query + Zustand + Tailwind 4（CSS-first 无 config）+ shadcn Base UI + OKLCH 语义 token + HugeIcons/lucide + Public Sans/Lora（@fontsource 本地）+ VChart + recharts + RHF + Zod + i18next + motion/sonner/vaul/cmdk
@@ -717,12 +727,4 @@ All notable changes to MetAPI-Go will be documented in this file.
 - 15 后台调度任务。
 - 单二进制 + Docker 部署。
 
-[v0.6.3]: https://github.com/DeliciousBuding/metapi-go/compare/v0.6.2...v0.6.3
-[v0.6.2]: https://github.com/DeliciousBuding/metapi-go/compare/v0.6.1...v0.6.2
-[v0.6.1]: https://github.com/DeliciousBuding/metapi-go/compare/v0.6.0...v0.6.1
-[v0.6.0]: https://github.com/DeliciousBuding/metapi-go/compare/v0.5.0...v0.6.0
-[v0.5.0]: https://github.com/DeliciousBuding/metapi-go/compare/v0.4.0...v0.5.0
-[v0.4.0]: https://github.com/DeliciousBuding/metapi-go/compare/v0.3.0...v0.4.0
-[v0.3.0]: https://github.com/DeliciousBuding/metapi-go/compare/v0.2.0...v0.3.0
-[v0.2.0]: https://github.com/DeliciousBuding/metapi-go/compare/v0.1.0...v0.2.0
-[v0.1.0]: https://github.com/DeliciousBuding/metapi-go/releases/tag/v0.1.0
+[v0.9.0]: https://github.com/DeliciousBuding/metapi-go/releases/tag/v0.9.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<https://github.com/DeliciousBuding/metapi-go/security/advisories/new> (for
+conduct issues not involving security, a private issue or direct message to the
+maintainer is also fine).
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to MetAPI Go
+
+Thanks for considering a contribution! This project follows a small, explicit
+set of rules so the master branch stays releasable at all times.
+
+## Development setup
+
+- **Go 1.26+** for the backend (`go.mod` pins the exact version).
+- **Bun 1.3+** for the frontend under `web/` (the SPA is pre-built and embedded
+  into the Go binary via `go:embed web/dist`).
+- No Node.js needed for backend work; the frontend build is Bun-only.
+
+Install the local pre-push hook so every push runs the local CI gate first:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook runs `go build`, `go vet`, the frontend gate, and the race-enabled
+test suite. Use `git push --no-verify` only for emergencies — GitHub Actions
+still runs the full 11-check CI on every PR.
+
+## Branch model
+
+GitHub Flow — `master` is the only long-lived branch and is always releasable.
+All work happens on short-lived branches:
+
+| Prefix   | Purpose                      | Example                     |
+|:---------|:-----------------------------|:----------------------------|
+| `feature/` | New features               | `feature/model-tester`      |
+| `fix/`     | Bug fixes                  | `fix/url-sync-nav`          |
+| `perf/`    | Performance                | `perf/dashboard-lazy-load`  |
+| `refactor/`| Refactoring, no behavior change | `refactor/search-params` |
+| `chore/`   | Engineering (CI, deps, cleanup) | `chore/ci-hardening`     |
+| `docs/`    | Documentation              | `docs/git-workflow`         |
+
+Never commit directly to `master` — branch protection requires a PR.
+
+## Local gates before pushing
+
+```bash
+go build ./cmd/server
+go vet ./...
+go test ./... -count=1 -race        # backend suite with race detector
+cd web && bun install                # once
+cd web && bun run typecheck && bun run lint && bun run test && bun run knip
+cd web && bun run format:check       # oxfmt
+make docs-hygiene                    # public-markdown hygiene (no local paths/secrets)
+```
+
+TL;DR: `make verify` covers the Go side; `make verify-race` adds the race
+detector. The pre-push hook runs all of it automatically.
+
+## Pull requests
+
+1. Branch from `master`, commit with [Conventional Commits](https://www.conventionalcommits.org/).
+2. Open a PR against `master` — the template is auto-filled; keep the summary
+   about *why*, not a file-by-file list.
+3. All 11 required CI checks must pass (they run on every PR, docs-only PRs
+   included — no `paths-ignore` shortcuts).
+4. PRs are **squash merged** (merge commits are disabled). The PR title becomes
+   the commit message, so make it a good Conventional Commit line.
+
+## Conventions to keep in mind
+
+- **API contract**: JSON responses use camelCase fields; env var names are
+  identical to the original TypeScript MetAPI (no prefix). Do not invent new
+  env var names or break the wire format.
+- **Dual dialect**: SQLite (dev/test) and PostgreSQL (production) are both
+  supported — never write SQLite-only SQL. `store.Open(dialect, dsn)` is the
+  entry point.
+- **Frontend i18n**: all user-facing text goes through `t()` keys in
+  `web/src/i18n/locales/{en,zh-CN}.json` — both languages must stay in sync
+  (checked by `web/src/i18n/__tests__/i18n-keys.test.ts`).
+- **Docs**: user-facing behavior changes update `docs/STATE.md` /
+  `docs/progress/MASTER.md` / `CHANGELOG.md`. Public docs must never contain
+  local paths, private hostnames, or credentials (`make docs-hygiene` enforces
+  this).
+- **Single binary**: the production image ships no Node/Bun runtime. Don't
+  add npm scripts to the runtime path.
+
+## Reporting issues & security
+
+- Bug reports: use the issue templates (bug / feature request).
+- Security vulnerabilities: **do not open a public issue** — report privately
+  via GitHub Security Advisory, see [`SECURITY.md`](SECURITY.md).
+- Questions: prefer opening a discussion over an issue.
+
+## Code of conduct
+
+By participating you agree to the [Contributor Covenant](CODE_OF_CONDUCT.md).
+
+## License
+
+MIT — by contributing you agree that your contributions are licensed under
+the same terms as the repository.

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ lint:
 
 # Run dependency vulnerability scan
 vuln:
-	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+	go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
 
 # Verify downloaded modules match go.sum checksums
 mod-verify:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 <p align="center">
   <a href="https://github.com/DeliciousBuding/metapi-go/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/DeliciousBuding/metapi-go/actions/workflows/ci.yml/badge.svg?branch=master"></a>
   <a href="https://github.com/DeliciousBuding/metapi-go/releases/latest"><img alt="Release" src="https://img.shields.io/github/v/release/DeliciousBuding/metapi-go?logo=github&label=release&color=blue"></a>
+  <a href="https://github.com/DeliciousBuding/metapi-go/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/DeliciousBuding/metapi-go?style=social"></a>
+  <a href="https://github.com/DeliciousBuding/metapi-go/forks"><img alt="Forks" src="https://img.shields.io/github/forks/DeliciousBuding/metapi-go?style=social"></a>
   <img alt="Go" src="https://img.shields.io/badge/Go-1.26.5-00ADD8?logo=go">
   <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react">
   <img alt="Bun" src="https://img.shields.io/badge/Bun-≥1.0-000000?logo=bun&logoColor=white">
@@ -120,12 +122,7 @@ go build -o metapi ./cmd/server
 AUTH_TOKEN=admin PROXY_TOKEN=proxy-token ./metapi
 ```
 
-Windows 本地运行且未设置 `HOST` 时，默认仅监听 `127.0.0.1`，避免 `go run` 或临时构建路径反复触发入站防火墙提示。需要局域网访问时显式设置 `HOST=0.0.0.0`，并自行收紧防火墙范围。历史临时二进制遗留规则可先审计，再精确清理：
-
-```powershell
-.\scripts\windows-firewall-maintenance.ps1 -Mode Audit
-.\scripts\windows-firewall-maintenance.ps1 -Mode Cleanup -Elevate
-```
+Windows 本地运行且未设置 `HOST` 时，默认仅监听 `127.0.0.1`，避免 `go run` 或临时构建路径反复触发入站防火墙提示。需要局域网访问时显式设置 `HOST=0.0.0.0`，并自行收紧防火墙范围。
 
 ---
 
@@ -240,7 +237,7 @@ v0.9.0 起前端 100% 对齐 [New API](https://github.com/QuantumNous/new-api) �
 - **13 个 feature 模块**：`auth`、`dashboard`（4 section + RealtimeOps WebSocket）、`sites`（引导式配置动线 站点→账号→路由）、`accounts`、`token-routes`（dnd-kit 拖拽）、`oauth`、`checkin`（嵌套响应解构 + 失败原因分类 badge）、`proxy-logs`（manual + 服务端分页 + 详情 Sheet）、`models`、`model-tester`（SSE 全协议流式）、`site-announcements`、`about`、`settings`（5 子区 drill-in）。
 - **data-table 四层架构**：`core`（TanStack table 渲染原语）+ `layout`（响应式页面组合）+ `toolbar`（filter/search/批量操作）+ `static`（本地数组轻量渲染）+ `hooks`（受控状态层，URL 三段式同步）。feature 经统一 `index.ts` 导入，专属列/动作留在各 feature 目录。
 - **OKLCH 设计系统**：三层 CSS（`theme.css` 语义 token + `theme-presets.css` 10 套预设 + `index.css` Tailwind 4 入口）；3 轴主题（preset/radius/scale）经 `<body data-theme-*>` 切换；暗色 class-based + cookie 持久化。图表取色用 JS 读 OKLCH token，MutationObserver 监听主题变化重采样。
-- **key-based i18n**：i18next + react-i18next，支持 `en` + `zh-CN`（各 ~900 key，双向 0 缺失）；React 组件 `useTranslation()` + `t()`，非 React 模块用 `i18n.t()`；key 双向一致性由 `web/src/i18n/__tests__/i18n-keys.test.ts` 校验。
+- **key-based i18n**：i18next + react-i18next，支持 `en` + `zh-CN`（各 1434 key，双向 0 缺失）；React 组件 `useTranslation()` + `t()`，非 React 模块用 `i18n.t()`；key 双向一致性由 `web/src/i18n/__tests__/i18n-keys.test.ts` 校验。
 
 ---
 
@@ -294,7 +291,7 @@ bun run dev            # 本地开发（rsbuild dev，/api /v1 代理到后端�
 bun run typecheck      # tsgo 类型检查
 bun run lint           # oxlint
 bun run lint:fix       # oxlint --fix
-bun run test           # vitest run（全量，当前 361 tests）
+bun run test           # vitest run（全量，当前 369 tests / 38 files）
 bun run knip           # 未使用代码检测
 bun run build          # rsbuild build（产物经 go:embed 打包进 Go 二进制）
 bun run build:check    # tsgo + build（发布前完整检查）
@@ -302,6 +299,24 @@ bun run format:check   # oxfmt 格式检查
 ```
 
 Dev proxy 默认指向 `http://localhost:4000`，可经 `DEV_PROXY_TARGET` / `VITE_DEV_PROXY_TARGET` / `PORT` / `VITE_BACKEND_PORT` 覆盖。
+
+### Windows 本地运行
+
+默认监听 `127.0.0.1`（避免 `go run` 或临时构建路径反复触发入站防火墙提示）。历史遗留的防火墙放行规则可先审计、再精确清理：
+
+```powershell
+.\scripts\windows-firewall-maintenance.ps1 -Mode Audit
+.\scripts\windows-firewall-maintenance.ps1 -Mode Cleanup -Elevate
+```
+
+---
+
+## 贡献与安全
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — 分支模型、PR 流程、本地门禁
+- [SECURITY.md](SECURITY.md) — 漏洞报告（Security Advisory）
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — 社区行为准则
+- [docs/git-workflow.md](docs/git-workflow.md) — Git 分支与保护规则
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -16,6 +16,8 @@
 <p align="center">
   <a href="https://github.com/DeliciousBuding/metapi-go/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/DeliciousBuding/metapi-go/actions/workflows/ci.yml/badge.svg?branch=master"></a>
   <a href="https://github.com/DeliciousBuding/metapi-go/releases/latest"><img alt="Release" src="https://img.shields.io/github/v/release/DeliciousBuding/metapi-go?logo=github&label=release&color=blue"></a>
+  <a href="https://github.com/DeliciousBuding/metapi-go/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/DeliciousBuding/metapi-go?style=social"></a>
+  <a href="https://github.com/DeliciousBuding/metapi-go/forks"><img alt="Forks" src="https://img.shields.io/github/forks/DeliciousBuding/metapi-go?style=social"></a>
   <img alt="Go" src="https://img.shields.io/badge/Go-1.26.5-00ADD8?logo=go">
   <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react">
   <img alt="Bun" src="https://img.shields.io/badge/Bun-≥1.0-000000?logo=bun&logoColor=white">
@@ -79,7 +81,7 @@ As of v0.9.0 the frontend is 100% aligned with the [New API](https://github.com/
 - **13 feature modules**: `auth`, `dashboard` (4 sections + RealtimeOps WebSocket), `sites` (guided setup: site→account→route), `accounts`, `token-routes` (dnd-kit drag), `oauth`, `checkin` (nested response destructuring + failure-reason badges), `proxy-logs` (manual + server pagination + detail Sheet), `models`, `model-tester` (SSE streaming, all protocols), `site-announcements`, `about`, `settings` (5 sub-areas).
 - **data-table four-layer architecture**: `core` (TanStack table primitives) + `layout` (responsive composition) + `toolbar` (filter/search/bulk actions) + `static` (local-array rendering) + `hooks` (controlled state, URL three-segment sync).
 - **OKLCH design system**: three-layer CSS (`theme.css` semantic tokens + `theme-presets.css` 10 presets + `index.css` Tailwind 4 entry); 3-axis theming (preset/radius/scale) via `<body data-theme-*>`; class-based dark mode with cookie persistence. Chart colors sampled from OKLCH tokens in JS with MutationObserver re-sampling on theme change.
-- **Key-based i18n**: i18next + react-i18next, supports `en` + `zh-CN` (~900 keys each, zero missing in either direction); React components use `useTranslation()` + `t()`, non-React modules use `i18n.t()`.
+- **Key-based i18n**: i18next + react-i18next, supports `en` + `zh-CN` (1434 keys each, zero missing in either direction); React components use `useTranslation()` + `t()`, non-React modules use `i18n.t()`.
 
 ## Proxy Usage
 
@@ -111,13 +113,6 @@ All env vars are identical to the TypeScript version.
 | `ADMIN_CORS_ALLOWED_ORIGINS` | empty; comma-separated exact `http(s)` admin browser origins allowed to call `/api/*`; `*` is rejected |
 
 Full list: [`.env.example`](.env.example).
-
-On Windows, the loopback default avoids repeated inbound-firewall prompts from changing `go run` or temporary build paths. Set `HOST=0.0.0.0` only for intentional LAN exposure. Audit and precisely remove stale MetAPI executable rules with:
-
-```powershell
-.\scripts\windows-firewall-maintenance.ps1 -Mode Audit
-.\scripts\windows-firewall-maintenance.ps1 -Mode Cleanup -Elevate
-```
 
 The runtime supports two database modes: single-process SQLite and PostgreSQL for production deployments. In PostgreSQL mode, side-effecting schedulers such as external requests, notifications, uploads, cleanup, and sync jobs use PG advisory locks so multiple replicas do not run the same job batch at the same time. Optional `REDIS_URL` / `METAPI_REDIS_URL` enables multi-instance shared **RPM/TPM admission** counters only (`auth.ConfigureSharedAdmissionFromRedisURL` + `internal/sharedcount`; fail-open to process-local windows if Redis is unreachable). Leave empty for single-node — no Redis process required. Sticky sessions remain process-local and are **not** shared across instances via Redis today (STICKY-B is residual, not product). See [`docs/analysis/redis-shared-state.md`](docs/analysis/redis-shared-state.md).
 
@@ -169,7 +164,7 @@ bun run dev            # local dev (rsbuild dev, /api /v1 proxied to backend, de
 bun run typecheck      # tsgo type check
 bun run lint           # oxlint
 bun run lint:fix       # oxlint --fix
-bun run test           # vitest run (currently 361 tests)
+bun run test           # vitest run (currently 369 tests / 38 files)
 bun run knip           # detect unused code
 bun run build          # rsbuild build (output embedded into Go binary via go:embed)
 bun run build:check    # tsgo + build (full pre-release check)
@@ -181,7 +176,12 @@ Dev proxy defaults to `http://localhost:4000`; override via `DEV_PROXY_TARGET` /
 ## Related Projects
 
 - [MetAPI (TypeScript)](https://github.com/cita-777/metapi) — Original Node.js implementation
-- [TokenDance Gateway](https://github.com/DeliciousBuding/tokendance-gateway) — Production NewAPI fork
+
+## Contributing & Security
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — branch model, PR flow, local gates
+- [SECURITY.md](SECURITY.md) — vulnerability reporting (Security Advisory)
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — community guidelines
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+MetAPI Go is a self-hosted API gateway. We take security seriously and
+appreciate responsible disclosure.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Report privately using GitHub's **Security Advisory** flow:
+
+1. Go to <https://github.com/DeliciousBuding/metapi-go/security/advisories/new>
+   (or the repo's **Security → Report a vulnerability** tab).
+2. Include as much as possible:
+   - Affected version (image tag, `metapi --version`, or commit hash).
+   - Deployment mode (Docker image / docker-compose / source build) and
+     database (SQLite / PostgreSQL).
+   - A minimal reproduction (steps, request samples — redact any real tokens).
+   - Impact assessment, if you have one.
+
+All reports are kept private until a fix is available.
+
+## Response expectations
+
+| Step | Target |
+|:-----|:-------|
+| Initial acknowledgement | Within 3 business days |
+| Triage and severity assessment | Within 10 business days |
+| Fix release for critical/high | As soon as possible, coordinated with the reporter |
+
+We will keep the reporter informed of progress and credit them in the release
+notes (unless anonymity is requested).
+
+## Scope
+
+- The `metapi` server itself (admin API, proxy layer, routing, auth, store).
+- The embedded frontend (React SPA).
+- The Docker image and build pipeline.
+
+Out of scope: misconfiguration of your own deployment (weak `AUTH_TOKEN`,
+exposed ports, etc.) — please check the deployment docs and harden your
+environment. General questions belong in issues or discussions, not
+advisories.
+
+## Self-hosting reminder
+
+This is a self-hosted product: all credentials and traffic live on your own
+server. Do not expose the admin UI or proxy port to the public internet
+without a reverse proxy, TLS, and strong `AUTH_TOKEN` / `PROXY_TOKEN` values.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@
 | Deploy / ops vars | [`deployment.md`](deployment.md) |
 | HTTP API | [`api.md`](api.md) |
 | Git branch & PR workflow | [`git-workflow.md`](git-workflow.md) |
+| Contribute / report | root [`CONTRIBUTING.md`](../CONTRIBUTING.md) · [`SECURITY.md`](../SECURITY.md) |
 
 ## Layout
 
@@ -38,6 +39,7 @@ docs/
   deployment.md             ← run / Docker / ops vars
   git-workflow.md           ← branch model / PR / protection rules
   migration.md              ← SQLite → PG / schema upgrade
+  responses-websocket-residual.md ← Responses API WS transport (501 residual)
   design/                   ← living design source of truth
     BACKEND.md                backend design philosophy, dependency rules
     DESIGN.md                 design system, tokens, visual language

--- a/docs/api.md
+++ b/docs/api.md
@@ -461,6 +461,8 @@ Update checkin schedule (cron or interval mode).
 
 ## Update Center
 
+> **501 residual**：本组接口当前返回 501（未实现）。版本更新提示走 GitHub Releases / GHCR 镜像 tag，前端不依赖此 API。详见 [`STATE.md`](STATE.md)。
+
 ### GET /api/update-center/status
 
 Get update center status.

--- a/docs/doc_hygiene_test.go
+++ b/docs/doc_hygiene_test.go
@@ -13,6 +13,9 @@ var (
 	unixHomePathRE     = regexp.MustCompile(`/(?:Users|home)/[^/\s` + "`" + `]+`)
 	dsnWithPasswordRE  = regexp.MustCompile(`(?i)\b(?:postgres(?:ql)?|mysql)://([^:\s` + "`" + `/]+):([^@\s` + "`" + `]+)@([^\s` + "`" + `/]+)`)
 	aiArtifactRE       = regexp.MustCompile(`(?i)(contentReference\[oaicite:|oai_citation|citeturn\d+search\d+|grok_card|utm_source=(?:chatgpt\.com|copilot\.com|openai|claude\.ai|perplexity\.ai))`)
+	// Public markdown must only link public repositories under this owner.
+	// Private deployment forks (e.g. tokendance-gateway) must never be cited.
+	ownerRepoLinkRE = regexp.MustCompile(`(?i)github\.com/DeliciousBuding/([A-Za-z0-9_.-]+)`)
 )
 
 func TestPublicMarkdownHygiene(t *testing.T) {
@@ -29,7 +32,7 @@ func TestPublicMarkdownHygiene(t *testing.T) {
 			// covers published tree paths (CI clones are clean; local worktrees
 			// under .claude/ must not fail public docs gates).
 			if name == ".git" || name == "node_modules" || name == "dist" ||
-				name == ".claude" || name == "worktrees" {
+				name == ".claude" || name == ".worktrees" {
 				return filepath.SkipDir
 			}
 			return nil
@@ -53,6 +56,8 @@ func TestPublicMarkdownHygiene(t *testing.T) {
 				findings = append(findings, formatFinding(rel, lineNo, "local Unix home path", line))
 			case aiArtifactRE.MatchString(line):
 				findings = append(findings, formatFinding(rel, lineNo, "AI citation or tracking artifact", line))
+			case hasPrivateRepoLink(line):
+				findings = append(findings, formatFinding(rel, lineNo, "link to a non-public repository under DeliciousBuding", line))
 			case dsnWithPasswordRE.MatchString(line) && !isAllowedExampleDSN(line):
 				findings = append(findings, formatFinding(rel, lineNo, "credential-bearing DSN without placeholders", line))
 			case looksLikeRedisSupportedClaim(line):
@@ -98,6 +103,19 @@ func mustRel(t *testing.T, root, path string) string {
 
 func formatFinding(path string, line int, kind string, text string) string {
 	return path + ":" + itoa(line) + ": " + kind + ": " + strings.TrimSpace(text)
+}
+
+func hasPrivateRepoLink(line string) bool {
+	matches := ownerRepoLinkRE.FindAllStringSubmatch(line, -1)
+	for _, match := range matches {
+		// metapi-go itself is the only public repository under this owner.
+		// Strip a trailing ".git" (clone URLs) before comparing.
+		repo := strings.TrimSuffix(strings.ToLower(match[1]), ".git")
+		if repo != "metapi-go" {
+			return true
+		}
+	}
+	return false
 }
 
 func isAllowedExampleDSN(line string) bool {

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -46,7 +46,7 @@ master (唯一长期分支，受保护，随时可发布)
 
 1. 从 master 切分支：`git checkout -b fix/xxx`
 2. 本地门禁全绿后提交（Conventional Commits 风格，见 §5），`git push -u origin fix/xxx`
-   - push 前 `.githooks/pre-push` 自动跑本地 CI（vet + 前端门禁 + race）；紧急跳过 `git push --no-verify`
+   - push 前 `.githooks/pre-push` 自动跑本地 CI（`go build` + `go vet` + 前端门禁 + `-race` 测试）；安装：`git config core.hooksPath .githooks`；紧急跳过 `git push --no-verify`
 3. 开 PR（`gh pr create`，模板自动填充），base = master
 4. CI 11 job 全绿（含 PG 集成测试）后 Squash merge
 5. 合并时把 PR 标题改写为最终提交信息（符合 Conventional Commits）
@@ -84,6 +84,6 @@ master (唯一长期分支，受保护，随时可发布)
 | CI | `.github/workflows/ci.yml` | PR + master push 全量 11 job |
 | CD | `.github/workflows/cd.yml` | master push + tag 发布镜像 |
 | Release | `.github/workflows/release.yml` | tag 建 Release |
-| 本地门禁 | `.githooks/pre-push` | push 前自动运行 |
+| 本地门禁 | `.githooks/pre-push` | `git config core.hooksPath .githooks` 安装后 push 前自动运行（build + vet + 前端 + race） |
 
 相关文档：[`deployment.md`](deployment.md)（部署）· [`STATE.md`](STATE.md)（当前状态）· `AGENTS.md`（工程规则）


### PR DESCRIPTION
## Summary

把仓库补齐到"公开产品化"标准，4 个扫描面（Git 配置 / CI-CD / 社区文档 / 发布面）的社区部分。

- **社区健康文件**：CONTRIBUTING.md（分支模型/PR 流程/本地门禁）、SECURITY.md（Security Advisory 漏洞披露 + 响应承诺）、CODE_OF_CONDUCT.md（Contributor Covenant 2.1）
- **Issue 模板**：bug_report.yml（版本/部署方式/DB/复现步骤）+ feature_request.yml + config.yml
- **Dependabot**：Go / npm(web) / GitHub Actions / Docker 四通道自动更新
- **仓库规范化**：.gitattributes（LF 统一 + 二进制声明）、.editorconfig、.gitignore 补 `*.pem/*.key/*.crt/*.p12` + 通用 `*.exe`
- **README 修正**（中/英）：369 tests / 1434 i18n keys（实测）、移除私有仓链接（tokendance-gateway 404）、Windows 防火墙细节下沉到开发节、star/fork badge、贡献与安全导航
- **docs**：Update Center 标注 501 residual、文档地图补 responses-websocket-residual.md、CHANGELOG 恢复 Unreleased 段 + 链接只保留真实 tag、pre-push hook 补 `go build`（对齐 AGENTS.md 门禁）、govulncheck 钉 v1.6.0
- **docs-hygiene 加固**：拒绝引用 DeliciousBuding 名下非公开仓库 + 修复 `.worktrees` 跳过（原写错为 `worktrees`）

## 自查

- [x] go vet / docs-hygiene 本地通过
- [x] 无内部路径/密钥泄漏（gitleaks 白名单内的测试占位除外）