### PR TITLE
chore(release): prepare v0.12.0 + reconcile docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.12.0] — 2026-08-14
+
+### Removed（架构简化：净删 ~21,000 行，Go 170K→150K）
+
+- 删除 test-only 的 canonical 转换层（`transform/canonical` + `transform/openai/chat` + `transform/anthropic/messages`，~6,600 行）——生产唯一跨协议路径（OpenAI→Gemini）为原生直连，绕过 canonical（#652）
+- 删除三套测试专用编排层（`proxy/conductor.go`、`SurfaceFailureToolkit`、`ExecuteEndpointFlow`）——生产实为 `handler/proxy/upstream.go` 内的手写重试循环（#653）
+- 删除未激活的 lease/sticky 会话队列机制、`routing/workflow.go` stub、`routing/snapshot.go` 死实现（`SnapshotDB` 接口保留，由 `service.ProxyRoutingStore` 实现）（#653）
+- 删除死 facade/符号：`app/prometheus.go` 11 个包装、`handler/shared` 半套 metrics/errors、`proxy/input_files.go`、`platform` 检测管线（`detect.go`/`InitRegistry`）、`service/adapter` 桥接、`service/proxy_util.go`、`DeployHelperToken`、`store.Migrate` 重复调用等（#650/#652/#651）
+- 前端删除 14 个未使用 shadcn 组件 + ~101 个未使用 i18n key + 空 barrel（#654）
+
+### Fixed
+
+- **cmd/migrate 静默丢数据**：离线迁移工具自维护 schema 副本且已漂移（`sites` 漏 7 列等），改为复用 `store.AutoMigrate` 并新增运行时漂移守卫 `TestBuildersMatchStoreSchema`，漂移永不再发生（#651）
+- **app 垃圾抽屉**：`app/proxy_upstream.go`（801 行 DB 访问层，违反 BACKEND.md「app 不得承载业务逻辑」）移入 `service/routing_store.go`（#651）
+- **store/switch.go 运行时切换丢配置**：`SwitchDatabase` 走旧 `Open()` 丢 `DB_SSLMODE` 与连接池预算，改为透传 `cfg.PostgresSSLMode()` + `postgresPoolConfigFromRuntimeConfig`（#651）
+
+### Changed（去重 + 标准化）
+
+- 手写 stdlib 重实现全部替换为标准库：Hinnant 日历算法→`time.UnixMilli().Format()`、手写 `formatInt/parseInt64/jsonMarshal`→`strconv`/`encoding/json`、`stringsTrimSpace`→`strings.TrimSpace`、`min64/max64`→内建 `min`/`max`（#653）
+- handler 去重：mask/coerce/coalesce 家族、`shared.WriteJSON`（删掉手写 JSON 序列化器）、`pathID`、`parseLimitOffset`、统一 `decodeJSONRequest` 与 `writeError` 错误响应（#650）
+- routing 去重：cooldown 决策树 ×4 收敛为 `resolveCooldownUpdate`、eligibility 双实现收敛（修复 admin 解释缺失 OAuth/token 检查的真值 bug）、breaker 过滤器 API 收敛（#653）
+- scheduler 去重：ticker 循环 ×11 收敛为 `intervalRunner`、retention ×3 收敛为 `NewRetentionScheduler`（#651）
+- platform 去重：balance/checkin/model-list 解析各 ×4 收敛为 `base.go` 共享 helper（#652）
+- god-file 拆分：`handler/admin/*`、`handler/proxy/upstream.go`、`routing/*`、`store/migrate.go`、`platform/newapi.go`/`sub2api.go`、前端 `lib/api.ts`（1997 行→10 个域模块 + 兼容 barrel）（#650/#652/#653/#654）
+
 ## [v0.11.0] — 2026-08-14
 
 ### Added

--- a/docs/analysis/package-boundaries.md
+++ b/docs/analysis/package-boundaries.md
@@ -36,10 +36,10 @@ This document is the **B1 ownership inventory**. It does **not** rewrite package
 | `store` | Dual-dialect open/migrate/schema/settings, `GetDB` | Auth, HTTP handlers, routing selection | auth, routing, service, scheduler, app, router |
 | `auth` | Admin/proxy middleware, downstream key policy, rate limits | Proxy orchestration, admin CRUD | `router`, `handler/proxy` |
 | `platform` | Upstream adapters + site HTTP proxy helpers | Persistence, route selection, admin HTTP | `service/*`, some `handler/*`, thin `proxy` |
