### PR TITLE
docs: capture round-2 multi-perspective findings (model-tester/oauth/availability)

### DIFF
--- a/docs/analysis/ui-ux-audit-2026-08.md
+++ b/docs/analysis/ui-ux-audit-2026-08.md
@@ -114,3 +114,30 @@
 ### 旅程链路核实结论
 
 `?siteId=…&create=1` 深链：`resolveDeepLinkPreselect` 校验 site 后预选 + 一次性消费 + `navigate(…, replace)`；`buildAccountsHref` 保留 transient 参数直至 effect strip；`showAccountCreatedToast` → `/token-routes?accountId=…&siteId=…` → `buildChannelDraftSeed(chainContext?.accountId)`。链路完整，唯一断点是 `route-form-dialog.tsx:423`：`accountOptions.length === 0` 时（未跑 Rebuild 模型发现）silently 隐藏 `channelDrafts` 段，深链 seed 的 account 不可见（M，需空态 hint + 「先 Rebuild」指引）。
+
+### 二轮复审（model-tester / oauth / availability）—— 2026-08-18 续
+
+三个只读 explore 子代理复审 model-tester / oauth / availability（一轮未深覆盖区）。下列为证据，未升格为承诺；标 ✅ 已收口，⚠️ 仍开放。
+
+**model-tester** (`web/src/features/model-tester/`)
+
+- ✅ **#840**：token 用量展示（`parseUsage` 从 upstream body 解析 prompt/completion/total，跨 OpenAI/Claude/Responses/Gemini；cost 不在 wire 上——harness 绕过计费，未伪造，记为 residual）；删 always-dead `chunks: 0` stat；failed run 抑制 empty badge 只显 error。
+- ⚠️ 批量对比行 dead-end（无 re-run / channel drilldown）（M，触 channels 列）；cooldown/breaker 通道可选可静默失败（M，触 channels 列）。
+
+**oauth** (`web/src/features/oauth/`)
+
+- ✅ **#844**（并行进程）：start-dialog provider loading/error/empty 三态分支 + retry/settings 链。
+- ✅ **#845**（并行进程）：refresh/rebind 行级 pending（`pendingActionId` 镜像 accounts `pendingStatusId`）+ per-account error toast（`skipErrorHandler` 防双 toast）。
+- ⚠️ quota / lastModelSyncError / routeUnit 字段未呈现（M，加 quota 列 + 状态 tooltip 或 OAuthDetailSheet）；Start-OAuth 流 dead-end——丢 `result.state`/`instructions`，无 pending session 轮询、无 manual-callback UI（L，后端 `getOAuthSession`/`submitOAuthManualCallback` 已存在未用）；无批量 refresh + `updateOAuthConnectionProxy` PATCH 未用（proxy 改需删重建）（M+S）。
+
+**availability** (`web/src/features/dashboard/sections/availability/`)
+
+- ✅ **#846**：realtime sparkline 按 success-rate 健康分档着色（healthy/degraded/unhealthy/idle → `bg-success`/`bg-warning`/`bg-destructive`/`bg-muted-foreground`，原单色）+ `role="img"`/`aria-label`。Latency 不在 realtime wire 上（后端 `RealtimePoint` 无 latency）→ 未伪造，记为后端 residual。
+- ✅ **#847**：attention 项 `createdAt` 渲染为相对时间（`Intl.RelativeTimeFormat` via `toBcp47`，零新 key，en/zh-CN 自动本地化）+ `<time dateTime>` + absolute `title` tooltip。
+- ⚠️ attention alert 点击 dead-end 到通用落地页（plain `<a href>` + 不支持的 `?accountId=` 参数）（M，触 accounts schema）；realtime 面板 success 下降时无 drill-down 到 per-channel 健康（M，触 channels）；WS 重连 5 次后永久放弃——无 retry 按钮、metrics 归零看起来像「无流量」（M，后端 `handler/shared/realtime.go` + 前端 hook）。
+
+**已收口（续，#838 + #840 + #842 + #846 + #847）**
+
+- **Dashboard onboarding banner**（User #1，#838）：`siteCount===0` 时显示 brand-tinted `<Card>` + 「Create site」CTA → `/sites`；`=== 0` 排除 loading 防误闪。
+- **Sites `?create=1` auto-open**（#838 follow-up，#842）：`sitesSearchSchema` 加 `create`，sites-page 一次性消费 + strip（镜像 accounts `?create`），overview CTA 改 `<Link to='/sites' search={{ create: true }}>` 直达 create dialog。
+- 详见上方 model-tester / availability 各 ✅ 项。

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,18 @@
 > Product milestone timeline (grouped by version). Not the current-state source of truth.
 > Current state → [`STATE.md`](STATE.md) · open items → [`progress/MASTER.md`](progress/MASTER.md) · detailed version narrative → root [`CHANGELOG.md`](../CHANGELOG.md)
 
