### PR TITLE
fix(oauth): start-dialog provider Select dead-end (loading/error/empty states)

### DIFF
--- a/web/src/features/oauth/components/oauth-start-dialog.tsx
+++ b/web/src/features/oauth/components/oauth-start-dialog.tsx
@@ -9,6 +9,7 @@
 // a toast instructs the user to complete the flow in the popup.
 
 import { zodResolver } from '@hookform/resolvers/zod'
+import { Link } from '@tanstack/react-router'
 import { ExternalLink as ExternalLinkIcon } from 'lucide-react'
 import { useEffect, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
@@ -68,6 +69,16 @@ export function OAuthStartDialog({
     () => (providersQuery.data ?? []).filter((provider) => provider.enabled),
     [providersQuery.data]
   )
+
+  // The provider <Select> collapses three distinct non-ready states into an
+  // empty dropdown otherwise. Branch on the query state so the user sees
+  // why there is nothing to pick and how to recover, instead of clicking
+  // Start and getting a bare "Please select a provider." validation error.
+  const providersLoading = providersQuery.isLoading
+  const providersError = providersQuery.isError
+  const hasEnabledProviders = enabledProviders.length > 0
+  const providersReady =
+    !providersLoading && !providersError && hasEnabledProviders
 
   const form = useForm<OAuthStartValues>({
     resolver: zodResolver(oauthStartSchema),
@@ -136,7 +147,7 @@ export function OAuthStartDialog({
                   <FormLabel>{t('oauth.form.provider')}</FormLabel>
                   <Select value={field.value} onValueChange={field.onChange}>
                     <FormControl>
-                      <SelectTrigger>
+                      <SelectTrigger disabled={!providersReady}>
                         <SelectValue>
                           {(selected) => {
                             if (!selected) {
@@ -163,6 +174,39 @@ export function OAuthStartDialog({
                       ))}
                     </SelectContent>
                   </Select>
+                  {providersLoading && (
+                    <div className='text-muted-foreground flex items-center gap-1.5 text-sm'>
+                      <Spinner className='size-3.5' />
+                      {t('oauth.form.loadingProviders')}
+                    </div>
+                  )}
+                  {providersError && (
+                    <div className='text-destructive flex items-center gap-2 text-sm'>
+                      <span>{t('oauth.form.providersLoadFailed')}</span>
+                      <Button
+                        type='button'
+                        variant='link'
+                        size='sm'
+                        className='h-auto px-0'
+                        onClick={() => providersQuery.refetch()}
+                      >
+                        {t('oauth.form.retry')}
+                      </Button>
+                    </div>
+                  )}
+                  {!providersLoading &&
+                    !providersError &&
+                    !hasEnabledProviders && (
+                      <FormDescription>
+                        {t('oauth.form.noProviders')}{' '}
+                        <Link
+                          to='/settings'
+                          className='text-primary hover:underline'
+                        >
+                          {t('oauth.form.goToSettings')}
+                        </Link>
+                      </FormDescription>
+                    )}
                   <FormMessage />
                 </FormItem>
               )}
@@ -238,7 +282,7 @@ export function OAuthStartDialog({
               >
                 {t('oauth.form.cancel')}
               </Button>
-              <Button type='submit' disabled={isSubmitting}>
+              <Button type='submit' disabled={isSubmitting || !providersReady}>
                 {isSubmitting ? (
                   <Spinner className='mr-1' />
                 ) : (

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -314,6 +314,11 @@
         "useSystemProxyDescription": "Route the OAuth flow through the system-configured proxy.",
         "cancel": "Cancel",
         "start": "Start",
+        "loadingProviders": "Loading providers…",
+        "providersLoadFailed": "Failed to load providers.",
+        "retry": "Retry",
+        "noProviders": "No OAuth providers are enabled.",
+        "goToSettings": "Go to settings",
         "errors": {
           "projectIdRequired": "Please enter the project ID.",
           "invalidProxyUrl": "Please enter a valid http or https URL.",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -314,6 +314,11 @@
         "useSystemProxyDescription": "通过系统配置的代理路由 OAuth 流程。",
         "cancel": "取消",
         "start": "开始",
+        "loadingProviders": "正在加载提供商…",
+        "providersLoadFailed": "加载提供商失败。",
+        "retry": "重试",
+        "noProviders": "没有已启用的 OAuth 提供商。",
+        "goToSettings": "前往设置",
         "errors": {
           "projectIdRequired": "请输入项目 ID。",
           "invalidProxyUrl": "请输入有效的 http 或 https 地址。",


### PR DESCRIPTION
## Summary

Closes Gap 4 from the OAuth multi-perspective review: the start-dialog's provider `<Select>` collapsed three distinct states (loading / load-failed / zero-enabled-providers) into one empty dropdown with no message or recovery — the user opened the dialog (often from the empty-state CTA), couldn't pick anything, clicked Start, got "Please select a provider." with zero signal whether to wait, fix config, or give up.

- **Loading** (`providersQuery.isLoading`): muted inline spinner + "Loading providers…".
- **Error** (`providersQuery.isError`): destructive "Failed to load providers." + a Retry button (`providersQuery.refetch()`).
- **Empty** (loaded, zero enabled): "No OAuth providers are enabled." + a `<Link to='/settings'>` "Go to settings".
- The `<SelectTrigger>` + the Start `<Button>` are now `disabled` until providers are ready (`!providersReady`), so the bare "Please select a provider." validation can't fire on an empty dropdown.

Approach: helper blocks BELOW the Select (not inline disabled SelectItems) — the explanation + recovery must be visible without opening the dropdown. Matches the codebase's existing `FormDescription` / inline-conditional patterns.

5 i18n keys added to en + zh-CN (`oauth.form.loadingProviders`/`providersLoadFailed`/`retry`/`noProviders`/`goToSettings`). Verified the settings route has no OAuth/providers section (providers are backend-config), so the link points to `/settings`.

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors
- [x] `bun run format:check` — green
- [x] `bun run test` — 519/519 across 61 files (incl. i18n-key parity gate)
- [x] Independent re-ran `oauth` (14/14) as暗卷 spot-check

## Notes
- Safe file domain (oauth start-dialog) — no overlap with the parallel process's badge/channel/route work.