### PR TITLE
feat(web): global search command palette (Ctrl/Cmd+K)

### DIFF
--- a/web/src/components/layout/components/app-header.tsx
+++ b/web/src/components/layout/components/app-header.tsx
@@ -1,7 +1,13 @@
 // metapi-go/layout — application header.
-// Brand on the left; shared language, appearance, and color-scheme controls on the right.
+// Brand on the left; global-search trigger plus the shared language,
+// appearance, and color-scheme controls on the right.
+
+import { Search } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 import { InterfaceControls } from '@/components/layout/components/interface-controls'
+import { Button } from '@/components/ui/button'
+import { isMacPlatform, Kbd } from '@/components/ui/kbd'
 import { SidebarTrigger } from '@/components/ui/sidebar'
 import { metapiIdentity } from '@/lib/identity-branding'
 import { cn } from '@/lib/utils'
@@ -13,12 +19,36 @@ type AppHeaderProps = {
   leftContent?: React.ReactNode
   /** Custom right content, overrides the default interface controls if provided. */
   rightContent?: React.ReactNode
+  /** Called when the global-search trigger is clicked. */
+  onSearchClick?: () => void
+}
+
+function SearchTrigger({ onClick }: { onClick?: () => void }) {
+  const { t } = useTranslation()
+  const modifierKey = isMacPlatform() ? '⌘' : 'Ctrl'
+
+  return (
+    <Button
+      variant='outline'
+      className='text-muted-foreground dark:border-input dark:bg-input/30 h-8 gap-2 px-2.5 font-normal'
+      onClick={onClick}
+      aria-label={t('search.trigger')}
+    >
+      <Search className='size-4' />
+      <span className='hidden md:inline'>{t('search.trigger')}</span>
+      <span className='hidden items-center gap-1 md:flex'>
+        <Kbd>{modifierKey}</Kbd>
+        <Kbd>K</Kbd>
+      </span>
+    </Button>
+  )
 }
 
 export function AppHeader({
   showThemeToggle = true,
   leftContent,
   rightContent,
+  onSearchClick,
 }: AppHeaderProps) {
   return (
     <header
@@ -44,10 +74,10 @@ export function AppHeader({
       )}
 
       {rightContent ?? (
-        <InterfaceControls
-          className='ms-auto'
-          showThemeToggle={showThemeToggle}
-        />
+        <div className='ms-auto flex items-center gap-1'>
+          <SearchTrigger onClick={onSearchClick} />
+          <InterfaceControls showThemeToggle={showThemeToggle} />
+        </div>
       )}
     </header>
   )

--- a/web/src/components/layout/components/authenticated-layout.tsx
+++ b/web/src/components/layout/components/authenticated-layout.tsx
@@ -1,10 +1,14 @@
 // metapi-go/layout — authenticated-layout adapted from newapi. AGPL header stripped.
 // SidebarProvider + SkipToMain + AppHeader + flex row (AppSidebar + SidebarInset).
 // Uses <Outlet /> from TanStack Router so matched child routes (/dashboard/*, /sites,
-// /accounts, /settings/*, ...) render inside SidebarInset.
+// /accounts, /settings/*, ...) render inside SidebarInset. Also owns the global
+// search palette state and mounts SearchModal here (inside the router, since
+// result clicks navigate).
 
 import { Outlet } from '@tanstack/react-router'
+import * as React from 'react'
 
+import { SearchModal } from '@/components/layout/search-modal'
 import { SkipToMain } from '@/components/skip-to-main'
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
 import { getCookie } from '@/lib/cookies'
@@ -15,11 +19,12 @@ import { AppSidebar } from './app-sidebar'
 
 export function AuthenticatedLayout() {
   const defaultOpen = getCookie('sidebar_state') !== 'false'
+  const [searchOpen, setSearchOpen] = React.useState(false)
 
   return (
     <SidebarProvider defaultOpen={defaultOpen} className='flex-col'>
       <SkipToMain />
-      <AppHeader />
+      <AppHeader onSearchClick={() => setSearchOpen(true)} />
       <div className='flex min-h-0 w-full flex-1 [--app-header-height:3.5rem]'>
         <AppSidebar />
         <SidebarInset
@@ -34,6 +39,7 @@ export function AuthenticatedLayout() {
           <Outlet />
         </SidebarInset>
       </div>
+      <SearchModal open={searchOpen} onOpenChange={setSearchOpen} />
     </SidebarProvider>
   )
 }

--- a/web/src/components/layout/search-modal.tsx
+++ b/web/src/components/layout/search-modal.tsx
@@ -1,0 +1,372 @@
+// metapi-go/layout — global search command palette (⌘K / Ctrl+K).
+//
+// A cmdk-based palette over the backend `POST /api/search` endpoint. The
+// trigger button lives in `app-header.tsx`; this component is mounted once
+// in `AuthenticatedLayout` (inside the router, because result clicks use
+// `useNavigate`) and owns:
+//   - the global ⌘K/Ctrl+K toggle (registered once, never hijacked inside
+//     editable targets),
+//   - a ~250 ms debounced search against `searchApi.search`,
+//   - grouped rendering of the six result categories (8 items max each).
+//
+// cmdk's own filtering is disabled (`shouldFilter={false}`): results are
+// already filtered by the backend, so empty/loading/hint states are rendered
+// explicitly instead of relying on cmdk's Empty semantics.
+
+import { useNavigate } from '@tanstack/react-router'
+import {
+  Boxes,
+  CalendarCheck,
+  Globe,
+  KeyRound,
+  ScrollText,
+  Search as SearchIcon,
+  UserRound,
+  type LucideIcon,
+} from 'lucide-react'
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  Command,
+  CommandDialog,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import { Spinner } from '@/components/ui/spinner'
+import {
+  searchApi,
+  type SearchAccount,
+  type SearchAccountToken,
+  type SearchCheckinLog,
+  type SearchModel,
+  type SearchProxyLog,
+  type SearchResponse,
+  type SearchSite,
+} from '@/lib/api/search'
+
+const SEARCH_DEBOUNCE_MS = 250
+const MAX_ITEMS_PER_GROUP = 8
+
+type SearchModalProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+type SearchItem = {
+  key: string
+  label: string
+  description: string | null
+  onSelect: () => void
+}
+
+type SearchGroup = {
+  key: string
+  heading: string
+  icon: LucideIcon
+  items: SearchItem[]
+}
+
+function isEditableTarget(target: HTMLElement): boolean {
+  const tagName = target.tagName
+  if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT') {
+    return true
+  }
+  return target.isContentEditable
+}
+
+function firstNonEmpty(
+  ...values: Array<string | null | undefined>
+): string | null {
+  for (const value of values) {
+    const trimmed = value?.trim()
+    if (trimmed) return trimmed
+  }
+  return null
+}
+
+export function SearchModal(props: SearchModalProps) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+
+  const [query, setQuery] = React.useState('')
+  const [results, setResults] = React.useState<SearchResponse | null>(null)
+  const [isSearching, setIsSearching] = React.useState(false)
+
+  const trimmedQuery = query.trim()
+  const hasQuery = trimmedQuery.length > 0
+
+  // Keep the latest open state in a ref so the global shortcut listener is
+  // registered exactly once and still sees fresh values.
+  const openRef = React.useRef(props.open)
+  const onOpenChangeRef = React.useRef(props.onOpenChange)
+
+  React.useEffect(() => {
+    openRef.current = props.open
+    onOpenChangeRef.current = props.onOpenChange
+  })
+
+  // Global Ctrl/Cmd+K toggle. Skipped inside editable targets so the
+  // shortcut never hijacks typing in inputs, textareas or the palette's own
+  // search field.
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.repeat || event.key.toLowerCase() !== 'k') return
+      if (!event.metaKey && !event.ctrlKey) return
+      if (
+        event.target instanceof HTMLElement &&
+        isEditableTarget(event.target)
+      ) {
+        return
+      }
+      event.preventDefault()
+      onOpenChangeRef.current(!openRef.current)
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [])
+
+  // Reset transient state whenever the palette closes so the next open
+  // starts from the hint state instead of stale results.
+  React.useEffect(() => {
+    if (!props.open) {
+      setQuery('')
+      setResults(null)
+      setIsSearching(false)
+    }
+  }, [props.open])
+
+  // Debounced backend search. The cleanup aborts in-flight requests and
+  // drops stale responses when the query changes or the palette unmounts.
+  React.useEffect(() => {
+    if (!trimmedQuery) {
+      setResults(null)
+      setIsSearching(false)
+      return
+    }
+
+    const controller = new AbortController()
+    let disposed = false
+
+    const timeoutId = window.setTimeout(() => {
+      setIsSearching(true)
+      searchApi
+        .search(trimmedQuery, { signal: controller.signal })
+        .then((response) => {
+          if (!disposed) setResults(response)
+        })
+        .finally(() => {
+          if (!disposed) setIsSearching(false)
+        })
+        .catch(() => {
+          // Failures are toasted by the shared http-client error handler;
+          // reset to the empty state here.
+          if (!disposed) setResults(null)
+        })
+    }, SEARCH_DEBOUNCE_MS)
+
+    return () => {
+      disposed = true
+      controller.abort()
+      window.clearTimeout(timeoutId)
+    }
+  }, [trimmedQuery])
+
+  const navigateToQueryPage = React.useCallback(
+    (to: '/sites' | '/accounts' | '/models') => {
+      props.onOpenChange(false)
+      navigate({ to, search: { q: trimmedQuery } })
+    },
+    [navigate, props, trimmedQuery]
+  )
+
+  const navigateToCheckin = React.useCallback(() => {
+    props.onOpenChange(false)
+    navigate({ to: '/checkin' })
+  }, [navigate, props])
+
+  const navigateToProxyLogs = React.useCallback(() => {
+    props.onOpenChange(false)
+    navigate({ to: '/observability', search: { section: 'proxy-logs' } })
+  }, [navigate, props])
+
+  const groups = React.useMemo(() => {
+    if (!results) return []
+
+    const unknownLabel = t('search.unknown')
+
+    const siteItems: SearchItem[] = (results.sites ?? [])
+      .slice(0, MAX_ITEMS_PER_GROUP)
+      .map((site: SearchSite) => ({
+        key: `site-${site.id}`,
+        label: firstNonEmpty(site.name) ?? unknownLabel,
+        description: firstNonEmpty(site.url),
+        onSelect: () => navigateToQueryPage('/sites'),
+      }))
+
+    const accountItems: SearchItem[] = (results.accounts ?? [])
+      .slice(0, MAX_ITEMS_PER_GROUP)
+      .map((account: SearchAccount) => ({
+        key: `account-${account.id}`,
+        label: firstNonEmpty(account.username) ?? unknownLabel,
+        description: firstNonEmpty(account.siteName),
+        onSelect: () => navigateToQueryPage('/accounts'),
+      }))
+
+    const tokenItems: SearchItem[] = (results.accountTokens ?? [])
+      .slice(0, MAX_ITEMS_PER_GROUP)
+      .map((token: SearchAccountToken) => ({
+        key: `token-${token.id}`,
+        label: firstNonEmpty(token.name) ?? unknownLabel,
+        description: firstNonEmpty(token.accountUsername),
+        onSelect: () => navigateToQueryPage('/accounts'),
+      }))
+
+    const checkinItems: SearchItem[] = (results.checkinLogs ?? [])
+      .slice(0, MAX_ITEMS_PER_GROUP)
+      .map((log: SearchCheckinLog) => ({
+        key: `checkin-${log.id}`,
+        label:
+          firstNonEmpty(log.message, log.reward, log.status) ?? unknownLabel,
+        description: firstNonEmpty(log.accountUsername),
+        onSelect: navigateToCheckin,
+      }))
+
+    const proxyLogItems: SearchItem[] = (results.proxyLogs ?? [])
+      .slice(0, MAX_ITEMS_PER_GROUP)
+      .map((log: SearchProxyLog) => ({
+        key: `proxy-log-${log.id}`,
+        label:
+          firstNonEmpty(log.modelRequested, log.modelActual) ?? unknownLabel,
+        description: firstNonEmpty(log.status),
+        onSelect: navigateToProxyLogs,
+      }))
+
+    const modelItems: SearchItem[] = (results.models ?? [])
+      .slice(0, MAX_ITEMS_PER_GROUP)
+      .map((model: SearchModel) => ({
+        key: `model-${model.modelName}`,
+        label: firstNonEmpty(model.modelName) ?? unknownLabel,
+        description:
+          model.tokenCount != null
+            ? t('search.modelTokens', { count: model.tokenCount })
+            : null,
+        onSelect: () => navigateToQueryPage('/models'),
+      }))
+
+    const builtGroups: SearchGroup[] = [
+      {
+        key: 'sites',
+        heading: t('search.groups.sites'),
+        icon: Globe,
+        items: siteItems,
+      },
+      {
+        key: 'accounts',
+        heading: t('search.groups.accounts'),
+        icon: UserRound,
+        items: accountItems,
+      },
+      {
+        key: 'accountTokens',
+        heading: t('search.groups.tokens'),
+        icon: KeyRound,
+        items: tokenItems,
+      },
+      {
+        key: 'checkinLogs',
+        heading: t('search.groups.checkinLogs'),
+        icon: CalendarCheck,
+        items: checkinItems,
+      },
+      {
+        key: 'proxyLogs',
+        heading: t('search.groups.proxyLogs'),
+        icon: ScrollText,
+        items: proxyLogItems,
+      },
+      {
+        key: 'models',
+        heading: t('search.groups.models'),
+        icon: Boxes,
+        items: modelItems,
+      },
+    ]
+
+    return builtGroups.filter((group) => group.items.length > 0)
+  }, [results, t, navigateToCheckin, navigateToProxyLogs, navigateToQueryPage])
+
+  const showHint = !hasQuery && !isSearching
+  const showEmpty = hasQuery && !isSearching && groups.length === 0
+
+  return (
+    <CommandDialog
+      modal
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      title={t('search.title')}
+      description={t('search.description')}
+      className='sm:max-w-xl'
+    >
+      <Command shouldFilter={false}>
+        <CommandInput
+          autoFocus
+          value={query}
+          onValueChange={setQuery}
+          placeholder={t('search.placeholder')}
+        />
+        <CommandList className='max-h-[min(60svh,28rem)]'>
+          {isSearching && (
+            <div className='text-muted-foreground flex items-center justify-center gap-2 px-2 py-4 text-sm'>
+              <Spinner />
+              <span>{t('search.searching')}</span>
+            </div>
+          )}
+          {showHint && (
+            <div className='flex flex-col items-center gap-1 px-4 py-10 text-center'>
+              <SearchIcon className='text-muted-foreground/60 size-5' />
+              <p className='text-sm font-medium'>{t('search.empty.title')}</p>
+              <p className='text-muted-foreground text-xs'>
+                {t('search.empty.description')}
+              </p>
+            </div>
+          )}
+          {showEmpty && (
+            <div className='flex flex-col items-center gap-1 px-4 py-10 text-center'>
+              <p className='text-sm font-medium'>
+                {t('search.noResults.title')}
+              </p>
+              <p className='text-muted-foreground text-xs'>
+                {t('search.noResults.description', { query: trimmedQuery })}
+              </p>
+            </div>
+          )}
+          {groups.map((group) => (
+            <CommandGroup key={group.key} heading={group.heading}>
+              {group.items.map((item) => (
+                <CommandItem
+                  key={item.key}
+                  value={item.key}
+                  onSelect={item.onSelect}
+                >
+                  <group.icon className='text-muted-foreground size-4 shrink-0' />
+                  <span className='flex min-w-0 flex-1 flex-col'>
+                    <span className='truncate'>{item.label}</span>
+                    {item.description ? (
+                      <span className='text-muted-foreground truncate text-xs'>
+                        {item.description}
+                      </span>
+                    ) : null}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          ))}
+        </CommandList>
+      </Command>
+    </CommandDialog>
+  )
+}

--- a/web/src/components/ui/kbd.tsx
+++ b/web/src/components/ui/kbd.tsx
@@ -1,0 +1,29 @@
+// metapi-go/ui — keyboard key-cap badge (e.g. ⌘K hints), base-nova style.
+import { cn } from '@/lib/utils'
+
+/**
+ * Detect whether the current platform uses the macOS key convention (⌘)
+ * instead of Ctrl. `navigator.platform` is deprecated but universally
+ * supported; fall back to the user agent string when it is empty.
+ */
+export function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false
+  const platform = navigator.platform || ''
+  if (platform) return /mac|iphone|ipad|ipod/i.test(platform)
+  return /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent)
+}
+
+function Kbd({ className, ...props }: React.ComponentProps<'kbd'>) {
+  return (
+    <kbd
+      data-slot='kbd'
+      className={cn(
+        'bg-muted text-muted-foreground pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm border px-1 font-sans text-xs font-medium select-none',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Kbd }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2124,6 +2124,31 @@
         "endpointCopied": "Endpoint copied",
         "jsonCopied": "Configuration copied"
       }
+    },
+    "search": {
+      "trigger": "Search…",
+      "placeholder": "Search sites, accounts, tokens, models, logs…",
+      "title": "Global search",
+      "description": "Search across sites, accounts, tokens, models, check-in and proxy logs.",
+      "searching": "Searching…",
+      "unknown": "Unknown",
+      "modelTokens": "{{count}} tokens",
+      "empty": {
+        "title": "Search everything",
+        "description": "Find sites, accounts, tokens, models, check-in and proxy logs."
+      },
+      "noResults": {
+        "title": "No results",
+        "description": "Nothing matched \"{{query}}\"."
+      },
+      "groups": {
+        "sites": "Sites",
+        "accounts": "Accounts",
+        "tokens": "Tokens",
+        "checkinLogs": "Check-in logs",
+        "proxyLogs": "Proxy logs",
+        "models": "Models"
+      }
     }
   }
 }

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2124,6 +2124,31 @@
         "endpointCopied": "接入地址已复制",
         "jsonCopied": "配置已复制"
       }
