### PR TITLE
feat(detect): wire adapter Detect chain into site auto-detection

### DIFF
--- a/service/site_detect.go
+++ b/service/site_detect.go
@@ -1,8 +1,12 @@
 package service
 
 import (
+	"context"
 	"net/url"
 	"strings"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/platform"
 )
 
 // DetectResult is the result of platform detection.
@@ -117,8 +121,13 @@ func DetectSite(rawURL string) *DetectResult {
 	case strings.Contains(host, "aistudio.google.com") || strings.Contains(host, "makersuite.google.com"):
 		platform = "gemini"
 	default:
-		// Check for common NewAPI/OneAPI patterns
-		if strings.Contains(host, "anyrouter") || strings.Contains(parsed.Path, "anyrouter") {
+		// Adapter-based detection for gateway forks (NewAPI/OneAPI/Sub2API/
+		// one-hub/done-hub/veloera/cliproxyapi/anyrouter). Keyword heuristics
+		// remain as a fallback for WAF/shield-fronted deployments whose HTTP
+		// probes are blocked.
+		if name := detectPlatformByAdapter(trimmed); name != "" {
+			platform = name
+		} else if strings.Contains(host, "anyrouter") || strings.Contains(parsed.Path, "anyrouter") {
 			platform = "anyrouter"
 		} else if strings.Contains(host, "oneapi") || strings.Contains(host, "new-api") || strings.Contains(host, "newapi") {
 			platform = "new-api"
@@ -164,4 +173,28 @@ func CanonicalizeSiteURL(rawURL string) string {
 	parsed.RawQuery = ""
 	parsed.Fragment = ""
 	return strings.TrimRight(parsed.String(), "/")
+}
+
+// adapterDetectTimeout bounds the adapter-chain detection. Detection is a
+// one-shot admin action (site create/import), so a few seconds is acceptable.
+const adapterDetectTimeout = 6 * time.Second
+
+// detectPlatformByAdapter runs the adapter registry Detect chain in registration
+// order (specific forks before generic adapters, OneAPI catch-all last). The
+// first true result wins. Errors are treated as "not detected" so one broken
+// probe cannot abort the whole chain.
+func detectPlatformByAdapter(rawURL string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), adapterDetectTimeout)
+	defer cancel()
+
+	for _, adapter := range platform.ListAdapters() {
+		ok, err := adapter.Detect(ctx, rawURL)
+		if err != nil {
+			continue
+		}
+		if ok {
+			return adapter.PlatformName()
+		}
+	}
+	return ""
 }

--- a/service/site_service_test.go
+++ b/service/site_service_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -277,10 +279,44 @@ func TestDetectSite_NewAPI(t *testing.T) {
 	}
 }
 
+func TestDetectSite_AdapterChain_NewAPI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/status" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true,"data":{"system_name":"MyNewAPI"}}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	result := DetectSite(server.URL)
+	if result == nil || result.Platform != "new-api" {
+		t.Fatalf("expected 'new-api', got %v", result)
+	}
+}
+
+func TestDetectSite_AdapterChain_OneAPI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/status" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true,"data":{"version":"1.0"}}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	result := DetectSite(server.URL)
+	if result == nil || result.Platform != "one-api" {
+		t.Fatalf("expected 'one-api', got %v", result)
+	}
+}
+
 func TestDetectSite_Unknown(t *testing.T) {
 	tests := []string{
 		"https://unknown-llm-provider.example.com",
-		"https://random-site.com",
+		"https://random-site.invalid",
 		"",
 	}
 	for _, url := range tests {


### PR DESCRIPTION
## Summary
`DetectSite` previously relied only on hostname string heuristics, so gateway forks (one-hub / done-hub / veloera / sub2api / cliproxyapi) could never be auto-detected, and real OneAPI hosts were mislabeled as `new-api`.

This wires the `platform.ListAdapters()` `Detect` chain into the default branch of `DetectSite`:
- Iterates the registry in registration order (specific forks before generic adapters, OneAPI catch-all last), first `true` wins.
- Bounded by a 6s context; a broken probe (error) is treated as "not detected".
- Keyword heuristics remain as a fallback for WAF/shield-fronted deployments whose HTTP probes are blocked.

## Test plan
- Added `TestDetectSite_AdapterChain_NewAPI` + `TestDetectSite_AdapterChain_OneAPI` (httptest) verifying the NewAPI vs OneAPI discriminator.
- Updated `TestDetectSite_Unknown` to use a reserved `.invalid` TLD so it never makes real network calls.
- `go build ./...` clean; `go test ./service/ -count=1` passes.

Closes #664