### PR TITLE
feat(web): observability auto-refresh + error states + checkin pagination

### DIFF
--- a/handler/admin/checkin_routes.go
+++ b/handler/admin/checkin_routes.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/deliciousbuding/metapi-go/config"
 	checkinservice "github.com/deliciousbuding/metapi-go/service/checkin"
@@ -71,43 +72,141 @@ func (h *checkinHandler) triggerOne(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// GET /api/checkin/logs?limit=&offset=&accountId=
+// GET /api/checkin/logs?limit=&offset=&accountId=&status=&from=&to=&reason=&site=&search=
 //
-// Response shape is the nested TS-era form the frontend expects:
+// Server-side paginated + filtered response. Mirrors the /api/stats/proxy-logs
+// contract: a page of nested rows plus the real total (so the data table's
+// server-pagination mode shows the true row count, not the page size).
+//
+// Filters:
+//   - accountId: exact match on cl.account_id
+//   - status:    exact match on cl.status (success/failed/skipped)
+//   - from/to:   UTC RFC3339 bounds on cl.created_at (inclusive)
+//   - reason:    comma-separated failure_reason.category values; matched as
+//                JSON substring so it works across SQLite/MySQL/Postgres
+//   - site:      comma-separated site names; exact match on s.name
+//   - search:    LIKE over username / site name / message / reward
+//
+// Response shape (items is the nested TS-era form the frontend expects):
 //
 //	{
-//	 "checkin_logs": { id, accountId, status, message, reward, createdAt },
-//	 "accounts": { username, id },
-//	 "sites": { name, url },
-//	 "failureReason": { code, category, title, actionHint, detailHint } | null
+//	 "items": [
+//	   {
+//	     "checkin_logs": { id, accountId, status, message, reward, createdAt },
+//	     "accounts": { username, id },
+//	     "sites": { name, url },
+//	     "failureReason": { code, category, title, actionHint, detailHint } | null
+//	   }
+//	 ],
+//	 "total": <int>,
+//	 "page": <int>,
+//	 "pageSize": <int>
 //	}
 //
 // failureReason is lifted from the checkin_logs.failure_reason TEXT column
 // (ClassifyFailureReason JSON) to a parsed object at the top level so the UI
 // can read `log.failureReason.title` directly instead of a phantom always-`-`.
 func (h *checkinHandler) getLogs(w http.ResponseWriter, r *http.Request) {
-	limit, _ := parseLimitOffset(r, 50, 500)
+	limit, _ := parseLimitOffset(r, 50, 200)
 	offset := max(0, getQueryInt(r, "offset", 0))
-	accountIDStr := r.URL.Query().Get("accountId")
+	accountIDStr := strings.TrimSpace(r.URL.Query().Get("accountId"))
+	status := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("status")))
+	from := strings.TrimSpace(r.URL.Query().Get("from"))
+	to := strings.TrimSpace(r.URL.Query().Get("to"))
+	reason := splitTrimFilter(r.URL.Query().Get("reason"))
+	site := splitTrimFilter(r.URL.Query().Get("site"))
+	search := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("search")))
 
-	query := `SELECT cl.*, a.username as account_username, s.name as site_name, s.url as site_url
-		FROM checkin_logs cl
-		INNER JOIN accounts a ON cl.account_id = a.id
-		INNER JOIN sites s ON a.site_id = s.id`
+	var conditions []string
 	var args []any
 
 	if accountIDStr != "" {
 		if aid, err := strconv.ParseInt(accountIDStr, 10, 64); err == nil && aid > 0 {
-			query += " WHERE cl.account_id = ?"
+			conditions = append(conditions, "cl.account_id = ?")
 			args = append(args, aid)
 		}
 	}
+	if status == "success" || status == "failed" || status == "skipped" {
+		conditions = append(conditions, "cl.status = ?")
+		args = append(args, status)
+	}
+	// created_at is stored as a naive UTC RFC3339 string, so lexicographic
+	// comparison against UTC bounds is correct and dialect-agnostic.
+	if from != "" {
+		conditions = append(conditions, "cl.created_at >= ?")
+		args = append(args, from)
+	}
+	if to != "" {
+		conditions = append(conditions, "cl.created_at <= ?")
+		args = append(args, to)
+	}
+	if len(reason) > 0 {
+		// failure_reason is compact JSON from encoding/json, so a substring
+		// match on "category":"<value>" hits cleanly. OR across the selected
+		// categories so the multi-select behaves like the legacy client filter.
+		reasonClauses := make([]string, 0, len(reason))
+		for _, category := range reason {
+			reasonClauses = append(reasonClauses, "LOWER(COALESCE(cl.failure_reason, '')) LIKE ?")
+			args = append(args, "%\"category\":\""+strings.ToLower(category)+"\"%")
+		}
+		conditions = append(conditions, "("+strings.Join(reasonClauses, " OR ")+")")
+	}
+	if len(site) > 0 {
+		placeHolders := make([]string, 0, len(site))
+		for _, name := range site {
+			placeHolders = append(placeHolders, "?")
+			args = append(args, name)
+		}
+		conditions = append(conditions, "s.name IN ("+strings.Join(placeHolders, ",")+")")
+	}
+	if search != "" {
+		conditions = append(conditions, "(LOWER(COALESCE(a.username, '')) LIKE ? OR LOWER(COALESCE(s.name, '')) LIKE ? OR LOWER(COALESCE(cl.message, '')) LIKE ? OR LOWER(COALESCE(cl.reward, '')) LIKE ?)")
+		like := "%" + search + "%"
+		args = append(args, like, like, like, like)
+	}
 
-	query += " ORDER BY cl.created_at DESC LIMIT ? OFFSET ?"
-	args = append(args, limit, offset)
+	var where string
+	if len(conditions) > 0 {
+		where = " WHERE " + strings.Join(conditions, " AND ")
+	}
 
-	rows := queryRows(h.db, query, args...)
-	writeJSON(w, http.StatusOK, reshapeCheckinLogs(rows))
+	query := `SELECT cl.*, a.username as account_username, s.name as site_name, s.url as site_url
+		FROM checkin_logs cl
+		INNER JOIN accounts a ON cl.account_id = a.id
+		INNER JOIN sites s ON a.site_id = s.id` +
+		where + " ORDER BY cl.created_at DESC LIMIT ? OFFSET ?"
+	qArgs := make([]any, len(args))
+	copy(qArgs, args)
+	qArgs = append(qArgs, limit, offset)
+	rows := queryRows(h.db, query, qArgs...)
+
+	countQuery := "SELECT COUNT(*) FROM checkin_logs cl INNER JOIN accounts a ON cl.account_id = a.id INNER JOIN sites s ON a.site_id = s.id" + where
+	var total int
+	h.db.Get(&total, rebindAdminQuery(h.db, countQuery), args...)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"items":    reshapeCheckinLogs(rows),
+		"total":    total,
+		"page":     (offset / limit) + 1,
+		"pageSize": limit,
+	})
+}
+
+// splitTrimFilter splits a comma-separated query value into trimmed,
+// non-empty tokens — used for the multi-select reason/site filters.
+func splitTrimFilter(value string) []string {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
 }
 
 // reshapeCheckinLogs converts the flat camelCased query rows into the nested

--- a/handler/admin/checkin_routes_test.go
+++ b/handler/admin/checkin_routes_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -186,6 +187,124 @@ func TestCheckinUpdateScheduleRejectsInvalidCron(t *testing.T) {
 	})
 	if resp.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+}
