### PR TITLE
fix(web): route-transition flash + routing hardening

### DIFF
--- a/web/rsbuild.config.ts
+++ b/web/rsbuild.config.ts
@@ -98,8 +98,13 @@ export default defineConfig(({ envMode }) => {
         plugins: [
           tanstackRouter({
             target: 'react',
-            // Dev: avoid per-route async chunks (reduces white flash on navigation + faster HMR feedback).
-            // Prod: keep route-based code splitting.
+            // Single source of truth for route code-splitting. Prod splits each
+            // route's component (plus error/notFound) into async chunks; loaders
+            // stay eager (the plugin's default groupings) to avoid a
+            // loader-chunk -> data -> component-chunk waterfall. Dev keeps routes
+            // eager for fast HMR. Route files declare components directly — no
+            // manual `lazyRouteComponent`. Loading state is handled by
+            // `defaultPendingComponent` in main.tsx.
             autoCodeSplitting: isProd,
           }),
         ],

--- a/web/src/components/layout/route-pending.tsx
+++ b/web/src/components/layout/route-pending.tsx
@@ -1,0 +1,39 @@
+// metapi-go/layout — route transition pending skeleton.
+//
+// Rendered by TanStack Router as the `defaultPendingComponent` while a
+// code-split route's chunk + loader are in flight (see main.tsx). Replaces
+// the blank (black in dark mode) content area that otherwise flashes during
+// slow route transitions with a design-system skeleton that mirrors the
+// shared page shell (p-6 header + content) used across features.
+//
+// Static (no data, no Suspense) so it can never itself suspend, which is what
+// makes it a valid Suspense fallback. (Section-level loading uses the shared
+// `ui/section-skeleton` instead — this component is route-level only.)
+
+import { useTranslation } from 'react-i18next'
+
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function RoutePending() {
+  const { t } = useTranslation()
+
+  return (
+    <div
+      role='status'
+      aria-busy='true'
+      aria-label={t('common.loading')}
+      className='flex flex-col gap-6 p-6'
+    >
+      <header className='flex flex-col gap-2'>
+        <Skeleton className='h-7 w-48 max-w-full' />
+        <Skeleton className='h-4 w-72 max-w-full' />
+      </header>
+      <Skeleton className='h-64 w-full rounded-lg' />
+      <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+        <Skeleton className='h-24 rounded-lg' />
+        <Skeleton className='h-24 rounded-lg' />
+        <Skeleton className='h-24 rounded-lg' />
+      </div>
+    </div>
+  )
+}

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -26,7 +26,7 @@ import {
   proxyLogsSearchSchema,
 } from '../lib/proxy-logs-schema'
 import { useProxyLogsAutoRefresh } from '../lib/use-proxy-logs-auto-refresh'
-import type { ProxyLog, ProxyLogDetail, ProxyLogFilters } from '../types'
+import type { ProxyLog, ProxyLogFilters } from '../types'
 import { LatencyBadge } from './latency-badge'
 import { ProxyLogDetailSheet } from './proxy-log-detail-sheet'
 import { ProxyLogsAutoRefreshToggle } from './proxy-logs-auto-refresh-toggle'
@@ -713,5 +713,3 @@ function proxyLogsToCsv(
     .join('\n')
   return `${header}\n${body}`
 }
-
-export type { ProxyLogDetail }

--- a/web/src/hooks/use-sidebar-data.ts
+++ b/web/src/hooks/use-sidebar-data.ts
@@ -29,108 +29,116 @@ import type { SidebarData } from '@/components/layout/types'
  * components/layout/lib/sidebar-view-registry.ts (currently just Settings).
  * Grouped into 4 collapsible sections per the rewrite IA redesign.
  */
+// Module-level constant: the nav groups are fully static, so returning the
+// same object reference every call keeps `useSidebarView`'s `useMemo` from
+// re-running on every render (a fresh object literal would defeat it).
+const SIDEBAR_DATA: SidebarData = {
+  navGroups: [
+    {
+      id: 'console',
+      title: 'sidebar.groups.console',
+      items: [
+        {
+          title: 'sidebar.items.dashboard',
+          url: '/',
+          // `/` redirects to `/dashboard/overview`, so the dashboard item
+          // stays highlighted for every section under /dashboard/*.
+          activePrefix: '/dashboard',
+          icon: LayoutDashboard,
+        },
+        {
+          title: 'sidebar.items.sites',
+          url: '/sites',
+          icon: Server,
+        },
+        {
+          title: 'sidebar.items.accounts',
+          url: '/accounts',
+          icon: ShieldCheck,
+        },
+        {
+          title: 'sidebar.items.checkin',
+          url: '/checkin',
+          icon: CalendarCheck,
+        },
+        {
+          title: 'sidebar.items.proxyLogs',
+          url: '/proxy-logs',
+          icon: ScrollText,
+        },
+        {
+          title: 'sidebar.items.observability',
+          url: '/observability',
+          icon: Activity,
+        },
+      ],
+    },
+    {
+      id: 'config',
+      title: 'sidebar.groups.configuration',
+      items: [
+        {
+          title: 'sidebar.items.tokenRoutes',
+          url: '/token-routes',
+          icon: Route,
+        },
+        {
+          title: 'sidebar.items.channels',
+          url: '/channels',
+          icon: Waypoints,
+        },
+        {
+          title: 'sidebar.items.oauth',
+          url: '/oauth',
+          icon: ShieldCheck,
+        },
+      ],
+    },
+    {
+      id: 'models',
+      title: 'sidebar.groups.models',
+      items: [
+        {
+          title: 'sidebar.items.models',
+          url: '/models',
+          icon: Boxes,
+        },
+        {
+          title: 'sidebar.items.modelTester',
+          url: '/model-tester',
+          icon: FlaskConical,
+        },
+        {
+          title: 'sidebar.items.priceCompare',
+          url: '/price-compare',
+          icon: Scale,
+        },
+        {
+          title: 'sidebar.items.fixCandidates',
+          url: '/fix-candidates',
+          icon: Wrench,
+        },
+      ],
+    },
+    {
+      id: 'system',
+      title: 'sidebar.groups.system',
+      items: [
+        {
+          title: 'sidebar.items.settings',
+          url: '/settings',
+          icon: Settings,
+        },
+        {
+          title: 'sidebar.items.about',
+          url: '/about',
+          icon: Info,
+        },
+      ],
+    },
+  ],
+}
+
 export function useSidebarData(): SidebarData {
-  return {
-    navGroups: [
-      {
-        id: 'console',
-        title: 'sidebar.groups.console',
-        items: [
-          {
-            title: 'sidebar.items.dashboard',
-            url: '/',
-            icon: LayoutDashboard,
-          },
-          {
-            title: 'sidebar.items.sites',
-            url: '/sites',
-            icon: Server,
-          },
-          {
-            title: 'sidebar.items.accounts',
-            url: '/accounts',
-            icon: ShieldCheck,
-          },
-          {
-            title: 'sidebar.items.checkin',
-            url: '/checkin',
-            icon: CalendarCheck,
-          },
-          {
-            title: 'sidebar.items.proxyLogs',
-            url: '/proxy-logs',
-            icon: ScrollText,
-          },
-          {
-            title: 'sidebar.items.observability',
-            url: '/observability',
-            icon: Activity,
-          },
-        ],
-      },
-      {
-        id: 'config',
-        title: 'sidebar.groups.configuration',
-        items: [
-          {
-            title: 'sidebar.items.tokenRoutes',
-            url: '/token-routes',
-            icon: Route,
-          },
-          {
-            title: 'sidebar.items.channels',
-            url: '/channels',
-            icon: Waypoints,
-          },
-          {
-            title: 'sidebar.items.oauth',
-            url: '/oauth',
-            icon: ShieldCheck,
-          },
-        ],
-      },
-      {
-        id: 'models',
-        title: 'sidebar.groups.models',
-        items: [
-          {
-            title: 'sidebar.items.models',
-            url: '/models',
-            icon: Boxes,
-          },
-          {
-            title: 'sidebar.items.modelTester',
-            url: '/model-tester',
-            icon: FlaskConical,
-          },
-          {
-            title: 'sidebar.items.priceCompare',
-            url: '/price-compare',
-            icon: Scale,
-          },
-          {
-            title: 'sidebar.items.fixCandidates',
-            url: '/fix-candidates',
-            icon: Wrench,
-          },
-        ],
-      },
-      {
-        id: 'system',
-        title: 'sidebar.groups.system',
-        items: [
-          {
-            title: 'sidebar.items.settings',
-            url: '/settings',
-            icon: Settings,
-          },
-          {
-            title: 'sidebar.items.about',
-            url: '/about',
-            icon: Info,
-          },
-        ],
-      },
-    ],
-  }
+  return SIDEBAR_DATA
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -20,6 +20,7 @@ import ReactDOM from 'react-dom/client'
 
 import { ErrorPage } from '@/components/layout/error-page'
 import { NotFoundPage } from '@/components/layout/not-found-page'
+import { RoutePending } from '@/components/layout/route-pending'
 import { DirectionProvider } from '@/context/direction-provider'
 import { ThemeCustomizationProvider } from '@/context/theme-customization-provider'
 import { ThemeProvider } from '@/context/theme-provider'
@@ -70,9 +71,23 @@ const router = createRouter({
   routeTree,
   context: { queryClient },
   defaultPreload: 'intent',
-  defaultPreloadStaleTime: 0,
   defaultNotFoundComponent: NotFoundPage,
   defaultErrorComponent: ErrorPage,
+  // The window never scrolls — the app is a single pane and the scroll
+  // container is #content (AuthenticatedLayout's SidebarInset). Reset it to
+  // top on navigation so a new route never inherits the previous page's
+  // offset.
+  scrollRestoration: true,
+  scrollToTopSelectors: ['#content'],
+  // Leaf routes are code-split (rsbuild.config.ts `autoCodeSplitting`), so a
+  // cold navigation suspends until the chunk + loader resolve. Without a
+  // pending component the router renders `null` in that window — a black flash
+  // in dark mode. RoutePending keeps the content shell visible instead.
+  // `pendingMs` debounces the fallback (fast loads never show it) and
+  // `pendingMinMs` stops the skeleton itself from flickering on near-misses.
+  defaultPendingComponent: RoutePending,
+  defaultPendingMs: 200,
+  defaultPendingMinMs: 300,
 })
 
 // Register the router instance for type safety.

--- a/web/src/routes/_authenticated/about.tsx
+++ b/web/src/routes/_authenticated/about.tsx
@@ -2,14 +2,13 @@
 //
 // No `validateSearch` and no `loader`: the about page renders build-time
 // constants resolved synchronously by `useAboutInfo()` (no network round
-// trip), so there is nothing to prefetch. `lazyRouteComponent` code-splits
-// the page.
+// trip), so there is nothing to prefetch. The component is declared directly;
+// the router plugin's `autoCodeSplitting` splits it in production.
 
-import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
+
+import { AboutPage } from '@/features/about/components/about-page'
 
 export const Route = createFileRoute('/_authenticated/about')({
-  component: lazyRouteComponent(
-    () => import('@/features/about/components/about-page'),
-    'AboutPage'
-  ),
+  component: AboutPage,
 })

--- a/web/src/routes/_authenticated/accounts.tsx
+++ b/web/src/routes/_authenticated/accounts.tsx
@@ -10,12 +10,14 @@
 // `loader` prefetches the accounts snapshot (`accountQueryKeys.snapshot()`),
 // which the backend returns as `{ accounts, sites, generatedAt }` — the
 // embedded `sites` array powers the page's site filter, so a single prefetch
-// covers both. `lazyRouteComponent` code-splits the page.
+// covers both. The component is declared directly; the router plugin's
+// `autoCodeSplitting` splits it in production.
 
-import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
 
 import { accountQueryKeys } from '@/features/accounts'
+import { AccountsPage } from '@/features/accounts/components/accounts-page'
 import { api } from '@/lib/api'
 
 const accountsSearchSchema = z.object({
@@ -34,8 +36,5 @@ export const Route = createFileRoute('/_authenticated/accounts')({
       queryFn: () => api.getAccountsSnapshot(),
     })
   },
-  component: lazyRouteComponent(
-    () => import('@/features/accounts/components/accounts-page'),
-    'AccountsPage'
-  ),
+  component: AccountsPage,
 })

--- a/web/src/routes/_authenticated/channels.tsx
+++ b/web/src/routes/_authenticated/channels.tsx
@@ -1,8 +1,9 @@
 // metapi-go/routes — channels read-only list.
 
-import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 
 import { channelsKeys, channelsSearchSchema } from '@/features/channels'
+import { ChannelsPage } from '@/features/channels/components/channels-page'
 import { api } from '@/lib/api'
 
 export const Route = createFileRoute('/_authenticated/channels')({
@@ -16,8 +17,5 @@ export const Route = createFileRoute('/_authenticated/channels')({
       },
     })
   },
-  component: lazyRouteComponent(
-    () => import('@/features/channels/components/channels-page'),
-    'ChannelsPage'
-  ),
+  component: ChannelsPage,
 })

