### PR TITLE
perf(platform): pool DoWithProxy transports for connection reuse

### DIFF
--- a/platform/site_proxy.go
+++ b/platform/site_proxy.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -22,6 +23,87 @@ var supportedProxySchemes = map[string]bool{
 	"http": true, "https": true,
 	"socks": true, "socks4": true, "socks4a": true,
 	"socks5": true, "socks5h": true,
+}
+
+// transportCache pools *http.Transport instances by (proxyURL, insecureSkipTLS)
+// so repeated DoWithProxy / SiteProxy.Do calls to the same proxy (or direct)
+// reuse the underlying keep-alive connection pool instead of forcing a fresh
+// TLS handshake + dial on every request. Probe loops and stream traffic are
+// the main beneficiaries: handshake amplification and fingerprint exposure at
+// shield-protected upstreams drop to one-per-(proxy,tls)-tuple per process.
+//
+// Entries live for the process lifetime; pooled transports hold idle
+// connections bounded by MaxIdleConns / MaxIdleConnsPerHost / IdleConnTimeout
+// (see newPooledTransport). The proxy func captured by a cached transport must
+// be effectively constant with respect to the request (http.ProxyURL,
+// SiteProxy.proxyFunc, or nil) so the cache key stays stable.
+var transportCache sync.Map // map[string]*http.Transport
+
+// getCachedTransport returns a pooled *http.Transport for the given
+// (proxy, insecureSkipTLS) tuple, creating and storing it on first miss.
+// Concurrency-safe: concurrent first-miss callers race via LoadOrStore; the
+// loser's transport is unreferenced and garbage-collected with no connections.
+func getCachedTransport(proxy func(*http.Request) (*url.URL, error), insecureSkipTLS bool) *http.Transport {
+	key := transportCacheKey(proxy, insecureSkipTLS)
+	if cached, ok := transportCache.Load(key); ok {
+		return cached.(*http.Transport)
+	}
+	transport := newPooledTransport(proxy, insecureSkipTLS)
+	actual, _ := transportCache.LoadOrStore(key, transport)
+	return actual.(*http.Transport)
+}
+
+// transportCacheKey derives the cache key from the proxy func by resolving it
+// against a sentinel request. proxy may be nil (direct connection), in which
+// case the proxy portion of the key is the empty string.
+func transportCacheKey(proxy func(*http.Request) (*url.URL, error), insecureSkipTLS bool) string {
+	proxyURL := ""
+	if proxy != nil {
+		sentinel := &http.Request{URL: &url.URL{Scheme: "http", Host: "transport-cache.sentinel.invalid"}}
+		if resolved, err := proxy(sentinel); err == nil && resolved != nil {
+			proxyURL = resolved.String()
+		}
+	}
+	insecure := "0"
+	if insecureSkipTLS {
+		insecure = "1"
+	}
+	return proxyURL + "|" + insecure
+}
+
+// newPooledTransport builds a fresh *http.Transport configured for connection
+// reuse. Called only on cache misses inside getCachedTransport.
+func newPooledTransport(proxy func(*http.Request) (*url.URL, error), insecureSkipTLS bool) *http.Transport {
+	transport := &http.Transport{
+		Proxy: proxy,
+		DialContext: (&net.Dialer{
+			Timeout:   defaultProxyConnectTimeout,
+			KeepAlive: defaultProxyKeepAliveInitial,
+		}).DialContext,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		// Pool sizing: keep idle sockets warm so repeated probes/streams to the
+		// same upstream reuse the same TCP+TLS pair instead of re-dialing.
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 20,
+		IdleConnTimeout:    90 * time.Second,
+	}
+	if insecureSkipTLS {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	return transport
+}
+
+// newProxyClient wraps a (pooled) *http.Transport with the shared timeout and
+// cross-origin redirect policy used by outbound site-proxy traffic. The
+// *http.Client is cheap to construct per request; only the Transport is pooled.
+func newProxyClient(transport *http.Transport) *http.Client {
+	return &http.Client{
+		Transport:     transport,
+		Timeout:       30 * time.Second,
+		CheckRedirect: RejectCrossOriginRedirect,
+	}
 }
 
 // SiteProxyConfig holds proxy configuration for a site.
@@ -128,26 +210,12 @@ func (sp *SiteProxy) doWithExplicitProxy(ctx context.Context, req *http.Request,
 		return nil, fmt.Errorf("unsupported proxy scheme: %s", scheme)
 	}
 
-	transport := &http.Transport{
-		Proxy: http.ProxyURL(proxyURL),
-		DialContext: (&net.Dialer{
-			Timeout:   defaultProxyConnectTimeout,
-			KeepAlive: defaultProxyKeepAliveInitial,
-		}).DialContext,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
-	}
-
-	if proxyConfig.InsecureSkipTLS {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
-
-	client := &http.Client{
-		Transport:     transport,
-		Timeout:       30 * time.Second,
-		CheckRedirect: RejectCrossOriginRedirect,
-	}
-
+	// Reuse a pooled transport so repeated requests through the same proxy
+	// share keep-alive connections instead of re-handshaking TLS every call.
+	// Only the *http.Transport is pooled; the *http.Client wrapper (timeout +
+	// redirect policy) is constructed per call and is cheap.
+	transport := getCachedTransport(http.ProxyURL(proxyURL), proxyConfig.InsecureSkipTLS)
+	client := newProxyClient(transport)
 	return client.Do(req)
 }
 
@@ -172,32 +240,12 @@ func DoWithProxy(ctx context.Context, req *http.Request, proxyConfig *ProxyConfi
 			return nil, fmt.Errorf("unsupported proxy scheme: %s", scheme)
 		}
 
-		client := newProxyHTTPClient(http.ProxyURL(proxyURL), insecureSkipTLS)
+		client := newProxyClient(getCachedTransport(http.ProxyURL(proxyURL), insecureSkipTLS))
 		return client.Do(req.WithContext(ctx))
 	}
 
