### PR TITLE
chore: scrub dev-machine absolute paths from committed docs/tooling

### DIFF
--- a/docs/internal/log.md
+++ b/docs/internal/log.md
@@ -7,7 +7,7 @@
 
 ## 2026-08-20 — 仓库店头重建：docs 公私分离 + README/Diátaxis 文档集 + llms.txt（#872 #873）
 
-对照原版 TS 仓库（cita-777/metapi，clone 于 `/root/metapi/metapi-ts`）与 2026 GitHub 开源最佳实践（Diátaxis 文档四象限、紧迫度递减 README 序、徽章 3-5 个上限、死链 CI 自动化、llms.txt）重做仓库对外门面：
+对照原版 TS 仓库（cita-777/metapi，已 clone 到本机对照）与 2026 GitHub 开源最佳实践（Diátaxis 文档四象限、紧迫度递减 README 序、徽章 3-5 个上限、死链 CI 自动化、llms.txt）重做仓库对外门面：
 
 - **docs 公私分离（#872）**：按受众边界重组 `docs/`——用户/贡献者文档留在 `docs/` 根（api/architecture/deployment/migration/testing/assets），维护者流程文档全部移入 `docs/internal/`（STATE/log/MASTER roadmap/benchmark/git-workflow/residual 说明/design/analysis/progress）。内部上下文与对外文档结构性隔离，不再可能渗进店面。门禁测试（`docs/doc_hygiene_test.go`）把边界变成机器断言：`TestStorefrontDoesNotLinkInternalDocs`（README 禁深链 internal）+ `TestRelativeMarkdownLinksResolve`（全站 markdown 相对链接必须可解析，抓出 1 个存量死链）。全部交叉引用同步（AGENTS.md/web/AGENTS.md/CONTRIBUTING.md/docs 地图/Go doc 指针）。
 - **对外店头重建（#873）**：README.md/README_EN.md 重写——hero + 徽章裁剪到 5 个、8 张 retina 截图墙（2x DPR webp，`screenshot-scan` 加 DPR 支持）、痛点表、copy-paste 快速上手、首个 `/v1` curl 示例、精简配置节指向新 reference。补齐 Diátaxis 四象限公开文档：`getting-started.md`（tutorial）/ `configuration.md`（reference，完整 env 矩阵）/ `client-integration.md`（how-to：Cursor/Claude Code/Codex/Open WebUI + 配置导出）/ `faq.md`（诚实问答）。根目录 `llms.txt`：面向 coding agent 的精选索引（一句描述 + 纯 markdown 链接，内部文档明确排除）。顺手清除 `.env.example` 指向已不存在 analysis 文档的残留指针；仓库 topics 已设置为 ai-aggregation/api-gateway/go/llm/metapi/new-api/one-api/openai/react/self-hosted/single-binary。

--- a/web/scripts/screenshot-scan.mjs
+++ b/web/scripts/screenshot-scan.mjs
@@ -8,15 +8,19 @@
 //
 // Usage:
 //   BASE_URL=http://127.0.0.1:4099 AUTH_TOKEN=dev-admin-token-123 \
-//     OUT_DIR=/root/metapi-shots node scripts/screenshot-scan.mjs
+//     OUT_DIR=<output-dir> node scripts/screenshot-scan.mjs
 
 import { mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { chromium } from 'playwright'
 
 const BASE_URL = process.env.BASE_URL ?? 'http://127.0.0.1:4099'
 const AUTH_TOKEN = process.env.AUTH_TOKEN ?? 'dev-admin-token-123'
-const OUT_DIR = process.env.OUT_DIR ?? '/root/metapi-shots'
+// Portable default: OS temp dir. Override OUT_DIR to keep screenshots
+// somewhere durable (e.g. when collecting README gallery material).
+const OUT_DIR = process.env.OUT_DIR ?? join(tmpdir(), 'metapi-shots')
 // Retina capture by default so README screenshots stay crisp on HiDPI screens.
 const DEVICE_SCALE = Number(process.env.DPR ?? '2')
 


### PR DESCRIPTION
## 改动摘要

清理由 leak-guard 边界复核标记的两处**开发机绝对路径泄漏**（违反内外边界规则——公开仓不应出现开发机路径）：

- **`docs/internal/log.md`**：08-20 店头重建里程碑注记中去掉绝对 clone 路径，改为仅按名称引用上游仓（cita-777/metapi）。
- **`web/scripts/screenshot-scan.mjs`**：`OUT_DIR` 默认值原为写死的开发机路径——既是工作区路径泄漏，也对其他贡献者不可移植。改为 `join(tmpdir(), 'metapi-shots')`（OS 临时目录，可移植）；保留 `OUT_DIR` 环境变量覆盖用于持久输出。提交源码中不含任何机器路径字面量。

## 类型

- [x] docs / chore（文档或工程维护）

## 测试验证

- [x] `node --check` 语法通过
- [x] `go test ./docs/ -count=1` 全绿（log.md 为 markdown，门禁含死链检查）
- [x] 全仓 tracked 文件扫描：`/root/metapi` 类标记 0 命中（main.yml 的 `/tmp/metapi-*` 为合法 CI 临时日志路径，保留）

## 自查清单

- [x] 无密钥/内部路径泄漏（本 PR 即为消除此类泄漏）
- [x] 用户可见文案已走 i18n（本 PR 无 UI 文案）
- [x] 行为变更已补充/更新测试（截图工具无行为变更，OUT_DIR 覆盖语义不变）