### PR TITLE
feat(ui): close onboarding dead-ends — dashboard stat-card drilldown + credential export test-request link

### DIFF
--- a/web/src/components/common/__tests__/credential-export-dialog.test.tsx
+++ b/web/src/components/common/__tests__/credential-export-dialog.test.tsx
@@ -1,0 +1,84 @@
+// Behavior test for the credential-export dialog footer. The onboarding
+// journey's final step ("make a test request") must not dead-end: the
+// footer carries a secondary link to the model tester playground so a
+// user can send a probe request without hunting for it in the sidebar.
+//
+// Mocks react-query (stable loading surface — the footer renders regardless
+// of the export fetch state) and the router Link (assertion targets
+// user-visible footer markup, not router context).
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { CredentialExportDialog } from '../credential-export-dialog'
+
+const { mockUseQuery } = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: mockUseQuery,
+}))
+
+// The real TanStack Router Link needs a router context; render a plain
+// anchor so the href is queryable via role=link + accessible name.
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ to, children }: { to: string; children: ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+}))
+
+// Toast helpers pull in sonner; stub them so no portal side effects run.
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+beforeAll(() => {
+  // Base UI primitives query matchMedia for reduced-motion/pointer tests.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+afterEach(() => cleanup())
+
+describe('CredentialExportDialog', () => {
+  it('renders a test-request link to /model-tester in the footer', async () => {
+    mockUseQuery.mockReturnValue({
+      isLoading: true,
+      isError: false,
+      data: undefined,
+      refetch: vi.fn(),
+    })
+
+    render(
+      <CredentialExportDialog
+        target={{ id: 1, name: 'demo-key', keyMasked: 'sk-***' }}
+        onOpenChange={() => {}}
+      />
+    )
+
+    const testRequestLink = await screen.findByRole('link', {
+      name: 'Send a test request',
+    })
+    expect(testRequestLink).toBeInTheDocument()
+    expect(testRequestLink).toHaveAttribute('href', '/model-tester')
+  })
+})

--- a/web/src/components/common/credential-export-dialog.tsx
+++ b/web/src/components/common/credential-export-dialog.tsx
@@ -10,6 +10,7 @@
 // exposes an adjacent copy fallback.
 
 import { useQuery } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
 import { Check, Copy, ExternalLink, Link2, Sparkles } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -342,6 +343,13 @@ export function CredentialExportDialog({
         {renderBody()}
 
         <DialogFooter>
+          <Button
+            variant='secondary'
+            render={<Link to='/model-tester' />}
+            onClick={() => onOpenChange(false)}
+          >
+            {t('connect.testRequest')}
+          </Button>
           <Button variant='ghost' onClick={() => onOpenChange(false)}>
             {t('settings.common.cancel')}
           </Button>

--- a/web/src/features/dashboard/components/__tests__/stat-card.test.tsx
+++ b/web/src/features/dashboard/components/__tests__/stat-card.test.tsx
@@ -1,0 +1,51 @@
+// Behavior tests for StatCard's optional drilldown link. Asserts only the
+// user-visible navigation affordance: when `to` is set the whole card is a
+// link to the destination; when omitted the card is a plain, non-interactive
+// surface. @tanstack/react-router's Link is stubbed so the test exercises the
+// StatCard wiring in isolation (no router context needed).
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { StatCard } from '../stat-card'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    to,
+    children,
+    className,
+  }: {
+    to?: string
+    children: ReactNode
+    className?: string
+  }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+}))
+
+afterEach(() => cleanup())
+
+describe('StatCard drilldown link', () => {
+  it('wraps the card in a link pointing at `to` when set', () => {
+    render(<StatCard title='Accounts' value='42' to='/accounts' />)
+
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/accounts')
+    expect(link).toHaveTextContent('Accounts')
+    expect(link).toHaveTextContent('42')
+  })
+
+  it('renders a plain card with no link when `to` is omitted', () => {
+    render(<StatCard title='Sites' value='7' />)
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.getByText('Sites')).toBeInTheDocument()
+    expect(screen.getByText('7')).toBeInTheDocument()
+  })
+})

--- a/web/src/features/dashboard/components/stat-card.tsx
+++ b/web/src/features/dashboard/components/stat-card.tsx
@@ -10,6 +10,7 @@
 // badge onto the semantic status tokens, and an optional two-cell details
 // grid (label + value) for extra information density.
 
