### PR TITLE
fix(dashboard): expose realtime WS reconnect + gaveUp notice

### DIFF
--- a/web/src/features/dashboard/components/today-snapshot.tsx
+++ b/web/src/features/dashboard/components/today-snapshot.tsx
@@ -119,7 +119,7 @@ export function TodaySnapshotStrip() {
     queryFn: () => api.getAttention(20) as Promise<AttentionResponse>,
   })
 
-  const realtime = useRealtimeOps()
+  const { sample: realtime } = useRealtimeOps()
 
   const trend = useMemo(
     () => computeBalanceTrend(balanceHistory),

--- a/web/src/features/dashboard/hooks/use-realtime-ops.ts
+++ b/web/src/features/dashboard/hooks/use-realtime-ops.ts
@@ -9,7 +9,7 @@
 // consecutive failures the hook gives up permanently (the panel then renders
 // the disconnected state rather than retrying forever).
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { getAuthToken } from '@/lib/auth-session'
 
@@ -20,6 +20,7 @@ import type {
 } from '../types'
 
 const MAX_FAILS = 5
+const INITIAL_BACKOFF_MS = 1_000
 const MAX_BACKOFF_MS = 15_000
 const SPARK_WINDOW = 60
 
@@ -61,25 +62,40 @@ const IDLE: RealtimeOpsSample = {
   gaveUp: false,
 }
 
+/** Return shape of {@link useRealtimeOps}. */
+export type UseRealtimeOpsReturn = {
+  sample: RealtimeOpsSample
+  reconnect: () => void
+}
+
 /**
  * Subscribe to the realtime ops WebSocket. Returns a rolling 60-sample
  * sparkline + derived qps / successRate / lifetime. Renders nothing usable
  * when there is no token (the panel hides itself in that case).
+ *
+ * Auto-reconnect with exponential backoff runs until MAX_FAILS consecutive
+ * failures, after which the hook gives up and surfaces `sample.gaveUp`. The
+ * returned `reconnect` callback lets the operator manually re-enter the
+ * connection from that gave-up state (it resets failure accounting, tears
+ * down any live socket, and re-invokes the effect's `connect`).
  */
-export function useRealtimeOps(): RealtimeOpsSample {
+export function useRealtimeOps(): UseRealtimeOpsReturn {
   const [sample, setSample] = useState<RealtimeOpsSample>(IDLE)
   const socketRef = useRef<WebSocket | null>(null)
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const failsRef = useRef(0)
   const previousTotalRef = useRef<number | null>(null)
   const sparkRef = useRef<RealtimeOpsSamplePoint[]>([])
+  // Latest connect() captured by the effect so the stable reconnect callback
+  // can re-enter it without a stale-closure.
+  const connectRef = useRef<(() => void) | null>(null)
+  const backoffRef = useRef(INITIAL_BACKOFF_MS)
 
   useEffect(() => {
     const token = getAuthToken()
     if (!token) return undefined
 
     let disposed = false
-    let backoff = 1000
 
     const connect = () => {
       if (disposed) return
@@ -96,7 +112,7 @@ export function useRealtimeOps(): RealtimeOpsSample {
 
       socket.onopen = () => {
         failsRef.current = 0
-        backoff = 1000
+        backoffRef.current = INITIAL_BACKOFF_MS
         setSample((prev) => ({ ...prev, connected: true, gaveUp: false }))
       }
 
@@ -147,15 +163,17 @@ export function useRealtimeOps(): RealtimeOpsSample {
           setSample(DISCONNECTED)
           return
         }
-        backoff = Math.min(backoff * 2, MAX_BACKOFF_MS)
-        reconnectTimer.current = setTimeout(connect, backoff)
+        backoffRef.current = Math.min(backoffRef.current * 2, MAX_BACKOFF_MS)
+        reconnectTimer.current = setTimeout(connect, backoffRef.current)
       }
     }
 
+    connectRef.current = connect
     connect()
 
     return () => {
       disposed = true
+      connectRef.current = null
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
       const socket = socketRef.current
       if (socket) {
@@ -169,5 +187,36 @@ export function useRealtimeOps(): RealtimeOpsSample {
     }
   }, [])
 
-  return sample
+  // Stable manual reconnect for the gave-up state. Resets failure accounting
+  // + pending backoff, tears down any live socket WITHOUT triggering
+  // auto-reconnect accounting (handlers nulled before close), clears the
+  // rolling window for a clean slate, then re-enters the latest connect().
+  const reconnect = useCallback(() => {
+    failsRef.current = 0
+    backoffRef.current = INITIAL_BACKOFF_MS
+    if (reconnectTimer.current) {
+      clearTimeout(reconnectTimer.current)
+      reconnectTimer.current = null
+    }
+    const socket = socketRef.current
+    if (socket) {
+      socket.onopen = null
+      socket.onmessage = null
+      socket.onerror = null
+      socket.onclose = null
+      if (
+        socket.readyState === WebSocket.OPEN ||
+        socket.readyState === WebSocket.CONNECTING
+      ) {
+        socket.close()
+      }
+      socketRef.current = null
+    }
+    sparkRef.current = []
+    previousTotalRef.current = null
+    setSample(IDLE)
+    connectRef.current?.()
+  }, [])
+
+  return { sample, reconnect }
 }

--- a/web/src/features/dashboard/sections/availability/__tests__/availability-attention-created-at.test.tsx
+++ b/web/src/features/dashboard/sections/availability/__tests__/availability-attention-created-at.test.tsx
@@ -51,6 +51,11 @@ const IDLE_SAMPLE: RealtimeOpsSample = {
   gaveUp: false,
 }
 
+/** Wrap a realtime sample in the hook's `{ sample, reconnect }` return shape. */
+function realtimeReturn(sample: RealtimeOpsSample) {
+  return { sample, reconnect: vi.fn() }
+}
+
 function createQueryClient() {
   return new QueryClient({
     defaultOptions: {
@@ -70,7 +75,7 @@ beforeEach(() => {
   mockGetAttention.mockReset()
   mockUseRealtimeOps.mockReset()
   // Sibling realtime ops panel renders idle without a live WebSocket.
-  mockUseRealtimeOps.mockReturnValue(IDLE_SAMPLE)
+  mockUseRealtimeOps.mockReturnValue(realtimeReturn(IDLE_SAMPLE))
   vi.spyOn(Date, 'now').mockReturnValue(FIXED_NOW)
 })
 

--- a/web/src/features/dashboard/sections/availability/__tests__/availability-reconnect.test.tsx
+++ b/web/src/features/dashboard/sections/availability/__tests__/availability-reconnect.test.tsx
@@ -1,0 +1,125 @@
+// Behavior test for the realtime ops panel's gave-up reconnect affordance.
+//
+// Closes availability gap 3: after MAX_FAILS consecutive WebSocket failures
+// the hook gave up permanently and the panel rendered zeroed metrics
+// (qps=0, successRate=0) indistinguishable from "no traffic". The panel now
+// surfaces a "Realtime connection lost." notice + a "Reconnect" button that
+// re-triggers the hook's connection. The zeroed metrics/sparkline stay hidden
+// while gaveUp so the operator can tell a dead connection from idle traffic.
+//
+// The realtime ops hook is stubbed (the WS is a browser boundary outside the
+// panel behavior under test); api.getAttention is stubbed so the sibling
+// Attention panel resolves without a network call. The mock `reconnect` is a
+// plain spy so the test asserts the panel wires it to the button's onClick.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+import { useRealtimeOps } from '@/features/dashboard/hooks/use-realtime-ops'
+import type { RealtimeOpsSample } from '@/features/dashboard/types'
+import { api } from '@/lib/api'
+
+import { AvailabilitySection } from '../availability-section'
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getAttention: vi.fn(),
+  },
+}))
+
+vi.mock('@/features/dashboard/hooks/use-realtime-ops', () => ({
+  useRealtimeOps: vi.fn(),
+}))
+
+const mockGetAttention = vi.mocked(api.getAttention)
+const mockUseRealtimeOps = vi.mocked(useRealtimeOps)
+
+// The post-give-up sample: the hook set DISCONNECTED (gaveUp=true) after
+// MAX_FAILS. The zeroed metrics + empty sparkline would look like "no
+// traffic" without the gaveUp branch.
+const GAVE_UP_SAMPLE: RealtimeOpsSample = {
+  qps: 0,
+  successRate: 0,
+  lifetime: 0,
+  spark: [],
+  connected: false,
+  gaveUp: true,
+}
+
+const CONNECTED_SAMPLE: RealtimeOpsSample = {
+  qps: 5,
+  successRate: 0.99,
+  lifetime: 120,
+  spark: [{ qps: 5, successRate: 0.99 }],
+  connected: true,
+  gaveUp: false,
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0, refetchOnWindowFocus: false },
+    },
+  })
+}
+
+function renderWithClient(ui: ReactNode) {
+  const queryClient = createQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  mockGetAttention.mockReset()
+  mockUseRealtimeOps.mockReset()
+  // Sibling Attention panel resolves to an empty list so it never throws.
+  mockGetAttention.mockResolvedValue({ items: [], total: 0 })
+})
+
+afterEach(() => cleanup())
+
+describe('AvailabilitySection realtime reconnect affordance', () => {
+  it('renders the connection-lost notice + Reconnect button when gaveUp', () => {
+    const reconnect = vi.fn()
+    mockUseRealtimeOps.mockReturnValue({ sample: GAVE_UP_SAMPLE, reconnect })
+
+    renderWithClient(<AvailabilitySection />)
+
+    expect(screen.getByText('Realtime connection lost.')).toBeInTheDocument()
+    const button = screen.getByRole('button', { name: 'Reconnect' })
+    expect(button).toBeInTheDocument()
+  })
+
+  it('calls reconnect when the operator clicks the Reconnect button', () => {
+    const reconnect = vi.fn()
+    mockUseRealtimeOps.mockReturnValue({ sample: GAVE_UP_SAMPLE, reconnect })
+
+    renderWithClient(<AvailabilitySection />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reconnect' }))
+
+    expect(reconnect).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not surface the Reconnect button while the stream is live', () => {
+    const reconnect = vi.fn()
+    mockUseRealtimeOps.mockReturnValue({
+      sample: CONNECTED_SAMPLE,
+      reconnect,
+    })
+
+    renderWithClient(<AvailabilitySection />)
+
+    expect(
+      screen.queryByRole('button', { name: 'Reconnect' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Realtime connection lost.')
+    ).not.toBeInTheDocument()
+  })
+})

--- a/web/src/features/dashboard/sections/availability/__tests__/availability-sparkline.test.tsx
+++ b/web/src/features/dashboard/sections/availability/__tests__/availability-sparkline.test.tsx
@@ -44,6 +44,14 @@ vi.mock('@/features/dashboard/hooks/use-realtime-ops', () => ({
 const mockGetAttention = vi.mocked(api.getAttention)
 const mockUseRealtimeOps = vi.mocked(useRealtimeOps)
 
+/**
+ * Wrap a realtime sample in the hook's `{ sample, reconnect }` return shape so
+ * each case only spells out the sample under test.
+ */
+function realtimeReturn(sample: RealtimeOpsSample) {
+  return { sample, reconnect: vi.fn() }
+}
+
 function createQueryClient() {
   return new QueryClient({
     defaultOptions: {
@@ -103,7 +111,7 @@ afterEach(() => cleanup())
 describe('AvailabilitySection realtime sparkline health', () => {
   it('labels the sparkline healthy when the latest sample is healthy', async () => {
     mockUseRealtimeOps.mockReturnValue(
-      sampleWithLatest({ qps: 12, successRate: 0.99 })
+      realtimeReturn(sampleWithLatest({ qps: 12, successRate: 0.99 }))
     )
 
     renderWithClient(<AvailabilitySection />)
@@ -115,7 +123,7 @@ describe('AvailabilitySection realtime sparkline health', () => {
 
   it('labels the sparkline degraded when success falls to the amber band', async () => {
     mockUseRealtimeOps.mockReturnValue(
-      sampleWithLatest({ qps: 12, successRate: 0.85 })
+      realtimeReturn(sampleWithLatest({ qps: 12, successRate: 0.85 }))
     )
 
     renderWithClient(<AvailabilitySection />)
@@ -127,7 +135,7 @@ describe('AvailabilitySection realtime sparkline health', () => {
 
   it('labels the sparkline unhealthy when success drops below the degraded band', async () => {
     mockUseRealtimeOps.mockReturnValue(
-      sampleWithLatest({ qps: 12, successRate: 0.5 })
+      realtimeReturn(sampleWithLatest({ qps: 12, successRate: 0.5 }))
     )
 
     renderWithClient(<AvailabilitySection />)
@@ -138,7 +146,7 @@ describe('AvailabilitySection realtime sparkline health', () => {
   })
 
   it('labels the sparkline idle when there is no recent traffic', async () => {
-    mockUseRealtimeOps.mockReturnValue(IDLE_SAMPLE)
+    mockUseRealtimeOps.mockReturnValue(realtimeReturn(IDLE_SAMPLE))
 
     renderWithClient(<AvailabilitySection />)
 
@@ -151,7 +159,7 @@ describe('AvailabilitySection realtime sparkline health', () => {
     // History is healthy, but the latest second is unhealthy — the name must
     // reflect the current state, not the historical baseline.
     mockUseRealtimeOps.mockReturnValue(
-      sampleWithLatest({ qps: 12, successRate: 0.4 })
+      realtimeReturn(sampleWithLatest({ qps: 12, successRate: 0.4 }))
     )
 
     renderWithClient(<AvailabilitySection />)

--- a/web/src/features/dashboard/sections/availability/availability-section.tsx
+++ b/web/src/features/dashboard/sections/availability/availability-section.tsx
@@ -11,6 +11,7 @@ import { Inbox, Radio, ShieldCheck, TriangleAlert } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import {
   Card,
   CardContent,
@@ -132,7 +133,7 @@ function RealtimeSparkline({ points }: { points: RealtimeOpsSamplePoint[] }) {
 
 function RealtimeOpsPanel() {
   const { t } = useTranslation()
-  const sample = useRealtimeOps()
+  const { sample, reconnect } = useRealtimeOps()
 
   const tone = sample.gaveUp
     ? 'border-destructive/40 bg-destructive/5'
@@ -180,33 +181,47 @@ function RealtimeOpsPanel() {
         </CardDescription>
       </CardHeader>
       <CardContent className='space-y-3'>
-        <div className='flex flex-wrap items-end justify-between gap-x-4 gap-y-2'>
-          <div>
-            <div className='text-muted-foreground text-xs'>
-              {t('dashboard.availability.realtime.metricQps')}
-            </div>
-            <div className='text-2xl font-semibold tabular-nums'>
-              {sample.qps}
-            </div>
+        {sample.gaveUp ? (
+          <div className='border-destructive/40 flex min-h-[8rem] flex-col items-center justify-center gap-3 rounded-lg border border-dashed py-6 text-center'>
+            <TriangleAlert className='text-destructive/80 size-5' />
+            <p className='text-destructive text-sm'>
+              {t('dashboard.availability.realtime.connectionLost')}
+            </p>
+            <Button variant='outline' size='sm' onClick={reconnect}>
+              {t('dashboard.availability.realtime.reconnect')}
+            </Button>
           </div>
-          <div>
-            <div className='text-muted-foreground text-xs'>
-              {t('dashboard.availability.realtime.metricSuccess')}
+        ) : (
+          <>
+            <div className='flex flex-wrap items-end justify-between gap-x-4 gap-y-2'>
+              <div>
+                <div className='text-muted-foreground text-xs'>
+                  {t('dashboard.availability.realtime.metricQps')}
+                </div>
+                <div className='text-2xl font-semibold tabular-nums'>
+                  {sample.qps}
+                </div>
+              </div>
+              <div>
+                <div className='text-muted-foreground text-xs'>
+                  {t('dashboard.availability.realtime.metricSuccess')}
+                </div>
+                <div className='text-2xl font-semibold tabular-nums'>
+                  {formatRate(sample.successRate)}
+                </div>
+              </div>
+              <div>
+                <div className='text-muted-foreground text-xs'>
+                  {t('dashboard.availability.realtime.metricUptime')}
+                </div>
+                <div className='text-2xl font-semibold tabular-nums'>
+                  {Math.floor(sample.lifetime / 60)}m
+                </div>
+              </div>
             </div>
-            <div className='text-2xl font-semibold tabular-nums'>
-              {formatRate(sample.successRate)}
-            </div>
-          </div>
-          <div>
-            <div className='text-muted-foreground text-xs'>
-              {t('dashboard.availability.realtime.metricUptime')}
-            </div>
-            <div className='text-2xl font-semibold tabular-nums'>
-              {Math.floor(sample.lifetime / 60)}m
-            </div>
-          </div>
-        </div>
-        <RealtimeSparkline points={sample.spark} />
+            <RealtimeSparkline points={sample.spark} />
+          </>
+        )}
       </CardContent>
     </Card>
   )

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -642,6 +642,8 @@
           "statusDisconnected": "disconnected",
           "statusLive": "live",
           "statusConnecting": "connecting",
+          "connectionLost": "Realtime connection lost.",
+          "reconnect": "Reconnect",
           "metricQps": "QPS",
           "metricSuccess": "success",
           "metricUptime": "uptime",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -642,6 +642,8 @@
           "statusDisconnected": "已断开",
           "statusLive": "实时",
           "statusConnecting": "连接中",
+          "connectionLost": "实时连接已断开。",
+          "reconnect": "重新连接",
           "metricQps": "QPS",
           "metricSuccess": "成功率",
           "metricUptime": "运行时间",


### PR DESCRIPTION
## Summary
- Closes availability Gap 3: the realtime ops panel silently died after 5 WS failures, rendering zeroed metrics indistinguishable from "no traffic".
- Refactored `useRealtimeOps` to return `{ sample, reconnect }` with a stable `useCallback` reconnect (resets `failsRef`/`backoffRef`/socket, re-enters `connect` via `connectRef`).
- When `sample.gaveUp`, the panel renders a "Connection lost — Reconnect" notice (dashed destructive border + TriangleAlert + outline button) instead of the zeroed metrics; `min-h-[8rem]` keeps the panel from collapsing.

## Test plan
- [x] `bun run typecheck && bun run lint && bun run format:check && bun run test` (534 tests)
- [x] `availability-reconnect.test.tsx`: gaveUp renders notice + Reconnect button; click calls `reconnect`; Reconnect absent while connected
- [ ] CI (12 checks)