### PR TITLE
docs: Wave 4 D2 线 — 对外展示升级（README 重构 + 门面整理）

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,39 @@
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-3DA639?logo=opensourceinitiative&logoColor=white"></a>
 </p>
 
+<p align="center">
+  <a href="#特性"><strong>特性</strong></a> ·
+  <a href="#界面预览">界面</a> ·
+  <a href="#快速开始3-分钟"><strong>快速开始</strong></a> ·
+  <a href="#部署与配置">部署与配置</a> ·
+  <a href="#从-typescript-版迁移">迁移</a> ·
+  <a href="#已知限制">限制</a>
+</p>
+
 ---
+
+## 什么是 Metapi
+
+AI 生态里基于 New API / One API 系列的聚合中转站越来越多，多站点的余额、模型列表和 API 密钥往往分散在各处。**Metapi** 是这些中转站之上的**元聚合层（Meta-Aggregation Layer）**：把多个站点统一到**一个入口**，下游所有工具（Cursor、Claude Code、Codex、Open WebUI 等）即可无感接入全部模型。
+
+支持的上游：
+
+- **聚合面板**：New API、One API、OneHub、DoneHub、Veloera、AnyRouter、Sub2API
+- **通用兼容接口**：OpenAI / Claude / Gemini 兼容端点，以及 `cliproxyapi` / CPA
+- **OAuth 连接**：Codex、Claude、Gemini CLI、Antigravity
+
+## 特性
+
+| 能力               | 说明                                                                                                   |
+| ------------------ | ------------------------------------------------------------------------------------------------------ |
+| **16 个上游适配器** | New API / One API / OneHub / DoneHub / Veloera / AnyRouter / Sub2API / OpenAI / Claude / Gemini / Gemini CLI / Codex / Antigravity / Grok / CLIProxyAPI / SenseTime |
+| **统一代理**        | OpenAI 与 Claude 双协议：Chat / Responses / Messages / Embeddings / Images / Models / Files，全量 SSE 流式，自动互转 |
+| **路由与容错**      | 模型自动发现、零配置建路由；按成本/余额/使用权重分配多通道；失败通道自动冷却并重试下一通道；运行时熔断 + half-open 探测 |
+| **计费真值**        | 四级成本信号（实测 → 账号配置 → models.dev 目录参考价 → 兜底）；使用日志逐请求记录 Token 与成本 |
+| **管理 UI**         | 站点 / 账号 / 路由 / 模型 / 日志 / 告警一站管理，React SPA 预构建后嵌入二进制，无需额外前端服务 |
+| **运营自动化**      | 定时签到、定时余额刷新、九种告警渠道、模型批量验证、审计日志、实时 QPS 面板 |
+| **轻量部署**        | 单二进制即跑；SQLite 默认、PostgreSQL 可选；启动自动执行幂等 schema 升级 |
+| **TS 版无缝接管**   | 同数据库 Schema、同环境变量名、同 API 契约；停旧服务、用同样环境变量启动即完成接管 |
 
 ## 界面预览
 
@@ -75,75 +107,25 @@
 
 ---
 
