### PR TITLE
test: OAuth CRUD + stats detail handler tests + compose env passthrough

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -34,6 +34,22 @@ services:
       DB_MAX_IDLE_CONNS: ${DB_MAX_IDLE_CONNS:-}
       DB_CONN_MAX_LIFETIME_SEC: ${DB_CONN_MAX_LIFETIME_SEC:-1800}
       DB_CONN_MAX_IDLE_TIME_SEC: ${DB_CONN_MAX_IDLE_TIME_SEC:-300}
+      # Configurable settings (uncomment to override defaults):
+      # LDOH_BASE_URL: https://ldoh.105117.xyz
+      # LDOH_PROXY_TIMEOUT_SEC: "30"
+      # PROXY_RATE_LIMIT_RPM: "60"
+      # PROXY_LOG_ASYNC: "true"
+      # PROXY_LOG_BATCH_SIZE: "50"
+      # PROXY_LOG_FLUSH_INTERVAL_MS: "1000"
+      # REQUEST_BODY_LIMIT_MB: "20"
+      # FILE_UPLOAD_LIMIT_MB: "100"
+      # ADMIN_RATE_LIMIT_RPS: "100"
+      # ADMIN_RATE_LIMIT_BURST: "200"
+      # OAUTH_RATE_LIMIT_RPS: "10"
+      # OAUTH_RATE_LIMIT_BURST: "20"
+      # PROXY_MAX_STREAM_RESPONSE_BYTES: "10485760"
+      # PROXY_MAX_BUFFERED_RESPONSE_BYTES: "20971520"
+      # LOG_LEVEL: info
     restart: unless-stopped
     # Runtime hardening (matches docker-compose.yml): drop caps, read-only root,
     # tmpfs /tmp, and bounded CPU/memory so a runaway process cannot exhaust the host.

--- a/handler/admin/oauth_routes.go
+++ b/handler/admin/oauth_routes.go
@@ -256,22 +256,101 @@ func (h *oauthHandler) rebindConnection(w http.ResponseWriter, r *http.Request) 
 
 // PATCH /api/oauth/connections/:accountId/proxy
 func (h *oauthHandler) updateProxy(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{"success": true})
+	idStr := chi.URLParam(r, "accountId")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || id <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"message": "invalid account id"})
+		return
+	}
+
+	// Body is optional: an empty body clears the per-connection proxy (falls
+	// back to system proxy). Malformed non-empty JSON is a 400.
+	var body struct {
+		ProxyURL       *string `json:"proxyUrl"`
+		UseSystemProxy *bool   `json:"useSystemProxy"`
+	}
+	if r.Body != nil && r.Body != http.NoBody {
+		if err := decodeJSONRequest(r, &body); err != nil {
+			if isEmptyJSONBodyError(err) {
+				body = struct {
+					ProxyURL       *string `json:"proxyUrl"`
+					UseSystemProxy *bool   `json:"useSystemProxy"`
+				}{}
+			} else {
+				writeJSON(w, http.StatusBadRequest, map[string]any{"message": "invalid request body"})
+				return
+			}
+		}
+	}
+
+	result, err := oauth.UpdateOauthConnectionProxySettings(id, body.ProxyURL, body.UseSystemProxy)
+	if err != nil {
+		msg := err.Error()
+		status := http.StatusNotFound
+		writeJSON(w, status, map[string]any{"message": msg})
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
 }
 
 // DELETE /api/oauth/connections/:accountId
 func (h *oauthHandler) deleteConnection(w http.ResponseWriter, r *http.Request) {
+	idStr := chi.URLParam(r, "accountId")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || id <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"message": "invalid account id"})
+		return
+	}
+
+	if err := oauth.DeleteOauthConnection(id); err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]any{"message": err.Error()})
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})
 }
 
 // POST /api/oauth/connections/:accountId/quota/refresh
 func (h *oauthHandler) refreshQuota(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{"success": true})
