### PR TITLE
test: harden flaky batch-writer shutdown + smoke verify-token real token

### DIFF
--- a/handler/proxy/proxy_log_batch_test.go
+++ b/handler/proxy/proxy_log_batch_test.go
@@ -59,12 +59,14 @@ func countProxyLogsRows(t *testing.T, db *store.DB, pattern string) int {
 	return count
 }
 
-// shutdownWriterSoon waits up to 2s for the writer to drain+flush after a stop
+// shutdownWriterSoon waits up to 15s for the writer to drain+flush after a stop
 // signal. The loop goroutine closes b.done once it returns, so a successful
-// shutdown means every enqueued entry has been flushed.
+// shutdown means every enqueued entry has been flushed. The generous budget
+// exists because the backpressure test performs 500 row inserts under -race
+// (2s was too tight on loaded CI runners: "context deadline exceeded").
 func shutdownWriterSoon(t *testing.T, b *proxyLogBatchWriter) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	if err := b.shutdown(ctx); err != nil {
 		t.Fatalf("batch writer shutdown: %v", err)

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -272,14 +272,14 @@ else
   fail_step "login skipped (no site id)"
 fi
 
-# 6. verify-token — documented: the endpoint takes a token, not a password.
-#    Sending the password is expected to fail; record FAIL with body and continue.
+# 6. verify-token — the token-paste path, exercised with the REAL session token
+#    obtained from the login step (not the password).
 if [ -n "$SITE_ID" ]; then
-  status="$(request POST "$METAPI_URL/api/accounts/verify-token" "{\"siteId\":$SITE_ID,\"accessToken\":\"$UPSTREAM_PASSWORD\",\"credentialMode\":\"password\"}" "$METAPI_AUTH_TOKEN")"
+  status="$(request POST "$METAPI_URL/api/accounts/verify-token" "{\"siteId\":$SITE_ID,\"accessToken\":\"$LOGIN_TOKEN\",\"credentialMode\":\"session\"}" "$METAPI_AUTH_TOKEN")"
   if [ "$status" = "200" ]; then
-    pass_step "verify-token (unexpected success with password input)"
+    pass_step "verify-token (real session token, HTTP 200)"
   else
-    fail_step "verify-token (expected: takes a token, not a password — HTTP $status)"
+    fail_step "verify-token (real session token, HTTP $status)"
     evidence
   fi
 else


### PR DESCRIPTION
## Summary
- Raise shutdownWriterSoon budget 2s->15s (TestProxyLogBatchWriter_BackpressureFallsBackToSync CI timeout under -race).
- smoke.sh verify-token step now uses the real session token from the login step instead of the password (which failed by design).

## Test plan
- go vet ./handler/proxy
- go test ./handler/proxy -run TestProxyLogBatchWriter -count=3
- go test ./handler/proxy -run TestProxyLogBatchWriter_BackpressureFallsBackToSync -race
- bash -n scripts/e2e/smoke.sh