### PR TITLE
feat(import): site detect + unified import wizard + idempotent batch import (PR4)

### DIFF
--- a/handler/admin/payloads/sites.go
+++ b/handler/admin/payloads/sites.go
@@ -69,6 +69,30 @@ type SiteDisabledModelsPayload struct {
 	Models []string `json:"models"`
 }
 
+// SiteImportAccount mirrors an account to attach during batch import.
+type SiteImportAccount struct {
+	Username    *string `json:"username,omitempty"`
+	AccessToken string  `json:"accessToken,omitempty"`
+	APIToken    string  `json:"apiToken,omitempty"`
+}
+
+// SiteImportItem is one candidate site in POST /api/sites/import.
+type SiteImportItem struct {
+	Name              string              `json:"name"`
+	URL               string              `json:"url"`
+	Platform          *string             `json:"platform,omitempty"`
+	GlobalWeight      *float64            `json:"globalWeight,omitempty"`
+	MaxConcurrency    *int64              `json:"maxConcurrency,omitempty"`
+	DuplicateStrategy string              `json:"duplicateStrategy,omitempty"`
+	Accounts          []SiteImportAccount `json:"accounts,omitempty"`
+}
+
+// SiteImportPayload is the JSON body for POST /api/sites/import.
+type SiteImportPayload struct {
+	Items             []SiteImportItem `json:"items"`
+	DuplicateStrategy string           `json:"duplicateStrategy,omitempty"`
+}
+
 // ProbeNowBody is the JSON body for POST /api/sites/:id/probe-now.
 type ProbeNowBody struct {
 	Scope              *string `json:"scope,omitempty"`

--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -10,13 +10,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-chi/chi/v5"
-	"github.com/jmoiron/sqlx"
 	"github.com/deliciousbuding/metapi-go/handler/admin/payloads"
 	"github.com/deliciousbuding/metapi-go/routing"
 	"github.com/deliciousbuding/metapi-go/scheduler"
 	"github.com/deliciousbuding/metapi-go/service"
 	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
 )
 
 // RegisterSitesRoutes registers all /api/sites routes.
@@ -29,6 +29,7 @@ func RegisterSitesRoutes(r chi.Router, db *sqlx.DB) {
 	r.Delete("/api/sites/{id}", handler.deleteSite)
 	r.Post("/api/sites/batch", handler.batchSites)
 	r.Post("/api/sites/detect", handler.detectSite)
+	r.Post("/api/sites/import", handler.importSites)
 
 	// Sub-resources
 	r.Get("/api/sites/{id}/disabled-models", handler.getDisabledModels)
@@ -556,6 +557,67 @@ func (h *sitesHandler) detectSite(w http.ResponseWriter, r *http.Request) {
 	}
 	// Failure must not use HTTP 200 with an error body.
 	writeError(w, http.StatusBadRequest, "Could not detect platform")
+}
+
+// ---- Import Sites (batch, idempotent) ----
+
+func (h *sitesHandler) importSites(w http.ResponseWriter, r *http.Request) {
+	var body payloads.SiteImportPayload
+	if err := decodeJSONRequest(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid import payload.")
+		return
+	}
+	if len(body.Items) == 0 {
+		writeError(w, http.StatusBadRequest, "items is required")
+		return
+	}
+
+	strategy := service.ImportDuplicateStrategy(strings.TrimSpace(body.DuplicateStrategy))
+	if strategy == "" {
+		strategy = service.ImportDuplicateSkip
+	}
+	if strategy != service.ImportDuplicateSkip && strategy != service.ImportDuplicateMerge {
+		writeError(w, http.StatusBadRequest, "Invalid duplicateStrategy. Expected skip or merge.")
+		return
+	}
+
+	items := make([]service.ImportSiteInput, 0, len(body.Items))
+	for _, item := range body.Items {
+		platform := ""
+		if item.Platform != nil {
+			platform = *item.Platform
+		}
+		accounts := make([]service.ImportAccountInput, 0, len(item.Accounts))
+		for _, acct := range item.Accounts {
+			accounts = append(accounts, service.ImportAccountInput{
+				Username:    acct.Username,
+				AccessToken: acct.AccessToken,
+				APIToken:    acct.APIToken,
+			})
+		}
+		items = append(items, service.ImportSiteInput{
+			Name:              item.Name,
+			URL:               item.URL,
+			Platform:          platform,
+			GlobalWeight:      item.GlobalWeight,
+			MaxConcurrency:    item.MaxConcurrency,
+			DuplicateStrategy: service.ImportDuplicateStrategy(item.DuplicateStrategy),
+			Accounts:          accounts,
+		})
+	}
+
+	result, err := service.ImportSites(h.db, items, strategy)
+	if err != nil {
+		slog.Error("ImportSites failed", "err", err)
+		writeError(w, http.StatusInternalServerError, "Import sites failed")
+		return
+	}
+
+	if result.Imported > 0 {
+		service.InvalidateSiteCaches()
+		routing.InvalidateCache()
+	}
+	writeJSON(w, http.StatusOK, result)
 }
 
 // ---- Disabled Models ----

--- a/handler/admin/sites_import_test.go
+++ b/handler/admin/sites_import_test.go
@@ -1,0 +1,83 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestSites_ImportIdempotent(t *testing.T) {
+	_, r := setupSitesTest(t)
+
+	body := map[string]any{
+		"duplicateStrategy": "skip",
+		"items": []map[string]any{
+			{"name": "OpenAI", "url": "https://api.openai.com/v1"},
+			{"name": "Anthropic", "url": "https://api.anthropic.com/v1"},
+		},
+	}
+	resp := doPostJSON(t, r, "/api/sites/import", body)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("import status=%d body=%s", resp.Code, resp.Body.String())
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result["imported"].(float64) != 2 {
+		t.Fatalf("imported=%v want 2 (body=%s)", result["imported"], resp.Body.String())
+	}
+
+	// Idempotent re-run: both skipped.
+	resp2 := doPostJSON(t, r, "/api/sites/import", body)
+	var result2 map[string]any
+	if err := json.Unmarshal(resp2.Body.Bytes(), &result2); err != nil {
+		t.Fatalf("decode rerun: %v", err)
+	}
+	if result2["imported"].(float64) != 0 || result2["skipped"].(float64) != 2 {
+		t.Fatalf("rerun imported=%v skipped=%v want 0/2", result2["imported"], result2["skipped"])
+	}
+}
+
+func TestSites_ImportMergeAccounts(t *testing.T) {
+	_, r := setupSitesTest(t)
+
+	first := map[string]any{
+		"duplicateStrategy": "skip",
+		"items": []map[string]any{
+			{"name": "OpenAI", "url": "https://api.openai.com/v1", "accounts": []map[string]any{
+				{"username": "ops", "accessToken": "sk-1"},
+			}},
+		},
+	}
+	resp := doPostJSON(t, r, "/api/sites/import", first)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("first import status=%d body=%s", resp.Code, resp.Body.String())
+	}
+
+	merge := map[string]any{
+		"duplicateStrategy": "skip",
+		"items": []map[string]any{
+			{"name": "OpenAI", "url": "https://api.openai.com/v1", "duplicateStrategy": "merge", "accounts": []map[string]any{
+				{"username": "ops2", "accessToken": "sk-2"},
+			}},
+		},
+	}
+	resp2 := doPostJSON(t, r, "/api/sites/import", merge)
+	if resp2.Code != http.StatusOK {
+		t.Fatalf("merge import status=%d body=%s", resp2.Code, resp2.Body.String())
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(resp2.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode merge: %v", err)
+	}
+	if result["imported"].(float64) != 1 {
+		t.Fatalf("merge imported=%v want 1 (body=%s)", result["imported"], resp2.Body.String())
+	}
+	results := result["results"].([]any)
+	if results[0].(map[string]any)["status"] != "merged" {
+		t.Fatalf("merge status=%v want merged", results[0].(map[string]any)["status"])
+	}
+}

--- a/service/site_detect.go
+++ b/service/site_detect.go
@@ -6,9 +6,18 @@ import (
 )
 
 // DetectResult is the result of platform detection.
+//
+// Platform/SiteType both hold the detected platform (SiteType mirrors the TS
+// "siteType" naming; Platform is retained for backward compatibility with the
+// existing /api/sites/detect consumers). Confidence is a coarse signal of how
+// the platform was resolved (preset match = 1.0, hostname heuristic = 0.8).
+// CanonicalURL is the normalized URL suitable for persistence/dedup.
 type DetectResult struct {
 	URL                    string  `json:"url"`
+	CanonicalURL           string  `json:"canonicalUrl"`
 	Platform               string  `json:"platform"`
+	SiteType               string  `json:"siteType"`
+	Confidence             float64 `json:"confidence"`
 	InitializationPresetID *string `json:"initializationPresetId,omitempty"`
 }
 
@@ -45,7 +54,10 @@ func DetectSite(rawURL string) *DetectResult {
 		id := preset.ID
 		return &DetectResult{
 			URL:                    canonicalURL,
+			CanonicalURL:           CanonicalizeSiteURL(trimmed),
 			Platform:               preset.Platform,
+			SiteType:               preset.Platform,
+			Confidence:             1.0,
 			InitializationPresetID: &id,
 		}
 	}