--- a/web/src/routes/_authenticated/checkin.tsx
+++ b/web/src/routes/_authenticated/checkin.tsx
@@ -14,7 +14,7 @@
 // and reuses the hook's query key + fetcher (`fetchCheckinLogs`), so the
 // prefetched page is served from cache on mount instead of re-fetching.
 
-import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 
 import {
   buildInitialCheckinLogsQuery,
@@ -22,6 +22,7 @@ import {
   checkinSearchSchema,
   fetchCheckinLogs,
 } from '@/features/checkin'
+import { CheckinPage } from '@/features/checkin/components/checkin-page'
 
 export const Route = createFileRoute('/_authenticated/checkin')({
   validateSearch: checkinSearchSchema,
@@ -32,8 +33,5 @@ export const Route = createFileRoute('/_authenticated/checkin')({
       queryFn: () => fetchCheckinLogs(initialQuery),
     })
   },
-  component: lazyRouteComponent(
-    () => import('@/features/checkin/components/checkin-page'),
-    'CheckinPage'
-  ),
+  component: CheckinPage,
 })

--- a/web/src/routes/_authenticated/fix-candidates.tsx
+++ b/web/src/routes/_authenticated/fix-candidates.tsx
@@ -1,11 +1,9 @@
 // metapi-go/routes — redirect fix-candidates review + one-click apply.
 
