### PR TITLE
fix: config validation + SSE env to config

### DIFF
--- a/config/body_limit_test.go
+++ b/config/body_limit_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -127,12 +128,26 @@ func TestLoadProxyRateLimitRPMIgnoresInvalidValue(t *testing.T) {
 	}
 }
 
-func TestLoadProxyRateLimitRPMClampsNegativeToZero(t *testing.T) {
+// Negative RPM values are intentionally left intact by Load so config.Validate
+// can surface a startup warning ("use 0 for explicit disable"). The limiter
+// consumer (auth.ProxyRateLimit) still treats <=0 as disabled, so the only
+// observable effect of a negative is the warning — no silent disable.
+func TestLoadProxyRateLimitRPMPreservesNegativeForValidation(t *testing.T) {
 	cfg := Load(map[string]string{
 		"PROXY_RATE_LIMIT_RPM": "-5",
 	})
-	if cfg.ProxyRateLimitRPM != 0 {
-		t.Fatalf("ProxyRateLimitRPM = %d, want 0 (clamped from negative)", cfg.ProxyRateLimitRPM)
+	if cfg.ProxyRateLimitRPM != -5 {
+		t.Fatalf("ProxyRateLimitRPM = %d, want -5 (preserved for Validate warning)", cfg.ProxyRateLimitRPM)
+	}
+	var warned bool
+	for _, err := range cfg.Validate() {
+		if IsWarning(err) && strings.Contains(err.Error(), "proxy_rate_limit_rpm") {
+			warned = true
+			break
+		}
+	}
+	if !warned {
+		t.Fatal("Validate did not warn on negative PROXY_RATE_LIMIT_RPM")
 	}
 }
 
@@ -156,12 +171,24 @@ func TestLoadProxyGlobalTokenRPMParsesCustomValue(t *testing.T) {
 	}
 }
 
-func TestLoadProxyGlobalTokenRPMClampsNegativeToZero(t *testing.T) {
+// Negative values are preserved (not clamped) so Validate can warn; the global
+// token limiter still treats <=0 as unlimited, matching 0 = explicit disable.
+func TestLoadProxyGlobalTokenRPMPreservesNegativeForValidation(t *testing.T) {
 	cfg := Load(map[string]string{
 		"PROXY_GLOBAL_TOKEN_RPM": "-10",
 	})
-	if cfg.ProxyGlobalTokenRPM != 0 {
-		t.Fatalf("ProxyGlobalTokenRPM = %d, want 0 (clamped from negative)", cfg.ProxyGlobalTokenRPM)
+	if cfg.ProxyGlobalTokenRPM != -10 {
+		t.Fatalf("ProxyGlobalTokenRPM = %d, want -10 (preserved for Validate warning)", cfg.ProxyGlobalTokenRPM)
+	}
+	var warned bool
+	for _, err := range cfg.Validate() {
+		if IsWarning(err) && strings.Contains(err.Error(), "proxy_global_token_rpm") {
+			warned = true
+			break
+		}
+	}
+	if !warned {
+		t.Fatal("Validate did not warn on negative PROXY_GLOBAL_TOKEN_RPM")
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -252,11 +252,16 @@ type Config struct {
 	ProxySessionChannelLeaseTtlMs       int
 	ProxySessionChannelLeaseKeepaliveMs int
 
-	// Proxy: Misc (6 fields)
+	// Proxy: Misc (7 fields)
 	CodexUpstreamWebsocketEnabled              bool
 	ResponsesCompactFallbackToResponsesEnabled bool
 	DisableCrossProtocolFallback               bool
 	ProxyEmptyContentFailEnabled               bool
+	// ProxyMaxStreamResponseBytes caps the total bytes relayed for a single
+	// SSE stream before a controlled termination (default 1 MB). Parsed once
+	// at startup from PROXY_MAX_STREAM_RESPONSE_BYTES so the hot stream path
+	// reads a struct field instead of calling os.Getenv per request.
+	ProxyMaxStreamResponseBytes int
 	ProxyErrorKeywords                         []string
 	GlobalBlockedBrands                        []string
 	GlobalAllowedModels                        []string
@@ -647,9 +652,13 @@ func Load(env map[string]string) *Config {
 	cfg.FileUploadLimitBytes = fileUploadLimitMB * 1024 * 1024
 
 	// Per-IP rate limiting for /v1 proxy routes (default 60 RPM; 0 = disabled).
-	cfg.ProxyRateLimitRPM = maxInt(0, int(math.Trunc(parseNumber(get("PROXY_RATE_LIMIT_RPM"), float64(DefaultProxyRateLimitRPM)))))
+	// Negative values are NOT clamped here so config.Validate can warn the
+	// operator — consumers (auth.ProxyRateLimit) already treat <=0 as disabled,
+	// so the only observable effect of a negative is the startup warning.
+	cfg.ProxyRateLimitRPM = int(math.Trunc(parseNumber(get("PROXY_RATE_LIMIT_RPM"), float64(DefaultProxyRateLimitRPM))))
 	// Global PROXY_TOKEN RPM cap across all IPs (default 0 = unlimited).
-	cfg.ProxyGlobalTokenRPM = maxInt(0, int(math.Trunc(parseNumber(get("PROXY_GLOBAL_TOKEN_RPM"), 0))))
+	// Negative left intact for Validate to warn on; <=0 disables at the limiter.
+	cfg.ProxyGlobalTokenRPM = int(math.Trunc(parseNumber(get("PROXY_GLOBAL_TOKEN_RPM"), 0)))
 
 	cfg.RoutingFallbackUnitCost = math.Max(1e-6, parseNumber(get("ROUTING_FALLBACK_UNIT_COST"), 1))
 	// Seconds; internal first-byte observation uses ms = sec * 1000.
@@ -665,7 +674,10 @@ func Load(env map[string]string) *Config {
 	cfg.TokenRouterCacheTtlMs = maxInt(100, int(math.Trunc(parseNumber(get("TOKEN_ROUTER_CACHE_TTL_MS"), DefaultTokenRouterCacheTtlMs))))
 
 	// ---- §3.15 Proxy: Channel ----
-	cfg.ProxyMaxChannelAttempts = maxInt(1, int(math.Trunc(parseNumber(get("PROXY_MAX_CHANNEL_ATTEMPTS"), DefaultProxyMaxChannelAttempts))))
+	// Negative left intact so config.Validate can warn the operator; the
+	// consumer (GetProxyMaxChannelAttempts) already clamps <=0 to 1, so the
+	// only observable effect of a negative is the startup warning.
+	cfg.ProxyMaxChannelAttempts = int(math.Trunc(parseNumber(get("PROXY_MAX_CHANNEL_ATTEMPTS"), DefaultProxyMaxChannelAttempts)))
 	cfg.ProxyStickySessionEnabled = parseBoolean(get("PROXY_STICKY_SESSION_ENABLED"), true)
 	cfg.ProxyStickySessionTtlMs = maxInt(30000, int(math.Trunc(parseNumber(get("PROXY_STICKY_SESSION_TTL_MS"), float64(DefaultProxyStickySessionTtlMs)))))
 
@@ -680,6 +692,14 @@ func Load(env map[string]string) *Config {
 	cfg.ResponsesCompactFallbackToResponsesEnabled = parseBoolean(get("RESPONSES_COMPACT_FALLBACK_TO_RESPONSES_ENABLED"), false)
 	cfg.DisableCrossProtocolFallback = parseBoolean(get("DISABLE_CROSS_PROTOCOL_FALLBACK"), false)
 	cfg.ProxyEmptyContentFailEnabled = parseBoolean(get("PROXY_EMPTY_CONTENT_FAIL"), false)
+	// PROXY_MAX_STREAM_RESPONSE_BYTES caps a single SSE stream (default 1 MB).
+	// 0/negative/invalid resolves to the default so the hot stream path never
+	// has to re-parse env or guard against a zero limit. Read once here.
+	streamBytesParsed := int(math.Trunc(parseNumber(get("PROXY_MAX_STREAM_RESPONSE_BYTES"), float64(DefaultProxyMaxStreamResponseBytes))))
+	if streamBytesParsed <= 0 {
+		streamBytesParsed = DefaultProxyMaxStreamResponseBytes
+	}
+	cfg.ProxyMaxStreamResponseBytes = streamBytesParsed
 	cfg.ProxyErrorKeywords = parseCsvList(get("PROXY_ERROR_KEYWORDS"))
 	cfg.GlobalBlockedBrands = []string{}
 	cfg.GlobalAllowedModels = []string{}

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -97,5 +97,12 @@ const (
 	DefaultProxyDebugRetentionHours = 24
 	DefaultProxyDebugMaxBodyBytes   = 262144
 
+	// DefaultProxyMaxStreamResponseBytes caps the total bytes relayed for a
+	// single SSE stream before a controlled termination (1 MB). Parsed from
+	// PROXY_MAX_STREAM_RESPONSE_BYTES; 0/negative/invalid falls back to this
+	// default. Read once at startup via config.Load — the stream handler reads
+	// the resolved value from the config singleton, not os.Getenv per request.
+	DefaultProxyMaxStreamResponseBytes = 1 << 20 // 1 MB
+
 	TelegramApiBaseUrl = "https://api.telegram.org"
 )

--- a/config/validate.go
+++ b/config/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/netip"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/robfig/cron/v3"
@@ -297,6 +298,122 @@ func (c *Config) Validate() []error {
 		})
 	}
 
+	// --- Critical/Warning: Lease keepalive vs TTL sanity ---
+	// keepalive > TTL is a genuine correctness bug: the lease expires before
+	// the renewal heartbeat can land, so sessions silently drop. keepalive ==
+	// TTL is borderline (no renewal headroom) and only warrants a warning.
+	if c.ProxySessionChannelLeaseKeepaliveMs > c.ProxySessionChannelLeaseTtlMs {
+		errs = append(errs, &configError{
+			field:    "proxy_session_channel_lease_keepalive_ms",
+			value:    fmt.Sprintf("%d > %d (ttl)", c.ProxySessionChannelLeaseKeepaliveMs, c.ProxySessionChannelLeaseTtlMs),
+			msg:      "keepalive interval must be < lease TTL — leases expire before renewal",
+			critical: true,
+		})
+	} else if c.ProxySessionChannelLeaseKeepaliveMs == c.ProxySessionChannelLeaseTtlMs && c.ProxySessionChannelLeaseTtlMs > 0 {
+		errs = append(errs, &configError{
+			field:    "proxy_session_channel_lease_keepalive_ms",
+			value:    fmt.Sprintf("%d == %d (ttl)", c.ProxySessionChannelLeaseKeepaliveMs, c.ProxySessionChannelLeaseTtlMs),
+			msg:      "keepalive equals TTL — set keepalive strictly less than TTL for renewal headroom",
+			critical: false,
+		})
+	}
+
+	// --- Warning: negative values silently disable limits ---
+	// Consumers treat <=0 as disabled, so a negative configures "disabled"
+	// without the operator realizing it. Recommend 0 for explicit disable.
+	if c.ProxyRateLimitRPM < 0 {
+		errs = append(errs, &configError{
+			field:    "proxy_rate_limit_rpm",
+			value:    fmt.Sprintf("%d", c.ProxyRateLimitRPM),
+			msg:      "negative value silently disables the per-IP limiter — use 0 for explicit disable",
+			critical: false,
+		})
+	}
+	if c.ProxyGlobalTokenRPM < 0 {
+		errs = append(errs, &configError{
+			field:    "proxy_global_token_rpm",
+			value:    fmt.Sprintf("%d", c.ProxyGlobalTokenRPM),
+			msg:      "negative value silently disables the global token limiter — use 0 for explicit disable",
+			critical: false,
+		})
+	}
+	if c.ProxyMaxChannelAttempts < 0 {
+		errs = append(errs, &configError{
+			field:    "proxy_max_channel_attempts",
+			value:    fmt.Sprintf("%d", c.ProxyMaxChannelAttempts),
+			msg:      "negative value silently clamps attempts to 1 — use 0 to disable retries",
+			critical: false,
+		})
+	}
+
+	// --- Warning: range checks for proxy session / router knobs ---
+	if c.ProxySessionChannelConcurrencyLimit < 1 {
+		errs = append(errs, &configError{
+			field:    "proxy_session_channel_concurrency_limit",
+			value:    fmt.Sprintf("%d", c.ProxySessionChannelConcurrencyLimit),
+			msg:      "should be >= 1 — 0 disables per-channel concurrency control",
+			critical: false,
+		})
+	}
+	if c.ProxyStickySessionEnabled && c.ProxyStickySessionTtlMs <= 0 {
+		errs = append(errs, &configError{
+			field:    "proxy_sticky_session_ttl_ms",
+			value:    fmt.Sprintf("%d", c.ProxyStickySessionTtlMs),
+			msg:      "should be > 0 when sticky sessions are enabled",
+			critical: false,
+		})
+	}
+	if c.TokenRouterCacheTtlMs <= 0 {
+		errs = append(errs, &configError{
+			field:    "token_router_cache_ttl_ms",
+			value:    fmt.Sprintf("%d", c.TokenRouterCacheTtlMs),
+			msg:      "should be > 0 — a non-positive cache TTL disables token-router caching",
+			critical: false,
+		})
+	}
+	if c.ProxySessionChannelQueueWaitMs < 0 {
+		errs = append(errs, &configError{
+			field:    "proxy_session_channel_queue_wait_ms",
+			value:    fmt.Sprintf("%d", c.ProxySessionChannelQueueWaitMs),
+			msg:      "should be >= 0 — negative values are treated as 0 (no queue wait)",
+			critical: false,
+		})
+	}
+
+	// --- Warning: webhook / service URLs must be well-formed http(s) ---
+	webhookUrls := []struct{ field, val string }{
+		{"webhook_url", c.WebhookUrl},
+		{"bark_url", c.BarkUrl},
+		{"feishu_webhook", c.FeishuWebhook},
+		{"dingtalk_webhook", c.DingtalkWebhook},
+		{"wecom_webhook", c.WecomWebhook},
+		{"ntfy_url", c.NtfyUrl},
+		{"resin_url", c.ResinURL},
+		{"telegram_api_base_url", c.TelegramApiBaseUrl},
+	}
+	for _, u := range webhookUrls {
+		if err := validateUrl(u.field, u.val, true); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	// --- Warning: proxy / redis URLs must parse (scheme left open) ---
+	for _, u := range []struct{ field, val string }{
+		{"system_proxy_url", c.SystemProxyUrl},
+		{"redis_url", c.RedisURL},
+	} {
+		if err := validateUrl(u.field, u.val, false); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// --- Warning: checkin window bounds must be HH:mm ---
+	if err := validateHhMm("checkin_window_start", c.CheckinWindowStart); err != nil {
+		errs = append(errs, err)
+	}
+	if err := validateHhMm("checkin_window_end", c.CheckinWindowEnd); err != nil {
+		errs = append(errs, err)
+	}
+
 	return errs
 }
 
@@ -323,6 +440,89 @@ func IsCritical(err error) bool {
 		return ce.critical
 	}
 	return false
+}
+
+// IsWarning returns true if the error represents a non-fatal config warning.
+// It is the complement of IsCritical for config errors produced by Validate.
+func IsWarning(err error) bool {
+	if ce, ok := err.(*configError); ok {
+		return !ce.critical
+	}
+	return false
+}
+
+// validateUrl parses a URL string and returns a warning configError when the
+// value is malformed. For webhook-style URLs (requireWebScheme=true) it also
+// warns when the scheme is not http/https; otherwise it warns when the URL is
+// missing a scheme or host. Empty values are treated as unset (no error).
+func validateUrl(field, value string, requireWebScheme bool) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return &configError{
+			field:    field,
+			value:    value,
+			msg:      "malformed URL — " + err.Error(),
+			critical: false,
+		}
+	}
+	if requireWebScheme {
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return &configError{
+				field:    field,
+				value:    value,
+				msg:      "scheme must be http or https",
+				critical: false,
+			}
+		}
+	} else if parsed.Scheme == "" {
+		return &configError{
+			field:    field,
+			value:    value,
+			msg:      "URL is missing a scheme",
+			critical: false,
+		}
+	}
+	if parsed.Host == "" {
+		return &configError{
+			field:    field,
+			value:    value,
+			msg:      "URL is missing a host",
+			critical: false,
+		}
+	}
+	return nil
+}
+
+// validateHhMm validates a 24h HH:mm window bound (2 digits : 2 digits with
+// hours 00-23 and minutes 00-59). Empty values are treated as unset.
+func validateHhMm(field, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	if len(value) != 5 || value[2] != ':' {
+		return &configError{
+			field:    field,
+			value:    value,
+			msg:      "must be HH:mm (2 digits : 2 digits)",
+			critical: false,
+		}
+	}
+	hh, errH := strconv.Atoi(value[:2])
+	mm, errM := strconv.Atoi(value[3:])
+	if errH != nil || errM != nil || hh < 0 || hh > 23 || mm < 0 || mm > 59 {
+		return &configError{
+			field:    field,
+			value:    value,
+			msg:      "must be HH:mm with hours 00-23 and minutes 00-59",
+			critical: false,
+		}
+	}
+	return nil
 }
 
 // ValidateCronExpr checks if a cron expression is parseable. Auto-normalizes

--- a/config/validate_hardening_test.go
+++ b/config/validate_hardening_test.go
@@ -1,0 +1,272 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// validBaseConfig returns a Config that is free of every existing Validate
+// warning/critical so the hardening tests can isolate a single rule by
+// flipping one field and asserting exactly one new diagnostic appears.
+func validBaseConfig() *Config {
+	return &Config{
+		AuthToken:                "admin-token-1234",
+		ProxyToken:               "proxy-token-1234",
+		AccountCredentialSecret:  "credential-secret-1234567890",
+		ClaudeClientId:           "claude-client-id",
+		CodexClientId:            "codex-client-id",
+		GeminiCliClientId:        "gemini-cli-client-id",
+		Port:                     4000,
+		ListenHost:               "0.0.0.0",
+		DbType:                   "sqlite",
+		DbMaxOpenConns:           10,
+		DbMaxIdleConns:           3,
+		DbConnMaxLifetimeSec:     1800,
+		DbConnMaxIdleTimeSec:     300,
+		CheckinScheduleMode:      "cron",
+		CheckinCron:              "0 8 * * *",
+		BalanceRefreshCron:       "0 * * * *",
+		LogCleanupCron:           "0 6 * * *",
+		CheckinIntervalHours:     6,
+		CheckinWindowStart:       "00:00",
+		CheckinWindowEnd:         "23:59",
+		NotifyCooldownSec:        300,
+		ProxyRateLimitRPM:        60,
+		ProxyGlobalTokenRPM:      0,
+		ProxyMaxChannelAttempts:  3,
+		ProxySessionChannelConcurrencyLimit: 2,
+		ProxyStickySessionEnabled:           false,
+		ProxyStickySessionTtlMs:             30 * 60 * 1000,
+		TokenRouterCacheTtlMs:               1500,
+		ProxySessionChannelQueueWaitMs:      1500,
+		ProxySessionChannelLeaseTtlMs:       90000,
+		ProxySessionChannelLeaseKeepaliveMs: 15000,
+		TelegramApiBaseUrl:                  "https://api.telegram.org",
+	}
+}
+
+// assertHasError fails the test unless Validate returns a diagnostic whose
+// message contains substr and whose severity matches wantCritical.
+func assertHasError(t *testing.T, cfg *Config, substr string, wantCritical bool) {
+	t.Helper()
+	for _, err := range cfg.Validate() {
+		if !strings.Contains(err.Error(), substr) {
+			continue
+		}
+		if wantCritical && !IsCritical(err) {
+			t.Fatalf("expected critical error for %q, got non-critical: %v", substr, err)
+		}
+		if !wantCritical && !IsWarning(err) {
+			t.Fatalf("expected warning for %q, got critical: %v", substr, err)
+		}
+		return
+	}
+	t.Fatalf("Validate did not return an error containing %q", substr)
+}
+
+// assertNoErrorFor fails the test if Validate returns any error mentioning substr.
+func assertNoErrorFor(t *testing.T, cfg *Config, substr string) {
+	t.Helper()
+	for _, err := range cfg.Validate() {
+		if strings.Contains(err.Error(), substr) {
+			t.Fatalf("Validate unexpectedly returned error for %q: %v", substr, err)
+		}
+	}
+}
+
+func TestValidateLeaseKeepaliveExceedsTtlIsCritical(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.ProxySessionChannelLeaseKeepaliveMs = 30000
+	cfg.ProxySessionChannelLeaseTtlMs = 10000
+	assertHasError(t, cfg, "proxy_session_channel_lease_keepalive_ms", true)
+}
+
+func TestValidateLeaseKeepaliveEqualsTtlIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.ProxySessionChannelLeaseKeepaliveMs = 30000
+	cfg.ProxySessionChannelLeaseTtlMs = 30000
+	assertHasError(t, cfg, "proxy_session_channel_lease_keepalive_ms", false)
+}
+
+func TestValidateLeaseKeepaliveBelowTtlIsClean(t *testing.T) {
+	cfg := validBaseConfig()
+	// keepalive (15000) < ttl (90000): the healthy default path must not warn.
+	assertNoErrorFor(t, cfg, "proxy_session_channel_lease_keepalive_ms")
+}
+
+func TestValidateNegativeProxyRateLimitRPMIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.ProxyRateLimitRPM = -5
+	assertHasError(t, cfg, "proxy_rate_limit_rpm", false)
+}
+
+func TestValidateZeroProxyRateLimitRPMIsClean(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.ProxyRateLimitRPM = 0 // explicit disable must not warn.
+	assertNoErrorFor(t, cfg, "proxy_rate_limit_rpm")
+}
+
+func TestValidateNegativeProxyGlobalTokenRPMIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.ProxyGlobalTokenRPM = -1
+	assertHasError(t, cfg, "proxy_global_token_rpm", false)
+}
+
+func TestValidateNegativeProxyMaxChannelAttemptsIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.ProxyMaxChannelAttempts = -2
+	assertHasError(t, cfg, "proxy_max_channel_attempts", false)
+}
+
+func TestValidateNegativeRateLimitRPMFromEnvIsWarning(t *testing.T) {
+	// End-to-end: PROXY_RATE_LIMIT_RPM is no longer clamped at parse time, so
+	// a negative env value reaches Validate and surfaces an operator warning.
+	cfg := Load(map[string]string{
+		"AUTH_TOKEN":               "admin-token-1234",
+		"PROXY_TOKEN":              "proxy-token-1234",
+		"ACCOUNT_CREDENTIAL_SECRET": "credential-secret-1234567890",
+		"CLAUDE_CLIENT_ID":         "claude-client-id",
+		"CODEX_CLIENT_ID":          "codex-client-id",
+		"GEMINI_CLI_CLIENT_ID":     "gemini-cli-client-id",
+		"PROXY_RATE_LIMIT_RPM":     "-5",
+	})
+	assertHasError(t, cfg, "proxy_rate_limit_rpm", false)
+}
+
+func TestValidateConcurrencyLimitBelowOneIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.ProxySessionChannelConcurrencyLimit = 0
+	assertHasError(t, cfg, "proxy_session_channel_concurrency_limit", false)
+}
+
+func TestValidateStickySessionTtlNonPositiveIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.ProxyStickySessionEnabled = true
+	cfg.ProxyStickySessionTtlMs = 0
+	assertHasError(t, cfg, "proxy_sticky_session_ttl_ms", false)
+}
+
+func TestValidateStickySessionDisabledSkipsTtlCheck(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.ProxyStickySessionEnabled = false
+	cfg.ProxyStickySessionTtlMs = 0 // disabled, so ttl is irrelevant
+	assertNoErrorFor(t, cfg, "proxy_sticky_session_ttl_ms")
+}
+
+func TestValidateTokenRouterCacheTtlNonPositiveIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.TokenRouterCacheTtlMs = 0
+	assertHasError(t, cfg, "token_router_cache_ttl_ms", false)
+}
+
+func TestValidateQueueWaitMsNegativeIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.ProxySessionChannelQueueWaitMs = -100
+	assertHasError(t, cfg, "proxy_session_channel_queue_wait_ms", false)
+}
+
+func TestValidateMalformedWebhookUrlIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.WebhookUrl = "://not-a-url"
+	assertHasError(t, cfg, "webhook_url", false)
+}
+
+func TestValidateNonHttpSchemeWebhookUrlIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.FeishuWebhook = "ftp://example.com/hook"
+	assertHasError(t, cfg, "feishu_webhook", false)
+}
+
+func TestValidateWebhookUrlMissingHostIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.BarkUrl = "https://"
+	assertHasError(t, cfg, "bark_url", false)
+}
+
+func TestValidateValidWebhookUrlsAreClean(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.WebhookUrl = "https://hooks.example.com/wh"
+	cfg.BarkUrl = "https://bark.example.com/key"
+	cfg.FeishuWebhook = "https://feishu.example.com/hook"
+	cfg.DingtalkWebhook = "https://oapi.dingtalk.com/hook"
+	cfg.WecomWebhook = "https://qyapi.weixin.example.com/hook"
+	cfg.NtfyUrl = "https://ntfy.example.com/topic"
+	cfg.ResinURL = "http://resin.local:2260/my-token"
+	for _, field := range []string{
+		"webhook_url", "bark_url", "feishu_webhook",
+		"dingtalk_webhook", "wecom_webhook", "ntfy_url", "resin_url",
+	} {
+		assertNoErrorFor(t, cfg, field)
+	}
+}
+
+func TestValidateMalformedRedisUrlIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.RedisURL = "://bad-redis"
+	assertHasError(t, cfg, "redis_url", false)
+}
+
+func TestValidateRedisUrlWithRedisSchemeIsClean(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.RedisURL = "redis://localhost:6379/0"
+	assertNoErrorFor(t, cfg, "redis_url")
+}
+
+func TestValidateSystemProxyUrlWithSocks5IsClean(t *testing.T) {
+	// system_proxy_url allows non-http schemes (e.g. socks5), so only a
+	// genuinely malformed / scheme-less value should warn.
+	cfg := validBaseConfig()
+	cfg.SystemProxyUrl = "socks5://proxy.local:1080"
+	assertNoErrorFor(t, cfg, "system_proxy_url")
+}
+
+func TestValidateSystemProxyUrlMissingSchemeIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.SystemProxyUrl = "proxy.local:1080"
+	assertHasError(t, cfg, "system_proxy_url", false)
+}
+
+func TestValidateBadHhMmFormatIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.CheckinWindowStart = "9:00" // not 2-digit
+	assertHasError(t, cfg, "checkin_window_start", false)
+}
+
+func TestValidateOutOfRangeHhMmIsWarning(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.CheckinWindowEnd = "25:99"
+	assertHasError(t, cfg, "checkin_window_end", false)
+}
+
+func TestValidateValidHhMmIsClean(t *testing.T) {
+	cfg := validBaseConfig()
+	cfg.CheckinWindowStart = "08:30"
+	cfg.CheckinWindowEnd = "22:15"
+	assertNoErrorFor(t, cfg, "checkin_window_start")
+	assertNoErrorFor(t, cfg, "checkin_window_end")
+}
+
+func TestLoadProxyMaxStreamResponseBytesDefaultAndOverride(t *testing.T) {
+	// Default when unset.
+	cfg := Load(map[string]string{})
+	if cfg.ProxyMaxStreamResponseBytes != DefaultProxyMaxStreamResponseBytes {
+		t.Fatalf("unset ProxyMaxStreamResponseBytes = %d, want %d",
+			cfg.ProxyMaxStreamResponseBytes, DefaultProxyMaxStreamResponseBytes)
+	}
+	// Explicit override.
+	cfg = Load(map[string]string{"PROXY_MAX_STREAM_RESPONSE_BYTES": "2048"})
+	if cfg.ProxyMaxStreamResponseBytes != 2048 {
+		t.Fatalf("ProxyMaxStreamResponseBytes = %d, want 2048", cfg.ProxyMaxStreamResponseBytes)
+	}
+	// Non-positive falls back to the default.
+	cfg = Load(map[string]string{"PROXY_MAX_STREAM_RESPONSE_BYTES": "0"})
+	if cfg.ProxyMaxStreamResponseBytes != DefaultProxyMaxStreamResponseBytes {
+		t.Fatalf("zero ProxyMaxStreamResponseBytes = %d, want default %d",
+			cfg.ProxyMaxStreamResponseBytes, DefaultProxyMaxStreamResponseBytes)
+	}
+	cfg = Load(map[string]string{"PROXY_MAX_STREAM_RESPONSE_BYTES": "-10"})
+	if cfg.ProxyMaxStreamResponseBytes != DefaultProxyMaxStreamResponseBytes {
+		t.Fatalf("negative ProxyMaxStreamResponseBytes = %d, want default %d",
+			cfg.ProxyMaxStreamResponseBytes, DefaultProxyMaxStreamResponseBytes)
+	}
+}

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -40,8 +40,6 @@ type UpstreamConfig struct {
 var upstreamCfg *UpstreamConfig
 var unconfiguredUpstreamLogOnce sync.Once
 
-const defaultMaxStreamResponseBytes int64 = 128 << 20
-
 // defaultUpstreamClient is used as a safety fallback when the RuntimeExecutor
 // has not been wired (e.g., during tests). It carries a 90s timeout so a hung
 // upstream never leaks a goroutine, and the shared RejectCrossOriginRedirect

--- a/handler/proxy/upstream_stream.go
+++ b/handler/proxy/upstream_stream.go
@@ -5,11 +5,10 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/config"
 	"github.com/deliciousbuding/metapi-go/handler/shared"
 	"github.com/deliciousbuding/metapi-go/proxy"
 )
