### PR TITLE
feat(probe): productize runtime probes (#558) — run history, SSE report panel, scheduler trigger, batch model probe

### DIFF
--- a/handler/admin/scheduler_status.go
+++ b/handler/admin/scheduler_status.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/scheduler"
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
-	"github.com/deliciousbuding/metapi-go/scheduler"
 )
 
 // RegisterSchedulerStatusRoutes exposes a unified run-history view of the
@@ -40,6 +40,22 @@ type schedulerRunStatus struct {
 	Runs24h    int64  `json:"runs24h"`
 	Success24h int64  `json:"success24h"`
 	Note       string `json:"note,omitempty"`
+	// RecentRuns is populated only by model-probe (in-memory ring buffer).
+	// Other jobs keep it empty — their history surfaces via per-job pages.
+	RecentRuns []probeRunSummaryJSON `json:"recentRuns,omitempty"`
+}
+
+// probeRunSummaryJSON is the wire form of one scheduler.ProbeRunSummary pass.
+type probeRunSummaryJSON struct {
+	StartedAt          string `json:"startedAt,omitempty"`
+	CompletedAt        string `json:"completedAt,omitempty"`
+	AccountsConsidered int    `json:"accountsConsidered"`
+	AccountsProbed     int    `json:"accountsProbed"`
+	TargetsScanned     int    `json:"targetsScanned"`
+	Success            int    `json:"success"`
+	Failed             int    `json:"failed"`
+	Inconclusive       int    `json:"inconclusive"`
+	Skipped            int    `json:"skipped"`
 }
 
 func (h *schedulerStatusHandler) status(w http.ResponseWriter, r *http.Request) {
@@ -53,7 +69,7 @@ func (h *schedulerStatusHandler) status(w http.ResponseWriter, r *http.Request) 
 		h.eventsStatus("usage-aggregation", "用量聚合"),
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"items": items,
+		"items":       items,
 		"generatedAt": time.Now().UTC().Format(time.RFC3339),
 	})
 }
@@ -123,12 +139,28 @@ func (h *schedulerStatusHandler) modelProbeStatus() schedulerRunStatus {
 			status = "failed"
 		}
 	}
+	runs := probe.RecentRunSummaries()
+	recent := make([]probeRunSummaryJSON, 0, len(runs))
+	for _, r := range runs {
+		recent = append(recent, probeRunSummaryJSON{
+			StartedAt:          msToRFC3339(r.StartedAtMs),
+			CompletedAt:        msToRFC3339(r.CompletedAtMs),
+			AccountsConsidered: r.AccountsConsidered,
+			AccountsProbed:     r.AccountsProbed,
+			TargetsScanned:     r.TargetsScanned,
+			Success:            r.Success,
+			Failed:             r.Failed,
+			Inconclusive:       r.Inconclusive,
+			Skipped:            r.Skipped,
+		})
+	}
 	return schedulerRunStatus{
 		Job:        "model-probe",
 		Enabled:    true,
 		LastRunAt:  msToRFC3339(summary.CompletedAtMs),
 		LastStatus: status,
 		Note:       "success=" + numStr(int64(summary.Success)) + " failed=" + numStr(int64(summary.Failed)),
+		RecentRuns: recent,
 	}
 }
 

--- a/handler/admin/scheduler_status_recent_runs_test.go
+++ b/handler/admin/scheduler_status_recent_runs_test.go
@@ -1,0 +1,113 @@
+// Test for the model-probe recentRuns extension on the unified
+// scheduler-status view: a fresh background pass must surface the honest
+// run summary (success/failed counts) as a recentRuns entry.
+
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/scheduler"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+type statusProbeStub struct{}
+
+func (statusProbeStub) ProbeChannel(_ context.Context, _ scheduler.ProbeTarget) (scheduler.ProbeOutcome, error) {
+	return scheduler.ProbeOutcome{Status: "success", LatencyMs: 12}, nil
+}
+
+// statusRecorderStub accepts outcomes without touching routing state — the
+// pass must still succeed so the run summary reports honest counts.
+type statusRecorderStub struct{}
+
+func (statusRecorderStub) RecordProbeSuccess(_ context.Context, _ int64, _ float64, _ *string, _ *int64) error {
+	return nil
+}
+
+func (statusRecorderStub) RecordProbeFailure(_ context.Context, _ int64, _ *int, _ *string, _ *string, _ *int64) error {
+	return nil
+}
+
+func TestSchedulerStatusModelProbeRecentRuns(t *testing.T) {
+	db, r := setupSchedulerStatusTest(t)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES ('p-site', 'https://p.example.test', 'openai', 'active', ?, ?)`, now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
+		VALUES (?, 'p-user', 'tok', 'active', 1, ?, ?)`, siteID, now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ := res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
+		VALUES ('all', 'pattern', 'weighted', 1, ?, ?)`, now, now)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	routeID, _ := res.LastInsertId()
+	_, err = db.Exec(`INSERT INTO route_channels (route_id, account_id, source_model, priority, weight, enabled, cooldown_until)
+		VALUES (?, ?, 'gpt-4o', 0, 10, 1, NULL)`, routeID, accountID)
+	if err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+
+	store.OverrideDB(db)
+	t.Cleanup(func() { store.OverrideDB(nil) })
+
+	prev := scheduler.GetGlobalModelProbeScheduler()
+	t.Cleanup(func() { scheduler.SetGlobalModelProbeScheduler(prev) })
+	sched := scheduler.NewModelProbeScheduler(&config.Config{})
+	sched.SetProbeExecutor(statusProbeStub{})
+	sched.SetHealthRecorder(statusRecorderStub{})
+	scheduler.SetGlobalModelProbeScheduler(sched)
+
+	sched.TriggerNow(true)
+
+	resp := doGet(t, r, "/api/scheduler/status")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	items, ok := body["items"].([]any)
+	if !ok {
+		t.Fatalf("items = %#v", body["items"])
+	}
+	var probeItem map[string]any
+	for _, it := range items {
+		item := it.(map[string]any)
+		if item["job"] == "model-probe" {
+			probeItem = item
+		}
+	}
+	if probeItem == nil {
+		t.Fatalf("model-probe job missing: %#v", items)
+	}
+	runs, ok := probeItem["recentRuns"].([]any)
+	if !ok || len(runs) != 1 {
+		t.Fatalf("recentRuns = %#v, want exactly 1 run", probeItem["recentRuns"])
+	}
+	run := runs[0].(map[string]any)
+	if run["success"].(float64) != 1 || run["failed"].(float64) != 0 {
+		t.Fatalf("recentRuns[0] counts = %#v, want success=1 failed=0", run)
+	}
+	if run["completedAt"] == "" || run["startedAt"] == "" {
+		t.Fatalf("recentRuns[0] timestamps empty: %#v", run)
+	}
+	if probeItem["lastStatus"] != "success" {
+		t.Fatalf("lastStatus = %v, want success", probeItem["lastStatus"])
+	}
+}

--- a/scheduler/model_probe.go
+++ b/scheduler/model_probe.go
@@ -57,6 +57,9 @@ type ModelProbeScheduler struct {
 
 	// lastRunSummary is retained for tests / operator diagnostics.
 	lastRunSummary ProbeRunSummary
+	// lastRuns is the ring buffer of recent completed passes (newest first,
+	// capped at 10) so the scheduler-status surface can show honest history.
+	lastRuns []ProbeRunSummary
 }
 
 // ProbeRunSummary summarizes one background probe pass.
@@ -68,6 +71,7 @@ type ProbeRunSummary struct {
 	Failed             int
 	Inconclusive       int
 	Skipped            int
+	StartedAtMs        int64
 	CompletedAtMs      int64
 }
 
@@ -153,11 +157,27 @@ func (s *ModelProbeScheduler) ResetLeases() {
 	s.accountLeases = make(map[int64]bool)
 }
 
+// probeRunHistoryDepth caps how many completed passes RecentRunSummaries
+// retains. Enough for the "last few runs" scheduler-status view without
+// unbounded memory growth (each entry is a handful of ints).
+const probeRunHistoryDepth = 10
+
 // LastRunSummary returns a copy of the most recent probe pass summary.
 func (s *ModelProbeScheduler) LastRunSummary() ProbeRunSummary {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.lastRunSummary
+}
+
+// RecentRunSummaries returns up to probeRunHistoryDepth completed passes,
+// newest first. Only background passes (runProbe) land in the ring buffer —
+// one-shot site probe-now passes are not scheduler runs and are excluded.
+func (s *ModelProbeScheduler) RecentRunSummaries() []ProbeRunSummary {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]ProbeRunSummary, len(s.lastRuns))
+	copy(out, s.lastRuns)
+	return out
 }
 
 // BatchProbeResult is one row of an operator-initiated batch verification
@@ -265,11 +285,15 @@ func (s *ModelProbeScheduler) runProbe() {
 func (s *ModelProbeScheduler) runProbeLocked(dbw *store.DB) {
 	slog.Info("model-probe: starting availability probe")
 
-	summary := ProbeRunSummary{}
+	summary := ProbeRunSummary{StartedAtMs: time.Now().UnixMilli()}
 	defer func() {
 		summary.CompletedAtMs = time.Now().UnixMilli()
 		s.mu.Lock()
 		s.lastRunSummary = summary
+		s.lastRuns = append([]ProbeRunSummary{summary}, s.lastRuns...)
+		if len(s.lastRuns) > probeRunHistoryDepth {
+			s.lastRuns = s.lastRuns[:probeRunHistoryDepth]
+		}
 		s.mu.Unlock()
 	}()
 

--- a/scheduler/model_probe_history_test.go
+++ b/scheduler/model_probe_history_test.go
@@ -1,0 +1,95 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// seedRouteChannel inserts site -> account -> token route -> channel used by
+// the probe-target loaders (mirrors channel_recovery_test seeding).
+func seedRouteChannel(t *testing.T, db *store.DB, suffix, model string, enabled bool) (channelID int64) {
+	t.Helper()
+	now := "2026-01-01T00:00:00Z"
+	res, err := db.Exec(`INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, 'openai', 'active', ?, ?)`, "s-"+suffix, "https://s-"+suffix+".example.test", now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, 'tok', 'active', 1, ?, ?)`, siteID, "u-"+suffix, now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ := res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`, "all", "pattern", "weighted", 1, now, now)
+	if err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	routeID, _ := res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO route_channels (route_id, account_id, source_model, priority, weight, enabled, cooldown_until) VALUES (?, ?, ?, 0, 10, ?, NULL)`, routeID, accountID, model, enabled)
+	if err != nil {
+		t.Fatalf("insert channel: %v", err)
+	}
+	channelID, _ = res.LastInsertId()
+	return channelID
+}
+
+// TestModelProbeScheduler_RecentRunSummaries covers the ring buffer behind
+// the scheduler-status "last few runs" view: newest-first ordering, honest
+// success/failure counts, StartedAtMs populated, and the depth cap.
+func TestModelProbeScheduler_RecentRunSummaries(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	store.OverrideDB(db)
+	t.Cleanup(func() { store.OverrideDB(nil) })
+
+	okChannel := seedRouteChannel(t, db, "ok", "gpt-ok", true)
+	failChannel := seedRouteChannel(t, db, "fail", "gpt-fail", true)
+
+	s := NewModelProbeScheduler(&config.Config{ModelAvailabilityProbeEnabled: true})
+	s.SetProbeExecutor(&fakeProbe{outcomes: map[int64]ProbeOutcome{
+		okChannel:   {Status: "success", LatencyMs: 21},
+		failChannel: {Status: "failure", HTTPStatus: 502, ErrorText: "bad gateway"},
+	}})
+	s.SetHealthRecorder(&fakeRecorder{})
+
+	// A single pass: both channels probed, one success one failure.
+	s.TriggerNow(true)
+	runs := s.RecentRunSummaries()
+	if len(runs) != 1 {
+		t.Fatalf("runs after first pass = %d, want 1", len(runs))
+	}
+	if runs[0].Success != 1 || runs[0].Failed != 1 {
+		t.Fatalf("first run counts = success=%d failed=%d, want 1/1", runs[0].Success, runs[0].Failed)
+	}
+	if runs[0].TargetsScanned != 2 {
+		t.Fatalf("first run targets = %d, want 2", runs[0].TargetsScanned)
+	}
+	if runs[0].StartedAtMs == 0 || runs[0].CompletedAtMs < runs[0].StartedAtMs {
+		t.Fatalf("timestamps not honest: started=%d completed=%d", runs[0].StartedAtMs, runs[0].CompletedAtMs)
+	}
+	if last := s.LastRunSummary(); last.CompletedAtMs != runs[0].CompletedAtMs {
+		t.Fatalf("LastRunSummary diverged from RecentRunSummaries[0]")
+	}
+
+	// Passes accumulate newest-first and the buffer is depth-capped.
+	for i := 0; i < 12; i++ {
+		s.TriggerNow(true)
+	}
+	runs = s.RecentRunSummaries()
+	if len(runs) != probeRunHistoryDepth {
+		t.Fatalf("runs after 13 passes = %d, want capped at %d", len(runs), probeRunHistoryDepth)
+	}
+	for i := 1; i < len(runs); i++ {
+		if runs[i].CompletedAtMs > runs[i-1].CompletedAtMs {
+			t.Fatalf("run %d not newest-first: %d > %d", i, runs[i-1].CompletedAtMs, runs[i].CompletedAtMs)
+		}
+	}
+}

