### PR TITLE
fix(api): NULL balance no longer 500s /api/sites or aborts balance refresh

### DIFF
--- a/.repro/r.json
+++ b/.repro/r.json
@@ -1,0 +1,1 @@
+{"distribution":[{"accountCount":0,"platform":"openai","siteId":3,"siteName":"Empty Site","totalBalance":0,"totalSpend":0},{"accountCount":1,"platform":"openai","siteId":2,"siteName":"Normal Site","totalBalance":100,"totalSpend":0},{"accountCount":2,"platform":"openai","siteId":1,"siteName":"Null Balance Site","totalBalance":12.5,"totalSpend":0}]}

--- a/.repro/resp.json
+++ b/.repro/resp.json
@@ -1,0 +1,1 @@
+{"items":[],"page":1,"pageSize":50,"total":0}

--- a/.repro/server.log
+++ b/.repro/server.log
@@ -1,0 +1,4 @@
+time=2026-08-22T14:18:49.926+08:00 level=ERROR msg="config validation" error="config critical: proxy_token=(default) — UNSAFE: using default proxy token — set PROXY_TOKEN"
+time=2026-08-22T14:18:49.926+08:00 level=WARN msg="config validation" error="config warning: claude_client_id=(placeholder) — Claude OAuth login will fail — set CLAUDE_CLIENT_ID"
+time=2026-08-22T14:18:49.926+08:00 level=WARN msg="config validation" error="config warning: codex_client_id=(placeholder) — Codex OAuth login will fail — set CODEX_CLIENT_ID"
+time=2026-08-22T14:18:49.926+08:00 level=WARN msg="config validation" error="config warning: gemini_cli_client_id=(placeholder) — Gemini CLI OAuth login will fail — set GEMINI_CLI_CLIENT_ID"

--- a/.repro/sites.json
+++ b/.repro/sites.json
@@ -1,0 +1,1 @@
+{"error":"Failed to load sites","request_id":"bohrium-4467702-1482256/S8pUrh9l4h-000006"}

