### PR TITLE
ci(workflow): bump upload/download-artifact + build-push-action majors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
       # The real dist is reused by test-sqlite/test-pg (SPA-fallback tests),
       # instead of each test job rebuilding the frontend.
       - name: Upload web dist for test jobs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: web-dist
           path: web/dist
@@ -152,7 +152,7 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
       - name: Download frontend dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: web-dist
           path: web/dist
@@ -200,7 +200,7 @@ jobs:
       # SPA-fallback and static-asset tests exercise the real embedded dist,
       # built once by the frontend job and passed through the artifact.
       - name: Download frontend dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: web-dist
           path: web/dist
@@ -231,7 +231,7 @@ jobs:
       # SPA-fallback and static-asset tests exercise the real embedded dist,
       # built once by the frontend job and passed through the artifact.
       - name: Download frontend dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: web-dist
           path: web/dist
@@ -277,7 +277,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: docker/setup-buildx-action@v4
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -345,7 +345,7 @@ jobs:
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=sha,prefix=,format=short,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
Consolidated from dependabot PRs #585/#586/#587 into one PR (each was blocked by branch-protection 'up to date' churn after #584 merged). Same three action major bumps, one CI run:

- actions/upload-artifact v4 → v7
- actions/download-artifact v4 → v8 (3 uses)
- docker/build-push-action v6 → v7 (2 uses)

Supersedes: #585 #586 #587