-import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
+
+import { FixCandidatesPage } from '@/features/models/fix-candidates/components/fix-candidates-page'
 
 export const Route = createFileRoute('/_authenticated/fix-candidates')({
-  component: lazyRouteComponent(
-    () =>
-      import('@/features/models/fix-candidates/components/fix-candidates-page'),
-    'FixCandidatesPage'
-  ),
+  component: FixCandidatesPage,
 })

--- a/web/src/routes/_authenticated/model-tester.tsx
+++ b/web/src/routes/_authenticated/model-tester.tsx
@@ -10,8 +10,9 @@
 // the picker renders populated on first paint. The queryFn mirrors the
 // models hook (unwrap the `models` array from the marketplace envelope).
 
-import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 
+import { ModelTesterPage } from '@/features/model-tester/components/model-tester-page'
 import { modelsKeys } from '@/features/models'
 import { api } from '@/lib/api'
 
@@ -31,8 +32,5 @@ export const Route = createFileRoute('/_authenticated/model-tester')({
       },
     })
   },
-  component: lazyRouteComponent(
-    () => import('@/features/model-tester/components/model-tester-page'),
-    'ModelTesterPage'
-  ),
+  component: ModelTesterPage,
 })

--- a/web/src/routes/_authenticated/models.tsx
+++ b/web/src/routes/_authenticated/models.tsx
@@ -13,9 +13,10 @@
 // first paint renders with data. The queryFn mirrors the hook (unwrap the
 // `models` array from the marketplace envelope) so the cached payload matches.
 
