### PR TITLE
chore(ci): bump Go 1.26.5 -> 1.26.6 (stdlib vuln fixes)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY web ./
 RUN bun run build:web
 
 # Stage 2: Go build
-FROM golang:1.26.5-alpine AS build
+FROM golang:1.26.6-alpine AS build
 ARG VERSION
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="https://github.com/DeliciousBuding/metapi-go/releases/latest"><img alt="Release" src="https://img.shields.io/github/v/release/DeliciousBuding/metapi-go?logo=github&label=release&color=blue"></a>
   <a href="https://github.com/DeliciousBuding/metapi-go/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/DeliciousBuding/metapi-go?style=social"></a>
   <a href="https://github.com/DeliciousBuding/metapi-go/forks"><img alt="Forks" src="https://img.shields.io/github/forks/DeliciousBuding/metapi-go?style=social"></a>
-  <img alt="Go" src="https://img.shields.io/badge/Go-1.26.5-00ADD8?logo=go">
+  <img alt="Go" src="https://img.shields.io/badge/Go-1.26.6-00ADD8?logo=go">
   <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react">
   <img alt="Bun" src="https://img.shields.io/badge/Bun-≥1.0-000000?logo=bun&logoColor=white">
   <a href="https://github.com/DeliciousBuding/metapi-go/pkgs/container/metapi-go"><img alt="Docker" src="https://img.shields.io/badge/ghcr-latest-2496ED?logo=docker&logoColor=white"></a>
@@ -220,7 +220,7 @@ Cron 定时执行（默认每日 08:00），智能解析奖励金额，签到失
 | 层 | 技术 |
 |----|------|
 | 后端 | [chi](https://github.com/go-chi/chi) 路由 + `net/http` |
-| 语言 | Go 1.26.5 |
+| 语言 | Go 1.26.6 |
 | 数据库 | SQLite / PostgreSQL + [sqlx](https://github.com/jmoiron/sqlx)；可选 Redis 仅用于 RPM/TPM admission（非必需） |
 | 定时任务 | [robfig/cron](https://github.com/robfig/cron) |
 | 容器化 | Docker（Alpine，15MB 镜像） |

--- a/README_EN.md
+++ b/README_EN.md
@@ -18,7 +18,7 @@
   <a href="https://github.com/DeliciousBuding/metapi-go/releases/latest"><img alt="Release" src="https://img.shields.io/github/v/release/DeliciousBuding/metapi-go?logo=github&label=release&color=blue"></a>
   <a href="https://github.com/DeliciousBuding/metapi-go/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/DeliciousBuding/metapi-go?style=social"></a>
   <a href="https://github.com/DeliciousBuding/metapi-go/forks"><img alt="Forks" src="https://img.shields.io/github/forks/DeliciousBuding/metapi-go?style=social"></a>
-  <img alt="Go" src="https://img.shields.io/badge/Go-1.26.5-00ADD8?logo=go">
+  <img alt="Go" src="https://img.shields.io/badge/Go-1.26.6-00ADD8?logo=go">
   <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react">
   <img alt="Bun" src="https://img.shields.io/badge/Bun-≥1.0-000000?logo=bun&logoColor=white">
   <a href="https://github.com/DeliciousBuding/metapi-go/pkgs/container/metapi-go"><img alt="Docker" src="https://img.shields.io/badge/ghcr-latest-2496ED?logo=docker&logoColor=white"></a>
@@ -68,7 +68,7 @@ Open `http://localhost:4000`.
 | Layer | Technology |
 |------|------|
 | Backend | [chi](https://github.com/go-chi/chi) router + `net/http` |
-| Language | Go 1.26.5 |
+| Language | Go 1.26.6 |
 | Database | SQLite / PostgreSQL + [sqlx](https://github.com/jmoiron/sqlx); optional Redis for RPM/TPM admission only |
 | Scheduling | [robfig/cron](https://github.com/robfig/cron) |
 | Container | Docker (Alpine, 15MB image) |

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -18,7 +18,7 @@
 | Production pin (ops) | **v0.9.0** image on `ghcr.io/deliciousbuding/metapi-go`; runtime deployment facts live in the deployment docs |
 | Current focus | production hardening |
 | Open issues / PRs | [#557](https://github.com/DeliciousBuding/metapi-go/issues/557) · [#558](https://github.com/DeliciousBuding/metapi-go/issues/558) |
-| Stack | Go 1.26.5 · React 19 + Bun + Rsbuild 2 + TanStack Router/Query/Table + Tailwind 4 + shadcn Base UI + OKLCH + i18next · dual dialect SQLite/PostgreSQL |
+| Stack | Go 1.26.6 · React 19 + Bun + Rsbuild 2 + TanStack Router/Query/Table + Tailwind 4 + shadcn Base UI + OKLCH + i18next · dual dialect SQLite/PostgreSQL |
 | Runtime shape | single embedded SPA binary · **16** background schedulers · OAuth callback listeners start only with an active flow |
 | Brand | **MetAPI** · transparent solid-blue SVG badge `web/public/logo.svg` (real U+03C0 π glyph) + `favicon.svg` · served from the embedded SPA root by the router whitelist |
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,7 +5,7 @@
 ## Prerequisites
 
 - Docker (for containerized deployment)
-- Go 1.26.5+ (for bare-metal deployment)
+- Go 1.26.6+ (for bare-metal deployment)
 - Bun 1.x (for frontend build)
 - PostgreSQL 16+ (optional, for production database)
 - A reverse proxy (nginx or Caddy) with TLS

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -14,7 +14,7 @@ The migration involves:
 
 ## Prerequisites
 
-- Go 1.26.5+ installed
+- Go 1.26.6+ installed
 - Built `metapi-migrate` binary: `make migrate-build`
 - PostgreSQL 16+ running (if migrating to PG)
 - Backed up your existing SQLite database

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/deliciousbuding/metapi-go
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/coder/websocket v1.8.15


### PR DESCRIPTION
## Summary

`govulncheck` began flagging 6 reachable Go standard-library vulnerabilities in `go1.26.5` (net/url quadratic complexity, crypto/tls, net/http, encoding/xml, encoding/asn1). All six are fixed in `go1.26.6`.

This bumps the Go toolchain across:

- `go.mod` (`go 1.26.6`)
- `Dockerfile` build image (`golang:1.26.6-alpine`)
- `README.md` / `README_EN.md` badges + stack tables
- `docs/STATE.md`, `docs/deployment.md`, `docs/migration.md`

No dependency changes; `go.sum` unchanged.
