### PR TITLE
docs(state): bump last-verified date

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,6 +1,6 @@
 # STATE.md — MetAPI Go product status
 
-**Last verified**: 2026-08-11
+**Last verified**: 2026-08-12
 
 > **Current state** (product repository). Only current facts and pointers, no narrative.
 > Deployment facts live in the deployment guide; open items → [`progress/MASTER.md`](progress/MASTER.md) · timeline → [`log.md`](log.md) · version narrative → root [`CHANGELOG.md`](../CHANGELOG.md)


### PR DESCRIPTION
STATE.md facts were verified live on 2026-08-12 (v0.10.0 release + single-pipeline main.yml); sync the header date.