### PR TITLE
fix: LOG_LEVEL + accounts error shape

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -53,6 +53,13 @@ func main() {
 	cfg := config.Load(env)
 	config.Set(cfg)
 
+	// Configure the slog threshold from LOG_LEVEL before validation so a
+	// raised threshold also quiets non-critical validation warnings. The
+	// default text handler to stderr is preserved; only the level changes.
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: config.SlogLevel(cfg.LogLevel),
+	})))
+
 	// ---- 1a. Validate config at startup ----
 	errs := cfg.Validate()
 	hasCritical := false

--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,13 @@ type Config struct {
 	DbApplicationName string
 	Tz                string
 
+	// LogLevel controls the slog threshold applied at startup (env LOG_LEVEL).
+	// Accepted values: debug, info, warn, error. Default "info". Raising the
+	// threshold silences per-request / SSE / WS Debug-downgraded hot-path logs
+	// that are already observable via Prometheus metrics, cutting log volume in
+	// production without losing Warn/Error signal.
+	LogLevel string
+
 	// Cron (5 fields)
 	CheckinCron          string
 	CheckinScheduleMode  string
@@ -541,6 +548,7 @@ func Load(env map[string]string) *Config {
 	cfg.DbConnMaxIdleTimeSec = int(math.Trunc(parseNumber(get("DB_CONN_MAX_IDLE_TIME_SEC"), float64(DefaultDbConnMaxIdleTimeSec))))
 	cfg.DbApplicationName = strings.TrimSpace(firstNonEmpty(get("DB_APPLICATION_NAME"), get("METAPI_DB_APPLICATION_NAME")))
 	cfg.Tz = get("TZ")
+	cfg.LogLevel = normalizeLogLevel(firstNonEmpty(get("LOG_LEVEL"), DefaultLogLevel))
 
 	// ---- §3.4 Cron ----
 	cfg.CheckinCron = firstNonEmpty(get("CHECKIN_CRON"), DefaultCheckinCron)
@@ -792,6 +800,41 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+// normalizeLogLevel canonicalizes a LOG_LEVEL env value to one of
+// debug|info|warn|error. Unknown/empty input falls back to DefaultLogLevel
+// ("info") so an invalid operator value can never silence Warn/Error output.
+func normalizeLogLevel(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "debug":
+		return "debug"
+	case "warn", "warning":
+		return "warn"
+	case "error":
+		return "error"
+	case "info", "":
+		return "info"
+	default:
+		return "info"
+	}
+}
+
+// SlogLevel maps a canonical log-level string to the matching slog.Level.
+// Callers (e.g. cmd/server/main.go) use this at startup to configure the
+// default slog handler threshold from config.LogLevel. Unknown values fall
+// back to LevelInfo, matching normalizeLogLevel's "info" default.
+func SlogLevel(logLevel string) slog.Level {
+	switch normalizeLogLevel(logLevel) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
 }
 
 // normalizeDbProfile maps env aliases to shared-tiny|normal|dedicated.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"log/slog"
 	"strings"
 	"testing"
 )
