### PR TITLE
fix: LDOH configurable URL + WebDAV SSRF hardening + error leak fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -212,6 +212,12 @@ RESIN_ENABLED=
 # traffic. Default false. Per-site use_utls overrides this flag.
 UTLS_ENABLED=
 
+# ---- LDOH monitor proxy base URL ----
+# The /monitor-proxy/ldoh/* admin surface proxies an upstream LDOH dashboard.
+# Override LDOH_BASE_URL to point the monitor iframe at a self-hosted LDOH
+# instance (default https://ldoh.105117.xyz).
+LDOH_BASE_URL=https://ldoh.105117.xyz
+
 # ---- DB extras ----
 # Optional PG SSL override (default false; true requires TLS). Prefer DB_SSLMODE for fine control.
 DB_SSL=

--- a/config/config.go
+++ b/config/config.go
@@ -197,6 +197,12 @@ type Config struct {
 	// traffic. Per-site use_utls overrides this flag (see service.UTLSEnabled).
 	UTLSEnabled bool
 
+	// LDOHBaseURL is the upstream LDOH dashboard URL proxied through
+	// /monitor-proxy/ldoh/* (env-only — no DDL). Parsed from LDOH_BASE_URL;
+	// defaults to DefaultLDOHBaseURL so operators can redirect the monitor
+	// iframe at a self-hosted LDOH instance without a code change.
+	LDOHBaseURL string
+
 	// UpdateCenterEnabled gates the residual update-center scheduler
 	// (scheduler.UpdateCenterScheduler). The scheduler is a log-only no-op
 	// today (no remote registry / version discovery), so it is disabled by
@@ -625,6 +631,9 @@ func Load(env map[string]string) *Config {
 
 	// ---- §3.11c uTLS TLS fingerprint masking ----
 	cfg.UTLSEnabled = parseBoolean(get("UTLS_ENABLED"), false)
+
+	// ---- §3.11e LDOH monitor proxy base URL ----
+	cfg.LDOHBaseURL = strings.TrimSpace(firstNonEmpty(get("LDOH_BASE_URL"), DefaultLDOHBaseURL))
 
 	// ---- §3.11d Update Center scheduler gate ----
 	cfg.UpdateCenterEnabled = parseBoolean(get("METAPI_ENABLE_UPDATE_CENTER"), false)

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -110,4 +110,10 @@ const (
 	DefaultProxyMaxStreamResponseBytes = 1 << 20 // 1 MB
 
 	TelegramApiBaseUrl = "https://api.telegram.org"
+
+	// DefaultLDOHBaseURL is the upstream LDOH (LdoHub) dashboard URL proxied
+	// by the /monitor-proxy/ldoh/* admin surface. Parsed from LDOH_BASE_URL
+	// so operators can point the monitor iframe at a self-hosted LDOH
+	// instance without rebuilding the binary.
+	DefaultLDOHBaseURL = "https://ldoh.105117.xyz"
 )

--- a/docs/api.md
+++ b/docs/api.md
@@ -777,6 +777,25 @@ Readiness check (no auth required). It pings the active database and returns `20
 
 Desktop health check. Returns `{"status":"ok"}`.
 
+## Security Notes
+
+### LDOH monitor proxy
+
+The `/monitor-proxy/ldoh/*` admin surface proxies an upstream LDOH dashboard. The base URL is configurable via `LDOH_BASE_URL` (default `https://ldoh.105117.xyz`). The `LDOH_BASE_URL` env var lets operators redirect the monitor iframe at a self-hosted LDOH instance without rebuilding.
+
+**At-rest cookie concern**: The upstream LDOH session cookie (`ld_auth_session=…`) is stored **plaintext** in the `settings` table (key `monitor_ldoh_cookie`). Anyone with read access to the database can impersonate the LDOH session until it expires upstream. This is an accepted short-term trade-off; a future improvement should encrypt this secret at rest (e.g. AES-GCM keyed by `ACCOUNT_CREDENTIAL_SECRET`). Treat database read access as equivalent to LDOH credential disclosure until then.
+
+**Error leakage**: Upstream request failures return a generic `"LDOH upstream request failed"` message to the browser. The full error (DNS/TLS/network details) is logged server-side via `slog` only, preventing upstream topology leakage to end users.
+
+### WebDAV backup SSRF hardening
+
+WebDAV import/export URLs (`fileUrl`) are validated against SSRF at two layers:
+
+1. **URL validation** (`isValidWebdavFileURL`): rejects schemes other than `http`/`https`, embedded userinfo, invalid ports, `localhost` hostnames, and literal IP addresses in private (RFC 1918), loopback (127.0.0.0/8, ::1), link-local (169.254.0.0/16, fe80::/10 — blocks cloud metadata endpoints like 169.254.169.254), multicast, and unspecified (0.0.0.0/8, ::) ranges.
+2. **Dial-time DNS resolution** (`rejectUnsafeWebdavDialHost`): resolves the hostname and rejects any resolved IP in the same unsafe ranges, preventing TOCTOU races where a hostname resolves differently between validation and connection.
+
+Redirect targets are validated with the same `isValidWebdavFileURL` check before being followed (max 5 redirects; HTTPS-to-HTTP downgrades refused).
+
 ## Browser CORS
 
 Admin routes under `/api/*` are same-origin by default. Set `ADMIN_CORS_ALLOWED_ORIGINS` to a comma-separated list of exact trusted `http(s)` browser origins only when the admin UI is hosted separately. Wildcards, paths, query strings, and fragments are rejected. Proxy routes and health/metrics endpoints retain wildcard CORS.

--- a/handler/admin/monitor.go
+++ b/handler/admin/monitor.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -42,7 +43,17 @@ type monitorHandler struct {
 
 const ldohCookieSettingKey = "monitor_ldoh_cookie"
 const monitorAuthCookie = "meta_monitor_auth"
-const ldohBaseURL = "https://ldoh.105117.xyz"
+
+// SECURITY: The LDOH upstream session cookie (ld_auth_session=…) is stored
+// PLAINTEXT in the settings table (key = monitor_ldoh_cookie). Anyone with
+// read access to the database — a leaked backup, a SQL injection in another
+// handler, or a snapshot on a shared host — can impersonate the LDOH session
+// until it expires upstream. This is an accepted short-term trade-off: the
+// value is already a bearer secret handed to the browser, and the settings
+// table is not field-level encrypted today. A future improvement should
+// encrypt this secret at rest (e.g. AES-GCM keyed by AccountCredentialSecret)
+// so a database read alone does not yield a usable session cookie. Until then,
+// treat DB access as equivalent to LDOH credential disclosure.
 
 // monitorCookiePath is scoped to the iframe proxy surface only.
 // Path=/ is intentionally avoided so a stolen cookie cannot be presented
@@ -199,7 +210,8 @@ func (h *monitorHandler) ldohProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wildcardPath := resolveLdohProxyPath(r)
-	targetURL, err := url.Parse(ldohBaseURL + "/" + wildcardPath)
+	baseURL := h.cfg.LDOHBaseURL
+	targetURL, err := url.Parse(baseURL + "/" + wildcardPath)
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid proxy path"})
 		return
@@ -242,15 +254,20 @@ func (h *monitorHandler) ldohProxy(w http.ResponseWriter, r *http.Request) {
 	}
 	upstreamResp, err := client.Do(upstreamReq)
 	if err != nil {
+		slog.Error("LDOH upstream request failed",
+			"method", method,
+			"url", targetURL.String(),
+			"error", err,
+		)
 		writeJSON(w, http.StatusBadGateway, map[string]any{
-			"error": "LDOH upstream request failed: " + err.Error(),
+			"error": "LDOH upstream request failed",
 		})
 		return
 	}
 	defer upstreamResp.Body.Close()
 
 	contentType := upstreamResp.Header.Get("Content-Type")
-	if location := rewriteLocationHeader(upstreamResp.Header.Get("Location")); location != "" {
+	if location := rewriteLocationHeader(upstreamResp.Header.Get("Location"), baseURL); location != "" {
 		w.Header().Set("Location", location)
 	}
 	if contentType != "" {
@@ -267,7 +284,7 @@ func (h *monitorHandler) ldohProxy(w http.ResponseWriter, r *http.Request) {
 		if readErr != nil {
 			return
 		}
-		_, _ = w.Write([]byte(rewriteProxyText(string(raw))))
+		_, _ = w.Write([]byte(rewriteProxyText(string(raw), baseURL)))
 		return
 	}
 
@@ -369,10 +386,16 @@ func resolveLdohProxyPath(r *http.Request) string {
 	return ""
 }
 
-func rewriteProxyText(text string) string {
+func rewriteProxyText(text, baseURL string) string {
+	// Build the URL-based replacer entries dynamically so operators who
+	// override LDOH_BASE_URL get correct body rewrites for their instance.
+	// The escaped variant handles JSON-encoded source maps / inline scripts
+	// where "/" is written as "\/".
+	baseURLPrefix := baseURL + "/"
+	escapedBaseURLPrefix := strings.ReplaceAll(baseURLPrefix, "/", `\/`)
 	replacer := strings.NewReplacer(
-		"https://ldoh.105117.xyz/", "/monitor-proxy/ldoh/",
-		`https:\/\/ldoh.105117.xyz\/`, `\/monitor-proxy\/ldoh\/`,
+		baseURLPrefix, "/monitor-proxy/ldoh/",
+		escapedBaseURLPrefix, `\/monitor-proxy\/ldoh\/`,
 		`src="/`, `src="/monitor-proxy/ldoh/`,
 		`src='/`, `src='/monitor-proxy/ldoh/`,
 		`href="/`, `href="/monitor-proxy/ldoh/`,
@@ -388,12 +411,12 @@ func rewriteProxyText(text string) string {
 	return replacer.Replace(text)
 }
 
-func rewriteLocationHeader(location string) string {
+func rewriteLocationHeader(location, baseURL string) string {
 	if location == "" {
 		return ""
 	}
-	if strings.HasPrefix(location, ldohBaseURL+"/") {
-		return "/monitor-proxy/ldoh/" + strings.TrimPrefix(location, ldohBaseURL+"/")
+	if strings.HasPrefix(location, baseURL+"/") {
+		return "/monitor-proxy/ldoh/" + strings.TrimPrefix(location, baseURL+"/")
 	}
 	if strings.HasPrefix(location, "/") {
 		return "/monitor-proxy/ldoh" + location

--- a/handler/admin/settings_backup_webdav.go
+++ b/handler/admin/settings_backup_webdav.go
@@ -260,7 +260,16 @@ func isValidWebdavFileURL(raw string) bool {
 			return false
 		}
 	}
-	return isAllowedWebdavTargetHost(parsed.Hostname())
+	// Explicit SSRF guard: reject literal IPs in private/loopback/link-local/
+	// unspecified ranges at the URL-validation layer. This complements the
+	// dial-time DNS resolution check in rejectUnsafeWebdavDialHost and the
+	// hostname-level guard in isAllowedWebdavTargetHost. The allowPrivateWebdavTargets
+	// flag (test-only) bypasses this guard so httptest servers on 127.0.0.1 work.
+	host := parsed.Hostname()
+	if !allowPrivateWebdavTargets && isPrivateOrLoopback(host) {
+		return false
+	}
+	return isAllowedWebdavTargetHost(host)
 }
 
 func decodeOptionalJSONRequest(r *http.Request, dst any) error {
@@ -546,6 +555,25 @@ func isUnsafeWebdavAddr(addr netip.Addr) bool {
 		addr.IsLinkLocalUnicast() ||
 		addr.IsLinkLocalMulticast() ||
 		addr.IsMulticast()
+}
+
+// isPrivateOrLoopback reports whether host is a literal IP address in a
+// private, loopback, link-local, multicast, or unspecified range. This covers:
+//   - Loopback: 127.0.0.0/8, ::1
+//   - Link-local: 169.254.0.0/16 (incl. cloud metadata 169.254.169.254), fe80::/10
+//   - Private: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+//   - Unspecified: 0.0.0.0/8, ::
+//
+// Hostnames that are not literal IPs return false: DNS resolution for
+// hostnames is deferred to the dial-time guard in rejectUnsafeWebdavDialHost
+// to avoid TOCTOU races (a hostname that resolves to a safe IP at validation
+// time could resolve to a private IP by dial time, and vice versa).
+func isPrivateOrLoopback(host string) bool {
+	addr, err := netip.ParseAddr(strings.Trim(host, "[]"))
+	if err != nil {
+		return false
+	}
+	return isUnsafeWebdavAddr(addr)
 }
 
 func readLimitedWebdavBody(body io.Reader, maxBytes int64) ([]byte, error) {


### PR DESCRIPTION
## Summary

- **LDOH base URL configurable**: Replaced the hardcoded `const ldohBaseURL` in `handler/admin/monitor.go` with a configurable `LDOHBaseURL` field on `config.Config`, parsed from `LDOH_BASE_URL` env var (default `https://ldoh.105117.xyz`). Operators can now point the monitor iframe at a self-hosted LDOH instance without rebuilding.
- **Error leak fix**: The LDOH proxy handler previously returned `"LDOH upstream request failed: " + err.Error()` to the browser, leaking raw upstream DNS/TLS/network error text. Now returns a generic `"LDOH upstream request failed"` message and logs the full error server-side via `slog`.
- **WebDAV SSRF hardening**: Added `isPrivateOrLoopback(host string) bool` guard in `isValidWebdavFileURL` checking loopback (127.0.0.0/8, ::1), link-local (169.254.0.0/16, fe80::/10 — blocks cloud metadata endpoints like 169.254.169.254), private (10/8, 172.16/12, 192.168/16), and unspecified (0.0.0.0/8, ::) ranges. This applies to both initial URLs and redirect targets (via the existing `CheckRedirect` callback that calls `isValidWebdavFileURL`). Complements the existing dial-time DNS resolution guard in `rejectUnsafeWebdavDialHost`.
- **LDOH cookie at-rest documentation**: Added a SECURITY code comment in `monitor.go` documenting that the LDOH session cookie is stored plaintext in the `settings` table and should be encrypted at rest in a future improvement. Added a Security Notes section to `docs/api.md` covering the LDOH at-rest concern, error leak fix, and WebDAV SSRF hardening.

## Files changed

- `config/defaults.go` — `DefaultLDOHBaseURL` constant
- `config/config.go` — `LDOHBaseURL` field + env parsing in `Load()`
- `.env.example` — `LDOH_BASE_URL` documentation
- `handler/admin/monitor.go` — configurable URL, error leak fix, at-rest comment, `rewriteProxyText`/`rewriteLocationHeader` take baseURL param
- `handler/admin/settings_backup_webdav.go` — `isPrivateOrLoopback` function + guard in `isValidWebdavFileURL`
- `docs/api.md` — Security Notes section

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./handler/admin/...` passes (all existing tests, including WebDAV SSRF tests with `allowPrivateWebdavTargets` bypass)
- [x] `go test ./config/...` passes
- [ ] Manual: verify LDOH proxy works with default URL and custom `LDOH_BASE_URL`
- [ ] Manual: verify 502 response does not contain upstream error text