### PR TITLE
chore(web): issue #887 hygiene — dead i18n keys, pricing copy i18n, reduced-transparency glass fallback, a11y-checklist truth

### DIFF
--- a/docs/internal/design/a11y-checklist.md
+++ b/docs/internal/design/a11y-checklist.md
@@ -3,7 +3,7 @@
 **Product**: Metapi admin
 **Scope**: accessibility checklist
 **Related source of truth**: `docs/internal/design/DESIGN.md`, `web/src/styles/theme.css`
-**Last updated**: 2026-08-18
+**Last updated**: 2026-08-21
 **Status**: living acceptance checklist; known limitations are documented, not an implicit backlog
 
 This document records keyboard, name, contrast, and responsive expectations. Known limitations are evidence only unless promoted to [`../progress/MASTER.md`](../progress/MASTER.md) or a scoped GitHub issue.
@@ -153,11 +153,11 @@ Breakpoints used by product:
 | Check         | Expected                                                            | Status                   |
 | ------------- | ------------------------------------------------------------------- | ------------------------ |
 | Topbar        | Hamburger + logo + compact tools; search may iconify                | Pass (shell)             |
-| Sidebar       | Hidden; content via `MobileDrawer`                                  | Pass                     |
+| Sidebar       | Hidden; content via mobile drawer                                   | Pass — `components/ui/sidebar.tsx` renders itself as a `Sheet` drawer on mobile |
 | Main padding  | Reduced; no clipped primary CTA                                     | Pass / page debt         |
-| Tables        | Card/list alternative or horizontal scroll inside table region only | Partial (page-dependent) |
-| Batch actions | `MobileBatchBar` / responsive batch bar                             | Partial                  |
-| Filters       | `ResponsiveFilterPanel` → bottom/side sheet                         | Partial                  |
+| Tables        | Card/list alternative or horizontal scroll inside table region only | `MobileCardList` (`data-table/layout/mobile-card-list.tsx`) auto-swaps at ≤640px for every `DataTablePage` consumer; remaining pages debt |
+| Batch actions | Floating selection bar reachable on mobile                          | Pass — shared `data-table/toolbar/bulk-actions.tsx` fixed bottom-center bar (sites / accounts / token-routes); no width-specific variant needed |
+| Filters       | Toolbar filters usable at narrow widths                             | Pass — single `flex-wrap` toolbar row (`data-table/toolbar/toolbar.tsx`: search / faceted filter / view options) wraps instead of moving into a sheet |
 | Touch targets | ≥36–44px for chrome icons                                           | Pass topbar              |
 | Safe areas    | Avoid fixed bars covering primary content                           | Residual on some pages   |
 
@@ -168,7 +168,7 @@ Breakpoints used by product:
 | Layout switch    | Mobile drawer path active at ≤768              | Pass              |
 | Topbar density   | Tools remain usable without overlap            | Pass              |
 | Modals           | Max-width constrained; close control reachable | Pass shared modal |
-| Two-column forms | Stack via `ResponsiveFormGrid` where used      | Partial adoption  |
+| Two-column forms | Stack at narrow widths where used               | Partial adoption — per-form responsive grid classes (`sm:/md:grid-cols-2`, e.g. site form dialog, model-tester form, several settings sections); no shared grid component |
 
 ### 5.3 1280px (desktop)
 
@@ -194,7 +194,7 @@ Breakpoints used by product:
 | Topic                                  | Expectation                                                                                                                     | Status                                                                                                                                                          |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `prefers-reduced-motion: reduce`       | Collapse non-essential transitions/animations                                                                                   | **Pass** — token durations → ~0 in `theme.css`; global hard-cut `animation/transition-duration` in `web/src/styles/index.css`                                   |
-| `prefers-reduced-transparency: reduce` | Glass → solid elevated; strip backdrop blur                                                                                     | **Pass** — glass family + sidebar/topbar tokens solidify; shell/login/toast/overlay blur stripped in `web/src/styles/index.css` + shadcn Base UI glass surfaces |
+| `prefers-reduced-transparency: reduce` | Glass → solid elevated; strip backdrop blur                                                                                     | **Pass** (2026-08-21) — `@media (prefers-reduced-transparency: reduce)` in `web/src/styles/index.css`: the shared glass recipe (topbar + floating bulk-actions bar: `.backdrop-blur-lg` over translucent `bg-background/*`) and the dialog/sheet/alert-dialog scrims (`bg-overlay` + `backdrop-blur-xs`) lose backdrop blur and solidify to opaque `--background`; borders/shadows untouched. Toasts already sit on opaque `--popover`; sidebar and sign-in are flat, so no fallback needed there. |
 | Dialog semantics                       | `role="dialog"` + `aria-modal` for blocking overlays                                                                            | Mobile drawer pass; SearchModal improved; not all legacy overlays                                                                                               |
 | Live regions                           | Toasts/errors announced                                                                                                         | Residual                                                                                                                                                        |
 | Language                               | `t()` for user-visible chrome strings; `aria-label` included in i18n attr list                                                  | Pass pattern                                                                                                                                                    |