+	idStr := chi.URLParam(r, "accountId")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || id <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"message": "invalid account id"})
+		return
+	}
+
+	snapshot, err := oauth.RefreshOauthQuotaSnapshot(id)
+	if err != nil {
+		msg := err.Error()
+		status := http.StatusInternalServerError
+		if strings.Contains(msg, "not found") || strings.Contains(msg, "not managed by oauth") {
+			status = http.StatusNotFound
+		}
+		writeJSON(w, status, map[string]any{"message": msg})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"success": true, "quota": snapshot})
 }
 
 // POST /api/oauth/connections/quota/refresh-batch
 func (h *oauthHandler) refreshQuotaBatch(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{"success": true})
+	var body struct {
+		AccountIDs []int64 `json:"accountIds"`
+	}
+	if r.Body != nil && r.Body != http.NoBody {
+		if err := decodeJSONRequest(r, &body); err != nil {
+			if isEmptyJSONBodyError(err) {
+				body = struct {
+					AccountIDs []int64 `json:"accountIds"`
+				}{}
+			} else {
+				writeJSON(w, http.StatusBadRequest, map[string]any{"message": "invalid request body"})
+				return
+			}
+		}
+	}
+
+	result := oauth.RefreshOauthConnectionQuotaBatch(body.AccountIDs)
+	writeJSON(w, http.StatusOK, result)
 }
 
 // POST /api/oauth/import

