### PR TITLE
fix: hot-path env read + .env.example gaps + LDOH timeout configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,11 @@ GEMINI_CLI_CLIENT_SECRET=
 
 PROXY_TOKEN=change-me-proxy-sk-token
 # Maximum buffered non-streaming upstream response size. Streaming responses are not buffered.
+# Default 20 MB (20971520). 0/negative/invalid falls back to default at Load time.
 PROXY_MAX_BUFFERED_RESPONSE_BYTES=20971520
+# Max total bytes relayed for a single SSE stream before a controlled termination.
+# Default 1 MB (1048576). 0/negative/invalid falls back to default at Load time.
+PROXY_MAX_STREAM_RESPONSE_BYTES=1048576
 # Test/demo only. Leave empty in production; unconfigured upstream forwarding returns 503.
 METAPI_ENABLE_PROXY_STUB=
 SYSTEM_PROXY_URL=
@@ -101,6 +105,10 @@ TRUSTED_PROXY_CIDRS=
 # Optional CSV of exact http(s) browser origins allowed to call /api/* admin endpoints.
 # Empty means same-origin admin UI only; proxy and health endpoints keep wildcard CORS.
 ADMIN_CORS_ALLOWED_ORIGINS=
+# slog threshold applied at startup (debug/info/warn/error). Default info.
+# Raising the threshold silences per-request / SSE / WS Debug-downgraded hot-path
+# logs that are already observable via Prometheus metrics, cutting log volume.
+LOG_LEVEL=info
 TZ=Asia/Shanghai
 
 # ---- Notifications (provider toggles; empty = disabled unless noted) ----
@@ -131,6 +139,16 @@ TELEGRAM_MESSAGE_THREAD_ID=
 TELEGRAM_USE_SYSTEM_PROXY=
 
 # ---- Proxy tuning ----
+# General body limit for /v1 proxy routes, in MB. Default 20, clamped [1, 200].
+REQUEST_BODY_LIMIT_MB=20
+# Higher multipart upload limit for /v1/files and /v1/images/*, in MB.
+# Default 100, clamped [1, 1000].
+FILE_UPLOAD_LIMIT_MB=100
+# Per-IP request-per-minute cap for /v1 proxy routes. Default 60; 0 = disabled.
+PROXY_RATE_LIMIT_RPM=60
+# Global PROXY_TOKEN RPM cap across all IPs. Default 0 = unlimited.
+# Safety net: even if the token leaks, upstream spend is bounded.
+PROXY_GLOBAL_TOKEN_RPM=0
 # First upstream response byte timeout, seconds.
 PROXY_FIRST_BYTE_TIMEOUT_SEC=
 # Max channel retry/failover attempts per request (default 3).
@@ -145,6 +163,14 @@ PROXY_SESSION_CHANNEL_QUEUE_WAIT_MS=1500
 PROXY_SESSION_CHANNEL_LEASE_TTL_MS=90000
 PROXY_SESSION_CHANNEL_LEASE_KEEPALIVE_MS=15000
 DISABLE_CROSS_PROTOCOL_FALLBACK=
+# Proxy log batch writer (async INSERT batching). Default async=true so
+# production gets the latency/SQLite-lock-contention win automatically; set
+# PROXY_LOG_ASYNC=false for tests/e2e that need write-through visibility.
+PROXY_LOG_ASYNC=true
+# Row count that triggers a batch flush (clamped [1, 1000]). Default 50.
+PROXY_LOG_BATCH_SIZE=50
+# Max time between flushes in ms (clamped [1, 60000]). Default 1000.
+PROXY_LOG_FLUSH_INTERVAL_MS=1000
 # Proxy data retention (days / prune interval minutes).
 PROXY_LOG_RETENTION_DAYS=30
 PROXY_LOG_RETENTION_PRUNE_INTERVAL_MINUTES=30
@@ -225,6 +251,17 @@ UTLS_ENABLED=
 # Override LDOH_BASE_URL to point the monitor iframe at a self-hosted LDOH
 # instance (default https://ldoh.105117.xyz).
 LDOH_BASE_URL=https://ldoh.105117.xyz
