### PR TITLE
refactor(web): pages own URL state via useSearch + navigate (T1 page migration)

### DIFF
--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -8,6 +8,7 @@
 // TanStack Query mutation hooks; the create/edit form, detail sheet, and
 // delete confirm live as siblings of the table.
 
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import type {
   ColumnFiltersState,
   OnChangeFn,
@@ -22,7 +23,7 @@ import {
   Trash2,
   Upload as UploadIcon,
 } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -57,41 +58,7 @@ import { AccountDetailSheet } from './account-detail-sheet'
 import { AccountFormDialog } from './account-form-dialog'
 import { useAccountsColumns } from './accounts-columns'
 
-// ---------------------------------------------------------------------------
-// URL state helpers — read initial table state from the query string on mount
-// and write subsequent changes back via history.replaceState. Keeping the sync
-// framework-agnostic (window.history) avoids coupling to TanStack Router's
-// generated route tree while /token-routes etc. are still unregistered.
-// ---------------------------------------------------------------------------
-
-interface InitialUrlState {
-  page: number
-  pageSize: number
-  search: string
-  status: string[]
-  siteIds: string[]
-}
-
 const DEFAULT_PAGE_SIZE = 20
-
-function readInitialFromUrl(): InitialUrlState {
-  if (typeof window === 'undefined') {
-    return {
-      page: 1,
-      pageSize: DEFAULT_PAGE_SIZE,
-      search: '',
-      status: [],
-      siteIds: [],
-    }
-  }
-  const params = new URLSearchParams(window.location.search)
-  const page = Math.max(1, Number(params.get('page')) || 1)
-  const pageSize = Number(params.get('pageSize')) || DEFAULT_PAGE_SIZE
-  const search = params.get('q') ?? ''
-  const status = params.get('status')?.split(',').filter(Boolean) ?? []
-  const siteIds = params.get('site')?.split(',').filter(Boolean) ?? []
-  return { page, pageSize, search, status, siteIds }
-}
 
 // ---------------------------------------------------------------------------
 // Page
@@ -99,6 +66,11 @@ function readInitialFromUrl(): InitialUrlState {
 
 export function AccountsPage() {
   const { t } = useTranslation()
+  // URL state is owned by the router: read the validated search via
+  // `useSearch` (no `window.location.search`), and write changes back via
+  // `navigate({ search, replace: true })` (no `history.replaceState`).
+  const search = useSearch({ from: '/_authenticated/accounts' })
+  const navigate = useNavigate()
   const { data, isLoading, isFetching, error } = useAccounts()
   const accounts = data?.accounts ?? []
   const sites = data?.sites ?? []
@@ -110,56 +82,56 @@ export function AccountsPage() {
   const checkinMutation = useToggleAccountCheckin()
 
   // --- table state (client-side, URL-synced) ---
-  const initial = useMemo(readInitialFromUrl, [])
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: initial.page - 1,
-    pageSize: initial.pageSize,
+    pageIndex: (search.page ?? 1) - 1,
+    pageSize: search.pageSize ?? DEFAULT_PAGE_SIZE,
   })
-  const [globalFilter, setGlobalFilter] = useState(initial.search)
+  const [globalFilter, setGlobalFilter] = useState(search.q ?? '')
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(() => {
     const filters: ColumnFiltersState = []
-    if (initial.status.length) {
-      filters.push({ id: 'status', value: initial.status })
+    const statusValues = search.status?.split(',').filter(Boolean) ?? []
+    const siteIds = search.site?.split(',').filter(Boolean) ?? []
+    if (statusValues.length) {
+      filters.push({ id: 'status', value: statusValues })
     }
-    if (initial.siteIds.length) {
-      filters.push({ id: 'site', value: initial.siteIds })
+    if (siteIds.length) {
+      filters.push({ id: 'site', value: siteIds })
     }
     return filters
   })
 
-  // Write state back to the URL (debounce-free replaceState is cheap enough).
+  // Write state back to the URL through the router (single source of truth).
+  // Skip the initial write — the URL already holds the search the state was
+  // initialised from.
+  const skipInitialWrite = useRef(true)
   useEffect(() => {
-    if (typeof window === 'undefined') return
-    const params = new URLSearchParams()
-    if (pagination.pageIndex > 0) {
-      params.set('page', String(pagination.pageIndex + 1))
+    if (skipInitialWrite.current) {
+      skipInitialWrite.current = false
+      return
     }
-    if (pagination.pageSize !== DEFAULT_PAGE_SIZE) {
-      params.set('pageSize', String(pagination.pageSize))
-    }
-    if (globalFilter) params.set('q', globalFilter)
     const statusFilter = columnFilters.find((filter) => filter.id === 'status')
-    if (
-      statusFilter &&
-      Array.isArray(statusFilter.value) &&
-      statusFilter.value.length
-    ) {
-      params.set('status', statusFilter.value.join(','))
-    }
     const siteFilter = columnFilters.find((filter) => filter.id === 'site')
-    if (
-      siteFilter &&
-      Array.isArray(siteFilter.value) &&
-      siteFilter.value.length
-    ) {
-      params.set('site', siteFilter.value.join(','))
-    }
-    const query = params.toString()
-    const url = query
-      ? `${window.location.pathname}?${query}`
-      : window.location.pathname
-    window.history.replaceState(null, '', url)
-  }, [pagination, globalFilter, columnFilters])
+    navigate({
+      to: '/accounts',
+      search: {
+        page: pagination.pageIndex > 0 ? pagination.pageIndex + 1 : undefined,
+        pageSize:
+          pagination.pageSize !== DEFAULT_PAGE_SIZE
+            ? pagination.pageSize
+            : undefined,
+        q: globalFilter || undefined,
+        status:
+          Array.isArray(statusFilter?.value) && statusFilter.value.length
+            ? statusFilter.value.join(',')
+            : undefined,
+        site:
+          Array.isArray(siteFilter?.value) && siteFilter.value.length
+            ? siteFilter.value.join(',')
+            : undefined,
+      },
+      replace: true,
+    })
+  }, [pagination, globalFilter, columnFilters, navigate])
 
   // onChange wrappers that reset to the first page on filter changes.
   const onGlobalFilterChange = useMemo<OnChangeFn<string>>(

--- a/web/src/features/checkin/__tests__/checkin-schema.test.ts
+++ b/web/src/features/checkin/__tests__/checkin-schema.test.ts
@@ -1,13 +1,11 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import {
-  buildCheckinSearchString,
   buildInitialCheckinLogsQuery,
   checkinSearchSchema,
   getCheckinSearchDefaultValues,
   parseCheckinSearch,
   parseFilterValues,
-  readCheckinSearchFromUrl,
 } from '../lib/checkin-schema'
 
 // ---------------------------------------------------------------------------
@@ -87,95 +85,6 @@ describe('parseFilterValues', () => {
     expect(parseFilterValues(undefined)).toEqual([])
     expect(parseFilterValues('')).toEqual([])
     expect(parseFilterValues('   ')).toEqual([])
-  })
-})
-
-// ---------------------------------------------------------------------------
-// buildCheckinSearchString
-// ---------------------------------------------------------------------------
-
-describe('buildCheckinSearchString', () => {
-  it('returns an empty string for the default page state', () => {
-    expect(
-      buildCheckinSearchString({
-        pageIndex: 0,
-        pageSize: 20,
-        statusValues: [],
-        reasonValues: [],
-        siteValues: [],
-      })
-    ).toBe('')
-  })
-
-  it('omits page on the first index and pageSize when it equals 20', () => {
-    const result = buildCheckinSearchString({
-      pageIndex: 0,
-      pageSize: 20,
-      statusValues: ['ok', 'fail'],
-      reasonValues: [],
-      siteValues: [],
-    })
-    const params = new URLSearchParams(result.slice(1))
-    expect(params.get('page')).toBeNull()
-    expect(params.get('pageSize')).toBeNull()
-    expect(params.get('status')).toBe('ok,fail')
-  })
-
-  it('writes page as pageIndex+1 and the pageSize when it differs from 20', () => {
-    const result = buildCheckinSearchString({
-      pageIndex: 2,
-      pageSize: 50,
-      statusValues: [],
-      reasonValues: [],
-      siteValues: [],
-      query: 'x',
-    })
-    const params = new URLSearchParams(result.slice(1))
-    expect(params.get('page')).toBe('3')
-    expect(params.get('pageSize')).toBe('50')
-    expect(params.get('q')).toBe('x')
-  })
-
-  it('emits accountId and date-range fields when provided', () => {
-    const result = buildCheckinSearchString({
-      pageIndex: 0,
-      pageSize: 20,
-      accountId: 42,
-      statusValues: [],
-      reasonValues: [],
-      siteValues: [],
-      from: '2026-01-01T00:00',
-      to: '2026-01-02T00:00',
-    })
-    const params = new URLSearchParams(result.slice(1))
-    expect(params.get('accountId')).toBe('42')
-    expect(params.get('from')).toBe('2026-01-01T00:00')
-    expect(params.get('to')).toBe('2026-01-02T00:00')
-  })
-})
-
-// ---------------------------------------------------------------------------
-// readCheckinSearchFromUrl
-// ---------------------------------------------------------------------------
-
-describe('readCheckinSearchFromUrl', () => {
-  afterEach(() => {
-    // Reset the URL so later suites see a clean location.
-    history.replaceState({}, '', '/')
-  })
-
-  it('parses a valid query string from window.location.search', () => {
-    history.replaceState({}, '', '/?page=3&status=ok,fail')
-    const result = readCheckinSearchFromUrl()
-    expect(result.page).toBe(3)
-    expect(result.status).toBe('ok,fail')
-  })
-
-  it('falls back to defaults when the query string is invalid', () => {
-    history.replaceState({}, '', '/?page=abc&pageSize=999')
-    const result = readCheckinSearchFromUrl()
-    expect(result.page).toBe(1)
-    expect(result.pageSize).toBe(20)
   })
 })
 

--- a/web/src/features/checkin/components/checkin-page.tsx
+++ b/web/src/features/checkin/components/checkin-page.tsx
@@ -7,13 +7,14 @@
 // search filters see the full log history instead of the legacy 500-row
 // client cap that silently dropped older records.
 
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import type {
   ColumnFiltersState,
   OnChangeFn,
   PaginationState,
 } from '@tanstack/react-table'
 import { CalendarRange, Loader2, RotateCw, Zap } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { DataTablePage, useDataTable } from '@/components/data-table'
@@ -32,9 +33,8 @@ import { toast } from '@/lib/toast'
 
 import { useCheckinAccount, useCheckinLogs, useManualCheckin } from '../api'
 import {
-  buildCheckinSearchString,
+  DEFAULT_CHECKIN_PAGE_SIZE,
   parseFilterValues,
-  readCheckinSearchFromUrl,
 } from '../lib/checkin-schema'
 import { localDatetimeInputToUtcRfc3339 } from '../lib/checkin-time'
 import { type CheckinLogRow, checkinLogRowSchema } from '../types'
@@ -46,27 +46,31 @@ const ACCOUNT_FILTER_ALL = 'all'
 
 export function CheckinPage() {
   const { t } = useTranslation()
-  const initial = useMemo(readCheckinSearchFromUrl, [])
+  // URL state is owned by the router: read the validated search via
+  // `useSearch` (no `window.location.search`), write changes back via
+  // `navigate({ search, replace: true })` (no `history.replaceState`).
+  const search = useSearch({ from: '/_authenticated/checkin' })
+  const navigate = useNavigate()
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: initial.page - 1,
-    pageSize: initial.pageSize,
+    pageIndex: search.page - 1,
+    pageSize: search.pageSize,
   })
-  const [globalFilter, setGlobalFilter] = useState(initial.q ?? '')
+  const [globalFilter, setGlobalFilter] = useState(search.q ?? '')
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(() => {
     const filters: ColumnFiltersState = []
-    const statusValues = parseFilterValues(initial.status)
+    const statusValues = parseFilterValues(search.status)
     if (statusValues.length) filters.push({ id: 'status', value: statusValues })
-    const reasonValues = parseFilterValues(initial.reason)
+    const reasonValues = parseFilterValues(search.reason)
     if (reasonValues.length) filters.push({ id: 'reason', value: reasonValues })
-    const siteValues = parseFilterValues(initial.site)
+    const siteValues = parseFilterValues(search.site)
     if (siteValues.length) filters.push({ id: 'site', value: siteValues })
     return filters
   })
   const [accountId, setAccountId] = useState<number | undefined>(
-    initial.accountId
+    search.accountId
   )
-  const [from, setFrom] = useState(initial.from ?? '')
-  const [to, setTo] = useState(initial.to ?? '')
+  const [from, setFrom] = useState(search.from ?? '')
+  const [to, setTo] = useState(search.to ?? '')
 
   const { data: accountsSnapshot } = useAccounts()
   const accountOptions = accountsSnapshot?.accounts ?? []
@@ -144,30 +148,43 @@ export function CheckinPage() {
   const logs = useMemo(() => logsPage?.items ?? [], [logsPage])
   const total = logsPage?.total ?? 0
 
+  // Write state back to the URL through the router (single source of truth).
+  // Skip the initial write — the URL already holds the search the state was
+  // initialised from.
+  const skipInitialWrite = useRef(true)
   useEffect(() => {
-    if (typeof window === 'undefined') return
-    const query = buildCheckinSearchString({
-      pageIndex: pagination.pageIndex,
-      pageSize: pagination.pageSize,
-      accountId,
-      statusValues,
-      reasonValues,
-      siteValues,
-      from: from || undefined,
-      to: to || undefined,
-      query: globalFilter || undefined,
+    if (skipInitialWrite.current) {
+      skipInitialWrite.current = false
+      return
+    }
+    navigate({
+      to: '/checkin',
+      search: {
+        page: pagination.pageIndex > 0 ? pagination.pageIndex + 1 : undefined,
+        pageSize:
+          pagination.pageSize !== DEFAULT_CHECKIN_PAGE_SIZE
+            ? pagination.pageSize
+            : undefined,
+        accountId: accountId || undefined,
+        status: statusValues.length ? statusValues.join(',') : undefined,
+        reason: reasonValues.length ? reasonValues.join(',') : undefined,
+        site: siteValues.length ? siteValues.join(',') : undefined,
+        from: from || undefined,
+        to: to || undefined,
+        q: globalFilter || undefined,
+      },
+      replace: true,
     })
-    window.history.replaceState(null, '', `${window.location.pathname}${query}`)
   }, [
     pagination,
     accountId,
-    columnFilters,
     from,
     to,
     globalFilter,
     statusValues,
     reasonValues,
     siteValues,
+    navigate,
   ])
 
   const onGlobalFilterChange = useMemo<OnChangeFn<string>>(

--- a/web/src/features/checkin/lib/checkin-schema.ts
+++ b/web/src/features/checkin/lib/checkin-schema.ts
@@ -5,16 +5,16 @@
 //
 // The `/checkin` route file registers this schema via `validateSearch`, and
 // its loader parses the router's `location.searchStr` with
-// `parseCheckinSearch`. The page still parses `window.location.search`
-// directly via `readCheckinSearchFromUrl` for its client-only state
-// initialisation (both share `parseCheckinSearch` underneath).
+// `parseCheckinSearch`. The page reads the validated search via `useSearch`
+// and writes changes back via `navigate({ search, replace: true })` — the
+// router owns URL state end to end.
 
 import { z } from 'zod'
 
 import type { CheckinLogsQuery } from '../types'
 import { localDatetimeInputToUtcRfc3339 } from './checkin-time'
 
-const DEFAULT_CHECKIN_PAGE_SIZE = 20
+export const DEFAULT_CHECKIN_PAGE_SIZE = 20
 
 // ---------------------------------------------------------------------------
 // URL search schema
@@ -58,16 +58,6 @@ export function parseCheckinSearch(searchStr: string): CheckinSearch {
 }
 
 /**
- * Parse `window.location.search` into a validated CheckinSearch (the page's
- * client-only entry point). Returns defaults on any validation failure so
- * the page always boots into a known state.
- */
-export function readCheckinSearchFromUrl(): CheckinSearch {
-  if (typeof window === 'undefined') return getCheckinSearchDefaultValues()
-  return parseCheckinSearch(window.location.search)
-}
-
-/**
  * Split a comma-separated filter string into a trimmed string array.
  */
 export function parseFilterValues(value: string | undefined): string[] {
@@ -76,43 +66,6 @@ export function parseFilterValues(value: string | undefined): string[] {
     .split(',')
     .map((item) => item.trim())
     .filter(Boolean)
-}
-
-/**
- * Build the query string for the current page state (used to write state
- * back to the URL via history.replaceState).
- */
-export function buildCheckinSearchString(params: {
-  pageIndex: number
-  pageSize: number
-  accountId?: number
-  statusValues: string[]
-  reasonValues: string[]
-  siteValues: string[]
-  from?: string
-  to?: string
-  query?: string
-}): string {
-  const search = new URLSearchParams()
-  if (params.pageIndex > 0) search.set('page', String(params.pageIndex + 1))
-  if (params.pageSize !== DEFAULT_CHECKIN_PAGE_SIZE) {
-    search.set('pageSize', String(params.pageSize))
-  }
-  if (params.accountId) search.set('accountId', String(params.accountId))
-  if (params.statusValues.length) {
-    search.set('status', params.statusValues.join(','))
-  }
-  if (params.reasonValues.length) {
-    search.set('reason', params.reasonValues.join(','))
-  }
-  if (params.siteValues.length) {
-    search.set('site', params.siteValues.join(','))
-  }
-  if (params.from) search.set('from', params.from)
-  if (params.to) search.set('to', params.to)
-  if (params.query) search.set('q', params.query)
-  const query = search.toString()
-  return query ? `?${query}` : ''
 }
 
 /**

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -2,9 +2,10 @@
 // metapi-go/features/proxy-logs/components — proxy logs list page.
 // i18n: all user-visible strings migrated to t() calls.
 
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import type { OnChangeFn, PaginationState } from '@tanstack/react-table'
 import { Download as DownloadIcon, RefreshCw } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { DataTablePage, useDataTable } from '@/components/data-table'
@@ -21,10 +22,7 @@ import { api } from '@/lib/api'
 import { toast } from '@/lib/toast'
 
 import { useProxyLogs, useProxyLogsMeta } from '../api'
-import {
-  PROXY_LOG_STATUS_FILTER_OPTIONS,
-  proxyLogsSearchSchema,
-} from '../lib/proxy-logs-schema'
+import { PROXY_LOG_STATUS_FILTER_OPTIONS } from '../lib/proxy-logs-schema'
 import { useProxyLogsAutoRefresh } from '../lib/use-proxy-logs-auto-refresh'
 import type { ProxyLog, ProxyLogFilters } from '../types'
 import { LatencyBadge } from './latency-badge'
@@ -42,139 +40,62 @@ const PROXY_LOGS_COLUMN_SIZING_STORAGE_KEY =
 const DEFAULT_PAGE_SIZE = 20
 const PROXY_LOGS_CSV_EXPORT_LIMIT = 10_000
 
-type ResolvedUrlState = {
-  pageIndex: number
-  pageSize: number
-  search: string
-  status: ProxyLogFilters['status']
-  siteId: number | null
-  client: string
-  from: string
-  to: string
-  latencyMin: number | null
-  latencyMax: number | null
-}
-
-function readUrlState(): ResolvedUrlState {
-  if (typeof window === 'undefined') {
-    return {
-      pageIndex: 0,
-      pageSize: DEFAULT_PAGE_SIZE,
-      search: '',
-      status: 'all',
-      siteId: null,
-      client: '',
-      from: '',
-      to: '',
-      latencyMin: null,
-      latencyMax: null,
-    }
-  }
-  const params = new URLSearchParams(window.location.search)
-  const parsed = proxyLogsSearchSchema.safeParse({
-    q: params.get('q') ?? undefined,
-    page: params.get('page') ?? undefined,
-    pageSize: params.get('pageSize') ?? undefined,
-    status: params.get('status') ?? undefined,
-    siteId: params.get('siteId') ?? undefined,
-    client: params.get('client') ?? undefined,
-    from: params.get('from') ?? undefined,
-    to: params.get('to') ?? undefined,
-    latencyMin: params.get('latencyMin') ?? undefined,
-    latencyMax: params.get('latencyMax') ?? undefined,
-  })
-  if (!parsed.success) {
-    return {
-      pageIndex: 0,
-      pageSize: DEFAULT_PAGE_SIZE,
-      search: '',
-      status: 'all',
-      siteId: null,
-      client: '',
-      from: '',
-      to: '',
-      latencyMin: null,
-      latencyMax: null,
-    }
-  }
-  const data = parsed.data
-  return {
-    pageIndex: data.page ?? 0,
-    pageSize: data.pageSize ?? DEFAULT_PAGE_SIZE,
-    search: data.q ?? '',
-    status: data.status ?? 'all',
-    siteId: data.siteId ?? null,
-    client: data.client ?? '',
-    from: data.from ?? '',
-    to: data.to ?? '',
-    latencyMin: data.latencyMin ?? null,
-    latencyMax: data.latencyMax ?? null,
-  }
-}
-
-function writeUrlState(state: ResolvedUrlState) {
-  if (typeof window === 'undefined') return
-  const params = new URLSearchParams()
-  if (state.search) params.set('q', state.search)
-  if (state.pageIndex > 0) params.set('page', String(state.pageIndex))
-  if (state.pageSize !== DEFAULT_PAGE_SIZE) {
-    params.set('pageSize', String(state.pageSize))
-  }
-  if (state.status && state.status !== 'all') params.set('status', state.status)
-  if (state.siteId !== null) params.set('siteId', String(state.siteId))
-  if (state.client) params.set('client', state.client)
-  if (state.from) params.set('from', state.from)
-  if (state.to) params.set('to', state.to)
-  if (state.latencyMin !== null) {
-    params.set('latencyMin', String(state.latencyMin))
-  }
-  if (state.latencyMax !== null) {
-    params.set('latencyMax', String(state.latencyMax))
-  }
-  const query = params.toString()
-  const url = query
-    ? `${window.location.pathname}?${query}`
-    : window.location.pathname
-  window.history.replaceState(null, '', url)
-}
-
 export function ProxyLogsPage() {
   const { t } = useTranslation()
-  const initial = useMemo(readUrlState, [])
+  // URL state is owned by the router: read the validated search via
+  // `useSearch` (no `window.location.search`), write changes back via
+  // `navigate({ search, replace: true })` (no `history.replaceState`).
+  const urlSearch = useSearch({ from: '/_authenticated/proxy-logs' })
+  const navigate = useNavigate()
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: initial.pageIndex,
-    pageSize: initial.pageSize,
+    pageIndex: urlSearch.page ?? 0,
+    pageSize: urlSearch.pageSize ?? DEFAULT_PAGE_SIZE,
   })
-  const [search, setSearch] = useState(initial.search)
+  const [search, setSearch] = useState(urlSearch.q ?? '')
   const [status, setStatus] = useState<ProxyLogFilters['status']>(
-    initial.status
+    urlSearch.status ?? 'all'
   )
-  const [siteId, setSiteId] = useState<number | null>(initial.siteId)
-  const [client, setClient] = useState(initial.client)
-  const [from, setFrom] = useState(initial.from)
-  const [to, setTo] = useState(initial.to)
+  const [siteId, setSiteId] = useState<number | null>(urlSearch.siteId ?? null)
+  const [client, setClient] = useState(urlSearch.client ?? '')
+  const [from, setFrom] = useState(urlSearch.from ?? '')
+  const [to, setTo] = useState(urlSearch.to ?? '')
   const [latencyMin, setLatencyMin] = useState<number | null>(
-    initial.latencyMin
+    urlSearch.latencyMin ?? null
   )
   const [latencyMax, setLatencyMax] = useState<number | null>(
-    initial.latencyMax
+    urlSearch.latencyMax ?? null
   )
   const [detailLog, setDetailLog] = useState<ProxyLog | null>(null)
   const [detailOpen, setDetailOpen] = useState(false)
   const [isExporting, setIsExporting] = useState(false)
 
+  // Write state back to the URL through the router (single source of truth).
+  // Skip the initial write — the URL already holds the search the state was
+  // initialised from.
+  const skipInitialWrite = useRef(true)
   useEffect(() => {
-    writeUrlState({
-      pageIndex: pagination.pageIndex,
-      pageSize: pagination.pageSize,
-      search,
-      status,
-      siteId,
-      client,
-      from,
-      to,
-      latencyMin,
-      latencyMax,
+    if (skipInitialWrite.current) {
+      skipInitialWrite.current = false
+      return
+    }
+    navigate({
+      to: '/proxy-logs',
+      search: {
+        page: pagination.pageIndex > 0 ? pagination.pageIndex : undefined,
+        pageSize:
+          pagination.pageSize !== DEFAULT_PAGE_SIZE
+            ? pagination.pageSize
+            : undefined,
+        q: search || undefined,
+        status: status !== 'all' ? status : undefined,
+        siteId: siteId ?? undefined,
+        client: client || undefined,
+        from: from || undefined,
+        to: to || undefined,
+        latencyMin: latencyMin ?? undefined,
+        latencyMax: latencyMax ?? undefined,
+      },
+      replace: true,
     })
   }, [
     pagination,
@@ -186,6 +107,7 @@ export function ProxyLogsPage() {
     to,
     latencyMin,
     latencyMax,
+    navigate,
   ])
 
   const queryPayload = useMemo(

--- a/web/src/features/token-routes/components/routes-page.tsx
+++ b/web/src/features/token-routes/components/routes-page.tsx
@@ -2,6 +2,7 @@
 // metapi-go features/token-routes/components — the routes list page.
 // i18n: all user-visible strings migrated to t() calls.
 
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import type {
   ColumnFiltersState,
   OnChangeFn,
@@ -9,7 +10,7 @@ import type {
   Table,
 } from '@tanstack/react-table'
 import { Loader2, Plus, Power, RefreshCw, Zap } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -50,40 +51,15 @@ import { RouteDetailSheet } from './route-detail-sheet'
 import { RouteFormDialog, type RouteAccountOption } from './route-form-dialog'
 import { useRoutesColumns } from './routes-columns'
 
-interface InitialUrlState {
-  page: number
-  pageSize: number
-  search: string
-  enabled: string[]
-  accountId?: number
-  siteId?: number
-}
-
 const DEFAULT_PAGE_SIZE = 20
-
-function readInitialFromUrl(): InitialUrlState {
-  if (typeof window === 'undefined') {
-    return { page: 1, pageSize: DEFAULT_PAGE_SIZE, search: '', enabled: [] }
-  }
-  const params = new URLSearchParams(window.location.search)
-  const page = Math.max(1, Number(params.get('page')) || 1)
-  const pageSize = Number(params.get('pageSize')) || DEFAULT_PAGE_SIZE
-  const search = params.get('q') ?? ''
-  const enabled = params.get('enabled')?.split(',').filter(Boolean) ?? []
-  const accountIdRaw = Number(params.get('accountId'))
-  const siteIdRaw = Number(params.get('siteId'))
-  return {
-    page,
-    pageSize,
-    search,
-    enabled,
-    accountId: accountIdRaw > 0 ? accountIdRaw : undefined,
-    siteId: siteIdRaw > 0 ? siteIdRaw : undefined,
-  }
-}
 
 export function RoutesPage() {
   const { t } = useTranslation()
+  // URL state is owned by the router: read the validated search via
+  // `useSearch` (no `window.location.search`), write changes back via
+  // `navigate({ search, replace: true })` (no `history.replaceState`).
+  const urlSearch = useSearch({ from: '/_authenticated/token-routes' })
+  const navigate = useNavigate()
   const { data: routesData, isLoading, isFetching, error } = useRoutes()
   const candidatesQuery = useModelTokenCandidates()
 
@@ -96,57 +72,59 @@ export function RoutesPage() {
   const routes = useMemo(() => routesData ?? [], [routesData])
   const candidates = candidatesQuery.data
 
+  // Chain context (account/site deep-link) is fixed for the session — read
+  // once from the validated search.
+  const accountId = urlSearch.accountId
+  const siteId = urlSearch.siteId
+
   const [showZeroChannel, setShowZeroChannel] = useState(false)
   const rows = useZeroChannelRoutes(routes, candidates, showZeroChannel)
 
-  const initial = useMemo(readInitialFromUrl, [])
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: initial.page - 1,
-    pageSize: initial.pageSize,
+    pageIndex: (urlSearch.page ?? 1) - 1,
+    pageSize: urlSearch.pageSize ?? DEFAULT_PAGE_SIZE,
   })
-  const [globalFilter, setGlobalFilter] = useState(initial.search)
+  const [globalFilter, setGlobalFilter] = useState(urlSearch.q ?? '')
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(() => {
     const filters: ColumnFiltersState = []
-    if (initial.enabled.length) {
-      filters.push({ id: 'enabled', value: initial.enabled })
+    const enabledValues = urlSearch.enabled?.split(',').filter(Boolean) ?? []
+    if (enabledValues.length) {
+      filters.push({ id: 'enabled', value: enabledValues })
     }
     return filters
   })
 
+  // Write state back to the URL through the router (single source of truth).
+  // Skip the initial write — the URL already holds the search the state was
+  // initialised from.
+  const skipInitialWrite = useRef(true)
   useEffect(() => {
-    if (typeof window === 'undefined') return
-    const params = new URLSearchParams()
-    if (pagination.pageIndex > 0) {
-      params.set('page', String(pagination.pageIndex + 1))
+    if (skipInitialWrite.current) {
+      skipInitialWrite.current = false
+      return
     }
-    if (pagination.pageSize !== DEFAULT_PAGE_SIZE) {
-      params.set('pageSize', String(pagination.pageSize))
-    }
-    if (globalFilter) params.set('q', globalFilter)
     const enabledFilter = columnFilters.find(
       (filter) => filter.id === 'enabled'
     )
-    if (
-      enabledFilter &&
-      Array.isArray(enabledFilter.value) &&
-      enabledFilter.value.length
-    ) {
-      params.set('enabled', enabledFilter.value.join(','))
-    }
-    if (initial.accountId) params.set('accountId', String(initial.accountId))
-    if (initial.siteId) params.set('siteId', String(initial.siteId))
-    const query = params.toString()
-    const url = query
-      ? `${window.location.pathname}?${query}`
-      : window.location.pathname
-    window.history.replaceState(null, '', url)
-  }, [
-    pagination,
-    globalFilter,
-    columnFilters,
-    initial.accountId,
-    initial.siteId,
-  ])
+    navigate({
+      to: '/token-routes',
+      search: {
+        page: pagination.pageIndex > 0 ? pagination.pageIndex + 1 : undefined,
+        pageSize:
+          pagination.pageSize !== DEFAULT_PAGE_SIZE
+            ? pagination.pageSize
+            : undefined,
+        q: globalFilter || undefined,
+        enabled:
+          Array.isArray(enabledFilter?.value) && enabledFilter.value.length
+            ? enabledFilter.value.join(',')
+            : undefined,
+        accountId,
+        siteId,
+      },
+      replace: true,
+    })
+  }, [pagination, globalFilter, columnFilters, accountId, siteId, navigate])
 
   const onGlobalFilterChange = useMemo<OnChangeFn<string>>(
     () => (updater) => {
@@ -255,10 +233,10 @@ export function RoutesPage() {
 
   const chainContext = useMemo(
     () => ({
-      accountId: initial.accountId,
-      siteId: initial.siteId,
+      accountId,
+      siteId,
     }),
-    [initial.accountId, initial.siteId]
+    [accountId, siteId]
   )
 
   const confirmDelete = async () => {
@@ -315,14 +293,14 @@ export function RoutesPage() {
         </div>
       </div>
 
-      {(initial.accountId || initial.siteId) && (
+      {(accountId || siteId) && (
         <div className='bg-muted/40 text-muted-foreground rounded-lg border p-2 text-sm'>
           {t('tokenRoutes.page.chainContext')}
-          {initial.accountId
-            ? ` ${t('tokenRoutes.page.chainContextAccount', { id: initial.accountId })}`
+          {accountId
+            ? ` ${t('tokenRoutes.page.chainContextAccount', { id: accountId })}`
             : ''}
-          {initial.siteId
-            ? ` / ${t('tokenRoutes.page.chainContextSite', { id: initial.siteId })} `
+          {siteId
+            ? ` / ${t('tokenRoutes.page.chainContextSite', { id: siteId })} `
             : ' '}
           {t('tokenRoutes.page.chainContextSuffix')}
         </div>

--- a/web/src/features/token-routes/lib/routes-schema.ts
+++ b/web/src/features/token-routes/lib/routes-schema.ts
@@ -184,7 +184,10 @@ export function transformRouteToFormValues(
 
 export const routesSearchSchema = z.object({
   q: z.string().optional(),
-  enabled: z.enum(['all', 'enabled', 'disabled']).optional(),
+  // The page encodes the enabled filter as a comma-separated string
+  // (`enabled,disabled`), so the schema accepts a raw string and the page
+  // splits it — a single enum would reject the page's own writes.
+  enabled: z.string().optional(),
   site: z.string().optional(),
   accountId: z.coerce.number().int().positive().optional(),
   siteId: z.coerce.number().int().positive().optional(),

--- a/web/src/routes/_authenticated/checkin.tsx
+++ b/web/src/routes/_authenticated/checkin.tsx
@@ -4,9 +4,8 @@
 // checkin page). The schema carries `.default()` values for page / pageSize;
 // with TanStack Router's default (non-strict) search handling these defaults
 // populate the validated `search` object passed to the loader / `useSearch()`
-// but are NOT written back to the URL, so the page's own
-// `window.location.search` reads (via `readCheckinSearchFromUrl`) stay
-// consistent.
+// but are NOT written back to the URL — the page reads that same `search` and
+// writes changes back via `navigate({ search, replace: true })`.
 //
 // `loader` prefetches the first server-paginated checkin-logs page the page's
 // `useCheckinLogs` hook will request. It builds the exact same


### PR DESCRIPTION
## Summary

完成 **T1（URL 状态统一）的页面级迁移**（#732 收尾）。此前 #744 已迁移 loader 到 `location.searchStr`，本 PR 把 4 个列表页（accounts / checkin / token-routes / proxy-logs）从「`window.location.search` 直读 + `history.replaceState` 直写」迁移到路由单一真值：

- **读**：`useSearch({ from: route })`（校验后的类型化 search）
- **写**：`navigate({ search, replace: true })`（`skipInitialWrite` ref 跳过首帧冗余导航）

## 顺带修正的不一致

- **checkin**：`buildCheckinSearchString` + `readCheckinSearchFromUrl` 迁移后成为死代码，一并删除（loader 已用 `parseCheckinSearch(location.searchStr)`）。
- **token-routes schema**：`enabled` 原本是 `z.enum(['all','enabled','disabled'])`，但页面把它编码成逗号分隔字符串（`enabled,disabled`）——一旦走 `navigate` 会被自己的 enum 拒绝。改为 `z.string()`，行为对齐页面。

## 验证

- typecheck / lint / knip / format 全绿
- build 通过
- 测试 338/338（移除了 6 个死代码测试）

## 说明

这是 spec-driven WEB-ARCH 里程碑（#732–#740）中 P0 任务 T1 的收尾。此前已合并 T1-loader（#744）、T2（#745）、T3（#745）、标题/notFound（#747）。剩余 T4–T9（动效/RTL/FOUC/图标/交互原语/文档）属 Phase 2。