@@ -594,5 +595,70 @@ func TestValidateAcceptsStrongCredentialSecret(t *testing.T) {
 		if configErrorField(err) == "account_credential_secret" {
 			t.Fatalf("Validate returned credential_secret error for 17 byte secret: %v", err)
 		}
+	}
+}
+
+func TestLoadLogLevelDefaultsToInfo(t *testing.T) {
+	cfg := Load(map[string]string{})
+	if cfg.LogLevel != DefaultLogLevel {
+		t.Fatalf("LogLevel = %q, want %q", cfg.LogLevel, DefaultLogLevel)
+	}
+	if cfg.LogLevel != "info" {
+		t.Fatalf("LogLevel = %q, want info", cfg.LogLevel)
+	}
+}
+
+func TestLoadLogLevelParsesKnownLevels(t *testing.T) {
+	cases := map[string]string{
+		"debug":   "debug",
+		"DEBUG":   "debug",
+		" info ":  "info",
+		"warn":    "warn",
+		"warning": "warn",
+		"Warn":    "warn",
+		"error":   "error",
+		"ERROR":   "error",
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			cfg := Load(map[string]string{"LOG_LEVEL": input})
+			if cfg.LogLevel != want {
+				t.Fatalf("LOG_LEVEL=%q → LogLevel = %q, want %q", input, cfg.LogLevel, want)
+			}
+		})
+	}
+}
+
+func TestLoadLogLevelFallsBackOnInvalid(t *testing.T) {
+	for _, input := range []string{"verbose", "trace", "123", "off"} {
+		t.Run(input, func(t *testing.T) {
+			cfg := Load(map[string]string{"LOG_LEVEL": input})
+			if cfg.LogLevel != "info" {
+				t.Fatalf("LOG_LEVEL=%q → LogLevel = %q, want info (fallback)", input, cfg.LogLevel)
+			}
+		})
+	}
+}
+
+func TestSlogLevelMapsCanonicalLevels(t *testing.T) {
+	cases := map[string]slog.Level{
+		"debug": slog.LevelDebug,
+		"info":  slog.LevelInfo,
+		"warn":  slog.LevelWarn,
+		"error": slog.LevelError,
+	}
+	for input, want := range cases {
+		if got := SlogLevel(input); got != want {
+			t.Fatalf("SlogLevel(%q) = %v, want %v", input, got, want)
+		}
+	}
+}
+
+func TestSlogLevelFallsBackToInfo(t *testing.T) {
+	if got := SlogLevel("bogus"); got != slog.LevelInfo {
+		t.Fatalf("SlogLevel(\"bogus\") = %v, want LevelInfo", got)
+	}
+	if got := SlogLevel(""); got != slog.LevelInfo {
+		t.Fatalf("SlogLevel(\"\") = %v, want LevelInfo", got)
 	}
 }

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -15,6 +15,11 @@ const (
 	DefaultDataDir = "./data"
 	DefaultDbType  = "sqlite"
 
+	// DefaultLogLevel is the slog threshold applied at startup when LOG_LEVEL
+	// is unset or invalid. "info" preserves the pre-config behavior so the
+	// hot-path Debug downgrades stay silent unless an operator opts in.
+	DefaultLogLevel = "info"
+
 	// DbProfile selects PostgreSQL pool presets. Explicit DB_MAX_* env vars
 	// always override the profile numbers. Dedicated/large-DB users can set
 	// DB_PROFILE=dedicated or raise DB_MAX_OPEN_CONNS freely.

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -588,7 +588,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 
 	adp := platform.GetAdapter(site.Platform)
 	if adp == nil {
-		writeJSON(w, http.StatusOK, map[string]any{"success": false, "message": "unsupported platform: " + site.Platform})
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "unsupported platform: " + site.Platform)
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
@@ -730,7 +730,7 @@ func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 
 	adp := platform.GetAdapter(site.Platform)
 	if adp == nil {
-		writeJSON(w, http.StatusOK, map[string]any{"success": false, "message": "unsupported platform: " + site.Platform})
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "unsupported platform: " + site.Platform)
 		return
 	}
 
@@ -738,15 +738,11 @@ func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	result, err := adp.VerifyToken(ctx, site.URL, accessToken, body.PlatformUserID, service.BuildPlatformProxyConfigForToken(h.cfg, &site, accessToken))
 	if err != nil {
-		writeJSON(w, http.StatusOK, map[string]any{"success": false, "message": err.Error()})
+		writeErrorWithRequest(w, r, http.StatusBadRequest, err.Error())
 		return
 	}
 	if result == nil || result.TokenType == "" || result.TokenType == "unknown" {
-		writeJSON(w, http.StatusOK, map[string]any{
-			"success":   false,
-			"tokenType": "unknown",
-			"message":   "token verification failed",
-		})
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "token verification failed")
 		return
 	}
 
@@ -988,7 +984,7 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 
 	row, err := service.GetAccountWithSiteByID(h.db, id)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"message": "account not found"})
+		writeErrorWithRequest(w, r, http.StatusNotFound, "account not found")
 		return
 	}
 
@@ -1361,12 +1357,12 @@ func (h *accountsHandler) refreshBalance(w http.ResponseWriter, r *http.Request)
 
 	result, err := balanceService.RefreshBalance(h.cfg, h.db, id)
 	if result == nil && err == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"message": "account not found or platform not supported"})
