### PR TITLE
fix(sites): stop customHeadersOverride data loss + error-state + tests

### DIFF
--- a/web/src/features/sites/components/__tests__/site-form-dialog.test.tsx
+++ b/web/src/features/sites/components/__tests__/site-form-dialog.test.tsx
@@ -1,0 +1,194 @@
+// Regression tests for the add/edit site form dialog. Guards the gap-1
+// round-trip of `customHeadersOverrideRequestHeaders`, Zod submission
+// errors, the create payload reaching `onCreated`, and the dirty-close
+// confirm guard. Mocks only the sites api + toast; keeps the real
+// RHF + Zod + dirty-close-hook code paths under test.
+import '@testing-library/jest-dom/vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+
+import type { Site } from '../../types'
+import { SiteFormDialog } from '../site-form-dialog'
+
+const { mockCreateMutate, mockUpdateMutate, mockDetectMutate, mockToastError } =
+  vi.hoisted(() => ({
+    mockCreateMutate: vi.fn(),
+    mockUpdateMutate: vi.fn(),
+    mockDetectMutate: vi.fn(),
+    mockToastError: vi.fn(),
+  }))
+
+vi.mock('../../api', () => ({
+  useCreateSite: () => ({ mutateAsync: mockCreateMutate, isPending: false }),
+  useUpdateSite: () => ({ mutateAsync: mockUpdateMutate, isPending: false }),
+  useDetectSite: () => ({ mutateAsync: mockDetectMutate, isPending: false }),
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: mockToastError,
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+beforeAll(() => {
+  // base-ui Dialog / AlertDialog / Select need matchMedia under jsdom.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  mockCreateMutate.mockReset()
+  mockUpdateMutate.mockReset()
+  mockDetectMutate.mockReset()
+  mockToastError.mockReset()
+  // Default: detection returns nothing so the platform stays manual.
+  mockDetectMutate.mockResolvedValue({})
+})
+
+afterEach(() => cleanup())
+
+function typeField(label: string, value: string) {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } })
+}
+
+describe('SiteFormDialog Zod submission errors', () => {
+  it('renders the nameRequired error when submitting with an empty name', async () => {
+    render(<SiteFormDialog open onOpenChange={vi.fn()} editingSite={null} />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Name')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Please enter a name.')).toBeInTheDocument()
+    })
+    // Validation failure must short-circuit before the create mutation fires.
+    expect(mockCreateMutate).not.toHaveBeenCalled()
+    expect(mockToastError).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('SiteFormDialog create payload', () => {
+  it('calls onCreated with the created site after a valid submit', async () => {
+    const createdSite: Site = {
+      id: 42,
+      name: 'My Site',
+      url: 'https://example.com',
+      platform: '',
+      status: 'active',
+    }
+    mockCreateMutate.mockResolvedValue(createdSite)
+    const onCreated = vi.fn()
+
+    render(
+      <SiteFormDialog
+        open
+        onOpenChange={vi.fn()}
+        editingSite={null}
+        onCreated={onCreated}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Name')).toBeInTheDocument()
+    })
+
+    typeField('Name', 'My Site')
+    typeField('URL', 'https://example.com')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => {
+      expect(mockCreateMutate).toHaveBeenCalledTimes(1)
+    })
+
+    // The payload must carry the entered fields plus the default
+    // `customHeadersOverrideRequestHeaders: false` (gap-1 round-trip
+    // contract: create sends the schema's boolean, never undefined).
+    const payload = mockCreateMutate.mock.calls[0]?.[0]
+    expect(payload).toMatchObject({
+      name: 'My Site',
+      url: 'https://example.com',
+      customHeadersOverrideRequestHeaders: false,
+    })
+    expect(onCreated).toHaveBeenCalledWith(createdSite)
+  })
+})
+
+describe('SiteFormDialog edit round-trip (gap-1)', () => {
+  it('checks the override-headers switch when editing a site with it enabled', async () => {
+    const editingSite: Site = {
+      id: 7,
+      name: 'Existing site',
+      url: 'https://existing.example',
+      platform: 'openai',
+      status: 'active',
+      customHeaders: '{"X-Test":"1"}',
+      customHeadersOverrideRequestHeaders: true,
+    }
+
+    render(
+      <SiteFormDialog open onOpenChange={vi.fn()} editingSite={editingSite} />
+    )
+
+    const overrideSwitch = await screen.findByRole('switch', {
+      name: 'Override request headers',
+    })
+
+    await waitFor(() => {
+      expect(overrideSwitch).toHaveAttribute('aria-checked', 'true')
+    })
+  })
+})
+
+describe('SiteFormDialog dirty-close guard', () => {
+  it('opens the discard confirm when closing with unsaved edits', async () => {
+    render(<SiteFormDialog open onOpenChange={vi.fn()} editingSite={null} />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Name')).toBeInTheDocument()
+    })
+
+    typeField('Name', 'dirty value')
+
+    // Trigger close via the dialog's close (X) button. The dirty-close
+    // guard must intercept and show the confirm instead of discarding.
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Discard unsaved changes?')).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/features/sites/components/__tests__/sites-page.test.tsx
+++ b/web/src/features/sites/components/__tests__/sites-page.test.tsx
@@ -1,0 +1,184 @@
+// Regression tests for the sites list page. Covers the three behaviors that
+// previously regressed: the one-shot `?create=1` deep link, the error state
+// suppressing the empty-state CTA, and the Retry button calling refetch.
+import '@testing-library/jest-dom/vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { SitesPage } from '../sites-page'
+
+const testState = vi.hoisted(() => ({
+  search: { create: false as boolean | undefined },
+  navigate: vi.fn(),
+  sitesQuery: {
+    data: [],
+    error: null as Error | null,
+    isLoading: false,
+    isFetching: false,
+    refetch: vi.fn().mockResolvedValue({}),
+  },
+  formOpenCount: 0,
+  previousFormOpen: undefined as boolean | undefined,
+  dataTableRendered: false,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => testState.navigate,
+  useSearch: () => testState.search,
+}))
+
+vi.mock('@/components/data-table', () => ({
+  DataTableBulkActions: () => null,
+  // Sentinel component so the error-state test can assert the table page is
+  // NOT rendered (and therefore the empty-state CTA inside it is absent).
+  DataTablePage: () => {
+    testState.dataTableRendered = true
+    return null
+  },
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    sorting: [],
+    onSortingChange: vi.fn(),
+    ensurePageInRange: vi.fn(),
+  }),
+  useDataTable: () => ({
+    table: {
+      getFilteredSelectedRowModel: () => ({ rows: [] }),
+      resetRowSelection: vi.fn(),
+    },
+  }),
+  encodeSorting: () => '',
+}))
+
+vi.mock('@/features/accounts', () => ({
+  useAccounts: () => ({ data: { accounts: [] }, isLoading: false }),
+}))
+
+vi.mock('@/features/import', () => ({
+  ImportWizardDialog: () => null,
+}))
+
+vi.mock('../../api', () => ({
+  useSites: () => testState.sitesQuery,
+  useDeleteSite: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateSite: () => ({ mutate: vi.fn(), isPending: false }),
+  useBatchUpdateSites: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDetectSite: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+vi.mock('../site-created-modal', () => ({
+  SiteCreatedModal: () => null,
+}))
+
+vi.mock('../site-detail-sheet', () => ({
+  SiteDetailSheet: () => null,
+}))
+
+vi.mock('../site-form-dialog', () => ({
+  SiteFormDialog: (props: { open: boolean }) => {
+    if (props.open && testState.previousFormOpen !== true) {
+      testState.formOpenCount += 1
+    }
+    testState.previousFormOpen = props.open
+    return null
+  },
+}))
+
+vi.mock('../sites-columns', () => ({
+  SITES_STATUS_FILTER_OPTIONS: [],
+  useSitesColumns: () => [],
+}))
+
+afterEach(() => cleanup())
+
+beforeEach(() => {
+  testState.navigate.mockReset()
+  testState.sitesQuery.refetch.mockReset()
+  testState.sitesQuery.refetch.mockResolvedValue({})
+  testState.formOpenCount = 0
+  testState.previousFormOpen = undefined
+  testState.dataTableRendered = false
+  testState.search = { create: false }
+  testState.sitesQuery.data = []
+  testState.sitesQuery.error = null
+  testState.sitesQuery.isLoading = false
+  testState.sitesQuery.isFetching = false
+})
+
+describe('SitesPage create deep link', () => {
+  it('opens the create dialog once and strips the transient create param', async () => {
+    testState.search = { create: true }
+    const { rerender } = render(<SitesPage />)
+
+    await waitFor(() => {
+      expect(testState.formOpenCount).toBe(1)
+    })
+
+    // After consumption, the page navigates to strip `create`; a remount
+    // (search.create now false) must not reopen the dialog.
+    testState.search = { create: false }
+    rerender(<SitesPage />)
+
+    await waitFor(() => {
+      expect(testState.formOpenCount).toBe(1)
+    })
+    expect(testState.navigate).toHaveBeenCalledTimes(1)
+    expect(testState.navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/sites',
+        replace: true,
+        search: expect.objectContaining({ create: undefined }),
+      })
+    )
+  })
+})
+
+describe('SitesPage error state', () => {
+  it('renders the error banner and Retry button, not the empty-state CTA', () => {
+    testState.sitesQuery.error = new Error('boom')
+    render(<SitesPage />)
+
+    expect(screen.getByText(/Failed to load sites: boom/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+
+    // The table page (which owns the empty-state "Add site" CTA) must be
+    // suppressed while the query is in an error state.
+    expect(testState.dataTableRendered).toBe(false)
+    expect(
+      screen.queryByRole('button', { name: /Add site/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the table page (not the error banner) when there is no error', () => {
+    testState.sitesQuery.error = null
+    render(<SitesPage />)
+
+    expect(testState.dataTableRendered).toBe(true)
+    expect(screen.queryByText(/Failed to load sites/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Retry' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('calls refetch when the Retry button is clicked', () => {
+    testState.sitesQuery.error = new Error('boom')
+    render(<SitesPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(testState.sitesQuery.refetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/features/sites/components/site-created-modal.tsx
+++ b/web/src/features/sites/components/site-created-modal.tsx
@@ -32,19 +32,6 @@ type SiteCreatedModalProps = {
   onOpenChange: (open: boolean) => void
 }
 
-/**
- * Build the accounts-page deep link. Uses the untyped `href` overload so it
- * works whether or not the `/accounts` route is registered in the typed
- * route tree yet (the accounts feature may land in a later phase).
- */
-function buildAccountsHref(siteId: number): string {
-  const params = new URLSearchParams({
-    siteId: String(siteId),
-    create: '1',
-  })
-  return `/accounts?${params.toString()}`
-}
-
 export function SiteCreatedModal({
   site,
   open,
@@ -56,7 +43,11 @@ export function SiteCreatedModal({
   function handleGoToAccounts() {
     if (!site) return
     onOpenChange(false)
-    navigate({ href: buildAccountsHref(site.id), replace: true })
+    navigate({
+      to: '/accounts',
+      search: { siteId: site.id, create: true },
+      replace: true,
+    })
   }
 
   return (

--- a/web/src/features/sites/components/site-form-dialog.tsx
+++ b/web/src/features/sites/components/site-form-dialog.tsx
@@ -84,7 +84,8 @@ function siteToFormValues(site: Site): SiteFormValues {
     proxyUrl: site.proxyUrl ?? '',
     useSystemProxy: site.useSystemProxy ?? false,
     customHeaders: site.customHeaders ?? '',
-    customHeadersOverrideRequestHeaders: false,
+    customHeadersOverrideRequestHeaders:
+      site.customHeadersOverrideRequestHeaders ?? false,
     globalWeight: site.globalWeight ?? 1,
     maxConcurrency: site.maxConcurrency ?? 0,
     postRefreshProbeEnabled: site.postRefreshProbeEnabled ?? false,
@@ -532,6 +533,29 @@ export function SiteFormDialog({
                     {t('sites.form.customHeadersHint')}
                   </FormDescription>
                   <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name='customHeadersOverrideRequestHeaders'
+              render={({ field }) => (
+                <FormItem className='flex items-center justify-between rounded-lg border p-3'>
+                  <div className='space-y-0.5'>
+                    <FormLabel>
+                      {t('sites.form.customHeadersOverrideRequestHeaders')}
+                    </FormLabel>
+                    <FormDescription>
+                      {t('sites.form.customHeadersOverrideRequestHeadersHint')}
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={(checked) => field.onChange(checked)}
+                    />
+                  </FormControl>
                 </FormItem>
               )}
             />

--- a/web/src/features/sites/components/sites-page.tsx
+++ b/web/src/features/sites/components/sites-page.tsx
@@ -12,6 +12,7 @@
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import {
   Plus as PlusIcon,
+  RotateCcw as RotateCcwIcon,
   Trash2 as Trash2Icon,
   Upload as UploadIcon,
 } from 'lucide-react'
@@ -357,84 +358,101 @@ export function SitesPage() {
         </p>
       </div>
 
-      {sitesQuery.error && (
-        <div className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg rounded-lg border p-3 text-sm'>
-          {t('sites.page.loadError', {
-            message: (sitesQuery.error as Error).message,
-          })}
+      {sitesQuery.error ? (
+        <div className='flex flex-col gap-3'>
+          <div className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg rounded-lg border p-3 text-sm'>
+            {t('sites.page.loadError', {
+              message: (sitesQuery.error as Error).message,
+            })}
+          </div>
+          <div>
+            <Button
+              variant='secondary'
+              onClick={() => sitesQuery.refetch()}
+              disabled={sitesQuery.isFetching}
+            >
+              {sitesQuery.isFetching ? (
+                <Spinner className='mr-1' />
+              ) : (
+                <RotateCcwIcon className='mr-1 size-4' />
+              )}
+              {t('sites.page.retry')}
+            </Button>
+          </div>
         </div>
+      ) : (
+        <DataTablePage
+          table={table}
+          columns={columns}
+          isLoading={sitesQuery.isLoading}
+          isFetching={sitesQuery.isFetching}
+          emptyTitle={t('sites.empty.title')}
+          emptyDescription={t('sites.empty.description')}
+          emptyAction={
+            <>
+              <Button onClick={() => setImportOpen(true)}>
+                <UploadIcon className='mr-1 size-4' />
+                {t('sites.empty.import')}
+              </Button>
+              <Button variant='outline' onClick={handleAddSite}>
+                <PlusIcon className='mr-1 size-4' />
+                {t('sites.empty.addSite')}
+              </Button>
+            </>
+          }
+          skeletonKeyPrefix='site-skeleton'
+          toolbarProps={{
+            searchPlaceholder: t('sites.toolbar.searchPlaceholder'),
+            searchDebounceMs: 400,
+            filters: [
+              {
+                columnId: 'status',
+                title: t('sites.columns.status'),
+                options: statusFilters,
+                singleSelect: true,
+              },
+            ],
+            preActions: (
+              <Button onClick={handleAddSite}>
+                <PlusIcon className='mr-1 size-4' />
+                {t('sites.toolbar.addSite')}
+              </Button>
+            ),
+          }}
+          bulkActions={
+            <DataTableBulkActions
+              table={table}
+              entityName={t('sites.entityName')}
+            >
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => handleBulkAction('enable')}
+                disabled={batchUpdateSites.isPending}
+              >
+                {t('sites.bulk.enable')}
+              </Button>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => handleBulkAction('disable')}
+                disabled={batchUpdateSites.isPending}
+              >
+                {t('sites.bulk.disable')}
+              </Button>
+              <Button
+                variant='destructive'
+                size='sm'
+                onClick={() => handleBulkAction('delete')}
+                disabled={batchUpdateSites.isPending}
+              >
+                <Trash2Icon className='mr-1 size-3.5' />
+                {t('sites.bulk.delete')}
+              </Button>
+            </DataTableBulkActions>
+          }
+        />
       )}
-      <DataTablePage
-        table={table}
-        columns={columns}
-        isLoading={sitesQuery.isLoading}
-        isFetching={sitesQuery.isFetching}
-        emptyTitle={t('sites.empty.title')}
-        emptyDescription={t('sites.empty.description')}
-        emptyAction={
-          <>
-            <Button onClick={() => setImportOpen(true)}>
-              <UploadIcon className='mr-1 size-4' />
-              {t('sites.empty.import')}
-            </Button>
-            <Button variant='outline' onClick={handleAddSite}>
-              <PlusIcon className='mr-1 size-4' />
-              {t('sites.empty.addSite')}
-            </Button>
-          </>
-        }
-        skeletonKeyPrefix='site-skeleton'
-        toolbarProps={{
-          searchPlaceholder: t('sites.toolbar.searchPlaceholder'),
-          searchDebounceMs: 400,
-          filters: [
-            {
-              columnId: 'status',
-              title: t('sites.columns.status'),
-              options: statusFilters,
-              singleSelect: true,
-            },
-          ],
-          preActions: (
-            <Button onClick={handleAddSite}>
-              <PlusIcon className='mr-1 size-4' />
-              {t('sites.toolbar.addSite')}
-            </Button>
-          ),
-        }}
-        bulkActions={
-          <DataTableBulkActions
-            table={table}
-            entityName={t('sites.entityName')}
-          >
-            <Button
-              variant='outline'
-              size='sm'
-              onClick={() => handleBulkAction('enable')}
-              disabled={batchUpdateSites.isPending}
-            >
-              {t('sites.bulk.enable')}
-            </Button>
-            <Button
-              variant='outline'
-              size='sm'
-              onClick={() => handleBulkAction('disable')}
-              disabled={batchUpdateSites.isPending}
-            >
-              {t('sites.bulk.disable')}
-            </Button>
-            <Button
-              variant='destructive'
-              size='sm'
-              onClick={() => handleBulkAction('delete')}
-              disabled={batchUpdateSites.isPending}
-            >
-              <Trash2Icon className='mr-1 size-3.5' />
-              {t('sites.bulk.delete')}
-            </Button>
-          </DataTableBulkActions>
-        }
-      />
 
       <SiteFormDialog
         open={formOpen}

--- a/web/src/features/sites/types.ts
+++ b/web/src/features/sites/types.ts
@@ -40,6 +40,7 @@ export type Site = {
   proxyUrl?: string | null
   useSystemProxy?: boolean
   customHeaders?: string | null
+  customHeadersOverrideRequestHeaders?: boolean
   globalWeight?: number
   maxConcurrency?: number
   isPinned?: boolean

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -368,6 +368,7 @@
     "sites": {
       "page": {
         "loadError": "Failed to load sites: {{message}}",
+        "retry": "Retry",
         "title": "Sites",
         "description": "Manage connected sites, their status, and routing weight."
       },
@@ -439,7 +440,7 @@
         "name": "Name",
         "namePlaceholder": "Enter a site name",
         "platform": "Platform",
-        "platformPlaceholder": "Select a platform",
+        "platformPlaceholder": "Enter a platform (e.g. openai)",
         "url": "URL",
         "detect": "Detect",
         "detectRequiresUrl": "Enter a URL to auto-detect the platform.",
@@ -464,6 +465,8 @@
         "utlsForceOff": "Force off",
         "customHeaders": "Custom headers",
         "customHeadersHint": "JSON object of extra request headers.",
+        "customHeadersOverrideRequestHeaders": "Override request headers",
+        "customHeadersOverrideRequestHeadersHint": "When enabled, the site's custom headers override the incoming request's headers.",
         "postRefreshProbeEnabled": "Post-refresh probe",
         "postRefreshProbeEnabledHint": "Send a probe request after each token refresh to verify the account.",
         "postRefreshProbeModel": "Probe model",
@@ -482,9 +485,9 @@
           "invalidUrlOrEmpty": "Please enter a valid URL, or leave it empty.",
           "invalidJson": "Please enter valid JSON.",
           "nameRequired": "Please enter a name.",
-          "nameTooLong": "Name must be at most 100 characters.",
+          "nameTooLong": "Name must be at most 120 characters.",
           "urlRequired": "Please enter a URL.",
-          "platformTooLong": "Platform must be at most 50 characters.",
+          "platformTooLong": "Platform must be at most 64 characters.",
           "globalWeightMin": "Weight must be at least 0.",
           "maxConcurrencyInteger": "Max concurrency must be an integer.",
           "maxConcurrencyMin": "Max concurrency must be at least 0.",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -368,6 +368,7 @@
     "sites": {
       "page": {
         "loadError": "加载站点失败：{{message}}",
+        "retry": "重试",
         "title": "站点",
         "description": "管理已连接的站点、状态与路由权重。"
       },
@@ -439,7 +440,7 @@
         "name": "名称",
         "namePlaceholder": "输入站点名称",
         "platform": "平台",
-        "platformPlaceholder": "选择平台",
+        "platformPlaceholder": "输入平台（如 openai）",
         "url": "地址",
         "detect": "自动检测",
         "detectRequiresUrl": "输入地址后可自动检测平台。",
@@ -464,6 +465,8 @@
         "utlsForceOff": "强制关闭",
         "customHeaders": "自定义请求头",
         "customHeadersHint": "额外请求头的 JSON 对象。",
+        "customHeadersOverrideRequestHeaders": "覆盖请求头",
+        "customHeadersOverrideRequestHeadersHint": "启用后，站点的自定义请求头将覆盖传入请求的请求头。",
         "postRefreshProbeEnabled": "刷新后探测",
         "postRefreshProbeEnabledHint": "每次令牌刷新后发送探测请求以验证账号。",
         "postRefreshProbeModel": "探测模型",
@@ -482,9 +485,9 @@
           "invalidUrlOrEmpty": "请输入有效的地址，或留空。",
           "invalidJson": "请输入有效的 JSON。",
           "nameRequired": "请输入名称。",
-          "nameTooLong": "名称不能超过 100 个字符。",
+          "nameTooLong": "名称不能超过 120 个字符。",
           "urlRequired": "请输入地址。",
-          "platformTooLong": "平台不能超过 50 个字符。",
+          "platformTooLong": "平台不能超过 64 个字符。",
           "globalWeightMin": "权重不能小于 0。",
           "maxConcurrencyInteger": "最大并发必须为整数。",
           "maxConcurrencyMin": "最大并发不能小于 0。",


### PR DESCRIPTION
## Summary
Closes 6 gaps from the sites feature multi-perspective review (sites was previously unreviewed):
- **gap-1 (P1)**: `customHeadersOverrideRequestHeaders` was hardcoded `false` in `siteToFormValues`, so editing a site's name silently downgraded header-merge behavior. Now round-trips the actual value + a visible Switch FormField (with label + hint).
- **gap-2 (P2)**: i18n error-copy limits (100/50) disagreed with the Zod schema (120/64) — aligned in en + zh-CN.
- **gap-8 (P3)**: "Select a platform" placeholder on a free-text input → "Enter a platform (e.g. openai)".
- **gap-10 (P3)**: error state co-rendered the empty-state CTA ("Add site") — now suppresses the table + shows only the error banner + a Retry button (`sitesQuery.refetch()`).
- **gap-12 (P3)**: `SiteCreatedModal` stale untyped `href` navigation → migrated to typed `navigate({ to: '/accounts', search: { siteId, create: true } })`, matching `site-detail-sheet.tsx`.
- **gap-4 (P2)**: added `sites-page.test.tsx` (3 tests: create deep-link, error+retry, no-error table) + `site-form-dialog.test.tsx` (4 tests: Zod error, create payload, edit round-trip of `customHeadersOverrideRequestHeaders`, dirty-close guard).

## Test plan
- [x] `bun run typecheck && bun run lint && bun run format:check && bun run knip && bun run test` (539 tests)
- [x] 暗卷: re-ran sites-page + site-form-dialog tests (8/8 pass)
- [ ] CI (12 checks)