### PR TITLE
refactor(web): unify motion + RTL dir ownership + FOUC bootstrap alignment (P2-B1)

### DIFF
--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -31,7 +31,7 @@ function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
     <SheetPrimitive.Backdrop
       data-slot='sheet-overlay'
       className={cn(
-        'fixed inset-0 z-50 bg-overlay transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs',
+        'data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 z-50 bg-overlay duration-150 supports-backdrop-filter:backdrop-blur-xs',
         className
       )}
       {...props}
@@ -62,15 +62,15 @@ function SheetContent({
         data-slot='sheet-content'
         data-side={side}
         className={cn(
-          'bg-background text-foreground fixed z-50 flex flex-col gap-4 overflow-hidden bg-clip-padding text-sm shadow-none transition duration-200 ease-in-out data-ending-style:opacity-0 data-starting-style:opacity-0',
+          'bg-background text-foreground data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed z-50 flex flex-col gap-4 overflow-hidden bg-clip-padding text-sm shadow-none duration-200',
           side === 'right' &&
-            'inset-y-0 right-0 h-full w-3/4 border-l data-ending-style:translate-x-[2.5rem] data-starting-style:translate-x-[2.5rem] sm:max-w-sm',
+            'inset-y-0 right-0 h-full w-3/4 border-l data-open:slide-in-from-right data-closed:slide-out-to-right sm:max-w-sm',
           side === 'left' &&
-            'inset-y-0 left-0 h-full w-3/4 border-r data-ending-style:translate-x-[-2.5rem] data-starting-style:translate-x-[-2.5rem] sm:max-w-sm',
+            'inset-y-0 left-0 h-full w-3/4 border-r data-open:slide-in-from-left data-closed:slide-out-to-left sm:max-w-sm',
           side === 'top' &&
-            'inset-x-0 top-0 h-auto border-b data-ending-style:translate-y-[-2.5rem] data-starting-style:translate-y-[-2.5rem]',
+            'inset-x-0 top-0 h-auto border-b data-open:slide-in-from-top data-closed:slide-out-to-top',
           side === 'bottom' &&
-            'inset-x-0 bottom-0 h-auto border-t data-ending-style:translate-y-[2.5rem] data-starting-style:translate-y-[2.5rem]',
+            'inset-x-0 bottom-0 h-auto border-t data-open:slide-in-from-bottom data-closed:slide-out-to-bottom',
           className
         )}
         {...props}

--- a/web/src/i18n/__tests__/language-switcher.test.tsx
+++ b/web/src/i18n/__tests__/language-switcher.test.tsx
@@ -1,7 +1,8 @@
 // metapi-go/i18n — language switcher integration test.
 // Drives the real AppHeader dropdown against the real i18n instance
 // (config.ts side-effect init) and asserts the active language, the
-// localStorage persistence and the <html lang>/dir sync.
+// localStorage persistence and the <html lang> sync. `dir` is owned by
+// DirectionProvider, so a language change must NOT touch it.
 
 import '@testing-library/jest-dom/vitest'
 import {
@@ -98,13 +99,16 @@ describe('language switcher', () => {
 
   it('switches i18n.language to zhCN and syncs <html lang> on click', async () => {
     renderHeader()
+    // Simulate an RTL user's direction choice — the language change must NOT
+    // clobber it (dir is owned by DirectionProvider, not the i18n layer).
+    document.documentElement.dir = 'rtl'
 
     fireEvent.click(screen.getByRole('button', { name: 'Language' }))
     fireEvent.click(await screen.findByRole('menuitem', { name: '简体中文' }))
 
     await waitFor(() => expect(i18n.language).toBe('zhCN'))
     expect(document.documentElement.lang).toBe('zh-CN')
-    expect(document.documentElement.dir).toBe('ltr')
+    expect(document.documentElement.dir).toBe('rtl')
 
     // The detector caches the choice in localStorage for next visit.
     expect(localStorage.getItem('i18nextLng')).toBe('zhCN')

--- a/web/src/i18n/config.ts
+++ b/web/src/i18n/config.ts
@@ -42,12 +42,13 @@ i18n
 
 /**
  * Keep `<html lang>` in sync with the active language so assistive tech,
- * spell checkers and locale-aware tooling see the current BCP-47 tag. Both
- * supported languages are LTR, so dir stays pinned to ltr.
+ * spell checkers and locale-aware tooling see the current BCP-47 tag.
+ * `dir` is intentionally NOT touched here — `DirectionProvider` is the single
+ * owner of the direction attribute (a language change must not clobber an
+ * RTL user's direction cookie).
  */
 function syncDocumentLanguage(language: string): void {
   document.documentElement.lang = toBcp47(language)
-  document.documentElement.dir = 'ltr'
 }
 
 i18n.on('languageChanged', syncDocumentLanguage)

--- a/web/src/styles/__tests__/fouc-bootstrap.test.ts
+++ b/web/src/styles/__tests__/fouc-bootstrap.test.ts
@@ -1,0 +1,55 @@
+// metapi-go FOUC bootstrap alignment gate.
+// index.html ships inline bootstrap scripts that set `data-theme-*` attributes
+// before first paint. The hardcoded allowlists in those scripts must stay in
+// sync with the theme constants (`THEME_PRESETS` / radius / scale) — a new
+// value added to the constants but forgotten here would flash the default
+// theme for one frame before React mounts.
+
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  THEME_PRESETS,
+  THEME_RADIUS_VALUES,
+  THEME_SCALE_VALUES,
+} from '../../lib/theme-customization'
+
+const WEB_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+const indexHtml = readFileSync(join(WEB_ROOT, 'index.html'), 'utf8')
+
+/** Extract the string literals of the first capture group of `regex`. */
+function extractStringList(regex: RegExp): string[] {
+  const match = indexHtml.match(regex)
+  expect(match).toBeTruthy()
+  const body = match?.[1] ?? ''
+  return [...body.matchAll(/'([^']+)'/g)].map((m) => m[1])
+}
+
+const isNotDefault = (value: string) => value !== 'default'
+
+describe('FOUC bootstrap ↔ theme constants', () => {
+  it('preset allowlist matches THEME_PRESETS minus the default preset', () => {
+    const bootstrapPresets = extractStringList(/var presets = \[([\s\S]*?)\]/)
+    const expected = THEME_PRESETS.map((p) => p.value).filter(isNotDefault)
+    expect(bootstrapPresets).toEqual(expected)
+  })
+
+  it('radius allowlist matches THEME_RADIUS_VALUES minus default', () => {
+    const bootstrapRadii = extractStringList(
+      /\[('none'[^\]]*)\]\.indexOf\(radius\)/
+    )
+    const expected = [...THEME_RADIUS_VALUES].filter(isNotDefault)
+    expect(bootstrapRadii).toEqual(expected)
+  })
+
+  it('scale allowlist matches THEME_SCALE_VALUES minus default', () => {
+    const bootstrapScales = extractStringList(
+      /\[('sm'[^\]]*)\]\.indexOf\(scale\)/
+    )
+    const expected = [...THEME_SCALE_VALUES].filter(isNotDefault)
+    expect(bootstrapScales).toEqual(expected)
+  })
+})

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -529,3 +529,22 @@
     animation: none !important;
   }
 }
+
+/*
+ * Global reduced-motion safety net for the shared tw-animate-css enter/exit
+ * animations (dialog / sheet / alert-dialog / select / tooltip / popover /
+ * dropdown-menu / context-menu) and Base UI transitions, which have no
+ * dedicated per-class selector above. Collapses every animation + transition
+ * to near-instant (and stops infinite spinners after one iteration) so
+ * `prefers-reduced-motion: reduce` users see no motion anywhere.
+ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary

WEB-ARCH 里程碑 Phase 2 · P2-B1（T4 动效 + T5 RTL + T6 FOUC）——三个单一职责的收敛：

1. **T4 动效统一** — `sheet` 是唯一用 Base UI `data-starting-style`/`data-ending-style` 的组件，而 dialog / select / tooltip / popover / dropdown / context-menu 都走 tw-animate-css。把 sheet 收敛到同一套 tw-animate-css 进出场（overlay fade + 按侧 slide），动效体系二选一完成。并加了一条全局 `prefers-reduced-motion: reduce` 兜底，把所有动画/过渡（tw-animate-css + Base UI + 自定义 keyframe）压成近瞬时。
2. **T5 RTL 归属** — `syncDocumentLanguage` 不再把 `<html dir>` 钉死成 `ltr`；`DirectionProvider` 成为方向属性的唯一归属，语言切换不再覆盖 RTL 用户的方向 cookie。
3. **T6 FOUC 对齐** — 新增 gate 测试，断言 `index.html` 内联 bootstrap 的 allowlist（preset / radius / scale）与 `THEME_PRESETS` / `THEME_RADIUS_VALUES` / `THEME_SCALE_VALUES` 保持一致，新增常量不会再与首屏 bootstrap 漂移。

## 验证

- typecheck / lint / knip / format 全绿
- build 通过
- 测试 341/341（新增 fouc-bootstrap gate 3 例；language-switcher 更新为断言 dir 不被覆盖）

Ref: spec-driven WEB-ARCH 里程碑，Phase 1（#744/#745/#751/#747）已合并；本 PR 为 Phase 2 第一批。