--- a/service/balance/balance.go
+++ b/service/balance/balance.go
@@ -654,8 +654,11 @@ func RefreshAllBalances(cfg *config.Config, db *sqlx.DB) []struct {
 	AccountID int64
 	Balance   *float64
 } {
-	var accounts []store.Account
-	if err := db.Select(&accounts, "SELECT * FROM accounts WHERE status = 'active'"); err != nil {
+	// Select only IDs: a SELECT * here would scan every column into store.Account,
+	// whose balance/balance_used/quota are non-nullable float64 — a NULL balance
+	// (migrated/never-refreshed account) would abort the whole refresh job.
+	var accountIDs []int64
+	if err := db.Select(&accountIDs, "SELECT id FROM accounts WHERE status = 'active'"); err != nil {
 		slog.Error("RefreshAllBalances: failed to query accounts", "error", err)
 		return nil
 	}
@@ -665,21 +668,21 @@ func RefreshAllBalances(cfg *config.Config, db *sqlx.DB) []struct {
 		Balance   *float64
 	}
 
-	results := make([]resultEntry, len(accounts))
+	results := make([]resultEntry, len(accountIDs))
 	var wg sync.WaitGroup
 
-	for i, account := range accounts {
+	for i, accountID := range accountIDs {
 		wg.Add(1)
-		go func(idx int, acc store.Account) {
+		go func(idx int, accID int64) {
 			defer wg.Done()
-			balanceResult, err := RefreshBalance(cfg, db, acc.ID)
+			balanceResult, err := RefreshBalance(cfg, db, accID)
 			if err != nil || balanceResult == nil {
-				results[idx] = resultEntry{AccountID: acc.ID, Balance: nil}
+				results[idx] = resultEntry{AccountID: accID, Balance: nil}
 			} else {
 				b := balanceResult.Balance
-				results[idx] = resultEntry{AccountID: acc.ID, Balance: &b}
+				results[idx] = resultEntry{AccountID: accID, Balance: &b}
 			}
-		}(i, account)
+		}(i, accountID)
 	}
 	wg.Wait()
 

--- a/service/site_service.go
+++ b/service/site_service.go
@@ -224,7 +224,11 @@ func ListSites(db *sqlx.DB) ([]map[string]any, error) {
 	// non-sub2api accounts in-memory (GetSub2ApiAuthFromExtraConfig returns nil
 	// for them, so they never allocate a map entry).
 	var accounts []accountAgg
-	if err := db.Select(&accounts, "SELECT site_id, balance, extra_config FROM accounts"); err != nil {
+	// COALESCE(balance, 0): accounts migrated from the TS version (or never
+	// refreshed) may carry a NULL balance, which sqlx cannot scan into float64
+	// and would 500 the whole /api/sites response. Aggregation treats an
+	// unknown balance as 0, matching the stats endpoints' existing convention.
+	if err := db.Select(&accounts, "SELECT site_id, COALESCE(balance, 0) AS balance, extra_config FROM accounts"); err != nil {
 		return nil, err
 	}
 

--- a/service/site_service_null_balance_test.go
+++ b/service/site_service_null_balance_test.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"testing"
+)
+
+// TestListSites_NullBalanceDoesNotError guards the /api/sites 500 regression:
+// an account with a NULL balance (migrated from the TS version, or never
+// refreshed) must not abort ListSites. The site's aggregated totalBalance
+// treats the unknown balance as 0 via COALESCE at the DB layer, matching the
+// stats endpoints' existing convention.
+func TestListSites_NullBalanceDoesNotError(t *testing.T) {
+	db := openTestDB(t)
+
+	siteID := createTestSite(t, db, "Null Balance Site", "https://api.example.com", "openai")
+	accountID := createTestAccount(t, db, siteID, strPtr("null-balance-user"), "sk-test")
+
+	if _, err := db.Exec("UPDATE accounts SET balance = NULL WHERE id = ?", accountID); err != nil {
+		t.Fatalf("set balance NULL: %v", err)
+	}
+
+	sites, err := ListSites(db.DB)
+	if err != nil {
+		t.Fatalf("ListSites with NULL balance account: %v", err)
+	}
+	if len(sites) != 1 {
+		t.Fatalf("expected 1 site, got %d", len(sites))
+	}
+
+	tb, ok := sites[0]["totalBalance"].(float64)
+	if !ok {
+		t.Fatalf("totalBalance type = %T, want float64", sites[0]["totalBalance"])
+	}
+	if tb != 0 {
+		t.Errorf("totalBalance = %v, want 0 (NULL balance aggregates as 0)", tb)
+	}
+}
+
+// TestListSites_NullBalanceWithSiblingSumsCorrectly ensures COALESCE only
+// neutralizes the NULL account while a sibling account's balance still counts.
+func TestListSites_NullBalanceWithSiblingSumsCorrectly(t *testing.T) {
+	db := openTestDB(t)
+
+	siteID := createTestSite(t, db, "Mixed Balance Site", "https://api.example.com", "openai")
+	nullAccount := createTestAccount(t, db, siteID, strPtr("null-balance-user"), "sk-a")
+	normalAccount := createTestAccount(t, db, siteID, strPtr("normal-user"), "sk-b")
+
+	if _, err := db.Exec("UPDATE accounts SET balance = NULL WHERE id = ?", nullAccount); err != nil {
+		t.Fatalf("set NULL account balance NULL: %v", err)
+	}
+	if _, err := db.Exec("UPDATE accounts SET balance = 12.5 WHERE id = ?", normalAccount); err != nil {
+		t.Fatalf("set normal account balance: %v", err)
+	}
+
+	sites, err := ListSites(db.DB)
+	if err != nil {
+		t.Fatalf("ListSites with mixed balances: %v", err)
+	}
+	if len(sites) != 1 {
+		t.Fatalf("expected 1 site, got %d", len(sites))
+	}
+
+	tb, ok := sites[0]["totalBalance"].(float64)
+	if !ok {
+		t.Fatalf("totalBalance type = %T, want float64", sites[0]["totalBalance"])
+	}
+	if tb != 12.5 {
+		t.Errorf("totalBalance = %v, want 12.5 (NULL neutralized, sibling counted)", tb)
+	}
+}


### PR DESCRIPTION
## 根因

从 TS 版迁移来的账号（或从未刷新过余额的账号）`balance` 列为 `NULL`，而 `store.Account.Balance` 等是**非空 `float64`**。凡把这些列扫进 `float64` 的路径，遇 `NULL` 即 `Scan error: converting NULL to float64`。

- `ListSites`：`SELECT site_id, balance, ... FROM accounts` → 单账号 NULL 让**整页 `/api/sites` 500**（已实测复现，R2-2 线移交的 P1）。
- `RefreshAllBalances`：`SELECT * FROM accounts WHERE status='active'` → 任一 NULL 账号让**整批余额刷新 job 失败**。

## 修复

1. `service/site_service.go` ListSites：`COALESCE(balance, 0)`——聚合口径把未知余额计 0，与 stats 端点既有 `COALESCE(balance, 0)` 约定一致；不改变快照/契约其他字段。
2. `service/balance/balance.go` RefreshAllBalances：`SELECT *` → `SELECT id`（循环只用到 `id`），绕开整行扫描。

## 测试（新增，均绿）

- `TestListSites_NullBalanceDoesNotError`：NULL 余额账号 → `/api/sites` 不报错，站点 `totalBalance = 0`。
- `TestListSites_NullBalanceWithSiblingSumsCorrectly`：NULL 账号 + 12.5 余额同站 → `totalBalance = 12.5`（COALESCE 只中和 NULL，不影响真实余额）。

## 移交（follow-up issue）

同模式扫描点还有 6 处（daily summary `SELECT a.*`、`routing_store` 两处 JOIN 扫描、`getAccountWithSiteBy`/`GetAccountByID`、login/rebind 与 oauth 的 `SELECT *`）——根治需把 `store.Account.Balance/BalanceUsed/Quota/ValueScore` 可空化（`*float64`/`sql.NullFloat64`），波及 `routing/weights.go` 等，超出本线最小侵入范围，已开 follow-up issue 追踪。

## 门禁

go build / vet + web(typecheck+lint+format:check+test) + go-race 全绿。
