### PR TITLE
fix(web): Round 3 E/F 域重审 — 3 处假成功红→绿修复

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -536,7 +536,17 @@ Test a SQLite or PostgreSQL connection string. Returns `400` when the dialect is
 
 ### POST /api/settings/database/migrate
 
-Returns `501`. Runtime database migration is not wired into the admin API yet. Use `metapi-migrate` for SQLite to PostgreSQL migration.
+Queues a migration of the live runtime database onto an external target as an
+admin background task and returns `202` with the task ID:
+`{ "success": true, "taskId": "...", "task": {...} }`. Progress is observed by
+polling `GET /api/tasks/{id}` until the task reaches `succeeded` (result
+carries per-table row counts) or `failed` (error carries the reason). The
+migration runs the same `store.RunMigration` code path as the `metapi-migrate`
+CLI; it is not wired to any remote helper.
+
+Returns `400` when the dialect is unsupported, the connection string is empty,
+or the target resolves to the live runtime database (migrating onto the
+database currently in use is refused).
 
 ---
 
@@ -616,15 +626,44 @@ Update checkin schedule (cron, interval, or random-window mode). The handler kee
 
 ## Update Center
 
-> **501 residual**：本组接口当前返回 501（未实现）。版本更新提示走 GitHub Releases / GHCR 镜像 tag，前端不依赖此 API。详见 [`STATE.md`](internal/STATE.md)。
+Local-only residual surface. Version updates ship via GitHub Releases / GHCR
+image tags; the admin UI renders this section read-only with external links
+and does not depend on in-app update discovery. Honest residuals: the
+status/check payloads always report `updateAvailable: false` and expose a
+`residual` string describing the limitation; deploy/rollback/task-stream
+return `501` rather than inventing task ids or fake SSE streams.
 
 ### GET /api/update-center/status
 
-Get update center status.
+Local status only. Returns `200` with
+`{ "currentVersion": "0.0.0", "latestVersion": "0.0.0", "updateAvailable": false, "lastCheckedAt": null, "mode": "external", "residual": "..." }`.
+Never invents `updateAvailable: true` or a fake `lastCheckedAt`.
 
 ### POST /api/update-center/check
 
-Trigger update center check.
+Same local-only payload as status (no remote registry polling, no deploy
+tasks started).
+
+### PUT /api/update-center/config
+
+Echo-only: accepts the config body and returns it with `success: true` plus a
+`residual` note. Not persisted as an update-center product config; deploy and
+rollback remain residual regardless of the echoed values.
+
+### POST /api/update-center/deploy
+
+Returns `501` (`{ "success": false, "message": "Update-center deploy is not implemented in Go", "residual": "..." }`).
+Remote binary/Helm deploy via a helper service is out of scope; use external
+deploy tooling (CI/CD or helper).
+
+### POST /api/update-center/rollback
+
+Returns `501` — same honest residual shape as deploy.
+
+### GET /api/update-center/tasks/:id/stream
+
+Returns `501`. No deploy/rollback task registry exists, so there is no SSE log
+stream to serve.
 
 ---
 

