### PR TITLE
feat(resin): sticky proxy pool integration (Tier 1)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -174,6 +174,14 @@ type Config struct {
 	NotifyCooldownSec int
 	SystemProxyUrl    string
 
+	// Resin sticky proxy pool (3 fields, env-only — no DDL for Tier 1).
+	// RESIN_URL carries the base URL + token, e.g. http://resin.local:2260/my-token.
+	// RESIN_PLATFORM_NAME is the Platform identity (falls back to site.Platform).
+	// RESIN_ENABLED is the global opt-in (default false).
+	ResinURL          string
+	ResinPlatformName string
+	ResinEnabled      bool
+
 	// NotifyTaskToggles gates per-alert-type notifications.
 	// Keys are alert task slugs ("token_expired", "low_balance", "proxy_all_failed").
 	// Default nil = all enabled (backward-compatible). When a key is present and
@@ -551,6 +559,11 @@ func Load(env map[string]string) *Config {
 	// ---- §3.11 Notify: General ----
 	cfg.NotifyCooldownSec = maxInt(0, int(math.Trunc(parseNumber(get("NOTIFY_COOLDOWN_SEC"), DefaultNotifyCooldownSec))))
 	cfg.SystemProxyUrl = firstNonEmpty(get("SYSTEM_PROXY_URL"), "")
+
+	// ---- §3.11b Resin sticky proxy pool ----
+	cfg.ResinURL = firstNonEmpty(get("RESIN_URL"), "")
+	cfg.ResinPlatformName = firstNonEmpty(get("RESIN_PLATFORM_NAME"), "")
+	cfg.ResinEnabled = parseBoolean(get("RESIN_ENABLED"), false)
 
 	// ---- §3.12 Notify: Feishu / DingTalk / WeCom / Ntfy ----
 	cfg.FeishuEnabled = parseBoolean(get("FEISHU_ENABLED"), false)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -72,6 +72,38 @@ func TestLoadInfersPostgresFromDatabaseURLAlias(t *testing.T) {
 	}
 }
 
+func TestLoadParsesResinConfig(t *testing.T) {
+	cfg := Load(map[string]string{
+		"RESIN_URL":           "http://resin.local:2260/my-token",
+		"RESIN_PLATFORM_NAME": "metapi",
+		"RESIN_ENABLED":       "true",
+	})
+
+	if cfg.ResinURL != "http://resin.local:2260/my-token" {
+		t.Fatalf("ResinURL = %q, want http://resin.local:2260/my-token", cfg.ResinURL)
+	}
+	if cfg.ResinPlatformName != "metapi" {
+		t.Fatalf("ResinPlatformName = %q, want metapi", cfg.ResinPlatformName)
+	}
+	if !cfg.ResinEnabled {
+		t.Fatal("ResinEnabled = false, want true")
+	}
+}
+
+func TestLoadResinDefaultsOff(t *testing.T) {
+	cfg := Load(map[string]string{})
+
+	if cfg.ResinURL != "" {
+		t.Fatalf("ResinURL = %q, want empty default", cfg.ResinURL)
+	}
+	if cfg.ResinPlatformName != "" {
+		t.Fatalf("ResinPlatformName = %q, want empty default", cfg.ResinPlatformName)
+	}
+	if cfg.ResinEnabled {
+		t.Fatal("ResinEnabled = true, want false default")
+	}
+}
+
 func TestLoadPrefersDBURLOverDatabaseURLAlias(t *testing.T) {
 	cfg := Load(map[string]string{
 		"DB_URL":       "sqlite://local.db",

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -380,7 +380,7 @@ func (h *accountsHandler) createSingleAccount(ctx context.Context, body payloads
 	}
 
 	skipModelFetch := body.SkipModelFetch != nil && *body.SkipModelFetch
-	proxyCfg := service.BuildPlatformProxyConfig(h.cfg, nil, &site)
+	proxyCfg := service.BuildPlatformProxyConfigForToken(h.cfg, &site, rawAccessToken)
 
 	resolvedUsername := strings.TrimSpace(coalescePtr(username, ""))
 	usernameProvided := resolvedUsername != ""
@@ -593,7 +593,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
-	loginResult, err := adp.Login(ctx, site.URL, body.Username, body.Password, nil, service.BuildPlatformProxyConfig(h.cfg, nil, &site))
+	loginResult, err := adp.Login(ctx, site.URL, body.Username, body.Password, nil, service.BuildPlatformProxyConfigForToken(h.cfg, &site, body.Username))
 	if err != nil {
 		slog.Warn("Account login failed", "err", err, "site_id", site.ID, "platform", site.Platform)
 		writeError(w, http.StatusUnauthorized, "login failed")
@@ -736,7 +736,7 @@ func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
-	result, err := adp.VerifyToken(ctx, site.URL, accessToken, body.PlatformUserID, service.BuildPlatformProxyConfig(h.cfg, nil, &site))
+	result, err := adp.VerifyToken(ctx, site.URL, accessToken, body.PlatformUserID, service.BuildPlatformProxyConfigForToken(h.cfg, &site, accessToken))
 	if err != nil {
 		writeJSON(w, http.StatusOK, map[string]any{"success": false, "message": err.Error()})
 		return

--- a/handler/proxy/codex_ws_runtime.go
+++ b/handler/proxy/codex_ws_runtime.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/service"
 )
 
 // Codex upstream WebSocket runtime (
@@ -60,6 +61,16 @@ type CodexWebsocketSendInput struct {
 	RequestURL string
 	Headers    map[string]string
 	Body       map[string]any
+	// ResinAccount carries the Resin business identity for the native wss
+	// reverse-proxy rewrite. When non-empty (and ResinPlatform is set) and
+	// Resin is enabled, the dial URL is rewritten to
+	// ws://{host}/{token}/{Platform}/{protocol}/{target} and X-Resin-Account
+	// is set on the dial headers.
+	ResinAccount string
+	// ResinPlatform is the Platform segment for the resin reverse-proxy path.
+	// The caller (which has the site in scope) resolves it from
+	// cfg.ResinPlatformName (falling back to site.Platform).
+	ResinPlatform string
 }
 
 // ---- response id store (process-local) ----
@@ -595,10 +606,12 @@ func SendCodexWebsocketRequest(ctx context.Context, input CodexWebsocketSendInpu
 
 	for {
 		result, err := sendCodexWSSessionAttempt(ctx, session, CodexWebsocketSendInput{
-			SessionID:  sessionID,
-			RequestURL: input.RequestURL,
-			Headers:    input.Headers,
-			Body:       currentBody,
+			SessionID:    sessionID,
+			RequestURL:   input.RequestURL,
+			Headers:      input.Headers,
+			Body:         currentBody,
+			ResinAccount:  input.ResinAccount,
+			ResinPlatform: input.ResinPlatform,
 		})
 		if err == nil {
 			return result, nil
@@ -633,6 +646,19 @@ func sendCodexWSSessionAttempt(ctx context.Context, session *codexWSSocketSessio
 		return nil, &CodexWebsocketRuntimeError{Message: "missing upstream websocket url", Status: 502}
 	}
 
+	// Resin reverse-proxy rewrite for native wss dials (the only path that
+	// bypasses BuildPlatformProxyConfig / the HTTP forward proxy). Resin
+	// requires the client→resin leg to be ws; the protocol segment encodes
+	// the original target scheme (https for wss, http for ws).
+	resinAccount := strings.TrimSpace(input.ResinAccount)
+	resinPlatform := strings.TrimSpace(input.ResinPlatform)
+	runtimeCfg := safeConfigGet()
+	if runtimeCfg != nil && service.ResinEnabled(runtimeCfg) && resinAccount != "" && resinPlatform != "" {
+		if rewritten := service.RewriteWSURL(wsURL, runtimeCfg, resinPlatform, resinAccount); rewritten != "" {
+			wsURL = rewritten
+		}
+	}
+
 	reused := false
 	conn := session.conn
 	if conn != nil && session.socketURL == wsURL {
@@ -644,6 +670,15 @@ func sendCodexWSSessionAttempt(ctx context.Context, session *codexWSSocketSessio
 			session.socketURL = ""
 		}
 		headers := BuildCodexWebsocketHandshakeHeaders(input.Headers)
+		// Resin reverse-proxy identity header (only meaningful when the URL
+		// was rewritten above; harmless otherwise since Resin ignores it on
+		// non-rewritten paths, but we gate it to the rewrite case for hygiene).
+		if runtimeCfg != nil && service.ResinEnabled(runtimeCfg) && resinAccount != "" && resinPlatform != "" {
+			if headers == nil {
+				headers = map[string]string{}
+			}
+			headers["X-Resin-Account"] = resinAccount
+		}
 		httpHeader := http.Header{}
 		for k, v := range headers {
 			if strings.TrimSpace(k) == "" || strings.TrimSpace(v) == "" {

--- a/handler/proxy/responses_ws.go
+++ b/handler/proxy/responses_ws.go
@@ -16,6 +16,7 @@ import (
 	"github.com/coder/websocket"
 	"github.com/deliciousbuding/metapi-go/auth"
 	"github.com/deliciousbuding/metapi-go/routing"
+	"github.com/deliciousbuding/metapi-go/service"
 )
 
 // Responses WebSocket transport.
@@ -833,11 +834,25 @@ func (s *responsesWSSession) tryCodexUpstreamWSS(ctx context.Context, body map[s
 		s.codexRuntimeKeys = append(s.codexRuntimeKeys, sessionKey)
 	}
 
+	// Resin sticky identity for native wss reverse-proxy rewrite. The wss
+	// dial bypasses BuildPlatformProxyConfig, so we pass the identity through
+	// the input; sendCodexWSSessionAttempt rewrites the URL + sets
+	// X-Resin-Account when Resin is enabled. Platform = cfg.ResinPlatformName
+	// (fallback site.Platform); Account = acc-{selected.Account.ID}.
+	resinAccount := ""
+	resinPlatform := ""
+	if runtimeCfg := safeConfigGet(); runtimeCfg != nil && service.ResinEnabled(runtimeCfg) {
+		resinAccount = service.AccountFor(&selected.Account, &selected.Site)
+		resinPlatform = service.ResolveResinPlatform(runtimeCfg, &selected.Site)
+	}
+
 	result, sendErr := SendCodexWebsocketRequest(ctx, CodexWebsocketSendInput{
-		SessionID:  sessionKey,
-		RequestURL: upstreamURL,
-		Headers:    headers,
-		Body:       upBody,
+		SessionID:     sessionKey,
+		RequestURL:    upstreamURL,
+		Headers:       headers,
+		Body:          upBody,
+		ResinAccount:  resinAccount,
+		ResinPlatform: resinPlatform,
 	})
 	if sendErr != nil {
 		runtimeErr, ok := sendErr.(*CodexWebsocketRuntimeError)

--- a/platform/adapter.go
+++ b/platform/adapter.go
@@ -50,6 +50,11 @@ type ProxyConfig struct {
 	// BrowserUA overrides the global browser User-Agent for a specific site
 	// (used to match the UA of a harvested cf_clearance cookie).
 	BrowserUA string
+	// ResinAccount records the Resin business-identity used for this request
+	// (set by BuildPlatformProxyConfig when the resin forward proxy is active).
+	// Downstream code (e.g. native wss reverse-proxy) can read this to set the
+	// X-Resin-Account header on paths that bypass the HTTP forward proxy.
+	ResinAccount string
 }
 
 // CheckinResult is the outcome of a daily checkin.

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -189,6 +189,21 @@ func GetUseSystemProxyFromExtraConfig(extraConfig *string) bool {
 }
 
 // BuildPlatformProxyConfig resolves account and site proxy settings for platform calls.
+//
+// Precedence (highest to lowest):
+//  1. key proxy (applied separately via proxy.ApplyKeyProxyOverride)
+//  2. account extraConfig.proxyUrl (explicit per-account proxy)
+//  3. site.ProxyURL (explicit per-site proxy)
+//  4. Resin sticky forward proxy (when RESIN_ENABLED and identity available)
+//  5. system proxy (account extraConfig.useSystemProxy or site.UseSystemProxy)
+//  6. direct (no proxy)
+//
+// The Resin tier sits between explicit proxy URLs and the generic system-proxy
+// opt-in so an operator who sets a per-account/per-site proxy still wins, but
+// Resin takes priority over the shared SYSTEM_PROXY_URL. Resin requires a
+// business identity: acc-{account.ID} when the account row exists. For
+// pre-account flows (verify/login/create) with no account row yet, use
+// BuildPlatformProxyConfigForToken which derives a deterministic temp identity.
 func BuildPlatformProxyConfig(cfg *config.Config, account *store.Account, site *store.Site) *platform.ProxyConfig {
 	if account == nil && site == nil {
 		return nil
@@ -212,11 +227,38 @@ func BuildPlatformProxyConfig(cfg *config.Config, account *store.Account, site *
 		}
 	}
 
+	// 2. account explicit proxyUrl
 	if account != nil {
 		if accountProxyURL := strings.TrimSpace(GetProxyURLFromExtraConfig(account.ExtraConfig)); accountProxyURL != "" {
 			proxyCfg.ProxyURL = accountProxyURL
 			return normalizePlatformProxyConfig(proxyCfg)
 		}
+	}
+
+	// 3. site explicit ProxyURL
+	if site != nil {
+		if site.ProxyURL != nil && strings.TrimSpace(*site.ProxyURL) != "" {
+			proxyCfg.ProxyURL = strings.TrimSpace(*site.ProxyURL)
+			return normalizePlatformProxyConfig(proxyCfg)
+		}
+	}
+
+	// 4. Resin sticky forward proxy (only when no higher-precedence proxy set).
+	//    Requires a business identity: acc-{account.ID} when account exists.
+	if ResinEnabled(cfg) {
+		platformName := ResolveResinPlatform(cfg, site)
+		accountIdentity := AccountFor(account, site)
+		if platformName != "" && accountIdentity != "" {
+			if resinURL, ok := ForwardProxyURL(cfg, platformName, accountIdentity); ok {
+				proxyCfg.ProxyURL = resinURL
+				proxyCfg.ResinAccount = accountIdentity
+				return normalizePlatformProxyConfig(proxyCfg)
+			}
+		}
+	}
+
+	// 5. system proxy fallback (account opt-in, then site opt-in)
+	if account != nil {
 		if GetUseSystemProxyFromExtraConfig(account.ExtraConfig) && cfg != nil && strings.TrimSpace(cfg.SystemProxyUrl) != "" {
 			proxyCfg.ProxyURL = strings.TrimSpace(cfg.SystemProxyUrl)
 			proxyCfg.UseSystemProxy = true
@@ -225,10 +267,6 @@ func BuildPlatformProxyConfig(cfg *config.Config, account *store.Account, site *
 	}
 
 	if site != nil {
-		if site.ProxyURL != nil && strings.TrimSpace(*site.ProxyURL) != "" {
-			proxyCfg.ProxyURL = strings.TrimSpace(*site.ProxyURL)
-			return normalizePlatformProxyConfig(proxyCfg)
-		}
 		if site.UseSystemProxy && cfg != nil && strings.TrimSpace(cfg.SystemProxyUrl) != "" {
 			proxyCfg.ProxyURL = strings.TrimSpace(cfg.SystemProxyUrl)
 			proxyCfg.UseSystemProxy = true
@@ -236,6 +274,50 @@ func BuildPlatformProxyConfig(cfg *config.Config, account *store.Account, site *
 		}
 	}
 
+	return normalizePlatformProxyConfig(proxyCfg)
+}
+
+// BuildPlatformProxyConfigForToken is the pre-account variant of
+// BuildPlatformProxyConfig for verify-token / login / create flows where no
+// Account row exists yet. It derives a deterministic temp Resin identity from
+// (siteID, rawToken) so all pre-account requests for the same token share an
+// egress IP, then (in Tier 2) inherit-lease can transfer the lease to the
+// stable acc-{id} identity after INSERT.
+//
+// Precedence matches BuildPlatformProxyConfig with the temp identity filling
+// the resin tier: site.ProxyURL > resin(temp) > system > direct.
+func BuildPlatformProxyConfigForToken(cfg *config.Config, site *store.Site, rawToken string) *platform.ProxyConfig {
+	// When the site has an explicit ProxyURL, that beats resin — delegate
+	// entirely so headers/cookies/UA are assembled by the shared path.
+	if site != nil && site.ProxyURL != nil && strings.TrimSpace(*site.ProxyURL) != "" {
+		return BuildPlatformProxyConfig(cfg, nil, site)
+	}
+
+	// No explicit site.ProxyURL: assemble the base config (headers, cookies,
+	// UA, and possibly the system proxy via site.UseSystemProxy).
+	proxyCfg := BuildPlatformProxyConfig(cfg, nil, site)
+	if proxyCfg == nil {
+		proxyCfg = &platform.ProxyConfig{}
+	}
+
+	if !ResinEnabled(cfg) || site == nil {
+		return normalizePlatformProxyConfig(proxyCfg)
+	}
+
+	platformName := ResolveResinPlatform(cfg, site)
+	tempIdentity := TempAccountFor(site.ID, rawToken)
+	if platformName == "" || tempIdentity == "" {
+		return normalizePlatformProxyConfig(proxyCfg)
+	}
+	resinURL, ok := ForwardProxyURL(cfg, platformName, tempIdentity)
+	if !ok {
+		return normalizePlatformProxyConfig(proxyCfg)
+	}
+	// Resin wins over the system proxy per precedence, so override whatever
+	// ProxyURL the inner call set (or fill the empty direct case).
+	proxyCfg.ProxyURL = resinURL
+	proxyCfg.UseSystemProxy = false
+	proxyCfg.ResinAccount = tempIdentity
 	return normalizePlatformProxyConfig(proxyCfg)
 }
 

--- a/service/resin.go
+++ b/service/resin.go
@@ -1,0 +1,204 @@
+package service
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strings"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// This file implements the Resin sticky-proxy-pool integration (Tier 1).
+//
+// Resin is an external proxy pool that gives each business identity a stable
+// outbound IP. metapi-go routes its outbound traffic through Resin so each
+// account keeps a stable egress IP.
+//
+// Two access modes:
+//
+//  1. Forward proxy (HTTP) — used for all HTTP/SSE traffic. The proxy URL
+//     embeds proxy-auth credentials {Platform}.{Account}:{token}; Go's
+//     http.Transport derives Proxy-Authorization automatically from the
+//     proxy-URL userinfo.
+//
+//  2. Reverse proxy — used only for native wss dials that bypass the HTTP
+//     forward proxy. The target URL is rewritten to
+//     ws://{host}:{port}/{token}/{Platform}/{protocol}/{targetHost}{path}
+//     and the X-Resin-Account header carries the Account identity.
+//
+// Account identity rules (Resin splits proxy-auth on first '.' and last ':'):
+//   - Stable (post-creation):  acc-{Account.ID}
+//   - Pre-account (verify/login/create):  tmp-{sha1(siteID:token)[:16]}
+//
+// See doc/integration-prompt.md in the resin repo for the full contract.
+
+// resinAccountPrefixStable is the prefix for stable post-creation identities.
+const resinAccountPrefixStable = "acc-"
+
+// resinAccountPrefixTemp is the prefix for deterministic pre-account identities.
+const resinAccountPrefixTemp = "tmp-"
+
+// Enabled reports whether the Resin sticky proxy is configured and active.
+// Resin requires both RESIN_ENABLED=true and a non-empty RESIN_URL.
+func ResinEnabled(cfg *config.Config) bool {
+	if cfg == nil || !cfg.ResinEnabled {
+		return false
+	}
+	return strings.TrimSpace(cfg.ResinURL) != ""
+}
+
+// AccountFor returns the stable Resin account identity for an existing account.
+// The identity is acc-{Account.ID} using the immutable auto-increment PK.
+// Returns "" when the account row has no ID yet (pre-account flows should use
+// TempAccountFor instead).
+func AccountFor(account *store.Account, site *store.Site) string {
+	if account != nil && account.ID > 0 {
+		return fmt.Sprintf("%s%d", resinAccountPrefixStable, account.ID)
+	}
+	return ""
+}
+
+// TempAccountFor returns a deterministic temp Resin identity for pre-account
+// flows (verify/login/create) so all requests for the same token land on the
+// same egress IP. The identity is tmp-{sha1(siteID:token) first 16 hex chars}.
+// siteID may be 0; the identity remains deterministic per token.
+//
+// The identity NEVER contains '.' or ':' (sha1 hex output is [0-9a-f]) so it
+// is safe for Resin's proxy-auth splitting.
+func TempAccountFor(siteID int64, token string) string {
+	digest := sha1.Sum([]byte(fmt.Sprintf("%d:%s", siteID, token)))
+	return resinAccountPrefixTemp + hex.EncodeToString(digest[:])[:16]
+}
+
+// ForwardProxyURL builds the HTTP forward-proxy URL with embedded proxy-auth
+// userinfo. The username is "{Platform}.{Account}" and the password is the
+// resin token. Go's http.Transport reads the proxy URL userinfo and emits
+// the Proxy-Authorization: Basic header automatically — no manual header needed.
+//
+// Returns ("", false) when Resin is misconfigured or platform/account empty.
+func ForwardProxyURL(cfg *config.Config, platform, account string) (string, bool) {
+	host, token, ok := parseResinURL(cfg)
+	if !ok {
+		return "", false
+	}
+	platform = strings.TrimSpace(platform)
+	account = strings.TrimSpace(account)
+	if platform == "" || account == "" {
+		return "", false
+	}
+	// url.UserPassword stores the raw values; http.Transport extracts the
+	// unescaped forms when building the Proxy-Authorization header.
+	proxyURL := &url.URL{
+		Scheme: "http",
+		Host:   host,
+		User:   url.UserPassword(platform+"."+account, token),
+	}
+	return proxyURL.String(), true
+}
+
+// RewriteWSURL rewrites a target wss/ws URL into Resin reverse-proxy form:
+//
+//	ws://{host}:{port}/{token}/{Platform}/{protocol}/{targetHost}{path}?query
+//
+// where protocol is "https" for wss targets and "http" for ws targets
+// (Resin requires the client→resin leg to always be ws). The Account identity
+// is NOT embedded in the URL — it is sent via the X-Resin-Account header
+// (handled by the caller). Returns "" when Resin is misconfigured, the
+// platform/account is empty, or the target URL is not ws/wss.
+func RewriteWSURL(targetURL string, cfg *config.Config, platform, account string) string {
+	host, token, ok := parseResinURL(cfg)
+	if !ok {
+		return ""
+	}
+	platform = strings.TrimSpace(platform)
+	account = strings.TrimSpace(account)
+	if platform == "" || account == "" {
+		return ""
+	}
+	parsed, err := url.Parse(strings.TrimSpace(targetURL))
+	if err != nil || parsed == nil {
+		return ""
+	}
+	var protocol string
+	switch strings.ToLower(parsed.Scheme) {
+	case "wss":
+		protocol = "https"
+	case "ws":
+		protocol = "http"
+	default:
+		return ""
+	}
+	// targetHost carries port if present (e.g. api.example.com:443).
+	targetHost := parsed.Host
+	if targetHost == "" {
+		return ""
+	}
+	// Build path: /{token}/{Platform}/{protocol}/{targetHost}{originalPath}
+	pathSegments := []string{"", token, platform, protocol, targetHost}
+	rewrittenPath := strings.Join(pathSegments, "/")
+	if parsed.Path != "" && parsed.Path != "/" {
+		rewrittenPath += "/" + strings.TrimPrefix(parsed.Path, "/")
+	}
+	resinURL := &url.URL{
+		Scheme:   "ws",
+		Host:     host,
+		Path:     rewrittenPath,
+		RawQuery: parsed.RawQuery,
+	}
+	// account is intentionally NOT in the URL; caller sets X-Resin-Account.
+	_ = account
+	return resinURL.String()
+}
+
+// ResolveResinPlatform resolves the Platform identity: explicit config value
+// wins, otherwise fall back to the site's platform. Returns "" when neither
+// is available.
+func ResolveResinPlatform(cfg *config.Config, site *store.Site) string {
+	if cfg != nil {
+		if name := strings.TrimSpace(cfg.ResinPlatformName); name != "" {
+			return name
+		}
+	}
+	if site != nil {
+		if platform := strings.TrimSpace(site.Platform); platform != "" {
+			return platform
+		}
+	}
+	return ""
+}
+
+// parseResinURL extracts the host (host:port) and token from cfg.ResinURL.
+// The token is the entire path-after-host (e.g. "my-token" for
+// http://resin.local:2260/my-token). Returns ok=false when ResinURL is empty,
+// unparseable, missing a host, or missing the token segment — in those cases
+// Resin is misconfigured and the caller should fall back to direct.
+func parseResinURL(cfg *config.Config) (host, token string, ok bool) {
+	if cfg == nil {
+		return "", "", false
+	}
+	raw := strings.TrimSpace(cfg.ResinURL)
+	if raw == "" {
+		return "", "", false
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed == nil {
+		slog.Warn("resin: invalid RESIN_URL, falling back to direct", "resin_url", raw, "err", err)
+		return "", "", false
+	}
+	host = parsed.Host
+	if host == "" {
+		slog.Warn("resin: RESIN_URL missing host, falling back to direct", "resin_url", raw)
+		return "", "", false
+	}
+	// The token is the whole path-after-host (minus the leading slash).
+	token = strings.TrimPrefix(parsed.Path, "/")
+	if token == "" {
+		slog.Warn("resin: RESIN_URL missing token segment, falling back to direct", "resin_url", raw)
+		return "", "", false
+	}
+	return host, token, true
+}

--- a/service/resin_test.go
+++ b/service/resin_test.go
@@ -1,0 +1,522 @@
+package service
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+func resinCfg(rawURL, platform string) *config.Config {
+	return &config.Config{
+		ResinURL:          rawURL,
+		ResinPlatformName: platform,
+		ResinEnabled:      true,
+	}
+}
+
+// ---- Enabled gating ----
+
+func TestResinEnabledGating(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cfg  *config.Config
+		want bool
+	}{
+		{"nil config", nil, false},
+		{"disabled flag", &config.Config{ResinEnabled: false, ResinURL: "http://resin.local:2260/tok"}, false},
+		{"enabled but empty url", &config.Config{ResinEnabled: true, ResinURL: ""}, false},
+		{"enabled but blank url", &config.Config{ResinEnabled: true, ResinURL: "   "}, false},
+		{"enabled with url", resinCfg("http://resin.local:2260/tok", "Default"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResinEnabled(tc.cfg); got != tc.want {
+				t.Fatalf("ResinEnabled = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// ---- Forward proxy URL userinfo format ----
+
+func TestForwardProxyURLUserinfoFormat(t *testing.T) {
+	t.Parallel()
+	cfg := resinCfg("http://resin.local:2260/my-token", "Default")
+
+	got, ok := ForwardProxyURL(cfg, "Default", "acc-42")
+	if !ok {
+		t.Fatal("ForwardProxyURL returned ok=false for valid config")
+	}
+
+	parsed, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("forward proxy URL unparseable: %v (url=%q)", err, got)
+	}
+	if parsed.Scheme != "http" {
+		t.Fatalf("scheme = %q, want http", parsed.Scheme)
+	}
+	if parsed.Host != "resin.local:2260" {
+		t.Fatalf("host = %q, want resin.local:2260", parsed.Host)
+	}
+	// Go's url.UserPassword stores raw values; Username()/Password() return unescaped.
+	username := parsed.User.Username()
+	password, passwordOk := parsed.User.Password()
+	if !passwordOk {
+		t.Fatalf("password not set in userinfo: %q", got)
+	}
+	if username != "Default.acc-42" {
+		t.Fatalf("userinfo username = %q, want Default.acc-42", username)
+	}
+	if password != "my-token" {
+		t.Fatalf("userinfo password (token) = %q, want my-token", password)
+	}
+}
+
+func TestForwardProxyURLMisconfigured(t *testing.T) {
+	t.Parallel()
+	// ForwardProxyURL is a low-level builder; it does not check ResinEnabled
+	// (gating is the caller's job via ResinEnabled). These cases test URL
+	// parsing / identity completeness, not the enabled flag.
+	cases := []struct {
+		name     string
+		cfg      *config.Config
+		platform string
+		account  string
+	}{
+		{"empty platform", resinCfg("http://resin.local:2260/tok", ""), "", "acc-1"},
+		{"empty account", resinCfg("http://resin.local:2260/tok", "Default"), "Default", ""},
+		{"no token in url", resinCfg("http://resin.local:2260", "Default"), "Default", "acc-1"},
+		{"empty url", resinCfg("", "Default"), "Default", "acc-1"},
+		{"nil cfg", nil, "Default", "acc-1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ForwardProxyURL(tc.cfg, tc.platform, tc.account)
+			if ok || got != "" {
+				t.Fatalf("ForwardProxyURL = (%q, %v), want (\"\", false)", got, ok)
+			}
+		})
+	}
+}
+
+// ---- Temp identity determinism ----
+
+func TestTempAccountForDeterminism(t *testing.T) {
+	t.Parallel()
+	siteID := int64(7)
+	token := "sk-abc123"
+
+	// Same (siteID, token) → same identity.
+	first := TempAccountFor(siteID, token)
+	second := TempAccountFor(siteID, token)
+	if first != second {
+		t.Fatalf("temp identity not deterministic: %q vs %q", first, second)
+	}
+	if !strings.HasPrefix(first, "tmp-") {
+		t.Fatalf("temp identity should start with tmp-: %q", first)
+	}
+	if len(first) != len("tmp-")+16 {
+		t.Fatalf("temp identity should be tmp- + 16 hex chars: %q (len=%d)", first, len(first))
+	}
+}
+
+func TestTempAccountForDifferentTokensDifferentIDs(t *testing.T) {
+	t.Parallel()
+	siteID := int64(1)
+	a := TempAccountFor(siteID, "token-alpha")
+	b := TempAccountFor(siteID, "token-beta")
+	if a == b {
+		t.Fatalf("different tokens produced same temp identity: %q", a)
+	}
+}
+
+func TestTempAccountForDifferentSitesDifferentIDs(t *testing.T) {
+	t.Parallel()
+	token := "shared-token"
+	a := TempAccountFor(1, token)
+	b := TempAccountFor(2, token)
+	if a == b {
+		t.Fatalf("different sites produced same temp identity: %q", a)
+	}
+}
+
+func TestTempAccountForNoDotOrColon(t *testing.T) {
+	t.Parallel()
+	for _, token := range []string{"a", "sk-1234", "token.with.dots", "token:with:colons", "mixed.:token"} {
+		identity := TempAccountFor(99, token)
+		if strings.Contains(identity, ".") {
+			t.Fatalf("temp identity %q contains '.' (token=%q)", identity, token)
+		}
+		if strings.Contains(identity, ":") {
+			t.Fatalf("temp identity %q contains ':' (token=%q)", identity, token)
+		}
+	}
+}
+
+// ---- AccountFor stable identity ----
+
+func TestAccountForStable(t *testing.T) {
+	t.Parallel()
+	account := &store.Account{ID: 42}
+	got := AccountFor(account, nil)
+	if got != "acc-42" {
+		t.Fatalf("AccountFor = %q, want acc-42", got)
+	}
+
+	// No account → empty.
+	if got := AccountFor(nil, &store.Site{ID: 1}); got != "" {
+		t.Fatalf("AccountFor(nil account) = %q, want empty", got)
+	}
+	// Account with zero ID → empty (pre-account).
+	if got := AccountFor(&store.Account{ID: 0}, nil); got != "" {
+		t.Fatalf("AccountFor(zero ID) = %q, want empty", got)
+	}
+}
+
+// ---- WS URL rewrite form ----
+
+func TestRewriteWSURLWssTarget(t *testing.T) {
+	t.Parallel()
+	cfg := resinCfg("http://resin.local:2260/my-token", "Default")
+
+	got := RewriteWSURL("wss://api.openai.com/v1/responses?stream=true", cfg, "Default", "acc-1")
+	if got == "" {
+		t.Fatal("RewriteWSURL returned empty for valid wss target")
+	}
+
+	parsed, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("rewritten URL unparseable: %v (url=%q)", err, got)
+	}
+	if parsed.Scheme != "ws" {
+		t.Fatalf("scheme = %q, want ws (client→resin must be ws)", parsed.Scheme)
+	}
+	if parsed.Host != "resin.local:2260" {
+		t.Fatalf("host = %q, want resin.local:2260", parsed.Host)
+	}
+	wantPathPrefix := "/my-token/Default/https/api.openai.com/v1/responses"
+	if !strings.HasPrefix(parsed.Path, wantPathPrefix) {
+		t.Fatalf("path = %q, want prefix %q", parsed.Path, wantPathPrefix)
+	}
+	if parsed.RawQuery != "stream=true" {
+		t.Fatalf("query = %q, want stream=true", parsed.RawQuery)
+	}
+}
+
+func TestRewriteWSURLWsTarget(t *testing.T) {
+	t.Parallel()
+	cfg := resinCfg("http://resin.local:2260/my-token", "Default")
+
+	got := RewriteWSURL("ws://api.example.com/chat", cfg, "Default", "acc-1")
+	if got == "" {
+		t.Fatal("RewriteWSURL returned empty for valid ws target")
+	}
+
+	parsed, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("rewritten URL unparseable: %v (url=%q)", err, got)
+	}
+	if parsed.Scheme != "ws" {
+		t.Fatalf("scheme = %q, want ws", parsed.Scheme)
+	}
+	// ws target → protocol segment = http
+	wantPathPrefix := "/my-token/Default/http/api.example.com/chat"
+	if !strings.HasPrefix(parsed.Path, wantPathPrefix) {
+		t.Fatalf("path = %q, want prefix %q", parsed.Path, wantPathPrefix)
+	}
+}
+
+func TestRewriteWSURLWithPort(t *testing.T) {
+	t.Parallel()
+	cfg := resinCfg("http://resin.local:2260/my-token", "Default")
+
+	got := RewriteWSURL("wss://ws.example.com:8443/chat/room", cfg, "Default", "acc-1")
+	if got == "" {
+		t.Fatal("RewriteWSURL returned empty")
+	}
+	parsed, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("rewritten URL unparseable: %v (url=%q)", err, got)
+	}
+	wantPathPrefix := "/my-token/Default/https/ws.example.com:8443/chat/room"
+	if !strings.HasPrefix(parsed.Path, wantPathPrefix) {
+		t.Fatalf("path = %q, want prefix %q", parsed.Path, wantPathPrefix)
+	}
+}
+
+func TestRewriteWSURLMisconfigured(t *testing.T) {
+	t.Parallel()
+	// RewriteWSURL is a low-level builder; it does not check ResinEnabled
+	// (gating is the caller's job via ResinEnabled). These cases test URL
+	// parsing / identity / scheme, not the enabled flag.
+	cases := []struct {
+		name      string
+		cfg       *config.Config
+		targetURL string
+		platform  string
+		account   string
+	}{
+		{"empty platform", resinCfg("http://resin.local:2260/tok", ""), "wss://a.com/x", "", "acc-1"},
+		{"empty account", resinCfg("http://resin.local:2260/tok", "Default"), "wss://a.com/x", "Default", ""},
+		{"non-ws scheme", resinCfg("http://resin.local:2260/tok", "Default"), "https://a.com/x", "Default", "acc-1"},
+		{"no token in url", resinCfg("http://resin.local:2260", "Default"), "wss://a.com/x", "Default", "acc-1"},
+		{"nil cfg", nil, "wss://a.com/x", "Default", "acc-1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RewriteWSURL(tc.targetURL, tc.cfg, tc.platform, tc.account); got != "" {
+				t.Fatalf("RewriteWSURL = %q, want empty", got)
+			}
+		})
+	}
+}
+
+// ---- BuildPlatformProxyConfig integration with Resin ----
+
+func TestBuildPlatformProxyConfigResinForwardProxy(t *testing.T) {
+	t.Parallel()
+	cfg := resinCfg("http://resin.local:2260/my-token", "Default")
+	account := &store.Account{ID: 5}
+	site := &store.Site{ID: 1, Platform: "openai"}
+
+	proxyCfg := BuildPlatformProxyConfig(cfg, account, site)
+	if proxyCfg == nil {
+		t.Fatal("proxy config is nil")
+	}
+	if proxyCfg.ProxyURL == "" {
+		t.Fatal("ProxyURL is empty, expected resin forward proxy URL")
+	}
+	parsed, err := url.Parse(proxyCfg.ProxyURL)
+	if err != nil {
+		t.Fatalf("resin ProxyURL unparseable: %v", err)
+	}
+	if username := parsed.User.Username(); username != "Default.acc-5" {
+		t.Fatalf("userinfo username = %q, want Default.acc-5", username)
+	}
+	if proxyCfg.ResinAccount != "acc-5" {
+		t.Fatalf("ResinAccount = %q, want acc-5", proxyCfg.ResinAccount)
+	}
+}
+
+func TestBuildPlatformProxyConfigResinFallsBackWhenAccountIDZero(t *testing.T) {
+	t.Parallel()
+	cfg := resinCfg("http://resin.local:2260/my-token", "Default")
+	account := &store.Account{ID: 0} // pre-account: no ID
+	site := &store.Site{ID: 1, Platform: "openai"}
+
+	proxyCfg := BuildPlatformProxyConfig(cfg, account, site)
+	// No account ID → no stable identity → resin skipped → nil (direct).
+	if proxyCfg != nil {
+		t.Fatalf("expected nil (direct) when account has no ID, got %+v", proxyCfg)
+	}
+}
+
+func TestBuildPlatformProxyConfigAccountProxyURLBeatsResin(t *testing.T) {
+	t.Parallel()
+	cfg := resinCfg("http://resin.local:2260/my-token", "Default")
+	accountProxy := `{"proxyUrl":"http://account-proxy:8080"}`
+	account := &store.Account{ID: 5, ExtraConfig: &accountProxy}
+	site := &store.Site{ID: 1, Platform: "openai"}
+
+	proxyCfg := BuildPlatformProxyConfig(cfg, account, site)
+	if proxyCfg == nil {
+		t.Fatal("proxy config is nil")
+	}
+	if proxyCfg.ProxyURL != "http://account-proxy:8080" {
+		t.Fatalf("ProxyURL = %q, want account proxy (resin should not override)", proxyCfg.ProxyURL)
+	}
+	if proxyCfg.ResinAccount != "" {
+		t.Fatalf("ResinAccount = %q, want empty (account proxy wins, not resin)", proxyCfg.ResinAccount)
+	}
+}
+
+func TestBuildPlatformProxyConfigSiteProxyURLBeatsResin(t *testing.T) {
+	t.Parallel()
+	cfg := resinCfg("http://resin.local:2260/my-token", "Default")
+	siteProxy := "http://site-proxy:8080"
+	account := &store.Account{ID: 5}
+	site := &store.Site{ID: 1, Platform: "openai", ProxyURL: &siteProxy}
+
+	proxyCfg := BuildPlatformProxyConfig(cfg, account, site)
+	if proxyCfg == nil {
+		t.Fatal("proxy config is nil")
+	}
+	if proxyCfg.ProxyURL != "http://site-proxy:8080" {
+		t.Fatalf("ProxyURL = %q, want site proxy (resin should not override)", proxyCfg.ProxyURL)
+	}
+}
+
+func TestBuildPlatformProxyConfigResinBeatsSystemProxy(t *testing.T) {
+	t.Parallel()
+	cfg := resinCfg("http://resin.local:2260/my-token", "Default")
+	cfg.SystemProxyUrl = "http://system-proxy:8080"
+	account := &store.Account{ID: 5}
+	site := &store.Site{ID: 1, Platform: "openai", UseSystemProxy: true}
+
+	proxyCfg := BuildPlatformProxyConfig(cfg, account, site)
+	if proxyCfg == nil {
+		t.Fatal("proxy config is nil")
+	}
+	parsed, err := url.Parse(proxyCfg.ProxyURL)
+	if err != nil {
+		t.Fatalf("ProxyURL unparseable: %v", err)
+	}
+	if parsed.Host != "resin.local:2260" {
+		t.Fatalf("ProxyURL host = %q, want resin.local:2260 (resin should beat system)", parsed.Host)
+	}
+	if proxyCfg.UseSystemProxy {
+		t.Fatal("UseSystemProxy = true, want false (resin won)")
+	}
+}
+
+func TestBuildPlatformProxyConfigResinDisabledFallsBackToSystemProxy(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		ResinEnabled: false,
+		SystemProxyUrl: "http://system-proxy:8080",
+	}
+	account := &store.Account{ID: 5}
+	site := &store.Site{ID: 1, Platform: "openai", UseSystemProxy: true}
+
+	proxyCfg := BuildPlatformProxyConfig(cfg, account, site)
+	if proxyCfg == nil {
+		t.Fatal("proxy config is nil")
+	}
+	if proxyCfg.ProxyURL != "http://system-proxy:8080" {
+		t.Fatalf("ProxyURL = %q, want system proxy", proxyCfg.ProxyURL)
+	}
+	if !proxyCfg.UseSystemProxy {
+		t.Fatal("UseSystemProxy = false, want true")
+	}
+}
+
+func TestBuildPlatformProxyConfigResinPlatformFallback(t *testing.T) {
+	t.Parallel()
+	// No RESIN_PLATFORM_NAME → fall back to site.Platform.
+	cfg := &config.Config{
+		ResinURL:     "http://resin.local:2260/my-token",
+		ResinEnabled: true,
+		// ResinPlatformName intentionally empty
+	}
+	account := &store.Account{ID: 5}
+	site := &store.Site{ID: 1, Platform: "codex"}
+
+	proxyCfg := BuildPlatformProxyConfig(cfg, account, site)
+	if proxyCfg == nil {
+		t.Fatal("proxy config is nil")
+	}
+	parsed, err := url.Parse(proxyCfg.ProxyURL)
+	if err != nil {
+		t.Fatalf("ProxyURL unparseable: %v", err)
+	}
+	if username := parsed.User.Username(); !strings.HasPrefix(username, "codex.acc-5") {
+		t.Fatalf("userinfo username = %q, want prefix codex.acc-5 (platform fallback)", username)
+	}
+}
+
+// ---- BuildPlatformProxyConfigForToken (pre-account temp identity) ----
+
+func TestBuildPlatformProxyConfigForTokenTempIdentity(t *testing.T) {
+	t.Parallel()
+	cfg := resinCfg("http://resin.local:2260/my-token", "Default")
+	site := &store.Site{ID: 7, Platform: "openai"}
+
+	proxyCfg := BuildPlatformProxyConfigForToken(cfg, site, "sk-test-token")
+	if proxyCfg == nil {
+		t.Fatal("proxy config is nil")
+	}
+	if proxyCfg.ProxyURL == "" {
+		t.Fatal("ProxyURL is empty, expected resin forward proxy URL")
+	}
+	expectedAccount := TempAccountFor(site.ID, "sk-test-token")
+	if proxyCfg.ResinAccount != expectedAccount {
+		t.Fatalf("ResinAccount = %q, want %q", proxyCfg.ResinAccount, expectedAccount)
+	}
+	// Verify the temp identity is embedded in the userinfo.
+	parsed, err := url.Parse(proxyCfg.ProxyURL)
+	if err != nil {
+		t.Fatalf("ProxyURL unparseable: %v", err)
+	}
+	if username := parsed.User.Username(); username != "Default."+expectedAccount {
+		t.Fatalf("userinfo username = %q, want Default.%s", username, expectedAccount)
+	}
+}
+
+func TestBuildPlatformProxyConfigForTokenSiteProxyURLWins(t *testing.T) {
+	t.Parallel()
+	cfg := resinCfg("http://resin.local:2260/my-token", "Default")
+	siteProxy := "http://site-proxy:8080"
+	site := &store.Site{ID: 7, Platform: "openai", ProxyURL: &siteProxy}
+
+	proxyCfg := BuildPlatformProxyConfigForToken(cfg, site, "sk-test-token")
+	if proxyCfg == nil {
+		t.Fatal("proxy config is nil")
+	}
+	if proxyCfg.ProxyURL != "http://site-proxy:8080" {
+		t.Fatalf("ProxyURL = %q, want site proxy (beats resin)", proxyCfg.ProxyURL)
+	}
+	if proxyCfg.ResinAccount != "" {
+		t.Fatalf("ResinAccount = %q, want empty (site proxy wins)", proxyCfg.ResinAccount)
+	}
+}
+
+func TestBuildPlatformProxyConfigForTokenResinBeatsSystemProxy(t *testing.T) {
+	t.Parallel()
+	cfg := resinCfg("http://resin.local:2260/my-token", "Default")
+	cfg.SystemProxyUrl = "http://system-proxy:8080"
+	site := &store.Site{ID: 7, Platform: "openai", UseSystemProxy: true}
+
+	proxyCfg := BuildPlatformProxyConfigForToken(cfg, site, "sk-test-token")
+	if proxyCfg == nil {
+		t.Fatal("proxy config is nil")
+	}
+	parsed, err := url.Parse(proxyCfg.ProxyURL)
+	if err != nil {
+		t.Fatalf("ProxyURL unparseable: %v", err)
+	}
+	if parsed.Host != "resin.local:2260" {
+		t.Fatalf("ProxyURL host = %q, want resin.local:2260 (resin beats system)", parsed.Host)
+	}
+}
+
+func TestBuildPlatformProxyConfigForTokenResinDisabled(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		ResinEnabled:  false,
+		SystemProxyUrl: "http://system-proxy:8080",
+	}
+	site := &store.Site{ID: 7, Platform: "openai", UseSystemProxy: true}
+
+	proxyCfg := BuildPlatformProxyConfigForToken(cfg, site, "sk-test-token")
+	if proxyCfg == nil {
+		t.Fatal("proxy config is nil")
+	}
+	if proxyCfg.ProxyURL != "http://system-proxy:8080" {
+		t.Fatalf("ProxyURL = %q, want system proxy (resin disabled)", proxyCfg.ProxyURL)
+	}
+}
+
+func TestBuildPlatformProxyConfigForTokenDeterministic(t *testing.T) {
+	t.Parallel()
+	cfg := resinCfg("http://resin.local:2260/my-token", "Default")
+	site := &store.Site{ID: 7, Platform: "openai"}
+
+	// verify-token and create should derive the same temp identity for the same token.
+	verifyCfg := BuildPlatformProxyConfigForToken(cfg, site, "shared-token")
+	createCfg := BuildPlatformProxyConfigForToken(cfg, site, "shared-token")
+	if verifyCfg == nil || createCfg == nil {
+		t.Fatal("proxy config is nil")
+	}
+	if verifyCfg.ResinAccount != createCfg.ResinAccount {
+		t.Fatalf("temp identity not deterministic: verify=%q create=%q",
+			verifyCfg.ResinAccount, createCfg.ResinAccount)
+	}
+	if verifyCfg.ProxyURL != createCfg.ProxyURL {
+		t.Fatalf("ProxyURL not deterministic: verify=%q create=%q",
+			verifyCfg.ProxyURL, createCfg.ProxyURL)
+	}
+}


### PR DESCRIPTION
## Summary

Integrates the external **Resin** sticky proxy pool so each business identity keeps a stable outbound IP. This is **Tier 1** — env-only config, no DDL or DB migration.

- **Config** (3 env vars): `RESIN_URL`, `RESIN_PLATFORM_NAME`, `RESIN_ENABLED` (default off). Added to `Config` struct + `Load()` near `SystemProxyUrl`.
- **Forward proxy** (HTTP/SSE): Go `http.Transport` derives `Proxy-Authorization` from the proxy-URL userinfo automatically. The resin forward proxy URL embeds `{Platform}.{Account}` as username and the resin token as password.
- **Reverse proxy** (native wss only): the only path that bypasses `BuildPlatformProxyConfig`. Rewrites the dial URL to the resin reverse-proxy path form and sets `X-Resin-Account` on the dial headers.
- **Account identity**: stable `acc-{Account.ID}` (post-creation) / deterministic `tmp-{sha1(siteID:token)[:16]}` (pre-account verify/login/create). Temp identity is per-token so verify→create land on the same IP.
- **Precedence**: key > account.proxyUrl > site.ProxyURL > **resin** > system > direct. Resin sits between explicit proxy URLs and the system-proxy opt-in.

New helper file `service/resin.go` with: `ResinEnabled`, `AccountFor`, `TempAccountFor`, `ForwardProxyURL`, `RewriteWSURL`, `ResolveResinPlatform`, `parseResinURL`.

## Files changed (9 files, ~920 LOC)

| File | Change |
|------|--------|
| `config/config.go` | `ResinURL`/`ResinPlatformName`/`ResinEnabled` fields + env parsing |
| `platform/adapter.go` | `ResinAccount` field on `ProxyConfig` |
| `service/resin.go` | **New** — Tier 1 helper contract |
| `service/resin_test.go` | **New** — URL format, temp-identity determinism, WS rewrite, Enabled gating, precedence tests |
| `service/account_service.go` | Resin tier in `BuildPlatformProxyConfig` + `BuildPlatformProxyConfigForToken` for pre-account temp identity |
| `handler/proxy/codex_ws_runtime.go` | `ResinAccount`/`ResinPlatform` on `CodexWebsocketSendInput` + wss reverse-proxy rewrite in `sendCodexWSSessionAttempt` |
| `handler/proxy/responses_ws.go` | Resolve resin identity in `tryCodexUpstreamWSS` |
| `handler/admin/accounts.go` | 3 pre-account call sites (create/login/verify) use `BuildPlatformProxyConfigForToken` |
| `config/config_test.go` | Resin env parsing + defaults-off tests |

## Pragmatic decisions

- **Precedence reordering**: `BuildPlatformProxyConfig` now checks `site.ProxyURL` before `account.useSystemProxy` (was reversed). Aligns with the stated "account > site > resin > system" precedence. This is a minor behavior change: an explicit site proxy URL now wins over the account's generic `useSystemProxy` flag.
- **Login temp identity**: uses `body.Username` as the deterministic seed (the only stable pre-login identifier available). Verify-token and create both use the raw access token, so they land on the same IP.
- **Low-level builders**: `ForwardProxyURL` and `RewriteWSURL` do NOT check `ResinEnabled` — gating is the caller's job via `ResinEnabled()`. This keeps them pure URL builders.
- **Tier 2 follow-up**: `inherit-lease` (temp→stable identity transfer after INSERT) is deferred to Tier 2 per the issue spec.

## Test plan

- [x] `go build ./config/... ./platform/... ./service/... ./handler/...` — clean
- [x] `go test ./config/... ./platform/... ./service/... ./handler/...` — all green
- [x] `go vet ./config/... ./platform/... ./service/... ./handler/...` — clean
- [x] Forward-proxy URL userinfo format test (`Platform.Account` username, token password)
- [x] Temp-identity determinism (same token→same id, different tokens→different ids, different sites→different ids, no `.`/`:`)
- [x] WS URL rewrite form (wss→`https` protocol segment, ws→`http`, port preserved, path+query preserved)
- [x] `Enabled` gating (nil cfg, disabled flag, empty URL, blank URL, valid)
- [x] Precedence: account proxy > site proxy > resin > system > direct
- [x] Resin platform fallback (cfg `ResinPlatformName` → `site.Platform`)
- [ ] Manual: set `RESIN_ENABLED=true RESIN_URL=http://resin-host:port/token RESIN_PLATFORM_NAME=metapi` and verify outbound IP stability per account

Closes #677