--- a/handler/admin/oauth_routes_crud_test.go
+++ b/handler/admin/oauth_routes_crud_test.go
@@ -1,0 +1,387 @@
+package admin
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// doPatchJSON issues a PATCH request with a JSON body. Mirrors doPostJSON /
+// doPutJSON so the PATCH-based oauth connection endpoints have the same
+// ergonomic helper used everywhere else in the admin test suite.
+func doPatchJSON(t *testing.T, r chi.Router, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req := httptest.NewRequest("PATCH", path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// doPatchRaw issues a PATCH request with an arbitrary raw body. Used to send
+// malformed payloads that json.Marshal could never produce.
+func doPatchRaw(t *testing.T, r chi.Router, path, rawBody string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("PATCH", path, bytes.NewReader([]byte(rawBody)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// insertOAuthAccountUnique inserts an OAuth account under a fresh site whose
+// (platform, url) pair is unique per call. The sites table enforces a UNIQUE
+// constraint on (platform, url), so the shared insertOAuthAccount helper
+// cannot be reused when a test needs more than one account.
+func insertOAuthAccountUnique(t *testing.T, db *store.DB, provider, suffix string) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	siteURL := "https://chatgpt.com/backend-api/" + suffix
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, use_system_proxy, is_pinned, global_weight, sort_order, created_at, updated_at)
+		 VALUES (?, ?, ?, 'active', 0, 0, 1, 0, ?, ?)`,
+		"Codex OAuth Test "+suffix, siteURL, provider, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+
+	accountKey := "acc-" + suffix
+	email := "user" + suffix + "@example.com"
+	extra := `{"oauth":{"provider":"` + provider + `","accountId":"` + accountKey + `","accountKey":"` + accountKey + `","email":"` + email + `","refreshToken":"rt-test"}}`
+	res, err = db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, checkin_enabled, status, oauth_provider, oauth_account_key, extra_config, is_pinned, sort_order, balance, balance_used, quota, value_score, created_at, updated_at)
+		 VALUES (?, ?, ?, 0, 'active', ?, ?, ?, 0, 0, 0, 0, 0, 0, ?, ?)`,
+		siteID, email, "at-test", provider, accountKey, extra, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("account id: %v", err)
+	}
+	return accountID
+}
+
+// ---- listConnections ----
+
+func TestOAuthListConnections_EmptyDB(t *testing.T) {
+	_, r := setupOAuthRoutesTest(t)
+
+	resp := doGet(t, r, "/api/oauth/connections")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	connections, ok := body["connections"].([]any)
+	if !ok {
+		t.Fatalf("connections not an array: %#v", body["connections"])
+	}
+	if len(connections) != 0 {
+		t.Fatalf("expected 0 connections on empty DB, got %d", len(connections))
+	}
+	if got := int64(body["total"].(float64)); got != 0 {
+		t.Fatalf("total=%d, want 0", got)
+	}
+}
+
+func TestOAuthListConnections_WithAccounts(t *testing.T) {
+	db, r := setupOAuthRoutesTest(t)
+	insertOAuthAccount(t, db, "codex")
+
+	resp := doGet(t, r, "/api/oauth/connections")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	connections, ok := body["connections"].([]any)
+	if !ok || len(connections) != 1 {
+		t.Fatalf("expected 1 connection, got %#v", body["connections"])
+	}
+	if got := int64(body["total"].(float64)); got != 1 {
+		t.Fatalf("total=%d, want 1", got)
+	}
+
+	item, ok := connections[0].(map[string]any)
+	if !ok {
+		t.Fatalf("connection item not an object: %#v", connections[0])
+	}
+	if item["provider"] != "codex" {
+		t.Fatalf("provider=%v, want codex", item["provider"])
+	}
+}
+
+func TestOAuthListConnections_Pagination(t *testing.T) {
+	db, r := setupOAuthRoutesTest(t)
+	// Two distinct OAuth accounts under unique sites so the UNIQUE(platform,url)
+	// constraint is satisfied while limit/offset is observable.
+	firstID := insertOAuthAccountUnique(t, db, "codex", "page-a")
+	secondID := insertOAuthAccountUnique(t, db, "codex", "page-b")
+	if firstID == secondID {
+		t.Fatalf("insertOAuthAccountUnique returned duplicate ids: %d", firstID)
+	}
+
+	// Page 1 (limit=1, offset=0): service orders by a.id DESC, so the most
+	// recently inserted account is returned while total stays 2.
+	page1 := doGet(t, r, "/api/oauth/connections?limit=1&offset=0")
+	if page1.Code != http.StatusOK {
+		t.Fatalf("page1 status=%d body=%s", page1.Code, page1.Body.String())
+	}
+	var body1 map[string]any
+	if err := json.Unmarshal(page1.Body.Bytes(), &body1); err != nil {
+		t.Fatalf("decode page1: %v", err)
+	}
+	if got := int64(body1["total"].(float64)); got != 2 {
+		t.Fatalf("page1 total=%d, want 2", got)
+	}
+	conns1, _ := body1["connections"].([]any)
+	if len(conns1) != 1 {
+		t.Fatalf("page1 expected 1 connection, got %d", len(conns1))
+	}
+
+	// Page 2 (limit=1, offset=1): the older account.
+	page2 := doGet(t, r, "/api/oauth/connections?limit=1&offset=1")
+	if page2.Code != http.StatusOK {
+		t.Fatalf("page2 status=%d body=%s", page2.Code, page2.Body.String())
+	}
+	var body2 map[string]any
+	if err := json.Unmarshal(page2.Body.Bytes(), &body2); err != nil {
+		t.Fatalf("decode page2: %v", err)
+	}
+	conns2, _ := body2["connections"].([]any)
+	if len(conns2) != 1 {
+		t.Fatalf("page2 expected 1 connection, got %d", len(conns2))
+	}
+
+	// The two pages must surface distinct accounts.
+	id1, _ := conns1[0].(map[string]any)["accountId"].(float64)
+	id2, _ := conns2[0].(map[string]any)["accountId"].(float64)
+	if id1 == id2 {
+		t.Fatalf("pagination returned the same account twice: %v", id1)
+	}
+}
+
+// ---- updateProxy ----
+
+func TestOAuthUpdateProxy_Success(t *testing.T) {
+	db, r := setupOAuthRoutesTest(t)
+	accountID := insertOAuthAccount(t, db, "codex")
+
+	resp := doPatchJSON(t, r, fmt.Sprintf("/api/oauth/connections/%d/proxy", accountID), map[string]any{
+		"proxyUrl": "http://127.0.0.1:7890",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != true {
+		t.Fatalf("success=%v, want true", body["success"])
+	}
+	if got, _ := body["proxyUrl"].(string); got != "http://127.0.0.1:7890" {
+		t.Fatalf("proxyUrl=%v, want http://127.0.0.1:7890", body["proxyUrl"])
+	}
+	if got := int64(body["accountId"].(float64)); got != accountID {
+		t.Fatalf("accountId=%d, want %d", got, accountID)
+	}
+}
+
+func TestOAuthUpdateProxy_NotFound(t *testing.T) {
+	_, r := setupOAuthRoutesTest(t)
+
+	resp := doPatchJSON(t, r, "/api/oauth/connections/999999/proxy", map[string]any{
+		"proxyUrl": "http://127.0.0.1:7890",
+	})
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if msg, _ := body["message"].(string); !strings.Contains(msg, "not found") {
+		t.Fatalf("message=%q, want 'not found'", msg)
+	}
+}
+
+func TestOAuthUpdateProxy_InvalidAccountID(t *testing.T) {
+	_, r := setupOAuthRoutesTest(t)
+
+	resp := doPatchJSON(t, r, "/api/oauth/connections/abc/proxy", map[string]any{
+		"proxyUrl": "http://127.0.0.1:7890",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+}
+
+func TestOAuthUpdateProxy_MalformedBody(t *testing.T) {
+	db, r := setupOAuthRoutesTest(t)
+	accountID := insertOAuthAccount(t, db, "codex")
+
+	resp := doPatchRaw(t, r, fmt.Sprintf("/api/oauth/connections/%d/proxy", accountID), "{not-json")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+}
+
+// ---- deleteConnection ----
+
+func TestOAuthDeleteConnection_Success(t *testing.T) {
+	db, r := setupOAuthRoutesTest(t)
+	accountID := insertOAuthAccount(t, db, "codex")
+
+	resp := doDelete(t, r, fmt.Sprintf("/api/oauth/connections/%d", accountID))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != true {
+		t.Fatalf("success=%v, want true", body["success"])
+	}
+
+	// The deleted connection must no longer appear in the listing.
+	listResp := doGet(t, r, "/api/oauth/connections")
+	if listResp.Code != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", listResp.Code, listResp.Body.String())
+	}
+	var listBody map[string]any
+	if err := json.Unmarshal(listResp.Body.Bytes(), &listBody); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if got := int64(listBody["total"].(float64)); got != 0 {
+		t.Fatalf("total after delete=%d, want 0", got)
+	}
+}
+
+func TestOAuthDeleteConnection_NotFound(t *testing.T) {
+	_, r := setupOAuthRoutesTest(t)
+
+	resp := doDelete(t, r, "/api/oauth/connections/999999")
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404", resp.Code, resp.Body.String())
+	}
+}
+
+func TestOAuthDeleteConnection_InvalidAccountID(t *testing.T) {
+	_, r := setupOAuthRoutesTest(t)
+
+	resp := doDelete(t, r, "/api/oauth/connections/not-a-number")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+}
+
+// ---- refreshQuota ----
+
+func TestOAuthRefreshQuota_Success(t *testing.T) {
+	db, r := setupOAuthRoutesTest(t)
+	accountID := insertOAuthAccount(t, db, "codex")
+
+	resp := doPostJSON(t, r, fmt.Sprintf("/api/oauth/connections/%d/quota/refresh", accountID), map[string]any{})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != true {
+		t.Fatalf("success=%v, want true", body["success"])
+	}
+	if body["quota"] == nil {
+		t.Fatalf("quota snapshot should be present in response")
+	}
+}
+
+func TestOAuthRefreshQuota_NotFound(t *testing.T) {
+	_, r := setupOAuthRoutesTest(t)
+
+	resp := doPostJSON(t, r, "/api/oauth/connections/999999/quota/refresh", map[string]any{})
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404", resp.Code, resp.Body.String())
+	}
+}
+
+func TestOAuthRefreshQuota_InvalidAccountID(t *testing.T) {
+	_, r := setupOAuthRoutesTest(t)
+
+	resp := doPostJSON(t, r, "/api/oauth/connections/abc/quota/refresh", map[string]any{})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+}
+
+// ---- refreshQuotaBatch ----
+
+func TestOAuthRefreshQuotaBatch_Empty(t *testing.T) {
+	_, r := setupOAuthRoutesTest(t)
+
+	resp := doPostJSON(t, r, "/api/oauth/connections/quota/refresh-batch", map[string]any{
+		"accountIds": []int64{},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["success"] != true {
+		t.Fatalf("success=%v, want true for empty batch", body["success"])
+	}
+	if got := int(body["refreshed"].(float64)); got != 0 {
+		t.Fatalf("refreshed=%d, want 0", got)
+	}
+}
+
+func TestOAuthRefreshQuotaBatch_MissingAccountID(t *testing.T) {
+	db, r := setupOAuthRoutesTest(t)
+	goodID := insertOAuthAccount(t, db, "codex")
+
+	// Batch with one valid + one non-existent account: the valid one refreshes
+	// (success) and the missing one records an error item, but the overall
+	// request still returns 200 with the per-account breakdown.
+	resp := doPostJSON(t, r, "/api/oauth/connections/quota/refresh-batch", map[string]any{
+		"accountIds": []int64{goodID, 999999},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	items, ok := body["items"].([]any)
+	if !ok || len(items) != 2 {
+		t.Fatalf("expected 2 batch items, got %#v", body["items"])
+	}
+}

--- a/handler/admin/stats_detail_test.go
+++ b/handler/admin/stats_detail_test.go
@@ -1,0 +1,396 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// ---- proxyLogDetail ----
+
+func TestStats_SQLiteProxyLogDetail_Found(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	siteID, accountID := insertSiteAccountForStats(t, db, "detail-site", "detail-user", now)
+
+	res, err := db.Exec(`INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, total_tokens, estimated_cost, latency_ms, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		accountID, "gpt-detail", "gpt-detail", "success", 42, 0.123, 250, now)
+	if err != nil {
+		t.Fatalf("insert proxy log: %v", err)
+	}
+	logID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("log id: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/stats/proxy-logs/"+itoa(logID))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got, _ := body["modelRequested"].(string); got != "gpt-detail" {
+		t.Fatalf("modelRequested=%v, want gpt-detail", body["modelRequested"])
+	}
+	if got, _ := body["siteName"].(string); got != "detail-site" {
+		t.Fatalf("siteName=%v, want detail-site", body["siteName"])
+	}
+	if got, _ := body["username"].(string); got != "detail-user" {
+		t.Fatalf("username=%v, want detail-user", body["username"])
+	}
+	if got := int64(body["totalTokens"].(float64)); got != 42 {
+		t.Fatalf("totalTokens=%d, want 42", got)
+	}
+	if got := int64(body["siteId"].(float64)); got != siteID {
+		t.Fatalf("siteId=%d, want %d", got, siteID)
+	}
+}
+
+func TestStats_SQLiteProxyLogDetail_NotFound(t *testing.T) {
+	_, r := setupStatsSQLiteTest(t)
+
+	resp := doGet(t, r, "/api/stats/proxy-logs/999999")
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if msg, _ := body["message"].(string); msg != "proxy log not found" {
+		t.Fatalf("message=%q, want 'proxy log not found'", msg)
+	}
+}
+
+func TestStats_SQLiteProxyLogDetail_ParsesBillingDetails(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	_, accountID := insertSiteAccountForStats(t, db, "billing-site", "billing-user", now)
+
+	// Insert a proxy log whose billing_details column holds a JSON object as a
+	// raw string. The handler must parse it into a structured object in the
+	// response rather than returning the opaque string.
+	billingDetails := `{"total":"0.05","currency":"USD"}`
+	res, err := db.Exec(`INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, billing_details, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		accountID, "gpt-billing", "gpt-billing", "success", billingDetails, now)
+	if err != nil {
+		t.Fatalf("insert proxy log: %v", err)
+	}
+	logID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("log id: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/stats/proxy-logs/"+itoa(logID))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	bd, ok := body["billingDetails"].(map[string]any)
+	if !ok {
+		t.Fatalf("billingDetails should be a parsed object, got %T: %#v", body["billingDetails"], body["billingDetails"])
+	}
+	if bd["currency"] != "USD" {
+		t.Fatalf("billingDetails.currency=%v, want USD", bd["currency"])
+	}
+}
+
+func TestStats_SQLiteProxyLogDetail_UnlinkedLog(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// A proxy log with no account_id: the LEFT JOINs yield NULL site/user
+	// fields but the log itself is still returned.
+	res, err := db.Exec(`INSERT INTO proxy_logs (model_requested, model_actual, status, total_tokens, created_at)
+		VALUES (?, ?, ?, ?, ?)`, "gpt-unlinked", "gpt-unlinked", "success", 5, now)
+	if err != nil {
+		t.Fatalf("insert proxy log: %v", err)
+	}
+	logID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("log id: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/stats/proxy-logs/"+itoa(logID))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got, _ := body["modelRequested"].(string); got != "gpt-unlinked" {
+		t.Fatalf("modelRequested=%v, want gpt-unlinked", body["modelRequested"])
+	}
+	// siteName is absent (nil) because the LEFT JOIN found no site.
+	if body["siteName"] != nil {
+		t.Fatalf("siteName=%v, want nil for unlinked log", body["siteName"])
+	}
+}
+
+// ---- debugTraces ----
+
+func TestStats_SQLiteDebugTraces_Empty(t *testing.T) {
+	_, r := setupStatsSQLiteTest(t)
+
+	resp := doGet(t, r, "/api/stats/proxy-debug/traces")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	items, ok := body["items"].([]any)
+	if !ok {
+		t.Fatalf("items not an array: %#v", body["items"])
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected 0 traces on empty DB, got %d", len(items))
+	}
+}
+
+func TestStats_SQLiteDebugTraces_WithTraces(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	insertDebugTrace(t, db, "/v1/chat/completions", now)
+	insertDebugTrace(t, db, "/v1/responses", now)
+
+	resp := doGet(t, r, "/api/stats/proxy-debug/traces")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	items, ok := body["items"].([]any)
+	if !ok || len(items) != 2 {
+		t.Fatalf("expected 2 traces, got %#v", body["items"])
+	}
+
+	// limit=1 returns only the most recent trace.
+	respLimit := doGet(t, r, "/api/stats/proxy-debug/traces?limit=1")
+	if respLimit.Code != http.StatusOK {
+		t.Fatalf("limit status=%d body=%s", respLimit.Code, respLimit.Body.String())
+	}
+	var limitBody map[string]any
+	if err := json.Unmarshal(respLimit.Body.Bytes(), &limitBody); err != nil {
+		t.Fatalf("decode limit: %v", err)
+	}
+	limitItems, _ := limitBody["items"].([]any)
+	if len(limitItems) != 1 {
+		t.Fatalf("expected 1 trace with limit=1, got %d", len(limitItems))
+	}
+}
+
+// ---- debugTraceDetail ----
+
+func TestStats_SQLiteDebugTraceDetail_FoundWithAttempts(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	traceID := insertDebugTrace(t, db, "/v1/chat/completions", now)
+	insertDebugAttempt(t, db, traceID, 0, now)
+	insertDebugAttempt(t, db, traceID, 1, now)
+
+	resp := doGet(t, r, "/api/stats/proxy-debug/traces/"+itoa(traceID))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got, _ := body["downstreamPath"].(string); got != "/v1/chat/completions" {
+		t.Fatalf("downstreamPath=%v, want /v1/chat/completions", body["downstreamPath"])
+	}
+	attempts, ok := body["attempts"].([]any)
+	if !ok || len(attempts) != 2 {
+		t.Fatalf("expected 2 attempts, got %#v", body["attempts"])
+	}
+}
+
+func TestStats_SQLiteDebugTraceDetail_NotFound(t *testing.T) {
+	_, r := setupStatsSQLiteTest(t)
+
+	resp := doGet(t, r, "/api/stats/proxy-debug/traces/999999")
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if msg, _ := body["message"].(string); msg != "proxy debug trace not found" {
+		t.Fatalf("message=%q, want 'proxy debug trace not found'", msg)
+	}
+}
+
+func TestStats_SQLiteDebugTraceDetail_NoAttempts(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	traceID := insertDebugTrace(t, db, "/v1/responses", now)
+
+	resp := doGet(t, r, "/api/stats/proxy-debug/traces/"+itoa(traceID))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	attempts, ok := body["attempts"].([]any)
+	if !ok || len(attempts) != 0 {
+		t.Fatalf("expected 0 attempts, got %#v", body["attempts"])
+	}
+}
+
+// ---- siteDistribution ----
+
+func TestStats_SQLiteSiteDistribution(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC()
+	nowStr := now.Format(time.RFC3339)
+	today := now.Format("2006-01-02")
+
+	// site-a: one account (balance 100) + recorded spend (0.5) today.
+	siteIDA, _ := insertSiteAccountForStatsWithBalance(t, db, "dist-a", "dist-user-a", nowStr, 100.0)
+	_, err := db.Exec(`INSERT INTO site_day_usage (local_day, site_id, total_calls, success_calls, failed_calls, total_tokens, total_summary_spend, total_site_spend, total_latency_ms, latency_count, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		today, siteIDA, 10, 8, 2, 200, 0.5, 0.0, 1000, 10, nowStr, nowStr)
+	if err != nil {
+		t.Fatalf("insert site_day_usage: %v", err)
+	}
+
+	// site-b: no accounts, no usage.
+	_, err = db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "dist-b", "https://dist-b.example.test", "openai", nowStr, nowStr)
+	if err != nil {
+		t.Fatalf("insert site-b: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/stats/site-distribution?days=7")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	distribution, ok := body["distribution"].([]any)
+	if !ok || len(distribution) != 2 {
+		t.Fatalf("expected 2 distribution entries, got %#v", body["distribution"])
+	}
+
+	// Ordered by total_spend DESC: dist-a (0.5) first, dist-b (0) second.
+	first := distribution[0].(map[string]any)
+	if first["siteName"] != "dist-a" {
+		t.Fatalf("first entry siteName=%v, want dist-a", first["siteName"])
+	}
+	if got := int(first["accountCount"].(float64)); got != 1 {
+		t.Fatalf("dist-a accountCount=%d, want 1", got)
+	}
+	if got := first["totalBalance"].(float64); got != 100 {
+		t.Fatalf("dist-a totalBalance=%v, want 100", got)
+	}
+	if got := first["totalSpend"].(float64); got != 0.5 {
+		t.Fatalf("dist-a totalSpend=%v, want 0.5", got)
+	}
+
+	second := distribution[1].(map[string]any)
+	if second["siteName"] != "dist-b" {
+		t.Fatalf("second entry siteName=%v, want dist-b", second["siteName"])
+	}
+	if got := int(second["accountCount"].(float64)); got != 0 {
+		t.Fatalf("dist-b accountCount=%d, want 0", got)
+	}
+	if got := second["totalSpend"].(float64); got != 0 {
+		t.Fatalf("dist-b totalSpend=%v, want 0", got)
+	}
+}
+
+// ---- modelProbe ----
+
+func TestStats_SQLiteModelProbe_SchedulerNotRunning(t *testing.T) {
+	_, r := setupStatsSQLiteTest(t)
+
+	resp := doPostJSON(t, r, "/api/models/probe", map[string]any{})
+	// In unit tests the global model-probe scheduler is never started, so the
+	// handler must report 503 Service Unavailable rather than queueing a job.
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("modelProbe status=%d body=%s, want 503", resp.Code, resp.Body.String())
+	}
+}
+
+// ---- helpers ----
+
+// insertSiteAccountForStats inserts a site and a linked account, returning
+// (siteID, accountID). Used by proxy-log detail tests that need the JOINs.
+func insertSiteAccountForStats(t *testing.T, db *store.DB, siteName, username, now string) (int64, int64) {
+	t.Helper()
+	return insertSiteAccountForStatsWithBalance(t, db, siteName, username, now, 0)
+}
+
+func insertSiteAccountForStatsWithBalance(t *testing.T, db *store.DB, siteName, username, now string, balance float64) (int64, int64) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, siteName, "https://"+siteName+".example.test", "openai", now, now)
+	if err != nil {
+		t.Fatalf("insert site %s: %v", siteName, err)
+	}
+	var siteID int64
+	if err := db.Get(&siteID, "SELECT id FROM sites WHERE name = ?", siteName); err != nil {
+		t.Fatalf("site id %s: %v", siteName, err)
+	}
+	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, balance, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, FALSE, ?, ?)`, siteID, username, "sk-"+siteName, balance, now, now)
+	if err != nil {
+		t.Fatalf("insert account %s: %v", username, err)
+	}
+	var accountID int64
+	if err := db.Get(&accountID, "SELECT id FROM accounts WHERE username = ?", username); err != nil {
+		t.Fatalf("account id %s: %v", username, err)
+	}
+	return siteID, accountID
+}
+
+// insertDebugTrace inserts a minimal proxy_debug_traces row and returns its id.
+func insertDebugTrace(t *testing.T, db *store.DB, downstreamPath, now string) int64 {
+	t.Helper()
+	res, err := db.Exec(`INSERT INTO proxy_debug_traces (downstream_path, created_at, updated_at)
+		VALUES (?, ?, ?)`, downstreamPath, now, now)
+	if err != nil {
+		t.Fatalf("insert debug trace: %v", err)
+	}
+	traceID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("trace id: %v", err)
+	}
+	return traceID
+}
+
+// insertDebugAttempt inserts a minimal proxy_debug_attempts row linked to a trace.
+func insertDebugAttempt(t *testing.T, db *store.DB, traceID, attemptIndex int64, now string) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO proxy_debug_attempts (trace_id, attempt_index, endpoint, request_path, target_url, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		traceID, attemptIndex, "https://api.openai.com", "/v1/chat/completions", "https://api.openai.com/v1/chat/completions", now)
+	if err != nil {
+		t.Fatalf("insert debug attempt: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- **OAuth CRUD handlers**: Wire the four stub handlers (`updateProxy`, `deleteConnection`, `refreshQuota`, `refreshQuotaBatch`) to their existing service-layer functions so they exercise real DB logic. Add HTTP handler tests covering `listConnections` (empty/with-accounts/pagination), `updateProxy` (success/not-found/invalid-input/malformed-body), `deleteConnection` (success/not-found/invalid-id), `refreshQuota` (success/not-found), and a `refreshQuotaBatch` smoke test.
- **Stats detail handlers**: Add `stats_detail_test.go` covering `proxyLogDetail` (found/not-found/billing-details-parsing/unlinked-log), `debugTraces` (empty/with-traces/limit), `debugTraceDetail` (found-with-attempts/not-found/no-attempts), `siteDistribution` (multi-site ordering with balances+spend), and `modelProbe` (503 when scheduler not running).
- **docker-compose.prod.yml**: Add a commented env-passthrough block for batch 9-13 configurable settings (LDOH, proxy rate-limit/log, body/upload limits, admin/oauth rate-limit, stream/buffer caps, `LOG_LEVEL`) matching the existing mapping syntax.

## Test plan

- [x] `go build ./handler/... ./service/... ./scheduler/... ./docs/...` passes
- [x] `go vet ./handler/... ./service/... ./scheduler/... ./docs/...` passes
- [x] `go test ./handler/admin/... -count=1 -timeout 120s` passes (all admin tests green)
- [x] `go test ./docs/... -run TestPgRebindGate` passes (no bare `?` placeholders through `*sqlx.DB`)
- [x] docker-compose YAML validated