### PR TITLE
fix(ui): design-system overflow safety + opaque footer + sticky header + form onInvalid

### DIFF
--- a/web/src/components/ui/__tests__/dialog-viewport.test.ts
+++ b/web/src/components/ui/__tests__/dialog-viewport.test.ts
@@ -23,4 +23,17 @@ describe('dialog viewport safety', () => {
 
     expect(source).toMatch(/sticky\s+bottom-0/)
   })
+
+  it('DialogFooter uses an opaque background (no see-through on scroll)', () => {
+    const source = readFileSync(DIALOG_PATH, 'utf8')
+    const footerMatch = source.match(
+      /function DialogFooter[\s\S]*?className=\{cn\(([\s\S]*?)\)\}/
+    )
+    expect(footerMatch).not.toBeNull()
+    const footerClasses = footerMatch![1]
+    // Semi-transparent bg (e.g. bg-muted/70) + backdrop-blur lets scrolling
+    // content bleed through the sticky footer. Require a solid bg instead.
+    expect(footerClasses).not.toMatch(/backdrop-blur/)
+    expect(footerClasses).not.toMatch(/bg-\w+\/\d+/)
+  })
 })

--- a/web/src/components/ui/alert-dialog.tsx
+++ b/web/src/components/ui/alert-dialog.tsx
@@ -53,7 +53,7 @@ function AlertDialogContent({
         data-slot='alert-dialog-content'
         data-size={size}
         className={cn(
-          'group/alert-dialog-content bg-popover text-popover-foreground ring-foreground/10 motion-reduce:animate-none! data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl p-4 ring-1 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm',
+          'group/alert-dialog-content bg-popover text-popover-foreground ring-foreground/10 motion-reduce:animate-none! data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 fixed top-1/2 left-1/2 z-50 flex max-h-[calc(100dvh-2rem)] w-full -translate-x-1/2 -translate-y-1/2 flex-col gap-4 overflow-y-auto rounded-xl p-4 ring-1 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm',
           className
         )}
         {...props}
@@ -86,7 +86,7 @@ function AlertDialogFooter({
     <div
       data-slot='alert-dialog-footer'
       className={cn(
-        'bg-muted/50 -mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end',
+        'bg-popover -mx-4 -mb-4 sticky bottom-0 z-10 flex flex-col-reverse gap-2 rounded-b-xl border-t p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end',
         className
       )}
       {...props}

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -85,7 +85,10 @@ function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot='dialog-header'
-      className={cn('flex flex-col gap-2', className)}
+      className={cn(
+        'bg-popover -mx-4 sticky top-0 z-10 flex flex-col gap-2 px-4 pt-4 pb-2',
+        className
+      )}
       {...props}
     />
   )

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -104,7 +104,7 @@ function DialogFooter({
     <div
       data-slot='dialog-footer'
       className={cn(
-        'bg-muted/70 -mx-4 -mb-4 sticky bottom-0 z-10 flex flex-col-reverse gap-2 rounded-b-xl border-t p-4 backdrop-blur-sm sm:flex-row sm:justify-end',
+        'bg-popover -mx-4 -mb-4 sticky bottom-0 z-10 flex flex-col-reverse gap-2 rounded-b-xl border-t p-4 sm:flex-row sm:justify-end',
         className
       )}
       {...props}

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -48,7 +48,7 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot='popover-content'
           className={cn(
-            'bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none! data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg p-2.5 text-sm shadow-md ring-1 outline-hidden duration-100',
+            'bg-popover text-popover-foreground ring-foreground/10 max-h-(--available-height) overflow-y-auto data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none! data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg p-2.5 text-sm shadow-md ring-1 outline-hidden duration-100',
             className
           )}
           {...props}

--- a/web/src/features/sites/components/site-form-dialog.tsx
+++ b/web/src/features/sites/components/site-form-dialog.tsx
@@ -251,7 +251,12 @@ export function SiteFormDialog({
         </DialogHeader>
 
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className='grid gap-4'>
+          <form
+            onSubmit={form.handleSubmit(onSubmit, () =>
+              toast.error(t('sites.form.invalid'))
+            )}
+            className='grid gap-4'
+          >
             <div className='grid gap-4 sm:grid-cols-2'>
               <FormField
                 control={form.control}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -428,6 +428,7 @@
       "form": {
         "addTitle": "Add site",
         "editTitle": "Edit site",
+        "invalid": "Please check the highlighted form fields",
         "addDescription": "Register a new upstream site.",
         "editDescription": "Update the site configuration.",
         "name": "Name",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -428,6 +428,7 @@
       "form": {
         "addTitle": "添加站点",
         "editTitle": "编辑站点",
+        "invalid": "请检查表单标红字段",
         "addDescription": "注册一个新的上游站点。",
         "editDescription": "更新站点配置。",
         "name": "名称",


### PR DESCRIPTION
## Summary

Deep UI/UX audit (4 parallel subagents) surfaced a class of overlay overflow bugs across the design-system primitives. This PR fixes the P0/P1 findings:

**Design-system primitives (root cause fixes)**
- **DialogFooter**: `bg-muted/70 backdrop-blur-sm` → `bg-popover` (opaque — was see-through on scroll, the user-reported "穿透" bug)
- **DialogHeader**: `sticky top-0 + bg-popover` (title/description stay pinned when tall form body scrolls — was scrolling away)
- **AlertDialogContent**: `grid` → `flex-col + max-h-[calc(100dvh-2rem)] + overflow-y-auto` (had **zero** height cap — same bug as DialogContent pre-#815)
- **AlertDialogFooter**: `bg-muted/50` → `bg-popover` (opaque) + `sticky bottom-0`
- **PopoverContent**: `max-h-(--available-height) + overflow-y-auto` (long popover content was overflowing past viewport)

**Interaction fix**
- **site-form-dialog**: add `onInvalid` handler (was silently swallowing Zod validation failures — submit button appeared dead when a field was invalid)
- **i18n**: add `sites.form.invalid` key in en/zh-CN

**Guard test**
- `dialog-viewport.test.ts`: add assertion that DialogFooter must NOT use `backdrop-blur` or semi-transparent `bg-*/<digit>` — prevents the see-through regression

## Subagent audit findings (consolidated)

**Overflow audit** (completed): AlertDialog uncapped (P1→fixed), DialogHeader not sticky (P1→fixed), PopoverContent no max-h (P1→fixed), close button scrolls with content (P2—noted, Escape/overlay still work), Sheet top/bottom variants lack max-h (P2—theoretical, no call site uses them), SheetHeader/SheetFooter lack shrink-0 (P2), keys-section Sheet overflow on SheetContent instead of inner body (P2).

**Interaction audit** (completed): Double error toast on ~15 settings mutations (P0—axios interceptor + local onError both fire; needs per-request `skipErrorHandler: true` fix, deferred to follow-up), site-form-dialog no onInvalid (P1→fixed), keys-section/oauth-start no dirty-close guard (P1—deferred), account-form-dialog password mode no field-level error mapping (P1—deferred).

**Visual polish + a11y audits**: running, findings will drive a follow-up PR.

## Test plan

- [x] `bun run format:check` — clean
- [x] `bun run typecheck` — 0 error
- [x] `bun run lint` — 0 error
- [x] `bun run knip` — clean
- [x] `bun run test` — 52 files / 482 tests green
- [ ] CI 16-check suite
- [ ] Reviewer: verify site form dialog footer is opaque + header stays when scrolling