### PR TITLE
feat(sub2api): group-aware models + token_model_availability backfill

### DIFF
--- a/handler/admin/model_refresh.go
+++ b/handler/admin/model_refresh.go
@@ -185,6 +185,21 @@ func refreshAccountModels(ctx context.Context, db *sqlx.DB, accountID int64, all
 		}
 	}
 
+	// Backfill token_model_availability for the resolved token so the
+	// marketplace stats and site model list (which read this table) reflect
+	// the freshly refreshed model set (#675). Best-effort: if the token does
+	// not match an account_tokens row, skip silently — the account-level
+	// model_availability rows remain the source of truth.
+	tokenBackfilled := false
+	if tokenID, ok := resolveAccountTokenID(db, accountID, token); ok {
+		if err := persistTokenModelAvailability(db, tokenID, clean, now); err != nil {
+			slog.Warn("model-refresh: token_model_availability backfill failed",
+				"account_id", accountID, "token_id", tokenID, "error", err)
+		} else {
+			tokenBackfilled = true
+		}
+	}
+
 	// Best-effort route rebuild from updated availability.
 	rebuildStats, rebuildErr := service.RebuildTokenRoutesFromAvailability(context.Background(), db)
 	rebuildPayload := map[string]any{
@@ -226,6 +241,7 @@ func refreshAccountModels(ctx context.Context, db *sqlx.DB, accountID int64, all
 		"redirects": map[string]any{
 			"generated": redirectsCreated,
 		},
+		"tokenBackfilled": tokenBackfilled,
 	}
 }
 
