### PR TITLE
fix(store): writable data-dir probe + migration --verify correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ docker run -d --name metapi \
   -p 4000:4000 \
   -e AUTH_TOKEN=your-admin-token \
   -e PROXY_TOKEN=your-proxy-sk-token \
+  -e ACCOUNT_CREDENTIAL_SECRET=$(openssl rand -hex 32) \
   -e TZ=Asia/Shanghai \
-  -v ./data:/app/data \
+  -v metapi_data:/app/data \
   --restart unless-stopped \
   ghcr.io/deliciousbuding/metapi-go:latest
 ```
@@ -125,7 +126,10 @@ docker run -d --name metapi \
 启动后访问 `http://localhost:4000`，用 `AUTH_TOKEN` 登录即可。
 
 > [!IMPORTANT]
-> 请务必修改 `AUTH_TOKEN` 和 `PROXY_TOKEN`，不要使用默认值。数据存储在 `./data` 目录，升级不会丢失。
+> 请务必修改 `AUTH_TOKEN` 和 `PROXY_TOKEN`，不要使用默认值。
+> `ACCOUNT_CREDENTIAL_SECRET` 用于加密存储的账号凭据，建议生成独立的 32+ 字节随机串（不设置时会回退为 `AUTH_TOKEN`，过短会直接启动失败）。
+> 数据建议用**命名卷**（如上 `metapi_data`）存放，容器以非 root 用户（uid 1001）运行，命名卷会自动继承属主、无需额外授权；若改用 `./data:/app/data` 这类 bind mount，需先在宿主机执行 `chown -R 1001:1001 ./data`。
+> 生产环境建议把镜像固定到具体版本标签（如 `ghcr.io/deliciousbuding/metapi-go:v0.16.1`），而不是 `latest`。
 
 ### Docker Compose
 
@@ -139,22 +143,29 @@ services:
     ports:
       - "4000:4000"
     volumes:
-      - ./data:/app/data
+      - metapi_data:/app/data
     environment:
       AUTH_TOKEN: ${AUTH_TOKEN:?AUTH_TOKEN is required}
       PROXY_TOKEN: ${PROXY_TOKEN:?PROXY_TOKEN is required}
+      ACCOUNT_CREDENTIAL_SECRET: ${ACCOUNT_CREDENTIAL_SECRET:-}
       CHECKIN_CRON: "0 8 * * *"
       BALANCE_REFRESH_CRON: "0 * * * *"
       PORT: ${PORT:-4000}
       DATA_DIR: /app/data
       TZ: ${TZ:-Asia/Shanghai}
     restart: unless-stopped
+
+volumes:
+  metapi_data:
 EOF
 
 export AUTH_TOKEN=your-admin-token
 export PROXY_TOKEN=your-proxy-sk-token
