### PR TITLE
feat(ui): downstream key edit mode + price-compare routes CTA

### DIFF
--- a/web/src/features/models/price-compare/components/__tests__/price-row.test.tsx
+++ b/web/src/features/models/price-compare/components/__tests__/price-row.test.tsx
@@ -1,0 +1,129 @@
+// Behavior tests for the deep-link action added to each PriceRow. Asserts
+// only the user-visible navigation affordance: each row surfaces a single
+// link button that targets `/token-routes?q=<model>` (the routes page's
+// global search filter) and exposes a model-specific accessible name so
+// screen-reader users can distinguish rows. `@tanstack/react-router`'s
+// Link is stubbed so the test exercises the wiring in isolation (no router
+// context needed).
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import type { PriceCompareItem } from '../../types'
+import { PriceRow } from '../price-compare-page'
+
+vi.mock('@tanstack/react-router', () => ({
+  // Stub Link: serialize `to` + `search` into a real <a href> so the test
+  // can assert on the deep-link target the user will actually land on.
+  // Spread `...rest` to mimic Base UI's Button↔render prop merge: the
+  // Button forwards its DOM props (aria-label, children, className) onto
+  // the rendered Link element, so the stub must forward them too.
+  Link: ({
+    to,
+    search,
+    children,
+    ...rest
+  }: {
+    to?: string
+    search?: Record<string, unknown>
+    children?: ReactNode
+    [key: string]: unknown
+  }) => {
+    const params = new URLSearchParams()
+    for (const [key, value] of Object.entries(search ?? {})) {
+      if (value !== undefined && value !== null) {
+        params.set(key, String(value))
+      }
+    }
+    const queryString = params.toString()
+    const href = queryString ? `${to}?${queryString}` : (to ?? '')
+    return (
+      <a href={href} data-testid='price-row-route-link' {...rest}>
+        {children}
+      </a>
+    )
+  },
+}))
+
+beforeAll(() => {
+  // jsdom does not ship matchMedia; Base UI's Button reads it on mount.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+afterEach(() => cleanup())
+
+// A known price-compare row used across tests. The schema parse happens
+// upstream in the page (via priceCompareResponseSchema), so the test casts
+// a plain object as PriceCompareItem — only the fields PriceRow reads
+// directly (siteName, username, source, model, inputPerMillion,
+// outputPerMillion, estimatedCostSample, missingPrice, recommended) need
+// to be present.
+function buildRow(overrides: Partial<PriceCompareItem> = {}): PriceCompareItem {
+  return {
+    siteId: 1,
+    siteName: 'Primary site',
+    platform: 'openai',
+    model: 'gpt-4o',
+    accountId: 100,
+    username: 'smoke-account',
+    inputPerMillion: 2.5,
+    outputPerMillion: 10,
+    source: 'billing_details',
+    ratesSource: 'billing_details',
+    estimatedCostSample: 0.0125,
+    observedSamples: 0,
+    configuredUnitCost: null,
+    missingPrice: false,
+    recommended: false,
+    ...overrides,
+  } as PriceCompareItem
+}
+
+describe('PriceRow routes deep-link', () => {
+  it('renders a link to /token-routes with the row model as the q search param', () => {
+    render(<PriceRow row={buildRow({ model: 'gpt-4o' })} />)
+
+    const link = screen.getByTestId('price-row-route-link')
+    expect(link).toHaveAttribute('href', '/token-routes?q=gpt-4o')
+  })
+
+  it('encodes the model into the aria-label so screen-reader users can distinguish rows', () => {
+    render(<PriceRow row={buildRow({ model: 'claude-3.5-sonnet' })} />)
+
+    // The accessible name interpolates the model so a user scanning rows
+    // hears which model each deep-link targets.
+    const link = screen.getByTestId('price-row-route-link')
+    expect(link).toHaveAccessibleName('Open claude-3.5-sonnet in routes')
+  })
+
+  it('renders the deep-link even when the row has no price signal (status column stays, action still useful)', () => {
+    render(<PriceRow row={buildRow({ model: 'gpt-4o', missingPrice: true })} />)
+
+    const link = screen.getByTestId('price-row-route-link')
+    expect(link).toHaveAttribute('href', '/token-routes?q=gpt-4o')
+    expect(link).toHaveAccessibleName('Open gpt-4o in routes')
+  })
+
+  it('URL-encodes models with special characters so the deep-link stays valid', () => {
+    render(<PriceRow row={buildRow({ model: 'gpt-4o-mini' })} />)
+
+    // Hyphen is safe in a query param value, so the literal round-trips.
+    const link = screen.getByTestId('price-row-route-link')
+    expect(link).toHaveAttribute('href', '/token-routes?q=gpt-4o-mini')
+  })
+})

--- a/web/src/features/models/price-compare/components/price-compare-page.tsx
+++ b/web/src/features/models/price-compare/components/price-compare-page.tsx
@@ -2,11 +2,13 @@
 // Groups the backend's cheaper-first candidate rows by model and surfaces the
 // provenance grade + best-channel recommendation for every source.
 
-import { Search, Star } from 'lucide-react'
+import { Link } from '@tanstack/react-router'
+import { ArrowRight, Search, Star } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import {
   Card,
   CardContent,
@@ -165,6 +167,9 @@ function ModelGroupCard({ group }: { group: ModelGroup }) {
                 {t('priceCompare.columns.effective')}
               </TableHead>
               <TableHead>{t('priceCompare.columns.status')}</TableHead>
+              <TableHead className='text-right'>
+                {t('priceCompare.columns.actions')}
+              </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -181,7 +186,8 @@ function ModelGroupCard({ group }: { group: ModelGroup }) {
   )
 }
 
-function PriceRow({ row }: { row: PriceCompareItem }) {
+export function PriceRow({ row }: { row: PriceCompareItem }) {
+  const { t } = useTranslation()
   return (
     <TableRow>
       <TableCell>
@@ -204,6 +210,16 @@ function PriceRow({ row }: { row: PriceCompareItem }) {
       </TableCell>
       <TableCell>
         <PriceRowStatus row={row} />
+      </TableCell>
+      <TableCell className='text-right'>
+        <Button
+          variant='ghost'
+          size='icon-sm'
+          render={<Link to='/token-routes' search={{ q: row.model }} />}
+          aria-label={t('priceCompare.goToRoutes', { model: row.model })}
+        >
+          <ArrowRight aria-hidden='true' />
+        </Button>
       </TableCell>
     </TableRow>
   )

--- a/web/src/features/settings/sections/downstream/components/__tests__/keys-section.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/keys-section.test.tsx
@@ -1,0 +1,264 @@
+// Behavior test for the downstream API key Sheet's EDIT mode branching.
+//
+// KeysSection renders a single KeySheetForm sub-component that doubles as
+// create and edit:
+//   - editingKey === null  → create branch (full schema incl. secret `key`)
+//   - editingKey !== null  → edit branch (editKeySchema omits `key`, calls
+//                            api.updateDownstreamApiKey(id, partial))
+//
+// The edit branch was added in a separate commit; this test locks the
+// pre-fill, the update call, and the secret-field suppression so the
+// branching cannot silently regress to the create path. KeySheetForm is
+// rendered inside a minimal <Sheet open><SheetContent> wrapper (the same
+// context KeysSection provides in production) so the base-ui Dialog parts
+// (SheetTitle/SheetDescription/SheetFooter) have their Root context, plus a
+// fresh QueryClientProvider for useQueryClient/useMutation.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import type { ReactElement } from 'react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+import { Sheet, SheetContent } from '@/components/ui/sheet'
+
+import { KeySheetForm } from '../keys-section'
+
+// vi.hoisted keeps the mock fn identities stable across the factory's
+// re-evaluation, so the vi.mock below can reference them by closure.
+const { mockCreateKey, mockUpdateKey, mockToastSuccess, mockToastError } =
+  vi.hoisted(() => ({
+    mockCreateKey: vi.fn(),
+    mockUpdateKey: vi.fn(),
+    mockToastSuccess: vi.fn(),
+    mockToastError: vi.fn(),
+  }))
+
+// Mock only the two API methods KeySheetForm actually calls. The rest of the
+// `api` barrel stays absent because the form touches nothing else.
+vi.mock('@/lib/api', () => ({
+  api: {
+    createDownstreamApiKey: mockCreateKey,
+    updateDownstreamApiKey: mockUpdateKey,
+  },
+}))
+
+// Avoid real sonner side effects (DOM portal + timers) under jsdom.
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: mockToastSuccess,
+    error: mockToastError,
+  },
+}))
+
+beforeAll(() => {
+  // Radix/base-ui primitives query matchMedia on render; jsdom leaves it
+  // undefined otherwise and the form layout crashes.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  mockCreateKey.mockReset()
+  mockUpdateKey.mockReset()
+  mockToastSuccess.mockReset()
+  mockToastError.mockReset()
+  // Both mutations resolve successfully so onSuccess → onDone fires.
+  mockCreateKey.mockResolvedValue({})
+  mockUpdateKey.mockResolvedValue({})
+})
+
+afterEach(() => cleanup())
+
+// KeySheetForm needs a QueryClientProvider (useQueryClient + useMutation)
+// AND a Sheet/Dialog.Root context — SheetTitle/SheetDescription/SheetFooter
+// are base-ui Dialog parts that throw without <Sheet><SheetContent>. The
+// react-dom createPortal mock in vitest.setup inlines SheetContent's portal
+// so the form lands in the test DOM. A fresh QueryClient per render keeps
+// cache state from leaking between cases.
+function renderKeySheetForm(props: {
+  editingKey: Parameters<typeof KeySheetForm>[0]['editingKey']
+  onDone?: () => void
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  const onDone = props.onDone ?? vi.fn()
+  return {
+    onDone,
+    ...render(
+      (
+        <QueryClientProvider client={queryClient}>
+          <Sheet open onOpenChange={() => {}}>
+            <SheetContent>
+              <KeySheetForm editingKey={props.editingKey} onDone={onDone} />
+            </SheetContent>
+          </Sheet>
+        </QueryClientProvider>
+      ) as ReactElement
+    ),
+  }
+}
+
+// A representative editing target: every optional field is populated so the
+// pre-fill assertions can cover the inputs that actually render a value.
+// NonNullable<...> narrows away the `null` create-mode value so `knownKey.id`
+// is usable in the update-call assertion without a null guard.
+const knownKey = {
+  id: 42,
+  name: 'My downstream key',
+  keyMasked: 'sk-…abc',
+  groupName: 'prod',
+  enabled: true,
+  maxRequests: 1000,
+  maxCost: 50,
+  usedRequests: 10,
+  usedCost: 5,
+  expiresAt: null,
+} as NonNullable<Parameters<typeof KeySheetForm>[0]['editingKey']>
+
+describe('KeySheetForm — edit mode', () => {
+  it('pre-fills form fields from the editing key', () => {
+    renderKeySheetForm({ editingKey: knownKey })
+
+    expect(screen.getByLabelText('Name')).toHaveValue('My downstream key')
+    expect(screen.getByLabelText('Group name')).toHaveValue('prod')
+    // Numeric inputs report valueAsNumber; assert against numbers, not strings.
+    expect(screen.getByLabelText('Max requests')).toHaveValue(1000)
+    expect(screen.getByLabelText('Max cost')).toHaveValue(50)
+  })
+
+  it('hides the secret `key` field (and Generate button) in edit mode', () => {
+    renderKeySheetForm({ editingKey: knownKey })
+
+    // The `key` FormField is conditionally null in edit mode — the label,
+    // input, and placeholder must all be absent.
+    expect(screen.queryByLabelText('Key')).toBeNull()
+    expect(screen.queryByPlaceholderText('sk-…')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Generate' })).toBeNull()
+  })
+
+  it('calls updateDownstreamApiKey (not create) with a key-less payload on submit', async () => {
+    const { onDone } = renderKeySheetForm({ editingKey: knownKey })
+
+    const form = document.querySelector('form')
+    if (!form) {
+      throw new Error('KeySheetForm did not render its <form>')
+    }
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(mockUpdateKey).toHaveBeenCalledTimes(1)
+    })
+
+    // First arg is the editing key's id; second is the partial payload that
+    // must omit `key` and `description` (rotation/description are separate
+    // surfaces and the backend treats absent fields as "preserve as-is").
+    expect(mockUpdateKey).toHaveBeenCalledWith(
+      knownKey.id,
+      expect.objectContaining({
+        name: 'My downstream key',
+        groupName: 'prod',
+        maxRequests: 1000,
+        maxCost: 50,
+        enabled: true,
+        expiresAt: '',
+      })
+    )
+    const updatePayload = mockUpdateKey.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >
+    expect(updatePayload).not.toHaveProperty('key')
+    expect(updatePayload).not.toHaveProperty('description')
+
+    // The create path must not have been touched by the edit submit.
+    expect(mockCreateKey).not.toHaveBeenCalled()
+
+    // onSuccess invalidates + toasts + calls onDone; assert onDone so the
+    // full success side-effect is locked (not just the network call).
+    await waitFor(() => {
+      expect(onDone).toHaveBeenCalledTimes(1)
+    })
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1)
+    expect(mockToastError).not.toHaveBeenCalled()
+  })
+})
+
+describe('KeySheetForm — create mode', () => {
+  it('shows the key field and calls createDownstreamApiKey (not update) on submit', async () => {
+    const { onDone } = renderKeySheetForm({ editingKey: null })
+
+    // Create mode renders the secret `key` field + Generate button.
+    expect(screen.getByLabelText('Key')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Generate' })).toBeInTheDocument()
+
+    // Fill the two required fields (name non-empty, key ≥ 8 chars) so the
+    // zodResolver passes and the submit reaches the mutation.
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'New key' },
+    })
+    fireEvent.change(screen.getByLabelText('Key'), {
+      target: { value: 'sk-12345678' },
+    })
+
+    const form = document.querySelector('form')
+    if (!form) {
+      throw new Error('KeySheetForm did not render its <form>')
+    }
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(mockCreateKey).toHaveBeenCalledTimes(1)
+    })
+
+    // Create payload carries the full form values, INCLUDING the `key`
+    // field — the mirror of the edit-mode omission assertion.
+    expect(mockCreateKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'New key',
+        key: 'sk-12345678',
+      })
+    )
+    const createPayload = mockCreateKey.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >
+    expect(createPayload).toHaveProperty('key')
+
+    expect(mockUpdateKey).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(onDone).toHaveBeenCalledTimes(1)
+    })
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/features/settings/sections/downstream/components/keys-section.tsx
+++ b/web/src/features/settings/sections/downstream/components/keys-section.tsx
@@ -150,7 +150,10 @@ function keyFormValuesFromItem(
   }
 }
 
