### PR TITLE
fix(routing): decay failCount on success so recovered channels aren't over-penalized

### DIFF
--- a/BLOCKED.md
+++ b/BLOCKED.md
@@ -1,0 +1,17 @@
+# BLOCKED
+
+无
+
+## 决策记录（无需裁决，仅留档）
+
+- **衰减因子取 `failCount / 2`（整数除法）**：按任务要求「衰减而非清零」。
+  failCount=1 时一次成功即归零（单次偶发失败不留记忆），failCount≥2 按几何
+  衰减保留少量记忆。OAuth route-unit member 路径同步衰减（与 channel 路径一致）。
+- **成功重置 4 字段不变**：cooldownUntil / lastFailAt / consecutiveFailCount /
+  cooldownLevel 保持清零，仅新增 failCount 衰减写入。
+- **`RecordProbeSuccess` 不动**：任务范围仅限 `RecordSuccess`（用户流量路径）；
+  探针成功路径保持原语义。
+- **gofmt**：`router_records.go` 在 HEAD 即非 gofmt-clean（map 字面量对齐风格），
+  CI（golangci-lint 配置）未启用 gofmt/gofumpt，故保持文件既有风格，未重排无关行。
+- **`web/dist`**：worktree 不含 gitignored 的 SPA 预构建产物，从主工作区拷贝同源
+  dist（本 PR 仅改 Go 代码，前端内容与 master 一致）以便本地 `go build`/pre-push 通过。

