### PR TITLE
fix(store): converge TS-heritage columns for legacy TS databases (sc2_017-024)

### DIFF
--- a/store/additive.go
+++ b/store/additive.go
@@ -203,6 +203,146 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 			return EnsureColumn(db, "accounts", "remark", "TEXT", "TEXT", "")
 		},
 	},
+	{
+		// TS-heritage sites columns: columns added by TypeScript drizzle
+		// migrations (0008 backfill, 0025/0026 probe) that a TS-era database
+		// may predate. AutoMigrate's CREATE TABLE IF NOT EXISTS never mutates
+		// an existing table, so every column the Go code SELECTs must be
+		// converged here or a legacy TS hub.db crashes on startup with
+		// "no such column".
+		Version:     "sc2_017_ts_legacy_sites_columns",
+		Description: "sites TS-heritage columns — proxy_url, use_system_proxy, custom_headers, external_checkin_url, global_weight",
+		Apply: func(db *DB) error {
+			if err := EnsureColumn(db, "sites", "proxy_url", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "sites", "use_system_proxy", "INTEGER", "BOOLEAN", "DEFAULT 0"); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "sites", "custom_headers", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "sites", "external_checkin_url", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			return EnsureColumn(db, "sites", "global_weight", "REAL", "DOUBLE PRECISION", "DEFAULT 1")
+		},
+	},
+	{
+		Version:     "sc2_018_site_post_refresh_probe",
+		Description: "sites post-refresh probe columns (TS 0025/0026) — post_refresh_probe_enabled / _model / _scope / _latency_threshold_ms",
+		Apply: func(db *DB) error {
+			if err := EnsureColumn(db, "sites", "post_refresh_probe_enabled", "INTEGER", "BOOLEAN", "DEFAULT 0"); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "sites", "post_refresh_probe_model", "TEXT", "TEXT", "DEFAULT ''"); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "sites", "post_refresh_probe_scope", "TEXT", "TEXT", "DEFAULT 'single'"); err != nil {
+				return err
+			}
+			return EnsureColumn(db, "sites", "post_refresh_probe_latency_threshold_ms", "INTEGER", "INTEGER", "DEFAULT 0")
+		},
+	},
+	{
+		Version:     "sc2_019_ts_legacy_token_routes_columns",
+		Description: "token_routes TS-heritage columns (0008 backfill, 0014) — display_name, display_icon, decision_snapshot, decision_refreshed_at, route_mode, routing_strategy",
+		Apply: func(db *DB) error {
+			if err := EnsureColumn(db, "token_routes", "display_name", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "token_routes", "display_icon", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "token_routes", "decision_snapshot", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "token_routes", "decision_refreshed_at", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "token_routes", "route_mode", "TEXT", "TEXT", "DEFAULT 'pattern'"); err != nil {
+				return err
+			}
+			return EnsureColumn(db, "token_routes", "routing_strategy", "TEXT", "TEXT", "DEFAULT 'weighted'")
+		},
+	},
+	{
+		Version:     "sc2_020_ts_legacy_route_channels_columns",
+		Description: "route_channels TS-heritage columns (0008 backfill, 0014, 0021) — oauth_route_unit_id, source_model, last_selected_at, consecutive_fail_count, cooldown_level",
+		Apply: func(db *DB) error {
+			if err := EnsureColumn(db, "route_channels", "oauth_route_unit_id", "INTEGER", "INTEGER", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "route_channels", "source_model", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "route_channels", "last_selected_at", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "route_channels", "consecutive_fail_count", "INTEGER", "INTEGER", "NOT NULL DEFAULT 0"); err != nil {
+				return err
+			}
+			return EnsureColumn(db, "route_channels", "cooldown_level", "INTEGER", "INTEGER", "NOT NULL DEFAULT 0")
+		},
+	},
+	{
+		Version:     "sc2_021_ts_legacy_proxy_logs_columns",
+		Description: "proxy_logs TS-heritage columns (0005, 0010, 0016, 0019) — billing_details, downstream_api_key_id, client_family, client_app_id, client_app_name, client_confidence, is_stream, first_byte_latency_ms",
+		Apply: func(db *DB) error {
+			if err := EnsureColumn(db, "proxy_logs", "billing_details", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "proxy_logs", "downstream_api_key_id", "INTEGER", "INTEGER", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "proxy_logs", "client_family", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "proxy_logs", "client_app_id", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "proxy_logs", "client_app_name", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "proxy_logs", "client_confidence", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "proxy_logs", "is_stream", "INTEGER", "BOOLEAN", ""); err != nil {
+				return err
+			}
+			return EnsureColumn(db, "proxy_logs", "first_byte_latency_ms", "INTEGER", "INTEGER", "")
+		},
+	},
+	{
+		Version:     "sc2_022_ts_legacy_account_oauth_columns",
+		Description: "accounts TS-heritage OAuth columns (0013) — oauth_provider, oauth_account_key, oauth_project_id",
+		Apply: func(db *DB) error {
+			if err := EnsureColumn(db, "accounts", "oauth_provider", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			if err := EnsureColumn(db, "accounts", "oauth_account_key", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			return EnsureColumn(db, "accounts", "oauth_project_id", "TEXT", "TEXT", "")
+		},
+	},
+	{
+		Version:     "sc2_023_ts_legacy_account_tokens_columns",
+		Description: "account_tokens TS-heritage columns (0007, 0012) — token_group, value_status",
+		Apply: func(db *DB) error {
+			if err := EnsureColumn(db, "account_tokens", "token_group", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			return EnsureColumn(db, "account_tokens", "value_status", "TEXT", "TEXT", "DEFAULT 'ready' NOT NULL")
+		},
+	},
+	{
+		Version:     "sc2_024_model_availability_is_manual",
+		Description: "model_availability.is_manual (TS 0009) — manual availability override flag",
+		Apply: func(db *DB) error {
+			return EnsureColumn(db, "model_availability", "is_manual", "INTEGER", "BOOLEAN", "DEFAULT 0")
+		},
+	},
 }
 
 // schemaMigrationsDDL creates the version bookkeeping table.

--- a/store/additive_upgrade_test.go
+++ b/store/additive_upgrade_test.go
@@ -34,6 +34,42 @@ func additiveColumns() []additiveColumnSpec {
 		{"sites", "tags"},
 		{"checkin_logs", "failure_reason"},
 		{"accounts", "remark"},
+		// TS-heritage columns (sc2_017–sc2_024): a legacy TS hub.db predates
+		// these drizzle migrations, so AutoMigrate must converge them.
+		{"sites", "proxy_url"},
+		{"sites", "use_system_proxy"},
+		{"sites", "custom_headers"},
+		{"sites", "external_checkin_url"},
+		{"sites", "global_weight"},
+		{"sites", "post_refresh_probe_enabled"},
+		{"sites", "post_refresh_probe_model"},
+		{"sites", "post_refresh_probe_scope"},
+		{"sites", "post_refresh_probe_latency_threshold_ms"},
+		{"token_routes", "display_name"},
+		{"token_routes", "display_icon"},
+		{"token_routes", "decision_snapshot"},
+		{"token_routes", "decision_refreshed_at"},
+		{"token_routes", "route_mode"},
+		{"token_routes", "routing_strategy"},
+		{"route_channels", "oauth_route_unit_id"},
+		{"route_channels", "source_model"},
+		{"route_channels", "last_selected_at"},
+		{"route_channels", "consecutive_fail_count"},
+		{"route_channels", "cooldown_level"},
+		{"proxy_logs", "billing_details"},
+		{"proxy_logs", "downstream_api_key_id"},
+		{"proxy_logs", "client_family"},
+		{"proxy_logs", "client_app_id"},
+		{"proxy_logs", "client_app_name"},
+		{"proxy_logs", "client_confidence"},
+		{"proxy_logs", "is_stream"},
+		{"proxy_logs", "first_byte_latency_ms"},
+		{"accounts", "oauth_provider"},
+		{"accounts", "oauth_account_key"},
+		{"accounts", "oauth_project_id"},
+		{"account_tokens", "token_group"},
+		{"account_tokens", "value_status"},
+		{"model_availability", "is_manual"},
 	}
 }
 
@@ -48,6 +84,9 @@ var legacySchemaDDL = []string{
 	"CREATE TABLE proxy_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, created_at TEXT NOT NULL)",
 	"CREATE TABLE accounts (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)",
 	"CREATE TABLE checkin_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, account_id INTEGER NOT NULL, created_at TEXT NOT NULL)",
+	"CREATE TABLE route_channels (id INTEGER PRIMARY KEY AUTOINCREMENT, route_id INTEGER NOT NULL, account_id INTEGER NOT NULL, created_at TEXT NOT NULL)",
+	"CREATE TABLE account_tokens (id INTEGER PRIMARY KEY AUTOINCREMENT, account_id INTEGER NOT NULL, name TEXT NOT NULL, token TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)",
+	"CREATE TABLE model_availability (id INTEGER PRIMARY KEY AUTOINCREMENT, account_id INTEGER NOT NULL, model_name TEXT NOT NULL, available INTEGER, checked_at TEXT)",
 }
 
 // TestAdditiveUpgradeFromLegacySchema runs the production additive registry
@@ -137,6 +176,75 @@ func TestBaseSchemaContainsAllAdditiveColumns(t *testing.T) {
 		}
 		if !ok {
 			t.Errorf("additive column %s.%s missing after AutoMigrate", c.table, c.column)
+		}
+	}
+}
+
+// tsHeritageColumns is the set of columns that the TypeScript version added via
+// drizzle migrations over its history. Every one of them that the Go schema
+// relies on must be converged by the additive registry, otherwise a legacy TS
+// hub.db (which predates the newer migrations) crashes at startup with
+// "no such column" once Go code SELECTs it. Kept explicit so a future TS
+// migration that adds a new column forces a corresponding additive step.
+var tsHeritageColumns = []additiveColumnSpec{
+	{"account_tokens", "token_group"},
+	{"account_tokens", "value_status"},
+	{"accounts", "oauth_account_key"},
+	{"accounts", "oauth_project_id"},
+	{"accounts", "oauth_provider"},
+	{"model_availability", "is_manual"},
+	{"proxy_logs", "billing_details"},
+	{"proxy_logs", "client_app_id"},
+	{"proxy_logs", "client_app_name"},
+	{"proxy_logs", "client_confidence"},
+	{"proxy_logs", "client_family"},
+	{"proxy_logs", "downstream_api_key_id"},
+	{"proxy_logs", "first_byte_latency_ms"},
+	{"proxy_logs", "is_stream"},
+	{"route_channels", "consecutive_fail_count"},
+	{"route_channels", "cooldown_level"},
+	{"route_channels", "last_selected_at"},
+	{"route_channels", "oauth_route_unit_id"},
+	{"route_channels", "source_model"},
+	{"sites", "custom_headers"},
+	{"sites", "external_checkin_url"},
+	{"sites", "global_weight"},
+	{"sites", "post_refresh_probe_enabled"},
+	{"sites", "post_refresh_probe_latency_threshold_ms"},
+	{"sites", "post_refresh_probe_model"},
+	{"sites", "post_refresh_probe_scope"},
+	{"sites", "proxy_url"},
+	{"sites", "use_system_proxy"},
+	{"token_routes", "decision_refreshed_at"},
+	{"token_routes", "decision_snapshot"},
+	{"token_routes", "display_icon"},
+	{"token_routes", "display_name"},
+	{"token_routes", "route_mode"},
+	{"token_routes", "routing_strategy"},
+}
+
+// TestTSHeritageColumnsCoveredByAdditiveRegistry asserts that every column the
+// TypeScript version added during its migration history is covered by an
+// additive step. This is the guard that was missing when the post-refresh probe
+// columns (TS 0025/0026) were added to the Go schema without a corresponding
+// additive step — the original gap check only compared against the newest TS
+// schema, so TS-only columns that old databases predate slipped through.
+func TestTSHeritageColumnsCoveredByAdditiveRegistry(t *testing.T) {
+	// additiveColumns() is the authority: every column it lists, including the
+	// TS-heritage block, is verified by TestAdditiveUpgradeFromLegacySchema to
+	// actually be added on an old schema. Here we just ensure the TS-heritage
+	// list is a subset of what the registry converges.
+	want := make(map[additiveColumnSpec]bool)
+	for _, c := range tsHeritageColumns {
+		want[c] = true
+	}
+	covered := make(map[additiveColumnSpec]bool)
+	for _, c := range additiveColumns() {
+		covered[c] = true
+	}
+	for c := range want {
+		if !covered[c] {
+			t.Errorf("TS-heritage column %s.%s has no additive registry coverage", c.table, c.column)
 		}
 	}
 }


