### PR TITLE
feat(channels)+feat(rebuild): Channels page + probe-backed route-rebuild filter (PR6, #622-#626)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,15 @@ func Get() *Config {
 	return globalCfg
 }
 
+// GetSafe returns the global config singleton, or nil when it has not been
+// loaded yet. Prefer Get() in the composition root; GetSafe is for optional
+// callbacks that may run before (or without) config initialization.
+func GetSafe() *Config {
+	cfgMu.RLock()
+	defer cfgMu.RUnlock()
+	return globalCfg
+}
+
 // CodexHeaderDefaults holds Codex-specific HTTP header defaults.
 type CodexHeaderDefaults struct {
 	UserAgent    string
@@ -238,6 +247,12 @@ type Config struct {
 	ModelAvailabilityProbeIntervalMs  int
 	ModelAvailabilityProbeTimeoutMs   int
 	ModelAvailabilityProbeConcurrency int
+
+	// RouteRebuildProbeFilterEnabled gates the route-rebuild probe filter (#625).
+	// Default false keeps the legacy non-probe rebuild path byte-for-byte.
+	RouteRebuildProbeFilterEnabled       bool
+	RouteRebuildProbeFilterIncludeModels []string
+	RouteRebuildProbeFilterExcludeModels []string
 
 	// Retention (6 fields)
 	ProxyLogRetentionDays                       int
@@ -631,6 +646,10 @@ func Load(env map[string]string) *Config {
 		int(math.Trunc(parseNumber(get("MODEL_AVAILABILITY_PROBE_CONCURRENCY"), DefaultModelAvailabilityProbeConcurrency))),
 		1, 16,
 	)
+
+	cfg.RouteRebuildProbeFilterEnabled = parseBoolean(get("ROUTE_REBUILD_PROBE_FILTER_ENABLED"), false)
+	cfg.RouteRebuildProbeFilterIncludeModels = parseCsvList(get("ROUTE_REBUILD_PROBE_FILTER_INCLUDE_MODELS"))
+	cfg.RouteRebuildProbeFilterExcludeModels = parseCsvList(get("ROUTE_REBUILD_PROBE_FILTER_EXCLUDE_MODELS"))
 
 	// ---- §3.21 Retention ----
 	cfg.ProxyLogRetentionDays = maxInt(0, int(math.Trunc(parseNumber(get("PROXY_LOG_RETENTION_DAYS"), DefaultProxyLogRetentionDays))))

--- a/handler/admin/channels.go
+++ b/handler/admin/channels.go
@@ -1,0 +1,119 @@
+package admin
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/deliciousbuding/metapi-go/routing"
+)
+
+// channelListRow is the flattened read-only projection for GET /api/channels.
+// It aggregates route_channels across the account/token/oauth_unit dimensions
+// and joins only the display fields the channels page needs (no credentials).
+type channelListRow struct {
+	ID                int64   `db:"id"`
+	RouteID           int64   `db:"route_id"`
+	AccountID         int64   `db:"account_id"`
+	TokenID           *int64  `db:"token_id"`
+	OAuthRouteUnitID  *int64  `db:"oauth_route_unit_id"`
+	SourceModel       *string `db:"source_model"`
+	Priority          int64   `db:"priority"`
+	Weight            int64   `db:"weight"`
+	Enabled           bool    `db:"enabled"`
+	ManualOverride    bool    `db:"manual_override"`
+	SuccessCount      int64   `db:"success_count"`
+	TotalLatencyMs    int64   `db:"total_latency_ms"`
+	CooldownUntil     *string `db:"cooldown_until"`
+	Username          string  `db:"username"`
+	SiteID            int64   `db:"site_id"`
+	SiteName          string  `db:"site_name"`
+	RouteModelPattern string  `db:"route_model_pattern"`
+	OAuthUnitName     string  `db:"oauth_unit_name"`
+	TokenName         string  `db:"token_name"`
+}
+
+// listChannels returns the aggregated read-only channel list (#622).
+// Status is derived from routing in-memory breaker state + persisted cooldown
+// so the UI never mutates routing health (read-only / soft isolation).
+func (h *tokenRoutesHandler) listChannels(w http.ResponseWriter, r *http.Request) {
+	var rows []channelListRow
+	if err := h.db.SelectContext(r.Context(), &rows, h.db.Rebind(`
+		SELECT rc.id, rc.route_id, rc.account_id, rc.token_id, rc.oauth_route_unit_id,
+		       rc.source_model, rc.priority, rc.weight, rc.enabled, rc.manual_override,
+		       rc.success_count, rc.total_latency_ms, rc.cooldown_until,
+		       COALESCE(a.username, '') AS username,
+		       a.site_id,
+		       COALESCE(s.name, '') AS site_name,
+		       COALESCE(tr.model_pattern, '') AS route_model_pattern,
+		       COALESCE(oru.name, '') AS oauth_unit_name,
+		       COALESCE(at.name, '') AS token_name
+		FROM route_channels rc
+		LEFT JOIN accounts a ON rc.account_id = a.id
+		LEFT JOIN sites s ON a.site_id = s.id
+		LEFT JOIN token_routes tr ON rc.route_id = tr.id
+		LEFT JOIN oauth_route_units oru ON rc.oauth_route_unit_id = oru.id
+		LEFT JOIN account_tokens at ON rc.token_id = at.id
+		ORDER BY rc.id ASC`)); err != nil {
+		slog.Error("channels list failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"success": false, "message": "加载通道列表失败"})
+		return
+	}
+
+	items := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, channelListItem(row))
+	}
+	writeJSON(w, http.StatusOK, normalizeSlice(items))
+}
+
+func channelListItem(row channelListRow) map[string]any {
+	sourceModel := ""
+	if row.SourceModel != nil {
+		sourceModel = *row.SourceModel
+	}
+	models := sourceModel
+	if models == "" {
+		models = row.RouteModelPattern
+	}
+
+	name := ""
+	chType := "account"
+	switch {
+	case row.OAuthRouteUnitID != nil && *row.OAuthRouteUnitID > 0:
+		chType = "oauth_unit"
+		name = row.OAuthUnitName
+	case row.TokenID != nil && *row.TokenID > 0:
+		chType = "token"
+		name = row.TokenName
+	default:
+		name = row.Username
+	}
+	if name == "" {
+		name = sourceModel
+	}
+	if name == "" {
+		name = row.RouteModelPattern
+	}
+
+	var responseMs *int64
+	if row.SuccessCount > 0 && row.TotalLatencyMs > 0 {
+		ms := row.TotalLatencyMs / row.SuccessCount
+		responseMs = &ms
+	}
+
+	return map[string]any{
+		"id":             row.ID,
+		"routeId":        row.RouteID,
+		"name":           name,
+		"site":           map[string]any{"id": row.SiteID, "name": row.SiteName},
+		"type":           chType,
+		"status":         routing.ChannelRuntimeStatus(row.SiteID, sourceModel, row.Enabled, row.CooldownUntil),
+		"models":         models,
+		"priority":       row.Priority,
+		"weight":         row.Weight,
+		"responseMs":     responseMs,
+		"cooldownUntil":  row.CooldownUntil,
+		"enabled":        row.Enabled,
+		"manualOverride": row.ManualOverride,
+	}
+}

