### PR TITLE
feat(ui): proxy-log detail drills down to route and channel pages

### DIFF
--- a/docs/analysis/ui-ux-audit-2026-08.md
+++ b/docs/analysis/ui-ux-audit-2026-08.md
@@ -102,7 +102,7 @@
 
 **动线 dead-end / 缺 CTA**
 
-- `proxy-log-detail-sheet.tsx:143-177` — channel/account/route/token ID 渲染为不可点 `#NNN`；要做 drilldown 需目标页支持 `?channelId=` 等 deep-link 过滤（M）。
+- `proxy-log-detail-sheet.tsx:143-177` — ~~channel/account/route/token ID 渲染为不可点 `#NNN`~~ 2026-08-18 部分修复：route/channel ID 改为 router Link（`/token-routes?routeId=N` / `/channels?channelId=N`），两目标页各自一次性消费参数打开详情 sheet 后 strip（accounts create/siteId 同款消费模式，stale id 静默清除），9 行为用例覆盖；account/token 字段已有名字回显（仅无名时显示 `#NNN`），留作后续观察（M）。
 - `channel-detail-sheet.tsx:216` — 无 `SheetFooter`，cooldown/breaker_open 通道无「清冷却 / 探测」动作（可复用 `useClearRouteCooldown` 模式）（M）。
 - `channels-page.tsx:139` — 空态无 CTA（应接 `/accounts` 或触发 `rebuildMutation`）（S，但 channels 列属并行进程 badge 范围，需协调）。
 - `overview-section.tsx:253` — 首次落地（0 site）无 onboarding banner/CTA（M，#828 stat-card drilldown 部分缓解）。

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,13 @@
 > Product milestone timeline (grouped by version). Not the current-state source of truth.
 > Current state → [`STATE.md`](STATE.md) · open items → [`progress/MASTER.md`](progress/MASTER.md) · detailed version narrative → root [`CHANGELOG.md`](../CHANGELOG.md)
 
+## 2026-08-18 — proxy-log 详情 → route/channel 钻取链路（复审 M 级收口）
+
+- **背景**：复审发现 proxy-log 详情 sheet 的 route/channel/account/token ID 是不可点 `#NNN`，排障动线「这条请求为什么失败 → 是哪条路由/通道」断在日志页。
+- **修复**：route/channel ID 改为 router Link（`/token-routes?routeId=N` / `/channels?channelId=N`）；`routesSearchSchema`/`channelsSearchSchema` 各加一个 tolerant 数字参数；两个目标页按 accounts create/siteId 既有消费模式一次性消费：等列表加载 → 打开对应详情 sheet → `navigate(replace)` strip 参数（stale id 静默清除，routes 页 strip 时保留 accountId/siteId chain context）。`routeId` 有意不写回 href 序列化。
+- **范围诚实**：account/token 字段已有名字回显（仅无名时回退 `#NNN`），drilldown 留作后续观察。
+- **验证**：新增 3 个测试文件 9 行为用例（链接目标 + search 参数 / 两页开 sheet + strip / stale id / 无参数不导航）；tsgo 0 error · oxlint 0 error · oxfmt green · vitest 全绿 · knip exit 0 · production build pass。
+
 ## 2026-08-18 — 多角度复审驱动：动线 dead-end 收口 + proxy-logs 过滤服务端化 + downstream key edit
 
 三轮 PM/工程师/用户只读复审（发现写入审计 doc `## 2026-08-18 多角度复审`）后，按 backlog 交付：

