### PR TITLE
fix(proxy-logs,settings): server-side list filters + edge-state hardening

### DIFF
--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -523,7 +523,15 @@ func (h *statsHandler) dashboardError(w http.ResponseWriter, operation string, e
 }
 
 // ---- Proxy Logs ----
-// GET /api/stats/proxy-logs?view=&limit=&offset=&status=&search=&client=&siteId=&from=&to=
+// GET /api/stats/proxy-logs?view=&limit=&offset=&status=&search=&client=&siteId=&from=&to=&latencyMin=&latencyMax=
+//
+// All list filters (status/search/client/siteId/from/to/latencyMin/latencyMax)
+// are applied SERVER-SIDE so that items, total, and summary share one
+// `where`/`args` slice and never disagree (the previous client-side latency
+// filter produced a wrong `total` + broken manualPagination). The `client`
+// param matches `client_family` exactly; `from`/`to` compare against
+// `created_at` (RFC3339 TEXT, lexicographic compare is correct); latency
+// bounds compare against `latency_ms` (INTEGER).
 func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 	view := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("view")))
 	if view != "query" && view != "meta" {
@@ -535,6 +543,11 @@ func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 	status := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("status")))
 	search := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("search")))
 	siteID := getQueryInt(r, "siteId", 0)
+	client := strings.TrimSpace(r.URL.Query().Get("client"))
+	from := strings.TrimSpace(r.URL.Query().Get("from"))
+	to := strings.TrimSpace(r.URL.Query().Get("to"))
+	latencyMin := getQueryInt(r, "latencyMin", 0)
+	latencyMax := getQueryInt(r, "latencyMax", 0)
 
 	var conditions []string
 	var args []any
@@ -552,6 +565,35 @@ func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 	if siteID > 0 {
 		conditions = append(conditions, "s.id = ?")
 		args = append(args, siteID)
+	}
+	// client filters on the upstream client family detected from the
+	// User-Agent (e.g. "openai-node"). Exact match: the dropdown sends a
+	// discrete value from clientOptions, not a free-text substring.
+	if client != "" {
+		conditions = append(conditions, "pl.client_family = ?")
+		args = append(args, client)
+	}
+	// from/to bound created_at (RFC3339 TEXT). Lexicographic ordering of
+	// RFC3339 strings is chronological, so `>=` / `<=` compare correctly
+	// without parsing to a datetime type — matches how rows are inserted
+	// (time.Now().UTC().Format(time.RFC3339) in handler/proxy/proxy_log.go).
+	if from != "" {
+		conditions = append(conditions, "pl.created_at >= ?")
+		args = append(args, from)
+	}
+	if to != "" {
+		conditions = append(conditions, "pl.created_at <= ?")
+		args = append(args, to)
+	}
+	// latency_ms bounds for the "Slow only" filter. 0 means unset (the
+	// frontend sends null/undefined → omitted from the query string).
+	if latencyMin > 0 {
+		conditions = append(conditions, "pl.latency_ms >= ?")
+		args = append(args, latencyMin)
+	}
+	if latencyMax > 0 {
+		conditions = append(conditions, "pl.latency_ms <= ?")
+		args = append(args, latencyMax)
 	}
 
 	var where string

