### PR TITLE
feat(checkin): aggregate round failures into single notification

### DIFF
--- a/service/checkin/checkin.go
+++ b/service/checkin/checkin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -31,8 +32,15 @@ const (
 
 // CheckinOptions configures checkin behavior.
 type CheckinOptions struct {
-	SkipEvent    bool
-	ScheduleMode string // "cron" or "interval"
+	SkipEvent bool
+	// SkipNotification suppresses the per-account failure notifications
+	// ("checkin failed" / "Cloudflare challenge") emitted from CheckinAccount.
+	// Callers that aggregate failures themselves (CheckinAll) set this so a
+	// round produces ONE consolidated notification instead of N per-account
+	// notifications (issue #667). Single-account callers (manual trigger)
+	// leave it false to preserve the existing per-account alert.
+	SkipNotification bool
+	ScheduleMode     string // "cron" or "interval"
 }
 
 // CheckinResult is the result of a single account checkin.
@@ -494,20 +502,25 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 			})
 		}
 
-		if isCloudflare {
-			notifypkg.SendNotification(cfg,
-				"Cloudflare challenge",
-				fmt.Sprintf("%s @ %s: %s", orUsername(account.Username, accountID), site.Name, result.Message),
-				"warning", nil,
-			)
-		}
+		// Per-account failure notifications are suppressed when the caller
+		// aggregates the round itself (CheckinAll → one consolidated alert,
+		// issue #667). Single-account manual triggers leave it on.
+		if !options.SkipNotification {
+			if isCloudflare {
+				notifypkg.SendNotification(cfg,
+					"Cloudflare challenge",
+					fmt.Sprintf("%s @ %s: %s", orUsername(account.Username, accountID), site.Name, result.Message),
+					"warning", nil,
+				)
+			}
 
-		if !unsupportedCheckin && !manualVerificationRequired {
-			notifypkg.SendNotification(cfg,
-				"checkin failed",
-				fmt.Sprintf("%s @ %s: %s", orUsername(account.Username, accountID), site.Name, result.Message),
-				"error", nil,
-			)
+			if !unsupportedCheckin && !manualVerificationRequired {
+				notifypkg.SendNotification(cfg,
+					"checkin failed",
+					fmt.Sprintf("%s @ %s: %s", orUsername(account.Username, accountID), site.Name, result.Message),
+					"error", nil,
+				)
+			}
 		}
 	}
 
@@ -521,7 +534,10 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 }
 
 // CheckinAll performs checkin for all eligible accounts.