--- a/web/src/features/channels/__tests__/channels-page-drilldown.test.tsx
+++ b/web/src/features/channels/__tests__/channels-page-drilldown.test.tsx
@@ -1,0 +1,133 @@
+// Behavior tests for the channels one-shot drilldown (proxy-log detail ->
+// `/channels?channelId=N`): the page opens the detail sheet for the
+// referenced channel and strips the param. A stale id is stripped without
+// opening anything. Mirrors the accounts create/siteId consume pattern.
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { ChannelsPage } from '../components/channels-page'
+import type { ChannelRow } from '../types'
+
+const testState = vi.hoisted(() => ({
+  search: {} as Record<string, unknown>,
+  channels: [] as ChannelRow[],
+  navigate: vi.fn(),
+  detailSheetProps: null as {
+    channel: ChannelRow | null
+    open: boolean
+  } | null,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => testState.navigate,
+  useSearch: () => testState.search,
+}))
+
+vi.mock('@/components/data-table', () => ({
+  DataTablePage: () => null,
+  encodeSorting: () => '',
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    sorting: [],
+    onSortingChange: vi.fn(),
+    ensurePageInRange: vi.fn(),
+  }),
+  useDataTable: () => ({ table: {} }),
+}))
+
+vi.mock('../api', () => ({
+  useChannels: () => ({
+    data: testState.channels,
+    isLoading: false,
+    isFetching: false,
+    error: null,
+  }),
+}))
+
+vi.mock('../components/channel-detail-sheet', () => ({
+  ChannelDetailSheet: (props: {
+    channel: ChannelRow | null
+    open: boolean
+  }) => {
+    testState.detailSheetProps = props
+    return null
+  },
+}))
+
+vi.mock('../components/channels-columns', () => ({
+  useChannelsColumns: () => [],
+}))
+
+function makeChannel(id: number): ChannelRow {
+  return {
+    id,
+    routeId: 1,
+    name: `channel-${id}`,
+    status: 'enabled',
+    enabled: true,
+  } as unknown as ChannelRow
+}
+
+beforeEach(() => {
+  testState.search = {}
+  testState.channels = []
+  testState.navigate.mockReset()
+  testState.detailSheetProps = null
+})
+
+afterEach(() => cleanup())
+
+describe('ChannelsPage drilldown', () => {
+  it('opens the detail sheet for the referenced channel and strips the param', async () => {
+    testState.search = { channelId: 3 }
+    testState.channels = [makeChannel(3), makeChannel(4)]
+
+    render(<ChannelsPage />)
+
+    await waitFor(() => {
+      expect(testState.detailSheetProps?.open).toBe(true)
+    })
+    expect(testState.detailSheetProps?.channel?.id).toBe(3)
+    expect(testState.navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/channels',
+        replace: true,
+        search: expect.objectContaining({ channelId: undefined }),
+      })
+    )
+  })
+
+  it('strips a stale channel id without opening the sheet', async () => {
+    testState.search = { channelId: 99 }
+    testState.channels = [makeChannel(3)]
+
+    render(<ChannelsPage />)
+
+    await waitFor(() => {
+      expect(testState.navigate).toHaveBeenCalled()
+    })
+    expect(testState.detailSheetProps?.open).toBe(false)
+    expect(testState.detailSheetProps?.channel).toBeNull()
+  })
+
+  it('does not navigate when no drilldown param is present', async () => {
+    testState.channels = [makeChannel(3)]
+
+    render(<ChannelsPage />)
+
+    await waitFor(() => {
+      expect(testState.detailSheetProps).not.toBeNull()
+    })
+    expect(testState.navigate).not.toHaveBeenCalled()
+    expect(testState.detailSheetProps?.open).toBe(false)
+  })
+})

