### PR TITLE
feat(web): route document titles + shell-scoped notFound for loader throws

### DIFF
--- a/web/src/components/layout/index.ts
+++ b/web/src/components/layout/index.ts
@@ -2,3 +2,4 @@
 
 export { AuthenticatedLayout } from './components/authenticated-layout'
 export { LayoutErrorBoundary } from './layout-error-boundary'
+export { NotFoundPage } from './not-found-page'

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -6,12 +6,18 @@
 
 import { useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
+import {
+  createRootRouteWithContext,
+  Outlet,
+  useRouterState,
+} from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { Toaster } from '@/components/ui/sonner'
 import { bootstrapAuthentication } from '@/lib/auth-session'
+import { metapiIdentity } from '@/lib/identity-branding'
 import { useAuthStore } from '@/stores/auth-store'
 
 let authBootstrapped = false
@@ -25,9 +31,30 @@ function isDevtoolsEnabled() {
   }
 }
 
+/**
+ * Keep `document.title` in sync with the current route: the deepest match's
+ * `staticData.title` holds an i18n key, translated and suffixed with the
+ * product name (`Accounts · MetAPI`); routes without a title fall back to the
+ * bare product name. Re-runs on navigation and on language change.
+ */
+function useDocumentTitle() {
+  const { t, i18n } = useTranslation()
+  const titleKey = useRouterState({
+    select: (state) => state.matches.at(-1)?.staticData?.title,
+  })
+
+  useEffect(() => {
+    const pageTitle = titleKey ? t(titleKey) : ''
+    document.title = pageTitle
+      ? `${pageTitle} · ${metapiIdentity.name}`
+      : metapiIdentity.name
+  }, [titleKey, t, i18n.language])
+}
+
 function RootComponent() {
   const queryClient = useQueryClient()
   const showDevtools = isDevtoolsEnabled()
+  useDocumentTitle()
 
   // Clear the query cache when the auth session changes (login/logout/tab
   // sync) so stale user-scoped data never leaks across sessions.

--- a/web/src/routes/_authenticated/accounts.tsx
+++ b/web/src/routes/_authenticated/accounts.tsx
@@ -30,6 +30,7 @@ const accountsSearchSchema = z.object({
 
 export const Route = createFileRoute('/_authenticated/accounts')({
   validateSearch: accountsSearchSchema,
+  staticData: { title: 'accounts.page.title' },
   loader: async ({ context }) => {
     await context.queryClient.prefetchQuery({
       queryKey: accountQueryKeys.snapshot(),

--- a/web/src/routes/_authenticated/channels.tsx
+++ b/web/src/routes/_authenticated/channels.tsx
@@ -8,6 +8,7 @@ import { api } from '@/lib/api'
 
 export const Route = createFileRoute('/_authenticated/channels')({
   validateSearch: channelsSearchSchema,
+  staticData: { title: 'channels.page.title' },
   loader: async ({ context }) => {
     await context.queryClient.prefetchQuery({
       queryKey: channelsKeys.list(),

--- a/web/src/routes/_authenticated/checkin.tsx
+++ b/web/src/routes/_authenticated/checkin.tsx
@@ -30,6 +30,7 @@ import { CheckinPage } from '@/features/checkin/components/checkin-page'
 
 export const Route = createFileRoute('/_authenticated/checkin')({
   validateSearch: checkinSearchSchema,
+  staticData: { title: 'checkin.page.title' },
   loader: async ({ context, location }) => {
     const initialQuery = buildInitialCheckinLogsQuery(
       parseCheckinSearch(location.searchStr)

--- a/web/src/routes/_authenticated/fix-candidates.tsx
+++ b/web/src/routes/_authenticated/fix-candidates.tsx
@@ -5,5 +5,6 @@ import { createFileRoute } from '@tanstack/react-router'
 import { FixCandidatesPage } from '@/features/models/fix-candidates/components/fix-candidates-page'
 
 export const Route = createFileRoute('/_authenticated/fix-candidates')({
+  staticData: { title: 'fixCandidates.page.title' },
   component: FixCandidatesPage,
 })

--- a/web/src/routes/_authenticated/model-tester.tsx
+++ b/web/src/routes/_authenticated/model-tester.tsx
@@ -24,6 +24,7 @@ const modelTesterSearchSchema = z.object({
 
 export const Route = createFileRoute('/_authenticated/model-tester')({
   validateSearch: modelTesterSearchSchema,
+  staticData: { title: 'modelTester.page.title' },
   loader: async ({ context }) => {
     await context.queryClient.prefetchQuery({
       queryKey: modelsKeys.marketplace({

--- a/web/src/routes/_authenticated/models.tsx
+++ b/web/src/routes/_authenticated/models.tsx
@@ -21,6 +21,7 @@ import { api } from '@/lib/api'
 
 export const Route = createFileRoute('/_authenticated/models')({
   validateSearch: modelsSearchSchema,
+  staticData: { title: 'models.page.title' },
   loader: async ({ context }) => {
     await context.queryClient.prefetchQuery({
       queryKey: modelsKeys.marketplace({

--- a/web/src/routes/_authenticated/oauth.tsx
+++ b/web/src/routes/_authenticated/oauth.tsx
@@ -20,6 +20,7 @@ import { api } from '@/lib/api'
 
 export const Route = createFileRoute('/_authenticated/oauth')({
   validateSearch: oauthSearchSchema,
+  staticData: { title: 'oauth.page.title' },
   loader: async ({ context }) => {
     await Promise.all([
       context.queryClient.prefetchQuery({

--- a/web/src/routes/_authenticated/price-compare.tsx
+++ b/web/src/routes/_authenticated/price-compare.tsx
@@ -7,5 +7,6 @@ import { createFileRoute } from '@tanstack/react-router'
 import { PriceComparePage } from '@/features/models/price-compare/components/price-compare-page'
 
 export const Route = createFileRoute('/_authenticated/price-compare')({
+  staticData: { title: 'priceCompare.page.title' },
   component: PriceComparePage,
 })

--- a/web/src/routes/_authenticated/proxy-logs.tsx
+++ b/web/src/routes/_authenticated/proxy-logs.tsx
@@ -46,6 +46,7 @@ function parseProxyLogsSearch(searchStr: string): ProxyLogsSearch | null {
 
 export const Route = createFileRoute('/_authenticated/proxy-logs')({
   validateSearch: proxyLogsSearchSchema,
+  staticData: { title: 'proxyLogs.page.title' },
   loader: async ({ context, location }) => {
     const search = parseProxyLogsSearch(location.searchStr)
     if (!search) return

--- a/web/src/routes/_authenticated/route.tsx
+++ b/web/src/routes/_authenticated/route.tsx
@@ -8,10 +8,19 @@
 // (AppHeader + AppSidebar + SidebarProvider) stays mounted and interactive.
 // Without this, a page crash would bubble to the router's
 // defaultErrorComponent (ErrorPage) and the whole shell would be lost.
+//
+// notFoundComponent mirrors that for `notFound()` throws from a loader /
+// beforeLoad (a missing resource, not a missing path — the latter is handled
+// by the `$` catch-all): the 404 renders inside the shell instead of falling
+// back to the router-level defaultNotFoundComponent.
 
 import { createFileRoute, redirect } from '@tanstack/react-router'
 
-import { AuthenticatedLayout, LayoutErrorBoundary } from '@/components/layout'
+import {
+  AuthenticatedLayout,
+  LayoutErrorBoundary,
+  NotFoundPage,
+} from '@/components/layout'
 import { hasValidAuthSession } from '@/lib/auth-session'
 
 export const Route = createFileRoute('/_authenticated')({
@@ -33,4 +42,5 @@ export const Route = createFileRoute('/_authenticated')({
   },
   component: AuthenticatedLayout,
   errorComponent: LayoutErrorBoundary,
+  notFoundComponent: NotFoundPage,
 })

--- a/web/src/routes/_authenticated/sites.tsx
+++ b/web/src/routes/_authenticated/sites.tsx
@@ -19,6 +19,7 @@ import { api } from '@/lib/api'
 
 export const Route = createFileRoute('/_authenticated/sites')({
   validateSearch: sitesSearchSchema,
+  staticData: { title: 'sites.page.title' },
   loader: async ({ context }) => {
     await context.queryClient.prefetchQuery({
       queryKey: sitesKeys.list(),

--- a/web/src/routes/_authenticated/token-routes.tsx
+++ b/web/src/routes/_authenticated/token-routes.tsx
@@ -23,6 +23,7 @@ import { api } from '@/lib/api'
 
 export const Route = createFileRoute('/_authenticated/token-routes')({
   validateSearch: routesSearchSchema,
+  staticData: { title: 'tokenRoutes.page.title' },
   loader: async ({ context }) => {
     await Promise.all([
       context.queryClient.prefetchQuery({


### PR DESCRIPTION
## Summary

路由层最后两处收尾：

1. **文档标题（document.title）** — 路由层早已声明 `StaticDataRouteOption.title`，但没有任何代码消费它，浏览器标签页一直是写死的 `MetAPI`。现在 `__root` 用一个 `useDocumentTitle` hook 把 `document.title` 同步为最深匹配路由的 `staticData.title`（存 i18n key，翻译后加产品名后缀，如 `Accounts · MetAPI`），并在语言切换时重跑。11 个列表页路由声明了各自的 title key。

2. **notFound 对称性** — `_authenticated` 有 `errorComponent`（渲染错误落在 shell 内），但没有 `notFoundComponent`：loader/beforeLoad 抛 `notFound()` 时会回退到 router 级 `defaultNotFoundComponent` 而丢掉 shell。现在补齐为 shell 内的 `NotFoundPage`（路径不存在已由 `$` catch-all 覆盖，本次补的是资源不存在的场景）。

## 验证

- typecheck / lint / knip / format 全绿
- build 通过
- 测试 344/344

## 说明

这是路由系统的最后一批：此前已合并 #685（闪烁根因）、#686（设计 P1）、#744（URL-state loader 收敛）、#745（404 catch-all + active-state + deep-link）。本次之后路由层在「路径 404 / 资源 notFound / 渲染错误」三类兜底上完全对称、且都在 shell 内。

页面级 `window.location.search` 直读 → `useSearch()` 的全量迁移经评估会**回退**（TSR v1 会对 search 做 JSON 序列化，把 `?sort=name:desc` 重写成 JSON 数组噪声；且 malformed URL 会从优雅降级变成 error boundary），故保留现状并已在 `searchParams.ts` 注释中说明。