--- a/routing/failure_isolation_test.go
+++ b/routing/failure_isolation_test.go
@@ -41,6 +41,10 @@ type isolationDB struct {
 	lastCooldownUpdates map[string]interface{}
 	cooldownCalls       int
 
+	// lastSuccessUpdates records the most recent UpdateChannelSuccessFields call
+	lastSuccessUpdates map[string]interface{}
+	successCalls       int
+
 	// lastMemberUpdate records OAuth member cooldown writes
 	lastMemberID      int64
 	lastMemberUpdates map[string]interface{}
@@ -214,6 +218,17 @@ func (db *isolationDB) UpdateChannelCooldownFields(ctx context.Context, channelI
 	return nil
 }
 func (db *isolationDB) UpdateChannelSuccessFields(ctx context.Context, channelID int64, updates map[string]interface{}) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.successCalls++
+	db.lastSuccessUpdates = updates
+	row, ok := db.channels[channelID]
+	if !ok {
+		return nil
+	}
+	if v, ok := updates["failCount"].(int64); ok {
+		row.Channel.FailCount = v
+	}
 	return nil
 }
 func (db *isolationDB) UpdateRouteUnitMemberCooldownFields(ctx context.Context, memberID int64, updates map[string]interface{}) error {
@@ -248,6 +263,19 @@ func (db *isolationDB) UpdateRouteUnitMemberCooldownFields(ctx context.Context, 
 	return nil
 }
 func (db *isolationDB) UpdateRouteUnitMemberSuccessFields(ctx context.Context, memberID int64, updates map[string]interface{}) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.memberCalls++
+	db.lastMemberID = memberID
+	db.lastMemberUpdates = updates
+	for _, row := range db.members {
+		if row.Member.ID != memberID {
+			continue
+		}
+		if v, ok := updates["failCount"].(int64); ok {
+			row.Member.FailCount = v
+		}
+	}
 	return nil
 }
 func (db *isolationDB) LoadRouteUnitMemberWithAccount(ctx context.Context, unitID, accountID int64) (*struct {

--- a/routing/router_records.go
+++ b/routing/router_records.go
@@ -27,6 +27,10 @@ func (tr *TokenRouter) RecordSuccess(ctx context.Context, channelID int64, laten
 	nextSuccessCount := max(0, ch.SuccessCount) + 1
 	nextTotalLatencyMs := max(0, ch.TotalLatencyMs) + int64(latencyMs)
 	nextTotalCost := math.Max(0, ch.TotalCost) + cost
+	// Decay (not zero) accumulated failCount on success: a recovered channel
+	// keeps a small memory of past failures, but its next failure is no longer
+	// over-penalized by Fibonacci backoff based on the historical peak.
+	nextFailCount := max(0, ch.FailCount) / 2
 
 	if ch.OAuthRouteUnitID != nil && *ch.OAuthRouteUnitID > 0 {
 		targetAccountID := account.ID
@@ -41,6 +45,7 @@ func (tr *TokenRouter) RecordSuccess(ctx context.Context, channelID int64, laten
 			memberTotalCost := math.Max(0, memberRow.Member.TotalCost) + cost
 			_ = tr.db.UpdateRouteUnitMemberSuccessFields(ctx, memberRow.Member.ID, map[string]interface{}{
 				"successCount":   memberSuccessCount,
+				"failCount":      max(0, memberRow.Member.FailCount) / 2,
 				"totalLatencyMs": memberTotalLatencyMs,
 				"totalCost":      memberTotalCost,
 				"lastUsedAt":     nowISO,
@@ -61,6 +66,7 @@ func (tr *TokenRouter) RecordSuccess(ctx context.Context, channelID int64, laten
 
 	_ = tr.db.UpdateChannelSuccessFields(ctx, channelID, map[string]interface{}{
 		"successCount":   nextSuccessCount,
+		"failCount":      nextFailCount,
 		"totalLatencyMs": nextTotalLatencyMs,
 		"totalCost":      nextTotalCost,
 		"lastUsedAt":     nowISO,
@@ -72,6 +78,7 @@ func (tr *TokenRouter) RecordSuccess(ctx context.Context, channelID int64, laten
 
 	tr.cache.PatchCachedChannel(channelID, func(ch *store.RouteChannel) {
 		ch.SuccessCount = nextSuccessCount
+		ch.FailCount = nextFailCount
 		ch.TotalLatencyMs = nextTotalLatencyMs
 		ch.TotalCost = nextTotalCost
 		ch.LastUsedAt = &nowISO

--- a/routing/success_decay_test.go
+++ b/routing/success_decay_test.go
@@ -1,0 +1,181 @@
+package routing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// =============================================================================
+// FailCount decay on success — recovered channels are not over-penalized
+
+// RecordSuccess must halve accumulated failCount instead of leaving it
+// untouched, so that a recovered channel's next failure cools with Fibonacci
+// backoff relative to its decayed (recent) failure memory, not its historical
+// peak. Decay keeps a small memory for repeat offenders while avoiding
+// "punished for ancient history" cooldowns.
+// =============================================================================
+
+func newDecayFixture(t *testing.T, failCount int64) (*isolationDB, *TokenRouter) {
+	t.Helper()
+	ResetSiteRuntimeHealthState()
+	siteRuntimeHealthLoaded = true
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	db := newIsolationDB()
+	route := isolationRoute(1, "weighted")
+	ch := isolationChannel(501, 1, 5001)
+	ch.FailCount = failCount
+	acc := isolationAccount(5001, 50)
+	db.seedChannel(ch, acc, route)
+	return db, newIsolationRouter(db)
+}
+
+// cooldownDurationMs extracts the cooldown duration (cooldownUntil - beforeMs)
+// written by the most recent UpdateChannelCooldownFields call.
+func cooldownDurationMs(t *testing.T, db *isolationDB, beforeMs int64) int64 {
+	t.Helper()
+	updates := db.lastCooldownUpdates
+	if updates == nil {
+		t.Fatal("expected cooldown update, got none")
+	}
+	raw, ok := updates["cooldownUntil"]
+	if !ok {
+		t.Fatal("cooldown update missing cooldownUntil")
+	}
+	cooldownUntil, ok := raw.(*string)
+	if !ok || cooldownUntil == nil {
+		t.Fatalf("cooldownUntil has unexpected type %T", raw)
+	}
+	untilMs := ParseISOTimeMs(cooldownUntil)
+	if untilMs == nil {
+		t.Fatalf("cannot parse cooldownUntil %q", *cooldownUntil)
+	}
+	return *untilMs - beforeMs
+}
+
+// TestRecordSuccess_DecaysFailCount proves one success writes failCount/2 and
+// repeated successes keep halving (geometric decay toward zero), while the
+// four reset fields still clear.
+func TestRecordSuccess_DecaysFailCount(t *testing.T) {
+	db, tr := newDecayFixture(t, 10)
+	ctx := context.Background()
+
+	if err := tr.RecordSuccess(ctx, 501, 100, 0.001, nil, nil); err != nil {
+		t.Fatalf("RecordSuccess: %v", err)
+	}
+
+	if db.successCalls != 1 {
+		t.Fatalf("expected 1 success write, got %d", db.successCalls)
+	}
+	if v, ok := db.lastSuccessUpdates["failCount"]; !ok || v != int64(5) {
+		t.Fatalf("success write failCount = %v (present=%v), want 5", v, ok)
+	}
+	if v, ok := db.lastSuccessUpdates["consecutiveFailCount"]; !ok || v != int64(0) {
+		t.Fatalf("success write consecutiveFailCount = %v (present=%v), want 0", v, ok)
+	}
+	if raw, exists := db.lastSuccessUpdates["cooldownUntil"]; !exists || raw != nil {
+		t.Fatalf("success write cooldownUntil = %v (present=%v), want nil", raw, exists)
+	}
+	if got := db.getChannel(501); got == nil || got.FailCount != 5 {
+		t.Fatalf("channel failCount after success = %v, want 5", got)
+	}
+
+	// Geometric decay: 10 → 5 → 2 → 1 → 0.
+	for _, want := range []int64{2, 1, 0} {
+		if err := tr.RecordSuccess(ctx, 501, 100, 0.001, nil, nil); err != nil {
+			t.Fatalf("RecordSuccess (want %d): %v", want, err)
+		}
+		if got := db.getChannel(501); got == nil || got.FailCount != want {
+			t.Fatalf("channel failCount = %v, want %d", got, want)
+		}
+	}
+}
+
+// TestRecordSuccess_DecayShortensNextFailureCooldown proves the end-to-end
+// behavior: N accumulated failures → one success → next failure cools far less
+// than without the success. failCount=10 + failure = 11 → 15·fib(11)=1335s;
+// with an intervening success failCount decays to 5, next failure = 6 →
+// 15·fib(6)=120s.
+func TestRecordSuccess_DecayShortensNextFailureCooldown(t *testing.T) {
+	failCtx := func() SiteRuntimeFailureContext {
+		status := 500
+		errText := "upstream error"
+		model := "gpt-test"
+		return SiteRuntimeFailureContext{Status: &status, ErrorText: &errText, ModelName: &model}
+	}
+
+	// Control: no success between failures — cooldown based on failCount 11.
+	controlDB, controlRouter := newDecayFixture(t, 10)
+	beforeMs := time.Now().UnixMilli()
+	if err := controlRouter.RecordFailure(context.Background(), 501, failCtx(), nil); err != nil {
+		t.Fatalf("control RecordFailure: %v", err)
+	}
+	controlMs := cooldownDurationMs(t, controlDB, beforeMs)
+	if controlMs < 1_330_000 || controlMs > 1_340_000 {
+		t.Fatalf("control cooldown = %dms, want ≈ 15·fib(11)s = 1335000ms", controlMs)
+	}
+
+	// Decayed: one success before the failure — cooldown based on failCount 6.
+	decayedDB, decayedRouter := newDecayFixture(t, 10)
+	if err := decayedRouter.RecordSuccess(context.Background(), 501, 100, 0.001, nil, nil); err != nil {
+		t.Fatalf("decayed RecordSuccess: %v", err)
+	}
+	beforeMs = time.Now().UnixMilli()
+	if err := decayedRouter.RecordFailure(context.Background(), 501, failCtx(), nil); err != nil {
+		t.Fatalf("decayed RecordFailure: %v", err)
+	}
+	decayedMs := cooldownDurationMs(t, decayedDB, beforeMs)
+	if decayedMs < 115_000 || decayedMs > 125_000 {
+		t.Fatalf("decayed cooldown = %dms, want ≈ 15·fib(6)s = 120000ms", decayedMs)
+	}
+
+	if decayedMs >= controlMs {
+		t.Fatalf("decayed cooldown %dms not shorter than control %dms", decayedMs, controlMs)
+	}
+	if got := decayedDB.getChannel(501); got == nil || got.FailCount != 6 {
+		t.Fatalf("channel failCount after decay+failure = %v, want 6", got)
+	}
+}
+
+// TestRecordSuccess_DecaysMemberFailCount proves the OAuth route-unit member
+// path also halves member failCount on success instead of leaving it stale.
+func TestRecordSuccess_DecaysMemberFailCount(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	siteRuntimeHealthLoaded = true
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	db := newIsolationDB()
+	route := isolationRoute(1, "weighted")
+	unitID := int64(7)
+	ch := isolationChannel(301, 1, 3001)
+	ch.OAuthRouteUnitID = &unitID
+	acc := isolationAccount(3001, 30)
+	db.seedChannel(ch, acc, route)
+
+	unit := store.OAuthRouteUnit{
+		ID: unitID, SiteID: 30, Provider: "codex", Name: "unit", Strategy: "round_robin", Enabled: true,
+	}
+	db.seedMember(store.OAuthRouteUnitMember{ID: 1, UnitID: unitID, AccountID: 3001, FailCount: 10}, acc, unit)
+
+	tr := newIsolationRouter(db)
+	if err := tr.RecordSuccess(context.Background(), 301, 100, 0.001, nil, nil); err != nil {
+		t.Fatalf("RecordSuccess: %v", err)
+	}
+
+	if db.memberCalls != 1 {
+		t.Fatalf("expected 1 member success write, got %d", db.memberCalls)
+	}
+	if db.lastMemberID != 1 {
+		t.Fatalf("expected member 1 updated, got %d", db.lastMemberID)
+	}
+	if v, ok := db.lastMemberUpdates["failCount"]; !ok || v != int64(5) {
+		t.Fatalf("member success write failCount = %v (present=%v), want 5", v, ok)
+	}
+	// Outer OAuth channel never accumulated failCount; success keeps it clean.
+	if got := db.getChannel(301); got == nil || got.FailCount != 0 {
+		t.Fatalf("outer oauth channel failCount mutated: %v, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a real routing-cooldown bug: `RecordSuccess` reset 4 cooldown fields (`cooldownUntil` / `lastFailAt` / `consecutiveFailCount` / `cooldownLevel`) but never touched `failCount`, which is the input to Fibonacci backoff. A channel that had accumulated failures (e.g. failCount=10) and then recovered was still punished by its historical peak on the next failure (15·fib(11) = 1335s cooldown instead of something proportional to recent behavior).

## Change

- `routing/router_records.go` `RecordSuccess` now writes `failCount = failCount / 2` (decay, not zero — repeat offenders keep a small memory, one-off failures clear after a success). Applied consistently to:
  - channel path (`UpdateChannelSuccessFields` + cache patch)
  - OAuth route-unit member path (`UpdateRouteUnitMemberSuccessFields`)
- The 4 existing reset fields keep their current clear-on-success semantics.

## Tests

- `TestRecordSuccess_DecaysFailCount`: one success writes failCount/2; repeated successes decay geometrically 10 → 5 → 2 → 1 → 0.
- `TestRecordSuccess_DecayShortensNextFailureCooldown`: failCount=10 → success → next failure cools 120s (15·fib(6)) vs 1335s (15·fib(11)) without the success.
- `TestRecordSuccess_DecaysMemberFailCount`: OAuth member path also halves member failCount.
- Test harness (`failure_isolation_test.go`) gained success-write recording in `UpdateChannelSuccessFields` / `UpdateRouteUnitMemberSuccessFields`.

## Verification

- `go build ./cmd/server && go vet ./... && go test ./routing/ -count=1 -race` — all green.
- Full WSL race suite `bash scripts/go-race.sh` (`go test ./... -count=1 -race`) — all packages ok.
- Frontend gate (typecheck + lint + 382 tests) — green (unchanged, verified via pre-push parity).