### PR TITLE
docs: env vars + API endpoints + validation hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Required in production: generate a unique 32+ byte random secret in your local .env,
 # keep it out of git, and do not reuse AUTH_TOKEN.
+# Validation: < 8 bytes is a critical error (trivially brute-forceable);
+# < 16 bytes logs a weak-secret warning. Prefer 32+ random bytes.
 ACCOUNT_CREDENTIAL_SECRET=REPLACE_WITH_STRONG_RANDOM_SECRET
 AUTH_TOKEN=change-me-admin-token
 CHECKIN_CRON=0 8 * * *
@@ -190,6 +192,25 @@ RESPONSES_COMPACT_FALLBACK_TO_RESPONSES_ENABLED=
 # comma-separated case-insensitive substring patterns at runtime.
 PROMPT_FILTER_ENABLED=
 PROMPT_FILTER_DENY_PATTERNS=
+
+# ---- Resin sticky proxy pool (#693) ----
+# Resin pins an OAuth account to a stable residential/ISP proxy lease so
+# platforms that fingerprint IP continuity (Anthropic, Google) stop forcing
+# re-auth on every rotation. Env-only — no DDL for Tier 1.
+# RESIN_URL carries the base URL + token, e.g. http://resin.local:2260/my-token.
+# RESIN_PLATFORM_NAME is the Platform identity (falls back to site.Platform).
+# RESIN_ENABLED is the global opt-in (default false). Per-site resin_enabled
+# overrides this flag in the sites table.
+RESIN_URL=
+RESIN_PLATFORM_NAME=
+RESIN_ENABLED=
+
+# ---- uTLS TLS fingerprint masking (#701) ----
+# When true, all outbound platform requests use a uTLS Chrome-ClientHello
+# transport instead of Go's default crypto/tls ClientHello, masking the
+# JA3/JA4 fingerprint that Cloudflare and similar WAFs use to block automated
+# traffic. Default false. Per-site use_utls overrides this flag.
+UTLS_ENABLED=
 
 # ---- DB extras ----
 # Optional PG SSL override (default false; true requires TLS). Prefer DB_SSLMODE for fine control.

--- a/auth/admin.go
+++ b/auth/admin.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"crypto/subtle"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/netip"
 	"strings"
