### PR TITLE
fix: close Resin per-site write path and notify settings hydration

### DIFF
--- a/service/site_resin_utls_test.go
+++ b/service/site_resin_utls_test.go
@@ -1,0 +1,291 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// baseSiteData returns the minimal siteData map required by CreateSite,
+// with nullable override fields (resinEnabled, useUtls) omitted so the
+// caller can add only the ones it wants to exercise.
+func baseSiteData(name string) map[string]any {
+	return map[string]any{
+		"name":                  name,
+		"url":                   "https://" + name + ".example.com",
+		"platform":              "openai",
+		"status":                "active",
+		"globalWeight":          1.0,
+		"maxConcurrency":        int64(0),
+		"postRefreshProbeScope": "single",
+	}
+}
+
+// resinEnabledFromSite extracts the *bool from the map returned by
+// LoadSiteWithEndpoints, failing the test if the type assertion fails.
+func resinEnabledFromSite(t *testing.T, site map[string]any) *bool {
+	t.Helper()
+	v, ok := site["resinEnabled"].(*bool)
+	if !ok {
+		t.Fatalf("resinEnabled = %v, expected *bool", site["resinEnabled"])
+	}
+	return v
+}
+
+func useUtlsFromSite(t *testing.T, site map[string]any) *bool {
+	t.Helper()
+	v, ok := site["useUtls"].(*bool)
+	if !ok {
+		t.Fatalf("useUtls = %v, expected *bool", site["useUtls"])
+	}
+	return v
+}
+
+// ---- CreateSite round-trip tests ----
+
+func TestCreateSite_ResinEnabledTrue_ReadsBack(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	data := baseSiteData("ResinTrue")
+	data["resinEnabled"] = true
+
+	id, err := CreateSite(db.DB, data)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	site, err := LoadSiteWithEndpoints(db.DB, id)
+	if err != nil {
+		t.Fatalf("LoadSiteWithEndpoints: %v", err)
+	}
+	if site == nil {
+		t.Fatal("site not found after create")
+	}
+
+	resin := resinEnabledFromSite(t, site)
+	if resin == nil || !*resin {
+		t.Fatalf("resinEnabled = %v, want *bool(true)", resin)
+	}
+}
+
+func TestCreateSite_UseUtlsTrue_ReadsBack(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	data := baseSiteData("UtlsTrue")
+	data["useUtls"] = true
+
+	id, err := CreateSite(db.DB, data)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	site, err := LoadSiteWithEndpoints(db.DB, id)
+	if err != nil {
+		t.Fatalf("LoadSiteWithEndpoints: %v", err)
+	}
+	if site == nil {
+		t.Fatal("site not found after create")
+	}
+
+	utls := useUtlsFromSite(t, site)
+	if utls == nil || !*utls {
+		t.Fatalf("useUtls = %v, want *bool(true)", utls)
+	}
+}
+
+func TestCreateSite_ResinAndUtlsOmitted_ReadsBackNil(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	data := baseSiteData("ResinNil")
+
+	id, err := CreateSite(db.DB, data)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	site, err := LoadSiteWithEndpoints(db.DB, id)
+	if err != nil {
+		t.Fatalf("LoadSiteWithEndpoints: %v", err)
+	}
+	if site == nil {
+		t.Fatal("site not found after create")
+	}
+
+	resin := resinEnabledFromSite(t, site)
+	if resin != nil {
+		t.Fatalf("resinEnabled = %v, want nil (inherit global)", resin)
+	}
+	utls := useUtlsFromSite(t, site)
+	if utls != nil {
+		t.Fatalf("useUtls = %v, want nil (inherit global)", utls)
+	}
+}
+
+// ---- UpdateSite tests ----
+
+func TestUpdateSite_ResinEnabledFalse_UpdatesValue(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	data := baseSiteData("ResinUpdate")
+	data["resinEnabled"] = true
+
+	id, err := CreateSite(db.DB, data)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	if err := UpdateSite(db.DB, id, map[string]any{"resinEnabled": false}); err != nil {
+		t.Fatalf("UpdateSite: %v", err)
+	}
+
+	site, err := LoadSiteWithEndpoints(db.DB, id)
+	if err != nil {
+		t.Fatalf("LoadSiteWithEndpoints: %v", err)
+	}
+	if site == nil {
+		t.Fatal("site not found after update")
+	}
+
+	resin := resinEnabledFromSite(t, site)
+	if resin == nil || *resin {
+		t.Fatalf("resinEnabled = %v, want *bool(false)", resin)
+	}
+}
+
+func TestUpdateSite_UseUtlsFalse_UpdatesValue(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	data := baseSiteData("UtlsUpdate")
+	data["useUtls"] = true
+
+	id, err := CreateSite(db.DB, data)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	if err := UpdateSite(db.DB, id, map[string]any{"useUtls": false}); err != nil {
+		t.Fatalf("UpdateSite: %v", err)
+	}
+
+	site, err := LoadSiteWithEndpoints(db.DB, id)
+	if err != nil {
+		t.Fatalf("LoadSiteWithEndpoints: %v", err)
+	}
+	if site == nil {
+		t.Fatal("site not found after update")
+	}
+
+	utls := useUtlsFromSite(t, site)
+	if utls == nil || *utls {
+		t.Fatalf("useUtls = %v, want *bool(false)", utls)
+	}
+}
+
+func TestUpdateSite_ResinEnabledOmitted_DoesNotTouchColumn(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	data := baseSiteData("ResinOmitted")
+	data["resinEnabled"] = true
+
+	id, err := CreateSite(db.DB, data)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	// Update an unrelated field; resinEnabled is omitted from the updates map.
+	if err := UpdateSite(db.DB, id, map[string]any{"status": "disabled"}); err != nil {
+		t.Fatalf("UpdateSite: %v", err)
+	}
+
+	site, err := LoadSiteWithEndpoints(db.DB, id)
+	if err != nil {
+		t.Fatalf("LoadSiteWithEndpoints: %v", err)
+	}
+	if site == nil {
+		t.Fatal("site not found after update")
+	}
+
+	resin := resinEnabledFromSite(t, site)
+	if resin == nil || !*resin {
+		t.Fatalf("resinEnabled = %v, want *bool(true) (untouched)", resin)
+	}
+}
+
+func TestUpdateSite_UseUtlsOmitted_DoesNotTouchColumn(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	data := baseSiteData("UtlsOmitted")
+	data["useUtls"] = true
+
+	id, err := CreateSite(db.DB, data)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	// Update an unrelated field; useUtls is omitted from the updates map.
+	if err := UpdateSite(db.DB, id, map[string]any{"status": "disabled"}); err != nil {
+		t.Fatalf("UpdateSite: %v", err)
+	}
+
+	site, err := LoadSiteWithEndpoints(db.DB, id)
+	if err != nil {
+		t.Fatalf("LoadSiteWithEndpoints: %v", err)
+	}
+	if site == nil {
+		t.Fatal("site not found after update")
+	}
+
+	utls := useUtlsFromSite(t, site)
+	if utls == nil || !*utls {
+		t.Fatalf("useUtls = %v, want *bool(true) (untouched)", utls)
+	}
+}

