### PR TITLE
feat: subscriptionSummary + test coverage for sharedcount/payloads

### DIFF
--- a/handler/admin/payloads/account_tokens_test.go
+++ b/handler/admin/payloads/account_tokens_test.go
@@ -1,0 +1,287 @@
+package payloads
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestAccountTokenCreatePayload_Decode covers valid/invalid/edge parsing of
+// AccountTokenCreatePayload — the request body for POST /api/account-tokens.
+func TestAccountTokenCreatePayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "full valid create",
+			input: `{"accountId":5,"name":"primary","token":"sk-1","enabled":true,"isDefault":false,"source":"manual","group":"vip","unlimitedQuota":true,"remainQuota":1000.5,"expiredTime":"2026-12-31","allowIps":"10.0.0.0/8","modelLimitsEnabled":true,"modelLimits":"gpt-4,claude-3"}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountTokenCreatePayload)
+				if p.AccountID != 5 {
+					t.Fatalf("accountId = %d", p.AccountID)
+				}
+				if p.Name == nil || *p.Name != "primary" {
+					t.Fatalf("name = %#v", p.Name)
+				}
+				if p.Token == nil || *p.Token != "sk-1" {
+					t.Fatalf("token = %#v", p.Token)
+				}
+				if p.Enabled == nil || !*p.Enabled {
+					t.Fatalf("enabled = %#v", p.Enabled)
+				}
+				if p.IsDefault == nil || *p.IsDefault {
+					t.Fatalf("isDefault = %#v", p.IsDefault)
+				}
+				if p.Source == nil || *p.Source != "manual" {
+					t.Fatalf("source = %#v", p.Source)
+				}
+				if p.Group == nil || *p.Group != "vip" {
+					t.Fatalf("group = %#v", p.Group)
+				}
+				if p.UnlimitedQuota == nil || !*p.UnlimitedQuota {
+					t.Fatalf("unlimitedQuota = %#v", p.UnlimitedQuota)
+				}
+				if p.RemainQuota == nil {
+					t.Fatalf("remainQuota should be present")
+				}
+				if p.AllowIPs == nil || *p.AllowIPs != "10.0.0.0/8" {
+					t.Fatalf("allowIps = %#v", p.AllowIPs)
+				}
+				if p.ModelLimitsEnabled == nil || !*p.ModelLimitsEnabled {
+					t.Fatalf("modelLimitsEnabled = %#v", p.ModelLimitsEnabled)
+				}
+				if p.ModelLimits == nil || *p.ModelLimits != "gpt-4,claude-3" {
+					t.Fatalf("modelLimits = %#v", p.ModelLimits)
+				}
+			},
+		},
+		{
+			name:  "any-typed remainQuota accepts string",
+			input: `{"accountId":1,"remainQuota":"unlimited"}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountTokenCreatePayload)
+				if p.RemainQuota == nil {
+					t.Fatal("remainQuota should be set")
+				}
+				if s, ok := p.RemainQuota.(string); !ok || s != "unlimited" {
+					t.Fatalf("remainQuota = %#v, want string unlimited", p.RemainQuota)
+				}
+			},
+		},
+		{
+			name:  "any-typed remainQuota accepts number",
+			input: `{"accountId":1,"remainQuota":500}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountTokenCreatePayload)
+				n, ok := p.RemainQuota.(float64)
+				if !ok || n != 500 {
+					t.Fatalf("remainQuota = %#v, want float 500", p.RemainQuota)
+				}
+			},
+		},
+		{
+			name:  "any-typed expiredTime accepts number",
+			input: `{"accountId":1,"expiredTime":1700000000}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountTokenCreatePayload)
+				n, ok := p.ExpiredTime.(float64)
+				if !ok || n != 1700000000 {
+					t.Fatalf("expiredTime = %#v, want float", p.ExpiredTime)
+				}
+			},
+		},
+		{
+			name:    "empty object leaves accountId zero",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountTokenCreatePayload)
+				if p.AccountID != 0 || p.Name != nil || p.RemainQuota != nil {
+					t.Fatalf("expected zero values: %#v", p)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"accountId":`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong accountId type rejected",
+			input:   `{"accountId":"x"}`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong name type rejected",
+			input:   `{"accountId":1,"name":5}`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong enabled type rejected",
+			input:   `{"accountId":1,"enabled":"yes"}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *AccountTokenCreatePayload { return &AccountTokenCreatePayload{} })
+}
+
+// TestAccountTokenUpdatePayload_Decode covers the partial update shape.
+func TestAccountTokenUpdatePayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "partial update",
+			input: `{"name":"renamed","enabled":false,"group":"g2","isDefault":true}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountTokenUpdatePayload)
+				if p.Name == nil || *p.Name != "renamed" {
+					t.Fatalf("name = %#v", p.Name)
+				}
+				if p.Enabled == nil || *p.Enabled {
+					t.Fatalf("enabled = %#v", p.Enabled)
+				}
+				if p.Group == nil || *p.Group != "g2" {
+					t.Fatalf("group = %#v", p.Group)
+				}
+				if p.IsDefault == nil || !*p.IsDefault {
+					t.Fatalf("isDefault = %#v", p.IsDefault)
+				}
+				if p.Token != nil {
+					t.Fatalf("untouched token should be nil: %#v", p.Token)
+				}
+			},
+		},
+		{
+			name:    "empty object",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountTokenUpdatePayload)
+				if p.Name != nil || p.Enabled != nil {
+					t.Fatalf("expected nil optionals: %#v", p)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"name":`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong isDefault type rejected",
+			input:   `{"isDefault":"x"}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *AccountTokenUpdatePayload { return &AccountTokenUpdatePayload{} })
+}
+
+// TestAccountTokenBatchPayload_Decode covers the batch action shape.
+func TestAccountTokenBatchPayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "valid batch",
+			input: `{"ids":[1,2,3],"action":"disable"}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountTokenBatchPayload)
+				if len(p.IDs) != 3 || p.IDs[0] != 1 {
+					t.Fatalf("ids = %#v", p.IDs)
+				}
+				if p.Action != "disable" {
+					t.Fatalf("action = %q", p.Action)
+				}
+			},
+		},
+		{
+			name:    "empty object",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountTokenBatchPayload)
+				if len(p.IDs) != 0 || p.Action != "" {
+					t.Fatalf("expected zero values: %#v", p)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"ids":[`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong ids element type rejected",
+			input:   `{"ids":["x"]}`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong action type rejected",
+			input:   `{"ids":[1],"action":5}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *AccountTokenBatchPayload { return &AccountTokenBatchPayload{} })
+}
+
+// TestAccountTokenSyncAllPayload_Decode covers the sync-all shape.
+func TestAccountTokenSyncAllPayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "wait true",
+			input: `{"wait":true}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountTokenSyncAllPayload)
+				if p.Wait == nil || !*p.Wait {
+					t.Fatalf("wait = %#v", p.Wait)
+				}
+			},
+		},
+		{
+			name:  "wait false",
+			input: `{"wait":false}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountTokenSyncAllPayload)
+				if p.Wait == nil || *p.Wait {
+					t.Fatalf("wait = %#v", p.Wait)
+				}
+			},
+		},
+		{
+			name:    "empty object",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				if d.(*AccountTokenSyncAllPayload).Wait != nil {
+					t.Fatalf("expected nil wait")
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"wait":`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong wait type rejected",
+			input:   `{"wait":"yes"}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *AccountTokenSyncAllPayload { return &AccountTokenSyncAllPayload{} })
+}
+
+// TestAccountTokenCreatePayload_OmitEmptyMarshal verifies optional pointer
+// fields are omitted when nil.
+func TestAccountTokenCreatePayload_OmitEmptyMarshal(t *testing.T) {
+	t.Parallel()
+	p := AccountTokenCreatePayload{AccountID: 5}
+	raw, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	encoded := string(raw)
+	if !contains(encoded, `"accountId":5`) {
+		t.Fatalf("accountId missing: %s", encoded)
+	}
+	if contains(encoded, "name") {
+		t.Fatalf("nil name should be omitted: %s", encoded)
+	}
+	if contains(encoded, "token") {
+		t.Fatalf("nil token should be omitted: %s", encoded)
+	}
+}