--- a/web/src/features/dashboard/sections/overview/__tests__/overview-section.test.tsx
+++ b/web/src/features/dashboard/sections/overview/__tests__/overview-section.test.tsx
@@ -19,7 +19,13 @@
 
 import '@testing-library/jest-dom/vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -33,6 +39,7 @@ vi.mock('@/lib/api', () => ({
     getDashboardSnapshot: vi.fn(),
     getBalanceHistory: vi.fn(),
     getSchedulerStatus: vi.fn(),
+    probeModelsNow: vi.fn(),
   },
 }))
 
@@ -54,9 +61,22 @@ vi.mock('@/features/dashboard/components/stat-card', () => ({
   StatCard: () => <div data-testid='stat-card' />,
 }))
 
+const { mockToastSuccess } = vi.hoisted(() => ({
+  mockToastSuccess: vi.fn(),
+}))
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: mockToastSuccess,
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
 const mockGetDashboardSnapshot = vi.mocked(api.getDashboardSnapshot)
 const mockGetBalanceHistory = vi.mocked(api.getBalanceHistory)
 const mockGetSchedulerStatus = vi.mocked(api.getSchedulerStatus)
+const mockProbeModelsNow = vi.mocked(api.probeModelsNow)
 
 function createQueryClient() {
   return new QueryClient({
@@ -77,6 +97,7 @@ beforeEach(() => {
   mockGetDashboardSnapshot.mockReset()
   mockGetBalanceHistory.mockReset()
   mockGetSchedulerStatus.mockReset()
+  mockProbeModelsNow.mockReset()
   // Non-banner queries resolve to empty-but-valid shapes so the section
   // renders without throwing; the snapshot is overridden per test.
   mockGetBalanceHistory.mockResolvedValue({ series: [], days: 8 })
@@ -140,5 +161,137 @@ describe('OverviewSection onboarding banner', () => {
     expect(
       screen.queryByRole('link', { name: /Create site/i })
     ).not.toBeInTheDocument()
+  })
+})
+
+describe('OverviewSection model-probe scheduler card', () => {
+  it('offers a manual trigger for the model-probe job and queues it', async () => {
+    mockGetDashboardSnapshot.mockResolvedValue({ siteCount: 3 })
+    mockGetSchedulerStatus.mockResolvedValue({
+      items: [
+        {
+          job: 'model-probe',
+          enabled: true,
+          lastStatus: 'success',
+          runs24h: 2,
+          success24h: 2,
+        },
+        {
+          job: 'checkin',
+          enabled: true,
+          lastStatus: 'success',
+          runs24h: 1,
+          success24h: 1,
+        },
+      ],
+      generatedAt: '',
+    })
+    mockProbeModelsNow.mockResolvedValue({
+      success: true,
+      queued: true,
+      reused: false,
+      jobId: 'probe-1',
+      status: 'pending',
+    })
+
+    renderWithClient(<OverviewSection />)
+
+    const trigger = await screen.findByRole('button', {
+      name: 'Run now',
+    })
+    expect(trigger).toBeInTheDocument()
+    // Only model-probe exposes a manual trigger — other jobs stay honest.
+    expect(screen.getAllByRole('button', { name: 'Run now' })).toHaveLength(1)
+
+    fireEvent.click(trigger)
+    await waitFor(() => {
+      expect(mockProbeModelsNow).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        'Model availability probe queued — recent runs appear here when the pass completes.'
+      )
+    })
+  })
+
+  it('shows the recent runs list when expanded, with honest failure verdicts', async () => {
+    mockGetDashboardSnapshot.mockResolvedValue({ siteCount: 3 })
+    mockGetSchedulerStatus.mockResolvedValue({
+      items: [
+        {
+          job: 'model-probe',
+          enabled: true,
+          lastStatus: 'failed',
+          runs24h: 2,
+          success24h: 1,
+          recentRuns: [
+            {
+              startedAt: '2026-08-23T01:00:00Z',
+              completedAt: '2026-08-23T01:00:05Z',
+              accountsConsidered: 2,
+              accountsProbed: 2,
+              targetsScanned: 3,
+              success: 2,
+              failed: 1,
+              inconclusive: 0,
+              skipped: 0,
+            },
+            {
+              startedAt: '2026-08-23T00:30:00Z',
+              completedAt: '2026-08-23T00:30:04Z',
+              accountsConsidered: 2,
+              accountsProbed: 2,
+              targetsScanned: 2,
+              success: 2,
+              failed: 0,
+              inconclusive: 0,
+              skipped: 0,
+            },
+          ],
+        },
+      ],
+      generatedAt: '',
+    })
+
+    renderWithClient(<OverviewSection />)
+
+    const toggle = await screen.findByRole('button', {
+      name: 'Recent runs',
+    })
+    fireEvent.click(toggle)
+
+    // The failed pass carries the destructive verdict; the clean pass stays
+    // success — the list never hides a failed run behind a green badge.
+    expect(await screen.findByText('Failed')).toBeInTheDocument()
+    expect(screen.getByText('Completed')).toBeInTheDocument()
+    expect(screen.getByText('3 targets')).toBeInTheDocument()
+    expect(
+      screen.getByText('ok 2 / failed 1 / inconclusive 0 / skipped 0')
+    ).toBeInTheDocument()
+  })
+
+  it('hides the trigger when the model-probe scheduler is disabled', async () => {
+    mockGetDashboardSnapshot.mockResolvedValue({ siteCount: 3 })
+    mockGetSchedulerStatus.mockResolvedValue({
+      items: [
+        {
+          job: 'model-probe',
+          enabled: false,
+          lastStatus: 'never',
+          note: 'not enabled (MODEL_AVAILABILITY_PROBE_ENABLED)',
+          runs24h: 0,
+          success24h: 0,
+        },
+      ],
+      generatedAt: '',
+    })
+
+    renderWithClient(<OverviewSection />)
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Run now' })
+      ).not.toBeInTheDocument()
+    )
   })
 })

