### PR TITLE
feat(checkin): edge-case polish — self-heal, catch-up, timeout, lease

### DIFF
--- a/scheduler/checkin.go
+++ b/scheduler/checkin.go
@@ -144,6 +144,13 @@ func (s *CheckinScheduler) startLocked() {
 // maybeCatchUpCheckin queries whether today's scheduled check-in already
 // passed without a run and, if so, triggers an immediate run (guarded by the
 // scheduler lease like every other run). Idempotent by construction.
+//
+// When the global catch-up does not apply (today's run already happened, or
+// the trigger is still ahead), it falls back to a per-account stale catch-up
+// (issue #669): enqueue accounts whose last_checkin_at is nil or older than
+// 24h. This covers cases the global "ranToday" gate misses — e.g. an account
+// was added mid-day, recovered after a transient failure, or was skipped by
+// an aborted prior run while other accounts succeeded.
 func (s *CheckinScheduler) maybeCatchUpCheckin() {
 	dbw := store.GetDB()
 	if dbw == nil {
@@ -163,11 +170,65 @@ func (s *CheckinScheduler) maybeCatchUpCheckin() {
 		return
 	}
 
-	if !shouldCatchUpCheckin(now, s.cfg.CheckinCron, ranToday > 0, enabled) {
+	if shouldCatchUpCheckin(now, s.cfg.CheckinCron, ranToday > 0, enabled) {
+		slog.Info("checkin: missed today's scheduled time, compensating with immediate run", "spec", s.cfg.CheckinCron)
+		go s.runCronJob()
 		return
 	}
-	slog.Info("checkin: missed today's scheduled time, compensating with immediate run", "spec", s.cfg.CheckinCron)
-	go s.runCronJob()
+
+	// Per-account catch-up (issue #669). Runs in a goroutine so startup is
+	// not blocked; pacing and the per-account lease are reused via CheckinAll.
+	go s.runStaleAccountCatchUp(dbw)
+}
+
+// runStaleAccountCatchUp enqueues an immediate checkin for every enabled,
+// active account whose last_checkin_at is nil/empty or older than 24h. Shares
+// the scheduler lease with cron/interval runs so a concurrent tick cannot
+// double-run. CheckinAll's same-site pacing and CheckinAccount's per-account
+// lease apply unchanged (issue #669).
+func (s *CheckinScheduler) runStaleAccountCatchUp(dbw *store.DB) {
+	staleIDs, err := selectStaleCheckinAccountIDs(dbw, time.Now().Add(-24*time.Hour).UTC().Format(time.RFC3339))
+	if err != nil {
+		slog.Warn("checkin stale catch-up: query failed", "error", err)
+		return
+	}
+	if len(staleIDs) == 0 {
+		return
+	}
+	slog.Info("checkin: stale account catch-up", "count", len(staleIDs))
+	runWithSchedulerLease(context.Background(), dbw, s.Name(), func() {
+		results := checkin.CheckinAll(s.cfg, dbw.DB, staleIDs, "catchup")
+		ok, bad := countResults(results)
+		slog.Info("checkin: stale account catch-up done", "enqueued", len(staleIDs), "success", ok, "failed", bad)
+	})
+}
+
+// selectStaleCheckinAccountIDs returns IDs of enabled, active accounts on
+// non-disabled sites whose last_checkin_at is nil/empty or older than the
+// cutoff (RFC3339). Pure query — pacing and execution happen via CheckinAll.
+// String comparison of RFC3339 timestamps is chronological because both
+// last_checkin_at and the cutoff are persisted in UTC.
+func selectStaleCheckinAccountIDs(dbw *store.DB, cutoffRFC3339 string) ([]int64, error) {
+	rows, err := dbw.Query(`
+		SELECT a.id FROM accounts a
+		INNER JOIN sites s ON a.site_id = s.id
+		WHERE a.checkin_enabled = TRUE AND a.status = 'active' AND s.status <> 'disabled'
+		  AND (a.last_checkin_at IS NULL OR a.last_checkin_at = '' OR a.last_checkin_at < ?)
+	`, cutoffRFC3339)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
 }
 
 func (s *CheckinScheduler) stopLocked() {

--- a/scheduler/checkin_catchup_stale_test.go
+++ b/scheduler/checkin_catchup_stale_test.go
@@ -1,0 +1,144 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// ---- issue #669: restart catch-up (per-account stale enqueue) ----
+//
+// selectStaleCheckinAccountIDs must return only enabled, active accounts on
+// non-disabled sites whose last_checkin_at is nil/empty or older than the
+// 24h cutoff. This complements the global "ranToday" catch-up for cases where
+// some accounts ran today but others are stale (newly added, recovered after a
+// transient failure, missed by an aborted prior run).
+
+func setupStaleCatchUpDB(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("auto-migrate: %v", err)
+	}
+	return db
+}
+
+func insertStaleCatchUpSite(t *testing.T, db *store.DB, name, status string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		"INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, 'new-api', ?, ?, ?)",
+		name, "https://"+name+".example.test", status, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site %s: %v", name, err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+	return id
+}
+
+func insertStaleCatchUpAccount(t *testing.T, db *store.DB, siteID int64, username, status, lastCheckinAt string, enabled bool) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	enabledArg := any(1)
+	if !enabled {
+		enabledArg = 0
+	}
+	res, err := db.Exec(
+		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, last_checkin_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+		siteID, username, "sk-"+username, status, enabledArg, nullableStr(lastCheckinAt), now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account %s: %v", username, err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("account id: %v", err)
+	}
+	return id
+}
+
+// nullableStr returns the empty string as a SQL NULL (nil) and otherwise the
+// literal value — sqlite stores '' and NULL distinctly, and the stale query
+// treats both as "no checkin yet".
+func nullableStr(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func TestSelectStaleCheckinAccountIDs_PicksNilAndOldSkipsRecentAndDisabled(t *testing.T) {
+	db := setupStaleCatchUpDB(t)
+	activeSite := insertStaleCatchUpSite(t, db, "active-site", "active")
+
+	cutoff := time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)
+	recent := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	veryOld := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	// Stale: nil last_checkin_at → must be picked up.
+	nilID := insertStaleCatchUpAccount(t, db, activeSite, "nil-account", "active", "", true)
+	// Stale: older than 24h → must be picked up.
+	oldID := insertStaleCatchUpAccount(t, db, activeSite, "old-account", "active", veryOld, true)
+	// Not stale: checked in recently → must be skipped.
+	insertStaleCatchUpAccount(t, db, activeSite, "recent-account", "active", recent, true)
+	// Not eligible: account disabled → must be skipped even though stale.
+	insertStaleCatchUpAccount(t, db, activeSite, "disabled-account", "disabled", "", true)
+	// Not eligible: checkin disabled → must be skipped even though stale.
+	insertStaleCatchUpAccount(t, db, activeSite, "checkin-off-account", "active", "", false)
+	// Stale: very old → must be picked up.
+	staleID := insertStaleCatchUpAccount(t, db, activeSite, "very-old-account", "active", veryOld, true)
+
+	// Disabled site: account must be skipped even if otherwise stale.
+	disabledSite := insertStaleCatchUpSite(t, db, "disabled-site", "disabled")
+	insertStaleCatchUpAccount(t, db, disabledSite, "disabled-site-account", "active", "", true)
+
+	ids, err := selectStaleCheckinAccountIDs(db, cutoff)
+	if err != nil {
+		t.Fatalf("selectStaleCheckinAccountIDs: %v", err)
+	}
+
+	want := map[int64]bool{nilID: true, oldID: true, staleID: true}
+	if len(ids) != len(want) {
+		t.Fatalf("got %d ids %v, want %d %v", len(ids), ids, len(want), keysOf(want))
+	}
+	for _, id := range ids {
+		if !want[id] {
+			t.Errorf("unexpected stale id %d (want %v)", id, keysOf(want))
+		}
+	}
+}
+
+func TestSelectStaleCheckinAccountIDs_EmptyWhenAllRecent(t *testing.T) {
+	db := setupStaleCatchUpDB(t)
+	siteID := insertStaleCatchUpSite(t, db, "all-recent-site", "active")
+	recent := time.Now().Add(-30 * time.Minute).UTC().Format(time.RFC3339)
+	cutoff := time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)
+
+	insertStaleCatchUpAccount(t, db, siteID, "a", "active", recent, true)
+	insertStaleCatchUpAccount(t, db, siteID, "b", "active", recent, true)
+
+	ids, err := selectStaleCheckinAccountIDs(db, cutoff)
+	if err != nil {
+		t.Fatalf("selectStaleCheckinAccountIDs: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("got %d stale ids %v, want none (all recent)", len(ids), ids)
+	}
+}
+
+func keysOf(m map[int64]bool) []int64 {
+	out := make([]int64, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/service/checkin/checkin.go
+++ b/service/checkin/checkin.go
@@ -53,6 +53,42 @@ type CheckinAllResult struct {
 	Result    CheckinResult
 }
 
+// checkinTimeout bounds a single adapter checkin call so a hung upstream
+// cannot block the worker indefinitely (issue #669). The existing
+// withProbeTimeout (5s) is for Detect; checkin needs a longer budget because
+// NewApi-family adapters fall back through Bearer → cookie → sign_in paths.
+// Declared as a var (not const) so tests can override it to assert enforcement
+// without sleeping for 30s.
+var checkinTimeout = 30 * time.Second
+
+// checkinInProgress is a process-local set of account IDs currently being
+// checked in. It prevents the scheduler and a concurrent admin manual trigger
+// from double-running the same account simultaneously (issue #669). The
+// scheduler-level runWithSchedulerLease guards against multi-instance
+// double-runs; this map guards the in-process per-account case.
+var checkinInProgress sync.Map // accountID int64 -> struct{}
+
+// tryAcquireCheckinLease attempts to mark accountID as in-progress. It returns
+// true when this caller now owns the lease (and must call releaseCheckinLease),
+// false when another checkin for the same account is already running.
+func tryAcquireCheckinLease(accountID int64) bool {
+	_, loaded := checkinInProgress.LoadOrStore(accountID, struct{}{})
+	return !loaded
+}
+
+// releaseCheckinLease clears the in-progress marker for accountID. Safe to
+// call unconditionally from a defer; a second release is a no-op.
+func releaseCheckinLease(accountID int64) {
+	checkinInProgress.Delete(accountID)
+}
+
+// checkinContext derives a per-account checkin context bounded by
+// checkinTimeout so a hung upstream cannot block the worker indefinitely
+// (issue #669). Mirrors the existing withProbeTimeout (5s) used for Detect.
+func checkinContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, checkinTimeout)
+}
+
 // IsSiteDisabled checks if a site status represents "disabled".
 func IsSiteDisabled(status string) bool {
 	normalized := strings.TrimSpace(status)
@@ -210,6 +246,18 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 		options = &CheckinOptions{}
 	}
 
+	// 0. Per-account in-progress lease: ensure the scheduler and a concurrent
+	// admin manual trigger cannot double-run the same account simultaneously
+	// (issue #669). Process-local; the scheduler-level advisory lock already
+	// guards multi-instance runs. Released on every return path below.
+	if !tryAcquireCheckinLease(accountID) {
+		return CheckinResult{
+			Success: true, Status: CheckinSkipped, Skipped: true,
+			Reason: "already_in_progress", Message: "checkin already in progress for this account",
+		}
+	}
+	defer releaseCheckinLease(accountID)
+
 	// 1. Load account + site
 	aws, err := service.GetAccountWithSiteByID(db, accountID)
 	if err != nil {
@@ -308,19 +356,32 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 	platformUserID := service.ResolvePlatformUserID(account.ExtraConfig, account.Username)
 	proxyConfig := service.BuildPlatformProxyConfig(cfg, account, site)
 
+	// Per-account checkin timeout (issue #669): a hung upstream must not block
+	// the worker indefinitely. The budget covers the NewApi Bearer → cookie →
+	// sign_in fallback chain; Detect still uses its own 5s withProbeTimeout.
+	ctx, cancel := checkinContext(context.Background())
+	defer cancel()
+
 	// 5. First checkin attempt
 	activeAccessToken := account.AccessToken
-	result, err := adp.Checkin(context.Background(), site.URL, activeAccessToken, platformUserIDPtr(platformUserID), proxyConfig)
+	result, err := adp.Checkin(ctx, site.URL, activeAccessToken, platformUserIDPtr(platformUserID), proxyConfig)
 	if err != nil {
 		result = &platform.CheckinResult{Success: false, Message: err.Error()}
 	}
 
-	// 6. Auto-relogin on failure
-	if !result.Success && shouldAttemptAutoRelogin(result.Message) {
+	// 6. Auth self-heal: on token-expiry signals OR a classified ClassAuth
+	// failure (401/403 with auth residual), attempt ONE re-login to refresh
+	// the session token, then retry the checkin once. Handles session expiry
+	// between scheduled runs (issue #669). If re-login fails or the adapter
+	// does not support login, the original auth error propagates unchanged.
+	if !result.Success && shouldAttemptSelfHealLogin(result.Message, adp) {
+		slog.Info("[checkin] session expired, attempting re-login", "accountID", account.ID)
 		refreshedToken, reloginErr := tryAutoRelogin(cfg, db, account, site)
-		if reloginErr == nil && refreshedToken != "" {
+		if reloginErr != nil {
+			slog.Warn("checkin: re-login failed; surfacing original auth error", "accountID", account.ID, "error", reloginErr)
+		} else if refreshedToken != "" {
 			activeAccessToken = refreshedToken
-			result, err = adp.Checkin(context.Background(), site.URL, activeAccessToken, platformUserIDPtr(platformUserID), proxyConfig)
+			result, err = adp.Checkin(ctx, site.URL, activeAccessToken, platformUserIDPtr(platformUserID), proxyConfig)
 			if err != nil {
 				result = &platform.CheckinResult{Success: false, Message: err.Error()}
 			}
@@ -334,7 +395,7 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 	// are NOT retried — they require operator intervention. Max 1 retry.
 	if shouldRetryTransient(result) {
 		time.Sleep(transientRetryBackoff())
-		result, err = adp.Checkin(context.Background(), site.URL, activeAccessToken, platformUserIDPtr(platformUserID), proxyConfig)
+		result, err = adp.Checkin(ctx, site.URL, activeAccessToken, platformUserIDPtr(platformUserID), proxyConfig)
 		if err != nil {
 			result = &platform.CheckinResult{Success: false, Message: err.Error()}
 		}
@@ -639,6 +700,42 @@ func shouldRetryTransient(result *platform.CheckinResult) bool {
 		return false
 	}
 	return platform.ClassifyUpstreamError(0, result.Message) == platform.ClassTransient
+}
+
+// adapterSupportsLogin reports whether adp can perform a real (network-backed)
+// Login to refresh an expired session. StandardAdapter-based adapters and
+// Sub2Api return a hardcoded "unsupported" message from Login without any
+// network call, so re-login would always no-op. NewApi, the OneApi family
+// and Veloera inherit BaseAdapter.Login (real POST /api/user/login) or
+// override it. Unknown adapters default to true: a re-login attempt against
+// an unsupported adapter is a cheap non-network no-op (issue #669).
+func adapterSupportsLogin(adp platform.PlatformAdapter) bool {
+	switch a := adp.(type) {
+	case *platform.Sub2ApiAdapter:
+		// JWT-only; Login always returns unsupported without a network call.
+		return false
+	case *platform.StandardAdapter:
+		return a.LoginUnsupportedMessage == ""
+	case *platform.OpenAiAdapter, *platform.ClaudeAdapter, *platform.GeminiAdapter,
+		*platform.GeminiCliAdapter, *platform.AntigravityAdapter,
+		*platform.CodexAdapter, *platform.CliProxyApiAdapter:
+		// All StandardAdapter-based with Login explicitly unsupported.
+		return false
+	}
+	return true
+}
+
+// shouldAttemptSelfHealLogin reports whether CheckinAccount should attempt a
+// single re-login before retrying the checkin. True for confirmed token-expiry
+// signals (the legacy shouldAttemptAutoRelogin path) OR for a classified
+// ClassAuth failure (401/403 with auth residual) when the adapter can actually
+// re-login. ClassAuth covers session-expiry-between-runs cases the legacy
+// message-patterns miss (issue #669).
+func shouldAttemptSelfHealLogin(message string, adp platform.PlatformAdapter) bool {
+	if shouldAttemptAutoRelogin(message) {
+		return true
+	}
+	return platform.ClassifyUpstreamError(0, message) == platform.ClassAuth && adapterSupportsLogin(adp)
 }
 
 // sameSitePacingDelay returns a ~1s delay (with minor jitter) used between

--- a/service/checkin/checkin_edge_test.go
+++ b/service/checkin/checkin_edge_test.go
@@ -1,0 +1,509 @@
+package checkin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/platform"
+	"github.com/deliciousbuding/metapi-go/service"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// ---- issue #669: ClassAuth self-heal, per-account timeout, manual-trigger lease ----
+//
+// These tests cover the four edge cases from #669:
+//   - adapterSupportsLogin + shouldAttemptSelfHealLogin (re-login decision)
+//   - end-to-end re-login mock: 401 → re-login → retry succeeds
+//   - per-account timeout enforcement (hung upstream bounded by checkinTimeout)
+//   - per-account in-progress lease contention (scheduler vs manual trigger)
+
+// TestAdapterSupportsLogin pins the capability detection against every
+// registered adapter. NewApi / OneApi family / Veloera support a real login
+// (BaseAdapter.Login POST /api/user/login or override); StandardAdapter-based
+// adapters and Sub2Api return a hardcoded unsupported message without a
+// network call, so re-login would always no-op.
+func TestAdapterSupportsLogin(t *testing.T) {
+	cases := []struct {
+		platformName string
+		want         bool
+	}{
+		{"new-api", true},
+		{"one-api", true},
+		{"one-hub", true},
+		{"done-hub", true},
+		{"veloera", true},
+		{"sub2api", false},
+		{"openai", false},
+		{"claude", false},
+		{"gemini", false},
+		{"gemini-cli", false},
+		{"antigravity", false},
+		{"codex", false},
+		{"cliproxyapi", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.platformName, func(t *testing.T) {
+			adp := platform.GetAdapter(tc.platformName)
+			if adp == nil {
+				t.Fatalf("no adapter registered for %q", tc.platformName)
+			}
+			if got := adapterSupportsLogin(adp); got != tc.want {
+				t.Errorf("adapterSupportsLogin(%s) = %v, want %v", tc.platformName, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShouldAttemptSelfHealLogin pins the re-login trigger predicate. A
+// ClassAuth failure (401/403 with auth residual) triggers re-login ONLY when
+// the adapter can actually re-login. Confirmed token-expiry signals trigger
+// regardless of adapter (legacy shouldAttemptAutoRelogin path). Transient /
+// billing / unknown failures never trigger re-login.
+func TestShouldAttemptSelfHealLogin(t *testing.T) {
+	newapi := platform.GetAdapter("new-api")   // supports login
+	sub2api := platform.GetAdapter("sub2api") // JWT-only, no login
+	if newapi == nil || sub2api == nil {
+		t.Fatal("required adapters not registered")
+	}
+
+	cases := []struct {
+		name          string
+		message       string
+		wantNewApi    bool
+		wantSub2Api   bool
+		wantClassNew  platform.UpstreamErrorClass
+	}{
+		// ClassAuth (401/403 with auth residual) → re-login only on supporting adapter.
+		// NOTE: avoid "access token invalid" wording — that is a confirmed
+		// credential-expiry signal and classifies as ClassExpired, not ClassAuth.
+		{"http 401 unauthorized", "HTTP 401: unauthorized", true, false, platform.ClassAuth},
+		{"http 403 forbidden", "HTTP 403: forbidden", true, false, platform.ClassAuth},
+		// Confirmed token-expiry → legacy path fires on every adapter.
+		{"jwt expired", "jwt expired", true, true, platform.ClassExpired},
+		{"invalid access token", "invalid access token", true, true, platform.ClassExpired},
+		// Transient / billing / unknown → never re-login.
+		{"rate limit", "HTTP 429: rate limit exceeded", false, false, platform.ClassTransient},
+		{"billing", "insufficient quota", false, false, platform.ClassBilling},
+		{"unknown opaque", "some opaque upstream error", false, false, platform.ClassUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotClass := platform.ClassifyUpstreamError(0, tc.message)
+			if gotClass != tc.wantClassNew {
+				t.Errorf("ClassifyUpstreamError(%q) = %s, want %s", tc.message, gotClass, tc.wantClassNew)
+			}
+			if got := shouldAttemptSelfHealLogin(tc.message, newapi); got != tc.wantNewApi {
+				t.Errorf("shouldAttemptSelfHealLogin(%q, new-api) = %v, want %v", tc.message, got, tc.wantNewApi)
+			}
+			if got := shouldAttemptSelfHealLogin(tc.message, sub2api); got != tc.wantSub2Api {
+				t.Errorf("shouldAttemptSelfHealLogin(%q, sub2api) = %v, want %v", tc.message, got, tc.wantSub2Api)
+			}
+		})
+	}
+}
+
+// TestCheckinTimeoutDefaultBudget documents the per-account checkin budget and
+// guards against accidental changes. 30s mirrors the issue #669 spec.
+func TestCheckinTimeoutDefaultBudget(t *testing.T) {
+	if checkinTimeout != 30*time.Second {
+		t.Fatalf("checkinTimeout = %v, want 30s", checkinTimeout)
+	}
+}
+
+// TestCheckinContextEnforcesDeadline verifies the per-account context wrapper
+// derives a deadline bounded by checkinTimeout (issue #669: per-account timeout).
+func TestCheckinContextEnforcesDeadline(t *testing.T) {
+	original := checkinTimeout
+	checkinTimeout = 250 * time.Millisecond
+	t.Cleanup(func() { checkinTimeout = original })
+
+	ctx, cancel := checkinContext(context.Background())
+	defer cancel()
+	dl, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("checkinContext produced a context with no deadline")
+	}
+	got := time.Until(dl)
+	if got <= 0 || got > 260*time.Millisecond {
+		t.Fatalf("deadline lead = %v, want ~250ms (0 < lead <= 260ms)", got)
+	}
+}
+
+// TestCheckinLeaseContention verifies the per-account in-progress lease is
+// mutually exclusive for a single account and re-entrant after release
+// (issue #669: manual-trigger lease).
+func TestCheckinLeaseContention(t *testing.T) {
+	const accountID int64 = 77799
+	checkinInProgress.Delete(accountID)
+	t.Cleanup(func() { checkinInProgress.Delete(accountID) })
+
+	if !tryAcquireCheckinLease(accountID) {
+		t.Fatal("first acquire failed on a free lease")
+	}
+	if tryAcquireCheckinLease(accountID) {
+		t.Fatal("second acquire succeeded while lease is held")
+	}
+	releaseCheckinLease(accountID)
+	if !tryAcquireCheckinLease(accountID) {
+		t.Fatal("acquire after release failed")
+	}
+	releaseCheckinLease(accountID)
+}
+
+// TestCheckinLeaseOnlyOneAcquiresUnderConcurrency hammers the lease from many
+// goroutines and asserts exactly one acquires (issue #669: lease contention).
+func TestCheckinLeaseOnlyOneAcquiresUnderConcurrency(t *testing.T) {
+	const accountID int64 = 88899
+	checkinInProgress.Delete(accountID)
+	t.Cleanup(func() { checkinInProgress.Delete(accountID) })
+
+	start := make(chan struct{})
+	var acquired atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if tryAcquireCheckinLease(accountID) {
+				acquired.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if got := acquired.Load(); got != 1 {
+		t.Fatalf("acquired = %d, want exactly 1", got)
+	}
+	releaseCheckinLease(accountID)
+}
+
+// ---- End-to-end re-login mock (issue #669: ClassAuth self-heal) ----
+//
+// A new-api account with an expired access token and a stored auto-relogin
+// config. The upstream returns 401 on the first checkin (expired token),
+// then a fresh token from /api/user/login, then 200 on the retried checkin.
+// CheckinAccount must: detect ClassAuth → re-login → retry once → succeed,
+// and persist the refreshed access token to the DB.
+
+func newSelfHealReloginServer(t *testing.T) (*httptest.Server, *[]string) {
+	t.Helper()
+	var seenTokens []string
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/user/checkin":
+			token := r.Header.Get("Authorization")
+			mu.Lock()
+			seenTokens = append(seenTokens, token)
+			mu.Unlock()
+			if token == "Bearer expired-token" {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"success":false,"message":"unauthorized"}`))
+				return
+			}
+			if token == "Bearer fresh-token" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"success":true,"message":"checkin success","data":{"reward":"5"}}`))
+				return
+			}
+			http.Error(w, `{"success":false,"message":"bad token"}`, http.StatusUnauthorized)
+		case "/api/user/login":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true,"message":"登录成功","token":"fresh-token"}`))
+		case "/api/user/self":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true,"data":{"username":"relogin-user","id":1}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, &seenTokens
+}
+
+func TestCheckinAccount_AuthSelfHeal_RetriesAfterRelogin(t *testing.T) {
+	db := openCheckinEdgeTestDB(t)
+	cfg := &config.Config{AccountCredentialSecret: "edge-test-secret"}
+
+	upstream, seenTokens := newSelfHealReloginServer(t)
+	siteID := insertEdgeSite(t, db, upstream.URL, "new-api")
+
+	cipher, err := service.EncryptAccountPassword(cfg, "relogin-password")
+	if err != nil {
+		t.Fatalf("encrypt password: %v", err)
+	}
+	extraConfig := buildEdgeExtraConfig(t, 1, "relogin-user", cipher)
+	accountID := insertEdgeAccount(t, db, siteID, "expired-token", extraConfig)
+
+	result := CheckinAccount(cfg, db.DB, accountID, &CheckinOptions{SkipEvent: true, ScheduleMode: "manual"})
+
+	if !result.Success || result.Status != CheckinSuccess {
+		t.Fatalf("CheckinAccount result = %+v, want success", result)
+	}
+
+	// Re-login must have refreshed the stored access token.
+	var storedToken string
+	if err := db.Get(&storedToken, "SELECT access_token FROM accounts WHERE id = ?", accountID); err != nil {
+		t.Fatalf("read access_token: %v", err)
+	}
+	if storedToken != "fresh-token" {
+		t.Fatalf("access_token = %q, want %q (re-login did not persist)", storedToken, "fresh-token")
+	}
+
+	// The retried checkin must have used the refreshed token. The new-api
+	// adapter also falls back to cookie-based checkin on a 401 (extra calls
+	// with an empty Authorization header), so the exact call count is
+	// adapter-dependent — what matters is that the fresh token was eventually
+	// used for the successful retry.
+	seen := *seenTokens
+	last := ""
+	if len(seen) > 0 {
+		last = seen[len(seen)-1]
+	}
+	if last != "Bearer fresh-token" {
+		t.Fatalf("last checkin token = %q, want %q (re-login retry did not use fresh token). seen=%v", last, "Bearer fresh-token", seen)
+	}
+	if !containsString(seen, "Bearer fresh-token") {
+		t.Fatalf("fresh token never used for checkin; seen=%v", seen)
+	}
+}
+
+// TestCheckinAccount_AuthSelfHeal_NoReloginConfigSurfacesOriginalError verifies
+// that when a ClassAuth failure occurs but no auto-relogin config is stored,
+// CheckinAccount surfaces the original auth error unchanged (no fabricated error).
+func TestCheckinAccount_AuthSelfHeal_NoReloginConfigSurfacesOriginalError(t *testing.T) {
+	db := openCheckinEdgeTestDB(t)
+	cfg := &config.Config{AccountCredentialSecret: "edge-test-secret"}
+
+	upstream, seenTokens := newSelfHealReloginServer(t)
+	siteID := insertEdgeSite(t, db, upstream.URL, "new-api")
+	// No autoRelogin in extra_config → tryAutoRelogin bails before calling Login.
+	accountID := insertEdgeAccount(t, db, siteID, "expired-token", buildEdgeExtraConfig(t, 1, "", ""))
+
+	result := CheckinAccount(cfg, db.DB, accountID, &CheckinOptions{SkipEvent: true, ScheduleMode: "manual"})
+
+	if result.Success {
+		t.Fatalf("CheckinAccount result = %+v, want failure", result)
+	}
+	if result.Status != CheckinFailed {
+		t.Fatalf("status = %v, want failed", result.Status)
+	}
+	// Original auth error must propagate (not a fabricated "login failed" string).
+	if result.Message == "" {
+		t.Fatal("result message empty; want the original 401 auth error")
+	}
+	// Without a stored relogin config, tryAutoRelogin bails before calling
+	// Login, so the refreshed token must NEVER be used for a checkin retry.
+	// (The new-api adapter may internally fall back to cookie-based checkin on
+	// a 401 — those calls carry an empty Authorization header, not the fresh
+	// token — so the precise call count is adapter-dependent.)
+	if containsString(*seenTokens, "Bearer fresh-token") {
+		t.Fatalf("fresh token was used for a checkin retry even though no relogin config was stored. seen=%v", *seenTokens)
+	}
+}
+
+// ---- Per-account timeout enforcement (issue #669) ----
+//
+// A hung upstream that never responds must not block the worker indefinitely.
+// With checkinTimeout overridden to a short budget, CheckinAccount must return
+// within that budget rather than hanging for the server's long sleep.
+
+func newHangingCheckinServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/user/checkin" {
+			select {
+			case <-time.After(5 * time.Second):
+			case <-r.Context().Done():
+			}
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestCheckinAccount_PerAccountTimeoutEnforced(t *testing.T) {
+	db := openCheckinEdgeTestDB(t)
+	cfg := &config.Config{AccountCredentialSecret: "edge-test-secret"}
+
+	original := checkinTimeout
+	checkinTimeout = 400 * time.Millisecond
+	t.Cleanup(func() { checkinTimeout = original })
+
+	upstream := newHangingCheckinServer(t)
+	siteID := insertEdgeSite(t, db, upstream.URL, "new-api")
+	accountID := insertEdgeAccount(t, db, siteID, "some-token", buildEdgeExtraConfig(t, 1, "", ""))
+
+	start := time.Now()
+	result := CheckinAccount(cfg, db.DB, accountID, &CheckinOptions{SkipEvent: true, ScheduleMode: "manual"})
+	elapsed := time.Since(start)
+
+	if result.Success {
+		t.Fatalf("CheckinAccount succeeded against a hanging upstream; result = %+v", result)
+	}
+	// Must return well within the 5s server sleep — bounded by the 400ms timeout.
+	if elapsed > 2*time.Second {
+		t.Fatalf("elapsed = %v, want < 2s (per-account timeout did not bound the hung call)", elapsed)
+	}
+}
+
+// ---- Manual-trigger lease contention at the CheckinAccount level (issue #669) ----
+//
+// Two concurrent CheckinAccount calls for the same account must not double-run
+// the upstream checkin: one proceeds, the other returns already_in_progress.
+
+func newSlowCheckinServer(t *testing.T, delay time.Duration) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/user/checkin":
+			calls.Add(1)
+			time.Sleep(delay)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true,"message":"checkin success","data":{"reward":"5"}}`))
+		case "/api/user/self":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true,"data":{"username":"edge-user","id":1}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, &calls
+}
+
+func TestCheckinAccount_LeaseSkipsConcurrentManualTrigger(t *testing.T) {
+	db := openCheckinEdgeTestDB(t)
+	cfg := &config.Config{AccountCredentialSecret: "edge-test-secret"}
+
+	upstream, upstreamCalls := newSlowCheckinServer(t, 400*time.Millisecond)
+	siteID := insertEdgeSite(t, db, upstream.URL, "new-api")
+	accountID := insertEdgeAccount(t, db, siteID, "session-token", buildEdgeExtraConfig(t, 1, "", ""))
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var results []CheckinResult
+	var mu sync.Mutex
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			r := CheckinAccount(cfg, db.DB, accountID, &CheckinOptions{SkipEvent: true, ScheduleMode: "manual"})
+			mu.Lock()
+			results = append(results, r)
+			mu.Unlock()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	var successes, alreadyInProgress int
+	for _, r := range results {
+		switch {
+		case r.Success && r.Status == CheckinSuccess:
+			successes++
+		case r.Skipped && r.Reason == "already_in_progress":
+			alreadyInProgress++
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("successes = %d, want 1 (results: %+v)", successes, results)
+	}
+	if alreadyInProgress != 1 {
+		t.Fatalf("already_in_progress = %d, want 1 (results: %+v)", alreadyInProgress, results)
+	}
+	// The upstream checkin endpoint must have been hit exactly once — the
+	// leased-out call never reached the adapter a second time.
+	if got := upstreamCalls.Load(); got != 1 {
+		t.Fatalf("upstream checkin calls = %d, want 1 (lease failed to prevent double-run)", got)
+	}
+}
+
+// ---- helpers ----
+
+func openCheckinEdgeTestDB(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("auto-migrate: %v", err)
+	}
+	return db
+}
+
+func insertEdgeSite(t *testing.T, db *store.DB, siteURL, platformName string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	result, err := db.Exec(
+		"INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, ?, 'active', ?, ?)",
+		"Edge Checkin "+platformName, siteURL, platformName, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+	return id
+}
+
+func insertEdgeAccount(t *testing.T, db *store.DB, siteID int64, accessToken, extraConfig string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	result, err := db.Exec(
+		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, 'active', 1, ?, ?, ?)",
+		siteID, "edge-user", accessToken, extraConfig, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("account id: %v", err)
+	}
+	return id
+}
+
+// buildEdgeExtraConfig builds an extra_config JSON with platformUserId and,
+// when username+passwordCipher are non-empty, an autoRelogin block.
+func buildEdgeExtraConfig(t *testing.T, platformUserID int, username, passwordCipher string) string {
+	t.Helper()
+	cfg := map[string]any{"platformUserId": float64(platformUserID)}
+	if username != "" && passwordCipher != "" {
+		cfg["autoRelogin"] = map[string]any{
+			"username":       username,
+			"passwordCipher": passwordCipher,
+		}
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal extra_config: %v", err)
+	}
+	return string(raw)
+}
+
+// containsString reports whether the slice contains the target string.
+func containsString(slice []string, target string) bool {
+	for _, s := range slice {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #669.

## Summary

Four lightweight edge cases layered on top of the #691 (already-claimed idempotency) and #692 (same-site pacing + transient retry) work:

- **ClassAuth self-heal** — when a checkin failure classifies as `ClassAuth` (401/403 with auth residual) and the adapter can actually re-login (`adapterSupportsLogin`), attempt ONE re-login to refresh the session token then retry the checkin once. Covers session expiry between scheduled runs that the legacy token-expiry message patterns miss. Re-login failure surfaces the original auth error unchanged.
- **Restart catch-up** — on startup, in addition to the global "missed today's scheduled time" catch-up, enqueue an immediate checkin for accounts whose `last_checkin_at` is nil/empty or older than 24h. Handles per-account staleness the global `ranToday` gate misses (newly added, recovered after a transient failure, skipped by an aborted prior run). Reuses `CheckinAll` same-site pacing and the scheduler lease.
- **Per-account timeout** — wrap every adapter checkin call in `context.WithTimeout(checkinTimeout = 30s)` so a hung upstream cannot block the worker indefinitely. Detect still uses its own 5s `withProbeTimeout`. Declared as a var so tests can override.
- **Manual-trigger lease** — package-level `sync.Map` (`checkinInProgress`) of in-progress account IDs acquired at the top of `CheckinAccount`. Both the scheduler (`CheckinAll`) and the admin manual trigger (`triggerOne`/`triggerAll`) consult it, so a concurrent manual + scheduled run of the same account cannot double-run. Returns a skipped `already_in_progress` result on contention. Process-local; the scheduler advisory lock still guards multi-instance runs.

### Notes / deviations
- `checkinTimeout` is a package-level `var` (not `const`) so the timeout-enforcement test can override it to a short budget without sleeping 30s. Runtime value is `30 * time.Second` as specified.
- The manual-trigger lease is implemented inside `CheckinAccount` itself, so all three callers (scheduler `CheckinAll`, `triggerOne`, `triggerAll`) are covered by one mechanism — no handler changes needed.
- The existing global catch-up (`maybeCatchUpCheckin`) is preserved; the per-account stale catch-up only runs when the global catch-up does not fire (it returns early after triggering the global run, which already covers everyone).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./service/checkin/... ./scheduler/... ./handler/... -race` — clean, no data races
- [x] `TestAdapterSupportsLogin` — capability detection pinned against all 13 registered adapters
- [x] `TestShouldAttemptSelfHealLogin` — re-login trigger predicate across ClassAuth / ClassExpired / ClassTransient / ClassBilling / ClassUnknown × supporting/unsupported adapter
- [x] `TestCheckinAccount_AuthSelfHeal_RetriesAfterRelogin` — end-to-end: 401 → re-login → retry succeeds, refreshed token persisted
- [x] `TestCheckinAccount_AuthSelfHeal_NoReloginConfigSurfacesOriginalError` — no relogin config → original auth error surfaces, no fresh-token retry
- [x] `TestCheckinAccount_PerAccountTimeoutEnforced` — hung upstream bounded by `checkinTimeout` override (returns in <2s, not 5s)
- [x] `TestCheckinLeaseOnlyOneAcquiresUnderConcurrency` — 50-goroutine race, exactly one acquires
- [x] `TestCheckinAccount_LeaseSkipsConcurrentManualTrigger` — two concurrent `CheckinAccount` calls → one runs, one skipped, upstream hit once
- [x] `TestSelectStaleCheckinAccountIDs_*` — stale query picks nil/old, skips recent/disabled/checkin-off/disabled-site