### PR TITLE
feat(web): database migration admin UI with background task polling

### DIFF
--- a/web/src/features/settings/sections/system-info/components/__tests__/database-migration-section.test.tsx
+++ b/web/src/features/settings/sections/system-info/components/__tests__/database-migration-section.test.tsx
@@ -316,36 +316,32 @@ describe('DatabaseMigrationSection — background task polling', () => {
     }
   )
 
-  it(
-    'surfaces the task error on failure',
-    { timeout: 15_000 },
-    async () => {
-      mockGetTask
-        .mockResolvedValueOnce({ success: true, task: runningTask })
-        .mockResolvedValueOnce({
-          success: true,
-          task: {
-            ...runningTask,
-            status: 'failed',
-            error: 'open target: connection refused',
-            finishedAt: '2026-08-20T10:00:05Z',
-          },
-        })
-      renderMigrationSection()
-
-      await fillConnection('postgres://user:pass@host:5432/db')
-      fireEvent.click(screen.getByRole('button', { name: 'Start migration' }))
-      await screen.findByText('Confirm data migration')
-      clickConfirmAction()
-
-      await waitFor(
-        () => {
-          expect(mockToastError).toHaveBeenCalledWith(
-            'open target: connection refused'
-          )
+  it('surfaces the task error on failure', { timeout: 15_000 }, async () => {
+    mockGetTask
+      .mockResolvedValueOnce({ success: true, task: runningTask })
+      .mockResolvedValueOnce({
+        success: true,
+        task: {
+          ...runningTask,
+          status: 'failed',
+          error: 'open target: connection refused',
+          finishedAt: '2026-08-20T10:00:05Z',
         },
-        { timeout: 6000 }
-      )
-    }
-  )
+      })
+    renderMigrationSection()
+
+    await fillConnection('postgres://user:pass@host:5432/db')
+    fireEvent.click(screen.getByRole('button', { name: 'Start migration' }))
+    await screen.findByText('Confirm data migration')
+    clickConfirmAction()
+
+    await waitFor(
+      () => {
+        expect(mockToastError).toHaveBeenCalledWith(
+          'open target: connection refused'
+        )
+      },
+      { timeout: 6000 }
+    )
+  })
 })