--- a/service/site_service.go
+++ b/service/site_service.go
@@ -138,7 +138,7 @@ func LoadSiteAPIEndpoints(db *sqlx.DB, siteIDs []int64) (map[int64][]store.SiteA
 const SiteSelectColumns = `id, name, url, external_checkin_url, platform, proxy_url, use_system_proxy,
 	custom_headers, custom_headers_override_request_headers, status, is_pinned, sort_order, global_weight, api_key, max_concurrency,
 	post_refresh_probe_enabled, post_refresh_probe_model, post_refresh_probe_scope,
-	post_refresh_probe_latency_threshold_ms, tags, cf_clearance, browser_ua, resin_enabled, created_at, updated_at`
+	post_refresh_probe_latency_threshold_ms, tags, cf_clearance, browser_ua, resin_enabled, use_utls, created_at, updated_at`
 
 // LoadSiteWithEndpoints loads a single site with its apiEndpoints attached.
 func LoadSiteWithEndpoints(db *sqlx.DB, siteID int64) (map[string]any, error) {
@@ -183,6 +183,7 @@ func siteToMap(site store.Site, endpoints []store.SiteAPIEndpoint) map[string]an
 		"browserUa":                           site.BrowserUA,
 		"cfClearance":                         site.CfClearance,
 		"resinEnabled":                        site.ResinEnabled,
+		"useUtls":                             site.UseUTLS,
 		"createdAt":                           site.CreatedAt,
 		"updatedAt":                           site.UpdatedAt,
 		"apiEndpoints":                        endpoints,
@@ -402,14 +403,19 @@ func CreateSite(db *sqlx.DB, siteData map[string]any) (int64, error) {
 
 	// Use RETURNING so PostgreSQL (no LastInsertId) and SQLite both get a real id
 	// inside the open transaction before apiEndpoints FK inserts.
+	//
+	// resin_enabled / use_utls are nullable *bool columns: nil = inherit the
+	// global RESIN_ENABLED / UTLS_ENABLED flag, true/false = per-site override.
+	// They are passed through directly from siteData (same nullable pattern as
+	// proxyUrl / customHeaders) so a missing key or JSON null stores NULL.
 	var siteID int64
 	err = tx.QueryRowx(
 		tx.Rebind(`INSERT INTO sites (name, url, platform, proxy_url, use_system_proxy, custom_headers,
 		 custom_headers_override_request_headers,
 		 external_checkin_url, status, is_pinned, sort_order, global_weight, max_concurrency,
 		 post_refresh_probe_enabled, post_refresh_probe_model, post_refresh_probe_scope,
-		 post_refresh_probe_latency_threshold_ms, browser_ua, cf_clearance, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 post_refresh_probe_latency_threshold_ms, browser_ua, cf_clearance, resin_enabled, use_utls, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 RETURNING id`),
 		name, urlStr, platform,
 		siteData["proxyUrl"], useSystemProxy, siteData["customHeaders"],
@@ -419,6 +425,7 @@ func CreateSite(db *sqlx.DB, siteData map[string]any) (int64, error) {
 		postRefreshProbeEnabled, postRefreshProbeModel,
 		postRefreshProbeScope, postRefreshProbeLatencyThresholdMs,
 		siteData["browserUa"], siteData["cfClearance"],
+		siteData["resinEnabled"], siteData["useUtls"],
 		now, now,
 	).Scan(&siteID)
 	if err != nil {
@@ -599,6 +606,8 @@ func jsonKeyToColumn(key string) string {
 		"postRefreshProbeLatencyThresholdMs":  "post_refresh_probe_latency_threshold_ms",
 		"browserUa":                          "browser_ua",
 		"cfClearance":                        "cf_clearance",
+		"resinEnabled":                       "resin_enabled",
+		"useUtls":                            "use_utls",
 	}
 	return mapping[key]
 }

--- a/store/settings.go
+++ b/store/settings.go
@@ -169,6 +169,12 @@ func ApplyRuntimeSettings(cfg *config.Config, settingsMap map[string]string) {
 		case "serverchan_enabled":
 			cfg.ServerChanEnabled = parseBoolSetting(value, cfg.ServerChanEnabled)
 
+		// Notify: General
+		case "notify_cooldown_sec":
+			cfg.NotifyCooldownSec = parseInt(value, cfg.NotifyCooldownSec)
+		case "system_proxy_url":
+			cfg.SystemProxyUrl = parseJSONSettingString(value)
+
 		// Telegram
 		case "telegram_enabled":
 			cfg.TelegramEnabled = parseBoolSetting(value, cfg.TelegramEnabled)
@@ -176,6 +182,12 @@ func ApplyRuntimeSettings(cfg *config.Config, settingsMap map[string]string) {
 			cfg.TelegramBotToken = parseJSONSettingString(value)
 		case "telegram_chat_id":
 			cfg.TelegramChatId = parseJSONSettingString(value)
+		case "telegram_api_base_url":
+			cfg.TelegramApiBaseUrl = parseJSONSettingString(value)
+		case "telegram_use_system_proxy":
+			cfg.TelegramUseSystemProxy = parseBoolSetting(value, cfg.TelegramUseSystemProxy)
+		case "telegram_message_thread_id":
+			cfg.TelegramMessageThreadId = parseJSONSettingString(value)
 
 		// SMTP
 		case "smtp_enabled":
@@ -192,6 +204,8 @@ func ApplyRuntimeSettings(cfg *config.Config, settingsMap map[string]string) {
 			cfg.SmtpFrom = parseJSONSettingString(value)
 		case "smtp_to":
 			cfg.SmtpTo = parseJSONSettingString(value)
+		case "smtp_secure":
+			cfg.SmtpSecure = parseBoolSetting(value, cfg.SmtpSecure)
 
 		// Log cleanup
 		case "log_cleanup.usage_logs_enabled":
@@ -285,7 +299,7 @@ func ApplyRuntimeSettings(cfg *config.Config, settingsMap map[string]string) {
 
 		default:
 			// Unknown setting — silently skip.
-			// Future: system_proxy_url, routing weights, admin_ip_allowlist, etc.
+			// Future: routing weights, admin_ip_allowlist, etc.
 		}
 	}
 }

--- a/store/settings_runtime_test.go
+++ b/store/settings_runtime_test.go
@@ -174,3 +174,82 @@ func TestApplyRuntimeSettingsDecodesNotifyTaskTogglesObject(t *testing.T) {
 		t.Fatalf("NotifyTaskToggles = %#v", cfg.NotifyTaskToggles)
 	}
 }
+
+// ---- Hydration tests for settings that were written but never read back ----
+//
+// upsertSettingDB (handler/admin/settings.go) JSON-marshals every value
+// before persisting: bools become "true"/"false", strings become
+// "\"value\"", ints become "60". ApplyRuntimeSettings must decode those
+// exact formats. These tests simulate a restart where the settings table
+// already contains persisted values and LoadRuntimeSettings feeds them
+// through ApplyRuntimeSettings.
+
+func TestApplyRuntimeSettings_SmtpSecure_ReadBack(t *testing.T) {
+	cfg := &config.Config{SmtpSecure: false}
+	ApplyRuntimeSettings(cfg, map[string]string{
+		"smtp_secure": `true`,
+	})
+	if !cfg.SmtpSecure {
+		t.Fatalf("SmtpSecure = %v, want true", cfg.SmtpSecure)
+	}
+}
+
+func TestApplyRuntimeSettings_SmtpSecure_False_ReadBack(t *testing.T) {
+	cfg := &config.Config{SmtpSecure: true}
+	ApplyRuntimeSettings(cfg, map[string]string{
+		"smtp_secure": `false`,
+	})
+	if cfg.SmtpSecure {
+		t.Fatalf("SmtpSecure = %v, want false", cfg.SmtpSecure)
+	}
+}
+
+func TestApplyRuntimeSettings_NotifyCooldownSec_ReadBack(t *testing.T) {
+	cfg := &config.Config{NotifyCooldownSec: 0}
+	ApplyRuntimeSettings(cfg, map[string]string{
+		"notify_cooldown_sec": `120`,
+	})
+	if cfg.NotifyCooldownSec != 120 {
+		t.Fatalf("NotifyCooldownSec = %d, want 120", cfg.NotifyCooldownSec)
+	}
+}
+
+func TestApplyRuntimeSettings_TelegramApiBaseUrl_ReadBack(t *testing.T) {
+	cfg := &config.Config{}
+	ApplyRuntimeSettings(cfg, map[string]string{
+		"telegram_api_base_url": `"https://api.telegram.local"`,
+	})
+	if cfg.TelegramApiBaseUrl != "https://api.telegram.local" {
+		t.Fatalf("TelegramApiBaseUrl = %q, want %q", cfg.TelegramApiBaseUrl, "https://api.telegram.local")
+	}
+}
+
+func TestApplyRuntimeSettings_TelegramUseSystemProxy_ReadBack(t *testing.T) {
+	cfg := &config.Config{TelegramUseSystemProxy: false}
+	ApplyRuntimeSettings(cfg, map[string]string{
+		"telegram_use_system_proxy": `true`,
+	})
+	if !cfg.TelegramUseSystemProxy {
+		t.Fatalf("TelegramUseSystemProxy = %v, want true", cfg.TelegramUseSystemProxy)
+	}
+}
+
+func TestApplyRuntimeSettings_TelegramMessageThreadId_ReadBack(t *testing.T) {
+	cfg := &config.Config{}
+	ApplyRuntimeSettings(cfg, map[string]string{
+		"telegram_message_thread_id": `"12345"`,
+	})
+	if cfg.TelegramMessageThreadId != "12345" {
+		t.Fatalf("TelegramMessageThreadId = %q, want %q", cfg.TelegramMessageThreadId, "12345")
+	}
+}
+
+func TestApplyRuntimeSettings_SystemProxyUrl_ReadBack(t *testing.T) {
+	cfg := &config.Config{}
+	ApplyRuntimeSettings(cfg, map[string]string{
+		"system_proxy_url": `"http://proxy.local:8080"`,
+	})
+	if cfg.SystemProxyUrl != "http://proxy.local:8080" {
+		t.Fatalf("SystemProxyUrl = %q, want %q", cfg.SystemProxyUrl, "http://proxy.local:8080")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `resin_enabled` and `use_utls` to CreateSite INSERT, UpdateSite jsonKeyToColumn mapping, SiteSelectColumns, and siteToMap so the per-site override is actually writable through the REST API
- Add six missing read-side cases to ApplyRuntimeSettings (smtp_secure, notify_cooldown_sec, telegram_api_base_url, telegram_use_system_proxy, telegram_message_thread_id, system_proxy_url) so persisted settings survive restart

## Test plan
- [x] 7 new Resin write-path tests (create/read-back, update, omit-does-not-touch)
- [x] 7 new settings hydration tests (read-back after persist)
- [x] `go build ./cmd/server` + `go vet ./...` + `go test ./service/... ./store/... ./config/... -count=1 -race`