### PR TITLE
fix: defensive pagination for routes/accounts/keys

### DIFF
--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -94,6 +94,17 @@ func (h *accountsHandler) listAccounts(w http.ResponseWriter, r *http.Request) {
 	refresh := strings.TrimSpace(r.URL.Query().Get("refresh"))
 	forceRefresh := refresh == "true" || refresh == "1"
 
+	// Defensive pagination (#719/#711 parity). When ?page is absent the handler
+	// returns the full 30s-TTL cached snapshot exactly as before (backward
+	// compat for the frontend that does not paginate). When ?page is supplied,
+	// bypass the snapshot cache and run a bounded LIMIT/OFFSET query so the
+	// response size stays capped as the account fleet grows.
+	pageStr := strings.TrimSpace(r.URL.Query().Get("page"))
+	if pageStr != "" {
+		h.listAccountsPaginated(w, r)
+		return
+	}
+
 	// Check snapshot cache
 	if !forceRefresh {
 		if cached, hit := globalAccountsCache.get(); hit {
@@ -119,40 +130,7 @@ func (h *accountsHandler) listAccounts(w http.ResponseWriter, r *http.Request) {
 	if metricsErr != nil {
 		slog.Error("Failed to load per-account today metrics", "err", metricsErr)
 	} else {
-		for _, account := range accounts {
-			accountID := coerceInt64(account["id"])
-			if accountID <= 0 {
-				continue
-			}
-			if m, exists := todayMetrics[accountID]; exists {
-				account["todayReward"] = m.Reward
-				account["todayRewardStatus"] = m.RewardStatus
-				account["todayRewardReason"] = m.RewardReason
-				account["todaySpend"] = m.Spend
-				account["todaySpendStatus"] = m.SpendStatus
-				account["todaySpendReason"] = m.SpendReason
-				account["todayTokens"] = m.Tokens
-				account["todayProxy"] = map[string]any{
-					"total":   m.ProxyTotal,
-					"success": m.ProxySuccess,
-					"failed":  m.ProxyFailed,
-					"unknown": m.ProxyUnknown,
-				}
-			} else {
-				// Real zero, not missing: account had no rows within the local day.
-				account["todayReward"] = 0.0
-				account["todayRewardStatus"] = "complete"
-				account["todaySpend"] = 0.0
-				account["todaySpendStatus"] = "complete"
-				account["todayTokens"] = int64(0)
-				account["todayProxy"] = map[string]any{
-					"total":   0,
-					"success": 0,
-					"failed":  0,
-					"unknown": 0,
-				}
-			}
-		}
+		applyAccountTodayMetrics(accounts, todayMetrics)
 	}
 
 	// Also fetch sites for the response
@@ -169,6 +147,85 @@ func (h *accountsHandler) listAccounts(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("x-accounts-snapshot-cache", "miss")
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// listAccountsPaginated serves GET /api/accounts?page=&pageSize= with a bounded
+// LIMIT/OFFSET query. The snapshot cache is intentionally bypassed: a paged
+// request is an explicit opt-out of the snapshot, and caching every page combo
+// would multiply the cache surface. Today metrics are still enriched for the
+// accounts on the current page. Response shape mirrors /api/channels:
+// {items, total, page, pageSize, generatedAt, sites}.
+func (h *accountsHandler) listAccountsPaginated(w http.ResponseWriter, r *http.Request) {
+	page := clampInt(getQueryInt(r, "page", 1), 1, 1_000_000)
+	pageSize := clampInt(getQueryInt(r, "pageSize", 50), 1, 200)
+	offset := (page - 1) * pageSize
+
+	accounts, total, err := service.ListAccountsWithSitesPaginated(h.db, pageSize, offset)
+	if err != nil {
+		slog.Error("Failed to load paginated accounts", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load accounts"})
+		return
+	}
+
+	todayMetrics, metricsErr := dailyservice.CollectPerAccountTodayMetrics(h.db, time.Now())
+	if metricsErr != nil {
+		slog.Error("Failed to load per-account today metrics", "err", metricsErr)
+	} else {
+		applyAccountTodayMetrics(accounts, todayMetrics)
+	}
+
+	var sites []store.Site
+	h.db.Select(&sites, "SELECT "+service.SiteSelectColumns+" FROM sites ORDER BY sort_order, id")
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"items":     normalizeSlice(accounts),
+		"total":     total,
+		"page":      page,
+		"pageSize":  pageSize,
+		"generatedAt": time.Now().UTC().Format(time.RFC3339),
+		"sites":     sites,
+	})
+}
+
+// applyAccountTodayMetrics merges per-account today aggregates onto each
+// account map. Accounts with no metrics for the local day get explicit zeros
+// with a "complete" status so the UI shows real zeros rather than placeholders.
+// Extracted from listAccounts so both the cached and paginated paths share it.
+func applyAccountTodayMetrics(accounts []map[string]any, todayMetrics map[int64]*dailyservice.AccountTodayMetrics) {
+	for _, account := range accounts {
+		accountID := coerceInt64(account["id"])
+		if accountID <= 0 {
+			continue
+		}
+		if m, exists := todayMetrics[accountID]; exists {
+			account["todayReward"] = m.Reward
+			account["todayRewardStatus"] = m.RewardStatus
+			account["todayRewardReason"] = m.RewardReason
+			account["todaySpend"] = m.Spend
+			account["todaySpendStatus"] = m.SpendStatus
+			account["todaySpendReason"] = m.SpendReason
+			account["todayTokens"] = m.Tokens
+			account["todayProxy"] = map[string]any{
+				"total":   m.ProxyTotal,
+				"success": m.ProxySuccess,
+				"failed":  m.ProxyFailed,
+				"unknown": m.ProxyUnknown,
+			}
+		} else {
+			// Real zero, not missing: account had no rows within the local day.
+			account["todayReward"] = 0.0
+			account["todayRewardStatus"] = "complete"
+			account["todaySpend"] = 0.0
+			account["todaySpendStatus"] = "complete"
+			account["todayTokens"] = int64(0)
+			account["todayProxy"] = map[string]any{
+				"total":   0,
+				"success": 0,
+				"failed":  0,
+				"unknown": 0,
+			}
+		}
+	}
 }
 
 // ---- Create Account ----

--- a/handler/admin/admin_pagination_test.go
+++ b/handler/admin/admin_pagination_test.go
@@ -1,0 +1,370 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// ---- listRoutes (GET /api/routes) pagination ----
+
+// TestListRoutes_NoPaginationReturnsFullArray verifies backward compatibility:
+// when ?page is absent the handler returns a bare JSON array of every route
+// (the pre-pagination response shape) so existing frontend code is untouched.
+func TestListRoutes_NoPaginationReturnsFullArray(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	seedRoutes(t, db, 3, now)
+
+	resp := doGet(t, r, "/api/routes")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+
+	// Backward-compat shape: a bare JSON array, NOT the {items,total,...} envelope.
+	var arr []any
+	if err := json.Unmarshal(resp.Body.Bytes(), &arr); err != nil {
+		t.Fatalf("expected bare array, decode failed: %v; body=%s", err, resp.Body.String())
+	}
+	if len(arr) != 3 {
+		t.Fatalf("routes len = %d, want 3 (full list, no LIMIT)", len(arr))
+	}
+}
+
+// TestListRoutes_PaginationReturnsSubsetAndTotal verifies that ?page=&pageSize=
+// applies LIMIT/OFFSET and returns the {items,total,page,pageSize} envelope
+// with the real total (not the page size).
+func TestListRoutes_PaginationReturnsSubsetAndTotal(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	seedRoutes(t, db, 3, now)
+
+	// page=1 pageSize=2 → 2 items, total=3
+	resp := doGet(t, r, "/api/routes?page=1&pageSize=2")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+	var page struct {
+		Items    []map[string]any `json:"items"`
+		Total    int              `json:"total"`
+		Page     int              `json:"page"`
+		PageSize int              `json:"pageSize"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode paginated envelope: %v; body=%s", err, resp.Body.String())
+	}
+	if page.Total != 3 {
+		t.Fatalf("total = %d, want 3 (real total, not page size)", page.Total)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("items len = %d, want 2 (pageSize)", len(page.Items))
+	}
+	if page.Page != 1 || page.PageSize != 2 {
+		t.Fatalf("page=%d pageSize=%d, want 1/2", page.Page, page.PageSize)
+	}
+
+	// page=2 → the remaining single route, total still 3.
+	resp2 := doGet(t, r, "/api/routes?page=2&pageSize=2")
+	if resp2.Code != http.StatusOK {
+		t.Fatalf("page 2 status = %d, want 200; body=%s", resp2.Code, resp2.Body.String())
+	}
+	var page2 struct {
+		Items []map[string]any `json:"items"`
+		Total int              `json:"total"`
+		Page  int              `json:"page"`
+	}
+	if err := json.Unmarshal(resp2.Body.Bytes(), &page2); err != nil {
+		t.Fatalf("decode page 2: %v; body=%s", err, resp2.Body.String())
+	}
+	if page2.Total != 3 {
+		t.Fatalf("page 2 total = %d, want 3", page2.Total)
+	}
+	if len(page2.Items) != 1 {
+		t.Fatalf("page 2 items len = %d, want 1 (remainder)", len(page2.Items))
+	}
+	if page2.Page != 2 {
+		t.Fatalf("page 2 page field = %d, want 2", page2.Page)
+	}
+}
+
+// TestListRoutes_PaginationScopesChannelBatchLoad confirms that paginated calls
+// only load channels for the routes on the current page, so a route on page 2
+// still receives its channels but a route on a different page does not leak in.
+func TestListRoutes_PaginationScopesChannelBatchLoad(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+
+	// Attach a channel to the seeded route so we can confirm it is still
+	// enriched on the page that contains it.
+	if _, err := db.Exec(
+		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+		 VALUES (?, ?, ?, 'gpt-4o', 1, 10, 1, 0)`,
+		routeID, accountID, tokenID,
+	); err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+
+	// The seeded route is the only one; pageSize=1 puts it on page 1 with its
+	// channel, and page 2 is empty.
+	resp := doGet(t, r, "/api/routes?page=1&pageSize=1")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", resp.Code, resp.Body.String())
+	}
+	var page struct {
+		Items []map[string]any `json:"items"`
+		Total int              `json:"total"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, resp.Body.String())
+	}
+	if page.Total != 1 {
+		t.Fatalf("total = %d, want 1", page.Total)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("items len = %d, want 1", len(page.Items))
+	}
+	channels, ok := page.Items[0]["channels"].([]any)
+	if !ok || len(channels) != 1 {
+		t.Fatalf("channels = %#v, want 1 enriched channel for the page-1 route", page.Items[0]["channels"])
+	}
+}
+
+func seedRoutes(t *testing.T, db *store.DB, count int, now string) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		if _, err := db.Exec(
+			`INSERT INTO token_routes (model_pattern, enabled, sort_order, created_at, updated_at)
+			 VALUES (?, 1, ?, ?, ?)`,
+			"model-"+strconv.Itoa(i)+"-*", i, now, now,
+		); err != nil {
+			t.Fatalf("seed route %d: %v", i, err)
+		}
+	}
+}
+
+// ---- listAccounts (GET /api/accounts) pagination ----
+
+func setupAccountsPaginationTest(t *testing.T) (*store.DB, chi.Router) {
+	t.Helper()
+	db, r, _ := setupAccountsTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		 VALUES ('Acct Site', 'https://acct.example.com', 'openai', 'active', ?, ?)`,
+		now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+
+	for i := 0; i < 3; i++ {
+		if _, err := db.Exec(
+			`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
+			 VALUES (?, ?, ?, 'active', 1, ?, ?)`,
+			siteID, "user-"+strconv.Itoa(i), "token-"+strconv.Itoa(i), now, now,
+		); err != nil {
+			t.Fatalf("seed account %d: %v", i, err)
+		}
+	}
+	return db, r
+}
+
+// TestListAccounts_NoPaginationReturnsCachedSnapshotShape verifies backward
+// compatibility: when ?page is absent the response shape is {generatedAt,
+// accounts, sites} with the full account list (no LIMIT).
+func TestListAccounts_NoPaginationReturnsCachedSnapshotShape(t *testing.T) {
+	_, r := setupAccountsPaginationTest(t)
+
+	resp := doGet(t, r, "/api/accounts?refresh=true")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", resp.Code, resp.Body.String())
+	}
+	var snapshot map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &snapshot); err != nil {
+		t.Fatalf("decode snapshot: %v; body=%s", err, resp.Body.String())
+	}
+	// Legacy shape: "accounts" key (not "items"), no total/page/pageSize.
+	accounts, ok := snapshot["accounts"].([]any)
+	if !ok {
+		t.Fatalf("expected 'accounts' array in legacy shape; got keys: %#v", mapKeys(snapshot))
+	}
+	if len(accounts) != 3 {
+		t.Fatalf("accounts len = %d, want 3 (full list, no LIMIT)", len(accounts))
+	}
+	if _, hasTotal := snapshot["total"]; hasTotal {
+		t.Fatalf("legacy shape must not include 'total'; got %#v", snapshot["total"])
+	}
+}
+
+// TestListAccounts_PaginationReturnsSubsetAndTotal verifies ?page=&pageSize=
+// bypasses the cache and returns the {items,total,page,pageSize} envelope.
+func TestListAccounts_PaginationReturnsSubsetAndTotal(t *testing.T) {
+	_, r := setupAccountsPaginationTest(t)
+
+	resp := doGet(t, r, "/api/accounts?page=1&pageSize=2")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", resp.Code, resp.Body.String())
+	}
+	var page struct {
+		Items    []map[string]any `json:"items"`
+		Total    int              `json:"total"`
+		Page     int              `json:"page"`
+		PageSize int              `json:"pageSize"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode paginated envelope: %v; body=%s", err, resp.Body.String())
+	}
+	if page.Total != 3 {
+		t.Fatalf("total = %d, want 3", page.Total)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("items len = %d, want 2", len(page.Items))
+	}
+	if page.Page != 1 || page.PageSize != 2 {
+		t.Fatalf("page=%d pageSize=%d, want 1/2", page.Page, page.PageSize)
+	}
+
+	// page 2 → the remaining account.
+	resp2 := doGet(t, r, "/api/accounts?page=2&pageSize=2")
+	if resp2.Code != http.StatusOK {
+		t.Fatalf("page 2 status = %d; body=%s", resp2.Code, resp2.Body.String())
+	}
+	var page2 struct {
+		Items []map[string]any `json:"items"`
+		Total int              `json:"total"`
+	}
+	if err := json.Unmarshal(resp2.Body.Bytes(), &page2); err != nil {
+		t.Fatalf("decode page 2: %v; body=%s", err, resp2.Body.String())
+	}
+	if page2.Total != 3 {
+		t.Fatalf("page 2 total = %d, want 3", page2.Total)
+	}
+	if len(page2.Items) != 1 {
+		t.Fatalf("page 2 items len = %d, want 1", len(page2.Items))
+	}
+}
+
+func mapKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// ---- listKeys (GET /api/downstream-keys) pagination ----
+
+func setupDownstreamKeysPaginationTest(t *testing.T) (*store.DB, chi.Router) {
+	t.Helper()
+	db, r := setupDownstreamKeysTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	for i := 0; i < 3; i++ {
+		if _, err := db.Exec(
+			`INSERT INTO downstream_api_keys (name, key, enabled, created_at, updated_at)
+			 VALUES (?, ?, 1, ?, ?)`,
+			"key-"+strconv.Itoa(i), "sk-key-"+strconv.Itoa(i), now, now,
+		); err != nil {
+			t.Fatalf("seed key %d: %v", i, err)
+		}
+	}
+	return db, r
+}
+
+// TestListKeys_NoPaginationReturnsLegacyShape verifies backward compatibility:
+// when ?page is absent the response shape is {success, items} with every key.
+func TestListKeys_NoPaginationReturnsLegacyShape(t *testing.T) {
+	_, r := setupDownstreamKeysPaginationTest(t)
+
+	resp := doGet(t, r, "/api/downstream-keys")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, resp.Body.String())
+	}
+	if body["success"] != true {
+		t.Fatalf("success = %#v, want true (legacy shape)", body["success"])
+	}
+	items, ok := body["items"].([]any)
+	if !ok {
+		t.Fatalf("expected 'items' array; got %#v", body["items"])
+	}
+	if len(items) != 3 {
+		t.Fatalf("items len = %d, want 3 (full list, no LIMIT)", len(items))
+	}
+	if _, hasTotal := body["total"]; hasTotal {
+		t.Fatalf("legacy shape must not include 'total'; got %#v", body["total"])
+	}
+}
+
+// TestListKeys_PaginationReturnsSubsetAndTotal verifies ?page=&pageSize=
+// applies LIMIT/OFFSET and returns the {items,total,page,pageSize} envelope.
+// downstream_api_keys are ordered by id DESC, so page 1 holds the newest keys.
+func TestListKeys_PaginationReturnsSubsetAndTotal(t *testing.T) {
+	_, r := setupDownstreamKeysPaginationTest(t)
+
+	resp := doGet(t, r, "/api/downstream-keys?page=1&pageSize=2")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", resp.Code, resp.Body.String())
+	}
+	var page struct {
+		Items []map[string]any `json:"items"`
+		Total int              `json:"total"`
+		Page  int              `json:"page"`
+		PageSize int           `json:"pageSize"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode paginated envelope: %v; body=%s", err, resp.Body.String())
+	}
+	if page.Total != 3 {
+		t.Fatalf("total = %d, want 3", page.Total)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("items len = %d, want 2", len(page.Items))
+	}
+	if page.Page != 1 || page.PageSize != 2 {
+		t.Fatalf("page=%d pageSize=%d, want 1/2", page.Page, page.PageSize)
+	}
+
+	// DESC ordering: page 1 holds the two newest keys (key-2, key-1).
+	firstName, _ := page.Items[0]["name"].(string)
+	if firstName != "key-2" {
+		t.Fatalf("page 1 first item name = %q, want 'key-2' (id DESC)", firstName)
+	}
+
+	// page 2 → the oldest key.
+	resp2 := doGet(t, r, "/api/downstream-keys?page=2&pageSize=2")
+	if resp2.Code != http.StatusOK {
+		t.Fatalf("page 2 status = %d; body=%s", resp2.Code, resp2.Body.String())
+	}
+	var page2 struct {
+		Items []map[string]any `json:"items"`
+		Total int              `json:"total"`
+	}
+	if err := json.Unmarshal(resp2.Body.Bytes(), &page2); err != nil {
+		t.Fatalf("decode page 2: %v; body=%s", err, resp2.Body.String())
+	}
+	if page2.Total != 3 {
+		t.Fatalf("page 2 total = %d, want 3", page2.Total)
+	}
+	if len(page2.Items) != 1 {
+		t.Fatalf("page 2 items len = %d, want 1", len(page2.Items))
+	}
+	oldestName, _ := page2.Items[0]["name"].(string)
+	if oldestName != "key-0" {
+		t.Fatalf("page 2 first item name = %q, want 'key-0' (id DESC remainder)", oldestName)
+	}
+
+	// Confirm the plaintext key is still redacted on the paginated path.
+	if rawKey, present := page.Items[0]["key"]; present && rawKey != "" {
+		t.Fatalf("paginated response leaked plaintext key: %#v", rawKey)
+	}
+}

--- a/handler/admin/downstream_keys.go
+++ b/handler/admin/downstream_keys.go
@@ -95,12 +95,47 @@ func (h *downstreamKeysHandler) summary(w http.ResponseWriter, r *http.Request) 
 }
 
 // GET /api/downstream-keys