+export ACCOUNT_CREDENTIAL_SECRET=$(openssl rand -hex 32)
 docker compose up -d
 ```
+
+> 如需从旧的 TypeScript 版迁移数据，改用 bind mount 指向原 `data` 目录，并先在宿主机执行 `chown -R 1001:1001 ./data`（详见 [迁移指南](docs/migration.md)）。
 
 Compose、反向代理、PostgreSQL 与升级细节见 [部署指南](docs/deployment.md)；从安装到发出第一个代理请求的完整 walkthrough 见 [快速上手](docs/getting-started.md)。
 
@@ -275,7 +286,7 @@ Cron 定时签到（默认每日 08:00），智能解析奖励金额，失败自
 
 ## 从 TypeScript 版迁移
 
-数据库 Schema 完全一致，Go 版启动时自动执行幂等迁移：停止旧服务，用同样的环境变量启动 Go 版即可，`./data` 目录原样复用。使用 MySQL 的部署需先经 `metapi-migrate` 工具迁到 PostgreSQL。完整步骤与回滚方案见 [迁移指南](docs/migration.md)。
+数据库 Schema 完全一致，Go 版启动时自动执行幂等迁移：停止旧服务，用同样的环境变量启动 Go 版即可。Go 镜像以非 root 用户（uid 1001）运行，若数据目录是 bind mount（如 `./data:/app/data`）且由旧版以 root 写入，需先在宿主机执行 `chown -R 1001:1001 ./data`（命名卷则无需处理）。使用 MySQL 的部署需先经 `metapi-migrate` 工具迁到 PostgreSQL。完整步骤与回滚方案见 [迁移指南](docs/migration.md)。
 
 ---
 

--- a/config/validate.go
+++ b/config/validate.go
@@ -259,14 +259,14 @@ func (c *Config) Validate() []error {
 			errs = append(errs, &configError{
 				field:    "account_credential_secret",
 				value:    fmt.Sprintf("%d bytes", secretLen),
-				msg:      "UNSAFE: secret is shorter than 8 bytes — trivially brute-forceable; use a 32+ byte random secret",
+				msg:      "UNSAFE: secret is shorter than 8 bytes — trivially brute-forceable; set ACCOUNT_CREDENTIAL_SECRET to a 32+ byte random secret (an unset secret falls back to AUTH_TOKEN)",
 				critical: true,
 			})
 		} else if secretLen < 16 {
 			errs = append(errs, &configError{
 				field:    "account_credential_secret",
 				value:    fmt.Sprintf("%d bytes", secretLen),
-				msg:      "weak: secret is shorter than 16 bytes — use a 32+ byte random secret for production",
+				msg:      "weak: secret is shorter than 16 bytes — use a 32+ byte random ACCOUNT_CREDENTIAL_SECRET for production",
 				critical: false,
 			})
 		}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,20 +5,35 @@
 #   1. Create a .env file with required values:
 #        AUTH_TOKEN=<your-admin-token>
 #        PROXY_TOKEN=<your-proxy-token>
+#        ACCOUNT_CREDENTIAL_SECRET=$(openssl rand -hex 32)   # recommended
 #   2. Start: docker compose -f docker-compose.prod.yml up -d
 #   3. Place nginx/Caddy reverse proxy in front of 127.0.0.1:4000
 
 services:
   metapi:
+    # Pin a release tag (e.g. ghcr.io/deliciousbuding/metapi-go:v0.16.1) instead
+    # of :latest for reproducible production deploys.
     image: ghcr.io/deliciousbuding/metapi-go:latest
     ports:
       - "127.0.0.1:4000:4000"
+    # Data directory. The image runs as non-root uid 1001, so:
+    #   - Named volume (recommended for fresh installs): ownership is copied
+    #     from the image automatically — no chown needed.
+    #       volumes: [ "metapi_data:/app/data" ]
+    #   - Bind mount (required when migrating existing TS data): the host
+    #     directory must be writable by uid 1001, otherwise startup fails with
+    #     "readonly database" / "unable to open database file". Fix on the host:
+    #       chown -R 1001:1001 ./data
     volumes:
       - ./data:/app/data
     environment:
       # Required (validated at startup -- missing = exit with error)
       AUTH_TOKEN: ${AUTH_TOKEN:?AUTH_TOKEN is required}
       PROXY_TOKEN: ${PROXY_TOKEN:?PROXY_TOKEN is required}
+      # Recommended: 32+ byte random secret for credential encryption.
+      # Generate: openssl rand -hex 32. Falls back to AUTH_TOKEN when unset;
+      # a short fallback makes startup fail with a critical validation error.
+      ACCOUNT_CREDENTIAL_SECRET: ${ACCOUNT_CREDENTIAL_SECRET:-}
       # Optional with defaults
       HOST: 0.0.0.0
       CHECKIN_CRON: ${CHECKIN_CRON:-0 8 * * *}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # Deployment Guide
 
-**Last updated**: 2026-08-17
+**Last updated**: 2026-08-20
 
 ## Prerequisites
 
@@ -12,6 +12,8 @@
 
 ## Environment Variables
 
+完整的环境变量清单见仓库根目录 [`.env.example`](../.env.example)（约 150 项，含通知、代理、调试等高级配置）；下表仅列部署必需与常用项。
+
 ### Required
 
 | Variable      | Description                                      |
@@ -21,12 +23,14 @@
 
 ### Optional
 
-| Variable                            | Default                       | Description                                                                                                                                                                                                                                                                                                                              |
-| ----------------------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PORT`                              | `4000`                        | HTTP listen port                                                                                                                                                                                                                                                                                                                         |
-| `DATA_DIR`                          | `/app/data`                   | SQLite database directory                                                                                                                                                                                                                                                                                                                |
-| `CHECKIN_CRON`                      | `0 8 * * *`                   | Daily checkin cron expression                                                                                                                                                                                                                                                                                                            |
-| `BALANCE_REFRESH_CRON`              | `0 * * * *`                   | Hourly balance refresh cron                                                                                                                                                                                                                                                                                                              |
+| Variable                            | Default                       | Description                                                                                                                                                                                                                                                                                                                                                                                        |
+| ----------------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ACCOUNT_CREDENTIAL_SECRET`         | fallback to `AUTH_TOKEN`      | Key used to encrypt stored account credentials. **Recommended**: a unique 32+ byte random secret (`openssl rand -hex 32`). `< 8` bytes is a critical startup error; `< 16` logs a weak-secret warning. Do not reuse `AUTH_TOKEN`.                                                                                                                                                                 |
+| `PORT`                              | `4000`                        | HTTP listen port                                                                                                                                                                                                                                                                                                                                                                                    |
+| `DATA_DIR`                          | `/app/data`                   | SQLite database directory                                                                                                                                                                                                                                                                                                                                                                           |
+| `LOG_LEVEL`                         | `info`                        | slog threshold: `debug`/`info`/`warn`/`error`. Raise to `warn` to quiet hot-path logs.                                                                                                                                                                                                                                                                                                              |
+| `CHECKIN_CRON`                      | `0 8 * * *`                   | Daily checkin cron expression                                                                                                                                                                                                                                                                                                                                                                      |
+| `BALANCE_REFRESH_CRON`              | `0 * * * *`                   | Hourly balance refresh cron                                                                                                                                                                                                                                                                                                                                                                        |
 | `TZ`                                | `Asia/Shanghai`               | Timezone for cron scheduling                                                                                                                                                                                                                                                                                                             |
 | `DB_TYPE`                           | `sqlite`                      | Database type: `sqlite` or `postgres`; inferred as `postgres` when a PostgreSQL URL is provided                                                                                                                                                                                                                                          |
 | `DATABASE_URL`                      | _(empty)_                     | PostgreSQL connection string; alias of `DB_URL`; when set to `postgres://` or `postgresql://`, uses PG instead of SQLite                                                                                                                                                                                                                 |
