### PR TITLE
fix(web): residual URL-entry crash holes + resilience regression test

### DIFF
--- a/web/src/features/checkin/components/checkin-page.tsx
+++ b/web/src/features/checkin/components/checkin-page.tsx
@@ -61,11 +61,11 @@ export function CheckinPage() {
   )
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(() => {
     const filters: ColumnFiltersState = []
-    const statusValues = parseFilterValues(search.status)
+    const statusValues = parseFilterValues(asStringParam(search.status))
     if (statusValues.length) filters.push({ id: 'status', value: statusValues })
-    const reasonValues = parseFilterValues(search.reason)
+    const reasonValues = parseFilterValues(asStringParam(search.reason))
     if (reasonValues.length) filters.push({ id: 'reason', value: reasonValues })
-    const siteValues = parseFilterValues(search.site)
+    const siteValues = parseFilterValues(asStringParam(search.site))
     if (siteValues.length) filters.push({ id: 'site', value: siteValues })
     return filters
   })

--- a/web/src/features/checkin/lib/checkin-schema.ts
+++ b/web/src/features/checkin/lib/checkin-schema.ts
@@ -33,10 +33,11 @@ export const checkinSearchSchema = z.object({
     .default(DEFAULT_CHECKIN_PAGE_SIZE),
   accountId: z.coerce.number().int().positive().optional().catch(undefined),
   // Comma-separated multi-select filter values (status / reason category /
-  // site name).
-  status: z.string().optional(),
-  reason: z.string().optional(),
-  site: z.string().optional(),
+  // site name). Tolerant of router-parsed primitives (null literals,
+  // duplicate-param arrays, numbers/booleans) via `stringSearchParam`.
+  status: stringSearchParam,
+  reason: stringSearchParam,
+  site: stringSearchParam,
   // datetime-local input values (YYYY-MM-DDTHH:mm, local tz). Router JSON
   // parsing may hand over numeric/boolean primitives for these too, so they
   // use the tolerant string param (normalized via `asStringParam`).
@@ -89,9 +90,9 @@ export function parseFilterValues(value: string | undefined): string[] {
 export function buildInitialCheckinLogsQuery(
   search: CheckinSearch
 ): CheckinLogsQuery {
-  const statusValues = parseFilterValues(search.status)
-  const reasonValues = parseFilterValues(search.reason)
-  const siteValues = parseFilterValues(search.site)
+  const statusValues = parseFilterValues(asStringParam(search.status))
+  const reasonValues = parseFilterValues(asStringParam(search.reason))
+  const siteValues = parseFilterValues(asStringParam(search.site))
   return {
     limit: search.pageSize,
     offset: (search.page - 1) * search.pageSize,

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -57,9 +57,9 @@ export function ProxyLogsPage() {
     urlSearch.status ?? 'all'
   )
   const [siteId, setSiteId] = useState<number | null>(urlSearch.siteId ?? null)
-  const [client, setClient] = useState(urlSearch.client ?? '')
-  const [from, setFrom] = useState(urlSearch.from ?? '')
-  const [to, setTo] = useState(urlSearch.to ?? '')
+  const [client, setClient] = useState(asStringParam(urlSearch.client) ?? '')
+  const [from, setFrom] = useState(asStringParam(urlSearch.from) ?? '')
+  const [to, setTo] = useState(asStringParam(urlSearch.to) ?? '')
   const [latencyMin, setLatencyMin] = useState<number | null>(
     urlSearch.latencyMin ?? null
   )

--- a/web/src/features/proxy-logs/lib/proxy-logs-schema.ts
+++ b/web/src/features/proxy-logs/lib/proxy-logs-schema.ts
@@ -28,9 +28,12 @@ export const proxyLogsSearchSchema = z.object({
     .catch(undefined),
   status: z.enum(['all', 'success', 'failed']).catch('all').default('all'),
   siteId: z.coerce.number().int().optional().catch(undefined),
-  client: z.string().optional(),
-  from: z.string().optional(),
-  to: z.string().optional(),
+  // Client name and datetime-local bounds. Tolerant of router-parsed
+  // primitives (null literals, duplicate-param arrays, numeric epochs) via
+  // `stringSearchParam`; read sites normalize with `asStringParam`.
+  client: stringSearchParam,
+  from: stringSearchParam,
+  to: stringSearchParam,
   latencyMin: z.coerce.number().int().min(0).optional().catch(undefined),
   latencyMax: z.coerce.number().int().min(0).optional().catch(undefined),
 })

--- a/web/src/features/token-routes/__tests__/routes-schema.test.ts
+++ b/web/src/features/token-routes/__tests__/routes-schema.test.ts
@@ -19,7 +19,6 @@ describe('routesSearchSchema', () => {
     expect(result).toEqual({
       q: 'gpt',
       enabled: 'enabled,disabled',
-      site: undefined,
       accountId: 7,
       siteId: 3,
       page: 2,

--- a/web/src/features/token-routes/lib/routes-schema.ts
+++ b/web/src/features/token-routes/lib/routes-schema.ts
@@ -194,7 +194,6 @@ export const routesSearchSchema = z.object({
   // (`enabled,disabled`), so the schema accepts a raw string and the page
   // splits it — a single enum would reject the page's own writes.
   enabled: stringSearchParam,
-  site: z.string().optional(),
   accountId: z.coerce.number().int().positive().optional().catch(undefined),
   siteId: z.coerce.number().int().positive().optional().catch(undefined),
   page: z.coerce.number().int().positive().catch(1).default(1),

--- a/web/src/lib/auth-session.ts
+++ b/web/src/lib/auth-session.ts
@@ -228,6 +228,23 @@ export function hasValidAuthSession(
 }
 
 /**
+ * Guarded variant of {@link hasValidAuthSession}: storage access can throw
+ * (SecurityError) in sandboxed/blocked-storage contexts. Treat that as
+ * unauthenticated so route guards (sign-in beforeLoad, authenticated
+ * layout) never crash on a hostile localStorage.
+ */
+export function hasValidAuthSessionSafe(
+  storage?: StorageLike | null,
+  nowMs: number = Date.now()
+): boolean {
+  try {
+    return hasValidAuthSession(storage, nowMs)
+  } catch {
+    return false
+  }
+}
+
+/**
  * Persist an AuthBundle to storage. Converts the bundle's
  * access_expires_at (unix seconds) to the ms epoch the legacy keys expect.
  */

--- a/web/src/lib/helpers/__tests__/search-params-resilience.test.ts
+++ b/web/src/lib/helpers/__tests__/search-params-resilience.test.ts
@@ -1,0 +1,181 @@
+// metapi-go/lib/helpers — regression gate for the URL-entry crash class:
+// router-parsed search values (null literals, duplicate-param arrays,
+// numeric/boolean primitives) must never make a route's `validateSearch`
+// throw on URL entry. Every schema/helper touched by the entry-crash sweep
+// is exercised here so this class of crash cannot silently return.
+
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import {
+  buildInitialCheckinLogsQuery,
+  checkinSearchSchema,
+} from '@/features/checkin/lib/checkin-schema'
+import { proxyLogsSearchSchema } from '@/features/proxy-logs/lib/proxy-logs-schema'
+import { routesSearchSchema } from '@/features/token-routes/lib/routes-schema'
+import { hasValidAuthSessionSafe } from '@/lib/auth-session'
+import { asStringParam, stringSearchParam } from '@/lib/helpers/searchParams'
+import { signInSearchSchema } from '@/routes/sign-in'
+
+// ---------------------------------------------------------------------------
+// stringSearchParam — the shared tolerant string param
+// ---------------------------------------------------------------------------
+
+describe('stringSearchParam', () => {
+  it('degrades null literals and duplicate-param arrays to undefined instead of throwing', () => {
+    expect(stringSearchParam.parse(null)).toBeUndefined()
+    expect(stringSearchParam.parse(['a', 'b'])).toBeUndefined()
+    expect(stringSearchParam.parse([])).toBeUndefined()
+  })
+
+  it('preserves router-parsed string / number / boolean primitives', () => {
+    expect(stringSearchParam.parse('gpt')).toBe('gpt')
+    expect(stringSearchParam.parse(123)).toBe(123)
+    expect(stringSearchParam.parse(true)).toBe(true)
+  })
+
+  it('defaults an absent object key to undefined', () => {
+    const schema = z.object({ q: stringSearchParam })
+    expect(schema.parse({}).q).toBeUndefined()
+    expect(schema.parse({ q: undefined }).q).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkinSearchSchema
+// ---------------------------------------------------------------------------
+
+describe('checkinSearchSchema', () => {
+  it('parses adversarial router values without throwing', () => {
+    const result = checkinSearchSchema.parse({
+      q: null,
+      status: true,
+      reason: ['a', 'b'],
+      site: 123,
+      page: 0,
+      pageSize: 9999,
+    })
+    expect(result.q).toBeUndefined()
+    expect(result.status).toBe(true)
+    expect(result.reason).toBeUndefined()
+    expect(result.site).toBe(123)
+    expect(result.page).toBe(1)
+    expect(result.pageSize).toBe(20)
+  })
+
+  it('coerces slipped-through primitives to strings in the loader payload', () => {
+    const query = buildInitialCheckinLogsQuery(
+      checkinSearchSchema.parse({
+        status: true,
+        reason: ['a', 'b'],
+        site: 123,
+      })
+    )
+    expect(query.status).toBe('true')
+    expect(query.reason).toEqual([])
+    expect(query.site).toEqual(['123'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// routesSearchSchema (token-routes)
+// ---------------------------------------------------------------------------
+
+describe('routesSearchSchema', () => {
+  it('tolerates null / array q values without throwing', () => {
+    expect(routesSearchSchema.parse({ q: null }).q).toBeUndefined()
+    expect(routesSearchSchema.parse({ q: ['a', 'b'] }).q).toBeUndefined()
+  })
+
+  it('ignores the removed site key without throwing', () => {
+    const result = routesSearchSchema.parse({ site: 123 })
+    expect(result).not.toHaveProperty('site')
+  })
+
+  it('falls back instead of throwing for page 0 / oversized pageSize', () => {
+    const result = routesSearchSchema.parse({ page: 0, pageSize: 9999 })
+    expect(result.page).toBe(1)
+    expect(result.pageSize).toBe(9999)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// proxyLogsSearchSchema
+// ---------------------------------------------------------------------------
+
+describe('proxyLogsSearchSchema', () => {
+  it('tolerates numeric epoch / null / array client·from·to values', () => {
+    const result = proxyLogsSearchSchema.parse({
+      client: ['a', 'b'],
+      from: 1755000000,
+      to: null,
+      status: true,
+      page: 0,
+      pageSize: 9999,
+    })
+    expect(result.client).toBeUndefined()
+    expect(result.from).toBe(1755000000)
+    expect(result.to).toBeUndefined()
+    expect(result.status).toBe('all')
+    expect(result.page).toBe(0)
+    expect(result.pageSize).toBe(20)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// signInSearchSchema
+// ---------------------------------------------------------------------------
+
+describe('signInSearchSchema', () => {
+  it('tolerates numeric / null / array redirect values without throwing', () => {
+    expect(signInSearchSchema.parse({ redirect: 123 }).redirect).toBe(123)
+    expect(
+      signInSearchSchema.parse({ redirect: null }).redirect
+    ).toBeUndefined()
+    expect(
+      signInSearchSchema.parse({ redirect: ['a', 'b'] }).redirect
+    ).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// asStringParam — read-site coercion
+// ---------------------------------------------------------------------------
+
+describe('asStringParam', () => {
+  it('coerces primitives that slip through the tolerant union to string', () => {
+    expect(asStringParam('gpt')).toBe('gpt')
+    expect(asStringParam(123)).toBe('123')
+    expect(asStringParam(true)).toBe('true')
+    expect(asStringParam(undefined)).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// hasValidAuthSessionSafe — sign-in / root beforeLoad storage guard
+// ---------------------------------------------------------------------------
+
+describe('hasValidAuthSessionSafe', () => {
+  it('treats a SecurityError-throwing storage as unauthenticated instead of crashing', () => {
+    const securityError = () => {
+      throw new DOMException('Storage access denied', 'SecurityError')
+    }
+    const throwingStorage = {
+      getItem: securityError,
+      setItem: securityError,
+      removeItem: securityError,
+    }
+    expect(() => hasValidAuthSessionSafe(throwingStorage)).not.toThrow()
+    expect(hasValidAuthSessionSafe(throwingStorage)).toBe(false)
+  })
+
+  it('reports a valid stored session as authenticated', () => {
+    const validStorage = {
+      getItem: (key: string) =>
+        key === 'auth_token' ? 'token-1' : '99999999999999',
+      setItem: () => {},
+      removeItem: () => {},
+    }
+    expect(hasValidAuthSessionSafe(validStorage)).toBe(true)
+  })
+})

--- a/web/src/lib/helpers/searchParams.ts
+++ b/web/src/lib/helpers/searchParams.ts
@@ -29,10 +29,16 @@ function encodeSortingItems(items: SortingItem[]): string {
  * though the page reads the same value back as a raw string via
  * `window.location.search`. Accepts all three and normalizes to string so
  * route `validateSearch` never throws on numeric/boolean-looking values.
+ *
+ * The `.catch(undefined)` is the resilience clause: `?q=null` JSON-parses to
+ * `null` and duplicate params (`?q=a&q=b`) parse to an array — neither is
+ * accepted by the union, and without the catch they would throw a
+ * `validateSearch` error on URL entry. Degrade both to `undefined` instead.
  */
 export const stringSearchParam = z
   .union([z.string(), z.number(), z.boolean()])
   .optional()
+  .catch(undefined)
 
 /**
  * Normalize a validated {@link stringSearchParam} value to a plain string.

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -87,12 +87,17 @@ export const Route = createRootRouteWithContext<{
 }>()({
   beforeLoad: async () => {
     if (authBootstrapped) return
-    const outcome = await bootstrapAuthentication()
-    if (outcome.kind === 'authenticated' && outcome.bundle) {
-      const { auth } = useAuthStore.getState()
-      if (!auth.accessToken) {
-        auth.setBundle(outcome.bundle)
+    try {
+      const outcome = await bootstrapAuthentication()
+      if (outcome.kind === 'authenticated' && outcome.bundle) {
+        const { auth } = useAuthStore.getState()
+        if (!auth.accessToken) {
+          auth.setBundle(outcome.bundle)
+        }
       }
+    } catch {
+      // localStorage can throw (SecurityError) in sandboxed/blocked-storage
+      // contexts; treat as anonymous rather than crashing the boot.
     }
     useAuthStore.getState().auth.setBootstrapState('complete')
     authBootstrapped = true

--- a/web/src/routes/_authenticated/proxy-logs.tsx
+++ b/web/src/routes/_authenticated/proxy-logs.tsx
@@ -57,9 +57,9 @@ export const Route = createFileRoute('/_authenticated/proxy-logs')({
     const status = search.status === 'all' ? undefined : search.status
     const searchText = asStringParam(search.q)?.trim() || undefined
     const siteId = search.siteId ?? undefined
-    const client = search.client || undefined
-    const from = search.from || undefined
-    const to = search.to || undefined
+    const client = asStringParam(search.client) || undefined
+    const from = asStringParam(search.from) || undefined
+    const to = asStringParam(search.to) || undefined
 
     const queryPayload = {
       limit: pageSize,

--- a/web/src/routes/sign-in.tsx
+++ b/web/src/routes/sign-in.tsx
@@ -8,22 +8,25 @@ import { z } from 'zod'
 
 import { SignInPage } from '@/features/auth'
 import { sanitizeAuthRedirect } from '@/features/auth/lib/auth-redirect'
-import { hasValidAuthSession } from '@/lib/auth-session'
+import { hasValidAuthSessionSafe } from '@/lib/auth-session'
+import { asStringParam, stringSearchParam } from '@/lib/helpers/searchParams'
 
-const searchSchema = z.object({
-  redirect: z.string().optional(),
+export const signInSearchSchema = z.object({
+  redirect: stringSearchParam,
 })
 
 function SignInComponent() {
   const { redirect } = Route.useSearch()
-  return <SignInPage redirectTo={redirect} />
+  return <SignInPage redirectTo={asStringParam(redirect)} />
 }
 
 export const Route = createFileRoute('/sign-in')({
   component: SignInComponent,
-  validateSearch: searchSchema,
+  validateSearch: signInSearchSchema,
   beforeLoad: ({ search }) => {
-    if (hasValidAuthSession(localStorage)) {
+    // localStorage can throw (SecurityError) in sandboxed/blocked-storage
+    // contexts; treat that as unauthenticated rather than crashing the guard.
+    if (hasValidAuthSessionSafe(localStorage)) {
       const target =
         sanitizeAuthRedirect(search?.redirect, window.location.origin) ?? '/'
       throw redirect({ href: target, replace: true })


### PR DESCRIPTION
## Summary

Closes the remaining "page errors on URL entry" holes found in the post-#767 audit, plus a regression gate so this class cannot return.

### Schema holes closed

1. **`stringSearchParam`** (`lib/helpers/searchParams.ts`) — added `.catch(undefined)` after `.optional()`. `?q=null` (JSON-parsed `null` literal) and duplicate params (`?q=a&q=b`, parsed as an array) now degrade to `undefined` instead of throwing in `validateSearch`. This alone closes the null/array class across ~10 routes. Type unchanged (`string | number | boolean | undefined`).
2. **Checkin** (`features/checkin/lib/checkin-schema.ts`) — `status` / `reason` / `site` switched from `z.string().optional()` to `stringSearchParam`; page and `buildInitialCheckinLogsQuery` read sites now normalize via `asStringParam`.
3. **Token routes** (`features/token-routes/lib/routes-schema.ts`) — the `site` field was read by nothing (verified by grep; the page uses `siteId`), so it was deleted instead of widened.
4. **Proxy logs** (`features/proxy-logs/lib/proxy-logs-schema.ts`) — `client` / `from` / `to` switched to `stringSearchParam`; page and route-loader read sites normalize via `asStringParam`.
5. **Sign-in** (`routes/sign-in.tsx`) — `redirect` switched to `stringSearchParam` (exported as `signInSearchSchema` for tests); component read site normalized via `asStringParam`.

### localStorage guards

- `routes/sign-in.tsx` `beforeLoad` now uses the new `hasValidAuthSessionSafe()` (try/catch over `hasValidAuthSession`), mirroring the `_authenticated` layout guard: a `SecurityError` from blocked storage is treated as unauthenticated instead of crashing.
- `routes/__root.tsx` `beforeLoad` wraps `bootstrapAuthentication()` in try/catch and falls back to the anonymous path (bootstrap state still completes).

### Regression gate

New `web/src/lib/helpers/__tests__/search-params-resilience.test.ts` asserts NO-THROW + sane fallbacks for every fixed schema/helper against adversarial router-parsed inputs (`null`, `123`, `true`, duplicate-param arrays, numeric epochs, `page: 0`, `pageSize: 9999`), plus a unit test that the session guard resolves to unauthenticated when storage access throws `SecurityError`.

## Test plan

- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test` ✅ (382 tests, +13 new)
- `bun run format:check` ✅
- `go build ./cmd/server && go vet ./...` ✅