### PR TITLE
chore(web): masked secret-field for token columns (PR3 security)

### DIFF
--- a/web/src/components/ui/secret-field.tsx
+++ b/web/src/components/ui/secret-field.tsx
@@ -1,0 +1,75 @@
+// metapi-go/components/ui — reusable masked-secret display with reveal + copy.
+// Shows the masked form by default; toggles to the full value on demand and
+// offers one-click copy. Used for API keys/tokens where the raw value is
+// sensitive but the URL/base_url is NOT (URLs stay plaintext elsewhere).
+
+import { Check, Copy, Eye, EyeOff } from 'lucide-react'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface SecretFieldProps {
+  /** Full secret value (may be empty when only a masked form is available). */
+  value?: string | null
+  /** Masked display form (e.g. "sk-abc***xyz"). */
+  masked?: string | null
+  /** Text shown when neither value nor masked is present. */
+  fallback?: string
+  className?: string
+}
+
+export function SecretField({
+  value,
+  masked,
+  fallback = '—',
+  className,
+}: SecretFieldProps) {
+  const [revealed, setRevealed] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const full = value?.trim() || ''
+  const mask = masked?.trim() || (full ? '••••••••••••' : fallback)
+  const hasRevealable = full.length > 0
+  const display = revealed && hasRevealable ? full : mask
+
+  const handleCopy = async () => {
+    const text = hasRevealable ? full : mask
+    if (!text || text === fallback) return
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Clipboard may be unavailable (non-secure context / permissions).
+    }
+  }
+
+  return (
+    <span className={cn('inline-flex max-w-full items-center gap-0.5', className)}>
+      <span className='text-muted-foreground truncate font-mono text-[11px]'>
+        {display}
+      </span>
+      {hasRevealable && (
+        <Button
+          variant='ghost'
+          size='icon-sm'
+          onClick={() => setRevealed((v) => !v)}
+          title={revealed ? 'Hide' : 'Reveal'}
+          aria-label={revealed ? 'Hide secret' : 'Reveal secret'}
+        >
+          {revealed ? <EyeOff /> : <Eye />}
+        </Button>
+      )}
+      <Button
+        variant='ghost'
+        size='icon-sm'
+        onClick={handleCopy}
+        title='Copy'
+        aria-label='Copy secret'
+      >
+        {copied ? <Check className='text-success' /> : <Copy />}
+      </Button>
+    </span>
+  )
+}

--- a/web/src/components/ui/secret-field.tsx
+++ b/web/src/components/ui/secret-field.tsx
@@ -46,7 +46,9 @@ export function SecretField({
   }
 
   return (
-    <span className={cn('inline-flex max-w-full items-center gap-0.5', className)}>
+    <span
+      className={cn('inline-flex max-w-full items-center gap-0.5', className)}
+    >
       <span className='text-muted-foreground truncate font-mono text-[11px]'>
         {display}
       </span>

--- a/web/src/features/accounts/tokens/components/tokens-panel.tsx
+++ b/web/src/features/accounts/tokens/components/tokens-panel.tsx
@@ -31,8 +31,8 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
-import { Separator } from '@/components/ui/separator'
 import { SecretField } from '@/components/ui/secret-field'
+import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 

--- a/web/src/features/accounts/tokens/components/tokens-panel.tsx
+++ b/web/src/features/accounts/tokens/components/tokens-panel.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
+import { SecretField } from '@/components/ui/secret-field'
 import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 
@@ -217,9 +218,7 @@ function TokenRow({
             </Badge>
           )}
         </div>
-        <span className='text-muted-foreground truncate font-mono text-[11px]'>
-          {token.tokenMasked || token.token || '—'}
-        </span>
+        <SecretField value={token.token} masked={token.tokenMasked} />
       </div>
 
       <div className='flex items-center gap-1'>


### PR DESCRIPTION
## 概要

PR3 — API key 掩码（纯前端，极低风险）。依据私有设计 SSOT §3 PR3（G1a/G1b）。

Closes #601 #602

## 变更

- 新增 `web/src/components/ui/secret-field.tsx`：默认显示掩码，按需 Eye/EyeOff 解锁、一键复制、完整 aria（`aria-label`/`title`），**仅 key 敏感，URL/base_url 保持明文**。
- `tokens-panel.tsx` 的 `TokenRow` 接入 `SecretField`（`value=token.token`、`masked=token.tokenMasked`）。

## 敏感边界（用户明确修正）

- URL/base_url 不敏感，保持明文。
- 仅 API key/token 掩码。

## 验证

- `bun run typecheck`（tsgo -b）通过。
- 空值回退 `—`、仅有掩码无 full 值时不显示解锁按钮、复制失败静默降级。

## 备注

- `accounts-columns.tsx` / `account-detail-sheet.tsx` 已核实不展示明文凭据（只展示 credentialMode badge + 嵌入 TokensPanel），故无需额外改造。
- 表单输入框（`account-form-dialog.tsx` accessToken/apiToken textarea）为**新建凭据录入**场景，非存量展示，按录入 UX 惯例保持明文输入，不在本 PR 掩码范围。