@@ -50,7 +49,7 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 
 	analyzer := newIncrementalSseAnalyzer()
 	sawStreamBytes := false
-	maxStreamBytes := maxStreamResponseBytes()
+	maxStreamBytes := streamResponseByteLimit()
 	var streamedBytes int64
 	buf := make([]byte, 4096)
 	for {
@@ -146,10 +145,11 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 			LogSseErrorEvents(result.ErrorEvents)
 		}
 
-		// Check for empty content (stream ended with no data events)
+		// Check for empty content (stream ended with no data events).
+		// ProxyEmptyContentFailEnabled is read from the startup-loaded config
+		// singleton instead of os.Getenv per stream request.
 		if !result.HasDataEvent {
-			emptyContentFail := os.Getenv("PROXY_EMPTY_CONTENT_FAIL")
-			if strings.ToLower(emptyContentFail) == "true" || emptyContentFail == "1" {
+			if cfg := config.GetSafe(); cfg != nil && cfg.ProxyEmptyContentFailEnabled {
 				slog.Warn("SSE stream contained no data events",
 					"latency_ms", latencyMs,
 					"event_count", result.EventCount,
@@ -164,16 +164,17 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 	return empty
 }
 
-func maxStreamResponseBytes() int64 {
-	raw := strings.TrimSpace(os.Getenv("PROXY_MAX_STREAM_RESPONSE_BYTES"))
-	if raw == "" {
-		return defaultMaxStreamResponseBytes
+// streamResponseByteLimit returns the configured max SSE stream response size
+// in bytes from the startup-loaded config singleton. Falls back to
+// DefaultProxyMaxStreamResponseBytes when config is not yet loaded (e.g. tests
+// that bypass TestMain) or when the operator left the value at zero/negative.
+// Reading a struct field per request is materially cheaper than re-parsing
+// os.Getenv on every SSE stream and keeps the hot path allocation-free here.
+func streamResponseByteLimit() int64 {
+	if cfg := config.GetSafe(); cfg != nil && cfg.ProxyMaxStreamResponseBytes > 0 {
+		return int64(cfg.ProxyMaxStreamResponseBytes)
 	}
-	n, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil || n <= 0 {
-		return defaultMaxStreamResponseBytes
-	}
-	return n
+	return int64(config.DefaultProxyMaxStreamResponseBytes)
 }
 
 func writeSSEStreamError(w http.ResponseWriter, flusher http.Flusher, message, typ string) {

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -134,6 +134,14 @@ func TestStreamUpstreamNon2xxRelaysJSONErrorStatus(t *testing.T) {
 }
 
 func TestHandleStreamUpstreamRelaysLargeSSE(t *testing.T) {
+	// The default stream byte limit (1 MB) would truncate this ~2 MB stream,
+	// so raise the config singleton for this test and restore it after.
+	prev := config.Get()
+	cfgCopy := *prev
+	cfgCopy.ProxyMaxStreamResponseBytes = 128 << 20
+	config.Set(&cfgCopy)
+	t.Cleanup(func() { config.Set(prev) })
+
 	event := "data: " + strings.Repeat("x", 512) + "\n\n"
 	var body strings.Builder
 	for i := 0; i < 4096; i++ {
@@ -165,7 +173,13 @@ func TestHandleStreamUpstreamRelaysLargeSSE(t *testing.T) {
 }
 
 func TestHandleStreamUpstreamStopsAtConfiguredByteLimit(t *testing.T) {
-	t.Setenv("PROXY_MAX_STREAM_RESPONSE_BYTES", "32")
+	// The stream byte limit is now read from the config singleton (set once
+	// at startup), not os.Getenv per request, so override the singleton here.
+	prev := config.Get()
+	cfgCopy := *prev
+	cfgCopy.ProxyMaxStreamResponseBytes = 32
+	config.Set(&cfgCopy)
+	t.Cleanup(func() { config.Set(prev) })
 
 	raw := "data: " + strings.Repeat("x", 128) + "\n\n"
 	resp := &http.Response{


### PR DESCRIPTION
## Summary
- **P2 — Config validation hardening** (`config/validate.go`): adds `IsWarning()` and surfaces startup diagnostics for the gaps that previously failed silently — lease keepalive vs TTL (critical when keepalive > TTL), negative `PROXY_RATE_LIMIT_RPM` / `PROXY_GLOBAL_TOKEN_RPM` / `PROXY_MAX_CHANNEL_ATTEMPTS` (warn + suggest 0 for explicit disable), out-of-range proxy session/router knobs (concurrency ≥1, sticky ttl >0 when enabled, token-router cache ttl >0, queue wait ≥0), malformed / non-http(s) webhook + service URLs (system_proxy + redis scheme left open), and checkin window bounds not matching `HH:mm` with 00–23/00–59 ranges. To make the negative-value warning operator-visible, the `maxInt(0/-)`/`maxInt(1)` clamps on those three env vars are removed in `Load` — consumers already treat `<=0` as disabled, so valid inputs are unchanged and the only new effect is the warning.
- **P3 — Move SSE env reads into config** (`handler/proxy/upstream_stream.go`): the hot stream path no longer calls `os.Getenv` per request. `PROXY_MAX_STREAM_RESPONSE_BYTES` (default 1 MB, new `ProxyMaxStreamResponseBytes`) and `PROXY_EMPTY_CONTENT_FAIL` (reuses the existing `ProxyEmptyContentFailEnabled`) are parsed once at startup in `config.Load` and read as struct fields off the config singleton. The old per-request `maxStreamResponseBytes()` helper and the unused 128 MB default const are removed.
- **Tests**: new `config/validate_hardening_test.go` covers every rule (critical for keepalive > TTL, warning for negative rate limit incl. an env→Load→Validate end-to-end case, malformed URL, bad HH:mm, plus clean-path assertions). The two proxy stream tests that used `t.Setenv` now override the config singleton, and the `body_limit_test.go` clamp tests are flipped to assert negatives are preserved + warned.

## Build & test
- `go build ./config/... ./handler/proxy/...` ✅ and `go vet ./config/... ./handler/proxy/...` ✅ (clean)
- `go test ./config/... ./handler/proxy/...` ✅ — both packages `ok`
- `go build ./...` reports only the pre-existing `web/embed.go` "dist" error (generated frontend assets absent from the worktree); `web/` is unchanged in this PR.

## Test plan
- [ ] `go test ./config/... ./handler/proxy/...` passes locally
- [ ] Startup with `PROXY_RATE_LIMIT_RPM=-5` logs a warning (not silent disable)
- [ ] Startup with `PROXY_SESSION_CHANNEL_LEASE_KEEPALIVE_MS` > TTL exits critical (lease correctness bug)
- [ ] SSE stream still terminates at the configured byte limit; `PROXY_MAX_STREAM_RESPONSE_BYTES` override respected

Co-authored-by: Cursor <cursor@vectorcontrol.tech>