### PR TITLE
fix(api): Wave 4 C 线 — 契约回归复验 + 测试补强

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # Admin API Reference
 
-**Last updated**: 2026-08-21
+**Last updated**: 2026-08-22
 
 Base URL: `http://localhost:4000/api`
 
@@ -12,23 +12,40 @@ Authorization: Bearer <AUTH_TOKEN>
 
 ## Response Format
 
-### Success
+All responses are JSON (`Content-Type: application/json`) with camelCase
+field names. There is no single global envelope; the shape depends on the
+endpoint family (the frontend consumes all of the shapes below):
+
+### Success (2xx)
+
+- **Resource lists (legacy shape)**: a bare JSON array of objects
+  (`GET /api/sites`, `GET /api/routes` without `?page`, `GET /api/account-tokens`).
+- **Paginated lists**: `{ "items": [...], "total": N, "page": N, "pageSize": N }`
+  (`GET /api/channels`, `GET /api/accounts?page=`, `GET /api/routes?page=`,
+  `GET /api/downstream-keys?page=`, `GET /api/checkin/logs`).
+  `total` is the true filtered row count, not the page size.
+- **Snapshot lists**: `{ "generatedAt": "...", "accounts": [...], "sites": [...] }`
+  (`GET /api/accounts` without `?page`).
+- **Operation results**: `{ "success": true, ... }` with operation-specific
+  fields (`POST /api/routes/rebuild`, downstream-keys summary, batch
+  endpoints). Batch endpoints report partial failures per item.
+
+### Error (non-2xx)
+
+Failures always use a non-2xx status code (never HTTP 200 with an error
+body). The unified error body is:
 
 ```json
 {
-  "success": true,
-  "data": { ... }
+  "error": "Error description",
+  "request_id": "optional correlation id"
 }
 ```
 
-### Error
-
-```json
-{
-  "success": false,
-  "message": "Error description"
-}
-```
+`request_id` is additive and omitted when no request ID is present. A few
+legacy endpoints (some batch/500 paths under `/api/accounts`, sites import)
+still answer with the TS-era `{ "message": "Error description" }` shape; the
+frontend reads both keys, so both forms surface identically.
 
 HTTP status codes: 200 (OK), 201 (Created), 202 (Accepted), 400 (Bad Request), 401 (Unauthorized), 404 (Not Found), 500 (Internal Server Error).
 
@@ -50,9 +67,11 @@ Returns the admin dashboard snapshot.
 
 ### GET /api/stats/proxy-logs
 
-Query proxy request logs.
+Query proxy request logs (server-side filtered and paginated).
 
-**Query params**: `page`, `limit`, `status`, `model`, `client`, `from`, `to`
+**Query params**: `view` (`full`|`query`|`meta`, default `full`), `limit` (1–100, default 50), `offset` (≥0), `status` (`success`|`failed`), `search` (substring on requested/actual model), `client` (exact client family), `siteId`, `channelId`, `from`/`to` (RFC3339 bounds on createdAt), `latencyMin`/`latencyMax` (ms bounds).
+
+**Response** (`view=query`/`full`): `{ items, total, page, pageSize }` where `total` respects all active filters; `view=meta`/`full` adds `summary` (totalCount/successCount/failedCount/totalCost/totalTokensAll), `sites`, `clientOptions`.
 
 ### GET /api/stats/proxy-logs/:id
 

