### PR TITLE
fix(store): 可空余额/配额列指针化，根治 NULL 扫描崩溃

### DIFF
--- a/routing/algorithm_test.go
+++ b/routing/algorithm_test.go
@@ -132,17 +132,17 @@ func TestRoundRobinStrategy_Ordering(t *testing.T) {
 	candidates := []RouteChannelCandidate{
 		{
 			Channel: store.RouteChannel{ID: 1, RouteID: 1, SourceModel: &gpt4, Priority: 0, Weight: 10, Enabled: true, LastSelectedAt: &now3},
-			Account: store.Account{ID: 101, SiteID: 10, Status: "active", Balance: 100, OAuthProvider: &gpt4},
+			Account: store.Account{ID: 101, SiteID: 10, Status: "active", Balance: ptrFloat(100), OAuthProvider: &gpt4},
 			Site:    store.Site{ID: 10, Status: "active", GlobalWeight: 1.0},
 		},
 		{
 			Channel: store.RouteChannel{ID: 2, RouteID: 1, SourceModel: &gpt4, Priority: 0, Weight: 10, Enabled: true, LastSelectedAt: &now1},
-			Account: store.Account{ID: 102, SiteID: 20, Status: "active", Balance: 100, OAuthProvider: &gpt4},
+			Account: store.Account{ID: 102, SiteID: 20, Status: "active", Balance: ptrFloat(100), OAuthProvider: &gpt4},
 			Site:    store.Site{ID: 20, Status: "active", GlobalWeight: 1.0},
 		},
 		{
 			Channel: store.RouteChannel{ID: 3, RouteID: 1, SourceModel: &gpt4, Priority: 0, Weight: 10, Enabled: true, LastSelectedAt: &now2},
-			Account: store.Account{ID: 103, SiteID: 30, Status: "active", Balance: 100, OAuthProvider: &gpt4},
+			Account: store.Account{ID: 103, SiteID: 30, Status: "active", Balance: ptrFloat(100), OAuthProvider: &gpt4},
 			Site:    store.Site{ID: 30, Status: "active", GlobalWeight: 1.0},
 		},
 	}
@@ -814,7 +814,7 @@ func buildTestCandidate(channelID, siteID, accountID int64, weight int64, priori
 			SiteID:        siteID,
 			Status:        "active",
 			UnitCost:      unitCost,
-			Balance:       balance,
+			Balance:       ptrFloat(balance),
 			OAuthProvider: oauthProvider,
 		},
 		Site: store.Site{
@@ -848,27 +848,27 @@ func makeRoundRobinTestCandidates() []RouteChannelCandidate {
 	return []RouteChannelCandidate{
 		{
 			Channel: store.RouteChannel{ID: 1, RouteID: 1, SourceModel: &gpt4, Priority: 0, Weight: 10, Enabled: true, LastSelectedAt: &now5, LastUsedAt: &now5},
-			Account: store.Account{ID: 101, SiteID: 10, Status: "active", Balance: 100, OAuthProvider: &gpt4},
+			Account: store.Account{ID: 101, SiteID: 10, Status: "active", Balance: ptrFloat(100), OAuthProvider: &gpt4},
 			Site:    store.Site{ID: 10, Status: "active", GlobalWeight: 1.0},
 		},
 		{
 			Channel: store.RouteChannel{ID: 2, RouteID: 1, SourceModel: &gpt4, Priority: 0, Weight: 10, Enabled: true, LastSelectedAt: &now1, LastUsedAt: &now1},
-			Account: store.Account{ID: 102, SiteID: 20, Status: "active", Balance: 100, OAuthProvider: &gpt4},
+			Account: store.Account{ID: 102, SiteID: 20, Status: "active", Balance: ptrFloat(100), OAuthProvider: &gpt4},
 			Site:    store.Site{ID: 20, Status: "active", GlobalWeight: 1.0},
 		},
 		{
 			Channel: store.RouteChannel{ID: 3, RouteID: 1, SourceModel: &gpt4, Priority: 0, Weight: 10, Enabled: true, LastSelectedAt: &now3, LastUsedAt: &now3},
-			Account: store.Account{ID: 103, SiteID: 30, Status: "active", Balance: 100, OAuthProvider: &gpt4},
+			Account: store.Account{ID: 103, SiteID: 30, Status: "active", Balance: ptrFloat(100), OAuthProvider: &gpt4},
 			Site:    store.Site{ID: 30, Status: "active", GlobalWeight: 1.0},
 		},
 		{
 			Channel: store.RouteChannel{ID: 4, RouteID: 1, SourceModel: &gpt4, Priority: 0, Weight: 10, Enabled: true, LastSelectedAt: &now2, LastUsedAt: &now2},
-			Account: store.Account{ID: 104, SiteID: 40, Status: "active", Balance: 100, OAuthProvider: &gpt4},
+			Account: store.Account{ID: 104, SiteID: 40, Status: "active", Balance: ptrFloat(100), OAuthProvider: &gpt4},
 			Site:    store.Site{ID: 40, Status: "active", GlobalWeight: 1.0},
 		},
 		{
 			Channel: store.RouteChannel{ID: 5, RouteID: 1, SourceModel: &gpt4, Priority: 0, Weight: 10, Enabled: true, LastSelectedAt: &now4, LastUsedAt: &now4},
-			Account: store.Account{ID: 105, SiteID: 50, Status: "active", Balance: 100, OAuthProvider: &gpt4},
+			Account: store.Account{ID: 105, SiteID: 50, Status: "active", Balance: ptrFloat(100), OAuthProvider: &gpt4},
 			Site:    store.Site{ID: 50, Status: "active", GlobalWeight: 1.0},
 		},
 	}

--- a/routing/failure_isolation_test.go
+++ b/routing/failure_isolation_test.go
@@ -329,9 +329,9 @@ func isolationAccount(id, siteID int64) store.Account {
 		AccessToken: token,
 		APIToken:    &token,
 		Status:      "active",
-		Balance:     100,
-		Quota:       1000,
-		ValueScore:  1,
+		Balance:     ptrFloat(100),
+		Quota:       ptrFloat(1000),
+		ValueScore:  ptrFloat(1),
 	}
 }
 

--- a/routing/half_open_breaker_test.go
+++ b/routing/half_open_breaker_test.go
@@ -296,7 +296,7 @@ func TestHalfOpenProbe_FilterBlocksProbingCandidates(t *testing.T) {
 				ID: channelID, RouteID: 1, AccountID: accountID,
 				SourceModel: &model, Priority: 0, Weight: 10, Enabled: true,
 			},
-			Account: store.Account{ID: accountID, SiteID: candidateSiteID, Status: "active", APIToken: &token, Balance: 100},
+			Account: store.Account{ID: accountID, SiteID: candidateSiteID, Status: "active", APIToken: &token, Balance: ptrFloat(100)},
 			Site:    store.Site{ID: candidateSiteID, Status: "active"},
 		}
 	}

