### PR TITLE
fix(platform): one-api v0.6.10 cookie-session login

### DIFF
--- a/platform/oneapi.go
+++ b/platform/oneapi.go
@@ -48,27 +48,215 @@ func (o *OneApiAdapter) Detect(ctx context.Context, url string) (bool, error) {
 	return strings.Contains(folded, "oneapi") || strings.Contains(folded, "one api"), nil
 }
 
-// Checkin: POST /api/user/checkin (Bearer auth).
+// Login POSTs /api/user/login and accepts either a legacy data.access_token
+// or a captured session cookie. one-api v0.6.10 returns success:true with an
+// EMPTY data.access_token and authenticates via a Set-Cookie session cookie,
+// so the cookie header becomes the stored credential. Mirrors
+// NewApiAdapter.Login (same fetchLoginResponse + hasUsableSessionCookie flow).
+func (o *OneApiAdapter) Login(ctx context.Context, baseURL, username, password string, platformUserId *int, proxy *ProxyConfig) (*LoginResult, error) {
+	body := map[string]string{"username": username, "password": password}
+	headers := map[string]string{
+		"X-Requested-With": "XMLHttpRequest",
+		"User-Agent":       DefaultBrowserUserAgent,
+	}
+
+	parsed, cookieHeader, err := fetchLoginResponse(ctx, baseURL+"/api/user/login", body, headers, proxy)
+	if err != nil {
+		return &LoginResult{Success: false, Message: err.Error()}, nil
+	}
+
+	if parsed == nil {
+		return &LoginResult{Success: false, Message: "shield challenge blocked login"}, nil
+	}
+
+	data, _ := getMap(parsed, "data")
+	accessToken := extractLoginToken(parsed, data)
+	success, hasSuccess := getBool(parsed, "success")
+
+	// Legacy one-api (v0.5) returns a real data.access_token; tolerate a
+	// missing top-level success the same way NewApiAdapter does.
+	if accessToken != "" && (!hasSuccess || success) {
+		return &LoginResult{Success: true, AccessToken: accessToken, Username: username}, nil
+	}
+
+	// one-api v0.6.10: success:true but empty data.access_token; the real
+	// credential is the session cookie captured from Set-Cookie.
+	if hasSuccess && success && hasUsableSessionCookie(cookieHeader) {
+		return &LoginResult{Success: true, AccessToken: cookieHeader, Username: username}, nil
+	}
+
+	msg := extractResponseMessage(parsed)
+	if msg == "" {
+		msg = "login failed: no usable session credential, try Cookie/Token import"
+	}
+	return &LoginResult{Success: false, Message: msg}, nil
+}
+
+// GetUserInfo: GET /api/user/self with Bearer auth first; session-cookie
+// credentials fall back to a Cookie header (one-api v0.6.10 login).
+func (o *OneApiAdapter) GetUserInfo(ctx context.Context, baseURL, accessToken string, platformUserId *int, proxy *ProxyConfig) (*UserInfo, error) {
+	resp, err := fetchJSON(ctx, baseURL+"/api/user/self", "GET", nil, authBearerHeaders(accessToken), proxy)
+	if err == nil {
+		if success, _ := getBool(resp, "success"); success {
+			if data, ok := getMap(resp, "data"); ok {
+				return parseUserInfo(data), nil
+			}
+		}
+	}
+
+	if isCookieCredential(accessToken) {
+		cookieResp, cookieErr := o.fetchSelfByCookie(ctx, baseURL, accessToken, proxy)
+		if cookieErr == nil && cookieResp != nil {
+			if data, ok := getMap(cookieResp, "data"); ok {
+				return parseUserInfo(data), nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+// VerifyToken mirrors BaseAdapter.VerifyToken but dispatches to the
+// cookie-aware overrides above. BaseAdapter.VerifyToken calls its own
+// Bearer-only GetUserInfo/GetBalance (Go static dispatch on the embedded
+// receiver), which would reject session-cookie credentials stored by the
+// v0.6.10 login; this override routes through o.GetUserInfo/o.GetBalance
+// instead.
+func (o *OneApiAdapter) VerifyToken(ctx context.Context, baseURL, token string, platformUserId *int, proxy *ProxyConfig) (*TokenVerifyResult, error) {
+	// 1. Try as session/access token
+	userInfo, err := o.GetUserInfo(ctx, baseURL, token, platformUserId, proxy)
+	if err == nil && userInfo != nil {
+		var balance *BalanceInfo
+		balanceInfo, err := o.GetBalance(ctx, baseURL, token, platformUserId, proxy)
+		if err == nil {
+			balance = balanceInfo
+		}
+
+		var apiToken *string
+		apiT, err := o.GetAPIToken(ctx, baseURL, token, platformUserId, proxy)
+		if err == nil && apiT != nil {
+			apiToken = apiT
+		}
+
+		apiTokenStr := ""
+		if apiToken != nil {
+			apiTokenStr = *apiToken
+		}
+		return &TokenVerifyResult{
+			TokenType: "session",
+			UserInfo:  userInfo,
+			Balance:   balance,
+			APIToken:  apiTokenStr,
+		}, nil
+	}
+
+	// 2. Try as API key (via /v1/models)
+	models, err := o.GetModels(ctx, baseURL, token, platformUserId, proxy)
+	if err == nil && len(models) > 0 {
+		return &TokenVerifyResult{
+			TokenType: "apikey",
+			Models:    models,
+		}, nil
+	}
+
+	return &TokenVerifyResult{TokenType: "unknown"}, nil
+}
+
+// Checkin: POST /api/user/checkin. Bearer auth first; session-cookie
+// credentials (one-api v0.6.10 login) fall back to a Cookie header.
 func (o *OneApiAdapter) Checkin(ctx context.Context, baseURL, accessToken string, platformUserId *int, proxy *ProxyConfig) (*CheckinResult, error) {
 	headers := authBearerHeaders(accessToken)
 	resp, err := fetchJSON(ctx, baseURL+"/api/user/checkin", "POST", nil, headers, proxy)
-	if err != nil {
+	if err == nil {
+		if success, _ := getBool(resp, "success"); success {
+			return checkinResultFromResponse(resp, "Check-in successful", "Check-in failed"), nil
+		}
+		if !isCookieCredential(accessToken) {
+			// Report the upstream business message (e.g. "already checked in").
+			return checkinResultFromResponse(resp, "Check-in successful", "Check-in failed"), nil
+		}
+	} else if !isCookieCredential(accessToken) {
 		return &CheckinResult{Success: false, Message: err.Error()}, nil
 	}
 
-	return checkinResultFromResponse(resp, "Check-in successful", "Check-in failed"), nil
+	// The Bearer attempt is always rejected for cookie-shaped credentials;
+	// retry with the session cookie as the Cookie header.
+	cookieResp, cookieErr := fetchJSON(ctx, baseURL+"/api/user/checkin", "POST", nil, map[string]string{"Cookie": strings.TrimSpace(accessToken)}, proxy)
+	if cookieErr == nil {
+		return checkinResultFromResponse(cookieResp, "Check-in successful", "Check-in failed"), nil
+	}
+	if err != nil {
+		return &CheckinResult{Success: false, Message: err.Error()}, nil
+	}
+	return &CheckinResult{Success: false, Message: cookieErr.Error()}, nil
 }
 
-// GetBalance: quota=total, balance=quota-used, divisor=500000.
+// GetBalance: quota=total, balance=quota-used, divisor=500000. Bearer auth
+// first; session-cookie credentials fall back to a Cookie header.
 func (o *OneApiAdapter) GetBalance(ctx context.Context, baseURL, accessToken string, platformUserId *int, proxy *ProxyConfig) (*BalanceInfo, error) {
 	headers := authBearerHeaders(accessToken)
 	resp, err := fetchJSON(ctx, baseURL+"/api/user/self", "GET", nil, headers, proxy)
-	if err != nil {
-		return &BalanceInfo{}, nil
+	if err == nil {
+		if success, _ := getBool(resp, "success"); success {
+			if data, ok := getMap(resp, "data"); ok {
+				balance := parseOneApiStyleBalance(data, 500000, false)
+				return &balance, nil
+			}
+		}
 	}
 
-	balance := parseOneApiStyleBalance(resp, 500000, false)
-	return &balance, nil
+	if isCookieCredential(accessToken) {
+		cookieResp, cookieErr := o.fetchSelfByCookie(ctx, baseURL, accessToken, proxy)
+		if cookieErr == nil && cookieResp != nil {
+			if data, ok := getMap(cookieResp, "data"); ok {
+				balance := parseOneApiStyleBalance(data, 500000, false)
+				return &balance, nil
+			}
+		}
+	}
+
+	return &BalanceInfo{}, nil
+}
+
+// fetchSelfByCookie fetches /api/user/self with the credential sent as a
+// Cookie header. Minimal mirror of NewApiAdapter.fetchUserSelfByCookie without
+// the New-Api-User header injection (one-api does not use that header).
+func (o *OneApiAdapter) fetchSelfByCookie(ctx context.Context, baseURL, credential string, proxy *ProxyConfig) (map[string]interface{}, error) {
+	resp, err := fetchJSON(ctx, baseURL+"/api/user/self", "GET", nil, map[string]string{"Cookie": strings.TrimSpace(credential)}, proxy)
+	if err != nil {
+		return nil, err
+	}
+	if success, _ := getBool(resp, "success"); !success {
+		return nil, fmt.Errorf("cookie session rejected")
+	}
+	if _, ok := getMap(resp, "data"); !ok {
+		return nil, fmt.Errorf("cookie session response missing data")
+	}
+	return resp, nil
+}
+
+// isCookieCredential reports whether a stored credential is a session-cookie
+// header (e.g. "session=abc123") rather than a Bearer token (sk- key, JWT).
+// A cookie header contains at least one name=value pair with no whitespace
+// before '='; the name must not contain '.' so JWT segments (which only carry
+// '=' as base64 padding) do not classify as cookies.
+func isCookieCredential(credential string) bool {
+	value := strings.TrimSpace(stripBearerPrefix(credential))
+	if value == "" {
+		return false
+	}
+	for _, pair := range strings.Split(value, ";") {
+		trimmed := strings.TrimSpace(pair)
+		eq := strings.Index(trimmed, "=")
+		if eq <= 0 || eq == len(trimmed)-1 {
+			continue
+		}
+		if strings.ContainsAny(trimmed[:eq], " \t.") {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // GetModels: GET /v1/models (Bearer auth).

--- a/platform/oneapi_login_test.go
+++ b/platform/oneapi_login_test.go
@@ -1,0 +1,294 @@
+package platform
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// oneApiAdapterUnderTest builds the adapter under test, mirroring
+// newApiAdapterUnderTest in newapi_login_test.go.
+func oneApiAdapterUnderTest() *OneApiAdapter {
+	return &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-api")}
+}
+
+// one-api v0.6.10 login: success:true with an EMPTY data.access_token; the
+// real credential is the Set-Cookie session cookie, which must become the
+// stored AccessToken.
+func TestOneApiAdapter_Login_V0610SessionCookie(t *testing.T) {
+	srv := loginFixtureServer(t, `{
+		"data": {"id": 1, "username": "root", "access_token": ""},
+		"message": "",
+		"success": true
+	}`, 0, "session=abc123; Path=/; HttpOnly")
+	o := oneApiAdapterUnderTest()
+	ctx, cancel := loginContext(t)
+	defer cancel()
+
+	result, err := o.Login(ctx, srv.URL, "root", "123456", nil, nil)
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Login.Success = false, want true (message: %q)", result.Message)
+	}
+	if result.AccessToken != "session=abc123" {
+		t.Errorf("AccessToken = %q, want session=abc123", result.AccessToken)
+	}
+	if result.Username != "root" {
+		t.Errorf("Username = %q, want root", result.Username)
+	}
+}
+
+// Legacy one-api (v0.5) login: success:true with a non-empty data.access_token
+// must keep returning the token.
+func TestOneApiAdapter_Login_LegacyAccessToken(t *testing.T) {
+	srv := loginFixtureServer(t, `{"success":true,"message":"","data":{"access_token":"sk-legacy-token"}}`, 0, "")
+	o := oneApiAdapterUnderTest()
+	ctx, cancel := loginContext(t)
+	defer cancel()
+
+	result, err := o.Login(ctx, srv.URL, "root", "123456", nil, nil)
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Login.Success = false, want true (message: %q)", result.Message)
+	}
+	if result.AccessToken != "sk-legacy-token" {
+		t.Errorf("AccessToken = %q, want sk-legacy-token", result.AccessToken)
+	}
+}
+
+// Failure: explicit success:false must stay a failure with the upstream message.
+func TestOneApiAdapter_Login_Failure(t *testing.T) {
+	srv := loginFixtureServer(t, `{"message":"Username or password is incorrect.","success":false}`, 0, "")
+	o := oneApiAdapterUnderTest()
+	ctx, cancel := loginContext(t)
+	defer cancel()
+
+	result, err := o.Login(ctx, srv.URL, "root", "wrong-password", nil, nil)
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if result.Success {
+		t.Fatal("Login.Success = true, want false")
+	}
+	if !strings.Contains(result.Message, "incorrect") {
+		t.Errorf("Message = %q, want the upstream error text", result.Message)
+	}
+}
+
+// success:true with neither a token nor a usable session cookie must FAIL
+// (BaseAdapter used to return Success:true with an empty token here, which
+// surfaced as a generic "login failed" after the empty-token rejection).
+func TestOneApiAdapter_Login_NoUsableCredentialFails(t *testing.T) {
+	srv := loginFixtureServer(t, `{"data":{"id":1,"username":"root","access_token":""},"message":"","success":true}`, 0, "acw_tc=waf-only; Path=/")
+	o := oneApiAdapterUnderTest()
+	ctx, cancel := loginContext(t)
+	defer cancel()
+
+	result, err := o.Login(ctx, srv.URL, "root", "123456", nil, nil)
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if result.Success {
+		t.Fatalf("Login.Success = true, want false (AccessToken: %q)", result.AccessToken)
+	}
+}
+
+// selfFixtureServer serves /api/user/self rejecting Bearer auth and accepting
+// the session cookie, so cookie-fallback tests can assert both the fallback
+// path and the exact Cookie header sent.
+func selfFixtureServer(t *testing.T, selfDataJSON string) (*httptest.Server, *string) {
+	t.Helper()
+	var cookieHeaderSeen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/user/self":
+			if r.Header.Get("Authorization") != "" {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"success":false,"message":"Invalid access token"}`)
+				return
+			}
+			cookieHeaderSeen = r.Header.Get("Cookie")
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"success":true,"message":"","data":%s}`, selfDataJSON)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &cookieHeaderSeen
+}
+
+func TestOneApiAdapter_GetUserInfo_CookieFallback(t *testing.T) {
+	srv, cookieSeen := selfFixtureServer(t,
+		`{"id":1,"username":"root","display_name":"Root Admin","email":"root@example.com"}`)
+	o := oneApiAdapterUnderTest()
+	ctx, cancel := loginContext(t)
+	defer cancel()
+
+	info, err := o.GetUserInfo(ctx, srv.URL, "session=abc123", nil, nil)
+	if err != nil {
+		t.Fatalf("GetUserInfo: %v", err)
+	}
+	if info == nil {
+		t.Fatal("GetUserInfo returned nil user info for a cookie credential")
+	}
+	if info.Username != "root" {
+		t.Errorf("Username = %q, want root", info.Username)
+	}
+	if info.DisplayName != "Root Admin" {
+		t.Errorf("DisplayName = %q, want Root Admin", info.DisplayName)
+	}
+	if *cookieSeen != "session=abc123" {
+		t.Errorf("Cookie header = %q, want session=abc123", *cookieSeen)
+	}
+}
+
+func TestOneApiAdapter_GetUserInfo_BearerPreferred(t *testing.T) {
+	// Bearer succeeds: the Cookie fallback must never be attempted.
+	var cookieHeaderSeen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/user/self" {
+			http.NotFound(w, r)
+			return
+		}
+		cookieHeaderSeen = r.Header.Get("Cookie")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"success":true,"message":"","data":{"id":1,"username":"root"}}`)
+	}))
+	t.Cleanup(srv.Close)
+	o := oneApiAdapterUnderTest()
+	ctx, cancel := loginContext(t)
+	defer cancel()
+
+	info, err := o.GetUserInfo(ctx, srv.URL, "sk-legacy-token", nil, nil)
+	if err != nil {
+		t.Fatalf("GetUserInfo: %v", err)
+	}
+	if info == nil || info.Username != "root" {
+		t.Fatalf("GetUserInfo = %+v, want root", info)
+	}
+	if cookieHeaderSeen != "" {
+		t.Errorf("unexpected Cookie header on Bearer path: %q", cookieHeaderSeen)
+	}
+}
+
+func TestOneApiAdapter_GetBalance_CookieFallback(t *testing.T) {
+	srv, cookieSeen := selfFixtureServer(t,
+		`{"id":1,"username":"root","quota":1000000,"used_quota":500000}`)
+	o := oneApiAdapterUnderTest()
+	ctx, cancel := loginContext(t)
+	defer cancel()
+
+	balance, err := o.GetBalance(ctx, srv.URL, "session=abc123", nil, nil)
+	if err != nil {
+		t.Fatalf("GetBalance: %v", err)
+	}
+	if balance.Balance != 1.0 {
+		t.Errorf("Balance = %f, want 1.0 ((1000000-500000)/500000)", balance.Balance)
+	}
+	if balance.Quota != 2.0 {
+		t.Errorf("Quota = %f, want 2.0", balance.Quota)
+	}
+	if *cookieSeen != "session=abc123" {
+		t.Errorf("Cookie header = %q, want session=abc123", *cookieSeen)
+	}
+}
+
+// checkinFixtureServer rejects Bearer POST /api/user/checkin and accepts the
+// Cookie header, recording what was sent.
+func checkinFixtureServer(t *testing.T) (*httptest.Server, *string) {
+	t.Helper()
+	var cookieHeaderSeen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/user/checkin" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"success":false,"message":"Invalid access token"}`)
+			return
+		}
+		cookieHeaderSeen = r.Header.Get("Cookie")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"success":true,"message":"Check-in successful"}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &cookieHeaderSeen
+}
+
+func TestOneApiAdapter_Checkin_CookieFallback(t *testing.T) {
+	srv, cookieSeen := checkinFixtureServer(t)
+	o := oneApiAdapterUnderTest()
+	ctx, cancel := loginContext(t)
+	defer cancel()
+
+	result, err := o.Checkin(ctx, srv.URL, "session=abc123", nil, nil)
+	if err != nil {
+		t.Fatalf("Checkin: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Checkin.Success = false, want true (message: %q)", result.Message)
+	}
+	if *cookieSeen != "session=abc123" {
+		t.Errorf("Cookie header = %q, want session=abc123", *cookieSeen)
+	}
+}
+
+// VerifyToken must dispatch to the cookie-aware overrides (BaseAdapter's
+// version statically calls its Bearer-only GetUserInfo and would return
+// TokenType "unknown" for a cookie credential).
+func TestOneApiAdapter_VerifyToken_CookieCredential(t *testing.T) {
+	srv, _ := selfFixtureServer(t,
+		`{"id":1,"username":"root","quota":1000000,"used_quota":0}`)
+	o := oneApiAdapterUnderTest()
+	ctx, cancel := loginContext(t)
+	defer cancel()
+
+	result, err := o.VerifyToken(ctx, srv.URL, "session=abc123", nil, nil)
+	if err != nil {
+		t.Fatalf("VerifyToken: %v", err)
+	}
+	if result.TokenType != "session" {
+		t.Fatalf("TokenType = %q, want session", result.TokenType)
+	}
+	if result.UserInfo == nil || result.UserInfo.Username != "root" {
+		t.Errorf("UserInfo = %+v, want root", result.UserInfo)
+	}
+	if result.Balance == nil || result.Balance.Balance != 2.0 {
+		t.Errorf("Balance = %+v, want quota 2.0 via cookie path", result.Balance)
+	}
+}
+
+func TestIsCookieCredential(t *testing.T) {
+	tests := []struct {
+		name       string
+		credential string
+		want       bool
+	}{
+		{"session cookie", "session=abc123", true},
+		{"multi-pair cookie header", "session=abc123; token=xyz", true},
+		{"cookie with whitespace between pairs", "session=abc123 ; token=xyz", true},
+		{"bearer-prefixed cookie string", "Bearer session=abc123", true},
+		{"sk token", "sk-v0-token", false},
+		{"bare token without equals", "abc123", false},
+		{"jwt segments", "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MX0.sig", false},
+		{"jwt with base64 padding", "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MX0.si==", false},
+		{"empty credential", "", false},
+		{"empty value pair", "session=", false},
+		{"pair with space before equals", "session =abc123", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCookieCredential(tt.credential); got != tt.want {
+				t.Errorf("isCookieCredential(%q) = %v, want %v", tt.credential, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Root cause

one-api v0.6.10 `POST /api/user/login` returns `success:true` with an **empty** `data.access_token`; the real session credential is a `Set-Cookie` session cookie. The adapter chain went through `BaseAdapter.Login`, which extracted an empty token and returned `LoginResult{Success:true, AccessToken:""}` — then `loginAccount` rejected the empty token as "login failed".

## Approach: mirror NewApiAdapter

`NewApiAdapter` already solved this for new-api; this PR reuses the same package-level helpers for `OneApiAdapter`:

- **`Login` override**: POSTs `{username, password}` via `fetchLoginResponse` (captures `Set-Cookie`). Accepts success when `success===true` AND (non-empty `data.access_token` OR a usable session cookie via `hasUsableSessionCookie`). Returns the token when present, else the cookie header as the credential. Failures surface the upstream `extractResponseMessage`.
- **Cookie-aware downstream**: `GetUserInfo` / `Checkin` / `GetBalance` try the Bearer path first, then fall back to sending the credential as a `Cookie` header when it is cookie-shaped (`isCookieCredential`: name=value pair with no whitespace before `=`, name must not contain `.` so JWT segments don't classify as cookies).
- **`VerifyToken` override** (downstream finding): `BaseAdapter.VerifyToken` statically dispatches to its own Bearer-only `GetUserInfo`/`GetBalance` on the embedded receiver, so it would still reject cookie credentials even with the overrides above. The one-api override routes through `o.GetUserInfo`/`o.GetBalance`/`o.GetAPIToken`.

`loginAccount`/`createAccount` need no changes — they already store the credential string (including new-api cookie headers) as the encrypted account `access_token` without platform special-casing.

## Tests

`platform/oneapi_login_test.go` (httptest fixtures, following `newapi_login_test.go` style):

- v0.6.10 login (success + empty access_token + `Set-Cookie` session) → `Success` with cookie as `AccessToken`
- legacy login (success + non-empty `data.access_token`) → token returned
- failure (`success:false`) → `Success=false`
- success with no usable credential (WAF-only cookie) → fails instead of empty-token success
- `GetUserInfo` / `GetBalance` / `Checkin` fall back to the `Cookie` path for cookie-shaped credentials (fixtures assert the exact `Cookie` header sent)
- `GetUserInfo` prefers Bearer and never falls back when Bearer succeeds
- `VerifyToken` on a cookie credential returns `TokenType:"session"` with user info + balance
- `isCookieCredential` table test

## Gates

- `go build ./cmd/server` ✓
- `go vet ./...` ✓
- `go test ./... -count=1` ✓
- `go test ./platform/... -count=1 -race` ✓