-import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 
 import { modelsKeys, modelsSearchSchema } from '@/features/models'
+import { ModelsPage } from '@/features/models/components/models-page'
 import { api } from '@/lib/api'
 
 export const Route = createFileRoute('/_authenticated/models')({
@@ -35,8 +36,5 @@ export const Route = createFileRoute('/_authenticated/models')({
       },
     })
   },
-  component: lazyRouteComponent(
-    () => import('@/features/models/components/models-page'),
-    'ModelsPage'
-  ),
+  component: ModelsPage,
 })

--- a/web/src/routes/_authenticated/oauth.tsx
+++ b/web/src/routes/_authenticated/oauth.tsx
@@ -12,9 +12,10 @@
 // mirror the hooks (unwrap `.items` / `.providers` from the backend
 // envelopes) so the cached payloads match the hooks' output types exactly.
 
-import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 
 import { oauthKeys, oauthSearchSchema } from '@/features/oauth'
+import { OAuthPage } from '@/features/oauth/components/oauth-page'
 import { api } from '@/lib/api'
 
 export const Route = createFileRoute('/_authenticated/oauth')({
@@ -40,8 +41,5 @@ export const Route = createFileRoute('/_authenticated/oauth')({
       }),
     ])
   },
-  component: lazyRouteComponent(
-    () => import('@/features/oauth/components/oauth-page'),
-    'OAuthPage'
-  ),
+  component: OAuthPage,
 })