--- a/web/src/features/dashboard/sections/overview/overview-section.tsx
+++ b/web/src/features/dashboard/sections/overview/overview-section.tsx
@@ -9,18 +9,20 @@
 // balance over the last 8 captured points), and api.getSchedulerStatus() for
 // the scheduled-tasks table.
 
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { Link, type LinkProps } from '@tanstack/react-router'
 import {
   Activity,
   CalendarCheck,
+  ChevronDown,
   ClipboardList,
   Globe,
+  Play,
   Plus,
   RefreshCw,
   Users,
 } from 'lucide-react'
-import { useMemo, type ReactNode } from 'react'
+import { Fragment, useMemo, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Badge } from '@/components/ui/badge'
@@ -49,8 +51,12 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { toBcp47 } from '@/i18n/languages'
 import { api } from '@/lib/api'
-import { formatInt, formatRatio } from '@/lib/format'
+import type { SchedulerProbeRunSummary } from '@/lib/api/types'
+import { formatInt, formatRatio, formatRelativeTime } from '@/lib/format'
+import { toast } from '@/lib/toast'
+import { cn } from '@/lib/utils'
 
 import { AnnouncementBanner } from '../../components/announcement-banner'
 import { StatCard } from '../../components/stat-card'
@@ -109,8 +115,67 @@ const SCHEDULER_STATUS_BADGE: Record<
   },
 }
 
