### PR TITLE
chore(release): codify patch-first versioning + fix stale release-governance counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,12 +66,7 @@ golangci-lint run --timeout=3m        # Lint check
 3. 发布助手：`bash scripts/release.sh X.Y.Z`（校验 CHANGELOG 节、`web/package.json` 版本、master 与远端同步后打 annotated tag 并推送）；或手动 `git tag -a vX.Y.Z` → `git push origin vX.Y.Z`（仅 SemVer tag 触发发布）
 4. Tag push 触发单一管道 `.github/workflows/main.yml`：全量 12 项检查通过 → 推送 `ghcr.io/deliciousbuding/metapi-go:vX.Y.Z`（amd64+arm64，provenance+SBOM）→ 5 平台二进制附件 + checksums + 二进制冒烟 → 自动创建 GitHub Release（body 取自 CHANGELOG 对应节）
 
-**版本号**：`vMAJOR.MINOR.PATCH`（SemVer 2.0）
-
-- PATCH：bug 修复
-- MINOR：新功能/性能优化
-- MAJOR：不兼容 API 变更
-- v0.x 阶段 minor 可用于新功能
+**版本号**：`vMAJOR.MINOR.PATCH`（SemVer 2.0）。**节奏为 patch-first —— 1.0 前最后一位持续迭代**（每波合入即 bump 最后一位并发布；中间位留给成体系的里程碑；第一位留到 1.0）。决策权威与 1.0 就绪标准见 [`docs/internal/git-workflow.md` §6.1](docs/internal/git-workflow.md)。拿不准下一版用 `bash scripts/next-version.sh`。
 
 ## CI Discipline
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,10 +56,20 @@ detector. The pre-push hook runs all of it automatically.
 1. Branch from `master`, commit with [Conventional Commits](https://www.conventionalcommits.org/).
 2. Open a PR against `master` — the template is auto-filled; keep the summary
    about *why*, not a file-by-file list.
-3. All 11 required CI checks must pass (they run on every PR, docs-only PRs
+3. All 12 required CI checks must pass (they run on every PR, docs-only PRs
    included — no `paths-ignore` shortcuts).
 4. PRs are **squash merged** (merge commits are disabled). The PR title becomes
    the commit message, so make it a good Conventional Commit line.
+
+## Versioning & release cadence
+
+Releases follow a **patch-first** cadence (pre-1.0 the last digit iterates
+continuously): each merged wave with user-visible changes bumps the **patch**
+digit and ships immediately; the minor digit is reserved for themed
+milestones; the major digit stays `0` until the 1.0 readiness criteria. The
+single source of truth is
+[`docs/internal/git-workflow.md` §6.1](docs/internal/git-workflow.md) —
+`bash scripts/next-version.sh` suggests the next candidate.
 
 ## Conventions to keep in mind
 

--- a/docs/internal/analysis/package-boundaries.md
+++ b/docs/internal/analysis/package-boundaries.md
@@ -4,7 +4,7 @@
 **Date**: 2026-08-14
 **Base**: `origin/master` @ v0.12.0 (`9cd5ca0`)
 **Authority companions**:
-- [`docs/design/BACKEND.md`](../design/BACKEND.md) — principles + allowed import edges
+- [`docs/internal/design/BACKEND.md`](../design/BACKEND.md) — principles + allowed import edges
 - [`docs/architecture.md`](../../architecture.md) — as-built package map and request flows
 
 This document is the **B1 ownership inventory**. It does **not** rewrite packages. Prefer docs and tiny zero-behavior moves; large boundary refactors need their own issues.
@@ -17,7 +17,7 @@ This document is the **B1 ownership inventory**. It does **not** rewrite package
 |--------|-----|
 | `go list -json ./...` | Non-test internal import graph |
 | Package `doc.go` / constructors | Public entrypoints |
-| `docs/design/BACKEND.md` §2 | Allowed / forbidden edges |
+| `docs/internal/design/BACKEND.md` §2 | Allowed / forbidden edges |
 | Static call-site scan | Singletons, exception edges, unused leaves |
 
 **Scope**: Go packages under module `github.com/deliciousbuding/metapi-go` (excluding pure frontend under `web/*`).

--- a/docs/internal/git-workflow.md
+++ b/docs/internal/git-workflow.md
@@ -1,8 +1,8 @@
 # Git Workflow — 分支策略与协作规范
 
-**最后更新**：2026-08-11
+**最后更新**：2026-08-20
 
-> 本文定义 metapi-go 的分支模型、保护规则、PR 流程与提交规范。规则已在 GitHub 仓库实际落地（见下文"已启用设置"），不依赖个人自觉。
+> 本文定义 metapi-go 的分支模型、保护规则、PR 流程、提交规范与**版本号策略**。规则已在 GitHub 仓库实际落地（见下文"已启用设置"），不依赖个人自觉。
 
 ## 1. 分支模型：GitHub Flow（单主线）
 
@@ -50,7 +50,7 @@ master (唯一长期分支，受保护，随时可发布)
 2. 本地门禁全绿后提交（Conventional Commits 风格，见 §5），`git push -u origin fix/xxx`
    - push 前 `.githooks/pre-push` 自动跑本地 CI（`go build` + `go vet` + 前端门禁 + `-race` 测试）；安装：`git config core.hooksPath .githooks`；紧急跳过 `git push --no-verify`
 3. 开 PR（`gh pr create`，模板自动填充），base = master
-4. CI 11 job 全绿（含 PG 集成测试）后 Squash merge
+4. CI 12 job 全绿（含 PG 集成测试）后 Squash merge
 5. 合并时把 PR 标题改写为最终提交信息（符合 Conventional Commits）
 6. 删除已合并分支（`gh pr merge --delete-branch` 自动处理；若远端分支残留——如合并时本地有未提交改动——手动 `git push origin --delete <branch>`）
 
@@ -72,6 +72,31 @@ master (唯一长期分支，受保护，随时可发布)
 3. Tag 推送触发单一管道 `.github/workflows/main.yml`：全量 12 项检查通过 → 推送 `ghcr.io/deliciousbuding/metapi-go`（**amd64 + arm64**，provenance + SBOM）→ 构建 5 平台二进制附件（linux/darwin/windows × amd64/arm64）+ `checksums.txt` → 冒烟 `metapi-linux-amd64 --version` → 创建 GitHub Release（body 取自 CHANGELOG 对应节）
 4. Tag 只从 master 打（master 即发布线）；SemVer 格式 `vX.Y.Z`（其他 tag 不触发发布）
 5. 版本号经 `-ldflags -X .../internal/version.Version` 注入二进制（`metapi --version` 可查）；tag 与 `web/package.json` 版本不一致会在发布前失败
+6. 拿不准下一个版本号时：`bash scripts/next-version.sh`（只读，从最新 tag 打印 patch/minor/major 三个候选，默认走 patch，见 §6.1）
+
+## 6.1 版本号策略（SemVer · patch-first 节奏）
+
+> **本节是版本号决策的唯一权威来源**。AGENTS.md / CONTRIBUTING.md / MASTER.md 只做引用，不重复定义。
+
+格式 `0.MAJOR.MINOR.PATCH`（SemVer 2.0）。1.0 之前主版本号恒为 `0`；下文「中间位」指 `0.X.Y` 的 `X`，「最后一位」指 `Y`。
+
+**节奏：默认 patch-first —— 最后一位持续迭代。**
+
+| 段 | 何时 bump | 说明 |
+|:---|:---|:---|
+| **最后一位（PATCH）** | **默认，每波都动** | 每波合入 master 且含用户可见变更 → 立即 bump 最后一位并发布。`0.16.2 → 0.16.3 → 0.16.4 …` 小步、高频，最后一位一直往前走。 |
+| **中间位（MINOR）** | 克制，里程碑才动 | 仅当一次交付构成一个有主题的里程碑（新子系统 / 新界面大类 / 成体系的交付波）时 bump 中间位并把最后一位归零。不为单点改动 bump。 |
+| **第一位（MAJOR）** | 1.0 及之后 | 1.0 前恒 `0`；只有 1.0 落地与其后的不兼容 API 变更才动用。 |
+
+**为什么 patch-first**：1.0 前的软件高频交付，最后一位持续递增表达「master 随时可发布」，同时避免中间位被琐碎改动快速吃满、稀释「里程碑」语义。发版频率由变更驱动，不由日历驱动。
+
+**1.0 就绪标准**（到齐才把第一位从 0 提走）：
+
+- 生产多通道级联证据落地（见 [`progress/MASTER.md`](progress/MASTER.md) Evidence closeout · A）
+- API / wire 契约冻结（无计划内的破坏性演进）
+- 备份 / 迁移双向路径文档化且有实测覆盖
+
+**与发布流程的关系**：选定版本号后，仍走 §6 的 CHANGELOG + `web/package.json` + tag 一致性校验（`scripts/release.sh` / CI release job 强制三者一致）。
 
 ## 6.5 处理 Dependabot 升级（别人追升级时的 SOP）
 

--- a/docs/internal/progress/MASTER.md
+++ b/docs/internal/progress/MASTER.md
@@ -68,6 +68,7 @@ Every wave inherits root [`AGENTS.md`](../../../AGENTS.md) and backend simplicit
 - Frontend slices: i18n parity, focused Vitest coverage, `bun run typecheck`, `bun run lint`, `bun run knip`, and production build.
 - Any Go slice: SQLite + PostgreSQL-safe implementation, focused tests, then `go build ./cmd/server`, `go vet ./...`, and `go test ./... -count=1 -race` before push.
 - No new dependency unless the existing stack cannot express the slice directly.
+- Release cadence is **patch-first** ([`../git-workflow.md` §6.1](../git-workflow.md)): each merged wave with user-visible changes bumps the patch digit; minor only for themed milestones; major stays `0` until the 1.0 readiness criteria.
 - Update `STATE.md` and this plan in the same PR that closes an outcome; do not leave completed checklists here.
 
 ## Deferred or out of scope

--- a/scripts/next-version.sh
+++ b/scripts/next-version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# next-version.sh — read-only helper for the patch-first release cadence
+# (docs/internal/git-workflow.md §6.1).
+#
+# Prints the next SemVer candidates derived from the latest vX.Y.Z tag. It
+# never tags or mutates anything; it only suggests. Pick the patch candidate
+# by default; reserve minor for themed milestones and major for the 1.0
+# readiness criteria.
+#
+# Usage:
+#   bash scripts/next-version.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+latest="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1 || true)"
+if [[ -z "$latest" ]]; then
+  echo "no version tags found; start at 0.1.0"
+  exit 0
+fi
+ver="${latest#v}"
+IFS='.' read -r major minor patch <<< "$ver"
+echo "latest tag : $latest"
+echo "next patch : $major.$minor.$((patch + 1))   # default cadence (§6.1)"
+echo "next minor : $major.$((minor + 1)).0     # themed milestone only"
+echo "next major : $((major + 1)).0.0        # 1.0 readiness criteria only"


### PR DESCRIPTION
## Summary
- **Version strategy (the ask)**: new authoritative `docs/internal/git-workflow.md §6.1` — **patch-first cadence**: pre-1.0 the **last digit iterates continuously** (each merged wave with user-visible changes bumps patch and ships immediately), minor reserved for themed milestones, major stays `0` until the 1.0 readiness criteria. Single source of truth; AGENTS/CONTRIBUTING/MASTER now reference it instead of restating.
- **Release tooling**: new read-only `scripts/next-version.sh` prints next patch/minor/major from the latest tag (verified: `v0.16.2` → patch `0.16.3`).
- **Governance fixes**: stale "11 required CI checks" → 12 (pipeline gates on 12, verified against branch protection) in git-workflow §4 + CONTRIBUTING; stale `docs/design/BACKEND.md` labels → `docs/internal/design/BACKEND.md` in package-boundaries.md.
- No runtime code changes.

## Test plan
- `go test ./docs/...` (link resolution + hygiene) green
- `go build ./cmd/server` green
- `scripts/next-version.sh` smoke-tested