### PR TITLE
test(e2e): Wave 4 E 线 — v0.16.6 实测证据

### DIFF
--- a/EVIDENCE.md
+++ b/EVIDENCE.md
@@ -1,0 +1,176 @@
+# EVIDENCE — Wave 4 E 线（实测验收）· v0.16.6 (master=f32d99d)
+
+日期均为 2026-08-22（本机时区 +08:00）。所有命令可在同环境 10 分钟内复跑。`$METAPI_BIN` = `go build -o <任意路径> ./cmd/server` 产物。
+脱敏约定：相对路径；不含主机名/内部实例标识；`request_id=<sanitized>` 表示原值含环境标识已抹除。
+
+---
+
+## E1 · Go e2e 套件全绿（任务 1）
+
+命令（仓库根）：
+
+```bash
+go test ./e2e/... -count=1 -v
+```
+
+输出摘录（完整日志见会话；31 pass / 0 fail / 0 skip）：
+
+```text
+--- PASS: TestBackupExportImportRoundtrip (0.17s)
+...
+--- PASS: TestShutdownRejectsNewConnections (0.08s)
+--- PASS: TestBasicChatCompletions (0.00s)
+--- PASS: TestChannelRetry (0.00s)
+...
+ok  	github.com/deliciousbuding/metapi-go/e2e	5.903s
+```
+
+7 个文件逐一结论（按 `--- PASS` 归属）：
+
+| 文件 | 结论 |
+|:---|:---|
+| `e2e/e2e_backup_test.go` | PASS ×8（roundtrip/accounts-only/preferences-only/invalid-type/空库/坏 JSON/设置保真/route_channel token NULL FK） |
+| `e2e/e2e_cascade_isolation_test.go` | PASS ×2（5xx 风暴下 channel 级排除；兄弟通道恢复） |
+| `e2e/e2e_flow_test.go` | PASS ×3（建站→代理全链路 / 未授权 / 流式） |
+| `e2e/e2e_hardening_test.go` | PASS ×4（常量时间比较 / 并发 / body 限流先于上游 / 限流拒绝） |
+| `e2e/e2e_shutdown_test.go` | PASS ×2（流式负载下优雅退出；退出后拒新连接） |
+| `e2e/e2e_test.go` | PASS ×12（基础补全/重试/下游鉴权/模型匹配/错误传播/SSE 等） |
+| `e2e/e2e_p0585_production_test.go` | 默认构建不编译（`//go:build staging`）。带 tag 无环境实跑：`--- FAIL ... staging cascade test requires env: METAPI_STAGING_URL, METAPI_AUTH_TOKEN, METAPI_PROXY_TOKEN` — fail-fast 行为符合文件头注释；无真实 staging 实例，未深跑（环境不允许，诚实记录） |
+
+## E2 · SQLite 方言启动 + 优雅退出（任务 2）
+
+```bash
+mkdir -p .tmp-e2e-data/sqlite
+PORT=4180 DATA_DIR=<worktree>/.tmp-e2e-data/sqlite \
+AUTH_TOKEN=<临时值> PROXY_TOKEN=<临时值> "$METAPI_BIN" &
+```
+
+探针输出（`curl --noproxy '*'`；注意：本机 shell 有 HTTP 代理变量，直连必须绕过）：
+
+```text
+GET /health → HTTP=200 {"status":"ok"}
+GET /ready  → HTTP=200 {"status":"ok","database":"ok"}
+```
+
+`kill -TERM <pid>` 后日志：
+
+```text
+level=INFO msg="received signal, shutting down" signal=terminated
+level=INFO msg="server stopped"
+```
+
+附加证据（端口冲突的诚实处理）：第二实例同端口启动 →
+`level=ERROR msg="server listen failed" error="listen tcp 0.0.0.0:4180: bind: address already in use"` → 后台调度器有序停止后退出。
+
+启动日志另观察到：`pricingcatalog: fetch https://models.dev/api.json: context deadline exceeded`（出网受限，降级到内置预设，属环境特性非缺陷）。
+
+## E3 · PostgreSQL 方言启动 + 优雅退出（任务 2）
+
+```bash
+psql -h 127.0.0.1 -p 55432 -U metapi_test -d metapi_test \
+  -c "CREATE DATABASE metapi_e2e_wave4;"
+PORT=4181 DATABASE_URL="postgres://metapi_test:<密码>@127.0.0.1:55432/metapi_e2e_wave4?sslmode=disable" \
+AUTH_TOKEN=<临时值> PROXY_TOKEN=<临时值> "$METAPI_BIN" &
+```
+
+```text
+level=INFO msg="store: database opened" dialect=postgres
+level=INFO msg="store: running auto-migration" dialect=postgres
+（24 条 additive migration 全部应用）
+GET /health → HTTP=200 {"status":"ok"}
+GET /ready  → HTTP=200 {"status":"ok","database":"ok"}
+kill -TERM → "received signal, shutting down" signal=terminated → "server stopped"
+psql ... -c "DROP DATABASE metapi_e2e_wave4;" → DROP DATABASE
+```
+
+## E4 · acceptance 旅程：假上游诚实行为（任务 3）
+
+一次性后端（SQLite 临时目录，端口 4182，临时 AUTH_TOKEN）+ 不可达上游 `http://127.0.0.1:39999`：
+
+```bash
+cd web && BASE_URL=http://127.0.0.1:4182 AUTH_TOKEN=<临时值> \
+UPSTREAM_URL=http://127.0.0.1:39999 UPSTREAM_USERNAME=metapi-e2e \
+PLATFORM=new-api bun run acceptance:e2e
+```
+
+```text
+$ node scripts/acceptance-e2e.mjs
+[PASS] journey: site onboarding: created "acceptance-real-site" -> http://127.0.0.1:39999 (new-api) via UI
+== acceptance:e2e summary — 1 passed, 0 failed ==
+```
+
+发现（非缺陷，属设计事实，已写进文档）：旅程显式选择平台，建站不依赖上游可达性——**假上游下旅程 1 也通过**，站点以 `status:"active"` 落库。检测端点本身对不可达上游诚实失败：
+
+```text
+POST /api/sites/detect {"url":"http://127.0.0.1:39999"}
+→ HTTP=400 {"error":"Could not detect platform","request_id":"<sanitized>"}
+```
+
+服务端逻辑：`handler/admin/sites.go` createSite 仅在请求未带 platform 时才跑 `service.DetectSite`。
+
+## E5 · acceptance 旅程：ACCEPT_LOGIN=1 全链路（任务 3）
+
+```bash
+cd web && BASE_URL=http://127.0.0.1:4182 AUTH_TOKEN=<临时值> \
+UPSTREAM_URL=http://127.0.0.1:39999 UPSTREAM_USERNAME=metapi-e2e \
+UPSTREAM_PASSWORD=<假值> ACCEPT_LOGIN=1 PLATFORM=new-api bun run acceptance:e2e
+```
+
+```text
+[PASS] journey: site onboarding: created "acceptance-real-site" -> http://127.0.0.1:39999 (new-api) via UI
+== acceptance:e2e summary — 1 passed, 2 failed ==
+  [FAIL] journey: account login via UI: step "account row appears": locator.waitFor: Timeout 25000ms exceeded.
+  [FAIL] journey: check-in via UI: step "locate account": account "metapi-e2e" not found
+```
+
+结论：脚本链路完整可跑、失败按步标注且诚实（上游不可达 → 后端真实登录不可能成功 → 账户不出现）。旅程 2 在失败前走过的全部步骤（快照轮询→/accounts→Add account→Password tab→站点选择→Username/Password→submit）证明这些选择器与当前 DOM 全部匹配。旅程 2/3 完整通过需要真实上游（见 BLOCKED.md）。
+
+## E6 · bun 调用形式（脚本层发现，已修文档）
+
+```bash
+bun --cwd web run acceptance:e2e   # bun 1.3.14：打印 usage 后 exit 0 —— 静默不执行！
+bun run --cwd web acceptance:e2e   # 正确形式，实际执行旅程
+```
+
+风险：操作者照文档（旧形式）跑会拿到 exit 0 误判为通过。已修正
+`docs/internal/analysis/e2e-acceptance-platform.md` §3 并加警示。
+
+## E7 · 选择器对账记录（任务 3）
+
+| 旅程 | 选择器 | 结论 | 依据 |
+|:---|:---|:---|:---|
+| 1 | `Add site` 按钮 / Name / URL label / Platform combobox / `Create` | 实测命中 | E4 旅程 PASS（真实 Chromium + built SPA） |
+| 2 | `Add account` / Password tab / `Select a site` combobox / Username / Password / dialog submit | 实测命中（至 submit） | E5 步骤日志在 submit 之后才失败 |
+| 3 | `Run all check-ins` / `table tbody tr` | 代码核对（未实跑到） | `features/checkin/components/checkin-page.tsx:406` 用 `t('checkin.page.runAll')`，en.json:1927 = "Run all check-ins"；表格经 data-table core 渲染真 `<table>/<tbody>/<tr>`（`components/data-table/core/data-table-view.tsx:103,259`） |
+
+i18n 标签核对：`accounts.page.addButton` = "Add account"、`sites.*.addSite` = "Add site"（en.json:1507/467）。`seedAuth` 的 `auth_token` localStorage 键与 SPA 鉴权一致（旅程通过登录守卫）。**无失效选择器，无需修复。**
+
+## E8 · §6 quirk 复测（任务 4，新探针 `web/scripts/acceptance-probe-header-quirk.mjs`）
+
+条件重建：API 建全新站点 → 立即进 /accounts（无快照轮询），20Hz 采样「Add account」按钮中心的 elementFromPoint，并行发起真实点击。累计 30+ trial（最终轮 10 次输出如下）：
+
+```text
+trial 1: click=clicked dialog=true firstEnabledAt=542ms ... loadTimeIntercepted=0 postClickIntercepted=35
+trial 2: click=clicked dialog=true firstEnabledAt=1360ms ... loadTimeIntercepted=0 postClickIntercepted=11
+trial 3..10: click 超时（按钮 1234~2265ms 才可操作）...
+== header-overlap probe summary: 2/10 clean clicks, 8 failed (...), load-time interception samples=0 ==
+NOT reproduced at load time: every interception sample occurred AFTER the probe's own click opened the create sheet
+```
+
+补充实测：
+- 无并发采样时，按钮 355~1176ms 出现、出现即可用、无 disabled 窗口（3 trial）。
+- 页面加载 2s 内 `[data-slot="sheet-content"]` popup 0 次挂载（100ms 采样 ×20）。
+- 曾观察到的拦截元素 `form.flex-1.space-y-5.overflow-y-auto.p-4` = AccountFormDialog 表单体（`features/accounts/components/account-form-dialog.tsx:280`，右侧 Sheet、fixed、z-50），经祖先链确认属于**点击成功后打开的 Sheet 本体**（`role="dialog" data-open data-slot="sheet-content"`），非加载期覆盖物。
+
+结论：**§6 所述「页头盖住工具栏」未在 v0.16.6 复现**（文档所述，2026-08-20 记录；本轮实测未见）。可复现的真实竞态是：全新站点后立即进入 /accounts，按钮要 ~0.4–2.3s 才可操作，且 `disabled={sites.length===0}`（`features/accounts/components/accounts-page.tsx:453`）在快照未含站点时钉住按钮——旅程脚本的 `waitForSiteInSnapshot` 正是为此而设，工作正常。详见移交清单。
+
+## E9 · 环境诚实记录（未跑/不允许）
+
+- 旅程 2/3 完整通过：需真实上游凭据——本轮决策不碰真实上游（BLOCKED.md）。
+- `e2e_p0585_production_test.go` 深跑：需 `METAPI_STAGING_URL` 等（无）。
+- `testbed/compose.template.yml` 链路：本机无 Docker（只读参考）。
+- `scripts/e2e/smoke.sh` / `verify-token-import.sh`：需要真实上游（可读可跑，无上游可跑）；未改动其内容（白名单外）。
+
+## E10 · 运维事故自述（防编造：真实发生，已处置）
+
+验证 bun 调用形式时，未显式传 BASE_URL 的一次测试命中了本机默认 4000 端口上的一个非预期监听（SSH 隧道）。acceptance 脚本按其设计清空了该实例的站点/账户并建了 1 个站点。已立即删除该站点并验证列表为空（`DELETE /api/sites/<id>` → `{"success":true}`，随后 `GET /api/sites` → `[]`）。教训已写入文档 §3 安全提示（显式 BASE_URL + 确认目标是一次性实例）。

