### PR TITLE
fix(web): close first-run onboarding dead-ends (import done step, key Connect, toast SPA nav)

### DIFF
--- a/web/src/features/accounts/components/account-created-toast.test.ts
+++ b/web/src/features/accounts/components/account-created-toast.test.ts
@@ -1,0 +1,65 @@
+// Behavior test for the account-created guided toast. Locks the SPA
+// navigation contract: the toast action must route through the shared
+// router instance (no window.location hard reload) and keep the
+// /token-routes deep link with the new account/site preselected.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { showAccountCreatedToast } from './account-created-toast'
+
+const { mockNavigate, mockToastSuccess } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockToastSuccess: vi.fn(),
+}))
+
+vi.mock('@/lib/router', () => ({
+  router: { navigate: mockNavigate },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: mockToastSuccess,
+  },
+}))
+
+function captureToastAction(): { onClick: () => Promise<void> } {
+  expect(mockToastSuccess).toHaveBeenCalledTimes(1)
+  const options = mockToastSuccess.mock.calls[0][1] as {
+    action?: { onClick?: () => Promise<void> }
+  }
+  expect(options.action?.onClick).toBeTypeOf('function')
+  return options.action as { onClick: () => Promise<void> }
+}
+
+beforeEach(() => {
+  mockNavigate.mockReset()
+  mockToastSuccess.mockReset()
+})
+
+describe('showAccountCreatedToast', () => {
+  it('routes the toast action to /token-routes via the SPA router', async () => {
+    showAccountCreatedToast(42, 7)
+
+    const action = captureToastAction()
+    await action.onClick()
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/token-routes',
+      search: { accountId: 42, siteId: 7 },
+    })
+  })
+
+  it('navigates without preselection when the ids are unknown', async () => {
+    showAccountCreatedToast()
+
+    const action = captureToastAction()
+    await action.onClick()
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/token-routes',
+      search: { accountId: undefined, siteId: undefined },
+    })
+  })
+})

--- a/web/src/features/accounts/components/account-created-toast.tsx
+++ b/web/src/features/accounts/components/account-created-toast.tsx
@@ -3,19 +3,15 @@
 // guided configuration chain (research/10-user-flows.md §4.2): the account
 // is added, and the operator is nudged to configure routes for it next.
 //
-// Navigation uses a hard assignment because the toast action outlives the
-// account form component that created it.
+// Navigation goes through the shared router instance (lib/router) because
+// the toast action outlives the account form component that created it —
+// a router.navigate keeps it a SPA transition instead of a hard reload.
+// The router is imported lazily inside the click handler: a static import
+// here would cycle back through routeTree.gen (router → routes → features
+// → this toast).
 
 import i18n from '@/i18n/config'
 import { toast } from '@/lib/toast'
