### PR TITLE
fix(web): audit residual P1 closeout — attention SPA links + load-error retry tests

### DIFF
--- a/web/src/features/accounts/__tests__/accounts-page-error-retry.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-page-error-retry.test.tsx
@@ -1,0 +1,124 @@
+// Regression tests for the accounts page load-error state: the shared
+// QueryErrorBanner + Retry button, wired to refetch, in the same shape the
+// sites page pins (audit gap-7: accounts/channels load errors had no Retry).
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { AccountsPage } from '../components/accounts-page'
+
+const testState = vi.hoisted(() => ({
+  search: { page: 1, pageSize: 20 } as Record<string, unknown>,
+  navigate: vi.fn(),
+  accountsQuery: {
+    data: undefined as { accounts: unknown[]; sites: unknown[] } | undefined,
+    error: null as Error | null,
+    isLoading: false,
+    isFetching: false,
+    refetch: vi.fn().mockResolvedValue({}),
+  },
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => testState.navigate,
+  useSearch: () => testState.search,
+}))
+
+vi.mock('@/components/data-table', () => ({
+  DataTableBulkActions: () => null,
+  DataTablePage: () => null,
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    ensurePageInRange: vi.fn(),
+  }),
+  useDataTable: () => ({
+    table: {
+      getFilteredSelectedRowModel: () => ({ rows: [] }),
+      resetRowSelection: vi.fn(),
+    },
+  }),
+}))
+
+vi.mock('@/features/import', () => ({
+  ImportWizardDialog: () => null,
+}))
+
+vi.mock('../api', () => ({
+  useAccounts: () => testState.accountsQuery,
+  useBatchUpdateAccounts: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteAccount: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRefreshAccount: () => ({ mutate: vi.fn(), isPending: false }),
+  useToggleAccountCheckin: () => ({ mutate: vi.fn(), isPending: false }),
+  useToggleAccountPin: () => ({ mutate: vi.fn(), isPending: false }),
+  useToggleAccountStatus: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+vi.mock('../components/account-detail-sheet', () => ({
+  AccountDetailSheet: () => null,
+}))
+
+vi.mock('../components/account-form-dialog', () => ({
+  AccountFormDialog: () => null,
+}))
+
+vi.mock('../components/accounts-columns', () => ({
+  useAccountsColumns: () => [],
+}))
+
+beforeEach(() => {
+  testState.navigate.mockReset()
+  testState.accountsQuery.refetch.mockReset()
+  testState.accountsQuery.refetch.mockResolvedValue({})
+  testState.accountsQuery.data = {
+    accounts: [],
+    sites: [{ id: 1, name: 'Primary site' }],
+  }
+  testState.accountsQuery.error = null
+  testState.accountsQuery.isLoading = false
+  testState.accountsQuery.isFetching = false
+})
+
+afterEach(() => cleanup())
+
+describe('AccountsPage load error state', () => {
+  it('renders the error banner with a Retry button when the snapshot fails', () => {
+    testState.accountsQuery.error = new Error('boom')
+
+    render(<AccountsPage />)
+
+    expect(
+      screen.getByText(/Failed to load accounts: boom/)
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+  })
+
+  it('renders no error banner or Retry button when the snapshot loads', () => {
+    testState.accountsQuery.error = null
+
+    render(<AccountsPage />)
+
+    expect(
+      screen.queryByText(/Failed to load accounts/)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Retry' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('calls refetch when the Retry button is clicked', () => {
+    testState.accountsQuery.error = new Error('boom')
+
+    render(<AccountsPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(testState.accountsQuery.refetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/features/channels/__tests__/channels-page-error-retry.test.tsx
+++ b/web/src/features/channels/__tests__/channels-page-error-retry.test.tsx
@@ -1,0 +1,112 @@
+// Regression tests for the channels page load-error state: the shared
+// QueryErrorBanner + Retry button wiring (audit gap-7: the accounts/channels
+// load errors had no Retry — sites shipped first, the two list pages now
+// share the same pattern).
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { ChannelsPage } from '../components/channels-page'
+import type { ChannelRow } from '../types'
+
+const testState = vi.hoisted(() => ({
+  search: {} as Record<string, unknown>,
+  channels: [] as ChannelRow[],
+  navigate: vi.fn(),
+  refetch: vi.fn().mockResolvedValue({}),
+  error: null as Error | null,
+  isLoading: false,
+  isFetching: false,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => testState.navigate,
+  useSearch: () => testState.search,
+}))
+
+vi.mock('@/components/data-table', () => ({
+  DataTablePage: () => null,
+  encodeSorting: () => '',
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    sorting: [],
+    onSortingChange: vi.fn(),
+    ensurePageInRange: vi.fn(),
+  }),
+  useDataTable: () => ({ table: {} }),
+}))
+
+vi.mock('../api', () => ({
+  useChannels: () => ({
+    data: testState.channels,
+    isLoading: testState.isLoading,
+    isFetching: testState.isFetching,
+    error: testState.error,
+    refetch: testState.refetch,
+  }),
+}))
+
+vi.mock('../components/channel-detail-sheet', () => ({
+  ChannelDetailSheet: () => null,
+}))
+
+vi.mock('../components/channels-columns', () => ({
+  useChannelsColumns: () => [],
+  CHANNELS_STATUS_FILTER_OPTIONS: [],
+}))
+
+beforeEach(() => {
+  testState.search = {}
+  testState.channels = []
+  testState.navigate.mockReset()
+  testState.refetch.mockReset()
+  testState.refetch.mockResolvedValue({})
+  testState.error = null
+  testState.isLoading = false
+  testState.isFetching = false
+})
+
+afterEach(() => cleanup())
+
+describe('ChannelsPage load error state', () => {
+  it('renders the error banner with a Retry button when the list fails', () => {
+    testState.error = new Error('boom')
+
+    render(<ChannelsPage />)
+
+    expect(
+      screen.getByText(/Failed to load channels: boom/)
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+  })
+
+  it('renders no error banner or Retry button when the list loads', () => {
+    testState.error = null
+
+    render(<ChannelsPage />)
+
+    expect(
+      screen.queryByText(/Failed to load channels/)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Retry' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('calls refetch when the Retry button is clicked', () => {
+    testState.error = new Error('boom')
+
+    render(<ChannelsPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(testState.refetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/features/dashboard/sections/availability/__tests__/attention-target.test.ts
+++ b/web/src/features/dashboard/sections/availability/__tests__/attention-target.test.ts
@@ -1,0 +1,53 @@
+// Unit tests for the attention target parser (the backend
+// GET /api/stats/attention target contract -> typed router location).
+import { describe, expect, it } from 'vitest'
+
+import { resolveAttentionTarget } from '../attention-target'
+
+describe('resolveAttentionTarget', () => {
+  it('maps an expired/low-balance account target to the accounts location', () => {
+    expect(resolveAttentionTarget('/accounts?accountId=42')).toEqual({
+      to: '/accounts',
+      search: { accountId: 42 },
+    })
+  })
+
+  it('maps a disabled-site target to the sites edit location', () => {
+    expect(resolveAttentionTarget('/sites?edit=7')).toEqual({
+      to: '/sites',
+      search: { edit: 7 },
+    })
+  })
+
+  it('maps an event target to the settings section path', () => {
+    expect(
+      resolveAttentionTarget('/settings/system-info/program-logs')
+    ).toEqual({
+      to: '/settings/$subarea/$section',
+      params: { subarea: 'system-info', section: 'program-logs' },
+    })
+  })
+
+  it('rejects malformed targets instead of emitting a dead link', () => {
+    const malformed = [
+      '',
+      '/accounts',
+      '/accounts?accountId=0',
+      '/accounts?accountId=abc',
+      '/accounts?accountId=1.5',
+      '/sites?edit=',
+      '/sites?edit=-3',
+      '/sites',
+      '/settings/system-info',
+      '/settings/system-info/program-logs/',
+      '/unknown/page',
+      'https://example.com/accounts?accountId=1',
+    ]
+    for (const target of malformed) {
+      expect(
+        resolveAttentionTarget(target),
+        `expected null for target ${JSON.stringify(target)}`
+      ).toBeNull()
+    }
+  })
+})

--- a/web/src/features/dashboard/sections/availability/__tests__/availability-attention-links.test.tsx
+++ b/web/src/features/dashboard/sections/availability/__tests__/availability-attention-links.test.tsx
@@ -1,0 +1,191 @@
+// Behavior test for the attention panel's deep-link rendering.
+//
+// Closes the availability attention dead-end: dashboard attention items used
+// to render plain `<a href>` anchors to backend target strings (a full-page
+// reload, ignoring the SPA router). Items now parse their target into a
+// typed router location and render a router `<Link>` — the accounts /
+// sites targets land on the real entity (the one-shot `accountId` / `edit`
+// deep links), event targets land on the settings program-logs section, and
+// unrecognized targets render as plain text instead of a dead link.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+import { useRealtimeOps } from '@/features/dashboard/hooks/use-realtime-ops'
+import type { RealtimeOpsSample } from '@/features/dashboard/types'
+import { api } from '@/lib/api'
+
+import { AvailabilitySection } from '../availability-section'
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getAttention: vi.fn(),
+  },
+}))
+
+vi.mock('@/features/dashboard/hooks/use-realtime-ops', () => ({
+  useRealtimeOps: vi.fn(),
+}))
+
+// The attention panel renders outside a mounted router in this unit test, so
+// render `Link` as a plain anchor that serializes `to` + `search` + `params`
+// (mirrors the batch-results test) — enough to assert the deep-link targets.
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    to,
+    search,
+    params,
+  }: {
+    children?: ReactNode
+    to: string
+    search?: Record<string, number | string | undefined>
+    params?: Record<string, string | undefined>
+  }) => {
+    const query = search
+      ? new URLSearchParams(
+          Object.entries(search)
+            .filter(([, value]) => value !== undefined)
+            .map(([key, value]) => [key, String(value)])
+        ).toString()
+      : ''
+    const path = params
+      ? Object.entries(params).reduce(
+          (pathname, [key, value]) =>
+            pathname.replace(`$${key}`, String(value)),
+          to
+        )
+      : to
+    return <a href={query ? `${path}?${query}` : path}>{children}</a>
+  },
+}))
+
+const mockGetAttention = vi.mocked(api.getAttention)
+const mockUseRealtimeOps = vi.mocked(useRealtimeOps)
+
+const IDLE_SAMPLE: RealtimeOpsSample = {
+  qps: 0,
+  successRate: 0,
+  lifetime: 0,
+  spark: [],
+  connected: false,
+  gaveUp: false,
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0, refetchOnWindowFocus: false },
+    },
+  })
+}
+
+function renderWithClient(ui: ReactNode) {
+  const queryClient = createQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  mockGetAttention.mockReset()
+  mockUseRealtimeOps.mockReset()
+  mockUseRealtimeOps.mockReturnValue({
+    sample: IDLE_SAMPLE,
+    lastFrameAt: null,
+    reconnect: vi.fn(),
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  cleanup()
+})
+
+describe('AvailabilitySection attention deep links', () => {
+  it('links an expired-account item to /accounts?accountId=N', async () => {
+    mockGetAttention.mockResolvedValue({
+      items: [
+        {
+          severity: 'critical',
+          category: 'expired_account',
+          label: 'Account expired',
+          target: '/accounts?accountId=5',
+          createdAt: '',
+        },
+      ],
+      total: 1,
+    })
+
+    renderWithClient(<AvailabilitySection />)
+
+    const link = await screen.findByRole('link', { name: 'Account expired' })
+    expect(link).toHaveAttribute('href', '/accounts?accountId=5')
+  })
+
+  it('links a disabled-site item to /sites?edit=N', async () => {
+    mockGetAttention.mockResolvedValue({
+      items: [
+        {
+          severity: 'warning',
+          category: 'disabled_site',
+          label: 'Site disabled',
+          target: '/sites?edit=3',
+          createdAt: '',
+        },
+      ],
+      total: 1,
+    })
+
+    renderWithClient(<AvailabilitySection />)
+
+    const link = await screen.findByRole('link', { name: 'Site disabled' })
+    expect(link).toHaveAttribute('href', '/sites?edit=3')
+  })
+
+  it('links an event item to the settings program-logs section', async () => {
+    mockGetAttention.mockResolvedValue({
+      items: [
+        {
+          severity: 'warning',
+          category: 'event',
+          label: 'Upstream rate limited',
+          target: '/settings/system-info/program-logs',
+          createdAt: '',
+        },
+      ],
+      total: 1,
+    })
+
+    renderWithClient(<AvailabilitySection />)
+
+    const link = await screen.findByRole('link', {
+      name: 'Upstream rate limited',
+    })
+    expect(link).toHaveAttribute('href', '/settings/system-info/program-logs')
+  })
+
+  it('renders plain text (no dead link) for an unrecognized target', async () => {
+    mockGetAttention.mockResolvedValue({
+      items: [
+        {
+          severity: 'info',
+          category: 'event',
+          label: 'Legacy payload',
+          target: '/legacy/deadend',
+          createdAt: '',
+        },
+      ],
+      total: 1,
+    })
+
+    renderWithClient(<AvailabilitySection />)
+
+    expect(await screen.findByText('Legacy payload')).toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/features/dashboard/sections/availability/attention-target.ts
+++ b/web/src/features/dashboard/sections/availability/attention-target.ts
@@ -1,0 +1,66 @@
+// metapi-go/features/dashboard/sections/availability — attention target parsing.
+//
+// The attention panel renders the backend `target` strings from
+// GET /api/stats/attention as SPA links. The handler contract
+// (handler/admin/stats_balance.go, attentionItem.Target) emits three shapes:
+//
+//   /accounts?accountId=N           — expired / low-balance accounts
+//   /sites?edit=N                   — disabled sites
+//   /settings/<subarea>/<section>   — warning/error events (program-logs)
+//
+// This module parses a raw target into the typed location the target page
+// exposes (accounts consumes `accountId`, sites consumes `edit` — both
+// one-shot deep links that open the referenced entity, then strip the param),
+// so the panel can render a router `<Link>` instead of a full-page anchor.
+// Unparseable targets resolve to null: the panel falls back to plain text
+// rather than emitting a dead link.
+
+export type AttentionTargetLocation =
+  | { to: '/accounts'; search: { accountId: number } }
+  | { to: '/sites'; search: { edit: number } }
+  | {
+      to: '/settings/$subarea/$section'
+      params: { subarea: string; section: string }
+    }
+
+/** Positive-int query param (mirrors the `z.coerce.number().int().positive()` route param contract). */
+function parsePositiveInt(raw: string | null): number | undefined {
+  if (raw === null) return undefined
+  const value = Number(raw)
+  return Number.isInteger(value) && value > 0 ? value : undefined
+}
+
+/** Parse a backend attention target into a typed router location (null when unrecognized). */
+export function resolveAttentionTarget(
+  target: string
+): AttentionTargetLocation | null {
+  if (!target) return null
+  const queryStart = target.indexOf('?')
+  const pathname = queryStart === -1 ? target : target.slice(0, queryStart)
+  const params = new URLSearchParams(
+    queryStart === -1 ? '' : target.slice(queryStart + 1)
+  )
+
+  switch (pathname) {
+    case '/accounts': {
+      const accountId = parsePositiveInt(params.get('accountId'))
+      return accountId !== undefined
+        ? { to: '/accounts', search: { accountId } }
+        : null
+    }
+    case '/sites': {
+      const edit = parsePositiveInt(params.get('edit'))
+      return edit !== undefined ? { to: '/sites', search: { edit } } : null
+    }
+    default: {
+      const match = /^\/settings\/([^/]+)\/([^/]+)$/.exec(pathname)
+      if (match) {
+        return {
+          to: '/settings/$subarea/$section',
+          params: { subarea: match[1], section: match[2] },
+        }
+      }
+      return null
+    }
+  }
+}

--- a/web/src/features/dashboard/sections/availability/availability-section.tsx
+++ b/web/src/features/dashboard/sections/availability/availability-section.tsx
@@ -7,7 +7,9 @@
 // operator eyes — expired accounts, low balances, disabled sites, events).
 
 import { useQuery } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
 import { Inbox, Radio, ShieldCheck, TriangleAlert } from 'lucide-react'
+import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Badge } from '@/components/ui/badge'
@@ -38,6 +40,10 @@ import { cn } from '@/lib/utils'
 
 import { useRealtimeOps } from '../../hooks/use-realtime-ops'
 import type { RealtimeOpsSamplePoint } from '../../types'
+import {
+  resolveAttentionTarget,
+  type AttentionTargetLocation,
+} from './attention-target'
 
 const SPARK_BARS = 60
 
@@ -283,6 +289,55 @@ function RealtimeOpsPanel() {
   )
 }
 
+/**
+ * Router-aware rendering of a parsed attention target. The backend target
+ * contract is small and pinned by handler tests, so a switch over the parsed
+ * discriminant keeps `to` / `search` / `params` fully typed (a union `Link`
+ * props object would need a cast). A parsed target is always SPA-navigable:
+ * the settings route redirects unknown sections to the subarea default, and
+ * the accounts/sites one-shot params resolve against the loaded snapshot.
+ */
+function AttentionTargetLink({
+  location,
+  children,
+}: {
+  location: AttentionTargetLocation
+  children: ReactNode
+}) {
+  switch (location.to) {
+    case '/accounts':
+      return (
+        <Link
+          to='/accounts'
+          search={{ accountId: location.search.accountId }}
+          className='block truncate text-sm hover:underline'
+        >
+          {children}
+        </Link>
+      )
+    case '/sites':
+      return (
+        <Link
+          to='/sites'
+          search={{ edit: location.search.edit }}
+          className='block truncate text-sm hover:underline'
+        >
+          {children}
+        </Link>
+      )
+    case '/settings/$subarea/$section':
+      return (
+        <Link
+          to='/settings/$subarea/$section'
+          params={location.params}
+          className='block truncate text-sm hover:underline'
+        >
+          {children}
+        </Link>
+      )
+  }
+}
+
 function AttentionPanel() {
   const { t, i18n } = useTranslation()
   const locale = toBcp47(i18n.language || 'en')
@@ -344,6 +399,11 @@ function AttentionPanel() {
                 `dashboard.availability.monitors.severity.${item.severity}`
               )
               const relativeTime = formatRelativeTime(item.createdAt, locale)
+              // Unrecognized targets (backend drift, malformed url) render as
+              // plain text — never a dead anchor.
+              const targetLocation = item.target
+                ? resolveAttentionTarget(item.target)
+                : null
               return (
                 <li
                   // eslint-disable-next-line react/no-array-index-key
@@ -358,13 +418,10 @@ function AttentionPanel() {
                     {label}
                   </Badge>
                   <div className='min-w-0 flex-1'>
-                    {item.target ? (
-                      <a
-                        href={item.target}
-                        className='block truncate text-sm hover:underline'
-                      >
+                    {targetLocation ? (
+                      <AttentionTargetLink location={targetLocation}>
                         {item.label}
-                      </a>
+                      </AttentionTargetLink>
                     ) : (
                       <span className='block truncate text-sm'>
                         {item.label}


### PR DESCRIPTION
## 概要

审计残留 P1 五项收口。核查结论：5 项中 4 项已被前波收口（代码现状与审计文档描述不一致），本次只补真实缺口。

## 变更

- fix(web)：availability attention 项剩余 `<a href>` 硬刷新改为 TanStack Router `<Link>`（新增 `attention-target.ts` 解析器，非法 target 降级纯文本，零新 i18n key）
- test(web)：accounts/channels load-error Retry 页面级测试（各 3 例，镜像 sites error-state 模式）

## 未改项（已收口证据）

- channel-detail-sheet footer/清冷却：已有 SheetFooter + useClearRouteCooldown（9 例测试）
- accounts 行级 toast：onTogglePin/onToggleCheckin 均带 onSuccess toast（3 例测试）
- model-tester 批量行：已深链到 /channels 详情 sheet（href 断言）
- availability attention 后端 target：#890 已修真实路由

## 测试

tsgo typecheck 0 错 · oxlint 0 errors · oxfmt format:check ✓ · 聚焦 vitest 5 文件 16 通过 · 回归 9 文件 36 通过 · i18n parity 4 通过。
