### PR TITLE
fix: SSE error + error boundary + WS origin + shutdown cancel

### DIFF
--- a/handler/admin/ops_ws.go
+++ b/handler/admin/ops_ws.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
-	"github.com/go-chi/chi/v5"
 	"github.com/deliciousbuding/metapi-go/config"
 	"github.com/deliciousbuding/metapi-go/handler/shared"
+	"github.com/go-chi/chi/v5"
 )
 
 // ---- B2: live ops WebSocket ----
@@ -53,7 +53,15 @@ func (h *opsWSHandler) serve(w http.ResponseWriter, r *http.Request) {
 	}
 
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		OriginPatterns: []string{"*"}, // admin UI served from the same origin
+		// Restrict cross-origin WebSocket upgrades to the operator-configured
+		// admin origins (ADMIN_CORS_ALLOWED_ORIGINS) plus localhost/127.0.0.1
+		// for dev. When no origins are configured, the slice is empty which
+		// makes coder/websocket enforce same-origin only (Origin host must
+		// match the request Host) — the safe default for an unconfigured box.
+		// The token check above is unaffected; this only tightens the
+		// browser-origin gate so a cross-site page cannot ride an admin's
+		// session via WebSocket.
+		OriginPatterns: opsWSOriginPatterns(h.cfg),
 	})
 	if err != nil {
 		return // handshake failure already written
@@ -107,4 +115,27 @@ func constantTimeEqual(a, b string) bool {
 		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// opsWSOriginPatterns returns the authorized WebSocket origin host patterns.
+//
+// When AdminCorsAllowedOrigins is empty the result is nil, which makes
+// coder/websocket enforce same-origin only (the Origin host must match the
+// request Host). When origins are configured, the configured entries are
+// returned alongside localhost/127.0.0.1 so local dev against a configured
+// box still works. Patterns are matched against the Origin URL host (or
+// scheme://host when the pattern itself contains "://"), matching the
+// library's authenticateOrigin rules.
+func opsWSOriginPatterns(cfg *config.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	configured := cfg.AdminCorsAllowedOrigins
+	if len(configured) == 0 {
+		return nil
+	}
+	patterns := make([]string, 0, len(configured)+2)
+	patterns = append(patterns, configured...)
+	patterns = append(patterns, "localhost", "127.0.0.1")
+	return patterns
 }

--- a/handler/admin/ops_ws_test.go
+++ b/handler/admin/ops_ws_test.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
-	"github.com/go-chi/chi/v5"
 	"github.com/deliciousbuding/metapi-go/config"
 	"github.com/deliciousbuding/metapi-go/handler/shared"
+	"github.com/go-chi/chi/v5"
 )
 
 // ---- B2: live ops WebSocket ----
@@ -88,5 +88,116 @@ func TestOpsWS_RequiresValidToken(t *testing.T) {
 	last := frame.Points[len(frame.Points)-1]
 	if last.Total < 1 || last.Success < 1 {
 		t.Fatalf("last point = %+v, want recorded traffic", last)
+	}
+}
+
+// TestOpsWSOriginPatterns covers the origin-restriction helper:
+//   - nil/empty config -> nil (same-origin only, the safe default)
+//   - configured origins -> configured + localhost/127.0.0.1 (dev convenience)
+func TestOpsWSOriginPatterns(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *config.Config
+		want []string
+	}{
+		{name: "nil config", cfg: nil, want: nil},
+		{name: "empty origins", cfg: &config.Config{}, want: nil},
+		{
+			name: "single origin",
+			cfg:  &config.Config{AdminCorsAllowedOrigins: []string{"admin.example.test"}},
+			want: []string{"admin.example.test", "localhost", "127.0.0.1"},
+		},
+		{
+			name: "multiple origins",
+			cfg:  &config.Config{AdminCorsAllowedOrigins: []string{"a.example", "b.example"}},
+			want: []string{"a.example", "b.example", "localhost", "127.0.0.1"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := opsWSOriginPatterns(tc.cfg)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d (got %v)", len(got), len(tc.want), got)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestOpsWS_RejectsCrossOriginWhenUnconfigured verifies that with no
+// AdminCorsAllowedOrigins set, a cross-origin WebSocket upgrade (Origin host
+// != request Host) is rejected with 403 — the safe same-origin default. The
+// admin token is valid; the rejection is purely on the Origin gate.
+func TestOpsWS_RejectsCrossOriginWhenUnconfigured(t *testing.T) {
+	cfg := &config.Config{AuthToken: "admin-secret-token"} // no AdminCorsAllowedOrigins
+	r := chi.NewRouter()
+	RegisterOpsWSRoutes(r, cfg)
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + srv.URL[4:] + "/api/admin/ops/ws?token=admin-secret-token"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, httpResp, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Origin": []string{"http://evil.example"}},
+	})
+	if err == nil {
+		t.Fatal("cross-origin dial should fail when origins are unconfigured")
+	}
+	if httpResp == nil {
+		t.Fatal("dial response is nil; want 403 response")
+	}
+	if httpResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("cross-origin status = %d, want 403", httpResp.StatusCode)
+	}
+}
+
+// TestOpsWS_AllowsConfiguredCrossOrigin verifies that when an origin is
+// present in AdminCorsAllowedOrigins, the cross-origin upgrade succeeds and
+// the server pushes frames.
+func TestOpsWS_AllowsConfiguredCrossOrigin(t *testing.T) {
+	cfg := &config.Config{
+		AuthToken:               "admin-secret-token",
+		AdminCorsAllowedOrigins: []string{"evil.example"},
+	}
+	r := chi.NewRouter()
+	RegisterOpsWSRoutes(r, cfg)
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + srv.URL[4:] + "/api/admin/ops/ws?token=admin-secret-token"
+
+	shared.ResetRealtimeForTest()
+	t.Cleanup(shared.ResetRealtimeForTest)
+	shared.RecordRealtimeOutcome(true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Origin": []string{"http://evil.example"}},
+	})
+	if err != nil {
+		t.Fatalf("configured cross-origin dial failed: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read frame: %v", err)
+	}
+	var frame struct {
+		Lifetime int64 `json:"lifetime"`
+	}
+	if err := json.Unmarshal(data, &frame); err != nil {
+		t.Fatalf("unmarshal frame: %v (%s)", err, string(data))
+	}
+	if frame.Lifetime < 1 {
+		t.Fatalf("lifetime = %d, want >= 1", frame.Lifetime)
 	}
 }

