### PR TITLE
chore(web): i18n a11y labels + drop orphan stub key + tighten SSE types

### DIFF
--- a/web/src/components/skip-to-main.tsx
+++ b/web/src/components/skip-to-main.tsx
@@ -2,9 +2,13 @@
 // Renders a visually-hidden link that becomes visible on focus, letting keyboard
 // users jump straight to the main content region.
 
+import { useTranslation } from 'react-i18next'
+
 import { cn } from '@/lib/utils'
 
 export function SkipToMain() {
+  const { t } = useTranslation()
+
   return (
     <a
       href='#content'
@@ -17,7 +21,7 @@ export function SkipToMain() {
         'focus-visible:pointer-events-auto focus-visible:translate-y-0'
       )}
     >
-      Skip to main content
+      {t('common.skipToMain')}
     </a>
   )
 }

--- a/web/src/components/ui/pagination.tsx
+++ b/web/src/components/ui/pagination.tsx
@@ -6,15 +6,18 @@ import {
 } from '@hugeicons/core-free-icons'
 import { HugeiconsIcon } from '@hugeicons/react'
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
 function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
+  const { t } = useTranslation()
+
   return (
     <nav
       role='navigation'
-      aria-label='pagination'
+      aria-label={t('common.pagination')}
       data-slot='pagination'
       className={cn('mx-auto flex w-full justify-center', className)}
       {...props}
@@ -73,9 +76,11 @@ function PaginationPrevious({
   text = 'Previous',
   ...props
 }: React.ComponentProps<typeof PaginationLink> & { text?: string }) {
+  const { t } = useTranslation()
+
   return (
     <PaginationLink
-      aria-label='Go to previous page'
+      aria-label={t('common.previousPage')}
       size='default'
       className={cn('pl-1.5!', className)}
       {...props}
@@ -95,9 +100,11 @@ function PaginationNext({
   text = 'Next',
   ...props
 }: React.ComponentProps<typeof PaginationLink> & { text?: string }) {
+  const { t } = useTranslation()
+
   return (
     <PaginationLink
-      aria-label='Go to next page'
+      aria-label={t('common.nextPage')}
       size='default'
       className={cn('pr-1.5!', className)}
       {...props}
@@ -116,6 +123,8 @@ function PaginationEllipsis({
   className,
   ...props
 }: React.ComponentProps<'span'>) {
+  const { t } = useTranslation()
+
   return (
     <span
       aria-hidden
@@ -127,7 +136,7 @@ function PaginationEllipsis({
       {...props}
     >
       <HugeiconsIcon icon={MoreHorizontalCircle01Icon} strokeWidth={2} />
-      <span className='sr-only'>More pages</span>
+      <span className='sr-only'>{t('common.morePages')}</span>
     </span>
   )
 }

--- a/web/src/components/ui/secret-field.tsx
+++ b/web/src/components/ui/secret-field.tsx
@@ -5,6 +5,7 @@
 
 import { Check, Copy, Eye, EyeOff } from 'lucide-react'
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -25,6 +26,7 @@ export function SecretField({
   fallback = '—',
   className,
 }: SecretFieldProps) {
+  const { t } = useTranslation()
   const [revealed, setRevealed] = useState(false)
   const [copied, setCopied] = useState(false)
 
@@ -57,8 +59,10 @@ export function SecretField({
           variant='ghost'
           size='icon-sm'
           onClick={() => setRevealed((v) => !v)}
-          title={revealed ? 'Hide' : 'Reveal'}
-          aria-label={revealed ? 'Hide secret' : 'Reveal secret'}
+          title={revealed ? t('common.hide') : t('common.reveal')}
+          aria-label={
+            revealed ? t('common.hideSecret') : t('common.revealSecret')
+          }
         >
           {revealed ? <EyeOff /> : <Eye />}
         </Button>
@@ -67,8 +71,8 @@ export function SecretField({
         variant='ghost'
         size='icon-sm'
         onClick={handleCopy}
-        title='Copy'
-        aria-label='Copy secret'
+        title={t('common.copy')}
+        aria-label={t('common.copySecret')}
       >
         {copied ? <Check className='text-success' /> : <Copy />}
       </Button>

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -56,7 +56,17 @@
       "languageName": {
         "en": "English",
         "zhCN": "简体中文"
-      }
+      },
+      "pagination": "Pagination",
+      "previousPage": "Go to previous page",
+      "nextPage": "Go to next page",
+      "morePages": "More pages",
+      "hideSecret": "Hide secret",
+      "revealSecret": "Reveal secret",
+      "copySecret": "Copy secret",
+      "hide": "Hide",
+      "reveal": "Reveal",
+      "copy": "Copy"
     },
     "about": {
       "title": "About",
@@ -1233,9 +1243,6 @@
             "factoryResetFailed": "Factory reset failed."
           }
         }
-      },
-      "stub": {
-        "placeholder": "TODO phase 3: migrate content from legacy"
       }
     },
     "accounts": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -56,7 +56,17 @@
       "languageName": {
         "en": "English",
         "zhCN": "简体中文"
-      }
+      },
+      "pagination": "分页",
+      "previousPage": "上一页",
+      "nextPage": "下一页",
+      "morePages": "更多页",
+      "hideSecret": "隐藏密钥",
+      "revealSecret": "显示密钥",
+      "copySecret": "复制密钥",
+      "hide": "隐藏",
+      "reveal": "显示",
+      "copy": "复制"
     },
     "about": {
       "title": "关于",
@@ -1233,9 +1243,6 @@
             "factoryResetFailed": "恢复出厂失败。"
           }
         }
-      },
-      "stub": {
-        "placeholder": "TODO phase 3: 从旧版迁移内容"
       }
     },
     "accounts": {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -137,8 +137,8 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
 async function streamSse(
   url: string,
   handlers: {
-    onLog?: (entry: any) => void
-    onDone?: (payload: any) => void
+    onLog?: (entry: unknown) => void
+    onDone?: (payload: unknown) => void
     signal?: AbortSignal
   }
 ) {
@@ -181,9 +181,10 @@ async function streamSse(
       }
 
       if (dataLines.length <= 0) continue
-      let payload: any = dataLines.join('\n')
+      const raw = dataLines.join('\n')
+      let payload: unknown = raw
       try {
-        payload = JSON.parse(payload)
+        payload = JSON.parse(raw)
       } catch {
         // keep string payload
       }
@@ -1659,8 +1660,8 @@ export const api = {
   streamUpdateCenterTaskLogs: (
     taskId: string,
     handlers: {
-      onLog?: (entry: any) => void
-      onDone?: (payload: any) => void
+      onLog?: (entry: unknown) => void
+      onDone?: (payload: unknown) => void
       signal?: AbortSignal
     }
   ) =>


### PR DESCRIPTION
## Summary

Frontend polish before the v0.11.0 release:

- Route hardcoded `aria`/`sr-only` labels through i18n in `skip-to-main`, `pagination`, and `secret-field` (new `common.*` keys in `en` + `zh-CN`).
- Remove the orphan `stub` i18n key (a `TODO phase 3` placeholder with no consumer) from both locales and fix the resulting trailing comma.
- Tighten `streamSse` payload/callback types from `any` to `unknown`.

## Verification

- `bun run typecheck` (`tsgo -b`)
- `bun run lint` (no new warnings)
- `bun run test` — 337 passed
- `bun test src/i18n/__tests__/i18n-keys.test.ts` — 4 passed (key parity + coverage)