--- a/handler/admin/contract_envelope_test.go
+++ b/handler/admin/contract_envelope_test.go
@@ -1,0 +1,264 @@
+package admin
+
+// Wave 4 contract audit — envelope consistency.
+//
+// The admin API has two response families and both are pinned here:
+//
+//  1. Success responses: 2xx + application/json + camelCase keys. Three
+//     list shapes coexist by design (the status quo the frontend consumes):
+//     bare array (/api/sites, /api/routes, /api/account-tokens),
+//     {items,total,page,pageSize} (/api/channels),
+//     and {success,...} envelopes (/api/downstream-keys).
+//  2. Error responses: non-2xx with the unified camelCase {"error":"..."}
+//     body (shared.WriteError). A few TS-era paths still answer non-2xx with
+//     a legacy {"message":"..."} body; the frontend http-client reads both
+//     (resolveResponseMessage), so that shape is pinned as-is rather than
+//     changed.
+//
+// snake_case keys must never leak into success payloads. The one documented
+// exception is the additive "request_id" correlation field on unified error
+// bodies (handler/shared/errors.go).
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// snakeCaseKeyAllowlist lists JSON keys that are intentionally snake_case.
+// request_id is the documented correlation field on unified error bodies.
+var snakeCaseKeyAllowlist = map[string]bool{
+	"request_id": true,
+}
+
+// assertNoSnakeCaseKeys walks decoded JSON and fails on any object key that
+// still carries an underscore (raw DB column leak), except the allowlist.
+func assertNoSnakeCaseKeys(t *testing.T, value any, path string) {
+	t.Helper()
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			childPath := key
+			if path != "" {
+				childPath = path + "." + key
+			}
+			if strings.Contains(key, "_") && !snakeCaseKeyAllowlist[key] {
+				t.Errorf("snake_case key %q leaked into response (at %q)", key, childPath)
+			}
+			assertNoSnakeCaseKeys(t, child, childPath)
+		}
+	case []any:
+		for index, child := range typed {
+			assertNoSnakeCaseKeys(t, child, path+"["+itoa(int64(index))+"]")
+		}
+	}
+}
+
+// assertSuccessEnvelope verifies a success response: 2xx status, JSON
+// content type, decodable body, and no snake_case key leaks. Returns the
+// decoded value for shape assertions.
+func assertSuccessEnvelope(t *testing.T, resp *httptest.ResponseRecorder) any {
+	t.Helper()
+	if resp.Code < 200 || resp.Code > 299 {
+		t.Fatalf("status = %d, want 2xx; body=%s", resp.Code, resp.Body.String())
+	}
+	if contentType := resp.Header().Get("Content-Type"); !strings.HasPrefix(contentType, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", contentType)
+	}
+	var decoded any
+	if err := json.Unmarshal(resp.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("success body is not valid JSON: %v; body=%s", err, resp.Body.String())
+	}
+	assertNoSnakeCaseKeys(t, decoded, "")
+	return decoded
+}
+
+// assertUnifiedErrorEnvelope verifies the unified admin error contract:
+// non-2xx status + {"error": non-empty string}, never success=true.
+func assertUnifiedErrorEnvelope(t *testing.T, resp *httptest.ResponseRecorder) {
+	t.Helper()
+	if resp.Code < 400 {
+		t.Fatalf("status = %d, want non-2xx for failure; body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("error body is not valid JSON: %v; raw=%s", err, resp.Body.String())
+	}
+	message, ok := body["error"].(string)
+	if !ok || strings.TrimSpace(message) == "" {
+		t.Fatalf("expected non-empty \"error\" string in unified error body, got %#v", body)
+	}
+	if success, has := body["success"]; has && success == true {
+		t.Fatalf("error body must not claim success=true: %#v", body)
+	}
+}
+
+// ---- Success envelopes: bare-array list endpoints ----
+
+func TestEnvelope_SitesList_BareArrayCamelCase(t *testing.T) {
+	_, r := setupSitesTest(t)
+	newSiteFixture(t, r, "EnvelopeSite", "https://api.openai.com")
+
+	decoded := assertSuccessEnvelope(t, doGet(t, r, "/api/sites"))
+	sites, ok := decoded.([]any)
+	if !ok {
+		t.Fatalf("GET /api/sites = %T, want bare JSON array", decoded)
+	}
+	if len(sites) != 1 {
+		t.Fatalf("sites = %d, want 1", len(sites))
+	}
+}
+
+func TestEnvelope_RoutesList_BareArrayCamelCase(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	seedRouteChannelRefs(t, db)
+
+	decoded := assertSuccessEnvelope(t, doGet(t, r, "/api/routes"))
+	routes, ok := decoded.([]any)
+	if !ok {
+		t.Fatalf("GET /api/routes (no page) = %T, want bare JSON array", decoded)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("routes = %d, want 1", len(routes))
+	}
+}
+
+func TestEnvelope_AccountTokensList_BareArrayCamelCase(t *testing.T) {
+	db, r := setupTokensTest(t)
+	_, accountID := tokenFixture(t, db, r)
+	createTokenFixture(t, db, accountID, "envelope-token", "sk-env-123456", "", true, true)
+
+	decoded := assertSuccessEnvelope(t, doGet(t, r, "/api/account-tokens"))
+	tokens, ok := decoded.([]any)
+	if !ok {
+		t.Fatalf("GET /api/account-tokens = %T, want bare JSON array", decoded)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("tokens = %d, want 1", len(tokens))
+	}
+}
+
+// ---- Success envelopes: paged-envelope list endpoints ----
+
+func TestEnvelope_ChannelsList_PagedEnvelope(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+	if _, err := db.Exec(
+		`INSERT INTO route_channels
+			(route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+		 VALUES (?, ?, ?, 'gpt-4o', 0, 10, 1, 0)`,
+		routeID, accountID, tokenID,
+	); err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+
+	decoded := assertSuccessEnvelope(t, doGet(t, r, "/api/channels"))
+	envelope, ok := decoded.(map[string]any)
+	if !ok {
+		t.Fatalf("GET /api/channels = %T, want object envelope", decoded)
+	}
+	for _, key := range []string{"items", "total", "page", "pageSize"} {
+		if _, present := envelope[key]; !present {
+			t.Fatalf("channels envelope missing key %q; got %#v", key, envelope)
+		}
+	}
+}
+
+func TestEnvelope_AccountsSnapshot_GeneratedAtAccountsSites(t *testing.T) {
+	_, r := setupAccountsPaginationTest(t)
+
+	decoded := assertSuccessEnvelope(t, doGet(t, r, "/api/accounts?refresh=true"))
+	snapshot, ok := decoded.(map[string]any)
+	if !ok {
+		t.Fatalf("GET /api/accounts = %T, want snapshot object", decoded)
+	}
+	for _, key := range []string{"generatedAt", "accounts", "sites"} {
+		if _, present := snapshot[key]; !present {
+			t.Fatalf("accounts snapshot missing key %q; got keys %#v", key, mapKeys(snapshot))
+		}
+	}
+}
+
+// ---- Success envelopes: {success,...} family ----
+
+func TestEnvelope_DownstreamKeysList_SuccessEnvelope(t *testing.T) {
+	db, r := setupDownstreamKeysTest(t)
+	seedDownstreamKeyFixture(t, db, "envelope-key", true)
+
+	decoded := assertSuccessEnvelope(t, doGet(t, r, "/api/downstream-keys"))
+	envelope, ok := decoded.(map[string]any)
+	if !ok {
+		t.Fatalf("GET /api/downstream-keys = %T, want object envelope", decoded)
+	}
+	if envelope["success"] != true {
+		t.Fatalf("downstream-keys envelope success = %v, want true", envelope["success"])
+	}
+	items, ok := envelope["items"].([]any)
+	if !ok {
+		t.Fatalf("downstream-keys envelope items = %#v, want array", envelope["items"])
+	}
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+}
+
+// ---- Error envelopes: unified {"error"} contract ----
+
+func TestEnvelope_SitesDeleteInvalidID_UnifiedError(t *testing.T) {
+	_, r := setupSitesTest(t)
+	assertUnifiedErrorEnvelope(t, doDelete(t, r, "/api/sites/not-a-number"))
+}
+
+func TestEnvelope_RouteChannelsInvalidID_UnifiedError(t *testing.T) {
+	_, r := setupTokenRoutesTest(t)
+	assertUnifiedErrorEnvelope(t, doGet(t, r, "/api/routes/abc/channels"))
+}
+
+func TestEnvelope_AccountTokensCreateInvalidAccount_UnifiedError(t *testing.T) {
+	_, r := setupTokensTest(t)
+	assertUnifiedErrorEnvelope(t, doPostJSON(t, r, "/api/account-tokens", map[string]any{
+		"accountId": 0,
+		"token":     "sk-anything",
+	}))
+}
+
+func TestEnvelope_AccountTokensUpdateInvalidID_UnifiedError(t *testing.T) {
+	_, r := setupTokensTest(t)
+	assertUnifiedErrorEnvelope(t, doPutJSON(t, r, "/api/account-tokens/0", map[string]any{
+		"name": "x",
+	}))
+}
+
+func TestEnvelope_RoutesCreateMissingPattern_UnifiedError(t *testing.T) {
+	_, r := setupTokenRoutesTest(t)
+	assertUnifiedErrorEnvelope(t, doPostJSON(t, r, "/api/routes", map[string]any{}))
+}
+
+// ---- Error envelopes: legacy TS-era {"message"} shape, pinned as-is ----
+
+// TestEnvelope_AccountsBatchInvalid_PinnedLegacyMessageEnvelope documents
+// that POST /api/accounts/batch still answers validation failures with the
+// TS-era {"message":"..."} body instead of the unified {"error"}. The
+// frontend http-client resolveResponseMessage reads `message` before
+// `error`, so both envelopes surface identically; the shape is pinned
+// instead of changed to keep the wire behavior stable.
+func TestEnvelope_AccountsBatchInvalid_PinnedLegacyMessageEnvelope(t *testing.T) {
+	_, r, _ := setupAccountsTest(t)
+	resp := doPostJSON(t, r, "/api/accounts/batch", map[string]any{})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("batch error body is not JSON: %v; raw=%s", err, resp.Body.String())
+	}
+	message, ok := body["message"].(string)
+	if !ok || strings.TrimSpace(message) == "" {
+		t.Fatalf("expected legacy non-empty \"message\" string, got %#v", body)
+	}
+	if success, has := body["success"]; has && success == true {
+		t.Fatalf("error body must not claim success=true: %#v", body)
+	}
+}