+## 2026-08-18 — 二轮复审驱动：onboarding 闭环 + model-tester 结果清晰度 + availability 健康可视化
+
+二轮 PM/工程师/用户复审（model-tester / oauth / availability，发现写入审计 doc `### 二轮复审`）后交付：
+
+- **Dashboard onboarding banner + sites `?create=1` 深链闭环**（#838 + #842）：`siteCount===0` 时 brand-tinted `<Card>` + 「Create site」CTA；sites-page 加 `create` schema + 一次性消费 strip（镜像 accounts `?create`）；overview CTA 改 `<Link search={{ create: true }}>` 直达 create dialog。闭合首次落地 dead-end。
+- **Model-tester 结果清晰度**（#840）：`parseUsage` 从 upstream body 解析 token 用量跨四协议（cost 不在 wire 上，harness 绕过计费——未伪造，记 residual）；删 always-dead `chunks: 0` stat；failed run 抑制 empty badge 只显 error。516 测试。
+- **Availability realtime sparkline 健康分档着色**（#846）：success-rate 按 healthy/degraded/unhealthy/idle 着色（原单色 `bg-chart-1/70`）+ `role="img"`/`aria-label`。Latency 不在 realtime wire 上（后端 `RealtimePoint` 无 latency）→ 未伪造，记后端 residual。
+- **Attention 项 `createdAt` 相对时间**（#847）：`Intl.RelativeTimeFormat` via `toBcp47`（零新 key，en/zh-CN 自动本地化）+ `<time dateTime>` + absolute `title` tooltip。`formatRelativeTime`/`formatAbsoluteDateTime` 入 `lib/format.ts` 共享。
+- **OAuth 二轮**（并行进程 #844/#845）：start-dialog provider 三态分支 + refresh/rebind 行级 pending + per-account error。
+- **验证**：go build/vet 绿；web tsgo/oxlint/oxfmt format:check/vitest 全绿（529→531 测试）；GHA CI 全绿（#832 + #847 首跑 golangci-lint schema 拉取超时 flaky，rerun 后绿）。
+- **工作流**：多 worktree 并行 + explore 子代理二轮深覆盖（model-tester/oauth/availability）+ 暗卷独立复跑聚焦测试。避让并行进程的 badge-feature 文件；2 处（oauth Gap 4/Gap 1）与并行进程 #844/#845 重复→本地丢弃未强推。剩余 entangled 项（proxy-log drilldown / WS 重连 / oauth quota 列）写入审计 doc 供协调。
+
 ## 2026-08-18 — 多角度复审驱动：动线 dead-end 收口 + proxy-logs 过滤服务端化 + downstream key edit
 
 三轮 PM/工程师/用户只读复审（发现写入审计 doc `## 2026-08-18 多角度复审`）后，按 backlog 交付：


### PR DESCRIPTION
## Summary

Knowledge-hygiene sync after the round-2 multi-perspective reviews (model-tester / oauth / availability — areas the round-1 review didn't deeply cover) + the merged #838/#840/#842/#846/#847.

Adds a "二轮复审" subsection to the audit doc capturing:
- **✅ Done**: #840 (model-tester result clarity — token usage, dead chunks, error badge), #844/#845 (oauth start-dialog states + row-pending — parallel process), #846 (availability sparkline health-band coloring), #847 (attention createdAt relative timestamp).
- **⚠️ Open** (with entanglement/coordination notes): oauth quota-column/start-session-poll/batch-refresh, availability attention-links-dead-end/realtime-drilldown/WS-reconnect-give-up, model-tester batch-comparison-dead-end/cooldown-channels-selectable.

Adds a log.md milestone entry for #838 (onboarding banner) + #842 (sites `?create=1` deep-link closure) + #840/#846/#847 + the parallel-process oauth #844/#845 + the 2 duplication incidents (Gap 4/Gap 1 discarded) + the golangci-lint flaky-rerun pattern.

No source changes — docs only. `go test ./docs/...` green.

## Test plan
- [x] `go test ./docs/...` — ok