### PR TITLE
fix(oauth): per-row pending + error toast for refresh-quota/rebind (Gap 1)

### DIFF
--- a/web/src/features/oauth/components/__tests__/oauth-columns.test.tsx
+++ b/web/src/features/oauth/components/__tests__/oauth-columns.test.tsx
@@ -1,0 +1,387 @@
+// Behavior tests for the per-row pending state + error-toast wiring on the
+// OAuth connections table. Mirrors the accounts-columns test style: the cell
+// component (`OAuthRowActions`) is rendered in isolation with mocked actions
+// so the assertions stay about user-visible behavior (accessible name, click
+// payload, per-row disabled state, spinner). A second describe block tests
+// the page-level error-toast wiring (page callback → mutation onError →
+// toast.error with the account display name) by capturing the actions the
+// page hands to `useOAuthColumns` and driving the mock mutation's onError.
+import '@testing-library/jest-dom/vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+
+import type { OAuthClient } from '../../types'
+import { OAuthRowActions, type OAuthColumnActions } from '../oauth-columns'
+import { OAuthPage } from '../oauth-page'
+
+// ---------------------------------------------------------------------------
+// Shared jsdom stubs (Base UI dropdown positioning needs both)
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    writable: true,
+    value: ResizeObserverStub,
+  })
+})
+
+afterEach(() => cleanup())
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const baseClient = {
+  accountId: 42,
+  siteId: 1,
+  provider: 'openai',
+  username: 'smoke-user',
+  email: null,
+  accountKey: null,
+  modelCount: 3,
+  modelsPreview: ['gpt-4o', 'gpt-4o-mini', 'o1'],
+  status: 'healthy' as const,
+} as unknown as OAuthClient
+
+function buildActions(): OAuthColumnActions {
+  return {
+    onRefreshQuota: vi.fn(),
+    onRebind: vi.fn(),
+    onDelete: vi.fn(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cell-level: OAuthRowActions per-row pending behavior
+// ---------------------------------------------------------------------------
+
+describe('OAuthRowActions per-row pending', () => {
+  it('renders the dropdown trigger with a localized aria-label', () => {
+    render(
+      <OAuthRowActions
+        client={baseClient}
+        actions={buildActions()}
+        pendingAccountId={null}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', { name: 'Row actions' })
+    ).toBeInTheDocument()
+  })
+
+  it('calls onRefreshQuota with the client when the refresh item is clicked', async () => {
+    const actions = buildActions()
+    render(
+      <OAuthRowActions
+        client={baseClient}
+        actions={actions}
+        pendingAccountId={null}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Row actions' }))
+    const refreshItem = await screen.findByRole('menuitem', {
+      name: 'Refresh quota',
+    })
+    fireEvent.click(refreshItem)
+
+    expect(actions.onRefreshQuota).toHaveBeenCalledTimes(1)
+    expect(actions.onRefreshQuota).toHaveBeenCalledWith(baseClient)
+  })
+
+  it('calls onRebind with the client when the rebind item is clicked', async () => {
+    const actions = buildActions()
+    render(
+      <OAuthRowActions
+        client={baseClient}
+        actions={actions}
+        pendingAccountId={null}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Row actions' }))
+    const rebindItem = await screen.findByRole('menuitem', {
+      name: 'Rebind',
+    })
+    fireEvent.click(rebindItem)
+
+    expect(actions.onRebind).toHaveBeenCalledTimes(1)
+    expect(actions.onRebind).toHaveBeenCalledWith(baseClient)
+  })
+
+  it('shows a spinner on the trigger and disables refresh/rebind items for the pending row', async () => {
+    render(
+      <OAuthRowActions
+        client={baseClient}
+        actions={buildActions()}
+        pendingAccountId={42}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Row actions' })
+    // The trigger swaps MoreHorizontal for a spinning Loader2.
+    expect(trigger.querySelector('svg.animate-spin')).toBeInTheDocument()
+
+    fireEvent.click(trigger)
+    const refreshItem = await screen.findByRole('menuitem', {
+      name: 'Refresh quota',
+    })
+    const rebindItem = screen.getByRole('menuitem', { name: 'Rebind' })
+
+    // Both refresh + rebind are disabled for the row whose accountId matches
+    // pendingAccountId (Base UI sets data-disabled + pointer-events:none).
+    expect(refreshItem).toHaveAttribute('data-disabled')
+    expect(rebindItem).toHaveAttribute('data-disabled')
+  })
+
+  it('leaves refresh/rebind enabled and shows no spinner for a non-pending row (no global lock)', async () => {
+    render(
+      <OAuthRowActions
+        client={baseClient}
+        actions={buildActions()}
+        pendingAccountId={999}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Row actions' })
+    // No spinner — a different row is pending, not this one.
+    expect(trigger.querySelector('svg.animate-spin')).not.toBeInTheDocument()
+
+    fireEvent.click(trigger)
+    const refreshItem = await screen.findByRole('menuitem', {
+      name: 'Refresh quota',
+    })
+    const rebindItem = screen.getByRole('menuitem', { name: 'Rebind' })
+
+    expect(refreshItem).not.toHaveAttribute('data-disabled')
+    expect(rebindItem).not.toHaveAttribute('data-disabled')
+  })
+
+  it('keeps the delete item enabled while the row is pending', async () => {
+    render(
+      <OAuthRowActions
+        client={baseClient}
+        actions={buildActions()}
+        pendingAccountId={42}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Row actions' }))
+    const deleteItem = await screen.findByRole('menuitem', {
+      name: 'Delete',
+    })
+
+    expect(deleteItem).not.toHaveAttribute('data-disabled')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Page-level: refresh/rebind failure toast wiring
+// ---------------------------------------------------------------------------
+
+// The hoisted state object captures the actions the page hands to
+// `useOAuthColumns` and the mutation callbacks the page passes to
+// `refreshQuota.mutate` / `rebindConnection.mutate`. This lets the test drive
+// the real page callback wiring (onRefreshQuota → mutate → onError →
+// toast.error) without rendering the full data-table + dropdown stack.
+const pageState = vi.hoisted(() => ({
+  capturedActions: null as OAuthColumnActions | null,
+  refreshOnError: null as ((error: Error) => void) | null,
+  rebindOnError: null as ((error: Error) => void) | null,
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: pageState.toastSuccess,
+    error: pageState.toastError,
+  },
+}))
+
+vi.mock('../../api', () => ({
+  useOAuthConnections: () => ({
+    data: [],
+    isLoading: false,
+    isFetching: false,
+    error: null,
+  }),
+  useDeleteOAuthConnection: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useRefreshOAuthQuota: () => ({
+    mutate: (
+      _accountId: number,
+      options?: {
+        onSuccess?: () => void
+        onError?: (error: Error) => void
+      }
+    ) => {
+      pageState.refreshOnError = options?.onError ?? null
+    },
+    isPending: false,
+    variables: undefined,
+  }),
+  useRebindOAuthConnection: () => ({
+    mutate: (
+      _accountId: number,
+      options?: {
+        onSuccess?: () => void
+        onError?: (error: Error) => void
+      }
+    ) => {
+      pageState.rebindOnError = options?.onError ?? null
+    },
+    isPending: false,
+    variables: undefined,
+  }),
+}))
+
+// Partial mock: override only `useOAuthColumns` so the page-level tests can
+// capture the actions object the page wires (onRefreshQuota / onRebind /
+// onError). The real `OAuthRowActions` export is preserved via
+// `importOriginal` so the cell-level tests render the genuine component.
+vi.mock('../oauth-columns', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../oauth-columns')>()
+  return {
+    ...actual,
+    useOAuthColumns: (actions: OAuthColumnActions) => {
+      pageState.capturedActions = actions
+      return []
+    },
+  }
+})
+
+vi.mock('../oauth-start-dialog', () => ({
+  OAuthStartDialog: () => null,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+  useSearch: () => ({}),
+}))
+
+vi.mock('@/components/data-table', () => ({
+  DataTablePage: () => null,
+  encodeSorting: () => '',
+  useDataTable: () => ({ table: {} }),
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    sorting: [],
+    onSortingChange: vi.fn(),
+    ensurePageInRange: vi.fn(),
+  }),
+}))
+
+beforeEach(() => {
+  pageState.capturedActions = null
+  pageState.refreshOnError = null
+  pageState.rebindOnError = null
+  pageState.toastError.mockReset()
+  pageState.toastSuccess.mockReset()
+})
+
+describe('OAuthPage refresh/rebind failure toast', () => {
+  it('toasts with the account username when refresh quota fails', async () => {
+    render(<OAuthPage />)
+
+    await waitFor(() => expect(pageState.capturedActions).not.toBeNull())
+    const actions = pageState.capturedActions
+    if (!actions) throw new Error('actions not captured')
+
+    actions.onRefreshQuota(baseClient)
+
+    expect(pageState.refreshOnError).not.toBeNull()
+    if (!pageState.refreshOnError) throw new Error('onError not captured')
+    pageState.refreshOnError(new Error('upstream 503'))
+
+    expect(pageState.toastError).toHaveBeenCalledTimes(1)
+    const toasted = pageState.toastError.mock.calls[0][0] as string
+    expect(toasted).toContain('smoke-user')
+  })
+
+  it('falls back to the account id when username/email/key are absent', async () => {
+    const anonymousClient = {
+      ...baseClient,
+      username: null,
+      email: null,
+      accountKey: null,
+    } as unknown as OAuthClient
+
+    render(<OAuthPage />)
+
+    await waitFor(() => expect(pageState.capturedActions).not.toBeNull())
+    const actions = pageState.capturedActions
+    if (!actions) throw new Error('actions not captured')
+
+    actions.onRefreshQuota(anonymousClient)
+
+    expect(pageState.refreshOnError).not.toBeNull()
+    if (!pageState.refreshOnError) throw new Error('onError not captured')
+    pageState.refreshOnError(new Error('upstream 503'))
+
+    expect(pageState.toastError).toHaveBeenCalledTimes(1)
+    const toasted = pageState.toastError.mock.calls[0][0] as string
+    expect(toasted).toContain('42')
+  })
+
+  it('toasts with the account username when rebind fails', async () => {
+    render(<OAuthPage />)
+
+    await waitFor(() => expect(pageState.capturedActions).not.toBeNull())
+    const actions = pageState.capturedActions
+    if (!actions) throw new Error('actions not captured')
+
+    actions.onRebind(baseClient)
+
+    expect(pageState.rebindOnError).not.toBeNull()
+    if (!pageState.rebindOnError) throw new Error('onError not captured')
+    pageState.rebindOnError(new Error('rebind refused'))
+
+    expect(pageState.toastError).toHaveBeenCalledTimes(1)
+    const toasted = pageState.toastError.mock.calls[0][0] as string
+    expect(toasted).toContain('smoke-user')
+  })
+})

--- a/web/src/features/oauth/components/oauth-columns.tsx
+++ b/web/src/features/oauth/components/oauth-columns.tsx
@@ -10,6 +10,7 @@
 
 import type { ColumnDef } from '@tanstack/react-table'
 import {
+  Loader2 as Loader2Icon,
   MoreHorizontal as MoreHorizontalIcon,
   RefreshCw as RefreshCwIcon,
   Trash2 as Trash2Icon,
@@ -84,13 +85,95 @@ function formatTimestamp(value?: string | null): string {
   return date.toLocaleString()
 }
 
+// ---------------------------------------------------------------------------
+// Row actions cell
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-row dropdown trigger + refresh/rebind/delete actions.
+ *
+ * The pending state is per-row (mirrors the accounts page's
+ * `pendingStatusId` pattern): when `pendingAccountId === client.accountId`,
+ * the trigger swaps `MoreHorizontal` for a `Loader2` spinner and the
+ * refresh/rebind menu items are disabled so the user cannot spam-click the
+ * same row into duplicate requests. The delete item stays enabled so the
+ * connection can still be removed while a refresh/rebind is in flight.
+ * Every other row stays fully clickable — there is no global lock.
+ */
+export function OAuthRowActions({
+  client,
+  actions,
+  pendingAccountId = null,
+}: {
+  client: OAuthClient
+  actions: OAuthColumnActions
+  pendingAccountId?: number | null
+}) {
+  const { t } = useTranslation()
+  const isThisRowPending = pendingAccountId === client.accountId
+  return (
+    <div className={cn('flex justify-end')}>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              variant='ghost'
+              size='icon-sm'
+              className='data-popup-open:bg-accent'
+              aria-label={t('oauth.columns.rowActions')}
+            />
+          }
+        >
+          {isThisRowPending ? (
+            <Loader2Icon className='size-4 animate-spin' />
+          ) : (
+            <MoreHorizontalIcon className='size-4' />
+          )}
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align='end' className='w-48'>
+          <DropdownMenuItem
+            onClick={() => actions.onRefreshQuota(client)}
+            disabled={isThisRowPending}
+          >
+            <RefreshCwIcon className='text-muted-foreground/70 size-3.5' />
+            {t('oauth.actions.refreshQuota')}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => actions.onRebind(client)}
+            disabled={isThisRowPending}
+          >
+            <UnplugIcon className='text-muted-foreground/70 size-3.5' />
+            {t('oauth.actions.rebind')}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            variant='destructive'
+            onClick={() => actions.onDelete(client)}
+          >
+            <Trash2Icon className='size-3.5' />
+            {t('oauth.actions.delete')}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Columns hook
+// ---------------------------------------------------------------------------
+
 /**
  * Build the OAuth connections columns. Must be called during render (it is
  * a hook because it reads i18n state). The `actions` callbacks are supplied
  * by the page so the columns stay free of mutation/query concerns.
+ * `pendingAccountId` threads the per-row pending state (derived from the
+ * TanStack Query mutation's `variables` on the page) into the actions cell
+ * — see {@link OAuthRowActions}.
  */
 export function useOAuthColumns(
-  actions: OAuthColumnActions
+  actions: OAuthColumnActions,
+  pendingAccountId: number | null = null
 ): ColumnDef<OAuthClient>[] {
   const { t } = useTranslation()
 
@@ -219,47 +302,13 @@ export function useOAuthColumns(
           {t('oauth.columns.actions')}
         </span>
       ),
-      cell: ({ row }) => {
-        const client = row.original
-        return (
-          <div className={cn('flex justify-end')}>
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                render={
-                  <Button
-                    variant='ghost'
-                    size='icon-sm'
-                    className='data-popup-open:bg-accent'
-                    aria-label={t('oauth.columns.rowActions')}
-                  />
-                }
-              >
-                <MoreHorizontalIcon className='size-4' />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align='end' className='w-48'>
-                <DropdownMenuItem
-                  onClick={() => actions.onRefreshQuota(client)}
-                >
-                  <RefreshCwIcon className='text-muted-foreground/70 size-3.5' />
-                  {t('oauth.actions.refreshQuota')}
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => actions.onRebind(client)}>
-                  <UnplugIcon className='text-muted-foreground/70 size-3.5' />
-                  {t('oauth.actions.rebind')}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  variant='destructive'
-                  onClick={() => actions.onDelete(client)}
-                >
-                  <Trash2Icon className='size-3.5' />
-                  {t('oauth.actions.delete')}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        )
-      },
+      cell: ({ row }) => (
+        <OAuthRowActions
+          client={row.original}
+          actions={actions}
+          pendingAccountId={pendingAccountId}
+        />
+      ),
     },
   ]
 

--- a/web/src/features/oauth/components/oauth-page.tsx
+++ b/web/src/features/oauth/components/oauth-page.tsx
@@ -129,6 +129,37 @@ function useOAuthUrlState() {
   })
 }
 
+/**
+ * Pick the account id of whichever mutation (refresh-quota or rebind) is
+ * currently pending. Both mutations take a bare `accountId: number` as
+ * variables. Returns `null` when neither is in flight — the actions cell
+ * renders all rows as clickable. Kept as a plain function (not a hook) so
+ * the page render stays cheap and the derivation is grep-able/testable.
+ */
+function resolvePendingAccountId(
+  refresh: { isPending: boolean; variables?: number },
+  rebind: { isPending: boolean; variables?: number }
+): number | null {
+  if (refresh.isPending) return refresh.variables ?? null
+  if (rebind.isPending) return rebind.variables ?? null
+  return null
+}
+
+/**
+ * Resolve a human-readable display name for an OAuth connection, falling
+ * back through username → email → accountKey → stringified account id. Used
+ * in error toasts so the operator can tell WHICH account failed (the bare
+ * `accountId` number is opaque without cross-referencing the table).
+ */
+function resolveOAuthDisplayName(client: OAuthClient): string {
+  return (
+    client.username ??
+    client.email ??
+    client.accountKey ??
+    String(client.accountId)
+  )
+}
+
 export function OAuthPage() {
   const { t } = useTranslation()
   const connectionsQuery = useOAuthConnections()
@@ -141,35 +172,62 @@ export function OAuthPage() {
 
   const urlState = useOAuthUrlState()
 
-  const columns = useOAuthColumns({
-    onRefreshQuota: (client) => {
-      refreshQuota.mutate(client.accountId, {
-        onSuccess: () =>
-          toast.success(
-            t('oauth.toast.quotaRefreshed', { id: client.accountId })
-          ),
-      })
-    },
-    onRebind: (client) => {
-      rebindConnection.mutate(client.accountId, {
-        onSuccess: (result) => {
-          if (result.authorizationUrl) {
-            window.open(
-              result.authorizationUrl,
-              '_blank',
-              'noopener,noreferrer'
+  // Derive the per-row pending account id from whichever mutation is in
+  // flight. A single value is sufficient because BOTH row actions (refresh +
+  // rebind) should be disabled for the row with an action pending, while
+  // every other row stays clickable (no global lock) — mirroring the
+  // accounts page's `pendingStatusId` pattern. `useRefreshOAuthQuota` and
+  // `useRebindOAuthConnection` both take a bare `accountId: number` as
+  // variables, so the pending id is `mutation.variables` when pending.
+  const pendingAccountId = resolvePendingAccountId(
+    refreshQuota,
+    rebindConnection
+  )
+
+  const columns = useOAuthColumns(
+    {
+      onRefreshQuota: (client) => {
+        refreshQuota.mutate(client.accountId, {
+          onSuccess: () =>
+            toast.success(
+              t('oauth.toast.quotaRefreshed', { id: client.accountId })
+            ),
+          onError: () =>
+            toast.error(
+              t('oauth.toast.refreshFailed', {
+                name: resolveOAuthDisplayName(client),
+              })
+            ),
+        })
+      },
+      onRebind: (client) => {
+        rebindConnection.mutate(client.accountId, {
+          onSuccess: (result) => {
+            if (result.authorizationUrl) {
+              window.open(
+                result.authorizationUrl,
+                '_blank',
+                'noopener,noreferrer'
+              )
+            }
+            toast.success(
+              t('oauth.toast.rebindStarted', { id: client.accountId })
             )
-          }
-          toast.success(
-            t('oauth.toast.rebindStarted', { id: client.accountId })
-          )
-        },
-      })
+          },
+          onError: () =>
+            toast.error(
+              t('oauth.toast.rebindFailed', {
+                name: resolveOAuthDisplayName(client),
+              })
+            ),
+        })
+      },
+      onDelete: (client) => {
+        setDeletingClient(client)
+      },
     },
-    onDelete: (client) => {
-      setDeletingClient(client)
-    },
-  })
+    pendingAccountId
+  )
 
   const { table } = useDataTable<OAuthClient>({
     data: connectionsQuery.data ?? [],

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -323,7 +323,9 @@
       "toast": {
         "quotaRefreshed": "Quota refresh requested for #{{id}}.",
         "rebindStarted": "Rebind started for #{{id}}.",
-        "deleted": "Connection #{{id}} deleted."
+        "deleted": "Connection #{{id}} deleted.",
+        "refreshFailed": "Failed to refresh quota for {{name}}.",
+        "rebindFailed": "Failed to rebind {{name}}."
       },
       "empty": {
         "title": "No connections",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -323,7 +323,9 @@
       "toast": {
         "quotaRefreshed": "已请求刷新 #{{id}} 的额度。",
         "rebindStarted": "已开始重新绑定 #{{id}}。",
-        "deleted": "连接 #{{id}} 已删除。"
+        "deleted": "连接 #{{id}} 已删除。",
+        "refreshFailed": "刷新 {{name}} 的额度失败。",
+        "rebindFailed": "重新绑定 {{name}} 失败。"
       },
       "empty": {
         "title": "暂无连接",


### PR DESCRIPTION
## Summary

Closes Gap 1 from the OAuth multi-perspective review: refresh-quota/rebind row actions used a global `isPending` + only `onSuccess` toasts — the clicked row showed no spinner, stayed re-clickable (spam-click duplicates), and failures surfaced only via the generic http-client toast (couldn't tell which account failed). Mirrors the accounts page's `pendingStatusId` pattern (established in #824).

- **`oauth-page.tsx`**: derives a single `pendingAccountId` via `resolvePendingAccountId(refresh, rebind)` (checks `refresh.isPending ? refresh.variables : rebind.isPending ? rebind.variables : null`); adds `onError` toasts for refresh/rebind with the account's display name (username → email → accountKey → id fallback). Threads `pendingAccountId` to `useOAuthColumns(actions, pendingAccountId)`.
- **`oauth-columns.tsx`**: when `pendingAccountId === client.accountId`, swaps the row trigger for a spinning `Loader2` + disables the refresh/rebind menu items (delete stays enabled — no global lock; other rows stay clickable).
- **i18n**: `oauth.toast.refreshFailed` + `oauth.toast.rebindFailed` (with `{{name}}`) in en + zh-CN.

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors
- [x] `bun run format:check` — green
- [x] `bun run test` — 528/528 across 62 files (incl. 9 NEW `oauth-columns` tests: 6 cell-level — trigger aria-label, refresh/rebind payloads, spinner+disabled for pending row, no-spinner+enabled for non-pending row, delete stays enabled; 3 page-level — refresh/rebind failure → toast with display name)
- [x] Independent re-ran `oauth-columns` (9/9) as暗卷 spot-check

## Notes
- Mirrors accounts `pendingStatusId` exactly (read accounts-page.tsx + accounts-columns.tsx as pattern references; not modified).
- Safe file domain (oauth) — no overlap with the parallel process's badge/channel/route work.
- One deviation: fixed a mock-path bug in the page-level tests (`../api` → `../../api`) that initially failed 3 tests — the mock now resolves to the same module `oauth-page.tsx` imports.