### PR TITLE
fix(web): tolerate legacy/router-parsed URL search params (10 routes)

### DIFF
--- a/web/src/components/layout/layout-error-boundary.tsx
+++ b/web/src/components/layout/layout-error-boundary.tsx
@@ -11,8 +11,8 @@
 // (language/theme) stay interactive — only the page area swaps to the error
 // card with Retry / Reload / show-detail controls.
 
-import { useRouter } from '@tanstack/react-router'
-import { RotateCw, TriangleAlert } from 'lucide-react'
+import { SearchParamError, useRouter } from '@tanstack/react-router'
+import { Link2Off, RotateCw, TriangleAlert } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -29,6 +29,21 @@ export function LayoutErrorBoundary({ error }: { error: Error }) {
   const router = useRouter()
   const [showDetail, setShowDetail] = useState(false)
 
+  // A throwing `validateSearch` (stale bookmarks / legacy URLs with
+  // JSON-parsed primitives like `?q=123` or `?enabled=true`) surfaces here
+  // as a SearchParamError. Offer a dedicated recovery path that keeps the
+  // pathname but drops the invalid query string entirely.
+  const isSearchParamError = error instanceof SearchParamError
+
+  const resetUrl = () => {
+    const { pathname } = router.state.location
+    router.navigate({ to: pathname, search: {} }).catch(() => {
+      // Fallback if the re-validation still fails: hard-navigate to the
+      // bare pathname.
+      window.location.replace(pathname)
+    })
+  }
+
   return (
     <SidebarProvider className='flex-col'>
       <SkipToMain />
@@ -44,29 +59,53 @@ export function LayoutErrorBoundary({ error }: { error: Error }) {
           )}
         >
           <div className='flex w-full max-w-md flex-col items-center gap-4'>
-            <div className='bg-destructive/10 flex size-16 items-center justify-center rounded-2xl'>
-              <TriangleAlert className='text-destructive size-8' />
+            <div
+              className={cn(
+                'flex size-16 items-center justify-center rounded-2xl',
+                isSearchParamError ? 'bg-warning/10' : 'bg-destructive/10'
+              )}
+            >
+              {isSearchParamError ? (
+                <Link2Off className='text-warning size-8' />
+              ) : (
+                <TriangleAlert className='text-destructive size-8' />
+              )}
             </div>
             <div className='space-y-1 text-center'>
               <p className='text-2xl font-semibold'>
-                {t('errors.renderTitle')}
+                {t(
+                  isSearchParamError
+                    ? 'errors.searchParamTitle'
+                    : 'errors.renderTitle'
+                )}
               </p>
               <p className='text-muted-foreground text-sm'>
-                {t('errors.renderDescription')}
+                {t(
+                  isSearchParamError
+                    ? 'errors.searchParamDescription'
+                    : 'errors.renderDescription'
+                )}
               </p>
             </div>
-            <div className='flex gap-2'>
-              <Button onClick={() => router.invalidate()}>
-                <RotateCw className='mr-1.5 size-4' />
-                {t('errors.retry')}
+            {isSearchParamError ? (
+              <Button onClick={resetUrl}>
+                <Link2Off className='mr-1.5 size-4' />
+                {t('errors.searchParamReset')}
               </Button>
-              <Button
-                variant='outline'
-                onClick={() => window.location.reload()}
-              >
-                {t('errors.reload')}
-              </Button>
-            </div>
+            ) : (
+              <div className='flex gap-2'>
+                <Button onClick={() => router.invalidate()}>
+                  <RotateCw className='mr-1.5 size-4' />
+                  {t('errors.retry')}
+                </Button>
+                <Button
+                  variant='outline'
+                  onClick={() => window.location.reload()}
+                >
+                  {t('errors.reload')}
+                </Button>
+              </div>
+            )}
             <button
               type='button'
               className='text-muted-foreground text-xs underline underline-offset-2'

--- a/web/src/features/accounts/__tests__/accounts-search-schema.test.ts
+++ b/web/src/features/accounts/__tests__/accounts-search-schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { accountsSearchSchema } from '@/routes/_authenticated/accounts'
+
+// ---------------------------------------------------------------------------
+// accountsSearchSchema (route-level validateSearch) — tolerant URL contract
+// ---------------------------------------------------------------------------
+
+describe('accountsSearchSchema', () => {
+  it('accepts the page-written URL shape', () => {
+    const result = accountsSearchSchema.parse({
+      page: '2',
+      pageSize: '50',
+      q: 'alice',
+      status: 'active,disabled',
+      site: '1,3',
+    })
+    expect(result.page).toBe(2)
+    expect(result.pageSize).toBe(50)
+    expect(result.q).toBe('alice')
+    expect(result.status).toBe('active,disabled')
+    expect(result.site).toBe('1,3')
+  })
+
+  it('tolerates router-parsed primitives without throwing', () => {
+    const result = accountsSearchSchema.parse({
+      page: 0,
+      pageSize: 'bogus',
+      q: 123,
+      status: true,
+      site: 7,
+    })
+    expect(result.page).toBe(1)
+    expect(result.pageSize).toBe(20)
+    expect(result.q).toBe(123)
+    expect(result.status).toBe(true)
+    expect(result.site).toBe(7)
+  })
+
+  it('falls back to page 1 / pageSize 20 for an empty input', () => {
+    const result = accountsSearchSchema.parse({})
+    expect(result.page).toBe(1)
+    expect(result.pageSize).toBe(20)
+    expect(result.q).toBeUndefined()
+  })
+})

--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -41,6 +41,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { ImportWizardDialog } from '@/features/import'
+import { asStringParam } from '@/lib/helpers/searchParams'
 import { toast } from '@/lib/toast'
 
 import {
@@ -86,11 +87,14 @@ export function AccountsPage() {
     pageIndex: (search.page ?? 1) - 1,
     pageSize: search.pageSize ?? DEFAULT_PAGE_SIZE,
   })
-  const [globalFilter, setGlobalFilter] = useState(search.q ?? '')
+  const [globalFilter, setGlobalFilter] = useState(
+    asStringParam(search.q) ?? ''
+  )
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(() => {
     const filters: ColumnFiltersState = []
-    const statusValues = search.status?.split(',').filter(Boolean) ?? []
-    const siteIds = search.site?.split(',').filter(Boolean) ?? []
+    const statusValues =
+      asStringParam(search.status)?.split(',').filter(Boolean) ?? []
+    const siteIds = asStringParam(search.site)?.split(',').filter(Boolean) ?? []
     if (statusValues.length) {
       filters.push({ id: 'status', value: statusValues })
     }

--- a/web/src/features/channels/__tests__/channels-schema.test.ts
+++ b/web/src/features/channels/__tests__/channels-schema.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { channelsSearchSchema } from '../lib/channels-schema'
+
+// ---------------------------------------------------------------------------
+// channelsSearchSchema — tolerant URL search contract
+// ---------------------------------------------------------------------------
+
+describe('channelsSearchSchema', () => {
+  it('normalizes a comma-separated sort descriptor to a canonical string', () => {
+    expect(channelsSearchSchema.parse({ sort: 'name:desc,url:asc' }).sort).toBe(
+      'name:desc,url:asc'
+    )
+  })
+
+  it('returns undefined for empty sort (no URL noise)', () => {
+    expect(channelsSearchSchema.parse({}).sort).toBeUndefined()
+    expect(channelsSearchSchema.parse({ sort: '[]' }).sort).toBeUndefined()
+  })
+
+  it('tolerates router-parsed primitives without throwing', () => {
+    const result = channelsSearchSchema.parse({
+      q: 123,
+      page: 0,
+      pageSize: 'bogus',
+      sort: true,
+    })
+    expect(result.q).toBe(123)
+    expect(result.page).toBe(0)
+    expect(result.pageSize).toBe(20)
+    expect(result.sort).toBeUndefined()
+  })
+
+  it('falls back to page 0 / pageSize 20 for an empty input', () => {
+    const result = channelsSearchSchema.parse({})
+    expect(result.page).toBe(0)
+    expect(result.pageSize).toBe(20)
+  })
+})

--- a/web/src/features/channels/lib/channels-schema.ts
+++ b/web/src/features/channels/lib/channels-schema.ts
@@ -11,13 +11,14 @@ import {
 
 export const channelsSearchSchema = z.object({
   q: stringSearchParam,
-  page: z.coerce.number().int().min(0).optional(),
-  pageSize: z.coerce.number().int().min(1).max(200).optional(),
+  page: z.coerce.number().int().min(0).catch(0).default(0),
+  pageSize: z.coerce.number().int().min(1).max(200).catch(20).default(20),
   sort: z
     .union([
       z.string(),
       z.array(z.object({ id: z.string(), desc: z.boolean() })),
     ])
     .optional()
-    .transform((value) => encodeSortingParam(value)),
+    .transform((value) => encodeSortingParam(value))
+    .catch(undefined),
 })

--- a/web/src/features/checkin/__tests__/checkin-schema.test.ts
+++ b/web/src/features/checkin/__tests__/checkin-schema.test.ts
@@ -34,15 +34,34 @@ describe('checkinSearchSchema', () => {
   })
 
   it.each([
-    ['non-numeric page', { page: 'abc' }],
-    ['page below 1', { page: '0' }],
-    ['pageSize above 200', { pageSize: '201' }],
-    ['pageSize below 1', { pageSize: '0' }],
-    ['non-positive accountId', { accountId: '-3' }],
-    ['fractional accountId', { accountId: '1.5' }],
-  ])('rejects %s', (_label, input) => {
+    ['non-numeric page', { page: 'abc' }, { page: 1 }],
+    ['page below 1', { page: '0' }, { page: 1 }],
+    ['pageSize above 200', { pageSize: '201' }, { pageSize: 20 }],
+    ['pageSize below 1', { pageSize: '0' }, { pageSize: 20 }],
+    ['non-positive accountId', { accountId: '-3' }, { accountId: undefined }],
+    ['fractional accountId', { accountId: '1.5' }, { accountId: undefined }],
+  ])('falls back instead of throwing for %s', (_label, input, fallback) => {
     const result = checkinSearchSchema.safeParse(input)
-    expect(result.success).toBe(false)
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data).toMatchObject(fallback)
+  })
+
+  it('tolerates router-parsed primitives without throwing', () => {
+    const result = checkinSearchSchema.parse({
+      page: 0,
+      pageSize: 'bogus',
+      accountId: 'bogus',
+      q: 123,
+      from: 2026,
+      to: false,
+    })
+    expect(result.page).toBe(1)
+    expect(result.pageSize).toBe(20)
+    expect(result.accountId).toBeUndefined()
+    expect(result.q).toBe(123)
+    expect(result.from).toBe(2026)
+    expect(result.to).toBe(false)
   })
 
   it('preserves free-form filter / datetime-local strings', () => {

--- a/web/src/features/checkin/components/checkin-page.tsx
+++ b/web/src/features/checkin/components/checkin-page.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/components/ui/select'
 import { useAccounts } from '@/features/accounts'
 import { useSites } from '@/features/sites/api'
+import { asStringParam } from '@/lib/helpers/searchParams'
 import { toast } from '@/lib/toast'
 
 import { useCheckinAccount, useCheckinLogs, useManualCheckin } from '../api'
@@ -55,7 +56,9 @@ export function CheckinPage() {
     pageIndex: search.page - 1,
     pageSize: search.pageSize,
   })
-  const [globalFilter, setGlobalFilter] = useState(search.q ?? '')
+  const [globalFilter, setGlobalFilter] = useState(
+    asStringParam(search.q) ?? ''
+  )
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(() => {
     const filters: ColumnFiltersState = []
     const statusValues = parseFilterValues(search.status)
@@ -69,8 +72,8 @@ export function CheckinPage() {
   const [accountId, setAccountId] = useState<number | undefined>(
     search.accountId
   )
-  const [from, setFrom] = useState(search.from ?? '')
-  const [to, setTo] = useState(search.to ?? '')
+  const [from, setFrom] = useState(asStringParam(search.from) ?? '')
+  const [to, setTo] = useState(asStringParam(search.to) ?? '')
 
   const { data: accountsSnapshot } = useAccounts()
   const accountOptions = accountsSnapshot?.accounts ?? []

--- a/web/src/features/checkin/lib/checkin-schema.ts
+++ b/web/src/features/checkin/lib/checkin-schema.ts
@@ -11,6 +11,8 @@
 
 import { z } from 'zod'
 
+import { asStringParam, stringSearchParam } from '@/lib/helpers/searchParams'
+
 import type { CheckinLogsQuery } from '../types'
 import { localDatetimeInputToUtcRfc3339 } from './checkin-time'
 
@@ -21,18 +23,26 @@ export const DEFAULT_CHECKIN_PAGE_SIZE = 20
 // ---------------------------------------------------------------------------
 
 export const checkinSearchSchema = z.object({
-  page: z.coerce.number().int().min(1).default(1),
-  pageSize: z.coerce.number().int().min(1).max(200).default(20),
-  accountId: z.coerce.number().int().positive().optional(),
+  page: z.coerce.number().int().min(1).catch(1).default(1),
+  pageSize: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(200)
+    .catch(DEFAULT_CHECKIN_PAGE_SIZE)
+    .default(DEFAULT_CHECKIN_PAGE_SIZE),
+  accountId: z.coerce.number().int().positive().optional().catch(undefined),
   // Comma-separated multi-select filter values (status / reason category /
   // site name).
   status: z.string().optional(),
   reason: z.string().optional(),
   site: z.string().optional(),
-  // datetime-local input values (YYYY-MM-DDTHH:mm, local tz).
-  from: z.string().optional(),
-  to: z.string().optional(),
-  q: z.string().optional(),
+  // datetime-local input values (YYYY-MM-DDTHH:mm, local tz). Router JSON
+  // parsing may hand over numeric/boolean primitives for these too, so they
+  // use the tolerant string param (normalized via `asStringParam`).
+  from: stringSearchParam,
+  to: stringSearchParam,
+  q: stringSearchParam,
 })
 export type CheckinSearch = z.infer<typeof checkinSearchSchema>
 
@@ -89,8 +99,8 @@ export function buildInitialCheckinLogsQuery(
     status: statusValues[0],
     reason: reasonValues,
     site: siteValues,
-    from: localDatetimeInputToUtcRfc3339(search.from, false),
-    to: localDatetimeInputToUtcRfc3339(search.to, true),
-    search: search.q || undefined,
+    from: localDatetimeInputToUtcRfc3339(asStringParam(search.from), false),
+    to: localDatetimeInputToUtcRfc3339(asStringParam(search.to), true),
+    search: asStringParam(search.q) || undefined,
   }
 }

--- a/web/src/features/model-tester/__tests__/model-tester-search.test.ts
+++ b/web/src/features/model-tester/__tests__/model-tester-search.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { modelTesterSearchSchema } from '@/routes/_authenticated/model-tester'
+
+// ---------------------------------------------------------------------------
+// modelTesterSearchSchema (route-level validateSearch) — tolerant deep link
+// ---------------------------------------------------------------------------
+
+describe('modelTesterSearchSchema', () => {
+  it('accepts a plain model deep-link param', () => {
+    expect(modelTesterSearchSchema.parse({ model: 'gpt-4o' }).model).toBe(
+      'gpt-4o'
+    )
+  })
+
+  it('returns undefined for an absent model param', () => {
+    expect(modelTesterSearchSchema.parse({}).model).toBeUndefined()
+  })
+
+  it('tolerates router-parsed primitives without throwing', () => {
+    expect(modelTesterSearchSchema.parse({ model: 123 }).model).toBe(123)
+    expect(modelTesterSearchSchema.parse({ model: true }).model).toBe(true)
+  })
+})

--- a/web/src/features/model-tester/components/model-tester-page.tsx
+++ b/web/src/features/model-tester/components/model-tester-page.tsx
@@ -30,6 +30,7 @@ import { useTranslation } from 'react-i18next'
 import { ConfirmDialog } from '@/components/common/confirm-dialog'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
+import { asStringParam } from '@/lib/helpers/searchParams'
 import { toast } from '@/lib/toast'
 
 import { useTestModel } from '../api'
@@ -60,7 +61,8 @@ export function ModelTesterPage() {
   // deep-link param comes from `useSearch()` (typed) rather than a raw
   // `window.location.search` read.
   const { model } = useSearch({ from: '/_authenticated/model-tester' })
-  const defaultModel = model?.trim() ? model : undefined
+  const modelParam = asStringParam(model)
+  const defaultModel = modelParam?.trim() ? modelParam : undefined
 
   const testModel = useTestModel()
 

--- a/web/src/features/models/__tests__/models-schema.test.ts
+++ b/web/src/features/models/__tests__/models-schema.test.ts
@@ -70,11 +70,29 @@ describe('modelsSearchSchema — numerics', () => {
   })
 
   it.each([
-    ['pageSize below 1', { pageSize: '0' }],
-    ['pageSize above 200', { pageSize: '201' }],
-    ['non-numeric page', { page: 'abc' }],
-  ])('rejects %s', (_label, input) => {
-    expect(modelsSearchSchema.safeParse(input).success).toBe(false)
+    ['pageSize below 1', { pageSize: '0' }, { pageSize: 20 }],
+    ['pageSize above 200', { pageSize: '201' }, { pageSize: 20 }],
+    ['non-numeric page', { page: 'abc' }, { page: 0 }],
+  ])('falls back instead of throwing for %s', (_label, input, fallback) => {
+    const result = modelsSearchSchema.safeParse(input)
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data).toMatchObject(fallback)
+  })
+
+  it('tolerates router-parsed primitives without throwing', () => {
+    const result = modelsSearchSchema.parse({
+      q: 123,
+      page: 0,
+      sort: true,
+      brand: 42,
+      capability: [{ bad: true }],
+    })
+    expect(result.q).toBe(123)
+    expect(result.page).toBe(0)
+    expect(result.sort).toBeUndefined()
+    expect(result.brand).toBeUndefined()
+    expect(result.capability).toBeUndefined()
   })
 })
 

--- a/web/src/features/models/lib/models-schema.ts
+++ b/web/src/features/models/lib/models-schema.ts
@@ -32,21 +32,24 @@ const paginationSchema = z.object({
 
 export const modelsSearchSchema = z.object({
   q: stringSearchParam,
-  page: z.coerce.number().int().min(0).optional(),
-  pageSize: z.coerce.number().int().min(1).max(200).optional(),
+  page: z.coerce.number().int().min(0).catch(0).default(0),
+  pageSize: z.coerce.number().int().min(1).max(200).catch(20).default(20),
   sort: z
     .union([z.string(), z.array(sortingItemSchema)])
     .optional()
-    .transform((value) => encodeSortingParam(value)),
+    .transform((value) => encodeSortingParam(value))
+    .catch(undefined),
   // Multi-select faceted filters, URL-encoded as comma-separated strings.
   brand: z
     .union([z.string(), z.array(z.string())])
     .optional()
-    .transform((value) => encodeStringListParam(value)),
+    .transform((value) => encodeStringListParam(value))
+    .catch(undefined),
   capability: z
     .union([z.string(), z.array(z.string())])
     .optional()
-    .transform((value) => encodeStringListParam(value)),
+    .transform((value) => encodeStringListParam(value))
+    .catch(undefined),
 })
 
 export const SORTING_ITEM_SCHEMA = sortingItemSchema

--- a/web/src/features/oauth/__tests__/oauth-schema.test.ts
+++ b/web/src/features/oauth/__tests__/oauth-schema.test.ts
@@ -146,8 +146,17 @@ describe('oauthSearchSchema', () => {
     expect(oauthSearchSchema.parse({ sort: '[]' }).sort).toBeUndefined()
   })
 
-  it('rejects pageSize above 200', () => {
-    expect(oauthSearchSchema.safeParse({ pageSize: '201' }).success).toBe(false)
+  it('falls back instead of throwing for out-of-range / non-string values', () => {
+    const result = oauthSearchSchema.parse({
+      page: 'abc',
+      pageSize: '201',
+      sort: 123,
+      q: 42,
+    })
+    expect(result.page).toBe(0)
+    expect(result.pageSize).toBe(20)
+    expect(result.sort).toBeUndefined()
+    expect(result.q).toBe(42)
   })
 })
 

--- a/web/src/features/oauth/lib/oauth-schema.ts
+++ b/web/src/features/oauth/lib/oauth-schema.ts
@@ -73,12 +73,13 @@ const columnFilterItemSchema = z.object({
 
 export const oauthSearchSchema = z.object({
   q: stringSearchParam,
-  page: z.coerce.number().int().min(0).optional(),
-  pageSize: z.coerce.number().int().min(1).max(200).optional(),
+  page: z.coerce.number().int().min(0).catch(0).default(0),
+  pageSize: z.coerce.number().int().min(1).max(200).catch(20).default(20),
   sort: z
     .union([z.string(), z.array(sortingItemSchema)])
     .optional()
-    .transform((value) => encodeSortingParam(value)),
+    .transform((value) => encodeSortingParam(value))
+    .catch(undefined),
   status: stringSearchParam,
 })
 

--- a/web/src/features/observability/__tests__/observability-schema.test.ts
+++ b/web/src/features/observability/__tests__/observability-schema.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { observabilitySearchSchema } from '../lib/observability-schema'
+
+// ---------------------------------------------------------------------------
+// observabilitySearchSchema — tolerant section param
+// ---------------------------------------------------------------------------
+
+describe('observabilitySearchSchema', () => {
+  it('accepts each registered section', () => {
+    expect(
+      observabilitySearchSchema.parse({ section: 'overview' }).section
+    ).toBe('overview')
+    expect(observabilitySearchSchema.parse({ section: 'health' }).section).toBe(
+      'health'
+    )
+    expect(
+      observabilitySearchSchema.parse({ section: 'proxy-logs' }).section
+    ).toBe('proxy-logs')
+  })
+
+  it('falls back to overview for an absent section', () => {
+    expect(observabilitySearchSchema.parse({}).section).toBe('overview')
+  })
+
+  it('falls back instead of throwing for unknown / non-string sections', () => {
+    expect(observabilitySearchSchema.parse({ section: 'bogus' }).section).toBe(
+      'overview'
+    )
+    expect(observabilitySearchSchema.parse({ section: 123 }).section).toBe(
+      'overview'
+    )
+    expect(observabilitySearchSchema.parse({ section: true }).section).toBe(
+      'overview'
+    )
+  })
+})

--- a/web/src/features/observability/lib/observability-schema.ts
+++ b/web/src/features/observability/lib/observability-schema.ts
@@ -8,5 +8,8 @@
 import { z } from 'zod'
 
 export const observabilitySearchSchema = z.object({
-  section: z.enum(['overview', 'health', 'proxy-logs']).optional(),
+  section: z
+    .enum(['overview', 'health', 'proxy-logs'])
+    .catch('overview')
+    .default('overview'),
 })

--- a/web/src/features/proxy-logs/__tests__/proxy-logs-schema.test.ts
+++ b/web/src/features/proxy-logs/__tests__/proxy-logs-schema.test.ts
@@ -50,11 +50,11 @@ describe('proxyLogsSearchSchema — status enum', () => {
     )
   })
 
-  it('rejects an unknown status with an enum error', () => {
-    const result = proxyLogsSearchSchema.safeParse({ status: 'partial' })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.message).toContain('Invalid option')
+  it('falls back to "all" for an unknown or non-string status', () => {
+    expect(proxyLogsSearchSchema.parse({ status: 'partial' }).status).toBe(
+      'all'
+    )
+    expect(proxyLogsSearchSchema.parse({ status: true }).status).toBe('all')
   })
 })
 
@@ -83,13 +83,39 @@ describe('proxyLogsSearchSchema — numerics', () => {
   })
 
   it.each([
-    ['pageSize below 1', { pageSize: '0' }],
-    ['pageSize above 200', { pageSize: '201' }],
-    ['latencyMin negative', { latencyMin: '-1' }],
-    ['non-numeric page', { page: 'abc' }],
-  ])('rejects %s', (_label, input) => {
+    ['pageSize below 1', { pageSize: '0' }, { pageSize: 20 }],
+    ['pageSize above 200', { pageSize: '201' }, { pageSize: 20 }],
+    ['latencyMin negative', { latencyMin: '-1' }, { latencyMin: undefined }],
+    ['non-numeric page', { page: 'abc' }, { page: 0 }],
+  ])('falls back instead of throwing for %s', (_label, input, fallback) => {
     const result = proxyLogsSearchSchema.safeParse(input)
-    expect(result.success).toBe(false)
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data).toMatchObject(fallback)
+  })
+
+  it('tolerates router-parsed primitives without throwing', () => {
+    const result = proxyLogsSearchSchema.parse({
+      q: 123,
+      page: 0,
+      pageSize: 'bogus',
+      status: 'bogus',
+      sort: 123,
+      latencyMin: 'abc',
+    })
+    expect(result.q).toBe(123)
+    expect(result.page).toBe(0)
+    expect(result.pageSize).toBe(20)
+    expect(result.status).toBe('all')
+    expect(result.sort).toBeUndefined()
+    expect(result.latencyMin).toBeUndefined()
+  })
+
+  it('tolerates a malformed sort array without throwing', () => {
+    const result = proxyLogsSearchSchema.parse({
+      sort: [{ id: 7, desc: 'yes' }],
+    })
+    expect(result.sort).toBeUndefined()
   })
 })
 

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { api } from '@/lib/api'
+import { asStringParam } from '@/lib/helpers/searchParams'
 import { toast } from '@/lib/toast'
 
 import { useProxyLogs, useProxyLogsMeta } from '../api'
@@ -51,7 +52,7 @@ export function ProxyLogsPage() {
     pageIndex: urlSearch.page ?? 0,
     pageSize: urlSearch.pageSize ?? DEFAULT_PAGE_SIZE,
   })
-  const [search, setSearch] = useState(urlSearch.q ?? '')
+  const [search, setSearch] = useState(asStringParam(urlSearch.q) ?? '')
   const [status, setStatus] = useState<ProxyLogFilters['status']>(
     urlSearch.status ?? 'all'
   )

--- a/web/src/features/proxy-logs/lib/proxy-logs-schema.ts
+++ b/web/src/features/proxy-logs/lib/proxy-logs-schema.ts
@@ -3,25 +3,36 @@
 
 import { z } from 'zod'
 
-import { encodeSortingParam } from '@/lib/helpers/searchParams'
+import {
+  encodeSortingParam,
+  stringSearchParam,
+} from '@/lib/helpers/searchParams'
 
 const sortingItemSchema = z.object({ id: z.string(), desc: z.boolean() })
 
+/**
+ * Tolerant URL search contract: the router JSON-parses search values, so
+ * `?q=123` arrives as a number, `?status=true` as a boolean, and a
+ * hand-written `?sort=123` or malformed JSON array as a non-string sort.
+ * Invalid values fall back to sane defaults instead of throwing a route
+ * error; valid values still validate exactly as before.
+ */
 export const proxyLogsSearchSchema = z.object({
-  q: z.string().optional(),
-  page: z.coerce.number().int().min(0).optional(),
-  pageSize: z.coerce.number().int().min(1).max(200).optional(),
+  q: stringSearchParam,
+  page: z.coerce.number().int().min(0).catch(0).default(0),
+  pageSize: z.coerce.number().int().min(1).max(200).catch(20).default(20),
   sort: z
     .union([z.string(), z.array(sortingItemSchema)])
     .optional()
-    .transform((value) => encodeSortingParam(value)),
-  status: z.enum(['all', 'success', 'failed']).optional(),
-  siteId: z.coerce.number().int().optional(),
+    .transform((value) => encodeSortingParam(value))
+    .catch(undefined),
+  status: z.enum(['all', 'success', 'failed']).catch('all').default('all'),
+  siteId: z.coerce.number().int().optional().catch(undefined),
   client: z.string().optional(),
   from: z.string().optional(),
   to: z.string().optional(),
-  latencyMin: z.coerce.number().int().min(0).optional(),
-  latencyMax: z.coerce.number().int().min(0).optional(),
+  latencyMin: z.coerce.number().int().min(0).optional().catch(undefined),
+  latencyMax: z.coerce.number().int().min(0).optional().catch(undefined),
 })
 
 export type ProxyLogsSearch = z.infer<typeof proxyLogsSearchSchema>

--- a/web/src/features/sites/__tests__/sites-schema.test.ts
+++ b/web/src/features/sites/__tests__/sites-schema.test.ts
@@ -247,8 +247,17 @@ describe('sitesSearchSchema', () => {
     })
   })
 
