### PR TITLE
fix: admin error request_id + ListSites perf + validation context

### DIFF
--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -176,19 +176,19 @@ func (h *accountsHandler) listAccounts(w http.ResponseWriter, r *http.Request) {
 func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountCreatePayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid account payload.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid account payload: " + err.Error())
 		return
 	}
 
 	if body.SiteID <= 0 {
-		writeError(w, http.StatusBadRequest, "Invalid siteId. Expected positive number.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid siteId. Expected positive number.")
 		return
 	}
 
 	// Check site exists
 	var site store.Site
 	if err := h.db.Get(&site, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), body.SiteID); err != nil {
-		writeError(w, http.StatusBadRequest, "site not found")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "site not found")
 		return
 	}
 
@@ -221,7 +221,7 @@ func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if len(requestedTokens) == 0 {
-		writeError(w, http.StatusBadRequest, "请填写 Token")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "请填写 Token")
 		return
 	}
 
@@ -562,27 +562,27 @@ func (h *accountsHandler) createSingleAccount(ctx context.Context, body payloads
 func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountLoginPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid login payload.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid login payload: " + err.Error())
 		return
 	}
 
 	if body.SiteID <= 0 {
-		writeError(w, http.StatusBadRequest, "Invalid siteId. Expected positive number.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid siteId. Expected positive number.")
 		return
 	}
 	if strings.TrimSpace(body.Username) == "" {
-		writeError(w, http.StatusBadRequest, "Invalid username. Expected string.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid username. Expected string.")
 		return
 	}
 	if strings.TrimSpace(body.Password) == "" {
-		writeError(w, http.StatusBadRequest, "Invalid password. Expected string.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid password. Expected string.")
 		return
 	}
 
 	// Get site
 	var site store.Site
 	if err := h.db.Get(&site, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), body.SiteID); err != nil {
-		writeError(w, http.StatusNotFound, "site not found")
+		writeErrorWithRequest(w, r, http.StatusNotFound, "site not found")
 		return
 	}
 
@@ -596,7 +596,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 	loginResult, err := adp.Login(ctx, site.URL, body.Username, body.Password, nil, service.BuildPlatformProxyConfigForToken(h.cfg, &site, body.Username))
 	if err != nil {
 		slog.Warn("Account login failed", "err", err, "site_id", site.ID, "platform", site.Platform)
-		writeError(w, http.StatusUnauthorized, "login failed")
+		writeErrorWithRequest(w, r, http.StatusUnauthorized, "login failed")
 		return
 	}
 	if loginResult == nil || !loginResult.Success || strings.TrimSpace(loginResult.AccessToken) == "" {
@@ -604,7 +604,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 		if loginResult != nil && strings.TrimSpace(loginResult.Message) != "" {
 			message = strings.TrimSpace(loginResult.Message)
 		}
-		writeError(w, http.StatusUnauthorized, message)
+		writeErrorWithRequest(w, r, http.StatusUnauthorized, message)
 		return
 	}
 	loginAccessToken := strings.TrimSpace(loginResult.AccessToken)
@@ -625,7 +625,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 	// Encrypt password for autoRelogin
 	passwordCipher, encErr := service.EncryptPassword(h.cfg, body.Password)
 	if encErr != nil {
-		writeError(w, http.StatusInternalServerError, "Failed to encrypt password.")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "Failed to encrypt password.")
 		return
 	}
 
@@ -648,7 +648,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 			loginAccessToken, true, extraConfigStr, now, existing.ID,
 		); err != nil {
 			slog.Error("Failed to update login account", "err", err, "account_id", existing.ID)
-			writeError(w, http.StatusInternalServerError, "Failed to save account.")
+			writeErrorWithRequest(w, r, http.StatusInternalServerError, "Failed to save account.")
 			return
 		}
 	} else {
@@ -660,7 +660,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 			body.SiteID, body.Username, loginAccessToken, true, false, sortOrder, extraConfigStr, now, now,
 		); err != nil {
 			slog.Error("Failed to insert login account", "err", err, "site_id", body.SiteID)
-			writeError(w, http.StatusInternalServerError, "Failed to save account.")
+			writeErrorWithRequest(w, r, http.StatusInternalServerError, "Failed to save account.")
 			return
 		}
 	}
@@ -669,7 +669,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 	var loginAcct store.Account
 	if err := h.db.Get(&loginAcct, h.db.Rebind("SELECT * FROM accounts WHERE site_id = ? AND username = ?"), body.SiteID, body.Username); err != nil {
 		slog.Error("Failed to load login account", "err", err, "site_id", body.SiteID)
-		writeError(w, http.StatusInternalServerError, "Failed to load account.")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "Failed to load account.")
 		return
 	}
 	loginAcctMap := map[string]any{
@@ -703,12 +703,12 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountVerifyTokenPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid verify-token payload.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid verify-token payload: " + err.Error())
 		return
 	}
 
 	if body.SiteID <= 0 {
-		writeError(w, http.StatusBadRequest, "Invalid siteId. Expected positive number.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid siteId. Expected positive number.")
 		return
 	}
 
@@ -717,14 +717,14 @@ func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 		accessToken = strings.TrimSpace(*body.AccessToken)
 	}
 	if accessToken == "" {
-		writeError(w, http.StatusBadRequest, "Token 不能为空")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Token 不能为空")
 		return
 	}
 
 	// Get site
 	var site store.Site
 	if err := h.db.Get(&site, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), body.SiteID); err != nil {
-		writeError(w, http.StatusNotFound, "site not found")
+		writeErrorWithRequest(w, r, http.StatusNotFound, "site not found")
 		return
 	}
 
@@ -898,7 +898,7 @@ func (h *accountsHandler) rebindSession(w http.ResponseWriter, r *http.Request) 
 
 	var body payloads.AccountRebindSessionPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid rebind payload.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid rebind payload: " + err.Error())
 		return
 	}
 
@@ -907,13 +907,13 @@ func (h *accountsHandler) rebindSession(w http.ResponseWriter, r *http.Request) 
 		nextAccessToken = strings.TrimSpace(*body.AccessToken)
 	}
 	if nextAccessToken == "" {
-		writeError(w, http.StatusBadRequest, "请提供新的 Session Token")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "请提供新的 Session Token")
 		return
 	}
 
 	row, err := service.GetAccountWithSiteByID(h.db, accountID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "账号不存在")
+		writeErrorWithRequest(w, r, http.StatusNotFound, "账号不存在")
 		return
 	}
 
@@ -935,14 +935,14 @@ func (h *accountsHandler) rebindSession(w http.ResponseWriter, r *http.Request) 
 		h.db.Rebind("UPDATE accounts SET access_token = ?, status = 'active', extra_config = ?, updated_at = ? WHERE id = ?"),
 		nextAccessToken, extraConfigStr, now, accountID,
 	); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to update account")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to update account")
 		return
 	}
 
 	// Fetch updated account for response
 	var rebindAcct store.Account
 	if err := h.db.Get(&rebindAcct, h.db.Rebind("SELECT * FROM accounts WHERE id = ?"), accountID); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to read updated account")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to read updated account")
 		return
 	}
 	rebindAcctMap := map[string]any{
@@ -982,7 +982,7 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 
 	var body payloads.AccountUpdatePayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid account payload."})
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid account payload: " + err.Error()})
 		return
 	}
 