--- a/web/src/features/checkin/__tests__/trigger-checkin-result.test.ts
+++ b/web/src/features/checkin/__tests__/trigger-checkin-result.test.ts
@@ -1,0 +1,51 @@
+// Envelope semantics for POST /api/checkin/trigger.
+//
+// The backend answers 200 with `success: (failed == 0)` plus a real
+// per-account `summary`. A partial completion (some accounts failed) is a
+// real outcome that callers must surface — collapsing it into a thrown
+// error hides the counts and leaves the UI with no honest feedback.
+// Only an envelope failure that carries no summary at all is a hard error.
+
+import { describe, expect, it } from 'vitest'
+
+import { parseTriggerCheckinAllResult } from '../api'
+
+describe('parseTriggerCheckinAllResult', () => {
+  it('returns the envelope when every account succeeded', () => {
+    const result = parseTriggerCheckinAllResult({
+      success: true,
+      status: 'completed',
+      message: '签到执行完成',
+      summary: { total: 2, success: 2, failed: 0, skipped: 0 },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.summary).toMatchObject({ total: 2, failed: 0 })
+  })
+
+  it('returns the envelope on partial failure so callers can surface the summary', () => {
+    const result = parseTriggerCheckinAllResult({
+      success: false,
+      status: 'completed',
+      message: '签到执行完成',
+      summary: { total: 3, success: 1, failed: 2, skipped: 0 },
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.summary).toMatchObject({ total: 3, success: 1, failed: 2 })
+  })
+
+  it('throws on an envelope failure that carries no summary', () => {
+    expect(() =>
+      parseTriggerCheckinAllResult({
+        success: false,
+        status: 'completed',
+        message: 'checkin unavailable',
+      })
+    ).toThrow('checkin unavailable')
+  })
+
+  it('throws with the i18n fallback when the failure has no message either', () => {
+    expect(() => parseTriggerCheckinAllResult({ success: false })).toThrow()
+  })
+})

--- a/web/src/features/checkin/api.ts
+++ b/web/src/features/checkin/api.ts
@@ -6,7 +6,9 @@ import {
   useQueryClient,
   type UseQueryOptions,
 } from '@tanstack/react-query'
+import type { z } from 'zod'
 
+import i18n from '@/i18n/config'
 import { api } from '@/lib/api'
 import { assertBusinessOk } from '@/lib/assert-business-ok'
 
@@ -91,14 +93,35 @@ export function useCheckinLogs(
   })
 }
 
