### PR TITLE
feat(accounts): password credential mode (bind upstream via username+password)

### DIFF
--- a/web/src/features/accounts/__tests__/accounts-schema.test.ts
+++ b/web/src/features/accounts/__tests__/accounts-schema.test.ts
@@ -7,7 +7,7 @@ import {
   transformFormToPayload,
   type AccountFormValues,
 } from '../lib/accounts-schema'
-import { type Account, accountSchema } from '../types'
+import { type Account, type AccountPayload, accountSchema } from '../types'
 
 // When the i18n runtime translation layer is active (the i18n.coverage suite
 // loads it first in the full run), Chinese-literal Zod messages are replaced
@@ -38,6 +38,15 @@ function validApikeyForm(): AccountFormValues {
     ...getAccountFormDefaultValues('apikey'),
     siteId: 1,
     apiToken: 'k',
+  }
+}
+
+function validPasswordForm(): AccountFormValues {
+  return {
+    ...getAccountFormDefaultValues('password'),
+    siteId: 1,
+    username: 'login-user',
+    password: 'secret',
   }
 }
 
@@ -77,6 +86,64 @@ describe('getAccountFormSchema — superRefine', () => {
     if (result.success) return
     expect(result.error.issues[0]?.path).toEqual(['apiToken'])
     expectLocalized(result.error.issues[0]?.message, '请填写 API Key')
+  })
+
+  it('requires a username in password mode', () => {
+    const result = getAccountFormSchema().safeParse({
+      ...validPasswordForm(),
+      username: '',
+    })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error.issues[0]?.path).toEqual(['username'])
+    expectLocalized(result.error.issues[0]?.message, '请填写站点用户名')
+  })
+
+  it('requires a password in password mode', () => {
+    const result = getAccountFormSchema().safeParse({
+      ...validPasswordForm(),
+      password: '',
+    })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error.issues[0]?.path).toEqual(['password'])
+    expectLocalized(result.error.issues[0]?.message, '请填写站点密码')
+  })
+
+  it('flags both username and password when both are blank', () => {
+    const result = getAccountFormSchema().safeParse({
+      ...validPasswordForm(),
+      username: '',
+      password: '',
+    })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    const paths = result.error.issues.map((issue) => issue.path[0])
+    expect(paths).toEqual(['username', 'password'])
+  })
+
+  it('treats whitespace-only password credentials as empty after trimming', () => {
+    const result = getAccountFormSchema().safeParse({
+      ...validPasswordForm(),
+      username: '   ',
+      password: '   ',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('does not require session or apikey credentials in password mode', () => {
+    const result = getAccountFormSchema().safeParse({
+      ...validPasswordForm(),
+      accessToken: '',
+      apiToken: '',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a fully valid password form', () => {
+    expect(getAccountFormSchema().safeParse(validPasswordForm()).success).toBe(
+      true
+    )
   })
 
   it('accepts a fully valid session form', () => {
@@ -172,8 +239,17 @@ describe('getAccountFormSchema — proxyUrl', () => {
 // ---------------------------------------------------------------------------
 
 describe('transformFormToPayload', () => {
+  // Session/apikey forms always produce a payload; password mode returns
+  // undefined (handled by the login endpoint). Assert the defined branch once
+  // so the individual assertions stay focused on the payload contract.
+  function expectPayload(values: AccountFormValues): AccountPayload {
+    const payload = transformFormToPayload(values)
+    expect(payload).toBeDefined()
+    return payload as AccountPayload
+  }
+
   it('folds proxyUrl into extraConfig for session mode', () => {
-    const payload = transformFormToPayload({
+    const payload = expectPayload({
       ...validSessionForm(),
       proxyUrl: 'http://p',
     })
@@ -184,7 +260,7 @@ describe('transformFormToPayload', () => {
   })
 
   it('sends a single-entry accessTokens array for apikey mode', () => {
-    const payload = transformFormToPayload(validApikeyForm())
+    const payload = expectPayload(validApikeyForm())
     expect(payload.credentialMode).toBe('apikey')
     expect(payload.accessTokens).toEqual(['k'])
     expect(payload.skipModelFetch).toBe(false)
@@ -192,7 +268,7 @@ describe('transformFormToPayload', () => {
   })
 
   it('sends an empty accessTokens array when apiToken is blank', () => {
-    const payload = transformFormToPayload({
+    const payload = expectPayload({
       ...validApikeyForm(),
       apiToken: '',
     })
@@ -200,7 +276,7 @@ describe('transformFormToPayload', () => {
   })
 
   it('parses tags on /[,，\\s]+/ and drops empties', () => {
-    const payload = transformFormToPayload({
+    const payload = expectPayload({
       ...validSessionForm(),
       tags: 'a, b，c d',
     })
@@ -208,11 +284,15 @@ describe('transformFormToPayload', () => {
   })
 
   it('returns undefined tags for a blank tag input', () => {
-    const payload = transformFormToPayload({
+    const payload = expectPayload({
       ...validSessionForm(),
       tags: '  ',
     })
     expect(payload.tags).toBeUndefined()
+  })
+
+  it('returns undefined for password mode (routed to the login endpoint)', () => {
+    expect(transformFormToPayload(validPasswordForm())).toBeUndefined()
   })
 })
 
@@ -258,6 +338,7 @@ describe('transformAccountToFormValues', () => {
     expect(form.accessToken).toBe('')
     expect(form.apiToken).toBe('')
     expect(form.refreshToken).toBe('')
+    expect(form.password).toBe('')
     expect(form.platformUserId).toBeUndefined()
     expect(form.tokenExpiresAt).toBeUndefined()
   })
@@ -280,6 +361,13 @@ describe('getAccountFormDefaultValues', () => {
 
   it('defaults to session mode', () => {
     expect(getAccountFormDefaultValues().credentialMode).toBe('session')
+  })
+
+  it('seeds password mode with a blank password field', () => {
+    expect(getAccountFormDefaultValues('password')).toMatchObject({
+      credentialMode: 'password',
+      password: '',
+    })
   })
 
   it('produces defaults that fail schema validation (siteId 0)', () => {

--- a/web/src/features/accounts/api.ts
+++ b/web/src/features/accounts/api.ts
@@ -22,7 +22,12 @@ import { api } from '@/lib/api'
 import { assertBusinessOk } from '@/lib/assert-business-ok'
 import { toast } from '@/lib/toast'
 
-import type { AccountPayload, AccountStatus, AccountsSnapshot } from './types'
+import type {
+  AccountPayload,
+  AccountStatus,
+  AccountsSnapshot,
+  LoginAccountPayload,
+} from './types'
 
 // ---------------------------------------------------------------------------
 // Query keys
@@ -73,6 +78,34 @@ export function useCreateAccount() {
       return assertBusinessOk<CreateAccountResult>(
         result,
         'accounts.toast.createFailed'
+      )
+    },
+    onSuccess: (data) => {
+      void queryClient.invalidateQueries({ queryKey: accountQueryKeys.all })
+      return data
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// useLoginAccount — POST /api/accounts/login (password-mode binding)
+// ---------------------------------------------------------------------------
+
+export interface LoginAccountResult {
+  success?: boolean
+  message?: string
+  account?: { id?: number; username?: string }
+  reusedAccount?: boolean
+}
+
+export function useLoginAccount() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (payload: LoginAccountPayload) => {
+      const result = await api.loginAccount(payload)
+      return assertBusinessOk<LoginAccountResult>(
+        result,
+        'accounts.toast.loginFailed'
       )
     },
     onSuccess: (data) => {

--- a/web/src/features/accounts/components/account-form-dialog.tsx
+++ b/web/src/features/accounts/components/account-form-dialog.tsx
@@ -51,7 +51,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
 import { toast } from '@/lib/toast'
 
-import { useCreateAccount, useUpdateAccount } from '../api'
+import { useCreateAccount, useLoginAccount, useUpdateAccount } from '../api'
 import {
   getAccountFormDefaultValues,
   getAccountFormSchema,
@@ -80,6 +80,7 @@ export function AccountFormDialog({
   const { t } = useTranslation()
   const createMutation = useCreateAccount()
   const updateMutation = useUpdateAccount()
+  const loginMutation = useLoginAccount()
   const isEdit = mode === 'edit' && !!account
 
   const schema = useMemo(() => getAccountFormSchema(), [])
@@ -117,8 +118,30 @@ export function AccountFormDialog({
   }, [open, isEdit, account, initializedFor, form])
 
   const onSubmit = async (values: AccountFormValues) => {
-    const payload = transformFormToPayload(values)
     try {
+      if (values.credentialMode === 'password') {
+        const result = await loginMutation.mutateAsync({
+          siteId: values.siteId,
+          username: values.username?.trim() ?? '',
+          password: values.password ?? '',
+        })
+        toast.success(
+          t(
+            result?.reusedAccount
+              ? 'accounts.toast.loginRelogged'
+              : 'accounts.toast.loginSucceeded'
+          )
+        )
+        form.reset()
+        onOpenChange(false)
+        return
+      }
+
+      const payload = transformFormToPayload(values)
+      if (!payload) {
+        toast.error(t('accounts.toast.loginFailed'))
+        return
+      }
       if (isEdit && account) {
         await updateMutation.mutateAsync({ id: account.id, payload })
       } else {
@@ -137,7 +160,10 @@ export function AccountFormDialog({
     toast.error(t('accounts.form.invalid'))
   }
 
-  const isSubmitting = createMutation.isPending || updateMutation.isPending
+  const isSubmitting =
+    createMutation.isPending ||
+    updateMutation.isPending ||
+    loginMutation.isPending
   const siteOptions = sites
 
   return (
@@ -234,34 +260,40 @@ export function AccountFormDialog({
                   <TabsTrigger value='apikey'>
                     {t('accounts.form.modeApiKey')}
                   </TabsTrigger>
+                  <TabsTrigger value='password'>
+                    {t('accounts.form.modePassword')}
+                  </TabsTrigger>
                 </TabsList>
               </Tabs>
             </FormItem>
 
-            {/* Connection name (optional) */}
-            <FormField
-              control={form.control}
-              name='username'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('accounts.form.connectionName')}</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder={t('accounts.form.connectionNamePlaceholder')}
-                      {...field}
-                      value={field.value ?? ''}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            {credentialMode === 'session' ? (
-              <SessionFields form={form} />
-            ) : (
-              <ApiKeyFields form={form} />
+            {/* Connection name (optional) — hidden in password mode, where
+                username is the site login name collected by PasswordFields */}
+            {credentialMode !== 'password' && (
+              <FormField
+                control={form.control}
+                name='username'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t('accounts.form.connectionName')}</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder={t(
+                          'accounts.form.connectionNamePlaceholder'
+                        )}
+                        {...field}
+                        value={field.value ?? ''}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             )}
+
+            {credentialMode === 'session' && <SessionFields form={form} />}
+            {credentialMode === 'apikey' && <ApiKeyFields form={form} />}
+            {credentialMode === 'password' && <PasswordFields form={form} />}
 
             {/* Status */}
             <FormField
@@ -525,6 +557,59 @@ function SessionFields({ form }: SessionFieldsProps) {
                 onBlur={field.onBlur}
               />
             </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Password-mode fields — username+password sign-in, bound via the separate
+// POST /api/accounts/login endpoint (the backend fetches the session token
+// and stores autoRelogin config on the account).
+// ---------------------------------------------------------------------------
+
+function PasswordFields({ form }: SessionFieldsProps) {
+  const { t } = useTranslation()
+  return (
+    <>
+      <FormField
+        control={form.control}
+        name='username'
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{t('accounts.formPassword.username')}</FormLabel>
+            <FormControl>
+              <Input
+                autoComplete='username'
+                placeholder={t('accounts.formPassword.usernamePlaceholder')}
+                {...field}
+                value={field.value ?? ''}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name='password'
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{t('accounts.formPassword.password')}</FormLabel>
+            <FormControl>
+              <Input
+                type='password'
+                autoComplete='new-password'
+                placeholder={t('accounts.formPassword.passwordPlaceholder')}
+                {...field}
+                value={field.value ?? ''}
+              />
+            </FormControl>
+            <FormDescription>{t('accounts.formPassword.hint')}</FormDescription>
             <FormMessage />
           </FormItem>
         )}

--- a/web/src/features/accounts/lib/accounts-schema.ts
+++ b/web/src/features/accounts/lib/accounts-schema.ts
@@ -3,11 +3,14 @@
 // a schema *factory* (so cross-field rules can run), default-values factory,
 // and two transformers (form → API payload, entity → form defaults).
 //
-// The form is mode-aware (session vs apikey credential mode). Session mode
-// collects an Access Token / optional platformUserId / optional sub2api
-// refresh token; apikey mode collects an API Key. Conditional required-field
-// rules live in `superRefine` rather than a discriminated union so the RHF
-// field array stays stable across mode switches.
+// The form is mode-aware (session / apikey / password credential modes).
+// Session mode collects an Access Token / optional platformUserId / optional
+// sub2api refresh token; apikey mode collects an API Key; password mode
+// collects the site login username + password (bound via the separate
+// POST /api/accounts/login endpoint, not the accounts create payload).
+// Conditional required-field rules live in `superRefine` rather than a
+// discriminated union so the RHF field array stays stable across mode
+// switches.
 //
 // Error messages are i18next keys (resolved by `<FormMessage>`).
 
@@ -26,8 +29,9 @@ export function getAccountFormSchema() {
         .number({ message: 'accounts.schema.siteRequired' })
         .int({ message: 'accounts.schema.siteRequired' })
         .positive({ message: 'accounts.schema.siteRequired' }),
-      credentialMode: z.enum(['session', 'apikey']),
+      credentialMode: z.enum(['session', 'apikey', 'password']),
       username: z.string().trim().optional(),
+      password: z.string().trim().optional(),
       accessToken: z.string().trim().optional(),
       apiToken: z.string().trim().optional(),
       platformUserId: z.number().int().positive().optional(),
@@ -55,12 +59,27 @@ export function getAccountFormSchema() {
             message: 'accounts.schema.accessTokenRequired',
           })
         }
-      } else {
+      } else if (value.credentialMode === 'apikey') {
         if (!value.apiToken || value.apiToken.length === 0) {
           ctx.addIssue({
             code: 'custom',
             path: ['apiToken'],
             message: 'accounts.schema.apiKeyRequired',
+          })
+        }
+      } else {
+        if (!value.username || value.username.length === 0) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['username'],
+            message: 'accounts.schema.usernameRequired',
+          })
+        }
+        if (!value.password || value.password.length === 0) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['password'],
+            message: 'accounts.schema.passwordRequired',
           })
         }
       }
@@ -80,6 +99,7 @@ export function getAccountFormDefaultValues(
     siteId: 0,
     credentialMode: mode,
     username: '',
+    password: '',
     accessToken: '',
     apiToken: '',
     platformUserId: undefined,
@@ -106,9 +126,14 @@ function parseTagsInput(raw: string | undefined): string[] | undefined {
     .filter(Boolean)
 }
 
+// Password mode has no accounts create/update payload: it posts
+// `{siteId, username, password}` to POST /api/accounts/login instead, so the
+// transform returns undefined and the caller routes to the login mutation.
 export function transformFormToPayload(
   values: AccountFormValues
-): AccountPayload {
+): AccountPayload | undefined {
+  if (values.credentialMode === 'password') return undefined
+
   const tags = parseTagsInput(values.tags)
   const extraConfig = values.proxyUrl
     ? JSON.stringify({ proxyUrl: values.proxyUrl })
@@ -153,6 +178,7 @@ export function transformAccountToFormValues(
     siteId: account.siteId,
     credentialMode: account.credentialMode,
     username: account.username ?? '',
+    password: '',
     accessToken: '',
     apiToken: '',
     platformUserId: undefined,

--- a/web/src/features/accounts/types.ts
+++ b/web/src/features/accounts/types.ts
@@ -24,7 +24,7 @@ const RUNTIME_HEALTH_STATES = [
 ] as const
 export type RuntimeHealthState = (typeof RUNTIME_HEALTH_STATES)[number]
 
-const CREDENTIAL_MODES = ['session', 'apikey'] as const
+const CREDENTIAL_MODES = ['session', 'apikey', 'password'] as const
 export type CredentialMode = (typeof CREDENTIAL_MODES)[number]
 
 // ---------------------------------------------------------------------------
@@ -161,6 +161,20 @@ export interface AccountPayload {
   skipModelFetch?: boolean
   tags?: string[]
   extraConfig?: string
+}
+
+// ---------------------------------------------------------------------------
+// Account login payload (POST /api/accounts/login) — password-based binding.
+// The backend signs in with username+password, then creates the account (or
+// updates an existing one for the same site+username) with the upstream
+// session token plus autoRelogin config. This is a separate endpoint from
+// POST/PUT /api/accounts, so it carries its own payload type.
+// ---------------------------------------------------------------------------
+
+export interface LoginAccountPayload {
+  siteId: number
+  username: string
+  password: string
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1304,13 +1304,14 @@
         "editTitle": "Edit account",
         "addTitle": "Add account",
         "editDescription": "Update account credentials and configuration. Empty credential fields will remain unchanged.",
-        "addDescription": "Connect a site account: Session mode for check-in/balance, API Key mode for proxy forwarding.",
+        "addDescription": "Connect a site account: Session / Password modes for check-in and balance, API Key mode for proxy forwarding.",
         "site": "Site",
         "sitePlaceholder": "Select a site",
         "siteEmpty": "No sites available, please add a site first",
         "credentialMode": "Credential mode",
         "modeSession": "Session",
         "modeApiKey": "API Key",
+        "modePassword": "Password",
         "connectionName": "Connection name (optional)",
         "connectionNamePlaceholder": "Leave empty to use the site username",
         "status": "Status",
@@ -1342,6 +1343,13 @@
         "apiKeyPlaceholder": "Paste the site's API Key (sk-...)",
         "skipModelFetch": "Skip model fetch",
         "skipModelFetchHint": "Do not verify the Key's available models (quick add)"
+      },
+      "formPassword": {
+        "username": "Username",
+        "usernamePlaceholder": "Site login username",
+        "password": "Password",
+        "passwordPlaceholder": "Site login password",
+        "hint": "Sign in with username and password; the session token is fetched and bound automatically."
       },
       "columns": {
         "healthHealthy": "Healthy",
@@ -1408,13 +1416,18 @@
         "bulkPartial": "{{success}} succeeded, {{failed}} failed: {{items}}",
         "pinFailed": "Failed to update pin",
         "statusFailed": "Failed to update status",
-        "checkinFailed": "Failed to update check-in"
+        "checkinFailed": "Failed to update check-in",
+        "loginSucceeded": "Account bound successfully",
+        "loginRelogged": "Account session refreshed",
+        "loginFailed": "Failed to bind account"
       },
       "schema": {
         "siteRequired": "Please select a site",
         "invalidProxyUrl": "Proxy URL must be a valid URL",
         "accessTokenRequired": "Please enter the Access Token / Cookie",
-        "apiKeyRequired": "Please enter the API Key"
+        "apiKeyRequired": "Please enter the API Key",
+        "usernameRequired": "Please enter the site username",
+        "passwordRequired": "Please enter the site password"
       },
       "tokens": {
         "title": "Access tokens",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1304,13 +1304,14 @@
         "editTitle": "编辑账号",
         "addTitle": "添加账号",
         "editDescription": "更新账号凭证与配置。留空的凭证字段将保持不变。",
-        "addDescription": "连接一个站点账号：Session 模式用于签到/余额，API Key 模式用于代理转发。",
+        "addDescription": "连接一个站点账号：Session / 密码登录模式用于签到与余额，API Key 模式用于代理转发。",
         "site": "站点",
         "sitePlaceholder": "选择站点",
         "siteEmpty": "暂无站点，请先添加站点",
         "credentialMode": "凭证模式",
         "modeSession": "Session",
         "modeApiKey": "API Key",
+        "modePassword": "密码登录",
         "connectionName": "连接名称（可选）",
         "connectionNamePlaceholder": "留空则使用站点用户名",
         "status": "状态",
@@ -1342,6 +1343,13 @@
         "apiKeyPlaceholder": "粘贴站点的 API Key（sk-...）",
         "skipModelFetch": "跳过模型获取",
         "skipModelFetchHint": "不验证 Key 的可用模型（快速添加）"
+      },
+      "formPassword": {
+        "username": "用户名",
+        "usernamePlaceholder": "站点登录用户名",
+        "password": "密码",
+        "passwordPlaceholder": "站点登录密码",
+        "hint": "使用用户名和密码登录站点，系统会自动获取并绑定会话 Token。"
       },
       "columns": {
         "healthHealthy": "健康",
@@ -1408,13 +1416,18 @@
         "bulkPartial": "{{success}} 个成功，{{failed}} 个失败：{{items}}",
         "pinFailed": "更新置顶失败",
         "statusFailed": "更新状态失败",
-        "checkinFailed": "更新签到失败"
+        "checkinFailed": "更新签到失败",
+        "loginSucceeded": "账号绑定成功",
+        "loginRelogged": "账号会话已刷新",
+        "loginFailed": "绑定账号失败"
       },
       "schema": {
         "siteRequired": "请选择站点",
         "invalidProxyUrl": "代理地址需为合法 URL",
         "accessTokenRequired": "请填写 Access Token / Cookie",
-        "apiKeyRequired": "请填写 API Key"
+        "apiKeyRequired": "请填写 API Key",
+        "usernameRequired": "请填写站点用户名",
+        "passwordRequired": "请填写站点密码"
       },
       "tokens": {
         "title": "访问令牌",


### PR DESCRIPTION
## Summary

Closes a real functional gap: the account creation dialog could not bind password-based upstreams (new-api / one-api with username+password). The backend has a complete `POST /api/accounts/login` flow (username+password → creates or updates the account with the upstream session token + autoRelogin config), but the frontend never called it — verified by real-browser testing: no verify-token/login call existed anywhere in the accounts feature. The form only offered session (paste token) and apikey modes.

## Changes

- `features/accounts/types.ts`: `CredentialMode` union now includes `'password'`; added `LoginAccountPayload` (`{siteId, username, password}`) for the separate login endpoint.
- `features/accounts/lib/accounts-schema.ts`: schema factory accepts `'password'`; added optional trimmed `password` field; `superRefine` requires BOTH username and password in password mode (i18n-key messages); defaults and `transformAccountToFormValues` include a blank `password` (never shown on edit); `transformFormToPayload` returns `undefined` for password mode (routed to the login mutation).
- `features/accounts/api.ts`: new `useLoginAccount` mutation (`POST /api/accounts/login`), same conventions as `useCreateAccount` — `assertBusinessOk` + invalidates `accountQueryKeys.all` on success.
- `features/accounts/components/account-form-dialog.tsx`: third "Password" tab (`accounts.form.modePassword`), `PasswordFields` (username + password with hint that it signs in and binds the session automatically), submit branch that calls the login mutation, success toast (`loginSucceeded` / `loginRelogged` based on `reusedAccount`), error path identical to the create flow (http-client toasts 400/401 `{error}` bodies).
- i18n: new `accounts.formPassword.*`, `accounts.form.modePassword`, `accounts.schema.usernameRequired/passwordRequired`, `accounts.toast.loginSucceeded/loginRelogged/loginFailed` keys added to BOTH `en.json` and `zh-CN.json` (parity test enforced).
- Tests: extended `accounts-schema.test.ts` with password-mode superRefine cases (username/password required, both-blank flags both paths, whitespace trimming, valid form) plus the transform decision (password mode → `undefined` payload).

## Test plan

All run in `web/`:

- `bun run typecheck` — pass (tsgo, 0 errors)
- `bun run lint` — pass (oxlint, 0 errors)
- `bun run test` — pass (369 tests / 34 files)
- `bun run format:check` — pass