### PR TITLE
feat(web): 全局告警红点 — 顶栏 attention 入口

### DIFF
--- a/web/src/components/layout/__tests__/attention-bell.test.tsx
+++ b/web/src/components/layout/__tests__/attention-bell.test.tsx
@@ -1,0 +1,290 @@
+// metapi-go/layout — global attention bell tests.
+//
+// Pins the header alert surface added for issue #887: an operator on any page
+// must see that attention items are pending (count badge + severity tone),
+// be able to jump to the item's deep link through the router, and never get a
+// silent failure — loading / error / empty each render their own state.
+//
+// `api.getAttention` and the router are stubbed; the bell is rendered
+// standalone inside a QueryClientProvider (the header mounts it inside the
+// app-wide provider from main.tsx).
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import type { ReactNode } from 'react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import i18n from '@/i18n/config'
+import { api } from '@/lib/api'
+
+import { AttentionBell } from '../components/attention-bell'
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getAttention: vi.fn(),
+  },
+}))
+
+const { navigateMock } = vi.hoisted(() => ({ navigateMock: vi.fn() }))
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    // Resolve `$param` placeholders so the footer link's href is assertable
+    // without mounting a real router.
+    Link: ({
+      to,
+      params,
+      children,
+      ...rest
+    }: {
+      to?: unknown
+      params?: Record<string, string>
+      children?: ReactNode
+    } & Record<string, unknown>) => {
+      const path = typeof to === 'string' ? to : '/'
+      const resolved = Object.entries(params ?? {}).reduce(
+        (href, [name, value]) => href.replace(`$${name}`, value),
+        path
+      )
+      return (
+        <a href={resolved} {...rest}>
+          {children}
+        </a>
+      )
+    },
+  }
+})
+
+const mockGetAttention = vi.mocked(api.getAttention)
+
+// Base UI positions the popover with browser APIs jsdom does not implement.
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    writable: true,
+    value: ResizeObserverStub,
+  })
+})
+
+beforeEach(async () => {
+  mockGetAttention.mockReset()
+  navigateMock.mockReset()
+  await i18n.changeLanguage('en')
+})
+
+afterEach(() => cleanup())
+
+function attentionItem(overrides: {
+  severity: 'critical' | 'warning' | 'info'
+  label: string
+  target?: string
+}) {
+  return {
+    category: 'expired_account',
+    target: '/accounts?accountId=7',
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function renderBell() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AttentionBell />
+    </QueryClientProvider>
+  )
+}
+
+function indicatorOf(container: HTMLElement) {
+  return container.querySelector('[data-slot="attention-indicator"]')
+}
+
+async function openBell() {
+  const rendered = renderBell()
+  const trigger = await screen.findByRole('button', {
+    name: /Attention items/,
+  })
+  fireEvent.click(trigger)
+  await screen.findByRole('dialog')
+  return rendered
+}
+
+describe('attention bell', () => {
+  it('names the icon-only trigger and folds the pending count into the name', async () => {
+    mockGetAttention.mockResolvedValue({
+      items: [
+        attentionItem({ severity: 'critical', label: 'Account expired: ops' }),
+        attentionItem({ severity: 'warning', label: 'Low balance: relay' }),
+      ],
+      total: 2,
+    })
+
+    renderBell()
+
+    expect(
+      await screen.findByRole('button', { name: 'Attention items (2 pending)' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders a destructive count badge when a critical item is pending', async () => {
+    mockGetAttention.mockResolvedValue({
+      items: [
+        attentionItem({ severity: 'warning', label: 'Low balance: relay' }),
+        attentionItem({ severity: 'critical', label: 'Account expired: ops' }),
+      ],
+      total: 2,
+    })
+
+    const { container } = renderBell()
+
+    await waitFor(() => expect(indicatorOf(container)).not.toBeNull())
+    const indicator = indicatorOf(container)
+    expect(indicator).toHaveTextContent('2')
+    expect(indicator).toHaveAttribute('data-severity', 'critical')
+    expect(indicator?.className).toContain('bg-destructive')
+  })
+
+  it('keeps the badge on the warning tone when no critical item is pending', async () => {
+    mockGetAttention.mockResolvedValue({
+      items: [attentionItem({ severity: 'warning', label: 'Site disabled' })],
+      total: 1,
+    })
+
+    const { container } = renderBell()
+
+    await waitFor(() => expect(indicatorOf(container)).not.toBeNull())
+    const indicator = indicatorOf(container)
+    expect(indicator).toHaveAttribute('data-severity', 'warning')
+    expect(indicator?.className).toContain('bg-warning')
+  })
+
+  it('caps the badge at 9+ so a long backlog cannot widen the trigger', async () => {
+    mockGetAttention.mockResolvedValue({
+      items: Array.from({ length: 12 }, (_unused, index) =>
+        attentionItem({ severity: 'warning', label: `Low balance ${index}` })
+      ),
+      total: 12,
+    })
+
+    const { container } = renderBell()
+
+    await waitFor(() => expect(indicatorOf(container)).not.toBeNull())
+    expect(indicatorOf(container)).toHaveTextContent('9+')
+  })
+
+  it('renders no badge and an empty state when nothing needs attention', async () => {
+    mockGetAttention.mockResolvedValue({ items: [], total: 0 })
+
+    const { container } = await openBell()
+
+    expect(
+      await screen.findByText('Nothing needs attention right now.')
+    ).toBeInTheDocument()
+    expect(indicatorOf(container)).toBeNull()
+    expect(
+      screen.getByRole('button', { name: 'Attention items' })
+    ).toBeInTheDocument()
+  })
+
+  it('navigates to the item target through the router on click', async () => {
+    mockGetAttention.mockResolvedValue({
+      items: [
+        attentionItem({
+          severity: 'critical',
+          label: 'Account expired: ops',
+          target: '/accounts?accountId=7',
+        }),
+      ],
+      total: 1,
+    })
+
+    await openBell()
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Account expired: ops/ })
+    )
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      href: '/accounts?accountId=7',
+    })
+  })
+
+  it('shows a relative timestamp and links to the availability panel', async () => {
+    mockGetAttention.mockResolvedValue({
+      items: [
+        attentionItem({
+          severity: 'warning',
+          label: 'Low balance: relay',
+          target: '/accounts?accountId=3',
+        }),
+      ],
+      total: 1,
+    })
+
+    const { container } = await openBell()
+
+    expect(container.ownerDocument.querySelector('time')).not.toBeNull()
+    expect(
+      screen.getByRole('link', { name: 'View all attention items' })
+    ).toHaveAttribute('href', '/dashboard/availability')
+  })
+
+  it('surfaces a load error instead of swallowing it', async () => {
+    mockGetAttention.mockRejectedValue(new Error('attention unavailable'))
+
+    await openBell()
+
+    expect(
+      await screen.findByText('Failed to load attention items.')
+    ).toBeInTheDocument()
+  })
+
+  it('renders a skeleton while the attention query is in flight', async () => {
+    mockGetAttention.mockReturnValue(new Promise(() => {}))
+
+    await openBell()
+
+    expect(
+      document.body.querySelectorAll('[data-slot="skeleton"]').length
+    ).toBeGreaterThan(0)
+  })
+})

