### PR TITLE
fix: admin probe — concurrent streaming + context + SSE deadline

### DIFF
--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -1,12 +1,14 @@
 package admin
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/deliciousbuding/metapi-go/handler/admin/payloads"
@@ -60,7 +62,7 @@ func (h *sitesHandler) listSites(w http.ResponseWriter, r *http.Request) {
 func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 	var body payloads.SiteCreatePayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid site payload: " + err.Error())
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid site payload: "+err.Error())
 		return
 	}
 
@@ -280,7 +282,7 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 
 	var body payloads.SiteUpdatePayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid site payload: " + err.Error())
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid site payload: "+err.Error())
 		return
 	}
 
@@ -470,7 +472,7 @@ func (h *sitesHandler) deleteSite(w http.ResponseWriter, r *http.Request) {
 func (h *sitesHandler) batchSites(w http.ResponseWriter, r *http.Request) {
 	var body payloads.SiteBatchPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid site payload: " + err.Error())
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid site payload: "+err.Error())
 		return
 	}
 
@@ -736,6 +738,14 @@ func (h *sitesHandler) getAvailableModels(w http.ResponseWriter, r *http.Request
 
 // ---- Probe Now ----
 
+// probeNowTimeout caps the total wall-clock a synchronous probe-now pass
+// may take. The server's WriteTimeout is 60s (app.newHTTPServer); 30s keeps
+// the handler well under that ceiling while leaving room for the typical
+// 32-target / 8-worker batch (probes are sub-second in practice; the 15s
+// per-probe timeout is a ceiling, not the median). Operators watching a
+// slow site should use the streaming endpoint instead.
+const probeNowTimeout = 30 * time.Second
+
 func (h *sitesHandler) probeNow(w http.ResponseWriter, r *http.Request) {
 	id, ok := pathID(w, r)
 	if !ok {
@@ -743,22 +753,61 @@ func (h *sitesHandler) probeNow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body payloads.ProbeNowBody
-	// Body is optional for probe-now.
+	// Body is optional for probe-now. When present, modelName filters which
+	// results are surfaced (the previously-discarded field is now wired).
 	_ = decodeJSONRequest(r, &body)
+	modelFilter := ""
+	if body.ModelName != nil {
+		modelFilter = strings.TrimSpace(*body.ModelName)
+	}
 
 	sched := scheduler.GetGlobalModelProbeScheduler()
 	if sched == nil {
 		// Fall back: create ephemeral scheduler for one-shot probe.
 		sched = scheduler.NewModelProbeScheduler(nil)
 	}
-	results, available, unavailable := sched.ProbeSite(id)
-	writeJSON(w, http.StatusOK, map[string]any{
+
+	// Bound the total work via the request context so a slow site cannot block
+	// the handler past WriteTimeout. Cancellation (client disconnect) also
+	// stops scheduling new probes immediately.
+	ctx, cancel := context.WithTimeout(r.Context(), probeNowTimeout)
+	defer cancel()
+
+	// The onResult callback is invoked from multiple probe goroutines
+	// concurrently, so the result slice and counters must be guarded.
+	var mu sync.Mutex
+	var results []scheduler.ProbeSiteResult
+	var available, unavailable int
+	probeErr := sched.ProbeSiteIncremental(ctx, id, func(res scheduler.ProbeSiteResult) {
+		if modelFilter != "" && res.Model != modelFilter {
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		results = append(results, res)
+		if res.Status == "success" {
+			available++
+		} else if res.Status == "failure" {
+			unavailable++
+		}
+	})
+	if results == nil {
+		results = []scheduler.ProbeSiteResult{}
+	}
+
+	response := map[string]any{
 		"success":     true,
 		"totalModels": len(results),
 		"available":   available,
 		"unavailable": unavailable,
 		"results":     results,
-	})
+		"complete":    probeErr == nil,
+	}
+	if probeErr != nil {
+		response["truncated"] = true
+		response["reason"] = probeErr.Error()
+	}
+	writeJSON(w, http.StatusOK, response)
 }
 
 // ---- Probe Stream (SSE) ----
@@ -780,31 +829,72 @@ func (h *sitesHandler) probeStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	scope := r.URL.Query().Get("scope")
-	modelName := r.URL.Query().Get("modelName")
-	latencyStr := r.URL.Query().Get("latencyThresholdMs")
+	// Clear the server-level WriteTimeout for this SSE stream. Without this,
+	// any probe pass exceeding app.Server.WriteTimeout (60s) is forcibly
+	// closed by net/http — the same fix the proxy SSE path applies
+	// (handler/proxy/upstream_stream.go:40-41). http.NewResponseController
+	// unwraps the middleware statusRecorder to reach the real connection.
+	rc := http.NewResponseController(w)
+	_ = rc.SetWriteDeadline(time.Time{})
 
-	_ = scope
-	_ = modelName
-	_ = latencyStr
+	// modelName, when provided, filters which probe results are streamed.
+	// scope and latencyThresholdMs were previously read and immediately
+	// discarded; they are now dropped to remove the dead-code smell.
+	modelFilter := strings.TrimSpace(r.URL.Query().Get("modelName"))
 
 	sched := scheduler.GetGlobalModelProbeScheduler()
 	if sched == nil {
 		sched = scheduler.NewModelProbeScheduler(nil)
 	}
-	results, available, unavailable := sched.ProbeSite(id)
+
 	sseWrite(w, flusher, "probe-start", map[string]any{
-		"totalModels": len(results),
 		"startedAt":   time.Now().UTC().Format(time.RFC3339),
+		"streaming":   true,
+		"modelFilter": modelFilter,
 	})
-	for _, res := range results {
+
+	var available, unavailable, sent int
+	// The onResult callback fires from multiple probe goroutines at once.
+	// http.ResponseWriter is not safe for concurrent use, and the counters
+	// are shared, so the whole write + bookkeeping must be serialized.
+	var writeMu sync.Mutex
+	probeErr := sched.ProbeSiteIncremental(r.Context(), id, func(res scheduler.ProbeSiteResult) {
+		if modelFilter != "" && res.Model != modelFilter {
+			return
+		}
+		writeMu.Lock()
+		defer writeMu.Unlock()
 		sseWrite(w, flusher, "probe-result", res)
+		sent++
+		if res.Status == "success" {
+			available++
+		} else if res.Status == "failure" {
+			unavailable++
+		}
+	})
+
+	// If the client disconnected (r.Context err'd), don't bother writing the
+	// closing events — the connection is gone and the writes would error.
+	if r.Context().Err() != nil {
+		return
 	}
-	sseWrite(w, flusher, "complete", map[string]any{
-		"totalModels": len(results),
+
+	completePayload := map[string]any{
+		"totalModels": sent,
 		"available":   available,
 		"unavailable": unavailable,
-	})
+	}
+	if probeErr != nil {
+		completePayload["truncated"] = true
+		completePayload["reason"] = probeErr.Error()
+	}
+	sseWrite(w, flusher, "complete", completePayload)
+
+	// OpenAI-style [DONE] sentinel so clients know the stream is finished.
+	_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	if flusher != nil {
+		flusher.Flush()
+	}
 }
 
 // ---- Helpers ----

--- a/handler/admin/sites_probe_stream_test.go
+++ b/handler/admin/sites_probe_stream_test.go
@@ -1,0 +1,336 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/scheduler"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// safeRecorder is a thread-safe http.ResponseWriter so a test goroutine can
+// poll the buffered body while the handler (running in another goroutine)
+// writes SSE events. httptest.ResponseRecorder's *bytes.Buffer is NOT safe
+// for concurrent read/write, so we use this for incremental-streaming tests.
+type safeRecorder struct {
+	mu     sync.Mutex
+	body   bytes.Buffer
+	header http.Header
+	status int
+}
+
+func newSafeRecorder() *safeRecorder {
+	return &safeRecorder{header: make(http.Header)}
+}
+
+func (r *safeRecorder) Header() http.Header { return r.header }
+
+func (r *safeRecorder) WriteHeader(code int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.status = code
+}
+
+func (r *safeRecorder) Write(b []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.body.Write(b)
+}
+
+// Flush is a no-op: writes are already in the buffer. Implementing http.Flusher
+// lets the handler obtain a flusher via type assertion.
+func (r *safeRecorder) Flush() {}
+
+func (r *safeRecorder) BodyString() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.body.String()
+}
+
+func (r *safeRecorder) StatusCode() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.status
+}
+
+// adminTimedProbe is a scheduler.ChannelHealthProbe that sleeps a per-channel
+// duration before returning. Used to prove SSE events are written
+// incrementally (the fast channel's event must appear before the slow one).
+type adminTimedProbe struct {
+	mu     sync.Mutex
+	calls  []int64
+	delays map[int64]time.Duration
+}
+
+func (p *adminTimedProbe) ProbeChannel(_ context.Context, target scheduler.ProbeTarget) (scheduler.ProbeOutcome, error) {
+	p.mu.Lock()
+	p.calls = append(p.calls, target.ChannelID)
+	delay := time.Duration(0)
+	if d, ok := p.delays[target.ChannelID]; ok {
+		delay = d
+	}
+	p.mu.Unlock()
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+	return scheduler.ProbeOutcome{Status: "success", LatencyMs: float64(delay.Milliseconds())}, nil
+}
+
+func (p *adminTimedProbe) startedCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.calls)
+}
+
+// adminReleaseProbe blocks every ProbeChannel call on a shared release
+// channel so the test controls exactly when in-flight probes finish.
+type adminReleaseProbe struct {
+	mu      sync.Mutex
+	calls   []int64
+	release chan struct{}
+}
+
+func (p *adminReleaseProbe) ProbeChannel(_ context.Context, target scheduler.ProbeTarget) (scheduler.ProbeOutcome, error) {
+	p.mu.Lock()
+	p.calls = append(p.calls, target.ChannelID)
+	p.mu.Unlock()
+	<-p.release
+	return scheduler.ProbeOutcome{Status: "success"}, nil
+}
+
+func (p *adminReleaseProbe) startedCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.calls)
+}
+
+// noopRecorder is a scheduler.ChannelHealthRecorder that records nothing.
+// probeOne requires a non-nil recorder; this satisfies it without mutating
+// routing health (the admin probe surface is a read-only-ish diagnostic).
+type noopRecorder struct{}
+
+func (noopRecorder) RecordProbeSuccess(context.Context, int64, float64, *string, *int64) error {
+	return nil
+}
+func (noopRecorder) RecordProbeFailure(context.Context, int64, *int, *string, *string, *int64) error {
+	return nil
+}
+
+// seedProbeTargetsForSite inserts a site + account + route + N channels with
+// the given source models and returns the channel IDs (in insert order).
+func seedProbeTargetsForSite(t *testing.T, db *store.DB, models []string) (siteID int64, chanIDs []int64) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		"ProbeStreamSite", "https://probe.example.com", "openai", "active", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ = res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO accounts (site_id, access_token, status, created_at, updated_at) VALUES (?, ?, 'active', ?, ?)`,
+		siteID, "tok", now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ := res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at) VALUES (?, 'pattern', 'weighted', true, ?, ?)`,
+		"m-*", now, now)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	routeID, _ := res.LastInsertId()
+	for _, m := range models {
+		res, err = db.Exec(`INSERT INTO route_channels (route_id, account_id, source_model, enabled) VALUES (?, ?, ?, true)`,
+			routeID, accountID, m)
+		if err != nil {
+			t.Fatalf("insert channel %s: %v", m, err)
+		}
+		cid, _ := res.LastInsertId()
+		chanIDs = append(chanIDs, cid)
+	}
+	return siteID, chanIDs
+}
+
+// setupAdminGlobalScheduler points store.GetDB() at the in-memory test DB and
+// installs a global model-probe scheduler with the given probe executor, so
+// the admin probe-now / probe-stream handlers use the fake instead of a real
+// upstream. Returns a cleanup func that restores the global state.
+func setupAdminGlobalScheduler(t *testing.T, db *store.DB, probe scheduler.ChannelHealthProbe) func() {
+	t.Helper()
+	store.OverrideDB(db)
+	sched := scheduler.NewModelProbeScheduler(&config.Config{
+		ModelAvailabilityProbeTimeoutMs: 5000,
+	})
+	sched.SetProbeExecutor(probe)
+	sched.SetHealthRecorder(noopRecorder{})
+	scheduler.SetGlobalModelProbeScheduler(sched)
+	return func() {
+		scheduler.SetGlobalModelProbeScheduler(nil)
+		store.OverrideDB(nil)
+	}
+}
+
+// TestSites_ProbeStream_IncrementalSSE verifies the probe-stream handler
+// writes each probe-result SSE event as the probe completes, not buffered and
+// replayed after all probes finish. With a fast channel (20ms) and a slow
+// channel (200ms), the fast channel's event must appear in the response
+// body well before the slow channel could have finished — proving real
+// incremental streaming through the SSE handler.
+func TestSites_ProbeStream_IncrementalSSE(t *testing.T) {
+	db, r := setupSitesTest(t)
+	cleanup := setupAdminGlobalScheduler(t, db, &adminTimedProbe{
+		delays: map[int64]time.Duration{}, // filled after we know channel IDs
+	})
+	defer cleanup()
+
+	// Seed two channels; the probe executor needs per-channel delays so we
+	// re-inject it once IDs are known.
+	siteID, chanIDs := seedProbeTargetsForSite(t, db, []string{"fast-model", "slow-model"})
+	if len(chanIDs) != 2 {
+		t.Fatalf("expected 2 channels, got %d", len(chanIDs))
+	}
+	// Replace the global scheduler's probe with one that knows the real IDs.
+	probe := &adminTimedProbe{delays: map[int64]time.Duration{
+		chanIDs[0]: 20 * time.Millisecond,  // fast-model
+		chanIDs[1]: 200 * time.Millisecond, // slow-model
+	}}
+	scheduler.GetGlobalModelProbeScheduler().SetProbeExecutor(probe)
+
+	rec := newSafeRecorder()
+	req := httptest.NewRequest("GET", "/api/sites/"+itoa(siteID)+"/probe-stream", nil)
+
+	start := time.Now()
+	done := make(chan struct{})
+	go func() {
+		r.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Wait for the fast channel's result event. Under the old batched-replay
+	// behavior, no probe-result would appear until ~200ms (all probes done).
+	deadline := start.Add(150 * time.Millisecond)
+	var fastAt time.Duration
+	for time.Now().Before(deadline) {
+		if strings.Contains(rec.BodyString(), "fast-model") {
+			fastAt = time.Since(start)
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if fastAt == 0 {
+		t.Fatalf("fast-model result never appeared before 150ms (body=%q)", rec.BodyString())
+	}
+	if fastAt >= 150*time.Millisecond {
+		t.Fatalf("fast-model event arrived at %v — looks buffered until all probes finished (want < 150ms)", fastAt)
+	}
+	// The slow channel must NOT have appeared yet (it finishes at 200ms).
+	if strings.Contains(rec.BodyString(), "slow-model") {
+		t.Fatalf("slow-model appeared at %v before its 200ms delay — incremental contract broken", fastAt)
+	}
+
+	// Now wait for the full stream to complete.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("probe-stream handler did not return within 2s")
+	}
+
+	body := rec.BodyString()
+	if !strings.Contains(body, "probe-start") {
+		t.Error("expected probe-start event")
+	}
+	if !strings.Contains(body, "complete") {
+		t.Error("expected complete event")
+	}
+	if !strings.Contains(body, "[DONE]") {
+		t.Error("expected [DONE] sentinel")
+	}
+	if got := strings.Count(body, "event: probe-result"); got != 2 {
+		t.Fatalf("expected 2 probe-result events, got %d (body=%q)", got, body)
+	}
+	if rec.StatusCode() != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.StatusCode())
+	}
+}
+
+// TestSites_ProbeStream_CancelStopsProbing verifies that cancelling the
+// request context (client disconnect) stops launching new probes: with 12
+// channels and 8-way concurrency, the first 8 start, then a cancel must
+// prevent channels 9-12 from ever starting. The handler returns without
+// writing the complete / [DONE] closing events because the client is gone.
+func TestSites_ProbeStream_CancelStopsProbing(t *testing.T) {
+	db, r := setupSitesTest(t)
+	releaseProbe := &adminReleaseProbe{release: make(chan struct{})}
+	cleanup := setupAdminGlobalScheduler(t, db, releaseProbe)
+	defer cleanup()
+
+	models := make([]string, 12)
+	for i := range models {
+		models[i] = "m" + itoa(int64(i))
+	}
+	siteID, _ := seedProbeTargetsForSite(t, db, models)
+	scheduler.GetGlobalModelProbeScheduler().SetProbeExecutor(releaseProbe)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest("GET", "/api/sites/"+itoa(siteID)+"/probe-stream", nil).WithContext(ctx)
+	rec := newSafeRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		r.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Wait until the 8-slot semaphore is saturated (8 probes started).
+	saturateDeadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(saturateDeadline) {
+		if releaseProbe.startedCount() == 8 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if got := releaseProbe.startedCount(); got != 8 {
+		t.Fatalf("expected 8 probes started before cancel, got %d", got)
+	}
+
+	// Cancel the request (client disconnect). No 9th-12th probe may start.
+	cancel()
+	time.Sleep(40 * time.Millisecond)
+	if got := releaseProbe.startedCount(); got != 8 {
+		t.Fatalf("after cancel, %d probes started (want 8 — no new probes should start)", got)
+	}
+
+	// Release the 8 in-flight probes so the handler can return.
+	close(releaseProbe.release)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("probe-stream handler did not return within 2s after in-flight probes were released")
+	}
+
+	body := rec.BodyString()
+	if !strings.Contains(body, "probe-start") {
+		t.Error("expected probe-start event to have been written before cancel")
+	}
+	// The client is gone: no probe-result, no complete, no [DONE].
+	if strings.Contains(body, "event: probe-result") {
+		t.Errorf("expected no probe-result events after cancel, got body=%q", body)
+	}
+	if strings.Contains(body, "complete") {
+		t.Errorf("expected no complete event after client disconnect, got body=%q", body)
+	}
+	if strings.Contains(body, "[DONE]") {
+		t.Errorf("expected no [DONE] sentinel after client disconnect, got body=%q", body)
+	}
+	if got := releaseProbe.startedCount(); got != 8 {
+		t.Fatalf("final started count = %d, want 8 (cancel must not launch the remaining targets)", got)
+	}
+}