+		writeErrorWithRequest(w, r, http.StatusNotFound, "account not found or platform not supported")
 		return
 	}
 	if err != nil {
 		if strings.Contains(err.Error(), "unsupported platform") {
-			writeJSON(w, http.StatusNotFound, map[string]string{"message": "account not found or platform not supported"})
+			writeErrorWithRequest(w, r, http.StatusNotFound, "account not found or platform not supported")
 			return
 		}
 		slog.Warn("Balance refresh failed", "err", err, "account_id", id)

--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/deliciousbuding/metapi-go/config"
 	"github.com/deliciousbuding/metapi-go/routing"
 	"github.com/deliciousbuding/metapi-go/service"
 	"github.com/deliciousbuding/metapi-go/service/alert"
 	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
 )
 
 func setupAccountsTest(t *testing.T) (*store.DB, chi.Router, *config.Config) {
@@ -2538,5 +2538,67 @@ func TestAccounts_List_IncludesPerAccountTodayMetrics(t *testing.T) {
 	}
 	if got := coerceString(cleanRow["todaySpendStatus"]); got != "complete" {
 		t.Fatalf("clean todaySpendStatus = %q, want complete", got)
+	}
+}
+
+// TestAccounts_ErrorResponsesUseStandardShape verifies that migrated error
+// paths in accounts.go emit the unified {"error":...} shape (via
+// writeErrorWithRequest) instead of the legacy {"success":false,"message":...}
+// or {"message":...} bodies, and use non-2xx status codes.
+func TestAccounts_ErrorResponsesUseStandardShape(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	res, err := db.Exec(
+		"INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, 'no-such-platform', 'active', ?, ?)",
+		"UnsupportedPlatformSite", "https://example.com", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert unsupported platform site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+
+	t.Run("verifyToken unsupported platform returns 400 standard error", func(t *testing.T) {
+		resp := doPostJSON(t, r, "/api/accounts/verify-token", map[string]any{
+			"siteId":      siteID,
+			"accessToken": "some-token",
+		})
+		assertStandardErrorShape(t, resp, http.StatusBadRequest, "unsupported platform: no-such-platform")
+	})
+
+	t.Run("loginAccount unsupported platform returns 400 standard error", func(t *testing.T) {
+		resp := doPostJSON(t, r, "/api/accounts/login", map[string]any{
+			"siteId":   siteID,
+			"username": "u",
+			"password": "p",
+		})
+		assertStandardErrorShape(t, resp, http.StatusBadRequest, "unsupported platform: no-such-platform")
+	})
+
+	t.Run("updateAccount nonexistent returns 404 standard error", func(t *testing.T) {
+		resp := doPutJSON(t, r, "/api/accounts/999999", map[string]any{"status": "active"})
+		assertStandardErrorShape(t, resp, http.StatusNotFound, "account not found")
+	})
+}
+
+// assertStandardErrorShape verifies a response uses the unified admin error
+// shape: non-2xx status, JSON body with an "error" key and no legacy
+// "success" or "message" keys (the markers of the pre-migration shapes).
+func assertStandardErrorShape(t *testing.T, resp *httptest.ResponseRecorder, wantStatus int, wantMessage string) {
+	t.Helper()
+	if resp.Code != wantStatus {
+		t.Fatalf("status = %d, want %d (body=%s)", resp.Code, wantStatus, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal error body: %v (body=%s)", err, resp.Body.String())
+	}
+	if body["error"] != wantMessage {
+		t.Fatalf("error = %v, want %q (body=%s)", body["error"], wantMessage, resp.Body.String())
+	}
+	if _, ok := body["success"]; ok {
+		t.Fatalf("unexpected legacy \"success\" field in error body: %s", resp.Body.String())
+	}
+	if _, ok := body["message"]; ok {
+		t.Fatalf("unexpected legacy \"message\" field in error body: %s", resp.Body.String())
 	}
 }

--- a/handler/proxy/responses_ws.go
+++ b/handler/proxy/responses_ws.go
@@ -171,7 +171,7 @@ func HandleResponsesWebsocket(w http.ResponseWriter, r *http.Request) {
 			ctx.Err() != nil {
 			return
 		}
-		slog.Info("responses websocket session ended",
+		slog.Debug("responses websocket session ended",
 			"err", err,
 			"path", path,
 		)

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -141,7 +141,7 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 		}
 		siteSlot, acquired := siteLimiter.TryAcquire(selected.Site.ID, selected.Site.MaxConcurrency)
 		if !acquired {
-			slog.Info("site concurrency saturated; skipping channel without failure cascade",
+			slog.Debug("site concurrency saturated; skipping channel without failure cascade",
 				"site_id", selected.Site.ID,
 				"channel_id", selected.Channel.ID,
 				"max_concurrency", selected.Site.MaxConcurrency,
@@ -439,7 +439,7 @@ func dispatchEndpointAttemptWithContinue(
 	if err != nil {
 		// First-byte timeout: continue to next protocol when allowed; do not poison.
 		if proxy.IsObservedFirstByteTimeoutError(err) {
-			slog.Info("upstream first-byte timeout",
+			slog.Debug("upstream first-byte timeout",
 				"url", upstreamURL,
 				"model", upstreamModel,
 				"channel_id", selected.Channel.ID,

--- a/handler/proxy/upstream_stream.go
+++ b/handler/proxy/upstream_stream.go
@@ -58,7 +58,7 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 			// Client disconnect / request cancel: still return any usage already
 			// extracted from earlier SSE events (best-effort partial). Do not
 			// invent tokens when upstream never emitted a usage event.
-			slog.Info("SSE downstream context ended",
+			slog.Debug("SSE downstream context ended",
 				"err", r.Context().Err(),
 				"latency_ms", latencyMs,
 				"streamed_bytes", streamedBytes,

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -63,7 +63,7 @@ func RequestLogger(next http.Handler) http.Handler {
 		if status == 0 {
 			status = http.StatusOK
 		}
-		slog.Info("request",
+		slog.Debug("request",
 			"method", r.Method,
 			"path", r.URL.Path,
 			"remote", r.RemoteAddr,


### PR DESCRIPTION
## Summary

- **P1 — LOG_LEVEL config**: Add `LOG_LEVEL` env (default `info`; accepts `debug`/`info`/`warn`/`error`) parsed in `config.Load` and applied to the default `slog` handler at startup. Operators can now raise the threshold in production to silence per-request / SSE / WS noise that is already observable via Prometheus metrics.
- **P1 — hot-path log downgrade**: Downgrade five unconditional `slog.Info` calls on the request hot path to `slog.Debug` — per-request router log, SSE client disconnect, site concurrency saturated, upstream first-byte timeout, and WS session end. `Warn`/`Error` calls are unchanged; the structured log format is unchanged.
- **P2 — accounts error shape consistency**: Migrate leftover `writeJSON(w, http.StatusOK, {"success":false,"message":...})` (HTTP 200) and `writeJSON(w, http.StatusNotFound, {"message":...})` patterns in `handler/admin/accounts.go` to `writeErrorWithRequest`, producing the standard `{"error":...,"request_id":...}` shape with correct non-2xx status codes.
- **Tests**: Added `LOG_LEVEL` parsing/normalization + `SlogLevel` mapping tests in `config`; added a `handler/admin` test verifying the migrated accounts error responses use the standard shape (no legacy `success`/`message` keys).

## Changed log sites (Info → Debug)

| File | Line | Call |
|------|------|------|
| `router/middleware.go` | ~66 | per-request log (every request) |
| `handler/proxy/upstream_stream.go` | ~61 | SSE client disconnect |
| `handler/proxy/upstream.go` | ~144 | site concurrency saturated per-retry |
| `handler/proxy/upstream.go` | ~442 | upstream first-byte timeout |
| `handler/proxy/responses_ws.go` | ~174 | WS session end |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./config/... ./handler/...` passes (incl. new tests)
- [x] `go test ./router/...` passes (RequestLogger change)
- [x] `go vet ./config/... ./router/... ./handler/... ./cmd/...` clean
- [x] `gofmt` clean on new/edited test files