--- a/docs/internal/analysis/e2e-acceptance-platform.md
+++ b/docs/internal/analysis/e2e-acceptance-platform.md
@@ -44,7 +44,7 @@ A **standing upstream host** (a real new-api deployment) is kept available so ac
 **Proven against a real new-api deployment (2026-08-20):**
 
 - Backend chain via `smoke.sh`: **13/13 PASS** — health, admin auth, platform detect, site create, **real login**, verify-token, account, models, balance, **check-in**, downstream token, route, `/v1` relay. Check-in correctly reports the honest upstream result.
-- Frontend journey via `acceptance-e2e.mjs`: **site onboarding PASS** — a real Chromium drives the built SPA to add a site pointed at the real upstream; the real detect round-trip fires and the site lands in the table.
+- Frontend journey via `acceptance-e2e.mjs`: **site onboarding PASS** — a real Chromium drives the built SPA to add a site pointed at the real upstream and the site lands in the table. The journey selects the platform explicitly so create does not depend on auto-detect timing; the detect round-trip fires when the platform is left to auto-detection (`POST /api/sites/detect`, also run in the dialog on URL paste).
 - Frontend **account-login journey** (add account → password mode → real upstream login → account appears) is implemented and **proven working**; it is opt-in (`ACCEPT_LOGIN=1`) because running it immediately after a *freshly created* site hits a transient accounts-page header overlap (a real UI quirk, tracked separately). Against a settled site it passes.
 
 ### How to run it
