### PR TITLE
fix: propagate DB errors in admin handlers and OAuth persistence

### DIFF
--- a/handler/admin/announcements.go
+++ b/handler/admin/announcements.go
@@ -66,7 +66,10 @@ func (h *announcementsHandler) loadAnnouncements(enabledOnly bool) ([]map[string
 	}
 	q += ` ORDER BY CASE a.severity WHEN 'critical' THEN 0 WHEN 'warning' THEN 1 ELSE 2 END, a.updated_at DESC`
 
-	rows := queryRows(h.db, rebindAdminQuery(h.db, q), args...)
+	rows, err := queryRowsErr(h.db, q, args...)
+	if err != nil {
+		return nil, err
+	}
 	items := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
 		item := map[string]any{

--- a/handler/admin/audit_logs.go
+++ b/handler/admin/audit_logs.go
@@ -155,10 +155,14 @@ func (h *auditLogsHandler) list(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows := queryRows(h.db,
+	rows, err := queryRowsErr(h.db,
 		"SELECT id, actor, method, path, status, request_id, remote_ip, created_at FROM admin_audit_logs WHERE "+
 			strings.Join(where, " AND ")+" ORDER BY id DESC LIMIT ? OFFSET ?",
 		append(args, limit, offset)...)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list audit logs")
+		return
+	}
 
 	items := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {

--- a/handler/admin/checkin_routes.go
+++ b/handler/admin/checkin_routes.go
@@ -178,7 +178,11 @@ func (h *checkinHandler) getLogs(w http.ResponseWriter, r *http.Request) {
 	qArgs := make([]any, len(args))
 	copy(qArgs, args)
 	qArgs = append(qArgs, limit, offset)
-	rows := queryRows(h.db, query, qArgs...)
+	rows, err := queryRowsErr(h.db, query, qArgs...)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load checkin logs")
+		return
+	}
 
 	countQuery := "SELECT COUNT(*) FROM checkin_logs cl INNER JOIN accounts a ON cl.account_id = a.id INNER JOIN sites s ON a.site_id = s.id" + where
 	var total int

--- a/handler/admin/credential_masking.go
+++ b/handler/admin/credential_masking.go
@@ -13,7 +13,7 @@ import (
 // hardens against logging/metrics side-channels: a credential that is never
 // scanned into Go memory cannot be leaked by a stray slog or metrics call.
 //
-// Aliases are emitted in snake_case so queryRows()' camelCase key mapping
+// Aliases are emitted in snake_case so queryRowsErr()' camelCase key mapping
 // yields {aliasBase}Prefix / {aliasBase}Suffix / {aliasBase}Len in the row.
 //
 // SQLite (modernc.org/sqlite) has no LEFT()/RIGHT() built-ins — confirmed by

--- a/handler/admin/downstream_keys.go
+++ b/handler/admin/downstream_keys.go
@@ -64,7 +64,11 @@ func (h *downstreamKeysHandler) summary(w http.ResponseWriter, r *http.Request) 
 	}
 	query += " ORDER BY id DESC"
 
-	rows := queryRows(h.db, query, args...)
+	rows, err := queryRowsErr(h.db, query, args...)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load downstream keys")
+		return
+	}
 
 	// Apply group filter and enrich with usage data
 	items := make([]map[string]any, 0)
@@ -109,17 +113,26 @@ func (h *downstreamKeysHandler) listKeys(w http.ResponseWriter, r *http.Request)
 
 	var rows []map[string]any
 	var total int64
+	var queryErr error
 	page, pageSize := 1, 50
 	if paginate {
 		page = clampInt(getQueryInt(r, "page", 1), 1, 1_000_000)
 		pageSize = clampInt(getQueryInt(r, "pageSize", 50), 1, 200)
 		offset := (page - 1) * pageSize
-		rows = queryRows(h.db, h.db.Rebind(
-			"SELECT * FROM downstream_api_keys ORDER BY id DESC LIMIT ? OFFSET ?"),
+		rows, queryErr = queryRowsErr(h.db,
+			"SELECT * FROM downstream_api_keys ORDER BY id DESC LIMIT ? OFFSET ?",
 			pageSize, offset)
+		if queryErr != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load downstream keys")
+			return
+		}
 		_ = h.db.Get(&total, h.db.Rebind("SELECT COUNT(*) FROM downstream_api_keys"))
 	} else {
-		rows = queryRows(h.db, "SELECT * FROM downstream_api_keys ORDER BY id DESC")
+		rows, queryErr = queryRowsErr(h.db, "SELECT * FROM downstream_api_keys ORDER BY id DESC")
+		if queryErr != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load downstream keys")
+			return
+		}
 	}
 
 	for _, row := range rows {
@@ -216,7 +229,12 @@ func (h *downstreamKeysHandler) createKey(w http.ResponseWriter, r *http.Request
 	keyWeight := normalizeKeyWeightInput(body.KeyWeight)
 
 	// Policy reference validation.
-	if refErr := h.validateDownstreamPolicyReferences(normalizedRouteIds, normalizedSWM, normalizedExcludedSites, normalizedCredRefs, normalizedAllowedSites, normalizedAllowedCredRefs); refErr != "" {
+	refErr, refDbErr := h.validateDownstreamPolicyReferences(normalizedRouteIds, normalizedSWM, normalizedExcludedSites, normalizedCredRefs, normalizedAllowedSites, normalizedAllowedCredRefs)
+	if refDbErr != nil {
+		writeError(w, http.StatusInternalServerError, "failed to validate policy references")
+		return
+	}
+	if refErr != "" {
 		writeError(w, http.StatusBadRequest, refErr)
 		return
 	}
@@ -562,7 +580,12 @@ func (h *downstreamKeysHandler) updateKey(w http.ResponseWriter, r *http.Request
 	}
 
 	// Policy reference validation.
-	if refErr := h.validateDownstreamPolicyReferences(allowedRouteIds, siteWeightMultipliers, excludedSiteIds, excludedCredentialRefs, allowedSiteIds, allowedCredentialRefs); refErr != "" {
+	refErr, refDbErr := h.validateDownstreamPolicyReferences(allowedRouteIds, siteWeightMultipliers, excludedSiteIds, excludedCredentialRefs, allowedSiteIds, allowedCredentialRefs)
+	if refDbErr != nil {
+		writeError(w, http.StatusInternalServerError, "failed to validate policy references")
+		return
+	}
+	if refErr != "" {
 		writeError(w, http.StatusBadRequest, refErr)
 		return
 	}
@@ -793,12 +816,15 @@ func (h *downstreamKeysHandler) validateDownstreamPolicyReferences(
 	excludedCredentialRefs []any,
 	allowedSiteIds []int64,
 	allowedCredentialRefs []any,
-) string {
+) (string, error) {
 	// Validate allowedRouteIds exist in token_routes.
 	if len(allowedRouteIds) > 0 {
 		query, args, err := sqlx.In("SELECT id FROM token_routes WHERE id IN (?)", allowedRouteIds)
 		if err == nil {
-			rows := queryRows(h.db, h.db.Rebind(query), args...)
+			rows, qErr := queryRowsErr(h.db, query, args...)
+			if qErr != nil {
+				return "", qErr
+			}
 			existingIds := make(map[int64]bool)
 			for _, row := range rows {
 				if id, ok := row["id"].(int64); ok {
@@ -812,7 +838,7 @@ func (h *downstreamKeysHandler) validateDownstreamPolicyReferences(
 				}
 			}
 			if len(missing) > 0 {
-				return fmt.Sprintf("allowedRouteIds 包含不存在的路由: %s", strings.Join(missing, ", "))
+				return fmt.Sprintf("allowedRouteIds 包含不存在的路由: %s", strings.Join(missing, ", ")), nil
 			}
 		}
 	}
@@ -842,7 +868,10 @@ func (h *downstreamKeysHandler) validateDownstreamPolicyReferences(
 		}
 		query, args, err := sqlx.In("SELECT id FROM sites WHERE id IN (?)", ids)
 		if err == nil {
-			rows := queryRows(h.db, h.db.Rebind(query), args...)
+			rows, qErr := queryRowsErr(h.db, query, args...)
+			if qErr != nil {
+				return "", qErr
+			}
 			existingIds := make(map[int64]bool)
 			for _, row := range rows {
 				if id, ok := row["id"].(int64); ok {
@@ -856,7 +885,7 @@ func (h *downstreamKeysHandler) validateDownstreamPolicyReferences(
 				}
 			}
 			if len(missing) > 0 {
-				return fmt.Sprintf("策略中包含不存在的站点: %s", strings.Join(missing, ", "))
+				return fmt.Sprintf("策略中包含不存在的站点: %s", strings.Join(missing, ", ")), nil
 			}
 		}
 	}
@@ -873,7 +902,7 @@ func (h *downstreamKeysHandler) validateDownstreamPolicyReferences(
 			accountId := coerceInt64(obj["accountId"])
 			siteId := coerceInt64(obj["siteId"])
 			if tokenId <= 0 {
-				return fmt.Sprintf("credentialRefs 包含不存在的令牌: %v", obj["tokenId"])
+				return fmt.Sprintf("credentialRefs 包含不存在的令牌: %v", obj["tokenId"]), nil
 			}
 			row := queryRow(h.db,
 				`SELECT at.id as token_id, at.account_id, a.site_id
@@ -881,12 +910,12 @@ func (h *downstreamKeysHandler) validateDownstreamPolicyReferences(
 				 INNER JOIN accounts a ON at.account_id = a.id
 				 WHERE at.id = ?`, tokenId)
 			if row == nil {
-				return fmt.Sprintf("credentialRefs 包含不存在的令牌: %d", tokenId)
+				return fmt.Sprintf("credentialRefs 包含不存在的令牌: %d", tokenId), nil
 			}
 			dbAccountId := coerceInt64(mustRowValue(row, "account_id"))
 			dbSiteId := coerceInt64(mustRowValue(row, "site_id"))
 			if dbAccountId != accountId || dbSiteId != siteId {
-				return fmt.Sprintf("credentialRefs 中的 account_token 引用与账号/站点不匹配: %d", tokenId)
+				return fmt.Sprintf("credentialRefs 中的 account_token 引用与账号/站点不匹配: %d", tokenId), nil
 			}
 		} else if kind == "default_api_key" {
 			accountId := coerceInt64(obj["accountId"])
@@ -895,20 +924,20 @@ func (h *downstreamKeysHandler) validateDownstreamPolicyReferences(
 				`SELECT id as account_id, site_id, api_token
 				 FROM accounts WHERE id = ?`, accountId)
 			if row == nil {
-				return fmt.Sprintf("credentialRefs 包含不存在的账号: %d", accountId)
+				return fmt.Sprintf("credentialRefs 包含不存在的账号: %d", accountId), nil
 			}
 			dbSiteId := coerceInt64(mustRowValue(row, "site_id"))
 			if dbSiteId != siteId {
-				return fmt.Sprintf("credentialRefs 中的 default_api_key 引用与站点不匹配: %d", accountId)
+				return fmt.Sprintf("credentialRefs 中的 default_api_key 引用与站点不匹配: %d", accountId), nil
 			}
 			apiToken, _ := mustRowValue(row, "api_token").(string)
 			if strings.TrimSpace(apiToken) == "" {
-				return fmt.Sprintf("credentialRefs 中的 default_api_key 账号缺少默认 API Key: %d", accountId)
+				return fmt.Sprintf("credentialRefs 中的 default_api_key 账号缺少默认 API Key: %d", accountId), nil
 			}
 		}
 	}
 
-	return ""
+	return "", nil
 }
 
 func mustRowValue(row map[string]any, key string) any {

--- a/handler/admin/helpers.go
+++ b/handler/admin/helpers.go
@@ -140,11 +140,6 @@ func coalescePtr[T any](v *T, fallback T) T {
 
 // ---- DB row helpers (moved from search.go) ----
 
-func queryRows(db *sqlx.DB, query string, args ...any) []map[string]any {
-	result, _ := queryRowsErr(db, query, args...)
-	return result
-}
-
 func queryRowsErr(db *sqlx.DB, query string, args ...any) ([]map[string]any, error) {
 	rows, err := db.Queryx(rebindAdminQuery(db, query), args...)
 	if err != nil {

--- a/handler/admin/model_price_compare.go
+++ b/handler/admin/model_price_compare.go
@@ -31,12 +31,21 @@ func (h *statsHandler) modelPriceCompare(w http.ResponseWriter, r *http.Request)
 	if modelQ != "" {
 		models = []string{modelQ}
 	} else {
-		models = h.topModelsForPriceCompare(topModels, since)
+		var err error
+		models, err = h.topModelsForPriceCompare(topModels, since)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load top models")
+			return
+		}
 	}
 
 	candidates := make([]routing.PriceCompareRow, 0)
 	for _, modelName := range models {
-		inputs := h.loadPriceCompareInputs(modelName, since)
+		inputs, err := h.loadPriceCompareInputs(modelName, since)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load price compare inputs")
+			return
+		}
 		for _, in := range inputs {
 			row := routing.BuildPriceCompareRow(in, routing.DefaultPriceCompareSampleUsage)
 			candidates = append(candidates, row)
@@ -86,8 +95,8 @@ func (h *statsHandler) modelPriceCompare(w http.ResponseWriter, r *http.Request)
 	})
 }
 
-func (h *statsHandler) topModelsForPriceCompare(limit int, since string) []string {
-	rows := queryRows(h.db, `
+func (h *statsHandler) topModelsForPriceCompare(limit int, since string) ([]string, error) {
+	rows, err := queryRowsErr(h.db, `
 		SELECT COALESCE(NULLIF(TRIM(pl.model_actual), ''), NULLIF(TRIM(pl.model_requested), ''), '') AS model,
 			COUNT(*) AS calls
 		FROM proxy_logs pl
@@ -98,6 +107,9 @@ func (h *statsHandler) topModelsForPriceCompare(limit int, since string) []strin
 		ORDER BY calls DESC
 		LIMIT ?
 	`, since, limit)
+	if err != nil {
+		return nil, err
+	}
 
 	out := make([]string, 0, len(rows))
 	seen := map[string]struct{}{}
@@ -114,16 +126,19 @@ func (h *statsHandler) topModelsForPriceCompare(limit int, since string) []strin
 		out = append(out, m)
 	}
 	if len(out) > 0 {
-		return out
+		return out, nil
 	}
 
-	avail := queryRows(h.db, `
+	avail, err := queryRowsErr(h.db, `
 		SELECT model_name AS model, COUNT(*) AS cnt
 		FROM model_availability
 		GROUP BY model_name
 		ORDER BY cnt DESC
 		LIMIT ?
 	`, limit)
+	if err != nil {
+		return nil, err
+	}
 	for _, row := range avail {
 		m := strings.TrimSpace(coerceString(row["model"]))
 		if m == "" {
@@ -136,7 +151,7 @@ func (h *statsHandler) topModelsForPriceCompare(limit int, since string) []strin
 		seen[key] = struct{}{}
 		out = append(out, m)
 	}
-	return out
+	return out, nil
 }
 
 type observedPriceSignal struct {
@@ -146,15 +161,15 @@ type observedPriceSignal struct {
 	ResolvedModel  string
 }
 
-func (h *statsHandler) loadPriceCompareInputs(modelName string, since string) []routing.PriceCompareInput {
+func (h *statsHandler) loadPriceCompareInputs(modelName string, since string) ([]routing.PriceCompareInput, error) {
 	modelName = strings.TrimSpace(modelName)
 	if modelName == "" {
-		return nil
+		return nil, nil
 	}
 	like := "%" + strings.ToLower(modelName) + "%"
 
 	// Observed success costs + latest-ish billing_details for matching models.
-	obsRows := queryRows(h.db, `
+	obsRows, err := queryRowsErr(h.db, `
 		SELECT
 			pl.account_id AS account_id,
 			COALESCE(NULLIF(TRIM(pl.model_actual), ''), NULLIF(TRIM(pl.model_requested), ''), '') AS model_name,
@@ -168,6 +183,9 @@ func (h *statsHandler) loadPriceCompareInputs(modelName string, since string) []
 			AND LOWER(COALESCE(NULLIF(TRIM(pl.model_actual), ''), NULLIF(TRIM(pl.model_requested), ''), '')) LIKE ?
 		GROUP BY pl.account_id, COALESCE(NULLIF(TRIM(pl.model_actual), ''), NULLIF(TRIM(pl.model_requested), ''), '')
 	`, since, like)
+	if err != nil {
+		return nil, err
+	}
 
 	obsByAccount := map[int64]observedPriceSignal{}
 	for _, row := range obsRows {
@@ -189,11 +207,14 @@ func (h *statsHandler) loadPriceCompareInputs(modelName string, since string) []
 	}
 
 	// Accounts that advertise the model via availability.
-	availRows := queryRows(h.db, `
+	availRows, err := queryRowsErr(h.db, `
 		SELECT account_id, model_name
 		FROM model_availability
 		WHERE LOWER(model_name) LIKE ?
 	`, like)
+	if err != nil {
+		return nil, err
+	}
 	availModelByAccount := map[int64]string{}
 	for _, row := range availRows {
 		accID := coerceInt64(row["accountId"])
@@ -207,7 +228,7 @@ func (h *statsHandler) loadPriceCompareInputs(modelName string, since string) []
 	}
 
 	// Active accounts on non-disabled sites.
-	accountRows := queryRows(h.db, `
+	accountRows, err := queryRowsErr(h.db, `
 		SELECT
 			s.id AS site_id,
 			s.name AS site_name,
@@ -223,6 +244,9 @@ func (h *statsHandler) loadPriceCompareInputs(modelName string, since string) []
 			AND COALESCE(s.status, '') <> 'disabled'
 		ORDER BY s.name ASC, a.id ASC
 	`)
+	if err != nil {
+		return nil, err
+	}
 
 	out := make([]routing.PriceCompareInput, 0)
 	for _, row := range accountRows {
@@ -293,7 +317,7 @@ func (h *statsHandler) loadPriceCompareInputs(modelName string, since string) []
 			}
 		}
 	}
-	return out
+	return out, nil
 }
 
 func applyBillingDetailsToPriceInput(in *routing.PriceCompareInput, raw string) {

--- a/handler/admin/model_rates.go
+++ b/handler/admin/model_rates.go
@@ -105,7 +105,7 @@ func (h *modelRatesHandler) updateRates(w http.ResponseWriter, r *http.Request) 
 // GET /api/models/rates
 func (h *modelRatesHandler) rates(w http.ResponseWriter, r *http.Request) {
 	// Accounts with their unit cost (nullable) and channel footprint.
-	accRows := queryRows(h.db, `
+	accRows, err := queryRowsErr(h.db, `
 		SELECT a.id AS account_id, COALESCE(a.username, '') AS username,
 			s.id AS site_id, COALESCE(s.name, '') AS site_name,
 			a.unit_cost AS unit_cost,
@@ -117,6 +117,10 @@ func (h *modelRatesHandler) rates(w http.ResponseWriter, r *http.Request) {
 		GROUP BY a.id, a.username, s.id, s.name, a.unit_cost
 		ORDER BY COALESCE(a.unit_cost, 0) DESC, a.id ASC
 	`)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load rate overview")
+		return
+	}
 	accounts := make([]map[string]any, 0, len(accRows))
 	for _, row := range accRows {
 		accounts = append(accounts, map[string]any{
@@ -131,7 +135,7 @@ func (h *modelRatesHandler) rates(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Channels with their weight (the effective routing multiplier).
-	chRows := queryRows(h.db, `
+	chRows, err := queryRowsErr(h.db, `
 		SELECT rc.id AS channel_id, rc.route_id, rc.account_id, rc.weight, rc.enabled,
 			COALESCE(rc.source_model, '') AS model_name,
 			COALESCE(tr.model_pattern, '') AS route_pattern,
@@ -141,6 +145,10 @@ func (h *modelRatesHandler) rates(w http.ResponseWriter, r *http.Request) {
 		LEFT JOIN accounts a ON a.id = rc.account_id
 		ORDER BY rc.weight DESC, rc.id ASC
 	`)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load rate overview")
+		return
+	}
 	channels := make([]map[string]any, 0, len(chRows))
 	for _, row := range chRows {
 		channels = append(channels, map[string]any{
@@ -156,10 +164,14 @@ func (h *modelRatesHandler) rates(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Sites with global weight.
-	siteRows := queryRows(h.db, `
+	siteRows, err := queryRowsErr(h.db, `
 		SELECT id AS site_id, COALESCE(name, '') AS site_name, global_weight
 		FROM sites ORDER BY global_weight DESC, id ASC
 	`)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load rate overview")
+		return
+	}
 	sites := make([]map[string]any, 0, len(siteRows))
 	for _, row := range siteRows {
 		sites = append(sites, map[string]any{
@@ -170,11 +182,15 @@ func (h *modelRatesHandler) rates(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Downstream keys with weight (the per-key multiplier).
-	keyRows := queryRows(h.db, `
+	keyRows, err := queryRowsErr(h.db, `
 		SELECT id AS key_id, COALESCE(name, '') AS name, key_weight
 		FROM downstream_api_keys
 		ORDER BY COALESCE(key_weight, 1.0) DESC, id ASC
 	`)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load rate overview")
+		return
+	}
 	keys := make([]map[string]any, 0, len(keyRows))
 	for _, row := range keyRows {
 		keys = append(keys, map[string]any{
@@ -185,7 +201,7 @@ func (h *modelRatesHandler) rates(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Observed model costs (30d) — the effective price evidence.
-	modelRows := queryRows(h.db, `
+	modelRows, err := queryRowsErr(h.db, `
 		SELECT model,
 			COALESCE(SUM(total_calls), 0) AS calls,
 			COALESCE(SUM(total_spend), 0) AS spend,
@@ -195,6 +211,10 @@ func (h *modelRatesHandler) rates(w http.ResponseWriter, r *http.Request) {
 		GROUP BY model
 		ORDER BY spend DESC, model ASC
 	`, time.Now().UTC().AddDate(0, 0, -29).Format("2006-01-02"))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load rate overview")
+		return
+	}
 	models := make([]map[string]any, 0, len(modelRows))
 	for _, row := range modelRows {
 		models = append(models, map[string]any{

--- a/handler/admin/model_redirects.go
+++ b/handler/admin/model_redirects.go
@@ -121,7 +121,11 @@ func (h *modelRedirectHandler) list(w http.ResponseWriter, r *http.Request) {
 	}
 	q += " ORDER BY mr.updated_at DESC, mr.id DESC"
 
-	rows := queryRows(h.db, rebindAdminQuery(h.db, q), args...)
+	rows, err := queryRowsErr(h.db, q, args...)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list model redirects")
+		return
+	}
 	items := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
 		items = append(items, map[string]any{
@@ -235,7 +239,11 @@ func (h *modelRedirectHandler) generate(w http.ResponseWriter, r *http.Request) 
 		models := body.Models
 		if len(models) == 0 {
 			// Deterministic order: insertion order ≈ upstream return order.
-			rows := queryRows(h.db, "SELECT model_name FROM model_availability WHERE account_id = ? AND available = 1 ORDER BY id ASC", body.AccountID)
+			rows, err := queryRowsErr(h.db, "SELECT model_name FROM model_availability WHERE account_id = ? AND available = 1 ORDER BY id ASC", body.AccountID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to load account models")
+				return
+			}
 			for _, row := range rows {
 				models = append(models, coerceString(row["modelName"]))
 			}

--- a/handler/admin/models_verify.go
+++ b/handler/admin/models_verify.go
@@ -97,7 +97,11 @@ func (h *statsHandler) verifyBatch(w http.ResponseWriter, r *http.Request) {
 	q += ` ORDER BY rc.id ASC LIMIT ?`
 	args = append(args, limit)
 
-	rows := queryRows(h.db, q, args...)
+	rows, err := queryRowsErr(h.db, q, args...)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load verification targets")
+		return
+	}
 	targets := make([]scheduler.ProbeTarget, 0, len(rows))
 	for _, row := range rows {
 		targets = append(targets, scheduler.ProbeTarget{
@@ -194,7 +198,11 @@ func (h *statsHandler) verifyHistory(w http.ResponseWriter, r *http.Request) {
 	q += ` ORDER BY v.created_at DESC, v.id DESC LIMIT ?`
 	args = append(args, limit)
 
-	rows := queryRows(h.db, q, args...)
+	rows, err := queryRowsErr(h.db, q, args...)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load verification history")
+		return
+	}
 	items := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
 		items = append(items, map[string]any{

--- a/handler/admin/monitor_health.go
+++ b/handler/admin/monitor_health.go
@@ -32,12 +32,28 @@ type monitorHealthHandler struct {
 func (h *monitorHealthHandler) health(w http.ResponseWriter, r *http.Request) {
 	runtimeHealth := routing.SnapshotRuntimeHealth()
 
+	cooldown, err := h.aggregateCooldown()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to aggregate cooldown")
+		return
+	}
+	sites, err := h.statusCounts("sites")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load status counts")
+		return
+	}
+	accounts, err := h.statusCounts("accounts")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load status counts")
+		return
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{
 		"generatedAt":   time.Now().UTC().Format(time.RFC3339),
 		"runtimeHealth": runtimeHealth,
-		"cooldown":      h.aggregateCooldown(),
-		"sites":         h.statusCounts("sites"),
-		"accounts":      h.statusCounts("accounts"),
+		"cooldown":      cooldown,
+		"sites":         sites,
+		"accounts":      accounts,
 	})
 }
 
@@ -45,8 +61,8 @@ func (h *monitorHealthHandler) health(w http.ResponseWriter, r *http.Request) {
 // writing anything. Cooling means cooldownUntil is still in the future;
 // recently-failed means failCount>0 with a lastFailAt inside the configured
 // Fibonacci backoff window.
-func (h *monitorHealthHandler) aggregateCooldown() map[string]any {
-	rows := queryRows(h.db, `
+func (h *monitorHealthHandler) aggregateCooldown() (map[string]any, error) {
+	rows, err := queryRowsErr(h.db, `
 		SELECT
 			rc.id AS id,
 			rc.account_id AS account_id,
@@ -62,6 +78,9 @@ func (h *monitorHealthHandler) aggregateCooldown() map[string]any {
 		ORDER BY rc.cooldown_until DESC
 		LIMIT 10000
 	`)
+	if err != nil {
+		return nil, err
+	}
 
 	nowISO := time.Now().UTC().Format(time.RFC3339)
 	nowMs := time.Now().UnixMilli()
@@ -100,13 +119,16 @@ func (h *monitorHealthHandler) aggregateCooldown() map[string]any {
 		"channelsWithFailures":   channelsWithFailures,
 		"channelsRecentlyFailed": channelsRecentlyFailed,
 		"cooling":                cooling,
-	}
+	}, nil
 }
 
 // statusCounts aggregates a table's `status` column into total/active/
 // disabled/other buckets. `table` is always a literal in this file.
-func (h *monitorHealthHandler) statusCounts(table string) map[string]any {
-	rows := queryRows(h.db, "SELECT status, COUNT(*) AS count FROM "+table+" GROUP BY status")
+func (h *monitorHealthHandler) statusCounts(table string) (map[string]any, error) {
+	rows, err := queryRowsErr(h.db, "SELECT status, COUNT(*) AS count FROM "+table+" GROUP BY status")
+	if err != nil {
+		return nil, err
+	}
 	result := map[string]any{
 		"total":    0,
 		"active":   0,
@@ -127,7 +149,7 @@ func (h *monitorHealthHandler) statusCounts(table string) map[string]any {
 		}
 	}
 	result["total"] = total
-	return result
+	return result, nil
 }
 
 // nullableString converts a nullable MapScan value into *string, treating nil

--- a/handler/admin/oauth_routes.go
+++ b/handler/admin/oauth_routes.go
@@ -202,13 +202,17 @@ func (h *oauthHandler) listConnections(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows := queryRows(h.db,
+	rows, err := queryRowsErr(h.db,
 		`SELECT a.*, s.name as site_name, s.platform as site_platform
 		 FROM accounts a
 		 INNER JOIN sites s ON a.site_id = s.id
 		 WHERE a.oauth_provider IS NOT NULL
 		 ORDER BY a.id ASC LIMIT ? OFFSET ?`,
 		limit, offset)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load oauth connections")
+		return
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"connections": normalizeSlice(rows),

--- a/handler/admin/resin.go
+++ b/handler/admin/resin.go
@@ -54,7 +54,11 @@ func (h *resinHandler) status(w http.ResponseWriter, r *http.Request) {
 	}
 
 	activeLeases := service.ActiveLeases()
-	perSiteOverrides := h.perSiteOverrides()
+	perSiteOverrides, err := h.perSiteOverrides()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load resin per-site overrides")
+		return
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"enabled":            enabled,
@@ -69,16 +73,19 @@ func (h *resinHandler) status(w http.ResponseWriter, r *http.Request) {
 // perSiteOverrides queries sites with a non-NULL resin_enabled column and
 // returns them in admin-list order. NULL-inherit sites are excluded so the
 // snapshot only lists operators' explicit decisions.
-func (h *resinHandler) perSiteOverrides() []map[string]any {
+func (h *resinHandler) perSiteOverrides() ([]map[string]any, error) {
 	if h.db == nil {
-		return []map[string]any{}
+		return []map[string]any{}, nil
 	}
-	rows := queryRows(h.db, `
+	rows, err := queryRowsErr(h.db, `
 		SELECT id, name, platform, resin_enabled
 		FROM sites
 		WHERE resin_enabled IS NOT NULL
 		ORDER BY sort_order, id
 	`)
+	if err != nil {
+		return nil, err
+	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
 		siteID := coerceInt64(row["id"])
@@ -92,5 +99,5 @@ func (h *resinHandler) perSiteOverrides() []map[string]any {
 			"resinEnabled":  resinEnabled,
 		})
 	}
-	return out
+	return out, nil
 }

--- a/handler/admin/search.go
+++ b/handler/admin/search.go
@@ -81,15 +81,21 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 
 	likePattern := "%" + q + "%"
 
-	// Search sites
-	sites := queryRows(h.db, "SELECT "+service.SiteSelectColumns+" FROM sites WHERE name LIKE ? OR url LIKE ? OR platform LIKE ? LIMIT ?",
+	// Search sites. Each query surfaces its error so a DB failure yields an
+	// explicit HTTP 500 instead of an empty 200 (silent swallows from the old
+	// queryRows helper masked real outages as "no results").
+	sites, err := queryRowsErr(h.db, "SELECT "+service.SiteSelectColumns+" FROM sites WHERE name LIKE ? OR url LIKE ? OR platform LIKE ? LIMIT ?",
 		likePattern, likePattern, likePattern, perCategory)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "search query failed")
+		return
+	}
 
 	// Search accounts. Select only credential fragments (first4/last4/length)
 	// instead of a.* — the plaintext access_token/api_token never cross the
 	// DB→Go boundary, so a stray slog/metrics call cannot leak them. The masked
 	// form is rebuilt in Go by redactSearchAccountSecrets().
-	accounts := queryRows(h.db,
+	accounts, err := queryRowsErr(h.db,
 		`SELECT `+accountPublicSelectColumns+`, `+
 			credentialFragmentsSelect(h.db, "a.access_token", "access_token")+`, `+
 			credentialFragmentsSelect(h.db, "a.api_token", "api_token")+`,
@@ -98,9 +104,13 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 		 WHERE a.username LIKE ? OR s.name LIKE ? OR s.platform LIKE ?
 		 LIMIT ?`,
 		likePattern, likePattern, likePattern, perCategory)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "search query failed")
+		return
+	}
 
 	// Search account tokens. Same fragment pattern for at.token.
-	accountTokens := queryRows(h.db,
+	accountTokens, err := queryRowsErr(h.db,
 		`SELECT `+accountTokenPublicSelectColumns+`, `+
 			credentialFragmentsSelect(h.db, "at.token", "token")+`,
 			a.username as account_username, s.name as site_name
@@ -110,23 +120,35 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 		 WHERE at.name LIKE ? OR coalesce(at.token_group,'') LIKE ? OR a.username LIKE ? OR s.name LIKE ?
 		 ORDER BY at.updated_at DESC LIMIT ?`,
 		likePattern, likePattern, likePattern, likePattern, perCategory)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "search query failed")
+		return
+	}
 
 	// Search checkin logs
-	checkinLogs := queryRows(h.db,
+	checkinLogs, err := queryRowsErr(h.db,
 		`SELECT cl.*, a.username as account_username
 		 FROM checkin_logs cl
 		 INNER JOIN accounts a ON cl.account_id = a.id
 		 WHERE coalesce(cl.message,'') LIKE ?
 		 ORDER BY cl.created_at DESC LIMIT ?`,
 		likePattern, perCategory)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "search query failed")
+		return
+	}
 
 	// Search proxy logs
-	proxyLogs := queryRows(h.db,
+	proxyLogs, err := queryRowsErr(h.db,
 		"SELECT * FROM proxy_logs WHERE coalesce(model_requested,'') LIKE ? ORDER BY created_at DESC LIMIT ?",
 		likePattern, perCategory)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "search query failed")
+		return
+	}
 
 	// Search models
-	modelRows := queryRows(h.db,
+	modelRows, err := queryRowsErr(h.db,
 		`SELECT DISTINCT tma.model_name, COUNT(DISTINCT at.id) as token_count,
 		        COUNT(DISTINCT a.id) as account_count, COUNT(DISTINCT s.id) as site_count
 		 FROM token_model_availability tma
@@ -137,6 +159,10 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 		 GROUP BY tma.model_name
 		 ORDER BY account_count DESC LIMIT ?`,
 		likePattern, perCategory)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "search query failed")
+		return
+	}
 
 	for _, row := range accounts {
 		redactSearchAccountSecrets(row)

--- a/handler/admin/settings_database.go
+++ b/handler/admin/settings_database.go
@@ -402,7 +402,10 @@ func (w *backgroundTaskLogWriter) Write(p []byte) (int, error) {
 }
 
 func loadSavedDatabaseConfig(db *sqlx.DB) (*savedDatabaseConfig, error) {
-	rows := queryRows(db, "SELECT key, value FROM settings WHERE key IN ('db_type', 'db_url', 'db_ssl')")
+	rows, err := queryRowsErr(db, "SELECT key, value FROM settings WHERE key IN ('db_type', 'db_url', 'db_ssl')")
+	if err != nil {
+		return nil, err
+	}
 	values := map[string]any{}
 	for _, row := range rows {
 		key, _ := row["key"].(string)

--- a/handler/admin/settings_maintenance.go
+++ b/handler/admin/settings_maintenance.go
@@ -40,20 +40,29 @@ const (
 func (h *maintenanceHandler) clearCache(w http.ResponseWriter, r *http.Request) {
 	// Count before deletion
 	var modelAvail, routeCh, tokenRoutes int64
-	_ = h.db.Get(&modelAvail, "SELECT COUNT(*) FROM model_availability")
-	_ = h.db.Get(&routeCh, "SELECT COUNT(*) FROM route_channels")
-	_ = h.db.Get(&tokenRoutes, "SELECT COUNT(*) FROM token_routes")
+	if err := h.db.Get(&modelAvail, h.db.Rebind("SELECT COUNT(*) FROM model_availability")); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("读取 model_availability 失败：%v", err))
+		return
+	}
+	if err := h.db.Get(&routeCh, h.db.Rebind("SELECT COUNT(*) FROM route_channels")); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("读取 route_channels 失败：%v", err))
+		return
+	}
+	if err := h.db.Get(&tokenRoutes, h.db.Rebind("SELECT COUNT(*) FROM token_routes")); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("读取 token_routes 失败：%v", err))
+		return
+	}
 
 	// Delete all (shared DB — multi-instance safe for durable state)
-	if _, err := h.db.Exec("DELETE FROM model_availability"); err != nil {
+	if _, err := h.db.Exec(h.db.Rebind("DELETE FROM model_availability")); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("清理 model_availability 失败：%v", err))
 		return
 	}
-	if _, err := h.db.Exec("DELETE FROM route_channels"); err != nil {
+	if _, err := h.db.Exec(h.db.Rebind("DELETE FROM route_channels")); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("清理 route_channels 失败：%v", err))
 		return
 	}
-	if _, err := h.db.Exec("DELETE FROM token_routes"); err != nil {
+	if _, err := h.db.Exec(h.db.Rebind("DELETE FROM token_routes")); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("清理 token_routes 失败：%v", err))
 		return
 	}

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -541,7 +541,11 @@ func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 		qArgs := make([]any, len(args))
 		copy(qArgs, args)
 		qArgs = append(qArgs, limit, offset)
-		items := queryRows(h.db, query, qArgs...)
+		items, err := queryRowsErr(h.db, query, qArgs...)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load proxy logs")
+			return
+		}
 		queryPayload["items"] = normalizeSlice(items)
 
 		var total int
@@ -580,7 +584,11 @@ func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 			"totalTokensAll": summary.TotalTokensAll,
 		}
 
-		sites := queryRows(h.db, "SELECT id, name, status FROM sites")
+		sites, err := queryRowsErr(h.db, "SELECT id, name, status FROM sites")
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load sites")
+			return
+		}
 		metaPayload["sites"] = normalizeSlice(sites)
 	}
 
@@ -634,7 +642,11 @@ func (h *statsHandler) proxyLogDetail(w http.ResponseWriter, r *http.Request) {
 func (h *statsHandler) debugTraces(w http.ResponseWriter, r *http.Request) {
 	limit, _ := parseLimitOffset(r, 50, 100)
 
-	rows := queryRows(h.db, "SELECT * FROM proxy_debug_traces ORDER BY created_at DESC LIMIT ?", limit)
+	rows, err := queryRowsErr(h.db, "SELECT * FROM proxy_debug_traces ORDER BY created_at DESC LIMIT ?", limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load debug traces")
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"items": normalizeSlice(rows)})
 }
 
@@ -653,7 +665,11 @@ func (h *statsHandler) debugTraceDetail(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Load related attempts
-	attempts := queryRows(h.db, "SELECT * FROM proxy_debug_attempts WHERE trace_id = ? ORDER BY attempt_index ASC", id)
+	attempts, err := queryRowsErr(h.db, "SELECT * FROM proxy_debug_attempts WHERE trace_id = ? ORDER BY attempt_index ASC", id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load debug trace attempts")
+		return
+	}
 	row["attempts"] = normalizeSlice(attempts)
 
 	writeJSON(w, http.StatusOK, row)
@@ -666,7 +682,7 @@ func (h *statsHandler) siteDistribution(w http.ResponseWriter, r *http.Request) 
 	fromDay := time.Now().UTC().AddDate(0, 0, -(days - 1)).Format("2006-01-02")
 
 	// Prefer projected site_day_usage spend; include live account balances.
-	rows := queryRows(h.db, `
+	rows, err := queryRowsErr(h.db, `
 		SELECT
 			s.id AS site_id,
 			s.name AS site_name,
@@ -688,6 +704,10 @@ func (h *statsHandler) siteDistribution(w http.ResponseWriter, r *http.Request) 
 		) usage ON usage.site_id = s.id
 		ORDER BY total_spend DESC, s.name ASC
 	`, fromDay)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load site distribution")
+		return
+	}
 
 	distribution := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
@@ -709,7 +729,7 @@ func (h *statsHandler) siteTrend(w http.ResponseWriter, r *http.Request) {
 	days := clampInt(getQueryInt(r, "days", 7), 1, 365)
 	fromDay := time.Now().UTC().AddDate(0, 0, -(days - 1)).Format("2006-01-02")
 
-	rows := queryRows(h.db, `
+	rows, err := queryRowsErr(h.db, `
 		SELECT
 			u.local_day AS local_day,
 			s.name AS site_name,
@@ -721,6 +741,10 @@ func (h *statsHandler) siteTrend(w http.ResponseWriter, r *http.Request) {
 		GROUP BY u.local_day, s.name
 		ORDER BY u.local_day ASC, s.name ASC
 	`, fromDay)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load site trend")
+		return
+	}
 
 	// Shape: [{ date, sites: { [siteName]: { spend, calls } } }]
 	byDate := make(map[string]map[string]map[string]any)
@@ -773,7 +797,11 @@ func (h *statsHandler) modelBySite(w http.ResponseWriter, r *http.Request) {
 	}
 	query += " GROUP BY model ORDER BY calls DESC"
 
-	rows := queryRows(h.db, query, args...)
+	rows, err := queryRowsErr(h.db, query, args...)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load model-by-site")
+		return
+	}
 	models := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
 		models = append(models, map[string]any{
@@ -800,7 +828,11 @@ func (h *statsHandler) marketplace(w http.ResponseWriter, r *http.Request) {
 	refreshRequested := parseTruthyQuery(r.URL.Query().Get("refresh"))
 	includePricing := parseTruthyQuery(r.URL.Query().Get("includePricing"))
 
-	models := h.buildMarketplaceModels()
+	models, err := h.buildMarketplaceModels()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to build marketplace models")
+		return
+	}
 	meta := map[string]any{
 		"refreshRequested": refreshRequested,
 		// No background pricing/catalog job in this surface — DB-derived only.
@@ -836,10 +868,26 @@ func (h *statsHandler) marketplace(w http.ResponseWriter, r *http.Request) {
 // - endpointTypesByModel: inferred endpoint types from site platforms
 func (h *statsHandler) tokenCandidates(w http.ResponseWriter, r *http.Request) {
 	allowed := h.loadGlobalAllowedModels()
-	models := h.buildTokenCandidateModels(allowed)
-	withoutToken := h.buildModelsWithoutToken(allowed)
-	missingGroups := h.buildModelsMissingTokenGroups(allowed)
-	endpointTypes := h.buildEndpointTypesByModel(allowed)
+	models, err := h.buildTokenCandidateModels(allowed)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load token candidates")
+		return
+	}
+	withoutToken, err := h.buildModelsWithoutToken(allowed)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load models without token")
+		return
+	}
+	missingGroups, err := h.buildModelsMissingTokenGroups(allowed)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load missing token groups")
+		return
+	}
+	endpointTypes, err := h.buildEndpointTypesByModel(allowed)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load endpoint types")
+		return
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"models":                   models,

--- a/handler/admin/stats_balance.go
+++ b/handler/admin/stats_balance.go
@@ -22,7 +22,11 @@ func (h *statsHandler) balanceHistory(w http.ResponseWriter, r *http.Request) {
 	}
 	q += ` ORDER BY local_day ASC, account_id ASC`
 
-	rows := queryRows(h.db, q, args...)
+	rows, err := queryRowsErr(h.db, q, args...)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load balance history")
+		return
+	}
 	byAccount := make(map[int64][]map[string]any)
 	for _, row := range rows {
 		accID := coerceInt64(row["accountId"])
@@ -73,7 +77,11 @@ func (h *statsHandler) balanceIncomeOutcome(w http.ResponseWriter, r *http.Reque
 	}
 	q += ` ORDER BY account_id ASC, local_day ASC`
 
-	rows := queryRows(h.db, q, args...)
+	rows, err := queryRowsErr(h.db, q, args...)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load balance income/outcome")
+		return
+	}
 
 	// Per-account chronological snapshots (already ordered).
 	type snapshot struct {
@@ -177,8 +185,12 @@ func (h *statsHandler) attention(w http.ResponseWriter, r *http.Request) {
 	items := make([]attentionItem, 0, limit)
 
 	// 1. Expired accounts — critical.
-	expired := queryRows(h.db, rebindAdminQuery(h.db, `SELECT id, username, site_id, updated_at
-		FROM accounts WHERE status = 'expired' ORDER BY updated_at DESC LIMIT ?`), limit)
+	expired, err := queryRowsErr(h.db, `SELECT id, username, site_id, updated_at
+		FROM accounts WHERE status = 'expired' ORDER BY updated_at DESC LIMIT ?`, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load attention items")
+		return
+	}
 	for _, row := range expired {
 		items = append(items, attentionItem{
 			Severity: "critical", Category: "expired_account",
@@ -193,9 +205,13 @@ func (h *statsHandler) attention(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 2. Low-balance accounts (< 1.0) — warning. Matches G1 threshold.
-	low := queryRows(h.db, rebindAdminQuery(h.db, `SELECT id, username, balance, site_id
+	low, err := queryRowsErr(h.db, `SELECT id, username, balance, site_id
 		FROM accounts WHERE status = 'active' AND COALESCE(balance, 0) < 1.0
-		ORDER BY balance ASC LIMIT ?`), limit)
+		ORDER BY balance ASC LIMIT ?`, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load attention items")
+		return
+	}
 	for _, row := range low {
 		items = append(items, attentionItem{
 			Severity: "warning", Category: "low_balance",
@@ -210,8 +226,12 @@ func (h *statsHandler) attention(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 3. Disabled sites — warning.
-	disabledSites := queryRows(h.db, rebindAdminQuery(h.db, `SELECT id, name, updated_at
-		FROM sites WHERE status = 'disabled' ORDER BY updated_at DESC LIMIT ?`), limit)
+	disabledSites, err := queryRowsErr(h.db, `SELECT id, name, updated_at
+		FROM sites WHERE status = 'disabled' ORDER BY updated_at DESC LIMIT ?`, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load attention items")
+		return
+	}
 	for _, row := range disabledSites {
 		items = append(items, attentionItem{
 			Severity: "warning", Category: "disabled_site",
@@ -227,9 +247,13 @@ func (h *statsHandler) attention(w http.ResponseWriter, r *http.Request) {
 
 	// 4. Recent unread warning/error events — info/warning (deep-link to events).
 	since24h := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
-	evRows := queryRows(h.db, rebindAdminQuery(h.db, `SELECT type, title, level, related_id, related_type, created_at
+	evRows, err := queryRowsErr(h.db, `SELECT type, title, level, related_id, related_type, created_at
 		FROM events WHERE level IN ('warning', 'error') AND created_at >= ?
-		ORDER BY created_at DESC LIMIT ?`), since24h, limit)
+		ORDER BY created_at DESC LIMIT ?`, since24h, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load attention items")
+		return
+	}
 	for _, row := range evRows {
 		severity := coerceString(row["level"])
 		if severity == "error" {

--- a/handler/admin/stats_heatmap.go
+++ b/handler/admin/stats_heatmap.go
@@ -23,7 +23,7 @@ func (h *statsHandler) usageHeatmap(w http.ResponseWriter, r *http.Request) {
 
 	if dimension == "site" {
 		// Prefer projected hour aggregates (cheap, already limited by projector).
-		rows := queryRows(h.db, `
+		rows, err := queryRowsErr(h.db, `
 			SELECT
 				u.bucket_start_utc AS bucket,
 				CAST(u.site_id AS TEXT) AS key,
@@ -37,13 +37,17 @@ func (h *statsHandler) usageHeatmap(w http.ResponseWriter, r *http.Request) {
 			ORDER BY u.bucket_start_utc ASC, u.total_calls DESC
 			LIMIT ?
 		`, since, usageHeatmapCellLimit)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load usage heatmap")
+			return
+		}
 		if len(rows) > 0 {
 			source = "site_hour_usage"
 			cells = makeUsageHeatmapCells(rows)
 		} else {
 			// Fallback: bounded live aggregate from proxy_logs when projection is empty.
 			hourExpr := hourBucketSQLExpr(h.db, "pl.created_at")
-			rows = queryRows(h.db, `
+			rows, err = queryRowsErr(h.db, `
 				SELECT
 					`+hourExpr+` AS bucket,
 					CAST(s.id AS TEXT) AS key,
@@ -59,13 +63,17 @@ func (h *statsHandler) usageHeatmap(w http.ResponseWriter, r *http.Request) {
 				ORDER BY bucket ASC, calls DESC
 				LIMIT ?
 			`, since, usageHeatmapCellLimit)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to load usage heatmap")
+				return
+			}
 			cells = makeUsageHeatmapCells(rows)
 		}
 	} else {
 		// Model density: no model_hour_usage table; aggregate proxy_logs with LIMIT.
 		hourExpr := hourBucketSQLExpr(h.db, "pl.created_at")
 		modelExpr := `COALESCE(NULLIF(pl.model_actual, ''), NULLIF(pl.model_requested, ''), 'unknown')`
-		rows := queryRows(h.db, `
+		rows, err := queryRowsErr(h.db, `
 			SELECT
 				`+hourExpr+` AS bucket,
 				`+modelExpr+` AS key,
@@ -79,6 +87,10 @@ func (h *statsHandler) usageHeatmap(w http.ResponseWriter, r *http.Request) {
 			ORDER BY bucket ASC, calls DESC
 			LIMIT ?
 		`, since, usageHeatmapCellLimit)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load usage heatmap")
+			return
+		}
 		cells = makeUsageHeatmapCells(rows)
 	}
 

--- a/handler/admin/stats_latency.go
+++ b/handler/admin/stats_latency.go
@@ -15,7 +15,7 @@ func (h *statsHandler) slowRequests(w http.ResponseWriter, r *http.Request) {
 	hours := clampInt(getQueryInt(r, "hours", 24), 1, 168)
 	since := time.Now().UTC().Add(-time.Duration(hours) * time.Hour).Format(time.RFC3339)
 
-	rows := queryRows(h.db, `
+	rows, err := queryRowsErr(h.db, `
 		SELECT
 			pl.id AS id,
 			COALESCE(NULLIF(pl.model_actual, ''), NULLIF(pl.model_requested, ''), '') AS model,
@@ -36,6 +36,10 @@ func (h *statsHandler) slowRequests(w http.ResponseWriter, r *http.Request) {
 		ORDER BY pl.latency_ms DESC, pl.created_at DESC
 		LIMIT ?
 	`, since, minLatencyMs, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load slow requests")
+		return
+	}
 
 	items := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
@@ -77,7 +81,7 @@ func (h *statsHandler) modelCostDistribution(w http.ResponseWriter, r *http.Requ
 	since := time.Now().UTC().AddDate(0, 0, -(days - 1)).Format("2006-01-02T00:00:00Z")
 
 	modelExpr := `COALESCE(NULLIF(pl.model_actual, ''), NULLIF(pl.model_requested, ''), 'unknown')`
-	rows := queryRows(h.db, `
+	rows, err := queryRowsErr(h.db, `
 		SELECT `+modelExpr+` AS model,
 			COUNT(*) AS calls,
 			COALESCE(SUM(COALESCE(pl.estimated_cost, 0)), 0) AS cost,
@@ -87,6 +91,10 @@ func (h *statsHandler) modelCostDistribution(w http.ResponseWriter, r *http.Requ
 		GROUP BY `+modelExpr+`
 		ORDER BY cost DESC, model ASC
 	`, since)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load model cost distribution")
+		return
+	}
 
 	items := make([]map[string]any, 0, topN+1)
 	var totalCost, totalCalls, totalTokens float64
@@ -147,7 +155,7 @@ func (h *statsHandler) latencyHistogram(w http.ResponseWriter, r *http.Request) 
 	bucketMs := clampInt(getQueryInt(r, "bucketMs", 500), 100, 60000)
 	since := time.Now().UTC().AddDate(0, 0, -(days - 1)).Format("2006-01-02T00:00:00Z")
 
-	rows := queryRows(h.db, `
+	rows, err := queryRowsErr(h.db, `
 		SELECT (COALESCE(pl.latency_ms, 0) / ?) * ? AS bucket_start,
 			COUNT(*) AS count
 		FROM proxy_logs pl
@@ -155,6 +163,10 @@ func (h *statsHandler) latencyHistogram(w http.ResponseWriter, r *http.Request) 
 		GROUP BY bucket_start
 		ORDER BY bucket_start ASC
 	`, bucketMs, bucketMs, since)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load latency histogram")
+		return
+	}
 
 	buckets := make([]map[string]any, 0, len(rows))
 	var total int64
@@ -199,7 +211,7 @@ func (h *statsHandler) latencyTrend(w http.ResponseWriter, r *http.Request) {
 	fromDay := time.Now().UTC().AddDate(0, 0, -(days - 1)).Format("2006-01-02")
 
 	dayExpr := dayBucketSQLExpr(h.db, "pl.created_at")
-	rows := queryRows(h.db, `
+	rows, err := queryRowsErr(h.db, `
 		SELECT `+dayExpr+` AS day,
 			COUNT(*) AS requests,
 			AVG(CASE WHEN COALESCE(pl.latency_ms, 0) > 0 THEN pl.latency_ms END) AS avg_latency,
@@ -211,6 +223,10 @@ func (h *statsHandler) latencyTrend(w http.ResponseWriter, r *http.Request) {
 		GROUP BY `+dayExpr+`
 		ORDER BY day ASC
 	`, fromDay)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load latency trend")
+		return
+	}
 
 	// p95 per day from a bounded descending sample. With LIMIT cap, the p95
 	// index (floor(0.05*n)) stays inside the sample while n < 20*cap.
@@ -242,7 +258,7 @@ func (h *statsHandler) latencyTrend(w http.ResponseWriter, r *http.Request) {
 		}
 		// COUNT(*) OVER () gives the true row count before LIMIT truncates,
 		// so p95 sampling stays honest when a day exceeds the sample cap.
-		samples := queryRows(h.db, `
+		samples, err := queryRowsErr(h.db, `
 			SELECT pl.latency_ms AS latency_ms, COUNT(*) OVER () AS total
 			FROM proxy_logs pl
 			WHERE pl.created_at >= ? AND pl.created_at < ?
@@ -250,6 +266,10 @@ func (h *statsHandler) latencyTrend(w http.ResponseWriter, r *http.Request) {
 			ORDER BY pl.latency_ms DESC
 			LIMIT ?
 		`, dayStart, dayEnd, p95SampleCap)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load latency trend samples")
+			return
+		}
 		n := len(samples)
 		if n > 0 {
 			total := coerceInt64(samples[0]["total"])

--- a/handler/admin/stats_marketplace.go
+++ b/handler/admin/stats_marketplace.go
@@ -26,7 +26,7 @@ type marketplaceAccountAgg struct {
 	tokenIDs map[int64]struct{}
 }
 
-func (h *statsHandler) buildMarketplaceModels() []map[string]any {
+func (h *statsHandler) buildMarketplaceModels() ([]map[string]any, error) {
 	// Collect model names from availability tables + exact token_routes patterns.
 	type modelKey = string
 	type modelAgg struct {
@@ -74,7 +74,7 @@ func (h *statsHandler) buildMarketplaceModels() []map[string]any {
 	}
 
 	// Account-level availability.
-	accountRows := queryRows(h.db, `
+	accountRows, err := queryRowsErr(h.db, `
 		SELECT
 			ma.model_name AS model_name,
 			ma.latency_ms AS latency_ms,
@@ -91,6 +91,9 @@ func (h *statsHandler) buildMarketplaceModels() []map[string]any {
 			AND COALESCE(s.status, '') <> 'disabled'
 		ORDER BY ma.model_name ASC, a.id ASC
 	`)
+	if err != nil {
+		return nil, err
+	}
 	for _, row := range accountRows {
 		model := strings.TrimSpace(coerceString(row["modelName"]))
 		if model == "" {
@@ -110,7 +113,7 @@ func (h *statsHandler) buildMarketplaceModels() []map[string]any {
 			latency,
 		)
 		// Attach enabled tokens for this account (may also appear via token availability).
-		tokenRows := queryRows(h.db, `
+		tokenRows, err := queryRowsErr(h.db, `
 			SELECT id, name, is_default
 			FROM account_tokens
 			WHERE account_id = ?
@@ -118,6 +121,9 @@ func (h *statsHandler) buildMarketplaceModels() []map[string]any {
 				AND (value_status IS NULL OR value_status <> 'expired')
 			ORDER BY is_default DESC, id ASC
 		`, acc.ID)
+		if err != nil {
+			return nil, err
+		}
 		for _, tr := range tokenRows {
 			tid := coerceInt64(tr["id"])
 			if tid <= 0 {
@@ -136,7 +142,7 @@ func (h *statsHandler) buildMarketplaceModels() []map[string]any {
 	}
 
 	// Token-level availability.
-	tokenAvailRows := queryRows(h.db, `
+	tokenAvailRows, err := queryRowsErr(h.db, `
 		SELECT
 			tma.model_name AS model_name,
 			tma.latency_ms AS latency_ms,
@@ -158,6 +164,9 @@ func (h *statsHandler) buildMarketplaceModels() []map[string]any {
 			AND COALESCE(s.status, '') <> 'disabled'
 		ORDER BY tma.model_name ASC, a.id ASC, at.id ASC
 	`)
+	if err != nil {
+		return nil, err
+	}
 	for _, row := range tokenAvailRows {
 		model := strings.TrimSpace(coerceString(row["modelName"]))
 		if model == "" {
@@ -193,12 +202,15 @@ func (h *statsHandler) buildMarketplaceModels() []map[string]any {
 
 	// Exact-model token_routes contribute model names even when availability is empty
 	// so operators still see configured routes in the marketplace list.
-	routeRows := queryRows(h.db, `
+	routeRows, err := queryRowsErr(h.db, `
 		SELECT model_pattern
 		FROM token_routes
 		WHERE enabled = 1
 			AND route_mode <> 'explicit_group'
 	`)
+	if err != nil {
+		return nil, err
+	}
 	for _, row := range routeRows {
 		pattern := strings.TrimSpace(coerceString(row["modelPattern"]))
 		if pattern == "" {
@@ -219,7 +231,7 @@ func (h *statsHandler) buildMarketplaceModels() []map[string]any {
 		total   int
 		success int
 	}{}
-	logRows := queryRows(h.db, `
+	logRows, err := queryRowsErr(h.db, `
 		SELECT
 			COALESCE(NULLIF(TRIM(model_actual), ''), NULLIF(TRIM(model_requested), ''), '') AS model,
 			COUNT(*) AS total,
@@ -229,6 +241,9 @@ func (h *statsHandler) buildMarketplaceModels() []map[string]any {
 			AND COALESCE(NULLIF(TRIM(model_actual), ''), NULLIF(TRIM(model_requested), ''), '') <> ''
 		GROUP BY COALESCE(NULLIF(TRIM(model_actual), ''), NULLIF(TRIM(model_requested), ''), '')
 	`, since)
+	if err != nil {
+		return nil, err
+	}
 	for _, row := range logRows {
 		model := strings.TrimSpace(coerceString(row["model"]))
 		if model == "" {
@@ -300,7 +315,7 @@ func (h *statsHandler) buildMarketplaceModels() []map[string]any {
 			"accounts":       accounts,
 		})
 	}
-	return out
+	return out, nil
 }
 
 func inferEndpointTypesForModel(modelName string, accounts []map[string]any) []string {
@@ -318,8 +333,8 @@ func inferEndpointTypesForModel(modelName string, accounts []map[string]any) []s
 	}
 }
 
-func (h *statsHandler) buildTokenCandidateModels(allowed map[string]struct{}) map[string][]map[string]any {
-	rows := queryRows(h.db, `
+func (h *statsHandler) buildTokenCandidateModels(allowed map[string]struct{}) (map[string][]map[string]any, error) {
+	rows, err := queryRowsErr(h.db, `
 		SELECT
 			tma.model_name AS model_name,
 			a.id AS account_id,
@@ -340,6 +355,9 @@ func (h *statsHandler) buildTokenCandidateModels(allowed map[string]struct{}) ma
 			AND COALESCE(s.status, '') <> 'disabled'
 		ORDER BY tma.model_name ASC, a.id ASC, at.id ASC
 	`)
+	if err != nil {
+		return nil, err
+	}
 
 	out := map[string][]map[string]any{}
 	seen := map[string]map[int64]struct{}{} // model -> tokenIDs
@@ -375,14 +393,14 @@ func (h *statsHandler) buildTokenCandidateModels(allowed map[string]struct{}) ma
 			"siteName":  coerceString(row["siteName"]),
 		})
 	}
-	return out
+	return out, nil
 }
 
-func (h *statsHandler) buildModelsWithoutToken(allowed map[string]struct{}) map[string][]map[string]any {
+func (h *statsHandler) buildModelsWithoutToken(allowed map[string]struct{}) (map[string][]map[string]any, error) {
 	// Accounts with available model_availability but no token_model_availability
 	// coverage for that model AND no enabled account_tokens at all (or none that
 	// list the model). Operators use this for zero-channel route hints.
-	rows := queryRows(h.db, `
+	rows, err := queryRowsErr(h.db, `
 		SELECT
 			ma.model_name AS model_name,
 			a.id AS account_id,
@@ -415,6 +433,9 @@ func (h *statsHandler) buildModelsWithoutToken(allowed map[string]struct{}) map[
 			)
 		ORDER BY ma.model_name ASC, a.id ASC
 	`)
+	if err != nil {
+		return nil, err
+	}
 
 	out := map[string][]map[string]any{}
 	seen := map[string]map[int64]struct{}{}
@@ -447,14 +468,14 @@ func (h *statsHandler) buildModelsWithoutToken(allowed map[string]struct{}) map[
 			"siteName":  coerceString(row["siteName"]),
 		})
 	}
-	return out
+	return out, nil
 }
 
-func (h *statsHandler) buildModelsMissingTokenGroups(allowed map[string]struct{}) map[string][]map[string]any {
+func (h *statsHandler) buildModelsMissingTokenGroups(allowed map[string]struct{}) (map[string][]map[string]any, error) {
 	// When an account has model availability and managed tokens, but none of the
 	// enabled tokens have a resolvable token_group label, group coverage is uncertain
 	// / missing. We do not invent required groups from a remote pricing catalog.
-	rows := queryRows(h.db, `
+	rows, err := queryRowsErr(h.db, `
 		SELECT
 			ma.model_name AS model_name,
 			a.id AS account_id,
@@ -474,6 +495,9 @@ func (h *statsHandler) buildModelsMissingTokenGroups(allowed map[string]struct{}
 			AND (at.value_status IS NULL OR at.value_status <> 'expired')
 		ORDER BY ma.model_name ASC, a.id ASC, at.id ASC
 	`)
+	if err != nil {
+		return nil, err
+	}
 
 	type accGroups struct {
 		accountID int64
@@ -551,7 +575,7 @@ func (h *statsHandler) buildModelsMissingTokenGroups(allowed map[string]struct{}
 			out[model] = append(out[model], item)
 		}
 	}
-	return out
+	return out, nil
 }
 
 func resolveTokenGroupLabel(tokenGroup, tokenName string) string {
@@ -574,14 +598,18 @@ func resolveTokenGroupLabel(tokenGroup, tokenName string) string {
 	return name
 }
 
-func (h *statsHandler) buildEndpointTypesByModel(allowed map[string]struct{}) map[string][]string {
+func (h *statsHandler) buildEndpointTypesByModel(allowed map[string]struct{}) (map[string][]string, error) {
 	// Union of endpoint types inferred from model names present in availability.
 	models := map[string]struct{}{}
-	for _, row := range queryRows(h.db, `
+	availModels, err := queryRowsErr(h.db, `
 		SELECT DISTINCT model_name AS model_name FROM model_availability WHERE COALESCE(available, 0) = 1
 		UNION
 		SELECT DISTINCT model_name AS model_name FROM token_model_availability WHERE COALESCE(available, 0) = 1
-	`) {
+	`)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range availModels {
 		model := strings.TrimSpace(coerceString(row["modelName"]))
 		if model == "" || !modelAllowed(model, allowed) {
 			continue
@@ -597,7 +625,7 @@ func (h *statsHandler) buildEndpointTypesByModel(allowed map[string]struct{}) ma
 		}
 		out[model] = types
 	}
-	return out
+	return out, nil
 }
 
 func (h *statsHandler) loadGlobalAllowedModels() map[string]struct{} {

--- a/handler/admin/tags.go
+++ b/handler/admin/tags.go
@@ -72,8 +72,11 @@ func encodeTagsJSON(tags []string) string {
 // total usage descending. Drives filter chips on Accounts/Sites pages.
 func (h *tagsHandler) listTags(w http.ResponseWriter, r *http.Request) {
 	counts := map[string]map[string]int{} // tag → {"accounts": n, "sites": n}
-	addRows := func(table string) {
-		rows := queryRows(h.db, "SELECT tags FROM "+table+" WHERE COALESCE(tags, '') <> ''")
+	addRows := func(table string) error {
+		rows, err := queryRowsErr(h.db, "SELECT tags FROM "+table+" WHERE COALESCE(tags, '') <> ''")
+		if err != nil {
+			return err
+		}
 		for _, row := range rows {
 			tags, err := parseTagsJSON(coerceString(row["tags"]))
 			if err != nil {
@@ -86,9 +89,16 @@ func (h *tagsHandler) listTags(w http.ResponseWriter, r *http.Request) {
 				counts[t][table]++
 			}
 		}
+		return nil
 	}
-	addRows("accounts")
-	addRows("sites")
+	if err := addRows("accounts"); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load tags")
+		return
+	}
+	if err := addRows("sites"); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load tags")
+		return
+	}
 
 	items := make([]map[string]any, 0, len(counts))
 	for tag, c := range counts {

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -89,7 +89,11 @@ type tokenRoutesHandler struct {
 // ---- List Lite ----
 // GET /api/routes/lite
 func (h *tokenRoutesHandler) listLite(w http.ResponseWriter, r *http.Request) {
-	rows := queryRows(h.db, "SELECT id, model_pattern, display_name, display_icon, route_mode, routing_strategy, enabled, context_length FROM token_routes ORDER BY sort_order ASC, id ASC")
+	rows, err := queryRowsErr(h.db, "SELECT id, model_pattern, display_name, display_icon, route_mode, routing_strategy, enabled, context_length FROM token_routes ORDER BY sort_order ASC, id ASC")
+	if err != nil {
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load routes")
+		return
+	}
 	type srcRow struct {
 		GroupRouteID  int64 `db:"group_route_id"`
 		SourceRouteID int64 `db:"source_route_id"`
@@ -114,7 +118,11 @@ func (h *tokenRoutesHandler) listLite(w http.ResponseWriter, r *http.Request) {
 // ---- List Summary ----
 // GET /api/routes/summary
 func (h *tokenRoutesHandler) listSummary(w http.ResponseWriter, r *http.Request) {
-	rows := queryRows(h.db, "SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC")
+	rows, err := queryRowsErr(h.db, "SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC")
+	if err != nil {
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load routes")
+		return
+	}
 
 	// Batch-load per-route channel counts in a single GROUP BY query instead of
 	// firing two COUNT queries per route (the previous N+1 shape). A route with
@@ -187,23 +195,36 @@ func (h *tokenRoutesHandler) listRoutes(w http.ResponseWriter, r *http.Request) 
 
 	var rows []map[string]any
 	var total int64
+	var queryErr error
 	page, pageSize := 1, 50
 	if paginate {
 		page = clampInt(getQueryInt(r, "page", 1), 1, 1_000_000)
 		pageSize = clampInt(getQueryInt(r, "pageSize", 50), 1, 200)
 		offset := (page - 1) * pageSize
-		rows = queryRows(h.db, h.db.Rebind(
-			"SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC LIMIT ? OFFSET ?"),
+		rows, queryErr = queryRowsErr(h.db,
+			"SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC LIMIT ? OFFSET ?",
 			pageSize, offset)
+		if queryErr != nil {
+			writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load routes")
+			return
+		}
 		// Separate COUNT keeps the row maps free of a window-function column
 		// (queryRows MapScans into map[string]any and would echo total_count
 		// into every route item otherwise).
 		_ = h.db.Get(&total, h.db.Rebind("SELECT COUNT(*) FROM token_routes"))
 	} else {
-		rows = queryRows(h.db, "SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC")
+		rows, queryErr = queryRowsErr(h.db, "SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC")
+		if queryErr != nil {
+			writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load routes")
+			return
+		}
 	}
 
-	result := h.enrichRoutesWithChannels(rows, paginate)
+	result, err := h.enrichRoutesWithChannels(rows, paginate)
+	if err != nil {
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load route channels")
+		return
+	}
 
 	if paginate {
 		writeJSON(w, http.StatusOK, map[string]any{
@@ -223,7 +244,7 @@ func (h *tokenRoutesHandler) listRoutes(w http.ResponseWriter, r *http.Request) 
 // current page so a 50-row page does not pull the entire fleet's channels;
 // when false (legacy unpaginated call) it loads every channel, matching the
 // pre-pagination behavior exactly.
-func (h *tokenRoutesHandler) enrichRoutesWithChannels(rows []map[string]any, scopeToPage bool) []map[string]any {
+func (h *tokenRoutesHandler) enrichRoutesWithChannels(rows []map[string]any, scopeToPage bool) ([]map[string]any, error) {
 	// Select only credential fragments (first4/last4/length) instead of the
 	// plaintext access_token/api_token — the full secret never crosses the
 	// DB→Go boundary, so a stray slog/metrics call cannot leak it. The masked
@@ -243,6 +264,7 @@ func (h *tokenRoutesHandler) enrichRoutesWithChannels(rows []map[string]any, sco
 	// behavior (an IN list of every route ID could also exceed SQLite's
 	// bind-parameter ceiling on very large fleets).
 	var allChannelRows []map[string]any
+	var channelErr error
 	if scopeToPage {
 		routeIDs := make([]int64, 0, len(rows))
 		for _, route := range rows {
@@ -259,14 +281,17 @@ func (h *tokenRoutesHandler) enrichRoutesWithChannels(rows []map[string]any, sco
 			}
 			channelQuery += " WHERE rc.route_id IN (" + strings.Join(placeholders, ",") + ")"
 			channelQuery += " ORDER BY rc.route_id ASC, rc.priority ASC, rc.id ASC"
-			allChannelRows = queryRows(h.db, channelQuery, args...)
+			allChannelRows, channelErr = queryRowsErr(h.db, channelQuery, args...)
 		} else {
 			channelQuery += " ORDER BY rc.route_id ASC, rc.priority ASC, rc.id ASC"
-			allChannelRows = queryRows(h.db, channelQuery)
+			allChannelRows, channelErr = queryRowsErr(h.db, channelQuery)
 		}
 	} else {
 		channelQuery += " ORDER BY rc.route_id ASC, rc.priority ASC, rc.id ASC"
-		allChannelRows = queryRows(h.db, channelQuery)
+		allChannelRows, channelErr = queryRowsErr(h.db, channelQuery)
+	}
+	if channelErr != nil {
+		return nil, channelErr
 	}
 
 	channelsByRoute := make(map[int64][]map[string]any)
@@ -317,7 +342,7 @@ func (h *tokenRoutesHandler) enrichRoutesWithChannels(rows []map[string]any, sco
 		}
 		result = append(result, item)
 	}
-	return result
+	return result, nil
 }
 
 // ---- Create Route ----

--- a/handler/admin/token_routes_channels.go
+++ b/handler/admin/token_routes_channels.go
@@ -17,7 +17,7 @@ func (h *tokenRoutesHandler) getRouteChannels(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	channelRows := queryRows(h.db,
+	channelRows, err := queryRowsErr(h.db,
 		`SELECT rc.*, a.username, `+
 			credentialFragmentsSelect(h.db, "a.access_token", "access_token")+`, `+
 			credentialFragmentsSelect(h.db, "a.api_token", "api_token")+`,
@@ -27,6 +27,10 @@ func (h *tokenRoutesHandler) getRouteChannels(w http.ResponseWriter, r *http.Req
 		 LEFT JOIN accounts a ON rc.account_id = a.id
 		 LEFT JOIN sites s ON a.site_id = s.id
 		 WHERE rc.route_id = ?`, id)
+	if err != nil {
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load route channels")
+		return
+	}
 	var enrichedChans []map[string]any
 	for _, ch := range channelRows {
 		enriched := map[string]any{

--- a/service/oauth/flow.go
+++ b/service/oauth/flow.go
@@ -521,7 +521,9 @@ func activatePersistedOAuthAccount(ctx context.Context, input ActivateInput) (*P
 
 		// If existing and we just updated: activate the account now that model refresh succeeded.
 		if !created && input.PersistedStatus == "" {
-			_, _ = db.Exec("UPDATE accounts SET status = 'active', updated_at = ? WHERE id = ?", now, accountID)
+			if _, err := db.Exec(db.Rebind("UPDATE accounts SET status = 'active', updated_at = ? WHERE id = ?"), now, accountID); err != nil {
+				slog.Warn("oauth status activation failed", "error", err, "account_id", accountID)
+			}
 		}
 
 		// Step 7f: Rebuild routes.

--- a/service/oauth/quota.go
+++ b/service/oauth/quota.go
@@ -282,7 +282,9 @@ func RecordOauthQuotaResetHint(accountID int64, statusCode int, errorText string
 	}
 	extraConfig := MergeAccountExtraConfig(account.ExtraConfig, extraPatch)
 	now := time.Now().Format(time.RFC3339)
-	_, _ = db.Exec("UPDATE accounts SET extra_config = ?, updated_at = ? WHERE id = ?", extraConfig, now, accountID)
+	if _, err := db.Exec(db.Rebind("UPDATE accounts SET extra_config = ?, updated_at = ? WHERE id = ?"), extraConfig, now, accountID); err != nil {
+		slog.Warn("oauth quota persist failed", "error", err, "account_id", accountID)
+	}
 }
 
 // ---- Internal helpers ----
@@ -443,7 +445,9 @@ func persistQuotaSnapshot(db *store.DB, accountID int64, snapshot *OauthQuotaSna
 	}
 	extraConfig := MergeAccountExtraConfig(account.ExtraConfig, extraPatch)
 	now := time.Now().Format(time.RFC3339)
-	db.Exec("UPDATE accounts SET extra_config = ?, updated_at = ? WHERE id = ?", extraConfig, now, accountID)
+	if _, err := db.Exec(db.Rebind("UPDATE accounts SET extra_config = ?, updated_at = ? WHERE id = ?"), extraConfig, now, accountID); err != nil {
+		slog.Warn("oauth quota persist failed", "error", err, "account_id", accountID)
+	}
 }
 
 func quotaFingerprint(snapshot *OauthQuotaSnapshot) string {


### PR DESCRIPTION
## Summary

- Remove silent `queryRows()` wrapper; all 24 admin callers now use `queryRowsErr()` and return HTTP 500 on DB failure instead of HTTP 200 with empty arrays (masked real outages as "no results")
- `clearUsage`/`clearCache`: propagate DB errors instead of ignoring with `_ =`; operator now sees 500 when DELETE/UPDATE fails instead of false success
- `persistQuotaSnapshot` + `RecordOauthQuotaResetHint`: add `slog.Warn` on failed UPDATE, use `db.Rebind()` for PG compatibility
- `flow.go` post-refresh status activation: add `slog.Warn` on error, use `db.Rebind()`

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./handler/admin/... ./service/oauth/...` passes
- [x] PG rebind gate test passes
- [ ] CI 12-check suite passes