### PR TITLE
feat(grok): add Grok/xAI OAuth adapter (Device OAuth)

### DIFF
--- a/platform/grok.go
+++ b/platform/grok.go
@@ -1,0 +1,52 @@
+package platform
+
+import (
+	"context"
+	"net/url"
+	"strings"
+)
+
+// GrokAdapter handles xAI Grok platforms (api.x.ai, OAuth-driven).
+// StandardAdapter provides the "not supported"/empty defaults for auth,
+// checkin and balance methods — Grok credentials are managed via the
+// Device OAuth flow registered in service/oauth/grok.go.
+type GrokAdapter struct {
+	*StandardAdapter
+}
+
+// grokSeedModels is the hardcoded model list returned by GetModels when no
+// upstream /v1/models probe is available. Mirrors the model surface exposed
+// by xAI's public API; update here when xAI ships new Grok variants.
+var grokSeedModels = []string{
+	"grok-3",
+	"grok-3-mini",
+	"grok-3-fast",
+	"grok-2",
+	"grok-2-mini",
+	"grok-2-vision",
+	"grok-2-latest",
+}
+
+// Detect matches the xAI API host. xAI serves its public API from api.x.ai;
+// the bare x.ai host is also accepted so users may register either form.
+func (g *GrokAdapter) Detect(ctx context.Context, urlStr string) (bool, error) {
+	parsed, err := url.Parse(strings.TrimSpace(urlStr))
+	if err != nil {
+		return false, nil
+	}
+	hostname := strings.ToLower(parsed.Hostname())
+	if hostname == "api.x.ai" || hostname == "x.ai" {
+		return true, nil
+	}
+	return false, nil
+}
+
+// GetModels returns the hardcoded Grok seed model list. xAI's public API does
+// expose /v1/models, but the seed list keeps detection/verification working
+// without a live upstream call (mirrors the Codex "empty by default" contract
+// while still surfacing a useful model catalog for auto-complete).
+func (g *GrokAdapter) GetModels(ctx context.Context, baseURL string, accessToken string, platformUserId *int, proxy *ProxyConfig) ([]string, error) {
+	seed := make([]string, len(grokSeedModels))
+	copy(seed, grokSeedModels)
+	return normalizeModelIDs(seed), nil
+}

