### PR TITLE
fix(e2e): guard first_model in smoke.sh route step

### DIFF
--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -406,7 +406,7 @@ if [ -n "$PROXY_TOKEN" ]; then
     fi
   fi
   if [ -n "$ROUTE_ID" ]; then
-    if [ "$ROUTE_MODEL" = "$PROXY_MODEL" ] && [ -z "$first_model" ]; then
+    if [ "$ROUTE_MODEL" = "$PROXY_MODEL" ] && [ -z "${first_model:-}" ]; then
       warn_step "route create (routeId=$ROUTE_ID, model=$ROUTE_MODEL) — upstream model list empty, used PROXY_MODEL"
     else
       pass_step "route create (routeId=$ROUTE_ID, model=$ROUTE_MODEL)"


### PR DESCRIPTION
Under set -u, smoke.sh's route-create step referenced $first_model which is only defined when the models step runs with a valid account id. On early degradation (login/account failure) it crashed with 'first_model: unbound variable' instead of WARN. Use ${first_model:-}.