### PR TITLE
feat(web): channel targeting and sync-only tester truth

### DIFF
--- a/web/src/features/channels/__tests__/channels-envelope.test.ts
+++ b/web/src/features/channels/__tests__/channels-envelope.test.ts
@@ -1,0 +1,54 @@
+// metapi-go/features/channels — envelope parsing regression tests.
+//
+// GET /api/channels returns `{items,total,page,pageSize}`, not a bare array.
+// These tests pin the parser to the real contract: a well-formed envelope
+// yields its items, an empty list stays empty, and any malformed body throws
+// (so the query fails explicitly instead of rendering an empty table).
+
+import { describe, expect, it } from 'vitest'
+
+import { parseChannelsEnvelope } from '../api'
+
+const sampleItem = { id: 1, name: 'channel-1' }
+
+describe('parseChannelsEnvelope', () => {
+  it('extracts items from a well-formed envelope', () => {
+    const items = [sampleItem]
+    const envelope = { items, total: 1, page: 1, pageSize: 50 }
+    expect(parseChannelsEnvelope(envelope)).toBe(items)
+  })
+
+  it('returns an empty array for an empty items array', () => {
+    expect(
+      parseChannelsEnvelope({ items: [], total: 0, page: 1, pageSize: 50 })
+    ).toEqual([])
+  })
+
+  it('throws when the items field is missing', () => {
+    expect(() =>
+      parseChannelsEnvelope({ total: 0, page: 1, pageSize: 50 })
+    ).toThrow('Invalid channels response')
+  })
+
+  it('throws when items is not an array', () => {
+    expect(() => parseChannelsEnvelope({ items: 'not-an-array' })).toThrow(
+      'Invalid channels response'
+    )
+  })
+
+  it('throws for a null or undefined body', () => {
+    expect(() => parseChannelsEnvelope(null)).toThrow(
+      'Invalid channels response'
+    )
+    expect(() => parseChannelsEnvelope(undefined)).toThrow(
+      'Invalid channels response'
+    )
+  })
+
+  it('throws for a primitive body', () => {
+    expect(() => parseChannelsEnvelope('channels')).toThrow(
+      'Invalid channels response'
+    )
+    expect(() => parseChannelsEnvelope(42)).toThrow('Invalid channels response')
+  })
+})

--- a/web/src/features/channels/api.ts
+++ b/web/src/features/channels/api.ts
@@ -1,12 +1,34 @@
 // metapi-go/features/channels — TanStack Query hook wrapping `lib/api.ts`.
-// GET /api/channels returns the full read-only list, so `useChannels` is a
-// single query and the table does client-side filtering/sorting/pagination.
+// GET /api/channels returns a paginated envelope
+// `{items: ChannelRow[], total, page, pageSize}` (see handler/admin/channels.go),
+// so `useChannels` parses the envelope and surfaces only the `items` array as
+// the read-only list. The table still filters/sorts/pages client-side.
 
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 
 import { api } from '@/lib/api'
 
 import { channelsKeys, type ChannelRow } from './types'
