### PR TITLE
fix(ui): cap DialogContent height + sticky footer + viewport guard test

### DIFF
--- a/web/src/components/ui/__tests__/dialog-viewport.test.ts
+++ b/web/src/components/ui/__tests__/dialog-viewport.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const WEB_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..')
+const DIALOG_PATH = join(WEB_ROOT, 'src/components/ui/dialog.tsx')
+
+describe('dialog viewport safety', () => {
+  it('DialogContent caps height and scrolls when content overflows', () => {
+    const source = readFileSync(DIALOG_PATH, 'utf8')
+
+    // DialogContent must declare a max-height bound (using dvh/vh) so a
+    // tall form cannot bleed past the viewport edges, and overflow-y-auto
+    // so the capped content is scrollable instead of clipped.
+    expect(source).toMatch(/max-h-\[calc\(100d?vh-\d+rem\)\]/)
+    expect(source).toMatch(/overflow-y-auto/)
+  })
+
+  it('DialogFooter sticks to the bottom so action buttons stay visible', () => {
+    const source = readFileSync(DIALOG_PATH, 'utf8')
+
+    expect(source).toMatch(/sticky\s+bottom-0/)
+  })
+})

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -55,7 +55,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot='dialog-content'
         className={cn(
-          'bg-popover text-popover-foreground ring-foreground/10 motion-reduce:animate-none! data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl p-4 text-sm ring-1 duration-100 outline-none sm:max-w-sm',
+          'bg-popover text-popover-foreground ring-foreground/10 motion-reduce:animate-none! data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 fixed top-1/2 left-1/2 z-50 flex max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 flex-col gap-4 overflow-y-auto rounded-xl p-4 text-sm ring-1 duration-100 outline-none sm:max-w-sm',
           className
         )}
         {...props}
@@ -104,7 +104,7 @@ function DialogFooter({
     <div
       data-slot='dialog-footer'
       className={cn(
-        'bg-muted/50 -mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t p-4 sm:flex-row sm:justify-end',
+        'bg-muted/70 -mx-4 -mb-4 sticky bottom-0 z-10 flex flex-col-reverse gap-2 rounded-b-xl border-t p-4 backdrop-blur-sm sm:flex-row sm:justify-end',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

The site-registration dialog (and any dialog with tall content) overflowed past the viewport — no height cap on `DialogContent`, no scroll, submit button unreachable.

- **DialogContent**: add `max-h-[calc(100dvh-2rem)]` + `overflow-y-auto` + switch `grid`→`flex-col` so every dialog is height-safe by default and the content scrolls instead of bleeding out.
- **DialogFooter**: `sticky bottom-0` + `backdrop-blur-sm` + `bg-muted/70` so action buttons stay pinned while the body scrolls.
- **Guard test** (`dialog-viewport.test.ts`): static assertion that `DialogContent` carries the `max-h` + `overflow-y-auto` contract and `DialogFooter` carries `sticky bottom-0`, so the design-system primitive cannot silently regress.

## Root cause

`DialogContent` had `max-w` (width cap) but no `max-h` or `overflow-y`. Tall forms like site-form-dialog (12+ fields: name/platform/url/checkin-url/proxy-url/weight/concurrency/system-proxy/Resin/uTLS/headers/probe) exceeded viewport height → modal bled past top/bottom edges, no scroll. The per-component `overflow-y-auto` patch in `route-form-dialog.tsx` (a Sheet, different pattern) was a local workaround; the base primitive lacked the constraint.

## Test plan

- [x] `bun run typecheck` (tsgo) — 0 error
- [x] `bun run lint` (oxlint) — 0 error
- [x] `bun run format:check` (oxfmt) — clean
- [x] `bun run knip` — clean
- [x] `bun run test` (vitest) — 52 files / 481 tests green (incl. new dialog-viewport guard)
- [ ] Reviewer: verify site-form dialog scrolls on a short viewport; footer stays visible