@@ -117,7 +129,13 @@ func DetectSite(rawURL string) *DetectResult {
 		return nil
 	}
 
-	result := &DetectResult{URL: canonicalURL, Platform: platform}
+	result := &DetectResult{
+		URL:          canonicalURL,
+		CanonicalURL: CanonicalizeSiteURL(trimmed),
+		Platform:     platform,
+		SiteType:     platform,
+		Confidence:   0.8,
+	}
 	// Optional: attach a preset when hostname heuristics already chose a vendor
 	// platform and a defaultUrl fallback matches under that protocol family.
 	// Prefer the detected protocol family when the heuristic platform itself is

--- a/service/site_import.go
+++ b/service/site_import.go
@@ -1,0 +1,296 @@
+package service
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/jmoiron/sqlx"
+)
+
+// ImportDuplicateStrategy controls how already-present sites are handled.
+type ImportDuplicateStrategy string
+
+const (
+	ImportDuplicateSkip  ImportDuplicateStrategy = "skip"
+	ImportDuplicateMerge ImportDuplicateStrategy = "merge"
+)
+
+// ImportAccountInput is a lightweight account definition attached to an
+// imported site. Imported accounts are stored as skipModelFetch API-key style
+// credentials: the import wizard defers upstream model discovery to the normal
+// background refresh instead of blocking the batch on per-account verification.
+type ImportAccountInput struct {
+	Username    *string `json:"username,omitempty"`
+	AccessToken string  `json:"accessToken,omitempty"`
+	APIToken    string  `json:"apiToken,omitempty"`
+}
+
+// ImportSiteInput is one candidate site in a batch import.
+type ImportSiteInput struct {
+	Name              string                  `json:"name"`
+	URL               string                  `json:"url"`
+	Platform          string                  `json:"platform,omitempty"`
+	GlobalWeight      *float64                `json:"globalWeight,omitempty"`
+	MaxConcurrency    *int64                  `json:"maxConcurrency,omitempty"`
+	DuplicateStrategy ImportDuplicateStrategy `json:"duplicateStrategy,omitempty"`
+	Accounts          []ImportAccountInput    `json:"accounts,omitempty"`
+}
+
+// ImportSiteItemResult is the per-item outcome of a batch import.
+type ImportSiteItemResult struct {
+	Name   string `json:"name"`
+	URL    string `json:"url"`
+	Status string `json:"status"` // imported | merged | skipped | failed
+	Reason string `json:"reason,omitempty"`
+	SiteID int64  `json:"siteId,omitempty"`
+}
+
+// ImportSitesResult is the batch import summary. Imported counts sites that
+// were newly created plus sites whose accounts were merged into an existing
+// site; skipped counts idempotent duplicate no-ops; failed counts hard errors.
+type ImportSitesResult struct {
+	Imported int                    `json:"imported"`
+	Skipped  int                    `json:"skipped"`
+	Failed   int                    `json:"failed"`
+	Results  []ImportSiteItemResult `json:"results"`
+}
+
+// ImportSites creates sites (and optional accounts) idempotently. A site is
+// considered a duplicate when (platform, canonical url) already exists; with
+// skip it is a no-op, with merge any provided accounts are attached to the
+// existing site. Re-running the same payload therefore converges to
+// imported=0, skipped=N.
+func ImportSites(db *sqlx.DB, items []ImportSiteInput, strategy ImportDuplicateStrategy) (*ImportSitesResult, error) {
+	if strategy == "" {
+		strategy = ImportDuplicateSkip
+	}
+
+	result := &ImportSitesResult{Results: []ImportSiteItemResult{}}
+	for i := range items {
+		item := &items[i]
+		itemResult := importOneSite(db, *item, strategy)
+		switch itemResult.Status {
+		case "imported", "merged":
+			result.Imported++
+		case "skipped":
+			result.Skipped++
+		case "failed":
+			result.Failed++
+		}
+		result.Results = append(result.Results, itemResult)
+	}
+	return result, nil
+}
+
+func importOneSite(db *sqlx.DB, item ImportSiteInput, strategy ImportDuplicateStrategy) ImportSiteItemResult {
+	effectiveStrategy := strategy
+	if item.DuplicateStrategy != "" {
+		effectiveStrategy = item.DuplicateStrategy
+	}
+	name := strings.TrimSpace(item.Name)
+	rawURL := strings.TrimSpace(item.URL)
+	canonicalURL := CanonicalizeSiteURL(rawURL)
+
+	base := ImportSiteItemResult{Name: name, URL: canonicalURL}
+
+	if rawURL == "" {
+		base.Reason = "Invalid url. Expected non-empty string."
+		base.Status = "failed"
+		return base
+	}
+	if name == "" {
+		base.Reason = "Invalid name. Expected non-empty string."
+		base.Status = "failed"
+		return base
+	}
+	if !IsValidHTTPURL(rawURL) {
+		base.Reason = "Invalid url. Expected a valid http(s) URL."
+		base.Status = "failed"
+		return base
+	}
+
+	platform := strings.TrimSpace(strings.ToLower(item.Platform))
+	if platform == "" {
+		if detected := DetectSite(rawURL); detected != nil {
+			platform = detected.Platform
+		}
+	}
+	if platform == "" {
+		base.Reason = "Could not detect platform. Please specify manually."
+		base.Status = "failed"
+		return base
+	}
+
+	// Idempotent duplicate handling.
+	existing, err := findSiteByPlatformURL(db, platform, canonicalURL)
+	if err != nil {
+		base.Reason = err.Error()
+		base.Status = "failed"
+		return base
+	}
+	if existing != nil {
+		if effectiveStrategy == ImportDuplicateMerge {
+			merged, mergeErr := mergeAccountsIntoExistingSite(db, existing.ID, item.Accounts)
+			if mergeErr != nil {
+				base.Reason = mergeErr.Error()
+				base.Status = "failed"
+				return base
+			}
+			base.SiteID = existing.ID
+			if merged == 0 {
+				base.Status = "skipped"
+				base.Reason = "Duplicate site (no accounts to merge)."
+				return base
+			}
+			base.Status = "merged"
+			base.Reason = fmt.Sprintf("Merged %d account(s) into existing site.", merged)
+			return base
+		}
+		base.SiteID = existing.ID
+		base.Status = "skipped"
+		base.Reason = "Duplicate site."
+		return base
+	}
+
+	siteID, err := createImportedSite(db, item, platform, canonicalURL)
+	if err != nil {
+		base.Reason = err.Error()
+		base.Status = "failed"
+		return base
+	}
+	base.SiteID = siteID
+
+	if _, err := mergeAccountsIntoExistingSite(db, siteID, item.Accounts); err != nil {
+		// The site was created; account import failure is non-fatal to keep the
+		// site idempotency sane. Record it in the reason but keep "imported".
+		base.Reason = err.Error()
+	}
+	base.Status = "imported"
+	return base
+}
+
+func findSiteByPlatformURL(db *sqlx.DB, platform, canonicalURL string) (*store.Site, error) {
+	var site store.Site
+	err := db.Get(&site, db.Rebind("SELECT "+SiteSelectColumns+" FROM sites WHERE platform = ? AND url = ?"), platform, canonicalURL)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &site, nil
+}
+
+func createImportedSite(db *sqlx.DB, item ImportSiteInput, platform, canonicalURL string) (int64, error) {
+	globalWeight := 1.0
+	if item.GlobalWeight != nil && *item.GlobalWeight > 0 {
+		globalWeight = *item.GlobalWeight
+	}
+	maxConcurrency := int64(0)
+	if item.MaxConcurrency != nil && *item.MaxConcurrency >= 0 {
+		maxConcurrency = *item.MaxConcurrency
+	}
+
+	siteData := map[string]any{
+		"name":                                strings.TrimSpace(item.Name),
+		"url":                                 canonicalURL,
+		"platform":                            platform,
+		"status":                              "active",
+		"isPinned":                            false,
+		"globalWeight":                        globalWeight,
+		"maxConcurrency":                      maxConcurrency,
+		"postRefreshProbeEnabled":             false,
+		"postRefreshProbeModel":               "",
+		"postRefreshProbeScope":               "single",
+		"postRefreshProbeLatencyThresholdMs":  int64(0),
+		"proxyUrl":                            nil,
+		"useSystemProxy":                      false,
+		"customHeaders":                       nil,
+		"customHeadersOverrideRequestHeaders": false,
+		"externalCheckinUrl":                  nil,
+	}
+	return CreateSite(db, siteData)
+}
+
+func mergeAccountsIntoExistingSite(db *sqlx.DB, siteID int64, accounts []ImportAccountInput) (int, error) {
+	merged := 0
+	for i := range accounts {
+		acct := &accounts[i]
+		token := strings.TrimSpace(acct.AccessToken)
+		apiToken := strings.TrimSpace(acct.APIToken)
+		if token == "" && apiToken == "" {
+			continue
+		}
+
+		dupe, err := findDuplicateAccount(db, siteID, token, apiToken)
+		if err != nil {
+			return merged, err
+		}
+		if dupe {
+			continue
+		}
+
+		if _, err := insertImportedAccount(db, siteID, acct, token, apiToken); err != nil {
+			return merged, err
+		}
+		merged++
+	}
+	return merged, nil
+}
+
+func findDuplicateAccount(db *sqlx.DB, siteID int64, accessToken, apiToken string) (bool, error) {
+	var count int
+	query := `SELECT COUNT(*) FROM accounts WHERE site_id = ? AND ((? <> '' AND access_token = ?) OR (? <> '' AND api_token = ?))`
+	args := []any{siteID, accessToken, accessToken, apiToken, apiToken}
+	if err := db.Get(&count, db.Rebind(query), args...); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func insertImportedAccount(db *sqlx.DB, siteID int64, acct *ImportAccountInput, accessToken, apiToken string) (int64, error) {
+	sortOrder, err := GetNextAccountSortOrder(db)
+	if err != nil {
+		return 0, err
+	}
+
+	var username *string
+	if acct.Username != nil && strings.TrimSpace(*acct.Username) != "" {
+		u := strings.TrimSpace(*acct.Username)
+		username = &u
+	}
+	var apiTokenPtr *string
+	if apiToken != "" {
+		t := apiToken
+		apiTokenPtr = &t
+	}
+	extraConfig := map[string]any{
+		"credentialMode": string(CredentialModeAPIKey),
+		"skipModelFetch": true,
+	}
+
+	account := map[string]any{
+		"siteId":             siteID,
+		"username":           username,
+		"accessToken":        accessToken,
+		"apiToken":           apiTokenPtr,
+		"balance":            0.0,
+		"balanceUsed":        0.0,
+		"quota":              0.0,
+		"unitCost":           nil,
+		"valueScore":         0.0,
+		"status":             "active",
+		"isPinned":           false,
+		"sortOrder":          sortOrder,
+		"checkinEnabled":     false,
+		"lastCheckinAt":      nil,
+		"lastBalanceRefresh": nil,
+		"oauthProvider":      nil,
+		"oauthAccountKey":    nil,
+		"oauthProjectID":     nil,
+		"extraConfig":        extraConfig,
+	}
+	return InsertAccount(db, account)
+}

--- a/service/site_import_test.go
+++ b/service/site_import_test.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+func openImportTestDB(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func TestImportSites_CreatesIdempotently(t *testing.T) {
+	db := openImportTestDB(t)
+
+	items := []ImportSiteInput{
+		{Name: "OpenAI", URL: "https://api.openai.com/v1"},
+		{Name: "Anthropic", URL: "https://api.anthropic.com/v1"},
+	}
+
+	res, err := ImportSites(db.DB, items, ImportDuplicateSkip)
+	if err != nil {
+		t.Fatalf("ImportSites: %v", err)
+	}
+	if res.Imported != 2 || res.Skipped != 0 || res.Failed != 0 {
+		t.Fatalf("first run imported=%d skipped=%d failed=%d, want 2/0/0", res.Imported, res.Skipped, res.Failed)
+	}
+
+	// Re-run the same payload: everything is a duplicate no-op.
+	res, err = ImportSites(db.DB, items, ImportDuplicateSkip)
+	if err != nil {
+		t.Fatalf("ImportSites rerun: %v", err)
+	}
+	if res.Imported != 0 || res.Skipped != 2 || res.Failed != 0 {
+		t.Fatalf("rerun imported=%d skipped=%d failed=%d, want 0/2/0", res.Imported, res.Skipped, res.Failed)
+	}
+}
+
+func TestImportSites_DuplicateMergeAttachesAccounts(t *testing.T) {
+	db := openImportTestDB(t)
+
+	items := []ImportSiteInput{
+		{Name: "OpenAI", URL: "https://api.openai.com/v1", Accounts: []ImportAccountInput{
+			{Username: strPtr("ops"), AccessToken: "sk-import-1"},
+		}},
+	}
+	res, err := ImportSites(db.DB, items, ImportDuplicateSkip)
+	if err != nil {
+		t.Fatalf("ImportSites: %v", err)
+	}
+	if res.Imported != 1 {
+		t.Fatalf("imported=%d want 1", res.Imported)
+	}
+
+	// Merge another account into the existing site.
+	merge := []ImportSiteInput{
+		{Name: "OpenAI", URL: "https://api.openai.com/v1", Accounts: []ImportAccountInput{
+			{Username: strPtr("ops2"), AccessToken: "sk-import-2"},
+		}},
+	}
+	res, err = ImportSites(db.DB, merge, ImportDuplicateMerge)
+	if err != nil {
+		t.Fatalf("ImportSites merge: %v", err)
+	}
+	if res.Imported != 1 || res.Results[0].Status != "merged" {
+		t.Fatalf("merge imported=%d status=%q, want imported=1 merged", res.Imported, res.Results[0].Status)
+	}
+
+	var accountCount int
+	if err := db.DB.Get(&accountCount, "SELECT COUNT(*) FROM accounts"); err != nil {
+		t.Fatalf("count accounts: %v", err)
+	}
+	if accountCount != 2 {
+		t.Fatalf("accounts=%d want 2", accountCount)
+	}
+}
+
+func TestImportSites_FailsOnUnknownPlatform(t *testing.T) {
+	db := openImportTestDB(t)
+
+	items := []ImportSiteInput{
+		{Name: "Unknown", URL: "https://totally-unknown-host.invalid/v1"},
+	}
+	res, err := ImportSites(db.DB, items, ImportDuplicateSkip)
+	if err != nil {
+		t.Fatalf("ImportSites: %v", err)
+	}
+	if res.Failed != 1 {
+		t.Fatalf("failed=%d want 1 (results=%+v)", res.Failed, res.Results)
+	}
+}

--- a/service/site_service_test.go
+++ b/service/site_service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -596,5 +597,27 @@ func TestIsValidHTTPURL_RejectsMetadata(t *testing.T) {
 	}
 	if !IsValidHTTPURL("http://10.0.0.5/checkin") {
 		t.Error("RFC1918 should remain valid for lab external checkin")
+	}
+}
+
+func TestDetectSite_ConfidenceAndCanonicalURL(t *testing.T) {
+	result := DetectSite("https://api.openai.com/v1?x=1#frag")
+	if result == nil {
+		t.Fatal("expected detection result, got nil")
+	}
+	if result.SiteType != "openai" {
+		t.Fatalf("siteType=%q want openai", result.SiteType)
+	}
+	if result.Confidence <= 0 || result.Confidence > 1 {
+		t.Fatalf("confidence=%v want (0,1]", result.Confidence)
+	}
+	if result.CanonicalURL == "" {
+		t.Fatal("canonicalUrl is empty")
+	}
+	if strings.HasSuffix(result.CanonicalURL, "/") {
+		t.Fatalf("canonicalUrl=%q should not end with slash", result.CanonicalURL)
+	}
+	if strings.Contains(result.CanonicalURL, "?") || strings.Contains(result.CanonicalURL, "#") {
+		t.Fatalf("canonicalUrl=%q should drop query/fragment", result.CanonicalURL)
 	}
 }

--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -39,6 +39,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { ImportWizardDialog } from '@/features/import'
 
 import {
   type BatchAccountAction,
@@ -51,7 +52,6 @@ import {
   useToggleAccountStatus,
 } from '../api'
 import { type Account, type AccountRowActions, accountSchema } from '../types'
-import { ImportWizardDialog } from '@/features/import'
 import { AccountDetailSheet } from './account-detail-sheet'
 import { AccountFormDialog } from './account-form-dialog'
 import { useAccountsColumns } from './accounts-columns'

--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -14,7 +14,14 @@ import type {
   PaginationState,
   Table,
 } from '@tanstack/react-table'
-import { Loader2, Plus, Power, RefreshCw, Trash2 } from 'lucide-react'
+import {
+  Loader2,
+  Plus,
+  Power,
+  RefreshCw,
+  Trash2,
+  Upload as UploadIcon,
+} from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -44,6 +51,7 @@ import {
   useToggleAccountStatus,
 } from '../api'
 import { type Account, type AccountRowActions, accountSchema } from '../types'
+import { ImportWizardDialog } from '@/features/import'
 import { AccountDetailSheet } from './account-detail-sheet'
 import { AccountFormDialog } from './account-form-dialog'
 import { useAccountsColumns } from './accounts-columns'
@@ -180,6 +188,7 @@ export function AccountsPage() {
   const [detailAccount, setDetailAccount] = useState<Account | null>(null)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [deleteAccount, setDeleteAccount] = useState<Account | null>(null)
+  const [importOpen, setImportOpen] = useState(false)
 
   const openCreate = () => {
     setFormMode('create')
@@ -288,6 +297,12 @@ export function AccountsPage() {
         isFetching={isFetching}
         emptyTitle={t('accounts.page.emptyTitle')}
         emptyDescription={t('accounts.page.emptyDescription')}
+        emptyAction={
+          <Button onClick={() => setImportOpen(true)}>
+            <UploadIcon className='mr-1 size-4' />
+            {t('accounts.page.emptyImport')}
+          </Button>
+        }
         skeletonKeyPrefix='accounts-skeleton'
         toolbarProps={{
           searchPlaceholder: t('accounts.page.searchPlaceholder'),
@@ -328,6 +343,8 @@ export function AccountsPage() {
         }}
         bulkActions={<AccountsBulkActions table={table} />}
       />
+
+      <ImportWizardDialog open={importOpen} onOpenChange={setImportOpen} />
 
       {/* Create / edit form (Sheet) */}
       <AccountFormDialog

--- a/web/src/features/import/api.ts
+++ b/web/src/features/import/api.ts
@@ -11,9 +11,9 @@ import {
   type UseMutationOptions,
 } from '@tanstack/react-query'
 
-import { api } from '@/lib/api'
 import { accountQueryKeys } from '@/features/accounts'
 import { sitesKeys } from '@/features/sites'
+import { api } from '@/lib/api'
 
 import type {
   ImportSitesPayload,

--- a/web/src/features/import/api.ts
+++ b/web/src/features/import/api.ts
@@ -1,0 +1,59 @@
+// metapi-go/features/import — TanStack Query hooks for the import wizard.
+//
+// Detection is per-URL (matching the backend /api/sites/detect contract), and
+// the final commit is a single idempotent POST /api/sites/import. Import
+// invalidates the sites list + accounts snapshot so list pages refresh after
+// the wizard closes.
+
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationOptions,
+} from '@tanstack/react-query'
+
+import { api } from '@/lib/api'
+import { accountQueryKeys } from '@/features/accounts'
+import { sitesKeys } from '@/features/sites'
+
+import type {
+  ImportSitesPayload,
+  ImportSitesResult,
+  SiteDetectResult,
+} from './types'
+
+/** Detect the platform for a single URL. Returns an empty object on 400. */
+export function useDetectSite(
+  options?: UseMutationOptions<SiteDetectResult, Error, string>
+) {
+  return useMutation<SiteDetectResult, Error, string>({
+    mutationFn: async (url) => {
+      try {
+        const detected = (await api.detectSite(url)) as SiteDetectResult
+        return detected ?? {}
+      } catch {
+        // Unknown / undetectable URLs surface as a client error; the wizard
+        // keeps them manually specifiable instead of failing the batch.
+        return {}
+      }
+    },
+    ...options,
+  })
+}
+
+/** Submit the assembled import batch and refresh the affected list queries. */
+export function useImportSites(
+  options?: UseMutationOptions<ImportSitesResult, Error, ImportSitesPayload>
+) {
+  const queryClient = useQueryClient()
+  return useMutation<ImportSitesResult, Error, ImportSitesPayload>({
+    mutationFn: async (payload) => {
+      const result = (await api.importSites(payload)) as ImportSitesResult
+      return result ?? { imported: 0, skipped: 0, failed: 0, results: [] }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: sitesKeys.list() })
+      queryClient.invalidateQueries({ queryKey: accountQueryKeys.snapshot() })
+    },
+    ...options,
+  })
+}

--- a/web/src/features/import/components/import-wizard-dialog.tsx
+++ b/web/src/features/import/components/import-wizard-dialog.tsx
@@ -1,0 +1,563 @@
+// metapi-go/features/import — unified five-step import wizard dialog.
+//
+// source → identify → connect → models/routes → done. The wizard collects
+// pasted URLs, auto-detects each platform (unknown stays manually specifiable),
+// flags duplicates with skip/merge, attaches optional accounts, sets routing
+// weight, then commits one idempotent POST /api/sites/import and reports the
+// imported/skipped/failed breakdown.
+
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import {
+  Check as CheckIcon,
+  Minus as MinusIcon,
+  TriangleAlert as AlertIcon,
+  Upload as UploadIcon,
+  X as XIcon,
+} from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { Spinner } from '@/components/ui/spinner'
+import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
+import { useSites } from '@/features/sites/api'
+import type { Site } from '@/features/sites/types'
+
+import { useDetectSite, useImportSites } from '../api'
+import { canonicalizeUrl, parseUrlLines } from '../lib/utils'
+import type {
+  ImportCandidate,
+  ImportDuplicateStrategy,
+  ImportSiteItem,
+  ImportSiteResultStatus,
+  ImportSitesResult,
+  ImportStepId,
+} from '../types'
+import { ImportStepper, type ImportStep } from './stepper'
+
+const STEP_ORDER: ImportStepId[] = [
+  'source',
+  'identify',
+  'connect',
+  'routes',
+  'done',
+]
+
+type ImportWizardDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function makeCandidate(url: string, index: number): ImportCandidate {
+  return {
+    id: `candidate-${index}-${url.slice(0, 32)}`,
+    url,
+    name: defaultSiteName(url),
+    platform: '',
+    confidence: null,
+    detected: false,
+    detecting: false,
+    duplicateStrategy: 'skip',
+    includeAccount: false,
+    username: '',
+    accessToken: '',
+    apiToken: '',
+    weight: 1,
+  }
+}
+
+function defaultSiteName(url: string): string {
+  try {
+    const withScheme = url.includes('://') ? url : `https://${url}`
+    const parsed = new URL(withScheme)
+    return parsed.hostname
+  } catch {
+    return url
+  }
+}
+
+function statusBadge(status: ImportSiteResultStatus) {
+  if (status === 'imported') {
+    return { variant: 'outline' as const, icon: CheckIcon, label: 'import.result.imported' }
+  }
+  if (status === 'merged') {
+    return { variant: 'outline' as const, icon: CheckIcon, label: 'import.result.merged' }
+  }
+  if (status === 'failed') {
+    return { variant: 'destructive' as const, icon: XIcon, label: 'import.result.failed' }
+  }
+  return { variant: 'secondary' as const, icon: MinusIcon, label: 'import.result.skipped' }
+}
+
+export function ImportWizardDialog({
+  open,
+  onOpenChange,
+}: ImportWizardDialogProps) {
+  const { t } = useTranslation()
+  const sitesQuery = useSites()
+  const detectSite = useDetectSite()
+  const importSites = useImportSites()
+
+  const [step, setStep] = useState<ImportStepId>('source')
+  const [sourceText, setSourceText] = useState('')
+  const [candidates, setCandidates] = useState<ImportCandidate[]>([])
+  const [result, setResult] = useState<ImportSitesResult | null>(null)
+
+  const steps: ImportStep[] = useMemo(
+    () => [
+      { id: 'source', label: t('import.steps.source') },
+      { id: 'identify', label: t('import.steps.identify') },
+      { id: 'connect', label: t('import.steps.connect') },
+      { id: 'routes', label: t('import.steps.routes') },
+      { id: 'done', label: t('import.steps.done') },
+    ],
+    [t]
+  )
+
+  const existingUrls = useMemo(() => {
+    const urls = new Set<string>()
+    for (const site of (sitesQuery.data ?? []) as Site[]) {
+      const canonical = canonicalizeUrl(site.url)
+      if (canonical) urls.add(canonical)
+    }
+    return urls
+  }, [sitesQuery.data])
+
+  const currentIndex = STEP_ORDER.indexOf(step)
+
+  function reset() {
+    setStep('source')
+    setSourceText('')
+    setCandidates([])
+    setResult(null)
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) reset()
+    onOpenChange(next)
+  }
+
+  function updateCandidate(id: string, patch: Partial<ImportCandidate>) {
+    setCandidates((prev) =>
+      prev.map((candidate) =>
+        candidate.id === id ? { ...candidate, ...patch } : candidate
+      )
+    )
+  }
+
+  async function detectAll(items: ImportCandidate[]) {
+    await Promise.all(
+      items.map(async (item) => {
+        if (item.platform !== '' || item.detecting) return
+        updateCandidate(item.id, { detecting: true })
+        try {
+          const detected = await detectSite.mutateAsync(item.url)
+          updateCandidate(item.id, {
+            platform: detected.platform ?? '',
+            confidence: detected.confidence ?? null,
+            detected: detected.platform != null,
+            detecting: false,
+          })
+        } catch {
+          updateCandidate(item.id, { detecting: false })
+        }
+      })
+    )
+  }
+
+  function handleSourceNext() {
+    const urls = parseUrlLines(sourceText)
+    if (urls.length === 0) {
+      toast.error(t('import.source.empty'))
+      return
+    }
+    const initial = urls.map((url, index) => makeCandidate(url, index))
+    setCandidates(initial)
+    setStep('identify')
+    void detectAll(initial)
+  }
+
+  function isDuplicate(candidate: ImportCandidate): boolean {
+    return existingUrls.has(canonicalizeUrl(candidate.url))
+  }
+
+  function handleIdentifyNext() {
+    const missing = candidates.filter((candidate) => candidate.platform.trim() === '')
+    if (missing.length > 0) {
+      toast.error(t('import.identify.missingPlatform'))
+      return
+    }
+    setStep('connect')
+  }
+
+  function handleConnectNext() {
+    setStep('routes')
+  }
+
+  async function handleSubmit() {
+    for (const candidate of candidates) {
+      if (!Number.isFinite(candidate.weight) || candidate.weight < 0) {
+        toast.error(t('import.routes.invalidWeight'))
+        return
+      }
+    }
+
+    const items: ImportSiteItem[] = candidates.map((candidate) => {
+      const accessToken = candidate.accessToken.trim()
+      const apiToken = candidate.apiToken.trim()
+      const hasAccount = candidate.includeAccount && (accessToken !== '' || apiToken !== '')
+      return {
+        name: candidate.name.trim() || candidate.url,
+        url: candidate.url,
+        platform: candidate.platform || undefined,
+        globalWeight: candidate.weight,
+        duplicateStrategy: candidate.duplicateStrategy,
+        accounts: hasAccount
+          ? [
+              {
+                username: candidate.username.trim() || undefined,
+                accessToken,
+                apiToken,
+              },
+            ]
+          : [],
+      }
+    })
+
+    try {
+      const importResult = await importSites.mutateAsync({
+        items,
+        duplicateStrategy: 'skip',
+      })
+      setResult(importResult)
+      setStep('done')
+    } catch {
+      // http-client toasted
+    }
+  }
+
+  function handleDone() {
+    reset()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className='sm:max-w-2xl'>
+        <DialogHeader>
+          <DialogTitle>{t('import.title')}</DialogTitle>
+          <DialogDescription>{t('import.description')}</DialogDescription>
+        </DialogHeader>
+
+        <ImportStepper steps={steps} currentIndex={currentIndex} />
+
+        <div className='mt-2 min-h-64'>
+          {step === 'source' && (
+            <div className='grid gap-3'>
+              <Label htmlFor='import-source-urls'>{t('import.source.label')}</Label>
+              <Textarea
+                id='import-source-urls'
+                rows={8}
+                value={sourceText}
+                onChange={(event) => setSourceText(event.target.value)}
+                placeholder={t('import.source.placeholder')}
+                className='font-mono text-xs'
+                autoFocus
+              />
+              <p className='text-xs text-muted-foreground'>
+                {t('import.source.hint')}
+              </p>
+            </div>
+          )}
+
+          {step === 'identify' && (
+            <div className='grid gap-3'>
+              {candidates.map((candidate) => {
+                const duplicate = isDuplicate(candidate)
+                return (
+                  <div
+                    key={candidate.id}
+                    className='grid gap-3 rounded-lg border p-3'
+                  >
+                    <div className='grid gap-2'>
+                      <Label>{t('import.identify.name')}</Label>
+                      <Input
+                        value={candidate.name}
+                        onChange={(event) =>
+                          updateCandidate(candidate.id, { name: event.target.value })
+                        }
+                      />
+                    </div>
+                    <div className='truncate font-mono text-xs text-muted-foreground'>
+                      {candidate.url}
+                    </div>
+                    <div className='grid gap-2'>
+                      <Label>{t('import.identify.platform')}</Label>
+                      <div className='flex items-center gap-2'>
+                        <Input
+                          value={candidate.platform}
+                          onChange={(event) =>
+                            updateCandidate(candidate.id, {
+                              platform: event.target.value,
+                              detected: false,
+                              confidence: null,
+                            })
+                          }
+                          className='flex-1'
+                        />
+                        {candidate.detecting && <Spinner />}
+                        {!candidate.detecting && candidate.detected && (
+                          <Badge variant='secondary'>
+                            <CheckIcon className='size-3' />
+                            {t('import.identify.detected', {
+                              confidence: Math.round((candidate.confidence ?? 0) * 100),
+                            })}
+                          </Badge>
+                        )}
+                      </div>
+                    </div>
+
+                    {duplicate && (
+                      <div className='rounded-lg border border-warning/40 bg-warning/10 p-3'>
+                        <div className='mb-2 flex items-center gap-2 text-sm'>
+                          <AlertIcon className='size-4 text-warning' />
+                          <span>{t('import.identify.duplicateWarning')}</span>
+                        </div>
+                        <RadioGroup
+                          value={candidate.duplicateStrategy}
+                          onValueChange={(value) =>
+                            updateCandidate(candidate.id, {
+                              duplicateStrategy: value as ImportDuplicateStrategy,
+                            })
+                          }
+                        >
+                          <div className='flex items-center gap-2'>
+                            <RadioGroupItem id={`${candidate.id}-skip`} value='skip' />
+                            <Label htmlFor={`${candidate.id}-skip`}>
+                              {t('import.identify.skip')}
+                            </Label>
+                          </div>
+                          <div className='flex items-center gap-2'>
+                            <RadioGroupItem id={`${candidate.id}-merge`} value='merge' />
+                            <Label htmlFor={`${candidate.id}-merge`}>
+                              {t('import.identify.merge')}
+                            </Label>
+                          </div>
+                        </RadioGroup>
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )}
+
+          {step === 'connect' && (
+            <div className='grid gap-3'>
+              {candidates.map((candidate) => (
+                <div
+                  key={candidate.id}
+                  className='grid gap-3 rounded-lg border p-3'
+                >
+                  <div className='flex items-center justify-between gap-3'>
+                    <div className='min-w-0'>
+                      <div className='truncate text-sm font-medium'>
+                        {candidate.name}
+                      </div>
+                      <div className='truncate text-xs text-muted-foreground'>
+                        {candidate.url}
+                      </div>
+                    </div>
+                    <Switch
+                      checked={candidate.includeAccount}
+                      onCheckedChange={(checked) =>
+                        updateCandidate(candidate.id, { includeAccount: checked })
+                      }
+                    />
+                  </div>
+                  {candidate.includeAccount && (
+                    <div className='grid gap-2 sm:grid-cols-3'>
+                      <div className='grid gap-1.5'>
+                        <Label>{t('import.connect.username')}</Label>
+                        <Input
+                          value={candidate.username}
+                          onChange={(event) =>
+                            updateCandidate(candidate.id, {
+                              username: event.target.value,
+                            })
+                          }
+                        />
+                      </div>
+                      <div className='grid gap-1.5'>
+                        <Label>{t('import.connect.accessToken')}</Label>
+                        <Input
+                          type='password'
+                          value={candidate.accessToken}
+                          onChange={(event) =>
+                            updateCandidate(candidate.id, {
+                              accessToken: event.target.value,
+                            })
+                          }
+                        />
+                      </div>
+                      <div className='grid gap-1.5'>
+                        <Label>{t('import.connect.apiToken')}</Label>
+                        <Input
+                          value={candidate.apiToken}
+                          onChange={(event) =>
+                            updateCandidate(candidate.id, {
+                              apiToken: event.target.value,
+                            })
+                          }
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {step === 'routes' && (
+            <div className='grid gap-3'>
+              <p className='text-xs text-muted-foreground'>
+                {t('import.routes.hint')}
+              </p>
+              {candidates.map((candidate) => (
+                <div
+                  key={candidate.id}
+                  className='flex items-center justify-between gap-3 rounded-lg border p-3'
+                >
+                  <div className='min-w-0'>
+                    <div className='truncate text-sm font-medium'>
+                      {candidate.name}
+                    </div>
+                    <div className='truncate text-xs text-muted-foreground'>
+                      {candidate.platform}
+                    </div>
+                  </div>
+                  <div className='flex items-center gap-2'>
+                    <Label>{t('import.routes.weight')}</Label>
+                    <Input
+                      type='number'
+                      min={0}
+                      step={0.1}
+                      value={candidate.weight}
+                      onChange={(event) =>
+                        updateCandidate(candidate.id, {
+                          weight: Number(event.target.value),
+                        })
+                      }
+                      className='w-24'
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {step === 'done' && result && (
+            <div className='grid gap-4'>
+              <div className='flex flex-wrap items-center gap-2'>
+                <Badge variant='outline'>
+                  <CheckIcon className='size-3' />
+                  {t('import.done.imported', { count: result.imported })}
+                </Badge>
+                <Badge variant='secondary'>
+                  <MinusIcon className='size-3' />
+                  {t('import.done.skipped', { count: result.skipped })}
+                </Badge>
+                <Badge variant='destructive'>
+                  <XIcon className='size-3' />
+                  {t('import.done.failed', { count: result.failed })}
+                </Badge>
+              </div>
+              <div className='grid gap-2'>
+                {result.results.map((item) => {
+                  const badge = statusBadge(item.status)
+                  const Icon = badge.icon
+                  return (
+                    <div
+                      key={`${item.url}-${item.status}`}
+                      className='flex items-center justify-between gap-3 rounded-lg border p-2.5'
+                    >
+                      <div className='min-w-0'>
+                        <div className='truncate text-sm'>{item.name}</div>
+                        <div className='truncate text-xs text-muted-foreground'>
+                          {item.url}
+                        </div>
+                      </div>
+                      <Badge variant={badge.variant}>
+                        <Icon className='size-3' />
+                        {t(badge.label)}
+                      </Badge>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter showCloseButton={false}>
+          {step !== 'source' && step !== 'done' && (
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() =>
+                setStep(STEP_ORDER[Math.max(0, currentIndex - 1)] as ImportStepId)
+              }
+            >
+              {t('import.back')}
+            </Button>
+          )}
+          {step === 'source' && (
+            <Button type='button' onClick={handleSourceNext}>
+              <UploadIcon className='mr-1 size-4' />
+              {t('import.next')}
+            </Button>
+          )}
+          {step === 'identify' && (
+            <Button type='button' onClick={handleIdentifyNext}>
+              {t('import.next')}
+            </Button>
+          )}
+          {step === 'connect' && (
+            <Button type='button' onClick={handleConnectNext}>
+              {t('import.next')}
+            </Button>
+          )}
+          {step === 'routes' && (
+            <Button
+              type='button'
+              onClick={handleSubmit}
+              disabled={importSites.isPending}
+            >
+              {importSites.isPending && <Spinner className='mr-2' />}
+              {t('import.submit')}
+            </Button>
+          )}
+          {step === 'done' && (
+            <Button type='button' onClick={handleDone}>
+              <CheckIcon className='mr-1 size-4' />
+              {t('import.done.close')}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/features/import/components/import-wizard-dialog.tsx
+++ b/web/src/features/import/components/import-wizard-dialog.tsx
@@ -6,9 +6,6 @@
 // weight, then commits one idempotent POST /api/sites/import and reports the
 // imported/skipped/failed breakdown.
 
-import { useMemo, useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import { toast } from 'sonner'
 import {
   Check as CheckIcon,
   Minus as MinusIcon,
@@ -16,6 +13,9 @@ import {
   Upload as UploadIcon,
   X as XIcon,
 } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -91,15 +91,31 @@ function defaultSiteName(url: string): string {
 
 function statusBadge(status: ImportSiteResultStatus) {
   if (status === 'imported') {
-    return { variant: 'outline' as const, icon: CheckIcon, label: 'import.result.imported' }
+    return {
+      variant: 'outline' as const,
+      icon: CheckIcon,
+      label: 'import.result.imported',
+    }
   }
   if (status === 'merged') {
-    return { variant: 'outline' as const, icon: CheckIcon, label: 'import.result.merged' }
+    return {
+      variant: 'outline' as const,
+      icon: CheckIcon,
+      label: 'import.result.merged',
+    }
   }
   if (status === 'failed') {
-    return { variant: 'destructive' as const, icon: XIcon, label: 'import.result.failed' }
+    return {
+      variant: 'destructive' as const,
+      icon: XIcon,
+      label: 'import.result.failed',
+    }
   }
-  return { variant: 'secondary' as const, icon: MinusIcon, label: 'import.result.skipped' }
+  return {
+    variant: 'secondary' as const,
+    icon: MinusIcon,
+    label: 'import.result.skipped',
+  }
 }
 
 export function ImportWizardDialog({
@@ -195,7 +211,9 @@ export function ImportWizardDialog({
   }
 
   function handleIdentifyNext() {
-    const missing = candidates.filter((candidate) => candidate.platform.trim() === '')
+    const missing = candidates.filter(
+      (candidate) => candidate.platform.trim() === ''
+    )
     if (missing.length > 0) {
       toast.error(t('import.identify.missingPlatform'))
       return
@@ -218,7 +236,8 @@ export function ImportWizardDialog({
     const items: ImportSiteItem[] = candidates.map((candidate) => {
       const accessToken = candidate.accessToken.trim()
       const apiToken = candidate.apiToken.trim()
-      const hasAccount = candidate.includeAccount && (accessToken !== '' || apiToken !== '')
+      const hasAccount =
+        candidate.includeAccount && (accessToken !== '' || apiToken !== '')
       return {
         name: candidate.name.trim() || candidate.url,
         url: candidate.url,
@@ -267,7 +286,9 @@ export function ImportWizardDialog({
         <div className='mt-2 min-h-64'>
           {step === 'source' && (
             <div className='grid gap-3'>
-              <Label htmlFor='import-source-urls'>{t('import.source.label')}</Label>
+              <Label htmlFor='import-source-urls'>
+                {t('import.source.label')}
+              </Label>
               <Textarea
                 id='import-source-urls'
                 rows={8}
@@ -277,7 +298,7 @@ export function ImportWizardDialog({
                 className='font-mono text-xs'
                 autoFocus
               />
-              <p className='text-xs text-muted-foreground'>
+              <p className='text-muted-foreground text-xs'>
                 {t('import.source.hint')}
               </p>
             </div>
@@ -297,11 +318,13 @@ export function ImportWizardDialog({
                       <Input
                         value={candidate.name}
                         onChange={(event) =>
-                          updateCandidate(candidate.id, { name: event.target.value })
+                          updateCandidate(candidate.id, {
+                            name: event.target.value,
+                          })
                         }
                       />
                     </div>
-                    <div className='truncate font-mono text-xs text-muted-foreground'>
+                    <div className='text-muted-foreground truncate font-mono text-xs'>
                       {candidate.url}
                     </div>
                     <div className='grid gap-2'>
@@ -323,7 +346,9 @@ export function ImportWizardDialog({
                           <Badge variant='secondary'>
                             <CheckIcon className='size-3' />
                             {t('import.identify.detected', {
-                              confidence: Math.round((candidate.confidence ?? 0) * 100),
+                              confidence: Math.round(
+                                (candidate.confidence ?? 0) * 100
+                              ),
                             })}
                           </Badge>
                         )}
@@ -331,27 +356,34 @@ export function ImportWizardDialog({
                     </div>
 
                     {duplicate && (
-                      <div className='rounded-lg border border-warning/40 bg-warning/10 p-3'>
+                      <div className='border-warning/40 bg-warning/10 rounded-lg border p-3'>
                         <div className='mb-2 flex items-center gap-2 text-sm'>
-                          <AlertIcon className='size-4 text-warning' />
+                          <AlertIcon className='text-warning size-4' />
                           <span>{t('import.identify.duplicateWarning')}</span>
                         </div>
                         <RadioGroup
                           value={candidate.duplicateStrategy}
                           onValueChange={(value) =>
                             updateCandidate(candidate.id, {
-                              duplicateStrategy: value as ImportDuplicateStrategy,
+                              duplicateStrategy:
+                                value as ImportDuplicateStrategy,
                             })
                           }
                         >
                           <div className='flex items-center gap-2'>
-                            <RadioGroupItem id={`${candidate.id}-skip`} value='skip' />
+                            <RadioGroupItem
+                              id={`${candidate.id}-skip`}
+                              value='skip'
+                            />
                             <Label htmlFor={`${candidate.id}-skip`}>
                               {t('import.identify.skip')}
                             </Label>
                           </div>
                           <div className='flex items-center gap-2'>
-                            <RadioGroupItem id={`${candidate.id}-merge`} value='merge' />
+                            <RadioGroupItem
+                              id={`${candidate.id}-merge`}
+                              value='merge'
+                            />
                             <Label htmlFor={`${candidate.id}-merge`}>
                               {t('import.identify.merge')}
                             </Label>
@@ -377,14 +409,16 @@ export function ImportWizardDialog({
                       <div className='truncate text-sm font-medium'>
                         {candidate.name}
                       </div>
-                      <div className='truncate text-xs text-muted-foreground'>
+                      <div className='text-muted-foreground truncate text-xs'>
                         {candidate.url}
                       </div>
                     </div>
                     <Switch
                       checked={candidate.includeAccount}
                       onCheckedChange={(checked) =>
-                        updateCandidate(candidate.id, { includeAccount: checked })
+                        updateCandidate(candidate.id, {
+                          includeAccount: checked,
+                        })
                       }
                     />
                   </div>
@@ -433,7 +467,7 @@ export function ImportWizardDialog({
 
           {step === 'routes' && (
             <div className='grid gap-3'>
-              <p className='text-xs text-muted-foreground'>
+              <p className='text-muted-foreground text-xs'>
                 {t('import.routes.hint')}
               </p>
               {candidates.map((candidate) => (
@@ -445,7 +479,7 @@ export function ImportWizardDialog({
                     <div className='truncate text-sm font-medium'>
                       {candidate.name}
                     </div>
-                    <div className='truncate text-xs text-muted-foreground'>
+                    <div className='text-muted-foreground truncate text-xs'>
                       {candidate.platform}
                     </div>
                   </div>
@@ -496,7 +530,7 @@ export function ImportWizardDialog({
                     >
                       <div className='min-w-0'>
                         <div className='truncate text-sm'>{item.name}</div>
-                        <div className='truncate text-xs text-muted-foreground'>
+                        <div className='text-muted-foreground truncate text-xs'>
                           {item.url}
                         </div>
                       </div>
@@ -518,7 +552,9 @@ export function ImportWizardDialog({
               type='button'
               variant='outline'
               onClick={() =>
-                setStep(STEP_ORDER[Math.max(0, currentIndex - 1)] as ImportStepId)
+                setStep(
+                  STEP_ORDER[Math.max(0, currentIndex - 1)] as ImportStepId
+                )
               }
             >
               {t('import.back')}

--- a/web/src/features/import/components/stepper.tsx
+++ b/web/src/features/import/components/stepper.tsx
@@ -19,7 +19,10 @@ type StepperProps = {
   currentIndex: number
 }
 
-function stepState(index: number, currentIndex: number): 'current' | 'completed' | 'upcoming' {
+function stepState(
+  index: number,
+  currentIndex: number
+): 'current' | 'completed' | 'upcoming' {
   if (index === currentIndex) return 'current'
   if (index < currentIndex) return 'completed'
   return 'upcoming'
@@ -27,10 +30,7 @@ function stepState(index: number, currentIndex: number): 'current' | 'completed'
 
 export function ImportStepper({ steps, currentIndex }: StepperProps) {
   return (
-    <ol
-      aria-label='Import progress'
-      className='flex items-center gap-1.5'
-    >
+    <ol aria-label='Import progress' className='flex items-center gap-1.5'>
       {steps.map((step, index) => {
         const state = stepState(index, currentIndex)
         const isCompleted = state === 'completed'
@@ -48,9 +48,9 @@ export function ImportStepper({ steps, currentIndex }: StepperProps) {
                 'flex h-7 min-w-7 shrink-0 items-center justify-center rounded-full border text-xs font-medium',
                 isCurrent &&
                   'border-primary bg-primary text-primary-foreground',
-                isCompleted &&
-                  'border-primary/30 bg-primary/10 text-primary',
-                !isCurrent && !isCompleted &&
+                isCompleted && 'border-primary/30 bg-primary/10 text-primary',
+                !isCurrent &&
+                  !isCompleted &&
                   'border-border text-muted-foreground'
               )}
             >
@@ -63,7 +63,9 @@ export function ImportStepper({ steps, currentIndex }: StepperProps) {
             <span
               className={cn(
                 'truncate text-xs',
-                isCurrent ? 'font-medium text-foreground' : 'text-muted-foreground'
+                isCurrent
+                  ? 'font-medium text-foreground'
+                  : 'text-muted-foreground'
               )}
             >
               {step.label}

--- a/web/src/features/import/components/stepper.tsx
+++ b/web/src/features/import/components/stepper.tsx
@@ -1,0 +1,85 @@
+// metapi-go/features/import — five-step wizard stepper.
+//
+// Each step carries one of three visual states: completed (check), current
+// (highlighted, aria-current="step"), and upcoming (dimmed). Color is never the
+// only signal: completed steps also show a check icon and the current step gets
+// a text label, so the states remain distinguishable without color.
+
+import { Check as CheckIcon } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+export type ImportStep = {
+  id: string
+  label: string
+}
+
+type StepperProps = {
+  steps: ImportStep[]
+  currentIndex: number
+}
+
+function stepState(index: number, currentIndex: number): 'current' | 'completed' | 'upcoming' {
+  if (index === currentIndex) return 'current'
+  if (index < currentIndex) return 'completed'
+  return 'upcoming'
+}
+
+export function ImportStepper({ steps, currentIndex }: StepperProps) {
+  return (
+    <ol
+      aria-label='Import progress'
+      className='flex items-center gap-1.5'
+    >
+      {steps.map((step, index) => {
+        const state = stepState(index, currentIndex)
+        const isCompleted = state === 'completed'
+        const isCurrent = state === 'current'
+
+        return (
+          <li
+            key={step.id}
+            className='flex min-w-0 flex-1 items-center gap-1.5'
+          >
+            <div
+              aria-current={isCurrent ? 'step' : undefined}
+              data-state={state}
+              className={cn(
+                'flex h-7 min-w-7 shrink-0 items-center justify-center rounded-full border text-xs font-medium',
+                isCurrent &&
+                  'border-primary bg-primary text-primary-foreground',
+                isCompleted &&
+                  'border-primary/30 bg-primary/10 text-primary',
+                !isCurrent && !isCompleted &&
+                  'border-border text-muted-foreground'
+              )}
+            >
+              {isCompleted ? (
+                <CheckIcon className='size-3.5' aria-hidden='true' />
+              ) : (
+                index + 1
+              )}
+            </div>
+            <span
+              className={cn(
+                'truncate text-xs',
+                isCurrent ? 'font-medium text-foreground' : 'text-muted-foreground'
+              )}
+            >
+              {step.label}
+            </span>
+            {index < steps.length - 1 && (
+              <div
+                aria-hidden='true'
+                className={cn(
+                  'h-px min-w-2 flex-1',
+                  isCompleted ? 'bg-primary/40' : 'bg-border'
+                )}
+              />
+            )}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}

--- a/web/src/features/import/index.ts
+++ b/web/src/features/import/index.ts
@@ -1,0 +1,12 @@
+// metapi-go/features/import — public barrel.
+//
+//   import { ImportWizardDialog } from '@/features/import'
+
+export { ImportWizardDialog } from './components/import-wizard-dialog'
+export type {
+  ImportCandidate,
+  ImportSiteItem,
+  ImportSitesResult,
+  ImportSiteItemResult,
+  ImportDuplicateStrategy,
+} from './types'

--- a/web/src/features/import/lib/utils.ts
+++ b/web/src/features/import/lib/utils.ts
@@ -19,7 +19,9 @@ export function canonicalizeUrl(raw: string): string {
   const trimmed = raw.trim()
   if (trimmed === '') return trimmed
   try {
-    const url = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`)
+    const url = new URL(
+      trimmed.includes('://') ? trimmed : `https://${trimmed}`
+    )
     url.search = ''
     url.hash = ''
     return url.toString().replace(/\/$/, '')

--- a/web/src/features/import/lib/utils.ts
+++ b/web/src/features/import/lib/utils.ts
@@ -1,0 +1,29 @@
+// metapi-go/features/import — pure helpers for parsing pasted URLs and a
+// lightweight canonicalization that mirrors the backend CanonicalizeSiteURL
+// (strip query/fragment, trim trailing slash) for duplicate comparison only.
+
+export function parseUrlLines(text: string): string[] {
+  const seen = new Set<string>()
+  const urls: string[] = []
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim()
+    if (line === '') continue
+    if (seen.has(line)) continue
+    seen.add(line)
+    urls.push(line)
+  }
+  return urls
+}
+
+export function canonicalizeUrl(raw: string): string {
+  const trimmed = raw.trim()
+  if (trimmed === '') return trimmed
+  try {
+    const url = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`)
+    url.search = ''
+    url.hash = ''
+    return url.toString().replace(/\/$/, '')
+  } catch {
+    return trimmed.replace(/\/$/, '')
+  }
+}

--- a/web/src/features/import/types.ts
+++ b/web/src/features/import/types.ts
@@ -26,7 +26,11 @@ export type ImportSitesPayload = {
   duplicateStrategy: ImportDuplicateStrategy
 }
 
-export type ImportSiteResultStatus = 'imported' | 'merged' | 'skipped' | 'failed'
+export type ImportSiteResultStatus =
+  | 'imported'
+  | 'merged'
+  | 'skipped'
+  | 'failed'
 
 export type ImportSiteItemResult = {
   name: string
@@ -70,9 +74,4 @@ export type ImportCandidate = {
   weight: number
 }
 
-export type ImportStepId =
-  | 'source'
-  | 'identify'
-  | 'connect'
-  | 'routes'
-  | 'done'
+export type ImportStepId = 'source' | 'identify' | 'connect' | 'routes' | 'done'

--- a/web/src/features/import/types.ts
+++ b/web/src/features/import/types.ts
@@ -1,0 +1,78 @@
+// metapi-go/features/import — domain types for the unified import wizard.
+//
+// The wizard turns a list of pasted URLs into candidate sites (auto-detected
+// platform + confidence), lets the operator attach accounts and routing weight,
+// then submits one idempotent POST /api/sites/import batch.
+
+export type ImportAccountInput = {
+  username?: string | null
+  accessToken?: string
+  apiToken?: string
+}
+
+export type ImportSiteItem = {
+  name: string
+  url: string
+  platform?: string
+  globalWeight?: number
+  maxConcurrency?: number
+  accounts?: ImportAccountInput[]
+}
+
+export type ImportDuplicateStrategy = 'skip' | 'merge'
+
+export type ImportSitesPayload = {
+  items: ImportSiteItem[]
+  duplicateStrategy: ImportDuplicateStrategy
+}
+
+export type ImportSiteResultStatus = 'imported' | 'merged' | 'skipped' | 'failed'
+
+export type ImportSiteItemResult = {
+  name: string
+  url: string
+  status: ImportSiteResultStatus
+  reason?: string
+  siteId?: number
+}
+
+export type ImportSitesResult = {
+  imported: number
+  skipped: number
+  failed: number
+  results: ImportSiteItemResult[]
+}
+
+/** Platform detection response from POST /api/sites/detect. */
+export type SiteDetectResult = {
+  url?: string
+  canonicalUrl?: string
+  platform?: string
+  siteType?: string
+  confidence?: number
+  initializationPresetId?: string | null
+}
+
+/** One candidate row held in wizard state across the five steps. */
+export type ImportCandidate = {
+  id: string
+  url: string
+  name: string
+  platform: string
+  confidence: number | null
+  detected: boolean
+  detecting: boolean
+  duplicateStrategy: ImportDuplicateStrategy
+  includeAccount: boolean
+  username: string
+  accessToken: string
+  apiToken: string
+  weight: number
+}
+
+export type ImportStepId =
+  | 'source'
+  | 'identify'
+  | 'connect'
+  | 'routes'
+  | 'done'

--- a/web/src/features/sites/components/site-form-dialog.tsx
+++ b/web/src/features/sites/components/site-form-dialog.tsx
@@ -137,6 +137,7 @@ export function SiteFormDialog({
   const createSite = useCreateSite()
   const updateSite = useUpdateSite()
   const detectSite = useDetectSite()
+  const detectSiteAsync = detectSite.mutateAsync
 
   useEffect(() => {
     if (!open) return
@@ -148,8 +149,32 @@ export function SiteFormDialog({
   }, [open, editingSite, form])
 
   const watchedUrl = form.watch('url')
+  const watchedPlatform = form.watch('platform')
   const probeEnabled = form.watch('postRefreshProbeEnabled')
   const isSubmitting = createSite.isPending || updateSite.isPending
+
+  // Auto-recognize platform when a URL is pasted and no platform has been
+  // chosen yet. Unknown sites resolve to an empty result and stay manually
+  // specifiable; a user-entered platform always wins over auto-detection.
+  useEffect(() => {
+    const url = watchedUrl.trim()
+    if (!url || isEditing || watchedPlatform.trim() !== '') return
+
+    const timer = window.setTimeout(() => {
+      void (async () => {
+        try {
+          const detected = await detectSiteAsync(url)
+          if (detected.platform && !form.getValues('platform').trim()) {
+            form.setValue('platform', detected.platform, { shouldDirty: true })
+          }
+        } catch {
+          // Unknown site: leave the platform empty for manual entry.
+        }
+      })()
+    }, 600)
+
+    return () => window.clearTimeout(timer)
+  }, [watchedUrl, watchedPlatform, isEditing, detectSiteAsync, form])
 
   async function handleDetect() {
     const url = watchedUrl.trim()

--- a/web/src/features/sites/components/sites-page.tsx
+++ b/web/src/features/sites/components/sites-page.tsx
@@ -9,7 +9,11 @@
 // `/sites` route file lands its own `validateSearch`. Mobile cards are
 // handled by `DataTablePage` via the column `meta` flags.
 
-import { Plus as PlusIcon, Trash2 as Trash2Icon } from 'lucide-react'
+import {
+  Plus as PlusIcon,
+  Trash2 as Trash2Icon,
+  Upload as UploadIcon,
+} from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -33,6 +37,7 @@ import {
 } from '@/components/ui/dialog'
 import { Spinner } from '@/components/ui/spinner'
 import { useAccounts } from '@/features/accounts'
+import { ImportWizardDialog } from '@/features/import'
 import { asStringParam, parseSortingParam } from '@/lib/helpers/searchParams'
 
 import {
@@ -167,6 +172,7 @@ export function SitesPage() {
   const batchUpdateSites = useBatchUpdateSites()
 
   const [formOpen, setFormOpen] = useState(false)
+  const [importOpen, setImportOpen] = useState(false)
   const [editingSite, setEditingSite] = useState<Site | null>(null)
   const [viewingSite, setViewingSite] = useState<Site | null>(null)
   const [createdSite, setCreatedSite] = useState<Site | null>(null)
@@ -335,10 +341,16 @@ export function SitesPage() {
         emptyTitle={t('sites.empty.title')}
         emptyDescription={t('sites.empty.description')}
         emptyAction={
-          <Button onClick={handleAddSite}>
-            <PlusIcon className='mr-1 size-4' />
-            {t('sites.empty.addSite')}
-          </Button>
+          <>
+            <Button onClick={() => setImportOpen(true)}>
+              <UploadIcon className='mr-1 size-4' />
+              {t('sites.empty.import')}
+            </Button>
+            <Button variant='outline' onClick={handleAddSite}>
+              <PlusIcon className='mr-1 size-4' />
+              {t('sites.empty.addSite')}
+            </Button>
+          </>
         }
         skeletonKeyPrefix='site-skeleton'
         toolbarProps={{
@@ -399,6 +411,8 @@ export function SitesPage() {
         editingSite={editingSite}
         onCreated={handleCreated}
       />
+
+      <ImportWizardDialog open={importOpen} onOpenChange={setImportOpen} />
 
       <SiteCreatedModal
         site={createdSite}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1,5 +1,57 @@
 {
   "translation": {
+    "import": {
+      "title": "Import sites",
+      "description": "Import one or more sites and optionally attach account credentials.",
+      "back": "Back",
+      "next": "Next",
+      "submit": "Import",
+      "cta": "Import sites",
+      "steps": {
+        "source": "Source",
+        "identify": "Identify",
+        "connect": "Connect",
+        "routes": "Models / routes",
+        "done": "Done"
+      },
+      "source": {
+        "label": "Site URLs",
+        "placeholder": "Paste one site URL per line",
+        "hint": "Each non-empty line becomes one site. Duplicates in the paste are ignored.",
+        "empty": "Paste at least one site URL."
+      },
+      "identify": {
+        "name": "Name",
+        "platform": "Platform",
+        "detected": "Detected · {{confidence}}%",
+        "duplicateWarning": "This site already exists. Choose how to handle the duplicate.",
+        "skip": "Skip",
+        "merge": "Merge accounts into existing site",
+        "missingPlatform": "Set a platform for every site (unknown sites stay manual)."
+      },
+      "connect": {
+        "username": "Username",
+        "accessToken": "Access token",
+        "apiToken": "API token"
+      },
+      "routes": {
+        "hint": "Imported sites are created active. Model discovery runs in the background; set the routing weight below.",
+        "weight": "Weight",
+        "invalidWeight": "Weight must be a number greater than or equal to 0."
+      },
+      "done": {
+        "imported": "Imported {{count}}",
+        "skipped": "Skipped {{count}}",
+        "failed": "Failed {{count}}",
+        "close": "Done"
+      },
+      "result": {
+        "imported": "Imported",
+        "merged": "Merged",
+        "skipped": "Skipped",
+        "failed": "Failed"
+      }
+    },
     "auth": {
       "login": {
         "title": "Sign in",
@@ -308,7 +360,8 @@
       "empty": {
         "title": "No sites",
         "description": "Add a site to start routing requests.",
-        "addSite": "Add site"
+        "addSite": "Add site",
+        "import": "Import sites"
       },
       "toolbar": {
         "searchPlaceholder": "Search sites…",
@@ -1231,6 +1284,7 @@
         "loadError": "Failed to load accounts: {{message}}",
         "emptyTitle": "No accounts",
         "emptyDescription": "Add an account to start managing connections, or visit the Sites page to add a site first.",
+        "emptyImport": "Import sites",
         "searchPlaceholder": "Search account name / site…",
         "filterStatusTitle": "Status",
         "filterStatusActive": "Active",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1,5 +1,57 @@
 {
   "translation": {
+    "import": {
+      "title": "导入站点",
+      "description": "批量导入一个或多个站点，并可选地附带账号凭证。",
+      "back": "上一步",
+      "next": "下一步",
+      "submit": "导入",
+      "cta": "导入站点",
+      "steps": {
+        "source": "来源",
+        "identify": "识别",
+        "connect": "接入",
+        "routes": "模型 / 路由",
+        "done": "完成"
+      },
+      "source": {
+        "label": "站点 URL",
+        "placeholder": "每行粘贴一个站点 URL",
+        "hint": "每个非空行对应一个站点，粘贴内容中的重复项会被忽略。",
+        "empty": "请至少粘贴一个站点 URL。"
+      },
+      "identify": {
+        "name": "名称",
+        "platform": "平台",
+        "detected": "已识别 · {{confidence}}%",
+        "duplicateWarning": "该站点已存在，请选择重复项处理方式。",
+        "skip": "跳过",
+        "merge": "将账号合并到已有站点",
+        "missingPlatform": "请为每个站点设置平台（未知站点可手动填写）。"
+      },
+      "connect": {
+        "username": "用户名",
+        "accessToken": "访问令牌",
+        "apiToken": "API 令牌"
+      },
+      "routes": {
+        "hint": "导入的站点默认启用，模型发现将在后台进行；请在下方设置路由权重。",
+        "weight": "权重",
+        "invalidWeight": "权重必须是大于等于 0 的数字。"
+      },
+      "done": {
+        "imported": "已导入 {{count}}",
+        "skipped": "已跳过 {{count}}",
+        "failed": "失败 {{count}}",
+        "close": "完成"
+      },
+      "result": {
+        "imported": "已导入",
+        "merged": "已合并",
+        "skipped": "已跳过",
+        "failed": "失败"
+      }
+    },
     "auth": {
       "login": {
         "title": "登录",
@@ -308,7 +360,8 @@
       "empty": {
         "title": "暂无站点",
         "description": "添加一个站点即可开始路由请求。",
-        "addSite": "添加站点"
+        "addSite": "添加站点",
+        "import": "导入站点"
       },
       "toolbar": {
         "searchPlaceholder": "搜索站点…",
@@ -1225,6 +1278,7 @@
         "loadError": "加载账号失败：{{message}}",
         "emptyTitle": "暂无账号",
         "emptyDescription": "添加一个账号以开始管理连接，或先到「站点」页添加站点。",
+        "emptyImport": "导入站点",
         "searchPlaceholder": "搜索账号名称 / 站点…",
         "filterStatusTitle": "状态",
         "filterStatusActive": "启用",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1006,6 +1006,11 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ url }),
     }),
+  importSites: (data: unknown) =>
+    request('/api/sites/import', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   getSiteDisabledModels: (siteId: number) =>
     request(`/api/sites/${siteId}/disabled-models`),
   updateSiteDisabledModels: (siteId: number, models: string[]) =>


### PR DESCRIPTION
## Summary
PR4 — import flow (#611-#616). Backend + frontend.

- #611 `POST /api/sites/detect` returns siteType + confidence + canonical URL (read-only probe).
- #612 site form auto-recognizes platform on URL paste (unknown stays manual).
- #613 unified 5-step import wizard (`web/src/features/import/`) with `aria-current` step states.
- #614 `POST /api/sites/import` idempotent batch import (imported/skipped/failed).
- #615 duplicate detection + skip/merge options (backend merges accounts on `merge`).
- #616 empty-state import CTA + guidance on Sites/Accounts.

## Validation
- Go: `go build ./cmd/server` ✅ · `go vet ./...` ✅ · `go test -p 1 ./... -count=1` ✅
- Web: `typecheck` ✅ · `lint` ✅ · `test` 29 files/337 ✅ · `build` ✅
- `-race` fails with Windows ThreadSanitizer "error 87" (known address-space limitation, not a code defect).