+//
+// Defensive pagination (#719/#711 parity): the endpoint is unbounded by
+// default, but operators can opt into server-side paging with ?page/&pageSize.
+// When ?page is absent the behavior and response shape are byte-identical to
+// the legacy surface ({success, items}) so existing frontend code keeps working
+// untouched. Only when a non-empty ?page is supplied does the handler apply
+// LIMIT/OFFSET and return the {items,total,page,pageSize} envelope used by
+// /api/channels and /api/checkin/logs.
 func (h *downstreamKeysHandler) listKeys(w http.ResponseWriter, r *http.Request) {
-	rows := queryRows(h.db, "SELECT * FROM downstream_api_keys ORDER BY id DESC")
+	pageStr := strings.TrimSpace(r.URL.Query().Get("page"))
+	paginate := pageStr != ""
+
+	var rows []map[string]any
+	var total int64
+	page, pageSize := 1, 50
+	if paginate {
+		page = clampInt(getQueryInt(r, "page", 1), 1, 1_000_000)
+		pageSize = clampInt(getQueryInt(r, "pageSize", 50), 1, 200)
+		offset := (page - 1) * pageSize
+		rows = queryRows(h.db, h.db.Rebind(
+			"SELECT * FROM downstream_api_keys ORDER BY id DESC LIMIT ? OFFSET ?"),
+			pageSize, offset)
+		_ = h.db.Get(&total, h.db.Rebind("SELECT COUNT(*) FROM downstream_api_keys"))
+	} else {
+		rows = queryRows(h.db, "SELECT * FROM downstream_api_keys ORDER BY id DESC")
+	}
+
 	for _, row := range rows {
 		// List must not return full key; only keyMasked.
 		redactDownstreamKeySecret(row)
 		enrichKeyRateWindow(row)
+	}
+
+	if paginate {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"items":    normalizeSlice(rows),
+			"total":    total,
+			"page":     page,
+			"pageSize": pageSize,
+		})
+		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success": true,

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -173,23 +173,102 @@ func (h *tokenRoutesHandler) listSummary(w http.ResponseWriter, r *http.Request)
 
 // ---- List Routes ----
 // GET /api/routes
