### PR TITLE
fix(model-tester): show token usage, drop dead chunks stat, suppress empty badge on error

### DIFF
--- a/web/src/features/model-tester/__tests__/api.test.ts
+++ b/web/src/features/model-tester/__tests__/api.test.ts
@@ -167,11 +167,69 @@ describe('runChatProbe', () => {
       doneReceived: true,
       statusCode: 200,
       latencyMs: 321,
-      chunks: 0,
       rawEvents: [truncatedBody],
       empty: false,
       error: undefined,
     })
+  })
+
+  it('extracts token usage from the bounded upstream body', async () => {
+    const truncatedBody = JSON.stringify({
+      choices: [
+        {
+          message: { content: 'upstream answer' },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: {
+        prompt_tokens: 12,
+        completion_tokens: 8,
+        total_tokens: 20,
+      },
+    })
+    testChatSync.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          statusCode: 200,
+          latencyMs: 321,
+          truncatedBody,
+          error: null,
+        }),
+        { status: 200 }
+      )
+    )
+
+    const result = await runChatProbe(buildChatPayload(formValues()))
+
+    expect(result.promptTokens).toBe(12)
+    expect(result.completionTokens).toBe(8)
+    expect(result.totalTokens).toBe(20)
+  })
+
+  it('derives total tokens when the upstream omits total_tokens', async () => {
+    const truncatedBody = JSON.stringify({
+      choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      usage: { input_tokens: 5, output_tokens: 7 },
+    })
+    testChatSync.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          statusCode: 200,
+          latencyMs: 10,
+          truncatedBody,
+          error: null,
+        }),
+        { status: 200 }
+      )
+    )
+
+    const result = await runChatProbe(buildChatPayload(formValues()))
+
+    expect(result.promptTokens).toBe(5)
+    expect(result.completionTokens).toBe(7)
+    expect(result.totalTokens).toBe(12)
   })
 
   it('surfaces the harness error instead of parsing it as model content', async () => {

--- a/web/src/features/model-tester/__tests__/batch-comparison.test.ts
+++ b/web/src/features/model-tester/__tests__/batch-comparison.test.ts
@@ -18,7 +18,6 @@ function response(overrides: Partial<TestResponse> = {}): TestResponse {
     doneReceived: true,
     statusCode: 200,
     latencyMs: 100,
-    chunks: 1,
     rawEvents: [],
     empty: false,
     ...overrides,

--- a/web/src/features/model-tester/api.ts
+++ b/web/src/features/model-tester/api.ts
@@ -55,6 +55,9 @@ type ParsedUpstreamBody = {
   doneReceived: boolean
   rawEvents: string[]
   error?: string
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
 }
 
 export function buildChatPayload(
@@ -280,12 +283,14 @@ function parseUpstreamBody(truncatedBody: string): ParsedUpstreamBody {
     const payload = JSON.parse(truncatedBody) as unknown
     const delta = parseAnyStreamDelta(payload)
     const error = extractErrorMessage(payload)
+    const usage = parseUsage(payload)
     return {
       content: delta.contentDelta ?? '',
       reasoningContent: delta.reasoningDelta ?? '',
       doneReceived: Boolean(delta.done),
       rawEvents: [truncatedBody],
       error: error || undefined,
+      ...usage,
     }
   } catch {
     return {
@@ -295,6 +300,79 @@ function parseUpstreamBody(truncatedBody: string): ParsedUpstreamBody {
       rawEvents: [truncatedBody],
     }
   }
+}
+
+function toTokenNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return undefined
+}
+
+/**
+ * Extract token usage from a parsed upstream body. Reads the OpenAI /
+ * Responses `usage` object (`prompt_tokens` / `completion_tokens` /
+ * `total_tokens`), the Claude `usage` object (`input_tokens` /
+ * `output_tokens`, total derived), and the Gemini `usageMetadata` object
+ * (`promptTokenCount` / `candidatesTokenCount` / `totalTokenCount`).
+ * Returns an empty object when the upstream body carries no usage (errors,
+ * non-JSON, or truncated bodies that failed to parse).
+ */
+function parseUsage(payload: unknown): {
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+} {
+  if (!payload || typeof payload !== 'object') return {}
+  const record = payload as Record<string, unknown>
+
+  const usage = record.usage as Record<string, unknown> | undefined
+  if (usage && typeof usage === 'object') {
+    const prompt = toTokenNumber(usage.prompt_tokens ?? usage.input_tokens)
+    const completion = toTokenNumber(
+      usage.completion_tokens ?? usage.output_tokens
+    )
+    const total = toTokenNumber(usage.total_tokens)
+    if (
+      prompt !== undefined ||
+      completion !== undefined ||
+      total !== undefined
+    ) {
+      const promptValue = prompt ?? 0
+      const completionValue = completion ?? 0
+      return {
+        promptTokens: promptValue,
+        completionTokens: completionValue,
+        totalTokens: total ?? promptValue + completionValue,
+      }
+    }
+  }
+
+  const usageMetadata = record.usageMetadata as
+    | Record<string, unknown>
+    | undefined
+  if (usageMetadata && typeof usageMetadata === 'object') {
+    const prompt = toTokenNumber(usageMetadata.promptTokenCount)
+    const completion = toTokenNumber(usageMetadata.candidatesTokenCount)
+    const total = toTokenNumber(usageMetadata.totalTokenCount)
+    if (
+      prompt !== undefined ||
+      completion !== undefined ||
+      total !== undefined
+    ) {
+      const promptValue = prompt ?? 0
+      const completionValue = completion ?? 0
+      return {
+        promptTokens: promptValue,
+        completionTokens: completionValue,
+        totalTokens: total ?? promptValue + completionValue,
+      }
+    }
+  }
+
+  return {}
 }
 
 function resolveHarnessError(
@@ -349,7 +427,9 @@ export async function resolveTestResponseError(
  * Run a single sync probe against `/api/test/chat` (the forced-channel
  * harness), unwrap its response envelope, and normalize the bounded upstream
  * body. The returned status, latency, and error come from the harness rather
- * than browser timing. No stream chunks or terminal SSE events are invented.
+ * than browser timing. Token usage is extracted from the upstream body when
+ * present; the harness does not compute estimated cost (only the proxy
+ * executor billing path does, which this probe bypasses).
  */
 export async function runChatProbe(
   chatPayload: ChatTestPayload,
@@ -371,10 +451,12 @@ export async function runChatProbe(
     doneReceived: upstreamBody.doneReceived,
     statusCode: envelope.statusCode,
     latencyMs: envelope.latencyMs,
-    chunks: 0,
     rawEvents: upstreamBody.rawEvents,
     empty: !upstreamBody.content && !upstreamBody.reasoningContent,
     error,
+    promptTokens: upstreamBody.promptTokens,
+    completionTokens: upstreamBody.completionTokens,
+    totalTokens: upstreamBody.totalTokens,
   }
 }
 

--- a/web/src/features/model-tester/components/test-response-viewer.tsx
+++ b/web/src/features/model-tester/components/test-response-viewer.tsx
@@ -4,7 +4,7 @@
 // assistant response) in order, with the live round streaming at the
 // bottom while a run is in flight. The reasoning and raw/JSON tabs keep
 // showing the current (or last) run's artifacts, and the stats bar reports
-// the last run's latency / chunk count / done sentinel / error. The parent
+// the last run's latency / token usage / done sentinel / error. The parent
 // owns the streaming accumulation state and passes the current strings down
 // each render so the viewer re-renders on every delta.
 
@@ -17,7 +17,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
 import { Spinner } from '@/components/ui/spinner'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { formatLatency } from '@/lib/format'
+import { formatInt, formatLatency } from '@/lib/format'
 import { cn } from '@/lib/utils'
 
 import type { ChatMessage, TestResponse } from '../types'
@@ -150,6 +150,11 @@ export function TestResponseViewer(props: TestResponseViewerProps) {
   const hasReasoning = props.reasoningContent.length > 0
   const lastMessage = props.messages.at(-1)
   const hasLiveRound = props.isRunning || lastMessage?.role === 'user'
+  const hasUsage =
+    !!props.response &&
+    (props.response.promptTokens !== undefined ||
+      props.response.completionTokens !== undefined ||
+      props.response.totalTokens !== undefined)
   const isEmpty =
     !props.isRunning &&
     !hasContent &&
@@ -267,20 +272,30 @@ export function TestResponseViewer(props: TestResponseViewerProps) {
         )}
         {props.response && !props.isRunning && (
           <>
-            <Badge variant={props.response.empty ? 'secondary' : 'default'}>
-              {props.response.empty
-                ? t('modelTester.viewer.empty')
-                : t('modelTester.viewer.done')}
-            </Badge>
-            <span className='text-muted-foreground text-xs'>
+            {!props.error && (
+              <Badge variant={props.response.empty ? 'secondary' : 'default'}>
+                {props.response.empty
+                  ? t('modelTester.viewer.empty')
+                  : t('modelTester.viewer.done')}
+              </Badge>
+            )}
+            <span className='text-muted-foreground text-xs tabular-nums'>
               {t('modelTester.viewer.latency', {
                 value: formatLatency(props.response.latencyMs),
               })}
             </span>
-            <span className='text-muted-foreground text-xs'>
-              {t('modelTester.viewer.chunks', { value: props.response.chunks })}
-            </span>
-            {!props.response.doneReceived && (
+            {hasUsage && (
+              <span className='text-muted-foreground text-xs tabular-nums'>
+                {t('modelTester.viewer.usage', {
+                  total: formatInt(props.response.totalTokens ?? null),
+                  prompt: formatInt(props.response.promptTokens ?? null),
+                  completion: formatInt(
+                    props.response.completionTokens ?? null
+                  ),
+                })}
+              </span>
+            )}
+            {!props.response.doneReceived && !props.error && (
               <span className='text-muted-foreground text-xs'>
                 {t('modelTester.viewer.noDone')}
               </span>

--- a/web/src/features/model-tester/types.ts
+++ b/web/src/features/model-tester/types.ts
@@ -75,8 +75,12 @@ export type TestStreamDelta = {
  * Finalised test response the viewer renders after the run finishes.
  * `content` / `reasoningContent` come from the harness's bounded upstream
  * body. `statusCode`, `latencyMs`, and `error` preserve upstream harness
- * truth. The synchronous harness does not emit stream chunks, so `chunks` is
- * zero; `rawEvents` contains the actual upstream body for the raw debug tab.
+ * truth. `promptTokens` / `completionTokens` / `totalTokens` are extracted
+ * from the upstream body's `usage` object (OpenAI `prompt_tokens` /
+ * Claude `input_tokens` / Gemini `usageMetadata`) when the upstream
+ * response carries them; absent for non-JSON or truncated bodies. The
+ * synchronous harness does not emit stream chunks. `rawEvents` contains
+ * the actual upstream body for the raw debug tab.
  */
 export type TestResponse = {
   content: string
@@ -84,10 +88,12 @@ export type TestResponse = {
   doneReceived: boolean
   statusCode: number
   latencyMs: number
-  chunks: number
   rawEvents: string[]
   empty: boolean
   error?: string
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
 }
 
 /**

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -223,7 +223,7 @@
         "empty": "Empty",
         "done": "Done",
         "latency": "Latency: {{value}}",
-        "chunks": "Chunks: {{value}}",
+        "usage": "Tokens: {{total}} ({{prompt}} in / {{completion}} out)",
         "noDone": "No done signal",
         "error": "Error",
         "emptyHint": "Send a request to see the response here.",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -223,7 +223,7 @@
         "empty": "空响应",
         "done": "完成",
         "latency": "延迟：{{value}}",
-        "chunks": "分块：{{value}}",
+        "usage": "Token：{{total}}（入 {{prompt}} / 出 {{completion}}）",
         "noDone": "未收到完成信号",
         "error": "错误",
         "emptyHint": "发送请求后可在此查看响应。",


### PR DESCRIPTION
## Summary

Closes 3 model-tester result-clarity gaps found in a fresh multi-perspective review of the tester feature (safe, model-tester-only files — no overlap with the parallel process's badge/channel/route work).

1. **Token usage now displayed** — a successful test response carries `usage` (prompt/completion/total tokens) inside the upstream body, but the result UI never showed it. Added `parseUsage` in `api.ts` (extracts across OpenAI/Claude/Responses/Gemini protocols, derives `total` when omitted) + extended `TestResponse` with optional `promptTokens`/`completionTokens`/`totalTokens`; the viewer renders the breakdown (via shared `formatInt`) only when usage is present. **Estimated cost is intentionally NOT displayed** — the test harness is a direct HTTP probe that bypasses the proxy executor billing path, so the cost isn't on the wire; fabricating it would violate the project's honesty rule (documented as a residual).

2. **Removed the dead "chunks: 0" stat** — `chunks` was hardcoded `0` (the sync harness never emits stream chunks; the stream endpoint is an honest 501). Removed the field, the `chunks: 0` assignment, the viewer span, and the `modelTester.viewer.chunks` i18n key (en + zh-CN).

3. **Suppressed the contradictory "empty" badge on failed runs** — a failed single run showed BOTH "empty" and "error" badges. Now the empty/done badge is suppressed when `error` is set (only the error badge shows; latency stays — factual).

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors
- [x] `bun run format:check` — green
- [x] `bun run test` — 516/516 across 60 files (incl. 2 NEW api cases: extracts token usage, derives total when omitted; updated batch-comparison helper to drop stale `chunks: 1`)
- [x] Independent re-ran the `api` suite (15/15) as暗卷 spot-check

## Notes
- Honest about cost: usage tokens are real (on the wire inside `truncatedBody`); estimated cost is not (harness bypasses billing) — not fabricated.
- Removed `chunks` entirely rather than conditionalizing — it was genuinely always-dead (sync harness, stream 501).