### PR TITLE
fix: propagate remaining swallowed DB errors in settings, pagination, and OAuth

### DIFF
--- a/handler/admin/downstream_keys.go
+++ b/handler/admin/downstream_keys.go
@@ -126,7 +126,10 @@ func (h *downstreamKeysHandler) listKeys(w http.ResponseWriter, r *http.Request)
 			writeError(w, http.StatusInternalServerError, "failed to load downstream keys")
 			return
 		}
-		_ = h.db.Get(&total, h.db.Rebind("SELECT COUNT(*) FROM downstream_api_keys"))
+		if err := h.db.Get(&total, h.db.Rebind("SELECT COUNT(*) FROM downstream_api_keys")); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to count downstream keys")
+			return
+		}
 	} else {
 		rows, queryErr = queryRowsErr(h.db, "SELECT * FROM downstream_api_keys ORDER BY id DESC")
 		if queryErr != nil {

--- a/handler/admin/settings.go
+++ b/handler/admin/settings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -444,10 +445,11 @@ func stringSliceOrEmpty(in []string) []string {
 }
 
 func logSettingsEvent(db *sqlx.DB, eventType, title, message, level, createdAt string) {
-	// Silently ignore errors (matches TS behavior)
 	query := db.Rebind(`INSERT INTO events (type, title, message, level, related_type, created_at, "read")
 		VALUES (?, ?, ?, ?, 'settings', ?, 0)`)
-	_, _ = db.Exec(query, eventType, title, message, level, createdAt)
+	if _, err := db.Exec(query, eventType, title, message, level, createdAt); err != nil {
+		slog.Warn("settings: failed to log settings event", "type", eventType, "error", err)
+	}
 }
 
 // decodeScheduleSpec converts a decoded JSON body value into a ScheduleSpec.

--- a/handler/admin/settings_apply.go
+++ b/handler/admin/settings_apply.go
@@ -27,12 +27,15 @@ func failSettings(status int, msg string) *settingsApplyError {
 
 // applyStringSetting handles the common "simple string field" pattern:
 // normalize the body value, mutate the config target, and persist it.
-// The upsert error is deliberately ignored, matching the historical handler.
-func applyStringSetting(db *sqlx.DB, body map[string]any, key string, target *string, dbKey string) {
+// Returns the upsert error so callers can surface it as HTTP 500.
+func applyStringSetting(db *sqlx.DB, body map[string]any, key string, target *string, dbKey string) error {
 	if v, ok := body[key]; ok {
 		*target = normalizeString(v)
-		upsertSettingDB(db, dbKey, *target)
+		if err := upsertSettingDB(db, dbKey, *target); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // applyProxyAccessSettings applies the proxy token and system proxy URL.
@@ -51,7 +54,9 @@ func (h *settingsHandler) applyProxyAccessSettings(body map[string]any) *setting
 	}
 
 	// System proxy URL
-	applyStringSetting(h.db, body, "systemProxyUrl", &h.cfg.SystemProxyUrl, "system_proxy_url")
+	if err := applyStringSetting(h.db, body, "systemProxyUrl", &h.cfg.SystemProxyUrl, "system_proxy_url"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
 
 	return nil
 }
@@ -329,9 +334,15 @@ func (h *settingsHandler) applyProxyDebugSettings(body map[string]any) *settings
 		return failSettings(http.StatusBadRequest, err.Error())
 	}
 
-	applyStringSetting(h.db, body, "proxyDebugTargetSessionId", &h.cfg.ProxyDebugTargetSessionId, "proxy_debug_target_session_id")
-	applyStringSetting(h.db, body, "proxyDebugTargetClientKind", &h.cfg.ProxyDebugTargetClientKind, "proxy_debug_target_client_kind")
-	applyStringSetting(h.db, body, "proxyDebugTargetModel", &h.cfg.ProxyDebugTargetModel, "proxy_debug_target_model")
+	if err := applyStringSetting(h.db, body, "proxyDebugTargetSessionId", &h.cfg.ProxyDebugTargetSessionId, "proxy_debug_target_session_id"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "proxyDebugTargetClientKind", &h.cfg.ProxyDebugTargetClientKind, "proxy_debug_target_client_kind"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "proxyDebugTargetModel", &h.cfg.ProxyDebugTargetModel, "proxy_debug_target_model"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
 
 	if v, ok := body["proxyDebugRetentionHours"]; ok {
 		n, err := toFloat64Strict(v)
@@ -466,37 +477,53 @@ func (h *settingsHandler) applyNotifySettings(body map[string]any) *settingsAppl
 	if err := applyBoolSettingDB(h.db, body, "webhookEnabled", &h.cfg.WebhookEnabled, "webhook_enabled"); err != nil {
 		return failSettings(http.StatusBadRequest, err.Error())
 	}
-	applyStringSetting(h.db, body, "webhookUrl", &h.cfg.WebhookUrl, "webhook_url")
+	if err := applyStringSetting(h.db, body, "webhookUrl", &h.cfg.WebhookUrl, "webhook_url"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
 
 	// Notify: Bark
 	if err := applyBoolSettingDB(h.db, body, "barkEnabled", &h.cfg.BarkEnabled, "bark_enabled"); err != nil {
 		return failSettings(http.StatusBadRequest, err.Error())
 	}
-	applyStringSetting(h.db, body, "barkUrl", &h.cfg.BarkUrl, "bark_url")
+	if err := applyStringSetting(h.db, body, "barkUrl", &h.cfg.BarkUrl, "bark_url"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
 
 	// Notify: ServerChan
 	if err := applyBoolSettingDB(h.db, body, "serverChanEnabled", &h.cfg.ServerChanEnabled, "serverchan_enabled"); err != nil {
 		return failSettings(http.StatusBadRequest, err.Error())
 	}
-	applyStringSetting(h.db, body, "serverChanKey", &h.cfg.ServerChanKey, "serverchan_key")
+	if err := applyStringSetting(h.db, body, "serverChanKey", &h.cfg.ServerChanKey, "serverchan_key"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
 
 	// Notify: Telegram
 	if err := applyBoolSettingDB(h.db, body, "telegramEnabled", &h.cfg.TelegramEnabled, "telegram_enabled"); err != nil {
 		return failSettings(http.StatusBadRequest, err.Error())
 	}
-	applyStringSetting(h.db, body, "telegramApiBaseUrl", &h.cfg.TelegramApiBaseUrl, "telegram_api_base_url")
-	applyStringSetting(h.db, body, "telegramBotToken", &h.cfg.TelegramBotToken, "telegram_bot_token")
-	applyStringSetting(h.db, body, "telegramChatId", &h.cfg.TelegramChatId, "telegram_chat_id")
+	if err := applyStringSetting(h.db, body, "telegramApiBaseUrl", &h.cfg.TelegramApiBaseUrl, "telegram_api_base_url"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "telegramBotToken", &h.cfg.TelegramBotToken, "telegram_bot_token"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "telegramChatId", &h.cfg.TelegramChatId, "telegram_chat_id"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
 	if err := applyBoolSettingDB(h.db, body, "telegramUseSystemProxy", &h.cfg.TelegramUseSystemProxy, "telegram_use_system_proxy"); err != nil {
 		return failSettings(http.StatusBadRequest, err.Error())
 	}
-	applyStringSetting(h.db, body, "telegramMessageThreadId", &h.cfg.TelegramMessageThreadId, "telegram_message_thread_id")
+	if err := applyStringSetting(h.db, body, "telegramMessageThreadId", &h.cfg.TelegramMessageThreadId, "telegram_message_thread_id"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
 
 	// Notify: SMTP
 	if err := applyBoolSettingDB(h.db, body, "smtpEnabled", &h.cfg.SmtpEnabled, "smtp_enabled"); err != nil {
 		return failSettings(http.StatusBadRequest, err.Error())
 	}
-	applyStringSetting(h.db, body, "smtpHost", &h.cfg.SmtpHost, "smtp_host")
+	if err := applyStringSetting(h.db, body, "smtpHost", &h.cfg.SmtpHost, "smtp_host"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
 	if v, ok := body["smtpPort"]; ok {
 		n, err := toFloat64Strict(v)
 		if err != nil {
@@ -508,32 +535,56 @@ func (h *settingsHandler) applyNotifySettings(body map[string]any) *settingsAppl
 	if err := applyBoolSettingDB(h.db, body, "smtpSecure", &h.cfg.SmtpSecure, "smtp_secure"); err != nil {
 		return failSettings(http.StatusBadRequest, err.Error())
 	}
-	applyStringSetting(h.db, body, "smtpUser", &h.cfg.SmtpUser, "smtp_user")
-	applyStringSetting(h.db, body, "smtpPass", &h.cfg.SmtpPass, "smtp_pass")
-	applyStringSetting(h.db, body, "smtpFrom", &h.cfg.SmtpFrom, "smtp_from")
-	applyStringSetting(h.db, body, "smtpTo", &h.cfg.SmtpTo, "smtp_to")
+	if err := applyStringSetting(h.db, body, "smtpUser", &h.cfg.SmtpUser, "smtp_user"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "smtpPass", &h.cfg.SmtpPass, "smtp_pass"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "smtpFrom", &h.cfg.SmtpFrom, "smtp_from"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "smtpTo", &h.cfg.SmtpTo, "smtp_to"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
 
 	// Notify: Feishu / DingTalk / WeCom / Ntfy
 	if err := applyBoolSettingDB(h.db, body, "feishuEnabled", &h.cfg.FeishuEnabled, "feishu_enabled"); err != nil {
 		return failSettings(http.StatusBadRequest, err.Error())
 	}
-	applyStringSetting(h.db, body, "feishuWebhook", &h.cfg.FeishuWebhook, "feishu_webhook")
-	applyStringSetting(h.db, body, "feishuSecret", &h.cfg.FeishuSecret, "feishu_secret")
+	if err := applyStringSetting(h.db, body, "feishuWebhook", &h.cfg.FeishuWebhook, "feishu_webhook"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "feishuSecret", &h.cfg.FeishuSecret, "feishu_secret"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
 	if err := applyBoolSettingDB(h.db, body, "dingtalkEnabled", &h.cfg.DingtalkEnabled, "dingtalk_enabled"); err != nil {
 		return failSettings(http.StatusBadRequest, err.Error())
 	}
-	applyStringSetting(h.db, body, "dingtalkWebhook", &h.cfg.DingtalkWebhook, "dingtalk_webhook")
-	applyStringSetting(h.db, body, "dingtalkSecret", &h.cfg.DingtalkSecret, "dingtalk_secret")
+	if err := applyStringSetting(h.db, body, "dingtalkWebhook", &h.cfg.DingtalkWebhook, "dingtalk_webhook"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "dingtalkSecret", &h.cfg.DingtalkSecret, "dingtalk_secret"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
 	if err := applyBoolSettingDB(h.db, body, "wecomEnabled", &h.cfg.WecomEnabled, "wecom_enabled"); err != nil {
 		return failSettings(http.StatusBadRequest, err.Error())
 	}
-	applyStringSetting(h.db, body, "wecomWebhook", &h.cfg.WecomWebhook, "wecom_webhook")
+	if err := applyStringSetting(h.db, body, "wecomWebhook", &h.cfg.WecomWebhook, "wecom_webhook"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
 	if err := applyBoolSettingDB(h.db, body, "ntfyEnabled", &h.cfg.NtfyEnabled, "ntfy_enabled"); err != nil {
 		return failSettings(http.StatusBadRequest, err.Error())
 	}
-	applyStringSetting(h.db, body, "ntfyUrl", &h.cfg.NtfyUrl, "ntfy_url")
-	applyStringSetting(h.db, body, "ntfyTopic", &h.cfg.NtfyTopic, "ntfy_topic")
-	applyStringSetting(h.db, body, "ntfyToken", &h.cfg.NtfyToken, "ntfy_token")
+	if err := applyStringSetting(h.db, body, "ntfyUrl", &h.cfg.NtfyUrl, "ntfy_url"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "ntfyTopic", &h.cfg.NtfyTopic, "ntfy_topic"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "ntfyToken", &h.cfg.NtfyToken, "ntfy_token"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
 
 	// Per-alert-type mute toggles (JSON object).
 	if v, ok := body["notifyTaskToggles"]; ok {
@@ -648,12 +699,24 @@ func (h *settingsHandler) applyFilterSettings(body map[string]any) *settingsAppl
 // applySiteBrandingSettings applies the site branding fields.
 func (h *settingsHandler) applySiteBrandingSettings(body map[string]any) *settingsApplyError {
 	// Site & Branding
-	applyStringSetting(h.db, body, "systemName", &h.cfg.SystemName, "system_name")
-	applyStringSetting(h.db, body, "logo", &h.cfg.Logo, "logo")
-	applyStringSetting(h.db, body, "footer", &h.cfg.Footer, "footer")
-	applyStringSetting(h.db, body, "about", &h.cfg.About, "about")
-	applyStringSetting(h.db, body, "homePageContent", &h.cfg.HomePageContent, "home_page_content")
-	applyStringSetting(h.db, body, "serverAddress", &h.cfg.ServerAddress, "server_address")
+	if err := applyStringSetting(h.db, body, "systemName", &h.cfg.SystemName, "system_name"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "logo", &h.cfg.Logo, "logo"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "footer", &h.cfg.Footer, "footer"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "about", &h.cfg.About, "about"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "homePageContent", &h.cfg.HomePageContent, "home_page_content"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
+	if err := applyStringSetting(h.db, body, "serverAddress", &h.cfg.ServerAddress, "server_address"); err != nil {
+		return failSettings(http.StatusInternalServerError, err.Error())
+	}
 
 	return nil
 }

--- a/handler/admin/settings_backup_webdav.go
+++ b/handler/admin/settings_backup_webdav.go
@@ -363,8 +363,10 @@ func updateWebdavBackupState(db *sqlx.DB, syncErr error) map[string]any {
 		state["lastSyncAt"] = now
 	}
 	data, err := json.Marshal(state)
-	if err == nil {
-		_ = saveBackupSettingString(db, backupWebdavStateSettingKey, string(data))
+	if err != nil {
+		slog.Warn("settings: failed to marshal webdav backup state", "error", err)
+	} else if saveErr := saveBackupSettingString(db, backupWebdavStateSettingKey, string(data)); saveErr != nil {
+		slog.Warn("settings: failed to persist webdav backup state", "error", saveErr)
 	}
 	return state
 }

--- a/handler/admin/settings_maintenance.go
+++ b/handler/admin/settings_maintenance.go
@@ -117,17 +117,29 @@ func invalidateLocalProcessCaches() {
 // POST /api/settings/maintenance/clear-usage
 func (h *maintenanceHandler) clearUsage(w http.ResponseWriter, r *http.Request) {
 	var deletedProxyLogs int64
-	_ = h.db.Get(&deletedProxyLogs, "SELECT COUNT(*) FROM proxy_logs")
-	_, _ = h.db.Exec("DELETE FROM proxy_logs")
+	if err := h.db.Get(&deletedProxyLogs, h.db.Rebind("SELECT COUNT(*) FROM proxy_logs")); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("读取 proxy_logs 失败：%v", err))
+		return
+	}
+	if _, err := h.db.Exec(h.db.Rebind("DELETE FROM proxy_logs")); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("清理 proxy_logs 失败：%v", err))
+		return
+	}
 
 	// Reset route channel stats
-	_, _ = h.db.Exec(`UPDATE route_channels SET
+	if _, err := h.db.Exec(h.db.Rebind(`UPDATE route_channels SET
 		success_count = 0, fail_count = 0, total_latency_ms = 0, total_cost = 0,
 		last_used_at = NULL, last_selected_at = NULL, last_fail_at = NULL,
-		consecutive_fail_count = 0, cooldown_level = 0, cooldown_until = NULL`)
+		consecutive_fail_count = 0, cooldown_level = 0, cooldown_until = NULL`)); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("清理 route_channels 统计失败：%v", err))
+		return
+	}
 
 	// Reset account balanceUsed
-	_, _ = h.db.Exec("UPDATE accounts SET balance_used = 0")
+	if _, err := h.db.Exec(h.db.Rebind("UPDATE accounts SET balance_used = 0")); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("清理 accounts 余额占用失败：%v", err))
+		return
+	}
 
 	// Accounts list snapshot may still show old balanceUsed until cleared.
 	if globalAccountsCache != nil {
@@ -192,11 +204,17 @@ func (h *maintenanceHandler) factoryReset(w http.ResponseWriter, r *http.Request
 	driverName := h.db.DriverName()
 	switch driverName {
 	case "sqlite", "sqlite3":
-		_, _ = tx.Exec("DELETE FROM sqlite_sequence")
+		if _, err := tx.Exec("DELETE FROM sqlite_sequence"); err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("工厂重置失败：无法重置自增序列：%v", err))
+			return
+		}
 	case "pgx", "postgres":
 		for _, table := range allTables {
 			seqName := table + "_id_seq"
-			_, _ = tx.Exec(fmt.Sprintf("ALTER SEQUENCE IF EXISTS %s RESTART WITH 1", seqName))
+			if _, err := tx.Exec(fmt.Sprintf("ALTER SEQUENCE IF EXISTS %s RESTART WITH 1", seqName)); err != nil {
+				writeError(w, http.StatusInternalServerError, fmt.Sprintf("工厂重置失败：无法重置序列 %s：%v", seqName, err))
+				return
+			}
 		}
 	}
 	// For other drivers, skip sequence reset (no-op).

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -211,7 +211,10 @@ func (h *tokenRoutesHandler) listRoutes(w http.ResponseWriter, r *http.Request) 
 		// Separate COUNT keeps the row maps free of a window-function column
 		// (queryRows MapScans into map[string]any and would echo total_count
 		// into every route item otherwise).
-		_ = h.db.Get(&total, h.db.Rebind("SELECT COUNT(*) FROM token_routes"))
+		if err := h.db.Get(&total, h.db.Rebind("SELECT COUNT(*) FROM token_routes")); err != nil {
+			writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to count routes")
+			return
+		}
 	} else {
 		rows, queryErr = queryRowsErr(h.db, "SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC")
 		if queryErr != nil {

--- a/service/model_redirects.go
+++ b/service/model_redirects.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -65,7 +67,11 @@ func CanonicalFromActual(actual string, candidates []string) (canonical string, 
 // models (settings) plus exact token_routes model patterns (no wildcards).
 func loadRedirectCandidates(ctx context.Context, db *sqlx.DB) ([]string, error) {
 	var raw string
-	_ = db.GetContext(ctx, &raw, `SELECT value FROM settings WHERE key = 'global_allowed_models'`)
+	if err := db.GetContext(ctx, &raw, `SELECT value FROM settings WHERE key = 'global_allowed_models'`); err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+	}
 	var candidates []string
 	if strings.TrimSpace(raw) != "" {
 		var list []string

--- a/service/oauth/flow.go
+++ b/service/oauth/flow.go
@@ -488,7 +488,9 @@ func activatePersistedOAuthAccount(ctx context.Context, input ActivateInput) (*P
 
 		// Get next sort order.
 		var maxSortOrder int64
-		_ = db.Get(&maxSortOrder, "SELECT COALESCE(MAX(sort_order), -1) FROM accounts")
+		if err := db.Get(&maxSortOrder, db.Rebind("SELECT COALESCE(MAX(sort_order), -1) FROM accounts")); err != nil {
+			slog.Warn("oauth: failed to query max sort_order for accounts, defaulting to 1", "error", err)
+		}
 		sortOrder := maxSortOrder + 1
 
 		accountID, err = execStoreInsertID(db,
@@ -644,7 +646,9 @@ func ensureOAuthProviderSite(db *store.DB, def *OAuthProviderDefinition) (*store
 
 	// Get next sort order.
 	var maxSortOrder int64
-	_ = db.Get(&maxSortOrder, "SELECT COALESCE(MAX(sort_order), -1) FROM sites")
+	if err := db.Get(&maxSortOrder, db.Rebind("SELECT COALESCE(MAX(sort_order), -1) FROM sites")); err != nil {
+		slog.Warn("oauth: failed to query max sort_order for sites, defaulting to 1", "error", err)
+	}
 	sortOrder := maxSortOrder + 1
 	now := time.Now().Format(time.RFC3339)
 


### PR DESCRIPTION
## Summary

Batch 12 (#746) started fixing silent DB error swallowing but missed several spots. This PR completes the remaining error propagation fixes:

- **`clearUsage` handler**: propagates each DB error as HTTP 500 with per-step messages (mirrors the `clearCache` pattern fixed in #746). Uses `db.Rebind()` for all SQL.
- **Pagination COUNT queries**: `token_routes.go` and `downstream_keys.go` now return HTTP 500 when the `COUNT(*)` query fails instead of silently swallowing the error.
- **`applyStringSetting`**: changed to return `error` (matching `applyBoolSettingDB`), and all ~30 call sites now propagate the error as HTTP 500 through the central `settingsApplyError` dispatch chain. Affects secrets like `smtpPass`, `feishuSecret`, `telegramBotToken`, `serverChanKey`, etc.
- **OAuth `MAX(sort_order)` queries** (`flow.go` L491, L647): added `slog.Warn` on error with default `sortOrder=1`; wrapped queries in `db.Rebind()`.
- **`model_redirects.go`**: `loadRedirectCandidates` now returns DB errors (except `sql.ErrNoRows`) instead of swallowing them.
- **`updateWebdavBackupState`**: added `slog.Warn` when state persistence (marshal/save) fails.
- **Factory-reset sequence**: `DELETE FROM sqlite_sequence` and `ALTER SEQUENCE ... RESTART` now propagate errors as HTTP 500.
- **`logSettingsEvent`**: added `slog.Warn` on insert failure instead of silently ignoring.

## Test plan

- [x] `go build ./handler/admin/... ./service/oauth/... ./service/...` passes
- [x] `go vet ./handler/admin/... ./service/oauth/... ./service/...` passes
- [x] `go test ./handler/admin/... ./service/oauth/... ./service/...` passes (all packages green)
- [x] `go test ./docs/... -run TestPgRebindGate` passes (rebind gate enforced)