### PR TITLE
docs: Wave 4 D 线 — 部署体验修复（新用户 3 分钟路径）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,8 @@ CHECKIN_INTERVAL_HOURS=6
 CHECKIN_WINDOW_START=00:00
 CHECKIN_WINDOW_END=23:59
 BALANCE_REFRESH_CRON=0 * * * *
-LOG_CLEANUP_CRON=0 3 * * *
+# Code default is 06:00 daily (DefaultLogCleanupCron).
+LOG_CLEANUP_CRON=0 6 * * *
 
 # Optional site branding overrides. Runtime settings can override these values.
 SYSTEM_NAME=Metapi

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 <h1 align="center">Metapi Go</h1>
 
 <p align="center">
-  <strong>中转站的中转站 — 将分散的 AI API 站点聚合为一个统一网关</strong>
+  <strong>中转站的中转站 —— 把分散的 AI API 站点聚合为一个统一网关</strong>
 </p>
 
 <p align="center">
-  把你在各处注册的 New API / One API / OneHub / Sub2API 等站点，<br>
-  汇聚成 <strong>一个 API Key、一个入口</strong>，自动发现模型、智能路由、成本最优。
+  将你在各处注册的 New API / One API / OneHub / Sub2API 等站点，<br>
+  汇聚成<strong>一个 API Key、一个入口</strong>：自动发现模型、智能路由、成本最优。
 </p>
 
 <p align="center">
@@ -75,11 +75,11 @@
 
 ---
 
-## 介绍
+## 什么是 Metapi
 
-现在 AI 生态里有越来越多基于 New API / One API 系列的聚合中转站，要管理多个站点的余额、模型列表和 API 密钥，往往既分散又费时。
+AI 生态里基于 New API / One API 系列的聚合中转站越来越多，多站点的余额、模型列表和 API 密钥往往分散在各处。**Metapi** 是这些中转站之上的**元聚合层（Meta-Aggregation Layer）**：把多个站点统一到**一个入口**，下游所有工具（Cursor、Claude Code、Codex、Open WebUI 等）即可无感接入全部模型。
 
-**Metapi** 作为这些中转站之上的**元聚合层（Meta-Aggregation Layer）**，把多个站点统一到 **一个入口（可按项目配置多个下游 API Key）**——下游所有工具（Cursor、Claude Code、Codex、Open WebUI 等）即可无感接入全部模型。当前支持的上游范围：
+支持的上游：
 
 - **聚合面板**：New API、One API、OneHub、DoneHub、Veloera、AnyRouter、Sub2API
 - **通用兼容接口**：OpenAI / Claude / Gemini 兼容端点，以及 `cliproxyapi` / CPA
@@ -87,29 +87,63 @@
 
 | 痛点                               | Metapi 怎么解决                                          |
 | ---------------------------------- | -------------------------------------------------------- |
-| 每个站点一个 Key，下游工具配置一堆 | **统一代理入口 + 多下游 Key 策略**，模型自动聚合到 `/v1/*` |
-| 不知道哪个站点用某个模型最便宜     | **智能路由**自动按成本、余额、使用率选最优通道           |
-| 某个站点挂了，手动切换好麻烦       | **自动故障转移**，一个通道失败自动冷却并切到下一个       |
-| 余额分散在各处，不知道还剩多少     | **集中看板**一目了然，余额不足自动告警                   |
+| 每个站点一个 Key，下游工具配置一堆 | **统一代理入口 + 多下游 Key**，模型自动聚合到 `/v1/*`    |
+| 不知道哪个站点用某个模型最便宜     | **智能路由**按成本、余额、使用率自动选最优通道           |
+| 站点挂了要手动切换                 | **自动故障转移**，失败通道冷却、请求自动重试下一通道     |
+| 余额分散，不知道还剩多少           | **集中看板**一目了然，余额不足自动告警                   |
 | 每天得去各站签到领额度             | **自动签到**定时执行，奖励自动追踪                       |
-| 不知道哪个站有什么模型             | **自动模型发现**，上游新增模型零配置出现在你的模型列表里 |
+| 不知道哪个站有什么模型             | **自动模型发现**，上游新增模型零配置进入路由             |
 