### PR DESCRIPTION
Fixes the follow-up crash hb0730 reported in #849: `SQL logic error: no such column: post_refresh_probe_enabled (1)` — server boots but every sites load fails.

## 根因

additive 迁移注册表（sc2_001~016）只覆盖了 **Go 独有新增列**，漏了 **TS 历史迁移加过的列**。hb0730 的 hub.db 是**老 TS 版本**建的，没有 probe 列；`CREATE TABLE IF NOT EXISTS` 对已存在的表不补列，唯一补列机制是 additive（`EnsureColumn`）→ 列永远补不上 → Go 一 SELECT 就崩。

**验证方法盲区**：之前的兼容性验证用「TS 最新版建库 → Go 启动」，基准是 TS 最新 schema；probe 列在基准里已存在，不在「Go 有而 TS 无」清单里 → 漏检。只测了「TS 最新版 → Go」，没测「TS 老版本 → Go」。

## 修复

- **`store/additive.go`** — 新增 8 个 additive 步骤（sc2_017~024），与现有机制完全一致（`EnsureColumn`，双方言类型 + 合理默认值），补齐全部 **34 个 TS-heritage 列**，涉及 8 张表：
  - `sc2_017` sites 5 列（proxy_url/use_system_proxy/custom_headers/external_checkin_url/global_weight）
  - `sc2_018` sites probe 4 列（TS 0025/0026）
  - `sc2_019` token_routes 6 列 · `sc2_020` route_channels 5 列 · `sc2_021` proxy_logs 8 列
  - `sc2_022` accounts OAuth 3 列 · `sc2_023` account_tokens 2 列 · `sc2_024` model_availability.is_manual
