### PR TITLE
fix(platform): cliproxyapi verify-token fails for management keys

### DIFF
--- a/platform/cliproxyapi.go
+++ b/platform/cliproxyapi.go
@@ -58,3 +58,50 @@ func (c *CliProxyApiAdapter) Detect(ctx context.Context, url string) (bool, erro
 func (c *CliProxyApiAdapter) GetModels(ctx context.Context, baseURL string, apiToken string, platformUserId *int, proxy *ProxyConfig) ([]string, error) {
 	return c.fetchModelsFromStandardEndpoint(ctx, baseURL, authBearerHeaders(apiToken), proxy)
 }
+
+// VerifyToken verifies a pasted CLIProxyAPI credential.
+//
+// CliProxyApiAdapter deliberately overrides VerifyToken instead of inheriting
+// BaseAdapter.VerifyToken: the base implementation statically dispatches to
+// one-api style GET /api/user/self (absent on CLIProxyAPI) and reports every
+// credential as "unknown". CLIProxyAPI credentials are keys: a provider API
+// key whose models are served through /v1/models, or the management key
+// (validated against the /v0/management API).
+func (c *CliProxyApiAdapter) VerifyToken(ctx context.Context, baseURL, token string, platformUserId *int, proxy *ProxyConfig) (*TokenVerifyResult, error) {
+	models, err := c.GetModels(ctx, baseURL, token, platformUserId, proxy)
+	if err == nil && len(models) > 0 {
+		return &TokenVerifyResult{TokenType: "apikey", Models: models}, nil
+	}
+
+	// /v1/models is unauthenticated on CLIProxyAPI (HTTP 200 with an empty
+	// list for valid and invalid keys alike when no auth files exist), so it
+	// cannot distinguish credentials. Probe the management API instead: a
+	// valid management key gets 2xx, anything else 401.
+	if c.isValidManagementKey(ctx, baseURL, token, proxy) {
+		return &TokenVerifyResult{TokenType: "apikey", Models: models}, nil
+	}
+
+	return &TokenVerifyResult{TokenType: "unknown"}, nil
+}
+
+// isValidManagementKey reports whether token authenticates against the
+// CLIProxyAPI management API (GET /v0/management/auth-files).
+func (c *CliProxyApiAdapter) isValidManagementKey(ctx context.Context, baseURL, token string, proxy *ProxyConfig) bool {
+	normalized := normalizePlatformBaseURL(baseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, normalized+"/v0/management/auth-files", nil)
+	if err != nil {
+		return false
+	}
+	for k, v := range authBearerHeaders(token) {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("User-Agent", DefaultBrowserUserAgent)
+	ApplySiteIdentity(req, proxy)
+
+	resp, err := DoWithProxy(ctx, req, proxy)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}

--- a/platform/cliproxyapi_test.go
+++ b/platform/cliproxyapi_test.go
@@ -2,7 +2,11 @@ package platform
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestCliProxyApiAdapter_Detect(t *testing.T) {
@@ -88,5 +92,107 @@ func TestCliProxyApiAdapter_DetectPort8317(t *testing.T) {
 	ok2, _ := a.Detect(ctx, "http://192.168.1.1:8317")
 	if !ok2 {
 		t.Error("should match port 8317 without path")
+	}
+}
+
+func newCliProxyApiVerifyTestAdapter() *CliProxyApiAdapter {
+	return &CliProxyApiAdapter{StandardAdapter: &StandardAdapter{BaseAdapter: NewBaseAdapter("cliproxyapi")}}
+}
+
+func TestCliProxyApiAdapter_VerifyToken_Models(t *testing.T) {
+	// Provider API key path: /v1/models serves models for the key.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/models" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"data":[{"id":"gpt-4o"},{"id":"claude-opus"}]}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	a := newCliProxyApiVerifyTestAdapter()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := a.VerifyToken(ctx, srv.URL, "any-key", nil, nil)
+	if err != nil {
+		t.Fatalf("VerifyToken: %v", err)
+	}
+	if result.TokenType != "apikey" {
+		t.Fatalf("TokenType = %q, want apikey", result.TokenType)
+	}
+	if len(result.Models) != 2 {
+		t.Fatalf("Models = %v, want 2 models", result.Models)
+	}
+}
+
+func TestCliProxyApiAdapter_VerifyToken_ManagementKey(t *testing.T) {
+	// Management key path: /v1/models is empty (unauthenticated on
+	// CLIProxyAPI), but the management probe accepts the key. VerifyToken
+	// must report "apikey" for the valid key and "unknown" for anything else.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/models":
+			fmt.Fprint(w, `{"data":[],"object":"list"}`)
+		case "/v0/management/auth-files":
+			if r.Header.Get("Authorization") != "Bearer mgmt-key" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			fmt.Fprint(w, `{"files":[]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := newCliProxyApiVerifyTestAdapter()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := a.VerifyToken(ctx, srv.URL, "mgmt-key", nil, nil)
+	if err != nil {
+		t.Fatalf("VerifyToken (valid key): %v", err)
+	}
+	if result.TokenType != "apikey" {
+		t.Fatalf("TokenType = %q, want apikey (valid management key)", result.TokenType)
+	}
+
+	invalid, err := a.VerifyToken(ctx, srv.URL, "wrong-key", nil, nil)
+	if err != nil {
+		t.Fatalf("VerifyToken (invalid key): %v", err)
+	}
+	if invalid.TokenType != "unknown" {
+		t.Fatalf("TokenType = %q, want unknown (invalid management key)", invalid.TokenType)
+	}
+}
+
+func TestCliProxyApiAdapter_VerifyToken_Unknown(t *testing.T) {
+	// Empty models + management probe 401: the credential is not valid.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/models":
+			fmt.Fprint(w, `{"data":[],"object":"list"}`)
+		case "/v0/management/auth-files":
+			w.WriteHeader(http.StatusUnauthorized)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := newCliProxyApiVerifyTestAdapter()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := a.VerifyToken(ctx, srv.URL, "garbage-token", nil, nil)
+	if err != nil {
+		t.Fatalf("VerifyToken: %v", err)
+	}
+	if result.TokenType != "unknown" {
+		t.Fatalf("TokenType = %q, want unknown", result.TokenType)
 	}
 }


### PR DESCRIPTION
## Summary

- `CliProxyApiAdapter` inherited `BaseAdapter.VerifyToken`, which statically dispatches to one-api style `GET /api/user/self` (absent on CLIProxyAPI) and reports every credential as `unknown`.
- Add a `CliProxyApiAdapter.VerifyToken` override: the credential is a key — `/v1/models` when the instance serves models, otherwise probe `GET /v0/management/auth-files` (2xx = valid management key, 401 = invalid). The management probe is required because CLIProxyAPI's `/v1/models` is unauthenticated (HTTP 200 + empty list for valid and invalid keys alike) and cannot distinguish credentials.

## E2E evidence (live testbed, native binary on :4100, upstream 127.0.0.1:3005)

- detect: `cliproxyapi` (confidence 0.8)
- `/v1/models` with management key: `200 {"data":[],"object":"list"}` (empty instance, no auth files)
- `/v0/management/auth-files`: 200 with management key, 401 with wrong key — the distinguishing signal

## Test plan

- New tests in `platform/cliproxyapi_test.go`: models path (apikey), management-key path (apikey for valid key / unknown for invalid), unknown path.
- `go build ./cmd/server && go vet ./... && go test ./... -count=1` green (also run by pre-push hook with -race).