--- a/handler/admin/contract_filters_test.go
+++ b/handler/admin/contract_filters_test.go
@@ -1,0 +1,219 @@
+package admin
+
+// Wave 4 contract audit — list filters actually reach the SQL WHERE clause.
+//
+// Positive filter coverage already exists elsewhere:
+//   - proxy-logs: TestStats_SQLiteProxyLogs*Filter* (status/search/client/
+//     siteId/channelId/from/to/latency bounds, combined, NULL handling)
+//   - checkin logs: TestCheckinLogsFiltersByStatusAndDateRange (incl. a
+//     future from-bound that must return zero rows)
+//   - audit-logs: TestAuditLogs_ListWithFilters (method + path substring)
+//
+// This file adds the gaps: account-tokens accountId scoping, downstream-keys
+// summary search/status scoping, and explicit "filter matches nothing →
+// empty result" negative cases so a filter silently degrading to "return
+// everything" cannot pass.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// seedDownstreamKeyFixture inserts a downstream API key row and returns its
+// id. Shared by the envelope, pagination-bounds and filter audits.
+func seedDownstreamKeyFixture(t *testing.T, db *store.DB, name string, enabled bool) int64 {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	enabledInt := 0
+	if enabled {
+		enabledInt = 1
+	}
+	res, err := db.Exec(
+		`INSERT INTO downstream_api_keys (name, key, enabled, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?)`,
+		name, "sk-test-"+name+"-secret-value", enabledInt, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert downstream key %s: %v", name, err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("downstream key id: %v", err)
+	}
+	return id
+}
+
+// ---- GET /api/account-tokens?accountId= ----
+
+func TestFilters_AccountTokens_AccountIDScopesList(t *testing.T) {
+	db, r := setupTokensTest(t)
+	siteID, accountA := tokenFixture(t, db, r)
+	createTokenFixture(t, db, accountA, "token-a", "sk-aaa-123456", "", true, true)
+
+	// Second account on the same site with its own token.
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
+		 VALUES (?, 'tokuser-b', 'sk-session-b', 'active', 1, ?, ?)`,
+		siteID, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account B: %v", err)
+	}
+	accountB, _ := res.LastInsertId()
+	createTokenFixture(t, db, accountB, "token-b", "sk-bbb-123456", "", true, true)
+
+	// Filter scopes to account A only.
+	filteredA := doGet(t, r, "/api/account-tokens?accountId="+itoa(accountA))
+	if filteredA.Code != http.StatusOK {
+		t.Fatalf("filtered list: %d %s", filteredA.Code, filteredA.Body.String())
+	}
+	var tokensA []map[string]any
+	if err := json.Unmarshal(filteredA.Body.Bytes(), &tokensA); err != nil {
+		t.Fatalf("decode filtered A: %v", err)
+	}
+	if len(tokensA) != 1 {
+		t.Fatalf("accountId=A: tokens = %d, want 1 (filter must reach WHERE)", len(tokensA))
+	}
+	if got := int64(tokensA[0]["accountId"].(float64)); got != accountA {
+		t.Fatalf("accountId=A: row accountId = %d, want %d", got, accountA)
+	}
+
+	filteredB := doGet(t, r, "/api/account-tokens?accountId="+itoa(accountB))
+	var tokensB []map[string]any
+	if err := json.Unmarshal(filteredB.Body.Bytes(), &tokensB); err != nil {
+		t.Fatalf("decode filtered B: %v", err)
+	}
+	if len(tokensB) != 1 {
+		t.Fatalf("accountId=B: tokens = %d, want 1", len(tokensB))
+	}
+
+	// Negative case: an accountId with no tokens returns an empty array,
+	// not the full list (filter degenerating to no-op) and not an error.
+	empty := doGet(t, r, "/api/account-tokens?accountId=999999")
+	if empty.Code != http.StatusOK {
+		t.Fatalf("empty filter: %d %s", empty.Code, empty.Body.String())
+	}
+	var tokensEmpty []map[string]any
+	if err := json.Unmarshal(empty.Body.Bytes(), &tokensEmpty); err != nil {
+		t.Fatalf("decode empty: %v; body=%s", err, empty.Body.String())
+	}
+	if len(tokensEmpty) != 0 {
+		t.Fatalf("accountId=999999: tokens = %d, want 0 (negative filter case)", len(tokensEmpty))
+	}
+
+	// No filter returns both accounts' tokens.
+	all := doGet(t, r, "/api/account-tokens")
+	var tokensAll []map[string]any
+	if err := json.Unmarshal(all.Body.Bytes(), &tokensAll); err != nil {
+		t.Fatalf("decode all: %v", err)
+	}
+	if len(tokensAll) != 2 {
+		t.Fatalf("unfiltered: tokens = %d, want 2", len(tokensAll))
+	}
+}
+
+// ---- GET /api/downstream-keys/summary?search=&status= ----
+
+func TestFilters_DownstreamKeys_SummarySearchAndStatusScoping(t *testing.T) {
+	db, r := setupDownstreamKeysTest(t)
+	seedDownstreamKeyFixture(t, db, "alpha-prod-key", true)
+	seedDownstreamKeyFixture(t, db, "beta-staging-key", false)
+
+	decodeItems := func(resp *httptest.ResponseRecorder) []map[string]any {
+		t.Helper()
+		if resp.Code != http.StatusOK {
+			t.Fatalf("summary: %d %s", resp.Code, resp.Body.String())
+		}
+		var envelope struct {
+			Items []map[string]any `json:"items"`
+		}
+		if err := json.Unmarshal(resp.Body.Bytes(), &envelope); err != nil {
+			t.Fatalf("decode summary: %v; body=%s", err, resp.Body.String())
+		}
+		return envelope.Items
+	}
+
+	// search narrows to the matching name.
+	items := decodeItems(doGet(t, r, "/api/downstream-keys/summary?search=alpha"))
+	if len(items) != 1 {
+		t.Fatalf("search=alpha: items = %d, want 1 (filter must reach WHERE)", len(items))
+	}
+
+	// status narrows to the disabled key.
+	items = decodeItems(doGet(t, r, "/api/downstream-keys/summary?status=disabled"))
+	if len(items) != 1 {
+		t.Fatalf("status=disabled: items = %d, want 1", len(items))
+	}
+
+	// Negative case: search matching nothing returns zero items, proving the
+	// LIKE condition is applied rather than silently dropped.
+	items = decodeItems(doGet(t, r, "/api/downstream-keys/summary?search=zzz-no-such-key"))
+	if len(items) != 0 {
+		t.Fatalf("search=zzz-no-such-key: items = %d, want 0 (negative filter case)", len(items))
+	}
+
+	// No filters returns both keys.
+	items = decodeItems(doGet(t, r, "/api/downstream-keys/summary"))
+	if len(items) != 2 {
+		t.Fatalf("unfiltered summary: items = %d, want 2", len(items))
+	}
+}
+
+// ---- GET /api/admin/audit-logs?method=&path= (negative cases) ----
+
+func TestFilters_AuditLogs_NegativeFiltersReturnEmpty(t *testing.T) {
+	db, _ := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, row := range []struct {
+		method string
+		path   string
+	}{
+		{"POST", "/api/sites"},
+		{"DELETE", "/api/sites/7"},
+	} {
+		if _, err := db.Exec(`INSERT INTO admin_audit_logs (actor, method, path, status, request_id, remote_ip, created_at)
+			VALUES ('aabbccdd', ?, ?, 200, 'req-x', '1.2.3.4', ?)`, row.method, row.path, now); err != nil {
+			t.Fatalf("seed audit row: %v", err)
+		}
+	}
+	r := chi.NewRouter()
+	RegisterAuditLogsRoutes(r, db.DB)
+
+	decode := func(resp *httptest.ResponseRecorder) (int, []any) {
+		t.Helper()
+		if resp.Code != http.StatusOK {
+			t.Fatalf("audit-logs: %d %s", resp.Code, resp.Body.String())
+		}
+		var body map[string]any
+		if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode audit-logs: %v; body=%s", err, resp.Body.String())
+		}
+		items, _ := body["items"].([]any)
+		return int(body["total"].(float64)), items
+	}
+
+	// Positive control: method=POST finds the seeded row.
+	total, items := decode(doGet(t, r, "/api/admin/audit-logs?method=POST"))
+	if total != 1 || len(items) != 1 {
+		t.Fatalf("method=POST: total=%d items=%d, want 1/1", total, len(items))
+	}
+
+	// Negative case: a method with no rows returns total=0 and empty items.
+	total, items = decode(doGet(t, r, "/api/admin/audit-logs?method=PATCH"))
+	if total != 0 || len(items) != 0 {
+		t.Fatalf("method=PATCH: total=%d items=%d, want 0/0 (negative filter case)", total, len(items))
+	}
+
+	// Negative case: path substring matching nothing returns zero rows.
+	total, items = decode(doGet(t, r, "/api/admin/audit-logs?path=zzz-no-such-endpoint"))
+	if total != 0 || len(items) != 0 {
+		t.Fatalf("path=zzz-no-such-endpoint: total=%d items=%d, want 0/0 (negative filter case)", total, len(items))
+	}
+}

--- a/handler/admin/contract_pagination_bounds_test.go
+++ b/handler/admin/contract_pagination_bounds_test.go
@@ -1,0 +1,298 @@
+package admin
+
+// Wave 4 contract audit — pagination boundary behavior.
+//
+// Four admin list endpoints accept ?page/&pageSize= with identical clamp
+// semantics (page → [1, 1_000_000], pageSize → [1, 200]); two more use the
+// ?limit/&offset= style (parseLimitOffset: limit → [1, max], offset → >= 0).
+// These tests pin the CURRENT clamp behavior for out-of-range inputs (0,
+// negative, oversized) so any future semantic drift is deliberate, not
+// accidental. The mixed 0-based-offset vs 1-based-page coexistence is the
+// documented status quo and is not changed here.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// pagedEnvelope is the shared {items,total,page,pageSize} list envelope.
+type pagedEnvelope struct {
+	Items    []map[string]any `json:"items"`
+	Total    int              `json:"total"`
+	Page     int              `json:"page"`
+	PageSize int              `json:"pageSize"`
+}
+
+func decodePagedEnvelope(t *testing.T, resp *httptest.ResponseRecorder) pagedEnvelope {
+	t.Helper()
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+	var envelope pagedEnvelope
+	if err := json.Unmarshal(resp.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode envelope: %v; body=%s", err, resp.Body.String())
+	}
+	return envelope
+}
+
+// ---- GET /api/routes (page-gated envelope) ----
+
+func TestPaginationBounds_Routes_PageZeroAndNegativeClampToFirstPage(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	seedRoutes(t, db, 3, "2026-01-01T00:00:00Z")
+
+	baseline := decodePagedEnvelope(t, doGet(t, r, "/api/routes?page=1&pageSize=2"))
+	pageZero := decodePagedEnvelope(t, doGet(t, r, "/api/routes?page=0&pageSize=2"))
+	pageNegative := decodePagedEnvelope(t, doGet(t, r, "/api/routes?page=-5&pageSize=2"))
+
+	for label, envelope := range map[string]pagedEnvelope{"page=0": pageZero, "page=-5": pageNegative} {
+		if envelope.Page != 1 {
+			t.Fatalf("%s: response page = %d, want clamped 1", label, envelope.Page)
+		}
+		if len(envelope.Items) != len(baseline.Items) || envelope.Total != baseline.Total {
+			t.Fatalf("%s: items=%d total=%d, want identical to page=1 (%d/%d)",
+				label, len(envelope.Items), envelope.Total, len(baseline.Items), baseline.Total)
+		}
+	}
+}
+
+func TestPaginationBounds_Routes_PageSizeZeroNegativeAndOversized(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	seedRoutes(t, db, 3, "2026-01-01T00:00:00Z")
+
+	sizeZero := decodePagedEnvelope(t, doGet(t, r, "/api/routes?page=1&pageSize=0"))
+	if sizeZero.PageSize != 1 || len(sizeZero.Items) != 1 {
+		t.Fatalf("pageSize=0: got pageSize=%d items=%d, want clamp to 1", sizeZero.PageSize, len(sizeZero.Items))
+	}
+
+	sizeNegative := decodePagedEnvelope(t, doGet(t, r, "/api/routes?page=1&pageSize=-10"))
+	if sizeNegative.PageSize != 1 || len(sizeNegative.Items) != 1 {
+		t.Fatalf("pageSize=-10: got pageSize=%d items=%d, want clamp to 1", sizeNegative.PageSize, len(sizeNegative.Items))
+	}
+
+	sizeOversized := decodePagedEnvelope(t, doGet(t, r, "/api/routes?page=1&pageSize=9999"))
+	if sizeOversized.PageSize != 200 {
+		t.Fatalf("pageSize=9999: got pageSize=%d, want clamp to 200", sizeOversized.PageSize)
+	}
+	if len(sizeOversized.Items) != 3 {
+		t.Fatalf("pageSize=9999: items=%d, want all 3 rows", len(sizeOversized.Items))
+	}
+}
+
+func TestPaginationBounds_Routes_PagePastLastPageKeepsTrueTotal(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	seedRoutes(t, db, 3, "2026-01-01T00:00:00Z")
+
+	envelope := decodePagedEnvelope(t, doGet(t, r, "/api/routes?page=99&pageSize=2"))
+	if len(envelope.Items) != 0 {
+		t.Fatalf("page past end: items = %d, want 0", len(envelope.Items))
+	}
+	if envelope.Total != 3 {
+		t.Fatalf("page past end: total = %d, want true total 3", envelope.Total)
+	}
+}
+
+// ---- GET /api/accounts (always-paginated path) ----
+
+func TestPaginationBounds_Accounts_OutOfRangeParamsClamped(t *testing.T) {
+	_, r := setupAccountsPaginationTest(t)
+
+	pageZero := decodePagedEnvelope(t, doGet(t, r, "/api/accounts?page=0&pageSize=-3"))
+	if pageZero.Page != 1 {
+		t.Fatalf("page=0: response page = %d, want clamped 1", pageZero.Page)
+	}
+	if pageZero.PageSize != 1 {
+		t.Fatalf("pageSize=-3: response pageSize = %d, want clamped 1", pageZero.PageSize)
+	}
+	if len(pageZero.Items) != 1 {
+		t.Fatalf("clamped page: items = %d, want 1", len(pageZero.Items))
+	}
+	if pageZero.Total != 3 {
+		t.Fatalf("clamped page: total = %d, want 3", pageZero.Total)
+	}
+
+	sizeOversized := decodePagedEnvelope(t, doGet(t, r, "/api/accounts?page=1&pageSize=5000"))
+	if sizeOversized.PageSize != 200 {
+		t.Fatalf("pageSize=5000: response pageSize = %d, want clamp to 200", sizeOversized.PageSize)
+	}
+	if len(sizeOversized.Items) != 3 {
+		t.Fatalf("pageSize=5000: items = %d, want all 3 accounts", len(sizeOversized.Items))
+	}
+}
+
+// ---- GET /api/downstream-keys (page-gated envelope) ----
+
+func TestPaginationBounds_DownstreamKeys_OutOfRangeParamsClamped(t *testing.T) {
+	db, r := setupDownstreamKeysTest(t)
+	for _, name := range []string{"bound-key-a", "bound-key-b", "bound-key-c"} {
+		seedDownstreamKeyFixture(t, db, name, true)
+	}
+
+	pageNegative := decodePagedEnvelope(t, doGet(t, r, "/api/downstream-keys?page=-1&pageSize=0"))
+	if pageNegative.Page != 1 || pageNegative.PageSize != 1 {
+		t.Fatalf("page=-1&pageSize=0: got page=%d pageSize=%d, want clamped 1/1",
+			pageNegative.Page, pageNegative.PageSize)
+	}
+	if len(pageNegative.Items) != 1 || pageNegative.Total != 3 {
+		t.Fatalf("clamped page: items=%d total=%d, want 1/3", len(pageNegative.Items), pageNegative.Total)
+	}
+
+	sizeOversized := decodePagedEnvelope(t, doGet(t, r, "/api/downstream-keys?page=1&pageSize=100000"))
+	if sizeOversized.PageSize != 200 {
+		t.Fatalf("pageSize=100000: got pageSize=%d, want clamp to 200", sizeOversized.PageSize)
+	}
+}
+
+// ---- GET /api/channels (explicit paging mode) ----
+
+func TestPaginationBounds_Channels_ExplicitPagingClampsAndCounts(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+	for i := 0; i < 5; i++ {
+		if _, err := db.Exec(
+			`INSERT INTO route_channels
+				(route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+			 VALUES (?, ?, ?, ?, 0, 10, 1, 0)`,
+			routeID, accountID, tokenID, "gpt-bound-"+itoa(int64(i)),
+		); err != nil {
+			t.Fatalf("insert channel %d: %v", i, err)
+		}
+	}
+
+	pageZero := decodePagedEnvelope(t, doGet(t, r, "/api/channels?page=0&pageSize=0"))
+	if pageZero.Page != 1 || pageZero.PageSize != 1 {
+		t.Fatalf("page=0&pageSize=0: got page=%d pageSize=%d, want clamped 1/1",
+			pageZero.Page, pageZero.PageSize)
+	}
+	if len(pageZero.Items) != 1 {
+		t.Fatalf("clamped channels page: items = %d, want 1", len(pageZero.Items))
+	}
+	// Explicit paging reports the true fleet total via COUNT(*) OVER () or
+	// the empty-page COUNT(*) fallback.
+	if pageZero.Total != 5 {
+		t.Fatalf("clamped channels page: total = %d, want 5", pageZero.Total)
+	}
+
+	sizeOversized := decodePagedEnvelope(t, doGet(t, r, "/api/channels?page=1&pageSize=999999"))
+	if sizeOversized.PageSize != 200 {
+		t.Fatalf("pageSize=999999: got pageSize=%d, want clamp to 200", sizeOversized.PageSize)
+	}
+
+	pastEnd := decodePagedEnvelope(t, doGet(t, r, "/api/channels?page=50&pageSize=50"))
+	if len(pastEnd.Items) != 0 {
+		t.Fatalf("page past end: items = %d, want 0", len(pastEnd.Items))
+	}
+	if pastEnd.Total != 5 {
+		t.Fatalf("page past end: total = %d, want true total 5 (COUNT fallback)", pastEnd.Total)
+	}
+}
+
+// ---- GET /api/checkin/logs (limit/offset style) ----
+
+func TestPaginationBounds_CheckinLogs_LimitOffsetClamped(t *testing.T) {
+	db, r, _ := setupCheckinRoutesTest(t)
+	upstream, _ := newCheckinAnyRouterServer(t)
+	siteID := insertCheckinRouteSite(t, db, upstream.URL)
+	accountID := insertCheckinRouteAccount(t, db, siteID, true)
+	seedCheckinLogs(t, db, accountID, []struct {
+		status  string
+		message string
+	}{
+		{"success", "reward a"},
+		{"failed", "boom"},
+		{"skipped", "no-op"},
+		{"success", "reward b"},
+	})
+
+	var envelope struct {
+		Items    []map[string]any `json:"items"`
+		Total    int              `json:"total"`
+		Page     int              `json:"page"`
+		PageSize int              `json:"pageSize"`
+	}
+
+	resp := doGet(t, r, "/api/checkin/logs?limit=0&offset=-10")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, resp.Body.String())
+	}
+	if envelope.PageSize != 1 {
+		t.Fatalf("limit=0: pageSize = %d, want clamp to 1", envelope.PageSize)
+	}
+	if len(envelope.Items) != 1 {
+		t.Fatalf("limit=0: items = %d, want 1", len(envelope.Items))
+	}
+	if envelope.Total != 4 {
+		t.Fatalf("limit=0: total = %d, want 4", envelope.Total)
+	}
+
+	resp = doGet(t, r, "/api/checkin/logs?limit=99999")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, resp.Body.String())
+	}
+	if envelope.PageSize != 200 {
+		t.Fatalf("limit=99999: pageSize = %d, want clamp to 200", envelope.PageSize)
+	}
+	if len(envelope.Items) != 4 {
+		t.Fatalf("limit=99999: items = %d, want all 4 logs", len(envelope.Items))
+	}
+}
+
+// ---- GET /api/admin/audit-logs (limit/offset style) ----
+
+func TestPaginationBounds_AuditLogs_LimitOffsetClamped(t *testing.T) {
+	db, _ := setupStatsSQLiteTest(t)
+	now := "2026-01-01T00:00:00Z"
+	for _, method := range []string{"POST", "PUT", "DELETE"} {
+		if _, err := db.Exec(`INSERT INTO admin_audit_logs (actor, method, path, status, request_id, remote_ip, created_at)
+			VALUES ('aabbccdd', ?, '/api/bounds', 200, 'req-x', '1.2.3.4', ?)`, method, now); err != nil {
+			t.Fatalf("seed audit row: %v", err)
+		}
+	}
+	r := chi.NewRouter()
+	RegisterAuditLogsRoutes(r, db.DB)
+
+	var envelope struct {
+		Items  []map[string]any `json:"items"`
+		Total  int              `json:"total"`
+		Limit  int              `json:"limit"`
+		Offset int              `json:"offset"`
+	}
+
+	resp := doGet(t, r, "/api/admin/audit-logs?limit=0&offset=-7")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, resp.Body.String())
+	}
+	if envelope.Limit != 1 {
+		t.Fatalf("limit=0: limit = %d, want clamp to 1", envelope.Limit)
+	}
+	if envelope.Offset != 0 {
+		t.Fatalf("offset=-7: offset = %d, want clamp to 0", envelope.Offset)
+	}
+	if len(envelope.Items) != 1 || envelope.Total != 3 {
+		t.Fatalf("clamped audit page: items=%d total=%d, want 1/3", len(envelope.Items), envelope.Total)
+	}
+
+	resp = doGet(t, r, "/api/admin/audit-logs?limit=50000")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, resp.Body.String())
+	}
+	if envelope.Limit != 200 {
+		t.Fatalf("limit=50000: limit = %d, want clamp to 200", envelope.Limit)
+	}
+}


### PR DESCRIPTION
Wave 4 C 线（契约回归）：对 Round 3 四个 P0 契约修复（#911）做回归复验，并对更广契约面（包络/分页/过滤）实测抽查。**零行为代码改动**：四点修复均被既有具名守卫兜住（含红→绿有效性验证），新发现均属「设计/TS 契约现状」，只补测试钉住与文档修正。

## 一、四契约点结论（测试映射表）

| # | 契约点（#911 修复） | 具名守卫测试 | 实测 |
|---|---|---|---|
| ① | account-token 列表 snake_case 字段丢失 | `TestTokens_List_WireContractCamelCase`（handler/admin/account_tokens_test.go）+ `..._Postgres`（PG 方言） | SQLite/PG 双绿 |
| ② | 表单字段后端静默丢弃 | `TestSites_Create/Update_PersistsResinEnabledAndUseUtls`、`TestAccounts_Update_PersistsTagsAndPlatformUserId`、`TestTokenRoutes_Update_PersistsRouteMode` | 全绿 |
| ③ | channels 固定截断 50 条 | `TestChannels_List_UnboundedReturnsAllRows`（120 行不截断）+ `TestChannels_ListProjection` | 绿 |
| ④ | route channels 不返回 success/fail/cooldown | `TestRouteChannels_IncludeRuntimeCounters`（detail 端点 + routes list 内嵌两处断言） | 绿 |

**测试有效性（红→绿）验证**：每点临时还原缺陷一行→守卫报红→还原修复→回绿：
- ① `tokenGroup` 键改回 `token_group` → `FAIL: tokenGroup = <nil>, want vip`
- ② createSite 摘除 resinEnabled 三态块 → `FAIL: resinEnabled = <nil>, want true`
- ③ `unbounded := false` → `FAIL: unbounded items = 50, want 120 (no truncation)`
- ④ 摘除 `successCount` → `FAIL: TestRouteChannels_IncludeRuntimeCounters`

验证后 `git diff master -- handler/ service/ transform/ proxy/ routing/ store/` 为空（实现文件逐字节还原，零改动）。

## 二、更广契约面抽查结论

**错误包络（12 端点：成功 6 + 失败 6）**：成功侧三种列表形状并存（裸数组 / `{items,total,page,pageSize}` / accounts snapshot / `{success,...}`），全部 2xx+JSON+camelCase（递归 snake_case 键泄漏扫描通过，唯一白名单 `request_id`）。失败侧统一非 2xx + `{"error":"..."}`。少量 TS 遗留 `{"message":"..."}` 路径（如 `POST /api/accounts/batch` 校验失败）：实测 metapi-ts 原版同形、前端 `resolveResponseMessage` 先读 message 后读 error → 判定为设计/兼容现状，测试钉住不改（`TestEnvelope_AccountsBatchInvalid_PinnedLegacyMessageEnvelope`）。

**分页边界（6 端点）**：4 个 page/pageSize 端点（routes/accounts/downstream-keys/channels）clamp 语义一致：`page` 0/负→1，`pageSize` 0/负→1、>200→200，超尾页返回空 items 且 total 保持真值；2 个 limit/offset 端点（checkin logs、audit-logs）limit→[1,max]、offset→≥0。0-based offset 与 1-based page 并存属现状，全部用新测试钉住。

**过滤参数真生效**：`/api/account-tokens?accountId`、`/api/downstream-keys/summary?search=&status=`、`/api/admin/audit-logs?method=&path=` 均实测进 WHERE（含「过滤应返回空」反向用例）。proxy-logs 过滤沿用既有 9 个具名测试（`TestStats_SQLiteProxyLogs*Filter*`，含 NULL/零值忽略）作为结论。

## 三、本轮修复与补测清单

- **补测（+23 个，只增不减）**：
  - `handler/admin/contract_envelope_test.go`（12）：成功/失败包络一致性 + snake_case 泄漏扫描。
  - `handler/admin/contract_pagination_bounds_test.go`（8）：page/pageSize 与 limit/offset 边界（0/负/超大/超尾页）。
  - `handler/admin/contract_filters_test.go`（3）：过滤进 WHERE + 反向空用例。
- **文档修正（非行为）**：`docs/api.md` Response Format 段原描述 `{success,data}/{success,message}` 包裹与实际完全不符，改写为实测契约形状；`/api/stats/proxy-logs` 查询参数行同步修正。
- **代码修复**：无（未发现查实的契约缺陷；#911 四点修复完整）。
- **记录在案未动手**（详见 BLOCKED 内容）：handler/admin PG 测试对脏共享库不幂等（固定 fixture URL→409，CI 干净库不受影响）；`{"message"}` 遗留包络判定为设计。

## 四、门禁输出（门禁机实测，2026-08-22）

```
+ go build ./cmd/server          -> ok
+ go vet ./...                   -> ok
+ cd web && bun install --frozen-lockfile -> 618 packages installed
+ bun run typecheck              -> tsgo -b ok
+ bun run lint                   -> ok
+ bun run test                   -> 138 files / 952 tests passed
+ bash ./scripts/go-race.sh      -> 39 packages ok, 0 FAIL
GATE_EXIT=0
```

全部 Go 包（含 handler/admin 587s、auth 267s、scheduler 130s、store 67s）`ok`，前端 952 个测试全绿，失败数 0 = 不高于本地基线（基线亦 0）。

## BLOCKED（随交付，.gitignore 忽略故贴于此）

无阻塞项。记录在案、未动手：
1. handler/admin 的 PG 测试跨次运行不幂等：固定 fixture（站点 URL `https://api.openai.com`）在残留数据的共享 PG 库上第二次运行会 409。CI 每次全新库，不受影响；本地用专用干净库规避。属测试基建观察项，未改测试代码。
2. `{"message"}` 遗留错误包络（`/api/accounts` 部分 batch/500 路径等）：实测 TS 原版同形，前端双读 → 判定为设计/TS 契约现状，测试钉住不改。

---
基线：`master = f32d99d`（v0.16.6）。本机全量 `-race` 基线（改动前）与门禁机全量门禁（改动后）均全绿，失败数不高于基线（0）。
