### PR TITLE
fix(web): improve import flow UX with per-item reasons, a11y, and tests

### DIFF
--- a/web/src/features/import/__tests__/import-wizard-dialog.test.tsx
+++ b/web/src/features/import/__tests__/import-wizard-dialog.test.tsx
@@ -11,16 +11,27 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react'
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 import '@/i18n/config'
+
 import { ImportWizardDialog } from '../components/import-wizard-dialog'
 
-const { mockDetectMutate, mockImportMutate, mockToastError } = vi.hoisted(() => ({
-  mockDetectMutate: vi.fn(),
-  mockImportMutate: vi.fn(),
-  mockToastError: vi.fn(),
-}))
+const { mockDetectMutate, mockImportMutate, mockToastError } = vi.hoisted(
+  () => ({
+    mockDetectMutate: vi.fn(),
+    mockImportMutate: vi.fn(),
+    mockToastError: vi.fn(),
+  })
+)
 
 vi.mock('../api', () => ({
   useDetectSite: () => ({ mutateAsync: mockDetectMutate, isPending: false }),

--- a/web/src/features/import/__tests__/import-wizard-dialog.test.tsx
+++ b/web/src/features/import/__tests__/import-wizard-dialog.test.tsx
@@ -1,0 +1,216 @@
+// Behavior tests for the import wizard. Mocks the detect/import mutations
+// and the sites list so each test exercises one user-visible wizard behavior
+// without touching the network. Asserts only what the user sees (toasts,
+// step transitions, rendered result text) — never internal state.
+
+import '@testing-library/jest-dom/vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+import { ImportWizardDialog } from '../components/import-wizard-dialog'
+
+const { mockDetectMutate, mockImportMutate, mockToastError } = vi.hoisted(() => ({
+  mockDetectMutate: vi.fn(),
+  mockImportMutate: vi.fn(),
+  mockToastError: vi.fn(),
+}))
+
+vi.mock('../api', () => ({
+  useDetectSite: () => ({ mutateAsync: mockDetectMutate, isPending: false }),
+  useImportSites: () => ({ mutateAsync: mockImportMutate, isPending: false }),
+}))
+
+vi.mock('@/features/sites/api', () => ({
+  useSites: () => ({ data: [], isPending: false }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mockToastError,
+    success: vi.fn(),
+  },
+}))
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  mockDetectMutate.mockReset()
+  mockImportMutate.mockReset()
+  mockToastError.mockReset()
+  // Default: detection returns undetectable (empty platform).
+  mockDetectMutate.mockResolvedValue({})
+})
+
+afterEach(() => cleanup())
+
+describe('ImportWizardDialog', () => {
+  it('shows a toast and stays on source when no URLs are pasted', async () => {
+    render(<ImportWizardDialog open onOpenChange={() => {}} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    expect(mockToastError).toHaveBeenCalledTimes(1)
+    // Still on source: the textarea label stays visible.
+    expect(screen.getByLabelText('Site URLs')).toBeInTheDocument()
+  })
+
+  it('advances from source to identify when URLs are provided', async () => {
+    mockDetectMutate.mockResolvedValue({
+      platform: 'new-api',
+      confidence: 0.9,
+    })
+
+    render(<ImportWizardDialog open onOpenChange={() => {}} />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Site URLs')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText('Site URLs'), {
+      target: { value: 'https://a.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    // Identify step renders the detected platform in the platform input.
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('new-api')).toBeInTheDocument()
+    })
+    // Back button only appears on non-source steps.
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument()
+  })
+
+  it('shows a toast when advancing from identify with a missing platform', async () => {
+    // Detection returns undetectable → platform stays empty.
+    mockDetectMutate.mockResolvedValue({})
+
+    render(<ImportWizardDialog open onOpenChange={() => {}} />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Site URLs')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText('Site URLs'), {
+      target: { value: 'https://a.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    // Wait for identify step (Back button appears).
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument()
+    })
+    // Let detection settle so the platform input has its final value.
+    await waitFor(() => {
+      expect(mockDetectMutate).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    expect(mockToastError).toHaveBeenCalledWith(
+      expect.stringContaining('platform')
+    )
+  })
+
+  it('renders the per-item reason on the done step for a failed item', async () => {
+    mockDetectMutate.mockResolvedValue({
+      platform: 'new-api',
+      confidence: 0.9,
+    })
+    mockImportMutate.mockResolvedValue({
+      imported: 0,
+      skipped: 0,
+      failed: 1,
+      results: [
+        {
+          name: 'a.com',
+          url: 'https://a.com',
+          status: 'failed',
+          reason: 'platform unsupported',
+        },
+      ],
+    })
+
+    render(<ImportWizardDialog open onOpenChange={() => {}} />)
+
+    // source → identify
+    await waitFor(() => {
+      expect(screen.getByLabelText('Site URLs')).toBeInTheDocument()
+    })
+    fireEvent.change(screen.getByLabelText('Site URLs'), {
+      target: { value: 'https://a.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    // Wait for detection to populate the platform.
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('new-api')).toBeInTheDocument()
+    })
+
+    // identify → connect
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    // Wait for connect step (Switch toggle appears).
+    await waitFor(() => {
+      expect(screen.getByRole('switch')).toBeInTheDocument()
+    })
+    // connect → routes
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    // Wait for routes step (weight input renders as a spinbutton).
+    await waitFor(() => {
+      expect(screen.getByRole('spinbutton')).toBeInTheDocument()
+    })
+    // routes → done
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }))
+
+    // Done step renders the raw backend reason (interpolated into the
+    // i18n "Reason: {{reason}}" label).
+    await waitFor(() => {
+      expect(screen.getByText(/platform unsupported/)).toBeInTheDocument()
+    })
+  })
+
+  it('opens the discard confirm dialog when closing with unsaved input', async () => {
+    render(<ImportWizardDialog open onOpenChange={() => {}} />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Site URLs')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText('Site URLs'), {
+      target: { value: 'https://a.com' },
+    })
+
+    // Trigger close via the dialog's close (X) button.
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    // The discard confirm dialog should appear with its title.
+    await waitFor(() => {
+      expect(screen.getByText('Discard this import?')).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/features/import/__tests__/utils.test.ts
+++ b/web/src/features/import/__tests__/utils.test.ts
@@ -1,0 +1,83 @@
+// Unit tests for the import wizard URL helpers. `parseUrlLines` only dedups
+// raw trimmed lines; canonical dedup (trailing slash, query, fragment) is
+// `canonicalizeUrl`'s job — exercised separately so the split of concerns
+// stays explicit.
+
+import { describe, expect, it } from 'vitest'
+
+import { canonicalizeUrl, parseUrlLines } from '../lib/utils'
+
+describe('parseUrlLines', () => {
+  it('returns an empty array for empty input', () => {
+    expect(parseUrlLines('')).toEqual([])
+  })
+
+  it('filters blank and whitespace-only lines', () => {
+    expect(parseUrlLines('\n  \n\t\n \n')).toEqual([])
+  })
+
+  it('trims leading and trailing whitespace from each line', () => {
+    expect(
+      parseUrlLines('  https://a.com  \n\t https://b.com\t')
+    ).toEqual(['https://a.com', 'https://b.com'])
+  })
+
+  it('dedups exact raw lines after trimming', () => {
+    expect(parseUrlLines('https://a.com\nhttps://a.com')).toEqual([
+      'https://a.com',
+    ])
+  })
+
+  it('keeps lines that only differ by trailing slash (canonicalization is separate)', () => {
+    // parseUrlLines deliberately does not canonicalize — the wizard relies
+    // on canonicalizeUrl for that comparison. Asserting this keeps the
+    // boundary honest instead of papering over it here.
+    expect(parseUrlLines('https://a.com\nhttps://a.com/')).toHaveLength(2)
+  })
+
+  it('preserves order of first occurrence after dedup', () => {
+    expect(
+      parseUrlLines('https://b.com\nhttps://a.com\nhttps://b.com')
+    ).toEqual(['https://b.com', 'https://a.com'])
+  })
+})
+
+describe('canonicalizeUrl', () => {
+  it('returns empty string for empty or whitespace-only input', () => {
+    expect(canonicalizeUrl('')).toBe('')
+    expect(canonicalizeUrl('   ')).toBe('')
+  })
+
+  it('strips the query string and fragment', () => {
+    expect(canonicalizeUrl('https://a.com/path?x=1#frag')).toBe(
+      'https://a.com/path'
+    )
+  })
+
+  it('strips a trailing slash', () => {
+    expect(canonicalizeUrl('https://a.com/')).toBe('https://a.com')
+  })
+
+  it('maps trailing-slash + query + fragment variants to one canonical form so a Set dedups them', () => {
+    const urls = [
+      'https://a.com',
+      'https://a.com/',
+      'https://a.com?x=1',
+      'https://a.com/#frag',
+      'https://a.com/?x=1#frag',
+    ]
+    const canonical = new Set(urls.map((url) => canonicalizeUrl(url)))
+    expect(canonical.size).toBe(1)
+    expect(canonical.has('https://a.com')).toBe(true)
+  })
+
+  it('handles mixed http/https: different schemes stay distinct, bare host gets https', () => {
+    expect(canonicalizeUrl('http://a.com')).toBe('http://a.com')
+    expect(canonicalizeUrl('https://a.com')).toBe('https://a.com')
+    expect(canonicalizeUrl('a.com')).toBe('https://a.com')
+  })
+
+  it('falls back to a trimmed trailing-slash strip for non-URL strings', () => {
+    expect(canonicalizeUrl('not a url/')).toBe('not a url')
+  })
+})

--- a/web/src/features/import/__tests__/utils.test.ts
+++ b/web/src/features/import/__tests__/utils.test.ts
@@ -17,9 +17,10 @@ describe('parseUrlLines', () => {
   })
 
   it('trims leading and trailing whitespace from each line', () => {
-    expect(
-      parseUrlLines('  https://a.com  \n\t https://b.com\t')
-    ).toEqual(['https://a.com', 'https://b.com'])
+    expect(parseUrlLines('  https://a.com  \n\t https://b.com\t')).toEqual([
+      'https://a.com',
+      'https://b.com',
+    ])
   })
 
   it('dedups exact raw lines after trimming', () => {

--- a/web/src/features/import/components/import-wizard-dialog.tsx
+++ b/web/src/features/import/components/import-wizard-dialog.tsx
@@ -13,7 +13,7 @@ import {
   Upload as UploadIcon,
   X as XIcon,
 } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -154,6 +154,35 @@ export function ImportWizardDialog({
   }, [sitesQuery.data])
 
   const currentIndex = STEP_ORDER.indexOf(step)
+
+  // Derived busy flags for the aria-busy region. isSubmitting covers the
+  // final POST; isDetecting covers the parallel detect fan-out.
+  const isSubmitting = importSites.isPending
+  const isDetecting = candidates.some((candidate) => candidate.detecting)
+
+  // Polite live region: announce detection completion (only on the true→false
+  // transition so the initial pre-detect render never fires a false "done")
+  // and the final imported/skipped/failed summary once results land.
+  const [liveMessage, setLiveMessage] = useState('')
+  const wasDetectingRef = useRef(false)
+  useEffect(() => {
+    if (step === 'done' && result) {
+      setLiveMessage(
+        t('import.done.announce', {
+          imported: result.imported,
+          skipped: result.skipped,
+          failed: result.failed,
+        })
+      )
+      return
+    }
+    if (step === 'identify' && wasDetectingRef.current && !isDetecting) {
+      setLiveMessage(
+        t('import.identify.detectionComplete', { count: candidates.length })
+      )
+    }
+    wasDetectingRef.current = isDetecting
+  }, [step, result, candidates.length, isDetecting, t])
 
   function reset() {
     setStep('source')
@@ -302,7 +331,7 @@ export function ImportWizardDialog({
 
           <ImportStepper steps={steps} currentIndex={currentIndex} />
 
-          <div className='mt-2 min-h-64'>
+          <div className='mt-2 min-h-64' aria-busy={isSubmitting || isDetecting}>
             {step === 'source' && (
               <div className='grid gap-3'>
                 <Label htmlFor='import-source-urls'>
@@ -333,8 +362,11 @@ export function ImportWizardDialog({
                       className='grid gap-3 rounded-lg border p-3'
                     >
                       <div className='grid gap-2'>
-                        <Label>{t('import.identify.name')}</Label>
+                        <Label htmlFor={`${candidate.id}-name`}>
+                          {t('import.identify.name')}
+                        </Label>
                         <Input
+                          id={`${candidate.id}-name`}
                           value={candidate.name}
                           onChange={(event) =>
                             updateCandidate(candidate.id, {
@@ -347,9 +379,12 @@ export function ImportWizardDialog({
                         {candidate.url}
                       </div>
                       <div className='grid gap-2'>
-                        <Label>{t('import.identify.platform')}</Label>
+                        <Label htmlFor={`${candidate.id}-platform`}>
+                          {t('import.identify.platform')}
+                        </Label>
                         <div className='flex items-center gap-2'>
                           <Input
+                            id={`${candidate.id}-platform`}
                             value={candidate.platform}
                             onChange={(event) =>
                               updateCandidate(candidate.id, {
@@ -439,13 +474,19 @@ export function ImportWizardDialog({
                             includeAccount: checked,
                           })
                         }
+                        aria-label={t('import.connect.includeAccount', {
+                          name: candidate.name,
+                        })}
                       />
                     </div>
                     {candidate.includeAccount && (
                       <div className='grid gap-2 sm:grid-cols-3'>
                         <div className='grid gap-1.5'>
-                          <Label>{t('import.connect.username')}</Label>
+                          <Label htmlFor={`${candidate.id}-username`}>
+                            {t('import.connect.username')}
+                          </Label>
                           <Input
+                            id={`${candidate.id}-username`}
                             value={candidate.username}
                             onChange={(event) =>
                               updateCandidate(candidate.id, {
@@ -455,8 +496,11 @@ export function ImportWizardDialog({
                           />
                         </div>
                         <div className='grid gap-1.5'>
-                          <Label>{t('import.connect.accessToken')}</Label>
+                          <Label htmlFor={`${candidate.id}-accessToken`}>
+                            {t('import.connect.accessToken')}
+                          </Label>
                           <Input
+                            id={`${candidate.id}-accessToken`}
                             type='password'
                             value={candidate.accessToken}
                             onChange={(event) =>
@@ -467,8 +511,11 @@ export function ImportWizardDialog({
                           />
                         </div>
                         <div className='grid gap-1.5'>
-                          <Label>{t('import.connect.apiToken')}</Label>
+                          <Label htmlFor={`${candidate.id}-apiToken`}>
+                            {t('import.connect.apiToken')}
+                          </Label>
                           <Input
+                            id={`${candidate.id}-apiToken`}
                             value={candidate.apiToken}
                             onChange={(event) =>
                               updateCandidate(candidate.id, {
@@ -503,8 +550,11 @@ export function ImportWizardDialog({
                       </div>
                     </div>
                     <div className='flex items-center gap-2'>
-                      <Label>{t('import.routes.weight')}</Label>
+                      <Label htmlFor={`${candidate.id}-weight`}>
+                        {t('import.routes.weight')}
+                      </Label>
                       <Input
+                        id={`${candidate.id}-weight`}
                         type='number'
                         min={0}
                         step={0.1}
@@ -542,10 +592,14 @@ export function ImportWizardDialog({
                   {result.results.map((item) => {
                     const badge = statusBadge(item.status)
                     const Icon = badge.icon
+                    const showReason =
+                      item.reason != null &&
+                      item.reason !== '' &&
+                      (item.status === 'failed' || item.status === 'skipped')
                     return (
                       <div
                         key={`${item.url}-${item.status}`}
-                        className='flex items-center justify-between gap-3 rounded-lg border p-2.5'
+                        className='flex items-start justify-between gap-3 rounded-lg border p-2.5'
                       >
                         <div className='min-w-0'>
                           <div className='truncate text-sm'>{item.name}</div>
@@ -553,16 +607,35 @@ export function ImportWizardDialog({
                             {item.url}
                           </div>
                         </div>
-                        <Badge variant={badge.variant}>
-                          <Icon className='size-3' />
-                          {t(badge.label)}
-                        </Badge>
+                        <div className='flex flex-col items-end gap-1'>
+                          <Badge variant={badge.variant}>
+                            <Icon className='size-3' />
+                            {t(badge.label)}
+                          </Badge>
+                          {showReason && (
+                            <span
+                              className={
+                                item.status === 'failed'
+                                  ? 'text-destructive text-xs'
+                                  : 'text-muted-foreground text-xs'
+                              }
+                            >
+                              {t('import.result.reason', {
+                                reason: item.reason,
+                              })}
+                            </span>
+                          )}
+                        </div>
                       </div>
                     )
                   })}
                 </div>
               </div>
             )}
+          </div>
+
+          <div aria-live='polite' className='sr-only'>
+            {liveMessage}
           </div>
 
           <DialogFooter showCloseButton={false}>

--- a/web/src/features/import/components/import-wizard-dialog.tsx
+++ b/web/src/features/import/components/import-wizard-dialog.tsx
@@ -331,7 +331,10 @@ export function ImportWizardDialog({
 
           <ImportStepper steps={steps} currentIndex={currentIndex} />
 
-          <div className='mt-2 min-h-64' aria-busy={isSubmitting || isDetecting}>
+          <div
+            className='mt-2 min-h-64'
+            aria-busy={isSubmitting || isDetecting}
+          >
             {step === 'source' && (
               <div className='grid gap-3'>
                 <Label htmlFor='import-source-urls'>

--- a/web/src/features/import/types.ts
+++ b/web/src/features/import/types.ts
@@ -16,6 +16,7 @@ export type ImportSiteItem = {
   platform?: string
   globalWeight?: number
   maxConcurrency?: number
+  duplicateStrategy?: ImportDuplicateStrategy
   accounts?: ImportAccountInput[]
 }
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2129,12 +2129,14 @@
         "duplicateWarning": "This site already exists. Choose how to handle the duplicate.",
         "skip": "Skip",
         "merge": "Merge accounts into existing site",
-        "missingPlatform": "Set a platform for every site (unknown sites stay manual)."
+        "missingPlatform": "Set a platform for every site (unknown sites stay manual).",
+        "detectionComplete": "Detection complete for {{count}} site(s)."
       },
       "connect": {
         "username": "Username",
         "accessToken": "Access token",
-        "apiToken": "API token"
+        "apiToken": "API token",
+        "includeAccount": "Include account for {{name}}"
       },
       "routes": {
         "hint": "Imported sites are created active. Model discovery runs in the background; set the routing weight below.",
@@ -2145,13 +2147,15 @@
         "imported": "Imported {{count}}",
         "skipped": "Skipped {{count}}",
         "failed": "Failed {{count}}",
-        "close": "Done"
+        "close": "Done",
+        "announce": "Imported {{imported}}, skipped {{skipped}}, failed {{failed}}."
       },
       "result": {
         "imported": "Imported",
         "merged": "Merged",
         "skipped": "Skipped",
-        "failed": "Failed"
+        "failed": "Failed",
+        "reason": "Reason: {{reason}}"
       },
       "discard": {
         "title": "Discard this import?",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2129,12 +2129,14 @@
         "duplicateWarning": "该站点已存在，请选择重复项处理方式。",
         "skip": "跳过",
         "merge": "将账号合并到已有站点",
-        "missingPlatform": "请为每个站点设置平台（未知站点可手动填写）。"
+        "missingPlatform": "请为每个站点设置平台（未知站点可手动填写）。",
+        "detectionComplete": "已完成 {{count}} 个站点的检测。"
       },
       "connect": {
         "username": "用户名",
         "accessToken": "访问令牌",
-        "apiToken": "API 令牌"
+        "apiToken": "API 令牌",
+        "includeAccount": "为 {{name}} 包含账号"
       },
       "routes": {
         "hint": "导入的站点默认启用，模型发现将在后台进行；请在下方设置路由权重。",
@@ -2145,13 +2147,15 @@
         "imported": "已导入 {{count}}",
         "skipped": "已跳过 {{count}}",
         "failed": "失败 {{count}}",
-        "close": "完成"
+        "close": "完成",
+        "announce": "已导入 {{imported}}，跳过 {{skipped}}，失败 {{failed}}。"
       },
       "result": {
         "imported": "已导入",
         "merged": "已合并",
         "skipped": "已跳过",
-        "failed": "失败"
+        "failed": "失败",
+        "reason": "原因：{{reason}}"
       },
       "discard": {
         "title": "放弃本次导入？",

--- a/web/src/lib/api/sites.ts
+++ b/web/src/lib/api/sites.ts
@@ -20,6 +20,7 @@ export const sitesApi = {
     request('/api/sites/detect', {
       method: 'POST',
       body: JSON.stringify({ url }),
+      skipErrorHandler: true,
     }),
   importSites: (data: unknown) =>
     request('/api/sites/import', {


### PR DESCRIPTION
## Summary
- Render per-item failure reason in the done step so users see why an item failed
- Stop toast spam on undetectable URLs by passing skipErrorHandler to the detect request
- Add aria-busy and aria-live regions for screen reader announcements
- Fix all label htmlFor/id associations and Switch aria-label
- Add duplicateStrategy to ImportSiteItem type to match what handleSubmit sends
- Add 17 focused tests covering parseUrlLines, canonicalizeUrl, and wizard behaviors

## Test plan
- [x] 12 utils tests (parseUrlLines + canonicalizeUrl)
- [x] 5 wizard component tests (empty source, advance, missing platform, reason render, discard)
- [x] tsgo 0 errors, oxlint 0 errors, vitest 479/479 passing