### PR TITLE
docs: sync multi-perspective backlog — mark #828/#832/#835 items addressed

### DIFF
--- a/docs/analysis/ui-ux-audit-2026-08.md
+++ b/docs/analysis/ui-ux-audit-2026-08.md
@@ -89,10 +89,14 @@
 
 三个只读 explore 子代理从产品经理、前端工程师、真实用户角度复审 5 条主流动线 + 边缘态 + 首次接入到首次代理请求的完整旅程。引导深链链路（site → account → route → downstream key）经核实完整。下列为**未升格为承诺的观察**（证据），立项须经 [`../progress/MASTER.md`](../progress/MASTER.md) 提升并附 owner + 验收标准。
 
-### 本轮已收口（#828，待合并）
+### 本轮已收口（#828 + #832 + #835）
 
-- **Dashboard stat 卡 drilldown**（PM #5 / User #1 partial）：`StatCard` 加 `to` prop → `<Link>`，四张卡接线 `/accounts`/`/sites`/`/checkin`/`/proxy-logs`（S）。
-- **接入凭证导出 → 测试请求深链**（User #5）：`credential-export-dialog.tsx` footer 加 secondary 按钮 `<Link to='/model-tester'>`，闭合旅程最后一步 dead-end（S）。
+- **Dashboard stat 卡 drilldown**（PM #5 / User #1 partial，#828）：`StatCard` 加 `to` prop → `<Link>`，四张卡接线 `/accounts`/`/sites`/`/checkin`/`/proxy-logs`（S）。
+- **接入凭证导出 → 测试请求深链**（User #5，#828）：`credential-export-dialog.tsx` footer 加 secondary 按钮 `<Link to='/model-tester'>`，闭合旅程最后一步 dead-end（S）。
+- **Proxy-logs 列表过滤服务端化**（功能 bug，#832）：`latencyMin`/`latencyMax` + 原 silent no-op 的 `client`/`from`/`to` 全部移入 `statsHandler.proxyLogs` 共享 `where`/`args`（items/count/summary 一致），删客户端过滤 memo；6 后端 + 3 前端测试（M）。
+- **Settings 边缘态硬化**（#832）：`keys-section` query 错误 → `SettingsSectionError`；enable `Switch` pending 禁用 + 唯一 `aria-label`（`enabledAria` i18n）；空态内联「Create」按钮；`update-center` 错误 → `SettingsSectionError`（4×S）。
+- **Downstream key edit mode**（PM #4，#835）：`KeySheetForm` 加 `editingKey`，`editKeySchema = createKeySchema.omit({ key })`（secret 不可改），调 `api.updateDownstreamApiKey`（PATCH 风格 partial update，`key`/`description` 省略以保留）；Pencil 行按钮 + 3 i18n + 4 测试（M）。
+- **Price-compare → routes 深链**（PM #3，#835）：`PriceRow` 加 ghost 图标按钮 `<Link to='/token-routes' search={{ q: row.model }}>`（routes 页 `q` 过滤匹配 `modelPattern`）+ 2 i18n + 4 测试（S）。
 
 ### 剩余观察（按主题）
 
@@ -100,25 +104,12 @@
 
 - `proxy-log-detail-sheet.tsx:143-177` — channel/account/route/token ID 渲染为不可点 `#NNN`；要做 drilldown 需目标页支持 `?channelId=` 等 deep-link 过滤（M）。
 - `channel-detail-sheet.tsx:216` — 无 `SheetFooter`，cooldown/breaker_open 通道无「清冷却 / 探测」动作（可复用 `useClearRouteCooldown` 模式）（M）。
-- `price-compare-page.tsx:184` — `PriceRow` 无动作列，比价结果不接 route weight 编辑（`/token-routes?model=` deep-link）（S）。
-- `keys-section.tsx:296` — downstream key 仅 create/toggle/delete/export，无 edit；改名/调 `maxCost`/`allowedIps` 需删重建（轮换 key 值，破坏所有客户端）（M）。
-- `channels-page.tsx:139` — 空态无 CTA（应接 `/accounts` 或触发 `rebuildMutation`）（S）。
-- `keys-section.tsx:221` — 空态仅一行文字，无内联「Create」按钮（仅 header 有）（S）。
+- `channels-page.tsx:139` — 空态无 CTA（应接 `/accounts` 或触发 `rebuildMutation`）（S，但 channels 列属并行进程 badge 范围，需协调）。
 - `overview-section.tsx:253` — 首次落地（0 site）无 onboarding banner/CTA（M，#828 stat-card drilldown 部分缓解）。
-
-**错误 / 空态处理**
-
-- `keys-section.tsx:190` — `keysQuery` 失败时 `items=[]` 渲染为「无 key」空态而非错误/重试 UI（S）。
-- `update-center-section.tsx:85` — `statusQuery` 失败渲染「version: unknown」无可区分错误提示/重试（S）。
 
 **行级 pending + a11y**
 
