### PR TITLE
fix(web): Wave 4 F 线 — C 域 a11y 补审计 + 动线实测修复

### DIFF
--- a/web/scripts/dark-contrast-probe.mjs
+++ b/web/scripts/dark-contrast-probe.mjs
@@ -69,6 +69,7 @@ for (const route of ROUTES) {
   // right after mount, which destroys the evaluation context mid-run. Retry
   // sampling once the navigation settles instead of crashing.
   let samples = []
+  let sampleError = null
   for (let attempt = 0; attempt < 3 && samples.length === 0; attempt += 1) {
     if (attempt > 0) await page.waitForTimeout(600)
     try {
@@ -102,9 +103,21 @@ for (const route of ROUTES) {
           })
         return out.slice(0, 300)
       })
-    } catch {
+      sampleError = null
+    } catch (error) {
       // Navigation raced the evaluate; retry after the route settles.
+      sampleError = error
     }
+  }
+  if (samples.length === 0) {
+    // Never emit a false "ok": an un-sampled route is an audit failure.
+    const reason = sampleError
+      ? String(sampleError.message ?? sampleError).split('\n')[0]
+      : 'no text samples collected'
+    console.log(`[${route}] SAMPLE-FAILED (${reason})`)
+    process.exitCode = 1
+    await page.close()
+    continue
   }
   const fails = []
   for (const s of samples) {

--- a/web/scripts/dark-contrast-probe.mjs
+++ b/web/scripts/dark-contrast-probe.mjs
@@ -4,6 +4,7 @@
 import { chromium } from 'playwright'
 
 const BASE_URL = process.env.BASE_URL ?? 'http://127.0.0.1:4099'
+const AUTH_TOKEN = process.env.AUTH_TOKEN ?? 'dev-admin-token-123'
 const ROUTES = [
   '/',
   '/sites',
@@ -53,7 +54,7 @@ await context.addInitScript(
     )
     localStorage.setItem('i18nextLng', 'zh-CN')
   },
-  { token: 'dev-admin-token-123' }
+  { token: AUTH_TOKEN }
 )
 
 for (const route of ROUTES) {
@@ -64,36 +65,47 @@ for (const route of ROUTES) {
   })
   await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {})
   await page.waitForTimeout(500)