@@ -319,6 +335,96 @@ func persistAccountModelAvailability(db *sqlx.DB, accountID int64, models []stri
 				SET available = ?, latency_ms = NULL, checked_at = ?
 				WHERE account_id = ? AND model_name = ?
 			`), true, now, accountID, model); err2 != nil {
+				return err
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+// resolveAccountTokenID finds the account_tokens row id matching the resolved
+// refresh token. Tokens are stored normalized (TrimSpace, no Bearer prefix);
+// the resolved token is also normalized, so an exact match is sufficient.
+// Returns (id, true) on match, (0, false) when no row matches — in which case
+// the caller skips the token_model_availability backfill (#675).
+func resolveAccountTokenID(db *sqlx.DB, accountID int64, token string) (int64, bool) {
+	normalized := strings.TrimSpace(token)
+	normalized = strings.TrimPrefix(normalized, "Bearer ")
+	normalized = strings.TrimSpace(normalized)
+	if normalized == "" {
+		return 0, false
+	}
+	var tokenID int64
+	err := db.Get(&tokenID, db.Rebind(
+		"SELECT id FROM account_tokens WHERE account_id = ? AND token = ? ORDER BY id DESC LIMIT 1",
+	), accountID, normalized)
+	if err != nil {
+		return 0, false
+	}
+	return tokenID, true
+}
+
+// persistTokenModelAvailability mirrors persistAccountModelAvailability for
+// the token_model_availability table: mark all existing rows for the token
+// unavailable, then upsert the current model set as available. Uses its own
+// transaction so a failure here never rolls back the account-level write.
+func persistTokenModelAvailability(db *sqlx.DB, tokenID int64, models []string, now string) error {
+	tx, err := db.Beginx()
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Mark all existing rows for this token unavailable before upserting the
+	// current set — mirrors the account-level "mark non-manual unavailable"
+	// pattern. token_model_availability has no is_manual column, so we clear
+	// everything and re-enable the freshly observed models.
+	if _, err := tx.Exec(tx.Rebind(`
+		UPDATE token_model_availability
+		SET available = ?, checked_at = ?
+		WHERE token_id = ?
+	`), false, now, tokenID); err != nil {
+		return err
+	}
+
+	for _, model := range models {
+		var existingID int64
+		err := tx.Get(&existingID, tx.Rebind(`
+			SELECT id FROM token_model_availability WHERE token_id = ? AND model_name = ?
+		`), tokenID, model)
+		if err == nil {
+			if _, err := tx.Exec(tx.Rebind(`
+				UPDATE token_model_availability
+				SET available = ?, latency_ms = NULL, checked_at = ?
+				WHERE id = ?
+			`), true, now, existingID); err != nil {
+				return err
+			}
+			continue
+		}
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		if _, err := tx.Exec(tx.Rebind(`
+			INSERT INTO token_model_availability (token_id, model_name, available, latency_ms, checked_at)
+			VALUES (?, ?, ?, NULL, ?)
+		`), tokenID, model, true, now); err != nil {
+			// Unique constraint violation: fall back to UPDATE.
+			if _, err2 := tx.Exec(tx.Rebind(`
+				UPDATE token_model_availability
+				SET available = ?, latency_ms = NULL, checked_at = ?
+				WHERE token_id = ? AND model_name = ?
+			`), true, now, tokenID, model); err2 != nil {
 				return err
 			}
 		}

--- a/handler/admin/model_refresh_test.go
+++ b/handler/admin/model_refresh_test.go
@@ -1,0 +1,350 @@
+package admin
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// openModelRefreshTestDB opens an in-memory SQLite DB with the full schema
+// migrated, ready for model_availability / token_model_availability tests.
+func openModelRefreshTestDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := store.AutoMigrate(db); err != nil {
+		db.Close()
+		t.Fatalf("automigrate: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db.DB
+}
+
+// seedAccountAndToken inserts a site, account, and an account_tokens row,
+// returning the accountID and tokenID for backfill tests.
+func seedAccountAndToken(t *testing.T, db *sqlx.DB, tokenValue string) (accountID, tokenID int64) {
+	t.Helper()
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, use_system_proxy, sort_order, global_weight, post_refresh_probe_enabled, created_at, updated_at)
+		 VALUES (?, ?, 'openai', 'active', 0, 0, 0, 0, ?, ?)`,
+		"TokenBackfillSite", "https://api.example.com", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+
+	accRes, err := db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, sort_order, created_at, updated_at)
+		 VALUES (?, 'tester', ?, 'active', 1, 0, ?, ?)`,
+		siteID, tokenValue, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ = accRes.LastInsertId()
+
+	tokRes, err := db.Exec(
+		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
+		 VALUES (?, 'default', ?, 'ready', 'manual', 1, 1, ?, ?)`,
+		accountID, tokenValue, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account_token: %v", err)
+	}
+	tokenID, _ = tokRes.LastInsertId()
+	return accountID, tokenID
+}
+
+func TestPersistTokenModelAvailability_UpsertsAndMarksUnavailable(t *testing.T) {
+	db := openModelRefreshTestDB(t)
+	_, tokenID := seedAccountAndToken(t, db, "sk-backfill")
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// First refresh: 2 models available.
+	if err := persistTokenModelAvailability(db, tokenID, []string{"gpt-4o", "claude-3"}, now); err != nil {
+		t.Fatalf("first persist: %v", err)
+	}
+
+	var availCount int
+	if err := db.Get(&availCount,
+		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = 1`,
+		tokenID,
+	); err != nil {
+		t.Fatalf("count available: %v", err)
+	}
+	if availCount != 2 {
+		t.Fatalf("expected 2 available, got %d", availCount)
+	}
+
+	// Second refresh: only 1 model — the other should be marked unavailable.
+	if err := persistTokenModelAvailability(db, tokenID, []string{"gpt-4o"}, now); err != nil {
+		t.Fatalf("second persist: %v", err)
+	}
+	if err := db.Get(&availCount,
+		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = 1`,
+		tokenID,
+	); err != nil {
+		t.Fatalf("count after second: %v", err)
+	}
+	if availCount != 1 {
+		t.Fatalf("expected 1 available after shrink, got %d", availCount)
+	}
+	var unavailCount int
+	if err := db.Get(&unavailCount,
+		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = 0`,
+		tokenID,
+	); err != nil {
+		t.Fatalf("count unavailable: %v", err)
+	}
+	if unavailCount != 1 {
+		t.Fatalf("expected 1 unavailable (claude-3), got %d", unavailCount)
+	}
+}
+
+func TestPersistTokenModelAvailability_ReAddsPreviouslyUnavailable(t *testing.T) {
+	db := openModelRefreshTestDB(t)
+	_, tokenID := seedAccountAndToken(t, db, "sk-cycle")
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Refresh 1: gpt-4o only.
+	if err := persistTokenModelAvailability(db, tokenID, []string{"gpt-4o"}, now); err != nil {
+		t.Fatalf("persist 1: %v", err)
+	}
+	// Refresh 2: claude-3 only (gpt-4o becomes unavailable).
+	if err := persistTokenModelAvailability(db, tokenID, []string{"claude-3"}, now); err != nil {
+		t.Fatalf("persist 2: %v", err)
+	}
+	// Refresh 3: gpt-4o comes back — should flip available=1, not insert a dupe.
+	if err := persistTokenModelAvailability(db, tokenID, []string{"gpt-4o", "claude-3"}, now); err != nil {
+		t.Fatalf("persist 3: %v", err)
+	}
+
+	var totalCount int
+	if err := db.Get(&totalCount,
+		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ?`,
+		tokenID,
+	); err != nil {
+		t.Fatalf("count total: %v", err)
+	}
+	if totalCount != 2 {
+		t.Fatalf("expected 2 total rows (no dupes), got %d", totalCount)
+	}
+	var availCount int
+	if err := db.Get(&availCount,
+		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = 1`,
+		tokenID,
+	); err != nil {
+		t.Fatalf("count available: %v", err)
+	}
+	if availCount != 2 {
+		t.Fatalf("expected 2 available after re-add, got %d", availCount)
+	}
+}
+
+func TestResolveAccountTokenID_MatchAndMiss(t *testing.T) {
+	db := openModelRefreshTestDB(t)
+	accountID, tokenID := seedAccountAndToken(t, db, "sk-match")
+
+	gotID, ok := resolveAccountTokenID(db, accountID, "sk-match")
+	if !ok {
+		t.Fatal("expected match for sk-match")
+	}
+	if gotID != tokenID {
+		t.Fatalf("token id = %d, want %d", gotID, tokenID)
+	}
+
+	// Bearer prefix should be stripped.
+	gotID2, ok2 := resolveAccountTokenID(db, accountID, "Bearer sk-match")
+	if !ok2 || gotID2 != tokenID {
+		t.Fatalf("bearer prefix: ok=%v id=%d, want %d", ok2, gotID2, tokenID)
+	}
+
+	// Non-matching token returns false.
+	_, ok3 := resolveAccountTokenID(db, accountID, "sk-nope")
+	if ok3 {
+		t.Fatal("expected false for non-matching token")
+	}
+
+	// Empty token returns false.
+	_, ok4 := resolveAccountTokenID(db, accountID, "")
+	if ok4 {
+		t.Fatal("expected false for empty token")
+	}
+}
+
+func TestResolveAccountTokenID_NoRows(t *testing.T) {
+	db := openModelRefreshTestDB(t)
+	accountID, _ := seedAccountAndToken(t, db, "sk-lone")
+	_, ok := resolveAccountTokenID(db, accountID, "sk-other")
+	if ok {
+		t.Fatal("expected false when no account_tokens row matches")
+	}
+}
+
+func TestResolveAccountTokenID_SQLiteNullScan(t *testing.T) {
+	db := openModelRefreshTestDB(t)
+	// No rows at all — should return false, not panic.
+	var dummyID int64
+	err := db.Get(&dummyID, `SELECT id FROM account_tokens WHERE id = 999`)
+	if err == nil {
+		t.Fatal("expected sql.ErrNoRows for nonexistent token")
+	}
+}
+
+// TestRefreshAccountModels_TokenBackfillEndToEnd verifies the full
+// refreshAccountModels path writes token_model_availability when the resolved
+// token matches an account_tokens row.
+func TestRefreshAccountModels_TokenBackfillEndToEnd(t *testing.T) {
+	dbConn, r, _ := setupAccountsTest(t)
+
+	// httptest OpenAI server that returns models for sk-backfill-token.
+	server := newOpenAIModelsServer(t, "sk-backfill-token", []string{"gpt-4o", "gpt-4o-mini"})
+
+	siteResp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "TokenBackfillE2E",
+		"url":      server.URL,
+		"platform": "openai",
+	})
+	if siteResp.Code != http.StatusOK {
+		t.Fatalf("create site: %d %s", siteResp.Code, siteResp.Body.String())
+	}
+	var site map[string]any
+	_ = json.Unmarshal(siteResp.Body.Bytes(), &site)
+	siteID := int64(site["id"].(float64))
+
+	createResp := doPostJSON(t, r, "/api/accounts", map[string]any{
+		"siteId":         siteID,
+		"accessToken":    "sk-backfill-token",
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
+	})
+	if createResp.Code != http.StatusOK {
+		t.Fatalf("create account: %d %s", createResp.Code, createResp.Body.String())
+	}
+	var created map[string]any
+	_ = json.Unmarshal(createResp.Body.Bytes(), &created)
+	accountID := int64(created["id"].(float64))
+
+	// Seed an account_tokens row matching the resolved token so backfill can fire.
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	res, err := dbConn.Exec(
+		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
+		 VALUES (?, 'default', 'sk-backfill-token', 'ready', 'manual', 1, 1, ?, ?)`,
+		accountID, now, now,
+	)
+	if err != nil {
+		t.Fatalf("seed account_token: %v", err)
+	}
+	tokenID, _ := res.LastInsertId()
+
+	// Run the real refresh.
+	result := refreshAccountModels(context.Background(), dbConn.DB, accountID, false)
+	if !modelRefreshSucceeded(result) {
+		t.Fatalf("refresh failed: %s", modelRefreshErrorMessage(result))
+	}
+	if backfilled, _ := result["tokenBackfilled"].(bool); !backfilled {
+		t.Fatal("expected tokenBackfilled=true, got false")
+	}
+
+	// Verify token_model_availability rows were written.
+	var availCount int
+	if err := dbConn.Get(&availCount,
+		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = 1`,
+		tokenID,
+	); err != nil {
+		t.Fatalf("count token models: %v", err)
+	}
+	if availCount != 2 {
+		t.Fatalf("expected 2 available token_model_availability rows, got %d", availCount)
+	}
+
+	// Also verify account-level model_availability was written.
+	var accountModelCount int
+	if err := dbConn.Get(&accountModelCount,
+		`SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND available = 1`,
+		accountID,
+	); err != nil {
+		t.Fatalf("count account models: %v", err)
+	}
+	if accountModelCount != 2 {
+		t.Fatalf("expected 2 available model_availability rows, got %d", accountModelCount)
+	}
+}
+
+// TestRefreshAccountModels_TokenBackfillSkipsWhenNoTokenMatch verifies the
+// backfill is silently skipped (tokenBackfilled=false) when no account_tokens
+// row matches the resolved token — account-level availability still works.
+func TestRefreshAccountModels_TokenBackfillSkipsWhenNoTokenMatch(t *testing.T) {
+	dbConn, r, _ := setupAccountsTest(t)
+	server := newOpenAIModelsServer(t, "sk-no-token-row", []string{"gpt-4o"})
+
+	siteResp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "TokenBackfillNoMatch",
+		"url":      server.URL,
+		"platform": "openai",
+	})
+	if siteResp.Code != http.StatusOK {
+		t.Fatalf("create site: %d %s", siteResp.Code, siteResp.Body.String())
+	}
+	var site map[string]any
+	_ = json.Unmarshal(siteResp.Body.Bytes(), &site)
+	siteID := int64(site["id"].(float64))
+
+	createResp := doPostJSON(t, r, "/api/accounts", map[string]any{
+		"siteId":         siteID,
+		"accessToken":    "sk-no-token-row",
+		"credentialMode": "apikey",
+		"skipModelFetch": true,
+	})
+	if createResp.Code != http.StatusOK {
+		t.Fatalf("create: %d %s", createResp.Code, createResp.Body.String())
+	}
+	var created map[string]any
+	_ = json.Unmarshal(createResp.Body.Bytes(), &created)
+	accountID := int64(created["id"].(float64))
+
+	// No account_tokens row seeded — backfill should skip.
+	result := refreshAccountModels(context.Background(), dbConn.DB, accountID, false)
+	if !modelRefreshSucceeded(result) {
+		t.Fatalf("refresh failed: %s", modelRefreshErrorMessage(result))
+	}
+	if backfilled, _ := result["tokenBackfilled"].(bool); backfilled {
+		t.Fatal("expected tokenBackfilled=false when no token match, got true")
+	}
+
+	// Account-level should still be written.
+	var accountModelCount int
+	if err := dbConn.Get(&accountModelCount,
+		`SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND available = 1`,
+		accountID,
+	); err != nil {
+		t.Fatalf("count account models: %v", err)
+	}
+	if accountModelCount != 1 {
+		t.Fatalf("expected 1 available model_availability row, got %d", accountModelCount)
+	}
+
+	// token_model_availability should be empty.
+	var tokenModelCount int
+	if err := dbConn.Get(&tokenModelCount,
+		`SELECT COUNT(*) FROM token_model_availability`,
+	); err != nil {
+		t.Fatalf("count token models: %v", err)
+	}
+	if tokenModelCount != 0 {
+		t.Fatalf("expected 0 token_model_availability rows, got %d", tokenModelCount)
+	}
+}
+
+// Silence unused import warnings for sql/sqlx when tests evolve.
+var _ = sql.ErrNoRows

--- a/platform/sub2api.go
+++ b/platform/sub2api.go
@@ -202,8 +202,16 @@ func (s *Sub2ApiAdapter) GetModels(ctx context.Context, baseURL, apiToken string
 		return directModels, nil
 	}
 
-	// Session JWT cannot access /v1/models directly; discover a user key first
-	discoveredToken, _ := s.GetAPIToken(ctx, managementBase, apiToken, platformUserId, proxy)
+	// Session JWT cannot access /v1/models directly; discover a user key first.
+	// Filter keys by the user's subscription group (from /api/v1/auth/me) so
+	// we pick a key from the SAME group as the user's subscription rather than
+	// blindly taking the first enabled key, which may belong to a different
+	// group and surface the wrong model set (#675).
+	userGroup := ""
+	if user, err := s.fetchAuthMe(ctx, normalized, apiToken, proxy); err == nil {
+		userGroup = user.group
+	}
+	discoveredToken, _ := s.getAPITokenForGroup(ctx, managementBase, apiToken, userGroup, platformUserId, proxy)
 	if discoveredToken == nil {
 		return finish(directErr)
 	}
@@ -260,6 +268,47 @@ func (s *Sub2ApiAdapter) GetAPIToken(ctx context.Context, baseURL, accessToken s
 		return &k, nil
 	}
 	return nil, nil
+}
+
+// getAPITokenForGroup returns an API key for the user's subscription group.
+// When group is non-empty, only keys whose TokenGroup matches are considered;
+// if no key matches the group, it falls back to first-enabled so a missing
+// group tag never blocks model enumeration entirely (#675).
+func (s *Sub2ApiAdapter) getAPITokenForGroup(ctx context.Context, baseURL, accessToken, group string, platformUserId *int, proxy *ProxyConfig) (*string, error) {
+	tokens, err := s.GetAPITokens(ctx, baseURL, accessToken, platformUserId, proxy)
+	if err != nil {
+		return nil, nil
+	}
+	return pickKeyForGroup(tokens, group), nil
+}
+
+// pickKeyForGroup selects the first enabled key whose TokenGroup matches the
+// user's group. Falls back to first-enabled when the group is empty, no keys
+// match, or all group-matched keys are disabled. Returns nil when there are
+// no keys at all.
+func pickKeyForGroup(tokens []ApiTokenInfo, group string) *string {
+	if len(tokens) == 0 {
+		return nil
+	}
+	if strings.TrimSpace(group) != "" {
+		for _, t := range tokens {
+			if !t.Enabled {
+				continue
+			}
+			if strings.TrimSpace(t.TokenGroup) == strings.TrimSpace(group) {
+				k := t.Key
+				return &k
+			}
+		}
+	}
+	for _, t := range tokens {
+		if t.Enabled {
+			k := t.Key
+			return &k
+		}
+	}
+	k := tokens[0].Key
+	return &k
 }
 
 // GetUserGroups: 5 endpoint fallback + key-based inference.
@@ -439,6 +488,10 @@ type sub2apiUser struct {
 	username string
 	email    string
 	balance  float64
+	// group holds the user's subscription group identifier (group_id or
+	// group_name) from /api/v1/auth/me, used to filter API keys by group
+	// during model enumeration fallback. Empty when the upstream omits it.
+	group string
 }
 
 type sub2apiKeyItem struct {
@@ -506,13 +559,47 @@ func (s *Sub2ApiAdapter) fetchAuthMe(ctx context.Context, baseURL, accessToken s
 	username, _ := getString(data, "username")
 	email, _ := getString(data, "email")
 	balance, _ := getFloat(data, "balance")
+	userGroup := parseSub2ApiUserGroup(data)
 
 	return &sub2apiUser{
 		id:       int(idFloat),
 		username: username,
 		email:    email,
 		balance:  balance,
+		group:    userGroup,
 	}, nil
+}
+
+// parseSub2ApiUserGroup extracts the subscription group identifier from an
+// /api/v1/auth/me payload. Sub2API exposes the group as either a numeric
+// group_id, a string group_name/group, or a nested subscription object.
+// Returns "" when the upstream omits the field.
+func parseSub2ApiUserGroup(data map[string]interface{}) string {
+	if data == nil {
+		return ""
+	}
+	if gid, ok := data["group_id"].(float64); ok && gid > 0 {
+		return fmt.Sprintf("%d", int(gid))
+	}
+	if g, ok := getString(data, "group_name"); ok && strings.TrimSpace(g) != "" {
+		return strings.TrimSpace(g)
+	}
+	if g, ok := getString(data, "group"); ok && strings.TrimSpace(g) != "" {
+		return strings.TrimSpace(g)
+	}
+	// Some deployments nest group under subscription/group.
+	if sub, ok := getMap(data, "subscription"); ok {
+		if gid, ok := sub["group_id"].(float64); ok && gid > 0 {
+			return fmt.Sprintf("%d", int(gid))
+		}
+		if g, ok := getString(sub, "group_name"); ok && strings.TrimSpace(g) != "" {
+			return strings.TrimSpace(g)
+		}
+		if g, ok := getString(sub, "group"); ok && strings.TrimSpace(g) != "" {
+			return strings.TrimSpace(g)
+		}
+	}
+	return ""
 }
 
 func (s *Sub2ApiAdapter) usdToQuota(balanceUsd float64) float64 {

--- a/platform/sub2api_group_test.go
+++ b/platform/sub2api_group_test.go
@@ -1,0 +1,186 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPickKeyForGroup_GroupMatch(t *testing.T) {
+	tokens := []ApiTokenInfo{
+		{Name: "alpha", Key: "sk-alpha", Enabled: true, TokenGroup: "group-a"},
+		{Name: "beta", Key: "sk-beta", Enabled: true, TokenGroup: "group-b"},
+		{Name: "gamma", Key: "sk-gamma", Enabled: true, TokenGroup: "group-a"},
+	}
+	got := pickKeyForGroup(tokens, "group-b")
+	if got == nil || *got != "sk-beta" {
+		t.Fatalf("expected sk-beta for group-b, got %v", got)
+	}
+}
+
+func TestPickKeyForGroup_FirstEnabledWhenGroupMatchDisabled(t *testing.T) {
+	tokens := []ApiTokenInfo{
+		{Name: "alpha", Key: "sk-alpha", Enabled: false, TokenGroup: "group-a"},
+		{Name: "beta", Key: "sk-beta", Enabled: true, TokenGroup: "group-b"},
+	}
+	got := pickKeyForGroup(tokens, "group-a")
+	if got == nil || *got != "sk-beta" {
+		t.Fatalf("expected fallback to first-enabled sk-beta, got %v", got)
+	}
+}
+
+func TestPickKeyForGroup_EmptyGroupFallsBackToFirstEnabled(t *testing.T) {
+	tokens := []ApiTokenInfo{
+		{Name: "alpha", Key: "sk-alpha", Enabled: false, TokenGroup: "group-a"},
+		{Name: "beta", Key: "sk-beta", Enabled: true, TokenGroup: "group-b"},
+	}
+	got := pickKeyForGroup(tokens, "")
+	if got == nil || *got != "sk-beta" {
+		t.Fatalf("expected first-enabled sk-beta for empty group, got %v", got)
+	}
+}
+
+func TestPickKeyForGroup_NoMatchFallsBackToFirstEnabled(t *testing.T) {
+	tokens := []ApiTokenInfo{
+		{Name: "alpha", Key: "sk-alpha", Enabled: true, TokenGroup: "group-a"},
+	}
+	got := pickKeyForGroup(tokens, "nonexistent-group")
+	if got == nil || *got != "sk-alpha" {
+		t.Fatalf("expected fallback to sk-alpha, got %v", got)
+	}
+}
+
+func TestPickKeyForGroup_EmptyTokensReturnsNil(t *testing.T) {
+	got := pickKeyForGroup(nil, "group-a")
+	if got != nil {
+		t.Fatalf("expected nil for empty tokens, got %v", *got)
+	}
+}
+
+func TestPickKeyForGroup_AllDisabledReturnsFirst(t *testing.T) {
+	tokens := []ApiTokenInfo{
+		{Name: "alpha", Key: "sk-alpha", Enabled: false, TokenGroup: "group-a"},
+		{Name: "beta", Key: "sk-beta", Enabled: false, TokenGroup: "group-b"},
+	}
+	got := pickKeyForGroup(tokens, "group-a")
+	if got == nil || *got != "sk-alpha" {
+		t.Fatalf("expected first token when all disabled, got %v", got)
+	}
+}
+
+func TestPickKeyForGroup_WhitespaceTrimmed(t *testing.T) {
+	tokens := []ApiTokenInfo{
+		{Name: "alpha", Key: "sk-alpha", Enabled: true, TokenGroup: "  group-a  "},
+	}
+	got := pickKeyForGroup(tokens, " group-a ")
+	if got == nil || *got != "sk-alpha" {
+		t.Fatalf("expected whitespace-trimmed match, got %v", got)
+	}
+}
+
+func TestParseSub2ApiUserGroup_GroupID(t *testing.T) {
+	data := map[string]interface{}{"group_id": float64(42)}
+	if g := parseSub2ApiUserGroup(data); g != "42" {
+		t.Fatalf("expected 42, got %q", g)
+	}
+}
+
+func TestParseSub2ApiUserGroup_GroupName(t *testing.T) {
+	data := map[string]interface{}{"group_name": "premium"}
+	if g := parseSub2ApiUserGroup(data); g != "premium" {
+		t.Fatalf("expected premium, got %q", g)
+	}
+}
+
+func TestParseSub2ApiUserGroup_Group(t *testing.T) {
+	data := map[string]interface{}{"group": "standard"}
+	if g := parseSub2ApiUserGroup(data); g != "standard" {
+		t.Fatalf("expected standard, got %q", g)
+	}
+}
+
+func TestParseSub2ApiUserGroup_NestedSubscription(t *testing.T) {
+	data := map[string]interface{}{
+		"subscription": map[string]interface{}{"group_id": float64(7)},
+	}
+	if g := parseSub2ApiUserGroup(data); g != "7" {
+		t.Fatalf("expected 7 from nested subscription, got %q", g)
+	}
+}
+
+func TestParseSub2ApiUserGroup_Empty(t *testing.T) {
+	if g := parseSub2ApiUserGroup(map[string]interface{}{}); g != "" {
+		t.Fatalf("expected empty, got %q", g)
+	}
+	if g := parseSub2ApiUserGroup(nil); g != "" {
+		t.Fatalf("expected empty for nil, got %q", g)
+	}
+}
+
+// TestFetchModelsByToken_CtxErrFastFail verifies that a cancelled context
+// short-circuits the endpoint probe loop so a slow first endpoint cannot
+// burn the whole budget (#675).
+func TestFetchModelsByToken_CtxErrFastFail(t *testing.T) {
+	s := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
+
+	var hitCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hitCount, 1)
+		// Simulate a slow response.
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel before the first call so ctx.Err() is non-nil on the very first
+	// iteration — no endpoint should be hit at all.
+	cancel()
+
+	models, err := s.fetchModelsByToken(ctx, server.URL, "sk-test", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 0 {
+		t.Fatalf("expected empty models, got %v", models)
+	}
+	if atomic.LoadInt32(&hitCount) != 0 {
+		t.Fatalf("expected 0 endpoint hits with pre-cancelled ctx, got %d", hitCount)
+	}
+}
+
+// TestFetchModelsByToken_CtxCancelledMidLoop verifies that when the context is
+// cancelled after the first endpoint returns, the remaining endpoints are
+// skipped. The first endpoint triggers the cancel synchronously so the second
+// iteration sees ctx.Err() != nil and breaks.
+func TestFetchModelsByToken_CtxCancelledMidLoop(t *testing.T) {
+	s := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var hitCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hitCount, 1)
+		// Cancel the context from within the first endpoint hit so the next
+		// loop iteration's ctx.Err() check breaks out.
+		if atomic.LoadInt32(&hitCount) == 1 {
+			cancel()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Return empty models so the loop would normally continue.
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+
+	_, _ = s.fetchModelsByToken(ctx, server.URL, "sk-test", nil)
+	// The first endpoint hit triggers cancel; the second iteration's
+	// ctx.Err() check should break before hitting the server again.
+	if got := atomic.LoadInt32(&hitCount); got > 1 {
+		t.Fatalf("expected at most 1 endpoint hit after mid-loop cancel, got %d", got)
+	}
+}

--- a/platform/sub2api_models.go
+++ b/platform/sub2api_models.go
@@ -41,8 +41,15 @@ func (s *Sub2ApiAdapter) fetchModelsByToken(ctx context.Context, baseURL, token 
 		return nil, nil
 	}
 
+	endpoints := s.resolveModelEndpoints(baseURL)
 	var lastErr error
-	for _, url := range s.resolveModelEndpoints(baseURL) {
+	for _, url := range endpoints {
+		// Fast-fail: a slow first endpoint must not burn the whole budget.
+		// Checking ctx.Err() between attempts lets a cancelled/deadline-exceeded
+		// context short-circuit the remaining endpoints (#675).
+		if ctx.Err() != nil {
+			break
+		}
 		headers := map[string]string{"Authorization": "Bearer " + authToken}
 		resp, err := fetchJSON(ctx, url, "GET", nil, headers, proxy)
 		if err != nil {


### PR DESCRIPTION
## Summary

Closes #675

Three fixes for Sub2API model enumeration and token-level availability:

- **Part A — Group-aware key selection**: `Sub2ApiAdapter.GetModels` now fetches the user's subscription group from `/api/v1/auth/me` when falling back from a session JWT, and filters API keys by `TokenGroup` before picking one (new `pickKeyForGroup` helper). This prevents enumerating models from a different group's key. Falls back to first-enabled when no group match exists so enumeration never blocks entirely.
- **Part B — `token_model_availability` backfill**: After `persistAccountModelAvailability` succeeds in `refreshAccountModels`, the same model list is upserted into `token_model_availability` for the resolved `account_tokens` row (new `resolveAccountTokenID` + `persistTokenModelAvailability` helpers). Mirrors the account-level "mark all unavailable → upsert current" pattern. Best-effort: silently skips when no token row matches — account-level availability remains the source of truth.
- **Part C — Fast-fail ctx check**: `fetchModelsByToken` now checks `ctx.Err()` between endpoint attempts so a slow/cancelled first endpoint does not burn the whole 4-endpoint probe budget.

## Notes

- The token backfill uses an exact `account_tokens.token` match (normalized: TrimSpace + Bearer-prefix stripped). If the resolved refresh token does not match any `account_tokens` row, the backfill is skipped — this is the safe default since account-level `model_availability` is always written.
- `token_model_availability` has no `is_manual` column, so the backfill marks ALL existing rows for the token unavailable before upserting the current set (no manual-row preservation).
- `sub2apiUser` struct extended with a `group` field parsed from `group_id`/`group_name`/`group`/nested `subscription` in `/api/v1/auth/me`.

## Test plan

- [x] `go build ./platform/... ./handler/... ./store/... ./service/...` — clean
- [x] `go test ./platform/` — all pass (11.5s), including new `TestPickKeyForGroup_*` (7 cases), `TestParseSub2ApiUserGroup_*` (5 cases), `TestFetchModelsByToken_CtxErrFastFail`, `TestFetchModelsByToken_CtxCancelledMidLoop`
- [x] `go test ./handler/admin/` — all pass (17.8s), including new `TestPersistTokenModelAvailability_UpsertsAndMarksUnavailable`, `TestPersistTokenModelAvailability_ReAddsPreviouslyUnavailable`, `TestResolveAccountTokenID_MatchAndMiss`, `TestResolveAccountTokenID_NoRows`, `TestRefreshAccountModels_TokenBackfillEndToEnd`, `TestRefreshAccountModels_TokenBackfillSkipsWhenNoTokenMatch`
- [ ] Manual: verify a Sub2API account with a group-tagged API key refreshes models from the correct group
- [ ] Manual: verify `token_model_availability` rows appear after a model refresh for an account with a matching `account_tokens` row