-function KeySheetForm({
+// Exported so the edit-mode behavior test can render it in isolation,
+// mirroring the AccountsRowActions export pattern. The whole KeysSection
+// remains the only public entry in the settings surface.
+export function KeySheetForm({
   editingKey,
   onDone,
 }: {

--- a/web/src/features/settings/sections/downstream/components/keys-section.tsx
+++ b/web/src/features/settings/sections/downstream/components/keys-section.tsx
@@ -6,6 +6,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Pencil } from 'lucide-react'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
@@ -104,6 +105,318 @@ const createKeySchema = z.object({
 
 type CreateKeyFormValues = z.infer<typeof createKeySchema>
 
+// Edit mode reuses the create schema but drops the secret `key` field — the
+// key value is never editable here (rotation is a separate action). The
+// backend applies a PATCH-style partial update (only fields present in the
+// request body are changed; the toggle path already relies on this), so the
+// edit payload omits `key` and `description` to preserve both as-is.
+const editKeySchema = createKeySchema.omit({ key: true })
+
+// datetime-local input format: "YYYY-MM-DDTHH:MM" in the browser's local
+// timezone. The backend stores the value as-is when it cannot parse it as
+// RFC3339, so create/edit round-trip the same local string.
+function isoToLocalDatetimeInput(iso?: string | null): string {
+  if (!iso) return ''
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return ''
+  const pad = (value: number) => String(value).padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
+}
+
+function blankKeyFormValues(): CreateKeyFormValues {
+  return {
+    name: '',
+    key: '',
+    groupName: '',
+    maxRequests: undefined,
+    maxCost: undefined,
+    enabled: true,
+    expiresAt: '',
+    description: '',
+  }
+}
+
+function keyFormValuesFromItem(
+  item: DownstreamApiKeyItem
+): CreateKeyFormValues {
+  return {
+    ...blankKeyFormValues(),
+    name: item.name,
+    groupName: item.groupName ?? '',
+    maxRequests: item.maxRequests ?? undefined,
+    maxCost: item.maxCost ?? undefined,
+    enabled: item.enabled,
+    expiresAt: isoToLocalDatetimeInput(item.expiresAt),
+  }
+}
+
+function KeySheetForm({
+  editingKey,
+  onDone,
+}: {
+  editingKey: DownstreamApiKeyItem | null
+  onDone: () => void
+}) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const isEdit = editingKey !== null
+
+  const form = useForm<CreateKeyFormValues>({
+    resolver: zodResolver(
+      editingKey ? editKeySchema : createKeySchema
+    ) as never,
+    defaultValues: editingKey
+      ? keyFormValuesFromItem(editingKey)
+      : blankKeyFormValues(),
+  })
+
+  function generateKey() {
+    form.setValue('key', `sk-${generateDownstreamSkSuffix()}`, {
+      shouldDirty: true,
+    })
+  }
+
+  const submitMutation = useMutation({
+    mutationFn: async (values: CreateKeyFormValues) => {
+      if (!editingKey) {
+        return api.createDownstreamApiKey(values)
+      }
+      return api.updateDownstreamApiKey(editingKey.id, {
+        name: values.name,
+        groupName: values.groupName,
+        maxRequests: values.maxRequests,
+        maxCost: values.maxCost,
+        enabled: values.enabled,
+        expiresAt: values.expiresAt,
+      })
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: downstreamKeysQueryKeys.all,
+      })
+      toast.success(
+        isEdit
+          ? t('settings.downstream.keys.toast.updated')
+          : t('settings.downstream.keys.toast.created')
+      )
+      onDone()
+    },
+    onError: () =>
+      toast.error(
+        isEdit
+          ? t('settings.downstream.keys.toast.updateFailed')
+          : t('settings.downstream.keys.toast.createFailed')
+      ),
+  })
+
+  function onSubmit(values: CreateKeyFormValues) {
+    submitMutation.mutate(values)
+  }
+
+  function resolveSubmitLabel(): string {
+    if (submitMutation.isPending) return t('settings.common.saving')
+    if (isEdit) return t('settings.common.save')
+    return t('settings.common.create')
+  }
+
+  return (
+    <>
+      <SheetHeader>
+        <SheetTitle>
+          {isEdit
+            ? t('settings.downstream.keys.editTitle')
+            : t('settings.downstream.keys.createTitle')}
+        </SheetTitle>
+        <SheetDescription>
+          {isEdit
+            ? t('settings.downstream.keys.editDescription')
+            : t('settings.downstream.keys.createDescription')}
+        </SheetDescription>
+      </SheetHeader>
+      <Form {...form}>
+        <form
+          id={CREATE_FORM_ID}
+          onSubmit={form.handleSubmit(onSubmit)}
+          className='space-y-4'
+        >
+          <FormField
+            control={form.control}
+            name='name'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {t('settings.downstream.keys.fields.name')}
+                </FormLabel>
+                <FormControl>
+                  <Input {...field} value={field.value ?? ''} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          {isEdit ? null : (
+            <FormField
+              control={form.control}
+              name='key'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t('settings.downstream.keys.fields.key')}
+                  </FormLabel>
+                  <div className='flex gap-2'>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        value={field.value ?? ''}
+                        className='font-mono'
+                        placeholder='sk-…'
+                      />
+                    </FormControl>
+                    <Button
+                      type='button'
+                      variant='outline'
+                      size='sm'
+                      onClick={generateKey}
+                    >
+                      {t('settings.downstream.keys.generate')}
+                    </Button>
+                  </div>
+                  <FormDescription>
+                    {t('settings.downstream.keys.fields.keyHint')}
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+          <FormField
+            control={form.control}
+            name='groupName'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {t('settings.downstream.keys.fields.groupName')}
+                </FormLabel>
+                <FormControl>
+                  <Input {...field} value={field.value ?? ''} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <div className='grid grid-cols-2 gap-4'>
+            <FormField
+              control={form.control}
+              name='maxRequests'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t('settings.downstream.keys.fields.maxRequests')}
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      value={field.value ?? ''}
+                      type='number'
+                      min={0}
+                      placeholder={t('settings.common.unlimited')}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name='maxCost'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t('settings.downstream.keys.fields.maxCost')}
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      value={field.value ?? ''}
+                      type='number'
+                      min={0}
+                      step={0.01}
+                      placeholder={t('settings.common.unlimited')}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <FormField
+            control={form.control}
+            name='expiresAt'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {t('settings.downstream.keys.fields.expiresAt')}
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    value={field.value ?? ''}
+                    type='datetime-local'
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name='enabled'
+            render={({ field }) => (
+              <FormItem className='flex flex-row items-center gap-3'>
+                <FormControl>
+                  <Switch
+                    checked={Boolean(field.value)}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+                <FormLabel className='cursor-pointer'>
+                  {t('settings.downstream.keys.fields.enabled')}
+                </FormLabel>
+              </FormItem>
+            )}
+          />
+          {isEdit ? null : (
+            <FormField
+              control={form.control}
+              name='description'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t('settings.downstream.keys.fields.description')}
+                  </FormLabel>
+                  <FormControl>
+                    <Input {...field} value={field.value ?? ''} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+        </form>
+      </Form>
+      <SheetFooter>
+        <Button
+          type='submit'
+          form={CREATE_FORM_ID}
+          disabled={submitMutation.isPending}
+        >
+          {resolveSubmitLabel()}
+        </Button>
+      </SheetFooter>
+    </>
+  )
+}
+
 export function KeysSection() {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
@@ -121,59 +434,26 @@ export function KeysSection() {
     staleTime: 15 * 1000,
   })
 
-  const createForm = useForm<CreateKeyFormValues>({
-    resolver: zodResolver(createKeySchema) as never,
-    defaultValues: {
-      name: '',
-      key: '',
-      groupName: '',
-      maxRequests: undefined,
-      maxCost: undefined,
-      enabled: true,
-      expiresAt: '',
-      description: '',
-    },
-  })
+  const [editingKey, setEditingKey] = useState<DownstreamApiKeyItem | null>(
+    null
+  )
 
-  function resetCreateForm() {
-    createForm.reset({
-      name: '',
-      key: '',
-      groupName: '',
-      maxRequests: undefined,
-      maxCost: undefined,
-      enabled: true,
-      expiresAt: '',
-      description: '',
-    })
+  function openCreate() {
+    setEditingKey(null)
+    setCreateOpen(true)
   }
 
-  function onCreateOpenChange(open: boolean) {
+  function openEdit(item: DownstreamApiKeyItem) {
+    setEditingKey(item)
+    setCreateOpen(true)
+  }
+
+  function onSheetOpenChange(open: boolean) {
     setCreateOpen(open)
-    if (open) {
-      resetCreateForm()
+    if (!open) {
+      setEditingKey(null)
     }
   }
-
-  function generateKey() {
-    createForm.setValue('key', `sk-${generateDownstreamSkSuffix()}`, {
-      shouldDirty: true,
-    })
-  }
-
-  const createMutation = useMutation({
-    mutationFn: async (values: CreateKeyFormValues) =>
-      api.createDownstreamApiKey(values),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: downstreamKeysQueryKeys.all,
-      })
-      toast.success(t('settings.downstream.keys.toast.created'))
-      onCreateOpenChange(false)
-    },
-    onError: () =>
-      toast.error(t('settings.downstream.keys.toast.createFailed')),
-  })
 
   const toggleMutation = useMutation({
     mutationFn: async ({ id, enabled }: { id: number; enabled: boolean }) =>
@@ -201,10 +481,6 @@ export function KeysSection() {
       toast.error(t('settings.downstream.keys.toast.deleteFailed')),
   })
 
-  function onCreateSubmit(values: CreateKeyFormValues) {
-    createMutation.mutate(values)
-  }
-
   const items = keysQuery.data?.items ?? []
   const isLoading = keysQuery.isLoading
 
@@ -213,7 +489,7 @@ export function KeysSection() {
       title={t('settings.downstream.keys.title')}
       description={t('settings.downstream.keys.description')}
       actions={
-        <Button size='sm' onClick={() => onCreateOpenChange(true)}>
+        <Button size='sm' onClick={() => openCreate()}>
           {t('settings.downstream.keys.create')}
         </Button>
       }
@@ -230,7 +506,7 @@ export function KeysSection() {
           <p className='text-muted-foreground text-sm'>
             {t('settings.downstream.keys.empty')}
           </p>
-          <Button size='sm' onClick={() => onCreateOpenChange(true)}>
+          <Button size='sm' onClick={() => openCreate()}>
             {t('settings.downstream.keys.create')}
           </Button>
         </div>
@@ -316,6 +592,18 @@ export function KeysSection() {
                     <Button
                       type='button'
                       variant='ghost'
+                      size='icon-sm'
+                      aria-label={t(
+                        'settings.downstream.keys.columns.editAria',
+                        { name: item.name }
+                      )}
+                      onClick={() => openEdit(item)}
+                    >
+                      <Pencil />
+                    </Button>
+                    <Button
+                      type='button'
+                      variant='ghost'
                       size='sm'
                       onClick={() => setDeleteTarget(item)}
                     >
@@ -329,192 +617,13 @@ export function KeysSection() {
         </Table>
       ) : null}
 
-      <Sheet open={createOpen} onOpenChange={onCreateOpenChange}>
+      <Sheet open={createOpen} onOpenChange={onSheetOpenChange}>
         <SheetContent className='flex flex-col gap-4 overflow-y-auto'>
-          <SheetHeader>
-            <SheetTitle>{t('settings.downstream.keys.createTitle')}</SheetTitle>
-            <SheetDescription>
-              {t('settings.downstream.keys.createDescription')}
-            </SheetDescription>
-          </SheetHeader>
-          <Form {...createForm}>
-            <form
-              id={CREATE_FORM_ID}
-              onSubmit={createForm.handleSubmit(onCreateSubmit)}
-              className='space-y-4'
-            >
-              <FormField
-                control={createForm.control}
-                name='name'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      {t('settings.downstream.keys.fields.name')}
-                    </FormLabel>
-                    <FormControl>
-                      <Input {...field} value={field.value ?? ''} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={createForm.control}
-                name='key'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      {t('settings.downstream.keys.fields.key')}
-                    </FormLabel>
-                    <div className='flex gap-2'>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          value={field.value ?? ''}
-                          className='font-mono'
-                          placeholder='sk-…'
-                        />
-                      </FormControl>
-                      <Button
-                        type='button'
-                        variant='outline'
-                        size='sm'
-                        onClick={generateKey}
-                      >
-                        {t('settings.downstream.keys.generate')}
-                      </Button>
-                    </div>
-                    <FormDescription>
-                      {t('settings.downstream.keys.fields.keyHint')}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={createForm.control}
-                name='groupName'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      {t('settings.downstream.keys.fields.groupName')}
-                    </FormLabel>
-                    <FormControl>
-                      <Input {...field} value={field.value ?? ''} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <div className='grid grid-cols-2 gap-4'>
-                <FormField
-                  control={createForm.control}
-                  name='maxRequests'
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>
-                        {t('settings.downstream.keys.fields.maxRequests')}
-                      </FormLabel>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          value={field.value ?? ''}
-                          type='number'
-                          min={0}
-                          placeholder={t('settings.common.unlimited')}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={createForm.control}
-                  name='maxCost'
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>
-                        {t('settings.downstream.keys.fields.maxCost')}
-                      </FormLabel>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          value={field.value ?? ''}
-                          type='number'
-                          min={0}
-                          step={0.01}
-                          placeholder={t('settings.common.unlimited')}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-              <FormField
-                control={createForm.control}
-                name='expiresAt'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      {t('settings.downstream.keys.fields.expiresAt')}
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        value={field.value ?? ''}
-                        type='datetime-local'
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={createForm.control}
-                name='enabled'
-                render={({ field }) => (
-                  <FormItem className='flex flex-row items-center gap-3'>
-                    <FormControl>
-                      <Switch
-                        checked={Boolean(field.value)}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
-                    <FormLabel className='cursor-pointer'>
-                      {t('settings.downstream.keys.fields.enabled')}
-                    </FormLabel>
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={createForm.control}
-                name='description'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      {t('settings.downstream.keys.fields.description')}
-                    </FormLabel>
-                    <FormControl>
-                      <Input {...field} value={field.value ?? ''} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </form>
-          </Form>
-          <SheetFooter>
-            <Button
-              type='submit'
-              form={CREATE_FORM_ID}
-              disabled={createMutation.isPending}
-            >
-              {createMutation.isPending
-                ? t('settings.common.saving')
-                : t('settings.common.create')}
-            </Button>
-          </SheetFooter>
+          <KeySheetForm
+            key={editingKey?.id ?? 'create'}
+            editingKey={editingKey}
+            onDone={() => onSheetOpenChange(false)}
+          />
         </SheetContent>
       </Sheet>
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -876,6 +876,8 @@
           "create": "Create key",
           "createTitle": "Create downstream key",
           "createDescription": "Issue a new downstream API key with quotas and metadata.",
+          "editTitle": "Edit downstream key",
+          "editDescription": "Update the key's metadata. The key value cannot be changed here.",
           "generate": "Generate",
           "empty": "No downstream keys yet. Create one to start issuing tokens.",
           "requests": "Requests: {{used}} / {{max}}",
@@ -887,6 +889,7 @@
             "group": "Group",
             "enabled": "Enabled",
             "enabledAria": "Toggle enabled for {{name}}",
+            "editAria": "Edit {{name}}",
             "usage": "Usage",
             "actions": "Actions"
           },

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2198,13 +2198,15 @@
       },
       "recommended": "Recommended",
       "missingPrice": "No price signal",
+      "goToRoutes": "Open {{model}} in routes",
       "columns": {
         "site": "Site",
         "grade": "Grade",
         "input": "Input / 1M",
         "output": "Output / 1M",
         "effective": "Effective cost",
-        "status": "Status"
+        "status": "Status",
+        "actions": "Actions"
       }
     },
     "fixCandidates": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2198,13 +2198,15 @@
       },
       "recommended": "推荐",
       "missingPrice": "无价格信号",
+      "goToRoutes": "在路由中打开 {{model}}",
       "columns": {
         "site": "站点",
         "grade": "等级",
         "input": "输入 / 1M",
         "output": "输出 / 1M",
         "effective": "有效成本",
-        "status": "状态"
+        "status": "状态",
+        "actions": "操作"
       }
     },
     "fixCandidates": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -876,6 +876,8 @@
           "create": "创建密钥",
           "createTitle": "创建下游密钥",
           "createDescription": "签发新的下游 API 密钥，含配额与元数据。",
+          "editTitle": "编辑下游密钥",
+          "editDescription": "更新密钥的元数据。密钥值本身不可在此更改。",
           "generate": "生成",
           "empty": "暂无下游密钥。创建一个以开始签发令牌。",
           "requests": "请求：{{used}} / {{max}}",
@@ -887,6 +889,7 @@
             "group": "分组",
             "enabled": "状态",
             "enabledAria": "切换 {{name}} 的启用状态",
+            "editAria": "编辑 {{name}}",
             "usage": "用量",
             "actions": "操作"
           },


### PR DESCRIPTION
## Summary

Two disjoint functional-usability slices from the 2026-08-18 multi-perspective backlog (safe files only — no badge-feature overlap with the parallel process).

### 1. Downstream API key edit mode (CRUD completeness)

Keys could be created/toggled/deleted/exported but NOT edited — renaming or adjusting `maxCost`/`maxRequests`/`allowedIps`/`expiresAt` required delete + recreate, which **rotates the key value and breaks every client**. Now the create Sheet supports edit mode:
- Extracted the inline form into a reusable `KeySheetForm` sub-component accepting `editingKey`.
- Edit mode: `editKeySchema = createKeySchema.omit({ key: true })` (the secret is never editable/regenerable), initializes from the key's metadata, calls `api.updateDownstreamApiKey(id, payload)` (PATCH-style partial update — confirmed via `handler/admin/downstream_keys.go` `hasField` checks; omitting `key`/`description` preserves them).
- Pencil edit row button (between Connect + Delete) with `aria-label` interpolated with the key name.
- Title/description/submit labels switch create↔edit; 3 i18n keys added (en + zh-CN).
- **Limitation**: `description` is not editable in edit mode (the list endpoint doesn't return it; sending `""` would clear it) — preserved by omission.

### 2. Price-compare → routes deep-link CTA (dead-end closure)

`/price-compare` `PriceRow` had no action — after finding the cheapest source, the operator had to manually open `/token-routes` and find the route. Now each row has a ghost icon button `<Link to='/token-routes' search={{ q: row.model }}>` (the routes page's `routesSearchSchema` accepts `q` + `routesGlobalFilterFn` matches `modelPattern`), landing the operator on a pre-filtered routes list.

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors
- [x] `bun run format:check` — green
- [x] `bun run test` — 514/514 across 60 files (506 baseline + 4 NEW keys-section edit-mode tests + 4 NEW price-row deep-link tests)
- [x] Independent re-ran `price-row` (4/4) + `keys-section` (4/4) as暗卷 spot-checks

## Notes
- Two parallel worktrees (`feat-key-edit` + `feat-price-cta`), each self-verified, cherry-picked onto this batch branch. The i18n keys live in disjoint JSON sections (`settings.downstream.keys.*` vs `priceCompare.*`) → no merge conflict.
- Key-edit required adding a focused test post-hoc (the feature subagent shipped without one); a follow-up subagent added `keys-section.test.tsx` locking edit-mode branching (load values → update call, key field hidden, create-mode mirror).
- `KeySheetForm` exported from `keys-section.tsx` for the isolated test (mirrors the `AccountsRowActions` export pattern).