### PR TITLE
fix: propagate errors in token_routes CRUD, usage_aggregation, and row scans

### DIFF
--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -429,7 +429,10 @@ func (h *tokenRoutesHandler) createRoute(w http.ResponseWriter, r *http.Request)
 	// For explicit_group, insert source route references
 	if routeMode == "explicit_group" && len(body.SourceRouteIds) > 0 {
 		for _, srcID := range body.SourceRouteIds {
-			h.db.Exec(h.db.Rebind("INSERT INTO route_group_sources (group_route_id, source_route_id) VALUES (?, ?)"), id, srcID)
+			if _, err := h.db.Exec(h.db.Rebind("INSERT INTO route_group_sources (group_route_id, source_route_id) VALUES (?, ?)"), id, srcID); err != nil {
+				writeErrorWithRequest(w, r, http.StatusInternalServerError, "创建路由分组来源失败")
+				return
+			}
 		}
 	}
 
@@ -473,50 +476,89 @@ func (h *tokenRoutesHandler) updateRoute(w http.ResponseWriter, r *http.Request)
 
 	now := time.Now().UTC().Format(time.RFC3339)
 
+	tx, err := h.db.Beginx()
+	if err != nil {
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "开启事务失败")
+		return
+	}
+	defer tx.Rollback()
+
 	if v, ok := body["modelPattern"]; ok {
 		if s, ok2 := v.(string); ok2 {
-			h.db.Exec(h.db.Rebind("UPDATE token_routes SET model_pattern = ?, updated_at = ? WHERE id = ?"), strings.TrimSpace(s), now, id)
+			if _, err := tx.Exec(tx.Rebind("UPDATE token_routes SET model_pattern = ?, updated_at = ? WHERE id = ?"), strings.TrimSpace(s), now, id); err != nil {
+				writeErrorWithRequest(w, r, http.StatusInternalServerError, "更新路由失败")
+				return
+			}
 		}
 	}
 	if v, ok := body["displayName"]; ok {
 		if s, ok2 := v.(string); ok2 {
-			h.db.Exec(h.db.Rebind("UPDATE token_routes SET display_name = ?, updated_at = ? WHERE id = ?"), s, now, id)
+			if _, err := tx.Exec(tx.Rebind("UPDATE token_routes SET display_name = ?, updated_at = ? WHERE id = ?"), s, now, id); err != nil {
+				writeErrorWithRequest(w, r, http.StatusInternalServerError, "更新路由失败")
+				return
+			}
 		}
 	}
 	if v, ok := body["displayIcon"]; ok {
 		if s, ok2 := v.(string); ok2 {
-			h.db.Exec(h.db.Rebind("UPDATE token_routes SET display_icon = ?, updated_at = ? WHERE id = ?"), s, now, id)
+			if _, err := tx.Exec(tx.Rebind("UPDATE token_routes SET display_icon = ?, updated_at = ? WHERE id = ?"), s, now, id); err != nil {
+				writeErrorWithRequest(w, r, http.StatusInternalServerError, "更新路由失败")
+				return
+			}
 		}
 	}
 	if v, ok := body["enabled"]; ok {
-		h.db.Exec(h.db.Rebind("UPDATE token_routes SET enabled = ?, updated_at = ? WHERE id = ?"), toBool(v), now, id)
+		if _, err := tx.Exec(tx.Rebind("UPDATE token_routes SET enabled = ?, updated_at = ? WHERE id = ?"), toBool(v), now, id); err != nil {
+			writeErrorWithRequest(w, r, http.StatusInternalServerError, "更新路由失败")
+			return
+		}
 	}
 	if v, ok := body["routingStrategy"]; ok {
 		if s, ok2 := v.(string); ok2 {
-			h.db.Exec(h.db.Rebind("UPDATE token_routes SET routing_strategy = ?, updated_at = ? WHERE id = ?"), s, now, id)
+			if _, err := tx.Exec(tx.Rebind("UPDATE token_routes SET routing_strategy = ?, updated_at = ? WHERE id = ?"), s, now, id); err != nil {
+				writeErrorWithRequest(w, r, http.StatusInternalServerError, "更新路由失败")
+				return
+			}
 		}
 	}
 	if v, ok := body["modelMapping"]; ok {
 		mappingJSON, _ := json.Marshal(v)
-		h.db.Exec(h.db.Rebind("UPDATE token_routes SET model_mapping = ?, updated_at = ? WHERE id = ?"), string(mappingJSON), now, id)
+		if _, err := tx.Exec(tx.Rebind("UPDATE token_routes SET model_mapping = ?, updated_at = ? WHERE id = ?"), string(mappingJSON), now, id); err != nil {
+			writeErrorWithRequest(w, r, http.StatusInternalServerError, "更新路由失败")
+			return
+		}
 	}
 	// contextLength: present key updates (including explicit null/0 clear → NULL).
 	// Metadata only — no proxy max-token enforcement is wired from this field yet.
 	if v, ok := body["contextLength"]; ok {
-		h.db.Exec(h.db.Rebind("UPDATE token_routes SET context_length = ?, updated_at = ? WHERE id = ?"), normalizeContextLengthOrNull(v), now, id)
+		if _, err := tx.Exec(tx.Rebind("UPDATE token_routes SET context_length = ?, updated_at = ? WHERE id = ?"), normalizeContextLengthOrNull(v), now, id); err != nil {
+			writeErrorWithRequest(w, r, http.StatusInternalServerError, "更新路由失败")
+			return
+		}
 	}
 
 	// Update source route IDs for explicit_group
 	if v, ok := body["sourceRouteIds"]; ok {
 		if ids, ok2 := v.([]any); ok2 {
-			h.db.Exec(h.db.Rebind("DELETE FROM route_group_sources WHERE group_route_id = ?"), id)
+			if _, err := tx.Exec(tx.Rebind("DELETE FROM route_group_sources WHERE group_route_id = ?"), id); err != nil {
+				writeErrorWithRequest(w, r, http.StatusInternalServerError, "更新路由分组来源失败")
+				return
+			}
 			for _, rawID := range ids {
 				switch rid := rawID.(type) {
 				case float64:
-					h.db.Exec(h.db.Rebind("INSERT INTO route_group_sources (group_route_id, source_route_id) VALUES (?, ?)"), id, int64(rid))
+					if _, err := tx.Exec(tx.Rebind("INSERT INTO route_group_sources (group_route_id, source_route_id) VALUES (?, ?)"), id, int64(rid)); err != nil {
+						writeErrorWithRequest(w, r, http.StatusInternalServerError, "更新路由分组来源失败")
+						return
+					}
 				}
 			}
 		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "提交事务失败")
+		return
 	}
 
 	// Pattern change: recompose automatic channels while preserving manual overrides.
