### PR TITLE
feat: About 页 Build Info 显示真实构建信息（issue #887 残留项）

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -443,6 +443,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve build provenance
+        id: provenance
+        run: echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
       - uses: docker/metadata-action@v6
         id: meta
         with:
@@ -461,6 +464,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'dev' }}
+            COMMIT=${{ github.sha }}
+            BUILD_TIME=${{ steps.provenance.outputs.build_time }}
             BUN_VERSION=${{ env.BUN_VERSION }}
           cache-from: type=gha,scope=${{ env.DOCKER_CACHE_SCOPE }}
           cache-to: type=gha,mode=max,scope=${{ env.DOCKER_CACHE_SCOPE }}
@@ -504,7 +509,9 @@ jobs:
       - name: Build multi-platform release binaries
         run: |
           set -euo pipefail
-          ldflags="-s -w -X github.com/deliciousbuding/metapi-go/internal/version.Version=${GITHUB_REF_NAME}"
+          version_pkg="github.com/deliciousbuding/metapi-go/internal/version"
+          build_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          ldflags="-s -w -X ${version_pkg}.Version=${GITHUB_REF_NAME} -X ${version_pkg}.Commit=${GITHUB_SHA} -X ${version_pkg}.BuildTime=${build_time}"
           mkdir -p dist-bin
           for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64; do
             os="${target%/*}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,12 @@
 
 # ARG declared before the first FROM is visible to every stage.
 ARG VERSION=dev
+# Build provenance surfaced by GET /api/about. No default: a plain
+# `docker build` produces an empty commit/build time, which the About page
+# renders as an em-dash instead of a fabricated SHA/timestamp. CI passes the
+# real values (see .github/workflows/main.yml docker-push).
+ARG COMMIT
+ARG BUILD_TIME
 # Single source of truth: .github/workflows/main.yml env.BUN_VERSION
 # (docker-push/docker-build pass it as a build-arg; default matches).
 ARG BUN_VERSION=1.3.14
@@ -25,6 +31,8 @@ RUN bun run build:web
 # Stage 2: Go build
 FROM golang:1.26.6-alpine AS build
 ARG VERSION
+ARG COMMIT
+ARG BUILD_TIME
 WORKDIR /app
 COPY go.mod go.sum ./
 # Module cache mount: `go mod download` becomes a no-op when go.sum hasn't
@@ -57,12 +65,12 @@ COPY --from=web /app/web/dist ./web/dist
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 go build -trimpath -buildvcs=false \
-    -ldflags="-s -w -X github.com/deliciousbuding/metapi-go/internal/version.Version=${VERSION}" \
+    -ldflags="-s -w -X github.com/deliciousbuding/metapi-go/internal/version.Version=${VERSION} -X github.com/deliciousbuding/metapi-go/internal/version.Commit=${COMMIT} -X github.com/deliciousbuding/metapi-go/internal/version.BuildTime=${BUILD_TIME}" \
     -o metapi ./cmd/server
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 go build -trimpath -buildvcs=false \
-    -ldflags="-s -w -X github.com/deliciousbuding/metapi-go/internal/version.Version=${VERSION}" \
+    -ldflags="-s -w -X github.com/deliciousbuding/metapi-go/internal/version.Version=${VERSION} -X github.com/deliciousbuding/metapi-go/internal/version.Commit=${COMMIT} -X github.com/deliciousbuding/metapi-go/internal/version.BuildTime=${BUILD_TIME}" \
     -o metapi-migrate ./cmd/migrate
 
 # Stage 3: Runtime

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,13 @@
 
 # Version injected into the binary at build time; "dev" when not on a tag.
 VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || echo dev)
-LDFLAGS := -s -w -X github.com/deliciousbuding/metapi-go/internal/version.Version=$(VERSION)
+# Build provenance injected alongside VERSION and surfaced by GET /api/about.
+# COMMIT stays empty outside a git checkout; the About page then renders an
+# em-dash instead of a fabricated SHA.
+COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null)
+BUILD_TIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+VERSION_PKG := github.com/deliciousbuding/metapi-go/internal/version
+LDFLAGS := -s -w -X $(VERSION_PKG).Version=$(VERSION) -X $(VERSION_PKG).Commit=$(COMMIT) -X $(VERSION_PKG).BuildTime=$(BUILD_TIME)
 
 # Build the server binary (requires web/dist/ to exist for go:embed)
 build:

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # Admin API Reference
 
-**Last updated**: 2026-08-15
+**Last updated**: 2026-08-21
 
 Base URL: `http://localhost:4000/api`
 
