### PR TITLE
fix(sites): invalidate accounts snapshot cache on site create

### DIFF
--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -328,6 +328,51 @@ func TestAccounts_UpdateClearsSnapshotCache(t *testing.T) {
 	}
 }
 
+// A freshly created site must invalidate the accounts snapshot cache so the
+// accounts page reflects it immediately (previously only update/delete
+// invalidated it, leaving "Add account" disabled after creating the first site).
+func TestAccounts_CreateSiteClearsSnapshotCache(t *testing.T) {
+	_, r, _ := setupAccountsTest(t)
+
+	first := doGet(t, r, "/api/accounts")
+	if first.Code != http.StatusOK {
+		t.Fatalf("first list accounts: %d %s", first.Code, first.Body.String())
+	}
+	second := doGet(t, r, "/api/accounts")
+	if second.Header().Get("x-accounts-snapshot-cache") != "hit" {
+		t.Fatalf("second list should hit cache, header=%q", second.Header().Get("x-accounts-snapshot-cache"))
+	}
+
+	create := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "cache-invalidation-site",
+		"url":      "http://cache-invalidation.example.com",
+		"platform": "new-api",
+	})
+	if create.Code != http.StatusOK {
+		t.Fatalf("create site: %d %s", create.Code, create.Body.String())
+	}
+
+	after := doGet(t, r, "/api/accounts")
+	if after.Code != http.StatusOK {
+		t.Fatalf("after list accounts: %d %s", after.Code, after.Body.String())
+	}
+	if after.Header().Get("x-accounts-snapshot-cache") == "hit" {
+		t.Fatal("site create should have invalidated the accounts snapshot cache")
+	}
+	var result map[string]any
+	json.Unmarshal(after.Body.Bytes(), &result)
+	sites, _ := result["sites"].([]any)
+	found := false
+	for _, s := range sites {
+		if m, ok := s.(map[string]any); ok && m["name"] == "cache-invalidation-site" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected newly created site in accounts snapshot, got %d sites", len(sites))
+	}
+}
+
 // ---- Create Account ----
 
 func TestAccounts_UpdateRemark(t *testing.T) {

--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -258,6 +258,10 @@ func (h *sitesHandler) createSite(w http.ResponseWriter, r *http.Request) {
 	if initializationPresetID != "" {
 		result["initializationPresetId"] = initializationPresetID
 	}
+	// Match update/delete: clear the process-local accounts snapshot cache (via
+	// the registered site-cache invalidator) so a freshly created site shows up
+	// on the accounts page immediately instead of waiting out the snapshot TTL.
+	service.InvalidateSiteCaches()
 	routing.InvalidateCache()
 	writeJSON(w, http.StatusOK, result)
 }

--- a/web/scripts/acceptance-e2e.mjs
+++ b/web/scripts/acceptance-e2e.mjs
@@ -6,19 +6,25 @@
 // backend that is itself pointed at a REAL upstream platform (new-api/one-api).
 // It is an operator-gated acceptance gate, NOT part of the blocking PR CI: it
 // needs live credentials and a running upstream, so it runs on demand via
-// `bun run acceptance:e2e` or the workflow_dispatch acceptance workflow.
+// `bun run acceptance:e2e` (see docs/internal/analysis/e2e-acceptance-platform.md).
 //
 // Journey 1 — Site onboarding: open the sites page, add a site by URL, pick the
-//   platform, submit, and assert the site lands in the table. This exercises the
-//   exact path a user takes to connect metapi to a real gateway, including the
-//   real platform detect round-trip against the live upstream.
+//   platform, submit, and assert it lands in the table (fires the real detect
+//   round-trip).
+// Journey 2 — Account login (opt-in via ACCEPT_LOGIN=1): add an account with the
+//   password credential mode against the site from journey 1 and submit; the
+//   backend performs a REAL login against the live upstream and the account must
+//   appear in the table.
 //
 // Configuration (environment variables):
 //   BASE_URL          metapi admin origin      (default http://127.0.0.1:4000)
 //   AUTH_TOKEN        admin Bearer token       (default e2e-admin-token)
 //   UPSTREAM_URL      real upstream platform   (default http://127.0.0.1:3000)
+//   UPSTREAM_USERNAME upstream login user      (default metapi-e2e)
+//   UPSTREAM_PASSWORD upstream login password  (required for journey 2)
 //   PLATFORM          platform to select       (default new-api)
 //   ACCEPT_SITE_NAME  site name to create      (default acceptance-real-site)
+//   ACCEPT_LOGIN      set to "1" to also run journey 2
 //
 // Requires a Chromium install (`bunx playwright install chromium`).
 
@@ -52,7 +58,6 @@ function collectPageFailures(page, label) {
     const text = message.text()
     // A 4xx "Failed to load resource" is a handled HTTP outcome (e.g. the
     // idempotent site-create race returns 409), not an application defect.
-    // Real failures are 5xx resources and app-thrown console errors.
     if (/Failed to load resource.*\b4\d\d\b/.test(text)) return
     fail(`${label}: console.error — ${text}`)
   })
@@ -148,8 +153,7 @@ async function journeySiteOnboarding(context) {
       .first()
       .click()
 
-    // The created site must appear in the sites table. Wait for a row cell
-    // containing the site name.
+    // The created site must appear in the sites table.
     await page
       .getByText(ACCEPT_SITE_NAME, { exact: false })
       .first()
@@ -165,17 +169,6 @@ async function journeySiteOnboarding(context) {
   }
 }
 