--- a/web/src/features/settings/sections/system-info/components/__tests__/database-migration-section.test.tsx
+++ b/web/src/features/settings/sections/system-info/components/__tests__/database-migration-section.test.tsx
@@ -1,0 +1,351 @@
+// Behavior test for the database migration section.
+//
+// Locks the destructive-migration flow: target defaults to the dialect away
+// from the live runtime, the connection string is required before testing or
+// migrating, the start button opens the destructive confirm dialog, and after
+// the backend accepts the job (202 + taskId) the task is polled through
+// api.getTask until a terminal status surfaces (success toast + row summary,
+// or error toast). The same-target 400 rejection is asserted to surface the
+// localized error instead of the raw server message.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+
+import { DatabaseMigrationSection } from '../database-migration-section'
+
+const {
+  mockGetConfig,
+  mockTestConnection,
+  mockStartMigration,
+  mockGetTask,
+  mockToastSuccess,
+  mockToastError,
+  mockToastInfo,
+} = vi.hoisted(() => ({
+  mockGetConfig: vi.fn(),
+  mockTestConnection: vi.fn(),
+  mockStartMigration: vi.fn(),
+  mockGetTask: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+  mockToastInfo: vi.fn(),
+}))
+
+// Mock only the API methods the section calls; the rest of the barrel stays
+// absent because the component touches nothing else.
+vi.mock('@/lib/api', () => ({
+  api: {
+    getRuntimeDatabaseConfig: mockGetConfig,
+    testExternalDatabaseConnection: mockTestConnection,
+    startDatabaseMigration: mockStartMigration,
+    getTask: mockGetTask,
+  },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: mockToastSuccess,
+    error: mockToastError,
+    info: mockToastInfo,
+  },
+}))
+
+const sqliteRuntimeConfig = {
+  active: { dialect: 'sqlite', connection: './data/metapi.db', ssl: false },
+  saved: null,
+  restartRequired: false,
+}
+
+const runningTask = {
+  id: 'task-1',
+  type: 'database_migration',
+  title: '数据库迁移',
+  status: 'running',
+  message: 'Inserting 12 rows...',
+  error: null,
+  result: null,
+  createdAt: '2026-08-20T10:00:00Z',
+  updatedAt: '2026-08-20T10:00:01Z',
+  logs: [
+    {
+      seq: 1,
+      message: 'Direction: SQLite → PostgreSQL (forward migration)',
+      createdAt: '2026-08-20T10:00:00Z',
+    },
+    {
+      seq: 2,
+      message: 'Reading source database...',
+      createdAt: '2026-08-20T10:00:00Z',
+    },
+  ],
+}
+
+const succeededTask = {
+  ...runningTask,
+  status: 'succeeded',
+  message: '数据库迁移 已完成',
+  finishedAt: '2026-08-20T10:00:05Z',
+  result: {
+    dialect: 'postgres',
+    connection: 'postgres://user:***@host:5432/db',
+    overwrite: true,
+    version: '0.16.2',
+    timestamp: 1755684005,
+    rows: { sites: 2, accounts: 1 },
+  },
+}
+
+beforeAll(() => {
+  // Radix/base-ui primitives query matchMedia on render; jsdom leaves it
+  // undefined otherwise and the select crashes.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  mockGetConfig.mockReset()
+  mockTestConnection.mockReset()
+  mockStartMigration.mockReset()
+  mockGetTask.mockReset()
+  mockToastSuccess.mockReset()
+  mockToastError.mockReset()
+  mockToastInfo.mockReset()
+  mockGetConfig.mockResolvedValue(sqliteRuntimeConfig)
+  mockTestConnection.mockResolvedValue({ success: true })
+  mockStartMigration.mockResolvedValue({
+    success: true,
+    message: 'ok',
+    taskId: 'task-1',
+  })
+})
+
+afterEach(() => cleanup())
+
+function renderMigrationSection() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DatabaseMigrationSection />
+    </QueryClientProvider>
+  )
+}
+
+async function fillConnection(connection: string) {
+  const input = await screen.findByLabelText('Connection string')
+  fireEvent.change(input, { target: { value: connection } })
+}
+
+// The confirm dialog action and the trigger share the 'Start migration'
+// label; the dialog action is the last matching button in the tree.
+function clickConfirmAction() {
+  const confirmButtons = screen.getAllByRole('button', {
+    name: 'Start migration',
+  })
+  const confirmButton = confirmButtons.at(-1)
+  if (!confirmButton) {
+    throw new Error('Confirm action button not found')
+  }
+  fireEvent.click(confirmButton)
+}
+
+describe('DatabaseMigrationSection — form and confirm flow', () => {
+  it('renders with a postgres default target when the live runtime is sqlite', async () => {
+    renderMigrationSection()
+
+    expect(await screen.findByText('Data migration')).toBeInTheDocument()
+    expect(
+      screen.getByText('Migration source (live runtime database)')
+    ).toBeInTheDocument()
+    expect(screen.getByText('PostgreSQL')).toBeInTheDocument()
+    // SSL checkbox only renders for postgres targets.
+    expect(
+      screen.getByRole('checkbox', { name: 'Enable SSL/TLS' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('checkbox', { name: 'Overwrite existing data' })
+    ).toBeChecked()
+  })
+
+  it('rejects testing without a connection string', async () => {
+    renderMigrationSection()
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Test connection' })
+    )
+
+    expect(
+      await screen.findByText('Enter the connection string to test.')
+    ).toBeInTheDocument()
+    expect(mockTestConnection).not.toHaveBeenCalled()
+  })
+
+  it('tests the connection with the form values', async () => {
+    renderMigrationSection()
+
+    await fillConnection('postgres://user:pass@host:5432/db')
+    fireEvent.click(screen.getByRole('button', { name: 'Test connection' }))
+
+    await waitFor(() => {
+      expect(mockTestConnection).toHaveBeenCalledWith({
+        dialect: 'postgres',
+        connectionString: 'postgres://user:pass@host:5432/db',
+        ssl: false,
+      })
+    })
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith('Connection OK.')
+    })
+  })
+
+  it('requires a confirm dialog before starting the migration', async () => {
+    renderMigrationSection()
+
+    await fillConnection('postgres://user:pass@host:5432/db')
+    fireEvent.click(screen.getByRole('button', { name: 'Start migration' }))
+
+    expect(
+      await screen.findByText('Confirm data migration')
+    ).toBeInTheDocument()
+    expect(mockStartMigration).not.toHaveBeenCalled()
+
+    // The destructive confirm action carries the same label as the trigger.
+    clickConfirmAction()
+
+    await waitFor(() => {
+      expect(mockStartMigration).toHaveBeenCalledWith({
+        dialect: 'postgres',
+        connectionString: 'postgres://user:pass@host:5432/db',
+        overwrite: true,
+        ssl: false,
+      })
+    })
+    await waitFor(() => {
+      expect(mockToastInfo).toHaveBeenCalledWith(
+        'Migration task started; it is running in the background.'
+      )
+    })
+  })
+
+  it('surfaces the localized same-target rejection instead of the raw server message', async () => {
+    mockStartMigration.mockRejectedValueOnce({
+      response: { data: { error: '目标数据库与当前运行库相同，无法迁移' } },
+    })
+    renderMigrationSection()
+
+    await fillConnection('./data/metapi.db')
+    fireEvent.click(screen.getByRole('button', { name: 'Start migration' }))
+    await screen.findByText('Confirm data migration')
+    clickConfirmAction()
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        'The target database is the same as the live runtime database; migration is not possible.'
+      )
+    })
+  })
+})
+
+describe('DatabaseMigrationSection — background task polling', () => {
+  it(
+    'polls the task and renders the row summary on success',
+    { timeout: 15_000 },
+    async () => {
+      mockGetTask
+        .mockResolvedValueOnce({ success: true, task: runningTask })
+        .mockResolvedValueOnce({ success: true, task: succeededTask })
+      renderMigrationSection()
+
+      await fillConnection('postgres://user:pass@host:5432/db')
+      fireEvent.click(screen.getByRole('button', { name: 'Start migration' }))
+      await screen.findByText('Confirm data migration')
+      clickConfirmAction()
+
+      await waitFor(() => {
+        expect(mockGetTask).toHaveBeenCalledWith('task-1')
+      })
+
+      // Poll interval is 2s; wait for the terminal poll to land and surface.
+      expect(
+        await screen.findByText('Migration result', {}, { timeout: 6000 })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText('Rows per table · 3 rows total')
+      ).toBeInTheDocument()
+      expect(screen.getByText('sites')).toBeInTheDocument()
+      expect(screen.getByText('2')).toBeInTheDocument()
+
+      await waitFor(() => {
+        expect(mockToastSuccess).toHaveBeenCalledWith(
+          'Data migration completed.'
+        )
+      })
+    }
+  )
+
+  it(
+    'surfaces the task error on failure',
+    { timeout: 15_000 },
+    async () => {
+      mockGetTask
+        .mockResolvedValueOnce({ success: true, task: runningTask })
+        .mockResolvedValueOnce({
+          success: true,
+          task: {
+            ...runningTask,
+            status: 'failed',
+            error: 'open target: connection refused',
+            finishedAt: '2026-08-20T10:00:05Z',
+          },
+        })
+      renderMigrationSection()
+
+      await fillConnection('postgres://user:pass@host:5432/db')
+      fireEvent.click(screen.getByRole('button', { name: 'Start migration' }))
+      await screen.findByText('Confirm data migration')
+      clickConfirmAction()
+
+      await waitFor(
+        () => {
+          expect(mockToastError).toHaveBeenCalledWith(
+            'open target: connection refused'
+          )
+        },
+        { timeout: 6000 }
+      )
+    }
+  )
+})

