### PR TITLE
feat(oauth): align Codex refresh with codex2api maturity

### DIFF
--- a/service/oauth/account.go
+++ b/service/oauth/account.go
@@ -30,6 +30,7 @@ type OauthInfo struct {
 	TokenExpiresAt       int64                  `json:"tokenExpiresAt,omitempty"`
 	RefreshToken         string                 `json:"refreshToken,omitempty"`
 	IDToken              string                 `json:"idToken,omitempty"`
+	SessionToken         string                 `json:"sessionToken,omitempty"`
 	ProviderData         map[string]interface{} `json:"providerData,omitempty"`
 	Quota                *OauthQuotaSnapshot     `json:"quota,omitempty"`
 	ModelDiscoveryStatus OauthModelDiscoveryStatus `json:"modelDiscoveryStatus,omitempty"`
@@ -45,6 +46,7 @@ type StoredOauthState struct {
 	TokenExpiresAt       int64                  `json:"tokenExpiresAt,omitempty"`
 	RefreshToken         string                 `json:"refreshToken,omitempty"`
 	IDToken              string                 `json:"idToken,omitempty"`
+	SessionToken         string                 `json:"sessionToken,omitempty"`
 	ProviderData         map[string]interface{} `json:"providerData,omitempty"`
 	Quota                *OauthQuotaSnapshot     `json:"quota,omitempty"`
 	ModelDiscoveryStatus OauthModelDiscoveryStatus `json:"modelDiscoveryStatus,omitempty"`
@@ -69,6 +71,7 @@ type parsedOauthInfo struct {
 	TokenExpiresAt       interface{} `json:"tokenExpiresAt"`
 	RefreshToken         interface{} `json:"refreshToken"`
 	IDToken              interface{} `json:"idToken"`
+	SessionToken         interface{} `json:"sessionToken"`
 	ProviderData         interface{} `json:"providerData"`
 	Quota                interface{} `json:"quota"`
 	ModelDiscoveryStatus interface{} `json:"modelDiscoveryStatus"`
@@ -118,6 +121,7 @@ func GetOauthInfoFromExtraConfig(extraConfig *string) *OauthInfo {
 	}
 	info.RefreshToken = asNonEmptyString(o.RefreshToken)
 	info.IDToken = asNonEmptyString(o.IDToken)
+	info.SessionToken = asNonEmptyString(o.SessionToken)
 	if pd, ok := o.ProviderData.(map[string]interface{}); ok {
 		info.ProviderData = pd
 	}
@@ -205,6 +209,7 @@ func GetOauthInfoFromAccount(account *store.Account) *OauthInfo {
 		info.TokenExpiresAt = storedIdentity.TokenExpiresAt
 		info.RefreshToken = storedIdentity.RefreshToken
 		info.IDToken = storedIdentity.IDToken
+		info.SessionToken = storedIdentity.SessionToken
 		info.ProviderData = storedIdentity.ProviderData
 		info.Quota = storedIdentity.Quota
 		info.ModelDiscoveryStatus = storedIdentity.ModelDiscoveryStatus
@@ -261,6 +266,9 @@ func BuildOauthInfo(extraConfig *string, patch *OauthInfo) (*OauthInfo, error) {
 		}
 		if patch.IDToken != "" {
 			info.IDToken = patch.IDToken
+		}
+		if patch.SessionToken != "" {
+			info.SessionToken = patch.SessionToken
 		}
 		if patch.ProviderData != nil {
 			info.ProviderData = patch.ProviderData
@@ -336,6 +344,9 @@ func BuildOauthInfoFromAccount(account *store.Account, patch *OauthInfo) (*Oauth
 		if patch.IDToken != "" {
 			info.IDToken = patch.IDToken
 		}
+		if patch.SessionToken != "" {
+			info.SessionToken = patch.SessionToken
+		}
 		if patch.ProviderData != nil {
 			info.ProviderData = patch.ProviderData
 		}
@@ -363,6 +374,7 @@ func BuildStoredOauthState(oauth *OauthInfo) *StoredOauthState {
 		TokenExpiresAt:       oauth.TokenExpiresAt,
 		RefreshToken:         oauth.RefreshToken,
 		IDToken:              oauth.IDToken,
+		SessionToken:         oauth.SessionToken,
 		ProviderData:         oauth.ProviderData,
 		Quota:                oauth.Quota,
 		ModelDiscoveryStatus: oauth.ModelDiscoveryStatus,

--- a/service/oauth/codex.go
+++ b/service/oauth/codex.go
@@ -22,11 +22,29 @@ const (
 	codexLoopbackPath        = "/auth/callback"
 	codexLoopbackRedirectURI = "http://localhost:1455/auth/callback"
 	codexUpstreamBaseURL     = "https://chatgpt.com/backend-api/codex"
+
+	// codexCLIUserAgent mirrors the Codex CLI client fingerprint used by the
+	// upstream OAuth/token endpoints. Without it, OpenAI's auth gateway is
+	// more likely to classify requests as non-CLI traffic.
+	codexCLIUserAgent = "codex-cli/0.91.0"
+
+	// codexSessionBrowserUserAgent mimics a Chrome browser UA for the
+	// session-cookie fallback. The session endpoint is a NextAuth route that
+	// expects browser traffic, not CLI traffic.
+	codexSessionBrowserUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+
+	// codexSessionCookieName is the NextAuth cookie carrying the web session
+	// token used by the fallback refresh path.
+	codexSessionCookieName = "__Secure-next-auth.session-token"
 )
 
 // codexTokenURL is a package var (not a const) so tests can swap in a local
 // httptest server via withCodexEndpointSwap, mirroring the grok.go pattern.
 var codexTokenURL = "https://auth.openai.com/oauth/token"
+
+// codexSessionURL is a package var (not a const) so tests can swap in a local
+// httptest server for the session-cookie fallback path.
+var codexSessionURL = "https://chatgpt.com/api/auth/session"
 
 func init() {
 	RegisterProvider(&OAuthProviderDefinition{
@@ -55,7 +73,9 @@ func init() {
 		BuildAuthorizationURL:     buildCodexAuthorizationURL,
 		ExchangeAuthorizationCode: exchangeCodexAuthorizationCode,
 		RefreshAccessToken:        refreshCodexAccessToken,
+		RefreshWithSessionToken:   refreshCodexWithSessionToken,
 		BuildProxyHeaders:         buildCodexProxyHeaders,
+		ParseAccessToken:           ParseCodexAccessToken,
 	})
 }
 
@@ -143,6 +163,7 @@ func exchangeCodexToken(form url.Values, proxyURL *string) (*codexTokenResponse,
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", codexCLIUserAgent)
 
 	resp, err := doHTTP(req, proxyURL, nil)
 	if err != nil {
@@ -191,28 +212,7 @@ func exchangeCodexAuthorizationCode(ctx context.Context, input ExchangeCodeInput
 	if _, idErr := requireCodexClientID(); idErr != nil {
 		return nil, idErr
 	}
-
-	claims, err := parseJWTClaims(payload.IDToken)
-	if err != nil {
-		return nil, fmt.Errorf("codex token exchange response invalid id_token")
-	}
-
-	accountID := strings.TrimSpace(claims.Auth.ChatGPTAccountID)
-	if accountID == "" {
-		return nil, fmt.Errorf("codex token exchange response missing chatgpt_account_id")
-	}
-
-	expiresIn, _ := parseExpiresIn(payload.ExpiresIn)
-	return &TokenSet{
-		AccessToken:    payload.AccessToken,
-		RefreshToken:   payload.RefreshToken,
-		TokenExpiresAt: time.Now().UnixMilli() + expiresIn*1000,
-		Email:          strings.TrimSpace(claims.Email),
-		AccountID:      accountID,
-		AccountKey:     accountID,
-		PlanType:       strings.TrimSpace(claims.Auth.ChatGPTPlanType),
-		IDToken:        payload.IDToken,
-	}, nil
+	return buildCodexTokenSetFromPayload(payload, "token exchange")
 }
 
 // ---- Token Refresh ----
@@ -228,15 +228,136 @@ func refreshCodexAccessToken(ctx context.Context, input RefreshTokenInput) (*Tok
 	if err != nil {
 		return nil, err
 	}
+	return buildCodexTokenSetFromPayload(payload, "token refresh")
+}
 
-	claims, err := parseJWTClaims(payload.IDToken)
-	if err != nil {
-		return nil, fmt.Errorf("codex token refresh response invalid id_token")
+// refreshCodexWithSessionToken is the session-cookie fallback invoked by the
+// refresh orchestrator after a non-retryable RT refresh failure (e.g. the
+// refresh token was revoked but the ChatGPT web session is still valid). It
+// hits the NextAuth session endpoint with the __Secure-next-auth.session-token
+// cookie and recovers a fresh access token. Identity (email, account id, plan
+// type) is parsed from the access_token JWT since the session endpoint does
+// not return an id_token. Mirrors codex2api's RefreshWithSessionToken.
+func refreshCodexWithSessionToken(ctx context.Context, input SessionTokenInput) (*TokenSet, error) {
+	sessionToken := strings.TrimSpace(input.SessionToken)
+	if sessionToken == "" {
+		return nil, fmt.Errorf("codex session refresh requires a session token")
 	}
 
-	accountID := strings.TrimSpace(claims.Auth.ChatGPTAccountID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, codexSessionURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("codex session refresh: create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", codexSessionBrowserUserAgent)
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	req.Header.Set("Sec-Fetch-Dest", "empty")
+	req.Header.Set("Sec-Fetch-Mode", "cors")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	req.AddCookie(&http.Cookie{Name: codexSessionCookieName, Value: sessionToken})
+
+	resp, err := doHTTP(req, input.ProxyURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("codex session refresh: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := readOAuthJSONResponseBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("codex session refresh: read body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("codex session refresh failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+
+	var sessionResp struct {
+		AccessToken string `json:"accessToken"`
+		Expires    string `json:"expires"`
+		User       struct {
+			Email string `json:"email"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal(body, &sessionResp); err != nil {
+		return nil, fmt.Errorf("codex session refresh: parse response: %w", err)
+	}
+
+	accessToken := strings.TrimSpace(sessionResp.AccessToken)
+	if accessToken == "" {
+		return nil, fmt.Errorf("codex session refresh: response missing accessToken")
+	}
+
+	// The session endpoint returns no id_token and no refresh_token. Identity
+	// is recovered from the access_token JWT (email under /profile, account id
+	// and plan type under /auth). Email falls back to sessionResp.User.Email.
+	identity := ParseCodexAccessToken(accessToken)
+	if identity == nil {
+		identity = &AccountIdentity{}
+	}
+	email := identity.Email
+	if email == "" {
+		email = strings.TrimSpace(sessionResp.User.Email)
+	}
+
+	accountID := identity.ChatGPTAccountID
 	if accountID == "" {
-		return nil, fmt.Errorf("codex token refresh response missing chatgpt_account_id")
+		return nil, fmt.Errorf("codex session refresh: access_token missing chatgpt_account_id")
+	}
+
+	expiresAt := parseCodexSessionExpires(sessionResp.Expires)
+	expiresIn := int64(time.Until(expiresAt).Seconds())
+	if expiresIn <= 0 {
+		expiresIn = 3600
+	}
+
+	return &TokenSet{
+		AccessToken:    accessToken,
+		TokenExpiresAt: time.Now().UnixMilli() + expiresIn*1000,
+		Email:          email,
+		AccountID:      accountID,
+		AccountKey:     accountID,
+		PlanType:        identity.PlanType,
+	}, nil
+}
+
+// parseCodexSessionExpires parses the RFC3339 expiry string returned by the
+// NextAuth session endpoint. Returns time.Now()+1h on parse failure so the
+// caller always gets a positive expiry.
+func parseCodexSessionExpires(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Now().Add(time.Hour)
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return parsed
+		}
+	}
+	return time.Now().Add(time.Hour)
+}
+
+// buildCodexTokenSetFromPayload converts a raw codex token response into a
+// TokenSet, applying the access_token identity fallback codex2api uses: when
+// the id_token omits email/account_id/plan_type, the access_token JWT (which
+// surfaces email under the /profile namespace) recovers them. account_id is
+// still required after the merge so an anonymous token fails loudly.
+func buildCodexTokenSetFromPayload(payload *codexTokenResponse, origin string) (*TokenSet, error) {
+	claims, err := parseJWTClaims(payload.IDToken)
+	if err != nil {
+		return nil, fmt.Errorf("codex %s response invalid id_token", origin)
+	}
+
+	identity := &AccountIdentity{
+		Email:             strings.TrimSpace(claims.Email),
+		ChatGPTAccountID: strings.TrimSpace(claims.Auth.ChatGPTAccountID),
+		PlanType:          strings.TrimSpace(claims.Auth.ChatGPTPlanType),
+	}
+	if identityIncomplete(identity) {
+		identity = MergeCodexIdentity(identity, ParseCodexAccessToken(payload.AccessToken))
+	}
+
+	accountID := strings.TrimSpace(identity.ChatGPTAccountID)
+	if accountID == "" {
+		return nil, fmt.Errorf("codex %s response missing chatgpt_account_id", origin)
 	}
 
 	expiresIn, _ := parseExpiresIn(payload.ExpiresIn)
@@ -244,10 +365,10 @@ func refreshCodexAccessToken(ctx context.Context, input RefreshTokenInput) (*Tok
 		AccessToken:    payload.AccessToken,
 		RefreshToken:   payload.RefreshToken,
 		TokenExpiresAt: time.Now().UnixMilli() + expiresIn*1000,
-		Email:          strings.TrimSpace(claims.Email),
+		Email:          identity.Email,
 		AccountID:      accountID,
 		AccountKey:     accountID,
-		PlanType:       strings.TrimSpace(claims.Auth.ChatGPTPlanType),
+		PlanType:       identity.PlanType,
 		IDToken:        payload.IDToken,
 	}, nil
 }

--- a/service/oauth/codex_session_test.go
+++ b/service/oauth/codex_session_test.go
@@ -1,0 +1,233 @@
+package oauth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildCodexAccessTokenForTest assembles an unsigned access_token JWT whose
+// payload carries the /profile email and /auth account_id/plan_type claims.
+func buildCodexAccessTokenForTest(t *testing.T, profileEmail, accountID, planType string) string {
+	t.Helper()
+	header := map[string]string{"alg": "none", "typ": "JWT"}
+	auth := map[string]any{}
+	if accountID != "" {
+		auth["chatgpt_account_id"] = accountID
+	}
+	if planType != "" {
+		auth["chatgpt_plan_type"] = planType
+	}
+	profile := map[string]any{}
+	if profileEmail != "" {
+		profile["email"] = profileEmail
+	}
+	claims := map[string]any{
+		"https://api.openai.com/auth":    auth,
+		"https://api.openai.com/profile": profile,
+	}
+	headerBytes, _ := json.Marshal(header)
+	payloadBytes, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	encode := func(b []byte) string {
+		return strings.TrimRight(base64.URLEncoding.EncodeToString(b), "=")
+	}
+	return encode(headerBytes) + "." + encode(payloadBytes) + ".sig"
+}
+
+// withCodexSessionServer swaps codexSessionURL to a test server and restores
+// it on cleanup.
+func withCodexSessionServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	original := codexSessionURL
+	server := httptest.NewServer(handler)
+	codexSessionURL = server.URL
+	t.Cleanup(func() {
+		codexSessionURL = original
+		server.Close()
+	})
+}
+
+func TestRefreshCodexWithSessionToken_Success(t *testing.T) {
+	accessToken := buildCodexAccessTokenForTest(t, "session-user@example.com", "acc_session", "plus")
+	expires := time.Now().Add(30 * time.Minute).UTC().Format(time.RFC3339)
+	withCodexSessionServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		cookie, err := r.Cookie(codexSessionCookieName)
+		if err != nil || cookie == nil {
+			t.Errorf("expected %s cookie, got %v", codexSessionCookieName, err)
+		} else if cookie.Value != "st-valid" {
+			t.Errorf("cookie value = %q, want %q", cookie.Value, "st-valid")
+		}
+		if ua := r.Header.Get("User-Agent"); ua != codexSessionBrowserUserAgent {
+			t.Errorf("User-Agent = %q", ua)
+		}
+		if v := r.Header.Get("Sec-Fetch-Mode"); v != "cors" {
+			t.Errorf("Sec-Fetch-Mode = %q", v)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accessToken": accessToken,
+			"expires":      expires,
+			"user":         map[string]string{"email": "fallback@example.com"},
+		})
+	})
+
+	token, err := refreshCodexWithSessionToken(context.Background(), SessionTokenInput{
+		SessionToken: "st-valid",
+	})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if token.AccessToken != accessToken {
+		t.Errorf("AccessToken mismatch")
+	}
+	if token.Email != "session-user@example.com" {
+		t.Errorf("Email = %q, want from AT /profile", token.Email)
+	}
+	if token.AccountID != "acc_session" {
+		t.Errorf("AccountID = %q", token.AccountID)
+	}
+	if token.PlanType != "plus" {
+		t.Errorf("PlanType = %q", token.PlanType)
+	}
+	if token.TokenExpiresAt <= 0 {
+		t.Errorf("TokenExpiresAt = %d, want positive", token.TokenExpiresAt)
+	}
+}
+
+func TestRefreshCodexWithSessionToken_EmailFallbackFromUser(t *testing.T) {
+	// AT has no /profile email → fall back to sessionResp.User.Email
+	accessToken := buildCodexAccessTokenForTest(t, "", "acc_no_email", "pro")
+	withCodexSessionServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accessToken": accessToken,
+			"expires":     time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			"user":        map[string]string{"email": "from-user@example.com"},
+		})
+	})
+
+	token, err := refreshCodexWithSessionToken(context.Background(), SessionTokenInput{
+		SessionToken: "st-valid",
+	})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if token.Email != "from-user@example.com" {
+		t.Errorf("Email = %q, want user fallback", token.Email)
+	}
+}
+
+func TestRefreshCodexWithSessionToken_MissingSessionToken(t *testing.T) {
+	_, err := refreshCodexWithSessionToken(context.Background(), SessionTokenInput{})
+	if err == nil {
+		t.Fatal("expected error for empty session token")
+	}
+	if !strings.Contains(err.Error(), "session token") {
+		t.Errorf("error should mention session token, got %q", err.Error())
+	}
+}
+
+func TestRefreshCodexWithSessionToken_HTTPError(t *testing.T) {
+	withCodexSessionServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"error":"unauthorized"}`)
+	})
+	_, err := refreshCodexWithSessionToken(context.Background(), SessionTokenInput{
+		SessionToken: "st-revoked",
+	})
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error should mention HTTP 401, got %q", err.Error())
+	}
+}
+
+func TestRefreshCodexWithSessionToken_MissingAccessToken(t *testing.T) {
+	withCodexSessionServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accessToken": "",
+			"user":         map[string]string{"email": "x@example.com"},
+		})
+	})
+	_, err := refreshCodexWithSessionToken(context.Background(), SessionTokenInput{
+		SessionToken: "st-valid",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing accessToken")
+	}
+	if !strings.Contains(err.Error(), "accessToken") {
+		t.Errorf("error should mention accessToken, got %q", err.Error())
+	}
+}
+
+func TestRefreshCodexWithSessionToken_ATMissingAccountID(t *testing.T) {
+	accessToken := buildCodexAccessTokenForTest(t, "e@example.com", "", "plan")
+	withCodexSessionServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"accessToken": accessToken,
+			"expires":      time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		})
+	})
+	_, err := refreshCodexWithSessionToken(context.Background(), SessionTokenInput{
+		SessionToken: "st-valid",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing chatgpt_account_id")
+	}
+	if !strings.Contains(err.Error(), "chatgpt_account_id") {
+		t.Errorf("error should mention chatgpt_account_id, got %q", err.Error())
+	}
+}
+
+func TestParseCodexSessionExpires_EmptyReturnsDefault(t *testing.T) {
+	got := parseCodexSessionExpires("")
+	if got.IsZero() {
+		t.Error("expected non-zero time for empty input")
+	}
+	if time.Until(got) > time.Hour+time.Second || time.Until(got) < time.Hour-time.Second {
+		t.Errorf("expected ~1h default, got %v", time.Until(got))
+	}
+}
+
+func TestParseCodexSessionExpires_InvalidReturnsDefault(t *testing.T) {
+	got := parseCodexSessionExpires("not-a-date")
+	if got.IsZero() {
+		t.Error("expected non-zero time for invalid input")
+	}
+}
+
+func TestParseCodexSessionExpires_ValidRFC3339(t *testing.T) {
+	raw := "2026-12-31T23:59:59Z"
+	got := parseCodexSessionExpires(raw)
+	if got.IsZero() {
+		t.Fatal("expected parsed time")
+	}
+	// Round-trip check
+	if got.UTC().Format(time.RFC3339) != raw {
+		t.Errorf("round-trip mismatch: got %v", got.UTC().Format(time.RFC3339))
+	}
+}
+
+func TestCodexProviderDefinition_RegistersSessionCapability(t *testing.T) {
+	def := GetProviderDefinition("codex")
+	if def == nil {
+		t.Fatal("codex provider not registered")
+	}
+	if def.RefreshWithSessionToken == nil {
+		t.Error("RefreshWithSessionToken should be registered for codex")
+	}
+	if def.ParseAccessToken == nil {
+		t.Error("ParseAccessToken should be registered for codex")
+	}
+}

--- a/service/oauth/flow.go
+++ b/service/oauth/flow.go
@@ -404,6 +404,7 @@ func activatePersistedOAuthAccount(ctx context.Context, input ActivateInput) (*P
 		RefreshToken:   input.Exchange.RefreshToken,
 		TokenExpiresAt: input.Exchange.TokenExpiresAt,
 		IDToken:        input.Exchange.IDToken,
+		SessionToken:   input.Exchange.SessionToken,
 		ProviderData:   input.Exchange.ProviderData,
 	})
 	if err != nil {

--- a/service/oauth/identity.go
+++ b/service/oauth/identity.go
@@ -1,0 +1,154 @@
+package oauth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// AccountIdentity is the subset of token-derived identity fields that the
+// connection refresh path actually carries into TokenSet. metapi-go has no
+// consumer for user_id or subscription expiry today (Simplicity first), so
+// this struct intentionally omits them.
+type AccountIdentity struct {
+	Email             string
+	ChatGPTAccountID string
+	PlanType          string
+}
+
+// codexIDTokenClaims mirrors the OpenAI id_token payload. The auth namespace
+// claim carries the ChatGPT account identity produced by the OAuth flow.
+type codexIDTokenClaims struct {
+	Email string `json:"email"`
+	Auth  *struct {
+		ChatGPTAccountID string `json:"chatgpt_account_id"`
+		ChatGPTPlanType  string `json:"chatgpt_plan_type"`
+	} `json:"https://api.openai.com/auth"`
+}
+
+// codexAccessTokenClaims mirrors the OpenAI access_token payload. The AT
+// stores email under a different namespace (https://api.openai.com/profile)
+// than the id_token's top-level email, so a dedicated parser is needed when
+// the id_token lacks fields.
+type codexAccessTokenClaims struct {
+	Auth    *struct {
+		ChatGPTAccountID string `json:"chatgpt_account_id"`
+		ChatGPTPlanType  string `json:"chatgpt_plan_type"`
+	} `json:"https://api.openai.com/auth"`
+	Profile *struct {
+		Email string `json:"email"`
+	} `json:"https://api.openai.com/profile"`
+}
+
+// ParseCodexIDToken extracts the id_token identity fields without verifying
+// the signature. Returns a non-nil identity with empty fields when the token
+// is malformed so callers can safely chain MergeCodexIdentity.
+func ParseCodexIDToken(idToken string) *AccountIdentity {
+	identity := &AccountIdentity{}
+	if idToken == "" {
+		return identity
+	}
+	payload, err := decodeJWTPayload(idToken)
+	if err != nil {
+		return identity
+	}
+	var claims codexIDTokenClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return identity
+	}
+	identity.Email = strings.TrimSpace(claims.Email)
+	if claims.Auth != nil {
+		identity.ChatGPTAccountID = strings.TrimSpace(claims.Auth.ChatGPTAccountID)
+		identity.PlanType = strings.TrimSpace(claims.Auth.ChatGPTPlanType)
+	}
+	return identity
+}
+
+// ParseCodexAccessToken extracts identity from the access_token JWT payload.
+// The AT surfaces email under https://api.openai.com/profile rather than the
+// id_token's top-level email, so this parser is the only way to recover the
+// email when the id_token omitted it. Returns nil for malformed tokens so
+// callers can distinguish "no AT available" from "empty identity".
+func ParseCodexAccessToken(accessToken string) *AccountIdentity {
+	if accessToken == "" {
+		return nil
+	}
+	payload, err := decodeJWTPayload(accessToken)
+	if err != nil {
+		return nil
+	}
+	var claims codexAccessTokenClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil
+	}
+	identity := &AccountIdentity{}
+	if claims.Profile != nil {
+		identity.Email = strings.TrimSpace(claims.Profile.Email)
+	}
+	if claims.Auth != nil {
+		identity.ChatGPTAccountID = strings.TrimSpace(claims.Auth.ChatGPTAccountID)
+		identity.PlanType = strings.TrimSpace(claims.Auth.ChatGPTPlanType)
+	}
+	return identity
+}
+
+// MergeCodexIdentity returns a copy of primary with any empty field filled
+// from fallback. fallback may be nil (no-op). This realizes the codex2api
+// behavior where the access_token recovers fields the id_token omitted.
+func MergeCodexIdentity(primary, fallback *AccountIdentity) *AccountIdentity {
+	merged := &AccountIdentity{}
+	if primary != nil {
+		*merged = *primary
+	}
+	if fallback == nil {
+		return merged
+	}
+	if strings.TrimSpace(merged.Email) == "" {
+		merged.Email = fallback.Email
+	}
+	if strings.TrimSpace(merged.ChatGPTAccountID) == "" {
+		merged.ChatGPTAccountID = fallback.ChatGPTAccountID
+	}
+	if strings.TrimSpace(merged.PlanType) == "" {
+		merged.PlanType = fallback.PlanType
+	}
+	return merged
+}
+
+// identityIncomplete reports whether any field a TokenSet consumer relies on
+// is missing from identity, signaling that an access_token fallback is worth
+// attempting.
+func identityIncomplete(identity *AccountIdentity) bool {
+	if identity == nil {
+		return true
+	}
+	return strings.TrimSpace(identity.Email) == "" ||
+		strings.TrimSpace(identity.ChatGPTAccountID) == "" ||
+		strings.TrimSpace(identity.PlanType) == ""
+}
+
+// decodeJWTPayload base64-decodes the payload segment of a JWT without
+// verifying the signature. Tolerates URL-safe and standard base64 plus
+// missing padding.
+func decodeJWTPayload(token string) ([]byte, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid JWT: expected 3 segments")
+	}
+	payload := parts[1]
+	switch len(payload) % 4 {
+	case 2:
+		payload += "=="
+	case 3:
+		payload += "="
+	}
+	decoded, err := base64.URLEncoding.DecodeString(payload)
+	if err != nil {
+		decoded, err = base64.StdEncoding.DecodeString(payload)
+		if err != nil {
+			return nil, fmt.Errorf("invalid JWT payload: %w", err)
+		}
+	}
+	return decoded, nil
+}

--- a/service/oauth/identity_test.go
+++ b/service/oauth/identity_test.go
@@ -1,0 +1,206 @@
+package oauth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// buildTestJWT assembles an unsigned JWT whose payload is the JSON-marshaled
+// claim map. Only the payload segment carries real data; header and signature
+// are filler since ParseCodexIDToken / ParseCodexAccessToken do not verify.
+func buildTestJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	header := map[string]string{"alg": "none", "typ": "JWT"}
+	headerBytes, _ := json.Marshal(header)
+	payloadBytes, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	encode := func(b []byte) string {
+		return strings.TrimRight(base64.URLEncoding.EncodeToString(b), "=")
+	}
+	return encode(headerBytes) + "." + encode(payloadBytes) + ".sig"
+}
+
+func idTokenClaims(email, accountID, planType string) map[string]any {
+	claims := map[string]any{}
+	if email != "" {
+		claims["email"] = email
+	}
+	auth := map[string]any{}
+	if accountID != "" {
+		auth["chatgpt_account_id"] = accountID
+	}
+	if planType != "" {
+		auth["chatgpt_plan_type"] = planType
+	}
+	if len(auth) > 0 {
+		claims["https://api.openai.com/auth"] = auth
+	}
+	return claims
+}
+
+func accessTokenClaims(profileEmail, accountID, planType string) map[string]any {
+	claims := map[string]any{}
+	if profileEmail != "" {
+		claims["https://api.openai.com/profile"] = map[string]any{"email": profileEmail}
+	}
+	auth := map[string]any{}
+	if accountID != "" {
+		auth["chatgpt_account_id"] = accountID
+	}
+	if planType != "" {
+		auth["chatgpt_plan_type"] = planType
+	}
+	if len(auth) > 0 {
+		claims["https://api.openai.com/auth"] = auth
+	}
+	return claims
+}
+
+func TestParseCodexIDToken_FullIdentity(t *testing.T) {
+	token := buildTestJWT(t, idTokenClaims("user@example.com", "acc_123", "plus"))
+	got := ParseCodexIDToken(token)
+	if got.Email != "user@example.com" {
+		t.Errorf("Email = %q", got.Email)
+	}
+	if got.ChatGPTAccountID != "acc_123" {
+		t.Errorf("ChatGPTAccountID = %q", got.ChatGPTAccountID)
+	}
+	if got.PlanType != "plus" {
+		t.Errorf("PlanType = %q", got.PlanType)
+	}
+}
+
+func TestParseCodexIDToken_EmptyTokenReturnsEmptyIdentity(t *testing.T) {
+	got := ParseCodexIDToken("")
+	if got == nil {
+		t.Fatal("expected non-nil identity")
+	}
+	if got.Email != "" || got.ChatGPTAccountID != "" || got.PlanType != "" {
+		t.Errorf("expected empty identity, got %+v", got)
+	}
+}
+
+func TestParseCodexIDToken_MalformedJWTReturnsEmpty(t *testing.T) {
+	got := ParseCodexIDToken("not.a.jwt")
+	if got == nil {
+		t.Fatal("expected non-nil identity")
+	}
+	if got.Email != "" {
+		t.Errorf("expected empty Email, got %q", got.Email)
+	}
+}
+
+func TestParseCodexIDToken_MissingPlanType(t *testing.T) {
+	token := buildTestJWT(t, idTokenClaims("user@example.com", "acc_123", ""))
+	got := ParseCodexIDToken(token)
+	if got.Email != "user@example.com" {
+		t.Errorf("Email = %q", got.Email)
+	}
+	if got.ChatGPTAccountID != "acc_123" {
+		t.Errorf("ChatGPTAccountID = %q", got.ChatGPTAccountID)
+	}
+	if got.PlanType != "" {
+		t.Errorf("expected empty PlanType, got %q", got.PlanType)
+	}
+}
+
+func TestParseCodexAccessToken_ProfileEmailNamespace(t *testing.T) {
+	token := buildTestJWT(t, accessTokenClaims("at-user@example.com", "acc_456", "pro"))
+	got := ParseCodexAccessToken(token)
+	if got == nil {
+		t.Fatal("expected non-nil identity")
+	}
+	if got.Email != "at-user@example.com" {
+		t.Errorf("Email = %q", got.Email)
+	}
+	if got.ChatGPTAccountID != "acc_456" {
+		t.Errorf("ChatGPTAccountID = %q", got.ChatGPTAccountID)
+	}
+	if got.PlanType != "pro" {
+		t.Errorf("PlanType = %q", got.PlanType)
+	}
+}
+
+func TestParseCodexAccessToken_EmptyTokenReturnsNil(t *testing.T) {
+	if got := ParseCodexAccessToken(""); got != nil {
+		t.Errorf("expected nil for empty token, got %+v", got)
+	}
+}
+
+func TestParseCodexAccessToken_MalformedReturnsNil(t *testing.T) {
+	if got := ParseCodexAccessToken("not-a-jwt"); got != nil {
+		t.Errorf("expected nil for malformed token, got %+v", got)
+	}
+}
+
+func TestMergeCodexIdentity_FillsEmptyFieldsFromFallback(t *testing.T) {
+	primary := &AccountIdentity{Email: "primary@example.com"} // accountID + planType empty
+	fallback := &AccountIdentity{
+		Email:             "fallback@example.com",
+		ChatGPTAccountID:  "acc_fb",
+		PlanType:          "pro",
+	}
+	merged := MergeCodexIdentity(primary, fallback)
+	if merged.Email != "primary@example.com" {
+		t.Errorf("Email should stay primary, got %q", merged.Email)
+	}
+	if merged.ChatGPTAccountID != "acc_fb" {
+		t.Errorf("ChatGPTAccountID should be filled from fallback, got %q", merged.ChatGPTAccountID)
+	}
+	if merged.PlanType != "pro" {
+		t.Errorf("PlanType should be filled from fallback, got %q", merged.PlanType)
+	}
+}
+
+func TestMergeCodexIdentity_NilFallbackIsNoOp(t *testing.T) {
+	primary := &AccountIdentity{Email: "keep@example.com", ChatGPTAccountID: "acc_1"}
+	merged := MergeCodexIdentity(primary, nil)
+	if merged.Email != "keep@example.com" || merged.ChatGPTAccountID != "acc_1" {
+		t.Errorf("nil fallback should not mutate primary, got %+v", merged)
+	}
+}
+
+func TestMergeCodexIdentity_NilPrimaryReturnsFallbackCopy(t *testing.T) {
+	fallback := &AccountIdentity{Email: "fb@example.com"}
+	merged := MergeCodexIdentity(nil, fallback)
+	if merged.Email != "fb@example.com" {
+		t.Errorf("expected fallback email, got %q", merged.Email)
+	}
+}
+
+func TestIdentityIncomplete(t *testing.T) {
+	cases := []struct {
+		name    string
+		identity *AccountIdentity
+		want    bool
+	}{
+		{"nil", nil, true},
+		{"all empty", &AccountIdentity{}, true},
+		{"missing plan", &AccountIdentity{Email: "e", ChatGPTAccountID: "a"}, true},
+		{"missing account", &AccountIdentity{Email: "e", PlanType: "p"}, true},
+		{"missing email", &AccountIdentity{ChatGPTAccountID: "a", PlanType: "p"}, true},
+		{"complete", &AccountIdentity{Email: "e", ChatGPTAccountID: "a", PlanType: "p"}, false},
+		{"whitespace only", &AccountIdentity{Email: "  "}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := identityIncomplete(tc.identity); got != tc.want {
+				t.Errorf("identityIncomplete(%+v) = %v, want %v", tc.identity, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecodeJWTPayload_StandardBase64Fallback(t *testing.T) {
+	header := base64.StdEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload := base64.StdEncoding.EncodeToString([]byte(`{"email":"std@example.com"}`))
+	token := header + "." + payload + ".sig"
+	got := ParseCodexIDToken(token)
+	if got.Email != "std@example.com" {
+		t.Errorf("expected standard-base64 fallback to parse, got Email=%q", got.Email)
+	}
+}

--- a/service/oauth/import.go
+++ b/service/oauth/import.go
@@ -162,10 +162,16 @@ func resolveImportedNativeOauthIdentity(payload map[string]interface{}) (*import
 		return nil, fmt.Errorf("oauth credentials missing access_token/session_token")
 	}
 
+	// Preserve the web session token independently so the refresh
+	// orchestrator can fall back to the session-cookie path when the RT
+	// is revoked. Only set when the payload actually carried one.
+	sessionToken := asNonEmptyString(payload["session_token"])
+
 	derived := resolveImportedOauthIdentityFields(provider, payload)
 
 	exchange := &TokenSet{
-		AccessToken: accessToken,
+		AccessToken:  accessToken,
+		SessionToken: sessionToken,
 	}
 	if v := asNonEmptyString(payload["refresh_token"]); v != "" {
 		exchange.RefreshToken = v

--- a/service/oauth/provider.go
+++ b/service/oauth/provider.go
@@ -60,6 +60,7 @@ type TokenSet struct {
 	PlanType       string                 `json:"planType,omitempty"`
 	ProjectID      string                 `json:"projectId,omitempty"`
 	IDToken        string                 `json:"idToken,omitempty"`
+	SessionToken   string                 `json:"sessionToken,omitempty"`
 	ProviderData   map[string]interface{} `json:"providerData,omitempty"`
 }
 
@@ -139,15 +140,36 @@ type RefreshOAuthContext struct {
 	ProviderData map[string]interface{}
 }
 
+// SessionTokenInput carries the ChatGPT web session token used by the
+// session-cookie fallback when a refresh token has been revoked but the web
+// session is still valid.
+type SessionTokenInput struct {
+	SessionToken string
+	ProxyURL     *string
+}
+
 // OAuthProviderDefinition defines the interface for an OAuth provider.
 type OAuthProviderDefinition struct {
 	Metadata ProviderMetadata `json:"metadata"`
 	Site     ProviderSiteConfig `json:"site"`
 	Loopback LoopbackConfig   `json:"loopback"`
 
-	BuildAuthorizationURL  func(ctx context.Context, input BuildAuthURLInput) (string, error)
-	ResolveRedirectURI     func(ctx context.Context, input ResolveRedirectURIInput) (string, error)
+	BuildAuthorizationURL     func(ctx context.Context, input BuildAuthURLInput) (string, error)
+	ResolveRedirectURI        func(ctx context.Context, input ResolveRedirectURIInput) (string, error)
 	ExchangeAuthorizationCode func(ctx context.Context, input ExchangeCodeInput) (*TokenSet, error)
-	RefreshAccessToken     func(ctx context.Context, input RefreshTokenInput) (*TokenSet, error)
-	BuildProxyHeaders      func(ctx context.Context, input ProxyHeaderInput) map[string]string
+	RefreshAccessToken        func(ctx context.Context, input RefreshTokenInput) (*TokenSet, error)
+	BuildProxyHeaders         func(ctx context.Context, input ProxyHeaderInput) map[string]string
+
+	// RefreshWithSessionToken is an optional capability: when non-nil, the
+	// refresh orchestrator falls back to it after a non-retryable RT refresh
+	// failure (e.g. invalid_grant). Providers that do not support a web
+	// session fallback leave this nil.
+	RefreshWithSessionToken func(ctx context.Context, input SessionTokenInput) (*TokenSet, error)
+
+	// ParseAccessToken is an optional capability: when non-nil, the refresh
+	// orchestrator uses it to recover identity fields (email, account id,
+	// plan type) that the id_token omitted, by parsing the access_token JWT.
+	// Providers whose access tokens are not JWTs or carry no identity leave
+	// this nil.
+	ParseAccessToken func(accessToken string) *AccountIdentity
 }

--- a/service/oauth/refresh.go
+++ b/service/oauth/refresh.go
@@ -1,7 +1,9 @@
 package oauth
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -105,11 +107,41 @@ func doRefreshAccessToken(accountID int64) refreshResult {
 
 	proxyURL := resolveAccountProxyURL(account.SiteID, account.ExtraConfig)
 
-	refreshed, err := def.RefreshAccessToken(nil, RefreshTokenInput{
-		RefreshToken: oauth.RefreshToken,
-		OAuth:        oauthCtx,
-		ProxyURL:     proxyURL,
+	// RefreshWithRetry wraps the provider call with exponential backoff and
+	// non-retryable short-circuiting. A bounded context lets the retry loop
+	// abort during backoff if the process is shutting down; the budget
+	// comfortably fits MaxRefreshRetries (1+2+4=7s) plus one attempt's
+	// worth of network latency.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	refreshed, err := RefreshWithRetry(ctx, func() (*TokenSet, error) {
+		return def.RefreshAccessToken(ctx, RefreshTokenInput{
+			RefreshToken: oauth.RefreshToken,
+			OAuth:        oauthCtx,
+			ProxyURL:     proxyURL,
+		})
 	})
+
+	// Chain 2: session-token fallback. When the RT refresh failed with a
+	// non-retryable error (invalid_grant etc.) and the provider exposes a
+	// session-cookie refresh capability, retry once with the stored web
+	// session token. This recovers accounts whose RT was revoked but whose
+	// ChatGPT web session is still alive — the same self-heal codex2api does.
+	if err != nil && IsNonRetryable(err) && def.RefreshWithSessionToken != nil && strings.TrimSpace(oauth.SessionToken) != "" {
+		sessionRefreshed, sessionErr := def.RefreshWithSessionToken(ctx, SessionTokenInput{
+			SessionToken: oauth.SessionToken,
+			ProxyURL:     proxyURL,
+		})
+		if sessionErr == nil {
+			refreshed = sessionRefreshed
+			err = nil
+		}
+		// On session-fallback failure, retain the original RT error so the
+		// account is marked with the root-cause (invalid_grant), not masked
+		// by a session-endpoint transport error.
+	}
+
 	if err != nil {
 		return refreshResult{AccountID: accountID, Err: err}
 	}
@@ -137,6 +169,7 @@ func doRefreshAccessToken(accountID int64) refreshResult {
 		"tokenExpiresAt": nextOauth.TokenExpiresAt,
 		"refreshToken":   nextOauth.RefreshToken,
 		"idToken":        nextOauth.IDToken,
+		"sessionToken":   nextOauth.SessionToken,
 	}
 	if nextOauth.ProviderData != nil {
 		oauthMap["providerData"] = nextOauth.ProviderData

--- a/service/oauth/retry.go
+++ b/service/oauth/retry.go
@@ -1,0 +1,94 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// MaxRefreshRetries caps how many times a transiently failing token refresh
+// is retried before giving up. Aligned with codex2api's MaxRetries constant.
+const MaxRefreshRetries = 3
+
+// retryBackoffFn is the backoff source used by RefreshWithRetry. It is a
+// package-level var (not a const) so tests can swap in a no-op sleeper to
+// keep the suite fast without short-circuiting real retry behavior.
+var retryBackoffFn = RetryBackoff
+
+// nonRetryableNeedles lists OAuth RFC 6749 error codes that signal a
+// permanent failure for the current credential — retrying cannot fix them.
+// Mirrors codex2api's isNonRetryable set so that a revoked refresh token or
+// a denied client does not burn the full retry budget.
+var nonRetryableNeedles = []string{
+	"invalid_grant",
+	"invalid_client",
+	"unauthorized_client",
+	"access_denied",
+	"refresh_token_reused",
+}
+
+// RetryBackoff returns the wait before the (attempt+1)-th retry. The first
+// retry (attempt=0) waits 1s, then 2s, then 4s — exponential with a 2x step.
+// attempt < 0 returns 0; attempt >= MaxRefreshRetries returns 0 so callers
+// can use it to detect end-of-budget without a separate bounds check.
+func RetryBackoff(attempt int) time.Duration {
+	if attempt < 0 || attempt >= MaxRefreshRetries {
+		return 0
+	}
+	return time.Duration(1<<uint(attempt)) * time.Second
+}
+
+// IsNonRetryable reports whether err carries one of the OAuth error codes
+// that cannot be fixed by retrying. The check is case-insensitive and matches
+// substrings because provider implementations surface these codes via
+// fmt.Errorf with mixed surrounding context (HTTP body, status, etc.).
+func IsNonRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, needle := range nonRetryableNeedles {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// RefreshWithRetry invokes fn up to MaxRefreshRetries+1 times, applying
+// RetryBackoff between attempts. A nil error short-circuits immediately. An
+// IsNonRetryable error short-circuits immediately (no point burning budget
+// on a revoked grant). ctx cancellation during the backoff window aborts the
+// retry loop with ctx.Err().
+//
+// fn is invoked at least once even when ctx is already cancelled, matching
+// the semantics of the existing singleflight refresh path which prefers one
+// real attempt over a zero-attempt failure.
+func RefreshWithRetry[T any](ctx context.Context, fn func() (T, error)) (T, error) {
+	var zero T
+	var lastErr error
+	for attempt := 0; attempt <= MaxRefreshRetries; attempt++ {
+		if attempt > 0 {
+			backoff := retryBackoffFn(attempt - 1)
+			select {
+			case <-ctx.Done():
+				return zero, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		result, err := fn()
+		if err == nil {
+			return result, nil
+		}
+		if IsNonRetryable(err) {
+			return zero, err
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("refresh failed after %d attempts", MaxRefreshRetries+1)
+	}
+	return zero, lastErr
+}

--- a/service/oauth/retry_test.go
+++ b/service/oauth/retry_test.go
@@ -1,0 +1,162 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// withNoBackoff swaps the package-level backoff source for a zero-duration
+// function so the retry suite does not sleep real seconds. It restores the
+// original on test cleanup.
+func withNoBackoff(t *testing.T) {
+	t.Helper()
+	original := retryBackoffFn
+	retryBackoffFn = func(int) time.Duration { return 0 }
+	t.Cleanup(func() { retryBackoffFn = original })
+}
+
+func TestRetryBackoff_Schedule(t *testing.T) {
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{-1, 0},
+		{0, 1 * time.Second},
+		{1, 2 * time.Second},
+		{2, 4 * time.Second},
+		{3, 0}, // at budget
+		{99, 0},
+	}
+	for _, tc := range cases {
+		if got := RetryBackoff(tc.attempt); got != tc.want {
+			t.Errorf("RetryBackoff(%d) = %v, want %v", tc.attempt, got, tc.want)
+		}
+	}
+}
+
+func TestIsNonRetryable(t *testing.T) {
+	retryable := fmt.Errorf("connection reset")
+	nonRetryable := []error{
+		errors.New("oauth: invalid_grant"),
+		errors.New("invalid_client"),
+		errors.New("UNAUTHORIZED_CLIENT"),
+		errors.New("access_denied: user revoked"),
+		errors.New("refresh_token_reused"),
+	}
+	if IsNonRetryable(nil) {
+		t.Error("nil err should not be non-retryable")
+	}
+	if IsNonRetryable(retryable) {
+		t.Errorf("generic error should be retryable: %v", retryable)
+	}
+	for _, err := range nonRetryable {
+		if !IsNonRetryable(err) {
+			t.Errorf("expected non-retryable: %v", err)
+		}
+	}
+}
+
+func TestRefreshWithRetry_FirstAttemptSuccess(t *testing.T) {
+	withNoBackoff(t)
+	calls := 0
+	fn := func() (string, error) {
+		calls++
+		return "ok", nil
+	}
+	result, err := RefreshWithRetry[string](context.Background(), fn)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if result != "ok" {
+		t.Errorf("result = %q", result)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRefreshWithRetry_TransientFailureThenSuccess(t *testing.T) {
+	withNoBackoff(t)
+	calls := 0
+	fn := func() (string, error) {
+		calls++
+		if calls < 3 {
+			return "", fmt.Errorf("temporary network failure")
+		}
+		return "recovered", nil
+	}
+	result, err := RefreshWithRetry[string](context.Background(), fn)
+	if err != nil {
+		t.Fatalf("expected recovery, got %v", err)
+	}
+	if result != "recovered" {
+		t.Errorf("result = %q", result)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls (2 transient failures + 1 success), got %d", calls)
+	}
+}
+
+func TestRefreshWithRetry_NonRetryableShortCircuits(t *testing.T) {
+	withNoBackoff(t)
+	calls := 0
+	fn := func() (string, error) {
+		calls++
+		return "", errors.New("invalid_grant: refresh token revoked")
+	}
+	_, err := RefreshWithRetry[string](context.Background(), fn)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsNonRetryable(err) {
+		t.Errorf("expected non-retryable error, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("non-retryable should short-circuit after 1 call, got %d", calls)
+	}
+}
+
+func TestRefreshWithRetry_ExhaustsBudget(t *testing.T) {
+	withNoBackoff(t)
+	calls := 0
+	fn := func() (string, error) {
+		calls++
+		return "", fmt.Errorf("temporary failure")
+	}
+	_, err := RefreshWithRetry[string](context.Background(), fn)
+	if err == nil {
+		t.Fatal("expected error after exhausting budget")
+	}
+	if calls != MaxRefreshRetries+1 {
+		t.Errorf("expected %d calls (budget exhausted), got %d", MaxRefreshRetries+1, calls)
+	}
+}
+
+func TestRefreshWithRetry_ContextCancelDuringBackoff(t *testing.T) {
+	// Use a real but short backoff so context cancel wins the select race.
+	original := retryBackoffFn
+	retryBackoffFn = func(int) time.Duration { return 100 * time.Millisecond }
+	t.Cleanup(func() { retryBackoffFn = original })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	fn := func() (string, error) {
+		calls++
+		return "", fmt.Errorf("temporary failure")
+	}
+	// Cancel during the first backoff window.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	_, err := RefreshWithRetry[string](ctx, fn)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if calls == 0 {
+		t.Error("expected at least 1 attempt before cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

- Brings the non-Resin Codex OAuth details that codex2api handles better into metapi-go's provider-abstraction architecture, addressing [#558](https://github.com/DeliciousBuding/metapi-go/issues/558)'s live-probe stability gap.
- Resin sticky-egress is intentionally out of scope (implemented in the sibling codex2api project).

## Changes

**New modules**
- `service/oauth/identity.go`: `ParseCodexIDToken` + `ParseCodexAccessToken` (email under `/profile` namespace, distinct from id_token) + `MergeCodexIdentity` fallback + `identityIncomplete` predicate.
- `service/oauth/retry.go`: cross-cutting `RefreshWithRetry[T]` with exponential backoff (1/2/4s, `MaxRefreshRetries=3`) + `IsNonRetryable` classification for OAuth RFC needles (`invalid_grant`, `invalid_client`, `unauthorized_client`, `access_denied`, `refresh_token_reused`).

**Provider interface** (`service/oauth/provider.go`)
- `OAuthProviderDefinition` gains two optional capabilities: `RefreshWithSessionToken` (session-cookie fallback) and `ParseAccessToken` (AT identity recovery). `nil` means the provider does not support it.
- `TokenSet` gains `SessionToken` field.

**Codex provider** (`service/oauth/codex.go`)
- `exchangeCodexToken` sets `User-Agent: codex-cli/0.91.0`.
- `buildCodexTokenSetFromPayload` merges id_token identity with AT fallback when id_token omits email/account_id/plan_type.
- `refreshCodexWithSessionToken`: GETs `chatgpt.com/api/auth/session` with `__Secure-next-auth.session-token` cookie, Chrome UA + Sec-Fetch-* headers, parses AT for identity (session endpoint returns no id_token).

**Refresh orchestrator** (`service/oauth/refresh.go`)
- `doRefreshAccessToken` becomes a 3-stage chain inside the existing singleflight:
  1. RT refresh wrapped in `RefreshWithRetry` with a 2min bounded context.
  2. On non-retryable failure + provider supports session fallback + ST stored → `RefreshWithSessionToken` (original error retained on fallback failure so root-cause is not masked).
  3. AT identity fallback at the provider level.

**Schema/storage**
- `SessionToken` flows through `OauthInfo` / `StoredOauthState` / `parsedOauthInfo` and is persisted in `extra_config.oauth.sessionToken` (camelCase, frontend contract-compatible). **No DB column change.** Existing rows deserialize to empty string → chain 2 skips → behavior unchanged. No migration needed.
- `import.go` preserves `session_token` independently alongside the existing "use ST as AT when AT missing" fallback.
- `flow.go` carries `Exchange.SessionToken` into `OauthInfo` on activate.

## Test plan

- [x] `identity_test.go`: id_token full/empty/malformed/missing-plan, AT `/profile` namespace, `MergeIdentity` nil edges, `identityIncomplete` matrix, standard-base64 fallback.
- [x] `retry_test.go`: backoff schedule, `IsNonRetryable` classification, first-call success, transient-then-success, non-retryable short-circuit, budget exhaustion, ctx cancel during backoff.
- [x] `codex_session_test.go`: session success (cookie+UA+Sec-Fetch verified), email fallback from user object, missing ST / 401 / missing AT / missing account_id, `parseCodexSessionExpires` edges, capability registration.
- [x] Local CI: `go build ./cmd/server` + `go vet ./...` + `go test ./... -count=1 -race` all green (exit 0).
- [ ] GitHub Actions 12-check suite green.
- [ ] #558 live probe still pending operator credentials (out of scope for this PR — code path is now ready).