--- a/handler/admin/channels_test.go
+++ b/handler/admin/channels_test.go
@@ -1,0 +1,99 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestChannels_ListProjection(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(
+		`INSERT INTO route_channels
+			(route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override, success_count, total_latency_ms)
+		 VALUES (?, ?, ?, 'gpt-4o', 5, 20, 1, 0, 2, 300)`,
+		routeID, accountID, tokenID,
+	); err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+	_ = now
+
+	req := httptest.NewRequest(http.MethodGet, "/api/channels", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var items []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &items); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+
+	item := items[0]
+	if item["status"] != "enabled" {
+		t.Fatalf("status = %v, want enabled", item["status"])
+	}
+	if item["type"] != "token" {
+		t.Fatalf("type = %v, want token", item["type"])
+	}
+	if item["models"] != "gpt-4o" {
+		t.Fatalf("models = %v, want gpt-4o", item["models"])
+	}
+	if item["priority"] != float64(5) {
+		t.Fatalf("priority = %v, want 5", item["priority"])
+	}
+	if item["weight"] != float64(20) {
+		t.Fatalf("weight = %v, want 20", item["weight"])
+	}
+	if item["responseMs"] != float64(150) {
+		t.Fatalf("responseMs = %v, want 150", item["responseMs"])
+	}
+	if item["enabled"] != true {
+		t.Fatalf("enabled = %v, want true", item["enabled"])
+	}
+	if item["manualOverride"] != false {
+		t.Fatalf("manualOverride = %v, want false", item["manualOverride"])
+	}
+}
+
+func TestChannels_ManuallyDisabledStatus(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+
+	if _, err := db.Exec(
+		`INSERT INTO route_channels
+			(route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+		 VALUES (?, ?, ?, 'gpt-4o', 0, 10, 0, 1)`,
+		routeID, accountID, tokenID,
+	); err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/channels", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &items); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+	if items[0]["status"] != "manually_disabled" {
+		t.Fatalf("status = %v, want manually_disabled", items[0]["status"])
+	}
+}

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -73,6 +73,7 @@ func RegisterTokenRoutesWithDeps(r chi.Router, db *sqlx.DB, deps TokenRoutesDeps
 	r.Post("/api/routes/{id}/cooldown/clear", handler.clearCooldown)
 
 	// Channel operations
+	r.Get("/api/channels", handler.listChannels)
 	r.Put("/api/channels/batch", handler.batchUpdateChannels)
 	r.Put("/api/channels/{channelId}", handler.updateChannel)
 	r.Delete("/api/channels/{channelId}", handler.deleteChannel)

--- a/routing/channel_status.go
+++ b/routing/channel_status.go
@@ -1,0 +1,31 @@
+package routing
+
+import "time"
+
+// Channel runtime status vocabulary for read-only operators (#622/#624).
+const (
+	ChannelStatusEnabled          = "enabled"
+	ChannelStatusCooldown         = "cooldown"
+	ChannelStatusBreakerOpen      = "breaker_open"
+	ChannelStatusManuallyDisabled = "manually_disabled"
+)
+
+// ChannelRuntimeStatus classifies a channel's current routing state by overlaying
+// the in-memory site/model runtime breaker and the persisted cooldown window on
+// top of the channel's enabled flag. It is intentionally read-only: it never
+// mutates routing state, so callers can render the status without hard-disabling
+// (soft isolation only).
+func ChannelRuntimeStatus(siteID int64, modelName string, enabled bool, cooldownUntil *string) string {
+	if !enabled {
+		return ChannelStatusManuallyDisabled
+	}
+	nowISO := time.Now().UTC().Format(time.RFC3339)
+	details := GetSiteRuntimeHealthDetails(siteID, modelName)
+	if details.GlobalBreakerOpen || details.ModelBreakerOpen {
+		return ChannelStatusBreakerOpen
+	}
+	if IsCooldownActive(cooldownUntil, nowISO) {
+		return ChannelStatusCooldown
+	}
+	return ChannelStatusEnabled
+}

--- a/routing/channel_status_test.go
+++ b/routing/channel_status_test.go
@@ -1,0 +1,65 @@
+package routing
+
+import (
+	"testing"
+	"time"
+)
+
+func TestChannelRuntimeStatus(t *testing.T) {
+	now := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	past := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)
+
+	t.Run("disabled maps to manually_disabled", func(t *testing.T) {
+		if got := ChannelRuntimeStatus(1, "gpt-4o", false, nil); got != ChannelStatusManuallyDisabled {
+			t.Fatalf("status = %s, want %s", got, ChannelStatusManuallyDisabled)
+		}
+	})
+
+	t.Run("healthy enabled", func(t *testing.T) {
+		if got := ChannelRuntimeStatus(9999, "gpt-4o", true, nil); got != ChannelStatusEnabled {
+			t.Fatalf("status = %s, want %s", got, ChannelStatusEnabled)
+		}
+	})
+
+	t.Run("active cooldown", func(t *testing.T) {
+		if got := ChannelRuntimeStatus(9998, "gpt-4o", true, &now); got != ChannelStatusCooldown {
+			t.Fatalf("status = %s, want %s", got, ChannelStatusCooldown)
+		}
+	})
+
+	t.Run("expired cooldown is enabled", func(t *testing.T) {
+		if got := ChannelRuntimeStatus(9997, "gpt-4o", true, &past); got != ChannelStatusEnabled {
+			t.Fatalf("status = %s, want %s", got, ChannelStatusEnabled)
+		}
+	})
+
+	t.Run("open site breaker", func(t *testing.T) {
+		future := time.Now().UTC().Add(time.Hour).UnixMilli()
+		healthStateMu.Lock()
+		siteRuntimeHealthStates[9001] = &SiteRuntimeHealthState{BreakerLevel: 1, BreakerUntilMs: &future}
+		healthStateMu.Unlock()
+		t.Cleanup(func() {
+			healthStateMu.Lock()
+			delete(siteRuntimeHealthStates, 9001)
+			healthStateMu.Unlock()
+		})
+		if got := ChannelRuntimeStatus(9001, "gpt-4o", true, nil); got != ChannelStatusBreakerOpen {
+			t.Fatalf("status = %s, want %s", got, ChannelStatusBreakerOpen)
+		}
+	})
+
+	t.Run("cooldown beats healthy but breaker wins over cooldown", func(t *testing.T) {
+		future := time.Now().UTC().Add(time.Hour).UnixMilli()
+		healthStateMu.Lock()
+		siteRuntimeHealthStates[9002] = &SiteRuntimeHealthState{BreakerLevel: 1, BreakerUntilMs: &future}
+		healthStateMu.Unlock()
+		t.Cleanup(func() {
+			healthStateMu.Lock()
+			delete(siteRuntimeHealthStates, 9002)
+			healthStateMu.Unlock()
+		})
+		if got := ChannelRuntimeStatus(9002, "gpt-4o", true, &now); got != ChannelStatusBreakerOpen {
+			t.Fatalf("status = %s, want %s", got, ChannelStatusBreakerOpen)
+		}
+	})
+}

--- a/scheduler/model_probe.go
+++ b/scheduler/model_probe.go
@@ -359,7 +359,7 @@ func (s *ModelProbeScheduler) runProbeLocked(dbw *store.DB) {
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			outcome := s.probeOne(target, timeoutMs)
+			outcome := s.probeOne(target, timeoutMs, dbw)
 			mu.Lock()
 			switch outcome {
 			case "success":
@@ -390,7 +390,7 @@ func (s *ModelProbeScheduler) runProbeLocked(dbw *store.DB) {
 	)
 }
 
-func (s *ModelProbeScheduler) probeOne(target ProbeTarget, timeoutMs int) string {
+func (s *ModelProbeScheduler) probeOne(target ProbeTarget, timeoutMs int, dbw ...*store.DB) string {
 	s.mu.Lock()
 	probe := s.probe
 	recorder := s.recorder
@@ -416,6 +416,7 @@ func (s *ModelProbeScheduler) probeOne(target ProbeTarget, timeoutMs int) string
 			"model", target.ModelName,
 			"error", err,
 		)
+		s.persistProbeResult(resolveProbeResultDB(dbw), target, "inconclusive", ProbeOutcome{Status: "inconclusive", ErrorText: err.Error()})
 		return "inconclusive"
 	}
 
@@ -427,6 +428,7 @@ func (s *ModelProbeScheduler) probeOne(target ProbeTarget, timeoutMs int) string
 	accountID := target.AccountID
 	accountPtr := &accountID
 
+	status := "inconclusive"
 	switch outcome.Status {
 	case "success":
 		if err := recorder.RecordProbeSuccess(ctx, target.ChannelID, outcome.LatencyMs, modelPtr, accountPtr); err != nil {
@@ -434,9 +436,9 @@ func (s *ModelProbeScheduler) probeOne(target ProbeTarget, timeoutMs int) string
 				"channel_id", target.ChannelID,
 				"error", err,
 			)
-			return "inconclusive"
+		} else {
+			status = "success"
 		}
-		return "success"
 	case "failure":
 		var statusPtr *int
 		if outcome.HTTPStatus > 0 {
@@ -453,15 +455,62 @@ func (s *ModelProbeScheduler) probeOne(target ProbeTarget, timeoutMs int) string
 				"channel_id", target.ChannelID,
 				"error", err,
 			)
-			return "inconclusive"
+		} else {
+			status = "failure"
 		}
-		return "failure"
 	case "skipped":
-		return "skipped"
+		status = "skipped"
 	default:
 		// inconclusive / unknown — do not mutate health or cooldown.
-		return "inconclusive"
+		status = "inconclusive"
 	}
