### PR TITLE
feat(ui): dashboard onboarding banner for first-time empty state

### DIFF
--- a/web/src/features/dashboard/sections/overview/__tests__/overview-section.test.tsx
+++ b/web/src/features/dashboard/sections/overview/__tests__/overview-section.test.tsx
@@ -1,0 +1,144 @@
+// Behavior test for the dashboard overview onboarding banner.
+//
+// Closes the first-time-landing dead-end (user-perspective #1): a first-time
+// user with zero sites sees a "Create site" CTA that deep-links to /sites.
+// Asserts:
+//   (a) the banner + CTA render when the dashboard snapshot reports zero
+//       sites, and the CTA points at /sites;
+//   (b) the banner is absent once the user has at least one site;
+//   (c) the banner does not flash while the snapshot is still loading
+//       (siteCount undefined) — no false "empty state" before the first byte.
+//
+// The dashboard snapshot query (api.getDashboardSnapshot) is the SOLE signal
+// for the empty state — no extra query is added. Sibling overview widgets
+// (AnnouncementBanner, TodaySnapshotStrip, StatCard) are stubbed so the test
+// exercises the OverviewSection banner wiring in isolation; each sibling has
+// its own coverage. TodaySnapshotStrip pulls a live WebSocket (useRealtimeOps)
+// and StatCard uses requestAnimationFrame (CountUp) + recharts — both are
+// browser/animation boundaries outside the banner behavior under test.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+import { api } from '@/lib/api'
+
+import { OverviewSection } from '../overview-section'
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getDashboardSnapshot: vi.fn(),
+    getBalanceHistory: vi.fn(),
+    getSchedulerStatus: vi.fn(),
+  },
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ to, children }: { to?: string; children: ReactNode }) => (
+    <a href={to} data-testid='router-link'>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('@/features/dashboard/components/today-snapshot', () => ({
+  TodaySnapshotStrip: () => null,
+}))
+vi.mock('@/features/dashboard/components/announcement-banner', () => ({
+  AnnouncementBanner: () => null,
+}))
+vi.mock('@/features/dashboard/components/stat-card', () => ({
+  StatCard: () => <div data-testid='stat-card' />,
+}))
+
+const mockGetDashboardSnapshot = vi.mocked(api.getDashboardSnapshot)
+const mockGetBalanceHistory = vi.mocked(api.getBalanceHistory)
+const mockGetSchedulerStatus = vi.mocked(api.getSchedulerStatus)
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0, refetchOnWindowFocus: false },
+    },
+  })
+}
+
+function renderWithClient(ui: ReactNode) {
+  const queryClient = createQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  mockGetDashboardSnapshot.mockReset()
+  mockGetBalanceHistory.mockReset()
+  mockGetSchedulerStatus.mockReset()
+  // Non-banner queries resolve to empty-but-valid shapes so the section
+  // renders without throwing; the snapshot is overridden per test.
+  mockGetBalanceHistory.mockResolvedValue({ series: [], days: 8 })
+  mockGetSchedulerStatus.mockResolvedValue({ items: [], generatedAt: '' })
+})
+
+afterEach(() => cleanup())
+
+describe('OverviewSection onboarding banner', () => {
+  it('renders the banner + "Create site" CTA when there are zero sites', async () => {
+    mockGetDashboardSnapshot.mockResolvedValue({ siteCount: 0 })
+
+    renderWithClient(<OverviewSection />)
+
+    // Wait for the snapshot query to resolve and the banner heading to mount.
+    const heading = await screen.findByRole('heading', {
+      name: 'Welcome to Metapi',
+      level: 2,
+    })
+    expect(heading).toBeInTheDocument()
+    expect(
+      screen.getByText('Create your first site to start aggregating AI APIs.')
+    ).toBeInTheDocument()
+
+    // StatCard links are stubbed, so the only link on the page is the CTA.
+    const cta = screen.getByRole('link', { name: /Create site/i })
+    expect(cta).toHaveAttribute('href', '/sites')
+  })
+
+  it('hides the banner once the user has at least one site', async () => {
+    mockGetDashboardSnapshot.mockResolvedValue({ siteCount: 3 })
+
+    renderWithClient(<OverviewSection />)
+
+    await waitFor(() => {
+      expect(mockGetDashboardSnapshot).toHaveBeenCalledTimes(1)
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('heading', { name: 'Welcome to Metapi' })
+      ).not.toBeInTheDocument()
+    })
+    expect(
+      screen.queryByRole('link', { name: /Create site/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not flash the banner while the snapshot is still loading', async () => {
+    // Never resolves — simulates the loading window before the first byte
+    // lands. siteCount stays undefined, so the banner must not render.
+    mockGetDashboardSnapshot.mockImplementation(
+      () => new Promise<{ siteCount: number }>(() => {})
+    )
+
+    renderWithClient(<OverviewSection />)
+
+    expect(
+      screen.queryByRole('heading', { name: 'Welcome to Metapi' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: /Create site/i })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/web/src/features/dashboard/sections/overview/overview-section.tsx
+++ b/web/src/features/dashboard/sections/overview/overview-section.tsx
@@ -10,11 +10,13 @@
 // the scheduled-tasks table.
 
 import { useQuery } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
 import {
   Activity,
   CalendarCheck,
   ClipboardList,
   Globe,
+  Plus,
   RefreshCw,
   Users,
 } from 'lucide-react'
@@ -255,6 +257,28 @@ export function OverviewSection() {
       <AnnouncementBanner />
 
       <TodaySnapshotStrip />
+
+      {siteCount === 0 && (
+        <Card className='border-primary/40 bg-primary/5 border'>
+          <CardContent className='flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between'>
+            <div className='space-y-1'>
+              <h2 className='text-base font-semibold'>
+                {t('dashboard.onboarding.title')}
+              </h2>
+              <p className='text-muted-foreground text-sm'>
+                {t('dashboard.onboarding.description')}
+              </p>
+            </div>
+            <Button
+              className='self-start sm:self-auto'
+              render={<Link to='/sites' />}
+            >
+              <Plus className='size-4' />
+              {t('dashboard.onboarding.createSite')}
+            </Button>
+          </CardContent>
+        </Card>
+      )}
 
       <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4'>
         <StatCard

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -576,6 +576,11 @@
           "retry": "Retry"
         }
       },
+      "onboarding": {
+        "title": "Welcome to Metapi",
+        "description": "Create your first site to start aggregating AI APIs.",
+        "createSite": "Create site"
+      },
       "traffic": {
         "loadError": "Failed to load traffic data.",
         "incomeOutcome": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -576,6 +576,11 @@
           "retry": "重试"
         }
       },
+      "onboarding": {
+        "title": "欢迎使用 Metapi",
+        "description": "创建你的第一个站点，开始聚合 AI API。",
+        "createSite": "创建站点"
+      },
       "traffic": {
         "loadError": "加载流量数据失败。",
         "incomeOutcome": {


### PR DESCRIPTION
## Summary

Closes the first-time-landing dead-end (User-perspective #1 from the multi-perspective review): a new user landing on `/dashboard/overview` saw four stat cards reading `0`/`—` + an empty scheduler table with no guidance — they had to discover "Sites" in the sidebar themselves.

- Adds a conditional onboarding `<Card>` (brand-tinted) BEFORE the stat-cards grid, shown ONLY when `snapshot?.siteCount === 0`. Reuses the overview's existing `getDashboardSnapshot()` query — no new query. The `=== 0` check excludes the loading window (`undefined !== 0`) so there's no false empty-state flash before the snapshot resolves.
- "Create site" primary `<Button>` CTA → plain `/sites` (the sites page does NOT support `?create=1` auto-open — that's a noted follow-up; the accounts page is the one with `?siteId=…&create=1`). Still closes the discovery dead-end — the user lands on the Sites page where the "Add site" button is prominent.
- 3 i18n keys (`dashboard.onboarding.title/description/createSite`) in en + zh-CN.

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors
- [x] `bun run format:check` — green
- [x] `bun run test` — 517/517 across 61 files (incl. 3 NEW overview-section tests: banner renders when siteCount===0, absent when >0, absent during loading)
- [x] Independent re-ran `overview` (3/3) as暗卷 spot-check

## Notes
- Safe file domain (dashboard/overview) — no overlap with the parallel process's badge/channel/route work.
- Follow-up: add `?create=1` auto-open support to the sites page so the CTA can deep-link straight into the create dialog (the accounts page already has this pattern).