### PR TITLE
docs: close TS compat milestone — MASTER roadmap + log entry

### DIFF
--- a/docs/internal/log.md
+++ b/docs/internal/log.md
@@ -5,6 +5,18 @@
 > Product milestone timeline (grouped by version). Not the current-state source of truth.
 > Current state → [`STATE.md`](STATE.md) · open items → [`progress/MASTER.md`](progress/MASTER.md) · detailed version narrative → root [`CHANGELOG.md`](../../CHANGELOG.md)
 
+## 2026-08-20 — TS 兼容与迁移收官：CLI 诚实化 + 反向检测 + 迁移 UI + 备份兼容 + 三场景文档
+
+一次综合设计解决 TS 版兼容与迁移的全部已知问题（技术 + UX），分析依据 `docs/internal/analysis/ts-go-migration-gap.md`，五个 PR 并行交付（#880 计划 / #881 后端 / #882 UI / #883 备份 / #884 文档）：
+
+- **CLI 诚实化（#881）**：`--verify` 校验和失败现在非零退出（此前只 warning、exit 0——脚本里等于没校验）；顺带修复一个「假绿」测试（NULL 被强转默认值吞掉校验和不匹配）。`buildSummary` 按目标报真实方言（不再硬编码 postgres）；`--batch-size` 从「接受但丢弃」变为真实批量 INSERT。
+- **反向检测（#881）**：防 hb0730 事故翻版——TS 库比 Go 认知新时启动即警告（读 `__drizzle_migrations` 判龄 + 以内存库 AutoMigrate 为权威清单扫未知列，列出列名 + 建议升级），永不阻断。干净库不误报（4 用例测试）。
+- **启动汇总（#881）**：AutoMigrate 有实际变更时输出 `store: converged legacy schema` 汇总。
+- **管理 UI 数据迁移（#882）**：此前被雪藏的迁移能力（后端 task 轮询早已就绪）接入 database-section——危险确认 + 2s 轮询进度 + 结果统计；`migrateExternalDatabase` 死代码复活为类型化 API；i18n 双语全量。后端补解析 overwrite 字段（#881）。
+- **TS 备份 v2.1 导入兼容（#883）**：Go import/preview 兼容 TS 原版备份 JSON（11 节 camelCase→snake_case 完整映射，FK 安全序单事务，未知字段忽略并计 warnings，settings value 重新 marshal），作为迁移最后兜底路径。
+- **文档三场景（#884）**：migration.md 重写——场景 A（TS SQLite 直接接管）/ B（TS PG 直接接管）/ C（TS MySQL 两段式：TS 管理界面自带迁移迁到 SQLite/PG 再接管）+ 版本锁定 + 故障排查；消除 README「metapi-migrate 支持 MySQL」的谎言与 FAQ 矛盾。
+- **PG 直接接管实测**：真实 TS 服务器在 PG 16 建 27 表 + 种子数据 → Go 直接接管：`/ready` OK、`/api/sites` 返回 TS 数据、additive 在 PG 上逐列收敛无崩溃。
+
 ## 2026-08-20 — 仓库店头重建：docs 公私分离 + README/Diátaxis 文档集 + llms.txt（#872 #873）
 
 对照原版 TS 仓库（cita-777/metapi，已 clone 到本机对照）与 2026 GitHub 开源最佳实践（Diátaxis 文档四象限、紧迫度递减 README 序、徽章 3-5 个上限、死链 CI 自动化、llms.txt）重做仓库对外门面：

--- a/docs/internal/progress/MASTER.md
+++ b/docs/internal/progress/MASTER.md
@@ -6,21 +6,17 @@
 
 > This is the only execution plan. It contains open work, order, ownership, and acceptance criteria. Current facts → [`../STATE.md`](../STATE.md) · product positioning → [`../benchmark.md`](../benchmark.md) · timeline → [`../log.md`](../log.md).
 
-## Active milestone — TS 兼容与迁移收官（2026-08-20 起）
+## Completed milestone — TS 兼容与迁移收官（2026-08-20 交付）
 
-分析依据：[`../analysis/ts-go-migration-gap.md`](../analysis/ts-go-migration-gap.md)。用户确认的四项决策：MySQL 走 TS 自带迁移（零 Go 新依赖）、实现反向检测、Admin UI 表面化迁移、TS 备份 v2.1 导入兼容。
+分析依据：[`../analysis/ts-go-migration-gap.md`](../analysis/ts-go-migration-gap.md)。全部批次已交付合并（#880 计划 / #881 后端 / #882 UI / #883 备份导入 / #884 文档）：
 
-| 批次 | 内容 | 验收基线 |
-|---|---|---|
-| A CLI 诚实化 | `--verify` 失败 exit≠0；buildSummary 真实方言；`--batch-size` 实现批量 INSERT；注释修正 | 校验和不匹配 → exit≠0；SQLite→SQLite summary 显示 sqlite |
-| B 反向检测 | `__drizzle_migrations` 判龄 + 未知列扫描 → 启动警告（列名 + 升级建议），不阻断 | TS 新版库夹具启动出现警告；干净库不误报 |
-| C 启动汇总 | AutoMigrate 有实际变更时输出「added N columns across M tables」汇总 | 老库有汇总行，空库无 |
-| D 迁移 UI | database-section 接入 migrate 端点 + task 轮询进度 + 危险确认 + i18n；启用 migrateExternalDatabase | UI 完成 SQLite→PG 真实迁移（本地 PG 55432） |
-| E 文档全修 | migration.md 三 personas（SQLite 接管/PG 接管/MySQL 经 TS 迁移）重写 + 版本锁定；README/FAQ 矛盾修复 | docs 门禁全绿；三种 persona 可照做 |
-| F TS 备份导入 | Go import 兼容 TS v2.1 备份格式 | TS v2.1 样本导入成功且数据正确 |
-| G PG 接管实测 | TS 契约 PG schema 被 Go 直接接管实测 | 不崩、数据可读；缺口记录归档 |
-
-批次完成即关闭；不再保留开放清单。
+- CLI 诚实化：`--verify` 失败非零退出、buildSummary 真实方言、`--batch-size` 生效（#881）
+- 反向检测：`__drizzle_migrations` 判龄 + 未知列扫描 → 启动警告不阻断（#881）
+- 启动汇总日志：`store: converged legacy schema`（#881）
+- 管理 UI 数据迁移：危险确认 + task 轮询进度（#882）+ overwrite 字段后端补解析（#881）
+- TS 备份 v2.1 导入兼容（#883）
+- 迁移文档三场景（SQLite/PG 直接接管、MySQL 经 TS 自带迁移）+ 版本锁定（#884）
+- PG 直接接管实测：真实 TS 契约 PG 库 → Go 启动 `/ready` OK、数据可读、additive 收敛（实测，无代码改动）
 
 ## Delivery model
 


### PR DESCRIPTION
## Summary
- Close the TS→Go migration compat milestone in `docs/internal/progress/MASTER.md` (all batches #880-#884 delivered; no open checklist remains)
- Add the milestone entry to `docs/internal/log.md`
- No code changes

## Test plan
- docs hygiene gate (`go test ./docs/...`)
- links resolve