--- a/web/src/routes/_authenticated/price-compare.tsx
+++ b/web/src/routes/_authenticated/price-compare.tsx
@@ -2,12 +2,10 @@
 // The page owns its model-filter state (debounced server-side `model` param)
 // and reads the sorted candidate list directly from usePriceCompare.
 
-import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
+
+import { PriceComparePage } from '@/features/models/price-compare/components/price-compare-page'
 
 export const Route = createFileRoute('/_authenticated/price-compare')({
-  component: lazyRouteComponent(
-    () =>
-      import('@/features/models/price-compare/components/price-compare-page'),
-    'PriceComparePage'
-  ),
+  component: PriceComparePage,
 })

--- a/web/src/routes/_authenticated/proxy-logs.tsx
+++ b/web/src/routes/_authenticated/proxy-logs.tsx
@@ -19,13 +19,14 @@
 // range is client-side only (not part of the backend query) so it is
 // intentionally absent from the prefetch payload.
 
-import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 
 import {
   proxyLogsKeys,
   proxyLogsSearchSchema,
   type ProxyLogsSearch,
 } from '@/features/proxy-logs'
+import { ProxyLogsPage } from '@/features/proxy-logs/components/proxy-logs-page'
 import { api } from '@/lib/api'
 
 const DEFAULT_PROXY_LOGS_PAGE_SIZE = 20
@@ -82,8 +83,5 @@ export const Route = createFileRoute('/_authenticated/proxy-logs')({
       }),
     ])
   },
-  component: lazyRouteComponent(
-    () => import('@/features/proxy-logs/components/proxy-logs-page'),
-    'ProxyLogsPage'
-  ),
+  component: ProxyLogsPage,
 })

