### PR TITLE
fix: frontend error handling + search a11y + API docs for sites/pricing

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -279,6 +279,78 @@ List all sites. Create a new site.
 
 Get, update, delete a site.
 
+### POST /api/sites/detect
+
+Detect the platform for a single URL (used by the import wizard's auto-detect step). Tries site-initialization presets first, then hostname heuristics.
+
+**Auth**: admin Bearer token.
+
+**Body**:
+```json
+{ "url": "https://api.deepseek.com/v1" }
+```
+
+**Response** (200):
+```json
+{
+  "url": "https://api.deepseek.com/v1",
+  "canonicalUrl": "https://api.deepseek.com/v1",
+  "platform": "openai",
+  "siteType": "openai",
+  "confidence": 1.0,
+  "initializationPresetId": "deepseek-openai"
+}
+```
+
+`confidence` is `0..1` (`1.0` when a preset matched). `initializationPresetId` is omitted when no preset matched. Returns `400` with `{"error":"Could not detect platform"}` when no platform can be resolved, and `400` with `{"error":"Invalid url. Expected non-empty string."}` for an empty/missing URL.
+
+### POST /api/sites/import
+
+Idempotent batch import of sites (and optional accounts) from the import wizard. A site is keyed by `(platform, url)`; duplicates are resolved per the chosen strategy.
+
+**Auth**: admin Bearer token.
+
+**Body**:
+```json
+{
+  "items": [
+    {
+      "name": "DeepSeek",
+      "url": "https://api.deepseek.com/v1",
+      "platform": "openai",
+      "globalWeight": 1.0,
+      "maxConcurrency": 0,
+      "duplicateStrategy": "skip",
+      "accounts": [
+        { "username": "svc-1", "accessToken": "sk-...", "apiToken": "" }
+      ]
+    }
+  ],
+  "duplicateStrategy": "skip"
+}
+```
+
+`items[].platform` is optional (auto-detected when omitted). `duplicateStrategy` is `skip` (default) or `merge`; per-item `duplicateStrategy` overrides the batch default. `accounts` is optional; each account is stored as an API-key style credential (model discovery is deferred to background refresh).
+
+**Response** (200):
+```json
+{
+  "imported": 1,
+  "skipped": 0,
+  "failed": 0,
+  "results": [
+    {
+      "name": "DeepSeek",
+      "url": "https://api.deepseek.com/v1",
+      "status": "imported",
+      "siteId": 12
+    }
+  ]
+}
+```
+
+`status` is one of `imported` | `merged` | `skipped` | `failed`; `reason` and `siteId` are omitted when not applicable. `imported` counts newly created sites plus accounts merged into an existing site; `skipped` counts idempotent no-ops; `failed` counts hard errors. Returns `400` with `{"error":"items is required"}` for an empty `items` array and `500` with `{"error":"Import sites failed"}` on internal failure. Site/route caches are invalidated when at least one site was imported.
+
 ---
 
 ## Accounts
@@ -804,6 +876,57 @@ OpenAI-compatible Files surface (proxy auth required). Forwards to the selected 
 | DELETE | `/v1/files/{fileId}` | Delete file. |
 
 Channel selection uses model key: body/multipart `model`, else `?model=`, else `X-Metapi-Files-Model`, else default `gpt-4o`. Residual platforms without a Files API return upstream errors.
+
+---
+
+## Downstream Pricing (`/v1/pricing`)
+
+Cross-site effective model price catalog exposed behind downstream-key (ProxyAuth) auth — NOT admin auth. A downstream consumer (中转站) holding a managed key can query effective cross-site model pricing for its own planning. Reuses the `modelPriceCompare` handler so the data surface is identical to `GET /api/models/price-compare`; no separate catalog to drift.
+
+Mounted under `/v1/*` so it inherits ProxyAuth + wildcard CORS.
+
+### GET /v1/pricing
+
+**Auth**: ProxyAuth (downstream API key), not admin Bearer token.
+
+**Query params**: `model` (optional name/substring), `days` (1–365, default 30), `limit` (default 50, max 200), `topModels` (1–50, default 12, used only when `model` is empty).
+
+**Response** (200):
+```json
+{
+  "model": "",
+  "days": 30,
+  "limit": 50,
+  "sampleUsage": { "promptTokens": 1000, "completionTokens": 500, "totalTokens": 1500 },
+  "items": [
+    {
+      "siteId": 3,
+      "siteName": "anthropic",
+      "platform": "anthropic",
+      "model": "claude-sonnet-4-20250514",
+      "accountId": 5,
+      "username": "svc-1",
+      "inputPerMillion": 3.0,
+      "outputPerMillion": 15.0,
+      "source": "billing_details",
+      "ratesSource": "billing_details",
+      "estimatedCostSample": 0.0105,
+      "observedSamples": 1200,
+      "configuredUnitCost": 0.003,
+      "missingPrice": false,
+      "recommended": true
+    }
+  ],
+  "meta": {
+    "count": 12,
+    "modelsConsidered": 12,
+    "sources": ["billing_details", "observed", "configured", "fallback"],
+    "notes": "Rates/costs from billing_details, observed proxy_logs, account unit_cost, or labeled fallback. missingPrice=true means no catalog/observed/configured signal."
+  }
+}
+```
+
+`source` is one of `billing_details` | `observed` | `configured` | `fallback`. Fallback is always labeled; `missingPrice=true` when no catalog/observed/configured signal exists. Rows are sorted cheapest-first and `recommended=true` marks the best channel per model. Alias: `GET /v1/models/price-compare` (same handler).
 
 ---
 

--- a/web/src/components/layout/search-modal.tsx
+++ b/web/src/components/layout/search-modal.tsx
@@ -317,6 +317,7 @@ export function SearchModal(props: SearchModalProps) {
           value={query}
           onValueChange={setQuery}
           placeholder={t('search.placeholder')}
+          aria-label={t('search.title')}
         />
         <CommandList className='max-h-[min(60svh,28rem)]'>
           {isSearching && (

--- a/web/src/features/import/api.ts
+++ b/web/src/features/import/api.ts
@@ -10,6 +10,7 @@ import {
   useQueryClient,
   type UseMutationOptions,
 } from '@tanstack/react-query'
+import axios from 'axios'
 
 import { accountQueryKeys } from '@/features/accounts'
 import { sitesKeys } from '@/features/sites'
@@ -21,7 +22,14 @@ import type {
   SiteDetectResult,
 } from './types'
 
-/** Detect the platform for a single URL. Returns an empty object on 400. */
+/**
+ * HTTP status codes that mean "the backend looked and the platform is not
+ * detectable" — a clean, expected negative result. The wizard keeps these URLs
+ * manually specifiable instead of treating them as failures.
+ */
+const UNDETECTABLE_STATUS_CODES = new Set([400, 404])
+
+/** Detect the platform for a single URL. Returns an empty object on 400/404. */
 export function useDetectSite(
   options?: UseMutationOptions<SiteDetectResult, Error, string>
 ) {
@@ -30,10 +38,18 @@ export function useDetectSite(
       try {
         const detected = (await api.detectSite(url)) as SiteDetectResult
         return detected ?? {}
-      } catch {
-        // Unknown / undetectable URLs surface as a client error; the wizard
-        // keeps them manually specifiable instead of failing the batch.
-        return {}
+      } catch (error: unknown) {
+        // Only 400/404 are clean "not detectable" responses — swallow them so
+        // the wizard renders the URL as manually specifiable. Transport
+        // errors (network/timeout) and 5xx must propagate so react-query can
+        // surface them instead of masquerading as a benign undetected URL.
+        if (
+          axios.isAxiosError(error) &&
+          UNDETECTABLE_STATUS_CODES.has(error.response?.status ?? 0)
+        ) {
+          return {}
+        }
+        throw error
       }
     },
     ...options,
@@ -48,7 +64,13 @@ export function useImportSites(
   return useMutation<ImportSitesResult, Error, ImportSitesPayload>({
     mutationFn: async (payload) => {
       const result = (await api.importSites(payload)) as ImportSitesResult
-      return result ?? { imported: 0, skipped: 0, failed: 0, results: [] }
+      if (!result) {
+        // A malformed/empty response hides the real outcome. Never fabricate
+        // an "everything failed" summary — let react-query surface the error
+        // so the caller can report it instead of showing fake zero counts.
+        throw new Error('Import response was empty')
+      }
+      return result
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: sitesKeys.list() })


### PR DESCRIPTION
## Summary
- `useDetectSite` no longer swallows transport/5xx errors: only `400`/`404` (clean "not detectable" responses) return `{}`; everything else (network failure, timeout, 5xx) rethrows so react-query can surface it instead of rendering identically to an undetected platform.
- `useImportSites` throws on a malformed/empty response instead of fabricating an `imported:0/skipped:0/failed:0` summary that hides the real failure count.
- Search palette a11y: the `SearchTrigger` button (in `app-header.tsx`) already carried `aria-label`; the actual unlabeled interactive element inside `search-modal.tsx` — the `CommandInput` (placeholder-only) — now has an explicit `aria-label`.
- Documented `POST /api/sites/detect`, `POST /api/sites/import`, and the ProxyAuth `GET /v1/pricing` catalog endpoint in `docs/api.md` with request/response examples.

## Test plan
- [x] `cd web && bun run format` (oxfmt)
- [x] `cd web && bun run lint` (oxlint — no new warnings in edited files)
- [x] `cd web && bun run knip` (clean)
- [x] `cd web && bun run test` (334 passed, incl. i18n key coverage test)