### PR TITLE
feat(dashboard): show relative createdAt on attention items

### DIFF
--- a/web/src/features/dashboard/sections/availability/__tests__/availability-attention-created-at.test.tsx
+++ b/web/src/features/dashboard/sections/availability/__tests__/availability-attention-created-at.test.tsx
@@ -1,0 +1,132 @@
+// Behavior test for the attention panel's relative-timestamp rendering.
+//
+// Closes availability gap 5: the attention/alerts list showed severity +
+// message but never the alert's `createdAt`, so an operator could not tell
+// a 30-second-old critical alert from one 3 hours stale. Each item now
+// renders a muted relative timestamp ("2 hours ago") next to the message
+// with the absolute timestamp as a hover tooltip. Items missing `createdAt`
+// render no timestamp (no "ago" with no date).
+//
+// The realtime ops hook + api.getAttention are stubbed (mirrors the sibling
+// sparkline test). `Date.now` is pinned so the relative formatter produces a
+// deterministic "2 hours ago" regardless of when the test runs.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+import { useRealtimeOps } from '@/features/dashboard/hooks/use-realtime-ops'
+import type { RealtimeOpsSample } from '@/features/dashboard/types'
+import { api } from '@/lib/api'
+
+import { AvailabilitySection } from '../availability-section'
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getAttention: vi.fn(),
+  },
+}))
+
+vi.mock('@/features/dashboard/hooks/use-realtime-ops', () => ({
+  useRealtimeOps: vi.fn(),
+}))
+
+const mockGetAttention = vi.mocked(api.getAttention)
+const mockUseRealtimeOps = vi.mocked(useRealtimeOps)
+
+// Pin "now" so the relative formatter is deterministic. The attention item
+// below is 2 hours older than this fixed instant → "2 hours ago" in en.
+const FIXED_NOW = new Date('2026-01-15T12:00:00Z').getTime()
+const CREATED_AT = new Date('2026-01-15T10:00:00Z').toISOString()
+
+const IDLE_SAMPLE: RealtimeOpsSample = {
+  qps: 0,
+  successRate: 0,
+  lifetime: 0,
+  spark: [],
+  connected: false,
+  gaveUp: false,
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0, refetchOnWindowFocus: false },
+    },
+  })
+}
+
+function renderWithClient(ui: ReactNode) {
+  const queryClient = createQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  mockGetAttention.mockReset()
+  mockUseRealtimeOps.mockReset()
+  // Sibling realtime ops panel renders idle without a live WebSocket.
+  mockUseRealtimeOps.mockReturnValue(IDLE_SAMPLE)
+  vi.spyOn(Date, 'now').mockReturnValue(FIXED_NOW)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  cleanup()
+})
+
+describe('AvailabilitySection attention item createdAt', () => {
+  it('renders a relative timestamp when an item has createdAt', async () => {
+    mockGetAttention.mockResolvedValue({
+      items: [
+        {
+          severity: 'critical',
+          category: 'account',
+          label: 'Account expired',
+          target: '/accounts/1',
+          createdAt: CREATED_AT,
+        },
+      ],
+      total: 1,
+    })
+
+    const { container } = renderWithClient(<AvailabilitySection />)
+
+    const timestamp = await screen.findByText('2 hours ago')
+    expect(timestamp).toBeInTheDocument()
+    expect(timestamp.tagName).toBe('TIME')
+
+    const timeElement = container.querySelector('time')
+    expect(timeElement).not.toBeNull()
+    expect(timeElement?.getAttribute('datetime')).toBe(CREATED_AT)
+    // The hover tooltip carries a localized absolute date (non-empty) so a
+    // stale alert can be read in full without expanding the row.
+    expect(timeElement?.getAttribute('title')?.length).toBeGreaterThan(0)
+  })
+
+  it('renders no timestamp when an item is missing createdAt', async () => {
+    mockGetAttention.mockResolvedValue({
+      items: [
+        {
+          severity: 'info',
+          category: 'site',
+          label: 'Site disabled',
+          target: '',
+          createdAt: '',
+        },
+      ],
+      total: 1,
+    })
+
+    const { container } = renderWithClient(<AvailabilitySection />)
+
+    // Wait for the attention list to render (item label is the stable hook).
+    await screen.findByText('Site disabled')
+
+    expect(container.querySelector('time')).toBeNull()
+  })
+})

--- a/web/src/features/dashboard/sections/availability/availability-section.tsx
+++ b/web/src/features/dashboard/sections/availability/availability-section.tsx
@@ -19,7 +19,9 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { toBcp47 } from '@/i18n/languages'
 import { api } from '@/lib/api'
+import { formatAbsoluteDateTime, formatRelativeTime } from '@/lib/format'
 import { cn } from '@/lib/utils'
 
 import { useRealtimeOps } from '../../hooks/use-realtime-ops'
@@ -211,7 +213,8 @@ function RealtimeOpsPanel() {
 }
 
 function AttentionPanel() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
+  const locale = toBcp47(i18n.language || 'en')
   const { data, isLoading, isError } = useQuery({
     queryKey: ['dashboard-attention', 20],
     queryFn: () => api.getAttention(20) as Promise<AttentionResponse>,
@@ -258,6 +261,7 @@ function AttentionPanel() {
               const label = t(
                 `dashboard.availability.monitors.severity.${item.severity}`
               )
+              const relativeTime = formatRelativeTime(item.createdAt, locale)
               return (
                 <li
                   // eslint-disable-next-line react/no-array-index-key
@@ -282,6 +286,15 @@ function AttentionPanel() {
                       </span>
                     )}
                   </div>
+                  {relativeTime ? (
+                    <time
+                      dateTime={item.createdAt}
+                      title={formatAbsoluteDateTime(item.createdAt, locale)}
+                      className='text-muted-foreground mt-0.5 shrink-0 text-xs tabular-nums'
+                    >
+                      {relativeTime}
+                    </time>
+                  ) : null}
                 </li>
               )
             })}

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -82,3 +82,89 @@ export function formatSuccessRate(rate: number | null | undefined): string {
   }
   return `${Math.round(rate)}%`
 }
