### PR TITLE
fix(store): DEALLOCATE ALL after PG migration to avoid cached plan errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/deliciousbuding/metapi-go
 go 1.26.6
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/coder/websocket v1.8.15
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-chi/cors v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/andybalholm/brotli v1.0.6 h1:Yf9fFpf49Zrxb9NlQaluyE92/+X7UVHlhMNJN2sxfOI=
 github.com/andybalholm/brotli v1.0.6/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
@@ -33,6 +35,7 @@ github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
 github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=

--- a/store/migrate.go
+++ b/store/migrate.go
@@ -106,7 +106,43 @@ func AutoMigrate(db *DB) error {
 		return err
 	}
 
+	// PostgreSQL caches prepared statement plans server-side per session. Once
+	// DDL mutates the schema, a plan cached before the change can fail with
+	// "cached plan must not change result type" (SQLSTATE 0A000). Clear the
+	// plan cache and session state so the pool re-plans against the migrated
+	// schema (reference: octopus internal/db/db.go). Best-effort: a cleanup
+	// failure must not fail a migration that already completed.
+	if err := ClearPreparedPlanCache(db); err != nil {
+		slog.Warn("store: failed to clear prepared plan cache after migration", "error", err)
+	}
+
 	slog.Info("store: auto-migration complete", "dialect", dialect)
+	return nil
+}
+
+// ClearPreparedPlanCache clears PostgreSQL server-side prepared statements
+// (DEALLOCATE ALL) and resets the session state that backs them (DISCARD ALL).
+// The two statements are executed separately because the pgx driver uses the
+// extended protocol, which rejects multiple commands in a single prepared
+// statement. It is a no-op for dialects without a server-side plan cache
+// (SQLite has no prepared plan cache concept).
+//
+// Scope note: DEALLOCATE ALL only affects the session it runs on. Every
+// AutoMigrate caller (server startup, runtime dialect switch, migration
+// target) opens a fresh pool on which no result-bearing statements have been
+// cached yet, so a single execution is sufficient to keep that pool clean.
+func ClearPreparedPlanCache(db *DB) error {
+	if db == nil {
+		return nil
+	}
+	if db.Dialect != DialectPostgres {
+		return nil
+	}
+	for _, statement := range []string{"DEALLOCATE ALL", "DISCARD ALL"} {
+		if _, err := db.Exec(statement); err != nil {
+			return fmt.Errorf("store: %s after migration: %w", statement, err)
+		}
+	}
 	return nil
 }
 

--- a/store/migrate_plan_cache_test.go
+++ b/store/migrate_plan_cache_test.go
@@ -1,0 +1,71 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+)
+
+// TestClearPreparedPlanCachePostgresIssuesStatements verifies that the
+// PostgreSQL branch issues DEALLOCATE ALL and DISCARD ALL as two separate
+// executions. The pgx driver speaks the extended protocol, which rejects
+// multiple commands inside a single prepared statement, so a combined
+// "DEALLOCATE ALL; DISCARD ALL" string must never be sent.
+func TestClearPreparedPlanCachePostgresIssuesStatements(t *testing.T) {
+	mockSQLDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer mockSQLDB.Close()
+
+	// sqlmock.New() defaults to ordered expectations, so this also pins the
+	// exact statement sequence.
+	mock.ExpectExec("DEALLOCATE ALL").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DISCARD ALL").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	db := &DB{DB: sqlx.NewDb(mockSQLDB, "sqlmock"), Dialect: DialectPostgres}
+	if err := ClearPreparedPlanCache(db); err != nil {
+		t.Fatalf("ClearPreparedPlanCache(postgres): %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestClearPreparedPlanCacheSQLiteNoop verifies the SQLite dialect
+// short-circuits without issuing any statement (SQLite has no server-side
+// prepared plan cache).
+func TestClearPreparedPlanCacheSQLiteNoop(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open(sqlite): %v", err)
+	}
+	defer db.Close()
+
+	if err := ClearPreparedPlanCache(db); err != nil {
+		t.Fatalf("ClearPreparedPlanCache(sqlite): %v", err)
+	}
+}
+
+// TestClearPreparedPlanCacheNilDB verifies a nil DB is a safe no-op.
+func TestClearPreparedPlanCacheNilDB(t *testing.T) {
+	if err := ClearPreparedPlanCache(nil); err != nil {
+		t.Fatalf("ClearPreparedPlanCache(nil): %v", err)
+	}
+}
+
+// TestAutoMigrateDoesNotRunPlanCacheCleanupOnSQLite verifies the
+// AutoMigrate integration stays SQLite-clean: the cleanup hook must not leak
+// PostgreSQL-only statements into the SQLite path.
+func TestAutoMigrateDoesNotRunPlanCacheCleanupOnSQLite(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open(sqlite): %v", err)
+	}
+	defer db.Close()
+
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate(sqlite): %v", err)
+	}
+}

--- a/store/postgres_test.go
+++ b/store/postgres_test.go
@@ -429,3 +429,15 @@ func TestPostgresEnsureColumnBooleanDefaultFALSE(t *testing.T) {
 		t.Fatal("column default is empty")
 	}
 }
+
+// TestClearPreparedPlanCachePostgres verifies that the prepared-plan cache
+// cleanup (DEALLOCATE ALL + DISCARD ALL) executes cleanly against a live
+// PostgreSQL database. Statement-issuance behavior is unit-tested without a
+// database in migrate_plan_cache_test.go; this test guards against real-PG
+// quirks (e.g. DISCARD ALL inside an implicit transaction).
+func TestClearPreparedPlanCachePostgres(t *testing.T) {
+	db := openTestPG(t)
+	if err := ClearPreparedPlanCache(db); err != nil {
+		t.Fatalf("ClearPreparedPlanCache on live PostgreSQL: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

PostgreSQL caches prepared statement plans server-side per session. After a migration mutates the schema, a plan cached before the change can fail with `cached plan must not change result type` (SQLSTATE 0A000). This PR clears the plan cache and session state after every PG auto-migration.

- `store.AutoMigrate` (the single DDL choke point covering server startup, runtime dialect switch, and the `cmd/migrate`/admin-migrate target) now runs `ClearPreparedPlanCache` when the dialect is postgres.
- `ClearPreparedPlanCache` executes `DEALLOCATE ALL` and `DISCARD ALL` as two separate statements — the pgx driver uses the extended protocol, which rejects multiple commands in a single prepared statement (same split as the octopus reference, `internal/db/db.go`).
- SQLite is untouched (no-op guard; no server-side plan cache concept).
- Cleanup failures are logged (`slog.Warn`) and never fail an already-completed migration.

## Tests

- `TestClearPreparedPlanCachePostgresIssuesStatements` — sqlmock unit test asserting both statements are issued in order (runs in local CI, no PG needed).
- `TestClearPreparedPlanCacheSQLiteNoop` / `TestClearPreparedPlanCacheNilDB` / `TestAutoMigrateDoesNotRunPlanCacheCleanupOnSQLite` — SQLite path unaffected.
- `TestClearPreparedPlanCachePostgres` — live-PG integration test (skips without `PG_TEST_DSN`, covered by CI).

## Verification

- `go build ./cmd/server && go build ./cmd/migrate && go vet ./... && go test ./store/ -count=1 -race` — green
- Frontend gate (typecheck + lint + 382 vitest tests) — green
- Full race suite via `scripts/go-race.sh` (WSL) — all packages green