### PR TITLE
docs: sync state to v0.13.0 + reconcile WEB-ARCH milestone

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,6 +1,6 @@
 # STATE.md — MetAPI Go product status
 
-**Last verified**: 2026-08-14
+**Last verified**: 2026-08-16
 
 > **Current state** (product repository). Only current facts and pointers, no narrative.
 > Deployment facts live in the deployment guide; open items → [`progress/MASTER.md`](progress/MASTER.md) · timeline → [`log.md`](log.md) · version narrative → root [`CHANGELOG.md`](../CHANGELOG.md)
@@ -10,7 +10,7 @@
 | Fact | Value |
 |:-----|:------|
 | Source | **[DeliciousBuding/metapi-go](https://github.com/DeliciousBuding/metapi-go)** · default branch `master` |
-| Latest release | **[v0.12.0](https://github.com/DeliciousBuding/metapi-go/releases/tag/v0.12.0)** (2026-08-14); master pipeline publishes `ghcr.io/deliciousbuding/metapi-go` — verified live: tags `latest`/`0.12.0`/`0.12`/sha |
+| Latest release | **[v0.13.0](https://github.com/DeliciousBuding/metapi-go/releases/tag/v0.13.0)** (2026-08-15); master pipeline publishes `ghcr.io/deliciousbuding/metapi-go` — verified live: tags `latest`/`0.13.0`/`0.13`/sha |
 | Release pipeline | Single pipeline (`.github/workflows/main.yml`): PR / master push / SemVer tag all run the same 12-check suite; master push pushes the **linux/amd64 + linux/arm64** image (provenance + SBOM, tags latest+sha); SemVer-only tags (`vX.Y.Z`) additionally build **5-platform binaries + checksums.txt** (linux/darwin/windows × amd64/arm64), smoke `metapi-linux-amd64 --version`, and create the GitHub Release with notes extracted from the matching `CHANGELOG.md` section; tag must match `web/package.json` version or the release fails |
 | Versioning | `metapi --version` reports the build version injected via `-ldflags -X .../internal/version.Version` (`dev` for local builds); Docker build arg `VERSION`; Makefile `VERSION` variable |
 | Dependency updates | Dependabot active (Go / npm / GitHub Actions / Docker) — weekly group PRs through the same 12-check CI; breaking major bumps are closed and need a manual migration PR |

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,6 +1,6 @@
 # 产品对标 — New API × All API Hub
 
-**Last updated**: 2026-08-14
+**Last updated**: 2026-08-16
 
 > 产品经理视角的对标基线（非架构文档）。当前事实 + 路线图结论；实现层面的
 > 待办落在 [`progress/MASTER.md`](progress/MASTER.md) 的 roadmap 表。
@@ -11,7 +11,7 @@
 |------|---------|------|---------|
 | New API（QuantumNous/new-api） | v1.0.0-rc.24（2026-08-07） | Go 单体 + React + Electron 桌面版 + relaykit | 卖 API 的站长 |
 | All API Hub（qixing-jk/all-api-hub） | 上游 #1290（2026-08-13 检出） | 浏览器插件（Chrome/Edge/Firefox） | 个人玩家 / 小型网关主 |
-| MetAPI-Go（本项目） | v0.12.0 | Go 单二进制 + 内嵌 SPA | 自用 / 小团队 |
+| MetAPI-Go（本项目） | v0.13.0 | Go 单二进制 + 内嵌 SPA | 自用 / 小团队 |
 
 ## 三方定位
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,9 +1,15 @@
 # log.md — MetAPI Go product milestones
 
-**Last updated**: 2026-08-15
+**Last updated**: 2026-08-16
 
 > Product milestone timeline (grouped by version). Not the current-state source of truth.
 > Current state → [`STATE.md`](STATE.md) · open items → [`progress/MASTER.md`](progress/MASTER.md) · detailed version narrative → root [`CHANGELOG.md`](../CHANGELOG.md)
+
+## 2026-08-16 — 前端架构化里程碑对账 + 工作区重排
+
+- **工作区重排**：主 root 回 `master`（快进至 #783/#784/#785）；`fix/uiux-state-stability-final`（PR #782）迁入 `.worktrees/fix-uiux-state-stability-final`
+- **WEB-ARCH 里程碑对账**（spec-driven `docs/plan/`，Issues #732–#740）：Phase 1/2 全落地——T1（4 页 URL 状态统一）在 PR #782；T2 404 壳内 catch-all、T3 checkIsActive/model deep-link、T4 动效 tw-animate-css + reduced-motion、T5 DirectionProvider 单一归属、T6 FOUC bootstrap 对齐测试、T7 图标 HugeIcons 收敛、T8 原语 token 化均已在 master；T9 文档销项 = 本次对账
+- **文档卫生**：STATE.md/MASTER.md/benchmark.md 版本基线 v0.12.0 → v0.13.0；`docs/plan/milestones.md` 状态 Pending → 落地
 
 ## 2026-08-15 — 真实平台测试战役：测试床 + 6 个实测 bug 修复 + CI e2e
 

--- a/docs/plan/milestones.md
+++ b/docs/plan/milestones.md
@@ -2,7 +2,7 @@
 
 | # | Milestone | Target | Criteria | Status |
 |:--|:----------|:-------|:---------|:-------|
-| 1 | Phase 1: 路由架构硬化 | After P1-B1 + P1-B2 | 4 页 URL 往返无损 + 深链可恢复 + loader 用目标参数 + 404 壳内 + checkIsActive/model 校验 | Pending |
-| 2 | Phase 2: 设计系统架构化 | After P2-B1 + P2-B2 | 动效/方向/主题单一来源 + 图标/原语收敛 + 文档销项 | Pending |
+| 1 | Phase 1: 路由架构硬化 | After P1-B1 + P1-B2 | 4 页 URL 往返无损 + 深链可恢复 + loader 用目标参数 + 404 壳内 + checkIsActive/model 校验 | **done** — T1（4 页）在 PR #782；T2/T3 已落 master |
+| 2 | Phase 2: 设计系统架构化 | After P2-B1 + P2-B2 | 动效/方向/主题单一来源 + 图标/原语收敛 + 文档销项 | **done** — T4–T8 已落 master；T9 文档销项 = 2026-08-16 对账 |
 
 > 每里程碑通过标准 = 该批 PR 全绿（typecheck/lint/format/test/build）+ S.U.P.E.R Quick Check + 测试/文档验收。

--- a/docs/plan/task-breakdown.md
+++ b/docs/plan/task-breakdown.md
@@ -1,10 +1,14 @@
 # Task Breakdown — 前端架构化（路由 + 设计系统）
 
-**Last updated**: 2026-08-14
+**Last updated**: 2026-08-16
 
 > Spec-driven 运行产物。范围：架构层（路由 + 设计系统架构债务），不含功能 feature P1。
 > 跟踪模式：GITHUB_STANDARD（Issue + Milestone + Label + worktree + 分批 PR）。
 > 上游分析：`docs/analysis/ui-ux-audit-2026-08.md` + 两份运行时审计（路由 / 设计）。
+>
+> **执行状态（2026-08-16 对账）**：全部落地。T1（4 页 URL 状态）在 PR #782；
+> T2/T3 已合入 master；Phase 2 T4–T8 已合入 master；T9（文档销项）= 本次对账。
+> 详见 [`milestones.md`](milestones.md)。
 
 ## Overview
 - **Total Phases**: 2

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -37,7 +37,7 @@
 
 | Item | Note |
 |------|------|
-| 前端架构化（spec-driven run 2026-08-14） | 路由 URL 归属统一 + 设计系统单一来源；计划 `docs/plan/`，Issues #732–#740（milestone WEB-ARCH） |
+| 前端架构化（spec-driven run 2026-08-14） | **done**（2026-08-16 对账）：Phase 1/2 全落地——T1 在 PR #782，T2–T8 在 master，T9 文档销项；计划 `docs/plan/`，Issues #732–#740（milestone WEB-ARCH） |
 | CI 旧 schema 升级 job | 并入 test-sqlite/test-pg 或独立 job |
 | web api.ts any → Zod | 类型收窄（自 api.ts 拆分后剩余面） |
 | a11y 门禁增强 | moderate/minor + 375px + zh-CN + 键盘 + reduced-transparency |

--- a/docs/progress/MASTER.md
+++ b/docs/progress/MASTER.md
@@ -1,10 +1,10 @@
 # Roadmap
 
-**Last updated**: 2026-08-14
+**Last updated**: 2026-08-16
 
 **Repo**: https://github.com/DeliciousBuding/metapi-go
 
-**Release**: v0.12.0 · master CD `ghcr.io/deliciousbuding/metapi-go`
+**Release**: v0.13.0 · master CD `ghcr.io/deliciousbuding/metapi-go`
 
 > Current status → [`../STATE.md`](../STATE.md) · Timeline → [`../log.md`](../log.md) ·
 > 产品对标 → [`../benchmark.md`](../benchmark.md)


### PR DESCRIPTION
## Summary

Documentation hygiene pass, two concerns:

1. **Version baseline sync (v0.12.0 → v0.13.0)**: `STATE.md` / `MASTER.md` / `benchmark.md` still pointed at v0.12.0 while v0.13.0 shipped 2026-08-15 (tag + CHANGELOG + `web/package.json` 0.13.0). Production pin (ops) intentionally left at v0.12.0 — upgrade is a separate deploy action.

2. **WEB-ARCH milestone reconciliation**: the frontend-architecture plan (`docs/plan/`) marked Phase 1/2 as Pending, but they are fully landed — T1 (4-page URL state) is in PR #782, T2–T8 are in master. Mark milestones done, add execution-status note to the task breakdown, update the MASTER.md backlog row, and log the workspace reorg + reconciliation.

No code changes.

## Test plan

- Docs only — no build/test impact.
- `docs/log.md` entry added (append-only timeline).