### PR TITLE
fix(platform): surface model fetch errors instead of silent empty lists

### DIFF
--- a/platform/oneapi.go
+++ b/platform/oneapi.go
@@ -58,7 +58,7 @@ func (o *OneApiAdapter) GetModels(ctx context.Context, baseURL string, apiToken 
 	headers := authBearerHeaders(apiToken)
 	resp, err := fetchJSON(ctx, baseURL+"/v1/models", "GET", nil, headers, proxy)
 	if err != nil {
-		return []string{}, nil
+		return nil, err
 	}
 
 	return extractModelIDsFromData(resp), nil

--- a/platform/standard.go
+++ b/platform/standard.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
@@ -56,7 +57,7 @@ func (s *StandardAdapter) fetchModelsFromStandardEndpoint(ctx context.Context, b
 
 	data, ok := resp["data"].([]interface{})
 	if !ok {
-		return nil, err
+		return nil, fmt.Errorf("unexpected /v1/models response shape")
 	}
 
 	models := make([]string, 0, len(data))

--- a/platform/sub2api.go
+++ b/platform/sub2api.go
@@ -186,7 +186,16 @@ func (s *Sub2ApiAdapter) GetModels(ctx context.Context, baseURL, apiToken string
 	normalized := normalizeBaseURL(baseURL)
 	managementBase := s.resolveManagementBaseURL(normalized)
 
-	directModels := s.fetchModelsByToken(ctx, normalized, apiToken, proxy)
+	// Surface a terminal fetch error so callers can classify it (unauthorized
+	// vs timeout); otherwise return an explicit empty list for "no models".
+	finish := func(err error) ([]string, error) {
+		if err != nil {
+			return nil, err
+		}
+		return []string{}, nil
+	}
+
+	directModels, directErr := s.fetchModelsByToken(ctx, normalized, apiToken, proxy)
 	if len(directModels) > 0 {
 		return directModels, nil
 	}
@@ -194,12 +203,20 @@ func (s *Sub2ApiAdapter) GetModels(ctx context.Context, baseURL, apiToken string
 	// Session JWT cannot access /v1/models directly; discover a user key first
 	discoveredToken, _ := s.GetAPIToken(ctx, managementBase, apiToken, platformUserId, proxy)
 	if discoveredToken == nil {
-		return []string{}, nil
+		return finish(directErr)
 	}
 	if normalizeTokenKeyForCompare(*discoveredToken) == normalizeTokenKeyForCompare(apiToken) {
-		return []string{}, nil
+		return finish(directErr)
 	}
-	return s.fetchModelsByToken(ctx, normalized, *discoveredToken, proxy), nil
+
+	fallbackModels, fallbackErr := s.fetchModelsByToken(ctx, normalized, *discoveredToken, proxy)
+	if len(fallbackModels) > 0 {
+		return fallbackModels, nil
+	}
+	if fallbackErr != nil {
+		return finish(fallbackErr)
+	}
+	return finish(directErr)
 }
 
 // GetAPITokens: GET /api/v1/keys?page=1&page_size=100 + /api/v1/api-keys?page=1&page_size=100.

--- a/platform/sub2api_models.go
+++ b/platform/sub2api_models.go
@@ -35,25 +35,30 @@ func (s *Sub2ApiAdapter) resolveModelEndpoints(baseURL string) []string {
 	}
 }
 
-func (s *Sub2ApiAdapter) fetchModelsByToken(ctx context.Context, baseURL, token string, proxy *ProxyConfig) []string {
+func (s *Sub2ApiAdapter) fetchModelsByToken(ctx context.Context, baseURL, token string, proxy *ProxyConfig) ([]string, error) {
 	authToken := stripBearerPrefix(token)
 	if authToken == "" {
-		return nil
+		return nil, nil
 	}
 
+	var lastErr error
 	for _, url := range s.resolveModelEndpoints(baseURL) {
 		headers := map[string]string{"Authorization": "Bearer " + authToken}
 		resp, err := fetchJSON(ctx, url, "GET", nil, headers, proxy)
 		if err != nil {
+			lastErr = err
 			continue
 		}
 		models := extractModelIDs(resp)
 		if len(models) > 0 {
-			return models
+			return models, nil
 		}
 	}
 
-	return nil
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return []string{}, nil
 }
 
 func extractModelIDs(payload map[string]interface{}) []string {

--- a/platform/sub2api_test.go
+++ b/platform/sub2api_test.go
@@ -130,11 +130,11 @@ func TestSub2ApiAdapter_GetModels(t *testing.T) {
 	ctx := context.Background()
 
 	models, err := s.GetModels(ctx, unreachableBaseURL(t), "token", nil, nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+	if err == nil {
+		t.Error("GetModels on unreachable should surface a fetch error")
 	}
 	if len(models) != 0 {
-		t.Error("GetModels on unreachable should return empty")
+		t.Error("GetModels on unreachable should return empty models")
 	}
 }
 

--- a/platform/veloera.go
+++ b/platform/veloera.go
@@ -79,7 +79,7 @@ func (v *VeloeraAdapter) GetModels(ctx context.Context, baseURL string, apiToken
 	headers := authBearerHeaders(apiToken)
 	resp, err := fetchJSON(ctx, baseURL+"/v1/models", "GET", nil, headers, proxy)
 	if err != nil {
-		return []string{}, nil
+		return nil, err
 	}
 
 	return extractModelIDsFromData(resp), nil

--- a/platform/veloera_test.go
+++ b/platform/veloera_test.go
@@ -136,10 +136,10 @@ func TestVeloeraAdapter_GetModels(t *testing.T) {
 	defer cancel()
 
 	models, err := v.GetModels(ctx, unreachableBaseURL(t), "token", nil, nil)
-	if err != nil {
-		t.Errorf("GetModels should not error: %v", err)
+	if err == nil {
+		t.Error("GetModels on unreachable should surface a fetch error")
 	}
 	if len(models) != 0 {
-		t.Error("GetModels on unreachable should return empty")
+		t.Error("GetModels on unreachable should return empty models")
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes the `(nil, nil)` silent-success bug in `fetchModelsFromStandardEndpoint` (malformed 200 → descriptive error).
- OneAPI / Veloera / Sub2API `GetModels` now propagate terminal fetch errors instead of swallowing them into empty lists, so `classifyModelRefreshError` can correctly report `unauthorized`/`timeout` instead of misleading "no models available".
- Sub2API `fetchModelsByToken` now returns `([]string, error)`, remembering the last endpoint error and surfacing it only when all probes fail; a genuinely empty result still returns `([]string{}, nil)`.

## Test plan
- Updated `TestVeloeraAdapter_GetModels` + `TestSub2ApiAdapter_GetModels` to assert the new error-surfacing behavior.
- `go build ./...` clean; `go test ./platform/...` passes.

Closes #673