-// Journey 2 — Account login via UI: open the accounts page, add an account with
-//   the password credential mode against the site from journey 1, and submit.
-//   The backend performs a REAL login against the live upstream (new-api) and
-//   stores the session; the created account must then appear in the table. This
-//   is the genuine login-system acceptance, end to end through the UI.
-//
-//   Opt-in via ACCEPT_LOGIN=1. It is gated because, when run immediately after
-//   journey 1 creates a FRESH site in the same process, the accounts page header
-//   transiently overlaps the toolbar and intercepts the "Add account" click (a
-//   real UI quirk under freshly-created-site state). Run it against a settled
-//   site (e.g. a second run, or standalone) for a clean pass.
 async function journeyAccountLogin(context) {
   const label = 'journey: account login via UI'
   if (!UPSTREAM_PASSWORD) {
@@ -193,36 +186,36 @@ async function journeyAccountLogin(context) {
       )
     }
   }
-  // Poll until the element is genuinely on top (nothing intercepts the hit-test),
-  // then let Playwright click it. A freshly created upstream site briefly renders
-  // a transient overlay, so a blind click races it; this waits it out instead.
-  const clickWhenClickable = async (locator, timeoutMs = 40_000) => {
+  // Poll the accounts snapshot until it includes the freshly created site,
+  // BEFORE navigating. The "Add account" button is disabled while the snapshot
+  // reports zero sites, and the page pins the first prefetched snapshot; waiting
+  // here ensures the first render already sees the site so the button enables.
+  const waitForSiteInSnapshot = async (timeoutMs = 45_000) => {
     const deadline = Date.now() + timeoutMs
+    const headers = { Authorization: `Bearer ${AUTH_TOKEN}` }
     for (;;) {
-      const onTop = await locator
-        .evaluate((el) => {
-          const rect = el.getBoundingClientRect()
-          const hit = document.elementFromPoint(
-            rect.left + rect.width / 2,
-            rect.top + rect.height / 2
-          )
-          return !!hit && (el === hit || el.contains(hit) || hit.contains(el))
-        })
-        .catch(() => false)
-      if (onTop) return locator.click({ timeout: 10_000 })
+      const resp = await context.request.get(`${BASE_URL}/api/accounts`, {
+        headers,
+      })
+      if (resp.status() === 200) {
+        const data = await resp.json().catch(() => null)
+        const sites = data?.sites ?? []
+        if (sites.some((site) => site?.name === ACCEPT_SITE_NAME)) return
+      }
       if (Date.now() > deadline)
-        throw new Error('element never became click-interceptable')
+        throw new Error('site never appeared in the accounts snapshot')
       await page.waitForTimeout(500)
     }
   }
   try {
+    await act('site in accounts snapshot', () => waitForSiteInSnapshot())
     await act('goto /accounts', () =>
       page.goto(`${BASE_URL}/accounts`, {
         waitUntil: 'networkidle',
         timeout: 30_000,
       })
     )
-    await page.waitForTimeout(1500)
+    await page.waitForTimeout(1000)
 
     const addAccount = page
       .getByRole('button', { name: /Add account/i })
@@ -230,7 +223,7 @@ async function journeyAccountLogin(context) {
     await act('Add account visible', () =>
       addAccount.waitFor({ state: 'visible', timeout: 10_000 })
     )
-    await act('click Add account', () => clickWhenClickable(addAccount))
+    await act('click Add account', () => addAccount.click({ timeout: 10_000 }))
     await page.waitForTimeout(500)
 
     // Switch to the password credential mode. Tabs: Session / API Key / Password.
@@ -314,11 +307,10 @@ try {
   await browser.close()
 }
 
-// Journey 2 (login) is opt-in; see its doc comment for why. When enabled, let
-// the freshly created site's background activity settle first, then run the
-// login journey in its own browser process.
+// Journey 2 (login) is opt-in. Give the freshly created site a brief moment to
+// commit, then run the login journey in its own browser process.
 if (process.env.ACCEPT_LOGIN === '1') {
-  await new Promise((resolve) => setTimeout(resolve, 12_000))
+  await new Promise((resolve) => setTimeout(resolve, 3_000))
 
   const loginBrowser = await chromium.launch({ headless: true })
   try {


### PR DESCRIPTION
## Summary
`createSite` only called `routing.InvalidateCache()`, while `updateSite`/`deleteSite` also call `service.InvalidateSiteCaches()` (which clears the process-local accounts snapshot cache). So after creating the **first site**, `GET /api/accounts` kept serving a stale snapshot with zero sites, leaving the accounts page **"Add account" button disabled** (`sites.length === 0`) until the 30s TTL lapsed and a refetch happened to run. This is a real UX bug for anyone creating their first site.

- `sites.go`: `createSite` now calls `service.InvalidateSiteCaches()` to match update/delete.
- `accounts_test.go`: `TestAccounts_CreateSiteClearsSnapshotCache` regression.
- `acceptance-e2e.mjs`: the account-login journey waits for the site to reach the accounts snapshot before navigating (the page pins its first prefetched snapshot), so the real-login journey runs reliably chained.

## Proven against a real new-api deployment
Acceptance journeys **2/2**: site onboarding + **real upstream account login via the UI**.

## Test plan
- [x] `go test ./handler/admin/ ./service/` green (incl. new regression)
- [x] acceptance:e2e 2/2 against live new-api