### PR TITLE
feat(security): /v1 rate limiting + configurable body limit

### DIFF
--- a/auth/ratelimit.go
+++ b/auth/ratelimit.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -111,6 +112,231 @@ func OAuthRateLimit(rps, burst int) func(http.Handler) http.Handler {
 			if !rl.allow(ip) {
 				w.Header().Set("Retry-After", "1")
 				writeJSON(w, http.StatusTooManyRequests, jsonError("Too many requests"))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fixed-window per-IP RPM rate limiter for /v1 proxy routes.
+//
+// Unlike the token-bucket ipRateLimiter above (which is RPS-based and does
+// not expose remaining/reset for standard X-RateLimit-* headers), this uses
+// a simple fixed-window counter per IP per minute. The fixed-window model
+// naturally provides Limit/Remaining/Reset values that map 1:1 to the
+// conventional rate-limit response headers.
+//
+// In-memory only (sync.Mutex + map). Idle entries are evicted every minute.
+// ---------------------------------------------------------------------------
+
+// fixedWindowRateLimitResult holds the outcome of a fixed-window rate check.
+type fixedWindowRateLimitResult struct {
+	Allowed   bool
+	Limit     int
+	Remaining int
+	ResetAt   time.Time
+}
+
+// fixedWindowIPRateLimiter is a per-IP fixed-window counter with a one-minute
+// window. Each IP gets its own {count, resetAt} entry. When the current time
+// passes resetAt, the window rolls over (count resets to 0, resetAt advances).
+type fixedWindowIPRateLimiter struct {
+	mu      sync.Mutex
+	windows map[string]*fixedWindowEntry
+	limit   int
+	window  time.Duration
+}
+
+type fixedWindowEntry struct {
+	count   int
+	resetAt time.Time
+}
+
+// newFixedWindowIPRateLimiter creates a per-IP fixed-window limiter that allows
+// at most limit requests per window per IP. A limit <= 0 means the limiter is
+// disabled and allow() always returns Allowed=true.
+func newFixedWindowIPRateLimiter(limit int) *fixedWindowIPRateLimiter {
+	rl := &fixedWindowIPRateLimiter{
+		windows: make(map[string]*fixedWindowEntry),
+		limit:   limit,
+		window:  time.Minute,
+	}
+	go rl.cleanupLoop()
+	return rl
+}
+
+// cleanupLoop evicts idle IP entries older than 5 minutes, mirroring the
+// token-bucket limiter's eviction policy.
+func (rl *fixedWindowIPRateLimiter) cleanupLoop() {
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+	for range ticker.C {
+		rl.mu.Lock()
+		now := time.Now()
+		for ip, entry := range rl.windows {
+			if now.After(entry.resetAt.Add(5 * time.Minute)) {
+				delete(rl.windows, ip)
+			}
+		}
+		rl.mu.Unlock()
+	}
+}
+
+// allow checks whether ip is within its per-minute request budget. On the
+// first request (or after the window rolled over), a fresh window is created.
+func (rl *fixedWindowIPRateLimiter) allow(ip string) fixedWindowRateLimitResult {
+	if rl.limit <= 0 {
+		return fixedWindowRateLimitResult{Allowed: true, Limit: 0, Remaining: 0, ResetAt: time.Time{}}
+	}
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	entry, exists := rl.windows[ip]
+	if !exists || now.After(entry.resetAt) {
+		entry = &fixedWindowEntry{count: 0, resetAt: now.Add(rl.window)}
+		rl.windows[ip] = entry
+	}
+	entry.count++
+	remaining := rl.limit - entry.count
+	if remaining < 0 {
+		remaining = 0
+	}
+	if entry.count > rl.limit {
+		return fixedWindowRateLimitResult{Allowed: false, Limit: rl.limit, Remaining: 0, ResetAt: entry.resetAt}
+	}
+	return fixedWindowRateLimitResult{Allowed: true, Limit: rl.limit, Remaining: remaining, ResetAt: entry.resetAt}
+}
+
+// writeProxyRateLimitHeaders writes the conventional X-RateLimit-* response
+// headers so compliant clients can back off intelligently.
+func writeProxyRateLimitHeaders(w http.ResponseWriter, result fixedWindowRateLimitResult) {
+	if result.Limit <= 0 {
+		return
+	}
+	w.Header().Set("X-RateLimit-Limit", strconv.Itoa(result.Limit))
+	w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(result.Remaining))
+	w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(result.ResetAt.Unix(), 10))
+}
+
+// ProxyRateLimit returns middleware that enforces a per-IP RPM cap on /v1 proxy
+// routes using a fixed-window counter. rpm<=0 disables the limiter (pass-through).
+//
+// On limit exceedance it responds with 429 Too Many Requests, a JSON error body,
+// Retry-After, and X-RateLimit-Limit/Remaining/Reset headers.
+func ProxyRateLimit(rpm int) func(http.Handler) http.Handler {
+	if rpm <= 0 {
+		return func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				next.ServeHTTP(w, r)
+			})
+		}
+	}
+	rl := newFixedWindowIPRateLimiter(rpm)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := extractClientIP(r)
+			result := rl.allow(ip)
+			writeProxyRateLimitHeaders(w, result)
+			if !result.Allowed {
+				sec := int(time.Until(result.ResetAt).Seconds())
+				if sec < 1 {
+					sec = 1
+				}
+				w.Header().Set("Retry-After", strconv.Itoa(sec))
+				writeJSON(w, http.StatusTooManyRequests, jsonError("Too many requests"))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Global PROXY_TOKEN RPM cap — safety net against token leakage.
+//
+// A single fixed-window counter shared across all IPs. Only requests that
+// authenticated with the global PROXY_TOKEN (source == "global") are counted.
+// Managed keys already have their own RPM/TPM admission in ProxyAuth, so
+// they are exempt.
+// ---------------------------------------------------------------------------
+
+// globalTokenRateLimiter is a single-bucket fixed-window counter for the
+// global PROXY_TOKEN. Not per-IP — the cap is global across all callers.
+type globalTokenRateLimiter struct {
+	mu      sync.Mutex
+	count   int
+	resetAt time.Time
+	limit   int
+	window  time.Duration
+}
+
+func newGlobalTokenRateLimiter(limit int) *globalTokenRateLimiter {
+	return &globalTokenRateLimiter{
+		limit:  limit,
+		window: time.Minute,
+	}
+}
+
+// allow checks the shared global-token budget. On a rolled-over window the
+// counter resets.
+func (rl *globalTokenRateLimiter) allow() fixedWindowRateLimitResult {
+	if rl.limit <= 0 {
+		return fixedWindowRateLimitResult{Allowed: true, Limit: 0, Remaining: 0, ResetAt: time.Time{}}
+	}
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	if now.After(rl.resetAt) {
+		rl.count = 0
+		rl.resetAt = now.Add(rl.window)
+	}
+	rl.count++
+	remaining := rl.limit - rl.count
+	if remaining < 0 {
+		remaining = 0
+	}
+	if rl.count > rl.limit {
+		return fixedWindowRateLimitResult{Allowed: false, Limit: rl.limit, Remaining: 0, ResetAt: rl.resetAt}
+	}
+	return fixedWindowRateLimitResult{Allowed: true, Limit: rl.limit, Remaining: remaining, ResetAt: rl.resetAt}
+}
+
+// ProxyGlobalTokenRateLimit returns middleware that caps the global
+// PROXY_TOKEN at rpm requests per minute across all IPs. Must be installed
+// AFTER ProxyAuth so it can read the resolved auth source from the request
+// context. rpm<=0 disables the cap (pass-through).
+//
+// Only requests whose ProxyAuthContext.Source == "global" are counted;
+// managed keys pass through unaffected (they have their own RPM admission).
+func ProxyGlobalTokenRateLimit(rpm int) func(http.Handler) http.Handler {
+	if rpm <= 0 {
+		return func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				next.ServeHTTP(w, r)
+			})
+		}
+	}
+	rl := newGlobalTokenRateLimiter(rpm)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			pac := GetProxyAuth(r.Context())
+			if pac == nil || pac.Source != "global" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			result := rl.allow()
+			writeProxyRateLimitHeaders(w, result)
+			if !result.Allowed {
+				sec := int(time.Until(result.ResetAt).Seconds())
+				if sec < 1 {
+					sec = 1
+				}
+				w.Header().Set("Retry-After", strconv.Itoa(sec))
+				writeJSON(w, http.StatusTooManyRequests, jsonError("Global proxy token rate limit exceeded"))
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/auth/ratelimit_proxy_test.go
+++ b/auth/ratelimit_proxy_test.go
@@ -1,0 +1,431 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// fixedWindowIPRateLimiter unit tests
+// ---------------------------------------------------------------------------
+
+func TestFixedWindowIPRateLimiter_AllowsUnderLimit(t *testing.T) {
+	rl := newFixedWindowIPRateLimiter(3)
+	for i := 0; i < 3; i++ {
+		result := rl.allow("1.2.3.4")
+		if !result.Allowed {
+			t.Fatalf("request %d: expected Allowed=true, got false (remaining=%d)", i+1, result.Remaining)
+		}
+		if result.Limit != 3 {
+			t.Fatalf("Limit = %d, want 3", result.Limit)
+		}
+	}
+}
+
+func TestFixedWindowIPRateLimiter_BlocksAtThreshold(t *testing.T) {
+	rl := newFixedWindowIPRateLimiter(2)
+
+	// First two requests pass.
+	if r := rl.allow("10.0.0.1"); !r.Allowed {
+		t.Fatal("first request should be allowed")
+	}
+	if r := rl.allow("10.0.0.1"); !r.Allowed {
+		t.Fatal("second request should be allowed")
+	}
+
+	// Third request exceeds the limit.
+	result := rl.allow("10.0.0.1")
+	if result.Allowed {
+		t.Fatal("third request should be blocked")
+	}
+	if result.Remaining != 0 {
+		t.Fatalf("Remaining = %d, want 0 when blocked", result.Remaining)
+	}
+	if result.ResetAt.IsZero() {
+		t.Fatal("ResetAt should be non-zero when blocked")
+	}
+}
+
+func TestFixedWindowIPRateLimiter_PerIPIsolation(t *testing.T) {
+	rl := newFixedWindowIPRateLimiter(2)
+	// Exhaust IP A's budget.
+	rl.allow("1.1.1.1")
+	rl.allow("1.1.1.1")
+	if r := rl.allow("1.1.1.1"); r.Allowed {
+		t.Fatal("IP A should be blocked after 2 requests")
+	}
+	// IP B should still have its own budget.
+	if r := rl.allow("2.2.2.2"); !r.Allowed {
+		t.Fatal("IP B should be allowed (separate budget)")
+	}
+}
+
+func TestFixedWindowIPRateLimiter_DisabledWhenLimitZero(t *testing.T) {
+	rl := newFixedWindowIPRateLimiter(0)
+	for i := 0; i < 100; i++ {
+		result := rl.allow("3.3.3.3")
+		if !result.Allowed {
+			t.Fatalf("request %d should be allowed when limiter disabled", i)
+		}
+		if result.Limit != 0 {
+			t.Fatalf("Limit = %d, want 0 for disabled limiter", result.Limit)
+		}
+	}
+}
+
+func TestFixedWindowIPRateLimiter_RemainingDecrements(t *testing.T) {
+	rl := newFixedWindowIPRateLimiter(3)
+	r1 := rl.allow("4.4.4.4")
+	if r1.Remaining != 2 {
+		t.Fatalf("after 1st request Remaining = %d, want 2", r1.Remaining)
+	}
+	r2 := rl.allow("4.4.4.4")
+	if r2.Remaining != 1 {
+		t.Fatalf("after 2nd request Remaining = %d, want 1", r2.Remaining)
+	}
+	r3 := rl.allow("4.4.4.4")
+	if r3.Remaining != 0 {
+		t.Fatalf("after 3rd request Remaining = %d, want 0", r3.Remaining)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ProxyRateLimit middleware tests
+// ---------------------------------------------------------------------------
+
+// rateLimitTestHandler is a no-op next handler that records whether it ran.
+func rateLimitTestHandler(called *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*called = true
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestProxyRateLimit_BlocksAfterThreshold(t *testing.T) {
+	mw := ProxyRateLimit(2)
+	var called bool
+	h := mw(rateLimitTestHandler(&called))
+
+	// Two requests pass.
+	for i := 0; i < 2; i++ {
+		called = false
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		req.RemoteAddr = "5.5.5.5:1234"
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: status = %d, want 200", i+1, rec.Code)
+		}
+		if !called {
+			t.Fatalf("request %d: next handler not called", i+1)
+		}
+	}
+
+	// Third request is blocked.
+	called = false
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.RemoteAddr = "5.5.5.5:1234"
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("third request: status = %d, want %d", rec.Code, http.StatusTooManyRequests)
+	}
+	if called {
+		t.Fatal("next handler should NOT be called when rate limited")
+	}
+}
+
+func TestProxyRateLimit_429HasJSONErrorBody(t *testing.T) {
+	mw := ProxyRateLimit(1)
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Exhaust the single-request budget.
+	rec1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req1.RemoteAddr = "6.6.6.6:1234"
+	h.ServeHTTP(rec1, req1)
+
+	// Second request → 429 with JSON body.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req2.RemoteAddr = "6.6.6.6:1234"
+	h.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", rec2.Code, http.StatusTooManyRequests)
+	}
+	ct := rec2.Header().Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec2.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal 429 body: %v (body=%q)", err, rec2.Body.String())
+	}
+	if body["error"] == "" {
+		t.Fatalf("429 body missing error field: %s", rec2.Body.String())
+	}
+}
+
+func TestProxyRateLimit_SetsRateLimitHeaders(t *testing.T) {
+	mw := ProxyRateLimit(5)
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.RemoteAddr = "7.7.7.7:1234"
+	h.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("X-RateLimit-Limit"); got != "5" {
+		t.Fatalf("X-RateLimit-Limit = %q, want %q", got, "5")
+	}
+	if got := rec.Header().Get("X-RateLimit-Remaining"); got != "4" {
+		t.Fatalf("X-RateLimit-Remaining = %q, want %q", got, "4")
+	}
+	if got := rec.Header().Get("X-RateLimit-Reset"); got == "" {
+		t.Fatal("X-RateLimit-Reset header is missing")
+	}
+}
+
+func TestProxyRateLimit_SetsRetryAfterOn429(t *testing.T) {
+	mw := ProxyRateLimit(1)
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First request passes.
+	rec1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req1.RemoteAddr = "8.8.8.8:1234"
+	h.ServeHTTP(rec1, req1)
+
+	// Second is blocked and must include Retry-After.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req2.RemoteAddr = "8.8.8.8:1234"
+	h.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", rec2.Code, http.StatusTooManyRequests)
+	}
+	if ra := rec2.Header().Get("Retry-After"); ra == "" {
+		t.Fatal("Retry-After header is missing on 429")
+	}
+}
+
+func TestProxyRateLimit_DisabledWhenRPMZero(t *testing.T) {
+	mw := ProxyRateLimit(0)
+	var called bool
+	h := mw(rateLimitTestHandler(&called))
+
+	// 200 requests should all pass when limiter is disabled.
+	for i := 0; i < 200; i++ {
+		called = false
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		req.RemoteAddr = "9.9.9.9:1234"
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: status = %d, want 200 (limiter disabled)", i+1, rec.Code)
+		}
+		if !called {
+			t.Fatalf("request %d: handler not called", i+1)
+		}
+	}
+}
+
+func TestProxyRateLimit_PerIPIsolation(t *testing.T) {
+	mw := ProxyRateLimit(1)
+	var called bool
+	h := mw(rateLimitTestHandler(&called))
+
+	// IP A exhausts its single-request budget.
+	recA := httptest.NewRecorder()
+	reqA := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	reqA.RemoteAddr = "10.0.0.1:1234"
+	h.ServeHTTP(recA, reqA)
+	if recA.Code != http.StatusOK {
+		t.Fatalf("IP A first request: status = %d, want 200", recA.Code)
+	}
+
+	// IP B should still get its own request.
+	called = false
+	recB := httptest.NewRecorder()
+	reqB := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	reqB.RemoteAddr = "10.0.0.2:1234"
+	h.ServeHTTP(recB, reqB)
+	if recB.Code != http.StatusOK {
+		t.Fatalf("IP B first request: status = %d, want 200 (per-IP isolation)", recB.Code)
+	}
+	if !called {
+		t.Fatal("IP B handler not called (per-IP isolation)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ProxyGlobalTokenRateLimit middleware tests
+// ---------------------------------------------------------------------------
+
+// globalTokenAuthHandler injects a ProxyAuthContext with the given source into
+// the request context before delegating to next. Used to simulate the
+// post-ProxyAuth state without running the full auth chain.
+func globalTokenAuthHandler(source string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pac := &ProxyAuthContext{
+			Token:  "test-global-token",
+			Source: source,
+		}
+		r = r.WithContext(WithProxyAuth(r.Context(), pac))
+		next.ServeHTTP(w, r)
+	})
+}
+
+func TestProxyGlobalTokenRateLimit_BlocksGlobalTokenAfterThreshold(t *testing.T) {
+	mw := ProxyGlobalTokenRateLimit(2)
+	var called bool
+	// Simulate auth resolving source="global" before the global cap runs.
+	h := globalTokenAuthHandler("global", mw(rateLimitTestHandler(&called)))
+
+	for i := 0; i < 2; i++ {
+		called = false
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: status = %d, want 200", i+1, rec.Code)
+		}
+	}
+
+	// Third request exceeds the global cap.
+	called = false
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("third request: status = %d, want %d", rec.Code, http.StatusTooManyRequests)
+	}
+	if called {
+		t.Fatal("handler should not be called when global cap exceeded")
+	}
+}
+
+func TestProxyGlobalTokenRateLimit_PassesThroughManagedKeys(t *testing.T) {
+	mw := ProxyGlobalTokenRateLimit(1)
+	var called bool
+	// Managed keys should bypass the global cap entirely.
+	h := globalTokenAuthHandler("managed", mw(rateLimitTestHandler(&called)))
+
+	for i := 0; i < 10; i++ {
+		called = false
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("managed request %d: status = %d, want 200 (managed bypass)", i+1, rec.Code)
+		}
+		if !called {
+			t.Fatalf("managed request %d: handler not called", i+1)
+		}
+	}
+}
+
+func TestProxyGlobalTokenRateLimit_DisabledWhenRPMZero(t *testing.T) {
+	mw := ProxyGlobalTokenRateLimit(0)
+	var called bool
+	h := globalTokenAuthHandler("global", mw(rateLimitTestHandler(&called)))
+
+	for i := 0; i < 100; i++ {
+		called = false
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: status = %d, want 200 (disabled)", i+1, rec.Code)
+		}
+	}
+}
+
+func TestProxyGlobalTokenRateLimit_429HasJSONBody(t *testing.T) {
+	mw := ProxyGlobalTokenRateLimit(1)
+	h := globalTokenAuthHandler("global", mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	// First passes.
+	rec1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	h.ServeHTTP(rec1, req1)
+
+	// Second is blocked.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	h.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", rec2.Code, http.StatusTooManyRequests)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec2.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal body: %v (body=%q)", err, rec2.Body.String())
+	}
+	if body["error"] == "" {
+		t.Fatalf("429 body missing error field: %s", rec2.Body.String())
+	}
+}
+
+func TestProxyGlobalTokenRateLimit_PassesWhenNoAuthContext(t *testing.T) {
+	mw := ProxyGlobalTokenRateLimit(1)
+	var called bool
+	// No auth context in the request (e.g. middleware misconfigured before auth)
+	// should pass through, not block.
+	h := mw(rateLimitTestHandler(&called))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("no-auth-context: status = %d, want 200 (pass-through)", rec.Code)
+	}
+	if !called {
+		t.Fatal("handler not called when auth context is nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// globalTokenRateLimiter window-rollover test (injectable via nowFn pattern)
+// ---------------------------------------------------------------------------
+
+func TestGlobalTokenRateLimiter_WindowRollover(t *testing.T) {
+	rl := newGlobalTokenRateLimiter(2)
+	rl.window = 50 * time.Millisecond // short window for fast test
+
+	// Exhaust the cap.
+	if r := rl.allow(); !r.Allowed {
+		t.Fatal("first should be allowed")
+	}
+	if r := rl.allow(); !r.Allowed {
+		t.Fatal("second should be allowed")
+	}
+	if r := rl.allow(); r.Allowed {
+		t.Fatal("third should be blocked")
+	}
+
+	// Wait for the window to roll over.
+	time.Sleep(60 * time.Millisecond)
+
+	// After rollover, the budget resets.
+	result := rl.allow()
+	if !result.Allowed {
+		t.Fatal("request after window rollover should be allowed")
+	}
+	if result.Remaining != 1 {
+		t.Fatalf("Remaining after rollover = %d, want 1", result.Remaining)
+	}
+}

--- a/config/body_limit_test.go
+++ b/config/body_limit_test.go
@@ -1,0 +1,175 @@
+package config
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// REQUEST_BODY_LIMIT_MB parsing tests
+// ---------------------------------------------------------------------------
+
+func TestLoadRequestBodyLimitDefaultsTo20MB(t *testing.T) {
+	cfg := Load(map[string]string{})
+	if cfg.RequestBodyLimit != 20*1024*1024 {
+		t.Fatalf("RequestBodyLimit = %d, want %d (20 MB default)", cfg.RequestBodyLimit, 20*1024*1024)
+	}
+}
+
+func TestLoadRequestBodyLimitParsesCustomMB(t *testing.T) {
+	cfg := Load(map[string]string{
+		"REQUEST_BODY_LIMIT_MB": "50",
+	})
+	if cfg.RequestBodyLimit != 50*1024*1024 {
+		t.Fatalf("RequestBodyLimit = %d, want %d (50 MB)", cfg.RequestBodyLimit, 50*1024*1024)
+	}
+}
+
+func TestLoadRequestBodyLimitClampsToMin1MB(t *testing.T) {
+	cfg := Load(map[string]string{
+		"REQUEST_BODY_LIMIT_MB": "0",
+	})
+	if cfg.RequestBodyLimit != 1*1024*1024 {
+		t.Fatalf("RequestBodyLimit = %d, want %d (clamped to 1 MB min)", cfg.RequestBodyLimit, 1*1024*1024)
+	}
+}
+
+func TestLoadRequestBodyLimitClampsToMax200MB(t *testing.T) {
+	cfg := Load(map[string]string{
+		"REQUEST_BODY_LIMIT_MB": "999",
+	})
+	if cfg.RequestBodyLimit != 200*1024*1024 {
+		t.Fatalf("RequestBodyLimit = %d, want %d (clamped to 200 MB max)", cfg.RequestBodyLimit, 200*1024*1024)
+	}
+}
+
+func TestLoadRequestBodyLimitIgnoresInvalidValue(t *testing.T) {
+	cfg := Load(map[string]string{
+		"REQUEST_BODY_LIMIT_MB": "not-a-number",
+	})
+	if cfg.RequestBodyLimit != 20*1024*1024 {
+		t.Fatalf("RequestBodyLimit = %d, want %d (default on invalid)", cfg.RequestBodyLimit, 20*1024*1024)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FILE_UPLOAD_LIMIT_MB parsing tests
+// ---------------------------------------------------------------------------
+
+func TestLoadFileUploadLimitDefaultsTo100MB(t *testing.T) {
+	cfg := Load(map[string]string{})
+	if cfg.FileUploadLimitBytes != 100*1024*1024 {
+		t.Fatalf("FileUploadLimitBytes = %d, want %d (100 MB default)", cfg.FileUploadLimitBytes, 100*1024*1024)
+	}
+}
+
+func TestLoadFileUploadLimitParsesCustomMB(t *testing.T) {
+	cfg := Load(map[string]string{
+		"FILE_UPLOAD_LIMIT_MB": "200",
+	})
+	if cfg.FileUploadLimitBytes != 200*1024*1024 {
+		t.Fatalf("FileUploadLimitBytes = %d, want %d (200 MB)", cfg.FileUploadLimitBytes, 200*1024*1024)
+	}
+}
+
+func TestLoadFileUploadLimitClampsToMin1MB(t *testing.T) {
+	cfg := Load(map[string]string{
+		"FILE_UPLOAD_LIMIT_MB": "0",
+	})
+	if cfg.FileUploadLimitBytes != 1*1024*1024 {
+		t.Fatalf("FileUploadLimitBytes = %d, want %d (clamped to 1 MB min)", cfg.FileUploadLimitBytes, 1*1024*1024)
+	}
+}
+
+func TestLoadFileUploadLimitClampsToMax1000MB(t *testing.T) {
+	cfg := Load(map[string]string{
+		"FILE_UPLOAD_LIMIT_MB": "99999",
+	})
+	if cfg.FileUploadLimitBytes != 1000*1024*1024 {
+		t.Fatalf("FileUploadLimitBytes = %d, want %d (clamped to 1000 MB max)", cfg.FileUploadLimitBytes, 1000*1024*1024)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROXY_RATE_LIMIT_RPM parsing tests
+// ---------------------------------------------------------------------------
+
+func TestLoadProxyRateLimitRPMDefaultsTo60(t *testing.T) {
+	cfg := Load(map[string]string{})
+	if cfg.ProxyRateLimitRPM != 60 {
+		t.Fatalf("ProxyRateLimitRPM = %d, want 60 (default)", cfg.ProxyRateLimitRPM)
+	}
+}
+
+func TestLoadProxyRateLimitRPMDisabledWhenZero(t *testing.T) {
+	cfg := Load(map[string]string{
+		"PROXY_RATE_LIMIT_RPM": "0",
+	})
+	if cfg.ProxyRateLimitRPM != 0 {
+		t.Fatalf("ProxyRateLimitRPM = %d, want 0 (disabled)", cfg.ProxyRateLimitRPM)
+	}
+}
+
+func TestLoadProxyRateLimitRPMParsesCustomValue(t *testing.T) {
+	cfg := Load(map[string]string{
+		"PROXY_RATE_LIMIT_RPM": "120",
+	})
+	if cfg.ProxyRateLimitRPM != 120 {
+		t.Fatalf("ProxyRateLimitRPM = %d, want 120", cfg.ProxyRateLimitRPM)
+	}
+}
+
+func TestLoadProxyRateLimitRPMIgnoresInvalidValue(t *testing.T) {
+	cfg := Load(map[string]string{
+		"PROXY_RATE_LIMIT_RPM": "abc",
+	})
+	if cfg.ProxyRateLimitRPM != 60 {
+		t.Fatalf("ProxyRateLimitRPM = %d, want 60 (default on invalid)", cfg.ProxyRateLimitRPM)
+	}
+}
+
+func TestLoadProxyRateLimitRPMClampsNegativeToZero(t *testing.T) {
+	cfg := Load(map[string]string{
+		"PROXY_RATE_LIMIT_RPM": "-5",
+	})
+	if cfg.ProxyRateLimitRPM != 0 {
+		t.Fatalf("ProxyRateLimitRPM = %d, want 0 (clamped from negative)", cfg.ProxyRateLimitRPM)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PROXY_GLOBAL_TOKEN_RPM parsing tests
+// ---------------------------------------------------------------------------
+
+func TestLoadProxyGlobalTokenRPMDefaultsToZero(t *testing.T) {
+	cfg := Load(map[string]string{})
+	if cfg.ProxyGlobalTokenRPM != 0 {
+		t.Fatalf("ProxyGlobalTokenRPM = %d, want 0 (default = unlimited)", cfg.ProxyGlobalTokenRPM)
+	}
+}
+
+func TestLoadProxyGlobalTokenRPMParsesCustomValue(t *testing.T) {
+	cfg := Load(map[string]string{
+		"PROXY_GLOBAL_TOKEN_RPM": "300",
+	})
+	if cfg.ProxyGlobalTokenRPM != 300 {
+		t.Fatalf("ProxyGlobalTokenRPM = %d, want 300", cfg.ProxyGlobalTokenRPM)
+	}
+}
+
+func TestLoadProxyGlobalTokenRPMClampsNegativeToZero(t *testing.T) {
+	cfg := Load(map[string]string{
+		"PROXY_GLOBAL_TOKEN_RPM": "-10",
+	})
+	if cfg.ProxyGlobalTokenRPM != 0 {
+		t.Fatalf("ProxyGlobalTokenRPM = %d, want 0 (clamped from negative)", cfg.ProxyGlobalTokenRPM)
+	}
+}
+
+func TestLoadProxyGlobalTokenRPMIgnoresInvalidValue(t *testing.T) {
+	cfg := Load(map[string]string{
+		"PROXY_GLOBAL_TOKEN_RPM": "nope",
+	})
+	if cfg.ProxyGlobalTokenRPM != 0 {
+		t.Fatalf("ProxyGlobalTokenRPM = %d, want 0 (default on invalid)", cfg.ProxyGlobalTokenRPM)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -204,9 +204,20 @@ type Config struct {
 	AdminCorsAllowedOrigins []string
 	TrustedProxyCidrs       []string
 
-	// Proxy: Core (2 fields)
+	// Proxy: Core (5 fields)
 	RequestBodyLimit        int
-	RoutingFallbackUnitCost float64
+	// FileUploadLimitBytes is the higher body limit applied to multipart upload
+	// routes (/v1/files, /v1/images/*) so large uploads are not rejected by the
+	// general RequestBodyLimit. Parsed from FILE_UPLOAD_LIMIT_MB.
+	FileUploadLimitBytes     int
+	// ProxyRateLimitRPM is the per-IP request-per-minute cap for /v1 proxy
+	// routes. Parsed from PROXY_RATE_LIMIT_RPM (default 60; 0 = disabled).
+	ProxyRateLimitRPM        int
+	// ProxyGlobalTokenRPM caps the global PROXY_TOKEN across all IPs. Parsed
+	// from PROXY_GLOBAL_TOKEN_RPM (default 0 = unlimited). Safety net: even if
+	// the token leaks, upstream spend is bounded.
+	ProxyGlobalTokenRPM      int
+	RoutingFallbackUnitCost  float64
 	// CacheRatioDefault / CacheRatioClaude override the prompt-cache ratio
 	// fallbacks used when an upstream pricing row omits cache_ratio. 0/missing =
 	// use the code defaults (DefaultCacheRatio=1.0, ClaudeCacheRatio=0.1).
@@ -605,7 +616,20 @@ func Load(env map[string]string) *Config {
 	cfg.TrustedProxyCidrs = parseCsvList(get("TRUSTED_PROXY_CIDRS"))
 
 	// ---- §3.13 Proxy: Core ----
-	cfg.RequestBodyLimit = DefaultRequestBodyLimit
+	// REQUEST_BODY_LIMIT_MB controls the general body limit (default 20 MB,
+	// clamped to [1, 200]). FILE_UPLOAD_LIMIT_MB controls a separate higher
+	// limit for multipart upload routes /v1/files and /v1/images/* (default
+	// 100 MB, clamped to [1, 1000]).
+	bodyLimitMB := ClampInt(int(math.Trunc(parseNumber(get("REQUEST_BODY_LIMIT_MB"), float64(DefaultRequestBodyLimitMB)))), 1, 200)
+	cfg.RequestBodyLimit = bodyLimitMB * 1024 * 1024
+	fileUploadLimitMB := ClampInt(int(math.Trunc(parseNumber(get("FILE_UPLOAD_LIMIT_MB"), float64(DefaultFileUploadLimitMB)))), 1, 1000)
+	cfg.FileUploadLimitBytes = fileUploadLimitMB * 1024 * 1024
+
+	// Per-IP rate limiting for /v1 proxy routes (default 60 RPM; 0 = disabled).
+	cfg.ProxyRateLimitRPM = maxInt(0, int(math.Trunc(parseNumber(get("PROXY_RATE_LIMIT_RPM"), float64(DefaultProxyRateLimitRPM)))))
+	// Global PROXY_TOKEN RPM cap across all IPs (default 0 = unlimited).
+	cfg.ProxyGlobalTokenRPM = maxInt(0, int(math.Trunc(parseNumber(get("PROXY_GLOBAL_TOKEN_RPM"), 0))))
+
 	cfg.RoutingFallbackUnitCost = math.Max(1e-6, parseNumber(get("ROUTING_FALLBACK_UNIT_COST"), 1))
 	// Seconds; internal first-byte observation uses ms = sec * 1000.
 	cfg.ProxyFirstByteTimeoutSec = maxInt(0, int(math.Trunc(parseNumber(get("PROXY_FIRST_BYTE_TIMEOUT_SEC"), 0))))

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -34,7 +34,19 @@ const (
 	DefaultDbConnMaxLifetimeSec = 1800
 	DefaultDbConnMaxIdleTimeSec = 300
 
-	DefaultRequestBodyLimit = 20 * 1024 * 1024 // 20 MB
+	// RequestBodyLimit / FileUploadLimit. Parsed from MB env vars in Load:
+	//   REQUEST_BODY_LIMIT_MB  (default 20, clamped [1, 200])
+	//   FILE_UPLOAD_LIMIT_MB   (default 100, clamped [1, 1000])
+	// DefaultRequestBodyLimit is kept as the byte equivalent of 20 MB for
+	// backward-compatible struct literals in tests and callers that don't
+	// run Load().
+	DefaultRequestBodyLimitMB = 20
+	DefaultFileUploadLimitMB  = 100
+	DefaultRequestBodyLimit   = DefaultRequestBodyLimitMB * 1024 * 1024 // 20 MB
+
+	// Per-IP rate limiting for /v1 proxy routes. Default 60 RPM per IP.
+	// 0 disables the per-IP limiter entirely.
+	DefaultProxyRateLimitRPM = 60
 
 	TokenRouterFailureCooldownMaxSecCeiling = 30 * 24 * 60 * 60 // 30 days
 

--- a/router/body_limit_test.go
+++ b/router/body_limit_test.go
@@ -1,0 +1,295 @@
+package router
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/web"
+)
+
+// ---------------------------------------------------------------------------
+// BodyLimitPathAware middleware tests
+// ---------------------------------------------------------------------------
+
+func TestBodyLimitPathAware_Returns413OnOversizedContentLength(t *testing.T) {
+	mw := BodyLimitPathAware(100, 200) // 100 bytes default, 200 bytes upload
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("x"))
+	req.ContentLength = 101 // exceeds 100-byte general limit
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d (413)", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+	ct := rec.Header().Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal 413 body: %v (body=%q)", err, rec.Body.String())
+	}
+	if body["error"] == "" {
+		t.Fatalf("413 body missing error field: %s", rec.Body.String())
+	}
+}
+
+func TestBodyLimitPathAware_AllowsUnderLimit(t *testing.T) {
+	mw := BodyLimitPathAware(100, 200)
+	var called bool
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("hello"))
+	req.ContentLength = 5
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !called {
+		t.Fatal("handler should be called for under-limit body")
+	}
+}
+
+func TestBodyLimitPathAware_UsesHigherLimitForFileUploadPaths(t *testing.T) {
+	mw := BodyLimitPathAware(100, 200) // 100 general, 200 upload
+	var called bool
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// /v1/files path should use the 200-byte file upload limit, not the 100-byte general.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/files", strings.NewReader("x"))
+	req.ContentLength = 150 // > 100 general but < 200 upload
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/v1/files with 150 bytes: status = %d, want 200 (higher upload limit)", rec.Code)
+	}
+	if !called {
+		t.Fatal("handler should be called for /v1/files under upload limit")
+	}
+}
+
+func TestBodyLimitPathAware_UsesHigherLimitForImagesPaths(t *testing.T) {
+	mw := BodyLimitPathAware(100, 200)
+	var called bool
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// /v1/images/edits should use the 200-byte file upload limit.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/edits", strings.NewReader("x"))
+	req.ContentLength = 180
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/v1/images/edits with 180 bytes: status = %d, want 200 (higher upload limit)", rec.Code)
+	}
+	if !called {
+		t.Fatal("handler should be called for /v1/images/edits under upload limit")
+	}
+}
+
+func TestBodyLimitPathAware_RejectsFileUploadExceedingHigherLimit(t *testing.T) {
+	mw := BodyLimitPathAware(100, 200)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// /v1/files with 201 bytes exceeds even the 200-byte upload limit.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/files", strings.NewReader("x"))
+	req.ContentLength = 201
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("/v1/files with 201 bytes: status = %d, want %d (413)", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestBodyLimitPathAware_NoLimitWhenDefaultZero(t *testing.T) {
+	mw := BodyLimitPathAware(0, 0)
+	var called bool
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("x"))
+	req.ContentLength = 999999
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (no limit when default=0)", rec.Code)
+	}
+	if !called {
+		t.Fatal("handler should be called when no limit is set")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: /v1 rate limiting via the full router
+// ---------------------------------------------------------------------------
+
+func TestV1ProxyRateLimitReturns429(t *testing.T) {
+	cfg := &config.Config{
+		AuthToken:         "admin-token",
+		ProxyToken:        "proxy-token",
+		RequestBodyLimit:  config.DefaultRequestBodyLimit,
+		ProxyRateLimitRPM: 2, // very low limit for fast testing
+	}
+	r := New(cfg, web.Dist)
+
+	// Two requests from the same IP without auth — both hit the per-IP limiter.
+	// Without auth they would get 401, but the rate limiter runs before auth
+	// and passes (count < limit). We expect 401 for both (auth fails) but the
+	// limiter still counts them.
+	for i := 0; i < 2; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		req.RemoteAddr = "192.0.2.1:1234"
+		r.ServeHTTP(rec, req)
+		// 401 because no auth token — that's fine, the limiter passed.
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("request %d: status = %d, want 401 (no auth)", i+1, rec.Code)
+		}
+	}
+
+	// Third request: same IP now over the per-IP limit → 429 from the limiter.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.RemoteAddr = "192.0.2.1:1234"
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("third request: status = %d, want %d (429 rate limited)", rec.Code, http.StatusTooManyRequests)
+	}
+	if got := rec.Header().Get("X-RateLimit-Limit"); got != "2" {
+		t.Fatalf("X-RateLimit-Limit = %q, want %q", got, "2")
+	}
+	if got := rec.Header().Get("Retry-After"); got == "" {
+		t.Fatal("Retry-After header missing on 429")
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal 429 body: %v (body=%q)", err, rec.Body.String())
+	}
+	if body["error"] == "" {
+		t.Fatalf("429 body missing error field: %s", rec.Body.String())
+	}
+}
+
+func TestV1ProxyRateLimitDisabledWhenRPMZero(t *testing.T) {
+	cfg := &config.Config{
+		AuthToken:         "admin-token",
+		ProxyToken:        "proxy-token",
+		RequestBodyLimit:  config.DefaultRequestBodyLimit,
+		ProxyRateLimitRPM: 0, // disabled
+	}
+	r := New(cfg, web.Dist)
+
+	// Fire many requests; all should get 401 (auth) not 429 (rate limited).
+	for i := 0; i < 50; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		req.RemoteAddr = "192.0.2.2:1234"
+		r.ServeHTTP(rec, req)
+		if rec.Code == http.StatusTooManyRequests {
+			t.Fatalf("request %d: got 429 but rate limiter is disabled", i+1)
+		}
+	}
+}
+
+func TestV1ProxyRateLimitPerIPIsolation(t *testing.T) {
+	cfg := &config.Config{
+		AuthToken:         "admin-token",
+		ProxyToken:        "proxy-token",
+		RequestBodyLimit:  config.DefaultRequestBodyLimit,
+		ProxyRateLimitRPM: 1,
+	}
+	r := New(cfg, web.Dist)
+
+	// IP A: one request, exhausts its single-request budget.
+	recA := httptest.NewRecorder()
+	reqA := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	reqA.RemoteAddr = "192.0.2.10:1234"
+	r.ServeHTTP(recA, reqA)
+
+	// IP B: different IP, should NOT be rate limited.
+	recB := httptest.NewRecorder()
+	reqB := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	reqB.RemoteAddr = "192.0.2.11:1234"
+	r.ServeHTTP(recB, reqB)
+
+	if recB.Code == http.StatusTooManyRequests {
+		t.Fatalf("IP B got 429 but should have its own budget (per-IP isolation)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: body limit 413 via the full router
+// ---------------------------------------------------------------------------
+
+func TestV1BodyLimitReturns413OnOversizedRequest(t *testing.T) {
+	cfg := &config.Config{
+		AuthToken:        "admin-token",
+		ProxyToken:       "proxy-token",
+		RequestBodyLimit: 1 * 1024, // 1 KB — tiny limit for testing
+	}
+	r := New(cfg, web.Dist)
+
+	// Craft a body with Content-Length exceeding the limit.
+	rec := httptest.NewRecorder()
+	body := strings.Repeat("x", 2048)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Length", "2048")
+	req.Header.Set("Authorization", "Bearer proxy-token")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d (413 oversized body)", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestV1FileUploadRouteUsesHigherBodyLimit(t *testing.T) {
+	cfg := &config.Config{
+		AuthToken:           "admin-token",
+		ProxyToken:          "proxy-token",
+		RequestBodyLimit:    1 * 1024,          // 1 KB general
+		FileUploadLimitBytes: 100 * 1024,       // 100 KB for uploads
+		ProxyRateLimitRPM:   0,                 // disable rate limiting for this test
+	}
+	r := New(cfg, web.Dist)
+
+	// A 2 KB request to /v1/files should NOT be rejected by the general 1 KB
+	// limit because the file upload route uses the higher 100 KB limit.
+	rec := httptest.NewRecorder()
+	body := strings.Repeat("x", 2048)
+	req := httptest.NewRequest(http.MethodPost, "/v1/files", strings.NewReader(body))
+	req.Header.Set("Content-Length", "2048")
+	req.Header.Set("Authorization", "Bearer proxy-token")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusRequestEntityTooLarge {
+		t.Fatalf("/v1/files with 2 KB got 413 but should use the higher upload limit (100 KB)")
+	}
+}

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -220,3 +220,54 @@ func BodyLimit(limitBytes int) func(http.Handler) http.Handler {
 		})
 	}
 }
+
+// isFileUploadPath reports whether the given request path targets a multipart
+// upload route that should use the higher file-upload body limit instead of
+// the general RequestBodyLimit. Covers /v1/files (POST upload) and
+// /v1/images/* (POST edits/variations may carry multipart image payloads).
+func isFileUploadPath(path string) bool {
+	if path == "/v1/files" {
+		return true
+	}
+	if strings.HasPrefix(path, "/v1/images/") {
+		return true
+	}
+	return false
+}
+
+// writeBodyLimitError emits a 413 Request Entity Too Large response with a
+// JSON error body, so clients receive a clean rejection instead of a silently
+// truncated body.
+func writeBodyLimitError(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusRequestEntityTooLarge)
+	_, _ = w.Write([]byte(`{"error":"Request body too large"}`))
+}
+
+// BodyLimitPathAware enforces a maximum request body size, selecting between a
+// general limit and a higher file-upload limit based on the request path.
+// Multipart upload routes (/v1/files, /v1/images/*) use the higher
+// fileUploadLimitBytes; all other paths use defaultLimitBytes.
+//
+// A Content-Length that already exceeds the selected limit is rejected early
+// with a 413 JSON response before the handler runs, so the client gets a
+// clean error instead of a truncated read. For chunked requests (no
+// Content-Length) http.MaxBytesReader still caps the body as a safety net.
+func BodyLimitPathAware(defaultLimitBytes, fileUploadLimitBytes int) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			limit := defaultLimitBytes
+			if isFileUploadPath(r.URL.Path) && fileUploadLimitBytes > 0 {
+				limit = fileUploadLimitBytes
+			}
+			if limit > 0 {
+				if r.ContentLength > int64(limit) {
+					writeBodyLimitError(w)
+					return
+				}
+				r.Body = http.MaxBytesReader(w, r.Body, int64(limit))
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/router/router.go
+++ b/router/router.go
@@ -29,7 +29,7 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 	r.Use(TrustedRealIP(cfg))
 	r.Use(RequestLogger)
 	r.Use(Recoverer)
-	r.Use(BodyLimit(cfg.RequestBodyLimit))
+	r.Use(BodyLimitPathAware(cfg.RequestBodyLimit, cfg.FileUploadLimitBytes))
 
 	// ---- /health and /ready (design addition, not in TS) ----
 	// Registered before route groups so it bypasses auth middleware.
@@ -121,10 +121,16 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 		})
 	})
 
