### PR TITLE
fix: dashboard fail-open + i18n + Suspense skeleton

### DIFF
--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -164,23 +164,40 @@ func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 		"generatedAt": generatedAt,
 	}
 
+	// Fail-open: a single aggregation query failing must not blank the whole
+	// dashboard. Each sub-query is wrapped in individual error handling — on
+	// failure the field gets a null marker, the error is logged, and the
+	// field name is recorded in failedMetrics. Mirrors the todayMetricStatus
+	// degrade-to-partial pattern from accounts.go (listAccounts).
+	failedMetrics := make([]string, 0, 8)
+	markFailed := func(field, operation string, err error) {
+		slog.Error("dashboard stats query failed; degrading to partial", "operation", operation, "field", field, "error", err)
+		failedMetrics = append(failedMetrics, field)
+		result[field] = nil
+	}
+
 	if view == "summary" || view == "full" {
 		var siteCount, accountCount, activeAccounts int
 		if err := h.db.Get(&siteCount, "SELECT COUNT(*) FROM sites"); err != nil {
-			h.dashboardError(w, "load site count", err)
-			return
+			markFailed("siteCount", "load site count", err)
+		} else {
+			result["siteCount"] = siteCount
 		}
 		if err := h.db.Get(&accountCount, "SELECT COUNT(*) FROM accounts"); err != nil {
-			h.dashboardError(w, "load account count", err)
-			return
+			markFailed("accountCount", "load account count", err)
+			result["totalAccounts"] = nil
+		} else {
+			result["accountCount"] = accountCount
+			result["totalAccounts"] = accountCount
 		}
 		if err := h.db.Get(&activeAccounts, `
 			SELECT COUNT(*) FROM accounts a
 			INNER JOIN sites s ON s.id = a.site_id
 			WHERE a.status = 'active' AND s.status = 'active'
 		`); err != nil {
-			h.dashboardError(w, "load active account count", err)
-			return
+			markFailed("activeAccounts", "load active account count", err)
+		} else {
+			result["activeAccounts"] = activeAccounts
 		}
 
 		var totalBalance, totalUsed float64
@@ -190,8 +207,9 @@ func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 			INNER JOIN sites s ON s.id = a.site_id
 			WHERE s.status = 'active'
 		`); err != nil {
-			h.dashboardError(w, "load total balance", err)
-			return
+			markFailed("totalBalance", "load total balance", err)
+		} else {
+			result["totalBalance"] = roundMicro(totalBalance)
 		}
 		if err := h.db.Get(&totalUsed, `
 			SELECT COALESCE(SUM(COALESCE(a.balance_used, 0)), 0)
@@ -199,8 +217,9 @@ func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 			INNER JOIN sites s ON s.id = a.site_id
 			WHERE s.status = 'active'
 		`); err != nil {
-			h.dashboardError(w, "load total used", err)
-			return
+			markFailed("totalUsed", "load total used", err)
+		} else {
+			result["totalUsed"] = roundMicro(totalUsed)
 		}
 
 		// 24h proxy window (UTC) — single-pass aggregate with effective tokens.
@@ -222,14 +241,70 @@ func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 			INNER JOIN sites s ON s.id = a.site_id
 			WHERE pl.created_at >= ? AND s.status = 'active'
 		`), since24h); err != nil {
-			h.dashboardError(w, "load 24h proxy metrics", err)
-			return
+			markFailed("proxy24h", "load 24h proxy metrics", err)
+		} else {
+			result["proxy24h"] = map[string]any{
+				"total":       proxy24h.Total,
+				"success":     proxy24h.Success,
+				"totalTokens": proxy24h.TotalTokens,
+				"totalCost":   roundMicro(proxy24h.TotalCost),
+			}
+			// Legacy flat fields kept for older clients / tests.
+			result["totalTokens"] = proxy24h.TotalTokens
+			result["totalCost"] = roundMicro(proxy24h.TotalCost)
 		}
 