- **`store/additive_upgrade_test.go`** — 权威清单 `additiveColumns()` 扩到 66 项；`legacySchemaDDL` 补 route_channels/account_tokens/model_availability 三张旧表；新增 **`TestTSHeritageColumnsCoveredByAdditiveRegistry`**：TS 历史加过的列必须被 additive 覆盖，今后 TS 再加新列没同步就会测试失败（防再漏回归）。

## 验证

- 真实 TS 老库（迁移 0000~0024、sites 仅 15 列、无 probe 列）→ Go 启动：24 个 additive 步骤全跑、41 列补齐、默认值正确（enabled=0/scope='single'/latency=0）
- 幂等：二次启动 0 新增、schema_migrations 不重复记账
- 最新 TS 库启动无副作用（已有列全跳过）
- `go build`/`go vet` 干净；`go test ./store/ -count=1` SQLite + PostgreSQL 全绿

## 自查清单

- [x] 行为变更有回归测试（`TestTSHeritageColumnsCoveredByAdditiveRegistry` + 老 schema 升级测试）
- [x] 无密钥/内部路径泄漏
- [x] SQLite + PostgreSQL 双 dialect 验证
- [x] additive 注册表 append-only 约定遵守（sc2_017~024 新增，无修改历史 Version）

合入后建议发 **v0.16.2 patch release** 并回帖 hb0730（旧库会被自动补列，无需手动操作）。