### PR TITLE
feat(alert): enrich alert messages with routes, alternatives, panel link

### DIFF
--- a/service/alert/alert.go
+++ b/service/alert/alert.go
@@ -5,10 +5,10 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/deliciousbuding/metapi-go/config"
 	"github.com/deliciousbuding/metapi-go/service"
 	notifypkg "github.com/deliciousbuding/metapi-go/service/notify"
+	"github.com/jmoiron/sqlx"
 )
 
 // TokenExpiredParams holds parameters for reportTokenExpired.
@@ -54,9 +54,10 @@ func ReportTokenExpired(cfg *config.Config, db *sqlx.DB, params TokenExpiredPara
 
 	// Write events
 	_ = createdAt
+	message := enrichAlertMessage(db, fmt.Sprintf("%s @ %s 的 Token 无效或已过期%s", accountLabel, siteLabel, detail),
+		alertEnrichmentScope{accountID: &params.AccountID})
 	service.CreateEvent(db, "token", "Token 已失效",
-		fmt.Sprintf("%s @ %s 的 Token 无效或已过期%s", accountLabel, siteLabel, detail),
-		"error", params.AccountID, "account")
+		message, "error", params.AccountID, "account")
 
 	// Update account status
 	db.Exec(db.Rebind("UPDATE accounts SET status = 'expired', updated_at = ? WHERE id = ?"),
@@ -72,8 +73,7 @@ func ReportTokenExpired(cfg *config.Config, db *sqlx.DB, params TokenExpiredPara
 	})
 
 	// Send notification
-	notifypkg.SendNotification(cfg, "Token 已失效",
-		fmt.Sprintf("%s @ %s 的 Token 无效或已过期%s", accountLabel, siteLabel, detail),
+	notifypkg.SendNotification(cfg, "Token 已失效", message,
 		"error", &notifypkg.SendNotificationOptions{TaskTag: "token_expired"})
 }
 
@@ -121,8 +121,10 @@ func ReportLowBalance(cfg *config.Config, db *sqlx.DB, params LowBalanceParams) 
 		siteLabel = *params.SiteName
 	}
 
-	msg := fmt.Sprintf("%s @ %s 余额不足：当前 $%.2f（阈值 $%.2f）",
-		accountLabel, siteLabel, params.Balance, params.Threshold)
+	msg := enrichAlertMessage(db,
+		fmt.Sprintf("%s @ %s 余额不足：当前 $%.2f（阈值 $%.2f）",
+			accountLabel, siteLabel, params.Balance, params.Threshold),
+		alertEnrichmentScope{accountID: &params.AccountID})
 
 	service.CreateEvent(db, "balance", "余额不足", msg, "warning",
 		params.AccountID, "account")
@@ -130,7 +132,6 @@ func ReportLowBalance(cfg *config.Config, db *sqlx.DB, params LowBalanceParams) 
 	notifypkg.SendNotification(cfg, "余额不足", msg, "warning",
 		&notifypkg.SendNotificationOptions{TaskTag: "low_balance"})
 }
