### PR TITLE
chore(web)+feat(observability): timing/tooltips + observability workspace (PR2, #603-#610)

### DIFF
--- a/handler/admin/monitor.go
+++ b/handler/admin/monitor.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/config"
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
-	"github.com/deliciousbuding/metapi-go/config"
 )
 
 // RegisterMonitorRoutes registers all /api/monitor and /monitor-proxy routes.
@@ -22,6 +22,7 @@ func RegisterMonitorRoutes(r chi.Router, db *sqlx.DB, cfg *config.Config) {
 	handler := &monitorHandler{db: db, cfg: cfg}
 
 	r.Get("/api/monitor/config", handler.getConfig)
+	RegisterMonitorHealthRoute(r, db, cfg) // GET /api/monitor/health (observability projection)
 	r.Put("/api/monitor/config", handler.saveConfig)
 	r.Post("/api/monitor/session", handler.createSession)
 	// DELETE clears the HttpOnly meta_monitor_auth cookie on admin logout.

--- a/handler/admin/monitor_health.go
+++ b/handler/admin/monitor_health.go
@@ -1,0 +1,144 @@
+package admin
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/routing"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+// RegisterMonitorHealthRoute mounts the read-only observability health
+// projection. It never hard-disables anything — the response only aggregates
+// the in-memory runtime breaker state and the DB-backed channel cooldown /
+// site+account health counters.
+func RegisterMonitorHealthRoute(r chi.Router, db *sqlx.DB, cfg *config.Config) {
+	h := &monitorHealthHandler{
+		db:               db,
+		configuredMaxSec: cfg.TokenRouterFailureCooldownMaxSec,
+	}
+	r.Get("/api/monitor/health", h.health)
+}
+
+type monitorHealthHandler struct {
+	db               *sqlx.DB
+	configuredMaxSec int
+}
+
+// health is the read-only projection endpoint backing the observability
+// Health section (site/account health + breaker/cooldown aggregation).
+func (h *monitorHealthHandler) health(w http.ResponseWriter, r *http.Request) {
+	runtimeHealth := routing.SnapshotRuntimeHealth()
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"generatedAt":   time.Now().UTC().Format(time.RFC3339),
+		"runtimeHealth": runtimeHealth,
+		"cooldown":      h.aggregateCooldown(),
+		"sites":         h.statusCounts("sites"),
+		"accounts":      h.statusCounts("accounts"),
+	})
+}
+
+// aggregateCooldown projects route_channels cooldown/failure state without
+// writing anything. Cooling means cooldownUntil is still in the future;
+// recently-failed means failCount>0 with a lastFailAt inside the configured
+// Fibonacci backoff window.
+func (h *monitorHealthHandler) aggregateCooldown() map[string]any {
+	rows := queryRows(h.db, `
+		SELECT
+			rc.id AS id,
+			rc.account_id AS account_id,
+			rc.fail_count AS fail_count,
+			rc.last_fail_at AS last_fail_at,
+			rc.cooldown_until AS cooldown_until,
+			s.id AS site_id,
+			COALESCE(s.name, '') AS site_name
+		FROM route_channels rc
+		LEFT JOIN accounts a ON a.id = rc.account_id
+		LEFT JOIN sites s ON s.id = a.site_id
+		WHERE rc.cooldown_until IS NOT NULL OR rc.fail_count > 0
+		ORDER BY rc.cooldown_until DESC
+		LIMIT 10000
+	`)
+
+	nowISO := time.Now().UTC().Format(time.RFC3339)
+	nowMs := time.Now().UnixMilli()
+
+	channelsCooling := 0
+	channelsWithFailures := 0
+	channelsRecentlyFailed := 0
+	cooling := make([]map[string]any, 0)
+
+	for _, row := range rows {
+		failCount := coerceInt64(row["failCount"])
+		cooldownUntil := nullableString(row["cooldownUntil"])
+		lastFailAt := nullableString(row["lastFailAt"])
+
+		if failCount > 0 {
+			channelsWithFailures++
+		}
+		if routing.IsChannelRecentlyFailed(&failCount, lastFailAt, nowMs, h.configuredMaxSec) {
+			channelsRecentlyFailed++
+		}
+		if routing.IsCooldownActive(cooldownUntil, nowISO) {
+			channelsCooling++
+			cooling = append(cooling, map[string]any{
+				"channelId":     coerceInt64(row["id"]),
+				"accountId":     coerceInt64(row["accountId"]),
+				"siteId":        coerceInt64(row["siteId"]),
+				"siteName":      coerceString(row["siteName"]),
+				"failCount":     failCount,
+				"cooldownUntil": coerceString(row["cooldownUntil"]),
+			})
+		}
+	}
+
+	return map[string]any{
+		"channelsCooling":        channelsCooling,
+		"channelsWithFailures":   channelsWithFailures,
+		"channelsRecentlyFailed": channelsRecentlyFailed,
+		"cooling":                cooling,
+	}
+}
+
+// statusCounts aggregates a table's `status` column into total/active/
+// disabled/other buckets. `table` is always a literal in this file.
+func (h *monitorHealthHandler) statusCounts(table string) map[string]any {
+	rows := queryRows(h.db, "SELECT status, COUNT(*) AS count FROM "+table+" GROUP BY status")
+	result := map[string]any{
+		"total":    0,
+		"active":   0,
+		"disabled": 0,
+		"other":    0,
+	}
+	var total int64
+	for _, row := range rows {
+		count := coerceInt64(row["count"])
+		total += count
+		switch coerceString(row["status"]) {
+		case "active":
+			result["active"] = count
+		case "disabled":
+			result["disabled"] = count
+		default:
+			result["other"] = coerceInt64(result["other"]) + count
+		}
+	}
+	result["total"] = total
+	return result
+}
+
+// nullableString converts a nullable MapScan value into *string, treating nil
+// and empty as nil so cooldown helpers see a genuinely absent timestamp.
+func nullableString(v any) *string {
+	if v == nil {
+		return nil
+	}
+	s := coerceString(v)
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/routing/runtime_health_snapshot.go
+++ b/routing/runtime_health_snapshot.go
@@ -1,0 +1,68 @@
+package routing
+
+// Read-only aggregation of the in-memory site/model runtime health state.
+//
+// The runtime breaker lives only in memory (persisted to settings on an
+// interval), so a projection endpoint cannot read it from the DB. This
+// snapshot copies counts + open-breaker rows under the same mutex the proxy
+// path uses, without mutating anything — soft isolation only.
+
+// RuntimeHealthBreaker is one open site-level or site+model breaker row.
+type RuntimeHealthBreaker struct {
+	SiteID         int64   `json:"siteId"`
+	Model          string  `json:"model"` // empty = site-level breaker
+	BreakerLevel   int64   `json:"breakerLevel"`
+	BreakerUntilMs *int64  `json:"breakerUntilMs,omitempty"`
+	PenaltyScore   float64 `json:"penaltyScore"`
+}
+
+// RuntimeHealthSnapshot is a read-only aggregate of runtime health state.
+type RuntimeHealthSnapshot struct {
+	SitesTracked      int                    `json:"sitesTracked"`
+	SitesBreakerOpen  int                    `json:"sitesBreakerOpen"`
+	ModelsTracked     int                    `json:"modelsTracked"`
+	ModelsBreakerOpen int                    `json:"modelsBreakerOpen"`
+	OpenBreakers      []RuntimeHealthBreaker `json:"openBreakers"`
+}
+
+// SnapshotRuntimeHealth returns a read-only projection of the in-memory
+// site/model runtime breaker state. Never hard-disables anything.
+func SnapshotRuntimeHealth() RuntimeHealthSnapshot {
+	healthStateMu.RLock()
+	defer healthStateMu.RUnlock()
+
+	snapshot := RuntimeHealthSnapshot{
+		SitesTracked: len(siteRuntimeHealthStates),
+		OpenBreakers: []RuntimeHealthBreaker{},
+	}
+
+	for siteID, state := range siteRuntimeHealthStates {
+		if isRuntimeHealthBreakerOpen(state) {
+			snapshot.SitesBreakerOpen++
+			snapshot.OpenBreakers = append(snapshot.OpenBreakers, RuntimeHealthBreaker{
+				SiteID:         siteID,
+				BreakerLevel:   state.BreakerLevel,
+				BreakerUntilMs: state.BreakerUntilMs,
+				PenaltyScore:   getDecayedSiteRuntimePenalty(state),
+			})
+		}
+	}
+
+	for siteID, models := range siteModelRuntimeHealthStates {
+		snapshot.ModelsTracked += len(models)
+		for model, state := range models {
+			if isRuntimeHealthBreakerOpen(state) {
+				snapshot.ModelsBreakerOpen++
+				snapshot.OpenBreakers = append(snapshot.OpenBreakers, RuntimeHealthBreaker{
+					SiteID:         siteID,
+					Model:          model,
+					BreakerLevel:   state.BreakerLevel,
+					BreakerUntilMs: state.BreakerUntilMs,
+					PenaltyScore:   getDecayedSiteRuntimePenalty(state),
+				})
+			}
+		}
+	}
+
+	return snapshot
+}

--- a/routing/runtime_health_snapshot_test.go
+++ b/routing/runtime_health_snapshot_test.go
@@ -1,0 +1,46 @@
+package routing
+
+import "testing"
+
+func TestSnapshotRuntimeHealth(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	defer ResetSiteRuntimeHealthState()
+
+	empty := SnapshotRuntimeHealth()
+	if empty.SitesTracked != 0 || empty.ModelsTracked != 0 {
+		t.Fatalf("expected empty snapshot, got sites=%d models=%d", empty.SitesTracked, empty.ModelsTracked)
+	}
+	if empty.OpenBreakers == nil {
+		t.Fatalf("expected non-nil OpenBreakers slice for stable JSON []")
+	}
+
+	until := nowMs() + 60_000
+	healthStateMu.Lock()
+	siteRuntimeHealthStates[7] = &SiteRuntimeHealthState{
+		BreakerLevel:   1,
+		BreakerUntilMs: &until,
+		PenaltyScore:   3,
+	}
+	if siteModelRuntimeHealthStates[7] == nil {
+		siteModelRuntimeHealthStates[7] = map[string]*SiteRuntimeHealthState{}
+	}
+	siteModelRuntimeHealthStates[7]["gpt-4"] = &SiteRuntimeHealthState{BreakerLevel: 0}
+	healthStateMu.Unlock()
+
+	snap := SnapshotRuntimeHealth()
+	if snap.SitesTracked != 1 {
+		t.Fatalf("expected 1 tracked site, got %d", snap.SitesTracked)
+	}
+	if snap.SitesBreakerOpen != 1 {
+		t.Fatalf("expected 1 open site breaker, got %d", snap.SitesBreakerOpen)
+	}
+	if snap.ModelsTracked != 1 {
+		t.Fatalf("expected 1 tracked model, got %d", snap.ModelsTracked)
+	}
+	if snap.ModelsBreakerOpen != 0 {
+		t.Fatalf("expected 0 open model breakers, got %d", snap.ModelsBreakerOpen)
+	}
+	if len(snap.OpenBreakers) != 1 || snap.OpenBreakers[0].SiteID != 7 {
+		t.Fatalf("unexpected open breakers: %+v", snap.OpenBreakers)
+	}
+}

--- a/web/src/components/layout/lib/sidebar-view-registry.ts
+++ b/web/src/components/layout/lib/sidebar-view-registry.ts
@@ -2,6 +2,7 @@
 // Resolves the active nested drill-in view for a given pathname.
 
 import { SYSTEM_SETTINGS_VIEW } from '../config/system-settings.config'
+import { OBSERVABILITY_VIEW } from '@/features/observability'
 import type { SidebarView } from '../types'
 
 /**
@@ -13,7 +14,7 @@ import type { SidebarView } from '../types'
  *
  * Match priority is array order; the first matching `pathPattern` wins.
  */
-const SIDEBAR_VIEWS: readonly SidebarView[] = [SYSTEM_SETTINGS_VIEW]
+const SIDEBAR_VIEWS: readonly SidebarView[] = [SYSTEM_SETTINGS_VIEW, OBSERVABILITY_VIEW]
 
 /**
  * Resolve the active nested view for the given path.

--- a/web/src/components/layout/lib/sidebar-view-registry.ts
+++ b/web/src/components/layout/lib/sidebar-view-registry.ts
@@ -1,8 +1,9 @@
 // metapi-go/layout — sidebar-view-registry ported from newapi. AGPL header stripped.
 // Resolves the active nested drill-in view for a given pathname.
 
-import { SYSTEM_SETTINGS_VIEW } from '../config/system-settings.config'
 import { OBSERVABILITY_VIEW } from '@/features/observability'
+
+import { SYSTEM_SETTINGS_VIEW } from '../config/system-settings.config'
 import type { SidebarView } from '../types'
 
 /**
@@ -14,7 +15,10 @@ import type { SidebarView } from '../types'
  *
  * Match priority is array order; the first matching `pathPattern` wins.
  */
-const SIDEBAR_VIEWS: readonly SidebarView[] = [SYSTEM_SETTINGS_VIEW, OBSERVABILITY_VIEW]
+const SIDEBAR_VIEWS: readonly SidebarView[] = [
+  SYSTEM_SETTINGS_VIEW,
+  OBSERVABILITY_VIEW,
+]
 
 /**
  * Resolve the active nested view for the given path.

--- a/web/src/features/accounts/components/accounts-columns.tsx
+++ b/web/src/features/accounts/components/accounts-columns.tsx
@@ -27,6 +27,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
 import {
@@ -291,13 +297,32 @@ export function useAccountsColumns(
       cell: ({ row }) => {
         const account = accountSchema.parse(row.original)
         const config = resolveHealth(account)
-        return (
+        const reason = account.runtimeHealth?.reason?.trim()
+        const badge = (
           <Badge variant={config.variant}>
             <span
               className={cn('size-1.5 rounded-full', config.dotClassName)}
             />
             {config.label}
           </Badge>
+        )
+        if (!reason) {
+          return badge
+        }
+        return (
+          <TooltipProvider delay={200}>
+            <Tooltip>
+              <TooltipTrigger render={<span className='w-fit'>{badge}</span>} />
+              <TooltipContent side='top' className='max-w-xs'>
+                <div className='flex flex-col gap-0.5'>
+                  <span className='font-medium'>
+                    {t('accounts.columns.healthDetail')}
+                  </span>
+                  <span className='text-xs'>{reason}</span>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         )
       },
       filterFn: (row, _columnId, filterValue: unknown) => {

--- a/web/src/features/models/components/models-columns.tsx
+++ b/web/src/features/models/components/models-columns.tsx
@@ -29,17 +29,17 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
 import type { ModelRow } from '../types'

--- a/web/src/features/models/components/models-columns.tsx
+++ b/web/src/features/models/components/models-columns.tsx
@@ -29,6 +29,12 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -59,6 +65,26 @@ function resolveLowestInputPrice(model: ModelRow): number | null {
     }
   }
   return lowest
+}
+
+function resolvePriceDetail(
+  model: ModelRow
+): Array<{ site: string; price: number }> {
+  const rows: Array<{ site: string; price: number }> = []
+  for (const source of model.pricingSources ?? []) {
+    let lowest: number | null = null
+    for (const groupKey of Object.keys(source.groupPricing ?? {})) {
+      const input = source.groupPricing[groupKey]?.inputPerMillion
+      if (typeof input === 'number' && Number.isFinite(input)) {
+        if (lowest === null || input < lowest) lowest = input
+      }
+    }
+    if (lowest !== null) {
+      rows.push({ site: source.siteName || `#${source.siteId}`, price: lowest })
+    }
+  }
+  rows.sort((a, b) => a.price - b.price)
+  return rows
 }
 
 function formatPrice(price: number | null): string {
@@ -248,14 +274,38 @@ export function useModelsColumns(
         ),
         cell: ({ row }) => {
           const price = resolveLowestInputPrice(row.original)
+          if (price === null) {
+            return <span className='text-muted-foreground text-sm'>—</span>
+          }
+          const detail = resolvePriceDetail(row.original)
+          const priceLabel = `$${formatPrice(price)}/M`
+          if (detail.length === 0) {
+            return <span className='text-sm tabular-nums'>{priceLabel}</span>
+          }
           return (
-            <span className='text-sm tabular-nums'>
-              {price === null ? (
-                <span className='text-muted-foreground'>—</span>
-              ) : (
-                `$${formatPrice(price)}/M`
-              )}
-            </span>
+            <TooltipProvider delay={200}>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <span className='text-sm tabular-nums underline decoration-dotted underline-offset-2' />
+                  }
+                >
+                  {priceLabel}
+                </TooltipTrigger>
+                <TooltipContent side='top' className='max-w-xs'>
+                  <div className='flex flex-col gap-1'>
+                    <span className='font-medium'>
+                      {t('models.columns.priceDetail')}
+                    </span>
+                    {detail.map((item) => (
+                      <span key={item.site} className='text-xs tabular-nums'>
+                        {item.site}: ${formatPrice(item.price)}/M
+                      </span>
+                    ))}
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )
         },
       },

--- a/web/src/features/observability/api.ts
+++ b/web/src/features/observability/api.ts
@@ -1,0 +1,54 @@
+// metapi-go/features/observability — TanStack Query hooks wrapping lib/api.ts.
+//
+// Each section owns one query. `useUsageHeatmap` / `useSlowRequests` power
+// the Overview section (reusing the existing /api/stats endpoints), and
+// `useMonitorHealth` powers the Health section (the read-only
+// /api/monitor/health projection).
+
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+
+import { api } from '@/lib/api'
+
+import {
+  observabilityKeys,
+  type MonitorHealthResponse,
+  type SlowRequestsResponse,
+  type UsageHeatmapResponse,
+} from './types'
+
+export function useUsageHeatmap(
+  params: { days?: number; dimension?: 'site' | 'model' } = {},
+  options?: Omit<UseQueryOptions<UsageHeatmapResponse>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery({
+    queryKey: observabilityKeys.usageHeatmap(params),
+    queryFn: () =>
+      api.getUsageHeatmap(params) as Promise<UsageHeatmapResponse>,
+    staleTime: 30 * 1000,
+    ...options,
+  })
+}
+
+export function useSlowRequests(
+  params: { limit?: number; minLatencyMs?: number; hours?: number } = {},
+  options?: Omit<UseQueryOptions<SlowRequestsResponse>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery({
+    queryKey: observabilityKeys.slowRequests(params),
+    queryFn: () =>
+      api.getSlowRequests(params) as Promise<SlowRequestsResponse>,
+    staleTime: 30 * 1000,
+    ...options,
+  })
+}
+
+export function useMonitorHealth(
+  options?: Omit<UseQueryOptions<MonitorHealthResponse>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery({
+    queryKey: observabilityKeys.monitorHealth(),
+    queryFn: () => api.getMonitorHealth() as Promise<MonitorHealthResponse>,
+    staleTime: 15 * 1000,
+    ...options,
+  })
+}

--- a/web/src/features/observability/api.ts
+++ b/web/src/features/observability/api.ts
@@ -22,8 +22,7 @@ export function useUsageHeatmap(
 ) {
   return useQuery({
     queryKey: observabilityKeys.usageHeatmap(params),
-    queryFn: () =>
-      api.getUsageHeatmap(params) as Promise<UsageHeatmapResponse>,
+    queryFn: () => api.getUsageHeatmap(params) as Promise<UsageHeatmapResponse>,
     staleTime: 30 * 1000,
     ...options,
   })
@@ -35,8 +34,7 @@ export function useSlowRequests(
 ) {
   return useQuery({
     queryKey: observabilityKeys.slowRequests(params),
-    queryFn: () =>
-      api.getSlowRequests(params) as Promise<SlowRequestsResponse>,
+    queryFn: () => api.getSlowRequests(params) as Promise<SlowRequestsResponse>,
     staleTime: 30 * 1000,
     ...options,
   })

--- a/web/src/features/observability/components/observability-page.tsx
+++ b/web/src/features/observability/components/observability-page.tsx
@@ -24,7 +24,9 @@ function resolveSectionId(
 ): ObservabilitySectionId {
   if (!activeSection) return OBSERVABILITY_DEFAULT_SECTION
   const known = new Set<string>(
-    getObservabilitySectionNavItems().map((item) => item.url.split('=').pop() ?? '')
+    getObservabilitySectionNavItems().map(
+      (item) => item.url.split('=').pop() ?? ''
+    )
   )
   return known.has(activeSection)
     ? (activeSection as ObservabilitySectionId)
@@ -73,4 +75,3 @@ export function ObservabilityPage({
     </div>
   )
 }
-

--- a/web/src/features/observability/components/observability-page.tsx
+++ b/web/src/features/observability/components/observability-page.tsx
@@ -1,0 +1,76 @@
+// metapi-go/features/observability/components — workspace shell + section
+// dispatcher. Renders the hub header + section tabs + the active section's
+// content. Presentational (no URL reading); the route layer passes the active
+// section and a navigate-backed `onSectionChange`, mirroring DashboardPage.
+
+import { useTranslation } from 'react-i18next'
+
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+
+import {
+  OBSERVABILITY_DEFAULT_SECTION,
+  getObservabilitySectionContent,
+  getObservabilitySectionNavItems,
+} from '../config/observability-config'
+import type { ObservabilitySectionId } from '../types'
+
+export type ObservabilityPageProps = {
+  activeSection?: string
+  onSectionChange?: (sectionId: ObservabilitySectionId) => void
+}
+
+function resolveSectionId(
+  activeSection: string | undefined
+): ObservabilitySectionId {
+  if (!activeSection) return OBSERVABILITY_DEFAULT_SECTION
+  const known = new Set<string>(
+    getObservabilitySectionNavItems().map((item) => item.url.split('=').pop() ?? '')
+  )
+  return known.has(activeSection)
+    ? (activeSection as ObservabilitySectionId)
+    : OBSERVABILITY_DEFAULT_SECTION
+}
+
+export function ObservabilityPage({
+  activeSection,
+  onSectionChange,
+}: ObservabilityPageProps) {
+  const { t } = useTranslation()
+  const sectionId = resolveSectionId(activeSection)
+  const navItems = getObservabilitySectionNavItems()
+  const content = getObservabilitySectionContent(sectionId)
+
+  return (
+    <div className='flex flex-col gap-6 p-6'>
+      <header className='flex flex-col gap-1'>
+        <h1 className='text-2xl font-normal tracking-tight'>
+          {t('observability.title')}
+        </h1>
+        <p className='text-muted-foreground text-sm'>
+          {t('observability.description')}
+        </p>
+      </header>
+
+      <Tabs
+        value={sectionId}
+        onValueChange={(value) =>
+          onSectionChange?.(value as ObservabilitySectionId)
+        }
+      >
+        <TabsList className='w-fit'>
+          {navItems.map((item) => {
+            const id = item.url.split('=').pop() ?? item.title
+            return (
+              <TabsTrigger key={id} value={id}>
+                {t(item.title)}
+              </TabsTrigger>
+            )
+          })}
+        </TabsList>
+      </Tabs>
+
+      <main className='min-w-0 flex-1'>{content}</main>
+    </div>
+  )
+}
+

--- a/web/src/features/observability/config/observability-config.ts
+++ b/web/src/features/observability/config/observability-config.ts
@@ -2,7 +2,13 @@
 // Health / Proxy Logs). Registered through a local section-registry factory
 // and consumed by ObservabilityPage + the route file + the sidebar drill-in.
 
-import { createElement, lazy, Suspense, type ComponentType, type ReactNode } from 'react'
+import {
+  createElement,
+  lazy,
+  Suspense,
+  type ComponentType,
+  type ReactNode,
+} from 'react'
 
 import type { ObservabilitySection, ObservabilitySectionId } from '../types'
 import { createObservabilitySectionRegistry } from '../utils/section-registry'
@@ -49,17 +55,18 @@ const OBSERVABILITY_SECTIONS: readonly ObservabilitySection[] = [
   },
 ]
 
-const observabilityRegistry = createObservabilitySectionRegistry<ObservabilitySectionId>({
-  sections: OBSERVABILITY_SECTIONS,
-  defaultSection: 'overview',
-  basePath: '/observability',
-})
+const observabilityRegistry =
+  createObservabilitySectionRegistry<ObservabilitySectionId>({
+    sections: OBSERVABILITY_SECTIONS,
+    defaultSection: 'overview',
+    basePath: '/observability',
+  })
 
 export const OBSERVABILITY_SECTION_IDS = observabilityRegistry.sectionIds
-export const OBSERVABILITY_DEFAULT_SECTION = observabilityRegistry.defaultSection
+export const OBSERVABILITY_DEFAULT_SECTION =
+  observabilityRegistry.defaultSection
 export const getObservabilitySectionNavItems =
   observabilityRegistry.getSectionNavItems
 export const getObservabilitySectionContent =
   observabilityRegistry.getSectionContent
-export const getObservabilitySectionMeta =
-  observabilityRegistry.getSectionMeta
+export const getObservabilitySectionMeta = observabilityRegistry.getSectionMeta

--- a/web/src/features/observability/config/observability-config.ts
+++ b/web/src/features/observability/config/observability-config.ts
@@ -1,0 +1,65 @@
+// metapi-go/features/observability/config — 3-section manifest (Overview /
+// Health / Proxy Logs). Registered through a local section-registry factory
+// and consumed by ObservabilityPage + the route file + the sidebar drill-in.
+
+import { createElement, lazy, Suspense, type ComponentType, type ReactNode } from 'react'
+
+import type { ObservabilitySection, ObservabilitySectionId } from '../types'
+import { createObservabilitySectionRegistry } from '../utils/section-registry'
+
+const LazyOverviewSection = lazy(() =>
+  import('../sections/overview').then((module) => ({
+    default: module.OverviewSection,
+  }))
+)
+const LazyHealthSection = lazy(() =>
+  import('../sections/health').then((module) => ({
+    default: module.HealthSection,
+  }))
+)
+const LazyProxyLogsSection = lazy(() =>
+  import('../sections/proxy-logs').then((module) => ({
+    default: module.ProxyLogsSection,
+  }))
+)
+
+function mountSection(component: ComponentType): () => ReactNode {
+  return () =>
+    createElement(Suspense, { fallback: null }, createElement(component))
+}
+
+const OBSERVABILITY_SECTIONS: readonly ObservabilitySection[] = [
+  {
+    id: 'overview',
+    title: 'observability.sections.overview.title',
+    description: 'observability.sections.overview.description',
+    build: mountSection(LazyOverviewSection),
+  },
+  {
+    id: 'health',
+    title: 'observability.sections.health.title',
+    description: 'observability.sections.health.description',
+    build: mountSection(LazyHealthSection),
+  },
+  {
+    id: 'proxy-logs',
+    title: 'observability.sections.proxyLogs.title',
+    description: 'observability.sections.proxyLogs.description',
+    build: mountSection(LazyProxyLogsSection),
+  },
+]
+
+const observabilityRegistry = createObservabilitySectionRegistry<ObservabilitySectionId>({
+  sections: OBSERVABILITY_SECTIONS,
+  defaultSection: 'overview',
+  basePath: '/observability',
+})
+
+export const OBSERVABILITY_SECTION_IDS = observabilityRegistry.sectionIds
+export const OBSERVABILITY_DEFAULT_SECTION = observabilityRegistry.defaultSection
+export const getObservabilitySectionNavItems =
+  observabilityRegistry.getSectionNavItems
+export const getObservabilitySectionContent =
+  observabilityRegistry.getSectionContent
+export const getObservabilitySectionMeta =
+  observabilityRegistry.getSectionMeta

--- a/web/src/features/observability/config/observability-nav.ts
+++ b/web/src/features/observability/config/observability-nav.ts
@@ -1,0 +1,33 @@
+// metapi-go/features/observability/config — sidebar drill-in view.
+//
+// Entering /observability swaps the root navigation for a contextual view
+// (Overview / Health / Proxy Logs) with a "Back to Home" affordance,
+// mirroring the Settings drill-in. Section titles are i18n keys resolved at
+// render time by nav-group.tsx.
+
+import type { NavGroup, SidebarView } from '@/components/layout/types'
+
+import { getObservabilitySectionNavItems } from './observability-config'
+
+function getObservabilityNavGroups(): NavGroup[] {
+  return [
+    {
+      id: 'observability',
+      title: 'sidebar.groups.observability',
+      items: getObservabilitySectionNavItems().map((item) => ({
+        title: item.title,
+        url: item.url,
+      })),
+    },
+  ]
+}
+
+export const OBSERVABILITY_VIEW: SidebarView = {
+  id: 'observability',
+  pathPattern: /^\/observability(\/|$)/,
+  parent: {
+    to: '/',
+    label: 'sidebar.backToHome',
+  },
+  getNavGroups: getObservabilityNavGroups,
+}

--- a/web/src/features/observability/index.ts
+++ b/web/src/features/observability/index.ts
@@ -21,4 +21,3 @@ export {
 export { useMonitorHealth, useSlowRequests, useUsageHeatmap } from './api'
 
 export type { ObservabilitySectionId } from './types'
-

--- a/web/src/features/observability/index.ts
+++ b/web/src/features/observability/index.ts
@@ -1,0 +1,24 @@
+// metapi-go/features/observability — barrel.
+//
+// Public API for the Observability workspace (Overview / Health / Proxy
+// Logs). Consumers (route file, sidebar, drill-in registry) import from
+// `@/features/observability`.
+
+export { ObservabilityPage } from './components/observability-page'
+
+export {
+  OBSERVABILITY_DEFAULT_SECTION,
+  OBSERVABILITY_SECTION_IDS,
+} from './config/observability-config'
+
+export { OBSERVABILITY_VIEW } from './config/observability-nav'
+
+export {
+  observabilitySearchSchema,
+  type ObservabilitySearch,
+} from './lib/observability-schema'
+
+export { useMonitorHealth, useSlowRequests, useUsageHeatmap } from './api'
+
+export type { ObservabilitySectionId } from './types'
+

--- a/web/src/features/observability/lib/observability-schema.ts
+++ b/web/src/features/observability/lib/observability-schema.ts
@@ -1,0 +1,14 @@
+// metapi-go/features/observability — Zod schema for the workspace URL state.
+//
+// The Observability workspace is a single route (`/observability`) whose
+// active section lives in the `section` search param (mirrors the proxy-logs
+// / models search-schema contract). `section` is validated against the three
+// registered sections and falls back to `overview` when absent/unknown.
+
+import { z } from 'zod'
+
+export const observabilitySearchSchema = z.object({
+  section: z.enum(['overview', 'health', 'proxy-logs']).optional(),
+})
+
+export type ObservabilitySearch = z.infer<typeof observabilitySearchSchema>

--- a/web/src/features/observability/sections/health/health-section.tsx
+++ b/web/src/features/observability/sections/health/health-section.tsx
@@ -1,0 +1,382 @@
+// metapi-go/features/observability/sections/health — site/account health +
+// routing breaker/cooldown aggregation. Reads the read-only
+// /api/monitor/health projection; never mutates routing state.
+
+import { useTranslation } from 'react-i18next'
+import { AlertTriangle, CheckCircle2, Server, ShieldCheck } from 'lucide-react'
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+import { useMonitorHealth } from '../../api'
+import type { CooldownChannel, RuntimeHealthBreaker } from '../../types'
+
+type Translate = (key: string) => string
+
+function formatCount(value: number | undefined): string {
+  return typeof value === 'number' ? value.toLocaleString() : '—'
+}
+
+function formatClock(ms?: number | null): string {
+  if (!ms) return '—'
+  const date = new Date(ms)
+  if (Number.isNaN(date.getTime())) return String(ms)
+  return date.toLocaleString()
+}
+
+function resolveToneClass(tone: 'neutral' | 'warning' | 'success'): string {
+  if (tone === 'warning') return 'text-warning'
+  if (tone === 'success') return 'text-success'
+  return 'text-foreground'
+}
+
+function StatCell({
+  label,
+  value,
+  tone = 'neutral',
+}: {
+  label: string
+  value: string
+  tone?: 'neutral' | 'warning' | 'success'
+}) {
+  return (
+    <div className='rounded-lg border bg-card p-3'>
+      <p className='text-muted-foreground text-xs'>{label}</p>
+      <p className={`text-2xl font-semibold tabular-nums ${resolveToneClass(tone)}`}>
+        {value}
+      </p>
+    </div>
+  )
+}
+
+export function HealthSection() {
+  const { t } = useTranslation()
+  const health = useMonitorHealth()
+
+  const data = health.data
+  const runtime = data?.runtimeHealth
+  const cooldown = data?.cooldown
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <Card>
+        <CardHeader>
+          <CardTitle className='flex items-center gap-2 text-sm font-medium'>
+            <ShieldCheck className='size-4' />
+            {t('observability.health.runtime.title')}
+          </CardTitle>
+          <CardDescription className='text-xs'>
+            {t('observability.health.runtime.description')}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {renderRuntimeStats(health.isLoading, runtime, t)}
+        </CardContent>
+      </Card>
+
+      <div className='grid grid-cols-1 gap-4 lg:grid-cols-2'>
+        <Card>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2 text-sm font-medium'>
+              <AlertTriangle className='size-4' />
+              {t('observability.health.breakers.title')}
+            </CardTitle>
+            <CardDescription className='text-xs'>
+              {t('observability.health.breakers.description')}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {renderBreakersBody(health.isLoading, runtime?.openBreakers ?? [], t)}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2 text-sm font-medium'>
+              <Server className='size-4' />
+              {t('observability.health.cooldown.title')}
+            </CardTitle>
+            <CardDescription className='text-xs'>
+              {t('observability.health.cooldown.description')}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {renderCooldownBody(health.isLoading, cooldown, t)}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className='flex items-center gap-2 text-sm font-medium'>
+            <Server className='size-4' />
+            {t('observability.health.inventory.title')}
+          </CardTitle>
+          <CardDescription className='text-xs'>
+            {t('observability.health.inventory.description')}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {health.isLoading ? (
+            <Skeleton className='h-16 w-full rounded-md' />
+          ) : (
+            <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
+              <InventoryCard
+                title={t('observability.health.inventory.sites')}
+                data={data?.sites}
+                t={t}
+              />
+              <InventoryCard
+                title={t('observability.health.inventory.accounts')}
+                data={data?.accounts}
+                t={t}
+              />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function renderRuntimeStats(
+  loading: boolean,
+  runtime: { sitesTracked: number; sitesBreakerOpen: number; modelsTracked: number; modelsBreakerOpen: number } | undefined,
+  t: Translate
+) {
+  if (loading) {
+    return (
+      <div className='grid grid-cols-2 gap-3 sm:grid-cols-4'>
+        {[0, 1, 2, 3].map((i) => (
+          <Skeleton key={i} className='h-20 rounded-lg' />
+        ))}
+      </div>
+    )
+  }
+  return (
+    <div className='grid grid-cols-2 gap-3 sm:grid-cols-4'>
+      <StatCell
+        label={t('observability.health.runtime.sitesTracked')}
+        value={formatCount(runtime?.sitesTracked)}
+      />
+      <StatCell
+        label={t('observability.health.runtime.sitesBreakerOpen')}
+        value={formatCount(runtime?.sitesBreakerOpen)}
+        tone={runtime?.sitesBreakerOpen ? 'warning' : 'success'}
+      />
+      <StatCell
+        label={t('observability.health.runtime.modelsTracked')}
+        value={formatCount(runtime?.modelsTracked)}
+      />
+      <StatCell
+        label={t('observability.health.runtime.modelsBreakerOpen')}
+        value={formatCount(runtime?.modelsBreakerOpen)}
+        tone={runtime?.modelsBreakerOpen ? 'warning' : 'success'}
+      />
+    </div>
+  )
+}
+
+function renderBreakersBody(
+  loading: boolean,
+  breakers: RuntimeHealthBreaker[],
+  t: Translate
+) {
+  if (loading) {
+    return <Skeleton className='h-40 w-full rounded-md' />
+  }
+  if (breakers.length === 0) {
+    return (
+      <div className='flex min-h-24 items-center justify-center gap-2 rounded-lg border border-dashed py-8 text-center'>
+        <CheckCircle2 className='text-success size-4' />
+        <p className='text-muted-foreground text-sm'>
+          {t('observability.health.breakers.empty')}
+        </p>
+      </div>
+    )
+  }
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>{t('observability.health.breakers.colSite')}</TableHead>
+          <TableHead>{t('observability.health.breakers.colModel')}</TableHead>
+          <TableHead className='text-right'>
+            {t('observability.health.breakers.colLevel')}
+          </TableHead>
+          <TableHead className='text-right'>
+            {t('observability.health.breakers.colUntil')}
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {breakers.map((breaker) => (
+          <TableRow key={`${breaker.siteId}:${breaker.model}`}>
+            <TableCell className='tabular-nums'>{breaker.siteId}</TableCell>
+            <TableCell className='truncate'>{breaker.model || '—'}</TableCell>
+            <TableCell className='text-right tabular-nums'>
+              {breaker.breakerLevel}
+            </TableCell>
+            <TableCell className='text-right tabular-nums'>
+              {formatClock(breaker.breakerUntilMs)}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+function renderCooldownBody(
+  loading: boolean,
+  cooldown: {
+    channelsCooling: number
+    channelsWithFailures: number
+    channelsRecentlyFailed: number
+    cooling: CooldownChannel[]
+  } | undefined,
+  t: Translate
+) {
+  if (loading) {
+    return <Skeleton className='h-40 w-full rounded-md' />
+  }
+  return (
+    <>
+      <div className='mb-3 grid grid-cols-3 gap-2'>
+        <StatCell
+          label={t('observability.health.cooldown.channelsCooling')}
+          value={formatCount(cooldown?.channelsCooling)}
+          tone={cooldown?.channelsCooling ? 'warning' : 'success'}
+        />
+        <StatCell
+          label={t('observability.health.cooldown.channelsWithFailures')}
+          value={formatCount(cooldown?.channelsWithFailures)}
+        />
+        <StatCell
+          label={t('observability.health.cooldown.channelsRecentlyFailed')}
+          value={formatCount(cooldown?.channelsRecentlyFailed)}
+        />
+      </div>
+      {renderCoolingTable(cooldown?.cooling ?? [], t)}
+    </>
+  )
+}
+
+function renderCoolingTable(channels: CooldownChannel[], t: Translate) {
+  if (channels.length === 0) {
+    return (
+      <div className='flex min-h-16 items-center justify-center gap-2 rounded-lg border border-dashed py-6 text-center'>
+        <p className='text-muted-foreground text-sm'>
+          {t('observability.health.cooldown.empty')}
+        </p>
+      </div>
+    )
+  }
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>{t('observability.health.cooldown.colSite')}</TableHead>
+          <TableHead className='text-right'>
+            {t('observability.health.cooldown.colChannel')}
+          </TableHead>
+          <TableHead className='text-right'>
+            {t('observability.health.cooldown.colFailCount')}
+          </TableHead>
+          <TableHead className='text-right'>
+            {t('observability.health.cooldown.colUntil')}
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {channels.map((channel) => (
+          <TableRow key={channel.channelId}>
+            <TableCell className='truncate'>
+              {channel.siteName || channel.siteId}
+            </TableCell>
+            <TableCell className='text-right tabular-nums'>
+              {channel.channelId}
+            </TableCell>
+            <TableCell className='text-right tabular-nums'>
+              {channel.failCount}
+            </TableCell>
+            <TableCell className='text-right tabular-nums'>
+              {channel.cooldownUntil || '—'}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+function InventoryCard({
+  title,
+  data,
+  t,
+}: {
+  title: string
+  data?: { total: number; active: number; disabled: number; other: number }
+  t: Translate
+}) {
+  return (
+    <div className='rounded-lg border bg-card p-3'>
+      <p className='text-muted-foreground mb-2 text-xs font-medium'>{title}</p>
+      <div className='grid grid-cols-4 gap-2 text-center'>
+        <InventoryMetric
+          label={t('observability.health.inventory.total')}
+          value={formatCount(data?.total)}
+          className='text-foreground'
+        />
+        <InventoryMetric
+          label={t('observability.health.inventory.active')}
+          value={formatCount(data?.active)}
+          className='text-success'
+        />
+        <InventoryMetric
+          label={t('observability.health.inventory.disabled')}
+          value={formatCount(data?.disabled)}
+          className='text-muted-foreground'
+        />
+        <InventoryMetric
+          label={t('observability.health.inventory.other')}
+          value={formatCount(data?.other)}
+          className='text-foreground'
+        />
+      </div>
+    </div>
+  )
+}
+
+function InventoryMetric({
+  label,
+  value,
+  className,
+}: {
+  label: string
+  value: string
+  className: string
+}) {
+  return (
+    <div>
+      <p className='text-muted-foreground text-xs'>{label}</p>
+      <p className={`text-lg font-semibold tabular-nums ${className}`}>{value}</p>
+    </div>
+  )
+}
+
+

--- a/web/src/features/observability/sections/health/health-section.tsx
+++ b/web/src/features/observability/sections/health/health-section.tsx
@@ -2,8 +2,8 @@
 // routing breaker/cooldown aggregation. Reads the read-only
 // /api/monitor/health projection; never mutates routing state.
 
-import { useTranslation } from 'react-i18next'
 import { AlertTriangle, CheckCircle2, Server, ShieldCheck } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 import {
   Card,
@@ -54,9 +54,11 @@ function StatCell({
   tone?: 'neutral' | 'warning' | 'success'
 }) {
   return (
-    <div className='rounded-lg border bg-card p-3'>
+    <div className='bg-card rounded-lg border p-3'>
       <p className='text-muted-foreground text-xs'>{label}</p>
-      <p className={`text-2xl font-semibold tabular-nums ${resolveToneClass(tone)}`}>
+      <p
+        className={`text-2xl font-semibold tabular-nums ${resolveToneClass(tone)}`}
+      >
         {value}
       </p>
     </div>
@@ -100,7 +102,11 @@ export function HealthSection() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            {renderBreakersBody(health.isLoading, runtime?.openBreakers ?? [], t)}
+            {renderBreakersBody(
+              health.isLoading,
+              runtime?.openBreakers ?? [],
+              t
+            )}
           </CardContent>
         </Card>
 
@@ -155,7 +161,14 @@ export function HealthSection() {
 
 function renderRuntimeStats(
   loading: boolean,
-  runtime: { sitesTracked: number; sitesBreakerOpen: number; modelsTracked: number; modelsBreakerOpen: number } | undefined,
+  runtime:
+    | {
+        sitesTracked: number
+        sitesBreakerOpen: number
+        modelsTracked: number
+        modelsBreakerOpen: number
+      }
+    | undefined,
   t: Translate
 ) {
   if (loading) {
@@ -243,12 +256,14 @@ function renderBreakersBody(
 
 function renderCooldownBody(
   loading: boolean,
-  cooldown: {
-    channelsCooling: number
-    channelsWithFailures: number
-    channelsRecentlyFailed: number
-    cooling: CooldownChannel[]
-  } | undefined,
+  cooldown:
+    | {
+        channelsCooling: number
+        channelsWithFailures: number
+        channelsRecentlyFailed: number
+        cooling: CooldownChannel[]
+      }
+    | undefined,
   t: Translate
 ) {
   if (loading) {
@@ -334,7 +349,7 @@ function InventoryCard({
   t: Translate
 }) {
   return (
-    <div className='rounded-lg border bg-card p-3'>
+    <div className='bg-card rounded-lg border p-3'>
       <p className='text-muted-foreground mb-2 text-xs font-medium'>{title}</p>
       <div className='grid grid-cols-4 gap-2 text-center'>
         <InventoryMetric
@@ -374,9 +389,9 @@ function InventoryMetric({
   return (
     <div>
       <p className='text-muted-foreground text-xs'>{label}</p>
-      <p className={`text-lg font-semibold tabular-nums ${className}`}>{value}</p>
+      <p className={`text-lg font-semibold tabular-nums ${className}`}>
+        {value}
+      </p>
     </div>
   )
 }
-
-

--- a/web/src/features/observability/sections/health/index.ts
+++ b/web/src/features/observability/sections/health/index.ts
@@ -1,0 +1,1 @@
+export { HealthSection } from './health-section'

--- a/web/src/features/observability/sections/overview/index.ts
+++ b/web/src/features/observability/sections/overview/index.ts
@@ -1,0 +1,1 @@
+export { OverviewSection } from './overview-section'

--- a/web/src/features/observability/sections/overview/overview-section.tsx
+++ b/web/src/features/observability/sections/overview/overview-section.tsx
@@ -1,0 +1,292 @@
+// metapi-go/features/observability/sections/overview — slow-request TOP list
+// + usage heatmap. Both consume existing /api/stats endpoints (no new
+// backend surface) so the Overview reads like a curated lens over proxy data.
+
+import { useMemo, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { BarChart3, Flame } from 'lucide-react'
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+import { useSlowRequests, useUsageHeatmap } from '../../api'
+import type { SlowRequestItem, UsageHeatmapCell } from '../../types'
+
+const MAX_HEATMAP_KEYS = 16
+
+function formatLatency(ms: number): string {
+  if (!Number.isFinite(ms)) return '—'
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)} s`
+  return `${Math.round(ms)} ms`
+}
+
+function formatClock(iso: string): string {
+  if (!iso) return '—'
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  return date.toLocaleString()
+}
+
+function formatBucket(iso: string): string {
+  if (!iso) return ''
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  return `${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(
+    date.getUTCDate()
+  ).padStart(2, '0')} ${String(date.getUTCHours()).padStart(2, '0')}:00`
+}
+
+function heatmapLayout(cells: UsageHeatmapCell[]) {
+  const buckets = [...new Set(cells.map((cell) => cell.bucket))].sort()
+  const totals = new Map<string, number>()
+  for (const cell of cells) {
+    totals.set(cell.key, (totals.get(cell.key) ?? 0) + cell.calls)
+  }
+  const keys = [...totals.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, MAX_HEATMAP_KEYS)
+    .map(([key]) => key)
+
+  const index = new Map<string, UsageHeatmapCell>()
+  for (const cell of cells) {
+    index.set(`${cell.bucket}\u0000${cell.key}`, cell)
+  }
+
+  let maxCalls = 1
+  for (const cell of cells) {
+    if (cell.calls > maxCalls) maxCalls = cell.calls
+  }
+
+  return { buckets, keys, index, maxCalls }
+}
+
+export function OverviewSection() {
+  const { t } = useTranslation()
+  const slow = useSlowRequests({ limit: 20, minLatencyMs: 1000, hours: 24 })
+  const heatmap = useUsageHeatmap({ days: 7, dimension: 'site' })
+
+  const layout = useMemo(
+    () => heatmapLayout(heatmap.data?.cells ?? []),
+    [heatmap.data]
+  )
+
+  const slowItems = slow.data?.items ?? []
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <Card>
+        <CardHeader>
+          <CardTitle className='flex items-center gap-2 text-sm font-medium'>
+            <Flame className='size-4' />
+            {t('observability.overview.slowRequests.title')}
+          </CardTitle>
+          <CardDescription className='text-xs'>
+            {t('observability.overview.slowRequests.description')}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {renderSlowRequestsBody(slow.isLoading, slowItems, t)}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className='flex items-center gap-2 text-sm font-medium'>
+            <BarChart3 className='size-4' />
+            {t('observability.overview.heatmap.title')}
+          </CardTitle>
+          <CardDescription className='text-xs'>
+            {t('observability.overview.heatmap.description')}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {renderHeatmapBody(heatmap.isLoading, layout, t)}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function renderSlowRequestsBody(
+  loading: boolean,
+  items: SlowRequestItem[],
+  t: (key: string) => string
+): ReactNode {
+  if (loading) {
+    return <Skeleton className='h-48 w-full rounded-md' />
+  }
+  if (items.length === 0) {
+    return (
+      <div className='flex min-h-24 flex-col items-center justify-center gap-2 rounded-lg border border-dashed py-8 text-center'>
+        <p className='text-muted-foreground text-sm'>
+          {t('observability.overview.slowRequests.empty')}
+        </p>
+      </div>
+    )
+  }
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>{t('observability.overview.slowRequests.colModel')}</TableHead>
+          <TableHead>{t('observability.overview.slowRequests.colSite')}</TableHead>
+          <TableHead className='text-right'>
+            {t('observability.overview.slowRequests.colLatency')}
+          </TableHead>
+          <TableHead className='text-right'>
+            {t('observability.overview.slowRequests.colFirstByte')}
+          </TableHead>
+          <TableHead className='text-right'>
+            {t('observability.overview.slowRequests.colHttp')}
+          </TableHead>
+          <TableHead>{t('observability.overview.slowRequests.colStatus')}</TableHead>
+          <TableHead className='text-right'>
+            {t('observability.overview.slowRequests.colTime')}
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {items.map((item) => (
+          <TableRow key={item.id}>
+            <TableCell className='max-w-56 truncate font-medium'>
+              {item.model || '—'}
+            </TableCell>
+            <TableCell className='max-w-40 truncate'>
+              {item.siteName || '—'}
+            </TableCell>
+            <TableCell className='text-right tabular-nums'>
+              {formatLatency(item.latencyMs)}
+            </TableCell>
+            <TableCell className='text-right tabular-nums'>
+              {formatLatency(item.firstByteLatencyMs)}
+            </TableCell>
+            <TableCell className='text-right tabular-nums'>
+              {item.httpStatus || '—'}
+            </TableCell>
+            <TableCell className='truncate'>{item.status || '—'}</TableCell>
+            <TableCell className='text-right tabular-nums'>
+              {formatClock(item.createdAt)}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+function renderHeatmapBody(
+  loading: boolean,
+  layout: ReturnType<typeof heatmapLayout>,
+  t: (key: string) => string
+): ReactNode {
+  if (loading) {
+    return <Skeleton className='h-48 w-full rounded-md' />
+  }
+  if (layout.keys.length === 0) {
+    return (
+      <div className='flex min-h-24 flex-col items-center justify-center gap-2 rounded-lg border border-dashed py-8 text-center'>
+        <p className='text-muted-foreground text-sm'>
+          {t('observability.overview.heatmap.empty')}
+        </p>
+      </div>
+    )
+  }
+  return (
+    <div className='overflow-x-auto'>
+      <div className='min-w-max'>
+        <div
+          className='grid gap-px'
+          style={{
+            gridTemplateColumns: `160px repeat(${layout.buckets.length}, 14px)`,
+          }}
+        >
+          <div />
+          {layout.buckets.map((bucket) => (
+            <div
+              key={bucket}
+              className='size-[14px]'
+              title={formatBucket(bucket)}
+              aria-label={formatBucket(bucket)}
+            />
+          ))}
+          {layout.keys.map((key) => (
+            <HeatmapRow
+              key={key}
+              keyName={key}
+              buckets={layout.buckets}
+              index={layout.index}
+              maxCalls={layout.maxCalls}
+            />
+          ))}
+        </div>
+        <div className='mt-2 flex items-center justify-end gap-2 text-xs text-muted-foreground'>
+          <span>{t('observability.overview.heatmap.legendLow')}</span>
+          <div className='flex gap-px'>
+            {[0, 0.25, 0.5, 0.75, 1].map((alpha) => (
+              <div
+                key={alpha}
+                className='size-3 rounded-sm'
+                style={{
+                  backgroundColor: `color-mix(in srgb, var(--chart-1) ${Math.round(alpha * 100)}%, transparent)`,
+                }}
+              />
+            ))}
+          </div>
+          <span>{t('observability.overview.heatmap.legendHigh')}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function HeatmapRow({
+  keyName,
+  buckets,
+  index,
+  maxCalls,
+}: {
+  keyName: string
+  buckets: string[]
+  index: Map<string, UsageHeatmapCell>
+  maxCalls: number
+}) {
+  const label = index.get(`${buckets[0]}\u0000${keyName}`)?.label ?? keyName
+  return (
+    <>
+      <div className='flex items-center gap-1 truncate pr-2 text-xs'>
+        <span className='truncate' title={label}>
+          {label}
+        </span>
+      </div>
+      {buckets.map((bucket) => {
+        const cell = index.get(`${bucket}\u0000${keyName}`)
+        const intensity = cell ? cell.calls / maxCalls : 0
+        return (
+          <div
+            key={bucket}
+            className='h-[14px] w-[14px] rounded-[2px]'
+            style={{
+              backgroundColor: `color-mix(in srgb, var(--chart-1) ${Math.round(intensity * 100)}%, transparent)`,
+            }}
+            title={cell ? `${label} · ${bucket} · ${cell.calls}` : undefined}
+          />
+        )
+      })}
+    </>
+  )
+}
+

--- a/web/src/features/observability/sections/overview/overview-section.tsx
+++ b/web/src/features/observability/sections/overview/overview-section.tsx
@@ -2,9 +2,9 @@
 // + usage heatmap. Both consume existing /api/stats endpoints (no new
 // backend surface) so the Overview reads like a curated lens over proxy data.
 
+import { BarChart3, Flame } from 'lucide-react'
 import { useMemo, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import { BarChart3, Flame } from 'lucide-react'
 
 import {
   Card,
@@ -142,8 +142,12 @@ function renderSlowRequestsBody(
     <Table>
       <TableHeader>
         <TableRow>
-          <TableHead>{t('observability.overview.slowRequests.colModel')}</TableHead>
-          <TableHead>{t('observability.overview.slowRequests.colSite')}</TableHead>
+          <TableHead>
+            {t('observability.overview.slowRequests.colModel')}
+          </TableHead>
+          <TableHead>
+            {t('observability.overview.slowRequests.colSite')}
+          </TableHead>
           <TableHead className='text-right'>
             {t('observability.overview.slowRequests.colLatency')}
           </TableHead>
@@ -153,7 +157,9 @@ function renderSlowRequestsBody(
           <TableHead className='text-right'>
             {t('observability.overview.slowRequests.colHttp')}
           </TableHead>
-          <TableHead>{t('observability.overview.slowRequests.colStatus')}</TableHead>
+          <TableHead>
+            {t('observability.overview.slowRequests.colStatus')}
+          </TableHead>
           <TableHead className='text-right'>
             {t('observability.overview.slowRequests.colTime')}
           </TableHead>
@@ -233,7 +239,7 @@ function renderHeatmapBody(
             />
           ))}
         </div>
-        <div className='mt-2 flex items-center justify-end gap-2 text-xs text-muted-foreground'>
+        <div className='text-muted-foreground mt-2 flex items-center justify-end gap-2 text-xs'>
           <span>{t('observability.overview.heatmap.legendLow')}</span>
           <div className='flex gap-px'>
             {[0, 0.25, 0.5, 0.75, 1].map((alpha) => (
@@ -289,4 +295,3 @@ function HeatmapRow({
     </>
   )
 }
-

--- a/web/src/features/observability/sections/proxy-logs/index.ts
+++ b/web/src/features/observability/sections/proxy-logs/index.ts
@@ -1,0 +1,1 @@
+export { ProxyLogsSection } from './proxy-logs-section'

--- a/web/src/features/observability/sections/proxy-logs/proxy-logs-section.tsx
+++ b/web/src/features/observability/sections/proxy-logs/proxy-logs-section.tsx
@@ -1,0 +1,46 @@
+// metapi-go/features/observability/sections/proxy-logs — pointer to the full
+// proxy request log workspace. The existing /proxy-logs page owns its own
+// URL state and single h1, so the Observability workspace links out instead
+// of embedding it and breaking the page-title / URL-state contracts.
+
+import { useTranslation } from 'react-i18next'
+import { Link } from '@tanstack/react-router'
+import { ScrollText } from 'lucide-react'
+
+import { buttonVariants } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+
+export function ProxyLogsSection() {
+  const { t } = useTranslation()
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className='flex items-center gap-2 text-sm font-medium'>
+          <ScrollText className='size-4' />
+          {t('observability.proxyLogs.title')}
+        </CardTitle>
+        <CardDescription className='text-xs'>
+          {t('observability.proxyLogs.description')}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className='flex flex-col items-start gap-3'>
+        <p className='text-muted-foreground text-sm'>
+          {t('observability.proxyLogs.hint')}
+        </p>
+        <Link
+          to='/proxy-logs'
+          className={buttonVariants({ variant: 'outline', size: 'sm' })}
+        >
+          {t('observability.proxyLogs.open')}
+        </Link>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/src/features/observability/sections/proxy-logs/proxy-logs-section.tsx
+++ b/web/src/features/observability/sections/proxy-logs/proxy-logs-section.tsx
@@ -3,9 +3,9 @@
 // URL state and single h1, so the Observability workspace links out instead
 // of embedding it and breaking the page-title / URL-state contracts.
 
-import { useTranslation } from 'react-i18next'
 import { Link } from '@tanstack/react-router'
 import { ScrollText } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 import { buttonVariants } from '@/components/ui/button'
 import {

--- a/web/src/features/observability/types.ts
+++ b/web/src/features/observability/types.ts
@@ -1,0 +1,122 @@
+// metapi-go/features/observability — shared types for the Observability
+// workspace (Overview / Health / Proxy Logs). The sections own their data
+// fetching; these types describe the backend wire contracts they consume.
+
+import type { ReactNode } from 'react'
+
+export type ObservabilitySectionId = 'overview' | 'health' | 'proxy-logs'
+
+export type ObservabilitySection = {
+  id: ObservabilitySectionId
+  title: string
+  description?: string
+  build: () => ReactNode
+}
+
+export type ObservabilitySectionNavItem = {
+  title: string
+  url: string
+}
+
+// ---- /api/stats/usage-heatmap ------------------------------------------
+
+export type UsageHeatmapCell = {
+  bucket: string
+  key: string
+  label: string
+  calls: number
+  tokens: number
+  spend: number
+}
+
+export type UsageHeatmapResponse = {
+  dimension: 'site' | 'model'
+  days: number
+  since: string
+  source: string
+  cellLimit: number
+  count: number
+  cells: UsageHeatmapCell[]
+}
+
+// ---- /api/stats/slow-requests ------------------------------------------
+
+export type SlowRequestItem = {
+  id: number
+  model: string
+  status: string
+  latencyMs: number
+  firstByteLatencyMs: number
+  httpStatus: number
+  requestId: string
+  accountId: number | null
+  siteId: number | null
+  siteName: string
+  createdAt: string
+}
+
+export type SlowRequestsResponse = {
+  hours: number
+  minLatencyMs: number
+  limit: number
+  since: string
+  count: number
+  items: SlowRequestItem[]
+}
+
+// ---- /api/monitor/health -------------------------------------------------
+
+export type RuntimeHealthBreaker = {
+  siteId: number
+  model: string
+  breakerLevel: number
+  breakerUntilMs?: number | null
+  penaltyScore: number
+}
+
+export type StatusCounts = {
+  total: number
+  active: number
+  disabled: number
+  other: number
+}
+
+export type CooldownChannel = {
+  channelId: number
+  accountId: number
+  siteId: number
+  siteName: string
+  failCount: number
+  cooldownUntil: string
+}
+
+export type MonitorHealthResponse = {
+  generatedAt: string
+  runtimeHealth: {
+    sitesTracked: number
+    sitesBreakerOpen: number
+    modelsTracked: number
+    modelsBreakerOpen: number
+    openBreakers: RuntimeHealthBreaker[]
+  }
+  cooldown: {
+    channelsCooling: number
+    channelsWithFailures: number
+    channelsRecentlyFailed: number
+    cooling: CooldownChannel[]
+  }
+  sites: StatusCounts
+  accounts: StatusCounts
+}
+
+export const observabilityKeys = {
+  all: ['observability'] as const,
+  usageHeatmap: (params: { days?: number; dimension?: 'site' | 'model' }) =>
+    [...observabilityKeys.all, 'usage-heatmap', params] as const,
+  slowRequests: (params: {
+    limit?: number
+    minLatencyMs?: number
+    hours?: number
+  }) => [...observabilityKeys.all, 'slow-requests', params] as const,
+  monitorHealth: () => [...observabilityKeys.all, 'monitor-health'] as const,
+}

--- a/web/src/features/observability/utils/section-registry.ts
+++ b/web/src/features/observability/utils/section-registry.ts
@@ -26,9 +26,7 @@ export type ObservabilitySectionRegistry<TSectionId extends string> = {
   getSectionMeta: (sectionId: TSectionId) => ObservabilitySection
 }
 
-export function createObservabilitySectionRegistry<
-  TSectionId extends string,
->(
+export function createObservabilitySectionRegistry<TSectionId extends string>(
   config: ObservabilitySectionRegistryConfig<TSectionId>
 ): ObservabilitySectionRegistry<TSectionId> {
   const { sections, defaultSection, basePath } = config

--- a/web/src/features/observability/utils/section-registry.ts
+++ b/web/src/features/observability/utils/section-registry.ts
@@ -1,0 +1,62 @@
+// metapi-go/features/observability — createSectionRegistry generic factory.
+//
+// Mirrors the dashboard feature's section-registry: each section is a lazy
+// builder returning a ReactNode; the registry derives nav items
+// (`/observability?section=<id>`) and the active section's content. The
+// generic `TSectionId` narrows the literal union for compile-time safety.
+
+import type { ReactNode } from 'react'
+
+import type {
+  ObservabilitySection,
+  ObservabilitySectionNavItem,
+} from '../types'
+
+export type ObservabilitySectionRegistryConfig<TSectionId extends string> = {
+  sections: readonly ObservabilitySection[]
+  defaultSection: TSectionId
+  basePath: string
+}
+
+export type ObservabilitySectionRegistry<TSectionId extends string> = {
+  sectionIds: readonly TSectionId[]
+  defaultSection: TSectionId
+  getSectionNavItems: () => ObservabilitySectionNavItem[]
+  getSectionContent: (sectionId: TSectionId) => ReactNode
+  getSectionMeta: (sectionId: TSectionId) => ObservabilitySection
+}
+
+export function createObservabilitySectionRegistry<
+  TSectionId extends string,
+>(
+  config: ObservabilitySectionRegistryConfig<TSectionId>
+): ObservabilitySectionRegistry<TSectionId> {
+  const { sections, defaultSection, basePath } = config
+
+  const sectionIds = sections.map(
+    (section) => section.id
+  ) as unknown as readonly TSectionId[]
+
+  function getSectionMeta(sectionId: TSectionId): ObservabilitySection {
+    return sections.find((section) => section.id === sectionId) ?? sections[0]
+  }
+
+  function getSectionNavItems(): ObservabilitySectionNavItem[] {
+    return sections.map((section) => ({
+      title: section.title,
+      url: `${basePath}?section=${section.id}`,
+    }))
+  }
+
+  function getSectionContent(sectionId: TSectionId): ReactNode {
+    return getSectionMeta(sectionId).build()
+  }
+
+  return {
+    sectionIds,
+    defaultSection,
+    getSectionNavItems,
+    getSectionContent,
+    getSectionMeta,
+  }
+}

--- a/web/src/features/proxy-logs/components/proxy-logs-columns.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-columns.tsx
@@ -20,8 +20,8 @@ import {
 import { cn } from '@/lib/utils'
 
 import type { ProxyLog } from '../types'
-import { TimingCell } from './timing-cell'
 import { StatusBadge } from './status-badge'
+import { TimingCell } from './timing-cell'
 
 export type ProxyLogsColumnActions = { onView: (log: ProxyLog) => void }
 

--- a/web/src/features/proxy-logs/components/proxy-logs-columns.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-columns.tsx
@@ -20,7 +20,7 @@ import {
 import { cn } from '@/lib/utils'
 
 import type { ProxyLog } from '../types'
-import { LatencyBadge } from './latency-badge'
+import { TimingCell } from './timing-cell'
 import { StatusBadge } from './status-badge'
 
 export type ProxyLogsColumnActions = { onView: (log: ProxyLog) => void }
@@ -203,7 +203,7 @@ export function useProxyLogsColumns(
         />
       ),
       cell: ({ row }) => (
-        <LatencyBadge
+        <TimingCell
           latencyMs={row.original.latencyMs}
           firstByteLatencyMs={row.original.firstByteLatencyMs}
         />

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -283,6 +283,7 @@ export function ProxyLogsPage() {
   }
 
   const hasLatencyFilter = latencyMin !== null || latencyMax !== null
+  const slowOnly = latencyMin === 2000 && latencyMax === null
 
   return (
     <div className='flex h-full flex-col gap-3 p-4'>
@@ -516,6 +517,24 @@ export function ProxyLogsPage() {
                   }}
                   className='w-[100px]'
                 />
+              </div>
+              <div className='flex items-center gap-1.5'>
+                <Button
+                  type='button'
+                  variant={slowOnly ? 'default' : 'outline'}
+                  size='sm'
+                  onClick={() => {
+                    if (slowOnly) {
+                      setLatencyMin(null)
+                    } else {
+                      setLatencyMin(2000)
+                      setLatencyMax(null)
+                    }
+                    setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+                  }}
+                >
+                  {t('proxyLogs.page.slowOnly')}
+                </Button>
               </div>
               {hasLatencyFilter && (
                 <div className='flex items-center gap-1.5 text-xs'>

--- a/web/src/features/proxy-logs/components/timing-cell.tsx
+++ b/web/src/features/proxy-logs/components/timing-cell.tsx
@@ -54,7 +54,7 @@ export function TimingCell({
 
   return (
     <div className={cn('flex w-fit items-center gap-2', className)}>
-      <span className='text-xs font-medium tabular-nums whitespace-nowrap'>
+      <span className='text-xs font-medium whitespace-nowrap tabular-nums'>
         {formatDuration(latencyMs)}
       </span>
       <span

--- a/web/src/features/proxy-logs/components/timing-cell.tsx
+++ b/web/src/features/proxy-logs/components/timing-cell.tsx
@@ -1,0 +1,91 @@
+// metapi-go/features/proxy-logs/components — timing cell.
+//
+// Two-segment latency bar: the left segment is time-to-first-byte and the
+// right segment is the remaining transfer time, so an operator sees both
+// "first token" and "total" in one compact cell. A Slow marker (text, not
+// color-only) appears when total latency crosses the slow threshold. All
+// segment colors are token-based (success/destructive/muted-foreground).
+
+import { useTranslation } from 'react-i18next'
+
+import { cn } from '@/lib/utils'
+
+const SLOW_THRESHOLD_MS = 2000
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)} ms`
+  const seconds = ms / 1000
+  return seconds >= 100 ? `${seconds.toFixed(0)} s` : `${seconds.toFixed(2)} s`
+}
+
+export type TimingCellProps = {
+  latencyMs: number | null | undefined
+  firstByteLatencyMs?: number | null
+  className?: string
+}
+
+export function TimingCell({
+  latencyMs,
+  firstByteLatencyMs,
+  className,
+}: TimingCellProps) {
+  const { t } = useTranslation()
+  if (latencyMs === null || latencyMs === undefined || latencyMs < 0) {
+    return (
+      <span className={cn('text-muted-foreground text-sm', className)}>—</span>
+    )
+  }
+
+  const total = Math.max(1, latencyMs)
+  const hasFirstByte =
+    firstByteLatencyMs !== null &&
+    firstByteLatencyMs !== undefined &&
+    firstByteLatencyMs >= 0
+  const firstByte = hasFirstByte ? Math.min(firstByteLatencyMs, total) : 0
+  const firstBytePct = (firstByte / total) * 100
+  const isSlow = latencyMs >= SLOW_THRESHOLD_MS
+
+  const ariaLabel = hasFirstByte
+    ? t('proxyLogs.timing.ariaFirstByte', {
+        firstByte: formatDuration(firstByte),
+        total: formatDuration(latencyMs),
+      })
+    : t('proxyLogs.timing.ariaTotal', { total: formatDuration(latencyMs) })
+
+  return (
+    <div className={cn('flex w-fit items-center gap-2', className)}>
+      <span className='text-xs font-medium tabular-nums whitespace-nowrap'>
+        {formatDuration(latencyMs)}
+      </span>
+      <span
+        role='img'
+        aria-label={ariaLabel}
+        className={cn(
+          'inline-flex h-1.5 w-16 shrink-0 items-stretch overflow-hidden rounded-full',
+          'bg-muted'
+        )}
+      >
+        <span
+          className={cn('h-full', isSlow ? 'bg-destructive' : 'bg-success')}
+          style={{ width: `${firstBytePct}%` }}
+        />
+        <span
+          className={cn(
+            'h-full flex-1',
+            isSlow ? 'bg-destructive/40' : 'bg-muted-foreground/30'
+          )}
+        />
+      </span>
+      {isSlow ? (
+        <span
+          className={cn(
+            'border-destructive/30 bg-destructive/10 text-destructive-soft-fg',
+            'rounded-sm border px-1 py-px text-[10px] font-medium whitespace-nowrap'
+          )}
+        >
+          {t('proxyLogs.timing.slow')}
+        </span>
+      ) : null}
+    </div>
+  )
+}

--- a/web/src/hooks/use-sidebar-data.ts
+++ b/web/src/hooks/use-sidebar-data.ts
@@ -116,4 +116,3 @@ export function useSidebarData(): SidebarData {
     ],
   }
 }
-

--- a/web/src/hooks/use-sidebar-data.ts
+++ b/web/src/hooks/use-sidebar-data.ts
@@ -4,6 +4,7 @@
 // Titles are i18n keys resolved via t() at render time (nav-group.tsx).
 
 import {
+  Activity,
   Boxes,
   CalendarCheck,
   FlaskConical,
@@ -56,6 +57,11 @@ export function useSidebarData(): SidebarData {
             title: 'sidebar.items.proxyLogs',
             url: '/proxy-logs',
             icon: ScrollText,
+          },
+          {
+            title: 'sidebar.items.observability',
+            url: '/observability',
+            icon: Activity,
           },
         ],
       },
@@ -110,3 +116,4 @@ export function useSidebarData(): SidebarData {
     ],
   }
 }
+

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1876,13 +1876,100 @@
         "lavender-dream": "Lavender Dream"
       }
     },
+    "observability": {
+    "title": "Observability",
+    "description": "Health, breakers and request analytics across sites and accounts.",
+    "sections": {
+      "overview": {
+        "title": "Overview",
+        "description": "Slow request ranking and usage density."
+      },
+      "health": {
+        "title": "Health",
+        "description": "Site/account health plus routing breaker and cooldown state."
+      },
+      "proxyLogs": {
+        "title": "Proxy Logs",
+        "description": "Full proxy request log workspace."
+      }
+    },
+    "overview": {
+      "slowRequests": {
+        "title": "Slow requests (top)",
+        "description": "Highest-latency proxy requests in the selected window.",
+        "empty": "No slow requests in the current window.",
+        "colModel": "Model",
+        "colSite": "Site",
+        "colLatency": "Latency",
+        "colFirstByte": "First byte",
+        "colHttp": "HTTP",
+        "colStatus": "Status",
+        "colTime": "Time"
+      },
+      "heatmap": {
+        "title": "Usage heatmap",
+        "description": "Hourly call density by site.",
+        "empty": "No usage density data for the selected range.",
+        "legendLow": "Less",
+        "legendHigh": "More"
+      }
+    },
+    "health": {
+      "runtime": {
+        "title": "Runtime health",
+        "description": "In-memory routing breaker state (soft isolation).",
+        "sitesTracked": "Sites tracked",
+        "sitesBreakerOpen": "Site breakers open",
+        "modelsTracked": "Models tracked",
+        "modelsBreakerOpen": "Model breakers open"
+      },
+      "breakers": {
+        "title": "Open breakers",
+        "description": "Sites and models currently filtered out of selection.",
+        "empty": "No open breakers.",
+        "colSite": "Site",
+        "colModel": "Model",
+        "colLevel": "Level",
+        "colUntil": "Until"
+      },
+      "cooldown": {
+        "title": "Channel cooldown",
+        "description": "Channels backing off after failures.",
+        "channelsCooling": "Cooling",
+        "channelsWithFailures": "With failures",
+        "channelsRecentlyFailed": "Recently failed",
+        "empty": "No channels currently cooling down.",
+        "colSite": "Site",
+        "colChannel": "Channel",
+        "colFailCount": "Fails",
+        "colUntil": "Until"
+      },
+      "inventory": {
+        "title": "Inventory",
+        "description": "Configured sites and accounts by status.",
+        "sites": "Sites",
+        "accounts": "Accounts",
+        "total": "Total",
+        "active": "Active",
+        "disabled": "Disabled",
+        "other": "Other"
+      }
+    },
+    "proxyLogs": {
+      "title": "Proxy request logs",
+      "description": "The full proxy request log workspace.",
+      "hint": "Open the dedicated proxy logs page for filters, columns and detail.",
+      "open": "Open proxy logs"
+    }
+  },
     "sidebar": {
       "groups": {
         "console": "Console",
         "configuration": "Configuration",
         "models": "Models",
         "system": "System",
-        "systemAdministration": "System Administration"
+        "systemAdministration": "System Administration",
+        "observability": "Observability"
       },
       "items": {
         "dashboard": "Dashboard",
@@ -1890,6 +1977,7 @@
         "accounts": "Accounts",
         "checkin": "Check-in",
         "proxyLogs": "Proxy Logs",
+        "observability": "Observability",
         "monitors": "Monitors",
         "tokenRoutes": "Token Routes",
         "oauth": "OAuth",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1877,91 +1877,91 @@
       }
     },
     "observability": {
-    "title": "Observability",
-    "description": "Health, breakers and request analytics across sites and accounts.",
-    "sections": {
+      "title": "Observability",
+      "description": "Health, breakers and request analytics across sites and accounts.",
+      "sections": {
+        "overview": {
+          "title": "Overview",
+          "description": "Slow request ranking and usage density."
+        },
+        "health": {
+          "title": "Health",
+          "description": "Site/account health plus routing breaker and cooldown state."
+        },
+        "proxyLogs": {
+          "title": "Proxy Logs",
+          "description": "Full proxy request log workspace."
+        }
+      },
       "overview": {
-        "title": "Overview",
-        "description": "Slow request ranking and usage density."
+        "slowRequests": {
+          "title": "Slow requests (top)",
+          "description": "Highest-latency proxy requests in the selected window.",
+          "empty": "No slow requests in the current window.",
+          "colModel": "Model",
+          "colSite": "Site",
+          "colLatency": "Latency",
+          "colFirstByte": "First byte",
+          "colHttp": "HTTP",
+          "colStatus": "Status",
+          "colTime": "Time"
+        },
+        "heatmap": {
+          "title": "Usage heatmap",
+          "description": "Hourly call density by site.",
+          "empty": "No usage density data for the selected range.",
+          "legendLow": "Less",
+          "legendHigh": "More"
+        }
       },
       "health": {
-        "title": "Health",
-        "description": "Site/account health plus routing breaker and cooldown state."
+        "runtime": {
+          "title": "Runtime health",
+          "description": "In-memory routing breaker state (soft isolation).",
+          "sitesTracked": "Sites tracked",
+          "sitesBreakerOpen": "Site breakers open",
+          "modelsTracked": "Models tracked",
+          "modelsBreakerOpen": "Model breakers open"
+        },
+        "breakers": {
+          "title": "Open breakers",
+          "description": "Sites and models currently filtered out of selection.",
+          "empty": "No open breakers.",
+          "colSite": "Site",
+          "colModel": "Model",
+          "colLevel": "Level",
+          "colUntil": "Until"
+        },
+        "cooldown": {
+          "title": "Channel cooldown",
+          "description": "Channels backing off after failures.",
+          "channelsCooling": "Cooling",
+          "channelsWithFailures": "With failures",
+          "channelsRecentlyFailed": "Recently failed",
+          "empty": "No channels currently cooling down.",
+          "colSite": "Site",
+          "colChannel": "Channel",
+          "colFailCount": "Fails",
+          "colUntil": "Until"
+        },
+        "inventory": {
+          "title": "Inventory",
+          "description": "Configured sites and accounts by status.",
+          "sites": "Sites",
+          "accounts": "Accounts",
+          "total": "Total",
+          "active": "Active",
+          "disabled": "Disabled",
+          "other": "Other"
+        }
       },
       "proxyLogs": {
-        "title": "Proxy Logs",
-        "description": "Full proxy request log workspace."
+        "title": "Proxy request logs",
+        "description": "The full proxy request log workspace.",
+        "hint": "Open the dedicated proxy logs page for filters, columns and detail.",
+        "open": "Open proxy logs"
       }
     },
-    "overview": {
-      "slowRequests": {
-        "title": "Slow requests (top)",
-        "description": "Highest-latency proxy requests in the selected window.",
-        "empty": "No slow requests in the current window.",
-        "colModel": "Model",
-        "colSite": "Site",
-        "colLatency": "Latency",
-        "colFirstByte": "First byte",
-        "colHttp": "HTTP",
-        "colStatus": "Status",
-        "colTime": "Time"
-      },
-      "heatmap": {
-        "title": "Usage heatmap",
-        "description": "Hourly call density by site.",
-        "empty": "No usage density data for the selected range.",
-        "legendLow": "Less",
-        "legendHigh": "More"
-      }
-    },
-    "health": {
-      "runtime": {
-        "title": "Runtime health",
-        "description": "In-memory routing breaker state (soft isolation).",
-        "sitesTracked": "Sites tracked",
-        "sitesBreakerOpen": "Site breakers open",
-        "modelsTracked": "Models tracked",
-        "modelsBreakerOpen": "Model breakers open"
-      },
-      "breakers": {
-        "title": "Open breakers",
-        "description": "Sites and models currently filtered out of selection.",
-        "empty": "No open breakers.",
-        "colSite": "Site",
-        "colModel": "Model",
-        "colLevel": "Level",
-        "colUntil": "Until"
-      },
-      "cooldown": {
-        "title": "Channel cooldown",
-        "description": "Channels backing off after failures.",
-        "channelsCooling": "Cooling",
-        "channelsWithFailures": "With failures",
-        "channelsRecentlyFailed": "Recently failed",
-        "empty": "No channels currently cooling down.",
-        "colSite": "Site",
-        "colChannel": "Channel",
-        "colFailCount": "Fails",
-        "colUntil": "Until"
-      },
-      "inventory": {
-        "title": "Inventory",
-        "description": "Configured sites and accounts by status.",
-        "sites": "Sites",
-        "accounts": "Accounts",
-        "total": "Total",
-        "active": "Active",
-        "disabled": "Disabled",
-        "other": "Other"
-      }
-    },
-    "proxyLogs": {
-      "title": "Proxy request logs",
-      "description": "The full proxy request log workspace.",
-      "hint": "Open the dedicated proxy logs page for filters, columns and detail.",
-      "open": "Open proxy logs"
-    }
-  },
     "sidebar": {
       "groups": {
         "console": "Console",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -134,7 +134,8 @@
         "successRate": "Success rate",
         "priceInput": "Input price",
         "actions": "Actions",
-        "rowActions": "Row actions"
+        "rowActions": "Row actions",
+        "priceDetail": "Price detail"
       },
       "actions": {
         "viewDetails": "View details",
@@ -565,7 +566,9 @@
         "learnMore": "learn more",
         "dismiss": "Dismiss announcement"
       },
-      "statCard": { "trendLabel": "Trend" }
+      "statCard": {
+        "trendLabel": "Trend"
+      }
     },
     "settings": {
       "subareas": {
@@ -870,7 +873,10 @@
             "source": "Source",
             "actions": "Actions"
           },
-          "source": { "sync": "Auto", "manual": "Manual" },
+          "source": {
+            "sync": "Auto",
+            "manual": "Manual"
+          },
           "toast": {
             "generated": "Generated {{created}} redirects across {{accounts}} accounts.",
             "generateFailed": "Failed to generate redirects.",
@@ -1221,7 +1227,9 @@
           }
         }
       },
-      "stub": { "placeholder": "TODO phase 3: migrate content from legacy" }
+      "stub": {
+        "placeholder": "TODO phase 3: migrate content from legacy"
+      }
     },
     "accounts": {
       "page": {
@@ -1327,7 +1335,8 @@
         "checkinUnsupported": "Not supported",
         "checkinOn": "On",
         "checkinOff": "Off",
-        "actions": "Actions"
+        "actions": "Actions",
+        "healthDetail": "Health detail"
       },
       "detail": {
         "fallbackApiKey": "API Key connection",
@@ -1714,7 +1723,8 @@
         "latencyMin": "Latency ≥",
         "latencyMax": "Latency ≤",
         "latencyUnit": "ms",
-        "latencyExample": "Example:"
+        "latencyExample": "Example:",
+        "slowOnly": "Slow only"
       },
       "columns": {
         "createdAt": "Time",
@@ -1784,6 +1794,11 @@
         "all": "All",
         "success": "Success",
         "failed": "Failed"
+      },
+      "timing": {
+        "slow": "Slow",
+        "ariaFirstByte": "First byte {{firstByte}}, total {{total}}",
+        "ariaTotal": "Total {{total}}"
       }
     },
     "No Data": "No Data",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -134,7 +134,8 @@
         "successRate": "成功率",
         "priceInput": "输入价格",
         "actions": "操作",
-        "rowActions": "行操作"
+        "rowActions": "行操作",
+        "priceDetail": "价格明细"
       },
       "actions": {
         "viewDetails": "查看详情",
@@ -565,7 +566,9 @@
         "learnMore": "了解更多",
         "dismiss": "关闭公告"
       },
-      "statCard": { "trendLabel": "趋势" }
+      "statCard": {
+        "trendLabel": "趋势"
+      }
     },
     "settings": {
       "subareas": {
@@ -845,7 +848,9 @@
             "suffix": "令牌后缀",
             "suffixHint": "sk- 前缀固定。生成或输入新后缀。"
           },
-          "schema": { "suffixMinLength": "后缀至少 8 个字符。" },
+          "schema": {
+            "suffixMinLength": "后缀至少 8 个字符。"
+          },
           "toast": {
             "saved": "代理令牌已更新。",
             "saveFailed": "更新代理令牌失败。"
@@ -868,7 +873,10 @@
             "source": "来源",
             "actions": "操作"
           },
-          "source": { "sync": "自动", "manual": "手动" },
+          "source": {
+            "sync": "自动",
+            "manual": "手动"
+          },
           "toast": {
             "generated": "已生成 {{created}} 条重定向，涉及 {{accounts}} 个账号。",
             "generateFailed": "生成重定向失败。",
@@ -1056,7 +1064,11 @@
             "enabled": "状态",
             "actions": "操作"
           },
-          "severity": { "info": "信息", "warning": "警告", "critical": "严重" },
+          "severity": {
+            "info": "信息",
+            "warning": "警告",
+            "critical": "严重"
+          },
           "fields": {
             "title": "标题",
             "message": "内容",
@@ -1215,7 +1227,9 @@
           }
         }
       },
-      "stub": { "placeholder": "TODO phase 3: 从旧版迁移内容" }
+      "stub": {
+        "placeholder": "TODO phase 3: 从旧版迁移内容"
+      }
     },
     "accounts": {
       "page": {
@@ -1321,7 +1335,8 @@
         "checkinUnsupported": "不支持",
         "checkinOn": "已开启",
         "checkinOff": "未开启",
-        "actions": "操作"
+        "actions": "操作",
+        "healthDetail": "健康详情"
       },
       "detail": {
         "fallbackApiKey": "API Key 连接",
@@ -1708,7 +1723,8 @@
         "latencyMin": "延迟 ≥",
         "latencyMax": "延迟 ≤",
         "latencyUnit": "ms",
-        "latencyExample": "示例："
+        "latencyExample": "示例：",
+        "slowOnly": "仅慢请求"
       },
       "columns": {
         "createdAt": "时间",
@@ -1778,6 +1794,11 @@
         "all": "全部",
         "success": "成功",
         "failed": "失败"
+      },
+      "timing": {
+        "slow": "慢",
+        "ariaFirstByte": "首字节 {{firstByte}}，总计 {{total}}",
+        "ariaTotal": "总计 {{total}}"
       }
     },
     "No Data": "暂无数据",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1877,91 +1877,91 @@
       }
     },
     "observability": {
-    "title": "可观测性",
-    "description": "站点与账号的健康、熔断与请求分析。",
-    "sections": {
+      "title": "可观测性",
+      "description": "站点与账号的健康、熔断与请求分析。",
+      "sections": {
+        "overview": {
+          "title": "概览",
+          "description": "慢请求排名与用量密度。"
+        },
+        "health": {
+          "title": "健康",
+          "description": "站点/账号健康以及路由熔断与冷却状态。"
+        },
+        "proxyLogs": {
+          "title": "使用日志",
+          "description": "完整的使用日志工作区。"
+        }
+      },
       "overview": {
-        "title": "概览",
-        "description": "慢请求排名与用量密度。"
+        "slowRequests": {
+          "title": "慢请求（Top）",
+          "description": "所选时间窗内延迟最高的请求。",
+          "empty": "当前时间窗内没有慢请求。",
+          "colModel": "模型",
+          "colSite": "站点",
+          "colLatency": "延迟",
+          "colFirstByte": "首字节",
+          "colHttp": "HTTP",
+          "colStatus": "状态",
+          "colTime": "时间"
+        },
+        "heatmap": {
+          "title": "用量热力图",
+          "description": "按站点的小时调用密度。",
+          "empty": "所选范围内没有用量密度数据。",
+          "legendLow": "少",
+          "legendHigh": "多"
+        }
       },
       "health": {
-        "title": "健康",
-        "description": "站点/账号健康以及路由熔断与冷却状态。"
+        "runtime": {
+          "title": "运行时健康",
+          "description": "内存中的路由熔断状态（软隔离）。",
+          "sitesTracked": "已跟踪站点",
+          "sitesBreakerOpen": "站点熔断开启",
+          "modelsTracked": "已跟踪模型",
+          "modelsBreakerOpen": "模型熔断开启"
+        },
+        "breakers": {
+          "title": "已开启熔断",
+          "description": "当前被排除在选路之外的站点与模型。",
+          "empty": "没有开启的熔断。",
+          "colSite": "站点",
+          "colModel": "模型",
+          "colLevel": "级别",
+          "colUntil": "截至"
+        },
+        "cooldown": {
+          "title": "通道冷却",
+          "description": "失败后正在退避的通道。",
+          "channelsCooling": "冷却中",
+          "channelsWithFailures": "有失败",
+          "channelsRecentlyFailed": "最近失败",
+          "empty": "当前没有处于冷却的通道。",
+          "colSite": "站点",
+          "colChannel": "通道",
+          "colFailCount": "失败数",
+          "colUntil": "截至"
+        },
+        "inventory": {
+          "title": "资源清单",
+          "description": "按状态统计的站点与账号。",
+          "sites": "站点",
+          "accounts": "账号",
+          "total": "总计",
+          "active": "活跃",
+          "disabled": "停用",
+          "other": "其他"
+        }
       },
       "proxyLogs": {
         "title": "使用日志",
-        "description": "完整的使用日志工作区。"
+        "description": "完整的使用日志工作区。",
+        "hint": "打开独立的使用日志页面查看筛选、列与详情。",
+        "open": "打开使用日志"
       }
     },
-    "overview": {
-      "slowRequests": {
-        "title": "慢请求（Top）",
-        "description": "所选时间窗内延迟最高的请求。",
-        "empty": "当前时间窗内没有慢请求。",
-        "colModel": "模型",
-        "colSite": "站点",
-        "colLatency": "延迟",
-        "colFirstByte": "首字节",
-        "colHttp": "HTTP",
-        "colStatus": "状态",
-        "colTime": "时间"
-      },
-      "heatmap": {
-        "title": "用量热力图",
-        "description": "按站点的小时调用密度。",
-        "empty": "所选范围内没有用量密度数据。",
-        "legendLow": "少",
-        "legendHigh": "多"
-      }
-    },
-    "health": {
-      "runtime": {
-        "title": "运行时健康",
-        "description": "内存中的路由熔断状态（软隔离）。",
-        "sitesTracked": "已跟踪站点",
-        "sitesBreakerOpen": "站点熔断开启",
-        "modelsTracked": "已跟踪模型",
-        "modelsBreakerOpen": "模型熔断开启"
-      },
-      "breakers": {
-        "title": "已开启熔断",
-        "description": "当前被排除在选路之外的站点与模型。",
-        "empty": "没有开启的熔断。",
-        "colSite": "站点",
-        "colModel": "模型",
-        "colLevel": "级别",
-        "colUntil": "截至"
-      },
-      "cooldown": {
-        "title": "通道冷却",
-        "description": "失败后正在退避的通道。",
-        "channelsCooling": "冷却中",
-        "channelsWithFailures": "有失败",
-        "channelsRecentlyFailed": "最近失败",
-        "empty": "当前没有处于冷却的通道。",
-        "colSite": "站点",
-        "colChannel": "通道",
-        "colFailCount": "失败数",
-        "colUntil": "截至"
-      },
-      "inventory": {
-        "title": "资源清单",
-        "description": "按状态统计的站点与账号。",
-        "sites": "站点",
-        "accounts": "账号",
-        "total": "总计",
-        "active": "活跃",
-        "disabled": "停用",
-        "other": "其他"
-      }
-    },
-    "proxyLogs": {
-      "title": "使用日志",
-      "description": "完整的使用日志工作区。",
-      "hint": "打开独立的使用日志页面查看筛选、列与详情。",
-      "open": "打开使用日志"
-    }
-  },
     "sidebar": {
       "groups": {
         "console": "控制台",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1876,13 +1876,100 @@
         "lavender-dream": "薰衣草梦"
       }
     },
+    "observability": {
+    "title": "可观测性",
+    "description": "站点与账号的健康、熔断与请求分析。",
+    "sections": {
+      "overview": {
+        "title": "概览",
+        "description": "慢请求排名与用量密度。"
+      },
+      "health": {
+        "title": "健康",
+        "description": "站点/账号健康以及路由熔断与冷却状态。"
+      },
+      "proxyLogs": {
+        "title": "使用日志",
+        "description": "完整的使用日志工作区。"
+      }
+    },
+    "overview": {
+      "slowRequests": {
+        "title": "慢请求（Top）",
+        "description": "所选时间窗内延迟最高的请求。",
+        "empty": "当前时间窗内没有慢请求。",
+        "colModel": "模型",
+        "colSite": "站点",
+        "colLatency": "延迟",
+        "colFirstByte": "首字节",
+        "colHttp": "HTTP",
+        "colStatus": "状态",
+        "colTime": "时间"
+      },
+      "heatmap": {
+        "title": "用量热力图",
+        "description": "按站点的小时调用密度。",
+        "empty": "所选范围内没有用量密度数据。",
+        "legendLow": "少",
+        "legendHigh": "多"
+      }
+    },
+    "health": {
+      "runtime": {
+        "title": "运行时健康",
+        "description": "内存中的路由熔断状态（软隔离）。",
+        "sitesTracked": "已跟踪站点",
+        "sitesBreakerOpen": "站点熔断开启",
+        "modelsTracked": "已跟踪模型",
+        "modelsBreakerOpen": "模型熔断开启"
+      },
+      "breakers": {
+        "title": "已开启熔断",
+        "description": "当前被排除在选路之外的站点与模型。",
+        "empty": "没有开启的熔断。",
+        "colSite": "站点",
+        "colModel": "模型",
+        "colLevel": "级别",
+        "colUntil": "截至"
+      },
+      "cooldown": {
+        "title": "通道冷却",
+        "description": "失败后正在退避的通道。",
+        "channelsCooling": "冷却中",
+        "channelsWithFailures": "有失败",
+        "channelsRecentlyFailed": "最近失败",
+        "empty": "当前没有处于冷却的通道。",
+        "colSite": "站点",
+        "colChannel": "通道",
+        "colFailCount": "失败数",
+        "colUntil": "截至"
+      },
+      "inventory": {
+        "title": "资源清单",
+        "description": "按状态统计的站点与账号。",
+        "sites": "站点",
+        "accounts": "账号",
+        "total": "总计",
+        "active": "活跃",
+        "disabled": "停用",
+        "other": "其他"
+      }
+    },
+    "proxyLogs": {
+      "title": "使用日志",
+      "description": "完整的使用日志工作区。",
+      "hint": "打开独立的使用日志页面查看筛选、列与详情。",
+      "open": "打开使用日志"
+    }
+  },
     "sidebar": {
       "groups": {
         "console": "控制台",
         "configuration": "配置",
         "models": "模型",
         "system": "系统",
-        "systemAdministration": "系统管理"
+        "systemAdministration": "系统管理",
+        "observability": "可观测性"
       },
       "items": {
         "dashboard": "仪表盘",
@@ -1890,6 +1977,7 @@
         "accounts": "账号",
         "checkin": "签到",
         "proxyLogs": "使用日志",
+        "observability": "可观测性",
         "monitors": "监控",
         "tokenRoutes": "路由",
         "oauth": "OAuth",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1316,6 +1316,13 @@ export const api = {
   },
   getProxyLogDetail: (id: number) =>
     request(`/api/stats/proxy-logs/${id}`) as Promise<ProxyLogDetail>,
+  getUsageHeatmap: (params?: { days?: number; dimension?: 'site' | 'model' }) =>
+    request(`/api/stats/usage-heatmap${buildQueryString(params)}`),
+  getSlowRequests: (params?: {
+    limit?: number
+    minLatencyMs?: number
+    hours?: number
+  }) => request(`/api/stats/slow-requests${buildQueryString(params)}`),
   getProxyDebugTraces: (params?: { limit?: number }) =>
     request(
       `/api/stats/proxy-debug/traces${buildQueryString(params)}`
@@ -1815,6 +1822,7 @@ export const api = {
 
   // Monitor embed
   getMonitorConfig: () => request('/api/monitor/config'),
+  getMonitorHealth: () => request('/api/monitor/health'),
   updateMonitorConfig: (data: { ldohCookie?: string | null }) =>
     request('/api/monitor/config', {
       method: 'PUT',
@@ -1958,3 +1966,4 @@ export const api = {
     })
   },
 }
+

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1966,4 +1966,3 @@ export const api = {
     })
   },
 }
-

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as AuthenticatedDashboardRouteRouteImport } from './routes/_authe
 import { Route as AuthenticatedModelTesterRouteImport } from './routes/_authenticated/model-tester'
 import { Route as AuthenticatedModelsRouteImport } from './routes/_authenticated/models'
 import { Route as AuthenticatedOauthRouteImport } from './routes/_authenticated/oauth'
+import { Route as AuthenticatedObservabilityRouteImport } from './routes/_authenticated/observability'
 import { Route as AuthenticatedProxyLogsRouteImport } from './routes/_authenticated/proxy-logs'
 import { Route as AuthenticatedSettingsRouteRouteImport } from './routes/_authenticated/settings/route'
 import { Route as AuthenticatedSiteAnnouncementsRouteImport } from './routes/_authenticated/site-announcements'
@@ -82,6 +83,12 @@ const AuthenticatedOauthRoute = AuthenticatedOauthRouteImport.update({
   path: '/oauth',
   getParentRoute: () => AuthenticatedRouteRoute,
 } as any)
+const AuthenticatedObservabilityRoute =
+  AuthenticatedObservabilityRouteImport.update({
+    id: '/observability',
+    path: '/observability',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedProxyLogsRoute = AuthenticatedProxyLogsRouteImport.update({
   id: '/proxy-logs',
   path: '/proxy-logs',
@@ -158,6 +165,7 @@ export interface FileRoutesByFullPath {
   '/model-tester': typeof AuthenticatedModelTesterRoute
   '/models': typeof AuthenticatedModelsRoute
   '/oauth': typeof AuthenticatedOauthRoute
+  '/observability': typeof AuthenticatedObservabilityRoute
   '/proxy-logs': typeof AuthenticatedProxyLogsRoute
   '/site-announcements': typeof AuthenticatedSiteAnnouncementsRoute
   '/sites': typeof AuthenticatedSitesRoute
@@ -177,6 +185,7 @@ export interface FileRoutesByTo {
   '/model-tester': typeof AuthenticatedModelTesterRoute
   '/models': typeof AuthenticatedModelsRoute
   '/oauth': typeof AuthenticatedOauthRoute
+  '/observability': typeof AuthenticatedObservabilityRoute
   '/proxy-logs': typeof AuthenticatedProxyLogsRoute
   '/site-announcements': typeof AuthenticatedSiteAnnouncementsRoute
   '/sites': typeof AuthenticatedSitesRoute
@@ -200,6 +209,7 @@ export interface FileRoutesById {
   '/_authenticated/model-tester': typeof AuthenticatedModelTesterRoute
   '/_authenticated/models': typeof AuthenticatedModelsRoute
   '/_authenticated/oauth': typeof AuthenticatedOauthRoute
+  '/_authenticated/observability': typeof AuthenticatedObservabilityRoute
   '/_authenticated/proxy-logs': typeof AuthenticatedProxyLogsRoute
   '/_authenticated/site-announcements': typeof AuthenticatedSiteAnnouncementsRoute
   '/_authenticated/sites': typeof AuthenticatedSitesRoute
@@ -225,6 +235,7 @@ export interface FileRouteTypes {
     | '/model-tester'
     | '/models'
     | '/oauth'
+    | '/observability'
     | '/proxy-logs'
     | '/site-announcements'
     | '/sites'
@@ -244,6 +255,7 @@ export interface FileRouteTypes {
     | '/model-tester'
     | '/models'
     | '/oauth'
+    | '/observability'
     | '/proxy-logs'
     | '/site-announcements'
     | '/sites'
@@ -266,6 +278,7 @@ export interface FileRouteTypes {
     | '/_authenticated/model-tester'
     | '/_authenticated/models'
     | '/_authenticated/oauth'
+    | '/_authenticated/observability'
     | '/_authenticated/proxy-logs'
     | '/_authenticated/site-announcements'
     | '/_authenticated/sites'
@@ -354,6 +367,13 @@ declare module '@tanstack/react-router' {
       path: '/oauth'
       fullPath: '/oauth'
       preLoaderRoute: typeof AuthenticatedOauthRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/observability': {
+      id: '/_authenticated/observability'
+      path: '/observability'
+      fullPath: '/observability'
+      preLoaderRoute: typeof AuthenticatedObservabilityRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/proxy-logs': {
@@ -496,6 +516,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedModelTesterRoute: typeof AuthenticatedModelTesterRoute
   AuthenticatedModelsRoute: typeof AuthenticatedModelsRoute
   AuthenticatedOauthRoute: typeof AuthenticatedOauthRoute
+  AuthenticatedObservabilityRoute: typeof AuthenticatedObservabilityRoute
   AuthenticatedProxyLogsRoute: typeof AuthenticatedProxyLogsRoute
   AuthenticatedSiteAnnouncementsRoute: typeof AuthenticatedSiteAnnouncementsRoute
   AuthenticatedSitesRoute: typeof AuthenticatedSitesRoute
@@ -513,6 +534,7 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedModelTesterRoute: AuthenticatedModelTesterRoute,
   AuthenticatedModelsRoute: AuthenticatedModelsRoute,
   AuthenticatedOauthRoute: AuthenticatedOauthRoute,
+  AuthenticatedObservabilityRoute: AuthenticatedObservabilityRoute,
   AuthenticatedProxyLogsRoute: AuthenticatedProxyLogsRoute,
   AuthenticatedSiteAnnouncementsRoute: AuthenticatedSiteAnnouncementsRoute,
   AuthenticatedSitesRoute: AuthenticatedSitesRoute,

--- a/web/src/routes/_authenticated/observability.tsx
+++ b/web/src/routes/_authenticated/observability.tsx
@@ -1,0 +1,37 @@
+// metapi-go/routes — observability workspace.
+//
+// Single route for the Observability hub. The active section lives in the
+// `section` search param (validated by `observabilitySearchSchema`) so a
+// deep link restores the exact section. The component renders
+// `ObservabilityPage` with a navigate-backed `onSectionChange`, mirroring the
+// dashboard `$section` dispatcher.
+
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+
+import {
+  ObservabilityPage,
+  observabilitySearchSchema,
+  type ObservabilitySectionId,
+} from '@/features/observability'
+
+export const Route = createFileRoute('/_authenticated/observability')({
+  validateSearch: observabilitySearchSchema,
+  component: ObservabilityRoute,
+})
+
+function ObservabilityRoute() {
+  const { section } = Route.useSearch()
+  const navigate = useNavigate()
+
+  return (
+    <ObservabilityPage
+      activeSection={section}
+      onSectionChange={(sectionId: ObservabilitySectionId) =>
+        navigate({
+          to: '/observability',
+          search: { section: sectionId },
+        })
+      }
+    />
+  )
+}


### PR DESCRIPTION
## Summary
PR2 — visualization + observability (#603-#610).

Visualization:
- #604 / #610: proxy-logs timing double-bar cell (first-byte/total + Slow marker) + "Slow only" filter.
- #605: models lowest-price per-site detail tooltip; accounts health-reason tooltip.
- #603: verified already satisfied (chart series consume `--chart-1..5`); issue closed.
- #606: verified already satisfied (bulk-actions keyboard nav + aria-live); issue closed.

Observability workspace:
- #607: `web/src/features/observability/` shell + sidebar entry + drill-in view + `/observability` route.
- #608: `GET /api/monitor/health` read-only breaker/runtime-health projection (`routing.SnapshotRuntimeHealth`, soft isolation only) + Health page.
- #609: Overview slow-requests TOP + usage heatmap (reuses `slow-requests` / `usage-heatmap`).

## Validation
- Go: `go build ./cmd/server` ✅ · `go vet ./...` ✅ · `go test -p 1 ./... -count=1` ✅
- Web: `typecheck` ✅ · `lint` ✅ · `test` 29 files/337 ✅ · `build` ✅
- `-race` fails with Windows ThreadSanitizer "error 87" (known address-space limitation, not a code defect).