### PR TITLE
fix(store): TS→Go migration hardening — honest verify, batch inserts, reverse-drift detection

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -14,7 +14,7 @@
 //
 // The migration matches the TS databaseMigrationService.ts behaviour:
 // - Per-column type coercion with fallback defaults
-// - JSON column serialization (13 columns across 5 tables)
+// - JSON column serialization (14 columns across 6 tables)
 // - FK-safe DELETE order during overwrite
 // - PostgreSQL sequence synchronization after insert (PG targets only;
 // SQLite AUTOINCREMENT handles itself)
@@ -62,6 +62,7 @@ func main() {
 		DryRun:    *flagDryRun,
 		Progress:  *flagProgress,
 		Verify:    *flagVerify,
+		BatchSize: *flagBatchSize,
 		LogWriter: os.Stderr,
 	})
 	if err != nil {
@@ -69,10 +70,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// batchSize is accepted for CLI compatibility but the row-by-row insert
-	// path is the only one the store.RunMigration implementation uses today.
-	_ = flagBatchSize
-
+	// RunMigration returns a nil summary together with an error (e.g. a
+	// failed --verify), so the err check above always exits before this
+	// print path is reached with a nil summary.
 	printSummary(summary)
 }
 

--- a/handler/admin/settings_database.go
+++ b/handler/admin/settings_database.go
@@ -253,10 +253,18 @@ func (h *databaseHandler) migrate(w http.ResponseWriter, r *http.Request) {
 		Dialect          string `json:"dialect"`
 		ConnectionString string `json:"connectionString"`
 		Ssl              bool   `json:"ssl"`
+		Overwrite        *bool  `json:"overwrite"`
 	}
 	if err := decodeJSONRequest(r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, "Invalid request body")
 		return
+	}
+
+	// Overwrite defaults to true (matches the TS admin migration behaviour);
+	// the admin UI sends an explicit flag so an operator can keep target data.
+	overwrite := true
+	if body.Overwrite != nil {
+		overwrite = *body.Overwrite
 	}
 
 	targetDialect, ok := normalizeRuntimeDatabaseDialect(body.Dialect)
@@ -301,7 +309,7 @@ func (h *databaseHandler) migrate(w http.ResponseWriter, r *http.Request) {
 		summary, runErr := store.RunMigration(store.RunMigrationOptions{
 			FromPath:  sourceURL,
 			ToURL:     targetURL,
-			Overwrite: true,
+			Overwrite: overwrite,
 			Progress:  true,
 			Verify:    false,
 			LogWriter: progress,

--- a/store/additive.go
+++ b/store/additive.go
@@ -408,30 +408,42 @@ func ApplyAdditiveMigrations(db *DB) error {
 	return applyAdditiveMigrations(db, enterpriseAdditiveSteps)
 }
 
-// applyAdditiveMigrations is the testable core that accepts an explicit step list.
+// applyAdditiveMigrations is the testable core that accepts an explicit step
+// list. It preserves the original signature; callers that need the count of
+// steps actually executed use applyAdditiveMigrationsCounted.
 func applyAdditiveMigrations(db *DB, steps []AdditiveStep) error {
+	_, err := applyAdditiveMigrationsCounted(db, steps)
+	return err
+}
+
+// applyAdditiveMigrationsCounted runs the additive core and reports how many
+// steps actually executed in this call. Steps already recorded in
+// schema_migrations are skipped and not counted, so a fully converged
+// database reports 0.
+func applyAdditiveMigrationsCounted(db *DB, steps []AdditiveStep) (int, error) {
 	if db == nil {
-		return fmt.Errorf("store: ApplyAdditiveMigrations: db is nil")
+		return 0, fmt.Errorf("store: ApplyAdditiveMigrations: db is nil")
 	}
 
 	if err := ensureSchemaMigrationsTable(db); err != nil {
-		return err
+		return 0, err
 	}
 
 	applied, err := appliedVersions(db)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
+	appliedCount := 0
 	for _, step := range steps {
 		if step.Version == "" {
-			return fmt.Errorf("store: additive step missing version")
+			return 0, fmt.Errorf("store: additive step missing version")
 		}
 		if _, ok := applied[step.Version]; ok {
 			continue
 		}
 		if step.Apply == nil {
-			return fmt.Errorf("store: additive step %s has nil Apply", step.Version)
+			return 0, fmt.Errorf("store: additive step %s has nil Apply", step.Version)
 		}
 
 		slog.Info("store: applying additive migration",
@@ -440,15 +452,16 @@ func applyAdditiveMigrations(db *DB, steps []AdditiveStep) error {
 			"dialect", db.Dialect,
 		)
 		if err := step.Apply(db); err != nil {
-			return fmt.Errorf("store: additive migration %s: %w", step.Version, err)
+			return 0, fmt.Errorf("store: additive migration %s: %w", step.Version, err)
 		}
 		if err := markMigrationApplied(db, step.Version, step.Description); err != nil {
-			return err
+			return 0, err
 		}
 		applied[step.Version] = struct{}{}
+		appliedCount++
 	}
 
-	return nil
+	return appliedCount, nil
 }
 
 // columnExists reports whether table.column is present.

--- a/store/additive_upgrade_test.go
+++ b/store/additive_upgrade_test.go
@@ -248,3 +248,82 @@ func TestTSHeritageColumnsCoveredByAdditiveRegistry(t *testing.T) {
 		}
 	}
 }
+
+// TestApplyAdditiveMigrationsCounted pins the startup summary contract used
+// by AutoMigrate: the counted core reports the number of steps actually
+// executed (first run on a legacy schema = every step; a converged re-run = 0).
+func TestApplyAdditiveMigrationsCounted(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	for _, ddl := range legacySchemaDDL {
+		if _, err := db.Exec(ddl); err != nil {
+			t.Fatalf("create legacy table: %v", err)
+		}
+	}
+
+	firstCount, err := applyAdditiveMigrationsCounted(db, enterpriseAdditiveSteps)
+	if err != nil {
+		t.Fatalf("first counted run: %v", err)
+	}
+	if firstCount != len(enterpriseAdditiveSteps) {
+		t.Fatalf("first run applied %d steps, want %d", firstCount, len(enterpriseAdditiveSteps))
+	}
+
+	secondCount, err := applyAdditiveMigrationsCounted(db, enterpriseAdditiveSteps)
+	if err != nil {
+		t.Fatalf("second counted run: %v", err)
+	}
+	if secondCount != 0 {
+		t.Fatalf("converged re-run applied %d steps, want 0", secondCount)
+	}
+}
+
+// TestAutoMigrateConvergesLegacySchema pins the AutoMigrate side of the
+// startup summary: when an install's additive bookkeeping is missing
+// (simulated by wiping schema_migrations on a converged schema), AutoMigrate
+// re-applies every step idempotently, re-records the bookkeeping, and a
+// subsequent counted run converges to zero new applications.
+func TestAutoMigrateConvergesLegacySchema(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	// Fresh install first: full schema + bookkeeping.
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate fresh: %v", err)
+	}
+
+	// Wipe the bookkeeping to simulate an install whose schema predates the
+	// additive registry. The columns already exist, so the steps re-run as
+	// no-op EnsureColumn calls and only the bookkeeping converges.
+	if _, err := db.Exec(`DELETE FROM schema_migrations`); err != nil {
+		t.Fatalf("wipe schema_migrations: %v", err)
+	}
+
+	// Second AutoMigrate must re-record every additive step.
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate after bookkeeping wipe: %v", err)
+	}
+	var recorded int
+	if err := db.QueryRow("SELECT COUNT(*) FROM schema_migrations").Scan(&recorded); err != nil {
+		t.Fatalf("count schema_migrations: %v", err)
+	}
+	if recorded != len(enterpriseAdditiveSteps) {
+		t.Fatalf("schema_migrations = %d after AutoMigrate, want %d", recorded, len(enterpriseAdditiveSteps))
+	}
+
+	// Now fully converged: the counted core reports 0 pending steps.
+	remaining, err := applyAdditiveMigrationsCounted(db, enterpriseAdditiveSteps)
+	if err != nil {
+		t.Fatalf("counted run after AutoMigrate: %v", err)
+	}
+	if remaining != 0 {
+		t.Fatalf("converged database still reports %d pending steps, want 0", remaining)
+	}
+}

