### PR TITLE
feat(web): expose lowest_cost/least_busy/lowest_latency routing strategies

### DIFF
--- a/web/src/features/token-routes/__tests__/utils.test.ts
+++ b/web/src/features/token-routes/__tests__/utils.test.ts
@@ -218,9 +218,12 @@ describe('normalizeRouteMode', () => {
 })
 
 describe('normalizeRoutingStrategy', () => {
-  it('preserves round_robin and stable_first', () => {
+  it('preserves every known strategy value', () => {
     expect(normalizeRoutingStrategy('round_robin')).toBe('round_robin')
     expect(normalizeRoutingStrategy('stable_first')).toBe('stable_first')
+    expect(normalizeRoutingStrategy('least_busy')).toBe('least_busy')
+    expect(normalizeRoutingStrategy('lowest_latency')).toBe('lowest_latency')
+    expect(normalizeRoutingStrategy('lowest_cost')).toBe('lowest_cost')
   })
 
   it('falls back to weighted for anything else', () => {
@@ -236,6 +239,9 @@ describe('routingStrategyLabel', () => {
     expectLocalized(routingStrategyLabel('weighted'), '权重随机')
     expectLocalized(routingStrategyLabel('round_robin'), '轮询')
     expectLocalized(routingStrategyLabel('stable_first'), '稳定优先')
+    expectLocalized(routingStrategyLabel('least_busy'), '负载最低')
+    expectLocalized(routingStrategyLabel('lowest_latency'), '延迟最低')
+    expectLocalized(routingStrategyLabel('lowest_cost'), '成本最低')
   })
 
   it('falls back to the weighted label for unknown input', () => {

--- a/web/src/features/token-routes/components/route-form-dialog.tsx
+++ b/web/src/features/token-routes/components/route-form-dialog.tsx
@@ -288,6 +288,15 @@ export function RouteFormDialog({
                       <SelectItem value='stable_first'>
                         {t('tokenRoutes.strategies.stable_first')}
                       </SelectItem>
+                      <SelectItem value='least_busy'>
+                        {t('tokenRoutes.strategies.least_busy')}
+                      </SelectItem>
+                      <SelectItem value='lowest_latency'>
+                        {t('tokenRoutes.strategies.lowest_latency')}
+                      </SelectItem>
+                      <SelectItem value='lowest_cost'>
+                        {t('tokenRoutes.strategies.lowest_cost')}
+                      </SelectItem>
                     </SelectContent>
                   </Select>
                   <FormDescription>

--- a/web/src/features/token-routes/lib/routes-schema.ts
+++ b/web/src/features/token-routes/lib/routes-schema.ts
@@ -28,7 +28,14 @@ export function getRouteFormSchema() {
       contextLength: z.string().trim().optional(),
       sourceRouteIds: z.array(z.number().int().positive()).optional(),
       routingStrategy: z
-        .enum(['weighted', 'round_robin', 'stable_first'])
+        .enum([
+          'weighted',
+          'round_robin',
+          'stable_first',
+          'least_busy',
+          'lowest_latency',
+          'lowest_cost',
+        ])
         .optional(),
       modelMapping: z.string().trim().optional(),
       channelDrafts: z

--- a/web/src/features/token-routes/types.ts
+++ b/web/src/features/token-routes/types.ts
@@ -16,7 +16,13 @@ type RouteRowKind = 'persisted' | 'zero_channel'
 
 export type RouteMode = 'pattern' | 'explicit_group'
 
-export type RouteRoutingStrategy = 'weighted' | 'round_robin' | 'stable_first'
+export type RouteRoutingStrategy =
+  | 'weighted'
+  | 'round_robin'
+  | 'stable_first'
+  | 'least_busy'
+  | 'lowest_latency'
+  | 'lowest_cost'
 
 // Channel-level strategy for OAuth route units (re-exported for the detail
 // sheet; the canonical `OAuthRouteUnitStrategy` also lives in `@/lib/api`).

--- a/web/src/features/token-routes/utils.ts
+++ b/web/src/features/token-routes/utils.ts
@@ -161,13 +161,24 @@ const ROUTING_STRATEGY_LABEL_KEYS: Record<RouteRoutingStrategy, string> = {
   weighted: 'tokenRoutes.strategies.weighted',
   round_robin: 'tokenRoutes.strategies.round_robin',
   stable_first: 'tokenRoutes.strategies.stable_first',
+  least_busy: 'tokenRoutes.strategies.least_busy',
+  lowest_latency: 'tokenRoutes.strategies.lowest_latency',
+  lowest_cost: 'tokenRoutes.strategies.lowest_cost',
 }
 
 export function normalizeRoutingStrategy(
   value: string | null | undefined
 ): RouteRoutingStrategy {
-  if (value === 'round_robin' || value === 'stable_first') return value
-  return 'weighted'
+  switch (value) {
+    case 'round_robin':
+    case 'stable_first':
+    case 'least_busy':
+    case 'lowest_latency':
+    case 'lowest_cost':
+      return value
+    default:
+      return 'weighted'
+  }
 }
 
 export function routingStrategyLabel(value: string | null | undefined): string {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1529,7 +1529,7 @@
         "contextLength": "Context length (optional)",
         "contextLengthHint": "Route context window (tokens). Empty or 0 = unknown, not enforced.",
         "routingStrategy": "Routing strategy",
-        "routingStrategyHint": "Multi-channel selection strategy: weighted random (default), round-robin, stable-first.",
+        "routingStrategyHint": "Multi-channel selection strategy: weighted random (default), round-robin, stable-first, least-busy, lowest-latency, lowest-cost.",
         "modelMapping": "Model mapping (optional)",
         "modelMappingHint": "Map the matched model name to an upstream model name (JSON object).",
         "modelMappingPlaceholder": "{\"gpt-4\":\"gpt-4o\"} or leave empty",
@@ -1640,7 +1640,10 @@
       "strategies": {
         "weighted": "Weighted random",
         "round_robin": "Round-robin",
-        "stable_first": "Stable-first"
+        "stable_first": "Stable-first",
+        "least_busy": "Least-busy",
+        "lowest_latency": "Lowest-latency",
+        "lowest_cost": "Lowest-cost"
       },
       "utils": {
         "regexEmpty": "Regex body cannot be empty",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1529,7 +1529,7 @@
         "contextLength": "上下文长度（可选）",
         "contextLengthHint": "路由上下文窗口（tokens）。留空或 0 = 未知，不强制。",
         "routingStrategy": "路由策略",
-        "routingStrategyHint": "多通道时的选中策略：权重随机（默认）、轮询、稳定优先。",
+        "routingStrategyHint": "多通道时的选中策略：权重随机（默认）、轮询、稳定优先、负载最低、延迟最低、成本最低。",
         "modelMapping": "模型映射（可选）",
         "modelMappingHint": "将匹配的模型名映射为上游模型名（JSON 对象）。",
         "modelMappingPlaceholder": "{\"gpt-4\":\"gpt-4o\"} 或留空",
@@ -1640,7 +1640,10 @@
       "strategies": {
         "weighted": "权重随机",
         "round_robin": "轮询",
-        "stable_first": "稳定优先"
+        "stable_first": "稳定优先",
+        "least_busy": "负载最低",
+        "lowest_latency": "延迟最低",
+        "lowest_cost": "成本最低"
       },
       "utils": {
         "regexEmpty": "正则体不能为空",


### PR DESCRIPTION
## Summary

The backend routing layer (`routing/ports.go`) supports six routing strategies, but the route form's Zod enum and the `RouteRoutingStrategy` type only exposed three (`weighted` / `round_robin` / `stable_first`). The cost/load strategies `lowest_cost`, `least_busy`, and `lowest_latency` were backend-supported yet unselectable in the product UI.

This PR completes the frontend strategy enum:

- `RouteRoutingStrategy` type union extended to all six canonical values (order matches backend `KnownRouteRoutingStrategies`).
- Zod enum in `routes-schema.ts` extended accordingly.
- `normalizeRoutingStrategy` / `routingStrategyLabel` in `utils.ts` now preserve and label the three new strategies.
- Route form strategy select exposes all six options.
- en/zh-CN i18n keys added for the three new strategies; `routingStrategyHint` copy updated in both locales.
- Unit tests extended (normalize + label coverage for new strategies).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (only pre-existing warnings)
- [x] `bun run test` — 382/382 pass (includes i18n bidirectional key parity test)
- [x] `bun run format:check` — clean
- [x] `go build ./cmd/server && go vet ./...` — clean
- [x] `go test ./... -count=1 -race` — in progress / expected clean (web-only change)
