### PR TITLE
ci: real-platform e2e job (new-api/one-api service containers)

### DIFF
--- a/.github/actions/go-toolchain/action.yml
+++ b/.github/actions/go-toolchain/action.yml
@@ -1,0 +1,18 @@
+name: Go toolchain + embed placeholder
+description: |
+  setup-go (from go.mod) and create the gitignored web/dist placeholder so the
+  go:embed directive in web/embed.go type-checks on a fresh checkout. Production
+  images build the real SPA inside the Dockerfile; test jobs reuse the real
+  dist via the web-dist artifact instead.
+inputs:
+  go-version-file:
+    description: Path to the go version file (relative to the workspace root)
+    default: go.mod
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@v7
+      with:
+        go-version-file: ${{ inputs.go-version-file }}
+    - shell: bash
+      run: mkdir -p web/dist && touch web/dist/placeholder.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,9 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8
+          # goinstall builds with the current toolchain (go.mod go directive is
+          # newer than the action's prebuilt binary), and still caches the build.
+          install-mode: goinstall
           args: --timeout=3m
 
   vet:
@@ -294,7 +297,7 @@ jobs:
         ports:
           - 3000:3000
       one-api:
-        image: songquanpeng/one-api:latest
+        image: justsong/one-api:latest
         ports:
           - 3001:3000
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,13 +37,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-      # web/embed.go embeds web/dist, which is gitignored and absent on a
-      # fresh checkout. A placeholder file lets Go tooling type-check the
-      # embed package; production images build the real SPA in the Dockerfile.
-      - run: mkdir -p web/dist && touch web/dist/placeholder.txt
+      - uses: ./.github/actions/go-toolchain
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
@@ -55,13 +49,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-      # web/embed.go embeds web/dist, which is gitignored and absent on a
-      # fresh checkout. A placeholder file lets go vet type-check the embed
-      # package; production images build the real SPA in the Dockerfile.
-      - run: mkdir -p web/dist && touch web/dist/placeholder.txt
+      - uses: ./.github/actions/go-toolchain
       - run: go vet ./...
 
   vulncheck:
@@ -69,10 +57,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-      - run: mkdir -p web/dist && touch web/dist/placeholder.txt
+      - uses: ./.github/actions/go-toolchain
       - run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
 
   mod-verify:
@@ -160,6 +145,12 @@ jobs:
       - name: Install web deps (playwright + axe-core)
         run: bun install --frozen-lockfile
         working-directory: web
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('web/bun.lockb') }}
+          restore-keys: playwright-${{ runner.os }}-
       - name: Install Playwright Chromium
         run: bunx playwright install --with-deps chromium
         working-directory: web
@@ -189,15 +180,24 @@ jobs:
           cd web
           BASE_URL=http://127.0.0.1:4099 bun run a11y:scan
 
-  test-sqlite:
+  test-sqlite-shard:
+    # The race detector makes the full suite the pipeline's long pole (~5 min).
+    # Shard packages round-robin across parallel runners to cut it ~4x while
+    # still running every package under -race. (Packages are independent; the
+    # handler tests use per-test :memory: sqlite, so sharding is safe.) The
+    # stable `test-sqlite` name below aggregates the shards so branch
+    # protection keeps a single required check.
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     needs: frontend
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+        total: [4]
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
+      - uses: ./.github/actions/go-toolchain
       # SPA-fallback and static-asset tests exercise the real embedded dist,
       # built once by the frontend job and passed through the artifact.
       - name: Download frontend dist
@@ -205,7 +205,32 @@ jobs:
         with:
           name: web-dist
           path: web/dist
-      - run: go test ./... -count=1 -race
+      - name: Run tests (shard ${{ matrix.shard }}/${{ matrix.total }})
+        run: |
+          set -euo pipefail
+          mapfile -t pkgs < <(go list ./...)
+          shard_pkgs=()
+          for i in "${!pkgs[@]}"; do
+            if (( i % matrix.total == matrix.shard )); then
+              shard_pkgs+=("${pkgs[i]}")
+            fi
+          done
+          if [ "${#shard_pkgs[@]}" -eq 0 ]; then
+            echo "no packages in shard; nothing to run"
+            exit 0
+          fi
+          echo "shard ${{ matrix.shard }} running ${#shard_pkgs[@]} packages:"
+          printf '  %s\n' "${shard_pkgs[@]}"
+          go test "${shard_pkgs[@]}" -count=1 -race
+
+  # Stable name that branch protection depends on: passes only when every
+  # shard above passed.
+  test-sqlite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: test-sqlite-shard
+    steps:
+      - run: echo "all test-sqlite shards passed"
 
   test-pg:
     runs-on: ubuntu-latest
@@ -250,10 +275,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-      - run: mkdir -p web/dist && touch web/dist/placeholder.txt
+      - uses: ./.github/actions/go-toolchain
       - run: go build -trimpath ./cmd/server
       - run: go build -trimpath ./cmd/migrate
 
@@ -277,11 +299,7 @@ jobs:
           - 3001:3000
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-      # smoke.sh exercises backend routes only; the SPA bundle is irrelevant.
-      - run: mkdir -p web/dist && touch web/dist/placeholder.txt
+      - uses: ./.github/actions/go-toolchain
       - name: Initialize upstreams
         run: |
           set -euo pipefail

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -350,13 +350,13 @@ jobs:
           PLATFORM=new-api \
           bash scripts/e2e/smoke.sh
 
