### PR TITLE
fix: PG BOOLEAN dialect drift in token-candidates + systematic guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to MetAPI-Go will be documented in this file.
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [v0.14.1] — 2026-08-17
+
+### Fixed
+
+- 修复 PostgreSQL BOOLEAN 列与整数字面量比较的 dialect 不兼容（#805）：`/api/models/token-candidates` 在生产 PG 上返回 500，根因是 `stats_marketplace.go` 四条 builder 查询用了 SQLite-only 的 `COALESCE(<bool>, 0) = 1` / `<bool> = 1`，PG 报 SQLSTATE 42804。改为 `COALESCE(<bool>, false) = true` / `<bool> = true`（双 dialect 通用）。同模式波及 `model_redirects.go` × 2 + `service/model_redirects.go` × 1，一并修复。
+- `tokenCandidates` handler 的四个 builder `err` 之前被静默丢弃（`writeError(500)` 不打日志），导致服务端日志无任何线索。现在每个 builder 失败时走 `slog.Error` 记录错误 + `writeErrorWithRequest` 带上 request_id。
+
+### Added
+
+- 新增 `docs/pg_boolean_gate_test.go` 静态 gate：扫描 `handler/ service/ scheduler/` 非测试 `.go` 文件，禁止 `COALESCE(<bool>, 0)` 和 `<bool> = [01]` 模式出现在已知 BOOLEAN 列（`available`/`enabled`/`is_default` 等）上。与既有 `pg_rebind_gate_test.go`（42601）互补，覆盖 42804 类 dialect drift，将"reactive per-incident gate"升级为"systematic dialect-compatibility contract"。
+- 新增 `handler/admin/stats_marketplace_pg_test.go`（build tag `integration`）：在真实 PG 上种子 site + account + token + availability 行，调用全部四个 builder，确保 SQL 在 PG 的 BOOLEAN 类型系统下不再回归。
+- `docs/deployment.md` nginx 反代模板补齐 WebSocket upgrade 头（`proxy_http_version 1.1` + `Upgrade`/`Connection: upgrade`），防止 `wss://` 握手在代理层被掐断。
+
 ## [v0.14.0] — 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ All notable changes to MetAPI-Go will be documented in this file.
 
 ### Fixed
 
-- 修复 PostgreSQL BOOLEAN 列与整数字面量比较的 dialect 不兼容（#805）：`/api/models/token-candidates` 在生产 PG 上返回 500，根因是 `stats_marketplace.go` 四条 builder 查询用了 SQLite-only 的 `COALESCE(<bool>, 0) = 1` / `<bool> = 1`，PG 报 SQLSTATE 42804。改为 `COALESCE(<bool>, false) = true` / `<bool> = true`（双 dialect 通用）。同模式波及 `model_redirects.go` × 2 + `service/model_redirects.go` × 1，一并修复。
+- 修复 PostgreSQL BOOLEAN 列与整数字面量比较的 dialect 不兼容（#805）：`/api/models/token-candidates` 在生产 PG 上返回 500，根因是 `stats_marketplace.go` 等文件用了 SQLite-only 的 `COALESCE(<bool>, 0) = 1` / `<bool> = 1`，PG 报 SQLSTATE 42804。改为 `COALESCE(<bool>, false) = true` / `<bool> = true`（双 dialect 通用）。波及 `stats_marketplace.go`（15 处）、`model_redirects.go` × 2、`service/model_redirects.go` × 1、`sites.go` × 2（`use_system_proxy = 1/0`）。
 - `tokenCandidates` handler 的四个 builder `err` 之前被静默丢弃（`writeError(500)` 不打日志），导致服务端日志无任何线索。现在每个 builder 失败时走 `slog.Error` 记录错误 + `writeErrorWithRequest` 带上 request_id。
 
 ### Added
 
-- 新增 `docs/pg_boolean_gate_test.go` 静态 gate：扫描 `handler/ service/ scheduler/` 非测试 `.go` 文件，禁止 `COALESCE(<bool>, 0)` 和 `<bool> = [01]` 模式出现在已知 BOOLEAN 列（`available`/`enabled`/`is_default` 等）上。与既有 `pg_rebind_gate_test.go`（42601）互补，覆盖 42804 类 dialect drift，将"reactive per-incident gate"升级为"systematic dialect-compatibility contract"。
+- 新增 `docs/pg_boolean_gate_test.go` 静态 gate：扫描 `handler/ service/ scheduler/` 非测试 `.go` 文件，禁止 `COALESCE(<bool>, 0)` 和 `<bool> = [01]` / `<> [01]` / `!= [01]` 模式出现在全部 16 个已知 BOOLEAN 列上（大小写不敏感）。与既有 `pg_rebind_gate_test.go`（42601）互补，覆盖 42804 类 dialect drift，将"reactive per-incident gate"升级为"systematic dialect-compatibility contract"。
 - 新增 `handler/admin/stats_marketplace_pg_test.go`（build tag `integration`）：在真实 PG 上种子 site + account + token + availability 行，调用全部四个 builder，确保 SQL 在 PG 的 BOOLEAN 类型系统下不再回归。
-- `docs/deployment.md` nginx 反代模板补齐 WebSocket upgrade 头（`proxy_http_version 1.1` + `Upgrade`/`Connection: upgrade`），防止 `wss://` 握手在代理层被掐断。
+- `docs/deployment.md` nginx 反代模板补齐 WebSocket upgrade 头（`proxy_http_version 1.1` + `Upgrade`/`Connection $connection_upgrade` map 模式），防止 `wss://` 握手在代理层被掐断。
 
 ## [v0.14.0] — 2026-08-17
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # Deployment Guide
 
-**Last updated**: 2026-08-16
+**Last updated**: 2026-08-17
 
 ## Prerequisites
 
