### PR TITLE
feat(web): dashboard home upgrade — today snapshot, StatCard icons, chart token

### DIFF
--- a/web/src/components/ui/icon-badge.tsx
+++ b/web/src/components/ui/icon-badge.tsx
@@ -1,0 +1,62 @@
+// metapi-go/ui — icon badge (soft solid-tone chip for stat cards / headers).
+//
+// Conceptually borrowed from newapi's icon-badge (quantumnous, AGPL) and
+// trimmed to the metapi-go semantic tokens. Solid soft fills only —
+// DESIGN.md §1 forbids gradients. Tones map 1:1 onto the OKLCH status tokens
+// declared in styles/theme.css, so every tone stays theme- and preset-aware.
+
+import { cva, type VariantProps } from 'class-variance-authority'
+import type { ReactNode } from 'react'
+
+import { cn } from '@/lib/utils'
+
+const iconBadgeVariants = cva(
+  'flex shrink-0 items-center justify-center [&>svg]:shrink-0',
+  {
+    variants: {
+      tone: {
+        default: 'bg-muted text-muted-foreground',
+        primary: 'bg-primary/10 text-primary',
+        success: 'bg-success/10 text-success',
+        warning: 'bg-warning/10 text-warning',
+        info: 'bg-info/10 text-info',
+        destructive: 'bg-destructive/10 text-destructive',
+      },
+      size: {
+        sm: 'size-7 rounded-md [&>svg]:size-3.5',
+        md: 'size-8 rounded-lg [&>svg]:size-4',
+        lg: 'size-10 rounded-xl [&>svg]:size-5',
+      },
+    },
+    defaultVariants: {
+      tone: 'default',
+      size: 'md',
+    },
+  }
+)
+
+type IconBadgeTone = NonNullable<VariantProps<typeof iconBadgeVariants>['tone']>
+type IconBadgeSize = NonNullable<VariantProps<typeof iconBadgeVariants>['size']>
+
+type IconBadgeProps = {
+  children?: ReactNode
+  tone?: IconBadgeTone
+  size?: IconBadgeSize
+  className?: string
+  /** Icons are decorative by default; the surrounding label carries meaning. */
+  decorative?: boolean
+}
+
+export function IconBadge(props: IconBadgeProps) {
+  return (
+    <span
+      className={cn(
+        iconBadgeVariants({ tone: props.tone, size: props.size }),
+        props.className
+      )}
+      aria-hidden={props.decorative ?? true}
+    >
+      {props.children}
+    </span>
+  )
+}

--- a/web/src/features/dashboard/components/stat-card.tsx
+++ b/web/src/features/dashboard/components/stat-card.tsx
@@ -6,10 +6,12 @@
 // VChart (canvas, needs useChartColors). This card renders a metric value +
 // an optional tiny area sparkline so the overview reads at a glance.
 //
-// Phase 2: values + sparkline data are stubbed by the overview section. Phase
-// 3 will feed real snapshot metrics (activeAccounts / sites / checkin success
-// / proxy 24h) from api.getDashboardSnapshot.
+// 2026-08 upgrade (audit ui-ux-2026-08): optional lucide icon rendered in an
+// IconBadge, an optional tone (default/success/warning) that maps the icon
+// badge onto the semantic status tokens, and an optional two-cell details
+// grid (label + value) for extra information density.
 
+import type { LucideIcon } from 'lucide-react'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Area, AreaChart } from 'recharts'
@@ -17,8 +19,17 @@ import { Area, AreaChart } from 'recharts'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ChartContainer, type ChartConfig } from '@/components/ui/chart'
 import { CountUp } from '@/components/ui/count-up'
