### PR TITLE
refactor(web): remove unsupported auth refresh scaffolding

### DIFF
--- a/web/src/features/auth/api.ts
+++ b/web/src/features/auth/api.ts
@@ -1,12 +1,12 @@
 // metapi-go/features/auth — login API + useLogin hook.
 //
-// metapi-go auth is token-based (plan §3.1 seamless-migration): the operator
+// metapi-go auth is token-based for seamless migration: the operator
 // enters an admin token, we validate it by calling GET /api/settings/auth/info
 // with `Authorization: Bearer <token>`. A 2xx response means the token is
 // valid; 401/403 means it is invalid (or IP-blocked); 5xx is a server fault.
 //
-// The call uses skipAuthRefresh/skipErrorHandler/skipBusinessError to bypass
-// the http-client's 401-refresh loop and global toast (the login form owns
+// The call uses skipAuthRetry/skipErrorHandler/skipBusinessError to bypass
+// the http-client's 401 retry path and global toast (the login form owns
 // error display). On success we persist the session to localStorage (via
 // setAuthBundle, byte-compatible with the legacy authSession.ts keys) and
 // hydrate the Zustand auth-store.
@@ -40,7 +40,7 @@ function resolveLoginErrorMessageKey(status: number, reason: string): string {
 async function validateAdminToken(token: string): Promise<AuthBundle> {
   await apiClient.get('/api/settings/auth/info', {
     headers: { Authorization: `Bearer ${token}` },
-    skipAuthRefresh: true,
+    skipAuthRetry: true,
     skipErrorHandler: true,
     skipBusinessError: true,
     disableDuplicate: true,
@@ -56,19 +56,6 @@ async function validateAdminToken(token: string): Promise<AuthBundle> {
   }
   return bundle
 }
-
-/**
- * Validate an admin token against the backend and build an AuthBundle on
- * success. The backend only confirms validity (200 OK); it does not rotate
- * the token or return a user profile in this response, so the bundle carries
- * the original token + a 12h expiry + null user/session.
- */
-
-/**
- * Map an HTTP failure status + backend reason string to an i18next key.
- * Mirrors the legacy `loginError.ts` decision tree (IP whitelist 403 /
- * invalid token 401 / 5xx / generic).
- */
 
 /**
  * Login mutation. Validates the token, persists the session, hydrates the

--- a/web/src/features/auth/types.ts
+++ b/web/src/features/auth/types.ts
@@ -8,7 +8,7 @@ export type { AuthBundle } from '@/lib/auth-session'
  * Login form payload. metapi-go uses token-based admin auth: the operator
  * pastes an admin token which is validated via GET /api/settings/auth/info
  * with `Authorization: Bearer <token>`. There is no username/password
- * endpoint (seamless-migration hard constraint, plan §3.1).
+ * endpoint; this preserves the existing admin-auth contract.
  */
 export interface LoginPayload {
   token: string

--- a/web/src/hooks/use-sidebar-view.ts
+++ b/web/src/hooks/use-sidebar-view.ts
@@ -1,7 +1,6 @@
 // metapi-go/hooks — use-sidebar-view ported from newapi, simplified for metapi.
 // metapi has no role-based filtering (fully open) and no server-side module gating,
 // so this hook only resolves the nested drill-in view (Settings) vs root nav.
-// TODO(phase 2): re-add role filtering once auth-store + roles land.
 
 import { useLocation } from '@tanstack/react-router'
 import { useMemo } from 'react'

--- a/web/src/lib/__tests__/auth-session.test.ts
+++ b/web/src/lib/__tests__/auth-session.test.ts
@@ -1,0 +1,195 @@
+// metapi-go/lib — auth-session regression tests.
+//
+// Protects the simplified auth contract after the refresh/rotation scaffold
+// was removed: a valid persisted bundle authenticates, a missing/expired
+// bundle clears and reports anonymous, and the one-shot post-401 re-read
+// picks up a token written by another tab. No refresh endpoint, broadcast
+// channel, or rotation facade is exercised here — those are gone by design.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  AUTH_SESSION_DURATION_MS,
+  bootstrapAuthentication,
+  getAccessToken,
+  getAuthToken,
+  hasValidAuthSession,
+  resolveAuthenticationAfterUnauthorized,
+  setAuthBundle,
+  type AuthBundle,
+} from '../auth-session'
+
+const TOKEN_KEY = 'auth_token'
+const EXPIRES_KEY = 'auth_token_expires_at'
+const NOW_MS = 1_750_000_000_000
+
+interface MemoryStorage {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+  removeItem: (key: string) => void
+  has: (key: string) => boolean
+  get: (key: string) => string | null
+}
+
+function memoryStorage(initial?: Record<string, string>): MemoryStorage {
+  const store = new Map<string, string>(Object.entries(initial ?? {}))
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+    has: (key) => store.has(key),
+    get: (key) => store.get(key) ?? null,
+  }
+}
+
+function bundle(token: string, expiresAtSec: number): AuthBundle {
+  return {
+    access_token: token,
+    token_type: 'Bearer',
+    access_expires_at: expiresAtSec,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Token resolution (the interceptor + route guards read through these)
+// ---------------------------------------------------------------------------
+
+describe('getAuthToken — token validity', () => {
+  it('returns the token for a valid unexpired session', () => {
+    const storage = memoryStorage({
+      [TOKEN_KEY]: 'token-a',
+      [EXPIRES_KEY]: String(NOW_MS + 60_000),
+    })
+    expect(getAuthToken(storage, NOW_MS)).toBe('token-a')
+    expect(getAccessToken(storage, NOW_MS)).toBe('token-a')
+    expect(hasValidAuthSession(storage, NOW_MS)).toBe(true)
+  })
+
+  it('returns null when no token is stored', () => {
+    expect(getAuthToken(memoryStorage(), NOW_MS)).toBeNull()
+  })
+
+  it('clears stale keys and returns null for an expired token', () => {
+    const storage = memoryStorage({
+      [TOKEN_KEY]: 'stale-token',
+      [EXPIRES_KEY]: String(NOW_MS - 1),
+    })
+    expect(getAuthToken(storage, NOW_MS)).toBeNull()
+    expect(storage.has(TOKEN_KEY)).toBe(false)
+    expect(storage.has(EXPIRES_KEY)).toBe(false)
+  })
+
+  it('clears and returns null for a non-numeric expiry', () => {
+    const storage = memoryStorage({
+      [TOKEN_KEY]: 'token-a',
+      [EXPIRES_KEY]: 'not-a-number',
+    })
+    expect(getAuthToken(storage, NOW_MS)).toBeNull()
+    expect(storage.has(TOKEN_KEY)).toBe(false)
+  })
+
+  it('re-persists a 12h TTL when expiry is missing (legacy migration)', () => {
+    const storage = memoryStorage({ [TOKEN_KEY]: 'legacy-token' })
+    expect(getAuthToken(storage, NOW_MS)).toBe('legacy-token')
+    expect(storage.get(EXPIRES_KEY)).toBe(
+      String(NOW_MS + AUTH_SESSION_DURATION_MS)
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+describe('setAuthBundle', () => {
+  it('persists the token and converts unix-seconds expiry to ms epoch', () => {
+    const storage = memoryStorage()
+    const expiresAtSec = Math.floor(Date.now() / 1000) + 3600
+    setAuthBundle(bundle('bundled-token', expiresAtSec), storage)
+    expect(storage.get(TOKEN_KEY)).toBe('bundled-token')
+    expect(storage.get(EXPIRES_KEY)).toBe(String(expiresAtSec * 1000))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Post-401 re-read — the "another tab wrote a new token" one-shot contract
+// ---------------------------------------------------------------------------
+
+describe('resolveAuthenticationAfterUnauthorized — one-shot re-read', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns authenticated when another tab wrote a valid token', () => {
+    const storage = memoryStorage({
+      [TOKEN_KEY]: 'fresh-token',
+      [EXPIRES_KEY]: String(Date.now() + 60_000),
+    })
+    vi.stubGlobal('localStorage', storage as unknown as Storage)
+
+    const outcome = resolveAuthenticationAfterUnauthorized()
+    expect(outcome.kind).toBe('authenticated')
+    if (outcome.kind === 'authenticated') {
+      expect(outcome.bundle.access_token).toBe('fresh-token')
+      expect(outcome.bundle.token_type).toBe('Bearer')
+    }
+    // A valid token is kept, not cleared.
+    expect(storage.has(TOKEN_KEY)).toBe(true)
+  })
+
+  it('clears and returns anonymous for an expired token', () => {
+    const storage = memoryStorage({
+      [TOKEN_KEY]: 'expired-token',
+      [EXPIRES_KEY]: String(Date.now() - 1),
+    })
+    vi.stubGlobal('localStorage', storage as unknown as Storage)
+
+    expect(resolveAuthenticationAfterUnauthorized()).toEqual({
+      kind: 'anonymous',
+    })
+    expect(storage.has(TOKEN_KEY)).toBe(false)
+    expect(storage.has(EXPIRES_KEY)).toBe(false)
+  })
+
+  it('returns anonymous when storage is empty', () => {
+    vi.stubGlobal('localStorage', memoryStorage() as unknown as Storage)
+    expect(resolveAuthenticationAfterUnauthorized()).toEqual({
+      kind: 'anonymous',
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Startup bootstrap — same resolve/clear contract
+// ---------------------------------------------------------------------------
+
+describe('bootstrapAuthentication', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns authenticated for a valid stored token', () => {
+    vi.stubGlobal(
+      'localStorage',
+      memoryStorage({
+        [TOKEN_KEY]: 'boot-token',
+        [EXPIRES_KEY]: String(Date.now() + 60_000),
+      }) as unknown as Storage
+    )
+    expect(bootstrapAuthentication().kind).toBe('authenticated')
+  })
+
+  it('returns anonymous and clears an expired token', () => {
+    const storage = memoryStorage({
+      [TOKEN_KEY]: 'expired-token',
+      [EXPIRES_KEY]: String(Date.now() - 1),
+    })
+    vi.stubGlobal('localStorage', storage as unknown as Storage)
+    expect(bootstrapAuthentication()).toEqual({ kind: 'anonymous' })
+    expect(storage.has(TOKEN_KEY)).toBe(false)
+  })
+})

--- a/web/src/lib/__tests__/http-client.test.ts
+++ b/web/src/lib/__tests__/http-client.test.ts
@@ -1,0 +1,136 @@
+// metapi-go/lib — http-client 401 interceptor regression tests.
+//
+// Protects the simplified 401 contract: on a 401 the interceptor re-reads
+// storage once (another tab may have replaced the token), replays at most
+// once, then clears the session and redirects to sign-in when no valid token
+// remains. No refresh endpoint or rotation facade is involved.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { apiClient } from '../http-client'
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    message: vi.fn(),
+    loading: vi.fn(),
+    custom: vi.fn(),
+    promise: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}))
+
+const TOKEN_KEY = 'auth_token'
+const EXPIRES_KEY = 'auth_token_expires_at'
+
+interface MemoryStorage {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+  removeItem: (key: string) => void
+  has: (key: string) => boolean
+}
+
+function memoryStorage(initial?: Record<string, string>): MemoryStorage {
+  const store = new Map<string, string>(Object.entries(initial ?? {}))
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value)
+    },
+    removeItem: (key) => {
+      store.delete(key)
+    },
+    has: (key) => store.has(key),
+  }
+}
+
+type AdapterError = Error & {
+  config?: unknown
+  response?: { status: number; data: unknown }
+}
+
+describe('apiClient 401 interceptor', () => {
+  const originalAdapter = apiClient.defaults.adapter
+  const originalLocation = window.location
+  const replaceMock = vi.fn()
+
+  function installLocationMock(): void {
+    // jsdom's Location methods are non-configurable, so `vi.spyOn` cannot
+    // redefine them. Replace the whole `window.location` value with a minimal
+    // stub that exposes a spyable `replace`.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        pathname: '/accounts',
+        href: 'http://localhost/accounts',
+        replace: replaceMock,
+        reload: () => {},
+      },
+    })
+  }
+
+  function restoreLocation(): void {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    })
+  }
+
+  beforeEach(() => {
+    replaceMock.mockReset()
+    installLocationMock()
+  })
+
+  afterEach(() => {
+    apiClient.defaults.adapter = originalAdapter
+    restoreLocation()
+    vi.unstubAllGlobals()
+  })
+
+  function installAlways401Adapter(adapterCalls: unknown[]): void {
+    apiClient.defaults.adapter = async (config) => {
+      adapterCalls.push(config)
+      const error = new Error(
+        'Request failed with status code 401'
+      ) as AdapterError
+      error.config = config
+      error.response = { status: 401, data: { error: 'unauthorized' } }
+      throw error
+    }
+  }
+
+  it('replays exactly once with a re-read token, then clears and redirects', async () => {
+    const storage = memoryStorage({
+      [TOKEN_KEY]: 'fresh-token',
+      [EXPIRES_KEY]: String(Date.now() + 60_000),
+    })
+    vi.stubGlobal('localStorage', storage as unknown as Storage)
+
+    const adapterCalls: unknown[] = []
+    installAlways401Adapter(adapterCalls)
+
+    await expect(apiClient.get('/api/protected')).rejects.toThrow()
+
+    // Initial request + exactly one replay — never an infinite retry loop.
+    expect(adapterCalls).toHaveLength(2)
+    expect(replaceMock).toHaveBeenCalledWith('/sign-in')
+    // The exhausted retry clears the persisted token.
+    expect(storage.has(TOKEN_KEY)).toBe(false)
+  })
+
+  it('redirects without replay when no valid token remains', async () => {
+    vi.stubGlobal('localStorage', memoryStorage() as unknown as Storage)
+
+    const adapterCalls: unknown[] = []
+    installAlways401Adapter(adapterCalls)
+
+    await expect(apiClient.get('/api/protected')).rejects.toThrow()
+
+    // anonymous → no replay, a single adapter call, redirect to sign-in.
+    expect(adapterCalls).toHaveLength(1)
+    expect(replaceMock).toHaveBeenCalledWith('/sign-in')
+  })
+})

--- a/web/src/lib/auth-session.ts
+++ b/web/src/lib/auth-session.ts
@@ -36,19 +36,6 @@ function currentValidAuthBundle(
   }
 }
 
-function isAuthBundle(value: unknown): value is AuthBundle {
-  if (!isRecord(value)) return false
-  return (
-    typeof value.access_token === 'string' &&
-    value.access_token.length > 0 &&
-    typeof value.token_type === 'string' &&
-    value.token_type.length > 0 &&
-    typeof value.access_expires_at === 'number' &&
-    Number.isFinite(value.access_expires_at) &&
-    value.access_expires_at > 0
-  )
-}
-
 function persistAuthSession(
   storage: StorageLike | null | undefined,
   token: string,
@@ -69,39 +56,17 @@ function persistAuthSession(
   target.setItem(AUTH_TOKEN_EXPIRES_AT_STORAGE_KEY, String(expiresAt))
 }
 
-function publishAuthSessionEvent(
-  event: AuthSessionEventName,
-  _sid?: string
-): void {
-  // TODO(tab-sync): include the SID payload and have the store reconcile on
-  // receipt. Storage-only tokens don't need it yet, so this is a no-op-ish
-  // ping that at least wakes other tabs to re-read storage.
-  const channel = resolveAuthSessionChannel()
-  if (!channel) return
-  try {
-    channel.postMessage({ event })
-  } catch {
-    // channel closed / sandboxed; ignore.
-  }
-}
-
 /**
  * Authentication session module for metapi-go.
  *
- * Adapted from the newapi auth-session design (single-flight refresh, tab
- * sync, bundle shape) but bound to metapi-go's existing auth contract: a
- * Bearer access token persisted to localStorage (`auth_token` +
- * `auth_token_expires_at`, ms epoch) and the HttpOnly `meta_monitor_auth`
- * cookie used by the monitor embed.
+ * Bound to metapi-go's existing auth contract: a Bearer access token
+ * persisted to localStorage (`auth_token` + `auth_token_expires_at`, ms
+ * epoch) and the HttpOnly `meta_monitor_auth` cookie used by the monitor
+ * embed.
  *
  * The token storage keys are kept byte-for-byte compatible with the legacy
  * `authSession.ts` so existing sessions survive the frontend rewrite
- * (seamless-migration hard constraint, plan §3.1).
- *
- * TODO(stores): once `@/stores/auth-store` (Zustand) lands, delegate
- * getAccessToken / getAuthSession / setAuthBundle / clearAuthentication to it
- * and keep this module as the refresh + tab-sync facade. Until then this
- * module is the interim source of truth so the lib/ layer is self-contained.
+ * (seamless-migration hard constraint).
  */
 
 const AUTH_TOKEN_STORAGE_KEY = 'auth_token'
@@ -135,11 +100,9 @@ export interface AuthBundle {
   session?: LoginSession | null
 }
 
-export type RefreshOutcome =
+export type AuthenticationOutcome =
   | { kind: 'authenticated'; bundle: AuthBundle }
   | { kind: 'anonymous' }
-  | { kind: 'transient_error'; error: unknown }
-  | { kind: 'out_of_sync'; code?: string }
 
 export type AuthBootstrapState = 'idle' | 'checking' | 'complete'
 
@@ -162,10 +125,6 @@ function resolveStorage(storage?: StorageLike | null): StorageLike | null {
     return localStorage
   }
   return null
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object'
 }
 
 /**
@@ -257,122 +216,31 @@ export function setAuthBundle(
   persistAuthSession(storage, bundle.access_token, ttlMs, nowMs)
 }
 
-/**
- * Build an AuthBundle from the currently stored token, when it is still
- * valid. user/session are unavailable from storage alone (TODO: hydrate from
- * /api/settings/auth/info once the auth-store bootstrap lands).
- */
-
-export function getAuthSession(
-  storage?: StorageLike | null,
-  nowMs: number = Date.now()
-): LoginSession | null {
-  // TODO(stores): return the live LoginSession from the Zustand auth-store.
-  // Storage-only tokens carry no session metadata, so the SID used for GET
-  // dedup falls back to 'anonymous' until the store lands.
-  void storage
-  void nowMs
-  return null
-}
-
-export function clearAuthentication(
-  synchronizeTabs = true,
-  _bootstrapState: AuthBootstrapState = 'complete'
-): void {
+export function clearAuthentication(): void {
   clearAuthSession()
-  authEpoch += 1
-  if (synchronizeTabs) {
-    publishAuthSessionEvent('signed_out')
-  }
 }
 
 /**
- * Apply a token rotation received in a response body (newapi-style).
- * metapi-go's backend does not currently rotate tokens, so this is a parity
- * stub that persists the bundle when one is present.
+ * Re-read storage after a 401 so a token replaced by another tab can be used
+ * for one retry. The backend has no refresh endpoint; without a newer valid
+ * token the session is cleared and the caller redirects to sign-in.
  */
-export function applyAuthRotation(value: unknown): void {
-  if (!isAuthBundle(value)) return
-  setAuthBundle(value)
-  authEpoch += 1
-  publishAuthSessionEvent('authenticated')
-}
-
-// ---------------------------------------------------------------------------
-// refreshAuthentication — single-flight + backoff scaffold (STUB)
-//
-// metapi-go has no /auth/refresh endpoint yet: the legacy client simply
-// cleared the token and reloaded the page on 401. To preserve that behaviour
-// while leaving the newapi-style refresh structure in place, the stub:
-//   1. single-flights concurrent callers onto one promise,
-//   2. returns 'authenticated' if the stored token is still valid,
-//   3. otherwise clears and returns 'anonymous' (so the 401 path redirects
-//      to /sign-in, matching the legacy reload-on-expiry behaviour).
-//
-// TODO(refresh): wire the real refresh endpoint (and 409 race/mismatch
-// handling) once the backend exposes one. The race-delay constants below are
-// kept from newapi so the backoff ladder is ready to fill in.
-// ---------------------------------------------------------------------------
-
-const refreshRaceDelays = [80, 200, 500] as const
-let refreshPromise: Promise<RefreshOutcome> | null = null
-let authEpoch = 0
-
-function waitForRefreshRace(delay: number): Promise<void> {
-  return new Promise((resolve) => globalThis.setTimeout(resolve, delay))
-}
-
-export function refreshAuthentication(): Promise<RefreshOutcome> {
-  if (!refreshPromise) {
-    refreshPromise = (async (): Promise<RefreshOutcome> => {
-      const bundle = currentValidAuthBundle()
-      if (bundle) {
-        return { kind: 'authenticated', bundle }
-      }
-
-      // TODO(refresh): call the real refresh endpoint here, then parse the
-      // AuthBundle and applyAuthRotation it. For now, no refresh endpoint
-      // exists, so clear and report anonymous — the 401 interceptor will
-      // redirect to /sign-in, matching the legacy reload-on-expiry flow.
-      void refreshRaceDelays
-      void waitForRefreshRace
-      clearAuthentication(true)
-      return { kind: 'anonymous' }
-    })().finally(() => {
-      refreshPromise = null
-    })
-  }
-  return refreshPromise
-}
-
-export async function bootstrapAuthentication(): Promise<RefreshOutcome> {
+export function resolveAuthenticationAfterUnauthorized(): AuthenticationOutcome {
   const bundle = currentValidAuthBundle()
   if (bundle) {
     return { kind: 'authenticated', bundle }
   }
-  return refreshAuthentication()
+
+  clearAuthentication()
+  return { kind: 'anonymous' }
 }
 
-// ---------------------------------------------------------------------------
-// Tab sync (STUB)
-//
-// newapi uses a dedicated auth-session-sync module + BroadcastChannel to keep
-// the Zustand auth-store in step across tabs. metapi-go's storage-only token
-// means cross-tab sync is mostly handled by the storage event already; the
-// structured publish/subscribe here is a parity scaffold for when the store
-// lands.
-//
-// TODO(tab-sync): wire auth-session-sync events into the Zustand store.
-// ---------------------------------------------------------------------------
+export function bootstrapAuthentication(): AuthenticationOutcome {
+  const bundle = currentValidAuthBundle()
+  if (bundle) {
+    return { kind: 'authenticated', bundle }
+  }
 
-type AuthSessionEventName = 'authenticated' | 'signed_out'
-const AUTH_SESSION_CHANNEL_NAME = 'metapi-go:auth-session'
-
-let authSessionChannel: BroadcastChannel | null = null
-
-function resolveAuthSessionChannel(): BroadcastChannel | null {
-  if (authSessionChannel) return authSessionChannel
-  if (typeof BroadcastChannel === 'undefined') return null
-  authSessionChannel = new BroadcastChannel(AUTH_SESSION_CHANNEL_NAME)
-  return authSessionChannel
+  clearAuthentication()
+  return { kind: 'anonymous' }
 }

--- a/web/src/lib/http-client.ts
+++ b/web/src/lib/http-client.ts
@@ -2,12 +2,10 @@ import axios, { type AxiosRequestConfig } from 'axios'
 
 import i18n from '@/i18n/config'
 import {
-  applyAuthRotation,
   clearAuthentication,
   clearAuthSession,
   getAccessToken,
-  getAuthSession,
-  refreshAuthentication,
+  resolveAuthenticationAfterUnauthorized,
 } from '@/lib/auth-session'
 import { toast } from '@/lib/toast'
 
@@ -19,12 +17,10 @@ declare module 'axios' {
     skipErrorHandler?: boolean
     /** Skip GET request dedup for this call. */
     disableDuplicate?: boolean
-    /** Skip the 401 → refresh → replay flow (used by the refresh call itself). */
-    skipAuthRefresh?: boolean
+    /** Skip the 401 → storage re-read → one replay flow. */
+    skipAuthRetry?: boolean
     /** Marker set on a request that is already a 401 retry, to avoid loops. */
     authRetry?: boolean
-    /** Apply an auth-rotation bundle found in `response.data.data`. */
-    acceptAuthRotation?: boolean
   }
 }
 
@@ -47,8 +43,8 @@ export const apiClient = axios.create({
 })
 
 // ---------------------------------------------------------------------------
-// GET dedup — collapse identical in-flight GETs onto one promise per
-// (session SID, url, params). Disabled per-request via `disableDuplicate`.
+// GET dedup — collapse identical in-flight GETs by URL and params.
+// Disabled per-request via `disableDuplicate`.
 // ---------------------------------------------------------------------------
 
 const inFlightGet = new Map<string, Promise<unknown>>()
@@ -58,8 +54,7 @@ apiClient.get = ((url: string, config: ApiRequestConfig = {}) => {
   if (config.disableDuplicate) return originalGet(url, config)
 
   const params = config.params ? JSON.stringify(config.params) : '{}'
-  const sessionSID = getAuthSession()?.sid || 'anonymous'
-  const key = `${sessionSID}:${url}?${params}`
+  const key = `${url}?${params}`
   const existingRequest = inFlightGet.get(key)
   if (existingRequest) return existingRequest
 
@@ -83,8 +78,8 @@ apiClient.interceptors.request.use((config) => {
 })
 
 // ---------------------------------------------------------------------------
-// Response + error interceptors — business error toasts, 401 refresh+replay,
-// and a catch-all error toast.
+// Response + error interceptors — business error toasts, one 401 replay when
+// another tab replaced the token, and a catch-all error toast.
 // ---------------------------------------------------------------------------
 
 function redirectToSignIn(): void {
@@ -108,10 +103,6 @@ function resolveResponseMessage(data: unknown): string | undefined {
 
 apiClient.interceptors.response.use(
   (response) => {
-    if (response.config.acceptAuthRotation && response.data?.success === true) {
-      applyAuthRotation(response.data.data)
-    }
-
     if (
       !response.config.skipBusinessError &&
       typeof response.data?.success === 'boolean' &&
@@ -129,9 +120,9 @@ apiClient.interceptors.response.use(
     const status = error?.response?.status
 
     if (status === 401) {
-      if (config && !config.skipAuthRefresh && !config.authRetry) {
+      if (config && !config.skipAuthRetry && !config.authRetry) {
         config.authRetry = true
-        const outcome = await refreshAuthentication()
+        const outcome = resolveAuthenticationAfterUnauthorized()
         if (outcome.kind === 'authenticated') {
           const token = getAccessToken()
           if (token) {
@@ -143,11 +134,10 @@ apiClient.interceptors.response.use(
           return apiClient.request(config)
         }
 
-        // anonymous / out_of_sync / transient_error — treat as signed out.
         if (!skipErrorHandler) toast.error(i18n.t('common.sessionExpired'))
         redirectToSignIn()
       } else if (config?.authRetry) {
-        clearAuthentication(false)
+        clearAuthentication()
         if (!skipErrorHandler) toast.error(i18n.t('common.sessionExpired'))
         redirectToSignIn()
       } else if (!skipErrorHandler) {
@@ -172,7 +162,7 @@ apiClient.interceptors.response.use(
 // Auth + timeout + 401 handling mirror the legacy `fetchAuthenticatedResponse`
 // contract so the streaming method bodies in api.ts stay byte-for-byte
 // faithful. 401/403 here clear the session and reload the page (legacy
-// behaviour); the axios path above does refresh+replay instead.
+// behaviour); the axios path above re-reads storage and retries once instead.
 // ---------------------------------------------------------------------------
 
 export type FetchAuthenticatedOptions = RequestInit & {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,10 +2,6 @@
 // Orchestrates: QueryClient (retry/401/403/500/staleTime) → RouterProvider
 // (TanStack Router, routeTree.gen.ts) → 3-layer Provider stack
 // (Theme → Direction → ThemeCustomization).
-//
-// Adapted from newapi web/src/main.tsx. Dropped system-branding bootstrap
-// (status/favicon) and legacy-route resolver — phase 2 will wire those once
-// the status hook + legacy-route map land.
 
 import {
   QueryCache,
@@ -52,16 +48,11 @@ const queryClient = new QueryClient({
       refetchOnWindowFocus: false,
       staleTime: 10 * 1000, // 10s
     },
-    mutations: {
-      // Skeleton: no global mutation error handler — features own their error
-      // display. TODO(phase2): wire @/lib/handle-server-error once it lands.
-    },
   },
   queryCache: new QueryCache({
     onError: (error) => {
       if (error instanceof AxiosError && error.response?.status === 500) {
         toast.error(i18next.t('errors.internalServerError'))
-        // TODO(phase2): router.navigate({ to: '/500' }) once error routes land
       }
     },
   }),


### PR DESCRIPTION
## Summary
删除不存在后端支持的 auth refresh/rotation scaffold，收敛 401 处理：
- 移除 `refreshAuthentication` / `applyAuthRotation` / `acceptAuthRotation` / BroadcastChannel 双轨。
- 401 收敛为一次有效 bundle 重读 + 重放（`skipAuthRefresh` → 真实语义 `skipAuthRetry`）。
- 删除过期计划与 speculative TODO 注释。
- 新增 `auth-session` / `http-client` 聚焦回归测试（13 用例），保护真实契约。

## Test plan
- `bun run typecheck` / `lint` / `knip` / `test`（395 tests / 37 files）