-// Mirrors TS checkinAll().
+// Mirrors TS checkinAll(). Per-account failure notifications are suppressed
+// here (SkipNotification) and aggregated into ONE round notification sent at
+// the end (issue #667): a 50-account failure burst now yields a single
+// "Checkin round <id>: N ok, M failed" alert instead of 50 separate ones.
 func CheckinAll(cfg *config.Config, db *sqlx.DB, accountIDs []int64, scheduleMode string) []CheckinAllResult {
 	query := `SELECT a.id AS "accounts.id", a.site_id AS "accounts.site_id", a.username AS "accounts.username",
 		a.access_token AS "accounts.access_token", a.balance AS "accounts.balance",
@@ -597,8 +613,9 @@ func CheckinAll(cfg *config.Config, db *sqlx.DB, accountIDs []int64, scheduleMod
 				}
 				row := rows[idx]
 				result := CheckinAccount(cfg, db, row.Accounts.ID, &CheckinOptions{
-					SkipEvent:    true,
-					ScheduleMode: scheduleMode,
+					SkipEvent:        true,
+					SkipNotification: true,
+					ScheduleMode:     scheduleMode,
 				})
 
 				username := ""
@@ -619,6 +636,8 @@ func CheckinAll(cfg *config.Config, db *sqlx.DB, accountIDs []int64, scheduleMod
 	}
 	wg.Wait()
 
+	sendCheckinRoundNotification(cfg, results)
+
 	return results
 }
 
@@ -627,6 +646,126 @@ func orUsername(username *string, id int64) string {
 		return *username
 	}
 	return fmt.Sprintf("ID:%d", id)
+}
+
+// notifySend is the notification dispatch function used by round aggregation.
+// It defaults to notifypkg.SendNotification; tests swap it to assert call
+// counts and message contents without touching real notification channels.
+var notifySend = notifypkg.SendNotification
+
+// checkinFailure captures a single failed account within a checkin round, for
+// inclusion in the aggregated round notification.
+type checkinFailure struct {
+	accountID   int64
+	accountName string
+	site        string
+	error       string
+}
+
+// checkinRoundResult is the aggregated outcome of one CheckinAll round: the
+// round identifier, the collected failures, and the success count. It backs
+// the single consolidated notification that replaces N per-account alerts.
+type checkinRoundResult struct {
+	roundID   string
+	failures  []checkinFailure
+	successes int
+}
+
+// accountLabel resolves a display name for a CheckinAllResult, falling back
+// to an ID-based label when the username is empty (mirrors orUsername but
+// works off the already-resolved string carried by CheckinAllResult).
+func accountLabel(username string, id int64) string {
+	if strings.TrimSpace(username) != "" {
+		return username
+	}
+	return fmt.Sprintf("ID:%d", id)
+}
+
+// firstLine returns the first line of a message, trimmed of surrounding
+// whitespace. Keeps the aggregated notification body compact when an adapter
+// returns a multi-line error blob.
+func firstLine(message string) string {
+	if idx := strings.IndexByte(message, '\n'); idx >= 0 {
+		return strings.TrimSpace(message[:idx])
+	}
+	return strings.TrimSpace(message)
+}
+
+// buildCheckinRoundResult aggregates CheckinAll results into a round summary.
+// Skipped accounts (unsupported endpoint / manual verification / disabled)
+// are neither successes nor failures for notification purposes. Returns nil
+// when there are no failures, matching the current behavior of NOT alerting
+// on a fully-clean round (all success or all skipped).
+func buildCheckinRoundResult(results []CheckinAllResult) *checkinRoundResult {
+	var failures []checkinFailure
+	successes := 0
+	for _, r := range results {
+		switch r.Result.Status {
+		case CheckinFailed:
+			failures = append(failures, checkinFailure{
+				accountID:   r.AccountID,
+				accountName: accountLabel(r.Username, r.AccountID),
+				site:        r.Site,
+				error:       firstLine(r.Result.Message),
+			})
+		case CheckinSuccess:
+			successes++
+		}
+	}
+	if len(failures) == 0 {
+		return nil
+	}
+	// Deterministic ordering across goroutine scheduling order so the
+	// notification body is stable and diffable.
+	sort.SliceStable(failures, func(i, j int) bool {
+		if failures[i].accountName != failures[j].accountName {
+			return failures[i].accountName < failures[j].accountName
+		}
+		return failures[i].accountID < failures[j].accountID
+	})
+	return &checkinRoundResult{
+		roundID:   time.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		successes: successes,
+		failures:  failures,
+	}
+}
+
+// maxFailuresPerNotification caps how many failure lines are rendered in the
+// body so a 50-account outage stays a readable summary, not a wall of text.
+const maxFailuresPerNotification = 25
+
+// notificationTitle renders the round notification title:
+// "Checkin round <id>: <ok> ok, <failed> failed".
+func (rr *checkinRoundResult) notificationTitle() string {
+	return fmt.Sprintf("Checkin round %s: %d ok, %d failed", rr.roundID, rr.successes, len(rr.failures))
+}
+
+// notificationBody renders one "account @ site: error" line per failure,
+// truncated to maxFailuresPerNotification entries with a tail count.
+func (rr *checkinRoundResult) notificationBody() string {
+	var builder strings.Builder
+	for i, f := range rr.failures {
+		if i > 0 {
+			builder.WriteString("\n")
+		}
+		if i >= maxFailuresPerNotification {
+			fmt.Fprintf(&builder, "…and %d more", len(rr.failures)-maxFailuresPerNotification)
+			break
+		}
+		fmt.Fprintf(&builder, "%s @ %s: %s", f.accountName, f.site, f.error)
+	}
+	return builder.String()
+}
+
+// sendCheckinRoundNotification aggregates a CheckinAll round's results into a
+// single failure notification. No-op on a clean round (no failures). This is
+// the issue #667 fix: one failed round → one notification, not N.
+func sendCheckinRoundNotification(cfg *config.Config, results []CheckinAllResult) {
+	round := buildCheckinRoundResult(results)
+	if round == nil {
+		return
+	}
+	notifySend(cfg, round.notificationTitle(), round.notificationBody(), "error", nil)
 }
 
 // shouldRetryTransient reports whether the current checkin result should be

--- a/service/checkin/round_aggregation_test.go
+++ b/service/checkin/round_aggregation_test.go
@@ -1,0 +1,364 @@
+package checkin
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	notifypkg "github.com/deliciousbuding/metapi-go/service/notify"
+)
+
+// notifyCall records a single invocation of the fake notifySend.
+type notifyCall struct {
+	title   string
+	message string
+	level   string
+}
+
+// swapNotifySend replaces the package-level notifySend with a recorder for the
+// duration of a test and returns the call slice (protected by its own mutex).
+// The original is restored on cleanup.
+func swapNotifySend(t *testing.T) *notifyRecorder {
+	t.Helper()
+	rec := &notifyRecorder{}
+	original := notifySend
+	notifySend = func(cfg *config.Config, title, message, level string, options *notifypkg.SendNotificationOptions) (*notifypkg.DispatchResult, error) {
+		rec.record(title, message, level)
+		return &notifypkg.DispatchResult{}, nil
+	}
+	t.Cleanup(func() { notifySend = original })
+	return rec
+}
+
+type notifyRecorder struct {
+	mu    sync.Mutex
+	calls []notifyCall
+}
+
+func (r *notifyRecorder) record(title, message, level string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, notifyCall{title: title, message: message, level: level})
+}
+
+func (r *notifyRecorder) snapshot() []notifyCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]notifyCall, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+// resultsFixture builds a CheckinAll result slice with the requested number of
+// successes, failures, and skips. Failures get distinct names/messages so the
+// test can assert both appear in the aggregated body.
+func resultsFixture(successes, failures, skips int) []CheckinAllResult {
+	var out []CheckinAllResult
+	for i := 0; i < successes; i++ {
+		out = append(out, CheckinAllResult{
+			AccountID: int64(i) + 1,
+			Username:  "okuser" + itoa(i),
+			Site:      "ok-site",
+			Result:    CheckinResult{Success: true, Status: CheckinSuccess, Message: "checkin success", Reward: "10"},
+		})
+	}
+	for i := 0; i < failures; i++ {
+		// Reverse-insert failures so the pre-sort order is non-alphabetic and
+		// the sort in buildCheckinRoundResult is actually exercised.
+		idx := failures - i
+		out = append(out, CheckinAllResult{
+			AccountID: int64(1000 + idx),
+			Username:  "failuser" + itoa(idx),
+			Site:      "fail-site-" + itoa(idx),
+			Result: CheckinResult{
+				Success: false, Status: CheckinFailed,
+				Message: "HTTP 500: upstream error " + itoa(idx),
+			},
+		})
+	}
+	for i := 0; i < skips; i++ {
+		out = append(out, CheckinAllResult{
+			AccountID: int64(2000 + i + 1),
+			Username:  "skipuser" + itoa(i),
+			Site:      "skip-site",
+			Result:    CheckinResult{Success: true, Status: CheckinSkipped, Skipped: true, Reason: "checkin_not_supported"},
+		})
+	}
+	return out
+}
+
+// itoa is a tiny local int->string to avoid pulling strconv into every fixture.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// ---- buildCheckinRoundResult ----
+
+func TestBuildCheckinRoundResult_ThreeSuccessTwoFailures(t *testing.T) {
+	results := resultsFixture(3, 2, 0)
+	round := buildCheckinRoundResult(results)
+	if round == nil {
+		t.Fatal("expected non-nil round for 2 failures")
+	}
+	if round.successes != 3 {
+		t.Errorf("successes = %d, want 3", round.successes)
+	}
+	if len(round.failures) != 2 {
+		t.Fatalf("failures len = %d, want 2", len(round.failures))
+	}
+
+	// Failures must be sorted by accountName ascending.
+	if round.failures[0].accountName != "failuser1" {
+		t.Errorf("first failure name = %q, want %q (sorted)", round.failures[0].accountName, "failuser1")
+	}
+	if round.failures[1].accountName != "failuser2" {
+		t.Errorf("second failure name = %q, want %q (sorted)", round.failures[1].accountName, "failuser2")
+	}
+
+	// Each failure carries the first-line error and site.
+	for _, f := range round.failures {
+		if f.site == "" {
+			t.Errorf("failure %q has empty site", f.accountName)
+		}
+		if f.error == "" {
+			t.Errorf("failure %q has empty error", f.accountName)
+		}
+	}
+
+	// roundID must be a non-empty UTC timestamp-ish string.
+	if round.roundID == "" || !strings.Contains(round.roundID, "T") {
+		t.Errorf("roundID = %q, want non-empty ISO-ish timestamp", round.roundID)
+	}
+}
+
+func TestBuildCheckinRoundResult_SkipsAreNeitherSuccessNorFailure(t *testing.T) {
+	results := resultsFixture(2, 1, 4) // 2 ok, 1 failed, 4 skipped
+	round := buildCheckinRoundResult(results)
+	if round == nil {
+		t.Fatal("expected non-nil round (1 failure present)")
+	}
+	if round.successes != 2 {
+		t.Errorf("successes = %d, want 2 (skips excluded)", round.successes)
+	}
+	if len(round.failures) != 1 {
+		t.Errorf("failures len = %d, want 1 (skips excluded)", len(round.failures))
+	}
+}
+
+func TestBuildCheckinRoundResult_AllSuccessReturnsNil(t *testing.T) {
+	if round := buildCheckinRoundResult(resultsFixture(5, 0, 0)); round != nil {
+		t.Errorf("expected nil round for clean success round, got %+v", round)
+	}
+}
+
+func TestBuildCheckinRoundResult_AllSkippedReturnsNil(t *testing.T) {
+	// Skipped-only rounds (unsupported endpoints, disabled accounts) must NOT
+	// alert: there is no failure to surface.
+	if round := buildCheckinRoundResult(resultsFixture(0, 0, 3)); round != nil {
+		t.Errorf("expected nil round for all-skipped round, got %+v", round)
+	}
+}
+
+func TestBuildCheckinRoundResult_EmptyResultsReturnsNil(t *testing.T) {
+	if round := buildCheckinRoundResult(nil); round != nil {
+		t.Errorf("expected nil round for nil results, got %+v", round)
+	}
+}
+
+func TestBuildCheckinRoundResult_EmptyUsernameFallsBackToIDLabel(t *testing.T) {
+	results := []CheckinAllResult{{
+		AccountID: 42,
+		Username:  "", // no username → ID:42
+		Site:      "site",
+		Result:    CheckinResult{Success: false, Status: CheckinFailed, Message: "boom"},
+	}}
+	round := buildCheckinRoundResult(results)
+	if round == nil || len(round.failures) != 1 {
+		t.Fatal("expected 1 failure")
+	}
+	if got := round.failures[0].accountName; got != "ID:42" {
+		t.Errorf("accountName = %q, want %q", got, "ID:42")
+	}
+}
+
+func TestBuildCheckinRoundResult_MultiLineErrorTruncatedToFirstLine(t *testing.T) {
+	results := []CheckinAllResult{{
+		AccountID: 1,
+		Username:  "u",
+		Site:      "s",
+		Result: CheckinResult{
+			Success: false, Status: CheckinFailed,
+			Message: "first line of error\nsecond line\nthird line",
+		},
+	}}
+	round := buildCheckinRoundResult(results)
+	if round == nil || len(round.failures) != 1 {
+		t.Fatal("expected 1 failure")
+	}
+	if got := round.failures[0].error; got != "first line of error" {
+		t.Errorf("error = %q, want first line only", got)
+	}
+}
+
+// ---- checkinRoundResult rendering ----
+
+func TestCheckinRoundResult_NotificationTitleFormat(t *testing.T) {
+	round := &checkinRoundResult{
+		roundID:   "2026-08-15T03:00:00Z",
+		successes: 3,
+		failures:  []checkinFailure{{}, {}}, // 2 failures
+	}
+	want := "Checkin round 2026-08-15T03:00:00Z: 3 ok, 2 failed"
+	if got := round.notificationTitle(); got != want {
+		t.Errorf("title = %q, want %q", got, want)
+	}
+}
+
+func TestCheckinRoundResult_NotificationBodyListsEveryFailure(t *testing.T) {
+	round := &checkinRoundResult{
+		successes: 0,
+		failures: []checkinFailure{
+			{accountName: "alpha", site: "siteA", error: "timeout"},
+			{accountName: "beta", site: "siteB", error: "5xx"},
+		},
+	}
+	body := round.notificationBody()
+	if !strings.Contains(body, "alpha @ siteA: timeout") {
+		t.Errorf("body missing alpha line: %q", body)
+	}
+	if !strings.Contains(body, "beta @ siteB: 5xx") {
+		t.Errorf("body missing beta line: %q", body)
+	}
+}
+
+func TestCheckinRoundResult_NotificationBodyTruncatesAtCap(t *testing.T) {
+	// Build maxFailuresPerNotification+5 failures and confirm the cap kicks in
+	// with a trailing "…and 5 more" and that entries beyond the cap are absent.
+	failures := make([]checkinFailure, maxFailuresPerNotification+5)
+	for i := range failures {
+		failures[i] = checkinFailure{
+			accountName: "acct" + itoa(i),
+			site:        "site",
+			error:       "err",
+		}
+	}
+	round := &checkinRoundResult{failures: failures}
+	body := round.notificationBody()
+
+	if !strings.Contains(body, "…and 5 more") {
+		t.Errorf("body missing tail count: %q", body)
+	}
+	// The entry just past the cap must NOT be fully rendered.
+	capped := "acct" + itoa(maxFailuresPerNotification) + " @ site: err"
+	if strings.Contains(body, capped) {
+		t.Errorf("body rendered an entry beyond the cap: %q", body)
+	}
+}
+
+// ---- sendCheckinRoundNotification (the issue #667 contract) ----
+//
+// The core assertion of the issue: a round with N failures produces exactly
+// ONE notification that lists every failure. Mirrored for the clean-round
+// case (zero notifications) and the single-failure case (still one).
+
+func TestSendCheckinRoundNotification_TwoFailuresSendsExactlyOneNotification(t *testing.T) {
+	rec := swapNotifySend(t)
+
+	results := resultsFixture(3, 2, 0) // 3 successes + 2 failures
+	sendCheckinRoundNotification(&config.Config{}, results)
+
+	calls := rec.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 notification, got %d", len(calls))
+	}
+
+	call := calls[0]
+	if call.level != "error" {
+		t.Errorf("level = %q, want error", call.level)
+	}
+	if !strings.Contains(call.title, "3 ok, 2 failed") {
+		t.Errorf("title %q missing counts", call.title)
+	}
+	// Both failure account names must appear in the single notification body.
+	for _, name := range []string{"failuser1", "failuser2"} {
+		if !strings.Contains(call.message, name) {
+			t.Errorf("notification body missing failure %q: %s", name, call.message)
+		}
+	}
+}
+
+func TestSendCheckinRoundNotification_AllSuccessSendsNothing(t *testing.T) {
+	rec := swapNotifySend(t)
+	sendCheckinRoundNotification(&config.Config{}, resultsFixture(5, 0, 0))
+	if calls := rec.snapshot(); len(calls) != 0 {
+		t.Errorf("expected 0 notifications on clean round, got %d", len(calls))
+	}
+}
+
+func TestSendCheckinRoundNotification_SingleFailureStillSendsOne(t *testing.T) {
+	rec := swapNotifySend(t)
+	sendCheckinRoundNotification(&config.Config{}, resultsFixture(0, 1, 0))
+	calls := rec.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 notification for single failure, got %d", len(calls))
+	}
+	if !strings.Contains(calls[0].title, "0 ok, 1 failed") {
+		t.Errorf("title %q missing counts", calls[0].title)
+	}
+}
+
+func TestSendCheckinRoundNotification_EmptyResultsSendsNothing(t *testing.T) {
+	rec := swapNotifySend(t)
+	sendCheckinRoundNotification(&config.Config{}, nil)
+	if calls := rec.snapshot(); len(calls) != 0 {
+		t.Errorf("expected 0 notifications for empty round, got %d", len(calls))
+	}
+}
+
+// ---- helper unit tests ----
+
+func TestAccountLabel(t *testing.T) {
+	if got := accountLabel("alice", 1); got != "alice" {
+		t.Errorf("accountLabel(alice,1) = %q, want alice", got)
+	}
+	if got := accountLabel("  ", 7); got != "ID:7" {
+		t.Errorf("accountLabel(blank,7) = %q, want ID:7", got)
+	}
+	if got := accountLabel("", 99); got != "ID:99" {
+		t.Errorf("accountLabel(empty,99) = %q, want ID:99", got)
+	}
+}
+
+func TestFirstLine(t *testing.T) {
+	if got := firstLine("only line"); got != "only line" {
+		t.Errorf("firstLine(single) = %q", got)
+	}
+	if got := firstLine("line one\nline two"); got != "line one" {
+		t.Errorf("firstLine(multi) = %q, want %q", got, "line one")
+	}
+	if got := firstLine("  spaced  \nsecond"); got != "spaced" {
+		t.Errorf("firstLine(trimmed) = %q, want %q", got, "spaced")
+	}
+	if got := firstLine(""); got != "" {
+		t.Errorf("firstLine(empty) = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Closes #667. A failed `CheckinAll` round previously sent one "checkin failed" notification per account (N alerts for N failures); the throttle could not dedup because each message carried a unique account name. Now one failed round → **one** consolidated notification.
- `CheckinAll` sets `SkipNotification` on every per-account call, suppressing the in-`CheckinAccount` "checkin failed" / "Cloudflare challenge" alerts. After the round, `sendCheckinRoundNotification` emits a single `Checkin round <id>: <ok> ok, <failed> failed` error notification whose body lists every failure (`account @ site: <first line of error>`), capped at 25 lines with a tail count.
- `CheckinAccount`'s return type is unchanged — aggregation reads the existing `CheckinAllResult.Status`. The single-account manual trigger path (`triggerOne`) leaves `SkipNotification` off, preserving the per-account alert for that one-account case. Clean rounds (all success / all skipped) send nothing, matching prior behavior. `ReportTokenExpired` stays per-account and tag-throttled (not the spam source) and is left ungated. Per-account pacing (#692) and transient retry (#668) are untouched.

## Test plan
- [x] `go build ./service/checkin/... ./service/alert/... ./service/notify/... ./scheduler/... ./handler/admin/...` — clean (the only repo-wide build error is the pre-existing `web/embed.go` `dist` frontend artifact, unrelated to this change).
- [x] `go test ./service/checkin/... ./service/alert/... ./service/notify/...` — green.
- [x] `go test ./scheduler/... ./handler/admin/...` — green.
- [x] `round_aggregation_test.go`: 3-success/2-failure round → **exactly 1** notification with both failures listed; single failure → 1; clean round → 0; empty round → 0; skips excluded from ok/failed counts; multi-line error truncated to first line; empty-username → `ID:<n>` fallback; body cap (25) with `…and N more` tail; helper unit tests.
- [ ] Manual/production: trigger a cron/interval round against ≥2 failing accounts and confirm a single aggregated notification lands across all configured channels.