### PR TITLE
refactor(ui): migrate dashboard badge spans to shared Badge primitive

### DIFF
--- a/web/src/features/dashboard/sections/availability/availability-section.tsx
+++ b/web/src/features/dashboard/sections/availability/availability-section.tsx
@@ -10,6 +10,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Inbox, Radio, ShieldCheck, TriangleAlert } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import { Badge } from '@/components/ui/badge'
 import {
   Card,
   CardContent,
@@ -39,19 +40,19 @@ type AttentionResponse = {
 
 const SEVERITY_TONE: Record<
   'critical' | 'warning' | 'info',
-  { dot: string; badge: string }
+  { dot: string; variant: 'destructive' | 'warning' | 'info' }
 > = {
   critical: {
     dot: 'bg-destructive',
-    badge: 'border-destructive/40 bg-destructive/10 text-destructive-soft-fg',
+    variant: 'destructive',
   },
   warning: {
     dot: 'bg-warning',
-    badge: 'border-warning/40 bg-warning/10 text-warning-soft-fg',
+    variant: 'warning',
   },
   info: {
     dot: 'bg-info',
-    badge: 'border-info/40 bg-info/10 text-info-soft-fg',
+    variant: 'info',
   },
 }
 
@@ -217,15 +218,10 @@ function AttentionPanel() {
                   key={`${item.target}-${index}`}
                   className='flex items-start gap-3'
                 >
-                  <span
-                    className={cn(
-                      'mt-1 inline-flex h-5 shrink-0 items-center gap-1 rounded-full border px-2 text-xs font-medium',
-                      tone.badge
-                    )}
-                  >
+                  <Badge variant={tone.variant} className='mt-1 shrink-0'>
                     <span className={cn('size-1.5 rounded-full', tone.dot)} />
                     {label}
-                  </span>
+                  </Badge>
                   <div className='min-w-0 flex-1'>
                     {item.target ? (
                       <a

--- a/web/src/features/dashboard/sections/overview/overview-section.tsx
+++ b/web/src/features/dashboard/sections/overview/overview-section.tsx
@@ -21,6 +21,7 @@ import {
 import { useMemo, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -40,7 +41,6 @@ import {
 } from '@/components/ui/table'
 import { api } from '@/lib/api'
 import { formatInt, formatRatio } from '@/lib/format'
-import { cn } from '@/lib/utils'
 
 import { AnnouncementBanner } from '../../components/announcement-banner'
 import { StatCard } from '../../components/stat-card'
@@ -79,23 +79,22 @@ type BalanceHistoryResponse = {
 /** Tone + label for a scheduler job last-status value. */
 const SCHEDULER_STATUS_BADGE: Record<
   string,
-  { className: string; key: string }
+  { variant: 'success' | 'destructive' | 'info' | 'secondary'; key: string }
 > = {
   success: {
-    className: 'border-success/40 bg-success/10 text-success-soft-fg',
+    variant: 'success',
     key: 'dashboard.overview.scheduledTasks.statusSuccess',
   },
   failed: {
-    className:
-      'border-destructive/40 bg-destructive/10 text-destructive-soft-fg',
+    variant: 'destructive',
     key: 'dashboard.overview.scheduledTasks.statusFailed',
   },
   running: {
-    className: 'border-info/40 bg-info/10 text-info-soft-fg',
+    variant: 'info',
     key: 'dashboard.overview.scheduledTasks.statusRunning',
   },
   never: {
-    className: 'border-border bg-muted text-muted-foreground',
+    variant: 'secondary',
     key: 'dashboard.overview.scheduledTasks.statusNever',
   },
 }
@@ -223,9 +222,6 @@ export function OverviewSection() {
             const status =
               SCHEDULER_STATUS_BADGE[row.lastStatus ?? ''] ??
               SCHEDULER_STATUS_BADGE.never
-            const enabledClassName = row.enabled
-              ? 'border-success/40 bg-success/10 text-success-soft-fg'
-              : 'border-border bg-muted text-muted-foreground'
             const enabledLabel = row.enabled
               ? t('dashboard.overview.scheduledTasks.enabled')
               : t('dashboard.overview.scheduledTasks.disabled')
@@ -233,24 +229,12 @@ export function OverviewSection() {
               <TableRow key={row.job}>
                 <TableCell className='font-medium'>{row.job}</TableCell>
                 <TableCell>
-                  <span
-                    className={cn(
-                      'inline-flex h-5 items-center rounded-full border px-2 text-xs font-medium',
-                      enabledClassName
-                    )}
-                  >
+                  <Badge variant={row.enabled ? 'success' : 'secondary'}>
                     {enabledLabel}
-                  </span>
+                  </Badge>
                 </TableCell>
                 <TableCell>
-                  <span
-                    className={cn(
-                      'inline-flex h-5 items-center rounded-full border px-2 text-xs font-medium',
-                      status.className
-                    )}
-                  >
-                    {t(status.key)}
-                  </span>
+                  <Badge variant={status.variant}>{t(status.key)}</Badge>
                 </TableCell>
                 <TableCell className='text-right tabular-nums'>
                   {formatInt(row.runs24h)}


### PR DESCRIPTION
## Summary

Migrates 3 hand-rolled `<span>` "badges" in the dashboard to the shared `<Badge>` primitive — pure design-system convergence, no logic/data/text change. Addresses the mechanical tranche of audit P1 #1 (the literal "hand-written green/blue badges" wording is stale post-2026-08 P0; this is the remaining spirit — bypass-`<Badge>` spans).

- `overview-section.tsx` — scheduler **last-status** span + **enabled** toggle span → `<Badge>`; `SCHEDULER_STATUS_BADGE` map `className`→`variant` (success/failed→destructive/running→info/never→secondary).
- `availability-section.tsx` — attention **severity** span → `<Badge>`; `SEVERITY_TONE` map `badge`→`variant` (critical→destructive/warning/info); dot + label kept as children.

Net: +16 / −36 lines across 2 files.

## Inherent visual diffs (using the primitive)
- `destructive` Badge has a transparent border (the hand-rolled `failed`/`critical` spans had a red-tinted `border-destructive/40`). Inherent to the primitive.
- `secondary` ≈ `muted` (near-match in current theme).
- `rounded-4xl` (Badge base) vs `rounded-full` (spans) — visually negligible on `h-5` (both pill).

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors in touched files
- [x] `bun run format:check` — green
- [x] `bun run test` — 500/500 across 55 files

## Notes
- The medium-risk tranche of P1 #1 (7 `variant='default'+dot` → `variant='success'` across accounts/checkin/routes/channels) is intentionally excluded — needs a deliberate design call + feature-by-feature with screenshots.
- `failure-reason-badge.tsx` left as-is (its `network`/`state` dot+secondary-chrome is documented intent, not oversight).