### PR TITLE
feat(proxy): add /v1/images/generations passthrough

### DIFF
--- a/handler/proxy/images_test.go
+++ b/handler/proxy/images_test.go
@@ -2,6 +2,7 @@ package proxyhandler
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/deliciousbuding/metapi-go/auth"
 	"github.com/deliciousbuding/metapi-go/routing"
 	"github.com/deliciousbuding/metapi-go/store"
 )
@@ -320,5 +322,179 @@ func TestHandleImagesVariations(t *testing.T) {
 
 	if rec.Code != 400 {
 		t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---- HandleImagesGenerations upstream passthrough + model validation ----
+
+// TestHandleImagesGenerations_ForwardsToUpstream wires a real upstream that
+// returns a fake gpt-image-1 response (with usage) and verifies:
+//   - the upstream response body is relayed verbatim to the client,
+//   - the request is forwarded to /v1/images/generations with Bearer auth,
+//   - the requested model is rewritten to the channel's ActualModel,
+//   - success + usage are recorded on the router (same path as chat completions).
+func TestHandleImagesGenerations_ForwardsToUpstream(t *testing.T) {
+	var (
+		gotPath  string
+		gotAuth  string
+		gotModel string
+		gotBody  []byte
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read upstream body: %v", err)
+		}
+		gotBody = body
+		var parsed map[string]any
+		_ = json.Unmarshal(body, &parsed)
+		if m, ok := parsed["model"].(string); ok {
+			gotModel = m
+		}
+
+		// Fake gpt-image-1 response with OpenAI-style usage object.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created":1710000000,"data":[{"b64_json":"ZmFrZQ=="}],"usage":{"prompt_tokens":12,"completion_tokens":0,"total_tokens":12}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	router := &upstreamTestRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active"},
+		TokenValue:  "upstream-token",
+		ActualModel: "gpt-image-1-upstream",
+	}}
+	SetUpstreamConfig(&UpstreamConfig{Router: router})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/images/generations", `{"model":"gpt-image-1","prompt":"a beautiful sunset"}`)
+	rec := httptest.NewRecorder()
+	HandleImagesGenerations(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if gotPath != "/v1/images/generations" {
+		t.Fatalf("upstream path = %q, want /v1/images/generations", gotPath)
+	}
+	if gotAuth != "Bearer upstream-token" {
+		t.Fatalf("Authorization = %q, want Bearer upstream-token", gotAuth)
+	}
+	if gotModel != "gpt-image-1-upstream" {
+		t.Fatalf("upstream model = %q, want gpt-image-1-upstream (ActualModel rewrite)", gotModel)
+	}
+	// Verify prompt survived forwarding (non-model fields pass through untouched).
+	if !strings.Contains(string(gotBody), `"a beautiful sunset"`) {
+		t.Fatalf("upstream body = %q, want prompt forwarded verbatim", string(gotBody))
+	}
+
+	// Response body must be relayed verbatim, including the b64 image payload + usage.
+	raw := rec.Body.String()
+	if !strings.Contains(raw, "ZmFrZQ==") {
+		t.Fatalf("body = %q, want upstream b64 image payload relayed", raw)
+	}
+	if !strings.Contains(raw, `"total_tokens":12`) {
+		t.Fatalf("body = %q, want upstream usage relayed", raw)
+	}
+
+	// Success + usage recorded on the router (same accounting path as chat completions).
+	if len(router.successes) != 1 {
+		t.Fatalf("router.successes = %d entries, want 1", len(router.successes))
+	}
+	succ := router.successes[0]
+	if succ.channelID != 42 {
+		t.Fatalf("RecordSuccess channelID = %d, want 42", succ.channelID)
+	}
+	if succ.modelName == nil || *succ.modelName != "gpt-image-1-upstream" {
+		t.Fatalf("RecordSuccess model = %v, want gpt-image-1-upstream", succ.modelName)
+	}
+}
+
+// TestHandleImagesGenerations_UpstreamErrorPassthrough verifies upstream 4xx
+// error responses are relayed to the client without rewriting the body.
+func TestHandleImagesGenerations_UpstreamErrorPassthrough(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"Invalid image size","type":"invalid_request_error","code":"invalid_image_size"}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:     store.RouteChannel{ID: 42, Enabled: true},
+			Account:     store.Account{ID: 7, Status: "active"},
+			Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active"},
+			TokenValue:  "upstream-token",
+			ActualModel: "gpt-image-1",
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/images/generations", `{"model":"gpt-image-1","prompt":"a cat","size":"99x99"}`)
+	rec := httptest.NewRecorder()
+	HandleImagesGenerations(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "Invalid image size") {
+		t.Fatalf("body = %q, want upstream error body relayed", body)
+	}
+}
+
+// TestHandleImagesGenerations_ModelDeniedByPolicy verifies that when the
+// request carries an explicit model, the downstream policy model-allow check
+// (the same IsModelAllowedByPolicy gate chat completions uses in PrepareCtx)
+// rejects models not in the key's SupportedModels list with 403.
+func TestHandleImagesGenerations_ModelDeniedByPolicy(t *testing.T) {
+	// Upstream should never be reached when policy denies the model.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("upstream should not be hit when model is denied by policy: %s", r.URL.Path)
+		http.Error(w, "should not reach", http.StatusInternalServerError)
+	}))
+	t.Cleanup(upstream.Close)
+
+	SetUpstreamConfig(&UpstreamConfig{
+		Router: &upstreamTestRouter{selected: routing.SelectedChannel{
+			Channel:     store.RouteChannel{ID: 42, Enabled: true},
+			Account:     store.Account{ID: 7, Status: "active"},
+			Site:        store.Site{ID: 3, URL: upstream.URL, Status: "active"},
+			TokenValue:  "upstream-token",
+			ActualModel: "gpt-image-1-upstream",
+		}},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	// Build an authenticated request whose policy only allows gpt-4o — the
+	// requested model dall-e-3 must be rejected at the PrepareCtx gate.
+	req := httptest.NewRequest("POST", "/v1/images/generations", strings.NewReader(`{"model":"dall-e-3","prompt":"a cat"}`))
+	req.Header.Set("Content-Type", "application/json")
+	pac := &auth.ProxyAuthContext{
+		Token:  "test-token",
+		Source: "global",
+		Policy: auth.DownstreamRoutingPolicy{
+			SupportedModels: []string{"gpt-4o"},
+		},
+	}
+	req = req.WithContext(auth.WithProxyAuth(req.Context(), pac))
+
+	rec := httptest.NewRecorder()
+	HandleImagesGenerations(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "model not allowed by downstream policy") {
+		t.Fatalf("body = %q, want clear policy-denial error", body)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #680.

The `/v1/images/generations` passthrough was already present in the baseline: the route is registered in `handler/proxy/router.go` (`r.Post("/images/generations", HandleImagesGenerations)`) and `handler/proxy/images.go`'s `HandleImagesGenerations` reuses the same `PrepareCtx` + `dispatchUpstream` flow as `/v1/chat/completions`. This PR completes the issue by adding the test coverage the issue explicitly requires — a mock upstream returning a fake image response, verifying passthrough + model validation.

- **Route + handler + auth + site resolution**: already wired via `PrepareCtx` (auth middleware, model policy gate) and `dispatchUpstream` (channel/site selection, upstream forward via `DoWithProxy`/`Executor`, non-streaming JSON relay). No production code change was needed — the pattern is identical to chat completions.
- **Model validation**: a `model` field present in the request body is validated via `IsModelAllowedByPolicy` (downstream policy → 403 on deny) and channel selection (→ 503 when no channel serves it) — identical to chat completions. When no model is present, it defaults to `gpt-image-1` (a routing necessity; `SelectProxyChannelForAttempt` keys off `RequestedModel`) and the upstream decides image-specific parameters.
- **Usage tracking**: reuses the existing `dispatchUpstream` non-streaming path, which calls `ParseUsageFromBody` + `recordUpstreamSuccess` + `writeSuccessProxyLog`. `ParseUsageFromBody` already handles OpenAI image-style usage (`prompt_tokens`/`completion_tokens`/`total_tokens` and `image_tokens` detail leaves), so no streaming-coupled tracking is needed.

### Tests added (`handler/proxy/images_test.go`)

- `TestHandleImagesGenerations_ForwardsToUpstream` — wires a real upstream returning a fake `gpt-image-1` response (with `usage`), verifies the response body is relayed verbatim (including the b64 image payload + usage), the request is forwarded to `/v1/images/generations` with `Bearer` auth, the requested model is rewritten to the channel's `ActualModel`, and success + usage are recorded on the router.
- `TestHandleImagesGenerations_UpstreamErrorPassthrough` — verifies upstream 4xx error responses are relayed to the client unmodified.
- `TestHandleImagesGenerations_ModelDeniedByPolicy` — verifies the `IsModelAllowedByPolicy` gate in `PrepareCtx` (the same model-validation check chat completions uses) rejects models not in the key's `SupportedModels` list with 403.

## Test plan

- [x] `go vet ./handler/proxy/` — clean
- [x] `go test ./handler/...` — all pass (proxy, admin, shared)
- [x] `go test ./handler/proxy/ -run 'TestHandleImagesGenerations' -v` — 6/6 pass (3 new + 3 existing)
- [x] `go build ./handler/... ./router/... ./service/... ./proxy/... ./auth/...` — clean
- [ ] Live smoke: `POST /v1/images/generations` with a real `gpt-image-1` channel configured, confirm an image is returned and `proxy_logs` records usage.

## Notes

- No streaming — image generation is request/response only, handled by the non-streaming branch of `dispatchUpstream`.
- Image editing (`/v1/images/edits`) and variations (`/v1/images/variations`) are out of scope for this issue (Tier 2); `HandleImagesEdits` already exists, `HandleImagesVariations` returns 400.
- `go build ./...` reports a pre-existing `web/embed.go: pattern dist: no matching files found` error (the React SPA `web/dist/` must be built with `cd web && npm ci && npm run build:web` before a full build). This is unrelated to this change and affects no Go package.