### PR TITLE
test: WebDAV SSRF guard + newapi_tokens + sub2api_subscriptions coverage

### DIFF
--- a/handler/admin/settings_backup_webdav_ssrf_test.go
+++ b/handler/admin/settings_backup_webdav_ssrf_test.go
@@ -1,0 +1,227 @@
+package admin
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// disallowPrivateWebdavTargetsForTest explicitly pins the test-only
+// allowPrivateWebdavTargets flag to false so the SSRF guards are exercised.
+// The flag defaults to false, but other tests in this package flip it to true
+// (see allowPrivateWebdavTargetsForTest), so we restore the prior value via
+// t.Cleanup to avoid cross-test contamination.
+func disallowPrivateWebdavTargetsForTest(t *testing.T) {
+	t.Helper()
+	previous := allowPrivateWebdavTargets
+	allowPrivateWebdavTargets = false
+	t.Cleanup(func() { allowPrivateWebdavTargets = previous })
+}
+
+// TestIsPrivateOrLoopback exercises the literal-IP classification used by the
+// URL-validation layer. Hostnames that are not literal IPs return false
+// because DNS resolution is deferred to the dial-time guard to avoid TOCTOU.
+func TestIsPrivateOrLoopback(t *testing.T) {
+	disallowPrivateWebdavTargetsForTest(t)
+
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{"localhost is not a literal IP", "localhost", false},
+		{"IPv4 loopback", "127.0.0.1", true},
+		{"IPv4 loopback high octet", "127.255.255.254", true},
+		{"cloud metadata link-local", "169.254.169.254", true},
+		{"IPv6 loopback", "::1", true},
+		{"IPv6 loopback bracketed", "[::1]", true},
+		{"private 10/8", "10.0.0.1", true},
+		{"private 172.16/12", "172.16.0.1", true},
+		{"private 192.168/16", "192.168.1.1", true},
+		{"unspecified 0.0.0.0", "0.0.0.0", true},
+		{"unspecified IPv6", "::", true},
+		{"public IPv4 8.8.8.8", "8.8.8.8", false},
+		{"public IPv4 1.1.1.1", "1.1.1.1", false},
+		{"public hostname is not a literal IP", "example.com", false},
+		{"empty string is not a literal IP", "", false},
+		{"garbage is not a literal IP", "not-an-ip", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPrivateOrLoopback(tt.host); got != tt.want {
+				t.Fatalf("isPrivateOrLoopback(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsAllowedWebdavTargetHost verifies the hostname-level allowlist that runs
+// before any DNS resolution. It rejects localhost and unsafe literal IPs while
+// permitting public IPs and arbitrary hostnames (whose resolution is deferred).
+func TestIsAllowedWebdavTargetHost(t *testing.T) {
+	disallowPrivateWebdavTargetsForTest(t)
+
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{"localhost rejected", "localhost", false},
+		{"localhost subdomain rejected", "api.localhost", false},
+		{"localhost trailing dot rejected", "localhost.", false},
+		{"IPv4 loopback rejected", "127.0.0.1", false},
+		{"cloud metadata rejected", "169.254.169.254", false},
+		{"IPv6 loopback rejected", "::1", false},
+		{"private 10/8 rejected", "10.0.0.1", false},
+		{"private 172.16/12 rejected", "172.16.0.1", false},
+		{"private 192.168/16 rejected", "192.168.1.1", false},
+		{"public IPv4 allowed", "8.8.8.8", true},
+		{"public DNS hostname allowed", "example.com", true},
+		{"empty host rejected", "", false},
+		{"zone-index host rejected", "fe80::1%eth0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAllowedWebdavTargetHost(tt.host); got != tt.want {
+				t.Fatalf("isAllowedWebdavTargetHost(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsAllowedWebdavTargetHost_FlagBypassed confirms that when the test-only
+// allowPrivateWebdavTargets flag is true, the hostname guard is disabled. This
+// documents why the positive SSRF tests above must run with the flag false.
+func TestIsAllowedWebdavTargetHost_FlagBypassed(t *testing.T) {
+	allowPrivateWebdavTargetsForTest(t) // flips to true
+
+	if !isAllowedWebdavTargetHost("127.0.0.1") {
+		t.Fatal("with allowPrivateWebdavTargets=true, 127.0.0.1 should be allowed")
+	}
+	if !isAllowedWebdavTargetHost("localhost") {
+		t.Fatal("with allowPrivateWebdavTargets=true, localhost should be allowed")
+	}
+}
+
+// TestRejectUnsafeWebdavDialHost exercises the dial-time guard. Literal IPs and
+// localhost are deterministic (no DNS required). Public literal IPs are parsed
+// directly and allowed without resolution.
+func TestRejectUnsafeWebdavDialHost(t *testing.T) {
+	disallowPrivateWebdavTargetsForTest(t)
+
+	tests := []struct {
+		name     string
+		host     string
+		wantErr  bool
+		dialSkip bool // true => behaviour depends on external DNS, skip assertion
+	}{
+		{"localhost rejected before DNS", "localhost", true, false},
+		{"IPv4 loopback rejected", "127.0.0.1", true, false},
+		{"cloud metadata rejected", "169.254.169.254", true, false},
+		{"IPv6 loopback rejected", "::1", true, false},
+		{"private 10/8 rejected", "10.0.0.1", true, false},
+		{"private 172.16/12 rejected", "172.16.0.1", true, false},
+		{"private 192.168/16 rejected", "192.168.1.1", true, false},
+		{"unspecified rejected", "0.0.0.0", true, false},
+		{"public IPv4 allowed (literal, no DNS)", "8.8.8.8", false, false},
+		{"public IPv6 allowed (literal, no DNS)", "2606:4700:4700::1111", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			err := rejectUnsafeWebdavDialHost(ctx, tt.host)
+			if tt.dialSkip {
+				t.Logf("rejectUnsafeWebdavDialHost(%q) err=%v (DNS-dependent, not asserted)", tt.host, err)
+				return
+			}
+			if tt.wantErr && err == nil {
+				t.Fatalf("rejectUnsafeWebdavDialHost(%q) = nil, want error", tt.host)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("rejectUnsafeWebdavDialHost(%q) = %v, want nil", tt.host, err)
+			}
+		})
+	}
+}
+
+// TestRejectUnsafeWebdavDialHost_PublicHostname covers a public DNS hostname.
+// This requires live DNS resolution; if the resolver is unavailable the test
+// is skipped rather than failing, so it remains robust in offline CI.
+func TestRejectUnsafeWebdavDialHost_PublicHostname(t *testing.T) {
+	disallowPrivateWebdavTargetsForTest(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := rejectUnsafeWebdavDialHost(ctx, "example.com")
+	if err == nil {
+		// DNS resolved to one or more public addresses — allowed as expected.
+		return
+	}
+	// A DNS lookup failure means the environment has no resolver; skip rather
+	// than fail. Any other error (resolved to a private address) is a real bug.
+	if isDNSLookupError(err) {
+		t.Skipf("skipping: no DNS resolver available: %v", err)
+	}
+	t.Fatalf("rejectUnsafeWebdavDialHost(example.com) = %v, want nil", err)
+}
+
+// isDNSLookupError heuristically detects resolver-unavailable errors so the
+// public-hostname dial test can skip in offline environments.
+func isDNSLookupError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	contains := func(sub string) bool {
+		return len(msg) >= len(sub) && stringContains(msg, sub)
+	}
+	return contains("no such host") || contains("lookup") || contains("no IP addresses") || contains("server misbehaving")
+}
+
+// stringContains is a tiny strings.Contains shim to avoid importing strings
+// just for the heuristic above.
+func stringContains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// TestIsValidWebdavFileURL_SSRFGuard ensures the URL-validation layer rejects
+// private/loopback targets when the allowPrivateWebdavTargets flag is false,
+// and that the guard composes correctly with isAllowedWebdavTargetHost.
+func TestIsValidWebdavFileURL_SSRFGuard(t *testing.T) {
+	disallowPrivateWebdavTargetsForTest(t)
+
+	tests := []struct {
+		name    string
+		rawURL  string
+		wantOK  bool
+	}{
+		{"https localhost rejected", "https://localhost/path", false},
+		{"https 127.0.0.1 rejected", "https://127.0.0.1/path", false},
+		{"https metadata rejected", "https://169.254.169.254/latest", false},
+		{"https private 10/8 rejected", "https://10.0.0.1/path", false},
+		{"https public IP allowed", "https://8.8.8.8/path", true},
+		{"https public host allowed", "https://example.com/path", true},
+		{"http public host allowed", "http://example.com/path", true},
+		{"ftp scheme rejected", "ftp://example.com/file", false},
+		{"empty host rejected", "https:///path", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidWebdavFileURL(tt.rawURL); got != tt.wantOK {
+				t.Fatalf("isValidWebdavFileURL(%q) = %v, want %v", tt.rawURL, got, tt.wantOK)
+			}
+		})
+	}
+}

--- a/platform/newapi_tokens_test.go
+++ b/platform/newapi_tokens_test.go
@@ -1,0 +1,293 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// newTokenTestServer spins up an httptest server whose handler decides what to
+// return based on method + path. It is used to drive the NewApi token CRUD
+// methods without any real upstream.
+func newTokenTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// tokenJSONResponse writes a JSON body with the standard content type.
+func tokenJSONResponse(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprint(w, body)
+}
+
+// newApiTokenAdapter builds a fresh NewApiAdapter for tests.
+func newApiTokenAdapter() *NewApiAdapter {
+	return &NewApiAdapter{BaseAdapter: NewBaseAdapter("new-api")}
+}
+
+// TestNewApiAdapter_GetAPITokens_Success verifies the happy path: the Bearer
+// request returns a populated token list and the adapter short-circuits before
+// any cookie fallback.
+func TestNewApiAdapter_GetAPITokens_Success(t *testing.T) {
+	srv := newTokenTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/token/" && r.Method == http.MethodGet {
+			tokenJSONResponse(w, `{"success":true,"data":[`+
+				`{"key":"sk-success-123","name":"primary","status":1},`+
+				`{"key":"sk-disabled-456","name":"secondary","status":2}`+
+				`]}`)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	n := newApiTokenAdapter()
+	uid := 1
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tokens, err := n.GetAPITokens(ctx, srv.URL, "bearer-token", &uid, nil)
+	if err != nil {
+		t.Fatalf("GetAPITokens: unexpected error: %v", err)
+	}
+	if len(tokens) != 2 {
+		t.Fatalf("GetAPITokens: got %d tokens, want 2", len(tokens))
+	}
+	if tokens[0].Key != "sk-success-123" {
+		t.Errorf("tokens[0].Key = %q, want sk-success-123", tokens[0].Key)
+	}
+	if !tokens[0].Enabled {
+		t.Errorf("tokens[0].Enabled = false, want true (status=1)")
+	}
+	if tokens[1].Enabled {
+		t.Errorf("tokens[1].Enabled = true, want false (status=2)")
+	}
+}
+
+// TestNewApiAdapter_GetAPITokens_EmptyList verifies that an empty data array
+// yields an empty (non-nil) token slice with no error. The adapter falls
+// through the cookie and probe fallbacks, all of which return nothing.
+func TestNewApiAdapter_GetAPITokens_EmptyList(t *testing.T) {
+	srv := newTokenTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/token/" && r.Method == http.MethodGet:
+			tokenJSONResponse(w, `{"success":true,"data":[]}`)
+		case r.URL.Path == "/api/user/self" && r.Method == http.MethodGet:
+			tokenJSONResponse(w, `{"success":false,"message":"unauthorized"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	n := newApiTokenAdapter()
+	uid := 1
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	tokens, err := n.GetAPITokens(ctx, srv.URL, "bearer-token", &uid, nil)
+	if err != nil {
+		t.Fatalf("GetAPITokens: unexpected error: %v", err)
+	}
+	if len(tokens) != 0 {
+		t.Fatalf("GetAPITokens: got %d tokens, want 0", len(tokens))
+	}
+}
+
+// TestNewApiAdapter_GetAPITokens_ErrorResponse verifies that when the upstream
+// returns HTTP errors for every request, the adapter swallows the errors and
+// returns an empty token slice rather than surfacing an error.
+func TestNewApiAdapter_GetAPITokens_ErrorResponse(t *testing.T) {
+	srv := newTokenTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"success":false,"message":"internal server error"}`)
+	})
+
+	n := newApiTokenAdapter()
+	uid := 1
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	tokens, err := n.GetAPITokens(ctx, srv.URL, "bearer-token", &uid, nil)
+	if err != nil {
+		t.Fatalf("GetAPITokens: unexpected error: %v", err)
+	}
+	if len(tokens) != 0 {
+		t.Fatalf("GetAPITokens: got %d tokens, want 0 on error response", len(tokens))
+	}
+}
+
+// TestNewApiAdapter_GetAPIToken_Success verifies the singular GetAPIToken
+// returns the first enabled token key.
+func TestNewApiAdapter_GetAPIToken_Success(t *testing.T) {
+	srv := newTokenTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/token/" && r.Method == http.MethodGet {
+			tokenJSONResponse(w, `{"success":true,"data":[`+
+				`{"key":"sk-disabled","name":"disabled","status":2},`+
+				`{"key":"sk-enabled-789","name":"enabled","status":1}`+
+				`]}`)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	n := newApiTokenAdapter()
+	uid := 1
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tok, err := n.GetAPIToken(ctx, srv.URL, "bearer-token", &uid, nil)
+	if err != nil {
+		t.Fatalf("GetAPIToken: unexpected error: %v", err)
+	}
+	if tok == nil {
+		t.Fatal("GetAPIToken: got nil, want non-nil token")
+	}
+	if *tok != "sk-enabled-789" {
+		t.Fatalf("GetAPIToken: got %q, want sk-enabled-789", *tok)
+	}
+}
+
+// TestNewApiAdapter_GetAPIToken_NotFound verifies that when no tokens are
+// returned, GetAPIToken yields a nil pointer without error.
+func TestNewApiAdapter_GetAPIToken_NotFound(t *testing.T) {
+	srv := newTokenTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/token/" && r.Method == http.MethodGet:
+			tokenJSONResponse(w, `{"success":true,"data":[]}`)
+		case r.URL.Path == "/api/user/self" && r.Method == http.MethodGet:
+			tokenJSONResponse(w, `{"success":false,"message":"unauthorized"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	n := newApiTokenAdapter()
+	uid := 1
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	tok, err := n.GetAPIToken(ctx, srv.URL, "bearer-token", &uid, nil)
+	if err != nil {
+		t.Fatalf("GetAPIToken: unexpected error: %v", err)
+	}
+	if tok != nil {
+		t.Fatalf("GetAPIToken: got %q, want nil", *tok)
+	}
+}
+
+// TestNewApiAdapter_CreateAPIToken_Success verifies that a successful POST
+// returns created=true.
+func TestNewApiAdapter_CreateAPIToken_Success(t *testing.T) {
+	srv := newTokenTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/token/" && r.Method == http.MethodPost {
+			tokenJSONResponse(w, `{"success":true,"data":{"key":"sk-new"}}`)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	n := newApiTokenAdapter()
+	uid := 1
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	created, err := n.CreateAPIToken(ctx, srv.URL, "bearer-token", &uid, &CreateAPITokenOptions{Name: "my-token"}, nil)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: unexpected error: %v", err)
+	}
+	if !created {
+		t.Fatal("CreateAPIToken: got created=false, want true")
+	}
+}
+
+// TestNewApiAdapter_CreateAPIToken_ValidationError verifies that a failed POST
+// (success:false from upstream) returns created=false without error.
+func TestNewApiAdapter_CreateAPIToken_ValidationError(t *testing.T) {
+	srv := newTokenTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/token/" && r.Method == http.MethodPost {
+			tokenJSONResponse(w, `{"success":false,"message":"token name too long"}`)
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	n := newApiTokenAdapter()
+	uid := 1
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	created, err := n.CreateAPIToken(ctx, srv.URL, "bearer-token", &uid, &CreateAPITokenOptions{Name: "x"}, nil)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: unexpected error: %v", err)
+	}
+	if created {
+		t.Fatal("CreateAPIToken: got created=true, want false")
+	}
+}
+
+// TestNewApiAdapter_DeleteAPIToken_Success verifies that when the token key is
+// found in the list and the DELETE succeeds, the adapter returns nil.
+func TestNewApiAdapter_DeleteAPIToken_Success(t *testing.T) {
+	srv := newTokenTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/token/" && r.Method == http.MethodGet:
+			tokenJSONResponse(w, `{"success":true,"data":[{"key":"sk-delete-me","id":42,"status":1}]}`)
+		case r.URL.Path == "/api/token/42" && r.Method == http.MethodDelete:
+			tokenJSONResponse(w, `{"success":true}`)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	n := newApiTokenAdapter()
+	uid := 1
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := n.DeleteAPIToken(ctx, srv.URL, "bearer-token", "sk-delete-me", &uid, nil); err != nil {
+		t.Fatalf("DeleteAPIToken: unexpected error: %v", err)
+	}
+}
+
+// TestNewApiAdapter_DeleteAPIToken_NotFound verifies that when the token key is
+// absent from the list, the delete is treated as idempotent (nil error).
+func TestNewApiAdapter_DeleteAPIToken_NotFound(t *testing.T) {
+	srv := newTokenTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/token/" && r.Method == http.MethodGet:
+			tokenJSONResponse(w, `{"success":true,"data":[{"key":"sk-other","id":99,"status":1}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	n := newApiTokenAdapter()
+	uid := 1
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := n.DeleteAPIToken(ctx, srv.URL, "bearer-token", "sk-nonexistent", &uid, nil); err != nil {
+		t.Fatalf("DeleteAPIToken: unexpected error: %v", err)
+	}
+}
+
+// TestNewApiAdapter_DeleteAPIToken_EmptyKey verifies that an empty token key is
+// a no-op (returns nil immediately without any HTTP traffic).
+func TestNewApiAdapter_DeleteAPIToken_EmptyKey(t *testing.T) {
+	srv := newTokenTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected HTTP request for empty-key delete: %s %s", r.Method, r.URL.Path)
+	})
+
+	n := newApiTokenAdapter()
+	uid := 1
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := n.DeleteAPIToken(ctx, srv.URL, "bearer-token", "", &uid, nil); err != nil {
+		t.Fatalf("DeleteAPIToken empty key: unexpected error: %v", err)
+	}
+}

--- a/platform/sub2api_subscriptions_test.go
+++ b/platform/sub2api_subscriptions_test.go
@@ -1,0 +1,546 @@
+package platform
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// expectedRFC3339 computes the same local-timezone RFC3339 string that the
+// production parseDateTime produces for a Unix-millisecond timestamp. This
+// keeps the tests timezone-independent (the production code uses
+// time.UnixMilli(...).Format(time.RFC3339) which honours the local zone).
+func expectedRFC333For(unixMillis int64) string {
+	return time.UnixMilli(unixMillis).Format(time.RFC3339)
+}
+
+// mustParseJSONSub unmarshals a JSON literal into a generic interface{} so the
+// parser tests can feed realistic shapes (maps, arrays, numbers as float64)
+// exactly as the production fetchJSON path would.
+func mustParseJSONSub(t *testing.T, raw string) interface{} {
+	t.Helper()
+	var v interface{}
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		t.Fatalf("mustParseJSONSub(%q): %v", raw, err)
+	}
+	return v
+}
+
+func newSub2ApiAdapterForSubs() *Sub2ApiAdapter {
+	return &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
+}
+
+// --- parseNonNegativeNumber ---
+
+func TestSub2ApiSubscriptions_parseNonNegativeNumber(t *testing.T) {
+	s := newSub2ApiAdapterForSubs()
+
+	tests := []struct {
+		name   string
+		values []interface{}
+		want   *float64
+	}{
+		{"positive float64", []interface{}{float64(5.0)}, floatPtr(5.0)},
+		{"zero is non-negative", []interface{}{float64(0.0)}, floatPtr(0.0)},
+		{"negative rejected", []interface{}{float64(-1.5)}, nil},
+		{"string number", []interface{}{"3.14"}, floatPtr(3.14)},
+		{"string zero", []interface{}{"0"}, floatPtr(0.0)},
+		{"negative string rejected", []interface{}{"-2.5"}, nil},
+		{"empty string skipped", []interface{}{""}, nil},
+		{"whitespace string skipped", []interface{}{"  "}, nil},
+		{"non-numeric string skipped", []interface{}{"abc"}, nil},
+		{"nil skipped", []interface{}{nil}, nil},
+		{"no arguments", []interface{}{}, nil},
+		{"first valid wins", []interface{}{float64(-1), float64(7.0)}, floatPtr(7.0)},
+		{"nil then valid", []interface{}{nil, float64(9.0)}, floatPtr(9.0)},
+		{"string then float", []interface{}{"invalid", float64(4.0)}, floatPtr(4.0)},
+		{"rounding to 6 decimals", []interface{}{float64(1.23456789)}, floatPtr(math.Round(1.23456789*1e6) / 1e6)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := s.parseNonNegativeNumber(tt.values...)
+			if !floatPtrEqual(got, tt.want) {
+				t.Fatalf("parseNonNegativeNumber(%v) = %v, want %v", tt.values, got, tt.want)
+			}
+		})
+	}
+}
+
+// floatPtr is a test helper that returns a pointer to the given float64.
+func floatPtr(v float64) *float64 {
+	return &v
+}
+
+// floatPtrEqual compares two *float64 for equality (both nil or both equal).
+func floatPtrEqual(a, b *float64) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+// --- parseDateTime ---
+
+func TestSub2ApiSubscriptions_parseDateTime(t *testing.T) {
+	s := newSub2ApiAdapterForSubs()
+
+	// 1705312200 is a Unix-seconds timestamp; the production code multiplies
+	// by 1000 when the value is below 10e9 (seconds → millis). Both the seconds
+	// and the millis form must produce the same RFC3339 string.
+	expectedFromSeconds := expectedRFC333For(1705312200000)
+
+	tests := []struct {
+		name         string
+		values       []string
+		want         string
+		wantNonEmpty bool
+	}{
+		{"unix seconds", []string{"1705312200"}, expectedFromSeconds, true},
+		{"unix milliseconds", []string{"1705312200000"}, expectedFromSeconds, true},
+		{"empty string", []string{""}, "", false},
+		{"whitespace string", []string{"  "}, "", false},
+		{"non-numeric non-date", []string{"not-a-date"}, "", false},
+		{"first empty then valid", []string{"", "1705312200"}, expectedFromSeconds, true},
+		{"no arguments", []string{}, "", false},
+		{"negative numeric rejected (<=0)", []string{"-100"}, "", false},
+		{"zero numeric rejected (<=0)", []string{"0"}, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := s.parseDateTime(tt.values...)
+			if tt.wantNonEmpty {
+				if got == "" {
+					t.Fatalf("parseDateTime(%v) = empty, want non-empty", tt.values)
+				}
+				if tt.want != "" && got != tt.want {
+					t.Fatalf("parseDateTime(%v) = %q, want %q", tt.values, got, tt.want)
+				}
+			} else {
+				if got != "" {
+					t.Fatalf("parseDateTime(%v) = %q, want empty", tt.values, got)
+				}
+			}
+		})
+	}
+}
+
+// --- getRaw ---
+
+func TestSub2ApiSubscriptions_getRaw(t *testing.T) {
+	s := newSub2ApiAdapterForSubs()
+
+	item := map[string]interface{}{
+		"present":   float64(42),
+		"str":       "hello",
+		"nilval":    nil,
+		"nested":    map[string]interface{}{"inner": float64(1)},
+	}
+
+	tests := []struct {
+		name string
+		key  string
+		want interface{}
+	}{
+		{"existing numeric", "present", float64(42)},
+		{"existing string", "str", "hello"},
+		{"existing nil value", "nilval", nil},
+		{"existing map value", "nested", item["nested"]},
+		{"missing key", "absent", nil},
+		{"empty key", "", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := s.getRaw(item, tt.key)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("getRaw(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- getRawString ---
+
+func TestSub2ApiSubscriptions_getRawString(t *testing.T) {
+	s := newSub2ApiAdapterForSubs()
+
+	item := map[string]interface{}{
+		"str":       "  spaced  ",
+		"num":       float64(12),
+		"nilval":    nil,
+		"boolval":   true,
+		"nested":    map[string]interface{}{"x": float64(1)},
+	}
+
+	tests := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{"string trimmed", "str", "spaced"},
+		{"float64 formatted", "num", "12"},
+		{"nil value empty", "nilval", ""},
+		{"missing key empty", "absent", ""},
+		{"bool value empty (unsupported type)", "boolval", ""},
+		{"map value empty (unsupported type)", "nested", ""},
+		{"empty key", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := s.getRawString(item, tt.key)
+			if got != tt.want {
+				t.Fatalf("getRawString(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- parseSingleSubscription ---
+
+func TestSub2ApiSubscriptions_parseSingleSubscription(t *testing.T) {
+	s := newSub2ApiAdapterForSubs()
+
+	t.Run("complete subscription", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `{
+			"id": 101,
+			"group_id": 5,
+			"group_name": "premium",
+			"status": "active",
+			"expires_at": "1705312200",
+			"daily_used_usd": 1.5,
+			"daily_limit_usd": 10,
+			"weekly_used_usd": 7.5,
+			"weekly_limit_usd": 50,
+			"monthly_used_usd": 30,
+			"monthly_limit_usd": 100
+		}`)
+		item, _ := raw.(map[string]interface{})
+
+		summary := s.parseSingleSubscription(item)
+		if summary == nil {
+			t.Fatal("parseSingleSubscription: got nil, want non-nil")
+		}
+		if summary.ID == nil || *summary.ID != 101 {
+			t.Errorf("ID = %v, want 101", summary.ID)
+		}
+		if summary.GroupID == nil || *summary.GroupID != 5 {
+			t.Errorf("GroupID = %v, want 5", summary.GroupID)
+		}
+		if summary.GroupName != "premium" {
+			t.Errorf("GroupName = %q, want premium", summary.GroupName)
+		}
+		if summary.Status != "active" {
+			t.Errorf("Status = %q, want active", summary.Status)
+		}
+		if summary.ExpiresAt != expectedRFC333For(1705312200000) {
+			t.Errorf("ExpiresAt = %q, want %q", summary.ExpiresAt, expectedRFC333For(1705312200000))
+		}
+		if summary.DailyUsedUsd == nil || *summary.DailyUsedUsd != 1.5 {
+			t.Errorf("DailyUsedUsd = %v, want 1.5", summary.DailyUsedUsd)
+		}
+		if summary.MonthlyLimitUsd == nil || *summary.MonthlyLimitUsd != 100 {
+			t.Errorf("MonthlyLimitUsd = %v, want 100", summary.MonthlyLimitUsd)
+		}
+	})
+
+	t.Run("nested group object", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `{"id": 7, "group": {"id": 3, "name": "nested-group"}}`)
+		item, _ := raw.(map[string]interface{})
+
+		summary := s.parseSingleSubscription(item)
+		if summary == nil {
+			t.Fatal("parseSingleSubscription: got nil")
+		}
+		if summary.GroupID == nil || *summary.GroupID != 3 {
+			t.Errorf("GroupID = %v, want 3 (from nested group.id)", summary.GroupID)
+		}
+		if summary.GroupName != "nested-group" {
+			t.Errorf("GroupName = %q, want nested-group", summary.GroupName)
+		}
+	})
+
+	t.Run("camelCase keys", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `{
+			"groupId": 88,
+			"groupName": "camel",
+			"monthlyUsedUsd": 5,
+			"monthlyLimitUsd": 50
+		}`)
+		item, _ := raw.(map[string]interface{})
+
+		summary := s.parseSingleSubscription(item)
+		if summary == nil {
+			t.Fatal("parseSingleSubscription: got nil")
+		}
+		if summary.GroupID == nil || *summary.GroupID != 88 {
+			t.Errorf("GroupID = %v, want 88", summary.GroupID)
+		}
+		if summary.GroupName != "camel" {
+			t.Errorf("GroupName = %q, want camel", summary.GroupName)
+		}
+		if summary.MonthlyUsedUsd == nil || *summary.MonthlyUsedUsd != 5 {
+			t.Errorf("MonthlyUsedUsd = %v, want 5", summary.MonthlyUsedUsd)
+		}
+	})
+
+	t.Run("partial - only status", func(t *testing.T) {
+		item := map[string]interface{}{"status": "expired"}
+
+		summary := s.parseSingleSubscription(item)
+		if summary == nil {
+			t.Fatal("parseSingleSubscription: got nil for partial")
+		}
+		if summary.Status != "expired" {
+			t.Errorf("Status = %q, want expired", summary.Status)
+		}
+		if summary.GroupName != "" {
+			t.Errorf("GroupName = %q, want empty", summary.GroupName)
+		}
+	})
+
+	t.Run("empty map returns nil", func(t *testing.T) {
+		summary := s.parseSingleSubscription(map[string]interface{}{})
+		if summary != nil {
+			t.Fatalf("parseSingleSubscription(empty) = %v, want nil", summary)
+		}
+	})
+
+	t.Run("all-negative numbers returns nil", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `{"daily_used_usd": -1, "monthly_used_usd": -2}`)
+		item, _ := raw.(map[string]interface{})
+
+		summary := s.parseSingleSubscription(item)
+		if summary != nil {
+			t.Fatalf("parseSingleSubscription(all-negative) = %v, want nil", summary)
+		}
+	})
+
+	t.Run("alias keys for monthly used", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `{"used_usd": 15.5, "limit_usd": 200}`)
+		item, _ := raw.(map[string]interface{})
+
+		summary := s.parseSingleSubscription(item)
+		if summary == nil {
+			t.Fatal("parseSingleSubscription: got nil")
+		}
+		if summary.MonthlyUsedUsd == nil || *summary.MonthlyUsedUsd != 15.5 {
+			t.Errorf("MonthlyUsedUsd = %v, want 15.5 (from used_usd)", summary.MonthlyUsedUsd)
+		}
+		if summary.MonthlyLimitUsd == nil || *summary.MonthlyLimitUsd != 200 {
+			t.Errorf("MonthlyLimitUsd = %v, want 200 (from limit_usd)", summary.MonthlyLimitUsd)
+		}
+	})
+}
+
+// --- parseSubscriptionItems ---
+
+func TestSub2ApiSubscriptions_parseSubscriptionItems(t *testing.T) {
+	s := newSub2ApiAdapterForSubs()
+
+	t.Run("array of subscriptions", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `[
+			{"id": 1, "status": "active", "monthly_used_usd": 5},
+			{"id": 2, "status": "expired"}
+		]`)
+		items := s.parseSubscriptionItems(raw)
+		if len(items) != 2 {
+			t.Fatalf("got %d items, want 2", len(items))
+		}
+		if items[0].ID == nil || *items[0].ID != 1 {
+			t.Errorf("items[0].ID = %v, want 1", items[0].ID)
+		}
+	})
+
+	t.Run("map with subscriptions key", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `{"subscriptions": [{"id": 10}]}`)
+		items := s.parseSubscriptionItems(raw)
+		if len(items) != 1 {
+			t.Fatalf("got %d items, want 1", len(items))
+		}
+	})
+
+	t.Run("map with items key", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `{"items": [{"id": 20}]}`)
+		items := s.parseSubscriptionItems(raw)
+		if len(items) != 1 {
+			t.Fatalf("got %d items, want 1", len(items))
+		}
+	})
+
+	t.Run("map with data key", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `{"data": [{"id": 30}]}`)
+		items := s.parseSubscriptionItems(raw)
+		if len(items) != 1 {
+			t.Fatalf("got %d items, want 1", len(items))
+		}
+	})
+
+	t.Run("map with list key", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `{"list": [{"id": 40}]}`)
+		items := s.parseSubscriptionItems(raw)
+		if len(items) != 1 {
+			t.Fatalf("got %d items, want 1", len(items))
+		}
+	})
+
+	t.Run("empty array", func(t *testing.T) {
+		items := s.parseSubscriptionItems([]interface{}{})
+		if len(items) != 0 {
+			t.Fatalf("got %d items, want 0", len(items))
+		}
+	})
+
+	t.Run("map with no array keys", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `{"foo": "bar"}`)
+		items := s.parseSubscriptionItems(raw)
+		if len(items) != 0 {
+			t.Fatalf("got %d items, want 0", len(items))
+		}
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		items := s.parseSubscriptionItems(nil)
+		if len(items) != 0 {
+			t.Fatalf("got %d items, want 0", len(items))
+		}
+	})
+
+	t.Run("malformed items skipped", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `[
+			{"id": 1},
+			"not-a-map",
+			42,
+			null,
+			{"id": 2}
+		]`)
+		items := s.parseSubscriptionItems(raw)
+		if len(items) != 2 {
+			t.Fatalf("got %d items, want 2 (non-map items skipped)", len(items))
+		}
+	})
+
+	t.Run("items that parse to nil are skipped", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `[
+			{"id": 1},
+			{"daily_used_usd": -5},
+			{"id": 2}
+		]`)
+		items := s.parseSubscriptionItems(raw)
+		if len(items) != 2 {
+			t.Fatalf("got %d items, want 2 (nil-summary item skipped)", len(items))
+		}
+	})
+}
+
+// --- buildSubscriptionSummary ---
+
+func TestSub2ApiSubscriptions_buildSubscriptionSummary(t *testing.T) {
+	s := newSub2ApiAdapterForSubs()
+
+	t.Run("array with active_count and total_used_usd", func(t *testing.T) {
+		// When raw is a bare array, body is nil so active_count/total_used_usd
+		// come from the fallback logic (len + sum).
+		raw := mustParseJSONSub(t, `[
+			{"id": 1, "monthly_used_usd": 5.0},
+			{"id": 2, "monthly_used_usd": 3.0}
+		]`)
+		summary := s.buildSubscriptionSummary(raw)
+		if summary == nil {
+			t.Fatal("buildSubscriptionSummary: got nil")
+		}
+		if summary.ActiveCount != 2 {
+			t.Errorf("ActiveCount = %d, want 2", summary.ActiveCount)
+		}
+		if summary.TotalUsedUsd != 8.0 {
+			t.Errorf("TotalUsedUsd = %f, want 8.0", summary.TotalUsedUsd)
+		}
+		if len(summary.Subscriptions) != 2 {
+			t.Errorf("len(Subscriptions) = %d, want 2", len(summary.Subscriptions))
+		}
+	})
+
+	t.Run("map with explicit counts", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `{
+			"active_count": 5,
+			"total_used_usd": 42.5,
+			"subscriptions": [{"id": 1, "monthly_used_usd": 10}]
+		}`)
+		summary := s.buildSubscriptionSummary(raw)
+		if summary == nil {
+			t.Fatal("buildSubscriptionSummary: got nil")
+		}
+		if summary.ActiveCount != 5 {
+			t.Errorf("ActiveCount = %d, want 5", summary.ActiveCount)
+		}
+		if summary.TotalUsedUsd != 42.5 {
+			t.Errorf("TotalUsedUsd = %f, want 42.5", summary.TotalUsedUsd)
+		}
+	})
+
+	t.Run("camelCase counts", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `{
+			"activeCount": 3,
+			"totalUsedUsd": 7.0
+		}`)
+		summary := s.buildSubscriptionSummary(raw)
+		if summary == nil {
+			t.Fatal("buildSubscriptionSummary: got nil")
+		}
+		if summary.ActiveCount != 3 {
+			t.Errorf("ActiveCount = %d, want 3", summary.ActiveCount)
+		}
+		if summary.TotalUsedUsd != 7.0 {
+			t.Errorf("TotalUsedUsd = %f, want 7.0", summary.TotalUsedUsd)
+		}
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		summary := s.buildSubscriptionSummary(map[string]interface{}{})
+		if summary == nil {
+			t.Fatal("buildSubscriptionSummary: got nil")
+		}
+		if summary.ActiveCount != 0 {
+			t.Errorf("ActiveCount = %d, want 0", summary.ActiveCount)
+		}
+		if summary.TotalUsedUsd != 0 {
+			t.Errorf("TotalUsedUsd = %f, want 0", summary.TotalUsedUsd)
+		}
+		if len(summary.Subscriptions) != 0 {
+			t.Errorf("len(Subscriptions) = %d, want 0", len(summary.Subscriptions))
+		}
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		summary := s.buildSubscriptionSummary(nil)
+		if summary == nil {
+			t.Fatal("buildSubscriptionSummary: got nil")
+		}
+		if summary.ActiveCount != 0 {
+			t.Errorf("ActiveCount = %d, want 0", summary.ActiveCount)
+		}
+	})
+
+	t.Run("fallback total from subscriptions when total_used_usd is zero", func(t *testing.T) {
+		raw := mustParseJSONSub(t, `{
+			"subscriptions": [
+				{"id": 1, "monthly_used_usd": 2.0},
+				{"id": 2, "monthly_used_usd": 3.0}
+			]
+		}`)
+		summary := s.buildSubscriptionSummary(raw)
+		if summary == nil {
+			t.Fatal("buildSubscriptionSummary: got nil")
+		}
+		if summary.TotalUsedUsd != 5.0 {
+			t.Errorf("TotalUsedUsd = %f, want 5.0 (sum of monthly_used_usd)", summary.TotalUsedUsd)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **WebDAV SSRF guard positive tests** (`handler/admin/settings_backup_webdav_ssrf_test.go`): Table-driven tests for `isPrivateOrLoopback`, `isAllowedWebdavTargetHost`, `rejectUnsafeWebdavDialHost`, and `isValidWebdavFileURL` with `allowPrivateWebdavTargets = false`. Covers localhost, loopback, cloud metadata (169.254.169.254), IPv6 loopback, all private ranges (10/8, 172.16/12, 192.168/16), and public allowlist (8.8.8.8, example.com). Uses `t.Cleanup` to restore the global flag.
- **newapi_tokens adapter tests** (`platform/newapi_tokens_test.go`): httptest-mocked tests for `GetAPITokens` (success, empty list, error response), `GetAPIToken` (success, not found), `CreateAPIToken` (success, validation error), and `DeleteAPIToken` (success, not found, empty key no-op).
- **sub2api_subscriptions parser tests** (`platform/sub2api_subscriptions_test.go`): Pure table-driven tests for `parseNonNegativeNumber`, `parseDateTime`, `getRaw`, `getRawString`, `parseSingleSubscription`, `parseSubscriptionItems`, and `buildSubscriptionSummary` covering complete/partial/missing/malformed inputs.

## Test plan

- [x] `go build ./handler/admin/... ./platform/...` passes
- [x] `go vet ./handler/admin/... ./platform/...` passes
- [x] `go test ./handler/admin/... ./platform/... -count=1 -timeout 120s` passes
- [x] `go test ./docs/... -run TestPgRebindGate` passes (rebind gate clean)