### PR TITLE
fix(security): stop SELECTing plaintext creds + channels pagination

### DIFF
--- a/handler/admin/admin_creds_test.go
+++ b/handler/admin/admin_creds_test.go
@@ -1,0 +1,409 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// setupCredsTest builds a router with both token routes (for /api/channels +
+// /api/routes) and search routes (for /api/search) on a fresh in-memory DB.
+func setupCredsTest(t *testing.T) (*store.DB, chi.Router) {
+	t.Helper()
+	globalChannelsCache.clear()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	r := chi.NewRouter()
+	RegisterTokenRoutesWithDeps(r, db.DB, TokenRoutesDeps{})
+	RegisterSearchRoutes(r, db.DB)
+	return db, r
+}
+
+// seedCredentialedAccount inserts a site + account carrying plaintext access_token
+// and api_token, plus an account_token carrying a plaintext token. Returns the
+// plaintext secrets so tests can assert they never appear in a response body.
+func seedCredentialedAccount(t *testing.T, db *store.DB) (accessSecret, apiSecret, tokenSecret string, routeID, accountID, tokenID int64) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	accessSecret = "FAKE-access-PLAINTEXT-AAAA1111"
+	apiSecret = "FAKE-api-PLAINTEXT-BBBB2222"
+	tokenSecret = "FAKE-token-PLAINTEXT-CCCC3333"
+
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		 VALUES ('Cred Site', 'https://cred.example.com', 'openai', 'active', ?, ?)`, now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+
+	res, err = db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
+		 VALUES (?, 'cred-user', ?, ?, 'active', 1, ?, ?)`,
+		siteID, accessSecret, apiSecret, now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ = res.LastInsertId()
+
+	res, err = db.Exec(
+		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
+		 VALUES (?, 'cred-token', ?, 'ready', 'manual', 1, 1, ?, ?)`,
+		accountID, tokenSecret, now, now)
+	if err != nil {
+		t.Fatalf("insert account_token: %v", err)
+	}
+	tokenID, _ = res.LastInsertId()
+
+	res, err = db.Exec(
+		`INSERT INTO token_routes (model_pattern, enabled, created_at, updated_at) VALUES ('gpt-*', 1, ?, ?)`, now, now)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	routeID, _ = res.LastInsertId()
+	return
+}
+
+// TestListRoutes_ResponseOmitsPlaintextCredentials is the P1 security guard:
+// GET /api/routes must never surface plaintext access_token/api_token in the
+// response body — only the masked form rebuilt from length/prefix/suffix
+// fragments may appear.
+func TestListRoutes_ResponseOmitsPlaintextCredentials(t *testing.T) {
+	db, r := setupCredsTest(t)
+	accessSecret, apiSecret, _, routeID, accountID, tokenID := seedCredentialedAccount(t, db)
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(
+		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+		 VALUES (?, ?, ?, 'gpt-4o', 1, 10, 1, 0)`, routeID, accountID, tokenID); err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+	_ = now
+
+	rec := doGet(t, r, "/api/routes")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, accessSecret) {
+		t.Fatalf("list routes leaked access_token plaintext: %s", body)
+	}
+	if strings.Contains(body, apiSecret) {
+		t.Fatalf("list routes leaked api_token plaintext: %s", body)
+	}
+
+	var listed []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, route := range listed {
+		if int64(route["id"].(float64)) != routeID {
+			continue
+		}
+		chans, _ := route["channels"].([]any)
+		if len(chans) != 1 {
+			t.Fatalf("expected 1 channel, got %d", len(chans))
+		}
+		acc := chans[0].(map[string]any)["account"].(map[string]any)
+		if _, ok := acc["accessToken"]; ok {
+			t.Fatalf("accessToken key present: %#v", acc["accessToken"])
+		}
+		if _, ok := acc["apiToken"]; ok {
+			t.Fatalf("apiToken key present: %#v", acc["apiToken"])
+		}
+		if acc["accessTokenMasked"] != maskSecret(accessSecret) {
+			t.Fatalf("accessTokenMasked=%#v want %q", acc["accessTokenMasked"], maskSecret(accessSecret))
+		}
+		if acc["apiTokenMasked"] != maskSecret(apiSecret) {
+			t.Fatalf("apiTokenMasked=%#v want %q", acc["apiTokenMasked"], maskSecret(apiSecret))
+		}
+	}
+}
+
+// TestGetRouteChannels_ResponseOmitsPlaintextCredentials guards the per-route
+// channel list (GET /api/routes/:id/channels), which shares the same SELECT.
+func TestGetRouteChannels_ResponseOmitsPlaintextCredentials(t *testing.T) {
+	db, r := setupCredsTest(t)
+	accessSecret, apiSecret, _, routeID, accountID, tokenID := seedCredentialedAccount(t, db)
+	if _, err := db.Exec(
+		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+		 VALUES (?, ?, ?, 'gpt-4o', 1, 10, 1, 0)`, routeID, accountID, tokenID); err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+
+	rec := doGet(t, r, "/api/routes/"+itoa(routeID)+"/channels")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, accessSecret) {
+		t.Fatalf("getRouteChannels leaked access_token plaintext: %s", body)
+	}
+	if strings.Contains(body, apiSecret) {
+		t.Fatalf("getRouteChannels leaked api_token plaintext: %s", body)
+	}
+
+	var chans []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &chans); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(chans) != 1 {
+		t.Fatalf("expected 1 channel, got %d", len(chans))
+	}
+	acc := chans[0]["account"].(map[string]any)
+	if _, ok := acc["accessToken"]; ok {
+		t.Fatalf("accessToken key present")
+	}
+	if acc["accessTokenMasked"] != maskSecret(accessSecret) {
+		t.Fatalf("accessTokenMasked=%#v want %q", acc["accessTokenMasked"], maskSecret(accessSecret))
+	}
+	if acc["apiTokenMasked"] != maskSecret(apiSecret) {
+		t.Fatalf("apiTokenMasked=%#v want %q", acc["apiTokenMasked"], maskSecret(apiSecret))
+	}
+}
+
+// TestSearch_ResponseOmitsPlaintextCredentials guards POST /api/search: the
+// accounts/account_tokens hits must never carry plaintext access_token,
+// api_token, or token — only the masked forms rebuilt from fragments.
+func TestSearch_ResponseOmitsPlaintextCredentials(t *testing.T) {
+	db, r := setupCredsTest(t)
+	accessSecret, apiSecret, tokenSecret, _, accountID, _ := seedCredentialedAccount(t, db)
+	_ = accountID
+
+	rec := doPostJSON(t, r, "/api/search", map[string]any{"query": "cred", "limit": 20})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, secret := range []string{accessSecret, apiSecret, tokenSecret} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("search response leaked plaintext secret %q: %s", secret, body)
+		}
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	accounts, _ := resp["accounts"].([]any)
+	if len(accounts) == 0 {
+		t.Fatalf("expected at least 1 account hit")
+	}
+	acc := accounts[0].(map[string]any)
+	if _, ok := acc["accessToken"]; ok {
+		t.Fatalf("account accessToken key present")
+	}
+	if _, ok := acc["apiToken"]; ok {
+		t.Fatalf("account apiToken key present")
+	}
+	if acc["accessTokenMasked"] != maskSecret(accessSecret) {
+		t.Fatalf("accessTokenMasked=%#v want %q", acc["accessTokenMasked"], maskSecret(accessSecret))
+	}
+	if acc["apiTokenMasked"] != maskSecret(apiSecret) {
+		t.Fatalf("apiTokenMasked=%#v want %q", acc["apiTokenMasked"], maskSecret(apiSecret))
+	}
+
+	toks, _ := resp["accountTokens"].([]any)
+	if len(toks) == 0 {
+		t.Fatalf("expected at least 1 accountToken hit")
+	}
+	tok := toks[0].(map[string]any)
+	if _, ok := tok["token"]; ok {
+		t.Fatalf("accountToken token key present")
+	}
+	if tok["tokenMasked"] != maskSecret(tokenSecret) {
+		t.Fatalf("tokenMasked=%#v want %q", tok["tokenMasked"], maskSecret(tokenSecret))
+	}
+}
+
+// TestChannels_PaginationReturnsCorrectTotal verifies the COUNT(*) OVER ()
+// total is accurate on every page, including the partial last page and a page
+// past the end (which falls back to a plain COUNT(*)).
+func TestChannels_PaginationReturnsCorrectTotal(t *testing.T) {
+	db, r := setupCredsTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+	now := time.Now().UTC().Format(time.RFC3339)
+	_ = now
+
+	// Insert 5 channels with distinct source models.
+	for i := 0; i < 5; i++ {
+		model := "gpt-pg-" + itoa(int64(i+1))
+		if _, err := db.Exec(
+			`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+			 VALUES (?, ?, ?, ?, 0, 10, 1, 0)`, routeID, accountID, tokenID, model); err != nil {
+			t.Fatalf("insert channel %d: %v", i, err)
+		}
+	}
+
+	pageSize := 2
+	pages := []struct {
+		page, wantItems, wantTotal int
+	}{
+		{1, 2, 5},
+		{2, 2, 5},
+		{3, 1, 5},
+		{4, 0, 5}, // past the end — total must still be 5 via fallback COUNT(*)
+	}
+	for _, tc := range pages {
+		req := httptest.NewRequest(http.MethodGet, "/api/channels?page="+itoa(int64(tc.page))+"&pageSize="+itoa(int64(pageSize)), nil)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("page %d: status=%d body=%s", tc.page, rec.Code, rec.Body.String())
+		}
+		var resp map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("page %d decode: %v", tc.page, err)
+		}
+		if resp["total"] != float64(tc.wantTotal) {
+			t.Fatalf("page %d total=%v want %d", tc.page, resp["total"], tc.wantTotal)
+		}
+		if resp["page"] != float64(tc.page) {
+			t.Fatalf("page %d echoed=%v", tc.page, resp["page"])
+		}
+		if resp["pageSize"] != float64(pageSize) {
+			t.Fatalf("page %d pageSize=%v want %d", tc.page, resp["pageSize"], pageSize)
+		}
+		items, _ := resp["items"].([]any)
+		if len(items) != tc.wantItems {
+			t.Fatalf("page %d items=%d want %d", tc.page, len(items), tc.wantItems)
+		}
+	}
+}
+
+// TestChannels_PageSizeClampedToMax verifies pageSize is clamped to the 200 cap.
+func TestChannels_PageSizeClampedToMax(t *testing.T) {
+	_, r := setupCredsTest(t)
+	rec := doGet(t, r, "/api/channels?pageSize=9999")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d", rec.Code)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["pageSize"] != float64(200) {
+		t.Fatalf("pageSize=%v want 200 (clamped)", resp["pageSize"])
+	}
+}
+
+// TestChannels_SnapshotCacheHitMissAndBypass verifies the 10s TTL snapshot
+// cache: first request is a miss (populates), second is a hit (same bytes),
+// and ?refresh=true forces a miss.
+func TestChannels_SnapshotCacheHitMissAndBypass(t *testing.T) {
+	_, r := setupCredsTest(t)
+
+	first := doGet(t, r, "/api/channels")
+	if first.Header().Get("x-channels-snapshot-cache") != "miss" {
+		t.Fatalf("first request cache header=%q want miss", first.Header().Get("x-channels-snapshot-cache"))
+	}
+
+	second := doGet(t, r, "/api/channels")
+	if second.Header().Get("x-channels-snapshot-cache") != "hit" {
+		t.Fatalf("second request cache header=%q want hit", second.Header().Get("x-channels-snapshot-cache"))
+	}
+	if second.Body.String() != first.Body.String() {
+		t.Fatalf("cached body differs from fresh body")
+	}
+
+	refreshed := doGet(t, r, "/api/channels?refresh=true")
+	if refreshed.Header().Get("x-channels-snapshot-cache") != "miss" {
+		t.Fatalf("refresh request cache header=%q want miss", refreshed.Header().Get("x-channels-snapshot-cache"))
+	}
+}
+
+// TestChannels_MutationInvalidatesSnapshotCache verifies that a route_channels
+// mutation clears the snapshot cache so the next list reflects the new row
+// immediately (not up to the 10s TTL later).
+func TestChannels_MutationInvalidatesSnapshotCache(t *testing.T) {
+	db, r := setupCredsTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+
+	before := doGet(t, r, "/api/channels")
+	if before.Header().Get("x-channels-snapshot-cache") != "miss" {
+		t.Fatalf("first request should be a miss")
+	}
+	var beforeResp map[string]any
+	_ = json.Unmarshal(before.Body.Bytes(), &beforeResp)
+	beforeItems, _ := beforeResp["items"].([]any)
+	if len(beforeItems) != 0 {
+		t.Fatalf("expected 0 channels before mutation, got %d", len(beforeItems))
+	}
+
+	// Add a channel — must invalidate the cache.
+	add := doPostJSON(t, r, "/api/routes/"+itoa(routeID)+"/channels", map[string]any{
+		"accountId":   accountID,
+		"tokenId":     tokenID,
+		"sourceModel": "gpt-4o",
+		"priority":    1,
+		"weight":      10,
+	})
+	if add.Code != http.StatusOK {
+		t.Fatalf("add channel: %d %s", add.Code, add.Body.String())
+	}
+
+	after := doGet(t, r, "/api/channels")
+	if after.Header().Get("x-channels-snapshot-cache") != "miss" {
+		t.Fatalf("post-mutation request should be a miss (cache invalidated), got %q", after.Header().Get("x-channels-snapshot-cache"))
+	}
+	var afterResp map[string]any
+	_ = json.Unmarshal(after.Body.Bytes(), &afterResp)
+	afterItems, _ := afterResp["items"].([]any)
+	if len(afterItems) != 1 {
+		t.Fatalf("expected 1 channel after mutation, got %d", len(afterItems))
+	}
+}
+
+// TestMaskSecretFromFragments_ParityWithMaskSecret is a table test asserting
+// that rebuilding the masked form from prefix/suffix/length fragments produces
+// byte-identical output to maskSecret(plaintext) across length boundaries.
+func TestMaskSecretFromFragments_ParityWithMaskSecret(t *testing.T) {
+	secrets := []string{
+		"",
+		"a",
+		"ab",
+		"abcd1234",     // exactly 8 -> "****"
+		"abcd12345",    // 9 -> first4+****+last4
+		"FAKE-access-secret-ABCDEF",
+		"FAKE-api-secret-XYZ12345",
+	}
+	for _, secret := range secrets {
+		var prefix, suffix any
+		var length int64
+		if secret != "" {
+			// SUBSTR(s,1,4) yields up to 4 chars; SUBSTR(s,-4) yields up to 4
+			// from the end. Mimic that (and MapScan's []byte) for len<4 input.
+			pEnd := 4
+			if len(secret) < pEnd {
+				pEnd = len(secret)
+			}
+			sStart := len(secret) - 4
+			if sStart < 0 {
+				sStart = 0
+			}
+			prefix = []byte(secret[:pEnd])
+			suffix = []byte(secret[sStart:])
+			length = int64(len(secret))
+		}
+		got := maskSecretFromFragments(prefix, suffix, length)
+		want := maskSecret(secret)
+		if got != want {
+			t.Errorf("secret=%q (len=%d): got %q want %q", secret, len(secret), got, want)
+		}
+		// Masked form must never contain the full plaintext.
+		if secret != "" && len(secret) > 8 && strings.Contains(got, secret) {
+			t.Errorf("secret=%q: masked form leaked plaintext: %q", secret, got)
+		}
+	}
+}

--- a/handler/admin/channels.go
+++ b/handler/admin/channels.go
@@ -1,8 +1,12 @@
 package admin
 
 import (
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
+	"time"
 
 	"github.com/deliciousbuding/metapi-go/routing"
 )
@@ -30,12 +34,88 @@ type channelListRow struct {
 	RouteModelPattern string  `db:"route_model_pattern"`
 	OAuthUnitName     string  `db:"oauth_unit_name"`
 	TokenName         string  `db:"token_name"`
+	// TotalCount is the COUNT(*) OVER () window result: the total number of
+	// route_channels rows matching the FROM/JOINs ignoring LIMIT/OFFSET, so the
+	// pager can show the true fleet size on every page. Identical across all
+	// rows in a page; read from the first row (or a fallback COUNT when empty).
+	TotalCount int64 `db:"total_count"`
 }
 
-// listChannels returns the aggregated read-only channel list (#622).
+// channelsSnapshotCache is an in-memory TTL cache for GET /api/channels pages.
+// Mirrors globalAccountsCache: a short-TTL snapshot so a fleet-wide 5-way JOIN
+// list does not run on every dashboard poll. Entries are keyed by "page:pageSize"
+// so distinct page requests don't shadow each other. ?refresh=true bypasses.
+type channelsSnapshotCache struct {
+	mu        sync.RWMutex
+	key       string
+	data      []byte
+	expiresAt time.Time
+	ttl       time.Duration
+}
+
+func (c *channelsSnapshotCache) get(key string) ([]byte, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.data != nil && c.key == key && time.Now().Before(c.expiresAt) {
+		return c.data, true
+	}
+	return nil, false
+}
+
+func (c *channelsSnapshotCache) set(key string, data []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.key = key
+	c.data = data
+	c.expiresAt = time.Now().Add(c.ttl)
+}
+
+func (c *channelsSnapshotCache) clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data = nil
+	c.key = ""
+	c.expiresAt = time.Time{}
+}
+
+var globalChannelsCache = &channelsSnapshotCache{ttl: 10 * time.Second}
+
+// invalidateChannelsSnapshotCache clears the channels list snapshot cache.
+// Called from every route_channels mutation so a freshly edited fleet shows
+// up immediately instead of up to ttl (10s) later.
+func invalidateChannelsSnapshotCache() {
+	globalChannelsCache.clear()
+}
+
+// listChannels returns the aggregated, paginated, read-only channel list (#622).
 // Status is derived from routing in-memory breaker state + persisted cooldown
 // so the UI never mutates routing health (read-only / soft isolation).
+//
+// Pagination: ?page (default 1) / ?pageSize (default 50, max 200). The total
+// fleet size comes from COUNT(*) OVER () so the pager is accurate even on
+// non-first pages. A 10s TTL snapshot cache (mirroring globalAccountsCache)
+// absorbs dashboard polling; ?refresh=true bypasses it, and any
+// route_channels mutation clears it via invalidateChannelsSnapshotCache().
+//
+// Response: {items:[...], total:N, page:int, pageSize:int} — same envelope
+// shape as /api/checkin/logs and /api/stats/proxy-logs.
 func (h *tokenRoutesHandler) listChannels(w http.ResponseWriter, r *http.Request) {
+	page := clampInt(getQueryInt(r, "page", 1), 1, 1_000_000)
+	pageSize := clampInt(getQueryInt(r, "pageSize", 50), 1, 200)
+	forceRefresh := parseTruthyQuery(r.URL.Query().Get("refresh"))
+	cacheKey := fmt.Sprintf("%d:%d", page, pageSize)
+
+	if !forceRefresh {
+		if cached, hit := globalChannelsCache.get(cacheKey); hit {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("x-channels-snapshot-cache", "hit")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(cached)
+			return
+		}
+	}
+
+	offset := (page - 1) * pageSize
 	var rows []channelListRow
 	if err := h.db.SelectContext(r.Context(), &rows, h.db.Rebind(`
 		SELECT rc.id, rc.route_id, rc.account_id, rc.token_id, rc.oauth_route_unit_id,
@@ -46,24 +126,48 @@ func (h *tokenRoutesHandler) listChannels(w http.ResponseWriter, r *http.Request
 		       COALESCE(s.name, '') AS site_name,
 		       COALESCE(tr.model_pattern, '') AS route_model_pattern,
 		       COALESCE(oru.name, '') AS oauth_unit_name,
-		       COALESCE(at.name, '') AS token_name
+		       COALESCE(at.name, '') AS token_name,
+		       COUNT(*) OVER () AS total_count
 		FROM route_channels rc
 		LEFT JOIN accounts a ON rc.account_id = a.id
 		LEFT JOIN sites s ON a.site_id = s.id
 		LEFT JOIN token_routes tr ON rc.route_id = tr.id
 		LEFT JOIN oauth_route_units oru ON rc.oauth_route_unit_id = oru.id
 		LEFT JOIN account_tokens at ON rc.token_id = at.id
-		ORDER BY rc.id ASC`)); err != nil {
+		ORDER BY rc.id ASC
+		LIMIT ? OFFSET ?`), pageSize, offset); err != nil {
 		slog.Error("channels list failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "加载通道列表失败")
 		return
 	}
 
 	items := make([]map[string]any, 0, len(rows))
-	for _, row := range rows {
+	var total int64
+	for i, row := range rows {
+		if i == 0 {
+			total = row.TotalCount
+		}
 		items = append(items, channelListItem(row))
 	}
-	writeJSON(w, http.StatusOK, normalizeSlice(items))
+	// COUNT(*) OVER () is absent from an empty page; fall back to a plain
+	// COUNT(*) so a pager past the last row still reports the true total.
+	if len(rows) == 0 {
+		_ = h.db.Get(&total, h.db.Rebind("SELECT COUNT(*) FROM route_channels"))
+	}
+
+	resp := map[string]any{
+		"items":    normalizeSlice(items),
+		"total":    total,
+		"page":     page,
+		"pageSize": pageSize,
+	}
+	respBytes, _ := json.Marshal(resp)
+	globalChannelsCache.set(cacheKey, respBytes)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("x-channels-snapshot-cache", "miss")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(respBytes)
 }
 
 func channelListItem(row channelListRow) map[string]any {

--- a/handler/admin/channels_test.go
+++ b/handler/admin/channels_test.go
@@ -31,15 +31,27 @@ func TestChannels_ListProjection(t *testing.T) {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
 
-	var items []map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &items); err != nil {
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode body: %v", err)
 	}
-	if len(items) != 1 {
-		t.Fatalf("items = %d, want 1", len(items))
+	if resp["page"] != float64(1) {
+		t.Fatalf("page = %v, want 1", resp["page"])
 	}
-
-	item := items[0]
+	if resp["pageSize"] != float64(50) {
+		t.Fatalf("pageSize = %v, want 50", resp["pageSize"])
+	}
+	if resp["total"] != float64(1) {
+		t.Fatalf("total = %v, want 1", resp["total"])
+	}
+	rawItems, ok := resp["items"].([]any)
+	if !ok {
+		t.Fatalf("items missing/wrong type: %#v", resp["items"])
+	}
+	if len(rawItems) != 1 {
+		t.Fatalf("items = %d, want 1", len(rawItems))
+	}
+	item := rawItems[0].(map[string]any)
 	if item["status"] != "enabled" {
 		t.Fatalf("status = %v, want enabled", item["status"])
 	}
@@ -86,14 +98,16 @@ func TestChannels_ManuallyDisabledStatus(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
-	var items []map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &items); err != nil {
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode body: %v", err)
 	}
-	if len(items) != 1 {
-		t.Fatalf("items = %d, want 1", len(items))
+	rawItems, ok := resp["items"].([]any)
+	if !ok || len(rawItems) != 1 {
+		t.Fatalf("items = %v, want 1 item", resp["items"])
 	}
-	if items[0]["status"] != "manually_disabled" {
-		t.Fatalf("status = %v, want manually_disabled", items[0]["status"])
+	item := rawItems[0].(map[string]any)
+	if item["status"] != "manually_disabled" {
+		t.Fatalf("status = %v, want manually_disabled", item["status"])
 	}
 }

--- a/handler/admin/credential_masking.go
+++ b/handler/admin/credential_masking.go
@@ -1,0 +1,46 @@
+package admin
+
+import (
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// credentialFragmentsSelect returns SQL column expressions that expose just
+// enough of a stored credential — the first 4 characters, the last 4
+// characters, and the total length — to rebuild its masked form, WITHOUT
+// materializing the full plaintext secret across the DB→Go boundary. This
+// hardens against logging/metrics side-channels: a credential that is never
+// scanned into Go memory cannot be leaked by a stray slog or metrics call.
+//
+// Aliases are emitted in snake_case so queryRows()' camelCase key mapping
+// yields {aliasBase}Prefix / {aliasBase}Suffix / {aliasBase}Len in the row.
+//
+// SQLite (modernc.org/sqlite) has no LEFT()/RIGHT() built-ins — confirmed by
+// query at runtime — so the SQLite branch uses SUBSTR(s, -4) for the suffix
+// (negative start = count from the right). Postgres + any future driver that
+// exposes LEFT()/RIGHT() uses those for readability.
+func credentialFragmentsSelect(db *sqlx.DB, column, aliasBase string) string {
+	if db != nil && db.DriverName() == "pgx" {
+		return fmt.Sprintf(
+			"LEFT(%s, 4) AS %s_prefix, RIGHT(%s, 4) AS %s_suffix, LENGTH(%s) AS %s_len",
+			column, aliasBase, column, aliasBase, column, aliasBase)
+	}
+	return fmt.Sprintf(
+		"SUBSTR(%s, 1, 4) AS %s_prefix, SUBSTR(%s, -4) AS %s_suffix, LENGTH(%s) AS %s_len",
+		column, aliasBase, column, aliasBase, column, aliasBase)
+}
+
+// maskSecretFromFragments rebuilds the exact maskSecret() output (first4 +
+// "****" + last4, collapsing to "****" for secrets <= 8 chars, "" for empty)
+// from the prefix/suffix/length fragments selected by credentialFragmentsSelect.
+// The plaintext secret never enters Go memory.
+func maskSecretFromFragments(prefix, suffix any, length int64) string {
+	if length <= 0 {
+		return ""
+	}
+	if length <= 8 {
+		return "****"
+	}
+	return coerceString(prefix) + "****" + coerceString(suffix)
+}

--- a/handler/admin/search.go
+++ b/handler/admin/search.go
@@ -24,6 +24,21 @@ type searchRequestBody struct {
 	Limit int    `json:"limit"`
 }
 
+// accountPublicSelectColumns lists every accounts column EXCEPT the plaintext
+// credentials (access_token, api_token). List/search endpoints pair this with
+// credentialFragmentsSelect() to expose masked secrets without ever scanning
+// the full plaintext into Go memory. Mirrors service.SiteSelectColumns.
+const accountPublicSelectColumns = `a.id, a.site_id, a.username, a.balance, a.balance_used,
+	a.quota, a.unit_cost, a.value_score, a.status, a.is_pinned, a.sort_order,
+	a.checkin_enabled, a.last_checkin_at, a.last_balance_refresh, a.oauth_provider,
+	a.oauth_account_key, a.oauth_project_id, a.extra_config, a.created_at,
+	a.updated_at, a.tags`
+
+// accountTokenPublicSelectColumns lists every account_tokens column EXCEPT the
+// plaintext token. Paired with credentialFragmentsSelect("at.token", ...).
+const accountTokenPublicSelectColumns = `at.id, at.account_id, at.name, at.token_group,
+	at.value_status, at.source, at.enabled, at.is_default, at.created_at, at.updated_at`
+
 // POST /api/search
 func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 	var body searchRequestBody
@@ -70,17 +85,25 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 	sites := queryRows(h.db, "SELECT "+service.SiteSelectColumns+" FROM sites WHERE name LIKE ? OR url LIKE ? OR platform LIKE ? LIMIT ?",
 		likePattern, likePattern, likePattern, perCategory)
 
-	// Search accounts
+	// Search accounts. Select only credential fragments (first4/last4/length)
+	// instead of a.* — the plaintext access_token/api_token never cross the
+	// DB→Go boundary, so a stray slog/metrics call cannot leak them. The masked
+	// form is rebuilt in Go by redactSearchAccountSecrets().
 	accounts := queryRows(h.db,
-		`SELECT a.*, s.name as site_name, s.platform as site_platform
+		`SELECT `+accountPublicSelectColumns+`, `+
+			credentialFragmentsSelect(h.db, "a.access_token", "access_token")+`, `+
+			credentialFragmentsSelect(h.db, "a.api_token", "api_token")+`,
+			s.name as site_name, s.platform as site_platform
 		 FROM accounts a INNER JOIN sites s ON a.site_id = s.id
 		 WHERE a.username LIKE ? OR s.name LIKE ? OR s.platform LIKE ?
 		 LIMIT ?`,
 		likePattern, likePattern, likePattern, perCategory)
 
-	// Search account tokens
+	// Search account tokens. Same fragment pattern for at.token.
 	accountTokens := queryRows(h.db,
-		`SELECT at.*, a.username as account_username, s.name as site_name
+		`SELECT `+accountTokenPublicSelectColumns+`, `+
+			credentialFragmentsSelect(h.db, "at.token", "token")+`,
+			a.username as account_username, s.name as site_name
 		 FROM account_tokens at
 		 INNER JOIN accounts a ON at.account_id = a.id
 		 INNER JOIN sites s ON a.site_id = s.id
@@ -131,28 +154,31 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// redactSearchAccountSecrets removes plaintext credentials from search account hits.
+// redactSearchAccountSecrets rebuilds masked credentials from the
+// prefix/suffix/length fragments selected by credentialFragmentsSelect().
+// The plaintext access_token/api_token are never pulled from the DB, so there
+// is nothing to delete — this helper exists to keep the response shape
+// (accessTokenMasked / apiTokenMasked) identical to the prior behavior.
 func redactSearchAccountSecrets(row map[string]any) {
 	if row == nil {
 		return
 	}
-	if s, ok := row["accessToken"].(string); ok && strings.TrimSpace(s) != "" {
-		row["accessTokenMasked"] = maskSecret(s)
+	if accessTokenLen := coerceInt64(row["accessTokenLen"]); accessTokenLen > 0 {
+		row["accessTokenMasked"] = maskSecretFromFragments(row["accessTokenPrefix"], row["accessTokenSuffix"], accessTokenLen)
 	}
-	delete(row, "accessToken")
-	if s, ok := row["apiToken"].(string); ok && strings.TrimSpace(s) != "" {
-		row["apiTokenMasked"] = maskSecret(s)
+	if apiTokenLen := coerceInt64(row["apiTokenLen"]); apiTokenLen > 0 {
+		row["apiTokenMasked"] = maskSecretFromFragments(row["apiTokenPrefix"], row["apiTokenSuffix"], apiTokenLen)
 	}
-	delete(row, "apiToken")
 }
 
-// redactSearchTokenSecrets removes plaintext token from search accountTokens hits.
+// redactSearchTokenSecrets rebuilds the masked token from the prefix/suffix/
+// length fragments selected by credentialFragmentsSelect(). The plaintext
+// token is never pulled from the DB.
 func redactSearchTokenSecrets(row map[string]any) {
 	if row == nil {
 		return
 	}
-	if s, ok := row["token"].(string); ok && strings.TrimSpace(s) != "" {
-		row["tokenMasked"] = maskSecret(s)
+	if tokenLen := coerceInt64(row["tokenLen"]); tokenLen > 0 {
+		row["tokenMasked"] = maskSecretFromFragments(row["tokenPrefix"], row["tokenSuffix"], tokenLen)
 	}
-	delete(row, "token")
 }

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -156,8 +156,15 @@ func (h *tokenRoutesHandler) listSummary(w http.ResponseWriter, r *http.Request)
 func (h *tokenRoutesHandler) listRoutes(w http.ResponseWriter, r *http.Request) {
 	rows := queryRows(h.db, "SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC")
 	// Batch-load all channels once (kill per-route N+1;).
+	// Select only credential fragments (first4/last4/length) instead of the
+	// plaintext access_token/api_token — the full secret never crosses the
+	// DB→Go boundary, so a stray slog/metrics call cannot leak it. The masked
+	// form is rebuilt in Go by routeChannelAccountPublic().
+	accessTokenFrags := credentialFragmentsSelect(h.db, "a.access_token", "access_token")
+	apiTokenFrags := credentialFragmentsSelect(h.db, "a.api_token", "api_token")
 	allChannelRows := queryRows(h.db,
-		`SELECT rc.*, a.username, a.access_token, a.api_token, a.balance, a.status as account_status,
+		`SELECT rc.*, a.username, `+accessTokenFrags+`, `+apiTokenFrags+`,
+		       a.balance, a.status as account_status,
 		        s.id as site_id, s.name as site_name, s.url as site_url, s.platform as site_platform, s.status as site_status
 		 FROM route_channels rc
 		 LEFT JOIN accounts a ON rc.account_id = a.id
@@ -313,6 +320,7 @@ func (h *tokenRoutesHandler) createRoute(w http.ResponseWriter, r *http.Request)
 	}
 	created["sourceRouteIds"] = body.SourceRouteIds
 	routing.InvalidateCache()
+	invalidateChannelsSnapshotCache()
 	writeJSON(w, http.StatusOK, created)
 }
 
@@ -405,6 +413,7 @@ func (h *tokenRoutesHandler) updateRoute(w http.ResponseWriter, r *http.Request)
 	h.db.Select(&srcIDs, h.db.Rebind("SELECT source_route_id FROM route_group_sources WHERE group_route_id = ?"), id)
 	updated["sourceRouteIds"] = srcIDs
 	routing.InvalidateCache()
+	invalidateChannelsSnapshotCache()
 	writeJSON(w, http.StatusOK, updated)
 }
 
@@ -421,6 +430,7 @@ func (h *tokenRoutesHandler) deleteRoute(w http.ResponseWriter, r *http.Request)
 	h.db.Exec(h.db.Rebind("DELETE FROM route_channels WHERE route_id = ?"), id)
 	h.db.Exec(h.db.Rebind("DELETE FROM token_routes WHERE id = ?"), id)
 	routing.InvalidateCache()
+	invalidateChannelsSnapshotCache()
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})
 }
 
@@ -459,6 +469,7 @@ func (h *tokenRoutesHandler) batchRoutes(w http.ResponseWriter, r *http.Request)
 	}
 
 	routing.InvalidateCache()
+	invalidateChannelsSnapshotCache()
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success":      true,
 		"updatedCount": updated,
@@ -484,6 +495,9 @@ func (h *tokenRoutesHandler) rebuildRoutes(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	shared.RecordRouteRebuildCompleted()
+	// Rebuild recomposes route_channels rows; drop the list snapshot so the
+	// next GET /api/channels reflects the rebuilt fleet immediately.
+	invalidateChannelsSnapshotCache()
 	slog.Info("routes rebuild completed",
 		"queued", false,
 		"status", "completed",
@@ -657,7 +671,9 @@ func execInsertID(db *sqlx.DB, query string, args ...any) (int64, error) {
 }
 
 // routeChannelAccountPublic returns account fields for admin route channel lists
-// without plaintext credentials.
+// without plaintext credentials. The masked form is rebuilt from the
+// prefix/suffix/length fragments selected by credentialFragmentsSelect() —
+// the plaintext access_token/api_token are never pulled from the DB.
 func routeChannelAccountPublic(ch map[string]any) map[string]any {
 	out := map[string]any{
 		"id":       ch["accountId"],
@@ -665,22 +681,11 @@ func routeChannelAccountPublic(ch map[string]any) map[string]any {
 		"balance":  ch["balance"],
 		"status":   ch["accountStatus"],
 	}
-	if v, ok := ch["accessToken"]; ok {
-		if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
-			out["accessTokenMasked"] = maskSecret(s)
-		}
+	if accessTokenLen := coerceInt64(ch["accessTokenLen"]); accessTokenLen > 0 {
+		out["accessTokenMasked"] = maskSecretFromFragments(ch["accessTokenPrefix"], ch["accessTokenSuffix"], accessTokenLen)
 	}
-	if v, ok := ch["apiToken"]; ok {
-		switch tv := v.(type) {
-		case string:
-			if strings.TrimSpace(tv) != "" {
-				out["apiTokenMasked"] = maskSecret(tv)
-			}
-		case *string:
-			if tv != nil && strings.TrimSpace(*tv) != "" {
-				out["apiTokenMasked"] = maskSecret(*tv)
-			}
-		}
+	if apiTokenLen := coerceInt64(ch["apiTokenLen"]); apiTokenLen > 0 {
+		out["apiTokenMasked"] = maskSecretFromFragments(ch["apiTokenPrefix"], ch["apiTokenSuffix"], apiTokenLen)
 	}
 	return out
 }

--- a/handler/admin/token_routes_channels.go
+++ b/handler/admin/token_routes_channels.go
@@ -18,7 +18,10 @@ func (h *tokenRoutesHandler) getRouteChannels(w http.ResponseWriter, r *http.Req
 	}
 
 	channelRows := queryRows(h.db,
-		`SELECT rc.*, a.username, a.access_token, a.api_token, a.balance, a.status as account_status,
+		`SELECT rc.*, a.username, `+
+			credentialFragmentsSelect(h.db, "a.access_token", "access_token")+`, `+
+			credentialFragmentsSelect(h.db, "a.api_token", "api_token")+`,
+		        a.balance, a.status as account_status,
 		        s.id as site_id, s.name as site_name, s.url as site_url, s.platform as site_platform, s.status as site_status
 		 FROM route_channels rc
 		 LEFT JOIN accounts a ON rc.account_id = a.id
@@ -107,6 +110,7 @@ func (h *tokenRoutesHandler) addChannel(w http.ResponseWriter, r *http.Request) 
 
 	created := queryRow(h.db, "SELECT * FROM route_channels WHERE id = ?", id)
 	routing.InvalidateCache()
+	invalidateChannelsSnapshotCache()
 	writeJSON(w, http.StatusOK, created)
 }
 
@@ -159,6 +163,7 @@ func (h *tokenRoutesHandler) batchAddChannels(w http.ResponseWriter, r *http.Req
 	}
 
 	routing.InvalidateCache()
+	invalidateChannelsSnapshotCache()
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success": true,
 		"created": created,
@@ -177,6 +182,7 @@ func (h *tokenRoutesHandler) clearCooldown(w http.ResponseWriter, r *http.Reques
 
 	h.db.Exec(h.db.Rebind(`UPDATE route_channels SET cooldown_until = NULL, consecutive_fail_count = 0, cooldown_level = 0 WHERE route_id = ?`), routeID)
 	routing.InvalidateCache()
+	invalidateChannelsSnapshotCache()
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})
 }
 
@@ -209,6 +215,7 @@ func (h *tokenRoutesHandler) batchUpdateChannels(w http.ResponseWriter, r *http.
 	}
 
 	routing.InvalidateCache()
+	invalidateChannelsSnapshotCache()
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success":  true,
 		"channels": normalizeSlice(updatedChannels),
@@ -328,6 +335,7 @@ func (h *tokenRoutesHandler) updateChannel(w http.ResponseWriter, r *http.Reques
 
 	updated := queryRow(h.db, "SELECT * FROM route_channels WHERE id = ?", channelID)
 	routing.InvalidateCache()
+	invalidateChannelsSnapshotCache()
 	writeJSON(w, http.StatusOK, updated)
 }
 
@@ -343,6 +351,7 @@ func (h *tokenRoutesHandler) deleteChannel(w http.ResponseWriter, r *http.Reques
 
 	h.db.Exec(h.db.Rebind("DELETE FROM route_channels WHERE id = ?"), channelID)
 	routing.InvalidateCache()
+	invalidateChannelsSnapshotCache()
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})
 }
 

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -18,6 +18,9 @@ import (
 
 func setupTokenRoutesTest(t *testing.T) (*store.DB, chi.Router) {
 	t.Helper()
+	// Each test gets a fresh :memory: DB; clear the process-global channels
+	// snapshot cache so a prior test's cached page can't shadow this one.
+	globalChannelsCache.clear()
 	db, err := store.Open(store.DialectSQLite, ":memory:", false)
 	if err != nil {
 		t.Fatalf("failed to open SQLite: %v", err)
@@ -1192,13 +1195,22 @@ func TestRoutes_ReorderAndListOrder(t *testing.T) {
 }
 
 func TestRouteChannelAccountPublic_OmitsSecrets(t *testing.T) {
+	// Plaintext secrets are never SELECTed anymore — the row carries only
+	// first4/last4/length fragments. routeChannelAccountPublic rebuilds the
+	// masked form from those fragments and must never expose plaintext.
+	const accessSecret = "FAKE-access-secret-ABCDEF" // 25 chars
+	const apiSecret = "FAKE-api-secret-XYZ12345"    // 25 chars
 	ch := map[string]any{
-		"accountId":     int64(7),
-		"username":      "u",
-		"accessToken":   "sk-access-secret-ABCDEF",
-		"apiToken":      "sk-api-secret-XYZ12345",
-		"balance":       1.5,
-		"accountStatus": "active",
+		"accountId":         int64(7),
+		"username":           "u",
+		"accessTokenPrefix":  accessSecret[:4],
+		"accessTokenSuffix":  accessSecret[len(accessSecret)-4:],
+		"accessTokenLen":     int64(len(accessSecret)),
+		"apiTokenPrefix":     apiSecret[:4],
+		"apiTokenSuffix":     apiSecret[len(apiSecret)-4:],
+		"apiTokenLen":        int64(len(apiSecret)),
+		"balance":            1.5,
+		"accountStatus":      "active",
 	}
 	got := routeChannelAccountPublic(ch)
 	if _, ok := got["accessToken"]; ok {
@@ -1210,8 +1222,16 @@ func TestRouteChannelAccountPublic_OmitsSecrets(t *testing.T) {
 	if got["accessTokenMasked"] == nil || got["apiTokenMasked"] == nil {
 		t.Fatalf("expected masked fields: %#v", got)
 	}
-	if s, _ := got["accessTokenMasked"].(string); strings.Contains(s, "sk-access-secret") {
-		t.Fatalf("mask leaked secret: %q", s)
+	if got["accessTokenMasked"] != maskSecret(accessSecret) {
+		t.Fatalf("accessTokenMasked = %#v, want %q", got["accessTokenMasked"], maskSecret(accessSecret))
+	}
+	if got["apiTokenMasked"] != maskSecret(apiSecret) {
+		t.Fatalf("apiTokenMasked = %#v, want %q", got["apiTokenMasked"], maskSecret(apiSecret))
+	}
+	// No fragment combination may reconstruct the full plaintext secret.
+	body := fmt.Sprintf("%v", got)
+	if strings.Contains(body, accessSecret) || strings.Contains(body, apiSecret) {
+		t.Fatalf("mask leaked plaintext: %s", body)
 	}
 }
 
@@ -1522,20 +1542,47 @@ func TestListRoutes_MultiRouteBatchChannelLoadAndRedaction(t *testing.T) {
 }
 
 func TestRedactSearchSecrets(t *testing.T) {
-	acc := map[string]any{"accessToken": "sk-acc-ABCDEFGH", "apiToken": "sk-api-ABCDEFGH", "username": "x"}
+	// Plaintext tokens are never SELECTed anymore — rows carry only
+	// first4/last4/length fragments. The redact helpers rebuild the masked
+	// form and must match maskSecret() exactly while never holding plaintext.
+	const accSecret = "sk-acc-ABCDEFGH"   // 16 chars
+	const apiSecret = "sk-api-ABCDEFGH"   // 16 chars
+	const tokSecret = "sk-token-ABCDEFGH" // 18 chars
+
+	acc := map[string]any{
+		"accessTokenPrefix": accSecret[:4],
+		"accessTokenSuffix": accSecret[len(accSecret)-4:],
+		"accessTokenLen":    int64(len(accSecret)),
+		"apiTokenPrefix":    apiSecret[:4],
+		"apiTokenSuffix":    apiSecret[len(apiSecret)-4:],
+		"apiTokenLen":       int64(len(apiSecret)),
+		"username":          "x",
+	}
 	redactSearchAccountSecrets(acc)
 	if _, ok := acc["accessToken"]; ok {
-		t.Fatal("accessToken not removed")
+		t.Fatal("accessToken key present (should never be selected)")
 	}
 	if _, ok := acc["apiToken"]; ok {
-		t.Fatal("apiToken not removed")
+		t.Fatal("apiToken key present (should never be selected)")
 	}
-	tok := map[string]any{"token": "sk-token-ABCDEFGH", "name": "n"}
+	if acc["accessTokenMasked"] != maskSecret(accSecret) {
+		t.Fatalf("accessTokenMasked = %#v, want %q", acc["accessTokenMasked"], maskSecret(accSecret))
+	}
+	if acc["apiTokenMasked"] != maskSecret(apiSecret) {
+		t.Fatalf("apiTokenMasked = %#v, want %q", acc["apiTokenMasked"], maskSecret(apiSecret))
+	}
+
+	tok := map[string]any{
+		"tokenPrefix": tokSecret[:4],
+		"tokenSuffix": tokSecret[len(tokSecret)-4:],
+		"tokenLen":    int64(len(tokSecret)),
+		"name":         "n",
+	}
 	redactSearchTokenSecrets(tok)
 	if _, ok := tok["token"]; ok {
-		t.Fatal("token not removed")
+		t.Fatal("token key present (should never be selected)")
 	}
-	if tok["tokenMasked"] == nil {
-		t.Fatal("tokenMasked missing")
+	if tok["tokenMasked"] != maskSecret(tokSecret) {
+		t.Fatalf("tokenMasked = %#v, want %q", tok["tokenMasked"], maskSecret(tokSecret))
 	}
 }


### PR DESCRIPTION
## Summary

- **P1 security — stop pulling plaintext credentials.** Admin list endpoints (`GET /api/routes`, `GET /api/routes/:id/channels`, `POST /api/search`) previously `SELECT`ed plaintext `access_token`/`api_token`/`token` only to mask them into `first4+****+last4` in Go — the full secret crossed the DB→Go boundary unnecessarily, where a stray `slog`/metrics call could leak it. Replaced plaintext columns with length/prefix/suffix fragments (`SUBSTR`+`LENGTH` on SQLite, `LEFT`/`RIGHT`+`LENGTH` on Postgres) and rebuilt the masked form in Go via `maskSecretFromFragments()`. The masked OUTPUT format is byte-identical to the prior `maskSecret()` output — the frontend is unchanged.
- **P1 performance — channels list pagination + cache.** `GET /api/channels` ran a 5-way JOIN over the whole fleet with no `LIMIT`/`OFFSET` and no cache. Added `page`/`pageSize` params (default 50, max 200), `COUNT(*) OVER ()` for the true total, and a 10s TTL snapshot cache mirroring `globalAccountsCache`. Response is now the `{items,total,page,pageSize}` envelope (matching `/api/checkin/logs`). Channel mutations invalidate the cache so edits show immediately.
- **Helpers.** New `credentialFragmentsSelect()` (dialect-aware: SQLite lacks `LEFT()`/`RIGHT()`, so it uses `SUBSTR(s,-4)`) + `maskSecretFromFragments()`. New `accountPublicSelectColumns` / `accountTokenPublicSelectColumns` constants enumerate every column except the plaintext secrets (mirrors `service.SiteSelectColumns`).
- **Tests.** Added security guards asserting list/search response bodies never contain plaintext secrets and masked fields match `maskSecret()`; pagination total across pages incl. past-end fallback `COUNT(*)`; cache hit/miss/`?refresh=true` bypass; mutation invalidation; and a parity table test for `maskSecretFromFragments` vs `maskSecret`. Updated existing channels/redact tests for the new envelope + fragment inputs.

## Test plan

- [x] `go build ./handler/... ./store/... ./service/...` — clean (the pre-existing `web/embed.go: pattern dist` error is an unbuilt frontend artifact, unrelated to this change)
- [x] `go test ./handler/admin/...` — all pass (incl. existing `TestListRoutes_MultiRouteBatchChannelLoadAndRedaction`, `TestChannels_*`, `TestRouteChannelAccountPublic_OmitsSecrets`, `TestRedactSearchSecrets`)
- [x] `go vet ./handler/admin/...` — clean
- [ ] Frontend adaptation for the new `{items,total,page,pageSize}` channels envelope (separate change; same shape as existing paginated endpoints)