--- a/handler/admin/channels.go
+++ b/handler/admin/channels.go
@@ -55,7 +55,7 @@ func (h *tokenRoutesHandler) listChannels(w http.ResponseWriter, r *http.Request
 		LEFT JOIN account_tokens at ON rc.token_id = at.id
 		ORDER BY rc.id ASC`)); err != nil {
 		slog.Error("channels list failed", "error", err)
-		writeError(w, http.StatusInternalServerError, "加载通道列表失败")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "加载通道列表失败")
 		return
 	}
 

--- a/handler/admin/helpers.go
+++ b/handler/admin/helpers.go
@@ -233,7 +233,7 @@ func pathID(w http.ResponseWriter, r *http.Request) (int64, bool) {
 	idStr := strings.TrimSpace(chi.URLParam(r, "id"))
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id <= 0 {
-		writeError(w, http.StatusBadRequest, "无效的 ID")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "无效的 ID")
 		return 0, false
 	}
 	return id, true

--- a/handler/admin/response_errors.go
+++ b/handler/admin/response_errors.go
@@ -4,11 +4,34 @@ import (
 	"net/http"
 
 	"github.com/deliciousbuding/metapi-go/handler/shared"
+	"github.com/go-chi/chi/v5/middleware"
 )
 
 // writeError writes a unified admin API error: non-2xx status + camelCase JSON
 // {"error":"..."}. Prefer this over writeJSON(..., {"success":false,...}) for
 // mutation failure paths so clients never see HTTP 200 with an error body.
+//
+// writeError does NOT populate request_id because it has no request access.
+// Use writeErrorWithRequest for any call site that has the *http.Request so
+// API consumers can correlate error bodies with server logs (the proxy path
+// already emits request_id via handler/proxy/router.go).
 func writeError(w http.ResponseWriter, code int, message string) {
 	shared.WriteError(w, code, message)
+}
+
+// writeErrorWithRequest writes a unified admin API error and, when a request
+// ID is present in the request context (set by router.WithRequestID via
+// chi's middleware.RequestID), mirrors it into the JSON body as the additive
+// "request_id" field and onto the X-Request-Id response header when unset.
+//
+// Backward compatibility: when no request ID is in context (e.g. ad-hoc
+// callers without the request-id middleware), the request_id field is
+// omitted entirely (omitempty) — never serialized as null.
+func writeErrorWithRequest(w http.ResponseWriter, r *http.Request, code int, message string) {
+	requestID := middleware.GetReqID(r.Context())
+	shared.WriteAPIError(w, &shared.APIError{
+		Code:      code,
+		Message:   message,
+		RequestID: requestID,
+	})
 }

--- a/handler/admin/response_errors_test.go
+++ b/handler/admin/response_errors_test.go
@@ -1,0 +1,181 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// TestWriteErrorWithRequest_IncludesRequestID verifies that the new helper
+// populates the additive request_id field in the JSON body and mirrors it
+// onto the X-Request-Id response header when a request ID is in context.
+// This is the core of Fix 1: admin error bodies must carry request_id so
+// API consumers can correlate errors with server logs (the proxy path
+// already did this via handler/proxy/router.go).
+func TestWriteErrorWithRequest_IncludesRequestID(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sites", nil)
+	req = req.WithContext(context.WithValue(req.Context(), middleware.RequestIDKey, "req-test-456"))
+
+	writeErrorWithRequest(rec, req, http.StatusBadRequest, "Invalid site payload: missing field 'name'")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if got := rec.Header().Get("X-Request-Id"); got != "req-test-456" {
+		t.Fatalf("X-Request-Id header = %q, want req-test-456", got)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, rec.Body.String())
+	}
+	if body["error"] != "Invalid site payload: missing field 'name'" {
+		t.Fatalf("error field = %v", body["error"])
+	}
+	if body["request_id"] != "req-test-456" {
+		t.Fatalf("request_id = %v, want req-test-456", body["request_id"])
+	}
+}
+
+// TestWriteErrorWithRequest_OmitsRequestIDWhenAbsent verifies backward
+// compatibility: when no request ID is in context (e.g. ad-hoc callers
+// without the request-id middleware), the request_id field is omitted
+// entirely (omitempty) — never serialized as null.
+func TestWriteErrorWithRequest_OmitsRequestIDWhenAbsent(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sites", nil)
+
+	writeErrorWithRequest(rec, req, http.StatusBadRequest, "bad request")
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, rec.Body.String())
+	}
+	if _, ok := body["request_id"]; ok {
+		t.Fatalf("request_id should be omitted when absent, got %v", body["request_id"])
+	}
+	if body["error"] != "bad request" {
+		t.Fatalf("error = %v, want 'bad request'", body["error"])
+	}
+}
+
+// TestWriteErrorWithRequest_DoesNotOverrideExistingHeader verifies that an
+// ingress-set X-Request-Id header is preserved (not overwritten) while the
+// body still carries the context request id. Mirrors the proxy path behavior.
+func TestWriteErrorWithRequest_DoesNotOverrideExistingHeader(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.Header().Set("X-Request-Id", "ingress-id")
+	req := httptest.NewRequest("GET", "/api/sites", nil)
+	req = req.WithContext(context.WithValue(req.Context(), middleware.RequestIDKey, "ctx-id"))
+
+	writeErrorWithRequest(rec, req, http.StatusBadGateway, "boom")
+
+	if got := rec.Header().Get("X-Request-Id"); got != "ingress-id" {
+		t.Fatalf("X-Request-Id = %q, want ingress-id (not overridden)", got)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["request_id"] != "ctx-id" {
+		t.Fatalf("body request_id = %v, want ctx-id", body["request_id"])
+	}
+}
+
+// TestSites_Create_MalformedJSON_RequestIDAndFieldContext is an integration
+// test covering Fix 1 (request_id in admin error body) + Fix 3 (generic
+// decode errors include the parse error context). It sends malformed JSON
+// to POST /api/sites with a known request ID injected into the context and
+// verifies the 400 response carries both the request_id and the decode
+// error suffix.
+func TestSites_Create_MalformedJSON_RequestIDAndFieldContext(t *testing.T) {
+	_, r := setupSitesTest(t)
+
+	req := httptest.NewRequest("POST", "/api/sites", strings.NewReader("{bad json"))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.RequestIDKey, "req-int-789"))
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("X-Request-Id"); got != "req-int-789" {
+		t.Fatalf("X-Request-Id = %q, want req-int-789", got)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, rec.Body.String())
+	}
+	if body["request_id"] != "req-int-789" {
+		t.Fatalf("request_id = %v, want req-int-789", body["request_id"])
+	}
+	errMsg, _ := body["error"].(string)
+	if !strings.HasPrefix(errMsg, "Invalid site payload:") {
+		t.Fatalf("error message should include 'Invalid site payload:' prefix (Fix 3), got %q", errMsg)
+	}
+	if !strings.Contains(errMsg, "invalid character") {
+		t.Fatalf("error message should include decode error context, got %q", errMsg)
+	}
+}
+
+// TestRoutes_Create_MalformedJSON_FieldContext verifies Fix 3 for the
+// token-routes create path: the generic "Invalid request body" message
+// now includes the decode error context (e.g. the JSON parse failure).
+func TestRoutes_Create_MalformedJSON_FieldContext(t *testing.T) {
+	_, r := setupTokenRoutesTest(t)
+
+	req := httptest.NewRequest("POST", "/api/routes", strings.NewReader("not json at all"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, rec.Body.String())
+	}
+	errMsg, _ := body["error"].(string)
+	if !strings.HasPrefix(errMsg, "Invalid request body:") {
+		t.Fatalf("error message should include 'Invalid request body:' prefix (Fix 3), got %q", errMsg)
+	}
+}
+
+// TestSites_Create_EmptyName_RequestIDInError verifies Fix 1 for a
+// field-specific validation error (not just the decode path): the 400 for a
+// missing 'name' field must also carry the request_id so the caller can
+// correlate the validation rejection with server logs.
+func TestSites_Create_EmptyName_RequestIDInError(t *testing.T) {
+	_, r := setupSitesTest(t)
+
+	body := map[string]any{"name": "  ", "url": "https://api.openai.com"}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/api/sites", strings.NewReader(string(raw)))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.RequestIDKey, "req-name-011"))
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, rec.Body.String())
+	}
+	if resp["request_id"] != "req-name-011" {
+		t.Fatalf("request_id = %v, want req-name-011", resp["request_id"])
+	}
+	if errMsg, _ := resp["error"].(string); !strings.Contains(errMsg, "name") {
+		t.Fatalf("error message should name the failing field, got %q", errMsg)
+	}
+}

--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -49,7 +49,7 @@ func (h *sitesHandler) listSites(w http.ResponseWriter, r *http.Request) {
 	sites, err := service.ListSites(h.db)
 	if err != nil {
 		slog.Error("Failed to load sites", "err", err)
-		writeError(w, http.StatusInternalServerError, "Failed to load sites")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "Failed to load sites")
 		return
 	}
 	writeJSON(w, http.StatusOK, sites)
@@ -60,57 +60,57 @@ func (h *sitesHandler) listSites(w http.ResponseWriter, r *http.Request) {
 func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 	var body payloads.SiteCreatePayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid site payload.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid site payload: " + err.Error())
 		return
 	}
 
 	// Validate name and url
 	if strings.TrimSpace(body.Name) == "" {
-		writeError(w, http.StatusBadRequest, "Invalid name. Expected non-empty string.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid name. Expected non-empty string.")
 		return
 	}
 	if strings.TrimSpace(body.URL) == "" {
-		writeError(w, http.StatusBadRequest, "Invalid url. Expected non-empty string.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid url. Expected non-empty string.")
 		return
 	}
 	if service.IsForbiddenSiteTargetURL(body.URL) {
-		writeError(w, http.StatusBadRequest, "Invalid url. Cloud metadata / link-local targets are not allowed.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid url. Cloud metadata / link-local targets are not allowed.")
 		return
 	}
 
 	// Normalize values
 	normalizedStatus := normalizeSiteStatusString(body.Status)
 	if body.Status != nil && normalizedStatus == "" {
-		writeError(w, http.StatusBadRequest, "Invalid site status. Expected active or disabled.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid site status. Expected active or disabled.")
 		return
 	}
 	if body.UseSystemProxy != nil {
 		if !boolPtrValid(body.UseSystemProxy) {
-			writeError(w, http.StatusBadRequest, "Invalid useSystemProxy value. Expected boolean.")
+			writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid useSystemProxy value. Expected boolean.")
 			return
 		}
 	}
 	if body.ProxyURL != nil && *body.ProxyURL != "" && !service.IsValidProxyURL(*body.ProxyURL) {
-		writeError(w, http.StatusBadRequest, "Invalid proxyUrl. Expected a valid http(s)/socks proxy URL.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid proxyUrl. Expected a valid http(s)/socks proxy URL.")
 		return
 	}
 	if body.ExternalCheckinURL != nil && *body.ExternalCheckinURL != "" && !service.IsValidHTTPURL(*body.ExternalCheckinURL) {
-		writeError(w, http.StatusBadRequest, "Invalid externalCheckinUrl. Expected a valid http(s) URL.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid externalCheckinUrl. Expected a valid http(s) URL.")
 		return
 	}
 	normalizedPinned := body.IsPinned
 	if body.IsPinned != nil && !boolPtrValid(body.IsPinned) {
-		writeError(w, http.StatusBadRequest, "Invalid isPinned value. Expected boolean.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid isPinned value. Expected boolean.")
 		return
 	}
 	normalizedSortOrder := service.NormalizeSortOrder(body.SortOrder)
 	if body.SortOrder != nil && normalizedSortOrder == nil {
-		writeError(w, http.StatusBadRequest, "Invalid sortOrder value. Expected non-negative integer.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid sortOrder value. Expected non-negative integer.")
 		return
 	}
 	normalizedWeight := service.NormalizeGlobalWeight(body.GlobalWeight)
 	if body.GlobalWeight != nil && normalizedWeight == nil {
-		writeError(w, http.StatusBadRequest, "Invalid globalWeight value. Expected a positive number.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid globalWeight value. Expected a positive number.")
 		return
 	}
 	if body.MaxConcurrency != nil && *body.MaxConcurrency < 0 {
@@ -119,7 +119,7 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.CustomHeaders != nil && *body.CustomHeaders != "" {
 		if !json.Valid([]byte(*body.CustomHeaders)) {
-			writeError(w, http.StatusBadRequest, "Invalid customHeaders.")
+			writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid customHeaders.")
 			return
 		}
 	}
@@ -127,7 +127,7 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 	// Normalize API endpoints
 	eps, err := normalizeAPIEndpointsInput(body.APIEndpoints)
 	if err != "" {
-		writeError(w, http.StatusBadRequest, err)
+		writeErrorWithRequest(w, r, http.StatusBadRequest, err)
 		return
 	}
 
@@ -144,7 +144,7 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if platform == "" {
-		writeError(w, http.StatusBadRequest, "Could not detect platform. Please specify manually.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Could not detect platform. Please specify manually.")
 		return
 	}
 
@@ -155,7 +155,7 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 	}
 	if initializationPresetID != "" {
 		if err := service.ValidateSiteInitializationPreset(initializationPresetID, platform, body.URL); err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
+			writeErrorWithRequest(w, r, http.StatusBadRequest, err.Error())
 			return
 		}
 	} else {
@@ -171,7 +171,7 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 	var existingCount int
 	h.db.Get(&existingCount, h.db.Rebind("SELECT COUNT(*) FROM sites WHERE platform = ? AND url = ?"), platform, canonicalURL)
 	if existingCount > 0 {
-		writeError(w, http.StatusConflict, fmt.Sprintf("A %s site with URL %s already exists.", platform, canonicalURL))
+		writeErrorWithRequest(w, r, http.StatusConflict, fmt.Sprintf("A %s site with URL %s already exists.", platform, canonicalURL))
 		return
 	}
 
@@ -233,23 +233,23 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 	if createErr != nil {
 		// Check for unique constraint violation
 		if isUniqueConstraintError(createErr) {
-			writeError(w, http.StatusConflict, fmt.Sprintf("A %s site with URL %s already exists.", platform, canonicalURL))
+			writeErrorWithRequest(w, r, http.StatusConflict, fmt.Sprintf("A %s site with URL %s already exists.", platform, canonicalURL))
 			return
 		}
 		slog.Error("CreateSite failed", "err", createErr, "platform", platform, "url", canonicalURL)
-		writeError(w, http.StatusInternalServerError, "Create site failed")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "Create site failed")
 		return
 	}
 
 	result, loadErr := service.LoadSiteWithEndpoints(h.db, createdID)
 	if loadErr != nil {
 		slog.Error("LoadSiteWithEndpoints after create failed", "err", loadErr, "site_id", createdID)
-		writeError(w, http.StatusInternalServerError, "Create site failed")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "Create site failed")
 		return
 	}
 	if result == nil {
 		slog.Error("LoadSiteWithEndpoints returned nil after create", "site_id", createdID)
-		writeError(w, http.StatusInternalServerError, "Create site failed")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "Create site failed")
 		return
 	}
 	if initializationPresetID != "" {
@@ -270,17 +270,17 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	var existing store.Site
 	err := h.db.Get(&existing, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), id)
 	if err == sql.ErrNoRows {
-		writeError(w, http.StatusNotFound, "Site not found")
+		writeErrorWithRequest(w, r, http.StatusNotFound, "Site not found")
 		return
 	} else if err != nil {
 		slog.Error("Failed to load site for update", "err", err, "site_id", id)
-		writeError(w, http.StatusInternalServerError, "Failed to load site")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "Failed to load site")
 		return
 	}
 
 	var body payloads.SiteUpdatePayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid site payload.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid site payload: " + err.Error())
 		return
 	}
 
@@ -289,18 +289,18 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	// Validate each field
 	if body.Name != nil {
 		if strings.TrimSpace(*body.Name) == "" {
-			writeError(w, http.StatusBadRequest, "Invalid name. Expected non-empty string.")
+			writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid name. Expected non-empty string.")
 			return
 		}
 		updates["name"] = *body.Name
 	}
 	if body.URL != nil {
 		if strings.TrimSpace(*body.URL) == "" {
-			writeError(w, http.StatusBadRequest, "Invalid url. Expected non-empty string.")
+			writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid url. Expected non-empty string.")
 			return
 		}
 		if service.IsForbiddenSiteTargetURL(*body.URL) {
-			writeError(w, http.StatusBadRequest, "Invalid url. Cloud metadata / link-local targets are not allowed.")
+			writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid url. Cloud metadata / link-local targets are not allowed.")
 			return
 		}
 		updates["url"] = service.CanonicalizeSiteURL(*body.URL)
@@ -308,14 +308,14 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	if body.Platform != nil {
 		p := strings.TrimSpace(strings.ToLower(*body.Platform))
 		if p == "" {
-			writeError(w, http.StatusBadRequest, "Invalid platform. Expected non-empty string.")
+			writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid platform. Expected non-empty string.")
 			return
 		}
 		updates["platform"] = p
 	}
 	if body.ProxyURL != nil {
 		if *body.ProxyURL != "" && !service.IsValidProxyURL(*body.ProxyURL) {
-			writeError(w, http.StatusBadRequest, "Invalid proxyUrl. Expected a valid http(s)/socks proxy URL.")
+			writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid proxyUrl. Expected a valid http(s)/socks proxy URL.")
 			return
 		}
 		updates["proxyUrl"] = service.NormalizeNullable(body.ProxyURL)
@@ -331,7 +331,7 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.ExternalCheckinURL != nil {
 		if *body.ExternalCheckinURL != "" && !service.IsValidHTTPURL(*body.ExternalCheckinURL) {
-			writeError(w, http.StatusBadRequest, "Invalid externalCheckinUrl. Expected a valid http(s) URL.")
+			writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid externalCheckinUrl. Expected a valid http(s) URL.")
 			return
 		}
 		updates["externalCheckinUrl"] = service.NormalizeNullable(body.ExternalCheckinURL)
@@ -339,7 +339,7 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	if body.Status != nil {
 		ns := normalizeSiteStatusString(body.Status)
 		if ns == "" {
-			writeError(w, http.StatusBadRequest, "Invalid site status. Expected active or disabled.")
+			writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid site status. Expected active or disabled.")
 			return
 		}
 		updates["status"] = ns
@@ -350,7 +350,7 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	if body.SortOrder != nil {
 		so := service.NormalizeSortOrder(body.SortOrder)
 		if so == nil {
-			writeError(w, http.StatusBadRequest, "Invalid sortOrder value. Expected non-negative integer.")
+			writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid sortOrder value. Expected non-negative integer.")
 			return
 		}
 		updates["sortOrder"] = int64(*so)
@@ -358,7 +358,7 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	if body.GlobalWeight != nil {
 		gw := service.NormalizeGlobalWeight(body.GlobalWeight)
 		if gw == nil {
-			writeError(w, http.StatusBadRequest, "Invalid globalWeight value. Expected a positive number.")
+			writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid globalWeight value. Expected a positive number.")
 			return
 		}
 		updates["globalWeight"] = *gw
@@ -395,7 +395,7 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	if body.APIEndpoints != nil {
 		eps, errMsg := normalizeAPIEndpointsInput(body.APIEndpoints)
 		if errMsg != "" {
-			writeError(w, http.StatusBadRequest, errMsg)
+			writeErrorWithRequest(w, r, http.StatusBadRequest, errMsg)
 			return
 		}
 		now := time.Now().UTC().Format(time.RFC3339)
@@ -422,18 +422,18 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 		var conflictCount int
 		h.db.Get(&conflictCount, h.db.Rebind("SELECT COUNT(*) FROM sites WHERE platform = ? AND url = ? AND id != ?"), nextPlatform, nextURL, id)
 		if conflictCount > 0 {
-			writeError(w, http.StatusConflict, fmt.Sprintf("A %s site with URL %s already exists.", nextPlatform, nextURL))
+			writeErrorWithRequest(w, r, http.StatusConflict, fmt.Sprintf("A %s site with URL %s already exists.", nextPlatform, nextURL))
 			return
 		}
 	}
 
 	if err := service.UpdateSite(h.db, id, updates); err != nil {
 		if isUniqueConstraintError(err) {
-			writeError(w, http.StatusConflict, fmt.Sprintf("A %s site with URL %s already exists.", nextPlatform, nextURL))
+			writeErrorWithRequest(w, r, http.StatusConflict, fmt.Sprintf("A %s site with URL %s already exists.", nextPlatform, nextURL))
 			return
 		}
 		slog.Error("Failed to update site", "err", err, "site_id", id)
-		writeError(w, http.StatusInternalServerError, "Failed to update site")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "Failed to update site")
 		return
 	}
 
@@ -457,7 +457,7 @@ func (h *sitesHandler) deleteSite(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := service.DeleteSite(h.db, id); err != nil {
 		slog.Error("Failed to delete site", "err", err, "site_id", id)
-		writeError(w, http.StatusInternalServerError, "Failed to delete site")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "Failed to delete site")
 		return
 	}
 	service.InvalidateSiteCaches()
@@ -470,12 +470,12 @@ func (h *sitesHandler) deleteSite(w http.ResponseWriter, r *http.Request) {
 func (h *sitesHandler) batchSites(w http.ResponseWriter, r *http.Request) {
 	var body payloads.SiteBatchPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid site payload.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid site payload: " + err.Error())
 		return
 	}
 
 	if len(body.IDs) == 0 {
-		writeError(w, http.StatusBadRequest, "ids is required")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "ids is required")
 		return
 	}
 
@@ -485,7 +485,7 @@ func (h *sitesHandler) batchSites(w http.ResponseWriter, r *http.Request) {
 		"enableSystemProxy": true, "disableSystemProxy": true,
 	}
 	if !validActions[action] {
-		writeError(w, http.StatusBadRequest, "Invalid action")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid action")
 		return
 	}
 
@@ -538,11 +538,11 @@ func (h *sitesHandler) batchSites(w http.ResponseWriter, r *http.Request) {
 func (h *sitesHandler) detectSite(w http.ResponseWriter, r *http.Request) {
 	var body payloads.SiteDetectPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid url. Expected non-empty string.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid url. Expected non-empty string.")
 		return
 	}
 	if strings.TrimSpace(body.URL) == "" {
-		writeError(w, http.StatusBadRequest, "Invalid url. Expected non-empty string.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid url. Expected non-empty string.")
 		return
 	}
 
@@ -552,7 +552,7 @@ func (h *sitesHandler) detectSite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Failure must not use HTTP 200 with an error body.
-	writeError(w, http.StatusBadRequest, "Could not detect platform")
+	writeErrorWithRequest(w, r, http.StatusBadRequest, "Could not detect platform")
 }
 
 // ---- Import Sites (batch, idempotent) ----
@@ -560,11 +560,11 @@ func (h *sitesHandler) detectSite(w http.ResponseWriter, r *http.Request) {
 func (h *sitesHandler) importSites(w http.ResponseWriter, r *http.Request) {
 	var body payloads.SiteImportPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid import payload.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid import payload.")
 		return
 	}
 	if len(body.Items) == 0 {
-		writeError(w, http.StatusBadRequest, "items is required")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "items is required")
 		return
 	}
 
@@ -573,7 +573,7 @@ func (h *sitesHandler) importSites(w http.ResponseWriter, r *http.Request) {
 		strategy = service.ImportDuplicateSkip
 	}
 	if strategy != service.ImportDuplicateSkip && strategy != service.ImportDuplicateMerge {
-		writeError(w, http.StatusBadRequest, "Invalid duplicateStrategy. Expected skip or merge.")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid duplicateStrategy. Expected skip or merge.")
 		return
 	}
 
@@ -605,7 +605,7 @@ func (h *sitesHandler) importSites(w http.ResponseWriter, r *http.Request) {
 	result, err := service.ImportSites(h.db, items, strategy)
 	if err != nil {
 		slog.Error("ImportSites failed", "err", err)
-		writeError(w, http.StatusInternalServerError, "Import sites failed")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "Import sites failed")
 		return
 	}
 
@@ -626,7 +626,7 @@ func (h *sitesHandler) getDisabledModels(w http.ResponseWriter, r *http.Request)
 
 	var existing store.Site
 	if err := h.db.Get(&existing, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), id); err != nil {
-		writeError(w, http.StatusNotFound, "Site not found")
+		writeErrorWithRequest(w, r, http.StatusNotFound, "Site not found")
 		return
 	}
 
@@ -642,7 +642,7 @@ func (h *sitesHandler) getDisabledModels(w http.ResponseWriter, r *http.Request)
 func (h *sitesHandler) updateDisabledModels(w http.ResponseWriter, r *http.Request) {
 	var body payloads.SiteDisabledModelsPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid models. Expected string[].")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid models. Expected string[].")
 		return
 	}
 
@@ -653,7 +653,7 @@ func (h *sitesHandler) updateDisabledModels(w http.ResponseWriter, r *http.Reque
 
 	var existing store.Site
 	if err := h.db.Get(&existing, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), id); err != nil {
-		writeError(w, http.StatusNotFound, "Site not found")
+		writeErrorWithRequest(w, r, http.StatusNotFound, "Site not found")
 		return
 	}
 
@@ -693,7 +693,7 @@ func (h *sitesHandler) getAvailableModels(w http.ResponseWriter, r *http.Request
 
 	var existing store.Site
 	if err := h.db.Get(&existing, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), id); err != nil {
-		writeError(w, http.StatusNotFound, "Site not found")
+		writeErrorWithRequest(w, r, http.StatusNotFound, "Site not found")
 		return
 	}
 

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -231,7 +231,7 @@ func (h *tokenRoutesHandler) createRoute(w http.ResponseWriter, r *http.Request)
 		Enabled       *bool `json:"enabled"`
 	}
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid request body")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid request body: " + err.Error())
 		return
 	}
 
@@ -251,12 +251,12 @@ func (h *tokenRoutesHandler) createRoute(w http.ResponseWriter, r *http.Request)
 	}
 
 	if routeMode != "explicit_group" && modelPattern == "" {
-		writeError(w, http.StatusBadRequest, "模型匹配不能为空")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "模型匹配不能为空")
 		return
 	}
 
 	if routeMode == "explicit_group" && displayName == "" {
-		writeError(w, http.StatusBadRequest, "显式群组必须填写对外模型名")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "显式群组必须填写对外模型名")
 		return
 	}
 
@@ -288,7 +288,7 @@ func (h *tokenRoutesHandler) createRoute(w http.ResponseWriter, r *http.Request)
 		modelMapping, routingStrategy, contextLength, enabled, now, now,
 	)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "创建路由失败")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "创建路由失败")
 		return
 	}
 
@@ -308,7 +308,7 @@ func (h *tokenRoutesHandler) createRoute(w http.ResponseWriter, r *http.Request)
 
 	created := queryRow(h.db, "SELECT * FROM token_routes WHERE id = ?", id)
 	if created == nil {
-		writeError(w, http.StatusInternalServerError, "创建路由失败")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "创建路由失败")
 		return
 	}
 	created["sourceRouteIds"] = body.SourceRouteIds
@@ -326,13 +326,13 @@ func (h *tokenRoutesHandler) updateRoute(w http.ResponseWriter, r *http.Request)
 
 	existing := queryRow(h.db, "SELECT * FROM token_routes WHERE id = ?", id)
 	if existing == nil {
-		writeError(w, http.StatusNotFound, "路由不存在")
+		writeErrorWithRequest(w, r, http.StatusNotFound, "路由不存在")
 		return
 	}
 
 	var body map[string]any
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid request body")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid request body: " + err.Error())
 		return
 	}
 
@@ -432,18 +432,18 @@ func (h *tokenRoutesHandler) batchRoutes(w http.ResponseWriter, r *http.Request)
 		IDs    []int64 `json:"ids"`
 	}
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid request body")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid request body: " + err.Error())
 		return
 	}
 
 	if len(body.IDs) == 0 {
-		writeError(w, http.StatusBadRequest, "ids 必须是非空数组")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "ids 必须是非空数组")
 		return
 	}
 
 	action := strings.TrimSpace(body.Action)
 	if action != "enable" && action != "disable" {
-		writeError(w, http.StatusBadRequest, "action 必须是 enable 或 disable")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "action 必须是 enable 或 disable")
 		return
 	}
 

--- a/handler/admin/token_routes_channels.go
+++ b/handler/admin/token_routes_channels.go
@@ -67,7 +67,7 @@ func (h *tokenRoutesHandler) addChannel(w http.ResponseWriter, r *http.Request) 
 		Weight      *int64  `json:"weight"`
 	}
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid request body")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid request body: " + err.Error())
 		return
 	}
 
@@ -89,7 +89,7 @@ func (h *tokenRoutesHandler) addChannel(w http.ResponseWriter, r *http.Request) 
 		 AND (source_model = ? OR (source_model IS NULL AND ? IS NULL))`),
 		routeID, body.AccountID, body.TokenID, body.TokenID, body.SourceModel, body.SourceModel)
 	if dupCount > 0 {
-		writeError(w, http.StatusBadRequest, "该来源模型的通道已存在")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "该来源模型的通道已存在")
 		return
 	}
 