@@ -849,6 +849,18 @@ Readiness check (no auth required). It pings the active database and returns `20
 
 Desktop health check. Returns `{"status":"ok"}`.
 
+---
+
+## About
+
+### GET /api/about
+
+Build provenance of the running binary, rendered by the admin About page.
+
+**Response**: `{ version, commit, buildTime, goVersion }`
+
+`version` is the `-ldflags` injected build version (`dev` for local builds). `commit` is the git SHA and `buildTime` the UTC RFC3339 build timestamp, both injected by the Makefile / Dockerfile / release pipeline; they are **empty strings** for builds without injection (plain `go build`, plain `docker build`) and the UI renders an em-dash rather than a fabricated value. `goVersion` comes from `runtime.Version()` and is always populated. The endpoint reads no database, so it keeps answering while the database is unavailable.
+
 ## Security Notes
 
 ### LDOH monitor proxy
@@ -953,6 +965,7 @@ Mounted under `/v1/*` so it inherits ProxyAuth + wildcard CORS.
 Complete list of registered `/api` admin routes (generated from the router registration). Path parameters use `:param` syntax.
 
 ### GET
+- `/api/about`
 - `/api/account-tokens`
 - `/api/account-tokens/:id/value`
 - `/api/account-tokens/account/:accountId/default`

--- a/handler/admin/about.go
+++ b/handler/admin/about.go
@@ -1,0 +1,40 @@
+package admin
+
+import (
+	"net/http"
+	"runtime"
+
+	"github.com/deliciousbuding/metapi-go/internal/version"
+	"github.com/go-chi/chi/v5"
+)
+
+// RegisterAboutRoutes registers GET /api/about, the build-provenance surface
+// the About page renders.
+//
+// This is a dedicated endpoint rather than an extension of an existing one:
+// /api/update-center/status is an explicit local-only stub whose contract is
+// "no in-app version discovery" (its 0.0.0 placeholders are asserted by
+// update_center_test.go), and /health + /ready are unauthenticated probes with
+// a frozen payload that must not leak build provenance. Build metadata has no
+// other owner, so it gets its own route.
+//
+// Takes no *sqlx.DB: every field comes from the linker or the Go runtime, so
+// the endpoint keeps answering when the database is unavailable.
+func RegisterAboutRoutes(r chi.Router) {
+	r.Get("/api/about", aboutInfo)
+}
+
+// aboutInfo reports the build provenance of the running binary.
+//
+// `commit` and `buildTime` are empty for builds without ldflags injection
+// (local `go build`, plain `docker build`). They stay empty on the wire — the
+// frontend renders an em-dash for absent values, which is honest, whereas a
+// synthesized SHA or a process-start timestamp would not be.
+func aboutInfo(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"version":   version.Version,
+		"commit":    version.Commit,
+		"buildTime": version.BuildTime,
+		"goVersion": runtime.Version(),
+	})
+}

--- a/handler/admin/about_test.go
+++ b/handler/admin/about_test.go
@@ -1,0 +1,104 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"runtime"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/internal/version"
+	"github.com/go-chi/chi/v5"
+)
+
+func setupAboutTest(t *testing.T) chi.Router {
+	t.Helper()
+	r := chi.NewRouter()
+	RegisterAboutRoutes(r)
+	return r
+}
+
+// decodeAboutBody asserts the endpoint answered 200 and decodes the payload as
+// a string map — the About page reads every field as a string.
+func decodeAboutBody(t *testing.T, r chi.Router) map[string]string {
+	t.Helper()
+	resp := doGet(t, r, "/api/about")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s, want 200", resp.Code, resp.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, resp.Body.String())
+	}
+	return body
+}
+
+// setInjectedBuildMetadata simulates an ldflags-injected binary and restores
+// the package defaults afterwards so sibling tests still see the real values.
+func setInjectedBuildMetadata(t *testing.T, commit, buildTime string) {
+	t.Helper()
+	originalCommit := version.Commit
+	originalBuildTime := version.BuildTime
+	t.Cleanup(func() {
+		version.Commit = originalCommit
+		version.BuildTime = originalBuildTime
+	})
+	version.Commit = commit
+	version.BuildTime = buildTime
+}
+
+func TestAboutInfo_ReturnsAllCamelCaseFields(t *testing.T) {
+	body := decodeAboutBody(t, setupAboutTest(t))
+
+	for _, field := range []string{"version", "commit", "buildTime", "goVersion"} {
+		if _, ok := body[field]; !ok {
+			t.Fatalf("missing field %q in %v", field, body)
+		}
+	}
+	if len(body) != 4 {
+		t.Fatalf("payload=%v, want exactly the four about fields", body)
+	}
+}
+
+func TestAboutInfo_GoVersionComesFromRuntime(t *testing.T) {
+	body := decodeAboutBody(t, setupAboutTest(t))
+
+	if body["goVersion"] != runtime.Version() {
+		t.Fatalf("goVersion=%q, want runtime.Version()=%q", body["goVersion"], runtime.Version())
+	}
+}
+
+func TestAboutInfo_VersionMirrorsInjectedBinaryVersion(t *testing.T) {
+	body := decodeAboutBody(t, setupAboutTest(t))
+
+	if body["version"] != version.Version {
+		t.Fatalf("version=%q, want %q", body["version"], version.Version)
+	}
+}
+
+// Uninjected builds must not fabricate provenance: empty stays empty on the
+// wire so the About page renders an em-dash instead of a fake SHA/timestamp.
+func TestAboutInfo_UninjectedProvenanceStaysEmpty(t *testing.T) {
+	setInjectedBuildMetadata(t, "", "")
+
+	body := decodeAboutBody(t, setupAboutTest(t))
+
+	if body["commit"] != "" {
+		t.Fatalf("commit=%q, want empty for an uninjected build", body["commit"])
+	}
+	if body["buildTime"] != "" {
+		t.Fatalf("buildTime=%q, want empty for an uninjected build", body["buildTime"])
+	}
+}
+
+func TestAboutInfo_InjectedProvenancePassesThrough(t *testing.T) {
+	setInjectedBuildMetadata(t, "0123456789abcdef0123456789abcdef01234567", "2026-08-21T10:11:12Z")
+
+	body := decodeAboutBody(t, setupAboutTest(t))
+
+	if body["commit"] != "0123456789abcdef0123456789abcdef01234567" {
+		t.Fatalf("commit=%q, want the injected SHA", body["commit"])
+	}
+	if body["buildTime"] != "2026-08-21T10:11:12Z" {
+		t.Fatalf("buildTime=%q, want the injected timestamp", body["buildTime"])
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,3 +5,15 @@ package version
 // -ldflags "-X github.com/deliciousbuding/metapi-go/internal/version.Version=vX.Y.Z".
 // Local builds without injection report "dev".
 var Version = "dev"
+
+// Commit is the git commit SHA the binary was built from, injected via
+// -ldflags "-X github.com/deliciousbuding/metapi-go/internal/version.Commit=<sha>".
+// Stays empty for builds without injection (local `go build`) — callers must
+// surface "unknown" rather than substituting a placeholder SHA.
+var Commit = ""
+
+// BuildTime is the UTC RFC3339 timestamp of the build, injected via
+// -ldflags "-X github.com/deliciousbuding/metapi-go/internal/version.BuildTime=<ts>".
+// Stays empty for builds without injection (local `go build`) — callers must
+// surface "unknown" rather than substituting the process start time.
+var BuildTime = ""

--- a/router/router.go
+++ b/router/router.go
@@ -76,6 +76,11 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 		// /debug/vars moved behind admin auth
 		r.Get("/api/debug/vars", app.MetricsHandler)
 
+		// Build provenance for the About page. Registered outside the
+		// db != nil block because every field comes from the linker or the
+		// Go runtime, never the database.
+		admin.RegisterAboutRoutes(r)
+
 		// Sites + Accounts + AccountTokens CRUD API
 		db := store.GetDB()
 		if db != nil {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -84,6 +84,49 @@ func TestAdminRouteStillRequiresAuth(t *testing.T) {
 	}
 }
 
+// TestAboutRouteRequiresAuthAndServesBuildInfoWithoutDatabase
+//
+// /api/about is registered outside the db != nil block (every field comes from
+// the linker or the Go runtime), so it must still answer when the database was
+// never initialized — while staying behind the admin auth middleware like the
+// rest of /api.
+func TestAboutRouteRequiresAuthAndServesBuildInfoWithoutDatabase(t *testing.T) {
+	if err := store.CloseDatabase(); err != nil {
+		t.Fatalf("CloseDatabase: %v", err)
+	}
+	cfg := &config.Config{
+		AuthToken:        "admin-token",
+		ProxyToken:       "proxy-token",
+		RequestBodyLimit: config.DefaultRequestBodyLimit,
+	}
+	r := New(cfg, web.Dist)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/about", nil)
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("/api/about without auth status = %d, want 401", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/about", nil)
+	req.Header.Set("Authorization", "Bearer admin-token")
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/api/about status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode about: %v", err)
+	}
+	if body["goVersion"] == "" {
+		t.Fatalf("goVersion empty in %v, want the runtime version", body)
+	}
+	if body["version"] == "" {
+		t.Fatalf("version empty in %v, want the injected binary version", body)
+	}
+}
+
 func TestAdminRoutesAreMountedWithoutDoubleAPIPrefix(t *testing.T) {
 	dataDir := t.TempDir()
 	cfg := &config.Config{

--- a/web/src/features/about/api.ts
+++ b/web/src/features/about/api.ts
@@ -1,20 +1,27 @@
 // metapi-go/features/about — TanStack Query hook for build/runtime info.
 //
-// No backend `/api/about` endpoint exists today. The query resolves
-// compile-time constants so the page can render immediately: `version` is the
-// `METAPI_WEB_VERSION` global injected by `source.define` in
-// rsbuild.config.ts (read from the web/package.json `version` field), and
-// the repo metadata below is curated here. The optional fields
-// (`buildTime` / `commit` / `goVersion`) are left undefined; when a backend
-// endpoint lands, swap the `queryFn` to call `api.getAbout()` (or
-// equivalent) and the page picks them up with no component changes.
-// `staleTime: Infinity` because the data is constant for the lifetime of
-// the page load.
+// The build provenance (`version` / `commit` / `buildTime` / `goVersion`) comes
+// from the Go binary via `GET /api/about`, so the About page shows the version
+// of the process actually serving the request rather than the frontend bundle
+// version. The repository metadata below is curated in the frontend — it
+// describes the project, not the build, and has no backend owner.
+//
+// Fields the backend leaves empty (a local `go build` injects no commit or
+// build time) stay undefined here so the page renders an em-dash instead of a
+// fabricated value.
 
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 
+import { api } from '@/lib/api'
+
 import { aboutKeys, type AboutInfo } from './types'
 
+/**
+ * Project metadata that is not build provenance: name, description, links,
+ * license and author. `version` is the `METAPI_WEB_VERSION` global injected by
+ * `source.define` in rsbuild.config.ts (read from web/package.json) and acts
+ * as the fallback when the backend does not report a binary version.
+ */
 const ABOUT_INFO: AboutInfo = {
   version: METAPI_WEB_VERSION,
   projectName: 'Metapi',
@@ -29,15 +36,43 @@ const ABOUT_INFO: AboutInfo = {
 export { ABOUT_INFO }
 
 /**
- * Fetch about/build info. Resolves build-time constants synchronously — no
- * network call. Pass `options.enabled` etc. to override.
+ * Narrow an untrusted backend field to a non-empty trimmed string, or
+ * undefined. Absent / blank / non-string values all collapse to undefined so
+ * the page's em-dash fallback takes over instead of rendering `"undefined"`.
+ */
+function optionalText(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+/**
+ * Merge the backend build provenance into the curated project metadata. The
+ * binary version wins over the bundle version because it describes the process
+ * answering the request; the bundle version remains the fallback for a backend
+ * that reports no version at all.
+ */
+async function fetchAboutInfo(): Promise<AboutInfo> {
+  const response = await api.getAbout()
+  return {
+    ...ABOUT_INFO,
+    version: optionalText(response?.version) ?? ABOUT_INFO.version,
+    commit: optionalText(response?.commit),
+    buildTime: optionalText(response?.buildTime),
+    goVersion: optionalText(response?.goVersion),
+  }
+}
+
+/**
+ * Fetch about/build info from `GET /api/about`. `staleTime: Infinity` because
+ * the build provenance of a running binary cannot change without a restart.
  */
 export function useAboutInfo(
   options?: Omit<UseQueryOptions<AboutInfo>, 'queryKey' | 'queryFn'>
 ) {
   return useQuery<AboutInfo>({
     queryKey: aboutKeys.info(),
-    queryFn: async () => ABOUT_INFO,
+    queryFn: fetchAboutInfo,
     staleTime: Infinity,
     ...options,
   })

--- a/web/src/features/about/components/__tests__/about-page.test.tsx
+++ b/web/src/features/about/components/__tests__/about-page.test.tsx
@@ -1,0 +1,169 @@
+// Regression test for the About page's Build Info card (issue #887 residual):
+// the three rows used to render a permanent em-dash because the feature never
+// called the backend. They now come from `GET /api/about`, and the card must
+// distinguish "loading", "request failed" and "the binary carries no such
+// value" instead of collapsing all three into an em-dash.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { AboutPage } from '../about-page'
+
+const { mockGetAbout } = vi.hoisted(() => ({
+  mockGetAbout: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: { getAbout: mockGetAbout },
+}))
+
+const INJECTED_BUILD_INFO = {
+  version: 'v0.16.3',
+  commit: '1604f49aa0b1c2d3e4f5061728394a5b6c7d8e9f',
+  buildTime: '2026-08-21T09:30:00Z',
+  goVersion: 'go1.26.6',
+}
+
+beforeEach(() => {
+  mockGetAbout.mockReset()
+})
+
+afterEach(() => cleanup())
+
+function renderAboutPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    (
+      <QueryClientProvider client={queryClient}>
+        <AboutPage />
+      </QueryClientProvider>
+    ) as ReactElement
+  )
+}
+
+/** The Build Info card, located by its section heading. */
+function getBuildInfoCard(): HTMLElement {
+  const heading = screen.getByText('Build info')
+  const card = heading.closest('[data-slot="card"]')
+  if (!(card instanceof HTMLElement)) {
+    throw new Error('Build info card not found')
+  }
+  return card
+}
+
+/** Read the value cell of a Build Info row by its label. */
+function getRowValue(label: string): string {
+  const card = getBuildInfoCard()
+  const labelNode = within(card).getByText(label)
+  const row = labelNode.parentElement
+  if (!row) throw new Error(`row for ${label} not found`)
+  const valueNode = row.lastElementChild
+  if (!valueNode) throw new Error(`value cell for ${label} not found`)
+  return valueNode.textContent ?? ''
+}
+
+describe('AboutPage — Build Info card', () => {
+  it('renders the real build provenance returned by the backend', async () => {
+    mockGetAbout.mockResolvedValue(INJECTED_BUILD_INFO)
+
+    renderAboutPage()
+
+    await waitFor(() => {
+      expect(getRowValue('Go version')).toBe('go1.26.6')
+    })
+    expect(getRowValue('Build time')).toBe('2026-08-21T09:30:00Z')
+    expect(getRowValue('Commit')).toBe(INJECTED_BUILD_INFO.commit)
+    expect(mockGetAbout).toHaveBeenCalledTimes(1)
+  })
+
+  it('prefers the backend binary version over the bundle constant', async () => {
+    mockGetAbout.mockResolvedValue(INJECTED_BUILD_INFO)
+
+    renderAboutPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('v0.16.3')).toBeInTheDocument()
+    })
+  })
+
+  it('shows an em-dash for fields the running binary does not carry', async () => {
+    // A local `go build` injects no commit/build time: the backend answers with
+    // empty strings, which must render as an em-dash — never as a fake value.
+    mockGetAbout.mockResolvedValue({
+      version: 'dev',
+      commit: '',
+      buildTime: '',
+      goVersion: 'go1.26.6',
+    })
+
+    renderAboutPage()
+
+    await waitFor(() => {
+      expect(getRowValue('Go version')).toBe('go1.26.6')
+    })
+    expect(getRowValue('Commit')).toBe('—')
+    expect(getRowValue('Build time')).toBe('—')
+  })
+
+  it('shows an em-dash when the backend omits the fields entirely', async () => {
+    mockGetAbout.mockResolvedValue({})
+
+    renderAboutPage()
+
+    await waitFor(() => {
+      expect(getRowValue('Commit')).toBe('—')
+    })
+    expect(getRowValue('Build time')).toBe('—')
+    expect(getRowValue('Go version')).toBe('—')
+  })
+
+  it('renders an error state with retry instead of a fabricated value', async () => {
+    mockGetAbout.mockRejectedValue(new Error('Network Error'))
+
+    renderAboutPage()
+
+    const card = await waitFor(() => {
+      const buildInfoCard = getBuildInfoCard()
+      expect(within(buildInfoCard).getByRole('alert')).toBeInTheDocument()
+      return buildInfoCard
+    })
+    expect(
+      within(card).getByText('Failed to load build info: Network Error')
+    ).toBeInTheDocument()
+    expect(
+      within(card).getByRole('button', { name: 'Retry' })
+    ).toBeInTheDocument()
+    // The error state must not silently degrade into em-dash rows.
+    expect(within(card).queryByText('—')).not.toBeInTheDocument()
+  })
+
+  it('keeps the network-independent page shell usable while loading', async () => {
+    // Never resolves: the shell (title + repository links) must already render.
+    mockGetAbout.mockReturnValue(new Promise(() => {}))
+
+    renderAboutPage()
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'About' })
+    ).toBeInTheDocument()
+    expect(screen.getByText('Repository')).toBeInTheDocument()
+    // Loading is a skeleton, not an em-dash: "not loaded yet" and "the binary
+    // carries no such value" must not look the same.
+    const card = getBuildInfoCard()
+    expect(within(card).queryByText('—')).not.toBeInTheDocument()
+    expect(card.querySelector('[data-slot="skeleton"]')).not.toBeNull()
+  })
+})

