### PR TITLE
fix(web): shell-scoped 404 + sidebar hash handling + model deep-link validation

### DIFF
--- a/web/src/components/layout/lib/__tests__/url-utils.test.ts
+++ b/web/src/components/layout/lib/__tests__/url-utils.test.ts
@@ -45,4 +45,19 @@ describe('checkIsActive', () => {
     expect(checkIsActive('/settings?tab=a', item)).toBe(true)
     expect(checkIsActive('/settings/general', item)).toBe(false)
   })
+
+  it('ignores the hash fragment when matching the item url', () => {
+    const item = link({ url: '/models' })
+    expect(checkIsActive('/models#top', item)).toBe(true)
+    expect(checkIsActive('/models?tab=a#top', item)).toBe(true)
+  })
+
+  it('ignores the hash fragment for activePrefix drill-ins', () => {
+    const item = link({
+      url: '/settings/general/site',
+      activePrefix: '/settings/general',
+    })
+    expect(checkIsActive('/settings/general/site#header', item)).toBe(true)
+    expect(checkIsActive('/settings/general/auth#x', item)).toBe(true)
+  })
 })

--- a/web/src/components/layout/lib/url-utils.ts
+++ b/web/src/components/layout/lib/url-utils.ts
@@ -23,23 +23,23 @@ function urlToString(url: LinkProps['to'] | (string & {})): string | null {
 }
 
 /**
- * Normalize URL by removing query parameters and trailing slashes
+ * Strip both the query string and the hash fragment from a URL, leaving only
+ * the pathname. The active-state comparison should ignore transient query /
+ * hash state so `/models#top` still highlights the `/models` nav item.
  */
+function stripQueryAndHash(url: string): string {
+  return url.split('?')[0].split('#')[0]
+}
 
 /**
- * Check if a navigation item is active
- * @param href - Current URL
+ * Check if a navigation item is active for the current href.
+ * @param href - Current URL (may include query string + hash fragment)
  * @param item - Navigation item
- * @param mainNav - Whether this is a main navigation item (matches first-level path)
  */
