### PR TITLE
chore(docs): verify a11y residuals — axe clean + Esc dismissal pinned

### DIFF
--- a/docs/design/a11y-checklist.md
+++ b/docs/design/a11y-checklist.md
@@ -3,7 +3,7 @@
 **Product**: Metapi admin
 **Scope**: accessibility checklist
 **Related source of truth**: `docs/design/DESIGN.md`, `web/src/styles/theme.css`
-**Last updated**: 2026-08-16
+**Last updated**: 2026-08-18
 **Status**: living acceptance checklist; known limitations are documented, not an implicit backlog
 
 This document records keyboard, name, contrast, and responsive expectations. Known limitations are evidence only unless promoted to [`../progress/MASTER.md`](../progress/MASTER.md) or a scoped GitHub issue.
@@ -18,6 +18,7 @@ This document records keyboard, name, contrast, and responsive expectations. Kno
 | `aria-label` on icon-only controls       | **pass for chrome**          | Topbar icon buttons labeled; mobile nav open/close labeled; SearchModal close labeled; sidebar collapse labeled when icon-only. Page action grids still have mixed coverage (debt). |
 | Contrast notes for primary text/surfaces | **documented**               | §4 below; body primary ≥ 4.5:1 both themes; muted/meta may fall near threshold.                                                                                                     |
 | Responsive checklist 375 / 768 / 1280    | **documented + shell pass**  | §5; shell breakpoints via `useIsMobile` (~768) and CSS media queries; no wholesale page redesign.                                                                                   |
+| axe-core live scan (authenticated routes)| **pass**                     | 2026-08-18 `bun run a11y:scan`: 15 routes (dashboard/models/sites/accounts/checkin/token-routes/proxy-logs/oauth/about/settings ×6), 0 serious/critical violations.              |
 | Residual a11y debt documented            | **yes**                      | §7                                                                                                                                                                                  |
 
 ---
@@ -29,11 +30,10 @@ This document records keyboard, name, contrast, and responsive expectations. Kno
 | Step                                    | Expected behavior                                                             | Current                |
 | --------------------------------------- | ----------------------------------------------------------------------------- | ---------------------- |
 | Login                                   | Tab: theme tools → token field → submit → external GitHub link; Enter submits | Pass                   |
-| Authenticated topbar                    | Tab order: mobile hamburger (if any) → language → search → theme → avatar     | Pass                   |
+| Authenticated topbar                    | Tab order: mobile hamburger (if any) → language → appearance → theme toggle → search | Pass            |
 | Search (`Ctrl/Cmd+K` or search trigger) | Focus moves to search input on open; Esc closes                               | Pass                   |
 | Mobile nav                              | Hamburger opens drawer; Esc / backdrop / close button dismisses               | Pass                   |
 | Sidebar collapse (desktop)              | Button remains focusable when collapsed (icon-only)                           | Pass after aria fix    |
-| Profile modal                           | Esc + explicit close when enabled; cancel/save in footer                      | Pass (`CenteredModal`) |
 
 ### 2.2 Focus visibility
 
@@ -53,7 +53,7 @@ This document records keyboard, name, contrast, and responsive expectations. Kno
 | Search modal         | Esc exits; Tab cycles within modal                          | **Pass** — `useFocusTrap` on panel |
 | Centered modal       | Esc optional via `closeOnEscape`; close button always named | **Pass** — trap + dialog name      |
 | Mobile drawer        | Esc exits; role=`dialog` + `aria-modal`                     | **Pass** — trap on panel           |
-| Theme/user dropdowns | Click-outside closes; Esc residual                          | Residual (non-modal menus)         |
+| Theme/user dropdowns | Esc dismisses non-modal menus                               | **Pass** (2026-08-18) — Base UI `DropdownMenu`/`Popover` close on Esc natively; pinned by `interface-controls.test.tsx` (language menu + appearance popover) |
 
 ### 2.4 Focus order anti-patterns (do not introduce)
 
