### PR TITLE
docs: capture sites round-3 review + WS reconnect closure

### DIFF
--- a/docs/analysis/ui-ux-audit-2026-08.md
+++ b/docs/analysis/ui-ux-audit-2026-08.md
@@ -134,10 +134,30 @@
 
 - ✅ **#846**：realtime sparkline 按 success-rate 健康分档着色（healthy/degraded/unhealthy/idle → `bg-success`/`bg-warning`/`bg-destructive`/`bg-muted-foreground`，原单色）+ `role="img"`/`aria-label`。Latency 不在 realtime wire 上（后端 `RealtimePoint` 无 latency）→ 未伪造，记为后端 residual。
 - ✅ **#847**：attention 项 `createdAt` 渲染为相对时间（`Intl.RelativeTimeFormat` via `toBcp47`，零新 key，en/zh-CN 自动本地化）+ `<time dateTime>` + absolute `title` tooltip。
-- ⚠️ attention alert 点击 dead-end 到通用落地页（plain `<a href>` + 不支持的 `?accountId=` 参数）（M，触 accounts schema）；realtime 面板 success 下降时无 drill-down 到 per-channel 健康（M，触 channels）；WS 重连 5 次后永久放弃——无 retry 按钮、metrics 归零看起来像「无流量」（M，后端 `handler/shared/realtime.go` + 前端 hook）。
+- ✅ **#850**：WS 重连 5 次永久放弃后，面板渲染「Connection lost — Reconnect」notice（dashed destructive border + TriangleAlert + outline button）替代归零 metrics（原看起来像「无流量」）；`useRealtimeOps` 重构为 `{ sample, reconnect }`，`reconnect` 是稳定 `useCallback`（reset `failsRef`/`backoffRef`/socket + 经 `connectRef` 重入 `connect`）；`min-h-[8rem]` 防面板塌缩。
+- ⚠️ attention alert 点击 dead-end 到通用落地页（plain `<a href>` + 不支持的 `?accountId=` 参数）（M，触 accounts schema）；realtime 面板 success 下降时无 drill-down 到 per-channel 健康（M，触 channels）。
 
 **已收口（续，#838 + #840 + #842 + #846 + #847）**
 
 - **Dashboard onboarding banner**（User #1，#838）：`siteCount===0` 时显示 brand-tinted `<Card>` + 「Create site」CTA → `/sites`；`=== 0` 排除 loading 防误闪。
 - **Sites `?create=1` auto-open**（#838 follow-up，#842）：`sitesSearchSchema` 加 `create`，sites-page 一次性消费 + strip（镜像 accounts `?create`），overview CTA 改 `<Link to='/sites' search={{ create: true }}>` 直达 create dialog。
 - 详见上方 model-tester / availability 各 ✅ 项。
