### PR TITLE
perf(store): enable synchronous=NORMAL + cache_size for SQLite

### DIFF
--- a/store/open.go
+++ b/store/open.go
@@ -384,8 +384,18 @@ func applyPostgresApplicationName(dsn string, appName string) string {
 
 var postgresKeywordSSLModeRE = regexp.MustCompile(`(^|\s)sslmode=\S+`)
 
-// applySQLitePragmas enables WAL mode and foreign key enforcement.
-// These are CRITICAL for SQLite correctness (FKs default to OFF in SQLite).
+// applySQLitePragmas enables WAL mode, foreign key enforcement, and the
+// runtime tuning pragmas for single-file SQLite databases.
+//
+// Correctness (fatal on failure):
+//   - journal_mode=WAL: concurrency + crash safety
+//   - foreign_keys=ON: FKs default to OFF in SQLite
+//
+// Performance/durability tuning (non-fatal, logged on failure):
+//   - synchronous=NORMAL: crash-safe in WAL mode, skips fsync per commit to
+//     cut write amplification (dev/test databases; Postgres is production)
+//   - busy_timeout=5000: wait instead of failing on concurrent writers
+//   - cache_size=10000: ~40MB page cache for faster reads on single-file DBs
 func applySQLitePragmas(db *DB) error {
 	if _, err := db.Exec("PRAGMA journal_mode = WAL"); err != nil {
 		return fmt.Errorf("PRAGMA journal_mode=WAL: %w", err)
@@ -393,8 +403,14 @@ func applySQLitePragmas(db *DB) error {
 	if _, err := db.Exec("PRAGMA foreign_keys = ON"); err != nil {
 		return fmt.Errorf("PRAGMA foreign_keys=ON: %w", err)
 	}
+	if _, err := db.Exec("PRAGMA synchronous = NORMAL"); err != nil {
+		slog.Warn("store: failed to set SQLite synchronous=NORMAL", "error", err)
+	}
 	if _, err := db.Exec("PRAGMA busy_timeout = 5000"); err != nil {
 		slog.Warn("store: failed to set SQLite busy_timeout", "error", err)
+	}
+	if _, err := db.Exec("PRAGMA cache_size = 10000"); err != nil {
+		slog.Warn("store: failed to set SQLite cache_size", "error", err)
 	}
 	return nil
 }

--- a/store/sqlite_test.go
+++ b/store/sqlite_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -57,6 +58,45 @@ func TestSQLiteOpenMemory(t *testing.T) {
 	if fkEnabled != 1 {
 		t.Errorf("expected foreign_keys=1, got %d", fkEnabled)
 	}
+}
+
+// TestSQLitePragmasOnFileDB verifies the full pragma contract applied at open
+// time on a file-backed database: WAL journal, synchronous=NORMAL, FK
+// enforcement, busy_timeout, and an enlarged page cache.
+func TestSQLitePragmasOnFileDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pragma-test.db")
+	db, err := Open(DialectSQLite, dbPath, false)
+	if err != nil {
+		t.Fatalf("Open(file) failed: %v", err)
+	}
+	defer db.Close()
+
+	assertPragmaInt := func(name string, want int) {
+		t.Helper()
+		var got int
+		if err := db.QueryRow("PRAGMA " + name).Scan(&got); err != nil {
+			t.Fatalf("PRAGMA %s failed: %v", name, err)
+		}
+		if got != want {
+			t.Errorf("PRAGMA %s: expected %d, got %d", name, want, got)
+		}
+	}
+	assertPragmaText := func(name string, want string) {
+		t.Helper()
+		var got string
+		if err := db.QueryRow("PRAGMA " + name).Scan(&got); err != nil {
+			t.Fatalf("PRAGMA %s failed: %v", name, err)
+		}
+		if got != want {
+			t.Errorf("PRAGMA %s: expected %q, got %q", name, want, got)
+		}
+	}
+
+	assertPragmaText("journal_mode", "wal")
+	assertPragmaInt("synchronous", 1) // NORMAL
+	assertPragmaInt("foreign_keys", 1)
+	assertPragmaInt("busy_timeout", 5000)
+	assertPragmaInt("cache_size", 10000)
 }
 
 // TestSQLiteAutoMigrateAllTables verifies all 35 tables are created.


### PR DESCRIPTION
## Summary

metapi-go 的 SQLite 连接此前只启用 `journal_mode=WAL` + `busy_timeout=5000` + `foreign_keys=ON` 三项 pragma。本 PR 在 `store/open.go` 的 `applySQLitePragmas` 基础上补两项运行时调优：

- **`synchronous=NORMAL`** — WAL 模式下崩溃安全（断电最多丢失最近几笔事务的持久性，不会损坏库），省去每笔提交的 fsync，显著降低开发/测试环境写放大。SQLite 仅用于 dev/test（生产走 PostgreSQL），与单连接池（`SetMaxOpenConns(1)`）组合下收益明确。
- **`cache_size=10000`** — 约 40MB 页缓存，提升单文件库读性能。

### 实现要点

- **注入方式核实**：任务假设沿用 octopus 的 DSN `_pragma=` 注入，经核实 metapi-go 的 SQLite DSN 是原样透传（`connStr = dsn`），pragma 实际由 `applySQLitePragmas()` 在单连接上 `Exec` 逐条应用。本 PR 沿用该既有模式，不改 DSN 构造。
- **失败策略**：WAL / foreign_keys 保持致命；`synchronous` / `cache_size` 与 `busy_timeout` 同为调优类，失败仅 `slog.Warn`（synchronous 失败回退 FULL 只会更安全）。
- **modernc 拼法实测**：`PRAGMA synchronous = NORMAL`、`PRAGMA cache_size = 10000` 在 modernc.org/sqlite v1.56.0 实测生效。

### 生效验证

新增 `TestSQLitePragmasOnFileDB`（文件库，非 `:memory:`）断言打开后读回：

```
PRAGMA journal_mode  → wal
PRAGMA synchronous   → 1    (NORMAL)
PRAGMA foreign_keys  → 1
PRAGMA busy_timeout  → 5000
PRAGMA cache_size    → 10000
```

## Test plan

- `go build ./cmd/server` ✅（先 `bun install && bun run build` 生成 gitignored 的 web/dist，与 embed.go 注释一致）
- `go vet ./...` ✅
- `go test ./store/ -count=1 -race` ✅
- `go test ./... -count=1 -race` ✅（全量，exit 0）
- `bun run typecheck` ✅