### PR TITLE
chore(deploy): harden docker-compose.prod + document upgrade checklist

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -35,3 +35,23 @@ services:
       DB_CONN_MAX_LIFETIME_SEC: ${DB_CONN_MAX_LIFETIME_SEC:-1800}
       DB_CONN_MAX_IDLE_TIME_SEC: ${DB_CONN_MAX_IDLE_TIME_SEC:-300}
     restart: unless-stopped
+    # Runtime hardening (matches docker-compose.yml): drop caps, read-only root,
+    # tmpfs /tmp, and bounded CPU/memory so a runaway process cannot exhaust the host.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=64M
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: "0.5"
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/metapi", "healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -209,6 +209,13 @@ docker compose -f docker-compose.prod.yml up -d
 
 Docker Compose will automatically recreate the container with the new image. Auto-migration runs at startup to apply any new schema changes.
 
+Upgrade checklist:
+
+1. Back up the database first (cp data/hub.db ... or pg_dump -Fc ...).
+2. Prefer pinning a released image tag (e.g. ghcr.io/deliciousbuding/metapi-go:v0.11.0) over latest so rollback is reproducible.
+3. After upgrade, verify GET /ready returns 200 and run bash web/scripts/verify-live-assets.sh http://127.0.0.1:4000.
+4. Rollback = restore the pre-upgrade backup and re-run the previous pinned image tag. Schema changes are forward-only; do not downgrade the schema by deleting rows from schema_migrations.
+
 ## Post-deploy asset smoke (mandatory)
 
 After every deploy, replay the browser asset graph against the running


### PR DESCRIPTION
## Summary

Harden the production Docker Compose stack and document a reproducible upgrade path.

## Changes

- `docker-compose.prod.yml`: add `healthcheck`, `no-new-privileges`, `cap_drop: ALL`, `read_only: true`, `tmpfs /tmp`, and CPU/memory limits (parity with the dev `docker-compose.yml`).
- `docs/deployment.md`: add an upgrade checklist (backup first, pin image tag, verify `/ready` + live-assets, forward-only rollback).

## Validation

- `docker compose -f docker-compose.prod.yml config` (with dummy AUTH_TOKEN/PROXY_TOKEN) → OK
- `go test ./docs -run TestPublicMarkdownHygiene -count=1`