@@ -54,6 +58,7 @@
 ```bash
 AUTH_TOKEN=<your-admin-token>
 PROXY_TOKEN=<your-proxy-token>
+ACCOUNT_CREDENTIAL_SECRET=$(openssl rand -hex 32)   # recommended
 ```
 
 2. Start the service:
@@ -68,6 +73,19 @@ docker compose -f docker-compose.prod.yml up -d
 curl http://localhost:4000/health
 # {"status":"ok"}
 ```
+
+### 数据目录与卷
+
+容器以**非 root 用户（uid 1001）**运行，数据目录的可写性是 Docker 部署最常见的坑：
+
+- **命名卷（全新部署推荐）**：Docker 首次使用时会把镜像内 `/app/data` 的内容连同属主一起拷入卷，容器用户天然可写，无需任何 chown。
+- **Bind mount（迁移旧数据时必须用）**：宿主目录保持宿主属主。旧 TypeScript 版以 root 运行，留下的 `./data` 和 `hub.db` 归 root 所有，Go 版写不进去，启动即报 `attempt to write a readonly database` 或 `unable to open database file`。启动前在宿主机执行一次：
+
+  ```bash
+  sudo chown -R 1001:1001 ./data
+  ```
+
+- **镜像标签**：`latest` 便于尝鲜；生产建议固定到版本标签（如 `ghcr.io/deliciousbuding/metapi-go:v0.16.1`），保证可复现部署。
 
 ## Nginx Reverse Proxy
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,6 +1,6 @@
 # Migration Guide: TypeScript to Go
 
-**Last updated**: 2026-08-11
+**Last updated**: 2026-08-20
 
 This guide walks through migrating from the TypeScript Metapi server to the Go rewrite.
 
@@ -121,11 +121,25 @@ System settings `db_type`, `db_url`, `db_ssl` are automatically filtered (they c
 
 ## Step 4: Start the Go Server
 
+> **Docker 数据目录权限（最常见启动失败原因）**
+> Go 版镜像以非 root 用户（uid 1001）运行，而旧 TypeScript 版容器以 root 运行，
+> 所以宿主机上由旧容器创建的 `./data` 和 `hub.db` 归 root 所有，Go 版写不进去。
+> 迁移前先在宿主机执行一次：
+>
+> ```bash
+> sudo chown -R 1001:1001 ./data
+> ```
+>
+> 否则启动会报 `attempt to write a readonly database`（带旧库）或
+> `PRAGMA journal_mode=WAL: unable to open database file`（新目录）并退出。
+> 全新部署则建议直接用命名卷（`-v metapi_data:/app/data`），无需任何 chown。
+
 ### With SQLite (same data)
 
 ```bash
 export AUTH_TOKEN=<your-token>
 export PROXY_TOKEN=<your-proxy-token>