--- a/web/src/features/models/components/model-detail-sheet.tsx
+++ b/web/src/features/models/components/model-detail-sheet.tsx
@@ -58,14 +58,19 @@ function GroupPricingRow({
   groupKey: string
   pricing: ModelGroupPricing
 }) {
+  const { t } = useTranslation()
   return (
     <li className='flex flex-wrap items-center gap-2 text-xs'>
       <Badge variant='outline'>{groupKey}</Badge>
       <span className='text-muted-foreground'>
-        in ${formatPrice(pricing.inputPerMillion)}/M
+        {t('models.detail.inputPrice', {
+          price: formatPrice(pricing.inputPerMillion),
+        })}
       </span>
       <span className='text-muted-foreground'>
-        out ${formatPrice(pricing.outputPerMillion)}/M
+        {t('models.detail.outputPrice', {
+          price: formatPrice(pricing.outputPerMillion),
+        })}
       </span>
     </li>
   )

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -12,8 +12,7 @@
         "tokenRequired": "Please enter the admin token",
         "submit": "Sign in",
         "submitting": "Signing in…",
-        "welcomeBack": "Welcome back!",
-        "note": "Only local server access is verified; the token is never sent to a third party."
+        "welcomeBack": "Welcome back!"
       }
     },
     "errors": {
@@ -48,9 +47,7 @@
       "noResultsDescription": "No records match your current filters.",
       "resetFilters": "Reset filters",
       "edit": "Edit",
-      "create": "Create",
       "close": "Close",
-      "no": "No",
       "retry": "Retry",
       "actions": "Actions",
       "status": "Status",
@@ -303,7 +300,6 @@
       "form": {
         "startTitle": "Start authorization",
         "startDescription": "Connect an OAuth account to enable it for routing.",
-        "startSucceeded": "Authorization started.",
         "startFailed": "Failed to start authorization.",
         "provider": "Provider",
         "providerPlaceholder": "Select a provider",
@@ -388,7 +384,6 @@
     "sites": {
       "page": {
         "loadError": "Failed to load sites: {{message}}",
-        "retry": "Retry",
         "title": "Sites",
         "description": "Manage connected sites, their status, and routing weight."
       },
@@ -1579,7 +1574,6 @@
       },
       "verify": {
         "button": "Verify",
-        "pending": "Verifying…",
         "verified": "Verified — {{tokenType}} ({{modelCount}} models)",
         "failed": "Verification failed",
         "siteRequired": "Select a site first",
@@ -1724,7 +1718,6 @@
         "selectRow": "Select row",
         "viewDetails": "View details",
         "clearCooldown": "Clear cooldown",
-        "refreshDecision": "Refresh decision",
         "notGenerated": "Not generated",
         "decisionCachedAt": "Decision cached at {{time}}",
         "modelAndName": "Model / name",
@@ -1750,7 +1743,6 @@
         "decisionRefresh": "Decision refresh",
         "modelMapping": "Model mapping",
         "clearCooldown": "Clear cooldown",
-        "refreshDecision": "Refresh decision",
         "channelTruthList": "Channel allocation and price",
         "channelTruthDescription": "Configured weights, enabled shares, and normalized prices from Price Compare.",
         "channelEmptyReadOnly": "No channels, complete the connection config first then rebuild routes.",
@@ -1790,7 +1782,6 @@
         "flowComplete": "Configuration flow complete.",
         "withRouteId": "Route #{{id}} created. {{suffix}}",
         "withoutRouteId": "Route created. {{suffix}}",
-        "action": "Back to Dashboard",
         "connectAction": "Connect a client"
       },
       "toast": {
@@ -1869,7 +1860,6 @@
         "createdAt": "Check-in time",
         "account": "Account",
         "site": "Site",
-        "status": "Status",
         "failureReason": "Failure reason",
         "message": "Message",
         "reward": "Reward"
@@ -2391,7 +2381,6 @@
         "oauth_unit": "OAuth unit"
       },
       "detail": {
-        "title": "Channel detail",
         "description": "Read-only routing health for a single channel.",
         "sectionOverview": "Overview",
         "sectionHealth": "Routing health",
@@ -2403,9 +2392,6 @@
         "enabled": "Enabled",
         "disabled": "Disabled",
         "routePattern": "Route pattern",
-        "oauthUnit": "OAuth unit",
-        "tokenName": "Token name",
-        "accountName": "Account",
         "priority": "Priority",
         "weight": "Weight",
         "avgLatency": "Average latency",
@@ -2413,9 +2399,7 @@
         "manualOverride": "Manual override",
         "manualOverrideActive": "Active",
         "manualOverrideNone": "None",
-        "modelsList": "Model list",
         "notAvailable": "—",
-        "never": "Never",
         "clearRouteCooldown": "Clear route cooldown",
         "clearRouteCooldownHint": "Resets cooldown and failure counts for every channel on this channel's route.",
         "editRoute": "Edit route",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -137,6 +137,8 @@
         "successRate": "Success rate",
         "capabilities": "Capabilities",
         "pricing": "Pricing",
+        "inputPrice": "in ${{price}}/M",
+        "outputPrice": "out ${{price}}/M",
         "unknownUser": "Unknown user",
         "availableAccounts": "Available accounts",
         "testModel": "Test model",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -137,6 +137,8 @@
         "successRate": "成功率",
         "capabilities": "能力",
         "pricing": "价格",
+        "inputPrice": "输入 ${{price}}/M",
+        "outputPrice": "输出 ${{price}}/M",
         "unknownUser": "未知用户",
         "availableAccounts": "可用账号",
         "testModel": "测试模型",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -12,8 +12,7 @@
         "tokenRequired": "请输入管理员令牌",
         "submit": "登录",
         "submitting": "登录中…",
-        "welcomeBack": "欢迎回来！",
-        "note": "仅校验本地服务访问权限，不会把令牌发送给第三方。"
+        "welcomeBack": "欢迎回来！"
       }
     },
     "errors": {
@@ -48,9 +47,7 @@
       "noResultsDescription": "没有符合当前筛选条件的记录。",
       "resetFilters": "重置筛选",
       "edit": "编辑",
-      "create": "新建",
       "close": "关闭",
-      "no": "否",
       "retry": "重试",
       "actions": "操作",
       "status": "状态",
@@ -303,7 +300,6 @@
       "form": {
         "startTitle": "开始授权",
         "startDescription": "连接一个 OAuth 账号以启用路由。",
-        "startSucceeded": "授权已开始。",
         "startFailed": "开始授权失败。",
         "provider": "提供商",
         "providerPlaceholder": "选择提供商",
@@ -388,7 +384,6 @@
     "sites": {
       "page": {
         "loadError": "加载站点失败：{{message}}",
-        "retry": "重试",
         "title": "站点",
         "description": "管理已连接的站点、状态与路由权重。"
       },
@@ -1579,7 +1574,6 @@
       },
       "verify": {
         "button": "验证",
-        "pending": "验证中…",
         "verified": "验证通过 — {{tokenType}}（{{modelCount}} 个模型）",
         "failed": "验证失败",
         "siteRequired": "请先选择站点",
@@ -1724,7 +1718,6 @@
         "selectRow": "选择此行",
         "viewDetails": "查看详情",
         "clearCooldown": "清除冷却",
-        "refreshDecision": "刷新决策",
         "notGenerated": "未生成",
         "decisionCachedAt": "决策缓存于 {{time}}",
         "modelAndName": "模型 / 名称",
@@ -1750,7 +1743,6 @@
         "decisionRefresh": "决策刷新",
         "modelMapping": "模型映射",
         "clearCooldown": "清除冷却",
-        "refreshDecision": "刷新决策",
         "channelTruthList": "通道分配与价格",
         "channelTruthDescription": "同一行展示配置权重、启用占比，以及来自价格对比的标准化价格。",
         "channelEmptyReadOnly": "暂无通道，先补齐连接配置后再重建路由。",
@@ -1790,7 +1782,6 @@
         "flowComplete": "配置动线已完成。",
         "withRouteId": "路由 #{{id}} 已创建。{{suffix}}",
         "withoutRouteId": "路由已创建。{{suffix}}",
-        "action": "返回 Dashboard",
         "connectAction": "接入客户端"
       },
       "toast": {
@@ -1869,7 +1860,6 @@
         "createdAt": "签到时间",
         "account": "账号",
         "site": "站点",
-        "status": "状态",
         "failureReason": "失败原因",
         "message": "信息",
         "reward": "奖励"
@@ -2391,7 +2381,6 @@
         "oauth_unit": "OAuth 单元"
       },
       "detail": {
-        "title": "通道详情",
         "description": "单个通道的只读路由健康视图。",
         "sectionOverview": "概览",
         "sectionHealth": "路由健康",
@@ -2403,9 +2392,6 @@
         "enabled": "已启用",
         "disabled": "已停用",
         "routePattern": "路由匹配规则",
-        "oauthUnit": "OAuth 单元",
-        "tokenName": "令牌名称",
-        "accountName": "账号",
         "priority": "优先级",
         "weight": "权重",
         "avgLatency": "平均延迟",
@@ -2413,9 +2399,7 @@
         "manualOverride": "手动覆盖",
         "manualOverrideActive": "已启用",
         "manualOverrideNone": "无",
-        "modelsList": "模型列表",
         "notAvailable": "—",
-        "never": "从未",
         "clearRouteCooldown": "清除路由冷却",
         "clearRouteCooldownHint": "重置该通道所属路由下全部通道的冷却与失败计数。",
         "editRoute": "编辑路由",

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -433,3 +433,27 @@
     scroll-behavior: auto !important;
   }
 }
+
+/*
+ * Reduced-transparency fallback for the glass material (DESIGN.md §2.6).
+ * The only surfaces that actually layer backdrop blur over a translucent
+ * fill are the shared glass recipe (`bg-background/95
+ * supports-[backdrop-filter]:bg-background/60 backdrop-blur-lg` — topbar in
+ * layout/app-header and the floating bulk-actions bar) and the
+ * dialog/sheet/alert-dialog scrims (`bg-overlay` + `backdrop-blur-xs`).
+ * Toasts already sit on opaque --popover, and the sidebar / sign-in page are
+ * flat, so nothing else needs a fallback. Under the preference the blur is
+ * stripped and the see-through fill becomes opaque --background; borders and
+ * shadows stay untouched so the elevation hierarchy survives. The query is
+ * the only activation gate — default appearance is unchanged.
+ */
+@media (prefers-reduced-transparency: reduce) {
+  .backdrop-blur-lg,
+  [data-slot='dialog-overlay'],
+  [data-slot='sheet-overlay'],
+  [data-slot='alert-dialog-overlay'] {
+    -webkit-backdrop-filter: none !important;
+    backdrop-filter: none !important;
+    background-color: var(--background) !important;
+  }
+}


### PR DESCRIPTION
## 改动摘要

Part of #887 收尾卫生波（审计条目 C/D 残留）。四项独立修复：清理 16 个验证为零引用的 i18n 死 key、model-detail 定价文案走 i18n、`prefers-reduced-transparency` 玻璃降级真实落地（此前文档标 Pass 但零实现）、a11y-checklist 失真条目诚实化。

## 类型

- [x] chore（工程维护）

## 改动明细

- **i18n 死 key 清理（-16 对）**：对全部 1909 个 leaf key 做字面量 + 动态前缀双重匹配验证后删除：auth.login.note、oauth.form.startSucceeded、accounts.verify.pending、tokenRoutes 三个（columns/detail refreshDecision、completion.action）、channels.detail 旧组 6 个、全量扫描新发现 4 个（checkin.columns.status、common.create、common.no、sites.page.retry）。**刻意保留**：`settings.common.schedule.everyHours_one/_other`（schedule-editor 经 `t(…, { count })` 运行时解析复数后缀，静态扫描判死但删除会导致语法回退）；旧审计点名的 ~38 个扁平表格 key 逐个核实已被新 data-table 体系复活，零删除
- **model-detail-sheet 定价文案 i18n**：硬编码 `in/out $…/M` → `models.detail.inputPrice/outputPrice`（en + zh-CN 插值 key）
- **prefers-reduced-transparency 落地**：真实 blur+半透明表面仅 5 个（topbar、批量操作浮动条共用玻璃配方 + dialog/sheet/alert-dialog 三个 scrim）；新增 `@media (prefers-reduced-transparency: reduce)` 对其 `backdrop-filter: none` + 实心底（OKLCH token），阴影/边框层次保留；默认外观零变化；no-gradients/token-hygiene 守卫仍绿；dist 产物确认包含该查询
- **a11y-checklist 诚实化**：§5.1/§5.2 四个幽灵组件名改为真实实现（bulk-actions 浮动条 / toolbar flex-wrap / MobileCardList / 表单自带响应式类）；§6 reduced-transparency 改为基于本次真实实现的 Pass

## 测试验证

- [x] `cd web && bun run typecheck` 0 error
- [x] `cd web && bun run lint` 0 error
- [x] `cd web && bun run test` 全绿（97 文件 / 705 用例）
- [x] `cd web && bun run knip` / `bun run build` / `bun run format:check` 通过

## 自查清单

- [x] 无密钥/内部路径泄漏
- [x] 用户可见文案已走 i18n
- [x] 行为变更已补充/更新测试（删除零引用 key 由 i18n 门禁 + 全量引用扫描守卫）
- [ ] CHANGELOG 随本批收尾版本统一更新

备注：审计曾报告 en.json `tokenRoutes.completion.connectAction` 为中文残留——经核实已被 #887 批次合入的 PR 修为正确英文（仍被 route-completion-toast 引用），本 PR 无需改动。

> 合并方式：Squash merge。