### PR TITLE
perf: dashboard cache + async proxy_log batch writer

### DIFF
--- a/app/proxy_upstream.go
+++ b/app/proxy_upstream.go
@@ -54,11 +54,22 @@ func ConfigureProxyUpstream(cfg *config.Config) error {
 		Coordinator: coord,
 		Executor:    proxy.NewRuntimeExecutor(requestTimeout),
 		// Persist successful/failed proxy attempts (token usage when available).
-		// Writer uses store.GetDB() so it follows runtime DB overrides in tests.
+		// EnqueueProxyLog routes through the async batch writer when
+		// PROXY_LOG_ASYNC is enabled (default), falling back to a synchronous
+		// InsertProxyLog in sync mode and under channel backpressure. The
+		// writer resolves store.GetDB() at flush time so runtime overrides in
+		// tests are honored.
 		LogProxy: func(ctx context.Context, entry proxy.ProxyLogEntry) error {
-			return proxyhandler.InsertProxyLog(ctx, store.GetDB(), entry)
+			return proxyhandler.EnqueueProxyLog(ctx, entry)
 		},
 	})
+	// Configure the proxy_log batch writer from env. Idempotent: a reconfigure
+	// first drains the previous writer so no goroutine or in-flight entry leaks.
+	proxyhandler.ConfigureProxyLogWriter(
+		cfg.ProxyLogAsync,
+		cfg.ProxyLogBatchSize,
+		cfg.ProxyLogFlushIntervalMs,
+	)
 	// Channel recovery active candidates follow coordinator leases.
 	// Normalize nil→empty so an empty lease set does not look "unset".
 	scheduler.SetActiveChannelIDsProvider(func() []int64 {
@@ -113,4 +124,14 @@ func (p proxyLoadProvider) GetChannelLoadSnapshot(params routing.ChannelLoadPara
 		WaitingCount:     snap.WaitingCount,
 		Saturated:        snap.Saturated,
 	}
+}
+
+// ShutdownProxyLogBatchWriter drains and stops the global proxy_log batch
+// writer. It is intended to be registered as an app OnClose hook during server
+// startup so the writer flushes its final batch before app.cleanup() calls
+// store.CloseDatabase(). Exposed here (rather than having cmd/server import
+// handler/proxy directly) to keep the cmd → app package boundary intact.
+// No-op when the writer was never started (sync mode / PROXY_LOG_ASYNC=false).
+func ShutdownProxyLogBatchWriter(ctx context.Context) error {
+	return proxyhandler.ShutdownProxyLogBatchWriter(ctx)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -98,6 +99,14 @@ func main() {
 	a := app.New(cfg, r)
 	a.RegisterOnClose(func() {
 		app.StopBackgroundServices()
+		// Drain the proxy_log batch writer before app.cleanup() calls
+		// store.CloseDatabase() so the final batch flushes against an
+		// still-open DB. Bounded wait so a stuck flush cannot block shutdown.
+		drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := app.ShutdownProxyLogBatchWriter(drainCtx); err != nil {
+			slog.Warn("proxy_log batch writer drain did not complete within timeout", "error", err)
+		}
 	})
 
 	// ---- 21-23. Listen + shutdown ----

--- a/config/config.go
+++ b/config/config.go
@@ -285,6 +285,16 @@ type Config struct {
 	ProxyVideoTaskRetentionDays                 int
 	ProxyVideoTaskRetentionPruneIntervalMinutes int
 
+	// Proxy Log Batch Writer (3 fields). PROXY_LOG_ASYNC (default true) routes
+	// proxy_logs INSERTs through a background batch writer that decouples the
+	// hot proxy path from DB write latency / SQLite write-lock contention.
+	// Set false for tests/e2e that need write-through visibility. BATCH_SIZE
+	// (default 50) is the row count that triggers a flush; FLUSH_INTERVAL_MS
+	// (default 1000) is the max time between flushes.
+	ProxyLogAsync            bool
+	ProxyLogBatchSize        int
+	ProxyLogFlushIntervalMs  int
+
 	// Routing Weights (5 fields)
 	RoutingWeights RoutingWeights
 
@@ -684,6 +694,20 @@ func Load(env map[string]string) *Config {
 	cfg.ProxyFileRetentionPruneIntervalMinutes = maxInt(1, int(math.Trunc(parseNumber(get("PROXY_FILE_RETENTION_PRUNE_INTERVAL_MINUTES"), float64(DefaultProxyFileRetentionPruneIntervalMinutes)))))
 	cfg.ProxyVideoTaskRetentionDays = maxInt(0, int(math.Trunc(parseNumber(get("PROXY_VIDEO_TASK_RETENTION_DAYS"), float64(DefaultProxyVideoTaskRetentionDays)))))
 	cfg.ProxyVideoTaskRetentionPruneIntervalMinutes = maxInt(1, int(math.Trunc(parseNumber(get("PROXY_VIDEO_TASK_RETENTION_PRUNE_INTERVAL_MINUTES"), float64(DefaultProxyVideoTaskRetentionPruneIntervalMinutes)))))
+
+	// ---- §3.21b Proxy Log Batch Writer ----
+	// Default async=true so production gets the latency win automatically; the
+	// clamp guards against malformed operator input. Batch size/interval floors
+	// of 1 keep the writer functional even under tiny operator-chosen values.
+	cfg.ProxyLogAsync = parseBoolean(get("PROXY_LOG_ASYNC"), DefaultProxyLogAsync)
+	cfg.ProxyLogBatchSize = ClampInt(
+		int(math.Trunc(parseNumber(get("PROXY_LOG_BATCH_SIZE"), float64(DefaultProxyLogBatchSize)))),
+		1, 1000,
+	)
+	cfg.ProxyLogFlushIntervalMs = ClampInt(
+		int(math.Trunc(parseNumber(get("PROXY_LOG_FLUSH_INTERVAL_MS"), float64(DefaultProxyLogFlushIntervalMs)))),
+		1, 60000,
+	)
 
 	// ---- §3.22 Routing Weights ----
 	cfg.RoutingWeights = RoutingWeights{

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -75,6 +75,13 @@ const (
 	DefaultProxyVideoTaskRetentionDays                 = 0
 	DefaultProxyVideoTaskRetentionPruneIntervalMinutes = 60
 
+	// Proxy log batch writer (async INSERT batching). Default async=true so
+	// production gets the latency/lock-contention win automatically; tests and
+	// e2e suites set PROXY_LOG_ASYNC=false for write-through visibility.
+	DefaultProxyLogAsync             = true
+	DefaultProxyLogBatchSize        = 50
+	DefaultProxyLogFlushIntervalMs = 1000
+
 	DefaultProxyDebugRetentionHours = 24
 	DefaultProxyDebugMaxBodyBytes   = 262144
 

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -1,12 +1,14 @@
 package admin
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/deliciousbuding/metapi-go/scheduler"
@@ -74,15 +76,85 @@ type statsHandler struct {
 	db *sqlx.DB
 }
 
+// dashboardSummaryCache is a short-TTL in-memory cache for the dashboard
+// summary endpoint. Dashboard aggregation queries (COUNT/SUM over 24h of
+// proxy_logs) are expensive enough to dedup rapid reloads but cheap enough
+// that a 10s window keeps near-real-time semantics. Mirrors the
+// accountsSnapshotCache pattern: RWMutex-guarded bytes + expiry timestamp.
+//
+// Keyed by view (summary|insights|full) so the three response shapes never
+// collide. Only successful responses are cached; error paths bypass the cache.
+// ?force=1 clears the cache (admin "force refresh").
+type dashboardSummaryCache struct {
+	mu      sync.RWMutex
+	entries map[string]dashboardCacheEntry
+	ttl     time.Duration
+}
+
+type dashboardCacheEntry struct {
+	data      []byte
+	expiresAt time.Time
+}
+
+func (c *dashboardSummaryCache) get(view string) ([]byte, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.entries[view]
+	if !ok || len(e.data) == 0 || time.Now().After(e.expiresAt) {
+		return nil, false
+	}
+	return e.data, true
+}
+
+func (c *dashboardSummaryCache) set(view string, data []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.entries == nil {
+		c.entries = make(map[string]dashboardCacheEntry)
+	}
+	// Copy the slice so later buffer reuse by the caller cannot mutate the
+	// cached payload (defensive against json.Marshal aliasing).
+	stored := make([]byte, len(data))
+	copy(stored, data)
+	c.entries[view] = dashboardCacheEntry{data: stored, expiresAt: time.Now().Add(c.ttl)}
+}
+
+func (c *dashboardSummaryCache) clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = nil
+}
+
+var globalDashboardCache = &dashboardSummaryCache{ttl: 10 * time.Second}
+
 // ---- Dashboard ----
-// GET /api/stats/dashboard?refresh=&view=
+// GET /api/stats/dashboard?force=&view=
 func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 	view := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("view")))
 	if view != "summary" && view != "insights" {
 		view = "full"
 	}
 
-	// Set cache headers
+	// ?force=1 (or true) is the admin "force refresh" hook: it invalidates the
+	// snapshot cache so this request recomputes from the DB and repopulates it.
+	forceRefresh := parseDashboardForceRefresh(r.URL.Query().Get("force"))
+	if forceRefresh {
+		globalDashboardCache.clear()
+	}
+
+	// Cache hit short-circuits the expensive aggregation queries. The cached
+	// bytes are the exact JSON the miss path would have produced.
+	if cached, hit := globalDashboardCache.get(view); hit {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("x-dashboard-summary-cache", "hit")
+		w.Header().Set("x-dashboard-insights-cache", "miss")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(cached)
+		return
+	}
+
+	// Cache miss: report miss and compute. Both headers default to "miss";
+	// the summary header reflects this cache's state.
 	w.Header().Set("x-dashboard-summary-cache", "miss")
 	w.Header().Set("x-dashboard-insights-cache", "miss")
 
@@ -323,7 +395,31 @@ func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 		result["siteAvailability"] = siteAvailability
 	}
 
-	writeJSON(w, http.StatusOK, result)
+	// Marshal once and cache the bytes on the success path only — error paths
+	// returned earlier via dashboardError. Caching the exact encoded bytes
+	// (json.Encoder appends a newline, matching shared.WriteJSON) guarantees a
+	// later cache-hit response is byte-identical to the miss that populated it.
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(result); err != nil {
+		slog.Error("dashboard stats marshal failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to encode dashboard statistics")
+		return
+	}
+	cached := buf.Bytes()
+	globalDashboardCache.set(view, cached)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(cached)
+}
+
+// parseDashboardForceRefresh accepts ?force=1 / ?force=true (case-insensitive)
+// as the admin "force refresh" signal. Empty and any other value miss the
+// cache normally. Mirrors the accounts handler's refresh=true convention but
+// uses the generic force name so it reads naturally for any cache-backed
+// admin endpoint.
+func parseDashboardForceRefresh(raw string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	return normalized == "1" || normalized == "true" || normalized == "yes" || normalized == "on"
 }
 
 func (h *statsHandler) dashboardError(w http.ResponseWriter, operation string, err error) {

--- a/handler/admin/stats_cache_test.go
+++ b/handler/admin/stats_cache_test.go
@@ -1,0 +1,189 @@
+package admin
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// seedDashboardCacheFixture inserts the minimal site + account + proxy_log rows
+// the dashboard queries need to return 200 (rather than erroring on empty
+// joins). Returns the account id so callers can mutate data between requests
+// to validate force-refresh.
+func seedDashboardCacheFixture(t *testing.T, db *store.DB) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	mustExec(t, db, `INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "cache-site", "https://cache.example.test", "openai", now, now)
+	var siteID int64
+	if err := db.Get(&siteID, "SELECT id FROM sites WHERE name = ?", "cache-site"); err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+	mustExec(t, db, `INSERT INTO accounts (site_id, username, access_token, status, balance, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, FALSE, ?, ?)`, siteID, "cache-user", "sk-cache", 5.0, now, now)
+	var accountID int64
+	if err := db.Get(&accountID, "SELECT id FROM accounts WHERE username = ?", "cache-user"); err != nil {
+		t.Fatalf("account id: %v", err)
+	}
+	mustExec(t, db, `INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, prompt_tokens, completion_tokens, total_tokens, estimated_cost, created_at)
+		VALUES (?, ?, ?, 'success', ?, ?, ?, ?, ?)`, accountID, "gpt-cache", "gpt-cache", 10, 20, 30, 0.1, now)
+	return accountID
+}
+
+// mustExec fails the test on a DB exec error.
+func mustExec(t *testing.T, db *store.DB, query string, args ...any) {
+	t.Helper()
+	if _, err := db.Exec(query, args...); err != nil {
+		t.Fatalf("exec %q: %v", query, err)
+	}
+}
+
+// TestDashboardCache_MissThenHit verifies the first request is a miss (and
+// populates the cache) and the second identical request is a hit returning the
+// same body. This is the core dedup contract.
+func TestDashboardCache_MissThenHit(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedDashboardCacheFixture(t, db)
+
+	first := doGet(t, r, "/api/stats/dashboard?view=summary")
+	if first.Code != 200 {
+		t.Fatalf("first dashboard: %d %s", first.Code, first.Body.String())
+	}
+	if got := first.Header().Get("x-dashboard-summary-cache"); got != "miss" {
+		t.Fatalf("first request cache header = %q, want miss", got)
+	}
+
+	second := doGet(t, r, "/api/stats/dashboard?view=summary")
+	if second.Code != 200 {
+		t.Fatalf("second dashboard: %d %s", second.Code, second.Body.String())
+	}
+	if got := second.Header().Get("x-dashboard-summary-cache"); got != "hit" {
+		t.Fatalf("second request cache header = %q, want hit", got)
+	}
+
+	// Hit must return byte-identical body to the miss that populated it.
+	if first.Body.String() != second.Body.String() {
+		t.Fatalf("cache hit body differs from miss body.\nmiss: %s\nhit:  %s", first.Body.String(), second.Body.String())
+	}
+}
+
+// TestDashboardCache_ForceRefreshBypassesAndInvalidates verifies ?force=1
+// reports miss, recomputes from the DB, and invalidates the cache so a
+// subsequent non-force request also sees fresh data.
+func TestDashboardCache_ForceRefreshBypassesAndInvalidates(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	accountID := seedDashboardCacheFixture(t, db)
+
+	// Populate the cache with the initial data set.
+	first := doGet(t, r, "/api/stats/dashboard?view=summary")
+	if first.Header().Get("x-dashboard-summary-cache") != "miss" {
+		t.Fatalf("first request should miss, got %q", first.Header().Get("x-dashboard-summary-cache"))
+	}
+
+	// Mutate the data so a fresh compute would differ. Insert another proxy log
+	// so proxy24h.total changes from 1 → 2.
+	now := time.Now().UTC().Format(time.RFC3339)
+	mustExec(t, db, `INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, total_tokens, estimated_cost, created_at)
+		VALUES (?, 'gpt-cache-2', 'gpt-cache-2', 'success', 7, 0.05, ?)`, accountID, now)
+
+	// A plain (non-force) request would still hit the stale cache.
+	stale := doGet(t, r, "/api/stats/dashboard?view=summary")
+	if stale.Header().Get("x-dashboard-summary-cache") != "hit" {
+		t.Fatalf("expected hit from stale cache, got %q", stale.Header().Get("x-dashboard-summary-cache"))
+	}
+
+	// force=1 must bypass + invalidate, recomputing from the DB.
+	forced := doGet(t, r, "/api/stats/dashboard?view=summary&force=1")
+	if forced.Code != 200 {
+		t.Fatalf("forced dashboard: %d %s", forced.Code, forced.Body.String())
+	}
+	if got := forced.Header().Get("x-dashboard-summary-cache"); got != "miss" {
+		t.Fatalf("force=1 should report miss, got %q", got)
+	}
+
+	// The forced (fresh) body must differ from the stale cached body.
+	if forced.Body.String() == stale.Body.String() {
+		t.Fatal("force=1 returned the same body as the stale cache; cache was not actually invalidated")
+	}
+	// And it must reflect the new proxy24h.total.
+	var fresh map[string]any
+	if err := json.Unmarshal(forced.Body.Bytes(), &fresh); err != nil {
+		t.Fatalf("unmarshal forced: %v", err)
+	}
+	proxy24h := fresh["proxy24h"].(map[string]any)
+	if got := int(proxy24h["total"].(float64)); got != 2 {
+		t.Fatalf("forced proxy24h.total = %d, want 2 (force did not recompute)", got)
+	}
+
+	// A subsequent non-force request must now hit the freshly-populated cache
+	// and return the fresh body (proving force repopulated, not just cleared).
+	after := doGet(t, r, "/api/stats/dashboard?view=summary")
+	if after.Header().Get("x-dashboard-summary-cache") != "hit" {
+		t.Fatalf("post-force request should hit repopulated cache, got %q", after.Header().Get("x-dashboard-summary-cache"))
+	}
+	if after.Body.String() != forced.Body.String() {
+		t.Fatal("post-force cache hit did not return the freshly-populated body")
+	}
+}
+
+// TestDashboardCache_ViewKeying verifies that caching one view does not serve
+// another view from the cache. summary and full have different shapes, so a
+// summary miss→hit must not make a full request a hit.
+func TestDashboardCache_ViewKeying(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedDashboardCacheFixture(t, db)
+
+	// Populate the summary view cache.
+	summaryFirst := doGet(t, r, "/api/stats/dashboard?view=summary")
+	if summaryFirst.Header().Get("x-dashboard-summary-cache") != "miss" {
+		t.Fatalf("summary first should miss, got %q", summaryFirst.Header().Get("x-dashboard-summary-cache"))
+	}
+
+	// full is a different view: must be a miss even though summary is cached.
+	fullFirst := doGet(t, r, "/api/stats/dashboard?view=full")
+	if fullFirst.Code != 200 {
+		t.Fatalf("full dashboard: %d %s", fullFirst.Code, fullFirst.Body.String())
+	}
+	if fullFirst.Header().Get("x-dashboard-summary-cache") != "miss" {
+		t.Fatalf("full first should miss (view-keyed cache), got %q", fullFirst.Header().Get("x-dashboard-summary-cache"))
+	}
+
+	// Now both should hit independently.
+	if doGet(t, r, "/api/stats/dashboard?view=summary").Header().Get("x-dashboard-summary-cache") != "hit" {
+		t.Fatal("summary should hit after population")
+	}
+	if doGet(t, r, "/api/stats/dashboard?view=full").Header().Get("x-dashboard-summary-cache") != "hit" {
+		t.Fatal("full should hit after population")
+	}
+}
+
+// TestDashboardCache_DoesNotCacheErrors verifies that a failed (500) response
+// is not cached, so a subsequent request after the DB is healthy again computes
+// fresh rather than replaying a cached error. The error path returns before
+// globalDashboardCache.set, so the next request must be a miss, never a hit.
+func TestDashboardCache_DoesNotCacheErrors(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedDashboardCacheFixture(t, db)
+
+	// First a healthy miss to confirm the cache is empty for this view.
+	healthy := doGet(t, r, "/api/stats/dashboard?view=summary")
+	if healthy.Header().Get("x-dashboard-summary-cache") != "miss" {
+		t.Fatalf("healthy first should miss, got %q", healthy.Header().Get("x-dashboard-summary-cache"))
+	}
+	// The healthy response IS cached now. Closing the DB then requesting would
+	// still hit the cache (a hit, not an error) — so to test the error-no-cache
+	// contract we need a view that was never populated. Use insights view and
+	// a closed DB: the query fails before set() is reached.
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	errResp := doGet(t, r, "/api/stats/dashboard?view=insights")
+	if errResp.Code != 500 {
+		t.Fatalf("insights on closed DB: got %d, want 500 (%s)", errResp.Code, errResp.Body.String())
+	}
+	if got := errResp.Header().Get("x-dashboard-summary-cache"); got != "miss" {
+		t.Fatalf("error response cache header = %q, want miss (errors must not be cached as hits)", got)
+	}
+}

--- a/handler/admin/stats_test.go
+++ b/handler/admin/stats_test.go
@@ -14,6 +14,9 @@ import (
 
 func setupStatsPostgresTest(t *testing.T) (*store.DB, chi.Router) {
 	t.Helper()
+	// Process-global cache must start empty per test so a prior test's cached
+	// summary never leaks in (especially for the DB-closed 500 test).
+	globalDashboardCache.clear()
 
 	dsn := strings.TrimSpace(os.Getenv("PG_TEST_DSN"))
 	if dsn == "" {
@@ -37,6 +40,9 @@ func setupStatsPostgresTest(t *testing.T) (*store.DB, chi.Router) {
 
 func setupStatsSQLiteTest(t *testing.T) (*store.DB, chi.Router) {
 	t.Helper()
+	// Process-global cache must start empty per test so a prior test's cached
+	// summary never leaks in (especially for the DB-closed 500 test).
+	globalDashboardCache.clear()
 	db, err := store.Open(store.DialectSQLite, ":memory:", false)
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
@@ -285,7 +291,7 @@ func TestStats_SQLiteDashboardUsesLocalDayRewardAndCheckinTruth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("insert unattributed proxy log: %v", err)
 	}
-	resp = doGet(t, r, "/api/stats/dashboard?view=summary")
+	resp = doGet(t, r, "/api/stats/dashboard?view=summary&force=1")
 	if resp.Code != 200 {
 		t.Fatalf("partial dashboard returned %d: %s", resp.Code, resp.Body.String())
 	}

--- a/handler/proxy/proxy_log.go
+++ b/handler/proxy/proxy_log.go
@@ -32,6 +32,44 @@ func InsertProxyLog(ctx context.Context, db *store.DB, entry proxy.ProxyLogEntry
 		return nil
 	}
 	createdAt := time.Now().UTC().Format(time.RFC3339)
+	args := proxyLogEntryArgs(entry, createdAt)
+	query := "INSERT INTO proxy_logs (" + proxyLogInsertColumns + ") VALUES " + proxyLogSingleRowPlaceholders
+	if ctx != nil {
+		_, err := db.ExecContext(ctx, query, args...)
+		return err
+	}
+	_, err := db.Exec(query, args...)
+	return err
+}
+
+// proxyLogInsertColumns is the canonical column list for a proxy_logs INSERT.
+// Order MUST match proxyLogEntryArgs. Shared by the single-row InsertProxyLog
+// path and the multi-row batch writer so the two never drift.
+const proxyLogInsertColumns = `route_id, channel_id, account_id, downstream_api_key_id,
+			model_requested, model_actual, status, http_status, is_stream,
+			first_byte_latency_ms, latency_ms,
+			prompt_tokens, completion_tokens, total_tokens,
+			estimated_cost, billing_details,
+			client_family, client_app_id, client_app_name, client_confidence,
+			error_message, retry_count, request_id, created_at`
+
+// proxyLogSingleRowPlaceholders is the 24 "?" placeholders for one row.
+// store.DB rebinds ? to $N for PostgreSQL, so the batch writer builds rows of
+// the same placeholder shape and lets the rebind do the dialect work.
+const proxyLogSingleRowPlaceholders = `(?, ?, ?, ?,
+			?, ?, ?, ?, ?,
+			?, ?,
+			?, ?, ?,
+			?, ?,
+			?, ?, ?, ?,
+			?, ?, ?, ?)`
+
+// proxyLogEntryArgs builds the positional args for one proxy_logs INSERT row,
+// matching proxyLogInsertColumns order. Shared by InsertProxyLog (single) and
+// batchInsertProxyLogs (multi-row). createdAt is injected by the caller so the
+// batch writer can stamp a whole batch with one timestamp while the single-row
+// path keeps its per-call time.Now().
+func proxyLogEntryArgs(entry proxy.ProxyLogEntry, createdAt string) []any {
 	var billingDetails any
 	if entry.BillingDetails != nil {
 		switch v := entry.BillingDetails.(type) {
@@ -43,27 +81,7 @@ func InsertProxyLog(ctx context.Context, db *store.DB, entry proxy.ProxyLogEntry
 			}
 		}
 	}
-
-	query := `
-		INSERT INTO proxy_logs (
-			route_id, channel_id, account_id, downstream_api_key_id,
-			model_requested, model_actual, status, http_status, is_stream,
-			first_byte_latency_ms, latency_ms,
-			prompt_tokens, completion_tokens, total_tokens,
-			estimated_cost, billing_details,
-			client_family, client_app_id, client_app_name, client_confidence,
-			error_message, retry_count, request_id, created_at
-		) VALUES (
-			?, ?, ?, ?,
-			?, ?, ?, ?, ?,
-			?, ?,
-			?, ?, ?,
-			?, ?,
-			?, ?, ?, ?,
-			?, ?, ?, ?
-		)`
-
-	args := []any{
+	return []any{
 		nullInt64(entry.RouteID),
 		nullInt64(entry.ChannelID),
 		nullInt64(entry.AccountID),
@@ -89,13 +107,6 @@ func InsertProxyLog(ctx context.Context, db *store.DB, entry proxy.ProxyLogEntry
 		nullString(strPtrOrEmpty(entry.RequestID)),
 		createdAt,
 	}
-
-	if ctx != nil {
-		_, err := db.ExecContext(ctx, query, args...)
-		return err
-	}
-	_, err := db.Exec(query, args...)
-	return err
 }
 
 func logProxy(ctx context.Context, cfg *UpstreamConfig, entry proxy.ProxyLogEntry) {

--- a/handler/proxy/proxy_log_batch.go
+++ b/handler/proxy/proxy_log_batch.go
@@ -1,0 +1,303 @@
+package proxyhandler
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/proxy"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// proxyLogBatchWriter drains proxy.ProxyLogEntry values from a buffered channel
+// and INSERTs them in batches, decoupling the hot proxy path from DB write
+// latency (especially SQLite's single-writer lock contention).
+//
+// Trade-off: entries are visible in proxy_logs up to flushInterval (default 1s)
+// after they are produced. Operators that need write-through visibility (e2e
+// tests, audit-on-write) set PROXY_LOG_ASYNC=false to bypass the writer.
+//
+// Reliability contract:
+//   - On enqueue: a non-blocking send fills the channel; when the channel is
+//     full (backpressure) the entry is written synchronously so logs are never
+//     dropped due to saturation.
+//   - On graceful shutdown: the loop drains everything still in the channel +
+//     the in-memory buffer and flushes before returning, so no log is lost
+//     when the server is stopped between flush ticks.
+//   - On batch INSERT failure: the batch falls back to per-row inserts so a
+//     single malformed row cannot sink the rest of the batch.
+type proxyLogBatchWriter struct {
+	ch            chan proxy.ProxyLogEntry
+	batchSize     int
+	flushInterval time.Duration
+	stop          chan struct{}
+	done          chan struct{}
+	stopOnce      sync.Once
+	wg            sync.WaitGroup
+}
+
+// newProxyLogBatchWriter constructs a writer. batchSize is clamped to a sane
+// floor; flushIntervalMs likewise. The channel capacity is a multiple of the
+// batch size to absorb short bursts before backpressure kicks in.
+func newProxyLogBatchWriter(batchSize int, flushIntervalMs int) *proxyLogBatchWriter {
+	if batchSize < 1 {
+		batchSize = defaultProxyLogBatchSize
+	}
+	if flushIntervalMs < 1 {
+		flushIntervalMs = defaultProxyLogFlushIntervalMs
+	}
+	// Channel headroom: 4× the batch size gives ~4 batches of burst capacity
+	// before enqueue falls back to synchronous writes. Bounded to keep memory
+	// predictable under sustained overload.
+	channelCapacity := batchSize * 4
+	return &proxyLogBatchWriter{
+		ch:            make(chan proxy.ProxyLogEntry, channelCapacity),
+		batchSize:     batchSize,
+		flushInterval: time.Duration(flushIntervalMs) * time.Millisecond,
+		stop:          make(chan struct{}),
+		done:          make(chan struct{}),
+	}
+}
+
+// start launches the background drain goroutine. It must be called exactly
+// once before any enqueue; shutdown must be called exactly once to stop it.
+func (b *proxyLogBatchWriter) start() {
+	b.wg.Add(1)
+	go b.loop()
+}
+
+// enqueue pushes entry onto the channel. When the channel is full it falls
+// back to a synchronous InsertProxyLog so logs are never dropped under
+// backpressure. Returns nil when there is no DB to write to (mirrors
+// InsertProxyLog's nil-DB no-op).
+func (b *proxyLogBatchWriter) enqueue(ctx context.Context, entry proxy.ProxyLogEntry) error {
+	select {
+	case b.ch <- entry:
+		return nil
+	default:
+	}
+	// Channel full: write through synchronously rather than blocking the hot
+	// path or dropping the log. This is the intended backpressure escape valve.
+	db := store.GetDB()
+	if db == nil {
+		return nil
+	}
+	return InsertProxyLog(ctx, db, entry)
+}
+
+// loop is the background drain goroutine. It accumulates entries into a buffer
+// and flushes when the buffer reaches batchSize OR the flush ticker fires,
+// whichever comes first. On stop it drains the channel + buffer one last time.
+func (b *proxyLogBatchWriter) loop() {
+	defer b.wg.Done()
+	defer close(b.done)
+
+	ticker := time.NewTicker(b.flushInterval)
+	defer ticker.Stop()
+
+	buf := make([]proxy.ProxyLogEntry, 0, b.batchSize)
+	flush := func() {
+		if len(buf) == 0 {
+			return
+		}
+		b.flushBatch(context.Background(), buf)
+		buf = buf[:0]
+	}
+
+	for {
+		select {
+		case entry := <-b.ch:
+			buf = append(buf, entry)
+			if len(buf) >= b.batchSize {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		case <-b.stop:
+			// Graceful shutdown: drain anything still queued so no log is lost
+			// between the last flush tick and process exit.
+			draining := true
+			for draining {
+				select {
+				case entry := <-b.ch:
+					buf = append(buf, entry)
+					if len(buf) >= b.batchSize {
+						flush()
+					}
+				default:
+					draining = false
+				}
+			}
+			flush()
+			return
+		}
+	}
+}
+
+// shutdown signals the loop to stop and blocks until it has finished draining
+// and flushing, or until ctx expires. Safe to call once (guarded by stopOnce);
+// subsequent calls are no-ops.
+func (b *proxyLogBatchWriter) shutdown(ctx context.Context) error {
+	b.stopOnce.Do(func() { close(b.stop) })
+	select {
+	case <-b.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// flushBatch writes entries as a single multi-row INSERT. On failure it falls
+// back to per-row inserts (via InsertProxyLog) so one bad row cannot sink the
+// whole batch. The DB is resolved at flush time via store.GetDB() so runtime
+// overrides (tests) are honored.
+func (b *proxyLogBatchWriter) flushBatch(ctx context.Context, entries []proxy.ProxyLogEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	db := store.GetDB()
+	if db == nil {
+		slog.Warn("proxy_log batch writer: no DB at flush, dropping batch", "count", len(entries))
+		return
+	}
+	if len(entries) == 1 {
+		if err := InsertProxyLog(ctx, db, entries[0]); err != nil {
+			slog.Warn("proxy_log single insert failed during flush", "err", err)
+		}
+		return
+	}
+	if err := batchInsertProxyLogs(ctx, db, entries); err != nil {
+		slog.Warn("proxy_log batch insert failed, falling back to per-row", "err", err, "count", len(entries))
+		for _, entry := range entries {
+			if err := InsertProxyLog(ctx, db, entry); err != nil {
+				slog.Warn("proxy_log per-row insert failed",
+					"err", err,
+					"status", entry.Status,
+					"model", entry.ModelRequested,
+					"request_id", entry.RequestID,
+				)
+			}
+		}
+	}
+}
+
+// batchInsertProxyLogs builds a single multi-row INSERT statement for the given
+// entries. Placeholders are ?-shaped; store.DB.ExecContext rebinds them to $N
+// for PostgreSQL, so the same query works across dialects. All rows share one
+// created_at timestamp (the flush instant) — within flushInterval of when
+// each entry was actually produced, which is well inside the 24h / 60s query
+// windows that consume the column.
+func batchInsertProxyLogs(ctx context.Context, db *store.DB, entries []proxy.ProxyLogEntry) error {
+	var sb strings.Builder
+	sb.WriteString("INSERT INTO proxy_logs (")
+	sb.WriteString(proxyLogInsertColumns)
+	sb.WriteString(") VALUES ")
+
+	// One timestamp for the whole batch; the per-row skew vs. real occurrence
+	// is bounded by the flush interval and is irrelevant to 24h/60s windows.
+	createdAt := time.Now().UTC().Format(time.RFC3339)
+	args := make([]any, 0, len(entries)*proxyLogInsertArgCount)
+	for i, entry := range entries {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(proxyLogSingleRowPlaceholders)
+		args = append(args, proxyLogEntryArgs(entry, createdAt)...)
+	}
+	_, err := db.ExecContext(ctx, sb.String(), args...)
+	return err
+}
+
+// proxyLogInsertArgCount is the number of positional args per proxy_logs row.
+// Kept as a constant so the batch writer can pre-size the args slice without a
+// runtime count of proxyLogEntryArgs output.
+const proxyLogInsertArgCount = 24
+
+// Default tunables for the proxy_log batch writer. Mirrors the env defaults in
+// config.Load so the writer is usable in isolation (tests, ad-hoc tooling).
+const (
+	defaultProxyLogBatchSize        = 50
+	defaultProxyLogFlushIntervalMs = 1000
+)
+
+// ---- Global writer singleton ----
+//
+// The process-wide writer is configured by app.ConfigureProxyUpstream from the
+// PROXY_LOG_ASYNC / PROXY_LOG_BATCH_SIZE / PROXY_LOG_FLUSH_INTERVAL_MS env
+// vars. When async is disabled the writer stays nil and EnqueueProxyLog writes
+// through synchronously — the test/e2e path that needs immediate visibility.
+var (
+	proxyLogBatchWriterMu sync.Mutex
+	proxyLogBatchWriterInst *proxyLogBatchWriter
+)
+
+// ConfigureProxyLogWriter sets up the global proxy log writer. When async is
+// true a batch writer is started; when false any existing writer is shut down
+// (drained) and the system reverts to synchronous writes. Idempotent: calling
+// again first drains the previous writer so reconfigure does not leak a
+// goroutine or lose in-flight entries.
+func ConfigureProxyLogWriter(async bool, batchSize int, flushIntervalMs int) {
+	proxyLogBatchWriterMu.Lock()
+	defer proxyLogBatchWriterMu.Unlock()
+
+	if proxyLogBatchWriterInst != nil {
+		// Drain the previous writer before replacing it so reconfigure never
+		// loses entries or strands a goroutine. A bounded wait is enough: the
+		// loop drains the channel in O(channel depth) before returning.
+		drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := proxyLogBatchWriterInst.shutdown(drainCtx); err != nil {
+			slog.Warn("proxy_log batch writer shutdown during reconfigure timed out", "err", err)
+		}
+		cancel()
+		proxyLogBatchWriterInst = nil
+	}
+
+	if !async {
+		return
+	}
+
+	w := newProxyLogBatchWriter(batchSize, flushIntervalMs)
+	w.start()
+	proxyLogBatchWriterInst = w
+	slog.Info("proxy_log batch writer enabled",
+		"batch_size", w.batchSize,
+		"flush_interval_ms", int(w.flushInterval/time.Millisecond),
+		"channel_capacity", cap(w.ch),
+	)
+}
+
+// ShutdownProxyLogBatchWriter drains and stops the global batch writer if one
+// is running. Called from app graceful shutdown BEFORE store.CloseDatabase so
+// the writer can flush its last batch against a still-open DB. No-op when the
+// writer is nil (sync mode).
+func ShutdownProxyLogBatchWriter(ctx context.Context) error {
+	proxyLogBatchWriterMu.Lock()
+	w := proxyLogBatchWriterInst
+	proxyLogBatchWriterInst = nil
+	proxyLogBatchWriterMu.Unlock()
+
+	if w == nil {
+		return nil
+	}
+	return w.shutdown(ctx)
+}
+
+// EnqueueProxyLog writes a proxy_logs entry, either via the async batch writer
+// (when configured) or synchronously (sync mode / tests). This is the
+// production write path wired into UpstreamConfig.LogProxy by
+// app.ConfigureProxyUpstream. Backpressure (channel full) falls back to a
+// synchronous InsertProxyLog so logs are never dropped.
+func EnqueueProxyLog(ctx context.Context, entry proxy.ProxyLogEntry) error {
+	proxyLogBatchWriterMu.Lock()
+	w := proxyLogBatchWriterInst
+	proxyLogBatchWriterMu.Unlock()
+
+	if w == nil {
+		// Sync mode: write through immediately. This is the test/e2e path and
+		// the PROXY_LOG_ASYNC=false operator opt-out.
+		return InsertProxyLog(ctx, store.GetDB(), entry)
+	}
+	return w.enqueue(ctx, entry)
+}

--- a/handler/proxy/proxy_log_batch_test.go
+++ b/handler/proxy/proxy_log_batch_test.go
@@ -1,0 +1,292 @@
+package proxyhandler
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/proxy"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// setupBatchTestDB opens an in-memory SQLite DB, auto-migrates it, and
+// overrides the process-global store DB so the batch writer (which resolves
+// store.GetDB() at flush time) writes here. Restores nil on cleanup.
+func setupBatchTestDB(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := store.AutoMigrate(db); err != nil {
+		db.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+	store.OverrideDB(db)
+	t.Cleanup(func() {
+		store.OverrideDB(nil)
+		db.Close()
+	})
+	return db
+}
+
+// sampleBatchEntry builds a proxy_logs-shaped entry distinct per index so a
+// test can assert all N entries landed (not just N copies of one row).
+func sampleBatchEntry(index int) proxy.ProxyLogEntry {
+	model := fmt.Sprintf("gpt-batch-%d", index)
+	return proxy.ProxyLogEntry{
+		ModelRequested: model,
+		ModelActual:    &model,
+		Status:         "success",
+		HTTPStatus:     200,
+		LatencyMs:      int64(index * 10),
+		TotalTokens:    int64Ptr(int64(index + 100)),
+		EstimatedCost:  0.01 * float64(index),
+		RequestID:      fmt.Sprintf("req-%d", index),
+	}
+}
+
+// countProxyLogsRows counts proxy_logs rows for a model pattern so parallel
+// tests do not double-count each other's data.
+func countProxyLogsRows(t *testing.T, db *store.DB, pattern string) int {
+	t.Helper()
+	var count int
+	if err := db.Get(&count, "SELECT COUNT(*) FROM proxy_logs WHERE model_requested LIKE ?", pattern); err != nil {
+		t.Fatalf("count proxy_logs: %v", err)
+	}
+	return count
+}
+
+// shutdownWriterSoon waits up to 2s for the writer to drain+flush after a stop
+// signal. The loop goroutine closes b.done once it returns, so a successful
+// shutdown means every enqueued entry has been flushed.
+func shutdownWriterSoon(t *testing.T, b *proxyLogBatchWriter) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := b.shutdown(ctx); err != nil {
+		t.Fatalf("batch writer shutdown: %v", err)
+	}
+}
+
+// TestProxyLogBatchWriter_FlushesOnBatchSize enqueues exactly batchSize entries
+// with a long flush interval so only the batch-size trigger can flush. After
+// shutdown (which would also drain), all entries must be present.
+func TestProxyLogBatchWriter_FlushesOnBatchSize(t *testing.T) {
+	db := setupBatchTestDB(t)
+	const batchSize = 3
+	// Long flush interval so only the batch-size trigger fires (not the ticker).
+	w := newProxyLogBatchWriter(batchSize, 60_000)
+	w.start()
+	t.Cleanup(func() { shutdownWriterSoon(t, w) })
+
+	for i := 0; i < batchSize; i++ {
+		if err := w.enqueue(context.Background(), sampleBatchEntry(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	// The batch-size flush happens in the loop goroutine; give it a moment.
+	waitFor(t, 1*time.Second, func() bool {
+		return countProxyLogsRows(t, db, "gpt-batch-%") == batchSize
+	})
+}
+
+// TestProxyLogBatchWriter_FlushesOnInterval enqueues fewer than batchSize
+// entries, then waits for the flush ticker. The entries must land via the
+// interval trigger alone (the batch-size path never fires).
+func TestProxyLogBatchWriter_FlushesOnInterval(t *testing.T) {
+	db := setupBatchTestDB(t)
+	// batchSize high so only the ticker can flush; interval short for speed.
+	w := newProxyLogBatchWriter(100, 50)
+	w.start()
+	t.Cleanup(func() { shutdownWriterSoon(t, w) })
+
+	for i := 0; i < 4; i++ {
+		if err := w.enqueue(context.Background(), sampleBatchEntry(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	// Wait for at least one ticker flush (50ms interval → 200ms is ample).
+	waitFor(t, 1*time.Second, func() bool {
+		return countProxyLogsRows(t, db, "gpt-batch-%") == 4
+	})
+}
+
+// TestProxyLogBatchWriter_GracefulShutdownDrainsChannel enqueues entries below
+// the batch threshold with the ticker effectively disabled, then immediately
+// shuts down. The drain path must flush every enqueued entry so no log is lost
+// on graceful shutdown.
+func TestProxyLogBatchWriter_GracefulShutdownDrainsChannel(t *testing.T) {
+	db := setupBatchTestDB(t)
+	const enqueued = 7
+	// batchSize=100 + 60s interval: neither trigger should fire before shutdown.
+	w := newProxyLogBatchWriter(100, 60_000)
+	w.start()
+
+	for i := 0; i < enqueued; i++ {
+		if err := w.enqueue(context.Background(), sampleBatchEntry(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	// Shut down immediately — the drain loop must flush all 7 queued entries.
+	shutdownWriterSoon(t, w)
+
+	if got := countProxyLogsRows(t, db, "gpt-batch-%"); got != enqueued {
+		t.Fatalf("after shutdown drain: proxy_logs rows = %d, want %d (entries were lost)", got, enqueued)
+	}
+}
+
+// TestProxyLogBatchWriter_BackpressureFallsBackToSync fills the channel past
+// capacity. Overflow entries must be written synchronously (not dropped), so
+// the final row count equals the total enqueued. The channel contents are then
+// drained on shutdown, so no entry is lost.
+func TestProxyLogBatchWriter_BackpressureFallsBackToSync(t *testing.T) {
+	db := setupBatchTestDB(t)
+	// batchSize=100, channel cap = 400. Enqueue 500 → 400 buffered, 100 sync.
+	w := newProxyLogBatchWriter(100, 60_000)
+	w.start()
+	t.Cleanup(func() { shutdownWriterSoon(t, w) })
+
+	const total = 500
+	for i := 0; i < total; i++ {
+		if err := w.enqueue(context.Background(), sampleBatchEntry(i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	// After shutdown drains the channel + flushes, every entry must be present.
+	shutdownWriterSoon(t, w)
+
+	if got := countProxyLogsRows(t, db, "gpt-batch-%"); got != total {
+		t.Fatalf("after backpressure + shutdown: proxy_logs rows = %d, want %d (logs were dropped under saturation)", got, total)
+	}
+}
+
+// TestEnqueueProxyLog_SyncModeWhenWriterNil verifies the default/sync path:
+// with no global batch writer configured, EnqueueProxyLog writes through
+// synchronously so the row is visible immediately (the test/e2e contract).
+func TestEnqueueProxyLog_SyncModeWhenWriterNil(t *testing.T) {
+	db := setupBatchTestDB(t)
+	// Ensure the global writer is nil (sync mode) for this test.
+	ConfigureProxyLogWriter(false, 50, 1000)
+	t.Cleanup(func() { ConfigureProxyLogWriter(false, 50, 1000) })
+
+	if err := EnqueueProxyLog(context.Background(), sampleBatchEntry(0)); err != nil {
+		t.Fatalf("EnqueueProxyLog sync: %v", err)
+	}
+	if got := countProxyLogsRows(t, db, "gpt-batch-%"); got != 1 {
+		t.Fatalf("sync mode rows = %d, want 1 (write-through visibility)", got)
+	}
+}
+
+// TestEnqueueProxyLog_AsyncViaGlobalWriter verifies the global async path:
+// ConfigureProxyLogWriter(true, ...) starts the writer and EnqueueProxyLog
+// routes through it, with the entry landing after a flush.
+func TestEnqueueProxyLog_AsyncViaGlobalWriter(t *testing.T) {
+	db := setupBatchTestDB(t)
+	// Small batch + short interval so the entry flushes quickly.
+	ConfigureProxyLogWriter(true, 5, 50)
+	t.Cleanup(func() {
+		// Drain + stop the global writer so it does not leak into other tests.
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = ShutdownProxyLogBatchWriter(ctx)
+	})
+
+	if err := EnqueueProxyLog(context.Background(), sampleBatchEntry(0)); err != nil {
+		t.Fatalf("EnqueueProxyLog async: %v", err)
+	}
+
+	waitFor(t, 1*time.Second, func() bool {
+		return countProxyLogsRows(t, db, "gpt-batch-%") == 1
+	})
+}
+
+// TestBatchInsertProxyLogs_MatchesSingleRowInserts verifies the multi-row
+// batch INSERT produces rows whose columns match the single-row InsertProxyLog
+// path — i.e. the shared args/columns helper did not drift. Each row's tokens
+// and cost must round-trip identically.
+func TestBatchInsertProxyLogs_MatchesSingleRowInserts(t *testing.T) {
+	db := setupBatchTestDB(t)
+
+	// Insert 3 rows as a batch.
+	entries := []proxy.ProxyLogEntry{
+		sampleBatchEntry(1),
+		sampleBatchEntry(2),
+		sampleBatchEntry(3),
+	}
+	if err := batchInsertProxyLogs(context.Background(), db, entries); err != nil {
+		t.Fatalf("batchInsertProxyLogs: %v", err)
+	}
+	// Insert 1 row the single-row path to confirm the same shape.
+	if err := InsertProxyLog(context.Background(), db, sampleBatchEntry(9)); err != nil {
+		t.Fatalf("InsertProxyLog: %v", err)
+	}
+
+	// Read back token totals per model; they must equal what was inserted.
+	for _, e := range append(entries, sampleBatchEntry(9)) {
+		var got int64
+		if err := db.Get(&got, "SELECT COALESCE(total_tokens, 0) FROM proxy_logs WHERE model_requested = ?", e.ModelRequested); err != nil {
+			t.Fatalf("select tokens for %s: %v", e.ModelRequested, err)
+		}
+		if want := *e.TotalTokens; got != want {
+			t.Fatalf("total_tokens for %s = %d, want %d (batch/single row drift)", e.ModelRequested, got, want)
+		}
+	}
+}
+
+// TestProxyLogBatchWriter_ConcurrentEnqueueIsThreadSafe hammers the writer from
+// several goroutines to exercise the RWMutex/chan contract. After shutdown,
+// every enqueued entry must be present exactly once — no doubles, no drops.
+func TestProxyLogBatchWriter_ConcurrentEnqueueIsThreadSafe(t *testing.T) {
+	db := setupBatchTestDB(t)
+	w := newProxyLogBatchWriter(25, 20)
+	w.start()
+	t.Cleanup(func() { shutdownWriterSoon(t, w) })
+
+	const goroutines = 8
+	const perGoroutine = 40
+	var total int64
+	done := make(chan struct{}, goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(gid int) {
+			for i := 0; i < perGoroutine; i++ {
+				idx := gid*perGoroutine + i
+				if err := w.enqueue(context.Background(), sampleBatchEntry(idx)); err != nil {
+					t.Errorf("goroutine %d enqueue %d: %v", gid, idx, err)
+					return
+				}
+				atomic.AddInt64(&total, 1)
+			}
+			done <- struct{}{}
+		}(g)
+	}
+	for g := 0; g < goroutines; g++ {
+		<-done
+	}
+
+	shutdownWriterSoon(t, w)
+	want := int(atomic.LoadInt64(&total))
+	if got := countProxyLogsRows(t, db, "gpt-batch-%"); got != want {
+		t.Fatalf("concurrent: proxy_logs rows = %d, want %d (lost or duplicated entries)", got, want)
+	}
+}
+
+// waitFor polls up to timeout for cond to return true, failing the test on
+// timeout. Keeps interval-based tests fast but non-flaky.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("condition not satisfied within %v", timeout)
+}


### PR DESCRIPTION
## Summary

Two P1 performance optimizations for the admin/proxy data plane.

### 1. Dashboard summary cache (`handler/admin/stats.go`)
Dashboard aggregation queries run `COUNT`/`SUM` over 24h of `proxy_logs` on every page load, and the `x-dashboard-summary-cache` header always wrote `"miss"` with no cache behind it. This adds a 10s TTL in-memory cache mirroring the working `accountsSnapshotCache` pattern (`handler/admin/accounts.go:52-82`):

- Package-level cache: `sync.RWMutex` + view-keyed entries (`summary`/`insights`/`full`).
- Cache hit → returns cached bytes with `x-dashboard-summary-cache: "hit"`.
- Cache miss → computes, marshals once, stores, returns `"miss"`.
- `?force=1` invalidates (clears) and recomputes — the admin "force refresh" hook.
- Only successful responses are cached; error paths return before `set()` so a transient query failure can never poison the cache.

### 2. Async batch writer for `proxy_logs` (`handler/proxy/proxy_log_batch.go`)
Each proxy request did a blocking `INSERT` into `proxy_logs` (`handler/proxy/proxy_log.go`), adding latency and SQLite write-lock contention under load. This adds a background batch writer:

- Enqueue into a buffered channel (cap = 4× batch size); a background goroutine drains every `PROXY_LOG_FLUSH_INTERVAL_MS` (default 1000) or when `PROXY_LOG_BATCH_SIZE` (default 50) entries accumulate, doing one multi-row `INSERT`.
- **Backpressure**: when the channel is full, `enqueue` falls back to a synchronous `InsertProxyLog` — logs are never dropped.
- **Graceful shutdown**: the loop drains the channel + in-memory buffer and flushes before returning; wired as an `app` OnClose hook that runs **before** `store.CloseDatabase()` so the final batch flushes against an open DB.
- Configurable via `PROXY_LOG_ASYNC` (default `true`; set `false` for tests/e2e to keep write-through visibility).
- `proxy_log.go` refactored so single-row and multi-row inserts share one `proxyLogEntryArgs`/columns helper — the two can never drift. No schema change.

## Test plan
- [x] `go build ./...` (green)
- [x] `go test ./handler/...` (green: admin 9.3s, proxy 1.7s, shared 0.03s)
- [x] `go vet ./handler/... ./app/... ./config/... ./cmd/...` (clean)
- [x] `go test ./docs/...` (package-boundary test passes — no new import edges)
- [x] Dashboard cache: hit/miss/force-refresh, view-keying, errors-not-cached (`handler/admin/stats_cache_test.go`)
- [x] Batch writer: flush-on-batch-size, flush-on-interval, graceful-shutdown drain, backpressure→sync fallback, sync mode when writer nil, async via global writer, batch/single-row column parity, concurrent enqueue thread-safety (`handler/proxy/proxy_log_batch_test.go`)

## Notes
- Cache TTL (10s) is short enough for near-real-time semantics; long enough to dedup rapid reloads / multi-panel dashboards.
- `created_at` for a batch is stamped once at flush time — within the flush interval of actual occurrence, well inside the 24h / 60s query windows that consume it.
- Test compatibility preserved: proxy handler unit tests inject their own `LogProxy` capture (bypass `EnqueueProxyLog`); `app/proxy_upstream_test.go` uses configs with `ProxyLogAsync=false` (zero value) → sync mode, identical to prior behavior.