+import { Link } from '@tanstack/react-router'
 import type { LucideIcon } from 'lucide-react'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -52,6 +53,8 @@ type StatCardProps = {
   /** Optional detail sub-cells (label + value) under the metric. */
   details?: StatCardDetail[]
   className?: string
+  /** When set, the whole card becomes a navigable link to this route. */
+  to?: string
 }
 
 const DETAIL_TONE_CLASSES: Record<StatCardTone, string> = {
@@ -88,8 +91,14 @@ export function StatCard(props: StatCardProps) {
   )
   const Icon = props.icon
 
-  return (
-    <Card className={cn('overflow-hidden', props.className)}>
+  const card = (
+    <Card
+      className={cn(
+        'overflow-hidden',
+        props.to && 'cursor-pointer transition-colors hover:bg-muted/50',
+        props.className
+      )}
+    >
       <CardHeader className='pb-2'>
         <div className='flex items-center gap-2'>
           {Icon ? (
@@ -179,4 +188,17 @@ export function StatCard(props: StatCardProps) {
       </CardContent>
     </Card>
   )
+
+  if (props.to) {
+    return (
+      <Link
+        to={props.to}
+        className='focus-visible:ring-ring block rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-offset-2'
+      >
+        {card}
+      </Link>
+    )
+  }
+
+  return card
 }

--- a/web/src/features/dashboard/sections/overview/overview-section.tsx
+++ b/web/src/features/dashboard/sections/overview/overview-section.tsx
@@ -266,6 +266,7 @@ export function OverviewSection() {
           spark={accountSpark}
           icon={Users}
           loading={snapshotLoading}
+          to='/accounts'
         />
         <StatCard
           title={t('dashboard.overview.statCards.siteCount')}
@@ -275,6 +276,7 @@ export function OverviewSection() {
           hint={t('dashboard.overview.statCards.siteCountHint')}
           icon={Globe}
           loading={snapshotLoading}
+          to='/sites'
         />
         <StatCard
           title={t('dashboard.overview.statCards.todayCheckin')}
@@ -283,6 +285,7 @@ export function OverviewSection() {
           tone='success'
           details={checkinDetails}
           loading={snapshotLoading}
+          to='/checkin'
         />
         <StatCard
           title={t('dashboard.overview.statCards.proxy24h')}
@@ -292,6 +295,7 @@ export function OverviewSection() {
           hint={proxyHint}
           icon={Activity}
           loading={snapshotLoading}
+          to='/proxy-logs'
         />
       </div>
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2307,6 +2307,7 @@
       "loadFailed": "Failed to load credential export.",
       "hint": "Deep links open the client app if installed; JSON/env copies are pasted manually into clients that do not support import links.",
       "copyFailed": "Copy failed — clipboard unavailable.",
+      "testRequest": "Send a test request",
       "toast": {
         "keyCopied": "API key copied",
         "endpointCopied": "Endpoint copied",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2307,6 +2307,7 @@
       "loadFailed": "接入配置加载失败。",
       "hint": "一键导入会唤起已安装的客户端；不支持导入链接的客户端请手动粘贴 JSON / 环境变量。",
       "copyFailed": "复制失败——剪贴板不可用。",
+      "testRequest": "发送测试请求",
       "toast": {
         "keyCopied": "API Key 已复制",
         "endpointCopied": "接入地址已复制",


### PR DESCRIPTION
## Summary

Two small, disjoint slices that close dead-ends in the primary user journey (multi-perspective PM/user review findings):

- **Dashboard stat-card drilldown** — `StatCard` gains an optional `to` prop that wraps the card in a TanStack `<Link>` (hover bg + cursor-pointer + focus-visible ring, ONLY when `to` is set; plain card otherwise). The four overview cards are wired to their pages: accounts → `/accounts`, sites → `/sites`, checkin → `/checkin`, proxy-24h → `/proxy-logs`. Closes PM #5 (cards were inert) + partially User #1 (dashboard glance → drill-in was manual sidebar navigation). Closes the #1 daily-ops friction point.
- **Credential export test-request link** — the credential-export dialog footer (which had only Cancel) gains a secondary "Send a test request" button (`Button render={<Link to='/model-tester' />}`, dismisses the dialog on click). Closes User #5 — the onboarding journey's final step ("make a test request") no longer dead-ends; the loop closes in-app. Adds `connect.testRequest` i18n key (en + zh-CN).

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] `bun run format:check` — green
- [x] `bun run test` — 503/503 across 57 files (500 baseline + 2 stat-card + 1 credential-export)
- [x] Independent re-ran `stat-card` (2/2) + `credential-export` (1/1) focused suites as暗卷 spot-checks

## Notes
- Two parallel worktrees (`feat-statcard-drilldown` + `feat-credential-test-link`), each self-verified, cherry-picked onto this batch branch (disjoint files — no conflicts). Verified no leakage into the main worktree.
- The stat-card `to` prop is opt-in — existing call sites that pass no `to` render the plain card unchanged.
- The credential-export test-request button is `variant='secondary'` (the copy/import actions above remain the primary affordance).