--- a/web/src/features/about/components/about-page.tsx
+++ b/web/src/features/about/components/about-page.tsx
@@ -1,7 +1,8 @@
 // metapi-go/features/about — the About page.
 //
-// A static information page (no data-table). Renders project metadata,
-// version/build info (em-dash for fields the backend does not yet supply),
+// A static information page (no data-table). Renders project metadata, the
+// build info reported by `GET /api/about` (em-dash for fields the running
+// binary was not linked with, e.g. commit/build time on a local `go build`),
 // curated key dependencies, and a public GitHub repository card. All links
 // point to the public DeliciousBuding/metapi-go repository — no internal
 // host paths, secrets, or private documentation references.
@@ -15,6 +16,7 @@ import {
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import { Badge } from '@/components/ui/badge'
 import {
   Card,
@@ -24,8 +26,9 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
+import { Skeleton } from '@/components/ui/skeleton'
 
-import { useAboutInfo } from '../api'
+import { ABOUT_INFO, useAboutInfo } from '../api'
 import { KEY_DEPENDENCIES, type AboutDependency } from '../types'
 
 const DEPENDENCY_CATEGORY_LABEL_KEY: Record<
@@ -68,14 +71,88 @@ function InfoRow({
   )
 }
 
+/**
+ * Placeholder rows shown while `GET /api/about` is in flight. A skeleton
+ * instead of an immediate em-dash: "not loaded yet" and "the binary carries no
+ * such value" are different facts and must not look alike.
+ */
+function BuildInfoSkeleton({ labels }: { labels: string[] }) {
+  return (
+    <div aria-busy='true' aria-live='polite'>
+      {labels.map((label) => (
+        <div
+          key={label}
+          className='flex items-center justify-between gap-4 py-2'
+        >
+          <span className='text-muted-foreground text-sm'>{label}</span>
+          <Skeleton className='h-4 w-40' />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Build Info body across the three query states: skeleton while loading, an
+ * error banner with retry when the request failed, and the real values on
+ * success (each row falling back to an em-dash when the running binary was
+ * linked without that value).
+ */
+function BuildInfoCardContent(props: {
+  buildTime?: string
+  commit?: string
+  goVersion?: string
+  isPending: boolean
+  error: Error | null
+  isRetrying: boolean
+  onRetry: () => void
+}) {
+  const { t } = useTranslation()
+  const labels = [
+    t('about.fields.buildTime'),
+    t('about.fields.commit'),
+    t('about.fields.goVersion'),
+  ]
+
+  if (props.isPending) {
+    return <BuildInfoSkeleton labels={labels} />
+  }
+
+  if (props.error) {
+    return (
+      <QueryErrorBanner
+        error={props.error}
+        messageKey='about.loadError'
+        onRetry={props.onRetry}
+        isRetrying={props.isRetrying}
+      />
+    )
+  }
+
+  return (
+    <div className='divide-border divide-y'>
+      <InfoRow
+        label={t('about.fields.buildTime')}
+        value={props.buildTime}
+        mono
+      />
+      <InfoRow label={t('about.fields.commit')} value={props.commit} mono />
+      <InfoRow
+        label={t('about.fields.goVersion')}
+        value={props.goVersion}
+        mono
+      />
+    </div>
+  )
+}
+
 export function AboutPage() {
   const { t } = useTranslation()
   const aboutQuery = useAboutInfo()
-  const info = aboutQuery.data
-
-  if (!info) {
-    return null
-  }
+  // The curated project metadata needs no network round trip, so the page
+  // shell (links, dependencies, license) stays usable even when /api/about
+  // fails; only the Build Info card depends on the query.
+  const info = aboutQuery.data ?? ABOUT_INFO
 
   const issueUrl = `${info.repository}/issues`
   const authorUrl = `https://github.com/${info.author}`
@@ -130,17 +207,15 @@ export function AboutPage() {
             {t('about.sections.buildInfoDescription')}
           </CardDescription>
         </CardHeader>
-        <CardContent className='divide-border divide-y'>
-          <InfoRow
-            label={t('about.fields.buildTime')}
-            value={info.buildTime}
-            mono
-          />
-          <InfoRow label={t('about.fields.commit')} value={info.commit} mono />
-          <InfoRow
-            label={t('about.fields.goVersion')}
-            value={info.goVersion}
-            mono
+        <CardContent>
+          <BuildInfoCardContent
+            buildTime={info.buildTime}
+            commit={info.commit}
+            goVersion={info.goVersion}
+            isPending={aboutQuery.isPending}
+            error={aboutQuery.error as Error | null}
+            isRetrying={aboutQuery.isFetching}
+            onRetry={() => aboutQuery.refetch()}
           />
         </CardContent>
       </Card>

--- a/web/src/features/about/types.ts
+++ b/web/src/features/about/types.ts
@@ -1,20 +1,20 @@
 // metapi-go/features/about — domain types for the About feature.
 //
-// The About page renders build/runtime metadata. There is no backend
-// `/api/about` endpoint today, so `useAboutInfo` resolves build-time
-// constants; the optional `buildTime` / `commit` / `goVersion` fields are
-// reserved for when the endpoint lands — the page shows an em-dash for any
-// field the backend does not yet supply. The public GitHub repository link
-// is the only external reference (metapi-go is a public repo).
+// The About page renders build/runtime metadata. `buildTime` / `commit` /
+// `goVersion` come from `GET /api/about` (the running Go binary); they stay
+// undefined when the binary was linked without ldflags injection (a local
+// `go build` reports no commit or build time), and the page then shows an
+// em-dash rather than a fabricated value. The public GitHub repository link is
+// the only external reference (metapi-go is a public repo).
 
 export type AboutInfo = {
-  /** Semver version, sourced from package.json at build time. */
+  /** Semver version: the binary version from /api/about, else the bundle version. */
   version: string
-  /** ISO build timestamp. Undefined until a backend endpoint supplies it. */
+  /** UTC RFC3339 build timestamp. Undefined when the binary carries none. */
   buildTime?: string
-  /** Git commit SHA. Undefined until a backend endpoint supplies it. */
+  /** Git commit SHA. Undefined when the binary carries none. */
   commit?: string
-  /** Go runtime version string. Undefined until a backend endpoint supplies it. */
+  /** Go runtime version string reported by the backend. */
   goVersion?: string
   /** Human-readable product name. */
   projectName: string

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -91,6 +91,7 @@
     "about": {
       "title": "About",
       "description": "Project information, build details, and useful links.",
+      "loadError": "Failed to load build info: {{message}}",
       "sections": {
         "projectInfo": "Project info",
         "projectInfoDescription": "Basic metadata about this deployment.",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -91,6 +91,7 @@
     "about": {
       "title": "关于",
       "description": "项目信息、构建详情与相关链接。",
+      "loadError": "加载构建信息失败：{{message}}",
       "sections": {
         "projectInfo": "项目信息",
         "projectInfoDescription": "当前部署的基本元数据。",

--- a/web/src/lib/api/system.ts
+++ b/web/src/lib/api/system.ts
@@ -1,6 +1,13 @@
 import { request } from './transport'
+import type { AboutBuildInfoResponse } from './types'
 
 export const systemApi = {
+  /**
+   * Build provenance of the running Go binary: version, commit, build time and
+   * Go runtime version. Uninjected local builds report empty commit/buildTime.
+   */
+  getAbout: () => request<AboutBuildInfoResponse>('/api/about'),
+
   // Monitor embed
   getMonitorConfig: () => request('/api/monitor/config'),
   getMonitorHealth: () => request('/api/monitor/health'),

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -739,6 +739,21 @@ export type DownstreamApiKeyTrendResponse = {
   buckets: DownstreamApiKeyTrendBucket[]
 }
 
+/**
+ * GET /api/about — build provenance of the running Go binary.
+ *
+ * `commit` and `buildTime` are only populated when the binary was linked with
+ * ldflags injection (release/Docker builds); a plain local `go build` reports
+ * them as empty strings, which the About page renders as an em-dash. Every
+ * field is optional here so a trimmed or older backend cannot crash the page.
+ */
+export type AboutBuildInfoResponse = {
+  version?: string
+  commit?: string
+  buildTime?: string
+  goVersion?: string
+}
+
 // ---------------------------------------------------------------------------
 // Business API — 179 methods across 13 domain groups.
 // Signatures preserved 1:1 from legacy api.ts; only the transport is swapped.

--- a/web/src/routes/_authenticated/about.tsx
+++ b/web/src/routes/_authenticated/about.tsx
@@ -1,9 +1,10 @@
-// metapi-go/routes — about (static info page).
+// metapi-go/routes — about (project + build info page).
 //
-// No `validateSearch` and no `loader`: the about page renders build-time
-// constants resolved synchronously by `useAboutInfo()` (no network round
-// trip), so there is nothing to prefetch. The component is declared directly;
-// the router plugin's `autoCodeSplitting` splits it in production.
+// No `validateSearch` and no `loader`: the page shell renders the curated
+// project metadata immediately and `useAboutInfo()` fetches the binary's build
+// provenance (`GET /api/about`) into the Build Info card, which owns its own
+// skeleton/error states. The component is declared directly; the router
+// plugin's `autoCodeSplitting` splits it in production.
 
 import { createFileRoute } from '@tanstack/react-router'
 


### PR DESCRIPTION
## 改动摘要

Part of #887 残留项：About 页「Build Info」卡片此前永远渲染 em-dash `—`，因为前端 `useAboutInfo` 只解析构建期常量，后端没有任何提供构建信息的端点。本次新增 `GET /api/about`（返回二进制真实 version / commit / buildTime / goVersion），并在 Makefile、Dockerfile、发布流水线注入真实 commit sha 与 UTC RFC3339 构建时间，前端改为真实请求该端点并补齐 loading/error 三态。

## 类型

- [x] feat（新功能）
- [ ] fix（bug 修复）
- [ ] perf（性能优化）
- [ ] refactor（重构，行为不变）
- [ ] docs / chore（文档或工程维护）

## 改动明细

### 后端（commit `0bc6c83`）
- `internal/version`：新增 `Commit` / `BuildTime` 两个 `-ldflags` 可注入变量，缺省为空字符串（诚实：不伪造 SHA/时间）；Go 版本用 `runtime.Version()` 真实取得，无需注入。
- 新端点 `GET /api/about`（`handler/admin/about.go`）：camelCase JSON `{ version, commit, buildTime, goVersion }`。
  - **宿主端点决策**：不扩展既有端点——`/api/update-center/status` 是显式本地 stub，契约就是「不做应用内版本发现」（其 0.0.0 占位符有测试断言）；`/health`、`/ready` 是无认证探针，载荷不允许泄漏构建溯源。构建元数据没有其他宿主，故独立成路由。
  - 不依赖数据库，注册在 admin auth 组内、`db != nil` 块之外（`router/router.go`）。
- 注入点（与现有 `VERSION` 注入风格一致）：
  - `Makefile`：`COMMIT`（`git rev-parse HEAD`）、`BUILD_TIME`（`date -u +%Y-%m-%dT%H:%M:%SZ`）变量并入 `LDFLAGS`；git 之外缺省为空串。
  - `Dockerfile`：`COMMIT` / `BUILD_TIME` build args（无默认值，裸 `docker build` 时留空 → 前端显示 em-dash），两个 Go 构建的 ldflags 同步。
  - `.github/workflows/main.yml`：docker-push 传 `COMMIT=${{ github.sha }}` + `BUILD_TIME`（新 provenance step）；release job 的 5 平台二进制 ldflags 传 `GITHUB_SHA` + UTC 时间。
- 测试：`about_test.go`（4 个字段齐备 + camelCase、`goVersion` 来源、未注入留空、注入透传）；`router_test.go` 新增用例（要求 admin auth、无数据库时仍 200）。
- `docs/api.md`：新增 About 章节 + 路由清单补 `/api/about`。

### 前端（commit `771141b`）
- `web/src/features/about/api.ts`：`useAboutInfo` 改真实调用 `api.getAbout()`（axios `api` 实例 + TanStack Query，遵循 web/AGENTS.md 5.6）；后端二进制 version 优先，缺失时退到构建期 `METAPI_WEB_VERSION`；`commit`/`buildTime`/`goVersion` 空值/缺失折叠为 undefined。
- `about-page.tsx`：删除 `if (!info) return null`，Build Info 卡片改为三态——loading skeleton（区分「未加载」与「无此值」）、`QueryErrorBanner` 错误态（带重试）、成功渲染真值；字段缺失仍显 em-dash，绝不伪造。页面外壳（链接/依赖/许可证）不依赖网络，请求失败仍可用。
- `lib/api/system.ts` + `lib/api/types.ts`：新增 `getAbout()` 与 `AboutBuildInfoResponse` 类型。
- i18n：新增 `about.loadError`（en + zh-CN）。
- 测试：`about-page.test.tsx` 6 例——成功渲染真值 / 后端 version 优先 / 空字段 em-dash / 字段全缺 / 错误态带重试 / loading skeleton。

## 测试验证（本地实跑）

- [x] `go build ./cmd/server` + `go vet ./...` 通过
- [x] `go test ./handler/... ./internal/... ./router/... ./docs/... -count=1` 全绿（handler/admin 33.7s、docs 含文档卫生门禁）
- [x] `cd web && bun run typecheck` 通过（tsgo 0 error）
- [x] `cd web && bun run lint` 0 error（仅存量 warning）
- [x] `cd web && bun run knip` 通过
- [x] `cd web && bun run format:check` 通过
- [x] `cd web && bun run test` 全绿：**133 files / 891 tests passed**（含新增 6 例 about-page、i18n key 双向对齐门禁）
- [x] `cd web && bun run build` 通过（Rsbuild + desktop icons）
- [ ] `test-pg`（CI，涉及 API 契约，随 PR 跑）

## 自查清单

- [x] 无密钥/内部路径泄漏（gitleaks 会在 CI 检查）
- [x] 用户可见文案已走 i18n（`t()`，新增 key 双语对齐）
- [x] 行为变更已补充/更新测试（Go 5 例 + web 6 例）
- [x] 需要时更新了 `docs/`（`docs/api.md`；`docs/internal/**` 未动）

> 合并方式：Squash merge（master 受保护，禁止直接 push）。合并时请把 PR 标题改成符合 Conventional Commits 的提交信息。