-### Go 版有什么不同
+本项目是 [Metapi（TypeScript 版）](https://github.com/cita-777/metapi) 的 Go 重写，客户端可见行为保持兼容：
 
-这是 [Metapi（TypeScript 版）](https://github.com/cita-777/metapi) 的 Go 重写，客户端可见行为保持兼容，运行时更轻：
-
-|             | Node.js（原版）  | Go（本版）     |
-| ----------- | ---------------- | -------------- |
-| 内存占用    | ~85 MB           | ~20 MB         |
-| Docker 镜像 | ~250 MB          | ~15 MB         |
-| 启动时间    | 5-10 秒          | 即时           |
-| 部署方式    | 需要 Node 运行时 | 单个二进制文件 |
+|             | Node.js（原版） | Go（本版）     |
+| ----------- | --------------- | -------------- |
+| 内存占用    | ~85 MB          | ~20 MB         |
+| Docker 镜像 | ~250 MB         | ~15 MB         |
+| 启动时间    | 5-10 秒         | 即时           |
+| 部署方式    | Node 运行时     | 单个二进制文件 |
 
 ---
 
-## 快速开始
+## 快速开始（3 分钟）
 
-### Docker（推荐）
+发布页提供 Linux / macOS / Windows 预编译二进制，单文件即跑。
+
+**1. 安装**（Linux / macOS；Windows 直接从 [Releases](https://github.com/DeliciousBuding/metapi-go/releases/latest) 下载 `metapi-windows-amd64.exe`）：
+
+```bash
+curl -fsSL https://github.com/DeliciousBuding/metapi-go/releases/latest/download/install.sh | bash
+```
+
+脚本自动校验 SHA-256 并安装到 `/usr/local/bin/metapi`。没有 `/usr/local` 写权限时，
+用 `METAPI_INSTALL_PREFIX` 指定安装目录（如 `METAPI_INSTALL_PREFIX=~/.local` 会安装到 `~/.local/bin/metapi`）。
+
+**2. 启动**（仅需两个令牌）：
+
+```bash
+export AUTH_TOKEN=$(openssl rand -hex 16)      # 管理后台登录令牌
+export PROXY_TOKEN=sk-$(openssl rand -hex 24)  # 下游客户端调用 /v1/* 的 Key
+metapi
+```
+
+**3. 验证**：
+
+```bash
+curl http://localhost:4000/health
+# {"status":"ok"}
+curl http://localhost:4000/ready
+# {"status":"ok","database":"ok"}
+```
+
+打开 `http://localhost:4000`，用 `AUTH_TOKEN` 登录。数据默认存放在 `./data`（SQLite），删除令牌环境变量不会丢失数据。
+
+> 以上为实测路径；端口被占用时用 `PORT=<端口>` 覆盖（默认 4000）。接下来在界面里添加站点与账号、自动重建路由，即可发出第一个代理请求——完整流程见 [快速上手](docs/getting-started.md)。
+
+## 部署
+
+### Docker
+
+> 以下命令与仓库 `Dockerfile` / `docker-compose.prod.yml` 逐项核对（本环境无 Docker，未实跑）。
 
 ```bash
 docker run -d --name metapi \
@@ -123,80 +157,58 @@ docker run -d --name metapi \
   ghcr.io/deliciousbuding/metapi-go:latest
 ```
 
-启动后访问 `http://localhost:4000`，用 `AUTH_TOKEN` 登录即可。
+要点：
 
-> [!IMPORTANT]
-> 请务必修改 `AUTH_TOKEN` 和 `PROXY_TOKEN`，不要使用默认值。
-> `ACCOUNT_CREDENTIAL_SECRET` 用于加密存储的账号凭据，建议生成独立的 32+ 字节随机串（不设置时会回退为 `AUTH_TOKEN`，过短会直接启动失败）。
-> 数据建议用**命名卷**（如上 `metapi_data`）存放，容器以非 root 用户（uid 1001）运行，命名卷会自动继承属主、无需额外授权；若改用 `./data:/app/data` 这类 bind mount，需先在宿主机执行 `chown -R 1001:1001 ./data`。
-> 生产环境建议把镜像固定到具体版本标签（如 `ghcr.io/deliciousbuding/metapi-go:v0.16.6`），而不是 `latest`（升级步骤见 [迁移指南](docs/migration.md)）。
+- 镜像以非 root 用户（uid 1001）运行。**命名卷**（如上 `metapi_data`）首次挂载自动继承镜像内属主，零配置；改用 `./data:/app/data` 这类 bind mount 时需先在宿主机执行 `chown -R 1001:1001 ./data`，详见 [部署指南](docs/deployment.md)。
+- `ACCOUNT_CREDENTIAL_SECRET` 用于加密存储的上游凭据，建议独立生成 32+ 字节随机串；不设置会回退为 `AUTH_TOKEN`。
+- 生产环境建议固定版本标签（如 `:v0.16.6`）而非 `latest`。
 
 ### Docker Compose
 
+`docker-compose.prod.yml`（GHCR 镜像 + 生产硬化）或 `docker-compose.yml`（本地构建）：
+
 ```bash
-mkdir metapi && cd metapi
-
-cat > docker-compose.yml << 'EOF'
-services:
-  metapi:
-    image: ghcr.io/deliciousbuding/metapi-go:latest
-    ports:
-      - "4000:4000"
-    volumes:
-      - metapi_data:/app/data
-    environment:
-      AUTH_TOKEN: ${AUTH_TOKEN:?AUTH_TOKEN is required}
-      PROXY_TOKEN: ${PROXY_TOKEN:?PROXY_TOKEN is required}
-      ACCOUNT_CREDENTIAL_SECRET: ${ACCOUNT_CREDENTIAL_SECRET:-}
-      CHECKIN_CRON: "0 8 * * *"
-      BALANCE_REFRESH_CRON: "0 * * * *"
-      PORT: ${PORT:-4000}
-      DATA_DIR: /app/data
-      TZ: ${TZ:-Asia/Shanghai}
-    restart: unless-stopped
-
-volumes:
-  metapi_data:
-EOF
-
-export AUTH_TOKEN=your-admin-token
-export PROXY_TOKEN=your-proxy-sk-token
-export ACCOUNT_CREDENTIAL_SECRET=$(openssl rand -hex 32)
-docker compose up -d
+cp .env.example .env   # 填入 AUTH_TOKEN / PROXY_TOKEN / ACCOUNT_CREDENTIAL_SECRET
+docker compose -f docker-compose.prod.yml up -d
 ```
 
-> 如需从旧的 TypeScript 版迁移数据，改用 bind mount 指向原 `data` 目录，并先在宿主机执行 `chown -R 1001:1001 ./data`（详见 [迁移指南](docs/migration.md)）。
+### 从源码构建
 
-Compose、反向代理、PostgreSQL 与升级细节见 [部署指南](docs/deployment.md)；从安装到发出第一个代理请求的完整 walkthrough 见 [快速上手](docs/getting-started.md)。
-
-### 从源码
+需要 Go 1.26+ 与 Bun 1.x（前端需先构建，产物经 `go:embed` 打包进二进制）：
 
 ```bash
 git clone https://github.com/DeliciousBuding/metapi-go.git
 cd metapi-go
+cd web && bun install --frozen-lockfile && bun run build:web && cd ..
 go build -o metapi ./cmd/server
 AUTH_TOKEN=your-admin-token PROXY_TOKEN=your-proxy-sk-token ./metapi
 ```
 
-Windows 本地运行且未设置 `HOST` 时，默认仅监听 `127.0.0.1`，避免反复触发入站防火墙提示；需要局域网访问时显式设置 `HOST=0.0.0.0`。
+反向代理、PostgreSQL、升级与回滚见 [部署指南](docs/deployment.md)。
 
 ---
 
 ## 第一个代理请求
 
-登录后在「下游密钥」里创建一把 Key（或直接使用 `PROXY_TOKEN`），然后像调用 OpenAI 一样调用 Metapi：
+在界面里添加至少一个上游站点与账号、执行「重建全部路由」后（见 [快速上手](docs/getting-started.md)），像调用 OpenAI 一样调用 Metapi：
 
 ```bash
 curl http://localhost:4000/v1/chat/completions \
   -H "Authorization: Bearer $PROXY_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "claude-3-5-sonnet",
+    "model": "<任意已路由模型>",
     "messages": [{ "role": "user", "content": "hello" }]
   }'
 ```
 
-Metapi 会自动在所有上游站点中选择成本最优、状态健康的通道；失败时自动冷却该通道并重试下一个。Claude 原生格式（`/v1/messages`）、Responses、Embeddings、Images、`/v1/models` 与 `/v1/files` 同样支持，完整端点清单见 [HTTP API](docs/api.md)，客户端接入（Cursor / Claude Code / Codex / Open WebUI）见 [客户端接入](docs/client-integration.md)。
+Metapi 自动在所有上游站点中选择成本最优、状态健康的通道；通道失败自动冷却并重试下一个。Claude 原生格式（`/v1/messages`）、Responses、Embeddings、Images、`/v1/models` 与 `/v1/files` 同样支持；完整端点清单见 [HTTP API](docs/api.md)，客户端接入见 [client-integration](docs/client-integration.md)。
+
+未配置任何路由时，代理请求如实返回 503（已实测）：
+
+```json
+{ "error": { "message": "No available channels", "type": "server_error", "request_id": "…" } }
+```
 
 ---
 
@@ -204,106 +216,102 @@ Metapi 会自动在所有上游站点中选择成本最优、状态健康的通�
 
 ### 统一代理网关
 
-兼容 **OpenAI** 与 **Claude** 下游格式，对接所有主流客户端。支持 Chat Completions、Responses、Messages、Completions（Legacy）、Embeddings、Images、Models，以及标准 `/v1/files` 文件接口。完整的 SSE 流式传输，自动格式转换（OpenAI ⇄ Claude）。
+兼容 **OpenAI** 与 **Claude** 下游格式。Chat Completions、Responses、Messages、Completions（Legacy）、Embeddings、Images、Models 与 `/v1/files`，完整 SSE 流式传输，自动格式转换（OpenAI ⇄ Claude）。
 
 ### 智能路由引擎
 
-- 自动发现所有上游站点的可用模型，**零配置**生成路由表
+- 自动发现所有上游模型，**零配置**生成路由表
 - 四级成本信号：实测成本 → 账号配置成本 → 目录参考价（models.dev）→ 默认兜底
-- 多通道概率分摊，基于成本、余额、使用率加权分配
-- 失败通道自动冷却与避让，请求失败自动重试切到其他可用通道
-- 运行时熔断器 + half-open 探测，恢复中的通道可受控重新进入候选集
+- 多通道概率分摊，按成本、余额、使用率加权分配
+- 失败通道自动冷却与避让，请求自动重试其他通道
+- 运行时熔断器 + half-open 探测，恢复中的通道受控重新进入候选集
 
 ### 多平台聚合管理
 
-| 平台                     | 适配器                          | 说明                 |
-| ------------------------ | ------------------------------- | -------------------- |
-| New API                  | `new-api`                       | 新一代大模型网关     |
-| One API                  | `one-api`                       | 经典 OpenAI 接口聚合 |
-| OneHub                   | `onehub`                        | One API 增强分支     |
-| DoneHub                  | `done-hub`                      | OneHub 增强分支      |
-| Veloera                  | `veloera`                       | API 网关平台         |
-| AnyRouter                | `anyrouter`                     | 通用路由平台         |
-| Sub2API                  | `sub2api`                       | 订阅制中转平台       |
-| OpenAI / Claude / Gemini | `openai` / `claude` / `gemini`  | 标准兼容接口         |
-
-共 **16** 个适配器，覆盖模型枚举、余额查询、Token 管理、代理接入等通用能力；登录、签到、用户信息等能力按平台而异。
+共 **16** 个适配器（`platform/`）：`new-api`、`one-api`、`one-hub`、`done-hub`、`veloera`、`anyrouter`、`sub2api`、`openai`、`claude`、`gemini`、`gemini-cli`、`codex`、`antigravity`、`grok`、`cliproxyapi`、`sensetime`。模型枚举、余额查询、Token 管理、代理接入为通用能力；登录、签到等按平台而异。
 
 ### 账号与 Token 管理
 
-多站点多账号，每个账号可持有多个 API Token。`healthy` / `unhealthy` / `degraded` / `disabled` 四级状态机；凭证加密存储在本地数据库中；Token 过期自动重新登录获取新凭证；禁用站点自动级联禁用所有关联账号。
+多站点多账号，每个账号可持有多个 API Token。`healthy` / `unhealthy` / `degraded` / `disabled` 四级状态机；凭据加密存储；Token 过期自动重新登录；禁用站点级联禁用关联账号。
 
 ### 模型广场与操练场
 
-跨站模型覆盖总览：哪些模型可用、多少账号覆盖、各站定价对比；延迟与成功率实测指标；交互式模型操练场可强制指定通道对比输出，保留真实状态与延迟。
+跨站模型覆盖总览、各站定价对比、延迟与成功率实测指标；交互式操练场可强制指定通道对比输出。
 
 ### 自动签到与余额
 
-Cron 定时签到（默认每日 08:00），智能解析奖励金额，失败自动通知，并发锁防重复；定时余额刷新（默认每小时），收入追踪与每日/累计消费趋势分析。
+Cron 定时签到（默认每日 08:00），奖励解析与失败通知，并发锁防重复；定时余额刷新（默认每小时），收入追踪与消费趋势分析。
 
 ### 告警通知
 
-九种通知渠道：Webhook、Bark、Server酱、Telegram Bot、SMTP 邮件、飞书（HMAC 加签）、钉钉（HMAC 加签）、企业微信、ntfy。告警场景覆盖余额不足、站点/账号异常、签到失败、代理请求失败、Token 过期与每日摘要，可按类型逐项静音，冷却机制防重复通知。
+九种渠道：Webhook、Bark、Server酱、Telegram Bot、SMTP 邮件、飞书、钉钉、企业微信、ntfy。覆盖余额不足、站点/账号异常、签到失败、代理失败、Token 过期与每日摘要，可按类型静音，冷却防重复。
 
 ### 运营与审计
 
-管理操作审计日志（写入留痕）；实时 QPS / 成功率运维面板（WebSocket 推流、断线自动重连）；批量模型验证、模型倍率总览与行内编辑、模型重定向映射、账号/站点标签；仪表盘快照 PNG 导出。
+管理操作审计日志；实时 QPS / 成功率面板（WebSocket 推流）；批量模型验证、模型倍率编辑、模型重定向映射、标签；仪表盘快照 PNG 导出。
 
 ### 轻量部署
 
-单 Docker 容器 + 本地数据目录即可运行，也可外接 PostgreSQL；SQLite 与 PostgreSQL 双 dialect，启动自动执行幂等 schema 升级。Go 单二进制，~15 MB 镜像，启动即时。数据完整导入导出，迁移无忧。
+单二进制 + 本地数据目录即可运行，也可外接 PostgreSQL；SQLite / PostgreSQL 双 dialect，启动自动执行幂等 schema 升级；数据完整导入导出。
 
 ---
 
 ## 配置
 
-只需两个必填环境变量即可启动：
+全部配置由环境变量驱动，启动只需两个必填项：
 
-| 变量         | 说明                          |
-| ------------ | ----------------------------- |
-| `AUTH_TOKEN` | 管理后台登录令牌              |
-| `PROXY_TOKEN`| 下游客户端调用 `/v1/*` 的 Key |
+| 变量          | 说明                          |
+| ------------- | ----------------------------- |
+| `AUTH_TOKEN`  | 管理后台登录令牌              |
+| `PROXY_TOKEN` | 下游客户端调用 `/v1/*` 的 Key |
 
-其余常用项：
+常用项：
 
-| 变量                 | 默认值      | 说明                          |
-| -------------------- | ----------- | ----------------------------- |
-| `PORT`               | `4000`      | 监听端口                      |
-| `HOST`               | 平台相关    | Windows 默认 `127.0.0.1`，其他 `0.0.0.0`；容器固定 `0.0.0.0` |
-| `DATABASE_URL`       | 空          | PostgreSQL 连接串；留空使用 SQLite |
-| `CHECKIN_CRON`       | `0 8 * * *` | 签到时间                      |
-| `BALANCE_REFRESH_CRON` | `0 * * * *` | 余额刷新频率                |
+| 变量                   | 默认值        | 说明                                             |
+| ---------------------- | ------------- | ------------------------------------------------ |
+| `ACCOUNT_CREDENTIAL_SECRET` | 回退 `AUTH_TOKEN` | 上游凭据加密密钥，建议 32+ 字节随机串      |
+| `PORT`                 | `4000`        | 监听端口                                         |
+| `HOST`                 | 平台相关      | Windows 默认 `127.0.0.1`，其他平台 `0.0.0.0`     |
+| `DATA_DIR`             | `./data`      | 数据目录（SQLite 库与上传文件）                  |
+| `DATABASE_URL`         | 空            | PostgreSQL 连接串；留空使用 SQLite               |
+| `LOG_LEVEL`            | `info`        | 日志级别：`debug` / `info` / `warn` / `error`    |
+| `CHECKIN_CRON`         | `0 8 * * *`   | 签到时间                                         |
+| `BALANCE_REFRESH_CRON` | `0 * * * *`   | 余额刷新频率                                     |
 
-完整环境变量清单（含 PostgreSQL 池预设、代理限额、CORS、可信代理 CIDR 等）见 [配置参考](docs/configuration.md) 与 [`.env.example`](.env.example)。
+完整清单（约 150 项：PostgreSQL 池预设、代理限额、速率限制、CORS、可信代理、通知渠道等）见 [配置参考](docs/configuration.md) 与 [`.env.example`](.env.example)。
 
-### 运维健康检查
+### 健康检查
 
-- `GET /health`：liveness，只确认 HTTP 进程存活
-- `GET /ready`：readiness，检查数据库；不可用或关停中返回 503
-- Docker 默认执行 `metapi healthcheck`，等价探测 `http://127.0.0.1:${PORT}/ready`
-
----
-
-## 从 TypeScript 版迁移
-
-数据库 Schema 完全一致，Go 版启动时自动执行幂等迁移：停止旧服务，用同样的环境变量启动 Go 版即可。Go 镜像以非 root 用户（uid 1001）运行，若数据目录是 bind mount（如 `./data:/app/data`）且由旧版以 root 写入，需先在宿主机执行 `chown -R 1001:1001 ./data`（命名卷则无需处理）。迁移路径按旧版数据库分三种：SQLite / PostgreSQL 库停止旧服务后由 Go 直接接管（首次启动自动补列）；MySQL 库需先在 TypeScript 版管理界面「设置 → 数据库」用其内置迁移功能迁到 SQLite 或 PostgreSQL，再按前两种方式接管。三种场景的完整步骤、`metapi-migrate` 工具参考、镜像版本锁定与回滚方案见 [迁移指南](docs/migration.md)。
+- `GET /health` — liveness，HTTP 进程存活即 200
+- `GET /ready` — readiness，检查数据库；不可用或关停中返回 503
+- Docker 镜像内置 `metapi healthcheck`（等价探测 `/ready`，实测 exit code 正确）
 
 ---
 
-## 文档导航
+## 文档
 
-| 文档                                             | 用途                                  |
-| ------------------------------------------------ | ------------------------------------- |
+| 文档                                                   | 用途                                  |
+| ------------------------------------------------------ | ------------------------------------- |
 | [docs/getting-started.md](docs/getting-started.md)     | **快速上手**：安装到第一个代理请求    |
-| [docs/deployment.md](docs/deployment.md)               | 部署 / 反向代理 / PostgreSQL          |
+| [docs/deployment.md](docs/deployment.md)               | 部署 / 反向代理 / PostgreSQL / 升级   |
 | [docs/configuration.md](docs/configuration.md)         | 环境变量完整参考                      |
 | [docs/client-integration.md](docs/client-integration.md) | 客户端接入（Cursor / Claude Code / Codex / Open WebUI） |
 | [docs/api.md](docs/api.md)                             | HTTP API 端点清单                     |
 | [docs/migration.md](docs/migration.md)                 | TS → Go 迁移（SQLite / PG / MySQL）   |
 | [docs/faq.md](docs/faq.md)                             | 常见问题                              |
 | [docs/architecture.md](docs/architecture.md)           | 包结构与请求路径（开发者）            |
-| [docs/README.md](docs/README.md)                       | 文档地图（含维护者文档索引）          |
+| [docs/README.md](docs/README.md)                       | 文档地图                              |
 | [CHANGELOG.md](CHANGELOG.md)                           | 版本变更                              |
+
+## 从 TypeScript 版迁移
+
+数据库 Schema 完全一致：停止旧服务，用同样的环境变量启动 Go 版即可，启动时自动执行幂等迁移。Go 镜像以 uid 1001 运行，旧版 root 写入的 bind mount 数据目录需先 `chown -R 1001:1001 ./data`（命名卷无需处理）。SQLite / PostgreSQL 直接接管，MySQL 需先经 TypeScript 版内置迁移转出。完整步骤、`metapi-migrate` 工具与回滚方案见 [迁移指南](docs/migration.md)。
+
+## 已知限制
+
+- 少量管理端点当前如实返回 `501`（未实现），清单见 [api.md](docs/api.md) 中的「501 残留」标注；版本更新提示请走 GitHub Releases / GHCR 镜像 tag。
+- 代理上游未配置时返回 503，不做合成成功响应。
+- 单进程语义为主；多实例部署的共享语义（Redis 共享 RPM/TPM 准入、PostgreSQL advisory lock）见 [FAQ](docs/faq.md)。
 
 ---
 
@@ -313,7 +321,7 @@ Cron 定时签到（默认每日 08:00），智能解析奖励金额，失败自
 
 ```bash
 make build    # 构建
-make test     # 运行全部测试（含 -race）
+make test     # 全部测试（含 -race）
 make vet      # go vet
 make lint     # golangci-lint
 make vuln     # govulncheck 漏洞扫描
@@ -332,15 +340,11 @@ bun run build       # rsbuild 构建（产物经 go:embed 打包进 Go 二进制
 
 贡献流程（分支模型、PR 门禁）见 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
----
-
 ## 贡献与安全
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) — 分支模型、PR 流程、本地门禁
 - [SECURITY.md](SECURITY.md) — 漏洞报告（Security Advisory）
 - [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — 社区行为准则
-
----
 
 ## 相关项目
 
@@ -348,14 +352,6 @@ bun run build       # rsbuild 构建（产物经 go:embed 打包进 Go 二进制
 - [New API](https://github.com/QuantumNous/new-api) — 主要上游之一
 - [One API](https://github.com/songquanpeng/one-api) — 经典 OpenAI 接口聚合
 
----
-
-## 隐私说明
-
-Metapi 完全自托管：所有数据（账号、令牌、路由、日志）存储在你自己的部署环境中，不向任何第三方上报；代理请求仅在你的服务器与上游站点之间直连传输。
-
----
-
 ## 许可证
 
-[MIT](LICENSE)
+[MIT](LICENSE)。Metapi 完全自托管：所有数据存储在你自己的部署环境中，代理请求仅在你的服务器与上游站点之间直连传输。

--- a/README_EN.md
+++ b/README_EN.md
@@ -46,7 +46,7 @@
   <tr>
     <td align="center">
       <img src="docs/assets/screenshots/routes.webp" alt="Smart routing" style="width:100%;height:auto;"/>
-      <div><b>Smart routing</b> — probabilistic multi-channel allocation</div>
+      <div><b>Smart routing</b> — probabilistic multi-channel allocation, cost-first</div>
     </td>
     <td align="center">
       <img src="docs/assets/screenshots/accounts.webp" alt="Accounts" style="width:100%;height:auto;"/>
@@ -77,34 +77,32 @@
 
 ---
 
-## Introduction
+## What is Metapi
 
 The AI ecosystem is full of aggregation relays built on New API / One API and
-friends. Managing balances, model lists and API keys across many of them is
-scattered and slow.
+friends, and balances, model lists and API keys end up scattered across many
+of them. **Metapi** is the **meta-aggregation layer** above those relays: it
+unifies your sites behind **one entrypoint**, so every downstream tool —
+Cursor, Claude Code, Codex, Open WebUI and anything that speaks OpenAI —
+reaches all of your models transparently.
 
-**Metapi** is a **meta-aggregation layer** above those relays: it unifies your
-sites behind **one entrypoint (with per-project downstream keys)**, so every
-downstream tool — Cursor, Claude Code, Codex, Open WebUI and anything that
-speaks OpenAI — reaches all of your models transparently. Supported upstreams:
+Supported upstreams:
 
 - **Aggregation panels**: New API, One API, OneHub, DoneHub, Veloera, AnyRouter, Sub2API
 - **Compatible endpoints**: OpenAI / Claude / Gemini compatible APIs, plus `cliproxyapi` / CPA
 - **OAuth connections**: Codex, Claude, Gemini CLI, Antigravity
 
-| Pain point                                    | How Metapi solves it                                        |
-| --------------------------------------------- | ----------------------------------------------------------- |
-| One key per site, a pile of client configs    | **Unified proxy entry + downstream keys**, models aggregated on `/v1/*` |
-| No idea which site is cheapest for a model    | **Smart routing** picks the best channel by cost, balance and usage |
-| A site goes down, manual switching            | **Automatic failover** with per-channel cooldown            |
-| Balances scattered everywhere                 | **Central dashboard** with low-balance alerts               |
-| Daily check-ins on every site                 | **Scheduled auto check-in** with reward tracking            |
-| No idea which site has which model            | **Auto model discovery** — new upstream models appear with zero config |
+| Pain point                                 | How Metapi solves it                                                    |
+| ------------------------------------------ | ----------------------------------------------------------------------- |
+| One key per site, a pile of client configs | **Unified proxy entry + multiple downstream keys**, models aggregated on `/v1/*` |
+| No idea which site is cheapest for a model | **Smart routing** picks the best channel by cost, balance and usage     |
+| A site goes down, manual switching         | **Automatic failover**: failed channels cool down, request retries on the next |
+| Balances scattered everywhere              | **Central dashboard** at a glance, with low-balance alerts              |
+| Daily check-ins on every site              | **Scheduled auto check-in** with reward tracking                        |
+| No idea which site has which model         | **Auto model discovery** — new upstream models enter routing with zero config |
 
-### How the Go version differs
-
-A ground-up Go rewrite of [Metapi (TypeScript)](https://github.com/cita-777/metapi)
-with client-visible compatibility, in a much lighter runtime:
+This project is a Go rewrite of [Metapi (TypeScript)](https://github.com/cita-777/metapi)
+with client-visible compatibility:
 
 |                | Node.js (original) | Go (this repo)   |
 | -------------- | ------------------ | ---------------- |
@@ -115,94 +113,130 @@ with client-visible compatibility, in a much lighter runtime:
 
 ---
 
-## Quick start
+## Quick start (3 minutes)
 
-### Docker (recommended)
+The release page ships pre-built binaries for Linux / macOS / Windows — one file, no runtime.
+
+**1. Install** (Linux / macOS; on Windows download `metapi-windows-amd64.exe` directly from [Releases](https://github.com/DeliciousBuding/metapi-go/releases/latest)):
+
+```bash
+curl -fsSL https://github.com/DeliciousBuding/metapi-go/releases/latest/download/install.sh | bash
+```
+
+The script verifies the SHA-256 checksum and installs to `/usr/local/bin/metapi`.
+If `/usr/local` is not writable, point `METAPI_INSTALL_PREFIX` at a directory of
+your choice (e.g. `METAPI_INSTALL_PREFIX=~/.local` installs to `~/.local/bin/metapi`).
+
+**2. Start** (only two tokens are required):
+
+```bash
+export AUTH_TOKEN=$(openssl rand -hex 16)      # admin UI login token
+export PROXY_TOKEN=sk-$(openssl rand -hex 24)  # downstream key for /v1/* calls
+metapi
+```
+
+**3. Verify**:
+
+```bash
+curl http://localhost:4000/health
+# {"status":"ok"}
+curl http://localhost:4000/ready
+# {"status":"ok","database":"ok"}
+```
+
+Open `http://localhost:4000` and sign in with `AUTH_TOKEN`. Data lives in `./data`
+(SQLite) by default and survives removing the token environment variables.
+
+> The path above was tested end to end. If the port is taken, override with
+> `PORT=<port>` (default 4000). Then add sites and accounts in the UI, run the
+> automatic route rebuild, and make your first proxied request — full walkthrough:
+> [getting started](docs/getting-started.md).
+
+## Deployment
+
+### Docker
+
+> The commands below were cross-checked line by line against the repo `Dockerfile` /
+> `docker-compose.prod.yml` (no Docker available in the test environment; not executed).
 
 ```bash
 docker run -d --name metapi \
   -p 4000:4000 \
   -e AUTH_TOKEN=your-admin-token \
   -e PROXY_TOKEN=your-proxy-sk-token \
+  -e ACCOUNT_CREDENTIAL_SECRET=$(openssl rand -hex 32) \
   -e TZ=Asia/Shanghai \
-  -v ./data:/app/data \
+  -v metapi_data:/app/data \
   --restart unless-stopped \
   ghcr.io/deliciousbuding/metapi-go:latest
 ```
 
-Open `http://localhost:4000` and sign in with `AUTH_TOKEN`.
+Key points:
 
-> [!IMPORTANT]
-> Change `AUTH_TOKEN` and `PROXY_TOKEN` — never ship the defaults. Data lives
-> in `./data` and survives upgrades.
+- The image runs as a non-root user (uid 1001). A **named volume** (`metapi_data`
+  above) inherits the image ownership on first mount — zero configuration. If you
+  use a bind mount such as `./data:/app/data` instead, run
+  `chown -R 1001:1001 ./data` on the host first; see the
+  [deployment guide](docs/deployment.md).
+- `ACCOUNT_CREDENTIAL_SECRET` encrypts the upstream credentials stored in the
+  database. Generate an independent 32+ byte random secret; when unset it falls
+  back to `AUTH_TOKEN`.
+- For production, pin a version tag (e.g. `:v0.16.6`) instead of `latest`.
 
 ### Docker Compose
 
+`docker-compose.prod.yml` (GHCR image + production hardening) or
+`docker-compose.yml` (local build):
+
 ```bash
-mkdir metapi && cd metapi
-
-cat > docker-compose.yml << 'EOF'
-services:
-  metapi:
-    image: ghcr.io/deliciousbuding/metapi-go:latest
-    ports:
-      - "4000:4000"
-    volumes:
-      - ./data:/app/data
-    environment:
-      AUTH_TOKEN: ${AUTH_TOKEN:?AUTH_TOKEN is required}
-      PROXY_TOKEN: ${PROXY_TOKEN:?PROXY_TOKEN is required}
-      CHECKIN_CRON: "0 8 * * *"
-      BALANCE_REFRESH_CRON: "0 * * * *"
-      PORT: ${PORT:-4000}
-      DATA_DIR: /app/data
-      TZ: ${TZ:-Asia/Shanghai}
-    restart: unless-stopped
-EOF
-
-export AUTH_TOKEN=your-admin-token
-export PROXY_TOKEN=your-proxy-sk-token
-docker compose up -d
+cp .env.example .env   # fill in AUTH_TOKEN / PROXY_TOKEN / ACCOUNT_CREDENTIAL_SECRET
+docker compose -f docker-compose.prod.yml up -d
 ```
 
-Reverse proxy, PostgreSQL and hardening details: [deployment guide](docs/deployment.md).
-A full install-to-first-request walkthrough: [getting started](docs/getting-started.md).
-
 ### From source
+
+Requires Go 1.26+ and Bun 1.x (the frontend must be built first; the output is
+embedded into the binary via `go:embed`):
 
 ```bash
 git clone https://github.com/DeliciousBuding/metapi-go.git
 cd metapi-go
+cd web && bun install --frozen-lockfile && bun run build:web && cd ..
 go build -o metapi ./cmd/server
 AUTH_TOKEN=your-admin-token PROXY_TOKEN=your-proxy-sk-token ./metapi
 ```
 
-On Windows, an empty `HOST` binds `127.0.0.1` by default to avoid recurring
-firewall prompts; set `HOST=0.0.0.0` for LAN access.
+Reverse proxy, PostgreSQL, upgrades and rollback: [deployment guide](docs/deployment.md).
 
 ---
 
 ## Your first proxied request
 
-Create a downstream key in the UI (or use `PROXY_TOKEN`), then call Metapi
-exactly like OpenAI:
+After adding at least one upstream site with an account in the UI and running
+"Auto-rebuild routes" (see [getting started](docs/getting-started.md)), call
+Metapi exactly like OpenAI:
 
 ```bash
 curl http://localhost:4000/v1/chat/completions \
   -H "Authorization: Bearer $PROXY_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "claude-3-5-sonnet",
+    "model": "<any routed model>",
     "messages": [{ "role": "user", "content": "hello" }]
   }'
 ```
 
-Metapi selects the cheapest healthy channel across all your sites; failed
-channels cool down and the request retries on the next one. Claude native
-(`/v1/messages`), Responses, Embeddings, Images, `/v1/models` and `/v1/files`
-work the same way. Full endpoint inventory: [HTTP API](docs/api.md); client
-setup for Cursor / Claude Code / Codex / Open WebUI:
-[client integration](docs/client-integration.md).
+Metapi picks the cheapest healthy channel across all of your upstream sites;
+failed channels cool down automatically and the request retries on the next one.
+Claude native format (`/v1/messages`), Responses, Embeddings, Images,
+`/v1/models` and `/v1/files` are supported the same way; full endpoint inventory:
+[HTTP API](docs/api.md), client setup: [client-integration](docs/client-integration.md).
+
+With no routes configured, proxy requests return an honest 503 (tested):
+
+```json
+{ "error": { "message": "No available channels", "type": "server_error", "request_id": "…" } }
+```
 
 ---
 
@@ -220,56 +254,59 @@ automatic OpenAI ⇄ Claude conversion.
 - Zero-config route tables from automatic model discovery
 - Four-level cost truth: measured → configured → models.dev catalog → fallback
 - Probabilistic multi-channel allocation weighted by cost, balance and usage
-- Failure cooldown + half-open probing so recovering channels re-enter safely
+- Automatic cooldown and avoidance of failed channels; requests retry on other channels
+- Runtime circuit breaker + half-open probing so recovering channels re-enter under control
 
 ### Multi-platform aggregation
 
-**16 adapters**: `new-api`, `one-api`, `onehub`, `done-hub`, `veloera`,
-`anyrouter`, `sub2api`, `openai`, `claude`, `gemini` and more — covering model
-enumeration, balance queries, token management and proxying; login/check-in
-capabilities per platform.
+**16** adapters in total (`platform/`): `new-api`, `one-api`, `one-hub`,
+`done-hub`, `veloera`, `anyrouter`, `sub2api`, `openai`, `claude`, `gemini`,
+`gemini-cli`, `codex`, `antigravity`, `grok`, `cliproxyapi`, `sensetime`.
+Model enumeration, balance queries, token management and proxying are generic;
+login/check-in capabilities vary per platform.
 
 ### Accounts & tokens
 
 Multi-site, multi-account, multiple API tokens per account. Four-state health
-machine; credentials encrypted at rest; automatic re-login on expiry;
-disabling a site cascades to its accounts.
+machine (`healthy` / `unhealthy` / `degraded` / `disabled`); credentials
+encrypted at rest; automatic re-login on token expiry; disabling a site cascades
+to its accounts.
 
 ### Model marketplace & tester
 
-Cross-site model coverage, per-site price comparison, latency and success
-metrics; an interactive tester that forces specific channels and preserves
-honest status/latency/errors.
+Cross-site model coverage, per-site price comparison, latency and success-rate
+metrics; an interactive tester that forces specific channels and compares outputs.
 
 ### Check-in & balances
 
-Scheduled check-in (default 08:00 daily) with reward parsing and failure
-alerts; hourly balance refresh; daily/cumulative spend trends.
+Scheduled check-in (default daily at 08:00) with reward parsing, failure
+notifications and a concurrency lock against duplicates; scheduled balance
+refresh (default hourly) with income tracking and spend trend analysis.
 
 ### Alerts
 
-Nine channels: Webhook, Bark, ServerChan, Telegram Bot, SMTP, Feishu (HMAC),
-DingTalk (HMAC), WeCom, ntfy. Low balance, site/account incidents, check-in
-failures, proxy failures, token expiry, daily digests — with per-type muting
-and cooldowns.
+Nine channels: Webhook, Bark, ServerChan, Telegram Bot, SMTP email, Feishu,
+DingTalk, WeCom, ntfy. Covers low balance, site/account incidents, check-in
+failures, proxy failures, token expiry and daily digests — with per-type muting
+and cooldowns against duplicates.
 
 ### Operations & audit
 
-Admin audit log for mutating operations; realtime QPS/success-rate panel
-(WebSocket with reconnect); batch model verification; model rate overview
-with inline editing; redirect mapping; tags; dashboard snapshot PNG export.
+Audit log for admin operations; realtime QPS / success-rate panel (WebSocket
+stream); batch model verification, model rate editing, model redirect mappings,
+tags; dashboard snapshot PNG export.
 
 ### Lightweight deployment
 
-One container plus a local data directory, or external PostgreSQL. SQLite
-and PostgreSQL dual dialect with automatic additive schema upgrades at
-startup. ~15 MB image, instant start, full import/export.
+A single binary plus a local data directory is enough to run, or attach an
+external PostgreSQL; SQLite / PostgreSQL dual dialect with idempotent schema
+upgrades at startup; full data import/export.
 
 ---
 
 ## Configuration
 
-Two required variables to boot:
+All configuration is driven by environment variables; only two are required to boot:
 
 | Variable      | Description                                  |
 | ------------- | -------------------------------------------- |
@@ -278,82 +315,97 @@ Two required variables to boot:
 
 Common options:
 
-| Variable           | Default     | Description                              |
-| ------------------ | ----------- | ---------------------------------------- |
-| `PORT`             | `4000`      | Listen port                              |
-| `HOST`             | per-platform | Windows defaults `127.0.0.1`, servers `0.0.0.0`; containers fixed `0.0.0.0` |
-| `DATABASE_URL`     | empty       | PostgreSQL DSN; empty = SQLite           |
-| `CHECKIN_CRON`     | `0 8 * * *` | Check-in schedule                        |
-| `BALANCE_REFRESH_CRON` | `0 * * * *` | Balance refresh schedule             |
+| Variable                  | Default              | Description                                          |
+| ------------------------- | -------------------- | ---------------------------------------------------- |
+| `ACCOUNT_CREDENTIAL_SECRET` | falls back to `AUTH_TOKEN` | Upstream credential encryption key; a 32+ byte random secret is recommended |
+| `PORT`                    | `4000`               | Listen port                                          |
+| `HOST`                    | platform-dependent   | Windows defaults to `127.0.0.1`, other platforms `0.0.0.0` |
+| `DATA_DIR`                | `./data`             | Data directory (SQLite database and uploaded files)  |
+| `DATABASE_URL`            | empty                | PostgreSQL connection string; empty = SQLite         |
+| `LOG_LEVEL`               | `info`               | Log level: `debug` / `info` / `warn` / `error`       |
+| `CHECKIN_CRON`            | `0 8 * * *`          | Check-in schedule                                    |
+| `BALANCE_REFRESH_CRON`    | `0 * * * *`          | Balance refresh schedule                             |
 
-The complete reference (PostgreSQL pool presets, proxy limits, CORS, trusted
-proxy CIDRs, notification providers, …) lives in
+The complete reference (~150 variables: PostgreSQL pool presets, proxy limits,
+rate limiting, CORS, trusted proxies, notification channels, …) lives in the
 [configuration reference](docs/configuration.md) and [`.env.example`](.env.example).
 
 ### Health checks
 
-- `GET /health` — liveness
-- `GET /ready` — readiness incl. database; 503 while unavailable or draining
-- Docker runs `metapi healthcheck`, equivalent to probing `/ready`
-
----
-
-## Migrating from the TypeScript version
-
-The schema is identical: stop the old server and start Metapi Go with the
-same environment — `./data` is reused and the schema migrates itself
-(additive column upgrades run automatically on first start). The Go image
-runs as non-root (uid 1001); for a bind-mounted data directory previously
-written by the root-owned TS container, run `chown -R 1001:1001 ./data` on
-the host first (named volumes need no chown). There are three migration
-paths depending on the database the old deployment used: SQLite and
-PostgreSQL databases are taken over directly after stopping the old server;
-MySQL databases must first be converted to SQLite or PostgreSQL from inside
-the TypeScript admin UI (Settings → Database migration), then taken over
-like the other two. Full steps, the `metapi-migrate` CLI reference, image
-version pinning and rollback: [migration guide](docs/migration.md).
+- `GET /health` — liveness; 200 as long as the HTTP process is alive
+- `GET /ready` — readiness; checks the database; 503 while unavailable or draining
+- The Docker image ships `metapi healthcheck` (equivalent to probing `/ready`; exit codes tested)
 
 ---
 
 ## Documentation
 
-| Document                                                       | Purpose                          |
-| -------------------------------------------------------------- | -------------------------------- |
-| [docs/getting-started.md](docs/getting-started.md)             | Install → first proxied request  |
-| [docs/deployment.md](docs/deployment.md)                       | Deployment / reverse proxy / PG  |
-| [docs/configuration.md](docs/configuration.md)                 | Full environment reference       |
-| [docs/client-integration.md](docs/client-integration.md)       | Cursor / Claude Code / Codex / Open WebUI |
-| [docs/api.md](docs/api.md)                                     | HTTP API inventory               |
-| [docs/migration.md](docs/migration.md)                         | TS → Go migration (SQLite / PG / MySQL) |
-| [docs/faq.md](docs/faq.md)                                     | Frequently asked questions       |
-| [docs/architecture.md](docs/architecture.md)                   | Package map & request paths      |
-| [docs/README.md](docs/README.md)                               | Docs map (incl. maintainer docs) |
-| [CHANGELOG.md](CHANGELOG.md)                                   | Release notes                    |
+| Document                                                     | Purpose                          |
+| ------------------------------------------------------------ | -------------------------------- |
+| [docs/getting-started.md](docs/getting-started.md)           | **Getting started**: install → first proxied request |
+| [docs/deployment.md](docs/deployment.md)                     | Deployment / reverse proxy / PostgreSQL / upgrades |
+| [docs/configuration.md](docs/configuration.md)               | Full environment variable reference |
+| [docs/client-integration.md](docs/client-integration.md)     | Client setup (Cursor / Claude Code / Codex / Open WebUI) |
+| [docs/api.md](docs/api.md)                                   | HTTP API endpoint inventory      |
+| [docs/migration.md](docs/migration.md)                       | TS → Go migration (SQLite / PG / MySQL) |
+| [docs/faq.md](docs/faq.md)                                   | Frequently asked questions       |
+| [docs/architecture.md](docs/architecture.md)                 | Package map & request paths (developers) |
+| [docs/README.md](docs/README.md)                             | Documentation map                |
+| [CHANGELOG.md](CHANGELOG.md)                                 | Release notes                    |
+
+## Migrating from the TypeScript version
+
+The database schema is identical: stop the old server and start the Go version
+with the same environment variables; the idempotent migration runs at startup.
+The Go image runs as uid 1001 — a bind-mounted data directory previously written
+by the root-owned TypeScript container needs `chown -R 1001:1001 ./data` first
+(named volumes need no action). SQLite / PostgreSQL deployments are taken over
+directly; MySQL data must be exported through the TypeScript version's built-in
+migration first. Full steps, the `metapi-migrate` tool and rollback:
+[migration guide](docs/migration.md).
+
+## Known limitations
+
+- A few admin endpoints currently return an honest `501` (not implemented); see
+  the "501 residual" markers in [api.md](docs/api.md). For version updates use
+  GitHub Releases / GHCR image tags.
+- With no upstream configured, proxy requests return 503 — never a synthetic success.
+- Single-process semantics are the primary target; the shared semantics for
+  multi-instance deployments (Redis-shared RPM/TPM admission, PostgreSQL
+  advisory locks) are described in the [FAQ](docs/faq.md).
 
 ---
 
 ## Development
 
-```bash
-# backend
-make build && make test && make vet && make lint && make vuln
+### Backend (Go)
 
-# frontend (web/, Bun)
-cd web && bun install && bun run dev     # /api /v1 proxy to :4000
-bun run typecheck && bun run test && bun run build
+```bash
+make build    # build
+make test     # all tests (incl. -race)
+make vet      # go vet
+make lint     # golangci-lint
+make vuln     # govulncheck vulnerability scan
+```
+
+### Frontend (`web/`, Bun)
+
+```bash
+cd web
+bun install
+bun run dev         # local dev (/api /v1 proxied to the backend on :4000)
+bun run typecheck   # tsgo type check
+bun run test        # vitest full suite
+bun run build       # rsbuild build (output embedded into the Go binary via go:embed)
 ```
 
 Contribution flow (branch model, PR gates): [CONTRIBUTING.md](CONTRIBUTING.md).
 
----
-
 ## Contributing & security
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) — branch model, PR flow, local gates
-- [SECURITY.md](SECURITY.md) — responsible disclosure
+- [SECURITY.md](SECURITY.md) — vulnerability disclosure (Security Advisory)
 - [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — community conduct
-
----
 
 ## Related projects
 
@@ -361,16 +413,8 @@ Contribution flow (branch model, PR gates): [CONTRIBUTING.md](CONTRIBUTING.md).
 - [New API](https://github.com/QuantumNous/new-api) — a primary upstream
 - [One API](https://github.com/songquanpeng/one-api) — the classic OpenAI-interface aggregator
 
----
-
-## Privacy
-
-Metapi is fully self-hosted: all data (accounts, tokens, routes, logs) stays
-in your deployment and nothing is reported anywhere; proxy traffic flows only
-between your server and your upstream sites.
-
----
-
 ## License
 
-[MIT](LICENSE)
+[MIT](LICENSE). Metapi is fully self-hosted: all data stays in your own
+deployment, and proxy traffic flows directly between your server and your
+upstream sites.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,21 +11,21 @@
 
 services:
   metapi:
-    # Pin a release tag (e.g. ghcr.io/deliciousbuding/metapi-go:v0.16.1) instead
+    # Pin a release tag (e.g. ghcr.io/deliciousbuding/metapi-go:v0.16.6) instead
     # of :latest for reproducible production deploys.
     image: ghcr.io/deliciousbuding/metapi-go:latest
     ports:
       - "127.0.0.1:4000:4000"
     # Data directory. The image runs as non-root uid 1001, so:
-    #   - Named volume (recommended for fresh installs): ownership is copied
-    #     from the image automatically — no chown needed.
-    #       volumes: [ "metapi_data:/app/data" ]
-    #   - Bind mount (required when migrating existing TS data): the host
+    #   - Named volume (recommended default, zero config): ownership is copied
+    #     from the image automatically on first mount — no chown needed.
+    #   - Bind mount (e.g. migrating existing TS data in ./data): the host
     #     directory must be writable by uid 1001, otherwise startup fails with
-    #     "readonly database" / "unable to open database file". Fix on the host:
-    #       chown -R 1001:1001 ./data
+    #     "readonly database" / "unable to open database file". On the host run
+    #     `chown -R 1001:1001 ./data` first, then swap the volumes entry for:
+    #       - ./data:/app/data
     volumes:
-      - ./data:/app/data
+      - metapi_data:/app/data
     environment:
       # Required (validated at startup -- missing = exit with error)
       AUTH_TOKEN: ${AUTH_TOKEN:?AUTH_TOKEN is required}
@@ -86,3 +86,6 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
+
+volumes:
+  metapi_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,12 @@ services:
     ports:
       - "127.0.0.1:4000:4000"
     volumes:
-      - ./data:/app/data
+      # Named volume is the zero-config default: the image runs as uid 1001
+      # and ownership is copied from the image on first mount.
+      # To reuse a host directory instead (e.g. existing ./data from the
+      # TypeScript version), run `chown -R 1001:1001 ./data` on the host
+      # first, then swap the entry below for: - ./data:/app/data
+      - metapi_data:/app/data
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -31,3 +36,6 @@ services:
       HOST: 0.0.0.0
       AUTH_TOKEN: ${AUTH_TOKEN:?Set AUTH_TOKEN in .env}
       PROXY_TOKEN: ${PROXY_TOKEN:?Set PROXY_TOKEN in .env}
+
+volumes:
+  metapi_data:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Reference
 
-**Last updated**: 2026-08-20
+**Last updated**: 2026-08-22
 
 Complete environment-variable reference. The single machine-readable source
 is [`.env.example`](../.env.example); this page groups and explains every
@@ -19,7 +19,7 @@ knob a deployment is likely to touch. Docker Compose users pass these via
 | Variable | Default | Description |
 |:---------|:--------|:------------|
 | `ACCOUNT_CREDENTIAL_SECRET` | falls back to `AUTH_TOKEN` | Independent secret for encrypting stored upstream credentials (AES key derived via SHA-256). Set a unique 32+ byte random value in production; empty falls back to `AUTH_TOKEN` with a startup warning, short values log weak-secret warnings. |
-| `TZ` | `Asia/Shanghai` | Timezone for cron schedules and daily aggregation. |
+| `TZ` | system local time | Timezone for cron schedules and daily aggregation. No code-level default; `.env.example` and the compose files preset `Asia/Shanghai`. |
 
 ## Server
 
@@ -52,11 +52,11 @@ knob a deployment is likely to touch. Docker Compose users pass these via
 | Variable | Default | Description |
 |:---------|:--------|:------------|
 | `CHECKIN_CRON` | `0 8 * * *` | Daily check-in cron. |
-| `CHECKIN_SCHEDULE_MODE` | `cron` | `cron`, `interval`, or `random-window` scheduling modes. |
+| `CHECKIN_SCHEDULE_MODE` | `cron` | `cron`, `interval`, or `window` scheduling modes (other values are rejected at startup). |
 | `CHECKIN_INTERVAL_HOURS` | `6` | Interval-mode period. |
 | `CHECKIN_WINDOW_START` / `CHECKIN_WINDOW_END` | `00:00` / `23:59` | Random-window mode bounds. |
 | `BALANCE_REFRESH_CRON` | `0 * * * *` | Balance refresh cron (hourly). |
-| `LOG_CLEANUP_CRON` | `0 3 * * *` | Retention pruning cron. |
+| `LOG_CLEANUP_CRON` | `0 6 * * *` | Retention pruning cron. |
 | `LOG_CLEANUP_USAGE_LOGS_ENABLED` / `LOG_CLEANUP_PROGRAM_LOGS_ENABLED` | auto | Which log families the cleanup prunes. |
 | `LOG_CLEANUP_RETENTION_DAYS` | `30` | Proxy/program log retention. |
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,14 +1,94 @@
 # Deployment Guide
 
-**Last updated**: 2026-08-20
+**Last updated**: 2026-08-22
 
 ## Prerequisites
 
-- Docker (for containerized deployment)
-- Go 1.26.6+ (for bare-metal deployment)
-- Bun 1.x (for frontend build)
-- PostgreSQL 16+ (optional, for production database)
-- A reverse proxy (nginx or Caddy) with TLS
+Pick the prerequisites for the path you deploy with:
+
+- **Release binary (fastest, recommended for first-time users)** — none.
+  Pre-built binaries ship with every [GitHub Release](https://github.com/DeliciousBuding/metapi-go/releases/latest);
+  `install.sh` only needs `curl` + `sha256sum`.
+- **Docker** — any recent Docker Engine with Compose v2 (for containerized deployment).
+- **From source** — Go 1.26.6+ **and** Bun 1.x. Bun is only needed to build the
+  embedded frontend (`cd web && bun install --frozen-lockfile && bun run build:web`
+  must run before `go build`); release binaries and GHCR images already include it.
+- PostgreSQL 16+ (optional, for a production database)
+- A reverse proxy (nginx or Caddy) with TLS (optional, for public exposure)
+
+## Quick paths
+
+Three equivalent ways to a running server. All commands below were executed
+against a real release/source build during documentation review; default port
+is 4000.
+
+### 1. Release binary (3 minutes)
+
+```bash
+curl -fsSL https://github.com/DeliciousBuding/metapi-go/releases/latest/download/install.sh | bash
+```
+
+The script downloads the matching platform binary from GitHub Releases,
+verifies its SHA-256 against `checksums.txt`, and installs to
+`/usr/local/bin/metapi` (override with `METAPI_INSTALL_PREFIX`; pin a version
+with `METAPI_VERSION=v0.16.6`). Windows: download `metapi-windows-amd64.exe`
+from the release page instead. Then start with the two required tokens:
+
+```bash
+export AUTH_TOKEN=$(openssl rand -hex 16)      # admin UI login token
+export PROXY_TOKEN=sk-$(openssl rand -hex 24)  # downstream key for /v1/* calls
+metapi
+```
+
+Data lands in `./data` (SQLite, code default) unless `DATA_DIR` / `DATABASE_URL` say otherwise.
+
+### 2. Docker
+
+```bash
+docker run -d --name metapi \
+  -p 4000:4000 \
+  -e AUTH_TOKEN=your-admin-token \
+  -e PROXY_TOKEN=your-proxy-sk-token \
+  -e ACCOUNT_CREDENTIAL_SECRET=$(openssl rand -hex 32) \
+  -e TZ=Asia/Shanghai \
+  -v metapi_data:/app/data \
+  --restart unless-stopped \
+  ghcr.io/deliciousbuding/metapi-go:latest
+```
+
+Named volume is the zero-config default; bind mounts need a one-time
+`chown -R 1001:1001` — see [数据目录与卷](#数据目录与卷). Compose variants:
+[Docker Compose (Production)](#docker-compose-production).
+
+### 3. From source
+
+```bash
+git clone https://github.com/DeliciousBuding/metapi-go.git
+cd metapi-go
+cd web && bun install --frozen-lockfile && bun run build:web && cd ..
+go build -o metapi ./cmd/server
+AUTH_TOKEN=your-admin-token PROXY_TOKEN=your-proxy-sk-token ./metapi
+```
+
+The frontend build step is mandatory: `web/dist/` is gitignored and `go build`
+fails with `pattern dist: no matching files found` without it.
+
+### Verify
+
+```bash
+curl http://localhost:4000/health
+# {"status":"ok"}
+curl http://localhost:4000/ready
+# {"status":"ok","database":"ok"}
+```
+
+Open `http://localhost:4000` and sign in with `AUTH_TOKEN`.
+
+> **First proxied request**: `/v1/*` needs at least one upstream site with a
+> verified account and a route rebuild first — without them the proxy answers
+> an honest `503 {"error":{"message":"No available channels","type":"server_error"}}`
+> (tested). The full walkthrough lives in
+> [getting-started.md](getting-started.md) (§2–§5).
 
 ## Environment Variables
 
@@ -27,11 +107,11 @@
 | ----------------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ACCOUNT_CREDENTIAL_SECRET`         | fallback to `AUTH_TOKEN`      | Key used to encrypt stored account credentials. **Recommended**: a unique 32+ byte random secret (`openssl rand -hex 32`). `< 8` bytes is a critical startup error; `< 16` logs a weak-secret warning. Do not reuse `AUTH_TOKEN`.                                                                                                                                                                 |
 | `PORT`                              | `4000`                        | HTTP listen port                                                                                                                                                                                                                                                                                                                                                                                    |
-| `DATA_DIR`                          | `/app/data`                   | SQLite database directory                                                                                                                                                                                                                                                                                                                                                                           |
+| `DATA_DIR`                          | `./data`                      | Data directory (SQLite database and uploaded files). Code default is `./data` relative to the working directory; the container image sets `DATA_DIR=/app/data` via its `ENV`, and compose files pass it through explicitly |
 | `LOG_LEVEL`                         | `info`                        | slog threshold: `debug`/`info`/`warn`/`error`. Raise to `warn` to quiet hot-path logs.                                                                                                                                                                                                                                                                                                              |
 | `CHECKIN_CRON`                      | `0 8 * * *`                   | Daily checkin cron expression                                                                                                                                                                                                                                                                                                                                                                      |
 | `BALANCE_REFRESH_CRON`              | `0 * * * *`                   | Hourly balance refresh cron                                                                                                                                                                                                                                                                                                                                                                        |
-| `TZ`                                | `Asia/Shanghai`               | Timezone for cron scheduling                                                                                                                                                                                                                                                                                                             |
+| `TZ`                                | system local time             | Timezone for cron scheduling. No code-level default; `.env.example` and the compose files preset `Asia/Shanghai`                                                                                                                                                                                                                                                                                   |
 | `DB_TYPE`                           | `sqlite`                      | Database type: `sqlite` or `postgres`; inferred as `postgres` when a PostgreSQL URL is provided                                                                                                                                                                                                                                          |
 | `DATABASE_URL`                      | _(empty)_                     | PostgreSQL connection string; alias of `DB_URL`; when set to `postgres://` or `postgresql://`, uses PG instead of SQLite                                                                                                                                                                                                                 |
 | `DB_URL`                            | _(empty)_                     | Database URL or SQLite file path; takes precedence over `DATABASE_URL`                                                                                                                                                                                                                                                                   |
@@ -52,6 +132,10 @@
 | `PRICING_CATALOG_URL`               | `https://models.dev/api.json` | models.dev dataset URL override (self-hosted mirror supported)                                                                                                                                                                                                                                                                           |
 
 ## Docker Compose (Production)
+
+Both compose files mount a **named volume** (`metapi_data:/app/data`) by
+default — zero configuration. To use a bind mount instead, follow the chown
+instructions in the compose file comments and in [数据目录与卷](#数据目录与卷).
 
 1. Create a `.env` file:
 


### PR DESCRIPTION
Wave 4 D 线（部署体验·纯文档线）：以「第一次来的用户」视角实测，查出 7 处部署卡点并修复文档，零代码改动。

## 卡点清单与修复对照（任务 0 实测，2026-08-22）

1. **[修]** README「从源码」快速开始在干净克隆上必然失败（`go build` 报 `pattern dist: no matching files found`）→ 快速开始改为 release 二进制 `install.sh` 3 分钟路径（实测输出在案），源码构建降为次路径并写清 `cd web && bun install --frozen-lockfile && bun run build:web` 前置
2. **[修]** README_EN Docker 快速开始 bind mount 缺 `chown -R 1001:1001`（必踩 #849 readonly 坑）→ 统一命名卷为默认推荐，bind mount 带 chown 说明，中英一致
3. **[修]** README_EN docker run / compose 缺 `ACCOUNT_CREDENTIAL_SECRET` → 与中文版对齐
4. **[修]** deployment.md `DATA_DIR` 默认值误导（代码默认 `./data`，Dockerfile ENV 是 `/app/data`）→ 两处语境分清、如实描述
5. **[修]** 两份 README 与 deployment.md 未提 GitHub Releases 预编译二进制与 `install.sh` → 补入口
6. **[修]** deployment.md 把 Bun 列为全局必需 → 改为仅源码构建需要
7. **[修]** 首个代理请求示例缺前置条件 → 补一句说明（需先有上游站点与路由）

## 三方核对（compose × .env.example × config）

以 `config/config.go` / `config/defaults.go` 为真源，核对 `docker-compose*.yml` 与 `.env.example` 的变量名/默认值，不一致处改文档侧（明细见提交 f7627b3 的 diff）。

## 门禁输出

huawei-dev 全量门禁（等价 pre-push）：build / vet / web(typecheck+lint+test) / go-race 全绿，`gate-d-r3 exit=0`。

## 移交清单

- `web/embed.go` 的 dist 依赖靠文档写清构建顺序解决，未改代码；未发现其他代码侧问题。