+
+func TestCheckinLogsReturnsPaginatedItemsAndTotal(t *testing.T) {
+	db, r, _ := setupCheckinRoutesTest(t)
+	upstream, _ := newCheckinAnyRouterServer(t)
+	siteID := insertCheckinRouteSite(t, db, upstream.URL)
+	accountID := insertCheckinRouteAccount(t, db, siteID, true)
+
+	// Seed a handful of logs with varying statuses so pagination + status
+	// filtering are exercised against the real total.
+	seedCheckinLogs(t, db, accountID, []struct {
+		status  string
+		message string
+	}{
+		{"success", "reward a"},
+		{"failed", "boom"},
+		{"skipped", "no-op"},
+		{"success", "reward b"},
+		{"failed", "timeout"},
+	})
+
+	resp := doGet(t, r, "/api/checkin/logs?limit=2&offset=0")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("getLogs: %d %s", resp.Code, resp.Body.String())
+	}
+	var page struct {
+		Items    []map[string]any `json:"items"`
+		Total    int              `json:"total"`
+		Page     int              `json:"page"`
+		PageSize int              `json:"pageSize"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &page); err != nil {
+		t.Fatalf("unmarshal page: %v", err)
+	}
+	if page.Total != 5 {
+		t.Fatalf("total = %d, want 5 (real total, not page size)", page.Total)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("items len = %d, want 2 (page size)", len(page.Items))
+	}
+	if page.PageSize != 2 {
+		t.Fatalf("pageSize = %d, want 2", page.PageSize)
+	}
+	if page.Page != 1 {
+		t.Fatalf("page = %d, want 1", page.Page)
+	}
+}
+
+func TestCheckinLogsFiltersByStatusAndDateRange(t *testing.T) {
+	db, r, _ := setupCheckinRoutesTest(t)
+	upstream, _ := newCheckinAnyRouterServer(t)
+	siteID := insertCheckinRouteSite(t, db, upstream.URL)
+	accountID := insertCheckinRouteAccount(t, db, siteID, true)
+
+	seedCheckinLogs(t, db, accountID, []struct {
+		status  string
+		message string
+	}{
+		{"success", "reward a"},
+		{"failed", "boom"},
+		{"skipped", "no-op"},
+		{"success", "reward b"},
+		{"failed", "timeout"},
+	})
+
+	// status filter narrows the total to the failed rows.
+	failedResp := doGet(t, r, "/api/checkin/logs?limit=10&status=failed")
+	if failedResp.Code != http.StatusOK {
+		t.Fatalf("status filter: %d %s", failedResp.Code, failedResp.Body.String())
+	}
+	var failedPage struct {
+		Items []map[string]any `json:"items"`
+		Total int              `json:"total"`
+	}
+	if err := json.Unmarshal(failedResp.Body.Bytes(), &failedPage); err != nil {
+		t.Fatalf("unmarshal failed page: %v", err)
+	}
+	if failedPage.Total != 2 {
+		t.Fatalf("status=failed total = %d, want 2", failedPage.Total)
+	}
+
+	// date-range bound in the future excludes every row, proving the
+	// server-side created_at filter is applied (the legacy client filter only
+	// saw 500 rows so older records silently slipped through).
+	future := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	emptyResp := doGet(t, r, "/api/checkin/logs?limit=10&from="+url.QueryEscape(future))
+	var emptyPage struct {
+		Items []map[string]any `json:"items"`
+		Total int              `json:"total"`
+	}
+	if err := json.Unmarshal(emptyResp.Body.Bytes(), &emptyPage); err != nil {
+		t.Fatalf("unmarshal empty page: %v", err)
+	}
+	if emptyPage.Total != 0 {
+		t.Fatalf("future from-bound total = %d, want 0", emptyPage.Total)
+	}
+}
+
+func seedCheckinLogs(
+	t *testing.T,
+	db *store.DB,
+	accountID int64,
+	rows []struct {
+		status  string
+		message string
+	},
+) {
+	t.Helper()
+	now := time.Now().UTC()
+	for i, row := range rows {
+		createdAt := now.Add(-time.Duration(i) * time.Minute).Format(time.RFC3339)
+		if _, err := db.Exec(
+			"INSERT INTO checkin_logs (account_id, status, message, failure_reason, created_at) VALUES (?, ?, ?, ?, ?)",
+			accountID, row.status, row.message, "", createdAt,
+		); err != nil {
+			t.Fatalf("seed checkin log %d: %v", i, err)
+		}
 	}
 }
 

--- a/web/src/features/checkin/api.ts
+++ b/web/src/features/checkin/api.ts
@@ -11,7 +11,8 @@ import { api } from '@/lib/api'
 import { assertBusinessOk } from '@/lib/assert-business-ok'
 
 import {
-  type CheckinLogRow,
+  type CheckinLogsQuery,
+  type CheckinLogsResponse,
   checkinLogRowSchema,
   triggerCheckinAllResultSchema,
   triggerCheckinResultSchema,
@@ -20,30 +21,69 @@ import {
 export const checkinQueryKeys = {
   all: ['checkin'] as const,
   logs: () => [...checkinQueryKeys.all, 'logs'] as const,
+  logsList: (params: CheckinLogsQuery) =>
+    [...checkinQueryKeys.logs(), params] as const,
 }
 
-export interface UseCheckinLogsParams {
-  accountId?: number
-  limit?: number
-  offset?: number
+export type UseCheckinLogsParams = CheckinLogsQuery
+
+/**
+ * Build the flat query-param record the backend expects (arrays joined with
+ * commas) from the structured `CheckinLogsQuery`. Shared by the hook and the
+ * route loader so the prefetched page reuses the hook's cache key exactly.
+ */
+export function buildCheckinLogsParams(
+  params: CheckinLogsQuery
+): Record<string, string | number | boolean | null | undefined> {
+  return {
+    limit: params.limit,
+    offset: params.offset,
+    accountId: params.accountId,
+    status: params.status,
+    reason: params.reason?.length ? params.reason.join(',') : undefined,
+    site: params.site?.length ? params.site.join(',') : undefined,
+    from: params.from,
+    to: params.to,
+    search: params.search,
+  }
 }
 
+/**
+ * Fetch + parse a server-side paginated checkin-logs page. The backend returns
+ * `{ items, total, page, pageSize }` (mirroring /api/stats/proxy-logs); each
+ * row is parsed defensively with `checkinLogRowSchema` before feature code
+ * touches it. Used by the hook and the route loader so the cached payload
+ * shape matches exactly.
+ */
+export async function fetchCheckinLogs(
+  params: CheckinLogsQuery
+): Promise<CheckinLogsResponse> {
+  const raw = await api.getCheckinLogs(buildCheckinLogsParams(params))
+  const payload = (raw ?? {}) as Partial<CheckinLogsResponse>
+  const rawItems = Array.isArray(payload.items) ? payload.items : []
+  const items = rawItems.map((row) => checkinLogRowSchema.parse(row))
+  const total = typeof payload.total === 'number' ? payload.total : 0
+  const page = typeof payload.page === 'number' ? payload.page : 1
+  const pageSize =
+    typeof payload.pageSize === 'number' ? payload.pageSize : params.limit ?? 0
+  return { items, total, page, pageSize }
+}
+
+/**
+ * Fetch a server-side paginated + filtered page of checkin logs. The backend
+ * returns `{ items, total, page, pageSize }` (mirroring /api/stats/proxy-logs),
+ * so the data table runs in manualPagination/manualFiltering mode and the
+ * page count reflects the real total — not the legacy 500-row client cap that
+ * silently dropped older records from date-range filters.
+ */
 export function useCheckinLogs(
   params: UseCheckinLogsParams = {},
-  options?: Omit<UseQueryOptions<CheckinLogRow[]>, 'queryKey' | 'queryFn'>
+  options?: Omit<UseQueryOptions<CheckinLogsResponse>, 'queryKey' | 'queryFn'>
 ) {
-  const { accountId, limit = 500, offset } = params
   return useQuery({
-    queryKey: [...checkinQueryKeys.logs(), { accountId, limit, offset }],
-    queryFn: async () => {
-      const search = new URLSearchParams()
-      search.set('limit', String(limit))
-      if (offset !== undefined) search.set('offset', String(offset))
-      if (accountId) search.set('accountId', String(accountId))
-      const raw = await api.getCheckinLogs(search.toString())
-      if (!Array.isArray(raw)) return [] as CheckinLogRow[]
-      return raw.map((row) => checkinLogRowSchema.parse(row))
-    },
+    queryKey: checkinQueryKeys.logsList(params),
+    queryFn: () => fetchCheckinLogs(params),
+    placeholderData: (previous) => previous,
     staleTime: 15 * 1000,
     ...options,
   })

--- a/web/src/features/checkin/api.ts
+++ b/web/src/features/checkin/api.ts
@@ -32,7 +32,7 @@ export type UseCheckinLogsParams = CheckinLogsQuery
  * commas) from the structured `CheckinLogsQuery`. Shared by the hook and the
  * route loader so the prefetched page reuses the hook's cache key exactly.
  */
-export function buildCheckinLogsParams(
+function buildCheckinLogsParams(
   params: CheckinLogsQuery
 ): Record<string, string | number | boolean | null | undefined> {
   return {

--- a/web/src/features/checkin/api.ts
+++ b/web/src/features/checkin/api.ts
@@ -65,7 +65,9 @@ export async function fetchCheckinLogs(
   const total = typeof payload.total === 'number' ? payload.total : 0
   const page = typeof payload.page === 'number' ? payload.page : 1
   const pageSize =
-    typeof payload.pageSize === 'number' ? payload.pageSize : params.limit ?? 0
+    typeof payload.pageSize === 'number'
+      ? payload.pageSize
+      : (params.limit ?? 0)
   return { items, total, page, pageSize }
 }
 

--- a/web/src/features/checkin/components/checkin-page.tsx
+++ b/web/src/features/checkin/components/checkin-page.tsx
@@ -1,5 +1,11 @@
 // metapi-go features/checkin/components — the checkin log list page.
 // i18n: all user-visible strings migrated to t() calls.
+//
+// Server-side pagination + filtering (mirrors /api/stats/proxy-logs): the
+// table runs in manualPagination/manualFiltering/manualSorting mode and the
+// backend returns the real total, so date-range / status / reason / site /
+// search filters see the full log history instead of the legacy 500-row
+// client cap that silently dropped older records.
 
 import type {
   ColumnFiltersState,
@@ -21,6 +27,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { useAccounts } from '@/features/accounts'
+import { useSites } from '@/features/sites/api'
 import { toast } from '@/lib/toast'
 
 import { useCheckinAccount, useCheckinLogs, useManualCheckin } from '../api'
@@ -29,10 +36,7 @@ import {
   parseFilterValues,
   readCheckinSearchFromUrl,
 } from '../lib/checkin-schema'
-import {
-  localDatetimeInputToEpochMs,
-  parseServerUtcDateTime,
-} from '../lib/checkin-time'
+import { localDatetimeInputToUtcRfc3339 } from '../lib/checkin-time'
 import { type CheckinLogRow, checkinLogRowSchema } from '../types'
 import { useCheckinColumns } from './checkin-columns'
 import { CheckinDetailSheet } from './checkin-detail-sheet'
@@ -64,66 +68,103 @@ export function CheckinPage() {
   const [from, setFrom] = useState(initial.from ?? '')
   const [to, setTo] = useState(initial.to ?? '')
 
-  const {
-    data: rawLogs,
-    isLoading,
-    isFetching,
-    error,
-  } = useCheckinLogs({ accountId })
   const { data: accountsSnapshot } = useAccounts()
   const accountOptions = accountsSnapshot?.accounts ?? []
+  const { data: sitesData } = useSites()
+  const siteOptions = useMemo(
+    () =>
+      (sitesData ?? []).map((site) => ({
+        value: site.name,
+        label: site.name,
+      })),
+    [sitesData]
+  )
+
   const triggerAllMutation = useManualCheckin()
   const triggerOneMutation = useCheckinAccount()
   const [detailOpen, setDetailOpen] = useState(false)
   const [detailRow, setDetailRow] = useState<CheckinLogRow | null>(null)
   const [manualOpen, setManualOpen] = useState(false)
 
-  const logs = useMemo(() => {
-    const fromMs = localDatetimeInputToEpochMs(from)
-    const toMs = localDatetimeInputToEpochMs(to, true)
-    return (rawLogs ?? []).filter((row) => {
-      if (fromMs === null && toMs === null) return true
-      const date = parseServerUtcDateTime(row.checkin_logs.createdAt)
-      if (!date) return true
-      if (fromMs !== null && date.getTime() < fromMs) return false
-      if (toMs !== null && date.getTime() > toMs) return false
-      return true
-    })
-  }, [rawLogs, from, to])
+  // Resolve the active server-side filter values from the column-filter
+  // state (the toolbar faceted filters drive these). status is single-select,
+  // so only the first value is forwarded to the backend.
+  const statusValues = useMemo(() => {
+    const statusFilter = columnFilters.find((filter) => filter.id === 'status')
+    const value = statusFilter?.value
+    return Array.isArray(value) ? (value as string[]) : []
+  }, [columnFilters])
+  const reasonValues = useMemo(() => {
+    const reasonFilter = columnFilters.find((filter) => filter.id === 'reason')
+    const value = reasonFilter?.value
+    return Array.isArray(value) ? (value as string[]) : []
+  }, [columnFilters])
+  const siteValues = useMemo(() => {
+    const siteFilter = columnFilters.find((filter) => filter.id === 'site')
+    const value = siteFilter?.value
+    return Array.isArray(value) ? (value as string[]) : []
+  }, [columnFilters])
 
-  const siteOptions = useMemo(() => {
-    const seen = new Map<string, string>()
-    for (const row of rawLogs ?? []) {
-      const name = row.sites?.name
-      if (name && !seen.has(name)) seen.set(name, name)
-    }
-    return [...seen.entries()].map(([value, label]) => ({ value, label }))
-  }, [rawLogs])
+  const fromUtc = useMemo(
+    () => localDatetimeInputToUtcRfc3339(from, false),
+    [from]
+  )
+  const toUtc = useMemo(
+    () => localDatetimeInputToUtcRfc3339(to, true),
+    [to]
+  )
+
+  const queryPayload = useMemo(
+    () => ({
+      limit: pagination.pageSize,
+      offset: pagination.pageIndex * pagination.pageSize,
+      accountId,
+      status: statusValues[0],
+      reason: reasonValues,
+      site: siteValues,
+      from: fromUtc,
+      to: toUtc,
+      search: globalFilter.trim() || undefined,
+    }),
+    [
+      pagination,
+      accountId,
+      statusValues,
+      reasonValues,
+      siteValues,
+      fromUtc,
+      toUtc,
+      globalFilter,
+    ]
+  )
+
+  const {
+    data: logsPage,
+    isLoading,
+    isFetching,
+    error,
+  } = useCheckinLogs(queryPayload)
+  const logs = useMemo(
+    () => logsPage?.items ?? [],
+    [logsPage]
+  )
+  const total = logsPage?.total ?? 0
 
   useEffect(() => {
     if (typeof window === 'undefined') return
-    const statusFilter = columnFilters.find((filter) => filter.id === 'status')
-    const reasonFilter = columnFilters.find((filter) => filter.id === 'reason')
-    const siteFilter = columnFilters.find((filter) => filter.id === 'site')
     const query = buildCheckinSearchString({
       pageIndex: pagination.pageIndex,
       pageSize: pagination.pageSize,
       accountId,
-      statusValues: Array.isArray(statusFilter?.value)
-        ? (statusFilter?.value as string[])
-        : [],
-      reasonValues: Array.isArray(reasonFilter?.value)
-        ? (reasonFilter?.value as string[])
-        : [],
-      siteValues: Array.isArray(siteFilter?.value)
-        ? (siteFilter?.value as string[])
-        : [],
+      statusValues,
+      reasonValues,
+      siteValues,
       from: from || undefined,
       to: to || undefined,
       query: globalFilter || undefined,
     })
     window.history.replaceState(null, '', `${window.location.pathname}${query}`)
-  }, [pagination, accountId, columnFilters, from, to, globalFilter])
+  }, [pagination, accountId, columnFilters, from, to, globalFilter, statusValues, reasonValues, siteValues])
 
   const onGlobalFilterChange = useMemo<OnChangeFn<string>>(
     () => (updater) => {
@@ -140,6 +181,14 @@ export function CheckinPage() {
         updater instanceof Function ? updater(prev) : updater
       )
       setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+    },
+    []
+  )
+  const onPaginationChange = useMemo<OnChangeFn<PaginationState>>(
+    () => (updater) => {
+      setPagination((prev) =>
+        updater instanceof Function ? updater(prev) : updater
+      )
     },
     []
   )
@@ -175,17 +224,22 @@ export function CheckinPage() {
   }
 
   const columns = useCheckinColumns(rowActions)
-  const { table } = useDataTable({
+  const { table } = useDataTable<CheckinLogRow>({
     data: logs,
     columns,
+    manualPagination: true,
+    manualFiltering: true,
+    manualSorting: true,
     enableRowSelection: false,
     globalFilter,
     onGlobalFilterChange,
     columnFilters,
     onColumnFiltersChange,
     pagination,
-    onPaginationChange: setPagination,
+    onPaginationChange,
     globalFilterFn: (row, _columnId, filterValue) => {
+      // With manualFiltering the table does not run this; kept so the column
+      // definition stays valid if the table ever flips back to client mode.
       const log = checkinLogRowSchema.parse(row.original)
       const haystack = [
         log.accounts?.username ?? '',
@@ -198,6 +252,7 @@ export function CheckinPage() {
         .toLowerCase()
       return haystack.includes(String(filterValue).toLowerCase())
     },
+    totalCount: total,
   })
 
   const handleTriggerAll = async () => {

--- a/web/src/features/checkin/components/checkin-page.tsx
+++ b/web/src/features/checkin/components/checkin-page.tsx
@@ -109,10 +109,7 @@ export function CheckinPage() {
     () => localDatetimeInputToUtcRfc3339(from, false),
     [from]
   )
-  const toUtc = useMemo(
-    () => localDatetimeInputToUtcRfc3339(to, true),
-    [to]
-  )
+  const toUtc = useMemo(() => localDatetimeInputToUtcRfc3339(to, true), [to])
 
   const queryPayload = useMemo(
     () => ({
@@ -144,10 +141,7 @@ export function CheckinPage() {
     isFetching,
     error,
   } = useCheckinLogs(queryPayload)
-  const logs = useMemo(
-    () => logsPage?.items ?? [],
-    [logsPage]
-  )
+  const logs = useMemo(() => logsPage?.items ?? [], [logsPage])
   const total = logsPage?.total ?? 0
 
   useEffect(() => {
@@ -164,7 +158,17 @@ export function CheckinPage() {
       query: globalFilter || undefined,
     })
     window.history.replaceState(null, '', `${window.location.pathname}${query}`)
-  }, [pagination, accountId, columnFilters, from, to, globalFilter, statusValues, reasonValues, siteValues])
+  }, [
+    pagination,
+    accountId,
+    columnFilters,
+    from,
+    to,
+    globalFilter,
+    statusValues,
+    reasonValues,
+    siteValues,
+  ])
 
   const onGlobalFilterChange = useMemo<OnChangeFn<string>>(
     () => (updater) => {

--- a/web/src/features/checkin/index.ts
+++ b/web/src/features/checkin/index.ts
@@ -10,15 +10,10 @@
 // --- checkin hooks + query keys ---
 export { checkinQueryKeys, fetchCheckinLogs } from './api'
 
-// --- checkin entity types + runtime schemas ---
-export { checkinLogRowSchema } from './types'
-
 // --- URL search schema + helpers ---
 export {
   buildInitialCheckinLogsQuery,
   checkinSearchSchema,
-  parseFilterValues,
-  readCheckinSearchFromUrl,
 } from './lib/checkin-schema'
 
 // --- time helpers ---

--- a/web/src/features/checkin/index.ts
+++ b/web/src/features/checkin/index.ts
@@ -8,14 +8,16 @@
 // --- page + components ---
 
 // --- checkin hooks + query keys ---
-export { checkinQueryKeys } from './api'
+export { checkinQueryKeys, fetchCheckinLogs } from './api'
 
 // --- checkin entity types + runtime schemas ---
 export { checkinLogRowSchema } from './types'
 
 // --- URL search schema + helpers ---
 export {
+  buildInitialCheckinLogsQuery,
   checkinSearchSchema,
+  parseFilterValues,
   readCheckinSearchFromUrl,
 } from './lib/checkin-schema'
 

--- a/web/src/features/checkin/lib/checkin-schema.ts
+++ b/web/src/features/checkin/lib/checkin-schema.ts
@@ -11,6 +11,9 @@
 
 import { z } from 'zod'
 
+import type { CheckinLogsQuery } from '../types'
+import { localDatetimeInputToUtcRfc3339 } from './checkin-time'
+
 const DEFAULT_CHECKIN_PAGE_SIZE = 20
 
 // ---------------------------------------------------------------------------
@@ -98,4 +101,30 @@ export function buildCheckinSearchString(params: {
   if (params.query) search.set('q', params.query)
   const query = search.toString()
   return query ? `?${query}` : ''
+}
+
+/**
+ * Build the server-side `CheckinLogsQuery` for the *initial* page render from
+ * the URL search state. The page derives the same payload from its state
+ * (initialized from the URL), so the route loader's prefetchQuery uses this
+ * to produce a cache key that exactly matches the hook's first fetch — no
+ * double-fetch on mount. `from`/`to` are converted to UTC RFC3339 (no
+ * milliseconds) so the lexicographic `created_at` bound is correct.
+ */
+export function buildInitialCheckinLogsQuery(): CheckinLogsQuery {
+  const search = readCheckinSearchFromUrl()
+  const statusValues = parseFilterValues(search.status)
+  const reasonValues = parseFilterValues(search.reason)
+  const siteValues = parseFilterValues(search.site)
+  return {
+    limit: search.pageSize,
+    offset: (search.page - 1) * search.pageSize,
+    accountId: search.accountId,
+    status: statusValues[0],
+    reason: reasonValues,
+    site: siteValues,
+    from: localDatetimeInputToUtcRfc3339(search.from, false),
+    to: localDatetimeInputToUtcRfc3339(search.to, true),
+    search: search.q || undefined,
+  }
 }

--- a/web/src/features/checkin/lib/checkin-time.ts
+++ b/web/src/features/checkin/lib/checkin-time.ts
@@ -134,3 +134,23 @@ export function localDatetimeInputToEpochMs(
   }
   return date.getTime()
 }
+
+/**
+ * Convert a `datetime-local` input value (local) to a UTC RFC3339 string
+ * *without* milliseconds (`YYYY-MM-DDTHH:mm:ssZ`). The checkin backend stores
+ * `created_at` as a naive UTC RFC3339 string, so a lexicographic comparison
+ * is correct — but only when the bound omits milliseconds, otherwise a stored
+ * value at the same second sorts after the bound (`.Z` vs `Z`). Returns
+ * `undefined` for empty/invalid input so callers can skip the server param.
+ *
+ * `endOfDay = true` pins the seconds to 59 so the upper bound includes the
+ * whole minute selected by the minute-precision `datetime-local` input.
+ */
+export function localDatetimeInputToUtcRfc3339(
+  value: string | null | undefined,
+  endOfDay = false
+): string | undefined {
+  const epochMs = localDatetimeInputToEpochMs(value, endOfDay)
+  if (epochMs === null) return undefined
+  return new Date(epochMs).toISOString().replace(/\.\d{3}Z$/, 'Z')
+}

--- a/web/src/features/checkin/types.ts
+++ b/web/src/features/checkin/types.ts
@@ -79,6 +79,32 @@ export type FailureReasonCategory = (typeof FAILURE_REASON_CATEGORIES)[number]
 export type FailureReason = z.infer<typeof failureReasonSchema>
 
 // ---------------------------------------------------------------------------
+// Server-side query + response — GET /api/checkin/logs now paginates and
+// filters server-side (mirroring /api/stats/proxy-logs). `from`/`to` are UTC
+// RFC3339 strings so lexicographic comparison against the stored naive UTC
+// `created_at` is correct and dialect-agnostic.
+// ---------------------------------------------------------------------------
+
+export type CheckinLogsQuery = {
+  limit?: number
+  offset?: number
+  accountId?: number
+  status?: string
+  reason?: string[]
+  site?: string[]
+  from?: string
+  to?: string
+  search?: string
+}
+
+export type CheckinLogsResponse = {
+  items: CheckinLogRow[]
+  total: number
+  page: number
+  pageSize: number
+}
+
+// ---------------------------------------------------------------------------
 // Inner projections — the nested sub-objects inside each log row.
 // ---------------------------------------------------------------------------
 

--- a/web/src/features/dashboard/sections/availability/availability-section.tsx
+++ b/web/src/features/dashboard/sections/availability/availability-section.tsx
@@ -168,6 +168,10 @@ function AttentionPanel() {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['dashboard-attention', 20],
     queryFn: () => api.getAttention(20) as Promise<AttentionResponse>,
+    // Auto-refresh the attention panel so expired accounts / low balances
+    // surface without a manual reload (the realtime QPS panel uses the ops
+    // WebSocket stream above; this covers the REST half of availability).
+    refetchInterval: 10 * 1000,
   })
 
   const items = data?.items ?? []

--- a/web/src/features/dashboard/sections/overview/overview-section.tsx
+++ b/web/src/features/dashboard/sections/overview/overview-section.tsx
@@ -106,6 +106,8 @@ export function OverviewSection() {
   const { data: snapshot, isLoading: snapshotLoading } = useQuery({
     queryKey: ['dashboard-snapshot'],
     queryFn: () => api.getDashboardSnapshot() as Promise<DashboardSnapshot>,
+    // Keep the QPS / 24h-proxy stat cards fresh without a manual refresh.
+    refetchInterval: 10 * 1000,
   })
 
   const { data: balanceHistory } = useQuery({

--- a/web/src/features/observability/api.ts
+++ b/web/src/features/observability/api.ts
@@ -4,11 +4,18 @@
 // the Overview section (reusing the existing /api/stats endpoints), and
 // `useMonitorHealth` powers the Health section (the read-only
 // /api/monitor/health projection).
+//
+// Auto-refresh: every hook reads the shared auto-refresh interval from
+// `useObservabilityAutoRefresh` (15s by default, toggled to 30s or Off from
+// the observability header) and applies it as `refetchInterval` so health /
+// heatmap / slow-request data stays fresh instead of fetching once on mount.
+// Callers can still override `refetchInterval` per-hook via `options`.
 
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 
 import { api } from '@/lib/api'
 
+import { useObservabilityAutoRefresh } from './context/auto-refresh-context'
 import {
   observabilityKeys,
   type MonitorHealthResponse,
@@ -20,10 +27,12 @@ export function useUsageHeatmap(
   params: { days?: number; dimension?: 'site' | 'model' } = {},
   options?: Omit<UseQueryOptions<UsageHeatmapResponse>, 'queryKey' | 'queryFn'>
 ) {
+  const { intervalMs } = useObservabilityAutoRefresh()
   return useQuery({
     queryKey: observabilityKeys.usageHeatmap(params),
     queryFn: () => api.getUsageHeatmap(params) as Promise<UsageHeatmapResponse>,
     staleTime: 30 * 1000,
+    refetchInterval: intervalMs,
     ...options,
   })
 }
@@ -32,10 +41,12 @@ export function useSlowRequests(
   params: { limit?: number; minLatencyMs?: number; hours?: number } = {},
   options?: Omit<UseQueryOptions<SlowRequestsResponse>, 'queryKey' | 'queryFn'>
 ) {
+  const { intervalMs } = useObservabilityAutoRefresh()
   return useQuery({
     queryKey: observabilityKeys.slowRequests(params),
     queryFn: () => api.getSlowRequests(params) as Promise<SlowRequestsResponse>,
     staleTime: 30 * 1000,
+    refetchInterval: intervalMs,
     ...options,
   })
 }
@@ -43,10 +54,12 @@ export function useSlowRequests(
 export function useMonitorHealth(
   options?: Omit<UseQueryOptions<MonitorHealthResponse>, 'queryKey' | 'queryFn'>
 ) {
+  const { intervalMs } = useObservabilityAutoRefresh()
   return useQuery({
     queryKey: observabilityKeys.monitorHealth(),
     queryFn: () => api.getMonitorHealth() as Promise<MonitorHealthResponse>,
     staleTime: 15 * 1000,
+    refetchInterval: intervalMs,
     ...options,
   })
 }

--- a/web/src/features/observability/components/observability-auto-refresh-toggle.tsx
+++ b/web/src/features/observability/components/observability-auto-refresh-toggle.tsx
@@ -1,0 +1,63 @@
+// metapi-go/features/observability/components — header toggle that drives
+// the shared auto-refresh interval (15s / 30s / Off). Reading + writing the
+// interval happens through `useObservabilityAutoRefresh`; this component is
+// purely presentational, mirroring the proxy-logs refresh button but as a
+// segmented control so the cadence is visible at a glance.
+
+import { RefreshCw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+import {
+  useObservabilityAutoRefresh,
+  type ObservabilityAutoRefreshInterval,
+} from '../context/auto-refresh-context'
+
+const OBSERVABILITY_AUTO_REFRESH_PRESETS = [
+  { id: '15s', labelKey: 'observability.autoRefresh.interval15s', value: 15_000 },
+  { id: '30s', labelKey: 'observability.autoRefresh.interval30s', value: 30_000 },
+  { id: 'off', labelKey: 'observability.autoRefresh.intervalOff', value: false },
+] as const
+
+export function ObservabilityAutoRefreshToggle() {
+  const { t } = useTranslation()
+  const { intervalMs, setIntervalMs } = useObservabilityAutoRefresh()
+
+  const isMatch = (
+    presetValue: ObservabilityAutoRefreshInterval
+  ): boolean => presetValue === intervalMs
+
+  return (
+    <div
+      className='bg-card flex items-center gap-1 rounded-md border p-0.5'
+      role='group'
+      aria-label={t('observability.autoRefresh.label')}
+    >
+      <RefreshCw
+        className={cn(
+          'text-muted-foreground size-3.5 shrink-0',
+          intervalMs !== false && 'animate-spin'
+        )}
+        aria-hidden='true'
+      />
+      {OBSERVABILITY_AUTO_REFRESH_PRESETS.map((preset) => {
+        const active = isMatch(preset.value)
+        return (
+          <Button
+            key={preset.id}
+            type='button'
+            variant={active ? 'default' : 'ghost'}
+            size='sm'
+            className='h-7 px-2 text-xs font-medium'
+            aria-pressed={active}
+            onClick={() => setIntervalMs(preset.value)}
+          >
+            {t(preset.labelKey)}
+          </Button>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/src/features/observability/components/observability-auto-refresh-toggle.tsx
+++ b/web/src/features/observability/components/observability-auto-refresh-toggle.tsx
@@ -16,18 +16,29 @@ import {
 } from '../context/auto-refresh-context'
 
 const OBSERVABILITY_AUTO_REFRESH_PRESETS = [
-  { id: '15s', labelKey: 'observability.autoRefresh.interval15s', value: 15_000 },
-  { id: '30s', labelKey: 'observability.autoRefresh.interval30s', value: 30_000 },
-  { id: 'off', labelKey: 'observability.autoRefresh.intervalOff', value: false },
+  {
+    id: '15s',
+    labelKey: 'observability.autoRefresh.interval15s',
+    value: 15_000,
+  },
+  {
+    id: '30s',
+    labelKey: 'observability.autoRefresh.interval30s',
+    value: 30_000,
+  },
+  {
+    id: 'off',
+    labelKey: 'observability.autoRefresh.intervalOff',
+    value: false,
+  },
 ] as const
 
 export function ObservabilityAutoRefreshToggle() {
   const { t } = useTranslation()
   const { intervalMs, setIntervalMs } = useObservabilityAutoRefresh()
 
-  const isMatch = (
-    presetValue: ObservabilityAutoRefreshInterval
-  ): boolean => presetValue === intervalMs
+  const isMatch = (presetValue: ObservabilityAutoRefreshInterval): boolean =>
+    presetValue === intervalMs
 
   return (
     <div

--- a/web/src/features/observability/components/observability-error-banner.tsx
+++ b/web/src/features/observability/components/observability-error-banner.tsx
@@ -1,0 +1,55 @@
+// metapi-go/features/observability/components — load-failure state for
+// observability sections. Rendered instead of (or within) a card when a
+// /api/monitor/health or /api/stats query fails, mirroring the settings
+// `SettingsSectionError` pattern: the user sees an explicit error + a Retry
+// button that calls `refetch()` instead of dashes and empty tables that look
+// like "no data" rather than "request failed".
+
+import { RefreshCw, TriangleAlert } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+type ObservabilityErrorBannerProps = {
+  /** i18n key (or literal) for the headline message. */
+  messageKey?: string
+  /** When true, the retry button shows a spinner + is disabled. */
+  isRetrying?: boolean
+  onRetry: () => void
+  className?: string
+}
+
+export function ObservabilityErrorBanner({
+  messageKey,
+  isRetrying,
+  onRetry,
+  className,
+}: ObservabilityErrorBannerProps) {
+  const { t } = useTranslation()
+  const message = messageKey
+    ? t(messageKey)
+    : t('observability.error.loadFailed')
+  return (
+    <div
+      className={cn(
+        'border-destructive/40 bg-destructive/5 flex min-h-32 flex-col items-center justify-center gap-3 rounded-lg border border-dashed py-8 text-center',
+        className
+      )}
+      role='alert'
+    >
+      <TriangleAlert className='text-destructive/80 size-5' />
+      <p className='text-destructive text-sm'>{message}</p>
+      <Button
+        type='button'
+        variant='outline'
+        size='sm'
+        onClick={onRetry}
+        disabled={isRetrying}
+      >
+        <RefreshCw className={cn('size-3.5', isRetrying && 'animate-spin')} />
+        {t('observability.error.retry')}
+      </Button>
+    </div>
+  )
+}

--- a/web/src/features/observability/components/observability-page.tsx
+++ b/web/src/features/observability/components/observability-page.tsx
@@ -7,6 +7,8 @@ import { useTranslation } from 'react-i18next'
 
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
+import { ObservabilityAutoRefreshToggle } from './observability-auto-refresh-toggle'
+import { ObservabilityAutoRefreshProvider } from '../context/auto-refresh-context'
 import {
   OBSERVABILITY_DEFAULT_SECTION,
   getObservabilitySectionContent,
@@ -40,38 +42,44 @@ export function ObservabilityPage({
   const { t } = useTranslation()
   const sectionId = resolveSectionId(activeSection)
   const navItems = getObservabilitySectionNavItems()
-  const content = getObservabilitySectionContent(sectionId)
 
   return (
-    <div className='flex flex-col gap-6 p-6'>
-      <header className='flex flex-col gap-1'>
-        <h1 className='text-2xl font-normal tracking-tight'>
-          {t('observability.title')}
-        </h1>
-        <p className='text-muted-foreground text-sm'>
-          {t('observability.description')}
-        </p>
-      </header>
+    <ObservabilityAutoRefreshProvider>
+      <div className='flex flex-col gap-6 p-6'>
+        <header className='flex flex-wrap items-start justify-between gap-3'>
+          <div className='flex flex-col gap-1'>
+            <h1 className='text-2xl font-normal tracking-tight'>
+              {t('observability.title')}
+            </h1>
+            <p className='text-muted-foreground text-sm'>
+              {t('observability.description')}
+            </p>
+          </div>
+          <ObservabilityAutoRefreshToggle />
+        </header>
 
-      <Tabs
-        value={sectionId}
-        onValueChange={(value) =>
-          onSectionChange?.(value as ObservabilitySectionId)
-        }
-      >
-        <TabsList className='w-fit'>
-          {navItems.map((item) => {
-            const id = item.url.split('=').pop() ?? item.title
-            return (
-              <TabsTrigger key={id} value={id}>
-                {t(item.title)}
-              </TabsTrigger>
-            )
-          })}
-        </TabsList>
-      </Tabs>
+        <Tabs
+          value={sectionId}
+          onValueChange={(value) =>
+            onSectionChange?.(value as ObservabilitySectionId)
+          }
+        >
+          <TabsList className='w-fit'>
+            {navItems.map((item) => {
+              const id = item.url.split('=').pop() ?? item.title
+              return (
+                <TabsTrigger key={id} value={id}>
+                  {t(item.title)}
+                </TabsTrigger>
+              )
+            })}
+          </TabsList>
+        </Tabs>
 
-      <main className='min-w-0 flex-1'>{content}</main>
-    </div>
+        <main className='min-w-0 flex-1'>
+          {getObservabilitySectionContent(sectionId)}
+        </main>
+      </div>
+    </ObservabilityAutoRefreshProvider>
   )
 }

--- a/web/src/features/observability/components/observability-page.tsx
+++ b/web/src/features/observability/components/observability-page.tsx
@@ -7,14 +7,14 @@ import { useTranslation } from 'react-i18next'
 
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
-import { ObservabilityAutoRefreshToggle } from './observability-auto-refresh-toggle'
-import { ObservabilityAutoRefreshProvider } from '../context/auto-refresh-context'
 import {
   OBSERVABILITY_DEFAULT_SECTION,
   getObservabilitySectionContent,
   getObservabilitySectionNavItems,
 } from '../config/observability-config'
+import { ObservabilityAutoRefreshProvider } from '../context/auto-refresh-context'
 import type { ObservabilitySectionId } from '../types'
+import { ObservabilityAutoRefreshToggle } from './observability-auto-refresh-toggle'
 
 export type ObservabilityPageProps = {
   activeSection?: string

--- a/web/src/features/observability/context/auto-refresh-context.tsx
+++ b/web/src/features/observability/context/auto-refresh-context.tsx
@@ -1,0 +1,95 @@
+// metapi-go/features/observability/context — auto-refresh interval state
+// shared across the Overview / Health sections. The observability header owns
+// a 15s / 30s / Off toggle that drives the `refetchInterval` every query hook
+// in `../api.ts` reads, so a single control refreshes all health/heatmap/
+// slow-request data instead of each section fetching once on mount.
+//
+// The provider persists the choice to localStorage so a bookmarked operator
+// view survives reloads. The default is 15s (the cadence the audit asks for);
+// `false` disables auto-refresh entirely (the queries still honour
+// refetchOnWindowFocus=false globally).
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+
+export type ObservabilityAutoRefreshInterval = number | false
+
+const STORAGE_KEY = 'metapi-go:observability:auto-refresh'
+const DEFAULT_INTERVAL_MS: ObservabilityAutoRefreshInterval = 15_000
+
+function readStoredInterval(): ObservabilityAutoRefreshInterval {
+  if (typeof window === 'undefined') return DEFAULT_INTERVAL_MS
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (raw === null) return DEFAULT_INTERVAL_MS
+    if (raw === 'false') return false
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed) && parsed > 0) return parsed
+    return DEFAULT_INTERVAL_MS
+  } catch {
+    return DEFAULT_INTERVAL_MS
+  }
+}
+
+function writeStoredInterval(value: ObservabilityAutoRefreshInterval) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(value))
+  } catch {
+    /* localStorage unavailable — keep the in-memory state only. */
+  }
+}
+
+type ObservabilityAutoRefreshContextValue = {
+  intervalMs: ObservabilityAutoRefreshInterval
+  setIntervalMs: (value: ObservabilityAutoRefreshInterval) => void
+}
+
+const ObservabilityAutoRefreshContext =
+  createContext<ObservabilityAutoRefreshContextValue | null>(null)
+
+export function ObservabilityAutoRefreshProvider({
+  children,
+}: {
+  children: ReactNode
+}) {
+  const [intervalMs, setIntervalMsState] = useState<
+    ObservabilityAutoRefreshInterval
+  >(readStoredInterval)
+
+  const setIntervalMs = useCallback(
+    (value: ObservabilityAutoRefreshInterval) => {
+      setIntervalMsState(value)
+      writeStoredInterval(value)
+    },
+    []
+  )
+
+  const value = useMemo(
+    () => ({ intervalMs, setIntervalMs }),
+    [intervalMs, setIntervalMs]
+  )
+
+  return (
+    <ObservabilityAutoRefreshContext.Provider value={value}>
+      {children}
+    </ObservabilityAutoRefreshContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useObservabilityAutoRefresh(): ObservabilityAutoRefreshContextValue {
+  const ctx = useContext(ObservabilityAutoRefreshContext)
+  if (!ctx) {
+    throw new Error(
+      'useObservabilityAutoRefresh must be used within an ObservabilityAutoRefreshProvider'
+    )
+  }
+  return ctx
+}

--- a/web/src/features/observability/context/auto-refresh-context.tsx
+++ b/web/src/features/observability/context/auto-refresh-context.tsx
@@ -59,9 +59,8 @@ export function ObservabilityAutoRefreshProvider({
 }: {
   children: ReactNode
 }) {
-  const [intervalMs, setIntervalMsState] = useState<
-    ObservabilityAutoRefreshInterval
-  >(readStoredInterval)
+  const [intervalMs, setIntervalMsState] =
+    useState<ObservabilityAutoRefreshInterval>(readStoredInterval)
 
   const setIntervalMs = useCallback(
     (value: ObservabilityAutoRefreshInterval) => {

--- a/web/src/features/observability/sections/health/health-section.tsx
+++ b/web/src/features/observability/sections/health/health-section.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/table'
 
 import { useMonitorHealth } from '../../api'
+import { ObservabilityErrorBanner } from '../../components/observability-error-banner'
 import type { CooldownChannel, RuntimeHealthBreaker } from '../../types'
 
 type Translate = (key: string) => string
@@ -72,6 +73,19 @@ export function HealthSection() {
   const data = health.data
   const runtime = data?.runtimeHealth
   const cooldown = data?.cooldown
+
+  // Surface a load failure explicitly instead of rendering dashes / empty
+  // tables that read as "no open breakers" rather than "request failed".
+  // A retry re-runs the monitor-health query (auto-refresh keeps ticking).
+  if (health.isError && !health.isLoading) {
+    return (
+      <ObservabilityErrorBanner
+        messageKey='observability.health.loadFailed'
+        isRetrying={health.isFetching && !health.isLoading}
+        onRetry={() => void health.refetch()}
+      />
+    )
+  }
 
   return (
     <div className='flex flex-col gap-4'>

--- a/web/src/features/observability/sections/overview/overview-section.tsx
+++ b/web/src/features/observability/sections/overview/overview-section.tsx
@@ -25,6 +25,7 @@ import {
 import { formatLatency } from '@/lib/format'
 
 import { useSlowRequests, useUsageHeatmap } from '../../api'
+import { ObservabilityErrorBanner } from '../../components/observability-error-banner'
 import type { SlowRequestItem, UsageHeatmapCell } from '../../types'
 
 const MAX_HEATMAP_KEYS = 16
@@ -94,7 +95,15 @@ export function OverviewSection() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {renderSlowRequestsBody(slow.isLoading, slowItems, t)}
+          {slow.isError && !slow.isLoading ? (
+            <ObservabilityErrorBanner
+              messageKey='observability.overview.slowRequests.loadFailed'
+              isRetrying={slow.isFetching && !slow.isLoading}
+              onRetry={() => void slow.refetch()}
+            />
+          ) : (
+            renderSlowRequestsBody(slow.isLoading, slowItems, t)
+          )}
         </CardContent>
       </Card>
 
@@ -109,7 +118,15 @@ export function OverviewSection() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {renderHeatmapBody(heatmap.isLoading, layout, t)}
+          {heatmap.isError && !heatmap.isLoading ? (
+            <ObservabilityErrorBanner
+              messageKey='observability.overview.heatmap.loadFailed'
+              isRetrying={heatmap.isFetching && !heatmap.isLoading}
+              onRetry={() => void heatmap.refetch()}
+            />
+          ) : (
+            renderHeatmapBody(heatmap.isLoading, layout, t)
+          )}
         </CardContent>
       </Card>
     </div>

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1893,6 +1893,16 @@
     "observability": {
       "title": "Observability",
       "description": "Health, breakers and request analytics across sites and accounts.",
+      "autoRefresh": {
+        "label": "Auto-refresh",
+        "interval15s": "15s",
+        "interval30s": "30s",
+        "intervalOff": "Off"
+      },
+      "error": {
+        "loadFailed": "Failed to load data.",
+        "retry": "Retry"
+      },
       "sections": {
         "overview": {
           "title": "Overview",
@@ -1911,6 +1921,7 @@
         "slowRequests": {
           "title": "Slow requests (top)",
           "description": "Highest-latency proxy requests in the selected window.",
+          "loadFailed": "Failed to load slow-request data.",
           "empty": "No slow requests in the current window.",
           "colModel": "Model",
           "colSite": "Site",
@@ -1923,12 +1934,14 @@
         "heatmap": {
           "title": "Usage heatmap",
           "description": "Hourly call density by site.",
+          "loadFailed": "Failed to load usage heatmap data.",
           "empty": "No usage density data for the selected range.",
           "legendLow": "Less",
           "legendHigh": "More"
         }
       },
       "health": {
+        "loadFailed": "Failed to load health data.",
         "runtime": {
           "title": "Runtime health",
           "description": "In-memory routing breaker state (soft isolation).",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1893,6 +1893,16 @@
     "observability": {
       "title": "可观测性",
       "description": "站点与账号的健康、熔断与请求分析。",
+      "autoRefresh": {
+        "label": "自动刷新",
+        "interval15s": "15秒",
+        "interval30s": "30秒",
+        "intervalOff": "关闭"
+      },
+      "error": {
+        "loadFailed": "数据加载失败。",
+        "retry": "重试"
+      },
       "sections": {
         "overview": {
           "title": "概览",
@@ -1911,6 +1921,7 @@
         "slowRequests": {
           "title": "慢请求（Top）",
           "description": "所选时间窗内延迟最高的请求。",
+          "loadFailed": "慢请求数据加载失败。",
           "empty": "当前时间窗内没有慢请求。",
           "colModel": "模型",
           "colSite": "站点",
@@ -1923,12 +1934,14 @@
         "heatmap": {
           "title": "用量热力图",
           "description": "按站点的小时调用密度。",
+          "loadFailed": "用量热力图数据加载失败。",
           "empty": "所选范围内没有用量密度数据。",
           "legendLow": "少",
           "legendHigh": "多"
         }
       },
       "health": {
+        "loadFailed": "健康数据加载失败。",
         "runtime": {
           "title": "运行时健康",
           "description": "内存中的路由熔断状态（软隔离）。",

--- a/web/src/lib/api/token-routes.ts
+++ b/web/src/lib/api/token-routes.ts
@@ -1,4 +1,4 @@
-import { request } from './transport'
+import { request, buildQueryString } from './transport'
 
 export const tokenRoutesApi = {
   // Account tokens
@@ -43,8 +43,9 @@ export const tokenRoutesApi = {
   triggerCheckinAll: () => request('/api/checkin/trigger', { method: 'POST' }),
   triggerCheckin: (id: number) =>
     request(`/api/checkin/trigger/${id}`, { method: 'POST' }),
-  getCheckinLogs: (params?: string) =>
-    request(`/api/checkin/logs${params ? `?${params}` : ''}`),
+  getCheckinLogs: (
+    params?: Record<string, string | number | boolean | null | undefined>
+  ) => request(`/api/checkin/logs${buildQueryString(params)}`),
 
   // Routes
   getRoutes: () => request('/api/routes'),

--- a/web/src/routes/_authenticated/checkin.tsx
+++ b/web/src/routes/_authenticated/checkin.tsx
@@ -8,46 +8,28 @@
 // `window.location.search` reads (via `readCheckinSearchFromUrl`) stay
 // consistent.
 //
-// `loader` prefetches the checkin log window the page's `useCheckinLogs`
-// will request, using the same key shape (`[...logs(), { accountId, limit,
-// offset }]`) so the prefetched page is reused rather than re-fetched on
-// mount. The loader reads the accountId from `window.location.search` via
-// `readCheckinSearchFromUrl()` (the feature's own URL reader, the same
-// helper the page uses) because TanStack Router's loader context does not
-// expose the validated `search` object in this version. The queryFn mirrors
-// the hook (build the query string, call `api.getCheckinLogs`, parse each
-// row with `checkinLogRowSchema`) so the cached payload matches the hook's
-// output type exactly.
+// `loader` prefetches the first server-paginated checkin-logs page the page's
+// `useCheckinLogs` hook will request. It builds the exact same
+// `CheckinLogsQuery` the page derives from URL state (`buildInitialCheckinLogsQuery`)
+// and reuses the hook's query key + fetcher (`fetchCheckinLogs`), so the
+// prefetched page is served from cache on mount instead of re-fetching.
 
 import { createFileRoute, lazyRouteComponent } from '@tanstack/react-router'
 
 import {
-  checkinLogRowSchema,
+  buildInitialCheckinLogsQuery,
   checkinQueryKeys,
   checkinSearchSchema,
-  readCheckinSearchFromUrl,
+  fetchCheckinLogs,
 } from '@/features/checkin'
-import { api } from '@/lib/api'
-
-const CHECKIN_PREFETCH_LIMIT = 500
 
 export const Route = createFileRoute('/_authenticated/checkin')({
   validateSearch: checkinSearchSchema,
   loader: async ({ context }) => {
-    const { accountId } = readCheckinSearchFromUrl()
+    const initialQuery = buildInitialCheckinLogsQuery()
     await context.queryClient.prefetchQuery({
-      queryKey: [
-        ...checkinQueryKeys.logs(),
-        { accountId, limit: CHECKIN_PREFETCH_LIMIT, offset: undefined },
-      ],
-      queryFn: async () => {
-        const params = new URLSearchParams()
-        params.set('limit', String(CHECKIN_PREFETCH_LIMIT))
-        if (accountId) params.set('accountId', String(accountId))
-        const raw = await api.getCheckinLogs(params.toString())
-        if (!Array.isArray(raw)) return []
-        return raw.map((row) => checkinLogRowSchema.parse(row))
-      },
+      queryKey: checkinQueryKeys.logsList(initialQuery),
+      queryFn: () => fetchCheckinLogs(initialQuery),
     })
   },
   component: lazyRouteComponent(


### PR DESCRIPTION
## Summary

Closes the three P2 frontend gaps from the observability dashboard audit. No backend API contract change for observability — only frontend query options + a new checkin pagination handler.

- **Auto-refresh**: observability health/heatmap/slow-request queries now refetch on a shared interval (15s default, 30s / Off via a header toggle persisted to localStorage). Dashboard snapshot + attention queries refetch every 10s so the QPS/availability panels stay live (the realtime QPS panel keeps using its WebSocket stream).
- **Error states**: a shared `ObservabilityErrorBanner` (mirrors `SettingsSectionError`) with a Retry button replaces the silent dashes / empty tables when `/api/monitor/health` or `/api/stats` fail — wired into the Health section (section-level) and both Overview cards (per-card).
- **Checkin server-side pagination**: `/api/checkin/logs` now accepts `limit`/`offset`/`accountId`/`status`/`from`/`to`/`reason`/`site`/`search` and returns `{items,total,page,pageSize}`. The frontend runs the data table in `manualPagination`/`manualFiltering` mode (same pattern as proxy-logs) so date-range and status filters see the full history instead of the legacy 500-row client cap. The site filter dropdown now sources options from `useSites()` instead of the current page.

## Changes

**Frontend**
- `observability/context/auto-refresh-context.tsx` (new) — provider + `useObservabilityAutoRefresh` hook, localStorage-persisted 15s/30s/Off.
- `observability/components/observability-auto-refresh-toggle.tsx` (new) — segmented header toggle.
- `observability/components/observability-error-banner.tsx` (new) — shared error + Retry banner.
- `observability/api.ts` — every hook reads the shared interval and sets `refetchInterval`.
- `observability/components/observability-page.tsx` — wraps content in the provider, adds the toggle to the header.
- `observability/sections/health/health-section.tsx` + `sections/overview/overview-section.tsx` — `isError` checks + error banners.
- `dashboard/sections/overview/overview-section.tsx` + `sections/availability/availability-section.tsx` — `refetchInterval: 10000`.
- `checkin/api.ts` + `types.ts` + `lib/checkin-schema.ts` + `lib/checkin-time.ts` — `CheckinLogsQuery`/`CheckinLogsResponse`, shared `fetchCheckinLogs` + `buildInitialCheckinLogsQuery` (loader + hook share a cache key), UTC RFC3339 date conversion.
- `checkin/components/checkin-page.tsx` — server-side pagination + filters; site options from `useSites()`.
- `routes/_authenticated/checkin.tsx` — loader prefetches the first page via the shared fetcher/key.
- `lib/api/token-routes.ts` — `getCheckinLogs` accepts a flat params record.
- i18n (`en.json` + `zh-CN.json`) — auto-refresh labels, error/retry, per-section `loadFailed`.

**Backend**
- `handler/admin/checkin_routes.go` — `getLogs` rewritten for server-side pagination + filters + a `COUNT(*)` total, returning `{items,total,page,pageSize}`.
- `handler/admin/checkin_routes_test.go` — pagination + status/date-range filter tests.

## Test plan

- [x] `cd web && bun run typecheck` — green
- [x] `cd web && bun run lint` — green (0 errors; only pre-existing warnings)
- [x] `cd web && bun run build:web` — green (`web/dist` produced)
- [x] `go build ./...` — green
- [x] `go test ./handler/...` — green (incl. new `TestCheckinLogsReturnsPaginatedItemsAndTotal` + `TestCheckinLogsFiltersByStatusAndDateRange`)
- [ ] Manual: open /observability → toggle 15s/30s/Off, confirm Health + Overview refetch on the cadence and the spinner reflects the active mode.
- [ ] Manual: stop the backend / force a 500 and confirm the Health section + Overview cards show the error banner with a working Retry.
- [ ] Manual: open /checkin, set a date-range older than the first page, confirm rows + total reflect the real server count across pages; status/reason/site/search filters narrow the total.