### PR TITLE
ci(cd): fix release binary build (frontend missing) + pin toolchains

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -101,6 +101,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
       - uses: docker/setup-buildx-action@v4
 
       - uses: docker/login-action@v4
@@ -180,6 +188,11 @@ jobs:
       # ---- Release (tag pushes only) ----
       # The GitHub Release is created here, after the image push succeeded,
       # so a published Release always points at a real ghcr.io tag.
+      - name: Build frontend for release binaries
+        if: startsWith(github.ref, 'refs/tags/v')
+        working-directory: web
+        run: bun install --frozen-lockfile && bun run build:web
+
       - name: Build multi-platform release binaries
         if: startsWith(github.ref, 'refs/tags/v')
         run: |


### PR DESCRIPTION
## What

CD #410 (v0.10.0 tag) failed at \Build multi-platform release binaries\:

\\\
web/embed.go:13:12: pattern dist: no matching files found
\\\

\web/embed.go\ embeds \web/dist\ (gitignored), and the binary step ran bare \go build\ on the runner with no frontend build — so \./cmd/server\ could not compile. The Docker image path was unaffected because the Dockerfile builds the SPA in a build stage.

## Changes (cd.yml, build-and-push job)

1. Add \ctions/setup-go@v5\ (pins Go from go.mod instead of relying on the runner's preinstalled toolchain + auto-download).
2. Add \oven-sh/setup-bun@v2\ and build the real \web/dist\ before compiling the 5 release binaries (tag pushes only), so release binaries embed the actual SPA — not the placeholder used by CI type-checks.

## Validation

- YAML parses.
- CD #410 log confirms the only failure was \pattern dist: no matching files found\ (release-gate ✅, image push ✅).
- After merge: re-tag v0.10.0 and re-run CD to create the v0.10.0 GitHub Release with 10 binaries + checksums.