### PR TITLE
feat(observability): access-log outcome fields + slog panic recovery + go runtime metrics

### DIFF
--- a/handler/shared/metrics.go
+++ b/handler/shared/metrics.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"fmt"
 	"net/http"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -26,7 +27,7 @@ type MetricsCollector struct {
 	routeRebuildOK     atomic.Int64
 	// Streams that requested include_usage but ended without usable tokens (known limitation).
 	streamMissingUsageTotal atomic.Int64
-	startTime          time.Time
+	startTime               time.Time
 
 	// Labeled outcomes + latency histograms (low-cardinality only).
 	outcomesMu sync.Mutex
@@ -169,7 +170,6 @@ func RecordStreamMissingUsage() { globalMetrics.streamMissingUsageTotal.Add(1) }
 
 // StreamMissingUsageTotal returns the missing-usage counter (tests/ops).
 func StreamMissingUsageTotal() int64 { return globalMetrics.streamMissingUsageTotal.Load() }
-
 
 // ObserveProxyOutcome records a terminal proxy outcome: labeled counter, latency
 // histogram, legacy error counter (when not success), and optional Observer hook.
@@ -491,6 +491,39 @@ func WritePrometheusMetrics(w http.ResponseWriter) error {
 			k.endpoint, k.status, h.count)
 	}
 	m.histMu.Unlock()
+
+	// Go runtime + memory metrics (stdlib only; keeps the zero-dependency design).
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	appendLine("# HELP go_goroutines Number of goroutines that currently exist\n")
+	appendLine("# TYPE go_goroutines gauge\n")
+	appendLine("go_goroutines %d\n", runtime.NumGoroutine())
+
+	appendLine("# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use\n")
+	appendLine("# TYPE go_memstats_alloc_bytes gauge\n")
+	appendLine("go_memstats_alloc_bytes %d\n", ms.Alloc)
+
+	appendLine("# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use\n")
+	appendLine("# TYPE go_memstats_heap_alloc_bytes gauge\n")
+	appendLine("go_memstats_heap_alloc_bytes %d\n", ms.HeapAlloc)
+
+	appendLine("# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use\n")
+	appendLine("# TYPE go_memstats_heap_inuse_bytes gauge\n")
+	appendLine("go_memstats_heap_inuse_bytes %d\n", ms.HeapInuse)
+
+	appendLine("# HELP go_memstats_heap_objects Number of allocated objects\n")
+	appendLine("# TYPE go_memstats_heap_objects gauge\n")
+	appendLine("go_memstats_heap_objects %d\n", ms.HeapObjects)
+
+	appendLine("# HELP go_memstats_sys_bytes Number of bytes obtained from system\n")
+	appendLine("# TYPE go_memstats_sys_bytes gauge\n")
+	appendLine("go_memstats_sys_bytes %d\n", ms.Sys)
+
+	appendLine("# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles\n")
+	appendLine("# TYPE go_gc_duration_seconds summary\n")
+	appendLine("go_gc_duration_seconds_sum %g\n", float64(ms.PauseTotalNs)/1e9)
+	appendLine("go_gc_duration_seconds_count %d\n", ms.NumGC)
 
 	_, err := w.Write(b)
 	return err

--- a/handler/shared/metrics_test.go
+++ b/handler/shared/metrics_test.go
@@ -215,3 +215,22 @@ func TestStatusFromHTTP(t *testing.T) {
 		t.Fatal("502")
 	}
 }
+
+func TestGoRuntimeMetricsExposed(t *testing.T) {
+	ResetMetricsForTest()
+	rec := httptest.NewRecorder()
+	if err := WritePrometheusMetrics(rec); err != nil {
+		t.Fatalf("WritePrometheusMetrics: %v", err)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"# TYPE go_goroutines gauge",
+		"# TYPE go_memstats_alloc_bytes gauge",
+		"# TYPE go_memstats_heap_inuse_bytes gauge",
+		"# TYPE go_gc_duration_seconds summary",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q", want)
+		}
+	}
+}

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -1,15 +1,20 @@
 package router
 
 import (
+	"bufio"
+	"errors"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/netip"
+	"runtime/debug"
 	"strings"
+	"time"
 
+	"github.com/deliciousbuding/metapi-go/config"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
-	"github.com/deliciousbuding/metapi-go/config"
 )
 
 // CORS returns a CORS middleware handler configured for MetAPI.