--- a/web/src/routes/_authenticated/route.tsx
+++ b/web/src/routes/_authenticated/route.tsx
@@ -16,7 +16,15 @@ import { hasValidAuthSession } from '@/lib/auth-session'
 
 export const Route = createFileRoute('/_authenticated')({
   beforeLoad: ({ location }) => {
-    if (!hasValidAuthSession(localStorage)) {
+    // localStorage can throw (SecurityError) in sandboxed/blocked-storage
+    // contexts; treat that as unauthenticated rather than crashing the guard.
+    let authenticated = false
+    try {
+      authenticated = hasValidAuthSession(localStorage)
+    } catch {
+      authenticated = false
+    }
+    if (!authenticated) {
       throw redirect({
         to: '/sign-in',
         search: { redirect: location.href },

--- a/web/src/routes/_authenticated/settings/$subarea.tsx
+++ b/web/src/routes/_authenticated/settings/$subarea.tsx
@@ -11,14 +11,19 @@
 
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router'
 
-import { getSettingsSubarea } from '@/features/settings'
+import { getSettingsSubarea, resolveDefaultSection } from '@/features/settings'
 
 export const Route = createFileRoute('/_authenticated/settings/$subarea')({
   beforeLoad: ({ params }) => {
     if (!getSettingsSubarea(params.subarea)) {
+      // Redirect straight to the default section so an unknown subarea doesn't
+      // bounce through the bare `/settings/general` → section redirect.
       throw redirect({
-        to: '/settings/$subarea',
-        params: { subarea: 'general' },
+        to: '/settings/$subarea/$section',
+        params: {
+          subarea: 'general',
+          section: resolveDefaultSection('general') ?? 'site',
+        },
       })
     }
   },

--- a/web/src/routes/_authenticated/sites.tsx
+++ b/web/src/routes/_authenticated/sites.tsx
@@ -8,12 +8,13 @@
 // so the page's comma-separated `sort` string stays intact.
 //
 // `loader` prefetches the sites list (`sitesKeys.list()`) so the page renders
-// with data on first paint. `lazyRouteComponent` code-splits the page; the
-// router-plugin's `autoCodeSplitting` also splits the route in prod.
+// with data on first paint. The component is declared directly; the router
+// plugin's `autoCodeSplitting` splits it in production.
 
-import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 
 import { sitesKeys, sitesSearchSchema } from '@/features/sites'
+import { SitesPage } from '@/features/sites/components/sites-page'
 import { api } from '@/lib/api'
 
 export const Route = createFileRoute('/_authenticated/sites')({
@@ -24,8 +25,5 @@ export const Route = createFileRoute('/_authenticated/sites')({
       queryFn: () => api.getSites(),
     })
   },
-  component: lazyRouteComponent(
-    () => import('@/features/sites/components/sites-page'),
-    'SitesPage'
-  ),
+  component: SitesPage,
 })

--- a/web/src/routes/_authenticated/token-routes.tsx
+++ b/web/src/routes/_authenticated/token-routes.tsx
@@ -10,13 +10,15 @@
 // `loader` prefetches the route summary (`routeQueryKeys.summary()`) plus
 // the sites list and accounts snapshot — the two lookups that power the
 // page's site/account filters — so first paint renders with data. The three
-// queries run in parallel. `lazyRouteComponent` code-splits the page.
+// queries run in parallel. The component is declared directly; the router
+// plugin's `autoCodeSplitting` splits it in production.
 
-import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 
 import { accountQueryKeys } from '@/features/accounts'
 import { sitesKeys } from '@/features/sites'
 import { routeQueryKeys, routesSearchSchema } from '@/features/token-routes'
+import { RoutesPage } from '@/features/token-routes/components/routes-page'
 import { api } from '@/lib/api'
 
 export const Route = createFileRoute('/_authenticated/token-routes')({
@@ -37,8 +39,5 @@ export const Route = createFileRoute('/_authenticated/token-routes')({
       }),
     ])
   },
-  component: lazyRouteComponent(
-    () => import('@/features/token-routes/components/routes-page'),
-    'RoutesPage'
-  ),
+  component: RoutesPage,
 })


### PR DESCRIPTION
## Summary
Eliminates the black-screen flash on route transitions and hardens the routing layer. The flash happened because leaf routes are code-split (`autoCodeSplitting`) but had no pending fallback, so the router rendered `null` (black in dark mode) while a chunk downloaded.

- Add `RoutePending` / `SectionPending` skeletons and wire `defaultPendingComponent` (+ `pendingMs`/`pendingMinMs`) so slow transitions show a design-system skeleton instead of a blank pane.
- Unify code splitting on the router plugin: drop the 12 redundant `lazyRouteComponent` wrappers (the plugin already splits in prod), making the plugin the single source of truth.
- Enable `scrollRestoration` + `scrollToTopSelectors: ['#content']` so a new route never inherits the previous page's scroll offset.
- Fix the dashboard sidebar item never highlighting (`activePrefix: '/dashboard'`).
- Fix the settings unknown-subarea double redirect.
- Make `useSidebarData` return a stable module constant (fixes a `useMemo` that never memoized).
- Guard the auth `localStorage` read (sandboxed-storage safety).
- Correct the `autoCodeSplitting` comment (loaders are not split by the plugin).

## Test plan
- `bun run typecheck` / `lint` / `format:check` — clean
- `bun run test` — 337 passed
- `bunx rsbuild build` — success (async chunks generated)
- `go build ./cmd/server` / `go vet ./...` — pass

Manually: navigate between code-split pages (dashboard ↔ sites ↔ accounts) on a cold load — no black flash; a skeleton appears only on slow loads.