-| `transform/*` | Protocol conversion (canonical intermediate) | HTTP, store, routing | **currently leaf-only** (see §5.4) |
+| `transform/*` | Protocol conversion (native per protocol; no canonical IR) | HTTP, store, routing | **currently leaf-only** (see §5.4) |
 | `routing` | TokenRouter, matcher, weights, cooldown, site breaker, ports | HTTP handlers, proxy conductor | `proxy`, `handler/*`, `app` wiring |
 | `service` (+ subpkgs) | Domain workflows (sites/accounts/checkin/balance/notify/oauth/backup/…) | Chi routes, proxy surface formatting | `handler/*`, `scheduler`, `proxy` |
-| `proxy` (+ `profiles`, `types`) | Conductor, session leases, retry, failure judge, site concurrency | Admin REST, SPA | `handler/proxy`, `app` |
+| `proxy` (+ `profiles`, `types`) | Coordinator, executor, channel selection, retry policy | Admin REST, SPA | `handler/proxy`, `app` |
 | `handler/shared` | Shared admin/proxy error + metrics helpers (HTTP-shaped) | Domain services | `handler/*`, `app` metrics export |
 | `handler/admin` | `/api/*` REST registrars + payloads | Router middleware stack, SPA | `router` |
 | `handler/proxy` | `/v1/*` and non-v1 proxy surfaces | Admin CRUD, cron registry | `router` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,12 +1,12 @@
 # Architecture Overview
 
-**Last updated**: 2026-08-11
+**Last updated**: 2026-08-14
 
 > **Navigation**: full docs map in [`docs/README.md`](README.md) · open items in [`progress/MASTER.md`](progress/MASTER.md).
 
 MetAPI Go is a ground-up rewrite of the TypeScript MetAPI proxy gateway in Go. This document describes the **as-built** package layout, request paths, and key design decisions. Design philosophy and package dependency rules live in [`docs/design/BACKEND.md`](design/BACKEND.md).
 
-> **Naming truth:** There is **no** `proxycore/` or `protocol/` package in this repository. The proxy engine is `proxy/` (with `proxy/profiles` and `proxy/types`). Protocol conversion is `transform/` (with `transform/canonical`, `openai`, `anthropic`, `gemini`, `shared`). Older docs or TS-era names that say “ProxyCore package” or “protocol package” refer to these real packages.
+> **Naming truth:** There is **no** `proxycore/` or `protocol/` package in this repository. The proxy engine is `proxy/` (with `proxy/profiles` and `proxy/types`). Protocol conversion is `transform/` (with `openai` [completions/embeddings/images/responses], `gemini`, and `shared`). There is **no** `transform/canonical` intermediate layer — cross-protocol conversion is native (e.g. OpenAI→Gemini) and bypasses any canonical representation. Older docs or TS-era names that say “ProxyCore package” or “protocol package” refer to these real packages.
 
 ## High-Level Architecture
 
@@ -29,9 +29,9 @@ MetAPI Go is a ground-up rewrite of the TypeScript MetAPI proxy gateway in Go. T
                  │              │
          ┌───────▼──────────────▼───────┐
          │           proxy/              │
-         │  Conductor → Session → Retry  │
-         │  ChannelSelection → Endpoint  │
-         │  FailureJudge → Surface       │
+         │  Coordinator · Executor       │
+         │  ChannelSelection · Retry     │
+         │  Profiles · Failure policy    │
          └──────────────┬───────────────┘
                         │
          ┌──────────────▼───────────────┐
@@ -42,8 +42,8 @@ MetAPI Go is a ground-up rewrite of the TypeScript MetAPI proxy gateway in Go. T
                         │
          ┌──────────────▼───────────────┐
          │        transform/             │
-         │  OpenAI / Anthropic / Gemini  │
-         │  via canonical intermediate   │
+         │  OpenAI / Gemini (native)     │
+         │  shared stream helpers        │
          └──────────────┬───────────────┘
                         │
          ┌──────────────▼───────────────┐
@@ -72,16 +72,14 @@ metapi-go/
 │   ├── admin/              # Admin REST handlers (+ payloads/)
 │   ├── proxy/              # /v1/* proxy surface handlers
 │   └── shared/             # Shared API error helpers
-├── proxy/                  # Dual-loop proxy orchestration (NOT "proxycore/")
+├── proxy/                  # Proxy orchestration (NOT "proxycore/")
 │   ├── profiles/           # Client/profile detection (Claude Code, Codex, Gemini CLI, …)
 │   └── types/              # Shared proxy types
 ├── routing/                # TokenRouter: match, weights, cooldown, site runtime breaker
 ├── platform/               # Upstream platform adapters (14) + site proxy
