### PR TITLE
feat(admin): surface changed stat in /api/routes/rebuild response

### DIFF
--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -515,6 +515,7 @@ func (h *tokenRoutesHandler) rebuildRoutes(w http.ResponseWriter, r *http.Reques
 		"channelsInserted": stats.ChannelsInserted,
 		"channelsRemoved":  stats.ChannelsRemoved,
 		"channelsKept":     stats.ChannelsKept,
+		"changed":          stats.Changed,
 	})
 }
 

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -125,6 +125,9 @@ func TestTokenRoutes_Rebuild_InvalidatesCacheTruthfully(t *testing.T) {
 	if _, ok := result["patternRoutes"]; !ok {
 		t.Fatalf("missing patternRoutes in rebuild response: %v", result)
 	}
+	if _, ok := result["changed"]; !ok {
+		t.Fatalf("missing changed in rebuild response: %v", result)
+	}
 
 	var chCount int
 	if err := db.Get(&chCount, `SELECT COUNT(*) FROM route_channels WHERE route_id = ?`, routeID); err != nil {


### PR DESCRIPTION
## 改动摘要

`/api/routes/rebuild` 已在 Go 侧计算 `RouteRebuildStats.Changed`（是否有自动通道被插入/移除），但响应 JSON 未返回该字段。本 PR 补充 `changed` 字段，让重建接口对 `probe-filter` 短路场景（无变更时跳过缓存失效）保持“真相式”响应，并新增测试断言。

## 类型

- [x] feat（新功能）

## 测试验证

- [x] `go test ./handler/admin/ -run TestTokenRoutes_Rebuild -count=1` 通过

## 自查清单

- [x] 无密钥/内部路径泄漏
- [x] 行为变更已补充测试
