### PR TITLE
fix(web): design-system P1 bugs + WCAG soft-tint contrast tokens

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -46,7 +46,7 @@
           root.style.colorScheme = theme
           // Use the design token as soon as CSS is available, with a matching
           // light/dark fallback before the stylesheet finishes loading.
-          var bg = theme === 'dark' ? '#111111' : '#ffffff'
+          var bg = theme === 'dark' ? '#1d1d1d' : '#ffffff'
           root.style.setProperty('--bootstrap-background', bg)
           root.style.backgroundColor =
             'var(--background, var(--bootstrap-background))'

--- a/web/src/components/data-table/core/column-pinning.ts
+++ b/web/src/components/data-table/core/column-pinning.ts
@@ -31,10 +31,13 @@ function getPinnedColumnClassName(
   pinnedColumn: DataTablePinnedColumn,
   kind: 'header' | 'cell'
 ) {
+  // `--foreground` is OKLCH, so `hsl(var(--foreground))` is invalid and the
+  // whole shadow is dropped. Mix the foreground at low alpha for a subtle
+  // pinned-column edge instead of a hard dark line.
   const edgeClassName =
     pinnedColumn.side === 'left'
-      ? 'shadow-[8px_0_10px_-10px_hsl(var(--foreground))]'
-      : 'shadow-[-8px_0_10px_-10px_hsl(var(--foreground))]'
+      ? 'shadow-[8px_0_10px_-10px_color-mix(in_oklch,var(--foreground)_12%,transparent)]'
+      : 'shadow-[-8px_0_10px_-10px_color-mix(in_oklch,var(--foreground)_12%,transparent)]'
 
   return cn(
     'sticky whitespace-nowrap',

--- a/web/src/components/data-table/core/data-table-view.tsx
+++ b/web/src/components/data-table/core/data-table-view.tsx
@@ -144,6 +144,7 @@ function SplitHeaderTableView<TData>({
       >
         <table
           data-slot='table'
+          data-table-stagger='true'
           className={cn(
             'w-full caption-bottom text-sm tabular-nums [&_td]:text-sm [&_td_*]:text-sm [&_th]:text-sm [&_th_*]:text-sm',
             props.tableClassName

--- a/web/src/components/data-table/core/status-badge.tsx
+++ b/web/src/components/data-table/core/status-badge.tsx
@@ -34,27 +34,27 @@ const dotColorMap = {
 } as const
 
 const textColorMap = {
-  success: 'text-success',
-  warning: 'text-warning',
-  danger: 'text-destructive',
-  info: 'text-info',
+  success: 'text-success-soft-fg',
+  warning: 'text-warning-soft-fg',
+  danger: 'text-destructive-soft-fg',
+  info: 'text-info-soft-fg',
   neutral: 'text-muted-foreground',
   purple: 'text-chart-4',
-  amber: 'text-warning',
+  amber: 'text-warning-soft-fg',
   blue: 'text-chart-1',
   cyan: 'text-chart-2',
-  green: 'text-success',
+  green: 'text-success-soft-fg',
   grey: 'text-muted-foreground',
   indigo: 'text-chart-1',
-  'light-blue': 'text-info',
-  'light-green': 'text-success',
+  'light-blue': 'text-info-soft-fg',
+  'light-green': 'text-success-soft-fg',
   lime: 'text-chart-3',
-  orange: 'text-warning',
+  orange: 'text-warning-soft-fg',
   pink: 'text-chart-5',
-  red: 'text-destructive',
+  red: 'text-destructive-soft-fg',
   teal: 'text-chart-2',
   violet: 'text-chart-4',
-  yellow: 'text-warning',
+  yellow: 'text-warning-soft-fg',
 } as const
 
 type StatusVariant = keyof typeof dotColorMap

--- a/web/src/components/layout/components/app-header.tsx
+++ b/web/src/components/layout/components/app-header.tsx
@@ -53,10 +53,9 @@ export function AppHeader({
   return (
     <header
       className={cn(
-        'bg-background/95 supports-[backdrop-filter]:bg-background/60',
+        'bg-background/95 supports-[backdrop-filter]:bg-background/60 backdrop-blur-lg',
         'sticky top-0 z-50 w-full',
-        'flex h-14 items-center gap-2 border-b px-4',
-        '[--app-header-height:3.5rem]'
+        'flex h-14 items-center gap-2 border-b px-4'
       )}
     >
       <SidebarTrigger className='md:hidden' />

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -16,10 +16,10 @@ const badgeVariants = cva(
         destructive:
           'bg-destructive/10 text-destructive-soft-fg focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20',
         warning:
-          'border-warning/40 bg-warning/10 text-warning focus-visible:ring-warning/20',
+          'border-warning/40 bg-warning/10 text-warning-soft-fg focus-visible:ring-warning/20',
         success:
-          'border-success/40 bg-success/10 text-success focus-visible:ring-success/20',
-        info: 'border-info/40 bg-info/10 text-info focus-visible:ring-info/20',
+          'border-success/40 bg-success/10 text-success-soft-fg focus-visible:ring-success/20',
+        info: 'border-info/40 bg-info/10 text-info-soft-fg focus-visible:ring-info/20',
         outline:
           'border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground',
         ghost:

--- a/web/src/components/ui/icon-badge.tsx
+++ b/web/src/components/ui/icon-badge.tsx
@@ -17,10 +17,10 @@ const iconBadgeVariants = cva(
       tone: {
         default: 'bg-muted text-muted-foreground',
         primary: 'bg-primary/10 text-primary',
-        success: 'bg-success/10 text-success',
-        warning: 'bg-warning/10 text-warning',
-        info: 'bg-info/10 text-info',
-        destructive: 'bg-destructive/10 text-destructive',
+        success: 'bg-success/10 text-success-soft-fg',
+        warning: 'bg-warning/10 text-warning-soft-fg',
+        info: 'bg-info/10 text-info-soft-fg',
+        destructive: 'bg-destructive/10 text-destructive-soft-fg',
       },
       size: {
         sm: 'size-7 rounded-md [&>svg]:size-3.5',

--- a/web/src/components/ui/skeleton.tsx
+++ b/web/src/components/ui/skeleton.tsx
@@ -5,7 +5,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot='skeleton'
-      className={cn('bg-muted animate-pulse rounded-md', className)}
+      className={cn('bg-(--skeleton-base) animate-pulse rounded-md', className)}
       {...props}
     />
   )

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -66,21 +66,21 @@ const Toaster = (props: ToasterProps) => {
             'color-mix(in oklch, var(--success) 16%, var(--popover))',
           '--success-border':
             'color-mix(in oklch, var(--success) 35%, var(--border))',
-          '--success-text': 'var(--success)',
+          '--success-text': 'var(--success-soft-fg)',
           '--info-bg': 'color-mix(in oklch, var(--info) 16%, var(--popover))',
           '--info-border':
             'color-mix(in oklch, var(--info) 35%, var(--border))',
-          '--info-text': 'var(--info)',
+          '--info-text': 'var(--info-soft-fg)',
           '--warning-bg':
             'color-mix(in oklch, var(--warning) 18%, var(--popover))',
           '--warning-border':
             'color-mix(in oklch, var(--warning) 38%, var(--border))',
-          '--warning-text': 'var(--warning)',
+          '--warning-text': 'var(--warning-soft-fg)',
           '--error-bg':
             'color-mix(in oklch, var(--destructive) 16%, var(--popover))',
           '--error-border':
             'color-mix(in oklch, var(--destructive) 35%, var(--border))',
-          '--error-text': 'var(--destructive)',
+          '--error-text': 'var(--destructive-soft-fg)',
           '--border-radius': 'var(--radius)',
         } as React.CSSProperties
       }

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -13,6 +13,7 @@ function Table({ className, ...props }: React.ComponentProps<'table'>) {
     >
       <table
         data-slot='table'
+        data-table-stagger='true'
         className={cn(
           'w-full caption-bottom text-sm tabular-nums [&_td]:text-sm [&_td_*]:text-sm [&_th]:text-sm [&_th_*]:text-sm',
           className

--- a/web/src/features/dashboard/components/announcement-banner.tsx
+++ b/web/src/features/dashboard/components/announcement-banner.tsx
@@ -23,11 +23,11 @@ const SEVERITY_TONE: Record<
     icon: Megaphone,
   },
   warning: {
-    wrapper: 'border-warning/40 bg-warning/10 text-warning',
+    wrapper: 'border-warning/40 bg-warning/10 text-warning-soft-fg',
     icon: Megaphone,
   },
   info: {
-    wrapper: 'border-info/40 bg-info/10 text-info',
+    wrapper: 'border-info/40 bg-info/10 text-info-soft-fg',
     icon: Info,
   },
 }

--- a/web/src/features/dashboard/components/stat-card.tsx
+++ b/web/src/features/dashboard/components/stat-card.tsx
@@ -56,8 +56,8 @@ type StatCardProps = {
 
 const DETAIL_TONE_CLASSES: Record<StatCardTone, string> = {
   default: 'text-foreground',
-  success: 'text-success',
-  warning: 'text-warning',
+  success: 'text-success-soft-fg',
+  warning: 'text-warning-soft-fg',
 }
 
 const SPARK_CONFIG_BASE: ChartConfig = {

--- a/web/src/features/dashboard/sections/availability/availability-section.tsx
+++ b/web/src/features/dashboard/sections/availability/availability-section.tsx
@@ -47,11 +47,11 @@ const SEVERITY_TONE: Record<
   },
   warning: {
     dot: 'bg-warning',
-    badge: 'border-warning/40 bg-warning/10 text-warning',
+    badge: 'border-warning/40 bg-warning/10 text-warning-soft-fg',
   },
   info: {
     dot: 'bg-info',
-    badge: 'border-info/40 bg-info/10 text-info',
+    badge: 'border-info/40 bg-info/10 text-info-soft-fg',
   },
 }
 

--- a/web/src/features/dashboard/sections/overview/overview-section.tsx
+++ b/web/src/features/dashboard/sections/overview/overview-section.tsx
@@ -82,7 +82,7 @@ const SCHEDULER_STATUS_BADGE: Record<
   { className: string; key: string }
 > = {
   success: {
-    className: 'border-success/40 bg-success/10 text-success',
+    className: 'border-success/40 bg-success/10 text-success-soft-fg',
     key: 'dashboard.overview.scheduledTasks.statusSuccess',
   },
   failed: {
@@ -91,7 +91,7 @@ const SCHEDULER_STATUS_BADGE: Record<
     key: 'dashboard.overview.scheduledTasks.statusFailed',
   },
   running: {
-    className: 'border-info/40 bg-info/10 text-info',
+    className: 'border-info/40 bg-info/10 text-info-soft-fg',
     key: 'dashboard.overview.scheduledTasks.statusRunning',
   },
   never: {
@@ -224,7 +224,7 @@ export function OverviewSection() {
               SCHEDULER_STATUS_BADGE[row.lastStatus ?? ''] ??
               SCHEDULER_STATUS_BADGE.never
             const enabledClassName = row.enabled
-              ? 'border-success/40 bg-success/10 text-success'
+              ? 'border-success/40 bg-success/10 text-success-soft-fg'
               : 'border-border bg-muted text-muted-foreground'
             const enabledLabel = row.enabled
               ? t('dashboard.overview.scheduledTasks.enabled')

--- a/web/src/features/observability/sections/health/health-section.tsx
+++ b/web/src/features/observability/sections/health/health-section.tsx
@@ -40,8 +40,8 @@ function formatClock(ms?: number | null): string {
 }
 
 function resolveToneClass(tone: 'neutral' | 'warning' | 'success'): string {
-  if (tone === 'warning') return 'text-warning'
-  if (tone === 'success') return 'text-success'
+  if (tone === 'warning') return 'text-warning-soft-fg'
+  if (tone === 'success') return 'text-success-soft-fg'
   return 'text-foreground'
 }
 

--- a/web/src/features/proxy-logs/components/latency-badge.tsx
+++ b/web/src/features/proxy-logs/components/latency-badge.tsx
@@ -10,13 +10,13 @@ import { cn } from '@/lib/utils'
 const LATENCY_TIERS = {
   fast: {
     thresholdMs: 500,
-    className: 'bg-success/10 text-success border-success/30',
+    className: 'bg-success/10 text-success-soft-fg border-success/30',
     dotClassName: 'bg-success',
     icon: Zap,
   },
   slow: {
     thresholdMs: 2000,
-    className: 'bg-warning/10 text-warning border-warning/30',
+    className: 'bg-warning/10 text-warning-soft-fg border-warning/30',
     dotClassName: 'bg-warning',
     icon: Clock,
   },

--- a/web/src/features/proxy-logs/components/status-badge.tsx
+++ b/web/src/features/proxy-logs/components/status-badge.tsx
@@ -13,17 +13,17 @@ type StatusTier = {
 
 const STATUS_TIERS = {
   success: {
-    className: 'bg-success/10 text-success border-success/30',
+    className: 'bg-success/10 text-success-soft-fg border-success/30',
     dotClassName: 'bg-success',
     fallbackLabelKey: 'proxyLogs.status.success',
   },
   redirect: {
-    className: 'bg-info/10 text-info border-info/30',
+    className: 'bg-info/10 text-info-soft-fg border-info/30',
     dotClassName: 'bg-info',
     fallbackLabelKey: 'proxyLogs.status.redirect',
   },
   clientError: {
-    className: 'bg-warning/10 text-warning border-warning/30',
+    className: 'bg-warning/10 text-warning-soft-fg border-warning/30',
     dotClassName: 'bg-warning',
     fallbackLabelKey: 'proxyLogs.status.clientError',
   },

--- a/web/src/features/settings/sections/system-info/components/database-section.tsx
+++ b/web/src/features/settings/sections/system-info/components/database-section.tsx
@@ -219,7 +219,7 @@ export function DatabaseSection() {
           </div>
         ) : null}
         {configQuery.data.restartRequired ? (
-          <div className='border-warning/35 bg-warning/10 text-warning rounded-lg border px-3 py-2 text-sm'>
+          <div className='border-warning/35 bg-warning/10 text-warning-soft-fg rounded-lg border px-3 py-2 text-sm'>
             {t('settings.systemInfo.database.restartRequired')}
           </div>
         ) : null}

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -85,11 +85,6 @@
     font-family: var(--font-body);
   }
 
-  /* Keep sticky headers stable while primitives lock body scrolling. */
-  body[data-scroll-locked] {
-    overflow: unset !important;
-  }
-
   /* Cursor pointer for buttons */
   button:not(:disabled),
   [role='button']:not(:disabled) {
@@ -104,16 +99,6 @@
       font-size: 16px !important;
     }
   }
-}
-
-/* Static skeleton treatment; color ramps are intentionally not used. */
-.skeleton-shimmer {
-  background: var(--skeleton-base);
-}
-
-/* Override auto-skeleton-react inline styles with the same flat fill. */
-.auto-skeleton-fade [class^='skeleton-'] {
-  background: var(--skeleton-base) !important;
 }
 
 @utility container {
@@ -300,7 +285,7 @@
   .animate-appear-zoom,
   .animate-scroll-up,
   .animate-scroll-down,
-  [data-slot='table'] tbody tr {
+  [data-slot='table'][data-table-stagger='true'] tbody tr {
     animation: none !important;
     opacity: 1;
     transform: none;
@@ -408,38 +393,40 @@
     transition: background-color 120ms ease;
   }
 
-  /* Table row stagger-in animation */
-  [data-slot='table'] tbody tr {
+  /* Table row stagger-in animation. Opt-in via `data-table-stagger` so
+     virtualized tables (rows appended during scroll) skip the entry
+     animation and never mount at opacity 0. */
+  [data-slot='table'][data-table-stagger='true'] tbody tr {
     animation: tableRowEnter 0.2s cubic-bezier(0.33, 1, 0.68, 1) both;
   }
-  [data-slot='table'] tbody tr:nth-child(2) {
+  [data-slot='table'][data-table-stagger='true'] tbody tr:nth-child(2) {
     animation-delay: 25ms;
   }
-  [data-slot='table'] tbody tr:nth-child(3) {
+  [data-slot='table'][data-table-stagger='true'] tbody tr:nth-child(3) {
     animation-delay: 50ms;
   }
-  [data-slot='table'] tbody tr:nth-child(4) {
+  [data-slot='table'][data-table-stagger='true'] tbody tr:nth-child(4) {
     animation-delay: 75ms;
   }
-  [data-slot='table'] tbody tr:nth-child(5) {
+  [data-slot='table'][data-table-stagger='true'] tbody tr:nth-child(5) {
     animation-delay: 100ms;
   }
-  [data-slot='table'] tbody tr:nth-child(6) {
+  [data-slot='table'][data-table-stagger='true'] tbody tr:nth-child(6) {
     animation-delay: 125ms;
   }
-  [data-slot='table'] tbody tr:nth-child(7) {
+  [data-slot='table'][data-table-stagger='true'] tbody tr:nth-child(7) {
     animation-delay: 150ms;
   }
-  [data-slot='table'] tbody tr:nth-child(8) {
+  [data-slot='table'][data-table-stagger='true'] tbody tr:nth-child(8) {
     animation-delay: 175ms;
   }
-  [data-slot='table'] tbody tr:nth-child(9) {
+  [data-slot='table'][data-table-stagger='true'] tbody tr:nth-child(9) {
     animation-delay: 200ms;
   }
-  [data-slot='table'] tbody tr:nth-child(10) {
+  [data-slot='table'][data-table-stagger='true'] tbody tr:nth-child(10) {
     animation-delay: 225ms;
   }
-  [data-slot='table'] tbody tr:nth-child(n + 11) {
+  [data-slot='table'][data-table-stagger='true'] tbody tr:nth-child(n + 11) {
     animation-delay: 250ms;
   }
 }

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -42,10 +42,13 @@
   --color-destructive-soft-fg: var(--destructive-soft-fg);
   --color-success: var(--success);
   --color-success-foreground: var(--success-foreground);
+  --color-success-soft-fg: var(--success-soft-fg);
   --color-warning: var(--warning);
   --color-warning-foreground: var(--warning-foreground);
+  --color-warning-soft-fg: var(--warning-soft-fg);
   --color-info: var(--info);
   --color-info-foreground: var(--info-foreground);
+  --color-info-soft-fg: var(--info-soft-fg);
   --color-neutral: var(--neutral);
   --color-neutral-foreground: var(--neutral-foreground);
   --color-border: var(--border);
@@ -77,7 +80,7 @@
 
 :root {
   --radius: 1rem;
-  --app-header-height: 3rem;
+  --app-header-height: 3.5rem;
   /* Static build-channel fallback consumed when JS hasn't booted yet. */
   --app-rev: '2k6e8r7p';
   /* Currently active body font. The font axis swaps this between
@@ -108,6 +111,12 @@
   --warning-foreground: oklch(0.145 0 0);
   --info: oklch(0.53 0.158 241.966);
   --info-foreground: oklch(0.985 0 0);
+  /* Soft-tint foregrounds: ink on `bg-<tone>/10` chips / toast text. Darker
+     than the base tone so 12px text clears WCAG AA (4.5:1) on the near-white
+     tint in light mode. */
+  --warning-soft-fg: oklch(0.5 0.15 75.834);
+  --success-soft-fg: oklch(0.48 0.14 163.225);
+  --info-soft-fg: oklch(0.48 0.15 241.966);
   --neutral: oklch(0.708 0 0);
   --neutral-foreground: oklch(0.145 0 0);
   --border: oklch(0.93 0 0);
@@ -185,6 +194,11 @@
   --warning-foreground: oklch(0.145 0 0);
   --info: oklch(0.613 0.14 239.919);
   --info-foreground: oklch(0.145 0 0);
+  /* Soft-tint foregrounds match the light, readable tones; dark mode already
+     passes AA so these mirror the base tones. */
+  --warning-soft-fg: oklch(0.769 0.188 70.08);
+  --success-soft-fg: oklch(0.696 0.17 162.48);
+  --info-soft-fg: oklch(0.613 0.14 239.919);
   --neutral: oklch(0.76 0 0);
   --neutral-foreground: oklch(0.155 0 0);
   --border: oklch(1 0 0 / 10%);


### PR DESCRIPTION
## Summary
Fixes silent rendering bugs and a WCAG AA contrast failure in the design system.

- Pinned-column edge shadow was invalid CSS (`hsl(var(--foreground))` where `--foreground` is OKLCH) and never rendered — now uses `color-mix(in oklch, var(--foreground) 12%, transparent)`.
- Chart colors ignored the selected preset because they read `<html>` while preset overrides are scoped to `<body>` — now read/observe `<body>`.
- Sticky header was missing `backdrop-blur`, so scrolled content ghosted through it.
- Introduced `--warning/--success/--info-soft-fg` semantic tokens and migrated the soft badge/status/toast pattern so 12px badge text clears 4.5:1 in light mode (was ~3.7:1 for warning).
- Unified `--app-header-height` (3.5rem) and removed the inline override.
- Fixed the FOUC bootstrap's wrong dark hex and `lang="zh-CN"` → `en`.
- Scoped the global table-row stagger to opt-in tables (safe for future virtualization).
- Pointed `Skeleton` at `--skeleton-base` and removed dead shimmer rules.
- Removed a dead body scroll-lock override.

## Test plan
- `bun run typecheck` / `lint` / `format:check` — clean
- `bun run test` — 347 passed
- `bunx rsbuild build` — success