+//
+// Defensive pagination (#719/#711 parity): the endpoint is unbounded by
+// default, but operators can opt into server-side paging with ?page/&pageSize.
+// When ?page is absent the behavior and response shape are byte-identical to
+// the legacy surface (a bare JSON array of routes with batched channels) so
+// existing frontend code that does not paginate keeps working untouched. Only
+// when a non-empty ?page is supplied does the handler apply LIMIT/OFFSET and
+// return the {items,total,page,pageSize} envelope used by /api/channels.
 func (h *tokenRoutesHandler) listRoutes(w http.ResponseWriter, r *http.Request) {
-	rows := queryRows(h.db, "SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC")
-	// Batch-load all channels once (kill per-route N+1;).
+	pageStr := strings.TrimSpace(r.URL.Query().Get("page"))
+	paginate := pageStr != ""
+
+	var rows []map[string]any
+	var total int64
+	page, pageSize := 1, 50
+	if paginate {
+		page = clampInt(getQueryInt(r, "page", 1), 1, 1_000_000)
+		pageSize = clampInt(getQueryInt(r, "pageSize", 50), 1, 200)
+		offset := (page - 1) * pageSize
+		rows = queryRows(h.db, h.db.Rebind(
+			"SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC LIMIT ? OFFSET ?"),
+			pageSize, offset)
+		// Separate COUNT keeps the row maps free of a window-function column
+		// (queryRows MapScans into map[string]any and would echo total_count
+		// into every route item otherwise).
+		_ = h.db.Get(&total, h.db.Rebind("SELECT COUNT(*) FROM token_routes"))
+	} else {
+		rows = queryRows(h.db, "SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC")
+	}
+
+	result := h.enrichRoutesWithChannels(rows, paginate)
+
+	if paginate {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"items":    normalizeSlice(result),
+			"total":    total,
+			"page":     page,
+			"pageSize": pageSize,
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+// enrichRoutesWithChannels batch-loads channels for the given route rows and
+// attaches the enriched channel list to each route. When scopeToPage is true
+// (paginated call) the channel query is filtered to the route IDs on the
+// current page so a 50-row page does not pull the entire fleet's channels;
+// when false (legacy unpaginated call) it loads every channel, matching the
+// pre-pagination behavior exactly.
+func (h *tokenRoutesHandler) enrichRoutesWithChannels(rows []map[string]any, scopeToPage bool) []map[string]any {
 	// Select only credential fragments (first4/last4/length) instead of the
 	// plaintext access_token/api_token — the full secret never crosses the
 	// DB→Go boundary, so a stray slog/metrics call cannot leak it. The masked
 	// form is rebuilt in Go by routeChannelAccountPublic().
 	accessTokenFrags := credentialFragmentsSelect(h.db, "a.access_token", "access_token")
 	apiTokenFrags := credentialFragmentsSelect(h.db, "a.api_token", "api_token")
-	allChannelRows := queryRows(h.db,
-		`SELECT rc.*, a.username, `+accessTokenFrags+`, `+apiTokenFrags+`,
+	channelQuery := `SELECT rc.*, a.username, ` + accessTokenFrags + `, ` + apiTokenFrags + `,
 		       a.balance, a.status as account_status,
 		        s.id as site_id, s.name as site_name, s.url as site_url, s.platform as site_platform, s.status as site_status
 		 FROM route_channels rc
 		 LEFT JOIN accounts a ON rc.account_id = a.id
-		 LEFT JOIN sites s ON a.site_id = s.id
-		 ORDER BY rc.route_id ASC, rc.priority ASC, rc.id ASC`)
+		 LEFT JOIN sites s ON a.site_id = s.id`
+
+	// Collect route IDs to scope the channel batch load to the current page.
+	// Scoping only happens on paginated calls; the legacy call keeps the
+	// unfiltered load so its result set is identical to the pre-pagination
+	// behavior (an IN list of every route ID could also exceed SQLite's
+	// bind-parameter ceiling on very large fleets).
+	var allChannelRows []map[string]any
+	if scopeToPage {
+		routeIDs := make([]int64, 0, len(rows))
+		for _, route := range rows {
+			if rid := coerceInt64(route["id"]); rid > 0 {
+				routeIDs = append(routeIDs, rid)
+			}
+		}
+		if len(routeIDs) > 0 {
+			placeholders := make([]string, len(routeIDs))
+			args := make([]any, len(routeIDs))
+			for i, id := range routeIDs {
+				placeholders[i] = "?"
+				args[i] = id
+			}
+			channelQuery += " WHERE rc.route_id IN (" + strings.Join(placeholders, ",") + ")"
+			channelQuery += " ORDER BY rc.route_id ASC, rc.priority ASC, rc.id ASC"
+			allChannelRows = queryRows(h.db, channelQuery, args...)
+		} else {
+			channelQuery += " ORDER BY rc.route_id ASC, rc.priority ASC, rc.id ASC"
+			allChannelRows = queryRows(h.db, channelQuery)
+		}
+	} else {
+		channelQuery += " ORDER BY rc.route_id ASC, rc.priority ASC, rc.id ASC"
+		allChannelRows = queryRows(h.db, channelQuery)
+	}
+
 	channelsByRoute := make(map[int64][]map[string]any)
 	for _, ch := range allChannelRows {
 		routeID := coerceInt64(ch["routeId"])
@@ -238,7 +317,7 @@ func (h *tokenRoutesHandler) listRoutes(w http.ResponseWriter, r *http.Request) 
 		}
 		result = append(result, item)
 	}
-	writeJSON(w, http.StatusOK, result)
+	return result
 }
 
 // ---- Create Route ----

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -623,6 +623,43 @@ func ListAccountsWithSites(db *sqlx.DB) ([]map[string]any, error) {
 	return result, nil
 }
 
+// ListAccountsWithSitesPaginated returns a single page of accounts joined with
+// their sites, plus the total row count matching the same join. Enrichment is
+// identical to ListAccountsWithSites so a paginated page is byte-compatible
+// with a slice of the unpaginated snapshot. Used by GET /api/accounts?page=...
+// to bound the admin list response when the fleet grows (defensive pagination,
+// same envelope as /api/channels and /api/checkin/logs).
+func ListAccountsWithSitesPaginated(db *sqlx.DB, limit, offset int) ([]map[string]any, int64, error) {
+	rows, err := db.Queryx(db.Rebind(
+		`SELECT a.*, s.id as site_id_val, s.name as site_name, s.url as site_url,
+		        s.platform as site_platform, s.status as site_status
+		 FROM accounts a INNER JOIN sites s ON a.site_id = s.id
+		 ORDER BY a.sort_order, a.id
+		 LIMIT ? OFFSET ?`), limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var result []map[string]any
+	for rows.Next() {
+		row := make(map[string]any)
+		if err := rows.MapScan(row); err != nil {
+			continue
+		}
+		normalizeMapScanValues(row)
+		account := mapKeysToCamel(row)
+		result = append(result, enrichAccountOverviewRow(account))
+	}
+
+	var total int64
+	if err := db.Get(&total, db.Rebind(
+		`SELECT COUNT(*) FROM accounts a INNER JOIN sites s ON a.site_id = s.id`)); err != nil {
+		return result, 0, err
+	}
+	return result, total, nil
+}
+
 // enrichAccountOverviewRow attaches admin-list overview fields used by the UI.
 func enrichAccountOverviewRow(account map[string]any) map[string]any {
 	if account == nil {


### PR DESCRIPTION
## Summary

- Adds opt-in `page`/`pageSize` pagination (default 1/50, max 200) to the three unbounded admin list endpoints — `GET /api/routes`, `GET /api/accounts`, `GET /api/downstream-keys` — mirroring the `listChannels` (#719) and `checkinLogs` (#711) pattern with a `{items, total, page, pageSize}` envelope.
- **Backward compatible by design**: when `?page` is absent every endpoint returns the identical response shape and unbounded behavior as before (no LIMIT), so existing frontend code that does not paginate is untouched. Only a non-empty `?page` triggers `LIMIT/OFFSET`.
- `listRoutes` scopes its channel batch load to the current page's route IDs so a 50-row page doesn't pull the entire fleet's channels; `listAccounts` bypasses the 30s snapshot cache on paged calls and adds `service.ListAccountsWithSitesPaginated`; all SQL uses `db.Rebind()` for PG compatibility.

## Changes

- `handler/admin/token_routes.go` — `listRoutes` pagination + `enrichRoutesWithChannels` helper (page-scoped channel load)
- `handler/admin/accounts.go` — `listAccounts` pagination branch + `listAccountsPaginated` + extracted `applyAccountTodayMetrics` shared helper
- `handler/admin/downstream_keys.go` — `listKeys` pagination (secret redaction preserved on paginated path)
- `service/account_service.go` — `ListAccountsWithSitesPaginated` (same enrichment as `ListAccountsWithSites` + COUNT)
- `handler/admin/admin_pagination_test.go` — 7 tests covering paginated subset+total and no-pagination full-list for all 3 endpoints

## Test plan

- [x] `go build ./handler/... ./service/...` — clean
- [x] `go test ./handler/admin/...` — all pass (incl. 7 new pagination tests)
- [x] `go test ./service/...` — all pass
- [x] Backward-compat verified: no-`?page` returns legacy shapes (bare array for routes, `{success,items}` for keys, `{generatedAt,accounts,sites}` for accounts)
- [x] Paginated path returns correct subset + real total across pages 1 and 2
- [x] `listKeys` DESC ordering + secret redaction verified on paginated path