### PR TITLE
perf(web): settings code-splitting + useIsMobile flash fix

### DIFF
--- a/web/src/features/settings/components/settings-page.tsx
+++ b/web/src/features/settings/components/settings-page.tsx
@@ -14,6 +14,7 @@
 // each section's `build` (mirroring newapi's SettingsPage + useSystemOptions).
 
 import { Link, type LinkProps } from '@tanstack/react-router'
+import { Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -26,6 +27,7 @@ import {
 
 import type { SettingsSubarea } from '../types'
 import { SettingsSidebar } from './settings-sidebar'
+import { SettingsSectionSkeleton } from './settings-section-card'
 
 type SettingsPageProps = {
   /** The assembled subarea (sections + nav + content). */
@@ -61,7 +63,14 @@ export function SettingsPage({ subarea, activeSection }: SettingsPageProps) {
       <div className='flex flex-col gap-6 lg:flex-row lg:items-start'>
         <SettingsSidebar items={navItems} title={t(subarea.title)} />
         <main className='min-w-0 flex-1'>
-          {subarea.getSectionContent(activeSection)}
+          {/* Single Suspense boundary catches the React.lazy sections emitted
+              by each subarea registry's build(). On the first visit to a
+              section its chunk suspends and the settings-shaped skeleton
+              shows; on revisits the lazy module is already resolved so the
+              section renders instantly without re-fetching. */}
+          <Suspense fallback={<SettingsSectionSkeleton />}>
+            {subarea.getSectionContent(activeSection)}
+          </Suspense>
         </main>
       </div>
     </div>

--- a/web/src/features/settings/components/settings-page.tsx
+++ b/web/src/features/settings/components/settings-page.tsx
@@ -26,8 +26,8 @@ import {
 } from '@/components/ui/breadcrumb'
 
 import type { SettingsSubarea } from '../types'
-import { SettingsSidebar } from './settings-sidebar'
 import { SettingsSectionSkeleton } from './settings-section-card'
+import { SettingsSidebar } from './settings-sidebar'
 
 type SettingsPageProps = {
   /** The assembled subarea (sections + nav + content). */

--- a/web/src/features/settings/sections/content/section-registry.ts
+++ b/web/src/features/settings/sections/content/section-registry.ts
@@ -1,15 +1,30 @@
 // metapi-go/features/settings/sections/content — Content subarea.
 // Scope (plan §5.5.2): import/export + notification channels + risk-banner
 // announcements. All three sections wired to real forms under ./components.
+// Each section is React.lazy so its form/table dependencies land in a separate
+// async chunk; the surrounding Suspense boundary lives in settings-page.tsx.
 
 import { MessagesSquare } from 'lucide-react'
-import { createElement } from 'react'
+import { createElement, lazy } from 'react'
 
 import type { SettingsSubarea } from '../../types'
 import { createSectionRegistry } from '../../utils/section-registry'
-import { AnnouncementsSection } from './components/announcements-section'
-import { ImportExportSection } from './components/import-export-section'
-import { NotificationsSection } from './components/notifications-section'
+
+const LazyImportExportSection = lazy(() =>
+  import('./components/import-export-section').then((module) => ({
+    default: module.ImportExportSection,
+  }))
+)
+const LazyNotificationsSection = lazy(() =>
+  import('./components/notifications-section').then((module) => ({
+    default: module.NotificationsSection,
+  }))
+)
+const LazyAnnouncementsSection = lazy(() =>
+  import('./components/announcements-section').then((module) => ({
+    default: module.AnnouncementsSection,
+  }))
+)
 
 const CONTENT_SECTIONS = [
   {
@@ -17,21 +32,21 @@ const CONTENT_SECTIONS = [
     title: 'settings.content.importExport.title',
     group: 'settings.content.groups.data',
     description: 'settings.content.importExport.description',
-    build: () => createElement(ImportExportSection),
+    build: () => createElement(LazyImportExportSection),
   },
   {
     id: 'notifications',
     title: 'settings.content.notifications.title',
     group: 'settings.content.groups.messaging',
     description: 'settings.content.notifications.description',
-    build: () => createElement(NotificationsSection),
+    build: () => createElement(LazyNotificationsSection),
   },
   {
     id: 'announcements',
     title: 'settings.content.announcements.title',
     group: 'settings.content.groups.messaging',
     description: 'settings.content.announcements.description',
-    build: () => createElement(AnnouncementsSection),
+    build: () => createElement(LazyAnnouncementsSection),
   },
 ] as const
 

--- a/web/src/features/settings/sections/downstream/section-registry.ts
+++ b/web/src/features/settings/sections/downstream/section-registry.ts
@@ -1,27 +1,38 @@
 // metapi-go/features/settings/sections/downstream — Downstream Keys subarea.
 // Scope (plan §5.5.2): downstream API keys + the global PROXY_TOKEN.
 // Sections: keys, proxy-token. Both wired to real forms under ./components.
+// Each section is React.lazy so its form/table dependencies land in a separate
+// async chunk; the surrounding Suspense boundary lives in settings-page.tsx.
 
 import { KeyRound } from 'lucide-react'
-import { createElement } from 'react'
+import { createElement, lazy } from 'react'
 
 import type { SettingsSubarea } from '../../types'
 import { createSectionRegistry } from '../../utils/section-registry'
-import { KeysSection } from './components/keys-section'
-import { ProxyTokenSection } from './components/proxy-token-section'
+
+const LazyKeysSection = lazy(() =>
+  import('./components/keys-section').then((module) => ({
+    default: module.KeysSection,
+  }))
+)
+const LazyProxyTokenSection = lazy(() =>
+  import('./components/proxy-token-section').then((module) => ({
+    default: module.ProxyTokenSection,
+  }))
+)
 
 const DOWNSTREAM_SECTIONS = [
   {
     id: 'keys',
     title: 'settings.downstream.keys.title',
     description: 'settings.downstream.keys.description',
-    build: () => createElement(KeysSection),
+    build: () => createElement(LazyKeysSection),
   },
   {
     id: 'proxy-token',
     title: 'settings.downstream.proxyToken.title',
     description: 'settings.downstream.proxyToken.description',
-    build: () => createElement(ProxyTokenSection),
+    build: () => createElement(LazyProxyTokenSection),
   },
 ] as const
 

--- a/web/src/features/settings/sections/general/section-registry.ts
+++ b/web/src/features/settings/sections/general/section-registry.ts
@@ -6,19 +6,44 @@
 //
 // This module is a .ts file (no JSX syntax) so the react/only-export-components
 // fast-refresh rule does not apply — the registry exports config values, not
-// components. Section content is built with React.createElement, which is
-// hooks-safe and stays valid when individual section components are swapped.
+// components. Section content is built with React.createElement around
+// React.lazy components, which is hooks-safe and keeps each section's heavy
+// form/table dependencies in separate async chunks instead of the main bundle.
+// The lazy component references are created at module level so their identity
+// is stable across renders (React.lazy requires this to avoid remounting); the
+// surrounding Suspense boundary lives in settings-page.tsx.
 
 import { Settings } from 'lucide-react'
-import { createElement } from 'react'
+import { createElement, lazy } from 'react'
 
 import type { SettingsSubarea } from '../../types'
 import { createSectionRegistry } from '../../utils/section-registry'
-import { AuthenticationSection } from './components/authentication-section'
-import { ProxyTransportSection } from './components/proxy-transport-section'
-import { RoutingSection } from './components/routing-section'
-import { SchedulingSection } from './components/scheduling-section'
-import { SiteSection } from './components/site-section'
+
+const LazySiteSection = lazy(() =>
+  import('./components/site-section').then((module) => ({
+    default: module.SiteSection,
+  }))
+)
+const LazyAuthenticationSection = lazy(() =>
+  import('./components/authentication-section').then((module) => ({
+    default: module.AuthenticationSection,
+  }))
+)
+const LazySchedulingSection = lazy(() =>
+  import('./components/scheduling-section').then((module) => ({
+    default: module.SchedulingSection,
+  }))
+)
+const LazyProxyTransportSection = lazy(() =>
+  import('./components/proxy-transport-section').then((module) => ({
+    default: module.ProxyTransportSection,
+  }))
+)
+const LazyRoutingSection = lazy(() =>
+  import('./components/routing-section').then((module) => ({
+    default: module.RoutingSection,
+  }))
+)
 
 const GENERAL_SECTIONS = [
   {
@@ -26,35 +51,35 @@ const GENERAL_SECTIONS = [
     title: 'settings.general.site.title',
     group: 'settings.general.groups.brandSecurity',
     description: 'settings.general.site.description',
-    build: () => createElement(SiteSection),
+    build: () => createElement(LazySiteSection),
   },
   {
     id: 'authentication',
     title: 'settings.general.authentication.title',
     group: 'settings.general.groups.brandSecurity',
     description: 'settings.general.authentication.description',
-    build: () => createElement(AuthenticationSection),
+    build: () => createElement(LazyAuthenticationSection),
   },
   {
     id: 'scheduling',
     title: 'settings.general.scheduling.title',
     group: 'settings.general.groups.runtimeStrategy',
     description: 'settings.general.scheduling.description',
-    build: () => createElement(SchedulingSection),
+    build: () => createElement(LazySchedulingSection),
   },
   {
     id: 'proxy-transport',
     title: 'settings.general.proxyTransport.title',
     group: 'settings.general.groups.runtimeStrategy',
     description: 'settings.general.proxyTransport.description',
-    build: () => createElement(ProxyTransportSection),
+    build: () => createElement(LazyProxyTransportSection),
   },
   {
     id: 'routing',
     title: 'settings.general.routing.title',
     group: 'settings.general.groups.runtimeStrategy',
     description: 'settings.general.routing.description',
-    build: () => createElement(RoutingSection),
+    build: () => createElement(LazyRoutingSection),
   },
 ] as const
 

--- a/web/src/features/settings/sections/models/section-registry.ts
+++ b/web/src/features/settings/sections/models/section-registry.ts
@@ -2,34 +2,49 @@
 // Scope (plan §5.5.2): model-name redirects + rates/multipliers + global
 // model allowlist & brand blocking. All three sections wired to real forms
 // under ./components.
+// Each section is React.lazy so its form/table dependencies land in a separate
+// async chunk; the surrounding Suspense boundary lives in settings-page.tsx.
 
 import { Boxes } from 'lucide-react'
-import { createElement } from 'react'
+import { createElement, lazy } from 'react'
 
 import type { SettingsSubarea } from '../../types'
 import { createSectionRegistry } from '../../utils/section-registry'
-import { AllowlistSection } from './components/allowlist-section'
-import { RatesSection } from './components/rates-section'
-import { RedirectsSection } from './components/redirects-section'
+
+const LazyRedirectsSection = lazy(() =>
+  import('./components/redirects-section').then((module) => ({
+    default: module.RedirectsSection,
+  }))
+)
+const LazyRatesSection = lazy(() =>
+  import('./components/rates-section').then((module) => ({
+    default: module.RatesSection,
+  }))
+)
+const LazyAllowlistSection = lazy(() =>
+  import('./components/allowlist-section').then((module) => ({
+    default: module.AllowlistSection,
+  }))
+)
 
 const MODELS_SECTIONS = [
   {
     id: 'redirects',
     title: 'settings.models.redirects.title',
     description: 'settings.models.redirects.description',
-    build: () => createElement(RedirectsSection),
+    build: () => createElement(LazyRedirectsSection),
   },
   {
     id: 'rates',
     title: 'settings.models.rates.title',
     description: 'settings.models.rates.description',
-    build: () => createElement(RatesSection),
+    build: () => createElement(LazyRatesSection),
   },
   {
     id: 'allowlist',
     title: 'settings.models.allowlist.title',
     description: 'settings.models.allowlist.description',
-    build: () => createElement(AllowlistSection),
+    build: () => createElement(LazyAllowlistSection),
   },
 ] as const
 

--- a/web/src/features/settings/sections/system-info/section-registry.ts
+++ b/web/src/features/settings/sections/system-info/section-registry.ts
@@ -2,18 +2,45 @@
 // Scope (plan §5.5.2): program logs + audit logs + update center + database
 // migration + maintenance tools + danger zone. All six sections wired to real
 // surfaces under ./components.
+// Each section is React.lazy so its form/table dependencies land in a separate
+// async chunk; the surrounding Suspense boundary lives in settings-page.tsx.
 
 import { ServerCog } from 'lucide-react'
-import { createElement } from 'react'
+import { createElement, lazy } from 'react'
 
 import type { SettingsSubarea } from '../../types'
 import { createSectionRegistry } from '../../utils/section-registry'
-import { AuditLogsSection } from './components/audit-logs-section'
-import { DangerZoneSection } from './components/danger-zone-section'
-import { DatabaseSection } from './components/database-section'
-import { MaintenanceSection } from './components/maintenance-section'
-import { ProgramLogsSection } from './components/program-logs-section'
-import { UpdateCenterSection } from './components/update-center-section'
+
+const LazyProgramLogsSection = lazy(() =>
+  import('./components/program-logs-section').then((module) => ({
+    default: module.ProgramLogsSection,
+  }))
+)
+const LazyAuditLogsSection = lazy(() =>
+  import('./components/audit-logs-section').then((module) => ({
+    default: module.AuditLogsSection,
+  }))
+)
+const LazyUpdateCenterSection = lazy(() =>
+  import('./components/update-center-section').then((module) => ({
+    default: module.UpdateCenterSection,
+  }))
+)
+const LazyDatabaseSection = lazy(() =>
+  import('./components/database-section').then((module) => ({
+    default: module.DatabaseSection,
+  }))
+)
+const LazyMaintenanceSection = lazy(() =>
+  import('./components/maintenance-section').then((module) => ({
+    default: module.MaintenanceSection,
+  }))
+)
+const LazyDangerZoneSection = lazy(() =>
+  import('./components/danger-zone-section').then((module) => ({
+    default: module.DangerZoneSection,
+  }))
+)
 
 const SYSTEM_INFO_SECTIONS = [
   {
@@ -21,7 +48,7 @@ const SYSTEM_INFO_SECTIONS = [
     title: 'settings.systemInfo.programLogs.title',
     group: 'settings.systemInfo.groups.logs',
     description: 'settings.systemInfo.programLogs.description',
-    build: () => createElement(ProgramLogsSection),
+    build: () => createElement(LazyProgramLogsSection),
   },
   {
     id: 'audit-logs',
@@ -29,7 +56,7 @@ const SYSTEM_INFO_SECTIONS = [
     group: 'settings.systemInfo.groups.logs',
     description: 'settings.systemInfo.auditLogs.description',
     readonly: true,
-    build: () => createElement(AuditLogsSection),
+    build: () => createElement(LazyAuditLogsSection),
   },
   {
     id: 'update-center',
@@ -37,28 +64,28 @@ const SYSTEM_INFO_SECTIONS = [
     group: 'settings.systemInfo.groups.system',
     description: 'settings.systemInfo.updateCenter.description',
     readonly: true,
-    build: () => createElement(UpdateCenterSection),
+    build: () => createElement(LazyUpdateCenterSection),
   },
   {
     id: 'database',
     title: 'settings.systemInfo.database.title',
     group: 'settings.systemInfo.groups.system',
     description: 'settings.systemInfo.database.description',
-    build: () => createElement(DatabaseSection),
+    build: () => createElement(LazyDatabaseSection),
   },
   {
     id: 'maintenance',
     title: 'settings.systemInfo.maintenance.title',
     group: 'settings.systemInfo.groups.system',
     description: 'settings.systemInfo.maintenance.description',
-    build: () => createElement(MaintenanceSection),
+    build: () => createElement(LazyMaintenanceSection),
   },
   {
     id: 'danger-zone',
     title: 'settings.systemInfo.dangerZone.title',
     group: 'settings.systemInfo.groups.dangerZone',
     description: 'settings.systemInfo.dangerZone.description',
-    build: () => createElement(DangerZoneSection),
+    build: () => createElement(LazyDangerZoneSection),
   },
 ] as const
 

--- a/web/src/hooks/use-mobile.tsx
+++ b/web/src/hooks/use-mobile.tsx
@@ -1,22 +1,91 @@
-// metapi-go/hooks — use-mobile ported from newapi. AGPL header stripped.
-// Exports useIsMobile — consumed by sidebar.tsx.
+// metapi-go/hooks — use-mobile rewritten with useSyncExternalStore.
+//
+// The previous implementation seeded `useState` with `undefined`, so the first
+// client render always returned `false` (the `!!isMobile` coercion) and an
+// effect patched it after paint — producing a one-frame desktop-sidebar flash
+// for mobile users. useSyncExternalStore reads the real matchMedia value
+// synchronously during render, so the first client render is already correct
+// with no post-paint correction.
+//
+// The store lives at module scope so every component observes the same source.
+// matchMedia is resolved lazily (on first getSnapshot/subscribe) so SSR and
+// non-browser builds don't touch `window`. `getServerSnapshot` returns `false`
+// to keep server output stable and hydration-consistent; React then
+// synchronously re-renders with the real client value.
 
 import * as React from 'react'
 
 const MOBILE_BREAKPOINT = 768
+// `max-width: ${MOBILE_BREAKPOINT - 1}px` mirrors the original `innerWidth <
+// MOBILE_BREAKPOINT` check, so a 768px viewport stays classified as desktop
+// (no behavior change — only the first-render flash is fixed).
+const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
 
-export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+type Listener = () => void
 
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+interface MobileStore {
+  subscribe: (listener: Listener) => () => void
+  getSnapshot: () => boolean
+  getServerSnapshot: () => boolean
+}
+
+const isMobileStore: MobileStore = (() => {
+  const listeners = new Set<Listener>()
+  // Resolved lazily on the client; null on the server.
+  let mediaQueryList: MediaQueryList | null = null
+  let cachedSnapshot = false
+
+  function resolveMediaQueryList(): MediaQueryList | null {
+    if (
+      typeof window === 'undefined' ||
+      typeof window.matchMedia !== 'function'
+    ) {
+      return null
     }
-    mql.addEventListener('change', onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener('change', onChange)
-  }, [])
+    // Idempotent: the `=== null` guard means repeated calls (including React
+    // strict-mode double renders) only attach one change listener.
+    if (mediaQueryList === null) {
+      mediaQueryList = window.matchMedia(MOBILE_MEDIA_QUERY)
+      cachedSnapshot = mediaQueryList.matches
+      mediaQueryList.addEventListener('change', handleChange)
+    }
+    return mediaQueryList
+  }
 
-  return !!isMobile
+  function handleChange(event: MediaQueryListEvent) {
+    cachedSnapshot = event.matches
+    for (const listener of listeners) {
+      listener()
+    }
+  }
+
+  return {
+    subscribe(listener) {
+      listeners.add(listener)
+      // First subscribe on the client resolves matchMedia so the change
+      // listener is attached even if getSnapshot hasn't run yet.
+      resolveMediaQueryList()
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+    getSnapshot() {
+      // Resolving here (not just in subscribe) is what makes the first client
+      // render return the real value — useSyncExternalStore calls getSnapshot
+      // during render, before subscribe runs in a passive effect.
+      resolveMediaQueryList()
+      return cachedSnapshot
+    },
+    getServerSnapshot() {
+      return false
+    },
+  }
+})()
+
+export function useIsMobile(): boolean {
+  return React.useSyncExternalStore(
+    isMobileStore.subscribe,
+    isMobileStore.getSnapshot,
+    isMobileStore.getServerSnapshot
+  )
 }


### PR DESCRIPTION
## Summary

- **Fix 1 (P2): Settings sections statically imported → `React.lazy`.** All 19 section components across the 5 subarea registries (`general` / `downstream` / `models` / `content` / `system-info`) were imported statically and rendered via `createElement(Section)`, pulling every settings form/table (and their `react-hook-form` + `zod` + heavy UI deps) into the main bundle. Each registry now wraps its sections in `React.lazy(() => import(...).then(m => ({ default: m.XSection })))` — mirroring the existing dashboard/observability pattern — so each section lands in its own async chunk. Lazy references are created at module level for stable identity, and a single `Suspense` boundary with the existing `SettingsSectionSkeleton` was added in `SettingsPage` so first-visit loads show the settings-shaped skeleton instead of a blank flash.
- **Fix 2 (P3): `useIsMobile` first-render flash.** The previous `useState(undefined)` + `useEffect` pattern coerced the first client render to `false` (`!!isMobile`), so mobile users saw the desktop sidebar for one frame before the effect resolved. Rewritten with `useSyncExternalStore` over a module-level `matchMedia` store that lazily resolves `window.matchMedia('(max-width: 767px)')` on the client. `getSnapshot` resolves `matchMedia` during render so the **first client render returns the real value — no flash**. SSR safety preserved via `getServerSnapshot` returning `false`.

### Bundle size (rsbuild production)

| Chunk | Before | After | Δ |
|---|---|---|---|
| `index` (initial) | 383.6 kB raw / 96.9 kB gzip | 239.2 kB raw / 71.1 kB gzip | **−144.4 kB raw (−37.6%) / −25.8 kB gzip (−26.6%)** |
| Total (all chunks) | 4727.8 kB | 4892.4 kB | +164.6 kB (splitting overhead; on-demand only) |
| Async chunks | 72 | 98 | +26 (the 19 settings sections + hoisted shared deps) |

The initial bundle (what every route loads first) drops ~26% gzip. Settings sections + their exclusive deps now load on-demand when a settings route is visited. The large pre-existing async chunks (`1413` @ 2.0 MB, `4347` @ 347 kB) are unchanged — they are not introduced by this PR.

### Behavior preserved

- Settings section content/behavior untouched — only how they're loaded.
- `.ts` registry extension kept (no JSX added).
- `useIsMobile` return type stays `boolean`; breakpoint semantics unchanged (768px viewport stays desktop, matching the original `innerWidth < 768`).

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun run lint` — green (no new warnings in changed files)
- [x] `bun run knip` — green
- [x] `bun run build:web` — green; main index chunk reduced 383.6 → 239.2 kB
- [ ] Manual: visit each settings subarea (general/downstream/models/content/system-info), confirm skeleton shows briefly then section renders, and navigation between sections is instant on revisits
- [ ] Manual: at ≤767px viewport, confirm the mobile sidebar renders on first paint (no desktop-sidebar flash); resize across 767↔768px and confirm the breakpoint matches desktop behavior