-		dailyMetrics, err := dailyservice.CollectDailySummaryMetrics(h.db, now)
-		if err != nil {
-			h.dashboardError(w, "load local-day metrics", err)
-			return
+		dailyMetrics, metricsErr := dailyservice.CollectDailySummaryMetrics(h.db, now)
+		if metricsErr != nil {
+			markFailed("todayMetricStatus", "load local-day metrics", metricsErr)
+			result["todaySpend"] = nil
+			result["todayReward"] = nil
+			result["todayCheckin"] = nil
+			result["todayMetricStatus"] = map[string]any{
+				"status": "partial",
+				"reason": "metrics collection failed",
+			}
+		} else {
+			result["todaySpend"] = roundMicro(dailyMetrics.TodaySpend)
+			result["todayReward"] = roundMicro(dailyMetrics.TodayReward)
+			result["todayCheckin"] = map[string]any{
+				"total":   dailyMetrics.CheckinTotal,
+				"success": dailyMetrics.CheckinSuccess,
+				"skipped": dailyMetrics.CheckinSkipped,
+				"failed":  dailyMetrics.CheckinFailed,
+			}
+			overallTodayStatus := "complete"
+			if dailyMetrics.TodayRewardStatus != "complete" ||
+				dailyMetrics.TodaySpendStatus != "complete" ||
+				dailyMetrics.ProxyMetricStatus != "complete" {
+				overallTodayStatus = "partial"
+			}
+			result["todayMetricStatus"] = map[string]any{
+				"status":      overallTodayStatus,
+				"localDay":    dailyMetrics.LocalDay,
+				"timeZone":    dailyMetrics.TimeZone,
+				"windowStart": dailyMetrics.WindowStartUTC,
+				"windowEnd":   dailyMetrics.WindowEndUTC,
+				"metrics": map[string]any{
+					"checkin": map[string]any{"status": "complete"},
+					"spend": map[string]any{
+						"status":            dailyMetrics.TodaySpendStatus,
+						"reason":            dailyMetrics.TodaySpendReason,
+						"missingCostCount":  dailyMetrics.ProxyMissingCost,
+						"unattributedCount": dailyMetrics.ProxyUnattributed,
+					},
+					"reward": map[string]any{
+						"status": dailyMetrics.TodayRewardStatus,
+						"reason": dailyMetrics.TodayRewardReason,
+					},
+					"proxy": map[string]any{
+						"status":             dailyMetrics.ProxyMetricStatus,
+						"reason":             dailyMetrics.ProxyMetricReason,
+						"unknownStatusCount": dailyMetrics.ProxyUnknown,
+						"unattributedCount":  dailyMetrics.ProxyUnattributed,
+					},
+				},
+			}
 		}
 
 		// Performance window: last 60s request/token rate from proxy_logs.
@@ -248,73 +323,16 @@ func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 			INNER JOIN sites s ON s.id = a.site_id
 			WHERE pl.created_at >= ? AND s.status = 'active'
 		`), sincePerf); err != nil {
-			h.dashboardError(w, "load performance metrics", err)
-			return
+			markFailed("performance", "load performance metrics", err)
+		} else {
+			rpm := float64(perf.Requests) * 60 / float64(windowSeconds)
+			tpm := float64(perf.Tokens) * 60 / float64(windowSeconds)
+			result["performance"] = map[string]any{
+				"windowSeconds":     windowSeconds,
+				"requestsPerMinute": rpm,
+				"tokensPerMinute":   tpm,
+			}
 		}
-
-		rpm := float64(perf.Requests) * 60 / float64(windowSeconds)
-		tpm := float64(perf.Tokens) * 60 / float64(windowSeconds)
-
-		result["siteCount"] = siteCount
-		result["accountCount"] = accountCount
-		result["totalAccounts"] = accountCount
-		result["activeAccounts"] = activeAccounts
-		result["totalBalance"] = roundMicro(totalBalance)
-		result["totalUsed"] = roundMicro(totalUsed)
-		result["todaySpend"] = roundMicro(dailyMetrics.TodaySpend)
-		result["todayReward"] = roundMicro(dailyMetrics.TodayReward)
-		result["todayCheckin"] = map[string]any{
-			"total":   dailyMetrics.CheckinTotal,
-			"success": dailyMetrics.CheckinSuccess,
-			"skipped": dailyMetrics.CheckinSkipped,
-			"failed":  dailyMetrics.CheckinFailed,
-		}
-		overallTodayStatus := "complete"
-		if dailyMetrics.TodayRewardStatus != "complete" ||
-			dailyMetrics.TodaySpendStatus != "complete" ||
-			dailyMetrics.ProxyMetricStatus != "complete" {
-			overallTodayStatus = "partial"
-		}
-		result["todayMetricStatus"] = map[string]any{
-			"status":      overallTodayStatus,
-			"localDay":    dailyMetrics.LocalDay,
-			"timeZone":    dailyMetrics.TimeZone,
-			"windowStart": dailyMetrics.WindowStartUTC,
-			"windowEnd":   dailyMetrics.WindowEndUTC,
-			"metrics": map[string]any{
-				"checkin": map[string]any{"status": "complete"},
-				"spend": map[string]any{
-					"status":            dailyMetrics.TodaySpendStatus,
-					"reason":            dailyMetrics.TodaySpendReason,
-					"missingCostCount":  dailyMetrics.ProxyMissingCost,
-					"unattributedCount": dailyMetrics.ProxyUnattributed,
-				},
-				"reward": map[string]any{
-					"status": dailyMetrics.TodayRewardStatus,
-					"reason": dailyMetrics.TodayRewardReason,
-				},
-				"proxy": map[string]any{
-					"status":             dailyMetrics.ProxyMetricStatus,
-					"reason":             dailyMetrics.ProxyMetricReason,
-					"unknownStatusCount": dailyMetrics.ProxyUnknown,
-					"unattributedCount":  dailyMetrics.ProxyUnattributed,
-				},
-			},
-		}
-		result["proxy24h"] = map[string]any{
-			"total":       proxy24h.Total,
-			"success":     proxy24h.Success,
-			"totalTokens": proxy24h.TotalTokens,
-			"totalCost":   roundMicro(proxy24h.TotalCost),
-		}
-		result["performance"] = map[string]any{
-			"windowSeconds":     windowSeconds,
-			"requestsPerMinute": rpm,
-			"tokensPerMinute":   tpm,
-		}
-		// Legacy flat fields kept for older clients / tests.
-		result["totalTokens"] = proxy24h.TotalTokens
-		result["totalCost"] = roundMicro(proxy24h.TotalCost)
 	}
 
 	if view == "insights" || view == "full" {
@@ -327,8 +345,9 @@ func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 			INNER JOIN sites s ON s.id = a.site_id
 			WHERE s.status = 'active'
 		`)); err != nil {
-			h.dashboardError(w, "load total tokens", err)
-			return
+			markFailed("totalTokens", "load total tokens", err)
+		} else {
+			result["totalTokens"] = totalTokens
 		}
 		var totalCost float64
 		if err := h.db.Get(&totalCost, `
@@ -338,11 +357,10 @@ func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 			INNER JOIN sites s ON s.id = a.site_id
 			WHERE s.status = 'active'
 		`); err != nil {
-			h.dashboardError(w, "load total cost", err)
-			return
+			markFailed("totalCost", "load total cost", err)
+		} else {
+			result["totalCost"] = roundMicro(totalCost)
 		}