--- a/routing/selector_preferred_test.go
+++ b/routing/selector_preferred_test.go
@@ -146,7 +146,7 @@ func preferredEligibleJoined(channelID, siteID, accountID int64, model string) s
 			SiteID:   siteID,
 			Status:   "active",
 			APIToken: &token,
-			Balance:  100,
+			Balance:  ptrFloat(100),
 		},
 		Site: store.Site{
 			ID:     siteID,

--- a/routing/weights.go
+++ b/routing/weights.go
@@ -139,7 +139,7 @@ func CalculateWeightedSelection(
 	minVS := math.Inf(1)
 	for i, c := range candidates {
 		unitCost := effectiveCosts[i].UnitCost
-		balance := c.Account.Balance
+		balance := c.Account.BalanceOrZero()
 		totalUsed := float64(c.Channel.SuccessCount + c.Channel.FailCount)
 		recentUsage := math.Max(totalUsed, 1)
 		valueScore := routingWeights.CostWeight*(1/unitCost) + routingWeights.BalanceWeight*balance + routingWeights.UsageWeight*(1/recentUsage)

--- a/routing/weights_test.go
+++ b/routing/weights_test.go
@@ -38,7 +38,7 @@ func makeCandidate(channelID, siteID, accountID int64, weight int64, priority in
 			SiteID:        siteID,
 			Status:        "active",
 			UnitCost:      unitCost,
-			Balance:       balance,
+			Balance:       ptrFloat(balance),
 			OAuthProvider: oauthProvider,
 		},
 		Site: store.Site{

--- a/service/account_null_balance_test.go
+++ b/service/account_null_balance_test.go
@@ -1,0 +1,67 @@
+package service
+
+import "testing"
+
+// TestGetAccountByID_NullBalanceDoesNotError guards the NULL-scan crash on the
+// single-account load path: an account whose balance/balance_used/quota/
+// value_score columns are NULL (migrated from TS, or never refreshed) must scan
+// into nil pointers, not fail with "converting NULL to float64".
+func TestGetAccountByID_NullBalanceDoesNotError(t *testing.T) {
+	db := openTestDB(t)
+
+	siteID := createTestSite(t, db, "Null Balance Site", "https://api.example.com", "openai")
+	accountID := createTestAccount(t, db, siteID, strPtr("null-balance-user"), "sk-test")
+
+	if _, err := db.Exec(`
+		UPDATE accounts SET balance = NULL, balance_used = NULL, quota = NULL, value_score = NULL
+		WHERE id = ?`, accountID); err != nil {
+		t.Fatalf("null the numeric columns: %v", err)
+	}
+
+	account, err := GetAccountByID(db.DB, accountID)
+	if err != nil {
+		t.Fatalf("GetAccountByID with NULL numeric columns: %v", err)
+	}
+	if account.Balance != nil {
+		t.Errorf("Balance = %v, want nil (NULL preserved)", *account.Balance)
+	}
+	if account.BalanceUsed != nil {
+		t.Errorf("BalanceUsed = %v, want nil", *account.BalanceUsed)
+	}
+	if account.Quota != nil {
+		t.Errorf("Quota = %v, want nil", *account.Quota)
+	}
+	if account.ValueScore != nil {
+		t.Errorf("ValueScore = %v, want nil", *account.ValueScore)
+	}
+	// OrZero helpers coerce the unknown values to 0 for numeric callers.
+	if account.BalanceOrZero() != 0 || account.QuotaOrZero() != 0 || account.ValueScoreOrZero() != 0 {
+		t.Errorf("OrZero helpers should return 0 for nil fields")
+	}
+}
+
+// TestGetAccountWithSiteByID_NullBalanceDoesNotError covers the balance-refresh
+// load path (the JOIN + inline-struct scan) with NULL numeric columns.
+func TestGetAccountWithSiteByID_NullBalanceDoesNotError(t *testing.T) {
+	db := openTestDB(t)
+
+	siteID := createTestSite(t, db, "Null Balance Site", "https://api.example.com", "openai")
+	accountID := createTestAccount(t, db, siteID, strPtr("null-balance-user"), "sk-test")
+
+	if _, err := db.Exec(`
+		UPDATE accounts SET balance = NULL, balance_used = NULL, quota = NULL, value_score = NULL
+		WHERE id = ?`, accountID); err != nil {
+		t.Fatalf("null the numeric columns: %v", err)
+	}
+
+	aws, err := GetAccountWithSiteByID(db.DB, accountID)
+	if err != nil {
+		t.Fatalf("GetAccountWithSiteByID with NULL numeric columns: %v", err)
+	}
+	if aws.Account.Balance != nil {
+		t.Errorf("Balance = %v, want nil", *aws.Account.Balance)
+	}
+	if aws.Account.ValueScore != nil {
+		t.Errorf("ValueScore = %v, want nil", *aws.Account.ValueScore)
+	}
+}

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -467,11 +467,11 @@ func getAccountWithSiteBy(q accountQueryExecer, id int64, forUpdate bool) (*Acco
 			Username           *string  `db:"username"`
 			AccessToken        string   `db:"access_token"`
 			APIToken           *string  `db:"api_token"`
-			Balance            float64  `db:"balance"`
-			BalanceUsed        float64  `db:"balance_used"`
-			Quota              float64  `db:"quota"`
+			Balance            *float64 `db:"balance"`
+			BalanceUsed        *float64 `db:"balance_used"`
+			Quota              *float64 `db:"quota"`
 			UnitCost           *float64 `db:"unit_cost"`
-			ValueScore         float64  `db:"value_score"`
+			ValueScore         *float64 `db:"value_score"`
 			Status             string   `db:"status"`
 			IsPinned           bool     `db:"is_pinned"`
 			SortOrder          int64    `db:"sort_order"`

--- a/service/balance/balance.go
+++ b/service/balance/balance.go
@@ -398,9 +398,9 @@ func RefreshBalance(cfg *config.Config, db *sqlx.DB, accountID int64) (*BalanceR
 			State: service.HealthDisabled, Reason: "账号已禁用", Source: service.HealthSourceBalance,
 		})
 		return &BalanceResult{
-			Balance: account.Balance,
-			Used:    account.BalanceUsed,
-			Quota:   account.Quota,
+			Balance: account.BalanceOrZero(),
+			Used:    account.BalanceUsedOrZero(),
+			Quota:   account.QuotaOrZero(),
 			Skipped: true,
 			Reason:  "account_disabled",
 		}, nil
@@ -411,9 +411,9 @@ func RefreshBalance(cfg *config.Config, db *sqlx.DB, accountID int64) (*BalanceR
 			State: service.HealthDisabled, Reason: "站点已禁用", Source: service.HealthSourceBalance,
 		})
 		return &BalanceResult{
-			Balance: account.Balance,
-			Used:    account.BalanceUsed,
-			Quota:   account.Quota,
+			Balance: account.BalanceOrZero(),
+			Used:    account.BalanceUsedOrZero(),
+			Quota:   account.QuotaOrZero(),
 			Skipped: true,
 			Reason:  "site_disabled",
 		}, nil
@@ -428,9 +428,9 @@ func RefreshBalance(cfg *config.Config, db *sqlx.DB, accountID int64) (*BalanceR
 	// API key connection check — skip balance refresh for apikey accounts
 	if service.IsAPIKeyConnection(account) {
 		return &BalanceResult{
-			Balance: account.Balance,
-			Used:    account.BalanceUsed,
-			Quota:   account.Quota,
+			Balance: account.BalanceOrZero(),
+			Used:    account.BalanceUsedOrZero(),
+			Quota:   account.QuotaOrZero(),
 			Skipped: true,
 			Reason:  "proxy_only",
 		}, nil

--- a/service/checkin/checkin.go
+++ b/service/checkin/checkin.go
@@ -510,8 +510,10 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 			}
 		}
 		if directCheckinSuccess && parsedReward <= 0 {
-			if refreshedBalanceInfo != nil {
-				inferredReward := InferRewardFromBalanceDelta(account.Balance, refreshedBalanceInfo.Balance)
+			// Only infer a reward delta when the pre-checkin balance is known;
+			// a NULL (never-refreshed) balance gives no baseline to diff against.
+			if refreshedBalanceInfo != nil && account.Balance != nil {
+				inferredReward := InferRewardFromBalanceDelta(*account.Balance, refreshedBalanceInfo.Balance)
 				if inferredReward > 0 {
 					parsedReward = inferredReward
 					logReward = fmt.Sprintf("%v", parsedReward)

--- a/service/daily/daily_summary.go
+++ b/service/daily/daily_summary.go
@@ -70,7 +70,10 @@ func CollectDailySummaryMetrics(db *sqlx.DB, now time.Time) (*DailySummaryMetric
 		if a.Status == "active" {
 			activeAccounts++
 		}
-		if a.Balance < 1 {
+		// A NULL balance means "never refreshed", which is unknown — not
+		// "low". Only count accounts with a known balance below the floor so
+		// migrated/never-refreshed rows don't produce false low-balance flags.
+		if a.Balance != nil && *a.Balance < 1 {
 			lowBalanceAccounts++
 		}
 	}

--- a/store/schema.go
+++ b/store/schema.go
@@ -78,11 +78,16 @@ type Account struct {
 	Username           *string  `db:"username" json:"username"`
 	AccessToken        string   `db:"access_token" json:"accessToken"`
 	APIToken           *string  `db:"api_token" json:"apiToken"`
-	Balance            float64  `db:"balance" json:"balance"`
-	BalanceUsed        float64  `db:"balance_used" json:"balanceUsed"`
-	Quota              float64  `db:"quota" json:"quota"`
+	// Balance/BalanceUsed/Quota/ValueScore are nullable in the accounts table
+	// (DEFAULT 0 without NOT NULL): rows migrated from the TS version, or never
+	// refreshed, carry NULL. Keep them as pointers so a NULL column scans to nil
+	// (JSON null) instead of failing with "converting NULL to float64". Readers
+	// that need a numeric default use the OrZero helpers below.
+	Balance            *float64 `db:"balance" json:"balance"`
+	BalanceUsed        *float64 `db:"balance_used" json:"balanceUsed"`
+	Quota              *float64 `db:"quota" json:"quota"`
 	UnitCost           *float64 `db:"unit_cost" json:"unitCost"`
-	ValueScore         float64  `db:"value_score" json:"valueScore"`
+	ValueScore         *float64 `db:"value_score" json:"valueScore"`
 	Status             string   `db:"status" json:"status"`
 	IsPinned           bool     `db:"is_pinned" json:"isPinned"`
 	SortOrder          int64    `db:"sort_order" json:"sortOrder"`
@@ -106,6 +111,38 @@ type Account struct {
 	// accessToken/apiToken (masked in list views), remark is returned in
 	// plaintext on admin list/search responses.
 	Remark *string `db:"remark" json:"remark"`
+}
+
+// OrZero helpers coerce the nullable numeric account columns for callers that
+// need a numeric default (routing weights, balance aggregation, refresh
+// results). Callers that must preserve the unknown/nil semantics (e.g. the
+// daily low-balance check, JSON display) should read the pointer directly.
+func (a Account) BalanceOrZero() float64 {
+	if a.Balance == nil {
+		return 0
+	}
+	return *a.Balance
+}
+
+func (a Account) BalanceUsedOrZero() float64 {
+	if a.BalanceUsed == nil {
+		return 0
+	}
+	return *a.BalanceUsed
+}
+
+func (a Account) QuotaOrZero() float64 {
+	if a.Quota == nil {
+		return 0
+	}
+	return *a.Quota
+}
+
+func (a Account) ValueScoreOrZero() float64 {
+	if a.ValueScore == nil {
+		return 0
+	}
+	return *a.ValueScore
 }
 
 // ---- Table 5: account_tokens ----


### PR DESCRIPTION
## 根因

`accounts.balance / balance_used / quota / value_score` 四列 schema 可空（`DEFAULT 0` 无 NOT NULL），但 `store.Account` 对应字段是**非空 `float64`**。TS 迁移来的账号、或从未刷新过的账号带 `NULL`，任何 `SELECT *`（或显式列扫描）到这些字段即 `Scan error: converting NULL to float64`，波及：

- 余额刷新自愈（`GetAccountByID` / `getAccountWithSiteBy`）
- 每日汇总 job（`CollectDailySummaryMetrics` `SELECT a.*`）
- 路由重建/装载（`scanRouteChannelJoin` / `scanRouteUnitMemberJoin` JOIN 扫描，**代理转发核心路径**）
- OAuth 配额/刷新、login/rebind（10+ 处 `SELECT * FROM accounts`）

此前 v0.16.7 已修 `ListSites`（COALESCE）与 `RefreshAllBalances`（SELECT id），本 PR 是 #927 的根治。

## 修复

- `store.Account.Balance/BalanceUsed/Quota/ValueScore` → `*float64`（对齐既有 `UnitCost` 模式）：NULL 扫描为 `nil`、JSON 序列化 `null`，与 `/api/accounts` 列表既有 null 行为一致。
- 新增 `BalanceOrZero()/BalanceUsedOrZero()/QuotaOrZero()/ValueScoreOrZero()` 助手，供数值调用方（路由权重、刷新结果）取 0 默认值。
- 两处 null 敏感读点按诚实语义处理：`daily_summary` 低余额判定只统计**已知**余额 <1（未知余额不误报低余额）；`checkin` 奖励差值推断仅在有已知基线时计算。

## 测试

- 新增 `TestGetAccountByID_NullBalanceDoesNotError` / `TestGetAccountWithSiteByID_NullBalanceDoesNotError`（红→绿：修复前 `converting NULL to float64`）。
- 5 个 routing 测试文件字面量 `Balance: 100` 等改为 `ptrFloat(...)`。
- 本地 `go build ./... && go vet ./... && go test ./... -count=1` 全绿。

## 说明

- 纯 Go 改动，零前端影响；CI 会跑完整 17 项含 race。
- 关闭 #927。