### PR TITLE
fix(ui): close residual UIUX audit gaps — OAuth poll, chain names, shared error banner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,11 @@ web/dist/
 # Binaries
 /bin/
 /dist/
+/metapi
 /metapi-go
+/metapi.exe
 /metapi-go.exe
+/server
 *.exe
 
 # Certificates & private keys (never commit)

--- a/web/src/components/common/query-error-banner.tsx
+++ b/web/src/components/common/query-error-banner.tsx
@@ -1,0 +1,73 @@
+// Shared load-error banner with an optional Retry button. Replaces the
+// per-page `{error && <div className='border-destructive/40 …'>}` pattern
+// (banner-only) and the sites/routes Pattern A (banner + retry button).
+// Pass `onRetry` to render the Retry button; omit it for a banner-only
+// inline warning above the table.
+
+import { TriangleAlert } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
+
+type QueryErrorBannerProps = {
+  /** The error object; renders nothing when null. */
+  error: Error | null
+  /** i18n key whose template interpolates `{{message}}` (e.g. `accounts.page.loadError`). */
+  messageKey: string
+  /** i18n key for the Retry button label; defaults to `common.retry`. */
+  retryKey?: string
+  /** When provided, a Retry button renders and re-fetches the query. */
+  onRetry?: () => void
+  /** True while the retry request is in flight (disables the button + shows a spinner). */
+  isRetrying?: boolean
+  /** Extra children rendered after the banner (e.g. a secondary action). */
+  children?: ReactNode
+  className?: string
+}
+
+export function QueryErrorBanner({
+  error,
+  messageKey,
+  retryKey = 'common.retry',
+  onRetry,
+  isRetrying = false,
+  children,
+  className,
+}: QueryErrorBannerProps) {
+  const { t } = useTranslation()
+  if (!error) return null
+
+  return (
+    <div className={`flex flex-col gap-3 ${className ?? ''}`}>
+      <div
+        role='alert'
+        className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg flex items-start gap-2 rounded-lg border p-3 text-sm'
+      >
+        <TriangleAlert className='mt-0.5 size-4 shrink-0' />
+        <span>{t(messageKey, { message: error.message })}</span>
+      </div>
+      {(onRetry || children) && (
+        <div className='flex items-center gap-2'>
+          {onRetry && (
+            <Button
+              variant='secondary'
+              size='sm'
+              onClick={onRetry}
+              disabled={isRetrying}
+            >
+              {isRetrying ? (
+                <Spinner className='mr-1' />
+              ) : (
+                <TriangleAlert className='mr-1 size-3.5' />
+              )}
+              {t(retryKey)}
+            </Button>
+          )}
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -27,6 +27,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import {
   DataTableBulkActions,
   DataTablePage,
@@ -197,7 +198,7 @@ export function AccountsPage() {
   const search = useSearch({ from: '/_authenticated/accounts' })
   const navigate = useNavigate()
   const urlState = useAccountsUrlState()
-  const { data, isLoading, isFetching, error } = useAccounts()
+  const { data, isLoading, isFetching, error, refetch } = useAccounts()
   const accounts = data?.accounts ?? []
   const sites = data?.sites ?? []
 
@@ -392,11 +393,12 @@ export function AccountsPage() {
         </Button>
       </div>
 
-      {error && (
-        <div className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg rounded-lg border p-3 text-sm'>
-          {t('accounts.page.loadError', { message: (error as Error).message })}
-        </div>
-      )}
+      <QueryErrorBanner
+        error={error as Error | null}
+        messageKey='accounts.page.loadError'
+        onRetry={() => refetch()}
+        isRetrying={isFetching}
+      />
 
       <DataTablePage
         table={table}

--- a/web/src/features/channels/__tests__/channel-detail-sheet.test.tsx
+++ b/web/src/features/channels/__tests__/channel-detail-sheet.test.tsx
@@ -191,8 +191,6 @@ describe('ChannelDetailSheet edit-route action', () => {
   it('disables the edit-route button when the channel has no routeId', () => {
     renderSheet(makeChannel({ routeId: 0 }))
 
-    expect(
-      screen.getByRole('button', { name: 'Edit route' })
-    ).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Edit route' })).toBeDisabled()
   })
 })

--- a/web/src/features/channels/__tests__/channel-detail-sheet.test.tsx
+++ b/web/src/features/channels/__tests__/channel-detail-sheet.test.tsx
@@ -55,7 +55,10 @@ function makeChannel(overrides: Partial<ChannelRow>): ChannelRow {
   } as ChannelRow
 }
 
-function renderSheet(channel: ChannelRow | null) {
+function renderSheet(
+  channel: ChannelRow | null,
+  onEdit?: (channel: ChannelRow) => void
+) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
@@ -65,7 +68,12 @@ function renderSheet(channel: ChannelRow | null) {
     )
   }
   return render(
-    <ChannelDetailSheet channel={channel} open onOpenChange={() => {}} />,
+    <ChannelDetailSheet
+      channel={channel}
+      open
+      onOpenChange={() => {}}
+      onEdit={onEdit}
+    />,
     { wrapper: Wrapper }
   )
 }
@@ -144,6 +152,47 @@ describe('ChannelDetailSheet cooldown action', () => {
 
     expect(
       screen.getByRole('button', { name: 'Clear route cooldown' })
+    ).toBeDisabled()
+  })
+})
+
+describe('ChannelDetailSheet edit-route action', () => {
+  it('renders the edit-route button in the footer for a healthy channel', () => {
+    renderSheet(makeChannel({ status: 'enabled' }))
+
+    expect(
+      screen.getByRole('button', { name: 'Edit route' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the edit-route button alongside the cooldown action', () => {
+    renderSheet(makeChannel({ status: 'cooldown' }))
+
+    expect(
+      screen.getByRole('button', { name: 'Edit route' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Clear route cooldown' })
+    ).toBeInTheDocument()
+  })
+
+  it('calls onEdit with the channel when the edit-route button is clicked', () => {
+    const onEdit = vi.fn()
+    renderSheet(makeChannel({ routeId: 42 }), onEdit)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit route' }))
+
+    expect(onEdit).toHaveBeenCalledTimes(1)
+    expect(onEdit).toHaveBeenCalledWith(
+      expect.objectContaining({ routeId: 42 })
+    )
+  })
+
+  it('disables the edit-route button when the channel has no routeId', () => {
+    renderSheet(makeChannel({ routeId: 0 }))
+
+    expect(
+      screen.getByRole('button', { name: 'Edit route' })
     ).toBeDisabled()
   })
 })

--- a/web/src/features/channels/components/channel-detail-sheet.tsx
+++ b/web/src/features/channels/components/channel-detail-sheet.tsx
@@ -13,6 +13,7 @@ import {
   CheckCircle2,
   Clock,
   Loader2,
+  Pencil,
   Snowflake,
   TriangleAlert,
 } from 'lucide-react'
@@ -40,6 +41,7 @@ type ChannelDetailSheetProps = {
   channel: ChannelRow | null
   open: boolean
   onOpenChange: (open: boolean) => void
+  onEdit?: (channel: ChannelRow) => void
 }
 
 const STATUS_CONFIG: Record<
@@ -107,6 +109,7 @@ export function ChannelDetailSheet({
   channel,
   open,
   onOpenChange,
+  onEdit,
 }: ChannelDetailSheetProps) {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
@@ -242,26 +245,39 @@ export function ChannelDetailSheet({
           </div>
         </ScrollArea>
 
-        {showCooldownAction ? (
-          <SheetFooter>
-            <p className='text-muted-foreground mr-auto max-w-[220px] text-xs'>
-              {t('channels.detail.clearRouteCooldownHint')}
-            </p>
-            <Button
-              type='button'
-              variant='outline'
-              onClick={handleClearRouteCooldown}
-              disabled={clearCooldownMutation.isPending}
-            >
-              {clearCooldownMutation.isPending ? (
-                <Loader2 className='animate-spin' />
-              ) : (
-                <Snowflake />
-              )}
-              {t('channels.detail.clearRouteCooldown')}
-            </Button>
-          </SheetFooter>
-        ) : null}
+        <SheetFooter className='sm:flex-row sm:items-center'>
+          <Button
+            type='button'
+            variant='outline'
+            className='sm:mr-auto'
+            onClick={() => onEdit?.(channel)}
+            disabled={!channel || !channel.routeId}
+            title={t('channels.detail.editRouteHint')}
+          >
+            <Pencil />
+            {t('channels.detail.editRoute')}
+          </Button>
+          {showCooldownAction ? (
+            <>
+              <p className='text-muted-foreground max-w-[220px] text-xs'>
+                {t('channels.detail.clearRouteCooldownHint')}
+              </p>
+              <Button
+                type='button'
+                variant='outline'
+                onClick={handleClearRouteCooldown}
+                disabled={clearCooldownMutation.isPending}
+              >
+                {clearCooldownMutation.isPending ? (
+                  <Loader2 className='animate-spin' />
+                ) : (
+                  <Snowflake />
+                )}
+                {t('channels.detail.clearRouteCooldown')}
+              </Button>
+            </>
+          ) : null}
+        </SheetFooter>
       </SheetContent>
     </Sheet>
   )

--- a/web/src/features/channels/components/channels-page.tsx
+++ b/web/src/features/channels/components/channels-page.tsx
@@ -11,6 +11,7 @@ import { Users } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import {
   DataTablePage,
   encodeSorting,
@@ -152,13 +153,12 @@ export function ChannelsPage() {
         </p>
       </div>
 
-      {channelsQuery.error && (
-        <div className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg rounded-lg border p-3 text-sm'>
-          {t('channels.page.loadError', {
-            message: (channelsQuery.error as Error).message,
-          })}
-        </div>
-      )}
+      <QueryErrorBanner
+        error={channelsQuery.error as Error | null}
+        messageKey='channels.page.loadError'
+        onRetry={() => channelsQuery.refetch()}
+        isRetrying={channelsQuery.isFetching}
+      />
 
       <DataTablePage
         table={table}
@@ -187,6 +187,13 @@ export function ChannelsPage() {
         channel={detailChannel}
         open={detailOpen}
         onOpenChange={setDetailOpen}
+        onEdit={(channel) => {
+          setDetailOpen(false)
+          void navigate({
+            to: '/token-routes',
+            search: { routeId: channel.routeId },
+          })
+        }}
       />
     </div>
   )

--- a/web/src/features/checkin/components/checkin-page.tsx
+++ b/web/src/features/checkin/components/checkin-page.tsx
@@ -18,6 +18,7 @@ import { CalendarRange, Loader2, RotateCw, Zap } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import {
   DataTablePage,
   type UrlTableState,
@@ -262,6 +263,7 @@ export function CheckinPage() {
     isLoading,
     isFetching,
     error,
+    refetch,
   } = useCheckinLogs(queryPayload)
   const logs = useMemo(() => logsPage?.items ?? [], [logsPage])
   const total = logsPage?.total ?? 0
@@ -400,11 +402,12 @@ export function CheckinPage() {
         </div>
       </div>
 
-      {error && (
-        <div className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg rounded-lg border p-3 text-sm'>
-          {t('checkin.page.loadError', { message: (error as Error).message })}
-        </div>
-      )}
+      <QueryErrorBanner
+        error={error as Error | null}
+        messageKey='checkin.page.loadError'
+        onRetry={() => refetch()}
+        isRetrying={isFetching}
+      />
 
       <div className='flex flex-wrap items-center gap-2'>
         <CalendarRange className='text-muted-foreground size-4' />

--- a/web/src/features/models/components/models-page.tsx
+++ b/web/src/features/models/components/models-page.tsx
@@ -16,6 +16,7 @@ import { RefreshCw as RefreshCwIcon } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import {
   DataTablePage,
   encodeSorting,
@@ -224,13 +225,12 @@ export function ModelsPage() {
         </p>
       </div>
 
-      {modelsQuery.error && (
-        <div className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg rounded-lg border p-3 text-sm'>
-          {t('models.page.loadError', {
-            message: (modelsQuery.error as Error).message,
-          })}
-        </div>
-      )}
+      <QueryErrorBanner
+        error={modelsQuery.error as Error | null}
+        messageKey='models.page.loadError'
+        onRetry={() => modelsQuery.refetch()}
+        isRetrying={modelsQuery.isFetching}
+      />
       <DataTablePage
         table={table}
         columns={columns}

--- a/web/src/features/models/fix-candidates/components/fix-candidates-page.tsx
+++ b/web/src/features/models/fix-candidates/components/fix-candidates-page.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ConfirmDialog } from '@/components/common/confirm-dialog'
+import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
 import {
@@ -56,13 +57,12 @@ export function FixCandidatesPage() {
         </div>
       )}
 
-      {list.error && (
-        <div className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg rounded-lg border p-3 text-sm'>
-          {t('fixCandidates.page.loadError', {
-            message: (list.error as Error).message,
-          })}
-        </div>
-      )}
+      <QueryErrorBanner
+        error={list.error as Error | null}
+        messageKey='fixCandidates.page.loadError'
+        onRetry={() => list.refetch()}
+        isRetrying={list.isFetching}
+      />
 
       {!list.isLoading && !list.error && count === 0 && (
         <div className='text-muted-foreground rounded-lg border border-dashed p-8 text-center text-sm'>

--- a/web/src/features/models/price-compare/components/price-compare-page.tsx
+++ b/web/src/features/models/price-compare/components/price-compare-page.tsx
@@ -7,6 +7,7 @@ import { ArrowRight, Search, Star } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -110,13 +111,12 @@ export function PriceComparePage() {
         </div>
       )}
 
-      {query.error && (
-        <div className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg rounded-lg border p-3 text-sm'>
-          {t('priceCompare.page.loadError', {
-            message: (query.error as Error).message,
-          })}
-        </div>
-      )}
+      <QueryErrorBanner
+        error={query.error as Error | null}
+        messageKey='priceCompare.page.loadError'
+        onRetry={() => query.refetch()}
+        isRetrying={query.isFetching}
+      />
 
       {!query.isLoading && !query.error && groups.length === 0 && (
         <div className='text-muted-foreground rounded-lg border border-dashed p-8 text-center text-sm'>

--- a/web/src/features/oauth/api.ts
+++ b/web/src/features/oauth/api.ts
@@ -18,7 +18,7 @@ import {
   type UseQueryOptions,
 } from '@tanstack/react-query'
 
-import { api } from '@/lib/api'
+import { api, type OAuthSessionInfo } from '@/lib/api'
 
 import {
   oauthKeys,
@@ -169,6 +169,61 @@ export function useRebindOAuthConnection(
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: oauthKeys.connections() })
+    },
+    ...options,
+  })
+}
+
+/**
+ * Poll a pending OAuth session by `state` until the backend reports success
+ * or error. Refetches every 2s while `status === 'pending'` and stops once
+ * the session settles. Pass `null` to disable (e.g. before the start-authorization
+ * mutation has returned a `state`).
+ */
+export function useOAuthSession(
+  state: string | null,
+  options?: Omit<UseQueryOptions<OAuthSessionInfo>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery<OAuthSessionInfo>({
+    queryKey: oauthKeys.session(state ?? ''),
+    queryFn: async () => {
+      // `enabled: !!state` guarantees `state` is non-null here; the guard
+      // satisfies the type checker without a non-null assertion.
+      if (!state) throw new Error('OAuth session state is required')
+      return api.getOAuthSession(state)
+    },
+    enabled: !!state,
+    refetchInterval: (query) =>
+      query.state.data?.status === 'pending' ? 2000 : false,
+    ...options,
+  })
+}
+
+/**
+ * Submit a manual callback URL for a pending OAuth session. Used when the
+ * provider's redirect cannot reach the local callback port directly (e.g.
+ * behind a firewall); the operator pastes the full redirect URL. Invalidates
+ * the session query so polling resumes immediately, plus the connections
+ * list so a newly created connection shows up.
+ */
+export function useSubmitOAuthManualCallback(
+  options?: UseMutationOptions<
+    { success: true },
+    Error,
+    { state: string; callbackUrl: string }
+  >
+) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ state, callbackUrl }) =>
+      api.submitOAuthManualCallback(state, callbackUrl),
+    onSettled: (_data, _err, vars) => {
+      void queryClient.invalidateQueries({
+        queryKey: oauthKeys.session(vars.state),
+      })
+      void queryClient.invalidateQueries({
+        queryKey: oauthKeys.connections(),
+      })
     },
     ...options,
   })

--- a/web/src/features/oauth/components/__tests__/oauth-start-dialog-session.test.tsx
+++ b/web/src/features/oauth/components/__tests__/oauth-start-dialog-session.test.tsx
@@ -17,12 +17,21 @@ import {
   waitFor,
 } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 import '@/i18n/config'
 
-import { OAuthStartDialog } from '../oauth-start-dialog'
 import type { OAuthStartInstructions } from '../../types'
+import { OAuthStartDialog } from '../oauth-start-dialog'
 
 // ---------------------------------------------------------------------------
 // Shared jsdom stubs (Base UI dropdown positioning needs both)
@@ -231,9 +240,7 @@ describe('OAuthStartDialog pending session', () => {
     })
 
     // Click the "Submit callback" button.
-    fireEvent.click(
-      screen.getByRole('button', { name: /^submit callback$/i })
-    )
+    fireEvent.click(screen.getByRole('button', { name: /^submit callback$/i }))
 
     await waitFor(() =>
       expect(mockState.callbackMutate).toHaveBeenCalledTimes(1)

--- a/web/src/features/oauth/components/__tests__/oauth-start-dialog-session.test.tsx
+++ b/web/src/features/oauth/components/__tests__/oauth-start-dialog-session.test.tsx
@@ -1,0 +1,280 @@
+// Behavior tests for the OAuth start-dialog pending-session flow.
+//
+// After `useStartOAuth` resolves, the dialog must NOT close — it switches to
+// a pending panel that polls `useOAuthSession(state)` and exposes a
+// manual-callback fallback. These tests verify: (1) the panel replaces the
+// form after submit, (2) the manual-callback form calls
+// `api.submitOAuthManualCallback`, and (3) a polled `status === 'success'`
+// fires `onOpenChange(false)`.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { OAuthStartDialog } from '../oauth-start-dialog'
+import type { OAuthStartInstructions } from '../../types'
+
+// ---------------------------------------------------------------------------
+// Shared jsdom stubs (Base UI dropdown positioning needs both)
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    writable: true,
+    value: ResizeObserverStub,
+  })
+
+  // jsdom prints "Not implemented: navigation" when window.open is called.
+  vi.stubGlobal('open', vi.fn())
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+afterAll(() => {
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Mock fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_STATE = 'test-session-state'
+
+const TEST_INSTRUCTIONS: OAuthStartInstructions = {
+  redirectUri: 'http://localhost:8080/callback',
+  callbackPort: 8080,
+  callbackPath: '/callback',
+  manualCallbackDelayMs: 5000,
+  sshTunnelCommand: 'ssh -L 8080:localhost:8080 user@host',
+}
+
+const TEST_START_RESULT = {
+  provider: 'openai',
+  state: TEST_STATE,
+  authorizationUrl: 'https://provider.example.com/auth',
+  instructions: TEST_INSTRUCTIONS,
+}
+
+const mockState = vi.hoisted(() => ({
+  startMutate: vi.fn(),
+  sessionData: null as null | {
+    provider: string
+    state: string
+    status: 'pending' | 'success' | 'error'
+    error?: string
+  },
+  callbackMutate: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: mockState.toastSuccess,
+    error: mockState.toastError,
+  },
+}))
+
+vi.mock('../../api', () => ({
+  useOAuthProviders: () => ({
+    data: [
+      {
+        provider: 'openai',
+        label: 'OpenAI',
+        platform: 'openai',
+        enabled: true,
+        loginType: 'oauth',
+        requiresProjectId: false,
+        supportsDirectAccountRouting: true,
+        supportsCloudValidation: true,
+        supportsNativeProxy: true,
+      },
+    ],
+    isLoading: false,
+    isError: false,
+  }),
+  useStartOAuth: () => ({
+    mutateAsync: mockState.startMutate,
+    isPending: false,
+  }),
+  useOAuthSession: (state: string | null) => ({
+    data: state ? mockState.sessionData : null,
+  }),
+  useSubmitOAuthManualCallback: () => ({
+    mutateAsync: mockState.callbackMutate,
+    isPending: false,
+  }),
+}))
+
+function renderDialog(onOpenChange = vi.fn()) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+  return render(<OAuthStartDialog open onOpenChange={onOpenChange} />, {
+    wrapper: Wrapper,
+  })
+}
+
+/**
+ * Select the first provider in the start-authorization form and click the
+ * Start button. `useStartOAuth` is mocked to resolve immediately with
+ * `TEST_START_RESULT`, which flips the dialog into the pending panel.
+ */
+async function submitStartForm() {
+  // Open the provider <Select> dropdown and pick the first provider.
+  fireEvent.mouseDown(screen.getByRole('combobox'))
+  const option = await screen.findByRole('option', { name: 'OpenAI' })
+  fireEvent.click(option)
+
+  // Click the "Start" submit button (the form's primary action).
+  fireEvent.click(screen.getByRole('button', { name: /^start$/i }))
+
+  await waitFor(() => expect(mockState.startMutate).toHaveBeenCalledTimes(1))
+}
+
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockState.startMutate.mockReset()
+  mockState.callbackMutate.mockReset()
+  mockState.sessionData = {
+    provider: 'openai',
+    state: TEST_STATE,
+    status: 'pending',
+  }
+  // Default: start mutation resolves with the test result.
+  mockState.startMutate.mockResolvedValue(TEST_START_RESULT)
+  mockState.toastSuccess.mockReset()
+  mockState.toastError.mockReset()
+})
+
+// ---------------------------------------------------------------------------
+// 1. After submit, the dialog stays open and shows the pending panel
+// ---------------------------------------------------------------------------
+
+describe('OAuthStartDialog pending session', () => {
+  it('switches to the pending panel instead of closing after submit', async () => {
+    const onOpenChange = vi.fn()
+    renderDialog(onOpenChange)
+
+    await submitStartForm()
+
+    // The dialog did NOT close (onOpenChange(false) was not called by the
+    // start-authorization path — only the session-success path closes).
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+
+    // The pending panel is rendered: the "Waiting for authorization…"
+    // title is visible, and the form's "Start" button is gone.
+    await waitFor(() => {
+      expect(
+        screen.getAllByText('Waiting for authorization…').length
+      ).toBeGreaterThan(0)
+    })
+    expect(
+      screen.queryByRole('button', { name: /^start$/i })
+    ).not.toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // 2. Manual callback submit calls api.submitOAuthManualCallback
+  // -------------------------------------------------------------------------
+
+  it('calls the manual-callback mutation with state + pasted URL', async () => {
+    const onOpenChange = vi.fn()
+    renderDialog(onOpenChange)
+
+    await submitStartForm()
+
+    // Type a callback URL into the manual-callback input.
+    const input = await screen.findByPlaceholderText(
+      'Paste the callback URL from the OAuth redirect'
+    )
+    fireEvent.change(input, {
+      target: { value: 'http://localhost:8080/callback?code=abc&state=test' },
+    })
+
+    // Click the "Submit callback" button.
+    fireEvent.click(
+      screen.getByRole('button', { name: /^submit callback$/i })
+    )
+
+    await waitFor(() =>
+      expect(mockState.callbackMutate).toHaveBeenCalledTimes(1)
+    )
+    expect(mockState.callbackMutate).toHaveBeenCalledWith({
+      state: TEST_STATE,
+      callbackUrl: 'http://localhost:8080/callback?code=abc&state=test',
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // 3. On session status === 'success', the dialog closes
+  // -------------------------------------------------------------------------
+
+  it('closes the dialog when the polled session reports success', async () => {
+    const onOpenChange = vi.fn()
+    const { rerender } = renderDialog(onOpenChange)
+
+    await submitStartForm()
+
+    // Sanity: the pending panel is showing.
+    await waitFor(() => {
+      expect(
+        screen.getAllByText('Waiting for authorization…').length
+      ).toBeGreaterThan(0)
+    })
+
+    // Flip the polled session to success and re-render so the mock
+    // `useOAuthSession` returns the updated status.
+    mockState.sessionData = {
+      provider: 'openai',
+      state: TEST_STATE,
+      status: 'success',
+    }
+    rerender(<OAuthStartDialog open onOpenChange={onOpenChange} />)
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+    expect(mockState.toastSuccess).toHaveBeenCalledWith(
+      'Authorization completed.'
+    )
+  })
+})

--- a/web/src/features/oauth/components/oauth-page.tsx
+++ b/web/src/features/oauth/components/oauth-page.tsx
@@ -12,6 +12,7 @@ import { Plus as PlusIcon } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import {
   DataTablePage,
   encodeSorting,
@@ -279,13 +280,12 @@ export function OAuthPage() {
         </p>
       </div>
 
-      {connectionsQuery.error && (
-        <div className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg rounded-lg border p-3 text-sm'>
-          {t('oauth.page.loadError', {
-            message: (connectionsQuery.error as Error).message,
-          })}
-        </div>
-      )}
+      <QueryErrorBanner
+        error={connectionsQuery.error as Error | null}
+        messageKey='oauth.page.loadError'
+        onRetry={() => connectionsQuery.refetch()}
+        isRetrying={connectionsQuery.isFetching}
+      />
       <DataTablePage
         table={table}
         columns={columns}

--- a/web/src/features/oauth/components/oauth-start-dialog.tsx
+++ b/web/src/features/oauth/components/oauth-start-dialog.tsx
@@ -5,13 +5,21 @@
 // provider's `requiresProjectId` is true — enforced in the submit handler
 // since the schema cannot see the runtime provider list), and optionally
 // configures a proxy. On submit, `useStartOAuth` calls the backend and the
-// returned `authorizationUrl` is opened in a new tab; the dialog closes and
-// a toast instructs the user to complete the flow in the popup.
+// returned `authorizationUrl` is opened in a new tab. The dialog does NOT
+// close: it switches to a pending panel that polls `useOAuthSession(state)`
+// until the backend reports success/error, and offers a manual-callback
+// fallback (paste the redirect URL) for environments where the callback
+// port is not reachable from the browser.
 
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
-import { ExternalLink as ExternalLinkIcon } from 'lucide-react'
-import { useEffect, useMemo } from 'react'
+import {
+  Check as CheckIcon,
+  Copy as CopyIcon,
+  ExternalLink as ExternalLinkIcon,
+} from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
@@ -45,12 +53,18 @@ import { Spinner } from '@/components/ui/spinner'
 import { Switch } from '@/components/ui/switch'
 import { toast } from '@/lib/toast'
 
-import { useOAuthProviders, useStartOAuth } from '../api'
+import {
+  useOAuthProviders,
+  useOAuthSession,
+  useStartOAuth,
+  useSubmitOAuthManualCallback,
+} from '../api'
 import {
   OAUTH_START_DEFAULT_VALUES,
   oauthStartSchema,
   type OAuthStartValues,
 } from '../lib/oauth-schema'
+import { oauthKeys, type OAuthStartInstructions } from '../types'
 
 type OAuthStartDialogProps = {
   open: boolean
@@ -62,8 +76,22 @@ export function OAuthStartDialog({
   onOpenChange,
 }: OAuthStartDialogProps) {
   const { t } = useTranslation()
+  const queryClient = useQueryClient()
   const providersQuery = useOAuthProviders({ enabled: open })
   const startOAuth = useStartOAuth()
+
+  // Pending-session state — set after `useStartOAuth` returns a `state`. While
+  // set, the dialog swaps the form for a pending panel that polls the
+  // session and offers a manual-callback fallback.
+  const [pendingState, setPendingState] = useState<string | null>(null)
+  const [instructions, setInstructions] = useState<OAuthStartInstructions | null>(
+    null
+  )
+  const [callbackUrl, setCallbackUrl] = useState('')
+  const [copiedTunnel, setCopiedTunnel] = useState(false)
+
+  const sessionQuery = useOAuthSession(pendingState)
+  const submitManualCallback = useSubmitOAuthManualCallback()
 
   const enabledProviders = useMemo(
     () => (providersQuery.data ?? []).filter((provider) => provider.enabled),
@@ -89,6 +117,35 @@ export function OAuthStartDialog({
     if (!open) return
     form.reset(OAUTH_START_DEFAULT_VALUES)
   }, [open, form])
+
+  // Drop pending state when the dialog closes (user cancelled mid-flow) so
+  // polling stops and the form re-renders fresh on next open.
+  useEffect(() => {
+    if (!open && pendingState) {
+      setPendingState(null)
+      setInstructions(null)
+      setCallbackUrl('')
+    }
+  }, [open, pendingState])
+
+  // React to the polled session status. On success, toast + invalidate the
+  // connections list (a new connection is now created) + close the dialog.
+  // On error, the panel surfaces the error string but stays open so the user
+  // can paste a corrected callback URL.
+  const sessionStatus = sessionQuery.data?.status
+  useEffect(() => {
+    if (!pendingState) return
+    if (sessionStatus === 'success') {
+      toast.success(t('oauth.session.succeeded'))
+      void queryClient.invalidateQueries({
+        queryKey: oauthKeys.connections(),
+      })
+      setPendingState(null)
+      setInstructions(null)
+      setCallbackUrl('')
+      onOpenChange(false)
+    }
+  }, [pendingState, sessionStatus, t, onOpenChange, queryClient])
 
   const selectedProviderId = form.watch('provider')
   const selectedProvider = useMemo(
@@ -118,181 +175,320 @@ export function OAuthStartDialog({
       if (result.authorizationUrl) {
         window.open(result.authorizationUrl, '_blank', 'noopener,noreferrer')
       }
-      toast.success(t('oauth.form.startSucceeded'))
-      onOpenChange(false)
+      // Keep the dialog open and switch to the pending panel: the backend
+      // creates the connection only after the OAuth callback completes.
+      setInstructions(result.instructions)
+      setPendingState(result.state)
     } catch {
       toast.error(t('oauth.form.startFailed'))
     }
   }
 
+  async function handleCopySshTunnel() {
+    const command = instructions?.sshTunnelCommand
+    if (!command) return
+    try {
+      await navigator.clipboard.writeText(command)
+      setCopiedTunnel(true)
+      setTimeout(() => setCopiedTunnel(false), 1500)
+    } catch {
+      // Clipboard may be unavailable (non-secure context / permissions).
+    }
+  }
+
+  async function handleManualCallbackSubmit(
+    event: React.FormEvent<HTMLFormElement>
+  ) {
+    event.preventDefault()
+    if (!pendingState) return
+    const url = callbackUrl.trim()
+    if (!url) return
+    try {
+      await submitManualCallback.mutateAsync({
+        state: pendingState,
+        callbackUrl: url,
+      })
+      setCallbackUrl('')
+    } catch {
+      toast.error(t('common.requestFailed'))
+    }
+  }
+
   const isSubmitting = startOAuth.isPending
+  const isSubmittingCallback = submitManualCallback.isPending
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className='sm:max-w-lg'>
-        <DialogHeader>
-          <DialogTitle>{t('oauth.form.startTitle')}</DialogTitle>
-          <DialogDescription>
-            {t('oauth.form.startDescription')}
-          </DialogDescription>
-        </DialogHeader>
+        {pendingState ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>{t('oauth.session.waiting')}</DialogTitle>
+              <DialogDescription>
+                {t('oauth.session.waitingDescription')}
+              </DialogDescription>
+            </DialogHeader>
 
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className='grid gap-4'>
-            <FormField
-              control={form.control}
-              name='provider'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('oauth.form.provider')}</FormLabel>
-                  <Select value={field.value} onValueChange={field.onChange}>
-                    <FormControl>
-                      <SelectTrigger disabled={!providersReady}>
-                        <SelectValue>
-                          {(selected) => {
-                            if (!selected) {
-                              return t('oauth.form.providerPlaceholder')
-                            }
-                            const provider = enabledProviders.find(
-                              (item) => item.provider === selected
-                            )
-                            return provider
-                              ? provider.label || provider.provider
-                              : String(selected)
-                          }}
-                        </SelectValue>
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {enabledProviders.map((provider) => (
-                        <SelectItem
-                          key={provider.provider}
-                          value={provider.provider}
-                        >
-                          {provider.label || provider.provider}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  {providersLoading && (
-                    <div className='text-muted-foreground flex items-center gap-1.5 text-sm'>
-                      <Spinner className='size-3.5' />
-                      {t('oauth.form.loadingProviders')}
-                    </div>
-                  )}
-                  {providersError && (
-                    <div className='text-destructive flex items-center gap-2 text-sm'>
-                      <span>{t('oauth.form.providersLoadFailed')}</span>
-                      <Button
-                        type='button'
-                        variant='link'
-                        size='sm'
-                        className='h-auto px-0'
-                        onClick={() => providersQuery.refetch()}
-                      >
-                        {t('oauth.form.retry')}
-                      </Button>
-                    </div>
-                  )}
-                  {!providersLoading &&
-                    !providersError &&
-                    !hasEnabledProviders && (
-                      <FormDescription>
-                        {t('oauth.form.noProviders')}{' '}
-                        <Link
-                          to='/settings'
-                          className='text-primary hover:underline'
-                        >
-                          {t('oauth.form.goToSettings')}
-                        </Link>
-                      </FormDescription>
-                    )}
-                  <FormMessage />
-                </FormItem>
+            <div className='grid gap-4'>
+              {sessionStatus === 'pending' && (
+                <div className='text-muted-foreground flex items-center gap-2 text-sm'>
+                  <Spinner className='size-3.5' />
+                  <span>{t('oauth.session.waiting')}</span>
+                </div>
               )}
-            />
 
-            {requiresProjectId && (
-              <FormField
-                control={form.control}
-                name='projectId'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('oauth.form.projectId')}</FormLabel>
-                    <FormControl>
-                      <Input
-                        placeholder={t('oauth.form.projectIdPlaceholder')}
-                        autoFocus
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      {t('oauth.form.projectIdDescription')}
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            )}
-
-            <FormField
-              control={form.control}
-              name='proxyUrl'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('oauth.form.proxyUrl')}</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder={t('oauth.form.optionalUrlPlaceholder')}
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
+              {sessionStatus === 'error' && (
+                <div className='text-destructive text-sm'>
+                  {t('oauth.session.failed', {
+                    error: sessionQuery.data?.error ?? '',
+                  })}
+                </div>
               )}
-            />
 
-            <FormField
-              control={form.control}
-              name='useSystemProxy'
-              render={({ field }) => (
-                <FormItem className='border-border flex flex-row items-center justify-between rounded-lg border p-3'>
-                  <div className='space-y-0.5'>
-                    <FormLabel>{t('oauth.form.useSystemProxy')}</FormLabel>
-                    <FormDescription>
-                      {t('oauth.form.useSystemProxyDescription')}
-                    </FormDescription>
+              {instructions?.sshTunnelCommand && (
+                <div className='grid gap-2'>
+                  <p className='text-muted-foreground text-sm'>
+                    {t('oauth.session.sshTunnelHint')}
+                  </p>
+                  <div className='flex items-center gap-2'>
+                    <code className='bg-muted flex-1 overflow-x-auto rounded px-2 py-1.5 text-xs'>
+                      {instructions.sshTunnelCommand}
+                    </code>
+                    <Button
+                      type='button'
+                      variant='outline'
+                      size='icon-sm'
+                      onClick={handleCopySshTunnel}
+                      aria-label={t('common.copy')}
+                    >
+                      {copiedTunnel ? (
+                        <CheckIcon className='size-3.5' />
+                      ) : (
+                        <CopyIcon className='size-3.5' />
+                      )}
+                    </Button>
                   </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </FormItem>
+                </div>
               )}
-            />
 
-            <DialogFooter>
-              <Button
-                type='button'
-                variant='outline'
-                onClick={() => onOpenChange(false)}
-                disabled={isSubmitting}
+              <form
+                onSubmit={handleManualCallbackSubmit}
+                className='grid gap-2'
               >
-                {t('oauth.form.cancel')}
-              </Button>
-              <Button type='submit' disabled={isSubmitting || !providersReady}>
-                {isSubmitting ? (
-                  <Spinner className='mr-1' />
-                ) : (
-                  <ExternalLinkIcon className='mr-1 size-3.5' />
+                <label
+                  className='text-sm font-medium'
+                  htmlFor='oauth-manual-callback-url'
+                >
+                  {t('oauth.session.callbackLabel')}
+                </label>
+                <Input
+                  id='oauth-manual-callback-url'
+                  value={callbackUrl}
+                  onChange={(event) => setCallbackUrl(event.target.value)}
+                  placeholder={t('oauth.session.callbackPlaceholder')}
+                  autoComplete='off'
+                  spellCheck={false}
+                />
+                <Button
+                  type='submit'
+                  disabled={!callbackUrl.trim() || isSubmittingCallback}
+                >
+                  {isSubmittingCallback ? (
+                    <Spinner className='mr-1' />
+                  ) : null}
+                  {t('oauth.session.callbackSubmit')}
+                </Button>
+              </form>
+
+              <DialogFooter>
+                <Button
+                  type='button'
+                  variant='outline'
+                  onClick={() => onOpenChange(false)}
+                >
+                  {t('oauth.form.cancel')}
+                </Button>
+              </DialogFooter>
+            </div>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>{t('oauth.form.startTitle')}</DialogTitle>
+              <DialogDescription>
+                {t('oauth.form.startDescription')}
+              </DialogDescription>
+            </DialogHeader>
+
+            <Form {...form}>
+              <form
+                onSubmit={form.handleSubmit(onSubmit)}
+                className='grid gap-4'
+              >
+                <FormField
+                  control={form.control}
+                  name='provider'
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('oauth.form.provider')}</FormLabel>
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <FormControl>
+                          <SelectTrigger disabled={!providersReady}>
+                            <SelectValue>
+                              {(selected) => {
+                                if (!selected) {
+                                  return t('oauth.form.providerPlaceholder')
+                                }
+                                const provider = enabledProviders.find(
+                                  (item) => item.provider === selected
+                                )
+                                return provider
+                                  ? provider.label || provider.provider
+                                  : String(selected)
+                              }}
+                            </SelectValue>
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {enabledProviders.map((provider) => (
+                            <SelectItem
+                              key={provider.provider}
+                              value={provider.provider}
+                            >
+                              {provider.label || provider.provider}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      {providersLoading && (
+                        <div className='text-muted-foreground flex items-center gap-1.5 text-sm'>
+                          <Spinner className='size-3.5' />
+                          {t('oauth.form.loadingProviders')}
+                        </div>
+                      )}
+                      {providersError && (
+                        <div className='text-destructive flex items-center gap-2 text-sm'>
+                          <span>{t('oauth.form.providersLoadFailed')}</span>
+                          <Button
+                            type='button'
+                            variant='link'
+                            size='sm'
+                            className='h-auto px-0'
+                            onClick={() => providersQuery.refetch()}
+                          >
+                            {t('oauth.form.retry')}
+                          </Button>
+                        </div>
+                      )}
+                      {!providersLoading &&
+                        !providersError &&
+                        !hasEnabledProviders && (
+                          <FormDescription>
+                            {t('oauth.form.noProviders')}{' '}
+                            <Link
+                              to='/settings'
+                              className='text-primary hover:underline'
+                            >
+                              {t('oauth.form.goToSettings')}
+                            </Link>
+                          </FormDescription>
+                        )}
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {requiresProjectId && (
+                  <FormField
+                    control={form.control}
+                    name='projectId'
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('oauth.form.projectId')}</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder={t(
+                              'oauth.form.projectIdPlaceholder'
+                            )}
+                            autoFocus
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t('oauth.form.projectIdDescription')}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
                 )}
-                {t('oauth.form.start')}
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
+
+                <FormField
+                  control={form.control}
+                  name='proxyUrl'
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('oauth.form.proxyUrl')}</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder={t('oauth.form.optionalUrlPlaceholder')}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name='useSystemProxy'
+                  render={({ field }) => (
+                    <FormItem className='border-border flex flex-row items-center justify-between rounded-lg border p-3'>
+                      <div className='space-y-0.5'>
+                        <FormLabel>{t('oauth.form.useSystemProxy')}</FormLabel>
+                        <FormDescription>
+                          {t('oauth.form.useSystemProxyDescription')}
+                        </FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+
+                <DialogFooter>
+                  <Button
+                    type='button'
+                    variant='outline'
+                    onClick={() => onOpenChange(false)}
+                    disabled={isSubmitting}
+                  >
+                    {t('oauth.form.cancel')}
+                  </Button>
+                  <Button
+                    type='submit'
+                    disabled={isSubmitting || !providersReady}
+                  >
+                    {isSubmitting ? (
+                      <Spinner className='mr-1' />
+                    ) : (
+                      <ExternalLinkIcon className='mr-1 size-3.5' />
+                    )}
+                    {t('oauth.form.start')}
+                  </Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/web/src/features/oauth/components/oauth-start-dialog.tsx
+++ b/web/src/features/oauth/components/oauth-start-dialog.tsx
@@ -84,9 +84,8 @@ export function OAuthStartDialog({
   // set, the dialog swaps the form for a pending panel that polls the
   // session and offers a manual-callback fallback.
   const [pendingState, setPendingState] = useState<string | null>(null)
-  const [instructions, setInstructions] = useState<OAuthStartInstructions | null>(
-    null
-  )
+  const [instructions, setInstructions] =
+    useState<OAuthStartInstructions | null>(null)
   const [callbackUrl, setCallbackUrl] = useState('')
   const [copiedTunnel, setCopiedTunnel] = useState(false)
 
@@ -293,9 +292,7 @@ export function OAuthStartDialog({
                   type='submit'
                   disabled={!callbackUrl.trim() || isSubmittingCallback}
                 >
-                  {isSubmittingCallback ? (
-                    <Spinner className='mr-1' />
-                  ) : null}
+                  {isSubmittingCallback ? <Spinner className='mr-1' /> : null}
                   {t('oauth.session.callbackSubmit')}
                 </Button>
               </form>
@@ -410,9 +407,7 @@ export function OAuthStartDialog({
                         <FormLabel>{t('oauth.form.projectId')}</FormLabel>
                         <FormControl>
                           <Input
-                            placeholder={t(
-                              'oauth.form.projectIdPlaceholder'
-                            )}
+                            placeholder={t('oauth.form.projectIdPlaceholder')}
                             autoFocus
                             {...field}
                           />

--- a/web/src/features/oauth/types.ts
+++ b/web/src/features/oauth/types.ts
@@ -7,7 +7,11 @@
 // OAuth-connected upstream account). `OAuthProvider` is an available
 // upstream provider (e.g. the platform whose OAuth flow can be started).
 
-import type { OAuthConnectionInfo, OAuthProviderInfo } from '@/lib/api'
+import type {
+  OAuthConnectionInfo,
+  OAuthProviderInfo,
+  OAuthStartResponse,
+} from '@/lib/api'
 
 /** Row type for the OAuth connections table (an OAuth-connected account). */
 export type OAuthClient = OAuthConnectionInfo
@@ -17,6 +21,13 @@ export type OAuthProvider = OAuthProviderInfo
 
 /** Result of starting an OAuth flow — contains the URL to open. */
 export type OAuthClientStatus = OAuthClient['status']
+
+/**
+ * Manual-callback instructions returned by `startOAuthProvider`. Surfaced to
+ * the user in the pending panel: the SSH tunnel command (if any) and the
+ * callback URL the operator may paste back manually.
+ */
+export type OAuthStartInstructions = OAuthStartResponse['instructions']
 
 /**
  * Wire payload for `api.startOAuthProvider`. `provider` is required;
@@ -38,4 +49,5 @@ export const oauthKeys = {
   all: ['oauth'] as const,
   providers: () => [...oauthKeys.all, 'providers'] as const,
   connections: () => [...oauthKeys.all, 'connections'] as const,
+  session: (state: string) => [...oauthKeys.all, 'session', state] as const,
 }

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -6,6 +6,7 @@ import { Download as DownloadIcon, RefreshCw } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import {
   DataTablePage,
   type UrlTableState,
@@ -366,13 +367,12 @@ export function ProxyLogsPage() {
         </div>
       )}
 
-      {logsQuery.error && (
-        <div className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg rounded-lg border p-3 text-sm'>
-          {t('proxyLogs.page.loadError', {
-            message: (logsQuery.error as Error).message,
-          })}
-        </div>
-      )}
+      <QueryErrorBanner
+        error={logsQuery.error as Error | null}
+        messageKey='proxyLogs.page.loadError'
+        onRetry={() => logsQuery.refetch()}
+        isRetrying={logsQuery.isFetching}
+      />
 
       <DataTablePage
         table={table}

--- a/web/src/features/sites/components/__tests__/sites-page.test.tsx
+++ b/web/src/features/sites/components/__tests__/sites-page.test.tsx
@@ -1,6 +1,6 @@
-// Regression tests for the sites list page. Covers the three behaviors that
-// previously regressed: the one-shot `?create=1` deep link, the error state
-// suppressing the empty-state CTA, and the Retry button calling refetch.
+// Regression tests for the sites list page. Covers the one-shot deep-link
+// params (`?create=1` and `?edit=<id>`), the error state suppressing the
+// empty-state CTA, and the Retry button calling refetch.
 import '@testing-library/jest-dom/vitest'
 import {
   cleanup,
@@ -16,10 +16,13 @@ import '@/i18n/config'
 import { SitesPage } from '../sites-page'
 
 const testState = vi.hoisted(() => ({
-  search: { create: false as boolean | undefined },
+  search: {
+    create: false as boolean | undefined,
+    edit: undefined as number | undefined,
+  } as { create?: boolean | undefined; edit?: number | undefined },
   navigate: vi.fn(),
   sitesQuery: {
-    data: [],
+    data: [] as unknown[],
     error: null as Error | null,
     isLoading: false,
     isFetching: false,
@@ -27,6 +30,7 @@ const testState = vi.hoisted(() => ({
   },
   formOpenCount: 0,
   previousFormOpen: undefined as boolean | undefined,
+  lastEditingSiteId: null as number | null,
   dataTableRendered: false,
 }))
 
@@ -88,9 +92,13 @@ vi.mock('../site-detail-sheet', () => ({
 }))
 
 vi.mock('../site-form-dialog', () => ({
-  SiteFormDialog: (props: { open: boolean }) => {
+  SiteFormDialog: (props: {
+    open: boolean
+    editingSite?: { id: number } | null
+  }) => {
     if (props.open && testState.previousFormOpen !== true) {
       testState.formOpenCount += 1
+      testState.lastEditingSiteId = props.editingSite?.id ?? null
     }
     testState.previousFormOpen = props.open
     return null
@@ -110,6 +118,7 @@ beforeEach(() => {
   testState.sitesQuery.refetch.mockResolvedValue({})
   testState.formOpenCount = 0
   testState.previousFormOpen = undefined
+  testState.lastEditingSiteId = null
   testState.dataTableRendered = false
   testState.search = { create: false }
   testState.sitesQuery.data = []
@@ -141,6 +150,99 @@ describe('SitesPage create deep link', () => {
         to: '/sites',
         replace: true,
         search: expect.objectContaining({ create: undefined }),
+      })
+    )
+  })
+})
+
+describe('SitesPage edit deep link', () => {
+  it('opens the edit dialog for the referenced site and strips the edit param', async () => {
+    const site = {
+      id: 5,
+      name: 'Edit Me',
+      url: 'https://edit.example.com',
+    }
+    testState.sitesQuery.data = [site]
+    testState.search = { edit: 5 }
+
+    const { rerender } = render(<SitesPage />)
+
+    await waitFor(() => {
+      expect(testState.formOpenCount).toBe(1)
+    })
+    expect(testState.lastEditingSiteId).toBe(5)
+
+    // After consumption, the page navigates to strip `edit`; a remount
+    // (search.edit now gone) must not reopen the dialog.
+    testState.search = {}
+    rerender(<SitesPage />)
+
+    await waitFor(() => {
+      expect(testState.formOpenCount).toBe(1)
+    })
+    expect(testState.navigate).toHaveBeenCalledTimes(1)
+    expect(testState.navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/sites',
+        replace: true,
+        search: expect.objectContaining({ edit: undefined }),
+      })
+    )
+  })
+
+  it('strips the edit param without opening the dialog when the id is unknown', async () => {
+    testState.sitesQuery.data = [
+      { id: 1, name: 'Other', url: 'https://other.example.com' },
+    ]
+    testState.search = { edit: 999 }
+
+    render(<SitesPage />)
+
+    await waitFor(() => {
+      expect(testState.navigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: '/sites',
+          replace: true,
+          search: expect.objectContaining({ edit: undefined }),
+        })
+      )
+    })
+    expect(testState.formOpenCount).toBe(0)
+    expect(testState.lastEditingSiteId).toBeNull()
+  })
+
+  it('waits for the list to resolve before opening the edit dialog', async () => {
+    const site = {
+      id: 5,
+      name: 'Edit Me',
+      url: 'https://edit.example.com',
+    }
+    testState.sitesQuery.data = []
+    testState.sitesQuery.isLoading = true
+    testState.search = { edit: 5 }
+
+    const { rerender } = render(<SitesPage />)
+
+    // While loading, the edit param must NOT be consumed and no navigate
+    // call (strip) must happen yet.
+    expect(testState.formOpenCount).toBe(0)
+    expect(testState.navigate).not.toHaveBeenCalled()
+
+    // Once the list resolves with the referenced site, the dialog opens and
+    // the param is stripped.
+    testState.sitesQuery.isLoading = false
+    testState.sitesQuery.data = [site]
+    rerender(<SitesPage />)
+
+    await waitFor(() => {
+      expect(testState.formOpenCount).toBe(1)
+    })
+    expect(testState.lastEditingSiteId).toBe(5)
+    expect(testState.navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/sites',
+        replace: true,
+        search: expect.objectContaining({ edit: undefined }),
       })
     )
   })

--- a/web/src/features/sites/components/site-form-dialog.tsx
+++ b/web/src/features/sites/components/site-form-dialog.tsx
@@ -459,9 +459,11 @@ export function SiteFormDialog({
                         field.onChange(selectValueToNullableBool(value))
                       }
                     >
-                      <SelectTrigger className='w-full'>
-                        <SelectValue />
-                      </SelectTrigger>
+                      <FormControl>
+                        <SelectTrigger className='w-full'>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
                       <SelectContent>
                         <SelectItem value='inherit'>
                           {t('sites.form.resinInherit')}
@@ -492,9 +494,11 @@ export function SiteFormDialog({
                         field.onChange(selectValueToNullableBool(value))
                       }
                     >
-                      <SelectTrigger className='w-full'>
-                        <SelectValue />
-                      </SelectTrigger>
+                      <FormControl>
+                        <SelectTrigger className='w-full'>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
                       <SelectContent>
                         <SelectItem value='inherit'>
                           {t('sites.form.utlsInherit')}
@@ -619,17 +623,19 @@ export function SiteFormDialog({
                             field.onChange(value as SiteProbeScope)
                           }
                         >
-                          <SelectTrigger className='w-full'>
-                            <SelectValue
-                              placeholder={t('sites.form.scopePlaceholder')}
-                            >
-                              {(value: unknown) =>
-                                value === 'all'
-                                  ? t('sites.form.scopeAll')
-                                  : t('sites.form.scopeSingle')
-                              }
-                            </SelectValue>
-                          </SelectTrigger>
+                          <FormControl>
+                            <SelectTrigger className='w-full'>
+                              <SelectValue
+                                placeholder={t('sites.form.scopePlaceholder')}
+                              >
+                                {(value: unknown) =>
+                                  value === 'all'
+                                    ? t('sites.form.scopeAll')
+                                    : t('sites.form.scopeSingle')
+                                }
+                              </SelectValue>
+                            </SelectTrigger>
+                          </FormControl>
                           <SelectContent>
                             <SelectItem value='single'>
                               {t('sites.form.scopeSingle')}

--- a/web/src/features/sites/components/sites-page.tsx
+++ b/web/src/features/sites/components/sites-page.tsx
@@ -112,12 +112,15 @@ function buildHref(next: UrlTableStateUpdate<SitesUrlFilters>): string {
   const sortString = encodeSorting(merged.sorting)
   if (sortString) params.set('sort', sortString)
   if (merged.filters.status) params.set('status', merged.filters.status)
-  // Preserve the one-shot `create` deep-link param across table-state
+  // Preserve the one-shot `create`/`edit` deep-link params across table-state
   // navigations (page-clamp / sort / filter) until the page's consumption
-  // effect strips it — mirrors the accounts page's buildAccountsHref guard
+  // effect strips them — mirrors the accounts page's buildAccountsHref guard
   // for its guided-flow `siteId`/`create` params.
-  const guidedCreate = new URLSearchParams(window.location.search).get('create')
+  const searchParams = new URLSearchParams(window.location.search)
+  const guidedCreate = searchParams.get('create')
   if (guidedCreate) params.set('create', guidedCreate)
+  const guidedEdit = searchParams.get('edit')
+  if (guidedEdit) params.set('edit', guidedEdit)
   const queryString = params.toString()
   return queryString ? `/sites?${queryString}` : '/sites'
 }
@@ -212,6 +215,35 @@ export function SitesPage() {
       replace: true,
     })
   }, [search, navigate])
+
+  // Consume the one-shot `?edit=<id>` deep link exactly once: resolve the
+  // referenced id against the loaded sites snapshot, open the edit dialog
+  // for it, then strip the transient `edit` param so a refetch / remount
+  // never reopens it. Waits for the list to resolve (isLoading false) so a
+  // stale or unknown id is ignored instead of opening a blank dialog —
+  // mirrors the accounts page's deep-link wait. The `useRef` guard survives
+  // the strict-mode double-invoke and the post-navigate re-render.
+  const editConsumed = useRef(false)
+  useEffect(() => {
+    if (
+      editConsumed.current ||
+      search.edit === undefined ||
+      sitesQuery.isLoading
+    ) {
+      return
+    }
+    const site = sitesQuery.data?.find((s) => s.id === search.edit)
+    editConsumed.current = true
+    if (site) {
+      setEditingSite(site)
+      setFormOpen(true)
+    }
+    navigate({
+      to: '/sites',
+      search: { ...search, edit: undefined },
+      replace: true,
+    })
+  }, [search, sitesQuery.isLoading, sitesQuery.data, navigate])
 
   const urlState = useSitesUrlState()
 

--- a/web/src/features/sites/lib/sites-schema.ts
+++ b/web/src/features/sites/lib/sites-schema.ts
@@ -140,4 +140,10 @@ export const sitesSearchSchema = z.object({
     .catch(undefined),
   status: stringSearchParam,
   create: z.coerce.boolean().optional().catch(undefined),
+  // `edit` is a one-shot transient deep-link param (`?edit=<id>`): it
+  // auto-opens the edit dialog for the referenced site once, then the page
+  // strips it. Mirrors `create` but resolves the id against the loaded list
+  // snapshot before opening, so a stale/unknown id is ignored rather than
+  // creating data.
+  edit: z.coerce.number().int().positive().optional().catch(undefined),
 })

--- a/web/src/features/token-routes/__tests__/routes-page-drilldown.test.tsx
+++ b/web/src/features/token-routes/__tests__/routes-page-drilldown.test.tsx
@@ -54,6 +54,13 @@ vi.mock('@/lib/toast', () => ({
   toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
 }))
 
+vi.mock('@/features/accounts/api', () => ({
+  useAccounts: () => ({ data: undefined }),
+}))
+vi.mock('@/features/sites/api', () => ({
+  useSites: () => ({ data: undefined }),
+}))
+
 vi.mock('../api', () => ({
   useRoutes: () => ({
     data: testState.routes,

--- a/web/src/features/token-routes/components/__tests__/routes-page.test.tsx
+++ b/web/src/features/token-routes/components/__tests__/routes-page.test.tsx
@@ -68,6 +68,13 @@ vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn(),
 }))
 
+vi.mock('@/features/accounts/api', () => ({
+  useAccounts: () => ({ data: undefined }),
+}))
+vi.mock('@/features/sites/api', () => ({
+  useSites: () => ({ data: undefined }),
+}))
+
 vi.mock('../../api', () => ({
   useRoutes: () => testState.routesQuery,
   useModelTokenCandidates: () => ({ data: undefined }),

--- a/web/src/features/token-routes/components/routes-columns.tsx
+++ b/web/src/features/token-routes/components/routes-columns.tsx
@@ -137,7 +137,11 @@ function RoutesRowActions({
           onClick={() => actions.onClearCooldown(route)}
           disabled={readOnly || isCooldownPending}
         >
-          {isCooldownPending ? <Loader2 className='animate-spin' /> : <Snowflake />}
+          {isCooldownPending ? (
+            <Loader2 className='animate-spin' />
+          ) : (
+            <Snowflake />
+          )}
           {t('tokenRoutes.columns.clearCooldown')}
         </DropdownMenuItem>
         <DropdownMenuSeparator />

--- a/web/src/features/token-routes/components/routes-columns.tsx
+++ b/web/src/features/token-routes/components/routes-columns.tsx
@@ -7,6 +7,7 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import {
   Eye,
+  Loader2,
   MoreHorizontal,
   Pencil,
   Power,
@@ -98,12 +99,18 @@ function resolveChannelSummary(
 function RoutesRowActions({
   route,
   actions,
+  pendingToggleId = null,
+  pendingCooldownId = null,
 }: {
   route: RouteSummaryRow
   actions: RouteRowActions
+  pendingToggleId?: number | null
+  pendingCooldownId?: number | null
 }) {
   const { t } = useTranslation()
   const readOnly = isReadOnlyRoute(route)
+  const isTogglePending = pendingToggleId === route.id
+  const isCooldownPending = pendingCooldownId === route.id
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -119,18 +126,18 @@ function RoutesRowActions({
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={() => actions.onToggleEnabled(route)}
-          disabled={readOnly}
+          disabled={readOnly || isTogglePending}
         >
-          <Power />
+          {isTogglePending ? <Loader2 className='animate-spin' /> : <Power />}
           {route.enabled
             ? t('tokenRoutes.columns.disable')
             : t('tokenRoutes.columns.enable')}
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={() => actions.onClearCooldown(route)}
-          disabled={readOnly}
+          disabled={readOnly || isCooldownPending}
         >
-          <Snowflake />
+          {isCooldownPending ? <Loader2 className='animate-spin' /> : <Snowflake />}
           {t('tokenRoutes.columns.clearCooldown')}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
@@ -155,7 +162,9 @@ function RoutesRowActions({
 }
 
 export function useRoutesColumns(
-  actions: RouteRowActions
+  actions: RouteRowActions,
+  pendingToggleId: number | null = null,
+  pendingCooldownId: number | null = null
 ): ColumnDef<RouteSummaryRow>[] {
   const { t } = useTranslation()
   return [
@@ -350,7 +359,14 @@ export function useRoutesColumns(
       header: () => <span className='sr-only'>{t('common.actions')}</span>,
       cell: ({ row }) => {
         const route = row.original as RouteSummaryRow
-        return <RoutesRowActions route={route} actions={actions} />
+        return (
+          <RoutesRowActions
+            route={route}
+            actions={actions}
+            pendingToggleId={pendingToggleId}
+            pendingCooldownId={pendingCooldownId}
+          />
+        )
       },
       meta: { pinned: 'right' },
     },

--- a/web/src/features/token-routes/components/routes-page.tsx
+++ b/web/src/features/token-routes/components/routes-page.tsx
@@ -27,6 +27,8 @@ import {
 } from '@/components/ui/dialog'
 import { Switch } from '@/components/ui/switch'
 import { asStringParam } from '@/lib/helpers/searchParams'
+import { useAccounts } from '@/features/accounts/api'
+import { useSites } from '@/features/sites/api'
 
 import {
   type BatchRouteAction,
@@ -277,7 +279,13 @@ export function RoutesPage() {
     [openEdit, updateMutation, clearCooldownMutation, refreshDecisionsMutation]
   )
 
-  const columns = useRoutesColumns(rowActions)
+  const columns = useRoutesColumns(
+    rowActions,
+    updateMutation.isPending ? (updateMutation.variables?.id ?? null) : null,
+    clearCooldownMutation.isPending
+      ? (clearCooldownMutation.variables ?? null)
+      : null
+  )
 
   const { table } = useDataTable({
     data: rows,
@@ -319,6 +327,22 @@ export function RoutesPage() {
     }),
     [accountId, siteId]
   )
+
+  // The loader already prefetches both the accounts snapshot and the sites
+  // list into the query cache, so these are cache hits (no extra round-trip).
+  // Resolve chain-context IDs to human-readable names with `#ID` fallback.
+  const { data: accountsSnapshot } = useAccounts()
+  const { data: sitesList } = useSites()
+  const chainAccountName = useMemo(() => {
+    if (!accountId) return undefined
+    const match = accountsSnapshot?.accounts.find((a) => a.id === accountId)
+    return match?.username ?? `#${accountId}`
+  }, [accountId, accountsSnapshot])
+  const chainSiteName = useMemo(() => {
+    if (!siteId) return undefined
+    const match = sitesList?.find((s) => s.id === siteId)
+    return match?.name ?? `#${siteId}`
+  }, [siteId, sitesList])
 
   const confirmDelete = async () => {
     if (!deleteRouteState) return
@@ -377,11 +401,11 @@ export function RoutesPage() {
       {(accountId || siteId) && (
         <div className='bg-muted/40 text-muted-foreground rounded-lg border p-2 text-sm'>
           {t('tokenRoutes.page.chainContext')}
-          {accountId
-            ? ` ${t('tokenRoutes.page.chainContextAccount', { id: accountId })}`
+          {chainAccountName
+            ? ` ${t('tokenRoutes.page.chainContextAccount', { name: chainAccountName })}`
             : ''}
-          {siteId
-            ? ` / ${t('tokenRoutes.page.chainContextSite', { id: siteId })} `
+          {chainSiteName
+            ? ` / ${t('tokenRoutes.page.chainContextSite', { name: chainSiteName })} `
             : ' '}
           {t('tokenRoutes.page.chainContextSuffix')}
         </div>
@@ -441,6 +465,15 @@ export function RoutesPage() {
           toolbarProps={{
             searchPlaceholder: t('tokenRoutes.page.searchPlaceholder'),
             searchDebounceMs: 300,
+            viewToggle: (
+              <label className='text-muted-foreground flex items-center gap-2 text-sm'>
+                <Switch
+                  checked={showZeroChannel}
+                  onCheckedChange={setShowZeroChannel}
+                />
+                {t('tokenRoutes.page.showZeroChannel')}
+              </label>
+            ),
             filters: [
               {
                 columnId: 'enabled',
@@ -462,14 +495,6 @@ export function RoutesPage() {
           bulkActions={<RoutesBulkActions table={table} />}
         />
       )}
-
-      <label className='text-muted-foreground flex items-center gap-2 text-sm'>
-        <Switch
-          checked={showZeroChannel}
-          onCheckedChange={setShowZeroChannel}
-        />
-        {t('tokenRoutes.page.showZeroChannel')}
-      </label>
 
       <RouteFormDialog
         open={formOpen}

--- a/web/src/features/token-routes/components/routes-page.tsx
+++ b/web/src/features/token-routes/components/routes-page.tsx
@@ -26,9 +26,9 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Switch } from '@/components/ui/switch'
-import { asStringParam } from '@/lib/helpers/searchParams'
 import { useAccounts } from '@/features/accounts/api'
 import { useSites } from '@/features/sites/api'
+import { asStringParam } from '@/lib/helpers/searchParams'
 
 import {
   type BatchRouteAction,

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -51,6 +51,7 @@
       "create": "Create",
       "close": "Close",
       "no": "No",
+      "retry": "Retry",
       "actions": "Actions",
       "status": "Status",
       "language": "Language",
@@ -324,6 +325,16 @@
           "invalidProxyUrl": "Please enter a valid http or https URL.",
           "providerRequired": "Please select a provider."
         }
+      },
+      "session": {
+        "waiting": "Waiting for authorization…",
+        "waitingDescription": "Complete the authorization in the opened tab, or paste the callback URL manually.",
+        "callbackLabel": "Manual callback URL",
+        "callbackPlaceholder": "Paste the callback URL from the OAuth redirect",
+        "callbackSubmit": "Submit callback",
+        "succeeded": "Authorization completed.",
+        "failed": "Authorization failed: {{error}}",
+        "sshTunnelHint": "If the callback port is not reachable from your browser, run this SSH tunnel:"
       },
       "toast": {
         "quotaRefreshed": "Quota refresh requested for #{{id}}.",
@@ -1563,8 +1574,8 @@
         "refreshDecisions": "Refresh decisions",
         "addButton": "Add route",
         "chainContext": "Configuring routes for",
-        "chainContextAccount": "account #{{id}}",
-        "chainContextSite": "site #{{id}}",
+        "chainContextAccount": "account \"{{name}}\"",
+        "chainContextSite": "site \"{{name}}\"",
         "chainContextSuffix": "— add a route to complete the configuration flow.",
         "loadError": "Failed to load routes: {{message}}",
         "retry": "Retry",
@@ -2323,7 +2334,9 @@
         "notAvailable": "—",
         "never": "Never",
         "clearRouteCooldown": "Clear route cooldown",
-        "clearRouteCooldownHint": "Resets cooldown and failure counts for every channel on this channel's route."
+        "clearRouteCooldownHint": "Resets cooldown and failure counts for every channel on this channel's route.",
+        "editRoute": "Edit route",
+        "editRouteHint": "Open the parent token route"
       }
     },
     "connect": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -51,6 +51,7 @@
       "create": "新建",
       "close": "关闭",
       "no": "否",
+      "retry": "重试",
       "actions": "操作",
       "status": "状态",
       "language": "语言",
@@ -324,6 +325,16 @@
           "invalidProxyUrl": "请输入有效的 http 或 https 地址。",
           "providerRequired": "请选择提供商。"
         }
+      },
+      "session": {
+        "waiting": "等待授权完成…",
+        "waitingDescription": "请在打开的标签页中完成授权，或手动粘贴回调地址。",
+        "callbackLabel": "手动回调地址",
+        "callbackPlaceholder": "粘贴 OAuth 回调跳转的地址",
+        "callbackSubmit": "提交回调",
+        "succeeded": "授权完成。",
+        "failed": "授权失败：{{error}}",
+        "sshTunnelHint": "如果回调端口无法从浏览器访问，请运行以下 SSH 隧道："
       },
       "toast": {
         "quotaRefreshed": "已请求刷新 #{{id}} 的额度。",
@@ -1563,8 +1574,8 @@
         "refreshDecisions": "刷新决策",
         "addButton": "添加路由",
         "chainContext": "正在为",
-        "chainContextAccount": "账号 #{{id}}",
-        "chainContextSite": "站点 #{{id}}",
+        "chainContextAccount": "账号「{{name}}」",
+        "chainContextSite": "站点「{{name}}」",
         "chainContextSuffix": "配置路由。添加一条路由即可完成配置动线。",
         "loadError": "加载路由失败：{{message}}",
         "retry": "重试",
@@ -2323,7 +2334,9 @@
         "notAvailable": "—",
         "never": "从未",
         "clearRouteCooldown": "清除路由冷却",
-        "clearRouteCooldownHint": "重置该通道所属路由下全部通道的冷却与失败计数。"
+        "clearRouteCooldownHint": "重置该通道所属路由下全部通道的冷却与失败计数。",
+        "editRoute": "编辑路由",
+        "editRouteHint": "打开所属令牌路由"
       }
     },
     "connect": {


### PR DESCRIPTION
## Summary

Closes the remaining open observations from `docs/analysis/ui-ux-audit-2026-08.md`, promoted to this slice with owner + acceptance tests. No Go code changed — this is a frontend + i18n slice.

### Changes

- **OAuth Start-OAuth dead-end**: capture `result.state`/`instructions`, render a pending panel with 2s `getOAuthSession` polling, SSH-tunnel copy, and a manual-callback input bound to `submitOAuthManualCallback` (backend endpoints already existed, frontend wrappers were unused).
- **token-routes chain-context banner**: resolve `accountId`/`siteId` to names via the loader-prefetched `useAccounts()`/`useSites()` cache, `#ID` fallback.
- **Form Select a11y**: wrap the 3 site-form `SelectTrigger`s in `FormControl` so `FormLabel.htmlFor` resolves to the trigger id.
- **Shared `<QueryErrorBanner>`**: new `components/common/query-error-banner.tsx` (`role=alert` + optional Retry); 8 banner-only pages migrated, all gain Retry.
- **routes per-row pending**: `useRoutesColumns` takes `pendingToggleId`/`pendingCooldownId` (mirrors accounts `pendingStatusId`); dropdown items swap to `Loader2` + disabled for the in-flight row.
- **showZeroChannel toggle** moved from below the table into toolbar `viewToggle`.
- **sites `?edit=<id>`** one-shot deep link (mirrors `?create=1`): schema + `buildHref` preservation + consume-and-strip effect.
- **channel-detail-sheet footer**: always render; add "Edit route" action → `navigate('/token-routes', { routeId })` (reuses the routes drilldown).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (only pre-existing warnings)
- [x] `bun run knip` — clean
- [x] `bun run test` (full) — **632/632 pass**, 86 files
- [x] `bun run build` (production) — exit 0
- [x] `go vet ./...` — clean
- [x] `go build ./cmd/server` — v0.16.0, 24M
- [ ] CI 12-check suite on GitHub

New focused tests: `oauth-start-dialog-session.test.tsx` (3), `sites-page` `?edit` suite (3), `channel-detail-sheet` edit-route suite (4). Existing `routes-page` tests updated to mock `useAccounts`/`useSites`.