### PR TITLE
feat(models): pricing layer + price-compare/fix-candidates UI + recommendations (PR5)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -195,11 +195,21 @@ Cross-site effective model price comparison for operators.
 
 Query: `model` (optional name/substring), `days` (default 30), `limit` (default 50), `topModels` (default 12 when model empty).
 
-Returns `{ model, days, limit, sampleUsage, items: [{ siteId, siteName, platform, model, accountId, username, inputPerMillion, outputPerMillion, source, ratesSource, estimatedCostSample, observedSamples, configuredUnitCost, missingPrice }], meta }`.
+Returns `{ model, days, limit, sampleUsage, items: [{ siteId, siteName, platform, model, accountId, username, inputPerMillion, outputPerMillion, source, ratesSource, estimatedCostSample, observedSamples, configuredUnitCost, missingPrice, recommended }], meta }`.
 
-`source` is one of `billing_details` | `observed` | `configured` | `fallback`. Fallback is always labeled; `missingPrice=true` when no catalog/observed/configured signal exists.
+`source` is one of `billing_details` | `observed` | `configured` | `fallback`. Fallback is always labeled; `missingPrice=true` when no catalog/observed/configured signal exists. Rows are sorted cheapest-first and `recommended=true` marks the best channel per model.
 
 Alias: `GET /api/stats/model-prices` (same handler).
+
+### GET /api/models/redirect-fix-candidates
+
+List disabled models that an existing redirect mapping can restore.
+
+Returns `{ items: [{ siteId, siteName, accountId, modelName, canonical, actual }], count }`.
+
+### POST /api/models/redirect-fix-candidates
+
+Apply the listed redirect fixes. Body: `{ "dryRun": false }` (`false` applies; `true` previews without deleting). Returns `{ success, dryRun, removed, count }`.
 
 ### GET /api/models/token-candidates
 

--- a/handler/admin/model_redirects.go
+++ b/handler/admin/model_redirects.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/service"
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
-	"github.com/deliciousbuding/metapi-go/service"
 )
 
 // ---- Model Name Redirects ----
