### PR TITLE
fix(web,handler): land attention deep links on their real targets

### DIFF
--- a/handler/admin/stats_balance.go
+++ b/handler/admin/stats_balance.go
@@ -235,8 +235,11 @@ func (h *statsHandler) attention(w http.ResponseWriter, r *http.Request) {
 	for _, row := range disabledSites {
 		items = append(items, attentionItem{
 			Severity: "warning", Category: "disabled_site",
-			Label:     "站点已禁用：" + coerceString(row["name"]),
-			Target:    "/sites?siteId=" + coerceString(row["id"]),
+			Label: "站点已禁用：" + coerceString(row["name"]),
+			// `/sites?edit=N` is the sites page's one-shot edit deep link
+			// (opens the edit dialog for the referenced site then strips
+			// the param); `siteId` is not part of the sites URL contract.
+			Target:    "/sites?edit=" + coerceString(row["id"]),
 			CreatedAt: coerceString(row["updatedAt"]),
 		})
 		if len(items) >= limit {
@@ -260,10 +263,13 @@ func (h *statsHandler) attention(w http.ResponseWriter, r *http.Request) {
 			severity = "critical"
 		}
 		items = append(items, attentionItem{
-			Severity:  severity,
-			Category:  "event",
-			Label:     coerceString(row["title"]),
-			Target:    "/settings", // events surface lives in settings/notifications area
+			Severity: severity,
+			Category: "event",
+			Label:    coerceString(row["title"]),
+			// The event log lives under settings → system-info → program-logs
+			// (/settings/<subarea>/<section>); a bare /settings link landed on
+			// the general section with no events in sight.
+			Target:    "/settings/system-info/program-logs",
 			CreatedAt: coerceString(row["createdAt"]),
 		})
 		if len(items) >= limit {

--- a/handler/admin/stats_test.go
+++ b/handler/admin/stats_test.go
@@ -591,10 +591,18 @@ func TestStats_SQLiteAttentionAggregatesExpiredLowBalanceDisabled(t *testing.T) 
 	if err != nil {
 		t.Fatalf("insert expired account: %v", err)
 	}
+	var expiredAccountID int64
+	if err := db.Get(&expiredAccountID, "SELECT id FROM accounts WHERE username = ?", "expired-user"); err != nil {
+		t.Fatalf("expired account id: %v", err)
+	}
 	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, balance, created_at, updated_at)
 		VALUES (?, ?, ?, 'active', ?, 0.3, ?, ?)`, siteID, "lowbal-user", "tok", true, nowStr, nowStr)
 	if err != nil {
 		t.Fatalf("insert lowbal account: %v", err)
+	}
+	var lowBalanceAccountID int64
+	if err := db.Get(&lowBalanceAccountID, "SELECT id FROM accounts WHERE username = ?", "lowbal-user"); err != nil {
+		t.Fatalf("lowbal account id: %v", err)
 	}
 	// recent warning event
 	_, err = db.Exec(`INSERT INTO events (type, title, message, level, read, created_at)
@@ -627,6 +635,26 @@ func TestStats_SQLiteAttentionAggregatesExpiredLowBalanceDisabled(t *testing.T) 
 	}
 	if !cats["low_balance"] || !cats["disabled_site"] {
 		t.Fatalf("missing categories: %v", cats)
+	}
+
+	// Deep-link targets must match the frontend URL contract: the accounts
+	// page consumes `accountId`, the sites page consumes `edit`, and the
+	// event log lives under settings → system-info → program-logs.
+	targets := map[string]string{}
+	for _, it := range items {
+		item := it.(map[string]any)
+		targets[item["category"].(string)] = item["target"].(string)
+	}
+	wantTargets := map[string]string{
+		"expired_account": "/accounts?accountId=" + strconv.FormatInt(expiredAccountID, 10),
+		"low_balance":     "/accounts?accountId=" + strconv.FormatInt(lowBalanceAccountID, 10),
+		"disabled_site":   "/sites?edit=" + strconv.FormatInt(siteID, 10),
+		"event":           "/settings/system-info/program-logs",
+	}
+	for category, wantTarget := range wantTargets {
+		if targets[category] != wantTarget {
+			t.Fatalf("%s target = %q, want %q", category, targets[category], wantTarget)
+		}
 	}
 }
 

--- a/web/src/features/accounts/__tests__/accounts-page-deep-link.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-page-deep-link.test.tsx
@@ -5,12 +5,31 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import '@/i18n/config'
 
 import { AccountsPage } from '../components/accounts-page'
+import type { Account } from '../types'
+
+const DEFAULT_SEARCH = { page: 1, pageSize: 20, create: true, siteId: 7 }
+const DEFAULT_SNAPSHOT = {
+  generatedAt: '',
+  accounts: [] as Array<Partial<Account>>,
+  sites: [
+    {
+      id: 7,
+      name: 'Primary site',
+      url: 'https://primary.example',
+      platform: 'openai',
+      status: 'active',
+    },
+  ],
+}
 
 const testState = vi.hoisted(() => ({
-  search: { page: 1, pageSize: 20, create: true, siteId: 7 },
+  search: { page: 1, pageSize: 20, create: true, siteId: 7 } as Record<
+    string,
+    unknown
+  >,
   snapshot: {
     generatedAt: '',
-    accounts: [],
+    accounts: [] as Array<Partial<Account>>,
     sites: [
       {
         id: 7,
@@ -25,6 +44,10 @@ const testState = vi.hoisted(() => ({
   formOpenCount: 0,
   formSiteIds: [] as Array<number | undefined>,
   previousFormOpen: undefined as boolean | undefined,
+  detailSheetProps: null as {
+    account: Account | null
+    open: boolean
+  } | null,
 }))
 
 vi.mock('@tanstack/react-router', () => ({
@@ -72,7 +95,10 @@ vi.mock('../api', () => ({
 }))
 
 vi.mock('../components/account-detail-sheet', () => ({
-  AccountDetailSheet: () => null,
+  AccountDetailSheet: (props: { account: Account | null; open: boolean }) => {
+    testState.detailSheetProps = props
+    return null
+  },
 }))
 
 vi.mock('../components/account-form-dialog', () => ({
@@ -93,10 +119,17 @@ vi.mock('../components/accounts-columns', () => ({
 afterEach(() => cleanup())
 
 beforeEach(() => {
+  testState.search = { ...DEFAULT_SEARCH }
+  testState.snapshot = {
+    ...DEFAULT_SNAPSHOT,
+    accounts: [...DEFAULT_SNAPSHOT.accounts],
+    sites: [...DEFAULT_SNAPSHOT.sites],
+  }
   testState.navigate.mockReset()
   testState.formOpenCount = 0
   testState.formSiteIds.length = 0
   testState.previousFormOpen = undefined
+  testState.detailSheetProps = null
 })
 
 describe('AccountsPage site create deep link', () => {
@@ -124,5 +157,71 @@ describe('AccountsPage site create deep link', () => {
         }),
       })
     )
+  })
+})
+
+function makeAccount(id: number): Account {
+  return {
+    id,
+    siteId: 7,
+    username: `account-${id}`,
+    status: 'active',
+  } as unknown as Account
+}
+
+// Dashboard attention items link `/accounts?accountId=N` for expired /
+// low-balance accounts; the page opens the detail sheet once and strips
+// the param. Mirrors the channels page's channelId drilldown tests.
+describe('AccountsPage account attention deep link', () => {
+  it('opens the detail sheet for the referenced account and clears the parameter', async () => {
+    testState.search = { page: 1, pageSize: 20, accountId: 3 }
+    testState.snapshot.accounts = [makeAccount(3), makeAccount(4)]
+    const { rerender } = render(<AccountsPage />)
+
+    await waitFor(() => {
+      expect(testState.detailSheetProps?.open).toBe(true)
+    })
+
+    rerender(<AccountsPage />)
+
+    await waitFor(() => {
+      expect(testState.detailSheetProps?.open).toBe(true)
+    })
+    expect(testState.detailSheetProps?.account?.id).toBe(3)
+    expect(testState.navigate).toHaveBeenCalledTimes(1)
+    expect(testState.navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/accounts',
+        replace: true,
+        search: expect.objectContaining({ accountId: undefined }),
+      })
+    )
+  })
+
+  it('clears a stale account id silently without opening the sheet', async () => {
+    testState.search = { page: 1, pageSize: 20, accountId: 99 }
+    testState.snapshot.accounts = [makeAccount(3)]
+
+    render(<AccountsPage />)
+
+    await waitFor(() => {
+      expect(testState.navigate).toHaveBeenCalled()
+    })
+    expect(testState.detailSheetProps?.open).toBe(false)
+    expect(testState.detailSheetProps?.account).toBeNull()
+  })
+
+  it('does not navigate when no account deep link is present', async () => {
+    testState.search = { page: 1, pageSize: 20 }
+    testState.snapshot.accounts = [makeAccount(3)]
+    testState.snapshot.sites = []
+
+    render(<AccountsPage />)
+
+    await waitFor(() => {
+      expect(testState.detailSheetProps).not.toBeNull()
+    })
+    expect(testState.navigate).not.toHaveBeenCalled()
+    expect(testState.detailSheetProps?.open).toBe(false)
   })
 })

--- a/web/src/features/accounts/__tests__/accounts-search-schema.test.ts
+++ b/web/src/features/accounts/__tests__/accounts-search-schema.test.ts
@@ -86,3 +86,39 @@ describe('accountsSearchSchema — deep-link params', () => {
     expect(result.create).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// accountsSearchSchema — dashboard attention deep-link param (accountId)
+// ---------------------------------------------------------------------------
+
+describe('accountsSearchSchema — accountId deep-link param', () => {
+  it('accepts the attention deep-link shape (accountId)', () => {
+    const result = accountsSearchSchema.parse({ accountId: '3' })
+    expect(result.accountId).toBe(3)
+  })
+
+  it('accepts a router-parsed number for accountId', () => {
+    const result = accountsSearchSchema.parse({ accountId: 3 })
+    expect(result.accountId).toBe(3)
+  })
+
+  it('degrades malformed or non-positive accountId to undefined', () => {
+    expect(
+      accountsSearchSchema.parse({ accountId: 'bogus' }).accountId
+    ).toBeUndefined()
+    expect(
+      accountsSearchSchema.parse({ accountId: 0 }).accountId
+    ).toBeUndefined()
+    expect(
+      accountsSearchSchema.parse({ accountId: -4 }).accountId
+    ).toBeUndefined()
+    expect(
+      accountsSearchSchema.parse({ accountId: 2.5 }).accountId
+    ).toBeUndefined()
+  })
+
+  it('omits accountId when absent', () => {
+    const result = accountsSearchSchema.parse({})
+    expect(result.accountId).toBeUndefined()
+  })
+})

--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -130,10 +130,15 @@ function buildAccountsHref(
   if (sortString) params.set('sort', sortString)
   if (merged.filters.status) params.set('status', merged.filters.status)
   if (merged.filters.site) params.set('site', merged.filters.site)
+  // Transient deep-link params are preserved across table-state syncs until
+  // the page's one-shot consume effects below have stripped them (a toolbar
+  // commit or page clamp firing first would otherwise drop the deep link).
   const guidedSiteId = currentParams.get('siteId')
   const guidedCreate = currentParams.get('create')
+  const attentionAccountId = currentParams.get('accountId')
   if (guidedSiteId) params.set('siteId', guidedSiteId)
   if (guidedCreate) params.set('create', guidedCreate)
+  if (attentionAccountId) params.set('accountId', attentionAccountId)
   const queryString = params.toString()
   return queryString ? `/accounts?${queryString}` : '/accounts'
 }
@@ -264,6 +269,35 @@ export function AccountsPage() {
     navigate({
       to: '/accounts',
       search: { ...search, siteId: undefined, create: undefined },
+      replace: true,
+    })
+  }, [search, isLoading, data, navigate])
+
+  // Consume the one-shot attention deep link exactly once (dashboard
+  // attention items link `/accounts?accountId=N` for expired / low-balance
+  // accounts): resolve the referenced id against the loaded snapshot, open
+  // the detail sheet with the same state the row "view detail" action uses,
+  // then strip the transient param so a refetch or remount never reopens
+  // the sheet. Waits for the snapshot so a stale or unknown id is cleared
+  // silently instead of opening a blank sheet — mirrors the channels page's
+  // `channelId` drilldown. The `useRef` guard survives the strict-mode
+  // double-invoke and the post-navigate re-render.
+  const accountDeepLinkConsumed = useRef(false)
+  useEffect(() => {
+    if (accountDeepLinkConsumed.current || !search.accountId) return
+    if (isLoading) return
+
+    const targetAccount = (data?.accounts ?? []).find(
+      (account) => account.id === search.accountId
+    )
+    accountDeepLinkConsumed.current = true
+    if (targetAccount) {
+      setDetailAccount(targetAccount)
+      setDetailOpen(true)
+    }
+    navigate({
+      to: '/accounts',
+      search: { ...search, accountId: undefined },
       replace: true,
     })
   }, [search, isLoading, data, navigate])

--- a/web/src/routes/_authenticated/accounts.tsx
+++ b/web/src/routes/_authenticated/accounts.tsx
@@ -32,8 +32,12 @@ import {
 // `siteId` / `create` are the one-shot deep-link params written by the sites
 // guided-flow CTA (`/accounts?siteId=…&create=1`): `siteId` preseeds the
 // referenced site in the create dialog, and `create` opens it once before the
-// page neutralizes both. They accept router-parsed primitives (`create=1`
-// arrives as number `1`) and degrade to `undefined` on stale/malformed values.
+// page neutralizes both. `accountId` is the one-shot deep-link param written
+// by the dashboard attention items (`/accounts?accountId=…` for expired /
+// low-balance accounts): the page opens the referenced account's detail
+// sheet once before neutralizing it. They accept router-parsed primitives
+// (`create=1` arrives as number `1`) and degrade to `undefined` on
+// stale/malformed values.
 export const accountsSearchSchema = z.object({
   page: z.coerce.number().int().positive().catch(1).default(1),
   pageSize: z.coerce.number().int().min(1).max(200).catch(20).default(20),
@@ -49,6 +53,7 @@ export const accountsSearchSchema = z.object({
   status: stringSearchParam,
   site: stringSearchParam,
   siteId: z.coerce.number().int().positive().optional().catch(undefined),
+  accountId: z.coerce.number().int().positive().optional().catch(undefined),
   create: z.coerce.boolean().optional().catch(undefined),
 })
 

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -15,24 +15,65 @@ if (typeof window !== 'undefined') {
 }
 
 // Node 25+ ships an experimental global `localStorage` (`--localstorage-file`).
-// When the file path is invalid the global exists but has no working getItem —
-// that breaks components reading `localStorage` directly (e.g. RealtimeOpsPanel
-// → getAuthToken). jsdom's window.localStorage is always complete; prefer it.
-if (
-  typeof globalThis !== 'undefined' &&
-  typeof window !== 'undefined' &&
-  typeof (globalThis as { localStorage?: Storage }).localStorage !==
-    'undefined' &&
-  typeof (globalThis as { localStorage?: Storage }).localStorage?.getItem !==
-    'function'
-) {
-  try {
-    Object.defineProperty(globalThis, 'localStorage', {
-      value: window.localStorage,
-      configurable: true,
-    })
-  } catch {
-    /* non-configurable global in some environments — jsdom path still fine */
+// Without a valid backing file the global exists but is a dead stub (no
+// getItem/setItem/clear), which breaks code reading `localStorage` directly
+// (RealtimeOpsPanel → getAuthToken, the i18n detector, tests calling
+// `localStorage.clear()`). Under vitest's jsdom environment `window
+// .localStorage` resolves to that SAME stub, so prefer any complete Storage
+// (global or window) and otherwise install an in-memory one on both.
+function isUsableStorage(candidate: unknown): candidate is Storage {
+  if (typeof candidate !== 'object' || candidate === null) return false
+  const storage = candidate as Storage
+  return (
+    typeof storage.getItem === 'function' &&
+    typeof storage.setItem === 'function' &&
+    typeof storage.removeItem === 'function' &&
+    typeof storage.clear === 'function'
+  )
+}
+
+function createMemoryStorage(): Storage {
+  const entries = new Map<string, string>()
+  return {
+    get length() {
+      return entries.size
+    },
+    clear: () => {
+      entries.clear()
+    },
+    getItem: (key: string) =>
+      entries.has(key) ? (entries.get(key) as string) : null,
+    key: (index: number) => [...entries.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      entries.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      entries.set(String(key), String(value))
+    },
+  }
+}
+
+if (typeof window !== 'undefined') {
+  let usableStorage: Storage | null = null
+  if (isUsableStorage(globalThis.localStorage)) {
+    usableStorage = globalThis.localStorage
+  } else if (isUsableStorage(window.localStorage)) {
+    usableStorage = window.localStorage
+  }
+  if (usableStorage === null || globalThis.localStorage !== usableStorage) {
+    const storage = usableStorage ?? createMemoryStorage()
+    try {
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: storage,
+        configurable: true,
+      })
+      Object.defineProperty(window, 'localStorage', {
+        value: storage,
+        configurable: true,
+      })
+    } catch {
+      /* non-configurable global in some environments — jsdom path still fine */
+    }
   }
 }
 


### PR DESCRIPTION
## 改动摘要

Part of #887（审计条目 A1，P0）。dashboard attention 告警的 target 与前端 URL 契约不匹配，点击 100% 落空：禁用站点发 `/sites?siteId=N`（sites schema 只有 `edit`）、事件发裸 `/settings`（事件日志在 system-info/program-logs）。本 PR 后端改发 `/sites?edit=N` 与 `/settings/system-info/program-logs`，前端给 accounts 补上 `accountId` 一次性深链消费（打开账号详情 sheet 后 replace 清除，stale id 静默清除，镜像 channels `channelId` 既有模式）。

## 类型

- [x] fix（bug 修复）

## 改动明细

- `handler/admin/stats_balance.go`：disabled_site target 改 `/sites?edit=N`；event target 改 `/settings/system-info/program-logs`；`/accounts?accountId=N` 保留并由前端承接
- `handler/admin/stats_test.go`：attention 测试钉住全部四种 target 形态
- `web/src/routes/_authenticated/accounts.tsx`：accountsSearchSchema 增加容错 `accountId` 参数
- `web/src/features/accounts/components/accounts-page.tsx`：一次性消费 accountId 打开详情 sheet（含 strict-mode 防重入），buildAccountsHref 保留 transient 参数直至消费
- 测试：accounts-page-deep-link（+深链打开/stale 清除用例）、accounts-search-schema（+参数容错用例）
- `web/vitest.setup.ts`：Node 25 的实验性全局 localStorage 是无后端的死 stub，导致 jsdom 下 language-switcher 套件 4 处崩溃——安装可用的 Storage 兜底（与 #887 批次内 chore/design-system-followthrough 的同名修复重叠，后合入者按任一侧解决即可）

## 测试验证

- [x] `go vet ./...` 通过
- [x] `go test ./handler/admin/... -count=1` 通过（全量 -race 由 CI 覆盖）
- [x] `cd web && bun run typecheck` 通过
- [x] `cd web && bun run lint` 0 error
- [x] `cd web && bun run test` 全绿
- [x] `cd web && bun run knip` / `bun run build` / `bun run format:check` 通过

## 自查清单

- [x] 无密钥/内部路径泄漏
- [x] 用户可见文案已走 i18n（本 PR 无新增用户可见文案）
- [x] 行为变更已补充/更新测试
- [ ] CHANGELOG/docs 待整批合入后统一更新

> 合并方式：Squash merge。