### PR TITLE
feat(web): proxy logs auto-refresh+CSV + channels detail sheet

### DIFF
--- a/web/src/features/channels/components/channel-detail-sheet.tsx
+++ b/web/src/features/channels/components/channel-detail-sheet.tsx
@@ -1,0 +1,220 @@
+// metapi-go/features/channels/components — channel detail Sheet (side panel).
+//
+// Opens from the row "view details" action. Mirrors the model detail sheet
+// pattern: a read-only side panel that renders fields already present on the
+// list row (no extra fetch — `useChannels` returns the full projection).
+// The panel surfaces the routing-health vocabulary the channels page already
+// displays (status / cooldown / avg latency / models) in a denser layout so
+// an operator can inspect a single channel without losing the list context.
+
+import { Ban, CheckCircle2, Clock, TriangleAlert } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Badge } from '@/components/ui/badge'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Separator } from '@/components/ui/separator'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { cn } from '@/lib/utils'
+
+import type { ChannelRow, ChannelStatus } from '../types'
+
+type ChannelDetailSheetProps = {
+  channel: ChannelRow | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const STATUS_CONFIG: Record<
+  ChannelStatus,
+  {
+    labelKey: string
+    variant: 'default' | 'warning' | 'destructive' | 'secondary'
+    dotClass: string
+    Icon: typeof CheckCircle2
+  }
+> = {
+  enabled: {
+    labelKey: 'channels.status.enabled',
+    variant: 'default',
+    dotClass: 'bg-success',
+    Icon: CheckCircle2,
+  },
+  cooldown: {
+    labelKey: 'channels.status.cooldown',
+    variant: 'warning',
+    dotClass: 'bg-warning',
+    Icon: Clock,
+  },
+  breaker_open: {
+    labelKey: 'channels.status.breakerOpen',
+    variant: 'destructive',
+    dotClass: 'bg-destructive',
+    Icon: TriangleAlert,
+  },
+  manually_disabled: {
+    labelKey: 'channels.status.manuallyDisabled',
+    variant: 'secondary',
+    dotClass: 'bg-muted-foreground',
+    Icon: Ban,
+  },
+}
+
+function formatResponse(ms: number | null): string {
+  if (ms === null || ms === undefined) return '—'
+  return `${Math.round(ms)}ms`
+}
+
+function formatCooldown(until: string | null): string {
+  if (!until) return '—'
+  const date = new Date(until)
+  return Number.isNaN(date.getTime()) ? '—' : date.toLocaleString()
+}
+
+function DetailRow({
+  label,
+  children,
+}: {
+  label: string
+  children: ReactNode
+}) {
+  return (
+    <div className='grid grid-cols-3 gap-2 py-1.5 text-sm'>
+      <span className='text-muted-foreground col-span-1'>{label}</span>
+      <div className='col-span-2 break-words'>{children}</div>
+    </div>
+  )
+}
+
+export function ChannelDetailSheet({
+  channel,
+  open,
+  onOpenChange,
+}: ChannelDetailSheetProps) {
+  const { t } = useTranslation()
+
+  if (!channel) {
+    return (
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent side='right' />
+      </Sheet>
+    )
+  }
+
+  const status = channel.status
+  const statusConfig = STATUS_CONFIG[status] ?? STATUS_CONFIG.enabled
+  const StatusIcon = statusConfig.Icon
+  const site = channel.site
+  const siteLabel = site.name || `#${site.id}`
+  const typeLabel = t(`channels.type.${channel.type}`)
+  const models = channel.models || t('channels.detail.notAvailable')
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side='right' className='sm:max-w-md'>
+        <SheetHeader>
+          <div className='flex items-center gap-3 pr-6'>
+            <div className='min-w-0 flex-1'>
+              <SheetTitle className='truncate'>{channel.name}</SheetTitle>
+              <SheetDescription className='truncate'>
+                {t('channels.detail.description')}
+              </SheetDescription>
+            </div>
+          </div>
+        </SheetHeader>
+
+        <ScrollArea className='flex-1'>
+          <div className='flex flex-col gap-4 px-4 pb-4'>
+            <section>
+              <h3 className='text-sm font-medium'>
+                {t('channels.detail.sectionOverview')}
+              </h3>
+              <div className='mt-2'>
+                <DetailRow label={t('channels.detail.name')}>
+                  <span className='font-medium'>{channel.name}</span>
+                </DetailRow>
+                <DetailRow label={t('channels.detail.site')}>
+                  {siteLabel}
+                </DetailRow>
+                <DetailRow label={t('channels.detail.type')}>
+                  <Badge variant='outline' className='capitalize'>
+                    {typeLabel}
+                  </Badge>
+                </DetailRow>
+                <DetailRow label={t('channels.detail.status')}>
+                  <Badge variant={statusConfig.variant} className='gap-1.5'>
+                    <span
+                      aria-hidden='true'
+                      className={cn(
+                        'size-1.5 rounded-full',
+                        statusConfig.dotClass
+                      )}
+                    />
+                    <StatusIcon aria-hidden='true' />
+                    {t(statusConfig.labelKey)}
+                  </Badge>
+                </DetailRow>
+                <DetailRow label={t('channels.detail.enabled')}>
+                  <Badge variant={channel.enabled ? 'default' : 'secondary'}>
+                    {channel.enabled
+                      ? t('channels.detail.enabled')
+                      : t('channels.detail.disabled')}
+                  </Badge>
+                </DetailRow>
+              </div>
+            </section>
+
+            <Separator />
+
+            <section>
+              <h3 className='text-sm font-medium'>
+                {t('channels.detail.sectionHealth')}
+              </h3>
+              <div className='mt-2'>
+                <DetailRow label={t('channels.detail.priority')}>
+                  {channel.priority}
+                </DetailRow>
+                <DetailRow label={t('channels.detail.weight')}>
+                  {channel.weight}
+                </DetailRow>
+                <DetailRow label={t('channels.detail.avgLatency')}>
+                  {formatResponse(channel.responseMs)}
+                </DetailRow>
+                <DetailRow label={t('channels.detail.cooldownUntil')}>
+                  {formatCooldown(channel.cooldownUntil)}
+                </DetailRow>
+                <DetailRow label={t('channels.detail.manualOverride')}>
+                  {channel.manualOverride
+                    ? t('channels.detail.manualOverrideActive')
+                    : t('channels.detail.manualOverrideNone')}
+                </DetailRow>
+              </div>
+            </section>
+
+            <Separator />
+
+            <section>
+              <h3 className='text-sm font-medium'>
+                {t('channels.detail.sectionModels')}
+              </h3>
+              <div className='bg-muted/40 mt-2 rounded-lg border p-2'>
+                <div className='text-muted-foreground text-[11px]'>
+                  {t('channels.detail.routePattern')}
+                </div>
+                <code className='block font-mono text-xs break-all'>
+                  {models}
+                </code>
+              </div>
+            </section>
+          </div>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/web/src/features/channels/components/channels-columns.tsx
+++ b/web/src/features/channels/components/channels-columns.tsx
@@ -4,15 +4,24 @@
 // color + icon + text (dual-channel, never color-only).
 
 import type { ColumnDef } from '@tanstack/react-table'
-import { Ban, CheckCircle2, Clock, TriangleAlert } from 'lucide-react'
+import {
+  Ban,
+  CheckCircle2,
+  Clock,
+  Eye as EyeIcon,
+  TriangleAlert,
+} from 'lucide-react'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { DataTableColumnHeader } from '@/components/data-table'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
 import type { ChannelRow, ChannelStatus } from '../types'
+
+export type ChannelsColumnActions = { onView: (channel: ChannelRow) => void }
 
 const STATUS_CONFIG: Record<
   ChannelStatus,
@@ -59,7 +68,9 @@ function formatCooldown(until: string | null): string {
   return new Date(until).toLocaleString()
 }
 
-export function useChannelsColumns(): ColumnDef<ChannelRow>[] {
+export function useChannelsColumns(
+  actions?: ChannelsColumnActions
+): ColumnDef<ChannelRow>[] {
   const { t } = useTranslation()
 
   return useMemo<ColumnDef<ChannelRow>[]>(
@@ -224,7 +235,37 @@ export function useChannelsColumns(): ColumnDef<ChannelRow>[] {
           </span>
         ),
       },
+      {
+        id: 'actions',
+        size: 56,
+        enableSorting: false,
+        enableHiding: false,
+        enableResizing: false,
+        meta: { mobileHidden: false, mobileOrder: 4 },
+        header: () => (
+          <span className='text-muted-foreground text-xs'>
+            {t('common.actions')}
+          </span>
+        ),
+        cell: ({ row }) => {
+          if (!actions) return null
+          const channel = row.original
+          return (
+            <div className={cn('flex justify-end')}>
+              <Button
+                variant='ghost'
+                size='icon-sm'
+                className='data-popup-open:bg-accent'
+                aria-label={t('channels.columns.viewDetails')}
+                onClick={() => actions.onView(channel)}
+              >
+                <EyeIcon className='size-4' />
+              </Button>
+            </div>
+          )
+        },
+      },
     ],
-    [t]
+    [t, actions]
   )
 }

--- a/web/src/features/channels/components/channels-page.tsx
+++ b/web/src/features/channels/components/channels-page.tsx
@@ -1,9 +1,12 @@
 // metapi-go/features/channels — read-only list page.
 // Wires the shared data-table to `useChannels` and mirrors search/page/sort
 // state to the URL. No mutation surfaces: this page is intentionally read-only
-// (soft isolation only — never hard-disable a channel).
+// (soft isolation only — never hard-disable a channel). A detail sheet (opened
+// from the row eye action) surfaces the routing-health fields the columns
+// already render, mirroring the model / route / account detail pattern.
 
 import type { ColumnFiltersState } from '@tanstack/react-table'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -18,7 +21,11 @@ import { asStringParam, parseSortingParam } from '@/lib/helpers/searchParams'
 import { useChannels } from '../api'
 import { channelsSearchSchema } from '../lib/channels-schema'
 import type { ChannelRow } from '../types'
-import { useChannelsColumns } from './channels-columns'
+import { ChannelDetailSheet } from './channel-detail-sheet'
+import {
+  useChannelsColumns,
+  type ChannelsColumnActions,
+} from './channels-columns'
 
 const CHANNELS_COLUMN_VISIBILITY_STORAGE_KEY =
   'metapi-go:channels:column-visibility'
@@ -77,7 +84,16 @@ export function ChannelsPage() {
   const { t } = useTranslation()
   const channelsQuery = useChannels()
   const urlState = useChannelsUrlState()
-  const columns = useChannelsColumns()
+  const [detailChannel, setDetailChannel] = useState<ChannelRow | null>(null)
+  const [detailOpen, setDetailOpen] = useState(false)
+
+  const columnActions: ChannelsColumnActions = {
+    onView: (channel) => {
+      setDetailChannel(channel)
+      setDetailOpen(true)
+    },
+  }
+  const columns = useChannelsColumns(columnActions)
 
   const { table } = useDataTable<ChannelRow>({
     data: channelsQuery.data ?? [],
@@ -126,6 +142,12 @@ export function ChannelsPage() {
           searchPlaceholder: t('channels.toolbar.searchPlaceholder'),
           searchDebounceMs: 400,
         }}
+      />
+
+      <ChannelDetailSheet
+        channel={detailChannel}
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
       />
     </div>
   )

--- a/web/src/features/proxy-logs/components/proxy-logs-auto-refresh-toggle.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-auto-refresh-toggle.tsx
@@ -1,0 +1,57 @@
+// metapi-go/features/proxy-logs/components — header toggle that drives the
+// page-level auto-refresh interval (5s / 15s / 30s / Off). Mirrors the
+// observability auto-refresh segmented control so the cadence is visible at
+// a glance; the interval is persisted to localStorage via
+// `useProxyLogsAutoRefresh` so a bookmarked operator view survives reloads.
+
+import { RefreshCw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+import {
+  PROXY_LOGS_AUTO_REFRESH_PRESETS,
+  useProxyLogsAutoRefresh,
+  type ProxyLogsAutoRefreshInterval,
+} from '../lib/use-proxy-logs-auto-refresh'
+
+export function ProxyLogsAutoRefreshToggle() {
+  const { t } = useTranslation()
+  const { intervalMs, setIntervalMs } = useProxyLogsAutoRefresh()
+
+  const isMatch = (presetValue: ProxyLogsAutoRefreshInterval): boolean =>
+    presetValue === intervalMs
+
+  return (
+    <div
+      className='bg-card flex items-center gap-1 rounded-md border p-0.5'
+      role='group'
+      aria-label={t('proxyLogs.page.autoRefresh.label')}
+    >
+      <RefreshCw
+        className={cn(
+          'text-muted-foreground size-3.5 shrink-0',
+          intervalMs !== false && 'animate-spin'
+        )}
+        aria-hidden='true'
+      />
+      {PROXY_LOGS_AUTO_REFRESH_PRESETS.map((preset) => {
+        const active = isMatch(preset.value)
+        return (
+          <Button
+            key={preset.id}
+            type='button'
+            variant={active ? 'default' : 'ghost'}
+            size='sm'
+            className='h-7 px-2 text-xs font-medium'
+            aria-pressed={active}
+            onClick={() => setIntervalMs(preset.value)}
+          >
+            {t(preset.labelKey)}
+          </Button>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -687,7 +687,7 @@ function proxyLogsToCsv(
 ): string {
   const header = PROXY_LOGS_CSV_COLUMNS.map((column) =>
     csvEscape(
-      t(`proxyLogs.page.exportCsv.column.${column}`, { defaultValue: column })
+      t(`proxyLogs.page.exportCsvColumn.${column}`, { defaultValue: column })
     )
   ).join(',')
   const body = rows

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -3,7 +3,7 @@
 // i18n: all user-visible strings migrated to t() calls.
 
 import type { OnChangeFn, PaginationState } from '@tanstack/react-table'
-import { RefreshCw } from 'lucide-react'
+import { Download as DownloadIcon, RefreshCw } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -17,14 +17,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { api } from '@/lib/api'
+import { toast } from '@/lib/toast'
 
 import { useProxyLogs, useProxyLogsMeta } from '../api'
 import {
   PROXY_LOG_STATUS_FILTER_OPTIONS,
   proxyLogsSearchSchema,
 } from '../lib/proxy-logs-schema'
+import { useProxyLogsAutoRefresh } from '../lib/use-proxy-logs-auto-refresh'
 import type { ProxyLog, ProxyLogDetail, ProxyLogFilters } from '../types'
 import { LatencyBadge } from './latency-badge'
+import { ProxyLogsAutoRefreshToggle } from './proxy-logs-auto-refresh-toggle'
 import { ProxyLogDetailSheet } from './proxy-log-detail-sheet'
 import {
   useProxyLogsColumns,
@@ -36,6 +40,7 @@ const PROXY_LOGS_COLUMN_VISIBILITY_STORAGE_KEY =
 const PROXY_LOGS_COLUMN_SIZING_STORAGE_KEY =
   'metapi-go:proxy-logs:column-sizing'
 const DEFAULT_PAGE_SIZE = 20
+const PROXY_LOGS_CSV_EXPORT_LIMIT = 10_000
 
 type ResolvedUrlState = {
   pageIndex: number
@@ -156,6 +161,7 @@ export function ProxyLogsPage() {
   )
   const [detailLog, setDetailLog] = useState<ProxyLog | null>(null)
   const [detailOpen, setDetailOpen] = useState(false)
+  const [isExporting, setIsExporting] = useState(false)
 
   useEffect(() => {
     writeUrlState({
@@ -207,7 +213,10 @@ export function ProxyLogsPage() {
     }),
     [queryPayload]
   )
-  const logsQuery = useProxyLogs(queryPayload)
+  const { intervalMs } = useProxyLogsAutoRefresh()
+  const logsQuery = useProxyLogs(queryPayload, {
+    refetchInterval: intervalMs === false ? false : intervalMs,
+  })
   const metaQuery = useProxyLogsMeta(metaPayload)
   const rawItems = useMemo(() => logsQuery.data?.items ?? [], [logsQuery.data])
   const total = logsQuery.data?.total ?? 0
@@ -282,6 +291,39 @@ export function ProxyLogsPage() {
     setPagination((prev) => ({ ...prev, pageIndex: 0 }))
   }
 
+  async function handleExportCsv() {
+    setIsExporting(true)
+    try {
+      const exportPayload = {
+        ...queryPayload,
+        limit: PROXY_LOGS_CSV_EXPORT_LIMIT,
+        offset: 0,
+      }
+      const response = await api.getProxyLogs(exportPayload)
+      const rows = response.items ?? []
+      const csv = proxyLogsToCsv(rows, t)
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+      const url = URL.createObjectURL(blob)
+      const anchor = document.createElement('a')
+      anchor.href = url
+      anchor.download = `metapi-proxy-logs-${formatExportStamp()}.csv`
+      anchor.click()
+      URL.revokeObjectURL(url)
+      toast.success(
+        t('proxyLogs.page.exportCsvToast', { count: rows.length })
+      )
+    } catch (exportError) {
+      toast.error(
+        t('proxyLogs.page.exportCsvFailed', {
+          message:
+            exportError instanceof Error ? exportError.message : 'unknown',
+        })
+      )
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
   const hasLatencyFilter = latencyMin !== null || latencyMax !== null
   const slowOnly = latencyMin === 2000 && latencyMax === null
 
@@ -294,17 +336,31 @@ export function ProxyLogsPage() {
             {t('proxyLogs.page.description')}
           </p>
         </div>
-        <Button
-          variant='outline'
-          size='sm'
-          onClick={() => logsQuery.refetch()}
-          disabled={logsQuery.isFetching}
-        >
-          <RefreshCw
-            className={logsQuery.isFetching ? 'animate-spin' : undefined}
-          />
-          {t('proxyLogs.page.refresh')}
-        </Button>
+        <div className='flex items-center gap-2'>
+          <ProxyLogsAutoRefreshToggle />
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={handleExportCsv}
+            disabled={isExporting}
+          >
+            <DownloadIcon
+              className={isExporting ? 'animate-pulse' : undefined}
+            />
+            {t('proxyLogs.page.exportCsv')}
+          </Button>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={() => logsQuery.refetch()}
+            disabled={logsQuery.isFetching}
+          >
+            <RefreshCw
+              className={logsQuery.isFetching ? 'animate-spin' : undefined}
+            />
+            {t('proxyLogs.page.refresh')}
+          </Button>
+        </div>
       </div>
 
       {summary && (
@@ -593,6 +649,68 @@ function SummaryCard({
       </div>
     </div>
   )
+}
+
+function formatExportStamp(): string {
+  const now = new Date()
+  const pad = (value: number) => String(value).padStart(2, '0')
+  return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}`
+}
+
+// CSV export column header keys. The proxy_logs table does not persist the
+// HTTP method or upstream path (only the downstream trace surface does), so
+// the CSV sticks to the columns the /api/stats/proxy-logs response actually
+// returns. httpStatus IS in the response (pl.*) even though the list type
+// historically omitted it, so it is surfaced here as a bonus column.
+const PROXY_LOGS_CSV_COLUMNS = [
+  'timestamp',
+  'httpStatus',
+  'status',
+  'model',
+  'account',
+  'site',
+  'duration',
+  'tokens',
+  'estimatedCost',
+] as const
+
+function csvEscape(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return ''
+  const text = String(value)
+  if (/[",\n\r]/.test(text)) {
+    return `"${text.replaceAll('"', '""')}"`
+  }
+  return text
+}
+
+function proxyLogsToCsv(
+  rows: ProxyLog[],
+  t: (key: string, params?: Record<string, unknown>) => string
+): string {
+  const header = PROXY_LOGS_CSV_COLUMNS.map((column) =>
+    csvEscape(t(`proxyLogs.page.exportCsv.column.${column}`, { defaultValue: column }))
+  ).join(',')
+  const body = rows
+    .map((log) => {
+      const accountLabel = log.username || (log.accountId ? `#${log.accountId}` : '')
+      const siteLabel =
+        log.siteName || (log.siteId ? `#${log.siteId}` : '')
+      const modelLabel = log.modelActual?.trim() || log.modelRequested?.trim() || ''
+      const cells = [
+        log.createdAt,
+        log.httpStatus ?? '',
+        log.status,
+        modelLabel,
+        accountLabel,
+        siteLabel,
+        log.latencyMs,
+        log.totalTokens ?? '',
+        log.estimatedCost ?? '',
+      ]
+      return cells.map(csvEscape).join(',')
+    })
+    .join('\n')
+  return `${header}\n${body}`
 }
 
 export type { ProxyLogDetail }

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -28,8 +28,8 @@ import {
 import { useProxyLogsAutoRefresh } from '../lib/use-proxy-logs-auto-refresh'
 import type { ProxyLog, ProxyLogDetail, ProxyLogFilters } from '../types'
 import { LatencyBadge } from './latency-badge'
-import { ProxyLogsAutoRefreshToggle } from './proxy-logs-auto-refresh-toggle'
 import { ProxyLogDetailSheet } from './proxy-log-detail-sheet'
+import { ProxyLogsAutoRefreshToggle } from './proxy-logs-auto-refresh-toggle'
 import {
   useProxyLogsColumns,
   type ProxyLogsColumnActions,
@@ -309,9 +309,7 @@ export function ProxyLogsPage() {
       anchor.download = `metapi-proxy-logs-${formatExportStamp()}.csv`
       anchor.click()
       URL.revokeObjectURL(url)
-      toast.success(
-        t('proxyLogs.page.exportCsvToast', { count: rows.length })
-      )
+      toast.success(t('proxyLogs.page.exportCsvToast', { count: rows.length }))
     } catch (exportError) {
       toast.error(
         t('proxyLogs.page.exportCsvFailed', {
@@ -688,14 +686,17 @@ function proxyLogsToCsv(
   t: (key: string, params?: Record<string, unknown>) => string
 ): string {
   const header = PROXY_LOGS_CSV_COLUMNS.map((column) =>
-    csvEscape(t(`proxyLogs.page.exportCsv.column.${column}`, { defaultValue: column }))
+    csvEscape(
+      t(`proxyLogs.page.exportCsv.column.${column}`, { defaultValue: column })
+    )
   ).join(',')
   const body = rows
     .map((log) => {
-      const accountLabel = log.username || (log.accountId ? `#${log.accountId}` : '')
-      const siteLabel =
-        log.siteName || (log.siteId ? `#${log.siteId}` : '')
-      const modelLabel = log.modelActual?.trim() || log.modelRequested?.trim() || ''
+      const accountLabel =
+        log.username || (log.accountId ? `#${log.accountId}` : '')
+      const siteLabel = log.siteName || (log.siteId ? `#${log.siteId}` : '')
+      const modelLabel =
+        log.modelActual?.trim() || log.modelRequested?.trim() || ''
       const cells = [
         log.createdAt,
         log.httpStatus ?? '',

--- a/web/src/features/proxy-logs/lib/use-proxy-logs-auto-refresh.ts
+++ b/web/src/features/proxy-logs/lib/use-proxy-logs-auto-refresh.ts
@@ -75,13 +75,10 @@ export function useProxyLogsAutoRefresh(): {
   const [intervalMs, setIntervalMsState] =
     useState<ProxyLogsAutoRefreshInterval>(readStoredInterval)
 
-  const setIntervalMs = useCallback(
-    (value: ProxyLogsAutoRefreshInterval) => {
-      setIntervalMsState(value)
-      writeStoredInterval(value)
-    },
-    []
-  )
+  const setIntervalMs = useCallback((value: ProxyLogsAutoRefreshInterval) => {
+    setIntervalMsState(value)
+    writeStoredInterval(value)
+  }, [])
 
   return { intervalMs, setIntervalMs }
 }

--- a/web/src/features/proxy-logs/lib/use-proxy-logs-auto-refresh.ts
+++ b/web/src/features/proxy-logs/lib/use-proxy-logs-auto-refresh.ts
@@ -1,0 +1,87 @@
+// metapi-go/features/proxy-logs/lib — localStorage-backed auto-refresh
+// preference for the proxy logs page. Mirrors the observability auto-refresh
+// pattern (the interval is persisted so a bookmarked operator view survives
+// reloads), but scoped to the proxy-logs page rather than shared via context:
+// proxy-logs is a single surface with no sub-sections, so a local hook is
+// enough and avoids the provider boilerplate.
+//
+// `false` disables auto-refresh entirely; a positive number is the
+// `refetchInterval` (in ms) forwarded to `useProxyLogs`. The default is Off
+// so an explicit opt-in is required before background polling starts.
+
+import { useCallback, useState } from 'react'
+
+export type ProxyLogsAutoRefreshInterval = number | false
+
+export const PROXY_LOGS_AUTO_REFRESH_PRESETS = [
+  {
+    id: '5s',
+    labelKey: 'proxyLogs.page.autoRefresh.interval5s',
+    value: 5_000,
+  },
+  {
+    id: '15s',
+    labelKey: 'proxyLogs.page.autoRefresh.interval15s',
+    value: 15_000,
+  },
+  {
+    id: '30s',
+    labelKey: 'proxyLogs.page.autoRefresh.interval30s',
+    value: 30_000,
+  },
+  {
+    id: 'off',
+    labelKey: 'proxyLogs.page.autoRefresh.intervalOff',
+    value: false,
+  },
+] as const
+
+const STORAGE_KEY = 'metapi-go:proxy-logs:auto-refresh'
+const DEFAULT_INTERVAL_MS: ProxyLogsAutoRefreshInterval = false
+
+function readStoredInterval(): ProxyLogsAutoRefreshInterval {
+  if (typeof window === 'undefined') return DEFAULT_INTERVAL_MS
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (raw === null) return DEFAULT_INTERVAL_MS
+    if (raw === 'false') return false
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed) && parsed > 0) return parsed
+    return DEFAULT_INTERVAL_MS
+  } catch {
+    return DEFAULT_INTERVAL_MS
+  }
+}
+
+function writeStoredInterval(value: ProxyLogsAutoRefreshInterval) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(value))
+  } catch {
+    /* localStorage unavailable — keep the in-memory state only. */
+  }
+}
+
+/**
+ * Resolve the proxy-logs auto-refresh interval (in ms, or `false` to disable)
+ * and a setter that persists the choice to localStorage. Re-mounts (route
+ * navigation, reloads) restore the last choice so an operator's preferred
+ * cadence survives without re-toggling each visit.
+ */
+export function useProxyLogsAutoRefresh(): {
+  intervalMs: ProxyLogsAutoRefreshInterval
+  setIntervalMs: (value: ProxyLogsAutoRefreshInterval) => void
+} {
+  const [intervalMs, setIntervalMsState] =
+    useState<ProxyLogsAutoRefreshInterval>(readStoredInterval)
+
+  const setIntervalMs = useCallback(
+    (value: ProxyLogsAutoRefreshInterval) => {
+      setIntervalMsState(value)
+      writeStoredInterval(value)
+    },
+    []
+  )
+
+  return { intervalMs, setIntervalMs }
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1739,7 +1739,28 @@
         "latencyMax": "Latency ≤",
         "latencyUnit": "ms",
         "latencyExample": "Example:",
-        "slowOnly": "Slow only"
+        "slowOnly": "Slow only",
+        "autoRefresh": {
+          "label": "Auto-refresh",
+          "interval5s": "5s",
+          "interval15s": "15s",
+          "interval30s": "30s",
+          "intervalOff": "Off"
+        },
+        "exportCsv": "Export CSV",
+        "exportCsvToast": "Exported {{count}} rows",
+        "exportCsvFailed": "CSV export failed: {{message}}",
+        "exportCsvColumn": {
+          "timestamp": "Timestamp",
+          "httpStatus": "HTTP status",
+          "status": "Status",
+          "model": "Model",
+          "account": "Account",
+          "site": "Site",
+          "duration": "Duration (ms)",
+          "tokens": "Tokens",
+          "estimatedCost": "Estimated cost"
+        }
       },
       "columns": {
         "createdAt": "Time",
@@ -2148,7 +2169,8 @@
         "priority": "Priority",
         "weight": "Weight",
         "response": "Response",
-        "cooldown": "Cooldown"
+        "cooldown": "Cooldown",
+        "viewDetails": "View details"
       },
       "status": {
         "enabled": "Enabled",
@@ -2160,6 +2182,33 @@
         "account": "Account",
         "token": "Token",
         "oauth_unit": "OAuth unit"
+      },
+      "detail": {
+        "title": "Channel detail",
+        "description": "Read-only routing health for a single channel.",
+        "sectionOverview": "Overview",
+        "sectionHealth": "Routing health",
+        "sectionModels": "Models",
+        "name": "Name",
+        "site": "Site",
+        "type": "Type",
+        "status": "Status",
+        "enabled": "Enabled",
+        "disabled": "Disabled",
+        "routePattern": "Route pattern",
+        "oauthUnit": "OAuth unit",
+        "tokenName": "Token name",
+        "accountName": "Account",
+        "priority": "Priority",
+        "weight": "Weight",
+        "avgLatency": "Average latency",
+        "cooldownUntil": "Cooldown until",
+        "manualOverride": "Manual override",
+        "manualOverrideActive": "Active",
+        "manualOverrideNone": "None",
+        "modelsList": "Model list",
+        "notAvailable": "—",
+        "never": "Never"
       }
     },
     "connect": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1739,7 +1739,28 @@
         "latencyMax": "延迟 ≤",
         "latencyUnit": "ms",
         "latencyExample": "示例：",
-        "slowOnly": "仅慢请求"
+        "slowOnly": "仅慢请求",
+        "autoRefresh": {
+          "label": "自动刷新",
+          "interval5s": "5秒",
+          "interval15s": "15秒",
+          "interval30s": "30秒",
+          "intervalOff": "关闭"
+        },
+        "exportCsv": "导出 CSV",
+        "exportCsvToast": "已导出 {{count}} 条记录",
+        "exportCsvFailed": "导出 CSV 失败：{{message}}",
+        "exportCsvColumn": {
+          "timestamp": "时间戳",
+          "httpStatus": "HTTP 状态",
+          "status": "状态",
+          "model": "模型",
+          "account": "账号",
+          "site": "站点",
+          "duration": "耗时（毫秒）",
+          "tokens": "令牌数",
+          "estimatedCost": "预估成本"
+        }
       },
       "columns": {
         "createdAt": "时间",
@@ -2148,7 +2169,8 @@
         "priority": "优先级",
         "weight": "权重",
         "response": "响应",
-        "cooldown": "冷却"
+        "cooldown": "冷却",
+        "viewDetails": "查看详情"
       },
       "status": {
         "enabled": "已启用",
@@ -2160,6 +2182,33 @@
         "account": "账号",
         "token": "令牌",
         "oauth_unit": "OAuth 单元"
+      },
+      "detail": {
+        "title": "通道详情",
+        "description": "单个通道的只读路由健康视图。",
+        "sectionOverview": "概览",
+        "sectionHealth": "路由健康",
+        "sectionModels": "模型",
+        "name": "名称",
+        "site": "站点",
+        "type": "类型",
+        "status": "状态",
+        "enabled": "已启用",
+        "disabled": "已停用",
+        "routePattern": "路由匹配规则",
+        "oauthUnit": "OAuth 单元",
+        "tokenName": "令牌名称",
+        "accountName": "账号",
+        "priority": "优先级",
+        "weight": "权重",
+        "avgLatency": "平均延迟",
+        "cooldownUntil": "冷却至",
+        "manualOverride": "手动覆盖",
+        "manualOverrideActive": "已启用",
+        "manualOverrideNone": "无",
+        "modelsList": "模型列表",
+        "notAvailable": "—",
+        "never": "从未"
       }
     },
     "connect": {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -434,6 +434,7 @@ export type ProxyLogListItem = {
   modelRequested: string
   modelActual: string
   status: string
+  httpStatus?: number | null
   latencyMs: number
   isStream?: boolean | null
   firstByteLatencyMs?: number | null


### PR DESCRIPTION
## Summary
- **Proxy logs auto-refresh**: new toolbar toggle (Off / 5s / 15s / 30s) that persists to localStorage and drives `refetchInterval` on `useProxyLogs`, mirroring the observability auto-refresh pattern from #711.
- **Proxy logs CSV export**: new toolbar button that fetches the current filtered query with `limit=10000` and triggers a Blob download. Columns: timestamp, httpStatus, status, model, account, site, duration, tokens, estimatedCost.
- **Channels detail sheet**: new `ChannelDetailSheet` mirroring the model/route detail pattern, opened from a new eye-icon action column on the channels list. Renders status, cooldown, avg latency, priority/weight, and the route/model pattern — no extra fetch.
- **Type fix**: `ProxyLogListItem` now declares the optional `httpStatus` field the backend already returns via `SELECT pl.*` (the list type historically omitted it).

## Notes
- The proxy_logs table does not persist HTTP method or upstream path, so the CSV surfaces the columns the `/api/stats/proxy-logs` response actually returns (httpStatus included as a bonus column).
- No backend changes — both features work with the existing API responses.

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes (no new warnings in changed files)
- [ ] `bun run knip` passes (no unused exports)
- [ ] `bun run build:web` succeeds
- [ ] Proxy logs: toggle each auto-refresh cadence, verify background polling kicks in and the spinner icon animates; reload the page and confirm the persisted cadence is restored.
- [ ] Proxy logs: with filters applied, click Export CSV and verify the downloaded file contains the filtered rows (up to 10k) with the expected column headers; confirm the success/error toast fires.
- [ ] Channels: click the eye icon on a row, verify the detail sheet opens with the right name/site/type/status/cooldown/latency/models; close and reopen from a different row.
- [ ] Channels: confirm the actions column is sortable=false / hideable=false and the eye icon is keyboard-accessible.