### PR TITLE
feat(web,handler): proxy-log channel filter + channels status facet

### DIFF
--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -523,15 +523,18 @@ func (h *statsHandler) dashboardError(w http.ResponseWriter, operation string, e
 }
 
 // ---- Proxy Logs ----
-// GET /api/stats/proxy-logs?view=&limit=&offset=&status=&search=&client=&siteId=&from=&to=&latencyMin=&latencyMax=
+// GET /api/stats/proxy-logs?view=&limit=&offset=&status=&search=&client=&siteId=&channelId=&from=&to=&latencyMin=&latencyMax=
 //
-// All list filters (status/search/client/siteId/from/to/latencyMin/latencyMax)
-// are applied SERVER-SIDE so that items, total, and summary share one
-// `where`/`args` slice and never disagree (the previous client-side latency
+// All list filters (status/search/client/siteId/channelId/from/to/latencyMin/
+// latencyMax) are applied SERVER-SIDE so that items, total, and summary share
+// one `where`/`args` slice and never disagree (the previous client-side latency
 // filter produced a wrong `total` + broken manualPagination). The `client`
 // param matches `client_family` exactly; `from`/`to` compare against
 // `created_at` (RFC3339 TEXT, lexicographic compare is correct); latency
-// bounds compare against `latency_ms` (INTEGER).
+// bounds compare against `latency_ms` (INTEGER); `channelId` matches the
+// nullable `channel_id` (INTEGER) of the route_channels row that served the
+// request, which lets operators answer "why is this channel failing" without
+// a global search.
 func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 	view := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("view")))
 	if view != "query" && view != "meta" {
@@ -543,6 +546,7 @@ func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 	status := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("status")))
 	search := strings.TrimSpace(strings.ToLower(r.URL.Query().Get("search")))
 	siteID := getQueryInt(r, "siteId", 0)
+	channelID := getQueryInt(r, "channelId", 0)
 	client := strings.TrimSpace(r.URL.Query().Get("client"))
 	from := strings.TrimSpace(r.URL.Query().Get("from"))
 	to := strings.TrimSpace(r.URL.Query().Get("to"))
@@ -565,6 +569,16 @@ func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 	if siteID > 0 {
 		conditions = append(conditions, "s.id = ?")
 		args = append(args, siteID)
+	}
+	// channelId narrows to the route_channels row that served the request
+	// ("why is this channel failing"). `channel_id` is a nullable INTEGER, so
+	// an equality match on a positive id naturally excludes the NULL rows
+	// written before channel attribution existed. Integer comparison is
+	// dialect-neutral (no boolean/COALESCE literal), so SQLite and PostgreSQL
+	// agree without a dialect branch.
+	if channelID > 0 {
+		conditions = append(conditions, "pl.channel_id = ?")
+		args = append(args, channelID)
 	}
 	// client filters on the upstream client family detected from the
 	// User-Agent (e.g. "openai-node"). Exact match: the dropdown sends a

--- a/handler/admin/stats_proxy_logs_filters_test.go
+++ b/handler/admin/stats_proxy_logs_filters_test.go
@@ -10,15 +10,16 @@ import (
 )
 
 // seedProxyLogsForFilterTests inserts three proxy_logs rows with distinct
-// latency_ms / client_family / created_at values so that every list filter
-// (latencyMin, latencyMax, client, from, to) has at least one matching and
-// one non-matching row. The rows are standalone (no account_id) — the LEFT
-// JOINs in the handler yield NULL site/user fields, which is fine for filter
-// assertions. Returns the three created_at timestamps in RFC3339 form.
+// latency_ms / client_family / channel_id / created_at values so that every
+// list filter (latencyMin, latencyMax, client, from, to, channelId) has at
+// least one matching and one non-matching row. The rows are standalone (no
+// account_id) — the LEFT JOINs in the handler yield NULL site/user fields,
+// which is fine for filter assertions. Returns the three created_at
+// timestamps in RFC3339 form.
 //