-
-function buildRouteTarget(accountId?: number, siteId?: number): string {
-  const params = new URLSearchParams()
-  if (accountId) params.set('accountId', String(accountId))
-  if (siteId) params.set('siteId', String(siteId))
-  const query = params.toString()
-  return query ? `/token-routes?${query}` : '/token-routes'
-}
 
 /**
  * Fire the post-create guided toast. Call from the create-account form's
@@ -26,13 +22,18 @@ export function showAccountCreatedToast(
   accountId?: number,
   siteId?: number
 ): void {
-  const target = buildRouteTarget(accountId, siteId)
   toast.success(i18n.t('accounts.created.title'), {
     description: i18n.t('accounts.created.description'),
     duration: 8000,
     action: {
       label: i18n.t('accounts.created.action'),
-      onClick: () => window.location.assign(target),
+      onClick: async () => {
+        const { router } = await import('@/lib/router')
+        await router.navigate({
+          to: '/token-routes',
+          search: { accountId, siteId },
+        })
+      },
     },
   })
 }

--- a/web/src/features/import/__tests__/import-wizard-dialog.test.tsx
+++ b/web/src/features/import/__tests__/import-wizard-dialog.test.tsx
@@ -25,13 +25,19 @@ import '@/i18n/config'
 
 import { ImportWizardDialog } from '../components/import-wizard-dialog'
 
-const { mockDetectMutate, mockImportMutate, mockToastError } = vi.hoisted(
-  () => ({
-    mockDetectMutate: vi.fn(),
-    mockImportMutate: vi.fn(),
-    mockToastError: vi.fn(),
-  })
-)
+const {
+  mockDetectMutate,
+  mockImportMutate,
+  mockToastError,
+  mockNavigate,
+  mockRebuildMutate,
+} = vi.hoisted(() => ({
+  mockDetectMutate: vi.fn(),
+  mockImportMutate: vi.fn(),
+  mockToastError: vi.fn(),
+  mockNavigate: vi.fn(),
+  mockRebuildMutate: vi.fn(),
+}))
 
 vi.mock('../api', () => ({
   useDetectSite: () => ({ mutateAsync: mockDetectMutate, isPending: false }),
@@ -40,6 +46,16 @@ vi.mock('../api', () => ({
 
 vi.mock('@/features/sites/api', () => ({
   useSites: () => ({ data: [], isPending: false }),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+}))
+
+// The wizard's done step reuses the shared rebuild mutation; mock it so the
+// tests never need a QueryClientProvider for it.
+vi.mock('@/features/token-routes/api', () => ({
+  useRebuildRoutes: () => ({ mutate: mockRebuildMutate, isPending: false }),
 }))
 
 vi.mock('sonner', () => ({
@@ -69,6 +85,8 @@ beforeEach(() => {
   mockDetectMutate.mockReset()
   mockImportMutate.mockReset()
   mockToastError.mockReset()
+  mockNavigate.mockReset()
+  mockRebuildMutate.mockReset()
   // Default: detection returns undetectable (empty platform).
   mockDetectMutate.mockResolvedValue({})
 })
@@ -343,5 +361,129 @@ describe('ImportWizardDialog', () => {
     await waitFor(() => {
       expect(sourceField).not.toHaveAttribute('aria-invalid')
     })
+  })
+})
+
+// Done-step next-step guidance. Import does not trigger a route rebuild on
+// the backend, so the done step must hand the operator the next actions:
+// rebuild routes (primary), add an account (secondary), or just close.
+describe('ImportWizardDialog — done step next steps', () => {
+  async function advanceToDoneStep(onOpenChange: (open: boolean) => void) {
+    mockDetectMutate.mockResolvedValue({
+      platform: 'new-api',
+      confidence: 0.9,
+    })
+    mockImportMutate.mockResolvedValue({
+      imported: 1,
+      skipped: 0,
+      failed: 0,
+      results: [
+        {
+          name: 'a.com',
+          url: 'https://a.com',
+          status: 'imported',
+        },
+      ],
+    })
+
+    render(<ImportWizardDialog open onOpenChange={onOpenChange} />)
+
+    // source → identify
+    await waitFor(() => {
+      expect(screen.getByLabelText('Site URLs')).toBeInTheDocument()
+    })
+    fireEvent.change(screen.getByLabelText('Site URLs'), {
+      target: { value: 'https://a.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('new-api')).toBeInTheDocument()
+    })
+
+    // identify → connect → routes
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await waitFor(() => {
+      expect(screen.getByRole('switch')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await waitFor(() => {
+      expect(screen.getByRole('spinbutton')).toBeInTheDocument()
+    })
+
+    // routes → done
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }))
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Rebuild routes' })
+      ).toBeInTheDocument()
+    })
+  }
+
+  it('explains that imported sites need a route rebuild and offers both CTAs', async () => {
+    await advanceToDoneStep(() => {})
+
+    // The explainer line tells the operator models are not routable yet.
+    expect(
+      screen.getByText(/only become routable after a route rebuild/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Rebuild routes' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Add account' })
+    ).toBeInTheDocument()
+    // The original close affordance survives.
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+  })
+
+  it('fires the rebuild mutation and closes the wizard once it succeeds', async () => {
+    const onOpenChange = vi.fn()
+    // Simulate a mutation that settles synchronously with success.
+    mockRebuildMutate.mockImplementation(
+      (_variables: unknown, callbacks?: { onSuccess?: () => void }) => {
+        callbacks?.onSuccess?.()
+      }
+    )
+
+    await advanceToDoneStep(onOpenChange)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rebuild routes' }))
+
+    expect(mockRebuildMutate).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('keeps the wizard open when the rebuild request fails', async () => {
+    const onOpenChange = vi.fn()
+    // Failure path: mutate settles with onError, never onSuccess.
+    mockRebuildMutate.mockImplementation(
+      (_variables: unknown, callbacks?: { onError?: () => void }) => {
+        callbacks?.onError?.()
+      }
+    )
+
+    await advanceToDoneStep(onOpenChange)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rebuild routes' }))
+
+    expect(mockRebuildMutate).toHaveBeenCalledTimes(1)
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    // Still on the done step: the CTA is still available for a retry.
+    expect(
+      screen.getByRole('button', { name: 'Rebuild routes' })
+    ).toBeInTheDocument()
+  })
+
+  it('navigates to /accounts and closes the wizard on Add account', async () => {
+    const onOpenChange = vi.fn()
+
+    await advanceToDoneStep(onOpenChange)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add account' }))
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/accounts' })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 })

--- a/web/src/features/import/components/import-wizard-dialog.tsx
+++ b/web/src/features/import/components/import-wizard-dialog.tsx
@@ -6,12 +6,15 @@
 // weight, then commits one idempotent POST /api/sites/import and reports the
 // imported/skipped/failed breakdown.
 
+import { useNavigate } from '@tanstack/react-router'
 import {
   Check as CheckIcon,
   Minus as MinusIcon,
   TriangleAlert as AlertIcon,
   Upload as UploadIcon,
+  UserPlus as UserPlusIcon,
   X as XIcon,
+  Zap as ZapIcon,
 } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -35,6 +38,7 @@ import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { useSites } from '@/features/sites/api'
 import type { Site } from '@/features/sites/types'
+import { useRebuildRoutes } from '@/features/token-routes/api'
 
 import { useDetectSite, useImportSites } from '../api'
 import { canonicalizeUrl, parseUrlLines } from '../lib/utils'
@@ -123,9 +127,11 @@ export function ImportWizardDialog({
   onOpenChange,
 }: ImportWizardDialogProps) {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const sitesQuery = useSites()
   const detectSite = useDetectSite()
   const importSites = useImportSites()
+  const rebuildRoutes = useRebuildRoutes()
 
   const [step, setStep] = useState<ImportStepId>('source')
   const [sourceText, setSourceText] = useState('')
@@ -388,6 +394,25 @@ export function ImportWizardDialog({
   function handleDone() {
     reset()
     onOpenChange(false)
+  }
+
+  // Imported sites are not routable until a route rebuild picks them up.
+  // Reuse the shared rebuild mutation (it already toasts queued/complete
+  // outcomes); close the wizard once the rebuild request lands. On failure
+  // the wizard stays open so the operator can retry.
+  function handleRebuildRoutes() {
+    rebuildRoutes.mutate(undefined, {
+      onSuccess: () => {
+        reset()
+        onOpenChange(false)
+      },
+    })
+  }
+
+  function handleGoToAccounts() {
+    reset()
+    onOpenChange(false)
+    navigate({ to: '/accounts' })
   }
 
   return (
@@ -686,6 +711,9 @@ export function ImportWizardDialog({
                     {t('import.done.failed', { count: result.failed })}
                   </Badge>
                 </div>
+                <p className='text-muted-foreground text-xs'>
+                  {t('import.done.rebuildHint')}
+                </p>
                 <div className='grid gap-2'>
                   {result.results.map((item) => {
                     const badge = statusBadge(item.status)
@@ -777,10 +805,32 @@ export function ImportWizardDialog({
               </Button>
             )}
             {step === 'done' && (
-              <Button type='button' onClick={handleDone}>
-                <CheckIcon className='mr-1 size-4' />
-                {t('import.done.close')}
-              </Button>
+              <>
+                <Button type='button' variant='ghost' onClick={handleDone}>
+                  <CheckIcon className='mr-1 size-4' />
+                  {t('import.done.close')}
+                </Button>
+                <Button
+                  type='button'
+                  variant='outline'
+                  onClick={handleGoToAccounts}
+                >
+                  <UserPlusIcon className='mr-1 size-4' />
+                  {t('import.done.addAccount')}
+                </Button>
+                <Button
+                  type='button'
+                  onClick={handleRebuildRoutes}
+                  disabled={rebuildRoutes.isPending}
+                >
+                  {rebuildRoutes.isPending ? (
+                    <Spinner className='mr-2' />
+                  ) : (
+                    <ZapIcon className='mr-1 size-4' />
+                  )}
+                  {t('import.done.rebuildRoutes')}
+                </Button>
+              </>
             )}
           </DialogFooter>
         </DialogContent>

--- a/web/src/features/settings/sections/downstream/components/__tests__/keys-section.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/keys-section.test.tsx
@@ -105,6 +105,7 @@ afterEach(() => cleanup())
 function renderKeySheetForm(props: {
   editingKey: Parameters<typeof KeySheetForm>[0]['editingKey']
   onDone?: () => void
+  onCreated?: (target: { id: number; name: string; keyMasked?: string }) => void
 }) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -113,14 +114,20 @@ function renderKeySheetForm(props: {
     },
   })
   const onDone = props.onDone ?? vi.fn()
+  const onCreated = props.onCreated ?? vi.fn()
   return {
     onDone,
+    onCreated,
     ...render(
       (
         <QueryClientProvider client={queryClient}>
           <Sheet open onOpenChange={() => {}}>
             <SheetContent>
-              <KeySheetForm editingKey={props.editingKey} onDone={onDone} />
+              <KeySheetForm
+                editingKey={props.editingKey}
+                onDone={onDone}
+                onCreated={onCreated}
+              />
             </SheetContent>
           </Sheet>
         </QueryClientProvider>
@@ -260,6 +267,70 @@ describe('KeySheetForm — create mode', () => {
       expect(onDone).toHaveBeenCalledTimes(1)
     })
     expect(mockToastSuccess).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports the created key to onCreated so KeysSection can auto-open Connect', async () => {
+    // The real backend envelope: POST /api/downstream-keys re-reads the
+    // inserted row and answers { success, item }.
+    mockCreateKey.mockResolvedValue({
+      success: true,
+      item: { id: 7, name: 'New key', keyMasked: 'sk-…5678' },
+    })
+
+    const { onDone, onCreated } = renderKeySheetForm({ editingKey: null })
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'New key' },
+    })
+    fireEvent.change(screen.getByLabelText('Key'), {
+      target: { value: 'sk-12345678' },
+    })
+
+    const form = document.querySelector('form')
+    if (!form) {
+      throw new Error('KeySheetForm did not render its <form>')
+    }
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith({
+        id: 7,
+        name: 'New key',
+        keyMasked: 'sk-…5678',
+      })
+    })
+    // The sheet still closes exactly once — Connect opens as the sheet
+    // dismisses, not instead of it.
+    await waitFor(() => {
+      expect(onDone).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('skips onCreated (keeps toast-only feedback) when the response lacks the created row', async () => {
+    // Legacy/empty envelope: nothing to build a dialog target from, and
+    // nothing may be fabricated.
+    mockCreateKey.mockResolvedValue({ success: true })
+
+    const { onDone, onCreated } = renderKeySheetForm({ editingKey: null })
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'New key' },
+    })
+    fireEvent.change(screen.getByLabelText('Key'), {
+      target: { value: 'sk-12345678' },
+    })
+
+    const form = document.querySelector('form')
+    if (!form) {
+      throw new Error('KeySheetForm did not render its <form>')
+    }
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(onDone).toHaveBeenCalledTimes(1)
+    })
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1)
+    expect(onCreated).not.toHaveBeenCalled()
   })
 })
 

--- a/web/src/features/settings/sections/downstream/components/keys-section.tsx
+++ b/web/src/features/settings/sections/downstream/components/keys-section.tsx
@@ -84,6 +84,15 @@ type DownstreamApiKeyItem = {
 
 type DownstreamKeysResponse = { items: DownstreamApiKeyItem[] }
 
+// POST /api/downstream-keys responds with the created row under `item` (the
+// handler re-reads the inserted row and adds a camelCase `keyMasked`). Only
+// the fields the connect dialog target needs are typed here; the dialog
+// fetches the full export payload (endpoint + plaintext key) on its own.
+type CreateDownstreamKeyResponse = {
+  success?: boolean
+  item?: Pick<DownstreamApiKeyItem, 'id' | 'name' | 'keyMasked'>
+}
+
 const downstreamKeysQueryKeys = {
   all: ['downstream-keys'] as const,
   list: () => [...downstreamKeysQueryKeys.all, 'list'] as const,
@@ -160,12 +169,18 @@ function keyFormValuesFromItem(
 // Exported so the edit-mode behavior test can render it in isolation,
 // mirroring the AccountsRowActions export pattern. The whole KeysSection
 // remains the only public entry in the settings surface.
+//
+// `onCreated` (create mode only) receives the created key's export-dialog
+// target straight from the create response so KeysSection can auto-open the
+// Connect surface — the operator no longer has to hunt the row down.
 export function KeySheetForm({
   editingKey,
   onDone,
+  onCreated,
 }: {
   editingKey: DownstreamApiKeyItem | null
   onDone: () => void
+  onCreated?: (target: CredentialExportTarget) => void
 }) {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
@@ -200,7 +215,7 @@ export function KeySheetForm({
         expiresAt: values.expiresAt,
       })
     },
-    onSuccess: () => {
+    onSuccess: (result, values) => {
       void queryClient.invalidateQueries({
         queryKey: downstreamKeysQueryKeys.all,
       })
@@ -209,6 +224,23 @@ export function KeySheetForm({
           ? t('settings.downstream.keys.toast.updated')
           : t('settings.downstream.keys.toast.created')
       )
+      if (!isEdit) {
+        // Auto-open the Connect dialog for the freshly created key. The
+        // dialog target only needs id/name/keyMasked, which the create
+        // response carries under `item`; the plaintext key itself is pulled
+        // by the dialog's own export query. When the response lacks the row
+        // (older/unexpected payloads) nothing is fabricated — the success
+        // toast above stays the only feedback.
+        const createdItem = (result as CreateDownstreamKeyResponse | undefined)
+          ?.item
+        if (createdItem && createdItem.id > 0) {
+          onCreated?.({
+            id: createdItem.id,
+            name: createdItem.name || values.name,
+            keyMasked: createdItem.keyMasked,
+          })
+        }
+      }
       onDone()
     },
     onError: () =>
@@ -651,6 +683,7 @@ export function KeysSection() {
             key={editingKey?.id ?? 'create'}
             editingKey={editingKey}
             onDone={() => onSheetOpenChange(false)}
+            onCreated={(target) => setExportTarget(target)}
           />
         </SheetContent>
       </Sheet>

--- a/web/src/features/token-routes/components/route-completion-toast.test.ts
+++ b/web/src/features/token-routes/components/route-completion-toast.test.ts
@@ -1,0 +1,60 @@
+// Behavior test for the route-completion guided toast. Locks the SPA
+// navigation contract: the toast action must route through the shared
+// router instance (no window.location hard reload) and land on the
+// Settings → Downstream subarea, same URL as before the fix.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { showRouteCompletionToast } from './route-completion-toast'
+
+const { mockNavigate, mockToastSuccess } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockToastSuccess: vi.fn(),
+}))
+
+vi.mock('@/lib/router', () => ({
+  router: { navigate: mockNavigate },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: mockToastSuccess,
+  },
+}))
+
+beforeEach(() => {
+  mockNavigate.mockReset()
+  mockToastSuccess.mockReset()
+})
+
+describe('showRouteCompletionToast', () => {
+  it('routes the toast action to Settings → Downstream via the SPA router', async () => {
+    showRouteCompletionToast(11, { accountId: 42, siteId: 7 })
+
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1)
+    const options = mockToastSuccess.mock.calls[0][1] as {
+      action?: { onClick?: () => Promise<void> }
+    }
+    const action = options.action as { onClick: () => Promise<void> }
+    await action.onClick()
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/settings/$subarea',
+      params: { subarea: 'downstream' },
+    })
+  })
+
+  it('still navigates when fired without route context', async () => {
+    showRouteCompletionToast()
+
+    const options = mockToastSuccess.mock.calls[0][1] as {
+      action?: { onClick?: () => Promise<void> }
+    }
+    const action = options.action as { onClick: () => Promise<void> }
+    await action.onClick()
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/features/token-routes/components/route-completion-toast.tsx
+++ b/web/src/features/token-routes/components/route-completion-toast.tsx
@@ -2,8 +2,12 @@
 // complete" toast shown after a route is created. This is the **final step**
 // of the site → account → route guided configuration chain.
 //
-// Navigation uses window.location.assign rather than TanStack Router's
-// type-safe `navigate`; a hard navigation keeps the deep-link working today.
+// Navigation goes through the shared router instance (lib/router) because
+// the toast action outlives the route form component that created it — a
+// router.navigate keeps it a SPA transition instead of a hard reload. The
+// router is imported lazily inside the click handler: a static import here
+// would cycle back through routeTree.gen (router → routes → features →
+// this toast).
 
 import i18n from '@/i18n/config'
 import { toast } from '@/lib/toast'
@@ -34,7 +38,13 @@ export function showRouteCompletionToast(
     duration: 8000,
     action: {
       label: i18n.t('tokenRoutes.completion.connectAction'),
-      onClick: () => window.location.assign('/settings/downstream'),
+      onClick: async () => {
+        const { router } = await import('@/lib/router')
+        await router.navigate({
+          to: '/settings/$subarea',
+          params: { subarea: 'downstream' },
+        })
+      },
     },
   })
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1770,7 +1770,7 @@
         "withRouteId": "Route #{{id}} created. {{suffix}}",
         "withoutRouteId": "Route created. {{suffix}}",
         "action": "Back to Dashboard",
-        "connectAction": "接入客户端"
+        "connectAction": "Connect a client"
       },
       "toast": {
         "updated": "Route updated",
@@ -2259,7 +2259,10 @@
         "skipped": "Skipped {{count}}",
         "failed": "Failed {{count}}",
         "close": "Done",
-        "announce": "Imported {{imported}}, skipped {{skipped}}, failed {{failed}}."
+        "announce": "Imported {{imported}}, skipped {{skipped}}, failed {{failed}}.",
+        "rebuildHint": "Imported sites only become routable after a route rebuild — rebuild now or later from the Routes page.",
+        "rebuildRoutes": "Rebuild routes",
+        "addAccount": "Add account"
       },
       "result": {
         "imported": "Imported",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2259,7 +2259,10 @@
         "skipped": "已跳过 {{count}}",
         "failed": "失败 {{count}}",
         "close": "完成",
-        "announce": "已导入 {{imported}}，跳过 {{skipped}}，失败 {{failed}}。"
+        "announce": "已导入 {{imported}}，跳过 {{skipped}}，失败 {{failed}}。",
+        "rebuildHint": "导入的站点需要重建路由后模型才可路由，可立即重建，或稍后在路由页执行。",
+        "rebuildRoutes": "重建路由",
+        "addAccount": "添加账号"
       },
       "result": {
         "imported": "已导入",

--- a/web/src/lib/router.ts
+++ b/web/src/lib/router.ts
@@ -1,0 +1,80 @@
+// metapi-go/lib — shared QueryClient + Router instances.
+//
+// Lives outside main.tsx so non-React call sites (e.g. sonner toast action
+// callbacks, which outlive the component that fired them) can navigate
+// through the SPA router instead of hard-reloading the page. main.tsx
+// imports both instances for the provider stack; nothing here depends on
+// main.tsx.
+
+import { QueryCache, QueryClient } from '@tanstack/react-query'
+import { createRouter } from '@tanstack/react-router'
+import { AxiosError } from 'axios'
+import i18next from 'i18next'
+
+import { ErrorPage } from '@/components/layout/error-page'
+import { NotFoundPage } from '@/components/layout/not-found-page'
+import { RoutePending } from '@/components/layout/route-pending'
+import { toast } from '@/lib/toast'
+// Generated route tree (TanStack Router plugin overwrites on dev/build)
+import { routeTree } from '@/routeTree.gen'
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: (failureCount, error) => {
+        // Dev: never retry (fail fast for debugging).
+        if (import.meta.env.DEV) return false
+        // Prod: cap at 3 retries.
+        if (failureCount > 3) return false
+        // Never retry auth errors (401/403) — they won't recover.
+        return !(
+          error instanceof AxiosError &&
+          [401, 403].includes(error.response?.status ?? 0)
+        )
+      },
+      // Keep focused tabs from silently re-running heavy pages.
+      refetchOnWindowFocus: false,
+      staleTime: 10 * 1000, // 10s
+    },
+  },
+  queryCache: new QueryCache({
+    onError: (error) => {
+      if (error instanceof AxiosError && error.response?.status === 500) {
+        toast.error(i18next.t('errors.internalServerError'))
+      }
+    },
+  }),
+})
+
+export const router = createRouter({
+  routeTree,
+  context: { queryClient },
+  defaultPreload: 'intent',
+  defaultNotFoundComponent: NotFoundPage,
+  defaultErrorComponent: ErrorPage,
+  // The window never scrolls — the app is a single pane and the scroll
+  // container is #content (AuthenticatedLayout's SidebarInset). Reset it to
+  // top on navigation so a new route never inherits the previous page's
+  // offset.
+  scrollRestoration: true,
+  scrollToTopSelectors: ['#content'],
+  // Leaf routes are code-split (rsbuild.config.ts `autoCodeSplitting`), so a
+  // cold navigation suspends until the chunk + loader resolve. Without a
+  // pending component the router renders `null` in that window — a black flash
+  // in dark mode. RoutePending keeps the content shell visible instead.
+  // `pendingMs` debounces the fallback (fast loads never show it) and
+  // `pendingMinMs` stops the skeleton itself from flickering on near-misses.
+  defaultPendingComponent: RoutePending,
+  defaultPendingMs: 200,
+  defaultPendingMinMs: 300,
+})
+
+// Register the router instance for type safety.
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router
+  }
+  interface StaticDataRouteOption {
+    title?: string
+  }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,95 +1,23 @@
 // metapi-go — application entry (main.tsx).
-// Orchestrates: QueryClient (retry/401/403/500/staleTime) → RouterProvider
-// (TanStack Router, routeTree.gen.ts) → 3-layer Provider stack
-// (Theme → Direction → ThemeCustomization).
+// Orchestrates: QueryClient + Router (shared instances from lib/router, so
+// non-React call sites can navigate too) → RouterProvider → 3-layer Provider
+// stack (Theme → Direction → ThemeCustomization).
 
-import {
-  QueryCache,
-  QueryClient,
-  QueryClientProvider,
-} from '@tanstack/react-query'
-import { RouterProvider, createRouter } from '@tanstack/react-router'
-import { AxiosError } from 'axios'
-import i18next from 'i18next'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { RouterProvider } from '@tanstack/react-router'
 import { StrictMode } from 'react'
 import ReactDOM from 'react-dom/client'
 
-import { ErrorPage } from '@/components/layout/error-page'
-import { NotFoundPage } from '@/components/layout/not-found-page'
-import { RoutePending } from '@/components/layout/route-pending'
 import { DirectionProvider } from '@/context/direction-provider'
 import { ThemeCustomizationProvider } from '@/context/theme-customization-provider'
 import { ThemeProvider } from '@/context/theme-provider'
-import { toast } from '@/lib/toast'
+import { queryClient, router } from '@/lib/router'
 
 // i18next side-effect init (config.ts calls i18n.init)
 import './i18n/config'
-// Generated route tree (TanStack Router plugin overwrites on dev/build)
-import { routeTree } from './routeTree.gen'
 
 // Global styles (Tailwind 4 entry + theme tokens)
 import './styles/index.css'
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: (failureCount, error) => {
-        // Dev: never retry (fail fast for debugging).
-        if (import.meta.env.DEV) return false
-        // Prod: cap at 3 retries.
-        if (failureCount > 3) return false
-        // Never retry auth errors (401/403) — they won't recover.
-        return !(
-          error instanceof AxiosError &&
-          [401, 403].includes(error.response?.status ?? 0)
-        )
-      },
-      // Keep focused tabs from silently re-running heavy pages.
-      refetchOnWindowFocus: false,
-      staleTime: 10 * 1000, // 10s
-    },
-  },
-  queryCache: new QueryCache({
-    onError: (error) => {
-      if (error instanceof AxiosError && error.response?.status === 500) {
-        toast.error(i18next.t('errors.internalServerError'))
-      }
-    },
-  }),
-})
-
-const router = createRouter({
-  routeTree,
-  context: { queryClient },
-  defaultPreload: 'intent',
-  defaultNotFoundComponent: NotFoundPage,
-  defaultErrorComponent: ErrorPage,
-  // The window never scrolls — the app is a single pane and the scroll
-  // container is #content (AuthenticatedLayout's SidebarInset). Reset it to
-  // top on navigation so a new route never inherits the previous page's
-  // offset.
-  scrollRestoration: true,
-  scrollToTopSelectors: ['#content'],
-  // Leaf routes are code-split (rsbuild.config.ts `autoCodeSplitting`), so a
-  // cold navigation suspends until the chunk + loader resolve. Without a
-  // pending component the router renders `null` in that window — a black flash
-  // in dark mode. RoutePending keeps the content shell visible instead.
-  // `pendingMs` debounces the fallback (fast loads never show it) and
-  // `pendingMinMs` stops the skeleton itself from flickering on near-misses.
-  defaultPendingComponent: RoutePending,
-  defaultPendingMs: 200,
-  defaultPendingMinMs: 300,
-})
-
-// Register the router instance for type safety.
-declare module '@tanstack/react-router' {
-  interface Register {
-    router: typeof router
-  }
-  interface StaticDataRouteOption {
-    title?: string
-  }
-}
 
 const rootElement = document.querySelector<HTMLElement>('#root')
 if (!rootElement) {


### PR DESCRIPTION
## 改动摘要

Part of #887（审计条目 A2 + A3 部分）。首次接入主路径（导入）在完成后是死胡同：向导 done 步只有统计 + 关闭，且后端导入不触发路由重建，用户不知道模型不可路由；密钥创建后不自动进入"接入"界面；两个引导 toast 用 `window.location.assign` 硬跳转（违反 AGENTS.md 5.8）。本 PR 闭合三处断点。

## 类型

- [x] fix（bug 修复）

## 改动明细

- **导入向导 done 步**：主 CTA「重建路由」复用共享 `useRebuildRoutes` mutation（含 queued/complete toast），成功后关闭向导；次 CTA「添加账号」SPA 导航 /accounts；新增说明文案（导入的站点需重建路由后模型才可路由），en + zh-CN
- **密钥创建自动接入**：创建成功后把 `POST /api/downstream-keys` 响应里的 `item`（id/name/keyMasked）交给 KeysSection，自动打开 CredentialExportDialog（与行上"接入"按钮同一界面，导出 payload 由对话框自取）；响应无 row 时不伪造、保持仅 toast
- **引导 toast SPA 化**：account-created / route-completion toast 改用 router 导航（目标不变：/token-routes?accountId&siteId、/settings/downstream）；router + QueryClient 实例从 main.tsx 移入 lib/router 供非 React 调用点使用，toast 侧懒加载避免 routeTree.gen 循环依赖（oxlint import/no-cycle）
- `vitest.setup.ts`：Node 25 实验性 localStorage 死 stub 兜底（与 #887 批次内另两个 PR 的同名修复重叠，后合入者按任一侧解决即可）

## 测试验证

- [x] `cd web && bun run typecheck` 通过
- [x] `cd web && bun run lint` 0 error
- [x] `cd web && bun run test` 全绿（662 例）
- [x] `cd web && bun run knip` / `bun run build` / `bun run format:check` 通过

新增测试：import-wizard done 步 +4、keys onCreated +2、toast SPA 导航 +4。

## 自查清单

- [x] 无密钥/内部路径泄漏
- [x] 用户可见文案已走 i18n
- [x] 行为变更已补充/更新测试
- [ ] CHANGELOG/docs 待整批合入后统一更新

> 合并方式：Squash merge。