+    },
+    "search": {
+      "trigger": "搜索…",
+      "placeholder": "搜索站点、账号、令牌、模型、日志…",
+      "title": "全局搜索",
+      "description": "跨站点、账号、令牌、模型、签到与代理日志搜索。",
+      "searching": "搜索中…",
+      "unknown": "未知",
+      "modelTokens": "{{count}} 个令牌",
+      "empty": {
+        "title": "全局搜索",
+        "description": "可搜索站点、账号、令牌、模型、签到与代理日志。"
+      },
+      "noResults": {
+        "title": "无匹配结果",
+        "description": "没有找到与「{{query}}」匹配的内容。"
+      },
+      "groups": {
+        "sites": "站点",
+        "accounts": "账号",
+        "tokens": "令牌",
+        "checkinLogs": "签到日志",
+        "proxyLogs": "代理日志",
+        "models": "模型"
+      }
     }
   }
 }

--- a/web/src/lib/api/search.ts
+++ b/web/src/lib/api/search.ts
@@ -1,10 +1,84 @@
 import { request } from './transport'
 
+export type SearchSite = {
+  id: number
+  name: string
+  url?: string | null
+  platform?: string | null
+  status?: string | null
+}
+
+export type SearchAccount = {
+  id: number
+  username?: string | null
+  siteName?: string | null
+  sitePlatform?: string | null
+}
+
+export type SearchAccountToken = {
+  id: number
+  name: string
+  tokenMasked?: string | null
+  accountUsername?: string | null
+  siteName?: string | null
+}
+
+export type SearchCheckinLog = {
+  id: number
+  accountUsername?: string | null
+  status?: string | null
+  message?: string | null
+  reward?: string | null
+  createdAt?: string | null
+}
+
+export type SearchProxyLog = {
+  id: number
+  modelRequested?: string | null
+  modelActual?: string | null
+  status?: string | null
+  latencyMs?: number | null
+  totalTokens?: number | null
+  errorMessage?: string | null
+  createdAt?: string | null
+}
+
+export type SearchModel = {
+  modelName: string
+  tokenCount?: number | null
+  accountCount?: number | null
+  siteCount?: number | null
+}
+
+export type SearchResponse = {
+  sites: SearchSite[]
+  accounts: SearchAccount[]
+  accountTokens: SearchAccountToken[]
+  checkinLogs: SearchCheckinLog[]
+  proxyLogs: SearchProxyLog[]
+  models: SearchModel[]
+}
+
+export type SearchOptions = {
+  signal?: AbortSignal
+  /** Per-category result cap passed to the backend (clamped to 10 server-side). */
+  limit?: number
+}
+
+// The backend splits `limit` evenly across the six categories, so ask for
+// 6 × 10 to get the maximum of 10 hits per category (server-side cap) and
+// let the palette trim to its own display cap.
+const SEARCH_REQUEST_LIMIT = 60
+
 export const searchApi = {
   // Search
-  search: (query: string) =>
-    request('/api/search', {
+  search: (query: string, options?: SearchOptions) =>
+    request<SearchResponse>('/api/search', {
       method: 'POST',
-      body: JSON.stringify({ query, limit: 20 }),
+      body: JSON.stringify({
+        query,
+        limit: options?.limit ?? SEARCH_REQUEST_LIMIT,
+      }),
+      signal: options?.signal,
     }),
 }


### PR DESCRIPTION
全局搜索 ⌘K：SearchModal + Kbd 键帽 + header 入口，后端 `/api/search` 六类分组结果，防抖 + 请求取消 + 类型化响应。tsgo/oxlint/vitest/knip 全绿。