### PR TITLE
docs: finalize UX fan-out — roadmap statuses + strict-mode note

### DIFF
--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -39,8 +39,10 @@ master (唯一长期分支，受保护，随时可发布)
 | 要求 approve | ❌ 不强制（个人项目，自己合并自己的 PR） |
 | 合并方式 | **Squash only**（仓库级设置：关闭 merge commit 与 rebase merge） |
 | 线性历史 | 由 Squash-only 保证 |
+| 要求分支最新（strict） | ❌ **已关闭（2026-08-14）**——仍保留 12 项必检 + squash 线性历史；关闭后多个并行分支可各自 CI 绿了直接合入，无需每个 PR 串行 rebase 重跑全量 CI |
 
 > 注意：必选状态检查与 CI 的 `paths-ignore` 互斥——任何 PR 都会触发全量 CI（含纯文档 PR），否则必选检查会永久 pending 卡住合并。
+> 注意：关闭 strict 后，合并时仍以「12 项必检全绿」为准；squash 合并若有真实文件冲突仍会被 GitHub 拦截。并行开发时优先让各分支文件面不重叠。
 
 ## 4. PR 流程
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,13 @@
 > Product milestone timeline (grouped by version). Not the current-state source of truth.
 > Current state → [`STATE.md`](STATE.md) · open items → [`progress/MASTER.md`](progress/MASTER.md) · detailed version narrative → root [`CHANGELOG.md`](../CHANGELOG.md)
 
+## 2026-08-14 — Leader/Worker 并行 fan-out：5 分支合入 + strict 模式关闭
+
+- **并行开发**：5 个 Flash worker 各自在 `.worktrees/` 独立分支实现，PR #658-#662 全部 squash 合入 master（全局搜索 / 首页今日快照+StatCard / 告警富化 / 表格交互 / 测试台会话化+模板库），连同 #657 共 6 个 PR
+- **工程策略**：关闭分支保护 strict「分支必须最新」——保留 12 项必检 + squash 线性历史，允许并行分支各自 CI 绿后直接合入（`docs/git-workflow.md` §3 已记录）
+- **hook-kit 修复**：修 `leak_guard.py` 新分支 push 用空树 diff 误报历史占位符的 bug，改为与远端 merge-base 求差（补回归测试）
+- 剩余 P1：接入向导 onboarding checklist、价格对比权重对照、测试台批量延迟对比
+
 ## 2026-08-14 — 多 Agent UI/UX 对照审计 + 分发端 P0 落地
 
 - **4 个审计 agent**（动线/视觉/交互/功能对标，对照 New API × All API Hub）：结论聚合进 `docs/analysis/ui-ux-audit-2026-08.md`（25 视觉项 / 9 交互项 / 5 动线 / 8 功能差距）

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -24,13 +24,13 @@
 
 | Pri | Item | Status |
 |-----|------|--------|
-| P0 | 客户端配置一键导出（Cherry Studio / CC Switch / env / JSON） | **done**（接入对话框 + keys 行内入口） |
+| P0 | 客户端配置一键导出（Cherry Studio / CC Switch / env / JSON） | **done**（#657，接入对话框 + keys 行内入口） |
 | P0 | 接入向导（平台 → 凭证 → 连通性测试 → 引导建 token 路由） | partial（完成 toast 已改接 `/settings/downstream`；onboarding checklist 与表单连通性测试待做） |
-| P1 | 全局搜索（跨站点/账号/模型/路由/告警） | planned（后端 `/api/search` 已完备，缺前端 SearchModal） |
-| P1 | 首页今日快照（签到/余额/告警/可用性聚合） | planned（API 已就绪） |
+| P1 | 全局搜索（跨站点/账号/模型/路由/告警） | **done**（#658，⌘K Command Palette，后端 `/api/search`） |
+| P1 | 首页今日快照（签到/余额/告警/可用性聚合） | **done**（#659，快照横条 + attention 直达） |
 | P1 | 价格对比增强（路由分配权重 vs 价格对照） | planned |
-| P1 | 告警富化（受影响路由 + 替代站点 + 直达链接） | planned（alert.go 3 处） |
-| P1 | 测试台增强（模板库 + 批量延迟对比） | planned |
+| P1 | 告警富化（受影响路由 + 替代站点 + 直达链接） | **done**（#660，3 条核心告警消息富化） |
+| P1 | 测试台增强（模板库 + 批量延迟对比） | partial（#662 会话化 + 模板库；批量延迟对比待做） |
 | P2 | WebDAV 加密同步 / 移动端 PWA / Realtime/Rerank 转发 | deferred（需需求信号） |
 
 ## Engineering backlog


### PR DESCRIPTION
标记 5 个已合并 UX 项为 done；记录分支保护 strict 关闭；log.md 里程碑。纯文档。