### PR TITLE
test: cover TokenRouter public surface + per-call pricing + StatusBadge labels

### DIFF
--- a/routing/pricing_cost_test.go
+++ b/routing/pricing_cost_test.go
@@ -11,8 +11,8 @@ func boolPtr(v bool) *bool { return &v }
 
 func TestIsClaudeModel(t *testing.T) {
 	cases := []struct {
-		name  string
-		want  bool
+		name string
+		want bool
 	}{
 		{"claude-opus-4-7", true},
 		{"Claude-Sonnet-4", true},
@@ -470,5 +470,56 @@ func TestCalculateModelUsageFullPrice_NoCacheMatchesBreakdownMath(t *testing.T) 
 	}
 	if fullPrice.Breakdown.OutputCost != breakdown.Breakdown.OutputCost {
 		t.Fatalf("outputCost fullPrice=%v breakdown=%v", fullPrice.Breakdown.OutputCost, breakdown.Breakdown.OutputCost)
+	}
+}
+
+func TestEstimateProxyCostFromModel_MatchesCalculateModelUsageCost(t *testing.T) {
+	// EstimateProxyCostFromModel is a thin alias over CalculateModelUsageCost;
+	// pin the equivalence so the public entry point cannot drift from the
+	// canonical math.
+	model := PricingModel{ModelName: "probe-estimate", QuotaType: 0, ModelRatio: 2, CompletionRatio: 6}
+	usage := UsageForCost{PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500}
+	groupRatio := map[string]float64{"default": 1.5}
+
+	got := EstimateProxyCostFromModel(model, usage, groupRatio)
+	want := CalculateModelUsageCost(model, usage, groupRatio)
+	if got != want {
+		t.Fatalf("EstimateProxyCostFromModel = %v, want %v (alias must match)", got, want)
+	}
+	if got <= 0 {
+		t.Fatalf("expected a positive cost, got %v", got)
+	}
+}
+
+func TestCalculatePerCallCost(t *testing.T) {
+	cases := []struct {
+		name       string
+		price      *ModelPrice
+		multiplier float64
+		want       float64
+	}{
+		{name: "nil price", price: nil, multiplier: 1, want: 0},
+		{name: "flat price", price: &ModelPrice{Flat: ptrF(0.5)}, multiplier: 2, want: 1.0},
+		{name: "pair price uses input ratio", price: &ModelPrice{IsPair: true, Input: 100, Output: 200}, multiplier: 1, want: 100 * 0.002},
+		{name: "pair price respects multiplier", price: &ModelPrice{IsPair: true, Input: 100, Output: 200}, multiplier: 2, want: 100 * 0.002 * 2},
+		{name: "scalar without flat is zero", price: &ModelPrice{}, multiplier: 1, want: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := calculatePerCallCost(tc.price, tc.multiplier); got != tc.want {
+				t.Fatalf("calculatePerCallCost = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCalculateModelUsageCost_PerCallQuotaAppliesGroupMultiplier(t *testing.T) {
+	flat := 0.25
+	model := PricingModel{ModelName: "per-call", QuotaType: 1, ModelPrice: &ModelPrice{Flat: &flat}}
+	if got := CalculateModelUsageCost(model, UsageForCost{}, map[string]float64{"default": 4}); got != 1.0 {
+		t.Fatalf("per-call cost with multiplier 4 = %v, want 1.0", got)
+	}
+	if got := CalculateModelUsageCost(model, UsageForCost{}, nil); got != 0.25 {
+		t.Fatalf("per-call cost with no group ratio = %v, want 0.25", got)
 	}
 }

--- a/routing/router_test.go
+++ b/routing/router_test.go
@@ -1,0 +1,227 @@
+package routing
+
+// TokenRouter public-surface tests. The deep-test coverage audit found the
+// entire TokenRouter API at 0%: NewTokenRouter defaults, GetAvailableModels /
+// GetAvailableModelContextLengths (route → exposed-model mapping), error
+// propagation, and the SelectChannel delegation path.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// routerTestDB is a minimal ChannelSelectorDB: FindAllEnabledRoutes and
+// LoadEnabledRoutes serve the configured route list; every other method is a
+// no-op (only exercised by selector flows this test file does not drive).
+type routerTestDB struct {
+	routes  []store.TokenRoute
+	routes2 []store.TokenRoute // LoadEnabledRoutes view (selector path)
+	err     error
+}
+
+func (db *routerTestDB) LoadEnabledRoutes(ctx context.Context) ([]store.TokenRoute, error) {
+	if db.err != nil {
+		return nil, db.err
+	}
+	return db.routes2, nil
+}
+func (db *routerTestDB) FindAllEnabledRoutes(ctx context.Context) ([]store.TokenRoute, error) {
+	if db.err != nil {
+		return nil, db.err
+	}
+	return db.routes, nil
+}
+func (db *routerTestDB) LoadRouteGroupSources(ctx context.Context, groupRouteIDs []int64) (map[int64][]int64, error) {
+	return nil, nil
+}
+func (db *routerTestDB) LoadRouteChannels(ctx context.Context, routeIDs []int64) ([]struct {
+	Channel store.RouteChannel
+	Account store.Account
+	Site    store.Site
+	Token   *store.AccountToken
+}, error) {
+	return nil, nil
+}
+func (db *routerTestDB) LoadOAuthRouteUnitSummaries(ctx context.Context, unitIDs []int64) (map[int64]OAuthRouteUnitSummary, error) {
+	return nil, nil
+}
+func (db *routerTestDB) LoadOAuthRouteUnitMembers(ctx context.Context, unitIDs []int64) (map[int64][]OAuthRouteUnitMemberCandidate, error) {
+	return nil, nil
+}
+func (db *routerTestDB) UpdateChannelLastSelectedAt(ctx context.Context, channelID int64, lastSelectedAt string) error {
+	return nil
+}
+func (db *routerTestDB) UpdateRouteUnitMemberLastSelectedAt(ctx context.Context, unitID, accountID int64, lastSelectedAt string) error {
+	return nil
+}
+func (db *routerTestDB) FindRouteIDsByOAuthRouteUnitID(ctx context.Context, unitID int64) ([]int64, error) {
+	return nil, nil
+}
+func (db *routerTestDB) LoadCredentialScopedChannelIDs(ctx context.Context, channel store.RouteChannel, accountID int64) ([]int64, error) {
+	return []int64{channel.ID}, nil
+}
+func (db *routerTestDB) LoadChannelWithAccount(ctx context.Context, channelID int64) (*struct {
+	Channel store.RouteChannel
+	Account store.Account
+}, error) {
+	return nil, nil
+}
+func (db *routerTestDB) LoadChannelWithAccountAndRoute(ctx context.Context, channelID int64) (*struct {
+	Channel store.RouteChannel
+	Account store.Account
+	Route   store.TokenRoute
+}, error) {
+	return nil, nil
+}
+func (db *routerTestDB) UpdateChannelCooldownFields(ctx context.Context, channelIDs []int64, updates map[string]interface{}) error {
+	return nil
+}
+func (db *routerTestDB) UpdateChannelSuccessFields(ctx context.Context, channelID int64, updates map[string]interface{}) error {
+	return nil
+}
+func (db *routerTestDB) UpdateRouteUnitMemberCooldownFields(ctx context.Context, memberID int64, updates map[string]interface{}) error {
+	return nil
+}
+func (db *routerTestDB) UpdateRouteUnitMemberSuccessFields(ctx context.Context, memberID int64, updates map[string]interface{}) error {
+	return nil
+}
+func (db *routerTestDB) LoadRouteUnitMemberWithAccount(ctx context.Context, unitID, accountID int64) (*struct {
+	Member  store.OAuthRouteUnitMember
+	Account store.Account
+	Unit    store.OAuthRouteUnit
+}, error) {
+	return nil, nil
+}
+func (db *routerTestDB) LoadChannelsByTokenID(ctx context.Context, tokenID int64) ([]store.RouteChannel, error) {
+	return nil, nil
+}
+func (db *routerTestDB) LoadChannelsByAccountIDWithoutToken(ctx context.Context, accountID int64) ([]store.RouteChannel, error) {
+	return nil, nil
+}
+func (db *routerTestDB) LoadRuntimeHealthChannelRows(ctx context.Context, channelIDs []int64) ([]struct {
+	SiteID            int64
+	SourceModel       *string
+	RouteModelPattern string
+}, error) {
+	return nil, nil
+}
+func (db *routerTestDB) ClearChannelFailureStates(ctx context.Context, channelIDs []int64) error {
+	return nil
+}
+
+func newTestTokenRouter(db *routerTestDB) *TokenRouter {
+	cfg := &config.Config{}
+	return NewTokenRouter(db, cfg, nil, nil)
+}
+
+func TestNewTokenRouter_AppliesDefaults(t *testing.T) {
+	db := &routerTestDB{}
+	tr := NewTokenRouter(db, &config.Config{}, nil, nil)
+	if tr.configuredMaxSec != TokenRouterFailureCooldownMaxSecCeiling {
+		t.Fatalf("configuredMaxSec = %d, want ceiling %d when config is 0", tr.configuredMaxSec, TokenRouterFailureCooldownMaxSecCeiling)
+	}
+	if tr.fallbackUnitCost != 1 {
+		t.Fatalf("fallbackUnitCost = %v, want 1 when config is 0", tr.fallbackUnitCost)
+	}
+}
+
+func TestTokenRouter_GetAvailableModels(t *testing.T) {
+	// FindAllEnabledRoutes (the DB side) already filters disabled routes;
+	// the router maps whatever it is given.
+	db := &routerTestDB{routes: []store.TokenRoute{
+		{ID: 1, ModelPattern: "gpt-4o", Enabled: true},
+		{ID: 2, ModelPattern: "gpt-4o-mini", Enabled: true},
+		{ID: 3, ModelPattern: "gpt-4o", Enabled: true}, // duplicate exposes once
+	}}
+	tr := newTestTokenRouter(db)
+
+	names, err := tr.GetAvailableModels(context.Background())
+	if err != nil {
+		t.Fatalf("GetAvailableModels: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("exposed names = %v, want exactly {gpt-4o, gpt-4o-mini}", names)
+	}
+	set := map[string]bool{}
+	for _, name := range names {
+		set[name] = true
+	}
+	if !set["gpt-4o"] || !set["gpt-4o-mini"] {
+		t.Fatalf("exposed names = %v, want gpt-4o and gpt-4o-mini (disabled + duplicates excluded)", names)
+	}
+}
+
+func TestTokenRouter_GetAvailableModels_WildcardDisplayNameCoversExact(t *testing.T) {
+	wildcardDisplay := "gpt-all" // must differ from the pattern to count as a custom display name
+	db := &routerTestDB{routes: []store.TokenRoute{
+		{ID: 1, ModelPattern: "gpt-*", DisplayName: &wildcardDisplay, Enabled: true},
+		{ID: 2, ModelPattern: "gpt-4o", Enabled: true}, // covered by the wildcard display route
+		{ID: 3, ModelPattern: "claude-3-5-sonnet", Enabled: true},
+	}}
+	tr := newTestTokenRouter(db)
+
+	names, err := tr.GetAvailableModels(context.Background())
+	if err != nil {
+		t.Fatalf("GetAvailableModels: %v", err)
+	}
+	set := map[string]bool{}
+	for _, name := range names {
+		set[name] = true
+	}
+	if set["gpt-4o"] {
+		t.Fatalf("gpt-4o should be covered by the gpt-* wildcard display route, names=%v", names)
+	}
+	if !set["gpt-all"] || !set["claude-3-5-sonnet"] {
+		t.Fatalf("exposed names = %v, want the wildcard display name and the uncovered exact model", names)
+	}
+}
+
+func TestTokenRouter_GetAvailableModelContextLengths_MaxWins(t *testing.T) {
+	db := &routerTestDB{routes: []store.TokenRoute{
+		{ID: 1, ModelPattern: "gpt-4o", Enabled: true, ContextLength: int64Ptr(64000)},
+		{ID: 2, ModelPattern: "gpt-4o", Enabled: true, ContextLength: int64Ptr(128000)},
+		{ID: 3, ModelPattern: "gpt-4o", Enabled: true, ContextLength: nil},
+	}}
+	tr := newTestTokenRouter(db)
+
+	lengths, err := tr.GetAvailableModelContextLengths(context.Background())
+	if err != nil {
+		t.Fatalf("GetAvailableModelContextLengths: %v", err)
+	}
+	if lengths["gpt-4o"] != 128000 {
+		t.Fatalf("gpt-4o = %d, want max positive 128000", lengths["gpt-4o"])
+	}
+}
+
+func TestTokenRouter_GetAvailableModels_DBErrorPropagates(t *testing.T) {
+	db := &routerTestDB{err: errors.New("boom")}
+	tr := newTestTokenRouter(db)
+
+	if _, err := tr.GetAvailableModels(context.Background()); err == nil {
+		t.Fatal("GetAvailableModels should surface the DB error")
+	}
+	if _, err := tr.GetAvailableModelContextLengths(context.Background()); err == nil {
+		t.Fatal("GetAvailableModelContextLengths should surface the DB error")
+	}
+}
+
+func TestTokenRouter_SelectChannel_NoRoutes(t *testing.T) {
+	db := &routerTestDB{}
+	tr := newTestTokenRouter(db)
+
+	// With no routes the composed ChannelSelector returns a nil channel
+	// without error ("no route matched" is a normal routing outcome; the
+	// caller treats nil as no-route-available). This asserts the delegation
+	// path runs through NewTokenRouter's composed selector.
+	channel, err := tr.SelectChannel(context.Background(), "gpt-4o", DownstreamRoutingPolicy{})
+	if err != nil {
+		t.Fatalf("SelectChannel with no routes should not error, got %v", err)
+	}
+	if channel != nil {
+		t.Fatalf("SelectChannel with no routes should return nil channel, got %+v", channel)
+	}
+}

--- a/web/src/features/proxy-logs/__tests__/status-badge.test.tsx
+++ b/web/src/features/proxy-logs/__tests__/status-badge.test.tsx
@@ -1,0 +1,71 @@
+// metapi-go/features/proxy-logs — StatusBadge label resolution tests.
+//
+// Covers the i18n fix (#869): known string statuses (success/failed/…)
+// resolve to translated labels, numeric HTTP codes stay numeric, unknown
+// strings fall back to the raw value, and missing status renders the
+// neutral "unknown" label.
+
+import { cleanup, render, screen } from '@testing-library/react'
+import i18n from 'i18next'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import '@/i18n/config'
+
+import { StatusBadge } from '../components/status-badge'
+
+beforeAll(async () => {
+  await i18n.changeLanguage('zhCN')
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+function renderBadge(props: {
+  httpStatus?: number | null
+  status?: string | null
+}) {
+  return render(<StatusBadge {...props} />)
+}
+
+describe('StatusBadge', () => {
+  it('translates the "success" string status via i18n', () => {
+    renderBadge({ status: 'success' })
+    expect(screen.getByText('成功')).toBeTruthy()
+  })
+
+  it('translates the "failed" string status via i18n', () => {
+    renderBadge({ status: 'failed' })
+    expect(screen.getByText('失败')).toBeTruthy()
+  })
+
+  it('translates error-family statuses as failed', () => {
+    renderBadge({ status: 'timeout' })
+    expect(screen.getByText('失败')).toBeTruthy()
+  })
+
+  it('keeps numeric HTTP codes as the raw label', () => {
+    renderBadge({ httpStatus: 200 })
+    expect(screen.getByText('200')).toBeTruthy()
+  })
+
+  it('keeps numeric status strings as the raw label', () => {
+    renderBadge({ status: '429' })
+    expect(screen.getByText('429')).toBeTruthy()
+  })
+
+  it('falls back to the raw value for unknown statuses', () => {
+    renderBadge({ status: 'banana' })
+    expect(screen.getByText('banana')).toBeTruthy()
+  })
+
+  it('renders the unknown label when no status is provided', () => {
+    renderBadge({})
+    expect(screen.getByText('未知')).toBeTruthy()
+  })
+
+  it('prefers the HTTP status over a string status', () => {
+    renderBadge({ httpStatus: 500, status: 'success' })
+    expect(screen.getByText('500')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

Closes coverage gaps the deep-test audit flagged as 0%:

- **`routing/router_test.go`** (new): minimal `ChannelSelectorDB` fake exercising the `TokenRouter` public surface — `NewTokenRouter` defaults (cooldown ceiling + fallback unit cost), `GetAvailableModels` (dedup, wildcard-display-name coverage of exact models, DB error propagation), `GetAvailableModelContextLengths` (max-wins), and the `SelectChannel` delegation path (documents the nil-channel no-error contract).
- **`routing/pricing_cost_test.go`**: `EstimateProxyCostFromModel` alias equivalence, `calculatePerCallCost` (flat / pair / nil / scalar cases), per-call quota group-multiplier.
- **`web/.../status-badge.test.tsx`** (new, 8 tests): pins the #869 i18n label resolution — known string statuses translate (成功/失败), numeric HTTP codes stay raw, unknown statuses fall back to the raw value, missing status renders the neutral label, HTTP status wins over string status.

## Verification

- Routing package coverage **73.0% → 75.2%**; the 7 audited functions went 0% → 100%.
- `go test ./routing` green, `go vet ./routing` clean, gofmt clean.
- Frontend: status-badge suite 8/8 + surrounding proxy-logs suites 40/40.