+
+	// Record the raw probe outcome for the route-rebuild probe filter (#625).
+	// Persisted status uses the measured outcome so connectivity filtering sees
+	// the actual upstream signal, not the recorder-applied result.
+	s.persistProbeResult(resolveProbeResultDB(dbw), target, status, outcome)
+	return status
+}
+
+func resolveProbeResultDB(dbw []*store.DB) *store.DB {
+	if len(dbw) == 0 {
+		return nil
+	}
+	return dbw[0]
+}
+
+// persistProbeResult appends one model_probe_results row for a background
+// probe outcome. It is best-effort: a failed history write must never block
+// health/cooldown mutation or the probe pass itself.
+func (s *ModelProbeScheduler) persistProbeResult(dbw *store.DB, target ProbeTarget, status string, outcome ProbeOutcome) {
+	if dbw == nil {
+		return
+	}
+	if status == "" {
+		status = "inconclusive"
+	}
+	var latencyPtr *float64
+	if outcome.LatencyMs > 0 {
+		l := outcome.LatencyMs
+		latencyPtr = &l
+	}
+	var httpPtr *int64
+	if outcome.HTTPStatus > 0 {
+		h := int64(outcome.HTTPStatus)
+		httpPtr = &h
+	}
+	var errPtr *string
+	if outcome.ErrorText != "" {
+		e := outcome.ErrorText
+		errPtr = &e
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, _ = dbw.Exec(
+		`INSERT INTO model_probe_results
+			(channel_id, account_id, site_id, model_name, status, latency_ms, http_status, error_text, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		target.ChannelID, target.AccountID, target.SiteID, target.ModelName, status, latencyPtr, httpPtr, errPtr, now,
+	)
 }
 
 // loadProbeTargets selects a budgeted set of active route channels for probing.

--- a/scheduler/model_probe_results_test.go
+++ b/scheduler/model_probe_results_test.go
@@ -1,0 +1,97 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+func seedProbeAccount(t *testing.T, db *store.DB, siteName, username string) (siteID, accountID int64) {
+	t.Helper()
+	now := "2026-01-01T00:00:00Z"
+	res, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, 'openai', 'active', ?, ?)`, siteName, "https://"+siteName+".example.com", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ = res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, 'tok', 'active', 1, ?, ?)`, siteID, username, now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ = res.LastInsertId()
+	return siteID, accountID
+}
+
+func TestProbeOnePersistsModelProbeResults(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	site1, account3 := seedProbeAccount(t, db, "s1", "u3")
+	site2, account4 := seedProbeAccount(t, db, "s2", "u4")
+
+	rec := &fakeRecorder{}
+	s := NewModelProbeScheduler(&config.Config{})
+	s.SetProbeExecutor(&fakeProbe{outcomes: map[int64]ProbeOutcome{
+		7: {Status: "failure", HTTPStatus: 502, ErrorText: "bad gateway"},
+		8: {Status: "success", LatencyMs: 31},
+	}})
+	s.SetHealthRecorder(rec)
+
+	targetFail := ProbeTarget{ChannelID: 7, AccountID: account3, SiteID: site1, ModelName: "gpt-4o"}
+	targetOK := ProbeTarget{ChannelID: 8, AccountID: account4, SiteID: site2, ModelName: "gpt-4o-mini"}
+
+	if got := s.probeOne(targetFail, 3000, db); got != "failure" {
+		t.Fatalf("failure probe status = %s", got)
+	}
+	if got := s.probeOne(targetOK, 3000, db); got != "success" {
+		t.Fatalf("success probe status = %s", got)
+	}
+
+	var failStatus string
+	var failErr string
+	if err := db.Get(&failStatus, `SELECT status FROM model_probe_results WHERE account_id = ?`, account3); err != nil {
+		t.Fatalf("load failure row: %v", err)
+	}
+	_ = db.Get(&failErr, `SELECT COALESCE(error_text, '') FROM model_probe_results WHERE account_id = ?`, account3)
+	if failStatus != "failure" {
+		t.Fatalf("persisted failure status = %q", failStatus)
+	}
+	if failErr != "bad gateway" {
+		t.Fatalf("persisted failure error = %q", failErr)
+	}
+
+	var okStatus string
+	var okLatency *float64
+	if err := db.QueryRowx(`SELECT status, latency_ms FROM model_probe_results WHERE account_id = ?`, account4).Scan(&okStatus, &okLatency); err != nil {
+		t.Fatalf("load success row: %v", err)
+	}
+	if okStatus != "success" {
+		t.Fatalf("persisted success status = %q", okStatus)
+	}
+	if okLatency == nil || *okLatency != 31 {
+		t.Fatalf("persisted latency = %v, want 31", okLatency)
+	}
+}
+
+func TestProbeOneWithoutDBDoesNotPersist(t *testing.T) {
+	rec := &fakeRecorder{}
+	s := NewModelProbeScheduler(&config.Config{})
+	s.SetProbeExecutor(&fakeProbe{outcomes: map[int64]ProbeOutcome{
+		9: {Status: "success", LatencyMs: 5},
+	}})
+	s.SetHealthRecorder(rec)
+
+	if got := s.probeOne(ProbeTarget{ChannelID: 9, AccountID: 1, SiteID: 1, ModelName: "m"}, 3000); got != "success" {
+		t.Fatalf("status = %s", got)
+	}
+	if len(rec.successCalls) != 1 {
+		t.Fatalf("success calls = %d, want 1", len(rec.successCalls))
+	}
+}

--- a/service/route_rebuild.go
+++ b/service/route_rebuild.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/deliciousbuding/metapi-go/config"
 	"github.com/deliciousbuding/metapi-go/routing"
 	"github.com/deliciousbuding/metapi-go/store"
 )
@@ -21,6 +22,24 @@ type RouteRebuildStats struct {
 	ChannelsInserted int `json:"channelsInserted"`
 	ChannelsRemoved  int `json:"channelsRemoved"`
 	ChannelsKept     int `json:"channelsKept"`
+	// Changed is true when at least one automatic channel was inserted or removed.
+	Changed bool `json:"changed"`
+}
+
+// RebuildOptions configures optional rebuild behavior. The zero value keeps the
+// legacy non-probe path byte-for-byte identical.
+type RebuildOptions struct {
+	ProbeFilter ProbeFilterConfig
+}
+
+// ProbeFilterConfig gates the route-rebuild probe filter (#625).
+// IncludeModels/ExcludeModels are optional exact source-model names; empty means
+// no-op. When Enabled, desired channels whose latest connectivity probe failed
+// are dropped before any route_channels diff is written.
+type ProbeFilterConfig struct {
+	Enabled       bool
+	IncludeModels []string
+	ExcludeModels []string
 }
 
 var (
@@ -47,7 +66,7 @@ func RebuildRoutesBestEffort() {
 		slog.Debug("route rebuild skipped: database not available")
 		return
 	}
-	stats, err := RebuildTokenRoutesFromAvailability(context.Background(), db)
+	stats, err := RebuildTokenRoutesFromAvailabilityWithOptions(context.Background(), db, rebuildOptionsFromConfig())
 	if err != nil {
 		slog.Warn("route rebuild best-effort failed", "error", err)
 		return
@@ -61,8 +80,15 @@ func RebuildRoutesBestEffort() {
 	)
 }
 
-// RebuildTokenRoutesFromAvailability repopulates automatic (non-manual) channels
-// for every pattern/exact route from dual sources:
+// RebuildTokenRoutesFromAvailability is the legacy (non-probe) rebuild entrypoint.
+// It keeps byte-for-byte identical semantics: the probe filter is off and the
+// in-process cache is always invalidated after the pass.
+func RebuildTokenRoutesFromAvailability(ctx context.Context, db *sqlx.DB) (RouteRebuildStats, error) {
+	return RebuildTokenRoutesFromAvailabilityWithOptions(ctx, db, RebuildOptions{})
+}
+
+// RebuildTokenRoutesFromAvailabilityWithOptions repopulates automatic
+// (non-manual) channels for every pattern/exact route from dual sources:
 // 1. channels on exact-model routes whose model_pattern matches the target pattern
 // 2. token_model_availability + model_availability rows whose model_name matches
 //
@@ -70,8 +96,13 @@ func RebuildRoutesBestEffort() {
 // route_group_sources, and channel expansion happens at select time. Manual
 // override channels on pattern routes are never deleted.
 //
+// When opts.ProbeFilter.Enabled is true, desired channels are filtered by
+// include/exclude model lists plus the latest connectivity probe result before
+// any diff is written, and the cache is invalidated only when the model set
+// actually changes. The zero-value RebuildOptions{} preserves legacy behavior.
+//
 // Concurrent rebuilds serialize on a process-wide mutex.
-func RebuildTokenRoutesFromAvailability(ctx context.Context, db *sqlx.DB) (RouteRebuildStats, error) {
+func RebuildTokenRoutesFromAvailabilityWithOptions(ctx context.Context, db *sqlx.DB, opts RebuildOptions) (RouteRebuildStats, error) {
 	var stats RouteRebuildStats
 	if db == nil {
 		return stats, fmt.Errorf("route rebuild: db is nil")
@@ -102,7 +133,7 @@ func RebuildTokenRoutesFromAvailability(ctx context.Context, db *sqlx.DB) (Route
 			continue
 		}
 		stats.PatternRoutes++
-		inserted, removed, kept, err := rebuildAutomaticRouteChannelsByModelPattern(ctx, db, route.ID, route.ModelPattern)
+		inserted, removed, kept, err := rebuildAutomaticRouteChannelsByModelPattern(ctx, db, route.ID, route.ModelPattern, opts)
 		if err != nil {
 			return stats, fmt.Errorf("rebuild route %d (%s): %w", route.ID, route.ModelPattern, err)
 		}
@@ -111,8 +142,18 @@ func RebuildTokenRoutesFromAvailability(ctx context.Context, db *sqlx.DB) (Route
 		stats.ChannelsKept += kept
 	}
 
-	// Always invalidate in-process cache after topology recompose.
-	routing.InvalidateCache()
+	changed := stats.ChannelsInserted + stats.ChannelsRemoved
+	stats.Changed = changed > 0
+	if opts.ProbeFilter.Enabled {
+		if changed > 0 {
+			routing.InvalidateCache()
+		} else {
+			slog.Info("route rebuild: model set unchanged, skipping cache invalidation")
+		}
+	} else {
+		// Legacy non-probe path: always invalidate (identical to prior behavior).
+		routing.InvalidateCache()
+	}
 	return stats, nil
 }
 
@@ -173,9 +214,12 @@ func channelKey(accountID int64, tokenID *int64, sourceModel *string) channelIde
 	return channelIdentity{AccountID: accountID, TokenID: tid, SourceModel: sm}
 }
 
-func rebuildAutomaticRouteChannelsByModelPattern(ctx context.Context, db *sqlx.DB, routeID int64, modelPattern string) (inserted, removed, kept int, err error) {
+func rebuildAutomaticRouteChannelsByModelPattern(ctx context.Context, db *sqlx.DB, routeID int64, modelPattern string, opts RebuildOptions) (inserted, removed, kept int, err error) {
 	desired, err := collectDesiredChannels(ctx, db, routeID, modelPattern)
 	if err != nil {
+		return 0, 0, 0, err
+	}
+	if err := applyProbeFilter(ctx, db, desired, opts); err != nil {
 		return 0, 0, 0, err
 	}
 
@@ -191,6 +235,22 @@ func rebuildAutomaticRouteChannelsByModelPattern(ctx context.Context, db *sqlx.D
 		db.Rebind(`SELECT id, account_id, token_id, source_model, manual_override
 		 FROM route_channels WHERE route_id = ?`), routeID); err != nil {
 		return 0, 0, 0, fmt.Errorf("load route_channels: %w", err)
+	}
+
+	// No-change short-circuit: when the automatic channel key set already equals
+	// the desired key set, skip every write. The caller uses the zero-diff result
+	// to skip cache invalidation on the probe-filter path.
+	autoExisting := make(map[channelIdentity]struct{}, len(rows))
+	manualCount := 0
+	for _, row := range rows {
+		if row.ManualOverride {
+			manualCount++
+			continue
+		}
+		autoExisting[channelKey(row.AccountID, row.TokenID, row.SourceModel)] = struct{}{}
+	}
+	if sameChannelKeySet(desired, autoExisting) {
+		return 0, 0, manualCount + len(autoExisting), nil
 	}
 
 	present := make(map[channelIdentity]struct{}, len(rows))
@@ -408,4 +468,105 @@ func resolveRebuildDB() *sqlx.DB {
 		return dbw.DB
 	}
 	return nil
+}
+
+func sameChannelKeySet(desired map[channelIdentity]desiredChannel, existing map[channelIdentity]struct{}) bool {
+	if len(desired) != len(existing) {
+		return false
+	}
+	for k := range desired {
+		if _, ok := existing[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func toStringSet(items []string) map[string]bool {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(items))
+	for _, item := range items {
+		out[item] = true
+	}
+	return out
+}
+
+type probeFailureKey struct {
+	AccountID int64
+	Model     string
+}
+
+// applyProbeFilter removes desired channels that the probe filter rejects.
+// It is intentionally a pure in-memory filter over the desired set; the caller
+// has not yet written any route_channels diff, so a rejected channel is simply
+// not materialised (soft isolation) rather than hard-disabled.
+func applyProbeFilter(ctx context.Context, db *sqlx.DB, desired map[channelIdentity]desiredChannel, opts RebuildOptions) error {
+	if !opts.ProbeFilter.Enabled {
+		return nil
+	}
+	include := toStringSet(opts.ProbeFilter.IncludeModels)
+	exclude := toStringSet(opts.ProbeFilter.ExcludeModels)
+	failed, err := loadLatestProbeFailures(ctx, db)
+	if err != nil {
+		return err
+	}
+	for key := range desired {
+		model := key.SourceModel
+		if len(include) > 0 && !include[model] {
+			delete(desired, key)
+			continue
+		}
+		if exclude[model] {
+			delete(desired, key)
+			continue
+		}
+		if failed[probeFailureKey{AccountID: key.AccountID, Model: model}] {
+			delete(desired, key)
+		}
+	}
+	return nil
+}
+
+// loadLatestProbeFailures returns the latest model_probe_results row per
+// (account_id, model_name), marking only rows whose latest status is "failure".
+// MAX(id) is monotonically increasing with time (SERIAL/AUTOINCREMENT), so this
+// works on both SQLite and PostgreSQL without dialect-specific window syntax.
+func loadLatestProbeFailures(ctx context.Context, db *sqlx.DB) (map[probeFailureKey]bool, error) {
+	type row struct {
+		AccountID int64  `db:"account_id"`
+		ModelName string `db:"model_name"`
+		Status    string `db:"status"`
+	}
+	var rows []row
+	if err := db.SelectContext(ctx, &rows, db.Rebind(`
+		SELECT account_id, model_name, status
+		FROM model_probe_results
+		WHERE id IN (SELECT MAX(id) FROM model_probe_results GROUP BY account_id, model_name)`)); err != nil {
+		return nil, fmt.Errorf("load latest probe results: %w", err)
+	}
+	out := make(map[probeFailureKey]bool, len(rows))
+	for _, r := range rows {
+		if r.Status == "failure" {
+			out[probeFailureKey{AccountID: r.AccountID, Model: r.ModelName}] = true
+		}
+	}
+	return out, nil
+}
+
+// rebuildOptionsFromConfig resolves the probe-filter configuration from the
+// global config singleton. A nil config yields the zero-value (legacy) options.
+func rebuildOptionsFromConfig() RebuildOptions {
+	cfg := config.GetSafe()
+	if cfg == nil {
+		return RebuildOptions{}
+	}
+	return RebuildOptions{
+		ProbeFilter: ProbeFilterConfig{
+			Enabled:       cfg.RouteRebuildProbeFilterEnabled,
+			IncludeModels: cfg.RouteRebuildProbeFilterIncludeModels,
+			ExcludeModels: cfg.RouteRebuildProbeFilterExcludeModels,
+		},
+	}
 }

--- a/service/route_rebuild_probe_test.go
+++ b/service/route_rebuild_probe_test.go
@@ -1,0 +1,183 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+func seedProbeResult(t *testing.T, db *store.DB, accountID, siteID int64, modelName, status string) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(
+		`INSERT INTO model_probe_results
+			(channel_id, account_id, site_id, model_name, status, created_at)
+		 VALUES (NULL, ?, ?, ?, ?, ?)`,
+		accountID, siteID, modelName, status, now,
+	); err != nil {
+		t.Fatalf("insert probe result: %v", err)
+	}
+}
+
+func seedPatternRoute(t *testing.T, db *store.DB, pattern string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
+		 VALUES (?, 'pattern', 'weighted', 1, ?, ?)`, pattern, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+func TestRebuild_ProbeFailureExcludesChannel(t *testing.T) {
+	db := setupRouteRebuildDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, accountID, tokenID := seedSiteAccountToken(t, db, "probe-fail")
+	siteID := siteIDForAccount(t, db, accountID)
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		t.Fatalf("avail: %v", err)
+	}
+	routeID := seedPatternRoute(t, db, "gpt-*")
+	seedProbeResult(t, db, accountID, siteID, "gpt-4o", "failure")
+
+	stats, err := RebuildTokenRoutesFromAvailabilityWithOptions(context.Background(), db.DB, RebuildOptions{
+		ProbeFilter: ProbeFilterConfig{Enabled: true},
+	})
+	if err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if stats.ChannelsInserted != 0 {
+		t.Fatalf("channelsInserted = %d, want 0 (probe-failed channel filtered)", stats.ChannelsInserted)
+	}
+	var count int
+	if err := db.Get(&count, `SELECT COUNT(*) FROM route_channels WHERE route_id = ?`, routeID); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("route channels = %d, want 0", count)
+	}
+}
+
+func TestRebuild_ProbeFilterDisabledKeepsProbeFailedChannel(t *testing.T) {
+	db := setupRouteRebuildDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, accountID, tokenID := seedSiteAccountToken(t, db, "legacy")
+	siteID := siteIDForAccount(t, db, accountID)
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		t.Fatalf("avail: %v", err)
+	}
+	seedPatternRoute(t, db, "gpt-*")
+	seedProbeResult(t, db, accountID, siteID, "gpt-4o", "failure")
+
+	stats, err := RebuildTokenRoutesFromAvailability(context.Background(), db.DB)
+	if err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if stats.ChannelsInserted < 1 {
+		t.Fatalf("channelsInserted = %d, want >= 1 (legacy path ignores probe)", stats.ChannelsInserted)
+	}
+}
+
+func TestRebuild_ProbeLatestSuccessWinsOverEarlierFailure(t *testing.T) {
+	db := setupRouteRebuildDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, accountID, tokenID := seedSiteAccountToken(t, db, "recovers")
+	siteID := siteIDForAccount(t, db, accountID)
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		t.Fatalf("avail: %v", err)
+	}
+	seedPatternRoute(t, db, "gpt-*")
+	seedProbeResult(t, db, accountID, siteID, "gpt-4o", "failure")
+	seedProbeResult(t, db, accountID, siteID, "gpt-4o", "success")
+
+	stats, err := RebuildTokenRoutesFromAvailabilityWithOptions(context.Background(), db.DB, RebuildOptions{
+		ProbeFilter: ProbeFilterConfig{Enabled: true},
+	})
+	if err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if stats.ChannelsInserted < 1 {
+		t.Fatalf("channelsInserted = %d, want >= 1 (latest success keeps channel)", stats.ChannelsInserted)
+	}
+}
+
+func TestRebuild_ExcludeModelListFiltersChannel(t *testing.T) {
+	db := setupRouteRebuildDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, _, tokenID := seedSiteAccountToken(t, db, "exclude")
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'claude-3', 1, ?)`, tokenID, now); err != nil {
+		t.Fatalf("avail: %v", err)
+	}
+	routeID := seedPatternRoute(t, db, "*")
+	stats, err := RebuildTokenRoutesFromAvailabilityWithOptions(context.Background(), db.DB, RebuildOptions{
+		ProbeFilter: ProbeFilterConfig{Enabled: true, ExcludeModels: []string{"claude-3"}},
+	})
+	if err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	var count int
+	if err := db.Get(&count, `SELECT COUNT(*) FROM route_channels WHERE route_id = ?`, routeID); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("route channels = %d, want 0 (excluded model)", count)
+	}
+	if stats.ChannelsInserted != 0 {
+		t.Fatalf("channelsInserted = %d, want 0", stats.ChannelsInserted)
+	}
+}
+
+func TestRebuild_NoChangeShortCircuitSkipsCacheInvalidation(t *testing.T) {
+	db := setupRouteRebuildDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, _, tokenID := seedSiteAccountToken(t, db, "short")
+	if _, err := db.Exec(
+		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
+		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		t.Fatalf("avail: %v", err)
+	}
+	seedPatternRoute(t, db, "gpt-*")
+
+	opts := RebuildOptions{ProbeFilter: ProbeFilterConfig{Enabled: true}}
+	first, err := RebuildTokenRoutesFromAvailabilityWithOptions(context.Background(), db.DB, opts)
+	if err != nil {
+		t.Fatalf("first rebuild: %v", err)
+	}
+	if first.ChannelsInserted < 1 || !first.Changed {
+		t.Fatalf("first rebuild changed=%v inserted=%d, want changed", first.Changed, first.ChannelsInserted)
+	}
+
+	second, err := RebuildTokenRoutesFromAvailabilityWithOptions(context.Background(), db.DB, opts)
+	if err != nil {
+		t.Fatalf("second rebuild: %v", err)
+	}
+	if second.ChannelsInserted != 0 || second.ChannelsRemoved != 0 {
+		t.Fatalf("second rebuild inserted=%d removed=%d, want 0/0", second.ChannelsInserted, second.ChannelsRemoved)
+	}
+	if second.Changed {
+		t.Fatalf("second rebuild Changed=true, want false (no model-set change)")
+	}
+}
+
+func siteIDForAccount(t *testing.T, db *store.DB, accountID int64) int64 {
+	t.Helper()
+	var siteID int64
+	if err := db.Get(&siteID, `SELECT site_id FROM accounts WHERE id = ?`, accountID); err != nil {
+		t.Fatalf("load site id: %v", err)
+	}
+	return siteID
+}

--- a/store/migrate.go
+++ b/store/migrate.go
@@ -87,6 +87,8 @@ func AutoMigrate(db *DB) error {
 		{"model_name_redirects", buildModelNameRedirectsDDL(dialect)},
 		// Table 34: admin_audit_logs
 		{"admin_audit_logs", buildAdminAuditLogsDDL(dialect)},
+		// Table 35: model_probe_results
+		{"model_probe_results", buildModelProbeResultsDDL(dialect)},
 	}
 
 	// Non-UNIQUE indexes are created separately via CREATE INDEX IF NOT EXISTS
@@ -1266,6 +1268,40 @@ func buildModelVerifyHistoryDDL(d string) string {
 	)`
 }
 