@@ -59,11 +59,21 @@ PLATFORM=new-api bash scripts/e2e/smoke.sh
 # 3. Frontend journeys (needs a Chromium install: bunx playwright install chromium):
 BASE_URL=http://127.0.0.1:4000 AUTH_TOKEN=<admin> \
 UPSTREAM_URL=<real-upstream> UPSTREAM_USERNAME=<user> UPSTREAM_PASSWORD=<pass> \
-  bun --cwd web run acceptance:e2e           # site-onboarding journey
-ACCEPT_LOGIN=1 ... bun --cwd web run acceptance:e2e   # + account-login journey
+  bun run --cwd web acceptance:e2e           # site-onboarding journey
+ACCEPT_LOGIN=1 ... bun run acceptance:e2e    # + account-login journey
 ```
 
+Note the invocation shape: `bun run --cwd web acceptance:e2e`. The reversed
+form (`bun --cwd web run acceptance:e2e`) prints usage help and exits 0
+without running the journeys on bun 1.x — a silent no-op, not a pass.
+
 Credentials are supplied by the operator environment; they are **never** committed.
+
+**Safety**: `acceptance-e2e.mjs` starts by wiping ALL sites and accounts on
+its target (that is how runs stay idempotent) and defaults to
+`BASE_URL=http://127.0.0.1:4000`. Always pass `BASE_URL`/`AUTH_TOKEN`
+explicitly and make sure the target is the dedicated throwaway instance —
+whatever listens on the default port gets wiped.
 
 ---
 
