### PR TITLE
fix: OAuth backfill off hot path + cache single-flight + SSRF guard dedup

### DIFF
--- a/app/oauth_backfill.go
+++ b/app/oauth_backfill.go
@@ -1,0 +1,26 @@
+package app
+
+import (
+	"log/slog"
+
+	"github.com/deliciousbuding/metapi-go/service/oauth"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// RunOauthIdentityBackfill runs the one-time OAuth identity column backfill at
+// startup. It is a bounded migration (LIMIT-batched, settings-marker-gated) so
+// the paginated admin list endpoint never pays the per-page scan+update cost
+// that the old in-request backfill imposed.
+//
+// Safe to call on every boot: the settings marker short-circuits healthy
+// instances, and a partial run (process killed mid-batch) leaves the marker
+// unset and retries on the next boot. Must run after the runtime database is
+// bootstrapped (store.EnsureRuntimeDatabase) so store.GetDB is non-nil.
+func RunOauthIdentityBackfill() {
+	db := store.GetDB()
+	if db == nil {
+		slog.Warn("oauth identity backfill skipped: database not initialized")
+		return
+	}
+	oauth.RunOauthIdentityBackfillOnce(db)
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -82,6 +82,10 @@ func main() {
 		slog.Error("startup bootstrap failed", "error", err)
 		os.Exit(1)
 	}
+	// One-time OAuth identity column backfill (bounded, marker-gated). Runs
+	// before the server accepts traffic so the admin list endpoint never
+	// pays the old per-request scan+update cost. See app.RunOauthIdentityBackfill.
+	app.RunOauthIdentityBackfill()
 	// N7: apply operator-configured cache-ratio fallback overrides to routing.
 	app.ApplyCacheRatioOverrides(cfg)
 	if err := app.ConfigureProxyUpstream(cfg); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/refraction-networking/utls v1.8.2
 	github.com/robfig/cron/v3 v3.0.1
+	golang.org/x/sync v0.21.0
 	golang.org/x/time v0.15.0
 	modernc.org/sqlite v1.56.0
 )
@@ -27,7 +28,6 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	modernc.org/libc v1.74.4 // indirect

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -22,6 +22,7 @@ import (
 	"github.com/deliciousbuding/metapi-go/store"
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
+	"golang.org/x/sync/singleflight"
 )
 
 // RegisterAccountsRoutes registers all /api/accounts routes.
@@ -54,6 +55,10 @@ type accountsSnapshotCache struct {
 	data      []byte
 	expiresAt time.Time
 	ttl       time.Duration
+	// flight deduplicates concurrent cache-miss computes so N admin sessions
+	// polling an expired snapshot share one ListAccountsWithSites + per-account
+	// metrics run instead of running it N× (thundering herd).
+	flight singleflight.Group
 }
 
 func (c *accountsSnapshotCache) get() ([]byte, bool) {
@@ -77,6 +82,35 @@ func (c *accountsSnapshotCache) clear() {
 	defer c.mu.Unlock()
 	c.data = nil
 	c.expiresAt = time.Time{}
+}
+
+// getOrCompute returns the cached snapshot, or computes it via the supplied
+// function under single-flight dedup so N concurrent admin sessions hitting a
+// cold/expired cache share one compute instead of running it N×. Returns
+// (data, hit, err): hit reports whether the fast-path cache served the bytes
+// (for the x-accounts-snapshot-cache response header). Only successful
+// computes are stored, so errors never poison the cache.
+func (c *accountsSnapshotCache) getOrCompute(compute func() ([]byte, error)) ([]byte, bool, error) {
+	if cached, hit := c.get(); hit {
+		return cached, true, nil
+	}
+	result, err, _ := c.flight.Do("snapshot", func() (any, error) {
+		// Re-check: a concurrent leader may have populated the cache while we
+		// waited for the single-flight slot.
+		if cached, hit := c.get(); hit {
+			return cached, nil
+		}
+		data, err := compute()
+		if err != nil {
+			return nil, err
+		}
+		c.set(data)
+		return data, nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return result.([]byte), false, nil
 }
 
 var globalAccountsCache = &accountsSnapshotCache{ttl: 30 * time.Second}
@@ -105,22 +139,43 @@ func (h *accountsHandler) listAccounts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check snapshot cache
-	if !forceRefresh {
-		if cached, hit := globalAccountsCache.get(); hit {
-			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("x-accounts-snapshot-cache", "hit")
-			w.WriteHeader(http.StatusOK)
-			w.Write(cached)
-			return
-		}
+	// Snapshot cache: a hit short-circuits; on a miss the single-flight group
+	// deduplicates concurrent computes so N admin sessions polling an expired
+	// snapshot share one ListAccountsWithSites + per-account metrics run
+	// instead of running it N× (thundering herd). ?refresh=true clears the
+	// cache first so a force request always recomputes and repopulates.
+	if forceRefresh {
+		globalAccountsCache.clear()
 	}
-
-	accounts, err := service.ListAccountsWithSites(h.db)
+	data, cacheHit, err := globalAccountsCache.getOrCompute(func() ([]byte, error) {
+		return h.computeAccountsSnapshot()
+	})
 	if err != nil {
 		slog.Error("Failed to load accounts", "err", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load accounts"})
 		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if cacheHit {
+		w.Header().Set("x-accounts-snapshot-cache", "hit")
+	} else {
+		w.Header().Set("x-accounts-snapshot-cache", "miss")
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+// computeAccountsSnapshot builds the full accounts+sites snapshot payload (the
+// cache-miss path). Extracted from listAccounts so the single-flight group can
+// deduplicate concurrent misses. Returns the marshaled JSON bytes; the caller
+// (getOrCompute) stores them in the cache. Today-metrics failure degrades to
+// "no metrics" and is logged — the account list itself must not fail because
+// an auxiliary aggregation query broke.
+func (h *accountsHandler) computeAccountsSnapshot() ([]byte, error) {
+	accounts, err := service.ListAccountsWithSites(h.db)
+	if err != nil {
+		return nil, err
 	}
 
 	// Per-account today truth. Failure degrades to "no metrics" (frontend shows
@@ -142,11 +197,7 @@ func (h *accountsHandler) listAccounts(w http.ResponseWriter, r *http.Request) {
 		"accounts":    accounts,
 		"sites":       sites,
 	}
-	respBytes, _ := json.Marshal(resp)
-	globalAccountsCache.set(respBytes)
-
-	w.Header().Set("x-accounts-snapshot-cache", "miss")
-	writeJSON(w, http.StatusOK, resp)
+	return json.Marshal(resp)
 }
 
 // listAccountsPaginated serves GET /api/accounts?page=&pageSize= with a bounded
@@ -178,12 +229,12 @@ func (h *accountsHandler) listAccountsPaginated(w http.ResponseWriter, r *http.R
 	h.db.Select(&sites, "SELECT "+service.SiteSelectColumns+" FROM sites ORDER BY sort_order, id")
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"items":     normalizeSlice(accounts),
-		"total":     total,
-		"page":      page,
-		"pageSize":  pageSize,
+		"items":       normalizeSlice(accounts),
+		"total":       total,
+		"page":        page,
+		"pageSize":    pageSize,
 		"generatedAt": time.Now().UTC().Format(time.RFC3339),
-		"sites":     sites,
+		"sites":       sites,
 	})
 }
 
@@ -233,7 +284,7 @@ func applyAccountTodayMetrics(accounts []map[string]any, todayMetrics map[int64]
 func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountCreatePayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid account payload: " + err.Error())
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid account payload: "+err.Error())
 		return
 	}
 
@@ -619,7 +670,7 @@ func (h *accountsHandler) createSingleAccount(ctx context.Context, body payloads
 func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountLoginPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid login payload: " + err.Error())
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid login payload: "+err.Error())
 		return
 	}
 
@@ -645,7 +696,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 
 	adp := platform.GetAdapter(site.Platform)
 	if adp == nil {
-		writeErrorWithRequest(w, r, http.StatusBadRequest, "unsupported platform: " + site.Platform)
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "unsupported platform: "+site.Platform)
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
@@ -760,7 +811,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 	var body payloads.AccountVerifyTokenPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid verify-token payload: " + err.Error())
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid verify-token payload: "+err.Error())
 		return
 	}
 
@@ -787,7 +838,7 @@ func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 
 	adp := platform.GetAdapter(site.Platform)
 	if adp == nil {
-		writeErrorWithRequest(w, r, http.StatusBadRequest, "unsupported platform: " + site.Platform)
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "unsupported platform: "+site.Platform)
 		return
 	}
 
@@ -951,7 +1002,7 @@ func (h *accountsHandler) rebindSession(w http.ResponseWriter, r *http.Request) 
 
 	var body payloads.AccountRebindSessionPayload
 	if err := decodeJSONRequest(r, &body); err != nil {
-		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid rebind payload: " + err.Error())
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid rebind payload: "+err.Error())
 		return
 	}
 

--- a/handler/admin/channels.go
+++ b/handler/admin/channels.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/deliciousbuding/metapi-go/handler/shared"
 	"github.com/deliciousbuding/metapi-go/routing"
+	"golang.org/x/sync/singleflight"
 )
 
 // channelListRow is the flattened read-only projection for GET /api/channels.
@@ -52,6 +53,10 @@ type channelsSnapshotCache struct {
 	data      []byte
 	expiresAt time.Time
 	ttl       time.Duration
+	// flight deduplicates concurrent cache-miss computes for the same page so
+	// N admin sessions polling an expired entry share one 5-way JOIN run
+	// instead of running it N× (thundering herd).
+	flight singleflight.Group
 }
 
 func (c *channelsSnapshotCache) get(key string) ([]byte, bool) {
@@ -77,6 +82,35 @@ func (c *channelsSnapshotCache) clear() {
 	c.data = nil
 	c.key = ""
 	c.expiresAt = time.Time{}
+}
+
+// getOrCompute returns the cached payload for key, or computes it via the
+// supplied function under single-flight dedup so N concurrent admin sessions
+// hitting a cold/expired entry share one 5-way JOIN run instead of running it
+// N× (thundering herd). Returns (data, hit, err): hit reports whether the
+// fast-path cache served the bytes (for the x-channels-snapshot-cache response
+// header). Only successful computes are stored, so errors never poison the cache.
+func (c *channelsSnapshotCache) getOrCompute(key string, compute func() ([]byte, error)) ([]byte, bool, error) {
+	if cached, hit := c.get(key); hit {
+		return cached, true, nil
+	}
+	result, err, _ := c.flight.Do(key, func() (any, error) {
+		// Re-check: a concurrent leader may have populated the cache while we
+		// waited for the single-flight slot.
+		if cached, hit := c.get(key); hit {
+			return cached, nil
+		}
+		data, err := compute()
+		if err != nil {
+			return nil, err
+		}
+		c.set(key, data)
+		return data, nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return result.([]byte), false, nil
 }
 
 var globalChannelsCache = &channelsSnapshotCache{ttl: 10 * time.Second}
@@ -106,16 +140,41 @@ func (h *tokenRoutesHandler) listChannels(w http.ResponseWriter, r *http.Request
 	forceRefresh := parseTruthyQuery(r.URL.Query().Get("refresh"))
 	cacheKey := fmt.Sprintf("%d:%d", page, pageSize)
 
-	if !forceRefresh {
-		if cached, hit := globalChannelsCache.get(cacheKey); hit {
-			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("x-channels-snapshot-cache", "hit")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(cached)
-			return
-		}
+	// Snapshot cache: a hit short-circuits; on a miss the single-flight group
+	// deduplicates concurrent computes for the same page so N admin sessions
+	// polling an expired entry share one 5-way JOIN run instead of running it
+	// N× (thundering herd). ?refresh=true clears the cache first so a force
+	// request always recomputes and repopulates.
+	if forceRefresh {
+		globalChannelsCache.clear()
+	}
+	data, cacheHit, err := globalChannelsCache.getOrCompute(cacheKey, func() ([]byte, error) {
+		return h.computeChannelsPage(r, page, pageSize)
+	})
+	if err != nil {
+		slog.Error("channels list failed", "error", err)
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "加载通道列表失败")
+		return
 	}
 
+	w.Header().Set("Content-Type", "application/json")
+	if cacheHit {
+		w.Header().Set("x-channels-snapshot-cache", "hit")
+	} else {
+		w.Header().Set("x-channels-snapshot-cache", "miss")
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+// computeChannelsPage runs the 5-way JOIN channel list query (the cache-miss
+// path). Extracted from listChannels so the single-flight group can
+// deduplicate concurrent misses. Uses the caller's request context so a client
+// disconnect cancels the in-flight query; under single-flight the leader's
+// context is shared (followers arrive while the leader is already running, so
+// their own context is not on the critical path). Returns the marshaled JSON
+// bytes; the caller (getOrCompute) stores them in the cache.
+func (h *tokenRoutesHandler) computeChannelsPage(r *http.Request, page, pageSize int) ([]byte, error) {
 	offset := (page - 1) * pageSize
 	var rows []channelListRow
 	if err := h.db.SelectContext(r.Context(), &rows, h.db.Rebind(`
@@ -137,9 +196,7 @@ func (h *tokenRoutesHandler) listChannels(w http.ResponseWriter, r *http.Request
 		LEFT JOIN account_tokens at ON rc.token_id = at.id
 		ORDER BY rc.id ASC
 		LIMIT ? OFFSET ?`), pageSize, offset); err != nil {
-		slog.Error("channels list failed", "error", err)
-		writeErrorWithRequest(w, r, http.StatusInternalServerError, "加载通道列表失败")
-		return
+		return nil, err
 	}
 
 	// Refresh the metapi_active_channels gauge so /metrics reflects the real
@@ -173,13 +230,7 @@ func (h *tokenRoutesHandler) listChannels(w http.ResponseWriter, r *http.Request
 		"page":     page,
 		"pageSize": pageSize,
 	}
-	respBytes, _ := json.Marshal(resp)
-	globalChannelsCache.set(cacheKey, respBytes)
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("x-channels-snapshot-cache", "miss")
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(respBytes)
+	return json.Marshal(resp)
 }
 
 func channelListItem(row channelListRow) map[string]any {

--- a/handler/admin/settings_backup_webdav.go
+++ b/handler/admin/settings_backup_webdav.go
@@ -11,13 +11,13 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"net/netip"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/deliciousbuding/metapi-go/app"
+	"github.com/deliciousbuding/metapi-go/internal/ssrf"
 	"github.com/deliciousbuding/metapi-go/scheduler"
 	"github.com/jmoiron/sqlx"
 )
@@ -262,14 +262,15 @@ func isValidWebdavFileURL(raw string) bool {
 	}
 	// Explicit SSRF guard: reject literal IPs in private/loopback/link-local/
 	// unspecified ranges at the URL-validation layer. This complements the
-	// dial-time DNS resolution check in rejectUnsafeWebdavDialHost and the
-	// hostname-level guard in isAllowedWebdavTargetHost. The allowPrivateWebdavTargets
-	// flag (test-only) bypasses this guard so httptest servers on 127.0.0.1 work.
+	// dial-time DNS resolution check in ssrf.RejectUnsafeWebdavDialHost and the
+	// hostname-level guard in ssrf.IsAllowedWebdavTargetHost. The
+	// allowPrivateWebdavTargets flag (test-only) bypasses this guard so
+	// httptest servers on 127.0.0.1 work.
 	host := parsed.Hostname()
-	if !allowPrivateWebdavTargets && isPrivateOrLoopback(host) {
+	if !allowPrivateWebdavTargets && ssrf.IsPrivateOrLoopbackLiteral(host) {
 		return false
 	}
-	return isAllowedWebdavTargetHost(host)
+	return ssrf.IsAllowedWebdavTargetHost(host, allowPrivateWebdavTargets)
 }
 
 func decodeOptionalJSONRequest(r *http.Request, dst any) error {
@@ -497,7 +498,7 @@ func newWebdavHTTPTransport() *http.Transport {
 				if err != nil {
 					return nil, err
 				}
-				if err := rejectUnsafeWebdavDialHost(ctx, host); err != nil {
+				if err := ssrf.RejectUnsafeWebdavDialHost(ctx, host, allowPrivateWebdavTargets); err != nil {
 					return nil, err
 				}
 			}
@@ -507,75 +508,6 @@ func newWebdavHTTPTransport() *http.Transport {
 		ResponseHeaderTimeout: backupWebdavFetchTimeout,
 		IdleConnTimeout:       30 * time.Second,
 	}
-}
-
-func rejectUnsafeWebdavDialHost(ctx context.Context, host string) error {
-	if !isAllowedWebdavTargetHost(host) {
-		return fmt.Errorf("refusing WebDAV request to unsafe host %q", host)
-	}
-	if _, err := netip.ParseAddr(strings.Trim(host, "[]")); err == nil {
-		return nil
-	}
-	ips, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
-	if err != nil {
-		return err
-	}
-	if len(ips) == 0 {
-		return fmt.Errorf("no IP addresses found for WebDAV host %q", host)
-	}
-	for _, ip := range ips {
-		if isUnsafeWebdavAddr(ip) {
-			return fmt.Errorf("refusing WebDAV request to unsafe resolved address %s", ip)
-		}
-	}
-	return nil
-}
-
-func isAllowedWebdavTargetHost(host string) bool {
-	if allowPrivateWebdavTargets {
-		return true
-	}
-	host = strings.TrimSpace(strings.Trim(host, "[]"))
-	if host == "" || strings.Contains(host, "%") {
-		return false
-	}
-	lower := strings.TrimSuffix(strings.ToLower(host), ".")
-	if lower == "localhost" || strings.HasSuffix(lower, ".localhost") {
-		return false
-	}
-	if addr, err := netip.ParseAddr(host); err == nil {
-		return !isUnsafeWebdavAddr(addr)
-	}
-	return true
-}
-
-func isUnsafeWebdavAddr(addr netip.Addr) bool {
-	addr = addr.Unmap()
-	return addr.IsUnspecified() ||
-		addr.IsLoopback() ||
-		addr.IsPrivate() ||
-		addr.IsLinkLocalUnicast() ||
-		addr.IsLinkLocalMulticast() ||
-		addr.IsMulticast()
-}
-
-// isPrivateOrLoopback reports whether host is a literal IP address in a
-// private, loopback, link-local, multicast, or unspecified range. This covers:
-//   - Loopback: 127.0.0.0/8, ::1
-//   - Link-local: 169.254.0.0/16 (incl. cloud metadata 169.254.169.254), fe80::/10
-//   - Private: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
-//   - Unspecified: 0.0.0.0/8, ::
-//
-// Hostnames that are not literal IPs return false: DNS resolution for
-// hostnames is deferred to the dial-time guard in rejectUnsafeWebdavDialHost
-// to avoid TOCTOU races (a hostname that resolves to a safe IP at validation
-// time could resolve to a private IP by dial time, and vice versa).
-func isPrivateOrLoopback(host string) bool {
-	addr, err := netip.ParseAddr(strings.Trim(host, "[]"))
-	if err != nil {
-		return false
-	}
-	return isUnsafeWebdavAddr(addr)
 }
 
 func readLimitedWebdavBody(body io.Reader, maxBytes int64) ([]byte, error) {

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -16,6 +16,7 @@ import (
 	dailyservice "github.com/deliciousbuding/metapi-go/service/daily"
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
+	"golang.org/x/sync/singleflight"
 )
 
 // RegisterStatsRoutes registers all /api/stats and /api/models routes.
@@ -89,6 +90,10 @@ type dashboardSummaryCache struct {
 	mu      sync.RWMutex
 	entries map[string]dashboardCacheEntry
 	ttl     time.Duration
+	// flight deduplicates concurrent cache-miss computes for the same view so
+	// N admin sessions polling an expired entry share one expensive
+	// aggregation run instead of running it N× (thundering herd).
+	flight singleflight.Group
 }
 
 type dashboardCacheEntry struct {
@@ -125,6 +130,40 @@ func (c *dashboardSummaryCache) clear() {
 	c.entries = nil
 }
 
+// getOrCompute returns the cached payload for view, or computes it via the
+// supplied function under single-flight dedup so N concurrent admin sessions
+// hitting a cold/expired cache share one expensive aggregation run instead of
+// running it N× (thundering herd). A leader that populates the cache mid-flight
+// lets concurrent followers short-circuit on the re-check inside Do.
+//
+// Returns (data, hit, err): hit reports whether the fast-path cache served the
+// bytes (for the x-dashboard-summary-cache response header). A single-flight-
+// shared compute is reported as a miss since this request did not get an
+// instant cached response — only successful computes are stored, so errors
+// never poison the cache.
+func (c *dashboardSummaryCache) getOrCompute(view string, compute func() ([]byte, error)) ([]byte, bool, error) {
+	if cached, hit := c.get(view); hit {
+		return cached, true, nil
+	}
+	result, err, _ := c.flight.Do(view, func() (any, error) {
+		// Re-check: a concurrent leader may have populated the cache while we
+		// waited for the single-flight slot.
+		if cached, hit := c.get(view); hit {
+			return cached, nil
+		}
+		data, err := compute()
+		if err != nil {
+			return nil, err
+		}
+		c.set(view, data)
+		return data, nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return result.([]byte), false, nil
+}
+
 var globalDashboardCache = &dashboardSummaryCache{ttl: 10 * time.Second}
 
 // ---- Dashboard ----
@@ -142,95 +181,85 @@ func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 		globalDashboardCache.clear()
 	}
 
-	// Cache hit short-circuits the expensive aggregation queries. The cached
-	// bytes are the exact JSON the miss path would have produced.
-	if cached, hit := globalDashboardCache.get(view); hit {
-		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("x-dashboard-summary-cache", "hit")
-		w.Header().Set("x-dashboard-insights-cache", "miss")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(cached)
-		return
-	}
-
-	// Cache miss: report miss and compute. Both headers default to "miss";
-	// the summary header reflects this cache's state.
-	w.Header().Set("x-dashboard-summary-cache", "miss")
-	w.Header().Set("x-dashboard-insights-cache", "miss")
-
-	now := time.Now()
-	generatedAt := now.UTC().Format(time.RFC3339)
-	result := map[string]any{
-		"generatedAt": generatedAt,
-	}
-
-	// Fail-open: a single aggregation query failing must not blank the whole
-	// dashboard. Each sub-query is wrapped in individual error handling — on
-	// failure the field gets a null marker, the error is logged, and the
-	// field name is recorded in failedMetrics. Mirrors the todayMetricStatus
-	// degrade-to-partial pattern from accounts.go (listAccounts).
-	failedMetrics := make([]string, 0, 8)
-	markFailed := func(field, operation string, err error) {
-		slog.Error("dashboard stats query failed; degrading to partial", "operation", operation, "field", field, "error", err)
-		failedMetrics = append(failedMetrics, field)
-		result[field] = nil
-	}
-
-	if view == "summary" || view == "full" {
-		var siteCount, accountCount, activeAccounts int
-		if err := h.db.Get(&siteCount, "SELECT COUNT(*) FROM sites"); err != nil {
-			markFailed("siteCount", "load site count", err)
-		} else {
-			result["siteCount"] = siteCount
+	// Cache hit short-circuits the expensive aggregation queries; on a miss
+	// the single-flight group deduplicates concurrent computes for the same
+	// view so N admin sessions polling an expired entry share one aggregation
+	// run instead of running it N× (thundering herd). ?force=1 cleared the
+	// cache above, so a force request always enters the compute path.
+	data, cacheHit, computeErr := globalDashboardCache.getOrCompute(view, func() ([]byte, error) {
+		now := time.Now()
+		generatedAt := now.UTC().Format(time.RFC3339)
+		result := map[string]any{
+			"generatedAt": generatedAt,
 		}
-		if err := h.db.Get(&accountCount, "SELECT COUNT(*) FROM accounts"); err != nil {
-			markFailed("accountCount", "load account count", err)
-			result["totalAccounts"] = nil
-		} else {
-			result["accountCount"] = accountCount
-			result["totalAccounts"] = accountCount
+
+		// Fail-open: a single aggregation query failing must not blank the whole
+		// dashboard. Each sub-query is wrapped in individual error handling — on
+		// failure the field gets a null marker, the error is logged, and the
+		// field name is recorded in failedMetrics. Mirrors the todayMetricStatus
+		// degrade-to-partial pattern from accounts.go (listAccounts).
+		failedMetrics := make([]string, 0, 8)
+		markFailed := func(field, operation string, err error) {
+			slog.Error("dashboard stats query failed; degrading to partial", "operation", operation, "field", field, "error", err)
+			failedMetrics = append(failedMetrics, field)
+			result[field] = nil
 		}
-		if err := h.db.Get(&activeAccounts, `
+
+		if view == "summary" || view == "full" {
+			var siteCount, accountCount, activeAccounts int
+			if err := h.db.Get(&siteCount, "SELECT COUNT(*) FROM sites"); err != nil {
+				markFailed("siteCount", "load site count", err)
+			} else {
+				result["siteCount"] = siteCount
+			}
+			if err := h.db.Get(&accountCount, "SELECT COUNT(*) FROM accounts"); err != nil {
+				markFailed("accountCount", "load account count", err)
+				result["totalAccounts"] = nil
+			} else {
+				result["accountCount"] = accountCount
+				result["totalAccounts"] = accountCount
+			}
+			if err := h.db.Get(&activeAccounts, `
 			SELECT COUNT(*) FROM accounts a
 			INNER JOIN sites s ON s.id = a.site_id
 			WHERE a.status = 'active' AND s.status = 'active'
 		`); err != nil {
-			markFailed("activeAccounts", "load active account count", err)
-		} else {
-			result["activeAccounts"] = activeAccounts
-		}
+				markFailed("activeAccounts", "load active account count", err)
+			} else {
+				result["activeAccounts"] = activeAccounts
+			}
 
-		var totalBalance, totalUsed float64
-		if err := h.db.Get(&totalBalance, `
+			var totalBalance, totalUsed float64
+			if err := h.db.Get(&totalBalance, `
 			SELECT COALESCE(SUM(COALESCE(a.balance, 0)), 0)
 			FROM accounts a
 			INNER JOIN sites s ON s.id = a.site_id
 			WHERE s.status = 'active'
 		`); err != nil {
-			markFailed("totalBalance", "load total balance", err)
-		} else {
-			result["totalBalance"] = roundMicro(totalBalance)
-		}
-		if err := h.db.Get(&totalUsed, `
+				markFailed("totalBalance", "load total balance", err)
+			} else {
+				result["totalBalance"] = roundMicro(totalBalance)
+			}
+			if err := h.db.Get(&totalUsed, `
 			SELECT COALESCE(SUM(COALESCE(a.balance_used, 0)), 0)
 			FROM accounts a
 			INNER JOIN sites s ON s.id = a.site_id
 			WHERE s.status = 'active'
 		`); err != nil {
-			markFailed("totalUsed", "load total used", err)
-		} else {
-			result["totalUsed"] = roundMicro(totalUsed)
-		}
+				markFailed("totalUsed", "load total used", err)
+			} else {
+				result["totalUsed"] = roundMicro(totalUsed)
+			}
 
-		// 24h proxy window (UTC) — single-pass aggregate with effective tokens.
-		since24h := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
-		var proxy24h struct {
-			Total       int     `db:"total"`
-			Success     int     `db:"success"`
-			TotalTokens int64   `db:"total_tokens"`
-			TotalCost   float64 `db:"total_cost"`
-		}
-		if err := h.db.Get(&proxy24h, rebindAdminQuery(h.db, `
+			// 24h proxy window (UTC) — single-pass aggregate with effective tokens.
+			since24h := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
+			var proxy24h struct {
+				Total       int     `db:"total"`
+				Success     int     `db:"success"`
+				TotalTokens int64   `db:"total_tokens"`
+				TotalCost   float64 `db:"total_cost"`
+			}
+			if err := h.db.Get(&proxy24h, rebindAdminQuery(h.db, `
 			SELECT
 				COUNT(*) AS total,
 				COALESCE(SUM(CASE WHEN pl.status = 'success' THEN 1 ELSE 0 END), 0) AS success,
@@ -241,80 +270,80 @@ func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 			INNER JOIN sites s ON s.id = a.site_id
 			WHERE pl.created_at >= ? AND s.status = 'active'
 		`), since24h); err != nil {
-			markFailed("proxy24h", "load 24h proxy metrics", err)
-		} else {
-			result["proxy24h"] = map[string]any{
-				"total":       proxy24h.Total,
-				"success":     proxy24h.Success,
-				"totalTokens": proxy24h.TotalTokens,
-				"totalCost":   roundMicro(proxy24h.TotalCost),
+				markFailed("proxy24h", "load 24h proxy metrics", err)
+			} else {
+				result["proxy24h"] = map[string]any{
+					"total":       proxy24h.Total,
+					"success":     proxy24h.Success,
+					"totalTokens": proxy24h.TotalTokens,
+					"totalCost":   roundMicro(proxy24h.TotalCost),
+				}
+				// Legacy flat fields kept for older clients / tests.
+				result["totalTokens"] = proxy24h.TotalTokens
+				result["totalCost"] = roundMicro(proxy24h.TotalCost)
 			}
-			// Legacy flat fields kept for older clients / tests.
-			result["totalTokens"] = proxy24h.TotalTokens
-			result["totalCost"] = roundMicro(proxy24h.TotalCost)
-		}
 
-		dailyMetrics, metricsErr := dailyservice.CollectDailySummaryMetrics(h.db, now)
-		if metricsErr != nil {
-			markFailed("todayMetricStatus", "load local-day metrics", metricsErr)
-			result["todaySpend"] = nil
-			result["todayReward"] = nil
-			result["todayCheckin"] = nil
-			result["todayMetricStatus"] = map[string]any{
-				"status": "partial",
-				"reason": "metrics collection failed",
-			}
-		} else {
-			result["todaySpend"] = roundMicro(dailyMetrics.TodaySpend)
-			result["todayReward"] = roundMicro(dailyMetrics.TodayReward)
-			result["todayCheckin"] = map[string]any{
-				"total":   dailyMetrics.CheckinTotal,
-				"success": dailyMetrics.CheckinSuccess,
-				"skipped": dailyMetrics.CheckinSkipped,
-				"failed":  dailyMetrics.CheckinFailed,
-			}
-			overallTodayStatus := "complete"
-			if dailyMetrics.TodayRewardStatus != "complete" ||
-				dailyMetrics.TodaySpendStatus != "complete" ||
-				dailyMetrics.ProxyMetricStatus != "complete" {
-				overallTodayStatus = "partial"
-			}
-			result["todayMetricStatus"] = map[string]any{
-				"status":      overallTodayStatus,
-				"localDay":    dailyMetrics.LocalDay,
-				"timeZone":    dailyMetrics.TimeZone,
-				"windowStart": dailyMetrics.WindowStartUTC,
-				"windowEnd":   dailyMetrics.WindowEndUTC,
-				"metrics": map[string]any{
-					"checkin": map[string]any{"status": "complete"},
-					"spend": map[string]any{
-						"status":            dailyMetrics.TodaySpendStatus,
-						"reason":            dailyMetrics.TodaySpendReason,
-						"missingCostCount":  dailyMetrics.ProxyMissingCost,
-						"unattributedCount": dailyMetrics.ProxyUnattributed,
+			dailyMetrics, metricsErr := dailyservice.CollectDailySummaryMetrics(h.db, now)
+			if metricsErr != nil {
+				markFailed("todayMetricStatus", "load local-day metrics", metricsErr)
+				result["todaySpend"] = nil
+				result["todayReward"] = nil
+				result["todayCheckin"] = nil
+				result["todayMetricStatus"] = map[string]any{
+					"status": "partial",
+					"reason": "metrics collection failed",
+				}
+			} else {
+				result["todaySpend"] = roundMicro(dailyMetrics.TodaySpend)
+				result["todayReward"] = roundMicro(dailyMetrics.TodayReward)
+				result["todayCheckin"] = map[string]any{
+					"total":   dailyMetrics.CheckinTotal,
+					"success": dailyMetrics.CheckinSuccess,
+					"skipped": dailyMetrics.CheckinSkipped,
+					"failed":  dailyMetrics.CheckinFailed,
+				}
+				overallTodayStatus := "complete"
+				if dailyMetrics.TodayRewardStatus != "complete" ||
+					dailyMetrics.TodaySpendStatus != "complete" ||
+					dailyMetrics.ProxyMetricStatus != "complete" {
+					overallTodayStatus = "partial"
+				}
+				result["todayMetricStatus"] = map[string]any{
+					"status":      overallTodayStatus,
+					"localDay":    dailyMetrics.LocalDay,
+					"timeZone":    dailyMetrics.TimeZone,
+					"windowStart": dailyMetrics.WindowStartUTC,
+					"windowEnd":   dailyMetrics.WindowEndUTC,
+					"metrics": map[string]any{
+						"checkin": map[string]any{"status": "complete"},
+						"spend": map[string]any{
+							"status":            dailyMetrics.TodaySpendStatus,
+							"reason":            dailyMetrics.TodaySpendReason,
+							"missingCostCount":  dailyMetrics.ProxyMissingCost,
+							"unattributedCount": dailyMetrics.ProxyUnattributed,
+						},
+						"reward": map[string]any{
+							"status": dailyMetrics.TodayRewardStatus,
+							"reason": dailyMetrics.TodayRewardReason,
+						},
+						"proxy": map[string]any{
+							"status":             dailyMetrics.ProxyMetricStatus,
+							"reason":             dailyMetrics.ProxyMetricReason,
+							"unknownStatusCount": dailyMetrics.ProxyUnknown,
+							"unattributedCount":  dailyMetrics.ProxyUnattributed,
+						},
 					},
-					"reward": map[string]any{
-						"status": dailyMetrics.TodayRewardStatus,
-						"reason": dailyMetrics.TodayRewardReason,
-					},
-					"proxy": map[string]any{
-						"status":             dailyMetrics.ProxyMetricStatus,
-						"reason":             dailyMetrics.ProxyMetricReason,
-						"unknownStatusCount": dailyMetrics.ProxyUnknown,
-						"unattributedCount":  dailyMetrics.ProxyUnattributed,
-					},
-				},
+				}
 			}
-		}
 
-		// Performance window: last 60s request/token rate from proxy_logs.
-		windowSeconds := 60
-		sincePerf := time.Now().UTC().Add(-time.Duration(windowSeconds) * time.Second).Format(time.RFC3339)
-		var perf struct {
-			Requests int64 `db:"requests"`
-			Tokens   int64 `db:"tokens"`
-		}
-		if err := h.db.Get(&perf, rebindAdminQuery(h.db, `
+			// Performance window: last 60s request/token rate from proxy_logs.
+			windowSeconds := 60
+			sincePerf := time.Now().UTC().Add(-time.Duration(windowSeconds) * time.Second).Format(time.RFC3339)
+			var perf struct {
+				Requests int64 `db:"requests"`
+				Tokens   int64 `db:"tokens"`
+			}
+			if err := h.db.Get(&perf, rebindAdminQuery(h.db, `
 			SELECT
 				COUNT(*) AS requests,
 				COALESCE(SUM(`+service.EffectiveProxyTokensSQL+`), 0) AS tokens
@@ -323,48 +352,48 @@ func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 			INNER JOIN sites s ON s.id = a.site_id
 			WHERE pl.created_at >= ? AND s.status = 'active'
 		`), sincePerf); err != nil {
-			markFailed("performance", "load performance metrics", err)
-		} else {
-			rpm := float64(perf.Requests) * 60 / float64(windowSeconds)
-			tpm := float64(perf.Tokens) * 60 / float64(windowSeconds)
-			result["performance"] = map[string]any{
-				"windowSeconds":     windowSeconds,
-				"requestsPerMinute": rpm,
-				"tokensPerMinute":   tpm,
+				markFailed("performance", "load performance metrics", err)
+			} else {
+				rpm := float64(perf.Requests) * 60 / float64(windowSeconds)
+				tpm := float64(perf.Tokens) * 60 / float64(windowSeconds)
+				result["performance"] = map[string]any{
+					"windowSeconds":     windowSeconds,
+					"requestsPerMinute": rpm,
+					"tokensPerMinute":   tpm,
+				}
 			}
 		}
-	}
 
-	if view == "insights" || view == "full" {
-		// All-time totals with effective token expression (no double count).
-		var totalTokens int64
-		if err := h.db.Get(&totalTokens, rebindAdminQuery(h.db, `
+		if view == "insights" || view == "full" {
+			// All-time totals with effective token expression (no double count).
+			var totalTokens int64
+			if err := h.db.Get(&totalTokens, rebindAdminQuery(h.db, `
 			SELECT COALESCE(SUM(`+service.EffectiveProxyTokensSQL+`), 0)
 			FROM proxy_logs pl
 			INNER JOIN accounts a ON a.id = pl.account_id
 			INNER JOIN sites s ON s.id = a.site_id
 			WHERE s.status = 'active'
 		`)); err != nil {
-			markFailed("totalTokens", "load total tokens", err)
-		} else {
-			result["totalTokens"] = totalTokens
-		}
-		var totalCost float64
-		if err := h.db.Get(&totalCost, `
+				markFailed("totalTokens", "load total tokens", err)
+			} else {
+				result["totalTokens"] = totalTokens
+			}
+			var totalCost float64
+			if err := h.db.Get(&totalCost, `
 			SELECT COALESCE(SUM(COALESCE(pl.estimated_cost, 0)), 0)
 			FROM proxy_logs pl
 			INNER JOIN accounts a ON a.id = pl.account_id
 			INNER JOIN sites s ON s.id = a.site_id
 			WHERE s.status = 'active'
 		`); err != nil {
-			markFailed("totalCost", "load total cost", err)
-		} else {
-			result["totalCost"] = roundMicro(totalCost)
-		}
+				markFailed("totalCost", "load total cost", err)
+			} else {
+				result["totalCost"] = roundMicro(totalCost)
+			}
 
-		// Site availability over last 24h from proxy_logs join path.
-		since24h := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
-		rows, err := queryRowsErr(h.db, `
+			// Site availability over last 24h from proxy_logs join path.
+			since24h := time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
+			rows, err := queryRowsErr(h.db, `
 			SELECT
 				s.id AS site_id,
 				s.name AS site_name,
@@ -389,77 +418,93 @@ func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
 			GROUP BY s.id, s.name, s.url, s.platform
 			ORDER BY total_requests DESC, s.name ASC
 		`, since24h)
-		if err != nil {
-			markFailed("siteAvailability", "load site availability", err)
-		} else {
-			siteAvailability := make([]map[string]any, 0, len(rows))
-			for _, row := range rows {
-				item := map[string]any{
-					"siteId":              row["siteId"],
-					"siteName":            row["siteName"],
-					"siteUrl":             row["siteUrl"],
-					"platform":            row["platform"],
-					"totalRequests":       row["totalRequests"],
-					"successCount":        row["successCount"],
-					"failedCount":         row["failedCount"],
-					"availabilityPercent": row["availabilityPercent"],
-					"averageLatencyMs":    row["averageLatencyMs"],
-					"buckets":             []any{},
+			if err != nil {
+				markFailed("siteAvailability", "load site availability", err)
+			} else {
+				siteAvailability := make([]map[string]any, 0, len(rows))
+				for _, row := range rows {
+					item := map[string]any{
+						"siteId":              row["siteId"],
+						"siteName":            row["siteName"],
+						"siteUrl":             row["siteUrl"],
+						"platform":            row["platform"],
+						"totalRequests":       row["totalRequests"],
+						"successCount":        row["successCount"],
+						"failedCount":         row["failedCount"],
+						"availabilityPercent": row["availabilityPercent"],
+						"averageLatencyMs":    row["averageLatencyMs"],
+						"buckets":             []any{},
+					}
+					siteAvailability = append(siteAvailability, item)
 				}
-				siteAvailability = append(siteAvailability, item)
+				result["siteAvailability"] = siteAvailability
 			}
-			result["siteAvailability"] = siteAvailability
 		}
-	}
 
-	// Aggregate per-metric health so the frontend can distinguish a fully
-	// healthy response from one where individual queries degraded to null.
-	dashboardStatus := "complete"
-	if len(failedMetrics) > 0 {
-		dashboardStatus = "partial"
-	}
-	result["dashboardStatus"] = map[string]any{
-		"status": dashboardStatus,
-		"failed": failedMetrics,
-	}
+		// Aggregate per-metric health so the frontend can distinguish a fully
+		// healthy response from one where individual queries degraded to null.
+		dashboardStatus := "complete"
+		if len(failedMetrics) > 0 {
+			dashboardStatus = "partial"
+		}
+		result["dashboardStatus"] = map[string]any{
+			"status": dashboardStatus,
+			"failed": failedMetrics,
+		}
 
-	// Truly fatal: every metric failed (e.g. DB connection lost, every table
-	// missing). Return 500 and do NOT cache — the response has no useful
-	// data and replaying it for 10s would hide a real outage. Individual
-	// query failures (some succeed, some null) are NOT fatal and fall
-	// through to the 200 + cache path below.
-	hasRealData := false
-	for key, value := range result {
-		if key == "generatedAt" || key == "dashboardStatus" || key == "todayMetricStatus" {
-			continue
+		// Truly fatal: every metric failed (e.g. DB connection lost, every table
+		// missing). Return 500 and do NOT cache — the response has no useful
+		// data and replaying it for 10s would hide a real outage. Individual
+		// query failures (some succeed, some null) are NOT fatal and fall
+		// through to the 200 + cache path below.
+		hasRealData := false
+		for key, value := range result {
+			if key == "generatedAt" || key == "dashboardStatus" || key == "todayMetricStatus" {
+				continue
+			}
+			if value != nil {
+				hasRealData = true
+				break
+			}
 		}
-		if value != nil {
-			hasRealData = true
-			break
+		if !hasRealData {
+			slog.Error("dashboard stats: all metrics failed; returning 500", "failedCount", len(failedMetrics))
+			return nil, fmt.Errorf("all %d metric queries failed", len(failedMetrics))
 		}
-	}
-	if !hasRealData {
-		slog.Error("dashboard stats: all metrics failed; returning 500", "failedCount", len(failedMetrics))
-		h.dashboardError(w, "load dashboard statistics", fmt.Errorf("all %d metric queries failed", len(failedMetrics)))
+
+		// Marshal once; getOrCompute stores the bytes in the cache. Partial
+		// responses (some fields null) are cached too — they are still HTTP 200
+		// and better than a 500 blank. The 10s TTL keeps recovery quick; ?force=1
+		// bypasses for a hard refresh. json.Encoder appends a newline, matching
+		// shared.WriteJSON, so a later cache-hit response is byte-identical to
+		// the miss that populated it.
+		var buf bytes.Buffer
+		if err := json.NewEncoder(&buf).Encode(result); err != nil {
+			slog.Error("dashboard stats marshal failed", "error", err)
+			return nil, fmt.Errorf("encode dashboard statistics: %w", err)
+		}
+		return buf.Bytes(), nil
+	})
+
+	if computeErr != nil {
+		// Error responses still report "miss": the compute ran but produced no
+		// cacheable payload, so the next request must recompute (errors are
+		// never stored as cache hits).
+		w.Header().Set("x-dashboard-summary-cache", "miss")
+		w.Header().Set("x-dashboard-insights-cache", "miss")
+		h.dashboardError(w, "load dashboard statistics", computeErr)
 		return
 	}
 
-	// Marshal once and cache the bytes. Partial responses (some fields null)
-	// are cached too — they are still HTTP 200 and better than a 500 blank.
-	// The 10s TTL keeps recovery quick; ?force=1 bypasses for a hard refresh.
-	// json.Encoder appends a newline, matching shared.WriteJSON, so a later
-	// cache-hit response is byte-identical to the miss that populated it.
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(result); err != nil {
-		slog.Error("dashboard stats marshal failed", "error", err)
-		writeError(w, http.StatusInternalServerError, "Failed to encode dashboard statistics")
-		return
-	}
-	cached := buf.Bytes()
-	globalDashboardCache.set(view, cached)
 	w.Header().Set("Content-Type", "application/json")
+	if cacheHit {
+		w.Header().Set("x-dashboard-summary-cache", "hit")
+	} else {
+		w.Header().Set("x-dashboard-summary-cache", "miss")
+	}
+	w.Header().Set("x-dashboard-insights-cache", "miss")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(cached)
+	_, _ = w.Write(data)
 }
 
 // parseDashboardForceRefresh accepts ?force=1 / ?force=true (case-insensitive)

--- a/internal/ssrf/webdav.go
+++ b/internal/ssrf/webdav.go
@@ -1,0 +1,106 @@
+// Package ssrf provides shared Server-Side Request Forgery (SSRF) guards for
+// outbound WebDAV / backup transports.
+//
+// Both the admin settings handler (handler/admin) and the backup scheduler
+// previously carried byte-identical copies of this logic under different
+// names (rejectUnsafeWebdavDialHost / rejectUnsafeBackupWebdavDialHost, etc.).
+// Centralizing it here keeps the two call sites from drifting: a fix to the
+// unsafe-range predicate or the TOCTOU-aware dial check lands in one place.
+//
+// Each call site passes its own allowPrivate flag so operator/test escape
+// hatches (e.g. pointing a WebDAV backup at a localhost test server) remain
+// independent per feature without coupling the two packages.
+package ssrf
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+)
+
+// RejectUnsafeWebdavDialHost validates a host immediately before a network
+// dial. It applies hostname-level allow/deny rules and then resolves the host
+// to verify that none of the resolved IPs fall in an unsafe range, preventing
+// the TOCTOU race where a hostname resolves to a safe IP at validation time
+// but a private IP by dial time (and vice versa).
+//
+// allowPrivate=true disables the guard entirely (operator escape hatch /
+// test isolation for httptest servers on 127.0.0.1).
+func RejectUnsafeWebdavDialHost(ctx context.Context, host string, allowPrivate bool) error {
+	if !IsAllowedWebdavTargetHost(host, allowPrivate) {
+		return fmt.Errorf("refusing WebDAV request to unsafe host %q", host)
+	}
+	if _, err := netip.ParseAddr(strings.Trim(host, "[]")); err == nil {
+		return nil
+	}
+	ips, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+	if err != nil {
+		return err
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("no IP addresses found for WebDAV host %q", host)
+	}
+	for _, ip := range ips {
+		if IsUnsafeAddr(ip) {
+			return fmt.Errorf("refusing WebDAV request to unsafe resolved address %s", ip)
+		}
+	}
+	return nil
+}
+
+// IsAllowedWebdavTargetHost applies hostname-level allow/deny rules before DNS
+// resolution. A bare hostname is allowed (its IPs are checked at dial time by
+// RejectUnsafeWebdavDialHost). Literal IP literals are allowed only when they
+// are not in an unsafe range. "localhost" and *.localhost are always denied.
+// allowPrivate=true permits all hosts (operator escape hatch).
+func IsAllowedWebdavTargetHost(host string, allowPrivate bool) bool {
+	if allowPrivate {
+		return true
+	}
+	host = strings.TrimSpace(strings.Trim(host, "[]"))
+	if host == "" || strings.Contains(host, "%") {
+		return false
+	}
+	lower := strings.TrimSuffix(strings.ToLower(host), ".")
+	if lower == "localhost" || strings.HasSuffix(lower, ".localhost") {
+		return false
+	}
+	if addr, err := netip.ParseAddr(host); err == nil {
+		return !IsUnsafeAddr(addr)
+	}
+	return true
+}
+
+// IsUnsafeAddr reports whether an IP address falls in an unsafe range for
+// outbound SSRF-sensitive traffic: unspecified, loopback, private,
+// link-local unicast, link-local multicast, or multicast.
+func IsUnsafeAddr(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	return addr.IsUnspecified() ||
+		addr.IsLoopback() ||
+		addr.IsPrivate() ||
+		addr.IsLinkLocalUnicast() ||
+		addr.IsLinkLocalMulticast() ||
+		addr.IsMulticast()
+}
+
+// IsPrivateOrLoopbackLiteral reports whether host is a literal IP address in a
+// private, loopback, link-local, multicast, or unspecified range. This covers:
+//   - Loopback: 127.0.0.0/8, ::1
+//   - Link-local: 169.254.0.0/16 (incl. cloud metadata 169.254.169.254), fe80::/10
+//   - Private: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+//   - Unspecified: 0.0.0.0/8, ::
+//
+// Hostnames that are not literal IPs return false: DNS resolution for
+// hostnames is deferred to the dial-time guard (RejectUnsafeWebdavDialHost)
+// to avoid TOCTOU races (a hostname that resolves to a safe IP at validation
+// time could resolve to a private IP by dial time, and vice versa).
+func IsPrivateOrLoopbackLiteral(host string) bool {
+	addr, err := netip.ParseAddr(strings.Trim(host, "[]"))
+	if err != nil {
+		return false
+	}
+	return IsUnsafeAddr(addr)
+}

--- a/scheduler/backup_webdav.go
+++ b/scheduler/backup_webdav.go
@@ -9,13 +9,13 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"net/netip"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/internal/ssrf"
 	backupsvc "github.com/deliciousbuding/metapi-go/service/backup"
 	"github.com/deliciousbuding/metapi-go/store"
 )
@@ -208,7 +208,7 @@ func newBackupWebdavHTTPTransport() *http.Transport {
 				if err != nil {
 					return nil, err
 				}
-				if err := rejectUnsafeBackupWebdavDialHost(ctx, host); err != nil {
+				if err := ssrf.RejectUnsafeWebdavDialHost(ctx, host, allowPrivateBackupWebdavTargets); err != nil {
 					return nil, err
 				}
 			}
@@ -218,28 +218,6 @@ func newBackupWebdavHTTPTransport() *http.Transport {
 		ResponseHeaderTimeout: backupWebdavFetchTimeout,
 		IdleConnTimeout:       30 * time.Second,
 	}
-}
-
-func rejectUnsafeBackupWebdavDialHost(ctx context.Context, host string) error {
-	if !isAllowedBackupWebdavTargetHost(host) {
-		return fmt.Errorf("refusing WebDAV request to unsafe host %q", host)
-	}
-	if _, err := netip.ParseAddr(strings.Trim(host, "[]")); err == nil {
-		return nil
-	}
-	ips, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
-	if err != nil {
-		return err
-	}
-	if len(ips) == 0 {
-		return fmt.Errorf("no IP addresses found for WebDAV host %q", host)
-	}
-	for _, ip := range ips {
-		if isUnsafeBackupWebdavAddr(ip) {
-			return fmt.Errorf("refusing WebDAV request to unsafe resolved address %s", ip)
-		}
-	}
-	return nil
 }
 
 func (s *BackupWebdavScheduler) updateState(store *store.SettingsStore, err error) {
@@ -317,33 +295,5 @@ func isValidHTTPURL(raw string) bool {
 			return false
 		}
 	}
-	return isAllowedBackupWebdavTargetHost(parsed.Hostname())
-}
-
-func isAllowedBackupWebdavTargetHost(host string) bool {
-	if allowPrivateBackupWebdavTargets {
-		return true
-	}
-	host = strings.TrimSpace(strings.Trim(host, "[]"))
-	if host == "" || strings.Contains(host, "%") {
-		return false
-	}
-	lower := strings.TrimSuffix(strings.ToLower(host), ".")
-	if lower == "localhost" || strings.HasSuffix(lower, ".localhost") {
-		return false
-	}
-	if addr, err := netip.ParseAddr(host); err == nil {
-		return !isUnsafeBackupWebdavAddr(addr)
-	}
-	return true
-}
-
-func isUnsafeBackupWebdavAddr(addr netip.Addr) bool {
-	addr = addr.Unmap()
-	return addr.IsUnspecified() ||
-		addr.IsLoopback() ||
-		addr.IsPrivate() ||
-		addr.IsLinkLocalUnicast() ||
-		addr.IsLinkLocalMulticast() ||
-		addr.IsMulticast()
+	return ssrf.IsAllowedWebdavTargetHost(parsed.Hostname(), allowPrivateBackupWebdavTargets)
 }

--- a/service/oauth/connection.go
+++ b/service/oauth/connection.go
@@ -80,11 +80,15 @@ func ListOauthConnections(input ListConnectionsInput) (*ListConnectionsResult, e
 	limit = config.ClampInt(limit, 1, 200)
 	offset := config.MaxInt(input.Offset, 0)
 
-	// Ensure OAuth identity backfill: backfill columns from extraConfig.oauth.
-	ensureOauthIdentityBackfill(db)
+	// OAuth identity backfill is a one-time startup migration (see
+	// RunOauthIdentityBackfillOnce, invoked from app startup). It must not
+	// run on every paginated list request: the original implementation did a
+	// full-table scan + N+1 UPDATE per page load on this hot path.
 
 	var total int64
-	_ = db.Get(&total, "SELECT COUNT(*) FROM accounts WHERE oauth_provider IS NOT NULL")
+	if err := db.Get(&total, "SELECT COUNT(*) FROM accounts WHERE oauth_provider IS NOT NULL"); err != nil {
+		return nil, fmt.Errorf("count oauth accounts: %w", err)
+	}
 
 	rows, err := selectOAuthAccountSiteRows(db, "ORDER BY a.id DESC LIMIT ? OFFSET ?", limit, offset)
 	if err != nil {
@@ -331,15 +335,63 @@ func strPtr(s *string) string {
 	return strings.TrimSpace(*s)
 }
 
-// ensureOauthIdentityBackfill backfills oauth_provider, oauth_account_key, and oauth_project_id
-// columns from extraConfig.oauth for accounts that have the data in extraConfig but not in columns.
-func ensureOauthIdentityBackfill(db *store.DB) {
-	// Find accounts with oauth in extraConfig but missing column fields.
+// oauthIdentityBackfillMarkerKey is the settings KV flag that marks the
+// one-time OAuth identity column backfill as complete. Once set, a healthy
+// instance never re-scans the accounts table for backfill candidates.
+const oauthIdentityBackfillMarkerKey = "oauth.identity_backfill_complete"
+
+// RunOauthIdentityBackfillOnce is a one-time startup migration that backfills
+// the oauth_provider, oauth_account_key, and oauth_project_id columns from
+// extraConfig.oauth for accounts that still carry the data only in extra_config.
+//
+// It is bounded (LIMIT-batched) and gated behind a settings marker so a healthy
+// instance never re-scans accounts after the first successful run. A partial
+// run (batch error) leaves the marker unset and retries on the next boot.
+//
+// This was previously invoked from ListOauthConnections on every page load,
+// which forced a full-table scan + N+1 UPDATEs per request on the admin list
+// hot path. Moving it to startup keeps the list endpoint O(limit).
+func RunOauthIdentityBackfillOnce(db *store.DB) {
+	settings := store.NewSettingsStore(db)
+	if done, _ := settings.Get(oauthIdentityBackfillMarkerKey); strings.TrimSpace(done) == "1" {
+		return
+	}
+
+	for {
+		backfilled, err := backfillOauthIdentityBatch(db, 100)
+		if err != nil {
+			slog.Warn("oauth identity backfill batch failed; will retry on next boot", "error", err)
+			return
+		}
+		if backfilled == 0 {
+			break
+		}
+	}
+
+	if err := settings.Set(oauthIdentityBackfillMarkerKey, "1"); err != nil {
+		slog.Warn("oauth identity backfill marker could not be set; will re-run on next boot", "error", err)
+		return
+	}
+	slog.Info("oauth identity backfill complete; settings marker set")
+}
+
+// backfillOauthIdentityBatch scans up to limit accounts whose oauth identity
+// columns are still NULL/empty while extra_config carries oauth data, and
+// updates them in place. Returns the number of rows updated. Row-level scan
+// and update failures are logged and skipped so a single bad row cannot
+// abort the whole migration; a query/scan failure (the whole batch) is
+// returned so the caller retries on the next boot.
+func backfillOauthIdentityBatch(db *store.DB, limit int) (int, error) {
 	rows, err := db.Queryx(
 		`SELECT id, oauth_provider, oauth_account_key, oauth_project_id, extra_config
-		 FROM accounts WHERE extra_config IS NOT NULL AND extra_config != ''`)
+		 FROM accounts
+		 WHERE extra_config IS NOT NULL AND extra_config != ''
+		   AND (oauth_provider IS NULL OR oauth_provider = ''
+		        OR oauth_account_key IS NULL OR oauth_account_key = ''
+		        OR oauth_project_id IS NULL OR oauth_project_id = '')
+		 LIMIT ?`, limit)
 	if err != nil {
-		return
+		return 0, fmt.Errorf("scan oauth identity backfill candidates: %w", err)
 	}
 	defer rows.Close()
 
@@ -351,9 +403,11 @@ func ensureOauthIdentityBackfill(db *store.DB) {
 		ExtraConfig     *string `db:"extra_config"`
 	}
 
+	updated := 0
 	for rows.Next() {
 		var row backfillRow
 		if err := rows.StructScan(&row); err != nil {
+			slog.Warn("oauth identity backfill: row scan failed; skipping", "accountID", row.ID, "error", err)
 			continue
 		}
 
@@ -362,11 +416,10 @@ func ensureOauthIdentityBackfill(db *store.DB) {
 			continue
 		}
 
-		needsUpdate := false
 		provider := ""
 		accountKey := ""
 		projectID := ""
-
+		needsUpdate := false
 		if (row.OAuthProvider == nil || *row.OAuthProvider == "") && oauth.Provider != "" {
 			provider = oauth.Provider
 			needsUpdate = true
@@ -379,16 +432,22 @@ func ensureOauthIdentityBackfill(db *store.DB) {
 			projectID = oauth.ProjectID
 			needsUpdate = true
 		}
-
-		if needsUpdate {
-			now := time.Now().Format(time.RFC3339)
-			_, _ = db.Exec(
-				`UPDATE accounts SET oauth_provider = COALESCE(NULLIF(?, ''), oauth_provider),
-				 oauth_account_key = COALESCE(NULLIF(?, ''), oauth_account_key),
-				 oauth_project_id = COALESCE(NULLIF(?, ''), oauth_project_id),
-				 updated_at = ?
-				 WHERE id = ?`,
-				provider, accountKey, projectID, now, row.ID)
+		if !needsUpdate {
+			continue
 		}
+
+		now := time.Now().Format(time.RFC3339)
+		if _, err := db.Exec(
+			`UPDATE accounts SET oauth_provider = COALESCE(NULLIF(?, ''), oauth_provider),
+			 oauth_account_key = COALESCE(NULLIF(?, ''), oauth_account_key),
+			 oauth_project_id = COALESCE(NULLIF(?, ''), oauth_project_id),
+			 updated_at = ?
+			 WHERE id = ?`,
+			provider, accountKey, projectID, now, row.ID); err != nil {
+			slog.Warn("oauth identity backfill: update failed for account", "accountID", row.ID, "error", err)
+			continue
+		}
+		updated++
 	}
+	return updated, nil
 }


### PR DESCRIPTION
## Summary

Three independent improvements bundled in one batch:

- **OAuth backfill off the list hot path:** `ensureOauthIdentityBackfill` ran a full-table scan + N+1 UPDATE on *every* paginated `ListOauthConnections` page load. It is now a one-time startup migration (`RunOauthIdentityBackfillOnce`) gated behind a settings marker (`oauth.identity_backfill_complete`): `LIMIT 100`-batched, only scans rows whose oauth identity columns are still NULL, logs (no longer swallows) per-row UPDATE errors, and runs once per instance lifetime. The swallowed `COUNT(*)` error in `ListOauthConnections` now surfaces.
- **Single-flight on admin caches:** the dashboard (10s), accounts (30s), and channels (10s) snapshot caches had no in-flight dedup, so N concurrent admin sessions recomputed the expensive aggregation N× per cache window. Added `golang.org/x/sync/singleflight` (`getOrCompute`) so a cache miss deduplicates concurrent computes; errors are never cached.
- **SSRF guard dedup:** the byte-identical WebDAV SSRF guard existed as two copies (`handler/admin` vs `scheduler`) under different names. Extracted to the shared `internal/ssrf` package; both call sites pass their own `allowPrivate` flag so test escape hatches stay independent.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./handler/admin/... ./service/oauth/... ./scheduler/...`
- [x] `go test ./docs/... -run TestPgRebindGate` (rebind gate — all SQL on `*sqlx.DB` stays Rebind-wrapped)
- [x] `go test ./docs/...` (package boundary + doc hygiene)
- [x] Dashboard cache tests: `TestDashboardCache_MissThenHit`, `_ForceRefreshBypassesAndInvalidates`, `_ViewKeying`, `_DoesNotCacheErrors`
- [x] Channels cache tests: `TestChannels_SnapshotCacheHitMissAndBypass`, `_MutationInvalidatesSnapshotCache`
- [x] Accounts cache test: `TestAccounts_UpdateClearsSnapshotCache`