### PR TITLE
chore(web): drop residual zero-reference CSS from landing removal

### DIFF
--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -222,10 +222,6 @@
 }
 
 @layer utilities {
-  .animation-delay-100 {
-    animation-delay: 100ms;
-  }
-
   /*
    * Shimmer: subtle highlight sweep across skeleton bars. Reuses the
    * --skeleton-base / --skeleton-highlight tokens (defined in theme.css
@@ -391,50 +387,6 @@
 .content-auto {
   content-visibility: auto;
   contain-intrinsic-size: 0 80px;
-}
-
-/* ── Hero terminal demo animations ── */
-@keyframes terminal-demo-blink {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0;
-  }
-}
-.terminal-demo-blink {
-  animation: terminal-demo-blink 1s step-end infinite;
-}
-
-@keyframes terminal-demo-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-.terminal-demo-spin {
-  animation: terminal-demo-spin 0.8s linear infinite;
-}
-
-@keyframes terminal-demo-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.3;
-  }
-}
-.terminal-demo-pulse {
-  animation: terminal-demo-pulse 1.5s ease-in-out infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .terminal-demo-blink,
-  .terminal-demo-spin,
-  .terminal-demo-pulse {
-    animation: none !important;
-  }
 }
 
 /*


### PR DESCRIPTION
## 改动摘要

Part of #887 的收尾残留项：上一轮 landing 动画清理时，有两块零引用 CSS 因不在当轮批准的删除清单内被漏掉，现全仓复核确认仍为零引用后删除（`web/src/styles/index.css`，纯删除 48 行，无新增）：

- `.animation-delay-100` —— `.animation-delay-*` 家族最后残余（300/700/1000 兄弟项已在上一轮删除）。
- hero terminal demo 动画：`terminal-demo-blink` / `terminal-demo-spin` / `terminal-demo-pulse` 三组 `@keyframes`、对应工具类，以及仅覆盖这三者的 `prefers-reduced-motion` gate。

零引用证据（rebase 到最新 master 后重新复核）：`git grep -E "animation-delay-100|terminal-demo"` 在 `origin/master` 上仅命中 `web/src/styles/index.css` 内的定义自身，`web/src`、`web/public`、`web/index.html`、`e2e/`、`electron/`、`docs/` 均无任何消费方；删除后全仓命中数为 0。

刻意保留（均为活跃接线，未受本 PR 影响）：

- `.animate-shimmer` —— `web/src/components/ui/skeleton.tsx` 在用，并有 `table-skeleton.test.tsx` 守卫。
- `data-table-stagger` 规则 —— `web/src/components/ui/table.tsx` 与 `data-table-view.tsx` 在用。
- `@media (prefers-reduced-transparency: reduce)` 玻璃兜底 —— #896 交付的无障碍降级，a11y-checklist 记录在案。

## 类型

- [ ] feat（新功能）
- [ ] fix（bug 修复）
- [ ] perf（性能优化）
- [ ] refactor（重构，行为不变）
- [x] docs / chore（文档或工程维护）

## 测试验证

本地全套前端门禁在 rebase 到 `origin/master`（`1604f49`）之后重跑，逐项全绿：

- [x] `cd web && bun run typecheck` 通过（`tsgo -b`，0 error）
- [x] `cd web && bun run lint` 0 error（仅存量 warning，与本改动无关）
- [x] `cd web && bun run knip` 通过（0 unused）
- [x] `cd web && bun run test` 全绿：**132 个测试文件 / 885 个用例全部 passed**（duration 488s）
- [x] `cd web && bun run build` 成功（产物 3127.1 kB，其中 CSS 197.7 kB）
- [x] `cd web && bun run format:check` 通过（oxfmt，535 文件格式正确）
- [ ] `go vet ./...` / `go test ./...`（本 PR 不涉及后端，未跑）
- [ ] 涉及 API/DB 契约时 `test-pg`（CI）通过（不涉及契约变更）

## 自查清单

- [x] 无密钥/内部路径泄漏（纯 CSS 删除，无任何新增内容）
- [x] 无用户可见文案变更 —— 纯死代码删除，不涉及 i18n（`t()`）
- [x] `web/src/styles/__tests__` 守卫（`no-gradients` / `token-hygiene`）保持绿，`table-skeleton.test.tsx` 的 `.animate-shimmer` 断言保持绿
- [x] 视觉零变化：被删规则在全仓无消费方，渲染结果不受影响，故无需补充新测试
- [ ] `CHANGELOG.md` / `docs/`：无需更新（#887 波次已记录，此为同波次零引用死码收尾）

---

> 合并方式：Squash merge（master 受保护，禁止直接 push）。
