### PR TITLE
fix(platform): one-api v0.6.10 detect (system_name value discriminator)

### DIFF
--- a/platform/newapi.go
+++ b/platform/newapi.go
@@ -15,10 +15,15 @@ type NewApiAdapter struct {
 	*BaseAdapter
 }
 
-// Detect probes GET /api/status and checks success===true and system_name is present.
+// Detect probes GET /api/status and checks success===true and that
+// data.system_name's value names a NewAPI fork. one-api v0.6.10 also ships
+// system_name (default "One API"), so mere presence of the key misdetects
+// one-api as new-api; the value-based check keeps the two apart.
 // Known NewAPI fork aliases (vo-api/super-api/rix-api/neo-api) short-circuit
 // via URL keyword so shield/WAF-fronted deployments whose /api/status probe is
 // blocked still get detected.
+// Operators who rename SYSTEM_NAME to something unrelated degrade to manual
+// platform selection — acceptable for an auto-detect heuristic.
 func (n *NewApiAdapter) Detect(ctx context.Context, url string) (bool, error) {
 	lower := strings.ToLower(url)
 	for _, kw := range []string{"vo-api", "super-api", "rix-api", "neo-api"} {
@@ -41,8 +46,12 @@ func (n *NewApiAdapter) Detect(ctx context.Context, url string) (bool, error) {
 	if !ok {
 		return false, nil
 	}
-	_, hasSystemName := data["system_name"]
-	return hasSystemName, nil
+	systemName, hasSystemName := getString(data, "system_name")
+	if !hasSystemName {
+		return false, nil
+	}
+	folded := strings.ToLower(systemName)
+	return strings.Contains(folded, "newapi") || strings.Contains(folded, "new api"), nil
 }
 
 // --- Login ---

--- a/platform/oneapi.go
+++ b/platform/oneapi.go
@@ -6,15 +6,20 @@ import (
 	"strings"
 )
 
-// OneApiAdapter handles OneAPI platforms (detect: /api/status without system_name).
+// OneApiAdapter handles OneAPI platforms (detect: /api/status by version +
+// system_name value discriminator against new-api).
 // Serves as the base for OneHubAdapter and DoneHubAdapter.
 type OneApiAdapter struct {
 	*BaseAdapter
 }
 
-// Detect probes GET /api/status and checks that success===true, system_name is
-// absent, and data.version is present (the catch-all discriminator). Requiring
-// version keeps unrelated /api/status endpoints from being labeled one-api.
+// Detect probes GET /api/status and checks success===true, data.version is
+// present, and system_name (when present) names one-api. one-api v0.5.x has no
+// system_name (legacy shape); v0.6.10+ ships system_name (default "One API").
+// The value check keeps new-api (default "New API") and one-api apart.
+// Requiring version keeps unrelated /api/status endpoints from being labeled
+// one-api. Operators who rename SYSTEM_NAME to something unrelated degrade to
+// manual platform selection — acceptable for an auto-detect heuristic.
 func (o *OneApiAdapter) Detect(ctx context.Context, url string) (bool, error) {
 	ctx, cancel := withProbeTimeout(ctx)
 	defer cancel()
@@ -30,11 +35,17 @@ func (o *OneApiAdapter) Detect(ctx context.Context, url string) (bool, error) {
 	if !ok {
 		return false, nil
 	}
-	if _, hasSystemName := data["system_name"]; hasSystemName {
+	if _, hasVersion := data["version"]; !hasVersion {
 		return false, nil
 	}
-	_, hasVersion := data["version"]
-	return hasVersion, nil
+	systemName, hasSystemName := getString(data, "system_name")
+	if !hasSystemName {
+		// Legacy v0.5 shape (or a non-string system_name): nothing to
+		// discriminate on, treat as absent.
+		return true, nil
+	}
+	folded := strings.ToLower(systemName)
+	return strings.Contains(folded, "oneapi") || strings.Contains(folded, "one api"), nil
 }
 
 // Checkin: POST /api/user/checkin (Bearer auth).

--- a/platform/oneapi_detect_test.go
+++ b/platform/oneapi_detect_test.go
@@ -1,0 +1,205 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// statusFixtureServer serves a canned GET /api/status response body.
+func statusFixtureServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/status" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func detectContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// TestOneApiNewApiDetect_DiscriminatesBySystemNameValue covers the
+// value-based discriminator that keeps one-api and new-api apart now that both
+// ship system_name in /api/status.
+func TestOneApiNewApiDetect_DiscriminatesBySystemNameValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusBody  string
+		wantNewApi  bool
+		wantOneApi  bool
+	}{
+		{
+			name: "one-api v0.6.10 shape (system_name One API)",
+			statusBody: `{
+				"success": true,
+				"message": "",
+				"data": {
+					"system_name": "One API",
+					"version": "v0.6.10",
+					"start_time": 1710000000,
+					"email_verification": false
+				}
+			}`,
+			wantNewApi: false,
+			wantOneApi: true,
+		},
+		{
+			name: "legacy one-api v0.5 shape (no system_name)",
+			statusBody: `{
+				"success": true,
+				"message": "",
+				"data": {
+					"version": "v0.5.11",
+					"start_time": 1710000000
+				}
+			}`,
+			wantNewApi: false,
+			wantOneApi: true,
+		},
+		{
+			name: "new-api v1 shape (system_name New API)",
+			statusBody: `{
+				"success": true,
+				"message": "",
+				"data": {
+					"system_name": "New API",
+					"version": "v1.0.0-rc.24",
+					"logo": "/logo.png"
+				}
+			}`,
+			wantNewApi: true,
+			wantOneApi: false,
+		},
+		{
+			name: "unknown /api/status (no system_name, no version)",
+			statusBody: `{
+				"success": true,
+				"message": "",
+				"data": {"uptime": 3600}
+			}`,
+			wantNewApi: false,
+			wantOneApi: false,
+		},
+		{
+			name: "renamed SYSTEM_NAME degrades to no match",
+			statusBody: `{
+				"success": true,
+				"message": "",
+				"data": {
+					"system_name": "My Gateway",
+					"version": "v0.6.10"
+				}
+			}`,
+			wantNewApi: false,
+			wantOneApi: false,
+		},
+		{
+			name: "one-api name without space matches",
+			statusBody: `{
+				"success": true,
+				"message": "",
+				"data": {
+					"system_name": "oneapi-community",
+					"version": "v0.6.10"
+				}
+			}`,
+			wantNewApi: false,
+			wantOneApi: true,
+		},
+		{
+			name: "new-api name without space matches",
+			statusBody: `{
+				"success": true,
+				"message": "",
+				"data": {
+					"system_name": "MyNewApi",
+					"version": "v1.0.0"
+				}
+			}`,
+			wantNewApi: true,
+			wantOneApi: false,
+		},
+		{
+			name: "case-insensitive matching",
+			statusBody: `{
+				"success": true,
+				"message": "",
+				"data": {
+					"system_name": "ONE API",
+					"version": "v0.6.10"
+				}
+			}`,
+			wantNewApi: false,
+			wantOneApi: true,
+		},
+		{
+			name: "success false never matches",
+			statusBody: `{
+				"success": false,
+				"message": "no",
+				"data": {
+					"system_name": "One API",
+					"version": "v0.6.10"
+				}
+			}`,
+			wantNewApi: false,
+			wantOneApi: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := statusFixtureServer(t, tt.statusBody)
+			ctx := detectContext(t)
+
+			newApi := &NewApiAdapter{BaseAdapter: NewBaseAdapter("new-api")}
+			newOK, err := newApi.Detect(ctx, srv.URL)
+			if err != nil {
+				t.Fatalf("NewApiAdapter.Detect error: %v", err)
+			}
+			if newOK != tt.wantNewApi {
+				t.Errorf("NewApiAdapter.Detect = %v, want %v", newOK, tt.wantNewApi)
+			}
+
+			oneApi := &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-api")}
+			oneOK, err := oneApi.Detect(ctx, srv.URL)
+			if err != nil {
+				t.Fatalf("OneApiAdapter.Detect error: %v", err)
+			}
+			if oneOK != tt.wantOneApi {
+				t.Errorf("OneApiAdapter.Detect = %v, want %v", oneOK, tt.wantOneApi)
+			}
+		})
+	}
+}
+
+// TestNewApiAdapter_Detect_URLKeywordAliasesUnchanged keeps the pre-existing
+// URL-keyword short-circuit for NewAPI fork aliases under test.
+func TestNewApiAdapter_Detect_URLKeywordAliasesUnchanged(t *testing.T) {
+	n := &NewApiAdapter{BaseAdapter: NewBaseAdapter("new-api")}
+	ctx := detectContext(t)
+
+	for _, keyword := range []string{"vo-api", "super-api", "rix-api", "neo-api"} {
+		url := "https://example.com/" + keyword + "/dashboard"
+		ok, err := n.Detect(ctx, url)
+		if err != nil {
+			t.Fatalf("Detect(%q) error: %v", url, err)
+		}
+		if !ok {
+			t.Errorf("Detect(%q) = false, want true via URL keyword", url)
+		}
+	}
+}


### PR DESCRIPTION
## Bug

one-api v0.6.10's `/api/status` now includes `system_name` (default "One API") alongside `version` ("v0.6.10"). Both existing discriminators broke:

- `NewApiAdapter.Detect` matched `success && system_name present` → matched BOTH new-api and one-api.
- `OneApiAdapter.Detect` matched `success && system_name ABSENT && version present` → matched NEITHER (one-api now has system_name).

Since the detect chain tries NewApiAdapter before OneApiAdapter, one-api v0.6.10 was misdetected as new-api (confidence 0.8).

**Live evidence:** `POST /api/sites/detect {url:"http://one-api:3000"}` → `platform:"new-api"` (WRONG). new-api v1 defaults: `system_name` = "New API", `version` = "v1.0.0-rc.24".

## Design: value-based discriminator + legacy compat

| Adapter | Accept condition on `/api/status` |
|---------|-----------------------------------|
| NewApiAdapter | `success===true` AND `data.system_name` present AND value (case-insensitive) contains `"newapi"` or `"new api"` |
| OneApiAdapter | `success===true` AND `data.version` present AND (system_name ABSENT [legacy v0.5] OR value (case-insensitive) contains `"oneapi"` or `"one api"`) |

- URL keyword aliases for NewApi forks (vo-api/super-api/rix-api/neo-api) unchanged.
- "One API" does not match NewApi's patterns and "New API" does not match OneApi's patterns.
- Operators who rename SYSTEM_NAME degrade to manual platform selection (documented in code comments).

## Chain-order findings

Detect chain (`platform/registry.go` `orderedPlatformNames`): openai, codex, claude, gemini, gemini-cli, antigravity, grok, cliproxyapi, sensetime, anyrouter, done-hub, one-hub, veloera, new-api, sub2api, one-api (last).

- Standard adapters inherit `BaseAdapter.Detect` (returns error → skipped).
- codex/gemini-cli/cliproxyapi/anyrouter/sub2api: URL keyword detects — no cross-match for one-api URLs.
- OneHub/DoneHub: own URL-keyword `Detect` ("onehub"/"one-hub", "donehub"/"done-hub") — unaffected by the base OneApiAdapter change.
- VeloeraAdapter probes `/api/status` too but requires "veloera" in system_name/version — no cross-match.
- new-api before one-api: with the value discriminator, "One API" no longer claimed by NewApi, falls through to OneApi correctly.

## Tests

New `platform/oneapi_detect_test.go` (httptest fixtures):

- one-api v0.6.10 shape → OneApi true, NewApi false
- legacy one-api v0.5 shape (no system_name) → OneApi true, NewApi false
- new-api v1 shape → NewApi true, OneApi false
- unknown `/api/status` (no system_name, no version) → both false
- Plus: renamed SYSTEM_NAME degrades to no match, no-space/case variants, `success:false` never matches, URL keyword aliases unchanged.

## Verification

- `go build ./cmd/server` ✅
- `go vet ./...` ✅
- `go test ./... -count=1` ✅ (all packages)
- `go test ./platform/... -count=1 -race` ✅