@@ -552,10 +594,35 @@ func (h *tokenRoutesHandler) deleteRoute(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	h.db.Exec(h.db.Rebind("DELETE FROM route_group_sources WHERE group_route_id = ?"), id)
-	h.db.Exec(h.db.Rebind("DELETE FROM route_group_sources WHERE source_route_id = ?"), id)
-	h.db.Exec(h.db.Rebind("DELETE FROM route_channels WHERE route_id = ?"), id)
-	h.db.Exec(h.db.Rebind("DELETE FROM token_routes WHERE id = ?"), id)
+	tx, err := h.db.Beginx()
+	if err != nil {
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "开启事务失败")
+		return
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(tx.Rebind("DELETE FROM route_group_sources WHERE group_route_id = ?"), id); err != nil {
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "删除路由失败")
+		return
+	}
+	if _, err := tx.Exec(tx.Rebind("DELETE FROM route_group_sources WHERE source_route_id = ?"), id); err != nil {
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "删除路由失败")
+		return
+	}
+	if _, err := tx.Exec(tx.Rebind("DELETE FROM route_channels WHERE route_id = ?"), id); err != nil {
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "删除路由失败")
+		return
+	}
+	if _, err := tx.Exec(tx.Rebind("DELETE FROM token_routes WHERE id = ?"), id); err != nil {
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "删除路由失败")
+		return
+	}
+
+	if err := tx.Commit(); err != nil {
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "提交事务失败")
+		return
+	}
+
 	routing.InvalidateCache()
 	invalidateChannelsSnapshotCache()
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})

