### PR TITLE
fix(admin): populate siteNames in routes listSummary (P1 dead column)

### DIFF
--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -145,10 +145,40 @@ func (h *tokenRoutesHandler) listSummary(w http.ResponseWriter, r *http.Request)
 		countsByRoute[c.RouteID] = c
 	}
 
+	// Batch-load distinct site names per route via a single GROUP BY query
+	// (route_channels → accounts → sites). A route with no channels has no
+	// row in route_channels and falls through to a non-nil empty slice —
+	// matching the frontend's `route.siteNames ?? []` render. GROUP BY on
+	// (route_id, site_name) collapses multiple channels that share a site
+	// so each site name appears at most once per route. No bind params means
+	// the dual-dialect rebind gate is a no-op here (same as the counts query).
+	type routeSiteName struct {
+		RouteID  int64  `db:"route_id"`
+		SiteName string `db:"site_name"`
+	}
+	var siteNameRows []routeSiteName
+	if err := h.db.Select(&siteNameRows, `
+		SELECT rc.route_id AS route_id, s.name AS site_name
+		FROM route_channels rc
+		JOIN accounts a ON rc.account_id = a.id
+		JOIN sites s ON a.site_id = s.id
+		WHERE s.name IS NOT NULL AND s.name <> ''
+		GROUP BY rc.route_id, s.name`); err != nil {
+		slog.Warn("listSummary: batch site names failed", "err", err)
+	}
+	siteNamesByRoute := make(map[int64][]string)
+	for _, sn := range siteNameRows {
+		siteNamesByRoute[sn.RouteID] = append(siteNamesByRoute[sn.RouteID], sn.SiteName)
+	}
+
 	result := make([]map[string]any, 0)
 	for _, route := range rows {
 		routeID := coerceInt64(route["id"])
 		c := countsByRoute[routeID]
+		siteNames := siteNamesByRoute[routeID]
+		if siteNames == nil {
+			siteNames = []string{}
+		}
 
 		item := map[string]any{
 			"id":                  route["id"],
@@ -163,7 +193,7 @@ func (h *tokenRoutesHandler) listSummary(w http.ResponseWriter, r *http.Request)
 			"enabled":             route["enabled"],
 			"channelCount":        c.Total,
 			"enabledChannelCount": c.EnabledCount,
-			"siteNames":           []string{},
+			"siteNames":           siteNames,
 			"decisionSnapshot":    nil,
 			"decisionRefreshedAt": route["decisionRefreshedAt"],
 		}

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -1674,3 +1674,89 @@ func TestTokenRoutes_SummaryBatchedCounts(t *testing.T) {
 		}
 	}
 }
+
+// TestTokenRoutes_Summary_PopulatesSiteNames verifies that GET
+// /api/routes/summary returns the distinct site names per route
+// (route_channels → accounts → sites) instead of the previous hardcoded
+// empty array. Covers the linked route (non-empty, deduped when multiple
+// channels share a site) and the empty route (no channels → non-nil empty
+// array, not JSON null) so the frontend's `route.siteNames ?? []` render
+// and the `routesGlobalFilterFn` site-name search both work.
+func TestTokenRoutes_Summary_PopulatesSiteNames(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// seedRouteChannelRefs creates a site named "Route Site" + account +
+	// token + one 'gpt-*' route.
+	linkedRouteID, accountID, tokenID := seedRouteChannelRefs(t, db)
+
+	// A second route with no channels — its siteNames must be a non-nil
+	// empty array. Inserted via SQL to bypass the createRoute handler's
+	// auto-populate side effect (deterministic, no model-availability seed).
+	res, err := db.Exec(
+		`INSERT INTO token_routes (model_pattern, enabled, created_at, updated_at)
+		 VALUES ('no-channel-*', 1, ?, ?)`, now, now)
+	if err != nil {
+		t.Fatalf("insert empty route: %v", err)
+	}
+	emptyRouteID, _ := res.LastInsertId()
+
+	// Attach three channels to the linked route, all pointing at the same
+	// account/site under different source models. All three resolve to the
+	// single site "Route Site", so siteNames must be deduped to one entry.
+	for _, sourceModel := range []string{"gpt-4o", "gpt-4o-mini", "gpt-4.1"} {
+		if _, err := db.Exec(
+			`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+			 VALUES (?, ?, ?, ?, 0, 10, 1, 0)`,
+			linkedRouteID, accountID, tokenID, sourceModel); err != nil {
+			t.Fatalf("insert linked route channel %s: %v", sourceModel, err)
+		}
+	}
+
+	resp := doGet(t, r, "/api/routes/summary")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("summary status = %d body=%s", resp.Code, resp.Body.String())
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &items); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	itemByID := make(map[int64]map[string]any, len(items))
+	for _, item := range items {
+		itemByID[int64(item["id"].(float64))] = item
+	}
+
+	// Linked route: three channels, same site → one deduped name.
+	linked, ok := itemByID[linkedRouteID]
+	if !ok {
+		t.Fatalf("linked route %d missing from summary", linkedRouteID)
+	}
+	siteNames, ok := linked["siteNames"].([]any)
+	if !ok {
+		t.Fatalf("linked route siteNames = %T (%v), want []any; body=%s",
+			linked["siteNames"], linked["siteNames"], resp.Body.String())
+	}
+	if len(siteNames) != 1 {
+		t.Fatalf("linked route siteNames len = %d, want 1 (deduped from 3 channels); got %v",
+			len(siteNames), siteNames)
+	}
+	if name, _ := siteNames[0].(string); name != "Route Site" {
+		t.Fatalf("linked route siteNames[0] = %q, want %q", name, "Route Site")
+	}
+
+	// Empty route: no channels → non-nil empty array (not JSON null), so the
+	// frontend renders "—" via `siteNames.length === 0` rather than crashing
+	// on a null dereference.
+	empty, ok := itemByID[emptyRouteID]
+	if !ok {
+		t.Fatalf("empty route %d missing from summary", emptyRouteID)
+	}
+	emptyNames, ok := empty["siteNames"].([]any)
+	if !ok {
+		t.Fatalf("empty route siteNames = %T (%v), want non-nil empty array; body=%s",
+			empty["siteNames"], empty["siteNames"], resp.Body.String())
+	}
+	if len(emptyNames) != 0 {
+		t.Fatalf("empty route siteNames len = %d, want 0; got %v", len(emptyNames), emptyNames)
+	}
+}


### PR DESCRIPTION
## Summary
- Closes token-routes gap-1 (P1): the "Sites" column + detail field always rendered `—` because `listSummary` hardcoded `siteNames: []string{}` and never joined sites. The global filter (`routesGlobalFilterFn` searches `siteNames`) also couldn't match by site name.
- `listSummary` now populates `siteNames` via a focused batch `GROUP BY (route_id, site_name)` query joining `route_channels` → `accounts` → `sites`, deduped per route. Nil coalesced to `[]string{}` for channel-less routes (non-nil empty array, not JSON null).
- Mirrors the existing `routeChannelCounts` batch pattern in `listSummary` (not the heavier `enrichRoutesWithChannels` from `listLite` — wrong tradeoff for a lightweight summary).
- Dual-dialect safe (no `?` placeholders, standard JOIN/GROUP BY).

## Test plan
- [x] `go build ./cmd/server && go vet ./... && go test ./... -count=1 -race`
- [x] `TestTokenRoutes_Summary_PopulatesSiteNames`: linked route (3 channels same site → deduped to 1) + empty route (non-nil `[]`)
- [x] 暗卷: re-ran the targeted test (pass)
- [ ] CI (12 checks)