### PR TITLE
feat(detect): add SenseTime platform detection

### DIFF
--- a/platform/registry.go
+++ b/platform/registry.go
@@ -40,6 +40,7 @@ var PlatformAliases = map[string]string{
 	"cliproxyapi":   "cliproxyapi",
 	"cpa":           "cliproxyapi",
 	"cli-proxy-api": "cliproxyapi",
+	"sensetime":     "sensetime",
 }
 
 // orderedPlatformNames defines the spec-required adapter registration order.
@@ -54,6 +55,7 @@ var orderedPlatformNames = []string{
 	"antigravity",
 	"grok",
 	"cliproxyapi",
+	"sensetime",
 	"anyrouter",
 	"done-hub",
 	"one-hub",
@@ -104,6 +106,8 @@ func buildAdapter(name string) PlatformAdapter {
 			LoginUnsupportedMessage:   "CLIProxyAPI does not support login",
 			CheckinUnsupportedMessage: "CLIProxyAPI does not support checkin",
 		}}
+	case "sensetime":
+		return NewStandardAdapter("sensetime")
 	case "anyrouter":
 		return &AnyRouterAdapter{NewApiAdapter: &NewApiAdapter{BaseAdapter: NewBaseAdapter("anyrouter")}}
 	case "done-hub":