--- a/scheduler/checkin.go
+++ b/scheduler/checkin.go
@@ -256,12 +256,19 @@ func selectStaleCheckinAccountIDs(dbw *store.DB, cutoffRFC3339 string) ([]int64,
 	defer rows.Close()
 
 	var ids []int64
+	var scanErr error
 	for rows.Next() {
 		var id int64
 		if err := rows.Scan(&id); err != nil {
+			if scanErr == nil {
+				scanErr = err
+			}
 			continue
 		}
 		ids = append(ids, id)
+	}
+	if scanErr != nil {
+		return ids, scanErr
 	}
 	return ids, rows.Err()
 }

--- a/scheduler/model_probe.go
+++ b/scheduler/model_probe.go
@@ -564,9 +564,13 @@ func queryProbeTargets(dbw *store.DB, query string, args ...any) ([]ProbeTarget,
 	defer rows.Close()
 
 	var out []ProbeTarget
+	var scanErr error
 	for rows.Next() {
 		var t ProbeTarget
 		if err := rows.Scan(&t.ChannelID, &t.AccountID, &t.SiteID, &t.ModelName); err != nil {
+			if scanErr == nil {
+				scanErr = err
+			}
 			continue
 		}
 		if t.ChannelID <= 0 || t.ModelName == "" {
@@ -574,7 +578,7 @@ func queryProbeTargets(dbw *store.DB, query string, args ...any) ([]ProbeTarget,
 		}
 		out = append(out, t)
 	}
-	return out, nil
+	return out, scanErr
 }
 
 // ApplyProbeOutcome is a pure helper used by tests and optional direct callers.

--- a/scheduler/usage_aggregation.go
+++ b/scheduler/usage_aggregation.go
@@ -285,12 +285,14 @@ func (s *UsageAggregationScheduler) releaseLease(dbw *store.DB, lease *projectio
 		msg := err.Error()
 		lastError = &msg
 	}
-	dbw.Exec(`
+	if _, execErr := dbw.Exec(`
 		UPDATE analytics_projection_checkpoints
 		SET lease_owner = NULL, lease_token = NULL, lease_expires_at = NULL,
 		    last_error = ?, updated_at = ?
 		WHERE projector_key = ? AND lease_token = ?
-	`, lastError, now, usageProjectorKey, lease.Token)
+	`, lastError, now, usageProjectorKey, lease.Token); execErr != nil {
+		slog.Warn("usage-aggregation: failed to release lease", "error", execErr, "lease_token", lease.Token)
+	}
 }
 
 func (s *UsageAggregationScheduler) readCheckpoint(dbw *store.DB) projectionCheckpoint {
@@ -765,8 +767,11 @@ func (s *UsageAggregationScheduler) RequestRecompute(fromLogID int64) {
 	if cp.RecomputeFromID != nil && *cp.RecomputeFromID > 0 && *cp.RecomputeFromID < fromID {
 		fromID = *cp.RecomputeFromID
 	}
-	dbw.Exec(`UPDATE analytics_projection_checkpoints
+	if _, err := dbw.Exec(`UPDATE analytics_projection_checkpoints
 		SET recompute_from_id = ?, recompute_requested_at = ?, updated_at = ?
-		WHERE projector_key = ?`, fromID, now, now, usageProjectorKey)
+		WHERE projector_key = ?`, fromID, now, now, usageProjectorKey); err != nil {
+		slog.Warn("usage-aggregation: failed to request recompute", "from_log_id", fromID, "error", err)
+		return
+	}
 	slog.Info("usage-aggregation: recompute requested", "from_log_id", fromID)
 }

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -611,16 +611,20 @@ func ListAccountsWithSites(db *sqlx.DB) ([]map[string]any, error) {
 	defer rows.Close()
 
 	var result []map[string]any
+	var scanErr error
 	for rows.Next() {
 		row := make(map[string]any)
 		if err := rows.MapScan(row); err != nil {
+			if scanErr == nil {
+				scanErr = err
+			}
 			continue
 		}
 		normalizeMapScanValues(row)
 		account := mapKeysToCamel(row)
 		result = append(result, enrichAccountOverviewRow(account))
 	}
-	return result, nil
+	return result, scanErr
 }
 
 // ListAccountsWithSitesPaginated returns a single page of accounts joined with
@@ -642,9 +646,13 @@ func ListAccountsWithSitesPaginated(db *sqlx.DB, limit, offset int) ([]map[strin
 	defer rows.Close()
 
 	var result []map[string]any
+	var scanErr error
 	for rows.Next() {
 		row := make(map[string]any)
 		if err := rows.MapScan(row); err != nil {
+			if scanErr == nil {
+				scanErr = err
+			}
 			continue
 		}
 		normalizeMapScanValues(row)
@@ -657,7 +665,7 @@ func ListAccountsWithSitesPaginated(db *sqlx.DB, limit, offset int) ([]map[strin
 		`SELECT COUNT(*) FROM accounts a INNER JOIN sites s ON a.site_id = s.id`)); err != nil {
 		return result, 0, err
 	}
-	return result, total, nil
+	return result, total, scanErr
 }
 
 // enrichAccountOverviewRow attaches admin-list overview fields used by the UI.


### PR DESCRIPTION
## Summary

Stop swallowing DB errors across token route CRUD, the usage aggregation scheduler, and several row-scan loops.

**`handler/admin/token_routes.go`**
- `createRoute`: the `INSERT INTO route_group_sources` error was ignored, so an `explicit_group` route could be created with silently-vanished group sources. Now captures the error and returns HTTP 500.
- `updateRoute`: ~9 field-by-field `UPDATE`s plus the source-route `DELETE`/`INSERT` all ignored errors, and the handler re-read the row and returned 200 even when writes failed, leaving a mixed mid-update state. All writes are now wrapped in a single `sqlx.Tx`; the first failure returns HTTP 500 and rolls back. The transaction commits before the (read-heavy) channel rebuild so the rebuild observes committed state.
- `deleteRoute`: 4 `DELETE`s ignored errors and always returned `{"success":true}`. They are now wrapped in a transaction; any failure returns HTTP 500.

**`scheduler/usage_aggregation.go`**
- `releaseLease`: the `dbw.Exec` error was ignored, leaving a stale lease held until expiry on a DB hiccup. Now `slog.Warn`s on failure.
- `RequestRecompute`: the `dbw.Exec` error was ignored and success was logged unconditionally. Now only logs the success line when the write succeeds; `slog.Warn`s on failure.

**Row-scan error drops (silently truncated results)**
- `selectStaleCheckinAccountIDs` (`scheduler/checkin.go`): scan error skipped an account via `continue`. Now collects the first scan error and returns it.
- `ListAccountsWithSites` / `ListAccountsWithSitesPaginated` (`service/account_service.go`): `MapScan` errors `continue`d, silently truncating the admin account list. Now collect and return the error.
- `queryProbeTargets` (`scheduler/model_probe.go`): probe targets were silently dropped via `continue`. Now collects and returns the error.

All SQL continues to go through `db.Rebind()` / `tx.Rebind()` / the `store.DB` wrapper.

## Test plan
- [x] `go build ./handler/... ./scheduler/... ./service/... ./store/... ./routing/...` (the repo-wide `go build ./...` has an unrelated pre-existing `web/embed.go` `dist` asset error in this worktree)
- [x] `go vet ./handler/admin/... ./scheduler/... ./service/...`
- [x] `go test ./handler/admin/... ./scheduler/... ./service/...` — all pass
- [x] `go test ./docs/... -run TestPgRebindGate` — rebind gate passes