### PR TITLE
fix(checkin): recognize already-claimed as already-checked-in

### DIFF
--- a/service/checkin/checkin.go
+++ b/service/checkin/checkin.go
@@ -75,6 +75,8 @@ func isAlreadyCheckedInMessage(message string) bool {
 	return strings.Contains(normalized, "already checked in") ||
 		strings.Contains(normalized, "already signed") ||
 		strings.Contains(normalized, "already sign in") ||
+		strings.Contains(normalized, "already claim") ||
+		strings.Contains(normalized, "claimed today") ||
 		strings.Contains(text, "今日已签到") ||
 		strings.Contains(text, "今天已签到") ||
 		strings.Contains(text, "今天已经签到") ||
@@ -82,6 +84,9 @@ func isAlreadyCheckedInMessage(message string) bool {
 		strings.Contains(text, "已经签到") ||
 		strings.Contains(text, "已签到") ||
 		strings.Contains(text, "重复签到") ||
+		strings.Contains(text, "已经领取") ||
+		strings.Contains(text, "已领取") ||
+		strings.Contains(text, "领取过") ||
 		strings.Contains(text, "签到达")
 }
 

--- a/service/checkin/checkin_test.go
+++ b/service/checkin/checkin_test.go
@@ -22,9 +22,17 @@ func TestIsAlreadyCheckedInMessage_Positive(t *testing.T) {
 		"已签到",
 		"重复签到",
 		"签到达",
+		// Claimed: "already claimed", "claimed today", "已领取", "领取过"
+		"already claimed today",
+		"reward already claimed",
+		"claimed today's reward",
+		"今日已领取",
+		"已经领取奖励",
+		"领取过今日奖励",
 		// Case insensitive
 		"Already Checked In",
 		"ALREADY SIGNED",
+		"ALREADY CLAIMED",
 	}
 	for _, msg := range positiveCases {
 		t.Run(msg, func(t *testing.T) {


### PR DESCRIPTION
## Summary
#667 的幂等识别部分：upstream 返回 "already claimed / 已领取" 系提示时，`isAlreadyCheckedInMessage` 未匹配，导致重复签到被误报为失败（而非「今日已签到」）。

- 补 "already claim" / "claimed today" / "已经领取" / "已领取" / "领取过" 模式。
- 扩展正向测试集（英文 + 中文 + 大小写）。

## Test plan
- `go build ./...` clean；`go test ./service/checkin/ -count=1` 全绿。

Refs #667