-export function OverviewSection() {
+/** Compact list of the model-probe scheduler's last completed passes. */
+function ProbeRecentRuns({
+  runs,
+  locale,
+}: {
+  runs: SchedulerProbeRunSummary[]
+  locale: string
+}) {
   const { t } = useTranslation()
+  if (runs.length === 0) {
+    return (
+      <p className='text-muted-foreground text-xs'>
+        {t('dashboard.overview.scheduledTasks.runsEmpty')}
+      </p>
+    )
+  }
+  return (
+    <ul className='space-y-1.5'>
+      {runs.map((run) => {
+        // Pass-level verdict stays honest: any failed target makes the pass
+        // a failure even when others succeeded.
+        const failed = run.failed > 0
+        return (
+          <li
+            key={`${run.startedAt ?? ''}-${run.completedAt ?? ''}`}
+            className='flex flex-wrap items-center gap-x-2 gap-y-1 text-xs'
+          >
+            <Badge variant={failed ? 'destructive' : 'success'}>
+              {failed
+                ? t('dashboard.overview.scheduledTasks.runFailed')
+                : t('dashboard.overview.scheduledTasks.runSuccess')}
+            </Badge>
+            <span className='text-muted-foreground tabular-nums'>
+              {run.completedAt
+                ? formatRelativeTime(run.completedAt, locale)
+                : '—'}
+            </span>
+            <span className='text-muted-foreground tabular-nums'>
+              {t('dashboard.overview.scheduledTasks.runTargets', {
+                count: run.targetsScanned,
+              })}
+            </span>
+            <span className='text-muted-foreground tabular-nums'>
+              {t('dashboard.overview.scheduledTasks.runCounts', {
+                success: run.success,
+                failed: run.failed,
+                inconclusive: run.inconclusive,
+                skipped: run.skipped,
+              })}
+            </span>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export function OverviewSection() {
+  const { t, i18n } = useTranslation()
+  const locale = toBcp47(i18n.language || 'en')
+  const [expandedJob, setExpandedJob] = useState<string | null>(null)
 
   const { data: snapshot, isLoading: snapshotLoading } = useQuery({
     queryKey: ['dashboard-snapshot'],
@@ -142,6 +207,24 @@ export function OverviewSection() {
   }, [balanceHistory])
 
   const schedulerRows = schedulerStatus?.items ?? []
+
+  const triggerProbeMutation = useMutation({
+    mutationFn: () => api.probeModelsNow(),
+    onSuccess: () => {
+      toast.success(t('dashboard.overview.scheduledTasks.triggerQueued'))
+      // The pass runs asynchronously server-side; a delayed refetch picks up
+      // the finished run for the recent-runs view.
+      window.setTimeout(() => {
+        void refetchScheduler()
+      }, 5000)
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error)
+      toast.error(
+        t('dashboard.overview.scheduledTasks.triggerFailed', { message })
+      )
+    },
+  })
 
   const totalAccounts = snapshot?.totalAccounts ?? snapshot?.accountCount
   const activeAccounts = snapshot?.activeAccounts
@@ -234,6 +317,9 @@ export function OverviewSection() {
               <TableHead className='text-right'>
                 {t('dashboard.overview.scheduledTasks.colSuccess24h')}
               </TableHead>
+              <TableHead className='text-right'>
+                {t('dashboard.overview.scheduledTasks.colActions')}
+              </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -244,24 +330,78 @@ export function OverviewSection() {
               const enabledLabel = row.enabled
                 ? t('dashboard.overview.scheduledTasks.enabled')
                 : t('dashboard.overview.scheduledTasks.disabled')
+              const canTrigger =
+                row.job === 'model-probe' && row.enabled === true
+              const expanded = expandedJob === row.job
+              const showRunsToggle =
+                row.job === 'model-probe' && (row.recentRuns?.length ?? 0) > 0
               return (
-                <TableRow key={row.job}>
-                  <TableCell className='font-medium'>{row.job}</TableCell>
-                  <TableCell>
-                    <Badge variant={row.enabled ? 'success' : 'secondary'}>
-                      {enabledLabel}
-                    </Badge>
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant={status.variant}>{t(status.key)}</Badge>
-                  </TableCell>
-                  <TableCell className='text-right tabular-nums'>
-                    {formatInt(row.runs24h)}
-                  </TableCell>
-                  <TableCell className='text-right tabular-nums'>
-                    {formatInt(row.success24h)}
-                  </TableCell>
-                </TableRow>
+                <Fragment key={row.job}>
+                  <TableRow>
+                    <TableCell className='font-medium'>{row.job}</TableCell>
+                    <TableCell>
+                      <Badge variant={row.enabled ? 'success' : 'secondary'}>
+                        {enabledLabel}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={status.variant}>{t(status.key)}</Badge>
+                    </TableCell>
+                    <TableCell className='text-right tabular-nums'>
+                      {formatInt(row.runs24h)}
+                    </TableCell>
+                    <TableCell className='text-right tabular-nums'>
+                      {formatInt(row.success24h)}
+                    </TableCell>
+                    <TableCell className='text-right'>
+                      <div className='flex items-center justify-end gap-1'>
+                        {canTrigger && (
+                          <Button
+                            variant='outline'
+                            size='sm'
+                            disabled={triggerProbeMutation.isPending}
+                            onClick={() => triggerProbeMutation.mutate()}
+                          >
+                            <Play className='size-3.5' />
+                            {t(
+                              'dashboard.overview.scheduledTasks.triggerButton'
+                            )}
+                          </Button>
+                        )}
+                        {showRunsToggle && (
+                          <Button
+                            variant='ghost'
+                            size='sm'
+                            aria-expanded={expanded}
+                            aria-label={t(
+                              'dashboard.overview.scheduledTasks.latestRuns'
+                            )}
+                            onClick={() =>
+                              setExpandedJob(expanded ? null : row.job)
+                            }
+                          >
+                            <ChevronDown
+                              className={cn(
+                                'size-3.5 transition-transform',
+                                expanded && 'rotate-180'
+                              )}
+                            />
+                          </Button>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                  {expanded && row.recentRuns && (
+                    <TableRow className='bg-muted/30'>
+                      <TableCell colSpan={6} className='px-3 py-2'>
+                        <ProbeRecentRuns
+                          runs={row.recentRuns}
+                          locale={locale}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </Fragment>
               )
             })}
           </TableBody>

--- a/web/src/features/models/components/__tests__/model-verify-dialog.test.tsx
+++ b/web/src/features/models/components/__tests__/model-verify-dialog.test.tsx
@@ -1,0 +1,136 @@
+// Behavior tests for the models batch availability probe dialog.
+//
+// Guards the honest-report contract of the G1 verify-batch surface: the
+// dialog renders the per-target outcome table with truthful status badges
+// (inconclusive is NOT success), surfaces the probe-failure message when the
+// scheduler is not running, and loads verification history on demand.
+
+import '@testing-library/jest-dom/vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { ModelVerifyDialog } from '../model-verify-dialog'
+
+const { mockVerifyBatch, mockVerifyHistory } = vi.hoisted(() => ({
+  mockVerifyBatch: vi.fn(),
+  mockVerifyHistory: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    verifyModelsBatch: mockVerifyBatch,
+    getModelVerifyHistory: mockVerifyHistory,
+  },
+}))
+
+beforeEach(() => {
+  mockVerifyBatch.mockReset()
+  mockVerifyHistory.mockReset()
+})
+
+afterEach(() => cleanup())
+
+function renderDialog() {
+  return render(<ModelVerifyDialog open onOpenChange={vi.fn()} />)
+}
+
+describe('ModelVerifyDialog', () => {
+  it('runs a batch probe and shows honest per-target outcomes', async () => {
+    mockVerifyBatch.mockResolvedValue({
+      success: true,
+      batchId: 'vb-1',
+      probed: 3,
+      summary: { success: 1, failure: 1, inconclusive: 1, skipped: 0 },
+      items: [
+        {
+          model: 'gpt-4o',
+          siteName: 'site-a',
+          status: 'success',
+          latencyMs: 120,
+        },
+        {
+          model: 'gpt-4o-mini',
+          siteName: 'site-a',
+          status: 'failure',
+          latencyMs: 0,
+          errorText: 'upstream 502',
+        },
+      ],
+    })
+
+    renderDialog()
+    fireEvent.click(screen.getByRole('button', { name: 'Run batch probe' }))
+
+    await waitFor(() => expect(mockVerifyBatch).toHaveBeenCalledTimes(1))
+    // Verdicts stay honest: failure is rendered as failure, not success.
+    expect(await screen.findByText('Failed')).toBeInTheDocument()
+    expect(screen.getByText('OK')).toBeInTheDocument()
+    expect(screen.getByText('upstream 502')).toBeInTheDocument()
+    expect(screen.getByText('probed 3')).toBeInTheDocument()
+    // No success-faking: filtered target list is exactly what came back.
+    expect(
+      screen.queryByText('gpt-4o-mini', { selector: 'td' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the probe failure message when the scheduler is not running', async () => {
+    mockVerifyBatch.mockRejectedValue(
+      new Error('model probe scheduler is not running (start schedulers)')
+    )
+
+    renderDialog()
+    fireEvent.click(screen.getByRole('button', { name: 'Run batch probe' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(
+      'Batch probe failed: model probe scheduler is not running (start schedulers)'
+    )
+  })
+
+  it('loads and renders verification history on demand', async () => {
+    mockVerifyBatch.mockResolvedValue({
+      success: true,
+      batchId: 'vb-2',
+      probed: 0,
+      summary: { success: 0, failure: 0, inconclusive: 0, skipped: 0 },
+      items: [],
+      note: 'no enabled route channels match the filter',
+    })
+    mockVerifyHistory.mockResolvedValue({
+      items: [
+        {
+          id: 41,
+          batchId: 'vb-1',
+          model: 'claude-sonnet-4',
+          siteName: 'site-b',
+          status: 'inconclusive',
+          latencyMs: null,
+          errorText: 'dial timeout',
+        },
+      ],
+    })
+
+    renderDialog()
+    fireEvent.click(screen.getByRole('button', { name: 'Run batch probe' }))
+    await waitFor(() =>
+      expect(
+        screen.getByText('no enabled route channels match the filter')
+      ).toBeInTheDocument()
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'View history' }))
+    await waitFor(() => expect(mockVerifyHistory).toHaveBeenCalledTimes(1))
+    expect(await screen.findByText('claude-sonnet-4')).toBeInTheDocument()
+    // Inconclusive stays inconclusive — nothing is dressed up as OK.
+    expect(screen.getByText('Inconclusive')).toBeInTheDocument()
+    expect(screen.queryByText('OK')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/features/models/components/model-verify-dialog.tsx
+++ b/web/src/features/models/components/model-verify-dialog.tsx
@@ -1,0 +1,363 @@
+// metapi-go/features/models — batch availability probe dialog.
+//
+// Collapses the models-page "batch probe" behind a single dialog that runs
+// POST /api/models/verify-batch (the same lightweight probe the background
+// model-probe scheduler uses, with durable per-row history) and renders the
+// honest per-target outcome table. A "history" toggle surfaces the recent
+// verification rows from GET /api/models/verify-history so past passes are
+// not lost when the dialog closes.
+//
+// Honesty rules: probe-machinery error (503 when the scheduler is not
+// running) is rendered as a failure with the message — never as success —
+// and inconclusive/skipped rows keep their own badge instead of being
+// counted as either success or failure.
+
+import { FlaskConical as FlaskConicalIcon } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Spinner } from '@/components/ui/spinner'
+import { api } from '@/lib/api'
+import type {
+  ModelVerifyItem,
+  VerifyBatchResponse,
+  VerifyHistoryResponse,
+} from '@/lib/api/types'
+import { formatLatency } from '@/lib/format'
+import { toast } from '@/lib/toast'
+import { cn } from '@/lib/utils'
+
+const STATUS_BADGE_VARIANT: Record<
+  ModelVerifyItem['status'],
+  'success' | 'destructive' | 'secondary' | 'outline'
+> = {
+  success: 'success',
+  failure: 'destructive',
+  inconclusive: 'secondary',
+  skipped: 'outline',
+}
+
+function statusLabelKey(status: ModelVerifyItem['status']): string {
+  switch (status) {
+    case 'success':
+      return 'models.verify.statusSuccess'
+    case 'failure':
+      return 'models.verify.statusFailure'
+    case 'inconclusive':
+      return 'models.verify.statusInconclusive'
+    default:
+      return 'models.verify.statusSkipped'
+  }
+}
+
+function VerifyItemRow({ item }: { item: ModelVerifyItem }) {
+  const { t } = useTranslation()
+  return (
+    <tr className='border-t'>
+      <td className='px-3 py-1.5 break-all'>{item.model}</td>
+      <td className='text-muted-foreground px-3 py-1.5'>
+        {item.siteName || '—'}
+      </td>
+      <td className='px-3 py-1.5'>
+        <Badge variant={STATUS_BADGE_VARIANT[item.status]}>
+          {t(statusLabelKey(item.status))}
+        </Badge>
+      </td>
+      <td className='px-3 py-1.5 text-right tabular-nums'>
+        {formatLatency(item.latencyMs, { autoSeconds: true, spaced: true })}
+      </td>
+      <td
+        className='text-muted-foreground max-w-52 px-3 py-1.5 break-words'
+        title={item.errorText ?? ''}
+      >
+        {item.errorText || '—'}
+      </td>
+    </tr>
+  )
+}
+
+type ModelVerifyDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ModelVerifyDialog({
+  open,
+  onOpenChange,
+}: ModelVerifyDialogProps) {
+  const { t } = useTranslation()
+
+  const [modelFilter, setModelFilter] = useState('')
+  const [phase, setPhase] = useState<'idle' | 'running' | 'done' | 'error'>(
+    'idle'
+  )
+  const [result, setResult] = useState<VerifyBatchResponse | null>(null)
+  const [errorMessage, setErrorMessage] = useState('')
+  const [showHistory, setShowHistory] = useState(false)
+  const [history, setHistory] = useState<ModelVerifyItem[] | null>(null)
+  const [historyLoading, setHistoryLoading] = useState(false)
+
+  // Reset the run state when the dialog reopens so a fresh pass starts
+  // from the idle phase instead of showing the previous run.
+  useEffect(() => {
+    if (open) {
+      setPhase('idle')
+      setResult(null)
+      setErrorMessage('')
+      setModelFilter('')
+      setShowHistory(false)
+      setHistory(null)
+    }
+  }, [open])
+
+  function parseModels(): string[] {
+    return modelFilter
+      .split(/[\s,]+/)
+      .map((m) => m.trim())
+      .filter(Boolean)
+  }
+
+  async function runVerify() {
+    setPhase('running')
+    setResult(null)
+    setErrorMessage('')
+    try {
+      const response = await api.verifyModelsBatch(parseModels(), 0, 50)
+      setResult(response)
+      setPhase('done')
+      setShowHistory(false)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      setErrorMessage(message)
+      setPhase('error')
+    }
+  }
+
+  async function loadHistory() {
+    setHistoryLoading(true)
+    try {
+      const response: VerifyHistoryResponse =
+        await api.getModelVerifyHistory(20)
+      setHistory(response.items)
+      setShowHistory(true)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      toast.error(t('models.verify.historyLoadFailed', { message }))
+    } finally {
+      setHistoryLoading(false)
+    }
+  }
+
+  const summary = result?.summary
+  const summaryKeys: Array<{
+    key: string
+    value: number
+    className: string
+  }> = [
+    {
+      key: 'models.verify.summarySuccess',
+      value: summary?.success ?? 0,
+      className: 'text-success-soft-fg',
+    },
+    {
+      key: 'models.verify.summaryFailure',
+      value: summary?.failure ?? 0,
+      className: 'text-destructive-soft-fg',
+    },
+    {
+      key: 'models.verify.summaryInconclusive',
+      value: summary?.inconclusive ?? 0,
+      className: 'text-muted-foreground',
+    },
+    {
+      key: 'models.verify.summarySkipped',
+      value: summary?.skipped ?? 0,
+      className: 'text-muted-foreground',
+    },
+  ]
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='sm:max-w-2xl'>
+        <DialogHeader>
+          <DialogTitle className='flex items-center gap-2'>
+            <FlaskConicalIcon className='size-4' />
+            {t('models.verify.title')}
+          </DialogTitle>
+          <DialogDescription className='text-xs'>
+            {t('models.verify.description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className='flex flex-col gap-3'>
+          <div className='flex flex-col gap-1.5'>
+            <label
+              className='text-sm font-medium'
+              htmlFor='model-verify-filter'
+            >
+              {t('models.verify.modelLabel')}
+            </label>
+            <Input
+              id='model-verify-filter'
+              value={modelFilter}
+              onChange={(e) => setModelFilter(e.target.value)}
+              placeholder={t('models.verify.modelPlaceholder')}
+              disabled={phase === 'running'}
+            />
+            <p className='text-muted-foreground text-xs'>
+              {t('models.verify.modelHint')}
+            </p>
+          </div>
+
+          {phase === 'error' && (
+            <div
+              role='alert'
+              className='border-destructive/40 bg-destructive/10 text-destructive rounded-md border p-2 text-xs'
+            >
+              {t('models.verify.errorMessage', { message: errorMessage })}
+            </div>
+          )}
+
+          {phase === 'done' && result && (
+            <div className='flex flex-col gap-2'>
+              <div
+                className='flex flex-wrap items-center gap-2 text-xs'
+                aria-live='polite'
+              >
+                {summaryKeys.map((entry) => (
+                  <span
+                    key={entry.key}
+                    className={cn('tabular-nums', entry.className)}
+                  >
+                    {t(entry.key)} {entry.value}
+                  </span>
+                ))}
+                <span className='text-muted-foreground tabular-nums'>
+                  {t('models.verify.probedCount', { count: result.probed })}
+                </span>
+              </div>
+
+              {result.items.length === 0 ? (
+                <p className='text-muted-foreground rounded-md border border-dashed p-3 text-center text-xs'>
+                  {result.note || t('models.verify.noRows')}
+                </p>
+              ) : (
+                <div className='max-h-64 overflow-y-auto rounded-md border'>
+                  <table className='w-full text-xs'>
+                    <thead className='bg-muted/50 sticky top-0 text-left'>
+                      <tr>
+                        <th className='px-3 py-2 font-medium'>
+                          {t('models.verify.colModel')}
+                        </th>
+                        <th className='px-3 py-2 font-medium'>
+                          {t('models.verify.colSite')}
+                        </th>
+                        <th className='px-3 py-2 font-medium'>
+                          {t('models.verify.colStatus')}
+                        </th>
+                        <th className='px-3 py-2 text-right font-medium'>
+                          {t('models.verify.colLatency')}
+                        </th>
+                        <th className='px-3 py-2 font-medium'>
+                          {t('models.verify.colError')}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {result.items.map((item) => (
+                        <VerifyItemRow
+                          key={`${item.channelId ?? 'c'}-${item.model}`}
+                          item={item}
+                        />
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+
+              <div className='flex items-center gap-2'>
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  onClick={() => void loadHistory()}
+                  disabled={historyLoading}
+                >
+                  {historyLoading ? <Spinner /> : null}
+                  {t('models.verify.viewHistory')}
+                </Button>
+                {showHistory && (
+                  <button
+                    type='button'
+                    className='text-muted-foreground hover:text-foreground text-xs underline'
+                    onClick={() => setShowHistory(false)}
+                  >
+                    {t('models.verify.hideHistory')}
+                  </button>
+                )}
+              </div>
+
+              {showHistory && history && (
+                <div className='max-h-48 overflow-y-auto rounded-md border'>
+                  <table className='w-full text-xs'>
+                    <thead className='bg-muted/50 sticky top-0 text-left'>
+                      <tr>
+                        <th className='px-3 py-2 font-medium'>
+                          {t('models.verify.colModel')}
+                        </th>
+                        <th className='px-3 py-2 font-medium'>
+                          {t('models.verify.colSite')}
+                        </th>
+                        <th className='px-3 py-2 font-medium'>
+                          {t('models.verify.colStatus')}
+                        </th>
+                        <th className='px-3 py-2 text-right font-medium'>
+                          {t('models.verify.colLatency')}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {history.map((item) => (
+                        <VerifyItemRow
+                          key={
+                            item.id != null
+                              ? `history-${item.id}`
+                              : `history-c${item.channelId ?? 'x'}-${item.model}`
+                          }
+                          item={item}
+                        />
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          {phase === 'running' && <Spinner />}
+          <Button
+            variant='default'
+            onClick={() => void runVerify()}
+            disabled={phase === 'running'}
+          >
+            {phase === 'running'
+              ? t('models.verify.runningLabel')
+              : t('models.verify.runButton')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/features/models/components/models-page.tsx
+++ b/web/src/features/models/components/models-page.tsx
@@ -12,7 +12,11 @@
 import { useMutation } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import type { ColumnFiltersState } from '@tanstack/react-table'
-import { RefreshCw as RefreshCwIcon, Users as UsersIcon } from 'lucide-react'
+import {
+  FlaskConical as FlaskConicalIcon,
+  RefreshCw as RefreshCwIcon,
+  Users as UsersIcon,
+} from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -40,6 +44,7 @@ import { useModels } from '../api'
 import { modelsSearchSchema } from '../lib/models-schema'
 import type { ModelRow } from '../types'
 import { ModelDetailSheet } from './model-detail-sheet'
+import { ModelVerifyDialog } from './model-verify-dialog'
 import {
   buildBrandFilterOptions,
   buildCapabilityFilterOptions,
@@ -163,6 +168,7 @@ export function ModelsPage() {
   const navigate = useNavigate()
 
   const [viewingModel, setViewingModel] = useState<ModelRow | null>(null)
+  const [verifyOpen, setVerifyOpen] = useState(false)
 
   const urlState = useModelsUrlState()
 
@@ -264,19 +270,29 @@ export function ModelsPage() {
             },
           ],
           preActions: (
-            <Button
-              variant='outline'
-              size='sm'
-              onClick={() => refreshMutation.mutate()}
-              disabled={refreshMutation.isPending}
-            >
-              {refreshMutation.isPending ? (
-                <Spinner />
-              ) : (
-                <RefreshCwIcon className='size-3.5' />
-              )}
-              {t('models.toolbar.refresh')}
-            </Button>
+            <>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => setVerifyOpen(true)}
+              >
+                <FlaskConicalIcon className='size-3.5' />
+                {t('models.toolbar.batchProbe')}
+              </Button>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => refreshMutation.mutate()}
+                disabled={refreshMutation.isPending}
+              >
+                {refreshMutation.isPending ? (
+                  <Spinner />
+                ) : (
+                  <RefreshCwIcon className='size-3.5' />
+                )}
+                {t('models.toolbar.refresh')}
+              </Button>
+            </>
           ),
         }}
       />
@@ -288,6 +304,8 @@ export function ModelsPage() {
           if (!open) setViewingModel(null)
         }}
       />
+
+      <ModelVerifyDialog open={verifyOpen} onOpenChange={setVerifyOpen} />
     </div>
   )
 }

--- a/web/src/features/sites/components/__tests__/site-probe-panel.test.tsx
+++ b/web/src/features/sites/components/__tests__/site-probe-panel.test.tsx
@@ -1,0 +1,202 @@
+// Behavior tests for the site probe report panel.
+//
+// The panel is the honest report surface for POST-probe-stream: it renders
+// live incremental results, marks probe-machinery `error` rows separately
+// from failures, shows the truncation banner when the pass was cut short,
+// and never turns a stopped/failed run into a success.
+
+import '@testing-library/jest-dom/vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+import type { SiteProbeResult } from '@/lib/api/sites'
+
+import { SiteProbePanel } from '../site-probe-panel'
+
+const { mockStreamSiteProbe, mockProbeSiteNow } = vi.hoisted(() => ({
+  mockStreamSiteProbe: vi.fn(),
+  mockProbeSiteNow: vi.fn(),
+}))
+
+vi.mock('@/lib/api/sites', () => ({
+  sitesApi: {
+    probeSiteNow: mockProbeSiteNow,
+    streamSiteProbe: mockStreamSiteProbe,
+  },
+}))
+
+type CapturedHandlers = {
+  onResult?: (result: SiteProbeResult) => void
+  onComplete?: (payload: {
+    totalModels: number
+    available: number
+    unavailable: number
+    truncated?: boolean
+    reason?: string
+  }) => void
+  signal?: AbortSignal
+}
+
+let captured: CapturedHandlers | null = null
+let streamPromise: Promise<void> | null = null
+
+beforeEach(() => {
+  mockStreamSiteProbe.mockReset()
+  mockProbeSiteNow.mockReset()
+  captured = null
+  streamPromise = null
+  mockStreamSiteProbe.mockImplementation(
+    (_siteId: number, handlers: CapturedHandlers) => {
+      captured = handlers
+      streamPromise = new Promise<void>(() => {})
+      return streamPromise
+    }
+  )
+})
+
+afterEach(() => cleanup())
+
+const successRow: SiteProbeResult = {
+  channelId: 1,
+  accountId: 10,
+  model: 'gpt-4o',
+  status: 'success',
+  latencyMs: 320,
+}
+const failureRow: SiteProbeResult = {
+  channelId: 2,
+  accountId: 11,
+  model: 'gpt-4o-mini',
+  status: 'failure',
+  latencyMs: 0,
+  error: 'upstream 503',
+}
+const errorRow: SiteProbeResult = {
+  channelId: 3,
+  accountId: 12,
+  model: 'claude-sonnet-4',
+  status: 'error',
+  latencyMs: 0,
+  error: 'target load failed',
+}
+
+describe('SiteProbePanel', () => {
+  it('starts idle with an honest empty state and a run button', () => {
+    render(<SiteProbePanel siteId={7} />)
+    expect(
+      screen.getByText(
+        'No probe results yet. Run a probe to check the models available on this site.'
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Run probe' })
+    ).toBeInTheDocument()
+  })
+
+  it('streams incremental results and renders the final honest summary', async () => {
+    render(<SiteProbePanel siteId={7} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Run probe' }))
+
+    await waitFor(() =>
+      expect(mockStreamSiteProbe).toHaveBeenCalledWith(7, expect.anything())
+    )
+    expect(captured).not.toBeNull()
+    expect(screen.getByRole('button', { name: /Stop/ })).toBeInTheDocument()
+
+    // Live incremental arrival: one success, then one failure with its
+    // honest error text.
+    captured?.onResult?.(successRow)
+    expect(await screen.findByText('gpt-4o')).toBeInTheDocument()
+    captured?.onResult?.(failureRow)
+    await waitFor(() =>
+      expect(screen.getByText('gpt-4o-mini')).toBeInTheDocument()
+    )
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.getByText('upstream 503')).toBeInTheDocument()
+
+    // A probe-machinery error row keeps its own badge + error text — it is
+    // never rendered as a success.
+    captured?.onResult?.(errorRow)
+    await waitFor(() =>
+      expect(screen.getByText('Probe error')).toBeInTheDocument()
+    )
+
+    captured?.onComplete?.({
+      totalModels: 3,
+      available: 1,
+      unavailable: 2,
+    })
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Total 3 · available 1 · unavailable 2/)
+      ).toBeInTheDocument()
+    )
+    expect(
+      screen.getByRole('button', { name: 'Run probe' })
+    ).toBeInTheDocument()
+  })
+
+  it('shows the truncation banner with the reason when the pass is cut short', async () => {
+    render(<SiteProbePanel siteId={7} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Run probe' }))
+    await waitFor(() => expect(captured).not.toBeNull())
+
+    captured?.onComplete?.({
+      totalModels: 2,
+      available: 1,
+      unavailable: 1,
+      truncated: true,
+      reason: 'context canceled',
+    })
+    expect(
+      await screen.findByText('Probe pass was cut short: context canceled')
+    ).toBeInTheDocument()
+  })
+
+  it('marks an aborted run as stopped instead of success', async () => {
+    // Reject when the caller aborts.
+    mockStreamSiteProbe.mockImplementation(
+      (_siteId: number, handlers: CapturedHandlers) =>
+        new Promise<void>((_, reject) => {
+          captured = handlers
+          handlers.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted')
+            err.name = 'AbortError'
+            reject(err)
+          })
+        })
+    )
+    render(<SiteProbePanel siteId={7} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Run probe' }))
+    await waitFor(() => expect(captured).not.toBeNull())
+
+    fireEvent.click(screen.getByRole('button', { name: /Stop/ }))
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'Probe stopped — only the results received so far are shown.'
+        )
+      ).toBeInTheDocument()
+    )
+    expect(screen.queryByText(/summary|Total/)).not.toBeInTheDocument()
+  })
+
+  it('renders the failure message on stream error', async () => {
+    mockStreamSiteProbe.mockImplementation(
+      (_siteId: number) =>
+        new Promise<void>((_, reject) => reject(new Error('network down')))
+    )
+    render(<SiteProbePanel siteId={7} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Run probe' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Probe failed: network down'
+    )
+  })
+})

--- a/web/src/features/sites/components/site-detail-sheet.tsx
+++ b/web/src/features/sites/components/site-detail-sheet.tsx
@@ -33,6 +33,7 @@ import {
 
 import { resolveSiteBalanceUsd } from '../lib/site-balance'
 import type { Site, SiteApiEndpoint, SiteStatus } from '../types'
+import { SiteProbePanel } from './site-probe-panel'
 
 type SiteDetailSheetProps = {
   site: Site | null
@@ -113,6 +114,10 @@ export function SiteDetailSheet({
           <Separator />
 
           <SiteBalanceSection site={site} locale={locale} />
+
+          <SiteProbePanel key={site.id} siteId={site.id} />
+
+          <Separator />
 
           <section>
             <dl className='grid grid-cols-2 gap-x-3 gap-y-2 text-sm'>

--- a/web/src/features/sites/components/site-probe-panel.tsx
+++ b/web/src/features/sites/components/site-probe-panel.tsx
@@ -1,0 +1,278 @@
+// metapi-go/features/sites — site probe report panel (detail Sheet).
+//
+// Drives GET /api/sites/{id}/probe-stream (SSE): the stream runs a probe
+// pass and pushes one `probe-result` event per model as it completes, then
+// a `complete` event with honest totals (including truncated + reason when
+// the server cut the pass short). The panel renders the live incremental
+// state, and the last completed report is cached in-module so reopening the
+// sheet shows the most recent result instead of a blank panel.
+//
+// Honesty rule: `failure` rows are rendered as failures (red), the probe
+// machinery's `error` status is rendered as probe error (warning) with the
+// error text, and a truncated pass shows the truncation banner — a broken
+// site is never presented as healthy.
+
+import { Search as SearchIcon } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
+import { toBcp47 } from '@/i18n/languages'
+import { sitesApi, type SiteProbeResult } from '@/lib/api/sites'
+import { formatLatency, formatRelativeTime } from '@/lib/format'
+
+type ProbeSummary = {
+  totalModels: number
+  available: number
+  unavailable: number
+  truncated?: boolean
+  reason?: string
+}
+
+type CompletedReport = {
+  rows: SiteProbeResult[]
+  summary: ProbeSummary | null
+  finishedAt: string
+}
+
+type RunPhase = 'idle' | 'running' | 'stopped' | 'error'
+
+/** Last completed report per siteId, kept for sheet reopen (session only). */
+const reportCache = new Map<number, CompletedReport>()
+
+function statusBadgeFor(status: SiteProbeResult['status']) {
+  switch (status) {
+    case 'success':
+      return { variant: 'success' as const, key: 'sites.probe.statusSuccess' }
+    case 'failure':
+      return {
+        variant: 'destructive' as const,
+        key: 'sites.probe.statusFailure',
+      }
+    default:
+      return { variant: 'warning' as const, key: 'sites.probe.statusError' }
+  }
+}
+
+export function SiteProbePanel({ siteId }: { siteId: number }) {
+  const { t, i18n } = useTranslation()
+  const locale = toBcp47(i18n.language || 'en')
+
+  // Seed from the session cache so a reopened sheet keeps the last report.
+  const [cached] = useState<CompletedReport | null>(
+    () => reportCache.get(siteId) ?? null
+  )
+  const [phase, setPhase] = useState<RunPhase>('idle')
+  const [rows, setRows] = useState<SiteProbeResult[]>(cached?.rows ?? [])
+  const [summary, setSummary] = useState<ProbeSummary | null>(
+    cached?.summary ?? null
+  )
+  const [finishedAt, setFinishedAt] = useState<string | null>(
+    cached?.finishedAt ?? null
+  )
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const abortRef = useRef<AbortController | null>(null)
+  // Guards against a stale sheet (siteId change) streaming into the new site.
+  const siteRef = useRef(siteId)
+  siteRef.current = siteId
+  const rowsRef = useRef(rows)
+  rowsRef.current = rows
+
+  useEffect(() => {
+    return () => abortRef.current?.abort()
+  }, [])
+
+  const startProbe = useCallback(() => {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    setPhase('running')
+    setRows([])
+    setSummary(null)
+    setFinishedAt(null)
+    setErrorMessage(null)
+
+    void sitesApi
+      .streamSiteProbe(siteRef.current, {
+        signal: controller.signal,
+        onResult: (result) => {
+          setRows((prev) => [...prev, result])
+        },
+        onComplete: (payload) => {
+          const completed = {
+            rows: rowsRef.current,
+            summary: {
+              totalModels: payload.totalModels,
+              available: payload.available,
+              unavailable: payload.unavailable,
+              truncated: payload.truncated,
+              reason: payload.reason,
+            },
+            finishedAt: new Date().toISOString(),
+          }
+          reportCache.set(siteRef.current, completed)
+          setSummary(completed.summary)
+          setFinishedAt(completed.finishedAt)
+          setPhase('idle')
+        },
+      })
+      .catch((error: unknown) => {
+        const err = error as Error | null
+        if (err?.name === 'AbortError' || controller.signal.aborted) {
+          // Aborted by the operator: keep what streamed so far, honestly
+          // marked as stopped rather than pretending the run completed.
+          setPhase('stopped')
+          return
+        }
+        setErrorMessage(err?.message ?? String(error))
+        setPhase('error')
+      })
+  }, [])
+
+  const stopProbe = useCallback(() => {
+    abortRef.current?.abort()
+    // phase settles in the catch handler
+  }, [])
+
+  const hasRows = rows.length > 0
+
+  return (
+    <section className='flex flex-col gap-2'>
+      <div className='flex flex-wrap items-center justify-between gap-2'>
+        <div>
+          <h3 className='text-sm font-medium'>{t('sites.probe.title')}</h3>
+          <p className='text-muted-foreground text-xs'>
+            {t('sites.probe.description')}
+          </p>
+        </div>
+        <div className='flex items-center gap-2'>
+          {phase === 'running' ? (
+            <Button variant='outline' size='sm' onClick={stopProbe}>
+              <Spinner />
+              {t('sites.probe.stopButton')}
+            </Button>
+          ) : (
+            <Button variant='outline' size='sm' onClick={startProbe}>
+              <SearchIcon className='size-3.5' />
+              {t('sites.probe.runButton')}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {phase === 'running' && !hasRows && (
+        <p className='text-muted-foreground text-xs' aria-live='polite'>
+          {t('sites.probe.awaitingResults')}
+        </p>
+      )}
+
+      {phase === 'stopped' && (
+        <p className='text-muted-foreground text-xs' aria-live='polite'>
+          {t('sites.probe.stoppedNotice')}
+        </p>
+      )}
+
+      {phase === 'error' && (
+        <div
+          role='alert'
+          className='border-destructive/40 bg-destructive/10 text-destructive rounded-md border p-2 text-xs'
+        >
+          <p>
+            {t('sites.probe.errorMessage', {
+              message: errorMessage ?? '',
+            })}
+          </p>
+        </div>
+      )}
+
+      {summary && (
+        <p className='text-muted-foreground text-xs' aria-live='polite'>
+          {t('sites.probe.summary', {
+            total: summary.totalModels,
+            available: summary.available,
+            unavailable: summary.unavailable,
+          })}
+          {finishedAt
+            ? ` · ${t('sites.probe.finishedAt', {
+                time: formatRelativeTime(finishedAt, locale),
+              })}`
+            : ''}
+        </p>
+      )}
+
+      {summary?.truncated && (
+        <p
+          className='border-warning/40 bg-warning/10 rounded-md border p-2 text-xs'
+          role='alert'
+        >
+          {t('sites.probe.truncatedWarning', {
+            reason: summary.reason ?? t('sites.probe.truncatedNoReason'),
+          })}
+        </p>
+      )}
+
+      {phase !== 'running' && !hasRows && (
+        <p
+          className='text-muted-foreground rounded-md border border-dashed p-3 text-center text-xs'
+          aria-live='polite'
+        >
+          {t('sites.probe.empty')}
+        </p>
+      )}
+
+      {hasRows && (
+        <div className='overflow-x-auto rounded-md border'>
+          <table className='w-full text-xs'>
+            <thead className='bg-muted/50 text-left'>
+              <tr>
+                <th className='px-2 py-1.5 font-medium'>
+                  {t('sites.probe.colModel')}
+                </th>
+                <th className='px-2 py-1.5 font-medium'>
+                  {t('sites.probe.colStatus')}
+                </th>
+                <th className='px-2 py-1.5 text-right font-medium'>
+                  {t('sites.probe.colLatency')}
+                </th>
+                <th className='px-2 py-1.5 font-medium'>
+                  {t('sites.probe.colError')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((result) => {
+                const badge = statusBadgeFor(result.status)
+                return (
+                  <tr
+                    key={`${result.channelId}-${result.model}`}
+                    className='border-t'
+                  >
+                    <td className='px-2 py-1.5 break-all'>{result.model}</td>
+                    <td className='px-2 py-1.5'>
+                      <Badge variant={badge.variant}>{t(badge.key)}</Badge>
+                    </td>
+                    <td className='px-2 py-1.5 text-right tabular-nums'>
+                      {formatLatency(result.latencyMs, {
+                        autoSeconds: true,
+                        spaced: true,
+                      })}
+                    </td>
+                    <td
+                      className='text-muted-foreground max-w-40 px-2 py-1.5 break-words'
+                      title={result.error}
+                    >
+                      {result.error || '—'}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -146,7 +146,8 @@
       },
       "toolbar": {
         "searchPlaceholder": "Search models…",
-        "refresh": "Refresh"
+        "refresh": "Refresh",
+        "batchProbe": "Batch probe"
       },
       "detail": {
         "noDescription": "No description available.",
@@ -179,6 +180,34 @@
       "actions": {
         "viewDetails": "View details",
         "testModel": "Test model"
+      },
+      "verify": {
+        "title": "Batch availability probe",
+        "description": "Runs a synchronous probe pass over the enabled route channels (up to 50 targets) using the same lightweight checker as the background scheduler, then shows the honest per-target outcome.",
+        "modelLabel": "Model filter (optional)",
+        "modelPlaceholder": "gpt-4o, claude-sonnet-4 …",
+        "modelHint": "Leave empty to probe all enabled route channels; separate multiple models with commas or spaces.",
+        "runButton": "Run batch probe",
+        "runningLabel": "Probing…",
+        "errorMessage": "Batch probe failed: {{message}}",
+        "probedCount": "probed {{count}}",
+        "noRows": "No targets matched the filter.",
+        "summarySuccess": "Success",
+        "summaryFailure": "Failed",
+        "summaryInconclusive": "Inconclusive",
+        "summarySkipped": "Skipped",
+        "colModel": "Model",
+        "colSite": "Site",
+        "colStatus": "Status",
+        "colLatency": "Latency",
+        "colError": "Error",
+        "statusSuccess": "OK",
+        "statusFailure": "Failed",
+        "statusInconclusive": "Inconclusive",
+        "statusSkipped": "Skipped",
+        "viewHistory": "View history",
+        "hideHistory": "Hide history",
+        "historyLoadFailed": "Failed to load verification history: {{message}}"
       }
     },
     "modelTester": {
@@ -622,6 +651,27 @@
         "nextStepBody": "Connect an account to start routing through this site.",
         "dismiss": "Dismiss",
         "goToAccounts": "Go to accounts"
+      },
+      "probe": {
+        "title": "Availability probe",
+        "description": "Probes every enabled route channel on this site and shows the live per-model outcome.",
+        "runButton": "Run probe",
+        "stopButton": "Stop",
+        "awaitingResults": "Probe running — results stream in as each model finishes.",
+        "stoppedNotice": "Probe stopped — only the results received so far are shown.",
+        "empty": "No probe results yet. Run a probe to check the models available on this site.",
+        "summary": "Total {{total}} · available {{available}} · unavailable {{unavailable}}",
+        "finishedAt": "finished {{time}}",
+        "truncatedWarning": "Probe pass was cut short: {{reason}}",
+        "truncatedNoReason": "probe timeout or server limit reached before all targets were checked",
+        "errorMessage": "Probe failed: {{message}}",
+        "colModel": "Model",
+        "colStatus": "Status",
+        "colLatency": "Latency",
+        "colError": "Error",
+        "statusSuccess": "OK",
+        "statusFailure": "Failed",
+        "statusError": "Probe error"
       }
     },
     "dashboard": {
@@ -684,7 +734,17 @@
           "disabled": "disabled",
           "empty": "No scheduled jobs configured.",
           "loadError": "Failed to load scheduled tasks.",
-          "retry": "Retry"
+          "retry": "Retry",
+          "colActions": "Actions",
+          "triggerButton": "Run now",
+          "triggerQueued": "Model availability probe queued — recent runs appear here when the pass completes.",
+          "triggerFailed": "Trigger failed: {{message}}",
+          "latestRuns": "Recent runs",
+          "runsEmpty": "No completed probe passes yet.",
+          "runSuccess": "Completed",
+          "runFailed": "Failed",
+          "runTargets": "{{count}} targets",
+          "runCounts": "ok {{success}} / failed {{failed}} / inconclusive {{inconclusive}} / skipped {{skipped}}"
         }
       },
       "onboarding": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -146,7 +146,8 @@
       },
       "toolbar": {
         "searchPlaceholder": "搜索模型…",
-        "refresh": "刷新"
+        "refresh": "刷新",
+        "batchProbe": "批量探针"
       },
       "detail": {
         "noDescription": "暂无描述。",
@@ -179,6 +180,34 @@
       "actions": {
         "viewDetails": "查看详情",
         "testModel": "测试模型"
+      },
+      "verify": {
+        "title": "批量可用性探针",
+        "description": "对启用路由渠道（上限 50 个目标）执行一次同步探测，复用后台调度器同一套轻量检查，并展示每个目标的真实结果。",
+        "modelLabel": "模型过滤（可选）",
+        "modelPlaceholder": "gpt-4o、claude-sonnet-4 …",
+        "modelHint": "留空则探测全部启用路由渠道；多个模型用逗号或空格分隔。",
+        "runButton": "开始批量探针",
+        "runningLabel": "探测中…",
+        "errorMessage": "批量探针失败：{{message}}",
+        "probedCount": "已探测 {{count}}",
+        "noRows": "没有匹配过滤条件的目标。",
+        "summarySuccess": "成功",
+        "summaryFailure": "失败",
+        "summaryInconclusive": "不确定",
+        "summarySkipped": "跳过",
+        "colModel": "模型",
+        "colSite": "站点",
+        "colStatus": "状态",
+        "colLatency": "延迟",
+        "colError": "错误信息",
+        "statusSuccess": "可用",
+        "statusFailure": "失败",
+        "statusInconclusive": "不确定",
+        "statusSkipped": "跳过",
+        "viewHistory": "查看历史",
+        "hideHistory": "收起历史",
+        "historyLoadFailed": "加载验证历史失败：{{message}}"
       }
     },
     "modelTester": {
@@ -622,6 +651,27 @@
         "nextStepBody": "连接一个账号即可开始通过该站点路由。",
         "dismiss": "知道了",
         "goToAccounts": "前往账号"
+      },
+      "probe": {
+        "title": "可用性探针",
+        "description": "探测该站点所有启用路由渠道，实时展示每个模型的探测结果。",
+        "runButton": "开始探针",
+        "stopButton": "停止",
+        "awaitingResults": "探针运行中 —— 每个模型完成后结果实时流入。",
+        "stoppedNotice": "探针已停止 —— 仅显示已返回的结果。",
+        "empty": "暂无探针结果。运行一次探针以检查该站点可用的模型。",
+        "summary": "共 {{total}} · 可用 {{available}} · 不可用 {{unavailable}}",
+        "finishedAt": "完成于 {{time}}",
+        "truncatedWarning": "探针被提前截断：{{reason}}",
+        "truncatedNoReason": "未检查完所有目标即超出探测时限或服务端限制",
+        "errorMessage": "探针失败：{{message}}",
+        "colModel": "模型",
+        "colStatus": "状态",
+        "colLatency": "延迟",
+        "colError": "错误信息",
+        "statusSuccess": "可用",
+        "statusFailure": "失败",
+        "statusError": "探针错误"
       }
     },
     "dashboard": {
@@ -684,7 +734,17 @@
           "disabled": "已停用",
           "empty": "未配置定时任务。",
           "loadError": "加载定时任务失败。",
-          "retry": "重试"
+          "retry": "重试",
+          "colActions": "操作",
+          "triggerButton": "立即运行",
+          "triggerQueued": "模型可用性探测已排队 —— 运行完成后会在下方显示最近结果。",
+          "triggerFailed": "触发失败：{{message}}",
+          "latestRuns": "最近运行",
+          "runsEmpty": "暂无已完成的探测运行。",
+          "runSuccess": "完成",
+          "runFailed": "失败",
+          "runTargets": "{{count}} 个目标",
+          "runCounts": "成功 {{success}} / 失败 {{failed}} / 不确定 {{inconclusive}} / 跳过 {{skipped}}"
         }
       },
       "onboarding": {

--- a/web/src/lib/api/sites.ts
+++ b/web/src/lib/api/sites.ts
@@ -1,4 +1,40 @@
-import { request } from './transport'
+import { request, streamSse } from './transport'
+
+/**
+ * One model outcome from the site probe pass (probe-now / probe-stream).
+ * `status` mirrors the backend vocabulary honestly — 'error' is a probe
+ * machinery failure (target load error), not a success or a failure.
+ */
+export type SiteProbeResult = {
+  channelId: number
+  accountId: number
+  model: string
+  status: 'success' | 'failure' | 'error'
+  latencyMs: number
+  error?: string
+}
+
+/** Synchronous probe-now response (POST /api/sites/{id}/probe-now). */
+export type SiteProbeNowResponse = {
+  success: boolean
+  totalModels: number
+  available: number
+  unavailable: number
+  results: SiteProbeResult[]
+  /** False when the probe pass was aborted (timeout / client disconnect). */
+  complete: boolean
+  truncated?: boolean
+  reason?: string
+}
+
+/** Incremental probe-stream complete payload. */
+export type SiteProbeCompletePayload = {
+  totalModels: number
+  available: number
+  unavailable: number
+  truncated?: boolean
+  reason?: string
+}
 
 export const sitesApi = {
   // Sites
@@ -48,5 +84,32 @@ export const sitesApi = {
       method: 'POST',
       body: JSON.stringify(options || {}),
       timeoutMs: options?.scope === 'all' ? 120_000 : 30_000,
+    }) as Promise<SiteProbeNowResponse>,
+  /**
+   * Live probe pass (GET /api/sites/{id}/probe-stream, SSE). Each run of the
+   * stream performs its own probe pass; results arrive incrementally as
+   * `probe-result` events and finish with a `complete` event carrying the
+   * honest totals (including truncated + reason when the pass was cut short).
+   */
+  streamSiteProbe: (
+    siteId: number,
+    handlers: {
+      onStart?: () => void
+      onResult?: (result: SiteProbeResult) => void
+      onComplete?: (payload: SiteProbeCompletePayload) => void
+      signal?: AbortSignal
+    }
+  ) =>
+    streamSse(`/api/sites/${siteId}/probe-stream`, {
+      signal: handlers.signal,
+      onEvent: (event, payload) => {
+        if (event === 'probe-start') {
+          handlers.onStart?.()
+        } else if (event === 'probe-result') {
+          handlers.onResult?.(payload as SiteProbeResult)
+        } else if (event === 'complete') {
+          handlers.onComplete?.(payload as SiteProbeCompletePayload)
+        }
+      },
     }),
 }

--- a/web/src/lib/api/stats.ts
+++ b/web/src/lib/api/stats.ts
@@ -2,6 +2,7 @@
 import { request, buildQueryString } from './transport'
 import type {
   SchedulerRunStatus,
+  TriggerModelProbeResponse,
   ModelCostDistributionResponse,
   LatencyHistogramResponse,
   LatencyTrendResponse,
@@ -119,11 +120,26 @@ export const statsApi = {
     request(
       `/api/stats/latency-trend?days=${days}`
     ) as Promise<LatencyTrendResponse>,
+  // Model availability probe: queue a background scheduler pass. Results
+  // land in the scheduler-status recentRuns + model_probe_results history.
+  probeModelsNow: () =>
+    request('/api/models/probe', {
+      method: 'POST',
+      skipErrorHandler: true,
+    }) as Promise<TriggerModelProbeResponse>,
   // G1: batch model verification + history.
-  verifyModelsBatch: (models: string[], accountId = 0, limit = 50) =>
+  verifyModelsBatch: (
+    models: string[],
+    accountId = 0,
+    limit = 50,
+    // A large batch with the 15s per-probe ceiling can outgrow the 30s
+    // default; allow long-running verification passes.
+    timeoutMs = 180_000
+  ) =>
     request('/api/models/verify-batch', {
       method: 'POST',
       body: JSON.stringify({ models, accountId, limit }),
+      timeoutMs,
     }) as Promise<VerifyBatchResponse>,
   getModelVerifyHistory: (limit = 50, model = '') =>
     request(

--- a/web/src/lib/api/transport.ts
+++ b/web/src/lib/api/transport.ts
@@ -126,6 +126,12 @@ export async function streamSse(
   handlers: {
     onLog?: (entry: unknown) => void
     onDone?: (payload: unknown) => void
+    /**
+     * Fires for every parsed SSE event (the raw event name + payload), so
+     * callers with custom event vocabularies (e.g. probe-stream's
+     * probe-start / probe-result / complete) do not need a second reader.
+     */
+    onEvent?: (event: string, payload: unknown) => void
     signal?: AbortSignal
   }
 ) {
@@ -176,6 +182,7 @@ export async function streamSse(
         // keep string payload
       }
 
+      handlers.onEvent?.(eventName, payload)
       if (eventName === 'log') {
         handlers.onLog?.(payload)
       } else if (eventName === 'done') {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -41,6 +41,31 @@ export type SchedulerRunStatus = {
   runs24h: number
   success24h: number
   note?: string
+  /** Populated only for model-probe (in-memory ring buffer of recent passes). */
+  recentRuns?: SchedulerProbeRunSummary[]
+}
+
+/** One completed model-probe scheduler pass (in-memory ring buffer entry). */
+export type SchedulerProbeRunSummary = {
+  startedAt?: string
+  completedAt?: string
+  accountsConsidered: number
+  accountsProbed: number
+  targetsScanned: number
+  success: number
+  failed: number
+  inconclusive: number
+  skipped: number
+}
+
+/** POST /api/models/probe — queue a background availability probe pass. */
+export type TriggerModelProbeResponse = {
+  success: boolean
+  queued: boolean
+  reused: boolean
+  jobId: string
+  status: string
+  message?: string
 }
 
 // A2: model cost distribution + latency chart gallery.
@@ -94,7 +119,9 @@ export type LatencyTrendResponse = {
 }
 
 // G1: batch model verification + history.
-type ModelVerifyItem = {
+export type ModelVerifyItem = {
+  id?: number | null
+  batchId?: string
   model: string
   channelId?: number | null
   accountId?: number | null


### PR DESCRIPTION
## 概要

关闭 #558：探针能力产品化——后端运行历史 + 前端三处产品面（站点探针报告 / 调度器手动触发 / 模型批量探针）。

## 变更

### 后端（#558 基础）
- `scheduler/model_probe.go`：StartedAtMs + 最近 10 轮运行环形历史 + RecentRunSummaries（内存环，单实例诚实，重启即失——不伪装持久）
- `handler/admin/scheduler_status.go`：model-probe job 带 recentRuns
- 新测试 ×2

### 前端
- **站点探针报告**（site-detail-sheet 新 panel）：probe-stream SSE 实时增量（probe-start/result/complete）；failure 红标、machinery error 黄标 + 原文、truncated 原因横幅、停止后保留部分结果诚实标注；会话内按站点缓存
- **调度器集成**：dashboard scheduled-tasks 卡 model-probe 行「立即运行」（队列 toast + 延迟 refetch）+ recentRuns 展开（任一失败即整轮 Failed 诚实判定）；调度器 disabled 时隐藏触发
- **模型批量探针**：models 工具栏对话框，verify-batch 同步结果表（inconclusive/skipped 各自徽标，不伪装成功），503 原文呈现，可拉 verify-history
- transport.ts 补 streamSse onEvent 通用能力

## 测试

- vitest 全量 151 files / 999 tests 全过（新测试 13 + i18n parity 4）
- tsgo / oxlint / oxfmt ✓
- `go build` / `go vet` / `go test ./handler/admin/... -run Probe` + scheduler 新测试 ✓

## 已知边界

- 探针报告为会话内缓存；per-model probe 历史端点未暴露（超范围）；手动触发仅覆盖 model-probe job

Closes #558