--- a/scheduler/site_probe_admin.go
+++ b/scheduler/site_probe_admin.go
@@ -1,7 +1,9 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
+	"sync"
 
 	"github.com/deliciousbuding/metapi-go/store"
 )
@@ -16,47 +18,129 @@ type ProbeSiteResult struct {
 	Error     string  `json:"error,omitempty"`
 }
 
-// ProbeSite runs probes for active channels on a site (bounded to 32).
+// adminProbeConcurrency bounds parallel probes for admin probe-now /
+// probe-stream. 8 workers turns a 32-target batch (~15s per-probe ceiling)
+// from a sequential ~8min HTTP block into ~4 waves ≈ 60s worst case, while
+// keeping upstream load bounded. The per-probe 15s timeout is a ceiling —
+// real probes are sub-second, so typical batches finish in well under a
+// second per wave.
+const adminProbeConcurrency = 8
+
+// ProbeSite runs probes for active channels on a site (bounded to 32) and
+// returns the aggregated results. It is a thin wrapper around
+// ProbeSiteIncremental that collects every result under a non-cancellable
+// background context. Kept for callers that want a single batch response
+// (app probe-wire tests, recovery paths).
 func (s *ModelProbeScheduler) ProbeSite(siteID int64) (results []ProbeSiteResult, available, unavailable int) {
+	_ = s.ProbeSiteIncremental(context.Background(), siteID, func(r ProbeSiteResult) {
+		results = append(results, r)
+		if r.Status == "success" {
+			available++
+		} else if r.Status == "failure" {
+			unavailable++
+		}
+	})
+	if results == nil {
+		results = []ProbeSiteResult{}
+	}
+	return results, available, unavailable
+}
+
+// ProbeSiteIncremental runs probes for active channels on a site (bounded to
+// 32 targets) with bounded concurrency and streams each result to onResult
+// as soon as it completes. It respects ctx cancellation: on cancel it stops
+// scheduling new probes and returns ctx.Err(). In-flight probes are allowed
+// to finish (they carry their own per-target timeout via probeOne) but their
+// results are not streamed to a cancelled caller.
+//
+// onResult may be nil. A nil scheduler, non-positive siteID, or missing DB
+// yields a no-op (returns nil). A target-load error is delivered as a single
+// ProbeSiteResult{Status:"error"} and also returned as err.
+func (s *ModelProbeScheduler) ProbeSiteIncremental(ctx context.Context, siteID int64, onResult func(ProbeSiteResult)) error {
+	if onResult == nil {
+		onResult = func(ProbeSiteResult) {}
+	}
 	if s == nil || siteID <= 0 {
-		return nil, 0, 0
+		return nil
 	}
 	dbw := store.GetDB()
 	if dbw == nil {
-		return nil, 0, 0
+		return nil
 	}
-	sql := "SELECT rc.id, rc.account_id, a.site_id, COALESCE(rc.source_model, '') AS source_model " +
+	// siteProbeTargetsSQL selects up to 32 enabled route channels on the site
+	// whose account/site is active and whose source model is non-empty. The
+	// LIMIT 32 caps total work per admin probe pass so a single call cannot
+	// explode into hundreds of upstream requests.
+	const siteProbeTargetsSQL = "SELECT rc.id, rc.account_id, a.site_id, COALESCE(rc.source_model, '') AS source_model " +
 		"FROM route_channels rc " +
 		"INNER JOIN accounts a ON rc.account_id = a.id " +
 		"INNER JOIN sites st ON a.site_id = st.id " +
 		"WHERE rc.enabled = TRUE AND a.status = 'active' AND st.status = 'active' " +
 		"AND a.site_id = ? AND COALESCE(rc.source_model, '') <> '' " +
 		"ORDER BY rc.id ASC LIMIT 32"
-	targets, err := queryProbeTargets(dbw, sql, siteID)
+	targets, err := queryProbeTargets(dbw, siteProbeTargetsSQL, siteID)
 	if err != nil {
-		return []ProbeSiteResult{{Status: "error", Error: fmt.Sprintf("%v", err)}}, 0, 0
+		onResult(ProbeSiteResult{Status: "error", Error: fmt.Sprintf("%v", err)})
+		return err
+	}
+	if len(targets) == 0 {
+		return nil
 	}
 	timeoutMs := 15000
 	if s.cfg != nil && s.cfg.ModelAvailabilityProbeTimeoutMs >= 3000 {
 		timeoutMs = s.cfg.ModelAvailabilityProbeTimeoutMs
 	}
+	s.probeSiteTargets(ctx, targets, timeoutMs, onResult)
+	return ctx.Err()
+}
+
+// probeSiteTargets runs probes for the given targets with bounded concurrency
+// and streams each result to onResult as soon as it completes. It respects
+// ctx cancellation: stops scheduling new probes on cancel; in-flight probes
+// finish (bounded by their own per-target timeout) but their results are not
+// streamed to a cancelled caller.
+//
+// This is split from ProbeSiteIncremental so tests can exercise the
+// concurrency / cancellation contract directly with synthetic targets and
+// a fake probe executor, without seeding a DB.
+func (s *ModelProbeScheduler) probeSiteTargets(ctx context.Context, targets []ProbeTarget, timeoutMs int, onResult func(ProbeSiteResult)) {
+	if onResult == nil {
+		onResult = func(ProbeSiteResult) {}
+	}
+	if len(targets) == 0 {
+		return
+	}
+	sem := make(chan struct{}, adminProbeConcurrency)
+	var wg sync.WaitGroup
+loop:
 	for _, target := range targets {
-		outcome := s.probeOne(target, timeoutMs)
-		res := ProbeSiteResult{
-			ChannelID: target.ChannelID,
-			AccountID: target.AccountID,
-			Model:     target.ModelName,
-			Status:    outcome,
+		target := target
+		// Stop scheduling new probes once the caller has cancelled. The
+		// select also unblocks on ctx.Done() so we never block waiting for
+		// a slot after cancellation.
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			break loop
 		}
-		results = append(results, res)
-		if outcome == "success" {
-			available++
-		} else if outcome == "failure" {
-			unavailable++
-		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			outcome := s.probeOne(target, timeoutMs)
+			// Don't stream to a cancelled caller — the client is gone and
+			// writing would just block / error downstream. The probe still
+			// ran to completion and any health mutation already happened.
+			if ctx.Err() != nil {
+				return
+			}
+			onResult(ProbeSiteResult{
+				ChannelID: target.ChannelID,
+				AccountID: target.AccountID,
+				Model:     target.ModelName,
+				Status:    outcome,
+			})
+		}()
 	}
-	if results == nil {
-		results = []ProbeSiteResult{}
-	}
-	return results, available, unavailable
+	wg.Wait()
 }

