### PR TITLE
fix(web): stabilize URL-owned table state

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,10 +125,10 @@ jobs:
           retention-days: 3
 
   a11y:
-    # axe-core a11y gate against the real production SPA: the Go server embeds
-    # web/dist (built by the frontend job) and serves the admin app + API from
-    # one origin, so the scan exercises the exact shipped bundle instead of the
-    # dev server. Requires a fresh sqlite runtime DB (server auto-migrates).
+    # Real-browser production-SPA gates: axe accessibility + route/crash/mobile
+    # smoke. The Go server embeds web/dist (built by the frontend job) and serves
+    # the admin app + API from one origin, so these exercise the exact shipped
+    # bundle instead of the dev server. Requires a fresh sqlite runtime DB.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: frontend
@@ -157,7 +157,7 @@ jobs:
       - name: Install Playwright Chromium
         run: bunx playwright install --with-deps chromium
         working-directory: web
-      - name: Serve SPA and run axe a11y gate
+      - name: Serve SPA and run browser gates
         run: |
           set -euo pipefail
           AUTH_TOKEN=dev-admin-token-123 \
@@ -182,6 +182,7 @@ jobs:
           fi
           cd web
           BASE_URL=http://127.0.0.1:4099 bun run a11y:scan
+          BASE_URL=http://127.0.0.1:4099 AUTH_TOKEN=dev-admin-token-123 bun run ui:smoke
 
   test-sqlite-shard:
     # The race detector makes the full suite the pipeline's long pole (~5 min).