--- a/web/src/features/channels/components/channels-page.tsx
+++ b/web/src/features/channels/components/channels-page.tsx
@@ -5,8 +5,9 @@
 // from the row eye action) surfaces the routing-health fields the columns
 // already render, mirroring the model / route / account detail pattern.
 
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import type { ColumnFiltersState } from '@tanstack/react-table'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -83,10 +84,36 @@ function useChannelsUrlState() {
 
 export function ChannelsPage() {
   const { t } = useTranslation()
+  const search = useSearch({ from: '/_authenticated/channels' })
+  const navigate = useNavigate()
   const channelsQuery = useChannels()
   const urlState = useChannelsUrlState()
   const [detailChannel, setDetailChannel] = useState<ChannelRow | null>(null)
   const [detailOpen, setDetailOpen] = useState(false)
+
+  // One-shot channel drilldown (proxy-log detail -> `?channelId=N`): wait
+  // for the list, open the detail sheet for the referenced channel, then
+  // strip the param so a refetch or remount never reopens the sheet. A
+  // stale or unknown id is stripped without opening anything.
+  const drilldownConsumed = useRef(false)
+  useEffect(() => {
+    if (drilldownConsumed.current || !search.channelId) return
+    if (channelsQuery.isLoading) return
+
+    const target = (channelsQuery.data ?? []).find(
+      (channel) => channel.id === search.channelId
+    )
+    drilldownConsumed.current = true
+    if (target) {
+      setDetailChannel(target)
+      setDetailOpen(true)
+    }
+    navigate({
+      to: '/channels',
+      search: { ...search, channelId: undefined },
+      replace: true,
+    })
+  }, [search, channelsQuery.isLoading, channelsQuery.data, navigate])
 
   const columnActions: ChannelsColumnActions = {
     onView: (channel) => {

--- a/web/src/features/channels/lib/channels-schema.ts
+++ b/web/src/features/channels/lib/channels-schema.ts
@@ -19,4 +19,8 @@ export const channelsSearchSchema = z.object({
     .optional()
     .transform((value) => encodeSortingParam(value))
     .catch(undefined),
+  // One-shot drilldown from the proxy-log detail sheet: open the detail
+  // view for this channel, then the page strips the param (same consume
+  // pattern as the accounts `create`/`siteId` deep link).
+  channelId: z.coerce.number().int().positive().optional().catch(undefined),
 })

--- a/web/src/features/proxy-logs/__tests__/proxy-log-detail-links.test.tsx
+++ b/web/src/features/proxy-logs/__tests__/proxy-log-detail-links.test.tsx
@@ -1,0 +1,124 @@
+// Behavior tests for the proxy-log detail drilldown links (2026-08-18
+// multi-perspective review: channel/account/route/token IDs rendered as
+// inert `#NNN`). Asserts the route/channel IDs are router links carrying
+// the one-shot drilldown search params their target pages consume.
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { ProxyLogDetailSheet } from '../components/proxy-log-detail-sheet'
+import type { ProxyLog, ProxyLogDetail } from '../types'
+
+const testState = vi.hoisted(() => ({
+  detail: null as ProxyLogDetail | null,
+  links: [] as Array<{ to: string; search: Record<string, unknown> }>,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    to,
+    search,
+    children,
+  }: {
+    to: string
+    search?: Record<string, unknown>
+    children?: ReactNode
+  }) => {
+    testState.links.push({ to, search: search ?? {} })
+    return <a href={to}>{children}</a>
+  },
+}))
+
+vi.mock('../api', () => ({
+  useProxyLog: () => ({
+    data: testState.detail,
+    isLoading: false,
+    isFetching: false,
+  }),
+}))
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    writable: true,
+    value: ResizeObserverStub,
+  })
+})
+
+function makeLog(): ProxyLog {
+  return {
+    id: 11,
+    createdAt: '2026-08-18T00:00:00Z',
+    status: 'success',
+    modelRequested: 'gpt-4o',
+  } as unknown as ProxyLog
+}
+
+afterEach(() => {
+  cleanup()
+  testState.detail = null
+  testState.links = []
+})
+
+describe('ProxyLogDetailSheet drilldown links', () => {
+  it('links the route id to the token-routes page with a routeId param', async () => {
+    testState.detail = {
+      ...makeLog(),
+      routeId: 5,
+      channelId: 8,
+    } as ProxyLogDetail
+
+    render(<ProxyLogDetailSheet log={makeLog()} open onOpenChange={() => {}} />)
+
+    const routeLink = await screen.findByRole('link', { name: '#5' })
+    expect(routeLink).toHaveAttribute('href', '/token-routes')
+    expect(testState.links.some((link) => link.search.routeId === 5)).toBe(true)
+  })
+
+  it('links the channel id to the channels page with a channelId param', async () => {
+    testState.detail = {
+      ...makeLog(),
+      routeId: 5,
+      channelId: 8,
+    } as ProxyLogDetail
+
+    render(<ProxyLogDetailSheet log={makeLog()} open onOpenChange={() => {}} />)
+
+    const channelLink = await screen.findByRole('link', { name: '#8' })
+    expect(channelLink).toHaveAttribute('href', '/channels')
+    expect(testState.links.some((link) => link.search.channelId === 8)).toBe(
+      true
+    )
+  })
+
+  it('renders a dash instead of a link when the ids are missing', async () => {
+    testState.detail = { ...makeLog() } as ProxyLogDetail
+
+    render(<ProxyLogDetailSheet log={makeLog()} open onOpenChange={() => {}} />)
+
+    await screen.findByText(/Overview/i)
+    expect(screen.queryAllByRole('link')).toHaveLength(0)
+  })
+})