+
+const SECONDS_PER_MINUTE = 60
+const SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE
+const SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR
+// Past 7 days a relative unit stops being actionable — surface an absolute
+// date so a stale alert still reads clearly instead of "8 days ago".
+const ABSOLUTE_THRESHOLD_SECONDS = 7 * SECONDS_PER_DAY
+
+function toTimestamp(
+  value: string | number | Date | null | undefined
+): number | null {
+  if (value === null || value === undefined || value === '') return null
+  const timestamp =
+    typeof value === 'number' ? value : new Date(value).getTime()
+  return Number.isFinite(timestamp) ? timestamp : null
+}
+
+/**
+ * Format a timestamp as a localized relative time ("just now", "2 minutes
+ * ago", "3 hours ago", "2 days ago"). Items older than 7 days fall back to
+ * a localized absolute date. Returns an empty string for null / empty /
+ * invalid input so the caller can conditionally render without surfacing
+ * "ago" with no date. Uses `Intl.RelativeTimeFormat` with `numeric: 'auto'`
+ * so the output localizes with the active BCP-47 locale (e.g. "2 minutes
+ * ago" in en, "2 分钟前" in zh-CN) without needing new translation keys.
+ * The `locale` MUST be a BCP-47 tag — pass i18next's `i18n.language` through
+ * `toBcp47()` first (`zhCN` would throw `RangeError`).
+ */
+export function formatRelativeTime(
+  value: string | number | Date | null | undefined,
+  locale: string
+): string {
+  const timestamp = toTimestamp(value)
+  if (timestamp === null) return ''
+  const deltaSeconds = Math.round((timestamp - Date.now()) / 1000)
+  const absDeltaSeconds = Math.abs(deltaSeconds)
+  if (absDeltaSeconds >= ABSOLUTE_THRESHOLD_SECONDS) {
+    return new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }).format(timestamp)
+  }
+  const relativeTime = new Intl.RelativeTimeFormat(locale, {
+    numeric: 'auto',
+  })
+  if (absDeltaSeconds < SECONDS_PER_MINUTE) {
+    return relativeTime.format(deltaSeconds, 'second')
+  }
+  if (absDeltaSeconds < SECONDS_PER_HOUR) {
+    return relativeTime.format(
+      Math.round(deltaSeconds / SECONDS_PER_MINUTE),
+      'minute'
+    )
+  }
+  if (absDeltaSeconds < SECONDS_PER_DAY) {
+    return relativeTime.format(
+      Math.round(deltaSeconds / SECONDS_PER_HOUR),
+      'hour'
+    )
+  }
+  return relativeTime.format(Math.round(deltaSeconds / SECONDS_PER_DAY), 'day')
+}
+
+/**
+ * Format a timestamp as a localized absolute date+time for a `title`
+ * tooltip (e.g. "Jan 15, 2026, 10:00 AM"). Returns an empty string for
+ * null / empty / invalid input so the caller can omit the attribute. Uses
+ * `Intl.DateTimeFormat` so the output localizes with the active BCP-47
+ * locale. The `locale` MUST be a BCP-47 tag (pass `i18n.language` through
+ * `toBcp47()` first).
+ */
+export function formatAbsoluteDateTime(
+  value: string | number | Date | null | undefined,
+  locale: string
+): string {
+  const timestamp = toTimestamp(value)
+  if (timestamp === null) return ''
+  return new Intl.DateTimeFormat(locale, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(timestamp)
+}


### PR DESCRIPTION
## Summary

Closes availability Gap 5 from the fresh availability-section review: the dashboard attention/alerts list rendered each item's severity badge + message but NOT its `createdAt` — the operator couldn't tell whether a critical alert fired 30 seconds ago (urgent) vs 3 hours ago (stale).

- Each attention item now shows a muted, small **relative timestamp** (e.g. "2 hours ago") right-aligned next to the severity + message, as a `<time>` element with `dateTime` (machine ISO) + `title` (absolute tooltip).
- Added two pure formatters to `web/src/lib/format.ts` (the existing shared-formatters file): `formatRelativeTime` (`Intl.RelativeTimeFormat`, `numeric: 'auto'`, largest sensible unit, absolute-date fallback >7d) + `formatAbsoluteDateTime` (`Intl.DateTimeFormat` for the tooltip). No date library added.
- **i18n**: `Intl.RelativeTimeFormat` via the existing `toBcp47(i18n.language)` bridge (i18n.language is `zhCN` which would throw in Intl) — output auto-localizes en/zh-CN live on language switch. **Zero new keys** (parity gate not triggered).
- Items missing/empty `createdAt` render nothing (no "ago" with no date).

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors
- [x] `bun run format:check` — green
- [x] `bun run test` — 531/531 across 63 files (incl. 2 NEW availability-attention cases: createdAt renders "2 hours ago" + tagName=TIME + dateTime + title; empty createdAt → no time element; Date.now pinned via vi.spyOn)
- [x] Independent re-ran `availability-attention` (2/2) as暗卷 spot-check

## Notes
- Safe file domain (dashboard/availability + shared lib/format.ts) — no overlap with the parallel process's badge/channel/route/oauth work; does NOT touch the #846 sparkline code.
- Reused Intl formatters (no new keys, no new dependency) — consistent with the project's "no fake translation" + "no new dep" rules.