### PR TITLE
chore(web): drop stale subagent-decomposition comments

### DIFF
--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -11,7 +11,6 @@ import {
 import { HugeiconsIcon } from '@hugeicons/react'
 import * as React from 'react'
 
-// TODO: depends on @/hooks (useMediaQuery) — provided by other subagent (hooks layer)
 import { useMediaQuery } from '@/hooks'
 import { cn } from '@/lib/utils'
 

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -26,7 +26,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-// TODO: depends on @/hooks/use-mobile (useIsMobile) — provided by other subagent (hooks layer)
 import { useIsMobile } from '@/hooks/use-mobile'
 import { cn } from '@/lib/utils'
 

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -11,7 +11,6 @@ import {
 import { HugeiconsIcon } from '@hugeicons/react'
 import { Toaster as Sonner, type ToasterProps } from 'sonner'
 
-// TODO: depends on @/context/theme-provider (useTheme) — provided by other subagent (context layer)
 import { useTheme } from '@/context/theme-provider'
 
 const Toaster = (props: ToasterProps) => {

--- a/web/src/features/checkin/types.ts
+++ b/web/src/features/checkin/types.ts
@@ -1,7 +1,7 @@
 // metapi-go features/checkin — entity types & runtime schemas.
 //
 // The checkin API (GET /api/checkin/logs) returns a flat JSON array whose
-// elements are *nested* objects — the F-subagent shape regression fix:
+// elements are *nested* objects — the shape regression fix:
 //
 //   {
 //     "checkin_logs": { id, accountId, status, message, reward, createdAt },

--- a/web/src/features/token-routes/components/route-completion-toast.tsx
+++ b/web/src/features/token-routes/components/route-completion-toast.tsx
@@ -3,8 +3,7 @@
 // of the site → account → route guided configuration chain.
 //
 // Navigation uses window.location.assign rather than TanStack Router's
-// type-safe `navigate` because the dashboard route registration is owned by
-// another subagent; a hard navigation keeps the deep-link working today.
+// type-safe `navigate`; a hard navigation keeps the deep-link working today.
 
 import i18n from '@/i18n/config'
 import { toast } from '@/lib/toast'


### PR DESCRIPTION
## Summary

Remove 5 stale comments left over from the parallel-subagent decomposition
phase. That decomposition was consolidated long ago, so references to a
hooks/context "layer provided by another subagent" are now just ordinary
imports and are actively misleading.

Changes (comment-only, no behavior change):

- `web/src/components/ui/select.tsx` — drop stale "useMediaQuery provided by other subagent" TODO
- `web/src/components/ui/sidebar.tsx` — drop stale "useIsMobile provided by other subagent" TODO
- `web/src/components/ui/sonner.tsx` — drop stale "useTheme provided by other subagent" TODO
- `web/src/features/checkin/types.ts` — reword "F-subagent shape regression fix" → "shape regression fix"
- `web/src/features/token-routes/components/route-completion-toast.tsx` — drop stale "owned by another subagent" rationale

No secrets, no host paths, no logic change.