--- a/handler/admin/stats_proxy_logs_filters_test.go
+++ b/handler/admin/stats_proxy_logs_filters_test.go
@@ -1,0 +1,214 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// seedProxyLogsForFilterTests inserts three proxy_logs rows with distinct
+// latency_ms / client_family / created_at values so that every list filter
+// (latencyMin, latencyMax, client, from, to) has at least one matching and
+// one non-matching row. The rows are standalone (no account_id) — the LEFT
+// JOINs in the handler yield NULL site/user fields, which is fine for filter
+// assertions. Returns the three created_at timestamps in RFC3339 form.
+//
+// Row A: latency 3000, client "openai-node",   created_at = t3 (latest)
+// Row B: latency  500, client "anthropic-sdk", created_at = t2 (middle)
+// Row C: latency 2500, client "openai-node",   created_at = t1 (earliest)
+func seedProxyLogsForFilterTests(t *testing.T, db *store.DB) (t1, t2, t3 string) {
+	t.Helper()
+	t1 = "2026-01-01T01:00:00Z"
+	t2 = "2026-01-01T02:00:00Z"
+	t3 = "2026-01-01T03:00:00Z"
+	rows := []struct {
+		model        string
+		latencyMs    int
+		clientFamily string
+		createdAt    string
+	}{
+		{"slow-A", 3000, "openai-node", t3},
+		{"fast-B", 500, "anthropic-sdk", t2},
+		{"slow-C", 2500, "openai-node", t1},
+	}
+	for _, row := range rows {
+		if _, err := db.Exec(`INSERT INTO proxy_logs (model_requested, model_actual, status, latency_ms, client_family, created_at)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+			row.model, row.model, "success", row.latencyMs, row.clientFamily, row.createdAt); err != nil {
+			t.Fatalf("insert %s: %v", row.model, err)
+		}
+	}
+	return t1, t2, t3
+}
+
+// proxyLogsFilterResponse captures just the list-page fields the filter
+// tests assert on. Decoding into a typed struct is more robust than
+// map[string]any when checking nested summary counts.
+type proxyLogsFilterResponse struct {
+	Items   []map[string]any `json:"items"`
+	Total   int              `json:"total"`
+	Summary struct {
+		TotalCount int `json:"totalCount"`
+	} `json:"summary"`
+}
+
+func fetchProxyLogsFiltered(t *testing.T, r chi.Router, query string) proxyLogsFilterResponse {
+	t.Helper()
+	resp := doGet(t, r, "/api/stats/proxy-logs?view=full&"+query)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("GET /api/stats/proxy-logs?%s status=%d body=%s", query, resp.Code, resp.Body.String())
+	}
+	var body proxyLogsFilterResponse
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal %s: %v", query, err)
+	}
+	return body
+}
+
+// modelSet extracts the distinct model_requested values from the response
+// items for concise assertion comparisons.
+func modelSet(items []map[string]any) map[string]struct{} {
+	out := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		if model, ok := item["modelRequested"].(string); ok {
+			out[model] = struct{}{}
+		}
+	}
+	return out
+}
+
+func TestStats_SQLiteProxyLogsLatencyMinFilter(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedProxyLogsForFilterTests(t, db)
+
+	// latencyMin=2000 (the "Slow only" preset): rows A (3000) + C (2500)
+	// match; row B (500) is filtered out. items, total, AND summary must
+	// agree — this is the core regression: previously `total` used the
+	// unfiltered count while items were client-side filtered.
+	body := fetchProxyLogsFiltered(t, r, "latencyMin=2000")
+	if body.Total != 2 {
+		t.Fatalf("latencyMin=2000 total=%d, want 2", body.Total)
+	}
+	if len(body.Items) != 2 {
+		t.Fatalf("latencyMin=2000 items=%d, want 2", len(body.Items))
+	}
+	if body.Summary.TotalCount != 2 {
+		t.Fatalf("latencyMin=2000 summary.totalCount=%d, want 2", body.Summary.TotalCount)
+	}
+	got := modelSet(body.Items)
+	if _, ok := got["slow-A"]; !ok {
+		t.Fatalf("latencyMin=2000 missing slow-A in items: %v", got)
+	}
+	if _, ok := got["slow-C"]; !ok {
+		t.Fatalf("latencyMin=2000 missing slow-C in items: %v", got)
+	}
+}
+
+func TestStats_SQLiteProxyLogsLatencyMaxFilter(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedProxyLogsForFilterTests(t, db)
+
+	// latencyMax=1000: only row B (500) matches.
+	body := fetchProxyLogsFiltered(t, r, "latencyMax=1000")
+	if body.Total != 1 {
+		t.Fatalf("latencyMax=1000 total=%d, want 1", body.Total)
+	}
+	if len(body.Items) != 1 {
+		t.Fatalf("latencyMax=1000 items=%d, want 1", len(body.Items))
+	}
+	got := modelSet(body.Items)
+	if _, ok := got["fast-B"]; !ok {
+		t.Fatalf("latencyMax=1000 expected fast-B, got %v", got)
+	}
+}
+
+func TestStats_SQLiteProxyLogsLatencyRangeFilter(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedProxyLogsForFilterTests(t, db)
+
+	// Both bounds: latencyMin=2000&latencyMax=3000 → rows A (3000) + C (2500).
+	// Row A is exactly at the max boundary (inclusive, `<=`).
+	body := fetchProxyLogsFiltered(t, r, "latencyMin=2000&latencyMax=3000")
+	if body.Total != 2 {
+		t.Fatalf("latency range total=%d, want 2", body.Total)
+	}
+	if len(body.Items) != 2 {
+		t.Fatalf("latency range items=%d, want 2", len(body.Items))
+	}
+}
+
+func TestStats_SQLiteProxyLogsClientFilter(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedProxyLogsForFilterTests(t, db)
+
+	// client=openai-node matches rows A + C; row B (anthropic-sdk) excluded.
+	body := fetchProxyLogsFiltered(t, r, "client=openai-node")
+	if body.Total != 2 {
+		t.Fatalf("client=openai-node total=%d, want 2", body.Total)
+	}
+	if len(body.Items) != 2 {
+		t.Fatalf("client=openai-node items=%d, want 2", len(body.Items))
+	}
+	if body.Summary.TotalCount != 2 {
+		t.Fatalf("client=openai-node summary.totalCount=%d, want 2", body.Summary.TotalCount)
+	}
+	got := modelSet(body.Items)
+	if _, ok := got["fast-B"]; ok {
+		t.Fatalf("client=openai-node should NOT include fast-B: %v", got)
+	}
+}
+
+func TestStats_SQLiteProxyLogsFromToFilters(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	_, t2, t3 := seedProxyLogsForFilterTests(t, db)
+
+	// from=t2&to=t3 → rows A (t3) + B (t2) match; row C (t1) is before the
+	// window. RFC3339 strings compare lexicographically, so `>=` / `<=` are
+	// chronologically correct (the column stores time.Now().UTC().Format
+	// (RFC3339) per handler/proxy/proxy_log.go).
+	body := fetchProxyLogsFiltered(t, r, "from="+t2+"&to="+t3)
+	if body.Total != 2 {
+		t.Fatalf("from/to total=%d, want 2", body.Total)
+	}
+	if len(body.Items) != 2 {
+		t.Fatalf("from/to items=%d, want 2", len(body.Items))
+	}
+	got := modelSet(body.Items)
+	if _, ok := got["slow-C"]; ok {
+		t.Fatalf("from/to should NOT include slow-C (before window): %v", got)
+	}
+
+	// Lower bound only: from=t2 → rows A (t3) + B (t2), excludes C (t1).
+	bodyFrom := fetchProxyLogsFiltered(t, r, "from="+t2)
+	if bodyFrom.Total != 2 {
+		t.Fatalf("from=t2 total=%d, want 2", bodyFrom.Total)
+	}
+
+	// Upper bound only: to=t2 → rows B (t2) + C (t1), excludes A (t3).
+	bodyTo := fetchProxyLogsFiltered(t, r, "to="+t2)
+	if bodyTo.Total != 2 {
+		t.Fatalf("to=t2 total=%d, want 2", bodyTo.Total)
+	}
+	gotTo := modelSet(bodyTo.Items)
+	if _, ok := gotTo["slow-A"]; ok {
+		t.Fatalf("to=t2 should NOT include slow-A (after window): %v", gotTo)
+	}
+}
+
+func TestStats_SQLiteProxyLogsCombinedFilters(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedProxyLogsForFilterTests(t, db)
+
+	// client=openai-node AND latencyMin=2000 → rows A + C (both openai-node
+	// AND latency >= 2000). Row B is both wrong client and too fast.
+	body := fetchProxyLogsFiltered(t, r, "client=openai-node&latencyMin=2000")
+	if body.Total != 2 {
+		t.Fatalf("combined total=%d, want 2", body.Total)
+	}
+	if len(body.Items) != 2 {
+		t.Fatalf("combined items=%d, want 2", len(body.Items))
+	}
+}

--- a/web/src/features/proxy-logs/__tests__/proxy-logs-query-payload.test.tsx
+++ b/web/src/features/proxy-logs/__tests__/proxy-logs-query-payload.test.tsx
@@ -1,0 +1,150 @@
+// Behavior test for the useProxyLogs query payload. Mocks the shared
+// axios instance (http-client) so the real `request()` transport runs end
+// to end and the request URL can be inspected — asserting the latency
+// bounds added to ProxyLogsQuery are serialized server-side.
+//
+// The original bug kept `latencyMin`/`latencyMax` OUT of the page's query
+// payload (filtering client-side), so `total` (server, unfiltered) and
+// `items` (client, filtered) disagreed. This test guards the type +
+// transport contract: once latency is on ProxyLogsQuery, useProxyLogs
+// forwards it to the request URL.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ProxyLogsQuery } from '@/lib/api'
+
+import { useProxyLogs } from '../api'
+
+const { mockApiClientGet } = vi.hoisted(() => ({
+  // capture stub for `apiClient.get(url, config)` — the JSON GET path used
+  // by `request()` in lib/api/transport.ts. Resolves to an empty-but-valid
+  // ProxyLogsResponse so the query succeeds and the URL is inspectable.
+  mockApiClientGet: vi.fn(),
+}))
+
+vi.mock('@/lib/http-client', () => ({
+  apiClient: {
+    get: mockApiClientGet,
+    request: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    patch: vi.fn(),
+  },
+  fetchAuthenticatedResponse: vi.fn(),
+  extractResponseErrorMessage: vi.fn(),
+}))
+
+const EMPTY_PROXY_LOGS_RESPONSE = {
+  items: [],
+  total: 0,
+  page: 1,
+  pageSize: 20,
+  clientOptions: [],
+  summary: {
+    totalCount: 0,
+    successCount: 0,
+    failedCount: 0,
+    totalCost: 0,
+    totalTokensAll: 0,
+  },
+  sites: [],
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0, refetchOnWindowFocus: false },
+    },
+  })
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+beforeEach(() => {
+  mockApiClientGet.mockReset()
+  mockApiClientGet.mockResolvedValue({ data: EMPTY_PROXY_LOGS_RESPONSE })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+// firstRequestedUrl returns the URL of the first apiClient.get call,
+// throwing if no call was made. Avoids non-null assertions while keeping
+// the assertions readable; the caller has already waitFor'd the call.
+function firstRequestedUrl(): string {
+  const url = mockApiClientGet.mock.calls[0]?.[0]
+  if (typeof url !== 'string') {
+    throw new Error('expected apiClient.get to have been called once')
+  }
+  return url
+}
+
+describe('useProxyLogs — latency filter payload', () => {
+  it('serializes latencyMin and latencyMax into the request URL when set', async () => {
+    const params: ProxyLogsQuery = {
+      limit: 20,
+      offset: 0,
+      latencyMin: 2000,
+      latencyMax: 4000,
+    }
+    const queryClient = createQueryClient()
+    renderHook(() => useProxyLogs(params), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => {
+      expect(mockApiClientGet).toHaveBeenCalledTimes(1)
+    })
+
+    const requestedUrl = firstRequestedUrl()
+    expect(requestedUrl).toContain('/api/stats/proxy-logs')
+    expect(requestedUrl).toContain('latencyMin=2000')
+    expect(requestedUrl).toContain('latencyMax=4000')
+  })
+
+  it('omits latency bounds from the URL when they are null/undefined', async () => {
+    const params: ProxyLogsQuery = { limit: 20, offset: 0 }
+    const queryClient = createQueryClient()
+    renderHook(() => useProxyLogs(params), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => {
+      expect(mockApiClientGet).toHaveBeenCalledTimes(1)
+    })
+
+    const requestedUrl = firstRequestedUrl()
+    expect(requestedUrl).not.toContain('latencyMin')
+    expect(requestedUrl).not.toContain('latencyMax')
+  })
+
+  it('serializes latencyMin alone (the "Slow only" preset, latencyMax unset)', async () => {
+    const params: ProxyLogsQuery = { limit: 20, offset: 0, latencyMin: 2000 }
+    const queryClient = createQueryClient()
+    renderHook(() => useProxyLogs(params), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => {
+      expect(mockApiClientGet).toHaveBeenCalledTimes(1)
+    })
+
+    const requestedUrl = firstRequestedUrl()
+    expect(requestedUrl).toContain('latencyMin=2000')
+    // latencyMax must NOT be emitted when unset — buildQueryString drops
+    // undefined/null/empty so the URL stays minimal.
+    expect(requestedUrl).not.toContain('latencyMax')
+  })
+})

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -177,8 +177,22 @@ export function ProxyLogsPage() {
       client: client || undefined,
       from: from || undefined,
       to: to || undefined,
+      // Latency bounds are sent to the server so total + summary agree with
+      // the returned items (manualPagination relies on the server total).
+      latencyMin: latencyMin ?? undefined,
+      latencyMax: latencyMax ?? undefined,
     }),
-    [pagination, status, globalFilter, siteId, client, from, to]
+    [
+      pagination,
+      status,
+      globalFilter,
+      siteId,
+      client,
+      from,
+      to,
+      latencyMin,
+      latencyMax,
+    ]
   )
 
   const metaPayload = useMemo(
@@ -189,6 +203,8 @@ export function ProxyLogsPage() {
       client: queryPayload.client,
       from: queryPayload.from,
       to: queryPayload.to,
+      latencyMin: queryPayload.latencyMin,
+      latencyMax: queryPayload.latencyMax,
     }),
     [queryPayload]
   )
@@ -200,16 +216,9 @@ export function ProxyLogsPage() {
   const rawItems = useMemo(() => logsQuery.data?.items ?? [], [logsQuery.data])
   const total = logsQuery.data?.total ?? 0
 
-  const items = useMemo(() => {
-    if (latencyMin === null && latencyMax === null) return rawItems
-    return rawItems.filter((log) => {
-      const latency = log.latencyMs
-      if (typeof latency !== 'number' || latency < 0) return false
-      if (latencyMin !== null && latency < latencyMin) return false
-      if (latencyMax !== null && latency > latencyMax) return false
-      return true
-    })
-  }, [rawItems, latencyMin, latencyMax])
+  // The server now applies the latency filter, so the page items are used
+  // directly — no client-side re-filter that would desync from `total`.
+  const items = rawItems
 
   // Memoized so the column defs keep a stable identity across renders.
   const columnActions = useMemo<ProxyLogsColumnActions>(

--- a/web/src/features/settings/sections/downstream/components/keys-section.tsx
+++ b/web/src/features/settings/sections/downstream/components/keys-section.tsx
@@ -59,6 +59,7 @@ import {
   SettingsSectionCard,
   SettingsSectionSkeleton,
 } from '../../../components/settings-section-card'
+import { SettingsSectionError } from '../../../components/settings-section-error'
 
 type DownstreamApiKeyItem = {
   id: number
@@ -218,12 +219,23 @@ export function KeysSection() {
       }
     >
       {isLoading ? <SettingsSectionSkeleton /> : null}
-      {!isLoading && items.length === 0 ? (
-        <p className='text-muted-foreground py-8 text-center text-sm'>
-          {t('settings.downstream.keys.empty')}
-        </p>
+      {keysQuery.isError ? (
+        <SettingsSectionError
+          title={t('settings.downstream.keys.title')}
+          onRetry={() => void keysQuery.refetch()}
+        />
       ) : null}
-      {!isLoading && items.length > 0 ? (
+      {!isLoading && !keysQuery.isError && items.length === 0 ? (
+        <div className='flex flex-col items-center gap-3 py-8'>
+          <p className='text-muted-foreground text-sm'>
+            {t('settings.downstream.keys.empty')}
+          </p>
+          <Button size='sm' onClick={() => onCreateOpenChange(true)}>
+            {t('settings.downstream.keys.create')}
+          </Button>
+        </div>
+      ) : null}
+      {!isLoading && !keysQuery.isError && items.length > 0 ? (
         <Table>
           <TableHeader>
             <TableRow>
@@ -267,10 +279,14 @@ export function KeysSection() {
                 <TableCell>
                   <Switch
                     checked={item.enabled}
+                    disabled={toggleMutation.isPending}
                     onCheckedChange={(checked) =>
                       toggleMutation.mutate({ id: item.id, enabled: checked })
                     }
-                    aria-label={t('settings.downstream.keys.columns.enabled')}
+                    aria-label={t(
+                      'settings.downstream.keys.columns.enabledAria',
+                      { name: item.name }
+                    )}
                   />
                 </TableCell>
                 <TableCell className='text-muted-foreground text-xs'>

--- a/web/src/features/settings/sections/system-info/components/update-center-section.tsx
+++ b/web/src/features/settings/sections/system-info/components/update-center-section.tsx
@@ -15,6 +15,7 @@ import {
   SettingsSectionCard,
   SettingsSectionSkeleton,
 } from '../../../components/settings-section-card'
+import { SettingsSectionError } from '../../../components/settings-section-error'
 
 type UpdateCenterStatus = {
   currentVersion?: string
@@ -53,6 +54,15 @@ export function UpdateCenterSection() {
       ? status.latestVersion
       : undefined
   const hasComparableVersions = Boolean(currentVersion && latestVersion)
+
+  if (statusQuery.isError) {
+    return (
+      <SettingsSectionError
+        title={t('settings.systemInfo.updateCenter.title')}
+        onRetry={() => void statusQuery.refetch()}
+      />
+    )
+  }
 
   return (
     <SettingsSectionCard

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -886,6 +886,7 @@
             "name": "Name",
             "group": "Group",
             "enabled": "Enabled",
+            "enabledAria": "Toggle enabled for {{name}}",
             "usage": "Usage",
             "actions": "Actions"
           },

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -886,6 +886,7 @@
             "name": "名称",
             "group": "分组",
             "enabled": "状态",
+            "enabledAria": "切换 {{name}} 的启用状态",
             "usage": "用量",
             "actions": "操作"
           },

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -485,6 +485,10 @@ export type ProxyLogsQuery = {
   siteId?: number
   from?: string
   to?: string
+  // Latency bounds (ms) for the "Slow only" filter. Applied server-side so
+  // total + summary agree with the returned items (no client-side re-filter).
+  latencyMin?: number | null
+  latencyMax?: number | null
 }
 
 type ProxyLogClientOption = {


### PR DESCRIPTION
## Summary

Two disjoint slices fixing real UX-affecting gaps found in the 2026-08-18 multi-perspective review.

### 1. Proxy-logs list filters moved server-side (functional bug)

The "Slow only" latency filter was applied **client-side to the current page only** while `total`/`manualPagination` used the server's unfiltered count → broken pagination + wrong total (a page claiming "20 of 5000" showing 2 items). Worse: a read-only scope confirmed the backend handler's WHERE builder **also silently no-op'd the `client`/`from`/`to` filters** (advertised in the docstring, never applied). All 5 filters are now server-side in the shared `where`/`args` slice (`statsHandler.proxyLogs`, `handler/admin/stats.go`) so items + count + summary agree:

- `latencyMin`/`latencyMax` → `pl.latency_ms >= ?` / `pl.latency_ms <= ?`
- `client` → `pl.client_family = ?`
- `from`/`to` → `pl.created_at >= ?` / `pl.created_at <= ?` (RFC3339 TEXT, lexicographic compare is correct)

All predicates mirror the existing `siteID`/`search` pattern + ride `rebindAdminQuery` for dual-dialect safety (no schema change; `latency_ms` + `client_family` + `created_at` columns already exist). Frontend: added `latencyMin`/`latencyMax` to `ProxyLogsQuery` + `queryPayload` + `metaPayload`; **removed** the client-side `items` filter memo (`items = rawItems` now — the server filters).

### 2. Settings edge-state hardening (error/empty/pending/a11y)

Four S fixes in the settings feature:
- `keys-section.tsx`: `keysQuery` failure now renders `SettingsSectionError` (retry) instead of masquerading as the "no keys" empty state.
- `keys-section.tsx`: per-row enable `Switch` now `disabled` while `toggleMutation.isPending` (prevents rapid double-click duplicate mutations) + unique `aria-label` via new `settings.downstream.keys.columns.enabledAria` i18n key (EN: "Toggle enabled for {{name}}", zh-CN: "切换 {{name}} 的启用状态") — screen readers can distinguish rows.
- `keys-section.tsx`: empty state gains an inline "Create key" button (co-located with the empty state, not just the header).
- `update-center-section.tsx`: `statusQuery` failure now renders `SettingsSectionError` instead of a calm "version: unknown".

## Test plan
- [x] `go build ./cmd/server` + `go vet ./...` — clean
- [x] `go test ./handler/admin/...` — incl. 6 NEW backend tests (latencyMin/max, range, client, from/to bounds, combined — each asserts items + total + summary agree)
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors
- [x] `bun run format:check` — green
- [x] `bun run test` — 506/506 across 58 files (incl. 3 NEW frontend payload tests asserting latency serialization)
- [x] Independent re-ran the Go handler tests (ok, 13.8s) + the settings keys tests (4/4) as暗卷 spot-checks

## Notes
- Two parallel worktrees (`fix-proxy-logs-filters` + `fix-settings-edge-state`), each self-verified, cherry-picked onto this batch branch (disjoint files — no conflicts). Verified no leakage into the main worktree.
- Did NOT touch badge-feature files (accounts/checkin/routes/channels columns) — a parallel process owns those.
- The proxy-logs `client` dropdown options still populate from a meta endpoint that returns `[]` (out of scope — the `client` filter is now honored when sent; populating the dropdown is a separate change).