--- a/handler/admin/payloads/accounts_test.go
+++ b/handler/admin/payloads/accounts_test.go
@@ -1,0 +1,421 @@
+package payloads
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestAccountCreatePayload_Decode covers valid/invalid/edge parsing of
+// AccountCreatePayload — the request body for POST /api/accounts.
+func TestAccountCreatePayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "full valid single token",
+			input: `{"siteId":5,"username":"u","accessToken":"tok","apiToken":"sk","platformUserId":9,"checkinEnabled":true,"credentialMode":"session","refreshToken":"rt","tokenExpiresAt":1700000000,"skipModelFetch":true}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountCreatePayload)
+				if p.SiteID != 5 {
+					t.Fatalf("siteId = %d", p.SiteID)
+				}
+				if p.Username == nil || *p.Username != "u" {
+					t.Fatalf("username = %#v", p.Username)
+				}
+				if p.AccessToken == nil || *p.AccessToken != "tok" {
+					t.Fatalf("accessToken = %#v", p.AccessToken)
+				}
+				if p.APIToken == nil || *p.APIToken != "sk" {
+					t.Fatalf("apiToken = %#v", p.APIToken)
+				}
+				if p.PlatformUserID == nil || *p.PlatformUserID != 9 {
+					t.Fatalf("platformUserId = %#v", p.PlatformUserID)
+				}
+				if p.CheckinEnabled == nil || !*p.CheckinEnabled {
+					t.Fatalf("checkinEnabled = %#v", p.CheckinEnabled)
+				}
+				if p.CredentialMode == nil || *p.CredentialMode != "session" {
+					t.Fatalf("credentialMode = %#v", p.CredentialMode)
+				}
+				if p.TokenExpiresAt == nil || *p.TokenExpiresAt != 1700000000 {
+					t.Fatalf("tokenExpiresAt = %#v", p.TokenExpiresAt)
+				}
+				if p.SkipModelFetch == nil || !*p.SkipModelFetch {
+					t.Fatalf("skipModelFetch = %#v", p.SkipModelFetch)
+				}
+			},
+		},
+		{
+			name:  "multi access tokens",
+			input: `{"siteId":1,"accessTokens":["a","b","c"]}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountCreatePayload)
+				if len(p.AccessTokens) != 3 || p.AccessTokens[2] != "c" {
+					t.Fatalf("accessTokens = %#v", p.AccessTokens)
+				}
+				if p.AccessToken != nil {
+					t.Fatalf("single accessToken should be nil: %#v", p.AccessToken)
+				}
+			},
+		},
+		{
+			name:    "empty object leaves siteId zero",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountCreatePayload)
+				if p.SiteID != 0 || len(p.AccessTokens) != 0 {
+					t.Fatalf("expected zero values: %#v", p)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"siteId":`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong siteId type rejected",
+			input:   `{"siteId":"x"}`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong accessTokens element type rejected",
+			input:   `{"siteId":1,"accessTokens":[1,2]}`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong tokenExpiresAt type rejected",
+			input:   `{"siteId":1,"tokenExpiresAt":"abc"}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *AccountCreatePayload { return &AccountCreatePayload{} })
+}
+
+// TestAccountUpdatePayload_Decode covers the partial update shape, including
+// the any-typed apiToken and extraConfig fields.
+func TestAccountUpdatePayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "partial update with any fields",
+			input: `{"status":"disabled","unitCost":0.5,"apiToken":null,"extraConfig":{"sub2apiAuth":{"refreshToken":"rt"}},"sortOrder":2}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountUpdatePayload)
+				if p.Status == nil || *p.Status != "disabled" {
+					t.Fatalf("status = %#v", p.Status)
+				}
+				if p.UnitCost == nil || *p.UnitCost != 0.5 {
+					t.Fatalf("unitCost = %#v", p.UnitCost)
+				}
+				// apiToken is any — JSON null leaves it nil.
+				if p.APIToken != nil {
+					t.Fatalf("apiToken = %#v, want nil", p.APIToken)
+				}
+				if p.ExtraConfig == nil {
+					t.Fatalf("extraConfig should be present")
+				}
+				if p.SortOrder == nil || *p.SortOrder != 2 {
+					t.Fatalf("sortOrder = %#v", p.SortOrder)
+				}
+			},
+		},
+		{
+			name:    "empty object",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountUpdatePayload)
+				if p.Status != nil || p.SortOrder != nil {
+					t.Fatalf("expected nil optionals: %#v", p)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"status":`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong unitCost type rejected",
+			input:   `{"unitCost":"x"}`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong sortOrder type rejected",
+			input:   `{"sortOrder":"x"}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *AccountUpdatePayload { return &AccountUpdatePayload{} })
+}
+
+// TestAccountBatchPayload_Decode covers the batch action shape.
+func TestAccountBatchPayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "valid batch",
+			input: `{"ids":[10,20],"action":"pin"}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountBatchPayload)
+				if len(p.IDs) != 2 || p.IDs[1] != 20 {
+					t.Fatalf("ids = %#v", p.IDs)
+				}
+				if p.Action != "pin" {
+					t.Fatalf("action = %q", p.Action)
+				}
+			},
+		},
+		{
+			name:    "empty object",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountBatchPayload)
+				if len(p.IDs) != 0 || p.Action != "" {
+					t.Fatalf("expected zero values: %#v", p)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"ids":[`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong ids element type rejected",
+			input:   `{"ids":["x"]}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *AccountBatchPayload { return &AccountBatchPayload{} })
+}
+
+// TestAccountLoginPayload_Decode covers the login shape.
+func TestAccountLoginPayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "valid login",
+			input: `{"siteId":3,"username":"u","password":"p"}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountLoginPayload)
+				if p.SiteID != 3 || p.Username != "u" || p.Password != "p" {
+					t.Fatalf("login = %+v", p)
+				}
+			},
+		},
+		{
+			name:    "empty object leaves fields zero",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountLoginPayload)
+				if p.SiteID != 0 || p.Username != "" || p.Password != "" {
+					t.Fatalf("expected zero values: %#v", p)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"siteId":`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong password type rejected",
+			input:   `{"siteId":1,"username":"u","password":5}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *AccountLoginPayload { return &AccountLoginPayload{} })
+}
+
+// TestAccountVerifyTokenPayload_Decode covers the verify shape.
+func TestAccountVerifyTokenPayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "valid verify",
+			input: `{"siteId":1,"accessToken":"tok","platformUserId":7,"credentialMode":"api"}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountVerifyTokenPayload)
+				if p.SiteID != 1 || *p.AccessToken != "tok" || *p.PlatformUserID != 7 || *p.CredentialMode != "api" {
+					t.Fatalf("verify = %+v", p)
+				}
+			},
+		},
+		{
+			name:    "empty object",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountVerifyTokenPayload)
+				if p.SiteID != 0 || p.AccessToken != nil {
+					t.Fatalf("expected zero values: %#v", p)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"siteId":`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong platformUserId type rejected",
+			input:   `{"siteId":1,"platformUserId":"x"}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *AccountVerifyTokenPayload { return &AccountVerifyTokenPayload{} })
+}
+
+// TestAccountRebindSessionPayload_Decode covers the rebind-session shape.
+func TestAccountRebindSessionPayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "valid rebind",
+			input: `{"accessToken":"new","platformUserId":9,"refreshToken":"rt","tokenExpiresAt":1700000000}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountRebindSessionPayload)
+				if p.AccessToken == nil || *p.AccessToken != "new" {
+					t.Fatalf("accessToken = %#v", p.AccessToken)
+				}
+				if p.PlatformUserID == nil || *p.PlatformUserID != 9 {
+					t.Fatalf("platformUserId = %#v", p.PlatformUserID)
+				}
+				if p.TokenExpiresAt == nil || *p.TokenExpiresAt != 1700000000 {
+					t.Fatalf("tokenExpiresAt = %#v", p.TokenExpiresAt)
+				}
+			},
+		},
+		{
+			name:    "empty object",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountRebindSessionPayload)
+				if p.AccessToken != nil || p.TokenExpiresAt != nil {
+					t.Fatalf("expected nil optionals: %#v", p)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"accessToken":`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong tokenExpiresAt type rejected",
+			input:   `{"tokenExpiresAt":"x"}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *AccountRebindSessionPayload { return &AccountRebindSessionPayload{} })
+}
+
+// TestAccountHealthRefreshPayload_Decode covers the health refresh shape.
+func TestAccountHealthRefreshPayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "valid health refresh",
+			input: `{"accountId":42,"wait":true}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountHealthRefreshPayload)
+				if p.AccountID == nil || *p.AccountID != 42 {
+					t.Fatalf("accountId = %#v", p.AccountID)
+				}
+				if p.Wait == nil || !*p.Wait {
+					t.Fatalf("wait = %#v", p.Wait)
+				}
+			},
+		},
+		{
+			name:    "empty object",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountHealthRefreshPayload)
+				if p.AccountID != nil || p.Wait != nil {
+					t.Fatalf("expected nil optionals: %#v", p)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"accountId":`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong accountId type rejected",
+			input:   `{"accountId":"x"}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *AccountHealthRefreshPayload { return &AccountHealthRefreshPayload{} })
+}
+
+// TestAccountManualModelsPayload_Decode covers the manual models shape.
+func TestAccountManualModelsPayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "valid models",
+			input: `{"models":["m1","m2"]}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*AccountManualModelsPayload)
+				if len(p.Models) != 2 || p.Models[0] != "m1" {
+					t.Fatalf("models = %#v", p.Models)
+				}
+			},
+		},
+		{
+			name:    "empty object",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				if len(d.(*AccountManualModelsPayload).Models) != 0 {
+					t.Fatalf("expected empty models")
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"models":[`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong model element type rejected",
+			input:   `{"models":[1]}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *AccountManualModelsPayload { return &AccountManualModelsPayload{} })
+}
+
+// TestAccountCreatePayload_OmitEmptyMarshal verifies optional pointer fields
+// are omitted when nil.
+func TestAccountCreatePayload_OmitEmptyMarshal(t *testing.T) {
+	t.Parallel()
+	p := AccountCreatePayload{SiteID: 5}
+	raw, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	encoded := string(raw)
+	if !contains(encoded, `"siteId":5`) {
+		t.Fatalf("siteId missing: %s", encoded)
+	}
+	if contains(encoded, "username") {
+		t.Fatalf("nil username should be omitted: %s", encoded)
+	}
+	if contains(encoded, "accessToken") {
+		t.Fatalf("nil accessToken should be omitted: %s", encoded)
+	}
+}
+
+// contains is a small local helper to avoid pulling strings just for this.
+func contains(s, sub string) bool { return len(s) >= len(sub) && indexOf(s, sub) >= 0 }
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/handler/admin/payloads/sites_test.go
+++ b/handler/admin/payloads/sites_test.go
@@ -1,0 +1,409 @@
+package payloads
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// sitesRoundTripCase describes a JSON round-trip through a sites payload type.
+type sitesRoundTripCase struct {
+	name    string
+	input   string
+	check   func(t *testing.T, decoded any)
+	wantErr bool
+}
+
+// runSitesDecode runs a table of decode cases against the generic decode target.
+func runSitesDecode[T any](t *testing.T, cases []sitesRoundTripCase, newTarget func() *T) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			target := newTarget()
+			err := json.Unmarshal([]byte(tc.input), target)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected decode error, got success: %#v", target)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected decode error: %v", err)
+			}
+			tc.check(t, target)
+		})
+	}
+}
+
+// TestSiteCreatePayload_Decode covers valid/invalid/edge parsing of
+// SiteCreatePayload — the request body for POST /api/sites.
+func TestSiteCreatePayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "full valid payload",
+			input: `{"name":"Acme","url":"https://acme.example","platform":"sub2api","proxyUrl":"http://p","useSystemProxy":true,"customHeaders":"H: v","customHeadersOverrideRequestHeaders":true,"externalCheckinUrl":"https://c","status":"active","isPinned":true,"sortOrder":3,"globalWeight":1.5,"maxConcurrency":8,"apiEndpoints":[{"url":"https://e1","enabled":true,"sortOrder":1}]}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*SiteCreatePayload)
+				if p.Name != "Acme" || p.URL != "https://acme.example" {
+					t.Fatalf("name/url mismatch: %+v", p)
+				}
+				if p.Platform == nil || *p.Platform != "sub2api" {
+					t.Fatalf("platform = %#v", p.Platform)
+				}
+				if p.UseSystemProxy == nil || !*p.UseSystemProxy {
+					t.Fatalf("useSystemProxy = %#v", p.UseSystemProxy)
+				}
+				if p.SortOrder == nil || *p.SortOrder != 3 {
+					t.Fatalf("sortOrder = %#v", p.SortOrder)
+				}
+				if p.GlobalWeight == nil || *p.GlobalWeight != 1.5 {
+					t.Fatalf("globalWeight = %#v", p.GlobalWeight)
+				}
+				if p.MaxConcurrency == nil || *p.MaxConcurrency != 8 {
+					t.Fatalf("maxConcurrency = %#v", p.MaxConcurrency)
+				}
+				if len(p.APIEndpoints) != 1 || p.APIEndpoints[0].URL != "https://e1" {
+					t.Fatalf("apiEndpoints = %#v", p.APIEndpoints)
+				}
+			},
+		},
+		{
+			name: "minimal required fields only",
+			input: `{"name":"N","url":"https://n.example"}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*SiteCreatePayload)
+				if p.Name != "N" {
+					t.Fatalf("name = %q", p.Name)
+				}
+				if p.Platform != nil {
+					t.Fatalf("optional platform should be nil, got %#v", p.Platform)
+				}
+				if len(p.APIEndpoints) != 0 {
+					t.Fatalf("apiEndpoints should be empty, got %#v", p.APIEndpoints)
+				}
+			},
+		},
+		{
+			name:    "empty object leaves required fields zero",
+			input:   `{}`,
+			wantErr: false,
+			check: func(t *testing.T, d any) {
+				p := d.(*SiteCreatePayload)
+				if p.Name != "" || p.URL != "" {
+					t.Fatalf("name/url should be zero, got %q/%q", p.Name, p.URL)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"name":`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type for name rejected",
+			input:   `{"name":123,"url":"x"}`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type for sortOrder rejected",
+			input:   `{"name":"x","url":"y","sortOrder":"not-int"}`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type for globalWeight rejected",
+			input:   `{"name":"x","url":"y","globalWeight":"abc"}`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type for maxConcurrency rejected",
+			input:   `{"name":"x","url":"y","maxConcurrency":"no"}`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type for apiEndpoints rejected",
+			input:   `{"name":"x","url":"y","apiEndpoints":"oops"}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *SiteCreatePayload { return &SiteCreatePayload{} })
+}
+
+// TestSiteCreatePayload_OmitEmptyMarshal verifies optional pointer fields are
+// omitted when nil so round-tripping a minimal payload stays minimal.
+func TestSiteCreatePayload_OmitEmptyMarshal(t *testing.T) {
+	t.Parallel()
+	p := SiteCreatePayload{Name: "N", URL: "https://n.example"}
+	raw, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	encoded := string(raw)
+	if strings.Contains(encoded, "platform") {
+		t.Fatalf("nil platform should be omitted: %s", encoded)
+	}
+	if strings.Contains(encoded, "apiEndpoints") {
+		t.Fatalf("empty apiEndpoints should be omitted: %s", encoded)
+	}
+	if !strings.Contains(encoded, `"name":"N"`) {
+		t.Fatalf("name missing from %s", encoded)
+	}
+}
+
+// TestSiteUpdatePayload_Decode covers the optional-field PATCH shape.
+func TestSiteUpdatePayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "partial update",
+			input: `{"status":"disabled","sortOrder":5,"postRefreshProbeEnabled":true}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*SiteUpdatePayload)
+				if p.Status == nil || *p.Status != "disabled" {
+					t.Fatalf("status = %#v", p.Status)
+				}
+				if p.SortOrder == nil || *p.SortOrder != 5 {
+					t.Fatalf("sortOrder = %#v", p.SortOrder)
+				}
+				if p.PostRefreshProbeEnabled == nil || !*p.PostRefreshProbeEnabled {
+					t.Fatalf("postRefreshProbeEnabled = %#v", p.PostRefreshProbeEnabled)
+				}
+				if p.Name != nil {
+					t.Fatalf("untouched name should be nil, got %#v", p.Name)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"name":`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type for postRefreshProbeLatencyThresholdMs rejected",
+			input:   `{"postRefreshProbeLatencyThresholdMs":"x"}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *SiteUpdatePayload { return &SiteUpdatePayload{} })
+}
+
+// TestSiteBatchPayload_Decode covers the batch action shape and rejects
+// non-integer IDs.
+func TestSiteBatchPayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "valid batch",
+			input: `{"ids":[1,2,3],"action":"delete"}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*SiteBatchPayload)
+				if len(p.IDs) != 3 || p.IDs[0] != 1 || p.IDs[2] != 3 {
+					t.Fatalf("ids = %#v", p.IDs)
+				}
+				if p.Action != "delete" {
+					t.Fatalf("action = %q", p.Action)
+				}
+			},
+		},
+		{
+			name:    "empty object zeroes everything",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*SiteBatchPayload)
+				if len(p.IDs) != 0 || p.Action != "" {
+					t.Fatalf("expected zero values: %#v", p)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"ids":[`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong ids element type rejected",
+			input:   `{"ids":["x"],"action":"delete"}`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong action type rejected",
+			input:   `{"ids":[1],"action":5}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *SiteBatchPayload { return &SiteBatchPayload{} })
+}
+
+// TestSiteDetectPayload_Decode covers the single-field detect shape.
+func TestSiteDetectPayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "valid",
+			input: `{"url":"https://detect.example"}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*SiteDetectPayload)
+				if p.URL != "https://detect.example" {
+					t.Fatalf("url = %q", p.URL)
+				}
+			},
+		},
+		{
+			name:    "empty object",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*SiteDetectPayload)
+				if p.URL != "" {
+					t.Fatalf("url = %q, want empty", p.URL)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"url":`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong url type rejected",
+			input:   `{"url":123}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *SiteDetectPayload { return &SiteDetectPayload{} })
+}
+
+// TestSiteDisabledModelsPayload_Decode covers the models-list shape.
+func TestSiteDisabledModelsPayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "valid models",
+			input: `{"models":["gpt-4","claude-3"]}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*SiteDisabledModelsPayload)
+				if len(p.Models) != 2 || p.Models[1] != "claude-3" {
+					t.Fatalf("models = %#v", p.Models)
+				}
+			},
+		},
+		{
+			name:    "empty object",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				if len(d.(*SiteDisabledModelsPayload).Models) != 0 {
+					t.Fatalf("expected empty models")
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"models":[`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong model element type rejected",
+			input:   `{"models":[1,2]}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *SiteDisabledModelsPayload { return &SiteDisabledModelsPayload{} })
+}
+
+// TestSiteImportPayload_Decode covers the nested batch import shape.
+func TestSiteImportPayload_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "valid nested import",
+			input: `{"items":[{"name":"S","url":"https://s.example","platform":"sub2api","globalWeight":2.0,"accounts":[{"accessToken":"tok"}]}],"duplicateStrategy":"skip"}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*SiteImportPayload)
+				if len(p.Items) != 1 {
+					t.Fatalf("items len = %d", len(p.Items))
+				}
+				if p.Items[0].Name != "S" {
+					t.Fatalf("item name = %q", p.Items[0].Name)
+				}
+				if p.Items[0].GlobalWeight == nil || *p.Items[0].GlobalWeight != 2.0 {
+					t.Fatalf("globalWeight = %#v", p.Items[0].GlobalWeight)
+				}
+				if len(p.Items[0].Accounts) != 1 || p.Items[0].Accounts[0].AccessToken != "tok" {
+					t.Fatalf("accounts = %#v", p.Items[0].Accounts)
+				}
+				if p.DuplicateStrategy != "skip" {
+					t.Fatalf("duplicateStrategy = %q", p.DuplicateStrategy)
+				}
+			},
+		},
+		{
+			name:    "empty object",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*SiteImportPayload)
+				if len(p.Items) != 0 || p.DuplicateStrategy != "" {
+					t.Fatalf("expected zero values: %#v", p)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"items":[`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong items element type rejected",
+			input:   `{"items":"oops"}`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong account accessToken type rejected",
+			input:   `{"items":[{"name":"S","url":"u","accounts":[{"accessToken":5}]}]}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *SiteImportPayload { return &SiteImportPayload{} })
+}
+
+// TestProbeNowBody_Decode covers the probe-now request shape.
+func TestProbeNowBody_Decode(t *testing.T) {
+	t.Parallel()
+	cases := []sitesRoundTripCase{
+		{
+			name:  "valid body",
+			input: `{"scope":"single","modelName":"gpt-4","latencyThresholdMs":800}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*ProbeNowBody)
+				if p.Scope == nil || *p.Scope != "single" {
+					t.Fatalf("scope = %#v", p.Scope)
+				}
+				if p.ModelName == nil || *p.ModelName != "gpt-4" {
+					t.Fatalf("modelName = %#v", p.ModelName)
+				}
+				if p.LatencyThresholdMs == nil || *p.LatencyThresholdMs != 800 {
+					t.Fatalf("latencyThresholdMs = %#v", p.LatencyThresholdMs)
+				}
+			},
+		},
+		{
+			name:    "empty object",
+			input:   `{}`,
+			check: func(t *testing.T, d any) {
+				p := d.(*ProbeNowBody)
+				if p.Scope != nil || p.ModelName != nil {
+					t.Fatalf("expected nil optionals: %#v", p)
+				}
+			},
+		},
+		{
+			name:    "malformed json rejected",
+			input:   `{"scope":`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong latencyThresholdMs type rejected",
+			input:   `{"latencyThresholdMs":"x"}`,
+			wantErr: true,
+		},
+	}
+	runSitesDecode(t, cases, func() *ProbeNowBody { return &ProbeNowBody{} })
+}

--- a/internal/sharedcount/redis_test.go
+++ b/internal/sharedcount/redis_test.go
@@ -32,24 +32,23 @@ type fakeRedis struct {
 
 func newFakeRedis(t *testing.T) *fakeRedis {
 	t.Helper()
+	return newFakeRedisWithAuth(t, "")
+}
+
+func newFakeRedisWithAuth(t *testing.T, password string) *fakeRedis {
+	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("fake redis listen: %v", err)
 	}
 	f := &fakeRedis{
-		data: make(map[string]int64),
-		ttl:  make(map[string]time.Time),
-		ln:   ln,
+		data:     make(map[string]int64),
+		ttl:      make(map[string]time.Time),
+		authPass: password,
+		ln:       ln,
 	}
 	f.wg.Add(1)
 	go f.serve()
-	return f
-}
-
-func newFakeRedisWithAuth(t *testing.T, password string) *fakeRedis {
-	t.Helper()
-	f := newFakeRedis(t)
-	f.authPass = password
 	return f
 }
 

--- a/internal/sharedcount/redis_test.go
+++ b/internal/sharedcount/redis_test.go
@@ -1,0 +1,719 @@
+package sharedcount
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ---- fake RESP Redis server ----
+
+// fakeRedis is a minimal in-memory RESP server for exercising RedisCounter
+// over a real TCP loopback connection (so NewRedisCounter + net.DialTimeout
+// are covered end-to-end). It supports AUTH, SELECT, INCR, DECR, INCRBY, GET
+// and PEXPIRE with real TTL expiry.
+type fakeRedis struct {
+	mu       sync.Mutex
+	data     map[string]int64
+	ttl      map[string]time.Time
+	authPass string
+	ln       net.Listener
+	wg       sync.WaitGroup
+}
+
+func newFakeRedis(t *testing.T) *fakeRedis {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("fake redis listen: %v", err)
+	}
+	f := &fakeRedis{
+		data: make(map[string]int64),
+		ttl:  make(map[string]time.Time),
+		ln:   ln,
+	}
+	f.wg.Add(1)
+	go f.serve()
+	return f
+}
+
+func newFakeRedisWithAuth(t *testing.T, password string) *fakeRedis {
+	t.Helper()
+	f := newFakeRedis(t)
+	f.authPass = password
+	return f
+}
+
+func (f *fakeRedis) addr() string { return f.ln.Addr().String() }
+
+func (f *fakeRedis) close() {
+	_ = f.ln.Close()
+	f.wg.Wait()
+}
+
+func (f *fakeRedis) serve() {
+	defer f.wg.Done()
+	for {
+		conn, err := f.ln.Accept()
+		if err != nil {
+			return
+		}
+		f.wg.Add(1)
+		go func(c net.Conn) {
+			defer f.wg.Done()
+			f.handle(c)
+		}(conn)
+	}
+}
+
+// expireLocked evicts a key whose TTL has elapsed. Caller must hold f.mu.
+func (f *fakeRedis) expireLocked(key string) {
+	if t, ok := f.ttl[key]; ok && time.Now().After(t) {
+		delete(f.data, key)
+		delete(f.ttl, key)
+	}
+}
+
+func (f *fakeRedis) handle(conn net.Conn) {
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	authed := f.authPass == ""
+	for {
+		parts, err := readRESPArray(reader)
+		if err != nil {
+			return
+		}
+		if len(parts) == 0 {
+			continue
+		}
+		cmd := strings.ToUpper(parts[0])
+		switch cmd {
+		case "AUTH":
+			if f.authPass != "" && (len(parts) < 2 || parts[1] != f.authPass) {
+				writeError(conn, "ERR invalid password")
+				return
+			}
+			authed = true
+			writeOK(conn)
+		case "SELECT":
+			writeOK(conn)
+		case "PING":
+			writeOK(conn)
+		default:
+			if !authed {
+				writeError(conn, "NOAUTH Authentication required")
+				return
+			}
+			if !f.handleCommand(conn, cmd, parts) {
+				return
+			}
+		}
+	}
+}
+
+// handleCommand returns false to signal the connection should close.
+func (f *fakeRedis) handleCommand(conn net.Conn, cmd string, parts []string) bool {
+	switch cmd {
+	case "INCR":
+		if len(parts) < 2 {
+			writeError(conn, "ERR wrong number of arguments")
+			return true
+		}
+		key := parts[1]
+		f.mu.Lock()
+		f.expireLocked(key)
+		v := f.data[key] + 1
+		f.data[key] = v
+		f.mu.Unlock()
+		writeInt(conn, v)
+	case "DECR":
+		if len(parts) < 2 {
+			writeError(conn, "ERR wrong number of arguments")
+			return true
+		}
+		key := parts[1]
+		f.mu.Lock()
+		f.expireLocked(key)
+		v := f.data[key] - 1
+		f.data[key] = v
+		f.mu.Unlock()
+		writeInt(conn, v)
+	case "INCRBY":
+		if len(parts) < 3 {
+			writeError(conn, "ERR wrong number of arguments")
+			return true
+		}
+		key := parts[1]
+		delta, err := strconv.ParseInt(parts[2], 10, 64)
+		if err != nil {
+			writeError(conn, "ERR value is not an integer")
+			return true
+		}
+		f.mu.Lock()
+		f.expireLocked(key)
+		v := f.data[key] + delta
+		f.data[key] = v
+		f.mu.Unlock()
+		writeInt(conn, v)
+	case "GET":
+		if len(parts) < 2 {
+			writeError(conn, "ERR wrong number of arguments")
+			return true
+		}
+		key := parts[1]
+		f.mu.Lock()
+		f.expireLocked(key)
+		v, ok := f.data[key]
+		f.mu.Unlock()
+		if !ok {
+			writeNullBulk(conn)
+		} else {
+			writeBulk(conn, strconv.FormatInt(v, 10))
+		}
+	case "PEXPIRE":
+		if len(parts) < 3 {
+			writeError(conn, "ERR wrong number of arguments")
+			return true
+		}
+		key := parts[1]
+		ms, err := strconv.ParseInt(parts[2], 10, 64)
+		if err != nil {
+			writeError(conn, "ERR value is not an integer")
+			return true
+		}
+		f.mu.Lock()
+		f.ttl[key] = time.Now().Add(time.Duration(ms) * time.Millisecond)
+		f.mu.Unlock()
+		writeInt(conn, 1)
+	case "QUIT":
+		writeOK(conn)
+		return false
+	default:
+		writeError(conn, "ERR unknown command '"+cmd+"'")
+	}
+	return true
+}
+
+// ---- RESP read/write helpers ----
+
+// readRESPArray reads one RESP array of bulk strings from a buffered reader.
+func readRESPArray(r *bufio.Reader) ([]string, error) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		if err == io.EOF && line == "" {
+			return nil, err
+		}
+		return nil, err
+	}
+	line = strings.TrimRight(line, "\r\n")
+	if line == "" {
+		return nil, nil
+	}
+	if line[0] != '*' {
+		// Inline command (rare from this client) — split on whitespace.
+		return strings.Fields(line), nil
+	}
+	n, err := strconv.Atoi(line[1:])
+	if err != nil {
+		return nil, fmt.Errorf("bad array header: %w", err)
+	}
+	parts := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		hdr, err := r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		hdr = strings.TrimRight(hdr, "\r\n")
+		if len(hdr) == 0 || hdr[0] != '$' {
+			return nil, fmt.Errorf("expected bulk header, got %q", hdr)
+		}
+		ln, err := strconv.Atoi(hdr[1:])
+		if err != nil {
+			return nil, fmt.Errorf("bad bulk length: %w", err)
+		}
+		if ln < 0 {
+			parts = append(parts, "")
+			continue
+		}
+		body := make([]byte, ln+2)
+		if _, err := io.ReadFull(r, body); err != nil {
+			return nil, err
+		}
+		parts = append(parts, string(body[:ln]))
+	}
+	return parts, nil
+}
+
+func writeOK(conn net.Conn) {
+	_, _ = conn.Write([]byte("+OK\r\n"))
+}
+
+func writeError(conn net.Conn, msg string) {
+	_, _ = fmt.Fprintf(conn, "-%s\r\n", msg)
+}
+
+func writeInt(conn net.Conn, n int64) {
+	_, _ = fmt.Fprintf(conn, ":%d\r\n", n)
+}
+
+func writeBulk(conn net.Conn, s string) {
+	_, _ = fmt.Fprintf(conn, "$%d\r\n%s\r\n", len(s), s)
+}
+
+func writeNullBulk(conn net.Conn) {
+	_, _ = conn.Write([]byte("$-1\r\n"))
+}
+
+// ---- test helpers ----
+
+// newCounterAt constructs a RedisCounter pointing at the fake redis address.
+func newCounterAt(t *testing.T, addr string) *RedisCounter {
+	t.Helper()
+	c, err := NewRedisCounter("redis://" + addr + "/0")
+	if err != nil {
+		t.Fatalf("NewRedisCounter: %v", err)
+	}
+	c.timeout = 2 * time.Second
+	return c
+}
+
+func newCounterWithAuth(t *testing.T, addr, password string) *RedisCounter {
+	t.Helper()
+	url := "redis://:" + password + "@" + addr + "/0"
+	c, err := NewRedisCounter(url)
+	if err != nil {
+		t.Fatalf("NewRedisCounter: %v", err)
+	}
+	c.timeout = 2 * time.Second
+	return c
+}
+
+// ---- RedisCounter round-trip tests ----
+
+func TestRedisCounter_IncrAndDecr(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+
+	ctx := context.Background()
+	n, err := c.Incr(ctx, "rpm", time.Minute)
+	if err != nil {
+		t.Fatalf("Incr: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("first Incr = %d, want 1", n)
+	}
+	n, err = c.Incr(ctx, "rpm", time.Minute)
+	if err != nil || n != 2 {
+		t.Fatalf("second Incr = %d, %v, want 2", n, err)
+	}
+	n, err = c.Decr(ctx, "rpm", time.Minute)
+	if err != nil || n != 1 {
+		t.Fatalf("Decr = %d, %v, want 1", n, err)
+	}
+	// Decr must not refresh TTL — but functionally the count still drops.
+	n, err = c.Decr(ctx, "rpm", time.Minute)
+	if err != nil || n != 0 {
+		t.Fatalf("Decr2 = %d, %v, want 0", n, err)
+	}
+}
+
+func TestRedisCounter_IncrByAndPeek(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+
+	ctx := context.Background()
+	n, err := c.IncrBy(ctx, "tpm", 500, time.Minute)
+	if err != nil || n != 500 {
+		t.Fatalf("first IncrBy = %d, %v, want 500", n, err)
+	}
+	n, err = c.IncrBy(ctx, "tpm", 250, time.Minute)
+	if err != nil || n != 750 {
+		t.Fatalf("second IncrBy = %d, %v, want 750", n, err)
+	}
+	// Zero delta is a peek (no reservation, no TTL refresh).
+	n, err = c.IncrBy(ctx, "tpm", 0, time.Minute)
+	if err != nil || n != 750 {
+		t.Fatalf("peek = %d, %v, want 750", n, err)
+	}
+	// Negative delta rolls back without refreshing TTL.
+	n, err = c.IncrBy(ctx, "tpm", -300, time.Minute)
+	if err != nil || n != 450 {
+		t.Fatalf("rollback = %d, %v, want 450", n, err)
+	}
+}
+
+func TestRedisCounter_GetMissingReturnsZero(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+
+	n, err := c.Get(context.Background(), "never-set")
+	if err != nil {
+		t.Fatalf("Get missing: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("Get missing = %d, want 0", n)
+	}
+}
+
+func TestRedisCounter_IncrSetsTTL(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+	ctx := context.Background()
+
+	// First Incr on a fresh key sets the TTL (PEXPIRE fires when count==1).
+	if _, err := c.Incr(ctx, "ttl-key", 50*time.Millisecond); err != nil {
+		t.Fatalf("Incr: %v", err)
+	}
+	// Key exists immediately after.
+	n, err := c.Get(ctx, "ttl-key")
+	if err != nil || n != 1 {
+		t.Fatalf("Get before expiry = %d, %v, want 1", n, err)
+	}
+	// After TTL elapses the fake redis evicts it.
+	time.Sleep(90 * time.Millisecond)
+	n, err = c.Get(ctx, "ttl-key")
+	if err != nil || n != 0 {
+		t.Fatalf("Get after TTL = %d, %v, want 0", n, err)
+	}
+}
+
+// ---- Redis failure paths ----
+
+func TestRedisCounter_DialFailure(t *testing.T) {
+	t.Parallel()
+	// Inject a dial that always errors — deterministic, no network.
+	c := &RedisCounter{
+		addr:    "unreachable:1",
+		timeout: 200 * time.Millisecond,
+		dial: func(network, address string, timeout time.Duration) (net.Conn, error) {
+			return nil, errors.New("dial boom")
+		},
+	}
+	_, err := c.Incr(context.Background(), "k", time.Minute)
+	if err == nil {
+		t.Fatal("expected dial error, got nil")
+	}
+	_, err = c.Decr(context.Background(), "k", time.Minute)
+	if err == nil {
+		t.Fatal("expected dial error on Decr, got nil")
+	}
+	_, err = c.IncrBy(context.Background(), "k", 5, time.Minute)
+	if err == nil {
+		t.Fatal("expected dial error on IncrBy, got nil")
+	}
+	_, err = c.Get(context.Background(), "k")
+	if err == nil {
+		t.Fatal("expected dial error on Get, got nil")
+	}
+}
+
+func TestRedisCounter_AuthFailure(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedisWithAuth(t, "real-secret")
+	defer f.close()
+	// Dial with the wrong password — fake redis rejects AUTH and closes.
+	c := newCounterWithAuth(t, f.addr(), "wrong-pass")
+	c.timeout = 500 * time.Millisecond
+	_, err := c.Incr(context.Background(), "k", time.Minute)
+	if err == nil {
+		t.Fatal("expected AUTH error, got nil")
+	}
+}
+
+func TestRedisCounter_ServerErrorReply(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+	// Peek on a missing key succeeds (returns 0) — GET returns null bulk.
+	_, err := c.IncrBy(context.Background(), "k", 0, time.Minute)
+	if err != nil {
+		t.Fatalf("peek missing should succeed: %v", err)
+	}
+}
+
+// ---- default window & edge cases ----
+
+func TestRedisCounter_ZeroOrNegativeWindowDefaultsToMinute(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+	ctx := context.Background()
+	// window <= 0 must not crash; the implementation falls back to a minute.
+	n, err := c.Incr(ctx, "win", 0)
+	if err != nil || n != 1 {
+		t.Fatalf("Incr window=0 = %d, %v", n, err)
+	}
+	n, err = c.IncrBy(ctx, "win-by", 10, -1)
+	if err != nil || n != 10 {
+		t.Fatalf("IncrBy window=-1 = %d, %v", n, err)
+	}
+}
+
+func TestRedisCounter_LargeDeltasDoNotOverflow(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+	ctx := context.Background()
+	big := int64(2_000_000_000)
+	n, err := c.IncrBy(ctx, "big", big, time.Minute)
+	if err != nil || n != big {
+		t.Fatalf("big IncrBy = %d, %v, want %d", n, err, big)
+	}
+	n, err = c.IncrBy(ctx, "big", big, time.Minute)
+	if err != nil || n != big*2 {
+		t.Fatalf("second big IncrBy = %d, %v, want %d", n, err, big*2)
+	}
+}
+
+// ---- MemoryCounter edge cases not covered by memory_test.go ----
+
+func TestMemoryCounter_GetMissingReturnsZero(t *testing.T) {
+	t.Parallel()
+	m := NewMemoryCounter()
+	n, err := m.Get(context.Background(), "nope")
+	if err != nil || n != 0 {
+		t.Fatalf("Get missing = %d, %v, want 0", n, err)
+	}
+}
+
+func TestMemoryCounter_ZeroOrNegativeWindowDefaultsToMinute(t *testing.T) {
+	t.Parallel()
+	m := NewMemoryCounter()
+	base := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	now := base
+	m.now = func() time.Time { return now }
+	n, err := m.Incr(context.Background(), "k", 0)
+	if err != nil || n != 1 {
+		t.Fatalf("Incr window=0 = %d, %v", n, err)
+	}
+	n, err = m.Incr(context.Background(), "k", -5)
+	if err != nil || n != 2 {
+		t.Fatalf("Incr window=-5 = %d, %v", n, err)
+	}
+}
+
+func TestMemoryCounter_IncrByOverrollbackFloorsAtZero(t *testing.T) {
+	t.Parallel()
+	m := NewMemoryCounter()
+	// Over-rollback beyond zero resets the window and floors at 0.
+	n, err := m.IncrBy(context.Background(), "tpm", -10_000, time.Minute)
+	if err != nil || n != 0 {
+		t.Fatalf("over-rollback = %d, %v, want 0", n, err)
+	}
+}
+
+// ---- concurrency safety ----
+
+func TestMemoryCounter_ConcurrentIncrNoRace(t *testing.T) {
+	t.Parallel()
+	m := NewMemoryCounter()
+	const goroutines = 64
+	const perGoroutine = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	ctx := context.Background()
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < perGoroutine; j++ {
+				_, _ = m.Incr(ctx, "race-key", time.Minute)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	n, err := m.Get(ctx, "race-key")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	want := int64(goroutines * perGoroutine)
+	if n != want {
+		t.Fatalf("concurrent Incr total = %d, want %d", n, want)
+	}
+}
+
+func TestMemoryCounter_ConcurrentIncrByNetZero(t *testing.T) {
+	t.Parallel()
+	m := NewMemoryCounter()
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+	ctx := context.Background()
+	start := make(chan struct{})
+	// Half increment, half decrement — net should be ~0 (floored at 0).
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 100; j++ {
+				_, _ = m.IncrBy(ctx, "tpm", 10, time.Minute)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 100; j++ {
+				_, _ = m.IncrBy(ctx, "tpm", -10, time.Minute)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	n, err := m.IncrBy(ctx, "tpm", 0, time.Minute)
+	if err != nil {
+		t.Fatalf("peek: %v", err)
+	}
+	if n < 0 {
+		t.Fatalf("net IncrBy = %d, must not be negative", n)
+	}
+}
+
+func TestRedisCounter_ConcurrentIncrAccurate(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+	const goroutines = 32
+	const perGoroutine = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	var total atomic.Int64
+	ctx := context.Background()
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < perGoroutine; j++ {
+				n, err := c.Incr(ctx, "concurrent", time.Minute)
+				if err != nil {
+					t.Errorf("concurrent Incr: %v", err)
+					return
+				}
+				total.Add(n - n) // no-op to use n; correctness checked below
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	n, err := c.Get(ctx, "concurrent")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	want := int64(goroutines * perGoroutine)
+	if n != want {
+		t.Fatalf("concurrent Incr total = %d, want %d", n, want)
+	}
+}
+
+// ---- ParseRedisURL extra coverage ----
+
+func TestParseRedisURL_Empty(t *testing.T) {
+	t.Parallel()
+	if _, _, _, err := ParseRedisURL(""); err == nil {
+		t.Fatal("expected error for empty url")
+	}
+	if _, _, _, err := ParseRedisURL("   "); err == nil {
+		t.Fatal("expected error for whitespace-only url")
+	}
+}
+
+func TestParseRedisURL_HostOnlyAppendsPort(t *testing.T) {
+	t.Parallel()
+	addr, pass, db, err := ParseRedisURL("redis.example.com")
+	if err != nil {
+		t.Fatalf("ParseRedisURL host-only: %v", err)
+	}
+	if addr != "redis.example.com:6379" {
+		t.Fatalf("addr = %q, want redis.example.com:6379", addr)
+	}
+	if pass != "" || db != 0 {
+		t.Fatalf("pass=%q db=%d, want empty/0", pass, db)
+	}
+}
+
+func TestParseRedisURL_HostPortNoScheme(t *testing.T) {
+	t.Parallel()
+	addr, pass, db, err := ParseRedisURL("10.0.0.5:6380")
+	if err != nil {
+		t.Fatalf("ParseRedisURL host:port: %v", err)
+	}
+	if addr != "10.0.0.5:6380" || pass != "" || db != 0 {
+		t.Fatalf("addr=%q pass=%q db=%d", addr, pass, db)
+	}
+}
+
+func TestParseRedisURL_UserWithoutPassword(t *testing.T) {
+	t.Parallel()
+	// "redis://user@host:6379" — user with no colon means userinfo is the password.
+	addr, _, _, err := ParseRedisURL("redis://user@localhost:6379")
+	if err != nil {
+		t.Fatalf("ParseRedisURL user@host: %v", err)
+	}
+	if addr != "localhost:6379" {
+		t.Fatalf("addr = %q, want localhost:6379", addr)
+	}
+}
+
+func TestParseRedisURL_InvalidDB(t *testing.T) {
+	t.Parallel()
+	if _, _, _, err := ParseRedisURL("redis://localhost:6379/abc"); err == nil {
+		t.Fatal("expected error for non-numeric db")
+	}
+}
+
+func TestParseRedisURL_RedissScheme(t *testing.T) {
+	t.Parallel()
+	addr, pass, db, err := ParseRedisURL("rediss://:secret@db.example:6390/3")
+	if err != nil {
+		t.Fatalf("ParseRedisURL rediss://: %v", err)
+	}
+	if addr != "db.example:6390" || pass != "secret" || db != 3 {
+		t.Fatalf("addr=%q pass=%q db=%d", addr, pass, db)
+	}
+}
+
+func TestNewRedisCounter_BuildsFields(t *testing.T) {
+	t.Parallel()
+	c, err := NewRedisCounter("redis://:pw@127.0.0.1:6390/4")
+	if err != nil {
+		t.Fatalf("NewRedisCounter: %v", err)
+	}
+	if c.addr != "127.0.0.1:6390" {
+		t.Fatalf("addr = %q", c.addr)
+	}
+	if c.password != "pw" {
+		t.Fatalf("password = %q", c.password)
+	}
+	if c.db != 4 {
+		t.Fatalf("db = %d", c.db)
+	}
+	if c.timeout != 800*time.Millisecond {
+		t.Fatalf("timeout = %v, want 800ms", c.timeout)
+	}
+	if c.dial == nil {
+		t.Fatal("dial should default to net.DialTimeout")
+	}
+}

--- a/service/site_service.go
+++ b/service/site_service.go
@@ -230,10 +230,77 @@ func ListSites(db *sqlx.DB) ([]map[string]any, error) {
 	return result, nil
 }
 
+// subscriptionSummary is the JSON-serializable summary of a site's sub2api
+// subscription state, aggregated from each account's extra_config.sub2apiAuth.
+// Mirrors the TS sites.ts buildSubscriptionSummary shape consumed by the
+// frontend (web/src/features/sites/components/sites-columns.tsx uses
+// activeCount as an accountCount fallback).
+type subscriptionSummary struct {
+	Group       string      `json:"group,omitempty"`
+	ExpiresAt   *time.Time  `json:"expiresAt,omitempty"`
+	Active      bool        `json:"active"`
+	ActiveCount int         `json:"activeCount"`
+}
+
+// buildSubscriptionSummary aggregates sub2api subscription info for a site by
+// scanning every account's extra_config for a sub2apiAuth object. The TS
+// version parsed sub2apiAuth to surface the subscription group, token expiry
+// and liveness; here we extract the same known fields without over-fetching.
+//
+// Returns nil when no account for the site carries a sub2apiAuth block (the
+// pre-existing behavior), so non-sub2api sites stay unaffected.
 func buildSubscriptionSummary(accounts []accountAgg, siteID int64) any {
-	// Subscription aggregation
-	// The TS version aggregates from sub2apiAuth in extraConfig
-	return nil
+	var (
+		group        string
+		latestExpiry *time.Time
+		activeCount  int
+		seenSub2Api  bool
+	)
+	now := time.Now().UTC()
+	for _, acc := range accounts {
+		if acc.SiteID != siteID {
+			continue
+		}
+		auth := GetSub2ApiAuthFromExtraConfig(acc.ExtraConfig)
+		if auth == nil {
+			continue
+		}
+		seenSub2Api = true
+
+		// Subscription group/plan name: prefer "group", fall back to "planName".
+		if g, ok := auth["group"].(string); ok && g != "" {
+			if group == "" {
+				group = g
+			}
+		} else if p, ok := auth["planName"].(string); ok && p != "" {
+			if group == "" {
+				group = p
+			}
+		}
+
+		// tokenExpiresAt is epoch seconds (see NormalizeManagedTokenExpiresAt).
+		if exp, ok := NormalizeManagedTokenExpiresAt(auth["tokenExpiresAt"]); ok && exp > 0 {
+			expiry := time.Unix(exp, 0).UTC()
+			if latestExpiry == nil || expiry.After(*latestExpiry) {
+				latestExpiry = &expiry
+			}
+			if expiry.After(now) {
+				activeCount++
+			}
+		} else {
+			// No usable expiry — treat as active so accountCount fallback still works.
+			activeCount++
+		}
+	}
+	if !seenSub2Api {
+		return nil
+	}
+	return &subscriptionSummary{
+		Group:       group,
+		ExpiresAt:   latestExpiry,
+		Active:      activeCount > 0,
+		ActiveCount: activeCount,
+	}
 }
 
 // CreateSite creates a new site with apiEndpoints in a transaction.

--- a/service/site_subscription_summary_test.go
+++ b/service/site_subscription_summary_test.go
@@ -1,0 +1,224 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// strPtr is provided by service/account_mutation_test.go (package service test helpers).
+
+// TestBuildSubscriptionSummary_NoAccounts asserts the stub-equivalent
+// behavior: with no accounts at all, the summary is nil.
+func TestBuildSubscriptionSummary_NoAccounts(t *testing.T) {
+	t.Parallel()
+	if got := buildSubscriptionSummary(nil, 1); got != nil {
+		t.Fatalf("expected nil for no accounts, got %#v", got)
+	}
+	if got := buildSubscriptionSummary([]accountAgg{}, 1); got != nil {
+		t.Fatalf("expected nil for empty accounts, got %#v", got)
+	}
+}
+
+// TestBuildSubscriptionSummary_NoSub2ApiAuth returns nil when none of the
+// site's accounts carry a sub2apiAuth block (non-sub2api sites stay null).
+func TestBuildSubscriptionSummary_NoSub2ApiAuth(t *testing.T) {
+	t.Parallel()
+	accounts := []accountAgg{
+		{SiteID: 1, ExtraConfig: strPtr(`{"proxyUrl":"http://proxy.local"}`)},
+		{SiteID: 1, ExtraConfig: nil},
+		{SiteID: 1, ExtraConfig: strPtr(``)},
+		{SiteID: 2, ExtraConfig: strPtr(`{"sub2apiAuth":{"group":"other-site"}}`)},
+	}
+	if got := buildSubscriptionSummary(accounts, 1); got != nil {
+		t.Fatalf("expected nil when no sub2apiAuth for site 1, got %#v", got)
+	}
+}
+
+// TestBuildSubscriptionSummary_MalformedExtraConfig is ignored gracefully —
+// a broken extra_config must not crash the aggregator.
+func TestBuildSubscriptionSummary_MalformedExtraConfig(t *testing.T) {
+	t.Parallel()
+	accounts := []accountAgg{
+		{SiteID: 1, ExtraConfig: strPtr(`{not-json`)},
+	}
+	if got := buildSubscriptionSummary(accounts, 1); got != nil {
+		t.Fatalf("expected nil for malformed extra_config, got %#v", got)
+	}
+}
+
+// TestBuildSubscriptionSummary_ActiveToken aggregates a single sub2api
+// account whose token expires in the future — it should be counted active.
+func TestBuildSubscriptionSummary_ActiveToken(t *testing.T) {
+	t.Parallel()
+	future := time.Now().Add(1 * time.Hour).Unix()
+	accounts := []accountAgg{
+		{SiteID: 1, ExtraConfig: strPtr(`{"sub2apiAuth":{"group":"pro-tier","tokenExpiresAt":` + itoa64(future) + `}}`)},
+	}
+	got := buildSubscriptionSummary(accounts, 1)
+	if got == nil {
+		t.Fatal("expected non-nil summary")
+	}
+	summary, ok := got.(*subscriptionSummary)
+	if !ok {
+		t.Fatalf("expected *subscriptionSummary, got %T", got)
+	}
+	if summary.Group != "pro-tier" {
+		t.Fatalf("Group = %q, want pro-tier", summary.Group)
+	}
+	if !summary.Active {
+		t.Fatalf("Active = false, want true")
+	}
+	if summary.ActiveCount != 1 {
+		t.Fatalf("ActiveCount = %d, want 1", summary.ActiveCount)
+	}
+	if summary.ExpiresAt == nil {
+		t.Fatal("ExpiresAt = nil, want set")
+	}
+	if !summary.ExpiresAt.Equal(time.Unix(future, 0).UTC()) {
+		t.Fatalf("ExpiresAt = %v, want %v", summary.ExpiresAt, time.Unix(future, 0).UTC())
+	}
+}
+
+// TestBuildSubscriptionSummary_ExpiredToken is not counted toward ActiveCount
+// but still surfaces ExpiresAt so operators can see when the last sub lapsed.
+func TestBuildSubscriptionSummary_ExpiredToken(t *testing.T) {
+	t.Parallel()
+	past := time.Now().Add(-30 * time.Minute).Unix()
+	accounts := []accountAgg{
+		{SiteID: 1, ExtraConfig: strPtr(`{"sub2apiAuth":{"group":"pro-tier","tokenExpiresAt":` + itoa64(past) + `}}`)},
+	}
+	got := buildSubscriptionSummary(accounts, 1)
+	summary := got.(*subscriptionSummary)
+	if summary.Group != "pro-tier" {
+		t.Fatalf("Group = %q, want pro-tier", summary.Group)
+	}
+	if summary.Active {
+		t.Fatalf("Active = true, want false for expired token")
+	}
+	if summary.ActiveCount != 0 {
+		t.Fatalf("ActiveCount = %d, want 0", summary.ActiveCount)
+	}
+	if summary.ExpiresAt == nil || !summary.ExpiresAt.Equal(time.Unix(past, 0).UTC()) {
+		t.Fatalf("ExpiresAt = %v, want %v", summary.ExpiresAt, time.Unix(past, 0).UTC())
+	}
+}
+
+// TestBuildSubscriptionSummary_NoExpiryTreatedActive falls back to active when
+// a sub2apiAuth block has no usable tokenExpiresAt (keeps accountCount fallback).
+func TestBuildSubscriptionSummary_NoExpiryTreatedActive(t *testing.T) {
+	t.Parallel()
+	accounts := []accountAgg{
+		{SiteID: 1, ExtraConfig: strPtr(`{"sub2apiAuth":{"group":"free","refreshToken":"rt_abc"}}`)},
+	}
+	got := buildSubscriptionSummary(accounts, 1)
+	summary := got.(*subscriptionSummary)
+	if !summary.Active {
+		t.Fatal("Active = false, want true when expiry unknown")
+	}
+	if summary.ActiveCount != 1 {
+		t.Fatalf("ActiveCount = %d, want 1", summary.ActiveCount)
+	}
+	if summary.ExpiresAt != nil {
+		t.Fatalf("ExpiresAt = %v, want nil", summary.ExpiresAt)
+	}
+}
+
+// TestBuildSubscriptionSummary_PlanNameFallback uses planName when group is
+// absent — the TS stored-summary field name.
+func TestBuildSubscriptionSummary_PlanNameFallback(t *testing.T) {
+	t.Parallel()
+	accounts := []accountAgg{
+		{SiteID: 1, ExtraConfig: strPtr(`{"sub2apiAuth":{"planName":"enterprise"}}`)},
+	}
+	summary := buildSubscriptionSummary(accounts, 1).(*subscriptionSummary)
+	if summary.Group != "enterprise" {
+		t.Fatalf("Group = %q, want enterprise (planName fallback)", summary.Group)
+	}
+}
+
+// TestBuildSubscriptionSummary_MultipleAccountsAggregate picks the latest
+// expiry across accounts and counts only non-expired tokens as active.
+func TestBuildSubscriptionSummary_MultipleAccountsAggregate(t *testing.T) {
+	t.Parallel()
+	now := time.Now().Unix()
+	past := now - 60
+	future1 := now + 60
+	future2 := now + 3600
+	accounts := []accountAgg{
+		{SiteID: 1, ExtraConfig: strPtr(`{"sub2apiAuth":{"group":"a","tokenExpiresAt":` + itoa64(past) + `}}`)},
+		{SiteID: 1, ExtraConfig: strPtr(`{"sub2apiAuth":{"group":"b","tokenExpiresAt":` + itoa64(future1) + `}}`)},
+		{SiteID: 1, ExtraConfig: strPtr(`{"sub2apiAuth":{"tokenExpiresAt":` + itoa64(future2) + `}}`)},
+		{SiteID: 2, ExtraConfig: strPtr(`{"sub2apiAuth":{"group":"other","tokenExpiresAt":` + itoa64(future2) + `}}`)},
+	}
+	summary := buildSubscriptionSummary(accounts, 1).(*subscriptionSummary)
+	// group "a" wins on first-seen order (b and the third are same site).
+	if summary.Group != "a" {
+		t.Fatalf("Group = %q, want a", summary.Group)
+	}
+	if summary.ActiveCount != 2 {
+		t.Fatalf("ActiveCount = %d, want 2", summary.ActiveCount)
+	}
+	if !summary.Active {
+		t.Fatal("Active = false, want true")
+	}
+	if !summary.ExpiresAt.Equal(time.Unix(future2, 0).UTC()) {
+		t.Fatalf("ExpiresAt = %v, want %v (latest)", summary.ExpiresAt, time.Unix(future2, 0).UTC())
+	}
+}
+
+// TestBuildSubscriptionSummary_JSONShape verifies the serialized shape keeps
+// the camelCase keys the frontend (sites-columns.tsx) reads via activeCount.
+func TestBuildSubscriptionSummary_JSONShape(t *testing.T) {
+	t.Parallel()
+	future := time.Now().Add(time.Hour).Unix()
+	accounts := []accountAgg{
+		{SiteID: 7, ExtraConfig: strPtr(`{"sub2apiAuth":{"group":"x","tokenExpiresAt":` + itoa64(future) + `}}`)},
+	}
+	got := buildSubscriptionSummary(accounts, 7)
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded["activeCount"].(float64) != 1 {
+		t.Fatalf("activeCount = %v, want 1", decoded["activeCount"])
+	}
+	if decoded["active"].(bool) != true {
+		t.Fatalf("active = %v, want true", decoded["active"])
+	}
+	if decoded["group"] != "x" {
+		t.Fatalf("group = %v, want x", decoded["group"])
+	}
+	if _, ok := decoded["expiresAt"]; !ok {
+		t.Fatal("expiresAt key missing")
+	}
+}
+
+// itoa64 formats an int64 as a string for JSON splicing in test fixtures.
+func itoa64(n int64) string {
+	const digits = "0123456789"
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = digits[n%10]
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
## Summary

Implements P2 TS-parity work for the `feat/ts-parity-misc` branch:

- **`subscriptionSummary` implementation** — `buildSubscriptionSummary` was a stub returning `nil`. It now aggregates each account's `extra_config.sub2apiAuth` block, surfacing `group`, `expiresAt`, `active`, and `activeCount`. Non-sub2api sites still return `nil` (preserves prior behavior), so the frontend `accountCount` fallback (`web/src/features/sites/components/sites-columns.tsx:194`) now gets real data without affecting other site types.
- **`internal/sharedcount` test coverage** — added a minimal in-memory RESP Redis server (no third-party deps) plus round-trip, TTL-expiry, dial/AUTH-failure, zero/negative-window, overflow, and concurrent Incr/IncrBy race-safety tests. Coverage **34.5% → 87.3%** (target >70%).
- **`handler/admin/payloads` test coverage** — added table-driven decode/marshal tests for all 14 payload types (valid, minimal, empty `{}`, malformed JSON, wrong-type rejection, omitempty round-trip). Went from **0 test files → 22 test functions** (target >60%). Note: the package is pure type declarations (no executable statements), so `go test -cover` reports `[no statements]` — a Go coverage limitation for pure-types packages, not a test gap.

## Build & test confirmation

- `go build ./service/... ./internal/sharedcount/... ./handler/admin/payloads/...` ✅
- `go vet ./service/... ./internal/sharedcount/... ./handler/admin/payloads/...` ✅ clean
- `go test -race ./internal/sharedcount/...` ✅ no data races
- `go test ./service/... ./internal/sharedcount/... ./handler/admin/payloads/... -cover` ✅ all pass

### Coverage numbers
| Package | Before | After |
|---|---|---|
| `internal/sharedcount` | 34.5% | **87.3%** |
| `handler/admin/payloads` | 0% (0 test files) | 22 test fns (`[no statements]` — pure types) |

## Test plan
- [ ] CI `go test ./...` is green (the pre-existing `web/embed.go` `dist:` embed error is unrelated to this change — frontend not built locally)
- [ ] Sites list endpoint still returns `subscriptionSummary: null` for non-sub2api sites
- [ ] Sites list returns populated `activeCount` for sub2api sites with non-expired tokens
- [ ] sharedcount counters behave correctly under concurrent load