+export ACCOUNT_CREDENTIAL_SECRET=$(openssl rand -hex 32)   # 建议设置，不设置则回退为 AUTH_TOKEN
 export DATA_DIR=./data
 ./metapi
 ```
@@ -135,6 +149,7 @@ export DATA_DIR=./data
 ```bash
 export AUTH_TOKEN=<your-token>
 export PROXY_TOKEN=<your-proxy-token>
+export ACCOUNT_CREDENTIAL_SECRET=$(openssl rand -hex 32)
 export DATABASE_URL='postgres://<user>:<password>@<host>:5432/metapi?sslmode=require'
 ./metapi
 ```

--- a/store/bootstrap.go
+++ b/store/bootstrap.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -53,10 +52,13 @@ func EnsureRuntimeDatabase(cfg *config.Config) error {
 
 	if dialect == DialectSQLite {
 		sqlitePath := ResolveSQLitePath(dsn, dataDir)
-		// Create parent directory for SQLite file if not :memory:.
+		// Verify the data directory and any existing database file are
+		// writable before SQLite opens them, so a Docker bind mount owned by
+		// root fails with an actionable message instead of a cryptic SQLite
+		// error (issue #849: "readonly database" / "unable to open database file").
 		if sqlitePath != ":memory:" {
-			if err := os.MkdirAll(filepath.Dir(sqlitePath), 0755); err != nil {
-				return fmt.Errorf("bootstrap: failed to create SQLite parent dir: %w", err)
+			if err := probeSQLiteWritable(sqlitePath); err != nil {
+				return fmt.Errorf("bootstrap: %w", err)
 			}
 		}
 		slog.Info("bootstrap: opening SQLite database", "path", sqlitePath)

--- a/store/checksum_test.go
+++ b/store/checksum_test.go
@@ -1,0 +1,130 @@
+package store
+
+import (
+	"bytes"
+	"io"
+	"path/filepath"
+	"testing"
+)
+
+// TestHashRowsOrderIndependent guards against the --verify false mismatch
+// class found while validating the TS→Go migration: hashRows must be
+// deterministic regardless of the source query's row order.
+func TestHashRowsOrderIndependent(t *testing.T) {
+	a := []map[string]interface{}{
+		{"id": int64(1), "name": "first", "enabled": int64(1)},
+		{"id": int64(2), "name": "second", "enabled": int64(0)},
+		{"id": int64(3), "name": "third", "enabled": int64(1)},
+	}
+	reversed := []map[string]interface{}{a[2], a[0], a[1]}
+	shuffled := []map[string]interface{}{a[1], a[2], a[0]}
+
+	h1 := hashRows(a)
+	if !bytes.Equal(h1, hashRows(reversed)) {
+		t.Fatal("hashRows differs under reversed row order")
+	}
+	if !bytes.Equal(h1, hashRows(shuffled)) {
+		t.Fatal("hashRows differs under shuffled row order")
+	}
+}
+
+// TestHashRowsNormalizesBooleans guards the cross-dialect boolean rule:
+// SQLite stores 0/1, PostgreSQL scans true/false — the hash must agree.
+func TestHashRowsNormalizesBooleans(t *testing.T) {
+	sqliteLike := []map[string]interface{}{
+		{"id": int64(1), "active": int64(1), "note": "x"},
+	}
+	pgLike := []map[string]interface{}{
+		{"id": int64(1), "active": true, "note": "x"},
+	}
+	if !bytes.Equal(hashRows(sqliteLike), hashRows(pgLike)) {
+		t.Fatal("hashRows should normalize booleans across dialects")
+	}
+}
+
+// TestRunMigrationVerifyTSSchemaOrder reproduces the real-world regression:
+// a source whose columns are laid out in the TypeScript drizzle order (with
+// the additive Go columns appended) migrated to a Go-created target must pass
+// --verify. This failed on three distinct bugs: column-order hashing,
+// settings runtime-key filtering, and row-order hashing.
+func TestRunMigrationVerifyTSSchemaOrder(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "source.db")
+	targetPath := filepath.Join(t.TempDir(), "target.db")
+
+	// Source mirrors a TS-version database: sites columns in the drizzle
+	// order with the Go additive columns appended at the end.
+	srcDB, err := Open(DialectSQLite, sourcePath, false)
+	if err != nil {
+		t.Fatalf("open source: %v", err)
+	}
+	if _, err := srcDB.Exec(`CREATE TABLE sites (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL,
+		url TEXT NOT NULL,
+		platform TEXT NOT NULL,
+		status TEXT NOT NULL,
+		api_key TEXT,
+		created_at TEXT DEFAULT (datetime('now')),
+		updated_at TEXT DEFAULT (datetime('now')),
+		global_weight REAL,
+		max_concurrency INTEGER,
+		tags TEXT
+	)`); err != nil {
+		t.Fatalf("create ts-order sites: %v", err)
+	}
+	if _, err := srcDB.Exec(`CREATE TABLE settings (
+		key TEXT PRIMARY KEY,
+		value TEXT
+	)`); err != nil {
+		t.Fatalf("create settings: %v", err)
+	}
+	if _, err := srcDB.Exec(`INSERT INTO sites (name, url, platform, status, api_key, global_weight, max_concurrency, tags) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		"新API站A", "https://a.example.com", "new-api", "active", "sk-a", 1.0, 0, `["prod"]`); err != nil {
+		t.Fatalf("seed sites: %v", err)
+	}
+	if _, err := srcDB.Exec(`INSERT INTO sites (name, url, platform, status, api_key) VALUES (?, ?, ?, ?, ?)`,
+		"站B", "https://b.example.com", "one-api", "active", "sk-b"); err != nil {
+		t.Fatalf("seed sites 2: %v", err)
+	}
+	// Runtime DB settings keys are documented as filtered out of migrations;
+	// verify must not flag the resulting count difference.
+	for _, kv := range [][2]string{{"db_type", "sqlite"}, {"db_url", "data/hub.db"}, {"site_name", "我的中转"}} {
+		if _, err := srcDB.Exec(`INSERT INTO settings (key, value) VALUES (?, ?)`, kv[0], kv[1]); err != nil {
+			t.Fatalf("seed settings: %v", err)
+		}
+	}
+	if err := srcDB.Close(); err != nil {
+		t.Fatalf("close source: %v", err)
+	}
+
+	summary, err := RunMigration(RunMigrationOptions{
+		FromPath:  sourcePath,
+		ToURL:     targetPath,
+		Overwrite: true,
+		Verify:    true,
+		LogWriter: io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("RunMigration with --verify failed on a TS-order source: %v", err)
+	}
+	if summary == nil || summary.Rows["sites"] != 2 {
+		t.Fatalf("summary sites rows = %+v, want 2", summary)
+	}
+	// summary.Rows reports the SOURCE snapshot counts; the runtime-key filter
+	// shows up on the target side, which is what --verify actually checks.
+	if got := summary.Rows["settings"]; got != 3 {
+		t.Fatalf("summary settings rows = %d, want 3 (source count)", got)
+	}
+	tgtDB, err := Open(DialectSQLite, targetPath, false)
+	if err != nil {
+		t.Fatalf("open target for inspection: %v", err)
+	}
+	defer tgtDB.Close()
+	var targetSettings int
+	if err := tgtDB.QueryRow(`SELECT COUNT(*) FROM settings`).Scan(&targetSettings); err != nil {
+		t.Fatalf("count target settings: %v", err)
+	}
+	if targetSettings != 1 {
+		t.Fatalf("target settings rows = %d, want 1 (runtime keys filtered)", targetSettings)
+	}
+}