+
+### 三轮复审（sites）—— 2026-08-18 续
+
+一个只读 explore 子代理从 PM / 工程师 / 用户视角复审 sites feature（此前一轮/二轮未深覆盖区）。下列为证据，标 ✅ 已收口（#851），⚠️ 仍开放/暂缓。
+
+**sites** (`web/src/features/sites/`)
+
+- ✅ **gap-1 (P1)**（#851）：`customHeadersOverrideRequestHeaders` 在 `siteToFormValues` 硬编码 `false` → 编辑站点名等不相关字段会静默把 header-merge 从「site-wins」降级为「request-wins」（生产影响）。修复：round-trip 真实值 + 加可见 Switch FormField（label + hint）；`Site` type 加 optional 字段（原仅在 `SiteFormPayload`）。
+- ✅ **gap-2 (P2)**（#851）：i18n 错误文案限额（100/50）与 Zod schema（120/64）不一致 → 用户输 110 字符名看到「最多 100 字符」。修复：en/zh-CN 对齐 120/64。
+- ✅ **gap-4 (P2)**（#851）：sites 页/form dialog 零测试 → 加 `sites-page.test.tsx`（3 例：create 深链、error+retry、no-error table）+ `site-form-dialog.test.tsx`（4 例：Zod 错误、create payload、edit round-trip `customHeadersOverrideRequestHeaders`、dirty-close guard）。
+- ✅ **gap-8 (P3)**（#851）：`platform` 是 free-text Input 但 placeholder 写「Select a platform」→ 改「Enter a platform (e.g. openai)」。
+- ✅ **gap-10 (P3)**（#851）：error 态同时渲染空态 CTA「Add site」（误导——加站点不修 load error）→ error 态只显 error banner + Retry 按钮（`sitesQuery.refetch()`），抑制 `<DataTablePage>`。
+- ✅ **gap-12 (P3)**（#851）：`SiteCreatedModal` 用 stale untyped `href` 导航（注释自承 workaround）→ 迁移到 typed `navigate({ to: '/accounts', search: { siteId, create: true } })`，匹配 `site-detail-sheet.tsx`。
+- ⚠️ **gap-3 (P2)**：无 `apiEndpoints` 增删/启用/排序 UI（form preserve-only，detail sheet read-only）。后端 `SiteAPIEndpointInput` 已支持完整数组。当前行为诚实（edit 保留既有、create 空），未做 UI 属 feature gap 暂缓（按真实需求再立项，或 document 为 residual）。
+- ⚠️ **gap-5 (P2)**：form `Select`/`Textarea` 未经 `id`/`htmlFor` 与 `FormLabel` 程序化关联（a11y）——跨 feature 模式问题（accounts form 同样），需在 `Form` primitive 层修，暂缓避免与并行进程 accounts 范围冲突。
+- ⚠️ **gap-9 (P3)**：后端 `probe-now`/`available-models`/`disabled-models` endpoint 未在 sites UI 呈现（`lib/api/sites.ts` 已封装未用）。需与 `features/models`/`model-tester` 协调 ownership，暂缓。
+- ⚠️ **gap-6 (P3)**：无 `?edit=<id>` 深链（打开 edit dialog 纯本地 state）——低优先级，除非运营者分享 edit 链接。
+- ⚠️ **gap-7 (P3)**：load error 无 Retry 按钮（#851 已为 sites 加，但 accounts/channels 同模式未统一——可抽 `<QueryErrorBanner>` shared 组件）。
+- ⚠️ **gap-11 (P3)**：`postRefreshProbeLatencyThresholdMs` 不可编辑（round-trips 但无 FormField）——probe 配置表面不完整，低优先级。

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,15 @@
 > Product milestone timeline (grouped by version). Not the current-state source of truth.
 > Current state → [`STATE.md`](STATE.md) · open items → [`progress/MASTER.md`](progress/MASTER.md) · detailed version narrative → root [`CHANGELOG.md`](../CHANGELOG.md)
 
+## 2026-08-18 — 三轮复审驱动：availability WS 重连 + sites 表单数据丢失修复
+
+三轮 PM/工程师/用户复审（sites feature，此前未深覆盖；发现写入审计 doc `### 三轮复审（sites）`）+ availability Gap 3 收口后交付：
+
+- **Realtime WS 重连 affordance**（#850）：`useRealtimeOps` 重构为 `{ sample, reconnect }`（稳定 `useCallback`，经 `connectRef` 重入 `connect`，reset `failsRef`/`backoffRef`/socket）；`gaveUp` 态渲染「Connection lost — Reconnect」notice 替代归零 metrics（原看起来像「无流量」的 incident-handling gap）；`min-h-[8rem]` 防塌缩 + 3 测试。
+- **Sites 表单静默数据丢失修复**（gap-1 P1，#851）：`customHeadersOverrideRequestHeaders` 在 `siteToFormValues` 硬编码 `false` → 编辑站点名等不相关字段会静默把 header-merge 从「site-wins」降级为「request-wins」。修复：round-trip 真实值 + 加可见 Switch FormField（label + hint）；`Site` type 加 optional 字段。
+- **Sites 批量打磨**（#851）：i18n 限额文案对齐 Zod（120/64）；error 态抑制空态 CTA + 加 Retry 按钮；`platform` placeholder 改「Enter a platform」；`SiteCreatedModal` 迁移 typed navigate；加 `sites-page` + `site-form-dialog` 测试（7 例）。
+- 三轮 sites 复审共 12 gap：6 已收口（#851），6 暂缓（endpoints editor feature gap / a11y label linkage 跨 feature / probe-now surfacing 跨 models / edit 深链 + retry shared 组件 + latency threshold 字段，均低优先级或需协调）。
+
 ## 2026-08-18 — 二轮复审驱动：onboarding 闭环 + model-tester 结果清晰度 + availability 健康可视化
 
 二轮 PM/工程师/用户复审（model-tester / oauth / availability，发现写入审计 doc `### 二轮复审`）后交付：


### PR DESCRIPTION
## Summary
- Audit doc `### 三轮复审（sites）`: 12 gaps from the sites feature multi-perspective review (6 ✅ #851, 6 ⚠️ deferred with reasons).
- Audit doc availability: WS reconnect Gap 3 marked ✅ #850.
- log.md: new milestone entry for #850 (WS reconnect) + #851 (sites batch).

Docs-only — no code changes.