### PR TITLE
fix: usage recompute errors + indexes + task retention

### DIFF
--- a/app/services.go
+++ b/app/services.go
@@ -22,7 +22,7 @@ var (
 	webdavScheduler     *scheduler.BackupWebdavScheduler
 )
 
-// StartBackgroundServices creates and starts all 16 background schedulers.
+// StartBackgroundServices creates and starts all 17 background schedulers.
 func StartBackgroundServices() {
 	slog.Info("starting background schedulers")
 
@@ -109,6 +109,12 @@ func buildSchedulers(cfg *config.Config) (
 
 	// ---- Scheduler 13b: Proxy Video Task Retention ----
 	newRegistry.Register(scheduler.NewProxyVideoTaskRetentionScheduler(cfg))
+
+	// ---- Scheduler 13c: Admin Background Task Retention ----
+	// Prunes terminal admin_background_tasks rows older than 30 days so the
+	// table (queried via ORDER BY created_at DESC LIMIT on every /api/tasks
+	// list) cannot grow unboundedly.
+	newRegistry.Register(scheduler.NewAdminBackgroundTaskRetentionScheduler(cfg))
 
 	// ---- Scheduler 14: Proxy Log Retention (legacy fallback) ----
 	newRegistry.Register(scheduler.NewProxyLogRetentionScheduler(cfg))

--- a/app/services_registration_test.go
+++ b/app/services_registration_test.go
@@ -31,6 +31,7 @@ func TestBuildSchedulersRegistration(t *testing.T) {
 		"proxy-file-retention",
 		"proxy-video-task-retention",
 		"proxy-log-retention",
+		"admin-background-task-retention",
 		"oauth-refresh",
 	}
 

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -1946,6 +1946,7 @@ func TestAllSchedulersImplementInterface(t *testing.T) {
 		NewSub2APIRefreshScheduler(cfg),
 		NewUpdateCenterScheduler(cfg),
 		NewSiteAnnouncementScheduler(cfg),
+		NewAdminBackgroundTaskRetentionScheduler(cfg),
 	}
 
 	names := make(map[string]bool)
@@ -1965,6 +1966,7 @@ func TestAllSchedulersImplementInterface(t *testing.T) {
 		"log-cleanup", "daily-summary", "usage-aggregation", "admin-snapshot",
 		"backup-webdav", "proxy-file-retention",
 		"proxy-log-retention", "sub2api-refresh", "update-center", "site-announcement",
+		"admin-background-task-retention",
 	}
 
 	for _, exp := range expectedNames {

--- a/scheduler/task_retention.go
+++ b/scheduler/task_retention.go
@@ -1,0 +1,39 @@
+package scheduler
+
+import (
+	"github.com/deliciousbuding/metapi-go/config"
+)
+
+// adminBackgroundTaskRetentionDays is the fixed retention window for
+// admin_background_tasks. Only terminal rows (succeeded/failed) older than
+// this window are pruned; pending/running rows are never deleted so in-flight
+// tasks remain visible to operators and cross-process task listings.
+const adminBackgroundTaskRetentionDays = 30
+
+// adminBackgroundTaskPruneIntervalMin is the prune cadence. A daily run keeps
+// the table bounded while never threatening a 30-day retention window: a row
+// is eligible for at most ~31 days (retention + up to one prune interval).
+const adminBackgroundTaskPruneIntervalMin = 24 * 60
+
+// AdminBackgroundTaskRetentionScheduler periodically prunes terminal
+// admin_background_tasks rows older than a 30-day window. Without this job the
+// table grows unboundedly (no DELETE path existed), forcing full-scan + sort
+// on every GET /api/tasks list. Implemented by the shared RetentionScheduler.
+type AdminBackgroundTaskRetentionScheduler = RetentionScheduler
+
+// NewAdminBackgroundTaskRetentionScheduler creates the admin background task
+// retention scheduler. It deletes only rows whose status is 'succeeded' or
+// 'failed' and whose created_at is older than the 30-day cutoff, so pending
+// and running tasks are always retained.
+func NewAdminBackgroundTaskRetentionScheduler(cfg *config.Config) *RetentionScheduler {
+	return NewRetentionScheduler(cfg, RetentionSchedulerOptions{
+		Name:               "admin-background-task-retention",
+		Table:              "admin_background_tasks",
+		ExtraWhere:         " AND status IN ('succeeded', 'failed')",
+		UseUTC:             true,
+		DefaultIntervalMin: adminBackgroundTaskPruneIntervalMin,
+		RetentionDaysFn:    func(*config.Config) int { return adminBackgroundTaskRetentionDays },
+		IntervalMinFn:      func(*config.Config) int { return adminBackgroundTaskPruneIntervalMin },
+		DisabledFn:         func(*config.Config) (bool, string) { return false, "" },
+	})
+}

--- a/scheduler/task_retention_test.go
+++ b/scheduler/task_retention_test.go
@@ -1,0 +1,64 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+)
+
+// TestAdminBackgroundTaskRetentionDeletesOldTerminalRowsKeepsRest verifies the
+// daily retention job prunes only terminal (succeeded/failed) rows older than
+// the 30-day window. Pending/running rows and in-window rows are always kept so
+// operators never lose visibility of in-flight or recent tasks.
+func TestAdminBackgroundTaskRetentionDeletesOldTerminalRowsKeepsRest(t *testing.T) {
+	db := openRetentionTestDB(t)
+
+	// Absolute ages relative to real now: retention uses time.Now() - retentionDays.
+	oldAt := time.Now().UTC().Add(-31 * 24 * time.Hour).Format(time.RFC3339) // outside 30d window
+	keepAt := time.Now().UTC().Add(-1 * 24 * time.Hour).Format(time.RFC3339) // inside 30d window
+
+	tasks := []struct {
+		taskID string
+		status string
+		createdAt string
+	}{
+		{"t-old-succeeded", "succeeded", oldAt}, // deleted (terminal + old)
+		{"t-old-failed", "failed", oldAt},       // deleted (terminal + old)
+		{"t-old-pending", "pending", oldAt},     // kept (non-terminal)
+		{"t-old-running", "running", oldAt},     // kept (non-terminal)
+		{"t-new-succeeded", "succeeded", keepAt}, // kept (in window)
+		{"t-new-failed", "failed", keepAt},       // kept (in window)
+	}
+	for _, tk := range tasks {
+		if _, err := db.Exec(
+			`INSERT INTO admin_background_tasks (task_id, type, title, status, created_at, updated_at)
+			 VALUES (?, 'test', ?, ?, ?, ?)`,
+			tk.taskID, tk.taskID, tk.status, tk.createdAt, tk.createdAt); err != nil {
+			t.Fatalf("seed admin_background_tasks %s: %v", tk.taskID, err)
+		}
+	}
+
+	s := NewAdminBackgroundTaskRetentionScheduler(&config.Config{})
+	s.runCleanupLocked(db, adminBackgroundTaskRetentionDays)
+
+	if got := countRows(t, db, `SELECT COUNT(*) FROM admin_background_tasks`); got != 4 {
+		t.Fatalf("admin_background_tasks count = %d, want 4 (2 old terminal deleted)", got)
+	}
+	if got := countRows(t, db, `SELECT COUNT(*) FROM admin_background_tasks WHERE status IN ('succeeded','failed')`); got != 2 {
+		t.Fatalf("terminal rows = %d, want 2 (only in-window retained)", got)
+	}
+	if got := countRows(t, db, `SELECT COUNT(*) FROM admin_background_tasks WHERE status = 'pending'`); got != 1 {
+		t.Errorf("pending rows = %d, want 1 (never pruned)", got)
+	}
+	if got := countRows(t, db, `SELECT COUNT(*) FROM admin_background_tasks WHERE status = 'running'`); got != 1 {
+		t.Errorf("running rows = %d, want 1 (never pruned)", got)
+	}
+	// Old non-terminal rows survive even though they are past the cutoff.
+	if got := countRows(t, db, `SELECT COUNT(*) FROM admin_background_tasks WHERE task_id = ?`, "t-old-pending"); got != 1 {
+		t.Errorf("old pending row deleted; retention must only touch terminal statuses")
+	}
+	if got := countRows(t, db, `SELECT COUNT(*) FROM admin_background_tasks WHERE task_id = ?`, "t-old-running"); got != 1 {
+		t.Errorf("old running row deleted; retention must only touch terminal statuses")
+	}
+}

--- a/scheduler/usage_aggregation.go
+++ b/scheduler/usage_aggregation.go
@@ -45,7 +45,7 @@ func (s *UsageAggregationScheduler) Start(ctx context.Context) error {
 		"lease_ms", usageProjectionLeaseMs,
 	)
 	return s.runner.start(ctx, time.Duration(usageProjectionIntervalMs)*time.Millisecond, true, func() {
-		s.runPass()
+		s.runPass(ctx)
 	})
 }
 
@@ -72,10 +72,10 @@ func (s *UsageAggregationScheduler) RunProjectionPass() *ProjectionPassResult {
 		// De-duplicate: return nil to signal in-flight
 		return nil
 	}
-	return s.runPass()
+	return s.runPass(context.Background())
 }
 