--- a/platform/registry_test.go
+++ b/platform/registry_test.go
@@ -31,7 +31,7 @@ func TestRegistry_RegistrationOrder(t *testing.T) {
 	// Verify order matches spec
 	expected := []string{
 		"openai", "codex", "claude", "gemini", "gemini-cli",
-		"antigravity", "grok", "cliproxyapi", "anyrouter", "done-hub",
+		"antigravity", "grok", "cliproxyapi", "sensetime", "anyrouter", "done-hub",
 		"one-hub", "veloera", "new-api", "sub2api", "one-api",
 	}
 	if len(names) != len(expected) {
@@ -61,6 +61,21 @@ func TestGetAdapter(t *testing.T) {
 	a3 := GetAdapter("")
 	if a3 != nil {
 		t.Errorf("GetAdapter('') should return nil: %v", a3)
+	}
+}
+
+func TestGetAdapter_SenseTime(t *testing.T) {
+	a := GetAdapter("sensetime")
+	if a == nil {
+		t.Fatal("expected adapter for 'sensetime', got nil")
+	}
+	if a.PlatformName() != "sensetime" {
+		t.Errorf("expected PlatformName 'sensetime', got %q", a.PlatformName())
+	}
+	// Alias normalization: mixed-case input resolves via PlatformAliases.
+	a2 := GetAdapter("SenseTime")
+	if a2 == nil || a2.PlatformName() != "sensetime" {
+		t.Errorf("GetAdapter('SenseTime') should resolve via alias: %v", a2)
 	}
 }
 

--- a/service/site_detect.go
+++ b/service/site_detect.go
@@ -36,9 +36,11 @@ func DetectSite(rawURL string) *DetectResult {
 	}
 
 	parsed, err := url.Parse(trimmed)
-	if err != nil {
-		// Allow scheme-less inputs such as "api.deepseek.com/v1".
-		if withScheme, schemeErr := url.Parse("https://" + trimmed); schemeErr == nil {
+	// Allow scheme-less inputs such as "api.deepseek.com/v1" or
+	// "api.sensetime.com": url.Parse succeeds but leaves Host empty for bare
+	// host/path strings, so retry with an https:// prefix.
+	if err != nil || parsed == nil || parsed.Host == "" {
+		if withScheme, schemeErr := url.Parse("https://" + trimmed); schemeErr == nil && withScheme.Host != "" {
 			parsed = withScheme
 			err = nil
 		}
@@ -118,6 +120,8 @@ func DetectSite(rawURL string) *DetectResult {
 		platform = "github-copilot"
 	case strings.Contains(host, "claude.ai"):
 		platform = "claude"
+	case strings.Contains(host, "api.sensetime.com") || strings.Contains(host, "sensetime.com"):
+		platform = "sensetime"
 	case strings.Contains(host, "aistudio.google.com") || strings.Contains(host, "makersuite.google.com"):
 		platform = "gemini"
 	default:

--- a/service/site_service_test.go
+++ b/service/site_service_test.go
@@ -157,6 +157,25 @@ func TestDetectSite_SiliconFlow(t *testing.T) {
 	}
 }
 
+func TestDetectSite_SenseTime(t *testing.T) {
+	tests := []string{
+		"https://api.sensetime.com/v1",
+		"https://sensetime.com",
+		"api.sensetime.com",
+	}
+	for _, url := range tests {
+		t.Run(url, func(t *testing.T) {
+			result := DetectSite(url)
+			if result == nil {
+				t.Fatalf("expected detection for %q, got nil", url)
+			}
+			if result.Platform != "sensetime" {
+				t.Errorf("expected 'sensetime' for %q, got %q", url, result.Platform)
+			}
+		})
+	}
+}
+
 func TestDetectSite_ModelScope(t *testing.T) {
 	// Bare modelscope inference root maps to the Claude-compatible preset.
 	result := DetectSite("https://api-inference.modelscope.cn")


### PR DESCRIPTION
## Summary

Fixes #562 — SenseTime (商汤) API endpoints were being auto-detected as invalid/unknown because there was no `sensetime` hostname heuristic and no adapter in the platform registry.

- **`service/site_detect.go`**: added a hostname heuristic case for `api.sensetime.com` / `sensetime.com` → `"sensetime"` (placed before the adapter-chain `default`). Also hardened the scheme-less input fallback so bare hostnames like `api.sensetime.com` — where `url.Parse` succeeds but leaves `Host` empty — get retried with an `https://` prefix. This matches the function's stated intent (`// Allow scheme-less inputs such as "api.deepseek.com/v1"`) and directly helps the reported "auto-judged as invalid" symptom for users pasting bare hostnames.
- **`platform/registry.go`**: registered `sensetime` as a `StandardAdapter` — added to `PlatformAliases`, `orderedPlatformNames` (vendor section, before the `one-api` catch-all), and a `buildAdapter` case returning `NewStandardAdapter("sensetime")`. SenseTime exposes an OpenAI-compatible API (`/v1/chat/completions`, `/v1/models`), so `StandardAdapter` provides `VerifyToken` / standard capabilities out of the box with no new platform package file.

### Notes
- **Site initialization preset**: intentionally **not** added. The preset registry keys off *protocol families* (`openai`/`claude`), and a host-matching preset would make `DetectSite` return `"openai"` (preset wins, confidence 1.0), which conflicts with the required detection result `"sensetime"`. The hostname heuristic cleanly yields `"sensetime"`; a future preset could be added if the protocol-family/vendor-tag model is reconciled.
- No new platform package file — `StandardAdapter` reuse only.

## Test plan

- [x] `go build ./platform/... ./service/...` clean; `go vet` clean
- [x] `go test ./platform/... ./service/...` — all green
- [x] `TestDetectSite_SenseTime` — `DetectSite` returns `"sensetime"` for `https://api.sensetime.com/v1`, `https://sensetime.com`, and bare `api.sensetime.com`
- [x] `TestGetAdapter_SenseTime` — `GetAdapter("sensetime")` resolves; `GetAdapter("SenseTime")` resolves via alias
- [x] `TestRegistry_RegistrationOrder` — `sensetime` registered in correct order (16 adapters, no duplicates)
- [x] No regressions: `TestDetectSite_InvalidURL`, `TestDetectSite_Unknown`, `TestDetectSite_EmptyString`, `TestRegistry_AdapterCount`, `TestRequiredPlatformNames`, `TestNormalizePlatformAlias` all pass

> Note: `go build ./...` shows one pre-existing, unrelated error in `web/embed.go` (`pattern dist: no matching files found`) because the frontend `dist` bundle is not built in this worktree. It is unrelated to these changes (service/platform only).