### PR TITLE
chore(release): prepare v0.11.0 (changelog + install.sh + version bump)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -432,6 +432,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+          # install.sh must ship as a release asset so the documented
+          # curl .../download/install.sh | bash flow resolves.
+          cp scripts/install.sh dist-bin/install.sh
           tag="$GITHUB_REF_NAME"
           if gh release view "$tag" >/dev/null 2>&1; then
             gh release upload "$tag" dist-bin/* --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,28 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
-## [Unreleased]
+## [v0.11.0] — 2026-08-13
+
+### Added
+- 管理控制台 UI/UX 与功能全量交付（#594–#626，合并为 #633/#634）
+  - UX 基础：共享格式化器、状态/空态组件、toast、CountUp、响应式 data-table + 移动端降级、无障碍、页面标题缩放（#594–#600）
+  - 安全：token 列脱敏（#601–#602）
+  - 可观测性工作台：Overview/Health/Proxy Logs、访问日志指标、slog panic 恢复、probe 驱动的路由重建过滤（#603–#610）
+  - 导入：站点探测 + 统一导入向导 + 幂等批量导入（#611–#616）
+  - 模型：定价层、价格对比、重定向修复候选 + 推荐（#617–#621）
+  - 通道：只读列表 + probe 驱动的重建过滤（#622–#626）
+- /api/routes/rebuild 响应新增 changed 统计（probe 过滤 no-change 短路时保持真实，含测试断言）
+- 访问日志记录 status/bytes/duration_ms；statusRecorder 转发 Flush/Hijack/ReadFrom/SetWriteDeadline 保持 SSE/WebSocket 可用；slog panic 恢复带 request_id；/metrics 新增 go_goroutines / go_memstats_* / go_gc_duration_seconds（纯 stdlib，零依赖）（#593）
 
 ### Changed
-- CI/CD 合并为单一 `.github/workflows/main.yml` 管道（测试 → 镜像推送 → GitHub Release），移除 cd.yml 中与 CI 重复的 release-gate；master push 推送镜像（latest+sha）；SemVer tag 额外构建 5 平台二进制 + checksums + 二进制冒烟并创建 Release
-- Bun 工具链版本单一来源（workflow `env.BUN_VERSION` + Dockerfile `BUN_VERSION` build-arg）；发布前校验 tag / `web/package.json` / CHANGELOG 节一致
-- 新增发布助手 `scripts/release.sh`（校验后打 annotated tag 并推送）
+- CI/CD 合并为单一 .github/workflows/main.yml 管道（测试 → 镜像推送 → GitHub Release），移除 cd.yml 中与 CI 重复的 release-gate；master push 推送镜像（latest+sha）；SemVer tag 额外构建 5 平台二进制 + checksums + 二进制冒烟并创建 Release
+- Bun 工具链版本单一来源（workflow env.BUN_VERSION + Dockerfile BUN_VERSION build-arg）；发布前校验 tag / web/package.json / CHANGELOG 节一致
+- 新增发布助手 scripts/release.sh（校验后打 annotated tag 并推送）
+
+### Chore
+- Dependabot：actions/setup-go 5→7（#584）、upload/download-artifact + build-push-action majors（#592）、frontend-deps 5 项（#588）
+- GitHub Actions Dependabot 分组 + 升级处理 SOP 文档（#591）
+- state 文档 last-verified 日期更新（#590）
 
 ## [v0.10.0] — 2026-08-12
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,15 +25,35 @@ case "$os" in
 esac
 
 if [ "$VERSION" = "latest" ]; then
-  url="https://github.com/${REPO}/releases/latest/download/${binary}"
+  base="https://github.com/${REPO}/releases/latest/download"
 else
-  url="https://github.com/${REPO}/releases/download/${VERSION}/${binary}"
+  base="https://github.com/${REPO}/releases/download/${VERSION}"
 fi
+url="${base}/${binary}"
 
 echo "Downloading ${binary} (${VERSION})..."
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 curl -fsSL "$url" -o "$tmp/metapi"
+
+# Verify the binary against the release checksums manifest.
+checksums_url="${base}/checksums.txt"
+curl -fsSL "$checksums_url" -o "$tmp/checksums.txt"
+expected="$(awk -v b="$binary" '$2 == b { print $1 }' "$tmp/checksums.txt")"
+if [ -z "$expected" ]; then
+  echo "checksums.txt did not contain an entry for ${binary}" >&2
+  exit 1
+fi
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$tmp/metapi" | awk '{print $1}')"
+else
+  actual="$(shasum -a 256 "$tmp/metapi" | awk '{print $1}')"
+fi
+if [ "$expected" != "$actual" ]; then
+  echo "checksum mismatch for ${binary}: expected ${expected}, got ${actual}" >&2
+  exit 1
+fi
+
 chmod +x "$tmp/metapi"
 
 install_dir="${PREFIX}/bin"

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metapi",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "Meta-layer management and unified proxy for AI API aggregation platforms",
   "keywords": [


### PR DESCRIPTION
## Summary

Release-readiness for v0.11.0.

## Changes

- **CHANGELOG**: rewrite `[Unreleased]` → `[v0.11.0] — 2026-08-13`, covering the #594–#626 admin-console UI/UX + feature overhaul, `/api/routes/rebuild` `changed` stat, #593 observability, #583 CI/CD unification, and dependabot/ci chores (#584/#588/#590/#591/#592).
- **scripts/install.sh**: verify the downloaded binary against the release `checksums.txt` manifest (`sha256sum` with `shasum` fallback) so the `curl | bash` flow fails closed on tampering.
- **.github/workflows/main.yml**: copy `scripts/install.sh` into `dist-bin/` before creating the release, so the documented `.../download/install.sh` URL actually resolves (previously 404).
- **web/package.json**: bump `0.10.0` → `0.11.0`.

## Validation

- `bash -n scripts/install.sh`
- `node -p "require('./web/package.json').version"` → `0.11.0`
- `grep '^## \[v0.11.0\]' CHANGELOG.md` → present
- release consistency (CHANGELOG + package.json) satisfied per `scripts/release.sh` preconditions