-  it('rejects pageSize above 200', () => {
-    expect(sitesSearchSchema.safeParse({ pageSize: '201' }).success).toBe(false)
+  it('falls back instead of throwing for out-of-range / non-string values', () => {
+    const result = sitesSearchSchema.parse({
+      page: 'abc',
+      pageSize: '201',
+      sort: 123,
+      q: 42,
+    })
+    expect(result.page).toBe(0)
+    expect(result.pageSize).toBe(20)
+    expect(result.sort).toBeUndefined()
+    expect(result.q).toBe(42)
   })
 })
 

--- a/web/src/features/sites/lib/sites-schema.ts
+++ b/web/src/features/sites/lib/sites-schema.ts
@@ -141,12 +141,13 @@ const columnFilterItemSchema = z.object({
 
 export const sitesSearchSchema = z.object({
   q: stringSearchParam,
-  page: z.coerce.number().int().min(0).optional(),
-  pageSize: z.coerce.number().int().min(1).max(200).optional(),
+  page: z.coerce.number().int().min(0).catch(0).default(0),
+  pageSize: z.coerce.number().int().min(1).max(200).catch(20).default(20),
   sort: z
     .union([z.string(), z.array(sortingItemSchema)])
     .optional()
-    .transform((value) => encodeSortingParam(value)),
+    .transform((value) => encodeSortingParam(value))
+    .catch(undefined),
   status: stringSearchParam,
 })
 

--- a/web/src/features/token-routes/__tests__/routes-schema.test.ts
+++ b/web/src/features/token-routes/__tests__/routes-schema.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { routesSearchSchema } from '../lib/routes-schema'
+
+// ---------------------------------------------------------------------------
+// routesSearchSchema — tolerant URL search contract
+// ---------------------------------------------------------------------------
+
+describe('routesSearchSchema', () => {
+  it('accepts the page-written URL shape', () => {
+    const result = routesSearchSchema.parse({
+      q: 'gpt',
+      enabled: 'enabled,disabled',
+      accountId: '7',
+      siteId: '3',
+      page: '2',
+      pageSize: '50',
+    })
+    expect(result).toEqual({
+      q: 'gpt',
+      enabled: 'enabled,disabled',
+      site: undefined,
+      accountId: 7,
+      siteId: 3,
+      page: 2,
+      pageSize: 50,
+    })
+  })
+
+  it('tolerates router-parsed primitives without throwing', () => {
+    const result = routesSearchSchema.parse({
+      q: 123,
+      enabled: true,
+      accountId: 'bogus',
+      siteId: 0,
+      page: 0,
+      pageSize: 'bogus',
+    })
+    expect(result.q).toBe(123)
+    expect(result.enabled).toBe(true)
+    expect(result.accountId).toBeUndefined()
+    expect(result.siteId).toBeUndefined()
+    expect(result.page).toBe(1)
+    expect(result.pageSize).toBe(20)
+  })
+
+  it('falls back to page 1 / pageSize 20 for an empty input', () => {
+    const result = routesSearchSchema.parse({})
+    expect(result.page).toBe(1)
+    expect(result.pageSize).toBe(20)
+    expect(result.q).toBeUndefined()
+  })
+})

--- a/web/src/features/token-routes/components/routes-page.tsx
+++ b/web/src/features/token-routes/components/routes-page.tsx
@@ -28,6 +28,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Switch } from '@/components/ui/switch'
+import { asStringParam } from '@/lib/helpers/searchParams'
 
 import {
   type BatchRouteAction,
@@ -84,10 +85,13 @@ export function RoutesPage() {
     pageIndex: (urlSearch.page ?? 1) - 1,
     pageSize: urlSearch.pageSize ?? DEFAULT_PAGE_SIZE,
   })
-  const [globalFilter, setGlobalFilter] = useState(urlSearch.q ?? '')
+  const [globalFilter, setGlobalFilter] = useState(
+    asStringParam(urlSearch.q) ?? ''
+  )
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(() => {
     const filters: ColumnFiltersState = []
-    const enabledValues = urlSearch.enabled?.split(',').filter(Boolean) ?? []
+    const enabledValues =
+      asStringParam(urlSearch.enabled)?.split(',').filter(Boolean) ?? []
     if (enabledValues.length) {
       filters.push({ id: 'enabled', value: enabledValues })
     }

--- a/web/src/features/token-routes/lib/routes-schema.ts
+++ b/web/src/features/token-routes/lib/routes-schema.ts
@@ -5,6 +5,8 @@
 
 import { z } from 'zod'
 
+import { stringSearchParam } from '@/lib/helpers/searchParams'
+
 import type { RouteFormPayload, RouteMode, RouteSummaryRow } from '../types'
 import {
   getModelPatternError,
@@ -182,15 +184,19 @@ export function transformRouteToFormValues(
 // URL state schema
 // ---------------------------------------------------------------------------
 
+// Tolerant URL search contract: the router JSON-parses search values, so
+// `?q=123` arrives as a number and `?enabled=true` as a boolean. Strings use
+// `stringSearchParam` (normalized via `asStringParam` by the page) and the
+// numerics fall back to sane defaults instead of throwing a route error.
 export const routesSearchSchema = z.object({
-  q: z.string().optional(),
+  q: stringSearchParam,
   // The page encodes the enabled filter as a comma-separated string
   // (`enabled,disabled`), so the schema accepts a raw string and the page
   // splits it — a single enum would reject the page's own writes.
-  enabled: z.string().optional(),
+  enabled: stringSearchParam,
   site: z.string().optional(),
-  accountId: z.coerce.number().int().positive().optional(),
-  siteId: z.coerce.number().int().positive().optional(),
-  page: z.coerce.number().int().positive().optional(),
-  pageSize: z.coerce.number().int().positive().optional(),
+  accountId: z.coerce.number().int().positive().optional().catch(undefined),
+  siteId: z.coerce.number().int().positive().optional().catch(undefined),
+  page: z.coerce.number().int().positive().catch(1).default(1),
+  pageSize: z.coerce.number().int().positive().catch(20).default(20),
 })

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -32,7 +32,10 @@
       "renderDescription": "An unexpected rendering error occurred.",
       "retry": "Retry",
       "reload": "Reload page",
-      "showDetail": "Show error details"
+      "showDetail": "Show error details",
+      "searchParamTitle": "The link parameters are no longer valid",
+      "searchParamDescription": "This link contains outdated or malformed parameters. Reset it to open the page with default settings.",
+      "searchParamReset": "Reset URL"
     },
     "common": {
       "skipToMain": "Skip to main content",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -32,7 +32,10 @@
       "renderDescription": "页面渲染时发生意外错误。",
       "retry": "重试",
       "reload": "重新加载",
-      "showDetail": "查看错误详情"
+      "showDetail": "查看错误详情",
+      "searchParamTitle": "链接参数已失效",
+      "searchParamDescription": "链接中包含过期或格式错误的参数。重置链接后将使用默认设置打开页面。",
+      "searchParamReset": "重置链接"
     },
     "common": {
       "skipToMain": "跳转到主要内容",

--- a/web/src/routes/_authenticated/accounts.tsx
+++ b/web/src/routes/_authenticated/accounts.tsx
@@ -19,13 +19,19 @@ import { z } from 'zod'
 import { accountQueryKeys } from '@/features/accounts'
 import { AccountsPage } from '@/features/accounts/components/accounts-page'
 import { api } from '@/lib/api'
+import { stringSearchParam } from '@/lib/helpers/searchParams'
 
-const accountsSearchSchema = z.object({
-  page: z.coerce.number().int().positive().optional(),
-  pageSize: z.coerce.number().int().min(1).max(200).optional(),
-  q: z.string().optional(),
-  status: z.string().optional(),
-  site: z.string().optional(),
+// Tolerant URL search contract: TanStack Router JSON-parses search values, so
+// `?q=123` arrives as a number and `?status=true` as a boolean. The string
+// fields accept all three primitives (normalized to string by the page via
+// `asStringParam`), and the numerics fall back to sane defaults instead of
+// throwing a route error on stale bookmarks / legacy URLs.
+export const accountsSearchSchema = z.object({
+  page: z.coerce.number().int().positive().catch(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(200).catch(20).default(20),
+  q: stringSearchParam,
+  status: stringSearchParam,
+  site: stringSearchParam,
 })
 
 export const Route = createFileRoute('/_authenticated/accounts')({

--- a/web/src/routes/_authenticated/model-tester.tsx
+++ b/web/src/routes/_authenticated/model-tester.tsx
@@ -17,9 +17,12 @@ import { z } from 'zod'
 import { ModelTesterPage } from '@/features/model-tester/components/model-tester-page'
 import { modelsKeys } from '@/features/models'
 import { api } from '@/lib/api'
+import { stringSearchParam } from '@/lib/helpers/searchParams'
 
-const modelTesterSearchSchema = z.object({
-  model: z.string().optional(),
+// Tolerant deep-link param: the router JSON-parses search values, so a
+// stale `?model=123` arrives as a number and must not throw a route error.
+export const modelTesterSearchSchema = z.object({
+  model: stringSearchParam,
 })
 
 export const Route = createFileRoute('/_authenticated/model-tester')({

--- a/web/src/routes/_authenticated/proxy-logs.tsx
+++ b/web/src/routes/_authenticated/proxy-logs.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/features/proxy-logs'
 import { ProxyLogsPage } from '@/features/proxy-logs/components/proxy-logs-page'
 import { api } from '@/lib/api'
+import { asStringParam } from '@/lib/helpers/searchParams'
 
 const DEFAULT_PROXY_LOGS_PAGE_SIZE = 20
 
@@ -54,7 +55,7 @@ export const Route = createFileRoute('/_authenticated/proxy-logs')({
     const pageIndex = search.page ?? 0
     const pageSize = search.pageSize ?? DEFAULT_PROXY_LOGS_PAGE_SIZE
     const status = search.status === 'all' ? undefined : search.status
-    const searchText = search.q?.trim() || undefined
+    const searchText = asStringParam(search.q)?.trim() || undefined
     const siteId = search.siteId ?? undefined
     const client = search.client || undefined
     const from = search.from || undefined


### PR DESCRIPTION
Fixes render-time crashes (the 'server error' page) caused by throwing validateSearch on stale/JSON-parsed URL params across accounts/checkin/token-routes/proxy-logs/oauth/observability/channels/models/sites/model-tester. Adds SearchParamError handling to the layout error boundary with a reset-URL action.