@@ -101,7 +101,7 @@ func (h *tokenRoutesHandler) addChannel(w http.ResponseWriter, r *http.Request) 
 		routeID, body.AccountID, body.TokenID, body.SourceModel, priority, weight, true, true,
 	)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "创建通道失败")
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "创建通道失败")
 		return
 	}
 
@@ -126,7 +126,7 @@ func (h *tokenRoutesHandler) batchAddChannels(w http.ResponseWriter, r *http.Req
 		} `json:"channels"`
 	}
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid request body")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid request body: " + err.Error())
 		return
 	}
 
@@ -190,7 +190,7 @@ func (h *tokenRoutesHandler) batchUpdateChannels(w http.ResponseWriter, r *http.
 		} `json:"updates"`
 	}
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid request body")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid request body: " + err.Error())
 		return
 	}
 
@@ -229,15 +229,15 @@ func (h *tokenRoutesHandler) reorderRoutes(w http.ResponseWriter, r *http.Reques
 		} `json:"items"`
 	}
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid payload")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "invalid payload: " + err.Error())
 		return
 	}
 	if len(body.Items) == 0 {
-		writeError(w, http.StatusBadRequest, "items is required")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "items is required")
 		return
 	}
 	if len(body.Items) > 1000 {
-		writeError(w, http.StatusBadRequest, "too many items (max 1000)")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "too many items (max 1000)")
 		return
 	}
 