@@ -88,3 +98,9 @@ The deterministic container `test-e2e` job already guarantees real-platform beha
 ## 6. Known quirk (tracked)
 
 When the account-login journey runs immediately after the site-onboarding journey creates a **fresh** site in the same process, the accounts-page header transiently overlaps the toolbar and intercepts the "Add account" click. Workaround: `ACCEPT_LOGIN=1` runs it in its own browser against a settled site. Root-causing the overlap is a small frontend fix, not a test bug.
+
+**v0.16.6 re-probe (2026-08-22, `web/scripts/acceptance-probe-header-quirk.mjs`)**: the visual overlap itself was **not reproduced**. The probe recreates the original conditions (create a fresh site via API → navigate to `/accounts` immediately, no snapshot polling) and samples at 20 Hz what element sits at the "Add account" button center while attempting a real click, across 25+ trials. Findings:
+
+- Zero load-time interceptions: no sample ever hit-tested a non-button element over "Add account" before a dialog existed; the account create Sheet (Base UI popup) is never mounted during page load. Every interception sample occurred *after* the probe's own successful click opened the create sheet — expected coverage, not the quirk.
+- The measurable transient failure right after a fresh site is **slow button actionability**: the button renders/enables only ~0.4–2.3 s after navigation (page hydration + accounts snapshot arrival), so an immediate click with a short budget times out. `disabled={sites.length === 0}` on the button pins it until the snapshot lists the site — exactly what the journey's `waitForSiteInSnapshot` guard absorbs.
+- Conclusion: the overlap as described was either fixed between 2026-08-20 and v0.16.6 or needs real-upstream latency to surface; the snapshot race remains the concrete, reproducible race and the journey's existing workaround is correct. The probe script is kept for regression re-runs.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,7 +12,7 @@
 | Frontend static gates     | `bun run typecheck`, `lint`, `format:check`, `knip`, `test`, `build:check` in `web/` | Types, lint, dead code, UI contracts, production bundle                      |
 | Repository e2e            | `e2e/`                                                                               | Full HTTP paths with controlled upstream fixtures                            |
 | Real-service CI           | `.github/workflows/main.yml`                                                         | New API and One API detect/login/route/proxy chains in service containers    |
-| Frontend acceptance       | [`../web/scripts/acceptance-e2e.mjs`](../web/scripts/acceptance-e2e.mjs)             | Real-browser user journeys (Playwright) against a live metapi + real upstream; operator-gated, not a PR check |
+| Frontend acceptance       | [`../web/scripts/acceptance-e2e.mjs`](../web/scripts/acceptance-e2e.mjs) (+ [`acceptance-probe-header-quirk.mjs`](../web/scripts/acceptance-probe-header-quirk.mjs) for the fresh-site accounts-page race) | Real-browser user journeys (Playwright) against a live metapi + real upstream; operator-gated, not a PR check |
 | Operator runtime evidence | `scripts/e2e/*.sh` and focused staging procedures                                    | Compatibility that requires real credentials, topology, or upstream behavior |
 
 ## Public testbed assets

--- a/web/package.json
+++ b/web/package.json
@@ -47,6 +47,7 @@
     "a11y:scan": "node scripts/a11y-scan.mjs",
     "ui:smoke": "node scripts/route-smoke.mjs",
     "acceptance:e2e": "node scripts/acceptance-e2e.mjs",
