### PR TITLE
test(ui): scroll pages in route-smoke so lazy-loaded assets fire before console-error collection

### DIFF
--- a/web/scripts/route-smoke.mjs
+++ b/web/scripts/route-smoke.mjs
@@ -144,6 +144,21 @@ async function scanRoute(context, route, failures, mobile = false) {
     })
     await page.waitForTimeout(500)
 
+    // Scroll through the page before collecting console errors: lazy-loaded
+    // content below the fold (e.g. brand icons) only fires its request when
+    // it approaches the viewport, so a CSP-blocked lazy image would stay
+    // silent without this pass (regression for the brand-icon CSP fix).
+    await page.evaluate(async () => {
+      const step = Math.max(1, Math.floor(window.innerHeight * 0.8))
+      const total = document.body.scrollHeight
+      for (let y = 0; y <= total; y += step) {
+        window.scrollTo(0, y)
+        await new Promise((resolve) => setTimeout(resolve, 30))
+      }
+      window.scrollTo(0, 0)
+    })
+    await page.waitForTimeout(300)
+
     if (response && response.status() >= 500) {
       failures.push(`${label}: document returned HTTP ${response.status()}`)
     }


### PR DESCRIPTION
## Summary

The brand-icon CSP bug shipped undetected because `loading='lazy'` images below the fold never issued their blocked request during the CI smoke pass — console-error collection happened before the browser ever tried to fetch them.

This adds a scroll pass through each page (after load, before assertions) so lazy-loaded assets fire their requests and any CSP-blocked/failed lazy fetch surfaces as a console error in CI.

No behavioral changes for normal (non-lazy) assets; adds ~1-2s to the smoke run.

## Verification

- Ran against the live seeded server: clean pass on all 41 desktop + 14 mobile routes.