--- a/web/src/features/proxy-logs/components/proxy-log-detail-sheet.tsx
+++ b/web/src/features/proxy-logs/components/proxy-log-detail-sheet.tsx
@@ -1,6 +1,7 @@
 // metapi-go/features/proxy-logs/components — proxy log detail Sheet.
 // i18n: all user-visible strings migrated to t() calls.
 
+import { Link } from '@tanstack/react-router'
 import { Copy as CopyIcon, Check as CheckIcon } from 'lucide-react'
 import { useMemo, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -171,10 +172,30 @@ function DetailOverview({ detail }: { detail: ProxyLogDetail }) {
           {detail.retryCount ? `×${detail.retryCount}` : '0'}
         </DetailField>
         <DetailField label={t('proxyLogs.detail.route')}>
-          {detail.routeId ? `#${detail.routeId}` : '—'}
+          {detail.routeId ? (
+            <Link
+              to='/token-routes'
+              search={{ routeId: detail.routeId }}
+              className='text-primary hover:underline'
+            >
+              {`#${detail.routeId}`}
+            </Link>
+          ) : (
+            '—'
+          )}
         </DetailField>
         <DetailField label={t('proxyLogs.detail.channel')}>
-          {detail.channelId ? `#${detail.channelId}` : '—'}
+          {detail.channelId ? (
+            <Link
+              to='/channels'
+              search={{ channelId: detail.channelId }}
+              className='text-primary hover:underline'
+            >
+              {`#${detail.channelId}`}
+            </Link>
+          ) : (
+            '—'
+          )}
         </DetailField>
         <DetailField label={t('proxyLogs.detail.estimatedCost')}>
           {detail.estimatedCost !== null && detail.estimatedCost !== undefined

--- a/web/src/features/token-routes/__tests__/routes-page-drilldown.test.tsx
+++ b/web/src/features/token-routes/__tests__/routes-page-drilldown.test.tsx
@@ -1,0 +1,160 @@
+// Behavior tests for the token-routes one-shot drilldown (proxy-log detail
+// -> `/token-routes?routeId=N`): the page opens the route detail sheet for
+// the referenced route and strips the param, without disturbing the
+// persistent accountId/siteId chain context. A stale id strips silently.
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { RoutesPage } from '../components/routes-page'
+import type { RouteSummaryRow } from '../types'
+
+const testState = vi.hoisted(() => ({
+  routeIdParam: '',
+  routerSearch: {} as Record<string, unknown>,
+  routes: [] as RouteSummaryRow[],
+  navigate: vi.fn(),
+  detailSheetProps: null as {
+    route: RouteSummaryRow | null
+    open: boolean
+  } | null,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => testState.navigate,
+  useSearch: () => testState.routerSearch,
+  Link: ({ children }: { children?: ReactNode }) => children,
+}))
+
+vi.mock('@/components/data-table', () => ({
+  DataTablePage: () => null,
+  DataTableBulkActions: () => null,
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    filters: {
+      enabled: '',
+      accountId: '',
+      siteId: '',
+      routeId: testState.routeIdParam,
+    },
+  }),
+  useDataTable: () => ({ table: {} }),
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}))
+
+vi.mock('../api', () => ({
+  useRoutes: () => ({
+    data: testState.routes,
+    isLoading: false,
+    isFetching: false,
+    error: null,
+  }),
+  useModelTokenCandidates: () => ({ data: undefined }),
+  useDeleteRoute: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateRoute: () => ({ mutate: vi.fn(), isPending: false }),
+  useClearRouteCooldown: () => ({ mutate: vi.fn(), isPending: false }),
+  useRebuildRoutes: () => ({ mutate: vi.fn(), isPending: false }),
+  useRefreshRouteDecisions: () => ({ mutate: vi.fn(), isPending: false }),
+  useBatchUpdateRoutes: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useZeroChannelRoutes: (routes: RouteSummaryRow[]) => routes,
+}))
+
+vi.mock('../components/route-detail-sheet', () => ({
+  RouteDetailSheet: (props: {
+    route: RouteSummaryRow | null
+    open: boolean
+  }) => {
+    testState.detailSheetProps = props
+    return null
+  },
+}))
+
+vi.mock('../components/route-form-dialog', () => ({
+  RouteFormDialog: () => null,
+}))
+
+vi.mock('../components/routes-columns', () => ({
+  useRoutesColumns: () => [],
+}))
+
+function makeRoute(id: number): RouteSummaryRow {
+  return {
+    id,
+    routeMode: 'pattern',
+    modelPattern: `model-${id}`,
+    enabled: true,
+  } as unknown as RouteSummaryRow
+}
+
+beforeEach(() => {
+  testState.routeIdParam = ''
+  testState.routerSearch = {}
+  testState.routes = []
+  testState.navigate.mockReset()
+  testState.detailSheetProps = null
+})
+
+afterEach(() => cleanup())
+
+describe('RoutesPage drilldown', () => {
+  it('opens the detail sheet for the referenced route and strips the param', async () => {
+    testState.routeIdParam = '5'
+    testState.routerSearch = { routeId: 5, accountId: 7 }
+    testState.routes = [makeRoute(5), makeRoute(6)]
+
+    render(<RoutesPage />)
+
+    await waitFor(() => {
+      expect(testState.detailSheetProps?.open).toBe(true)
+    })
+    expect(testState.detailSheetProps?.route?.id).toBe(5)
+    // Strip is a replace-navigation that keeps the chain context intact.
+    expect(testState.navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/token-routes',
+        replace: true,
+        search: expect.objectContaining({
+          routeId: undefined,
+          accountId: 7,
+        }),
+      })
+    )
+  })
+
+  it('strips a stale route id without opening the sheet', async () => {
+    testState.routeIdParam = '99'
+    testState.routes = [makeRoute(5)]
+
+    render(<RoutesPage />)
+
+    await waitFor(() => {
+      expect(testState.navigate).toHaveBeenCalled()
+    })
+    expect(testState.detailSheetProps?.open).toBe(false)
+    expect(testState.detailSheetProps?.route).toBeNull()
+  })
+
+  it('does not navigate when no drilldown param is present', async () => {
+    testState.routes = [makeRoute(5)]
+
+    render(<RoutesPage />)
+
+    await waitFor(() => {
+      expect(testState.detailSheetProps).not.toBeNull()
+    })
+    expect(testState.navigate).not.toHaveBeenCalled()
+    expect(testState.detailSheetProps?.open).toBe(false)
+  })
+})