-          echo "===== one-api detect ====="
-          curl -fsS -X POST http://127.0.0.1:4010/api/sites/detect \
-            -H "Authorization: Bearer e2e-admin-token" \
-            -H 'Content-Type: application/json' \
-            -d '{"url":"http://127.0.0.1:3001"}' \
-            | grep -q '"platform":"one-api"'
-          echo "one-api detect: platform=one-api OK"
+          echo "===== one-api full chain ====="
+          METAPI_URL=http://127.0.0.1:4010 \
+          METAPI_AUTH_TOKEN=e2e-admin-token \
+          UPSTREAM_URL=http://127.0.0.1:3001 \
+          UPSTREAM_USERNAME=root UPSTREAM_PASSWORD=123456 \
+          PLATFORM=one-api SITE_NAME=e2e-smoke-oneapi TOKEN_NAME=e2e-smoke-oneapi-token \
+          bash scripts/e2e/smoke.sh
 
   # Build + smoke the image on every run (this is also a required check on PRs).
   # It does not push; docker-push publishes the same image via shared cache.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,14 +40,15 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
       # web/embed.go embeds web/dist, which is gitignored and absent on a
       # fresh checkout. A placeholder file lets Go tooling type-check the
       # embed package; production images build the real SPA in the Dockerfile.
       - run: mkdir -p web/dist && touch web/dist/placeholder.txt
       - name: Run golangci-lint
-        run: golangci-lint run --timeout=3m
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.8
+          args: --timeout=3m
 
   vet:
     runs-on: ubuntu-latest
@@ -256,6 +257,89 @@ jobs:
       - run: go build -trimpath ./cmd/server
       - run: go build -trimpath ./cmd/migrate
 
+  # Real-platform e2e: boots REAL upstreams (new-api v1, one-api) as service
+  # containers, starts a live metapi server on the runner, and drives
+  # scripts/e2e/smoke.sh through the full admin + proxy chain (detect → login →
+  # verify → account → models → balance → checkin → downstream token → route →
+  # /v1 relay). This is the durable, free-on-Actions version of the transient
+  # ARM testbed: no external infra, no secrets, re-runnable per push.
+  test-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      new-api:
+        image: calciumion/new-api:latest
+        ports:
+          - 3000:3000
+      one-api:
+        image: songquanpeng/one-api:latest
+        ports:
+          - 3001:3000
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      # smoke.sh exercises backend routes only; the SPA bundle is irrelevant.
+      - run: mkdir -p web/dist && touch web/dist/placeholder.txt
+      - name: Initialize upstreams
+        run: |
+          set -euo pipefail
+          # new-api v1 has no default password: first-run setup creates root.
+          for i in $(seq 1 30); do
+            if curl -fsS -X POST http://127.0.0.1:3000/api/setup \
+              -H 'Content-Type: application/json' \
+              -d '{"username":"root","password":"metapi123","confirmPassword":"metapi123","SelfUseModeEnabled":false,"DemoSiteEnabled":false}' >/dev/null 2>&1; then
+              echo "new-api initialized"
+              break
+            fi
+            sleep 2
+          done
+          # one-api auto-seeds root/123456; just wait for readiness.
+          for i in $(seq 1 30); do
+            curl -fsS http://127.0.0.1:3001/api/status >/dev/null 2>&1 && { echo "one-api ready"; break; }
+            sleep 2
+          done
+      - name: Run live server + smoke chains
+        run: |
+          set -euo pipefail
+          AUTH_TOKEN=e2e-admin-token \
+          PROXY_TOKEN=e2e-proxy-token \
+          DATA_DIR="$(mktemp -d)/data" \
+          PORT=4010 \
+          go run ./cmd/server >/tmp/metapi-e2e.log 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid" >/dev/null 2>&1 || true' EXIT
+          ready=
+          for _ in $(seq 1 90); do
+            if curl -fsS http://127.0.0.1:4010/ready 2>/dev/null | grep -q '"status":"ok"'; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          if [ -z "$ready" ]; then
+            echo "metapi server failed to become ready; log:"
+            cat /tmp/metapi-e2e.log
+            exit 1
+          fi
+
+          echo "===== new-api full chain ====="
+          METAPI_URL=http://127.0.0.1:4010 \
+          METAPI_AUTH_TOKEN=e2e-admin-token \
+          UPSTREAM_URL=http://127.0.0.1:3000 \
+          UPSTREAM_USERNAME=root UPSTREAM_PASSWORD=metapi123 \
+          PLATFORM=new-api \
+          bash scripts/e2e/smoke.sh
+
+          echo "===== one-api detect ====="
+          curl -fsS -X POST http://127.0.0.1:4010/api/sites/detect \
+            -H "Authorization: Bearer e2e-admin-token" \
+            -H 'Content-Type: application/json' \
+            -d '{"url":"http://127.0.0.1:3001"}' \
+            | grep -q '"platform":"one-api"'
+          echo "one-api detect: platform=one-api OK"
+
   # Build + smoke the image on every run (this is also a required check on PRs).
   # It does not push; docker-push publishes the same image via shared cache.
   docker-build:
@@ -273,6 +357,7 @@ jobs:
       - test-sqlite
       - test-pg
       - build
+      - test-e2e
     steps:
       - uses: actions/checkout@v7
       - uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Summary
Durable CI version of the transient ARM testbed:
- New `test-e2e` job: boots calciumion/new-api + songquanpeng/one-api as service containers, starts a live metapi server, runs `scripts/e2e/smoke.sh` (full admin+proxy chain) for new-api, and asserts one-api detect (#769). Free on Actions, no external infra or secrets.
- Switches `lint` to golangci-lint-action@v6 for toolchain caching (was `go install` every run).
- Adds `test-e2e` to `docker-build` needs so it gates the image build.

## Notes
- one-api full password chain is deferred until #773 (cookie-session login) lands; currently detect-only.
- test-e2e should be added to the master branch-protection required checks.