### PR TITLE
fix(web): close drilldown dead-ends (route edit param, health/tester row links, empty-state CTAs)

### DIFF
--- a/web/src/features/channels/components/channels-page.tsx
+++ b/web/src/features/channels/components/channels-page.tsx
@@ -189,9 +189,12 @@ export function ChannelsPage() {
         onOpenChange={setDetailOpen}
         onEdit={(channel) => {
           setDetailOpen(false)
+          // One-shot `edit` deep link: the routes page opens the edit
+          // dialog for this route (a `routeId` link would only open the
+          // read-only detail sheet).
           void navigate({
             to: '/token-routes',
-            search: { routeId: channel.routeId },
+            search: { edit: channel.routeId },
           })
         }}
       />

--- a/web/src/features/checkin/components/__tests__/checkin-page-empty.test.tsx
+++ b/web/src/features/checkin/components/__tests__/checkin-page-empty.test.tsx
@@ -1,0 +1,148 @@
+// Behavior tests for the checkin page empty-state CTA: with accounts
+// present the CTA reuses the header's manual check-in flow (same dialog,
+// same mutation); without accounts there is nothing to check in, so the
+// CTA links to the accounts page instead of rendering a disabled button.
+
+import '@testing-library/jest-dom/vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { CheckinPage } from '../checkin-page'
+
+const testState = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  accounts: [] as Array<{ id: number; username: string }>,
+  manualDialogOpen: false,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => testState.navigate,
+}))
+
+vi.mock('@/components/data-table', () => ({
+  // Render only the empty-state action slot (testid-scoped) so the test
+  // can assert the CTA without colliding with the page header's own
+  // "Manual check-in" button.
+  DataTablePage: (props: { emptyAction?: ReactNode }) => (
+    <div data-testid='empty-action-slot'>{props.emptyAction}</div>
+  ),
+  useDataTable: () => ({ table: {} }),
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    sorting: [],
+    onSortingChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    filters: {
+      status: '',
+      reason: '',
+      site: '',
+      accountId: '',
+      from: '',
+      to: '',
+    },
+    updateUrlState: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/common/query-error-banner', () => ({
+  QueryErrorBanner: () => null,
+}))
+
+vi.mock('@/features/accounts', () => ({
+  useAccounts: () => ({ data: { accounts: testState.accounts } }),
+}))
+
+vi.mock('@/features/sites/api', () => ({
+  useSites: () => ({ data: [] }),
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}))
+
+vi.mock('../../api', () => ({
+  useCheckinLogs: () => ({
+    data: { items: [], total: 0 },
+    isLoading: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useManualCheckin: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCheckinAccount: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+vi.mock('../checkin-columns', () => ({
+  useCheckinColumns: () => [],
+}))
+
+vi.mock('../checkin-detail-sheet', () => ({
+  CheckinDetailSheet: () => null,
+}))
+
+vi.mock('../manual-checkin-dialog', () => ({
+  ManualCheckinDialog: (props: { open: boolean }) => {
+    testState.manualDialogOpen = props.open
+    return null
+  },
+}))
+
+beforeEach(() => {
+  testState.navigate.mockReset()
+  testState.accounts = []
+  testState.manualDialogOpen = false
+})
+
+afterEach(() => cleanup())
+
+describe('CheckinPage empty state', () => {
+  it('offers the manual check-in flow when accounts exist', () => {
+    testState.accounts = [{ id: 1, username: 'acc-1' }]
+
+    render(<CheckinPage />)
+
+    // Scope to the empty-state slot: the page header renders its own
+    // "Manual check-in" button as well.
+    const emptySlot = screen.getByTestId('empty-action-slot')
+    const cta = within(emptySlot).getByRole('button', {
+      name: /Manual check-in/,
+    })
+    expect(cta).toBeInTheDocument()
+    expect(testState.manualDialogOpen).toBe(false)
+
+    fireEvent.click(cta)
+    expect(testState.manualDialogOpen).toBe(true)
+    expect(testState.navigate).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a manage-accounts CTA when no accounts exist', () => {
+    testState.accounts = []
+
+    render(<CheckinPage />)
+
+    const emptySlot = screen.getByTestId('empty-action-slot')
+    expect(
+      within(emptySlot).queryByRole('button', { name: /Manual check-in/ })
+    ).not.toBeInTheDocument()
+
+    const cta = within(emptySlot).getByRole('button', {
+      name: /Manage accounts/,
+    })
+    fireEvent.click(cta)
+    expect(testState.navigate).toHaveBeenCalledTimes(1)
+    expect(testState.navigate).toHaveBeenCalledWith({ to: '/accounts' })
+  })
+})

--- a/web/src/features/checkin/components/checkin-page.tsx
+++ b/web/src/features/checkin/components/checkin-page.tsx
@@ -13,8 +13,9 @@
 // local `useState` mirror + `useEffect` write-back that can feed back into an
 // infinite render loop.
 
+import { useNavigate } from '@tanstack/react-router'
 import type { ColumnFiltersState } from '@tanstack/react-table'
-import { CalendarRange, Loader2, RotateCw, Zap } from 'lucide-react'
+import { CalendarRange, Loader2, RotateCw, Users, Zap } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -181,6 +182,7 @@ function checkinGlobalFilterFn(
 
 export function CheckinPage() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const {
     globalFilter,
     pagination,
@@ -492,6 +494,26 @@ export function CheckinPage() {
         isFetching={isFetching}
         emptyTitle={t('checkin.page.emptyTitle')}
         emptyDescription={t('checkin.page.emptyDescription')}
+        emptyAction={
+          // With accounts present the CTA reuses the header's manual
+          // check-in flow (same dialog, same mutation) to generate logs;
+          // without accounts there is nothing to check in, so the exit
+          // points to the accounts page instead of a disabled button.
+          accountOptions.length > 0 ? (
+            <Button onClick={() => setManualOpen(true)}>
+              <Zap className='mr-1 size-4' />
+              {t('checkin.page.manualCheckin')}
+            </Button>
+          ) : (
+            <Button
+              variant='outline'
+              onClick={() => void navigate({ to: '/accounts' })}
+            >
+              <Users className='mr-1 size-4' />
+              {t('checkin.page.manageAccounts')}
+            </Button>
+          )
+        }
         skeletonKeyPrefix='checkin-skeleton'
         toolbarProps={{
           searchPlaceholder: t('checkin.page.searchPlaceholder'),

--- a/web/src/features/model-tester/components/batch-results.test.tsx
+++ b/web/src/features/model-tester/components/batch-results.test.tsx
@@ -1,11 +1,36 @@
 import '@testing-library/jest-dom/vitest'
 import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import '@/i18n/config'
 import type { ChannelRow } from '@/features/channels'
 
 import { BatchResults } from './batch-results'
+
+// The comparison table runs outside a mounted router in this unit test, so
+// render `Link` as a plain anchor that serializes `to` + `search` — enough
+// to assert the channel deep-link targets.
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    to,
+    search,
+  }: {
+    children?: ReactNode
+    to: string
+    search?: Record<string, number | string | undefined>
+  }) => {
+    const query = search
+      ? new URLSearchParams(
+          Object.entries(search)
+            .filter(([, value]) => value !== undefined)
+            .map(([key, value]) => [key, String(value)])
+        ).toString()
+      : ''
+    return <a href={query ? `${to}?${query}` : to}>{children}</a>
+  },
+}))
 
 const channels: ChannelRow[] = [
   {
@@ -48,6 +73,11 @@ describe('BatchResults', () => {
     expect(screen.getByText('Primary channel')).toBeInTheDocument()
     expect(screen.getByText('Primary site')).toBeInTheDocument()
     expect(screen.getByText('upstream unavailable')).toBeInTheDocument()
+    // The failed row's channel identity deep-links into the channels page
+    // detail sheet instead of ending as plain text.
+    expect(
+      screen.getByRole('link', { name: 'Primary channel' })
+    ).toHaveAttribute('href', '/channels?channelId=1')
   })
 
   it('announces a pending comparison before rows settle', () => {

--- a/web/src/features/model-tester/components/batch-results.tsx
+++ b/web/src/features/model-tester/components/batch-results.tsx
@@ -5,6 +5,7 @@
 // parent (successes by ascending latency, then failures in input order); the
 // summary line reports "N succeeded / M failed".
 
+import { Link } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 
 import type { ChannelRow } from '@/features/channels'
@@ -89,7 +90,17 @@ export function BatchResults({
                 return (
                   <tr key={result.channelId} className='border-t'>
                     <td className='px-3 py-2'>
-                      {channel?.name ?? result.channelId}
+                      {/* Every settled result carries its channelId, so the
+                          channel identity deep-links into the channels page
+                          detail sheet (one-shot `channelId` param) — failed
+                          rows are no longer a dead end. */}
+                      <Link
+                        to='/channels'
+                        search={{ channelId: result.channelId }}
+                        className='text-primary hover:underline'
+                      >
+                        {channel?.name ?? result.channelId}
+                      </Link>
                     </td>
                     <td className='text-muted-foreground px-3 py-2'>
                       {channel?.site.name ?? '—'}

--- a/web/src/features/models/components/__tests__/models-page-empty.test.tsx
+++ b/web/src/features/models/components/__tests__/models-page-empty.test.tsx
@@ -1,0 +1,89 @@
+// Behavior test for the models page empty-state CTA: the empty copy says
+// models appear once accounts are connected, so the empty state must offer
+// the exit to the accounts page instead of a dead end.
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { ModelsPage } from '../models-page'
+
+const testState = vi.hoisted(() => ({
+  navigate: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => testState.navigate,
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+vi.mock('@/components/data-table', () => ({
+  // Render only the empty-state action slot so the test can assert the CTA.
+  DataTablePage: (props: { emptyAction?: ReactNode }) => (
+    <div>{props.emptyAction}</div>
+  ),
+  encodeSorting: () => '',
+  useDataTable: () => ({ table: {} }),
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    sorting: [],
+    onSortingChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    ensurePageInRange: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/common/query-error-banner', () => ({
+  QueryErrorBanner: () => null,
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: { getModelsMarketplace: vi.fn() },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}))
+
+vi.mock('../../api', () => ({
+  useModels: () => ({ data: [], isLoading: false, isFetching: false }),
+}))
+
+vi.mock('../model-detail-sheet', () => ({
+  ModelDetailSheet: () => null,
+}))
+
+vi.mock('../models-columns', () => ({
+  useModelsColumns: () => [],
+  buildBrandFilterOptions: () => [],
+  buildCapabilityFilterOptions: () => [],
+}))
+
+beforeEach(() => {
+  testState.navigate.mockReset()
+})
+
+afterEach(() => cleanup())
+
+describe('ModelsPage empty state', () => {
+  it('renders a manage-accounts CTA that navigates to /accounts', () => {
+    render(<ModelsPage />)
+
+    const cta = screen.getByRole('button', { name: /Manage accounts/ })
+    expect(cta).toBeInTheDocument()
+
+    fireEvent.click(cta)
+    expect(testState.navigate).toHaveBeenCalledTimes(1)
+    expect(testState.navigate).toHaveBeenCalledWith({ to: '/accounts' })
+  })
+})

--- a/web/src/features/models/components/models-page.tsx
+++ b/web/src/features/models/components/models-page.tsx
@@ -12,7 +12,7 @@
 import { useMutation } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import type { ColumnFiltersState } from '@tanstack/react-table'
-import { RefreshCw as RefreshCwIcon } from 'lucide-react'
+import { RefreshCw as RefreshCwIcon, Users as UsersIcon } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -238,6 +238,15 @@ export function ModelsPage() {
         isFetching={modelsQuery.isFetching}
         emptyTitle={t('models.empty.title')}
         emptyDescription={t('models.empty.description')}
+        emptyAction={
+          <Button
+            variant='outline'
+            onClick={() => void navigate({ to: '/accounts' })}
+          >
+            <UsersIcon className='mr-1 size-4' />
+            {t('models.empty.manageAccounts')}
+          </Button>
+        }
         skeletonKeyPrefix='model-skeleton'
         toolbarProps={{
           searchPlaceholder: t('models.toolbar.searchPlaceholder'),

--- a/web/src/features/observability/sections/health/health-section.tsx
+++ b/web/src/features/observability/sections/health/health-section.tsx
@@ -2,6 +2,7 @@
 // routing breaker/cooldown aggregation. Reads the read-only
 // /api/monitor/health projection; never mutates routing state.
 
+import { Link } from '@tanstack/react-router'
 import { AlertTriangle, CheckCircle2, Server, ShieldCheck } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -253,7 +254,18 @@ function renderBreakersBody(
       <TableBody>
         {breakers.map((breaker) => (
           <TableRow key={`${breaker.siteId}:${breaker.model}`}>
-            <TableCell className='tabular-nums'>{breaker.siteId}</TableCell>
+            <TableCell className='tabular-nums'>
+              {/* The breaker projection carries no site name, so the cell
+                  keeps the raw id but deep-links into the sites page edit
+                  dialog (one-shot `edit` param). */}
+              <Link
+                to='/sites'
+                search={{ edit: breaker.siteId }}
+                className='text-primary hover:underline'
+              >
+                {breaker.siteId}
+              </Link>
+            </TableCell>
             <TableCell className='truncate'>{breaker.model || '—'}</TableCell>
             <TableCell className='text-right tabular-nums'>
               {breaker.breakerLevel}
@@ -338,7 +350,13 @@ function renderCoolingTable(channels: CooldownChannel[], t: Translate) {
               {channel.siteName || channel.siteId}
             </TableCell>
             <TableCell className='text-right tabular-nums'>
-              {channel.channelId}
+              <Link
+                to='/channels'
+                search={{ channelId: channel.channelId }}
+                className='text-primary hover:underline'
+              >
+                {channel.channelId}
+              </Link>
             </TableCell>
             <TableCell className='text-right tabular-nums'>
               {channel.failCount}

--- a/web/src/features/token-routes/__tests__/routes-page-drilldown.test.tsx
+++ b/web/src/features/token-routes/__tests__/routes-page-drilldown.test.tsx
@@ -1,7 +1,11 @@
-// Behavior tests for the token-routes one-shot drilldown (proxy-log detail
-// -> `/token-routes?routeId=N`): the page opens the route detail sheet for
-// the referenced route and strips the param, without disturbing the
-// persistent accountId/siteId chain context. A stale id strips silently.
+// Behavior tests for the token-routes one-shot drilldowns:
+// - proxy-log detail -> `/token-routes?routeId=N`: the page opens the route
+//   detail sheet for the referenced route and strips the param, without
+//   disturbing the persistent accountId/siteId chain context.
+// - channel detail sheet -> `/token-routes?edit=N`: the page opens the edit
+//   dialog (same state as the row edit action) for the referenced route and
+//   strips the param.
+// A stale id strips silently in both flows.
 
 import '@testing-library/jest-dom/vitest'
 import { cleanup, render, waitFor } from '@testing-library/react'
@@ -17,10 +21,16 @@ const testState = vi.hoisted(() => ({
   routeIdParam: '',
   routerSearch: {} as Record<string, unknown>,
   routes: [] as RouteSummaryRow[],
+  routesLoading: false,
   navigate: vi.fn(),
   detailSheetProps: null as {
     route: RouteSummaryRow | null
     open: boolean
+  } | null,
+  formDialogProps: null as {
+    route: RouteSummaryRow | null
+    open: boolean
+    mode: 'create' | 'edit'
   } | null,
 }))
 
@@ -64,7 +74,7 @@ vi.mock('@/features/sites/api', () => ({
 vi.mock('../api', () => ({
   useRoutes: () => ({
     data: testState.routes,
-    isLoading: false,
+    isLoading: testState.routesLoading,
     isFetching: false,
     error: null,
   }),
@@ -89,7 +99,14 @@ vi.mock('../components/route-detail-sheet', () => ({
 }))
 
 vi.mock('../components/route-form-dialog', () => ({
-  RouteFormDialog: () => null,
+  RouteFormDialog: (props: {
+    route: RouteSummaryRow | null
+    open: boolean
+    mode: 'create' | 'edit'
+  }) => {
+    testState.formDialogProps = props
+    return null
+  },
 }))
 
 vi.mock('../components/routes-columns', () => ({
@@ -109,8 +126,10 @@ beforeEach(() => {
   testState.routeIdParam = ''
   testState.routerSearch = {}
   testState.routes = []
+  testState.routesLoading = false
   testState.navigate.mockReset()
   testState.detailSheetProps = null
+  testState.formDialogProps = null
 })
 
 afterEach(() => cleanup())
@@ -163,5 +182,103 @@ describe('RoutesPage drilldown', () => {
     })
     expect(testState.navigate).not.toHaveBeenCalled()
     expect(testState.detailSheetProps?.open).toBe(false)
+  })
+})
+
+describe('RoutesPage edit drilldown', () => {
+  it('opens the edit dialog for the referenced route and strips the param', async () => {
+    testState.routerSearch = { edit: 5, accountId: 7 }
+    testState.routes = [makeRoute(5), makeRoute(6)]
+
+    render(<RoutesPage />)
+
+    await waitFor(() => {
+      expect(testState.formDialogProps?.open).toBe(true)
+    })
+    expect(testState.formDialogProps?.mode).toBe('edit')
+    expect(testState.formDialogProps?.route?.id).toBe(5)
+    // The detail sheet (the old `routeId` target) must stay closed — the
+    // edit deep link opens the editor, not the read-only panel.
+    expect(testState.detailSheetProps?.open).toBe(false)
+    // Strip is a replace-navigation that keeps the chain context intact.
+    expect(testState.navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/token-routes',
+        replace: true,
+        search: expect.objectContaining({
+          edit: undefined,
+          accountId: 7,
+        }),
+      })
+    )
+  })
+
+  it('strips a stale edit id without opening the dialog', async () => {
+    testState.routerSearch = { edit: 99 }
+    testState.routes = [makeRoute(5)]
+
+    render(<RoutesPage />)
+
+    await waitFor(() => {
+      expect(testState.navigate).toHaveBeenCalled()
+    })
+    expect(testState.formDialogProps?.open).toBe(false)
+    expect(testState.formDialogProps?.route).toBeNull()
+    expect(testState.navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/token-routes',
+        replace: true,
+        search: expect.objectContaining({ edit: undefined }),
+      })
+    )
+  })
+
+  it('waits for the list to resolve before consuming the edit param', async () => {
+    testState.routerSearch = { edit: 5 }
+    testState.routes = []
+    testState.routesLoading = true
+
+    const { rerender } = render(<RoutesPage />)
+
+    // While loading, the param must NOT be consumed and no strip navigate
+    // may happen yet.
+    expect(testState.formDialogProps?.open).toBe(false)
+    expect(testState.navigate).not.toHaveBeenCalled()
+
+    // Once the list resolves with the referenced route, the dialog opens
+    // and the param is stripped.
+    testState.routesLoading = false
+    testState.routes = [makeRoute(5)]
+    rerender(<RoutesPage />)
+
+    await waitFor(() => {
+      expect(testState.formDialogProps?.open).toBe(true)
+    })
+    expect(testState.formDialogProps?.route?.id).toBe(5)
+    expect(testState.navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/token-routes',
+        replace: true,
+        search: expect.objectContaining({ edit: undefined }),
+      })
+    )
+  })
+
+  it('opens the dialog exactly once across remount-like re-renders', async () => {
+    testState.routerSearch = { edit: 5 }
+    testState.routes = [makeRoute(5)]
+
+    const { rerender } = render(<RoutesPage />)
+
+    await waitFor(() => {
+      expect(testState.formDialogProps?.open).toBe(true)
+    })
+
+    // After consumption the page strips `edit`; a re-render with the
+    // stripped search must not navigate again (consumed-ref guard).
+    testState.routerSearch = {}
+    rerender(<RoutesPage />)
+
+    expect(testState.navigate).toHaveBeenCalledTimes(1)
   })
 })

--- a/web/src/features/token-routes/__tests__/routes-schema.test.ts
+++ b/web/src/features/token-routes/__tests__/routes-schema.test.ts
@@ -49,6 +49,20 @@ describe('routesSearchSchema', () => {
     expect(result.pageSize).toBe(20)
     expect(result.q).toBeUndefined()
   })
+
+  it('parses the one-shot edit deep-link param like routeId', () => {
+    // String form arrives from raw URL parsing, number form from the
+    // router's JSON parsing — both must land on the same positive int.
+    expect(routesSearchSchema.parse({ edit: '12' }).edit).toBe(12)
+    expect(routesSearchSchema.parse({ edit: 12 }).edit).toBe(12)
+  })
+
+  it('drops a stale or malformed edit param instead of throwing', () => {
+    expect(routesSearchSchema.parse({ edit: 'bogus' }).edit).toBeUndefined()
+    expect(routesSearchSchema.parse({ edit: 0 }).edit).toBeUndefined()
+    expect(routesSearchSchema.parse({ edit: -3 }).edit).toBeUndefined()
+    expect(routesSearchSchema.parse({}).edit).toBeUndefined()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/web/src/features/token-routes/components/routes-page.tsx
+++ b/web/src/features/token-routes/components/routes-page.tsx
@@ -118,6 +118,12 @@ function buildTokenRoutesHref(
     params.set('accountId', merged.filters.accountId)
   }
   if (merged.filters.siteId) params.set('siteId', merged.filters.siteId)
+  // Preserve the one-shot `edit` deep-link param across table-state
+  // navigations (page-clamp / sort / filter) until the page's consumption
+  // effect strips it — mirrors the sites page's buildHref guard for its
+  // guided `create`/`edit` params.
+  const guidedEdit = new URLSearchParams(window.location.search).get('edit')
+  if (guidedEdit) params.set('edit', guidedEdit)
   const queryString = params.toString()
   return queryString ? `/token-routes?${queryString}` : '/token-routes'
 }
@@ -251,6 +257,31 @@ export function RoutesPage() {
     setEditRoute(route)
     setFormOpen(true)
   }, [])
+
+  // One-shot edit drilldown (channel detail sheet -> `?edit=N`): wait for
+  // the list, open the edit dialog for the referenced route (the same state
+  // the row edit action uses), then strip the param so a refetch or remount
+  // never reopens it. A stale or unknown id is stripped without opening
+  // anything — mirrors the sites page's `edit` consumption and this page's
+  // `routeId` drilldown, including the strict-mode re-entry guard.
+  const editDrilldownConsumed = useRef(false)
+  useEffect(() => {
+    if (editDrilldownConsumed.current || routerSearch.edit === undefined) {
+      return
+    }
+    if (isLoading) return
+
+    const target = routes.find((route) => route.id === routerSearch.edit)
+    editDrilldownConsumed.current = true
+    if (target) {
+      openEdit(target)
+    }
+    navigate({
+      to: '/token-routes',
+      search: { ...routerSearch, edit: undefined },
+      replace: true,
+    })
+  }, [routerSearch, isLoading, routes, navigate, openEdit])
 
   // Memoized so the column defs keep a stable identity across renders.
   const rowActions = useMemo<RouteRowActions>(

--- a/web/src/features/token-routes/lib/routes-schema.ts
+++ b/web/src/features/token-routes/lib/routes-schema.ts
@@ -225,6 +225,12 @@ export const routesSearchSchema = z.object({
   // One-shot drilldown from the proxy-log detail sheet: open the detail
   // sheet for this route, then the page strips the param.
   routeId: z.coerce.number().int().positive().optional().catch(undefined),
+  // One-shot drilldown from the channel detail sheet (`?edit=<id>`): open
+  // the edit dialog for this route once, then the page strips the param.
+  // Mirrors the sites page's `edit` deep link: the id is resolved against
+  // the loaded list snapshot before opening, so a stale/unknown id is
+  // stripped silently instead of opening a blank dialog.
+  edit: z.coerce.number().int().positive().optional().catch(undefined),
   page: z.coerce.number().int().positive().catch(1).default(1),
   pageSize: z.coerce.number().int().positive().catch(20).default(20),
 })

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -125,7 +125,8 @@
       },
       "empty": {
         "title": "No models",
-        "description": "Models will appear here once accounts are connected."
+        "description": "Models will appear here once accounts are connected.",
+        "manageAccounts": "Manage accounts"
       },
       "toolbar": {
         "searchPlaceholder": "Search models…",
@@ -1813,6 +1814,7 @@
         "title": "Check-in records",
         "description": "View check-in execution logs and failure reasons; supports manual single-account or all-account check-in.",
         "manualCheckin": "Manual check-in",
+        "manageAccounts": "Manage accounts",
         "runAll": "Run all check-ins",
         "loadError": "Failed to load check-in records: {{message}}",
         "startTime": "Start time",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -125,7 +125,8 @@
       },
       "empty": {
         "title": "暂无模型",
-        "description": "连接账号后，模型会显示在这里。"
+        "description": "连接账号后，模型会显示在这里。",
+        "manageAccounts": "管理账号"
       },
       "toolbar": {
         "searchPlaceholder": "搜索模型…",
@@ -1813,6 +1814,7 @@
         "title": "签到记录",
         "description": "查看签到执行日志与失败原因，支持手动触发单账号或全部签到。",
         "manualCheckin": "手动签到",
+        "manageAccounts": "管理账号",
         "runAll": "运行所有签到",
         "loadError": "加载签到记录失败：{{message}}",
         "startTime": "开始时间",


### PR DESCRIPTION
## 改动摘要

Part of #887（审计条目 A3 部分 + A4）。四处"看得见却到不了"的下钻断点：channel 详情"编辑路由"实际打开只读详情、observability 健康表与 model-tester 对比结果无行级出口、models/checkin 空态承诺动作却没有按钮。深链基建（sites edit / channels channelId 一次性消费）均已存在，本 PR 补齐缺失的链接与参数。

## 类型

- [x] fix（bug 修复）

## 改动明细

- **routes 页新增一次性 `edit` 参数**：routesSearchSchema + routes-page 消费（对照快照解析后打开编辑对话框——与行编辑同一状态，replace 清除参数，stale id 静默清除，consumed-ref 防 strict-mode 重入）；channel-detail-sheet"编辑路由"改跳 `?edit=N`（此前跳 `?routeId=N` 被消费为只读详情，名不副实）。镜像 sites 页 edit 深链模式
- **observability health 表补出口**：熔断器行 siteId → `/sites?edit=N`，冷却行 channelId → `/channels?channelId=N`（两个目标页的一次性消费均已存在）
- **model-tester 对比结果行级链接**：BatchProbeResult 恒带 channelId，每行通道标识 → `/channels?channelId=N`
- **空态 CTA**：models 页 → /accounts；checkin 页有账号时复用页头手动签到流程、无账号时 → /accounts（不再是禁用按钮）
- `vitest.setup.ts`：Node 25 localStorage 死 stub 兜底（基线提交在本环境即失败，已验证为既有问题；与 #887 批次内其他 PR 同名修复重叠，后合入者按任一侧解决）

## 测试验证

- [x] `cd web && bun run typecheck` 通过
- [x] `cd web && bun run lint` 0 error
- [x] `cd web && bun run test` 全绿
- [x] `cd web && bun run knip` / `bun run build` / `bun run format:check` 通过

新增测试：routes-page edit 深链消费（open/stale/wait/remount）、routesSearchSchema edit 解析、models/checkin 空态 CTA、batch-results 通道深链。i18n：models.empty.manageAccounts、checkin.page.manageAccounts（en + zh-CN）。

## 自查清单

- [x] 无密钥/内部路径泄漏
- [x] 用户可见文案已走 i18n
- [x] 行为变更已补充/更新测试
- [ ] CHANGELOG/docs 待整批合入后统一更新

> 合并方式：Squash merge。