### PR TITLE
fix(dashboard): color realtime sparkline by success-rate health band

### DIFF
--- a/web/src/features/dashboard/hooks/use-realtime-ops.ts
+++ b/web/src/features/dashboard/hooks/use-realtime-ops.ts
@@ -13,7 +13,11 @@ import { useEffect, useRef, useState } from 'react'
 
 import { getAuthToken } from '@/lib/auth-session'
 
-import type { RealtimeOpsFrame, RealtimeOpsSample } from '../types'
+import type {
+  RealtimeOpsFrame,
+  RealtimeOpsSample,
+  RealtimeOpsSamplePoint,
+} from '../types'
 
 const MAX_FAILS = 5
 const MAX_BACKOFF_MS = 15_000
@@ -68,7 +72,7 @@ export function useRealtimeOps(): RealtimeOpsSample {
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const failsRef = useRef(0)
   const previousTotalRef = useRef<number | null>(null)
-  const sparkRef = useRef<number[]>([])
+  const sparkRef = useRef<RealtimeOpsSamplePoint[]>([])
 
   useEffect(() => {
     const token = getAuthToken()
@@ -113,7 +117,10 @@ export function useRealtimeOps(): RealtimeOpsSample {
         previousTotalRef.current = latest.total
         const successRate = computeSuccessRate(latest.success, latest.total)
 
-        const nextSpark = [...sparkRef.current, qps]
+        const nextSpark: RealtimeOpsSamplePoint[] = [
+          ...sparkRef.current,
+          { qps, successRate },
+        ]
         if (nextSpark.length > SPARK_WINDOW) nextSpark.shift()
         sparkRef.current = nextSpark
 

--- a/web/src/features/dashboard/sections/availability/__tests__/availability-sparkline.test.tsx
+++ b/web/src/features/dashboard/sections/availability/__tests__/availability-sparkline.test.tsx
@@ -1,0 +1,166 @@
+// Behavior test for the realtime ops sparkline health colouring.
+//
+// Closes the availability-section gap (dashboard review): the realtime ops
+// panel's sparkline was volume-only + monochrome, so a slow degradation
+// (success rate falling while volume holds) was invisible at a glance. The
+// sparkline now colours each bar by per-second success-rate health band and
+// exposes the current band as the sparkline's accessible name, so:
+//   (a) the bar colour shifts green → amber → red as success degrades;
+//   (b) the accessible name (not the colour alone) carries the health state
+//       for assistive tech + gives the test a stable, non-brittle contract.
+//
+// The realtime ops WebSocket hook (useRealtimeOps) is stubbed so the panel
+// renders with controlled spark samples; api.getAttention is stubbed so the
+// sibling Attention panel resolves without a network call. Each case asserts
+// the sparkline's accessible name reflects the LATEST sample's health band.
+//
+// Note on latency: the realtime ops stream carries no latency field
+// (handler/shared/realtime.go: RealtimePoint = {Ts, Total, Success}), so the
+// panel intentionally displays no latency stat — this test does not assert one.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+import { useRealtimeOps } from '@/features/dashboard/hooks/use-realtime-ops'
+import type { RealtimeOpsSample } from '@/features/dashboard/types'
+import { api } from '@/lib/api'
+
+import { AvailabilitySection } from '../availability-section'
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getAttention: vi.fn(),
+  },
+}))
+
+vi.mock('@/features/dashboard/hooks/use-realtime-ops', () => ({
+  useRealtimeOps: vi.fn(),
+}))
+
+const mockGetAttention = vi.mocked(api.getAttention)
+const mockUseRealtimeOps = vi.mocked(useRealtimeOps)
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0, refetchOnWindowFocus: false },
+    },
+  })
+}
+
+function renderWithClient(ui: ReactNode) {
+  const queryClient = createQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  )
+}
+
+/**
+ * Build a connected realtime sample whose sparkline ends at the given point.
+ * Earlier bars are a healthy baseline so the LATEST point is what determines
+ * the sparkline's accessible name (the "latest wins" behaviour under test).
+ */
+function sampleWithLatest(point: {
+  qps: number
+  successRate: number
+}): RealtimeOpsSample {
+  return {
+    qps: point.qps,
+    successRate: point.successRate,
+    lifetime: 120,
+    spark: [
+      { qps: 10, successRate: 0.99 },
+      { qps: 10, successRate: 0.97 },
+      point,
+    ],
+    connected: true,
+    gaveUp: false,
+  }
+}
+
+const IDLE_SAMPLE: RealtimeOpsSample = {
+  qps: 0,
+  successRate: 0,
+  lifetime: 0,
+  spark: [],
+  connected: false,
+  gaveUp: false,
+}
+
+beforeEach(() => {
+  mockGetAttention.mockReset()
+  mockUseRealtimeOps.mockReset()
+  // Sibling Attention panel resolves to an empty list so it never throws.
+  mockGetAttention.mockResolvedValue({ items: [], total: 0 })
+})
+
+afterEach(() => cleanup())
+
+describe('AvailabilitySection realtime sparkline health', () => {
+  it('labels the sparkline healthy when the latest sample is healthy', async () => {
+    mockUseRealtimeOps.mockReturnValue(
+      sampleWithLatest({ qps: 12, successRate: 0.99 })
+    )
+
+    renderWithClient(<AvailabilitySection />)
+
+    expect(
+      await screen.findByRole('img', { name: 'Traffic healthy' })
+    ).toBeInTheDocument()
+  })
+
+  it('labels the sparkline degraded when success falls to the amber band', async () => {
+    mockUseRealtimeOps.mockReturnValue(
+      sampleWithLatest({ qps: 12, successRate: 0.85 })
+    )
+
+    renderWithClient(<AvailabilitySection />)
+
+    expect(
+      await screen.findByRole('img', { name: 'Traffic degraded' })
+    ).toBeInTheDocument()
+  })
+
+  it('labels the sparkline unhealthy when success drops below the degraded band', async () => {
+    mockUseRealtimeOps.mockReturnValue(
+      sampleWithLatest({ qps: 12, successRate: 0.5 })
+    )
+
+    renderWithClient(<AvailabilitySection />)
+
+    expect(
+      await screen.findByRole('img', { name: 'Traffic unhealthy' })
+    ).toBeInTheDocument()
+  })
+
+  it('labels the sparkline idle when there is no recent traffic', async () => {
+    mockUseRealtimeOps.mockReturnValue(IDLE_SAMPLE)
+
+    renderWithClient(<AvailabilitySection />)
+
+    expect(
+      await screen.findByRole('img', { name: 'No recent traffic' })
+    ).toBeInTheDocument()
+  })
+
+  it('derives the accessible name from the latest sample (latest wins)', async () => {
+    // History is healthy, but the latest second is unhealthy — the name must
+    // reflect the current state, not the historical baseline.
+    mockUseRealtimeOps.mockReturnValue(
+      sampleWithLatest({ qps: 12, successRate: 0.4 })
+    )
+
+    renderWithClient(<AvailabilitySection />)
+
+    expect(
+      await screen.findByRole('img', { name: 'Traffic unhealthy' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('img', { name: 'Traffic healthy' })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/web/src/features/dashboard/sections/availability/availability-section.tsx
+++ b/web/src/features/dashboard/sections/availability/availability-section.tsx
@@ -23,6 +23,7 @@ import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
 
 import { useRealtimeOps } from '../../hooks/use-realtime-ops'
+import type { RealtimeOpsSamplePoint } from '../../types'
 
 const SPARK_BARS = 60
 
@@ -60,20 +61,65 @@ function formatRate(rate: number): string {
   return `${(rate * 100).toFixed(1)}%`
 }
 
-function RealtimeSparkline({ samples }: { samples: number[] }) {
-  const max = Math.max(1, ...samples)
+// Health bands for the realtime sparkline. A second with no traffic is idle
+// (neutral); otherwise the success fraction at that second maps to a band:
+// healthy >= 0.95, degraded >= 0.80, unhealthy < 0.80. The bars stay shaped
+// by qps, so volume + health read together — a slow degradation (success
+// falling while volume holds) shifts the bars green → amber → red.
+const HEALTHY_SUCCESS_THRESHOLD = 0.95
+const DEGRADED_SUCCESS_THRESHOLD = 0.8
+
+type SparkHealth = 'healthy' | 'degraded' | 'unhealthy' | 'idle'
+
+const SPARK_HEALTH_TONE: Record<SparkHealth, string> = {
+  healthy: 'bg-success/70',
+  degraded: 'bg-warning/70',
+  unhealthy: 'bg-destructive/70',
+  idle: 'bg-muted-foreground/30',
+}
+
+const SPARK_HEALTH_LABEL_KEY: Record<SparkHealth, string> = {
+  healthy: 'dashboard.availability.realtime.healthHealthy',
+  degraded: 'dashboard.availability.realtime.healthDegraded',
+  unhealthy: 'dashboard.availability.realtime.healthUnhealthy',
+  idle: 'dashboard.availability.realtime.healthIdle',
+}
+
+const IDLE_SPARK_POINT: RealtimeOpsSamplePoint = { qps: 0, successRate: 0 }
+
+function sparkHealthFor(point: RealtimeOpsSamplePoint): SparkHealth {
+  if (point.qps <= 0) return 'idle'
+  if (point.successRate >= HEALTHY_SUCCESS_THRESHOLD) return 'healthy'
+  if (point.successRate >= DEGRADED_SUCCESS_THRESHOLD) return 'degraded'
+  return 'unhealthy'
+}
+
+function RealtimeSparkline({ points }: { points: RealtimeOpsSamplePoint[] }) {
+  const { t } = useTranslation()
+  const max = Math.max(1, ...points.map((point) => point.qps))
   const bars =
-    samples.length > 0 ? samples : Array.from({ length: SPARK_BARS }, () => 0)
+    points.length > 0
+      ? points
+      : Array.from({ length: SPARK_BARS }, () => IDLE_SPARK_POINT)
+  const latestHealth = sparkHealthFor(points.at(-1) ?? IDLE_SPARK_POINT)
 
   return (
-    <div className='flex h-16 w-full items-end gap-px' aria-hidden='true'>
-      {bars.map((sample, index) => {
-        const ratio = Math.max(0.04, sample / max)
+    <div
+      role='img'
+      aria-label={t(SPARK_HEALTH_LABEL_KEY[latestHealth])}
+      className='flex h-16 w-full items-end gap-px'
+    >
+      {bars.map((point, index) => {
+        const ratio = Math.max(0.04, point.qps / max)
+        const health = sparkHealthFor(point)
         return (
           <div
             // eslint-disable-next-line react/no-array-index-key
             key={index}
-            className='bg-chart-1/70 min-w-0 flex-1 rounded-sm'
+            className={cn(
+              'min-w-0 flex-1 rounded-sm',
+              SPARK_HEALTH_TONE[health]
+            )}
             style={{ height: `${ratio * 100}%` }}
           />
         )
@@ -158,7 +204,7 @@ function RealtimeOpsPanel() {
             </div>
           </div>
         </div>
-        <RealtimeSparkline samples={sample.spark} />
+        <RealtimeSparkline points={sample.spark} />
       </CardContent>
     </Card>
   )

--- a/web/src/features/dashboard/types.ts
+++ b/web/src/features/dashboard/types.ts
@@ -90,12 +90,25 @@ export type RealtimeOpsFrame = {
   points: Array<{ ts: number; total: number; success: number }>
 }
 
+/**
+ * One sparkline sample — a single second's derived traffic + the success
+ * fraction observed at that second. The success fraction drives the bar's
+ * health colour (healthy / degraded / unhealthy), so a slow degradation is
+ * visible at a glance even while volume stays normal. The realtime ops
+ * stream itself carries no latency (see handler/shared/realtime.go), so
+ * volume + success are the only signals on the wire.
+ */
+export type RealtimeOpsSamplePoint = {
+  qps: number
+  successRate: number
+}
+
 /** Live traffic sparkline sample (rolling 60s window). */
 export type RealtimeOpsSample = {
   qps: number
   successRate: number
   lifetime: number
-  spark: number[]
+  spark: RealtimeOpsSamplePoint[]
   connected: boolean
   gaveUp: boolean
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -644,7 +644,11 @@
           "statusConnecting": "connecting",
           "metricQps": "QPS",
           "metricSuccess": "success",
-          "metricUptime": "uptime"
+          "metricUptime": "uptime",
+          "healthHealthy": "Traffic healthy",
+          "healthDegraded": "Traffic degraded",
+          "healthUnhealthy": "Traffic unhealthy",
+          "healthIdle": "No recent traffic"
         },
         "monitors": {
           "title": "Attention required",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -644,7 +644,11 @@
           "statusConnecting": "连接中",
           "metricQps": "QPS",
           "metricSuccess": "成功率",
-          "metricUptime": "运行时间"
+          "metricUptime": "运行时间",
+          "healthHealthy": "流量健康",
+          "healthDegraded": "流量降级",
+          "healthUnhealthy": "流量异常",
+          "healthIdle": "近期无流量"
         },
         "monitors": {
           "title": "需要关注",


### PR DESCRIPTION
## Summary

Closes an availability-section gap from a fresh multi-perspective review: the realtime ops sparkline was **monochrome** (`bg-chart-1/70` regardless of health) — a slow degradation (latency creeping up, success rate dropping, while volume stays normal) was invisible until it became a full outage.

- **Sparkline now colored by per-second success-rate health band**: healthy (≥0.95) → `bg-success/70`, degraded (≥0.80) → `bg-warning/70`, unhealthy (<0.80) → `bg-destructive/70`, idle (no traffic) → `bg-muted-foreground/30`. Matches the existing connection-status-dot tokens. Bars stay shaped by qps, so volume + health read together — a slow degradation shifts bars green → amber → red.
- **a11y**: the sparkline container now carries `role="img"` + an `aria-label` reflecting the **latest** sample's health band — state is not carried by color alone.
- `RealtimeOpsSample.spark` changed from `number[]` to `RealtimeOpsSamplePoint[]` (`{ qps, successRate }`) — contained (only consumed by the availability sparkline).

## Latency — NOT displayed (honest residual)
The realtime data source carries NO latency. Verified end-to-end: frontend `RealtimeOpsFrame = { lifetime, points: [{ ts, total, success }] }` (`dashboard/types.ts`); backend `RealtimePoint = { Ts, Total, Success }` (`handler/shared/realtime.go:39`), pushed by `pushOpsFrame` (`handler/admin/ops_ws.go:94`) — the ring buffer tracks per-second `total`/`success` + a lifetime counter, **no latency recorded or sent**. Per the project honesty rule, no latency stat was fabricated. To surface realtime latency, the backend would need to add a latency field to `RealtimePoint` + track per-second latency in the ring buffer (a separate Go slice — out of scope here).

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors
- [x] `bun run format:check` — green
- [x] `bun run test` — 529/529 across 62 files (incl. 5 NEW availability-sparkline cases: health-band accessible name for healthy/degraded/unhealthy/idle + "latest wins")
- [x] Independent re-ran `availability-sparkline` (5/5) as暗卷 spot-check

## Notes
- Safe file domain (dashboard/availability) — no overlap with the parallel process's badge/channel/route/oauth work.
- Honest about latency: not on the realtime wire → not fabricated; documented as a backend residual.