+export type TriggerCheckinAllResult = z.infer<
+  typeof triggerCheckinAllResultSchema
+>
+
+/**
+ * Parse the POST /api/checkin/trigger envelope. The backend answers 200 with
+ * `success: (failed == 0)` plus a real per-account summary. A partial
+ * completion is a genuine outcome the caller must present (some succeeded,
+ * some failed), so it is returned — not thrown — and only an envelope failure
+ * that carries no summary at all counts as a hard error. Throwing on every
+ * `success:false` here used to swallow the breakdown before any UI could
+ * show it.
+ */
+export function parseTriggerCheckinAllResult(
+  raw: unknown
+): TriggerCheckinAllResult {
+  const parsed = triggerCheckinAllResultSchema.parse(raw)
+  if (!parsed.success && !parsed.summary) {
+    throw new Error(parsed.message || i18n.t('checkin.toast.triggerFailed'))
+  }
+  return parsed
+}
+
 export function useManualCheckin() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async () => {
       const result = await api.triggerCheckinAll()
-      return triggerCheckinAllResultSchema.parse(
-        assertBusinessOk(result, 'checkin.toast.triggerFailed')
-      )
+      return parseTriggerCheckinAllResult(result)
     },
     onSuccess: (result) => {
       void queryClient.invalidateQueries({ queryKey: checkinQueryKeys.logs() })

--- a/web/src/features/checkin/components/__tests__/checkin-page-partial.test.tsx
+++ b/web/src/features/checkin/components/__tests__/checkin-page-partial.test.tsx
@@ -1,0 +1,190 @@
+// Partial-failure honesty for the "run all check-ins" header action.
+//
+// POST /api/checkin/trigger answers 200 with `success: (failed == 0)` plus a
+// per-account summary. When some accounts fail, the page must surface the
+// real breakdown (partialFailed toast + counts) instead of collapsing into a
+// swallowed error with no feedback. Regression guard: the summary branch used
+// to be dead code because the mutation threw on `success:false` before the
+// result could reach it.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { CheckinPage } from '../checkin-page'
+
+const testState = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  triggerCheckinAll: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  toastWarning: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => testState.navigate,
+}))
+
+vi.mock('@/components/data-table', () => ({
+  DataTablePage: (props: { emptyAction?: ReactNode }) => (
+    <div data-testid='table-slot'>{props.emptyAction}</div>
+  ),
+  useDataTable: () => ({ table: {} }),
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    sorting: [],
+    onSortingChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    filters: {
+      status: '',
+      reason: '',
+      site: '',
+      accountId: '',
+      from: '',
+      to: '',
+    },
+    updateUrlState: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/common/query-error-banner', () => ({
+  QueryErrorBanner: () => null,
+}))
+
+vi.mock('@/features/accounts', () => ({
+  useAccounts: () => ({
+    data: { accounts: [{ id: 1, username: 'acc-1' }] },
+  }),
+}))
+
+vi.mock('@/features/sites/api', () => ({
+  useSites: () => ({ data: [] }),
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: testState.toastSuccess,
+    error: testState.toastError,
+    warning: testState.toastWarning,
+    info: vi.fn(),
+  },
+}))
+
+// Only the transport layer is mocked: the real useManualCheckin hook runs,
+// so the envelope handling under test is the production code path.
+vi.mock('@/lib/api', () => ({
+  api: {
+    getCheckinLogs: vi.fn().mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    }),
+    triggerCheckinAll: (...args: unknown[]) =>
+      testState.triggerCheckinAll(...args),
+    triggerCheckin: vi.fn(),
+  },
+}))
+
+vi.mock('../checkin-columns', () => ({
+  useCheckinColumns: () => [],
+}))
+
+vi.mock('../checkin-detail-sheet', () => ({
+  CheckinDetailSheet: () => null,
+}))
+
+vi.mock('../manual-checkin-dialog', () => ({
+  ManualCheckinDialog: () => null,
+}))
+
+beforeEach(() => {
+  testState.navigate.mockReset()
+  testState.triggerCheckinAll.mockReset()
+  testState.toastSuccess.mockReset()
+  testState.toastError.mockReset()
+  testState.toastWarning.mockReset()
+})
+
+afterEach(() => cleanup())
+
+function renderCheckinPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CheckinPage />
+    </QueryClientProvider>
+  )
+}
+
+describe('CheckinPage — run-all partial failure honesty', () => {
+  it('surfaces the per-account breakdown when some accounts fail', async () => {
+    testState.triggerCheckinAll.mockResolvedValue({
+      success: false,
+      queued: false,
+      status: 'completed',
+      message: '签到执行完成',
+      summary: { total: 3, success: 1, failed: 2, skipped: 0 },
+    })
+
+    renderCheckinPage()
+
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: /Run all check-ins|执行全部签到/,
+      })
+    )
+
+    await waitFor(() => {
+      expect(testState.toastError).toHaveBeenCalledTimes(1)
+    })
+    const [title, options] = testState.toastError.mock.calls[0] ?? []
+    expect(String(title)).toMatch(/partially failed|部分失败/)
+    expect(String((options as { description?: string })?.description)).toMatch(
+      /1|2|3/
+    )
+    expect(testState.toastSuccess).not.toHaveBeenCalled()
+  })
+
+  it('reports success only when every account succeeded', async () => {
+    testState.triggerCheckinAll.mockResolvedValue({
+      success: true,
+      queued: false,
+      status: 'completed',
+      message: '签到执行完成',
+      summary: { total: 2, success: 2, failed: 0, skipped: 0 },
+    })
+
+    renderCheckinPage()
+
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: /Run all check-ins|执行全部签到/,
+      })
+    )
+
+    await waitFor(() => {
+      expect(testState.toastSuccess).toHaveBeenCalledTimes(1)
+    })
+    expect(testState.toastError).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/features/checkin/components/checkin-page.tsx
+++ b/web/src/features/checkin/components/checkin-page.tsx
@@ -15,6 +15,7 @@
 
 import { useNavigate } from '@tanstack/react-router'
 import type { ColumnFiltersState } from '@tanstack/react-table'
+import axios from 'axios'
 import { CalendarRange, RotateCw, Users, Zap } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -358,7 +359,18 @@ export function CheckinPage() {
       } else {
         toast.success(result.message || t('checkin.toast.complete'))
       }