+    "acceptance:probe-header-quirk": "node scripts/acceptance-probe-header-quirk.mjs",
     "screenshots": "node scripts/screenshot-scan.mjs",
     "ui:audit": "node scripts/dom-audit.mjs",
     "ui:probe-dialog": "node scripts/probe-sites-dialog.mjs",

--- a/web/scripts/acceptance-probe-header-quirk.mjs
+++ b/web/scripts/acceptance-probe-header-quirk.mjs
@@ -273,9 +273,9 @@ const clickedTrials = results.filter(
 )
 console.log(
   `== header-overlap probe summary: ${clickedTrials.length}/${results.length} clean clicks, ` +
-    `${failedTrials.length} failed (${failedTrials
-      .map((r) => r.clickOutcome)
-      .join(', ') || '-'}), load-time interception samples=${loadTimeInterceptionTotal} ==`
+    `${failedTrials.length} failed (${
+      failedTrials.map((r) => r.clickOutcome).join(', ') || '-'
+    }), load-time interception samples=${loadTimeInterceptionTotal} ==`
 )
 if (loadTimeInterceptionTotal > 0) {
   console.log(
@@ -285,6 +285,6 @@ if (loadTimeInterceptionTotal > 0) {
 } else {
   console.log(
     'NOT reproduced at load time: every interception sample occurred AFTER the ' +
-      'probe\'s own click opened the create sheet (expected coverage, not the §6 quirk).'
+      "probe's own click opened the create sheet (expected coverage, not the §6 quirk)."
   )
 }

--- a/web/scripts/acceptance-probe-header-quirk.mjs
+++ b/web/scripts/acceptance-probe-header-quirk.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+// metapi-go — probe for the transient accounts-page header overlap documented
+// in docs/internal/analysis/e2e-acceptance-platform.md §6 ("fresh site → enter
+// accounts page immediately → page header transiently covers the toolbar and
+// intercepts the Add account click").
+//
+// The main acceptance journey (acceptance-e2e.mjs) works around the quirk by
+// polling the accounts snapshot until the site appears BEFORE navigating. This
+// probe deliberately recreates the ORIGINAL failing conditions — navigate to
+// /accounts immediately after creating a fresh site, no snapshot polling — and
+// samples, at high frequency, what element sits at the "Add account" button
+// center during the first moments after load, plus whether a real (non-force)
+// click succeeds, is intercepted, or finds the button disabled.
+//
+// Verdicts per trial:
+//   clicked        — real click landed and the create dialog opened
+//   disabled       — button present but disabled (snapshot race, distinct bug)
+//   intercepted    — click hit-tested onto another element (the §6 overlap)
+//   missing        — button never appeared in the sampling window
+//
+// Configuration:
+//   BASE_URL     metapi admin origin  (default http://127.0.0.1:4000)
+//   AUTH_TOKEN   admin Bearer token   (default e2e-admin-token)
+//   UPSTREAM_URL upstream for the fresh site (any URL; reachability irrelevant)
+//   PROBE_REPEATS number of trials    (default 5)
+
+import { chromium } from 'playwright'
+
+const BASE_URL = (process.env.BASE_URL ?? 'http://127.0.0.1:4000').replace(
+  /\/$/,
+  ''
+)
+const AUTH_TOKEN = process.env.AUTH_TOKEN ?? 'e2e-admin-token'
+const UPSTREAM_URL = process.env.UPSTREAM_URL ?? 'http://127.0.0.1:39999'
+const REPEATS = Number(process.env.PROBE_REPEATS ?? '5')
+const SAMPLE_WINDOW_MS = 2500
+
+const headers = { Authorization: `Bearer ${AUTH_TOKEN}` }
+
+async function wipeState(request) {
+  // Both endpoints return bare JSON arrays (not {accounts}/{sites} wrappers),
+  // but accept either shape defensively like acceptance-e2e.mjs does.
+  const accounts = await request.get(`${BASE_URL}/api/accounts`, { headers })
+  if (accounts.status() === 200) {
+    const data = await accounts.json().catch(() => null)
+    const accountList = Array.isArray(data) ? data : (data?.accounts ?? [])
+    for (const account of accountList) {
+      await request.delete(`${BASE_URL}/api/accounts/${account.id}`, {
+        headers,
+      })
+    }
+  }
+  const sites = await request.get(`${BASE_URL}/api/sites`, { headers })
+  if (sites.status() === 200) {
+    const data = await sites.json().catch(() => null)
+    const siteList = Array.isArray(data) ? data : (data?.sites ?? [])
+    for (const site of siteList) {
+      await request.delete(`${BASE_URL}/api/sites/${site.id}`, { headers })
+    }
+  }
+}
+
+async function createFreshSite(request, name) {
+  const response = await request.post(`${BASE_URL}/api/sites`, {
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    data: { name, url: UPSTREAM_URL, platform: 'new-api' },
+  })
+  if (response.status() !== 200) {
+    throw new Error(
+      `create site failed: HTTP ${response.status()} ${await response.text()}`
+    )
+  }
+}
+
+// High-frequency DOM sampling from inside the page. Returns per-sample rows:
+// button state (absent/disabled/enabled), elementFromPoint at button center,
+// and the header-row vs toolbar rects so an overlap is visible in evidence.
+// Uses setInterval (not rAF) so sampling keeps firing even if the compositor
+// considers the page idle; a hard stop makes the promise always resolve.
+// NOTE: everything the in-page function needs arrives via `arg` — closure
+// variables do NOT survive page.evaluate serialization.
+function samplerInPage({ windowMs, buttonText }) {
+  return new Promise((resolve) => {
+    const startedAt = performance.now()
+    const samples = []
+    const findButton = () => {
+      const buttons = Array.from(document.querySelectorAll('button'))
+      return buttons.find((element) =>
+        new RegExp(buttonText, 'i').test(element.textContent ?? '')
+      )
+    }
+    const describeElement = (element) => {
+      if (!element) return null
+      const className =
+        typeof element.className === 'string'
+          ? element.className.split(/\s+/).slice(0, 4).join('.')
+          : ''
+      return {
+        tag: element.tagName.toLowerCase(),
+        role: element.getAttribute('role'),
+        classes: className,
+      }
+    }
+    const timer = window.setInterval(() => {
+      const elapsed = Math.round(performance.now() - startedAt)
+      const button = findButton()
+      const row = { elapsedMs: elapsed, button: 'absent' }
+      // Interception samples must be separable by cause: a dialog opened by
+      // the probe's own successful click legitimately covers the button
+      // afterwards, which is NOT the load-time overlap this probe hunts.
+      row.dialogOpen = !!document.querySelector('[role="dialog"]')
+      if (button) {
+        const rect = button.getBoundingClientRect()
+        const centerX = rect.left + rect.width / 2
+        const centerY = rect.top + rect.height / 2
+        const hitTarget = document.elementFromPoint(centerX, centerY)
+        row.button = button.disabled ? 'disabled' : 'enabled'
+        row.buttonRect = {
+          top: Math.round(rect.top),
+          height: Math.round(rect.height),
+        }
+        row.hitTarget = describeElement(hitTarget)
+        row.hitIsButton =
+          !!hitTarget && (hitTarget === button || button.contains(hitTarget))
+        const heading = document.querySelector('h1')
+        if (heading) {
+          const headerRow = heading.closest('div')?.getBoundingClientRect()
+          if (headerRow) row.headerRowBottom = Math.round(headerRow.bottom)
+        }
+      }
+      samples.push(row)
+      if (elapsed >= windowMs) {
+        window.clearInterval(timer)
+        resolve(samples)
+      }
+    }, 50)
+  })
+}
+
+function summarizeTrial(samples, clickOutcome, dialogOpened) {
+  // Load-time interception (the §6 quirk) = covered BEFORE any dialog exists.
+  // Post-click interception = the sheet opened by our own successful click
+  // legitimately covering the button afterwards (expected, not a quirk).
+  const loadTimeIntercepted = samples.filter(
+    (row) =>
+      row.button === 'enabled' && row.hitIsButton === false && !row.dialogOpen
+  )
+  const postClickIntercepted = samples.filter(
+    (row) =>
+      row.button === 'enabled' && row.hitIsButton === false && row.dialogOpen
+  )
+  const disabledSamples = samples.filter((row) => row.button === 'disabled')
+  const firstEnabledAt = samples.find((row) => row.button === 'enabled')
+  return {
+    clickOutcome,
+    dialogOpened,
+    firstEnabledAtMs: firstEnabledAt?.elapsedMs ?? null,
+    disabledSampleCount: disabledSamples.length,
+    loadTimeInterceptedCount: loadTimeIntercepted.length,
+    postClickInterceptedCount: postClickIntercepted.length,
+    loadTimeTargets: [
+      ...new Set(
+        loadTimeIntercepted.map(
+          (row) =>
+            `${row.hitTarget?.tag ?? '?'}${row.hitTarget?.classes ? '.' + row.hitTarget.classes : ''}`
+        )
+      ),
+    ],
+    sampleCount: samples.length,
+  }
+}
+
+const browser = await chromium.launch({ headless: true })
+const results = []
+try {
+  for (let trial = 1; trial <= REPEATS; trial += 1) {
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 900 },
+      locale: 'en',
+    })
+    await context.addInitScript(
+      ({ token }) => {
+        localStorage.setItem('auth_token', token)
+        localStorage.setItem(
+          'auth_token_expires_at',
+          String(Date.now() + 12 * 3600 * 1000)
+        )
+        localStorage.setItem('i18nextLng', 'en')
+      },
+      { token: AUTH_TOKEN }
+    )
+
+    await wipeState(context.request)
+    await createFreshSite(context.request, `quirk-probe-${trial}`)
+
+    const page = await context.newPage()
+    // Navigate immediately after create — no snapshot polling (the point).
+    await page.goto(`${BASE_URL}/accounts`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 20_000,
+    })
+
+    const samplingPromise = page.evaluate(samplerInPage, {
+      windowMs: SAMPLE_WINDOW_MS,
+      buttonText: 'Add account',
+    })
+    // Never let a stuck in-page sampler hang the whole probe.
+    const samplingGuard = new Promise((resolve) =>
+      setTimeout(() => resolve([]), SAMPLE_WINDOW_MS + 5000)
+    )
+    samplingPromise.catch(() => {})
+
+    // Concurrently attempt a real, actionable click (no force): Playwright
+    // waits for visible+enabled+stable+receives-events, so its failure reason
+    // distinguishes "disabled" from "intercepted by another element".
+    const addAccount = page
+      .getByRole('button', { name: /Add account/i })
+      .first()
+    let clickOutcome = 'clicked'
+    try {
+      await addAccount.click({ timeout: SAMPLE_WINDOW_MS })
+    } catch (error) {
+      // Playwright's timeout error embeds the full chronological call log; the
+      // LAST matching reason is the state that consumed the timeout budget.
+      const message = String(error?.message ?? error)
+      const interceptAt = message.search(/intercept/i)
+      const notEnabledAt = message.search(/not enabled|disabled/i)
+      if (interceptAt === -1 && notEnabledAt === -1) {
+        clickOutcome = `error: ${message.split('\n')[0]}`
+      } else if (interceptAt > notEnabledAt) {
+        clickOutcome = 'intercepted'
+      } else {
+        clickOutcome = 'disabled'
+      }
+    }
+
+    let dialogOpened = false
+    if (clickOutcome === 'clicked') {
+      dialogOpened = await page
+        .locator('[role="dialog"]')
+        .first()
+        .isVisible()
+        .catch(() => false)
+    }
+
+    const samples = await Promise.race([samplingPromise, samplingGuard])
+    const summary = summarizeTrial(samples, clickOutcome, dialogOpened)
+    results.push({ trial, ...summary })
+    console.log(
+      `trial ${trial}: click=${summary.clickOutcome} dialog=${summary.dialogOpened} ` +
+        `firstEnabledAt=${summary.firstEnabledAtMs}ms ` +
+        `disabledSamples=${summary.disabledSampleCount} ` +
+        `loadTimeIntercepted=${summary.loadTimeInterceptedCount} ` +
+        `postClickIntercepted=${summary.postClickInterceptedCount}` +
+        (summary.loadTimeTargets.length
+          ? ` loadTimeTargets=[${summary.loadTimeTargets.join(', ')}]`
+          : '')
+    )
+    await page.close().catch(() => {})
+    await context.close().catch(() => {})
+  }
+} finally {
+  await browser.close()
+}
+
+const loadTimeInterceptionTotal = results.reduce(
+  (sum, r) => sum + r.loadTimeInterceptedCount,
+  0
+)
+const failedTrials = results.filter((r) => r.clickOutcome !== 'clicked')
+const clickedTrials = results.filter(
+  (r) => r.clickOutcome === 'clicked' && r.dialogOpened
+)
+console.log(
+  `== header-overlap probe summary: ${clickedTrials.length}/${results.length} clean clicks, ` +
+    `${failedTrials.length} failed (${failedTrials
+      .map((r) => r.clickOutcome)
+      .join(', ') || '-'}), load-time interception samples=${loadTimeInterceptionTotal} ==`
+)
+if (loadTimeInterceptionTotal > 0) {
+  console.log(
+    'REPRODUCED: §6 load-time overlap — button covered by: ' +
+      [...new Set(results.flatMap((r) => r.loadTimeTargets))].join(', ')
+  )
+} else {
+  console.log(
+    'NOT reproduced at load time: every interception sample occurred AFTER the ' +
+      'probe\'s own click opened the create sheet (expected coverage, not the §6 quirk).'
+  )
+}