--- a/handler/proxy/upstream_stream.go
+++ b/handler/proxy/upstream_stream.go
@@ -124,6 +124,11 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 		}
 		if err != nil {
 			if err != io.EOF {
+				// Mid-stream upstream failure (network reset, upstream crash,
+				// truncated body): emit a final SSE error event so the client
+				// can surface the failure explicitly instead of inferring it
+				// from a missing [DONE] marker. Mirrors the byte-limit path.
+				writeSSEStreamError(w, flusher, "upstream stream interrupted", "upstream_error")
 				slog.Warn("SSE stream read error", "err", err, "latency_ms", latencyMs)
 			}
 			break

--- a/handler/proxy/upstream_stream_test.go
+++ b/handler/proxy/upstream_stream_test.go
@@ -1,0 +1,117 @@
+package proxyhandler
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// errorAfterReader emits the given payload on the first Read and then returns
+// err on every subsequent Read. It models a mid-stream upstream failure where
+// the connection resets after partial data — the exact case the SSE error
+// event must surface to the client.
+type errorAfterReader struct {
+	payload  []byte
+	consumed bool
+	err      error
+}
+
+func (r *errorAfterReader) Read(p []byte) (int, error) {
+	if !r.consumed {
+		n := copy(p, r.payload)
+		r.consumed = true
+		return n, nil
+	}
+	return 0, r.err
+}
+
+func (r *errorAfterReader) Close() error { return nil }
+
+// TestHandleStreamUpstreamEmitsErrorEventOnReadError verifies that a
+// non-EOF read error from the upstream body triggers a final SSE error
+// event (plus [DONE]) before the connection closes. Without this event the
+// client would only see a truncated stream and have to infer failure from
+// the missing [DONE] marker.
+func TestHandleStreamUpstreamEmitsErrorEventOnReadError(t *testing.T) {
+	raw := "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"
+	body := &errorAfterReader{
+		payload: []byte(raw),
+		err:     errors.New("upstream connection reset"),
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(body),
+	}
+	resp.Header.Set("Content-Type", "text/event-stream")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	handleStreamUpstream(rec, req, resp, 7)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	out := rec.Body.String()
+
+	if !strings.HasPrefix(out, raw) {
+		t.Fatalf("body should start with the partial upstream chunk; got prefix %q", prefix(out, len(raw)))
+	}
+	if !strings.Contains(out, `data: {"error":{"message":"upstream stream interrupted","type":"upstream_error"}}`) {
+		t.Fatalf("body = %q, want SSE error event for upstream stream interrupted", out)
+	}
+	if !strings.Contains(out, "data: [DONE]") {
+		t.Fatalf("body = %q, want [DONE] marker after error event", out)
+	}
+	// Error event must come after the partial data, not replace it.
+	errorIdx := strings.Index(out, "upstream stream interrupted")
+	doneIdx := strings.Index(out, "data: [DONE]")
+	dataIdx := strings.Index(out, `data: {"choices"`)
+	if errorIdx < 0 || doneIdx < 0 || dataIdx < 0 {
+		t.Fatalf("missing expected segments in body: %q", out)
+	}
+	if dataIdx > errorIdx {
+		t.Fatalf("partial data chunk must precede the error event; dataIdx=%d errorIdx=%d", dataIdx, errorIdx)
+	}
+	if errorIdx > doneIdx {
+		t.Fatalf("error event must precede the [DONE] marker; errorIdx=%d doneIdx=%d", errorIdx, doneIdx)
+	}
+}
+
+// TestHandleStreamUpstreamNoErrorEventOnCleanEOF verifies a clean EOF (the
+// normal end-of-stream path) does NOT inject an error event — only non-EOF
+// read errors surface the upstream_error event.
+func TestHandleStreamUpstreamNoErrorEventOnCleanEOF(t *testing.T) {
+	raw := "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n"
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(raw)),
+	}
+	resp.Header.Set("Content-Type", "text/event-stream")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	handleStreamUpstream(rec, req, resp, 3)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	out := rec.Body.String()
+	if out != raw {
+		t.Fatalf("body = %q, want clean relay of upstream body", out)
+	}
+	if strings.Contains(out, "upstream stream interrupted") {
+		t.Fatalf("clean EOF must not emit an upstream_error event; body=%q", out)
+	}
+}
+
+func prefix(s string, n int) string {
+	if len(s) < n {
+		return s
+	}
+	return s[:n]
+}