+
+/**
+ * Parse the GET /api/channels envelope. Returns the `items` array when the
+ * body is a well-formed `{items: [...]}` object; throws otherwise so a
+ * malformed body fails the query explicitly instead of masquerading as an
+ * empty list.
+ */
+export function parseChannelsEnvelope(result: unknown): ChannelRow[] {
+  if (result && typeof result === 'object') {
+    const items = (result as { items?: unknown }).items
+    if (Array.isArray(items)) return items as ChannelRow[]
+  }
+  throw new Error('Invalid channels response')
+}
+
+/** Shared queryFn for the channels list (route loader + useChannels). */
+export async function getChannelsList(): Promise<ChannelRow[]> {
+  const result = await api.getChannels()
+  return parseChannelsEnvelope(result)
+}
 
 export function useChannels(
   queryOptions?: Omit<
@@ -16,10 +38,7 @@ export function useChannels(
 ) {
   return useQuery<ChannelRow[], Error>({
     queryKey: channelsKeys.list(),
-    queryFn: async () => {
-      const result = await api.getChannels()
-      return (result ?? []) as ChannelRow[]
-    },
+    queryFn: getChannelsList,
     staleTime: 10 * 1000,
     ...queryOptions,
   })

--- a/web/src/features/channels/index.ts
+++ b/web/src/features/channels/index.ts
@@ -1,3 +1,4 @@
 // metapi-go/features/channels — barrel re-exports.
 export { channelsSearchSchema } from './lib/channels-schema'
+export { getChannelsList } from './api'
 export { channelsKeys } from './types'

--- a/web/src/features/channels/index.ts
+++ b/web/src/features/channels/index.ts
@@ -1,4 +1,4 @@
 // metapi-go/features/channels — barrel re-exports.
 export { channelsSearchSchema } from './lib/channels-schema'
-export { getChannelsList } from './api'
+export { getChannelsList, useChannels } from './api'
 export { channelsKeys } from './types'

--- a/web/src/features/model-tester/__tests__/api.test.ts
+++ b/web/src/features/model-tester/__tests__/api.test.ts
@@ -1,10 +1,10 @@
 // metapi-go/features/model-tester — error-mapping + payload unit tests.
 //
 // `resolveTestResponseError` turns non-ok test responses into user-facing
-// messages: backend 501s are known limitations (no fake SSE stream; the sync
-// harness requires a forced channel) and map to a friendly localized key
-// instead of the raw "not implemented" text. `buildChatPayload` renders the
-// conversation history into the request `messages` array.
+// messages: backend 501s are known limitations (the sync harness requires a
+// forced channel) and map to a friendly localized key instead of the raw
+// "not implemented" text. `buildChatPayload` renders the conversation history
+// into the request `messages` array and forwards the targeted `channelId`.
 
 import { describe, expect, it } from 'vitest'
 
@@ -20,7 +20,6 @@ function formValues(overrides: Partial<TestFormValues> = {}): TestFormValues {
     temperature: 0.7,
     topP: 1,
     maxTokens: 1024,
-    stream: true,
     ...overrides,
   }
 }
@@ -60,8 +59,17 @@ describe('buildChatPayload', () => {
     expect(payload.temperature).toBe(0.2)
     expect(payload.top_p).toBe(0.9)
     expect(payload.max_tokens).toBeUndefined()
-    expect(payload.stream).toBe(true)
     expect(payload.targetFormat).toBe('openai')
+  })
+
+  it('forwards channelId when a channel is targeted', () => {
+    const payload = buildChatPayload(formValues({ channelId: 42 }))
+    expect(payload.channelId).toBe(42)
+  })
+
+  it('omits channelId when no channel is targeted', () => {
+    const payload = buildChatPayload(formValues())
+    expect(payload.channelId).toBeUndefined()
   })
 })
 
@@ -72,19 +80,6 @@ describe('resolveTestResponseError', () => {
         success: false,
         message:
           'Chat test requires channelId, siteId, or forcedChannelId for the forced-channel harness',
-      }),
-      { status: 501 }
-    )
-    expect(await resolveTestResponseError(response)).toBe(
-      'modelTester.error.notAvailable'
-    )
-  })
-
-  it('maps the stream 501 (SSE not implemented) to notAvailable', async () => {
-    const response = new Response(
-      JSON.stringify({
-        success: false,
-        message: 'Chat stream test is not implemented in Go',
       }),
       { status: 501 }
     )

--- a/web/src/features/model-tester/__tests__/tester-schema.test.ts
+++ b/web/src/features/model-tester/__tests__/tester-schema.test.ts
@@ -212,7 +212,10 @@ describe('testerSchema — no coercion + enum', () => {
   })
 
   it('accepts an omitted channelId (optional channel targeting)', () => {
-    const result = testerSchema.safeParse({ ...validInput(), channelId: undefined })
+    const result = testerSchema.safeParse({
+      ...validInput(),
+      channelId: undefined,
+    })
     expect(result.success).toBe(true)
   })
 })

--- a/web/src/features/model-tester/__tests__/tester-schema.test.ts
+++ b/web/src/features/model-tester/__tests__/tester-schema.test.ts
@@ -14,7 +14,6 @@ function validOverrides(): Partial<TesterFormValues> {
     temperature: 0.7,
     topP: 1,
     maxTokens: 1024,
-    stream: false,
   }
 }
 
@@ -204,12 +203,17 @@ describe('testerSchema — no coercion + enum', () => {
     expect(result.error.issues[0]?.message).toContain('Invalid option')
   })
 
-  it('rejects a string stream flag (no coerce)', () => {
+  it('rejects a non-integer channelId (no coerce)', () => {
     const result = testerSchema.safeParse({
       ...validInput(),
-      stream: 'true' as unknown as boolean,
+      channelId: '42' as unknown as number,
     })
     expect(result.success).toBe(false)
+  })
+
+  it('accepts an omitted channelId (optional channel targeting)', () => {
+    const result = testerSchema.safeParse({ ...validInput(), channelId: undefined })
+    expect(result.success).toBe(true)
   })
 })
 