@@ -75,7 +75,6 @@ This document records keyboard, name, contrast, and responsive expectations. Kno
 | Language toggle          | bilingual explicit labels            | `web/src/components/layout/components/app-header.tsx`  |
 | Search trigger           | `搜索 (Ctrl+K)`                      | `web/src/components/layout/components/app-header.tsx`  |
 | Theme menu trigger       | mode label (+ resolved system theme) | `web/src/components/layout/components/app-header.tsx`  |
-| Avatar menu              | display name                         | `web/src/components/layout/components/app-header.tsx`  |
 | Sidebar item (collapsed) | item label                           | `web/src/components/layout/components/app-sidebar.tsx` |
 | Sidebar collapse         | `收起侧边栏` / `展开侧边栏`          | `web/src/components/layout/components/app-sidebar.tsx` |
 | Mobile drawer close      | `关闭导航` (or `closeLabel`)         | `web/src/components/ui/sheet.tsx`                      |
@@ -83,6 +82,10 @@ This document records keyboard, name, contrast, and responsive expectations. Kno
 | Search modal close       | `关闭`                               | `web/src/components/ui/command.tsx`                    |
 | Login GitHub icon link   | `GitHub`                             | `web/src/features/auth/components/login-form.tsx`      |
 | Login theme tools group  | `外观设置`                           | `web/src/features/auth/components/login-form.tsx`      |
+
+> 2026-08-18 hygiene: the historical `Avatar menu` row was removed — the
+> current header ships no avatar/account menu (auth is token-based), so
+> there is no control to name.
 
 ### 3.2 Shared component rules
 
@@ -204,10 +207,9 @@ Breakpoints used by product:
 This section lists open residuals only. Closure history lives in [`../log.md`](../log.md) and root [`../../CHANGELOG.md`](../../CHANGELOG.md). Open work is committed through [`../progress/MASTER.md`](../progress/MASTER.md) or a scoped issue.
 
 1. **Charts keyboard series access** — recharts renders series as non-focusable SVG; assistive tech relies on the text axes, legends, and rich text tooltips (balance/cost, accounts, calls, tokens, share) that already carry the data. Non-color status encoding (text labels on availability buckets, attention badges) is in place; no color-only status.
-2. **Theme/user dropdown Esc** — non-modal menus close on click-outside; Esc dismissal is residual (modal surfaces already trap + close on Esc).
-3. **Global focus-ring utility** — chrome controls share the `--ring` recipe; a single shared rule for every page-level action grid is not yet in place (`.modal-close-button:focus-visible` uses a primary outline).
-4. **Hex hygiene** — no new brand hex is allowed in pages (see [`DESIGN.md`](./DESIGN.md) §1 Principles). Existing brand assets and other justified exceptions are reviewed when their owning surface changes; this is not a standalone sweep.
-5. **Preset contrast (audit-only)** — the default theme passes AA/AAA; user-chosen presets are explicit choices and out of scope. Underground/rose-garden/sunset-glow pass with white; forest-whisper, ocean-breeze, and lavender-dream remain below AA on white text — a preset-specific fix is deferred until a real user need appears.
+2. **Global focus-ring utility** — chrome controls share the `--ring` recipe; a single shared rule for every page-level action grid is not yet in place (`.modal-close-button:focus-visible` uses a primary outline).
+3. **Hex hygiene** — no new brand hex is allowed in pages (see [`DESIGN.md`](./DESIGN.md) §1 Principles). Existing brand assets and other justified exceptions are reviewed when their owning surface changes; this is not a standalone sweep.
+4. **Preset contrast (audit-only)** — the default theme passes AA/AAA; user-chosen presets are explicit choices and out of scope. Underground/rose-garden/sunset-glow pass with white; forest-whisper, ocean-breeze, and lavender-dream remain below AA on white text — a preset-specific fix is deferred until a real user need appears.
 
 ---
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,13 @@
 > Product milestone timeline (grouped by version). Not the current-state source of truth.
 > Current state → [`STATE.md`](STATE.md) · open items → [`progress/MASTER.md`](progress/MASTER.md) · detailed version narrative → root [`CHANGELOG.md`](../CHANGELOG.md)
 
