### PR TITLE
feat(platform): send a browser User-Agent on outbound adapter calls

### DIFF
--- a/platform/base.go
+++ b/platform/base.go
@@ -216,6 +216,9 @@ func fetchJSON(ctx context.Context, url, method string, body interface{}, header
 	if _, ok := headers["Content-Type"]; !ok {
 		headers["Content-Type"] = "application/json"
 	}
+	if _, ok := headers["User-Agent"]; !ok {
+		headers["User-Agent"] = DefaultBrowserUserAgent
+	}
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
@@ -259,6 +262,7 @@ func fetchText(ctx context.Context, url string, proxy *ProxyConfig) (string, str
 		return "", "", fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,*/*;q=0.8")
+	req.Header.Set("User-Agent", DefaultBrowserUserAgent)
 
 	resp, err := DoWithProxy(ctx, req, proxy)
 	if err != nil {

--- a/platform/browser_profile.go
+++ b/platform/browser_profile.go
@@ -1,0 +1,10 @@
+package platform
+
+// DefaultBrowserUserAgent is the single fixed browser identity used for
+// outbound requests to upstream sites. Adapter API calls (login/checkin/
+// balance/model pull) previously went out as Go's default "Go-http-client/1.1",
+// which is a bright bot beacon for UA-denial WAF rules on NewAPI/OneAPI forks.
+//
+// Keep the Chrome version bumped quarterly so the declared identity stays
+// current with the real Chrome release cadence.
+const DefaultBrowserUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"

--- a/platform/browser_profile_test.go
+++ b/platform/browser_profile_test.go
@@ -1,0 +1,43 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchJSON_SendsDefaultBrowserUserAgent(t *testing.T) {
+	var gotUA string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	if _, err := fetchJSON(context.Background(), server.URL, "GET", nil, nil, nil); err != nil {
+		t.Fatalf("fetchJSON error: %v", err)
+	}
+	if gotUA != DefaultBrowserUserAgent {
+		t.Errorf("User-Agent = %q, want %q", gotUA, DefaultBrowserUserAgent)
+	}
+}
+
+func TestFetchJSON_DoesNotOverrideExplicitUserAgent(t *testing.T) {
+	var gotUA string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	custom := "custom-client/2.0"
+	if _, err := fetchJSON(context.Background(), server.URL, "GET", nil, map[string]string{"User-Agent": custom}, nil); err != nil {
+		t.Fatalf("fetchJSON error: %v", err)
+	}
+	if gotUA != custom {
+		t.Errorf("User-Agent = %q, want explicit %q", gotUA, custom)
+	}
+}

--- a/platform/newapi.go
+++ b/platform/newapi.go
@@ -39,7 +39,7 @@ func (n *NewApiAdapter) Login(ctx context.Context, baseURL, username, password s
 	body := map[string]string{"username": username, "password": password}
 	headers := map[string]string{
 		"X-Requested-With": "XMLHttpRequest",
-		"User-Agent":       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+		"User-Agent":       DefaultBrowserUserAgent,
 	}
 
 	parsed, cookieHeader, err := fetchLoginResponse(ctx, baseURL+"/api/user/login", body, headers, proxy)


### PR DESCRIPTION
## Summary
Adapter API 调用（login/checkin/balance/model pull）此前以 Go 默认 `Go-http-client/1.1` 出站，是 NewAPI/OneAPI fork 上 UA-denial WAF 规则最明显的 bot 信标。

- 新增 `platform/browser_profile.go` 的单一 Chrome UA 常量（版本化，季度 bump）。
- `fetchJSON`/`fetchText` 默认填入该 UA（request-wins，不覆盖显式 UA）。
- `NewApiAdapter.Login` 复用同一常量，消除硬编码 UA。

这是 #670 的 Part 1。每站 `cf_clearance` 注入（需 sites 表迁移 + plumbing）作为后续 PR。

## Test plan
- `TestFetchJSON_SendsDefaultBrowserUserAgent` + `TestFetchJSON_DoesNotOverrideExplicitUserAgent`（httptest 捕获 UA）。
- `go build ./...` clean；`go test ./platform/ -run TestFetchJSON` 通过。

Refs #670