-
 
 type ProxyAllFailedParams struct {
 	Model  string
@@ -142,12 +143,14 @@ type ProxyAllFailedParams struct {
 func ReportProxyAllFailed(cfg *config.Config, db *sqlx.DB, params ProxyAllFailedParams) {
 	createdAt := service.FormatUtcSqlDateTime(time.Now())
 
-	service.CreateEvent(db, "proxy", "代理全部失败",
+	message := enrichAlertMessage(db,
 		fmt.Sprintf("模型=%s, 原因=%s", params.Model, params.Reason),
-		"error", 0, "route")
+		alertEnrichmentScope{model: params.Model})
 
-	notifypkg.SendNotification(cfg, "代理全部失败",
-		fmt.Sprintf("模型=%s, 原因=%s", params.Model, params.Reason),
+	service.CreateEvent(db, "proxy", "代理全部失败",
+		message, "error", 0, "route")
+
+	notifypkg.SendNotification(cfg, "代理全部失败", message,
 		"error", &notifypkg.SendNotificationOptions{TaskTag: "proxy_all_failed"})
 
 	_ = createdAt // already used above

--- a/service/alert/enrich.go
+++ b/service/alert/enrich.go
@@ -1,0 +1,216 @@
+package alert
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/deliciousbuding/metapi-go/routing"
+	"github.com/jmoiron/sqlx"
+)
+
+// Enrichment presentation limits and the panel deep link appended to
+// token-expired / low-balance / proxy-all-failed alert messages.
+const (
+	enrichMaxRoutesShown = 3
+	enrichMaxSitesShown  = 2
+	alertPanelLink       = "/observability?section=health"
+)
+
+// alertEnrichmentScope selects the lookup key for enrichment queries.
+// Account-scoped alerts (token expired / low balance) resolve through
+// route_channels.account_id; model-scoped alerts (proxy all failed) resolve
+// through token_routes.model_pattern matching.
+type alertEnrichmentScope struct {
+	accountID *int64
+	model     string
+}
+
+// siteChannelCount is one alternative site with its usable channel count.
+type siteChannelCount struct {
+	name  string
+	count int
+}
+
+// enrichAlertMessage appends up to three context lines to base:
+//
+//	受影响路由: <patterns, 最多 3 条>
+//	替代站点: <站点名(通道数), 最多 2 个站点>
+//	面板: /observability?section=health
+//
+// A nil db or any query failure degrades to the original message so alert
+// delivery never depends on enrichment success.
+func enrichAlertMessage(db *sqlx.DB, base string, scope alertEnrichmentScope) string {
+	if db == nil {
+		return base
+	}
+	lines, err := buildEnrichmentLines(db, scope)
+	if err != nil {
+		return base
+	}
+	return base + "\n" + strings.Join(lines, "\n")
+}
+
+func buildEnrichmentLines(db *sqlx.DB, scope alertEnrichmentScope) ([]string, error) {
+	routes, routeIDs, err := loadAffectedRoutes(db, scope)
+	if err != nil {
+		return nil, err
+	}
+	sites, err := loadAlternativeSites(db, scope, routeIDs)
+	if err != nil {
+		return nil, err
+	}
+	return []string{
+		"受影响路由: " + formatAffectedRoutes(routes),
+		"替代站点: " + formatAlternativeSites(sites),
+		"面板: " + alertPanelLink,
+	}, nil
+}
+
+type routeRow struct {
+	ID           int64   `db:"id"`
+	ModelPattern string  `db:"model_pattern"`
+	DisplayName  *string `db:"display_name"`
+}
+
+// loadAffectedRoutes returns the routes touched by the failing account (all
+// wired routes) or by the failing model (enabled dispatch routes whose
+// pattern/display name matches). The second return value carries route ids
+// so the alternative-site lookup can reuse them for model-scoped alerts.
+func loadAffectedRoutes(db *sqlx.DB, scope alertEnrichmentScope) ([]string, []int64, error) {
+	var rows []routeRow
+	var err error
+	if scope.accountID != nil {
+		err = db.Select(&rows, db.Rebind(`
+			SELECT DISTINCT tr.id, tr.model_pattern, tr.display_name
+			FROM route_channels rc
+			JOIN token_routes tr ON tr.id = rc.route_id
+			WHERE rc.account_id = ?
+			ORDER BY tr.id`), *scope.accountID)
+	} else {
+		err = db.Select(&rows, db.Rebind(`
+			SELECT id, model_pattern, display_name
+			FROM token_routes
+			WHERE enabled = ?
+			ORDER BY id`), true)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	labels := make([]string, 0, len(rows))
+	routeIDs := make([]int64, 0, len(rows))
+	seen := make(map[string]bool, len(rows))
+	model := strings.TrimSpace(scope.model)
+	for _, row := range rows {
+		if scope.accountID == nil {
+			if !routing.MatchesModelPattern(model, row.ModelPattern) &&
+				!routing.IsRouteDisplayNameMatch(model, row.DisplayName) {
+				continue
+			}
+		}
+		label := routing.GetExposedModelNameForRoute(row.DisplayName, row.ModelPattern)
+		routeIDs = append(routeIDs, row.ID)
+		if seen[label] {
+			continue
+		}
+		seen[label] = true
+		labels = append(labels, label)
+	}
+	return labels, routeIDs, nil
+}
+
+type altSiteRow struct {
+	Name         string `db:"name"`
+	ChannelCount int    `db:"channel_count"`
+}
+
+// loadAlternativeSites lists other enabled sites that can still serve the
+// affected routes. Account-scoped alerts exclude the failing account's own
+// site; model-scoped alerts use the matched route ids directly. Sites are
+// ordered by usable channel count descending.
+func loadAlternativeSites(db *sqlx.DB, scope alertEnrichmentScope, routeIDs []int64) ([]siteChannelCount, error) {
+	var rows []altSiteRow
+	if scope.accountID != nil {
+		// The failing account's site is excluded so candidates are truly
+		// "other sites"; channels must sit on a route the account serves.
+		err := db.Select(&rows, db.Rebind(`
+			SELECT s.name, COUNT(rc.id) AS channel_count
+			FROM route_channels rc
+			JOIN accounts a ON a.id = rc.account_id
+			JOIN sites s ON s.id = a.site_id
+			WHERE rc.enabled = ?
+			  AND a.status = 'active'
+			  AND s.status = 'active'
+			  AND NOT EXISTS (
+			      SELECT 1 FROM accounts a2
+			      WHERE a2.id = ? AND a2.site_id = a.site_id
+			  )
+			  AND EXISTS (
+			      SELECT 1 FROM route_channels rc2
+			      WHERE rc2.account_id = ? AND rc2.route_id = rc.route_id
+			  )
+			GROUP BY s.id, s.name
+			ORDER BY channel_count DESC, s.name`), true, *scope.accountID, *scope.accountID)
+		if err != nil {
+			return nil, err
+		}
+	} else if len(routeIDs) > 0 {
+		query, args, err := sqlx.In(`
+			SELECT s.name, COUNT(rc.id) AS channel_count
+			FROM route_channels rc
+			JOIN accounts a ON a.id = rc.account_id
+			JOIN sites s ON s.id = a.site_id
+			WHERE rc.enabled = ?
+			  AND a.status = 'active'
+			  AND s.status = 'active'
+			  AND rc.route_id IN (?)
+			GROUP BY s.id, s.name
+			ORDER BY channel_count DESC, s.name`, true, routeIDs)
+		if err != nil {
+			return nil, err
+		}
+		if err := db.Select(&rows, db.Rebind(query), args...); err != nil {
+			return nil, err
+		}
+	}
+
+	sites := make([]siteChannelCount, 0, len(rows))
+	for _, row := range rows {
+		sites = append(sites, siteChannelCount{name: row.Name, count: row.ChannelCount})
+	}
+	return sites, nil
+}
+
+func formatAffectedRoutes(labels []string) string {
+	if len(labels) == 0 {
+		return "无"
+	}
+	shown := labels
+	if len(shown) > enrichMaxRoutesShown {
+		shown = shown[:enrichMaxRoutesShown]
+	}
+	line := strings.Join(shown, ", ")
+	if len(labels) > enrichMaxRoutesShown {
+		line += fmt.Sprintf(" 等 %d 条", len(labels))
+	}
+	return line
+}
+
+func formatAlternativeSites(sites []siteChannelCount) string {
+	if len(sites) == 0 {
+		return "无"
+	}
+	shown := sites
+	if len(shown) > enrichMaxSitesShown {
+		shown = shown[:enrichMaxSitesShown]
+	}
+	parts := make([]string, 0, len(shown))
+	for _, site := range shown {
+		parts = append(parts, fmt.Sprintf("%s(%d)", site.name, site.count))
+	}
+	line := strings.Join(parts, ", ")
+	if len(sites) > enrichMaxSitesShown {
+		line += fmt.Sprintf(" 等 %d 个站点", len(sites))
+	}
+	return line
+}

--- a/service/alert/enrich_test.go
+++ b/service/alert/enrich_test.go
@@ -1,0 +1,339 @@
+package alert
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// ---- Enrichment fixtures ----
+
+func seedEnrichSite(t *testing.T, db *store.DB, siteName, accountName string) (siteID, accountID int64) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		 VALUES (?, ?, 'openai', 'active', ?, ?)`,
+		siteName, "https://"+siteName+".example.com", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site %s: %v", siteName, err)
+	}
+	siteID, _ = res.LastInsertId()
+	res, err = db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
+		 VALUES (?, ?, 'tok', 'active', 1, ?, ?)`,
+		siteID, accountName, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account %s: %v", accountName, err)
+	}
+	accountID, _ = res.LastInsertId()
+	return siteID, accountID
+}
+
+func seedEnrichAccount(t *testing.T, db *store.DB, siteID int64, accountName string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
+		 VALUES (?, ?, 'tok', 'active', 1, ?, ?)`,
+		siteID, accountName, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account %s: %v", accountName, err)
+	}
+	accountID, _ := res.LastInsertId()
+	return accountID
+}
+
+func seedEnrichRoute(t *testing.T, db *store.DB, pattern string, enabled bool) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	enabledFlag := 0
+	if enabled {
+		enabledFlag = 1
+	}
+	res, err := db.Exec(
+		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
+		 VALUES (?, 'pattern', 'weighted', ?, ?, ?)`,
+		pattern, enabledFlag, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert route %s: %v", pattern, err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+func seedEnrichChannel(t *testing.T, db *store.DB, routeID, accountID int64, enabled bool) {
+	t.Helper()
+	enabledFlag := 0
+	if enabled {
+		enabledFlag = 1
+	}
+	_, err := db.Exec(
+		`INSERT INTO route_channels (route_id, account_id, priority, weight, enabled, manual_override)
+		 VALUES (?, ?, 0, 10, ?, 0)`,
+		routeID, accountID, enabledFlag,
+	)
+	if err != nil {
+		t.Fatalf("insert channel route %d account %d: %v", routeID, accountID, err)
+	}
+}
+
+// ---- enrichAlertMessage unit tests ----
+
+func TestEnrichAlertMessage_AccountScope(t *testing.T) {
+	db := setupAlertTestDB(t)
+	_, failingAccount := seedEnrichSite(t, db, "acme", "alice")
+	_, betaAccount := seedEnrichSite(t, db, "beta", "bob")
+	_, gammaAccount := seedEnrichSite(t, db, "gamma", "carol")
+
+	gptRoute := seedEnrichRoute(t, db, "gpt-*", true)
+	claudeRoute := seedEnrichRoute(t, db, "claude-*", true)
+
+	seedEnrichChannel(t, db, gptRoute, failingAccount, true)
+	seedEnrichChannel(t, db, claudeRoute, failingAccount, true)
+	seedEnrichChannel(t, db, gptRoute, betaAccount, true)
+	seedEnrichChannel(t, db, gptRoute, gammaAccount, true)
+	seedEnrichChannel(t, db, claudeRoute, gammaAccount, true)
+
+	message := enrichAlertMessage(db.DB,
+		"alice @ acme 的 Token 无效或已过期 (jwt expired)",
+		alertEnrichmentScope{accountID: &failingAccount})
+
+	want := strings.Join([]string{
+		"alice @ acme 的 Token 无效或已过期 (jwt expired)",
+		"受影响路由: gpt-*, claude-*",
+		"替代站点: gamma(2), beta(1)",
+		"面板: /observability?section=health",
+	}, "\n")
+	if message != want {
+		t.Fatalf("message mismatch:\n got: %q\nwant: %q", message, want)
+	}
+}
+
+func TestEnrichAlertMessage_ExcludesOwnSiteAndDisabledChannels(t *testing.T) {
+	db := setupAlertTestDB(t)
+	failingSite, failingAccount := seedEnrichSite(t, db, "acme", "alice")
+	sameSiteAccount := seedEnrichAccount(t, db, failingSite, "mallory")
+	_, betaAccount := seedEnrichSite(t, db, "beta", "bob")
+
+	route := seedEnrichRoute(t, db, "gpt-*", true)
+	seedEnrichChannel(t, db, route, failingAccount, true)
+	// Same-site sibling account must NOT count as an alternative site.
+	seedEnrichChannel(t, db, route, sameSiteAccount, true)
+	// Disabled channel on another site must NOT count.
+	seedEnrichChannel(t, db, route, betaAccount, false)
+
+	message := enrichAlertMessage(db.DB, "base line", alertEnrichmentScope{accountID: &failingAccount})
+	if !strings.Contains(message, "受影响路由: gpt-*") {
+		t.Fatalf("missing affected routes: %q", message)
+	}
+	if !strings.Contains(message, "替代站点: 无") {
+		t.Fatalf("expected no alternative sites (same site + disabled channel), got: %q", message)
+	}
+}
+
+func TestEnrichAlertMessage_NoWiring(t *testing.T) {
+	db := setupAlertTestDB(t)
+	_, orphanAccount := seedEnrichSite(t, db, "acme", "alice")
+
+	message := enrichAlertMessage(db.DB, "base line", alertEnrichmentScope{accountID: &orphanAccount})
+	want := strings.Join([]string{
+		"base line",
+		"受影响路由: 无",
+		"替代站点: 无",
+		"面板: /observability?section=health",
+	}, "\n")
+	if message != want {
+		t.Fatalf("message mismatch:\n got: %q\nwant: %q", message, want)
+	}
+}
+
+func TestEnrichAlertMessage_Truncation(t *testing.T) {
+	db := setupAlertTestDB(t)
+	_, failingAccount := seedEnrichSite(t, db, "acme", "alice")
+
+	var routes []int64
+	for _, pattern := range []string{"r1", "r2", "r3", "r4", "r5"} {
+		routes = append(routes, seedEnrichRoute(t, db, pattern, true))
+		seedEnrichChannel(t, db, routes[len(routes)-1], failingAccount, true)
+	}
+	for _, siteName := range []string{"beta", "delta", "gamma", "zeta"} {
+		_, altAccount := seedEnrichSite(t, db, siteName, siteName+"-user")
+		seedEnrichChannel(t, db, routes[0], altAccount, true)
+	}
+
+	message := enrichAlertMessage(db.DB, "base line", alertEnrichmentScope{accountID: &failingAccount})
+	if !strings.Contains(message, "受影响路由: r1, r2, r3 等 5 条") {
+		t.Fatalf("expected truncated route list, got: %q", message)
+	}
+	// Sites are ordered by count DESC then name ASC; all have count 1.
+	if !strings.Contains(message, "替代站点: beta(1), delta(1) 等 4 个站点") {
+		t.Fatalf("expected truncated site list, got: %q", message)
+	}
+	if lines := strings.Split(message, "\n"); len(lines) != 4 {
+		t.Fatalf("expected 4 lines, got %d: %q", len(lines), message)
+	}
+}
+
+func TestEnrichAlertMessage_ModelScope(t *testing.T) {
+	db := setupAlertTestDB(t)
+	_, betaAccount := seedEnrichSite(t, db, "beta", "bob")
+
+	globRoute := seedEnrichRoute(t, db, "gpt-*", true)
+	seedEnrichRoute(t, db, "gpt-4", true)         // exact — must not match model "gpt-4o"
+	seedEnrichRoute(t, db, "claude-*", true)      // unrelated — must not match
+	seedEnrichRoute(t, db, "gpt-disabled", false) // disabled — excluded from dispatch surface
+	seedEnrichChannel(t, db, globRoute, betaAccount, true)
+
+	message := enrichAlertMessage(db.DB, "模型=gpt-4o, 原因=all channels exhausted",
+		alertEnrichmentScope{model: "gpt-4o"})
+
+	want := strings.Join([]string{
+		"模型=gpt-4o, 原因=all channels exhausted",
+		"受影响路由: gpt-*",
+		"替代站点: beta(1)",
+		"面板: /observability?section=health",
+	}, "\n")
+	if message != want {
+		t.Fatalf("message mismatch:\n got: %q\nwant: %q", message, want)
+	}
+}
+
+func TestEnrichAlertMessage_ModelScopeNoMatch(t *testing.T) {
+	db := setupAlertTestDB(t)
+	seedEnrichRoute(t, db, "gpt-*", true)
+
+	message := enrichAlertMessage(db.DB, "base line", alertEnrichmentScope{model: "claude-3-opus"})
+	if !strings.Contains(message, "受影响路由: 无") {
+		t.Fatalf("expected no matching routes, got: %q", message)
+	}
+	if !strings.Contains(message, "替代站点: 无") {
+		t.Fatalf("expected no alternative sites, got: %q", message)
+	}
+}
+
+func TestEnrichAlertMessage_NilDBDegrades(t *testing.T) {
+	base := "原始消息"
+	if got := enrichAlertMessage(nil, base, alertEnrichmentScope{model: "gpt-4o"}); got != base {
+		t.Fatalf("nil db must degrade to base, got %q", got)
+	}
+}
+
+func TestEnrichAlertMessage_QueryFailureDegrades(t *testing.T) {
+	db := setupAlertTestDB(t)
+	db.Close() // closed pool forces query errors
+
+	base := "原始消息"
+	got := enrichAlertMessage(db.DB, base, alertEnrichmentScope{model: "gpt-4o"})
+	if got != base {
+		t.Fatalf("query failure must degrade to base, got %q", got)
+	}
+}
+
+// ---- Report* integration tests (enriched message lands in events) ----
+
+func TestReportLowBalance_EnrichedEventMessage(t *testing.T) {
+	db := setupAlertTestDB(t)
+	cfg := &config.Config{AuthToken: "a", ProxyToken: "p"}
+	_, accountID := seedEnrichSite(t, db, "acme", "alice")
+	routeID := seedEnrichRoute(t, db, "gpt-*", true)
+	seedEnrichChannel(t, db, routeID, accountID, true)
+
+	uname := "alice"
+	site := "acme"
+	ReportLowBalance(cfg, db.DB, LowBalanceParams{
+		AccountID: accountID, Username: &uname, SiteName: &site,
+		Balance: 0.42, Threshold: 1.0,
+	})
+
+	var message string
+	if err := db.Get(&message,
+		`SELECT message FROM events WHERE type = 'balance' AND related_id = ?`, accountID); err != nil {
+		t.Fatalf("load event: %v", err)
+	}
+	if !strings.Contains(message, "alice @ acme 余额不足：当前 $0.42（阈值 $1.00）") {
+		t.Fatalf("missing base message: %q", message)
+	}
+	if !strings.Contains(message, "受影响路由: gpt-*") {
+		t.Fatalf("missing affected routes: %q", message)
+	}
+	if !strings.Contains(message, "替代站点: 无") {
+		t.Fatalf("expected no alternative sites: %q", message)
+	}
+	if !strings.Contains(message, "面板: /observability?section=health") {
+		t.Fatalf("missing panel link: %q", message)
+	}
+	if lines := strings.Split(message, "\n"); len(lines) > 6 {
+		t.Fatalf("message has %d lines, want <= 6: %q", len(lines), message)
+	}
+}
+
+func TestReportTokenExpired_EnrichedEventMessage(t *testing.T) {
+	db := setupAlertTestDB(t)
+	cfg := &config.Config{AuthToken: "a", ProxyToken: "p"}
+	_, accountID := seedEnrichSite(t, db, "acme", "alice")
+	routeID := seedEnrichRoute(t, db, "gpt-*", true)
+	seedEnrichChannel(t, db, routeID, accountID, true)
+
+	uname := "alice"
+	site := "acme"
+	ReportTokenExpired(cfg, db.DB, TokenExpiredParams{
+		AccountID: accountID, Username: &uname, SiteName: &site,
+		Detail: "jwt expired",
+	})
+
+	var message string
+	if err := db.Get(&message,
+		`SELECT message FROM events WHERE type = 'token' AND related_id = ?`, accountID); err != nil {
+		t.Fatalf("load event: %v", err)
+	}
+	if !strings.Contains(message, "alice @ acme 的 Token 无效或已过期") {
+		t.Fatalf("missing base message: %q", message)
+	}
+	if !strings.Contains(message, "受影响路由: gpt-*") {
+		t.Fatalf("missing affected routes: %q", message)
+	}
+	if !strings.Contains(message, "面板: /observability?section=health") {
+		t.Fatalf("missing panel link: %q", message)
+	}
+}
+
+func TestReportProxyAllFailed_EnrichedEventMessage(t *testing.T) {
+	db := setupAlertTestDB(t)
+	cfg := &config.Config{AuthToken: "a", ProxyToken: "p"}
+	_, betaAccount := seedEnrichSite(t, db, "beta", "bob")
+	globRoute := seedEnrichRoute(t, db, "gpt-*", true)
+	seedEnrichChannel(t, db, globRoute, betaAccount, true)
+
+	ReportProxyAllFailed(cfg, db.DB, ProxyAllFailedParams{
+		Model: "gpt-4o", Reason: "all channels exhausted",
+	})
+
+	var message string
+	if err := db.Get(&message,
+		`SELECT message FROM events WHERE type = 'proxy' ORDER BY id DESC LIMIT 1`); err != nil {
+		t.Fatalf("load event: %v", err)
+	}
+	if !strings.Contains(message, "模型=gpt-4o, 原因=all channels exhausted") {
+		t.Fatalf("missing base message: %q", message)
+	}
+	if !strings.Contains(message, "受影响路由: gpt-*") {
+		t.Fatalf("missing affected routes: %q", message)
+	}
+	if !strings.Contains(message, "替代站点: beta(1)") {
+		t.Fatalf("missing alternative sites: %q", message)
+	}
+	if !strings.Contains(message, "面板: /observability?section=health") {
+		t.Fatalf("missing panel link: %q", message)
+	}
+	if lines := strings.Split(message, "\n"); len(lines) > 6 {
+		t.Fatalf("message has %d lines, want <= 6: %q", len(lines), message)
+	}
+}


### PR DESCRIPTION
三条核心告警（Token 失效/余额不足/代理全失败）消息富化：受影响路由（≤3 条）+ 替代站点候选（≤2 个）+ 面板直达链接；参数化 SQL + 失败降级到原始消息；新增 11 个单测。go build/vet/test 全绿。