--- a/scheduler/checkin.go
+++ b/scheduler/checkin.go
@@ -32,6 +32,15 @@ type CheckinScheduler struct {
 	intervalStop     chan struct{}
 	attemptByAccount map[int64]int64 // accountId -> last attempt timestamp (ms)
 
+	// ctx is the lifecycle context captured from Start. Job timeouts derive
+	// from it instead of context.Background() so that Stop (which cancels it)
+	// also cancels in-flight checkin passes on shutdown. Defaults to
+	// context.Background() so behavior before/without Start matches the old
+	// code (just not cancellable by Stop). UpdateCheckinSchedule does NOT
+	// reset it — the lifecycle ctx is tied to Start/Stop, not config reload.
+	ctx    context.Context
+	cancel context.CancelFunc
+
 	// checkinAll is the checkin execution function. Defaults to
 	// checkin.CheckinAll; overridable in tests to inject a mock that records
 	// calls without touching real upstreams.
@@ -45,6 +54,7 @@ func NewCheckinScheduler(cfg *config.Config) *CheckinScheduler {
 		mode:             cfg.CheckinScheduleMode,
 		attemptByAccount: make(map[int64]int64),
 		checkinAll:       checkin.CheckinAll,
+		ctx:              context.Background(),
 	}
 }
 
@@ -56,6 +66,12 @@ func (s *CheckinScheduler) Name() string { return "checkin" }
 func (s *CheckinScheduler) Start(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Capture the runner lifecycle context so per-job timeouts derive from it
+	// (cancelled on Stop) instead of context.Background() (never cancelled).
+	// Set before startLocked so goroutines launched by maybeCatchUpCheckin
+	// (runCronJob / runStaleAccountCatchUp) observe the captured ctx.
+	s.ctx, s.cancel = context.WithCancel(ctx)
 
 	activeCron := resolveCronSetting("checkin_cron", s.cfg.CheckinCron)
 	activeMode := resolveCheckinScheduleMode(s.cfg)
@@ -88,6 +104,13 @@ func (s *CheckinScheduler) Stop() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.stopLocked()
+	// Cancel the lifecycle context so any in-flight checkin pass whose job
+	// timeout derives from it aborts promptly. Lease Release falls back to
+	// context.Background() when the job ctx is already done, so this does
+	// not strand an advisory lock.
+	if s.cancel != nil {
+		s.cancel()
+	}
 	return nil
 }
 
@@ -203,7 +226,10 @@ func (s *CheckinScheduler) runStaleAccountCatchUp(dbw *store.DB) {
 		return
 	}
 	slog.Info("checkin: stale account catch-up", "count", len(staleIDs))
