### PR TITLE
feat(web): model tester session history + template library

### DIFF
--- a/web/src/features/model-tester/__tests__/api.test.ts
+++ b/web/src/features/model-tester/__tests__/api.test.ts
@@ -1,13 +1,69 @@
-// metapi-go/features/model-tester — error-mapping unit tests.
+// metapi-go/features/model-tester — error-mapping + payload unit tests.
 //
 // `resolveTestResponseError` turns non-ok test responses into user-facing
 // messages: backend 501s are known limitations (no fake SSE stream; the sync
 // harness requires a forced channel) and map to a friendly localized key
-// instead of the raw "not implemented" text.
+// instead of the raw "not implemented" text. `buildChatPayload` renders the
+// conversation history into the request `messages` array.
 
 import { describe, expect, it } from 'vitest'
 
-import { resolveTestResponseError } from '../api'
+import { buildChatPayload, resolveTestResponseError } from '../api'
+import type { ChatMessage, TestFormValues } from '../types'
+
+function formValues(overrides: Partial<TestFormValues> = {}): TestFormValues {
+  return {
+    model: 'gpt-4o',
+    systemPrompt: '',
+    prompt: 'current question',
+    targetFormat: 'openai',
+    temperature: 0.7,
+    topP: 1,
+    maxTokens: 1024,
+    stream: true,
+    ...overrides,
+  }
+}
+
+function historyTurn(role: ChatMessage['role'], content: string): ChatMessage {
+  return { id: `${role}-${content}`, role, content }
+}
+
+describe('buildChatPayload', () => {
+  it('keeps the single-shot shape when history is empty', () => {
+    const payload = buildChatPayload(formValues())
+    expect(payload.messages).toEqual([
+      { role: 'user', content: 'current question' },
+    ])
+  })
+
+  it('prepends the system prompt, then history, then the current prompt', () => {
+    const payload = buildChatPayload(
+      formValues({ systemPrompt: '  behave  ' }),
+      [
+        historyTurn('user', 'first question'),
+        historyTurn('assistant', 'first answer'),
+      ]
+    )
+    expect(payload.messages).toEqual([
+      { role: 'system', content: 'behave' },
+      { role: 'user', content: 'first question' },
+      { role: 'assistant', content: 'first answer' },
+      { role: 'user', content: 'current question' },
+    ])
+  })
+
+  it('maps sampling params onto the wire (snake_case + omitted max_tokens at 0)', () => {
+    const payload = buildChatPayload(
+      formValues({ temperature: 0.2, topP: 0.9, maxTokens: 0 })
+    )
+    expect(payload.temperature).toBe(0.2)
+    expect(payload.top_p).toBe(0.9)
+    expect(payload.max_tokens).toBeUndefined()
+    expect(payload.stream).toBe(true)
+    expect(payload.targetFormat).toBe('openai')
+  })
+})
 
 describe('resolveTestResponseError', () => {
   it('maps the sync 501 (forced-channel harness required) to notAvailable', async () => {

--- a/web/src/features/model-tester/__tests__/templates.test.ts
+++ b/web/src/features/model-tester/__tests__/templates.test.ts
@@ -1,0 +1,92 @@
+// metapi-go/features/model-tester — template library unit tests.
+//
+// `loadTesterTemplates` seeds the localStorage-backed preset library on
+// first access and keeps returning valid stored templates afterwards;
+// corrupt or malformed stores fall back to the presets.
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  TESTER_TEMPLATE_PRESETS,
+  loadTesterTemplates,
+  type TesterTemplate,
+} from '../lib/templates'
+
+const STORAGE_KEY = 'model-tester.templates'
+
+type MemoryStorage = {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+}
+
+function makeStorage(initial?: Record<string, string>): MemoryStorage {
+  const data = new Map<string, string>(Object.entries(initial ?? {}))
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, value)
+    },
+  }
+}
+
+function readStoredTemplates(storage: MemoryStorage): unknown {
+  const raw = storage.getItem(STORAGE_KEY)
+  return raw ? (JSON.parse(raw) as unknown) : null
+}
+
+describe('TESTER_TEMPLATE_PRESETS', () => {
+  it('ships five presets with unique ids and i18n keys', () => {
+    expect(TESTER_TEMPLATE_PRESETS).toHaveLength(5)
+    const ids = TESTER_TEMPLATE_PRESETS.map((template) => template.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    for (const template of TESTER_TEMPLATE_PRESETS) {
+      expect(template.labelKey.startsWith('modelTester.template.')).toBe(true)
+      expect(template.promptKey.startsWith('modelTester.template.')).toBe(true)
+    }
+  })
+})
+
+describe('loadTesterTemplates', () => {
+  it('seeds the presets into storage on first load', () => {
+    const storage = makeStorage()
+    const templates = loadTesterTemplates(storage)
+    expect(templates).toEqual([...TESTER_TEMPLATE_PRESETS])
+    expect(readStoredTemplates(storage)).toEqual([...TESTER_TEMPLATE_PRESETS])
+  })
+
+  it('returns stored templates without re-seeding', () => {
+    const custom: TesterTemplate[] = [
+      {
+        id: 'custom',
+        labelKey: 'modelTester.template.templates.quickConnectivity.label',
+        promptKey: 'modelTester.template.templates.quickConnectivity.prompt',
+      },
+    ]
+    const storage = makeStorage({ [STORAGE_KEY]: JSON.stringify(custom) })
+    expect(loadTesterTemplates(storage)).toEqual(custom)
+  })
+
+  it('falls back to presets when the stored value is invalid JSON', () => {
+    const storage = makeStorage({ [STORAGE_KEY]: '{broken' })
+    expect(loadTesterTemplates(storage)).toEqual([...TESTER_TEMPLATE_PRESETS])
+  })
+
+  it('falls back to presets when the stored value is not an array', () => {
+    const storage = makeStorage({ [STORAGE_KEY]: JSON.stringify({ nope: 1 }) })
+    expect(loadTesterTemplates(storage)).toEqual([...TESTER_TEMPLATE_PRESETS])
+  })
+
+  it('drops malformed entries when filtering stored templates', () => {
+    const storage = makeStorage({
+      [STORAGE_KEY]: JSON.stringify([
+        { missingKeys: true },
+        TESTER_TEMPLATE_PRESETS[0],
+      ]),
+    })
+    expect(loadTesterTemplates(storage)).toEqual([TESTER_TEMPLATE_PRESETS[0]])
+  })
+
+  it('returns presets without any storage (no window)', () => {
+    expect(loadTesterTemplates()).toEqual([...TESTER_TEMPLATE_PRESETS])
+  })
+})

--- a/web/src/features/model-tester/api.ts
+++ b/web/src/features/model-tester/api.ts
@@ -13,6 +13,12 @@
 // caller passes an `AbortSignal` so the Stop button cancels an in-flight
 // test.
 //
+// `buildChatPayload` renders the conversation history into the request
+// `messages` array (system → prior user/assistant turns → current prompt)
+// so multi-turn context travels on the wire. Backends that only consume a
+// single message keep working: they ignore the extra entries and read the
+// last user prompt.
+//
 // A mutation (rather than a query) is the right shape here: the test is a
 // user-initiated command with a single terminal resolution, not a cacheable
 // read, and TanStack's `isPending` / `mutateAsync` / `reset` map cleanly
@@ -23,6 +29,7 @@ import { useMutation } from '@tanstack/react-query'
 import { api } from '@/lib/api'
 
 import type {
+  ChatMessage,
   ChatTestPayload,
   TestFormValues,
   TestModelVariables,
@@ -32,10 +39,16 @@ import type {
 
 const MAX_RAW_EVENTS = 200
 
-function buildChatPayload(values: TestFormValues): ChatTestPayload {
+export function buildChatPayload(
+  values: TestFormValues,
+  history: ChatMessage[] = []
+): ChatTestPayload {
   const messages: Array<{ role: string; content: string }> = []
   if (values.systemPrompt.trim().length > 0) {
     messages.push({ role: 'system', content: values.systemPrompt.trim() })
+  }
+  for (const message of history) {
+    messages.push({ role: message.role, content: message.content })
   }
   messages.push({ role: 'user', content: values.prompt })
   return {
@@ -258,8 +271,8 @@ export async function resolveTestResponseError(
 async function runTestStream(
   variables: TestModelVariables
 ): Promise<TestResponse> {
-  const { payload, onDelta, onDone, signal } = variables
-  const chatPayload = buildChatPayload(payload)
+  const { payload, history, onDelta, onDone, signal } = variables
+  const chatPayload = buildChatPayload(payload, history)
   const startedAt = performance.now()
 
   let content = ''

--- a/web/src/features/model-tester/components/model-tester-page.tsx
+++ b/web/src/features/model-tester/components/model-tester-page.tsx
@@ -1,29 +1,48 @@
 // metapi-go/features/model-tester — tester page (dual-column layout).
 //
 // Left column: `TestForm` (model picker + prompt + params). Right column:
-// `TestResponseViewer` (streaming content / reasoning / raw SSE). The page
-// owns the streaming accumulation state (`content` / `reasoningContent`)
-// and the `AbortController`, and wires them to the `useTestModel` mutation:
-// each parsed delta appends to the live strings (functional setState so
-// rapid chunks don't clobber each other); the resolved `TestResponse`
-// summary is committed to the viewer's stats bar when the stream closes.
+// `TestResponseViewer` (conversation turns + live streaming content /
+// reasoning / raw SSE). The page owns the conversation history
+// (`messages`) and the streaming accumulation state (`content` /
+// `reasoningContent`) plus the `AbortController`, and wires them to the
+// `useTestModel` mutation: each parsed delta appends to the live strings
+// (functional setState so rapid chunks don't clobber each other); the
+// resolved `TestResponse` summary is committed to the viewer's stats bar
+// when the stream closes.
+//
+// Session semantics: submitting appends the user prompt to `messages`
+// immediately and sends the prior turns as request context; when the run
+// finishes with non-empty content the assistant turn is appended. Stopped
+// or failed runs are never committed (their partial output stays visible
+// until the next submit). The Clear button (with confirmation) wipes the
+// conversation and the live run state.
 //
 // A deep link from the marketplace (`/model-tester?model=…`) pre-selects
 // the model in the form. The Stop button aborts the in-flight fetch; the
 // resulting `AbortError` is detected and surfaced as a "stopped" state
 // rather than a hard error.
 
+import { Trash2 as TrashIcon } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { ConfirmDialog } from '@/components/common/confirm-dialog'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { toast } from '@/lib/toast'
 
 import { useTestModel } from '../api'
 import type { TesterFormValues } from '../lib/tester-schema'
-import type { TestResponse, TestStreamDelta } from '../types'
+import type { ChatMessage, TestResponse, TestStreamDelta } from '../types'
 import { TestForm } from './test-form'
 import { TestResponseViewer } from './test-response-viewer'
+
+let messageIdCounter = 0
+
+function nextMessageId(): string {
+  messageIdCounter += 1
+  return `message-${messageIdCounter}`
+}
 
 function isAbortError(error: unknown): boolean {
   if (!(error instanceof Error)) return false
@@ -50,10 +69,12 @@ export function ModelTesterPage() {
 
   const testModel = useTestModel()
 
+  const [messages, setMessages] = useState<ChatMessage[]>([])
   const [content, setContent] = useState('')
   const [reasoningContent, setReasoningContent] = useState('')
   const [response, setResponse] = useState<TestResponse | null>(null)
   const [error, setError] = useState<string | undefined>(undefined)
+  const [clearDialogOpen, setClearDialogOpen] = useState(false)
 
   const abortControllerRef = useRef<AbortController | null>(null)
 
@@ -72,6 +93,13 @@ export function ModelTesterPage() {
 
   const handleSubmit = useCallback(
     async (values: TesterFormValues) => {
+      // The current prompt joins the conversation immediately; the prior
+      // turns (before this prompt) are sent as request context.
+      const history = messages
+      setMessages((prev) => [
+        ...prev,
+        { id: nextMessageId(), role: 'user', content: values.prompt },
+      ])
       // Reset previous run state.
       setContent('')
       setReasoningContent('')
@@ -84,6 +112,7 @@ export function ModelTesterPage() {
       try {
         const result = await testModel.mutateAsync({
           payload: values,
+          history,
           onDelta: handleDelta,
           signal: controller.signal,
         })
@@ -93,6 +122,16 @@ export function ModelTesterPage() {
         } else if (result.empty) {
           toast.warning(t('modelTester.toast.empty'))
         } else {
+          if (result.content) {
+            setMessages((prev) => [
+              ...prev,
+              {
+                id: nextMessageId(),
+                role: 'assistant',
+                content: result.content,
+              },
+            ])
+          }
           toast.success(t('modelTester.toast.succeeded'))
         }
       } catch (err) {
@@ -115,18 +154,40 @@ export function ModelTesterPage() {
         abortControllerRef.current = null
       }
     },
-    [handleDelta, testModel, t]
+    [handleDelta, testModel, t, messages]
   )
+
+  const handleClearSession = useCallback(() => {
+    setMessages([])
+    setContent('')
+    setReasoningContent('')
+    setResponse(null)
+    setError(undefined)
+    setClearDialogOpen(false)
+    toast.success(t('modelTester.toast.cleared'))
+  }, [t])
 
   const isRunning = testModel.isPending
 
   return (
     <div className='flex h-full flex-col gap-4 p-4'>
-      <div>
-        <h1 className='text-lg font-normal'>{t('modelTester.page.title')}</h1>
-        <p className='text-muted-foreground text-sm'>
-          {t('modelTester.page.description')}
-        </p>
+      <div className='flex flex-wrap items-start justify-between gap-3'>
+        <div>
+          <h1 className='text-lg font-normal'>{t('modelTester.page.title')}</h1>
+          <p className='text-muted-foreground text-sm'>
+            {t('modelTester.page.description')}
+          </p>
+        </div>
+        <Button
+          type='button'
+          variant='outline'
+          size='sm'
+          onClick={() => setClearDialogOpen(true)}
+          disabled={isRunning}
+        >
+          <TrashIcon className='mr-1 size-3.5' />
+          {t('modelTester.clear.button')}
+        </Button>
       </div>
 
       <div className='grid min-h-0 flex-1 grid-cols-1 gap-4 lg:grid-cols-2 lg:overflow-hidden'>
@@ -144,6 +205,7 @@ export function ModelTesterPage() {
         <Card className='flex h-full min-h-0 flex-col'>
           <CardContent className='flex min-h-0 flex-1 flex-col p-0'>
             <TestResponseViewer
+              messages={messages}
               content={content}
               reasoningContent={reasoningContent}
               isRunning={isRunning}
@@ -153,6 +215,17 @@ export function ModelTesterPage() {
           </CardContent>
         </Card>
       </div>
+
+      <ConfirmDialog
+        open={clearDialogOpen}
+        title={t('modelTester.clear.title')}
+        description={t('modelTester.clear.description')}
+        confirmLabel={t('modelTester.clear.confirm')}
+        cancelLabel={t('modelTester.clear.cancel')}
+        destructive
+        onConfirm={handleClearSession}
+        onCancel={() => setClearDialogOpen(false)}
+      />
     </div>
   )
 }

--- a/web/src/features/model-tester/components/test-form.tsx
+++ b/web/src/features/model-tester/components/test-form.tsx
@@ -1,15 +1,17 @@
 // metapi-go/features/model-tester — test form (RHF + Zod + shadcn).
 //
-// Renders the left column of the tester: model picker (populated from the
-// models marketplace via `useModels`), target protocol format, system +
-// user prompts, and sampling parameters (temperature / top_p / max_tokens /
-// stream). The parent owns the run/stop lifecycle; this form only emits
-// validated values on submit. When `defaultModel` is provided (deep link
-// from the marketplace `/models?...` → `/model-tester?model=…`) the model
-// field is pre-selected as soon as the marketplace list loads.
+// Renders the left column of the tester: a local template picker (fills
+// the prompt + sampling parameters from the localStorage template library),
+// model picker (populated from the models marketplace via `useModels`),
+// target protocol format, system + user prompts, and sampling parameters
+// (temperature / top_p / max_tokens / stream). The parent owns the
+// run/stop lifecycle; this form only emits validated values on submit.
+// When `defaultModel` is provided (deep link from the marketplace
+// `/models?...` → `/model-tester?model=…`) the model field is pre-selected
+// as soon as the marketplace list loads.
 
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
@@ -38,6 +40,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { useModels } from '@/features/models'
 import { cn } from '@/lib/utils'
 
+import { defaultTemplateStorage, loadTesterTemplates } from '../lib/templates'
 import {
   TESTER_FORM_DEFAULT_VALUES,
   testerSchema,
@@ -90,9 +93,65 @@ export function TestForm({
     onSubmit(values)
   })
 
+  // The template picker is not part of the validated schema: selecting a
+  // template fills the prompt + sampling params, then resets to the
+  // placeholder so the same template can be applied again.
+  const templates = useMemo(
+    () => loadTesterTemplates(defaultTemplateStorage()),
+    []
+  )
+  const [selectedTemplateId, setSelectedTemplateId] = useState('')
+
+  const applyTemplate = (templateId: string | null) => {
+    if (!templateId) return
+    const template = templates.find((item) => item.id === templateId)
+    if (!template) return
+    form.setValue('prompt', t(template.promptKey), {
+      shouldDirty: true,
+      shouldValidate: true,
+    })
+    if (template.temperature !== undefined) {
+      form.setValue('temperature', template.temperature, {
+        shouldDirty: true,
+      })
+    }
+    if (template.topP !== undefined) {
+      form.setValue('topP', template.topP, { shouldDirty: true })
+    }
+    if (template.maxTokens !== undefined) {
+      form.setValue('maxTokens', template.maxTokens, { shouldDirty: true })
+    }
+    setSelectedTemplateId('')
+  }
+
   return (
     <Form {...form}>
       <form onSubmit={handleSubmit} className='flex h-full flex-col gap-4'>
+        <FormItem>
+          <FormLabel>{t('modelTester.template.label')}</FormLabel>
+          <Select
+            value={selectedTemplateId}
+            onValueChange={applyTemplate}
+            disabled={isRunning}
+          >
+            <FormControl>
+              <SelectTrigger>
+                <SelectValue
+                  placeholder={t('modelTester.template.placeholder')}
+                />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              {templates.map((template) => (
+                <SelectItem key={template.id} value={template.id}>
+                  {t(template.labelKey)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <FormDescription>{t('modelTester.template.hint')}</FormDescription>
+        </FormItem>
+
         <FormField
           control={form.control}
           name='model'

--- a/web/src/features/model-tester/components/test-response-viewer.tsx
+++ b/web/src/features/model-tester/components/test-response-viewer.tsx
@@ -1,15 +1,15 @@
-/* eslint-disable no-nested-ternary -- content-kind selection uses chained ternary */
 // metapi-go/features/model-tester — response viewer (right column).
 //
-// Renders the streaming assistant output as it arrives: a live content
-// panel (auto-scrolls while streaming), a reasoning panel for
-// chain-of-thought text, a raw/JSON panel of the last N SSE data events,
-// and a stats bar (latency / chunk count / done sentinel / error). The
-// parent owns the streaming accumulation state and passes the current
-// strings down each render so the viewer re-renders on every delta.
+// Renders the tester conversation: every committed turn (user prompt +
+// assistant response) in order, with the live round streaming at the
+// bottom while a run is in flight. The reasoning and raw/JSON tabs keep
+// showing the current (or last) run's artifacts, and the stats bar reports
+// the last run's latency / chunk count / done sentinel / error. The parent
+// owns the streaming accumulation state and passes the current strings down
+// each render so the viewer re-renders on every delta.
 
 import { Brain as BrainIcon, Code as CodeIcon } from 'lucide-react'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Badge } from '@/components/ui/badge'
@@ -20,9 +20,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { formatLatency } from '@/lib/format'
 import { cn } from '@/lib/utils'
 
-import type { TestResponse } from '../types'
+import type { ChatMessage, TestResponse } from '../types'
 
 type TestResponseViewerProps = {
+  messages: ChatMessage[]
   content: string
   reasoningContent: string
   isRunning: boolean
@@ -43,12 +44,7 @@ function prettyPrintRawEvents(rawEvents: string[]): string {
   return pretty.join('\n\n')
 }
 
-function ContentArea({
-  text,
-  placeholder,
-  autoScroll,
-  className,
-}: {
+function ContentArea(props: {
   text: string
   placeholder: string
   autoScroll: boolean
@@ -57,43 +53,205 @@ function ContentArea({
   const scrollRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
-    if (!autoScroll) return
+    if (!props.autoScroll) return
     const node = scrollRef.current
     if (node) {
       node.scrollTop = node.scrollHeight
     }
-  }, [text, autoScroll])
+  }, [props.text, props.autoScroll])
 
   return (
     <div
       ref={scrollRef}
       className={cn(
         'h-full overflow-y-auto whitespace-pre-wrap break-words p-4 text-sm leading-relaxed',
-        className
+        props.className
       )}
     >
-      {text ? (
-        text
+      {props.text ? (
+        props.text
       ) : (
-        <span className='text-muted-foreground'>{placeholder}</span>
+        <span className='text-muted-foreground'>{props.placeholder}</span>
       )}
     </div>
   )
 }
 
-export function TestResponseViewer({
-  content,
-  reasoningContent,
-  isRunning,
-  response,
-  error,
-}: TestResponseViewerProps) {
+function ConversationArea(props: { autoScroll: boolean; children: ReactNode }) {
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!props.autoScroll) return
+    const node = scrollRef.current
+    if (node) {
+      node.scrollTop = node.scrollHeight
+    }
+  })
+
+  return (
+    <div
+      ref={scrollRef}
+      className='flex h-full flex-col gap-4 overflow-y-auto p-4'
+    >
+      {props.children}
+    </div>
+  )
+}
+
+function TurnBlock(props: {
+  role: ChatMessage['role']
+  text: string
+  isStreaming?: boolean
+  error?: string
+  placeholder?: string
+}) {
+  const { t } = useTranslation()
+  const roleLabel =
+    props.role === 'user'
+      ? t('modelTester.viewer.roleYou')
+      : t('modelTester.viewer.roleAssistant')
+
+  let body: ReactNode
+  if (props.text.length > 0) {
+    body = (
+      <div className='text-sm leading-relaxed break-words whitespace-pre-wrap'>
+        {props.text}
+      </div>
+    )
+  } else if (props.error) {
+    body = (
+      <div className='text-destructive text-sm break-words'>{props.error}</div>
+    )
+  } else {
+    body = (
+      <div className='text-muted-foreground text-sm'>
+        {props.placeholder ?? ''}
+      </div>
+    )
+  }
+
+  return (
+    <div className='flex flex-col gap-1.5'>
+      <div className='flex items-center gap-2'>
+        <Badge variant={props.role === 'user' ? 'secondary' : 'default'}>
+          {roleLabel}
+        </Badge>
+        {props.isStreaming ? <Spinner className='size-3.5' /> : null}
+      </div>
+      {body}
+    </div>
+  )
+}
+
+export function TestResponseViewer(props: TestResponseViewerProps) {
   const { t } = useTranslation()
 
-  const hasContent = content.length > 0
-  const hasReasoning = reasoningContent.length > 0
+  const hasContent = props.content.length > 0
+  const hasReasoning = props.reasoningContent.length > 0
+  const lastMessage = props.messages.at(-1)
+  const hasLiveRound = props.isRunning || lastMessage?.role === 'user'
   const isEmpty =
-    !isRunning && !hasContent && !hasReasoning && !response && !error
+    !props.isRunning &&
+    !hasContent &&
+    !hasReasoning &&
+    !props.response &&
+    !props.error &&
+    props.messages.length === 0
+
+  let body: ReactNode
+  if (isEmpty) {
+    body = (
+      <div className='flex flex-1 items-center justify-center p-8 text-center'>
+        <div className='text-muted-foreground max-w-sm text-sm'>
+          {t('modelTester.viewer.emptyHint')}
+        </div>
+      </div>
+    )
+  } else if (
+    props.error &&
+    !props.isRunning &&
+    !hasContent &&
+    props.messages.length === 0
+  ) {
+    body = (
+      <div className='flex flex-1 flex-col items-center justify-center gap-2 p-8 text-center'>
+        <Badge variant='destructive'>{t('modelTester.viewer.error')}</Badge>
+        <div className='text-destructive max-w-sm text-sm break-words'>
+          {props.error}
+        </div>
+      </div>
+    )
+  } else {
+    body = (
+      <Tabs defaultValue='content' className='flex min-h-0 flex-1 flex-col'>
+        <TabsList className='mx-3 mt-3 w-fit'>
+          <TabsTrigger value='content'>
+            {t('modelTester.viewer.tabContent')}
+          </TabsTrigger>
+          <TabsTrigger value='reasoning'>
+            <BrainIcon className='mr-1 size-3.5' />
+            {t('modelTester.viewer.tabReasoning')}
+            {hasReasoning && (
+              <span className='text-muted-foreground ml-1 text-xs'>●</span>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value='raw'>
+            <CodeIcon className='mr-1 size-3.5' />
+            {t('modelTester.viewer.tabRaw')}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value='content' className='min-h-0 flex-1'>
+          <ScrollArea className='h-full'>
+            <ConversationArea autoScroll={props.isRunning}>
+              {props.messages.map((message) => (
+                <TurnBlock
+                  key={message.id}
+                  role={message.role}
+                  text={message.content}
+                />
+              ))}
+              {hasLiveRound ? (
+                <TurnBlock
+                  role='assistant'
+                  text={props.content}
+                  isStreaming={props.isRunning}
+                  error={props.isRunning ? undefined : props.error}
+                  placeholder={
+                    props.isRunning
+                      ? t('modelTester.viewer.awaitingContent')
+                      : t('modelTester.viewer.noContent')
+                  }
+                />
+              ) : null}
+            </ConversationArea>
+          </ScrollArea>
+        </TabsContent>
+
+        <TabsContent value='reasoning' className='min-h-0 flex-1'>
+          <ScrollArea className='h-full'>
+            <ContentArea
+              text={props.reasoningContent}
+              placeholder={t('modelTester.viewer.noReasoning')}
+              autoScroll={props.isRunning}
+              className='text-muted-foreground'
+            />
+          </ScrollArea>
+        </TabsContent>
+
+        <TabsContent value='raw' className='min-h-0 flex-1'>
+          <ScrollArea className='h-full'>
+            <ContentArea
+              text={prettyPrintRawEvents(props.response?.rawEvents ?? [])}
+              placeholder={t('modelTester.viewer.noRaw')}
+              autoScroll={false}
+              className='font-mono text-xs'
+            />
+          </ScrollArea>
+        </TabsContent>
+      </Tabs>
+    )
+  }
 
   return (
     <div className='flex h-full flex-col'>
@@ -101,115 +259,49 @@ export function TestResponseViewer({
         <span className='text-sm font-medium'>
           {t('modelTester.viewer.title')}
         </span>
-        {isRunning && (
+        {props.isRunning && (
           <Badge variant='secondary'>
             <Spinner className='mr-1' />
             {t('modelTester.viewer.streaming')}
           </Badge>
         )}
-        {response && !isRunning && (
+        {props.response && !props.isRunning && (
           <>
-            <Badge variant={response.empty ? 'secondary' : 'default'}>
-              {response.empty
+            <Badge variant={props.response.empty ? 'secondary' : 'default'}>
+              {props.response.empty
                 ? t('modelTester.viewer.empty')
                 : t('modelTester.viewer.done')}
             </Badge>
             <span className='text-muted-foreground text-xs'>
               {t('modelTester.viewer.latency', {
-                value: formatLatency(response.latencyMs),
+                value: formatLatency(props.response.latencyMs),
               })}
             </span>
             <span className='text-muted-foreground text-xs'>
-              {t('modelTester.viewer.chunks', { value: response.chunks })}
+              {t('modelTester.viewer.chunks', { value: props.response.chunks })}
             </span>
-            {!response.doneReceived && (
+            {!props.response.doneReceived && (
               <span className='text-muted-foreground text-xs'>
                 {t('modelTester.viewer.noDone')}
               </span>
             )}
           </>
         )}
-        {error && !isRunning && (
+        {props.error && !props.isRunning && (
           <Badge variant='destructive'>{t('modelTester.viewer.error')}</Badge>
         )}
       </div>
 
-      {isEmpty ? (
-        <div className='flex flex-1 items-center justify-center p-8 text-center'>
-          <div className='text-muted-foreground max-w-sm text-sm'>
-            {t('modelTester.viewer.emptyHint')}
-          </div>
-        </div>
-      ) : error && !isRunning && !hasContent ? (
-        <div className='flex flex-1 flex-col items-center justify-center gap-2 p-8 text-center'>
-          <Badge variant='destructive'>{t('modelTester.viewer.error')}</Badge>
-          <div className='text-destructive max-w-sm text-sm break-words'>
-            {error}
-          </div>
-        </div>
-      ) : (
-        <Tabs defaultValue='content' className='flex min-h-0 flex-1 flex-col'>
-          <TabsList className='mx-3 mt-3 w-fit'>
-            <TabsTrigger value='content'>
-              {t('modelTester.viewer.tabContent')}
-            </TabsTrigger>
-            <TabsTrigger value='reasoning'>
-              <BrainIcon className='mr-1 size-3.5' />
-              {t('modelTester.viewer.tabReasoning')}
-              {hasReasoning && (
-                <span className='text-muted-foreground ml-1 text-xs'>●</span>
-              )}
-            </TabsTrigger>
-            <TabsTrigger value='raw'>
-              <CodeIcon className='mr-1 size-3.5' />
-              {t('modelTester.viewer.tabRaw')}
-            </TabsTrigger>
-          </TabsList>
-
-          <TabsContent value='content' className='min-h-0 flex-1'>
-            <ScrollArea className='h-full'>
-              <ContentArea
-                text={content}
-                placeholder={
-                  isRunning
-                    ? t('modelTester.viewer.awaitingContent')
-                    : t('modelTester.viewer.noContent')
-                }
-                autoScroll={isRunning}
-              />
-            </ScrollArea>
-          </TabsContent>
-
-          <TabsContent value='reasoning' className='min-h-0 flex-1'>
-            <ScrollArea className='h-full'>
-              <ContentArea
-                text={reasoningContent}
-                placeholder={t('modelTester.viewer.noReasoning')}
-                autoScroll={isRunning}
-                className='text-muted-foreground'
-              />
-            </ScrollArea>
-          </TabsContent>
-
-          <TabsContent value='raw' className='min-h-0 flex-1'>
-            <ScrollArea className='h-full'>
-              <ContentArea
-                text={prettyPrintRawEvents(response?.rawEvents ?? [])}
-                placeholder={t('modelTester.viewer.noRaw')}
-                autoScroll={false}
-                className='font-mono text-xs'
-              />
-            </ScrollArea>
-          </TabsContent>
-        </Tabs>
-      )}
+      {body}
 
       <Separator />
       <div className='text-muted-foreground flex items-center justify-between p-2 text-xs'>
         <span>{t('modelTester.viewer.hint')}</span>
         {hasContent && (
           <span className='tabular-nums'>
-            {t('modelTester.viewer.contentChars', { value: content.length })}
+            {t('modelTester.viewer.contentChars', {
+              value: props.content.length,
+            })}
           </span>
         )}
       </div>

--- a/web/src/features/model-tester/lib/templates.ts
+++ b/web/src/features/model-tester/lib/templates.ts
@@ -1,0 +1,114 @@
+// metapi-go/features/model-tester — local template library (localStorage).
+//
+// The tester ships with a small preset library (quick connectivity, format
+// conversion, long context, tool calling, chain-of-thought reasoning).
+// Presets are seeded into localStorage on first load so the library is
+// purely local (no backend dependency) and can later grow user-authored
+// templates without a wire change. Template prompts live in the i18n
+// dictionaries so the injected prompt matches the active UI language; the
+// stored records only carry i18n keys, never resolved text.
+
+export type TesterTemplate = {
+  id: string
+  labelKey: string
+  promptKey: string
+  temperature?: number
+  topP?: number
+  maxTokens?: number
+}
+
+const TEMPLATES_STORAGE_KEY = 'model-tester.templates'
+
+export const TESTER_TEMPLATE_PRESETS: readonly TesterTemplate[] = [
+  {
+    id: 'quick-connectivity',
+    labelKey: 'modelTester.template.templates.quickConnectivity.label',
+    promptKey: 'modelTester.template.templates.quickConnectivity.prompt',
+    temperature: 0,
+    maxTokens: 64,
+  },
+  {
+    id: 'format-conversion',
+    labelKey: 'modelTester.template.templates.formatConversion.label',
+    promptKey: 'modelTester.template.templates.formatConversion.prompt',
+    temperature: 0.2,
+    maxTokens: 1024,
+  },
+  {
+    id: 'long-context',
+    labelKey: 'modelTester.template.templates.longContext.label',
+    promptKey: 'modelTester.template.templates.longContext.prompt',
+    temperature: 0.3,
+    maxTokens: 2048,
+  },
+  {
+    id: 'tool-calling',
+    labelKey: 'modelTester.template.templates.toolCalling.label',
+    promptKey: 'modelTester.template.templates.toolCalling.prompt',
+    temperature: 0,
+    maxTokens: 512,
+  },
+  {
+    id: 'chain-of-thought',
+    labelKey: 'modelTester.template.templates.chainOfThought.label',
+    promptKey: 'modelTester.template.templates.chainOfThought.prompt',
+    temperature: 0.6,
+    topP: 0.9,
+    maxTokens: 2048,
+  },
+]
+
+type TemplateStorage = Pick<Storage, 'getItem' | 'setItem'>
+
+function isTesterTemplate(value: unknown): value is TesterTemplate {
+  if (!value || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  return (
+    typeof record.id === 'string' &&
+    typeof record.labelKey === 'string' &&
+    typeof record.promptKey === 'string'
+  )
+}
+
+function readStoredTemplates(storage?: TemplateStorage): TesterTemplate[] {
+  if (!storage) return []
+  try {
+    const raw = storage.getItem(TEMPLATES_STORAGE_KEY)
+    if (!raw) return []
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(isTesterTemplate)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Load the template library: stored templates win; on first visit (or a
+ * corrupt/empty store) the presets are seeded into localStorage. Callers
+ * may inject storage (tests); `defaultTemplateStorage` resolves the
+ * browser's localStorage.
+ */
+export function loadTesterTemplates(
+  storage?: TemplateStorage
+): TesterTemplate[] {
+  const stored = readStoredTemplates(storage)
+  if (stored.length > 0) return stored
+  if (storage) {
+    try {
+      storage.setItem(
+        TEMPLATES_STORAGE_KEY,
+        JSON.stringify(TESTER_TEMPLATE_PRESETS)
+      )
+    } catch {
+      // Storage unavailable (quota/denied) — fall back to the in-memory presets.
+    }
+  }
+  return [...TESTER_TEMPLATE_PRESETS]
+}
+
+/** Browser localStorage when available (jsdom/tests may omit it). */
+export function defaultTemplateStorage(): TemplateStorage | undefined {
+  if (typeof window === 'undefined') return undefined
+  return window.localStorage
+}

--- a/web/src/features/model-tester/types.ts
+++ b/web/src/features/model-tester/types.ts
@@ -10,6 +10,18 @@
 export type TestTargetFormat = 'openai' | 'claude' | 'responses' | 'gemini'
 
 /**
+ * One turn in the tester conversation. The user prompt is appended when a
+ * run starts; the assistant turn is appended when the run finishes with
+ * non-empty content. `id` is a UI-only stable key for list rendering — the
+ * wire payload only carries `role` + `content`.
+ */
+export type ChatMessage = {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+}
+
+/**
  * Form values produced by `testerSchema`. The tester builds the
  * `TestChatRequestPayload.messages` array from `systemPrompt` (role=system,
  * when present) + `prompt` (role=user). Numeric fields are plain `z.number()`
@@ -27,7 +39,10 @@ export type TestFormValues = {
 }
 
 /**
- * Variables accepted by the `useTestModel` mutation. `onDelta` is invoked
+ * Variables accepted by the `useTestModel` mutation. `history` carries the
+ * prior conversation turns (excluding the current user prompt, which
+ * `buildChatPayload` appends last) so multi-turn context is sent on the
+ * wire when the backend honors the `messages` array. `onDelta` is invoked
  * for every parsed SSE chunk during streaming so the viewer can render
  * content/reasoning as it arrives; `onDone` fires once when the stream
  * closes (success or empty). `signal` lets the caller abort an in-flight
@@ -35,6 +50,7 @@ export type TestFormValues = {
  */
 export type TestModelVariables = {
   payload: TestFormValues
+  history?: ChatMessage[]
   onDelta?: (delta: TestStreamDelta) => void
   onDone?: (summary: TestResponse) => void
   signal?: AbortSignal

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -197,7 +197,8 @@
         "empty": "The response is empty.",
         "succeeded": "Request succeeded.",
         "stopped": "Request stopped.",
-        "failed": "Request failed."
+        "failed": "Request failed.",
+        "cleared": "Session cleared."
       },
       "error": {
         "stopped": "Request was stopped.",
@@ -222,11 +223,47 @@
         "noReasoning": "No reasoning",
         "noRaw": "No raw events",
         "hint": "Tip: reasoning and raw tabs show extra model output.",
-        "contentChars": "{{value}} chars"
+        "contentChars": "{{value}} chars",
+        "roleYou": "You",
+        "roleAssistant": "Assistant"
       },
       "page": {
         "title": "Model Tester",
         "description": "Send test prompts to a model and inspect the response."
+      },
+      "template": {
+        "label": "Template",
+        "placeholder": "Load a preset…",
+        "hint": "Fills the prompt and sampling parameters from the local template library.",
+        "templates": {
+          "quickConnectivity": {
+            "label": "Quick connectivity",
+            "prompt": "ping"
+          },
+          "formatConversion": {
+            "label": "Format conversion",
+            "prompt": "Convert the following JSON object into a Markdown table and keep every field:\n\n{\n  \"id\": 42,\n  \"name\": \"relay\",\n  \"enabled\": true,\n  \"weight\": 3.5\n}\n\nReturn only the table."
+          },
+          "longContext": {
+            "label": "Long context",
+            "prompt": "Read the passage below and answer the question that follows.\n\nPassage:\nMetAPI is a meta-layer management and unified proxy for AI API aggregation platforms. It centralizes sites, accounts, token routes and channels so that one entry point can fan out to many upstream AI providers. Operators configure provider sites (OpenAI, Anthropic, Gemini, and others), connect accounts with their credentials, and define token routes that pick channels by model, weight and priority. Downstream clients then talk to a single MetAPI endpoint that behaves like each upstream API, while logs, quotas and alerts keep the fleet observable.\n\nQuestion:\nIn one short paragraph, list the four building blocks an operator configures in MetAPI."
+          },
+          "toolCalling": {
+            "label": "Tool calling",
+            "prompt": "You are an assistant that must respond with a tool call. Simulate the call for fetching the current weather in Beijing and return a JSON object with exactly three fields: \"tool\", \"arguments\", and \"result\". Output only the JSON object."
+          },
+          "chainOfThought": {
+            "label": "Chain-of-thought reasoning",
+            "prompt": "Solve the following problem step by step, showing your reasoning before the final answer:\n\nA farmer keeps chickens and rabbits. Together the animals have 35 heads and 94 legs. How many chickens and how many rabbits are there?\n\nEnd with a line that starts with \"Answer:\"."
+          }
+        }
+      },
+      "clear": {
+        "button": "Clear session",
+        "title": "Clear the session?",
+        "description": "This removes all previous rounds from the conversation. The current model and parameter settings are kept.",
+        "confirm": "Clear",
+        "cancel": "Cancel"
       }
     },
     "oauth": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -197,7 +197,8 @@
         "empty": "响应为空。",
         "succeeded": "请求成功。",
         "stopped": "请求已停止。",
-        "failed": "请求失败。"
+        "failed": "请求失败。",
+        "cleared": "会话已清空。"
       },
       "error": {
         "stopped": "请求已停止。",
@@ -222,11 +223,47 @@
         "noReasoning": "暂无推理",
         "noRaw": "暂无原始事件",
         "hint": "提示：推理和原始选项卡显示额外的模型输出。",
-        "contentChars": "{{value}} 字符"
+        "contentChars": "{{value}} 字符",
+        "roleYou": "你",
+        "roleAssistant": "助手"
       },
       "page": {
         "title": "模型测试器",
         "description": "向模型发送测试提示并查看响应。"
+      },
+      "template": {
+        "label": "模板",
+        "placeholder": "选择预设模板…",
+        "hint": "从本地模板库填入提示词与采样参数。",
+        "templates": {
+          "quickConnectivity": {
+            "label": "快速连通性",
+            "prompt": "ping"
+          },
+          "formatConversion": {
+            "label": "格式转换",
+            "prompt": "把下面的 JSON 对象转换成 Markdown 表格，保留所有字段：\n\n{\n  \"id\": 42,\n  \"name\": \"relay\",\n  \"enabled\": true,\n  \"weight\": 3.5\n}\n\n只输出表格。"
+          },
+          "longContext": {
+            "label": "长上下文",
+            "prompt": "阅读下面的材料，然后回答问题。\n\n材料：\nMetAPI 是 AI API 聚合平台的元层管理与统一代理。它把站点、账号、令牌路由和渠道集中在一起，让一个入口可以分发到多个上游 AI 提供商。运营人员配置供应商站点（OpenAI、Anthropic、Gemini 等），用凭证接入账号，并定义按模型、权重和优先级选择渠道的令牌路由。下游客户端只需对接一个 MetAPI 端点即可获得与各上游 API 一致的体验，同时日志、配额和告警让整个集群保持可观测。\n\n问题：\n用一段简短的话列出运营人员在 MetAPI 中配置的四个基本模块。"
+          },
+          "toolCalling": {
+            "label": "工具调用",
+            "prompt": "你是一个必须以工具调用作答的助手。请模拟一次查询北京当前天气的工具调用，返回一个只包含 \"tool\"、\"arguments\"、\"result\" 三个字段的 JSON 对象。只输出 JSON 对象。"
+          },
+          "chainOfThought": {
+            "label": "思维链推理",
+            "prompt": "逐步解答下面的问题，先展示推理过程，再给出最终答案：\n\n农场主养了鸡和兔，两种动物一共有 35 个头、94 只脚，鸡和兔各有多少只？\n\n结尾以「答案：」开头输出。"
+          }
+        }
+      },
+      "clear": {
+        "button": "清空会话",
+        "title": "清空会话？",
+        "description": "将删除对话中之前的所有轮次，当前模型与参数设置会保留。",
+        "confirm": "清空",
+        "cancel": "取消"
       }
     },
     "oauth": {


### PR DESCRIPTION
测试台会话化（多轮历史随请求体上送）+ localStorage 模板库（5 预置）+ 清空确认。tsgo/oxlint/vitest 全绿（347 tests）。