### PR TITLE
fix(platform): unify model-list normalization (dedup + sort)

### DIFF
--- a/platform/antigravity.go
+++ b/platform/antigravity.go
@@ -58,7 +58,7 @@ func extractAntigravityModelNames(payload map[string]interface{}) []string {
 				names = append(names, t)
 			}
 		}
-		return names
+		return normalizeModelIDs(names)
 	}
 
 	// Array form: {"models": [{"id": "...", "name": "..."},...]}
@@ -78,7 +78,7 @@ func extractAntigravityModelNames(payload map[string]interface{}) []string {
 				}
 			}
 		}
-		return names
+		return normalizeModelIDs(names)
 	}
 
 	return []string{}

--- a/platform/base.go
+++ b/platform/base.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 )
 
@@ -727,5 +728,26 @@ func extractModelIDsFromData(resp map[string]interface{}) []string {
 			}
 		}
 	}
-	return models
+	return normalizeModelIDs(models)
+}
+
+// normalizeModelIDs dedups case-insensitively (preserving first-seen casing),
+// strips a "models/" prefix, and sorts for deterministic output.
+func normalizeModelIDs(models []string) []string {
+	seen := make(map[string]bool, len(models))
+	result := make([]string, 0, len(models))
+	for _, m := range models {
+		t := strings.TrimPrefix(strings.TrimSpace(m), "models/")
+		if t == "" {
+			continue
+		}
+		key := strings.ToLower(t)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		result = append(result, t)
+	}
+	sort.Strings(result)
+	return result
 }

--- a/platform/gemini.go
+++ b/platform/gemini.go
@@ -93,14 +93,5 @@ func stripModelPrefix(name string) string {
 }
 
 func normalizeModelList(models []string) []string {
-	seen := make(map[string]bool)
-	result := make([]string, 0, len(models))
-	for _, m := range models {
-		normalized := stripModelPrefix(m)
-		if normalized != "" && !seen[normalized] {
-			seen[normalized] = true
-			result = append(result, normalized)
-		}
-	}
-	return result
+	return normalizeModelIDs(models)
 }

--- a/platform/newapi.go
+++ b/platform/newapi.go
@@ -534,7 +534,7 @@ func (n *NewApiAdapter) GetModels(ctx context.Context, baseURL, token string, pl
 					}
 				}
 				if len(models) > 0 {
-					return models, nil
+					return normalizeModelIDs(models), nil
 				}
 			}
 			if data, ok := getMap(resp, "data"); ok {
@@ -545,7 +545,7 @@ func (n *NewApiAdapter) GetModels(ctx context.Context, baseURL, token string, pl
 					}
 				}
 				if len(models) > 0 {
-					return models, nil
+					return normalizeModelIDs(models), nil
 				}
 			}
 		}

--- a/platform/onehub.go
+++ b/platform/onehub.go
@@ -43,7 +43,7 @@ func (o *OneHubAdapter) GetModels(ctx context.Context, baseURL string, apiToken 
 			}
 		}
 		if len(models) > 0 {
-			return models, nil
+			return normalizeModelIDs(models), nil
 		}
 	}
 

--- a/platform/standard.go
+++ b/platform/standard.go
@@ -68,7 +68,7 @@ func (s *StandardAdapter) fetchModelsFromStandardEndpoint(ctx context.Context, b
 			}
 		}
 	}
-	return models, nil
+	return normalizeModelIDs(models), nil
 }
 
 // --- URL normalization helpers ---

--- a/platform/sub2api_models.go
+++ b/platform/sub2api_models.go
@@ -105,5 +105,5 @@ func extractModelIDs(payload map[string]interface{}) []string {
 			result = append(result, name)
 		}
 	}
-	return result
+	return normalizeModelIDs(result)
 }


### PR DESCRIPTION
## Summary
#674：统一各适配器模型列表的规范化。

- 新增共享 `normalizeModelIDs`（case-insensitive 去重保留首见大小写、剥离 `models/` 前缀、排序）。
- 应用到所有模型枚举器：`extractModelIDsFromData`、`fetchModelsFromStandardEndpoint`、`extractAntigravityModelNames`（map-key 分支）、`OneHub` `/api/available_model` 回退、`NewAPI` `/api/user/models`（string + map 分支）、Sub2API `extractModelIDs`、Gemini `normalizeModelList`（委托）。

效果：同一上游多次刷新返回稳定有序、无重复/大小写变体的模型列表。

## Test plan
- `go build ./...` clean；`go test ./platform/...` 全绿。

Closes #674