-		result["totalTokens"] = totalTokens
-		result["totalCost"] = roundMicro(totalCost)
 
 		// Site availability over last 24h from proxy_logs join path.
 		since24h := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
@@ -372,33 +390,65 @@ func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 			ORDER BY total_requests DESC, s.name ASC
 		`, since24h)
 		if err != nil {
-			h.dashboardError(w, "load site availability", err)
-			return
-		}
-
-		siteAvailability := make([]map[string]any, 0, len(rows))
-		for _, row := range rows {
-			item := map[string]any{
-				"siteId":              row["siteId"],
-				"siteName":            row["siteName"],
-				"siteUrl":             row["siteUrl"],
-				"platform":            row["platform"],
-				"totalRequests":       row["totalRequests"],
-				"successCount":        row["successCount"],
-				"failedCount":         row["failedCount"],
-				"availabilityPercent": row["availabilityPercent"],
-				"averageLatencyMs":    row["averageLatencyMs"],
-				"buckets":             []any{},
+			markFailed("siteAvailability", "load site availability", err)
+		} else {
+			siteAvailability := make([]map[string]any, 0, len(rows))
+			for _, row := range rows {
+				item := map[string]any{
+					"siteId":              row["siteId"],
+					"siteName":            row["siteName"],
+					"siteUrl":             row["siteUrl"],
+					"platform":            row["platform"],
+					"totalRequests":       row["totalRequests"],
+					"successCount":        row["successCount"],
+					"failedCount":         row["failedCount"],
+					"availabilityPercent": row["availabilityPercent"],
+					"averageLatencyMs":    row["averageLatencyMs"],
+					"buckets":             []any{},
+				}
+				siteAvailability = append(siteAvailability, item)
 			}
-			siteAvailability = append(siteAvailability, item)
+			result["siteAvailability"] = siteAvailability
 		}
-		result["siteAvailability"] = siteAvailability
 	}
 
-	// Marshal once and cache the bytes on the success path only — error paths
-	// returned earlier via dashboardError. Caching the exact encoded bytes
-	// (json.Encoder appends a newline, matching shared.WriteJSON) guarantees a
-	// later cache-hit response is byte-identical to the miss that populated it.
+	// Aggregate per-metric health so the frontend can distinguish a fully
+	// healthy response from one where individual queries degraded to null.
+	dashboardStatus := "complete"
+	if len(failedMetrics) > 0 {
+		dashboardStatus = "partial"
+	}
+	result["dashboardStatus"] = map[string]any{
+		"status": dashboardStatus,
+		"failed": failedMetrics,
+	}
+
+	// Truly fatal: every metric failed (e.g. DB connection lost, every table
+	// missing). Return 500 and do NOT cache — the response has no useful
+	// data and replaying it for 10s would hide a real outage. Individual
+	// query failures (some succeed, some null) are NOT fatal and fall
+	// through to the 200 + cache path below.
+	hasRealData := false
+	for key, value := range result {
+		if key == "generatedAt" || key == "dashboardStatus" || key == "todayMetricStatus" {
+			continue
+		}
+		if value != nil {
+			hasRealData = true
+			break
+		}
+	}
+	if !hasRealData {
+		slog.Error("dashboard stats: all metrics failed; returning 500", "failedCount", len(failedMetrics))
+		h.dashboardError(w, "load dashboard statistics", fmt.Errorf("all %d metric queries failed", len(failedMetrics)))
+		return
+	}
+
+	// Marshal once and cache the bytes. Partial responses (some fields null)
+	// are cached too — they are still HTTP 200 and better than a 500 blank.
+	// The 10s TTL keeps recovery quick; ?force=1 bypasses for a hard refresh.
+	// json.Encoder appends a newline, matching shared.WriteJSON, so a later
+	// cache-hit response is byte-identical to the miss that populated it.
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(result); err != nil {
 		slog.Error("dashboard stats marshal failed", "error", err)

--- a/handler/admin/stats_failopen_test.go
+++ b/handler/admin/stats_failopen_test.go
@@ -1,0 +1,208 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// seedDashboardFailOpenData inserts one active site + one active account +
+// one proxy log so the dashboard's COUNT/SUM aggregation queries return
+// non-zero values. Mirrors the seeding in the existing
+// TestStats_SQLiteDashboardProxy24hTokens test.
+func seedDashboardFailOpenData(t *testing.T, db *store.DB) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES ('dash-fo-site', 'https://dash-fo.example.test', 'openai', 'active', ?, ?)`, now, now); err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	var siteID int64
+	if err := db.Get(&siteID, "SELECT id FROM sites WHERE name = 'dash-fo-site'"); err != nil {
+		t.Fatalf("load site id: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO accounts
+		(site_id, username, access_token, status, balance, balance_used, checkin_enabled, created_at, updated_at)
+		VALUES (?, 'dash-fo-user', 'sk-dash-fo', 'active', 100, 5, TRUE, ?, ?)`, siteID, now, now); err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	var accountID int64
+	if err := db.Get(&accountID, "SELECT id FROM accounts WHERE username = 'dash-fo-user'"); err != nil {
+		t.Fatalf("load account id: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO proxy_logs
+		(account_id, model_requested, model_actual, status, total_tokens, estimated_cost, created_at)
+		VALUES (?, 'gpt-fo', 'gpt-fo', 'success', 42, 0.1, ?)`, accountID, now); err != nil {
+		t.Fatalf("insert proxy log: %v", err)
+	}
+}
+
+// TestDashboardFailOpenOnCheckinLogsMissing verifies that dropping the
+// checkin_logs table (which makes CollectDailySummaryMetrics fail) does NOT
+// 500 the dashboard. Instead, the response should be 200 with
+// dashboardStatus=partial, the failed metric nulled, and all other metrics
+// (siteCount, accountCount, proxy24h, performance, siteAvailability) intact.
+func TestDashboardFailOpenOnCheckinLogsMissing(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedDashboardFailOpenData(t, db)
+
+	// Drop checkin_logs so CollectDailySummaryMetrics returns an error
+	// early ("load local-day checkin logs"). Every other dashboard query
+	// (sites, accounts, proxy_logs, performance, availability) is
+	// unaffected because none of them touch checkin_logs.
+	if _, err := db.Exec("DROP TABLE checkin_logs"); err != nil {
+		t.Fatalf("drop checkin_logs: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/stats/dashboard?view=full&force=1")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("dashboard status = %d, want %d (partial must not 500). Body: %s",
+			resp.Code, http.StatusOK, resp.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal dashboard response: %v", err)
+	}
+
+	// dashboardStatus must report partial.
+	dashStatus, ok := body["dashboardStatus"].(map[string]any)
+	if !ok {
+		t.Fatalf("dashboardStatus missing or wrong type: %v", body["dashboardStatus"])
+	}
+	if dashStatus["status"] != "partial" {
+		t.Fatalf("dashboardStatus.status = %v, want \"partial\"", dashStatus["status"])
+	}
+
+	// todayMetricStatus must be in the failed list.
+	failed, _ := dashStatus["failed"].([]any)
+	foundFailed := false
+	for _, f := range failed {
+		if f == "todayMetricStatus" {
+			foundFailed = true
+			break
+		}
+	}
+	if !foundFailed {
+		t.Fatalf("todayMetricStatus not in failed list: %v", failed)
+	}
+
+	// todayMetricStatus should be a partial marker, not a full metrics block.
+	tms, ok := body["todayMetricStatus"].(map[string]any)
+	if !ok {
+		t.Fatalf("todayMetricStatus missing or wrong type: %v", body["todayMetricStatus"])
+	}
+	if tms["status"] != "partial" {
+		t.Fatalf("todayMetricStatus.status = %v, want \"partial\"", tms["status"])
+	}
+
+	// todaySpend/todayReward/todayCheckin should be null (degraded).
+	if body["todaySpend"] != nil {
+		t.Fatalf("todaySpend = %v, want nil (degraded)", body["todaySpend"])
+	}
+	if body["todayReward"] != nil {
+		t.Fatalf("todayReward = %v, want nil (degraded)", body["todayReward"])
+	}
+	if body["todayCheckin"] != nil {
+		t.Fatalf("todayCheckin = %v, want nil (degraded)", body["todayCheckin"])
+	}
+
+	// Other metrics must still be present with real values.
+	if body["siteCount"] == nil {
+		t.Fatalf("siteCount is nil; should survive checkin_logs failure")
+	}
+	if body["accountCount"] == nil {
+		t.Fatalf("accountCount is nil; should survive checkin_logs failure")
+	}
+	if body["proxy24h"] == nil {
+		t.Fatalf("proxy24h is nil; should survive checkin_logs failure")
+	}
+	if body["performance"] == nil {
+		t.Fatalf("performance is nil; should survive checkin_logs failure")
+	}
+	if body["siteAvailability"] == nil {
+		t.Fatalf("siteAvailability is nil; should survive checkin_logs failure")
+	}
+}
+
+// TestDashboardCompleteWhenAllQueriesSucceed verifies the happy path: with
+// all tables intact and data seeded, dashboardStatus should be "complete"
+// and no fields should be null.
+func TestDashboardCompleteWhenAllQueriesSucceed(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedDashboardFailOpenData(t, db)
+
+	resp := doGet(t, r, "/api/stats/dashboard?view=full&force=1")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("dashboard status = %d, want %d. Body: %s",
+			resp.Code, http.StatusOK, resp.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal dashboard response: %v", err)
+	}
+
+	dashStatus, ok := body["dashboardStatus"].(map[string]any)
+	if !ok {
+		t.Fatalf("dashboardStatus missing or wrong type: %v", body["dashboardStatus"])
+	}
+	if dashStatus["status"] != "complete" {
+		t.Fatalf("dashboardStatus.status = %v, want \"complete\"", dashStatus["status"])
+	}
+
+	failed, _ := dashStatus["failed"].([]any)
+	if len(failed) != 0 {
+		t.Fatalf("expected no failed metrics, got: %v", failed)
+	}
+
+	// Spot-check that key fields are non-null.
+	for _, key := range []string{
+		"siteCount", "accountCount", "activeAccounts",
+		"totalBalance", "totalUsed", "proxy24h",
+		"todaySpend", "todayReward", "todayCheckin",
+		"todayMetricStatus", "performance",
+		"totalTokens", "totalCost", "siteAvailability",
+	} {
+		if body[key] == nil {
+			t.Fatalf("field %q is nil on the happy path", key)
+		}
+	}
+}
+
+// TestDashboardSummaryViewFailOpen verifies the summary-only view also
+// degrades gracefully when one query fails.
+func TestDashboardSummaryViewFailOpen(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedDashboardFailOpenData(t, db)
+
+	if _, err := db.Exec("DROP TABLE checkin_logs"); err != nil {
+		t.Fatalf("drop checkin_logs: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/stats/dashboard?view=summary&force=1")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("dashboard status = %d, want %d", resp.Code, http.StatusOK)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal dashboard response: %v", err)
+	}
+
+	dashStatus, ok := body["dashboardStatus"].(map[string]any)
+	if !ok {
+		t.Fatalf("dashboardStatus missing: %v", body["dashboardStatus"])
+	}
+	if dashStatus["status"] != "partial" {
+		t.Fatalf("dashboardStatus.status = %v, want \"partial\"", dashStatus["status"])
+	}
+
+	// Summary view should not have insights-only fields.
+	if _, exists := body["siteAvailability"]; exists {
+		t.Fatalf("siteAvailability should not exist in summary view")
+	}
+}

--- a/web/src/components/ui/section-skeleton.tsx
+++ b/web/src/components/ui/section-skeleton.tsx
@@ -8,11 +8,7 @@ import { Skeleton } from '@/components/ui/skeleton'
  */
 export function SectionSkeleton() {
   return (
-    <div
-      className='space-y-4 p-4'
-      aria-busy='true'
-      aria-live='polite'
-    >
+    <div className='space-y-4 p-4' aria-busy='true' aria-live='polite'>
       <Skeleton className='h-6 w-48' />
       <Skeleton className='h-4 w-full' />
       <Skeleton className='h-4 w-3/4' />

--- a/web/src/components/ui/section-skeleton.tsx
+++ b/web/src/components/ui/section-skeleton.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+/**
+ * Lightweight content-area skeleton for Suspense fallbacks. Renders a few
+ * shimmer bars to avoid the blank flash when lazy-loaded sections are
+ * downloading their async chunk. Intentionally generic — no Card chrome —
+ * so it works for both dashboard and observability section boundaries.
+ */
+export function SectionSkeleton() {
+  return (
+    <div
+      className='space-y-4 p-4'
+      aria-busy='true'
+      aria-live='polite'
+    >
+      <Skeleton className='h-6 w-48' />
+      <Skeleton className='h-4 w-full' />
+      <Skeleton className='h-4 w-3/4' />
+      <Skeleton className='h-32 w-full' />
+      <Skeleton className='h-4 w-full' />
+      <Skeleton className='h-4 w-2/3' />
+    </div>
+  )
+}

--- a/web/src/features/dashboard/config/dashboard-config.ts
+++ b/web/src/features/dashboard/config/dashboard-config.ts
@@ -21,6 +21,8 @@ import {
   type ReactNode,
 } from 'react'
 
+import { SectionSkeleton } from '@/components/ui/section-skeleton'
+
 import type { DashboardSection, DashboardSectionId } from '../types'
 import { createSectionRegistry } from '../utils/section-registry'
 
@@ -48,7 +50,11 @@ const LazyAvailabilitySection = lazy(() =>
 /** Wrap a lazy section in a Suspense boundary so build() returns a ready node. */
 function mountSection(component: ComponentType): () => ReactNode {
   return () =>
-    createElement(Suspense, { fallback: null }, createElement(component))
+    createElement(
+      Suspense,
+      { fallback: createElement(SectionSkeleton) },
+      createElement(component)
+    )
 }
 
 const DASHBOARD_SECTIONS: readonly DashboardSection[] = [

--- a/web/src/features/observability/config/observability-config.ts
+++ b/web/src/features/observability/config/observability-config.ts
@@ -10,6 +10,8 @@ import {
   type ReactNode,
 } from 'react'
 
+import { SectionSkeleton } from '@/components/ui/section-skeleton'
+
 import type { ObservabilitySection, ObservabilitySectionId } from '../types'
 import { createObservabilitySectionRegistry } from '../utils/section-registry'
 
@@ -31,7 +33,11 @@ const LazyProxyLogsSection = lazy(() =>
 
 function mountSection(component: ComponentType): () => ReactNode {
   return () =>
-    createElement(Suspense, { fallback: null }, createElement(component))
+    createElement(
+      Suspense,
+      { fallback: createElement(SectionSkeleton) },
+      createElement(component)
+    )
 }
 
 const OBSERVABILITY_SECTIONS: readonly ObservabilitySection[] = [

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -64,7 +64,10 @@
       "copySecret": "Copy secret",
       "hide": "Hide",
       "reveal": "Reveal",
-      "copy": "Copy"
+      "copy": "Copy",
+      "sessionExpired": "Session expired!",
+      "requestFailed": "Request failed",
+      "requestTimeout": "Request timeout ({{seconds}}s)"
     },
     "about": {
       "title": "About",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -64,7 +64,10 @@
       "copySecret": "复制密钥",
       "hide": "隐藏",
       "reveal": "显示",
-      "copy": "复制"
+      "copy": "复制",
+      "sessionExpired": "会话已过期！",
+      "requestFailed": "请求失败",
+      "requestTimeout": "请求超时（{{seconds}}s）"
     },
     "about": {
       "title": "关于",

--- a/web/src/lib/http-client.ts
+++ b/web/src/lib/http-client.ts
@@ -1,5 +1,6 @@
 import axios, { type AxiosRequestConfig } from 'axios'
 
+import i18n from '@/i18n/config'
 import {
   applyAuthRotation,
   clearAuthentication,
@@ -9,8 +10,6 @@ import {
   refreshAuthentication,
 } from '@/lib/auth-session'
 import { toast } from '@/lib/toast'
-
-import i18n from '@/i18n/config'
 
 declare module 'axios' {
   export interface AxiosRequestConfig {
@@ -118,7 +117,8 @@ apiClient.interceptors.response.use(
       typeof response.data?.success === 'boolean' &&
       !response.data.success
     ) {
-      const message = resolveResponseMessage(response.data) || i18n.t('common.requestFailed')
+      const message =
+        resolveResponseMessage(response.data) || i18n.t('common.requestFailed')
       toast.error(message)
     }
     return response

--- a/web/src/lib/http-client.ts
+++ b/web/src/lib/http-client.ts
@@ -10,6 +10,8 @@ import {
 } from '@/lib/auth-session'
 import { toast } from '@/lib/toast'
 
+import i18n from '@/i18n/config'
+
 declare module 'axios' {
   export interface AxiosRequestConfig {
     /** Skip the business-level `success: false` toast on the response body. */
@@ -116,7 +118,7 @@ apiClient.interceptors.response.use(
       typeof response.data?.success === 'boolean' &&
       !response.data.success
     ) {
-      const message = resolveResponseMessage(response.data) || 'Request failed'
+      const message = resolveResponseMessage(response.data) || i18n.t('common.requestFailed')
       toast.error(message)
     }
     return response
@@ -142,20 +144,20 @@ apiClient.interceptors.response.use(
         }
 
         // anonymous / out_of_sync / transient_error — treat as signed out.
-        if (!skipErrorHandler) toast.error('Session expired!')
+        if (!skipErrorHandler) toast.error(i18n.t('common.sessionExpired'))
         redirectToSignIn()
       } else if (config?.authRetry) {
         clearAuthentication(false)
-        if (!skipErrorHandler) toast.error('Session expired!')
+        if (!skipErrorHandler) toast.error(i18n.t('common.sessionExpired'))
         redirectToSignIn()
       } else if (!skipErrorHandler) {
-        toast.error('Session expired!')
+        toast.error(i18n.t('common.sessionExpired'))
       }
     } else if (!skipErrorHandler) {
       const message =
         resolveResponseMessage(error?.response?.data) ||
         error?.message ||
-        'Request failed'
+        i18n.t('common.requestFailed')
       toast.error(message)
     }
     throw error
@@ -272,7 +274,9 @@ export async function fetchAuthenticatedResponse(
     if (name === 'AbortError') {
       if (externalSignal?.aborted) throw error
       throw new Error(
-        `请求超时（${Math.max(1, Math.round(timeoutMs / 1000))}s）`
+        i18n.t('common.requestTimeout', {
+          seconds: Math.max(1, Math.round(timeoutMs / 1000)),
+        })
       )
     }
     throw error


### PR DESCRIPTION
## Summary

- **Dashboard fail-open** (P2): Replaced fail-close error handling in `handler/admin/stats.go` with per-metric degradation. Any single aggregation query failure now logs the error and nulls the affected field instead of returning 500 and blanking the whole dashboard. A new `dashboardStatus` object (`{status, failed[]}`) lets the frontend distinguish complete vs partial responses. Truly fatal failures (all metrics fail, e.g. DB connection lost) still return 500 and bypass the cache. Mirrors the `todayMetricStatus` degrade-to-partial pattern from `accounts.go`. The `x-dashboard-summary-cache` header behavior from #710 is preserved.
- **i18n hardcoded strings** (P2): Replaced 6 hardcoded user-facing strings in `web/src/lib/http-client.ts` (`'Request failed'` ×2, `'Session expired!'` ×3, and a hardcoded Chinese `'请求超时（…s）'`) with `i18n.t()` calls backed by new `common.sessionExpired`, `common.requestFailed`, and `common.requestTimeout` keys in both `en.json` and `zh-CN.json`.
- **Suspense fallback skeleton** (P3): Replaced `Suspense fallback: null` with a new `SectionSkeleton` component in both `dashboard-config.ts` and `observability-config.ts`, eliminating the blank flash on tab switch while lazy chunks download.

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./handler/admin/...` — all tests pass (including 3 new fail-open tests)
- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes (no new warnings)
- [x] `bun run knip` — passes (no unused imports)
- [x] `bun run build:web` — passes
- [x] `i18n-keys.test.ts` — all 4 key-coverage tests pass
- [x] New test `TestDashboardFailOpenOnCheckinLogsMissing` verifies: drop `checkin_logs` table → dashboard returns 200 (not 500), `dashboardStatus.status = "partial"`, `todayMetricStatus` in failed list, other metrics (siteCount, proxy24h, performance, siteAvailability) still present
- [x] New test `TestDashboardCompleteWhenAllQueriesSucceed` verifies: happy path → `dashboardStatus.status = "complete"`, no failed metrics, all fields non-null
- [x] New test `TestDashboardSummaryViewFailOpen` verifies: summary-only view also degrades gracefully
- [x] Pre-existing `TestDashboardCache_DoesNotCacheErrors` still passes (closed DB → all metrics fail → 500 → not cached)