-├── transform/              # Protocol transformers (NOT "protocol/")
-│   ├── canonical/          # Shared intermediate representation
-│   ├── openai/             # chat, completions, embeddings, images, responses
-│   ├── anthropic/          # messages
-│   ├── gemini/             # generate_content
+├── transform/              # Protocol transformers (NOT "protocol/"; no canonical IR)
+│   ├── openai/             # completions, embeddings, images, responses
+│   ├── gemini/             # generate_content (native OpenAI→Gemini bridge)
 │   └── shared/             # Cross-protocol helpers
 ├── service/                # Domain services (sites, accounts, checkin, balance, notify, oauth, backup, …)
 ├── scheduler/              # Background cron jobs (checkin, balance, recovery, retention, …)
@@ -109,10 +107,10 @@ metapi-go/
 | `config` | Env → `Config` (names match TS; no `METAPI_` prefix) |
 | `handler/admin` | Admin CRUD + settings + ops endpoints |
 | `handler/proxy` | Protocol surfaces under `/v1/*` |
-| `proxy` | Orchestration: channel pick, session lease, retry, failure judge |
+| `proxy` | Coordinator + executor + channel selection + retry policy (the request loop itself lives in `handler/proxy/upstream.go`) |
 | `routing` | Model/route match, weighted selection, Fibonacci cooldown, site breaker |
 | `platform` | Per-upstream adapter behavior (detect, auth headers, admin APIs) |
-| `transform` | Request/response (+ SSE) conversion via canonical model |
+| `transform` | Request/response (+ SSE) conversion, native per protocol (no canonical intermediate) |
 | `service` | Business workflows used by handlers and schedulers |
 | `scheduler` | Cron-driven background work |
 | `store` | Dual-dialect persistence |
@@ -131,11 +129,10 @@ Client → /v1/chat/completions (or messages / generateContent / …)
   → routing selector (weights / round-robin / stable-first)
       · skip cooldown channels
       · skip open site/model runtime breakers
-  → proxy.Conductor.Execute
+  → handler/proxy upstream loop (per-attempt retry in `upstream.go`)
       → profile detect (proxy/profiles)
-      → session lease / sticky preference
-      → endpoint flow + retry policy
-          → transform (client format ↔ provider format via canonical)
+      → endpoint dispatch + retry policy (proxy.retry_policy)
+          → transform (client format ↔ provider format, native per protocol)
           → HTTP to upstream (platform-aware headers / site proxy)
           → transform response / SSE
       → failure judge (content + policy)
@@ -200,7 +197,7 @@ Routing isolates bad channels instead of cascading:
 - **Per-channel cooldown** — Fibonacci backoff on failures (`routing` cooldown helpers).
 - **Site runtime breaker** — streak-based open periods at site and model granularity (`SiteRuntimeBreakerLevelsMs`).
 - **Selection filters** — open breakers and recent failures are removed before weighted/round-robin pick.
-- **Proxy failover** — conductor can retry same channel, refresh auth, or failover to the next channel without taking the whole gateway down.
+- **Proxy failover** — the request loop can retry the same channel, refresh auth, or failover to the next channel without taking the whole gateway down.
 
 ### 6. Config via env, TS-compatible names
 