-func (s *UsageAggregationScheduler) runPass() *ProjectionPassResult {
+func (s *UsageAggregationScheduler) runPass(ctx context.Context) *ProjectionPassResult {
 	s.mu.Lock()
 	if s.projectionInFlight {
 		s.mu.Unlock()
@@ -132,7 +132,7 @@ func (s *UsageAggregationScheduler) runPass() *ProjectionPassResult {
 
 		// Recompute phase
 		if cp.RecomputeFromID != nil && *cp.RecomputeFromID > 0 {
-			cp, passErr = s.applyRecompute(dbw, cp)
+			cp, passErr = s.applyRecompute(ctx, dbw, cp)
 			if passErr != nil {
 				return
 			}
@@ -621,7 +621,7 @@ func projectionTimestamp(raw *string) time.Time {
 	return time.Now().UTC()
 }
 
-func (s *UsageAggregationScheduler) applyRecompute(dbw *store.DB, cp projectionCheckpoint) (projectionCheckpoint, error) {
+func (s *UsageAggregationScheduler) applyRecompute(ctx context.Context, dbw *store.DB, cp projectionCheckpoint) (projectionCheckpoint, error) {
 	recomputeFromID := int64(0)
 	if cp.RecomputeFromID != nil {
 		recomputeFromID = *cp.RecomputeFromID
@@ -639,11 +639,22 @@ func (s *UsageAggregationScheduler) applyRecompute(dbw *store.DB, cp projectionC
 		ORDER BY id ASC LIMIT 1
 	`, recomputeFromID)
 	if err := row.Scan(&affectedID, &affectedCreatedAt); err != nil {
-		// Affected row no longer exists - clear recompute
+		// Affected row no longer exists - clear recompute. On failure we keep
+		// recompute_from_id at its prior value so the next pass retries the
+		// clear instead of silently dropping the recompute request.
 		now := time.Now().UTC().Format(time.RFC3339)
-		dbw.Exec(`UPDATE analytics_projection_checkpoints
+		result, err := dbw.ExecContext(ctx, `UPDATE analytics_projection_checkpoints
 			SET recompute_from_id = NULL, recompute_requested_at = NULL, updated_at = ?
 			WHERE projector_key = ?`, now, usageProjectorKey)
+		if err != nil {
+			slog.Error("usage-aggregation: recompute clear (row gone) failed",
+				"error", err, "recompute_from_id", recomputeFromID)
+			return cp, fmt.Errorf("recompute: clear checkpoint (row gone): %w", err)
+		}
+		if affected, _ := result.RowsAffected(); affected == 0 {
+			slog.Warn("usage-aggregation: recompute clear (row gone) affected 0 rows",
+				"recompute_from_id", recomputeFromID)
+		}
 		return projectionCheckpoint{
 			ProjectorKey:         cp.ProjectorKey,
 			TimeZone:             cp.TimeZone,
@@ -667,19 +678,66 @@ func (s *UsageAggregationScheduler) applyRecompute(dbw *store.DB, cp projectionC
 
 	now := time.Now().UTC().Format(time.RFC3339)
 
-	// Delete aggregates for affected day and beyond
-	dbw.Exec("DELETE FROM site_day_usage WHERE local_day >= ?", affectedDay)
-	dbw.Exec("DELETE FROM site_hour_usage WHERE bucket_start_utc >= ?", dayStartUTC.Format(time.RFC3339))
-	dbw.Exec("DELETE FROM model_day_usage WHERE local_day >= ?", affectedDay)
+	// Delete aggregates for the affected day and beyond. Each DELETE is
+	// idempotent, so a mid-sequence failure is safe to retry on the next
+	// pass: recompute_from_id is only cleared by the checkpoint reset below,
+	// which never runs when an earlier step returns an error. This is the
+	// core fix for silent usage-aggregate corruption: a failed DELETE no
+	// longer advances the watermark past the gap it failed to clear.
+	deleteResult, err := dbw.ExecContext(ctx, "DELETE FROM site_day_usage WHERE local_day >= ?", affectedDay)
+	if err != nil {
+		slog.Error("usage-aggregation: recompute delete site_day_usage failed",
+			"error", err, "affected_day", affectedDay)
+		return cp, fmt.Errorf("recompute: delete site_day_usage: %w", err)
+	}
+	if deleted, _ := deleteResult.RowsAffected(); deleted > 0 {
+		slog.Info("usage-aggregation: recompute deleted site_day_usage",
+			"rows", deleted, "affected_day", affectedDay)
+	}
 
-	// Reset checkpoint
+	hourCutoff := dayStartUTC.Format(time.RFC3339)
+	deleteResult, err = dbw.ExecContext(ctx, "DELETE FROM site_hour_usage WHERE bucket_start_utc >= ?", hourCutoff)
+	if err != nil {
+		slog.Error("usage-aggregation: recompute delete site_hour_usage failed",
+			"error", err, "hour_cutoff", hourCutoff)
+		return cp, fmt.Errorf("recompute: delete site_hour_usage: %w", err)
+	}
+	if deleted, _ := deleteResult.RowsAffected(); deleted > 0 {
+		slog.Info("usage-aggregation: recompute deleted site_hour_usage",
+			"rows", deleted, "hour_cutoff", hourCutoff)
+	}
+
+	deleteResult, err = dbw.ExecContext(ctx, "DELETE FROM model_day_usage WHERE local_day >= ?", affectedDay)
+	if err != nil {
+		slog.Error("usage-aggregation: recompute delete model_day_usage failed",
+			"error", err, "affected_day", affectedDay)
+		return cp, fmt.Errorf("recompute: delete model_day_usage: %w", err)
+	}
+	if deleted, _ := deleteResult.RowsAffected(); deleted > 0 {
+		slog.Info("usage-aggregation: recompute deleted model_day_usage",
+			"rows", deleted, "affected_day", affectedDay)
+	}
+
+	// Reset checkpoint so projection replays from just before the affected row.
+	// This runs only after all three DELETEs succeeded, so a partial failure
+	// leaves recompute_from_id set and the next pass replays the whole rewind.
 	restartFromID := affectedID - 1
 	if restartFromID < 0 {
 		restartFromID = 0
 	}
-	dbw.Exec(`UPDATE analytics_projection_checkpoints
+	result, err := dbw.ExecContext(ctx, `UPDATE analytics_projection_checkpoints
 		SET last_proxy_log_id = ?, recompute_from_id = NULL, recompute_requested_at = NULL, updated_at = ?
 		WHERE projector_key = ?`, restartFromID, now, usageProjectorKey)
+	if err != nil {
+		slog.Error("usage-aggregation: recompute checkpoint reset failed",
+			"error", err, "restart_from_id", restartFromID)
+		return cp, fmt.Errorf("recompute: reset checkpoint: %w", err)
+	}
+	if affected, _ := result.RowsAffected(); affected == 0 {
+		slog.Error("usage-aggregation: recompute checkpoint reset affected 0 rows",
+			"restart_from_id", restartFromID)
+		return cp, fmt.Errorf("recompute: reset checkpoint affected 0 rows")
+	}
 
 	return projectionCheckpoint{
 		ProjectorKey:         cp.ProjectorKey,

--- a/scheduler/usage_recompute_test.go
+++ b/scheduler/usage_recompute_test.go
@@ -1,0 +1,243 @@
+package scheduler
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// seedRecomputeCheckpoint installs (or upserts) the projection checkpoint with a
+// pending recompute starting at recomputeFromID, mirroring how RequestRecompute
+// records the rewind point for the next pass.
+func seedRecomputeCheckpoint(t *testing.T, db *store.DB, watermark, recomputeFromID int64) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(`INSERT INTO analytics_projection_checkpoints
+		(projector_key, time_zone, last_proxy_log_id, lease_owner, lease_token, lease_expires_at, created_at, updated_at, recompute_from_id, recompute_requested_at)
+		VALUES (?, 'UTC', ?, NULL, NULL, NULL, ?, ?, ?, ?)
+		ON CONFLICT(projector_key) DO UPDATE SET
+			last_proxy_log_id = excluded.last_proxy_log_id,
+			lease_owner = NULL,
+			lease_token = NULL,
+			lease_expires_at = NULL,
+			last_error = NULL,
+			recompute_from_id = excluded.recompute_from_id,
+			recompute_requested_at = excluded.recompute_requested_at,
+			updated_at = excluded.updated_at`,
+		usageProjectorKey, watermark, now, now, recomputeFromID, now); err != nil {
+		t.Fatalf("seed recompute checkpoint: %v", err)
+	}
+}
+
+func seedDayUsageRow(t *testing.T, db *store.DB, siteID int64, day, now string) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO site_day_usage (local_day, site_id, total_calls, created_at, updated_at)
+		VALUES (?, ?, 1, ?, ?)`, day, siteID, now, now); err != nil {
+		t.Fatalf("seed site_day_usage: %v", err)
+	}
+}
+
+func seedHourUsageRow(t *testing.T, db *store.DB, siteID int64, hour, now string) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO site_hour_usage (bucket_start_utc, site_id, total_calls, created_at, updated_at)
+		VALUES (?, ?, 1, ?, ?)`, hour, siteID, now, now); err != nil {
+		t.Fatalf("seed site_hour_usage: %v", err)
+	}
+}
+
+func seedModelDayUsageRow(t *testing.T, db *store.DB, siteID int64, day, model, now string) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO model_day_usage (local_day, site_id, model, total_calls, created_at, updated_at)
+		VALUES (?, ?, ?, 1, ?, ?)`, day, siteID, model, now, now); err != nil {
+		t.Fatalf("seed model_day_usage: %v", err)
+	}
+}
+
+// readCheckpointRecompute reads last_proxy_log_id + recompute_from_id back from
+// the DB so tests can assert the on-disk state after applyRecompute.
+func readCheckpointRecompute(t *testing.T, db *store.DB) (watermark int64, recompute *int64) {
+	t.Helper()
+	row := db.QueryRow(`SELECT last_proxy_log_id, recompute_from_id
+		FROM analytics_projection_checkpoints WHERE projector_key = ?`, usageProjectorKey)
+	if err := row.Scan(&watermark, &recompute); err != nil {
+		t.Fatalf("read checkpoint recompute: %v", err)
+	}
+	return watermark, recompute
+}
+
+// TestApplyRecomputeDeletesAggregatesAndResetsCheckpoint is the positive path:
+// a recompute from a known log id wipes the three usage tables for the affected
+// day onward and rewinds the watermark so the next pass replays that window.
+func TestApplyRecomputeDeletesAggregatesAndResetsCheckpoint(t *testing.T) {
+	db := openRetentionTestDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	suffix := strings.ReplaceAll(t.Name(), "/", "-")
+
+	siteID := insertProjectionSite(t, db, suffix, now)
+	accountID := insertProjectionAccount(t, db, siteID, suffix, now)
+
+	logTime := time.Date(2026, 7, 6, 10, 37, 42, 0, time.UTC)
+	logID := insertProjectionProxyLog(t, db, accountID, "success", "gpt-4.1", 120, 0.42, 230, logTime)
+
+	affectedDay := logTime.Format("2006-01-02")
+	affectedHour := logTime.Truncate(time.Hour).Format(time.RFC3339)
+
+	// Stale aggregates for the affected day must be deleted by the recompute.
+	seedDayUsageRow(t, db, siteID, affectedDay, now)
+	seedHourUsageRow(t, db, siteID, affectedHour, now)
+	seedModelDayUsageRow(t, db, siteID, affectedDay, "gpt-4.1", now)
+
+	seedRecomputeCheckpoint(t, db, logID, logID)
+
+	s := NewUsageAggregationScheduler(testConfig())
+	cp := projectionCheckpoint{
+		ProjectorKey:   usageProjectorKey,
+		TimeZone:       "UTC",
+		LastProxyLogID: logID,
+		RecomputeFromID: &logID,
+	}
+
+	out, err := s.applyRecompute(context.Background(), db, cp)
+	if err != nil {
+		t.Fatalf("applyRecompute returned error: %v", err)
+	}
+
+	wantRestart := logID - 1
+	if wantRestart < 0 {
+		wantRestart = 0
+	}
+	if out.LastProxyLogID != wantRestart {
+		t.Errorf("returned watermark = %d, want %d", out.LastProxyLogID, wantRestart)
+	}
+	if out.RecomputeFromID != nil {
+		t.Errorf("returned RecomputeFromID = %v, want nil (cleared)", *out.RecomputeFromID)
+	}
+
+	if n := countRows(t, db, `SELECT COUNT(*) FROM site_day_usage WHERE site_id = ? AND local_day >= ?`, siteID, affectedDay); n != 0 {
+		t.Errorf("site_day_usage rows after recompute = %d, want 0", n)
+	}
+	if n := countRows(t, db, `SELECT COUNT(*) FROM site_hour_usage WHERE site_id = ? AND bucket_start_utc >= ?`, siteID, affectedHour); n != 0 {
+		t.Errorf("site_hour_usage rows after recompute = %d, want 0", n)
+	}
+	if n := countRows(t, db, `SELECT COUNT(*) FROM model_day_usage WHERE site_id = ? AND local_day >= ?`, siteID, affectedDay); n != 0 {
+		t.Errorf("model_day_usage rows after recompute = %d, want 0", n)
+	}
+
+	watermark, recompute := readCheckpointRecompute(t, db)
+	if watermark != wantRestart {
+		t.Errorf("db watermark = %d, want %d", watermark, wantRestart)
+	}
+	if recompute != nil {
+		t.Errorf("db recompute_from_id = %v, want NULL (cleared)", *recompute)
+	}
+}
+
+// TestApplyRecomputeAbortsOnErrorKeepsRecomputeFlag is the regression guard for
+// the silent-corruption bug: when a DELETE/UPDATE fails, the recompute must
+// abort and leave recompute_from_id at its prior value so the next pass retries
+// the whole rewind instead of advancing the watermark past the un-cleared gap.
+//
+// The error is injected by cancelling the job context; database/sql then returns
+// context.Canceled from ExecContext without ever issuing the DELETE, so the
+// stale aggregates survive and the checkpoint is left untouched.
+func TestApplyRecomputeAbortsOnErrorKeepsRecomputeFlag(t *testing.T) {
+	db := openRetentionTestDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	suffix := strings.ReplaceAll(t.Name(), "/", "-")
+
+	siteID := insertProjectionSite(t, db, suffix, now)
+	accountID := insertProjectionAccount(t, db, siteID, suffix, now)
+
+	logTime := time.Date(2026, 7, 6, 10, 37, 42, 0, time.UTC)
+	logID := insertProjectionProxyLog(t, db, accountID, "success", "gpt-4.1", 120, 0.42, 230, logTime)
+
+	affectedDay := logTime.Format("2006-01-02")
+	seedDayUsageRow(t, db, siteID, affectedDay, now)
+
+	seedRecomputeCheckpoint(t, db, logID, logID)
+
+	s := NewUsageAggregationScheduler(testConfig())
+	cp := projectionCheckpoint{
+		ProjectorKey:   usageProjectorKey,
+		TimeZone:       "UTC",
+		LastProxyLogID: logID,
+		RecomputeFromID: &logID,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	out, err := s.applyRecompute(ctx, db, cp)
+	if err == nil {
+		t.Fatal("applyRecompute with cancelled ctx returned nil error; want non-nil")
+	}
+
+	// The returned checkpoint must still carry recompute_from_id so the caller
+	// does not believe the rewind completed.
+	if out.RecomputeFromID == nil {
+		t.Fatal("returned RecomputeFromID = nil; want kept for retry")
+	}
+	if *out.RecomputeFromID != logID {
+		t.Errorf("returned RecomputeFromID = %d, want %d", *out.RecomputeFromID, logID)
+	}
+
+	// On-disk checkpoint must be unchanged: watermark unchanged and
+	// recompute_from_id still set so the next pass replays the rewind.
+	watermark, recompute := readCheckpointRecompute(t, db)
+	if watermark != logID {
+		t.Errorf("db watermark = %d, want %d (must not advance on abort)", watermark, logID)
+	}
+	if recompute == nil {
+		t.Fatal("db recompute_from_id = NULL; want still set so next run retries")
+	}
+	if *recompute != logID {
+		t.Errorf("db recompute_from_id = %d, want %d", *recompute, logID)
+	}
+
+	// The stale aggregate must survive because the DELETE never executed.
+	if n := countRows(t, db, `SELECT COUNT(*) FROM site_day_usage WHERE site_id = ? AND local_day = ?`, siteID, affectedDay); n != 1 {
+		t.Errorf("site_day_usage rows = %d, want 1 (DELETE must not run on aborted ctx)", n)
+	}
+}
+
+// TestApplyRecomputeNoopWhenRecomputeFlagUnset guards the early return so a pass
+// with no pending recompute does not touch any usage table or the checkpoint.
+func TestApplyRecomputeNoopWhenRecomputeFlagUnset(t *testing.T) {
+	db := openRetentionTestDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	suffix := strings.ReplaceAll(t.Name(), "/", "-")
+
+	siteID := insertProjectionSite(t, db, suffix, now)
+	accountID := insertProjectionAccount(t, db, siteID, suffix, now)
+	logID := insertProjectionProxyLog(t, db, accountID, "success", "gpt-4.1", 120, 0.42, 230,
+		time.Date(2026, 7, 6, 10, 37, 42, 0, time.UTC))
+
+	affectedDay := "2026-07-06"
+	seedDayUsageRow(t, db, siteID, affectedDay, now)
+	seedRecomputeCheckpoint(t, db, logID, 0) // recompute_from_id = 0 → no-op
+
+	s := NewUsageAggregationScheduler(testConfig())
+	cp := projectionCheckpoint{
+		ProjectorKey:   usageProjectorKey,
+		TimeZone:       "UTC",
+		LastProxyLogID: logID,
+		// RecomputeFromID intentionally nil
+	}
+
+	out, err := s.applyRecompute(context.Background(), db, cp)
+	if err != nil {
+		t.Fatalf("applyRecompute noop returned error: %v", err)
+	}
+	if out.LastProxyLogID != logID {
+		t.Errorf("noop watermark = %d, want %d (unchanged)", out.LastProxyLogID, logID)
+	}
+	if out.RecomputeFromID != nil {
+		t.Errorf("noop RecomputeFromID = %v, want nil", *out.RecomputeFromID)
+	}
+	if n := countRows(t, db, `SELECT COUNT(*) FROM site_day_usage WHERE site_id = ? AND local_day = ?`, siteID, affectedDay); n != 1 {
+		t.Errorf("site_day_usage rows = %d, want 1 (noop must not delete)", n)
+	}
+}

--- a/store/indexes.go
+++ b/store/indexes.go
@@ -1,6 +1,6 @@
 package store
 
-// buildIndexes returns all 67 non-UNIQUE index creation statements.
+// buildIndexes returns all 69 non-UNIQUE index creation statements.
 // Both SQLite and PostgreSQL support CREATE INDEX IF NOT EXISTS syntax.
 // UNIQUE constraints are already handled inside CREATE TABLE via CONSTRAINT... UNIQUE.
 func buildIndexes() []struct {
@@ -121,6 +121,10 @@ func buildIndexes() []struct {
 		{"events_read_created_at_idx", `CREATE INDEX IF NOT EXISTS events_read_created_at_idx ON events (read, created_at)`},
 		{"events_type_created_at_idx", `CREATE INDEX IF NOT EXISTS events_type_created_at_idx ON events (type, created_at)`},
 		{"events_created_at_idx", `CREATE INDEX IF NOT EXISTS events_created_at_idx ON events (created_at)`},
+		// admin_background_tasks
+		{"admin_background_tasks_created_at_idx", `CREATE INDEX IF NOT EXISTS admin_background_tasks_created_at_idx ON admin_background_tasks (created_at)`},
+		// announcement_dismissals
+		{"announcement_dismissals_announcement_id_idx", `CREATE INDEX IF NOT EXISTS announcement_dismissals_announcement_id_idx ON announcement_dismissals (announcement_id)`},
 	}
 }
 


### PR DESCRIPTION
## Summary

- **P1 — `applyRecompute` silent corruption**: the recompute path ran 3 `DELETE`s on the usage-aggregate tables plus 2 checkpoint `UPDATE`s via unchecked `dbw.Exec` with no context. A failed `DELETE` silently left stale aggregates while the checkpoint still rewrote, permanently corrupting that day's numbers. All five statements now use `dbw.ExecContext(ctx, ...)` with per-statement error checks; on any failure the recompute **aborts and keeps `recompute_from_id`** at its prior value so the next pass replays the whole rewind (idempotent `DELETE`s make retry safe). The job context is now threaded from `Start(ctx)` → `runPass(ctx)` → `applyRecompute(ctx, …)`.
- **P1 — `admin_background_tasks` unbounded growth + full-scan list**: the `ORDER BY created_at DESC LIMIT` query in `handler/admin/tasks.go` had no index and no `DELETE` path existed anywhere. Added `admin_background_tasks_created_at_idx ON admin_background_tasks (created_at)` (idempotent `CREATE INDEX IF NOT EXISTS`, applied on every startup via `buildIndexes()`) and a new daily `admin-background-task-retention` scheduler that prunes only terminal (`succeeded`/`failed`) rows older than 30 days — pending/running rows are always kept.
- **P2 — `announcement_dismissals` JOIN index**: the `LEFT JOIN announcement_dismissals d ON d.announcement_id = a.id` in `handler/admin/announcements.go` scanned the dismissal table per announcement. Added `announcement_dismissals_announcement_id_idx ON announcement_dismissals (announcement_id)`.

## Changes
- `scheduler/usage_aggregation.go`: `runPass`/`applyRecompute` take a `context.Context`; 5 `Exec` → `ExecContext` with error logging + abort; watermark/`recompute_from_id` left intact on abort.
- `store/indexes.go`: 2 new indexes (`admin_background_tasks_created_at_idx`, `announcement_dismissals_announcement_id_idx`); doc count 67 → 69.
- `scheduler/task_retention.go` (new): `AdminBackgroundTaskRetentionScheduler` built on the shared `RetentionScheduler` (30-day retention, daily prune, UTC RFC3339 cutoffs consistent with the sibling proxy-file/video-task retention jobs).
- `app/services.go`: register the new scheduler (Scheduler 13c); count 16 → 17.
- Tests: `scheduler/usage_recompute_test.go` (positive recompute deletes + resets watermark; **error abort keeps `recompute_from_id` and leaves aggregates/checkpoint untouched**; no-op when flag unset) and `scheduler/task_retention_test.go` (deletes old terminal rows, keeps pending/running + in-window rows). Interface-compliance test extended.

## Verification
- `go build ./scheduler/... ./store/... ./app/... ./handler/...` — clean.
- `go vet ./scheduler/... ./store/... ./app/...` — clean.
- `go test -race ./scheduler/... ./store/...` — `ok scheduler`, `ok store`.
- New tests pass: `TestApplyRecomputeDeletesAggregatesAndResetsCheckpoint`, `TestApplyRecomputeAbortsOnErrorKeepsRecomputeFlag`, `TestApplyRecomputeNoopWhenRecomputeFlagUnset`, `TestAdminBackgroundTaskRetentionDeletesOldTerminalRowsKeepsRest`, `TestAllSchedulersImplementInterface`.

## Notes
- All schema changes are additive (new indexes only, `IF NOT EXISTS`); no existing column/table touched.
- `go build ./...` (whole repo) surfaces a pre-existing, unrelated `web/embed.go: pattern dist: no matching files found` (frontend `dist` not built in this worktree) — untouched by this PR; the Go packages changed here build clean.

## Test plan
- [ ] Fresh boot migrates both new indexes (`CREATE INDEX IF NOT EXISTS` is idempotent on existing installs).
- [ ] Trigger a recompute (`RequestRecompute`) and confirm the three usage tables are wiped for the affected day onward and the watermark rewinds.
- [ ] With the DB briefly unreachable mid-recompute, confirm `recompute_from_id` is **not** cleared and the next pass retries.
- [ ] Seed `admin_background_tasks` with 31-day-old `succeeded`/`failed`/`pending` rows and confirm only old terminal rows are pruned after the retention tick.