--- a/store/bootstrap.go
+++ b/store/bootstrap.go
@@ -82,6 +82,14 @@ func EnsureRuntimeDatabase(cfg *config.Config) error {
 		return fmt.Errorf("bootstrap: auto-migration failed: %w", err)
 	}
 
+	// TS→Go reverse-drift detection (SQLite only, warn-only): a database
+	// produced by a NEWER TypeScript build may carry columns or migration
+	// journal entries this Go build has never seen; surface that at startup
+	// instead of crashing at the first SELECT (hb0730 failure mode).
+	if db.Dialect == DialectSQLite {
+		warnTSSchemaDrift(db)
+	}
+
 	activeDB = db
 	initialized = true
 

--- a/store/checksum_test.go
+++ b/store/checksum_test.go
@@ -82,8 +82,8 @@ func TestRunMigrationVerifyTSSchemaOrder(t *testing.T) {
 		"新API站A", "https://a.example.com", "new-api", "active", "sk-a", 1.0, 0, `["prod"]`); err != nil {
 		t.Fatalf("seed sites: %v", err)
 	}
-	if _, err := srcDB.Exec(`INSERT INTO sites (name, url, platform, status, api_key) VALUES (?, ?, ?, ?, ?)`,
-		"站B", "https://b.example.com", "one-api", "active", "sk-b"); err != nil {
+	if _, err := srcDB.Exec(`INSERT INTO sites (name, url, platform, status, api_key, global_weight, max_concurrency) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"站B", "https://b.example.com", "one-api", "active", "sk-b", 1.0, 0); err != nil {
 		t.Fatalf("seed sites 2: %v", err)
 	}
 	// Runtime DB settings keys are documented as filtered out of migrations;

--- a/store/migrate.go
+++ b/store/migrate.go
@@ -7,8 +7,10 @@ import (
 
 // AutoMigrate creates all 35 tables with indexes, unique constraints, foreign keys,
 // and check constraints. Uses CREATE TABLE IF NOT EXISTS for idempotency.
-// After the base bootstrap it runs ApplyAdditiveMigrations (schema_migrations
-// bookkeeping + ordered enterprise steps). Run on startup after Open().
+// After the base bootstrap it runs the additive enterprise steps
+// (schema_migrations bookkeeping + ordered ALTER TABLE upgrades) and logs a
+// one-line summary when legacy-schema convergence actually happened. Run on
+// startup after Open().
 func AutoMigrate(db *DB) error {
 	dialect := db.Dialect
 	slog.Info("store: running auto-migration", "dialect", dialect)
@@ -102,8 +104,17 @@ func AutoMigrate(db *DB) error {
 
 	// Additive upgrades for existing installs (ALTER TABLE ADD COLUMN, etc.).
 	// CREATE TABLE IF NOT EXISTS alone never mutates an already-created table.
-	if err := ApplyAdditiveMigrations(db); err != nil {
+	// The counted variant reports how many steps actually executed so startup
+	// logs can summarize schema convergence for old databases.
+	appliedAdditive, err := applyAdditiveMigrationsCounted(db, enterpriseAdditiveSteps)
+	if err != nil {
 		return err
+	}
+	if appliedAdditive > 0 {
+		slog.Info("store: converged legacy schema",
+			"additive_migrations", appliedAdditive,
+			"dialect", dialect,
+		)
 	}
 
 	slog.Info("store: auto-migration complete", "dialect", dialect)

--- a/store/migrate_runner.go
+++ b/store/migrate_runner.go
@@ -6,7 +6,7 @@
 //
 // The migration matches the TS databaseMigrationService.ts behaviour:
 // - Per-column type coercion with fallback defaults
-// - JSON column serialization (13 columns across 5 tables)
+// - JSON column serialization (14 columns across 6 tables)
 // - FK-safe DELETE order during overwrite
 // - PostgreSQL sequence synchronization after insert (PG targets only;
 // SQLite AUTOINCREMENT handles itself)
@@ -49,6 +49,10 @@ type RunMigrationOptions struct {
 	Progress bool
 	// Verify computes row-count + hash checksums after migration.
 	Verify bool
+	// BatchSize groups consecutive same-table rows into multi-row INSERT
+	// statements of at most BatchSize rows. <= 0 keeps the row-by-row path
+	// (the TS default); the CLI --batch-size flag maps here.
+	BatchSize int
 	// LogWriter receives structural + progress log lines. nil discards output;
 	// the CLI passes os.Stderr, the admin handler passes a task-log-backed writer
 	// so /api/tasks/{id} polling surfaces meaningful migration progress.
@@ -128,7 +132,7 @@ func asNullableBool(v interface{}) interface{} {
 // ---- JSON column serialization (matching TS serializeColumnValue) ----
 
 // jsonColumnSet records which columns have logical type 'json'.
-// 14 columns across 5 tables, matching the TS schemaContract.json logical types.
+// 14 columns across 6 tables, matching the TS schemaContract.json logical types.
 // (downstream_api_keys.tags is intentionally absent: it migrated as a plain
 // TEXT passthrough before this refactor and keeps that behavior.)
 var jsonColumnSet = map[string]bool{
@@ -331,24 +335,34 @@ func RunMigration(opts RunMigrationOptions) (*MigrationSummary, error) {
 		}
 	}
 
-	// 9. Insert all rows (dialect-specific placeholders)
+	// 9. Insert all rows (dialect-specific placeholders). BatchSize > 0 groups
+	// consecutive same-table rows into multi-row INSERT statements of at most
+	// BatchSize rows; BatchSize <= 0 keeps the row-by-row path (TS default).
 	fmt.Fprintf(logw, "\nInserting %d rows...\n", len(inserts))
 	inserted := 0
 	start := time.Now()
 
-	for _, stmt := range inserts {
+	for _, group := range groupInsertStatements(inserts, opts.BatchSize) {
 		var sqlText string
 		var args []interface{}
-		if toSQLite {
-			sqlText, args = buildInsertSQLite(stmt)
+		if len(group) == 1 {
+			if toSQLite {
+				sqlText, args = buildInsertSQLite(group[0])
+			} else {
+				sqlText, args = buildInsertPG(group[0])
+			}
 		} else {
-			sqlText, args = buildInsertPG(stmt)
+			if toSQLite {
+				sqlText, args = buildInsertBatchSQLite(group)
+			} else {
+				sqlText, args = buildInsertBatchPG(group)
+			}
 		}
 		if _, err := tx.Exec(sqlText, args...); err != nil {
-			return nil, fmt.Errorf("insert into %s: %w", stmt.table, err)
+			return nil, fmt.Errorf("insert into %s: %w", group[0].table, err)
 		}
-		inserted++
-		if progress && inserted%100 == 0 {
+		inserted += len(group)
+		if progress && (inserted%100 == 0 || inserted == len(inserts)) {
 			elapsed := time.Since(start)
 			fmt.Fprintf(logw, "  %d/%d rows inserted (%s elapsed)\n", inserted, len(inserts), elapsed.Round(time.Millisecond))
 		}
@@ -378,14 +392,16 @@ func RunMigration(opts RunMigrationOptions) (*MigrationSummary, error) {
 
 	summary := buildSummary(snapshot, toURL, overwrite)
 
-	// 12. Verify checksums (if requested)
+	// 12. Verify checksums (if requested). A verification failure is a hard
+	// error: the copy demonstrably diverged from the source, so the CLI must
+	// exit non-zero instead of printing a "warning" and claiming success.
 	if verify {
 		fmt.Fprintf(logw, "\nVerifying checksums...\n")
 		if err := verifyChecksums(srcDB, tgtDB, snapshot); err != nil {
-			fmt.Fprintf(logw, "  Verification warning: %v\n", err)
-		} else {
-			fmt.Fprintf(logw, "  All checksums match.\n")
+			fmt.Fprintf(logw, "  Verification failed: %v\n", err)
+			return nil, fmt.Errorf("verification failed: %w", err)
 		}
+		fmt.Fprintf(logw, "  All checksums match.\n")
 	}
 
 	return summary, nil
@@ -1135,6 +1151,100 @@ func buildInsertSQLite(s insertStmt) (string, []interface{}) {
 	return sqlText, s.values
 }
 
+// groupInsertStatements splits the flat row list into executable groups.
+// Consecutive statements that share table + column list are merged into one
+// multi-row INSERT of at most batchSize rows; batchSize <= 0 degenerates to
+// single-row groups (the row-by-row TS default). buildStatements emits
+// per-table runs in order, so grouping never reorders rows.
+func groupInsertStatements(inserts []insertStmt, batchSize int) [][]insertStmt {
+	if batchSize <= 0 {
+		batchSize = 1
+	}
+	var groups [][]insertStmt
+	var current []insertStmt
+	flush := func() {
+		if len(current) > 0 {
+			groups = append(groups, current)
+			current = nil
+		}
+	}
+	for _, stmt := range inserts {
+		if len(current) > 0 {
+			sameShape := current[0].table == stmt.table && equalStringSlices(current[0].columns, stmt.columns)
+			if !sameShape || len(current) >= batchSize {
+				flush()
+			}
+		}
+		current = append(current, stmt)
+	}
+	flush()
+	return groups
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// buildInsertBatchSQLite renders one multi-row INSERT for a group of
+// statements sharing the same table + column list: one VALUES tuple per row,
+// all rows using "?" placeholders.
+func buildInsertBatchSQLite(stmts []insertStmt) (string, []interface{}) {
+	first := stmts[0]
+	quotedCols := make([]string, len(first.columns))
+	for i, c := range first.columns {
+		quotedCols[i] = `"` + c + `"`
+	}
+	rowPlaceholders := "(" + strings.TrimSuffix(strings.Repeat("?, ", len(first.columns)), ", ") + ")"
+	tuples := make([]string, len(stmts))
+	args := make([]interface{}, 0, len(stmts)*len(first.columns))
+	for i, s := range stmts {
+		tuples[i] = rowPlaceholders
+		args = append(args, s.values...)
+	}
+	sqlText := fmt.Sprintf("INSERT INTO \"%s\" (%s) VALUES %s",
+		first.table,
+		strings.Join(quotedCols, ", "),
+		strings.Join(tuples, ", "),
+	)
+	return sqlText, args
+}
+
+// buildInsertBatchPG renders one multi-row INSERT for a group of statements
+// sharing the same table + column list, with $N placeholders numbered across
+// all rows.
+func buildInsertBatchPG(stmts []insertStmt) (string, []interface{}) {
+	first := stmts[0]
+	quotedCols := make([]string, len(first.columns))
+	for i, c := range first.columns {
+		quotedCols[i] = quoteIdentPG(c)
+	}
+	colsPerRow := len(first.columns)
+	tuples := make([]string, len(stmts))
+	args := make([]interface{}, 0, len(stmts)*colsPerRow)
+	for i, s := range stmts {
+		placeholders := make([]string, colsPerRow)
+		for j := range placeholders {
+			placeholders[j] = fmt.Sprintf("$%d", i*colsPerRow+j+1)
+		}
+		tuples[i] = "(" + strings.Join(placeholders, ", ") + ")"
+		args = append(args, s.values...)
+	}
+	sqlText := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s",
+		first.table,
+		strings.Join(quotedCols, ", "),
+		strings.Join(tuples, ", "),
+	)
+	return sqlText, args
+}
+
 // ---- Checksum verification ----
 
 func verifyChecksums(srcDB *sql.DB, tgtDB *DB, snapshot map[string][]map[string]interface{}) error {
@@ -1377,8 +1487,14 @@ func diffColumnSets(expected, actual []string) (missing, extra []string) {
 // ---- Summary ----
 
 func buildSummary(snapshot map[string][]map[string]interface{}, toURL string, overwrite bool) *MigrationSummary {
+	// Report the TARGET's real dialect (previously hardcoded "postgres",
+	// which mislabeled SQLite→SQLite copies in the CLI summary).
+	dialect := "postgres"
+	if isSQLiteTarget(toURL) {
+		dialect = "sqlite"
+	}
 	s := &MigrationSummary{
-		Dialect:    "postgres",
+		Dialect:    dialect,
 		Connection: maskPassword(toURL),
 		Overwrite:  overwrite,
 		Version:    "live-db-snapshot",

--- a/store/migrate_runner_test.go
+++ b/store/migrate_runner_test.go
@@ -1,9 +1,12 @@
 package store
 
 import (
+	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -204,10 +207,218 @@ func TestBuildersMatchStoreSchema(t *testing.T) {
 	}
 }
 
-// TestBuildSitesIncludesPreviouslyDroppedColumns pins the exact regression:
-// before the refactor buildSites copied only 15 columns and silently dropped
-// max_concurrency, the post_refresh_probe_* group,
-// custom_headers_override_request_headers and tags.
+// TestRunMigrationVerifyFailureReturnsError pins the CLI-honesty fix: a
+// checksum mismatch must surface as an error (and a nil summary) so
+// cmd/migrate exits non-zero instead of printing a "warning" and claiming
+// success. The mismatch is forced by pre-seeding the target with a row the
+// (empty) source lacks; Overwrite=false keeps the seed alive while passing
+// the target-state gate (which only inspects sites).
+func TestRunMigrationVerifyFailureReturnsError(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "source.db")
+	targetPath := filepath.Join(t.TempDir(), "target.db")
+
+	// 1. Source: canonical schema, zero rows.
+	srcDB, err := Open(DialectSQLite, sourcePath, false)
+	if err != nil {
+		t.Fatalf("open source: %v", err)
+	}
+	if err := AutoMigrate(srcDB); err != nil {
+		t.Fatalf("auto-migrate source: %v", err)
+	}
+	if err := srcDB.Close(); err != nil {
+		t.Fatalf("close source: %v", err)
+	}
+
+	// 2. Target: canonical schema plus one settings row the source lacks.
+	tgtSeed, err := Open(DialectSQLite, targetPath, false)
+	if err != nil {
+		t.Fatalf("open target seed: %v", err)
+	}
+	if err := AutoMigrate(tgtSeed); err != nil {
+		t.Fatalf("auto-migrate target seed: %v", err)
+	}
+	if _, err := tgtSeed.Exec(`INSERT INTO settings (key, value) VALUES (?, ?)`, "extra_key", "extra"); err != nil {
+		t.Fatalf("seed target settings: %v", err)
+	}
+	if err := tgtSeed.Close(); err != nil {
+		t.Fatalf("close target seed: %v", err)
+	}
+
+	// 3. Migrate with --verify: the target's extra settings row must trip the
+	// checksum comparison and RunMigration must fail.
+	summary, err := RunMigration(RunMigrationOptions{
+		FromPath:  sourcePath,
+		ToURL:     targetPath,
+		Overwrite: false,
+		Verify:    true,
+		LogWriter: io.Discard,
+	})
+	if err == nil {
+		t.Fatal("RunMigration with --verify succeeded despite a checksum mismatch, want error")
+	}
+	if summary != nil {
+		t.Fatalf("summary = %+v, want nil when verification fails", summary)
+	}
+}
+
+// TestBuildSummaryReportsTargetDialect pins the dialect fix: the summary must
+// describe the TARGET's real dialect (SQLite targets were previously
+// mislabeled "postgres").
+func TestBuildSummaryReportsTargetDialect(t *testing.T) {
+	empty := map[string][]map[string]interface{}{}
+
+	sqliteSummary := buildSummary(empty, "data/hub.db", true)
+	if sqliteSummary.Dialect != "sqlite" {
+		t.Errorf("SQLite target summary dialect = %q, want sqlite", sqliteSummary.Dialect)
+	}
+
+	sqliteURLSummary := buildSummary(empty, "sqlite://data/hub.db", true)
+	if sqliteURLSummary.Dialect != "sqlite" {
+		t.Errorf("sqlite:// target summary dialect = %q, want sqlite", sqliteURLSummary.Dialect)
+	}
+
+	pgSummary := buildSummary(empty, "postgres://host:5432/db", true)
+	if pgSummary.Dialect != "postgres" {
+		t.Errorf("PostgreSQL target summary dialect = %q, want postgres", pgSummary.Dialect)
+	}
+}
+
+// TestRunMigrationBatchInsertMatchesRowByRow pins the --batch-size
+// implementation: BatchSize=3 must land the same 10 rows a row-by-row
+// migration lands (same counts, same hashed content).
+func TestRunMigrationBatchInsertMatchesRowByRow(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "source.db")
+
+	srcDB, err := Open(DialectSQLite, sourcePath, false)
+	if err != nil {
+		t.Fatalf("open source: %v", err)
+	}
+	if err := AutoMigrate(srcDB); err != nil {
+		t.Fatalf("auto-migrate source: %v", err)
+	}
+	for i := 1; i <= 10; i++ {
+		// sites carries a UNIQUE (platform, url) constraint, so every row
+		// needs a distinct url.
+		url := fmt.Sprintf("https://batch-%02d.example.com", i)
+		if _, err := srcDB.Exec(
+			`INSERT INTO sites (name, url, platform, status, global_weight) VALUES (?, ?, ?, ?, ?)`,
+			fmt.Sprintf("site-%02d", i), url, "openai", "active", float64(i),
+		); err != nil {
+			t.Fatalf("seed site %d: %v", i, err)
+		}
+	}
+	if err := srcDB.Close(); err != nil {
+		t.Fatalf("close source: %v", err)
+	}
+
+	batchTarget := filepath.Join(t.TempDir(), "batch-target.db")
+	rowTarget := filepath.Join(t.TempDir(), "row-target.db")
+
+	batchSummary, err := RunMigration(RunMigrationOptions{
+		FromPath:  sourcePath,
+		ToURL:     batchTarget,
+		Overwrite: true,
+		BatchSize: 3,
+		LogWriter: io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("batched RunMigration: %v", err)
+	}
+	rowSummary, err := RunMigration(RunMigrationOptions{
+		FromPath:  sourcePath,
+		ToURL:     rowTarget,
+		Overwrite: true,
+		BatchSize: 0,
+		LogWriter: io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("row-by-row RunMigration: %v", err)
+	}
+	if batchSummary == nil || batchSummary.Rows["sites"] != 10 {
+		t.Fatalf("batched summary sites rows = %+v, want 10", batchSummary)
+	}
+	if rowSummary == nil || rowSummary.Rows["sites"] != 10 {
+		t.Fatalf("row-by-row summary sites rows = %+v, want 10", rowSummary)
+	}
+
+	// Both targets must contain the identical sites content (hashed under the
+	// same canonical serialization verifyChecksums uses).
+	batchDB, err := Open(DialectSQLite, batchTarget, false)
+	if err != nil {
+		t.Fatalf("open batch target: %v", err)
+	}
+	defer batchDB.Close()
+	rowDB, err := Open(DialectSQLite, rowTarget, false)
+	if err != nil {
+		t.Fatalf("open row target: %v", err)
+	}
+	defer rowDB.Close()
+
+	batchSnapshot, err := readAllTables(batchDB.DB.DB)
+	if err != nil {
+		t.Fatalf("read batch target: %v", err)
+	}
+	rowSnapshot, err := readAllTables(rowDB.DB.DB)
+	if err != nil {
+		t.Fatalf("read row target: %v", err)
+	}
+	if !bytes.Equal(hashRows(batchSnapshot["sites"]), hashRows(rowSnapshot["sites"])) {
+		t.Fatal("batched migration content differs from row-by-row migration")
+	}
+}
+
+// TestGroupInsertStatements pins the batching shape: BatchSize splits runs,
+// a column-list change breaks a run, and BatchSize <= 0 yields single rows.
+func TestGroupInsertStatements(t *testing.T) {
+	mk := func(table string, cols []string, n int) []insertStmt {
+		var out []insertStmt
+		for i := 0; i < n; i++ {
+			out = append(out, insertStmt{table: table, columns: cols, values: []interface{}{i}})
+		}
+		return out
+	}
+	inserts := append(mk("sites", []string{"id", "name"}, 5),
+		mk("accounts", []string{"id", "name"}, 1)...)
+
+	groups := groupInsertStatements(inserts, 3)
+	if len(groups) != 3 {
+		t.Fatalf("groups = %d, want 3 (3+2 sites, 1 accounts)", len(groups))
+	}
+	if len(groups[0]) != 3 || len(groups[1]) != 2 || len(groups[2]) != 1 {
+		t.Fatalf("group sizes = %d/%d/%d, want 3/2/1", len(groups[0]), len(groups[1]), len(groups[2]))
+	}
+	if groups[2][0].table != "accounts" {
+		t.Fatalf("third group table = %q, want accounts (column-list change must split)", groups[2][0].table)
+	}
+
+	single := groupInsertStatements(inserts, 0)
+	if len(single) != 6 {
+		t.Fatalf("row-by-row groups = %d, want 6", len(single))
+	}
+	for _, g := range single {
+		if len(g) != 1 {
+			t.Fatalf("row-by-row group size = %d, want 1", len(g))
+		}
+	}
+}
+
+// TestBuildInsertBatchPGNumbering pins the PostgreSQL batch builder: $N
+// placeholders must count across all rows in order.
+func TestBuildInsertBatchPGNumbering(t *testing.T) {
+	stmts := []insertStmt{
+		{table: "sites", columns: []string{"id", "name", "weight"}, values: []interface{}{int64(1), "a", 2.5}},
+		{table: "sites", columns: []string{"id", "name", "weight"}, values: []interface{}{int64(2), "b", 3.5}},
+	}
+	sqlText, args := buildInsertBatchPG(stmts)
+	wantTuple := "($1, $2, $3), ($4, $5, $6)"
+	if !strings.Contains(sqlText, wantTuple) {
+		t.Errorf("batch PG SQL = %q, want it to contain %q", sqlText, wantTuple)
+	}
+	if len(args) != 6 {
+		t.Fatalf("batch PG args = %d, want 6", len(args))
+	}
+}
+
 func TestBuildSitesIncludesPreviouslyDroppedColumns(t *testing.T) {
 	stmts := buildSites([]map[string]interface{}{{}})
 	if len(stmts) != 1 {

--- a/store/ts_schema_detect.go
+++ b/store/ts_schema_detect.go
@@ -1,0 +1,222 @@
+// ts_schema_detect.go implements startup-time reverse-drift detection for the
+// TS→Go migration: a SQLite database produced by a NEWER TypeScript build may
+// carry columns (or __drizzle_migrations journal entries) this Go build has
+// never seen. Without detection the old binary boots fine and only crashes
+// later, at SELECT time, with "no such column" (the hb0730 failure mode).
+//
+// Detection is deliberately warn-only. Unknown columns may be harmless, and
+// blocking startup would brick the older binary against any future TS
+// migration — the Go server must keep serving even when the TS side has moved
+// ahead.
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+)
+
+// knownLatestTSMigrationWhen is the `when` (epoch ms) of the newest entry in
+// the TypeScript drizzle migration journal (metapi-ts/drizzle/meta/_journal.json)
+// at the time this Go build was written. A database whose __drizzle_migrations
+// max(created_at) exceeds this value was produced by a newer TypeScript build.
+// When the TS side adds migrations, bump this constant (and keep an eye on the
+// reverse-migration column coverage).
+const knownLatestTSMigrationWhen int64 = 1776944000000
+
+// tsSchemaDriftResult describes what a reverse-drift scan found.
+type tsSchemaDriftResult struct {
+	// TSJournalNewer reports whether __drizzle_migrations carries a
+	// created_at newer than knownLatestTSMigrationWhen.
+	TSJournalNewer bool
+	// TSJournalMaxWhen is max(__drizzle_migrations.created_at); 0 when the
+	// journal is absent or empty.
+	TSJournalMaxWhen int64
+	// UnknownColumns lists table.column entries present in the database but
+	// absent from the Go authority schema, sorted.
+	UnknownColumns []string
+}
+
+// warnTSSchemaDrift runs the SQLite reverse-drift scan and emits Chinese
+// startup warnings. It is a no-op for non-SQLite databases and never blocks
+// startup: detection errors degrade to a warning of their own.
+func warnTSSchemaDrift(db *DB) {
+	if db == nil || db.Dialect != DialectSQLite {
+		return
+	}
+	result, err := detectTSSchemaDrift(db)
+	if err != nil {
+		slog.Warn("store: TS 反向漂移检测失败，跳过", "error", err)
+		return
+	}
+	if result == nil {
+		return
+	}
+	if result.TSJournalNewer {
+		slog.Warn("store: 数据库由更新版本的 TypeScript 创建，请升级 Metapi Go",
+			"ts_migration_when", result.TSJournalMaxWhen,
+			"known_latest_when", knownLatestTSMigrationWhen)
+	}
+	if len(result.UnknownColumns) > 0 {
+		slog.Warn("store: 检测到 Go 不认识的列（可能由更新版本的 TypeScript 写入，旧版本会忽略这些列直到查询报错），建议升级 Metapi Go",
+			"unknown_columns", strings.Join(result.UnknownColumns, ", "))
+	}
+}
+
+// detectTSSchemaDrift inspects a SQLite database for two signs that it was
+// created by a newer TypeScript build:
+//
+//  1. __drizzle_migrations (the TS migration journal marker) carries a
+//     created_at newer than knownLatestTSMigrationWhen.
+//  2. Known tables carry columns the Go authority schema does not have.
+//
+// The Go authority is built at scan time from a fresh in-memory SQLite
+// database (Open + AutoMigrate + PRAGMA table_info), so future Go DDL changes
+// are picked up automatically without a hand-maintained column list.
+// Returns (nil, nil) for nil or non-SQLite databases.
+func detectTSSchemaDrift(db *DB) (*tsSchemaDriftResult, error) {
+	if db == nil || db.Dialect != DialectSQLite {
+		return nil, nil
+	}
+	result := &tsSchemaDriftResult{}
+
+	// 1. TS journal age.
+	hasJournal, err := sqliteTableExists(db, "__drizzle_migrations")
+	if err != nil {
+		return nil, err
+	}
+	if hasJournal {
+		var maxWhen sql.NullFloat64
+		if err := db.QueryRow(`SELECT MAX(created_at) FROM "__drizzle_migrations"`).Scan(&maxWhen); err != nil {
+			return nil, fmt.Errorf("store: read __drizzle_migrations age: %w", err)
+		}
+		if maxWhen.Valid {
+			result.TSJournalMaxWhen = int64(maxWhen.Float64)
+			result.TSJournalNewer = result.TSJournalMaxWhen > knownLatestTSMigrationWhen
+		}
+	}
+
+	// 2. Unknown-column scan against the in-memory authority schema.
+	authority, err := buildAuthorityColumnMap()
+	if err != nil {
+		return nil, err
+	}
+	tables := make([]string, 0, len(authority))
+	for table := range authority {
+		tables = append(tables, table)
+	}
+	sort.Strings(tables)
+
+	for _, table := range tables {
+		actual, err := sqliteTableColumns(db, table)
+		if err != nil {
+			return nil, err
+		}
+		expected := authority[table]
+		for _, column := range actual {
+			if !expected[column] {
+				result.UnknownColumns = append(result.UnknownColumns, table+"."+column)
+			}
+		}
+	}
+	sort.Strings(result.UnknownColumns)
+	return result, nil
+}
+
+// buildAuthorityColumnMap builds the "Go knows these columns" authority from
+// a throwaway in-memory SQLite database: Open + AutoMigrate, then PRAGMA
+// table_info per user table. SQLite internal tables (sqlite_*) and the TS
+// journal (__drizzle_migrations) are excluded.
+func buildAuthorityColumnMap() (map[string]map[string]bool, error) {
+	memDB, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		return nil, fmt.Errorf("store: open authority schema db: %w", err)
+	}
+	defer memDB.Close()
+
+	if err := AutoMigrate(memDB); err != nil {
+		return nil, fmt.Errorf("store: build authority schema: %w", err)
+	}
+
+	tables, err := sqliteUserTables(memDB)
+	if err != nil {
+		return nil, err
+	}
+	authority := make(map[string]map[string]bool, len(tables))
+	for _, table := range tables {
+		columns, err := sqliteTableColumns(memDB, table)
+		if err != nil {
+			return nil, err
+		}
+		set := make(map[string]bool, len(columns))
+		for _, column := range columns {
+			set[column] = true
+		}
+		authority[table] = set
+	}
+	return authority, nil
+}
+
+// sqliteTableExists reports whether a table exists in sqlite_master.
+func sqliteTableExists(db *DB, table string) (bool, error) {
+	var found int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, table,
+	).Scan(&found); err != nil {
+		return false, fmt.Errorf("store: probe sqlite_master for %s: %w", table, err)
+	}
+	return found > 0, nil
+}
+
+// sqliteUserTables lists non-internal tables: sqlite_* internals and the TS
+// journal marker are excluded.
+func sqliteUserTables(db *DB) ([]string, error) {
+	rows, err := db.Query(`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("store: list sqlite tables: %w", err)
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("store: scan sqlite table name: %w", err)
+		}
+		if strings.HasPrefix(name, "sqlite_") || name == "__drizzle_migrations" {
+			continue
+		}
+		tables = append(tables, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: iterate sqlite tables: %w", err)
+	}
+	return tables, nil
+}
+
+// sqliteTableColumns returns a table's column names via PRAGMA table_info.
+// Unknown tables yield an empty list (PRAGMA returns no rows).
+func sqliteTableColumns(db *DB, table string) ([]string, error) {
+	rows, err := db.Query(fmt.Sprintf(`PRAGMA table_info(%s)`, quoteIdentSQLite(table)))
+	if err != nil {
+		return nil, fmt.Errorf("store: table_info(%s): %w", table, err)
+	}
+	defer rows.Close()
+
+	var columns []string
+	for rows.Next() {
+		var cid, notNull, pk int
+		var name, colType string
+		var dflt *string
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &dflt, &pk); err != nil {
+			return nil, fmt.Errorf("store: scan table_info(%s): %w", table, err)
+		}
+		columns = append(columns, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: iterate table_info(%s): %w", table, err)
+	}
+	return columns, nil
+}

