### PR TITLE
fix(sites): render postRefreshProbeLatencyThresholdMs field in form

### DIFF
--- a/web/src/features/sites/components/__tests__/site-form-dialog.test.tsx
+++ b/web/src/features/sites/components/__tests__/site-form-dialog.test.tsx
@@ -147,6 +147,62 @@ describe('SiteFormDialog create payload', () => {
   })
 })
 
+describe('SiteFormDialog post-refresh probe latency threshold (gap-11)', () => {
+  it('renders the latency threshold field when probe is enabled and round-trips the value into the payload', async () => {
+    // A successful create resolves with a minimal site object; only the
+    // payload contract is asserted, not the created echo.
+    mockCreateMutate.mockResolvedValue({
+      id: 99,
+      name: 'Probe site',
+      url: 'https://probe.example',
+      platform: '',
+      status: 'active',
+    })
+
+    render(<SiteFormDialog open onOpenChange={vi.fn()} editingSite={null} />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Name')).toBeInTheDocument()
+    })
+
+    // Fill the required fields so a valid submit can fire.
+    typeField('Name', 'Probe site')
+    typeField('URL', 'https://probe.example')
+
+    // The latency threshold field must NOT render while the probe is off.
+    expect(
+      screen.queryByLabelText('Probe latency threshold (ms)')
+    ).not.toBeInTheDocument()
+
+    // Toggle the post-refresh probe switch on; the conditional block
+    // (model + scope + latency threshold) must now render.
+    fireEvent.click(screen.getByRole('switch', { name: 'Post-refresh probe' }))
+
+    const latencyField = await screen.findByLabelText(
+      'Probe latency threshold (ms)'
+    )
+    expect(latencyField).toBeInTheDocument()
+
+    // Enter a threshold; the numeric onChange (valueAsNumber) must
+    // round-trip the entered value into the submit payload.
+    fireEvent.change(latencyField, { target: { value: '1500' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => {
+      expect(mockCreateMutate).toHaveBeenCalledTimes(1)
+    })
+
+    const payload = mockCreateMutate.mock.calls[0]?.[0]
+    expect(payload).toMatchObject({
+      name: 'Probe site',
+      url: 'https://probe.example',
+      postRefreshProbeEnabled: true,
+      postRefreshProbeLatencyThresholdMs: 1500,
+    })
+  })
+})
+
 describe('SiteFormDialog edit round-trip (gap-1)', () => {
   it('checks the override-headers switch when editing a site with it enabled', async () => {
     const editingSite: Site = {

--- a/web/src/features/sites/components/site-form-dialog.tsx
+++ b/web/src/features/sites/components/site-form-dialog.tsx
@@ -584,7 +584,7 @@ export function SiteFormDialog({
                 )}
               />
               {probeEnabled && (
-                <div className='mt-3 grid gap-4 sm:grid-cols-3'>
+                <div className='mt-3 grid gap-4 sm:grid-cols-2'>
                   <FormField
                     control={form.control}
                     name='postRefreshProbeModel'
@@ -639,6 +639,43 @@ export function SiteFormDialog({
                             </SelectItem>
                           </SelectContent>
                         </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name='postRefreshProbeLatencyThresholdMs'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>
+                          {t(
+                            'sites.form.postRefreshProbeLatencyThresholdMsLabel'
+                          )}
+                        </FormLabel>
+                        <FormControl>
+                          <Input
+                            type='number'
+                            min={0}
+                            step={100}
+                            value={field.value}
+                            onChange={(event) =>
+                              field.onChange(
+                                Number.isNaN(event.target.valueAsNumber)
+                                  ? 0
+                                  : event.target.valueAsNumber
+                              )
+                            }
+                            onBlur={field.onBlur}
+                            name={field.name}
+                            ref={field.ref}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t(
+                            'sites.form.postRefreshProbeLatencyThresholdMsHint'
+                          )}
+                        </FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -475,6 +475,8 @@
         "scopePlaceholder": "Select a scope",
         "scopeAll": "All accounts",
         "scopeSingle": "Single account",
+        "postRefreshProbeLatencyThresholdMsLabel": "Probe latency threshold (ms)",
+        "postRefreshProbeLatencyThresholdMsHint": "Only probe if the last response latency exceeds this threshold. 0 = always probe.",
         "cancel": "Cancel",
         "save": "Save",
         "create": "Create",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -475,6 +475,8 @@
         "scopePlaceholder": "选择范围",
         "scopeAll": "全部账号",
         "scopeSingle": "单个账号",
+        "postRefreshProbeLatencyThresholdMsLabel": "探测延迟阈值（毫秒）",
+        "postRefreshProbeLatencyThresholdMsHint": "仅当上次响应延迟超过此阈值时探测。0 = 始终探测。",
         "cancel": "取消",
         "save": "保存",
         "create": "创建",


### PR DESCRIPTION
## Summary
- Closes sites gap-11: `postRefreshProbeLatencyThresholdMs` round-tripped on edit but had no FormField, so the operator couldn't set the probe latency threshold via UI (always 0 on create).
- Added a number `FormField` inside the `probeEnabled` conditional block (2-col grid: model full-width, scope + latency side-by-side), mirroring the existing `valueAsNumber` + NaN→0 numeric binding.
- Completes the probe config surface (model + scope + threshold now all visible/editable when probe is enabled).

## Test plan
- [x] `bun run typecheck && bun run lint && bun run format:check && bun run test` (543 tests)
- [x] 暗卷: site-form-dialog 5/5 pass (field renders when probe toggled on + round-trips 1500 into payload)
- [ ] CI (12 checks)