### PR TITLE
fix(platform): sub2api verify-token fails for session JWTs

### DIFF
--- a/platform/sub2api_verify.go
+++ b/platform/sub2api_verify.go
@@ -1,0 +1,44 @@
+package platform
+
+import (
+	"context"
+)
+
+// VerifyToken verifies a pasted Sub2API credential.
+//
+// Sub2ApiAdapter deliberately overrides VerifyToken instead of inheriting
+// BaseAdapter.VerifyToken: the base implementation dispatches statically to
+// BaseAdapter.GetUserInfo (one-api style GET /api/user/self, which does not
+// exist on Sub2API) and BaseAdapter.GetModels (always empty), so an inherited
+// implementation would report every Sub2API credential as "unknown".
+//
+// The session path validates the JWT against /api/v1/auth/me and resolves
+// user info, balance and the first API key; a pasted API key (sk-...) falls
+// back to /v1/models verification with the key-discovery fallback.
+func (s *Sub2ApiAdapter) VerifyToken(ctx context.Context, baseURL, token string, platformUserId *int, proxy *ProxyConfig) (*TokenVerifyResult, error) {
+	normalized := normalizeBaseURL(baseURL)
+
+	if _, err := s.fetchAuthMe(ctx, normalized, token, proxy); err == nil {
+		userInfo, _ := s.GetUserInfo(ctx, normalized, token, platformUserId, proxy)
+		balance, _ := s.GetBalance(ctx, normalized, token, platformUserId, proxy)
+		apiToken, _ := s.GetAPIToken(ctx, normalized, token, platformUserId, proxy)
+
+		apiTokenStr := ""
+		if apiToken != nil {
+			apiTokenStr = *apiToken
+		}
+		return &TokenVerifyResult{
+			TokenType: "session",
+			UserInfo:  userInfo,
+			Balance:   balance,
+			APIToken:  apiTokenStr,
+		}, nil
+	}
+
+	models, modelsErr := s.GetModels(ctx, normalized, token, platformUserId, proxy)
+	if modelsErr == nil && len(models) > 0 {
+		return &TokenVerifyResult{TokenType: "apikey", Models: models}, nil
+	}
+
+	return &TokenVerifyResult{TokenType: "unknown"}, nil
+}

