### PR TITLE
test(p0585): production cascade verification + staging test

### DIFF
--- a/docs/analysis/p0585-production-verification.md
+++ b/docs/analysis/p0585-production-verification.md
@@ -48,7 +48,7 @@ Exclusion is **channel-only** — same-site sibling channels stay eligible. Site
 
 ## 3. What was missing (the gap this change addresses)
 
-`docs/STATE.md` records `cascade | partial | HTTP load proof exists; production multi-channel proof still required`. The HTTP e2e tests use `httptest.Server` mocks — they prove the code path is correct, **not** that a real production instance with a real multi-site topology actually cascades. Issue #557 requires production/staging evidence against the `hk3` deployment (34.92.70.144:4000).
+`docs/STATE.md` records `cascade | partial | HTTP load proof exists; production multi-channel proof still required`. The HTTP e2e tests use `httptest.Server` mocks — they prove the code path is correct, **not** that a real production instance with a real multi-site topology actually cascades. Issue #557 requires production/staging evidence against the live deployment (the operator runs the script against the instance via `METAPI_URL`).
 
 This change ships the **verification tooling** (a read-only shell script + a build-tagged Go test) and the **procedure** (this document) so an operator can collect that evidence without faking it. It does **not** attach captured evidence files, because:
 
@@ -59,26 +59,26 @@ This change ships the **verification tooling** (a read-only shell script + a bui
 
 ### 4.1 Prerequisites
 
-- Access to the `hk3` host (SSH) or an SSH tunnel (`ssh -L 4000:127.0.0.1:4000 hk3`).
+- Access to the production host (SSH) or an SSH tunnel (`ssh -L 4000:127.0.0.1:4000 <prod-host>`).
 - `METAPI_AUTH_TOKEN` (admin `AUTH_TOKEN`) — needed for `/api/*` (topology + proxy_logs).
 - `METAPI_PROXY_TOKEN` (downstream `PROXY_TOKEN`) — needed for `/v1/*` (live probe).
 - `curl` and `jq` on the machine running the script.
 
 ### 4.2 Run the verification script
 
-The script is at `scripts/verify-cascade-hk3.sh`. It is **read-only**: it checks health, snapshots topology, sends one minimal chat-completions probe, diffs Prometheus counters, and groups recent `proxy_logs` by `request_id` to surface cascade attempts. It does **not** disable channels or mutate routing state.
+The script is at `scripts/verify-cascade-prod.sh`. It is **read-only**: it checks health, snapshots topology, sends one minimal chat-completions probe, diffs Prometheus counters, and groups recent `proxy_logs` by `request_id` to surface cascade attempts. It does **not** disable channels or mutate routing state.
 
 ```bash
-# Option A — run on the hk3 host itself (instance bound to 127.0.0.1:4000):
-ssh hk3 'bash -s' < scripts/verify-cascade-hk3.sh
+# Option A — run on the production host itself (instance bound to 127.0.0.1:4000):
+ssh <prod-host> 'bash -s' < scripts/verify-cascade-prod.sh
 
-# Option B — run locally against an SSH tunnel:
-ssh -L 4000:127.0.0.1:4000 hk3 -N   # in one terminal
+# Option B — run locally against an SSH tunnel to the production host:
+ssh -L 4000:127.0.0.1:4000 <prod-host> -N   # in one terminal
 METAPI_URL=http://127.0.0.1:4000 \
 METAPI_AUTH_TOKEN=<admin-token> \
 METAPI_PROXY_TOKEN=<proxy-token> \
 METAPI_TEST_MODEL=<a-model-on-a-multi-channel-route> \
-  ./scripts/verify-cascade-hk3.sh
+  ./scripts/verify-cascade-prod.sh
 ```
 
 The script writes a structured JSON report to `./cascade-verify-reports/cascade-verify-<timestamp>.json` and raw artefacts (metrics, topology, proxy_logs) to a sibling `raw-<timestamp>/` directory. Keep both when attaching evidence to the issue.
@@ -97,7 +97,7 @@ METAPI_TEST_MODEL=<a-model-on-a-multi-channel-route> \
 
 ### 4.4 Triggering a cascade (operator-gated, NOT automated)
 
-The script and the Go test do **not** force a 5xx — that would require disabling a production channel, which is destructive and out of scope for a read-only verification. To genuinely trigger a cascade against `hk3`, an operator performs these steps manually (documented in the script's final report block):
+The script and the Go test do **not** force a 5xx — that would require disabling a production channel, which is destructive and out of scope for a read-only verification. To genuinely trigger a cascade against the production instance, an operator performs these steps manually (documented in the script's final report block):
 
 1. Pick a route with ≥2 channels (the script's `topology.perRoute` field identifies these).
 2. `PUT /api/channels/{id}` with `{"enabled":false}` on the **first** channel only, **or** point its account at a deliberately broken upstream.
@@ -126,13 +126,13 @@ The decisive signal is the last one: a `requestId` with multiple `proxy_logs` ro
 | Verified by this change | Still partial |
 |---|---|
 | Verification **procedure + tooling** shipped (script + build-tagged test). | No captured production evidence is committed; evidence must be attached by an operator run. |
-| Read-only topology/metrics/proxy_logs collection is automated and safe. | Cascade is only observable on a real 5xx; a fully-healthy `hk3` yields no cascade rows (the test honestly `t.Skip`s). |
+| Read-only topology/metrics/proxy_logs collection is automated and safe. | Cascade is only observable on a real 5xx; a fully-healthy instance yields no cascade rows (the test honestly `t.Skip`s). |
 | Staging test asserts channel-scoped exclude + bounded retry **when** cascade occurs. | The destructive trigger (channel disable) is operator-gated, not automated. |
-| `go build ./...` + existing `e2e` tests stay green; the staging test is build-tagged out of CI. | If `hk3` has no multi-channel route, cascade cannot be exercised on that instance at all — a topology gap, not a code gap. |
+| `go build ./...` + existing `e2e` tests stay green; the staging test is build-tagged out of CI. | If the production instance has no multi-channel route, cascade cannot be exercised on it at all — a topology gap, not a code gap. |
 
 ## 7. Related files
 
-- `scripts/verify-cascade-hk3.sh` — read-only production verification script.
+- `scripts/verify-cascade-prod.sh` — read-only production verification script.
 - `e2e/e2e_p0585_production_test.go` — `//go:build staging` test; deeper assertions when cascade is observed.
 - `e2e/e2e_cascade_isolation_test.go` — the HTTP-path load-proof tests (mock upstreams).
 - `handler/proxy/upstream.go` — the cascade retry loop (`dispatchUpstream`).

--- a/docs/analysis/p0585-production-verification.md
+++ b/docs/analysis/p0585-production-verification.md
@@ -1,0 +1,143 @@
+# P0-585 Production Multi-Channel Cascade Verification
+
+**Status**: partial → verification procedure shipped; on-disk evidence collection automated; live cascade remains operator-gated.
+**Issue**: [#557](https://github.com/DeliciousBuding/metapi-go/issues/557)
+**Last updated**: 2026-08-15
+
+> Companion to the cascade isolation SSOT in [`docs/architecture.md`](../architecture.md) §"Channel isolation, cooldown, circuit breaker" and the honesty row in [`docs/STATE.md`](../STATE.md) (`cascade | partial`). This document closes out the production-evidence gap referenced there.
+
+## 1. What the P0-585 cascade is
+
+P0-585 is the multi-channel cascade failover path inside the proxy request loop. When an upstream channel returns a retryable failure (≥500, 408/409/425/429, 401/403, or an error text matching the retryable patterns in `proxy/retry_policy.go`), the conductor **excludes that channel for the remainder of the request** and tries the next healthy sibling. The cascade is **channel-scoped**: exclusion never poisons sibling channels on the same site, and it is bounded by `ProxyMaxChannelAttempts` (env `PROXY_MAX_CHANNEL_ATTEMPTS`, default 3).
+
+### Where the loop lives
+
+The request loop is in `handler/proxy/upstream.go` → `dispatchUpstream`:
+
+```304:340:handler/proxy/upstream.go
+	excludeChannelIDs := make([]int64, 0)
+	maxRetries := ctx.MaxRetries
+```
+
+Each attempt calls `proxy.SelectProxyChannelForAttempt` with the growing `excludeChannelIDs` list, dispatches via `dispatchSelectedUpstream`, and on a retryable failure records the failure (channel-scoped cooldown) and loops to the next sibling. The `X-Request-Id` header (set by the `WithRequestID` middleware) is **stable across all retry/failover attempts for one client call**, and every attempt writes a `proxy_logs` row tagged with that `request_id` and a stepping `retry_count`. That on-disk correlation is the primary production evidence surface.
+
+### Decision matrix (retry policy)
+
+`proxy.ShouldRetryProxyRequest` decides whether a failure justifies a cascade attempt:
+
+| Upstream signal | Retryable? | Notes |
+|---|---|---|
+| HTTP ≥ 500 | yes | always cascade |
+| 408 / 409 / 425 / 429 | yes | timeout / conflict / rate-limit |
+| 401 / 403 | yes | may resolve via OAuth refresh on another channel |
+| model-unsupported text | yes | try a channel that has the model |
+| non-retryable request text (malformed, unknown param) | no | bad request, do not cascade |
+| 400 / 404 / 422 | no | unless error text overrides |
+
+Exclusion is **channel-only** — same-site sibling channels stay eligible. Site-scoped concerns (cooldown, site runtime breaker, credential-scoped usage-limit) are applied independently by the routing selector, never by expanding the request-local exclude list.
+
+## 2. Existing automated evidence (before this change)
+
+| Layer | File | What it proves |
+|---|---|---|
+| HTTP e2e — storm | `e2e/e2e_cascade_isolation_test.go` → `TestCascadeIsolation_MultiChannel5xxStorm_ChannelScopedExclude` | A 6-channel 5xx storm selects exactly `ProxyMaxChannelAttempts` unique channels, never re-selects an excluded channel, and the exclude snapshots grow by one channel id per failover step. |
+| HTTP e2e — recovery | `e2e/e2e_cascade_isolation_test.go` → `TestCascadeIsolation_5xxThenHealthySiblingSucceeds` | A 5xx on channel 1 followed by a healthy channel 2 recovers on the sibling without re-hitting channel 1, and channel 3 is never selected. |
+| Routing unit | `routing/failure_isolation_test.go`, `routing/probe_health_test.go` | Cooldown and probe failures stay channel-scoped (no sibling poison). |
+
+> **Naming note:** the issue brief referenced `proxy/conductor_test.go` and `TestConductor_P0585LoadProof_*`. Those filenames do not exist in the as-built tree — the conductor role is split across `proxy/channel_selection.go` (`SelectProxyChannelForAttempt`), `proxy/retry_policy.go` (`ShouldRetryProxyRequest`), and `handler/proxy/upstream.go` (the retry loop). The actual load-proof tests are the two `TestCascadeIsolation_*` functions above. This doc uses the real names.
+
+## 3. What was missing (the gap this change addresses)
+
+`docs/STATE.md` records `cascade | partial | HTTP load proof exists; production multi-channel proof still required`. The HTTP e2e tests use `httptest.Server` mocks — they prove the code path is correct, **not** that a real production instance with a real multi-site topology actually cascades. Issue #557 requires production/staging evidence against the `hk3` deployment (34.92.70.144:4000).
+
+This change ships the **verification tooling** (a read-only shell script + a build-tagged Go test) and the **procedure** (this document) so an operator can collect that evidence without faking it. It does **not** attach captured evidence files, because:
+
+1. The script is read-only and production-safe; it must be run by an operator who has the instance's tokens.
+2. Cascade is only observable when an upstream genuinely 5xxs. A healthy instance produces no cascade rows — and we do not fabricate 5xxs against production.
+
+## 4. Verification procedure
+
+### 4.1 Prerequisites
+
+- Access to the `hk3` host (SSH) or an SSH tunnel (`ssh -L 4000:127.0.0.1:4000 hk3`).
+- `METAPI_AUTH_TOKEN` (admin `AUTH_TOKEN`) — needed for `/api/*` (topology + proxy_logs).
+- `METAPI_PROXY_TOKEN` (downstream `PROXY_TOKEN`) — needed for `/v1/*` (live probe).
+- `curl` and `jq` on the machine running the script.
+
+### 4.2 Run the verification script
+
+The script is at `scripts/verify-cascade-hk3.sh`. It is **read-only**: it checks health, snapshots topology, sends one minimal chat-completions probe, diffs Prometheus counters, and groups recent `proxy_logs` by `request_id` to surface cascade attempts. It does **not** disable channels or mutate routing state.
+
+```bash
+# Option A — run on the hk3 host itself (instance bound to 127.0.0.1:4000):
+ssh hk3 'bash -s' < scripts/verify-cascade-hk3.sh
+
+# Option B — run locally against an SSH tunnel:
+ssh -L 4000:127.0.0.1:4000 hk3 -N   # in one terminal
+METAPI_URL=http://127.0.0.1:4000 \
+METAPI_AUTH_TOKEN=<admin-token> \
+METAPI_PROXY_TOKEN=<proxy-token> \
+METAPI_TEST_MODEL=<a-model-on-a-multi-channel-route> \
+  ./scripts/verify-cascade-hk3.sh
+```
+
+The script writes a structured JSON report to `./cascade-verify-reports/cascade-verify-<timestamp>.json` and raw artefacts (metrics, topology, proxy_logs) to a sibling `raw-<timestamp>/` directory. Keep both when attaching evidence to the issue.
+
+### 4.3 Run the staging Go test (optional, deeper assertions)
+
+The staging test is at `e2e/e2e_p0585_production_test.go` and is guarded by the `//go:build staging` tag, so it is **never** compiled into the normal CI binary. It sends one probe, captures the `X-Request-Id`, fetches recent `proxy_logs`, and asserts channel-scoped/bounded semantics **when** a cascade is observed. When the instance is healthy it `t.Skip`s with an honest residual.
+
+```bash
+METAPI_STAGING_URL=http://127.0.0.1:4000 \
+METAPI_AUTH_TOKEN=<admin-token> \
+METAPI_PROXY_TOKEN=<proxy-token> \
+METAPI_TEST_MODEL=<a-model-on-a-multi-channel-route> \
+  go test ./e2e -tags=staging -run 'P0585_ProductionCascade_Staging' -v -timeout=120s
+```
+
+### 4.4 Triggering a cascade (operator-gated, NOT automated)
+
+The script and the Go test do **not** force a 5xx — that would require disabling a production channel, which is destructive and out of scope for a read-only verification. To genuinely trigger a cascade against `hk3`, an operator performs these steps manually (documented in the script's final report block):
+
+1. Pick a route with ≥2 channels (the script's `topology.perRoute` field identifies these).
+2. `PUT /api/channels/{id}` with `{"enabled":false}` on the **first** channel only, **or** point its account at a deliberately broken upstream.
+3. Send a chat completion for the route's model; expect the conductor to exclude the failing channel and retry on a healthy sibling.
+4. Confirm by querying `proxy_logs` for the `X-Request-Id`: you should see ≥2 rows with the same `requestId`, distinct `channelId`, and `retryCount` stepping `0 → 1`.
+5. Re-enable the channel and verify recovery.
+
+Steps 2–3 are the only destructive part and are intentionally left to a human.
+
+## 5. Evidence to capture
+
+When attaching production evidence to issue #557, capture:
+
+| Artefact | Source | What it shows |
+|---|---|---|
+| `cascade-verify-<ts>.json` | script report | Verdict, topology, metrics diff, cascade-evidence summary |
+| `raw-<ts>/metrics_before.txt` + `metrics_after.txt` | `/metrics` | `metapi_proxy_requests_total` / `metapi_proxy_errors_total` / labeled `metapi_proxy_outcomes_total` movement |
+| `raw-<ts>/sites.json`, `routes.json`, `channels.json` | `/api/sites`, `/api/routes`, `/api/channels` | The multi-channel topology that makes cascade possible |
+| `raw-<ts>/proxy_logs.json` | `/api/stats/proxy-logs` | Rows grouped by `requestId` — ≥2 rows with distinct `channelId` and stepping `retryCount` are the cascade proof |
+| Staging test `-v` output | `go test -tags=staging` | `verified: cascade used N distinct channels` / `verified: cascade bounded (max retry_count=N)` lines |
+
+The decisive signal is the last one: a `requestId` with multiple `proxy_logs` rows, distinct `channelId`s, and `retryCount` stepping — exactly the on-disk truth the HTTP e2e asserts against, observed against a live instance.
+
+## 6. Honest residual
+
+| Verified by this change | Still partial |
+|---|---|
+| Verification **procedure + tooling** shipped (script + build-tagged test). | No captured production evidence is committed; evidence must be attached by an operator run. |
+| Read-only topology/metrics/proxy_logs collection is automated and safe. | Cascade is only observable on a real 5xx; a fully-healthy `hk3` yields no cascade rows (the test honestly `t.Skip`s). |
+| Staging test asserts channel-scoped exclude + bounded retry **when** cascade occurs. | The destructive trigger (channel disable) is operator-gated, not automated. |
+| `go build ./...` + existing `e2e` tests stay green; the staging test is build-tagged out of CI. | If `hk3` has no multi-channel route, cascade cannot be exercised on that instance at all — a topology gap, not a code gap. |
+
+## 7. Related files
+
+- `scripts/verify-cascade-hk3.sh` — read-only production verification script.
+- `e2e/e2e_p0585_production_test.go` — `//go:build staging` test; deeper assertions when cascade is observed.
+- `e2e/e2e_cascade_isolation_test.go` — the HTTP-path load-proof tests (mock upstreams).
+- `handler/proxy/upstream.go` — the cascade retry loop (`dispatchUpstream`).
+- `proxy/retry_policy.go` — `ShouldRetryProxyRequest` decision matrix.
+- `proxy/channel_selection.go` — `SelectProxyChannelForAttempt` (channel-scoped exclude).
+- `routing/selector.go` — `SelectChannel` / `SelectNextChannel` (exclude-aware selection).
+- `docs/architecture.md` — architecture SSOT (§"Channel isolation, cooldown, circuit breaker").
+- `docs/STATE.md` — product honesty row (`cascade | partial`).

--- a/e2e/e2e_p0585_production_test.go
+++ b/e2e/e2e_p0585_production_test.go
@@ -1,0 +1,390 @@
+//go:build staging
+
+// Package e2e contains end-to-end integration tests for the proxy pipeline.
+//
+// This file holds the P0-585 production / staging cascade verification test.
+// It is guarded by the `staging` build tag so it is NEVER compiled into the
+// normal CI test binary — it only runs when an operator explicitly invokes:
+//
+//	go test ./e2e -tags=staging -run 'P0585_ProductionCascade_Staging' \
+//	  -v -timeout=120s
+//
+// The test connects to a real metapi instance (env: METAPI_STAGING_URL,
+// METAPI_AUTH_TOKEN, METAPI_PROXY_TOKEN) and gathers honest on-disk cascade
+// evidence from proxy_logs. It does NOT mutate routing state and does NOT
+// disable channels — cascade is only observed when an upstream genuinely 5xxs.
+// When the instance is fully healthy (no cascade triggered), the test reports
+// an honest residual via t.Skipf instead of faking a pass.
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Staging env knobs. All three are required — the test fails fast if absent.
+const (
+	stagingURLEnv      = "METAPI_STAGING_URL"
+	stagingAuthEnv     = "METAPI_AUTH_TOKEN"
+	stagingProxyEnv    = "METAPI_PROXY_TOKEN"
+	stagingModelEnv    = "METAPI_TEST_MODEL" // optional; auto-detected if unset
+	stagingRequestModel = "METAPI_REQUEST_MODEL" // accepted alias
+)
+
+// requireStagingEnv returns the staging instance config or fails the test with
+// a clear message about which env vars are missing.
+func requireStagingEnv(t *testing.T) (baseURL, authToken, proxyToken string) {
+	t.Helper()
+	baseURL = strings.TrimRight(strings.TrimSpace(os.Getenv(stagingURLEnv)), "/")
+	authToken = strings.TrimSpace(os.Getenv(stagingAuthEnv))
+	proxyToken = strings.TrimSpace(os.Getenv(stagingProxyEnv))
+	missing := []string{}
+	if baseURL == "" {
+		missing = append(missing, stagingURLEnv)
+	}
+	if authToken == "" {
+		missing = append(missing, stagingAuthEnv)
+	}
+	if proxyToken == "" {
+		missing = append(missing, stagingProxyEnv)
+	}
+	if len(missing) > 0 {
+		t.Fatalf("staging cascade test requires env: %s (missing: %s). "+
+			"Run with: go test ./e2e -tags=staging -run P0585_ProductionCascade_Staging",
+			strings.Join([]string{stagingURLEnv, stagingAuthEnv, stagingProxyEnv}, ", "),
+			strings.Join(missing, ", "))
+	}
+	return baseURL, authToken, proxyToken
+}
+
+// stagingHTTPClient is a shared client with a bounded timeout so a hung
+// upstream never stalls the test beyond the Go test timeout.
+func stagingHTTPClient() *http.Client {
+	return &http.Client{Timeout: 45 * time.Second}
+}
+
+// stagingGet performs an authenticated GET and returns status + body bytes.
+func stagingGet(t *testing.T, client *http.Client, baseURL, token, path string) (int, []byte) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, baseURL+path, nil)
+	if err != nil {
+		t.Fatalf("staging GET %s: %v", path, err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("staging GET %s: %v", path, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, body
+}
+
+// stagingProxyChat sends a minimal chat-completions request and returns the
+// HTTP status, the X-Request-Id (correlating cascade attempts in proxy_logs),
+// and the response body excerpt.
+func stagingProxyChat(t *testing.T, client *http.Client, baseURL, proxyToken, model string) (status int, requestID string, bodyExcerpt string) {
+	t.Helper()
+	payload := map[string]any{
+		"model":      model,
+		"messages":   []map[string]string{{"role": "user", "content": "p0585 cascade staging verify (read-only)"}},
+		"max_tokens": 1,
+		"stream":     false,
+	}
+	rawPayload, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal chat payload: %v", err)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, baseURL+"/v1/chat/completions", bytes.NewReader(rawPayload))
+	if err != nil {
+		t.Fatalf("staging POST chat/completions: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+proxyToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Metapi-Verify", "cascade-p0585-staging")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("staging POST chat/completions: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+	requestID = resp.Header.Get("X-Request-Id")
+	return resp.StatusCode, requestID, string(body)
+}
+
+// resolveStagingModel picks a model to probe: explicit env override first,
+// otherwise the first id from /v1/models, otherwise the first route's model.
+func resolveStagingModel(t *testing.T, client *http.Client, baseURL, proxyToken, authToken string) string {
+	t.Helper()
+	if override := strings.TrimSpace(os.Getenv(stagingModelEnv)); override != "" {
+		t.Logf("using explicit %s=%s", stagingModelEnv, override)
+		return override
+	}
+	if alias := strings.TrimSpace(os.Getenv(stagingRequestModel)); alias != "" {
+		t.Logf("using explicit %s=%s", stagingRequestModel, alias)
+		return alias
+	}
+	// Best-effort: downstream-visible model catalog.
+	if status, body := stagingGet(t, client, baseURL, proxyToken, "/v1/models"); status == 200 {
+		var catalog struct {
+			Data []struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		}
+		if json.Unmarshal(body, &catalog) == nil && len(catalog.Data) > 0 {
+			t.Logf("auto-detected probe model from /v1/models: %s", catalog.Data[0].ID)
+			return catalog.Data[0].ID
+		}
+	}
+	// Fallback: first route summary's source model.
+	if status, body := stagingGet(t, client, baseURL, authToken, "/api/routes?view=summary"); status == 200 {
+		var routes []map[string]any
+		if json.Unmarshal(body, &routes) == nil && len(routes) > 0 {
+			if sm, ok := routes[0]["sourceModel"].(string); ok && sm != "" {
+				return sm
+			}
+			if sm, ok := routes[0]["source_model"].(string); ok && sm != "" {
+				return sm
+			}
+		}
+	}
+	return ""
+}
+
+// proxyLogRow is the subset of proxy_logs columns the staging test inspects.
+// Field names mirror the admin /api/stats/proxy-logs?view=query payload
+// (camelCase JSON keys, as emitted by the admin handler).
+type proxyLogRow struct {
+	ID          int64  `json:"id"`
+	ChannelID   *int64 `json:"channelId"`
+	AccountID   *int64 `json:"accountId"`
+	ModelReq    string `json:"modelRequested"`
+	ModelAct    string `json:"modelActual"`
+	Status      string `json:"status"`
+	HTTPStatus  *int   `json:"httpStatus"`
+	RetryCount  *int   `json:"retryCount"`
+	RequestID   string `json:"requestId"`
+	CreatedAt   string `json:"createdAt"`
+}
+
+// fetchStagingProxyLogs retrieves the most recent proxy_log rows. The admin
+// endpoint returns {items:[...]} with camelCase keys. We read at most 100 rows
+// (the endpoint ceiling) and let the caller filter by request_id.
+func fetchStagingProxyLogs(t *testing.T, client *http.Client, baseURL, authToken string) []proxyLogRow {
+	t.Helper()
+	status, body := stagingGet(t, client, baseURL, authToken, "/api/stats/proxy-logs?view=query&limit=100")
+	if status != 200 {
+		t.Logf("proxy-logs endpoint returned %d (cannot gather cascade evidence)", status)
+		return nil
+	}
+	var payload struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Logf("proxy-logs payload unmarshal failed: %v (cascade evidence unavailable)", err)
+		return nil
+	}
+	rows := make([]proxyLogRow, 0, len(payload.Items))
+	for _, item := range payload.Items {
+		row := proxyLogRow{
+			ID:        toInt64(item["id"]),
+			ChannelID: toInt64Ptr(item["channelId"]),
+			AccountID: toInt64Ptr(item["accountId"]),
+			ModelReq:  toString(item["modelRequested"]),
+			ModelAct:  toString(item["modelActual"]),
+			Status:    toString(item["status"]),
+			HTTPStatus: toIntPtr(item["httpStatus"]),
+			RetryCount: toIntPtr(item["retryCount"]),
+			RequestID: toString(item["requestId"]),
+			CreatedAt: toString(item["createdAt"]),
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// TestP0585_ProductionCascade_Staging gathers honest cascade evidence against a
+// real staging/production instance. It is NOT a self-contained cascade trigger:
+// it sends one minimal request and then reads proxy_logs for the resulting
+// X-Request-Id. Cascade is only observable when an upstream genuinely returned
+// 5xx for that request. When the instance is healthy, the test skips with an
+// honest residual rather than faking a pass.
+//
+// Asserts (when cascade IS observed):
+//   - the request_id has >1 proxy_log row (multiple channel attempts)
+//   - the attempted channel_id values are distinct (channel-scoped exclude)
+//   - retry_count steps 0 -> 1 -> ... (bounded by ProxyMaxChannelAttempts)
+//
+// Asserts (always):
+//   - at least one proxy_log row exists for the request_id (request-path + logging works)
+//   - the chat probe either succeeded (200) or failed without crashing the instance
+func TestP0585_ProductionCascade_Staging(t *testing.T) {
+	baseURL, authToken, proxyToken := requireStagingEnv(t)
+	client := stagingHTTPClient()
+
+	// --- Preflight: health ---
+	if status, _ := stagingGet(t, client, baseURL, "", "/health"); status != 200 {
+		t.Fatalf("staging instance not healthy: GET /health -> %d", status)
+	}
+	t.Logf("staging instance healthy at %s", baseURL)
+
+	// --- Preflight: topology (is this instance even cascade-capable?) ---
+	type siteRow struct {
+		ID     int64  `json:"id"`
+		Name   string `json:"name"`
+		Status string `json:"status"`
+	}
+	var sites []siteRow
+	if status, body := stagingGet(t, client, baseURL, authToken, "/api/sites"); status == 200 {
+		_ = json.Unmarshal(body, &sites)
+	}
+	t.Logf("topology: %d site(s) configured", len(sites))
+
+	// --- Resolve a probe model ---
+	model := resolveStagingModel(t, client, baseURL, proxyToken, authToken)
+	if model == "" {
+		t.Skip("no probe model resolved — set METAPI_TEST_MODEL, or ensure /v1/models or /api/routes returns at least one model")
+	}
+	t.Logf("probe model: %s", model)
+
+	// --- Send the probe request ---
+	probeStatus, requestID, bodyExcerpt := stagingProxyChat(t, client, baseURL, proxyToken, model)
+	t.Logf("probe status=%d request_id=%q", probeStatus, requestID)
+	if probeStatus == 200 {
+		t.Logf("probe succeeded (happy path) — cascade only observable if upstream 5xx'd")
+	} else {
+		t.Logf("probe non-200 (status=%d). body excerpt: %s", probeStatus, truncateForLog(bodyExcerpt, 200))
+	}
+	if requestID == "" {
+		t.Fatal("probe response missing X-Request-Id — cannot correlate cascade attempts in proxy_logs")
+	}
+
+	// Give the instance a brief moment to flush the proxy_log row. The log is
+	// written synchronously at the end of dispatchUpstream, but a small grace
+	// period keeps the test robust under load.
+	time.Sleep(500 * time.Millisecond)
+
+	// --- Gather proxy_logs and isolate rows for this request_id ---
+	allRows := fetchStagingProxyLogs(t, client, baseURL, authToken)
+	matchingRows := make([]proxyLogRow, 0)
+	for _, row := range allRows {
+		if row.RequestID == requestID {
+			matchingRows = append(matchingRows, row)
+		}
+	}
+	t.Logf("proxy_logs: %d recent rows, %d match request_id=%q", len(allRows), len(matchingRows), requestID)
+
+	if len(matchingRows) == 0 {
+		t.Fatalf("no proxy_log row found for request_id=%q — the request-path logging is not consistent; cascade cannot be evidenced",
+			requestID)
+	}
+
+	// Always-verifiable: the request was logged exactly once for the terminal
+	// attempt (or multiple times if cascade happened).
+	t.Logf("verified: proxy_log captured the request-path (request_id=%q, rows=%d)", requestID, len(matchingRows))
+
+	// --- Cascade evidence (only present when an upstream genuinely 5xx'd) ---
+	if len(matchingRows) < 2 {
+		t.Skipf("no cascade observed for request_id=%q (only %d proxy_log row). "+
+			"Instance upstreams were healthy; cascade is only observable on a real 5xx. "+
+			"This is an honest residual — see docs/analysis/p0585-production-verification.md.",
+			requestID, len(matchingRows))
+	}
+
+	// Cascade observed: assert channel-scoped, bounded retry semantics.
+	channelIDs := make(map[int64]bool)
+	var maxRetry int
+	for _, row := range matchingRows {
+		if row.ChannelID != nil {
+			channelIDs[*row.ChannelID] = true
+		}
+		if row.RetryCount != nil && *row.RetryCount > maxRetry {
+			maxRetry = *row.RetryCount
+		}
+	}
+
+	// Distinct channels prove channel-scoped exclude (failed channel not retried).
+	if len(channelIDs) < 2 {
+		t.Errorf("cascade rows share a single channel_id (%v) — exclude is not channel-scoped as P0-585 requires",
+			channelIDs)
+	} else {
+		t.Logf("verified: cascade used %d distinct channels (channel-scoped exclude intact): %v",
+			len(channelIDs), channelIDs)
+	}
+
+	// retry_count stepping proves the cascade is bounded by ProxyMaxChannelAttempts.
+	if maxRetry < 1 {
+		t.Errorf("cascade rows present but max retry_count=%d — expected >=1 for a failover", maxRetry)
+	} else {
+		t.Logf("verified: cascade bounded (max retry_count=%d, default ProxyMaxChannelAttempts=3)", maxRetry)
+	}
+
+	// Terminal status of the cascade: either the last attempt succeeded (recovery)
+	// or all attempts failed (bounded exhaustion). Both are valid cascade outcomes.
+	last := matchingRows[len(matchingRows)-1]
+	if last.Status == "success" {
+		t.Logf("verified: cascade recovered — last attempt succeeded on a healthy sibling")
+	} else {
+		t.Logf("cascade exhausted without recovery (last status=%q) — bounded failure, not a crash", last.Status)
+	}
+
+	t.Logf("P0-585 staging cascade evidence captured for request_id=%q: rows=%d channels=%d max_retry=%d",
+		requestID, len(matchingRows), len(channelIDs), maxRetry)
+}
+
+// --- helpers for loosely-typed admin JSON payloads ---
+
+func toInt64(v any) int64 {
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	}
+	return 0
+}
+
+func toInt64Ptr(v any) *int64 {
+	if v == nil {
+		return nil
+	}
+	n := toInt64(v)
+	if n == 0 {
+		// nil-channel / nil-account come through as 0 — preserve null semantics.
+		return nil
+	}
+	return &n
+}
+
+func toIntPtr(v any) *int {
+	if v == nil {
+		return nil
+	}
+	n := int(toInt64(v))
+	return &n
+}
+
+func toString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func truncateForLog(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...(truncated)"
+}

--- a/scripts/verify-cascade-hk3.sh
+++ b/scripts/verify-cascade-hk3.sh
@@ -1,0 +1,451 @@
+#!/usr/bin/env bash
+# verify-cascade-hk3.sh — P0-585 production multi-channel cascade verification.
+#
+# Connects to a running metapi instance (hk3 or any reachable host) and captures
+# honest, READ-ONLY evidence of the multi-channel cascade failover behaviour.
+# This script performs NO destructive actions: it does not disable channels,
+# rotate credentials, or mutate routing state. It only:
+#   1. checks health / readiness
+#   2. snapshots the configured topology (sites / routes / channels)
+#   3. records Prometheus counters before a test request
+#   4. sends ONE minimal chat-completions request (if a model is available)
+#   5. records Prometheus counters after, and diffs them
+#   6. pulls recent proxy_logs and groups them by request_id to surface any
+#      multi-channel retry (cascade) attempts already recorded by the instance
+#
+# Cascade evidence comes from rows in proxy_logs that share a request_id but
+# differ on channel_id / retry_count — that is the same on-disk truth the unit
+# and HTTP e2e tests assert against, observed against a live instance.
+#
+# ---------------------------------------------------------------------------
+# Usage:
+#   # On the hk3 host itself (instance bound to 127.0.0.1:4000):
+#   ssh hk3 'bash -s' < scripts/verify-cascade-hk3.sh
+#
+#   # Locally against a tunnel (ssh -L 4000:127.0.0.1:4000 hk3):
+#   METAPI_URL=http://127.0.0.1:4000 \
+#   METAPI_AUTH_TOKEN=<admin-token> \
+#   METAPI_PROXY_TOKEN=<proxy-token> \
+#   ./scripts/verify-cascade-hk3.sh
+#
+#   # Override the model used for the live probe (recommended):
+#   METAPI_TEST_MODEL=gpt-4o-mini ./scripts/verify-cascade-hk3.sh
+#
+# Required env:
+#   METAPI_AUTH_TOKEN  — admin AUTH_TOKEN (for /api/* topology + proxy_logs)
+#   METAPI_PROXY_TOKEN — downstream PROXY_TOKEN (for /v1/* live probe)
+#
+# Optional env:
+#   METAPI_URL          default http://127.0.0.1:4000
+#   METAPI_TEST_MODEL   model for the live probe (auto-detected if unset)
+#   METAPI_REQUEST_TIMEOUT  default 30 (seconds)
+#   METAPI_REPORT_DIR   default ./cascade-verify-reports (JSON report output)
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+METAPI_URL="${METAPI_URL:-http://127.0.0.1:4000}"
+METAPI_AUTH_TOKEN="${METAPI_AUTH_TOKEN:-}"
+METAPI_PROXY_TOKEN="${METAPI_PROXY_TOKEN:-}"
+METAPI_TEST_MODEL="${METAPI_TEST_MODEL:-}"
+METAPI_REQUEST_TIMEOUT="${METAPI_REQUEST_TIMEOUT:-30}"
+METAPI_REPORT_DIR="${METAPI_REPORT_DIR:-./cascade-verify-reports}"
+
+# Strip a trailing slash so URL composition is predictable.
+METAPI_URL="${METAPI_URL%/}"
+
+TIMESTAMP_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TIMESTAMP_FILE="$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$METAPI_REPORT_DIR"
+REPORT_JSON="$METAPI_REPORT_DIR/cascade-verify-${TIMESTAMP_FILE}.json"
+RAW_DIR="$METAPI_REPORT_DIR/raw-${TIMESTAMP_FILE}"
+mkdir -p "$RAW_DIR"
+
+# Color helpers (disabled when not a TTY so log scraping stays clean).
+if [ -t 1 ]; then
+	C_GREEN=$'\033[32m'; C_RED=$'\033[31m'; C_YELLOW=$'\033[33m'; C_DIM=$'\033[2m'; C_RESET=$'\033[0m'
+else
+	C_GREEN=""; C_RED=""; C_YELLOW=""; C_DIM=""; C_RESET=""
+fi
+
+log()      { printf '%s[p0585]%s %s\n' "$C_DIM" "$C_RESET" "$*"; }
+log_ok()   { printf '%s[p0585] OK   %s%s\n'  "$C_GREEN" "$C_RESET" "$*"; }
+log_warn() { printf '%s[p0585] WARN %s%s\n'  "$C_YELLOW" "$C_RESET" "$*"; }
+log_err()  { printf '%s[p0585] ERR  %s%s\n'  "$C_RED" "$C_RESET" "$*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+preflight_failures=0
+require_cmd() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		log_err "required command not found: $1"
+		preflight_failures=$((preflight_failures + 1))
+	fi
+}
+require_cmd curl
+require_cmd jq
+
+if [ -z "$METAPI_AUTH_TOKEN" ]; then
+	log_err "METAPI_AUTH_TOKEN is empty — admin /api/* checks will fail"
+	preflight_failures=$((preflight_failures + 1))
+fi
+if [ -z "$METAPI_PROXY_TOKEN" ]; then
+	log_err "METAPI_PROXY_TOKEN is empty — live /v1/* probe will fail"
+	preflight_failures=$((preflight_failures + 1))
+fi
+if [ "$preflight_failures" -gt 0 ]; then
+	log_err "preflight failed ($preflight_failures). Set METAPI_AUTH_TOKEN and METAPI_PROXY_TOKEN."
+	exit 2
+fi
+
+# Initialise the JSON report skeleton. Fields are filled in as the script runs.
+report_init() {
+	jq -n \
+		--arg timestamp "$TIMESTAMP_ISO" \
+		--arg url "$METAPI_URL" \
+		'{
+			feature: "P0-585 multi-channel cascade failover",
+			timestamp: $timestamp,
+			instanceUrl: $url,
+			verdict: "partial",
+			verified: [],
+			residual: [],
+			topology: {},
+			metricsDiff: {},
+			liveProbe: {},
+			cascadeEvidence: {}
+		}' > "$REPORT_JSON"
+}
+report_set() { jq --argjson v "$2" "$1 = $v" "$REPORT_JSON" > "$REPORT_JSON.tmp" && mv "$REPORT_JSON.tmp" "$REPORT_JSON"; }
+report_push_verified() { jq --arg v "$1" '.verified += [$v]' "$REPORT_JSON" > "$REPORT_JSON.tmp" && mv "$REPORT_JSON.tmp" "$REPORT_JSON"; }
+report_push_residual() { jq --arg v "$1" '.residual += [$v]' "$REPORT_JSON" > "$REPORT_JSON.tmp" && mv "$REPORT_JSON.tmp" "$REPORT_JSON"; }
+report_save_raw() { cp "$1" "$RAW_DIR/$2" 2>/dev/null || true; }
+
+report_init
+
+log "verifying P0-585 cascade against $METAPI_URL (report: $REPORT_JSON)"
+
+# ---------------------------------------------------------------------------
+# HTTP helpers (curl with auth + timeout, capturing status + body)
+# ---------------------------------------------------------------------------
+curl_public() {
+	# $1 = path
+	curl -sS -o "$RAW_DIR/$2" -w '%{http_code}' \
+		--max-time "$METAPI_REQUEST_TIMEOUT" \
+		"${METAPI_URL}${1}" 2>"$RAW_DIR/$2.err" || true
+}
+curl_admin() {
+	# $1 = path, $2 = raw filename
+	curl -sS -o "$RAW_DIR/$2" -w '%{http_code}' \
+		-H "Authorization: Bearer ${METAPI_AUTH_TOKEN}" \
+		--max-time "$METAPI_REQUEST_TIMEOUT" \
+		"${METAPI_URL}${1}" 2>"$RAW_DIR/$2.err" || true
+}
+curl_proxy_json() {
+	# $1 = path, $2 = raw filename, $3 = JSON body
+	curl -sS -D "$RAW_DIR/$2.headers" -o "$RAW_DIR/$2.body" -w '%{http_code}' \
+		-H "Authorization: Bearer ${METAPI_PROXY_TOKEN}" \
+		-H "Content-Type: application/json" \
+		-H "X-Metapi-Verify: cascade-p0585" \
+		-X POST --data "$3" \
+		--max-time "$METAPI_REQUEST_TIMEOUT" \
+		"${METAPI_URL}${1}" 2>"$RAW_DIR/$2.err" || true
+}
+
+# ---------------------------------------------------------------------------
+# 1. Health & readiness
+# ---------------------------------------------------------------------------
+log "step 1: health / readiness"
+health_code="$(curl_public /health health.json)"
+ready_code="$(curl_public /ready ready.json)"
+report_set '.health' "$(jq -n \
+	--argjson healthStatus "$health_code" \
+	--argjson readyStatus "$ready_code" \
+	'{health: $healthStatus, ready: $readyStatus}')"
+
+if [ "$health_code" = "200" ] && [ "$ready_code" = "200" ]; then
+	log_ok "health=$health_code ready=$ready_code"
+	report_push_verified "instance health + readiness (HTTP 200)"
+else
+	log_warn "health=$health_code ready=$ready_code — instance may not be ready"
+	report_push_residual "health/ready non-200 (health=$health_code ready=$ready_code)"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Topology snapshot (sites / routes / channels)
+# ---------------------------------------------------------------------------
+log "step 2: topology snapshot (sites, routes, channels)"
+sites_code="$(curl_admin /api/sites sites.json)"
+routes_code="$(curl_admin '/api/routes?view=summary' routes.json)"
+channels_code="$(curl_admin /api/channels channels.json)"
+
+site_count="$(jq 'length' "$RAW_DIR/sites.json" 2>/dev/null || echo 0)"
+route_count="$(jq 'length // (.items | length) // 0' "$RAW_DIR/routes.json" 2>/dev/null || echo 0)"
+channel_count="$(jq 'length // (.items | length) // 0' "$RAW_DIR/channels.json" 2>/dev/null || echo 0)"
+
+# Count channels per route — the key multi-channel readiness signal.
+# /api/routes?view=summary returns route summaries; channel counts may live in
+# /api/routes/{id}/channels. Best-effort: derive from channels list grouped by routeId.
+multi_channel_routes=0
+max_channels_per_route=0
+if [ "$channels_code" = "200" ] && [ -s "$RAW_DIR/channels.json" ]; then
+	# Channels payload shape is either a bare array or {items:[...]}.
+	per_route_json="$(jq '[.. | objects | (.routeId // .route_id // empty)] | group_by(.) | map({routeId: .[0], channels: length})' "$RAW_DIR/channels.json" 2>/dev/null || echo '[]')"
+	max_channels_per_route="$(echo "$per_route_json" | jq '[.[].channels] | max // 0')"
+	multi_channel_routes="$(echo "$per_route_json" | jq '[.[] | select(.channels > 1)] | length')"
+else
+	per_route_json='[]'
+fi
+
+report_set '.topology' "$(jq -n \
+	--argjson sitesStatus "$sites_code" \
+	--argjson routesStatus "$routes_code" \
+	--argjson channelsStatus "$channels_code" \
+	--argjson siteCount "$site_count" \
+	--argjson routeCount "$route_count" \
+	--argjson channelCount "$channel_count" \
+	--argjson multiChannelRoutes "$multi_channel_routes" \
+	--argjson maxChannelsPerRoute "$max_channels_per_route" \
+	--argjson perRoute "$per_route_json" \
+	'{
+		sitesStatus: $sitesStatus, routesStatus: $routesStatus, channelsStatus: $channelsStatus,
+		siteCount: $siteCount, routeCount: $routeCount, channelCount: $channelCount,
+		multiChannelRoutes: $multiChannelRoutes, maxChannelsPerRoute: $maxChannelsPerRoute,
+		perRoute: $perRoute
+	}')"
+
+if [ "$sites_code" = "200" ] && [ "$routes_code" = "200" ] && [ "$channels_code" = "200" ]; then
+	log_ok "topology: sites=$site_count routes=$route_count channels=$channel_count"
+	report_push_verified "topology snapshot captured (sites=$site_count, routes=$route_count, channels=$channel_count)"
+else
+	log_warn "topology endpoints incomplete (sites=$sites_code routes=$routes_code channels=$channels_code)"
+	report_push_residual "topology endpoints incomplete (sites=$sites_code routes=$routes_code channels=$channels_code)"
+fi
+
+if [ "$multi_channel_routes" -gt 0 ]; then
+	log_ok "multi-channel routes present: $multi_channel_routes (max $max_channels_per_route channels on one route)"
+	report_push_verified "$multi_channel_routes route(s) have >=2 channels (cascade-capable topology)"
+else
+	log_warn "no route with >=2 channels detected — cascade has no sibling to failover to"
+	report_push_residual "no multi-channel route detected — cascade failover cannot be exercised on this instance"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Metrics before
+# ---------------------------------------------------------------------------
+log "step 3: metrics snapshot (before)"
+metrics_before_code="$(curl_public /metrics metrics_before.txt)"
+
+extract_counter() {
+	# $1 = metric name. Returns the numeric sample (last match) or 0.
+	awk -v m="$1" '$1==m {print $2} END{if(!found) print 0}' "$RAW_DIR/metrics_before.txt" 2>/dev/null \
+		| tail -n1 || echo 0
+}
+
+requests_before="$(grep -E '^metapi_proxy_requests_total ' "$RAW_DIR/metrics_before.txt" 2>/dev/null | awk '{print $2}' | tail -n1 || echo 0)"
+errors_before="$(grep -E '^metapi_proxy_errors_total ' "$RAW_DIR/metrics_before.txt" 2>/dev/null | awk '{print $2}' | tail -n1 || echo 0)"
+
+# Labeled outcome counters (endpoint|status|stream) — capture the full block so
+# we can diff after the probe. Store as a sorted blob for jq comparison.
+outcomes_before_json="$(awk '/^metapi_proxy_outcomes_total\{/{found=1} found{print} /^$/{found=0}' "$RAW_DIR/metrics_before.txt" 2>/dev/null | sort || true)"
+report_save_raw "$RAW_DIR/metrics_before.txt" metrics_before.txt
+
+log "  requests_total=$requests_before errors_total=$errors_before"
+
+# ---------------------------------------------------------------------------
+# 4. Live probe — minimal chat completion
+# ---------------------------------------------------------------------------
+log "step 4: live probe (minimal chat completion)"
+
+# Resolve a model to probe. Prefer the explicit override; otherwise derive
+# from /v1/models (downstream-visible catalog) or the first route's model.
+probe_model="$METAPI_TEST_MODEL"
+if [ -z "$probe_model" ]; then
+	models_code="$(curl -sS -o "$RAW_DIR/models.json" -w '%{http_code}' \
+		-H "Authorization: Bearer ${METAPI_PROXY_TOKEN}" \
+		--max-time "$METAPI_REQUEST_TIMEOUT" \
+		"${METAPI_URL}/v1/models" 2>"$RAW_DIR/models.err" || true)"
+	if [ "$models_code" = "200" ] && [ -s "$RAW_DIR/models.json" ]; then
+		# /v1/models returns {data:[{id:...}]}
+		probe_model="$(jq -r '.data[0].id // empty' "$RAW_DIR/models.json" 2>/dev/null || true)"
+	fi
+	if [ -z "$probe_model" ]; then
+		# Fallback: first route's source model from the routes summary.
+		probe_model="$(jq -r '.[0].sourceModel // .[0].source_model // .items[0].sourceModel // empty' "$RAW_DIR/routes.json" 2>/dev/null || true)"
+	fi
+fi
+
+probe_status=""
+probe_request_id=""
+probe_body_excerpt=""
+probe_skipped=0
+
+if [ -z "$probe_model" ]; then
+	log_warn "no probe model resolved — skipping live probe (set METAPI_TEST_MODEL to force one)"
+	probe_skipped=1
+	report_push_residual "live probe skipped — no model resolved (set METAPI_TEST_MODEL)"
+else
+	log "  probing model: $probe_model"
+	probe_body="{\"model\":\"${probe_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"p0585 cascade verify (read-only)\"}],\"max_tokens\":1,\"stream\":false}"
+	probe_status="$(curl_proxy_json /v1/chat/completions probe.json "$probe_body")"
+	if [ -f "$RAW_DIR/probe.json.headers" ]; then
+		probe_request_id="$(awk -F': ' 'tolower($1)=="x-request-id"{gsub(/\r/,"",$2); print $2; exit}' "$RAW_DIR/probe.json.headers" 2>/dev/null || true)"
+	fi
+	if [ -f "$RAW_DIR/probe.json.body" ]; then
+		probe_body_excerpt="$(head -c 240 "$RAW_DIR/probe.json.body" | tr -d '\n')"
+	fi
+	log "  probe status=$probe_status request_id=$probe_request_id"
+fi
+
+report_set '.liveProbe' "$(jq -n \
+	--arg model "$probe_model" \
+	--argjson status "$probe_status" \
+	--arg requestId "$probe_request_id" \
+	--arg bodyExcerpt "$probe_body_excerpt" \
+	--argjson skipped "$probe_skipped" \
+	'{model: $model, status: $status, requestId: $requestId, bodyExcerpt: $bodyExcerpt, skipped: $skipped}')"
+
+if [ "$probe_skipped" -eq 0 ] && [ "$probe_status" = "200" ]; then
+	log_ok "live probe succeeded (HTTP 200, request_id=$probe_request_id)"
+	report_push_verified "live chat-completions probe returned 200 (happy path intact)"
+elif [ "$probe_skipped" -eq 0 ]; then
+	log_warn "live probe returned $probe_status — not necessarily a cascade failure (model may be unavailable upstream)"
+	report_push_residual "live probe status=$probe_status (model=$probe_model) — non-200, see body in raw report"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Metrics after + diff
+# ---------------------------------------------------------------------------
+log "step 5: metrics snapshot (after) + diff"
+metrics_after_code="$(curl_public /metrics metrics_after.txt)"
+requests_after="$(grep -E '^metapi_proxy_requests_total ' "$RAW_DIR/metrics_after.txt" 2>/dev/null | awk '{print $2}' | tail -n1 || echo 0)"
+errors_after="$(grep -E '^metapi_proxy_errors_total ' "$RAW_DIR/metrics_after.txt" 2>/dev/null | awk '{print $2}' | tail -n1 || echo 0)"
+outcomes_after_json="$(awk '/^metapi_proxy_outcomes_total\{/{found=1} found{print} /^$/{found=0}' "$RAW_DIR/metrics_after.txt" 2>/dev/null | sort || true)"
+
+req_delta=$(( requests_after - requests_before ))
+err_delta=$(( errors_after - errors_before ))
+
+report_set '.metricsDiff' "$(jq -n \
+	--argjson requestsBefore "$requests_before" \
+	--argjson requestsAfter "$requests_after" \
+	--argjson requestsDelta "$req_delta" \
+	--argjson errorsBefore "$errors_before" \
+	--argjson errorsAfter "$errors_after" \
+	--argjson errorsDelta "$err_delta" \
+	'{requestsBefore: $requestsBefore, requestsAfter: $requestsAfter, requestsDelta: $requestsDelta, errorsBefore: $errorsBefore, errorsAfter: $errorsAfter, errorsDelta: $errorsDelta}')"
+
+if [ "$req_delta" -ge 1 ]; then
+	log_ok "metrics moved: requests_total +$req_delta (errors +$err_delta)"
+	report_push_verified "Prometheus counters moved after probe (requests +$req_delta, errors +$err_delta)"
+else
+	log_warn "metrics did not move — probe may not have reached the proxy loop"
+	report_push_residual "metrics did not move after probe (requests_delta=$req_delta)"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Cascade evidence — group recent proxy_logs by request_id
+# ---------------------------------------------------------------------------
+log "step 6: cascade evidence (recent proxy_logs grouped by request_id)"
+logs_code="$(curl_admin '/api/stats/proxy-logs?view=query&limit=100' proxy_logs.json)"
+
+cascaded_request_count=0
+cascaded_examples_json='[]'
+if [ "$logs_code" = "200" ] && [ -s "$RAW_DIR/proxy_logs.json" ]; then
+	# Items is a list of proxy_log rows. Group by requestId; rows sharing a
+	# request_id with >1 distinct channelId (or retry_count>0) are cascade
+	# evidence. We only read fields — never mutate.
+	cascaded_examples_json="$(jq -r '
+		.items // []
+		| group_by(.requestId // "")
+		| map(select(.[0].requestId != ""))
+		| map({
+			requestId: .[0].requestId,
+			attempts: length,
+			distinctChannels: ([.[].channelId // .[0].channel_id] | unique | length),
+			channels: [.[].channelId // .[0].channel_id],
+			retryCounts: [.[].retryCount // .[0].retry_count // 0],
+			statuses: [.[].status],
+			httpStatuses: [.[].httpStatus // .[0].http_status],
+			model: (.[0].modelRequested // .[0].model_requested // .[0].model // ""),
+			createdAt: .[0].createdAt
+		})
+		| map(select(.attempts > 1 or ([.retryCounts[]] | any(. > 0))))
+	' "$RAW_DIR/proxy_logs.json" 2>/dev/null || echo '[]')"
+	cascaded_request_count="$(echo "$cascaded_examples_json" | jq 'length')"
+else
+	log_warn "proxy_logs endpoint returned $logs_code — cannot collect cascade evidence from logs"
+	report_push_residual "proxy_logs endpoint unavailable ($logs_code) — no on-disk cascade evidence collected"
+fi
+
+if [ "$cascaded_request_count" -gt 0 ]; then
+	log_ok "found $cascaded_request_count request(s) with multi-channel cascade attempts in recent logs"
+	report_push_verified "$cascaded_request_count request(s) show multi-channel cascade attempts in proxy_logs (on-disk evidence)"
+else
+	log_warn "no multi-channel cascade attempts found in the last 100 proxy_logs"
+	report_push_residual "no cascade attempt found in recent 100 proxy_logs — either topology is single-channel or no 5xx occurred recently"
+fi
+report_set '.cascadeEvidence' "$(jq -n \
+	--argjson logsStatus "$logs_code" \
+	--argjson cascadedRequestCount "$cascaded_request_count" \
+	--argjson examples "$cascaded_examples_json" \
+	'{logsStatus: $logsStatus, cascadedRequestCount: $cascadedRequestCount, examples: $examples}')"
+
+# ---------------------------------------------------------------------------
+# 7. Manual cascade-trigger procedure (documentation only — NOT executed)
+# ---------------------------------------------------------------------------
+log "step 7: documenting manual cascade-trigger procedure (NOT executed — read-only)"
+
+manual_procedure='To force a cascade against this instance (destructive — do NOT run unattended):
+  1. Pick a route with >=2 channels (see topology.perRoute in this report).
+  2. PUT /api/channels/{id} with {"enabled":false} on the first channel only,
+     OR point its account at a deliberately broken upstream.
+  3. Send a chat completion for the route model; expect the conductor to
+     exclude the failing channel and retry on a healthy sibling.
+  4. Confirm by querying proxy_logs for the X-Request-Id: you should see
+     >=2 rows with the same requestId, distinct channelId, and retryCount
+     stepping 0 -> 1.
+  5. Re-enable the channel and verify recovery.
+This script intentionally does NOT perform step 2-3 automatically because
+disabling a production channel is a destructive, non-read-only action.'
+report_push_residual "manual cascade-trigger procedure documented but NOT executed (production-safe)"
+
+# ---------------------------------------------------------------------------
+# 8. Verdict + human summary
+# ---------------------------------------------------------------------------
+# Verdict is honest: "verified" only when both topology AND on-disk/live
+# evidence were collected; otherwise "partial".
+verified_count="$(jq '.verified | length' "$REPORT_JSON")"
+residual_count="$(jq '.residual | length' "$REPORT_JSON")"
+
+if [ "$cascaded_request_count" -gt 0 ] && [ "$multi_channel_routes" -gt 0 ]; then
+	verdict="verified"
+else
+	verdict="partial"
+fi
+report_set '.verdict' "$(jq -n --arg v "$verdict" '$v')"
+
+echo ""
+echo "================ P0-585 cascade verification report ================"
+echo " Instance      : $METAPI_URL"
+echo " Timestamp     : $TIMESTAMP_ISO"
+echo " Verdict       : $verdict"
+echo " Verified      : $verified_count item(s)"
+echo " Residual      : $residual_count item(s)"
+echo " Topology      : sites=$site_count routes=$route_count channels=$channel_count multi-channel-routes=$multi_channel_routes (max $max_channels_per_route)"
+echo " Live probe    : model=$probe_model status=$probe_status request_id=$probe_request_id"
+echo " Metrics diff  : requests +$req_delta, errors +$err_delta"
+echo " Cascade logs  : $cascaded_request_count request(s) with multi-channel attempts in last 100 proxy_logs"
+echo " Report JSON   : $REPORT_JSON"
+echo " Raw artefacts : $RAW_DIR/"
+echo "====================================================================="
+echo ""
+echo "Verified:"
+jq -r '.verified[] | "  - " + .' "$REPORT_JSON"
+echo "Residual (honest gaps):"
+jq -r '.residual[] | "  - " + .' "$REPORT_JSON" || echo "  (none)"
+echo ""
+echo "Manual procedure (NOT executed):"
+echo "$manual_procedure"

--- a/scripts/verify-cascade-prod.sh
+++ b/scripts/verify-cascade-prod.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# verify-cascade-hk3.sh — P0-585 production multi-channel cascade verification.
+# verify-cascade-prod.sh — P0-585 production multi-channel cascade verification.
 #
-# Connects to a running metapi instance (hk3 or any reachable host) and captures
-# honest, READ-ONLY evidence of the multi-channel cascade failover behaviour.
+# Connects to a running metapi instance (any reachable host — set METAPI_URL)
+# and captures honest, READ-ONLY evidence of the multi-channel cascade
+# failover behaviour.
 # This script performs NO destructive actions: it does not disable channels,
 # rotate credentials, or mutate routing state. It only:
 #   1. checks health / readiness
@@ -19,17 +20,18 @@
 #
 # ---------------------------------------------------------------------------
 # Usage:
-#   # On the hk3 host itself (instance bound to 127.0.0.1:4000):
-#   ssh hk3 'bash -s' < scripts/verify-cascade-hk3.sh
+#   # On the production host itself (instance bound to 127.0.0.1:4000):
+#   ssh <prod-host> 'bash -s' < scripts/verify-cascade-prod.sh
 #
-#   # Locally against a tunnel (ssh -L 4000:127.0.0.1:4000 hk3):
+#   # Locally against an SSH tunnel to the production host:
+#   ssh -L 4000:127.0.0.1:4000 <prod-host> -N   # in one terminal
 #   METAPI_URL=http://127.0.0.1:4000 \
 #   METAPI_AUTH_TOKEN=<admin-token> \
 #   METAPI_PROXY_TOKEN=<proxy-token> \
-#   ./scripts/verify-cascade-hk3.sh
+#   ./scripts/verify-cascade-prod.sh
 #
 #   # Override the model used for the live probe (recommended):
-#   METAPI_TEST_MODEL=gpt-4o-mini ./scripts/verify-cascade-hk3.sh
+#   METAPI_TEST_MODEL=gpt-4o-mini ./scripts/verify-cascade-prod.sh
 #
 # Required env:
 #   METAPI_AUTH_TOKEN  — admin AUTH_TOKEN (for /api/* topology + proxy_logs)


### PR DESCRIPTION
## Summary

Closes #557 partially — ships the verification **tooling and procedure** for collecting honest production multi-channel cascade evidence against the live deployment, without faking it. The `docs/STATE.md` honesty row `cascade | partial` is addressed: the gap was "production multi-channel proof still required"; this PR provides the operator-runnable script and the build-tagged staging test that collect that proof, plus the procedure document.

- **`scripts/verify-cascade-prod.sh`** — a read-only shell script that connects to any reachable metapi instance (`METAPI_URL`), snapshots the topology (`/api/sites`, `/api/routes`, `/api/channels`), diffs Prometheus counters around a minimal chat-completions probe, and groups recent `proxy_logs` by `request_id` to surface multi-channel cascade attempts. Production-safe: no channel disable or routing mutation. Outputs a structured JSON report + raw artefacts.
- **`e2e/e2e_p0585_production_test.go`** — a `//go:build staging` test (excluded from normal CI) that sends a probe, captures `X-Request-Id`, fetches `proxy_logs`, and asserts channel-scoped exclude + bounded `retry_count` semantics **when** a cascade is observed. `t.Skip`s with an honest residual on a healthy instance (no 5xx ⇒ no cascade).
- **`docs/analysis/p0585-production-verification.md`** — documents the cascade isolation feature, the step-by-step verification procedure, the evidence to capture, and an honest verified-vs-residual matrix.

## What's verified vs. what's still residual

**Verified (by this PR):**
- Verification procedure + tooling shipped (read-only script + build-tagged staging test).
- Topology/metrics/proxy_logs collection is automated and production-safe.
- Staging test asserts channel-scoped exclude + bounded retry **when** cascade occurs.
- `go build ./...`, `go vet ./e2e` (default + `-tags=staging`), existing `e2e` tests, and `docs-hygiene` all pass; the staging test is build-tagged out of CI.

**Still partial (honest):**
- No captured production evidence is committed — an operator must run the script against the live instance and attach the JSON report.
- Cascade is only observable on a real upstream 5xx; a fully-healthy instance yields no cascade rows (the test honestly `t.Skip`s).
- The destructive cascade trigger (channel disable via `PUT /api/channels/{id}`) is operator-gated, not automated.
- If the production instance has no multi-channel route, cascade cannot be exercised on it at all — a topology gap, not a code gap.

## Verification procedure

```bash
# Tunnel to the production instance, then:
METAPI_URL=http://127.0.0.1:4000 \
METAPI_AUTH_TOKEN=<admin-token> \
METAPI_PROXY_TOKEN=<proxy-token> \
METAPI_TEST_MODEL=<a-model-on-a-multi-channel-route> \
  ./scripts/verify-cascade-prod.sh

# Deeper assertions (build-tagged, NOT run in CI):
METAPI_STAGING_URL=http://127.0.0.1:4000 \
METAPI_AUTH_TOKEN=<admin-token> \
METAPI_PROXY_TOKEN=<proxy-token> \
  go test ./e2e -tags=staging -run 'P0585_ProductionCascade_Staging' -v -timeout=120s
```

The decisive cascade signal: a `requestId` with multiple `proxy_logs` rows, distinct `channelId`s, and `retry_count` stepping — the same on-disk truth the HTTP e2e asserts against, observed against a live instance.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./e2e/...` passes (default tags)
- [x] `go vet -tags=staging ./e2e/...` passes (staging test compiles)
- [x] `go test ./e2e/...` passes (existing e2e green; staging test excluded by build tag)
- [x] `go test ./docs/... -run TestPublicMarkdownHygiene` passes
- [x] `bash -n scripts/verify-cascade-prod.sh` syntax OK
- [ ] Operator run against the live instance + attach `cascade-verify-*.json` to #557 (residual)