-	client := newProxyHTTPClient(nil, insecureSkipTLS)
+	client := newProxyClient(getCachedTransport(nil, insecureSkipTLS))
 	return client.Do(req.WithContext(ctx))
-}
-
-func newProxyHTTPClient(proxy func(*http.Request) (*url.URL, error), insecureSkipTLS bool) *http.Client {
-	transport := &http.Transport{
-		Proxy: proxy,
-		DialContext: (&net.Dialer{
-			Timeout:   defaultProxyConnectTimeout,
-			KeepAlive: defaultProxyKeepAliveInitial,
-		}).DialContext,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
-	}
-	if insecureSkipTLS {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	}
-	return &http.Client{
-		Transport:     transport,
-		Timeout:       30 * time.Second,
-		CheckRedirect: RejectCrossOriginRedirect,
-	}
 }
 
 // RejectCrossOriginRedirect is the shared CheckRedirect policy for outbound

--- a/platform/transport_pool_test.go
+++ b/platform/transport_pool_test.go
@@ -1,0 +1,133 @@
+package platform
+
+import (
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestGetCachedTransport_SameKeyReturnsSamePointer verifies the core pooling
+// invariant: two lookups with the same (proxy, insecure) tuple must return the
+// same *http.Transport pointer, while the insecure variant is distinct.
+func TestGetCachedTransport_SameKeyReturnsSamePointer(t *testing.T) {
+	proxyURL, err := url.Parse("http://same-key.example:8080")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	proxy := http.ProxyURL(proxyURL)
+
+	first := getCachedTransport(proxy, false)
+	second := getCachedTransport(proxy, false)
+	if first != second {
+		t.Fatal("same (proxy, insecure) must return the same *http.Transport pointer")
+	}
+
+	// The insecure variant maps to a different cache key and must be distinct.
+	insecure := getCachedTransport(proxy, true)
+	if insecure == first {
+		t.Fatal("insecure variant should be a distinct transport")
+	}
+}
+
+// TestGetCachedTransport_DifferentKeysReturnDifferentPointers verifies that
+// different proxy URLs do not alias to the same pooled transport.
+func TestGetCachedTransport_DifferentKeysReturnDifferentPointers(t *testing.T) {
+	proxyA, _ := url.Parse("http://distinct-a.example:8080")
+	proxyB, _ := url.Parse("http://distinct-b.example:8080")
+
+	transportA := getCachedTransport(http.ProxyURL(proxyA), false)
+	transportB := getCachedTransport(http.ProxyURL(proxyB), false)
+	if transportA == transportB {
+		t.Fatal("different proxy URLs must map to different transports")
+	}
+}
+
+// TestGetCachedTransport_NilProxyDirectConnection covers the direct-connection
+// path used by DoWithProxy when no ProxyURL is configured. The Proxy field on a
+// direct transport must be nil so environment proxies (HTTP_PROXY) are ignored.
+func TestGetCachedTransport_NilProxyDirectConnection(t *testing.T) {
+	direct := getCachedTransport(nil, false)
+	if direct == nil {
+		t.Fatal("direct transport must not be nil")
+	}
+	if direct.Proxy != nil {
+		t.Fatal("direct transport must have nil Proxy so env proxies are ignored")
+	}
+	// Same nil-proxy + insecure combo must be stable across calls.
+	directAgain := getCachedTransport(nil, false)
+	if direct != directAgain {
+		t.Fatal("nil proxy must be cached and stable across calls")
+	}
+}
+
+// TestGetCachedTransport_PoolingSettingsApplied asserts the pooled transport is
+// configured for real connection reuse (the whole point of the cache).
+func TestGetCachedTransport_PoolingSettingsApplied(t *testing.T) {
+	// Unique socks5 URL so this test does not collide with cache entries
+	// populated by other tests in the package.
+	proxyURL, _ := url.Parse("socks5://pool-settings.example:1080")
+	transport := getCachedTransport(http.ProxyURL(proxyURL), false)
+	if got, want := transport.MaxIdleConns, 100; got != want {
+		t.Errorf("MaxIdleConns = %d, want %d", got, want)
+	}
+	if got, want := transport.MaxIdleConnsPerHost, 20; got != want {
+		t.Errorf("MaxIdleConnsPerHost = %d, want %d", got, want)
+	}
+	if got, want := transport.IdleConnTimeout, 90*time.Second; got != want {
+		t.Errorf("IdleConnTimeout = %v, want %v", got, want)
+	}
+}
+
+// TestGetCachedTransport_ConcurrentSameKey confirms the cache is concurrency
+// safe: many goroutines racing on the same first-miss key all observe the same
+// transport pointer (no duplicate entries, no panics).
+func TestGetCachedTransport_ConcurrentSameKey(t *testing.T) {
+	proxyURL, _ := url.Parse("http://concurrent.example:8080")
+	proxy := http.ProxyURL(proxyURL)
+
+	const goroutines = 64
+	pointers := make([]*http.Transport, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			<-start
+			pointers[i] = getCachedTransport(proxy, false)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	baseline := getCachedTransport(proxy, false)
+	for i, got := range pointers {
+		if got != baseline {
+			t.Fatalf("goroutine %d got %p, want %p (cache must dedupe under concurrency)", i, got, baseline)
+		}
+	}
+}
+
+// TestTransportCacheKey_StableAndDistinct pins the key format so future
+// refactors of the proxy-func introspection do not silently change caching
+// behavior (e.g. merging the direct and proxied paths).
+func TestTransportCacheKey_StableAndDistinct(t *testing.T) {
+	proxyURL, _ := url.Parse("http://key.example:8080")
+	proxy := http.ProxyURL(proxyURL)
+
+	if got, want := transportCacheKey(proxy, false), "http://key.example:8080|0"; got != want {
+		t.Errorf("secure key = %q, want %q", got, want)
+	}
+	if got, want := transportCacheKey(proxy, true), "http://key.example:8080|1"; got != want {
+		t.Errorf("insecure key = %q, want %q", got, want)
+	}
+	if got, want := transportCacheKey(nil, false), "|0"; got != want {
+		t.Errorf("nil-proxy secure key = %q, want %q", got, want)
+	}
+	if got, want := transportCacheKey(nil, true), "|1"; got != want {
+		t.Errorf("nil-proxy insecure key = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- `DoWithProxy` and `SiteProxy.doWithExplicitProxy` built a brand-new `*http.Transport` on **every** request, forcing a fresh TLS handshake + dial each time — this multiplied handshakes in probe loops / stream traffic, defeated keep-alive, and amplified fingerprint exposure at shield-protected upstreams (issue #671).
- Add a package-level `sync.Map` cache (`transportCache`) keyed by `"<proxyURL>|<insecureSkipTLS>"` and a `getCachedTransport(proxy, insecure)` helper; both call sites now reuse the pooled `*http.Transport` and its keep-alive pool. The `*http.Client` wrapper (30s `Timeout`, `RejectCrossOriginRedirect`) is **unchanged** — only the `Transport` is pooled.
- Pooled transports are configured for real connection reuse: `MaxIdleConns=100`, `MaxIdleConnsPerHost=20`, `IdleConnTimeout=90s`. The cache key is derived by resolving the (constant) proxy func against a sentinel request, so `http.ProxyURL`, `SiteProxy.proxyFunc`, and `nil` (direct) all key deterministically.

## Behavior preserved
- No new packages; everything is inline in `platform/site_proxy.go`.
- `*http.Client` timeout + redirect semantics untouched (`newProxyClient` wraps the pooled transport with the same 30s / `RejectCrossOriginRedirect`).
- Direct (no-proxy) path still ignores `HTTP_PROXY`/`HTTPS_PROXY` env vars (pooled transport has `Proxy == nil`).
- Concurrency-safe: `LoadOrStore` dedupes first-miss races; loser transports are GC'd with zero connections.

## Test plan
- [x] `go build ./platform/...` clean; `go vet ./platform/...` clean.
- [x] `go test ./platform/... -count=1` green (existing `site_proxy_test.go` suite still passes — redirect policy, env-proxy bypass, explicit-proxy routing all unchanged).
- [x] New `platform/transport_pool_test.go` green under `-race`:
  - `TestGetCachedTransport_SameKeyReturnsSamePointer` — same `(proxy, insecure)` ⇒ identical pointer; insecure variant distinct.
  - `TestGetCachedTransport_DifferentKeysReturnDifferentPointers` — different proxy URLs ⇒ distinct transports.
  - `TestGetCachedTransport_NilProxyDirectConnection` — direct transport has nil `Proxy` (env-proxy bypass intact) and is cached.
  - `TestGetCachedTransport_PoolingSettingsApplied` — asserts `MaxIdleConns`/`MaxIdleConnsPerHost`/`IdleConnTimeout`.
  - `TestGetCachedTransport_ConcurrentSameKey` — 64 goroutines racing on the same key all observe the same pointer.
  - `TestTransportCacheKey_StableAndDistinct` — pins the key format.

Closes #671