@@ -287,13 +287,13 @@ func (h *tokenRoutesHandler) updateChannel(w http.ResponseWriter, r *http.Reques
 	idStr := chi.URLParam(r, "channelId")
 	channelID, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || channelID <= 0 {
-		writeError(w, http.StatusNotFound, "通道不存在")
+		writeErrorWithRequest(w, r, http.StatusNotFound, "通道不存在")
 		return
 	}
 
 	var body map[string]any
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "Invalid request body")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid request body: " + err.Error())
 		return
 	}
 

--- a/service/site_service.go
+++ b/service/site_service.go
@@ -207,13 +207,28 @@ func ListSites(db *sqlx.DB) ([]map[string]any, error) {
 		return nil, err
 	}
 
-	// Aggregate totalBalance and subscriptionSummary per site
+	// Aggregate totalBalance and subscriptionSummary per site.
+	//
+	// The accounts query pulls balance + extra_config for every account once.
+	// We then build both the per-site balance sum and the per-site sub2api
+	// subscription summary in a SINGLE pass over the accounts slice (O(accounts))
+	// before the site loop, so the site loop does O(1) map lookups instead of
+	// rescanning the whole accounts slice per site (the previous behavior was
+	// O(sites × accounts) — 50 sites × 1000 accounts = 50,000 iterations).
+	//
+	// A LIKE filter on extra_config was considered to skip non-sub2api accounts
+	// at the DB layer, but balanceBySite must sum across ALL accounts (sub2api
+	// or not), so filtering the shared query would change totalBalance. We keep
+	// the unfiltered query and let buildSubscriptionSummariesBySite skip
+	// non-sub2api accounts in-memory (GetSub2ApiAuthFromExtraConfig returns nil
+	// for them, so they never allocate a map entry).
 	var accounts []accountAgg
 	if err := db.Select(&accounts, "SELECT site_id, balance, extra_config FROM accounts"); err != nil {
 		return nil, err
 	}
 
 	balanceBySite := make(map[int64]float64)
