### PR TITLE
refactor(web): loaders parse router location.searchStr instead of window.location

### DIFF
--- a/web/src/features/checkin/__tests__/checkin-schema.test.ts
+++ b/web/src/features/checkin/__tests__/checkin-schema.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import {
   buildCheckinSearchString,
+  buildInitialCheckinLogsQuery,
   checkinSearchSchema,
   getCheckinSearchDefaultValues,
+  parseCheckinSearch,
   parseFilterValues,
   readCheckinSearchFromUrl,
 } from '../lib/checkin-schema'
@@ -174,5 +176,81 @@ describe('readCheckinSearchFromUrl', () => {
     const result = readCheckinSearchFromUrl()
     expect(result.page).toBe(1)
     expect(result.pageSize).toBe(20)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseCheckinSearch — pure parser shared by the page + route loader
+// ---------------------------------------------------------------------------
+
+describe('parseCheckinSearch', () => {
+  it('parses a query string with a leading question mark', () => {
+    const result = parseCheckinSearch('?page=3&status=ok,fail')
+    expect(result.page).toBe(3)
+    expect(result.status).toBe('ok,fail')
+  })
+
+  it('parses a query string without a leading question mark', () => {
+    const result = parseCheckinSearch('page=2&pageSize=50&accountId=7')
+    expect(result.page).toBe(2)
+    expect(result.pageSize).toBe(50)
+    expect(result.accountId).toBe(7)
+  })
+
+  it('falls back to defaults on malformed input', () => {
+    const result = parseCheckinSearch('page=abc&pageSize=999')
+    expect(result.page).toBe(1)
+    expect(result.pageSize).toBe(20)
+  })
+
+  it('falls back to defaults on an empty string', () => {
+    const result = parseCheckinSearch('')
+    expect(result).toEqual(getCheckinSearchDefaultValues())
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildInitialCheckinLogsQuery — pure loader payload builder
+// ---------------------------------------------------------------------------
+
+describe('buildInitialCheckinLogsQuery', () => {
+  it('derives limit/offset from page/pageSize and forwards accountId + q', () => {
+    const result = buildInitialCheckinLogsQuery(
+      checkinSearchSchema.parse({ page: 2, pageSize: 50, accountId: 7, q: 'x' })
+    )
+    expect(result.limit).toBe(50)
+    expect(result.offset).toBe(50)
+    expect(result.accountId).toBe(7)
+    expect(result.search).toBe('x')
+  })
+
+  it('splits comma-separated status/reason/site filters', () => {
+    const result = buildInitialCheckinLogsQuery(
+      checkinSearchSchema.parse({
+        status: 'ok,fail',
+        reason: 'timeout, quota',
+        site: 'site-a',
+      })
+    )
+    // status is single-select: only the first value is forwarded.
+    expect(result.status).toBe('ok')
+    expect(result.reason).toEqual(['timeout', 'quota'])
+    expect(result.site).toEqual(['site-a'])
+  })
+
+  it('omits empty date bounds and empty q', () => {
+    const result = buildInitialCheckinLogsQuery(checkinSearchSchema.parse({}))
+    expect(result.from).toBeUndefined()
+    expect(result.to).toBeUndefined()
+    expect(result.search).toBeUndefined()
+  })
+
+  it('converts a provided date bound to a UTC RFC3339 string', () => {
+    const result = buildInitialCheckinLogsQuery(
+      checkinSearchSchema.parse({ from: '2026-01-01T00:00' })
+    )
+    // Timezone-dependent, so assert only the RFC3339 shape (no milliseconds).
+    expect(result.from).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)
+    expect(result.to).toBeUndefined()
   })
 })

--- a/web/src/features/checkin/index.ts
+++ b/web/src/features/checkin/index.ts
@@ -14,6 +14,7 @@ export { checkinQueryKeys, fetchCheckinLogs } from './api'
 export {
   buildInitialCheckinLogsQuery,
   checkinSearchSchema,
+  parseCheckinSearch,
 } from './lib/checkin-schema'
 
 // --- time helpers ---

--- a/web/src/features/checkin/lib/checkin-schema.ts
+++ b/web/src/features/checkin/lib/checkin-schema.ts
@@ -3,11 +3,11 @@
 // status / reason / date-range / text query are all encoded in the query
 // string so a bookmarked or shared URL restores the exact view.
 //
-// This mirrors the sites feature's `sitesSearchSchema` safe-parse pattern:
-// the route file for /checkin is not registered yet, so the page parses
-// `window.location.search` directly via this schema (gracefully falling
-// back to defaults on malformed input) instead of relying on TanStack
-// Router's generated search-param validation.
+// The `/checkin` route file registers this schema via `validateSearch`, and
+// its loader parses the router's `location.searchStr` with
+// `parseCheckinSearch`. The page still parses `window.location.search`
+// directly via `readCheckinSearchFromUrl` for its client-only state
+// initialisation (both share `parseCheckinSearch` underneath).
 
 import { z } from 'zod'
 
@@ -41,18 +41,30 @@ export function getCheckinSearchDefaultValues(): CheckinSearch {
 }
 
 /**
- * Parse `window.location.search` into a validated CheckinSearch. Returns
- * defaults on any validation failure so the page always boots into a known
- * state — the route layer will replace this with typed search params once
- * /checkin is registered.
+ * Parse a raw search string (with or without the leading `?`) into a
+ * validated CheckinSearch. Pure — no `window` access — so both the page
+ * (client, `window.location.search`) and the route loader (router
+ * `location.searchStr`) share the same parser. Returns defaults on any
+ * validation failure so callers always boot into a known state.
  */
-export function readCheckinSearchFromUrl(): CheckinSearch {
-  if (typeof window === 'undefined') return getCheckinSearchDefaultValues()
+export function parseCheckinSearch(searchStr: string): CheckinSearch {
   const entries = Object.fromEntries(
-    new URLSearchParams(window.location.search).entries()
+    new URLSearchParams(
+      searchStr.startsWith('?') ? searchStr.slice(1) : searchStr
+    ).entries()
   )
   const parsed = checkinSearchSchema.safeParse(entries)
   return parsed.success ? parsed.data : getCheckinSearchDefaultValues()
+}
+
+/**
+ * Parse `window.location.search` into a validated CheckinSearch (the page's
+ * client-only entry point). Returns defaults on any validation failure so
+ * the page always boots into a known state.
+ */
+export function readCheckinSearchFromUrl(): CheckinSearch {
+  if (typeof window === 'undefined') return getCheckinSearchDefaultValues()
+  return parseCheckinSearch(window.location.search)
 }
 
 /**
@@ -104,15 +116,16 @@ export function buildCheckinSearchString(params: {
 }
 
 /**
- * Build the server-side `CheckinLogsQuery` for the *initial* page render from
- * the URL search state. The page derives the same payload from its state
- * (initialized from the URL), so the route loader's prefetchQuery uses this
- * to produce a cache key that exactly matches the hook's first fetch — no
- * double-fetch on mount. `from`/`to` are converted to UTC RFC3339 (no
- * milliseconds) so the lexicographic `created_at` bound is correct.
+ * Build the server-side `CheckinLogsQuery` from an already-parsed
+ * `CheckinSearch`. Pure (no `window` access) so the route loader can pass the
+ * result of `parseCheckinSearch(location.searchStr)` — the prefetch cache key
+ * then exactly matches the hook's first fetch (no double-fetch on mount).
+ * `from`/`to` are converted to UTC RFC3339 (no milliseconds) so the
+ * lexicographic `created_at` bound is correct.
  */
-export function buildInitialCheckinLogsQuery(): CheckinLogsQuery {
-  const search = readCheckinSearchFromUrl()
+export function buildInitialCheckinLogsQuery(
+  search: CheckinSearch
+): CheckinLogsQuery {
   const statusValues = parseFilterValues(search.status)
   const reasonValues = parseFilterValues(search.reason)
   const siteValues = parseFilterValues(search.site)

--- a/web/src/routes/_authenticated/checkin.tsx
+++ b/web/src/routes/_authenticated/checkin.tsx
@@ -10,9 +10,12 @@
 //
 // `loader` prefetches the first server-paginated checkin-logs page the page's
 // `useCheckinLogs` hook will request. It builds the exact same
-// `CheckinLogsQuery` the page derives from URL state (`buildInitialCheckinLogsQuery`)
-// and reuses the hook's query key + fetcher (`fetchCheckinLogs`), so the
-// prefetched page is served from cache on mount instead of re-fetching.
+// `CheckinLogsQuery` the page derives from URL state, parsing the router's
+// `location.searchStr` (rather than the global `window.location.search`, so
+// the loader is SSR-safe and follows the router's location) via
+// `parseCheckinSearch` + `buildInitialCheckinLogsQuery`, and reuses the
+// hook's query key + fetcher (`fetchCheckinLogs`) so the prefetched page is
+// served from cache on mount instead of re-fetching.
 
 import { createFileRoute } from '@tanstack/react-router'
 
@@ -21,13 +24,16 @@ import {
   checkinQueryKeys,
   checkinSearchSchema,
   fetchCheckinLogs,
+  parseCheckinSearch,
 } from '@/features/checkin'
 import { CheckinPage } from '@/features/checkin/components/checkin-page'
 
 export const Route = createFileRoute('/_authenticated/checkin')({
   validateSearch: checkinSearchSchema,
-  loader: async ({ context }) => {
-    const initialQuery = buildInitialCheckinLogsQuery()
+  loader: async ({ context, location }) => {
+    const initialQuery = buildInitialCheckinLogsQuery(
+      parseCheckinSearch(location.searchStr)
+    )
     await context.queryClient.prefetchQuery({
       queryKey: checkinQueryKeys.logsList(initialQuery),
       queryFn: () => fetchCheckinLogs(initialQuery),

--- a/web/src/routes/_authenticated/proxy-logs.tsx
+++ b/web/src/routes/_authenticated/proxy-logs.tsx
@@ -10,14 +10,11 @@
 // `loader` prefetches both the proxy-logs page (`proxyLogsKeys.list(...)`)
 // and the meta facets (`proxyLogsKeys.meta(...)`) the page's `useProxyLogs`
 // / `useProxyLogsMeta` will request, building the same `ProxyLogsQuery`
-// payload from the URL search so the prefetched pages are reused. The
-// loader reads `window.location.search` and safe-parses it with
-// `proxyLogsSearchSchema` (the same schema the page uses) because TanStack
-// Router's loader context does not expose the validated `search` object in
-// this version; on a malformed URL the prefetch is skipped and the page
-// fetches on mount (its own safe-parse falls back to defaults). Latency
-// range is client-side only (not part of the backend query) so it is
-// intentionally absent from the prefetch payload.
+// payload from the router's `location.searchStr` (SSR-safe, rather than the
+// global `window.location.search`) so the prefetched pages are reused and the
+// cache key matches the page's first fetch. Latency range is client-side only
+// (not part of the backend query) so it is intentionally absent from the
+// prefetch payload.
 
 import { createFileRoute } from '@tanstack/react-router'
 
@@ -32,14 +29,16 @@ import { api } from '@/lib/api'
 const DEFAULT_PROXY_LOGS_PAGE_SIZE = 20
 
 /**
- * Read the proxy-logs URL search state via the feature schema. Returns
- * `null` on a malformed URL so the loader can skip the prefetch (the page
- * owns the fallback). Mirrors the page's `readUrlState` safe-parse approach.
+ * Safe-parse a raw search string with the feature schema. Returns `null` on a
+ * malformed string so the loader can skip the prefetch (the page owns the
+ * fallback). Pure — no `window` access — so it is shared by the loader (router
+ * `location.searchStr`) and mirrors the page's `readUrlState` approach.
  */
-function readProxyLogsUrlSearch(): ProxyLogsSearch | null {
-  if (typeof window === 'undefined') return null
+function parseProxyLogsSearch(searchStr: string): ProxyLogsSearch | null {
   const entries = Object.fromEntries(
-    new URLSearchParams(window.location.search).entries()
+    new URLSearchParams(
+      searchStr.startsWith('?') ? searchStr.slice(1) : searchStr
+    ).entries()
   )
   const parsed = proxyLogsSearchSchema.safeParse(entries)
   return parsed.success ? parsed.data : null
@@ -47,8 +46,8 @@ function readProxyLogsUrlSearch(): ProxyLogsSearch | null {
 
 export const Route = createFileRoute('/_authenticated/proxy-logs')({
   validateSearch: proxyLogsSearchSchema,
-  loader: async ({ context }) => {
-    const search = readProxyLogsUrlSearch()
+  loader: async ({ context, location }) => {
+    const search = parseProxyLogsSearch(location.searchStr)
     if (!search) return
 
     const pageIndex = search.page ?? 0


### PR DESCRIPTION
## Summary

Routing 系统 T1（P0 根因）：loader 层 URL-state 读取收敛到 TanStack Router 的 `location.searchStr`。

- **checkin / proxy-logs 两个 loader** 原来重读全局 `window.location.search`（SSR 不安全、绕过 router 自身 location），改为从 loader context 的 `location.searchStr` 解析（TSR v1.170 的 `LoaderFnContext` 不暴露 validated `search`，故仍走 feature schema 的 safe-parse）。
- **checkin-schema 抽出纯函数** `parseCheckinSearch(searchStr)`：page（`readCheckinSearchFromUrl`）与 loader 共用；`buildInitialCheckinLogsQuery` 改为接收已解析的 `CheckinSearch`，不再自己读 URL。
- 新增 `parseCheckinSearch` + `buildInitialCheckinLogsQuery` 测试。

## 说明

- accounts / token-routes 两个 loader 本身只预取静态数据（不读 URL），本次无需改动。
- 页面层的 `window.location.search` 直读（page state 初始化）属于更大的 page-level 迁移，不在本次 P0 范围内。

## 验证

- typecheck / lint / knip / format 全绿
- build 通过
- 测试 342/342（新增 8 个）

Ref: 路由系统系统性优化批次 P1-B1。