-export function checkIsActive(
-  href: string,
-  item: NavItem,
-  mainNav = false
-): boolean {
-  const hrefWithoutQuery = href.split('?')[0]
+export function checkIsActive(href: string, item: NavItem): boolean {
+  const hrefPath = stripQueryAndHash(href)
 
-  if (item.activeUrls?.some((url) => urlToString(url) === hrefWithoutQuery)) {
+  if (item.activeUrls?.some((url) => urlToString(url) === hrefPath)) {
     return true
   }
 
@@ -49,9 +49,7 @@ export function checkIsActive(
     const prefix = item.activePrefix.split('?')[0]
     const cleanPrefix = prefix.length > 1 ? prefix.replace(/\/+$/, '') : prefix
     const cleanHref =
-      hrefWithoutQuery.length > 1
-        ? hrefWithoutQuery.replace(/\/+$/, '')
-        : hrefWithoutQuery
+      hrefPath.length > 1 ? hrefPath.replace(/\/+$/, '') : hrefPath
     if (cleanHref === cleanPrefix || cleanHref.startsWith(`${cleanPrefix}/`)) {
       return true
     }
@@ -69,9 +67,9 @@ export function checkIsActive(
         const subItemUrl = urlToString(i.url)
         if (!subItemUrl) return false
         if (href === subItemUrl) return true
-        const subItemUrlWithoutQuery = subItemUrl.split('?')[0]
+        const subItemUrlPath = stripQueryAndHash(subItemUrl)
         const subItemUrlHasQuery = subItemUrl.includes('?')
-        if (subItemUrlWithoutQuery === hrefWithoutQuery) {
+        if (subItemUrlPath === hrefPath) {
           if (!subItemUrlHasQuery) return true
           if (subItemUrlHasQuery && href === subItemUrl) return true
         }
@@ -91,20 +89,13 @@ export function checkIsActive(
   // Exact match
   if (href === itemUrl) return true
 
-  const itemUrlWithoutQuery = itemUrl.split('?')[0]
+  const itemUrlPath = stripQueryAndHash(itemUrl)
   const itemUrlHasQuery = itemUrl.includes('?')
 
   // If both URLs have the same base path
-  if (hrefWithoutQuery === itemUrlWithoutQuery) {
+  if (hrefPath === itemUrlPath) {
     if (!itemUrlHasQuery) return true
     if (itemUrlHasQuery && href === itemUrl) return true
-  }
-
-  // Main navigation match (matches first-level path)
-  if (mainNav && href.split('/')[1] && itemUrl) {
-    const hrefFirstPath = href.split('/')[1]
-    const itemFirstPath = itemUrl.split('/')[1]
-    return hrefFirstPath === itemFirstPath
   }
 
   return false

--- a/web/src/components/layout/not-found-page.tsx
+++ b/web/src/components/layout/not-found-page.tsx
@@ -13,7 +13,10 @@ import { Button } from '@/components/ui/button'
 export function NotFoundPage() {
   const { t } = useTranslation()
   return (
-    <div className='flex min-h-screen flex-col items-center justify-center gap-4 p-6'>
+    // `min-h-full` (not `min-h-screen`) so the page fills its container: the
+    // authenticated 404 catch-all renders it inside SidebarInset
+    // (`h-[calc(100svh-header)]`), where 100vh would overflow and add a scroll.
+    <div className='flex min-h-full flex-col items-center justify-center gap-4 p-6'>
       <div className='bg-muted/60 flex size-16 items-center justify-center rounded-2xl'>
         <Compass className='text-muted-foreground size-8' />
       </div>

--- a/web/src/features/model-tester/components/model-tester-page.tsx
+++ b/web/src/features/model-tester/components/model-tester-page.tsx
@@ -22,6 +22,7 @@
 // resulting `AbortError` is detected and surfaced as a "stopped" state
 // rather than a hard error.
 
+import { useSearch } from '@tanstack/react-router'
 import { Trash2 as TrashIcon } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -53,19 +54,13 @@ function isAbortError(error: unknown): boolean {
   )
 }
 
-function readDefaultModelFromUrl(): string | undefined {
-  if (typeof window === 'undefined') return undefined
-  const params = new URLSearchParams(window.location.search)
-  const model = params.get('model')
-  return model && model.trim().length > 0 ? model : undefined
-}
-
 export function ModelTesterPage() {
   const { t } = useTranslation()
-  // The `/model-tester` route file does not land its own validateSearch yet,
-  // so the page reads the `model` deep-link param directly from the URL (the
-  // same pattern the sites page uses for its search state).
-  const defaultModel = readDefaultModelFromUrl()
+  // The `/model-tester` route validates `?model=` via validateSearch, so the
+  // deep-link param comes from `useSearch()` (typed) rather than a raw
+  // `window.location.search` read.
+  const { model } = useSearch({ from: '/_authenticated/model-tester' })
+  const defaultModel = model?.trim() ? model : undefined
 
   const testModel = useTestModel()
 

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as AuthenticatedRouteRouteImport } from './routes/_authenticated/route'
 import { Route as SignInRouteImport } from './routes/sign-in'
 import { Route as AuthenticatedIndexRouteImport } from './routes/_authenticated/index'
+import { Route as AuthenticatedSplatRouteImport } from './routes/_authenticated/$'
 import { Route as AuthenticatedAboutRouteImport } from './routes/_authenticated/about'
 import { Route as AuthenticatedAccountsRouteImport } from './routes/_authenticated/accounts'
 import { Route as AuthenticatedChannelsRouteImport } from './routes/_authenticated/channels'
@@ -47,6 +48,11 @@ const SignInRoute = SignInRouteImport.update({
 const AuthenticatedIndexRoute = AuthenticatedIndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => AuthenticatedRouteRoute,
+} as any)
+const AuthenticatedSplatRoute = AuthenticatedSplatRouteImport.update({
+  id: '/$',
+  path: '/$',
   getParentRoute: () => AuthenticatedRouteRoute,
 } as any)
 const AuthenticatedAboutRoute = AuthenticatedAboutRouteImport.update({
@@ -179,6 +185,7 @@ export interface FileRoutesByFullPath {
   '/sign-in': typeof SignInRoute
   '/dashboard': typeof AuthenticatedDashboardRouteRouteWithChildren
   '/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
+  '/$': typeof AuthenticatedSplatRoute
   '/about': typeof AuthenticatedAboutRoute
   '/accounts': typeof AuthenticatedAccountsRoute
   '/channels': typeof AuthenticatedChannelsRoute
@@ -202,6 +209,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/sign-in': typeof SignInRoute
+  '/$': typeof AuthenticatedSplatRoute
   '/about': typeof AuthenticatedAboutRoute
   '/accounts': typeof AuthenticatedAccountsRoute
   '/channels': typeof AuthenticatedChannelsRoute
@@ -229,6 +237,7 @@ export interface FileRoutesById {
   '/sign-in': typeof SignInRoute
   '/_authenticated/dashboard': typeof AuthenticatedDashboardRouteRouteWithChildren
   '/_authenticated/settings': typeof AuthenticatedSettingsRouteRouteWithChildren
+  '/_authenticated/$': typeof AuthenticatedSplatRoute
   '/_authenticated/about': typeof AuthenticatedAboutRoute
   '/_authenticated/accounts': typeof AuthenticatedAccountsRoute
   '/_authenticated/channels': typeof AuthenticatedChannelsRoute
@@ -258,6 +267,7 @@ export interface FileRouteTypes {
     | '/sign-in'
     | '/dashboard'
     | '/settings'
+    | '/$'
     | '/about'
     | '/accounts'
     | '/channels'
@@ -281,6 +291,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/sign-in'
+    | '/$'
     | '/about'
     | '/accounts'
     | '/channels'
@@ -307,6 +318,7 @@ export interface FileRouteTypes {
     | '/sign-in'
     | '/_authenticated/dashboard'
     | '/_authenticated/settings'
+    | '/_authenticated/$'
     | '/_authenticated/about'
     | '/_authenticated/accounts'
     | '/_authenticated/channels'
@@ -356,6 +368,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof AuthenticatedIndexRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/$': {
+      id: '/_authenticated/$'
+      path: '/$'
+      fullPath: '/$'
+      preLoaderRoute: typeof AuthenticatedSplatRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/about': {
@@ -569,6 +588,7 @@ const AuthenticatedSettingsRouteRouteWithChildren =
 interface AuthenticatedRouteRouteChildren {
   AuthenticatedDashboardRouteRoute: typeof AuthenticatedDashboardRouteRouteWithChildren
   AuthenticatedSettingsRouteRoute: typeof AuthenticatedSettingsRouteRouteWithChildren
+  AuthenticatedSplatRoute: typeof AuthenticatedSplatRoute
   AuthenticatedAboutRoute: typeof AuthenticatedAboutRoute
   AuthenticatedAccountsRoute: typeof AuthenticatedAccountsRoute
   AuthenticatedChannelsRoute: typeof AuthenticatedChannelsRoute
@@ -590,6 +610,7 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedDashboardRouteRoute:
     AuthenticatedDashboardRouteRouteWithChildren,
   AuthenticatedSettingsRouteRoute: AuthenticatedSettingsRouteRouteWithChildren,
+  AuthenticatedSplatRoute: AuthenticatedSplatRoute,
   AuthenticatedAboutRoute: AuthenticatedAboutRoute,
   AuthenticatedAccountsRoute: AuthenticatedAccountsRoute,
   AuthenticatedChannelsRoute: AuthenticatedChannelsRoute,

--- a/web/src/routes/_authenticated/$.tsx
+++ b/web/src/routes/_authenticated/$.tsx
@@ -1,0 +1,19 @@
+// metapi-go/routes — authenticated catch-all (404 inside the app shell).
+//
+// Without this, an unknown path under `/_authenticated` (e.g. `/nope`) matches
+// the pathless `_authenticated` route but no child, so TanStack Router falls
+// back to the router-level `defaultNotFoundComponent` and renders the 404
+// *outside* the sidebar/header shell. This catch-all matches any unmatched
+// path, so the 404 renders inside `AuthenticatedLayout`'s SidebarInset — the
+// shell (and the auth guard above) stay intact.
+//
+// `NotFoundPage` uses `min-h-full` so it fills the SidebarInset container
+// rather than overflowing it.
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { NotFoundPage } from '@/components/layout/not-found-page'
+
+export const Route = createFileRoute('/_authenticated/$')({
+  component: NotFoundPage,
+})

--- a/web/src/routes/_authenticated/model-tester.tsx
+++ b/web/src/routes/_authenticated/model-tester.tsx
@@ -1,8 +1,9 @@
 // metapi-go/routes — model tester (playground).
 //
-// No `validateSearch`: the page reads the `?model=` deep-link param directly
-// from `window.location.search` (same transitional pattern the sites page
-// uses), and the tester form owns the rest of its state in-memory.
+// `validateSearch` types the single deep-link param `?model=` (from the
+// marketplace "try it" link) so the page can read it via `useSearch()` instead
+// of `window.location.search`. The tester form owns the rest of its state
+// in-memory.
 //
 // `loader` prefetches the base model marketplace
 // (`modelsKeys.marketplace({ refresh: false, includePricing: false })`) — the
@@ -11,12 +12,18 @@
 // models hook (unwrap the `models` array from the marketplace envelope).
 
 import { createFileRoute } from '@tanstack/react-router'
+import { z } from 'zod'
 
 import { ModelTesterPage } from '@/features/model-tester/components/model-tester-page'
 import { modelsKeys } from '@/features/models'
 import { api } from '@/lib/api'
 
+const modelTesterSearchSchema = z.object({
+  model: z.string().optional(),
+})
+
 export const Route = createFileRoute('/_authenticated/model-tester')({
+  validateSearch: modelTesterSearchSchema,
   loader: async ({ context }) => {
     await context.queryClient.prefetchQuery({
       queryKey: modelsKeys.marketplace({


### PR DESCRIPTION
## Summary

Routing 系统 P1-B2（三个小项，一个 PR）：

1. **404 渲染在 shell 内** — 新增 `/_authenticated/$` catch-all，未知路径在 `AuthenticatedLayout` 的 SidebarInset 内显示 404（此前会落到 router 级 `defaultNotFoundComponent`，丢掉 sidebar/header）。`NotFoundPage` 由 `min-h-screen` 改 `min-h-full`，填满容器而非溢出。
2. **checkIsActive 清理** — 删除从未传参的死代码 `mainNav` 参数；并剥离 hash fragment，`/models#top` 现在能正确高亮 `/models`。
3. **model-tester `?model=` 校验** — 通过 `validateSearch` 校验 deep-link 参数，页面用 `useSearch()` 读取替代 `window.location.search` 直读。

另重新生成 `routeTree.gen.ts`（新 catch-all 路由）。

## 验证

- typecheck / lint / knip / format 全绿
- build 通过
- 测试 336/336（新增 2 个 hash 匹配用例）

Ref: 路由系统系统性优化批次 P1-B2。