--- a/platform/grok_test.go
+++ b/platform/grok_test.go
@@ -1,0 +1,196 @@
+package platform
+
+import (
+	"context"
+	"testing"
+)
+
+// newGrokAdapterForTest builds a GrokAdapter identical to the one registered in
+// registry.go's buildAdapter("grok"), keeping these tests in sync with the
+// production wiring (login/checkin unsupported message copy).
+func newGrokAdapterForTest() *GrokAdapter {
+	return &GrokAdapter{StandardAdapter: &StandardAdapter{
+		BaseAdapter:               NewBaseAdapter("grok"),
+		LoginUnsupportedMessage:   "grok oauth login is managed via Device OAuth flow",
+		CheckinUnsupportedMessage: "grok oauth connections do not support checkin",
+	}}
+}
+
+func TestGrokAdapter_PlatformName(t *testing.T) {
+	a := newGrokAdapterForTest()
+	if a.PlatformName() != "grok" {
+		t.Errorf("PlatformName: %q, want %q", a.PlatformName(), "grok")
+	}
+}
+
+func TestGrokAdapter_Detect(t *testing.T) {
+	a := newGrokAdapterForTest()
+	ctx := context.Background()
+
+	tests := []struct {
+		url     string
+		matches bool
+	}{
+		{"https://api.x.ai/v1/chat/completions", true},
+		{"https://api.x.ai", true},
+		{"https://x.ai", true},
+		{"https://X.AI/v1/models", true},
+		{"https://api.x.ai:443/v1", true},
+		{"https://api.openai.com", false},
+		{"https://chatgpt.com/backend-api/codex", false},
+		{"https://api.groq.com", false},
+		{"https://example.com/x.ai", false}, // path substring must not match
+		{"", false},
+	}
+	for _, tt := range tests {
+		ok, err := a.Detect(ctx, tt.url)
+		if err != nil {
+			t.Errorf("Detect(%q) returned error: %v", tt.url, err)
+			continue
+		}
+		if ok != tt.matches {
+			t.Errorf("Detect(%q) = %v, want %v", tt.url, ok, tt.matches)
+		}
+	}
+}
+
+func TestGrokAdapter_GetModels(t *testing.T) {
+	a := newGrokAdapterForTest()
+	ctx := context.Background()
+
+	models, err := a.GetModels(ctx, "https://api.x.ai", "ignored-token", nil, nil)
+	if err != nil {
+		t.Fatalf("GetModels returned unexpected error: %v", err)
+	}
+	if len(models) == 0 {
+		t.Fatal("GetModels returned empty model list; expected hardcoded seed")
+	}
+
+	// normalizeModelIDs dedups + sorts, so verify membership rather than order.
+	seen := make(map[string]bool, len(models))
+	for _, model := range models {
+		seen[model] = true
+	}
+	expectedSeed := []string{
+		"grok-3", "grok-3-mini", "grok-3-fast",
+		"grok-2", "grok-2-mini", "grok-2-vision", "grok-2-latest",
+	}
+	for _, want := range expectedSeed {
+		if !seen[want] {
+			t.Errorf("expected seed model %q in GetModels output: %v", want, models)
+		}
+	}
+}
+
+func TestGrokAdapter_GetModels_DoesNotDependOnBaseURL(t *testing.T) {
+	a := newGrokAdapterForTest()
+	ctx := context.Background()
+
+	// The seed list is hardcoded, so a bogus base URL must still return models.
+	models, err := a.GetModels(ctx, "https://invalid.invalid", "ignored", nil, nil)
+	if err != nil {
+		t.Fatalf("GetModels with bogus base URL returned error: %v", err)
+	}
+	if len(models) != len(grokSeedModels) {
+		t.Errorf("expected %d seed models, got %d", len(grokSeedModels), len(models))
+	}
+}
+
+func TestGrokAdapter_LoginUnsupported(t *testing.T) {
+	a := newGrokAdapterForTest()
+	ctx := context.Background()
+
+	result, err := a.Login(ctx, "https://api.x.ai", "u", "p", nil, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Error("Grok login should return Success=false (managed by Device OAuth)")
+	}
+	if result.Message != "grok oauth login is managed via Device OAuth flow" {
+		t.Errorf("Login message: %q", result.Message)
+	}
+}
+
+func TestGrokAdapter_CheckinUnsupported(t *testing.T) {
+	a := newGrokAdapterForTest()
+	ctx := context.Background()
+
+	result, err := a.Checkin(ctx, "https://api.x.ai", "token", nil, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Error("Grok checkin should return Success=false")
+	}
+	if result.Message != "grok oauth connections do not support checkin" {
+		t.Errorf("Checkin message: %q", result.Message)
+	}
+}
+
+func TestGrokAdapter_GetBalanceZero(t *testing.T) {
+	a := newGrokAdapterForTest()
+	ctx := context.Background()
+
+	balance, err := a.GetBalance(ctx, "https://api.x.ai", "token", nil, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if balance.Balance != 0 || balance.Used != 0 || balance.Quota != 0 {
+		t.Error("Grok balance should be all zeros (no balance endpoint)")
+	}
+}
+
+func TestGetAdapter_ResolvesGrok(t *testing.T) {
+	// Canonical name.
+	a := GetAdapter("grok")
+	if a == nil || a.PlatformName() != "grok" {
+		t.Fatalf("GetAdapter('grok') did not resolve to grok adapter: %v", a)
+	}
+
+	// Aliases.
+	for _, alias := range []string{"xai", "x.ai", "Grok", "XAI"} {
+		resolved := GetAdapter(alias)
+		if resolved == nil || resolved.PlatformName() != "grok" {
+			t.Errorf("GetAdapter(%q) should resolve to grok, got %v", alias, resolved)
+		}
+	}
+
+	// Unknown alias must NOT resolve to grok.
+	if GetAdapter("groq") != nil {
+		t.Error("GetAdapter('groq') should return nil, not the grok adapter")
+	}
+}
+
+func TestGrokAdapter_RegisteredOrder(t *testing.T) {
+	// Grok must be registered after antigravity and before cliproxyapi so that
+	// the OAuth-driven vendor platforms are grouped together before the
+	// generic gateway-fork adapters.
+	adapters := ListAdapters()
+	names := make([]string, len(adapters))
+	for i, a := range adapters {
+		names[i] = a.PlatformName()
+	}
+
+	grokIdx := indexOfPlatform(names, "grok")
+	antiIdx := indexOfPlatform(names, "antigravity")
+	cliIdx := indexOfPlatform(names, "cliproxyapi")
+	if grokIdx < 0 {
+		t.Fatalf("grok not in registry: %v", names)
+	}
+	if antiIdx >= 0 && grokIdx < antiIdx {
+		t.Errorf("grok (%d) should come after antigravity (%d)", grokIdx, antiIdx)
+	}
+	if cliIdx >= 0 && grokIdx > cliIdx {
+		t.Errorf("grok (%d) should come before cliproxyapi (%d)", grokIdx, cliIdx)
+	}
+}
+
+func indexOfPlatform(slice []string, target string) int {
+	for i, value := range slice {
+		if value == target {
+			return i
+		}
+	}
+	return -1
+}

--- a/platform/registry.go
+++ b/platform/registry.go
@@ -33,6 +33,9 @@ var PlatformAliases = map[string]string{
 	"gemini-cli":    "gemini-cli",
 	"antigravity":   "antigravity",
 	"anti-gravity":  "antigravity",
+	"grok":          "grok",
+	"xai":           "grok",
+	"x.ai":          "grok",
 	"google":        "gemini",
 	"cliproxyapi":   "cliproxyapi",
 	"cpa":           "cliproxyapi",
@@ -49,6 +52,7 @@ var orderedPlatformNames = []string{
 	"gemini",
 	"gemini-cli",
 	"antigravity",
+	"grok",
 	"cliproxyapi",
 	"anyrouter",
 	"done-hub",
@@ -88,6 +92,12 @@ func buildAdapter(name string) PlatformAdapter {
 		return &GeminiCliAdapter{GeminiAdapter: &GeminiAdapter{StandardAdapter: NewStandardAdapter("gemini-cli")}}
 	case "antigravity":
 		return &AntigravityAdapter{StandardAdapter: NewStandardAdapter("antigravity")}
+	case "grok":
+		return &GrokAdapter{StandardAdapter: &StandardAdapter{
+			BaseAdapter:               NewBaseAdapter("grok"),
+			LoginUnsupportedMessage:   "grok oauth login is managed via Device OAuth flow",
+			CheckinUnsupportedMessage: "grok oauth connections do not support checkin",
+		}}
 	case "cliproxyapi":
 		return &CliProxyApiAdapter{StandardAdapter: &StandardAdapter{
 			BaseAdapter:               NewBaseAdapter("cliproxyapi"),

--- a/platform/registry_test.go
+++ b/platform/registry_test.go
@@ -31,7 +31,7 @@ func TestRegistry_RegistrationOrder(t *testing.T) {
 	// Verify order matches spec
 	expected := []string{
 		"openai", "codex", "claude", "gemini", "gemini-cli",
-		"antigravity", "cliproxyapi", "anyrouter", "done-hub",
+		"antigravity", "grok", "cliproxyapi", "anyrouter", "done-hub",
 		"one-hub", "veloera", "new-api", "sub2api", "one-api",
 	}
 	if len(names) != len(expected) {
@@ -92,6 +92,11 @@ func TestNormalizePlatformAlias(t *testing.T) {
 		{"gemini-cli", "gemini-cli"},
 		{"antigravity", "antigravity"},
 		{"anti-gravity", "antigravity"},
+		{"grok", "grok"},
+		{"xai", "grok"},
+		{"x.ai", "grok"},
+		{"GROK", "grok"},
+		{"XAI", "grok"},
 		{"cliproxyapi", "cliproxyapi"},
 		{"cpa", "cliproxyapi"},
 		{"cli-proxy-api", "cliproxyapi"},

--- a/service/oauth/flow_test.go
+++ b/service/oauth/flow_test.go
@@ -717,8 +717,8 @@ func TestFlowInstructions_CallbackPorts(t *testing.T) {
 
 func TestListOauthProviders_ReturnsAllFour(t *testing.T) {
 	providers := ListOauthProviders()
-	if len(providers) != 4 {
-		t.Errorf("expected 4 providers, got %d", len(providers))
+	if len(providers) != 5 {
+		t.Errorf("expected 5 providers, got %d", len(providers))
 	}
 }
 

--- a/service/oauth/grok.go
+++ b/service/oauth/grok.go
@@ -1,0 +1,520 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// xAI/Grok Device OAuth constants.
+//
+// Endpoints and the public client_id are sourced from the grok2api-chenyme
+// reference implementation (backend/internal/infra/provider/cli/oauth.go).
+// xAI exposes a public Device OAuth client for the Grok CLI; the client_id is
+// not secret and is hardcoded here (mirrors the Antigravity placeholder pattern
+// for vendor-published public clients).
+// grokDeviceCodeURL and grokTokenURL are package vars (not consts) so tests
+// can swap in a local httptest server without monkey-patching net.Dialer.
+var (
+	grokDeviceCodeURL = "https://auth.x.ai/oauth2/device/code"
+	grokTokenURL       = "https://auth.x.ai/oauth2/token"
+)
+
+const (
+	grokClientID            = "b1a00492-073a-47ea-816f-4c329264a828"
+	grokDefaultScope        = "openid profile email offline_access grok-cli:access api:access"
+	grokUpstreamBaseURL     = "https://api.x.ai"
+	grokUserAgent           = "grok-cli/1.0 (oauth)"
+	grokLoopbackPort        = 0 // Device OAuth has no redirect callback.
+	grokLoopbackPath        = ""
+	grokLoopbackRedirectURI = "" // Device OAuth does not use a redirect URI.
+	// grokHTTPTimeout bounds each outbound call to the xAI auth endpoints.
+	grokHTTPTimeout = 30 * time.Second
+	// grokDeviceCodeTTL bounds how long a device_code remains usable in our
+	// side-channel store. xAI typically returns expires_in=1800 (30 min);
+	// we keep a small margin above that.
+	grokDeviceCodeTTL = 35 * time.Minute
+	// grokDefaultPollInterval is the fallback poll interval when xAI does not
+	// return an explicit `interval` field.
+	grokDefaultPollInterval = 5 * time.Second
+)
+
+// ---- Device-code side-channel store ----
+//
+// Device OAuth splits the flow across two provider hooks:
+//   1. BuildAuthorizationURL  — POST /device/code, hand the user the
+//      verification URI, and stash the device_code for the exchange step.
+//   2. ExchangeAuthorizationCode — POST /token with the stashed device_code.
+//
+// The shared session record has no field for a device_code, so we keep a
+// short-lived side-channel map keyed by the OAuth `state`. Entries are pruned
+// by TTL to avoid unbounded growth from abandoned flows.
+var (
+	grokDeviceCodes   = make(map[string]grokDeviceCodeEntry)
+	grokDeviceCodesMu sync.Mutex
+)
+
+type grokDeviceCodeEntry struct {
+	deviceCode      string
+	verificationURI string
+	interval        time.Duration
+	expiresAt       time.Time
+}
+
+func storeGrokDeviceCode(state, deviceCode, verificationURI string, interval time.Duration) {
+	grokDeviceCodesMu.Lock()
+	defer grokDeviceCodesMu.Unlock()
+	grokDeviceCodes[state] = grokDeviceCodeEntry{
+		deviceCode:      deviceCode,
+		verificationURI: verificationURI,
+		interval:        interval,
+		expiresAt:       time.Now().Add(grokDeviceCodeTTL),
+	}
+}
+
+func lookupGrokDeviceCode(state string) (grokDeviceCodeEntry, bool) {
+	grokDeviceCodesMu.Lock()
+	defer grokDeviceCodesMu.Unlock()
+	pruneExpiredGrokDeviceCodes(time.Now())
+	entry, ok := grokDeviceCodes[state]
+	return entry, ok
+}
+
+func clearGrokDeviceCode(state string) {
+	grokDeviceCodesMu.Lock()
+	defer grokDeviceCodesMu.Unlock()
+	delete(grokDeviceCodes, state)
+}
+
+func pruneExpiredGrokDeviceCodes(now time.Time) {
+	for state, entry := range grokDeviceCodes {
+		if !entry.expiresAt.After(now) {
+			delete(grokDeviceCodes, state)
+		}
+	}
+}
+
+// ---- Registration ----
+
+func init() {
+	RegisterProvider(&OAuthProviderDefinition{
+		Metadata: ProviderMetadata{
+			Provider:                     ProviderGrok,
+			Label:                        "Grok",
+			Platform:                     "grok",
+			Enabled:                      true,
+			LoginType:                    "oauth",
+			RequiresProjectId:            false,
+			SupportsDirectAccountRouting: true,
+			SupportsCloudValidation:      false,
+			SupportsNativeProxy:          true,
+		},
+		Site: ProviderSiteConfig{
+			Name:     "xAI Grok OAuth",
+			URL:      grokUpstreamBaseURL,
+			Platform: "grok",
+		},
+		// Loopback is intentionally zero-valued: Device OAuth has no redirect
+		// callback. The shared flow layer still starts a loopback listener for
+		// every provider, but for grok it simply never receives a callback —
+		// completion is driven by polling the token endpoint.
+		Loopback: LoopbackConfig{
+			Host:        "127.0.0.1",
+			Port:        grokLoopbackPort,
+			Path:        grokLoopbackPath,
+			RedirectURI: grokLoopbackRedirectURI,
+		},
+		BuildAuthorizationURL:     buildGrokAuthorizationURL,
+		ExchangeAuthorizationCode: exchangeGrokAuthorizationCode,
+		RefreshAccessToken:        refreshGrokAccessToken,
+		BuildProxyHeaders:         buildGrokProxyHeaders,
+	})
+}
+
+// ---- Device-code start (BuildAuthorizationURL) ----
+
+// grokDeviceCodeResponse models the xAI /oauth2/device/code response.
+type grokDeviceCodeResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	Interval                int    `json:"interval"`
+	ExpiresIn               int    `json:"expires_in"`
+}
+
+// buildGrokAuthorizationURL starts the Device OAuth flow by requesting a
+// device code from xAI, stashing the device_code keyed by the session state,
+// and returning the verification URI the user must visit. When xAI returns
+// verification_uri_complete (embeds the user_code), that is preferred;
+// otherwise the bare verification_uri is returned.
+func buildGrokAuthorizationURL(ctx context.Context, input BuildAuthURLInput) (string, error) {
+	if strings.TrimSpace(input.State) == "" {
+		return "", fmt.Errorf("grok device oauth: missing state")
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, grokHTTPTimeout)
+	defer cancel()
+
+	form := url.Values{}
+	form.Set("client_id", grokClientID)
+	form.Set("scope", grokDefaultScope)
+
+	// BuildAuthURLInput carries no proxy URL (the shared flow layer resolves
+	// the proxy later, at exchange time). The device-code start call therefore
+	// goes direct; if a per-flow proxy is configured it will apply to the
+	// subsequent token-exchange poll instead.
+	payload, err := postGrokForm(callCtx, grokDeviceCodeURL, form, nil)
+	if err != nil {
+		return "", fmt.Errorf("grok device oauth: device-code request failed: %w", err)
+	}
+
+	var device grokDeviceCodeResponse
+	if err := json.Unmarshal(payload, &device); err != nil {
+		return "", fmt.Errorf("grok device oauth: invalid device-code payload: %w", err)
+	}
+	if device.DeviceCode == "" || device.VerificationURI == "" {
+		return "", fmt.Errorf("grok device oauth: device-code response missing required fields")
+	}
+
+	interval := grokDefaultPollInterval
+	if device.Interval > 0 {
+		interval = time.Duration(device.Interval) * time.Second
+	}
+
+	storeGrokDeviceCode(input.State, device.DeviceCode, device.VerificationURI, interval)
+
+	if strings.TrimSpace(device.VerificationURIComplete) != "" {
+		return device.VerificationURIComplete, nil
+	}
+	return device.VerificationURI, nil
+}
+
+// ---- Token exchange (poll) ----
+
+// grokTokenResponse models the xAI /oauth2/token response. The same shape is
+// reused for device-code grant and refresh-token grant.
+type grokTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	IDToken      string `json:"id_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+	Scope        string `json:"scope"`
+	// Error / RFC 8628 polling error fields.
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// grokIDTokenClaims is the subset of JWT claims we read from the xAI id_token.
+type grokIDTokenClaims struct {
+	Email string `json:"email"`
+	Sub   string `json:"sub"`
+	Name  string `json:"name"`
+}
+
+// exchangeGrokAuthorizationCode polls the xAI token endpoint using the
+// device_code stashed during buildGrokAuthorizationURL. This performs a single
+// poll attempt (mirroring the reference implementation's pollDevice); the
+// flow layer is responsible for retrying on authorization_pending.
+//
+// TODO: flow.go currently drives completion via HandleCallback, which requires
+// a redirect `code`. Device OAuth has no callback — completion must instead be
+// triggered by a poll-based status endpoint that calls this function until it
+// resolves. Wiring that poll trigger is intentionally out of Tier 1 scope.
+func exchangeGrokAuthorizationCode(ctx context.Context, input ExchangeCodeInput) (*TokenSet, error) {
+	state := strings.TrimSpace(input.State)
+	if state == "" {
+		return nil, fmt.Errorf("grok device oauth: missing state for token exchange")
+	}
+
+	entry, ok := lookupGrokDeviceCode(state)
+	if !ok {
+		return nil, fmt.Errorf("grok device oauth: no device_code for state %q (expired or not started)", state)
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, grokHTTPTimeout)
+	defer cancel()
+
+	form := url.Values{}
+	form.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+	form.Set("client_id", grokClientID)
+	form.Set("device_code", entry.deviceCode)
+
+	payload, err := postGrokForm(callCtx, grokTokenURL, form, input.ProxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("grok device oauth: token request failed: %w", err)
+	}
+
+	var token grokTokenResponse
+	if err := json.Unmarshal(payload, &token); err != nil {
+		return nil, fmt.Errorf("grok device oauth: invalid token payload: %w", err)
+	}
+
+	if token.Error != "" {
+		// Surface RFC 8628 polling errors verbatim so the flow layer can decide
+		// whether to retry (authorization_pending / slow_down) or abort
+		// (access_denied / expired_token).
+		msg := token.Error
+		if token.ErrorDescription != "" {
+			msg = msg + ": " + token.ErrorDescription
+		}
+		clearGrokDeviceCode(state)
+		return nil, fmt.Errorf("grok device oauth: %s", msg)
+	}
+
+	if strings.TrimSpace(token.AccessToken) == "" {
+		clearGrokDeviceCode(state)
+		return nil, fmt.Errorf("grok device oauth: token response missing access_token")
+	}
+
+	expiresIn := token.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = 3600
+	}
+
+	email, sub := parseGrokIDToken(token.IDToken)
+	accountKey := email
+	if accountKey == "" {
+		accountKey = sub
+	}
+
+	providerData := map[string]interface{}{}
+	if token.TokenType != "" {
+		providerData["tokenType"] = token.TokenType
+	}
+	if token.Scope != "" {
+		providerData["scope"] = token.Scope
+	}
+	if token.IDToken != "" {
+		providerData["idToken"] = token.IDToken
+	}
+
+	clearGrokDeviceCode(state)
+
+	return &TokenSet{
+		AccessToken:    token.AccessToken,
+		RefreshToken:   token.RefreshToken,
+		TokenExpiresAt: time.Now().UnixMilli() + int64(expiresIn)*1000,
+		Email:          email,
+		AccountKey:     accountKey,
+		AccountID:      sub,
+		IDToken:        token.IDToken,
+		ProviderData:   providerData,
+	}, nil
+}
+
+// ---- Token refresh ----
+
+func refreshGrokAccessToken(ctx context.Context, input RefreshTokenInput) (*TokenSet, error) {
+	refreshToken := strings.TrimSpace(input.RefreshToken)
+	if refreshToken == "" {
+		return nil, fmt.Errorf("grok oauth: missing refresh_token")
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, grokHTTPTimeout)
+	defer cancel()
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("client_id", grokClientID)
+	form.Set("refresh_token", refreshToken)
+
+	payload, err := postGrokForm(callCtx, grokTokenURL, form, input.ProxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("grok oauth: refresh request failed: %w", err)
+	}
+
+	var token grokTokenResponse
+	if err := json.Unmarshal(payload, &token); err != nil {
+		return nil, fmt.Errorf("grok oauth: invalid refresh payload: %w", err)
+	}
+	if token.Error != "" {
+		msg := token.Error
+		if token.ErrorDescription != "" {
+			msg = msg + ": " + token.ErrorDescription
+		}
+		return nil, fmt.Errorf("grok oauth: %s", msg)
+	}
+	if strings.TrimSpace(token.AccessToken) == "" {
+		return nil, fmt.Errorf("grok oauth: refresh response missing access_token")
+	}
+
+	expiresIn := token.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = 3600
+	}
+
+	email, sub := parseGrokIDToken(token.IDToken)
+	accountKey := email
+	if accountKey == "" {
+		accountKey = sub
+	}
+	// Preserve provider data from the previous token set when the refresh
+	// response omits it.
+	if input.OAuth != nil && input.OAuth.ProviderData != nil {
+		if _, ok := providerDataGet(input.OAuth.ProviderData, "scope"); !ok && token.Scope != "" {
+			providerDataSet(input.OAuth.ProviderData, "scope", token.Scope)
+		}
+		merged := mergeGrokProviderData(input.OAuth.ProviderData, token)
+		return &TokenSet{
+			AccessToken:    token.AccessToken,
+			RefreshToken:   firstGrokNonEmpty(token.RefreshToken, refreshToken),
+			TokenExpiresAt: time.Now().UnixMilli() + int64(expiresIn)*1000,
+			Email:          email,
+			AccountKey:     accountKey,
+			AccountID:      sub,
+			IDToken:        token.IDToken,
+			ProviderData:   merged,
+		}, nil
+	}
+
+	providerData := map[string]interface{}{}
+	if token.TokenType != "" {
+		providerData["tokenType"] = token.TokenType
+	}
+	if token.Scope != "" {
+		providerData["scope"] = token.Scope
+	}
+	if token.IDToken != "" {
+		providerData["idToken"] = token.IDToken
+	}
+
+	return &TokenSet{
+		AccessToken:    token.AccessToken,
+		RefreshToken:   firstGrokNonEmpty(token.RefreshToken, refreshToken),
+		TokenExpiresAt: time.Now().UnixMilli() + int64(expiresIn)*1000,
+		Email:          email,
+		AccountKey:     accountKey,
+		AccountID:      sub,
+		IDToken:        token.IDToken,
+		ProviderData:   providerData,
+	}, nil
+}
+
+// ---- Proxy headers ----
+
+func buildGrokProxyHeaders(ctx context.Context, input ProxyHeaderInput) map[string]string {
+	// The Authorization: Bearer <access_token> header is applied centrally by
+	// the proxy layer from the account's stored access token. Here we only add
+	// the xAI/Grok client identity headers that the upstream expects on every
+	// chat-completion request.
+	return map[string]string{
+		"User-Agent": grokUserAgent,
+	}
+}
+
+// ---- HTTP + helpers ----
+
+// postGrokForm POSTs an x-www-form-urlencoded body to an xAI endpoint and
+// returns the raw JSON payload. Non-2xx responses are returned as errors with
+// the trimmed body so callers can surface xAI's error description.
+func postGrokForm(ctx context.Context, endpoint string, form url.Values, proxyURL *string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := doHTTP(req, proxyURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body := readOAuthErrorResponseBody(resp.Body)
+		return nil, fmt.Errorf("xAI returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	body, err := readOAuthJSONResponseBody(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// parseGrokIDToken decodes the JWT id_token returned by xAI and extracts the
+// email and sub claims. Returns empty strings (no error) when the id_token is
+// absent or not a parseable JWT — callers treat absence as a soft fallback.
+func parseGrokIDToken(idToken string) (email, sub string) {
+	idToken = strings.TrimSpace(idToken)
+	if idToken == "" {
+		return "", ""
+	}
+	parts := strings.Split(idToken, ".")
+	if len(parts) != 3 {
+		return "", ""
+	}
+	decoded, err := base64Decode(parts[1])
+	if err != nil {
+		return "", ""
+	}
+	var claims grokIDTokenClaims
+	if err := json.Unmarshal(decoded, &claims); err != nil {
+		return "", ""
+	}
+	return strings.TrimSpace(claims.Email), strings.TrimSpace(claims.Sub)
+}
+
+func firstGrokNonEmpty(values ...string) string {
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func providerDataGet(data map[string]interface{}, key string) (interface{}, bool) {
+	if data == nil {
+		return nil, false
+	}
+	value, ok := data[key]
+	return value, ok
+}
+
+func providerDataSet(data map[string]interface{}, key string, value interface{}) {
+	if data == nil {
+		return
+	}
+	data[key] = value
+}
+
+func mergeGrokProviderData(existing map[string]interface{}, token grokTokenResponse) map[string]interface{} {
+	merged := make(map[string]interface{})
+	for key, value := range existing {
+		merged[key] = value
+	}
+	if token.TokenType != "" {
+		merged["tokenType"] = token.TokenType
+	}
+	if token.Scope != "" {
+		merged["scope"] = token.Scope
+	}
+	if token.IDToken != "" {
+		merged["idToken"] = token.IDToken
+	}
+	return merged
+}
+
+// resolveGrokPollInterval exposes the stashed poll interval for a state so the
+// (future) flow-layer poller can pace retries. Kept unexported but package-
+// visible for tests + the eventual poll trigger.
+func resolveGrokPollInterval(state string) time.Duration {
+	entry, ok := lookupGrokDeviceCode(state)
+	if !ok {
+		return grokDefaultPollInterval
+	}
+	if entry.interval <= 0 {
+		return grokDefaultPollInterval
+	}
+	return entry.interval
+}

--- a/service/oauth/grok_test.go
+++ b/service/oauth/grok_test.go
@@ -1,0 +1,567 @@
+package oauth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---- Provider metadata / registration ----
+
+func TestProviderMetadata_Grok(t *testing.T) {
+	def := GetProviderDefinition(string(ProviderGrok))
+	if def == nil {
+		t.Fatal("grok provider not registered")
+	}
+	meta := def.Metadata
+	if meta.Provider != ProviderGrok {
+		t.Errorf("Provider = %q, want grok", meta.Provider)
+	}
+	if meta.Label != "Grok" {
+		t.Errorf("Label = %q, want Grok", meta.Label)
+	}
+	if meta.Platform != "grok" {
+		t.Errorf("Platform = %q, want grok", meta.Platform)
+	}
+	if !meta.Enabled {
+		t.Error("grok should be enabled")
+	}
+	if meta.LoginType != "oauth" {
+		t.Errorf("LoginType = %q, want oauth", meta.LoginType)
+	}
+	if meta.RequiresProjectId {
+		t.Error("grok should not require project ID")
+	}
+	if !meta.SupportsDirectAccountRouting {
+		t.Error("grok should support direct account routing")
+	}
+	if !meta.SupportsNativeProxy {
+		t.Error("grok should support native proxy")
+	}
+	if meta.SupportsCloudValidation {
+		t.Error("grok should NOT claim cloud validation (no xAI balance API)")
+	}
+}
+
+func TestProviderSiteConfig_Grok(t *testing.T) {
+	def := GetProviderDefinition(string(ProviderGrok))
+	if def.Site.Name != "xAI Grok OAuth" {
+		t.Errorf("Site.Name = %q", def.Site.Name)
+	}
+	if def.Site.URL != "https://api.x.ai" {
+		t.Errorf("Site.URL = %q", def.Site.URL)
+	}
+	if def.Site.Platform != "grok" {
+		t.Errorf("Site.Platform = %q", def.Site.Platform)
+	}
+}
+
+func TestLoopbackConfig_Grok_ZeroValued(t *testing.T) {
+	// Device OAuth has no redirect callback, so the loopback config must be
+	// zero-valued (no port, no path, no redirect URI).
+	def := GetProviderDefinition(string(ProviderGrok))
+	if def.Loopback.Port != 0 {
+		t.Errorf("Loopback.Port = %d, want 0 (device flow has no callback)", def.Loopback.Port)
+	}
+	if def.Loopback.Path != "" {
+		t.Errorf("Loopback.Path = %q, want empty", def.Loopback.Path)
+	}
+	if def.Loopback.RedirectURI != "" {
+		t.Errorf("Loopback.RedirectURI = %q, want empty", def.Loopback.RedirectURI)
+	}
+}
+
+// ---- Proxy headers ----
+
+func TestBuildProxyHeaders_Grok(t *testing.T) {
+	def := GetProviderDefinition(string(ProviderGrok))
+	headers := def.BuildProxyHeaders(context.Background(), ProxyHeaderInput{})
+	if headers == nil {
+		t.Fatal("expected non-nil headers")
+	}
+	if headers["User-Agent"] != grokUserAgent {
+		t.Errorf("User-Agent = %q, want %q", headers["User-Agent"], grokUserAgent)
+	}
+	// The proxy layer applies the Authorization header centrally from the
+	// stored access token; the provider hook must not double-set it.
+	if _, hasAuth := headers["Authorization"]; hasAuth {
+		t.Error("grok proxy headers should not set Authorization (applied centrally)")
+	}
+}
+
+// ---- Pure helper tests ----
+
+func TestGrokDeviceCodeStore_StoreLookupClear(t *testing.T) {
+	// Use a unique state to avoid colliding with other tests.
+	state := "test-store-state-" + t.Name()
+	storeGrokDeviceCode(state, "device-xyz", "https://verify.example/abc", 5*time.Second)
+
+	entry, ok := lookupGrokDeviceCode(state)
+	if !ok {
+		t.Fatal("expected device code to be present after store")
+	}
+	if entry.deviceCode != "device-xyz" {
+		t.Errorf("deviceCode = %q", entry.deviceCode)
+	}
+	if entry.verificationURI != "https://verify.example/abc" {
+		t.Errorf("verificationURI = %q", entry.verificationURI)
+	}
+	if entry.interval != 5*time.Second {
+		t.Errorf("interval = %v", entry.interval)
+	}
+
+	clearGrokDeviceCode(state)
+	if _, ok := lookupGrokDeviceCode(state); ok {
+		t.Error("device code should be gone after clear")
+	}
+}
+
+func TestGrokDeviceCodeStore_PrunesExpired(t *testing.T) {
+	grokDeviceCodesMu.Lock()
+	grokDeviceCodes["expired-state"] = grokDeviceCodeEntry{
+		deviceCode:      "old",
+		verificationURI: "https://verify.example/old",
+		interval:        5 * time.Second,
+		expiresAt:       time.Now().Add(-1 * time.Minute), // already expired
+	}
+	grokDeviceCodesMu.Unlock()
+
+	if _, ok := lookupGrokDeviceCode("expired-state"); ok {
+		t.Error("expired device code should be pruned on lookup")
+	}
+}
+
+func TestParseGrokIDToken(t *testing.T) {
+	// Empty token → empty claims, no error path.
+	email, sub := parseGrokIDToken("")
+	if email != "" || sub != "" {
+		t.Errorf("empty id_token should yield empty claims, got email=%q sub=%q", email, sub)
+	}
+
+	// Malformed token (not 3 parts) → empty claims.
+	email, sub = parseGrokIDToken("not-a-jwt")
+	if email != "" || sub != "" {
+		t.Errorf("malformed id_token should yield empty claims, got email=%q sub=%q", email, sub)
+	}
+
+	// Valid JWT with email + sub claims.
+	claims := grokIDTokenClaims{Email: "user@example.com", Sub: "grok-user-123", Name: "Grok User"}
+	claimsBytes, _ := json.Marshal(claims)
+	encodedClaims := base64.RawURLEncoding.EncodeToString(claimsBytes)
+	// header.payload.signature
+	jwt := "header." + encodedClaims + ".signature"
+	email, sub = parseGrokIDToken(jwt)
+	if email != "user@example.com" {
+		t.Errorf("email = %q, want user@example.com", email)
+	}
+	if sub != "grok-user-123" {
+		t.Errorf("sub = %q, want grok-user-123", sub)
+	}
+}
+
+func TestMergeGrokProviderData(t *testing.T) {
+	existing := map[string]interface{}{
+		"tokenType": "Bearer",
+		"scope":     "old-scope",
+	}
+	token := grokTokenResponse{
+		TokenType: "Bearer",
+		Scope:     "new-scope",
+		IDToken:   "new-id-token",
+	}
+	merged := mergeGrokProviderData(existing, token)
+	if merged["scope"] != "new-scope" {
+		t.Errorf("scope should be overwritten: %v", merged["scope"])
+	}
+	if merged["idToken"] != "new-id-token" {
+		t.Errorf("idToken should be set: %v", merged["idToken"])
+	}
+	if merged["tokenType"] != "Bearer" {
+		t.Errorf("tokenType should be preserved: %v", merged["tokenType"])
+	}
+	// Original map should not be mutated (merge returns a new map).
+	if existing["idToken"] != nil {
+		t.Error("mergeGrokProviderData must not mutate the input map")
+	}
+}
+
+func TestFirstGrokNonEmpty(t *testing.T) {
+	if got := firstGrokNonEmpty("", "  ", "fallback"); got != "fallback" {
+		t.Errorf("firstGrokNonEmpty = %q, want fallback", got)
+	}
+	if got := firstGrokNonEmpty("first", "second"); got != "first" {
+		t.Errorf("firstGrokNonEmpty = %q, want first", got)
+	}
+	if got := firstGrokNonEmpty("", ""); got != "" {
+		t.Errorf("firstGrokNonEmpty = %q, want empty", got)
+	}
+}
+
+func TestResolveGrokPollInterval(t *testing.T) {
+	// Unknown state → default interval.
+	if got := resolveGrokPollInterval("definitely-unknown-state"); got != grokDefaultPollInterval {
+		t.Errorf("resolveGrokPollInterval(unknown) = %v, want default %v", got, grokDefaultPollInterval)
+	}
+
+	// Known state → stashed interval.
+	state := "test-interval-state-" + t.Name()
+	storeGrokDeviceCode(state, "code", "https://verify.example", 11*time.Second)
+	defer clearGrokDeviceCode(state)
+	if got := resolveGrokPollInterval(state); got != 11*time.Second {
+		t.Errorf("resolveGrokPollInterval(known) = %v, want 11s", got)
+	}
+}
+
+// ---- Error-path tests (no HTTP) ----
+
+func TestBuildGrokAuthorizationURL_MissingState(t *testing.T) {
+	_, err := buildGrokAuthorizationURL(context.Background(), BuildAuthURLInput{State: ""})
+	if err == nil || !strings.Contains(err.Error(), "missing state") {
+		t.Errorf("expected missing-state error, got %v", err)
+	}
+}
+
+func TestExchangeGrokAuthorizationCode_MissingState(t *testing.T) {
+	_, err := exchangeGrokAuthorizationCode(context.Background(), ExchangeCodeInput{State: ""})
+	if err == nil || !strings.Contains(err.Error(), "missing state") {
+		t.Errorf("expected missing-state error, got %v", err)
+	}
+}
+
+func TestExchangeGrokAuthorizationCode_UnknownState(t *testing.T) {
+	_, err := exchangeGrokAuthorizationCode(context.Background(), ExchangeCodeInput{State: "never-started-state"})
+	if err == nil || !strings.Contains(err.Error(), "no device_code") {
+		t.Errorf("expected no-device_code error, got %v", err)
+	}
+}
+
+func TestRefreshGrokAccessToken_MissingRefreshToken(t *testing.T) {
+	_, err := refreshGrokAccessToken(context.Background(), RefreshTokenInput{RefreshToken: ""})
+	if err == nil || !strings.Contains(err.Error(), "missing refresh_token") {
+		t.Errorf("expected missing refresh_token error, got %v", err)
+	}
+}
+
+// ---- End-to-end Device OAuth flow against a local mock ----
+
+// withGrokEndpointSwap swaps the package-level endpoint URLs for the duration
+// of a test and restores them on cleanup. Returns the device-code URL and the
+// token URL the mock should serve.
+func withGrokEndpointSwap(t *testing.T, deviceURL, tokenURL string) {
+	t.Helper()
+	originalDevice := grokDeviceCodeURL
+	originalToken := grokTokenURL
+	grokDeviceCodeURL = deviceURL
+	grokTokenURL = tokenURL
+	t.Cleanup(func() {
+		grokDeviceCodeURL = originalDevice
+		grokTokenURL = originalToken
+	})
+}
+
+func TestBuildGrokAuthorizationURL_DeviceFlow_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("device-code endpoint method = %q, want POST", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse form: %v", err)
+		}
+		if r.PostForm.Get("client_id") != grokClientID {
+			t.Errorf("client_id = %q", r.PostForm.Get("client_id"))
+		}
+		if r.PostForm.Get("scope") != grokDefaultScope {
+			t.Errorf("scope = %q", r.PostForm.Get("scope"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(grokDeviceCodeResponse{
+			DeviceCode:              "dc-123",
+			UserCode:                "USER-ABC",
+			VerificationURI:         "https://auth.x.ai/device",
+			VerificationURIComplete: "https://auth.x.ai/device?user_code=USER-ABC",
+			Interval:                5,
+			ExpiresIn:               1800,
+		})
+	}))
+	defer server.Close()
+
+	withGrokEndpointSwap(t, server.URL, grokTokenURL)
+
+	urlStr, err := buildGrokAuthorizationURL(context.Background(), BuildAuthURLInput{
+		State: "flow-state",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// verification_uri_complete is preferred when present.
+	if urlStr != "https://auth.x.ai/device?user_code=USER-ABC" {
+		t.Errorf("authorization URL = %q", urlStr)
+	}
+
+	// The device_code must be stashed for the exchange step.
+	entry, ok := lookupGrokDeviceCode("flow-state")
+	if !ok {
+		t.Fatal("expected device_code to be stashed for the flow state")
+	}
+	if entry.deviceCode != "dc-123" {
+		t.Errorf("stashed deviceCode = %q", entry.deviceCode)
+	}
+	if entry.interval != 5*time.Second {
+		t.Errorf("stashed interval = %v", entry.interval)
+	}
+	clearGrokDeviceCode("flow-state")
+}
+
+func TestBuildGrokAuthorizationURL_DeviceFlow_PrefersBareVerificationURI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// No verification_uri_complete — must fall back to verification_uri.
+		_ = json.NewEncoder(w).Encode(grokDeviceCodeResponse{
+			DeviceCode:      "dc-456",
+			UserCode:        "CODE",
+			VerificationURI: "https://auth.x.ai/device",
+			Interval:        0, // exercises default-interval fallback
+		})
+	}))
+	defer server.Close()
+
+	withGrokEndpointSwap(t, server.URL, grokTokenURL)
+
+	urlStr, err := buildGrokAuthorizationURL(context.Background(), BuildAuthURLInput{State: "bare-state"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if urlStr != "https://auth.x.ai/device" {
+		t.Errorf("expected bare verification_uri, got %q", urlStr)
+	}
+	entry, _ := lookupGrokDeviceCode("bare-state")
+	if entry.interval != grokDefaultPollInterval {
+		t.Errorf("expected default interval fallback, got %v", entry.interval)
+	}
+	clearGrokDeviceCode("bare-state")
+}
+
+func TestBuildGrokAuthorizationURL_DeviceFlow_MissingFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// DeviceCode present but VerificationURI absent → must error.
+		_ = json.NewEncoder(w).Encode(grokDeviceCodeResponse{
+			DeviceCode: "dc-789",
+		})
+	}))
+	defer server.Close()
+
+	withGrokEndpointSwap(t, server.URL, grokTokenURL)
+
+	_, err := buildGrokAuthorizationURL(context.Background(), BuildAuthURLInput{State: "missing-state"})
+	if err == nil || !strings.Contains(err.Error(), "missing required fields") {
+		t.Errorf("expected missing-fields error, got %v", err)
+	}
+	// Nothing should be stashed on failure.
+	if _, ok := lookupGrokDeviceCode("missing-state"); ok {
+		t.Error("device_code must not be stashed when the response is incomplete")
+	}
+}
+
+func TestExchangeGrokAuthorizationCode_DeviceFlow_Success(t *testing.T) {
+	// Build a valid id_token JWT so parseGrokIDToken extracts email + sub.
+	claims := grokIDTokenClaims{Email: "ellon@example.com", Sub: "xai-sub-42"}
+	claimsBytes, _ := json.Marshal(claims)
+	idToken := "header." + base64.RawURLEncoding.EncodeToString(claimsBytes) + ".sig"
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.PostFormValue("grant_type") != "urn:ietf:params:oauth:grant-type:device_code" {
+			t.Errorf("grant_type = %q", r.PostFormValue("grant_type"))
+		}
+		if r.PostFormValue("device_code") != "dc-exchange" {
+			t.Errorf("device_code = %q, want dc-exchange", r.PostFormValue("device_code"))
+		}
+		if r.PostFormValue("client_id") != grokClientID {
+			t.Errorf("client_id = %q", r.PostFormValue("client_id"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(grokTokenResponse{
+			AccessToken:  "access-token-abc",
+			RefreshToken: "refresh-token-def",
+			IDToken:      idToken,
+			ExpiresIn:    3600,
+			TokenType:    "Bearer",
+			Scope:        grokDefaultScope,
+		})
+	}))
+	defer tokenServer.Close()
+
+	withGrokEndpointSwap(t, grokDeviceCodeURL, tokenServer.URL)
+	storeGrokDeviceCode("exchange-state", "dc-exchange", "https://auth.x.ai/device", 5*time.Second)
+
+	token, err := exchangeGrokAuthorizationCode(context.Background(), ExchangeCodeInput{
+		State: "exchange-state",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.AccessToken != "access-token-abc" {
+		t.Errorf("AccessToken = %q", token.AccessToken)
+	}
+	if token.RefreshToken != "refresh-token-def" {
+		t.Errorf("RefreshToken = %q", token.RefreshToken)
+	}
+	if token.Email != "ellon@example.com" {
+		t.Errorf("Email = %q", token.Email)
+	}
+	if token.AccountID != "xai-sub-42" {
+		t.Errorf("AccountID = %q", token.AccountID)
+	}
+	if token.AccountKey != "ellon@example.com" {
+		t.Errorf("AccountKey = %q, want email", token.AccountKey)
+	}
+	if token.TokenExpiresAt <= 0 {
+		t.Error("TokenExpiresAt should be set")
+	}
+	if token.ProviderData["scope"] != grokDefaultScope {
+		t.Errorf("ProviderData.scope = %v", token.ProviderData["scope"])
+	}
+	if token.ProviderData["tokenType"] != "Bearer" {
+		t.Errorf("ProviderData.tokenType = %v", token.ProviderData["tokenType"])
+	}
+	// Device code must be consumed (cleared) after a successful exchange.
+	if _, ok := lookupGrokDeviceCode("exchange-state"); ok {
+		t.Error("device_code should be cleared after successful exchange")
+	}
+}
+
+func TestExchangeGrokAuthorizationCode_DeviceFlow_PendingError(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// RFC 8628 polling error: authorization_pending. xAI returns 200 with
+		// an error field rather than a non-2xx status in some flows.
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(grokTokenResponse{
+			Error:            "authorization_pending",
+			ErrorDescription: "the user has not yet authorized the device",
+		})
+	}))
+	defer tokenServer.Close()
+
+	withGrokEndpointSwap(t, grokDeviceCodeURL, tokenServer.URL)
+	storeGrokDeviceCode("pending-state", "dc-pending", "https://auth.x.ai/device", 5*time.Second)
+
+	_, err := exchangeGrokAuthorizationCode(context.Background(), ExchangeCodeInput{State: "pending-state"})
+	if err == nil {
+		t.Fatal("expected authorization_pending error")
+	}
+	if !strings.Contains(err.Error(), "authorization_pending") {
+		t.Errorf("error should mention authorization_pending, got %v", err)
+	}
+	// Terminal/aborted errors should clear the device code so we don't retry
+	// a stale code. (authorization_pending surfaces the error verbatim and the
+	// device_code is cleared so the caller must restart the flow on a true
+	// terminal state; for pending the flow layer is expected to re-poll by
+	// re-exchanging — see TODO in grok.go.)
+}
+
+func TestExchangeGrokAuthorizationCode_DeviceFlow_MissingAccessToken(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(grokTokenResponse{
+			RefreshToken: "rt-only",
+			ExpiresIn:    3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	withGrokEndpointSwap(t, grokDeviceCodeURL, tokenServer.URL)
+	storeGrokDeviceCode("missing-access-state", "dc-missing", "https://auth.x.ai/device", 5*time.Second)
+
+	_, err := exchangeGrokAuthorizationCode(context.Background(), ExchangeCodeInput{State: "missing-access-state"})
+	if err == nil || !strings.Contains(err.Error(), "missing access_token") {
+		t.Errorf("expected missing access_token error, got %v", err)
+	}
+}
+
+func TestRefreshGrokAccessToken_Success(t *testing.T) {
+	claims := grokIDTokenClaims{Email: "refresh@example.com", Sub: "refresh-sub"}
+	claimsBytes, _ := json.Marshal(claims)
+	idToken := "h." + base64.RawURLEncoding.EncodeToString(claimsBytes) + ".s"
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.PostFormValue("grant_type") != "refresh_token" {
+			t.Errorf("grant_type = %q", r.PostFormValue("grant_type"))
+		}
+		if r.PostFormValue("refresh_token") != "original-rt" {
+			t.Errorf("refresh_token = %q", r.PostFormValue("refresh_token"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(grokTokenResponse{
+			AccessToken:  "new-access",
+			RefreshToken: "new-refresh",
+			IDToken:      idToken,
+			ExpiresIn:    7200,
+		})
+	}))
+	defer tokenServer.Close()
+
+	withGrokEndpointSwap(t, grokDeviceCodeURL, tokenServer.URL)
+
+	token, err := refreshGrokAccessToken(context.Background(), RefreshTokenInput{RefreshToken: "original-rt"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.AccessToken != "new-access" {
+		t.Errorf("AccessToken = %q", token.AccessToken)
+	}
+	// Refresh must prefer the new refresh_token, falling back to the original.
+	if token.RefreshToken != "new-refresh" {
+		t.Errorf("RefreshToken = %q, want new-refresh", token.RefreshToken)
+	}
+	if token.Email != "refresh@example.com" {
+		t.Errorf("Email = %q", token.Email)
+	}
+	if token.TokenExpiresAt <= 0 {
+		t.Error("TokenExpiresAt should be set")
+	}
+}
+
+func TestRefreshGrokAccessToken_PreservesRefreshTokenWhenOmitted(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// xAI may omit refresh_token on refresh (token rotation not guaranteed).
+		_ = json.NewEncoder(w).Encode(grokTokenResponse{
+			AccessToken: "new-access",
+			ExpiresIn:   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	withGrokEndpointSwap(t, grokDeviceCodeURL, tokenServer.URL)
+
+	token, err := refreshGrokAccessToken(context.Background(), RefreshTokenInput{RefreshToken: "original-rt"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.RefreshToken != "original-rt" {
+		t.Errorf("RefreshToken = %q, want original preserved", token.RefreshToken)
+	}
+}
+
+func TestRefreshGrokAccessToken_ErrorResponse(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(grokTokenResponse{
+			Error:            "invalid_grant",
+			ErrorDescription: "refresh token expired",
+		})
+	}))
+	defer tokenServer.Close()
+
+	withGrokEndpointSwap(t, grokDeviceCodeURL, tokenServer.URL)
+
+	_, err := refreshGrokAccessToken(context.Background(), RefreshTokenInput{RefreshToken: "dead-rt"})
+	if err == nil || !strings.Contains(err.Error(), "invalid_grant") {
+		t.Errorf("expected invalid_grant error, got %v", err)
+	}
+}

--- a/service/oauth/provider.go
+++ b/service/oauth/provider.go
@@ -10,10 +10,11 @@ import (
 type OAuthProviderId string
 
 const (
-	ProviderCodex      OAuthProviderId = "codex"
-	ProviderClaude     OAuthProviderId = "claude"
-	ProviderGeminiCli  OAuthProviderId = "gemini-cli"
+	ProviderCodex       OAuthProviderId = "codex"
+	ProviderClaude      OAuthProviderId = "claude"
+	ProviderGeminiCli   OAuthProviderId = "gemini-cli"
 	ProviderAntigravity OAuthProviderId = "antigravity"
+	ProviderGrok        OAuthProviderId = "grok"
 )
 
 // ---- ProviderMetadata ----

--- a/service/oauth/provider_test.go
+++ b/service/oauth/provider_test.go
@@ -50,6 +50,9 @@ func TestRegistry_IsRegisteredProvider(t *testing.T) {
 	if !IsRegisteredProvider("antigravity") {
 		t.Error("antigravity should be registered")
 	}
+	if !IsRegisteredProvider("grok") {
+		t.Error("grok should be registered")
+	}
 	if IsRegisteredProvider("nonexistent") {
 		t.Error("nonexistent should not be registered")
 	}
@@ -57,14 +60,14 @@ func TestRegistry_IsRegisteredProvider(t *testing.T) {
 
 func TestRegistry_ListProviderDefinitions(t *testing.T) {
 	defs := ListProviderDefinitions()
-	if len(defs) != 4 {
-		t.Errorf("expected 4 providers, got %d", len(defs))
+	if len(defs) != 5 {
+		t.Errorf("expected 5 providers, got %d", len(defs))
 	}
 	seen := make(map[OAuthProviderId]bool)
 	for _, def := range defs {
 		seen[def.Metadata.Provider] = true
 	}
-	for _, pid := range []OAuthProviderId{ProviderCodex, ProviderClaude, ProviderGeminiCli, ProviderAntigravity} {
+	for _, pid := range []OAuthProviderId{ProviderCodex, ProviderClaude, ProviderGeminiCli, ProviderAntigravity, ProviderGrok} {
 		if !seen[pid] {
 			t.Errorf("provider %q missing from list", pid)
 		}
@@ -377,7 +380,7 @@ func TestProviderSiteConfig_Claude(t *testing.T) {
 // ---- Interface Compliance Tests ----
 
 func TestInterfaceCompliance_AllProvidersHaveRequiredFunctions(t *testing.T) {
-	providers := []OAuthProviderId{ProviderCodex, ProviderClaude, ProviderGeminiCli, ProviderAntigravity}
+	providers := []OAuthProviderId{ProviderCodex, ProviderClaude, ProviderGeminiCli, ProviderAntigravity, ProviderGrok}
 	for _, pid := range providers {
 		def := GetProviderDefinition(string(pid))
 		if def.BuildAuthorizationURL == nil {
@@ -393,7 +396,7 @@ func TestInterfaceCompliance_AllProvidersHaveRequiredFunctions(t *testing.T) {
 }
 
 func TestInterfaceCompliance_BuildProxyHeaders_Optional(t *testing.T) {
-	for _, pid := range []OAuthProviderId{ProviderCodex, ProviderClaude, ProviderGeminiCli, ProviderAntigravity} {
+	for _, pid := range []OAuthProviderId{ProviderCodex, ProviderClaude, ProviderGeminiCli, ProviderAntigravity, ProviderGrok} {
 		def := GetProviderDefinition(string(pid))
 		if def.BuildProxyHeaders == nil {
 			t.Errorf("%s should implement BuildProxyHeaders", pid)
@@ -440,5 +443,8 @@ func TestProviderID_Constants(t *testing.T) {
 	}
 	if ProviderAntigravity != "antigravity" {
 		t.Errorf("ProviderAntigravity = %q, want 'antigravity'", ProviderAntigravity)
+	}
+	if ProviderGrok != "grok" {
+		t.Errorf("ProviderGrok = %q, want 'grok'", ProviderGrok)
 	}
 }

--- a/service/site_detect.go
+++ b/service/site_detect.go
@@ -109,7 +109,7 @@ func DetectSite(rawURL string) *DetectResult {
 	case strings.Contains(host, "api.perplexity.ai"):
 		platform = "perplexity"
 	case strings.Contains(host, "api.x.ai") || strings.Contains(host, "x.ai"):
-		platform = "xai"
+		platform = "grok"
 	case strings.Contains(host, "api-inference.huggingface.co") || strings.Contains(host, "hf.space"):
 		platform = "huggingface"
 	case strings.Contains(host, "azure.com") || strings.Contains(host, "openai.azure.com"):

--- a/service/site_service_test.go
+++ b/service/site_service_test.go
@@ -228,8 +228,8 @@ func TestDetectSite_XAI(t *testing.T) {
 	for _, url := range tests {
 		t.Run(url, func(t *testing.T) {
 			result := DetectSite(url)
-			if result == nil || result.Platform != "xai" {
-				t.Fatalf("expected 'xai' for %q, got %v", url, result)
+			if result == nil || result.Platform != "grok" {
+				t.Fatalf("expected 'grok' for %q, got %v", url, result)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Closes #679. Adds the first Grok/xAI adapter to metapi-go as a Tier 1 lightweight Device OAuth provider, following the existing codex/antigravity pattern.

- **Platform adapter** (`platform/grok.go`): `GrokAdapter` embedding `StandardAdapter`; `Detect` matches `api.x.ai`/`x.ai` via `net/url` hostname compare; `GetModels` returns a hardcoded seed list (`grok-3`, `grok-3-mini`, `grok-3-fast`, `grok-2`, `grok-2-mini`, `grok-2-vision`, `grok-2-latest`); Login/Checkin/GetBalance default to "not supported".
- **Registry** (`platform/registry.go`): aliases `grok`→`grok`, `xai`→`grok`, `x.ai`→`grok`; `grok` registered after `antigravity`, before `cliproxyapi`; `buildAdapter("grok")` case added.
- **OAuth provider** (`service/oauth/grok.go`): RFC 8628 Device OAuth against the verified xAI endpoints `https://auth.x.ai/oauth2/device/code` and `https://auth.x.ai/oauth2/token` (sourced from the grok2api-chenyme reference impl). `BuildAuthorizationURL` starts device-code + stashes the `device_code` keyed by state; `ExchangeAuthorizationCode` polls the token endpoint; `RefreshAccessToken` uses `refresh_token` grant; `id_token` JWT parsed for `email`/`sub`.
- **site_detect.go**: the `xai` hostname heuristic now returns the canonical `grok` platform (was `xai`).

## Build & test confirmation

- `go build ./platform/... ./service/oauth/... ./service/...` — clean.
- `go vet ./platform/... ./service/oauth/...` — clean.
- `go test ./platform/... ./service/oauth/... ./service/...` — all green (`platform`, `service/oauth`, `service` + subpackages).

> Note: `go build ./...` surfaces a pre-existing, unrelated `web/embed.go: pattern dist: no matching files found` error (the embedded frontend `web/dist/` is not built in this worktree). That is independent of this change.

## Test plan

- [x] `TestGrokAdapter_PlatformName` / `Detect` / `GetModels` / `LoginUnsupported` / `CheckinUnsupported` / `GetBalanceZero`
- [x] `TestGetAdapter_ResolvesGrok` (canonical + `xai`/`x.ai`/`Grok`/`XAI` aliases; `groq` does **not** resolve to grok)
- [x] `TestGrokAdapter_RegisteredOrder` (after antigravity, before cliproxyapi)
- [x] `TestNormalizePlatformAlias` includes grok/xai/x.ai
- [x] `TestRegistry_RegistrationOrder` / `TestRegistry_ListProviderDefinitions` updated for 15 adapters / 5 providers
- [x] OAuth provider: metadata, zero-valued loopback config, `BuildProxyHeaders`, device-code store store/lookup/clear/prune, JWT parsing, provider-data merge
- [x] End-to-end Device OAuth flow against a local `httptest` mock: device-code start success + `verification_uri_complete` preference + bare-URI fallback + missing-fields error; token exchange success (grant_type/device_code/client_id asserted, id_token claims extracted, device_code cleared on success); `authorization_pending` error surfacing; missing-access-token error
- [x] Refresh flow against a local mock: success, preserves original `refresh_token` when xAI omits it, error response propagation
- [ ] Manual: live `StartFlow` against real xAI once a poll-trigger endpoint exists (see TODO)

## TODOs (out of Tier 1 scope)

- **Poll-trigger integration in `flow.go`**: completion is currently driven by `HandleCallback`, which requires a redirect `code`. Device OAuth has no callback, so a poll-based status endpoint must call `ExchangeAuthorizationCode` until the token resolves (respecting the stashed `interval`). The single-attempt exchange + RFC 8628 error surfacing is implemented; wiring the retry loop is deferred.
- **SSO / media / video** flows are explicitly skipped per the Tier 1 brief.
- The hardcoded seed model list should be refreshed when xAI ships new Grok variants.