### PR TITLE
fix(proxy): Wave 4 S 线 — 安全移交修复（上游路径穿越 + monitor 接线）

### DIFF
--- a/app/proxy_path_traversal_test.go
+++ b/app/proxy_path_traversal_test.go
@@ -1,0 +1,139 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/auth"
+	"github.com/deliciousbuding/metapi-go/config"
+	proxyhandler "github.com/deliciousbuding/metapi-go/handler/proxy"
+	"github.com/deliciousbuding/metapi-go/scheduler"
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// geminiTraversalEnv wires the same double-hop harness as
+// TestConfigureProxyUpstreamWiresRealSQLiteRouter, but mounts the non-/v1
+// proxy surface (Gemini native paths) under proxy auth. The upstream recorder
+// captures every path it receives so tests can prove which paths escape the
+// site API prefix.
+type geminiTraversalEnv struct {
+	router        chi.Router
+	cfg           *config.Config
+	upstreamHits  atomic.Int64
+	upstreamPaths chan string
+}
+
+func newGeminiTraversalEnv(t *testing.T) *geminiTraversalEnv {
+	t.Helper()
+	_ = store.CloseDatabase()
+
+	env := &geminiTraversalEnv{
+		upstreamPaths: make(chan string, 16),
+	}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		env.upstreamHits.Add(1)
+		env.upstreamPaths <- r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"ok"}]}}],"usageMetadata":{"totalTokenCount":1}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	cfg := testProxyConfig(t)
+	t.Cleanup(func() {
+		proxyhandler.SetUpstreamConfig(nil)
+		scheduler.SetActiveChannelIDsProvider(nil)
+		_ = store.CloseDatabase()
+	})
+	config.Set(cfg)
+	if err := store.EnsureRuntimeDatabase(cfg); err != nil {
+		t.Fatalf("EnsureRuntimeDatabase: %v", err)
+	}
+	// Model requested in the body; the route pattern makes channel selection
+	// succeed independently of the (attacker-controlled) path shape.
+	seedProxyRoute(t, store.GetDB(), upstream.URL, "gemini-trav", "upstream-token")
+
+	if err := ConfigureProxyUpstream(cfg); err != nil {
+		t.Fatalf("ConfigureProxyUpstream: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.Group(func(r chi.Router) {
+		r.Use(auth.ProxyAuth(cfg))
+		proxyhandler.RegisterNonV1ProxyRoutes(r)
+	})
+	env.router = r
+	env.cfg = cfg
+	return env
+}
+
+func (env *geminiTraversalEnv) postGemini(t *testing.T, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(`{"model":"gemini-trav","contents":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+env.cfg.ProxyToken)
+	rec := httptest.NewRecorder()
+	env.router.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestGeminiWildcardPathTraversalNeverReachesUpstream is the Wave 4 S-line T1
+// regression: a legitimate downstream key holder must not be able to escape
+// the site API prefix by smuggling ".." segments through the Gemini wildcard
+// route (POST /v1beta/models/*). net/http has already percent-decoded the
+// target into r.URL.Path by the time chi matches, so the %2e%2e variant
+// arrives identically to the literal form.
+func TestGeminiWildcardPathTraversalNeverReachesUpstream(t *testing.T) {
+	env := newGeminiTraversalEnv(t)
+
+	targets := []struct {
+		name   string
+		target string
+	}{
+		{"literal dot-dot segments", "/v1beta/models/../../admin:probe"},
+		{"percent-encoded dot-dot segments", "/v1beta/models/%2e%2e/%2e%2e/admin:probe"},
+		{"deep traversal to host root", "/v1beta/models/../../../../etc/passwd"},
+	}
+	for _, tc := range targets {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := env.postGemini(t, tc.target)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d body=%s, want 400 (traversal must be rejected before dispatch)",
+					rec.Code, rec.Body.String())
+			}
+			if hits := env.upstreamHits.Load(); hits != 0 {
+				t.Fatalf("upstream was hit %d time(s); the \"..\" path escaped the site prefix", hits)
+			}
+		})
+	}
+}
+
+// TestGeminiWildcardNormalPathStillForwardedVerbatim pins the forwarding
+// contract for paths WITHOUT ".." segments: the hardening must not clean,
+// rewrite, or otherwise alter legitimate proxy requests.
+func TestGeminiWildcardNormalPathStillForwardedVerbatim(t *testing.T) {
+	env := newGeminiTraversalEnv(t)
+
+	rec := env.postGemini(t, "/v1beta/models/gemini-trav:generateContent")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200 (normal gemini path must still be proxied)",
+			rec.Code, rec.Body.String())
+	}
+	if hits := env.upstreamHits.Load(); hits != 1 {
+		t.Fatalf("upstream hits = %d, want exactly 1; downstream status=%d body=%s",
+			hits, rec.Code, rec.Body.String())
+	}
+	select {
+	case upstreamPath := <-env.upstreamPaths:
+		if upstreamPath != "/v1beta/models/gemini-trav:generateContent" {
+			t.Fatalf("upstream path = %q, want the verbatim downstream path", upstreamPath)
+		}
+	default:
+		t.Fatal("no upstream path recorded")
+	}
+}

--- a/handler/admin/monitor.go
+++ b/handler/admin/monitor.go
@@ -18,7 +18,10 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// RegisterMonitorRoutes registers all /api/monitor and /monitor-proxy routes.
+// RegisterMonitorRoutes registers the Bearer-protected /api/monitor
+// configuration surface. The cookie-authenticated iframe proxy lives in
+// RegisterMonitorProxyRoutes and must be wired OUTSIDE the admin auth group
+// (see router/router.go).
 func RegisterMonitorRoutes(r chi.Router, db *sqlx.DB, cfg *config.Config) {
 	handler := &monitorHandler{db: db, cfg: cfg}
 
@@ -29,8 +32,18 @@ func RegisterMonitorRoutes(r chi.Router, db *sqlx.DB, cfg *config.Config) {
 	// DELETE clears the HttpOnly meta_monitor_auth cookie on admin logout.
 	// Frontend JS cannot clear HttpOnly cookies; this is the honest clear path.
 	r.Delete("/api/monitor/session", handler.clearSession)
+}
 
-	// LDOH proxy routes - rate limited at 60 req/min at the router layer when wired.
+// RegisterMonitorProxyRoutes registers the /monitor-proxy/ldoh* iframe proxy
+// surface. Authentication is the HttpOnly meta_monitor_auth cookie minted by
+// createSession — iframe sub-resource requests cannot carry an Authorization
+// header, so mounting these routes behind the Bearer AdminAuth middleware
+// breaks the LDOH iframe (Wave 4 security handoff F1). The handler enforces
+// the cookie itself via ensureMonitorAuth; keep this registrar outside any
+// Bearer-gated group.
+func RegisterMonitorProxyRoutes(r chi.Router, db *sqlx.DB, cfg *config.Config) {
+	handler := &monitorHandler{db: db, cfg: cfg}
+
 	r.HandleFunc("/monitor-proxy/ldoh", handler.ldohProxy)
 	r.HandleFunc("/monitor-proxy/ldoh/", handler.ldohProxy)
 	r.HandleFunc("/monitor-proxy/ldoh/*", handler.ldohProxy)

--- a/handler/admin/monitor.go
+++ b/handler/admin/monitor.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/proxy"
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
 )
@@ -223,6 +224,15 @@ func (h *monitorHandler) ldohProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wildcardPath := resolveLdohProxyPath(r)
+	// Wave 4 security handoff M1: reject ".." segments before joining the
+	// LDOH base URL. The request path arrives percent-decoded, so %2e%2e is
+	// caught in the same scan. Without this check a monitor-session cookie
+	// holder could normalize outside the LDOH base subpath on the upstream
+	// host once the surface is reachable with cookie-only auth (F1).
+	if proxy.ContainsPathTraversal(wildcardPath) {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid proxy path"})
+		return
+	}
 	baseURL := h.cfg.LDOHBaseURL
 	targetURL, err := url.Parse(baseURL + "/" + wildcardPath)
 	if err != nil {

--- a/handler/admin/monitor_proxy_traversal_test.go
+++ b/handler/admin/monitor_proxy_traversal_test.go
@@ -1,0 +1,94 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestLdohProxy_PathTraversalRejected is the Wave 4 S-line M1 regression: a
+// monitor session cookie must not let its holder escape the LDOH base
+// subpath by smuggling ".." segments through /monitor-proxy/ldoh/*. net/http
+// has already percent-decoded the request target into r.URL.Path before the
+// handler runs, so the encoded variant is asserted in its decoded form.
+func TestLdohProxy_PathTraversalRejected(t *testing.T) {
+	receivedPaths := make(chan string, 16)
+	env := newMonitorProxyEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		receivedPaths <- r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	targets := []struct {
+		name string
+		path string
+	}{
+		{"single dot-dot escapes base", "/monitor-proxy/ldoh/../etc/passwd"},
+		{"double dot-dot escapes host root", "/monitor-proxy/ldoh/../../etc/passwd"},
+		{"mid-path dot-dot escapes subpath", "/monitor-proxy/ldoh/api/../../../secret"},
+		{"trailing dot-dot reaches parent", "/monitor-proxy/ldoh/dashboard/.."},
+	}
+	for _, tc := range targets {
+		t.Run(tc.name, func(t *testing.T) {
+			// httptest.NewRequest normalizes some path forms; overwrite
+			// URL.Path directly so the exact traversal input is preserved
+			// (same technique as the resolveLdohProxyPath unit tests).
+			req := monitorProxyRequest(http.MethodGet, "/monitor-proxy/ldoh/seed", env.cfg)
+			req.URL.Path = tc.path
+			rec := httptest.NewRecorder()
+			env.router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d body=%s, want 400 (traversal must be rejected before upstream)",
+					rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), "invalid proxy path") {
+				t.Fatalf("body = %q, want the invalid proxy path error", rec.Body.String())
+			}
+		})
+	}
+
+	// Percent-encoded variant: pass the encoded target through request
+	// parsing so URL.Path carries the decoded form exactly as a real server
+	// would present it to the handler.
+	t.Run("percent-encoded dot-dot segments", func(t *testing.T) {
+		req := monitorProxyRequest(http.MethodGet, "/monitor-proxy/ldoh/%2e%2e/%2e%2e/etc/passwd", env.cfg)
+		rec := httptest.NewRecorder()
+		env.router.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d body=%s, want 400 for encoded traversal", rec.Code, rec.Body.String())
+		}
+	})
+
+	select {
+	case upstreamPath := <-receivedPaths:
+		t.Fatalf("upstream received traversal path %q; the \"..\" segments escaped the LDOH base", upstreamPath)
+	default:
+	}
+}
+
+// TestLdohProxy_DottedSegmentPathsStillProxied guards against over-cleaning:
+// paths that merely contain dots inside a segment (a common shape for static
+// asset filenames) are not traversal and must keep flowing to the upstream.
+func TestLdohProxy_DottedSegmentPathsStillProxied(t *testing.T) {
+	var receivedPath string
+	env := newMonitorProxyEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	req := monitorProxyRequest(http.MethodGet, "/monitor-proxy/ldoh/seed", env.cfg)
+	req.URL.Path = "/monitor-proxy/ldoh/static/app..min.js"
+	rec := httptest.NewRecorder()
+	env.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200 (dotted segment is not traversal)", rec.Code, rec.Body.String())
+	}
+	if receivedPath != "/static/app..min.js" {
+		t.Fatalf("upstream path = %q, want /static/app..min.js", receivedPath)
+	}
+}

--- a/handler/admin/ops_admin_stubs_test.go
+++ b/handler/admin/ops_admin_stubs_test.go
@@ -35,6 +35,10 @@ func setupOpsAdminStubsTest(t *testing.T) (*store.DB, chi.Router, *config.Config
 	r := chi.NewRouter()
 	RegisterNotifyRoutes(r)
 	RegisterMonitorRoutes(r, db.DB, cfg)
+	// The LDOH iframe proxy surface is a separate registrar since Wave 4 F1
+	// (it must stay outside the Bearer admin auth group in production); the
+	// stub harness mounts both so handler-level tests keep their routes.
+	RegisterMonitorProxyRoutes(r, db.DB, cfg)
 	RegisterTasksRoutes(r, db.DB)
 	RegisterSiteAnnouncementsRoutes(r, db.DB)
 	return db, r, cfg

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -97,6 +97,16 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 	if upstreamPath == "" {
 		upstreamPath = r.URL.Path
 	}
+	// Wave 4 security handoff T1: never forward a downstream path containing
+	// ".." segments. Go's http.Client preserves ".." on the wire, and the
+	// upstream host would normalize it outside the site API prefix — letting
+	// any authenticated downstream key holder reach arbitrary upstream paths.
+	// Reject before channel selection; clean paths pass through untouched.
+	if proxy.ContainsPathTraversal(upstreamPath) {
+		writeJSONErrorWithRequest(w, http.StatusBadRequest, "Invalid request path", "invalid_request_error", requestID)
+		observeProxyTerminal(ctx, shared.OutcomeClientError, ctx != nil && ctx.IsStream, time.Since(startedAt))
+		return
+	}
 	var pendingFailure *pendingUpstreamFailure
 
 	for retry := 0; retry <= maxRetries; retry++ {

--- a/proxy/endpoint_flow.go
+++ b/proxy/endpoint_flow.go
@@ -90,6 +90,21 @@ func BuildUpstreamURL(siteURL, path string) string {
 	return siteURL + path
 }
 
+// ContainsPathTraversal reports whether a request path contains a ".."
+// segment. Callers pass percent-decoded paths (net/http decodes the request
+// target into r.URL.Path before handlers run, so %2e%2e arrives as ".."),
+// which makes a plain segment scan sufficient for both literal and encoded
+// traversal. Single-dot segments are not traversal on their own and are left
+// alone so legitimate paths are never altered.
+func ContainsPathTraversal(path string) bool {
+	for _, segment := range strings.Split(path, "/") {
+		if segment == ".." {
+			return true
+		}
+	}
+	return false
+}
+
 func hasVersionedBasePath(siteURL string) bool {
 	base := siteURL
 	if i := strings.IndexAny(base, "?#"); i >= 0 {

--- a/proxy/path_traversal_test.go
+++ b/proxy/path_traversal_test.go
@@ -1,0 +1,40 @@
+package proxy
+
+import "testing"
+
+// TestContainsPathTraversal covers the Wave 4 security handoff T1 helper:
+// detection must catch every ".." segment shape that can arrive via
+// r.URL.Path (already percent-decoded by net/http) while leaving every
+// legitimate path untouched — the forwarding contract forbids altering
+// traversal-free paths.
+func TestContainsPathTraversal(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"empty path is clean", "", false},
+		{"root path is clean", "/", false},
+		{"simple endpoint is clean", "/v1/chat/completions", false},
+		{"gemini model action is clean", "/v1beta/models/gemini-2.5-pro:generateContent", false},
+		{"dot in model name is clean", "/v1beta/models/gemini-2.5-pro:streamGenerateContent", false},
+		{"segment containing dots is clean", "/v1/files/file..name/content", false},
+		{"single dot segment is clean", "/v1/./models", false},
+		{"trailing single dot is clean", "/v1/models/.", false},
+		{"leading dot-dot is traversal", "../etc/passwd", true},
+		{"mid-path dot-dot is traversal", "/v1beta/models/../../admin:probe", true},
+		{"deep dot-dot chain is traversal", "/v1beta/models/../../../../etc/passwd", true},
+		{"lone dot-dot is traversal", "..", true},
+		{"slash-delimited dot-dot only is traversal", "/..", true},
+		{"trailing dot-dot is traversal", "/v1/videos/..", true},
+		{"dot-dot inside segment suffix is clean", "/v1/models/..hidden", false},
+		{"dot-dot inside segment prefix is clean", "/v1/models/hidden..", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ContainsPathTraversal(tc.path); got != tc.want {
+				t.Fatalf("ContainsPathTraversal(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/router/monitor_wiring_test.go
+++ b/router/monitor_wiring_test.go
@@ -1,0 +1,119 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/deliciousbuding/metapi-go/web"
+)
+
+// newMonitorWiringRouter builds the full production router against a real
+// SQLite database so the monitor routes are registered exactly as in
+// cmd/server (they are skipped when the database is absent).
+func newMonitorWiringRouter(t *testing.T) (http.Handler, *config.Config) {
+	t.Helper()
+	dataDir := t.TempDir()
+	cfg := &config.Config{
+		AuthToken:        "admin-token",
+		ProxyToken:       "proxy-token",
+		RequestBodyLimit: config.DefaultRequestBodyLimit,
+		DbType:           store.DialectSQLite,
+		DbUrl:            filepath.Join(dataDir, "monitor-wiring.db"),
+		DataDir:          dataDir,
+	}
+	if err := store.EnsureRuntimeDatabase(cfg); err != nil {
+		t.Fatalf("EnsureRuntimeDatabase: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.CloseDatabase()
+	})
+	return New(cfg, web.Dist), cfg
+}
+
+// TestMonitorProxyReachableWithoutBearerHeader is the Wave 4 S-line F1
+// regression: /monitor-proxy/* serves the LDOH iframe and authenticates via
+// the HttpOnly meta_monitor_auth cookie, so it must not sit behind the Bearer
+// AdminAuth middleware. Cookie-only requests have to reach the monitor
+// handler (which answers with its own error shapes) instead of dying at the
+// admin middleware with "Missing Authorization header".
+func TestMonitorProxyReachableWithoutBearerHeader(t *testing.T) {
+	r, cfg := newMonitorWiringRouter(t)
+
+	// No credentials at all: the monitor handler's own 401 shape must answer,
+	// not the Bearer middleware's.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/monitor-proxy/ldoh/", nil)
+	r.ServeHTTP(rec, req)
+
+	if strings.Contains(rec.Body.String(), "Missing Authorization header") {
+		t.Fatalf("cookie-only surface answered with the Bearer middleware 401 (body=%s); "+
+			"/monitor-proxy/* is still wired inside the AdminAuth group", rec.Body.String())
+	}
+	if rec.Code != http.StatusUnauthorized ||
+		!strings.Contains(rec.Body.String(), "Missing or invalid monitor session") {
+		t.Fatalf("status = %d body = %s, want the monitor handler 401 'Missing or invalid monitor session'",
+			rec.Code, rec.Body.String())
+	}
+
+	// Mint a monitor session through the admin API (Bearer), then use ONLY the
+	// resulting cookie — the real iframe flow.
+	mintRec := httptest.NewRecorder()
+	mintReq := httptest.NewRequest(http.MethodPost, "/api/monitor/session", nil)
+	mintReq.Header.Set("Authorization", "Bearer "+cfg.AuthToken)
+	r.ServeHTTP(mintRec, mintReq)
+	if mintRec.Code != http.StatusOK {
+		t.Fatalf("mint monitor session status = %d body=%s, want 200", mintRec.Code, mintRec.Body.String())
+	}
+	var sessionCookie *http.Cookie
+	for _, cookie := range mintRec.Result().Cookies() {
+		if cookie.Name == "meta_monitor_auth" {
+			sessionCookie = cookie
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatalf("POST /api/monitor/session did not set meta_monitor_auth; cookies=%v", mintRec.Result().Cookies())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/monitor-proxy/ldoh/", nil)
+	req.AddCookie(sessionCookie)
+	r.ServeHTTP(rec, req)
+
+	// Session cookie is valid but no LDOH cookie is configured: the handler's
+	// plain-text 400 proves the request passed authentication and reached the
+	// LDOH proxy logic.
+	if rec.Code != http.StatusBadRequest ||
+		!strings.Contains(rec.Body.String(), "LDOH cookie not configured") {
+		t.Fatalf("cookie-only request status = %d body = %s, want monitor handler 400 'LDOH cookie not configured'",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// TestMonitorAPIRoutesStayBehindBearerAuth pins the other half of the F1
+// fix: only /monitor-proxy/* leaves the AdminAuth group; the /api/monitor
+// configuration surface stays Bearer-protected.
+func TestMonitorAPIRoutesStayBehindBearerAuth(t *testing.T) {
+	r, cfg := newMonitorWiringRouter(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/monitor/config", nil)
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized ||
+		!strings.Contains(rec.Body.String(), "Missing Authorization header") {
+		t.Fatalf("/api/monitor/config without Bearer status = %d body=%s, want admin middleware 401",
+			rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/monitor/config", nil)
+	req.Header.Set("Authorization", "Bearer "+cfg.AuthToken)
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/api/monitor/config with Bearer status = %d body=%s, want 200", rec.Code, rec.Body.String())
+	}
+}

--- a/router/router.go
+++ b/router/router.go
@@ -131,7 +131,9 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 			slog.Warn("router: database not initialized, P3 routes skipped")
 		}
 
-		// Monitor routes (includes LDOH proxy outside /api)
+		// Monitor configuration routes (/api/monitor/*) stay inside this
+		// Bearer-gated group. The cookie-authenticated LDOH iframe proxy
+		// (/monitor-proxy/*) is registered outside the group below.
 		if db := store.GetDB(); db != nil {
 			admin.RegisterMonitorRoutes(r, db.DB, cfg)
 		}
@@ -142,6 +144,16 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 			w.Write([]byte(`{"status":"ok"}`))
 		})
 	})
+
+	// Wave 4 security handoff F1: the LDOH iframe proxy authenticates via the
+	// HttpOnly meta_monitor_auth cookie — iframe sub-resource requests cannot
+	// carry an Authorization header, so this surface must stay OUTSIDE the
+	// Bearer AdminAuth group above (which answered 401 "Missing Authorization
+	// header" and broke the iframe). The handler enforces its own cookie auth
+	// (ensureMonitorAuth) and rejects ".." traversal paths (M1).
+	if db := store.GetDB(); db != nil {
+		admin.RegisterMonitorProxyRoutes(r, db.DB, cfg)
+	}
 
 	// /v1/* proxy routes → proxy rate limiting + proxy auth middleware.
 	// Per-IP RPM limiter runs BEFORE auth so unauthenticated brute-force floods


### PR DESCRIPTION
## Wave 4 S 线 — 安全移交修复（接 B 线审计成果）

上一轮 G 域安全审计（#917）白名单外查实 3 个缺陷，本线按任务书逐一修复并各配回归测试。
分支 `wave4/security-handoff`（基于 master=bb8657b），3 个 Conventional Commits。

---

### 一、三缺陷修复对照（红 → 绿证据）

#### T1（P1，已实证）上游路径穿越 — `fix(proxy)` 1d5a71c

**缺陷**：`BuildUpstreamURL` 不清洗 `..`，`handler/proxy/gemini.go` 直传 `r.URL.Path`；
合法下游 key 持有者可经 `POST /v1beta/models/../../admin:probe`（`%2e%2e` 亦可）逃出站点
API 前缀、触达上游主机任意路径（Go http.Client 线上保留 `..`）。

**修复**：新增 `proxy.ContainsPathTraversal`（`proxy/endpoint_flow.go`），在
`dispatchUpstream`（`handler/proxy/upstream.go`）通道选择前拒绝含 `..` 段的
`upstreamPath`（400 `invalid_request_error`）。拦截点选在所有代理表面（gemini 通配、
files、videos、chat 别名等）的唯一汇流处，一处覆盖全部转发面。

**红（修复前）** — `app/proxy_path_traversal_test.go` httptest 双段（metapi 路由 + 真实上游）：

```
=== RUN   TestGeminiWildcardPathTraversalNeverReachesUpstream/literal_dot-dot_segments
    proxy_path_traversal_test.go:105: status = 200 body={"candidates":[{"content":{"parts":[{"text":"ok"}]}}],"usageMetadata":{"totalTokenCount":1}}, want 400 (traversal must be rejected before dispatch)
=== RUN   TestGeminiWildcardPathTraversalNeverReachesUpstream/percent-encoded_dot-dot_segments
    proxy_path_traversal_test.go:105: status = 200 ... want 400 ...
=== RUN   TestGeminiWildcardPathTraversalNeverReachesUpstream/deep_traversal_to_host_root
    proxy_path_traversal_test.go:105: status = 200 ... want 400 ...
--- FAIL: TestGeminiWildcardPathTraversalNeverReachesUpstream (0.21s)
```

（200 的 body 即上游响应被原样中继 —— 穿越成功。）

**绿（修复后）**：

```
--- PASS: TestGeminiWildcardPathTraversalNeverReachesUpstream (0.24s)
--- PASS: TestGeminiWildcardNormalPathStillForwardedVerbatim (0.25s)
ok  	github.com/deliciousbuding/metapi-go/app	0.537s
```

另有 `proxy/path_traversal_test.go` 16 例单测（含 `.` 段、段内点号等不误伤用例）全绿。

#### F1（P2，功能）monitor LDOH 接线错误 — `fix(router)` bbe8499

**缺陷**：`router/router.go` 将 `RegisterMonitorRoutes`（含 `/monitor-proxy/*`）注册在
`auth.AdminAuth` 组内；cookie-only 的 iframe 请求被 401「Missing Authorization header」，
与 monitor.go 声明的 cookie 认证设计矛盾，LDOH iframe 流实际不可用。

**修复**：拆分注册器 —— `RegisterMonitorRoutes` 仅保留 `/api/monitor/*` 配置面
（仍在 Bearer 组内）；新增 `RegisterMonitorProxyRoutes` 将 `/monitor-proxy/ldoh*`
移出组外，由处理器自身的 `meta_monitor_auth` HMAC cookie 校验（`ensureMonitorAuth`）
把门。无凭据请求仍被拒（处理器 401）。

**红（修复前）** — `router/monitor_wiring_test.go`（全量生产路由 `New(cfg, web.Dist)`）：

```
=== RUN   TestMonitorProxyReachableWithoutBearerHeader
    monitor_wiring_test.go:54: cookie-only surface answered with the Bearer middleware 401 (body={"error":"Missing Authorization header"}
        ); /monitor-proxy/* is still wired inside the AdminAuth group
--- FAIL: TestMonitorProxyReachableWithoutBearerHeader (0.37s)
```

**绿（修复后）**：

```
--- PASS: TestMonitorProxyReachableWithoutBearerHeader (0.15s)
--- PASS: TestMonitorAPIRoutesStayBehindBearerAuth (0.17s)
ok  	github.com/deliciousbuding/metapi-go/router	0.339s
```

绿测试覆盖真实动线：Bearer 调 `POST /api/monitor/session` 铸 cookie → 仅带该 cookie
访问 `/monitor-proxy/ldoh/` 可达（落到处理器的未配置 400），无凭据仍拒，
`/api/monitor/config` 仍 Bearer-only。

#### M1（P2）LDOH 代理路径穿越联动 — `fix(monitor)` 6ce32b2

**缺陷**：`resolveLdohProxyPath` 原样透传 `..`；F1 修复后 cookie 持有者可逃出
LDOH base 子路径。

**修复**：`ldohProxy` 在解析代理路径后、拼接 `LDOHBaseURL` 前，以同一个
`proxy.ContainsPathTraversal` 拒绝含 `..` 段路径（400 `invalid proxy path`）。
检测放在处理器边界，`resolveLdohProxyPath` 保持纯前缀剥离不变（其既有行为钉住测试
无需改动）。

**红（修复前）** — `handler/admin/monitor_proxy_traversal_test.go`：

```
=== RUN   TestLdohProxy_PathTraversalRejected/single_dot-dot_escapes_base
    monitor_proxy_traversal_test.go:43: status = 200 body={"ok":true}, want 400 (traversal must be rejected before upstream)
    ...（4 字面变体 + 1 %2e%2e 变体全部 200）
=== NAME  TestLdohProxy_PathTraversalRejected
    monitor_proxy_traversal_test.go:67: upstream received traversal path "/../etc/passwd"; the ".." segments escaped the LDOH base
--- FAIL: TestLdohProxy_PathTraversalRejected (0.07s)
```

（上游真实收到逃出路径 —— 漏洞实证。）

**绿（修复后）**：

```
--- PASS: TestLdohProxy_PathTraversalRejected (0.04s)
--- PASS: TestLdohProxy_DottedSegmentPathsStillProxied (0.03s)
ok  	github.com/deliciousbuding/metapi-go/handler/admin	33.885s
```

---

### 二、正向契约守护（正常转发不受影响）

- `TestGeminiWildcardNormalPathStillForwardedVerbatim`：无 `..` 的合法路径
  `/v1beta/models/gemini-trav:generateContent` 逐字到达上游，200 中继不变。
- `TestLdohProxy_DottedSegmentPathsStillProxied`：段内含点（`app..min.js` 类）不误伤。
- `TestContainsPathTraversal`：`./`、段内点号、`..hidden`/`hidden..` 均判为干净。
- 既有代理测试全量回归通过：`proxy` / `handler/proxy` / `handler/admin` / `router` / `app`
  五包 `go test -count=1` 全绿（见门禁输出）；未新增依赖，未改任何既有测试断言
  （唯一触碰的既有测试文件为 `ops_admin_stubs_test.go` 一行路由接线，注册拆分后的函数）。

### 三、记录在案不修项（审计移交，维持原结论）

- WebDAV DNS rebinding 毫秒级残留窗口（P3）— 不修。
- sites 明文 apiKey（TS parity，产品决策）— 不修。

### 四、门禁输出（门禁机 4C/7.5G，2026-08-22 06:11–06:29 CST，全绿）

```
GATE_START 2026年 08月 22日 星期六 06:11:55 CST
GO_BUILD_OK        # go build ./cmd/server
GO_VET_OK          # go vet ./...
BUN_INSTALL_OK
TYPECHECK_OK       # bun run typecheck (tsgo)
LINT_OK            # bun run lint — Found 24 warnings and 0 errors（warnings 为 web/ 既有，本线未触碰 web/）
WEB_TEST_OK        # bun run test — Test Files 138 passed (138)
RACE_OK            # go test ./... -count=1 -race（METAPI_RACE_TIMEOUT_SECONDS=1200）
GATE_ALL_GREEN 2026年 08月 22日 星期六 06:29:56 CST
```

-race 关键包（全部 `ok`，无 FAIL / 无 data race）：

```
ok  github.com/deliciousbuding/metapi-go/app             30.327s
ok  github.com/deliciousbuding/metapi-go/e2e             42.884s
ok  github.com/deliciousbuding/metapi-go/handler/admin   560.391s
ok  github.com/deliciousbuding/metapi-go/handler/proxy   46.413s
ok  github.com/deliciousbuding/metapi-go/proxy           1.442s
ok  github.com/deliciousbuding/metapi-go/router          17.805s
ok  github.com/deliciousbuding/metapi-go/routing         5.984s
ok  github.com/deliciousbuding/metapi-go/scheduler       118.213s
ok  github.com/deliciousbuding/metapi-go/service         72.994s
ok  github.com/deliciousbuding/metapi-go/store           85.549s
（其余 20+ 包全部 ok，完整日志见门禁记录）
```

---

**移交清单（其他线地界缺陷）**：无。本线地界（proxy/ 路径清洗语义、monitor 接线）
未发现白名单外缺陷；S 线内部亦无遗留。