-	// /v1/* proxy routes → proxy auth middleware
+	// /v1/* proxy routes → proxy rate limiting + proxy auth middleware.
+	// Per-IP RPM limiter runs BEFORE auth so unauthenticated brute-force floods
+	// are rejected without burning a DB lookup. The global-token cap runs AFTER
+	// auth since it needs the resolved auth source to know whether the request
+	// used the global PROXY_TOKEN (managed keys have their own RPM admission).
 	r.Route("/v1", func(r chi.Router) {
 		r.Use(CORS())
+		r.Use(auth.ProxyRateLimit(cfg.ProxyRateLimitRPM))
 		r.Use(auth.ProxyAuth(cfg))
+		r.Use(auth.ProxyGlobalTokenRateLimit(cfg.ProxyGlobalTokenRPM))
 		proxyhandler.RegisterProxyRoutes(r)
 		// N2: downstream-key-visible cross-site price catalog (not admin auth).
 		// Mounted under /v1 so it inherits ProxyAuth; reuses the admin
@@ -137,9 +143,12 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 	// Non-/v1 proxy routes (chat alias, responses aliases, Gemini native paths).
 	// Use an inline group instead of Route("/") so proxy auth only applies to
 	// the exact registered proxy paths and does not shadow the SPA fallback.
+	// Same rate-limiting stack as /v1: per-IP before auth, global-token after.
 	r.Group(func(r chi.Router) {
 		r.Use(CORS())
+		r.Use(auth.ProxyRateLimit(cfg.ProxyRateLimitRPM))
 		r.Use(auth.ProxyAuth(cfg))
+		r.Use(auth.ProxyGlobalTokenRateLimit(cfg.ProxyGlobalTokenRPM))
 		proxyhandler.RegisterNonV1ProxyRoutes(r)
 	})
 


### PR DESCRIPTION
## Summary

- **Per-IP rate limiting on `/v1` proxy routes**: New `PROXY_RATE_LIMIT_RPM` env (default 60 RPM, 0=disabled). Fixed-window counter per IP per minute with `X-RateLimit-Limit`/`Remaining`/`Reset` headers and 429 JSON error body. Runs before `ProxyAuth` so unauthenticated brute-force floods are rejected without a DB lookup.
- **Global PROXY_TOKEN RPM cap**: New `PROXY_GLOBAL_TOKEN_RPM` env (default 0=unlimited). Single-bucket safety net — even if the global token leaks, upstream spend is bounded. Only counts requests whose auth source is `"global"`; managed keys keep their existing RPM/TPM admission path untouched.
- **Configurable request body limit**: `REQUEST_BODY_LIMIT_MB` (default 20, clamped [1,200]) with a separate higher `FILE_UPLOAD_LIMIT_MB` (default 100, clamped [1,1000]) for `/v1/files` and `/v1/images/*` multipart upload routes. Oversized requests now get a clean 413 JSON error instead of a silently truncated body.

## Key design decisions

- **In-memory only** (`sync.Mutex` + `map` with periodic eviction) — no Redis dependency required for single-instance deployments. The existing `internal/sharedcount` Redis-backed counters for managed-key admission are untouched.
- **Per-IP limiter runs before auth**, so brute-force floods from a single IP hit the 429 cap without burning a `downstream_api_keys` DB lookup.
- **Global token cap runs after auth** — it reads `ProxyAuthContext.Source` to decide whether to count. Managed keys bypass it entirely (they have their own `GlobalKeyAdmission` RPM/TPM gate).
- **Fixed-window counter** (not token bucket) was chosen for the proxy rate limiter because it naturally exposes `Limit`/`Remaining`/`Reset` values for the conventional `X-RateLimit-*` headers.

## Files changed

| File | Change |
|------|--------|
| `config/defaults.go` | New constants: `DefaultRequestBodyLimitMB`, `DefaultFileUploadLimitMB`, `DefaultProxyRateLimitRPM` |
| `config/config.go` | New fields + env parsing: `RequestBodyLimit`, `FileUploadLimitBytes`, `ProxyRateLimitRPM`, `ProxyGlobalTokenRPM` |
| `auth/ratelimit.go` | New: `fixedWindowIPRateLimiter`, `ProxyRateLimit`, `globalTokenRateLimiter`, `ProxyGlobalTokenRateLimit` middleware |
| `router/middleware.go` | New: `BodyLimitPathAware` middleware (path-aware, 413 JSON), `isFileUploadPath` |
| `router/router.go` | Wire rate limiters into `/v1` and non-`/v1` proxy groups; replace `BodyLimit` with `BodyLimitPathAware` |

## Test plan

- [x] `auth/ratelimit_proxy_test.go`: fixed-window limiter triggers at threshold, per-IP isolation, disabled-when-zero, 429 JSON body, X-RateLimit-* headers, Retry-After, global-token cap blocks after threshold, managed-key bypass, window rollover
- [x] `config/body_limit_test.go`: env parsing for all 4 new vars (defaults, custom values, clamping, invalid input, negative clamping)
- [x] `router/body_limit_test.go`: `BodyLimitPathAware` 413 on oversized Content-Length, path-aware higher limit for `/v1/files`+`/v1/images/*`, no-limit-when-zero, full-router integration (413, rate-limit 429, per-IP isolation, disabled-when-zero)
- [x] `go build ./...` — clean
- [x] `go test ./router/... ./auth/... ./config/...` — all pass
- [x] `go vet ./router/... ./auth/... ./config/...` — clean