+	summariesBySite := buildSubscriptionSummariesBySite(accounts)
 	for _, a := range accounts {
 		balanceBySite[a.SiteID] += a.Balance
 	}
@@ -223,7 +238,7 @@ func ListSites(db *sqlx.DB) ([]map[string]any, error) {
 		siteMap := siteToMap(s, endpointsBySite[s.ID])
 		totalBalance := math.Round(balanceBySite[s.ID]*1_000_000) / 1_000_000
 		siteMap["totalBalance"] = totalBalance
-		siteMap["subscriptionSummary"] = buildSubscriptionSummary(accounts, s.ID)
+		siteMap["subscriptionSummary"] = summariesBySite[s.ID]
 		result[i] = siteMap
 	}
 
@@ -236,71 +251,81 @@ func ListSites(db *sqlx.DB) ([]map[string]any, error) {
 // frontend (web/src/features/sites/components/sites-columns.tsx uses
 // activeCount as an accountCount fallback).
 type subscriptionSummary struct {
-	Group       string      `json:"group,omitempty"`
-	ExpiresAt   *time.Time  `json:"expiresAt,omitempty"`
-	Active      bool        `json:"active"`
-	ActiveCount int         `json:"activeCount"`
+	Group       string     `json:"group,omitempty"`
+	ExpiresAt   *time.Time `json:"expiresAt,omitempty"`
+	Active      bool       `json:"active"`
+	ActiveCount int        `json:"activeCount"`
 }
 
-// buildSubscriptionSummary aggregates sub2api subscription info for a site by
-// scanning every account's extra_config for a sub2apiAuth object. The TS
-// version parsed sub2apiAuth to surface the subscription group, token expiry
-// and liveness; here we extract the same known fields without over-fetching.
+// buildSubscriptionSummariesBySite aggregates sub2api subscription info for
+// every site in a single pass over the accounts slice, returning a map keyed
+// by site ID. Sites whose accounts carry no sub2apiAuth block are absent from
+// the map (callers treat a missing key as nil — the pre-existing behavior, so
+// non-sub2api sites stay unaffected).
 //
-// Returns nil when no account for the site carries a sub2apiAuth block (the
-// pre-existing behavior), so non-sub2api sites stay unaffected.
-func buildSubscriptionSummary(accounts []accountAgg, siteID int64) any {
-	var (
-		group        string
-		latestExpiry *time.Time
-		activeCount  int
-		seenSub2Api  bool
-	)
+// This is the O(accounts) replacement for the previous per-site
+// buildSubscriptionSummary(accounts, siteID) call inside the site loop, which
+// rescanned the whole accounts slice per site (O(sites × accounts)).
+func buildSubscriptionSummariesBySite(accounts []accountAgg) map[int64]*subscriptionSummary {
+	result := make(map[int64]*subscriptionSummary)
 	now := time.Now().UTC()
 	for _, acc := range accounts {
-		if acc.SiteID != siteID {
-			continue
-		}
 		auth := GetSub2ApiAuthFromExtraConfig(acc.ExtraConfig)
 		if auth == nil {
 			continue
 		}
-		seenSub2Api = true
+		summary := result[acc.SiteID]
+		if summary == nil {
+			summary = &subscriptionSummary{}
+			result[acc.SiteID] = summary
+		}
 
 		// Subscription group/plan name: prefer "group", fall back to "planName".
-		if g, ok := auth["group"].(string); ok && g != "" {
-			if group == "" {
-				group = g
-			}
-		} else if p, ok := auth["planName"].(string); ok && p != "" {
-			if group == "" {
-				group = p
+		// First-seen wins so the caller-visible group is stable across accounts.
+		if summary.Group == "" {
+			if g, ok := auth["group"].(string); ok && g != "" {
+				summary.Group = g
+			} else if p, ok := auth["planName"].(string); ok && p != "" {
+				summary.Group = p
 			}
 		}
 
 		// tokenExpiresAt is epoch seconds (see NormalizeManagedTokenExpiresAt).
 		if exp, ok := NormalizeManagedTokenExpiresAt(auth["tokenExpiresAt"]); ok && exp > 0 {
 			expiry := time.Unix(exp, 0).UTC()
-			if latestExpiry == nil || expiry.After(*latestExpiry) {
-				latestExpiry = &expiry
+			if summary.ExpiresAt == nil || expiry.After(*summary.ExpiresAt) {
+				summary.ExpiresAt = &expiry
 			}
 			if expiry.After(now) {
-				activeCount++
+				summary.ActiveCount++
 			}
 		} else {
 			// No usable expiry — treat as active so accountCount fallback still works.
-			activeCount++
+			summary.ActiveCount++
 		}
 	}
-	if !seenSub2Api {
-		return nil
+	// Derive the Active flag once after all accounts are folded in, since
+	// ActiveCount is incremented across multiple accounts per site.
+	for _, summary := range result {
+		summary.Active = summary.ActiveCount > 0
 	}
-	return &subscriptionSummary{
-		Group:       group,
-		ExpiresAt:   latestExpiry,
-		Active:      activeCount > 0,
-		ActiveCount: activeCount,
+	return result
+}
+
+// buildSubscriptionSummary aggregates sub2api subscription info for a single
+// site by scanning every account's extra_config for a sub2apiAuth object.
+//
+// Kept for backward compatibility with existing tests and any caller that
+// needs a single-site summary. It delegates to buildSubscriptionSummariesBySite
+// (single pass) and looks up the requested site. Returns an untyped nil when
+// no account for the site carries a sub2apiAuth block (matching the original
+// behavior; indexing a missing map key would yield a typed-nil *subscriptionSummary
+// which compares != nil, so we guard with the comma-ok form).
+func buildSubscriptionSummary(accounts []accountAgg, siteID int64) any {
+	if s, ok := buildSubscriptionSummariesBySite(accounts)[siteID]; ok {
+		return s
 	}
+	return nil
 }
 
 // CreateSite creates a new site with apiEndpoints in a transaction.

--- a/service/site_subscription_summary_test.go
+++ b/service/site_subscription_summary_test.go
@@ -198,6 +198,114 @@ func TestBuildSubscriptionSummary_JSONShape(t *testing.T) {
 	}
 }
 
+// TestBuildSubscriptionSummariesBySite_MultiSiteSinglePass verifies the new
+// single-pass aggregator (Fix 2) produces correct per-site summaries in one
+// scan of the accounts slice, instead of rescanning per site. This is the
+// O(accounts) replacement for the old O(sites × accounts) per-site loop.
+func TestBuildSubscriptionSummariesBySite_MultiSiteSinglePass(t *testing.T) {
+	t.Parallel()
+	now := time.Now().Unix()
+	past := now - 60
+	future1 := now + 60
+	future2 := now + 3600
+	accounts := []accountAgg{
+		// Site 1: two sub2api accounts — one expired (past), one active (future1).
+		{SiteID: 1, ExtraConfig: strPtr(`{"sub2apiAuth":{"group":"a","tokenExpiresAt":` + itoa64(past) + `}}`)},
+		{SiteID: 1, ExtraConfig: strPtr(`{"sub2apiAuth":{"group":"b","tokenExpiresAt":` + itoa64(future1) + `}}`)},
+		// Site 2: one sub2api account — active with the latest expiry.
+		{SiteID: 2, ExtraConfig: strPtr(`{"sub2apiAuth":{"group":"c","tokenExpiresAt":` + itoa64(future2) + `}}`)},
+		// Site 3: no sub2api account — must be ABSENT from the map (not a
+		// typed-nil entry, which would break nil comparisons downstream).
+		{SiteID: 3, ExtraConfig: strPtr(`{"proxyUrl":"http://proxy.local"}`)},
+		{SiteID: 3, ExtraConfig: nil},
+	}
+	summaries := buildSubscriptionSummariesBySite(accounts)
+	if len(summaries) != 2 {
+		t.Fatalf("expected 2 sites with summaries, got %d (%#v)", len(summaries), summaries)
+	}
+	if _, ok := summaries[3]; ok {
+		t.Fatal("site 3 (no sub2api) should be absent from map, not a typed-nil entry")
+	}
+	if _, ok := summaries[99]; ok {
+		t.Fatal("site 99 (no accounts at all) should be absent from map")
+	}
+
+	s1 := summaries[1]
+	if s1 == nil {
+		t.Fatal("site 1 summary is nil")
+	}
+	if s1.Group != "a" {
+		t.Fatalf("site 1 Group = %q, want a (first-seen wins)", s1.Group)
+	}
+	if s1.ActiveCount != 1 {
+		t.Fatalf("site 1 ActiveCount = %d, want 1 (only future1 is active)", s1.ActiveCount)
+	}
+	if !s1.Active {
+		t.Fatal("site 1 Active = false, want true (ActiveCount > 0)")
+	}
+	if s1.ExpiresAt == nil || !s1.ExpiresAt.Equal(time.Unix(future1, 0).UTC()) {
+		t.Fatalf("site 1 ExpiresAt = %v, want %v (latest of past+future1)", s1.ExpiresAt, time.Unix(future1, 0).UTC())
+	}
+
+	s2 := summaries[2]
+	if s2 == nil {
+		t.Fatal("site 2 summary is nil")
+	}
+	if s2.Group != "c" {
+		t.Fatalf("site 2 Group = %q, want c", s2.Group)
+	}
+	if s2.ActiveCount != 1 {
+		t.Fatalf("site 2 ActiveCount = %d, want 1", s2.ActiveCount)
+	}
+	if !s2.ExpiresAt.Equal(time.Unix(future2, 0).UTC()) {
+		t.Fatalf("site 2 ExpiresAt = %v, want %v", s2.ExpiresAt, time.Unix(future2, 0).UTC())
+	}
+}
+
+// TestBuildSubscriptionSummariesBySite_EmptyInput verifies the single-pass
+// aggregator returns a non-nil empty map (not nil) for nil/empty input, so
+// callers can safely do `summaries[siteID]` without nil-map panics.
+func TestBuildSubscriptionSummariesBySite_EmptyInput(t *testing.T) {
+	t.Parallel()
+	if got := buildSubscriptionSummariesBySite(nil); got == nil || len(got) != 0 {
+		t.Fatalf("nil input: expected non-nil empty map, got %#v", got)
+	}
+	if got := buildSubscriptionSummariesBySite([]accountAgg{}); got == nil || len(got) != 0 {
+		t.Fatalf("empty input: expected non-nil empty map, got %#v", got)
+	}
+}
+
+// TestBuildSubscriptionSummary_DelegatesToSinglePass verifies the backward-
+// compat wrapper returns the same value as the single-pass map lookup, and
+// returns an untyped nil (not a typed-nil pointer) when the site has no
+// sub2api accounts — guarding against the Go typed-nil comparison gotcha.
+func TestBuildSubscriptionSummary_DelegatesToSinglePass(t *testing.T) {
+	t.Parallel()
+	future := time.Now().Add(time.Hour).Unix()
+	accounts := []accountAgg{
+		{SiteID: 1, ExtraConfig: strPtr(`{"sub2apiAuth":{"group":"x","tokenExpiresAt":` + itoa64(future) + `}}`)},
+		{SiteID: 2, ExtraConfig: strPtr(`{"proxyUrl":"http://no-sub2api.local"}`)},
+	}
+	// Site 1 has a sub2api summary.
+	got := buildSubscriptionSummary(accounts, 1)
+	if got == nil {
+		t.Fatal("site 1: expected non-nil summary")
+	}
+	summary, ok := got.(*subscriptionSummary)
+	if !ok {
+		t.Fatalf("site 1: expected *subscriptionSummary, got %T", got)
+	}
+	if summary.Group != "x" {
+		t.Fatalf("site 1: Group = %q, want x", summary.Group)
+	}
+	// Site 2 has no sub2api — must be untyped nil so `got != nil` is false.
+	// A typed-nil *subscriptionSummary would wrongly report non-nil.
+	got = buildSubscriptionSummary(accounts, 2)
+	if got != nil {
+		t.Fatalf("site 2: expected untyped nil (no sub2api), got %#v (typed-nil trap?)", got)
+	}
+}
+
 // itoa64 formats an int64 as a string for JSON splicing in test fixtures.
 func itoa64(n int64) string {
 	const digits = "0123456789"


### PR DESCRIPTION
## Summary

- **Fix 1 (P2)**: Admin API error responses now include the additive `request_id` field (in body + `X-Request-Id` header) so consumers can correlate error bodies with server logs — the proxy path already did this via `handler/proxy/router.go`, admin bodies didn't. Adds `writeErrorWithRequest(w, r, code, msg)` helper pulling the request ID from chi context; migrates all admin mutation error paths (sites, accounts, channels, token-routes) + `pathID`. Backward compatible: `request_id` is `omitempty` when no middleware injected a context value (never `null`).
- **Fix 2 (P2)**: `ListSites` subscription summary is now **O(accounts)** instead of **O(sites × accounts)**. New `buildSubscriptionSummariesBySite` does a single pass over the accounts slice to build `map[siteID]*subscriptionSummary` before the site loop, which then does O(1) map lookups (50 sites × 1000 accounts went from 50,000 iterations to 1,000). The optional `WHERE extra_config LIKE '%sub2apiAuth%'` filter was **skipped** because `balanceBySite` must sum ALL accounts (filtering would silently change `totalBalance`). Response format unchanged.
- **Fix 3 (P3)**: Generic validation errors (`"Invalid site payload."`, `"Invalid request body"`) now include the decode error context so callers know which field/character broke parsing — e.g. `"Invalid site payload: invalid character 'b' looking for beginning of object key string"`.

## Test plan

- [x] `go build ./...` passes (clean)
- [x] `go test ./handler/... ./service/...` — all green (existing + new tests)
- [x] `go vet ./handler/admin/... ./handler/shared/... ./service/...` — clean
- [x] New: `TestWriteErrorWithRequest_IncludesRequestID` — body + header carry request_id
- [x] New: `TestWriteErrorWithRequest_OmitsRequestIDWhenAbsent` — backward compat (omitempty, not null)
- [x] New: `TestWriteErrorWithRequest_DoesNotOverrideExistingHeader` — ingress header preserved
- [x] New: `TestSites_Create_MalformedJSON_RequestIDAndFieldContext` — integration: Fix 1 + Fix 3 via POST /api/sites
- [x] New: `TestRoutes_Create_MalformedJSON_FieldContext` — Fix 3 for token-routes create path
- [x] New: `TestSites_Create_EmptyName_RequestIDInError` — Fix 1 for field-specific validation error
- [x] New: `TestBuildSubscriptionSummariesBySite_MultiSiteSinglePass` — Fix 2 multi-site correctness
- [x] New: `TestBuildSubscriptionSummariesBySite_EmptyInput` — non-nil empty map for nil/empty input
- [x] New: `TestBuildSubscriptionSummary_DelegatesToSinglePass` — backward-compat wrapper + typed-nil guard
- [x] All 9 existing `TestBuildSubscriptionSummary_*` tests still pass (behavior preserved)