### PR TITLE
fix(proxy): full-price fallback when usage lacks cache detail

### DIFF
--- a/BLOCKED.md
+++ b/BLOCKED.md
@@ -4,14 +4,23 @@
 
 ## 决策记录（无需裁决，仅留档）
 
-- **衰减因子取 `failCount / 2`（整数除法）**：按任务要求「衰减而非清零」。
-  failCount=1 时一次成功即归零（单次偶发失败不留记忆），failCount≥2 按几何
-  衰减保留少量记忆。OAuth route-unit member 路径同步衰减（与 channel 路径一致）。
-- **成功重置 4 字段不变**：cooldownUntil / lastFailAt / consecutiveFailCount /
-  cooldownLevel 保持清零，仅新增 failCount 衰减写入。
-- **`RecordProbeSuccess` 不动**：任务范围仅限 `RecordSuccess`（用户流量路径）；
-  探针成功路径保持原语义。
-- **gofmt**：`router_records.go` 在 HEAD 即非 gofmt-clean（map 字面量对齐风格），
-  CI（golangci-lint 配置）未启用 gofmt/gofumpt，故保持文件既有风格，未重排无关行。
-- **`web/dist`**：worktree 不含 gitignored 的 SPA 预构建产物，从主工作区拷贝同源
-  dist（本 PR 仅改 Go 代码，前端内容与 master 一致）以便本地 `go build`/pre-push 通过。
+- **全价兜底档位语义**：`usage.Found == true` 且 `CacheReadTokens == 0 && CacheCreationTokens == 0`
+  时进入新档位 `CalculateModelUsageFullPrice`——全部输入 token × 输入单价 + 输出 token ×
+  输出单价，不做缓存减免。语义对齐 octopus `internal/relay/metrics.go:53-57`
+  （缓存明细缺失 → nonCachedTokens = promptTokens 全价），落在 fallback_token_cost
+  （除数额）与三段分价（ratio 公式）之间。
+- **单价复用**：新档位经 `CacheAwarePerMillionRates` 取
+  `inputPerMillion = modelRatio × 2 × multiplier` / `outputPerMillion = modelRatio ×
+  completionRatio × 2 × multiplier`，未硬编新公式；与既有 breakdown 在无缓存 token 时
+  数值一致（不回归），有真实 ratio 时区别于除数额。
+- **pricing.source 标记**：新档位记 `full_price_fallback`，且不输出 `cache_ratio` /
+  `cache_creation_ratio` 键（无缓存明细，不打折、不虚构）。三段分价仍记
+  `model_ratio_defaults`；无 token 仍记 `fallback_token_cost`。
+- **仅补「缺失」档，不移植 oversized-cache 守卫**：octopus 的
+  `nonCachedTokens < 0 → 全价` 负值守卫（缓存明细超过总输入时保守回退）不在本任务范围；
+  三段分价对 oversized 缓存仍沿用现有 `billable < 0 → 0` 钳制（不回归要求）。如需对齐
+  可另开任务。
+- **无 split 的 total-only 用量**：全价档将 total 全部按输入单价计（与
+  `normalizeUsageBreakdownInput` 的 effectivePrompt 选择一致，保守）。
+- **web/dist**：worktree 不含 gitignored 的 SPA 预构建产物，已从主工作区拷贝同源 dist
+  （本 PR 仅改 Go 代码，前端内容与 master 一致）以便本地 `go build`/pre-push 通过。

--- a/handler/proxy/billing_cost.go
+++ b/handler/proxy/billing_cost.go
@@ -52,26 +52,58 @@ func EstimateBillingCostFromUsage(modelName, platform string, usage ParsedUsage)
 			CacheReadTokens:     usage.CacheReadTokens,
 			CacheCreationTokens: usage.CacheCreationTokens,
 		}