@@ -223,7 +220,7 @@ routing → store, config
 service → platform, store, config, service/*
 scheduler → service/*, store, config
 platform → (leaf; no store/handler imports)
-transform/* → transform/canonical, transform/shared (leaf protocol layer)
+transform/* → transform/shared (leaf protocol layer)
 store → config
 config, web, handler/shared → leaves
 ```
@@ -236,7 +233,7 @@ config, web, handler/shared → leaves
 - **U** (understandable): real names match code (`proxy`, `transform`, `routing`)
 - **P** (pluggable): platform adapters and protocol transforms register/compose independently
 - **E** (environment-agnostic): SQLite or PostgreSQL via dialect store
-- **R** (replaceable): conductor dependencies and adapters are injectable/replaceable
+- **R** (replaceable): coordinator dependencies and platform adapters are injectable/replaceable
 
 ## Related docs
 

--- a/docs/design/BACKEND.md
+++ b/docs/design/BACKEND.md
@@ -50,7 +50,7 @@ Gateway resilience is **per channel / per site**, not process-wide suicide:
 | Fibonacci failure cooldown | `routing` | Back off a bad channel without blackholing the fleet |
 | Recent-failure filters | `routing` selector | Prefer healthy candidates in the current pick |
 | Site/model runtime breaker | `routing` runtime health | Open breaker after streak; tiered open windows |
-| Conductor failover | `proxy` | Retry same channel, refresh auth, or move to next channel |
+| Channel failover | `handler/proxy` loop + `proxy` retry policy | Retry same channel, refresh auth, or move to next channel |
 | Content failure judge | `proxy` | Detect “HTTP 200 but empty/error body” without trusting status alone |
 
 Rules of thumb:
@@ -115,7 +115,7 @@ Arrows mean **“may import”**. Edges not shown are forbidden unless listed un
 | `handler/shared` | — | domain packages |
 | `store` | `config` | `handler`, `proxy`, `router`, `scheduler`, `service`, `auth` |
 | `platform` | — (leaf adapters) | `store`, `handler`, `proxy`, `router`, `scheduler` |
-| `transform/*` | `transform/canonical`, `transform/shared` | `handler`, `store`, `proxy`, `routing`, `service` |
+| `transform/*` | `transform/shared` | `handler`, `store`, `proxy`, `routing`, `service` |
 | `proxy/types`, `proxy/profiles` | `proxy/types` only (profiles) | upper layers |
 | `routing` | `config`, `store` | `handler`, `proxy`, `router`, `scheduler`, `service` |
 | `auth` | `config`, `store` | `handler`, `proxy`, `router` |

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,13 @@
 > Product milestone timeline (grouped by version). Not the current-state source of truth.
 > Current state → [`STATE.md`](STATE.md) · open items → [`progress/MASTER.md`](progress/MASTER.md) · detailed version narrative → root [`CHANGELOG.md`](../CHANGELOG.md)
 
+## 2026-08-14 — v0.12.0 架构简化（净删 ~21K 行）
+
+- **死代码大清扫**（#650–#653，5 个 PR）：删 test-only 的 canonical 转换层（~6.6K）、三套测试专用编排层（conductor/surface/endpoint_flow）、未激活的 lease/sticky 队列、死 facade（app/prometheus、shared 半套 metrics/errors、input_files、检测管线、service/adapter 桥接）；Go 170K→150K，无生产行为变化
+- **数据完整性修复**：cmd/migrate 自维护 schema 副本已漂移（sites 漏 7 列）→ 复用 store.AutoMigrate + 运行时漂移守卫；app/proxy_upstream.go 垃圾抽屉移入 service/routing_store.go
+- **去重 + 标准化**：手写 stdlib 重实现（Hinnant 日历/JSON/int/TrimSpace）→ 标准库；handler/routing/scheduler/platform 各去重 3-11 份复制；god-file 按自然接缝拆分（含前端 api.ts 1997→10 模块）
+- **文档对账**：architecture/BACKEND/package-boundaries 同步为 as-built 真相（无 canonical、无 Conductor 编排）
+
 ## 2026-08-14 — v0.11.0 管理控制台 UI/UX 全量 + 开源打磨
 
 - **管理控制台 UI/UX 与功能全量交付**（#594–#626，合并为 #633/#634）：共享格式化器、状态/空态组件、toast、CountUp、响应式 data-table + 移动端降级、无障碍、token 列脱敏、可观测性工作台（Overview/Health/Proxy Logs）、站点探测 + 统一导入向导、模型定价/价格对比/重定向修复、通道只读列表 + probe 驱动重建过滤

--- a/docs/package_boundary_test.go
+++ b/docs/package_boundary_test.go
@@ -156,7 +156,7 @@ func forbiddenImport(pkg, imp string) string {
 			return "rule 2: platform ↛ store/handler/proxy/router/scheduler (only config + proxy/profiles)"
 		}
 	case "transform":
-		// Allowed: transform/canonical, transform/shared, and same-protocol siblings.
+		// Allowed: transform/shared, and same-protocol siblings.
 		if impTop == "transform" {
 			return "" // leaf cluster
 		}

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metapi",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "description": "Meta-layer management and unified proxy for AI API aggregation platforms",
   "keywords": [


### PR DESCRIPTION
## Summary
- CHANGELOG v0.12.0 section (architecture simplification: net -21K lines) + web/package.json 0.12.0 bump.
- Reconcile docs with the simplified as-built: remove deleted canonical/Conductor/session-lease references from architecture.md, BACKEND.md, package-boundaries.md, package_boundary_test.go.
- docs/log.md v0.12.0 milestone entry.

## Test plan
- Docs-only + version bump; go build + docs tests green.