@@ -27,6 +27,75 @@ func RegisterModelRedirectRoutes(r chi.Router, db *sqlx.DB) {
 
 type modelRedirectHandler struct {
 	db *sqlx.DB
+}
+
+// RegisterModelRedirectFixRoutes mounts the model-governance fix-candidate
+// endpoints. They wrap service.ListRedirectFixCandidates /
+// service.ApplyRedirectFixes so the admin SPA can review and apply
+// redirect-repairable disabled models without driving raw SQL.
+func RegisterModelRedirectFixRoutes(r chi.Router, db *sqlx.DB) {
+	h := &modelRedirectHandler{db: db}
+	r.Get("/api/models/redirect-fix-candidates", h.listFixCandidates)
+	r.Post("/api/models/redirect-fix-candidates", h.applyFixCandidates)
+}
+
+// GET /api/models/redirect-fix-candidates
+func (h *modelRedirectHandler) listFixCandidates(w http.ResponseWriter, r *http.Request) {
+	candidates, err := service.ListRedirectFixCandidates(r.Context(), h.db)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to list fix candidates"})
+		return
+	}
+	if candidates == nil {
+		candidates = []service.RedirectFixCandidate{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": candidates, "count": len(candidates)})
+}
+
+// POST /api/models/redirect-fix-candidates — body {dryRun?: bool}.
+// dryRun=true reports without deleting; the default (false) applies the
+// fixes, records an event per candidate, and reloads the hot-path registry.
+func (h *modelRedirectHandler) applyFixCandidates(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		DryRun *bool `json:"dryRun"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "invalid JSON body"})
+		return
+	}
+	dryRun := body.DryRun != nil && *body.DryRun
+
+	candidates, err := service.ListRedirectFixCandidates(r.Context(), h.db)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to list fix candidates"})
+		return
+	}
+
+	if dryRun {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"success": true,
+			"dryRun":  true,
+			"items":   candidates,
+			"count":   len(candidates),
+		})
+		return
+	}
+
+	removed, err := service.ApplyRedirectFixes(r.Context(), h.db, candidates)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "apply failed: " + err.Error()})
+		return
+	}
+	for _, c := range candidates {
+		_ = recordRedirectEvent(h.db, c)
+	}
+	service.ReloadRedirectRegistry(r.Context(), h.db) // K1b: keep hot-path registry fresh
+	writeJSON(w, http.StatusOK, map[string]any{
+		"success": true,
+		"dryRun":  false,
+		"removed": removed,
+		"count":   len(candidates),
+	})
 }
 
 // GET /api/model-redirects?accountId=&source=
@@ -236,10 +305,10 @@ func (h *modelRedirectHandler) apply(w http.ResponseWriter, r *http.Request) {
 
 	if dryRun {
 		writeJSON(w, http.StatusOK, map[string]any{
-			"success":   true,
-			"dryRun":    true,
+			"success":    true,
+			"dryRun":     true,
 			"candidates": candidates,
-			"count":     len(candidates),
+			"count":      len(candidates),
 		})
 		return
 	}

--- a/handler/admin/model_redirects_test.go
+++ b/handler/admin/model_redirects_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
 )
 
 // ---- K1a: model name redirects ----
@@ -42,6 +42,7 @@ func setupRedirectTest(t *testing.T) (*store.DB, chi.Router, int64, int64) {
 
 	r := chi.NewRouter()
 	RegisterModelRedirectRoutes(r, db.DB)
+	RegisterModelRedirectFixRoutes(r, db.DB)
 	return db, r, siteID, accountID
 }
 
@@ -170,9 +171,9 @@ func TestRedirects_GenerationRules(t *testing.T) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	for _, m := range []string{
 		"claude-3-5-sonnet-20241022-v2", // date+revision suffix
-		"claude-3-5-haiku-latest",        // version suffix
-		"gpt-4o",                         // exact → no mapping
-		"CLAUDE-3-5-SONNET-20250101",     // case-folded date suffix
+		"claude-3-5-haiku-latest",       // version suffix
+		"gpt-4o",                        // exact → no mapping
+		"CLAUDE-3-5-SONNET-20250101",    // case-folded date suffix
 	} {
 		_, err := db.Exec(`INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at)
 			VALUES (?, ?, 1, 0, ?)`, accountID, m, now)
@@ -227,5 +228,70 @@ func TestRedirects_Validation(t *testing.T) {
 	resp = doPutJSON(t, r, "/api/model-redirects/abc", map[string]any{"actual": "x"})
 	if resp.Code != 400 {
 		t.Fatalf("bad id returned %d, want 400", resp.Code)
+	}
+}
+
+func TestRedirectFixCandidates_ListAndApply(t *testing.T) {
+	db, r, siteID, accountID := setupRedirectTest(t)
+
+	// Generate the redirect mapping (canonical -> date-suffixed actual).
+	resp := doPostJSON(t, r, "/api/model-redirects/generate", map[string]any{"accountId": accountID})
+	if resp.Code != 200 {
+		t.Fatalf("generate returned %d: %s", resp.Code, resp.Body.String())
+	}
+
+	// Add a disabled-model entry for the canonical model.
+	if _, err := db.Exec(`INSERT INTO site_disabled_models (site_id, model_name, created_at)
+		VALUES (?, ?, ?)`, siteID, "claude-3-5-sonnet", time.Now().UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("insert disabled: %v", err)
+	}
+
+	// GET lists the candidate without side effects.
+	resp = doGet(t, r, "/api/models/redirect-fix-candidates")
+	if resp.Code != 200 {
+		t.Fatalf("list returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal list: %v", err)
+	}
+	if body["count"].(float64) != 1 {
+		t.Fatalf("count = %#v, want 1", body)
+	}
+	items := body["items"].([]any)
+	cand := items[0].(map[string]any)
+	if cand["canonical"] != "claude-3-5-sonnet" || cand["actual"] != "claude-3-5-sonnet-20241022" {
+		t.Fatalf("candidate = %#v", cand)
+	}
+
+	// POST dry-run does not delete.
+	resp = doPostJSON(t, r, "/api/models/redirect-fix-candidates", map[string]any{"dryRun": true})
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal dry-run: %v", err)
+	}
+	if body["dryRun"] != true {
+		t.Fatalf("dry-run = %#v", body)
+	}
+	var disabledCount int
+	if err := db.Get(&disabledCount, "SELECT COUNT(*) FROM site_disabled_models"); err != nil {
+		t.Fatalf("count disabled: %v", err)
+	}
+	if disabledCount != 1 {
+		t.Fatalf("disabled count after dry-run = %d, want 1", disabledCount)
+	}
+
+	// POST apply deletes it.
+	resp = doPostJSON(t, r, "/api/models/redirect-fix-candidates", map[string]any{"dryRun": false})
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal apply: %v", err)
+	}
+	if body["removed"].(float64) != 1 {
+		t.Fatalf("removed = %#v, want 1", body)
+	}
+	if err := db.Get(&disabledCount, "SELECT COUNT(*) FROM site_disabled_models"); err != nil {
+		t.Fatalf("count after apply: %v", err)
+	}
+	if disabledCount != 0 {
+		t.Fatalf("disabled count after apply = %d, want 0", disabledCount)
 	}
 }

--- a/router/router.go
+++ b/router/router.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/deliciousbuding/metapi-go/app"
 	"github.com/deliciousbuding/metapi-go/auth"
 	"github.com/deliciousbuding/metapi-go/config"
@@ -16,6 +15,7 @@ import (
 	"github.com/deliciousbuding/metapi-go/handler/proxy"
 	"github.com/deliciousbuding/metapi-go/service"
 	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
 )
 
 // New creates and configures the Chi router with the full middleware stack,
@@ -86,6 +86,8 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 			admin.RegisterAnnouncementsRoutes(r, db.DB)
 			// K1a: model name redirects.
 			admin.RegisterModelRedirectRoutes(r, db.DB)
+			// K1a: model-governance fix candidates (list + apply).
+			admin.RegisterModelRedirectFixRoutes(r, db.DB)
 			// Read-only multiplier/rate overview.
 			admin.RegisterModelRatesRoutes(r, db.DB)
 			// B1: admin write-operation audit log.

--- a/routing/price_compare.go
+++ b/routing/price_compare.go
@@ -2,6 +2,8 @@ package routing
 
 import (
 	"strings"
+
+	"github.com/deliciousbuding/metapi-go/service/pricing"
 )
 
 // Price comparison provenance labels. Callers must not invent unlabeled prices.
@@ -54,20 +56,21 @@ type PriceCompareInput struct {
 
 // PriceCompareRow is one cross-site effective price candidate for admin UX.
 type PriceCompareRow struct {
-	SiteID               int64   `json:"siteId"`
-	SiteName             string  `json:"siteName"`
-	Platform             string  `json:"platform"`
-	Model                string  `json:"model"`
-	AccountID            int64   `json:"accountId"`
-	Username             string  `json:"username,omitempty"`
-	InputPerMillion      float64 `json:"inputPerMillion"`
-	OutputPerMillion     float64 `json:"outputPerMillion"`
-	Source               string  `json:"source"`
-	RatesSource          string  `json:"ratesSource"`
-	EstimatedCostSample  float64 `json:"estimatedCostSample"`
-	ObservedSamples      int     `json:"observedSamples,omitempty"`
-	ConfiguredUnitCost   *float64 `json:"configuredUnitCost,omitempty"`
-	MissingPrice         bool    `json:"missingPrice"`
+	SiteID              int64    `json:"siteId"`
+	SiteName            string   `json:"siteName"`
+	Platform            string   `json:"platform"`
+	Model               string   `json:"model"`
+	AccountID           int64    `json:"accountId"`
+	Username            string   `json:"username,omitempty"`
+	InputPerMillion     float64  `json:"inputPerMillion"`
+	OutputPerMillion    float64  `json:"outputPerMillion"`
+	Source              string   `json:"source"`
+	RatesSource         string   `json:"ratesSource"`
+	EstimatedCostSample float64  `json:"estimatedCostSample"`
+	ObservedSamples     int      `json:"observedSamples,omitempty"`
+	ConfiguredUnitCost  *float64 `json:"configuredUnitCost,omitempty"`
+	MissingPrice        bool     `json:"missingPrice"`
+	Recommended         bool     `json:"recommended"`
 }
 
 // BuildPriceCompareRow resolves effective rates + sample cost without inventing
@@ -187,7 +190,27 @@ func AggregatePriceCompareRows(rows []PriceCompareRow) []PriceCompareRow {
 			}
 		}
 	}
-	return out
+	return markPriceCompareRecommendations(out)
+}
+
+// markPriceCompareRecommendations flags the cheapest priced row of each model
+// as the recommended best channel. Rows without a resolvable model name or
+// without a price are never recommended.
+func markPriceCompareRecommendations(rows []PriceCompareRow) []PriceCompareRow {
+	seen := make(map[string]struct{}, len(rows))
+	for i := range rows {
+		row := &rows[i]
+		key := strings.ToLower(strings.TrimSpace(row.Model))
+		if key == "" || row.MissingPrice {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		row.Recommended = true
+	}
+	return rows
 }
 
 func priceCompareLess(a, b PriceCompareRow) bool {
@@ -215,24 +238,13 @@ func resolvePriceCompareRates(in PriceCompareInput, model string) (inputPerM, ou
 
 	if (in.ModelRatio != nil && isFiniteFloat(*in.ModelRatio) && *in.ModelRatio > 0) ||
 		(in.CompletionRatio != nil && isFiniteFloat(*in.CompletionRatio) && *in.CompletionRatio > 0) {
-		pm := PricingModel{
+		canonical := pricing.NormalizeToProductCanonical(pricing.NormalizeInput{
 			ModelName:       model,
-			QuotaType:       0,
-			ModelRatio:      1,
-			CompletionRatio: 1,
-		}
-		if in.ModelRatio != nil && isFiniteFloat(*in.ModelRatio) && *in.ModelRatio > 0 {
-			pm.ModelRatio = *in.ModelRatio
-		}
-		if in.CompletionRatio != nil && isFiniteFloat(*in.CompletionRatio) && *in.CompletionRatio > 0 {
-			pm.CompletionRatio = *in.CompletionRatio
-		}
-		groupMul := 1.0
-		if in.GroupRatio != nil && isFiniteFloat(*in.GroupRatio) && *in.GroupRatio > 0 {
-			groupMul = *in.GroupRatio
-		}
-		inM, outM, _, _ := CacheAwarePerMillionRates(pm, groupMul)
-		return inM, outM, PriceSourceBilling
+			ModelRatio:      in.ModelRatio,
+			CompletionRatio: in.CompletionRatio,
+			GroupMultiplier: in.GroupRatio,
+		})
+		return canonical.InputPerMillion, canonical.OutputPerMillion, PriceSourceBilling
 	}
 
 	// Explicit single-sided rates still count as billing when one side is known.

--- a/routing/price_compare_test.go
+++ b/routing/price_compare_test.go
@@ -169,3 +169,26 @@ func TestAggregatePriceCompareRows_SortCheapestFirstMissingLast(t *testing.T) {
 		t.Fatalf("last should be missing A, got %+v", got[3])
 	}
 }
+
+func TestAggregatePriceCompareRows_MarksRecommendedCheapestPerModel(t *testing.T) {
+	rows := []PriceCompareRow{
+		{SiteName: "Expensive", Model: "gpt-4o", EstimatedCostSample: 0.5, MissingPrice: false, AccountID: 1},
+		{SiteName: "Cheap", Model: "gpt-4o", EstimatedCostSample: 0.1, MissingPrice: false, AccountID: 2},
+		{SiteName: "Missing", Model: "gpt-4o", EstimatedCostSample: 0.0, MissingPrice: true, AccountID: 3},
+		{SiteName: "OtherModel", Model: "claude-x", EstimatedCostSample: 0.2, MissingPrice: false, AccountID: 4},
+	}
+	got := AggregatePriceCompareRows(rows)
+	byAccount := map[int64]PriceCompareRow{}
+	for _, r := range got {
+		byAccount[r.AccountID] = r
+	}
+	if !byAccount[2].Recommended {
+		t.Fatalf("cheapest gpt-4o row should be recommended: %+v", byAccount[2])
+	}
+	if byAccount[1].Recommended || byAccount[3].Recommended {
+		t.Fatal("only the cheapest priced row should be recommended")
+	}
+	if !byAccount[4].Recommended {
+		t.Fatal("sole priced row for claude-x should be recommended")
+	}
+}

--- a/service/pricing/pricing.go
+++ b/service/pricing/pricing.go
@@ -1,0 +1,95 @@
+// Package pricing provides pure, database-free functions for normalizing
+// upstream pricing signals into a canonical product model and converting
+// pricing multipliers (ratios) into USD per million tokens. It is shared by
+// the admin price-comparison surface so every consumer applies the same math
+// and never invents an unlabeled price.
+package pricing
+
+import (
+	"math"
+	"strings"
+)
+
+// BaseUSDPerMillionInput is the base USD per 1M input tokens at model ratio
+// 1.0. It matches routing.CacheAwarePerMillionRates
+// (input = modelRatio x 2 x groupMultiplier) so the canonical layer and the
+// routing layer agree on the same effective rate.
+const BaseUSDPerMillionInput = 2.0
+
+// ProductCanonicalModel is a normalized cross-site product model with
+// effective USD-per-million input/output rates. It is the reusable shape
+// consumed by price comparison rather than a wire type.
+type ProductCanonicalModel struct {
+	ModelName        string  `json:"modelName"`
+	InputPerMillion  float64 `json:"inputPerMillion"`
+	OutputPerMillion float64 `json:"outputPerMillion"`
+}
+
+// NormalizeInput carries the raw pricing signals for one model. Pointer
+// fields distinguish "missing" from an explicit zero.
+type NormalizeInput struct {
+	ModelName        string
+	InputPerMillion  *float64 // explicit $/M input (already normalized)
+	OutputPerMillion *float64 // explicit $/M output
+	ModelRatio       *float64
+	CompletionRatio  *float64
+	GroupMultiplier  *float64
+}
+
+// MultiplierToUSDPerMillion converts a pricing multiplier into USD per 1M
+// input tokens. Non-positive, NaN, or Inf multipliers yield 0 (no invented
+// price).
+func MultiplierToUSDPerMillion(multiplier float64) float64 {
+	if !(multiplier > 0) || math.IsNaN(multiplier) || math.IsInf(multiplier, 0) {
+		return 0
+	}
+	return round6(multiplier * BaseUSDPerMillionInput)
+}
+
+// NormalizeToProductCanonical resolves raw pricing signals into canonical
+// USD-per-million rates. Explicit per-million values win when both sides are
+// present; otherwise ratios are converted via MultiplierToUSDPerMillion.
+func NormalizeToProductCanonical(in NormalizeInput) ProductCanonicalModel {
+	out := ProductCanonicalModel{ModelName: strings.TrimSpace(in.ModelName)}
+
+	inPerM := positiveFloat(in.InputPerMillion)
+	outPerM := positiveFloat(in.OutputPerMillion)
+	if inPerM != nil && outPerM != nil {
+		out.InputPerMillion = round6(*inPerM)
+		out.OutputPerMillion = round6(*outPerM)
+		return out
+	}
+
+	modelRatio := positiveOr(in.ModelRatio, 1)
+	completionRatio := positiveOr(in.CompletionRatio, 1)
+	groupMultiplier := positiveOr(in.GroupMultiplier, 1)
+
+	out.InputPerMillion = MultiplierToUSDPerMillion(modelRatio * groupMultiplier)
+	out.OutputPerMillion = MultiplierToUSDPerMillion(modelRatio * completionRatio * groupMultiplier)
+	return out
+}
+
+// positiveFloat returns v when it is a finite positive number, else nil.
+func positiveFloat(v *float64) *float64 {
+	if v == nil || !(*v > 0) || math.IsNaN(*v) || math.IsInf(*v, 0) {
+		return nil
+	}
+	return v
+}
+
+// positiveOr returns a finite positive pointer value or the fallback.
+func positiveOr(v *float64, fallback float64) float64 {
+	if p := positiveFloat(v); p != nil {
+		return *p
+	}
+	return fallback
+}
+
+// round6 rounds a non-negative value to six decimal places (matching the
+// routing layer's roundCost precision) and clamps negatives/non-finite to 0.
+func round6(v float64) float64 {
+	if v < 0 || math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0
+	}
+	return math.Round(v*1_000_000) / 1_000_000
+}

--- a/service/pricing/pricing_test.go
+++ b/service/pricing/pricing_test.go
@@ -1,0 +1,104 @@
+package pricing
+
+import (
+	"math"
+	"testing"
+)
+
+func TestMultiplierToUSDPerMillion(t *testing.T) {
+	tests := []struct {
+		name       string
+		multiplier float64
+		want       float64
+	}{
+		{"base ratio", 1, 2},
+		{"half ratio", 0.5, 1},
+		{"fractional", 2.5, 5},
+		{"zero", 0, 0},
+		{"negative", -1, 0},
+		{"NaN", math.NaN(), 0},
+		{"positive inf", math.Inf(1), 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MultiplierToUSDPerMillion(tt.multiplier)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Fatalf("MultiplierToUSDPerMillion(%v) = %v, want %v", tt.multiplier, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeToProductCanonical_ExplicitPerMillionWins(t *testing.T) {
+	in := 3.0
+	out := 15.0
+	model := NormalizeToProductCanonical(NormalizeInput{
+		ModelName:        "gpt-4o",
+		InputPerMillion:  &in,
+		OutputPerMillion: &out,
+		ModelRatio:       toPtr(99.0),
+		CompletionRatio:  toPtr(99.0),
+	})
+	if model.ModelName != "gpt-4o" {
+		t.Fatalf("model name = %q", model.ModelName)
+	}
+	if model.InputPerMillion != 3 || model.OutputPerMillion != 15 {
+		t.Fatalf("rates = %v/%v, want 3/15", model.InputPerMillion, model.OutputPerMillion)
+	}
+}
+
+func TestNormalizeToProductCanonical_Ratios(t *testing.T) {
+	mr := 2.5
+	cr := 4.0
+	model := NormalizeToProductCanonical(NormalizeInput{
+		ModelName:       "gpt-x",
+		ModelRatio:      &mr,
+		CompletionRatio: &cr,
+	})
+	// input = 2.5 * 2 = 5; output = 2.5 * 4 * 2 = 20
+	if model.InputPerMillion != 5 || model.OutputPerMillion != 20 {
+		t.Fatalf("rates = %v/%v, want 5/20", model.InputPerMillion, model.OutputPerMillion)
+	}
+}
+
+func TestNormalizeToProductCanonical_GroupMultiplier(t *testing.T) {
+	mr := 2.5
+	cr := 4.0
+	gr := 0.5
+	model := NormalizeToProductCanonical(NormalizeInput{
+		ModelName:       "gpt-x",
+		ModelRatio:      &mr,
+		CompletionRatio: &cr,
+		GroupMultiplier: &gr,
+	})
+	// input = 2.5 * 0.5 * 2 = 2.5; output = 2.5 * 4 * 0.5 * 2 = 10
+	if model.InputPerMillion != 2.5 || model.OutputPerMillion != 10 {
+		t.Fatalf("rates = %v/%v, want 2.5/10", model.InputPerMillion, model.OutputPerMillion)
+	}
+}
+
+func TestNormalizeToProductCanonical_DefaultsAndClamps(t *testing.T) {
+	model := NormalizeToProductCanonical(NormalizeInput{ModelName: "  bare  "})
+	if model.ModelName != "bare" {
+		t.Fatalf("model name trimmed = %q", model.ModelName)
+	}
+	// Defaults: modelRatio=1, completionRatio=1, group=1 → 2/2.
+	if model.InputPerMillion != 2 || model.OutputPerMillion != 2 {
+		t.Fatalf("default rates = %v/%v, want 2/2", model.InputPerMillion, model.OutputPerMillion)
+	}
+
+	neg := -1.0
+	clamped := NormalizeToProductCanonical(NormalizeInput{
+		ModelName:       "clamped",
+		ModelRatio:      &neg,
+		CompletionRatio: &neg,
+		GroupMultiplier: &neg,
+	})
+	if clamped.InputPerMillion != 2 || clamped.OutputPerMillion != 2 {
+		t.Fatalf("clamped rates = %v/%v, want 2/2 (negative falls back to 1)", clamped.InputPerMillion, clamped.OutputPerMillion)
+	}
+}
+
+func toPtr(v float64) *float64 {
+	return &v
+}

--- a/web/src/features/models/fix-candidates/api.ts
+++ b/web/src/features/models/fix-candidates/api.ts
@@ -1,0 +1,51 @@
+// metapi-go/features/models/fix-candidates — TanStack Query hooks.
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import i18n from '@/i18n/config'
+import { api } from '@/lib/api'
+
+import {
+  fixCandidatesQueryKeys,
+  redirectFixApplyResponseSchema,
+  redirectFixCandidatesResponseSchema,
+} from './types'
+
+export function useRedirectFixCandidates() {
+  return useQuery({
+    queryKey: fixCandidatesQueryKeys.list(),
+    queryFn: async () => {
+      const raw = await api.getRedirectFixCandidates()
+      return redirectFixCandidatesResponseSchema.parse(raw)
+    },
+    staleTime: 15 * 1000,
+  })
+}
+
+export function useApplyRedirectFixCandidates() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async () => {
+      const raw = await api.applyRedirectFixCandidates()
+      return redirectFixApplyResponseSchema.parse(raw)
+    },
+    onSuccess: (res) => {
+      void queryClient.invalidateQueries({
+        queryKey: fixCandidatesQueryKeys.all,
+      })
+      toast.success(
+        i18n.t('fixCandidates.toast.applySucceeded', {
+          count: res.removed ?? res.count ?? 0,
+        })
+      )
+    },
+    onError: (err) => {
+      toast.error(
+        i18n.t('fixCandidates.toast.applyFailed', {
+          message: (err as Error).message,
+        })
+      )
+    },
+  })
+}

--- a/web/src/features/models/fix-candidates/components/fix-candidates-page.tsx
+++ b/web/src/features/models/fix-candidates/components/fix-candidates-page.tsx
@@ -17,10 +17,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 
-import {
-  useApplyRedirectFixCandidates,
-  useRedirectFixCandidates,
-} from '../api'
+import { useApplyRedirectFixCandidates, useRedirectFixCandidates } from '../api'
 
 export function FixCandidatesPage() {
   const { t } = useTranslation()
@@ -91,8 +88,10 @@ export function FixCandidatesPage() {
                 <TableCell className='font-medium'>
                   {candidate.siteName}
                 </TableCell>
-                <TableCell className='font-mono'>{candidate.modelName}</TableCell>
-                <TableCell className='font-mono text-muted-foreground'>
+                <TableCell className='font-mono'>
+                  {candidate.modelName}
+                </TableCell>
+                <TableCell className='text-muted-foreground font-mono'>
                   {candidate.canonical} → {candidate.actual}
                 </TableCell>
                 <TableCell className='tabular-nums'>

--- a/web/src/features/models/fix-candidates/components/fix-candidates-page.tsx
+++ b/web/src/features/models/fix-candidates/components/fix-candidates-page.tsx
@@ -1,0 +1,122 @@
+// metapi-go/features/models/fix-candidates — list disabled models that an
+// existing redirect can restore, with a one-click apply + result feedback.
+
+import { CheckCircle2 } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { ConfirmDialog } from '@/components/common/confirm-dialog'
+import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+import {
+  useApplyRedirectFixCandidates,
+  useRedirectFixCandidates,
+} from '../api'
+
+export function FixCandidatesPage() {
+  const { t } = useTranslation()
+  const list = useRedirectFixCandidates()
+  const apply = useApplyRedirectFixCandidates()
+  const [confirmOpen, setConfirmOpen] = useState(false)
+
+  const candidates = list.data?.items ?? []
+  const count = list.data?.count ?? candidates.length
+
+  return (
+    <div className='flex h-full flex-col gap-3 p-4'>
+      <div className='flex items-end justify-between gap-3'>
+        <div>
+          <h1 className='text-lg font-normal'>
+            {t('fixCandidates.page.title')}
+          </h1>
+          <p className='text-muted-foreground text-sm'>
+            {t('fixCandidates.page.description')}
+          </p>
+        </div>
+        <Button
+          size='sm'
+          disabled={count === 0 || list.isLoading || apply.isPending}
+          onClick={() => setConfirmOpen(true)}
+        >
+          <CheckCircle2 className='mr-1 size-3.5' />
+          {t('fixCandidates.apply')}
+        </Button>
+      </div>
+
+      {list.isLoading && (
+        <div className='text-muted-foreground flex items-center gap-2 text-sm'>
+          <Spinner />
+          {t('common.loading')}
+        </div>
+      )}
+
+      {list.error && (
+        <div className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg rounded-lg border p-3 text-sm'>
+          {t('fixCandidates.page.loadError', {
+            message: (list.error as Error).message,
+          })}
+        </div>
+      )}
+
+      {!list.isLoading && !list.error && count === 0 && (
+        <div className='text-muted-foreground rounded-lg border border-dashed p-8 text-center text-sm'>
+          {t('fixCandidates.page.emptyDescription')}
+        </div>
+      )}
+
+      {!list.isLoading && !list.error && count > 0 && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{t('fixCandidates.columns.site')}</TableHead>
+              <TableHead>{t('fixCandidates.columns.model')}</TableHead>
+              <TableHead>{t('fixCandidates.columns.redirect')}</TableHead>
+              <TableHead>{t('fixCandidates.columns.account')}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {candidates.map((candidate) => (
+              <TableRow
+                key={`${candidate.siteId}-${candidate.accountId}-${candidate.modelName}`}
+              >
+                <TableCell className='font-medium'>
+                  {candidate.siteName}
+                </TableCell>
+                <TableCell className='font-mono'>{candidate.modelName}</TableCell>
+                <TableCell className='font-mono text-muted-foreground'>
+                  {candidate.canonical} → {candidate.actual}
+                </TableCell>
+                <TableCell className='tabular-nums'>
+                  #{candidate.accountId}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <ConfirmDialog
+        open={confirmOpen}
+        title={t('fixCandidates.confirm.title')}
+        description={t('fixCandidates.confirm.description', { count })}
+        confirmLabel={t('common.confirm')}
+        cancelLabel={t('common.cancel')}
+        destructive
+        onConfirm={() => {
+          setConfirmOpen(false)
+          apply.mutate()
+        }}
+        onCancel={() => setConfirmOpen(false)}
+      />
+    </div>
+  )
+}

--- a/web/src/features/models/fix-candidates/index.ts
+++ b/web/src/features/models/fix-candidates/index.ts
@@ -1,0 +1,14 @@
+// metapi-go/features/models/fix-candidates — barrel re-exports.
+
+export { useApplyRedirectFixCandidates, useRedirectFixCandidates } from './api'
+export {
+  fixCandidatesQueryKeys,
+  redirectFixApplyResponseSchema,
+  redirectFixCandidateSchema,
+  redirectFixCandidatesResponseSchema,
+} from './types'
+export type {
+  RedirectFixApplyResponse,
+  RedirectFixCandidate,
+  RedirectFixCandidatesResponse,
+} from './types'

--- a/web/src/features/models/fix-candidates/types.ts
+++ b/web/src/features/models/fix-candidates/types.ts
@@ -1,0 +1,37 @@
+// metapi-go/features/models/fix-candidates — domain types for redirect
+// fix-candidate review/apply. Mirrors service.RedirectFixCandidate.
+
+import { z } from 'zod'
+
+export const redirectFixCandidateSchema = z.object({
+  siteId: z.coerce.number().default(0),
+  siteName: z.string().catch(''),
+  accountId: z.coerce.number().default(0),
+  modelName: z.string().catch(''),
+  canonical: z.string().catch(''),
+  actual: z.string().catch(''),
+})
+export type RedirectFixCandidate = z.infer<typeof redirectFixCandidateSchema>
+
+export const redirectFixCandidatesResponseSchema = z.object({
+  items: z.array(redirectFixCandidateSchema).catch([]),
+  count: z.coerce.number().default(0),
+})
+export type RedirectFixCandidatesResponse = z.infer<
+  typeof redirectFixCandidatesResponseSchema
+>
+
+export const redirectFixApplyResponseSchema = z.object({
+  success: z.coerce.boolean().default(false),
+  dryRun: z.coerce.boolean().default(false),
+  removed: z.coerce.number().nullish(),
+  count: z.coerce.number().nullish(),
+})
+export type RedirectFixApplyResponse = z.infer<
+  typeof redirectFixApplyResponseSchema
+>
+
+export const fixCandidatesQueryKeys = {
+  all: ['models', 'redirect-fix-candidates'] as const,
+  list: () => [...fixCandidatesQueryKeys.all, 'list'] as const,
+}

--- a/web/src/features/models/price-compare/api.ts
+++ b/web/src/features/models/price-compare/api.ts
@@ -1,0 +1,39 @@
+// metapi-go/features/models/price-compare — TanStack Query hooks.
+// The backend returns the full sorted candidate list (cheaper first); the
+// page groups by model for the cross-site view.
+
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+
+import { api } from '@/lib/api'
+
+import {
+  priceCompareQueryKeys,
+  priceCompareResponseSchema,
+  type PriceCompareItem,
+} from './types'
+
+export type PriceCompareParams = {
+  model?: string
+  days?: number
+  limit?: number
+  topModels?: number
+}
+
+export function usePriceCompare(
+  params: PriceCompareParams = {},
+  options?: Omit<
+    UseQueryOptions<PriceCompareItem[], Error, PriceCompareItem[]>,
+    'queryKey' | 'queryFn'
+  >
+) {
+  return useQuery({
+    queryKey: priceCompareQueryKeys.list(params),
+    queryFn: async () => {
+      const raw = await api.getModelPriceCompare(params)
+      const parsed = priceCompareResponseSchema.parse(raw)
+      return parsed.items
+    },
+    staleTime: 30 * 1000,
+    ...options,
+  })
+}

--- a/web/src/features/models/price-compare/components/price-compare-page.tsx
+++ b/web/src/features/models/price-compare/components/price-compare-page.tsx
@@ -102,7 +102,7 @@ export function PriceComparePage() {
       </div>
 
       {query.isLoading && (
-        <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+        <div className='text-muted-foreground flex items-center gap-2 text-sm'>
           <Spinner />
           {t('common.loading')}
         </div>
@@ -147,9 +147,7 @@ function ModelGroupCard({ group }: { group: ModelGroup }) {
             </Badge>
           )}
         </CardTitle>
-        <CardDescription>
-          {t('priceCompare.group.description')}
-        </CardDescription>
+        <CardDescription>{t('priceCompare.group.description')}</CardDescription>
       </CardHeader>
       <CardContent>
         <Table>
@@ -171,7 +169,10 @@ function ModelGroupCard({ group }: { group: ModelGroup }) {
           </TableHeader>
           <TableBody>
             {group.rows.map((row) => (
-              <PriceRow key={`${row.siteId}-${row.accountId}-${row.model}`} row={row} />
+              <PriceRow
+                key={`${row.siteId}-${row.accountId}-${row.model}`}
+                row={row}
+              />
             ))}
           </TableBody>
         </Table>
@@ -186,9 +187,7 @@ function PriceRow({ row }: { row: PriceCompareItem }) {
       <TableCell>
         <div className='font-medium'>{row.siteName}</div>
         {row.username && (
-          <div className='text-muted-foreground text-xs'>
-            {row.username}
-          </div>
+          <div className='text-muted-foreground text-xs'>{row.username}</div>
         )}
       </TableCell>
       <TableCell>

--- a/web/src/features/models/price-compare/components/price-compare-page.tsx
+++ b/web/src/features/models/price-compare/components/price-compare-page.tsx
@@ -1,0 +1,232 @@
+// metapi-go/features/models/price-compare — standalone cross-site price page.
+// Groups the backend's cheaper-first candidate rows by model and surfaces the
+// provenance grade + best-channel recommendation for every source.
+
+import { Search, Star } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Badge } from '@/components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Spinner } from '@/components/ui/spinner'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+import { usePriceCompare } from '../api'
+import type { PriceCompareItem } from '../types'
+import { PriceGradeBadge } from './price-grade-badge'
+
+function formatPerMillion(value: number): string {
+  return value.toFixed(4)
+}
+
+function formatSampleCost(value: number): string {
+  return `$${value.toFixed(6)}`
+}
+
+type ModelGroup = {
+  key: string
+  model: string
+  rows: PriceCompareItem[]
+}
+
+export function PriceComparePage() {
+  const { t } = useTranslation()
+  const [search, setSearch] = useState('')
+  const [modelParam, setModelParam] = useState('')
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setModelParam(search.trim())
+    }, 350)
+    return () => window.clearTimeout(timer)
+  }, [search])
+
+  const query = usePriceCompare({
+    model: modelParam || undefined,
+    limit: 200,
+  })
+
+  const groups = useMemo<ModelGroup[]>(() => {
+    const map = new Map<string, PriceCompareItem[]>()
+    for (const item of query.data ?? []) {
+      const key = item.model.trim().toLowerCase() || '__unknown__'
+      const list = map.get(key) ?? []
+      list.push(item)
+      map.set(key, list)
+    }
+    return [...map.entries()].map(([key, rows]) => ({
+      key,
+      model: rows[0]?.model ?? '',
+      rows,
+    }))
+  }, [query.data])
+
+  return (
+    <div className='flex h-full flex-col gap-3 p-4'>
+      <div className='flex items-end justify-between gap-3'>
+        <div>
+          <h1 className='text-lg font-normal'>
+            {t('priceCompare.page.title')}
+          </h1>
+          <p className='text-muted-foreground text-sm'>
+            {t('priceCompare.page.description')}
+          </p>
+        </div>
+        <div className='relative w-64'>
+          <Search
+            aria-hidden='true'
+            className='text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2'
+          />
+          <Input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder={t('priceCompare.page.searchPlaceholder')}
+            aria-label={t('priceCompare.page.searchPlaceholder')}
+            className='pl-8'
+          />
+        </div>
+      </div>
+
+      {query.isLoading && (
+        <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+          <Spinner />
+          {t('common.loading')}
+        </div>
+      )}
+
+      {query.error && (
+        <div className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg rounded-lg border p-3 text-sm'>
+          {t('priceCompare.page.loadError', {
+            message: (query.error as Error).message,
+          })}
+        </div>
+      )}
+
+      {!query.isLoading && !query.error && groups.length === 0 && (
+        <div className='text-muted-foreground rounded-lg border border-dashed p-8 text-center text-sm'>
+          {t('priceCompare.page.emptyDescription')}
+        </div>
+      )}
+
+      <div className='flex flex-col gap-4'>
+        {groups.map((group) => (
+          <ModelGroupCard key={group.key} group={group} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ModelGroupCard({ group }: { group: ModelGroup }) {
+  const { t } = useTranslation()
+  const hasRecommended = group.rows.some((row) => row.recommended)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className='flex items-center gap-2 text-base font-normal'>
+          <span className='font-mono'>{group.model}</span>
+          {hasRecommended && (
+            <Badge variant='secondary'>
+              <Star aria-hidden='true' className='size-3!' />
+              {t('priceCompare.recommended')}
+            </Badge>
+          )}
+        </CardTitle>
+        <CardDescription>
+          {t('priceCompare.group.description')}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{t('priceCompare.columns.site')}</TableHead>
+              <TableHead>{t('priceCompare.columns.grade')}</TableHead>
+              <TableHead className='text-right'>
+                {t('priceCompare.columns.input')}
+              </TableHead>
+              <TableHead className='text-right'>
+                {t('priceCompare.columns.output')}
+              </TableHead>
+              <TableHead className='text-right'>
+                {t('priceCompare.columns.effective')}
+              </TableHead>
+              <TableHead>{t('priceCompare.columns.status')}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {group.rows.map((row) => (
+              <PriceRow key={`${row.siteId}-${row.accountId}-${row.model}`} row={row} />
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}
+
+function PriceRow({ row }: { row: PriceCompareItem }) {
+  return (
+    <TableRow>
+      <TableCell>
+        <div className='font-medium'>{row.siteName}</div>
+        {row.username && (
+          <div className='text-muted-foreground text-xs'>
+            {row.username}
+          </div>
+        )}
+      </TableCell>
+      <TableCell>
+        <PriceGradeBadge grade={row.source} />
+      </TableCell>
+      <TableCell className='text-right tabular-nums'>
+        {formatPerMillion(row.inputPerMillion)}
+      </TableCell>
+      <TableCell className='text-right tabular-nums'>
+        {formatPerMillion(row.outputPerMillion)}
+      </TableCell>
+      <TableCell className='text-right tabular-nums'>
+        {row.missingPrice ? '—' : formatSampleCost(row.estimatedCostSample)}
+      </TableCell>
+      <TableCell>
+        <PriceRowStatus row={row} />
+      </TableCell>
+    </TableRow>
+  )
+}
+
+function PriceRowStatus({ row }: { row: PriceCompareItem }) {
+  const { t } = useTranslation()
+  if (row.missingPrice) {
+    return (
+      <span className='text-muted-foreground inline-flex items-center gap-1 text-xs'>
+        <Star aria-hidden='true' className='size-3 opacity-40' />
+        {t('priceCompare.missingPrice')}
+      </span>
+    )
+  }
+  if (row.recommended) {
+    return (
+      <Badge variant='default'>
+        <Star aria-hidden='true' className='size-3!' />
+        {t('priceCompare.recommended')}
+      </Badge>
+    )
+  }
+  return null
+}

--- a/web/src/features/models/price-compare/components/price-grade-badge.tsx
+++ b/web/src/features/models/price-compare/components/price-grade-badge.tsx
@@ -1,0 +1,48 @@
+// metapi-go/features/models/price-compare — provenance grade badge.
+// Dual-channel status: icon + text + semantic color, never color-only.
+
+import {
+  Activity,
+  CheckCircle2,
+  Settings,
+  TriangleAlert,
+  type LucideIcon,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Badge } from '@/components/ui/badge'
+
+import { priceGradeValues, type PriceGrade } from '../types'
+
+const gradeIcon: Record<PriceGrade, LucideIcon> = {
+  billing_details: CheckCircle2,
+  observed: Activity,
+  configured: Settings,
+  fallback: TriangleAlert,
+}
+
+const gradeVariant: Record<
+  PriceGrade,
+  'default' | 'secondary' | 'warning' | 'outline'
+> = {
+  billing_details: 'default',
+  observed: 'secondary',
+  configured: 'warning',
+  fallback: 'outline',
+}
+
+function isPriceGrade(value: string): value is PriceGrade {
+  return (priceGradeValues as readonly string[]).includes(value)
+}
+
+export function PriceGradeBadge({ grade }: { grade: string }) {
+  const { t } = useTranslation()
+  const normalized: PriceGrade = isPriceGrade(grade) ? grade : 'fallback'
+  const Icon = gradeIcon[normalized]
+  return (
+    <Badge variant={gradeVariant[normalized]}>
+      <Icon aria-hidden='true' />
+      {t(`priceCompare.grade.${normalized}`)}
+    </Badge>
+  )
+}

--- a/web/src/features/models/price-compare/index.ts
+++ b/web/src/features/models/price-compare/index.ts
@@ -1,0 +1,11 @@
+// metapi-go/features/models/price-compare — barrel re-exports.
+
+export { usePriceCompare } from './api'
+export type { PriceCompareParams } from './api'
+export {
+  priceCompareItemSchema,
+  priceCompareQueryKeys,
+  priceCompareResponseSchema,
+  priceGradeValues,
+} from './types'
+export type { PriceCompareItem, PriceGrade } from './types'

--- a/web/src/features/models/price-compare/types.ts
+++ b/web/src/features/models/price-compare/types.ts
@@ -1,0 +1,59 @@
+// metapi-go/features/models/price-compare — domain types for cross-site
+// effective price comparison. Mirrors handler/admin/model_price_compare.go
+// and routing.PriceCompareRow (camelCase wire contract).
+
+import { z } from 'zod'
+
+/** Provenance grades for a price, mirroring routing price-source labels. */
+export const priceGradeValues = [
+  'billing_details',
+  'observed',
+  'configured',
+  'fallback',
+] as const
+export type PriceGrade = (typeof priceGradeValues)[number]
+
+export const priceCompareItemSchema = z.object({
+  siteId: z.coerce.number().default(0),
+  siteName: z.string().catch(''),
+  platform: z.string().catch(''),
+  model: z.string().catch(''),
+  accountId: z.coerce.number().default(0),
+  username: z.string().nullish().default(null),
+  inputPerMillion: z.coerce.number().default(0),
+  outputPerMillion: z.coerce.number().default(0),
+  source: z.string().catch('fallback'),
+  ratesSource: z.string().catch('fallback'),
+  estimatedCostSample: z.coerce.number().default(0),
+  observedSamples: z.coerce.number().default(0),
+  configuredUnitCost: z.number().nullish(),
+  missingPrice: z.coerce.boolean().default(false),
+  recommended: z.coerce.boolean().default(false),
+})
+export type PriceCompareItem = z.infer<typeof priceCompareItemSchema>
+
+export const priceCompareResponseSchema = z.object({
+  model: z.string().catch(''),
+  days: z.coerce.number().default(30),
+  limit: z.coerce.number().default(50),
+  sampleUsage: z
+    .object({
+      promptTokens: z.coerce.number().default(1000),
+      completionTokens: z.coerce.number().default(1000),
+      totalTokens: z.coerce.number().default(2000),
+    })
+    .catch({ promptTokens: 1000, completionTokens: 1000, totalTokens: 2000 }),
+  items: z.array(priceCompareItemSchema).catch([]),
+  meta: z.unknown().nullish(),
+})
+export type PriceCompareResponse = z.infer<typeof priceCompareResponseSchema>
+
+export const priceCompareQueryKeys = {
+  all: ['models', 'price-compare'] as const,
+  list: (params: {
+    model?: string
+    days?: number
+    limit?: number
+    topModels?: number
+  }) => [...priceCompareQueryKeys.all, params] as const,
+}

--- a/web/src/hooks/use-sidebar-data.ts
+++ b/web/src/hooks/use-sidebar-data.ts
@@ -11,9 +11,11 @@ import {
   LayoutDashboard,
   ScrollText,
   Route,
+  Scale,
   Server,
   Settings,
   ShieldCheck,
+  Wrench,
 } from 'lucide-react'
 
 import type { SidebarData } from '@/components/layout/types'
@@ -88,6 +90,16 @@ export function useSidebarData(): SidebarData {
             title: 'sidebar.items.modelTester',
             url: '/model-tester',
             icon: FlaskConical,
+          },
+          {
+            title: 'sidebar.items.priceCompare',
+            url: '/price-compare',
+            icon: Scale,
+          },
+          {
+            title: 'sidebar.items.fixCandidates',
+            url: '/fix-candidates',
+            icon: Wrench,
           },
         ],
       },

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1861,6 +1861,57 @@
         "lavender-dream": "Lavender Dream"
       }
     },
+    "priceCompare": {
+      "page": {
+        "title": "Price Compare",
+        "description": "Cross-site effective model pricing with provenance grades.",
+        "searchPlaceholder": "Filter by model…",
+        "loadError": "Failed to load price comparison: {{message}}",
+        "emptyDescription": "No price data yet. Connect accounts or run traffic to see effective pricing."
+      },
+      "group": {
+        "description": "Effective price per source site, cheapest first."
+      },
+      "grade": {
+        "billing_details": "Billing",
+        "observed": "Observed",
+        "configured": "Configured",
+        "fallback": "Fallback"
+      },
+      "recommended": "Recommended",
+      "missingPrice": "No price signal",
+      "columns": {
+        "site": "Site",
+        "grade": "Grade",
+        "input": "Input / 1M",
+        "output": "Output / 1M",
+        "effective": "Effective cost",
+        "status": "Status"
+      }
+    },
+    "fixCandidates": {
+      "page": {
+        "title": "Redirect Fix Candidates",
+        "description": "Disabled models that an existing redirect mapping can restore.",
+        "loadError": "Failed to load fix candidates: {{message}}",
+        "emptyDescription": "No disabled models are repairable by an existing redirect."
+      },
+      "apply": "Apply fixes",
+      "confirm": {
+        "title": "Apply redirect fixes?",
+        "description": "This re-enables {{count}} disabled model(s) via their redirect mapping."
+      },
+      "toast": {
+        "applySucceeded": "Applied {{count}} fix(es).",
+        "applyFailed": "Failed to apply fixes: {{message}}"
+      },
+      "columns": {
+        "site": "Site",
+        "model": "Model",
+        "redirect": "Redirect",
+        "account": "Account"
+      }
+    },
     "sidebar": {
       "groups": {
         "console": "Console",
@@ -1880,6 +1931,8 @@
         "oauth": "OAuth",
         "models": "Models",
         "modelTester": "Model Tester",
+        "priceCompare": "Price Compare",
+        "fixCandidates": "Fix Candidates",
         "settings": "Settings",
         "about": "About"
       },

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1855,6 +1855,57 @@
         "lavender-dream": "薰衣草梦"
       }
     },
+    "priceCompare": {
+      "page": {
+        "title": "价格对比",
+        "description": "跨站点有效模型价格，附价格来源等级。",
+        "searchPlaceholder": "按模型筛选…",
+        "loadError": "加载价格对比失败：{{message}}",
+        "emptyDescription": "暂无价格数据。连接账号或产生流量后即可查看有效价格。"
+      },
+      "group": {
+        "description": "按来源站点的有效价格，从低到高。"
+      },
+      "grade": {
+        "billing_details": "计费明细",
+        "observed": "观测",
+        "configured": "已配置",
+        "fallback": "兜底"
+      },
+      "recommended": "推荐",
+      "missingPrice": "无价格信号",
+      "columns": {
+        "site": "站点",
+        "grade": "等级",
+        "input": "输入 / 1M",
+        "output": "输出 / 1M",
+        "effective": "有效成本",
+        "status": "状态"
+      }
+    },
+    "fixCandidates": {
+      "page": {
+        "title": "重定向修复候选项",
+        "description": "可通过已有重定向映射恢复的禁用模型。",
+        "loadError": "加载修复候选项失败：{{message}}",
+        "emptyDescription": "没有可通过现有重定向修复的禁用模型。"
+      },
+      "apply": "应用修复",
+      "confirm": {
+        "title": "应用重定向修复？",
+        "description": "将恢复 {{count}} 个禁用模型（通过其重定向映射）。"
+      },
+      "toast": {
+        "applySucceeded": "已应用 {{count}} 项修复。",
+        "applyFailed": "应用修复失败：{{message}}"
+      },
+      "columns": {
+        "site": "站点",
+        "model": "模型",
+        "redirect": "重定向",
+        "account": "账号"
+      }
+    },
     "sidebar": {
       "groups": {
         "console": "控制台",
@@ -1874,6 +1925,8 @@
         "oauth": "OAuth",
         "models": "模型",
         "modelTester": "操练场",
+        "priceCompare": "价格对比",
+        "fixCandidates": "修复候选项",
         "settings": "设置",
         "about": "关于"
       },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1442,6 +1442,22 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ dryRun }),
     }) as Promise<RedirectApplyResponse>,
+  // K1a: model-governance fix candidates (list + apply).
+  getRedirectFixCandidates: () =>
+    request('/api/models/redirect-fix-candidates') as Promise<{
+      items: RedirectFixCandidate[]
+      count: number
+    }>,
+  applyRedirectFixCandidates: (dryRun = false) =>
+    request('/api/models/redirect-fix-candidates', {
+      method: 'POST',
+      body: JSON.stringify({ dryRun }),
+    }) as Promise<{
+      success: boolean
+      dryRun: boolean
+      removed?: number
+      count?: number
+    }>,
   // multiplier/rate overview (GET) + batch edit (PUT).
   getRateOverview: () =>
     request('/api/models/rates') as Promise<RateOverviewResponse>,

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -16,9 +16,11 @@ import { Route as AuthenticatedAboutRouteImport } from './routes/_authenticated/
 import { Route as AuthenticatedAccountsRouteImport } from './routes/_authenticated/accounts'
 import { Route as AuthenticatedCheckinRouteImport } from './routes/_authenticated/checkin'
 import { Route as AuthenticatedDashboardRouteRouteImport } from './routes/_authenticated/dashboard/route'
+import { Route as AuthenticatedFixCandidatesRouteImport } from './routes/_authenticated/fix-candidates'
 import { Route as AuthenticatedModelTesterRouteImport } from './routes/_authenticated/model-tester'
 import { Route as AuthenticatedModelsRouteImport } from './routes/_authenticated/models'
 import { Route as AuthenticatedOauthRouteImport } from './routes/_authenticated/oauth'
+import { Route as AuthenticatedPriceCompareRouteImport } from './routes/_authenticated/price-compare'
 import { Route as AuthenticatedProxyLogsRouteImport } from './routes/_authenticated/proxy-logs'
 import { Route as AuthenticatedSettingsRouteRouteImport } from './routes/_authenticated/settings/route'
 import { Route as AuthenticatedSiteAnnouncementsRouteImport } from './routes/_authenticated/site-announcements'
@@ -66,6 +68,12 @@ const AuthenticatedDashboardRouteRoute =
     path: '/dashboard',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
+const AuthenticatedFixCandidatesRoute =
+  AuthenticatedFixCandidatesRouteImport.update({
+    id: '/fix-candidates',
+    path: '/fix-candidates',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedModelTesterRoute =
   AuthenticatedModelTesterRouteImport.update({
     id: '/model-tester',
@@ -82,6 +90,12 @@ const AuthenticatedOauthRoute = AuthenticatedOauthRouteImport.update({
   path: '/oauth',
   getParentRoute: () => AuthenticatedRouteRoute,
 } as any)
+const AuthenticatedPriceCompareRoute =
+  AuthenticatedPriceCompareRouteImport.update({
+    id: '/price-compare',
+    path: '/price-compare',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedProxyLogsRoute = AuthenticatedProxyLogsRouteImport.update({
   id: '/proxy-logs',
   path: '/proxy-logs',
@@ -155,9 +169,11 @@ export interface FileRoutesByFullPath {
   '/about': typeof AuthenticatedAboutRoute
   '/accounts': typeof AuthenticatedAccountsRoute
   '/checkin': typeof AuthenticatedCheckinRoute
+  '/fix-candidates': typeof AuthenticatedFixCandidatesRoute
   '/model-tester': typeof AuthenticatedModelTesterRoute
   '/models': typeof AuthenticatedModelsRoute
   '/oauth': typeof AuthenticatedOauthRoute
+  '/price-compare': typeof AuthenticatedPriceCompareRoute
   '/proxy-logs': typeof AuthenticatedProxyLogsRoute
   '/site-announcements': typeof AuthenticatedSiteAnnouncementsRoute
   '/sites': typeof AuthenticatedSitesRoute
@@ -174,9 +190,11 @@ export interface FileRoutesByTo {
   '/about': typeof AuthenticatedAboutRoute
   '/accounts': typeof AuthenticatedAccountsRoute
   '/checkin': typeof AuthenticatedCheckinRoute
+  '/fix-candidates': typeof AuthenticatedFixCandidatesRoute
   '/model-tester': typeof AuthenticatedModelTesterRoute
   '/models': typeof AuthenticatedModelsRoute
   '/oauth': typeof AuthenticatedOauthRoute
+  '/price-compare': typeof AuthenticatedPriceCompareRoute
   '/proxy-logs': typeof AuthenticatedProxyLogsRoute
   '/site-announcements': typeof AuthenticatedSiteAnnouncementsRoute
   '/sites': typeof AuthenticatedSitesRoute
@@ -197,9 +215,11 @@ export interface FileRoutesById {
   '/_authenticated/about': typeof AuthenticatedAboutRoute
   '/_authenticated/accounts': typeof AuthenticatedAccountsRoute
   '/_authenticated/checkin': typeof AuthenticatedCheckinRoute
+  '/_authenticated/fix-candidates': typeof AuthenticatedFixCandidatesRoute
   '/_authenticated/model-tester': typeof AuthenticatedModelTesterRoute
   '/_authenticated/models': typeof AuthenticatedModelsRoute
   '/_authenticated/oauth': typeof AuthenticatedOauthRoute
+  '/_authenticated/price-compare': typeof AuthenticatedPriceCompareRoute
   '/_authenticated/proxy-logs': typeof AuthenticatedProxyLogsRoute
   '/_authenticated/site-announcements': typeof AuthenticatedSiteAnnouncementsRoute
   '/_authenticated/sites': typeof AuthenticatedSitesRoute
@@ -222,9 +242,11 @@ export interface FileRouteTypes {
     | '/about'
     | '/accounts'
     | '/checkin'
+    | '/fix-candidates'
     | '/model-tester'
     | '/models'
     | '/oauth'
+    | '/price-compare'
     | '/proxy-logs'
     | '/site-announcements'
     | '/sites'
@@ -241,9 +263,11 @@ export interface FileRouteTypes {
     | '/about'
     | '/accounts'
     | '/checkin'
+    | '/fix-candidates'
     | '/model-tester'
     | '/models'
     | '/oauth'
+    | '/price-compare'
     | '/proxy-logs'
     | '/site-announcements'
     | '/sites'
@@ -263,9 +287,11 @@ export interface FileRouteTypes {
     | '/_authenticated/about'
     | '/_authenticated/accounts'
     | '/_authenticated/checkin'
+    | '/_authenticated/fix-candidates'
     | '/_authenticated/model-tester'
     | '/_authenticated/models'
     | '/_authenticated/oauth'
+    | '/_authenticated/price-compare'
     | '/_authenticated/proxy-logs'
     | '/_authenticated/site-announcements'
     | '/_authenticated/sites'
@@ -335,6 +361,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedDashboardRouteRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/fix-candidates': {
+      id: '/_authenticated/fix-candidates'
+      path: '/fix-candidates'
+      fullPath: '/fix-candidates'
+      preLoaderRoute: typeof AuthenticatedFixCandidatesRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/model-tester': {
       id: '/_authenticated/model-tester'
       path: '/model-tester'
@@ -354,6 +387,13 @@ declare module '@tanstack/react-router' {
       path: '/oauth'
       fullPath: '/oauth'
       preLoaderRoute: typeof AuthenticatedOauthRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/price-compare': {
+      id: '/_authenticated/price-compare'
+      path: '/price-compare'
+      fullPath: '/price-compare'
+      preLoaderRoute: typeof AuthenticatedPriceCompareRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/proxy-logs': {
@@ -493,9 +533,11 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedAboutRoute: typeof AuthenticatedAboutRoute
   AuthenticatedAccountsRoute: typeof AuthenticatedAccountsRoute
   AuthenticatedCheckinRoute: typeof AuthenticatedCheckinRoute
+  AuthenticatedFixCandidatesRoute: typeof AuthenticatedFixCandidatesRoute
   AuthenticatedModelTesterRoute: typeof AuthenticatedModelTesterRoute
   AuthenticatedModelsRoute: typeof AuthenticatedModelsRoute
   AuthenticatedOauthRoute: typeof AuthenticatedOauthRoute
+  AuthenticatedPriceCompareRoute: typeof AuthenticatedPriceCompareRoute
   AuthenticatedProxyLogsRoute: typeof AuthenticatedProxyLogsRoute
   AuthenticatedSiteAnnouncementsRoute: typeof AuthenticatedSiteAnnouncementsRoute
   AuthenticatedSitesRoute: typeof AuthenticatedSitesRoute
@@ -510,9 +552,11 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedAboutRoute: AuthenticatedAboutRoute,
   AuthenticatedAccountsRoute: AuthenticatedAccountsRoute,
   AuthenticatedCheckinRoute: AuthenticatedCheckinRoute,
+  AuthenticatedFixCandidatesRoute: AuthenticatedFixCandidatesRoute,
   AuthenticatedModelTesterRoute: AuthenticatedModelTesterRoute,
   AuthenticatedModelsRoute: AuthenticatedModelsRoute,
   AuthenticatedOauthRoute: AuthenticatedOauthRoute,
+  AuthenticatedPriceCompareRoute: AuthenticatedPriceCompareRoute,
   AuthenticatedProxyLogsRoute: AuthenticatedProxyLogsRoute,
   AuthenticatedSiteAnnouncementsRoute: AuthenticatedSiteAnnouncementsRoute,
   AuthenticatedSitesRoute: AuthenticatedSitesRoute,

--- a/web/src/routes/_authenticated/fix-candidates.tsx
+++ b/web/src/routes/_authenticated/fix-candidates.tsx
@@ -2,14 +2,10 @@
 
 import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
 
-export const Route = createFileRoute(
-  '/_authenticated/fix-candidates'
-)({
+export const Route = createFileRoute('/_authenticated/fix-candidates')({
   component: lazyRouteComponent(
     () =>
-      import(
-        '@/features/models/fix-candidates/components/fix-candidates-page'
-      ),
+      import('@/features/models/fix-candidates/components/fix-candidates-page'),
     'FixCandidatesPage'
   ),
 })

--- a/web/src/routes/_authenticated/fix-candidates.tsx
+++ b/web/src/routes/_authenticated/fix-candidates.tsx
@@ -1,0 +1,15 @@
+// metapi-go/routes — redirect fix-candidates review + one-click apply.
+
+import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+
+export const Route = createFileRoute(
+  '/_authenticated/fix-candidates'
+)({
+  component: lazyRouteComponent(
+    () =>
+      import(
+        '@/features/models/fix-candidates/components/fix-candidates-page'
+      ),
+    'FixCandidatesPage'
+  ),
+})

--- a/web/src/routes/_authenticated/price-compare.tsx
+++ b/web/src/routes/_authenticated/price-compare.tsx
@@ -1,0 +1,15 @@
+// metapi-go/routes — standalone cross-site price comparison page.
+// The page owns its model-filter state (debounced server-side `model` param)
+// and reads the sorted candidate list directly from usePriceCompare.
+
+import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/price-compare')({
+  component: lazyRouteComponent(
+    () =>
+      import(
+        '@/features/models/price-compare/components/price-compare-page'
+      ),
+    'PriceComparePage'
+  ),
+})

--- a/web/src/routes/_authenticated/price-compare.tsx
+++ b/web/src/routes/_authenticated/price-compare.tsx
@@ -7,9 +7,7 @@ import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
 export const Route = createFileRoute('/_authenticated/price-compare')({
   component: lazyRouteComponent(
     () =>
-      import(
-        '@/features/models/price-compare/components/price-compare-page'
-      ),
+      import('@/features/models/price-compare/components/price-compare-page'),
     'PriceComparePage'
   ),
 })


### PR DESCRIPTION
## Summary
PR5 — model governance (#617-#621). Backend + frontend.

- #617 `service/pricing` pure layer: multiplier → USD/1M + `ProductCanonicalModel` + unit tests.
- #618 standalone price-compare page (`/price-compare`), grouped by model.
- #619 cheapest-channel recommendation + provenance grade (`billing_details|observed|configured|fallback`).
- #620 `GET/POST /api/models/redirect-fix-candidates` endpoints.
- #621 fix-candidates UI (`/fix-candidates`) with one-click Apply + result feedback.

## Validation
- Go: `go build ./cmd/server` ✅ · `go vet ./...` ✅ · `go test -p 1 ./... -count=1` ✅
- Web: `typecheck` ✅ · `lint` ✅ · `test` 29 files/337 ✅ · `build` ✅
- `-race` fails with Windows ThreadSanitizer "error 87" (known address-space limitation).