-		if detail := routing.CalculateModelUsageBreakdown(pm, u, map[string]float64{"default": 1}); detail != nil {
-			details["breakdown"] = map[string]any{
-				"input_cost":          detail.Breakdown.InputCost,
-				"output_cost":         detail.Breakdown.OutputCost,
-				"cache_read_cost":     detail.Breakdown.CacheReadCost,
-				"cache_creation_cost": detail.Breakdown.CacheCreationCost,
-				"total_cost":          detail.Breakdown.TotalCost,
-				"fallback_total_cost": cost,
+		groupRatios := map[string]float64{"default": 1}
+		hasCacheDetail := usage.CacheReadTokens > 0 || usage.CacheCreationTokens > 0
+		if hasCacheDetail {
+			// Cache detail present: cache-aware three-way split.
+			detail := routing.CalculateModelUsageBreakdown(pm, u, groupRatios)
+			if detail != nil {
+				details["breakdown"] = map[string]any{
+					"input_cost":          detail.Breakdown.InputCost,
+					"output_cost":         detail.Breakdown.OutputCost,
+					"cache_read_cost":     detail.Breakdown.CacheReadCost,
+					"cache_creation_cost": detail.Breakdown.CacheCreationCost,
+					"total_cost":          detail.Breakdown.TotalCost,
+					"fallback_total_cost": cost,
+				}
+				details["pricing"] = map[string]any{
+					"source":               "model_ratio_defaults",
+					"model_ratio":          detail.Pricing.ModelRatio,
+					"completion_ratio":     detail.Pricing.CompletionRatio,
+					"cache_ratio":          detail.Pricing.CacheRatio,
+					"cache_creation_ratio": detail.Pricing.CacheCreationRatio,
+					"platform":             strings.TrimSpace(platform),
+					"model":                strings.TrimSpace(modelName),
+				}
+				if detail.Breakdown.TotalCost > 0 {
+					cost = detail.Breakdown.TotalCost
+				}
 			}
-			details["pricing"] = map[string]any{
-				"source":               "model_ratio_defaults",
-				"model_ratio":          detail.Pricing.ModelRatio,
-				"completion_ratio":     detail.Pricing.CompletionRatio,
-				"cache_ratio":          detail.Pricing.CacheRatio,
-				"cache_creation_ratio": detail.Pricing.CacheCreationRatio,
-				"platform":             strings.TrimSpace(platform),
-				"model":                strings.TrimSpace(modelName),
-			}
-			if detail.Breakdown.TotalCost > 0 {
-				cost = detail.Breakdown.TotalCost
+		} else {
+			// Tokens reported but no cache detail: full-price tier. Bill every
+			// input token at the input rate and every output token at the
+			// output rate (no cache discount), instead of degrading to the
+			// token-divisor estimate.
+			detail := routing.CalculateModelUsageFullPrice(pm, u, groupRatios)
+			if detail != nil {
+				details["breakdown"] = map[string]any{
+					"input_cost":          detail.Breakdown.InputCost,
+					"output_cost":         detail.Breakdown.OutputCost,
+					"cache_read_cost":     detail.Breakdown.CacheReadCost,
+					"cache_creation_cost": detail.Breakdown.CacheCreationCost,
+					"total_cost":          detail.Breakdown.TotalCost,
+					"fallback_total_cost": cost,
+				}
+				details["pricing"] = map[string]any{
+					"source":           "full_price_fallback",
+					"model_ratio":      detail.Pricing.ModelRatio,
+					"completion_ratio": detail.Pricing.CompletionRatio,
+					"platform":         strings.TrimSpace(platform),
+					"model":            strings.TrimSpace(modelName),
+				}
+				if detail.Breakdown.TotalCost > 0 {
+					cost = detail.Breakdown.TotalCost
+				}
 			}
 		}
 	}

--- a/handler/proxy/billing_cost_test.go
+++ b/handler/proxy/billing_cost_test.go
@@ -1,6 +1,9 @@
 package proxyhandler
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestEstimateBillingCostFromUsage_FallbackPositive(t *testing.T) {
 	got := EstimateBillingCostFromUsage("gpt-4o", "openai", ParsedUsage{
@@ -85,6 +88,119 @@ func TestEstimateBillingCostFromUsage_NonClaudeMissingCacheRatiosStayOne(t *test
 	}
 	if asFloat(t, breakdown["cache_creation_cost"]) <= 0 {
 		t.Fatalf("cache_creation_cost should be present and > 0 when tokens > 0: %#v", breakdown)
+	}
+}
+
+func TestEstimateBillingCostFromUsage_NoCacheDetailFullPrice(t *testing.T) {
+	// Tokens present but no cache detail → full-price tier: every input token
+	// at the input rate, every output token at the output rate, no cache keys.
+	got := EstimateBillingCostFromUsage("gpt-4o", "openai", ParsedUsage{
+		PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500,
+		Found: true, Source: "upstream",
+	})
+	if got.BillingDetails == nil {
+		t.Fatal("nil details")
+	}
+
+	pricing, ok := got.BillingDetails["pricing"].(map[string]any)
+	if !ok {
+		t.Fatalf("pricing missing: %#v", got.BillingDetails)
+	}
+	if src, _ := pricing["source"].(string); src != "full_price_fallback" {
+		t.Fatalf("pricing.source=%v want full_price_fallback", src)
+	}
+	// Full-price tier must not advertise cache discounts.
+	if _, present := pricing["cache_ratio"]; present {
+		t.Fatalf("full-price tier must not emit cache_ratio: %#v", pricing)
+	}
+	if _, present := pricing["cache_creation_ratio"]; present {
+		t.Fatalf("full-price tier must not emit cache_creation_ratio: %#v", pricing)
+	}
+
+	breakdown, ok := got.BillingDetails["breakdown"].(map[string]any)
+	if !ok {
+		t.Fatalf("breakdown missing: %#v", got.BillingDetails)
+	}
+	// input = 1000 × 2/1e6, output = 500 × 2/1e6 (default ratio 1).
+	if got := asFloat(t, breakdown["input_cost"]); math.Abs(got-0.002) > 1e-9 {
+		t.Fatalf("input_cost=%v want 0.002", got)
+	}
+	if got := asFloat(t, breakdown["output_cost"]); math.Abs(got-0.001) > 1e-9 {
+		t.Fatalf("output_cost=%v want 0.001", got)
+	}
+	if got := asFloat(t, breakdown["cache_read_cost"]); got != 0 {
+		t.Fatalf("cache_read_cost=%v want 0", got)
+	}
+	if got := asFloat(t, breakdown["cache_creation_cost"]); got != 0 {
+		t.Fatalf("cache_creation_cost=%v want 0", got)
+	}
+	if math.Abs(got.EstimatedCost-0.003) > 1e-9 {
+		t.Fatalf("EstimatedCost=%v want 0.003", got.EstimatedCost)
+	}
+}
+
+func TestEstimateBillingCostFromUsage_NoCacheDetailClaudeStillFullPrice(t *testing.T) {
+	// Claude without cache detail must also bill the whole input at the input
+	// rate — no Anthropic cache-ratio defaults leak into a no-cache request.
+	got := EstimateBillingCostFromUsage("claude-sonnet-4", "anthropic", ParsedUsage{
+		PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150,
+		Found: true, Source: "upstream",
+	})
+	if got.BillingDetails == nil {
+		t.Fatal("nil details")
+	}
+
+	pricing, ok := got.BillingDetails["pricing"].(map[string]any)
+	if !ok {
+		t.Fatalf("pricing missing: %#v", got.BillingDetails)
+	}
+	if src, _ := pricing["source"].(string); src != "full_price_fallback" {
+		t.Fatalf("pricing.source=%v want full_price_fallback", src)
+	}
+	if _, present := pricing["cache_ratio"]; present {
+		t.Fatalf("full-price tier must not emit cache_ratio: %#v", pricing)
+	}
+
+	breakdown, ok := got.BillingDetails["breakdown"].(map[string]any)
+	if !ok {
+		t.Fatalf("breakdown missing: %#v", got.BillingDetails)
+	}
+	// input = 100 × 2/1e6, output = 50 × 2/1e6.
+	if got := asFloat(t, breakdown["input_cost"]); math.Abs(got-0.0002) > 1e-9 {
+		t.Fatalf("input_cost=%v want 0.0002", got)
+	}
+	if got := asFloat(t, breakdown["output_cost"]); math.Abs(got-0.0001) > 1e-9 {
+		t.Fatalf("output_cost=%v want 0.0001", got)
+	}
+	if math.Abs(got.EstimatedCost-0.0003) > 1e-9 {
+		t.Fatalf("EstimatedCost=%v want 0.0003", got.EstimatedCost)
+	}
+}
+
+func TestEstimateBillingCostFromUsage_NotFoundStaysDivisionFallback(t *testing.T) {
+	// No token fields at all → the original fallback_token_cost tier stays.
+	got := EstimateBillingCostFromUsage("gpt-4o", "openai", ParsedUsage{
+		TotalTokens: 1500, Source: "unknown",
+	})
+	if got.BillingDetails == nil {
+		t.Fatal("nil details")
+	}
+	pricing, ok := got.BillingDetails["pricing"].(map[string]any)
+	if !ok {
+		t.Fatalf("pricing missing: %#v", got.BillingDetails)
+	}
+	if src, _ := pricing["source"].(string); src != "fallback_token_cost" {
+		t.Fatalf("pricing.source=%v want fallback_token_cost", src)
+	}
+	breakdown, ok := got.BillingDetails["breakdown"].(map[string]any)
+	if !ok {
+		t.Fatalf("breakdown missing: %#v", got.BillingDetails)
+	}
+	if _, present := breakdown["input_cost"]; present {
+		t.Fatalf("fallback tier must not emit input_cost: %#v", breakdown)
+	}
+	if math.Abs(got.EstimatedCost-0.003) > 1e-9 {
+		t.Fatalf("EstimatedCost=%v want 0.003 (1500/500000)", got.EstimatedCost)
 	}
 }
 

--- a/routing/pricing_cost.go
+++ b/routing/pricing_cost.go
@@ -284,6 +284,79 @@ func CalculateModelUsageBreakdown(
 	}
 }
 
+// CalculateModelUsageFullPrice bills the no-cache-detail tier: every input
+// token at the input rate and every output token at the output rate, with no
+// cache discount. Upstreams that report token usage without cache detail must
+// not be discounted — octopus semantics (internal/relay/metrics.go): missing
+// cache detail means nonCachedTokens = promptTokens, so the whole input side
+// is billed at full input price. This tier sits between FallbackTokenCost
+// (token-divisor estimate) and CalculateModelUsageBreakdown (cache-aware
+// three-way split). Unit prices reuse the existing conversion
+// (inputPerMillion = modelRatio × 2 × multiplier) via CacheAwarePerMillionRates
+// instead of hardcoding new formulas. Returns nil for per-call quotaType (1),
+// matching CalculateModelUsageBreakdown.
+func CalculateModelUsageFullPrice(
+	model PricingModel,
+	usage UsageForCost,
+	groupRatio map[string]float64,
+) *ProxyBillingDetails {
+	if model.QuotaType == 1 {
+		return nil
+	}
+
+	multiplier := resolveGroupMultiplier(model, groupRatio)
+	normalized := normalizeUsageBreakdownInput(usage)
+
+	inputPerMillion, outputPerMillion, _, _ := CacheAwarePerMillionRates(model, multiplier)
+
+	// No cache subtraction: bill the entire input side at the input rate.
+	// When upstream reported only a total (no prompt/completion split), the
+	// total is billed as input — the conservative choice, matching the
+	// effectivePrompt selection in normalizeUsageBreakdownInput.
+	inputTokens := normalized.PromptTokens
+	if normalized.PromptTokens == 0 && normalized.CompletionTokens == 0 {
+		inputTokens = normalized.TotalTokens
+	}
+	inputCost := roundCost((float64(inputTokens) / 1_000_000) * inputPerMillion)
+	outputCost := roundCost((float64(normalized.CompletionTokens) / 1_000_000) * outputPerMillion)
+	totalCost := roundCost(inputCost + outputCost)
+
+	// Reflect that the full input side was billed without cache discounts.
+	normalized.BillablePromptTokens = inputTokens
+
+	modelRatio := model.ModelRatio
+	if modelRatio <= 0 || !isFiniteFloat(modelRatio) {
+		modelRatio = 1
+	}
+	completionRatio := model.CompletionRatio
+	if completionRatio <= 0 || !isFiniteFloat(completionRatio) {
+		completionRatio = 1
+	}
+
+	return &ProxyBillingDetails{
+		QuotaType: model.QuotaType,
+		Usage:     normalized,
+		Pricing: ProxyBillingPricing{
+			ModelRatio:         modelRatio,
+			CompletionRatio:    completionRatio,
+			CacheRatio:         0,
+			CacheCreationRatio: 0,
+			GroupRatio:         multiplier,
+		},
+		Breakdown: ProxyBillingBreakdown{
+			InputPerMillion:         inputPerMillion,
+			OutputPerMillion:        outputPerMillion,
+			CacheReadPerMillion:     0,
+			CacheCreationPerMillion: 0,
+			InputCost:               inputCost,
+			OutputCost:              outputCost,
+			CacheReadCost:           0,
+			CacheCreationCost:       0,
+			TotalCost:               totalCost,
+		},
+	}
+}
+
 // CalculateModelUsageCost returns the estimated cost for a model + usage.
 func CalculateModelUsageCost(
 	model PricingModel,

--- a/routing/pricing_cost_test.go
+++ b/routing/pricing_cost_test.go
@@ -331,3 +331,144 @@ func TestCalculateModelUsageCost_TokenBasedNoCache(t *testing.T) {
 		t.Fatalf("cost=%v want 0.014", cost)
 	}
 }
+
+func TestCalculateModelUsageFullPrice_RealRatios(t *testing.T) {
+	// Full-price tier reuses the ratio-based unit prices: with a real model
+	// ratio the result must NOT collapse to the token-divisor fallback
+	// (1500/500000 = 0.003).
+	model := PricingModel{
+		ModelName:       "gpt-4o",
+		QuotaType:       0,
+		ModelRatio:      2,
+		CompletionRatio: 3,
+		EnableGroups:    []string{"vip"},
+	}
+	detail := CalculateModelUsageFullPrice(model, UsageForCost{
+		PromptTokens:     1000,
+		CompletionTokens: 500,
+		TotalTokens:      1500,
+	}, map[string]float64{"default": 1, "vip": 2})
+	if detail == nil {
+		t.Fatal("detail nil")
+	}
+	// inputPerMillion = modelRatio × 2 × multiplier = 2×2×2 = 8
+	// outputPerMillion = modelRatio × completionRatio × 2 × multiplier = 2×3×2×2 = 24
+	if detail.Breakdown.InputPerMillion != 8 {
+		t.Fatalf("inputPerMillion=%v want 8", detail.Breakdown.InputPerMillion)
+	}
+	if detail.Breakdown.OutputPerMillion != 24 {
+		t.Fatalf("outputPerMillion=%v want 24", detail.Breakdown.OutputPerMillion)
+	}
+	if detail.Breakdown.InputCost != 0.008 {
+		t.Fatalf("inputCost=%v want 0.008", detail.Breakdown.InputCost)
+	}
+	if detail.Breakdown.OutputCost != 0.012 {
+		t.Fatalf("outputCost=%v want 0.012", detail.Breakdown.OutputCost)
+	}
+	if detail.Breakdown.TotalCost != 0.02 {
+		t.Fatalf("totalCost=%v want 0.02", detail.Breakdown.TotalCost)
+	}
+	if detail.Breakdown.CacheReadCost != 0 || detail.Breakdown.CacheCreationCost != 0 {
+		t.Fatalf("cache costs must be zero in full-price tier: %+v", detail.Breakdown)
+	}
+	if detail.Breakdown.CacheReadPerMillion != 0 || detail.Breakdown.CacheCreationPerMillion != 0 {
+		t.Fatalf("cache rates must be zero in full-price tier: %+v", detail.Breakdown)
+	}
+	if detail.Usage.BillablePromptTokens != 1000 {
+		t.Fatalf("billablePromptTokens=%v want 1000 (whole input billed)", detail.Usage.BillablePromptTokens)
+	}
+	if math.Abs(FallbackTokenCost(1500, "openai")-0.003) > 1e-9 {
+		t.Fatalf("sanity: fallback division=%v want 0.003", FallbackTokenCost(1500, "openai"))
+	}
+}
+
+func TestCalculateModelUsageFullPrice_TotalOnlyBilledAsInput(t *testing.T) {
+	// No prompt/completion split: the whole total is billed as input at the
+	// input rate (conservative).
+	model := PricingModel{ModelName: "gpt-4o", QuotaType: 0, ModelRatio: 1, CompletionRatio: 1}
+	detail := CalculateModelUsageFullPrice(model, UsageForCost{
+		TotalTokens: 2000,
+	}, map[string]float64{"default": 1})
+	if detail == nil {
+		t.Fatal("detail nil")
+	}
+	if detail.Breakdown.InputCost != 0.004 {
+		t.Fatalf("inputCost=%v want 0.004", detail.Breakdown.InputCost)
+	}
+	if detail.Breakdown.OutputCost != 0 {
+		t.Fatalf("outputCost=%v want 0", detail.Breakdown.OutputCost)
+	}
+	if detail.Breakdown.TotalCost != 0.004 {
+		t.Fatalf("totalCost=%v want 0.004", detail.Breakdown.TotalCost)
+	}
+	if detail.Usage.BillablePromptTokens != 2000 {
+		t.Fatalf("billablePromptTokens=%v want 2000", detail.Usage.BillablePromptTokens)
+	}
+}
+
+func TestCalculateModelUsageFullPrice_IgnoresCacheDiscounts(t *testing.T) {
+	// Defensive: even when cache fields are present, the full-price tier bills
+	// the entire input side at the input rate — no subtraction, no cache lines.
+	model := PricingModel{ModelName: "gpt-4o", QuotaType: 0, ModelRatio: 2, CompletionRatio: 3}
+	detail := CalculateModelUsageFullPrice(model, UsageForCost{
+		PromptTokens:        1000,
+		CompletionTokens:    500,
+		TotalTokens:         1500,
+		CacheReadTokens:     300,
+		CacheCreationTokens: 200,
+	}, map[string]float64{"default": 1})
+	if detail == nil {
+		t.Fatal("detail nil")
+	}
+	// input = 1000 × 4/1e6 = 0.004, NOT (1000-300-200) × 4/1e6.
+	if detail.Breakdown.InputCost != 0.004 {
+		t.Fatalf("inputCost=%v want 0.004", detail.Breakdown.InputCost)
+	}
+	if detail.Breakdown.CacheReadCost != 0 || detail.Breakdown.CacheCreationCost != 0 {
+		t.Fatalf("cache costs must be zero in full-price tier: %+v", detail.Breakdown)
+	}
+	if detail.Usage.BillablePromptTokens != 1000 {
+		t.Fatalf("billablePromptTokens=%v want 1000", detail.Usage.BillablePromptTokens)
+	}
+}
+
+func TestCalculateModelUsageFullPrice_PerCallQuotaReturnsNil(t *testing.T) {
+	model := PricingModel{QuotaType: 1}
+	if got := CalculateModelUsageFullPrice(model, UsageForCost{PromptTokens: 10}, map[string]float64{"default": 1}); got != nil {
+		t.Fatalf("quotaType=1 should return nil, got %+v", got)
+	}
+}
+
+func TestCalculateModelUsageFullPrice_NoCacheMatchesBreakdownMath(t *testing.T) {
+	// With no cache tokens the full-price tier and the cache-aware breakdown
+	// agree numerically (both bill the whole input at the input rate), which
+	// is what keeps the existing three-way behavior unchanged.
+	model := PricingModel{
+		ModelName:       "gpt-4o",
+		QuotaType:       0,
+		ModelRatio:      2,
+		CompletionRatio: 1.5,
+		EnableGroups:    []string{"vip"},
+	}
+	usage := UsageForCost{
+		PromptTokens:     1000,
+		CompletionTokens: 500,
+		TotalTokens:      1500,
+	}
+	groups := map[string]float64{"default": 1, "vip": 2}
+	fullPrice := CalculateModelUsageFullPrice(model, usage, groups)
+	breakdown := CalculateModelUsageBreakdown(model, usage, groups)
+	if fullPrice == nil || breakdown == nil {
+		t.Fatal("nil details")
+	}
+	if fullPrice.Breakdown.TotalCost != breakdown.Breakdown.TotalCost {
+		t.Fatalf("fullPrice=%v breakdown=%v should match without cache tokens",
+			fullPrice.Breakdown.TotalCost, breakdown.Breakdown.TotalCost)
+	}
+	if fullPrice.Breakdown.InputCost != breakdown.Breakdown.InputCost {
+		t.Fatalf("inputCost fullPrice=%v breakdown=%v", fullPrice.Breakdown.InputCost, breakdown.Breakdown.InputCost)
+	}
+	if fullPrice.Breakdown.OutputCost != breakdown.Breakdown.OutputCost {
+		t.Fatalf("outputCost fullPrice=%v breakdown=%v", fullPrice.Breakdown.OutputCost, breakdown.Breakdown.OutputCost)
+	}
+}


### PR DESCRIPTION
## Summary

补全计费兜底缺失的一档：当上游给了 token 用量、但没给缓存明细（cacheRead/cacheCreation 缺失）时，按「全部输入 token × 输入单价 + 输出 token × 输出单价」全价计费，而不是落到 `fallback_token_cost` 除数额。

- 新增 `routing.CalculateModelUsageFullPrice`：无缓存减免，全部输入侧按输入单价计费，语义对齐 octopus `internal/relay/metrics.go:53-57`（缓存明细缺失 → nonCachedTokens = promptTokens 全价）。
- 单价复用既有换算（`inputPerMillion = modelRatio × 2 × multiplier`，经 `CacheAwarePerMillionRates`），未硬编新公式。
- `EstimateBillingCostFromUsage` 三段分支：无 token → `fallback_token_cost`；有 token 无缓存明细 → 新档位 `full_price_fallback`（pricing.source 标记，不输出 cache_ratio 键）；有缓存明细 → 既有三段分价（不回归）。
- 单测覆盖：有 token 无缓存明细 → 全价（含 Claude 无缓存不泄入 Anthropic 折扣比）；有缓存明细 → 三段分价（既有测试全绿）；全价档与除数额/三段分价的数值关系（真实 ratio 下 ≠ total/500000）。

## Test plan

- `go build ./cmd/server && go vet ./... && go test ./handler/proxy/ ./routing/ -count=1 -race` 全绿
- 全量 `go test ./... -count=1 -race` 通过（179s，全部 ok）

## 决策记录

详见 `BLOCKED.md`（决策无需裁决：不移植 oversized-cache 守卫、total-only 按输入全价计、web/dist 从主工作区拷贝同源产物）。