### PR TITLE
test(store): reconcile table count + close schema coverage gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ v0.9.0 起前端 100% 对齐 [New API](https://github.com/QuantumNous/new-api) �
 - **13 个 feature 模块**：`auth`、`dashboard`（4 section + RealtimeOps WebSocket）、`sites`（引导式配置动线 站点→账号→路由）、`accounts`、`token-routes`（dnd-kit 拖拽）、`oauth`、`checkin`（嵌套响应解构 + 失败原因分类 badge）、`proxy-logs`（manual + 服务端分页 + 详情 Sheet）、`models`、`model-tester`（SSE 全协议流式）、`site-announcements`、`about`、`settings`（5 子区 drill-in）。
 - **data-table 四层架构**：`core`（TanStack table 渲染原语）+ `layout`（响应式页面组合）+ `toolbar`（filter/search/批量操作）+ `static`（本地数组轻量渲染）+ `hooks`（受控状态层，URL 三段式同步）。feature 经统一 `index.ts` 导入，专属列/动作留在各 feature 目录。
 - **OKLCH 设计系统**：三层 CSS（`theme.css` 语义 token + `theme-presets.css` 10 套预设 + `index.css` Tailwind 4 入口）；3 轴主题（preset/radius/scale）经 `<body data-theme-*>` 切换；暗色 class-based + cookie 持久化。图表取色用 JS 读 OKLCH token，MutationObserver 监听主题变化重采样。
-- **key-based i18n**：i18next + react-i18next，支持 `en` + `zh-CN`（各 1434 key，双向 0 缺失）；React 组件 `useTranslation()` + `t()`，非 React 模块用 `i18n.t()`；key 双向一致性由 `web/src/i18n/__tests__/i18n-keys.test.ts` 校验。
+- **key-based i18n**：i18next + react-i18next，支持 `en` + `zh-CN`（各 1641 key，双向 0 缺失）；React 组件 `useTranslation()` + `t()`，非 React 模块用 `i18n.t()`；key 双向一致性由 `web/src/i18n/__tests__/i18n-keys.test.ts` 校验。
 
 ---
 
@@ -291,7 +291,7 @@ bun run dev            # 本地开发（rsbuild dev，/api /v1 代理到后端�
 bun run typecheck      # tsgo 类型检查
 bun run lint           # oxlint
 bun run lint:fix       # oxlint --fix
-bun run test           # vitest run（全量，当前 369 tests / 38 files）
+bun run test           # vitest run（全量，当前 337 tests / 29 files）
 bun run knip           # 未使用代码检测
 bun run build          # rsbuild build（产物经 go:embed 打包进 Go 二进制）
 bun run build:check    # tsgo + build（发布前完整检查）

--- a/store/bootstrap.go
+++ b/store/bootstrap.go
@@ -74,7 +74,7 @@ func EnsureRuntimeDatabase(cfg *config.Config) error {
 		return fmt.Errorf("bootstrap: failed to open database: %w", err)
 	}
 
-	// Run auto-migration (CREATE TABLE IF NOT EXISTS for all 27 tables).
+	// Run auto-migration (CREATE TABLE IF NOT EXISTS for all 35 tables).
 	if err := AutoMigrate(db); err != nil {
 		db.Close()
 		return fmt.Errorf("bootstrap: auto-migration failed: %w", err)

--- a/store/migrate.go
+++ b/store/migrate.go
@@ -7,7 +7,7 @@ import (
 	"github.com/deliciousbuding/metapi-go/config"
 )
 
-// AutoMigrate creates all 28 tables with indexes, unique constraints, foreign keys,
+// AutoMigrate creates all 35 tables with indexes, unique constraints, foreign keys,
 // and check constraints. Uses CREATE TABLE IF NOT EXISTS for idempotency.
 // After the base bootstrap it runs ApplyAdditiveMigrations (schema_migrations
 // bookkeeping + ordered enterprise steps). Run on startup after Open().
@@ -1232,7 +1232,7 @@ func buildBalanceHistoryDDL(d string) string {
 }
 
 // buildModelVerifyHistoryDDL creates the model_verify_history table
-//. One row per model/channel probe result from an
+// . One row per model/channel probe result from an
 // operator-initiated batch verification pass (POST /api/models/verify-batch).
 // batch_id groups one operator action; status is success | failure |
 // inconclusive | skipped (same vocabulary as the background model probe).
@@ -1303,7 +1303,7 @@ func buildModelProbeResultsDDL(d string) string {
 }
 
 // buildProductAnnouncementsDDL creates the product_announcements table
-//. Operator-authored severity-ranked banners shown on
+// . Operator-authored severity-ranked banners shown on
 // the Dashboard. Content edits (PUT) reset any dismissal so a new revision is
 // seen again (dismiss-revision semantics).
 func buildProductAnnouncementsDDL(d string) string {
@@ -1332,7 +1332,7 @@ func buildProductAnnouncementsDDL(d string) string {
 }
 
 // buildAnnouncementDismissalsDDL creates the announcement_dismissals table
-//. One row per dismissed announcement; content
+// . One row per dismissed announcement; content
 // revisions delete the row so the new revision surfaces again.
 func buildAnnouncementDismissalsDDL(d string) string {
 	if isPG(d) {
@@ -1349,7 +1349,7 @@ func buildAnnouncementDismissalsDDL(d string) string {
 }
 
 // buildModelNameRedirectsDDL creates the model_name_redirects table
-//. Maps a canonical route model name to the actual
+// . Maps a canonical route model name to the actual
 // upstream name per account (e.g. claude-3-5-sonnet → claude-3-5-sonnet-20241022).
 // source is sync (auto-generated) or manual (operator-authored, never
 // overwritten by sync generation).
@@ -1409,7 +1409,7 @@ func buildEventsDDL(d string) string {
 }
 
 // buildAdminAuditLogsDDL creates the admin_audit_logs table
-//. Records authenticated admin write
+// . Records authenticated admin write
 // operations (POST/PUT/PATCH/DELETE) for traceability and compliance.
 // actor is a sha256 prefix of the admin bearer token — never the raw token.
 func buildAdminAuditLogsDDL(d string) string {

--- a/store/migrate_test.go
+++ b/store/migrate_test.go
@@ -23,15 +23,15 @@ func TestAutoMigrateIdempotent(t *testing.T) {
 		t.Fatalf("second AutoMigrate failed (should be idempotent): %v", err)
 	}
 
-	// Verify all 27 tables still exist.
+	// Verify all 35 tables still exist.
 	var count int
 	err = db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table'").Scan(&count)
 	if err != nil {
 		t.Fatalf("table count query failed: %v", err)
 	}
-	// 27 user tables + sqlite_sequence may exist.
-	if count < 27 {
-		t.Errorf("expected at least 27 tables after double migrate, got %d", count)
+	// 35 user tables + sqlite_sequence may exist.
+	if count < 35 {
+		t.Errorf("expected at least 35 tables after double migrate, got %d", count)
 	}
 }
 

--- a/store/postgres_test.go
+++ b/store/postgres_test.go
@@ -86,7 +86,7 @@ func TestPostgresSSLModeOverrideCanDisableTLS(t *testing.T) {
 	defer db.Close()
 }
 
-// TestPostgresAutoMigrateAllTables verifies all 28 tables exist after AutoMigrate.
+// TestPostgresAutoMigrateAllTables verifies all 35 tables exist after AutoMigrate.
 func TestPostgresAutoMigrateAllTables(t *testing.T) {
 	db := openTestPG(t)
 
@@ -103,6 +103,9 @@ func TestPostgresAutoMigrateAllTables(t *testing.T) {
 		"analytics_projection_checkpoints",
 		"site_day_usage", "site_hour_usage", "model_day_usage",
 		"downstream_api_keys", "site_announcements", "events",
+		"balance_history", "model_verify_history",
+		"product_announcements", "announcement_dismissals",
+		"model_name_redirects", "admin_audit_logs", "model_probe_results",
 	}
 
 	for _, table := range expectedTables {

--- a/store/schema_test.go
+++ b/store/schema_test.go
@@ -26,7 +26,7 @@ var tableColumnCount = map[string]int{
 	"ProxyDebugTrace":               26,
 	"ProxyDebugAttempt":             18,
 	"ProxyVideoTask":                15,
-	"AdminBackgroundTask":           15,
+	"AdminBackgroundTask":           14,
 	"ProxyFile":                     13,
 	"Setting":                       2,
 	"AdminSnapshot":                 9,
@@ -38,9 +38,15 @@ var tableColumnCount = map[string]int{
 	"SiteAnnouncement":              17,
 	"Event":                         9,
 	"BalanceHistory":                8,
+	"ModelVerifyRecord":             11,
+	"ModelProbeResult":              10,
+	"ProductAnnouncement":           8,
+	"AnnouncementDismissal":         2,
+	"ModelNameRedirect":             8,
+	"AdminAuditLog":                 8,
 }
 
-// allStructs returns a list of all 27 table structs for reflection-based testing.
+// allStructs returns a list of all 35 table structs for reflection-based testing.
 func allStructs() []any {
 	return []any{
 		Site{},
@@ -71,14 +77,21 @@ func allStructs() []any {
 		SiteAnnouncement{},
 		Event{},
 		BalanceHistory{},
+		AdminBackgroundTask{},
+		ModelVerifyRecord{},
+		ProductAnnouncement{},
+		AnnouncementDismissal{},
+		ModelNameRedirect{},
+		AdminAuditLog{},
+		ModelProbeResult{},
 	}
 }
 
-// TestTableCount verifies that there are exactly 28 table structs.
+// TestTableCount verifies that there are exactly 35 table structs.
 func TestTableCount(t *testing.T) {
 	structs := allStructs()
-	if len(structs) != 28 {
-		t.Errorf("expected 28 table structs, got %d", len(structs))
+	if len(structs) != 35 {
+		t.Errorf("expected 35 table structs, got %d", len(structs))
 	}
 }
 

--- a/store/sqlite_test.go
+++ b/store/sqlite_test.go
@@ -59,7 +59,7 @@ func TestSQLiteOpenMemory(t *testing.T) {
 	}
 }
 
-// TestSQLiteAutoMigrateAllTables verifies all 28 tables are created.
+// TestSQLiteAutoMigrateAllTables verifies all 35 tables are created.
 func TestSQLiteAutoMigrateAllTables(t *testing.T) {
 	db := openTestSQLite(t)
 
@@ -92,6 +92,13 @@ func TestSQLiteAutoMigrateAllTables(t *testing.T) {
 		"downstream_api_keys",
 		"site_announcements",
 		"events",
+		"balance_history",
+		"model_verify_history",
+		"product_announcements",
+		"announcement_dismissals",
+		"model_name_redirects",
+		"admin_audit_logs",
+		"model_probe_results",
 	}
 
 	for _, table := range expectedTables {


### PR DESCRIPTION
## Summary

Reconcile stale table/i18n/test counts and close a real test-coverage gap.

## Changes

- **store tests**: `TestSQLiteAutoMigrateAllTables` / `TestPostgresAutoMigrateAllTables` now verify all **35** DDL tables (7 newer tables were previously missing from `expectedTables`).
- **store/schema_test.go**: `allStructs()` + `tableColumnCount` now cover all 35 structs; fix `AdminBackgroundTask` column count 15 → 14 (actual exported-field count).
- **store comments**: `28` / `27` table references → `35`.
- **README**: i18n key count `1434` → `1641`; frontend test count `369 tests / 38 files` → `337 tests / 29 files`.

## Validation

- `go test ./store/... -count=1`
- `go vet ./...`
- `go test -p 1 ./... -count=1` (full suite green)
- Frontend counts measured from `bun run test` (29 files / 337 tests) and locale leaf-key count (1641 each).