--- a/web/src/components/layout/components/app-header.tsx
+++ b/web/src/components/layout/components/app-header.tsx
@@ -1,11 +1,12 @@
 // metapi-go/layout — application header.
-// Brand on the left; global-search trigger, the shared language /
-// appearance / color-scheme controls, and the user menu (version, About,
-// documentation, sign-out) on the right.
+// Brand on the left; global-search trigger, the attention bell, the shared
+// language / appearance / color-scheme controls, and the user menu (version,
+// About, documentation, sign-out) on the right.
 
 import { Search } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import { AttentionBell } from '@/components/layout/components/attention-bell'
 import { InterfaceControls } from '@/components/layout/components/interface-controls'
 import { UserMenu } from '@/components/layout/components/user-menu'
 import { Button } from '@/components/ui/button'
@@ -62,21 +63,25 @@ export function AppHeader({
     >
       <SidebarTrigger className='md:hidden' />
       {leftContent ?? (
-        <div className='flex items-center gap-2'>
+        // The brand is the only flexible header cell: on narrow viewports it
+        // truncates so the right-hand controls (search, attention bell,
+        // interface controls, user menu) keep their full hit targets.
+        <div className='flex min-w-0 items-center gap-2'>
           <img
             src={metapiIdentity.logoPath}
             alt={metapiIdentity.name}
-            className='size-6 rounded-sm'
+            className='size-6 shrink-0 rounded-sm'
           />
-          <span className='text-sm font-semibold tracking-tight'>
+          <span className='truncate text-sm font-semibold tracking-tight'>
             {metapiIdentity.name}
           </span>
         </div>
       )}
 
       {rightContent ?? (
-        <div className='ms-auto flex items-center gap-1'>
+        <div className='ms-auto flex shrink-0 items-center gap-1'>
           <SearchTrigger onClick={onSearchClick} />
+          <AttentionBell />
           <InterfaceControls showThemeToggle={showThemeToggle} />
           <UserMenu />
         </div>

--- a/web/src/components/layout/components/attention-bell.tsx
+++ b/web/src/components/layout/components/attention-bell.tsx
@@ -1,0 +1,276 @@
+// metapi-go/layout — global attention bell.
+//
+// Audit follow-up (#887): actionable attention items were only visible on the
+// dashboard (today snapshot + availability panel), so an operator inspecting
+// any other page had no way to notice a new critical item, let alone jump back
+// to the problem. The header now carries a bell with a severity-toned count
+// badge plus a popover listing the most recent items, each deep-linking to the
+// page that resolves it.
+//
+// The data source is the dashboard's existing attention query — same
+// `['dashboard-attention', 20]` key, same `api.getAttention(20)` wrapper and
+// the same 10s poll as the availability panel — so TanStack Query dedupes the
+// request and shares one cache entry instead of opening a second data source.
+
+import { useQuery } from '@tanstack/react-query'
+import { Link, useNavigate } from '@tanstack/react-router'
+import { Bell } from 'lucide-react'
+import { useState, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { Separator } from '@/components/ui/separator'
+import { Skeleton } from '@/components/ui/skeleton'
+import { toBcp47 } from '@/i18n/languages'
+import { api } from '@/lib/api'
+import { formatAbsoluteDateTime, formatRelativeTime } from '@/lib/format'
+import { cn } from '@/lib/utils'
+
+/** Matches the dashboard attention query so the cache entry is shared. */
+const ATTENTION_LIMIT = 20
+/** Same cadence as the availability panel — no more aggressive polling. */
+const ATTENTION_REFETCH_INTERVAL_MS = 10 * 1000
+/** Counts above this render as "9+" so the badge never widens the trigger. */
+const BADGE_COUNT_CEILING = 9
+/** The popover is a peek surface; "view all" leads to the full panel. */
+const POPOVER_ITEM_LIMIT = 6
+
+type AttentionSeverity = 'critical' | 'warning' | 'info'
+
+type AttentionItem = {
+  severity: AttentionSeverity
+  category: string
+  label: string
+  target: string
+  createdAt: string
+}
+
+/** Attention response (GET /api/stats/attention?limit=20). */
+type AttentionResponse = {
+  items: AttentionItem[]
+  total: number
+}
+
+const SEVERITY_BADGE_VARIANT: Record<
+  AttentionSeverity,
+  'destructive' | 'warning' | 'info'
+> = {
+  critical: 'destructive',
+  warning: 'warning',
+  info: 'info',
+}
+
+const SEVERITY_DOT_CLASS: Record<AttentionSeverity, string> = {
+  critical: 'bg-destructive',
+  warning: 'bg-warning',
+  info: 'bg-info',
+}
+
+/** Solid tone for the trigger's count badge (the "red dot" affordance). */
+const SEVERITY_INDICATOR_CLASS: Record<AttentionSeverity, string> = {
+  critical: 'bg-destructive text-destructive-foreground',
+  warning: 'bg-warning text-warning-foreground',
+  info: 'bg-info text-info-foreground',
+}
+
+/** Most severe first — the badge tone follows the worst pending item. */
+const SEVERITY_PRIORITY: AttentionSeverity[] = ['critical', 'warning', 'info']
+
+/**
+ * The worst severity present, or `null` when nothing is pending (no items →
+ * no red dot). Items carrying a severity the UI does not know about still
+ * count, and read as `info`.
+ */
+function resolveHighestSeverity(
+  items: AttentionItem[]
+): AttentionSeverity | null {
+  if (items.length === 0) return null
+  for (const severity of SEVERITY_PRIORITY) {
+    if (items.some((item) => item.severity === severity)) return severity
+  }
+  return 'info'
+}
+
+function formatBadgeCount(count: number): string {
+  return count > BADGE_COUNT_CEILING ? `${BADGE_COUNT_CEILING}+` : String(count)
+}
+
+type AttentionListProps = {
+  items: AttentionItem[]
+  locale: string
+  onSelect: (target: string) => void
+}
+
+function AttentionList(props: AttentionListProps) {
+  const { t } = useTranslation()
+
+  return (
+    <ul className='flex flex-col'>
+      {props.items.map((item, index) => {
+        const badgeVariant =
+          SEVERITY_BADGE_VARIANT[item.severity] ?? SEVERITY_BADGE_VARIANT.info
+        const dotClass =
+          SEVERITY_DOT_CLASS[item.severity] ?? SEVERITY_DOT_CLASS.info
+        const relativeTime = formatRelativeTime(item.createdAt, props.locale)
+        return (
+          <li
+            // The backend has no stable item id — target + position is unique
+            // within one severity-ranked response.
+            // eslint-disable-next-line react/no-array-index-key
+            key={`${item.target}-${index}`}
+          >
+            <Button
+              variant='ghost'
+              className='h-auto w-full items-start justify-start gap-2 px-2 py-2 text-start font-normal whitespace-normal'
+              onClick={() => props.onSelect(item.target)}
+            >
+              <Badge variant={badgeVariant} className='mt-px shrink-0'>
+                <span
+                  aria-hidden='true'
+                  className={cn('size-1.5 rounded-full', dotClass)}
+                />
+                {t(`attention.severity.${item.severity}`)}
+              </Badge>
+              <span className='min-w-0 flex-1 truncate text-sm'>
+                {item.label}
+              </span>
+              {relativeTime ? (
+                <time
+                  dateTime={item.createdAt}
+                  title={formatAbsoluteDateTime(item.createdAt, props.locale)}
+                  className='text-muted-foreground shrink-0 text-xs tabular-nums'
+                >
+                  {relativeTime}
+                </time>
+              ) : null}
+            </Button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export function AttentionBell() {
+  const { t, i18n } = useTranslation()
+  const locale = toBcp47(i18n.language || 'en')
+  const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['dashboard-attention', ATTENTION_LIMIT],
+    queryFn: () =>
+      api.getAttention(ATTENTION_LIMIT) as Promise<AttentionResponse>,
+    refetchInterval: ATTENTION_REFETCH_INTERVAL_MS,
+  })
+
+  const items = data?.items ?? []
+  const highestSeverity = resolveHighestSeverity(items)
+
+  const handleSelect = (target: string) => {
+    setOpen(false)
+    // `target` is a plain SPA path (possibly with a query string), so it goes
+    // through the router's `href` option instead of window.location.
+    if (target) navigate({ href: target })
+  }
+
+  const triggerLabel =
+    items.length > 0
+      ? t('attention.triggerWithCount', { value: items.length })
+      : t('attention.trigger')
+
+  const renderPopoverBody = (): ReactNode => {
+    if (isLoading) {
+      return (
+        <div className='flex flex-col gap-2 p-2'>
+          <Skeleton className='h-5 w-full' />
+          <Skeleton className='h-5 w-4/5' />
+          <Skeleton className='h-5 w-3/5' />
+        </div>
+      )
+    }
+    if (isError) {
+      return (
+        <p className='text-destructive px-2 py-6 text-center text-sm'>
+          {t('attention.loadError')}
+        </p>
+      )
+    }
+    if (items.length === 0) {
+      return (
+        <p className='text-muted-foreground px-2 py-6 text-center text-sm'>
+          {t('attention.empty')}
+        </p>
+      )
+    }
+    return (
+      <AttentionList
+        items={items.slice(0, POPOVER_ITEM_LIMIT)}
+        locale={locale}
+        onSelect={handleSelect}
+      />
+    )
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            variant='ghost'
+            size='icon'
+            className='relative'
+            aria-label={triggerLabel}
+          />
+        }
+      >
+        <Bell className='size-4' aria-hidden='true' />
+        {highestSeverity ? (
+          <span
+            data-slot='attention-indicator'
+            data-severity={highestSeverity}
+            aria-hidden='true'
+            className={cn(
+              'absolute -end-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[0.625rem] leading-none font-semibold tabular-nums',
+              SEVERITY_INDICATOR_CLASS[highestSeverity]
+            )}
+          >
+            {formatBadgeCount(items.length)}
+          </span>
+        ) : null}
+      </PopoverTrigger>
+      <PopoverContent
+        align='end'
+        className='w-80 max-w-(--available-width) gap-0 p-0'
+      >
+        <div className='flex items-center justify-between gap-2 px-3 py-2'>
+          <span className='text-sm font-semibold'>{t('attention.title')}</span>
+          {highestSeverity ? (
+            <Badge variant={SEVERITY_BADGE_VARIANT[highestSeverity]}>
+              {items.length}
+            </Badge>
+          ) : null}
+        </div>
+        <Separator />
+        <div className='max-h-72 overflow-y-auto p-1'>
+          {renderPopoverBody()}
+        </div>
+        <Separator />
+        <Link
+          to='/dashboard/$section'
+          params={{ section: 'availability' }}
+          onClick={() => setOpen(false)}
+          className='text-primary block px-3 py-2 text-center text-xs font-medium hover:underline'
+        >
+          {t('attention.viewAll')}
+        </Link>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/web/src/i18n/__tests__/language-switcher.test.tsx
+++ b/web/src/i18n/__tests__/language-switcher.test.tsx
@@ -5,6 +5,7 @@
 // DirectionProvider, so a language change must NOT touch it.
 
 import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
   cleanup,
   fireEvent,
@@ -26,6 +27,14 @@ import { AppHeader } from '@/components/layout/components/app-header'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { ThemeProvider } from '@/context/theme-provider'
 import i18n from '@/i18n/config'
+
+// The header's attention bell polls GET /api/stats/attention — stub the
+// transport so this i18n test never reaches the network.
+vi.mock('@/lib/api', () => ({
+  api: {
+    getAttention: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+  },
+}))
 
 // jsdom has no window.matchMedia (ThemeProvider reads prefers-color-scheme)
 // and no ResizeObserver (Base UI positions the dropdown popup with it).
@@ -70,12 +79,17 @@ afterEach(() => {
 })
 
 function renderHeader() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+  })
   return render(
-    <ThemeProvider>
-      <SidebarProvider defaultOpen={false}>
-        <AppHeader />
-      </SidebarProvider>
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <SidebarProvider defaultOpen={false}>
+          <AppHeader />
+        </SidebarProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
   )
 }
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2515,6 +2515,19 @@
       "about": "About",
       "documentation": "Documentation",
       "signOut": "Sign out"
+    },
+    "attention": {
+      "trigger": "Attention items",
+      "triggerWithCount": "Attention items ({{value}} pending)",
+      "title": "Attention required",
+      "empty": "Nothing needs attention right now.",
+      "loadError": "Failed to load attention items.",
+      "viewAll": "View all attention items",
+      "severity": {
+        "critical": "critical",
+        "warning": "warning",
+        "info": "info"
+      }
     }
   }
 }

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2515,6 +2515,19 @@
       "about": "关于",
       "documentation": "文档",
       "signOut": "退出登录"
+    },
+    "attention": {
+      "trigger": "待关注告警",
+      "triggerWithCount": "待关注告警（{{value}} 项待处理）",
+      "title": "需要关注",
+      "empty": "暂无待关注项。",
+      "loadError": "加载关注事项失败。",
+      "viewAll": "查看全部待关注项",
+      "severity": {
+        "critical": "严重",
+        "warning": "警告",
+        "info": "提示"
+      }
     }
   }
 }


### PR DESCRIPTION
## 改动摘要

Part of #887 残留项：**全站只有 dashboard 能看见告警**。待关注告警（attention）此前只出现在 dashboard 的今日快照条与 availability 面板，运营者在其他任何页面巡检时既无法感知有新告警，也无法被拉回问题现场。

本 PR 在顶栏加入 attention bell：有未处理项时显示语义色计数徽章，点击展开 popover 列出最近若干条（severity 徽章 + 文案 + 相对时间），点击任一条经 TanStack Router 跳转到该项的深链（`/accounts?accountId=N`、`/sites?edit=N`、`/settings/system-info/program-logs`），底部「查看全部」进入 availability 面板。

数据源**复用** dashboard 既有 query：同一个 `['dashboard-attention', 20]` queryKey、同一个 `api.getAttention(20)` wrapper、同一个 10s 轮询间隔，TanStack Query 自动去重并共享缓存，没有新增第二套数据源、没有新增依赖、没有新增抽象层。

## 类型

- [x] feat（新功能）
- [ ] fix（缺陷修复）
- [ ] refactor（重构）
- [ ] docs（文档）
- [ ] chore（杂项）

## 改动明细

| 文件 | 说明 |
| --- | --- |
| `web/src/components/layout/components/attention-bell.tsx` | 新增。bell 触发器（`ui/button` icon-only + lucide `Bell` + `aria-label`）、计数徽章、popover 列表、三态、深链导航、「查看全部」链接 |
| `web/src/components/layout/components/app-header.tsx` | 顶栏右侧控件组接入 `<AttentionBell />`（search → bell → 语言/外观/主题 → 用户菜单）；品牌区改为可收缩 + `truncate`，右侧控件 `shrink-0`，窄屏空间紧张时优先保住控件命中区 |
| `web/src/i18n/locales/en.json` / `zh-CN.json` | 新增 `attention.*` 双语文案（trigger / triggerWithCount / title / empty / loadError / viewAll / severity.\*） |
| `web/src/components/layout/__tests__/attention-bell.test.tsx` | 新增 9 条 vitest 用例 |
| `web/src/i18n/__tests__/language-switcher.test.tsx` | 顶栏现在含数据驱动控件：渲染包一层 `QueryClientProvider` 并 stub `api.getAttention`，避免测试触网 |

实现要点：

- **语义色策略**：徽章/红点跟随「最严重的待处理项」— 有 critical → `bg-destructive` + `text-destructive-foreground`；仅 warning → `bg-warning` + `text-warning-foreground`；info → `bg-info`；无告警 → 完全不渲染红点。列表内 severity 用 `ui/badge` 语义 variant（destructive / warning / info）+ 语义色圆点，状态不只依赖颜色（配文字）。全部走 OKLCH 语义 token，无硬编码颜色。
- **上限显示**：计数 > 9 显示 `9+`，红点宽度不会撑开顶栏。
- **三态**：loading → `ui/skeleton` 三行骨架；error → `text-destructive` 简短提示（不吞错）；empty → 「暂无待关注项。」。
- **导航**：`useNavigate()` + `navigate({ href: target })`（target 是带 query 的 SPA 路径），不使用 `window.location`。
- **popover 契约**：`ui/popover` 原语 + `max-h` / `overflow-y-auto`（内容区 `max-h-72 overflow-y-auto`，宽度 `w-80 max-w-(--available-width)` 适配窄屏）。
- **a11y**：icon-only 触发器必带 `aria-label`，且把待处理数量折进 accessible name（`Attention items (3 pending)`）；视觉红点 `aria-hidden`，装饰图标/圆点 `aria-hidden`；相对时间用 `<time datetime>` + 绝对时间 `title`。
- **图标分层**：layout 业务层沿用 lucide-react，同文件未混用 HugeIcons。

## 测试验证

本地门禁（`web/`，全部通过）：

| 门禁 | 结果 |
| --- | --- |
| `bun install` | ok（no changes） |
| `bun run typecheck` | 0 error |
| `bun run lint` | 0 error（24 条既有 warning，与本改动无关） |
| `bun run knip` | exit 0 |
| `bun run test` | **133 files / 894 tests passed**（516s） |
| `bun run build` | ok（Total 3132.4 kB / gzip 1145.5 kB） |
| `bun run format:check` | All matched files use the correct format |

新增用例（`attention-bell.test.tsx`，9 条）：

1. icon-only 触发器有 `aria-label`，且未处理数量折入 accessible name
2. 存在 critical 时红点为 destructive 语义色 + 计数正确
3. 只有 warning 时红点为 warning 语义色
4. 计数 12 → 徽章显示 `9+`
5. 无告警时不渲染红点，并展示 empty 文案
6. 点击列表项经 router 导航到该项 `target`（`{ href: '/accounts?accountId=7' }`）
7. 列表项渲染相对时间，底部链接指向 availability 面板
8. 请求失败时展示 error 文案（不静默吞错）
9. 请求在途时渲染骨架

重跑受影响的 layout + i18n 目录：9 files / 50 tests passed。

## 自查清单

- [x] 只改本切片 owner 的文件（layout 顶栏 + 新组件 + i18n locales/测试），未触碰 settings / oauth / proxy-logs / channels / about 等其他切片
- [x] 未改 `docs/internal/**`
- [x] 复用既有 query key / wrapper / 轮询间隔，未新建数据源、未新增依赖、未加抽象层
- [x] 新文案 en + zh-CN 双语齐全，key 命名对齐邻近风格，i18n 对齐门禁通过
- [x] 无硬编码颜色（OKLCH 语义 token）；ui/ 原语与业务层图标分层未混用
- [x] icon-only 控件带 `aria-label`，装饰元素 `aria-hidden`，状态不只靠颜色
- [x] 移动端排布：bell 恒为 icon-only；顶栏品牌可收缩、右侧控件 `shrink-0`；popover 宽度受 `max-w-(--available-width)` 约束
- [x] Conventional Commits

合并方式：Squash merge