-    } catch {}
+    } catch (error) {
+      // Transport failures (non-2xx) are already toasted by the http-client
+      // error interceptor; envelope failures thrown by the parser are not, so
+      // they get their own honest error toast instead of being swallowed.
+      if (!axios.isAxiosError(error)) {
+        toast.error(
+          error instanceof Error && error.message
+            ? error.message
+            : t('checkin.toast.triggerFailed')
+        )
+      }
+    }
   }
 
   const handleResetFilters = () => {

--- a/web/src/features/settings/sections/general/components/__tests__/proxy-transport-section.test.tsx
+++ b/web/src/features/settings/sections/general/components/__tests__/proxy-transport-section.test.tsx
@@ -1,0 +1,153 @@
+// Honesty test for the system-proxy connectivity probe.
+//
+// POST /api/settings/system-proxy/test reports an unreachable proxy as
+// HTTP 200 + `{success:false, ok:false, reachable:false, message}` — the
+// probe outcome lives in the envelope, not the status code. The section must
+// surface the probe's real verdict (error toast with the probe message) and
+// never toast "Proxy reachable" for a failed probe.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+
+import { ProxyTransportSection } from '../proxy-transport-section'
+
+const testState = vi.hoisted(() => ({
+  testSystemProxy: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getRuntimeSettings: vi.fn().mockResolvedValue({
+      systemProxyUrl: 'http://127.0.0.1:7890',
+    }),
+    updateRuntimeSettings: vi.fn(),
+    testSystemProxy: (...args: unknown[]) => testState.testSystemProxy(...args),
+  },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: testState.toastSuccess,
+    error: testState.toastError,
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: (props: { children?: React.ReactNode }) => <a>{props.children}</a>,
+}))
+
+vi.mock('../../../../components/form-navigation-guard', () => ({
+  FormNavigationGuard: () => null,
+}))
+
+vi.mock('../../../../components/settings-form-actions', () => ({
+  SettingsFormActions: () => null,
+}))
+
+beforeAll(() => {
+  // base-ui primitives query matchMedia under jsdom.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  testState.testSystemProxy.mockReset()
+  testState.toastSuccess.mockReset()
+  testState.toastError.mockReset()
+})
+
+afterEach(() => cleanup())
+
+function renderProxyTransportSection() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ProxyTransportSection />
+    </QueryClientProvider>
+  )
+}
+
+describe('ProxyTransportSection — probe honesty', () => {
+  it('reports the real failure when the probe cannot reach the proxy', async () => {
+    testState.testSystemProxy.mockResolvedValue({
+      success: false,
+      ok: false,
+      reachable: false,
+      latencyMs: 0,
+      proxyUrl: 'http://127.0.0.1:7890',
+      targetUrl: 'https://www.gstatic.com/generate_204',
+      message:
+        'Get "https://www.gstatic.com/generate_204": proxyconnect tcp: dial tcp 127.0.0.1:7890: connect: connection refused',
+    })
+
+    renderProxyTransportSection()
+
+    fireEvent.click(await screen.findByRole('button', { name: /Test|测试/ }))
+
+    await waitFor(() => {
+      expect(testState.toastError).toHaveBeenCalledTimes(1)
+    })
+    expect(String(testState.toastError.mock.calls[0]?.[0])).toMatch(
+      /connection refused/
+    )
+    expect(testState.toastSuccess).not.toHaveBeenCalled()
+  })
+
+  it('toasts success only when the probe actually succeeded', async () => {
+    testState.testSystemProxy.mockResolvedValue({
+      success: true,
+      ok: true,
+      reachable: true,
+      latencyMs: 88,
+      proxyUrl: 'http://127.0.0.1:7890',
+      targetUrl: 'https://www.gstatic.com/generate_204',
+    })
+
+    renderProxyTransportSection()
+
+    fireEvent.click(await screen.findByRole('button', { name: /Test|测试/ }))
+
+    await waitFor(() => {
+      expect(testState.toastSuccess).toHaveBeenCalledTimes(1)
+    })
+    expect(testState.toastError).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/features/settings/sections/general/components/__tests__/scheduling-section.test.tsx
+++ b/web/src/features/settings/sections/general/components/__tests__/scheduling-section.test.tsx
@@ -1,0 +1,169 @@
+// Partial-failure honesty for the settings "Trigger check-in now" action.
+//
+// POST /api/checkin/trigger answers 200 with `success: (failed == 0)`. The
+// section previously ignored the envelope entirely and toasted success even
+// when accounts failed. The trigger must report partial outcomes with the
+// real counts and only celebrate when nothing failed.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+
+import { SchedulingSection } from '../scheduling-section'
+
+const testState = vi.hoisted(() => ({
+  triggerCheckinAll: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  toastWarning: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getRuntimeSettings: vi.fn().mockResolvedValue({}),
+    triggerCheckinAll: (...args: unknown[]) =>
+      testState.triggerCheckinAll(...args),
+    getSettingsMigrationPreview: vi
+      .fn()
+      .mockResolvedValue({ success: true, pending: 0 }),
+    applySettingsMigration: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: testState.toastSuccess,
+    error: testState.toastError,
+    warning: testState.toastWarning,
+    info: vi.fn(),
+  },
+}))
+
+// The router primitives are irrelevant to the trigger behaviour.
+vi.mock('@tanstack/react-router', () => ({
+  Link: (props: { children?: React.ReactNode }) => <a>{props.children}</a>,
+}))
+
+// Keep the harness focused on the mutation: heavy form chrome is stubbed.
+vi.mock('../../../../components/form-navigation-guard', () => ({
+  FormNavigationGuard: () => null,
+}))
+
+vi.mock('../../../../components/schedule-editor', () => ({
+  ScheduleEditor: () => <div data-testid='schedule-editor-stub' />,
+}))
+
+vi.mock('../../../../components/settings-form-actions', () => ({
+  SettingsFormActions: () => null,
+}))
+
+beforeAll(() => {
+  // base-ui primitives query matchMedia under jsdom.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  testState.triggerCheckinAll.mockReset()
+  testState.toastSuccess.mockReset()
+  testState.toastError.mockReset()
+  testState.toastWarning.mockReset()
+})
+
+afterEach(() => cleanup())
+
+function renderSchedulingSection() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SchedulingSection />
+    </QueryClientProvider>
+  )
+}
+
+describe('SchedulingSection — trigger check-in honesty', () => {
+  it('warns with the real counts when some accounts failed', async () => {
+    testState.triggerCheckinAll.mockResolvedValue({
+      success: false,
+      queued: false,
+      status: 'completed',
+      message: '签到执行完成',
+      summary: { total: 3, success: 1, failed: 2, skipped: 0 },
+    })
+
+    renderSchedulingSection()
+
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: /Trigger check-in now|立即签到/,
+      })
+    )
+
+    await waitFor(() => {
+      expect(testState.toastWarning).toHaveBeenCalledTimes(1)
+    })
+    const [title, options] = testState.toastWarning.mock.calls[0] ?? []
+    expect(String(title)).toMatch(/partially failed|部分失败/)
+    expect(String((options as { description?: string })?.description)).toMatch(
+      /1|2|3/
+    )
+    expect(testState.toastSuccess).not.toHaveBeenCalled()
+  })
+
+  it('toasts success only when every account succeeded', async () => {
+    testState.triggerCheckinAll.mockResolvedValue({
+      success: true,
+      queued: false,
+      status: 'completed',
+      message: '签到执行完成',
+      summary: { total: 2, success: 2, failed: 0, skipped: 0 },
+    })
+
+    renderSchedulingSection()
+
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: /Trigger check-in now|立即签到/,
+      })
+    )
+
+    await waitFor(() => {
+      expect(testState.toastSuccess).toHaveBeenCalledTimes(1)
+    })
+    expect(testState.toastWarning).not.toHaveBeenCalled()
+    expect(testState.toastError).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/features/settings/sections/general/components/proxy-transport-section.tsx
+++ b/web/src/features/settings/sections/general/components/proxy-transport-section.tsx
@@ -180,11 +180,30 @@ export function ProxyTransportSection() {
       serverValues,
     })
 