+// buildModelProbeResultsDDL creates the model_probe_results table.
+// One row per background model-probe result (scheduler/model_probe.go pass),
+// used as the connectivity signal for the route-rebuild probe filter (#625).
+// status shares the probe vocabulary: success | failure | inconclusive | skipped.
+func buildModelProbeResultsDDL(d string) string {
+	if isPG(d) {
+		return `CREATE TABLE IF NOT EXISTS model_probe_results (
+			id SERIAL PRIMARY KEY,
+			channel_id INTEGER,
+			account_id INTEGER NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+			site_id INTEGER NOT NULL,
+			model_name TEXT NOT NULL,
+			status TEXT NOT NULL,
+			latency_ms DOUBLE PRECISION,
+			http_status INTEGER,
+			error_text TEXT,
+			created_at TEXT NOT NULL
+		)`
+	}
+	return `CREATE TABLE IF NOT EXISTS model_probe_results (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		channel_id INTEGER,
+		account_id INTEGER NOT NULL,
+		site_id INTEGER NOT NULL,
+		model_name TEXT NOT NULL,
+		status TEXT NOT NULL,
+		latency_ms REAL,
+		http_status INTEGER,
+		error_text TEXT,
+		created_at TEXT NOT NULL,
+		FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE
+	)`
+}
+
 // buildProductAnnouncementsDDL creates the product_announcements table
 //. Operator-authored severity-ranked banners shown on
 // the Dashboard. Content edits (PUT) reset any dismissal so a new revision is
