### PR TITLE
feat(accounts): add remark field for human-readable account notes

### DIFF
--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -1193,6 +1193,11 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 			"proxyUrl": service.NormalizeNullable(body.ProxyURL),
 		})
 	}
+	// Remark is a free-form human-readable note. An empty/whitespace string
+	// clears the column (NULL); otherwise the trimmed value is persisted.
+	if body.Remark != nil {
+		updates["remark"] = service.NormalizeNullable(body.Remark)
+	}
 	// Sub2API managed auth: merge top-level / nested refreshToken+tokenExpiresAt
 	// into extraConfig.sub2apiAuth without clobbering unrelated keys.
 	if service.IsSub2ApiPlatform(row.Site.Platform) {
@@ -1291,6 +1296,7 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 		"extraConfig":        updated.ExtraConfig,
 		"createdAt":          updated.CreatedAt,
 		"updatedAt":          updated.UpdatedAt,
+		"remark":             updated.Remark,
 		"credentialMode":     string(service.ResolveStoredCredentialMode(&updated)),
 		"capabilities":       caps,
 		"runtimeHealth": service.BuildRuntimeHealthForAccount(service.RuntimeHealthInput{

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -1195,6 +1195,8 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 	}
 	// Remark is a free-form human-readable note. An empty/whitespace string
 	// clears the column (NULL); otherwise the trimmed value is persisted.
+	// Do not store credentials here — remark is returned in plaintext on
+	// admin list/search responses (unlike accessToken/apiToken which are masked).
 	if body.Remark != nil {
 		updates["remark"] = service.NormalizeNullable(body.Remark)
 	}

--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -330,6 +330,56 @@ func TestAccounts_UpdateClearsSnapshotCache(t *testing.T) {
 
 // ---- Create Account ----
 
+func TestAccounts_UpdateRemark(t *testing.T) {
+	_, r, _ := setupAccountsTest(t)
+	_, accountID := setupAccountFixture(t, r)
+	endpoint := "/api/accounts/" + strconv.FormatInt(accountID, 10)
+
+	// Set a remark.
+	setResp := doPutJSON(t, r, endpoint, map[string]any{"remark": "donor: linux.do user foo"})
+	if setResp.Code != http.StatusOK {
+		t.Fatalf("set remark: %d %s", setResp.Code, setResp.Body.String())
+	}
+	var setBody map[string]any
+	if err := json.Unmarshal(setResp.Body.Bytes(), &setBody); err != nil {
+		t.Fatalf("unmarshal set response: %v", err)
+	}
+	if got := setBody["remark"]; got != "donor: linux.do user foo" {
+		t.Fatalf("set response remark = %v, want the echoed note", got)
+	}
+
+	// The list snapshot surfaces the persisted remark.
+	listResp := doGet(t, r, "/api/accounts")
+	if listResp.Code != http.StatusOK {
+		t.Fatalf("list: %d %s", listResp.Code, listResp.Body.String())
+	}
+	var listBody struct {
+		Accounts []map[string]any `json:"accounts"`
+	}
+	if err := json.Unmarshal(listResp.Body.Bytes(), &listBody); err != nil {
+		t.Fatalf("unmarshal list: %v", err)
+	}
+	if len(listBody.Accounts) != 1 {
+		t.Fatalf("list accounts len = %d, want 1", len(listBody.Accounts))
+	}
+	if got := listBody.Accounts[0]["remark"]; got != "donor: linux.do user foo" {
+		t.Fatalf("list remark = %v, want the persisted note", got)
+	}
+
+	// Empty/whitespace remark clears the column to NULL.
+	clearResp := doPutJSON(t, r, endpoint, map[string]any{"remark": "   "})
+	if clearResp.Code != http.StatusOK {
+		t.Fatalf("clear remark: %d %s", clearResp.Code, clearResp.Body.String())
+	}
+	var clearBody map[string]any
+	if err := json.Unmarshal(clearResp.Body.Bytes(), &clearBody); err != nil {
+		t.Fatalf("unmarshal clear response: %v", err)
+	}
+	if clearBody["remark"] != nil {
+		t.Fatalf("clear response remark = %v, want nil", clearBody["remark"])
+	}
+}
+
 func TestAccounts_Create(t *testing.T) {
 	_, r, _ := setupAccountsTest(t)
 	server := newOpenAIModelsServer(t, "sk-test-create-token-12345", []string{"gpt-4o-mini"})

--- a/handler/admin/payloads/accounts.go
+++ b/handler/admin/payloads/accounts.go
@@ -29,6 +29,7 @@ type AccountUpdatePayload struct {
 	IsPinned       *bool    `json:"isPinned,omitempty"`
 	SortOrder      *int     `json:"sortOrder,omitempty"`
 	ProxyURL       *string  `json:"proxyUrl,omitempty"`
+	Remark         *string  `json:"remark,omitempty"`
 }
 
 // AccountBatchPayload mirrors TS AccountBatchPayload.

--- a/handler/admin/search.go
+++ b/handler/admin/search.go
@@ -37,7 +37,7 @@ const accountPublicSelectColumns = `a.id, a.site_id, a.username, a.balance, a.ba
 	a.quota, a.unit_cost, a.value_score, a.status, a.is_pinned, a.sort_order,
 	a.checkin_enabled, a.last_checkin_at, a.last_balance_refresh, a.oauth_provider,
 	a.oauth_account_key, a.oauth_project_id, a.extra_config, a.created_at,
-	a.updated_at, a.tags`
+	a.updated_at, a.tags, a.remark`
 
 // accountTokenPublicSelectColumns lists every account_tokens column EXCEPT the
 // plaintext token. Paired with credentialFragmentsSelect("at.token", ...).

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -421,6 +421,7 @@ func GetAccountWithSiteByID(db *sqlx.DB, id int64) (*AccountWithSite, error) {
 		a.oauth_provider AS "accounts.oauth_provider", a.oauth_account_key AS "accounts.oauth_account_key",
 		a.oauth_project_id AS "accounts.oauth_project_id", a.extra_config AS "accounts.extra_config",
 		a.created_at AS "accounts.created_at", a.updated_at AS "accounts.updated_at",
+		a.remark AS "accounts.remark",
 		s.id AS "sites.id", s.name AS "sites.name", s.url AS "sites.url",
 		s.platform AS "sites.platform", s.proxy_url AS "sites.proxy_url",
 		s.use_system_proxy AS "sites.use_system_proxy",
@@ -453,6 +454,7 @@ func GetAccountWithSiteByID(db *sqlx.DB, id int64) (*AccountWithSite, error) {
 			ExtraConfig        *string  `db:"extra_config"`
 			CreatedAt          string   `db:"created_at"`
 			UpdatedAt          string   `db:"updated_at"`
+			Remark             *string `db:"remark"`
 		} `db:"accounts"`
 		Sites struct {
 			ID                                  int64   `db:"id"`
@@ -483,6 +485,7 @@ func GetAccountWithSiteByID(db *sqlx.DB, id int64) (*AccountWithSite, error) {
 			OAuthProvider: row.Accounts.OAuthProvider, OAuthAccountKey: row.Accounts.OAuthAccountKey,
 			OAuthProjectID: row.Accounts.OAuthProjectID, ExtraConfig: row.Accounts.ExtraConfig,
 			CreatedAt: row.Accounts.CreatedAt, UpdatedAt: row.Accounts.UpdatedAt,
+			Remark: row.Accounts.Remark,
 		},
 		Site: store.Site{
 			ID: row.Sites.ID, Name: row.Sites.Name,
@@ -573,6 +576,7 @@ func UpdateAccountFields(db *sqlx.DB, accountID int64, updates map[string]any) e
 		"quota":              "quota",
 		"valueScore":         "value_score",
 		"lastBalanceRefresh": "last_balance_refresh",
+		"remark":             "remark",
 	}
 
 	for key, val := range updates {

--- a/store/additive.go
+++ b/store/additive.go
@@ -193,6 +193,16 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 			return EnsureColumn(db, "sites", "use_utls", "INTEGER", "BOOLEAN", "")
 		},
 	},
+	{
+		// #804: accounts.remark — free-form human-readable note (account
+		// source, expiry, donor). Complements the machine-readable tags
+		// column. NULL means no remark. Surfaced via PUT /api/accounts/{id}.
+		Version:     "sc2_016_account_remark",
+		Description: "accounts.remark TEXT NULL — free-form human-readable note; complements tags; NULL means no remark",
+		Apply: func(db *DB) error {
+			return EnsureColumn(db, "accounts", "remark", "TEXT", "TEXT", "")
+		},
+	},
 }
 
 // schemaMigrationsDDL creates the version bookkeeping table.

--- a/store/additive_upgrade_test.go
+++ b/store/additive_upgrade_test.go
@@ -33,6 +33,7 @@ func additiveColumns() []additiveColumnSpec {
 		{"accounts", "tags"},
 		{"sites", "tags"},
 		{"checkin_logs", "failure_reason"},
+		{"accounts", "remark"},
 	}
 }
 

--- a/store/migrate_runner.go
+++ b/store/migrate_runner.go
@@ -709,7 +709,7 @@ func buildAccounts(rows []map[string]interface{}) []insertStmt {
 		"quota", "unit_cost", "value_score", "status", "is_pinned", "sort_order",
 		"checkin_enabled", "last_checkin_at", "last_balance_refresh",
 		"oauth_provider", "oauth_account_key", "oauth_project_id",
-		"extra_config", "created_at", "updated_at", "tags",
+		"extra_config", "created_at", "updated_at", "tags", "remark",
 	}
 	var stmts []insertStmt
 	for _, row := range rows {
@@ -739,6 +739,7 @@ func buildAccounts(rows []map[string]interface{}) []insertStmt {
 				asNullableString(v(row, "created_at")),
 				asNullableString(v(row, "updated_at")),
 				asNullableString(v(row, "tags")),
+				asNullableString(v(row, "remark")),
 			},
 		})
 	}

--- a/store/schema.go
+++ b/store/schema.go
@@ -98,6 +98,10 @@ type Account struct {
 	// Tags holds a JSON array of operator labels.
 	// NULL/empty means no tags; JSON array text like ["prod","priority"].
 	Tags *string `db:"tags" json:"tags"`
+	// Remark holds a free-form human-readable note (e.g. account source,
+	// expiry, donor). NULL means no remark. Complements the machine-readable
+	// Tags column; surfaced via PUT /api/accounts/{id}.
+	Remark *string `db:"remark" json:"remark"`
 }
 
 // ---- Table 5: account_tokens ----

--- a/store/schema.go
+++ b/store/schema.go
@@ -101,6 +101,10 @@ type Account struct {
 	// Remark holds a free-form human-readable note (e.g. account source,
 	// expiry, donor). NULL means no remark. Complements the machine-readable
 	// Tags column; surfaced via PUT /api/accounts/{id}.
+	//
+	// Do not store access tokens, passwords, or other secrets here. Unlike
+	// accessToken/apiToken (masked in list views), remark is returned in
+	// plaintext on admin list/search responses.
 	Remark *string `db:"remark" json:"remark"`
 }
 

--- a/store/schema_test.go
+++ b/store/schema_test.go
@@ -12,7 +12,7 @@ var tableColumnCount = map[string]int{
 	"Site":                          26, // +tags (I1) +browser_ua +cf_clearance (sc2_013) +resin_enabled (sc2_014) +use_utls (sc2_015)
 	"SiteAPIEndpoint":               11,
 	"SiteDisabledModel":             4,
-	"Account":                       23, // +tags (I1)
+	"Account":                       24, // +tags (I1) +remark (#804)
 	"AccountToken":                  11,
 	"CheckinLog":                    7, // +failure_reason (sc2_012)
 	"ModelAvailability":             7,


### PR DESCRIPTION
## Summary

- Adds `accounts.remark` (TEXT NULL): a free-form human-readable note column, complementing the machine-readable `tags` column. Surfaced via `PUT /api/accounts/{id}` and the `GET /api/accounts` snapshot.
- Follows the established `sc2_011_account_site_tags` additive-migration pattern (additive-only, `EnsureColumn`, dual-dialect, idempotent); no base DDL change.
- The SQLite→PG migrate tool (`buildAccounts`) carries `remark` across transfer so migrations don't drop the column.

## Changes

- **store**: `Account.Remark` field + `sc2_016_account_remark` additive migration; `migrate_runner` `buildAccounts` column list + value.
- **service**: `UpdateAccountFields` colMap gains `remark`; `GetAccountWithSiteByID` SELECT/inline-struct/mapping carry `remark` so the update response truthfully returns the post-update value.
- **handler/admin**: `AccountUpdatePayload.Remark` wired through `NormalizeNullable` (empty/whitespace string clears to NULL); update response includes `remark`.
- **tests**: `schema_test` Account count 23→24; `additive_upgrade_test` `additiveColumns` gains `{accounts, remark}` (guards both legacy-upgrade and fresh-install paths).

## Test plan

- [x] `go build ./cmd/server ./cmd/migrate`
- [x] `go vet ./...`
- [x] `go test ./... -count=1 -race` — all packages `ok`
- [x] `store` additive upgrade + base schema convergence tests pass