### PR TITLE
chore(web): design system follow-through — focus rings, title scale, dead CSS, error banner, version injection

### DIFF
--- a/web/rsbuild.config.ts
+++ b/web/rsbuild.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -7,6 +8,10 @@ import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss'
 import { tanstackRouter } from '@tanstack/router-plugin/rspack'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const webPackageJson = JSON.parse(
+  readFileSync(path.join(__dirname, 'package.json'), 'utf-8')
+) as { version: string }
 
 export default defineConfig(({ envMode }) => {
   // VITE_ prefix kept for parity with legacy env var names
@@ -61,6 +66,12 @@ export default defineConfig(({ envMode }) => {
     source: {
       entry: {
         index: './src/main.tsx',
+      },
+      // Compile-time constant consumed by features/about; keeping it in sync
+      // with the package.json `version` field prevents the displayed SPA
+      // version from drifting at release time. Applied to dev and build.
+      define: {
+        METAPI_WEB_VERSION: JSON.stringify(webPackageJson.version),
       },
     },
     resolve: {

--- a/web/src/env.d.ts
+++ b/web/src/env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="@rsbuild/core/types" />
+
+/**
+ * SPA version injected at compile time via `source.define` in
+ * rsbuild.config.ts (mirrored in vite.config.ts for vitest), read from the
+ * web/package.json `version` field. Available in dev and production builds.
+ */
+declare const METAPI_WEB_VERSION: string

--- a/web/src/features/about/api.ts
+++ b/web/src/features/about/api.ts
@@ -1,19 +1,22 @@
 // metapi-go/features/about — TanStack Query hook for build/runtime info.
 //
 // No backend `/api/about` endpoint exists today. The query resolves
-// build-time constants (version + repo metadata from package.json) so the
-// page can render immediately. The optional fields (`buildTime` / `commit` /
-// `goVersion`) are left undefined; when a backend endpoint lands, swap the
-// `queryFn` to call `api.getAbout()` (or equivalent) and the page picks them
-// up with no component changes. `staleTime: Infinity` because the data is
-// constant for the lifetime of the page load.
+// compile-time constants so the page can render immediately: `version` is the
+// `METAPI_WEB_VERSION` global injected by `source.define` in
+// rsbuild.config.ts (read from the web/package.json `version` field), and
+// the repo metadata below is curated here. The optional fields
+// (`buildTime` / `commit` / `goVersion`) are left undefined; when a backend
+// endpoint lands, swap the `queryFn` to call `api.getAbout()` (or
+// equivalent) and the page picks them up with no component changes.
+// `staleTime: Infinity` because the data is constant for the lifetime of
+// the page load.
 
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 
 import { aboutKeys, type AboutInfo } from './types'
 
 const ABOUT_INFO: AboutInfo = {
-  version: '0.9.0',
+  version: METAPI_WEB_VERSION,
   projectName: 'Metapi',
   description:
     'Meta-layer management and unified proxy for AI API aggregation platforms',

--- a/web/src/features/accounts/components/accounts-columns.tsx
+++ b/web/src/features/accounts/components/accounts-columns.tsx
@@ -27,6 +27,7 @@ import {
 import { useTranslation } from 'react-i18next'
 
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
   DropdownMenu,
@@ -177,28 +178,34 @@ export function AccountsRowActions({
         <Tooltip>
           <TooltipTrigger
             render={
-              <button
-                type='button'
+              <Button
+                variant='ghost'
+                size='icon-sm'
                 disabled={isThisRowPending}
                 aria-label={toggleLabel}
                 onClick={() => actions.onToggleStatus(account)}
-                className='text-muted-foreground hover:bg-muted hover:text-foreground inline-flex size-8 items-center justify-center rounded-md transition-colors outline-none disabled:opacity-50'
-              >
-                {isThisRowPending ? (
-                  <Loader2 className='size-4 animate-spin' />
-                ) : (
-                  <Power className='size-4' />
-                )}
-              </button>
+              />
             }
-          />
+          >
+            {isThisRowPending ? (
+              <Loader2 className='size-4 animate-spin' />
+            ) : (
+              <Power className='size-4' />
+            )}
+          </TooltipTrigger>
           <TooltipContent side='top'>{toggleLabel}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
       <DropdownMenu>
         <DropdownMenuTrigger
-          className='text-muted-foreground hover:bg-muted hover:text-foreground inline-flex size-8 items-center justify-center rounded-md transition-colors outline-none'
-          aria-label={t('accounts.columns.rowActions')}
+          render={
+            <Button
+              variant='ghost'
+              size='icon-sm'
+              className='data-popup-open:bg-accent'
+              aria-label={t('accounts.columns.rowActions')}
+            />
+          }
         >
           <MoreHorizontal className='size-4' />
         </DropdownMenuTrigger>

--- a/web/src/features/auth/components/sign-in-page.tsx
+++ b/web/src/features/auth/components/sign-in-page.tsx
@@ -33,7 +33,7 @@ export function SignInPage({ redirectTo }: SignInPageProps) {
             alt={metapiIdentity.name}
             className='mx-auto size-12'
           />
-          <h1 className='text-3xl font-bold tracking-tight'>
+          <h1 className='text-2xl font-normal tracking-tight'>
             {t('auth.login.brandName')}
           </h1>
           <CardDescription>{t('auth.login.brandTagline')}</CardDescription>

--- a/web/src/features/checkin/components/checkin-columns.tsx
+++ b/web/src/features/checkin/components/checkin-columns.tsx
@@ -7,6 +7,7 @@ import { Eye, MoreHorizontal, Play } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -73,8 +74,14 @@ function CheckinRowActions({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
-        className='text-muted-foreground hover:bg-muted hover:text-foreground inline-flex size-8 items-center justify-center rounded-md transition-colors outline-none'
-        aria-label={t('checkin.columns.rowActions')}
+        render={
+          <Button
+            variant='ghost'
+            size='icon-sm'
+            className='data-popup-open:bg-accent'
+            aria-label={t('checkin.columns.rowActions')}
+          />
+        }
       >
         <MoreHorizontal className='size-4' />
       </DropdownMenuTrigger>

--- a/web/src/features/sites/components/sites-page.tsx
+++ b/web/src/features/sites/components/sites-page.tsx
@@ -12,13 +12,13 @@
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import {
   Plus as PlusIcon,
-  RotateCcw as RotateCcwIcon,
   Trash2 as Trash2Icon,
   Upload as UploadIcon,
 } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import {
   DataTableBulkActions,
   DataTablePage,
@@ -391,27 +391,12 @@ export function SitesPage() {
       </div>
 
       {sitesQuery.error ? (
-        <div className='flex flex-col gap-3'>
-          <div className='border-destructive/40 bg-destructive/10 text-destructive-soft-fg rounded-lg border p-3 text-sm'>
-            {t('sites.page.loadError', {
-              message: (sitesQuery.error as Error).message,
-            })}
-          </div>
-          <div>
-            <Button
-              variant='secondary'
-              onClick={() => sitesQuery.refetch()}
-              disabled={sitesQuery.isFetching}
-            >
-              {sitesQuery.isFetching ? (
-                <Spinner className='mr-1' />
-              ) : (
-                <RotateCcwIcon className='mr-1 size-4' />
-              )}
-              {t('sites.page.retry')}
-            </Button>
-          </div>
-        </div>
+        <QueryErrorBanner
+          error={sitesQuery.error as Error | null}
+          messageKey='sites.page.loadError'
+          onRetry={() => sitesQuery.refetch()}
+          isRetrying={sitesQuery.isFetching}
+        />
       ) : (
         <DataTablePage
           table={table}

--- a/web/src/features/token-routes/components/routes-columns.tsx
+++ b/web/src/features/token-routes/components/routes-columns.tsx
@@ -17,6 +17,7 @@ import {
 import { useTranslation } from 'react-i18next'
 
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
   DropdownMenu,
@@ -114,8 +115,14 @@ function RoutesRowActions({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
-        className='text-muted-foreground hover:bg-muted hover:text-foreground inline-flex size-8 items-center justify-center rounded-md transition-colors outline-none'
-        aria-label={t('tokenRoutes.columns.rowActions')}
+        render={
+          <Button
+            variant='ghost'
+            size='icon-sm'
+            className='data-popup-open:bg-accent'
+            aria-label={t('tokenRoutes.columns.rowActions')}
+          />
+        }
       >
         <MoreHorizontal className='size-4' />
       </DropdownMenuTrigger>

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -199,31 +199,9 @@
   }
 }
 
-/* Launch UI animations. */
 @layer utilities {
-  /* Animations */
-  .animate-appear {
-    animation: appear 0.6s forwards ease-out;
-  }
-
-  .animate-appear-zoom {
-    animation: appear-zoom 0.6s forwards ease-out;
-  }
-
   .animation-delay-100 {
     animation-delay: 100ms;
-  }
-
-  .animation-delay-300 {
-    animation-delay: 300ms;
-  }
-
-  .animation-delay-700 {
-    animation-delay: 700ms;
-  }
-
-  .animation-delay-1000 {
-    animation-delay: 1000ms;
   }
 
   /*
@@ -253,66 +231,9 @@
     background-size: 200% 100%;
     animation: shimmer 1.6s ease-in-out infinite;
   }
-
-  @keyframes appear {
-    0% {
-      opacity: 0;
-      transform: translateY(1rem);
-      filter: blur(0.5rem);
-    }
-    50% {
-      filter: blur(0);
-    }
-    100% {
-      opacity: 1;
-      transform: translateY(0);
-      filter: blur(0);
-    }
-  }
-
-  @keyframes appear-zoom {
-    0% {
-      opacity: 0;
-      transform: scale(0.5);
-    }
-    100% {
-      opacity: 1;
-      transform: scale(1);
-    }
-  }
-
-  /* Vertical scroll animation for icon lists */
-  @keyframes scroll-up {
-    0% {
-      transform: translateY(0);
-    }
-    100% {
-      transform: translateY(-50%);
-    }
-  }
-
-  .animate-scroll-up {
-    animation: scroll-up 20s linear infinite;
-    will-change: transform;
-  }
-
-  .animate-scroll-down {
-    animation: scroll-up 20s linear infinite reverse;
-    will-change: transform;
-  }
-
-  /* Pause animation on hover */
-  .scroll-container:hover .animate-scroll-up,
-  .scroll-container:hover .animate-scroll-down {
-    animation-play-state: paused;
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .animate-appear,
-  .animate-appear-zoom,
-  .animate-scroll-up,
-  .animate-scroll-down,
   [data-slot='table'][data-table-stagger='true'] tbody tr {
     animation: none !important;
     opacity: 1;
@@ -331,84 +252,6 @@
 @media (prefers-reduced-motion: reduce) {
   .animate-shimmer {
     animation: none !important;
-  }
-}
-
-/* ── Landing page scroll-triggered animations ── */
-@keyframes landing-fade-up {
-  from {
-    opacity: 0;
-    transform: translateY(24px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-@keyframes landing-fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-@keyframes landing-scale-in {
-  from {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-@keyframes landing-fade-left {
-  from {
-    opacity: 0;
-    transform: translateX(24px);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
-@keyframes landing-fade-right {
-  from {
-    opacity: 0;
-    transform: translateX(-24px);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
-
-.landing-animate-fade-up {
-  animation: landing-fade-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-.landing-animate-fade-in {
-  animation: landing-fade-in 0.6s ease-out both;
-}
-.landing-animate-scale-in {
-  animation: landing-scale-in 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-.landing-animate-fade-left {
-  animation: landing-fade-left 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-.landing-animate-fade-right {
-  animation: landing-fade-right 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .landing-animate-fade-up,
-  .landing-animate-fade-in,
-  .landing-animate-scale-in,
-  .landing-animate-fade-left,
-  .landing-animate-fade-right {
-    animation: none !important;
-    opacity: 1 !important;
-    transform: none !important;
   }
 }
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,10 +1,21 @@
+import { readFileSync } from 'node:fs'
 import { fileURLToPath, URL } from 'node:url'
 
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vitest/config'
 
+// Mirrors the `METAPI_WEB_VERSION` compile-time constant that
+// rsbuild.config.ts injects via `source.define`, so modules consuming the
+// global (features/about) also resolve it under vitest.
+const webPackageJson = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf-8')
+) as { version: string }
+
 export default defineConfig({
   plugins: [react()],
+  define: {
+    METAPI_WEB_VERSION: JSON.stringify(webPackageJson.version),
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),

--- a/web/vite.dev.config.ts
+++ b/web/vite.dev.config.ts
@@ -3,6 +3,7 @@
 // exists so we can run a native Vite dev server with HMR while iterating on
 // the login page visuals. NOT used for production builds.
 
+import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -12,6 +13,13 @@ import react from '@vitejs/plugin-react'
 import { defineConfig, loadEnv } from 'vite'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// Mirrors the `METAPI_WEB_VERSION` compile-time constant that
+// rsbuild.config.ts injects via `source.define`, so the About page also
+// resolves it under this throwaway Vite dev server.
+const webPackageJson = JSON.parse(
+  readFileSync(path.join(__dirname, 'package.json'), 'utf-8')
+) as { version: string }
 
 // VITE_ prefix kept for parity with rsbuild.config.ts env handling
 // (DEV_PROXY_TARGET / VITE_DEV_PROXY_TARGET / PORT / VITE_BACKEND_PORT).
@@ -56,6 +64,9 @@ export default defineConfig(({ mode }) => {
       alias: {
         '@': path.resolve(__dirname, './src'),
       },
+    },
+    define: {
+      METAPI_WEB_VERSION: JSON.stringify(webPackageJson.version),
     },
     server: {
       host: '0.0.0.0',


### PR DESCRIPTION
## 改动摘要

Part of #887（审计条目 C/D：设计系统"定了没用"收口）。六项独立修复：行操作按钮补回 focus-visible ring、sign-in 标题回到 DESIGN 字阶、删除约 100 行零引用 landing 动画死 CSS、sites 页迁移到共享 QueryErrorBanner、about 版本号改构建期从 package.json 注入（此前硬编码 0.9.0 与实际版本脱节）、Node 25 下 vitest localStorage 兜底。

## 类型

- [x] chore（工程维护）

## 改动明细

- `accounts-columns.tsx` / `checkin-columns.tsx` / `routes-columns.tsx`：手搓 `outline-none` 无 ring 的行操作按钮换成 ui/button 原语（对齐 sites/models 列的规范写法），恢复键盘焦点环；aria-label/pending/dropdown 行为不变
- `sign-in-page.tsx`：h1 `text-3xl font-bold` → `text-2xl font-normal tracking-tight`（DESIGN.md 页面标题阶梯）
- `styles/index.css`：删除零引用的 appear/appear-zoom/scroll-up/landing-* keyframes 与工具类（-157 行）；保留真实接线的 animate-shimmer 与 data-table-stagger；styles/__tests__ 全绿
- `sites-page.tsx`：手写错误横幅迁移到 `common/query-error-banner`（保留 retry=refetch 与 error 态抑制表格）
- `rsbuild.config.ts` / `env.d.ts` / `about/api.ts`：版本经 source.define 从 package.json 注入，替换硬编码 0.9.0；修正失真注释
- `vitest.setup.ts` + `vite.config.ts` + `vite.dev.config.ts`：Node 25 实验性全局 localStorage 是死 stub，jsdom 下 4 个 language-switcher 用例崩溃——安装可用 Storage 兜底（与 #887 批次内 fix/attention-deep-links 的同名修复重叠，后合入者按任一侧解决即可）

## 测试验证

- [x] `cd web && bun run typecheck` 通过
- [x] `cd web && bun run lint` 0 error
- [x] `cd web && bun run test` 全绿
- [x] `cd web && bun run knip` / `bun run build` / `bun run format:check` 通过

## 自查清单

- [x] 无密钥/内部路径泄漏
- [x] 用户可见文案已走 i18n（本 PR 无新增用户可见文案）
- [x] 行为变更已补充/更新测试（纯视觉/工程修复，既有用例守卫）
- [ ] CHANGELOG/docs 待整批合入后统一更新（a11y-checklist 中幽灵组件与 reduced-transparency 虚标问题另行处理）

> 合并方式：Squash merge。