@@ -1502,6 +1538,10 @@ func buildIndexes() []struct {
 		// model_verify_history
 		{"model_verify_history_batch_idx", `CREATE INDEX IF NOT EXISTS model_verify_history_batch_idx ON model_verify_history (batch_id, created_at)`},
 		{"model_verify_history_model_idx", `CREATE INDEX IF NOT EXISTS model_verify_history_model_idx ON model_verify_history (model_name, created_at)`},
+		// model_probe_results
+		{"model_probe_results_channel_model_idx", `CREATE INDEX IF NOT EXISTS model_probe_results_channel_model_idx ON model_probe_results (channel_id, model_name, created_at)`},
+		{"model_probe_results_account_model_idx", `CREATE INDEX IF NOT EXISTS model_probe_results_account_model_idx ON model_probe_results (account_id, model_name, created_at)`},
+		{"model_probe_results_created_at_idx", `CREATE INDEX IF NOT EXISTS model_probe_results_created_at_idx ON model_probe_results (created_at)`},
 		// model_name_redirects
 		{"model_name_redirects_account_actual_idx", `CREATE INDEX IF NOT EXISTS model_name_redirects_account_actual_idx ON model_name_redirects (account_id, actual)`},
 		// admin_audit_logs

--- a/store/schema.go
+++ b/store/schema.go
@@ -459,6 +459,20 @@ type ModelVerifyRecord struct {
 	CreatedAt   string   `db:"created_at" json:"createdAt"`
 }
 
+// ---- Table 35: model_probe_results ----
+type ModelProbeResult struct {
+	ID          int64    `db:"id" json:"id"`
+	ChannelID   *int64   `db:"channel_id" json:"channelId"`
+	AccountID   int64    `db:"account_id" json:"accountId"`
+	SiteID      int64    `db:"site_id" json:"siteId"`
+	ModelName   string   `db:"model_name" json:"modelName"`
+	Status      string   `db:"status" json:"status"` // success | failure | inconclusive | skipped
+	LatencyMs   *float64 `db:"latency_ms" json:"latencyMs"`
+	HTTPStatus  *int64   `db:"http_status" json:"httpStatus"`
+	ErrorText   *string  `db:"error_text" json:"errorText"`
+	CreatedAt   string   `db:"created_at" json:"createdAt"`
+}
+
 // ---- Table 31: product_announcements ----
 type ProductAnnouncement struct {
 	ID        int64   `db:"id" json:"id"`

--- a/web/src/features/channels/api.ts
+++ b/web/src/features/channels/api.ts
@@ -1,0 +1,26 @@
+// metapi-go/features/channels — TanStack Query hook wrapping `lib/api.ts`.
+// GET /api/channels returns the full read-only list, so `useChannels` is a
+// single query and the table does client-side filtering/sorting/pagination.
+
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+
+import { api } from '@/lib/api'
+
+import { channelsKeys, type ChannelRow } from './types'
+
+export function useChannels(
+  queryOptions?: Omit<
+    UseQueryOptions<ChannelRow[], Error, ChannelRow[]>,
+    'queryKey' | 'queryFn'
+  >
+) {
+  return useQuery<ChannelRow[], Error>({
+    queryKey: channelsKeys.list(),
+    queryFn: async () => {
+      const result = await api.getChannels()
+      return (result ?? []) as ChannelRow[]
+    },
+    staleTime: 10 * 1000,
+    ...queryOptions,
+  })
+}

--- a/web/src/features/channels/components/channels-columns.tsx
+++ b/web/src/features/channels/components/channels-columns.tsx
@@ -1,0 +1,226 @@
+// metapi-go/features/channels — TanStack Table column definitions for the
+// read-only Channels list. Status uses the routing package vocabulary
+// (enabled / cooldown / breaker_open / manually_disabled) and renders it with
+// color + icon + text (dual-channel, never color-only).
+
+import type { ColumnDef } from '@tanstack/react-table'
+import {
+  Ban,
+  CheckCircle2,
+  Clock,
+  TriangleAlert,
+} from 'lucide-react'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { DataTableColumnHeader } from '@/components/data-table'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+import type { ChannelRow, ChannelStatus } from '../types'
+
+const STATUS_CONFIG: Record<
+  ChannelStatus,
+  { labelKey: string; variant: 'default' | 'warning' | 'destructive' | 'secondary'; dotClass: string; Icon: typeof CheckCircle2 }
+> = {
+  enabled: {
+    labelKey: 'channels.status.enabled',
+    variant: 'default',
+    dotClass: 'bg-success',
+    Icon: CheckCircle2,
+  },
+  cooldown: {
+    labelKey: 'channels.status.cooldown',
+    variant: 'warning',
+    dotClass: 'bg-warning',
+    Icon: Clock,
+  },
+  breaker_open: {
+    labelKey: 'channels.status.breakerOpen',
+    variant: 'destructive',
+    dotClass: 'bg-destructive',
+    Icon: TriangleAlert,
+  },
+  manually_disabled: {
+    labelKey: 'channels.status.manuallyDisabled',
+    variant: 'secondary',
+    dotClass: 'bg-muted-foreground',
+    Icon: Ban,
+  },
+}
+
+function formatResponse(ms: number | null): string {
+  if (ms === null || ms === undefined) return '—'
+  return `${Math.round(ms)}ms`
+}
+
+function formatCooldown(until: string | null): string {
+  if (!until) return '—'
+  return new Date(until).toLocaleString()
+}
+
+export function useChannelsColumns(): ColumnDef<ChannelRow>[] {
+  const { t } = useTranslation()
+
+  return useMemo<ColumnDef<ChannelRow>[]>(
+    () => [
+      {
+        id: 'name',
+        accessorKey: 'name',
+        size: 200,
+        meta: { mobileTitle: true, mobileOrder: 0 },
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t('channels.columns.name')}
+          />
+        ),
+        cell: ({ row }) => (
+          <span className='font-medium'>{row.original.name}</span>
+        ),
+      },
+      {
+        id: 'site',
+        accessorFn: (row) => row.site.name,
+        size: 160,
+        meta: { mobileOrder: 1 },
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t('channels.columns.site')}
+          />
+        ),
+        cell: ({ row }) => (
+          <span className='text-muted-foreground text-sm'>
+            {row.original.site.name || '—'}
+          </span>
+        ),
+      },
+      {
+        id: 'type',
+        accessorKey: 'type',
+        size: 110,
+        meta: { mobileHidden: true, mobileOrder: 30 },
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t('channels.columns.type')}
+          />
+        ),
+        cell: ({ row }) => {
+          const type = row.original.type
+          return (
+            <Badge variant='outline' className='capitalize'>
+              {t(`channels.type.${type}`)}
+            </Badge>
+          )
+        },
+      },
+      {
+        id: 'status',
+        accessorKey: 'status',
+        size: 170,
+        meta: { mobileBadge: true, mobileOrder: 2 },
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t('channels.columns.status')}
+          />
+        ),
+        cell: ({ row }) => {
+          const status = row.original.status
+          const config = STATUS_CONFIG[status] ?? STATUS_CONFIG.enabled
+          const Icon = config.Icon
+          return (
+            <Badge variant={config.variant} className='gap-1.5'>
+              <span
+                aria-hidden='true'
+                className={cn('size-1.5 rounded-full', config.dotClass)}
+              />
+              <Icon aria-hidden='true' />
+              {t(config.labelKey)}
+            </Badge>
+          )
+        },
+      },
+      {
+        id: 'models',
+        accessorKey: 'models',
+        size: 180,
+        meta: { mobileHidden: true, mobileOrder: 31 },
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t('channels.columns.models')}
+          />
+        ),
+        cell: ({ row }) => (
+          <span className='text-muted-foreground text-sm'>
+            {row.original.models || '—'}
+          </span>
+        ),
+      },
+      {
+        id: 'priority',
+        accessorKey: 'priority',
+        size: 90,
+        meta: { mobileHidden: true, mobileOrder: 32 },
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t('channels.columns.priority')}
+          />
+        ),
+        cell: ({ row }) => <span className='text-sm'>{row.original.priority}</span>,
+      },
+      {
+        id: 'weight',
+        accessorKey: 'weight',
+        size: 90,
+        meta: { mobileHidden: true, mobileOrder: 33 },
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t('channels.columns.weight')}
+          />
+        ),
+        cell: ({ row }) => <span className='text-sm'>{row.original.weight}</span>,
+      },
+      {
+        id: 'response',
+        accessorFn: (row) => row.responseMs,
+        size: 110,
+        meta: { mobileHidden: true, mobileOrder: 34 },
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t('channels.columns.response')}
+          />
+        ),
+        cell: ({ row }) => (
+          <span className='text-muted-foreground text-sm'>
+            {formatResponse(row.original.responseMs)}
+          </span>
+        ),
+      },
+      {
+        id: 'cooldown',
+        accessorFn: (row) => row.cooldownUntil,
+        size: 180,
+        meta: { mobileHidden: true, mobileOrder: 35 },
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={t('channels.columns.cooldown')}
+          />
+        ),
+        cell: ({ row }) => (
+          <span className='text-muted-foreground text-sm'>
+            {formatCooldown(row.original.cooldownUntil)}
+          </span>
+        ),
+      },
+    ],
+    [t]
+  )
+}