--- a/web/src/features/token-routes/components/__tests__/routes-page.test.tsx
+++ b/web/src/features/token-routes/components/__tests__/routes-page.test.tsx
@@ -53,7 +53,7 @@ vi.mock('@/components/data-table', () => ({
     onPaginationChange: vi.fn(),
     sorting: [],
     onSortingChange: vi.fn(),
-    filters: { enabled: '', accountId: '', siteId: '' },
+    filters: { enabled: '', accountId: '', siteId: '', routeId: '' },
   }),
   useDataTable: () => ({
     table: {
@@ -61,6 +61,11 @@ vi.mock('@/components/data-table', () => ({
       resetRowSelection: vi.fn(),
     },
   }),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useSearch: () => ({}),
+  useNavigate: () => vi.fn(),
 }))
 
 vi.mock('../../api', () => ({

--- a/web/src/features/token-routes/components/routes-page.tsx
+++ b/web/src/features/token-routes/components/routes-page.tsx
@@ -2,9 +2,10 @@
 // metapi-go features/token-routes/components — the routes list page.
 // i18n: all user-visible strings migrated to t() calls.
 
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import type { ColumnFiltersState, Table } from '@tanstack/react-table'
 import { Loader2, Plus, Power, RefreshCw, Zap } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -52,11 +53,15 @@ import { useRoutesColumns } from './routes-columns'
 
 const DEFAULT_PAGE_SIZE = 20
 
-/** Page-specific URL filters: the `enabled` column filter + chain context. */
+/** Page-specific URL filters: the `enabled` column filter + chain context.
+ * `routeId` is a one-shot drilldown param (proxy-log detail sheet) that the
+ * page consumes into the detail sheet and then strips; it is deliberately
+ * never serialized back into hrefs. */
 type TokenRoutesUrlFilters = {
   enabled: string
   accountId: string
   siteId: string
+  routeId: string
 }
 
 /**
@@ -84,6 +89,7 @@ function readTokenRoutesSearch(
       accountId:
         search?.accountId === undefined ? '' : String(search.accountId),
       siteId: search?.siteId === undefined ? '' : String(search.siteId),
+      routeId: search?.routeId === undefined ? '' : String(search.routeId),
     },
   }
 }
@@ -161,6 +167,8 @@ function routesGlobalFilterFn(
 
 export function RoutesPage() {
   const { t } = useTranslation()
+  const routerSearch = useSearch({ from: '/_authenticated/token-routes' })
+  const navigate = useNavigate()
   const {
     globalFilter,
     pagination,
@@ -200,6 +208,29 @@ export function RoutesPage() {
   const [deleteRouteState, setDeleteRoute] = useState<RouteSummaryRow | null>(
     null
   )
+
+  // One-shot route drilldown (proxy-log detail -> `?routeId=N`): wait for
+  // the list, open the detail sheet for the referenced route, then strip
+  // the param so a refetch or remount never reopens the sheet. A stale or
+  // unknown id is stripped without opening anything.
+  const routeDrilldownConsumed = useRef(false)
+  useEffect(() => {
+    if (routeDrilldownConsumed.current || !filters.routeId) return
+    if (isLoading) return
+
+    const targetId = Number(filters.routeId)
+    const target = routes.find((route) => route.id === targetId)
+    routeDrilldownConsumed.current = true
+    if (target) {
+      setDetailRoute(target)
+      setDetailOpen(true)
+    }
+    navigate({
+      to: '/token-routes',
+      search: { ...routerSearch, routeId: undefined },
+      replace: true,
+    })
+  }, [filters.routeId, isLoading, routes, routerSearch, navigate])
 
   const openCreate = () => {
     setFormMode('create')

--- a/web/src/features/token-routes/lib/routes-schema.ts
+++ b/web/src/features/token-routes/lib/routes-schema.ts
@@ -222,6 +222,9 @@ export const routesSearchSchema = z.object({
   enabled: stringSearchParam,
   accountId: z.coerce.number().int().positive().optional().catch(undefined),
   siteId: z.coerce.number().int().positive().optional().catch(undefined),
+  // One-shot drilldown from the proxy-log detail sheet: open the detail
+  // sheet for this route, then the page strips the param.
+  routeId: z.coerce.number().int().positive().optional().catch(undefined),
   page: z.coerce.number().int().positive().catch(1).default(1),
   pageSize: z.coerce.number().int().positive().catch(20).default(20),
 })


### PR DESCRIPTION
## Summary

- The 2026-08-18 multi-perspective review flagged the proxy-log detail sheet's route/channel IDs as inert text: the troubleshooting journey "why did this request fail -> which route/channel served it" dead-ended on the log page.
- Route/channel IDs are now router Links carrying one-shot drilldown params (`/token-routes?routeId=N`, `/channels?channelId=N`). Both feature search schemas gain a tolerant positive-int param (same style as the existing `accountId`/`siteId` chain params).
- Both target pages consume the param with the established accounts `create`/`siteId` pattern: wait for the list, open the matching detail sheet, then `navigate(replace)` to strip the param. Stale/unknown ids strip silently; the routes page strip preserves the persistent `accountId`/`siteId` chain context, and `routeId` is never serialized back into table hrefs.
- Scope honesty: account/token fields already echo names (the id fallback only shows when nameless), so their drilldown stays an observation, documented in the audit.

Gates: typecheck 0 error, lint 0 error, oxfmt green, vitest 526/526, knip exit 0, production build pass.

## Test plan

- [x] 9 new behavior tests across 3 files (link targets + search params; both pages open the right sheet + strip; stale ids strip without opening; no navigation without the param); full suite 526/526
- [x] Typecheck / lint / format / knip / production build green
- [ ] Manual: Proxy Logs -> open a log detail -> click #routeId -> routes page opens with that route's detail sheet and the param stripped; same for #channelId; deep-link a stale id -> page loads clean without the sheet