### PR DESCRIPTION
## Wave 4 E 线（实测验收）· v0.16.6 (master=f32d99d) · 2026-08-22

本 PR 无产品代码改动（探针脚本 + 文档 + 证据）。实测证据与缺陷移交见下；完整命令与输出见 `EVIDENCE.md`（本 PR 内）。

### 证据清单（每条可在 10 分钟内复跑）

1. **Go e2e 套件全绿** — `go test ./e2e/... -count=1 -v`：31 PASS / 0 FAIL / 0 SKIP（`ok github.com/deliciousbuding/metapi-go/e2e 5.903s`）。7 个文件逐一结论见 EVIDENCE.md E1；`e2e_p0585_production_test.go` 为 `-tags=staging`，缺环境时按设计 fail-fast。
2. **SQLite 方言启动 + 优雅退出** — `/health`→200 `{"status":"ok"}`、`/ready`→200 `{"status":"ok","database":"ok"}`；SIGTERM 后日志 `received signal, shutting down signal=terminated` → `server stopped`。端口冲突时有序报错退出（E2）。
3. **PostgreSQL 方言启动 + 优雅退出** — 临时库建库/迁移（`dialect=postgres`，24 条 additive migration 应用）/健康探针 200/SIGTERM 优雅退出/删库（E3）。
4. **acceptance 旅程（假上游，诚实行为）** — 不可达上游 `http://127.0.0.1:39999` 下旅程 1 仍 PASS（显式选平台，建站不依赖上游可达）；`POST /api/sites/detect` 对不可达上游诚实 400 `{"error":"Could not detect platform"}`（E4）。
5. **ACCEPT_LOGIN=1 全链路按步诚实失败** — 旅程 2 失败于 `step "account row appears": Timeout 25000ms`（无真实上游登录不可能成功），旅程 3 失败于 `locate account`；失败前全部步骤（快照轮询→Add account→Password tab→站点选择→凭据→submit）选择器均命中当前 DOM（E5/E7）。
6. **§6 quirk 探针（30+ trial）** — 新增 `web/scripts/acceptance-probe-header-quirk.mjs`：20Hz elementFromPoint 采样 + 并行真实点击。视觉重叠未复现；实测残余 = 按钮 ~0.4–2.3s 后才可操作 + `disabled={sites.length===0}` 快照钉住（E8）。
7. **门禁机全绿** — 实测节点：`go build` OK、`go vet ./...` OK、`bun run typecheck` OK、`bun run lint` OK（0 errors / 24 既有 warnings）、`bun run test` 138 文件 952 测试全过、`bash ./scripts/go-race.sh` OK。

