### PR TITLE
fix(scheduler): register balance/log-cleanup/webdav schedulers

### DIFF
--- a/app/services.go
+++ b/app/services.go
@@ -27,6 +27,36 @@ func StartBackgroundServices() {
 	slog.Info("starting background schedulers")
 
 	cfg := config.Get()
+	newRegistry, checkin, balance, logCleanup, webdav := buildSchedulers(cfg)
+
+	// Start all
+	newRegistry.StartAll(context.Background())
+
+	// Publish scheduler pointers only after StartAll so a config update can
+	// never observe a half-started scheduler.
+	servicesMu.Lock()
+	registry = newRegistry
+	checkinScheduler = checkin
+	balanceScheduler = balance
+	logCleanupScheduler = logCleanup
+	webdavScheduler = webdav
+	servicesMu.Unlock()
+
+	slog.Info("all background schedulers registered",
+		"count", len(newRegistry.List()),
+	)
+}
+
+// buildSchedulers constructs and registers every background scheduler without
+// starting them, so registration coverage can be asserted independently of the
+// runtime side effects of StartAll.
+func buildSchedulers(cfg *config.Config) (
+	*scheduler.Registry,
+	*scheduler.CheckinScheduler,
+	*scheduler.BalanceScheduler,
+	*scheduler.LogCleanupScheduler,
+	*scheduler.BackupWebdavScheduler,
+) {
 	newRegistry := scheduler.NewRegistry()
 
 	// ---- Usage Aggregation (needed by admin-snapshot) ----
@@ -39,15 +69,18 @@ func StartBackgroundServices() {
 
 	// ---- Scheduler 2: Balance Refresh ----
 	balance := scheduler.NewBalanceScheduler(cfg, nil)
+	newRegistry.Register(balance)
 
 	// ---- Scheduler 3: Daily Summary ----
 	newRegistry.Register(scheduler.NewDailySummaryScheduler(cfg))
 
 	// ---- Scheduler 4: Log Cleanup ----
 	logCleanup := scheduler.NewLogCleanupScheduler(cfg)
+	newRegistry.Register(logCleanup)
 
 	// ---- Scheduler 5: Backup WebDAV ----
 	webdav := scheduler.NewBackupWebdavScheduler(cfg)
+	newRegistry.Register(webdav)
 
 	// ---- Scheduler 6: Site Announcements ----
 	newRegistry.Register(scheduler.NewSiteAnnouncementScheduler(cfg))
@@ -83,22 +116,7 @@ func StartBackgroundServices() {
 	// ---- Scheduler 15: OAuth Token Refresh ----
 	newRegistry.Register(scheduler.NewOAuthRefreshScheduler(cfg))
 
-	// Start all
-	newRegistry.StartAll(context.Background())
-
-	// Publish scheduler pointers only after StartAll so a config update can
-	// never observe a half-started scheduler.
-	servicesMu.Lock()
-	registry = newRegistry
-	checkinScheduler = checkin
-	balanceScheduler = balance
-	logCleanupScheduler = logCleanup
-	webdavScheduler = webdav
-	servicesMu.Unlock()
-
-	slog.Info("all background schedulers registered",
-		"count", len(newRegistry.List()),
-	)
+	return newRegistry, checkin, balance, logCleanup, webdav
 }
 
 // StopBackgroundServices stops all background schedulers.

--- a/app/services_registration_test.go
+++ b/app/services_registration_test.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+)
+
+// TestBuildSchedulersRegistration guards the full background-scheduler wiring.
+// Regression: balance-refresh, log-cleanup and backup-webdav were constructed
+// but never Register()ed, so they silently never started. This test fails if a
+// scheduler is added or removed without keeping the expected set in sync.
+func TestBuildSchedulersRegistration(t *testing.T) {
+	cfg := &config.Config{}
+	reg, checkin, balance, logCleanup, webdav := buildSchedulers(cfg)
+
+	got := reg.List()
+	want := []string{
+		"usage-aggregation",
+		"checkin",
+		"balance-refresh",
+		"daily-summary",
+		"log-cleanup",
+		"backup-webdav",
+		"site-announcement",
+		"model-probe",
+		"channel-recovery",
+		"sub2api-refresh",
+		"update-center",
+		"admin-snapshot",
+		"proxy-file-retention",
+		"proxy-video-task-retention",
+		"proxy-log-retention",
+		"oauth-refresh",
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("registered %d schedulers, want %d: got=%v", len(got), len(want), got)
+	}
+
+	seen := map[string]bool{}
+	for _, name := range got {
+		if seen[name] {
+			t.Errorf("duplicate scheduler name %q", name)
+		}
+		seen[name] = true
+	}
+	for _, name := range want {
+		if !seen[name] {
+			t.Errorf("scheduler %q not registered; registered=%v", name, got)
+		}
+	}
+
+	// The four hot-reloadable schedulers must be returned as non-nil pointers.
+	for name, ptr := range map[string]any{
+		"checkin":    checkin,
+		"balance":    balance,
+		"logCleanup": logCleanup,
+		"webdav":     webdav,
+	} {
+		if ptr == nil {
+			t.Errorf("%s scheduler pointer is nil", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`balance-refresh`, `log-cleanup` and `backup-webdav` schedulers were constructed and hot-reloadable, but were never `Register()`ed on the startup registry. They silently never started — the most user-visible being balance refresh never auto-updating for check-in users.

## Changes

- `app/services.go`: register the three schedulers; extract `buildSchedulers()` so registration coverage is testable without starting goroutines.
- `app/services_registration_test.go`: regression test asserting the full 16-scheduler set and non-nil hot-reload pointers.

## Validation

- `go build ./cmd/server`
- `go vet ./...`
- `go test -p 1 ./... -count=1` (all packages green)