### PR TITLE
feat(web): batch channel latency comparison in model tester

### DIFF
--- a/web/src/features/channels/index.ts
+++ b/web/src/features/channels/index.ts
@@ -2,3 +2,4 @@
 export { channelsSearchSchema } from './lib/channels-schema'
 export { getChannelsList, useChannels } from './api'
 export { channelsKeys } from './types'
+export type { ChannelRow } from './types'

--- a/web/src/features/model-tester/__tests__/api.test.ts
+++ b/web/src/features/model-tester/__tests__/api.test.ts
@@ -20,6 +20,8 @@ function formValues(overrides: Partial<TestFormValues> = {}): TestFormValues {
     temperature: 0.7,
     topP: 1,
     maxTokens: 1024,
+    compareChannels: false,
+    channelIds: [],
     ...overrides,
   }
 }

--- a/web/src/features/model-tester/__tests__/batch-comparison.test.ts
+++ b/web/src/features/model-tester/__tests__/batch-comparison.test.ts
@@ -1,0 +1,93 @@
+// metapi-go/features/model-tester — batch comparison orchestration tests.
+//
+// `runBatchComparison` settles every probe independently with bounded
+// concurrency and one shared abort; `sortBatchResults` orders successes by
+// ascending latency ahead of failures. Both are pure helpers (the `run`
+// boundary is mocked per-probe, matching the "only mock the network boundary"
+// rule).
+
+import { describe, expect, it } from 'vitest'
+
+import { runBatchComparison, sortBatchResults } from '../api'
+import type { TestResponse } from '../types'
+
+function response(overrides: Partial<TestResponse> = {}): TestResponse {
+  return {
+    content: 'ok',
+    reasoningContent: '',
+    doneReceived: true,
+    latencyMs: 100,
+    chunks: 1,
+    rawEvents: [],
+    empty: false,
+    ...overrides,
+  }
+}
+
+describe('runBatchComparison', () => {
+  it('settles each probe independently (mixed success/failure)', async () => {
+    const results = await runBatchComparison([
+      {
+        channelId: 1,
+        run: () => Promise.resolve(response({ latencyMs: 300 })),
+      },
+      { channelId: 2, run: () => Promise.reject(new Error('boom')) },
+      {
+        channelId: 3,
+        run: () =>
+          Promise.resolve(response({ latencyMs: 100, error: 'upstream' })),
+      },
+    ])
+    expect(results).toEqual([
+      { channelId: 1, status: 'success', latencyMs: 300 },
+      { channelId: 2, status: 'failure', error: 'boom' },
+      { channelId: 3, status: 'failure', latencyMs: 100, error: 'upstream' },
+    ])
+  })
+
+  it('preserves input order regardless of settle timing', async () => {
+    const results = await runBatchComparison([
+      { channelId: 1, run: () => Promise.resolve(response({ latencyMs: 10 })) },
+      { channelId: 2, run: () => Promise.resolve(response({ latencyMs: 1 })) },
+    ])
+    expect(results.map((result) => result.channelId)).toEqual([1, 2])
+  })
+
+  it('marks aborted probes with the aborted status', async () => {
+    const abortError = new Error('This operation was aborted')
+    abortError.name = 'AbortError'
+    const results = await runBatchComparison([
+      { channelId: 1, run: () => Promise.resolve(response({})) },
+      { channelId: 2, run: () => Promise.reject(abortError) },
+    ])
+    expect(results[1]).toEqual({ channelId: 2, status: 'aborted' })
+  })
+
+  it('returns an empty array for an empty probe set', async () => {
+    expect(await runBatchComparison([])).toEqual([])
+  })
+})
+
+describe('sortBatchResults', () => {
+  it('sorts successes by ascending latency, then failures in input order', () => {
+    const sorted = sortBatchResults([
+      { channelId: 1, status: 'failure', error: 'x' },
+      { channelId: 2, status: 'success', latencyMs: 300 },
+      { channelId: 3, status: 'success', latencyMs: 100 },
+      { channelId: 4, status: 'failure', error: 'y' },
+    ])
+    expect(sorted.map((result) => result.channelId)).toEqual([3, 2, 1, 4])
+  })
+
+  it('keeps input order for equal-latency successes (stable)', () => {
+    const sorted = sortBatchResults([
+      { channelId: 1, status: 'success', latencyMs: 100 },
+      { channelId: 2, status: 'success', latencyMs: 100 },
+    ])
+    expect(sorted.map((result) => result.channelId)).toEqual([1, 2])
+  })
+
+  it('returns an empty array for empty input', () => {
+    expect(sortBatchResults([])).toEqual([])
+  })
+})