-## 什么是 Metapi
-
-AI 生态里基于 New API / One API 系列的聚合中转站越来越多，多站点的余额、模型列表和 API 密钥往往分散在各处。**Metapi** 是这些中转站之上的**元聚合层（Meta-Aggregation Layer）**：把多个站点统一到**一个入口**，下游所有工具（Cursor、Claude Code、Codex、Open WebUI 等）即可无感接入全部模型。
-
-支持的上游：
-
-- **聚合面板**：New API、One API、OneHub、DoneHub、Veloera、AnyRouter、Sub2API
-- **通用兼容接口**：OpenAI / Claude / Gemini 兼容端点，以及 `cliproxyapi` / CPA
-- **OAuth 连接**：Codex、Claude、Gemini CLI、Antigravity
-
-| 痛点                               | Metapi 怎么解决                                          |
-| ---------------------------------- | -------------------------------------------------------- |
-| 每个站点一个 Key，下游工具配置一堆 | **统一代理入口 + 多下游 Key**，模型自动聚合到 `/v1/*`    |
-| 不知道哪个站点用某个模型最便宜     | **智能路由**按成本、余额、使用率自动选最优通道           |
-| 站点挂了要手动切换                 | **自动故障转移**，失败通道冷却、请求自动重试下一通道     |
-| 余额分散，不知道还剩多少           | **集中看板**一目了然，余额不足自动告警                   |
-| 每天得去各站签到领额度             | **自动签到**定时执行，奖励自动追踪                       |
-| 不知道哪个站有什么模型             | **自动模型发现**，上游新增模型零配置进入路由             |
-
-本项目是 [Metapi（TypeScript 版）](https://github.com/cita-777/metapi) 的 Go 重写，客户端可见行为保持兼容：
-
-|             | Node.js（原版） | Go（本版）     |
-| ----------- | --------------- | -------------- |
-| 内存占用    | ~85 MB          | ~20 MB         |
-| Docker 镜像 | ~250 MB         | ~15 MB         |
-| 启动时间    | 5-10 秒         | 即时           |
-| 部署方式    | Node 运行时     | 单个二进制文件 |
-
----
-
 ## 快速开始（3 分钟）
 
-发布页提供 Linux / macOS / Windows 预编译二进制，单文件即跑。
+三种等价方式，任选其一。启动只需要两个令牌：`AUTH_TOKEN`（管理后台登录）与 `PROXY_TOKEN`（下游调用 `/v1/*` 的 Key）。
 
-**1. 安装**（Linux / macOS；Windows 直接从 [Releases](https://github.com/DeliciousBuding/metapi-go/releases/latest) 下载 `metapi-windows-amd64.exe`）：
+### 方式一：Release 二进制（推荐）
 
-```bash
-curl -fsSL https://github.com/DeliciousBuding/metapi-go/releases/latest/download/install.sh | bash
-```
-
-脚本自动校验 SHA-256 并安装到 `/usr/local/bin/metapi`。没有 `/usr/local` 写权限时，
-用 `METAPI_INSTALL_PREFIX` 指定安装目录（如 `METAPI_INSTALL_PREFIX=~/.local` 会安装到 `~/.local/bin/metapi`）。
-
-**2. 启动**（仅需两个令牌）：
+发布页提供 Linux / macOS / Windows 预编译二进制，单文件即跑：
 
 ```bash
+curl -fsSL https://github.com/DeliciousBuding/metapi-go/releases/download/v0.16.6/install.sh | bash
+
 export AUTH_TOKEN=$(openssl rand -hex 16)      # 管理后台登录令牌
 export PROXY_TOKEN=sk-$(openssl rand -hex 24)  # 下游客户端调用 /v1/* 的 Key
 metapi
 ```
 
-**3. 验证**：
+脚本自动校验 SHA-256 并安装到 `/usr/local/bin/metapi`（默认安装最新发布，`METAPI_VERSION` 可钉住版本，`METAPI_INSTALL_PREFIX` 可换安装目录）。Windows 直接从 [Releases](https://github.com/DeliciousBuding/metapi-go/releases/latest) 下载 `metapi-windows-amd64.exe`。
 
-```bash
-curl http://localhost:4000/health
-# {"status":"ok"}
-curl http://localhost:4000/ready
-# {"status":"ok","database":"ok"}
-```
-
-打开 `http://localhost:4000`，用 `AUTH_TOKEN` 登录。数据默认存放在 `./data`（SQLite），删除令牌环境变量不会丢失数据。
-
-> 以上为实测路径；端口被占用时用 `PORT=<端口>` 覆盖（默认 4000）。接下来在界面里添加站点与账号、自动重建路由，即可发出第一个代理请求——完整流程见 [快速上手](docs/getting-started.md)。
-
-## 部署
-
-### Docker
-
-> 以下命令与仓库 `Dockerfile` / `docker-compose.prod.yml` 逐项核对（本环境无 Docker，未实跑）。
+### 方式二：Docker（命名卷，零配置）
 
 ```bash
 docker run -d --name metapi \
@@ -157,24 +139,16 @@ docker run -d --name metapi \
   ghcr.io/deliciousbuding/metapi-go:latest
 ```
 
-要点：
-
-- 镜像以非 root 用户（uid 1001）运行。**命名卷**（如上 `metapi_data`）首次挂载自动继承镜像内属主，零配置；改用 `./data:/app/data` 这类 bind mount 时需先在宿主机执行 `chown -R 1001:1001 ./data`，详见 [部署指南](docs/deployment.md)。
-- `ACCOUNT_CREDENTIAL_SECRET` 用于加密存储的上游凭据，建议独立生成 32+ 字节随机串；不设置会回退为 `AUTH_TOKEN`。
-- 生产环境建议固定版本标签（如 `:v0.16.6`）而非 `latest`。
-
-### Docker Compose
-
-`docker-compose.prod.yml`（GHCR 镜像 + 生产硬化）或 `docker-compose.yml`（本地构建）：
+命名卷首次挂载自动继承镜像内属主，开箱即用；改用 bind mount（`./data:/app/data`）需先在宿主机 `chown -R 1001:1001 ./data`。Compose 方式（生产硬化配置）：
 
 ```bash
 cp .env.example .env   # 填入 AUTH_TOKEN / PROXY_TOKEN / ACCOUNT_CREDENTIAL_SECRET
 docker compose -f docker-compose.prod.yml up -d
 ```
 
-### 从源码构建
+### 方式三：源码构建
 
-需要 Go 1.26+ 与 Bun 1.x（前端需先构建，产物经 `go:embed` 打包进二进制）：
+需要 Go 1.26+ 与 Bun 1.x。前端必须先构建——产物经 `go:embed` 打包进二进制，跳过会报 `pattern dist: no matching files found`：
 
 ```bash
 git clone https://github.com/DeliciousBuding/metapi-go.git
@@ -184,13 +158,20 @@ go build -o metapi ./cmd/server
 AUTH_TOKEN=your-admin-token PROXY_TOKEN=your-proxy-sk-token ./metapi
 ```
 
-反向代理、PostgreSQL、升级与回滚见 [部署指南](docs/deployment.md)。
+### 验证
 
----
+```bash
+curl http://localhost:4000/health
+# {"status":"ok"}
+curl http://localhost:4000/ready
+# {"status":"ok","database":"ok"}
+```
+
+打开 `http://localhost:4000`，用 `AUTH_TOKEN` 登录。数据默认存放在 `./data`（SQLite）。端口被占用时用 `PORT=<端口>` 覆盖（默认 4000）。
 
 ## 第一个代理请求
 
-在界面里添加至少一个上游站点与账号、执行「重建全部路由」后（见 [快速上手](docs/getting-started.md)），像调用 OpenAI 一样调用 Metapi：
+在界面里添加至少一个上游站点与账号、执行「重建全部路由」后（完整流程见 [快速上手](docs/getting-started.md)），像调用 OpenAI 一样调用 Metapi：
 
 ```bash
 curl http://localhost:4000/v1/chat/completions \
@@ -202,61 +183,17 @@ curl http://localhost:4000/v1/chat/completions \
   }'
 ```
 
-Metapi 自动在所有上游站点中选择成本最优、状态健康的通道；通道失败自动冷却并重试下一个。Claude 原生格式（`/v1/messages`）、Responses、Embeddings、Images、`/v1/models` 与 `/v1/files` 同样支持；完整端点清单见 [HTTP API](docs/api.md)，客户端接入见 [client-integration](docs/client-integration.md)。
-
-未配置任何路由时，代理请求如实返回 503（已实测）：
+Metapi 自动在所有上游站点中选择成本最优、状态健康的通道；通道失败自动冷却并重试下一个。未配置任何路由时返回如实的 503：
 
 ```json
 { "error": { "message": "No available channels", "type": "server_error", "request_id": "…" } }
 ```
 
----
-
-## 核心功能
-
-### 统一代理网关
-
-兼容 **OpenAI** 与 **Claude** 下游格式。Chat Completions、Responses、Messages、Completions（Legacy）、Embeddings、Images、Models 与 `/v1/files`，完整 SSE 流式传输，自动格式转换（OpenAI ⇄ Claude）。
-
-### 智能路由引擎
-
-- 自动发现所有上游模型，**零配置**生成路由表
-- 四级成本信号：实测成本 → 账号配置成本 → 目录参考价（models.dev）→ 默认兜底
-- 多通道概率分摊，按成本、余额、使用率加权分配
-- 失败通道自动冷却与避让，请求自动重试其他通道
-- 运行时熔断器 + half-open 探测，恢复中的通道受控重新进入候选集
-
-### 多平台聚合管理
-
-共 **16** 个适配器（`platform/`）：`new-api`、`one-api`、`one-hub`、`done-hub`、`veloera`、`anyrouter`、`sub2api`、`openai`、`claude`、`gemini`、`gemini-cli`、`codex`、`antigravity`、`grok`、`cliproxyapi`、`sensetime`。模型枚举、余额查询、Token 管理、代理接入为通用能力；登录、签到等按平台而异。
-
-### 账号与 Token 管理
-
-多站点多账号，每个账号可持有多个 API Token。`healthy` / `unhealthy` / `degraded` / `disabled` 四级状态机；凭据加密存储；Token 过期自动重新登录；禁用站点级联禁用关联账号。
-
-### 模型广场与操练场
-
-跨站模型覆盖总览、各站定价对比、延迟与成功率实测指标；交互式操练场可强制指定通道对比输出。
-
-### 自动签到与余额
-
-Cron 定时签到（默认每日 08:00），奖励解析与失败通知，并发锁防重复；定时余额刷新（默认每小时），收入追踪与消费趋势分析。
-
-### 告警通知
-
-九种渠道：Webhook、Bark、Server酱、Telegram Bot、SMTP 邮件、飞书、钉钉、企业微信、ntfy。覆盖余额不足、站点/账号异常、签到失败、代理失败、Token 过期与每日摘要，可按类型静音，冷却防重复。
-
-### 运营与审计
-
-管理操作审计日志；实时 QPS / 成功率面板（WebSocket 推流）；批量模型验证、模型倍率编辑、模型重定向映射、标签；仪表盘快照 PNG 导出。
-
-### 轻量部署
-
-单二进制 + 本地数据目录即可运行，也可外接 PostgreSQL；SQLite / PostgreSQL 双 dialect，启动自动执行幂等 schema 升级；数据完整导入导出。
+Claude 原生格式（`/v1/messages`）、Responses、Embeddings、Images、`/v1/models` 与 `/v1/files` 同样支持；完整端点清单见 [HTTP API](docs/api.md)，客户端接入见 [client-integration](docs/client-integration.md)。
 
 ---
 
-## 配置
+## 部署与配置
 
 全部配置由环境变量驱动，启动只需两个必填项：
 
@@ -267,49 +204,41 @@ Cron 定时签到（默认每日 08:00），奖励解析与失败通知，并发
 
 常用项：
 
-| 变量                   | 默认值        | 说明                                             |
-| ---------------------- | ------------- | ------------------------------------------------ |
-| `ACCOUNT_CREDENTIAL_SECRET` | 回退 `AUTH_TOKEN` | 上游凭据加密密钥，建议 32+ 字节随机串      |
-| `PORT`                 | `4000`        | 监听端口                                         |
-| `HOST`                 | 平台相关      | Windows 默认 `127.0.0.1`，其他平台 `0.0.0.0`     |
-| `DATA_DIR`             | `./data`      | 数据目录（SQLite 库与上传文件）                  |
-| `DATABASE_URL`         | 空            | PostgreSQL 连接串；留空使用 SQLite               |
-| `LOG_LEVEL`            | `info`        | 日志级别：`debug` / `info` / `warn` / `error`    |
-| `CHECKIN_CRON`         | `0 8 * * *`   | 签到时间                                         |
-| `BALANCE_REFRESH_CRON` | `0 * * * *`   | 余额刷新频率                                     |
+| 变量                        | 默认值              | 说明                                          |
+| --------------------------- | ------------------- | --------------------------------------------- |
+| `ACCOUNT_CREDENTIAL_SECRET` | 回退 `AUTH_TOKEN`   | 上游凭据加密密钥，建议 32+ 字节随机串         |
+| `PORT`                      | `4000`              | 监听端口                                      |
+| `DATA_DIR`                  | `./data`            | 数据目录（SQLite 库与上传文件）               |
+| `DATABASE_URL`              | 空                  | PostgreSQL 连接串；留空使用 SQLite            |
+| `LOG_LEVEL`                 | `info`              | 日志级别：`debug` / `info` / `warn` / `error` |
+| `CHECKIN_CRON`              | `0 8 * * *`         | 签到时间                                      |
+| `BALANCE_REFRESH_CRON`      | `0 * * * *`         | 余额刷新频率                                  |
 
-完整清单（约 150 项：PostgreSQL 池预设、代理限额、速率限制、CORS、可信代理、通知渠道等）见 [配置参考](docs/configuration.md) 与 [`.env.example`](.env.example)。
+完整清单（约 150 项）见 [配置参考](docs/configuration.md) 与 [`.env.example`](.env.example)。
 
-### 健康检查
+**健康检查**：`GET /health`（liveness）、`GET /ready`（readiness，检查数据库）；Docker 镜像内置 `metapi healthcheck` 等价探测 `/ready`。
 
-- `GET /health` — liveness，HTTP 进程存活即 200
-- `GET /ready` — readiness，检查数据库；不可用或关停中返回 503
-- Docker 镜像内置 `metapi healthcheck`（等价探测 `/ready`，实测 exit code 正确）
+**深入阅读**：
 
----
-
-## 文档
-
-| 文档                                                   | 用途                                  |
-| ------------------------------------------------------ | ------------------------------------- |
-| [docs/getting-started.md](docs/getting-started.md)     | **快速上手**：安装到第一个代理请求    |
-| [docs/deployment.md](docs/deployment.md)               | 部署 / 反向代理 / PostgreSQL / 升级   |
-| [docs/configuration.md](docs/configuration.md)         | 环境变量完整参考                      |
-| [docs/client-integration.md](docs/client-integration.md) | 客户端接入（Cursor / Claude Code / Codex / Open WebUI） |
-| [docs/api.md](docs/api.md)                             | HTTP API 端点清单                     |
-| [docs/migration.md](docs/migration.md)                 | TS → Go 迁移（SQLite / PG / MySQL）   |
-| [docs/faq.md](docs/faq.md)                             | 常见问题                              |
-| [docs/architecture.md](docs/architecture.md)           | 包结构与请求路径（开发者）            |
-| [docs/README.md](docs/README.md)                       | 文档地图                              |
-| [CHANGELOG.md](CHANGELOG.md)                           | 版本变更                              |
+| 文档                                                     | 用途                                                  |
+| -------------------------------------------------------- | ----------------------------------------------------- |
+| [docs/getting-started.md](docs/getting-started.md)       | **快速上手**：安装到第一个代理请求                    |
+| [docs/deployment.md](docs/deployment.md)                 | 反向代理 / TLS / PostgreSQL / 备份 / 升级回滚         |
+| [docs/configuration.md](docs/configuration.md)           | 环境变量完整参考                                      |
+| [docs/client-integration.md](docs/client-integration.md) | 客户端接入（Cursor / Claude Code / Codex / Open WebUI）|
+| [docs/api.md](docs/api.md)                               | HTTP API 端点清单                                     |
+| [docs/migration.md](docs/migration.md)                   | TS → Go 迁移（SQLite / PG / MySQL）                   |
+| [docs/faq.md](docs/faq.md)                               | 常见问题                                              |
+| [docs/architecture.md](docs/architecture.md)             | 包结构与请求路径（开发者）                            |
+| [CHANGELOG.md](CHANGELOG.md)                             | 版本变更                                              |
 
 ## 从 TypeScript 版迁移
 
-数据库 Schema 完全一致：停止旧服务，用同样的环境变量启动 Go 版即可，启动时自动执行幂等迁移。Go 镜像以 uid 1001 运行，旧版 root 写入的 bind mount 数据目录需先 `chown -R 1001:1001 ./data`（命名卷无需处理）。SQLite / PostgreSQL 直接接管，MySQL 需先经 TypeScript 版内置迁移转出。完整步骤、`metapi-migrate` 工具与回滚方案见 [迁移指南](docs/migration.md)。
+数据库 Schema 完全一致：停止旧服务，用同样的环境变量启动 Go 版即可，启动时自动执行幂等迁移。SQLite / PostgreSQL 直接接管，MySQL 需先经 TypeScript 版内置迁移转出。Go 镜像以 uid 1001 运行，旧版 root 写入的 bind mount 目录需先 `chown -R 1001:1001 ./data`（命名卷无需处理）。完整步骤、`metapi-migrate` 工具与回滚方案见 [迁移指南](docs/migration.md)。
 
 ## 已知限制
 
-- 少量管理端点当前如实返回 `501`（未实现），清单见 [api.md](docs/api.md) 中的「501 残留」标注；版本更新提示请走 GitHub Releases / GHCR 镜像 tag。
+- 少量管理端点当前如实返回 `501`（未实现），清单见 [api.md](docs/api.md) 中的「501 残留」标注。
 - 代理上游未配置时返回 503，不做合成成功响应。
 - 单进程语义为主；多实例部署的共享语义（Redis 共享 RPM/TPM 准入、PostgreSQL advisory lock）见 [FAQ](docs/faq.md)。
 
@@ -339,6 +268,17 @@ bun run build       # rsbuild 构建（产物经 go:embed 打包进 Go 二进制
 ```
 
 贡献流程（分支模型、PR 门禁）见 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+## 验证说明
+
+本项目的文档命令按以下口径核实，集中说明一次，正文不再重复：
+
+| 路径                                  | 核实口径                                             |
+| ------------------------------------- | ---------------------------------------------------- |
+| Release 二进制：安装 → 启动 → 健康检查 | 端到端实测（v0.16.6）                                |
+| 源码构建：前端构建 → go build → 启动   | 端到端实测                                           |
+| Docker / Compose 命令                  | 与仓库 `Dockerfile` / `docker-compose.prod.yml` 逐项核对 |
+| 未配置路由返回 503、健康检查退出码     | 实测                                                 |
 
 ## 贡献与安全
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -9,15 +9,15 @@
 </p>
 
 <p align="center">
-  One key for every AI gateway. <br>
+  One key for every AI gateway.<br>
   Unify the New API / One API / OneHub / Sub2API sites you registered everywhere into
   <strong>a single API key and a single entrypoint</strong> — with automatic model
   discovery, smart routing and cost-optimal channel selection.
 </p>
 
 <p align="center">
-  <a href="README.md"><strong>中文</strong></a> ·
-  <a href="README_EN.md">English</a>
+  <a href="README.md">中文</a> ·
+  <a href="README_EN.md"><strong>English</strong></a>
 </p>
 
 <p align="center">
@@ -28,7 +28,44 @@
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-3DA639?logo=opensourceinitiative&logoColor=white"></a>
 </p>
 
+<p align="center">
+  <a href="#features"><strong>Features</strong></a> ·
+  <a href="#screenshots">Screenshots</a> ·
+  <a href="#quick-start-3-minutes"><strong>Quick Start</strong></a> ·
+  <a href="#deployment--configuration">Deployment</a> ·
+  <a href="#migrating-from-the-typescript-version">Migration</a> ·
+  <a href="#known-limitations">Limitations</a>
+</p>
+
 ---
+
+## What is Metapi
+
+The AI ecosystem is full of aggregation relays built on New API / One API and
+friends, and balances, model lists and API keys end up scattered across many
+of them. **Metapi** is the **meta-aggregation layer** above those relays: it
+unifies your sites behind **one entrypoint**, so every downstream tool —
+Cursor, Claude Code, Codex, Open WebUI and anything that speaks OpenAI —
+reaches all of your models transparently.
+
+Supported upstreams:
+
+- **Aggregation panels**: New API, One API, OneHub, DoneHub, Veloera, AnyRouter, Sub2API
+- **Compatible endpoints**: OpenAI / Claude / Gemini compatible APIs, plus `cliproxyapi` / CPA
+- **OAuth connections**: Codex, Claude, Gemini CLI, Antigravity
+
+## Features
+
+| Capability                 | Description                                                                                                                                    |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **16 upstream adapters**   | New API / One API / OneHub / DoneHub / Veloera / AnyRouter / Sub2API / OpenAI / Claude / Gemini / Gemini CLI / Codex / Antigravity / Grok / CLIProxyAPI / SenseTime |
+| **Unified proxy**          | OpenAI and Claude protocols side by side: Chat / Responses / Messages / Embeddings / Images / Models / Files, full SSE streaming, automatic conversion |
+| **Routing & fault tolerance** | Automatic model discovery builds route tables with zero config; multi-channel allocation weighted by cost / balance / usage; failed channels cool down while the request retries on the next; runtime circuit breaker with half-open probing |
+| **Cost ground truth**      | Four-level cost signal (measured → account-configured → models.dev catalog → fallback); every request logged with tokens and cost            |
+| **Admin UI**               | Sites / accounts / routes / models / logs / alerts in one SPA, pre-built and embedded into the binary — no separate frontend service needed  |
+| **Operations automation**  | Scheduled check-ins, scheduled balance refresh, nine alert channels, batch model verification, audit log, realtime QPS panel                 |
+| **Lightweight deployment** | A single binary is enough; SQLite by default, PostgreSQL optional; idempotent schema upgrades run automatically at startup                    |
+| **Drop-in TS takeover**    | Same database schema, same environment variable names, same API contract — stop the old server and start this one with the same variables     |
 
 ## Screenshots
 
@@ -77,87 +114,29 @@
 
 ---
 
-## What is Metapi
-
-The AI ecosystem is full of aggregation relays built on New API / One API and
-friends, and balances, model lists and API keys end up scattered across many
-of them. **Metapi** is the **meta-aggregation layer** above those relays: it
-unifies your sites behind **one entrypoint**, so every downstream tool —
-Cursor, Claude Code, Codex, Open WebUI and anything that speaks OpenAI —
-reaches all of your models transparently.
-
-Supported upstreams:
-
-- **Aggregation panels**: New API, One API, OneHub, DoneHub, Veloera, AnyRouter, Sub2API
-- **Compatible endpoints**: OpenAI / Claude / Gemini compatible APIs, plus `cliproxyapi` / CPA
-- **OAuth connections**: Codex, Claude, Gemini CLI, Antigravity
-
-| Pain point                                 | How Metapi solves it                                                    |
-| ------------------------------------------ | ----------------------------------------------------------------------- |
-| One key per site, a pile of client configs | **Unified proxy entry + multiple downstream keys**, models aggregated on `/v1/*` |
-| No idea which site is cheapest for a model | **Smart routing** picks the best channel by cost, balance and usage     |
-| A site goes down, manual switching         | **Automatic failover**: failed channels cool down, request retries on the next |
-| Balances scattered everywhere              | **Central dashboard** at a glance, with low-balance alerts              |
-| Daily check-ins on every site              | **Scheduled auto check-in** with reward tracking                        |
-| No idea which site has which model         | **Auto model discovery** — new upstream models enter routing with zero config |
-
-This project is a Go rewrite of [Metapi (TypeScript)](https://github.com/cita-777/metapi)
-with client-visible compatibility:
-
-|                | Node.js (original) | Go (this repo)   |
-| -------------- | ------------------ | ---------------- |
-| Memory         | ~85 MB             | ~20 MB           |
-| Docker image   | ~250 MB            | ~15 MB           |
-| Startup        | 5-10 s             | instant          |
-| Deployment     | Node runtime       | single binary    |
-
----
-
 ## Quick start (3 minutes)
 
-The release page ships pre-built binaries for Linux / macOS / Windows — one file, no runtime.
+Three equivalent ways — pick any one. Starting the server needs only two tokens:
+`AUTH_TOKEN` (admin UI login) and `PROXY_TOKEN` (the downstream key for `/v1/*`).
 
-**1. Install** (Linux / macOS; on Windows download `metapi-windows-amd64.exe` directly from [Releases](https://github.com/DeliciousBuding/metapi-go/releases/latest)):
+### Option 1: Release binary (recommended)
 
-```bash
-curl -fsSL https://github.com/DeliciousBuding/metapi-go/releases/latest/download/install.sh | bash
-```
-
-The script verifies the SHA-256 checksum and installs to `/usr/local/bin/metapi`.
-If `/usr/local` is not writable, point `METAPI_INSTALL_PREFIX` at a directory of
-your choice (e.g. `METAPI_INSTALL_PREFIX=~/.local` installs to `~/.local/bin/metapi`).
-
-**2. Start** (only two tokens are required):
+Pre-built binaries for Linux / macOS / Windows — one file, no runtime:
 
 ```bash
+curl -fsSL https://github.com/DeliciousBuding/metapi-go/releases/download/v0.16.6/install.sh | bash
+
 export AUTH_TOKEN=$(openssl rand -hex 16)      # admin UI login token
 export PROXY_TOKEN=sk-$(openssl rand -hex 24)  # downstream key for /v1/* calls
 metapi
 ```
 
-**3. Verify**:
+The script verifies the SHA-256 checksum and installs to `/usr/local/bin/metapi`
+(it installs the latest release by default; pin a version with `METAPI_VERSION`,
+change the install location with `METAPI_INSTALL_PREFIX`). On Windows, download
+`metapi-windows-amd64.exe` directly from [Releases](https://github.com/DeliciousBuding/metapi-go/releases/latest).
 
-```bash
-curl http://localhost:4000/health
-# {"status":"ok"}
-curl http://localhost:4000/ready
-# {"status":"ok","database":"ok"}
-```
-
-Open `http://localhost:4000` and sign in with `AUTH_TOKEN`. Data lives in `./data`
-(SQLite) by default and survives removing the token environment variables.
-
-> The path above was tested end to end. If the port is taken, override with
-> `PORT=<port>` (default 4000). Then add sites and accounts in the UI, run the
-> automatic route rebuild, and make your first proxied request — full walkthrough:
-> [getting started](docs/getting-started.md).
-
-## Deployment
-
-### Docker
-
-> The commands below were cross-checked line by line against the repo `Dockerfile` /
-> `docker-compose.prod.yml` (no Docker available in the test environment; not executed).
+### Option 2: Docker (named volume, zero config)
 
 ```bash
 docker run -d --name metapi \
@@ -171,32 +150,20 @@ docker run -d --name metapi \
   ghcr.io/deliciousbuding/metapi-go:latest
 ```
 
-Key points:
-
-- The image runs as a non-root user (uid 1001). A **named volume** (`metapi_data`
-  above) inherits the image ownership on first mount — zero configuration. If you
-  use a bind mount such as `./data:/app/data` instead, run
-  `chown -R 1001:1001 ./data` on the host first; see the
-  [deployment guide](docs/deployment.md).
-- `ACCOUNT_CREDENTIAL_SECRET` encrypts the upstream credentials stored in the
-  database. Generate an independent 32+ byte random secret; when unset it falls
-  back to `AUTH_TOKEN`.
-- For production, pin a version tag (e.g. `:v0.16.6`) instead of `latest`.
-
-### Docker Compose
-
-`docker-compose.prod.yml` (GHCR image + production hardening) or
-`docker-compose.yml` (local build):
+A named volume inherits the image ownership on first mount — it just works.
+If you prefer a bind mount (`./data:/app/data`), run `chown -R 1001:1001 ./data`
+on the host first. With Compose (production-hardened config):
 
 ```bash
 cp .env.example .env   # fill in AUTH_TOKEN / PROXY_TOKEN / ACCOUNT_CREDENTIAL_SECRET
 docker compose -f docker-compose.prod.yml up -d
 ```
 
-### From source
+### Option 3: From source
 
-Requires Go 1.26+ and Bun 1.x (the frontend must be built first; the output is
-embedded into the binary via `go:embed`):
+Requires Go 1.26+ and Bun 1.x. The frontend must be built first — the output is
+embedded into the binary via `go:embed`, and skipping it fails with
+`pattern dist: no matching files found`:
 
 ```bash
 git clone https://github.com/DeliciousBuding/metapi-go.git
@@ -206,15 +173,24 @@ go build -o metapi ./cmd/server
 AUTH_TOKEN=your-admin-token PROXY_TOKEN=your-proxy-sk-token ./metapi
 ```
 
-Reverse proxy, PostgreSQL, upgrades and rollback: [deployment guide](docs/deployment.md).
+### Verify
 
----
+```bash
+curl http://localhost:4000/health
+# {"status":"ok"}
+curl http://localhost:4000/ready
+# {"status":"ok","database":"ok"}
+```
+
+Open `http://localhost:4000` and sign in with `AUTH_TOKEN`. Data lives in
+`./data` (SQLite) by default. If the port is taken, override with `PORT=<port>`
+(default 4000).
 
 ## Your first proxied request
 
 After adding at least one upstream site with an account in the UI and running
-"Auto-rebuild routes" (see [getting started](docs/getting-started.md)), call
-Metapi exactly like OpenAI:
+"Auto-rebuild routes" (full walkthrough: [getting started](docs/getting-started.md)),
+call Metapi exactly like OpenAI:
 
 ```bash
 curl http://localhost:4000/v1/chat/completions \
@@ -228,83 +204,19 @@ curl http://localhost:4000/v1/chat/completions \
 
 Metapi picks the cheapest healthy channel across all of your upstream sites;
 failed channels cool down automatically and the request retries on the next one.
-Claude native format (`/v1/messages`), Responses, Embeddings, Images,
-`/v1/models` and `/v1/files` are supported the same way; full endpoint inventory:
-[HTTP API](docs/api.md), client setup: [client-integration](docs/client-integration.md).
-
-With no routes configured, proxy requests return an honest 503 (tested):
+With no routes configured, you get an honest 503:
 
 ```json
 { "error": { "message": "No available channels", "type": "server_error", "request_id": "…" } }
 ```
 
----
-
-## Core features
-
-### Unified proxy gateway
-
-OpenAI **and** Claude downstream formats for every mainstream client. Chat
-Completions, Responses, Messages, Completions (legacy), Embeddings, Images,
-Models and the standard `/v1/files` endpoint, with full SSE streaming and
-automatic OpenAI ⇄ Claude conversion.
-
-### Smart routing engine
-
-- Zero-config route tables from automatic model discovery
-- Four-level cost truth: measured → configured → models.dev catalog → fallback
-- Probabilistic multi-channel allocation weighted by cost, balance and usage
-- Automatic cooldown and avoidance of failed channels; requests retry on other channels
-- Runtime circuit breaker + half-open probing so recovering channels re-enter under control
-
-### Multi-platform aggregation
-
-**16** adapters in total (`platform/`): `new-api`, `one-api`, `one-hub`,
-`done-hub`, `veloera`, `anyrouter`, `sub2api`, `openai`, `claude`, `gemini`,
-`gemini-cli`, `codex`, `antigravity`, `grok`, `cliproxyapi`, `sensetime`.
-Model enumeration, balance queries, token management and proxying are generic;
-login/check-in capabilities vary per platform.
-
-### Accounts & tokens
-
-Multi-site, multi-account, multiple API tokens per account. Four-state health
-machine (`healthy` / `unhealthy` / `degraded` / `disabled`); credentials
-encrypted at rest; automatic re-login on token expiry; disabling a site cascades
-to its accounts.
-
-### Model marketplace & tester
-
-Cross-site model coverage, per-site price comparison, latency and success-rate
-metrics; an interactive tester that forces specific channels and compares outputs.
-
-### Check-in & balances
-
-Scheduled check-in (default daily at 08:00) with reward parsing, failure
-notifications and a concurrency lock against duplicates; scheduled balance
-refresh (default hourly) with income tracking and spend trend analysis.
-
-### Alerts
-
-Nine channels: Webhook, Bark, ServerChan, Telegram Bot, SMTP email, Feishu,
-DingTalk, WeCom, ntfy. Covers low balance, site/account incidents, check-in
-failures, proxy failures, token expiry and daily digests — with per-type muting
-and cooldowns against duplicates.
-
-### Operations & audit
-
-Audit log for admin operations; realtime QPS / success-rate panel (WebSocket
-stream); batch model verification, model rate editing, model redirect mappings,
-tags; dashboard snapshot PNG export.
-
-### Lightweight deployment
-
-A single binary plus a local data directory is enough to run, or attach an
-external PostgreSQL; SQLite / PostgreSQL dual dialect with idempotent schema
-upgrades at startup; full data import/export.
+Claude native format (`/v1/messages`), Responses, Embeddings, Images,
+`/v1/models` and `/v1/files` are supported the same way; full endpoint inventory:
+[HTTP API](docs/api.md), client setup: [client-integration](docs/client-integration.md).
 
 ---
 
-## Configuration
+## Deployment & configuration
 
 All configuration is driven by environment variables; only two are required to boot:
 
@@ -315,60 +227,51 @@ All configuration is driven by environment variables; only two are required to b
 
 Common options:
 
-| Variable                  | Default              | Description                                          |
-| ------------------------- | -------------------- | ---------------------------------------------------- |
+| Variable                  | Default                    | Description                                    |
+| ------------------------- | -------------------------- | ---------------------------------------------- |
 | `ACCOUNT_CREDENTIAL_SECRET` | falls back to `AUTH_TOKEN` | Upstream credential encryption key; a 32+ byte random secret is recommended |
-| `PORT`                    | `4000`               | Listen port                                          |
-| `HOST`                    | platform-dependent   | Windows defaults to `127.0.0.1`, other platforms `0.0.0.0` |
-| `DATA_DIR`                | `./data`             | Data directory (SQLite database and uploaded files)  |
-| `DATABASE_URL`            | empty                | PostgreSQL connection string; empty = SQLite         |
-| `LOG_LEVEL`               | `info`               | Log level: `debug` / `info` / `warn` / `error`       |
-| `CHECKIN_CRON`            | `0 8 * * *`          | Check-in schedule                                    |
-| `BALANCE_REFRESH_CRON`    | `0 * * * *`          | Balance refresh schedule                             |
+| `PORT`                    | `4000`                     | Listen port                                    |
+| `DATA_DIR`                | `./data`                   | Data directory (SQLite database and uploads)   |
+| `DATABASE_URL`            | empty                      | PostgreSQL connection string; empty = SQLite   |
+| `LOG_LEVEL`               | `info`                     | Log level: `debug` / `info` / `warn` / `error` |
+| `CHECKIN_CRON`            | `0 8 * * *`                | Check-in schedule                              |
+| `BALANCE_REFRESH_CRON`    | `0 * * * *`                | Balance refresh schedule                       |
 
-The complete reference (~150 variables: PostgreSQL pool presets, proxy limits,
-rate limiting, CORS, trusted proxies, notification channels, …) lives in the
+The complete reference (~150 variables) lives in the
 [configuration reference](docs/configuration.md) and [`.env.example`](.env.example).
 
-### Health checks
+**Health checks**: `GET /health` (liveness), `GET /ready` (readiness, checks the
+database); the Docker image ships `metapi healthcheck`, which probes `/ready`.
 
-- `GET /health` — liveness; 200 as long as the HTTP process is alive
-- `GET /ready` — readiness; checks the database; 503 while unavailable or draining
-- The Docker image ships `metapi healthcheck` (equivalent to probing `/ready`; exit codes tested)
+**Further reading**:
 
----
-
-## Documentation
-
-| Document                                                     | Purpose                          |
-| ------------------------------------------------------------ | -------------------------------- |
+| Document                                                     | Purpose                                              |
+| ------------------------------------------------------------ | ---------------------------------------------------- |
 | [docs/getting-started.md](docs/getting-started.md)           | **Getting started**: install → first proxied request |
-| [docs/deployment.md](docs/deployment.md)                     | Deployment / reverse proxy / PostgreSQL / upgrades |
-| [docs/configuration.md](docs/configuration.md)               | Full environment variable reference |
+| [docs/deployment.md](docs/deployment.md)                     | Reverse proxy / TLS / PostgreSQL / backup / upgrades |
+| [docs/configuration.md](docs/configuration.md)               | Full environment variable reference                  |
 | [docs/client-integration.md](docs/client-integration.md)     | Client setup (Cursor / Claude Code / Codex / Open WebUI) |
-| [docs/api.md](docs/api.md)                                   | HTTP API endpoint inventory      |
-| [docs/migration.md](docs/migration.md)                       | TS → Go migration (SQLite / PG / MySQL) |
-| [docs/faq.md](docs/faq.md)                                   | Frequently asked questions       |
-| [docs/architecture.md](docs/architecture.md)                 | Package map & request paths (developers) |
-| [docs/README.md](docs/README.md)                             | Documentation map                |
-| [CHANGELOG.md](CHANGELOG.md)                                 | Release notes                    |
+| [docs/api.md](docs/api.md)                                   | HTTP API endpoint inventory                          |
+| [docs/migration.md](docs/migration.md)                       | TS → Go migration (SQLite / PG / MySQL)              |
+| [docs/faq.md](docs/faq.md)                                   | Frequently asked questions                           |
+| [docs/architecture.md](docs/architecture.md)                 | Package map & request paths (developers)             |
+| [CHANGELOG.md](CHANGELOG.md)                                 | Release notes                                        |
 
 ## Migrating from the TypeScript version
 
 The database schema is identical: stop the old server and start the Go version
 with the same environment variables; the idempotent migration runs at startup.
-The Go image runs as uid 1001 — a bind-mounted data directory previously written
-by the root-owned TypeScript container needs `chown -R 1001:1001 ./data` first
-(named volumes need no action). SQLite / PostgreSQL deployments are taken over
-directly; MySQL data must be exported through the TypeScript version's built-in
-migration first. Full steps, the `metapi-migrate` tool and rollback:
+SQLite / PostgreSQL deployments are taken over directly; MySQL data must be
+exported through the TypeScript version's built-in migration first. The Go image
+runs as uid 1001 — a bind-mounted data directory previously written by the
+root-owned TypeScript container needs `chown -R 1001:1001 ./data` first (named
+volumes need no action). Full steps, the `metapi-migrate` tool and rollback:
 [migration guide](docs/migration.md).
 
 ## Known limitations
 
 - A few admin endpoints currently return an honest `501` (not implemented); see
-  the "501 residual" markers in [api.md](docs/api.md). For version updates use
-  GitHub Releases / GHCR image tags.
+  the "501 residual" markers in [api.md](docs/api.md).
 - With no upstream configured, proxy requests return 503 — never a synthetic success.
 - Single-process semantics are the primary target; the shared semantics for
   multi-instance deployments (Redis-shared RPM/TPM admission, PostgreSQL
@@ -400,6 +303,18 @@ bun run build       # rsbuild build (output embedded into the Go binary via go:e
 ```
 
 Contribution flow (branch model, PR gates): [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Verification notes
+
+Every command in this documentation was verified as summarized below — stated
+once here instead of scattered through the text:
+
+| Path                                            | How it was verified                                            |
+| ----------------------------------------------- | -------------------------------------------------------------- |
+| Release binary: install → start → health checks | Tested end to end (v0.16.6)                                    |
+| From source: frontend build → go build → start  | Tested end to end                                              |
+| Docker / Compose commands                       | Cross-checked line by line against the repo `Dockerfile` / `docker-compose.prod.yml` |
+| 503 without routes, healthcheck exit codes      | Tested                                                         |
 
 ## Contributing & security
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,14 @@ is [`.env.example`](../.env.example); this page groups and explains every
 knob a deployment is likely to touch. Docker Compose users pass these via
 `environment:` (see [`deployment.md`](deployment.md)).
 
+> **How to read this page**: first-time deployment only needs the two
+> [Required](#required) variables (plus the
+> [Recommended](#recommended) credential secret). Everything else is optional
+> and grouped by area — [Server](#server), [Database](#database),
+> [Scheduling](#scheduling), [Notifications](#notifications),
+> [Proxy behavior](#proxy-behavior), [Routing](#routing) and so on. When in
+> doubt, `.env.example` is the source of truth for names and defaults.
+
 ## Required
 
 | Variable | Default | Description |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,6 +2,14 @@
 
 **Last updated**: 2026-08-22
 
+> **How to read this page**: just getting started? The README Quick Start covers
+> the 3-minute paths — this page is the full reference behind them. Start with
+> [Prerequisites](#prerequisites) and [Quick paths](#quick-paths), then jump to
+> the production topics you need: reverse proxy and TLS, PostgreSQL, backup,
+> upgrades and rollback. Every environment variable is listed in
+> [`.env.example`](../.env.example); the grouped reference with explanations is
+> [configuration.md](configuration.md).
+
 ## Prerequisites
 
 Pick the prerequisites for the path you deploy with:
@@ -57,8 +65,8 @@ docker run -d --name metapi \
 ```
 
 Named volume is the zero-config default; bind mounts need a one-time
-`chown -R 1001:1001` — see [数据目录与卷](#数据目录与卷). Compose variants:
-[Docker Compose (Production)](#docker-compose-production).
+`chown -R 1001:1001` — see [Data directory & volumes](#data-directory--volumes).
+Compose variants: [Docker Compose (Production)](#docker-compose-production).
 
 ### 3. From source
 
@@ -92,7 +100,9 @@ Open `http://localhost:4000` and sign in with `AUTH_TOKEN`.
 
 ## Environment Variables
 
-完整的环境变量清单见仓库根目录 [`.env.example`](../.env.example)（约 150 项，含通知、代理、调试等高级配置）；下表仅列部署必需与常用项。
+The complete variable inventory (~150 entries, including notifications, proxy
+and debugging options) lives in [`.env.example`](../.env.example) at the repo
+root; the tables below list only what a deployment needs plus common options.
 
 ### Required
 
@@ -135,7 +145,8 @@ Open `http://localhost:4000` and sign in with `AUTH_TOKEN`.
 
 Both compose files mount a **named volume** (`metapi_data:/app/data`) by
 default — zero configuration. To use a bind mount instead, follow the chown
-instructions in the compose file comments and in [数据目录与卷](#数据目录与卷).
+instructions in the compose file comments and in
+[Data directory & volumes](#data-directory--volumes).
 
 1. Create a `.env` file:
 
@@ -158,18 +169,27 @@ curl http://localhost:4000/health
 # {"status":"ok"}
 ```
 
-### 数据目录与卷
+## Data directory & volumes
 
-容器以**非 root 用户（uid 1001）**运行，数据目录的可写性是 Docker 部署最常见的坑：
+The container runs as a **non-root user (uid 1001)**, and writability of the
+data directory is the most common Docker deployment pitfall:
 
-- **命名卷（全新部署推荐）**：Docker 首次使用时会把镜像内 `/app/data` 的内容连同属主一起拷入卷，容器用户天然可写，无需任何 chown。
-- **Bind mount（迁移旧数据时必须用）**：宿主目录保持宿主属主。旧 TypeScript 版以 root 运行，留下的 `./data` 和 `hub.db` 归 root 所有，Go 版写不进去，启动即报 `attempt to write a readonly database` 或 `unable to open database file`。启动前在宿主机执行一次：
+- **Named volume (recommended for fresh deployments)**: on first use Docker
+  copies the image's `/app/data` contents — including ownership — into the
+  volume, so the container user can write immediately. No `chown` needed.
+- **Bind mount (required when migrating existing data)**: a host directory
+  keeps its host ownership. The old TypeScript version ran as root, so a
+  leftover `./data` / `hub.db` is root-owned and the Go container cannot write
+  it — startup fails with `attempt to write a readonly database` or `unable to
+  open database file`. Fix it once on the host before starting:
 
   ```bash
   sudo chown -R 1001:1001 ./data
   ```
 
-- **镜像标签**：`latest` 便于尝鲜；生产建议固定到版本标签（如 `ghcr.io/deliciousbuding/metapi-go:v0.16.6`），保证可复现部署。
+- **Image tags**: `latest` is convenient for trying things out; for production,
+  pin a version tag (e.g. `ghcr.io/deliciousbuding/metapi-go:v0.16.6`) so
+  deployments stay reproducible.
 
 ## Nginx Reverse Proxy
 


### PR DESCRIPTION
## 目标

把 README/README_EN 从「工程师防御性说明」升级为大气、清晰的开源项目门面：新用户 3 分钟跑起来，看完能明白怎么部署、怎么用。

## 改动

- **README.md / README_EN.md 重构**：徽章（链接逐一核对真实）→ 一句话定位 → 特性矩阵（16 平台适配器 / 路由+重试+熔断 / 计费真值 / 管理 UI / TS 无缝接管，一行一条不吹嘘）→ 三段快速开始（release 二进制 `install.sh` 3 分钟路径 / Docker 命名卷零配置 / 源码构建含 `bun run build:web` 前置）→ 部署与配置导航 → 简短诚实的限制 → 许可。
- **防御性文字归拢**：散布各处的 `(tested)`/`(measured)`/「本环境无 Docker 未实跑」等收敛为单一「验证说明」，正文保持干净叙事；中英两版结构完全对齐。
- **docs/deployment.md / docs/configuration.md**：各加顶部导读（谁该读、按什么顺序、与 README 分工）；deployment.md 中英混杂与标题层级修正。

## 未做（如实记录）

- 截图本轮放弃（`bun run screenshots` 此前实测挂死，本轮不引入）。

## 门禁

go build / vet + web(typecheck+lint+format:check+test) 全绿（纯文档改动，无 Go 逻辑变更）。