--- a/scheduler/site_probe_admin_incremental_test.go
+++ b/scheduler/site_probe_admin_incremental_test.go
@@ -1,0 +1,187 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// timedProbe is a ChannelHealthProbe that sleeps a per-channel duration before
+// returning. It is used to prove probeSiteTargets streams results in
+// completion order rather than buffering everything until the end.
+type timedProbe struct {
+	mu     sync.Mutex
+	calls  []int64
+	delays map[int64]time.Duration
+}
+
+func (p *timedProbe) ProbeChannel(_ context.Context, target ProbeTarget) (ProbeOutcome, error) {
+	p.mu.Lock()
+	p.calls = append(p.calls, target.ChannelID)
+	delay := time.Duration(0)
+	if d, ok := p.delays[target.ChannelID]; ok {
+		delay = d
+	}
+	p.mu.Unlock()
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+	return ProbeOutcome{Status: "success", LatencyMs: float64(delay.Milliseconds())}, nil
+}
+
+// TestProbeSiteTargets_StreamsResultsIncrementally verifies that results are
+// delivered to onResult as each probe completes, not buffered and replayed
+// after every probe finishes. Three targets with staggered delays (10ms /
+// 80ms / 150ms) are probed concurrently; the first result must arrive before
+// the slowest probe's delay elapses.
+func TestProbeSiteTargets_StreamsResultsIncrementally(t *testing.T) {
+	s := NewModelProbeScheduler(testConfig())
+	probe := &timedProbe{delays: map[int64]time.Duration{
+		101: 10 * time.Millisecond,
+		102: 80 * time.Millisecond,
+		103: 150 * time.Millisecond,
+	}}
+	s.SetProbeExecutor(probe)
+	s.SetHealthRecorder(&fakeRecorder{})
+
+	// Drive the bounded-concurrency runner directly with synthetic targets so
+	// this test does not need a seeded store.GetDB().
+	targets := []ProbeTarget{
+		{ChannelID: 101, AccountID: 1, ModelName: "fast"},
+		{ChannelID: 102, AccountID: 1, ModelName: "mid"},
+		{ChannelID: 103, AccountID: 1, ModelName: "slow"},
+	}
+
+	type timedResult struct {
+		ChannelID int64
+		At        time.Duration
+	}
+	var mu sync.Mutex
+	var got []timedResult
+	start := time.Now()
+	s.probeSiteTargets(context.Background(), targets, 5000, func(r ProbeSiteResult) {
+		mu.Lock()
+		got = append(got, timedResult{ChannelID: r.ChannelID, At: time.Since(start)})
+		mu.Unlock()
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 3 {
+		t.Fatalf("expected 3 streamed results, got %d (%+v)", len(got), got)
+	}
+	// Results must arrive in completion order: fast(10ms) → mid(80ms) → slow(150ms).
+	if got[0].ChannelID != 101 {
+		t.Fatalf("first result should be the fast channel 101, got %d (order=%+v)", got[0].ChannelID, got)
+	}
+	if got[1].ChannelID != 102 {
+		t.Fatalf("second result should be the mid channel 102, got %d (order=%+v)", got[1].ChannelID, got)
+	}
+	if got[2].ChannelID != 103 {
+		t.Fatalf("third result should be the slow channel 103, got %d (order=%+v)", got[2].ChannelID, got)
+	}
+	// The critical incremental assertion: the first result arrived BEFORE the
+	// slowest probe could have finished. The old sequential/replay behavior
+	// would not write any result until ~150ms (all done). Allow generous
+	// slack to avoid CI flake.
+	if got[0].At >= 100*time.Millisecond {
+		t.Fatalf("first result arrived at %v — looks buffered until probes finished (want < 100ms)", got[0].At)
+	}
+	if got[2].At < 100*time.Millisecond {
+		t.Fatalf("last result arrived at %v — too fast, slowest probe is 150ms", got[2].At)
+	}
+}
+
+// releaseProbe blocks every ProbeChannel call on a shared release channel so
+// tests can control exactly when in-flight probes finish. It records how many
+// calls ever started.
+type releaseProbe struct {
+	mu      sync.Mutex
+	calls   []int64
+	release chan struct{}
+}
+
+func (p *releaseProbe) ProbeChannel(_ context.Context, target ProbeTarget) (ProbeOutcome, error) {
+	p.mu.Lock()
+	p.calls = append(p.calls, target.ChannelID)
+	p.mu.Unlock()
+	<-p.release
+	return ProbeOutcome{Status: "success"}, nil
+}
+
+func (p *releaseProbe) startedCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.calls)
+}
+
+// TestProbeSiteTargets_CancelStopsScheduling verifies that cancelling the
+// context stops launching new probes: with 12 targets and concurrency 8, the
+// first 8 start (filling every slot), then a cancel must prevent targets 9-12
+// from ever starting. In-flight probes finish after the test releases them,
+// but their results are NOT streamed to the cancelled caller.
+func TestProbeSiteTargets_CancelStopsScheduling(t *testing.T) {
+	s := NewModelProbeScheduler(testConfig())
+	probe := &releaseProbe{release: make(chan struct{})}
+	s.SetProbeExecutor(probe)
+	s.SetHealthRecorder(&fakeRecorder{})
+
+	// 12 targets > adminProbeConcurrency (8) so the 9th can never acquire a
+	// slot until an in-flight probe finishes.
+	targets := make([]ProbeTarget, 12)
+	for i := range targets {
+		targets[i] = ProbeTarget{ChannelID: int64(200 + i), AccountID: 1, ModelName: "m"}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var streamed atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		s.probeSiteTargets(ctx, targets, 5000, func(ProbeSiteResult) {
+			streamed.Add(1)
+		})
+		close(done)
+	}()
+
+	// Wait until the 8-slot semaphore is saturated (8 probes started).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if probe.startedCount() == adminProbeConcurrency {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if got := probe.startedCount(); got != adminProbeConcurrency {
+		t.Fatalf("expected %d probes started before cancel, got %d", adminProbeConcurrency, got)
+	}
+
+	// Cancel: targets 9-12 must never start.
+	cancel()
+
+	// Give the scheduler a moment to observe cancellation and exit the
+	// scheduling loop. No new ProbeChannel calls should appear.
+	time.Sleep(40 * time.Millisecond)
+	if got := probe.startedCount(); got != adminProbeConcurrency {
+		t.Fatalf("after cancel, %d probes started (want %d — no new probes should start)", got, adminProbeConcurrency)
+	}
+
+	// Release the 8 in-flight probes so probeSiteTargets' wg.Wait() returns.
+	close(probe.release)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("probeSiteTargets did not return within 2s after in-flight probes were released")
+	}
+
+	// No results should have been streamed: ctx was cancelled before any
+	// in-flight probe finished, so onResult is skipped for all of them.
+	if n := streamed.Load(); n != 0 {
+		t.Fatalf("expected 0 streamed results after cancel, got %d", n)
+	}
+	if got := probe.startedCount(); got != adminProbeConcurrency {
+		t.Fatalf("final started count = %d, want %d (cancellation must not launch the remaining targets)", got, adminProbeConcurrency)
+	}
+}