+  // POST /api/settings/system-proxy/test reports an unreachable proxy as
+  // HTTP 200 + `{success:false, reachable:false, message}` — the verdict lives
+  // in the envelope, not the status code. A failed probe must surface its real
+  // outcome (and reason), never a "proxy reachable" celebration.
   const testProxyMutation = useMutation({
-    mutationFn: async (proxyUrl: string) => api.testSystemProxy({ proxyUrl }),
-    onSuccess: (result) => {
-      const latency = (result as { latencyMs?: number } | null)?.latencyMs
-      if (typeof latency === 'number') {
+    mutationFn: async (proxyUrl: string) => {
+      const result = await api.testSystemProxy({ proxyUrl })
+      const probe = result as {
+        success?: boolean
+        reachable?: boolean
+        latencyMs?: number
+        message?: string
+      } | null
+      if (probe && probe.success === false) {
+        throw new Error(
+          probe.message ||
+            t('settings.general.proxyTransport.toast.proxyFailed')
+        )
+      }
+      return probe
+    },
+    onSuccess: (probe) => {
+      const latency = probe?.latencyMs
+      if (typeof latency === 'number' && latency > 0) {
         toast.success(
           t('settings.general.proxyTransport.toast.proxyOk', { ms: latency })
         )
@@ -192,8 +211,19 @@ export function ProxyTransportSection() {
         toast.success(t('settings.general.proxyTransport.toast.proxyOkGeneric'))
       }
     },
-    onError: () =>
-      toast.error(t('settings.general.proxyTransport.toast.proxyFailed')),
+    onError: (error) => {
+      const responseData = (
+        error as {
+          response?: { data?: { message?: string; error?: string } }
+        } | null
+      )?.response?.data
+      const message =
+        responseData?.message ||
+        responseData?.error ||
+        (error instanceof Error ? error.message : '') ||
+        t('settings.general.proxyTransport.toast.proxyFailed')
+      toast.error(message)
+    },
   })
 
   function onSubmit(values: ProxyTransportFormValues) {

--- a/web/src/features/settings/sections/general/components/scheduling-section.tsx
+++ b/web/src/features/settings/sections/general/components/scheduling-section.tsx
@@ -200,10 +200,47 @@ export function SchedulingSection() {
       serverValues,
     })
 
+  // POST /api/checkin/trigger answers 200 with `success:(failed==0)` plus a
+  // per-account summary. A partial failure must be reported as one — with the
+  // real counts — instead of the blanket "triggered" success the old code
+  // toasted regardless of the envelope.
   const triggerCheckinMutation = useMutation({
-    mutationFn: async () => api.triggerCheckinAll(),
-    onSuccess: () =>
-      toast.success(t('settings.general.scheduling.toast.checkinTriggered')),
+    mutationFn: async () =>
+      api.triggerCheckinAll() as Promise<{
+        success?: boolean
+        message?: string
+        summary?: {
+          total: number
+          success: number
+          failed: number
+          skipped: number
+        } | null
+      }>,
+    onSuccess: (result) => {
+      const summary = result?.summary
+      if (summary && summary.failed > 0) {
+        toast.warning(
+          t('settings.general.scheduling.toast.checkinPartialFailed'),
+          {
+            description: t('checkin.toast.summary', {
+              total: summary.total,
+              success: summary.success,
+              failed: summary.failed,
+              skipped: summary.skipped,
+            }),
+          }
+        )
+        return
+      }
+      if (result && result.success === false) {
+        toast.error(
+          result.message ||
+            t('settings.general.scheduling.toast.checkinTriggerFailed')
+        )
+        return
+      }
+      toast.success(t('settings.general.scheduling.toast.checkinTriggered'))
+    },
     onError: () =>
       toast.error(t('settings.general.scheduling.toast.checkinTriggerFailed')),
   })

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -936,7 +936,8 @@
             "saved": "Schedule saved.",
             "saveFailed": "Failed to save schedule.",
             "checkinTriggered": "Check-in triggered.",
-            "checkinTriggerFailed": "Failed to trigger check-in."
+            "checkinTriggerFailed": "Failed to trigger check-in.",
+            "checkinPartialFailed": "Check-in partially failed"
           }
         },
         "proxyTransport": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -936,7 +936,8 @@
             "saved": "计划已保存。",
             "saveFailed": "保存计划失败。",
             "checkinTriggered": "已触发签到。",
-            "checkinTriggerFailed": "触发签到失败。"
+            "checkinTriggerFailed": "触发签到失败。",
+            "checkinPartialFailed": "签到部分失败"
           }
         },
         "proxyTransport": {

--- a/web/src/lib/api/token-routes.ts
+++ b/web/src/lib/api/token-routes.ts
@@ -40,7 +40,16 @@ export const tokenRoutesApi = {
     }),
 
   // Check-in