-	jobCtx, cancel := context.WithTimeout(context.Background(), checkinJobTimeout)
+	// Derive the job timeout from the lifecycle ctx (cancellable on Stop),
+	// not context.Background(). runWithSchedulerLease still releases the
+	// lease via context.Background() when this ctx is already done.
+	jobCtx, cancel := context.WithTimeout(s.ctx, checkinJobTimeout)
 	defer cancel()
 	runWithSchedulerLease(jobCtx, dbw, s.Name(), func() {
 		results := checkin.CheckinAll(s.cfg, dbw.DB, staleIDs, "catchup")
@@ -315,7 +341,10 @@ func (s *CheckinScheduler) runCronJob() {
 		slog.Error("checkin: database not available")
 		return
 	}
-	jobCtx, cancel := context.WithTimeout(context.Background(), checkinJobTimeout)
+	// Derive the job timeout from the lifecycle ctx (cancellable on Stop),
+	// not context.Background(). runWithSchedulerLease still releases the
+	// lease via context.Background() when this ctx is already done.
+	jobCtx, cancel := context.WithTimeout(s.ctx, checkinJobTimeout)
 	defer cancel()
 	runWithSchedulerLease(jobCtx, dbw, s.Name(), func() {
 		results := checkin.CheckinAll(s.cfg, dbw.DB, nil, "cron")
@@ -329,7 +358,10 @@ func (s *CheckinScheduler) runIntervalPass() {
 	if dbw == nil {
 		return
 	}
-	jobCtx, cancel := context.WithTimeout(context.Background(), checkinJobTimeout)
+	// Derive the job timeout from the lifecycle ctx (cancellable on Stop),
+	// not context.Background(). runWithSchedulerLease still releases the
+	// lease via context.Background() when this ctx is already done.
+	jobCtx, cancel := context.WithTimeout(s.ctx, checkinJobTimeout)
 	defer cancel()
 	runWithSchedulerLease(jobCtx, dbw, s.Name(), func() {
 		s.runIntervalPassLocked(dbw)

--- a/scheduler/oauth_refresh.go
+++ b/scheduler/oauth_refresh.go
@@ -35,16 +35,30 @@ type OAuthRefreshScheduler struct {
 	mu           sync.Mutex
 	passInFlight bool
 	runner       *intervalRunner
+	// ctx is the lifecycle context captured from Start. Job timeouts derive
+	// from it instead of context.Background() so Stop (which cancels it) also
+	// cancels in-flight refresh passes on shutdown. Defaults to
+	// context.Background() so behavior without Start matches the old code.
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // NewOAuthRefreshScheduler creates a new OAuth token refresh scheduler.
 func NewOAuthRefreshScheduler(cfg *config.Config) *OAuthRefreshScheduler {
-	return &OAuthRefreshScheduler{cfg: cfg, runner: &intervalRunner{}}
+	return &OAuthRefreshScheduler{
+		cfg:    cfg,
+		runner: &intervalRunner{},
+		ctx:    context.Background(),
+	}
 }
 
 func (s *OAuthRefreshScheduler) Name() string { return "oauth-refresh" }
 
 func (s *OAuthRefreshScheduler) Start(ctx context.Context) error {
+	// Capture the runner lifecycle context so per-job timeouts derive from it
+	// (cancelled on Stop) instead of context.Background() (never cancelled).
+	s.ctx, s.cancel = context.WithCancel(ctx)
+
 	intervalMs := config.MaxInt(oauthRefreshSchedulerIntervalMs, oauthRefreshSchedulerMinIntervalMs)
 	interval := time.Duration(intervalMs) * time.Millisecond
 
@@ -53,6 +67,13 @@ func (s *OAuthRefreshScheduler) Start(ctx context.Context) error {
 }
 
 func (s *OAuthRefreshScheduler) Stop() error {
+	// Cancel the lifecycle context first so any in-flight refresh pass whose
+	// job timeout derives from it aborts promptly. The runner stop then halts
+	// future ticks. Lease Release falls back to context.Background() when the
+	// job ctx is already done, so this does not strand an advisory lock.
+	if s.cancel != nil {
+		s.cancel()
+	}
 	return s.runner.stop()
 }
 
@@ -92,7 +113,10 @@ func (s *OAuthRefreshScheduler) runPass() {
 	if dbw == nil {
 		return
 	}
-	jobCtx, cancel := context.WithTimeout(context.Background(), oauthRefreshJobTimeout)
+	// Derive the job timeout from the lifecycle ctx (cancellable on Stop),
+	// not context.Background(). runWithSchedulerLease still releases the
+	// lease via context.Background() when this ctx is already done.
+	jobCtx, cancel := context.WithTimeout(s.ctx, oauthRefreshJobTimeout)
 	defer cancel()
 	runWithSchedulerLease(jobCtx, dbw, s.Name(), func() {
 		s.runPassLocked()

--- a/scheduler/retention.go
+++ b/scheduler/retention.go
@@ -38,6 +38,13 @@ type RetentionScheduler struct {
 	cfg    *config.Config
 	opts   RetentionSchedulerOptions
 	runner *intervalRunner
+	// ctx is the lifecycle context captured from Start. Job timeouts derive
+	// from it instead of context.Background() so that Stop (which cancels it)
+	// also cancels in-flight cleanups on shutdown. Defaults to
+	// context.Background() so a job running before/without Start behaves like
+	// the old code (just not cancellable by Stop).
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // NewRetentionScheduler builds a generic retention scheduler.
@@ -46,12 +53,17 @@ func NewRetentionScheduler(cfg *config.Config, opts RetentionSchedulerOptions) *
 		cfg:    cfg,
 		opts:   opts,
 		runner: &intervalRunner{},
+		ctx:    context.Background(),
 	}
 }
 
 func (s *RetentionScheduler) Name() string { return s.opts.Name }
 
 func (s *RetentionScheduler) Start(ctx context.Context) error {
+	// Capture the runner lifecycle context so per-job timeouts derive from it
+	// (cancelled on Stop) instead of context.Background() (never cancelled).
+	s.ctx, s.cancel = context.WithCancel(ctx)
+
 	if disabled, reason := s.opts.DisabledFn(s.cfg); disabled {
 		slog.Info(s.opts.Name + ": disabled (" + reason + ")")
 		return nil
@@ -71,6 +83,13 @@ func (s *RetentionScheduler) Start(ctx context.Context) error {
 }
 
 func (s *RetentionScheduler) Stop() error {
+	// Cancel the lifecycle context first so any in-flight cleanup whose job
+	// timeout derives from it aborts promptly. The runner stop then halts
+	// future ticks. Lease Release falls back to context.Background() when the
+	// job ctx is already done, so this does not strand an advisory lock.
+	if s.cancel != nil {
+		s.cancel()
+	}
 	return s.runner.stop()
 }
 
@@ -84,7 +103,10 @@ func (s *RetentionScheduler) runCleanup() {
 	if retentionDays <= 0 {
 		return
 	}
-	jobCtx, cancel := context.WithTimeout(context.Background(), retentionJobTimeout)
+	// Derive the job timeout from the lifecycle ctx (cancellable on Stop),
+	// not context.Background(). runWithSchedulerLease still releases the
+	// lease via context.Background() when this ctx is already done.
+	jobCtx, cancel := context.WithTimeout(s.ctx, retentionJobTimeout)
 	defer cancel()
 	runWithSchedulerLease(jobCtx, dbw, s.Name(), func() {
 		s.runCleanupLocked(dbw, retentionDays)

--- a/scheduler/shutdown_cancel_test.go
+++ b/scheduler/shutdown_cancel_test.go
@@ -1,0 +1,156 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+)
+
+// TestRetentionScheduler_StopCancelsInFlightJobContext verifies the core of
+// the shutdown-cancel fix: a per-job timeout derived from the scheduler's
+// lifecycle ctx (exactly what runCleanup does) is cancelled when Stop is
+// called. Before the fix, jobs derived from context.Background() which is
+// never cancelled, so in-flight cleanups survived shutdown.
+func TestRetentionScheduler_StopCancelsInFlightJobContext(t *testing.T) {
+	cfg := testConfig()
+	s := NewRetentionScheduler(cfg, RetentionSchedulerOptions{
+		Name:               "test-retention-cancel",
+		Table:              "proxy_logs",
+		DefaultIntervalMin: 30,
+		RetentionDaysFn:    func(*config.Config) int { return 30 },
+		IntervalMinFn:      func(*config.Config) int { return 30 },
+		// Disabled so Start arms the lifecycle ctx but does not start the
+		// tick runner — keeps the test free of DB/lease machinery.
+		DisabledFn: func(*config.Config) (bool, string) { return true, "test" },
+	})
+
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	defer rootCancel()
+
+	if err := s.Start(rootCtx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if s.ctx == nil {
+		t.Fatal("lifecycle ctx not captured after Start")
+	}
+
+	// Mirror runCleanup's derivation: context.WithTimeout(s.ctx, jobTimeout).
+	jobCtx, jobCancel := context.WithTimeout(s.ctx, 5*time.Second)
+	defer jobCancel()
+	if jobCtx.Err() != nil {
+		t.Fatal("job ctx should be alive before Stop")
+	}
+
+	if err := s.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if s.ctx.Err() == nil {
+		t.Fatal("lifecycle ctx must be cancelled by Stop")
+	}
+	if jobCtx.Err() == nil {
+		t.Fatal("in-flight job ctx (derived from lifecycle ctx) must be cancelled by Stop")
+	}
+}
+
+// TestOAuthRefreshScheduler_StopCancelsInFlightJobContext mirrors the
+// retention assertion for the oauth-refresh scheduler. runPass derives its
+// job timeout from s.ctx; Stop must cancel that chain.
+func TestOAuthRefreshScheduler_StopCancelsInFlightJobContext(t *testing.T) {
+	cfg := testConfig()
+	s := NewOAuthRefreshScheduler(cfg)
+
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	defer rootCancel()
+
+	if err := s.Start(rootCtx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if s.ctx == nil {
+		t.Fatal("lifecycle ctx not captured after Start")
+	}
+	// Give the immediate runPass goroutine (no-ops on nil DB) a moment to
+	// settle so it does not race the Stop.
+	time.Sleep(50 * time.Millisecond)
+
+	jobCtx, jobCancel := context.WithTimeout(s.ctx, oauthRefreshJobTimeout)
+	defer jobCancel()
+	if jobCtx.Err() != nil {
+		t.Fatal("job ctx should be alive before Stop")
+	}
+
+	if err := s.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if s.ctx.Err() == nil {
+		t.Fatal("lifecycle ctx must be cancelled by Stop")
+	}
+	if jobCtx.Err() == nil {
+		t.Fatal("in-flight oauth-refresh job ctx must be cancelled by Stop")
+	}
+}
+
+// TestCheckinScheduler_StopCancelsInFlightJobContext mirrors the assertion
+// for the checkin scheduler, whose runCronJob / runIntervalPass /
+// runStaleAccountCatchUp all derive from s.ctx. Uses cron mode with no DB so
+// Start arms the lifecycle ctx + cron runner without firing a real pass.
+func TestCheckinScheduler_StopCancelsInFlightJobContext(t *testing.T) {
+	cfg := testConfig() // cron mode, valid CheckinCron
+	s := NewCheckinScheduler(cfg)
+
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	defer rootCancel()
+
+	if err := s.Start(rootCtx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if s.ctx == nil {
+		t.Fatal("lifecycle ctx not captured after Start")
+	}
+
+	jobCtx, jobCancel := context.WithTimeout(s.ctx, checkinJobTimeout)
+	defer jobCancel()
+	if jobCtx.Err() != nil {
+		t.Fatal("job ctx should be alive before Stop")
+	}
+
+	if err := s.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if s.ctx.Err() == nil {
+		t.Fatal("lifecycle ctx must be cancelled by Stop")
+	}
+	if jobCtx.Err() == nil {
+		t.Fatal("in-flight checkin job ctx must be cancelled by Stop")
+	}
+}
+
+// TestSchedulerJobContextFallsBackBeforeStart verifies the safe default: a
+// scheduler that has not been Started still has s.ctx == context.Background()
+// (from the constructor), so deriving a job ctx does not panic and is simply
+// not cancellable by Stop — matching the pre-fix behavior for any code path
+// that runs before Start completes.
+func TestSchedulerJobContextFallsBackBeforeStart(t *testing.T) {
+	cfg := testConfig()
+	s := NewRetentionScheduler(cfg, RetentionSchedulerOptions{
+		Name:               "test-retention-fallback",
+		Table:              "proxy_logs",
+		DefaultIntervalMin: 30,
+		RetentionDaysFn:    func(*config.Config) int { return 30 },
+		IntervalMinFn:      func(*config.Config) int { return 30 },
+		DisabledFn:         func(*config.Config) (bool, string) { return true, "test" },
+	})
+	if s.ctx == nil {
+		t.Fatal("constructor must default s.ctx to context.Background()")
+	}
+	if s.ctx != context.Background() {
+		t.Fatal("constructor default ctx must be context.Background()")
+	}
+	// Deriving a job timeout from the default ctx must not panic.
+	jobCtx, cancel := context.WithTimeout(s.ctx, time.Second)
+	defer cancel()
+	if jobCtx.Err() != nil {
+		t.Fatal("job ctx derived from default ctx should be alive")
+	}
+}

--- a/web/src/components/layout/index.ts
+++ b/web/src/components/layout/index.ts
@@ -1,3 +1,4 @@
 // metapi-go/layout — barrel re-exports for the layout layer.
 
 export { AuthenticatedLayout } from './components/authenticated-layout'
+export { LayoutErrorBoundary } from './layout-error-boundary'

--- a/web/src/components/layout/layout-error-boundary.tsx
+++ b/web/src/components/layout/layout-error-boundary.tsx
@@ -1,0 +1,82 @@
+// metapi-go/components/layout — layout-preserving route error boundary.
+//
+// Mounted as the errorComponent on the _authenticated route so a render-time
+// crash in any page (a child route) replaces only the page content, not the
+// sidebar/nav shell. The router's defaultErrorComponent (ErrorPage) is
+// full-screen and is still used for crashes outside the authenticated shell
+// (e.g. the sign-in route or the root outlet).
+//
+// The error boundary reuses the same AppHeader + AppSidebar + SidebarProvider
+// shell as AuthenticatedLayout, so the sidebar, brand, and interface controls
+// (language/theme) stay interactive — only the page area swaps to the error
+// card with Retry / Reload / show-detail controls.
+
+import { useRouter } from '@tanstack/react-router'
+import { RotateCw, TriangleAlert } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { SkipToMain } from '@/components/skip-to-main'
+import { Button } from '@/components/ui/button'
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
+import { cn } from '@/lib/utils'
+
+import { AppHeader } from './components/app-header'
+import { AppSidebar } from './components/app-sidebar'
+
+export function LayoutErrorBoundary({ error }: { error: Error }) {
+  const { t } = useTranslation()
+  const router = useRouter()
+  const [showDetail, setShowDetail] = useState(false)
+
+  return (
+    <SidebarProvider className='flex-col'>
+      <SkipToMain />
+      <AppHeader />
+      <div className='flex min-h-0 w-full flex-1 [--app-header-height:3.5rem]'>
+        <AppSidebar />
+        <SidebarInset
+          id='content'
+          className={cn(
+            '@container/content',
+            'flex min-h-0 items-center justify-center overflow-x-hidden overflow-y-auto p-6',
+            'peer-data-[variant=inset]:h-[calc(100svh-var(--app-header-height,0px)-(var(--spacing)*4))]'
+          )}
+        >
+          <div className='flex w-full max-w-md flex-col items-center gap-4'>
+            <div className='bg-destructive/10 flex size-16 items-center justify-center rounded-2xl'>
+              <TriangleAlert className='text-destructive size-8' />
+            </div>
+            <div className='space-y-1 text-center'>
+              <p className='text-2xl font-semibold'>{t('errors.renderTitle')}</p>
+              <p className='text-muted-foreground text-sm'>
+                {t('errors.renderDescription')}
+              </p>
+            </div>
+            <div className='flex gap-2'>
+              <Button onClick={() => router.invalidate()}>
+                <RotateCw className='mr-1.5 size-4' />
+                {t('errors.retry')}
+              </Button>
+              <Button variant='outline' onClick={() => window.location.reload()}>
+                {t('errors.reload')}
+              </Button>
+            </div>
+            <button
+              type='button'
+              className='text-muted-foreground text-xs underline underline-offset-2'
+              onClick={() => setShowDetail((prev) => !prev)}
+            >
+              {t('errors.showDetail')}
+            </button>
+            {showDetail ? (
+              <pre className='bg-muted/60 max-w-xl overflow-auto rounded-lg border p-3 text-xs'>
+                {error?.message ?? String(error)}
+              </pre>
+            ) : null}
+          </div>
+        </SidebarInset>
+      </div>
+    </SidebarProvider>
+  )
+}

--- a/web/src/components/layout/layout-error-boundary.tsx
+++ b/web/src/components/layout/layout-error-boundary.tsx
@@ -48,7 +48,9 @@ export function LayoutErrorBoundary({ error }: { error: Error }) {
               <TriangleAlert className='text-destructive size-8' />
             </div>
             <div className='space-y-1 text-center'>
-              <p className='text-2xl font-semibold'>{t('errors.renderTitle')}</p>
+              <p className='text-2xl font-semibold'>
+                {t('errors.renderTitle')}
+              </p>
               <p className='text-muted-foreground text-sm'>
                 {t('errors.renderDescription')}
               </p>
@@ -58,7 +60,10 @@ export function LayoutErrorBoundary({ error }: { error: Error }) {
                 <RotateCw className='mr-1.5 size-4' />
                 {t('errors.retry')}
               </Button>
-              <Button variant='outline' onClick={() => window.location.reload()}>
+              <Button
+                variant='outline'
+                onClick={() => window.location.reload()}
+              >
                 {t('errors.reload')}
               </Button>
             </div>

--- a/web/src/routes/_authenticated/route.tsx
+++ b/web/src/routes/_authenticated/route.tsx
@@ -2,10 +2,16 @@
 // beforeLoad checks the localStorage session (storage is the source of truth
 // for cold-load guards, avoiding a Zustand hydration race). On failure,
 // redirects to /sign-in with the current href as the redirect target.
+//
+// errorComponent mounts LayoutErrorBoundary so a render-time crash in any
+// authenticated page replaces only the page content — the sidebar/nav shell
+// (AppHeader + AppSidebar + SidebarProvider) stays mounted and interactive.
+// Without this, a page crash would bubble to the router's
+// defaultErrorComponent (ErrorPage) and the whole shell would be lost.
 
 import { createFileRoute, redirect } from '@tanstack/react-router'
 
-import { AuthenticatedLayout } from '@/components/layout'
+import { AuthenticatedLayout, LayoutErrorBoundary } from '@/components/layout'
 import { hasValidAuthSession } from '@/lib/auth-session'
 
 export const Route = createFileRoute('/_authenticated')({
@@ -18,4 +24,5 @@ export const Route = createFileRoute('/_authenticated')({
     }
   },
   component: AuthenticatedLayout,
+  errorComponent: LayoutErrorBoundary,
 })


### PR DESCRIPTION
## Summary

Four P3 reliability/a11y fixes:

- **SSE error event** (`handler/proxy/upstream_stream.go`): on a non-EOF upstream read error, emit a final `data: {"error":{"message":"upstream stream interrupted","type":"upstream_error"}}` event (+ `[DONE]`) before closing. Clients no longer have to infer mid-stream failure from a missing `[DONE]` marker. Mirrors the existing byte-limit path via `writeSSEStreamError`.
- **Route error boundary** (`web/src/routes/_authenticated/route.tsx` + `web/src/components/layout/layout-error-boundary.tsx`): mount `LayoutErrorBoundary` as the `_authenticated` route `errorComponent`. A render crash in any authenticated page now replaces only the page content — the sidebar/nav shell (AppHeader + AppSidebar) stays mounted and interactive, instead of bubbling to the full-screen `defaultErrorComponent`. `ErrorPage` remains the router-level fallback for crashes outside the authenticated shell.
- **Ops WS origin restriction** (`handler/admin/ops_ws.go`): replace `OriginPatterns: []string{"*"}` with the configured `AdminCorsAllowedOrigins` plus `localhost`/`127.0.0.1` for dev. Empty config → empty slice → coder/websocket enforces same-origin only. Admin token verification unchanged.
- **Scheduler shutdown cancel** (`scheduler/checkin.go`, `retention.go`, `oauth_refresh.go`): capture the runner lifecycle ctx in `Start` and cancel it in `Stop`; checkin/retention/oauth-refresh job timeouts now derive from it (`context.WithTimeout(s.ctx, jobTimeout)`) instead of `context.Background()`, so in-flight jobs abort on shutdown. Lease `Release` still falls back to `context.Background()` when the job ctx is done (#717), so advisory locks are not stranded.

## Test plan

- [x] `go build ./...` (green after `web/dist` produced by `bun run build:web`)
- [x] `go test ./handler/... ./scheduler/...`
- [x] `cd web && bun run typecheck && bun run lint && bun run knip && bun run build:web`
- [x] New tests: `TestHandleStreamUpstreamEmitsErrorEventOnReadError`, `TestHandleStreamUpstreamNoErrorEventOnCleanEOF`, `TestOpsWSOriginPatterns`, `TestOpsWS_RejectsCrossOriginWhenUnconfigured`, `TestOpsWS_AllowsConfiguredCrossOrigin`, `TestRetentionScheduler_StopCancelsInFlightJobContext`, `TestOAuthRefreshScheduler_StopCancelsInFlightJobContext`, `TestCheckinScheduler_StopCancelsInFlightJobContext`, `TestSchedulerJobContextFallsBackBeforeStart`