--- a/store/ts_schema_detect_test.go
+++ b/store/ts_schema_detect_test.go
@@ -1,0 +1,141 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+)
+
+// createDrizzleMigrations replicates the TypeScript __drizzle_migrations
+// journal table (metapi-ts/src/server/db/migrate.ts ensureDrizzleMigrationsTable).
+func createDrizzleMigrations(t *testing.T, db *DB) {
+	t.Helper()
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			hash text NOT NULL,
+			created_at numeric
+		)`); err != nil {
+		t.Fatalf("create __drizzle_migrations: %v", err)
+	}
+}
+
+// TestDetectTSSchemaDriftNewerTSJournal pins the journal-age half of the
+// reverse-drift scan: a __drizzle_migrations max(created_at) above
+// knownLatestTSMigrationWhen means the database was produced by a newer
+// TypeScript build.
+func TestDetectTSSchemaDriftNewerTSJournal(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	createDrizzleMigrations(t, db)
+	for i, when := range []int64{
+		knownLatestTSMigrationWhen - 1000,
+		knownLatestTSMigrationWhen + 1000, // newer than Go knows
+	} {
+		if _, err := db.Exec(
+			`INSERT INTO "__drizzle_migrations" (hash, created_at) VALUES (?, ?)`,
+			fmt.Sprintf("hash-%d", i), when,
+		); err != nil {
+			t.Fatalf("insert journal row %d: %v", i, err)
+		}
+	}
+
+	result, err := detectTSSchemaDrift(db)
+	if err != nil {
+		t.Fatalf("detectTSSchemaDrift: %v", err)
+	}
+	if result == nil {
+		t.Fatal("detectTSSchemaDrift returned nil result for SQLite")
+	}
+	if !result.TSJournalNewer {
+		t.Fatal("TSJournalNewer = false, want true (journal newer than knownLatestTSMigrationWhen)")
+	}
+	if result.TSJournalMaxWhen != knownLatestTSMigrationWhen+1000 {
+		t.Fatalf("TSJournalMaxWhen = %d, want %d", result.TSJournalMaxWhen, knownLatestTSMigrationWhen+1000)
+	}
+}
+
+// TestDetectTSSchemaDriftJournalWithinRange pins the no-warning side: a
+// journal at or below the known latest `when` is not flagged.
+func TestDetectTSSchemaDriftJournalWithinRange(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	createDrizzleMigrations(t, db)
+	if _, err := db.Exec(
+		`INSERT INTO "__drizzle_migrations" (hash, created_at) VALUES (?, ?)`,
+		"hash-0", knownLatestTSMigrationWhen,
+	); err != nil {
+		t.Fatalf("insert journal row: %v", err)
+	}
+
+	result, err := detectTSSchemaDrift(db)
+	if err != nil {
+		t.Fatalf("detectTSSchemaDrift: %v", err)
+	}
+	if result.TSJournalNewer {
+		t.Fatal("TSJournalNewer = true, want false (journal at known latest when)")
+	}
+	if len(result.UnknownColumns) != 0 {
+		t.Fatalf("UnknownColumns = %v, want none", result.UnknownColumns)
+	}
+}
+
+// TestDetectTSSchemaDriftUnknownColumn pins the unknown-column half: a
+// future TS migration adding sites.future_column must be listed.
+func TestDetectTSSchemaDriftUnknownColumn(t *testing.T) {
+	db := openTestSQLite(t)
+
+	if _, err := db.Exec(`ALTER TABLE sites ADD COLUMN future_column TEXT`); err != nil {
+		t.Fatalf("add future_column: %v", err)
+	}
+
+	result, err := detectTSSchemaDrift(db)
+	if err != nil {
+		t.Fatalf("detectTSSchemaDrift: %v", err)
+	}
+	found := false
+	for _, unknown := range result.UnknownColumns {
+		if unknown == "sites.future_column" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("UnknownColumns = %v, want it to contain sites.future_column", result.UnknownColumns)
+	}
+}
+
+// TestDetectTSSchemaDriftCleanDatabase pins the quiet case: a fresh Go
+// database (empty DB after AutoMigrate) produces no journal warning and no
+// unknown columns — including the __drizzle_migrations and sqlite_* tables,
+// which are excluded from the scan.
+func TestDetectTSSchemaDriftCleanDatabase(t *testing.T) {
+	db := openTestSQLite(t)
+
+	// The TS journal marker and SQLite internals must never be reported as
+	// unknown columns, even when present.
+	createDrizzleMigrations(t, db)
+	if _, err := db.Exec(
+		`INSERT INTO "__drizzle_migrations" (hash, created_at) VALUES (?, ?)`,
+		"hash-0", knownLatestTSMigrationWhen,
+	); err != nil {
+		t.Fatalf("insert journal row: %v", err)
+	}
+
+	result, err := detectTSSchemaDrift(db)
+	if err != nil {
+		t.Fatalf("detectTSSchemaDrift: %v", err)
+	}
+	if result.TSJournalNewer {
+		t.Fatal("TSJournalNewer = true on a clean Go database, want false")
+	}
+	if len(result.UnknownColumns) != 0 {
+		t.Fatalf("UnknownColumns = %v on a clean Go database, want none", result.UnknownColumns)
+	}
+}


### PR DESCRIPTION
TS→Go 迁移收官的 Go 后端批次（批次 A+B+C，依据 docs/internal/analysis/ts-go-migration-gap.md）。

## 批次 A：CLI 诚实化

- `--verify` 校验和不匹配现在**非零退出**（此前只打 warning、exit 0——脚本里等于没校验）。顺带发现并修复一个「假绿」测试：`TestRunMigrationVerifyTSSchemaOrder` 的 fixture 第二行因 NULL 被 builder 强转默认值导致校验和真实不匹配但被吞——诚实化后暴露，已补全 fixture 使测试钉住本意。
- `buildSummary` 不再硬编码 `Dialect:"postgres"`，按目标 URL 报真实方言。
- `--batch-size` 从「接受但丢弃」变为真实生效（multi-row INSERT 批次，PG 跨行占位符编号；0/负值=逐行原路径）；dry-run 与 verify 不受影响。
- 头注释 13/14 列陈旧修正。

## 批次 B：反向检测（防 hb0730 事故翻版）

TS 库比 Go 认知新时（TS 未来又加列），启动即警告而非 SELECT 才崩：

- `store/ts_schema_detect.go`：读 `__drizzle_migrations` 的 `MAX(created_at)` 判龄（vs 常量 `knownLatestTSMigrationWhen` = TS journal 最新 when）+ 以内存库 AutoMigrate 为权威清单逐表比对未知列；警告列出列名 + 建议升级 Go；**永不阻断**（未知列可能无害，阻断会锁死旧二进制）。
- 接入 `EnsureRuntimeDatabase`（SQLite 方言）。

## 批次 C：启动汇总

`AutoMigrate` 有实际变更时输出 `store: converged legacy schema, additive_migrations=N` 汇总行（空库/无变更静默）。

## 管理补丁

migrate handler 补解析 `overwrite` 字段（此前硬编码 true，UI 发来的字段被忽略），默认 true 与 TS 行为一致。

## 验证

- `go build ./...`、`go vet ./store/ ./cmd/...`、`go test ./store/ -count=1`、`go test ./cmd/migrate/` 全绿
- 新测试：反向检测 4 用例（TS 新库警告 / 界内不警告 / 未知列列出 / 干净库不误报）
- **真实 PG 接管实测**（管理方亲测）：真实 TS 服务器在 PG 16 上建 27 表 + 种子数据 → Go 直接接管：`/ready` OK、`/api/sites` 返回 TS 数据、additive 逐列收敛无崩溃

## 自查清单

- [x] 行为变更有回归测试
- [x] 无密钥/内部路径泄漏
- [x] SQLite + PostgreSQL 双方言安全（批量 INSERT 占位符有 PG 编号单测）
- [x] 不引入新依赖