### PR TITLE
fix(ui): settings section nav collapses to chip strip below lg (audit P2 #6)

### DIFF
--- a/docs/analysis/ui-ux-audit-2026-08.md
+++ b/docs/analysis/ui-ux-audit-2026-08.md
@@ -69,7 +69,7 @@
 | 3   | 已交付 #757       | 文档漂移销项                              | DESIGN.md（9 vs 10 预设）、标题 400 vs 500           | 预设数、标题字重、状态色、图表栈和 CTA 对比度已对齐实现                 |
 | 4   | 已交付（代码）    | 圆角层级 / header 高度双来源              | `app-header.tsx`、`authenticated-layout.tsx`、`layout-error-boundary.tsx` | 圆角半 stale（`data-table-view` 已用 `rounded-lg` token，无双来源）；header 高度半已收口到单一 `--app-header-height` token + 删 2 处冗余 inline re-declaration + 静态守卫 `header-height-ssot.test.ts`（#824） |
 | 5   | 已交付（代码）    | 导入向导校验失败聚焦首错字段              | `import-wizard-dialog.tsx`                           | e1991ef 落地 `markInvalidAndFocusFirst` + `aria-invalid` + per-field clear，9 用例覆盖（`import-wizard-dialog.test.tsx`）；其他表单（`account-form-dialog.tsx` 等）仍为观察 |
-| 6   | 未承诺            | 移动端首帧侧栏 / settings 375px 导航      | `use-mobile.tsx` / `settings-sidebar.tsx`            | 审计观察，按复现证据再立项                                              |
+| 6   | 已交付          | 移动端首帧侧栏 / settings 375px 导航      | `use-mobile.tsx`、`settings-sidebar.tsx`           | 两半均收口：首帧闪烁 #712 已修（`useIsMobile` 改 `useSyncExternalStore`，首渲染同步取 matchMedia 真值）；settings section nav 在 <lg 降级为横向滚动 chip 条（原全宽垂直列表把内容挤出 375px 首屏），active 项补 `aria-current="page"`，6 个布局契约用例守卫 |
 | 7   | 已交付（代码）    | 骨架屏 shimmer / 表格骨架差异化           | `index.css`、`skeleton.tsx`、`table-skeleton.tsx`    | 唤醒休眠 `--skeleton-highlight` token（`.animate-shimmer` 渐变 + reduced-motion gate，替换 `animate-pulse`）；`table-skeleton` 按 `column.getSize()` 取宽替换固定百分比池；`no-gradients` allowlist 加 `index.css` 例外（#824） |
 | 8   | 部分交付 → MASTER | Playground 会话化 + 模板库 + 批量延迟对比 | `model-tester/`                                      | #662 已交付会话化 + 模板库；批量延迟对比由 MASTER Wave 2–3 接管         |
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,12 @@
 > Product milestone timeline (grouped by version). Not the current-state source of truth.
 > Current state → [`STATE.md`](STATE.md) · open items → [`progress/MASTER.md`](progress/MASTER.md) · detailed version narrative → root [`CHANGELOG.md`](../CHANGELOG.md)
 
+## 2026-08-18 — settings 375px 导航收口（audit P2 #6）
+
+- **核实 + 修复**：P2 #6 的「移动端首帧侧栏」半经核实为 stale（#712 已把 `useIsMobile` 改 `useSyncExternalStore`，首渲染同步取 matchMedia 真值，无桌面侧栏闪烁）；「settings 375px 导航」半为真——section nav 在 <lg 渲染为全宽垂直列表（system-info 等 5–7 项把首个 section 卡挤出首屏）。
+- **修复**：`settings-sidebar.tsx` 单 DOM 双形态——<lg 降级为单行横向滚动 chip 条（`overflow-x-auto` + `shrink-0`/`whitespace-nowrap`/`rounded-full`，组标题 `hidden lg:block`），lg+ 保留 sticky w-60 垂直栏；active 项补 `aria-current="page"`。
+- **验证**：新增 `settings-sidebar.test.tsx` 6 个布局契约用例（chip 条方向/溢出策略、桌面 sticky 契约、aria-current 深链归一）；tsgo 0 error · oxlint 0 error · oxfmt green · vitest 全绿 · knip exit 0 · production build pass。
+
 ## 2026-08-18 — UI/UX 批次：账户行内操作 + header SSOT + skeleton shimmer + 徽章机械迁移
 
 - **P2 #5 收口**：导入向导 focus-first-invalid 补 4 回归用例 + 2 处 `curly` lint 修复（#824）。

--- a/web/src/features/settings/__tests__/settings-sidebar.test.tsx
+++ b/web/src/features/settings/__tests__/settings-sidebar.test.tsx
@@ -42,7 +42,7 @@ vi.mock('@tanstack/react-router', () => ({
 }))
 
 function requireElement(container: HTMLElement, selector: string): HTMLElement {
-  const element = container.querySelector(selector)
+  const element = container.querySelector<HTMLElement>(selector)
   if (!element) throw new Error(`Expected element matching ${selector}`)
   return element
 }

--- a/web/src/features/settings/__tests__/settings-sidebar.test.tsx
+++ b/web/src/features/settings/__tests__/settings-sidebar.test.tsx
@@ -1,0 +1,166 @@
+// Layout contract tests for the settings section nav (audit P2 #6 closeout).
+//
+// Below `lg` the nav must degrade into a single-row horizontally scrollable
+// chip strip so it never buries the page content on a 375px viewport; at
+// `lg` and above it keeps the sticky vertical sidebar shape. Active state is
+// URL-derived (query string and trailing slashes ignored) and exposed as
+// `aria-current="page"`. Asserts stable DOM/class contracts only.
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { SettingsSidebar } from '../components/settings-sidebar'
+import type { SettingsSectionNavItem } from '../types'
+
+const locationState = vi.hoisted(() => ({
+  href: '/settings/general/authentication',
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    to,
+    children,
+    ...props
+  }: {
+    to?: unknown
+    children?: ReactNode
+  } & AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={String(to)} {...props}>
+      {children}
+    </a>
+  ),
+  useLocation: (options?: {
+    select?: (location: { href: string }) => unknown
+  }) => {
+    const location = { href: locationState.href }
+    return options?.select ? options.select(location) : location
+  },
+}))
+
+function requireElement(container: HTMLElement, selector: string): HTMLElement {
+  const element = container.querySelector(selector)
+  if (!element) throw new Error(`Expected element matching ${selector}`)
+  return element
+}
+
+const sections: SettingsSectionNavItem[] = [
+  {
+    title: 'Authentication',
+    url: '/settings/general/authentication',
+    group: 'settings.groups.account',
+  },
+  {
+    title: 'Notifications',
+    url: '/settings/general/notifications',
+    group: 'settings.groups.account',
+  },
+  {
+    title: 'Danger zone',
+    url: '/settings/general/danger',
+    readonly: true,
+  },
+]
+
+beforeEach(() => {
+  locationState.href = '/settings/general/authentication'
+})
+
+afterEach(() => cleanup())
+
+describe('SettingsSidebar', () => {
+  it('renders one link per section and keeps group labels in the DOM', () => {
+    render(<SettingsSidebar items={sections} title='General' />)
+
+    expect(
+      screen.getByRole('link', { name: /Authentication/ })
+    ).toHaveAttribute('href', '/settings/general/authentication')
+    expect(
+      screen.getByRole('link', { name: /Notifications/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /Danger zone/ })
+    ).toBeInTheDocument()
+    // Group labels stay in the DOM for the desktop layout; CSS hides them
+    // below lg rather than unmounting them.
+    expect(screen.getByText('General')).toBeInTheDocument()
+  })
+
+  it('marks the URL-derived active section with aria-current', () => {
+    render(<SettingsSidebar items={sections} />)
+
+    expect(
+      screen.getByRole('link', { name: /Authentication/ })
+    ).toHaveAttribute('aria-current', 'page')
+    expect(
+      screen.getByRole('link', { name: /Notifications/ })
+    ).not.toHaveAttribute('aria-current')
+  })
+
+  it('matches the active section ignoring query strings and trailing slashes', () => {
+    locationState.href = '/settings/general/notifications/?highlight=1'
+
+    render(<SettingsSidebar items={sections} />)
+
+    expect(screen.getByRole('link', { name: /Notifications/ })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+    expect(
+      screen.getByRole('link', { name: /Authentication/ })
+    ).not.toHaveAttribute('aria-current')
+  })
+
+  it('renders read-only sections with the read-only badge', () => {
+    render(<SettingsSidebar items={sections} />)
+
+    expect(screen.getByRole('link', { name: /Read-only/ })).toHaveTextContent(
+      'Danger zone'
+    )
+  })
+
+  it('collapses into a horizontal scrollable chip strip below lg', () => {
+    const { container } = render(
+      <SettingsSidebar items={sections} title='General' />
+    )
+
+    const nav = requireElement(container, 'nav')
+    // Mobile-first overflow contract: one row, horizontal scroll.
+    expect(nav.className).toContain('flex-row')
+    expect(nav.className).toContain('overflow-x-auto')
+
+    // Chips must not wrap or shrink, otherwise the strip reflows into a wall.
+    for (const link of screen.getAllByRole('link')) {
+      expect(link.className).toContain('whitespace-nowrap')
+      expect(link.className).toContain('shrink-0')
+      expect(link.className).toContain('rounded-full')
+    }
+
+    // Title and group labels collapse on mobile via hidden + lg:block while
+    // staying mounted for the desktop layout.
+    expect(screen.getByText('General').className).toContain('hidden')
+    expect(screen.getByText('General').className).toContain('lg:block')
+    expect(screen.getByText('settings.groups.account').className).toContain(
+      'hidden'
+    )
+  })
+
+  it('keeps the desktop sticky vertical sidebar contract', () => {
+    const { container } = render(<SettingsSidebar items={sections} />)
+
+    const aside = requireElement(container, 'aside')
+    expect(aside.className).toContain('lg:sticky')
+    expect(aside.className).toContain('lg:top-6')
+    expect(aside.className).toContain('lg:w-60')
+
+    const nav = requireElement(container, 'nav')
+    expect(nav.className).toContain('lg:flex-col')
+    for (const link of screen.getAllByRole('link')) {
+      expect(link.className).toContain('lg:w-full')
+      expect(link.className).toContain('lg:rounded-md')
+    }
+  })
+})

--- a/web/src/features/settings/components/settings-sidebar.tsx
+++ b/web/src/features/settings/components/settings-sidebar.tsx
@@ -1,13 +1,21 @@
 // metapi-go/features/settings — in-page section sidebar.
 //
-// Renders the current subarea's sections as a vertical nav. This is the
-// secondary navigation shown inside the Settings workspace: once the user has
-// drilled into a subarea (e.g. /settings/general), this sidebar lists that
-// subarea's sections and highlights the active one. It complements the main
-// app sidebar (which lists the 5 subareas themselves).
+// Renders the current subarea's sections as the secondary navigation inside
+// the Settings workspace: once the user has drilled into a subarea (e.g.
+// /settings/general), this nav lists that subarea's sections and highlights
+// the active one. It complements the main app sidebar (which lists the 5
+// subareas themselves).
 //
-// Active-state is derived from the live URL so the sidebar stays correct
-// across browser back/forward and direct deep links.
+// Responsive contract (audit P2 #6 closeout): at `lg` and above this is the
+// classic sticky vertical sidebar (w-60); below `lg` the same DOM degrades
+// into a single-row horizontally scrollable chip strip so the section nav
+// never buries the page content on a 375px viewport (a full-height vertical
+// list pushed the first section card below the fold). Group labels collapse
+// on mobile — chips are self-explanatory and labels would add scroll noise.
+//
+// Active-state is derived from the live URL so the nav stays correct across
+// browser back/forward and direct deep links; the active link additionally
+// exposes `aria-current="page"`.
 
 import { Link, useLocation } from '@tanstack/react-router'
 import { useMemo } from 'react'
@@ -19,7 +27,7 @@ import type { SettingsSectionNavItem } from '../types'
 
 type SettingsSidebarProps = {
   items: SettingsSectionNavItem[]
-  /** Optional group label rendered above the section list. */
+  /** Optional group label rendered above the section list (desktop only). */
   title?: string
 }
 
@@ -41,19 +49,19 @@ export function SettingsSidebar({ items, title }: SettingsSidebarProps) {
 
   return (
     <aside className='w-full shrink-0 lg:sticky lg:top-6 lg:w-60'>
-      <nav className='flex flex-col gap-1'>
+      <nav className='flex flex-row gap-1 overflow-x-auto lg:flex-col lg:overflow-visible'>
         {title ? (
-          <p className='text-muted-foreground/70 px-3 pb-2 text-[11px] font-medium tracking-wider uppercase'>
+          <p className='text-muted-foreground/70 hidden px-3 pb-2 text-[11px] font-medium tracking-wider uppercase lg:block'>
             {title}
           </p>
         ) : null}
         {groups.map(([groupKey, groupItems]) => (
           <div
             key={groupKey ?? '__ungrouped__'}
-            className='flex flex-col gap-1'
+            className='flex shrink-0 flex-row gap-1 lg:flex-col'
           >
             {groupKey ? (
-              <p className='text-muted-foreground/75 px-3 pt-2 pb-1 text-[11px] font-medium tracking-wider uppercase'>
+              <p className='text-muted-foreground/75 hidden px-3 pt-2 pb-1 text-[11px] font-medium tracking-wider uppercase lg:block'>
                 {t(groupKey)}
               </p>
             ) : null}
@@ -64,14 +72,15 @@ export function SettingsSidebar({ items, title }: SettingsSidebarProps) {
                 <Link
                   key={String(item.url)}
                   to={item.url}
+                  aria-current={isActive ? 'page' : undefined}
                   className={cn(
-                    'flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
+                    'flex shrink-0 items-center gap-2 rounded-full px-3 py-1.5 text-sm whitespace-nowrap transition-colors lg:w-full lg:rounded-md lg:py-2 lg:whitespace-normal',
                     isActive
                       ? 'bg-accent font-medium text-accent-foreground'
                       : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
                   )}
                 >
-                  <span className='min-w-0 flex-1 truncate'>
+                  <span className='min-w-0 truncate lg:flex-1'>
                     {t(item.title)}
                   </span>
                   {item.readonly ? (


### PR DESCRIPTION
## Summary

- Closes the real half of audit P2 #6: below lg the settings section sidebar rendered as a full-width vertical list stacked above the content, so on a 375px viewport the 5-7 section links pushed the first section card below the fold on every settings page. The nav now degrades into a single-row horizontally scrollable chip strip on the same DOM (overflow-x-auto + shrink-0/whitespace-nowrap/rounded-full links; group labels collapse via hidden lg:block); the lg+ sticky w-60 vertical sidebar is unchanged.
- The first half of P2 #6 (mobile first-frame sidebar flash) was verified stale — useIsMobile has used useSyncExternalStore since #712, so the first client render is already correct; audit row updated accordingly.
- A11y: the URL-derived active link gains aria-current=page (previously class-only).
- 6 layout-contract tests (settings-sidebar.test.tsx): chip-strip direction + overflow policy, desktop sticky contract, aria-current with query-string/trailing-slash normalization, readonly badge.

Gates: typecheck 0 error, lint 0 error, format:check green, vitest 509/509, knip exit 0, production build pass.

## Test plan

- [x] New layout-contract tests: 6/6 green; full suite 509/509
- [x] Typecheck / lint / format / knip / production build green
- [ ] Visual check at 375px (dev tools): Settings > System & Maintenance shows one swipeable chip row, first section card visible in the first viewport; at >=1024px the sticky vertical sidebar is unchanged; active chip/row highlighted with aria-current