--- a/store/migrate_runner.go
+++ b/store/migrate_runner.go
@@ -419,7 +419,11 @@ func openSourceDB(raw string) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	return sql.Open("sqlite", sourcePath+"?_journal_mode=WAL")
+	// Open the source without touching its journal mode. Forcing
+	// `_journal_mode=WAL` would contradict the documented read-only promise for
+	// the source (docs/migration.md) and fails on a read-only source; a WAL
+	// source (the TypeScript version's default) is read correctly regardless.
+	return sql.Open("sqlite", sourcePath)
 }
 
 // openTargetDB opens a SQLite path or a PostgreSQL URL as the target via
@@ -437,6 +441,13 @@ func openTargetDB(raw string) (*DB, error) {
 		sqlitePath, pathErr := normalizeSQLitePath(raw)
 		if pathErr != nil {
 			return nil, pathErr
+		}
+		// Surface a writable data directory instead of a cryptic SQLite error
+		// (same probe the server bootstrap uses for its SQLite database).
+		if sqlitePath != ":memory:" {
+			if probeErr := probeSQLiteWritable(sqlitePath); probeErr != nil {
+				return nil, probeErr
+			}
 		}
 		db, err = Open(DialectSQLite, sqlitePath, false)
 	}
@@ -1128,7 +1139,34 @@ func buildInsertSQLite(s insertStmt) (string, []interface{}) {
 
 func verifyChecksums(srcDB *sql.DB, tgtDB *DB, snapshot map[string][]map[string]interface{}) error {
 	for _, table := range AllTableNames() {
-		srcCount := len(snapshot[table])
+		srcRows := snapshot[table]
+
+		// Runtime DB settings (db_type/db_url/db_ssl) are intentionally not
+		// copied by buildSettings, so exclude them from the source side too —
+		// otherwise settings always reports a false mismatch on real TS DBs.
+		if table == "settings" {
+			filtered := make([]map[string]interface{}, 0, len(srcRows))
+			for _, row := range srcRows {
+				if !runtimeDBSettingKeys[asString(v(row, "key"))] {
+					filtered = append(filtered, row)
+				}
+			}
+			srcRows = filtered
+		}
+
+		// The column set actually present in the source is the data being
+		// copied. A raw TypeScript database does not carry the Go additive
+		// columns, so only hash this set on the target side too — otherwise
+		// --verify always reports a false mismatch against a Go-created
+		// target schema.
+		sourceCols := make(map[string]struct{})
+		for _, row := range srcRows {
+			for col := range row {
+				sourceCols[col] = struct{}{}
+			}
+		}
+
+		srcCount := len(srcRows)
 
 		var tgtCount int
 		if err := tgtDB.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM "%s"`, table)).Scan(&tgtCount); err != nil {
@@ -1140,8 +1178,8 @@ func verifyChecksums(srcDB *sql.DB, tgtDB *DB, snapshot map[string][]map[string]
 		}
 
 		// Compute hash of source and target for this table
-		srcHash := hashRows(snapshot[table])
-		tgtHash, err := hashPGTable(tgtDB, table)
+		srcHash := hashRows(srcRows)
+		tgtHash, err := hashPGTable(tgtDB, table, sourceCols)
 		if err != nil {
 			return fmt.Errorf("hash %s: %w", table, err)
 		}
@@ -1154,9 +1192,17 @@ func verifyChecksums(srcDB *sql.DB, tgtDB *DB, snapshot map[string][]map[string]
 }
 
 func hashRows(rows []map[string]interface{}) []byte {
+	// The source snapshot comes from an unordered SELECT *, so sort rows by
+	// their canonical serialization before hashing — otherwise the hash
+	// depends on the source row order and never matches the target side
+	// (which orders by primary key).
+	sortedRows := append([]map[string]interface{}(nil), rows...)
+	sort.SliceStable(sortedRows, func(i, j int) bool {
+		return serializeRowForHash(sortedRows[i]) < serializeRowForHash(sortedRows[j])
+	})
+
 	h := sha256.New()
-	// Sort keys for deterministic serialization
-	for _, row := range rows {
+	for _, row := range sortedRows {
 		keys := make([]string, 0, len(row))
 		for k := range row {
 			keys = append(keys, k)
@@ -1164,14 +1210,37 @@ func hashRows(rows []map[string]interface{}) []byte {
 		sort.Strings(keys)
 		for _, k := range keys {
 			h.Write([]byte(k))
-			h.Write([]byte(fmt.Sprintf("%v", row[k])))
+			h.Write([]byte(fmt.Sprintf("%v", normalizeHashValue(row[k]))))
 		}
 	}
 	return h.Sum(nil)
 }
 
-func hashPGTable(db *DB, table string) ([]byte, error) {
-	rows, err := db.Query(fmt.Sprintf(`SELECT * FROM "%s" ORDER BY id`, table))
+// serializeRowForHash renders a row as a deterministic "k=v,k=v,..." string so
+// rows can be ordered independently of the source query plan.
+func serializeRowForHash(row map[string]interface{}) string {
+	keys := make([]string, 0, len(row))
+	for k := range row {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(fmt.Sprintf("%v", normalizeHashValue(row[k])))
+		b.WriteByte(',')
+	}
+	return b.String()
+}
+
+// hashPGTable hashes the target table restricted to the given allowed column
+// set (the columns present in the source snapshot). A target created by
+// store.AutoMigrate carries extra Go-only columns; hashing only the migrated
+// column set keeps the checksum a pure data-copy verification that works for
+// raw TypeScript sources as well as already-migrated ones.
+func hashPGTable(db *DB, table string, allowedCols map[string]struct{}) ([]byte, error) {
+	rows, err := db.Query(fmt.Sprintf(`SELECT * FROM "%s"`, table))
 	if err != nil {
 		return nil, err
 	}
@@ -1182,7 +1251,17 @@ func hashPGTable(db *DB, table string) ([]byte, error) {
 		return nil, err
 	}
 
-	h := sha256.New()
+	// Scan the target side into the same map form hashRows consumes, keeping
+	// only the migrated columns, then reuse hashRows so both sides hash under
+	// the identical canonical (sorted-key, sorted-row) serialization. An
+	// ORDER BY in the query would be insufficient: the source snapshot's row
+	// order is arbitrary, so the row order must come from the row content.
+	colIndex := make(map[string]int, len(cols))
+	for i, col := range cols {
+		colIndex[col] = i
+	}
+
+	var scanned []map[string]interface{}
 	for rows.Next() {
 		values := make([]interface{}, len(cols))
 		valuePtrs := make([]interface{}, len(cols))
@@ -1192,12 +1271,32 @@ func hashPGTable(db *DB, table string) ([]byte, error) {
 		if err := rows.Scan(valuePtrs...); err != nil {
 			return nil, err
 		}
-		for i, col := range cols {
-			h.Write([]byte(col))
-			h.Write([]byte(fmt.Sprintf("%v", values[i])))
+		row := make(map[string]interface{}, len(cols))
+		for col, i := range colIndex {
+			if _, ok := allowedCols[col]; ok {
+				row[col] = normalizeHashValue(values[i])
+			}
 		}
+		scanned = append(scanned, row)
 	}
-	return h.Sum(nil), rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return hashRows(scanned), nil
+}
+
+// normalizeHashValue canonicalizes values that scan differently across
+// dialects so checksums agree on both sides of a migration: SQLite stores
+// booleans as INTEGER 0/1 while PostgreSQL scans them as bool true/false.
+func normalizeHashValue(v interface{}) interface{} {
+	if b, ok := v.(bool); ok {
+		if b {
+			return int64(1)
+		}
+		return int64(0)
+	}
+	return v
 }
 
 // ---- Drift guard ----

--- a/store/open.go
+++ b/store/open.go
@@ -433,10 +433,42 @@ func configurePostgresPool(db *DB, pool PostgresPoolConfig) error {
 	return nil
 }
 
-// EnsureDataDir creates the data directory if it does not exist.
-func EnsureDataDir(dataDir string) error {
-	if dataDir == "" || dataDir == ":memory:" {
-		return nil
+// probeSQLiteWritable verifies, before SQLite opens the file, that the data
+// directory (and an existing database file) are writable by the current
+// process. The container image runs as a non-root user (uid 1001), so a Docker
+// bind-mounted data directory owned by root produces cryptic failures later:
+// "unable to open database file" on fresh installs and "attempt to write a
+// readonly database" when migrating data created by the old root-running
+// TypeScript container. Fail fast with an actionable fix instead.
+func probeSQLiteWritable(dbPath string) error {
+	dir := filepath.Dir(dbPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("store: failed to create data directory %q: %w", dir, err)
 	}
-	return os.MkdirAll(filepath.Dir(dataDir), 0755)
+
+	// An existing database file (e.g. hub.db left behind by the TypeScript
+	// container) must be writable, not just the directory.
+	if _, err := os.Stat(dbPath); err == nil {
+		file, openErr := os.OpenFile(dbPath, os.O_WRONLY, 0)
+		if openErr != nil {
+			return writableDataDirError(dir)
+		}
+		_ = file.Close()
+	}
+
+	// WAL mode creates sibling files (-wal/-shm), so the directory itself must
+	// accept new files, not only the existing database file.
+	probe, err := os.CreateTemp(dir, ".metapi-write-probe-*")
+	if err != nil {
+		return writableDataDirError(dir)
+	}
+	_ = probe.Close()
+	_ = os.Remove(probe.Name())
+	return nil
+}
+
+func writableDataDirError(dir string) error {
+	return fmt.Errorf(
+		"store: data directory %q is not writable by the current process (uid %d). The metapi image runs as non-root uid 1001 — on the Docker host, make the mounted data directory writable by uid 1001, e.g. 'chown -R 1001:1001 <host-data-dir>' or 'chmod -R a+rwX <host-data-dir>'",
+		dir, os.Getuid())
 }

--- a/store/writable_test.go
+++ b/store/writable_test.go
@@ -1,0 +1,69 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProbeSQLiteWritableWritableDir(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "hub.db")
+	if err := probeSQLiteWritable(dbPath); err != nil {
+		t.Fatalf("probeSQLiteWritable(writable dir) = %v, want nil", err)
+	}
+	// The probe must not create the database file itself.
+	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
+		t.Fatalf("probe created the database file: %v", err)
+	}
+}
+
+func TestProbeSQLiteWritableExistingWritableFile(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "hub.db")
+	if err := os.WriteFile(dbPath, []byte("stub"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := probeSQLiteWritable(dbPath); err != nil {
+		t.Fatalf("probeSQLiteWritable(existing writable file) = %v, want nil", err)
+	}
+}
+
+func TestProbeSQLiteWritableNonWritableDir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission checks are bypassed for root")
+	}
+	dir := filepath.Join(t.TempDir(), "data")
+	if err := os.MkdirAll(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	err := probeSQLiteWritable(filepath.Join(dir, "hub.db"))
+	if err == nil {
+		t.Fatal("probeSQLiteWritable(non-writable dir) = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "chown") {
+		t.Fatalf("error should carry the chown hint, got: %v", err)
+	}
+}
+
+func TestProbeSQLiteWritableNonWritableFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission checks are bypassed for root")
+	}
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "hub.db")
+	if err := os.WriteFile(dbPath, []byte("stub"), 0o444); err != nil {
+		t.Fatal(err)
+	}
+
+	err := probeSQLiteWritable(dbPath)
+	if err == nil {
+		t.Fatal("probeSQLiteWritable(non-writable file) = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "chown") {
+		t.Fatalf("error should carry the chown hint, got: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #849

## 问题（issue #849）

从 TS 版迁移到 Go 版后容器启动失败。根因不是迁移逻辑，而是 **Docker 数据目录权限**：Go 镜像以非 root **uid 1001** 运行（`USER appuser`），而 TS 版容器以 root 运行；`./data:/app/data` bind mount 会覆盖镜像内属主，宿主机 `hub.db`/目录归 root → uid 1001 写不进去，产生两条报错：

- 带旧库迁移：`attempt to write a readonly database (8)`
- 全新启动：`PRAGMA journal_mode=WAL: unable to open database file (14)`

## 修复

**启动前可写性探针**（`store/open.go` `probeSQLiteWritable`）：在 SQLite 打开前探测数据目录 + 既有库文件可写性，不可写时报可操作的 `chown -R 1001:1001 <dir>` / `chmod` 提示并快速失败，替代原先的隐晦 SQLite 报错。接入服务器 bootstrap 与迁移目标库；删除被取代的死代码 `EnsureDataDir`。

**迁移源只读承诺**（`store/migrate_runner.go`）：源库去掉 `_journal_mode=WAL`（兑现文档「只读源库」承诺，只读源不再失败）。

**`--verify` 校验和 4 处误报修复**（用真实 TS 数据库验证时发现）：
1. `hashPGTable` 原按物理列序哈希 → 限定为源侧实际列集合（列序无关，Go 追加列不误报）
2. settings 源侧过滤运行时键（`db_type`/`db_url`/`db_ssl`，本就有意不迁移）
3. `hashRows` 按规范化串排序（源侧 `SELECT *` 行序随机不再影响哈希）
4. 跨方言布尔规范化（SQLite `0/1` vs PG `true/false`）+ 去掉 settings 无 `id` 列的 `ORDER BY id`

**配置**：弱 `ACCOUNT_CREDENTIAL_SECRET` 报错点名环境变量并说明 `AUTH_TOKEN` 回退行为。

**文档**：README / docker-compose.prod / deployment / migration 补「命名卷零配置 vs bind mount + chown」「`ACCOUNT_CREDENTIAL_SECRET`」「版本锁定」，与 uid 1001 运行模型一致。

## 测试

- 新增 `store/writable_test.go`（探针 4 用例；权限用例在 non-root 下实跑通过，root 下自动 skip）
- 新增 `store/checksum_test.go`（行序无关 / 布尔规范化 / TS schema 序端到端 `--verify` 回归）
- `go build ./...`、`go vet`、`go test ./store/... ./config/... ./docs/... ./cmd/...` 全绿
- 裸 TS 源与 Go 迁移源 `--verify` 均 "All checksums match"

## 自查清单

- [x] 行为变更有回归测试（探针 + 校验和）
- [x] 无密钥/内部路径泄漏
- [x] SQLite + PostgreSQL 双 dialect 安全（本 PR 不改 SQL 方言路径）
- [x] 更新了 `docs/`（deployment / migration / README / compose）