@@ -81,6 +81,9 @@ server {
 
     location / {
         proxy_pass http://127.0.0.1:4000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -72,6 +72,13 @@ curl http://localhost:4000/health
 ## Nginx Reverse Proxy
 
 ```nginx
+# Map for WebSocket Connection header: only send "upgrade" when the client
+# actually requested an upgrade; otherwise close (standard nginx WS pattern).
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 443 ssl http2;
     server_name metapi.example.com;
@@ -83,7 +90,7 @@ server {
         proxy_pass http://127.0.0.1:4000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docs/pg_boolean_gate_test.go
+++ b/docs/pg_boolean_gate_test.go
@@ -1,0 +1,173 @@
+package docs
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// pgBooleanLiteralGate scans handler/ service/ scheduler/ for SQL that
+// compares BOOLEAN columns against integer literals (0/1) or wraps them in
+// COALESCE(..., 0). Both patterns are SQLite-only: SQLite stores booleans as
+// 0/1 integers so the comparison type-checks, but PostgreSQL's BOOLEAN type
+// rejects them with SQLSTATE 42804 ("COALESCE types boolean and integer
+// cannot be matched" / "operator does not exist: boolean = integer").
+//
+// Background: the 2026-08-17 v0.14.0 deployment surfaced this on the
+// /api/models/token-candidates endpoint — four builder queries in
+// stats_marketplace.go used COALESCE(<bool>, 0) = 1 and <bool> = 1, which
+// PostgreSQL rejected. The bug shipped because (a) no test exercised those
+// builders on PG, and (b) the existing pg_rebind_gate_test.go only catches
+// ?-placeholder dialect drift (SQLSTATE 42601), not boolean-literal drift.
+// This gate generalizes dialect-drift detection to the boolean-literal class.
+//
+// Rule: in any .go file (excluding _test.go), no SQL string literal may
+// contain:
+//
+//	COALESCE(<optional-table-alias.><bool-col>, 0)
+//	<bool-col> = 0 | 1
+//	<bool-col> <> 0 | 1
+//
+// where <bool-col> is one of the known BOOLEAN columns: available, enabled,
+// is_default, resin_enabled, use_utls, post_refresh_probe_enabled. Use
+// COALESCE(<col>, false) = true / <col> = true / IS TRUE instead — these are
+// portable across both SQLite and PostgreSQL.
+
+var (
+	// knownBooleanColumns is the set of column names declared BOOLEAN in
+	// store/schema_ddl.go. Adding a new BOOLEAN column here extends the gate.
+	knownBooleanColumns = []string{
+		"available",
+		"enabled",
+		"is_default",
+		"resin_enabled",
+		"use_utls",
+		"post_refresh_probe_enabled",
+	}
+
+	// booleanColumnAlternation builds `(?:available|enabled|is_default|...)`
+	// from the list above, used inside the shared regex.
+	booleanColumnAlternation = "(?:" + strings.Join(knownBooleanColumns, "|") + ")"
+
+	// coalesceBoolIntRe matches COALESCE(<optional-alias.><bool-col>, 0) or
+	// COALESCE(<bool-col>, 0). The column may be prefixed by a table alias
+	// like "tma." or "at.". Captures the column name for the violation
+	// message.
+	coalesceBoolIntRe = regexp.MustCompile(
+		`COALESCE\(\s*(?:[a-z_]+\.)?` + booleanColumnAlternation + `\s*,\s*0\s*\)`,
+	)
+
+	// boolEqualsIntRe matches <optional-alias.><bool-col> = 0|1 or <> 0|1.
+	// Word boundaries prevent matching substrings like "not_available".
+	boolEqualsIntRe = regexp.MustCompile(
+		`(?:[a-z_]+\.)?\b` + booleanColumnAlternation + `\b\s*(?:=|<>)\s*[01]\b`,
+	)
+)
+
+func TestPgBooleanLiteralGateNoIntComparison(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Dir(filepath.Dir(thisFile)) // docs/ → repo root
+	dirs := []string{"handler", "service", "scheduler"}
+	var violations []string
+
+	for _, dir := range dirs {
+		root := filepath.Join(repoRoot, dir)
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			src, err := os.ReadFile(path)
+			if err != nil {
+				return nil
+			}
+			content := string(src)
+			for _, line := range strings.Split(content, "\n") {
+				// Skip comment lines — doc comments may legitimately mention
+				// "available=1" as prose (e.g. service/model_redirects.go:189).
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "//") {
+					continue
+				}
+				for _, m := range coalesceBoolIntRe.FindAllString(line, -1) {
+					violations = append(violations, path+": "+m+
+						" — use COALESCE(<col>, false) = true instead (PG 42804)")
+				}
+				for _, m := range boolEqualsIntRe.FindAllString(line, -1) {
+					violations = append(violations, path+": "+m+
+						" — use <col> = true / false instead (PG 42804)")
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", dir, err)
+		}
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf(
+			"boolean column compared against integer literal (PostgreSQL would 42804). "+
+				"Use COALESCE(<col>, false) = true or <col> = true / false:\n%s",
+			strings.Join(violations, "\n"),
+		)
+	}
+}
+
+// TestPgBooleanLiteralGateRegexpSanity locks the matcher behaviour so future
+// column additions don't silently weaken the gate.
+func TestPgBooleanLiteralGateRegexpSanity(t *testing.T) {
+	// COALESCE with integer default must be flagged — prefixed and bare.
+	coalescePrefixed := "WHERE COALESCE(tma.available, 0) = 1"
+	if !coalesceBoolIntRe.MatchString(coalescePrefixed) {
+		t.Fatalf("regexp must match COALESCE with prefixed boolean column: %s", coalescePrefixed)
+	}
+	coalesceBare := "WHERE COALESCE(available, 0) = 1"
+	if !coalesceBoolIntRe.MatchString(coalesceBare) {
+		t.Fatalf("regexp must match COALESCE with bare boolean column: %s", coalesceBare)
+	}
+
+	// COALESCE with false default must NOT be flagged (dialect-safe).
+	coalesceSafe := "WHERE COALESCE(tma.available, false) = true"
+	if coalesceBoolIntRe.MatchString(coalesceSafe) {
+		t.Fatalf("regexp must not flag dialect-safe COALESCE: %s", coalesceSafe)
+	}
+
+	// Direct = 1 / = 0 / <> 1 must be flagged.
+	equalsOne := "AND at.enabled = 1"
+	if !boolEqualsIntRe.MatchString(equalsOne) {
+		t.Fatalf("regexp must match <bool> = 1: %s", equalsOne)
+	}
+	equalsZero := "WHERE enabled = 0"
+	if !boolEqualsIntRe.MatchString(equalsZero) {
+		t.Fatalf("regexp must match <bool> = 0: %s", equalsZero)
+	}
+	notEqualsOne := "AND at.enabled <> 1"
+	if !boolEqualsIntRe.MatchString(notEqualsOne) {
+		t.Fatalf("regexp must match <bool> <> 1: %s", notEqualsOne)
+	}
+
+	// = true / = false must NOT be flagged (dialect-safe).
+	equalsTrue := "AND at.enabled = true"
+	if boolEqualsIntRe.MatchString(equalsTrue) {
+		t.Fatalf("regexp must not flag <bool> = true: %s", equalsTrue)
+	}
+
+	// Comment lines must be skipped by the walker (not by the regex — the
+	// walker checks strings.HasPrefix(trimmed, "//") before applying the
+	// regex). Verify the regex itself is agnostic: a comment-style string
+	// would match, but the walker excludes it. This test documents that the
+	// exclusion is in the walker, not the regex.
+	commentLine := "// available=1 in a comment is fine"
+	if !boolEqualsIntRe.MatchString(commentLine) {
+		t.Fatalf("regexp matches comment content; walker excludes comment lines — this is intentional")
+	}
+}

--- a/docs/pg_boolean_gate_test.go
+++ b/docs/pg_boolean_gate_test.go
@@ -30,22 +30,37 @@ import (
 //	COALESCE(<optional-table-alias.><bool-col>, 0)
 //	<bool-col> = 0 | 1
 //	<bool-col> <> 0 | 1
+//	<bool-col> != 0 | 1
 //
-// where <bool-col> is one of the known BOOLEAN columns: available, enabled,
-// is_default, resin_enabled, use_utls, post_refresh_probe_enabled. Use
-// COALESCE(<col>, false) = true / <col> = true / IS TRUE instead — these are
-// portable across both SQLite and PostgreSQL.
+// where <bool-col> is one of the known BOOLEAN columns declared in
+// store/schema_ddl.go (the full 16-column inventory is in knownBooleanColumns
+// below). Matching is case-insensitive so uppercase identifiers (AVAILABLE,
+// COALESCE) are also caught. Use COALESCE(<col>, false) = true /
+// <col> = true / IS TRUE instead — these are portable across both SQLite
+// and PostgreSQL.
 
 var (
 	// knownBooleanColumns is the set of column names declared BOOLEAN in
 	// store/schema_ddl.go. Adding a new BOOLEAN column here extends the gate.
+	// The list is the complete inventory from schema_ddl.go as of 2026-08-17;
+	// when adding a new BOOLEAN column to the schema, add it here too.
 	knownBooleanColumns = []string{
 		"available",
+		"checkin_enabled",
+		"custom_headers_override_request_headers",
+		"downgrade_decision",
 		"enabled",
 		"is_default",
-		"resin_enabled",
-		"use_utls",
+		"is_manual",
+		"is_pinned",
+		"is_stream",
+		"manual_override",
 		"post_refresh_probe_enabled",
+		"read",
+		"recover_applied",
+		"resin_enabled",
+		"use_system_proxy",
+		"use_utls",
 	}
 
 	// booleanColumnAlternation builds `(?:available|enabled|is_default|...)`
@@ -54,16 +69,17 @@ var (
 
 	// coalesceBoolIntRe matches COALESCE(<optional-alias.><bool-col>, 0) or
 	// COALESCE(<bool-col>, 0). The column may be prefixed by a table alias
-	// like "tma." or "at.". Captures the column name for the violation
-	// message.
+	// like "tma." or "at.". Case-insensitive (?i) so uppercase identifiers
+	// (AVAILABLE, COALESCE) are also caught — SQL is case-insensitive.
 	coalesceBoolIntRe = regexp.MustCompile(
-		`COALESCE\(\s*(?:[a-z_]+\.)?` + booleanColumnAlternation + `\s*,\s*0\s*\)`,
+		`(?i)COALESCE\(\s*(?:[a-z_]+\.)?` + booleanColumnAlternation + `\s*,\s*0\s*\)`,
 	)
 
-	// boolEqualsIntRe matches <optional-alias.><bool-col> = 0|1 or <> 0|1.
+	// boolEqualsIntRe matches <optional-alias.><bool-col> = 0|1 or <> 0|1 or != 0|1.
 	// Word boundaries prevent matching substrings like "not_available".
+	// Case-insensitive (?i) so uppercase identifiers are also caught.
 	boolEqualsIntRe = regexp.MustCompile(
-		`(?:[a-z_]+\.)?\b` + booleanColumnAlternation + `\b\s*(?:=|<>)\s*[01]\b`,
+		`(?i)(?:[a-z_]+\.)?\b` + booleanColumnAlternation + `\b\s*(?:=|<>|!=)\s*[01]\b`,
 	)
 )
 
@@ -141,7 +157,7 @@ func TestPgBooleanLiteralGateRegexpSanity(t *testing.T) {
 		t.Fatalf("regexp must not flag dialect-safe COALESCE: %s", coalesceSafe)
 	}
 
-	// Direct = 1 / = 0 / <> 1 must be flagged.
+	// Direct = 1 / = 0 / <> 1 / != 1 must be flagged.
 	equalsOne := "AND at.enabled = 1"
 	if !boolEqualsIntRe.MatchString(equalsOne) {
 		t.Fatalf("regexp must match <bool> = 1: %s", equalsOne)
@@ -153,6 +169,20 @@ func TestPgBooleanLiteralGateRegexpSanity(t *testing.T) {
 	notEqualsOne := "AND at.enabled <> 1"
 	if !boolEqualsIntRe.MatchString(notEqualsOne) {
 		t.Fatalf("regexp must match <bool> <> 1: %s", notEqualsOne)
+	}
+	bangNotEquals := "AND at.enabled != 1"
+	if !boolEqualsIntRe.MatchString(bangNotEquals) {
+		t.Fatalf("regexp must match <bool> != 1: %s", bangNotEquals)
+	}
+
+	// Case-insensitivity: uppercase identifiers must be flagged.
+	upperCase := "WHERE AVAILABLE = 1"
+	if !boolEqualsIntRe.MatchString(upperCase) {
+		t.Fatalf("regexp must match uppercase AVAILABLE = 1: %s", upperCase)
+	}
+	upperCoalesce := "WHERE COALESCE(TMA.AVAILABLE, 0) = 1"
+	if !coalesceBoolIntRe.MatchString(upperCoalesce) {
+		t.Fatalf("regexp must match uppercase COALESCE: %s", upperCoalesce)
 	}
 
 	// = true / = false must NOT be flagged (dialect-safe).

--- a/handler/admin/model_redirects.go
+++ b/handler/admin/model_redirects.go
@@ -239,7 +239,7 @@ func (h *modelRedirectHandler) generate(w http.ResponseWriter, r *http.Request) 
 		models := body.Models
 		if len(models) == 0 {
 			// Deterministic order: insertion order ≈ upstream return order.
-			rows, err := queryRowsErr(h.db, "SELECT model_name FROM model_availability WHERE account_id = ? AND available = 1 ORDER BY id ASC", body.AccountID)
+			rows, err := queryRowsErr(h.db, "SELECT model_name FROM model_availability WHERE account_id = ? AND available = true ORDER BY id ASC", body.AccountID)
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, "failed to load account models")
 				return
@@ -264,7 +264,7 @@ func (h *modelRedirectHandler) generate(w http.ResponseWriter, r *http.Request) 
 		ModelName string `db:"model_name"`
 	}
 	var rows []acctModel
-	if err := h.db.Select(&rows, "SELECT account_id, model_name FROM model_availability WHERE available = 1"); err != nil {
+	if err := h.db.Select(&rows, "SELECT account_id, model_name FROM model_availability WHERE available = true"); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "generate failed: " + err.Error()})
 		return
 	}

--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -509,9 +509,9 @@ func (h *sitesHandler) batchSites(w http.ResponseWriter, r *http.Request) {
 		case "delete":
 			h.db.Exec(h.db.Rebind("DELETE FROM sites WHERE id = ?"), id)
 		case "enableSystemProxy":
-			h.db.Exec(h.db.Rebind("UPDATE sites SET use_system_proxy = 1, updated_at = ? WHERE id = ?"), now, id)
+			h.db.Exec(h.db.Rebind("UPDATE sites SET use_system_proxy = true, updated_at = ? WHERE id = ?"), now, id)
 		case "disableSystemProxy":
-			h.db.Exec(h.db.Rebind("UPDATE sites SET use_system_proxy = 0, updated_at = ? WHERE id = ?"), now, id)
+			h.db.Exec(h.db.Rebind("UPDATE sites SET use_system_proxy = false, updated_at = ? WHERE id = ?"), now, id)
 		case "enable":
 			h.db.Exec(h.db.Rebind("UPDATE sites SET status = 'active', updated_at = ? WHERE id = ?"), now, id)
 			service.ApplySiteStatusSideEffects(h.db, id, existing.Name, "active")

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -915,22 +915,26 @@ func (h *statsHandler) tokenCandidates(w http.ResponseWriter, r *http.Request) {
 	allowed := h.loadGlobalAllowedModels()
 	models, err := h.buildTokenCandidateModels(allowed)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load token candidates")
+		slog.Error("token-candidates: buildTokenCandidateModels failed", "error", err)
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load token candidates")
 		return
 	}
 	withoutToken, err := h.buildModelsWithoutToken(allowed)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load models without token")
+		slog.Error("token-candidates: buildModelsWithoutToken failed", "error", err)
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load models without token")
 		return
 	}
 	missingGroups, err := h.buildModelsMissingTokenGroups(allowed)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load missing token groups")
+		slog.Error("token-candidates: buildModelsMissingTokenGroups failed", "error", err)
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load missing token groups")
 		return
 	}
 	endpointTypes, err := h.buildEndpointTypesByModel(allowed)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load endpoint types")
+		slog.Error("token-candidates: buildEndpointTypesByModel failed", "error", err)
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load endpoint types")
 		return
 	}
 

--- a/handler/admin/stats_marketplace.go
+++ b/handler/admin/stats_marketplace.go
@@ -86,7 +86,7 @@ func (h *statsHandler) buildMarketplaceModels() ([]map[string]any, error) {
 		FROM model_availability ma
 		INNER JOIN accounts a ON a.id = ma.account_id
 		INNER JOIN sites s ON s.id = a.site_id
-		WHERE COALESCE(ma.available, 0) = 1
+		WHERE COALESCE(ma.available, false) = true
 			AND COALESCE(a.status, '') <> 'disabled'
 			AND COALESCE(s.status, '') <> 'disabled'
 		ORDER BY ma.model_name ASC, a.id ASC
@@ -117,7 +117,7 @@ func (h *statsHandler) buildMarketplaceModels() ([]map[string]any, error) {
 			SELECT id, name, is_default
 			FROM account_tokens
 			WHERE account_id = ?
-				AND enabled = 1
+				AND enabled = true
 				AND (value_status IS NULL OR value_status <> 'expired')
 			ORDER BY is_default DESC, id ASC
 		`, acc.ID)
@@ -157,8 +157,8 @@ func (h *statsHandler) buildMarketplaceModels() ([]map[string]any, error) {
 		INNER JOIN account_tokens at ON at.id = tma.token_id
 		INNER JOIN accounts a ON a.id = at.account_id
 		INNER JOIN sites s ON s.id = a.site_id
-		WHERE COALESCE(tma.available, 0) = 1
-			AND at.enabled = 1
+		WHERE COALESCE(tma.available, false) = true
+			AND at.enabled = true
 			AND (at.value_status IS NULL OR at.value_status <> 'expired')
 			AND COALESCE(a.status, '') <> 'disabled'
 			AND COALESCE(s.status, '') <> 'disabled'
@@ -205,7 +205,7 @@ func (h *statsHandler) buildMarketplaceModels() ([]map[string]any, error) {
 	routeRows, err := queryRowsErr(h.db, `
 		SELECT model_pattern
 		FROM token_routes
-		WHERE enabled = 1
+		WHERE enabled = true
 			AND route_mode <> 'explicit_group'
 	`)
 	if err != nil {
@@ -348,8 +348,8 @@ func (h *statsHandler) buildTokenCandidateModels(allowed map[string]struct{}) (m
 		INNER JOIN account_tokens at ON at.id = tma.token_id
 		INNER JOIN accounts a ON a.id = at.account_id
 		INNER JOIN sites s ON s.id = a.site_id
-		WHERE COALESCE(tma.available, 0) = 1
-			AND at.enabled = 1
+		WHERE COALESCE(tma.available, false) = true
+			AND at.enabled = true
 			AND (at.value_status IS NULL OR at.value_status <> 'expired')
 			AND COALESCE(a.status, '') <> 'disabled'
 			AND COALESCE(s.status, '') <> 'disabled'
@@ -410,7 +410,7 @@ func (h *statsHandler) buildModelsWithoutToken(allowed map[string]struct{}) (map
 		FROM model_availability ma
 		INNER JOIN accounts a ON a.id = ma.account_id
 		INNER JOIN sites s ON s.id = a.site_id
-		WHERE COALESCE(ma.available, 0) = 1
+		WHERE COALESCE(ma.available, false) = true
 			AND COALESCE(a.status, '') <> 'disabled'
 			AND COALESCE(s.status, '') <> 'disabled'
 			AND NOT EXISTS (
@@ -418,9 +418,9 @@ func (h *statsHandler) buildModelsWithoutToken(allowed map[string]struct{}) (map
 				FROM account_tokens at
 				INNER JOIN token_model_availability tma ON tma.token_id = at.id
 				WHERE at.account_id = a.id
-					AND at.enabled = 1
+					AND at.enabled = true
 					AND (at.value_status IS NULL OR at.value_status <> 'expired')
-					AND COALESCE(tma.available, 0) = 1
+					AND COALESCE(tma.available, false) = true
 					AND tma.model_name = ma.model_name
 			)
 			AND NOT EXISTS (
@@ -428,7 +428,7 @@ func (h *statsHandler) buildModelsWithoutToken(allowed map[string]struct{}) (map
 				-- are still "without token" for route channel binding when no account_tokens rows exist.
 				SELECT 1 FROM account_tokens at
 				WHERE at.account_id = a.id
-					AND at.enabled = 1
+					AND at.enabled = true
 					AND (at.value_status IS NULL OR at.value_status <> 'expired')
 			)
 		ORDER BY ma.model_name ASC, a.id ASC
@@ -488,10 +488,10 @@ func (h *statsHandler) buildModelsMissingTokenGroups(allowed map[string]struct{}
 		INNER JOIN accounts a ON a.id = ma.account_id
 		INNER JOIN sites s ON s.id = a.site_id
 		INNER JOIN account_tokens at ON at.account_id = a.id
-		WHERE COALESCE(ma.available, 0) = 1
+		WHERE COALESCE(ma.available, false) = true
 			AND COALESCE(a.status, '') <> 'disabled'
 			AND COALESCE(s.status, '') <> 'disabled'
-			AND at.enabled = 1
+			AND at.enabled = true
 			AND (at.value_status IS NULL OR at.value_status <> 'expired')
 		ORDER BY ma.model_name ASC, a.id ASC, at.id ASC
 	`)
@@ -602,9 +602,9 @@ func (h *statsHandler) buildEndpointTypesByModel(allowed map[string]struct{}) (m
 	// Union of endpoint types inferred from model names present in availability.
 	models := map[string]struct{}{}
 	availModels, err := queryRowsErr(h.db, `
-		SELECT DISTINCT model_name AS model_name FROM model_availability WHERE COALESCE(available, 0) = 1
+		SELECT DISTINCT model_name AS model_name FROM model_availability WHERE COALESCE(available, false) = true
 		UNION
-		SELECT DISTINCT model_name AS model_name FROM token_model_availability WHERE COALESCE(available, 0) = 1
+		SELECT DISTINCT model_name AS model_name FROM token_model_availability WHERE COALESCE(available, false) = true
 	`)
 	if err != nil {
 		return nil, err

--- a/handler/admin/stats_marketplace_pg_test.go
+++ b/handler/admin/stats_marketplace_pg_test.go
@@ -86,10 +86,11 @@ func TestStatsMarketplaceBuildersPostgres(t *testing.T) {
 		t.Fatalf("load account id: %v", err)
 	}
 
-	// Seed account_token (enabled, not expired).
+	// Seed account_token (enabled, not expired). value_status is NOT NULL on PG;
+	// use 'active' so the token is treated as valid by the builder WHERE clauses.
 	if _, err := db.Exec(db.Rebind(
 		`INSERT INTO account_tokens (account_id, name, token, enabled, is_default, value_status, created_at, updated_at)
-		 VALUES (?, ?, 'tok-probe', true, true, NULL, NOW(), NOW())`), accountID, probeToken); err != nil {
+		 VALUES (?, ?, 'tok-probe', true, true, 'active', NOW(), NOW())`), accountID, probeToken); err != nil {
 		t.Fatalf("seed account_token: %v", err)
 	}
 	var tokenID int64

--- a/handler/admin/stats_marketplace_pg_test.go
+++ b/handler/admin/stats_marketplace_pg_test.go
@@ -1,0 +1,202 @@
+//go:build integration
+
+package admin
+
+import (
+	"os"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// pgDSN returns the PostgreSQL DSN from PG_TEST_DSN (empty when unset).
+func pgDSN() string {
+	return os.Getenv("PG_TEST_DSN")
+}
+
+// TestStatsMarketplaceBuildersPostgres is the regression test for the
+// 2026-08-17 v0.14.0 deployment incident: four builder queries in
+// stats_marketplace.go used SQLite-only boolean literal syntax
+// (COALESCE(<bool>, 0) = 1 and <bool> = 1) that PostgreSQL rejects with
+// SQLSTATE 42804 ("COALESCE types boolean and integer cannot be matched" /
+// "operator does not exist: boolean = integer"). The bug caused
+// /api/models/token-candidates to return HTTP 500 on production Azure PG.
+//
+// This test seeds a site + account + token + availability rows on PostgreSQL
+// and exercises all four builders so the SQL runs against PG's BOOLEAN type
+// system — catching any future regression to integer-literal comparisons.
+//
+// It mirrors service/balance/balance_pg_test.go's pattern: build tag
+// "integration", skip when PG_TEST_DSN is unset, AutoMigrate on a fresh
+// connection, unique probe rows to avoid collisions with other PG integration
+// tests, and cleanup via t.Cleanup.
+func TestStatsMarketplaceBuildersPostgres(t *testing.T) {
+	if pgDSN() == "" {
+		t.Skip("PG_TEST_DSN not set; skipping PostgreSQL integration test")
+	}
+
+	db, err := store.Open(store.DialectPostgres, pgDSN(), false)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("auto-migrate: %v", err)
+	}
+
+	// Seed a site + account + token + availability rows. Use NOW() (PG) —
+	// the rebind helper handles placeholder conversion; NOW() is portable
+	// across SQLite (returns current timestamp) and PG.
+	probeSite := "pg-tc-probe-site"
+	probeAccount := "pg-tc-probe-account"
+	probeToken := "pg-tc-probe-token"
+	probeModel := "gpt-4o-tc-probe"
+
+	// Clean up any leftover rows from a prior run (idempotent re-run safety).
+	cleanup := func() {
+		db.MustExec(`DELETE FROM token_model_availability WHERE model_name = $1`, probeModel)
+		db.MustExec(`DELETE FROM model_availability WHERE model_name = $1`, probeModel)
+		db.MustExec(`DELETE FROM account_tokens WHERE name = $1`, probeToken)
+		db.MustExec(`DELETE FROM accounts WHERE username = $1`, probeAccount)
+		db.MustExec(`DELETE FROM sites WHERE name = $1`, probeSite)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	// Seed site.
+	if _, err := db.Exec(db.Rebind(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		 VALUES (?, 'https://probe.example.test', 'openai', 'active', NOW(), NOW())`), probeSite); err != nil {
+		t.Fatalf("seed site: %v", err)
+	}
+	var siteID int64
+	if err := db.Get(&siteID, db.Rebind(`SELECT id FROM sites WHERE name = ?`), probeSite); err != nil {
+		t.Fatalf("load site id: %v", err)
+	}
+
+	// Seed account.
+	if _, err := db.Exec(db.Rebind(
+		`INSERT INTO accounts (site_id, username, access_token, status, created_at, updated_at)
+		 VALUES (?, ?, 'sk-probe', 'active', NOW(), NOW())`), siteID, probeAccount); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	var accountID int64
+	if err := db.Get(&accountID, db.Rebind(`SELECT id FROM accounts WHERE username = ?`), probeAccount); err != nil {
+		t.Fatalf("load account id: %v", err)
+	}
+
+	// Seed account_token (enabled, not expired).
+	if _, err := db.Exec(db.Rebind(
+		`INSERT INTO account_tokens (account_id, name, token, enabled, is_default, value_status, created_at, updated_at)
+		 VALUES (?, ?, 'tok-probe', true, true, NULL, NOW(), NOW())`), accountID, probeToken); err != nil {
+		t.Fatalf("seed account_token: %v", err)
+	}
+	var tokenID int64
+	if err := db.Get(&tokenID, db.Rebind(`SELECT id FROM account_tokens WHERE name = ?`), probeToken); err != nil {
+		t.Fatalf("load token id: %v", err)
+	}
+
+	// Seed model_availability (account-level: available=true).
+	if _, err := db.Exec(db.Rebind(
+		`INSERT INTO model_availability (account_id, model_name, available, created_at, updated_at)
+		 VALUES (?, ?, true, NOW(), NOW())`), accountID, probeModel); err != nil {
+		t.Fatalf("seed model_availability: %v", err)
+	}
+
+	// Seed token_model_availability (token-level: available=true).
+	if _, err := db.Exec(db.Rebind(
+		`INSERT INTO token_model_availability (token_id, model_name, available, created_at, updated_at)
+		 VALUES (?, ?, true, NOW(), NOW())`), tokenID, probeModel); err != nil {
+		t.Fatalf("seed token_model_availability: %v", err)
+	}
+
+	// Exercise all four builders. Before the dialect-safe SQL fix, every one
+	// of these would fail with PG 42804 because the SQL used
+	// COALESCE(<bool>, 0) = 1 and <bool> = 1.
+	h := &statsHandler{db: db}
+	allowed := h.loadGlobalAllowedModels()
+
+	t.Run("buildTokenCandidateModels", func(t *testing.T) {
+		models, err := h.buildTokenCandidateModels(allowed)
+		if err != nil {
+			t.Fatalf("buildTokenCandidateModels failed on PG: %v", err)
+		}
+		if len(models) == 0 {
+			t.Fatalf("buildTokenCandidateModels returned no models; expected at least %s", probeModel)
+		}
+		candidates, ok := models[probeModel]
+		if !ok {
+			t.Fatalf("buildTokenCandidateModels did not include %s; got models: %v", probeModel, modelKeys(models))
+		}
+		if len(candidates) == 0 {
+			t.Fatalf("buildTokenCandidateModels returned 0 candidates for %s", probeModel)
+		}
+		// The seeded token should appear in the candidate list.
+		found := false
+		for _, c := range candidates {
+			if c["tokenId"].(int64) == tokenID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("buildTokenCandidateModels did not include token %d in candidates for %s", tokenID, probeModel)
+		}
+	})
+
+	t.Run("buildModelsWithoutToken", func(t *testing.T) {
+		// Our seeded account HAS a token, so it should NOT appear in
+		// modelsWithoutToken. The key assertion is that the query runs without
+		// error on PG — the data shape is a secondary check.
+		without, err := h.buildModelsWithoutToken(allowed)
+		if err != nil {
+			t.Fatalf("buildModelsWithoutToken failed on PG: %v", err)
+		}
+		// The probe account has a managed token, so it must not be "without token".
+		if accounts, ok := without[probeModel]; ok {
+			for _, a := range accounts {
+				if a["accountId"].(int64) == accountID {
+					t.Fatalf("buildModelsWithoutToken incorrectly included probe account %d (it has a token)", accountID)
+				}
+			}
+		}
+	})
+
+	t.Run("buildModelsMissingTokenGroups", func(t *testing.T) {
+		// The query must run without error on PG. The probe token has no
+		// token_group, so it may appear in the "uncertain" surface — but the
+		// key assertion is no SQL error.
+		_, err := h.buildModelsMissingTokenGroups(allowed)
+		if err != nil {
+			t.Fatalf("buildModelsMissingTokenGroups failed on PG: %v", err)
+		}
+	})
+
+	t.Run("buildEndpointTypesByModel", func(t *testing.T) {
+		// The query must run without error on PG and should include the
+		// probe model (inferred endpoint type "openai" for gpt-* names).
+		types, err := h.buildEndpointTypesByModel(allowed)
+		if err != nil {
+			t.Fatalf("buildEndpointTypesByModel failed on PG: %v", err)
+		}
+		if len(types) == 0 {
+			t.Fatalf("buildEndpointTypesByModel returned no models")
+		}
+		epTypes, ok := types[probeModel]
+		if !ok {
+			t.Fatalf("buildEndpointTypesByModel did not include %s; got: %v", probeModel, modelKeys(types))
+		}
+		if len(epTypes) == 0 {
+			t.Fatalf("buildEndpointTypesByModel returned empty types for %s", probeModel)
+		}
+	})
+}
+
+// modelKeys returns the keys of a map for diagnostic output.
+func modelKeys[V any](m map[string][]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/handler/admin/stats_marketplace_pg_test.go
+++ b/handler/admin/stats_marketplace_pg_test.go
@@ -26,10 +26,10 @@ func pgDSN() string {
 // and exercises all four builders so the SQL runs against PG's BOOLEAN type
 // system — catching any future regression to integer-literal comparisons.
 //
-// It mirrors service/balance/balance_pg_test.go's pattern: build tag
-// "integration", skip when PG_TEST_DSN is unset, AutoMigrate on a fresh
-// connection, unique probe rows to avoid collisions with other PG integration
-// tests, and cleanup via t.Cleanup.
+// Diverges from service/balance/balance_pg_test.go in two ways: (1) uses a
+// //go:build integration tag so the file compiles only when -tags=integration
+// is passed (the balance test relies solely on t.Skip); (2) uses NOW() which
+// is PG-native (the test is PG-only via the build tag + PG_TEST_DSN guard).
 func TestStatsMarketplaceBuildersPostgres(t *testing.T) {
 	if pgDSN() == "" {
 		t.Skip("PG_TEST_DSN not set; skipping PostgreSQL integration test")
@@ -44,9 +44,10 @@ func TestStatsMarketplaceBuildersPostgres(t *testing.T) {
 		t.Fatalf("auto-migrate: %v", err)
 	}
 
-	// Seed a site + account + token + availability rows. Use NOW() (PG) —
-	// the rebind helper handles placeholder conversion; NOW() is portable
-	// across SQLite (returns current timestamp) and PG.
+	// Seed a site + account + token + availability rows. NOW() is PG-native;
+	// the rebind helper handles placeholder conversion (? → $N). The test is
+	// PG-only (build tag + PG_TEST_DSN guard) so cross-dialect portability
+	// of NOW() is not a concern here.
 	probeSite := "pg-tc-probe-site"
 	probeAccount := "pg-tc-probe-account"
 	probeToken := "pg-tc-probe-token"
@@ -113,7 +114,7 @@ func TestStatsMarketplaceBuildersPostgres(t *testing.T) {
 	// Exercise all four builders. Before the dialect-safe SQL fix, every one
 	// of these would fail with PG 42804 because the SQL used
 	// COALESCE(<bool>, 0) = 1 and <bool> = 1.
-	h := &statsHandler{db: db}
+	h := &statsHandler{db: db.DB}
 	allowed := h.loadGlobalAllowedModels()
 
 	t.Run("buildTokenCandidateModels", func(t *testing.T) {

--- a/handler/admin/stats_marketplace_pg_test.go
+++ b/handler/admin/stats_marketplace_pg_test.go
@@ -98,17 +98,19 @@ func TestStatsMarketplaceBuildersPostgres(t *testing.T) {
 		t.Fatalf("load token id: %v", err)
 	}
 
-	// Seed model_availability (account-level: available=true).
+	// Seed model_availability (account-level: available=true). This table
+	// has no created_at/updated_at columns — uses checked_at TEXT instead.
 	if _, err := db.Exec(db.Rebind(
-		`INSERT INTO model_availability (account_id, model_name, available, created_at, updated_at)
-		 VALUES (?, ?, true, NOW(), NOW())`), accountID, probeModel); err != nil {
+		`INSERT INTO model_availability (account_id, model_name, available)
+		 VALUES (?, ?, true)`), accountID, probeModel); err != nil {
 		t.Fatalf("seed model_availability: %v", err)
 	}
 
-	// Seed token_model_availability (token-level: available=true).
+	// Seed token_model_availability (token-level: available=true). Same
+	// schema as model_availability — no created_at/updated_at.
 	if _, err := db.Exec(db.Rebind(
-		`INSERT INTO token_model_availability (token_id, model_name, available, created_at, updated_at)
-		 VALUES (?, ?, true, NOW(), NOW())`), tokenID, probeModel); err != nil {
+		`INSERT INTO token_model_availability (token_id, model_name, available)
+		 VALUES (?, ?, true)`), tokenID, probeModel); err != nil {
 		t.Fatalf("seed token_model_availability: %v", err)
 	}
 

--- a/service/model_redirects.go
+++ b/service/model_redirects.go
@@ -202,7 +202,7 @@ func ListRedirectFixCandidates(ctx context.Context, db *sqlx.DB) ([]RedirectFixC
 		INNER JOIN sites s ON s.id = sdm.site_id
 		WHERE EXISTS (
 			SELECT 1 FROM model_availability ma
-			WHERE ma.account_id = r.account_id AND ma.model_name = r.actual AND ma.available = 1
+			WHERE ma.account_id = r.account_id AND ma.model_name = r.actual AND ma.available = true
 		)
 		ORDER BY s.name ASC, sdm.model_name ASC`))
 	if err != nil {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metapi",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "description": "Meta-layer management and unified proxy for AI API aggregation platforms",
   "keywords": [


### PR DESCRIPTION
## Summary

Closes #805.

Production `/api/models/token-candidates` returned HTTP 500 on PostgreSQL because four builder queries used SQLite-only boolean literal syntax (`COALESCE(<bool>, 0) = 1` / `<bool> = 1`). PG's BOOLEAN type rejects these with SQLSTATE 42804.

Root cause reaches deeper than the SQL: **zero test coverage** on these builders, and the existing `pg_rebind_gate_test.go` only catches `?`-placeholder drift (42601), not boolean-literal drift (42804). The codebase states dual-dialect as an invariant but had no automated check enforcing it beyond one incident class.

### Three-layer fix

1. **Dialect-safe SQL** — `COALESCE(<bool>, false) = true` / `<bool> = true` (8 production sites across `stats_marketplace.go`, `model_redirects.go` ×2, `service/model_redirects.go` ×1). Preserves nullable-safe COALESCE intent; portable across both dialects.
2. **Error observability** — `tokenCandidates` now logs each builder `err` via `slog.Error` + `writeErrorWithRequest` (request_id in response body). Previously errors were silently discarded — server logs were empty during the entire investigation.
3. **Systematic guard** — New `docs/pg_boolean_gate_test.go` mirrors the existing `pg_rebind_gate_test.go` pattern. Scans `handler/ service/ scheduler/` non-test `.go` files for `COALESCE(<bool>, 0)` and `<bool> = [01]` on known BOOLEAN columns (`available`/`enabled`/`is_default`/`resin_enabled`/`use_utls`/`post_refresh_probe_enabled`). Closes the architectural gap by generalizing dialect-drift detection beyond `?`-placeholders.
4. **PG integration regression test** — New `handler/admin/stats_marketplace_pg_test.go` (build tag `integration`, skipped when `PG_TEST_DSN` unset) seeds site + account + token + availability rows on PG and exercises all four builders so the SQL runs against PG's BOOLEAN type system.
5. **Deployment doc** — `docs/deployment.md` nginx template adds WebSocket upgrade headers (`proxy_http_version 1.1` + `Upgrade`/`Connection: upgrade`) so `wss://` handshake is not dropped at the proxy layer (fixes the same investigation's nginx finding on hk3).

## Why tests didn't catch it (process gap)

| Gap | Explanation |
| --- | --- |
| Zero builder coverage | No `*_test.go` or `*_pg_test.go` file called any of the four builders or the `tokenCandidates` handler. |
| PG integration is opt-in | CI's `test-pg` runs `go test -tags=integration`, but only `//go:build integration` files execute against PG. No `stats_marketplace_pg_test.go` existed. |
| Static gate was reactive | `pg_rebind_gate_test.go` was built per-incident (42601 × 3) not as a generalized dialect-compatibility contract. It caught `?`-placeholders but not boolean-literal drift (42804). |
| Errors silently discarded | `tokenCandidates` did `writeError(500, "...")` and discarded `err` — no `slog.Error` call, no request_id correlation. Server logs were empty. |

This PR addresses all four: builder coverage (layer 4), PG integration (layer 4), generalized static gate (layer 3), and error observability (layer 2).

## Test plan

- [x] `go build ./cmd/server && go build ./cmd/migrate` — pass
- [x] `go vet ./...` — pass
- [x] `go test ./docs -run "TestPgBooleanLiteralGate|TestPgRebindGate" -v -count=1` — new gate + existing gate both pass
- [x] `go test ./... -count=1 -race` — all packages pass (140s)
- [ ] CI `test-pg` job (runs on PR) — will exercise `stats_marketplace_pg_test.go` against PG 16
- [ ] Post-merge: deploy v0.14.1 to hk3, verify `curl -H "Authorization: Bearer ..." http://127.0.0.1:4000/api/models/token-candidates` returns 200
- [ ] Post-merge: verify WebSocket `wss://metapi.vectorcontrol.tech/api/admin/ops/ws?token=...` works from browser (nginx already patched on hk3)