--- a/platform/sub2api_verify_test.go
+++ b/platform/sub2api_verify_test.go
@@ -1,0 +1,126 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func newSub2ApiVerifyTestAdapter() *Sub2ApiAdapter {
+	return &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
+}
+
+func TestSub2ApiAdapter_VerifyToken_SessionJWT(t *testing.T) {
+	// Session JWT path: /api/v1/auth/me resolves the user, /api/v1/keys
+	// provides the first API key. VerifyToken must report "session" with the
+	// resolved user info, balance and discovered API token.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/auth/me":
+			if r.Header.Get("Authorization") != "Bearer jwt-token" {
+				w.WriteHeader(http.StatusUnauthorized)
+				fmt.Fprint(w, `{"code":"UNAUTHORIZED","message":"invalid token"}`)
+				return
+			}
+			fmt.Fprint(w, `{"code":0,"message":"success","data":{"id":1,"email":"admin@testbed.local","username":"admin","balance":2.5}}`)
+		case "/api/v1/keys":
+			fmt.Fprint(w, `{"code":0,"message":"success","data":{"items":[{"id":7,"key":"sk-test-key-7","name":"metapi","status":"active"}],"total":1}}`)
+		case "/api/v1/api-keys":
+			fmt.Fprint(w, `{"code":0,"message":"success","data":{"items":[]}}`)
+		case "/api/v1/subscriptions/summary":
+			fmt.Fprint(w, `{"code":0,"message":"success","data":{"items":[]}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := newSub2ApiVerifyTestAdapter()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := a.VerifyToken(ctx, srv.URL, "jwt-token", nil, nil)
+	if err != nil {
+		t.Fatalf("VerifyToken: %v", err)
+	}
+	if result.TokenType != "session" {
+		t.Fatalf("TokenType = %q, want session", result.TokenType)
+	}
+	if result.UserInfo == nil || result.UserInfo.Username != "admin" {
+		t.Fatalf("UserInfo = %+v, want username admin", result.UserInfo)
+	}
+	if result.APIToken != "sk-test-key-7" {
+		t.Fatalf("APIToken = %q, want sk-test-key-7", result.APIToken)
+	}
+	if result.Balance == nil {
+		t.Fatal("Balance is nil for a verified session JWT")
+	}
+}
+
+func TestSub2ApiAdapter_VerifyToken_APIKeyFallback(t *testing.T) {
+	// API key path: /api/v1/auth/me rejects the key, /v1/models accepts it.
+	// VerifyToken must fall back to "apikey" with the model list.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/auth/me":
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, `{"code":"UNAUTHORIZED","message":"invalid token"}`)
+		case "/v1/models":
+			fmt.Fprint(w, `{"data":[{"id":"gpt-4o-mini"},{"id":"claude-3-5-sonnet"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := newSub2ApiVerifyTestAdapter()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := a.VerifyToken(ctx, srv.URL, "sk-api-key", nil, nil)
+	if err != nil {
+		t.Fatalf("VerifyToken: %v", err)
+	}
+	if result.TokenType != "apikey" {
+		t.Fatalf("TokenType = %q, want apikey", result.TokenType)
+	}
+	if len(result.Models) != 2 {
+		t.Fatalf("Models = %v, want 2 models", result.Models)
+	}
+}
+
+func TestSub2ApiAdapter_VerifyToken_Unknown(t *testing.T) {
+	// Neither /api/v1/auth/me nor /v1/models accepts the credential:
+	// VerifyToken must report "unknown" without error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/auth/me":
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, `{"code":"UNAUTHORIZED","message":"invalid token"}`)
+		case "/v1/models":
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, `{"code":"INVALID_API_KEY","message":"Invalid API key"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := newSub2ApiVerifyTestAdapter()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := a.VerifyToken(ctx, srv.URL, "garbage-token", nil, nil)
+	if err != nil {
+		t.Fatalf("VerifyToken: %v", err)
+	}
+	if result.TokenType != "unknown" {
+		t.Fatalf("TokenType = %q, want unknown", result.TokenType)
+	}
+}


### PR DESCRIPTION
## Summary

- `Sub2ApiAdapter` inherited `BaseAdapter.VerifyToken`, whose embedded-receiver calls statically dispatch to `BaseAdapter.GetUserInfo` (one-api style `GET /api/user/self` — 404 on Sub2API) and `BaseAdapter.GetModels` (always empty). Every Sub2API credential therefore verified as `unknown`, so verify-token returned 400 and account creation failed closed.
- Add a `Sub2ApiAdapter.VerifyToken` override: session path validates the JWT against `/api/v1/auth/me` and resolves user info + balance + first API key; pasted API keys fall back to `/v1/models` (with the existing key-discovery fallback).

## E2E evidence (live testbed, native binary on :4100, upstream 127.0.0.1:3004)

- detect: `sub2api` (confidence 0.8)
- `/api/v1/auth/me` with JWT: `200 code:0` (direct), `/api/user/self`: 404 (the inherited probe), `/v1/models` with JWT: `INVALID_API_KEY` (session JWT is not an API key)
- verify-token before fix: `400 {"error":"token verification failed"}` (inherited static dispatch)
- verify-token after fix: `200 tokenType=session` (see live re-run in PR thread after deploy)

## Test plan

- New `platform/sub2api_verify_test.go`: session-JWT fixture (auth/me + keys + subscriptions), apikey fallback fixture, unknown-credential fixture.
- `go build ./cmd/server && go vet ./... && go test ./... -count=1` green (also run by pre-push hook with -race).