--- a/docs/design/DESIGN.md
+++ b/docs/design/DESIGN.md
@@ -132,6 +132,8 @@ Fallback: `supports-[backdrop-filter]` gates translucency so browsers without `b
 
 Primitive ownership map: [`components.md`](./components.md). Component props and variants are defined by the implementation in `web/src/components/ui/**`, not duplicated in documentation.
 
+State-management rules for URL-synced tables and filters (single URL owner, stable callbacks, one-transaction updates): [`state-stability.md`](./state-stability.md).
+
 | Layer            | Prefix / classes                    | Where                                            |
 | ---------------- | ----------------------------------- | ------------------------------------------------ |
 | Base UI (shadcn) | `ui-*` components (data-slot attrs) | `web/src/components/ui/**`                       |
@@ -149,7 +151,8 @@ New UI must start from shadcn Base UI primitives when possible. Import via `@/co
 3. `cd web && bun run lint` — oxlint
 4. `cd web && bun run build` — production bundle gate (`build:web`)
 5. `cd web && bun run a11y:scan` — axe-core serious/critical gate (needs the dev server; see `web/scripts/a11y-scan.mjs`). Also enforced in CI: the `a11y` job serves the real embedded SPA via the Go server (fresh sqlite runtime DB) and scans all 15 admin routes against it (`BASE_URL`-driven; `.github/workflows/main.yml`)
-6. Manual score rubric (target ≥ 4/5 each):
+6. `cd web && bun run ui:smoke` — real-Chromium route/crash/mobile smoke gate (`web/scripts/route-smoke.mjs`); also enforced in CI in the `a11y` job against the shipped bundle
+7. Manual score rubric (target ≥ 4/5 each):
    - Material (glass/solid hierarchy)
    - Brand calm (GCP blue, no neon)
    - Spacing rhythm

--- a/docs/design/state-stability.md
+++ b/docs/design/state-stability.md
@@ -1,0 +1,183 @@
+# State stability — URL-owned table/filter state
+
+**Scope**: how list pages own their navigable state (search / page / page-size /
+sorting / faceted + page-specific filters) without falling into render loops,
+URL write-back loops, or back/forward corruption.
+
+**Source of truth for the rules below**: `web/src/components/data-table/hooks/use-url-table-state.ts`
+and `web/src/components/data-table/hooks/use-data-table.ts`. The list pages
+(sites / models / oauth / channels / accounts / checkin / proxy-logs /
+token-routes) all build on these two hooks.
+
+---
+
+## 1. The bug this prevents
+
+The accounts page historically froze the renderer. The root cause was a
+feedback loop, not backend load:
+
+```
+URL state
+  ↓
+React controlled state (useState mirror)
+  ↓
+TanStack Table
+  ↓
+onChange callback
+  ↓
+router navigate
+  ↓
+URL state
+```
+
+Three concrete triggers, all now banned:
+
+1. **Unstable callback identity** — a fresh inline `onPaginationChange` /
+   `onGlobalFilterChange` / `onColumnFiltersChange` every render re-resolves the
+   TanStack table, which re-runs its `autoResetPageIndex` effect, which can feed
+   back through the URL sync into an infinite loop.
+2. **URL owned by local state + an effect** — `useState(initial)` seeded from the
+   URL plus a `useEffect(() => navigate(...))` write-back creates a two-way sync
+   where either side can fight the other.
+3. **Multiple navigations per logical change** — changing a filter resets the
+   page in a *separate* navigate, so an older transaction can overwrite a newer
+   one.
+
+## 2. Rules
+
+### R1 — the URL is the single owner of persistent navigable state
+
+For a table page, the URL search string is the **only** source of truth for
+search / page / page-size / sorting / filters. There is no `useState` mirror of
+any of these values. Pages **derive** the current view from the URL and **write**
+changes straight back to the URL.
+
+```text
+Browser URL
+  → route schema / parser (`read`)
+  → useUrlTableState (derived values + stable callbacks)
+  → useDataTable / controls
+```
+
+User input:
+
+```text
+UI action → stable callback → ONE logical URL update → router → UI re-derives
+```
+
+The banned shape is:
+
+```text
+URL ⇄ useState mirror ⇄ table ⇄ useEffect ⇄ URL
+```
+
+### R2 — controlled callbacks must keep a stable identity
+
+`useDataTable` hands the controlled-state callbacks directly into
+`useReactTable`. If their identity changes every render, TanStack re-resolves
+the table. Therefore:
+
+- `useUrlTableState` returns `onGlobalFilterChange` / `onPaginationChange` /
+  `onSortingChange` / `onColumnFiltersChange` as `useCallback`s whose deps are
+  the parsed URL state (which only changes on navigation).
+- `useControllableTableState` inside `useDataTable` keeps its `setValue` stable
+  by reading the `onChange` prop through a ref (`onChangeRef`).
+- Page-supplied option functions (`read` / `buildHref` / `toColumnFilters` /
+  `fromColumnFilters`) are read through refs so inline definitions do not break
+  the contract.
+- Table `globalFilterFn` and `rowActions`/`columnActions` live at module level or
+  in `useMemo`, never inline per render.
+
+### R3 — one logical change = one URL transaction
+
+A filter change that also resets the page must be a single `navigate`, not
+`navigate(filters)` followed by `navigate(page=1)`.
+
+- Server-side pages pass `resetPageIndexOnFilterChange: true` to
+  `useUrlTableState`, which folds `pageIndex: 0` into the same update as the
+  filter change, and pass `autoResetPageIndex: false` to `useDataTable` so
+  TanStack does not fire a second, redundant reset.
+- Page-specific controls (date ranges, account/client selects, latency bounds)
+  call `updateUrlState({ filters: { … }, pageIndex: 0 })` — one transaction.
+
+### R4 — URL updates merge the *latest* URL
+
+Serializers must merge over the current `window.location.search`, never over a
+stale closure captured during render. Every page `buildHref` reads the current
+URL, spreads the partial update over it, and shallow-merges `filters`:
+
+```ts
+const current = readSearch(window.location.search)
+const merged = { ...current, ...next, filters: { ...current.filters, ...next.filters } }
+```
+
+This is why changing `q` cannot accidentally drop an existing `status`/`site`
+filter.
+
+### R5 — guard pathname, unmount, and same-href
+
+`updateUrlState` ignores a change when:
+
+- the built href is for a different pathname (the user navigated away and a
+  stale table callback fired — the "clicked a sidebar link and snapped back"
+  bug), or
+- the built href equals the current href (no-op, no navigation).
+
+### R6 — browser acceptance is part of the design system
+
+`typecheck + lint + test` cannot prove a UI does not freeze or that back/forward
+restores the right view. A real-Chromium smoke/axe gate is mandatory for these
+pages (`web/scripts/route-smoke.mjs` + `web/scripts/a11y-scan.mjs`), and is run
+in CI against the real production bundle.
+
+---
+
+## 3. The shared hooks
+
+### `useUrlTableState<TFilters>`
+
+Per-page contract (implemented via `read` / `buildHref` / `toColumnFilters` /
+`fromColumnFilters`):
+
+| Returned value | What it is |
+|----------------|-----------|
+| `globalFilter` / `pagination` / `sorting` / `columnFilters` | derived from the URL; plug into `useDataTable` |
+| `onGlobalFilterChange` / `onPaginationChange` / `onSortingChange` / `onColumnFiltersChange` | stable callbacks that navigate |
+| `filters` | the raw page-specific `TFilters` (for controls + server query payloads) |
+| `updateUrlState(next)` | generic single-transaction navigate for page-specific filters |
+| `ensurePageInRange(pageCount)` | clamp the URL page when data shrinks |
+
+`UrlTableStateUpdate<TFilters>` is a partial update where `filters` is itself
+`Partial<TFilters>`, so a caller changes only the fields it owns.
+
+### `useDataTable`
+
+Owns the TanStack plumbing (row models, column visibility/sizing persistence,
+selection, pagination). Its `useControllableTableState` guarantees a stable
+setter identity for the controlled states it manages.
+
+---
+
+## 4. Page checklist
+
+When adding or auditing a list page:
+
+1. There is **no** `useState` initialized from `useSearch`/`window.location.search`
+   for any URL-backed field.
+2. There is **no** `useEffect` that calls `navigate` to write state back.
+3. Every table callback is a stable `useUrlTableState` return (not inline).
+4. Filter + page reset happen in **one** `updateUrlState`/`navigate`.
+5. `buildHref` merges the current URL (never a stale closure).
+6. `globalFilterFn` / `rowActions` / `columnActions` are module-level or memoized.
+7. Server-side pages use `resetPageIndexOnFilterChange: true` +
+   `autoResetPageIndex: false`.
+8. Deep links and back/forward round-trip (verified by the browser smoke gate).
+
+## 5. Anti-patterns (banned)
+
+- `useState(initialSearch)` + `useEffect(() => navigate({ search, replace: true }))`.
+- `history.replaceState` / `window.history.replaceState` called directly by a page
+  (always go through the router).
+- Inline `onPaginationChange={(value) => …}` / `globalFilterFn={(row) => …}`.
+- Multiple `navigate` calls for one user action (e.g. filter then page reset).
+- Serializing from a render-time snapshot of `search` instead of the live URL.

--- a/web/package.json
+++ b/web/package.json
@@ -43,7 +43,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
-    "a11y:scan": "node scripts/a11y-scan.mjs"
+    "a11y:scan": "node scripts/a11y-scan.mjs",
+    "ui:smoke": "node scripts/route-smoke.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/web/scripts/a11y-scan.mjs
+++ b/web/scripts/a11y-scan.mjs
@@ -17,6 +17,7 @@ import { fileURLToPath } from 'node:url'
 import { chromium } from 'playwright'
 
 const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3000'
+const AUTH_TOKEN = process.env.AUTH_TOKEN ?? 'dev-admin-token-123'
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const AXE_SOURCE = join(
   SCRIPT_DIR,
@@ -48,15 +49,18 @@ const browser = await chromium.launch({ headless: true })
 const context = await browser.newContext({
   viewport: { width: 1440, height: 900 },
 })
-await context.addInitScript(() => {
-  localStorage.setItem('auth_token', 'dev-admin-token-123')
-  localStorage.setItem(
-    'auth_token_expires_at',
-    String(Date.now() + 12 * 3600 * 1000)
-  )
-  localStorage.setItem('i18nextLng', 'en')
-  document.cookie = 'vite-ui-theme=light; path=/'
-})
+await context.addInitScript(
+  ({ token }) => {
+    localStorage.setItem('auth_token', token)
+    localStorage.setItem(
+      'auth_token_expires_at',
+      String(Date.now() + 12 * 3600 * 1000)
+    )
+    localStorage.setItem('i18nextLng', 'en')
+    document.cookie = 'vite-ui-theme=light; path=/'
+  },
+  { token: AUTH_TOKEN }
+)
 
 const failures = []
 for (const [name, path] of ROUTES) {

--- a/web/scripts/route-smoke.mjs
+++ b/web/scripts/route-smoke.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+// metapi-go — production-SPA crash / route / interaction smoke gate.
+//
+// This complements unit tests and axe: it loads the actual built SPA in a real
+// Chromium instance and fails on renderer exceptions, console errors, 5xx
+// responses, route-level error UI, or document-wide mobile overflow. It also
+// exercises the account-creation credential tabs because that flow previously
+// admitted a render feedback loop that unit/schema tests did not catch.
+
+import { chromium } from 'playwright'
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3000'
+const AUTH_TOKEN = process.env.AUTH_TOKEN ?? 'dev-admin-token-123'
+
+const DESKTOP_ROUTES = [
+  '/',
+  '/dashboard',
+  '/dashboard/overview',
+  '/dashboard/traffic',
+  '/dashboard/models',
+  '/dashboard/availability',
+  '/sites',
+  '/accounts',
+  '/checkin',
+  '/models',
+  '/model-tester',
+  '/oauth',
+  '/channels',
+  '/token-routes',
+  '/proxy-logs',
+  '/observability',
+  '/price-compare',
+  '/site-announcements',
+  '/fix-candidates',
+  '/about',
+  '/settings',
+  '/settings/general/site',
+  '/settings/general/authentication',
+  '/settings/general/scheduling',
+  '/settings/general/proxy-transport',
+  '/settings/general/routing',
+  '/settings/downstream/keys',
+  '/settings/downstream/proxy-token',
+  '/settings/models/redirects',
+  '/settings/models/rates',
+  '/settings/models/allowlist',
+  '/settings/content/import-export',
+  '/settings/content/notifications',
+  '/settings/content/announcements',
+  '/settings/system-info/program-logs',
+  '/settings/system-info/audit-logs',
+  '/settings/system-info/update-center',
+  '/settings/system-info/database',
+  '/settings/system-info/maintenance',
+  '/settings/system-info/danger-zone',
+]
+
+// Main product workspaces get a second pass at the 375px mobile contract.
+const MOBILE_ROUTES = [
+  '/',
+  '/sites',
+  '/accounts',
+  '/checkin',
+  '/models',
+  '/model-tester',
+  '/oauth',
+  '/channels',
+  '/token-routes',
+  '/proxy-logs',
+  '/observability',
+  '/price-compare',
+  '/site-announcements',
+  '/settings',
+]
+
+const ERROR_TEXT =
+  /(服务器错误|服务器内部错误|internal server error|something went wrong|application error|chunkloaderror)/i
+
+async function seedAuth(context) {
+  await context.addInitScript(
+    ({ token }) => {
+      localStorage.setItem('auth_token', token)
+      localStorage.setItem(
+        'auth_token_expires_at',
+        String(Date.now() + 12 * 3600 * 1000)
+      )
+      localStorage.setItem('i18nextLng', 'zh-CN')
+      document.cookie = 'vite-ui-theme=light; path=/'
+    },
+    { token: AUTH_TOKEN }
+  )
+}
+
+async function seedInteractionData(request) {
+  const response = await request.post(`${BASE_URL}/api/sites`, {
+    headers: {
+      Authorization: `Bearer ${AUTH_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    data: {
+      name: 'Browser Smoke Site',
+      url: 'https://example.invalid',
+      platform: 'new-api',
+    },
+  })
+  if (![200, 201, 409].includes(response.status())) {
+    throw new Error(
+      `failed to seed browser-smoke site: HTTP ${response.status()} ${await response.text()}`
+    )
+  }
+}
+
+function collectPageFailures(page, failures, label) {
+  page.on('pageerror', (error) => {
+    failures.push(`${label}: pageerror — ${error.message}`)
+  })
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      failures.push(`${label}: console.error — ${message.text()}`)
+    }
+  })
+  page.on('requestfailed', (request) => {
+    failures.push(
+      `${label}: request failed — ${request.method()} ${request.url()} (${request.failure()?.errorText ?? 'unknown'})`
+    )
+  })
+  page.on('response', (response) => {
+    if (response.status() >= 500) {
+      failures.push(
+        `${label}: HTTP ${response.status()} — ${response.request().method()} ${response.url()}`
+      )
+    }
+  })
+}
+
+async function scanRoute(context, route, failures, mobile = false) {
+  const label = `${mobile ? 'mobile' : 'desktop'} ${route}`
+  const page = await context.newPage()
+  collectPageFailures(page, failures, label)
+  try {
+    const response = await page.goto(BASE_URL + route, {
+      waitUntil: 'domcontentloaded',
+      timeout: 15_000,
+    })
+    await page.waitForTimeout(500)
+
+    if (response && response.status() >= 500) {
+      failures.push(`${label}: document returned HTTP ${response.status()}`)
+    }
+
+    const body = await page.locator('body').innerText({ timeout: 4_000 })
+    const errorText = body.match(ERROR_TEXT)?.[0]
+    if (errorText) failures.push(`${label}: rendered error UI — ${errorText}`)
+
+    // Renderer liveness check: this times out if a render/effect loop wedges the
+    // main thread after initial navigation.
+    await page.locator('body').getAttribute('class', { timeout: 3_000 })
+
+    if (mobile) {
+      const overflow = await page.evaluate(() => ({
+        viewport: document.documentElement.clientWidth,
+        document: document.documentElement.scrollWidth,
+      }))
+      // One CSS pixel of tolerance avoids fractional-rounding false positives.
+      if (overflow.document > overflow.viewport + 1) {
+        failures.push(
+          `${label}: document horizontal overflow ${overflow.document}px > ${overflow.viewport}px`
+        )
+      }
+    }
+  } catch (error) {
+    failures.push(
+      `${label}: smoke exception — ${String(error?.message ?? error).split('\n')[0]}`
+    )
+  } finally {
+    await page.close().catch(() => {})
+  }
+}
+
+async function exerciseUrlOwnedPage(context, route, failures) {
+  const label = `${route} url-state interaction`
+  const page = await context.newPage()
+  collectPageFailures(page, failures, label)
+  try {
+    await page.goto(`${BASE_URL}${route}`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 15_000,
+    })
+    await page.waitForTimeout(500)
+
+    // The toolbar's global search is the only input carrying a placeholder
+    // (date inputs are `datetime-local` with aria-labels, and the account/
+    // client selects expose their own unlabeled hidden input), so it is
+    // unambiguous here.
+    const search = page.locator('input[placeholder]').first()
+    await search.waitFor({ state: 'visible', timeout: 5_000 })
+    await search.fill('smokeq')
+
+    // The URL-owned hook navigates once after the toolbar debounce; this wait
+    // is the regression assertion for the old local-state + effect write-back
+    // loop (which either froze the renderer or never settled the URL).
+    await page.waitForFunction(
+      () => new URLSearchParams(window.location.search).get('q') === 'smokeq',
+      undefined,
+      { timeout: 5_000 }
+    )
+    await page.locator('body').getAttribute('class', { timeout: 3_000 })
+
+    if ((await search.inputValue()) !== 'smokeq') {
+      failures.push(
+        `${label}: search input lost the committed query after URL round-trip`
+      )
+    }
+
+    // Navigating away must not be hijacked by a stale table callback.
+    await page.goto(`${BASE_URL}/dashboard`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 15_000,
+    })
+    await page.waitForTimeout(500)
+    if (!page.url().startsWith(`${BASE_URL}/dashboard`)) {
+      failures.push(`${label}: navigation away was hijacked (${page.url()})`)
+    }
+    await page.locator('body').getAttribute('class', { timeout: 3_000 })
+  } catch (error) {
+    failures.push(`${label}: ${String(error?.message ?? error).split('\n')[0]}`)
+  } finally {
+    await page.close().catch(() => {})
+  }
+}
+
+async function exerciseAccounts(context, failures) {
+  const label = 'accounts interaction'
+  const page = await context.newPage()
+  collectPageFailures(page, failures, label)
+  try {
+    await page.goto(`${BASE_URL}/accounts`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 15_000,
+    })
+    await page.waitForTimeout(500)
+
+    const add = page
+      .getByRole('button', { name: /添加账号|Add account|Add/i })
+      .first()
+    await add.waitFor({ state: 'visible', timeout: 5_000 })
+    if (!(await add.isEnabled())) {
+      failures.push(
+        `${label}: add-account button unexpectedly disabled after site seed`
+      )
+      return
+    }
+
+    await add.click({ timeout: 5_000 })
+    const tabs = page.getByRole('tab')
+    if ((await tabs.count()) < 3) {
+      failures.push(`${label}: expected 3 credential-mode tabs`)
+      return
+    }
+
+    const password = page.getByRole('tab', { name: /密码|Password/i }).first()
+    await password.click({ timeout: 5_000 })
+    await page.waitForTimeout(200)
+
+    // A post-click DOM read is the regression assertion for the historical
+    // renderer freeze: it must complete promptly after the mode switch.
+    const body = await page.locator('body').innerText({ timeout: 3_000 })
+    if (!/密码|Password/i.test(body)) {
+      failures.push(`${label}: password credential mode did not render`)
+    }
+  } catch (error) {
+    failures.push(`${label}: ${String(error?.message ?? error).split('\n')[0]}`)
+  } finally {
+    await page.close().catch(() => {})
+  }
+}
+
+const browser = await chromium.launch({ headless: true })
+const failures = []
+try {
+  const desktop = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    locale: 'zh-CN',
+  })
+  await seedAuth(desktop)
+  await seedInteractionData(desktop.request)
+  for (const route of DESKTOP_ROUTES) {
+    await scanRoute(desktop, route, failures)
+  }
+  await exerciseAccounts(desktop, failures)
+  for (const route of ['/checkin', '/proxy-logs', '/token-routes']) {
+    await exerciseUrlOwnedPage(desktop, route, failures)
+  }
+  await desktop.close()
+
+  const mobile = await browser.newContext({
+    viewport: { width: 375, height: 812 },
+    locale: 'zh-CN',
+    isMobile: true,
+  })
+  await seedAuth(mobile)
+  for (const route of MOBILE_ROUTES) {
+    await scanRoute(mobile, route, failures, true)
+  }
+  await mobile.close()
+} finally {
+  await browser.close()
+}
+
+if (failures.length > 0) {
+  console.error(`[ui-smoke] ${failures.length} failure(s):`)
+  for (const failure of [...new Set(failures)]) console.error(`  ${failure}`)
+  process.exit(1)
+}
+
+console.log(
+  `[ui-smoke] clean — ${DESKTOP_ROUTES.length} desktop routes + ${MOBILE_ROUTES.length} mobile routes + accounts interaction + checkin/proxy-logs/token-routes url-state interactions.`
+)

--- a/web/src/components/data-table/hooks/use-data-table.ts
+++ b/web/src/components/data-table/hooks/use-data-table.ts
@@ -121,14 +121,20 @@ function useControllableTableState<TValue>(
 
   const value = controlledValue ?? uncontrolledValue
 
+  // Keep the callback stable: a fresh setValue identity on every render
+  // re-resolves the TanStack table, which re-runs its autoResetPageIndex
+  // effect and can feed an infinite render loop through the URL sync.
+  const onChangeRef = React.useRef(onChange)
+  onChangeRef.current = onChange
+
   const setValue = React.useCallback<OnChangeFn<TValue>>(
     (updater) => {
       if (controlledValue === undefined) {
         setUncontrolledValue((previous) => resolveUpdater(updater, previous))
       }
-      onChange?.(updater)
+      onChangeRef.current?.(updater)
     },
-    [controlledValue, onChange]
+    [controlledValue]
   )
 
   return [value, setValue]

--- a/web/src/components/data-table/hooks/use-url-table-state.ts
+++ b/web/src/components/data-table/hooks/use-url-table-state.ts
@@ -1,20 +1,34 @@
 // metapi-go/data-table — shared URL-synced table state hook.
 //
-// The list pages (sites / oauth / models) each mirror
-// table state (search / page / page-size / sorting / faceted filters) to the
-// URL so a deep link restores the exact view. This hook owns the TanStack
-// Router plumbing that was previously duplicated per page:
+// The list pages (sites / oauth / models / accounts / checkin / proxy-logs /
+// token-routes / …) each mirror table state (search / page / page-size /
+// sorting / faceted filters) plus page-specific filters to the URL so a deep
+// link restores the exact view. This hook owns the TanStack Router plumbing
+// that was previously duplicated per page:
 //
 //   - subscribing to `location.searchStr` (router does not re-render a route
 //     component on same-path search-only navigation otherwise)
 //   - the URL-sync guard that stops table callbacks from hijacking an
 //     in-flight navigation away from the page
-//   - the four controlled-state callbacks (globalFilter / pagination /
-//     sorting / columnFilters) that serialize changes back to the URL
+//   - the controlled-state callbacks (globalFilter / pagination / sorting /
+//     columnFilters) that serialize changes back to the URL
+//   - a generic `updateUrlState` primitive so page-specific, non-table filters
+//     (date ranges, account/client selects, latency bounds, …) change in the
+//     exact same single-transaction way instead of re-implementing navigate
+//     logic per page
 //
 // Each page supplies only the page-specific parts: how to parse the URL
 // (`read`), how to serialize it (`buildHref`), and how page filter values map
 // to TanStack column filters (`toColumnFilters` / `fromColumnFilters`).
+//
+// Stability contract: every returned value and callback keeps a stable
+// identity as long as its inputs are unchanged. useDataTable hands these
+// straight into useReactTable, and unstable callback identities force the
+// table to re-resolve every render — which re-runs TanStack's
+// autoResetPageIndex effect and can feed back through the URL into an
+// infinite render loop (the accounts page freeze). The page-supplied option
+// functions are read through a ref so inline definitions do not break the
+// contract.
 
 import { useLocation, useNavigate } from '@tanstack/react-router'
 import type {
@@ -23,6 +37,7 @@ import type {
   SortingState,
   Updater,
 } from '@tanstack/react-table'
+import * as React from 'react'
 
 /** Validated URL state for a list page. `filters` holds page-specific values. */
 export type UrlTableState<TFilters> = {
@@ -33,19 +48,37 @@ export type UrlTableState<TFilters> = {
   filters: TFilters
 }
 
+/**
+ * A partial URL-state update. `filters` is itself partial so a caller can
+ * change a single page-specific filter (or a single table column filter)
+ * without supplying every field; `buildHref` merges it over the current state.
+ */
+export type UrlTableStateUpdate<TFilters> = Partial<
+  Omit<UrlTableState<TFilters>, 'filters'>
+> & {
+  filters?: Partial<TFilters>
+}
+
 export type UrlTableStateOptions<TFilters> = {
   /** Base pathname used to build hrefs (e.g. '/sites'). */
   basePath: string
   /** Parse the validated URL state from a raw search string. */
   read: (searchString: string) => UrlTableState<TFilters>
   /** Serialize a partial state update back to a full href (path + query). */
-  buildHref: (next: Partial<UrlTableState<TFilters>>) => string
+  buildHref: (next: UrlTableStateUpdate<TFilters>) => string
   /** Map page filter values to table column filters. */
   toColumnFilters: (filters: TFilters) => ColumnFiltersState
   /** Map table column filters back to page filter values. */
   fromColumnFilters: (
     filters: ColumnFiltersState
-  ) => Partial<UrlTableState<TFilters>>
+  ) => UrlTableStateUpdate<TFilters>
+  /**
+   * When true, a globalFilter / columnFilters change also resets the page to 0
+   * in the same URL transaction. Server-side paginated pages want an explicit
+   * page reset on every filter change (and pass `autoResetPageIndex: false`
+   * to useDataTable so TanStack does not fire a second, redundant reset).
+   */
+  resetPageIndexOnFilterChange?: boolean
 }
 
 function resolveUpdater<TValue>(
@@ -66,7 +99,9 @@ export function encodeSorting(sorting: SortingState): string {
 
 /**
  * Controlled table state whose source of truth is the URL search string.
- * Re-exported fields plug straight into `useDataTable`.
+ * Re-exported fields plug straight into `useDataTable`; `filters` +
+ * `updateUrlState` cover the page-specific controls that are not TanStack
+ * column filters.
  */
 export function useUrlTableState<TFilters>(
   options: UrlTableStateOptions<TFilters>
@@ -74,9 +109,32 @@ export function useUrlTableState<TFilters>(
   const navigate = useNavigate()
   // Subscribe to the router location so search-only navigation re-renders.
   const searchStr = useLocation({ select: (loc) => loc.searchStr })
-  const search = options.read(searchStr)
+  const resetPageIndexOnFilterChange =
+    options.resetPageIndexOnFilterChange ?? false
 
-  const columnFilters = options.toColumnFilters(search.filters)
+  // Page-supplied functions are read through refs so inline definitions
+  // (recreated every render by the page) do not change any identity below.
+  const readRef = React.useRef(options.read)
+  readRef.current = options.read
+  const buildHrefRef = React.useRef(options.buildHref)
+  buildHrefRef.current = options.buildHref
+  const toColumnFiltersRef = React.useRef(options.toColumnFilters)
+  toColumnFiltersRef.current = options.toColumnFilters
+  const fromColumnFiltersRef = React.useRef(options.fromColumnFilters)
+  fromColumnFiltersRef.current = options.fromColumnFilters
+
+  const search = React.useMemo(() => readRef.current(searchStr), [searchStr])
+  const columnFilters = React.useMemo(
+    () => toColumnFiltersRef.current(search.filters),
+    [search.filters]
+  )
+  const pagination = React.useMemo<PaginationState>(
+    () => ({
+      pageIndex: search.pageIndex,
+      pageSize: search.pageSize,
+    }),
+    [search.pageIndex, search.pageSize]
+  )
 
   // URL-sync guard: table state callbacks can fire while the router is
   // navigating away (the useLocation subscription re-renders this page with
@@ -84,53 +142,73 @@ export function useUrlTableState<TFilters>(
   // callback would navigate straight back, hijacking the in-flight
   // navigation — the "clicked a sidebar link but the page snapped back"
   // bug. Only sync when we are still on this page.
-  function syncUrl(next: Partial<UrlTableState<TFilters>>) {
-    const href = options.buildHref(next)
-    if (!href.startsWith(window.location.pathname)) return
-    navigate({ href, replace: true })
-  }
+  const updateUrlState = React.useCallback(
+    (next: UrlTableStateUpdate<TFilters>) => {
+      const href = buildHrefRef.current(next)
+      if (!href.startsWith(window.location.pathname)) return
+      navigate({ href, replace: true })
+    },
+    [navigate]
+  )
 
-  const onGlobalFilterChange = (updater: Updater<string>) => {
-    syncUrl({ q: resolveUpdater(updater, search.q) })
-  }
-  const onPaginationChange = (updater: Updater<PaginationState>) => {
-    const next = resolveUpdater(updater, {
-      pageIndex: search.pageIndex,
-      pageSize: search.pageSize,
-    })
-    syncUrl({ pageIndex: next.pageIndex, pageSize: next.pageSize })
-  }
-  const onSortingChange = (updater: Updater<SortingState>) => {
-    syncUrl({ sorting: resolveUpdater(updater, search.sorting) })
-  }
-  const onColumnFiltersChange = (updater: Updater<ColumnFiltersState>) => {
-    const next = resolveUpdater(updater, columnFilters)
-    syncUrl(options.fromColumnFilters(next))
-  }
+  const onGlobalFilterChange = React.useCallback(
+    (updater: Updater<string>) => {
+      updateUrlState({
+        q: resolveUpdater(updater, search.q),
+        ...(resetPageIndexOnFilterChange ? { pageIndex: 0 } : {}),
+      })
+    },
+    [updateUrlState, search.q, resetPageIndexOnFilterChange]
+  )
+  const onPaginationChange = React.useCallback(
+    (updater: Updater<PaginationState>) => {
+      const next = resolveUpdater(updater, pagination)
+      updateUrlState({ pageIndex: next.pageIndex, pageSize: next.pageSize })
+    },
+    [updateUrlState, pagination]
+  )
+  const onSortingChange = React.useCallback(
+    (updater: Updater<SortingState>) => {
+      updateUrlState({ sorting: resolveUpdater(updater, search.sorting) })
+    },
+    [updateUrlState, search.sorting]
+  )
+  const onColumnFiltersChange = React.useCallback(
+    (updater: Updater<ColumnFiltersState>) => {
+      const next = resolveUpdater(updater, columnFilters)
+      updateUrlState({
+        ...fromColumnFiltersRef.current(next),
+        ...(resetPageIndexOnFilterChange ? { pageIndex: 0 } : {}),
+      })
+    },
+    [updateUrlState, columnFilters, resetPageIndexOnFilterChange]
+  )
 
   // Clamp the URL page when the data shrinks (deep-linked stale page numbers
   // would otherwise render an empty page with a confusing "no results" empty
   // state). Pass this directly to useDataTable's `ensurePageInRange`.
-  function ensurePageInRange(pageCount: number) {
-    if (pageCount <= 0) return
-    const maxIndex = pageCount - 1
-    if (search.pageIndex > maxIndex) {
-      syncUrl({ pageIndex: maxIndex })
-    }
-  }
+  const ensurePageInRange = React.useCallback(
+    (pageCount: number) => {
+      if (pageCount <= 0) return
+      const maxIndex = pageCount - 1
+      if (search.pageIndex > maxIndex) {
+        updateUrlState({ pageIndex: maxIndex })
+      }
+    },
+    [updateUrlState, search.pageIndex]
+  )
 
   return {
     globalFilter: search.q,
     onGlobalFilterChange,
-    pagination: {
-      pageIndex: search.pageIndex,
-      pageSize: search.pageSize,
-    } as PaginationState,
+    pagination,
     onPaginationChange,
     sorting: search.sorting,
     onSortingChange,
     columnFilters,
     onColumnFiltersChange,
+    filters: search.filters,
+    updateUrlState,
     ensurePageInRange,
   }
 }

--- a/web/src/components/data-table/index.ts
+++ b/web/src/components/data-table/index.ts
@@ -6,4 +6,7 @@ export { DataTableBulkActions } from './toolbar/bulk-actions'
 export { DataTablePage } from './layout/data-table-page'
 export { useDataTable } from './hooks/use-data-table'
 export { encodeSorting, useUrlTableState } from './hooks/use-url-table-state'
-export type { UrlTableState } from './hooks/use-url-table-state'
+export type {
+  UrlTableState,
+  UrlTableStateUpdate,
+} from './hooks/use-url-table-state'

--- a/web/src/features/accounts/__tests__/accounts-page-deep-link.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-page-deep-link.test.tsx
@@ -35,6 +35,15 @@ vi.mock('@tanstack/react-router', () => ({
 vi.mock('@/components/data-table', () => ({
   DataTableBulkActions: () => null,
   DataTablePage: () => null,
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    ensurePageInRange: vi.fn(),
+  }),
   useDataTable: () => ({
     table: {
       getFilteredSelectedRowModel: () => ({ rows: [] }),

--- a/web/src/features/accounts/__tests__/accounts-search-schema.test.ts
+++ b/web/src/features/accounts/__tests__/accounts-search-schema.test.ts
@@ -12,12 +12,14 @@ describe('accountsSearchSchema', () => {
       page: '2',
       pageSize: '50',
       q: 'alice',
+      sort: 'name:asc,status:desc',
       status: 'active,disabled',
       site: '1,3',
     })
     expect(result.page).toBe(2)
     expect(result.pageSize).toBe(50)
     expect(result.q).toBe('alice')
+    expect(result.sort).toBe('name:asc,status:desc')
     expect(result.status).toBe('active,disabled')
     expect(result.site).toBe('1,3')
   })

--- a/web/src/features/accounts/components/__tests__/account-form-dialog.test.tsx
+++ b/web/src/features/accounts/components/__tests__/account-form-dialog.test.tsx
@@ -20,6 +20,7 @@ vi.mock('../../api', () => ({
   useCreateAccount: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useUpdateAccount: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useLoginAccount: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useVerifyAccountToken: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }))
 
 beforeAll(() => {

--- a/web/src/features/accounts/components/__tests__/account-form-dialog.test.tsx
+++ b/web/src/features/accounts/components/__tests__/account-form-dialog.test.tsx
@@ -1,0 +1,76 @@
+// Regression guard for the credential-mode UI used by the account-creation
+// browser smoke. The real-browser gate owns renderer-loop detection; this unit
+// test keeps the three modes and password field transition cheap to diagnose.
+import '@testing-library/jest-dom/vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import type { Site } from '../../types'
+import { AccountFormDialog } from '../account-form-dialog'
+
+vi.mock('../../api', () => ({
+  useCreateAccount: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateAccount: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useLoginAccount: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+afterEach(() => cleanup())
+
+const sites: Site[] = [
+  {
+    id: 1,
+    name: 'Browser Smoke Site',
+    url: 'https://example.invalid',
+    platform: 'new-api',
+    status: 'active',
+  },
+]
+
+describe('AccountFormDialog credential modes', () => {
+  it('renders all modes and switches to password fields', async () => {
+    render(
+      <AccountFormDialog
+        open
+        onOpenChange={() => {}}
+        mode='create'
+        account={null}
+        sites={sites}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('tab')).toHaveLength(3)
+    })
+
+    const passwordTab = screen.getByRole('tab', { name: /密码|Password/i })
+    fireEvent.click(passwordTab)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/密码|Password/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -7,14 +7,15 @@
 // automatically by DataTablePage. Row actions + bulk actions call the
 // TanStack Query mutation hooks; the create/edit form, detail sheet, and
 // delete confirm live as siblings of the table.
+//
+// URL state uses the shared useUrlTableState hook (same as sites/oauth/
+// models): the URL is the single source of truth and the callbacks navigate,
+// so there is no local state + navigate effect that can feed back into an
+// infinite render loop (the accounts page previously froze the renderer on
+// any interaction — see the URL-state loop fix).
 
 import { useNavigate, useSearch } from '@tanstack/react-router'
-import type {
-  ColumnFiltersState,
-  OnChangeFn,
-  PaginationState,
-  Table,
-} from '@tanstack/react-table'
+import type { ColumnFiltersState, Table } from '@tanstack/react-table'
 import {
   Loader2,
   Plus,
@@ -23,13 +24,17 @@ import {
   Trash2,
   Upload as UploadIcon,
 } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
   DataTableBulkActions,
   DataTablePage,
+  encodeSorting,
+  type UrlTableState,
+  type UrlTableStateUpdate,
   useDataTable,
+  useUrlTableState,
 } from '@/components/data-table'
 import { Button } from '@/components/ui/button'
 import {
@@ -41,7 +46,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { ImportWizardDialog } from '@/features/import'
-import { asStringParam } from '@/lib/helpers/searchParams'
+import { parseSortingParam } from '@/lib/helpers/searchParams'
 import { toast } from '@/lib/toast'
 
 import {
@@ -62,101 +67,144 @@ import { useAccountsColumns } from './accounts-columns'
 
 const DEFAULT_PAGE_SIZE = 20
 
+/** Page-specific URL filters: comma-separated status + site id lists. */
+type AccountsUrlFilters = {
+  status: string
+  site: string
+}
+
+/**
+ * Parse the raw search string into URL table state. The accounts URL uses a
+ * 1-based `page` param (route schema: accountsSearchSchema); `q` / `status` /
+ * `site` are plain strings.
+ */
+function readAccountsSearch(
+  searchString: string
+): UrlTableState<AccountsUrlFilters> {
+  const params = new URLSearchParams(searchString)
+  const rawPage = Number(params.get('page') ?? '1')
+  const rawPageSize = Number(
+    params.get('pageSize') ?? String(DEFAULT_PAGE_SIZE)
+  )
+  const pageIndex =
+    Number.isFinite(rawPage) && rawPage > 0 ? Math.max(0, rawPage - 1) : 0
+  const pageSize =
+    Number.isFinite(rawPageSize) && rawPageSize > 0
+      ? Math.min(200, Math.max(1, rawPageSize))
+      : DEFAULT_PAGE_SIZE
+  return {
+    q: params.get('q') ?? '',
+    pageIndex,
+    pageSize,
+    sorting: parseSortingParam(params.get('sort') ?? undefined),
+    filters: {
+      status: params.get('status') ?? '',
+      site: params.get('site') ?? '',
+    },
+  }
+}
+
+/** Serialize a partial state update back to the 1-based accounts href,
+ *  merging over the CURRENT url state (so a pagination sync preserves q /
+ *  status / site — stripping them re-triggered the toolbar's debounced
+ *  search commit and looped the renderer). */
+function buildAccountsHref(
+  next: UrlTableStateUpdate<AccountsUrlFilters>
+): string {
+  const currentParams = new URLSearchParams(window.location.search)
+  const current = readAccountsSearch(window.location.search)
+  const merged: UrlTableState<AccountsUrlFilters> = {
+    ...current,
+    ...next,
+    filters: { ...current.filters, ...next.filters },
+  }
+  const params = new URLSearchParams()
+  if (merged.q) params.set('q', merged.q)
+  if (merged.pageIndex > 0) params.set('page', String(merged.pageIndex + 1))
+  if (merged.pageSize !== DEFAULT_PAGE_SIZE) {
+    params.set('pageSize', String(merged.pageSize))
+  }
+  const sortString = encodeSorting(merged.sorting)
+  if (sortString) params.set('sort', sortString)
+  if (merged.filters.status) params.set('status', merged.filters.status)
+  if (merged.filters.site) params.set('site', merged.filters.site)
+  const guidedSiteId = currentParams.get('siteId')
+  const guidedCreate = currentParams.get('create')
+  if (guidedSiteId) params.set('siteId', guidedSiteId)
+  if (guidedCreate) params.set('create', guidedCreate)
+  const queryString = params.toString()
+  return queryString ? `/accounts?${queryString}` : '/accounts'
+}
+
+/** The "feature useSearch" stage, mirroring the sites page. */
+function useAccountsUrlState() {
+  return useUrlTableState<AccountsUrlFilters>({
+    basePath: '/accounts',
+    read: readAccountsSearch,
+    buildHref: buildAccountsHref,
+    toColumnFilters: (filters) => {
+      const out: ColumnFiltersState = []
+      const statusValues = filters.status.split(',').filter(Boolean)
+      const siteIds = filters.site.split(',').filter(Boolean)
+      if (statusValues.length) out.push({ id: 'status', value: statusValues })
+      if (siteIds.length) out.push({ id: 'site', value: siteIds })
+      return out
+    },
+    fromColumnFilters: (filters) => {
+      const statusEntry = filters.find((filter) => filter.id === 'status')
+      const siteEntry = filters.find((filter) => filter.id === 'site')
+      return {
+        filters: {
+          status: Array.isArray(statusEntry?.value)
+            ? statusEntry.value.join(',')
+            : '',
+          site: Array.isArray(siteEntry?.value)
+            ? siteEntry.value.join(',')
+            : '',
+        },
+      }
+    },
+  })
+}
+
+// Module-level so the table's globalFilterFn keeps a stable identity across
+// renders (a fresh inline function would re-resolve the table every render).
+function accountsGlobalFilterFn(
+  row: { original: unknown },
+  _columnId: string,
+  filterValue: string
+): boolean {
+  const account = accountSchema.parse(row.original)
+  const haystack = [
+    account.username ?? '',
+    account.site?.name ?? '',
+    account.site?.platform ?? '',
+    account.site?.url ?? '',
+    ...(account.tags ?? []),
+  ]
+    .join(' ')
+    .toLowerCase()
+  return haystack.includes(String(filterValue).toLowerCase())
+}
+
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
 export function AccountsPage() {
   const { t } = useTranslation()
-  // URL state is owned by the router: read the validated search via
-  // `useSearch` (no `window.location.search`), and write changes back via
-  // `navigate({ search, replace: true })` (no `history.replaceState`).
   const search = useSearch({ from: '/_authenticated/accounts' })
   const navigate = useNavigate()
+  const urlState = useAccountsUrlState()
   const { data, isLoading, isFetching, error } = useAccounts()
   const accounts = data?.accounts ?? []
   const sites = data?.sites ?? []
 
-  const refreshMutation = useRefreshAccount()
+  const { mutate: refreshAccount } = useRefreshAccount()
   const deleteMutation = useDeleteAccount()
-  const pinMutation = useToggleAccountPin()
-  const statusMutation = useToggleAccountStatus()
-  const checkinMutation = useToggleAccountCheckin()
-
-  // --- table state (client-side, URL-synced) ---
-  const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: (search.page ?? 1) - 1,
-    pageSize: search.pageSize ?? DEFAULT_PAGE_SIZE,
-  })
-  const [globalFilter, setGlobalFilter] = useState(
-    asStringParam(search.q) ?? ''
-  )
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(() => {
-    const filters: ColumnFiltersState = []
-    const statusValues =
-      asStringParam(search.status)?.split(',').filter(Boolean) ?? []
-    const siteIds = asStringParam(search.site)?.split(',').filter(Boolean) ?? []
-    if (statusValues.length) {
-      filters.push({ id: 'status', value: statusValues })
-    }
-    if (siteIds.length) {
-      filters.push({ id: 'site', value: siteIds })
-    }
-    return filters
-  })
-
-  // Write state back to the URL through the router (single source of truth).
-  // Skip the initial write — the URL already holds the search the state was
-  // initialised from.
-  const skipInitialWrite = useRef(true)
-  useEffect(() => {
-    if (skipInitialWrite.current) {
-      skipInitialWrite.current = false
-      return
-    }
-    const statusFilter = columnFilters.find((filter) => filter.id === 'status')
-    const siteFilter = columnFilters.find((filter) => filter.id === 'site')
-    navigate({
-      to: '/accounts',
-      search: {
-        page: pagination.pageIndex > 0 ? pagination.pageIndex + 1 : undefined,
-        pageSize:
-          pagination.pageSize !== DEFAULT_PAGE_SIZE
-            ? pagination.pageSize
-            : undefined,
-        q: globalFilter || undefined,
-        status:
-          Array.isArray(statusFilter?.value) && statusFilter.value.length
-            ? statusFilter.value.join(',')
-            : undefined,
-        site:
-          Array.isArray(siteFilter?.value) && siteFilter.value.length
-            ? siteFilter.value.join(',')
-            : undefined,
-      },
-      replace: true,
-    })
-  }, [pagination, globalFilter, columnFilters, navigate])
-
-  // onChange wrappers that reset to the first page on filter changes.
-  const onGlobalFilterChange = useMemo<OnChangeFn<string>>(
-    () => (updater) => {
-      setGlobalFilter((prev) =>
-        updater instanceof Function ? updater(prev) : updater
-      )
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }))
-    },
-    []
-  )
-  const onColumnFiltersChange = useMemo<OnChangeFn<ColumnFiltersState>>(
-    () => (updater) => {
-      setColumnFilters((prev) =>
-        updater instanceof Function ? updater(prev) : updater
-      )
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }))
-    },
-    []
-  )
+  const { mutate: toggleAccountPin } = useToggleAccountPin()
+  const { mutate: toggleAccountStatus } = useToggleAccountStatus()
+  const { mutate: toggleAccountCheckin } = useToggleAccountCheckin()
 
   // --- dialog state ---
   const [formOpen, setFormOpen] = useState(false)
@@ -208,37 +256,49 @@ export function AccountsPage() {
     })
   }, [search, isLoading, data, navigate])
 
-  const openEdit = (account: Account) => {
+  const openEdit = useCallback((account: Account) => {
     setFormMode('edit')
     setEditAccount(account)
     setFormOpen(true)
-  }
+  }, [])
 
   // --- row actions (handed to the columns hook) ---
-  const rowActions: AccountRowActions = {
-    onEdit: openEdit,
-    onDelete: (account) => {
-      setDeleteAccount(account)
-      setDeleteOpen(true)
-    },
-    onRefresh: (account) => refreshMutation.mutate(account.id),
-    onViewDetail: (account) => {
-      setDetailAccount(account)
-      setDetailOpen(true)
-    },
-    onTogglePin: (account) =>
-      pinMutation.mutate({ id: account.id, isPinned: !account.isPinned }),
-    onToggleStatus: (account) =>
-      statusMutation.mutate({
-        id: account.id,
-        status: account.status === 'active' ? 'disabled' : 'active',
-      }),
-    onToggleCheckin: (account) =>
-      checkinMutation.mutate({
-        id: account.id,
-        checkinEnabled: !account.checkinEnabled,
-      }),
-  }
+  // Memoized so the column defs keep a stable identity across renders; a
+  // fresh object every render re-resolves the TanStack table instance and
+  // re-runs its autoResetPageIndex effect (the old render-loop feedback).
+  const rowActions = useMemo<AccountRowActions>(
+    () => ({
+      onEdit: openEdit,
+      onDelete: (account) => {
+        setDeleteAccount(account)
+        setDeleteOpen(true)
+      },
+      onRefresh: (account) => refreshAccount(account.id),
+      onViewDetail: (account) => {
+        setDetailAccount(account)
+        setDetailOpen(true)
+      },
+      onTogglePin: (account) =>
+        toggleAccountPin({ id: account.id, isPinned: !account.isPinned }),
+      onToggleStatus: (account) =>
+        toggleAccountStatus({
+          id: account.id,
+          status: account.status === 'active' ? 'disabled' : 'active',
+        }),
+      onToggleCheckin: (account) =>
+        toggleAccountCheckin({
+          id: account.id,
+          checkinEnabled: !account.checkinEnabled,
+        }),
+    }),
+    [
+      openEdit,
+      refreshAccount,
+      toggleAccountPin,
+      toggleAccountStatus,
+      toggleAccountCheckin,
+    ]
+  )
 
   const columns = useAccountsColumns(rowActions)
 
@@ -246,28 +306,14 @@ export function AccountsPage() {
     data: accounts,
     columns,
     enableRowSelection: true,
-    globalFilter,
-    onGlobalFilterChange,
-    columnFilters,
-    onColumnFiltersChange,
-    pagination,
-    onPaginationChange: setPagination,
-    // Client-side global search across username / site name / platform /
-    // url / tags. Passed inline so the option's contextual typing drives the
-    // param types (avoids implicit-any + keeps the filter stable enough).
-    globalFilterFn: (row, _columnId, filterValue) => {
-      const account = accountSchema.parse(row.original)
-      const haystack = [
-        account.username ?? '',
-        account.site?.name ?? '',
-        account.site?.platform ?? '',
-        account.site?.url ?? '',
-        ...(account.tags ?? []),
-      ]
-        .join(' ')
-        .toLowerCase()
-      return haystack.includes(String(filterValue).toLowerCase())
-    },
+    globalFilter: urlState.globalFilter,
+    onGlobalFilterChange: urlState.onGlobalFilterChange,
+    columnFilters: urlState.columnFilters,
+    onColumnFiltersChange: urlState.onColumnFiltersChange,
+    pagination: urlState.pagination,
+    onPaginationChange: urlState.onPaginationChange,
+    ensurePageInRange: urlState.ensurePageInRange,
+    globalFilterFn: accountsGlobalFilterFn,
   })
 
   const confirmDelete = async () => {

--- a/web/src/features/channels/components/channels-page.tsx
+++ b/web/src/features/channels/components/channels-page.tsx
@@ -15,6 +15,7 @@ import {
   useDataTable,
   useUrlTableState,
   type UrlTableState,
+  type UrlTableStateUpdate,
 } from '@/components/data-table'
 import { asStringParam, parseSortingParam } from '@/lib/helpers/searchParams'
 
@@ -57,7 +58,7 @@ function readSearch(searchString?: string): UrlTableState<ChannelsUrlFilters> {
   }
 }
 
-function buildHref(next: Partial<UrlTableState<ChannelsUrlFilters>>): string {
+function buildHref(next: UrlTableStateUpdate<ChannelsUrlFilters>): string {
   const current = readSearch()
   const merged = { ...current, ...next }
   const params = new URLSearchParams()

--- a/web/src/features/channels/lib/channels-schema.ts
+++ b/web/src/features/channels/lib/channels-schema.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 import {
   encodeSortingParam,
   stringSearchParam,
+  tableSortingItemSchema,
 } from '@/lib/helpers/searchParams'
 
 export const channelsSearchSchema = z.object({
@@ -14,10 +15,7 @@ export const channelsSearchSchema = z.object({
   page: z.coerce.number().int().min(0).catch(0).default(0),
   pageSize: z.coerce.number().int().min(1).max(200).catch(20).default(20),
   sort: z
-    .union([
-      z.string(),
-      z.array(z.object({ id: z.string(), desc: z.boolean() })),
-    ])
+    .union([z.string(), z.array(tableSortingItemSchema)])
     .optional()
     .transform((value) => encodeSortingParam(value))
     .catch(undefined),

--- a/web/src/features/checkin/components/checkin-page.tsx
+++ b/web/src/features/checkin/components/checkin-page.tsx
@@ -6,18 +6,25 @@
 // backend returns the real total, so date-range / status / reason / site /
 // search filters see the full log history instead of the legacy 500-row
 // client cap that silently dropped older records.
+//
+// URL state uses the shared useUrlTableState hook (same as sites/oauth/
+// models/accounts): the URL is the single source of truth and every control
+// navigates in one transaction (filter + page reset together), so there is no
+// local `useState` mirror + `useEffect` write-back that can feed back into an
+// infinite render loop.
 
-import { useNavigate, useSearch } from '@tanstack/react-router'
-import type {
-  ColumnFiltersState,
-  OnChangeFn,
-  PaginationState,
-} from '@tanstack/react-table'
+import type { ColumnFiltersState } from '@tanstack/react-table'
 import { CalendarRange, Loader2, RotateCw, Zap } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { DataTablePage, useDataTable } from '@/components/data-table'
+import {
+  DataTablePage,
+  type UrlTableState,
+  type UrlTableStateUpdate,
+  useDataTable,
+  useUrlTableState,
+} from '@/components/data-table'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -35,6 +42,7 @@ import { toast } from '@/lib/toast'
 import { useCheckinAccount, useCheckinLogs, useManualCheckin } from '../api'
 import {
   DEFAULT_CHECKIN_PAGE_SIZE,
+  parseCheckinSearch,
   parseFilterValues,
 } from '../lib/checkin-schema'
 import { localDatetimeInputToUtcRfc3339 } from '../lib/checkin-time'
@@ -45,35 +53,143 @@ import { ManualCheckinDialog } from './manual-checkin-dialog'
 
 const ACCOUNT_FILTER_ALL = 'all'
 
-export function CheckinPage() {
-  const { t } = useTranslation()
-  // URL state is owned by the router: read the validated search via
-  // `useSearch` (no `window.location.search`), write changes back via
-  // `navigate({ search, replace: true })` (no `history.replaceState`).
-  const search = useSearch({ from: '/_authenticated/checkin' })
-  const navigate = useNavigate()
-  const [pagination, setPagination] = useState<PaginationState>({
+/** Page-specific URL filters: comma-separated lists + date range + account. */
+type CheckinUrlFilters = {
+  status: string
+  reason: string
+  site: string
+  accountId: string
+  from: string
+  to: string
+}
+
+/**
+ * Parse the raw search string into URL table state. Reuses the route's
+ * `parseCheckinSearch` (same schema the loader uses) so the page's derived
+ * query payload exactly matches the prefetched cache key — no double fetch.
+ */
+function readCheckinSearch(
+  searchString: string
+): UrlTableState<CheckinUrlFilters> {
+  const search = parseCheckinSearch(searchString)
+  return {
+    q: asStringParam(search.q) ?? '',
     pageIndex: search.page - 1,
     pageSize: search.pageSize,
+    sorting: [],
+    filters: {
+      status: asStringParam(search.status) ?? '',
+      reason: asStringParam(search.reason) ?? '',
+      site: asStringParam(search.site) ?? '',
+      accountId: search.accountId === undefined ? '' : String(search.accountId),
+      from: asStringParam(search.from) ?? '',
+      to: asStringParam(search.to) ?? '',
+    },
+  }
+}
+
+/** Serialize a partial state update back to the checkin href, merging over
+ *  the CURRENT url state so a single filter change preserves all others. */
+function buildCheckinHref(
+  next: UrlTableStateUpdate<CheckinUrlFilters>
+): string {
+  const current = readCheckinSearch(window.location.search)
+  const merged: UrlTableState<CheckinUrlFilters> = {
+    ...current,
+    ...next,
+    filters: { ...current.filters, ...next.filters },
+  }
+  const params = new URLSearchParams()
+  if (merged.q) params.set('q', merged.q)
+  if (merged.pageIndex > 0) params.set('page', String(merged.pageIndex + 1))
+  if (merged.pageSize !== DEFAULT_CHECKIN_PAGE_SIZE) {
+    params.set('pageSize', String(merged.pageSize))
+  }
+  if (merged.filters.status) params.set('status', merged.filters.status)
+  if (merged.filters.reason) params.set('reason', merged.filters.reason)
+  if (merged.filters.site) params.set('site', merged.filters.site)
+  if (merged.filters.accountId) {
+    params.set('accountId', merged.filters.accountId)
+  }
+  if (merged.filters.from) params.set('from', merged.filters.from)
+  if (merged.filters.to) params.set('to', merged.filters.to)
+  const queryString = params.toString()
+  return queryString ? `/checkin?${queryString}` : '/checkin'
+}
+
+function useCheckinUrlState() {
+  return useUrlTableState<CheckinUrlFilters>({
+    basePath: '/checkin',
+    read: readCheckinSearch,
+    buildHref: buildCheckinHref,
+    toColumnFilters: (filters) => {
+      const out: ColumnFiltersState = []
+      const statusValues = parseFilterValues(filters.status)
+      const reasonValues = parseFilterValues(filters.reason)
+      const siteValues = parseFilterValues(filters.site)
+      if (statusValues.length) out.push({ id: 'status', value: statusValues })
+      if (reasonValues.length) out.push({ id: 'reason', value: reasonValues })
+      if (siteValues.length) out.push({ id: 'site', value: siteValues })
+      return out
+    },
+    fromColumnFilters: (filters) => {
+      const statusEntry = filters.find((filter) => filter.id === 'status')
+      const reasonEntry = filters.find((filter) => filter.id === 'reason')
+      const siteEntry = filters.find((filter) => filter.id === 'site')
+      return {
+        filters: {
+          status: Array.isArray(statusEntry?.value)
+            ? statusEntry.value.join(',')
+            : '',
+          reason: Array.isArray(reasonEntry?.value)
+            ? reasonEntry.value.join(',')
+            : '',
+          site: Array.isArray(siteEntry?.value)
+            ? siteEntry.value.join(',')
+            : '',
+        },
+      }
+    },
+    resetPageIndexOnFilterChange: true,
   })
-  const [globalFilter, setGlobalFilter] = useState(
-    asStringParam(search.q) ?? ''
-  )
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(() => {
-    const filters: ColumnFiltersState = []
-    const statusValues = parseFilterValues(asStringParam(search.status))
-    if (statusValues.length) filters.push({ id: 'status', value: statusValues })
-    const reasonValues = parseFilterValues(asStringParam(search.reason))
-    if (reasonValues.length) filters.push({ id: 'reason', value: reasonValues })
-    const siteValues = parseFilterValues(asStringParam(search.site))
-    if (siteValues.length) filters.push({ id: 'site', value: siteValues })
-    return filters
-  })
-  const [accountId, setAccountId] = useState<number | undefined>(
-    search.accountId
-  )
-  const [from, setFrom] = useState(asStringParam(search.from) ?? '')
-  const [to, setTo] = useState(asStringParam(search.to) ?? '')
+}
+
+// Module-level so the table's globalFilterFn keeps a stable identity across
+// renders (a fresh inline function would re-resolve the table every render).
+function checkinGlobalFilterFn(
+  row: { original: unknown },
+  _columnId: string,
+  filterValue: string
+): boolean {
+  const log = checkinLogRowSchema.parse(row.original)
+  const haystack = [
+    log.accounts?.username ?? '',
+    log.sites?.name ?? '',
+    log.sites?.url ?? '',
+    log.checkin_logs.message ?? '',
+    log.checkin_logs.reward ?? '',
+  ]
+    .join(' ')
+    .toLowerCase()
+  return haystack.includes(String(filterValue).toLowerCase())
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function CheckinPage() {
+  const { t } = useTranslation()
+  const {
+    globalFilter,
+    pagination,
+    columnFilters,
+    onGlobalFilterChange,
+    onPaginationChange,
+    onColumnFiltersChange,
+    filters,
+    updateUrlState,
+  } = useCheckinUrlState()
 
   const { data: accountsSnapshot } = useAccounts()
   const accountOptions = accountsSnapshot?.accounts ?? []
@@ -93,24 +209,23 @@ export function CheckinPage() {
   const [detailRow, setDetailRow] = useState<CheckinLogRow | null>(null)
   const [manualOpen, setManualOpen] = useState(false)
 
-  // Resolve the active server-side filter values from the column-filter
-  // state (the toolbar faceted filters drive these). status is single-select,
-  // so only the first value is forwarded to the backend.
-  const statusValues = useMemo(() => {
-    const statusFilter = columnFilters.find((filter) => filter.id === 'status')
-    const value = statusFilter?.value
-    return Array.isArray(value) ? (value as string[]) : []
-  }, [columnFilters])
-  const reasonValues = useMemo(() => {
-    const reasonFilter = columnFilters.find((filter) => filter.id === 'reason')
-    const value = reasonFilter?.value
-    return Array.isArray(value) ? (value as string[]) : []
-  }, [columnFilters])
-  const siteValues = useMemo(() => {
-    const siteFilter = columnFilters.find((filter) => filter.id === 'site')
-    const value = siteFilter?.value
-    return Array.isArray(value) ? (value as string[]) : []
-  }, [columnFilters])
+  // Derive the active server-side filter values directly from the URL-owned
+  // filters (single source of truth — no local mirror to sync back).
+  const accountId = filters.accountId ? Number(filters.accountId) : undefined
+  const from = filters.from
+  const to = filters.to
+  const statusValues = useMemo(
+    () => parseFilterValues(filters.status),
+    [filters.status]
+  )
+  const reasonValues = useMemo(
+    () => parseFilterValues(filters.reason),
+    [filters.reason]
+  )
+  const siteValues = useMemo(
+    () => parseFilterValues(filters.site),
+    [filters.site]
+  )
 
   const fromUtc = useMemo(
     () => localDatetimeInputToUtcRfc3339(from, false),
@@ -151,101 +266,44 @@ export function CheckinPage() {
   const logs = useMemo(() => logsPage?.items ?? [], [logsPage])
   const total = logsPage?.total ?? 0
 
-  // Write state back to the URL through the router (single source of truth).
-  // Skip the initial write — the URL already holds the search the state was
-  // initialised from.
-  const skipInitialWrite = useRef(true)
-  useEffect(() => {
-    if (skipInitialWrite.current) {
-      skipInitialWrite.current = false
-      return
-    }
-    navigate({
-      to: '/checkin',
-      search: {
-        page: pagination.pageIndex > 0 ? pagination.pageIndex + 1 : undefined,
-        pageSize:
-          pagination.pageSize !== DEFAULT_CHECKIN_PAGE_SIZE
-            ? pagination.pageSize
-            : undefined,
-        accountId: accountId || undefined,
-        status: statusValues.length ? statusValues.join(',') : undefined,
-        reason: reasonValues.length ? reasonValues.join(',') : undefined,
-        site: siteValues.length ? siteValues.join(',') : undefined,
-        from: from || undefined,
-        to: to || undefined,
-        q: globalFilter || undefined,
-      },
-      replace: true,
-    })
-  }, [
-    pagination,
-    accountId,
-    from,
-    to,
-    globalFilter,
-    statusValues,
-    reasonValues,
-    siteValues,
-    navigate,
-  ])
-
-  const onGlobalFilterChange = useMemo<OnChangeFn<string>>(
-    () => (updater) => {
-      setGlobalFilter((prev) =>
-        updater instanceof Function ? updater(prev) : updater
-      )
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }))
-    },
-    []
-  )
-  const onColumnFiltersChange = useMemo<OnChangeFn<ColumnFiltersState>>(
-    () => (updater) => {
-      setColumnFilters((prev) =>
-        updater instanceof Function ? updater(prev) : updater
-      )
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }))
-    },
-    []
-  )
-  const onPaginationChange = useMemo<OnChangeFn<PaginationState>>(
-    () => (updater) => {
-      setPagination((prev) =>
-        updater instanceof Function ? updater(prev) : updater
-      )
-    },
-    []
-  )
-
-  const handleTriggerOne = async (row: CheckinLogRow) => {
-    const targetAccountId = row.checkin_logs.accountId
-    try {
-      const result = await triggerOneMutation.mutateAsync(targetAccountId)
-      if (result.status === 'success') {
-        toast.success(t('checkin.toast.success'), {
-          description: result.reward
-            ? t('checkin.toast.successReward', { reward: result.reward })
-            : undefined,
-        })
-      } else if (result.status === 'skipped' || result.skipped) {
-        toast.info(t('checkin.toast.skipped'), {
-          description: result.message || undefined,
-        })
-      } else {
-        toast.error(t('checkin.toast.failed'), {
-          description: result.message || undefined,
-        })
+  const handleTriggerOne = useCallback(
+    async (row: CheckinLogRow) => {
+      const targetAccountId = row.checkin_logs.accountId
+      try {
+        const result = await triggerOneMutation.mutateAsync(targetAccountId)
+        if (result.status === 'success') {
+          toast.success(t('checkin.toast.success'), {
+            description: result.reward
+              ? t('checkin.toast.successReward', { reward: result.reward })
+              : undefined,
+          })
+        } else if (result.status === 'skipped' || result.skipped) {
+          toast.info(t('checkin.toast.skipped'), {
+            description: result.message || undefined,
+          })
+        } else {
+          toast.error(t('checkin.toast.failed'), {
+            description: result.message || undefined,
+          })
+        }
+      } catch {
+        // http-client toasted
       }
-    } catch {}
-  }
-
-  const rowActions = {
-    onViewDetail: (row: CheckinLogRow) => {
-      setDetailRow(row)
-      setDetailOpen(true)
     },
-    onTriggerAccount: handleTriggerOne,
-  }
+    [triggerOneMutation, t]
+  )
+
+  // Memoized so the column defs keep a stable identity across renders.
+  const rowActions = useMemo(
+    () => ({
+      onViewDetail: (row: CheckinLogRow) => {
+        setDetailRow(row)
+        setDetailOpen(true)
+      },
+      onTriggerAccount: handleTriggerOne,
+    }),
+    [handleTriggerOne]
+  )
 
   const columns = useCheckinColumns(rowActions)
   const { table } = useDataTable<CheckinLogRow>({
@@ -255,27 +313,17 @@ export function CheckinPage() {
     manualFiltering: true,
     manualSorting: true,
     enableRowSelection: false,
+    // The URL-synced callbacks already reset the page on every filter change
+    // (resetPageIndexOnFilterChange), so disable TanStack's own auto-reset to
+    // avoid a second redundant page update.
+    autoResetPageIndex: false,
     globalFilter,
     onGlobalFilterChange,
     columnFilters,
     onColumnFiltersChange,
     pagination,
     onPaginationChange,
-    globalFilterFn: (row, _columnId, filterValue) => {
-      // With manualFiltering the table does not run this; kept so the column
-      // definition stays valid if the table ever flips back to client mode.
-      const log = checkinLogRowSchema.parse(row.original)
-      const haystack = [
-        log.accounts?.username ?? '',
-        log.sites?.name ?? '',
-        log.sites?.url ?? '',
-        log.checkin_logs.message ?? '',
-        log.checkin_logs.reward ?? '',
-      ]
-        .join(' ')
-        .toLowerCase()
-      return haystack.includes(String(filterValue).toLowerCase())
-    },
+    globalFilterFn: checkinGlobalFilterFn,
     totalCount: total,
   })
 
@@ -302,12 +350,18 @@ export function CheckinPage() {
   }
 
   const handleResetFilters = () => {
-    setFrom('')
-    setTo('')
-    setAccountId(undefined)
-    setColumnFilters([])
-    setGlobalFilter('')
-    setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+    updateUrlState({
+      q: '',
+      pageIndex: 0,
+      filters: {
+        status: '',
+        reason: '',
+        site: '',
+        accountId: '',
+        from: '',
+        to: '',
+      },
+    })
   }
 
   const hasActiveDateRange = from !== '' || to !== ''
@@ -358,8 +412,10 @@ export function CheckinPage() {
           type='datetime-local'
           value={from}
           onChange={(event) => {
-            setFrom(event.target.value)
-            setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+            updateUrlState({
+              filters: { from: event.target.value },
+              pageIndex: 0,
+            })
           }}
           className='w-[200px]'
           aria-label={t('checkin.page.startTime')}
@@ -371,8 +427,10 @@ export function CheckinPage() {
           type='datetime-local'
           value={to}
           onChange={(event) => {
-            setTo(event.target.value)
-            setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+            updateUrlState({
+              filters: { to: event.target.value },
+              pageIndex: 0,
+            })
           }}
           className='w-[200px]'
           aria-label={t('checkin.page.endTime')}
@@ -380,10 +438,12 @@ export function CheckinPage() {
         <Select
           value={accountId ? String(accountId) : ACCOUNT_FILTER_ALL}
           onValueChange={(value) => {
-            setAccountId(
-              !value || value === ACCOUNT_FILTER_ALL ? undefined : Number(value)
-            )
-            setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+            updateUrlState({
+              filters: {
+                accountId: !value || value === ACCOUNT_FILTER_ALL ? '' : value,
+              },
+              pageIndex: 0,
+            })
           }}
         >
           <SelectTrigger

--- a/web/src/features/models/__tests__/models-schema.test.ts
+++ b/web/src/features/models/__tests__/models-schema.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  PAGINATION_SCHEMA,
-  SORTING_ITEM_SCHEMA,
-  modelsSearchSchema,
-} from '../lib/models-schema'
+import { modelsSearchSchema } from '../lib/models-schema'
 
 // ---------------------------------------------------------------------------
 // brand / capability transforms
@@ -93,37 +89,5 @@ describe('modelsSearchSchema — numerics', () => {
     expect(result.sort).toBeUndefined()
     expect(result.brand).toBeUndefined()
     expect(result.capability).toBeUndefined()
-  })
-})
-
-// ---------------------------------------------------------------------------
-// PAGINATION_SCHEMA + SORTING_ITEM_SCHEMA
-// ---------------------------------------------------------------------------
-
-describe('PAGINATION_SCHEMA', () => {
-  it('applies defaults to an empty input', () => {
-    expect(PAGINATION_SCHEMA.parse({})).toEqual({
-      pageIndex: 0,
-      pageSize: 20,
-    })
-  })
-
-  it('coerces string numerics', () => {
-    expect(PAGINATION_SCHEMA.parse({ pageIndex: '3', pageSize: '50' })).toEqual(
-      { pageIndex: 3, pageSize: 50 }
-    )
-  })
-
-  it('rejects pageSize above 200', () => {
-    expect(PAGINATION_SCHEMA.safeParse({ pageSize: '300' }).success).toBe(false)
-  })
-})
-
-describe('SORTING_ITEM_SCHEMA', () => {
-  it('requires both id and desc', () => {
-    expect(SORTING_ITEM_SCHEMA.safeParse({ id: 'a' }).success).toBe(false)
-    expect(SORTING_ITEM_SCHEMA.safeParse({ id: 'a', desc: true }).success).toBe(
-      true
-    )
   })
 })

--- a/web/src/features/models/components/models-page.tsx
+++ b/web/src/features/models/components/models-page.tsx
@@ -22,6 +22,7 @@ import {
   useDataTable,
   useUrlTableState,
   type UrlTableState,
+  type UrlTableStateUpdate,
 } from '@/components/data-table'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
@@ -94,7 +95,7 @@ function readSearch(searchString?: string): UrlTableState<ModelsUrlFilters> {
   }
 }
 
-function buildHref(next: Partial<UrlTableState<ModelsUrlFilters>>): string {
+function buildHref(next: UrlTableStateUpdate<ModelsUrlFilters>): string {
   const current = readSearch()
   const merged: UrlTableState<ModelsUrlFilters> = {
     ...current,

--- a/web/src/features/models/lib/models-schema.ts
+++ b/web/src/features/models/lib/models-schema.ts
@@ -18,24 +18,15 @@ import {
   encodeSortingParam,
   encodeStringListParam,
   stringSearchParam,
+  tableSortingItemSchema,
 } from '@/lib/helpers/searchParams'
-
-const sortingItemSchema = z.object({
-  id: z.string(),
-  desc: z.boolean(),
-})
-
-const paginationSchema = z.object({
-  pageIndex: z.coerce.number().int().min(0).default(0),
-  pageSize: z.coerce.number().int().min(1).max(200).default(20),
-})
 
 export const modelsSearchSchema = z.object({
   q: stringSearchParam,
   page: z.coerce.number().int().min(0).catch(0).default(0),
   pageSize: z.coerce.number().int().min(1).max(200).catch(20).default(20),
   sort: z
-    .union([z.string(), z.array(sortingItemSchema)])
+    .union([z.string(), z.array(tableSortingItemSchema)])
     .optional()
     .transform((value) => encodeSortingParam(value))
     .catch(undefined),
@@ -51,6 +42,3 @@ export const modelsSearchSchema = z.object({
     .transform((value) => encodeStringListParam(value))
     .catch(undefined),
 })
-
-export const SORTING_ITEM_SCHEMA = sortingItemSchema
-export const PAGINATION_SCHEMA = paginationSchema

--- a/web/src/features/oauth/__tests__/oauth-schema.test.ts
+++ b/web/src/features/oauth/__tests__/oauth-schema.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  OAUTH_COLUMN_FILTER_ITEM_SCHEMA,
-  OAUTH_PAGINATION_SCHEMA,
-  OAUTH_SORTING_ITEM_SCHEMA,
   OAUTH_START_DEFAULT_VALUES,
   oauthSearchSchema,
   oauthStartSchema,
@@ -157,34 +154,5 @@ describe('oauthSearchSchema', () => {
     expect(result.pageSize).toBe(20)
     expect(result.sort).toBeUndefined()
     expect(result.q).toBe(42)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// shared item schemas
-// ---------------------------------------------------------------------------
-
-describe('shared OAuth item schemas', () => {
-  it('OAUTH_PAGINATION_SCHEMA applies defaults', () => {
-    expect(OAUTH_PAGINATION_SCHEMA.parse({})).toEqual({
-      pageIndex: 0,
-      pageSize: 20,
-    })
-  })
-
-  it('OAUTH_SORTING_ITEM_SCHEMA requires both fields', () => {
-    expect(OAUTH_SORTING_ITEM_SCHEMA.safeParse({ id: 'a' }).success).toBe(false)
-    expect(
-      OAUTH_SORTING_ITEM_SCHEMA.safeParse({ id: 'a', desc: true }).success
-    ).toBe(true)
-  })
-
-  it('OAUTH_COLUMN_FILTER_ITEM_SCHEMA accepts string / string[] / boolean', () => {
-    expect(
-      OAUTH_COLUMN_FILTER_ITEM_SCHEMA.safeParse({ id: 'a', value: 'x' }).success
-    ).toBe(true)
-    expect(
-      OAUTH_COLUMN_FILTER_ITEM_SCHEMA.safeParse({ id: 'a', value: 42 }).success
-    ).toBe(false)
   })
 })

--- a/web/src/features/oauth/components/oauth-page.tsx
+++ b/web/src/features/oauth/components/oauth-page.tsx
@@ -18,6 +18,7 @@ import {
   useDataTable,
   useUrlTableState,
   type UrlTableState,
+  type UrlTableStateUpdate,
 } from '@/components/data-table'
 import { Button } from '@/components/ui/button'
 import {
@@ -84,7 +85,7 @@ function readSearch(searchString?: string): UrlTableState<OAuthUrlFilters> {
   }
 }
 
-function buildHref(next: Partial<UrlTableState<OAuthUrlFilters>>): string {
+function buildHref(next: UrlTableStateUpdate<OAuthUrlFilters>): string {
   const current = readSearch()
   const merged: UrlTableState<OAuthUrlFilters> = {
     ...current,

--- a/web/src/features/oauth/lib/oauth-schema.ts
+++ b/web/src/features/oauth/lib/oauth-schema.ts
@@ -17,6 +17,7 @@ import { z } from 'zod'
 import {
   encodeSortingParam,
   stringSearchParam,
+  tableSortingItemSchema,
 } from '@/lib/helpers/searchParams'
 
 const HTTP_OR_EMPTY_MESSAGE_KEY = 'oauth.form.errors.invalidProxyUrl'
@@ -50,39 +51,14 @@ export const OAUTH_START_DEFAULT_VALUES: OAuthStartValues = {
 
 // --- URL search state -------------------------------------------------------
 
-const sortingItemSchema = z.object({
-  id: z.string(),
-  desc: z.boolean(),
-})
-
-const paginationSchema = z.object({
-  pageIndex: z.coerce.number().int().min(0).default(0),
-  pageSize: z.coerce.number().int().min(1).max(200).default(20),
-})
-
-const columnFilterValueSchema = z.union([
-  z.string(),
-  z.array(z.string()),
-  z.boolean(),
-])
-
-const columnFilterItemSchema = z.object({
-  id: z.string(),
-  value: columnFilterValueSchema,
-})
-
 export const oauthSearchSchema = z.object({
   q: stringSearchParam,
   page: z.coerce.number().int().min(0).catch(0).default(0),
   pageSize: z.coerce.number().int().min(1).max(200).catch(20).default(20),
   sort: z
-    .union([z.string(), z.array(sortingItemSchema)])
+    .union([z.string(), z.array(tableSortingItemSchema)])
     .optional()
     .transform((value) => encodeSortingParam(value))
     .catch(undefined),
   status: stringSearchParam,
 })
-
-export const OAUTH_SORTING_ITEM_SCHEMA = sortingItemSchema
-export const OAUTH_PAGINATION_SCHEMA = paginationSchema
-export const OAUTH_COLUMN_FILTER_ITEM_SCHEMA = columnFilterItemSchema

--- a/web/src/features/proxy-logs/__tests__/proxy-logs-schema.test.ts
+++ b/web/src/features/proxy-logs/__tests__/proxy-logs-schema.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 
 import {
   PROXY_LOG_STATUS_FILTER_OPTIONS,
-  SORTING_ITEM_SCHEMA,
   proxyLogsSearchSchema,
 } from '../lib/proxy-logs-schema'
 
@@ -116,24 +115,6 @@ describe('proxyLogsSearchSchema — numerics', () => {
       sort: [{ id: 7, desc: 'yes' }],
     })
     expect(result.sort).toBeUndefined()
-  })
-})
-
-// ---------------------------------------------------------------------------
-// SORTING_ITEM_SCHEMA
-// ---------------------------------------------------------------------------
-
-describe('SORTING_ITEM_SCHEMA', () => {
-  it('parses a well-formed item', () => {
-    expect(SORTING_ITEM_SCHEMA.parse({ id: 'created', desc: true })).toEqual({
-      id: 'created',
-      desc: true,
-    })
-  })
-
-  it('requires both id and desc', () => {
-    expect(SORTING_ITEM_SCHEMA.safeParse({ id: 'created' }).success).toBe(false)
-    expect(SORTING_ITEM_SCHEMA.safeParse({ desc: true }).success).toBe(false)
   })
 })
 

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -1,14 +1,18 @@
-/* eslint-disable no-nested-ternary -- status-icon selection uses chained ternaries */
+/* eslint-disable no-nested-ternary -- status-select display uses chained ternaries */
 // metapi-go/features/proxy-logs/components — proxy logs list page.
 // i18n: all user-visible strings migrated to t() calls.
 
-import { useNavigate, useSearch } from '@tanstack/react-router'
-import type { OnChangeFn, PaginationState } from '@tanstack/react-table'
 import { Download as DownloadIcon, RefreshCw } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { DataTablePage, useDataTable } from '@/components/data-table'
+import {
+  DataTablePage,
+  type UrlTableState,
+  type UrlTableStateUpdate,
+  useDataTable,
+  useUrlTableState,
+} from '@/components/data-table'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -23,7 +27,11 @@ import { asStringParam } from '@/lib/helpers/searchParams'
 import { toast } from '@/lib/toast'
 
 import { useProxyLogs, useProxyLogsMeta } from '../api'
-import { PROXY_LOG_STATUS_FILTER_OPTIONS } from '../lib/proxy-logs-schema'
+import {
+  PROXY_LOG_STATUS_FILTER_OPTIONS,
+  proxyLogsSearchSchema,
+  type ProxyLogsSearch,
+} from '../lib/proxy-logs-schema'
 import { useProxyLogsAutoRefresh } from '../lib/use-proxy-logs-auto-refresh'
 import type { ProxyLog, ProxyLogFilters } from '../types'
 import { LatencyBadge } from './latency-badge'
@@ -41,88 +49,136 @@ const PROXY_LOGS_COLUMN_SIZING_STORAGE_KEY =
 const DEFAULT_PAGE_SIZE = 20
 const PROXY_LOGS_CSV_EXPORT_LIMIT = 10_000
 
+/** Page-specific URL filters (all strings for URL round-trip simplicity). */
+type ProxyLogsUrlFilters = {
+  status: string
+  siteId: string
+  client: string
+  from: string
+  to: string
+  latencyMin: string
+  latencyMax: string
+}
+
+/**
+ * Parse the raw search string into URL table state, reusing the route's
+ * `proxyLogsSearchSchema` so the derived query payload matches the prefetched
+ * cache key (no double fetch). Returns schema defaults on a malformed string.
+ */
+function readProxyLogsSearch(
+  searchString: string
+): UrlTableState<ProxyLogsUrlFilters> {
+  const entries = Object.fromEntries(
+    new URLSearchParams(
+      searchString.startsWith('?') ? searchString.slice(1) : searchString
+    ).entries()
+  )
+  const parsed = proxyLogsSearchSchema.safeParse(entries)
+  const search: ProxyLogsSearch | null = parsed.success ? parsed.data : null
+  return {
+    q: asStringParam(search?.q) ?? '',
+    // The proxy-logs URL is 0-based (`page`), unlike the other list pages.
+    pageIndex: search?.page ?? 0,
+    pageSize: search?.pageSize ?? DEFAULT_PAGE_SIZE,
+    sorting: [],
+    filters: {
+      status: search?.status ?? 'all',
+      siteId: search?.siteId === undefined ? '' : String(search.siteId),
+      client: asStringParam(search?.client) ?? '',
+      from: asStringParam(search?.from) ?? '',
+      to: asStringParam(search?.to) ?? '',
+      latencyMin:
+        search?.latencyMin === undefined ? '' : String(search.latencyMin),
+      latencyMax:
+        search?.latencyMax === undefined ? '' : String(search.latencyMax),
+    },
+  }
+}
+
+/** Serialize a partial state update back to the proxy-logs href, merging over
+ *  the CURRENT url state so a single filter change preserves all others. */
+function buildProxyLogsHref(
+  next: UrlTableStateUpdate<ProxyLogsUrlFilters>
+): string {
+  const current = readProxyLogsSearch(window.location.search)
+  const merged: UrlTableState<ProxyLogsUrlFilters> = {
+    ...current,
+    ...next,
+    filters: { ...current.filters, ...next.filters },
+  }
+  const params = new URLSearchParams()
+  if (merged.q) params.set('q', merged.q)
+  if (merged.pageIndex > 0) params.set('page', String(merged.pageIndex))
+  if (merged.pageSize !== DEFAULT_PAGE_SIZE) {
+    params.set('pageSize', String(merged.pageSize))
+  }
+  if (merged.filters.status !== 'all') {
+    params.set('status', merged.filters.status)
+  }
+  if (merged.filters.siteId) params.set('siteId', merged.filters.siteId)
+  if (merged.filters.client) params.set('client', merged.filters.client)
+  if (merged.filters.from) params.set('from', merged.filters.from)
+  if (merged.filters.to) params.set('to', merged.filters.to)
+  if (merged.filters.latencyMin) {
+    params.set('latencyMin', merged.filters.latencyMin)
+  }
+  if (merged.filters.latencyMax) {
+    params.set('latencyMax', merged.filters.latencyMax)
+  }
+  const queryString = params.toString()
+  return queryString ? `/proxy-logs?${queryString}` : '/proxy-logs'
+}
+
+function useProxyLogsUrlState() {
+  return useUrlTableState<ProxyLogsUrlFilters>({
+    basePath: '/proxy-logs',
+    read: readProxyLogsSearch,
+    buildHref: buildProxyLogsHref,
+    // No TanStack column filters on this page: status / site / client /
+    // date / latency are all page-specific controls driven by `filters`.
+    toColumnFilters: () => [],
+    fromColumnFilters: () => ({}),
+    resetPageIndexOnFilterChange: true,
+  })
+}
+
 export function ProxyLogsPage() {
   const { t } = useTranslation()
-  // URL state is owned by the router: read the validated search via
-  // `useSearch` (no `window.location.search`), write changes back via
-  // `navigate({ search, replace: true })` (no `history.replaceState`).
-  const urlSearch = useSearch({ from: '/_authenticated/proxy-logs' })
-  const navigate = useNavigate()
-  const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: urlSearch.page ?? 0,
-    pageSize: urlSearch.pageSize ?? DEFAULT_PAGE_SIZE,
-  })
-  const [search, setSearch] = useState(asStringParam(urlSearch.q) ?? '')
-  const [status, setStatus] = useState<ProxyLogFilters['status']>(
-    urlSearch.status ?? 'all'
-  )
-  const [siteId, setSiteId] = useState<number | null>(urlSearch.siteId ?? null)
-  const [client, setClient] = useState(asStringParam(urlSearch.client) ?? '')
-  const [from, setFrom] = useState(asStringParam(urlSearch.from) ?? '')
-  const [to, setTo] = useState(asStringParam(urlSearch.to) ?? '')
-  const [latencyMin, setLatencyMin] = useState<number | null>(
-    urlSearch.latencyMin ?? null
-  )
-  const [latencyMax, setLatencyMax] = useState<number | null>(
-    urlSearch.latencyMax ?? null
-  )
+  const {
+    globalFilter,
+    pagination,
+    onGlobalFilterChange,
+    onPaginationChange,
+    filters,
+    updateUrlState,
+  } = useProxyLogsUrlState()
+
+  // Derive the active server-side filter values directly from the URL-owned
+  // filters (single source of truth — no local mirror to sync back).
+  const status = filters.status as ProxyLogFilters['status']
+  const siteId = filters.siteId ? Number(filters.siteId) : null
+  const client = filters.client
+  const from = filters.from
+  const to = filters.to
+  const latencyMin = filters.latencyMin ? Number(filters.latencyMin) : null
+  const latencyMax = filters.latencyMax ? Number(filters.latencyMax) : null
+
   const [detailLog, setDetailLog] = useState<ProxyLog | null>(null)
   const [detailOpen, setDetailOpen] = useState(false)
   const [isExporting, setIsExporting] = useState(false)
-
-  // Write state back to the URL through the router (single source of truth).
-  // Skip the initial write — the URL already holds the search the state was
-  // initialised from.
-  const skipInitialWrite = useRef(true)
-  useEffect(() => {
-    if (skipInitialWrite.current) {
-      skipInitialWrite.current = false
-      return
-    }
-    navigate({
-      to: '/proxy-logs',
-      search: {
-        page: pagination.pageIndex > 0 ? pagination.pageIndex : undefined,
-        pageSize:
-          pagination.pageSize !== DEFAULT_PAGE_SIZE
-            ? pagination.pageSize
-            : undefined,
-        q: search || undefined,
-        status: status !== 'all' ? status : undefined,
-        siteId: siteId ?? undefined,
-        client: client || undefined,
-        from: from || undefined,
-        to: to || undefined,
-        latencyMin: latencyMin ?? undefined,
-        latencyMax: latencyMax ?? undefined,
-      },
-      replace: true,
-    })
-  }, [
-    pagination,
-    search,
-    status,
-    siteId,
-    client,
-    from,
-    to,
-    latencyMin,
-    latencyMax,
-    navigate,
-  ])
 
   const queryPayload = useMemo(
     () => ({
       limit: pagination.pageSize,
       offset: pagination.pageIndex * pagination.pageSize,
       status: status === 'all' ? undefined : status,
-      search: search.trim() || undefined,
+      search: globalFilter.trim() || undefined,
       siteId: siteId ?? undefined,
       client: client || undefined,
       from: from || undefined,
       to: to || undefined,
     }),
-    [pagination, status, search, siteId, client, from, to]
+    [pagination, status, globalFilter, siteId, client, from, to]
   )
 
   const metaPayload = useMemo(
@@ -155,30 +211,16 @@ export function ProxyLogsPage() {
     })
   }, [rawItems, latencyMin, latencyMax])
 
-  const onGlobalFilterChange = useMemo<OnChangeFn<string>>(
-    () => (updater) => {
-      setSearch((prev) =>
-        updater instanceof Function ? updater(prev) : updater
-      )
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }))
-    },
+  // Memoized so the column defs keep a stable identity across renders.
+  const columnActions = useMemo<ProxyLogsColumnActions>(
+    () => ({
+      onView: (log) => {
+        setDetailLog(log)
+        setDetailOpen(true)
+      },
+    }),
     []
   )
-  const onPaginationChange = useMemo<OnChangeFn<PaginationState>>(
-    () => (updater) => {
-      setPagination((prev) =>
-        updater instanceof Function ? updater(prev) : updater
-      )
-    },
-    []
-  )
-
-  const columnActions: ProxyLogsColumnActions = {
-    onView: (log) => {
-      setDetailLog(log)
-      setDetailOpen(true)
-    },
-  }
   const columns = useProxyLogsColumns(columnActions)
 
   const { table } = useDataTable<ProxyLog>({
@@ -190,7 +232,11 @@ export function ProxyLogsPage() {
     enableColumnResizing: true,
     columnVisibilityStorageKey: PROXY_LOGS_COLUMN_VISIBILITY_STORAGE_KEY,
     columnSizingStorageKey: PROXY_LOGS_COLUMN_SIZING_STORAGE_KEY,
-    globalFilter: search,
+    // The URL-synced callbacks already reset the page on every filter change
+    // (resetPageIndexOnFilterChange), so disable TanStack's own auto-reset to
+    // avoid a second redundant page update.
+    autoResetPageIndex: false,
+    globalFilter,
     onGlobalFilterChange,
     pagination,
     onPaginationChange,
@@ -203,15 +249,19 @@ export function ProxyLogsPage() {
   const siteOptions = metaQuery.data?.sites ?? []
 
   function handleReset() {
-    setSearch('')
-    setStatus('all')
-    setSiteId(null)
-    setClient('')
-    setFrom('')
-    setTo('')
-    setLatencyMin(null)
-    setLatencyMax(null)
-    setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+    updateUrlState({
+      q: '',
+      pageIndex: 0,
+      filters: {
+        status: 'all',
+        siteId: '',
+        client: '',
+        from: '',
+        to: '',
+        latencyMin: '',
+        latencyMax: '',
+      },
+    })
   }
 
   async function handleExportCsv() {
@@ -331,8 +381,10 @@ export function ProxyLogsPage() {
               <Select
                 value={status}
                 onValueChange={(value) => {
-                  setStatus(value as ProxyLogFilters['status'])
-                  setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+                  updateUrlState({
+                    filters: { status: value ?? 'all' },
+                    pageIndex: 0,
+                  })
                 }}
               >
                 <SelectTrigger
@@ -365,8 +417,12 @@ export function ProxyLogsPage() {
                 <Select
                   value={siteId === null ? 'all' : String(siteId)}
                   onValueChange={(value) => {
-                    setSiteId(value === 'all' ? null : Number(value))
-                    setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+                    updateUrlState({
+                      filters: {
+                        siteId: !value || value === 'all' ? '' : value,
+                      },
+                      pageIndex: 0,
+                    })
                   }}
                 >
                   <SelectTrigger
@@ -404,8 +460,12 @@ export function ProxyLogsPage() {
                 <Select
                   value={client || 'all'}
                   onValueChange={(value) => {
-                    setClient(!value || value === 'all' ? '' : value)
-                    setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+                    updateUrlState({
+                      filters: {
+                        client: !value || value === 'all' ? '' : value,
+                      },
+                      pageIndex: 0,
+                    })
                   }}
                 >
                   <SelectTrigger
@@ -442,8 +502,10 @@ export function ProxyLogsPage() {
                 aria-label={t('proxyLogs.page.startTime')}
                 value={from}
                 onChange={(event) => {
-                  setFrom(event.target.value)
-                  setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+                  updateUrlState({
+                    filters: { from: event.target.value },
+                    pageIndex: 0,
+                  })
                 }}
                 className='w-[180px]'
               />
@@ -452,8 +514,10 @@ export function ProxyLogsPage() {
                 aria-label={t('proxyLogs.page.endTime')}
                 value={to}
                 onChange={(event) => {
-                  setTo(event.target.value)
-                  setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+                  updateUrlState({
+                    filters: { to: event.target.value },
+                    pageIndex: 0,
+                  })
                 }}
                 className='w-[180px]'
               />
@@ -472,8 +536,10 @@ export function ProxyLogsPage() {
                   value={latencyMin ?? ''}
                   onChange={(event) => {
                     const value = event.target.value
-                    setLatencyMin(value === '' ? null : Number(value))
-                    setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+                    updateUrlState({
+                      filters: { latencyMin: value },
+                      pageIndex: 0,
+                    })
                   }}
                   className='w-[100px]'
                 />
@@ -489,8 +555,10 @@ export function ProxyLogsPage() {
                   value={latencyMax ?? ''}
                   onChange={(event) => {
                     const value = event.target.value
-                    setLatencyMax(value === '' ? null : Number(value))
-                    setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+                    updateUrlState({
+                      filters: { latencyMax: value },
+                      pageIndex: 0,
+                    })
                   }}
                   className='w-[100px]'
                 />
@@ -502,12 +570,16 @@ export function ProxyLogsPage() {
                   size='sm'
                   onClick={() => {
                     if (slowOnly) {
-                      setLatencyMin(null)
+                      updateUrlState({
+                        filters: { latencyMin: '', latencyMax: '' },
+                        pageIndex: 0,
+                      })
                     } else {
-                      setLatencyMin(2000)
-                      setLatencyMax(null)
+                      updateUrlState({
+                        filters: { latencyMin: '2000', latencyMax: '' },
+                        pageIndex: 0,
+                      })
                     }
-                    setPagination((prev) => ({ ...prev, pageIndex: 0 }))
                   }}
                 >
                   {t('proxyLogs.page.slowOnly')}
@@ -627,7 +699,7 @@ function proxyLogsToCsv(
         modelLabel,
         accountLabel,
         siteLabel,
-        log.latencyMs,
+        log.latencyMs ?? '',
         log.totalTokens ?? '',
         log.estimatedCost ?? '',
       ]

--- a/web/src/features/proxy-logs/lib/proxy-logs-schema.ts
+++ b/web/src/features/proxy-logs/lib/proxy-logs-schema.ts
@@ -6,9 +6,8 @@ import { z } from 'zod'
 import {
   encodeSortingParam,
   stringSearchParam,
+  tableSortingItemSchema,
 } from '@/lib/helpers/searchParams'
-
-const sortingItemSchema = z.object({ id: z.string(), desc: z.boolean() })
 
 /**
  * Tolerant URL search contract: the router JSON-parses search values, so
@@ -22,7 +21,7 @@ export const proxyLogsSearchSchema = z.object({
   page: z.coerce.number().int().min(0).catch(0).default(0),
   pageSize: z.coerce.number().int().min(1).max(200).catch(20).default(20),
   sort: z
-    .union([z.string(), z.array(sortingItemSchema)])
+    .union([z.string(), z.array(tableSortingItemSchema)])
     .optional()
     .transform((value) => encodeSortingParam(value))
     .catch(undefined),
@@ -39,7 +38,6 @@ export const proxyLogsSearchSchema = z.object({
 })
 
 export type ProxyLogsSearch = z.infer<typeof proxyLogsSearchSchema>
-export const SORTING_ITEM_SCHEMA = sortingItemSchema
 
 export const PROXY_LOG_STATUS_FILTER_OPTIONS = [
   { labelKey: 'proxyLogs.filter.all', value: 'all' },

--- a/web/src/features/sites/__tests__/sites-schema.test.ts
+++ b/web/src/features/sites/__tests__/sites-schema.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  COLUMN_FILTER_ITEM_SCHEMA,
-  PAGINATION_SCHEMA,
   SITE_FORM_DEFAULT_VALUES,
-  SORTING_ITEM_SCHEMA,
   siteFormSchema,
   sitesSearchSchema,
   type SiteFormValues,
@@ -258,34 +255,5 @@ describe('sitesSearchSchema', () => {
     expect(result.pageSize).toBe(20)
     expect(result.sort).toBeUndefined()
     expect(result.q).toBe(42)
-  })
-})
-
-describe('PAGINATION_SCHEMA + SORTING_ITEM_SCHEMA + COLUMN_FILTER_ITEM_SCHEMA', () => {
-  it('PAGINATION_SCHEMA applies defaults', () => {
-    expect(PAGINATION_SCHEMA.parse({})).toEqual({ pageIndex: 0, pageSize: 20 })
-  })
-
-  it('SORTING_ITEM_SCHEMA requires both fields', () => {
-    expect(SORTING_ITEM_SCHEMA.safeParse({ id: 'a' }).success).toBe(false)
-    expect(SORTING_ITEM_SCHEMA.safeParse({ id: 'a', desc: true }).success).toBe(
-      true
-    )
-  })
-
-  it('COLUMN_FILTER_ITEM_SCHEMA accepts string / string[] / boolean values', () => {
-    expect(
-      COLUMN_FILTER_ITEM_SCHEMA.safeParse({ id: 'a', value: 'x' }).success
-    ).toBe(true)
-    expect(
-      COLUMN_FILTER_ITEM_SCHEMA.safeParse({ id: 'a', value: ['x', 'y'] })
-        .success
-    ).toBe(true)
-    expect(
-      COLUMN_FILTER_ITEM_SCHEMA.safeParse({ id: 'a', value: true }).success
-    ).toBe(true)
-    expect(
-      COLUMN_FILTER_ITEM_SCHEMA.safeParse({ id: 'a', value: 42 }).success
-    ).toBe(false)
   })
 })

--- a/web/src/features/sites/components/sites-page.tsx
+++ b/web/src/features/sites/components/sites-page.tsx
@@ -24,6 +24,7 @@ import {
   useDataTable,
   useUrlTableState,
   type UrlTableState,
+  type UrlTableStateUpdate,
 } from '@/components/data-table'
 import { Button } from '@/components/ui/button'
 import {
@@ -95,7 +96,7 @@ function readSearch(searchString?: string): UrlTableState<SitesUrlFilters> {
   }
 }
 
-function buildHref(next: Partial<UrlTableState<SitesUrlFilters>>): string {
+function buildHref(next: UrlTableStateUpdate<SitesUrlFilters>): string {
   const current = readSearch()
   const merged: UrlTableState<SitesUrlFilters> = {
     ...current,

--- a/web/src/features/sites/lib/sites-schema.ts
+++ b/web/src/features/sites/lib/sites-schema.ts
@@ -19,6 +19,7 @@ import { z } from 'zod'
 import {
   encodeSortingParam,
   stringSearchParam,
+  tableSortingItemSchema,
 } from '@/lib/helpers/searchParams'
 
 import type { SiteProbeScope } from '../types'
@@ -118,39 +119,14 @@ export const SITE_FORM_DEFAULT_VALUES: SiteFormValues = {
 
 // --- URL search state -------------------------------------------------------
 
-const sortingItemSchema = z.object({
-  id: z.string(),
-  desc: z.boolean(),
-})
-
-const paginationSchema = z.object({
-  pageIndex: z.coerce.number().int().min(0).default(0),
-  pageSize: z.coerce.number().int().min(1).max(200).default(20),
-})
-
-const columnFilterValueSchema = z.union([
-  z.string(),
-  z.array(z.string()),
-  z.boolean(),
-])
-
-const columnFilterItemSchema = z.object({
-  id: z.string(),
-  value: columnFilterValueSchema,
-})
-
 export const sitesSearchSchema = z.object({
   q: stringSearchParam,
   page: z.coerce.number().int().min(0).catch(0).default(0),
   pageSize: z.coerce.number().int().min(1).max(200).catch(20).default(20),
   sort: z
-    .union([z.string(), z.array(sortingItemSchema)])
+    .union([z.string(), z.array(tableSortingItemSchema)])
     .optional()
     .transform((value) => encodeSortingParam(value))
     .catch(undefined),
   status: stringSearchParam,
 })
-
-export const SORTING_ITEM_SCHEMA = sortingItemSchema
-export const PAGINATION_SCHEMA = paginationSchema
-export const COLUMN_FILTER_ITEM_SCHEMA = columnFilterItemSchema

--- a/web/src/features/token-routes/components/routes-page.tsx
+++ b/web/src/features/token-routes/components/routes-page.tsx
@@ -2,21 +2,18 @@
 // metapi-go features/token-routes/components — the routes list page.
 // i18n: all user-visible strings migrated to t() calls.
 
-import { useNavigate, useSearch } from '@tanstack/react-router'
-import type {
-  ColumnFiltersState,
-  OnChangeFn,
-  PaginationState,
-  Table,
-} from '@tanstack/react-table'
+import type { ColumnFiltersState, Table } from '@tanstack/react-table'
 import { Loader2, Plus, Power, RefreshCw, Zap } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
   DataTableBulkActions,
   DataTablePage,
+  type UrlTableState,
+  type UrlTableStateUpdate,
   useDataTable,
+  useUrlTableState,
 } from '@/components/data-table'
 import { Button } from '@/components/ui/button'
 import {
@@ -42,6 +39,7 @@ import {
   useUpdateRoute,
   useZeroChannelRoutes,
 } from '../api'
+import { routesSearchSchema } from '../lib/routes-schema'
 import type { RouteRowActions, RouteSummaryRow } from '../types'
 import {
   isExplicitGroupRoute,
@@ -54,13 +52,125 @@ import { useRoutesColumns } from './routes-columns'
 
 const DEFAULT_PAGE_SIZE = 20
 
+/** Page-specific URL filters: the `enabled` column filter + chain context. */
+type TokenRoutesUrlFilters = {
+  enabled: string
+  accountId: string
+  siteId: string
+}
+
+/**
+ * Parse the raw search string into URL table state, reusing the route's
+ * `routesSearchSchema` so the derived state matches the loader's validated
+ * search. The page uses a 1-based `page` param.
+ */
+function readTokenRoutesSearch(
+  searchString: string
+): UrlTableState<TokenRoutesUrlFilters> {
+  const entries = Object.fromEntries(
+    new URLSearchParams(
+      searchString.startsWith('?') ? searchString.slice(1) : searchString
+    ).entries()
+  )
+  const parsed = routesSearchSchema.safeParse(entries)
+  const search = parsed.success ? parsed.data : null
+  return {
+    q: asStringParam(search?.q) ?? '',
+    pageIndex: (search?.page ?? 1) - 1,
+    pageSize: search?.pageSize ?? DEFAULT_PAGE_SIZE,
+    sorting: [],
+    filters: {
+      enabled: asStringParam(search?.enabled) ?? '',
+      accountId:
+        search?.accountId === undefined ? '' : String(search.accountId),
+      siteId: search?.siteId === undefined ? '' : String(search.siteId),
+    },
+  }
+}
+
+/** Serialize a partial state update back to the token-routes href, merging
+ *  over the CURRENT url state (preserves chain context accountId/siteId). */
+function buildTokenRoutesHref(
+  next: UrlTableStateUpdate<TokenRoutesUrlFilters>
+): string {
+  const current = readTokenRoutesSearch(window.location.search)
+  const merged: UrlTableState<TokenRoutesUrlFilters> = {
+    ...current,
+    ...next,
+    filters: { ...current.filters, ...next.filters },
+  }
+  const params = new URLSearchParams()
+  if (merged.q) params.set('q', merged.q)
+  if (merged.pageIndex > 0) params.set('page', String(merged.pageIndex + 1))
+  if (merged.pageSize !== DEFAULT_PAGE_SIZE) {
+    params.set('pageSize', String(merged.pageSize))
+  }
+  if (merged.filters.enabled) params.set('enabled', merged.filters.enabled)
+  if (merged.filters.accountId) {
+    params.set('accountId', merged.filters.accountId)
+  }
+  if (merged.filters.siteId) params.set('siteId', merged.filters.siteId)
+  const queryString = params.toString()
+  return queryString ? `/token-routes?${queryString}` : '/token-routes'
+}
+
+function useTokenRoutesUrlState() {
+  return useUrlTableState<TokenRoutesUrlFilters>({
+    basePath: '/token-routes',
+    read: readTokenRoutesSearch,
+    buildHref: buildTokenRoutesHref,
+    toColumnFilters: (filters) => {
+      const out: ColumnFiltersState = []
+      const enabledValues = filters.enabled.split(',').filter(Boolean)
+      if (enabledValues.length) {
+        out.push({ id: 'enabled', value: enabledValues })
+      }
+      return out
+    },
+    fromColumnFilters: (filters) => {
+      const enabledEntry = filters.find((filter) => filter.id === 'enabled')
+      return {
+        filters: {
+          enabled: Array.isArray(enabledEntry?.value)
+            ? enabledEntry.value.join(',')
+            : '',
+        },
+      }
+    },
+    resetPageIndexOnFilterChange: true,
+  })
+}
+
+// Module-level so the table's globalFilterFn keeps a stable identity across
+// renders (a fresh inline function would re-resolve the table every render).
+function routesGlobalFilterFn(
+  row: { original: unknown },
+  _columnId: string,
+  filterValue: string
+): boolean {
+  const route = row.original as RouteSummaryRow
+  const haystack = [
+    route.modelPattern,
+    route.displayName ?? '',
+    ...(route.siteNames ?? []),
+  ]
+    .join(' ')
+    .toLowerCase()
+  return haystack.includes(String(filterValue).toLowerCase())
+}
+
 export function RoutesPage() {
   const { t } = useTranslation()
-  // URL state is owned by the router: read the validated search via
-  // `useSearch` (no `window.location.search`), write changes back via
-  // `navigate({ search, replace: true })` (no `history.replaceState`).
-  const urlSearch = useSearch({ from: '/_authenticated/token-routes' })
-  const navigate = useNavigate()
+  const {
+    globalFilter,
+    pagination,
+    columnFilters,
+    onGlobalFilterChange,
+    onPaginationChange,
+    onColumnFiltersChange,
+    filters,
+  } = useTokenRoutesUrlState()
+
   const { data: routesData, isLoading, isFetching, error } = useRoutes()
   const candidatesQuery = useModelTokenCandidates()
 
@@ -73,81 +183,13 @@ export function RoutesPage() {
   const routes = useMemo(() => routesData ?? [], [routesData])
   const candidates = candidatesQuery.data
 
-  // Chain context (account/site deep-link) is fixed for the session — read
-  // once from the validated search.
-  const accountId = urlSearch.accountId
-  const siteId = urlSearch.siteId
+  // Chain context (account/site deep-link) is read from the URL-owned filters;
+  // it is preserved across every navigation but never modified by this page.
+  const accountId = filters.accountId ? Number(filters.accountId) : undefined
+  const siteId = filters.siteId ? Number(filters.siteId) : undefined
 
   const [showZeroChannel, setShowZeroChannel] = useState(false)
   const rows = useZeroChannelRoutes(routes, candidates, showZeroChannel)
-
-  const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: (urlSearch.page ?? 1) - 1,
-    pageSize: urlSearch.pageSize ?? DEFAULT_PAGE_SIZE,
-  })
-  const [globalFilter, setGlobalFilter] = useState(
-    asStringParam(urlSearch.q) ?? ''
-  )
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(() => {
-    const filters: ColumnFiltersState = []
-    const enabledValues =
-      asStringParam(urlSearch.enabled)?.split(',').filter(Boolean) ?? []
-    if (enabledValues.length) {
-      filters.push({ id: 'enabled', value: enabledValues })
-    }
-    return filters
-  })
-
-  // Write state back to the URL through the router (single source of truth).
-  // Skip the initial write — the URL already holds the search the state was
-  // initialised from.
-  const skipInitialWrite = useRef(true)
-  useEffect(() => {
-    if (skipInitialWrite.current) {
-      skipInitialWrite.current = false
-      return
-    }
-    const enabledFilter = columnFilters.find(
-      (filter) => filter.id === 'enabled'
-    )
-    navigate({
-      to: '/token-routes',
-      search: {
-        page: pagination.pageIndex > 0 ? pagination.pageIndex + 1 : undefined,
-        pageSize:
-          pagination.pageSize !== DEFAULT_PAGE_SIZE
-            ? pagination.pageSize
-            : undefined,
-        q: globalFilter || undefined,
-        enabled:
-          Array.isArray(enabledFilter?.value) && enabledFilter.value.length
-            ? enabledFilter.value.join(',')
-            : undefined,
-        accountId,
-        siteId,
-      },
-      replace: true,
-    })
-  }, [pagination, globalFilter, columnFilters, accountId, siteId, navigate])
-
-  const onGlobalFilterChange = useMemo<OnChangeFn<string>>(
-    () => (updater) => {
-      setGlobalFilter((prev) =>
-        updater instanceof Function ? updater(prev) : updater
-      )
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }))
-    },
-    []
-  )
-  const onColumnFiltersChange = useMemo<OnChangeFn<ColumnFiltersState>>(
-    () => (updater) => {
-      setColumnFilters((prev) =>
-        updater instanceof Function ? updater(prev) : updater
-      )
-      setPagination((prev) => ({ ...prev, pageIndex: 0 }))
-    },
-    []
-  )
 
   const [formOpen, setFormOpen] = useState(false)
   const [formMode, setFormMode] = useState<'create' | 'edit'>('create')
@@ -165,34 +207,38 @@ export function RoutesPage() {
     setFormOpen(true)
   }
 
-  const openEdit = (route: RouteSummaryRow) => {
+  const openEdit = useCallback((route: RouteSummaryRow) => {
     setFormMode('edit')
     setEditRoute(route)
     setFormOpen(true)
-  }
+  }, [])
 
-  const rowActions: RouteRowActions = {
-    onEdit: openEdit,
-    onDelete: (route) => {
-      setDeleteRoute(route)
-      setDeleteOpen(true)
-    },
-    onToggleEnabled: (route) =>
-      updateMutation.mutate({
-        id: route.id,
-        payload: { enabled: !route.enabled },
-      }),
-    onViewDetail: (route) => {
-      setDetailRoute(route)
-      setDetailOpen(true)
-    },
-    onClearCooldown: (route) => {
-      clearCooldownMutation.mutate(route.id)
-    },
-    onRefreshDecision: () => {
-      refreshDecisionsMutation.mutate()
-    },
-  }
+  // Memoized so the column defs keep a stable identity across renders.
+  const rowActions = useMemo<RouteRowActions>(
+    () => ({
+      onEdit: openEdit,
+      onDelete: (route) => {
+        setDeleteRoute(route)
+        setDeleteOpen(true)
+      },
+      onToggleEnabled: (route) =>
+        updateMutation.mutate({
+          id: route.id,
+          payload: { enabled: !route.enabled },
+        }),
+      onViewDetail: (route) => {
+        setDetailRoute(route)
+        setDetailOpen(true)
+      },
+      onClearCooldown: (route) => {
+        clearCooldownMutation.mutate(route.id)
+      },
+      onRefreshDecision: () => {
+        refreshDecisionsMutation.mutate()
+      },
+    }),
+    [openEdit, updateMutation, clearCooldownMutation, refreshDecisionsMutation]
+  )
 
   const columns = useRoutesColumns(rowActions)
 
@@ -200,23 +246,17 @@ export function RoutesPage() {
     data: rows,
     columns,
     enableRowSelection: true,
+    // The URL-synced callbacks already reset the page on every filter change
+    // (resetPageIndexOnFilterChange), so disable TanStack's own auto-reset to
+    // avoid a second redundant page update.
+    autoResetPageIndex: false,
     globalFilter,
     onGlobalFilterChange,
     columnFilters,
     onColumnFiltersChange,
     pagination,
-    onPaginationChange: setPagination,
-    globalFilterFn: (row, _columnId, filterValue) => {
-      const route = row.original as RouteSummaryRow
-      const haystack = [
-        route.modelPattern,
-        route.displayName ?? '',
-        ...(route.siteNames ?? []),
-      ]
-        .join(' ')
-        .toLowerCase()
-      return haystack.includes(String(filterValue).toLowerCase())
-    },
+    onPaginationChange,
+    globalFilterFn: routesGlobalFilterFn,
   })
 
   const availableRoutes = useMemo(

--- a/web/src/lib/helpers/__tests__/search-params-resilience.test.ts
+++ b/web/src/lib/helpers/__tests__/search-params-resilience.test.ts
@@ -14,7 +14,11 @@ import {
 import { proxyLogsSearchSchema } from '@/features/proxy-logs/lib/proxy-logs-schema'
 import { routesSearchSchema } from '@/features/token-routes/lib/routes-schema'
 import { hasValidAuthSessionSafe } from '@/lib/auth-session'
-import { asStringParam, stringSearchParam } from '@/lib/helpers/searchParams'
+import {
+  asStringParam,
+  stringSearchParam,
+  tableSortingItemSchema,
+} from '@/lib/helpers/searchParams'
 import { signInSearchSchema } from '@/routes/sign-in'
 
 // ---------------------------------------------------------------------------
@@ -177,5 +181,19 @@ describe('hasValidAuthSessionSafe', () => {
       removeItem: () => {},
     }
     expect(hasValidAuthSessionSafe(validStorage)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// tableSortingItemSchema — shared sorting item shape
+// ---------------------------------------------------------------------------
+
+describe('tableSortingItemSchema', () => {
+  it('requires both id and desc', () => {
+    expect(tableSortingItemSchema.safeParse({ id: 'a' }).success).toBe(false)
+    expect(tableSortingItemSchema.safeParse({ desc: true }).success).toBe(false)
+    expect(
+      tableSortingItemSchema.safeParse({ id: 'a', desc: true }).success
+    ).toBe(true)
   })
 })

--- a/web/src/lib/helpers/searchParams.ts
+++ b/web/src/lib/helpers/searchParams.ts
@@ -1,5 +1,6 @@
-// metapi-go/helpers — URL search-param decode helpers shared by the feature
-// search schemas (sites / proxy-logs / models / oauth).
+// metapi-go/helpers — URL search-param decode helpers and shared Zod schema
+// fragments used by the feature search schemas (sites / proxy-logs / models /
+// oauth / channels).
 
 import { z } from 'zod'
 //
@@ -144,3 +145,13 @@ export function encodeStringListParam(
   if (trimmed.length === 0 || trimmed === '[]') return undefined
   return parseStringListParam(trimmed).join(',') || undefined
 }
+
+/**
+ * Shared Zod schema for a single TanStack sorting item (`{ id, desc }`).
+ * The feature search schemas reuse this in their `sort` field instead of
+ * re-declaring the shape per feature.
+ */
+export const tableSortingItemSchema = z.object({
+  id: z.string(),
+  desc: z.boolean(),
+})

--- a/web/src/routes/_authenticated/accounts.tsx
+++ b/web/src/routes/_authenticated/accounts.tsx
@@ -1,11 +1,10 @@
 // metapi-go/routes — accounts list.
 //
-// `validateSearch` validates the URL search state the accounts page reads via
-// `window.location.search`: `page` / `pageSize` (1-based, coerced from the
-// string URL), and `q` / `status` / `site` (strings; `status` + `site` are
-// comma-separated lists the page splits itself). Keeping them as strings
-// (not arrays) preserves the URL shape the page writes via
-// `history.replaceState`, so no search-param normalization rewrites the URL.
+// `validateSearch` validates the URL search state consumed by the accounts
+// page: `page` / `pageSize` (1-based), `q` / `status` / `site` strings, and the
+// canonical comma-separated `sort` value. The page reads the raw search string
+// through the shared URL-table hook and writes changes back through TanStack
+// Router, so direct links and back/forward restore the same table view.
 //
 // `loader` prefetches the accounts snapshot (`accountQueryKeys.snapshot()`),
 // which the backend returns as `{ accounts, sites, generatedAt }` — the
@@ -19,7 +18,10 @@ import { z } from 'zod'
 import { accountQueryKeys } from '@/features/accounts'
 import { AccountsPage } from '@/features/accounts/components/accounts-page'
 import { api } from '@/lib/api'
-import { stringSearchParam } from '@/lib/helpers/searchParams'
+import {
+  encodeSortingParam,
+  stringSearchParam,
+} from '@/lib/helpers/searchParams'
 
 // Tolerant URL search contract: TanStack Router JSON-parses search values, so
 // `?q=123` arrives as a number and `?status=true` as a boolean. The string
@@ -36,6 +38,14 @@ export const accountsSearchSchema = z.object({
   page: z.coerce.number().int().positive().catch(1).default(1),
   pageSize: z.coerce.number().int().min(1).max(200).catch(20).default(20),
   q: stringSearchParam,
+  sort: z
+    .union([
+      z.string(),
+      z.array(z.object({ id: z.string(), desc: z.boolean() })),
+    ])
+    .optional()
+    .transform((value) => encodeSortingParam(value))
+    .catch(undefined),
   status: stringSearchParam,
   site: stringSearchParam,
   siteId: z.coerce.number().int().positive().optional().catch(undefined),


### PR DESCRIPTION
## Summary
- make URL the single owner of navigable table, pagination, filter, and search state
- stabilize controlled table callbacks and merge navigations against the latest URL
- add real-browser route, accessibility, and mobile smoke acceptance for state stability
- consolidate duplicated search schemas and document the state-stability architecture

## Test plan
- [x] 42 frontend test files / 437 tests
- [x] typecheck, lint, format check, knip, and production build
- [x] real-browser smoke and accessibility checks in CI
- [x] Go build, vet, SQLite, PostgreSQL, Docker, secret, and vulnerability CI inherited from master