-  triggerCheckinAll: () => request('/api/checkin/trigger', { method: 'POST' }),
+  // skipBusinessError: the trigger answers 200 with `success:(failed==0)` + a
+  // per-account summary. Both callers (checkin page, scheduling section)
+  // render that breakdown themselves, so the generic interceptor toast — whose
+  // message is the always-"执行完成" envelope text and would read as success
+  // even on partial failure — is suppressed in favour of the precise feedback.
+  triggerCheckinAll: () =>
+    request('/api/checkin/trigger', {
+      method: 'POST',
+      skipBusinessError: true,
+    }),
   triggerCheckin: (id: number) =>
     request(`/api/checkin/trigger/${id}`, { method: 'POST' }),
   getCheckinLogs: (

--- a/web/src/lib/api/transport.ts
+++ b/web/src/lib/api/transport.ts
@@ -22,6 +22,7 @@ export type RequestOptions = {
   signal?: AbortSignal
   headers?: Record<string, string>
   skipErrorHandler?: boolean
+  skipBusinessError?: boolean
 }
 
 /**
@@ -40,6 +41,7 @@ export async function request<T = unknown>(
     signal,
     headers,
     skipErrorHandler = false,
+    skipBusinessError = false,
   } = options
 
   const requestHeaders: Record<string, string> | undefined = body
@@ -51,6 +53,7 @@ export async function request<T = unknown>(
     signal,
     headers: requestHeaders,
     skipErrorHandler,
+    skipBusinessError,
   }
 
   const response =


### PR DESCRIPTION
## 范围

Round 3 E/F 域重审（代码健康 + 产品诚实度）：对 mutation 面与产品能力做「不诚实猎杀」，查实 3 个 P1 假成功并修复。

## 查实并修复的 3 个假成功（均红 → 绿）

1. **checkin trigger 忽略 `success:false` envelope**：`scheduling-section` 与 checkin 页两入口对 `success:false` 无感知，呈现误导性成功。→ 新增 `parseTriggerCheckinAllResult` 呈现真实部分结果（仅无 summary 才 throw），两入口分别呈现 warning+计数 / error+message。
2. **`triggerCheckinAll` 部分失败死代码**：`skipBusinessError` 未透传，拦截器红 toast「签到执行完成」与真实部分失败矛盾。→ transport 透传该选项，消除误导红 toast。
3. **proxy test 假成功**：`200 + success:false` 仍弹「代理可用」。→ 呈现后端真实 message。

## 文档修正

`docs/api.md` 两处过期描述按实测契约改写：migrate（已实现 202+后台任务）、update-center（部分诚实 501）。

## 测试

4 个新测试文件红→绿；全量 vitest 143 文件 / 964 用例全绿、0 skipped（≥ 基线）。

## 移交清单

成本归因 fallback 口径（`billing_details.pricing.source` 留痕 + partial/unattributed 诚实降级）根因在 `handler/proxy/`（本线禁区），记录在案不擅动。

## 门禁

go build / vet + web(typecheck+lint+format:check+test) 全绿。
