### PR TITLE
fix(backup): import TS backup JSON v2.1 payloads (migration fallback)

### DIFF
--- a/handler/admin/settings_backup.go
+++ b/handler/admin/settings_backup.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	backupsvc "github.com/deliciousbuding/metapi-go/service/backup"
+	"github.com/deliciousbuding/metapi-go/store"
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
 )
@@ -111,7 +112,7 @@ func isKnownTable(name string) bool {
 
 // POST /api/settings/backup/import
 func (h *backupHandler) importBackup(w http.ResponseWriter, r *http.Request) {
-	body, err := decodeBackupImportBody(r)
+	raw, err := readLimitedWebdavBody(r.Body, backupWebdavImportMaxBytes)
 	if err != nil {
 		status := http.StatusBadRequest
 		message := "导入数据格式错误：需要 JSON 对象且包含 tables 字段"
@@ -121,6 +122,18 @@ func (h *backupHandler) importBackup(w http.ResponseWriter, r *http.Request) {
 			message = err.Error()
 		}
 		writeError(w, status, message)
+		return
+	}
+
+	// TS (cita-777/metapi) backup v2.1 payloads take the dedicated parser.
+	if backupsvc.IsTSV21Payload(raw) {
+		h.importTSV21Backup(w, raw)
+		return
+	}
+
+	body, err := decodeBackupImportBodyFrom(raw)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "导入数据格式错误：需要 JSON 对象且包含 tables 字段")
 		return
 	}
 
@@ -137,13 +150,67 @@ func (h *backupHandler) importBackup(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// importTSV21Backup handles the TS backup v2.1 branch of the import endpoint.
+func (h *backupHandler) importTSV21Backup(w http.ResponseWriter, raw []byte) {
+	if err := rejectDuplicateJSONKeys(raw); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("导入数据格式错误：%v", err))
+		return
+	}
+	result, err := backupsvc.ImportTSV21(backupStoreDB(h.db), raw)
+	if err != nil {
+		writeError(w, backupImportErrorStatus(err), err.Error())
+		return
+	}
+
+	response := map[string]any{
+		"success":  true,
+		"message":  "导入完成",
+		"imported": result.Imported,
+	}
+	if result.SkippedSettings > 0 {
+		response["skippedSettings"] = result.SkippedSettings
+	}
+	if len(result.Warnings) > 0 {
+		response["warnings"] = result.Warnings
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
 // F1: preview backup import BEFORE committing. Reuses the
 // same decode + validate path as importBackup but returns a plan — per-table
 // rows to insert, rows that would be skipped (runtime-local settings), and
 // rows whose PK (id, or key for settings) already exists in the target DB
 // (ON CONFLICT DO NOTHING would drop them). No rows are written.
 func (h *backupHandler) previewBackupImport(w http.ResponseWriter, r *http.Request) {
-	body, err := decodeBackupImportBody(r)
+	raw, err := readLimitedWebdavBody(r.Body, backupWebdavImportMaxBytes)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "导入数据格式错误：需要 JSON 对象且包含 tables 字段")
+		return
+	}
+
+	// TS (cita-777/metapi) backup v2.1 payloads take the dedicated parser.
+	if backupsvc.IsTSV21Payload(raw) {
+		if err := rejectDuplicateJSONKeys(raw); err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("导入数据格式错误：%v", err))
+			return
+		}
+		preview, err := backupsvc.PreviewTSV21(backupStoreDB(h.db), raw)
+		if err != nil {
+			writeError(w, backupImportErrorStatus(err), err.Error())
+			return
+		}
+		response := map[string]any{
+			"success": true,
+			"plan":    preview.Plan,
+		}
+		if len(preview.Warnings) > 0 {
+			response["warnings"] = preview.Warnings
+		}
+		writeJSON(w, http.StatusOK, response)
+		return
+	}
+
+	body, err := decodeBackupImportBodyFrom(raw)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "导入数据格式错误：需要 JSON 对象且包含 tables 字段")
 		return
@@ -165,8 +232,8 @@ func (h *backupHandler) previewBackupImport(w http.ResponseWriter, r *http.Reque
 	})
 }
 
-// decodeBackupImportBody decodes a backup import request body and returns the
-// tables map. Accepts both shapes:
+// decodeBackupImportBodyFrom decodes a backup import request body and returns
+// the tables map. Accepts both shapes:
 // - {"tables": {...}} (backend/webdav canonical)
 // - {"data": {"tables": {...}}} (legacy frontend wrapper — api.importBackup
 // sends JSON.stringify({data}) around the pasted export which itself is