--- a/web/src/features/settings/sections/system-info/components/database-migration-section.tsx
+++ b/web/src/features/settings/sections/system-info/components/database-migration-section.tsx
@@ -1,0 +1,601 @@
+// metapi-go/features/settings/sections/system-info/components — database
+// migration section. Queues a copy of the live runtime database onto an
+// external sqlite/postgres target as an admin background task and polls
+// /api/tasks/{id} for progress, replacing the retired CLI-only migration note.
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { useEffect, useRef, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { z } from 'zod'
+
+import { ConfirmDialog } from '@/components/common/confirm-dialog'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { api } from '@/lib/api'
+import { toast } from '@/lib/toast'
+
+import {
+  SettingsSectionCard,
+  SettingsSectionSkeleton,
+} from '../../../components/settings-section-card'
+import { SettingsSectionError } from '../../../components/settings-section-error'
+import {
+  runtimeDatabaseQueryKeys,
+  type RuntimeDatabaseConfig,
+} from './database-shared'
+
+const MIGRATION_POLL_INTERVAL_MS = 2000
+const LOG_TAIL_LINES = 8
+
+type MigrationTaskStatus = 'pending' | 'running' | 'succeeded' | 'failed'
+
+const TERMINAL_TASK_STATUSES: ReadonlySet<MigrationTaskStatus> = new Set([
+  'succeeded',
+  'failed',
+])
+
+type BackgroundTaskLogEntry = {
+  seq: number
+  message: string
+  createdAt: string
+}
+
+type MigrationTaskResult = {
+  dialect: string
+  connection: string
+  overwrite: boolean
+  version: string
+  timestamp: number
+  rows: Record<string, number>
+}
+
+// Mirrors handler/admin.BackgroundTask (camelCase JSON) as observed through
+// GET /api/tasks/{id} → { success, task }.
+type DatabaseMigrationTask = {
+  id: string
+  type: string
+  title: string
+  status: MigrationTaskStatus
+  message: string
+  error?: string | null
+  result?: MigrationTaskResult | null
+  dedupeKey?: string | null
+  createdAt: string
+  updatedAt: string
+  startedAt?: string | null
+  finishedAt?: string | null
+  logs?: BackgroundTaskLogEntry[]
+}
+
+type GetTaskResponse = {
+  success: boolean
+  task: DatabaseMigrationTask
+}
+
+const migrationSchema = z.object({
+  dialect: z.enum(['sqlite', 'postgres']),
+  connectionString: z.string(),
+  overwrite: z.boolean(),
+  ssl: z.boolean(),
+})
+
+type MigrationFormValues = z.infer<typeof migrationSchema>
+
+const DEFAULT_VALUES: MigrationFormValues = {
+  dialect: 'postgres',
+  connectionString: '',
+  overwrite: true,
+  ssl: false,
+}
+
+const taskStatusBadgeVariant: Record<
+  MigrationTaskStatus,
+  'secondary' | 'info' | 'success' | 'destructive'
+> = {
+  pending: 'secondary',
+  running: 'info',
+  succeeded: 'success',
+  failed: 'destructive',
+}
+
+/**
+ * The migrate endpoint surfaces rejection reasons (e.g. a target that
+ * resolves to the live runtime database) as a plain 400 `{error}` message;
+ * there is no machine-readable detail classifier to match on.
+ */
+function extractServerErrorMessage(error: unknown): string | null {
+  const responseData = (error as { response?: { data?: unknown } } | null)
+    ?.response?.data
+  if (!responseData || typeof responseData !== 'object') return null
+  const record = responseData as Record<string, unknown>
+  if (typeof record.error === 'string' && record.error) return record.error
+  if (typeof record.message === 'string' && record.message) {
+    return record.message
+  }
+  return null
+}
+
+function isSameMigrationTargetError(message: string): boolean {
+  return message.includes('相同')
+}
+
+type MigrationResultSummaryProps = {
+  result: MigrationTaskResult
+  finishedAt?: string | null
+}
+
+function MigrationResultSummary({
+  result,
+  finishedAt,
+}: MigrationResultSummaryProps) {
+  const { t } = useTranslation()
+  const tableEntries = Object.entries(result.rows).sort(([left], [right]) =>
+    left.localeCompare(right)
+  )
+  const totalRows = tableEntries.reduce(
+    (total, [, rowCount]) => total + rowCount,
+    0
+  )
+
+  return (
+    <div className='space-y-2'>
+      <p className='text-sm font-medium'>
+        {t('settings.systemInfo.database.migration.status.resultTitle')}
+      </p>
+      <dl className='text-muted-foreground grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs'>
+        <dt>{t('settings.systemInfo.database.migration.status.target')}</dt>
+        <dd className='font-mono break-all'>{result.connection}</dd>
+        <dt>{t('settings.systemInfo.database.migration.status.version')}</dt>
+        <dd className='font-mono'>{result.version}</dd>
+        {finishedAt ? (
+          <>
+            <dt>
+              {t('settings.systemInfo.database.migration.status.finishedAt')}
+            </dt>
+            <dd>{new Date(finishedAt).toLocaleString()}</dd>
+          </>
+        ) : null}
+      </dl>
+      {tableEntries.length > 0 ? (
+        <div className='space-y-1'>
+          <p className='text-muted-foreground text-xs'>
+            {t('settings.systemInfo.database.migration.status.rowsTitle')} ·{' '}
+            {t('settings.systemInfo.database.migration.status.rowsTotal', {
+              count: totalRows,
+            })}
+          </p>
+          <div className='bg-muted/40 max-h-40 overflow-auto rounded-md border px-2 py-1'>
+            {tableEntries.map(([tableName, rowCount]) => (
+              <div
+                key={tableName}
+                className='flex items-center justify-between gap-4 border-b border-dashed py-1 text-xs last:border-b-0'
+              >
+                <code className='text-muted-foreground'>{tableName}</code>
+                <span className='font-mono tabular-nums'>{rowCount}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export function DatabaseMigrationSection() {
+  const { t } = useTranslation()
+  const [migrationTaskId, setMigrationTaskId] = useState<string | null>(null)
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  // Guards the terminal-status toasts: the task query refetches every poll,
+  // so each new task object would otherwise re-fire the effect.
+  const handledTerminalRef = useRef<string | null>(null)
+
+  const configQuery = useQuery<RuntimeDatabaseConfig>({
+    queryKey: runtimeDatabaseQueryKeys.all,
+    queryFn: async () =>
+      (await api.getRuntimeDatabaseConfig()) as RuntimeDatabaseConfig,
+    staleTime: 30 * 1000,
+  })
+
+  const form = useForm<MigrationFormValues>({
+    resolver: zodResolver(migrationSchema) as never,
+    defaultValues: DEFAULT_VALUES,
+  })
+
+  const dialect = form.watch('dialect')
+
+  // Sensible default target: migrate away from the live dialect. Skipped once
+  // the user has touched the form so their edits are never clobbered.
+  useEffect(() => {
+    if (!configQuery.data || form.formState.isDirty) return
+    const liveDialect = configQuery.data.active?.dialect
+    const targetDialect = liveDialect === 'postgres' ? 'sqlite' : 'postgres'
+    form.setValue('dialect', targetDialect, { shouldDirty: false })
+    if (targetDialect === 'sqlite') {
+      form.setValue('ssl', false, { shouldDirty: false })
+    }
+  }, [configQuery.data, form])
+
+  const taskQuery = useQuery<DatabaseMigrationTask>({
+    queryKey: ['background-task', migrationTaskId],
+    queryFn: async () => {
+      // `enabled` guarantees a taskId; the guard keeps the type checker happy.
+      if (!migrationTaskId) {
+        throw new Error('Background task polling requires a task id')
+      }
+      const response = (await api.getTask(migrationTaskId)) as GetTaskResponse
+      return response.task
+    },
+    enabled: Boolean(migrationTaskId),
+    refetchInterval: (query) =>
+      query.state.data && TERMINAL_TASK_STATUSES.has(query.state.data.status)
+        ? false
+        : MIGRATION_POLL_INTERVAL_MS,
+  })
+
+  const task = taskQuery.data
+  // A task is "active" from the moment its id is known until the polled task
+  // reaches a terminal status — this covers the window between the 202
+  // response and the first poll result, where `task` is still undefined.
+  // A poll error (transient network hiccup) un-blocks the form: the interval
+  // keeps retrying while no data has arrived, and the backend dedupes
+  // concurrent migrations on the same task anyway.
+  const polledStatus = taskQuery.data?.status
+  const taskIsActive =
+    Boolean(migrationTaskId) &&
+    !taskQuery.isError &&
+    (polledStatus === undefined || !TERMINAL_TASK_STATUSES.has(polledStatus))
+
+  useEffect(() => {
+    if (!task || !TERMINAL_TASK_STATUSES.has(task.status)) return
+    const terminalKey = `${task.id}:${task.status}`
+    if (handledTerminalRef.current === terminalKey) return
+    handledTerminalRef.current = terminalKey
+    if (task.status === 'succeeded') {
+      toast.success(t('settings.systemInfo.database.migration.toast.completed'))
+    } else {
+      toast.error(
+        task.error ?? t('settings.systemInfo.database.migration.toast.failed')
+      )
+    }
+  }, [task, t])
+
+  const testMutation = useMutation({
+    mutationFn: async (values: MigrationFormValues) =>
+      api.testExternalDatabaseConnection({
+        dialect: values.dialect,
+        connectionString: values.connectionString.trim(),
+        ssl: values.ssl,
+      }),
+    onSuccess: () =>
+      toast.success(t('settings.systemInfo.database.toast.testOk')),
+    onError: () =>
+      toast.error(t('settings.systemInfo.database.toast.testFailed')),
+  })
+
+  const startMutation = useMutation({
+    mutationFn: async (values: MigrationFormValues) =>
+      api.startDatabaseMigration({
+        dialect: values.dialect,
+        connectionString: values.connectionString.trim(),
+        overwrite: values.overwrite,
+        ssl: values.ssl,
+      }),
+    onSuccess: (response) => {
+      handledTerminalRef.current = null
+      setMigrationTaskId(response.taskId)
+      setConfirmOpen(false)
+      toast.info(t('settings.systemInfo.database.migration.toast.started'))
+    },
+    onError: (error) => {
+      setConfirmOpen(false)
+      const serverMessage = extractServerErrorMessage(error)
+      if (serverMessage && isSameMigrationTargetError(serverMessage)) {
+        toast.error(
+          t('settings.systemInfo.database.migration.toast.sameTarget')
+        )
+      } else if (serverMessage) {
+        toast.error(serverMessage)
+      } else {
+        toast.error(
+          t('settings.systemInfo.database.migration.toast.startFailed')
+        )
+      }
+    },
+  })
+
+  function requireConnection(messageKey: string): string | null {
+    const connection = form.getValues('connectionString').trim()
+    if (connection) return connection
+    form.setError('connectionString', { message: messageKey })
+    return null
+  }
+
+  function handleTestConnection() {
+    const connection = requireConnection(
+      'settings.systemInfo.database.migration.schema.testConnectionRequired'
+    )
+    if (!connection) return
+    testMutation.mutate({
+      ...form.getValues(),
+      connectionString: connection,
+    })
+  }
+
+  function handleStartMigration() {
+    const connection = requireConnection(
+      'settings.systemInfo.database.migration.schema.connectionRequired'
+    )
+    if (!connection) return
+    setConfirmOpen(true)
+  }
+
+  const busy = taskIsActive || startMutation.isPending || testMutation.isPending
+  const activeConfig = configQuery.data?.active
+
+  if (configQuery.isLoading) {
+    return <SettingsSectionSkeleton />
+  }
+  if (configQuery.isError || !configQuery.data) {
+    return (
+      <SettingsSectionError
+        title={t('settings.systemInfo.database.migration.title')}
+        onRetry={() => void configQuery.refetch()}
+      />
+    )
+  }
+
+  return (
+    <SettingsSectionCard
+      title={t('settings.systemInfo.database.migration.title')}
+      description={t('settings.systemInfo.database.migration.description')}
+    >
+      <div className='space-y-5'>
+        {activeConfig ? (
+          <div className='bg-muted/25 rounded-lg border p-3'>
+            <p className='text-muted-foreground text-xs font-medium'>
+              {t('settings.systemInfo.database.migration.sourceLabel')}
+            </p>
+            <code className='text-foreground mt-1 block text-xs break-all'>
+              {activeConfig.dialect} · {activeConfig.connection}
+              {activeConfig.ssl ? ' · SSL' : ''}
+            </code>
+          </div>
+        ) : null}
+
+        <Form {...form}>
+          <form className='space-y-4'>
+            <FormField
+              control={form.control}
+              name='dialect'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t('settings.systemInfo.database.migration.fields.dialect')}
+                  </FormLabel>
+                  <Select
+                    value={field.value}
+                    disabled={busy}
+                    onValueChange={(value) => {
+                      field.onChange(value)
+                      if (value === 'sqlite') {
+                        form.setValue('ssl', false, { shouldDirty: true })
+                      }
+                    }}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue>
+                          {(selected) => {
+                            if (selected === 'sqlite') return 'SQLite'
+                            if (selected === 'postgres') return 'PostgreSQL'
+                            return ''
+                          }}
+                        </SelectValue>
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value='sqlite'>SQLite</SelectItem>
+                      <SelectItem value='postgres'>PostgreSQL</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name='connectionString'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t(
+                      'settings.systemInfo.database.migration.fields.connectionString'
+                    )}
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      value={field.value ?? ''}
+                      className='font-mono'
+                      autoComplete='off'
+                      spellCheck={false}
+                      disabled={busy}
+                      placeholder={
+                        dialect === 'postgres'
+                          ? 'postgres://user:pass@host:5432/db'
+                          : './data/target.db'
+                      }
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    {t(
+                      'settings.systemInfo.database.migration.fields.connectionStringHint'
+                    )}
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {dialect === 'postgres' ? (
+              <FormField
+                control={form.control}
+                name='ssl'
+                render={({ field }) => (
+                  <FormItem className='flex flex-row items-start gap-3 rounded-lg border p-3'>
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        disabled={busy}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                    <div className='space-y-1'>
+                      <FormLabel className='cursor-pointer'>
+                        {t('settings.systemInfo.database.migration.fields.ssl')}
+                      </FormLabel>
+                      <FormDescription>
+                        {t(
+                          'settings.systemInfo.database.migration.fields.sslHint'
+                        )}
+                      </FormDescription>
+                    </div>
+                  </FormItem>
+                )}
+              />
+            ) : null}
+            <FormField
+              control={form.control}
+              name='overwrite'
+              render={({ field }) => (
+                <FormItem className='flex flex-row items-start gap-3 rounded-lg border p-3'>
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      disabled={busy}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <div className='space-y-1'>
+                    <FormLabel className='cursor-pointer'>
+                      {t(
+                        'settings.systemInfo.database.migration.fields.overwrite'
+                      )}
+                    </FormLabel>
+                    <FormDescription>
+                      {t(
+                        'settings.systemInfo.database.migration.fields.overwriteHint'
+                      )}
+                    </FormDescription>
+                  </div>
+                </FormItem>
+              )}
+            />
+
+            <div className='flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between'>
+              <div className='flex flex-wrap gap-2'>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  disabled={busy}
+                  onClick={handleTestConnection}
+                >
+                  {testMutation.isPending
+                    ? t('settings.common.testing')
+                    : t(
+                        'settings.systemInfo.database.migration.testConnection'
+                      )}
+                </Button>
+                <Button
+                  type='button'
+                  variant='destructive'
+                  size='sm'
+                  disabled={busy}
+                  onClick={handleStartMigration}
+                >
+                  {startMutation.isPending || taskIsActive
+                    ? t('settings.systemInfo.database.migration.migrating')
+                    : t(
+                        'settings.systemInfo.database.migration.startMigration'
+                      )}
+                </Button>
+              </div>
+            </div>
+          </form>
+        </Form>
+
+        {task ? (
+          <div className='space-y-3 rounded-lg border p-3'>
+            <div className='flex flex-wrap items-center gap-2'>
+              <Badge variant={taskStatusBadgeVariant[task.status]}>
+                {t(
+                  `settings.systemInfo.database.migration.status.${task.status}`
+                )}
+              </Badge>
+              <p className='text-muted-foreground min-w-0 flex-1 truncate text-xs'>
+                {task.message}
+              </p>
+            </div>
+            {task.logs && task.logs.length > 0 ? (
+              <div className='space-y-1'>
+                <p className='text-muted-foreground text-xs'>
+                  {t('settings.systemInfo.database.migration.status.logsTitle')}
+                </p>
+                <pre className='bg-muted/40 text-muted-foreground max-h-40 overflow-auto rounded-md border p-2 font-mono text-xs whitespace-pre-wrap'>
+                  {task.logs
+                    .slice(-LOG_TAIL_LINES)
+                    .map((entry) => entry.message)
+                    .join('\n')}
+                </pre>
+              </div>
+            ) : null}
+            {task.status === 'succeeded' && task.result ? (
+              <MigrationResultSummary
+                result={task.result}
+                finishedAt={task.finishedAt}
+              />
+            ) : null}
+            {task.status === 'failed' && task.error ? (
+              <p className='text-destructive text-sm break-all'>{task.error}</p>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      <ConfirmDialog
+        open={confirmOpen}
+        title={t('settings.systemInfo.database.migration.confirm.title')}
+        description={t(
+          'settings.systemInfo.database.migration.confirm.description'
+        )}
+        confirmLabel={t(
+          'settings.systemInfo.database.migration.confirm.confirmLabel'
+        )}
+        cancelLabel={t('settings.common.cancel')}
+        destructive
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => startMutation.mutate(form.getValues())}
+      />
+    </SettingsSectionCard>
+  )
+}

--- a/web/src/features/settings/sections/system-info/components/database-section.tsx
+++ b/web/src/features/settings/sections/system-info/components/database-section.tsx
@@ -1,6 +1,7 @@
 // metapi-go/features/settings/sections/system-info/components — database
-// section. Runtime DB selection is restart-pending configuration; destructive
-// data migration remains CLI-only and is not presented as a working UI action.
+// section. Runtime DB selection is restart-pending configuration; the data
+// migration action lives in DatabaseMigrationSection, rendered as its own
+// card below this one.
 
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
@@ -40,6 +41,11 @@ import {
   collectChangedFields,
   hasChanges,
 } from '../../../lib/collect-changed-fields'
+import { DatabaseMigrationSection } from './database-migration-section'
+import {
+  runtimeDatabaseQueryKeys,
+  type RuntimeDatabaseConfig,
+} from './database-shared'
 
 const SAVE_FORM_ID = 'settings-system-info-database-form'
 
@@ -51,25 +57,10 @@ const databaseSchema = z.object({
 
 type DatabaseFormValues = z.infer<typeof databaseSchema>
 
-type RuntimeDatabaseConfig = {
-  active?: { dialect: string; connection: string; ssl?: boolean }
-  saved?: {
-    dialect: 'sqlite' | 'postgres'
-    connectionStringMasked?: string
-    hasConnectionString?: boolean
-    ssl?: boolean
-  }
-  restartRequired?: boolean
-}
-
 const DEFAULT_VALUES: DatabaseFormValues = {
   dialect: 'sqlite',
   connectionString: '',
   ssl: false,
-}
-
-const runtimeDatabaseQueryKeys = {
-  all: ['runtime-database-config'] as const,
 }
 
 function deriveServerValues(
@@ -188,167 +179,176 @@ export function DatabaseSection() {
   })
 
   if (configQuery.isLoading) {
-    return <SettingsSectionSkeleton />
+    return (
+      <>
+        <SettingsSectionSkeleton />
+        <DatabaseMigrationSection />
+      </>
+    )
   }
   if (configQuery.isError || !configQuery.data) {
     return (
-      <SettingsSectionError
-        title={t('settings.systemInfo.database.title')}
-        onRetry={() => void configQuery.refetch()}
-      />
+      <>
+        <SettingsSectionError
+          title={t('settings.systemInfo.database.title')}
+          onRetry={() => void configQuery.refetch()}
+        />
+        <DatabaseMigrationSection />
+      </>
     )
   }
 
   const active = configQuery.data.active
 
   return (
-    <SettingsSectionCard
-      title={t('settings.systemInfo.database.title')}
-      description={t('settings.systemInfo.database.description')}
-    >
-      <div className='space-y-5'>
-        {active ? (
-          <div className='bg-muted/25 rounded-lg border p-3'>
-            <p className='text-muted-foreground text-xs font-medium'>
-              {t('settings.systemInfo.database.currentRuntime')}
-            </p>
-            <code className='text-foreground mt-1 block text-xs break-all'>
-              {active.dialect} · {active.connection}
-              {active.ssl ? ' · SSL' : ''}
-            </code>
-          </div>
-        ) : null}
-        {configQuery.data.restartRequired ? (
-          <div className='border-warning/35 bg-warning/10 text-warning-soft-fg rounded-lg border px-3 py-2 text-sm'>
-            {t('settings.systemInfo.database.restartRequired')}
-          </div>
-        ) : null}
+    <>
+      <SettingsSectionCard
+        title={t('settings.systemInfo.database.title')}
+        description={t('settings.systemInfo.database.description')}
+      >
+        <div className='space-y-5'>
+          {active ? (
+            <div className='bg-muted/25 rounded-lg border p-3'>
+              <p className='text-muted-foreground text-xs font-medium'>
+                {t('settings.systemInfo.database.currentRuntime')}
+              </p>
+              <code className='text-foreground mt-1 block text-xs break-all'>
+                {active.dialect} · {active.connection}
+                {active.ssl ? ' · SSL' : ''}
+              </code>
+            </div>
+          ) : null}
+          {configQuery.data.restartRequired ? (
+            <div className='border-warning/35 bg-warning/10 text-warning-soft-fg rounded-lg border px-3 py-2 text-sm'>
+              {t('settings.systemInfo.database.restartRequired')}
+            </div>
+          ) : null}
 
-        <Form {...form}>
-          <form
-            id={SAVE_FORM_ID}
-            onSubmit={form.handleSubmit(onSave)}
-            className='space-y-4'
-          >
-            <FormField
-              control={form.control}
-              name='dialect'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>
-                    {t('settings.systemInfo.database.fields.dialect')}
-                  </FormLabel>
-                  <Select
-                    value={field.value}
-                    onValueChange={(value) => {
-                      field.onChange(value)
-                      if (value === 'sqlite') {
-                        form.setValue('ssl', false, { shouldDirty: true })
-                      }
-                    }}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue>
-                          {(selected) => {
-                            if (selected === 'sqlite') return 'SQLite'
-                            if (selected === 'postgres') return 'PostgreSQL'
-                            return ''
-                          }}
-                        </SelectValue>
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value='sqlite'>SQLite</SelectItem>
-                      <SelectItem value='postgres'>PostgreSQL</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name='connectionString'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>
-                    {t('settings.systemInfo.database.fields.connectionString')}
-                  </FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      value={field.value ?? ''}
-                      className='font-mono'
-                      autoComplete='off'
-                      spellCheck={false}
-                      placeholder={connectionPlaceholder}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    {t(
-                      savedConfig?.hasConnectionString
-                        ? 'settings.systemInfo.database.fields.connectionSavedHint'
-                        : 'settings.systemInfo.database.fields.connectionStringHint'
-                    )}
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            {dialect === 'postgres' ? (
+          <Form {...form}>
+            <form
+              id={SAVE_FORM_ID}
+              onSubmit={form.handleSubmit(onSave)}
+              className='space-y-4'
+            >
               <FormField
                 control={form.control}
-                name='ssl'
+                name='dialect'
                 render={({ field }) => (
-                  <FormItem className='flex flex-row items-start gap-3 rounded-lg border p-3'>
-                    <FormControl>
-                      <Checkbox
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
-                    <div className='space-y-1'>
-                      <FormLabel className='cursor-pointer'>
-                        {t('settings.systemInfo.database.fields.ssl')}
-                      </FormLabel>
-                      <FormDescription>
-                        {t('settings.systemInfo.database.fields.sslHint')}
-                      </FormDescription>
-                    </div>
+                  <FormItem>
+                    <FormLabel>
+                      {t('settings.systemInfo.database.fields.dialect')}
+                    </FormLabel>
+                    <Select
+                      value={field.value}
+                      onValueChange={(value) => {
+                        field.onChange(value)
+                        if (value === 'sqlite') {
+                          form.setValue('ssl', false, { shouldDirty: true })
+                        }
+                      }}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue>
+                            {(selected) => {
+                              if (selected === 'sqlite') return 'SQLite'
+                              if (selected === 'postgres') return 'PostgreSQL'
+                              return ''
+                            }}
+                          </SelectValue>
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value='sqlite'>SQLite</SelectItem>
+                        <SelectItem value='postgres'>PostgreSQL</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
                   </FormItem>
                 )}
               />
-            ) : null}
-
-            <div className='flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between'>
-              <Button
-                type='button'
-                variant='outline'
-                size='sm'
-                disabled={testMutation.isPending}
-                onClick={() => void testConnection()}
-              >
-                {testMutation.isPending
-                  ? t('settings.common.testing')
-                  : t('settings.systemInfo.database.testConnection')}
-              </Button>
-              <SettingsFormActions
-                formId={SAVE_FORM_ID}
-                isDirty={isDirty}
-                isPending={saveMutation.isPending}
-                onReset={() => syncFromServer(serverValues ?? DEFAULT_VALUES)}
-                saveLabel={t('settings.systemInfo.database.saveAsRuntime')}
+              <FormField
+                control={form.control}
+                name='connectionString'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t(
+                        'settings.systemInfo.database.fields.connectionString'
+                      )}
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        value={field.value ?? ''}
+                        className='font-mono'
+                        autoComplete='off'
+                        spellCheck={false}
+                        placeholder={connectionPlaceholder}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      {t(
+                        savedConfig?.hasConnectionString
+                          ? 'settings.systemInfo.database.fields.connectionSavedHint'
+                          : 'settings.systemInfo.database.fields.connectionStringHint'
+                      )}
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
               />
-            </div>
-          </form>
-        </Form>
+              {dialect === 'postgres' ? (
+                <FormField
+                  control={form.control}
+                  name='ssl'
+                  render={({ field }) => (
+                    <FormItem className='flex flex-row items-start gap-3 rounded-lg border p-3'>
+                      <FormControl>
+                        <Checkbox
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                      <div className='space-y-1'>
+                        <FormLabel className='cursor-pointer'>
+                          {t('settings.systemInfo.database.fields.ssl')}
+                        </FormLabel>
+                        <FormDescription>
+                          {t('settings.systemInfo.database.fields.sslHint')}
+                        </FormDescription>
+                      </div>
+                    </FormItem>
+                  )}
+                />
+              ) : null}
 
-        <p className='text-muted-foreground rounded-lg border border-dashed px-3 py-2 text-xs'>
-          {t('settings.systemInfo.database.migrationCliOnly')}
-        </p>
-      </div>
-      <FormNavigationGuard enabled={isDirty} />
-    </SettingsSectionCard>
+              <div className='flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between'>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  disabled={testMutation.isPending}
+                  onClick={() => void testConnection()}
+                >
+                  {testMutation.isPending
+                    ? t('settings.common.testing')
+                    : t('settings.systemInfo.database.testConnection')}
+                </Button>
+                <SettingsFormActions
+                  formId={SAVE_FORM_ID}
+                  isDirty={isDirty}
+                  isPending={saveMutation.isPending}
+                  onReset={() => syncFromServer(serverValues ?? DEFAULT_VALUES)}
+                  saveLabel={t('settings.systemInfo.database.saveAsRuntime')}
+                />
+              </div>
+            </form>
+          </Form>
+        </div>
+        <FormNavigationGuard enabled={isDirty} />
+      </SettingsSectionCard>
+      <DatabaseMigrationSection />
+    </>
   )
 }

--- a/web/src/features/settings/sections/system-info/components/database-shared.ts
+++ b/web/src/features/settings/sections/system-info/components/database-shared.ts
@@ -1,0 +1,19 @@
+// metapi-go/features/settings/sections/system-info/components — shared
+// runtime-database types + query key used by both the runtime-config section
+// and the migration section. Living in its own module avoids a component
+// import cycle (database-section ↔ database-migration-section).
+
+export type RuntimeDatabaseConfig = {
+  active?: { dialect: string; connection: string; ssl?: boolean }
+  saved?: {
+    dialect: 'sqlite' | 'postgres'
+    connectionStringMasked?: string
+    hasConnectionString?: boolean
+    ssl?: boolean
+  }
+  restartRequired?: boolean
+}
+
+export const runtimeDatabaseQueryKeys = {
+  all: ['runtime-database-config'] as const,
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1299,7 +1299,6 @@
           "restartRequired": "Saved config pending — restart required to apply.",
           "testConnection": "Test connection",
           "saveAsRuntime": "Save configuration",
-          "migrationCliOnly": "Data migration is not executed in the admin UI. Use the metapi-migrate CLI and back up the database first.",
           "fields": {
             "dialect": "Dialect",
             "connectionString": "Connection string",
@@ -1318,6 +1317,52 @@
             "saveFailed": "Failed to save database config.",
             "testOk": "Connection OK.",
             "testFailed": "Connection test failed."
+          },
+          "migration": {
+            "title": "Data migration",
+            "description": "Copy all data from the live runtime database to a target database; the migration runs as a background task. Existing target data will be wiped. Do not restart the server during migration.",
+            "sourceLabel": "Migration source (live runtime database)",
+            "fields": {
+              "dialect": "Target dialect",
+              "connectionString": "Connection string",
+              "connectionStringHint": "sqlite path or postgres URL.",
+              "overwrite": "Overwrite existing data",
+              "overwriteHint": "Wipe the target database before writing.",
+              "ssl": "Enable SSL/TLS",
+              "sslHint": "postgres only."
+            },
+            "testConnection": "Test connection",
+            "startMigration": "Start migration",
+            "migrating": "Migrating…",
+            "confirm": {
+              "title": "Confirm data migration",
+              "description": "All data from the live runtime database will be copied to the target, and existing target data will be wiped. Do not restart during migration.",
+              "confirmLabel": "Start migration"
+            },
+            "schema": {
+              "connectionRequired": "Enter a target database connection string.",
+              "testConnectionRequired": "Enter the connection string to test."
+            },
+            "status": {
+              "pending": "Queued",
+              "running": "Running",
+              "succeeded": "Completed",
+              "failed": "Failed",
+              "logsTitle": "Task logs",
+              "resultTitle": "Migration result",
+              "target": "Target",
+              "version": "Version",
+              "finishedAt": "Finished",
+              "rowsTitle": "Rows per table",
+              "rowsTotal": "{{count}} rows total"
+            },
+            "toast": {
+              "started": "Migration task started; it is running in the background.",
+              "completed": "Data migration completed.",
+              "failed": "Data migration failed.",
+              "startFailed": "Failed to start the migration.",
+              "sameTarget": "The target database is the same as the live runtime database; migration is not possible."
+            }
           }
         },
         "maintenance": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1299,7 +1299,6 @@
           "restartRequired": "已保存待生效——需重启以应用。",
           "testConnection": "测试连接",
           "saveAsRuntime": "保存配置",
-          "migrationCliOnly": "数据迁移不会在管理界面中执行。请使用 metapi-migrate CLI，并在操作前备份数据库。",
           "fields": {
             "dialect": "方言",
             "connectionString": "连接字符串",
@@ -1318,6 +1317,52 @@
             "saveFailed": "保存数据库配置失败。",
             "testOk": "连接正常。",
             "testFailed": "连接测试失败。"
+          },
+          "migration": {
+            "title": "数据迁移",
+            "description": "将当前运行库的全部数据复制到目标数据库，迁移作为后台任务执行。目标库已有数据将被清空；迁移期间请勿重启服务。",
+            "sourceLabel": "迁移源（当前运行库）",
+            "fields": {
+              "dialect": "目标方言",
+              "connectionString": "连接字符串",
+              "connectionStringHint": "sqlite 路径或 postgres URL。",
+              "overwrite": "覆盖已有数据",
+              "overwriteHint": "写入前清空目标库中的现有数据。",
+              "ssl": "启用 SSL/TLS",
+              "sslHint": "仅 postgres。"
+            },
+            "testConnection": "测试连接",
+            "startMigration": "开始迁移",
+            "migrating": "迁移中…",
+            "confirm": {
+              "title": "确认数据迁移",
+              "description": "将把当前运行库的全部数据复制到目标库，目标库已有数据将被清空。迁移期间请勿重启。",
+              "confirmLabel": "开始迁移"
+            },
+            "schema": {
+              "connectionRequired": "请输入目标数据库连接字符串。",
+              "testConnectionRequired": "请输入要测试的连接字符串。"
+            },
+            "status": {
+              "pending": "排队中",
+              "running": "迁移中",
+              "succeeded": "已完成",
+              "failed": "失败",
+              "logsTitle": "任务日志",
+              "resultTitle": "迁移结果",
+              "target": "目标",
+              "version": "版本",
+              "finishedAt": "完成时间",
+              "rowsTitle": "各表行数",
+              "rowsTotal": "共 {{count}} 行"
+            },
+            "toast": {
+              "started": "迁移任务已启动，正在后台执行。",
+              "completed": "数据迁移完成。",
+              "failed": "数据迁移失败。",
+              "startFailed": "启动迁移失败。",
+              "sameTarget": "目标数据库与当前运行库相同，无法迁移。"
+            }
           }
         },
         "maintenance": {

--- a/web/src/lib/api/settings.ts
+++ b/web/src/lib/api/settings.ts
@@ -98,18 +98,25 @@ export const settingsApi = {
       body: JSON.stringify(data),
       skipErrorHandler: true,
     }),
-  migrateExternalDatabase: (data: {
+  /**
+   * Queue a migration of the live runtime database onto an external target as
+   * an admin background task. Resolves with the task ID once the backend has
+   * accepted the job (202); progress is observed by polling `eventsApi.getTask`.
+   */
+  startDatabaseMigration: (data: {
     dialect: 'sqlite' | 'postgres'
     connectionString: string
     overwrite?: boolean
     ssl?: boolean
   }) =>
-    request('/api/settings/database/migrate', {
-      method: 'POST',
-      body: JSON.stringify(data),
-      timeoutMs: 120_000,
-      skipErrorHandler: true,
-    }),
+    request<{ success: boolean; message: string; taskId: string }>(
+      '/api/settings/database/migrate',
+      {
+        method: 'POST',
+        body: JSON.stringify(data),
+        skipErrorHandler: true,
+      }
+    ),
   getDownstreamApiKeys: () => request('/api/downstream-keys'),
   createDownstreamApiKey: (data: unknown) =>
     request('/api/downstream-keys', {


### PR DESCRIPTION
批次 D：把已就绪但被雪藏的数据库迁移能力接入管理 UI（web/src/features/settings/sections/system-info/components/）。

- 新增「数据迁移」Card：目标方言 Select + 连接串 + ssl/覆盖勾选 + 测试连接 + 危险确认（AlertDialog）+ 2s 轮询 `/api/tasks/{id}`（状态 Badge + 日志尾部 + 结果行数统计），迁移期表单禁用。
- 死代码 `migrateExternalDatabase` 重写为 `startDatabaseMigration`（202+taskId 类型化）；删除 `migrationCliOnly` 提示。
- i18n zh-CN/en 全量 key（`settings.systemInfo.database.migration.*`），无硬编码。
- 配套后端补丁（在 #fix/ts-migration-backend 分支）：migrate handler 解析 overwrite 字段。

## 验证

- `bun run typecheck` / `bun run lint` / `bun run knip` 全干净
- `bun run test` 652/652 通过（含新增 7 用例：确认弹窗、同库拒绝、轮询成功/失败）

## 自查清单

- [x] i18n 双语 + key 守卫
- [x] 危险动作用确认弹窗
- [x] 无新依赖