### PR DESCRIPTION
## Summary

P1 reliability fix for the admin probe endpoints (`POST /api/sites/{id}/probe-now` and `GET /api/sites/{id}/probe-stream`), which had three critical issues:

- **Blocking**: `ProbeSite` ran up to 32 targets × 15s sequentially — worst case ~8min blocking the HTTP handler.
- **Fake SSE stream**: `probeStream` wrote nothing until ALL probes finished, then replayed events; the 60s `WriteTimeout` (`app/app.go`) killed any run longer than 60s.
- **No client-cancel propagation**: `ProbeSite` ignored `r.Context()`, so a disconnected client left probes running.

### Changes

- **`scheduler/site_probe_admin.go`**: add `ProbeSiteIncremental(ctx, siteID, onResult)` — 8-way bounded concurrency (`adminProbeConcurrency`), streams results as they complete, returns early on `ctx` cancellation (stops scheduling new probes; in-flight probes finish but their results are not streamed to a cancelled caller). `ProbeSite` becomes a thin `context.Background()` wrapper (keeps `app` probe-wire tests + recovery callers working). The bounded runner `probeSiteTargets` is split out so the concurrency/cancellation contract is unit-testable without seeding a DB.
- **`handler/admin/sites.go` `probeStream`**: clear the server `WriteTimeout` via `http.NewResponseController(w).SetWriteDeadline(time.Time{})` (same pattern as `handler/proxy/upstream_stream.go:40-41`), stream each `probe-result` as it completes, send a final `complete` event + OpenAI-style `data: [DONE]` sentinel, and respect `r.Context()` (skip closing events when the client is gone).
- **`handler/admin/sites.go` `probeNow`**: bound total work with a 30s `context.WithTimeout(r.Context(), ...)` and surface `complete` / `truncated` flags (well under the 60s `WriteTimeout`; operators watching slow sites should use the streaming endpoint).
- **Wire discarded params**: `modelName` (probe-now body + stream query) now filters results; the dead reads of `scope` and `latencyThresholdMs` are removed.
- **Concurrency safety**: the `onResult` callbacks in both handlers are guarded with a mutex — `http.ResponseWriter` is not safe for concurrent writes, and the shared counters/slice were racy (caught by `go test -race`).

The probe logic itself (HTTP request, model check) is unchanged — only the orchestration (concurrency, streaming, context).

## Test plan

- [x] `go build ./scheduler/... ./handler/admin/... ./app/...`
- [x] `go vet ./scheduler/... ./handler/admin/...`
- [x] `go test ./handler/admin/... ./scheduler/...` (green)
- [x] `go test ./handler/admin/... ./scheduler/... -race` (green — no data races)
- [x] `go test ./app -run TestWireModelProbeScheduler_ProbeMutatesHealth` (ProbeSite wrapper still mutates health)
- [x] New: `scheduler.TestProbeSiteTargets_StreamsResultsIncrementally` — staggered delays prove results arrive in completion order, not buffered until the end.
- [x] New: `scheduler.TestProbeSiteTargets_CancelStopsScheduling` — 12 targets / 8 slots; cancel prevents targets 9-12 from ever starting; in-flight results are not streamed.
- [x] New: `handler/admin.TestSites_ProbeStream_IncrementalSSE` — fast channel's SSE event appears before the slow channel's 200ms delay elapses (real incremental writes through the handler).
- [x] New: `handler/admin.TestSites_ProbeStream_CancelStopsProbing` — client disconnect stops probing; no `complete` / `[DONE]` written to a gone client.