--- a/web/src/features/channels/components/channels-columns.tsx
+++ b/web/src/features/channels/components/channels-columns.tsx
@@ -4,12 +4,7 @@
 // color + icon + text (dual-channel, never color-only).
 
 import type { ColumnDef } from '@tanstack/react-table'
-import {
-  Ban,
-  CheckCircle2,
-  Clock,
-  TriangleAlert,
-} from 'lucide-react'
+import { Ban, CheckCircle2, Clock, TriangleAlert } from 'lucide-react'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -21,7 +16,12 @@ import type { ChannelRow, ChannelStatus } from '../types'
 
 const STATUS_CONFIG: Record<
   ChannelStatus,
-  { labelKey: string; variant: 'default' | 'warning' | 'destructive' | 'secondary'; dotClass: string; Icon: typeof CheckCircle2 }
+  {
+    labelKey: string
+    variant: 'default' | 'warning' | 'destructive' | 'secondary'
+    dotClass: string
+    Icon: typeof CheckCircle2
+  }
 > = {
   enabled: {
     labelKey: 'channels.status.enabled',
@@ -171,7 +171,9 @@ export function useChannelsColumns(): ColumnDef<ChannelRow>[] {
             title={t('channels.columns.priority')}
           />
         ),
-        cell: ({ row }) => <span className='text-sm'>{row.original.priority}</span>,
+        cell: ({ row }) => (
+          <span className='text-sm'>{row.original.priority}</span>
+        ),
       },
       {
         id: 'weight',
@@ -184,7 +186,9 @@ export function useChannelsColumns(): ColumnDef<ChannelRow>[] {
             title={t('channels.columns.weight')}
           />
         ),
-        cell: ({ row }) => <span className='text-sm'>{row.original.weight}</span>,
+        cell: ({ row }) => (
+          <span className='text-sm'>{row.original.weight}</span>
+        ),
       },
       {
         id: 'response',

--- a/web/src/features/channels/components/channels-page.tsx
+++ b/web/src/features/channels/components/channels-page.tsx
@@ -1,0 +1,131 @@
+// metapi-go/features/channels — read-only list page.
+// Wires the shared data-table to `useChannels` and mirrors search/page/sort
+// state to the URL. No mutation surfaces: this page is intentionally read-only
+// (soft isolation only — never hard-disable a channel).
+
+import type { ColumnFiltersState } from '@tanstack/react-table'
+import { useTranslation } from 'react-i18next'
+
+import {
+  DataTablePage,
+  encodeSorting,
+  useDataTable,
+  useUrlTableState,
+  type UrlTableState,
+} from '@/components/data-table'
+import { asStringParam, parseSortingParam } from '@/lib/helpers/searchParams'
+
+import { useChannels } from '../api'
+import { channelsSearchSchema } from '../lib/channels-schema'
+import type { ChannelRow } from '../types'
+import { useChannelsColumns } from './channels-columns'
+
+const CHANNELS_COLUMN_VISIBILITY_STORAGE_KEY =
+  'metapi-go:channels:column-visibility'
+const CHANNELS_COLUMN_SIZING_STORAGE_KEY = 'metapi-go:channels:column-sizing'
+
+type ChannelsUrlFilters = Record<string, never>
+
+function readSearch(searchString?: string): UrlTableState<ChannelsUrlFilters> {
+  if (typeof window === 'undefined') {
+    return { q: '', pageIndex: 0, pageSize: 20, sorting: [], filters: {} }
+  }
+  const params = new URLSearchParams(searchString ?? window.location.search)
+  const parsed = channelsSearchSchema.safeParse({
+    q: params.get('q') ?? undefined,
+    page: params.get('page') ?? undefined,
+    pageSize: params.get('pageSize') ?? undefined,
+    sort: params.get('sort') ?? undefined,
+  })
+  if (!parsed.success) {
+    return { q: '', pageIndex: 0, pageSize: 20, sorting: [], filters: {} }
+  }
+  const data = parsed.data
+  return {
+    q: asStringParam(data.q) ?? '',
+    pageIndex: data.page ?? 0,
+    pageSize: data.pageSize ?? 20,
+    sorting: parseSortingParam(data.sort),
+    filters: {},
+  }
+}
+
+function buildHref(next: Partial<UrlTableState<ChannelsUrlFilters>>): string {
+  const current = readSearch()
+  const merged = { ...current, ...next }
+  const params = new URLSearchParams()
+  if (merged.q) params.set('q', merged.q)
+  if (merged.pageIndex > 0) params.set('page', String(merged.pageIndex))
+  if (merged.pageSize !== 20) params.set('pageSize', String(merged.pageSize))
+  const sortString = encodeSorting(merged.sorting)
+  if (sortString) params.set('sort', sortString)
+  const queryString = params.toString()
+  return queryString ? `/channels?${queryString}` : '/channels'
+}
+
+function useChannelsUrlState() {
+  return useUrlTableState<ChannelsUrlFilters>({
+    basePath: '/channels',
+    read: readSearch,
+    buildHref,
+    toColumnFilters: () => [] as ColumnFiltersState,
+    fromColumnFilters: () => ({}),
+  })
+}
+
+export function ChannelsPage() {
+  const { t } = useTranslation()
+  const channelsQuery = useChannels()
+  const urlState = useChannelsUrlState()
+  const columns = useChannelsColumns()
+
+  const { table } = useDataTable<ChannelRow>({
+    data: channelsQuery.data ?? [],
+    columns,
+    enableColumnResizing: true,
+    columnVisibilityStorageKey: CHANNELS_COLUMN_VISIBILITY_STORAGE_KEY,
+    columnSizingStorageKey: CHANNELS_COLUMN_SIZING_STORAGE_KEY,
+    globalFilter: urlState.globalFilter,
+    onGlobalFilterChange: urlState.onGlobalFilterChange,
+    pagination: urlState.pagination,
+    onPaginationChange: urlState.onPaginationChange,
+    sorting: urlState.sorting,
+    onSortingChange: urlState.onSortingChange,
+    columnFilters: urlState.columnFilters,
+    onColumnFiltersChange: urlState.onColumnFiltersChange,
+    getRowId: (row) => String(row.id),
+  })
+
+  return (
+    <div className='flex h-full flex-col gap-3 p-4'>
+      <div>
+        <h1 className='text-lg font-normal'>{t('channels.page.title')}</h1>
+        <p className='text-muted-foreground text-sm'>
+          {t('channels.page.description')}
+        </p>
+      </div>
+
+      {channelsQuery.error && (
+        <div className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg rounded-lg border p-3 text-sm'>
+          {t('channels.page.loadError', {
+            message: (channelsQuery.error as Error).message,
+          })}
+        </div>
+      )}
+
+      <DataTablePage
+        table={table}
+        columns={columns}
+        isLoading={channelsQuery.isLoading}
+        isFetching={channelsQuery.isFetching}
+        emptyTitle={t('channels.empty.title')}
+        emptyDescription={t('channels.empty.description')}
+        skeletonKeyPrefix='channel-skeleton'
+        toolbarProps={{
+          searchPlaceholder: t('channels.toolbar.searchPlaceholder'),
+          searchDebounceMs: 400,
+        }}
+      />
+    </div>
+  )
+}

--- a/web/src/features/channels/index.ts
+++ b/web/src/features/channels/index.ts
@@ -1,0 +1,4 @@
+// metapi-go/features/channels — barrel re-exports.
+export { useChannels } from './api'
+export { channelsSearchSchema } from './lib/channels-schema'
+export { channelsKeys } from './types'

--- a/web/src/features/channels/lib/channels-schema.ts
+++ b/web/src/features/channels/lib/channels-schema.ts
@@ -1,0 +1,23 @@
+// metapi-go/features/channels — Zod schema for the list URL search state.
+// Only search / page / page-size / sorting are URL-backed; the channels list
+// has no faceted filters today.
+
+import { z } from 'zod'
+
+import {
+  encodeSortingParam,
+  stringSearchParam,
+} from '@/lib/helpers/searchParams'
+
+export const channelsSearchSchema = z.object({
+  q: stringSearchParam,
+  page: z.coerce.number().int().min(0).optional(),
+  pageSize: z.coerce.number().int().min(1).max(200).optional(),
+  sort: z
+    .union([
+      z.string(),
+      z.array(z.object({ id: z.string(), desc: z.boolean() })),
+    ])
+    .optional()
+    .transform((value) => encodeSortingParam(value)),
+})

--- a/web/src/features/channels/types.ts
+++ b/web/src/features/channels/types.ts
@@ -1,0 +1,37 @@
+// metapi-go/features/channels — domain types for the Channels read-only list.
+// The backend `/api/channels` surface returns an aggregated projection across
+// account/token/oauth_unit dimensions; this contract stays 1:1 with the
+// handler/admin/channels.go payload (camelCase).
+
+export type ChannelStatus =
+  | 'enabled'
+  | 'cooldown'
+  | 'breaker_open'
+  | 'manually_disabled'
+
+export type ChannelType = 'account' | 'token' | 'oauth_unit'
+
+export type ChannelRow = {
+  id: number
+  routeId: number
+  name: string
+  site: { id: number; name: string }
+  type: ChannelType
+  status: ChannelStatus
+  models: string
+  priority: number
+  weight: number
+  responseMs: number | null
+  cooldownUntil: string | null
+  enabled: boolean
+  manualOverride: boolean
+}
+
+/**
+ * TanStack Query key factory. The channels list is a single full-list query
+ * (no server-side pagination), so one stable key is enough for invalidation.
+ */
+export const channelsKeys = {
+  all: ['channels'] as const,
+  list: () => [...channelsKeys.all, 'list'] as const,
+}

--- a/web/src/hooks/use-sidebar-data.ts
+++ b/web/src/hooks/use-sidebar-data.ts
@@ -14,6 +14,7 @@ import {
   Server,
   Settings,
   ShieldCheck,
+  Waypoints,
 } from 'lucide-react'
 
 import type { SidebarData } from '@/components/layout/types'
@@ -67,6 +68,11 @@ export function useSidebarData(): SidebarData {
             title: 'sidebar.items.tokenRoutes',
             url: '/token-routes',
             icon: Route,
+          },
+          {
+            title: 'sidebar.items.channels',
+            url: '/channels',
+            icon: Waypoints,
           },
           {
             title: 'sidebar.items.oauth',

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1861,6 +1861,42 @@
         "lavender-dream": "Lavender Dream"
       }
     },
+    "channels": {
+        "page": {
+            "title": "Channels",
+            "description": "Read-only routing health across every site, account, token and OAuth unit.",
+            "loadError": "Failed to load channels: {{message}}"
+        },
+        "empty": {
+            "title": "No channels",
+            "description": "No routing channels have been materialised yet."
+        },
+        "toolbar": {
+            "searchPlaceholder": "Search channels..."
+        },
+        "columns": {
+            "name": "Name",
+            "site": "Site",
+            "type": "Type",
+            "status": "Status",
+            "models": "Models",
+            "priority": "Priority",
+            "weight": "Weight",
+            "response": "Response",
+            "cooldown": "Cooldown"
+        },
+        "status": {
+            "enabled": "Enabled",
+            "cooldown": "Cooldown",
+            "breakerOpen": "Breaker open",
+            "manuallyDisabled": "Manually disabled"
+        },
+        "type": {
+            "account": "Account",
+            "token": "Token",
+            "oauth_unit": "OAuth unit"
+        }
+    },
     "sidebar": {
       "groups": {
         "console": "Console",
@@ -1877,6 +1913,7 @@
         "proxyLogs": "Proxy Logs",
         "monitors": "Monitors",
         "tokenRoutes": "Token Routes",
+        "channels": "Channels",
         "oauth": "OAuth",
         "models": "Models",
         "modelTester": "Model Tester",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1862,40 +1862,40 @@
       }
     },
     "channels": {
-        "page": {
-            "title": "Channels",
-            "description": "Read-only routing health across every site, account, token and OAuth unit.",
-            "loadError": "Failed to load channels: {{message}}"
-        },
-        "empty": {
-            "title": "No channels",
-            "description": "No routing channels have been materialised yet."
-        },
-        "toolbar": {
-            "searchPlaceholder": "Search channels..."
-        },
-        "columns": {
-            "name": "Name",
-            "site": "Site",
-            "type": "Type",
-            "status": "Status",
-            "models": "Models",
-            "priority": "Priority",
-            "weight": "Weight",
-            "response": "Response",
-            "cooldown": "Cooldown"
-        },
-        "status": {
-            "enabled": "Enabled",
-            "cooldown": "Cooldown",
-            "breakerOpen": "Breaker open",
-            "manuallyDisabled": "Manually disabled"
-        },
-        "type": {
-            "account": "Account",
-            "token": "Token",
-            "oauth_unit": "OAuth unit"
-        }
+      "page": {
+        "title": "Channels",
+        "description": "Read-only routing health across every site, account, token and OAuth unit.",
+        "loadError": "Failed to load channels: {{message}}"
+      },
+      "empty": {
+        "title": "No channels",
+        "description": "No routing channels have been materialised yet."
+      },
+      "toolbar": {
+        "searchPlaceholder": "Search channels..."
+      },
+      "columns": {
+        "name": "Name",
+        "site": "Site",
+        "type": "Type",
+        "status": "Status",
+        "models": "Models",
+        "priority": "Priority",
+        "weight": "Weight",
+        "response": "Response",
+        "cooldown": "Cooldown"
+      },
+      "status": {
+        "enabled": "Enabled",
+        "cooldown": "Cooldown",
+        "breakerOpen": "Breaker open",
+        "manuallyDisabled": "Manually disabled"
+      },
+      "type": {
+        "account": "Account",
+        "token": "Token",
+        "oauth_unit": "OAuth unit"
+      }
     },
     "sidebar": {
       "groups": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1856,40 +1856,40 @@
       }
     },
     "channels": {
-        "page": {
-            "title": "通道",
-            "description": "跨站点、账号、令牌与 OAuth 单元的只读路由健康视图。",
-            "loadError": "加载通道失败：{{message}}"
-        },
-        "empty": {
-            "title": "暂无通道",
-            "description": "当前尚未生成任何路由通道。"
-        },
-        "toolbar": {
-            "searchPlaceholder": "搜索通道..."
-        },
-        "columns": {
-            "name": "名称",
-            "site": "站点",
-            "type": "类型",
-            "status": "状态",
-            "models": "模型",
-            "priority": "优先级",
-            "weight": "权重",
-            "response": "响应",
-            "cooldown": "冷却"
-        },
-        "status": {
-            "enabled": "已启用",
-            "cooldown": "冷却中",
-            "breakerOpen": "熔断已开",
-            "manuallyDisabled": "已手动停用"
-        },
-        "type": {
-            "account": "账号",
-            "token": "令牌",
-            "oauth_unit": "OAuth 单元"
-        }
+      "page": {
+        "title": "通道",
+        "description": "跨站点、账号、令牌与 OAuth 单元的只读路由健康视图。",
+        "loadError": "加载通道失败：{{message}}"
+      },
+      "empty": {
+        "title": "暂无通道",
+        "description": "当前尚未生成任何路由通道。"
+      },
+      "toolbar": {
+        "searchPlaceholder": "搜索通道..."
+      },
+      "columns": {
+        "name": "名称",
+        "site": "站点",
+        "type": "类型",
+        "status": "状态",
+        "models": "模型",
+        "priority": "优先级",
+        "weight": "权重",
+        "response": "响应",
+        "cooldown": "冷却"
+      },
+      "status": {
+        "enabled": "已启用",
+        "cooldown": "冷却中",
+        "breakerOpen": "熔断已开",
+        "manuallyDisabled": "已手动停用"
+      },
+      "type": {
+        "account": "账号",
+        "token": "令牌",
+        "oauth_unit": "OAuth 单元"
+      }
     },
     "sidebar": {
       "groups": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1855,6 +1855,42 @@
         "lavender-dream": "薰衣草梦"
       }
     },