--- a/web/src/features/model-tester/__tests__/tester-schema.test.ts
+++ b/web/src/features/model-tester/__tests__/tester-schema.test.ts
@@ -221,6 +221,43 @@ describe('testerSchema — no coercion + enum', () => {
 })
 
 // ---------------------------------------------------------------------------
+// channel comparison
+// ---------------------------------------------------------------------------
+
+describe('testerSchema — channel comparison', () => {
+  it('accepts compare mode with at least two channels', () => {
+    const result = testerSchema.safeParse({
+      ...validInput(),
+      compareChannels: true,
+      channelIds: [1, 2],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects compare mode with fewer than two channels', () => {
+    const result = testerSchema.safeParse({
+      ...validInput(),
+      compareChannels: true,
+      channelIds: [1],
+    })
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error.issues[0]?.message).toBe(
+      'modelTester.form.errors.compareMinChannels'
+    )
+  })
+
+  it('accepts empty channelIds when compare mode is off', () => {
+    const result = testerSchema.safeParse({
+      ...validInput(),
+      compareChannels: false,
+      channelIds: [],
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // defaults
 // ---------------------------------------------------------------------------
 
@@ -229,6 +266,8 @@ describe('TESTER_FORM_DEFAULT_VALUES', () => {
     expect(TESTER_FORM_DEFAULT_VALUES).toEqual({
       model: '',
       channelId: undefined,
+      compareChannels: false,
+      channelIds: [],
       systemPrompt: '',
       prompt: '',
       targetFormat: 'openai',

--- a/web/src/features/model-tester/api.ts
+++ b/web/src/features/model-tester/api.ts
@@ -32,6 +32,7 @@ import { useMutation } from '@tanstack/react-query'
 import { api } from '@/lib/api'
 
 import type {
+  BatchProbeResult,
   ChatMessage,
   ChatTestPayload,
   TestFormValues,
@@ -245,17 +246,16 @@ export async function resolveTestResponseError(
 }
 
 /**
- * Run a single sync chat test. Posts to `/api/test/chat` (the forced-channel
- * harness) and parses the single JSON body as one delta so the viewer renders
- * the final content. Forwards the delta to `onDelta` and resolves to a
- * `TestResponse` summary; throws on auth failure, non-ok responses, or caller
- * abort.
+ * Run a single sync probe against `/api/test/chat` (the forced-channel
+ * harness) and parse the JSON body as one delta. Returns a `TestResponse`
+ * summary (including measured `latencyMs`); throws on auth failure, non-ok
+ * responses, or caller abort. Shared by the single-run mutation and the batch
+ * comparison so both measure latency through the same path.
  */
-async function runChatTest(
-  variables: TestModelVariables
+export async function runChatProbe(
+  chatPayload: ChatTestPayload,
+  signal?: AbortSignal
 ): Promise<TestResponse> {
-  const { payload, history, onDelta, onDone, signal } = variables
-  const chatPayload = buildChatPayload(payload, history)
   const startedAt = performance.now()
 
   const response = await api.testChatSync(chatPayload, signal)
@@ -276,7 +276,7 @@ async function runChatTest(
       const parsed = JSON.parse(text) as unknown
       const errorText = extractErrorMessage(parsed)
       if (errorText) {
-        const summary: TestResponse = {
+        return {
           content: '',
           reasoningContent: '',
           doneReceived: true,
@@ -286,8 +286,6 @@ async function runChatTest(
           empty: true,
           error: errorText,
         }
-        onDone?.(summary)
-        return summary
       }
       const delta = parseAnyStreamDelta(parsed)
       content = delta.contentDelta ?? ''
@@ -299,7 +297,7 @@ async function runChatTest(
     }
   }
 
-  const summary: TestResponse = {
+  return {
     content,
     reasoningContent,
     doneReceived,
@@ -308,13 +306,123 @@ async function runChatTest(
     rawEvents,
     empty: !content && !reasoningContent,
   }
+}
+
+/**
+ * Detect a caller-triggered abort so the UI can show a "stopped" state
+ * instead of a hard error. Handles the message variants produced by
+ * `AbortController.abort()` across browsers and the fetch polyfill.
+ */
+export function isAbortError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  return (
+    error.name === 'AbortError' ||
+    error.message === 'This operation was aborted' ||
+    error.message === 'The user aborted a request.'
+  )
+}
+
+/**
+ * Run a single sync chat test for the viewer. Builds the payload from form
+ * values + history, delegates to `runChatProbe`, then forwards the single
+ * delta to `onDelta` and the summary to `onDone`.
+ */
+async function runChatTest(
+  variables: TestModelVariables
+): Promise<TestResponse> {
+  const { payload, history, onDelta, onDone, signal } = variables
+  const summary = await runChatProbe(buildChatPayload(payload, history), signal)
   onDelta?.({
-    contentDelta: content,
-    reasoningDelta: reasoningContent,
+    contentDelta: summary.content,
+    reasoningDelta: summary.reasoningContent,
     done: true,
   })
   onDone?.(summary)
   return summary
+}
+
+/**
+ * Run a batch of channel probes with bounded concurrency and one shared abort
+ * lifecycle, settling every request independently so one slow/failing channel
+ * never erases the others. Returns one result per probe in input order.
+ */
+export async function runBatchComparison(
+  probes: Array<{
+    channelId: number
+    run: (signal?: AbortSignal) => Promise<TestResponse>
+  }>,
+  options: { concurrency?: number; signal?: AbortSignal } = {}
+): Promise<BatchProbeResult[]> {
+  const concurrency = Math.max(1, options.concurrency ?? 3)
+  const results: BatchProbeResult[] = Array.from({ length: probes.length })
+  let nextIndex = 0
+
+  async function worker(): Promise<void> {
+    while (nextIndex < probes.length) {
+      const index = nextIndex
+      nextIndex += 1
+      const probe = probes[index]
+      results[index] = await settleProbe(
+        probe.channelId,
+        probe.run,
+        options.signal
+      )
+    }
+  }
+
+  const workerCount = Math.min(concurrency, probes.length)
+  await Promise.all(Array.from({ length: workerCount }, () => worker()))
+  return results
+}
+
+async function settleProbe(
+  channelId: number,
+  run: (signal?: AbortSignal) => Promise<TestResponse>,
+  signal?: AbortSignal
+): Promise<BatchProbeResult> {
+  try {
+    const summary = await run(signal)
+    if (summary.error) {
+      return {
+        channelId,
+        status: 'failure',
+        latencyMs: summary.latencyMs,
+        error: summary.error,
+      }
+    }
+    return { channelId, status: 'success', latencyMs: summary.latencyMs }
+  } catch (error) {
+    if (isAbortError(error)) return { channelId, status: 'aborted' }
+    return {
+      channelId,
+      status: 'failure',
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+/**
+ * Order batch results for display: completed successes first, sorted by
+ * ascending latency, then failures/aborted entries in their original input
+ * order (a stable sort so reruns do not jumble otherwise-identical rows).
+ */
+export function sortBatchResults(
+  results: BatchProbeResult[]
+): BatchProbeResult[] {
+  return results
+    .map((result, index) => ({ result, index }))
+    .sort((a, b) => {
+      const aSuccess = a.result.status === 'success'
+      const bSuccess = b.result.status === 'success'
+      if (aSuccess && bSuccess) {
+        const latencyDiff =
+          (a.result.latencyMs ?? 0) - (b.result.latencyMs ?? 0)
+        return latencyDiff !== 0 ? latencyDiff : a.index - b.index
+      }
+      if (aSuccess !== bSuccess) return aSuccess ? -1 : 1
+      return a.index - b.index
+    })
+    .map((entry) => entry.result)
 }
 
 export function useTestModel() {

--- a/web/src/features/model-tester/components/batch-results.tsx
+++ b/web/src/features/model-tester/components/batch-results.tsx
@@ -1,0 +1,97 @@
+// metapi-go/features/model-tester — batch latency comparison results table.
+//
+// Renders one row per channel with channel/site identity, success/failure
+// status, observed latency, and a concise error. Rows are pre-sorted by the
+// parent (successes by ascending latency, then failures in input order); the
+// summary line reports "N succeeded / M failed".
+
+import { useTranslation } from 'react-i18next'
+
+import type { ChannelRow } from '@/features/channels'
+import { cn } from '@/lib/utils'
+
+import type { BatchProbeResult } from '../types'
+
+type BatchResultsProps = {
+  results: BatchProbeResult[]
+  channels: ChannelRow[]
+}
+
+function statusKeyFor(result: BatchProbeResult): string {
+  if (result.status === 'success') return 'modelTester.compare.statusSuccess'
+  if (result.status === 'failure') return 'modelTester.compare.statusFailure'
+  return 'modelTester.compare.statusAborted'
+}
+
+export function BatchResults({ results, channels }: BatchResultsProps) {
+  const { t } = useTranslation()
+  const channelById = new Map(channels.map((channel) => [channel.id, channel]))
+  const succeeded = results.filter(
+    (result) => result.status === 'success'
+  ).length
+  const failed = results.length - succeeded
+
+  return (
+    <div className='flex h-full flex-col gap-3 p-4'>
+      <div>
+        <h2 className='text-base font-normal'>
+          {t('modelTester.compare.title')}
+        </h2>
+        <p className='text-muted-foreground text-sm'>
+          {t('modelTester.compare.summary', { succeeded, failed })}
+        </p>
+      </div>
+
+      <div className='min-h-0 flex-1 overflow-y-auto rounded-lg border'>
+        <table className='w-full text-sm'>
+          <thead className='bg-muted/50 sticky top-0 text-left'>
+            <tr>
+              <th className='px-3 py-2 font-medium'>
+                {t('modelTester.compare.channel')}
+              </th>
+              <th className='px-3 py-2 font-medium'>
+                {t('modelTester.compare.site')}
+              </th>
+              <th className='px-3 py-2 font-medium'>
+                {t('modelTester.compare.status')}
+              </th>
+              <th className='px-3 py-2 font-medium'>
+                {t('modelTester.compare.latency')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {results.map((result) => {
+              const channel = channelById.get(result.channelId)
+              return (
+                <tr key={result.channelId} className='border-t'>
+                  <td className='px-3 py-2'>
+                    {channel?.name ?? result.channelId}
+                  </td>
+                  <td className='text-muted-foreground px-3 py-2'>
+                    {channel?.site.name ?? '—'}
+                  </td>
+                  <td className='px-3 py-2'>
+                    <span
+                      className={cn(
+                        'text-xs font-medium',
+                        result.status === 'success' && 'text-success',
+                        result.status === 'failure' && 'text-destructive',
+                        result.status === 'aborted' && 'text-muted-foreground'
+                      )}
+                    >
+                      {t(statusKeyFor(result))}
+                    </span>
+                  </td>
+                  <td className='px-3 py-2 tabular-nums'>
+                    {result.latencyMs != null ? `${result.latencyMs} ms` : '—'}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/web/src/features/model-tester/components/model-tester-page.tsx
+++ b/web/src/features/model-tester/components/model-tester-page.tsx
@@ -30,12 +30,26 @@ import { useTranslation } from 'react-i18next'
 import { ConfirmDialog } from '@/components/common/confirm-dialog'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
+import { useChannels } from '@/features/channels'
 import { asStringParam } from '@/lib/helpers/searchParams'
 import { toast } from '@/lib/toast'
 
-import { useTestModel } from '../api'
+import {
+  buildChatPayload,
+  isAbortError,
+  runBatchComparison,
+  runChatProbe,
+  sortBatchResults,
+  useTestModel,
+} from '../api'
 import type { TesterFormValues } from '../lib/tester-schema'
-import type { ChatMessage, TestResponse, TestStreamDelta } from '../types'
+import type {
+  BatchProbeResult,
+  ChatMessage,
+  TestResponse,
+  TestStreamDelta,
+} from '../types'
+import { BatchResults } from './batch-results'
 import { TestForm } from './test-form'
 import { TestResponseViewer } from './test-response-viewer'
 
@@ -44,15 +58,6 @@ let messageIdCounter = 0
 function nextMessageId(): string {
   messageIdCounter += 1
   return `message-${messageIdCounter}`
-}
-
-function isAbortError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false
-  return (
-    error.name === 'AbortError' ||
-    error.message === 'This operation was aborted' ||
-    error.message === 'The user aborted a request.'
-  )
 }
 
 export function ModelTesterPage() {
@@ -65,6 +70,7 @@ export function ModelTesterPage() {
   const defaultModel = modelParam?.trim() ? modelParam : undefined
 
   const testModel = useTestModel()
+  const channelsQuery = useChannels()
 
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [content, setContent] = useState('')
@@ -72,6 +78,8 @@ export function ModelTesterPage() {
   const [response, setResponse] = useState<TestResponse | null>(null)
   const [error, setError] = useState<string | undefined>(undefined)
   const [clearDialogOpen, setClearDialogOpen] = useState(false)
+  const [comparison, setComparison] = useState<BatchProbeResult[] | null>(null)
+  const [isComparing, setIsComparing] = useState(false)
 
   const abortControllerRef = useRef<AbortController | null>(null)
 
@@ -105,6 +113,40 @@ export function ModelTesterPage() {
 
       const controller = new AbortController()
       abortControllerRef.current = controller
+
+      if (values.compareChannels) {
+        setComparison(null)
+        setIsComparing(true)
+        try {
+          const probes = (values.channelIds ?? []).map((channelId) => ({
+            channelId,
+            run: (signal?: AbortSignal) =>
+              runChatProbe(
+                buildChatPayload({ ...values, channelId }, history),
+                signal
+              ),
+          }))
+          const results = await runBatchComparison(probes, {
+            signal: controller.signal,
+          })
+          setComparison(sortBatchResults(results))
+          const succeeded = results.filter(
+            (result) => result.status === 'success'
+          ).length
+          toast.success(
+            t('modelTester.compare.summary', {
+              succeeded,
+              failed: results.length - succeeded,
+            })
+          )
+        } catch {
+          toast.error(t('modelTester.toast.failed'))
+        } finally {
+          setIsComparing(false)
+          abortControllerRef.current = null
+        }
+        return
+      }
 
       try {
         const result = await testModel.mutateAsync({
@@ -160,11 +202,12 @@ export function ModelTesterPage() {
     setReasoningContent('')
     setResponse(null)
     setError(undefined)
+    setComparison(null)
     setClearDialogOpen(false)
     toast.success(t('modelTester.toast.cleared'))
   }, [t])
 
-  const isRunning = testModel.isPending
+  const isRunning = testModel.isPending || isComparing
 
   return (
     <div className='flex h-full flex-col gap-4 p-4'>
@@ -201,14 +244,21 @@ export function ModelTesterPage() {
 
         <Card className='flex h-full min-h-0 flex-col'>
           <CardContent className='flex min-h-0 flex-1 flex-col p-0'>
-            <TestResponseViewer
-              messages={messages}
-              content={content}
-              reasoningContent={reasoningContent}
-              isRunning={isRunning}
-              response={response}
-              error={error}
-            />
+            {comparison || isComparing ? (
+              <BatchResults
+                results={comparison ?? []}
+                channels={channelsQuery.data ?? []}
+              />
+            ) : (
+              <TestResponseViewer
+                messages={messages}
+                content={content}
+                reasoningContent={reasoningContent}
+                isRunning={isRunning}
+                response={response}
+                error={error}
+              />
+            )}
           </CardContent>
         </Card>
       </div>

--- a/web/src/features/model-tester/components/test-form.tsx
+++ b/web/src/features/model-tester/components/test-form.tsx
@@ -17,6 +17,7 @@ import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Form,
   FormControl,
@@ -36,6 +37,7 @@ import {
 } from '@/components/ui/select'
 import { Slider } from '@/components/ui/slider'
 import { Spinner } from '@/components/ui/spinner'
+import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { useChannels } from '@/features/channels'
 import { useModels } from '@/features/models'
@@ -79,6 +81,9 @@ export function TestForm({
     resolver: zodResolver(testerSchema),
     defaultValues: TESTER_FORM_DEFAULT_VALUES,
   })
+
+  const compareChannels = form.watch('compareChannels')
+  const selectedChannelIds = form.watch('channelIds') ?? []
 
   // Pre-select the model from a deep link once the marketplace list lands.
   useEffect(() => {
@@ -197,52 +202,125 @@ export function TestForm({
 
         <FormField
           control={form.control}
-          name='channelId'
+          name='compareChannels'
           render={({ field }) => (
-            <FormItem>
-              <FormLabel>{t('modelTester.form.channel')}</FormLabel>
-              <Select
-                value={field.value ? String(field.value) : 'none'}
-                onValueChange={(value) =>
-                  field.onChange(value === 'none' ? undefined : Number(value))
-                }
-                disabled={isRunning}
-              >
-                <FormControl>
-                  <SelectTrigger>
-                    <SelectValue>
-                      {(selected) => {
-                        if (!selected || selected === 'none') {
-                          return t('modelTester.form.channelNone')
-                        }
-                        const channel = (channelsQuery.data ?? []).find(
-                          (item) => String(item.id) === selected
-                        )
-                        return channel
-                          ? `${channel.name} · ${channel.site.name}`
-                          : String(selected)
-                      }}
-                    </SelectValue>
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  <SelectItem value='none'>
-                    {t('modelTester.form.channelNone')}
-                  </SelectItem>
-                  {(channelsQuery.data ?? []).map((channel) => (
-                    <SelectItem key={channel.id} value={String(channel.id)}>
-                      {channel.name} · {channel.site.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <FormDescription>
-                {t('modelTester.form.channelHint')}
-              </FormDescription>
-              <FormMessage />
+            <FormItem className='flex flex-row items-center justify-between rounded-lg border p-3'>
+              <div className='space-y-0.5'>
+                <FormLabel>{t('modelTester.form.compareChannels')}</FormLabel>
+                <FormDescription>
+                  {t('modelTester.form.compareChannelsHint')}
+                </FormDescription>
+              </div>
+              <FormControl>
+                <Switch
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                  disabled={isRunning}
+                />
+              </FormControl>
             </FormItem>
           )}
         />
+
+        {!compareChannels && (
+          <FormField
+            control={form.control}
+            name='channelId'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t('modelTester.form.channel')}</FormLabel>
+                <Select
+                  value={field.value ? String(field.value) : 'none'}
+                  onValueChange={(value) =>
+                    field.onChange(value === 'none' ? undefined : Number(value))
+                  }
+                  disabled={isRunning}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue>
+                        {(selected) => {
+                          if (!selected || selected === 'none') {
+                            return t('modelTester.form.channelNone')
+                          }
+                          const channel = (channelsQuery.data ?? []).find(
+                            (item) => String(item.id) === selected
+                          )
+                          return channel
+                            ? `${channel.name} · ${channel.site.name}`
+                            : String(selected)
+                        }}
+                      </SelectValue>
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value='none'>
+                      {t('modelTester.form.channelNone')}
+                    </SelectItem>
+                    {(channelsQuery.data ?? []).map((channel) => (
+                      <SelectItem key={channel.id} value={String(channel.id)}>
+                        {channel.name} · {channel.site.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormDescription>
+                  {t('modelTester.form.channelHint')}
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
+
+        {compareChannels && (
+          <FormField
+            control={form.control}
+            name='channelIds'
+            render={() => (
+              <FormItem>
+                <FormLabel>
+                  {t('modelTester.form.compareChannelsLabel')}
+                </FormLabel>
+                <div className='max-h-48 space-y-1 overflow-y-auto rounded-lg border p-2'>
+                  {(channelsQuery.data ?? []).map((channel) => {
+                    const checked = selectedChannelIds.includes(channel.id)
+                    return (
+                      <label
+                        key={channel.id}
+                        className='hover:bg-muted flex items-center gap-2 rounded px-2 py-1'
+                      >
+                        <Checkbox
+                          checked={checked}
+                          onCheckedChange={(value) => {
+                            const next = value
+                              ? [...selectedChannelIds, channel.id]
+                              : selectedChannelIds.filter(
+                                  (id) => id !== channel.id
+                                )
+                            form.setValue('channelIds', next, {
+                              shouldValidate: true,
+                            })
+                          }}
+                          disabled={isRunning}
+                        />
+                        <span className='truncate text-sm'>
+                          {channel.name} · {channel.site.name}
+                        </span>
+                      </label>
+                    )
+                  })}
+                </div>
+                <FormDescription>
+                  {t('modelTester.form.compareChannelsCount', {
+                    count: selectedChannelIds.length,
+                  })}
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
 
         <FormField
           control={form.control}

--- a/web/src/features/model-tester/lib/tester-schema.ts
+++ b/web/src/features/model-tester/lib/tester-schema.ts
@@ -2,13 +2,15 @@
 //
 // Validates the test form: model (required), target channel (optional —
 // absent means the backend's honest 501 "requires channelId" residual, since
-// the sync harness only runs against a forced channel), system prompt
-// (optional), user prompt (required), target protocol format, and sampling
-// parameters (temperature / top_p / max_tokens). Numeric fields use plain
-// `z.number()` (no `z.coerce`/`.default()`) so the zod resolver's input and
-// output types match and RHF typing stays clean; the form binds them with an
-// explicit `onChange` that converts via `valueAsNumber`. Error messages are
-// i18next keys (resolved by `<FormMessage>`).
+// the sync harness only runs against a forced channel), a comparison mode
+// (`compareChannels` + a multi-channel `channelIds` list requiring at least
+// two channels), system prompt (optional), user prompt (required), target
+// protocol format, and sampling parameters (temperature / top_p / max_tokens).
+// Numeric fields use plain `z.number()` (no `z.coerce`/`.default()`) so the
+// zod resolver's input and output types match and RHF typing stays clean; the
+// form binds them with an explicit `onChange` that converts via
+// `valueAsNumber`. Error messages are i18next keys (resolved by
+// `<FormMessage>`).
 
 import { z } from 'zod'
 
@@ -21,36 +23,50 @@ const TARGET_FORMATS = [
   'gemini',
 ] as const satisfies readonly TestTargetFormat[]
 
-export const testerSchema = z.object({
-  model: z.string().trim().min(1, 'modelTester.form.errors.modelRequired'),
-  channelId: z.number().int().positive().optional(),
-  systemPrompt: z.string().max(4000, 'modelTester.form.errors.systemTooLong'),
-  prompt: z
-    .string()
-    .trim()
-    .min(1, 'modelTester.form.errors.promptRequired')
-    .max(16000, 'modelTester.form.errors.promptTooLong'),
-  targetFormat: z.enum(TARGET_FORMATS),
-  temperature: z
-    .number()
-    .min(0, 'modelTester.form.errors.temperatureMin')
-    .max(2, 'modelTester.form.errors.temperatureMax'),
-  topP: z
-    .number()
-    .min(0, 'modelTester.form.errors.topPMin')
-    .max(1, 'modelTester.form.errors.topPMax'),
-  maxTokens: z
-    .number()
-    .int('modelTester.form.errors.maxTokensInteger')
-    .min(0, 'modelTester.form.errors.maxTokensMin')
-    .max(128000, 'modelTester.form.errors.maxTokensMax'),
-})
+export const testerSchema = z
+  .object({
+    model: z.string().trim().min(1, 'modelTester.form.errors.modelRequired'),
+    channelId: z.number().int().positive().optional(),
+    compareChannels: z.boolean(),
+    channelIds: z.array(z.number().int().positive()).max(32).optional(),
+    systemPrompt: z.string().max(4000, 'modelTester.form.errors.systemTooLong'),
+    prompt: z
+      .string()
+      .trim()
+      .min(1, 'modelTester.form.errors.promptRequired')
+      .max(16000, 'modelTester.form.errors.promptTooLong'),
+    targetFormat: z.enum(TARGET_FORMATS),
+    temperature: z
+      .number()
+      .min(0, 'modelTester.form.errors.temperatureMin')
+      .max(2, 'modelTester.form.errors.temperatureMax'),
+    topP: z
+      .number()
+      .min(0, 'modelTester.form.errors.topPMin')
+      .max(1, 'modelTester.form.errors.topPMax'),
+    maxTokens: z
+      .number()
+      .int('modelTester.form.errors.maxTokensInteger')
+      .min(0, 'modelTester.form.errors.maxTokensMin')
+      .max(128000, 'modelTester.form.errors.maxTokensMax'),
+  })
+  .superRefine((values, ctx) => {
+    if (values.compareChannels && (values.channelIds ?? []).length < 2) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['channelIds'],
+        message: 'modelTester.form.errors.compareMinChannels',
+      })
+    }
+  })
 
 export type TesterFormValues = z.infer<typeof testerSchema>
 
 export const TESTER_FORM_DEFAULT_VALUES: TesterFormValues = {
   model: '',
   channelId: undefined,
+  compareChannels: false,
+  channelIds: [],
   systemPrompt: '',
   prompt: '',
   targetFormat: 'openai',

--- a/web/src/features/model-tester/types.ts
+++ b/web/src/features/model-tester/types.ts
@@ -25,12 +25,15 @@ export type ChatMessage = {
  * `ChatTestPayload.messages` array from `systemPrompt` (role=system, when
  * present) + `prompt` (role=user). `channelId` targets a specific channel via
  * the forced-channel harness; when absent the backend returns its honest 501
- * "requires channelId" residual. Numeric fields are plain `z.number()` so RHF
- * input/output types match.
+ * "requires channelId" residual. `compareChannels` + `channelIds` drive the
+ * batch latency comparison (single-run path keeps using `channelId`).
+ * Numeric fields are plain `z.number()` so RHF input/output types match.
  */
 export type TestFormValues = {
   model: string
   channelId?: number
+  compareChannels: boolean
+  channelIds?: number[]
   systemPrompt: string
   prompt: string
   targetFormat: TestTargetFormat
@@ -99,4 +102,18 @@ export type ChatTestPayload = {
   temperature?: number
   top_p?: number
   max_tokens?: number
+}
+
+/**
+ * Settled result for one channel in a batch latency comparison. `status`
+ * distinguishes a clean response from an upstream error (the probe resolved
+ * with a `TestResponse.error`) or a caller abort; `latencyMs` is the observed
+ * wall-clock from request start to settle (only set when the probe actually
+ * issued a request).
+ */
+export type BatchProbeResult = {
+  channelId: number
+  status: 'success' | 'failure' | 'aborted'
+  latencyMs?: number
+  error?: string
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -169,6 +169,10 @@
         "channel": "Channel",
         "channelNone": "No channel (default routing)",
         "channelHint": "Run the test against a specific channel. Leave empty to use default routing.",
+        "compareChannels": "Compare channels",
+        "compareChannelsHint": "Run the same prompt across several channels and compare latency.",
+        "compareChannelsLabel": "Channels to compare",
+        "compareChannelsCount": "{{count}} selected",
         "targetFormatLabel": "Target format",
         "targetFormat": {
           "openai": "OpenAI",
@@ -197,7 +201,8 @@
           "topPMax": "Top P must be at most 1.",
           "maxTokensInteger": "Max tokens must be an integer.",
           "maxTokensMin": "Max tokens must be at least 0.",
-          "maxTokensMax": "Max tokens must be at most 128000."
+          "maxTokensMax": "Max tokens must be at most 128000.",
+          "compareMinChannels": "Select at least two channels to compare."
         }
       },
       "toast": {
@@ -233,6 +238,19 @@
         "contentChars": "{{value}} chars",
         "roleYou": "You",
         "roleAssistant": "Assistant"
+      },
+      "compare": {
+        "title": "Channel comparison",
+        "emptyHint": "Select two or more channels and run a comparison.",
+        "summary": "{{succeeded}} succeeded / {{failed}} failed",
+        "channel": "Channel",
+        "site": "Site",
+        "status": "Status",
+        "latency": "Latency",
+        "error": "Error",
+        "statusSuccess": "Success",
+        "statusFailure": "Failed",
+        "statusAborted": "Stopped"
       },
       "page": {
         "title": "Model Tester",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -169,6 +169,10 @@
         "channel": "渠道",
         "channelNone": "不指定渠道（默认路由）",
         "channelHint": "针对指定渠道发起测试。留空则使用默认路由。",
+        "compareChannels": "对比渠道",
+        "compareChannelsHint": "用同一提示词在多个渠道上运行并对比延迟。",
+        "compareChannelsLabel": "待对比渠道",
+        "compareChannelsCount": "已选 {{count}} 个",
         "targetFormatLabel": "目标格式",
         "targetFormat": {
           "openai": "OpenAI",
@@ -197,7 +201,8 @@
           "topPMax": "Top P 不能超过 1。",
           "maxTokensInteger": "最大令牌数必须为整数。",
           "maxTokensMin": "最大令牌数不能小于 0。",
-          "maxTokensMax": "最大令牌数不能超过 128000。"
+          "maxTokensMax": "最大令牌数不能超过 128000。",
+          "compareMinChannels": "请至少选择两个渠道进行对比。"
         }
       },
       "toast": {
@@ -233,6 +238,19 @@
         "contentChars": "{{value}} 字符",
         "roleYou": "你",
         "roleAssistant": "助手"
+      },
+      "compare": {
+        "title": "渠道对比",
+        "emptyHint": "选择两个或更多渠道后运行对比。",
+        "summary": "{{succeeded}} 成功 / {{failed}} 失败",
+        "channel": "渠道",
+        "site": "站点",
+        "status": "状态",
+        "latency": "延迟",
+        "error": "错误",
+        "statusSuccess": "成功",
+        "statusFailure": "失败",
+        "statusAborted": "已停止"
       },
       "page": {
         "title": "模型测试器",


### PR DESCRIPTION
## Summary
Wave 3 — P1 批量延迟对比（C7/C8/C9）：

- **C7 批量选择**：测试台新增「对比渠道」开关 + 多选渠道清单，保留单渠道路径；对比模式至少选择两个渠道（Zod `superRefine` 校验）。
- **C8 有界执行**：`runBatchComparison` 以固定并发（默认 3）+ 共享 `AbortController` 复用单通道同步探针，逐通道独立结算；单通道失败不抹除其余结果。
- **C9 结果契约**：新增 `BatchResults` 表，按渠道/站点/状态/延迟渲染；成功按延迟升序排序，汇总显示「N 成功 / M 失败」；混合结果保持可见。

## Test plan
- 新增 `batch-comparison.test.ts`（编排混合成功/失败、输入序保持、abort、稳定排序）+ 对比模式 schema 校验。
- `bun run typecheck` / `lint` / `knip` / `format:check` / `test`（433 tests / 40 files）/ `rsbuild build` / i18n 双向一致性全绿。