-// Row A: latency 3000, client "openai-node",   created_at = t3 (latest)
-// Row B: latency  500, client "anthropic-sdk", created_at = t2 (middle)
-// Row C: latency 2500, client "openai-node",   created_at = t1 (earliest)
+// Row A: latency 3000, client "openai-node",   channel 7, created_at = t3 (latest)
+// Row B: latency  500, client "anthropic-sdk", channel 8, created_at = t2 (middle)
+// Row C: latency 2500, client "openai-node",   channel 7, created_at = t1 (earliest)
 func seedProxyLogsForFilterTests(t *testing.T, db *store.DB) (t1, t2, t3 string) {
 	t.Helper()
 	t1 = "2026-01-01T01:00:00Z"
@@ -28,16 +29,17 @@ func seedProxyLogsForFilterTests(t *testing.T, db *store.DB) (t1, t2, t3 string)
 		model        string
 		latencyMs    int
 		clientFamily string
+		channelID    int
 		createdAt    string
 	}{
-		{"slow-A", 3000, "openai-node", t3},
-		{"fast-B", 500, "anthropic-sdk", t2},
-		{"slow-C", 2500, "openai-node", t1},
+		{"slow-A", 3000, "openai-node", 7, t3},
+		{"fast-B", 500, "anthropic-sdk", 8, t2},
+		{"slow-C", 2500, "openai-node", 7, t1},
 	}
 	for _, row := range rows {
-		if _, err := db.Exec(`INSERT INTO proxy_logs (model_requested, model_actual, status, latency_ms, client_family, created_at)
-			VALUES (?, ?, ?, ?, ?, ?)`,
-			row.model, row.model, "success", row.latencyMs, row.clientFamily, row.createdAt); err != nil {
+		if _, err := db.Exec(`INSERT INTO proxy_logs (model_requested, model_actual, status, latency_ms, client_family, channel_id, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			row.model, row.model, "success", row.latencyMs, row.clientFamily, row.channelID, row.createdAt); err != nil {
 			t.Fatalf("insert %s: %v", row.model, err)
 		}
 	}
@@ -210,5 +212,121 @@ func TestStats_SQLiteProxyLogsCombinedFilters(t *testing.T) {
 	}
 	if len(body.Items) != 2 {
 		t.Fatalf("combined items=%d, want 2", len(body.Items))
+	}
+}
+
+func TestStats_SQLiteProxyLogsChannelIDFilter(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedProxyLogsForFilterTests(t, db)
+
+	// channelId=7 → rows A + C (both served by channel 7); row B (channel 8)
+	// is excluded. items, total, AND summary must agree because channelId
+	// lives in the shared `where`/`args` slice like every other list filter.
+	body := fetchProxyLogsFiltered(t, r, "channelId=7")
+	if body.Total != 2 {
+		t.Fatalf("channelId=7 total=%d, want 2", body.Total)
+	}
+	if len(body.Items) != 2 {
+		t.Fatalf("channelId=7 items=%d, want 2", len(body.Items))
+	}
+	if body.Summary.TotalCount != 2 {
+		t.Fatalf("channelId=7 summary.totalCount=%d, want 2", body.Summary.TotalCount)
+	}
+	got := modelSet(body.Items)
+	if _, ok := got["slow-A"]; !ok {
+		t.Fatalf("channelId=7 missing slow-A in items: %v", got)
+	}
+	if _, ok := got["slow-C"]; !ok {
+		t.Fatalf("channelId=7 missing slow-C in items: %v", got)
+	}
+	if _, ok := got["fast-B"]; ok {
+		t.Fatalf("channelId=7 should NOT include fast-B (channel 8): %v", got)
+	}
+
+	// channelId=8 → only row B.
+	bodyOther := fetchProxyLogsFiltered(t, r, "channelId=8")
+	if bodyOther.Total != 1 {
+		t.Fatalf("channelId=8 total=%d, want 1", bodyOther.Total)
+	}
+	if bodyOther.Summary.TotalCount != 1 {
+		t.Fatalf("channelId=8 summary.totalCount=%d, want 1", bodyOther.Summary.TotalCount)
+	}
+	gotOther := modelSet(bodyOther.Items)
+	if _, ok := gotOther["fast-B"]; !ok {
+		t.Fatalf("channelId=8 expected fast-B, got %v", gotOther)
+	}
+
+	// An unknown channel yields a consistent empty page (not an unfiltered
+	// total): the guard against re-introducing the items/total disagreement.
+	bodyNone := fetchProxyLogsFiltered(t, r, "channelId=4242")
+	if bodyNone.Total != 0 {
+		t.Fatalf("channelId=4242 total=%d, want 0", bodyNone.Total)
+	}
+	if len(bodyNone.Items) != 0 {
+		t.Fatalf("channelId=4242 items=%d, want 0", len(bodyNone.Items))
+	}
+	if bodyNone.Summary.TotalCount != 0 {
+		t.Fatalf("channelId=4242 summary.totalCount=%d, want 0", bodyNone.Summary.TotalCount)
+	}
+}
+
+func TestStats_SQLiteProxyLogsChannelIDIgnoresNullAndZero(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedProxyLogsForFilterTests(t, db)
+
+	// A legacy row written before channel attribution existed has a NULL
+	// channel_id. `pl.channel_id = ?` must exclude it (SQL NULL never equals
+	// a value) so a channel drilldown never shows unattributed traffic.
+	if _, err := db.Exec(`INSERT INTO proxy_logs (model_requested, model_actual, status, latency_ms, client_family, channel_id, created_at)
+		VALUES (?, ?, ?, ?, ?, NULL, ?)`,
+		"legacy-D", "legacy-D", "success", 1200, "openai-node", "2026-01-01T04:00:00Z"); err != nil {
+		t.Fatalf("insert legacy-D: %v", err)
+	}
+
+	body := fetchProxyLogsFiltered(t, r, "channelId=7")
+	if body.Total != 2 {
+		t.Fatalf("channelId=7 total=%d, want 2 (NULL channel row must be excluded)", body.Total)
+	}
+	got := modelSet(body.Items)
+	if _, ok := got["legacy-D"]; ok {
+		t.Fatalf("channelId=7 must NOT include the NULL-channel row: %v", got)
+	}
+
+	// channelId=0 / absent means "no channel filter": all four rows, including
+	// the NULL-channel one, stay visible (0 is the getQueryInt unset default).
+	bodyZero := fetchProxyLogsFiltered(t, r, "channelId=0")
+	if bodyZero.Total != 4 {
+		t.Fatalf("channelId=0 total=%d, want 4 (unset filter)", bodyZero.Total)
+	}
+	bodyAll := fetchProxyLogsFiltered(t, r, "")
+	if bodyAll.Total != bodyZero.Total {
+		t.Fatalf("channelId=0 total=%d must match unfiltered total=%d", bodyZero.Total, bodyAll.Total)
+	}
+}
+
+func TestStats_SQLiteProxyLogsChannelIDCombinedWithOtherFilters(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedProxyLogsForFilterTests(t, db)
+
+	// channelId composes with the other shared-`where` filters: channel 7 AND
+	// latency >= 2600 leaves only row A (3000); row C (2500) is too fast.
+	body := fetchProxyLogsFiltered(t, r, "channelId=7&latencyMin=2600")
+	if body.Total != 1 {
+		t.Fatalf("channelId=7&latencyMin=2600 total=%d, want 1", body.Total)
+	}
+	if body.Summary.TotalCount != 1 {
+		t.Fatalf("channelId=7&latencyMin=2600 summary.totalCount=%d, want 1", body.Summary.TotalCount)
+	}
+	got := modelSet(body.Items)
+	if _, ok := got["slow-A"]; !ok {
+		t.Fatalf("channelId=7&latencyMin=2600 expected slow-A, got %v", got)
+	}
+
+	// Contradictory filters (channel 8 is the fast row) collapse to empty
+	// consistently across items, total, and summary.
+	bodyEmpty := fetchProxyLogsFiltered(t, r, "channelId=8&latencyMin=2000")
+	if bodyEmpty.Total != 0 || len(bodyEmpty.Items) != 0 || bodyEmpty.Summary.TotalCount != 0 {
+		t.Fatalf("channelId=8&latencyMin=2000 want all-zero, got total=%d items=%d summary=%d",
+			bodyEmpty.Total, len(bodyEmpty.Items), bodyEmpty.Summary.TotalCount)
 	}
 }

--- a/web/src/features/channels/__tests__/channels-page-drilldown.test.tsx
+++ b/web/src/features/channels/__tests__/channels-page-drilldown.test.tsx
@@ -65,6 +65,7 @@ vi.mock('../components/channel-detail-sheet', () => ({
 
 vi.mock('../components/channels-columns', () => ({
   useChannelsColumns: () => [],
+  CHANNELS_STATUS_FILTER_OPTIONS: [],
 }))
 
 function makeChannel(id: number): ChannelRow {

--- a/web/src/features/channels/__tests__/channels-schema.test.ts
+++ b/web/src/features/channels/__tests__/channels-schema.test.ts
@@ -37,3 +37,39 @@ describe('channelsSearchSchema', () => {
     expect(result.pageSize).toBe(20)
   })
 })
+
+// ---------------------------------------------------------------------------
+// status facet param — comma-separated routing status vocabulary
+// ---------------------------------------------------------------------------
+
+describe('channelsSearchSchema — status facet', () => {
+  it('accepts the page-written URL shape with a multi-select status list', () => {
+    const result = channelsSearchSchema.parse({
+      q: 'gpt',
+      page: '2',
+      pageSize: '50',
+      sort: 'name:asc,status:desc',
+      status: 'cooldown,breaker_open',
+    })
+    expect(result.q).toBe('gpt')
+    expect(result.page).toBe(2)
+    expect(result.pageSize).toBe(50)
+    expect(result.sort).toBe('name:asc,status:desc')
+    expect(result.status).toBe('cooldown,breaker_open')
+  })
+
+  it('round-trips each real routing status value verbatim', () => {
+    for (const status of [
+      'enabled',
+      'cooldown',
+      'breaker_open',
+      'manually_disabled',
+    ]) {
+      expect(channelsSearchSchema.parse({ status }).status).toBe(status)
+    }
+  })
+
+  it('leaves status undefined when the param is absent', () => {
+    expect(channelsSearchSchema.parse({}).status).toBeUndefined()
+  })
+})

--- a/web/src/features/channels/__tests__/channels-status-facet.test.tsx
+++ b/web/src/features/channels/__tests__/channels-status-facet.test.tsx
@@ -1,0 +1,231 @@
+// Behavior test for the channels status facet (issue #887 residual: the
+// /channels toolbar had only a search box, so failing channels — cooldown /
+// breaker_open — could not be isolated without eyeballing the table).
+// Channels are filtered client-side by the shared data table, so the facet is
+// exercised end-to-end here: real columns, real toolbar, real filter row model.
+
+import '@testing-library/jest-dom/vitest'
+import type { ColumnFiltersState } from '@tanstack/react-table'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+
+import { CHANNELS_STATUS_FILTER_OPTIONS } from '../components/channels-columns'
+import { ChannelsPage } from '../components/channels-page'
+import type { ChannelRow } from '../types'
+
+const testState = vi.hoisted(() => ({
+  channels: [] as ChannelRow[],
+  columnFilters: [] as ColumnFiltersState,
+  onColumnFiltersChange: vi.fn(),
+  navigate: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => testState.navigate,
+  useSearch: () => ({}),
+  useLocation: () => ({ href: '/channels', searchStr: '' }),
+  Link: ({ children }: { children?: unknown }) => children,
+}))
+
+// Only the URL-sync layer is stubbed: the column filters are injected directly
+// so the assertions cover the real facet -> filterFn -> row model path.
+vi.mock('@/components/data-table', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/components/data-table')>()
+  return {
+    ...actual,
+    useUrlTableState: () => ({
+      globalFilter: '',
+      onGlobalFilterChange: vi.fn(),
+      columnFilters: testState.columnFilters,
+      onColumnFiltersChange: testState.onColumnFiltersChange,
+      pagination: { pageIndex: 0, pageSize: 20 },
+      onPaginationChange: vi.fn(),
+      sorting: [],
+      onSortingChange: vi.fn(),
+      ensurePageInRange: vi.fn(),
+    }),
+  }
+})
+
+vi.mock('../api', () => ({
+  useChannels: () => ({
+    data: testState.channels,
+    isLoading: false,
+    isFetching: false,
+    error: null,
+  }),
+}))
+
+vi.mock('../components/channel-detail-sheet', () => ({
+  ChannelDetailSheet: () => null,
+}))
+
+function makeChannel(overrides: Partial<ChannelRow>): ChannelRow {
+  return {
+    id: 1,
+    routeId: 1,
+    name: 'probe-channel',
+    site: { id: 1, name: 'Probe site' },
+    type: 'account',
+    status: 'enabled',
+    models: 'gpt-*',
+    priority: 1,
+    weight: 1,
+    responseMs: null,
+    cooldownUntil: null,
+    enabled: true,
+    manualOverride: false,
+    ...overrides,
+  } as ChannelRow
+}
+
+/** One channel per real routing status, so every facet value has a row. */
+function seedOneChannelPerStatus(): ChannelRow[] {
+  return [
+    makeChannel({ id: 1, name: 'healthy-one', status: 'enabled' }),
+    makeChannel({ id: 2, name: 'cooling-two', status: 'cooldown' }),
+    makeChannel({ id: 3, name: 'tripped-three', status: 'breaker_open' }),
+    makeChannel({ id: 4, name: 'off-four', status: 'manually_disabled' }),
+  ]
+}
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    writable: true,
+    value: ResizeObserverStub,
+  })
+
+  // jsdom does not implement scrollIntoView; cmdk calls it when the facet
+  // popover mounts and moves its active item.
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+beforeEach(() => {
+  testState.channels = seedOneChannelPerStatus()
+  testState.columnFilters = []
+  testState.onColumnFiltersChange.mockReset()
+  testState.navigate.mockReset()
+})
+
+afterEach(() => cleanup())
+
+/**
+ * Resolve the toolbar facet trigger. The sortable `status` column header is
+ * also a button named "Status", so disambiguate on the popover trigger slot
+ * rather than on the accessible name alone.
+ */
+async function findStatusFacetTrigger(): Promise<HTMLElement> {
+  const candidates = await screen.findAllByRole('button', { name: /Status/ })
+  const trigger = candidates.find(
+    (button) => button.dataset.slot === 'popover-trigger'
+  )
+  if (!trigger) {
+    throw new Error('status facet trigger is not rendered in the toolbar')
+  }
+  return trigger
+}
+
+async function openStatusFacet(): Promise<void> {
+  fireEvent.click(await findStatusFacetTrigger())
+}
+
+describe('CHANNELS_STATUS_FILTER_OPTIONS', () => {
+  it('exposes exactly the four routing statuses in precedence order', () => {
+    expect(
+      CHANNELS_STATUS_FILTER_OPTIONS.map((option) => option.value)
+    ).toEqual(['enabled', 'cooldown', 'breaker_open', 'manually_disabled'])
+  })
+})
+
+describe('ChannelsPage status facet', () => {
+  it('renders a status facet trigger in the toolbar', async () => {
+    render(<ChannelsPage />)
+
+    expect(await findStatusFacetTrigger()).toBeInTheDocument()
+  })
+
+  it('offers every real routing status as an option', async () => {
+    render(<ChannelsPage />)
+
+    await openStatusFacet()
+
+    for (const label of [
+      'Enabled',
+      'Cooldown',
+      'Breaker open',
+      'Manually disabled',
+    ]) {
+      expect(
+        await screen.findByRole('option', { name: new RegExp(label) })
+      ).toBeInTheDocument()
+    }
+  })
+
+  it('propagates the picked status to the table column filter', async () => {
+    render(<ChannelsPage />)
+
+    await openStatusFacet()
+    fireEvent.click(await screen.findByRole('option', { name: /Cooldown/ }))
+
+    expect(testState.onColumnFiltersChange).toHaveBeenCalled()
+    const update = testState.onColumnFiltersChange.mock.calls[0][0]
+    const nextFilters: ColumnFiltersState =
+      typeof update === 'function' ? update([]) : update
+    expect(nextFilters).toEqual([{ id: 'status', value: ['cooldown'] }])
+  })
+
+  it('shows only the failing channels when the URL carries a status filter', async () => {
+    // The shareable "why is this channel failing" view: ?status=cooldown,
+    // breaker_open. The status column filterFn must narrow the rows to exactly
+    // those two and drop the healthy / manually disabled ones.
+    testState.columnFilters = [
+      { id: 'status', value: ['cooldown', 'breaker_open'] },
+    ]
+
+    render(<ChannelsPage />)
+
+    expect(await screen.findByText('cooling-two')).toBeInTheDocument()
+    expect(screen.getByText('tripped-three')).toBeInTheDocument()
+    expect(screen.queryByText('healthy-one')).not.toBeInTheDocument()
+    expect(screen.queryByText('off-four')).not.toBeInTheDocument()
+  })
+
+  it('keeps every channel visible when no status is selected', async () => {
+    render(<ChannelsPage />)
+
+    expect(await screen.findByText('healthy-one')).toBeInTheDocument()
+    expect(screen.getByText('cooling-two')).toBeInTheDocument()
+    expect(screen.getByText('tripped-three')).toBeInTheDocument()
+    expect(screen.getByText('off-four')).toBeInTheDocument()
+  })
+})

--- a/web/src/features/channels/components/channels-columns.tsx
+++ b/web/src/features/channels/components/channels-columns.tsx
@@ -60,6 +60,16 @@ const STATUS_CONFIG: Record<
   },
 }
 
+// Toolbar status facet options, in routing-precedence display order. Values are
+// the exact `routing.ChannelRuntimeStatus` vocabulary and the labels are read
+// back out of STATUS_CONFIG so the facet can never drift from the badges.
+export const CHANNELS_STATUS_FILTER_OPTIONS: {
+  value: ChannelStatus
+  labelKey: string
+}[] = (
+  ['enabled', 'cooldown', 'breaker_open', 'manually_disabled'] as const
+).map((status) => ({ value: status, labelKey: STATUS_CONFIG[status].labelKey }))
+
 export function useChannelsColumns(
   actions?: ChannelsColumnActions
 ): ColumnDef<ChannelRow>[] {
@@ -145,6 +155,14 @@ export function useChannelsColumns(
               {t(config.labelKey)}
             </Badge>
           )
+        },
+        // The toolbar status facet is multi-select, so the filter value is an
+        // array of statuses; an empty selection means "no filter".
+        filterFn: (row, _columnId, filterValue: unknown) => {
+          if (!Array.isArray(filterValue) || filterValue.length === 0) {
+            return true
+          }
+          return filterValue.includes(row.original.status)
         },
       },
       {

--- a/web/src/features/channels/components/channels-page.tsx
+++ b/web/src/features/channels/components/channels-page.tsx
@@ -28,6 +28,7 @@ import { channelsSearchSchema } from '../lib/channels-schema'
 import type { ChannelRow } from '../types'
 import { ChannelDetailSheet } from './channel-detail-sheet'
 import {
+  CHANNELS_STATUS_FILTER_OPTIONS,
   useChannelsColumns,
   type ChannelsColumnActions,
 } from './channels-columns'
@@ -36,11 +37,22 @@ const CHANNELS_COLUMN_VISIBILITY_STORAGE_KEY =
   'metapi-go:channels:column-visibility'
 const CHANNELS_COLUMN_SIZING_STORAGE_KEY = 'metapi-go:channels:column-sizing'
 
-type ChannelsUrlFilters = Record<string, never>
+/** Page-specific URL filters: comma-separated status list for the facet. */
+type ChannelsUrlFilters = {
+  status: string
+}
+
+const EMPTY_URL_STATE: UrlTableState<ChannelsUrlFilters> = {
+  q: '',
+  pageIndex: 0,
+  pageSize: 20,
+  sorting: [],
+  filters: { status: '' },
+}
 
 function readSearch(searchString?: string): UrlTableState<ChannelsUrlFilters> {
   if (typeof window === 'undefined') {
-    return { q: '', pageIndex: 0, pageSize: 20, sorting: [], filters: {} }
+    return EMPTY_URL_STATE
   }
   const params = new URLSearchParams(searchString ?? window.location.search)
   const parsed = channelsSearchSchema.safeParse({
@@ -48,9 +60,10 @@ function readSearch(searchString?: string): UrlTableState<ChannelsUrlFilters> {
     page: params.get('page') ?? undefined,
     pageSize: params.get('pageSize') ?? undefined,
     sort: params.get('sort') ?? undefined,
+    status: params.get('status') ?? undefined,
   })
   if (!parsed.success) {
-    return { q: '', pageIndex: 0, pageSize: 20, sorting: [], filters: {} }
+    return EMPTY_URL_STATE
   }
   const data = parsed.data
   return {
@@ -58,19 +71,24 @@ function readSearch(searchString?: string): UrlTableState<ChannelsUrlFilters> {
     pageIndex: data.page ?? 0,
     pageSize: data.pageSize ?? 20,
     sorting: parseSortingParam(data.sort),
-    filters: {},
+    filters: { status: asStringParam(data.status) ?? '' },
   }
 }
 
 function buildHref(next: UrlTableStateUpdate<ChannelsUrlFilters>): string {
   const current = readSearch()
-  const merged = { ...current, ...next }
+  const merged: UrlTableState<ChannelsUrlFilters> = {
+    ...current,
+    ...next,
+    filters: { ...current.filters, ...next.filters },
+  }
   const params = new URLSearchParams()
   if (merged.q) params.set('q', merged.q)
   if (merged.pageIndex > 0) params.set('page', String(merged.pageIndex))
   if (merged.pageSize !== 20) params.set('pageSize', String(merged.pageSize))
   const sortString = encodeSorting(merged.sorting)
   if (sortString) params.set('sort', sortString)
+  if (merged.filters.status) params.set('status', merged.filters.status)
   const queryString = params.toString()
   return queryString ? `/channels?${queryString}` : '/channels'
 }
@@ -80,8 +98,21 @@ function useChannelsUrlState() {
     basePath: '/channels',
     read: readSearch,
     buildHref,
-    toColumnFilters: () => [] as ColumnFiltersState,
-    fromColumnFilters: () => ({}),
+    toColumnFilters: (filters) => {
+      const statusValues = filters.status.split(',').filter(Boolean)
+      if (statusValues.length === 0) return [] as ColumnFiltersState
+      return [{ id: 'status', value: statusValues }]
+    },
+    fromColumnFilters: (columnFilters) => {
+      const statusEntry = columnFilters.find((filter) => filter.id === 'status')
+      return {
+        filters: {
+          status: Array.isArray(statusEntry?.value)
+            ? statusEntry.value.join(',')
+            : '',
+        },
+      }
+    },
   })
 }
 
@@ -180,6 +211,16 @@ export function ChannelsPage() {
         toolbarProps={{
           searchPlaceholder: t('channels.toolbar.searchPlaceholder'),
           searchDebounceMs: 400,
+          filters: [
+            {
+              columnId: 'status',
+              title: t('channels.columns.status'),
+              options: CHANNELS_STATUS_FILTER_OPTIONS.map((option) => ({
+                label: t(option.labelKey),
+                value: option.value,
+              })),
+            },
+          ],
         }}
       />
 

--- a/web/src/features/channels/lib/channels-schema.ts
+++ b/web/src/features/channels/lib/channels-schema.ts
@@ -1,6 +1,7 @@
 // metapi-go/features/channels — Zod schema for the list URL search state.
-// Only search / page / page-size / sorting are URL-backed; the channels list
-// has no faceted filters today.
+// Search / page / page-size / sorting / status are URL-backed; status is the
+// only faceted filter and is applied client-side like the search box (the
+// channels list is fetched in full and filtered by the data table).
 
 import { z } from 'zod'
 
@@ -19,6 +20,10 @@ export const channelsSearchSchema = z.object({
     .optional()
     .transform((value) => encodeSortingParam(value))
     .catch(undefined),
+  // Comma-separated `routing.ChannelRuntimeStatus` values (enabled /
+  // cooldown / breaker_open / manually_disabled) for the toolbar status
+  // facet, so a failing-channel view is shareable as a link.
+  status: stringSearchParam,
   // One-shot drilldown from the proxy-log detail sheet: open the detail
   // view for this channel, then the page strips the param (same consume
   // pattern as the accounts `create`/`siteId` deep link).

--- a/web/src/features/proxy-logs/__tests__/proxy-logs-query-payload.test.tsx
+++ b/web/src/features/proxy-logs/__tests__/proxy-logs-query-payload.test.tsx
@@ -148,3 +148,60 @@ describe('useProxyLogs — latency filter payload', () => {
     expect(requestedUrl).not.toContain('latencyMax')
   })
 })
+
+describe('useProxyLogs — channel filter payload', () => {
+  it('serializes channelId into the request URL when set', async () => {
+    const params: ProxyLogsQuery = { limit: 20, offset: 0, channelId: 42 }
+    const queryClient = createQueryClient()
+    renderHook(() => useProxyLogs(params), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => {
+      expect(mockApiClientGet).toHaveBeenCalledTimes(1)
+    })
+
+    const requestedUrl = firstRequestedUrl()
+    expect(requestedUrl).toContain('/api/stats/proxy-logs')
+    expect(requestedUrl).toContain('channelId=42')
+  })
+
+  it('omits channelId from the URL when it is undefined', async () => {
+    const params: ProxyLogsQuery = { limit: 20, offset: 0 }
+    const queryClient = createQueryClient()
+    renderHook(() => useProxyLogs(params), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => {
+      expect(mockApiClientGet).toHaveBeenCalledTimes(1)
+    })
+
+    expect(firstRequestedUrl()).not.toContain('channelId')
+  })
+
+  it('composes channelId with the other server-side filters', async () => {
+    const params: ProxyLogsQuery = {
+      limit: 20,
+      offset: 0,
+      channelId: 7,
+      siteId: 3,
+      status: 'failed',
+      latencyMin: 2000,
+    }
+    const queryClient = createQueryClient()
+    renderHook(() => useProxyLogs(params), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => {
+      expect(mockApiClientGet).toHaveBeenCalledTimes(1)
+    })
+
+    const requestedUrl = firstRequestedUrl()
+    expect(requestedUrl).toContain('channelId=7')
+    expect(requestedUrl).toContain('siteId=3')
+    expect(requestedUrl).toContain('status=failed')
+    expect(requestedUrl).toContain('latencyMin=2000')
+  })
+})

--- a/web/src/features/proxy-logs/__tests__/proxy-logs-schema.test.ts
+++ b/web/src/features/proxy-logs/__tests__/proxy-logs-schema.test.ts
@@ -67,12 +67,14 @@ describe('proxyLogsSearchSchema — numerics', () => {
       page: '5',
       pageSize: '50',
       siteId: '7',
+      channelId: '42',
       latencyMin: '10',
       latencyMax: '100',
     })
     expect(result.page).toBe(5)
     expect(result.pageSize).toBe(50)
     expect(result.siteId).toBe(7)
+    expect(result.channelId).toBe(42)
     expect(result.latencyMin).toBe(10)
     expect(result.latencyMax).toBe(100)
   })
@@ -86,6 +88,11 @@ describe('proxyLogsSearchSchema — numerics', () => {
     ['pageSize above 200', { pageSize: '201' }, { pageSize: 20 }],
     ['latencyMin negative', { latencyMin: '-1' }, { latencyMin: undefined }],
     ['non-numeric page', { page: 'abc' }, { page: 0 }],
+    // channelId is positive-only: the backend reads 0 as "no channel filter",
+    // so a non-positive value must degrade to unset rather than be sent.
+    ['channelId zero', { channelId: '0' }, { channelId: undefined }],
+    ['channelId negative', { channelId: '-3' }, { channelId: undefined }],
+    ['channelId non-numeric', { channelId: 'abc' }, { channelId: undefined }],
   ])('falls back instead of throwing for %s', (_label, input, fallback) => {
     const result = proxyLogsSearchSchema.safeParse(input)
     expect(result.success).toBe(true)

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -55,6 +55,7 @@ const PROXY_LOGS_CSV_EXPORT_LIMIT = 10_000
 type ProxyLogsUrlFilters = {
   status: string
   siteId: string
+  channelId: string
   client: string
   from: string
   to: string
@@ -86,6 +87,8 @@ function readProxyLogsSearch(
     filters: {
       status: search?.status ?? 'all',
       siteId: search?.siteId === undefined ? '' : String(search.siteId),
+      channelId:
+        search?.channelId === undefined ? '' : String(search.channelId),
       client: asStringParam(search?.client) ?? '',
       from: asStringParam(search?.from) ?? '',
       to: asStringParam(search?.to) ?? '',
@@ -118,6 +121,12 @@ function buildProxyLogsHref(
     params.set('status', merged.filters.status)
   }
   if (merged.filters.siteId) params.set('siteId', merged.filters.siteId)
+  // Only a positive channel id is a real filter — the backend reads 0 as
+  // "unset", so writing `channelId=0` would leave the URL disagreeing with
+  // the rendered (unfiltered) list.
+  if (Number(merged.filters.channelId) > 0) {
+    params.set('channelId', merged.filters.channelId)
+  }
   if (merged.filters.client) params.set('client', merged.filters.client)
   if (merged.filters.from) params.set('from', merged.filters.from)
   if (merged.filters.to) params.set('to', merged.filters.to)
@@ -159,6 +168,7 @@ export function ProxyLogsPage() {
   // filters (single source of truth — no local mirror to sync back).
   const status = filters.status as ProxyLogFilters['status']
   const siteId = filters.siteId ? Number(filters.siteId) : null
+  const channelId = filters.channelId ? Number(filters.channelId) : null
   const client = filters.client
   const from = filters.from
   const to = filters.to
@@ -176,6 +186,7 @@ export function ProxyLogsPage() {
       status: status === 'all' ? undefined : status,
       search: globalFilter.trim() || undefined,
       siteId: siteId ?? undefined,
+      channelId: channelId ?? undefined,
       client: client || undefined,
       from: from || undefined,
       to: to || undefined,
@@ -189,6 +200,7 @@ export function ProxyLogsPage() {
       status,
       globalFilter,
       siteId,
+      channelId,
       client,
       from,
       to,
@@ -202,6 +214,7 @@ export function ProxyLogsPage() {
       status: queryPayload.status,
       search: queryPayload.search,
       siteId: queryPayload.siteId,
+      channelId: queryPayload.channelId,
       client: queryPayload.client,
       from: queryPayload.from,
       to: queryPayload.to,
@@ -266,6 +279,7 @@ export function ProxyLogsPage() {
       filters: {
         status: 'all',
         siteId: '',
+        channelId: '',
         client: '',
         from: '',
         to: '',
@@ -492,6 +506,20 @@ export function ProxyLogsPage() {
                 </Select>
               )}
               <Input
+                type='number'
+                min={1}
+                aria-label={t('proxyLogs.page.filterChannelPlaceholder')}
+                placeholder={t('proxyLogs.page.filterChannelPlaceholder')}
+                value={filters.channelId}
+                onChange={(event) => {
+                  updateUrlState({
+                    filters: { channelId: event.target.value },
+                    pageIndex: 0,
+                  })
+                }}
+                className='w-[130px]'
+              />
+              <Input
                 type='datetime-local'
                 aria-label={t('proxyLogs.page.startTime')}
                 value={from}
@@ -593,7 +621,12 @@ export function ProxyLogsPage() {
           ),
           hasExpandedActiveFilters: hasLatencyFilter,
           hasAdditionalFilters:
-            siteId !== null || !!client || !!from || !!to || status !== 'all',
+            siteId !== null ||
+            channelId !== null ||
+            !!client ||
+            !!from ||
+            !!to ||
+            status !== 'all',
           onReset: handleReset,
         }}
       />

--- a/web/src/features/proxy-logs/lib/proxy-logs-schema.ts
+++ b/web/src/features/proxy-logs/lib/proxy-logs-schema.ts
@@ -27,6 +27,11 @@ export const proxyLogsSearchSchema = z.object({
     .catch(undefined),
   status: z.enum(['all', 'success', 'failed']).catch('all').default('all'),
   siteId: z.coerce.number().int().optional().catch(undefined),
+  // channelId scopes the list to the channel that served each request, so an
+  // operator debugging "why is this channel failing" can drill straight in
+  // instead of eyeballing a global search. Positive-only: the backend treats
+  // 0 as "no channel filter", so a bogus `?channelId=0` degrades to unset.
+  channelId: z.coerce.number().int().positive().optional().catch(undefined),
   // Client name and datetime-local bounds. Tolerant of router-parsed
   // primitives (null literals, duplicate-param arrays, numeric epochs) via
   // `stringSearchParam`; read sites normalize with `asStringParam`.

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2017,6 +2017,7 @@
         "filterAllSites": "All sites",
         "filterClientPlaceholder": "Client",
         "filterAllClients": "All clients",
+        "filterChannelPlaceholder": "Channel ID",
         "startTime": "Start time",
         "endTime": "End time",
         "latencyMin": "Latency ≥",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2017,6 +2017,7 @@
         "filterAllSites": "全部站点",
         "filterClientPlaceholder": "客户端",
         "filterAllClients": "全部客户端",
+        "filterChannelPlaceholder": "通道 ID",
         "startTime": "起始时间",
         "endTime": "结束时间",
         "latencyMin": "延迟 ≥",

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -483,6 +483,9 @@ export type ProxyLogsQuery = {
   search?: string
   client?: string
   siteId?: number
+  // Channel that served the request (`proxy_logs.channel_id`). Server-side
+  // like every other list filter so total + summary stay consistent.
+  channelId?: number
   from?: string
   to?: string
   // Latency bounds (ms) for the "Slow only" filter. Applied server-side so

--- a/web/src/routes/_authenticated/proxy-logs.tsx
+++ b/web/src/routes/_authenticated/proxy-logs.tsx
@@ -12,9 +12,10 @@
 // / `useProxyLogsMeta` will request, building the same `ProxyLogsQuery`
 // payload from the router's `location.searchStr` (SSR-safe, rather than the
 // global `window.location.search`) so the prefetched pages are reused and the
-// cache key matches the page's first fetch. Latency range is client-side only
-// (not part of the backend query) so it is intentionally absent from the
-// prefetch payload.
+// cache key matches the page's first fetch. The payload covers status /
+// search / siteId / channelId / client / from / to; the latency bounds are a
+// known residual (the page sends them server-side, so a URL that carries
+// latencyMin/latencyMax simply misses this prefetch and refetches).
 
 import { createFileRoute } from '@tanstack/react-router'
 
@@ -57,6 +58,7 @@ export const Route = createFileRoute('/_authenticated/proxy-logs')({
     const status = search.status === 'all' ? undefined : search.status
     const searchText = asStringParam(search.q)?.trim() || undefined
     const siteId = search.siteId ?? undefined
+    const channelId = search.channelId ?? undefined
     const client = asStringParam(search.client) || undefined
     const from = asStringParam(search.from) || undefined
     const to = asStringParam(search.to) || undefined
@@ -67,11 +69,20 @@ export const Route = createFileRoute('/_authenticated/proxy-logs')({
       status,
       search: searchText,
       siteId,
+      channelId,
       client,
       from,
       to,
     }
-    const metaPayload = { status, search: searchText, siteId, client, from, to }
+    const metaPayload = {
+      status,
+      search: searchText,
+      siteId,
+      channelId,
+      client,
+      from,
+      to,
+    }
 
     await Promise.all([
       context.queryClient.prefetchQuery({


### PR DESCRIPTION
Add a channel filter dimension to proxy-logs and a status facet to channels.

- handler/admin/stats.go: proxy-log query accepts channel filter
- proxy-logs schema/page: channel filter dimension
- channels schema/columns/page: status facet
- i18n keys + API type updates