### PR TITLE
fix(checkin): add same-site pacing and transient retry

### DIFF
--- a/service/checkin/checkin.go
+++ b/service/checkin/checkin.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"strings"
 	"sync"
 	"time"
@@ -326,6 +327,19 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 		}
 	}
 
+	// 6.5. Transient retry: if still failing AND the failure classifies as
+	// transient (rate-limit / timeout / 5xx / network-like), wait a short
+	// backoff and retry the checkin once. This protects the daily checkin
+	// from a single transient blip. Auth/billing/model/validation failures
+	// are NOT retried — they require operator intervention. Max 1 retry.
+	if shouldRetryTransient(result) {
+		time.Sleep(transientRetryBackoff())
+		result, err = adp.Checkin(context.Background(), site.URL, activeAccessToken, platformUserIDPtr(platformUserID), proxyConfig)
+		if err != nil {
+			result = &platform.CheckinResult{Success: false, Message: err.Error()}
+		}
+	}
+
 	// 7. Classify result
 	isCloudflare := alert.IsCloudflareChallenge(result.Message)
 	alreadyCheckedIn := isAlreadyCheckedInMessage(result.Message)
@@ -574,7 +588,13 @@ func CheckinAll(cfg *config.Config, db *sqlx.DB, accountIDs []int64, scheduleMod
 		wg.Add(1)
 		go func(indices []int) {
 			defer wg.Done()
-			for _, idx := range indices {
+			for i, idx := range indices {
+				if i > 0 {
+					// Same-site pacing: space consecutive checkins on the same site
+					// to avoid tripping upstream rate limits (429). Cross-site
+					// parallelism is preserved by the per-site goroutine above.
+					time.Sleep(sameSitePacingDelay())
+				}
 				row := rows[idx]
 				result := CheckinAccount(cfg, db, row.Accounts.ID, &CheckinOptions{
 					SkipEvent:    true,
@@ -607,4 +627,29 @@ func orUsername(username *string, id int64) string {
 		return *username
 	}
 	return fmt.Sprintf("ID:%d", id)
+}
+
+// shouldRetryTransient reports whether the current checkin result should be
+// retried once as a transient failure (rate-limit / timeout / 5xx / network).
+// Auth/billing/model/validation failures return false — they require operator
+// intervention, not a retry. Used by CheckinAccount after the auto-relogin
+// path (issue #668: transient-retry). Max 1 retry.
+func shouldRetryTransient(result *platform.CheckinResult) bool {
+	if result == nil || result.Success {
+		return false
+	}
+	return platform.ClassifyUpstreamError(0, result.Message) == platform.ClassTransient
+}
+
+// sameSitePacingDelay returns a ~1s delay (with minor jitter) used between
+// consecutive same-site checkins in CheckinAll to avoid upstream rate limits
+// (issue #668: same-site pacing).
+func sameSitePacingDelay() time.Duration {
+	return time.Second + time.Duration(rand.IntN(250))*time.Millisecond
+}
+
+// transientRetryBackoff returns a ~2-3s backoff used before retrying a transient
+// checkin failure (rate-limit / timeout / 5xx / network) in CheckinAccount.
+func transientRetryBackoff() time.Duration {
+	return 2*time.Second + time.Duration(rand.IntN(1000))*time.Millisecond
 }

--- a/service/checkin/checkin_test.go
+++ b/service/checkin/checkin_test.go
@@ -2,6 +2,9 @@ package checkin
 
 import (
 	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/platform"
 )
 
 // ---- isAlreadyCheckedInMessage Tests (12 patterns) ----
@@ -332,5 +335,128 @@ func TestCheckinExecutionStatus_Constants(t *testing.T) {
 	}
 	if CheckinSkipped != "skipped" {
 		t.Errorf("CheckinSkipped should be 'skipped', got %q", CheckinSkipped)
+	}
+}
+
+// ---- shouldRetryTransient Tests (issue #668: transient-retry classification decision) ----
+//
+// These tests pin the retry-decision predicate used by CheckinAccount (step
+// 6.5). A failure is retried once ONLY when it classifies as ClassTransient
+// (rate-limit / timeout / 5xx / network). Auth/billing/model/validation/state
+// failures must NOT retry — they require operator intervention.
+
+func TestShouldRetryTransient_TransientMessagesRetry(t *testing.T) {
+	// Realistic adapter-produced failure messages that the platform
+	// classifier maps to ClassTransient (httpStatus=0, message-driven).
+	transientMessages := []string{
+		"HTTP 429: rate limit exceeded",
+		"HTTP 429: too many requests",
+		"HTTP 503: service unavailable",
+		"HTTP 502: bad gateway",
+		"HTTP 504: gateway timeout",
+		"request: connection refused",
+		"request: connection reset by peer",
+		"rate limit exceeded",
+		"request timed out",
+		"too many requests",
+	}
+	for _, msg := range transientMessages {
+		t.Run(msg, func(t *testing.T) {
+			// Sanity-check the underlying classifier so the retry decision
+			// and the platform classification agree.
+			if platform.ClassifyUpstreamError(0, msg) != platform.ClassTransient {
+				t.Fatalf("classifier returned %s for %q, want ClassTransient",
+					platform.ClassifyUpstreamError(0, msg), msg)
+			}
+			result := &platform.CheckinResult{Success: false, Message: msg}
+			if !shouldRetryTransient(result) {
+				t.Errorf("shouldRetryTransient(%q) = false, want true", msg)
+			}
+		})
+	}
+}
+
+func TestShouldRetryTransient_NonTransientMessagesNoRetry(t *testing.T) {
+	// Failures that must NOT trigger the transient retry path.
+	nonTransientCases := []struct {
+		msg   string
+		label string
+	}{
+		{"jwt expired", "expired"},
+		{"invalid access token", "expired"},
+		{"access token is invalid", "expired"},
+		{"HTTP 401: unauthorized", "auth"},
+		{"insufficient quota", "billing"},
+		{"no payment method", "billing"},
+		{"model not supported", "model"},
+		{"invalid_argument", "validation"},
+		{"already checked in", "state"},
+		{"turnstile token 为空", "verification"},
+		{"some unknown opaque error", "unknown"},
+	}
+	for _, tt := range nonTransientCases {
+		t.Run(tt.label, func(t *testing.T) {
+			if platform.ClassifyUpstreamError(0, tt.msg) == platform.ClassTransient {
+				t.Fatalf("classifier returned ClassTransient for %q (%s); pick a non-transient fixture",
+					tt.msg, tt.label)
+			}
+			result := &platform.CheckinResult{Success: false, Message: tt.msg}
+			if shouldRetryTransient(result) {
+				t.Errorf("shouldRetryTransient(%q) = true, want false (%s)", tt.msg, tt.label)
+			}
+		})
+	}
+}
+
+func TestShouldRetryTransient_SuccessAndNilNoRetry(t *testing.T) {
+	// A successful checkin must never enter the retry path.
+	success := &platform.CheckinResult{Success: true, Message: "checkin success", Reward: "50"}
+	if shouldRetryTransient(success) {
+		t.Error("shouldRetryTransient(success) = true, want false")
+	}
+
+	// Defensive: a nil result must not panic or retry.
+	if shouldRetryTransient(nil) {
+		t.Error("shouldRetryTransient(nil) = true, want false")
+	}
+
+	// An empty-message failure is NOT transient (ClassUnknown), so no retry.
+	empty := &platform.CheckinResult{Success: false, Message: ""}
+	if shouldRetryTransient(empty) {
+		t.Error("shouldRetryTransient(empty failure) = true, want false")
+	}
+}
+
+// ---- Pacing & backoff helper Tests (issue #668: same-site pacing) ----
+//
+// These pin the existence and magnitude of the delays used between same-site
+// checkins (CheckinAll) and before the transient retry (CheckinAccount).
+
+func TestSameSitePacingDelay(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		d := sameSitePacingDelay()
+		// Base 1s + 0-249ms jitter → [1000ms, 1249ms]. Use a safe envelope.
+		if d < 950*time.Millisecond || d > 1300*time.Millisecond {
+			t.Errorf("sameSitePacingDelay() = %v, want ~1s (950ms-1300ms) on iteration %d", d, i)
+		}
+	}
+}
+
+func TestSameSitePacingDelay_AlwaysPositive(t *testing.T) {
+	// Must never be zero or negative (would mean no pacing).
+	for i := 0; i < 200; i++ {
+		if sameSitePacingDelay() <= 0 {
+			t.Fatal("sameSitePacingDelay() returned non-positive duration")
+		}
+	}
+}
+
+func TestTransientRetryBackoff(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		d := transientRetryBackoff()
+		// Base 2s + 0-999ms jitter → [2000ms, 2999ms].
+		if d < 2*time.Second || d > 3*time.Second {
+			t.Errorf("transientRetryBackoff() = %v, want 2s-3s on iteration %d", d, i)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Same-site pacing**: in `CheckinAll`, consecutive same-site checkins are now spaced by ~1s (with minor jitter) to avoid tripping upstream rate limits (429). Cross-site parallelism is preserved by the existing per-site goroutine — only same-site serialization gains a delay.
- **Transient retry**: in `CheckinAccount`, after the first checkin attempt **and** the existing auto-relogin path, the checkin is retried **once** when the failure classifies as `ClassTransient` (rate-limit / timeout / 5xx / network) via `platform.ClassifyUpstreamError`. Auth/billing/model/validation failures are NOT retried (they need operator intervention). Max 1 retry with a ~2-3s backoff. The auto-relogin path is unchanged.
- Adds three small helpers (`shouldRetryTransient`, `sameSitePacingDelay`, `transientRetryBackoff`) — no new packages, no retry framework. The existing `CheckinAccount` control flow (steps 1–11) is otherwise untouched.

Closes #668.

## Test plan

- [x] `go vet ./service/checkin/...` clean
- [x] `gofmt` clean on both modified files
- [x] `go build ./service/checkin/...` clean
- [x] `go test ./service/checkin/...` passes (existing + new tests)
- [x] New: `TestShouldRetryTransient_TransientMessagesRetry` — realistic adapter messages (`HTTP 429: rate limit exceeded`, `request: connection refused`, `HTTP 503: service unavailable`, …) classify as `ClassTransient` and trigger the retry predicate
- [x] New: `TestShouldRetryTransient_NonTransientMessagesNoRetry` — expired / auth / billing / model / validation / state / verification / unknown failures do NOT trigger the retry
- [x] New: `TestShouldRetryTransient_SuccessAndNilNoRetry` — success, nil, and empty-message failures are never retried
- [x] New: `TestSameSitePacingDelay` / `TestTransientRetryBackoff` — pin delay magnitudes (~1s and 2-3s envelopes)

> Note: `go build ./...` at the repo root reports a **pre-existing** `web/embed.go: pattern dist: no matching files found` (missing built frontend assets) that is unrelated to this change and reproduces on the unmodified base branch. The `service/checkin` package builds and tests cleanly.