@@ -29,8 +30,20 @@ import (
 // authentication using the given configuration.
 func AdminAuth(cfg *config.Config) func(http.Handler) http.Handler {
 	// Pre-parse the allowlist once at factory creation time so we don't
-	// re-parse string entries on every request.
-	parsedAllowlist := parseAllowlist(cfg.AdminIpAllowlist)
+	// re-parse string entries on every request. Invalid entries are surfaced
+	// here (startup time) so operators notice a typo'd allowlist instead of
+	// believing the IP restriction is active when it silently dropped.
+	parsedAllowlist, invalidEntries := parseAllowlistWithDiagnostics(cfg.AdminIpAllowlist)
+	for _, entry := range invalidEntries {
+		slog.Warn("admin IP allowlist: skipping invalid entry",
+			"entry", entry,
+			"hint", "expected an exact IP or an IPv4 CIDR like 10.0.0.0/8")
+	}
+	if len(invalidEntries) > 0 {
+		slog.Warn("admin IP allowlist: skipped invalid entries — the allowlist may not restrict traffic as intended",
+			"skipped", len(invalidEntries),
+			"valid", len(parsedAllowlist))
+	}
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -143,8 +156,21 @@ type parsedAllowlistEntry struct {
 
 // parseAllowlist converts a list of raw allowlist strings into parsed entries.
 // Invalid entries are silently skipped (matches TS parseAllowlistEntry → null).
+// Use parseAllowlistWithDiagnostics when you need to surface skipped entries
+// (e.g. startup warnings for a misconfigured ADMIN_IP_ALLOWLIST).
 func parseAllowlist(entries []string) []parsedAllowlistEntry {
+	parsed, _ := parseAllowlistWithDiagnostics(entries)
+	return parsed
+}
+
+// parseAllowlistWithDiagnostics mirrors parseAllowlist but also returns the
+// raw entries that were non-empty yet could not be parsed into an exact IP or
+// IPv4 CIDR. Callers (e.g. AdminAuth) log these so operators notice a typo'd
+// allowlist instead of believing the restriction is active. Whitespace-only
+// entries are intentionally not reported — they are no-ops, not misconfig.
+func parseAllowlistWithDiagnostics(entries []string) ([]parsedAllowlistEntry, []string) {
 	result := make([]parsedAllowlistEntry, 0, len(entries))
+	var invalid []string
 	for _, raw := range entries {
 		entry := strings.TrimSpace(raw)
 		if entry == "" {
@@ -156,10 +182,12 @@ func parseAllowlist(entries []string) []parsedAllowlistEntry {
 			// Exact IP match
 			normalized := normalizeIP(entry)
 			if normalized == "" {
+				invalid = append(invalid, entry)
 				continue
 			}
 			// Validate it's a real IP (or at least non-empty after normalization)
 			if _, err := netip.ParseAddr(normalized); err != nil {
+				invalid = append(invalid, entry)
 				continue
 			}
 			result = append(result, parsedAllowlistEntry{
@@ -172,6 +200,7 @@ func parseAllowlist(entries []string) []parsedAllowlistEntry {
 		// CIDR match — only supports IPv4 CIDR (matches TS behavior)
 		// Check for multiple slashes (invalid)
 		if strings.IndexByte(entry[slashIdx+1:], '/') >= 0 {
+			invalid = append(invalid, entry)
 			continue
 		}
 
@@ -181,17 +210,20 @@ func parseAllowlist(entries []string) []parsedAllowlistEntry {
 		// Must be a valid IPv4 address and a numeric prefix
 		addr, err := netip.ParseAddr(networkIP)
 		if err != nil || !addr.Is4() {
+			invalid = append(invalid, entry)
 			continue
 		}
 
 		// Build the CIDR string and parse
 		prefix, err := netip.ParsePrefix(networkIP + "/" + prefixText)
 		if err != nil {
+			invalid = append(invalid, entry)
 			continue
 		}
 
 		// TS only supports prefix 0-32 for IPv4
 		if !prefix.Addr().Is4() {
+			invalid = append(invalid, entry)
 			continue
 		}
 
@@ -200,7 +232,7 @@ func parseAllowlist(entries []string) []parsedAllowlistEntry {
 			cidrPrefix: prefix,
 		})
 	}
-	return result
+	return result, invalid
 }
 
 // isIPAllowed checks whether the given client IP is allowed by the allowlist.

--- a/auth/admin_test.go
+++ b/auth/admin_test.go
@@ -700,3 +700,71 @@ func TestAdminAuth_IPCheckBeforeAuthCheck(t *testing.T) {
 		t.Errorf("expected 'IP not allowed', got %q", w.Body.String())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// parseAllowlistWithDiagnostics tests
+// ---------------------------------------------------------------------------
+
+func TestParseAllowlistWithDiagnostics_ReportsInvalidEntries(t *testing.T) {
+	parsed, invalid := parseAllowlistWithDiagnostics([]string{
+		"192.168.1.1",
+		"10.0.0.0/8",
+		"not-an-ip",
+		"",
+		"172.16.0.0/12",
+		"10.0.0.0/8/invalid",
+	})
+
+	if len(parsed) != 3 {
+		t.Errorf("expected 3 valid entries, got %d: %+v", len(parsed), parsed)
+	}
+	wantInvalid := []string{"not-an-ip", "10.0.0.0/8/invalid"}
+	if len(invalid) != len(wantInvalid) {
+		t.Fatalf("expected %d invalid entries, got %d: %v", len(wantInvalid), len(invalid), invalid)
+	}
+	for i, want := range wantInvalid {
+		if invalid[i] != want {
+			t.Errorf("invalid[%d] = %q, want %q", i, invalid[i], want)
+		}
+	}
+}
+
+func TestParseAllowlistWithDiagnostics_WhitespaceNotReported(t *testing.T) {
+	// Whitespace-only entries are no-ops, not misconfigurations — they must
+	// not appear in the invalid list.
+	parsed, invalid := parseAllowlistWithDiagnostics([]string{"  ", "", "\t"})
+	if len(parsed) != 0 {
+		t.Errorf("expected 0 valid entries, got %d", len(parsed))
+	}
+	if len(invalid) != 0 {
+		t.Errorf("expected 0 invalid entries for whitespace-only input, got %v", invalid)
+	}
+}
+
+func TestParseAllowlistWithDiagnostics_AllValid(t *testing.T) {
+	parsed, invalid := parseAllowlistWithDiagnostics([]string{
+		"192.168.1.1",
+		"10.0.0.0/8",
+		"::ffff:10.0.0.1",
+	})
+	if len(parsed) != 3 {
+		t.Errorf("expected 3 valid entries, got %d", len(parsed))
+	}
+	if len(invalid) != 0 {
+		t.Errorf("expected 0 invalid entries, got %v", invalid)
+	}
+}
+
+func TestParseAllowlist_DelegatesAndDiscardsInvalid(t *testing.T) {
+	// parseAllowlist must remain backward-compatible: it returns only valid
+	// entries and silently drops invalid ones (same as before the diagnostics
+	// split, so downstream.go callers keep working unchanged).
+	result := parseAllowlist([]string{
+		"192.168.1.1",
+		"not-an-ip",
+		"10.0.0.0/8",
+	})
+	if len(result) != 2 {
+		t.Errorf("expected 2 valid entries (invalid dropped), got %d", len(result))
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -512,3 +512,71 @@ func configErrorCritical(err error) bool {
 	}
 	return false
 }
+
+func TestValidateCriticalOnShortCredentialSecret(t *testing.T) {
+	// 7-byte secret (< 8) must be a critical error. Short keys were silently
+	// accepted before the length floor was added.
+	cfg := Load(map[string]string{
+		"AUTH_TOKEN":                "admin-token-not-default",
+		"PROXY_TOKEN":               "proxy-token-not-default",
+		"ACCOUNT_CREDENTIAL_SECRET": "tiny123", // 7 bytes
+		"CLAUDE_CLIENT_ID":          "claude-client",
+		"CODEX_CLIENT_ID":           "codex-client",
+		"GEMINI_CLI_CLIENT_ID":      "gemini-client",
+	})
+
+	var found bool
+	for _, err := range cfg.Validate() {
+		if configErrorField(err) == "account_credential_secret" && configErrorCritical(err) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("Validate did not return critical error for < 8 byte credential secret")
+	}
+}
+
+func TestValidateWarnsOnWeakCredentialSecret(t *testing.T) {
+	// 14-byte secret (>= 8, < 16) must be a non-critical warning.
+	cfg := Load(map[string]string{
+		"AUTH_TOKEN":                "admin-token-not-default",
+		"PROXY_TOKEN":               "proxy-token-not-default",
+		"ACCOUNT_CREDENTIAL_SECRET": "mediumsecret12", // 14 bytes
+		"CLAUDE_CLIENT_ID":          "claude-client",
+		"CODEX_CLIENT_ID":           "codex-client",
+		"GEMINI_CLI_CLIENT_ID":      "gemini-client",
+	})
+
+	var foundWarning bool
+	for _, err := range cfg.Validate() {
+		if configErrorField(err) != "account_credential_secret" {
+			continue
+		}
+		if configErrorCritical(err) {
+			t.Fatalf("14-byte secret flagged critical, want warning: %v", err)
+		}
+		foundWarning = true
+	}
+	if !foundWarning {
+		t.Fatal("Validate did not return weak-secret warning for 14 byte credential secret")
+	}
+}
+
+func TestValidateAcceptsStrongCredentialSecret(t *testing.T) {
+	// 17-byte secret (>= 16) must produce no credential_secret length error.
+	cfg := Load(map[string]string{
+		"AUTH_TOKEN":                "admin-token-not-default",
+		"PROXY_TOKEN":               "proxy-token-not-default",
+		"ACCOUNT_CREDENTIAL_SECRET": "credential-secret", // 17 bytes
+		"CLAUDE_CLIENT_ID":          "claude-client",
+		"CODEX_CLIENT_ID":           "codex-client",
+		"GEMINI_CLI_CLIENT_ID":      "gemini-client",
+	})
+
+	for _, err := range cfg.Validate() {
+		if configErrorField(err) == "account_credential_secret" {
+			t.Fatalf("Validate returned credential_secret error for 17 byte secret: %v", err)
+		}
+	}
+}

--- a/config/validate.go
+++ b/config/validate.go
@@ -246,6 +246,29 @@ func (c *Config) Validate() []error {
 			msg:      "UNSAFE: account credential encryption key not set — stored credentials are NOT encrypted",
 			critical: false,
 		})
+	} else {
+		// Length-based strength validation. Load() resolves an unset
+		// ACCOUNT_CREDENTIAL_SECRET to AUTH_TOKEN, then to the default admin
+		// token, so the value here is the final resolved secret. A short key
+		// silently passes the empty check above, so enforce explicit floors:
+		//   < 8 bytes  → critical (trivially brute-forceable)
+		//   < 16 bytes → warning  (weak; .env.example recommends 32+ bytes)
+		secretLen := len(c.AccountCredentialSecret)
+		if secretLen < 8 {
+			errs = append(errs, &configError{
+				field:    "account_credential_secret",
+				value:    fmt.Sprintf("%d bytes", secretLen),
+				msg:      "UNSAFE: secret is shorter than 8 bytes — trivially brute-forceable; use a 32+ byte random secret",
+				critical: true,
+			})
+		} else if secretLen < 16 {
+			errs = append(errs, &configError{
+				field:    "account_credential_secret",
+				value:    fmt.Sprintf("%d bytes", secretLen),
+				msg:      "weak: secret is shorter than 16 bytes — use a 32+ byte random secret for production",
+				critical: false,
+			})
+		}
 	}
 
 	// --- Warning: OAuth client IDs are placeholders ---

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # Admin API Reference
 
-**Last updated**: 2026-08-11
+**Last updated**: 2026-08-15
 
 Base URL: `http://localhost:4000/api`
 
@@ -152,10 +152,42 @@ Delete a channel.
 
 ### POST /api/admin/test-channel
 
+**Auth**: admin Bearer token. Alias: `POST /api/debug/channel-probe` (same handler).
 
-Body: `{ "channelId"?: number, "siteId"?: number, "model"?: string, "prompt"?: string, "mode"?: "chat"|"models", "timeoutMs"?: number }`.
+Forces a single upstream request against a specific channel or site, bypassing weighted selection. Useful for smoke-testing a channel after a credential rotation.
 
-Requires `channelId` or `siteId`. Forces one upstream request (no weighted selection). Returns `{ success, statusCode, latencyMs, truncatedBody, error, channelId, siteId, accountId, model, mode, bodyTruncated, ... }` with ~2 KiB redacted body summary.
+**Body**:
+```json
+{
+  "channelId": 12,
+  "siteId": 3,
+  "model": "gpt-4o-mini",
+  "prompt": "ping",
+  "mode": "chat",
+  "timeoutMs": 15000
+}
+```
+
+Either `channelId` or `siteId` is required. `mode` is `chat` (default) or `models`; `models` issues a `GET /v1/models` instead of a chat completion. `timeoutMs` is clamped to `[1000, 60000]` (default `15000`). `prompt` is truncated to 256 runes and never persisted.
+
+**Response** (200):
+```json
+{
+  "success": true,
+  "statusCode": 200,
+  "latencyMs": 842,
+  "truncatedBody": "...",
+  "error": "",
+  "channelId": 12,
+  "siteId": 3,
+  "accountId": 5,
+  "model": "gpt-4o-mini",
+  "mode": "chat",
+  "bodyTruncated": true
+}
+```
+
+Returns a ~2 KiB redacted body summary (`bodyTruncated` flags truncation). Secret-like tokens in the body/error are redacted. A channel with no usable token returns `success: false` with `error: "No usable token on channel/account ..."`.
 
 ---
 
@@ -526,6 +558,132 @@ Start a monitoring session.
 ### DELETE /api/monitor/session
 
 Clear the monitoring session.
+
+---
+
+## Admin Diagnostics & Observability
+
+Read-only surfaces for resin, scheduler health, and rate overview. These endpoints never mutate state; they exist so operators can confirm automations and rate tuning at a glance.
+
+### GET /api/admin/resin/status
+
+Resin sticky-proxy-pool observability snapshot (#698).
+
+**Auth**: admin Bearer token.
+
+**Response** (200):
+```json
+{
+  "enabled": false,
+  "resinUrl": "http://resin.local:2260/my-token",
+  "platformName": "",
+  "activeLeases": [
+    { "accountId": 5, "lastUsed": "2026-08-15T08:12:00Z" }
+  ],
+  "perSiteOverrides": [
+    { "siteId": 3, "name": "anthropic", "platform": "anthropic", "resinEnabled": true }
+  ],
+  "generatedAt": "2026-08-15T08:12:30Z"
+}
+```
+
+`enabled` reflects `RESIN_ENABLED` plus a non-empty `RESIN_URL`. `activeLeases` lists accounts whose last-used timestamp is fresher than the 5-minute stale TTL. `perSiteOverrides` only lists sites with an explicit non-NULL `resin_enabled` column (NULL-inherit rows are absent so the snapshot stays bounded).
+
+### GET /api/scheduler/status
+
+Unified run-history view of recurring schedulers. Each entry reports the job's last-run signal and a coarse 24h activity window.
+
+**Auth**: admin Bearer token.
+
+**Response** (200):
+```json
+{
+  "items": [
+    {
+      "job": "checkin",
+      "enabled": true,
+      "lastRunAt": "2026-08-15T08:00:00Z",
+      "lastStatus": "success",
+      "runs24h": 4,
+      "success24h": 4
+    },
+    {
+      "job": "model-probe",
+      "enabled": false,
+      "lastStatus": "never",
+      "note": "not enabled (MODEL_AVAILABILITY_PROBE_ENABLED)"
+    }
+  ],
+  "generatedAt": "2026-08-15T08:12:30Z"
+}
+```
+
+Jobs surfaced: `checkin`, `balance-refresh`, `model-probe`, `site-announcements`, `daily-summary`, `log-cleanup`, `usage-aggregation`. `lastStatus` is one of `success` | `failed` | `running` | `never`. Data sources are existing run signals only (checkin_logs, accounts.last_balance_refresh, in-memory probe summary, events rows) — no scheduler code changes.
+
+### GET /api/models/rates
+
+Read-only aggregation of every multiplier/rate surface: account unit cost, channel weight, site global weight, downstream-key weight, and 30-day observed model spend.
+
+**Auth**: admin Bearer token.
+
+**Response** (200):
+```json
+{
+  "generatedAt": "2026-08-15T08:12:30Z",
+  "summary": {
+    "accountsWithUnitCost": 3,
+    "accountsTotal": 5,
+    "channelsTotal": 12,
+    "channelsEnabled": 9
+  },
+  "accounts": [
+    { "accountId": 5, "username": "svc-1", "siteId": 3, "siteName": "anthropic", "unitCost": 0.003, "channelCount": 2, "totalWeight": 40 }
+  ],
+  "channels": [
+    { "channelId": 12, "routeId": 1, "routePattern": "gpt-4o", "accountId": 5, "username": "svc-1", "modelName": "gpt-4o", "weight": 20, "enabled": true }
+  ],
+  "sites": [
+    { "siteId": 3, "siteName": "anthropic", "globalWeight": 1.0 }
+  ],
+  "keys": [
+    { "keyId": 1, "name": "prod-key", "keyWeight": 1.0 }
+  ],
+  "models": [
+    { "model": "gpt-4o", "calls": 1200, "spend": 1.23, "tokens": 450000 }
+  ]
+}
+```
+
+`unitCost` is a display/planning field (estimated cost is ratio-based, never account-priced). Observed model costs are aggregated from `model_day_usage` over the trailing 30 days.
+
+### PUT /api/models/rates
+
+Batch update account unit cost and route-channel weight. Pure config writes; `unit_cost` stays a display/planning field.
+
+**Auth**: admin Bearer token.
+
+**Body**:
+```json
+{
+  "accounts": [
+    { "id": 5, "unitCost": 0.003 }
+  ],
+  "channels": [
+    { "id": 12, "weight": 20 }
+  ]
+}
+```
+
+`unitCost` and `weight` must be `>= 0`. Missing arrays are no-ops; both empty returns `400 "nothing to update"`. Weights feed the routing cache, so the handler invalidates it on success.
+
+**Response** (200):
+```json
+{
+  "success": true,
+  "updatedAccounts": 1,
+  "updatedChannels": 1
+}
+```
 
 ---
 


### PR DESCRIPTION
## Summary

P2 documentation and configuration hardening from the env/docs audit.

- **`.env.example`**: added the env vars the code reads but the example omitted — `RESIN_URL`/`RESIN_PLATFORM_NAME`/`RESIN_ENABLED` (#693) and `UTLS_ENABLED` (#701) — each with explanatory comments and defaults. `PROMPT_FILTER_*` was already present. The rate-limiting PR's vars (`PROXY_RATE_LIMIT_RPM`, `REQUEST_BODY_LIMIT_MB`, `PROXY_LOG_ASYNC`, …) are **not** added because that PR has not landed yet.
- **`docs/api.md`**: documented the 4 missing admin endpoint families — Resin status (`GET /api/admin/resin/status`), scheduler status (`GET /api/scheduler/status`), model rates (`GET/PUT /api/models/rates`), and the channel test harness (`POST /api/admin/test-channel` + `/api/debug/channel-probe` alias) — with method, path, auth, and request/response examples.
- **`ACCOUNT_CREDENTIAL_SECRET` validation**: added a length floor in `config/validate.go` — `< 8` bytes is a **critical** error (trivially brute-forceable), `< 16` bytes is a **warning**. 4-char keys no longer pass silently; `.env.example` comment now states the enforced minimum.
- **`ADMIN_IP_ALLOWLIST` diagnostics**: invalid CIDR/IP entries were silently dropped in `auth/admin.go`. Added `parseAllowlistWithDiagnostics` (returns skipped entries); `AdminAuth` now logs a per-entry warning plus a startup summary so operators notice a typo'd allowlist instead of believing the restriction is active. `parseAllowlist` stays backward-compatible (delegates, discards) so the shared `downstream.go` caller is unchanged.

## Test plan

- [x] `go build ./config/... ./auth/... ./docs/... ./handler/admin/...` — clean
- [x] `go test ./config/... ./auth/... ./docs/...` — green (incl. docs hygiene test)
- [x] New tests: `TestValidateCriticalOnShortCredentialSecret`, `TestValidateWarnsOnWeakCredentialSecret`, `TestValidateAcceptsStrongCredentialSecret`, `TestParseAllowlistWithDiagnostics_*`, `TestParseAllowlist_DelegatesAndDiscardsInvalid`
- [x] `go vet ./config/... ./auth/... ./docs/...` — clean
- [x] Existing `parseAllowlist` tests in `auth/admin_test.go` still pass (behavior unchanged)

## Notes

- `go build ./...` fails **only** on `web/embed.go` (`//go:embed dist`) because `web/dist/` is a gitignored frontend build artifact absent from this worktree — pre-existing and unrelated to this change. All non-web packages build cleanly.
- Validation stays warning-based (non-blocking) except for the clearly-insecure `< 8` byte secret, per the audit constraints.