+import { IconBadge } from '@/components/ui/icon-badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { cn } from '@/lib/utils'
+
+type StatCardTone = 'default' | 'success' | 'warning'
+
+type StatCardDetail = {
+  label: string
+  value: string
+  tone?: StatCardTone
+}
 
 type StatCardProps = {
   title: string
@@ -31,11 +42,23 @@ type StatCardProps = {
   accentClassName?: string
   /** Render skeleton placeholders while the metric is still loading. */
   loading?: boolean
-  /** Numeric value to animate (CountUp). When set, overrides the static alue string. */
+  /** Numeric value to animate (CountUp). When set, overrides the static value string. */
   valueNumber?: number
   /** Formatter applied to the animated numeric value. */
   valueFormat?: (value: number) => string
+  /** Optional lucide icon rendered in a soft badge next to the title. */
+  icon?: LucideIcon
+  /** Icon-badge tone mapped onto semantic tokens (default/success/warning). */
+  tone?: StatCardTone
+  /** Optional detail sub-cells (label + value) under the metric. */
+  details?: StatCardDetail[]
   className?: string
+}
+
+const DETAIL_TONE_CLASSES: Record<StatCardTone, string> = {
+  default: 'text-foreground',
+  success: 'text-success',
+  warning: 'text-warning',
 }
 
 const SPARK_CONFIG_BASE: ChartConfig = {
@@ -44,17 +67,7 @@ const SPARK_CONFIG_BASE: ChartConfig = {
   },
 }
 
-export function StatCard({
-  title,
-  value,
-  hint,
-  spark,
-  accentClassName,
-  loading = false,
-  valueNumber,
-  valueFormat,
-  className,
-}: StatCardProps) {
+export function StatCard(props: StatCardProps) {
   const { t } = useTranslation()
   const sparkConfig: ChartConfig = useMemo(
     () => ({
@@ -68,22 +81,30 @@ export function StatCard({
   )
   const data = useMemo(
     () =>
-      (spark ?? []).map((sample, index) => ({
+      (props.spark ?? []).map((sample, index) => ({
         index,
         value: sample,
       })),
-    [spark]
+    [props.spark]
   )
+  const Icon = props.icon
 
   return (
-    <Card className={cn('overflow-hidden', className)}>
+    <Card className={cn('overflow-hidden', props.className)}>
       <CardHeader className='pb-2'>
-        <CardTitle className='text-muted-foreground text-xs font-medium tracking-wide uppercase'>
-          {title}
-        </CardTitle>
+        <div className='flex items-center gap-2'>
+          {Icon ? (
+            <IconBadge tone={props.tone ?? 'default'} size='sm'>
+              <Icon />
+            </IconBadge>
+          ) : null}
+          <CardTitle className='text-muted-foreground text-xs font-medium tracking-wide uppercase'>
+            {props.title}
+          </CardTitle>
+        </div>
       </CardHeader>
       <CardContent className='space-y-2'>
-        {loading ? (
+        {props.loading ? (
           <div className='space-y-2'>
             <Skeleton className='h-7 w-20' />
             <Skeleton className='h-4 w-32' />
@@ -91,23 +112,47 @@ export function StatCard({
         ) : (
           <>
             <div className='flex items-end justify-between gap-2'>
-              {valueNumber !== undefined && Number.isFinite(valueNumber) ? (
+              {props.valueNumber !== undefined &&
+              Number.isFinite(props.valueNumber) ? (
                 <CountUp
-                  value={valueNumber}
-                  format={valueFormat}
+                  value={props.valueNumber}
+                  format={props.valueFormat}
                   className='text-2xl font-semibold tracking-tight'
                 />
               ) : (
                 <span className='text-2xl font-semibold tracking-tight tabular-nums'>
-                  {value}
+                  {props.value}
                 </span>
               )}
-              {hint ? (
+              {props.hint ? (
                 <span className='text-muted-foreground text-xs tabular-nums'>
-                  {hint}
+                  {props.hint}
                 </span>
               ) : null}
             </div>
+            {props.details && props.details.length > 0 ? (
+              <div className='grid grid-cols-2 gap-2'>
+                {props.details.map((detail) => (
+                  <div
+                    key={detail.label}
+                    className='bg-muted/40 rounded-lg border border-transparent px-2.5 py-2'
+                  >
+                    <div className='text-muted-foreground truncate text-[11px] leading-none font-medium'>
+                      {detail.label}
+                    </div>
+                    <div
+                      className={cn(
+                        'mt-1.5 truncate text-xs font-semibold tabular-nums',
+                        DETAIL_TONE_CLASSES[detail.tone ?? 'default']
+                      )}
+                      title={detail.value}
+                    >
+                      {detail.value}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : null}
             {data.length > 1 ? (
               <ChartContainer
                 config={sparkConfig}
@@ -125,7 +170,7 @@ export function StatCard({
                     fill='var(--color-value)'
                     fillOpacity={0.16}
                     isAnimationActive={false}
-                    className={accentClassName}
+                    className={props.accentClassName}
                   />
                 </AreaChart>
               </ChartContainer>

--- a/web/src/features/dashboard/components/today-snapshot.tsx
+++ b/web/src/features/dashboard/components/today-snapshot.tsx
@@ -1,0 +1,257 @@
+// metapi-go/features/dashboard/components — today snapshot strip.
+//
+// The overview's one-screen aggregation row (audit ui-ux-2026-08: the home
+// page lacked an at-a-glance "today" surface). Four cells:
+//   - aggregate balance + 7-day delta (newest vs oldest captured point of the
+//     8-day balance-history window; the backend serves points chronologically
+//     ASC, so the oldest point is ~7 days ago),
+//   - today's successful check-ins (dashboard snapshot),
+//   - actionable attention count (deep-links to the availability section),
+//   - a live availability dot backed by the realtime ops WebSocket.
+// Missing data renders "—" — numbers are never invented.
+
+import { useQuery } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
+import { ArrowDownRight, ArrowUpRight, Minus } from 'lucide-react'
+import { useMemo, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { api } from '@/lib/api'
+import { formatInt } from '@/lib/format'
+import { cn } from '@/lib/utils'
+
+import { useRealtimeOps } from '../hooks/use-realtime-ops'
+
+/** Summary-view dashboard snapshot (GET /api/stats/dashboard?view=summary). */
+type DashboardSnapshot = {
+  todayCheckin?: {
+    total: number
+    success: number
+    skipped: number
+    failed: number
+  }
+}
+
+/** Aggregate balance history (GET /api/stats/balance-history?accountId=0). */
+type BalanceHistoryResponse = {
+  series: Array<{
+    accountId: number
+    points: Array<{ day: string; balance: number }>
+  }>
+  days: number
+}
+
+/** Attention response (GET /api/stats/attention?limit=20). */
+type AttentionResponse = {
+  total: number
+}
+
+type BalanceTrend = {
+  total: number | undefined
+  deltaPercent: number | undefined
+}
+
+/** Adaptive currency formatting (mirrors the legacy chart tooltips). */
+function formatBalance(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return '—'
+  }
+  let fractionDigits = 6
+  if (value >= 1) fractionDigits = 3
+  if (value >= 1000) fractionDigits = 2
+  return [
+    '$',
+    value.toLocaleString(undefined, {
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    }),
+  ].join('')
+}
+
+/**
+ * Aggregate the balance across all account series. The delta compares the
+ * newest captured point with the oldest point of the window (~7 days ago).
+ * A zero previous total yields no delta — dividing by zero would invent one.
+ */
+function computeBalanceTrend(
+  balanceHistory: BalanceHistoryResponse | undefined
+): BalanceTrend {
+  const series = balanceHistory?.series ?? []
+  let latestTotal = 0
+  let previousTotal = 0
+  let hasPoints = false
+  for (const entry of series) {
+    const points = entry.points ?? []
+    if (points.length === 0) continue
+    hasPoints = true
+    const latestPoint = points.at(-1)
+    const earliestPoint = points.at(0)
+    latestTotal += latestPoint ? latestPoint.balance : 0
+    previousTotal += earliestPoint ? earliestPoint.balance : 0
+  }
+  if (!hasPoints) return { total: undefined, deltaPercent: undefined }
+  if (!Number.isFinite(previousTotal) || previousTotal === 0) {
+    return { total: latestTotal, deltaPercent: undefined }
+  }
+  const deltaPercent =
+    ((latestTotal - previousTotal) / Math.abs(previousTotal)) * 100
+  return { total: latestTotal, deltaPercent }
+}
+
+export function TodaySnapshotStrip() {
+  const { t } = useTranslation()
+
+  const { data: snapshot, isLoading: snapshotLoading } = useQuery({
+    queryKey: ['dashboard-snapshot'],
+    queryFn: () => api.getDashboardSnapshot() as Promise<DashboardSnapshot>,
+  })
+
+  const { data: balanceHistory, isLoading: balanceLoading } = useQuery({
+    queryKey: ['dashboard-balance-spark', 0, 8],
+    queryFn: () =>
+      api.getBalanceHistory(0, 8) as Promise<BalanceHistoryResponse>,
+  })
+
+  const { data: attention, isLoading: attentionLoading } = useQuery({
+    queryKey: ['dashboard-attention', 20],
+    queryFn: () => api.getAttention(20) as Promise<AttentionResponse>,
+  })
+
+  const realtime = useRealtimeOps()
+
+  const trend = useMemo(
+    () => computeBalanceTrend(balanceHistory),
+    [balanceHistory]
+  )
+  const checkinSuccess = snapshot?.todayCheckin?.success
+  const attentionTotal = attention?.total
+
+  const renderBalanceValue = (): ReactNode => {
+    if (balanceLoading) return <Skeleton className='h-7 w-28' />
+    return (
+      <div className='truncate text-xl font-semibold tabular-nums'>
+        {formatBalance(trend.total)}
+      </div>
+    )
+  }
+
+  const renderBalanceDelta = (): ReactNode | null => {
+    if (balanceLoading) return null
+    const delta = trend.deltaPercent
+    if (delta === undefined || !Number.isFinite(delta)) {
+      return (
+        <div className='text-muted-foreground flex items-center gap-1 text-xs'>
+          <Minus className='size-3' />
+          <span className='tabular-nums'>—</span>
+          <span>{t('dashboard.overview.snapshot.vs7d')}</span>
+        </div>
+      )
+    }
+    let DeltaIcon = Minus
+    let deltaClassName = 'text-muted-foreground'
+    if (delta > 0) {
+      DeltaIcon = ArrowUpRight
+      deltaClassName = 'text-success'
+    } else if (delta < 0) {
+      DeltaIcon = ArrowDownRight
+      deltaClassName = 'text-destructive'
+    }
+    const sign = delta > 0 ? '+' : ''
+    return (
+      <div className={cn('flex items-center gap-1 text-xs', deltaClassName)}>
+        <DeltaIcon className='size-3' />
+        <span className='tabular-nums'>
+          {sign}
+          {delta.toFixed(1)}%
+        </span>
+        <span className='text-muted-foreground'>
+          {t('dashboard.overview.snapshot.vs7d')}
+        </span>
+      </div>
+    )
+  }
+
+  let statusKey = 'dashboard.availability.realtime.statusConnecting'
+  let statusDotClassName = 'animate-pulse bg-muted-foreground/50'
+  if (realtime.gaveUp) {
+    statusKey = 'dashboard.availability.realtime.statusDisconnected'
+    statusDotClassName = 'bg-destructive'
+  } else if (realtime.connected) {
+    statusKey = 'dashboard.availability.realtime.statusLive'
+    statusDotClassName = 'bg-success'
+  }
+
+  return (
+    <Card>
+      <CardHeader className='pb-2'>
+        <CardTitle className='text-sm font-medium'>
+          {t('dashboard.overview.snapshot.title')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className='grid grid-cols-2 gap-4 lg:grid-cols-4 lg:gap-6'>
+          <div className='flex min-w-0 flex-col gap-1'>
+            <div className='text-muted-foreground truncate text-xs'>
+              {t('dashboard.overview.snapshot.totalBalance')}
+            </div>
+            {renderBalanceValue()}
+            {renderBalanceDelta()}
+          </div>
+
+          <div className='flex min-w-0 flex-col gap-1'>
+            <div className='text-muted-foreground truncate text-xs'>
+              {t('dashboard.overview.snapshot.checkinSuccess')}
+            </div>
+            {snapshotLoading ? (
+              <Skeleton className='h-7 w-12' />
+            ) : (
+              <div className='text-xl font-semibold tabular-nums'>
+                {formatInt(checkinSuccess ?? null)}
+              </div>
+            )}
+          </div>
+
+          <Link
+            to='/dashboard/$section'
+            params={{ section: 'availability' }}
+            aria-label={t('dashboard.overview.snapshot.attentionOpen')}
+            className='group focus-visible:ring-ring/50 flex min-w-0 flex-col gap-1 rounded-lg outline-none focus-visible:ring-3'
+          >
+            <span className='text-muted-foreground truncate text-xs'>
+              {t('dashboard.overview.snapshot.attention')}
+            </span>
+            {attentionLoading ? (
+              <Skeleton className='h-7 w-12' />
+            ) : (
+              <span
+                className={cn(
+                  'text-xl font-semibold tabular-nums group-hover:underline',
+                  attentionTotal === 0 ? 'text-success' : 'text-foreground'
+                )}
+              >
+                {formatInt(attentionTotal ?? null)}
+              </span>
+            )}
+          </Link>
+
+          <div className='flex min-w-0 flex-col gap-1'>
+            <div className='text-muted-foreground truncate text-xs'>
+              {t('dashboard.overview.snapshot.availability')}
+            </div>
+            <div className='flex items-center gap-1.5 text-sm font-medium'>
+              <span
+                className={cn(
+                  'size-2 shrink-0 rounded-full',
+                  statusDotClassName
+                )}
+              />
+              {t(statusKey)}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/src/features/dashboard/sections/availability/availability-section.tsx
+++ b/web/src/features/dashboard/sections/availability/availability-section.tsx
@@ -72,7 +72,7 @@ function RealtimeSparkline({ samples }: { samples: number[] }) {
           <div
             // eslint-disable-next-line react/no-array-index-key
             key={index}
-            className='bg-primary/70 min-w-0 flex-1 rounded-sm'
+            className='bg-chart-1/70 min-w-0 flex-1 rounded-sm'
             style={{ height: `${ratio * 100}%` }}
           />
         )

--- a/web/src/features/dashboard/sections/overview/overview-section.tsx
+++ b/web/src/features/dashboard/sections/overview/overview-section.tsx
@@ -10,7 +10,14 @@
 // the scheduled-tasks table.
 
 import { useQuery } from '@tanstack/react-query'
-import { Activity, ClipboardList, RefreshCw } from 'lucide-react'
+import {
+  Activity,
+  CalendarCheck,
+  ClipboardList,
+  Globe,
+  RefreshCw,
+  Users,
+} from 'lucide-react'
 import { useMemo, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -37,6 +44,7 @@ import { cn } from '@/lib/utils'
 
 import { AnnouncementBanner } from '../../components/announcement-banner'
 import { StatCard } from '../../components/stat-card'
+import { TodaySnapshotStrip } from '../../components/today-snapshot'
 
 /** Summary-view dashboard snapshot (GET /api/stats/dashboard?view=summary). */
 type DashboardSnapshot = {
@@ -137,14 +145,24 @@ export function OverviewSection() {
   const accountHint = t('dashboard.overview.statCards.accountCountHint', {
     active: activeAccounts !== undefined ? formatInt(activeAccounts) : '—',
   })
-  const checkinHint = t('dashboard.overview.statCards.todayCheckinHint', {
-    success: checkin?.success ?? 0,
-    total: checkin?.total ?? 0,
-  })
   const proxyHint = t('dashboard.overview.statCards.proxy24hHint', {
     success: proxy?.success ?? 0,
     rpm: performance?.requestsPerMinute ?? 0,
   })
+
+  const checkinDetails = useMemo(() => {
+    if (!checkin) return undefined
+    return [
+      {
+        label: t('dashboard.overview.statCards.checkinSucceeded'),
+        value: formatInt(checkin.success),
+      },
+      {
+        label: t('dashboard.overview.statCards.checkinSkipped'),
+        value: formatInt(checkin.skipped),
+      },
+    ]
+  }, [checkin, t])
 
   const renderSchedulerBody = (): ReactNode => {
     if (schedulerLoading) {
@@ -250,6 +268,8 @@ export function OverviewSection() {
     <div className='flex flex-col gap-4'>
       <AnnouncementBanner />
 
+      <TodaySnapshotStrip />
+
       <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4'>
         <StatCard
           title={t('dashboard.overview.statCards.accountCount')}
@@ -258,6 +278,7 @@ export function OverviewSection() {
           valueFormat={animateInt}
           hint={accountHint}
           spark={accountSpark}
+          icon={Users}
           loading={snapshotLoading}
         />
         <StatCard
@@ -266,12 +287,15 @@ export function OverviewSection() {
           valueNumber={siteCount ?? undefined}
           valueFormat={animateInt}
           hint={t('dashboard.overview.statCards.siteCountHint')}
+          icon={Globe}
           loading={snapshotLoading}
         />
         <StatCard
           title={t('dashboard.overview.statCards.todayCheckin')}
           value={!checkin ? '—' : formatRatio(checkin.success, checkin.total)}
-          hint={checkinHint}
+          icon={CalendarCheck}
+          tone='success'
+          details={checkinDetails}
           loading={snapshotLoading}
         />
         <StatCard
@@ -280,6 +304,7 @@ export function OverviewSection() {
           valueNumber={proxy ? proxy.total : undefined}
           valueFormat={animateInt}
           hint={proxyHint}
+          icon={Activity}
           loading={snapshotLoading}
         />
       </div>

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -471,9 +471,19 @@
           "siteCount": "Sites",
           "siteCountHint": "tracked sites",
           "todayCheckin": "Today's check-in",
-          "todayCheckinHint": "{{success}} / {{total}} succeeded",
+          "checkinSucceeded": "succeeded",
+          "checkinSkipped": "skipped",
           "proxy24h": "Proxy 24h",
           "proxy24hHint": "{{success}} ok · {{rpm}}/min"
+        },
+        "snapshot": {
+          "title": "Today snapshot",
+          "totalBalance": "Total balance",
+          "vs7d": "vs 7d ago",
+          "checkinSuccess": "Successful check-ins today",
+          "attention": "Needs attention",
+          "attentionOpen": "Open availability",
+          "availability": "Availability"
         },
         "scheduledTasks": {
           "title": "Scheduled tasks",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -471,9 +471,19 @@
           "siteCount": "站点",
           "siteCountHint": "已跟踪站点",
           "todayCheckin": "今日签到",
-          "todayCheckinHint": "{{success}} / {{total}} 成功",
+          "checkinSucceeded": "成功",
+          "checkinSkipped": "跳过",
           "proxy24h": "代理 24h",
           "proxy24hHint": "{{success}} 成功 · {{rpm}}/分"
+        },
+        "snapshot": {
+          "title": "今日快照",
+          "totalBalance": "总余额",
+          "vs7d": "较 7 天前",
+          "checkinSuccess": "今日签到成功",
+          "attention": "待处理",
+          "attentionOpen": "打开可用性",
+          "availability": "可用性"
         },
         "scheduledTasks": {
           "title": "定时任务",


### PR DESCRIPTION
首页升级：今日快照横条（余额环比/签到/待处理/实时状态）、attention 直达、StatCard icon/tone/details + IconBadge 原语、RealtimeSparkline 图表 token 修正。tsgo/oxlint/vitest 全绿（337 tests）。