+## 2026-08-18 — a11y 残差核实：axe 全绿 + 菜单 Esc 行为钉死（a11y-checklist 卫生）
+
+- **活体扫描**：`bun run a11y:scan`（Playwright + axe-core，dev-admin 会话）15 条认证路由 0 serious/critical 违规；结果进 `a11y-checklist.md` §1 AC。
+- **残差 #2（菜单 Esc）核实为 stale**：header 语言菜单（Base UI `DropdownMenu modal={false}`）与外观定制（`Popover`）原生支持 Esc 关闭；补 2 个行为用例钉死（`interface-controls.test.tsx`），防原语替换静默丢行为。§7 移除该项。
+- **清单卫生**：§3.1 删除已不存在的 `Avatar menu` 行（当前 header 无账号菜单，token 认证）、§2.1 删除 stale `Profile modal`（`CenteredModal` 已不存在）并修正 topbar Tab 顺序描述。
+- **验证**：vitest 布局/行为用例全绿（interface-controls 4/4）· tsgo/oxlint/oxfmt green。
+
 ## 2026-08-18 — UI/UX 批次：账户行内操作 + header SSOT + skeleton shimmer + 徽章机械迁移
 
 - **P2 #5 收口**：导入向导 focus-first-invalid 补 4 回归用例 + 2 处 `curly` lint 修复（#824）。

--- a/web/src/components/layout/components/interface-controls.test.tsx
+++ b/web/src/components/layout/components/interface-controls.test.tsx
@@ -90,4 +90,36 @@ describe('interface controls', () => {
     await waitFor(() => expect(document.documentElement).toHaveClass('dark'))
     expect(document.documentElement.style.colorScheme).toBe('dark')
   })
+
+  // Checklist residual §7 #2 verification: the header's non-modal menus must
+  // dismiss on Escape, not only on click-outside. Base UI Menu/Popover wire
+  // this natively; these tests pin the behavior so a primitive swap cannot
+  // silently drop it.
+  it('dismisses the language menu on Escape', async () => {
+    renderControls()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Language' }))
+    const menu = await screen.findByRole('menu')
+
+    fireEvent.keyDown(menu, { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    })
+  })
+
+  it('dismisses the appearance popover on Escape', async () => {
+    renderControls()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Customize appearance' })
+    )
+    const popover = await screen.findByRole('dialog')
+
+    fireEvent.keyDown(popover, { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Evidence pass over the a11y checklist's documented residuals (same verify-before-fix discipline as the audit closeouts):
  - Ran the live axe-core gate (`bun run a11y:scan`, Playwright + dev-admin session): **15 authenticated routes, 0 serious/critical violations** — recorded as a new acceptance-criteria row.
  - Residual "theme/user dropdown Esc" verified **stale**: the header language `DropdownMenu (modal={false})` and the appearance `Popover` are Base UI surfaces that dismiss on Escape natively. Added 2 behavior tests to `interface-controls.test.tsx` to pin it against future primitive swaps; residual removed from checklist section 7.
  - Checklist hygiene: removed the long-gone Avatar menu row (the current header ships no account menu) and the stale Profile modal row (`CenteredModal` no longer exists); corrected the topbar Tab-order description.

Gates: typecheck 0 error, lint 0 error, oxfmt green, vitest 508/508.

## Test plan

- [x] interface-controls tests 4/4 (incl. 2 new Esc-dismissal cases); full suite 508/508
- [x] bun run a11y:scan clean on 15 routes
- [ ] Reviewer sanity check on the checklist wording