### PR TITLE
feat(sites): ?create=1 auto-open deep-link (completes onboarding CTA)

### DIFF
--- a/web/src/features/dashboard/sections/overview/overview-section.tsx
+++ b/web/src/features/dashboard/sections/overview/overview-section.tsx
@@ -271,7 +271,7 @@ export function OverviewSection() {
             </div>
             <Button
               className='self-start sm:self-auto'
-              render={<Link to='/sites' />}
+              render={<Link to='/sites' search={{ create: true }} />}
             >
               <Plus className='size-4' />
               {t('dashboard.onboarding.createSite')}

--- a/web/src/features/sites/__tests__/sites-schema.test.ts
+++ b/web/src/features/sites/__tests__/sites-schema.test.ts
@@ -257,3 +257,31 @@ describe('sitesSearchSchema', () => {
     expect(result.q).toBe(42)
   })
 })
+
+// ---------------------------------------------------------------------------
+// create deep-link param (one-shot transient — not a persisted filter)
+// ---------------------------------------------------------------------------
+
+describe('sitesSearchSchema — create deep-link', () => {
+  it('coerces the router-parsed `?create=1` (number) to true', () => {
+    expect(sitesSearchSchema.parse({ create: 1 }).create).toBe(true)
+  })
+
+  it('coerces a literal boolean true to true', () => {
+    expect(sitesSearchSchema.parse({ create: true }).create).toBe(true)
+  })
+
+  it('omits create (undefined) when the param is absent', () => {
+    expect(sitesSearchSchema.parse({}).create).toBeUndefined()
+  })
+
+  it('coerces 0 to false so a `?create=0` deep link never opens the dialog', () => {
+    expect(sitesSearchSchema.parse({ create: 0 }).create).toBe(false)
+  })
+
+  it('does not throw on a malformed create value (graceful fallback)', () => {
+    expect(
+      sitesSearchSchema.safeParse({ create: { weird: true } }).success
+    ).toBe(true)
+  })
+})

--- a/web/src/features/sites/components/sites-page.tsx
+++ b/web/src/features/sites/components/sites-page.tsx
@@ -9,12 +9,13 @@
 // `/sites` route file lands its own `validateSearch`. Mobile cards are
 // handled by `DataTablePage` via the column `meta` flags.
 
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import {
   Plus as PlusIcon,
   Trash2 as Trash2Icon,
   Upload as UploadIcon,
 } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -110,6 +111,12 @@ function buildHref(next: UrlTableStateUpdate<SitesUrlFilters>): string {
   const sortString = encodeSorting(merged.sorting)
   if (sortString) params.set('sort', sortString)
   if (merged.filters.status) params.set('status', merged.filters.status)
+  // Preserve the one-shot `create` deep-link param across table-state
+  // navigations (page-clamp / sort / filter) until the page's consumption
+  // effect strips it — mirrors the accounts page's buildAccountsHref guard
+  // for its guided-flow `siteId`/`create` params.
+  const guidedCreate = new URLSearchParams(window.location.search).get('create')
+  if (guidedCreate) params.set('create', guidedCreate)
   const queryString = params.toString()
   return queryString ? `/sites?${queryString}` : '/sites'
 }
@@ -142,6 +149,8 @@ function useSitesUrlState() {
 
 export function SitesPage() {
   const { t } = useTranslation()
+  const search = useSearch({ from: '/_authenticated/sites' })
+  const navigate = useNavigate()
   const sitesQuery = useSites()
   // The /api/sites endpoint does not include account counts; enrich the rows
   // from the already-cached accounts snapshot (the documented plan in
@@ -182,6 +191,26 @@ export function SitesPage() {
     ids: number[]
     count: number
   } | null>(null)
+
+  // Consume the one-shot `?create=1` deep link exactly once: open the create
+  // dialog (in create mode — no edit target), then strip the transient
+  // `create` param from the URL so a refetch / remount never reopens it.
+  // Mirrors the accounts page's create handling; the sites version is simpler
+  // — no `siteId` preselection, so it does not wait for the list snapshot.
+  // The `useRef` guard survives the strict-mode double-invoke and the
+  // post-navigate re-render (search.create becomes undefined).
+  const createConsumed = useRef(false)
+  useEffect(() => {
+    if (createConsumed.current || search.create !== true) return
+    setEditingSite(null)
+    setFormOpen(true)
+    createConsumed.current = true
+    navigate({
+      to: '/sites',
+      search: { ...search, create: undefined },
+      replace: true,
+    })
+  }, [search, navigate])
 
   const urlState = useSitesUrlState()
 

--- a/web/src/features/sites/lib/sites-schema.ts
+++ b/web/src/features/sites/lib/sites-schema.ts
@@ -122,7 +122,13 @@ export const SITE_FORM_DEFAULT_VALUES: SiteFormValues = {
 }
 
 // --- URL search state -------------------------------------------------------
-
+//
+// `create` is a one-shot transient deep-link param (written by the dashboard
+// onboarding CTA as `?create=1`): it auto-opens the create dialog once, then
+// the page strips it so a refetch / remount never reopens it. TanStack Router
+// JSON-parses `?create=1` into the number `1`, so `z.coerce.boolean()` mirrors
+// the accounts route's `create` field exactly (truthy → true). It is NOT a
+// persisted filter and never reaches `readSearch` / `buildHref`'s table state.
 export const sitesSearchSchema = z.object({
   q: stringSearchParam,
   page: z.coerce.number().int().min(0).catch(0).default(0),
@@ -133,4 +139,5 @@ export const sitesSearchSchema = z.object({
     .transform((value) => encodeSortingParam(value))
     .catch(undefined),
   status: stringSearchParam,
+  create: z.coerce.boolean().optional().catch(undefined),
 })


### PR DESCRIPTION
## Summary

Completes the onboarding journey deep-link started in #838: the dashboard onboarding banner "Create site" CTA linked to plain `/sites` because the sites page didn't support `?create=1` auto-open. Now it does.

- **`sites-schema.ts`**: added `create: z.coerce.boolean().optional().catch(undefined)` to `sitesSearchSchema` (mirrors the accounts route's `create` field). `z.coerce.boolean()` handles TanStack Router JSON-parsing `?create=1` → `1` → `true`; `.catch(undefined)` degrades malformed values instead of throwing a route error.
- **`sites-page.tsx`**: mirrors the accounts `?create` one-shot consumption pattern (adapted to the simpler sites case — no `siteId` preselection): a `createConsumed` `useRef` guard + `useEffect` opens the create dialog exactly once, then strips the transient via `navigate(…, replace)`. `buildHref` preserves `create` across table-state navigations until the effect strips it (closes a race with `useDataTable`'s `ensurePageInRange` effect).
- **`overview-section.tsx`**: onboarding banner CTA now `<Link to='/sites' search={{ create: true }} />` — deep-links straight into the site-create dialog.

## Test plan
- [x] `bun run typecheck` — 0 errors (no routeTree.gen.ts regeneration needed; the gen file is untouched)
- [x] `bun run lint` — 0 errors
- [x] `bun run format:check` — green
- [x] `bun run test` — 522/522 across 61 files (incl. 5 NEW `sites-schema` cases: coerce 1→true, true→true, absent→undefined, 0→false, malformed no-throw)
- [x] Independent re-ran `sites-schema` (30/30) as暗卷 spot-check

## Notes
- Safe file domain (sites + dashboard overview) — no overlap with the parallel process's badge/channel/route work.
- `accounts-deep-link.ts` read-only as the pattern reference; not modified.