@@ -41,20 +46,69 @@ func corsOptions(allowedOrigins []string) cors.Options {
 	}
 }
 
-// RequestLogger logs every incoming request using slog.
+// RequestLogger logs every incoming request using slog after it completes,
+// including status, duration, and bytes written for latency/error triage.
 // Includes request_id for log correlation when RequestID middleware is active.
-// Equivalent to TS Fastify `logger: true`.
+// Equivalent to TS Fastify `logger: true`, extended with outcome fields.
 func RequestLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
 		reqID := middleware.GetReqID(r.Context())
+		sw := &statusRecorder{
+			WrapResponseWriter: middleware.NewWrapResponseWriter(w, r.ProtoMajor),
+		}
+		next.ServeHTTP(sw, r)
+
+		status := sw.Status()
+		if status == 0 {
+			status = http.StatusOK
+		}
 		slog.Info("request",
 			"method", r.Method,
 			"path", r.URL.Path,
 			"remote", r.RemoteAddr,
 			"request_id", reqID,
+			"status", status,
+			"bytes", sw.BytesWritten(),
+			"duration_ms", float64(time.Since(start).Microseconds())/1000.0,
 		)
-		next.ServeHTTP(w, r)
 	})
+}
+
+// statusRecorder wraps a chi WrapResponseWriter and forwards the optional
+// http.ResponseWriter interfaces that chi's interface does not expose. The
+// proxy SSE path opts out of the server-level WriteTimeout via SetWriteDeadline
+// (handler/proxy/upstream.go), SSE needs Flush, and WebSocket upgrades need
+// Hijack — dropping any of these would silently break streaming.
+type statusRecorder struct {
+	middleware.WrapResponseWriter
+}
+
+func (s *statusRecorder) Flush() {
+	if f, ok := s.WrapResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (s *statusRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := s.WrapResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, errors.New("statusRecorder: underlying writer does not support hijacking")
+}
+
+func (s *statusRecorder) ReadFrom(r io.Reader) (int64, error) {
+	if rf, ok := s.WrapResponseWriter.(io.ReaderFrom); ok {
+		return rf.ReadFrom(r)
+	}
+	return io.Copy(s.WrapResponseWriter, r)
+}
+
+func (s *statusRecorder) SetWriteDeadline(t time.Time) error {
+	if rc, ok := s.Unwrap().(interface{ SetWriteDeadline(time.Time) error }); ok {
+		return rc.SetWriteDeadline(t)
+	}
+	return nil
 }
 
 // TrustedRealIP reads X-Forwarded-For / X-Real-IP only from explicitly
@@ -129,10 +183,28 @@ func normalizeForwardedIP(raw string) string {
 	return addr.Unmap().String()
 }
 
-// Recoverer catches panics and returns 500.
-// Equivalent to TS Fastify default error handling.
+// Recoverer catches panics, logs the panic + stack via slog (with request_id
+// for correlation), and returns 500. Equivalent to chi middleware.Recoverer but
+// keeps panic diagnostics in the structured log instead of stderr.
 func Recoverer(next http.Handler) http.Handler {
-	return middleware.Recoverer(next)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rv := recover(); rv != nil {
+				if rv == http.ErrAbortHandler {
+					panic(rv)
+				}
+				slog.Error("panic recovered",
+					"panic", rv,
+					"method", r.Method,
+					"path", r.URL.Path,
+					"request_id", middleware.GetReqID(r.Context()),
+					"stack", string(debug.Stack()),
+				)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
 }
 
 // BodyLimit enforces a maximum request body size using http.MaxBytesReader.

--- a/router/middleware_test.go
+++ b/router/middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/deliciousbuding/metapi-go/config"
 )
@@ -67,4 +68,91 @@ func TestTrustedRealIPIgnoresForwardedHeaderFromUntrustedPeer(t *testing.T) {
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("status = %d", rec.Code)
 	}
+}
+
+func TestRequestLoggerCapturesStatusAndBytes(t *testing.T) {
+	var gotStatus, gotBytes int
+	handler := RequestLogger(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("hello"))
+		sw, ok := w.(*statusRecorder)
+		if !ok {
+			t.Fatalf("writer = %T, want *statusRecorder", w)
+		}
+		gotStatus = sw.Status()
+		gotBytes = sw.BytesWritten()
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", rec.Code)
+	}
+	if gotStatus != http.StatusCreated {
+		t.Fatalf("recorded status = %d, want 201", gotStatus)
+	}
+	if gotBytes != 5 {
+		t.Fatalf("recorded bytes = %d, want 5", gotBytes)
+	}
+	if rec.Body.String() != "hello" {
+		t.Fatalf("body = %q, want hello", rec.Body.String())
+	}
+}
+
+func TestRequestLoggerPreservesStreamingInterfaces(t *testing.T) {
+	base := &fakeStreamWriter{}
+	handler := RequestLogger(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := w.(http.Flusher); !ok {
+			t.Fatalf("wrapped writer lost http.Flusher")
+		}
+		sd, ok := w.(interface{ SetWriteDeadline(time.Time) error })
+		if !ok {
+			t.Fatalf("wrapped writer lost SetWriteDeadline")
+		}
+		if err := sd.SetWriteDeadline(time.Time{}); err != nil {
+			t.Fatalf("SetWriteDeadline: %v", err)
+		}
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(base, req)
+
+	if !base.deadlineSet {
+		t.Fatalf("SetWriteDeadline was not forwarded to the underlying writer")
+	}
+}
+
+func TestRecovererReturns500OnPanic(t *testing.T) {
+	handler := Recoverer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	}))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+type fakeStreamWriter struct {
+	header      http.Header
+	status      int
+	deadlineSet bool
+}
+
+func (f *fakeStreamWriter) Header() http.Header {
+	if f.header == nil {
+		f.header = http.Header{}
+	}
+	return f.header
+}
+func (f *fakeStreamWriter) WriteHeader(code int)        { f.status = code }
+func (f *fakeStreamWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (f *fakeStreamWriter) Flush()                      {}
+func (f *fakeStreamWriter) SetWriteDeadline(t time.Time) error {
+	f.deadlineSet = true
+	return nil
 }


### PR DESCRIPTION
## What & why

Closes the remaining modern-production observability gaps found in a full architecture/ops review. The repo already has graceful shutdown, fail-closed auth, channel isolation, hand-rolled Prometheus metrics, and a zero-dep design — this fills the three concrete holes.

## Changes

1. **Access log records outcome** (`router/middleware.go`): `RequestLogger` now logs `status`, `bytes`, `duration_ms` after the response (was method/path/remote/request_id only). A `statusRecorder` wraps the writer and **forwards `Flush`/`Hijack`/`ReadFrom`/`SetWriteDeadline`** so SSE streaming and WebSocket upgrades are unaffected — `SetWriteDeadline` is what the proxy SSE path uses to opt out of the 60s `WriteTimeout`.
2. **Panic recovery via slog** (`Recoverer`): logs `panic` + stack with `request_id` and returns 500, instead of chi's stderr default.
3. **Go runtime metrics in /metrics** (`handler/shared/metrics.go`): `go_goroutines`, `go_memstats_alloc_bytes/heap_alloc/heap_inuse/heap_objects/sys`, and `go_gc_duration_seconds` summary — stdlib only, no new dependencies.

## Validation

- `go vet` clean; `gofmt` clean.
- `go test ./router ./handler/shared -count=1` green with the real `web/dist` build (full CI runs `-race` on Linux; Windows TSan fails address-space allocation as documented).
- New tests: `TestRequestLoggerCapturesStatusAndBytes`, `TestRequestLoggerPreservesStreamingInterfaces` (asserts `Flusher` + `SetWriteDeadline` survive wrapping), `TestRecovererReturns500OnPanic`, `TestGoRuntimeMetricsExposed`.