### 缺陷移交清单（只记录不动手；无 B/C/M 线缺陷）

| # | 严重度 | 现象 | 证据 | 归属线 |
|:--|:--|:--|:--|:--|
| 1 | 低 | 全新站点后立即进 /accounts，「Add account」按钮 ~0.4–2.3s 不可操作；快照未含站点时 `disabled={sites.length===0}` 钉住按钮（`features/accounts/components/accounts-page.tsx:453`）。脚本侧已有 `waitForSiteInSnapshot` 防护并实测有效；建议 F 线评估骨架态/禁用提示的 UX 收口 | E8 探针 30+ trial | F |
| 2 | 低 | §6 文档所述「页头瞬态盖住工具栏」在 v0.16.6 未复现（文档所述，2026-08-20 记录；本轮实测未现，或已随 #895/#910 修复，或需真实上游延迟环境才显现）；文档 §6 已更新实测结论，建议 F 线确认是否关闭该条目 | E8 | F |
| 3 | — | 无 B（auth/config）/ C（handler/store/proxy）/ M（迁移）线缺陷：e2e 31/31、双方言启动、优雅退出、detect 端点行为均符合预期 | E1–E3 | 无 |

### 脚本层修复（本 PR 白名单内）

- 新增探针 `web/scripts/acceptance-probe-header-quirk.mjs`（operator-gated，用于复测 §6 竞态）。
- 文档修正：`bun --cwd web run acceptance:e2e` 在 bun 1.x 打印 usage 且 exit 0（静默 no-op 假绿）→ 正确形式 `bun run --cwd web acceptance:e2e`；并新增安全提示（旅程会清空目标实例全部站点/账户，务必显式 BASE_URL 指向一次性实例）。
- 文档 §3/§6 澄清：显式选平台时建站跳过 detect；quirk 复测结论与 file:line。

### 环境诚实记录（未跑/不允许）

- 旅程 2/3 完整通过需真实上游凭据 — 本轮决策不碰真实上游，只跑诚实失败路径（BLOCKED B1）。
- `e2e_p0585_production_test.go` 深跑需 staging 实例（无，BLOCKED B2）。
- 本机无 Docker，`testbed/compose.template.yml` 链路未跑（BLOCKED B3）。
- `PROGRESS.md`/`BLOCKED.md` 被仓库 `.gitignore`（第 92–93 行）显式忽略，未纳入提交；内容并入本 body 与 `EVIDENCE.md`。