@@ -221,13 +225,13 @@ describe('TESTER_FORM_DEFAULT_VALUES', () => {
   it('exposes the canonical default form shape', () => {
     expect(TESTER_FORM_DEFAULT_VALUES).toEqual({
       model: '',
+      channelId: undefined,
       systemPrompt: '',
       prompt: '',
       targetFormat: 'openai',
       temperature: 0.7,
       topP: 1,
       maxTokens: 1024,
-      stream: false,
     })
   })
 

--- a/web/src/features/model-tester/api.ts
+++ b/web/src/features/model-tester/api.ts
@@ -2,22 +2,25 @@
 // metapi-go/features/model-tester — TanStack Query mutation for the chat test.
 //
 // `useTestModel` is a `useMutation` whose `mutationFn` runs the chat test:
-// with `stream: true` it opens the SSE stream (`api.testChatStream`) and
-// consumes it in a reader loop; otherwise it posts a single sync request
-// (`api.testChatSync`) and parses the JSON body as one delta. Both paths
-// normalize across OpenAI / Claude / Responses / Gemini protocols (ported
-// from the legacy `pages/ModelTester.tsx` parser). Each parsed delta is
-// forwarded to the caller's `onDelta` callback so the response viewer can
-// render content/reasoning as it arrives; when the test finishes the
-// resolved `TestResponse` summary is returned and `onDone` fires. The
-// caller passes an `AbortSignal` so the Stop button cancels an in-flight
-// test.
+// it posts a single sync request (`api.testChatSync`) to `/api/test/chat`
+// (the forced-channel harness) and parses the JSON body as one delta,
+// normalizing across OpenAI / Claude / Responses / Gemini protocols (ported
+// from the legacy `pages/ModelTester.tsx` parser). The single delta is
+// forwarded to the caller's `onDelta` callback so the response viewer renders
+// the content/reasoning; when the test finishes the resolved `TestResponse`
+// summary is returned and `onDone` fires. The caller passes an `AbortSignal`
+// so the Stop button cancels an in-flight test.
+//
+// The tester is sync-only by design: the Go backend returns an honest 501 for
+// `/api/test/chat/stream` (SSE is not implemented), so the UI no longer offers
+// a stream toggle or a synthetic chunk path. `resolveTestResponseError` maps
+// that 501 residual (and the "requires channelId" residual) to a friendly
+// localized key.
 //
 // `buildChatPayload` renders the conversation history into the request
 // `messages` array (system → prior user/assistant turns → current prompt)
-// so multi-turn context travels on the wire. Backends that only consume a
-// single message keep working: they ignore the extra entries and read the
-// last user prompt.
+// so multi-turn context travels on the wire, and forwards the selected
+// `channelId` when the operator targets a specific channel.
 //
 // A mutation (rather than a query) is the right shape here: the test is a
 // user-initiated command with a single terminal resolution, not a cacheable
@@ -37,8 +40,6 @@ import type {
   TestStreamDelta,
 } from './types'
 
-const MAX_RAW_EVENTS = 200
-
 export function buildChatPayload(
   values: TestFormValues,
   history: ChatMessage[] = []
@@ -54,8 +55,8 @@ export function buildChatPayload(
   return {
     model: values.model,
     messages,
+    ...(values.channelId ? { channelId: values.channelId } : {}),
     targetFormat: values.targetFormat,
-    stream: values.stream,
     temperature: values.temperature,
     top_p: values.topP,
     max_tokens: values.maxTokens > 0 ? values.maxTokens : undefined,
@@ -76,27 +77,8 @@ function extractErrorMessage(payload: unknown): string {
   return typeof message === 'string' ? message : ''
 }
 
-function parseSseBlock(block: string): { event: string; data: string | null } {
-  const lines = block.split(/\r?\n/)
-  let event = 'message'
-  const dataLines: string[] = []
-  for (const line of lines) {
-    if (line.startsWith('event:')) {
-      event = line.slice(6).trim()
-      continue
-    }
-    if (line.startsWith('data:')) {
-      dataLines.push(line.slice(5).trimStart())
-    }
-  }
-  return {
-    event,
-    data: dataLines.length > 0 ? dataLines.join('\n') : null,
-  }
-}
-
 /**
- * Normalize a parsed SSE event payload into a content/reasoning/done delta.
+ * Normalize a parsed event payload into a content/reasoning/done delta.
  * Faithful port of the legacy `parseAnyStreamDelta`: handles OpenAI
  * `choices[].delta`, Anthropic `content_block_delta` / `message_stop`,
  * Responses-API `response.output_text.delta` /
@@ -263,152 +245,80 @@ export async function resolveTestResponseError(
 }
 
 /**
- * Run a single chat test (streaming or sync, per `payload.stream`). Streams
- * forward each parsed delta to `onDelta` and resolve to a `TestResponse`
- * summary when the stream closes; sync mode parses the single JSON body as
- * one delta. Throws on auth failure, non-ok responses, or caller abort.
+ * Run a single sync chat test. Posts to `/api/test/chat` (the forced-channel
+ * harness) and parses the single JSON body as one delta so the viewer renders
+ * the final content. Forwards the delta to `onDelta` and resolves to a
+ * `TestResponse` summary; throws on auth failure, non-ok responses, or caller
+ * abort.
  */
-async function runTestStream(
+async function runChatTest(
   variables: TestModelVariables
 ): Promise<TestResponse> {
   const { payload, history, onDelta, onDone, signal } = variables
   const chatPayload = buildChatPayload(payload, history)
   const startedAt = performance.now()
 
-  let content = ''
-  let reasoningContent = ''
-  let doneReceived = false
-  let chunks = 0
-  const rawEvents: string[] = []
-
-  const response = payload.stream
-    ? await api.testChatStream(chatPayload, signal)
-    : await api.testChatSync(chatPayload, signal)
+  const response = await api.testChatSync(chatPayload, signal)
 
   if (!response.ok) {
     throw new Error(await resolveTestResponseError(response))
   }
-  if (!response.body) {
-    throw new Error('modelTester.error.emptyStream')
-  }
 
-  // Non-streaming mode: the backend returns a single JSON body. Parse it as
-  // one delta so the viewer still renders the final content.
-  if (!payload.stream) {
-    const text = await response.text()
-    if (text) {
-      rawEvents.push(text)
-      try {
-        const parsed = JSON.parse(text) as unknown
-        const errorText = extractErrorMessage(parsed)
-        if (errorText) {
-          const summary: TestResponse = {
-            content: '',
-            reasoningContent: '',
-            doneReceived: true,
-            latencyMs: Math.round(performance.now() - startedAt),
-            chunks: 1,
-            rawEvents,
-            empty: true,
-            error: errorText,
-          }
-          onDone?.(summary)
-          return summary
-        }
-        const delta = parseAnyStreamDelta(parsed)
-        content = delta.contentDelta ?? ''
-        reasoningContent = delta.reasoningDelta ?? ''
-        doneReceived = Boolean(delta.done)
-      } catch {
-        content = text
-        doneReceived = true
-      }
-    }
-    const summary: TestResponse = {
-      content,
-      reasoningContent,
-      doneReceived,
-      latencyMs: Math.round(performance.now() - startedAt),
-      chunks: 1,
-      rawEvents,
-      empty: !content && !reasoningContent,
-    }
-    onDelta?.({
-      contentDelta: content,
-      reasoningDelta: reasoningContent,
-      done: true,
-    })
-    onDone?.(summary)
-    return summary
-  }
+  let content = ''
+  let reasoningContent = ''
+  let doneReceived = false
+  const rawEvents: string[] = []
 
-  const reader = response.body.getReader()
-  const decoder = new TextDecoder()
-  let buffer = ''
-
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    if (!value) continue
-
-    buffer += decoder.decode(value, { stream: true })
-    const events = buffer.split(/\r?\n\r?\n/)
-    buffer = events.pop() ?? ''
-
-    for (const eventBlock of events) {
-      const parsed = parseSseBlock(eventBlock)
-      if (!parsed.data) continue
-
-      rawEvents.push(parsed.data)
-      if (rawEvents.length > MAX_RAW_EVENTS) {
-        rawEvents.splice(0, rawEvents.length - MAX_RAW_EVENTS)
-      }
-      chunks += 1
-
-      if (parsed.data === '[DONE]') {
-        doneReceived = true
-        continue
-      }
-
-      let eventPayload: unknown
-      try {
-        eventPayload = JSON.parse(parsed.data)
-      } catch {
-        continue
-      }
-
-      const errorText = extractErrorMessage(eventPayload)
+  const text = await response.text()
+  if (text) {
+    rawEvents.push(text)
+    try {
+      const parsed = JSON.parse(text) as unknown
+      const errorText = extractErrorMessage(parsed)
       if (errorText) {
-        throw new Error(errorText)
+        const summary: TestResponse = {
+          content: '',
+          reasoningContent: '',
+          doneReceived: true,
+          latencyMs: Math.round(performance.now() - startedAt),
+          chunks: 1,
+          rawEvents,
+          empty: true,
+          error: errorText,
+        }
+        onDone?.(summary)
+        return summary
       }
-
-      const delta = parseAnyStreamDelta(eventPayload)
-      if (delta.contentDelta) content += delta.contentDelta
-      if (delta.reasoningDelta) reasoningContent += delta.reasoningDelta
-      if (delta.done) doneReceived = true
-      if (delta.contentDelta || delta.reasoningDelta || delta.done) {
-        onDelta?.(delta)
-      }
+      const delta = parseAnyStreamDelta(parsed)
+      content = delta.contentDelta ?? ''
+      reasoningContent = delta.reasoningDelta ?? ''
+      doneReceived = Boolean(delta.done)
+    } catch {
+      content = text
+      doneReceived = true
     }
   }
 
-  const latencyMs = Math.round(performance.now() - startedAt)
-  const empty = !content && !reasoningContent
   const summary: TestResponse = {
     content,
     reasoningContent,
     doneReceived,
-    latencyMs,
-    chunks,
+    latencyMs: Math.round(performance.now() - startedAt),
+    chunks: 1,
     rawEvents,
-    empty,
+    empty: !content && !reasoningContent,
   }
+  onDelta?.({
+    contentDelta: content,
+    reasoningDelta: reasoningContent,
+    done: true,
+  })
   onDone?.(summary)
   return summary
 }
 
 export function useTestModel() {
   return useMutation<TestResponse, Error, TestModelVariables>({
-    mutationFn: runTestStream,
+    mutationFn: runChatTest,
   })
 }

--- a/web/src/features/model-tester/components/test-form.tsx
+++ b/web/src/features/model-tester/components/test-form.tsx
@@ -2,11 +2,12 @@
 //
 // Renders the left column of the tester: a local template picker (fills
 // the prompt + sampling parameters from the localStorage template library),
-// model picker (populated from the models marketplace via `useModels`),
-// target protocol format, system + user prompts, and sampling parameters
-// (temperature / top_p / max_tokens / stream). The parent owns the
-// run/stop lifecycle; this form only emits validated values on submit.
-// When `defaultModel` is provided (deep link from the marketplace
+// model picker (populated from the models marketplace via `useModels`), a
+// channel picker (populated from the channels list via `useChannels`, targeting
+// the forced-channel sync harness), target protocol format, system + user
+// prompts, and sampling parameters (temperature / top_p / max_tokens). The
+// parent owns the run/stop lifecycle; this form only emits validated values on
+// submit. When `defaultModel` is provided (deep link from the marketplace
 // `/models?...` → `/model-tester?model=…`) the model field is pre-selected
 // as soon as the marketplace list loads.
 
@@ -35,8 +36,8 @@ import {
 } from '@/components/ui/select'
 import { Slider } from '@/components/ui/slider'
 import { Spinner } from '@/components/ui/spinner'
-import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
+import { useChannels } from '@/features/channels'
 import { useModels } from '@/features/models'
 import { cn } from '@/lib/utils'
 
@@ -72,6 +73,7 @@ export function TestForm({
 }: TestFormProps) {
   const { t } = useTranslation()
   const modelsQuery = useModels()
+  const channelsQuery = useChannels()
 
   const form = useForm<TesterFormValues>({
     resolver: zodResolver(testerSchema),
@@ -188,6 +190,55 @@ export function TestForm({
                   {t('modelTester.form.modelLoading')}
                 </FormDescription>
               )}
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name='channelId'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('modelTester.form.channel')}</FormLabel>
+              <Select
+                value={field.value ? String(field.value) : 'none'}
+                onValueChange={(value) =>
+                  field.onChange(value === 'none' ? undefined : Number(value))
+                }
+                disabled={isRunning}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue>
+                      {(selected) => {
+                        if (!selected || selected === 'none') {
+                          return t('modelTester.form.channelNone')
+                        }
+                        const channel = (channelsQuery.data ?? []).find(
+                          (item) => String(item.id) === selected
+                        )
+                        return channel
+                          ? `${channel.name} · ${channel.site.name}`
+                          : String(selected)
+                      }}
+                    </SelectValue>
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value='none'>
+                    {t('modelTester.form.channelNone')}
+                  </SelectItem>
+                  {(channelsQuery.data ?? []).map((channel) => (
+                    <SelectItem key={channel.id} value={String(channel.id)}>
+                      {channel.name} · {channel.site.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormDescription>
+                {t('modelTester.form.channelHint')}
+              </FormDescription>
               <FormMessage />
             </FormItem>
           )}
@@ -333,61 +384,38 @@ export function TestForm({
           />
         </div>
 
-        <div className='grid gap-4 sm:grid-cols-2'>
-          <FormField
-            control={form.control}
-            name='maxTokens'
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>{t('modelTester.form.maxTokens')}</FormLabel>
-                <FormControl>
-                  <Input
-                    type='number'
-                    min={0}
-                    step={1}
-                    value={field.value}
-                    onChange={(event) =>
-                      field.onChange(
-                        Number.isNaN(event.target.valueAsNumber)
-                          ? 0
-                          : event.target.valueAsNumber
-                      )
-                    }
-                    onBlur={field.onBlur}
-                    name={field.name}
-                    ref={field.ref}
-                    disabled={isRunning}
-                  />
-                </FormControl>
-                <FormDescription>
-                  {t('modelTester.form.maxTokensHint')}
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name='stream'
-            render={({ field }) => (
-              <FormItem className='flex flex-row items-center justify-between rounded-lg border p-3'>
-                <div className='space-y-0.5'>
-                  <FormLabel>{t('modelTester.form.stream')}</FormLabel>
-                  <FormDescription>
-                    {t('modelTester.form.streamHint')}
-                  </FormDescription>
-                </div>
-                <FormControl>
-                  <Switch
-                    checked={field.value}
-                    onCheckedChange={field.onChange}
-                    disabled={isRunning}
-                  />
-                </FormControl>
-              </FormItem>
-            )}
-          />
-        </div>
+        <FormField
+          control={form.control}
+          name='maxTokens'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('modelTester.form.maxTokens')}</FormLabel>
+              <FormControl>
+                <Input
+                  type='number'
+                  min={0}
+                  step={1}
+                  value={field.value}
+                  onChange={(event) =>
+                    field.onChange(
+                      Number.isNaN(event.target.valueAsNumber)
+                        ? 0
+                        : event.target.valueAsNumber
+                    )
+                  }
+                  onBlur={field.onBlur}
+                  name={field.name}
+                  ref={field.ref}
+                  disabled={isRunning}
+                />
+              </FormControl>
+              <FormDescription>
+                {t('modelTester.form.maxTokensHint')}
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <div className={cn('mt-auto flex gap-2')}>
           {isRunning ? (

--- a/web/src/features/model-tester/lib/tester-schema.ts
+++ b/web/src/features/model-tester/lib/tester-schema.ts
@@ -1,8 +1,10 @@
 // metapi-go/features/model-tester — Zod form schema.
 //
-// Validates the test form: model (required), system prompt (optional),
-// user prompt (required), target protocol format, and sampling parameters
-// (temperature / top_p / max_tokens / stream). Numeric fields use plain
+// Validates the test form: model (required), target channel (optional —
+// absent means the backend's honest 501 "requires channelId" residual, since
+// the sync harness only runs against a forced channel), system prompt
+// (optional), user prompt (required), target protocol format, and sampling
+// parameters (temperature / top_p / max_tokens). Numeric fields use plain
 // `z.number()` (no `z.coerce`/`.default()`) so the zod resolver's input and
 // output types match and RHF typing stays clean; the form binds them with an
 // explicit `onChange` that converts via `valueAsNumber`. Error messages are
@@ -21,6 +23,7 @@ const TARGET_FORMATS = [
 
 export const testerSchema = z.object({
   model: z.string().trim().min(1, 'modelTester.form.errors.modelRequired'),
+  channelId: z.number().int().positive().optional(),
   systemPrompt: z.string().max(4000, 'modelTester.form.errors.systemTooLong'),
   prompt: z
     .string()
@@ -41,18 +44,17 @@ export const testerSchema = z.object({
     .int('modelTester.form.errors.maxTokensInteger')
     .min(0, 'modelTester.form.errors.maxTokensMin')
     .max(128000, 'modelTester.form.errors.maxTokensMax'),
-  stream: z.boolean(),
 })
 
 export type TesterFormValues = z.infer<typeof testerSchema>
 
 export const TESTER_FORM_DEFAULT_VALUES: TesterFormValues = {
   model: '',
+  channelId: undefined,
   systemPrompt: '',
   prompt: '',
   targetFormat: 'openai',
   temperature: 0.7,
   topP: 1,
   maxTokens: 1024,
-  stream: false,
 }

--- a/web/src/features/model-tester/types.ts
+++ b/web/src/features/model-tester/types.ts
@@ -1,11 +1,10 @@
 // metapi-go/features/model-tester — domain types for the model tester.
 //
-// The tester drives `api.testChatStream`, which POSTs a
-// `TestChatRequestPayload` to `/api/test/chat/stream` and returns a raw
-// `Response` whose body is an SSE stream. These types model the request
-// envelope, the per-chunk delta (normalized across OpenAI / Claude /
-// Responses / Gemini protocols), and the finalised response the viewer
-// renders after the stream closes.
+// The tester drives `api.testChatSync`, which POSTs a `ChatTestPayload` to
+// `/api/test/chat` (the forced-channel harness) and returns a single JSON
+// body. These types model the request envelope, the normalized response
+// delta (across OpenAI / Claude / Responses / Gemini protocols), and the
+// finalised response the viewer renders after the run finishes.
 
 export type TestTargetFormat = 'openai' | 'claude' | 'responses' | 'gemini'
 
@@ -23,19 +22,21 @@ export type ChatMessage = {
 
 /**
  * Form values produced by `testerSchema`. The tester builds the
- * `TestChatRequestPayload.messages` array from `systemPrompt` (role=system,
- * when present) + `prompt` (role=user). Numeric fields are plain `z.number()`
- * so RHF input/output types match.
+ * `ChatTestPayload.messages` array from `systemPrompt` (role=system, when
+ * present) + `prompt` (role=user). `channelId` targets a specific channel via
+ * the forced-channel harness; when absent the backend returns its honest 501
+ * "requires channelId" residual. Numeric fields are plain `z.number()` so RHF
+ * input/output types match.
  */
 export type TestFormValues = {
   model: string
+  channelId?: number
   systemPrompt: string
   prompt: string
   targetFormat: TestTargetFormat
   temperature: number
   topP: number
   maxTokens: number
-  stream: boolean
 }
 
 /**
@@ -43,10 +44,9 @@ export type TestFormValues = {
  * prior conversation turns (excluding the current user prompt, which
  * `buildChatPayload` appends last) so multi-turn context is sent on the
  * wire when the backend honors the `messages` array. `onDelta` is invoked
- * for every parsed SSE chunk during streaming so the viewer can render
- * content/reasoning as it arrives; `onDone` fires once when the stream
- * closes (success or empty). `signal` lets the caller abort an in-flight
- * test (the Stop button).
+ * with the single normalized delta so the viewer can render content /
+ * reasoning; `onDone` fires once when the run finishes (success or empty).
+ * `signal` lets the caller abort an in-flight test (the Stop button).
  */
 export type TestModelVariables = {
   payload: TestFormValues
@@ -57,10 +57,10 @@ export type TestModelVariables = {
 }
 
 /**
- * Normalized per-chunk delta. `contentDelta` is the assistant text token;
- * `reasoningDelta` is the chain-of-thought text token (Claude thinking /
- * DeepSeek reasoning / Responses reasoning summary). `done` marks a
- * terminal structural event (finish_reason / message_stop / response.completed).
+ * Normalized response delta. `contentDelta` is the assistant text;
+ * `reasoningDelta` is the chain-of-thought text (Claude thinking / DeepSeek
+ * reasoning / Responses reasoning summary). `done` marks a terminal
+ * structural event (finish_reason / message_stop / response.completed).
  */
 export type TestStreamDelta = {
   contentDelta?: string
@@ -69,11 +69,11 @@ export type TestStreamDelta = {
 }
 
 /**
- * Finalised test response the viewer renders after the stream closes.
+ * Finalised test response the viewer renders after the run finishes.
  * `content` / `reasoningContent` are the accumulated full strings; `latencyMs`
- * is the wall-clock from request start to stream end; `chunks` is the count
- * of SSE data events consumed (capped for memory); `rawEvents` stores the
- * last N raw data lines for the JSON/raw debug tab.
+ * is the wall-clock from request start to completion; `chunks` is the count
+ * of data events consumed; `rawEvents` stores the last N raw data lines for
+ * the JSON/raw debug tab.
  */
 export type TestResponse = {
   content: string
@@ -87,16 +87,15 @@ export type TestResponse = {
 }
 
 /**
- * Wire shape for `/api/test/chat/stream`. Defined locally because
- * `lib/api.ts` keeps `TestChatRequestPayload` un-exported during the
- * rewrite; the structural shape is identical so `api.testChatStream`
- * accepts it via structural typing.
+ * Wire shape for `/api/test/chat`. Defined locally because `lib/api.ts` keeps
+ * `TestChatRequestPayload` un-exported during the rewrite; the structural
+ * shape is identical so `api.testChatSync` accepts it via structural typing.
  */
 export type ChatTestPayload = {
   model: string
   messages: Array<{ role: string; content: string }>
+  channelId?: number
   targetFormat?: TestTargetFormat
-  stream?: boolean
   temperature?: number
   top_p?: number
   max_tokens?: number

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -166,6 +166,9 @@
         "model": "Model",
         "modelLoading": "Loading models…",
         "modelPlaceholder": "Select a model",
+        "channel": "Channel",
+        "channelNone": "No channel (default routing)",
+        "channelHint": "Run the test against a specific channel. Leave empty to use default routing.",
         "targetFormatLabel": "Target format",
         "targetFormat": {
           "openai": "OpenAI",
@@ -181,8 +184,6 @@
         "topP": "Top P",
         "maxTokens": "Max tokens",
         "maxTokensHint": "Maximum number of tokens to generate.",
-        "stream": "Stream",
-        "streamHint": "Stream the response token by token (backend support pending).",
         "stop": "Stop",
         "submit": "Send",
         "errors": {
@@ -209,7 +210,7 @@
       "error": {
         "stopped": "Request was stopped.",
         "unknown": "An unknown error occurred.",
-        "notAvailable": "Model testing isn't available yet: the backend needs a configured channel to run a test, and streaming support is still pending."
+        "notAvailable": "Model testing isn't available yet: select a channel to run a test through the forced-channel harness."
       },
       "viewer": {
         "title": "Response",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -166,6 +166,9 @@
         "model": "模型",
         "modelLoading": "加载模型中…",
         "modelPlaceholder": "选择模型",
+        "channel": "渠道",
+        "channelNone": "不指定渠道（默认路由）",
+        "channelHint": "针对指定渠道发起测试。留空则使用默认路由。",
         "targetFormatLabel": "目标格式",
         "targetFormat": {
           "openai": "OpenAI",
@@ -181,8 +184,6 @@
         "topP": "Top P",
         "maxTokens": "最大令牌数",
         "maxTokensHint": "生成的最大令牌数。",
-        "stream": "流式输出",
-        "streamHint": "逐令牌流式返回响应（后端支持待实现）。",
         "stop": "停止",
         "submit": "发送",
         "errors": {
@@ -209,7 +210,7 @@
       "error": {
         "stopped": "请求已停止。",
         "unknown": "发生未知错误。",
-        "notAvailable": "模型测试暂不可用：后端需要配置渠道才能运行测试，流式支持仍在开发中。"
+        "notAvailable": "模型测试暂不可用：请选择渠道，通过强制渠道测试通道发起测试。"
       },
       "viewer": {
         "title": "响应",

--- a/web/src/lib/api/test-chat.ts
+++ b/web/src/lib/api/test-chat.ts
@@ -88,25 +88,6 @@ export const testChatApi = {
       method: 'POST',
       body: JSON.stringify(data),
     }),
-  testChatStream: async (
-    data: TestChatRequestPayload,
-    signal?: AbortSignal
-  ) => {
-    const token = getAuthToken(localStorage)
-    if (!token) {
-      clearAuthSession(localStorage)
-      throw new Error('Session expired')
-    }
-    return fetch('/api/test/chat/stream', {
-      method: 'POST',
-      signal,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(data),
-    })
-  },
   testChatSync: async (data: TestChatRequestPayload, signal?: AbortSignal) => {
     const token = getAuthToken(localStorage)
     if (!token) {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -226,6 +226,7 @@ export type TestChatRequestPayload = {
   messages: Array<{ role: string; content: string }>
   targetFormat?: 'openai' | 'claude' | 'responses' | 'gemini'
   stream?: boolean
+  channelId?: number | null
   forcedChannelId?: number | null
   temperature?: number
   top_p?: number

--- a/web/src/routes/_authenticated/channels.tsx
+++ b/web/src/routes/_authenticated/channels.tsx
@@ -2,9 +2,8 @@
 
 import { createFileRoute } from '@tanstack/react-router'
 
-import { channelsKeys, channelsSearchSchema } from '@/features/channels'
+import { channelsKeys, channelsSearchSchema, getChannelsList } from '@/features/channels'
 import { ChannelsPage } from '@/features/channels/components/channels-page'
-import { api } from '@/lib/api'
 
 export const Route = createFileRoute('/_authenticated/channels')({
   validateSearch: channelsSearchSchema,
@@ -12,10 +11,7 @@ export const Route = createFileRoute('/_authenticated/channels')({
   loader: async ({ context }) => {
     await context.queryClient.prefetchQuery({
       queryKey: channelsKeys.list(),
-      queryFn: async () => {
-        const result = await api.getChannels()
-        return (result ?? []) as unknown[]
-      },
+      queryFn: () => getChannelsList(),
     })
   },
   component: ChannelsPage,

--- a/web/src/routes/_authenticated/channels.tsx
+++ b/web/src/routes/_authenticated/channels.tsx
@@ -2,7 +2,11 @@
 
 import { createFileRoute } from '@tanstack/react-router'
 
-import { channelsKeys, channelsSearchSchema, getChannelsList } from '@/features/channels'
+import {
+  channelsKeys,
+  channelsSearchSchema,
+  getChannelsList,
+} from '@/features/channels'
 import { ChannelsPage } from '@/features/channels/components/channels-page'
 
 export const Route = createFileRoute('/_authenticated/channels')({


### PR DESCRIPTION
## Summary
Wave 2 — 测试台真值基础（P1）：

- **C4 通道契约**：`GET /api/channels` 返回 `{items,total,page,pageSize}`，修复 `useChannels` 直接强转 envelope 的问题，改为解析 `items`；非法响应明确抛错而非伪装空列表。
- **C5 强制通道探针**：测试台新增通道选择器（`channelId`），通过现有同步 `/api/test/chat` 强制通道 harness 发起；Stop 使用真实 `AbortController`；展示真实 latency / response / upstream error。
- **C6 流式诚实**：移除 UI 的 stream 开关与 SSE 读取死分支（`/api/test/chat/stream` 保持 501），测试台改为 sync-only，不再宣传后端不支持的流式成功路径。

## Test plan
- 新增 channel envelope 解析测试 + channelId payload/schema 测试。
- `bun run typecheck` / `lint` / `knip` / `test`（390 tests / 36 files）/ i18n 双向一致性全绿。

> 注：Wave 3（批量延迟比较）依赖本 PR 合并后开始；Wave 4（价格/权重对照）独立。