+    "channels": {
+        "page": {
+            "title": "通道",
+            "description": "跨站点、账号、令牌与 OAuth 单元的只读路由健康视图。",
+            "loadError": "加载通道失败：{{message}}"
+        },
+        "empty": {
+            "title": "暂无通道",
+            "description": "当前尚未生成任何路由通道。"
+        },
+        "toolbar": {
+            "searchPlaceholder": "搜索通道..."
+        },
+        "columns": {
+            "name": "名称",
+            "site": "站点",
+            "type": "类型",
+            "status": "状态",
+            "models": "模型",
+            "priority": "优先级",
+            "weight": "权重",
+            "response": "响应",
+            "cooldown": "冷却"
+        },
+        "status": {
+            "enabled": "已启用",
+            "cooldown": "冷却中",
+            "breakerOpen": "熔断已开",
+            "manuallyDisabled": "已手动停用"
+        },
+        "type": {
+            "account": "账号",
+            "token": "令牌",
+            "oauth_unit": "OAuth 单元"
+        }
+    },
     "sidebar": {
       "groups": {
         "console": "控制台",
@@ -1871,6 +1907,7 @@
         "proxyLogs": "使用日志",
         "monitors": "监控",
         "tokenRoutes": "路由",
+        "channels": "通道",
         "oauth": "OAuth",
         "models": "模型",
         "modelTester": "操练场",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1156,6 +1156,7 @@ export const api = {
   getRoutesSummary: () => request('/api/routes/summary'),
   getRouteChannels: (routeId: number) =>
     request(`/api/routes/${routeId}/channels`),
+  getChannels: () => request('/api/channels'),
   batchAddChannels: (
     routeId: number,
     channels: Array<{

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as SignInRouteImport } from './routes/sign-in'
 import { Route as AuthenticatedIndexRouteImport } from './routes/_authenticated/index'
 import { Route as AuthenticatedAboutRouteImport } from './routes/_authenticated/about'
 import { Route as AuthenticatedAccountsRouteImport } from './routes/_authenticated/accounts'
+import { Route as AuthenticatedChannelsRouteImport } from './routes/_authenticated/channels'
 import { Route as AuthenticatedCheckinRouteImport } from './routes/_authenticated/checkin'
 import { Route as AuthenticatedDashboardRouteRouteImport } from './routes/_authenticated/dashboard/route'
 import { Route as AuthenticatedModelTesterRouteImport } from './routes/_authenticated/model-tester'
@@ -53,6 +54,11 @@ const AuthenticatedAboutRoute = AuthenticatedAboutRouteImport.update({
 const AuthenticatedAccountsRoute = AuthenticatedAccountsRouteImport.update({
   id: '/accounts',
   path: '/accounts',
+  getParentRoute: () => AuthenticatedRouteRoute,
+} as any)
+const AuthenticatedChannelsRoute = AuthenticatedChannelsRouteImport.update({
+  id: '/channels',
+  path: '/channels',
   getParentRoute: () => AuthenticatedRouteRoute,
 } as any)
 const AuthenticatedCheckinRoute = AuthenticatedCheckinRouteImport.update({
@@ -154,6 +160,7 @@ export interface FileRoutesByFullPath {
   '/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
   '/about': typeof AuthenticatedAboutRoute
   '/accounts': typeof AuthenticatedAccountsRoute
+  '/channels': typeof AuthenticatedChannelsRoute
   '/checkin': typeof AuthenticatedCheckinRoute
   '/model-tester': typeof AuthenticatedModelTesterRoute
   '/models': typeof AuthenticatedModelsRoute
@@ -173,6 +180,7 @@ export interface FileRoutesByTo {
   '/sign-in': typeof SignInRoute
   '/about': typeof AuthenticatedAboutRoute
   '/accounts': typeof AuthenticatedAccountsRoute
+  '/channels': typeof AuthenticatedChannelsRoute
   '/checkin': typeof AuthenticatedCheckinRoute
   '/model-tester': typeof AuthenticatedModelTesterRoute
   '/models': typeof AuthenticatedModelsRoute
@@ -196,6 +204,7 @@ export interface FileRoutesById {
   '/_authenticated/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
   '/_authenticated/about': typeof AuthenticatedAboutRoute
   '/_authenticated/accounts': typeof AuthenticatedAccountsRoute
+  '/_authenticated/channels': typeof AuthenticatedChannelsRoute
   '/_authenticated/checkin': typeof AuthenticatedCheckinRoute
   '/_authenticated/model-tester': typeof AuthenticatedModelTesterRoute
   '/_authenticated/models': typeof AuthenticatedModelsRoute
@@ -221,6 +230,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/about'
     | '/accounts'
+    | '/channels'
     | '/checkin'
     | '/model-tester'
     | '/models'
@@ -240,6 +250,7 @@ export interface FileRouteTypes {
     | '/sign-in'
     | '/about'
     | '/accounts'
+    | '/channels'
     | '/checkin'
     | '/model-tester'
     | '/models'
@@ -262,6 +273,7 @@ export interface FileRouteTypes {
     | '/_authenticated/settings'
     | '/_authenticated/about'
     | '/_authenticated/accounts'
+    | '/_authenticated/channels'
     | '/_authenticated/checkin'
     | '/_authenticated/model-tester'
     | '/_authenticated/models'
@@ -319,6 +331,13 @@ declare module '@tanstack/react-router' {
       path: '/accounts'
       fullPath: '/accounts'
       preLoaderRoute: typeof AuthenticatedAccountsRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/channels': {
+      id: '/_authenticated/channels'
+      path: '/channels'
+      fullPath: '/channels'
+      preLoaderRoute: typeof AuthenticatedChannelsRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/checkin': {
@@ -492,6 +511,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedSettingsRouteRoute: typeof AuthenticatedSettingsRouteRouteWithChildren
   AuthenticatedAboutRoute: typeof AuthenticatedAboutRoute
   AuthenticatedAccountsRoute: typeof AuthenticatedAccountsRoute
+  AuthenticatedChannelsRoute: typeof AuthenticatedChannelsRoute
   AuthenticatedCheckinRoute: typeof AuthenticatedCheckinRoute
   AuthenticatedModelTesterRoute: typeof AuthenticatedModelTesterRoute
   AuthenticatedModelsRoute: typeof AuthenticatedModelsRoute
@@ -509,6 +529,7 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedSettingsRouteRoute: AuthenticatedSettingsRouteRouteWithChildren,
   AuthenticatedAboutRoute: AuthenticatedAboutRoute,
   AuthenticatedAccountsRoute: AuthenticatedAccountsRoute,
+  AuthenticatedChannelsRoute: AuthenticatedChannelsRoute,
   AuthenticatedCheckinRoute: AuthenticatedCheckinRoute,
   AuthenticatedModelTesterRoute: AuthenticatedModelTesterRoute,
   AuthenticatedModelsRoute: AuthenticatedModelsRoute,

--- a/web/src/routes/_authenticated/channels.tsx
+++ b/web/src/routes/_authenticated/channels.tsx
@@ -1,0 +1,23 @@
+// metapi-go/routes — channels read-only list.
+
+import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+
+import { channelsKeys, channelsSearchSchema } from '@/features/channels'
+import { api } from '@/lib/api'
+
+export const Route = createFileRoute('/_authenticated/channels')({
+  validateSearch: channelsSearchSchema,
+  loader: async ({ context }) => {
+    await context.queryClient.prefetchQuery({
+      queryKey: channelsKeys.list(),
+      queryFn: async () => {
+        const result = await api.getChannels()
+        return (result ?? []) as unknown[]
+      },
+    })
+  },
+  component: lazyRouteComponent(
+    () => import('@/features/channels/components/channels-page'),
+    'ChannelsPage'
+  ),
+})


### PR DESCRIPTION
## Summary
PR6 — channels + probe-backed filtering (#622-#626). Backend + frontend. Contains the single routing hot-path change (#625).

- #622 `GET /api/channels` read-only projection (site/account/token/oauth_unit dimensions; no credentials in response).
- #623 first-class Channels page (`/channels`) + sidebar entry; columns Name/Site/Type/Status/Models/Priority/Weight/Response/Cooldown.
- #624 cooldown/breaker status visualization (enabled/cooldown/breaker_open/manually_disabled, color + icon + text); read-only soft isolation.
- #625 probe-backed model filtering before route rebuild. **Gated OFF by default** (`ROUTE_REBUILD_PROBE_FILTER_ENABLED`, default false) so the legacy non-probe path is byte-for-byte unchanged; `RebuildTokenRoutesFromAvailability` is now a thin wrapper over the options variant. No-change short-circuit skips writes + cache invalidation.
- #626 `model_probe_results` table (SQLite+PG DDL + indexes) reused by the existing probe scheduler (no new cron).

## Validation
- Go: `go build ./cmd/server` ✅ · `go vet ./...` ✅ · `go test -p 1 ./... -count=1` ✅ (incl. `service/route_rebuild_probe_test.go`, `routing/channel_status_test.go`, `scheduler/model_probe_results_test.go`)
- Web: `typecheck` ✅ · `lint` ✅ · `test` 29 files/337 ✅ · `build` ✅
- `-race` not run: known Windows ThreadSanitizer "error 87" address-space limitation.

## Notes (non-blocking)
- No PG runtime integration test for `model_probe_results` DDL (SQLite path exercised; PG DDL structural only).
- `RouteRebuildStats.Changed` populated but not yet surfaced in `/api/routes/rebuild` JSON.