-- `keys-section.tsx:268` — enable `Switch` 共享一个 mutation，pending 时不禁用（可连点重复 mutate）+ 全行 `aria-label="Enabled"` 非唯一（S）。
-- `accounts/api.ts:281` — `useToggleAccountPin`/`useToggleAccountStatus`/`useToggleAccountCheckin` `onSuccess` 只 invalidate 不 toast（status 已由 #824 行内 Loader2 救场；pin/checkin 仍走下拉菜单 fire-and-forget 无反馈）（S）。
-
-**功能 bug（非 polish）**
-
-- `proxy-logs-page.tsx:200` — 「Slow only」`latencyMin`/`latencyMax` 仅客户端过滤当前页，而 `total`/`manualPagination` 用服务端未过滤计数 → 分页与总数不一致，过滤结果页间漂移；`ProxyLogsQuery`（`lib/api/types.ts:479`）无 latency 字段，需后端支持或移除该过滤（M）。
+- `accounts/api.ts:281` — `useToggleAccountPin`/`useToggleAccountStatus`/`useToggleAccountCheckin` `onSuccess` 只 invalidate 不 toast（status 已由 #824 行内 Loader2 救场；pin/checkin 仍走下拉菜单 fire-and-forget 无反馈）（S，accounts 列属并行进程 badge 范围，需协调）。
 
 ### 旅程链路核实结论
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,18 @@
 > Product milestone timeline (grouped by version). Not the current-state source of truth.
 > Current state → [`STATE.md`](STATE.md) · open items → [`progress/MASTER.md`](progress/MASTER.md) · detailed version narrative → root [`CHANGELOG.md`](../CHANGELOG.md)
 
+## 2026-08-18 — 多角度复审驱动：动线 dead-end 收口 + proxy-logs 过滤服务端化 + downstream key edit
+
+三轮 PM/工程师/用户只读复审（发现写入审计 doc `## 2026-08-18 多角度复审`）后，按 backlog 交付：
+
+- **Dashboard stat 卡 drilldown + 凭证导出测试链**（#828）：`StatCard` 加 `to` → `<Link>`（四卡接线 `/accounts`/`/sites`/`/checkin`/`/proxy-logs`）；`credential-export-dialog` footer 加「发送测试请求」`<Link to='/model-tester'>`，闭合 onboarding 旅程最后一步 dead-end。503 测试。
+- **Proxy-logs 列表过滤服务端化**（功能 bug，#832）：`latencyMin`/`latencyMax` + 原 silent no-op 的 `client`/`from`/`to` 全部移入 `statsHandler.proxyLogs` 共享 `where`/`args`（items/count/summary 一致，`rebindAdminQuery` 双 dialect 安全），删客户端过滤 memo；6 后端 + 3 前端测试。
+- **Settings 边缘态硬化**（#832）：keys query 错误 → `SettingsSectionError`；enable `Switch` pending 禁用 + 唯一 `aria-label`；空态内联「Create」按钮；`update-center` 错误 → `SettingsSectionError`。506 测试。
+- **Downstream key edit mode**（#835）：`KeySheetForm` 加 `editingKey`，`editKeySchema = createKeySchema.omit({ key })`（secret 不可改），调 `api.updateDownstreamApiKey`（PATCH partial update，`key`/`description` 省略以保留）；Pencil 行按钮 + 4 测试。
+- **Price-compare → routes 深链**（#835）：`PriceRow` 加 `<Link to='/token-routes' search={{ q: row.model }}>`（routes 页 `q` 匹配 `modelPattern`）+ 4 测试。514 测试。
+- **验证**：go build/vet + handler/admin 测试绿；web tsgo/oxlint/oxfmt format:check/vitest 全绿；12 项 GHA CI 全绿（#832 首跑 golangci-lint schema 拉取超时 flaky，rerun 后绿）。
+- **工作流**：多 worktree 并行 + explore 子代理先核实审计真伪（proxy-logs 过滤 bug + client/from/to silent no-op 均经核实）+ 暗卷独立复跑聚焦测试。避让并行进程的 badge-feature 文件（accounts/checkin/routes/channels 列）。
+
 ## 2026-08-18 — UI/UX 批次：账户行内操作 + header SSOT + skeleton shimmer + 徽章机械迁移
 
 - **P2 #5 收口**：导入向导 focus-first-invalid 补 4 回归用例 + 2 处 `curly` lint 修复（#824）。


### PR DESCRIPTION
## Summary

Knowledge-hygiene sync after #828/#832/#835 merged — the audit doc's "2026-08-18 多角度复审" section now reflects what's been delivered vs. what remains:

- **Moved to "已收口"**: 6 items addressed across #828/#832/#835 — dashboard stat-card drilldown, credential-export test-request link, proxy-logs server-side filters (latency + client/from/to), settings edge-state hardening (keys error UI + Switch pending/a11y + empty-state inline Create + update-center error), downstream key edit mode, price-compare routes CTA.
- **Remaining as observations**: 5 items — proxy-log detail drilldown (M, needs target-page deep-link), channel detail action footer (M), channels empty-state CTA (S, overlaps parallel badge work), onboarding banner (M), accounts pin/checkin toast (S, overlaps parallel badge work).
- **log.md**: one milestone entry for the multi-perspective-driven fixes (#828/#832/#835).

No source changes — docs only. `go test ./docs/...` green.

## Test plan
- [x] `go test ./docs/...` — ok