### PR TITLE
chore(release): prepare v0.10.0 (settings v2 UI/UX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to MetAPI-Go will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.10.0] — 2026-08-12
+
 ### Added
 - Versioned `ScheduleSpec` v1 for daily, interval, random-window, and custom Cron schedules, with additive preview/apply migration endpoints that preserve every legacy key.
 - Unified settings form actions, load-error states, dirty navigation guards, semantic schedule controls, and responsive settings navigation.

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metapi",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "description": "Meta-layer management and unified proxy for AI API aggregation platforms",
   "keywords": [


### PR DESCRIPTION
## Summary

Release prep for **v0.10.0**, the first SemVer tag carrying the settings workspace v2 + design-system alignment work (merged via #580).

## Changes

- **CHANGELOG.md**: promoted the accumulated `[Unreleased]` entries (settings v2, ScheduleSpec v1, audit-log pagination, design tokens, a11y CI gate, announcement-banner dismissal persistence, brand/i18n polish, Git-workflow/CI-CD hardening) into a `## [v0.10.0] — 2026-08-12` section; added a fresh empty `[Unreleased]` for future work.
- **web/package.json**: `0.9.0` → `0.10.0`.

## Why now

- `master` now contains the full settings v2 UI/UX work but no release tag points at it (latest tag/release is `v0.9.0`, which predates it).
- The CD pipeline (`cd.yml`) builds/pushes the multi-platform GHCR image (`linux/amd64,linux/arm64` + provenance/SBOM) and attaches 5-target release binaries + checksums for SemVer tags; tagging `v0.10.0` after this merge will exercise that path end-to-end.

## Validation

- `package.json` remains valid JSON; CHANGELOG section header matches the release-extraction format (`## [vX.Y.Z] — YYYY-MM-DD`).
- No source changes; CI on this PR runs the standard frontend + Go checks.