+# Per-request timeout for the LDOH upstream HTTP client, in seconds.
+# Default 30. 0/negative/invalid falls back to default at Load time.
+LDOH_PROXY_TIMEOUT_SEC=30
+
+# ---- Update Center scheduler gate ----
+# METAPI_ENABLE_UPDATE_CENTER gates the residual update-center scheduler
+# (scheduler.UpdateCenterScheduler). The scheduler is a log-only no-op today
+# (no remote registry / version discovery), so it is disabled by default to
+# avoid a 15-min lease heartbeat with no product value. Set true to re-enable
+# the periodic log line while a real helper/registry client is wired.
+METAPI_ENABLE_UPDATE_CENTER=
 
 # ---- DB extras ----
 # Optional PG SSL override (default false; true requires TLS). Prefer DB_SSLMODE for fine control.

--- a/config/config.go
+++ b/config/config.go
@@ -202,6 +202,13 @@ type Config struct {
 	// defaults to DefaultLDOHBaseURL so operators can redirect the monitor
 	// iframe at a self-hosted LDOH instance without a code change.
 	LDOHBaseURL string
+	// LDOHProxyTimeoutSec is the per-request timeout for the LDOH upstream
+	// HTTP client used by the /monitor-proxy/ldoh/* admin surface (env-only —
+	// no DDL). Parsed from LDOH_PROXY_TIMEOUT_SEC (default 30). Previously
+	// hardcoded to 30s in handler/admin/monitor.go; making it configurable
+	// lets operators raise the budget for slow LDOH instances or tighten it
+	// to fail fast. 0/negative/invalid falls back to the default at Load time.
+	LDOHProxyTimeoutSec int
 
 	// UpdateCenterEnabled gates the residual update-center scheduler
 	// (scheduler.UpdateCenterScheduler). The scheduler is a log-only no-op
@@ -286,6 +293,14 @@ type Config struct {
 	// at startup from PROXY_MAX_STREAM_RESPONSE_BYTES so the hot stream path
 	// reads a struct field instead of calling os.Getenv per request.
 	ProxyMaxStreamResponseBytes int
+	// ProxyMaxBufferedResponseBytes caps the total bytes read for a single
+	// non-streaming upstream response before a controlled termination
+	// (default 20 MB). Parsed once at startup from
+	// PROXY_MAX_BUFFERED_RESPONSE_BYTES so the buffered-response hot path
+	// (upstream.go / upstream_stream.go / executor.go) reads a struct field
+	// instead of re-parsing os.Getenv + strconv.ParseInt on every proxied
+	// request. 0/negative/invalid falls back to the default at Load time.
+	ProxyMaxBufferedResponseBytes int
 	ProxyErrorKeywords                         []string
 	GlobalBlockedBrands                        []string
 	GlobalAllowedModels                        []string
@@ -645,6 +660,14 @@ func Load(env map[string]string) *Config {
 
 	// ---- §3.11e LDOH monitor proxy base URL ----
 	cfg.LDOHBaseURL = strings.TrimSpace(firstNonEmpty(get("LDOH_BASE_URL"), DefaultLDOHBaseURL))
+	// LDOH_PROXY_TIMEOUT_SEC: per-request timeout for the LDOH upstream HTTP
+	// client. 0/negative/invalid falls back to the default (30s) so a
+	// misconfigured value never produces an unbounded-context LDOH call.
+	ldohTimeoutParsed := int(math.Trunc(parseNumber(get("LDOH_PROXY_TIMEOUT_SEC"), float64(DefaultLDOHProxyTimeoutSec))))
+	if ldohTimeoutParsed <= 0 {
+		ldohTimeoutParsed = DefaultLDOHProxyTimeoutSec
+	}
+	cfg.LDOHProxyTimeoutSec = ldohTimeoutParsed
 
 	// ---- §3.11d Update Center scheduler gate ----
 	cfg.UpdateCenterEnabled = parseBoolean(get("METAPI_ENABLE_UPDATE_CENTER"), false)
@@ -735,6 +758,16 @@ func Load(env map[string]string) *Config {
 		streamBytesParsed = DefaultProxyMaxStreamResponseBytes
 	}
 	cfg.ProxyMaxStreamResponseBytes = streamBytesParsed
+	// PROXY_MAX_BUFFERED_RESPONSE_BYTES caps a single non-streaming upstream
+	// response (default 20 MB). 0/negative/invalid resolves to the default so
+	// the buffered-response hot path never has to re-parse env or guard against
+	// a zero limit. Read once here — upstream.go / upstream_stream.go /
+	// executor.go read the resolved value from the config singleton.
+	bufferedBytesParsed := int(math.Trunc(parseNumber(get("PROXY_MAX_BUFFERED_RESPONSE_BYTES"), float64(DefaultProxyMaxBufferedResponseBytes))))
+	if bufferedBytesParsed <= 0 {
+		bufferedBytesParsed = int(DefaultProxyMaxBufferedResponseBytes)
+	}
+	cfg.ProxyMaxBufferedResponseBytes = bufferedBytesParsed
 	cfg.ProxyErrorKeywords = parseCsvList(get("PROXY_ERROR_KEYWORDS"))
 	cfg.GlobalBlockedBrands = []string{}
 	cfg.GlobalAllowedModels = []string{}

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -117,6 +117,14 @@ const (
 	// the resolved value from the config singleton, not os.Getenv per request.
 	DefaultProxyMaxStreamResponseBytes = 1 << 20 // 1 MB
 
+	// DefaultProxyMaxBufferedResponseBytes caps the total bytes read for a
+	// single non-streaming upstream response before a controlled termination
+	// (20 MB). Parsed from PROXY_MAX_BUFFERED_RESPONSE_BYTES; 0/negative/invalid
+	// falls back to this default. Read once at startup via config.Load so the
+	// buffered-response hot path reads a struct field instead of re-parsing
+	// os.Getenv + strconv.ParseInt on every proxied request.
+	DefaultProxyMaxBufferedResponseBytes int64 = 20 << 20 // 20 MB
+
 	TelegramApiBaseUrl = "https://api.telegram.org"
 
 	// DefaultLDOHBaseURL is the upstream LDOH (LdoHub) dashboard URL proxied
@@ -124,4 +132,11 @@ const (
 	// so operators can point the monitor iframe at a self-hosted LDOH
 	// instance without rebuilding the binary.
 	DefaultLDOHBaseURL = "https://ldoh.105117.xyz"
+
+	// DefaultLDOHProxyTimeoutSec is the per-request timeout for the LDOH
+	// upstream HTTP client used by the /monitor-proxy/ldoh/* admin surface.
+	// Parsed from LDOH_PROXY_TIMEOUT_SEC; 0/negative/invalid falls back to
+	// this default. Matches the previous hardcoded 30s so existing
+	// deployments are unchanged without an env override.
+	DefaultLDOHProxyTimeoutSec = 30
 )

--- a/handler/admin/monitor.go
+++ b/handler/admin/monitor.go
@@ -247,7 +247,7 @@ func (h *monitorHandler) ldohProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	client := &http.Client{
-		Timeout: 30 * time.Second,
+		Timeout: time.Duration(h.cfg.LDOHProxyTimeoutSec) * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -494,7 +494,14 @@ func TestDispatchUpstreamNonStreamFailoversOnRetryableHTTPStatusAndRecordsHealth
 }
 
 func TestNonStreamingUpstreamRejectsOversizedBufferedResponse(t *testing.T) {
-	t.Setenv("PROXY_MAX_BUFFERED_RESPONSE_BYTES", "8")
+	// The buffered byte limit is now read from the config singleton (set once
+	// at startup via config.Load), not os.Getenv per request, so override the
+	// singleton here — same pattern as TestHandleStreamUpstreamStopsAtConfiguredByteLimit.
+	prev := config.Get()
+	cfgCopy := *prev
+	cfgCopy.ProxyMaxBufferedResponseBytes = 8
+	config.Set(&cfgCopy)
+	t.Cleanup(func() { config.Set(prev) })
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/proxy/buffered_response.go
+++ b/proxy/buffered_response.go
@@ -4,25 +4,32 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"strconv"
-	"strings"
+
+	"github.com/deliciousbuding/metapi-go/config"
 )
 
+// DefaultMaxBufferedResponseBodyBytes is retained as the local fallback used
+// only when the global config singleton has not been loaded yet (e.g. tests
+// that bypass TestMain). Production callers go through Load(), which resolves
+// PROXY_MAX_BUFFERED_RESPONSE_BYTES once at startup and stores the value on
+// config.Config.ProxyMaxBufferedResponseBytes.
 const DefaultMaxBufferedResponseBodyBytes int64 = 20 << 20
 
 var ErrBufferedResponseBodyTooLarge = errors.New("upstream response body exceeded buffered limit")
 
+// MaxBufferedResponseBodyBytes returns the configured max non-streaming
+// upstream response size in bytes from the startup-loaded config singleton.
+// Falls back to DefaultProxyMaxBufferedResponseBytes when config is not yet
+// loaded (e.g. tests that bypass TestMain) or when the operator left the
+// value at zero/negative (Load already clamps, but GetSafe guards anyway).
+// Reading a struct field per request is materially cheaper than re-parsing
+// os.Getenv + strconv.ParseInt on every proxied request — this function is
+// on the hot path called from upstream.go, upstream_stream.go, executor.go.
 func MaxBufferedResponseBodyBytes() int64 {
-	raw := strings.TrimSpace(os.Getenv("PROXY_MAX_BUFFERED_RESPONSE_BYTES"))
-	if raw == "" {
-		return DefaultMaxBufferedResponseBodyBytes
+	if cfg := config.GetSafe(); cfg != nil && cfg.ProxyMaxBufferedResponseBytes > 0 {
+		return int64(cfg.ProxyMaxBufferedResponseBytes)
 	}
-	n, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil || n <= 0 {
-		return DefaultMaxBufferedResponseBodyBytes
-	}
-	return n
+	return int64(config.DefaultProxyMaxBufferedResponseBytes)
 }
 
 func ReadBufferedResponseBody(r io.Reader) ([]byte, error) {

--- a/proxy/executor_test.go
+++ b/proxy/executor_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -132,7 +134,12 @@ func TestDoWithObservedFirstByteDoesNotCancelBodyAfterHeaders(t *testing.T) {
 }
 
 func TestDispatchRejectsOversizedBufferedResponse(t *testing.T) {
-	t.Setenv("PROXY_MAX_BUFFERED_RESPONSE_BYTES", "8")
+	// The buffered byte limit is now read from the config singleton (set once
+	// at startup via config.Load), not os.Getenv per request, so load a config
+	// with the limit and install it as the global singleton for this test.
+	prev := config.GetSafe()
+	t.Cleanup(func() { config.Set(prev) })
+	config.Set(config.Load(map[string]string{"PROXY_MAX_BUFFERED_RESPONSE_BYTES": "8"}))
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, "123456789")
@@ -154,7 +161,12 @@ func TestDispatchRejectsOversizedBufferedResponse(t *testing.T) {
 }
 
 func TestWithObservedFirstByteRejectsOversizedBufferedResponse(t *testing.T) {
-	t.Setenv("PROXY_MAX_BUFFERED_RESPONSE_BYTES", "8")
+	// The buffered byte limit is now read from the config singleton (set once
+	// at startup via config.Load), not os.Getenv per request, so load a config
+	// with the limit and install it as the global singleton for this test.
+	prev := config.GetSafe()
+	t.Cleanup(func() { config.Set(prev) })
+	config.Set(config.Load(map[string]string{"PROXY_MAX_BUFFERED_RESPONSE_BYTES": "8"}))
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, "123456789")


### PR DESCRIPTION
## Summary

- **Task 1 — hot-path env read**: `MaxBufferedResponseBodyBytes()` previously called `os.Getenv` + `strconv.ParseInt` on every proxied non-streaming request (`upstream.go`, `upstream_stream.go`, `executor.go`). Now parsed once at startup into `config.Config.ProxyMaxBufferedResponseBytes` (default 20 MB) and read as a struct field via `config.GetSafe()` — same pattern as `ProxyMaxStreamResponseBytes`.
- **Task 2 — `.env.example` gaps**: Added 11 missing env-var entries (`LOG_LEVEL`, `REQUEST_BODY_LIMIT_MB`, `FILE_UPLOAD_LIMIT_MB`, `PROXY_RATE_LIMIT_RPM`, `PROXY_GLOBAL_TOKEN_RPM`, `PROXY_LOG_ASYNC`, `PROXY_LOG_BATCH_SIZE`, `PROXY_LOG_FLUSH_INTERVAL_MS`, `PROXY_MAX_STREAM_RESPONSE_BYTES`, `METAPI_ENABLE_UPDATE_CENTER`, `LDOH_PROXY_TIMEOUT_SEC`) with correct defaults and clamp ranges.
- **Task 3 — LDOH timeout configurable**: The `/monitor-proxy/ldoh/*` handler hardcoded a 30 s `http.Client.Timeout`. Added `config.Config.LDOHProxyTimeoutSec` (env `LDOH_PROXY_TIMEOUT_SEC`, default 30, 0/negative/invalid falls back to default) and wired it into the client.

## Test plan

- [x] `go build ./config/... ./proxy/... ./handler/admin/... ./handler/proxy/...` — clean (pre-existing `web/embed.go` dist-asset failure is unrelated)
- [x] `go vet ./config/... ./proxy/... ./handler/admin/... ./handler/proxy/...` — clean
- [x] `go test ./config/... ./proxy/... ./handler/proxy/...` — all pass
- [x] 3 tests updated from `t.Setenv` → config-singleton override (matches the existing `ProxyMaxStreamResponseBytes` test pattern)