@@ -174,14 +241,14 @@ func (h *backupHandler) previewBackupImport(w http.ResponseWriter, r *http.Reque
 
 // Normalizing here fixes the manual JSON-import path that previously always
 // 400'd because the top-level key was "data" not "tables".
-func decodeBackupImportBody(r *http.Request) (map[string]json.RawMessage, error) {
+func decodeBackupImportBodyFrom(raw []byte) (map[string]json.RawMessage, error) {
 	var body struct {
 		Tables map[string]json.RawMessage `json:"tables"`
 		Data   *struct {
 			Tables map[string]json.RawMessage `json:"tables"`
 		} `json:"data"`
 	}
-	if err := decodeBackupImportRequest(r, &body); err != nil {
+	if err := decodeBackupPayload(raw, &body); err != nil {
 		return nil, err
 	}
 	if body.Tables != nil {
@@ -191,6 +258,16 @@ func decodeBackupImportBody(r *http.Request) (map[string]json.RawMessage, error)
 		return body.Data.Tables, nil
 	}
 	return nil, fmt.Errorf("导入数据格式错误：需要 JSON 对象且包含 tables 字段")
+}
+
+// backupStoreDB wraps the handler's *sqlx.DB in a store.DB so v2.1 import
+// helpers get automatic ? → $N rebinding on PostgreSQL.
+func backupStoreDB(db *sqlx.DB) *store.DB {
+	dialect := store.DialectSQLite
+	if db.DriverName() == "pgx" {
+		dialect = store.DialectPostgres
+	}
+	return &store.DB{DB: db, Dialect: dialect}
 }
 
 // backupImportPreview is the per-table preview summary.
@@ -307,14 +384,6 @@ func queryExistingPKs(db *sqlx.DB, table, pkCol string, values []string) map[str
 	return out
 }
 
-func decodeBackupImportRequest(r *http.Request, dst any) error {
-	raw, err := readLimitedWebdavBody(r.Body, backupWebdavImportMaxBytes)
-	if err != nil {
-		return err
-	}
-	return decodeBackupPayload(raw, dst)
-}
-
 func importBackupTables(db *sqlx.DB, tables map[string]json.RawMessage) (map[string]int64, error) {
 	if tables == nil {
 		return nil, fmt.Errorf("导入数据格式错误：需要 JSON 对象且包含 tables 字段")
@@ -401,6 +470,10 @@ func (e backupImportClientError) Error() string {
 func backupImportErrorStatus(err error) int {
 	var clientErr backupImportClientError
 	if errors.As(err, &clientErr) {
+		return http.StatusBadRequest
+	}
+	var tsClientErr backupsvc.TSV21ClientError
+	if errors.As(err, &tsClientErr) {
 		return http.StatusBadRequest
 	}
 	return http.StatusInternalServerError
@@ -501,14 +574,6 @@ func validateBackupImportCellValue(column string, value any) error {
 	}
 }
 
-var runtimeLocalSettingKeys = map[string]bool{
-	"auth_token":             true,
-	"backup_webdav_state_v1": true,
-	"db_ssl":                 true,
-	"db_type":                true,
-	"db_url":                 true,
-}
-
 func shouldSkipBackupImportRow(table string, row map[string]any) bool {
 	if table != "settings" {
 		return false
@@ -517,7 +582,7 @@ func shouldSkipBackupImportRow(table string, row map[string]any) bool {
 	if !ok {
 		return false
 	}
-	return runtimeLocalSettingKeys[key]
+	return backupsvc.RuntimeLocalSettingKeys[key]
 }
 
 func tableColumns(conn backupImportConn, table string) (map[string]bool, error) {

--- a/handler/admin/settings_backup_test.go
+++ b/handler/admin/settings_backup_test.go
@@ -939,3 +939,97 @@ func TestWebdavSaveAcceptsValidAutoSyncCron(t *testing.T) {
 		t.Fatalf("status = %d body=%s, want 200", rec.Code, rec.Body.String())
 	}
 }
+
+// tsV21EndpointBackup is a minimal TS (cita-777/metapi) v2.1 payload used to
+// exercise the endpoint-level branch in importBackup / previewBackupImport.
+const tsV21EndpointBackup = `{
+  "version": "2.1",
+  "timestamp": 1755678900000,
+  "accounts": {
+    "sites": [{"id": 1, "name": "站A", "url": "https://a.example.com", "platform": "new-api"}],
+    "futureSection": {"x": 1}
+  },
+  "preferences": {
+    "settings": [{"key": "theme", "value": "dark"}]
+  }
+}`
+
+func TestImportTSV21Endpoint(t *testing.T) {
+	db := setupBackupTestDB(t)
+	r := chi.NewRouter()
+	RegisterBackupRoutes(r, db.DB)
+
+	rec := doPostJSON(t, r, "/api/settings/backup/import", json.RawMessage(tsV21EndpointBackup))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+
+	var response struct {
+		Success  bool             `json:"success"`
+		Imported map[string]int64 `json:"imported"`
+		Warnings []string         `json:"warnings"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v (body=%s)", err, rec.Body.String())
+	}
+	if !response.Success {
+		t.Fatalf("success = false, body=%s", rec.Body.String())
+	}
+	if response.Imported["sites"] != 1 || response.Imported["settings"] != 1 {
+		t.Fatalf("imported = %#v, want sites=1 settings=1", response.Imported)
+	}
+	if len(response.Warnings) == 0 || !strings.Contains(strings.Join(response.Warnings, "\n"), "accounts.futureSection") {
+		t.Fatalf("warnings = %q, want unknown section warning", response.Warnings)
+	}
+
+	var siteName string
+	if err := db.Get(&siteName, "SELECT name FROM sites WHERE id = 1"); err != nil {
+		t.Fatalf("read site: %v", err)
+	}
+	if siteName != "站A" {
+		t.Fatalf("site name = %q, want 站A", siteName)
+	}
+	var themeValue string
+	if err := db.Get(&themeValue, "SELECT value FROM settings WHERE key = ?", "theme"); err != nil {
+		t.Fatalf("read setting: %v", err)
+	}
+	if themeValue != `"dark"` {
+		t.Fatalf("settings[theme] = %q, want %q", themeValue, `"dark"`)
+	}
+}
+
+func TestPreviewTSV21Endpoint(t *testing.T) {
+	db := setupBackupTestDB(t)
+	r := chi.NewRouter()
+	RegisterBackupRoutes(r, db.DB)
+
+	rec := doPostJSON(t, r, "/api/settings/backup/import/preview", json.RawMessage(tsV21EndpointBackup))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Plan    map[string]struct {
+			Rows     int64 `json:"rows"`
+			ToInsert int64 `json:"toInsert"`
+		} `json:"plan"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v (body=%s)", err, rec.Body.String())
+	}
+	if !response.Success {
+		t.Fatalf("success = false, body=%s", rec.Body.String())
+	}
+	if plan := response.Plan["sites"]; plan.Rows != 1 || plan.ToInsert != 1 {
+		t.Fatalf("sites plan = %+v, want rows=1 toInsert=1", plan)
+	}
+
+	var siteCount int
+	if err := db.Get(&siteCount, "SELECT COUNT(*) FROM sites"); err != nil {
+		t.Fatalf("count sites: %v", err)
+	}
+	if siteCount != 0 {
+		t.Fatalf("preview wrote %d site rows, want 0", siteCount)
+	}
+}

--- a/service/backup/ts_backup_v21.go
+++ b/service/backup/ts_backup_v21.go
@@ -1,0 +1,967 @@
+package backup
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/jmoiron/sqlx"
+)
+
+// TS backup v2.1 (cita-777/metapi) import support.
+//
+// The TS original exports backups in the shape produced by
+// src/server/services/backupService.ts exportBackup:
+//
+//	{
+//	  "version": "2.1",
+//	  "timestamp": 1755678900000,
+//	  "type": "all" | "accounts" | "preferences",   // omitted when "all"
+//	  "accounts": {
+//	    "sites": [...],
+//	    "siteApiEndpoints": [...],
+//	    "siteDisabledModels": [{"siteId", "modelName"}],
+//	    "accounts": [...],
+//	    "accountTokens": [...],
+//	    "tokenRoutes": [...],
+//	    "routeChannels": [...],
+//	    "routeGroupSources": [...],
+//	    "manualModels": [{"accountId", "modelName"}],
+//	    "downstreamApiKeys": [...]
+//	  },
+//	  "preferences": {
+//	    "settings": [{"key": "...", "value": <parsed JSON value>}]
+//	  }
+//	}
+//
+// Drizzle emits rows keyed by the TS camelCase property names while the Go
+// schema uses snake_case columns, so every TS field is mapped explicitly here.
+// Unknown top-level keys, unknown account sections and unknown row fields are
+// ignored and reported as warnings instead of failing the import, so future
+// TS releases with extra fields remain importable. Duplicate handling matches
+// the existing tables-path import: INSERT ... ON CONFLICT DO NOTHING (rows
+// whose primary key already exists are skipped, nothing is overwritten).
+
+// TSBackupVersionV21 is the backup version string emitted by the TS original.
+const TSBackupVersionV21 = "2.1"
+
+var (
+	// TSV21MaxRowsPerTable, TSV21MaxColumnsPerRow and TSV21MaxCellBytes mirror
+	// the tables-path import limits in handler/admin (50k rows per table,
+	// 128 columns per row, 4MB per cell).
+	TSV21MaxRowsPerTable  = 50_000
+	TSV21MaxColumnsPerRow = 128
+	TSV21MaxCellBytes     = 4 << 20
+)
+
+// RuntimeLocalSettingKeys are settings whose values are bound to the current
+// deployment (admin credentials, DB wiring, webdav sync state). Backup imports
+// must never overwrite them. Shared with the tables-path import in
+// handler/admin so both paths apply the same policy.
+var RuntimeLocalSettingKeys = map[string]bool{
+	"auth_token":             true,
+	"backup_webdav_state_v1": true,
+	"db_ssl":                 true,
+	"db_type":                true,
+	"db_url":                 true,
+}
+
+// TSV21ClientError reports a payload problem that is the caller's fault
+// (malformed JSON, missing required fields, limit violations). Handlers map it
+// to HTTP 400.
+type TSV21ClientError struct {
+	Message string
+}
+
+func (e TSV21ClientError) Error() string { return e.Message }
+
+// IsTSV21Payload reports whether raw looks like a TS backup JSON carrying
+// version "2.1".
+func IsTSV21Payload(raw []byte) bool {
+	var probe struct {
+		Version json.RawMessage `json:"version"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return false
+	}
+	var version string
+	if err := json.Unmarshal(probe.Version, &version); err != nil {
+		return false
+	}
+	return version == TSBackupVersionV21
+}
+
+// TSV21Parsed is a v2.1 payload normalized to canonical snake_case table rows
+// in FK-safe import order.
+type TSV21Parsed struct {
+	// Type is the optional top-level type ("all" | "accounts" | "preferences");
+	// empty when the payload has no type field.
+	Type string
+	// TableOrder lists Go tables in FK-safe import order.
+	TableOrder []string
+	// Tables maps Go table names to converted rows.
+	Tables map[string][]map[string]any
+	// Warnings collects everything that was ignored (unknown fields/sections,
+	// malformed rows). Imports must never fail because of them.
+	Warnings []string
+	// SkippedSettings counts settings rows excluded by policy (runtime-local
+	// keys, empty keys).
+	SkippedSettings int64
+}
+
+// ParseTSV21 converts a v2.1 payload into canonical table rows. It performs
+// all structural validation but does not touch the database.
+func ParseTSV21(raw []byte) (*TSV21Parsed, error) {
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return nil, TSV21ClientError{Message: fmt.Sprintf("导入数据格式错误：无法解析 JSON：%v", err)}
+	}
+	if top == nil {
+		return nil, TSV21ClientError{Message: "导入数据格式错误：必须为 JSON 对象"}
+	}
+
+	parsed := &TSV21Parsed{Tables: map[string][]map[string]any{}}
+
+	// The TS importer refuses payloads without a timestamp; mirror that so
+	// truncated files fail with a clear message instead of importing half data.
+	if rawTimestamp, ok := top["timestamp"]; !ok || isRawJSONNull(rawTimestamp) {
+		return nil, TSV21ClientError{Message: "导入数据格式错误：缺少 timestamp"}
+	}
+
+	if rawType, ok := top["type"]; ok && !isRawJSONNull(rawType) {
+		_ = json.Unmarshal(rawType, &parsed.Type)
+	}
+
+	for key := range top {
+		switch key {
+		case "version", "timestamp", "type", "accounts", "preferences":
+		default:
+			parsed.Warnings = append(parsed.Warnings, fmt.Sprintf("忽略未知顶层字段 %s", key))
+		}
+	}
+
+	accountsRaw, hasAccounts := top["accounts"]
+	preferencesRaw, hasPreferences := top["preferences"]
+	if hasAccounts && isRawJSONNull(accountsRaw) {
+		hasAccounts = false
+	}
+	if hasPreferences && isRawJSONNull(preferencesRaw) {
+		hasPreferences = false
+	}
+
+	// Mirror TS importBackup gating: the type field forces a section, sections
+	// that are present are always imported.
+	accountsRequested := parsed.Type == "accounts" || hasAccounts
+	preferencesRequested := parsed.Type == "preferences" || hasPreferences
+	if !accountsRequested && !preferencesRequested {
+		return nil, TSV21ClientError{Message: "导入数据中没有可识别的账号或设置数据"}
+	}
+	if parsed.Type == "accounts" && !hasAccounts {
+		return nil, TSV21ClientError{Message: "导入数据格式错误：账号数据结构不正确"}
+	}
+	if parsed.Type == "preferences" && !hasPreferences {
+		return nil, TSV21ClientError{Message: "导入数据格式错误：设置数据结构不正确"}
+	}
+
+	if hasAccounts {
+		if err := parseTSV21AccountsSectionInto(accountsRaw, parsed); err != nil {
+			return nil, err
+		}
+	}
+	if hasPreferences {
+		if err := parseTSV21PreferencesSectionInto(preferencesRaw, parsed); err != nil {
+			return nil, err
+		}
+	}
+
+	sort.Strings(parsed.Warnings)
+	return parsed, nil
+}
+
+func isRawJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+}
+
+// ---- field mapping ----
+
+type tsV21FieldKind int
+
+const (
+	tsV21Text     tsV21FieldKind = iota
+	tsV21JSONText                // JSON-encoded TEXT column: non-string values are re-marshaled
+	tsV21Int
+	tsV21Bool
+	tsV21Real
+)
+
+type tsV21Field struct {
+	tsName   string
+	goColumn string
+	kind     tsV21FieldKind
+}
+
+type tsV21TableSpec struct {
+	goTable string
+	section string
+	// required lists Go columns that must be present in every row (NOT NULL
+	// without a default in the Go schema).
+	required []string
+	fields   []tsV21Field
+	fieldSet map[string]bool
+}
+
+func newTSV21TableSpec(goTable, section string, required []string, fields ...tsV21Field) tsV21TableSpec {
+	spec := tsV21TableSpec{
+		goTable:  goTable,
+		section:  section,
+		required: required,
+		fields:   fields,
+		fieldSet: map[string]bool{},
+	}
+	for _, field := range fields {
+		spec.fieldSet[field.tsName] = true
+	}
+	return spec
+}
+
+// tsV21AccountTableSpecs lists the regular account sections in FK-safe import
+// order. manualModels is handled separately because it maps into
+// model_availability with synthetic columns.
+var tsV21AccountTableSpecs = []tsV21TableSpec{
+	newTSV21TableSpec("sites", "sites",
+		[]string{"name", "url", "platform"},
+		tsV21Field{"id", "id", tsV21Int},
+		tsV21Field{"name", "name", tsV21Text},
+		tsV21Field{"url", "url", tsV21Text},
+		tsV21Field{"externalCheckinUrl", "external_checkin_url", tsV21Text},
+		tsV21Field{"platform", "platform", tsV21Text},
+		tsV21Field{"proxyUrl", "proxy_url", tsV21Text},
+		tsV21Field{"useSystemProxy", "use_system_proxy", tsV21Bool},
+		tsV21Field{"customHeaders", "custom_headers", tsV21JSONText},
+		tsV21Field{"status", "status", tsV21Text},
+		tsV21Field{"isPinned", "is_pinned", tsV21Bool},
+		tsV21Field{"sortOrder", "sort_order", tsV21Int},
+		tsV21Field{"globalWeight", "global_weight", tsV21Real},
+		tsV21Field{"apiKey", "api_key", tsV21Text},
+		tsV21Field{"postRefreshProbeEnabled", "post_refresh_probe_enabled", tsV21Bool},
+		tsV21Field{"postRefreshProbeModel", "post_refresh_probe_model", tsV21Text},
+		tsV21Field{"postRefreshProbeScope", "post_refresh_probe_scope", tsV21Text},
+		tsV21Field{"postRefreshProbeLatencyThresholdMs", "post_refresh_probe_latency_threshold_ms", tsV21Int},
+		tsV21Field{"createdAt", "created_at", tsV21Text},
+		tsV21Field{"updatedAt", "updated_at", tsV21Text},
+	),
+	newTSV21TableSpec("site_api_endpoints", "siteApiEndpoints",
+		[]string{"site_id", "url"},
+		tsV21Field{"id", "id", tsV21Int},
+		tsV21Field{"siteId", "site_id", tsV21Int},
+		tsV21Field{"url", "url", tsV21Text},
+		tsV21Field{"enabled", "enabled", tsV21Bool},
+		tsV21Field{"sortOrder", "sort_order", tsV21Int},
+		tsV21Field{"cooldownUntil", "cooldown_until", tsV21Text},
+		tsV21Field{"lastSelectedAt", "last_selected_at", tsV21Text},
+		tsV21Field{"lastFailedAt", "last_failed_at", tsV21Text},
+		tsV21Field{"lastFailureReason", "last_failure_reason", tsV21Text},
+		tsV21Field{"createdAt", "created_at", tsV21Text},
+		tsV21Field{"updatedAt", "updated_at", tsV21Text},
+	),
+	newTSV21TableSpec("site_disabled_models", "siteDisabledModels",
+		[]string{"site_id", "model_name"},
+		tsV21Field{"siteId", "site_id", tsV21Int},
+		tsV21Field{"modelName", "model_name", tsV21Text},
+	),
+	newTSV21TableSpec("accounts", "accounts",
+		[]string{"site_id", "access_token"},
+		tsV21Field{"id", "id", tsV21Int},
+		tsV21Field{"siteId", "site_id", tsV21Int},
+		tsV21Field{"username", "username", tsV21Text},
+		tsV21Field{"accessToken", "access_token", tsV21Text},
+		tsV21Field{"apiToken", "api_token", tsV21Text},
+		tsV21Field{"balance", "balance", tsV21Real},
+		tsV21Field{"balanceUsed", "balance_used", tsV21Real},
+		tsV21Field{"quota", "quota", tsV21Real},
+		tsV21Field{"unitCost", "unit_cost", tsV21Real},
+		tsV21Field{"valueScore", "value_score", tsV21Real},
+		tsV21Field{"status", "status", tsV21Text},
+		tsV21Field{"isPinned", "is_pinned", tsV21Bool},
+		tsV21Field{"sortOrder", "sort_order", tsV21Int},
+		tsV21Field{"checkinEnabled", "checkin_enabled", tsV21Bool},
+		tsV21Field{"lastCheckinAt", "last_checkin_at", tsV21Text},
+		tsV21Field{"lastBalanceRefresh", "last_balance_refresh", tsV21Text},
+		tsV21Field{"oauthProvider", "oauth_provider", tsV21Text},
+		tsV21Field{"oauthAccountKey", "oauth_account_key", tsV21Text},
+		tsV21Field{"oauthProjectId", "oauth_project_id", tsV21Text},
+		tsV21Field{"extraConfig", "extra_config", tsV21JSONText},
+		tsV21Field{"createdAt", "created_at", tsV21Text},
+		tsV21Field{"updatedAt", "updated_at", tsV21Text},
+	),
+	newTSV21TableSpec("account_tokens", "accountTokens",
+		[]string{"account_id", "name", "token"},
+		tsV21Field{"id", "id", tsV21Int},
+		tsV21Field{"accountId", "account_id", tsV21Int},
+		tsV21Field{"name", "name", tsV21Text},
+		tsV21Field{"token", "token", tsV21Text},
+		tsV21Field{"tokenGroup", "token_group", tsV21Text},
+		tsV21Field{"valueStatus", "value_status", tsV21Text},
+		tsV21Field{"source", "source", tsV21Text},
+		tsV21Field{"enabled", "enabled", tsV21Bool},
+		tsV21Field{"isDefault", "is_default", tsV21Bool},
+		tsV21Field{"createdAt", "created_at", tsV21Text},
+		tsV21Field{"updatedAt", "updated_at", tsV21Text},
+	),
+	newTSV21TableSpec("token_routes", "tokenRoutes",
+		[]string{"model_pattern"},
+		tsV21Field{"id", "id", tsV21Int},
+		tsV21Field{"modelPattern", "model_pattern", tsV21Text},
+		tsV21Field{"displayName", "display_name", tsV21Text},
+		tsV21Field{"displayIcon", "display_icon", tsV21Text},
+		tsV21Field{"routeMode", "route_mode", tsV21Text},
+		tsV21Field{"modelMapping", "model_mapping", tsV21JSONText},
+		tsV21Field{"decisionSnapshot", "decision_snapshot", tsV21JSONText},
+		tsV21Field{"decisionRefreshedAt", "decision_refreshed_at", tsV21Text},
+		tsV21Field{"routingStrategy", "routing_strategy", tsV21Text},
+		tsV21Field{"enabled", "enabled", tsV21Bool},
+		tsV21Field{"createdAt", "created_at", tsV21Text},
+		tsV21Field{"updatedAt", "updated_at", tsV21Text},
+	),
+	newTSV21TableSpec("route_group_sources", "routeGroupSources",
+		[]string{"group_route_id", "source_route_id"},
+		tsV21Field{"id", "id", tsV21Int},
+		tsV21Field{"groupRouteId", "group_route_id", tsV21Int},
+		tsV21Field{"sourceRouteId", "source_route_id", tsV21Int},
+	),
+	newTSV21TableSpec("route_channels", "routeChannels",
+		[]string{"route_id", "account_id"},
+		tsV21Field{"id", "id", tsV21Int},
+		tsV21Field{"routeId", "route_id", tsV21Int},
+		tsV21Field{"accountId", "account_id", tsV21Int},
+		tsV21Field{"tokenId", "token_id", tsV21Int},
+		tsV21Field{"oauthRouteUnitId", "oauth_route_unit_id", tsV21Int},
+		tsV21Field{"sourceModel", "source_model", tsV21Text},
+		tsV21Field{"priority", "priority", tsV21Int},
+		tsV21Field{"weight", "weight", tsV21Int},
+		tsV21Field{"enabled", "enabled", tsV21Bool},
+		tsV21Field{"manualOverride", "manual_override", tsV21Bool},
+		tsV21Field{"successCount", "success_count", tsV21Int},
+		tsV21Field{"failCount", "fail_count", tsV21Int},
+		tsV21Field{"totalLatencyMs", "total_latency_ms", tsV21Int},
+		tsV21Field{"totalCost", "total_cost", tsV21Real},
+		tsV21Field{"lastUsedAt", "last_used_at", tsV21Text},
+		tsV21Field{"lastSelectedAt", "last_selected_at", tsV21Text},
+		tsV21Field{"lastFailAt", "last_fail_at", tsV21Text},
+		tsV21Field{"consecutiveFailCount", "consecutive_fail_count", tsV21Int},
+		tsV21Field{"cooldownLevel", "cooldown_level", tsV21Int},
+		tsV21Field{"cooldownUntil", "cooldown_until", tsV21Text},
+	),
+	newTSV21TableSpec("downstream_api_keys", "downstreamApiKeys",
+		[]string{"name", "key"},
+		tsV21Field{"name", "name", tsV21Text},
+		tsV21Field{"key", "key", tsV21Text},
+		tsV21Field{"description", "description", tsV21Text},
+		tsV21Field{"groupName", "group_name", tsV21Text},
+		tsV21Field{"tags", "tags", tsV21JSONText},
+		tsV21Field{"enabled", "enabled", tsV21Bool},
+		tsV21Field{"expiresAt", "expires_at", tsV21Text},
+		tsV21Field{"maxCost", "max_cost", tsV21Real},
+		tsV21Field{"usedCost", "used_cost", tsV21Real},
+		tsV21Field{"maxRequests", "max_requests", tsV21Int},
+		tsV21Field{"usedRequests", "used_requests", tsV21Int},
+		tsV21Field{"supportedModels", "supported_models", tsV21JSONText},
+		tsV21Field{"allowedRouteIds", "allowed_route_ids", tsV21JSONText},
+		tsV21Field{"siteWeightMultipliers", "site_weight_multipliers", tsV21JSONText},
+		tsV21Field{"excludedSiteIds", "excluded_site_ids", tsV21JSONText},
+		tsV21Field{"excludedCredentialRefs", "excluded_credential_refs", tsV21JSONText},
+		tsV21Field{"lastUsedAt", "last_used_at", tsV21Text},
+	),
+}
+
+// tsV21KnownAccountSections is every section name the TS v2.1 accounts object
+// may carry. Anything else is reported as an unknown section.
+var tsV21KnownAccountSections = map[string]bool{
+	"sites":              true,
+	"siteApiEndpoints":   true,
+	"siteDisabledModels": true,
+	"accounts":           true,
+	"accountTokens":      true,
+	"tokenRoutes":        true,
+	"routeChannels":      true,
+	"routeGroupSources":  true,
+	"manualModels":       true,
+	"downstreamApiKeys":  true,
+}
+
+func parseTSV21AccountsSectionInto(raw json.RawMessage, parsed *TSV21Parsed) error {
+	var section map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &section); err != nil || section == nil {
+		return TSV21ClientError{Message: "导入数据格式错误：accounts 必须是 JSON 对象"}
+	}
+
+	for key := range section {
+		if !tsV21KnownAccountSections[key] {
+			parsed.Warnings = append(parsed.Warnings, fmt.Sprintf("忽略未知节 accounts.%s", key))
+		}
+	}
+
+	// Parent tables first, manualModels in the middle (model_availability
+	// references accounts), children afterwards.
+	for _, spec := range tsV21AccountTableSpecs[:5] {
+		if err := appendTSV21SectionRows(section, spec, parsed); err != nil {
+			return err
+		}
+	}
+	if err := appendTSV21ManualModels(section, parsed); err != nil {
+		return err
+	}
+	for _, spec := range tsV21AccountTableSpecs[5:] {
+		if err := appendTSV21SectionRows(section, spec, parsed); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func appendTSV21SectionRows(section map[string]json.RawMessage, spec tsV21TableSpec, parsed *TSV21Parsed) error {
+	rawRows, present := section[spec.section]
+	if !present || isRawJSONNull(rawRows) {
+		return nil
+	}
+	rows, err := parseTSV21SectionRows(spec, rawRows, &parsed.Warnings)
+	if err != nil {
+		return err
+	}
+	if len(rows) > 0 {
+		parsed.Tables[spec.goTable] = rows
+		parsed.TableOrder = append(parsed.TableOrder, spec.goTable)
+	}
+	return nil
+}
+
+func parseTSV21SectionRows(spec tsV21TableSpec, raw json.RawMessage, warnings *[]string) ([]map[string]any, error) {
+	var rawRows []json.RawMessage
+	if err := json.Unmarshal(raw, &rawRows); err != nil {
+		return nil, TSV21ClientError{Message: fmt.Sprintf("导入数据格式错误：accounts.%s 必须是数组", spec.section)}
+	}
+	if TSV21MaxRowsPerTable > 0 && len(rawRows) > TSV21MaxRowsPerTable {
+		return nil, TSV21ClientError{Message: fmt.Sprintf("导入失败：accounts.%s 行数超过上限 %d", spec.section, TSV21MaxRowsPerTable)}
+	}
+
+	unknownFieldCounts := map[string]int{}
+	rows := make([]map[string]any, 0, len(rawRows))
+	for i, rawRow := range rawRows {
+		var row map[string]any
+		if err := json.Unmarshal(rawRow, &row); err != nil || row == nil {
+			*warnings = append(*warnings, fmt.Sprintf("忽略 accounts.%s 第 %d 行：不是 JSON 对象", spec.section, i+1))
+			continue
+		}
+
+		converted, err := convertTSV21Row(spec, row, i+1)
+		if err != nil {
+			return nil, err
+		}
+		if TSV21MaxColumnsPerRow > 0 && len(converted) > TSV21MaxColumnsPerRow {
+			return nil, TSV21ClientError{Message: fmt.Sprintf("导入失败：accounts.%s 第 %d 行超过 %d 列上限", spec.section, i+1, TSV21MaxColumnsPerRow)}
+		}
+		for field := range row {
+			if !spec.fieldSet[field] {
+				unknownFieldCounts[field]++
+			}
+		}
+		if len(converted) > 0 {
+			rows = append(rows, converted)
+		}
+	}
+
+	unknownFields := make([]string, 0, len(unknownFieldCounts))
+	for field := range unknownFieldCounts {
+		unknownFields = append(unknownFields, field)
+	}
+	sort.Strings(unknownFields)
+	for _, field := range unknownFields {
+		count := unknownFieldCounts[field]
+		if count > 1 {
+			*warnings = append(*warnings, fmt.Sprintf("忽略未知字段 %s.%s（%d 行）", spec.section, field, count))
+		} else {
+			*warnings = append(*warnings, fmt.Sprintf("忽略未知字段 %s.%s", spec.section, field))
+		}
+	}
+	return rows, nil
+}
+
+func convertTSV21Row(spec tsV21TableSpec, row map[string]any, rowIndex int) (map[string]any, error) {
+	converted := make(map[string]any, len(spec.fields))
+	for _, field := range spec.fields {
+		value, present := row[field.tsName]
+		if !present {
+			continue
+		}
+		normalized, err := convertTSV21FieldValue(field, value)
+		if err != nil {
+			return nil, err
+		}
+		converted[field.goColumn] = normalized
+	}
+	for _, required := range spec.required {
+		if _, ok := converted[required]; !ok {
+			return nil, TSV21ClientError{Message: fmt.Sprintf("导入失败：accounts.%s 第 %d 行缺少必填字段 %s", spec.section, rowIndex, required)}
+		}
+	}
+	return converted, nil
+}
+
+func convertTSV21FieldValue(field tsV21Field, value any) (any, error) {
+	switch field.kind {
+	case tsV21Text:
+		switch v := value.(type) {
+		case nil:
+			return nil, nil
+		case string:
+			if err := checkTSV21CellBytes(field.tsName, v); err != nil {
+				return nil, err
+			}
+			return v, nil
+		default:
+			return nil, TSV21ClientError{Message: fmt.Sprintf("导入失败：字段 %s 必须是字符串或 null", field.tsName)}
+		}
+	case tsV21JSONText:
+		switch v := value.(type) {
+		case nil:
+			return nil, nil
+		case string:
+			if err := checkTSV21CellBytes(field.tsName, v); err != nil {
+				return nil, err
+			}
+			return v, nil
+		default:
+			raw, err := json.Marshal(v)
+			if err != nil {
+				return nil, TSV21ClientError{Message: fmt.Sprintf("导入失败：字段 %s 无法序列化：%v", field.tsName, err)}
+			}
+			if err := checkTSV21CellBytes(field.tsName, string(raw)); err != nil {
+				return nil, err
+			}
+			return string(raw), nil
+		}
+	case tsV21Int:
+		switch v := value.(type) {
+		case nil:
+			return nil, nil
+		case float64:
+			if math.IsNaN(v) || math.IsInf(v, 0) || math.Trunc(v) != v {
+				return nil, TSV21ClientError{Message: fmt.Sprintf("导入失败：字段 %s 必须是整数", field.tsName)}
+			}
+			return int64(v), nil
+		case int64:
+			return v, nil
+		default:
+			return nil, TSV21ClientError{Message: fmt.Sprintf("导入失败：字段 %s 必须是整数", field.tsName)}
+		}
+	case tsV21Bool:
+		switch v := value.(type) {
+		case nil:
+			return nil, nil
+		case bool:
+			return v, nil
+		case float64:
+			if v == 0 {
+				return false, nil
+			}
+			if v == 1 {
+				return true, nil
+			}
+		}
+		return nil, TSV21ClientError{Message: fmt.Sprintf("导入失败：字段 %s 必须是布尔值", field.tsName)}
+	case tsV21Real:
+		switch v := value.(type) {
+		case nil:
+			return nil, nil
+		case float64:
+			return v, nil
+		case int64:
+			return float64(v), nil
+		}
+		return nil, TSV21ClientError{Message: fmt.Sprintf("导入失败：字段 %s 必须是数字", field.tsName)}
+	default:
+		return nil, TSV21ClientError{Message: fmt.Sprintf("导入失败：字段 %s 类型无法识别", field.tsName)}
+	}
+}
+
+func checkTSV21CellBytes(field, value string) error {
+	if TSV21MaxCellBytes > 0 && len(value) > TSV21MaxCellBytes {
+		return TSV21ClientError{Message: fmt.Sprintf("导入失败：字段 %s 超过 %d 字节上限", field, TSV21MaxCellBytes)}
+	}
+	return nil
+}
+
+// appendTSV21ManualModels maps TS manualModels rows into model_availability
+// rows with is_manual=true / available=true (mirroring the TS importer).
+func appendTSV21ManualModels(section map[string]json.RawMessage, parsed *TSV21Parsed) error {
+	rawRows, present := section["manualModels"]
+	if !present || isRawJSONNull(rawRows) {
+		return nil
+	}
+	var rawList []json.RawMessage
+	if err := json.Unmarshal(rawRows, &rawList); err != nil {
+		return TSV21ClientError{Message: "导入数据格式错误：accounts.manualModels 必须是数组"}
+	}
+	if TSV21MaxRowsPerTable > 0 && len(rawList) > TSV21MaxRowsPerTable {
+		return TSV21ClientError{Message: fmt.Sprintf("导入失败：accounts.manualModels 行数超过上限 %d", TSV21MaxRowsPerTable)}
+	}
+
+	checkedAt := time.Now().UTC().Format(time.RFC3339)
+	rows := make([]map[string]any, 0, len(rawList))
+	for i, rawRow := range rawList {
+		var row map[string]any
+		if err := json.Unmarshal(rawRow, &row); err != nil || row == nil {
+			parsed.Warnings = append(parsed.Warnings, fmt.Sprintf("忽略 accounts.manualModels 第 %d 行：不是 JSON 对象", i+1))
+			continue
+		}
+		accountID, err := convertTSV21FieldValue(tsV21Field{tsName: "accountId", goColumn: "account_id", kind: tsV21Int}, row["accountId"])
+		if err != nil {
+			return err
+		}
+		if accountID == nil {
+			return TSV21ClientError{Message: fmt.Sprintf("导入失败：accounts.manualModels 第 %d 行缺少必填字段 accountId", i+1)}
+		}
+		modelName, ok := row["modelName"].(string)
+		modelName = strings.TrimSpace(modelName)
+		if !ok || modelName == "" {
+			return TSV21ClientError{Message: fmt.Sprintf("导入失败：accounts.manualModels 第 %d 行缺少必填字段 modelName", i+1)}
+		}
+		for field := range row {
+			if field != "accountId" && field != "modelName" {
+				parsed.Warnings = append(parsed.Warnings, fmt.Sprintf("忽略未知字段 manualModels.%s", field))
+			}
+		}
+		rows = append(rows, map[string]any{
+			"account_id": accountID,
+			"model_name": modelName,
+			"available":  true,
+			"is_manual":  true,
+			"latency_ms": nil,
+			"checked_at": checkedAt,
+		})
+	}
+	if len(rows) > 0 {
+		parsed.Tables["model_availability"] = rows
+		parsed.TableOrder = append(parsed.TableOrder, "model_availability")
+	}
+	return nil
+}
+
+func parseTSV21PreferencesSectionInto(raw json.RawMessage, parsed *TSV21Parsed) error {
+	var section map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &section); err != nil || section == nil {
+		return TSV21ClientError{Message: "导入数据格式错误：preferences 必须是 JSON 对象"}
+	}
+	for key := range section {
+		if key != "settings" {
+			parsed.Warnings = append(parsed.Warnings, fmt.Sprintf("忽略未知节 preferences.%s", key))
+		}
+	}
+
+	rawSettings, present := section["settings"]
+	if !present || isRawJSONNull(rawSettings) {
+		return TSV21ClientError{Message: "导入数据格式错误：preferences.settings 必须是数组"}
+	}
+	var rawRows []json.RawMessage
+	if err := json.Unmarshal(rawSettings, &rawRows); err != nil {
+		return TSV21ClientError{Message: "导入数据格式错误：preferences.settings 必须是数组"}
+	}
+	if TSV21MaxRowsPerTable > 0 && len(rawRows) > TSV21MaxRowsPerTable {
+		return TSV21ClientError{Message: fmt.Sprintf("导入失败：preferences.settings 行数超过上限 %d", TSV21MaxRowsPerTable)}
+	}
+
+	rows := make([]map[string]any, 0, len(rawRows))
+	for i, rawRow := range rawRows {
+		var row map[string]any
+		if err := json.Unmarshal(rawRow, &row); err != nil || row == nil {
+			parsed.Warnings = append(parsed.Warnings, fmt.Sprintf("忽略 preferences.settings 第 %d 行：不是 JSON 对象", i+1))
+			continue
+		}
+
+		key, _ := row["key"].(string)
+		key = strings.TrimSpace(key)
+		if key == "" {
+			parsed.SkippedSettings++
+			parsed.Warnings = append(parsed.Warnings, fmt.Sprintf("忽略 preferences.settings 第 %d 行：key 缺失或为空", i+1))
+			continue
+		}
+		if RuntimeLocalSettingKeys[key] {
+			parsed.SkippedSettings++
+			continue
+		}
+
+		for field := range row {
+			if field != "key" && field != "value" {
+				parsed.Warnings = append(parsed.Warnings, fmt.Sprintf("忽略未知字段 settings.%s", field))
+			}
+		}
+
+		value, hasValue := row["value"]
+		if !hasValue {
+			value = nil
+		}
+		// The TS importer stores JSON.stringify(value); the Go settings table
+		// also holds JSON-encoded text, so re-marshal the parsed value.
+		rawValue, err := json.Marshal(value)
+		if err != nil {
+			return TSV21ClientError{Message: fmt.Sprintf("导入失败：preferences.settings 第 %d 行 value 无法序列化：%v", i+1, err)}
+		}
+		if err := checkTSV21CellBytes("value", string(rawValue)); err != nil {
+			return err
+		}
+		rows = append(rows, map[string]any{"key": key, "value": string(rawValue)})
+	}
+	if len(rows) > 0 {
+		parsed.Tables["settings"] = rows
+		parsed.TableOrder = append(parsed.TableOrder, "settings")
+	}
+	return nil
+}
+
+// ---- import ----
+
+// TSV21ImportResult reports what a v2.1 import actually did.
+type TSV21ImportResult struct {
+	// Imported maps Go table names to the number of rows inserted. Rows whose
+	// primary key already existed are skipped (ON CONFLICT DO NOTHING).
+	Imported map[string]int64 `json:"imported"`
+	// SkippedSettings counts settings rows excluded by policy.
+	SkippedSettings int64    `json:"skippedSettings,omitempty"`
+	Warnings        []string `json:"warnings,omitempty"`
+}
+
+// ImportTSV21 parses a v2.1 payload and imports it into db inside a single
+// transaction. Duplicate handling matches the tables-path import: rows whose
+// primary key already exists are skipped, nothing is overwritten.
+func ImportTSV21(db *store.DB, raw []byte) (*TSV21ImportResult, error) {
+	parsed, err := ParseTSV21(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := db.Beginx()
+	if err != nil {
+		return nil, fmt.Errorf("begin import tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	result, err := importTSV21Parsed(tx, parsed)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit import tx: %w", err)
+	}
+	committed = true
+	return result, nil
+}
+
+// tsV21Conn is satisfied by both *store.DB and *sqlx.Tx; every statement goes
+// through Rebind so ? placeholders work on PostgreSQL as well as SQLite.
+type tsV21Conn interface {
+	Rebind(query string) string
+	Queryx(query string, args ...any) (*sqlx.Rows, error)
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
+func importTSV21Parsed(conn tsV21Conn, parsed *TSV21Parsed) (*TSV21ImportResult, error) {
+	result := &TSV21ImportResult{
+		Imported:        map[string]int64{},
+		SkippedSettings: parsed.SkippedSettings,
+		Warnings:        parsed.Warnings,
+	}
+	for _, table := range parsed.TableOrder {
+		count, err := importTSV21TableRows(conn, table, parsed.Tables[table])
+		if err != nil {
+			return nil, fmt.Errorf("导入失败：表 %s：%w", table, err)
+		}
+		result.Imported[table] = count
+	}
+	return result, nil
+}
+
+func importTSV21TableRows(conn tsV21Conn, table string, rows []map[string]any) (int64, error) {
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	knownColumns, err := tsV21TableColumns(conn, table)
+	if err != nil {
+		return 0, err
+	}
+
+	var imported int64
+	for _, row := range rows {
+		if len(row) == 0 {
+			continue
+		}
+		columns := make([]string, 0, len(row))
+		values := make([]any, 0, len(row))
+		for column, value := range row {
+			if !knownColumns[column] {
+				return 0, fmt.Errorf("目标库中表 %s 不存在列 %q", table, column)
+			}
+			columns = append(columns, column)
+			values = append(values, value)
+		}
+
+		quotedColumns := make([]string, len(columns))
+		placeholders := make([]string, len(columns))
+		for i, column := range columns {
+			quotedColumns[i] = quoteIdentifier(column)
+			placeholders[i] = "?"
+		}
+		query := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s) ON CONFLICT DO NOTHING",
+			quoteIdentifier(table),
+			strings.Join(quotedColumns, ", "),
+			strings.Join(placeholders, ", "),
+		)
+		result, err := conn.Exec(conn.Rebind(query), values...)
+		if err != nil {
+			return 0, fmt.Errorf("insert row: %w", err)
+		}
+		affected, _ := result.RowsAffected()
+		imported += affected
+	}
+	return imported, nil
+}
+
+func tsV21TableColumns(conn tsV21Conn, table string) (map[string]bool, error) {
+	query := fmt.Sprintf("SELECT * FROM %s LIMIT 0", quoteIdentifier(table))
+	rows, err := conn.Queryx(conn.Rebind(query))
+	if err != nil {
+		return nil, fmt.Errorf("read table columns: %w", err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, fmt.Errorf("read table columns: %w", err)
+	}
+	allowed := make(map[string]bool, len(cols))
+	for _, col := range cols {
+		allowed[col] = true
+	}
+	return allowed, nil
+}
+
+// ---- preview ----
+
+// TSV21TablePreview is the per-table preview plan for a v2.1 import.
+type TSV21TablePreview struct {
+	Rows        int64 `json:"rows"`
+	ToInsert    int64 `json:"toInsert"`
+	Duplicates  int64 `json:"duplicates"`
+	SkippedRows int64 `json:"skippedRows"`
+}
+
+// TSV21PreviewResult is the full v2.1 import plan without writes.
+type TSV21PreviewResult struct {
+	Plan     map[string]TSV21TablePreview `json:"plan"`
+	Warnings []string                     `json:"warnings,omitempty"`
+}
+
+// PreviewTSV21 computes the import plan for a v2.1 payload without writing
+// anything. PK detection mirrors the tables-path preview: "id" for every table
+// except "settings" which uses "key".
+func PreviewTSV21(db *store.DB, raw []byte) (*TSV21PreviewResult, error) {
+	parsed, err := ParseTSV21(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	preview := &TSV21PreviewResult{
+		Plan:     map[string]TSV21TablePreview{},
+		Warnings: parsed.Warnings,
+	}
+	for _, table := range parsed.TableOrder {
+		rows := parsed.Tables[table]
+		plan := TSV21TablePreview{Rows: int64(len(rows))}
+		if table == "settings" {
+			plan.SkippedRows = parsed.SkippedSettings
+		}
+		pkColumn := "id"
+		if table == "settings" {
+			pkColumn = "key"
+		}
+
+		existing := map[string]bool{}
+		var pkValues []string
+		hasPKColumn := false
+		for _, row := range rows {
+			rawValue, present := row[pkColumn]
+			if !present {
+				plan.ToInsert++
+				continue
+			}
+			hasPKColumn = true
+			pk := fmt.Sprintf("%v", rawValue)
+			if _, duplicate := existing[pk]; duplicate {
+				plan.Duplicates++
+				continue
+			}
+			existing[pk] = true
+			pkValues = append(pkValues, pk)
+		}
+		if hasPKColumn && len(pkValues) > 0 {
+			existingInDB := tsV21QueryExistingPKs(db, table, pkColumn, pkValues)
+			for _, pk := range pkValues {
+				if existingInDB[pk] {
+					plan.Duplicates++
+				} else {
+					plan.ToInsert++
+				}
+			}
+		}
+		preview.Plan[table] = plan
+	}
+	return preview, nil
+}
+
+// tsV21QueryExistingPKs returns the set of PK values already present in the
+// table, chunked to stay under SQL variable limits (SQLite 999 / PG 65535).
+// Preview is best-effort: a read failure degrades to "no existing PKs known".
+func tsV21QueryExistingPKs(conn tsV21Conn, table, pkColumn string, values []string) map[string]bool {
+	out := map[string]bool{}
+	if len(values) == 0 {
+		return out
+	}
+	const chunkSize = 500
+	for start := 0; start < len(values); start += chunkSize {
+		end := start + chunkSize
+		if end > len(values) {
+			end = len(values)
+		}
+		chunk := values[start:end]
+		placeholders := make([]string, len(chunk))
+		args := make([]any, len(chunk))
+		for i, value := range chunk {
+			placeholders[i] = "?"
+			args[i] = value
+		}
+		query := fmt.Sprintf("SELECT %s FROM %s WHERE %s IN (%s)",
+			quoteIdentifier(pkColumn), quoteIdentifier(table), quoteIdentifier(pkColumn), strings.Join(placeholders, ","))
+		rows, err := conn.Queryx(conn.Rebind(query), args...)
+		if err != nil {
+			return out
+		}
+		for rows.Next() {
+			var value string
+			if err := rows.Scan(&value); err == nil {
+				out[value] = true
+			}
+		}
+		_ = rows.Close()
+	}
+	return out
+}

--- a/service/backup/ts_backup_v21_test.go
+++ b/service/backup/ts_backup_v21_test.go
@@ -1,0 +1,616 @@
+package backup_test
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	backupsvc "github.com/deliciousbuding/metapi-go/service/backup"
+)
+
+// tsV21SampleBackup is a realistic TS (cita-777/metapi) backup JSON v2.1
+// payload matching the shape produced by exportBackup in backupService.ts:
+// drizzle rows keyed by camelCase property names, settings values as parsed
+// JSON, plus a few unknown fields/sections to exercise the warning path.
+const tsV21SampleBackup = `{
+  "version": "2.1",
+  "timestamp": 1755678900000,
+  "type": "all",
+  "futureTopLevelField": {"hello": "world"},
+  "accounts": {
+    "sites": [
+      {
+        "id": 1,
+        "name": "站A",
+        "url": "https://a.example.com",
+        "externalCheckinUrl": null,
+        "platform": "new-api",
+        "proxyUrl": null,
+        "useSystemProxy": false,
+        "customHeaders": "{\"X-Token\":\"abc\"}",
+        "status": "active",
+        "isPinned": true,
+        "sortOrder": 0,
+        "globalWeight": 1,
+        "apiKey": "site-key-a",
+        "postRefreshProbeEnabled": false,
+        "postRefreshProbeModel": "",
+        "postRefreshProbeScope": "single",
+        "postRefreshProbeLatencyThresholdMs": 0,
+        "createdAt": "2026-08-01 10:00:00",
+        "updatedAt": "2026-08-01 10:00:00",
+        "futureSiteField": "ignored"
+      },
+      {
+        "id": 2,
+        "name": "站B",
+        "url": "https://b.example.com",
+        "platform": "one-api",
+        "proxyUrl": "http://proxy.local:8080",
+        "useSystemProxy": true,
+        "customHeaders": null,
+        "status": "active",
+        "isPinned": false,
+        "sortOrder": 1,
+        "globalWeight": 1.5,
+        "apiKey": null,
+        "postRefreshProbeEnabled": true,
+        "postRefreshProbeModel": "gpt-4o-mini",
+        "postRefreshProbeScope": "all",
+        "postRefreshProbeLatencyThresholdMs": 800,
+        "createdAt": "2026-08-02 10:00:00",
+        "updatedAt": "2026-08-02 10:00:00"
+      }
+    ],
+    "siteApiEndpoints": [
+      {
+        "id": 1,
+        "siteId": 1,
+        "url": "https://a.example.com/api",
+        "enabled": true,
+        "sortOrder": 0,
+        "cooldownUntil": null,
+        "lastSelectedAt": null,
+        "lastFailedAt": null,
+        "lastFailureReason": null,
+        "createdAt": "2026-08-01 10:00:00",
+        "updatedAt": "2026-08-01 10:00:00"
+      }
+    ],
+    "siteDisabledModels": [
+      {"siteId": 1, "modelName": "gpt-5"}
+    ],
+    "accounts": [
+      {
+        "id": 1,
+        "siteId": 1,
+        "username": "user-a",
+        "accessToken": "acc-token-a",
+        "apiToken": "api-token-a",
+        "balance": 12.5,
+        "quota": 20,
+        "unitCost": null,
+        "valueScore": 0.8,
+        "status": "active",
+        "isPinned": false,
+        "sortOrder": 0,
+        "checkinEnabled": true,
+        "oauthProvider": null,
+        "oauthAccountKey": null,
+        "oauthProjectId": null,
+        "extraConfig": "{\"plan\":\"pro\"}",
+        "createdAt": "2026-08-01 10:00:00",
+        "updatedAt": "2026-08-01 10:00:00"
+      },
+      {
+        "id": 2,
+        "siteId": 2,
+        "username": null,
+        "accessToken": "acc-token-b",
+        "apiToken": null,
+        "balance": 0,
+        "quota": 0,
+        "unitCost": 0.2,
+        "valueScore": 0,
+        "status": "disabled",
+        "isPinned": true,
+        "sortOrder": 1,
+        "checkinEnabled": false,
+        "oauthProvider": "github",
+        "oauthAccountKey": "gh-1",
+        "oauthProjectId": "proj-1",
+        "extraConfig": null,
+        "createdAt": "2026-08-02 10:00:00",
+        "updatedAt": "2026-08-02 10:00:00"
+      }
+    ],
+    "accountTokens": [
+      {
+        "id": 1,
+        "accountId": 1,
+        "name": "默认令牌",
+        "token": "token-1",
+        "tokenGroup": null,
+        "valueStatus": "ready",
+        "source": "manual",
+        "enabled": true,
+        "isDefault": true,
+        "createdAt": "2026-08-01 10:00:00",
+        "updatedAt": "2026-08-01 10:00:00"
+      }
+    ],
+    "tokenRoutes": [
+      {
+        "id": 1,
+        "modelPattern": "gpt-*",
+        "displayName": "GPT 路由",
+        "displayIcon": null,
+        "routeMode": "pattern",
+        "modelMapping": null,
+        "decisionSnapshot": null,
+        "decisionRefreshedAt": null,
+        "routingStrategy": "weighted",
+        "enabled": true,
+        "createdAt": "2026-08-01 10:00:00",
+        "updatedAt": "2026-08-01 10:00:00"
+      }
+    ],
+    "routeChannels": [
+      {
+        "id": 1,
+        "routeId": 1,
+        "accountId": 1,
+        "tokenId": 1,
+        "oauthRouteUnitId": null,
+        "sourceModel": "gpt-4o",
+        "priority": 0,
+        "weight": 10,
+        "enabled": true,
+        "manualOverride": false
+      }
+    ],
+    "routeGroupSources": [],
+    "manualModels": [
+      {"accountId": 1, "modelName": "gpt-4o-mini"}
+    ],
+    "downstreamApiKeys": [
+      {
+        "name": "客户端A",
+        "key": "sk-downstream-1",
+        "description": "外部调用方",
+        "groupName": "prod",
+        "tags": "[\"vip\"]",
+        "enabled": true,
+        "expiresAt": null,
+        "maxCost": 100,
+        "maxRequests": null,
+        "supportedModels": "[\"gpt-4o\"]",
+        "allowedRouteIds": "[1]",
+        "siteWeightMultipliers": "{\"1\":2}",
+        "excludedSiteIds": "[]",
+        "excludedCredentialRefs": "[]"
+      }
+    ],
+    "futureSection": {"hello": "world"}
+  },
+  "preferences": {
+    "settings": [
+      {"key": "theme", "value": "dark"},
+      {
+        "key": "routing_weights",
+        "value": {
+          "baseWeightFactor": 1.2,
+          "valueScoreFactor": 0.5,
+          "costWeight": 1,
+          "balanceWeight": 1,
+          "usageWeight": 1
+        }
+      },
+      {"key": "auth_token", "value": "should-be-skipped"},
+      {"futureSettingField": true}
+    ]
+  }
+}`
+
+func TestIsTSV21Payload(t *testing.T) {
+	if !backupsvc.IsTSV21Payload([]byte(tsV21SampleBackup)) {
+		t.Fatal("IsTSV21Payload = false for a v2.1 payload, want true")
+	}
+	if backupsvc.IsTSV21Payload([]byte(`{"tables":{"sites":[]}}`)) {
+		t.Fatal("IsTSV21Payload = true for a tables payload, want false")
+	}
+	if backupsvc.IsTSV21Payload([]byte(`{"version":"1.0","tables":{}}`)) {
+		t.Fatal("IsTSV21Payload = true for a v1.0 payload, want false")
+	}
+	if backupsvc.IsTSV21Payload([]byte(`not json`)) {
+		t.Fatal("IsTSV21Payload = true for invalid JSON, want false")
+	}
+}
+
+func TestParseTSV21NormalizesFieldsAndWarns(t *testing.T) {
+	parsed, err := backupsvc.ParseTSV21([]byte(tsV21SampleBackup))
+	if err != nil {
+		t.Fatalf("ParseTSV21: %v", err)
+	}
+
+	if parsed.Type != "all" {
+		t.Fatalf("type = %q, want all", parsed.Type)
+	}
+	if parsed.SkippedSettings != 2 {
+		t.Fatalf("SkippedSettings = %d, want 2 (auth_token + key-less row)", parsed.SkippedSettings)
+	}
+
+	// camelCase → snake_case conversion on a sites row.
+	siteRows := parsed.Tables["sites"]
+	if len(siteRows) != 2 {
+		t.Fatalf("sites rows = %d, want 2", len(siteRows))
+	}
+	secondSite := siteRows[1]
+	if secondSite["external_checkin_url"] != nil {
+		// field absent in TS row must not be synthesized
+		t.Fatalf("site[1] external_checkin_url = %#v, want nil", secondSite["external_checkin_url"])
+	}
+	if secondSite["proxy_url"] != "http://proxy.local:8080" {
+		t.Fatalf("site[1] proxy_url = %#v", secondSite["proxy_url"])
+	}
+	if secondSite["use_system_proxy"] != true {
+		t.Fatalf("site[1] use_system_proxy = %#v, want true", secondSite["use_system_proxy"])
+	}
+	if secondSite["post_refresh_probe_latency_threshold_ms"] != int64(800) {
+		t.Fatalf("site[1] post_refresh_probe_latency_threshold_ms = %#v, want int64(800)", secondSite["post_refresh_probe_latency_threshold_ms"])
+	}
+	if _, hasUnknown := secondSite["futureSiteField"]; hasUnknown {
+		t.Fatal("unknown TS field leaked into the converted row")
+	}
+
+	// manualModels → model_availability with synthetic columns.
+	manualRows := parsed.Tables["model_availability"]
+	if len(manualRows) != 1 {
+		t.Fatalf("model_availability rows = %d, want 1", len(manualRows))
+	}
+	if manualRows[0]["is_manual"] != true || manualRows[0]["available"] != true {
+		t.Fatalf("model_availability row = %#v, want is_manual/available true", manualRows[0])
+	}
+	if manualRows[0]["model_name"] != "gpt-4o-mini" {
+		t.Fatalf("model_availability model_name = %#v", manualRows[0]["model_name"])
+	}
+
+	// settings values re-marshaled to JSON text; runtime-local and key-less
+	// rows dropped.
+	settingsRows := parsed.Tables["settings"]
+	if len(settingsRows) != 2 {
+		t.Fatalf("settings rows = %d, want 2 (auth_token + key-less row skipped)", len(settingsRows))
+	}
+	byKey := map[string]string{}
+	for _, row := range settingsRows {
+		byKey[row["key"].(string)] = row["value"].(string)
+	}
+	if byKey["theme"] != `"dark"` {
+		t.Fatalf("settings[theme] = %q, want %q", byKey["theme"], `"dark"`)
+	}
+	var weights map[string]float64
+	if err := json.Unmarshal([]byte(byKey["routing_weights"]), &weights); err != nil {
+		t.Fatalf("settings[routing_weights] not valid JSON: %v (%q)", err, byKey["routing_weights"])
+	}
+	if weights["baseWeightFactor"] != 1.2 {
+		t.Fatalf("routing_weights.baseWeightFactor = %v, want 1.2", weights["baseWeightFactor"])
+	}
+
+	// Unknown top-level field, unknown section, unknown row field and the
+	// key-less settings row must all surface as warnings.
+	wantWarnings := []string{
+		"忽略未知顶层字段 futureTopLevelField",
+		"忽略未知节 accounts.futureSection",
+		"忽略未知字段 sites.futureSiteField",
+		"忽略 preferences.settings 第 4 行：key 缺失或为空",
+	}
+	joined := strings.Join(parsed.Warnings, "\n")
+	for _, want := range wantWarnings {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("warnings %q missing %q", parsed.Warnings, want)
+		}
+	}
+}
+
+func TestImportTSV21ImportsSampleIntoSqlite(t *testing.T) {
+	db := setupBackupServiceTestDB(t)
+
+	result, err := backupsvc.ImportTSV21(db, []byte(tsV21SampleBackup))
+	if err != nil {
+		t.Fatalf("ImportTSV21: %v", err)
+	}
+
+	wantImported := map[string]int64{
+		"sites":                2,
+		"site_api_endpoints":   1,
+		"site_disabled_models": 1,
+		"accounts":             2,
+		"account_tokens":       1,
+		"token_routes":         1,
+		"route_channels":       1,
+		"model_availability":   1,
+		"downstream_api_keys":  1,
+		"settings":             2,
+	}
+	for table, want := range wantImported {
+		if got := result.Imported[table]; got != want {
+			t.Fatalf("imported[%s] = %d, want %d (full: %#v)", table, got, want, result.Imported)
+		}
+	}
+	if result.SkippedSettings != 2 {
+		t.Fatalf("SkippedSettings = %d, want 2 (auth_token + key-less row)", result.SkippedSettings)
+	}
+
+	// sites: snake_case columns populated, booleans stored, unknown field dropped.
+	var siteCount int
+	if err := db.Get(&siteCount, "SELECT COUNT(*) FROM sites"); err != nil || siteCount != 2 {
+		t.Fatalf("sites count = %d err=%v, want 2", siteCount, err)
+	}
+	var siteB struct {
+		ProxyURL     string  `db:"proxy_url"`
+		GlobalWeight float64 `db:"global_weight"`
+		UseSystem    int     `db:"use_system_proxy"`
+		ProbeScope   string  `db:"post_refresh_probe_scope"`
+	}
+	if err := db.Get(&siteB, "SELECT proxy_url, global_weight, use_system_proxy, post_refresh_probe_scope FROM sites WHERE id = 2"); err != nil {
+		t.Fatalf("read site 2: %v", err)
+	}
+	if siteB.ProxyURL != "http://proxy.local:8080" || siteB.GlobalWeight != 1.5 || siteB.UseSystem != 1 || siteB.ProbeScope != "all" {
+		t.Fatalf("site 2 = %+v, want mapped values", siteB)
+	}
+
+	// accounts: checkin_enabled boolean stored, extra_config text preserved.
+	var accountB struct {
+		CheckinEnabled int            `db:"checkin_enabled"`
+		OAuthProvider  sql.NullString `db:"oauth_provider"`
+		ExtraConfig    sql.NullString `db:"extra_config"`
+	}
+	if err := db.Get(&accountB, "SELECT checkin_enabled, oauth_provider, extra_config FROM accounts WHERE id = 2"); err != nil {
+		t.Fatalf("read account 2: %v", err)
+	}
+	if accountB.CheckinEnabled != 0 || accountB.OAuthProvider.String != "github" {
+		t.Fatalf("account 2 = %+v, want checkin_enabled=0 oauth_provider=github", accountB)
+	}
+	if accountB.ExtraConfig.Valid {
+		t.Fatalf("account 2 extra_config = %q, want NULL", accountB.ExtraConfig.String)
+	}
+	var accountA struct {
+		CheckinEnabled int    `db:"checkin_enabled"`
+		ExtraConfig    string `db:"extra_config"`
+	}
+	if err := db.Get(&accountA, "SELECT checkin_enabled, extra_config FROM accounts WHERE id = 1"); err != nil {
+		t.Fatalf("read account 1: %v", err)
+	}
+	if accountA.CheckinEnabled != 1 || accountA.ExtraConfig != `{"plan":"pro"}` {
+		t.Fatalf("account 1 = %+v, want checkin_enabled=1 extra_config preserved", accountA)
+	}
+
+	// token routes + route channels.
+	var route struct {
+		ModelPattern string `db:"model_pattern"`
+		Strategy     string `db:"routing_strategy"`
+	}
+	if err := db.Get(&route, "SELECT model_pattern, routing_strategy FROM token_routes WHERE id = 1"); err != nil {
+		t.Fatalf("read token route: %v", err)
+	}
+	if route.ModelPattern != "gpt-*" || route.Strategy != "weighted" {
+		t.Fatalf("token route = %+v", route)
+	}
+	var channel struct {
+		SourceModel string `db:"source_model"`
+		Weight      int64  `db:"weight"`
+	}
+	if err := db.Get(&channel, "SELECT source_model, weight FROM route_channels WHERE id = 1"); err != nil {
+		t.Fatalf("read route channel: %v", err)
+	}
+	if channel.SourceModel != "gpt-4o" || channel.Weight != 10 {
+		t.Fatalf("route channel = %+v", channel)
+	}
+
+	// site_disabled_models / model_availability / downstream_api_keys.
+	var disabled struct {
+		ModelName string `db:"model_name"`
+	}
+	if err := db.Get(&disabled, "SELECT model_name FROM site_disabled_models WHERE site_id = 1"); err != nil {
+		t.Fatalf("read site_disabled_models: %v", err)
+	}
+	if disabled.ModelName != "gpt-5" {
+		t.Fatalf("site_disabled_models = %+v", disabled)
+	}
+	var availability struct {
+		IsManual  int    `db:"is_manual"`
+		Available int    `db:"available"`
+		CheckedAt string `db:"checked_at"`
+	}
+	if err := db.Get(&availability, "SELECT is_manual, available, checked_at FROM model_availability WHERE account_id = 1"); err != nil {
+		t.Fatalf("read model_availability: %v", err)
+	}
+	if availability.IsManual != 1 || availability.Available != 1 || availability.CheckedAt == "" {
+		t.Fatalf("model_availability = %+v, want is_manual=1 available=1 checked_at set", availability)
+	}
+	var downstream struct {
+		GroupName string `db:"group_name"`
+		Enabled   int    `db:"enabled"`
+		Weights   string `db:"site_weight_multipliers"`
+	}
+	if err := db.Get(&downstream, "SELECT group_name, enabled, site_weight_multipliers FROM downstream_api_keys WHERE key = ?", "sk-downstream-1"); err != nil {
+		t.Fatalf("read downstream_api_keys: %v", err)
+	}
+	if downstream.GroupName != "prod" || downstream.Enabled != 1 || downstream.Weights != `{"1":2}` {
+		t.Fatalf("downstream_api_keys = %+v", downstream)
+	}
+
+	// settings: theme stored as JSON text, auth_token skipped.
+	var themeValue string
+	if err := db.Get(&themeValue, "SELECT value FROM settings WHERE key = ?", "theme"); err != nil {
+		t.Fatalf("read settings theme: %v", err)
+	}
+	if themeValue != `"dark"` {
+		t.Fatalf("settings[theme] = %q, want %q", themeValue, `"dark"`)
+	}
+	var authTokenCount int
+	if err := db.Get(&authTokenCount, "SELECT COUNT(*) FROM settings WHERE key = ?", "auth_token"); err != nil {
+		t.Fatalf("count auth_token: %v", err)
+	}
+	if authTokenCount != 0 {
+		t.Fatal("runtime-local setting auth_token was imported")
+	}
+
+	// Unknown fields/sections must produce warnings without failing.
+	if len(result.Warnings) == 0 {
+		t.Fatal("expected warnings for unknown fields/sections, got none")
+	}
+}
+
+func TestImportTSV21SecondImportSkipsDuplicates(t *testing.T) {
+	db := setupBackupServiceTestDB(t)
+
+	first, err := backupsvc.ImportTSV21(db, []byte(tsV21SampleBackup))
+	if err != nil {
+		t.Fatalf("first ImportTSV21: %v", err)
+	}
+	if first.Imported["sites"] != 2 {
+		t.Fatalf("first import sites = %d, want 2", first.Imported["sites"])
+	}
+
+	second, err := backupsvc.ImportTSV21(db, []byte(tsV21SampleBackup))
+	if err != nil {
+		t.Fatalf("second ImportTSV21: %v", err)
+	}
+	for table, count := range second.Imported {
+		if count != 0 {
+			t.Fatalf("second import %s = %d, want 0 (ON CONFLICT DO NOTHING)", table, count)
+		}
+	}
+}
+
+func TestPreviewTSV21PlansInsertAndDuplicates(t *testing.T) {
+	db := setupBackupServiceTestDB(t)
+
+	before, err := backupsvc.PreviewTSV21(db, []byte(tsV21SampleBackup))
+	if err != nil {
+		t.Fatalf("PreviewTSV21 before import: %v", err)
+	}
+	sitesPlan := before.Plan["sites"]
+	if sitesPlan.Rows != 2 || sitesPlan.ToInsert != 2 || sitesPlan.Duplicates != 0 {
+		t.Fatalf("sites plan before import = %+v, want rows=2 toInsert=2 duplicates=0", sitesPlan)
+	}
+	settingsPlan := before.Plan["settings"]
+	if settingsPlan.Rows != 2 || settingsPlan.ToInsert != 2 || settingsPlan.SkippedRows != 2 {
+		t.Fatalf("settings plan before import = %+v, want rows=2 toInsert=2 skippedRows=2", settingsPlan)
+	}
+	// downstream keys carry no id in v2.1 exports, so they count as inserts.
+	keysPlan := before.Plan["downstream_api_keys"]
+	if keysPlan.Rows != 1 || keysPlan.ToInsert != 1 {
+		t.Fatalf("downstream_api_keys plan = %+v, want rows=1 toInsert=1", keysPlan)
+	}
+	if len(before.Warnings) == 0 {
+		t.Fatal("preview should surface warnings")
+	}
+
+	if _, err := backupsvc.ImportTSV21(db, []byte(tsV21SampleBackup)); err != nil {
+		t.Fatalf("ImportTSV21: %v", err)
+	}
+
+	after, err := backupsvc.PreviewTSV21(db, []byte(tsV21SampleBackup))
+	if err != nil {
+		t.Fatalf("PreviewTSV21 after import: %v", err)
+	}
+	sitesAfter := after.Plan["sites"]
+	if sitesAfter.Rows != 2 || sitesAfter.ToInsert != 0 || sitesAfter.Duplicates != 2 {
+		t.Fatalf("sites plan after import = %+v, want rows=2 toInsert=0 duplicates=2", sitesAfter)
+	}
+	settingsAfter := after.Plan["settings"]
+	if settingsAfter.Rows != 2 || settingsAfter.ToInsert != 0 || settingsAfter.Duplicates != 2 {
+		t.Fatalf("settings plan after import = %+v, want rows=2 toInsert=0 duplicates=2", settingsAfter)
+	}
+}
+
+func TestParseTSV21RejectsMalformedPayloads(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		wantSub string
+	}{
+		{
+			name:    "missing timestamp",
+			payload: `{"version":"2.1","accounts":{"sites":[]}}`,
+			wantSub: "缺少 timestamp",
+		},
+		{
+			name:    "no recognizable sections",
+			payload: `{"version":"2.1","timestamp":1}`,
+			wantSub: "没有可识别的账号或设置数据",
+		},
+		{
+			name:    "type accounts without accounts section",
+			payload: `{"version":"2.1","timestamp":1,"type":"accounts"}`,
+			wantSub: "账号数据结构不正确",
+		},
+		{
+			name:    "type preferences without preferences section",
+			payload: `{"version":"2.1","timestamp":1,"type":"preferences"}`,
+			wantSub: "设置数据结构不正确",
+		},
+		{
+			name:    "sites not an array",
+			payload: `{"version":"2.1","timestamp":1,"accounts":{"sites":{"a":1}}}`,
+			wantSub: "accounts.sites 必须是数组",
+		},
+		{
+			name:    "missing required field",
+			payload: `{"version":"2.1","timestamp":1,"accounts":{"sites":[{"url":"https://a.example.com","platform":"new-api"}]}}`,
+			wantSub: "缺少必填字段 name",
+		},
+		{
+			name:    "preferences settings not an array",
+			payload: `{"version":"2.1","timestamp":1,"preferences":{"settings":{"theme":"dark"}}}`,
+			wantSub: "preferences.settings 必须是数组",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := backupsvc.ParseTSV21([]byte(tc.payload))
+			if err == nil {
+				t.Fatalf("ParseTSV21 succeeded, want error containing %q", tc.wantSub)
+			}
+			var clientErr backupsvc.TSV21ClientError
+			if !errors.As(err, &clientErr) {
+				t.Fatalf("error = %v, want TSV21ClientError", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error = %q, want containing %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestImportTSV21RollsBackOnFailure(t *testing.T) {
+	db := setupBackupServiceTestDB(t)
+
+	// Second site row violates accounts FK (site_id 99 does not exist), so the
+	// import must fail and roll back everything inserted before the failure.
+	payload := `{
+	  "version": "2.1",
+	  "timestamp": 1755678900000,
+	  "accounts": {
+	    "sites": [{"id": 1, "name": "站A", "url": "https://a.example.com", "platform": "new-api"}],
+	    "accounts": [{"id": 1, "siteId": 99, "accessToken": "acc-token-a"}]
+	  }
+	}`
+
+	if _, err := backupsvc.ImportTSV21(db, []byte(payload)); err == nil {
+		t.Fatal("ImportTSV21 succeeded, want FK failure")
+	}
+
+	var siteCount int
+	if err := db.Get(&siteCount, "SELECT COUNT(*) FROM sites"); err != nil {
+		t.Fatalf("count sites: %v", err)
+	}
+	if siteCount != 0 {
+		t.Fatalf("sites count = %d after rollback, want 0", siteCount)
+	}
+}


### PR DESCRIPTION
批次 F：Go 备份导入兼容 TS 原版备份 JSON v2.1，作为 TS→Go 迁移的最后兜底路径。

- 完整字段映射（TS drizzle camelCase → Go snake_case，11 个节：sites/siteApiEndpoints/siteDisabledModels/accounts/accountTokens/tokenRoutes/routeChannels/routeGroupSources/manualModels→model_availability/downstreamApiKeys/settings），FK 安全序单事务导入，失败整体回滚。
- settings value 重新 marshal 为 JSON 文本（对齐 TS 语义）；运行时本地键静默跳过。
- 未知节/字段：忽略并计数进 `warnings`（确定性排序），不因 TS 未来加字段而失败。
- 重复数据沿用 `ON CONFLICT DO NOTHING`；限制沿用 50k 行/128 列/4MB。
- import 与 preview 均支持；handler + service 双层测试（真实形态 v2.1 样本、preview 不写库、二次导入全 0、FK 失败回滚、畸形 payload 报错）。

## 验证

- `go build ./...`、`go vet ./handler/... ./service/...`、`go test ./handler/admin/ ./service/backup/ -count=1` 全绿

## 自查清单

- [x] 行为变更有回归测试
- [x] SQLite + PostgreSQL 双方言（store.DB rebind）
- [x] 无新依赖