-  const samples = await page.evaluate(() => {
-    const bg = (el) => {
-      let node = el
-      while (node && node !== document.documentElement) {
-        const c = getComputedStyle(node).backgroundColor
-        if (c && c !== 'rgba(0, 0, 0, 0)' && c !== 'transparent') return c
-        node = node.parentElement
-      }
-      return getComputedStyle(document.body).backgroundColor
-    }
-    const out = []
-    document
-      .querySelectorAll('p, span, div, td, th, label, a, button, li')
-      .forEach((el) => {
-        if (el.children.length > 0) return
-        const r = el.getBoundingClientRect()
-        if (r.width === 0 || r.height === 0) return
-        const s = getComputedStyle(el)
-        if (s.fontSize === '0px') return
-        const text = el.textContent.trim()
-        if (!text || text.length > 40) return
-        out.push({
-          text: text.slice(0, 30),
-          color: s.color,
-          bg: bg(el),
-          fontSize: parseFloat(s.fontSize),
-        })
+  // List pages sync list state into the URL (e.g. /sites -> ?page=0&pageSize=20)
+  // right after mount, which destroys the evaluation context mid-run. Retry
+  // sampling once the navigation settles instead of crashing.
+  let samples = []
+  for (let attempt = 0; attempt < 3 && samples.length === 0; attempt += 1) {
+    if (attempt > 0) await page.waitForTimeout(600)
+    try {
+      samples = await page.evaluate(() => {
+        const bg = (el) => {
+          let node = el
+          while (node && node !== document.documentElement) {
+            const c = getComputedStyle(node).backgroundColor
+            if (c && c !== 'rgba(0, 0, 0, 0)' && c !== 'transparent') return c
+            node = node.parentElement
+          }
+          return getComputedStyle(document.body).backgroundColor
+        }
+        const out = []
+        document
+          .querySelectorAll('p, span, div, td, th, label, a, button, li')
+          .forEach((el) => {
+            if (el.children.length > 0) return
+            const r = el.getBoundingClientRect()
+            if (r.width === 0 || r.height === 0) return
+            const s = getComputedStyle(el)
+            if (s.fontSize === '0px') return
+            const text = el.textContent.trim()
+            if (!text || text.length > 40) return
+            out.push({
+              text: text.slice(0, 30),
+              color: s.color,
+              bg: bg(el),
+              fontSize: parseFloat(s.fontSize),
+            })
+          })
+        return out.slice(0, 300)
       })
-    return out.slice(0, 300)
-  })
+    } catch {
+      // Navigation raced the evaluate; retry after the route settles.
+    }
+  }
   const fails = []
   for (const s of samples) {
     const fg = parseColor(s.color)

--- a/web/scripts/probe-page.mjs
+++ b/web/scripts/probe-page.mjs
@@ -6,6 +6,7 @@ import { chromium } from 'playwright'
 
 const route = process.argv[2] ?? '/accounts'
 const BASE_URL = process.env.BASE_URL ?? 'http://127.0.0.1:4099'
+const AUTH_TOKEN = process.env.AUTH_TOKEN ?? 'dev-admin-token-123'
 const browser = await chromium.launch({
   headless: true,
   args: ['--no-proxy-server'],
@@ -23,7 +24,7 @@ await context.addInitScript(
     )
     localStorage.setItem('i18nextLng', 'zh-CN')
   },
-  { token: 'dev-admin-token-123' }
+  { token: AUTH_TOKEN }
 )
 const page = await context.newPage()
 const errors = []

--- a/web/scripts/probe-sites-dialog.mjs
+++ b/web/scripts/probe-sites-dialog.mjs
@@ -3,6 +3,7 @@
 import { chromium } from 'playwright'
 
 const BASE_URL = process.env.BASE_URL ?? 'http://127.0.0.1:4099'
+const AUTH_TOKEN = process.env.AUTH_TOKEN ?? 'dev-admin-token-123'
 const browser = await chromium.launch({
   headless: true,
   args: ['--no-proxy-server'],
@@ -20,7 +21,7 @@ await context.addInitScript(
     )
     localStorage.setItem('i18nextLng', 'zh-CN')
   },
-  { token: 'dev-admin-token-123' }
+  { token: AUTH_TOKEN }
 )
 const page = await context.newPage()
 await page.goto(`${BASE_URL}/sites`, {

--- a/web/src/components/ui/__tests__/form-message.test.tsx
+++ b/web/src/components/ui/__tests__/form-message.test.tsx
@@ -1,0 +1,72 @@
+// metapi-go/ui — FormMessage announcement contract.
+// Field errors rendered by the shared form primitives must be announced by
+// assistive tech the moment they appear: the message element carries an
+// assertive live-region role, and the invalid control references it through
+// aria-describedby (wired by FormControl).
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import '@/i18n/config'
+
+type HarnessValues = { token: string }
+
+function FormMessageHarness() {
+  const form = useForm<HarnessValues>({ defaultValues: { token: '' } })
+
+  useEffect(() => {
+    form.setError('token', { message: 'The login token is invalid.' })
+  }, [form])
+
+  return (
+    <Form {...form}>
+      <form>
+        <FormField
+          control={form.control}
+          name='token'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Admin token</FormLabel>
+              <FormControl>
+                <input type='password' {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </form>
+    </Form>
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('FormMessage error announcement', () => {
+  it('renders the field error inside an assertive live region (role=alert)', async () => {
+    render(<FormMessageHarness />)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('The login token is invalid.')
+  })
+
+  it('links the invalid control to the error message via aria-describedby', async () => {
+    render(<FormMessageHarness />)
+
+    const alert = await screen.findByRole('alert')
+    const input = screen.getByLabelText('Admin token')
+    const describedBy = input.getAttribute('aria-describedby') ?? ''
+
+    expect(input).toHaveAttribute('aria-invalid', 'true')
+    expect(describedBy.split(' ')).toContain(alert.id)
+  })
+})

--- a/web/src/components/ui/form.tsx
+++ b/web/src/components/ui/form.tsx
@@ -249,6 +249,10 @@ function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
       data-slot='form-message'
       data-form-root={formContext?.id}
       id={formMessageId}
+      // Assertive live region: errors mount after a failed submit, and the
+      // role makes screen readers announce them without waiting for focus to
+      // reach the (aria-describedby-linked) control.
+      role='alert'
       className={cn('text-destructive text-sm', className)}
       {...props}
     >


### PR DESCRIPTION
## 发现清单（任务 1 — C 域 a11y 补审计，全部实测取证）

取证方式：真实渲染 DOM（Playwright/Chromium 探针 × 真实起服的 Go 二进制 + 嵌入式前端，:4321，SQLite 临时 DATA_DIR）+ API 走线（curl）。

| # | 严重度 | 位置 | 描述 |
|---|---|---|---|
| A | P1 | `web/src/components/ui/form.tsx` `FormMessage` | 表单错误信息无 `role="alert"`/live region，错误出现时读屏不主动播报。实测：`BAD-LOGIN render: {"alertText":"(no role=alert)","ariaInvalid":"true","stillOnSignIn":true}`。对应 a11y-checklist §6「Live regions — Residual」 |
| B | P1 | `web/scripts/dark-contrast-probe.mjs` | `bun run ui:contrast` 在列表路由崩溃：列表页挂载后把分页状态同步进 URL，navigation 摧毁 evaluate 上下文（`Execution context was destroyed`），对比度审计管线被阻断 |
| C | P2 | `web/src/components/ui/sidebar.tsx` `SidebarRail` | 拖拽条命中宽度 16px（WCAG 2.5.8 建议 24px）；`tabIndex=-1` 纯鼠标辅助，键盘有 Ctrl/Cmd+B 等价路径 |
| D | P2 | 面包屑/设置子导航文字链接 | 20px 高文字链接（ui:audit TINY-HIT ×~40）；行内文字链接属 2.5.8 豁免范畴 |
| E | P2 | 维护页「查看程序日志」链接 | 14px 高 text-xs 链接（TINY-HIT），同豁免范畴 |
| F | P2 | 登录页 Tab 序 | docs 链接后一次 focus 落 body 再到 InterfaceControls；多按一次 Tab 可达，不阻断 |
| G | 环境 | dom-audit 交互段 | /accounts /models /token-routes 行菜单探针超时——审计时三页 0 行数据无行菜单可点；route-smoke 同交互带数据全绿，非产品缺陷 |
| H | 记录 | 404 页 3×403 console | 探针故意植入假 token，shell fetch 得 403 属预期；404 UI 正常（"Page not found / Back to dashboard"） |

P0：无。扫描基线：`a11y:scan` 15 路由 0 serious/critical；`ui:audit` 35 desktop + 7 mobile 0 hard failure；`ui:contrast`（修复后）7/7 ok；键盘-only 抽查登录页/站点列表/站点表单对话框全通（焦点入对话框、Escape 关闭、错误可见、aria-invalid、焦点移至首个非法字段）。

## 本轮修复（任务 3）

1. **P1-A** `FormMessage` 加 `role='alert'`（共享原语，全站表单错误播报受益）。红→绿：新增 `web/src/components/ui/__tests__/form-message.test.tsx`，红 `Tests 2 failed (2)`（`findByRole('alert')` 超时）→ 绿 `Tests 2 passed (2)`；真实 DOM 复验：`BAD-LOGIN render: {"alertText":"The login token is invalid.",...}`（negative-probe 复跑）。
2. **P1-B** `dark-contrast-probe.mjs` 导航竞态重试修复。红 = 崩溃栈 → 绿 = 7/7 路由 ok（真实 Chromium 复跑，人工验证）。
3. 探针脚本一致性：`probe-page.mjs` / `probe-sites-dialog.mjs` 补 `AUTH_TOKEN` env（与姊妹脚本对齐，默认值不变，向后兼容）。

修复后复测：`a11y:scan` clean（15 路由）、`ui:contrast` 7/7 ok、typecheck/lint/knip 全绿。

## 残留清单（P2 本轮不修，只列）

- C/D/E：小命中目标（sidebar rail 16px、文字链接 20/14px）——豁免/替代路径存在。
- F：登录页 Tab 序一次落 body。
- 动线④观察：/v1 失败请求的 proxy-log 为异步入账（实测 ~1 分钟后可见，`/api/stats/proxy-logs` total=1）；入账延迟属 Go 侧行为，不在本线白名单。

### 移交清单（别线地界观察）

- 后端校验错误文案为中文硬编码（如 `请填写 Token`、`模型匹配不能为空`、`key 不能为空`），与前端 i18n 体系不一致——建议后端线评估。
- proxy-log 异步 flush 间隔未文档化（实测 ~1 分钟），使用日志页在请求刚发生后可能暂时为空——建议后端/文档线评估。
- `docs/internal/design/a11y-checklist.md` §6「Live regions — Residual」：表单错误的 live region 已由本 PR 补齐（FormMessage role=alert），toast 播报仍未覆盖；且该残差条目本身需 docs owner 更新（docs/ 不在 F 线白名单）。

## 门禁输出（任务 4）

门禁在独立 gate 机（go1.26.6）的干净 worktree（@ 6a23434）执行，命令按任务书：`export PATH=<go1.26.6>:$PATH; go build ./cmd/server && go vet ./... && cd web && bun install && bun run typecheck && bun run lint && bun run test && cd .. && METAPI_RACE_TIMEOUT_SECONDS=1200 bash ./scripts/go-race.sh`，**退出码 0**。

- `go build ./cmd/server` ✓；`go vet ./...` ✓；`bun install` + `typecheck`（tsgo exit 0）+ `lint`（0 error）✓
- `bun run test`（门禁机）：`Test Files 139 passed (139)` / `Tests 954 passed (954)` / Duration 420.12s
- `go-race`（`go test ./... -count=1 -race`）：38 包全 `ok`，0 FAIL，含 `ok github.com/deliciousbuding/metapi-go/service/oauth 105.026s`、`store 88.848s`

备注：门禁第 1 次尝试在 race 段 `service/oauth TestRefreshAccessTokenSingleflight_Dedupes` 单点失败（`refresh_test.go:595: concurrent singleflight 1 failed: oauth refresh token missing`）。本分支 0 行 Go 改动（diff 全在 web/**），同窗口其他线同基线门禁全绿；空闲机上该测试 `-count=3 -race` 连过，判为并发负载时序 flake。第 2 次尝试（机器近空闲）全绿，即上述输出。

## BLOCKED

无。

## 五动线实测记录（任务 2）

1. **首次接入**（站点→账号→路由）：建站点 200 → 建账号 200（apikey 模式）→ 建路由 200（pattern 模式）→ 挂渠道 200。首跑因探针 payload 用错字段 400（`请填写 Token`），修正 payload 后全通。通过。
2. **下游 token 创建与使用**：客户端生成 `sk-…` 创建 200 → 持 key 打 `/v1/chat/completions` 得 502 上游错误（非 401/403）= 准入链路通、上游错误正确冒泡。通过。
3. **模型测试器**：`/api/admin/test-channel` 返回结构化上游错误（error/latencyMs/upstreamHost），`/model-tester` 页渲染 0 console error。通过。
4. **使用日志/可观测**：`/api/stats/proxy-logs` 复查 total=1（异步入账），`/api/stats/dashboard` 200，两页渲染正常。通过（含异步入账备注）。
5. **设置导入导出**：`/api/settings/backup/export` 200（metadata+tables），`/api/settings/runtime` 200，import-export 页渲染正常。通过。

**反向验证**：不存在路由 → SPA fallback 200 + "Page not found / Back to dashboard"；非法表单（建站点缺 url）→ 400 `Invalid url. Expected non-empty string.`；错 token 登录 → 错误文案 + `aria-invalid=true` + 停留登录页；坏 admin token 调 API → 403 `Invalid token`。
