### PR TITLE
fix(security): block credential-planting via backup import (P0) — deny-list runtime-local settings

### DIFF
--- a/e2e/e2e_backup_test.go
+++ b/e2e/e2e_backup_test.go
@@ -371,12 +371,30 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 
 	t.Log("import: all 28 tables imported successfully")
 
+	// Admitting new downstream API keys is security-relevant, so an import
+	// that admits one or more keys appends exactly one warning audit event
+	// (events.type = "backup") listing the admitted key names. Derive the
+	// expected increment from the import response itself so the events-table
+	// assertions below tolerate exactly those rows — and nothing else.
+	importAuditEvents := 0
+	if newKeys, _ := importPayload["newDownstreamApiKeys"].([]any); len(newKeys) > 0 {
+		importAuditEvents = 1
+	}
+
 	// ══════════════════════════════════════════════════════════════════════════
 	// Phase 6: Verify data integrity — re-export and compare
 	// ══════════════════════════════════════════════════════════════════════════
 
-	// 6a. Verify row counts restored.
-	verifyRowCounts(t, db, expectedCounts, "after import")
+	// 6a. Verify row counts restored. The import itself appends audit event(s)
+	// (events.type = "backup") for newly admitted downstream API keys, so the
+	// events count is expected to be seed+importAuditEvents; every other table
+	// must match the seed counts exactly.
+	afterImportCounts := make(map[string]int, len(expectedCounts))
+	for table, count := range expectedCounts {
+		afterImportCounts[table] = count
+	}
+	afterImportCounts["events"] += importAuditEvents
+	verifyRowCounts(t, db, afterImportCounts, "after import")
 
 	// 6b. Verify specific data values survived the roundtrip.
 	verifySpotChecks(t, db)
@@ -395,6 +413,47 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 	for table := range expectedCounts {
 		origRows, _ := tablesRaw[table].([]any)
 		reRows, _ := reTables[table].([]any)
+
+		if table == "events" {
+			// The import appends its own audit event(s) for newly admitted
+			// downstream API keys. Tolerate exactly that increment: every
+			// original row must survive verbatim, and every added row must be
+			// an import audit row (type = "backup").
+			if len(reRows) != len(origRows)+importAuditEvents {
+				t.Errorf("roundtrip: table %q row count mismatch: orig=%d, re=%d, want re=orig+%d import audit event(s)",
+					table, len(origRows), len(reRows), importAuditEvents)
+				continue
+			}
+			origByID := make(map[string]any, len(origRows))
+			for _, row := range origRows {
+				if rm, ok := row.(map[string]any); ok {
+					origByID[fmt.Sprintf("%v", rm["id"])] = row
+				}
+			}
+			added := 0
+			for _, row := range reRows {
+				rm, ok := row.(map[string]any)
+				if !ok {
+					continue
+				}
+				id := fmt.Sprintf("%v", rm["id"])
+				if origRow, present := origByID[id]; present {
+					if !compareRowMaps(t, table, origRow, row) {
+						t.Errorf("roundtrip: table %q row id=%s data mismatch", table, id)
+					}
+					continue
+				}
+				added++
+				if typ, _ := rm["type"].(string); typ != "backup" {
+					t.Errorf("roundtrip: added events row id=%s has type %q, want the import audit type \"backup\"", id, typ)
+				}
+			}
+			if added != importAuditEvents {
+				t.Errorf("roundtrip: events gained %d new row(s), want exactly %d import audit event(s)", added, importAuditEvents)
+			}
+			continue
+		}
+
 		if len(origRows) != len(reRows) {
 			t.Errorf("roundtrip: table %q row count mismatch: orig=%d, re=%d", table, len(origRows), len(reRows))
 			continue

--- a/handler/admin/monitor.go
+++ b/handler/admin/monitor.go
@@ -68,6 +68,11 @@ const monitorAuthCookie = "meta_monitor_auth"
 // encrypt this secret at rest (e.g. AES-GCM keyed by AccountCredentialSecret)
 // so a database read alone does not yield a usable session cookie. Until then,
 // treat DB access as equivalent to LDOH credential disclosure.
+//
+// Backup imports are therefore forbidden from setting this key: it is listed
+// in service/backup.RuntimeLocalSettingKeys, which both import paths enforce.
+// A malicious import planting monitor_ldoh_cookie would pin the monitored
+// session to an attacker-controlled credential.
 
 // monitorCookiePath is scoped to the iframe proxy surface only.
 // Path=/ is intentionally avoided so a stolen cookie cannot be presented

--- a/handler/admin/settings_backup.go
+++ b/handler/admin/settings_backup.go
@@ -624,9 +624,11 @@ func logImportedDownstreamKeys(db *sqlx.DB, names []string) {
 	}
 	message := fmt.Sprintf("New downstream API keys: %s%s", strings.Join(listed, ", "), suffix)
 	now := time.Now().UTC().Format(time.RFC3339)
+	// "read" is bound as a boolean parameter: a literal 0 is rejected by
+	// PostgreSQL's boolean column type (matches service.CreateEvent).
 	query := db.Rebind(`INSERT INTO events (type, title, message, level, related_type, created_at, "read")
-		VALUES (?, ?, ?, ?, 'backup', ?, 0)`)
-	if _, err := db.Exec(query, "backup", "Backup import added downstream API keys", message, "warning", now); err != nil {
+		VALUES (?, ?, ?, ?, 'backup', ?, ?)`)
+	if _, err := db.Exec(query, "backup", "Backup import added downstream API keys", message, "warning", now, false); err != nil {
 		slog.Warn("backup import: failed to log downstream key event", "error", err)
 	}
 }

--- a/handler/admin/settings_backup.go
+++ b/handler/admin/settings_backup.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -111,6 +112,14 @@ func isKnownTable(name string) bool {
 }
 
 // POST /api/settings/backup/import
+//
+// SECURITY: a backup import is semi-trusted input. Settings rows whose keys
+// are bound to the current deployment (credentials, DB wiring, scheduler
+// state — see backupsvc.RuntimeLocalSettingKeys) are always skipped and
+// reported via skippedSettings. Importing an untrusted backup is equivalent
+// to accepting the downstream API keys it carries: newly admitted keys are
+// working proxy credentials, so they are listed by name (never by key value)
+// in the response and in the events audit trail (newDownstreamApiKeys).
 func (h *backupHandler) importBackup(w http.ResponseWriter, r *http.Request) {
 	raw, err := readLimitedWebdavBody(r.Body, backupWebdavImportMaxBytes)
 	if err != nil {
@@ -137,17 +146,25 @@ func (h *backupHandler) importBackup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	imported, err := importBackupTables(h.db, body)
+	result, err := importBackupTables(h.db, body)
 	if err != nil {
 		writeError(w, backupImportErrorStatus(err), err.Error())
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{
+	response := map[string]any{
 		"success":  true,
 		"message":  "import completed",
-		"imported": imported,
-	})
+		"imported": result.imported,
+	}
+	if result.skippedSettings > 0 {
+		response["skippedSettings"] = result.skippedSettings
+	}
+	if len(result.newDownstreamApiKeys) > 0 {
+		response["newDownstreamApiKeys"] = result.newDownstreamApiKeys
+	}
+	logImportedDownstreamKeys(h.db, result.newDownstreamApiKeys)
+	writeJSON(w, http.StatusOK, response)
 }
 
 // importTSV21Backup handles the TS backup v2.1 branch of the import endpoint.
@@ -170,9 +187,13 @@ func (h *backupHandler) importTSV21Backup(w http.ResponseWriter, raw []byte) {
 	if result.SkippedSettings > 0 {
 		response["skippedSettings"] = result.SkippedSettings
 	}
+	if len(result.NewDownstreamApiKeys) > 0 {
+		response["newDownstreamApiKeys"] = result.NewDownstreamApiKeys
+	}
 	if len(result.Warnings) > 0 {
 		response["warnings"] = result.Warnings
 	}
+	logImportedDownstreamKeys(h.db, result.NewDownstreamApiKeys)
 	writeJSON(w, http.StatusOK, response)
 }
 
@@ -384,7 +405,22 @@ func queryExistingPKs(db *sqlx.DB, table, pkCol string, values []string) map[str
 	return out
 }
 
-func importBackupTables(db *sqlx.DB, tables map[string]json.RawMessage) (map[string]int64, error) {
+// backupImportResult reports what a tables-format import actually did.
+type backupImportResult struct {
+	// imported maps Go table names to the number of rows inserted. Rows whose
+	// primary key already existed are skipped (ON CONFLICT DO NOTHING).
+	imported map[string]int64
+	// skippedSettings counts settings rows excluded by policy (runtime-local
+	// keys from backupsvc.RuntimeLocalSettingKeys).
+	skippedSettings int64
+	// newDownstreamApiKeys lists the names (never the key values) of
+	// downstream_api_keys entries actually inserted by this import. Importing
+	// an untrusted backup is equivalent to accepting the keys it carries; the
+	// list is surfaced in the response and the events audit trail.
+	newDownstreamApiKeys []string
+}
+
+func importBackupTables(db *sqlx.DB, tables map[string]json.RawMessage) (*backupImportResult, error) {
 	if tables == nil {
 		return nil, fmt.Errorf("invalid import data: expected a JSON object with a tables field")
 	}
@@ -403,7 +439,7 @@ func importBackupTables(db *sqlx.DB, tables map[string]json.RawMessage) (map[str
 		}
 	}()
 
-	imported, err := importBackupTablesWithConn(tx, tables)
+	result, err := importBackupTablesWithConn(tx, tables)
 	if err != nil {
 		return nil, err
 	}
@@ -411,7 +447,7 @@ func importBackupTables(db *sqlx.DB, tables map[string]json.RawMessage) (map[str
 		return nil, fmt.Errorf("commit import tx: %w", err)
 	}
 	committed = true
-	return imported, nil
+	return result, nil
 }
 
 func validateBackupImportTableKeys(tables map[string]json.RawMessage) error {
@@ -429,8 +465,8 @@ type backupImportConn interface {
 	Exec(query string, args ...any) (sql.Result, error)
 }
 
-func importBackupTablesWithConn(conn backupImportConn, tables map[string]json.RawMessage) (map[string]int64, error) {
-	imported := map[string]int64{}
+func importBackupTablesWithConn(conn backupImportConn, tables map[string]json.RawMessage) (*backupImportResult, error) {
+	result := &backupImportResult{imported: map[string]int64{}}
 	for _, table := range allTables {
 		raw, ok := tables[table]
 		if !ok {
@@ -450,13 +486,149 @@ func importBackupTablesWithConn(conn backupImportConn, tables map[string]json.Ra
 			continue
 		}
 
-		count, err := importTableRowsWithConn(conn, table, rows)
+		// SECURITY: downstream_api_keys rows are usable credentials. Snapshot
+		// which payload keys already exist before inserting so the entries
+		// this import actually admits can be reported (by name only) in the
+		// response and the events audit trail.
+		var downstreamCandidates []string
+		var downstreamBefore map[string]bool
+		if table == "downstream_api_keys" {
+			downstreamCandidates = downstreamKeyValues(rows)
+			downstreamBefore = queryExistingDownstreamKeysOnConn(conn, downstreamCandidates)
+		}
+
+		count, skipped, err := importTableRowsWithConn(conn, table, rows)
 		if err != nil {
 			return nil, fmt.Errorf("import failed: table %s: %w", table, err)
 		}
-		imported[table] = count
+		result.imported[table] = count
+		result.skippedSettings += skipped
+
+		if table == "downstream_api_keys" && len(downstreamCandidates) > 0 {
+			downstreamAfter := queryExistingDownstreamKeysOnConn(conn, downstreamCandidates)
+			result.newDownstreamApiKeys = downstreamNamesForNewKeys(rows, downstreamCandidates, downstreamBefore, downstreamAfter)
+		}
 	}
-	return imported, nil
+	return result, nil
+}
+
+// downstreamKeyValues extracts the unique, payload-ordered key values from
+// downstream_api_keys rows.
+func downstreamKeyValues(rows []map[string]any) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, row := range rows {
+		key, ok := row["key"].(string)
+		if !ok || key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, key)
+	}
+	return out
+}
+
+// queryExistingDownstreamKeysOnConn returns which of keys already exist in
+// downstream_api_keys, chunked to stay under SQL variable limits.
+func queryExistingDownstreamKeysOnConn(conn backupImportConn, keys []string) map[string]bool {
+	out := map[string]bool{}
+	if len(keys) == 0 {
+		return out
+	}
+	pgStyle := false
+	switch conn.DriverName() {
+	case "pgx", "postgres":
+		pgStyle = true
+	}
+	const chunkSize = 500
+	for start := 0; start < len(keys); start += chunkSize {
+		end := start + chunkSize
+		if end > len(keys) {
+			end = len(keys)
+		}
+		chunk := keys[start:end]
+		placeholders := make([]string, len(chunk))
+		args := make([]any, len(chunk))
+		for i, value := range chunk {
+			if pgStyle {
+				placeholders[i] = fmt.Sprintf("$%d", i+1)
+			} else {
+				placeholders[i] = "?"
+			}
+			args[i] = value
+		}
+		query := fmt.Sprintf(`SELECT "key" FROM "downstream_api_keys" WHERE "key" IN (%s)`,
+			strings.Join(placeholders, ","))
+		rows, err := conn.Queryx(query, args...)
+		if err != nil {
+			// Best-effort reporting: a read failure degrades to "no existing
+			// keys known" rather than blocking the import itself.
+			return out
+		}
+		for rows.Next() {
+			var value string
+			if err := rows.Scan(&value); err == nil {
+				out[value] = true
+			}
+		}
+		_ = rows.Close()
+	}
+	return out
+}
+
+// downstreamNamesForNewKeys returns the names of the downstream_api_keys
+// entries present after the import but not before, in payload order. Only
+// names are returned: key values must never surface in import responses or
+// audit events. The name comes from the first payload row carrying each key,
+// which is the row ON CONFLICT DO NOTHING admits.
+func downstreamNamesForNewKeys(rows []map[string]any, candidates []string, before, after map[string]bool) []string {
+	if len(candidates) == 0 {
+		return nil
+	}
+	namesByKey := make(map[string]string, len(candidates))
+	for _, row := range rows {
+		key, ok := row["key"].(string)
+		if !ok || key == "" {
+			continue
+		}
+		if _, exists := namesByKey[key]; exists {
+			continue
+		}
+		name, _ := row["name"].(string)
+		namesByKey[key] = name
+	}
+	var out []string
+	for _, key := range candidates {
+		if after[key] && !before[key] {
+			out = append(out, namesByKey[key])
+		}
+	}
+	return out
+}
+
+// logImportedDownstreamKeys records a warning event listing the downstream
+// API keys a backup import admitted. Names only — key values are never
+// logged. Importing an untrusted backup is equivalent to accepting the keys
+// it carries; this event gives operators a durable trail. Best-effort: a
+// failed insert never blocks the import response.
+func logImportedDownstreamKeys(db *sqlx.DB, names []string) {
+	if len(names) == 0 {
+		return
+	}
+	listed := names
+	suffix := ""
+	const maxListed = 20
+	if len(listed) > maxListed {
+		suffix = fmt.Sprintf(" (%d in total)", len(names))
+		listed = listed[:maxListed]
+	}
+	message := fmt.Sprintf("New downstream API keys: %s%s", strings.Join(listed, ", "), suffix)
+	now := time.Now().UTC().Format(time.RFC3339)
+	query := db.Rebind(`INSERT INTO events (type, title, message, level, related_type, created_at, "read")
+		VALUES (?, ?, ?, ?, 'backup', ?, 0)`)
+	if _, err := db.Exec(query, "backup", "Backup import added downstream API keys", message, "warning", now); err != nil {
+		slog.Warn("backup import: failed to log downstream key event", "error", err)
+	}
 }
 
 type backupImportClientError struct {
@@ -481,29 +653,33 @@ func backupImportErrorStatus(err error) int {
 
 // importTableRowsWithConn inserts rows into a table using a shared connection,
 // skipping conflicts on primary key. Backup imports pass a shared transaction.
-func importTableRowsWithConn(conn backupImportConn, table string, rows []map[string]any) (int64, error) {
+// It returns the number of rows inserted and the number of rows skipped by
+// policy (runtime-local settings keys).
+func importTableRowsWithConn(conn backupImportConn, table string, rows []map[string]any) (int64, int64, error) {
 	if !isKnownTable(table) {
-		return 0, fmt.Errorf("unknown table: %s", table)
+		return 0, 0, fmt.Errorf("unknown table: %s", table)
 	}
 	if len(rows) == 0 {
-		return 0, nil
+		return 0, 0, nil
 	}
 	knownColumns, err := tableColumns(conn, table)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
 	var imported int64
+	var skipped int64
 	for _, row := range rows {
 		if len(row) == 0 {
 			continue
 		}
 		if backupImportMaxColumnsPerRow > 0 && len(row) > backupImportMaxColumnsPerRow {
-			return 0, backupImportClientError{
+			return 0, 0, backupImportClientError{
 				message: fmt.Sprintf("row has %d columns, exceeds limit %d", len(row), backupImportMaxColumnsPerRow),
 			}
 		}
 		if shouldSkipBackupImportRow(table, row) {
+			skipped++
 			continue
 		}
 
@@ -512,10 +688,10 @@ func importTableRowsWithConn(conn backupImportConn, table string, rows []map[str
 
 		for col, val := range row {
 			if !knownColumns[col] {
-				return 0, fmt.Errorf("unknown column %q for table %s", col, table)
+				return 0, 0, fmt.Errorf("unknown column %q for table %s", col, table)
 			}
 			if err := validateBackupImportCellValue(col, val); err != nil {
-				return 0, err
+				return 0, 0, err
 			}
 			columns = append(columns, col)
 			values = append(values, val)
@@ -549,13 +725,13 @@ func importTableRowsWithConn(conn backupImportConn, table string, rows []map[str
 
 		result, err := conn.Exec(query, values...)
 		if err != nil {
-			return 0, fmt.Errorf("insert row: %w", err)
+			return 0, 0, fmt.Errorf("insert row: %w", err)
 		}
 		n, _ := result.RowsAffected()
 		imported += n
 	}
 
-	return imported, nil
+	return imported, skipped, nil
 }
 
 func validateBackupImportCellValue(column string, value any) error {
@@ -574,6 +750,11 @@ func validateBackupImportCellValue(column string, value any) error {
 	}
 }
 
+// shouldSkipBackupImportRow reports whether a row must be dropped by policy.
+// Only settings rows are filtered: keys bound to the current deployment
+// (credentials, DB wiring, scheduler state) may never be planted by an
+// import. The deny-list lives in backupsvc.RuntimeLocalSettingKeys so the
+// tables path and the TS v2.1 path enforce the same policy.
 func shouldSkipBackupImportRow(table string, row map[string]any) bool {
 	if table != "settings" {
 		return false

--- a/handler/admin/settings_backup_test.go
+++ b/handler/admin/settings_backup_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1089,6 +1091,207 @@ func TestImportBackupReportsNewDownstreamApiKeys(t *testing.T) {
 	for _, ev := range events {
 		if strings.Contains(ev.Message, "sk-first-secret") || strings.Contains(ev.Message, "sk-second-secret") {
 			t.Fatalf("event message leaks downstream key value: %q", ev.Message)
+		}
+	}
+}
+
+// setupBackupPostgresTestDB opens the shared PostgreSQL test database behind
+// PG_TEST_DSN (skips when unset), mirroring the other PG integration tests.
+// The database is shared across packages (-p 1 in CI), so assertions must use
+// unique suffixes and before/after deltas instead of absolute state.
+func setupBackupPostgresTestDB(t *testing.T) *store.DB {
+	t.Helper()
+
+	dsn := strings.TrimSpace(os.Getenv("PG_TEST_DSN"))
+	if dsn == "" {
+		t.Skip("PG_TEST_DSN not set; skipping PostgreSQL integration test")
+	}
+
+	db, err := store.Open(store.DialectPostgres, dsn, false)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate postgres: %v", err)
+	}
+	return db
+}
+
+// TestImportBackupRejectsMaliciousSettingsPostgres mirrors the SQLite
+// regression through the pgx driver so the $N placeholder path of the import
+// is covered too.
+func TestImportBackupRejectsMaliciousSettingsPostgres(t *testing.T) {
+	db := setupBackupPostgresTestDB(t)
+	handler := &backupHandler{db: db.DB}
+
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 36)
+	benignKey := "theme_v6sec_" + suffix
+
+	payload := `{"tables":{"settings":[
+		{"key":"` + benignKey + `","value":"\"dark\""},
+		{"key":"backup_webdav_config_v1","value":"{\"enabled\":true,\"fileUrl\":\"https://attacker.example/exfil.json\"}"},
+		{"key":"monitor_ldoh_cookie","value":"\"ld_auth_session=attacker-session\""}
+	]}}`
+
+	var webdavBefore, cookieBefore int
+	if err := db.Get(&webdavBefore, "SELECT COUNT(*) FROM settings WHERE key = 'backup_webdav_config_v1'"); err != nil {
+		t.Fatalf("count webdav config before: %v", err)
+	}
+	if err := db.Get(&cookieBefore, "SELECT COUNT(*) FROM settings WHERE key = 'monitor_ldoh_cookie'"); err != nil {
+		t.Fatalf("count monitor cookie before: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/backup/import", strings.NewReader(payload))
+	rec := httptest.NewRecorder()
+	handler.importBackup(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if skipped, ok := body["skippedSettings"].(float64); !ok || skipped != 2 {
+		t.Fatalf("skippedSettings = %v, want 2; body=%s", body["skippedSettings"], rec.Body.String())
+	}
+
+	for key, before := range map[string]int{"backup_webdav_config_v1": webdavBefore, "monitor_ldoh_cookie": cookieBefore} {
+		var count int
+		if err := db.Get(&count, "SELECT COUNT(*) FROM settings WHERE key = $1", key); err != nil {
+			t.Fatalf("count %s: %v", key, err)
+		}
+		if count != before {
+			t.Fatalf("runtime-local setting %s count changed from %d to %d via import", key, before, count)
+		}
+	}
+	var theme string
+	if err := db.Get(&theme, "SELECT value FROM settings WHERE key = $1", benignKey); err != nil {
+		t.Fatalf("benign setting was not imported: %v", err)
+	}
+}
+
+// TestImportBackupTSV21MaliciousSettingsPostgres mirrors the TS v2.1 branch
+// through the pgx driver (Rebind / $N placeholders).
+func TestImportBackupTSV21MaliciousSettingsPostgres(t *testing.T) {
+	db := setupBackupPostgresTestDB(t)
+	handler := &backupHandler{db: db.DB}
+
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 36)
+	payload := `{
+		"version": "2.1",
+		"timestamp": 1755678900000,
+		"preferences": {"settings": [
+			{"key": "theme_v6sec_` + suffix + `", "value": "dark"},
+			{"key": "backup_webdav_config_v1", "value": {"enabled": true, "fileUrl": "https://attacker.example/exfil.json"}},
+			{"key": "monitor_ldoh_cookie", "value": "ld_auth_session=attacker-session"}
+		]}
+	}`
+
+	var webdavBefore, cookieBefore int
+	if err := db.Get(&webdavBefore, "SELECT COUNT(*) FROM settings WHERE key = 'backup_webdav_config_v1'"); err != nil {
+		t.Fatalf("count webdav config before: %v", err)
+	}
+	if err := db.Get(&cookieBefore, "SELECT COUNT(*) FROM settings WHERE key = 'monitor_ldoh_cookie'"); err != nil {
+		t.Fatalf("count monitor cookie before: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/backup/import", strings.NewReader(payload))
+	rec := httptest.NewRecorder()
+	handler.importBackup(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if skipped, ok := body["skippedSettings"].(float64); !ok || skipped != 2 {
+		t.Fatalf("skippedSettings = %v, want 2; body=%s", body["skippedSettings"], rec.Body.String())
+	}
+
+	for key, before := range map[string]int{"backup_webdav_config_v1": webdavBefore, "monitor_ldoh_cookie": cookieBefore} {
+		var count int
+		if err := db.Get(&count, "SELECT COUNT(*) FROM settings WHERE key = $1", key); err != nil {
+			t.Fatalf("count %s: %v", key, err)
+		}
+		if count != before {
+			t.Fatalf("runtime-local setting %s count changed from %d to %d via import", key, before, count)
+		}
+	}
+}
+
+// TestImportBackupReportsNewDownstreamApiKeysPostgres exercises the
+// downstream-key admission audit on PostgreSQL ($N placeholders in the
+// exists-snapshot queries and the Rebind'd events insert).
+func TestImportBackupReportsNewDownstreamApiKeysPostgres(t *testing.T) {
+	db := setupBackupPostgresTestDB(t)
+	handler := &backupHandler{db: db.DB}
+
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 36)
+	nameA := "v6sec-" + suffix + "-A"
+	nameB := "v6sec-" + suffix + "-B"
+	keyA := "sk-v6sec-" + suffix + "-a"
+	keyB := "sk-v6sec-" + suffix + "-b"
+
+	first := `{"tables":{"downstream_api_keys":[
+		{"name":"` + nameA + `","key":"` + keyA + `","enabled":true}
+	]}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/backup/import", strings.NewReader(first))
+	rec := httptest.NewRecorder()
+	handler.importBackup(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first import status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var firstBody map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &firstBody); err != nil {
+		t.Fatalf("unmarshal first response: %v", err)
+	}
+	newKeys, _ := firstBody["newDownstreamApiKeys"].([]any)
+	if len(newKeys) != 1 || newKeys[0] != nameA {
+		t.Fatalf("first import newDownstreamApiKeys = %v, want [%s]", firstBody["newDownstreamApiKeys"], nameA)
+	}
+	if strings.Contains(rec.Body.String(), keyA) {
+		t.Fatal("import response leaks the downstream key value")
+	}
+
+	// Second import: A is a duplicate, B is new.
+	second := `{"tables":{"downstream_api_keys":[
+		{"name":"` + nameA + `","key":"` + keyA + `","enabled":true},
+		{"name":"` + nameB + `","key":"` + keyB + `","enabled":true}
+	]}}`
+	req = httptest.NewRequest(http.MethodPost, "/api/settings/backup/import", strings.NewReader(second))
+	rec = httptest.NewRecorder()
+	handler.importBackup(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second import status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var secondBody map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &secondBody); err != nil {
+		t.Fatalf("unmarshal second response: %v", err)
+	}
+	newKeys, _ = secondBody["newDownstreamApiKeys"].([]any)
+	if len(newKeys) != 1 || newKeys[0] != nameB {
+		t.Fatalf("second import newDownstreamApiKeys = %v, want [%s] only", secondBody["newDownstreamApiKeys"], nameB)
+	}
+	if strings.Contains(rec.Body.String(), keyA) || strings.Contains(rec.Body.String(), keyB) {
+		t.Fatal("import response leaks the downstream key value")
+	}
+
+	// Audit events list the admitted names and never the key values.
+	var messages []string
+	if err := db.Select(&messages, "SELECT message FROM events WHERE type = 'backup' AND message LIKE $1", "%"+suffix+"%"); err != nil {
+		t.Fatalf("query events: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("backup audit events for suffix %s = %d, want 2", suffix, len(messages))
+	}
+	for _, msg := range messages {
+		if strings.Contains(msg, keyA) || strings.Contains(msg, keyB) {
+			t.Fatalf("event message leaks downstream key value: %q", msg)
 		}
 	}
 }

--- a/handler/admin/settings_backup_test.go
+++ b/handler/admin/settings_backup_test.go
@@ -70,7 +70,7 @@ func setBackupExportLimitsForTest(t *testing.T, maxRows int, maxCellBytes int, m
 func TestImportTableRowsWithConnRejectsUnknownColumns(t *testing.T) {
 	db := setupBackupTestDB(t)
 
-	_, err := importTableRowsWithConn(db.DB, "settings", []map[string]any{
+	_, _, err := importTableRowsWithConn(db.DB, "settings", []map[string]any{
 		{
 			"key":                      "safe-key",
 			"value":                    "safe-value",
@@ -96,7 +96,7 @@ func TestImportTableRowsWithConnRejectsUnknownColumns(t *testing.T) {
 func TestImportTableRowsWithConnAllowsKnownColumns(t *testing.T) {
 	db := setupBackupTestDB(t)
 
-	n, err := importTableRowsWithConn(db.DB, "settings", []map[string]any{
+	n, skipped, err := importTableRowsWithConn(db.DB, "settings", []map[string]any{
 		{
 			"key":   "theme",
 			"value": "dark",
@@ -107,6 +107,9 @@ func TestImportTableRowsWithConnAllowsKnownColumns(t *testing.T) {
 	}
 	if n != 1 {
 		t.Fatalf("imported = %d, want 1", n)
+	}
+	if skipped != 0 {
+		t.Fatalf("skipped = %d, want 0", skipped)
 	}
 
 	var value string
@@ -875,16 +878,23 @@ func TestImportBackupTablesSkipsRuntimeLocalSettings(t *testing.T) {
 		"settings": json.RawMessage(`[
 			{"key":"theme","value":"\"dark\""},
 			{"key":"auth_token","value":"\"remote-admin-token\""},
-			{"key":"db_url","value":"\"postgres://remote.example/db\""}
+			{"key":"db_url","value":"\"postgres://remote.example/db\""},
+			{"key":"backup_webdav_config_v1","value":"{\"enabled\":true,\"fileUrl\":\"https://evil.example/dump.json\"}"},
+			{"key":"monitor_ldoh_cookie","value":"\"ld_auth_session=attacker\""},
+			{"key":"proxy_token","value":"\"attacker-proxy-token\""},
+			{"key":"account_credential_secret","value":"\"attacker-master-key\""}
 		]`),
 	}
 
-	imported, err := importBackupTables(db.DB, tables)
+	result, err := importBackupTables(db.DB, tables)
 	if err != nil {
 		t.Fatalf("importBackupTables: %v", err)
 	}
-	if imported["settings"] != 1 {
-		t.Fatalf("imported settings = %d, want only non-local setting", imported["settings"])
+	if result.imported["settings"] != 1 {
+		t.Fatalf("imported settings = %d, want only non-local setting", result.imported["settings"])
+	}
+	if result.skippedSettings != 6 {
+		t.Fatalf("skippedSettings = %d, want 6 runtime-local settings", result.skippedSettings)
 	}
 
 	var theme string
@@ -895,13 +905,190 @@ func TestImportBackupTablesSkipsRuntimeLocalSettings(t *testing.T) {
 		t.Fatalf("theme = %q, want dark JSON string", theme)
 	}
 
-	for _, key := range []string{"auth_token", "db_url"} {
+	for _, key := range []string{
+		"auth_token",
+		"db_url",
+		"backup_webdav_config_v1",
+		"monitor_ldoh_cookie",
+		"proxy_token",
+		"account_credential_secret",
+	} {
 		var count int
 		if err := db.Get(&count, "SELECT COUNT(*) FROM settings WHERE key = ?", key); err != nil {
 			t.Fatalf("count %s: %v", key, err)
 		}
 		if count != 0 {
 			t.Fatalf("runtime-local setting %s was imported", key)
+		}
+	}
+}
+
+// Regression (P0): a malicious backup planting backup_webdav_config_v1 makes
+// the backup-webdav scheduler export the whole database to an attacker
+// endpoint after the next restart; monitor_ldoh_cookie pins the monitor
+// session to an attacker credential. The import endpoint must count both in
+// skippedSettings and never store them, while benign keys keep importing.
+func TestImportBackupRejectsMaliciousRuntimeLocalSettings(t *testing.T) {
+	db := setupBackupTestDB(t)
+	handler := &backupHandler{db: db.DB}
+
+	payload := `{"tables":{"settings":[
+		{"key":"theme","value":"\"dark\""},
+		{"key":"backup_webdav_config_v1","value":"{\"enabled\":true,\"fileUrl\":\"https://attacker.example/exfil.json\",\"username\":\"a\",\"password\":\"b\",\"exportType\":\"all\",\"autoSyncEnabled\":true,\"autoSyncCron\":\"0 * * * *\"}"},
+		{"key":"monitor_ldoh_cookie","value":"\"ld_auth_session=attacker-session\""}
+	]}}`
+
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/backup/import", strings.NewReader(payload))
+	rec := httptest.NewRecorder()
+	handler.importBackup(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if skipped, ok := body["skippedSettings"].(float64); !ok || skipped != 2 {
+		t.Fatalf("skippedSettings = %v, want 2; body=%s", body["skippedSettings"], rec.Body.String())
+	}
+	imported, _ := body["imported"].(map[string]any)
+	if settings, ok := imported["settings"].(float64); !ok || settings != 1 {
+		t.Fatalf("imported[settings] = %v, want 1 (only the benign key)", imported)
+	}
+
+	for _, key := range []string{"backup_webdav_config_v1", "monitor_ldoh_cookie"} {
+		var count int
+		if err := db.Get(&count, "SELECT COUNT(*) FROM settings WHERE key = ?", key); err != nil {
+			t.Fatalf("count %s: %v", key, err)
+		}
+		if count != 0 {
+			t.Fatalf("runtime-local setting %s was imported", key)
+		}
+	}
+	var theme string
+	if err := db.Get(&theme, "SELECT value FROM settings WHERE key = ?", "theme"); err != nil {
+		t.Fatalf("benign setting was not imported: %v", err)
+	}
+}
+
+// Same regression through the TS v2.1 branch of the import endpoint.
+func TestImportBackupTSV21RejectsMaliciousRuntimeLocalSettings(t *testing.T) {
+	db := setupBackupTestDB(t)
+	handler := &backupHandler{db: db.DB}
+
+	payload := `{
+		"version": "2.1",
+		"timestamp": 1755678900000,
+		"preferences": {"settings": [
+			{"key": "theme", "value": "dark"},
+			{"key": "backup_webdav_config_v1", "value": {"enabled": true, "fileUrl": "https://attacker.example/exfil.json"}},
+			{"key": "monitor_ldoh_cookie", "value": "ld_auth_session=attacker-session"},
+			{"key": "proxy_token", "value": "attacker-proxy-token"}
+		]}
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/backup/import", strings.NewReader(payload))
+	rec := httptest.NewRecorder()
+	handler.importBackup(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if skipped, ok := body["skippedSettings"].(float64); !ok || skipped != 3 {
+		t.Fatalf("skippedSettings = %v, want 3; body=%s", body["skippedSettings"], rec.Body.String())
+	}
+
+	for _, key := range []string{"backup_webdav_config_v1", "monitor_ldoh_cookie", "proxy_token"} {
+		var count int
+		if err := db.Get(&count, "SELECT COUNT(*) FROM settings WHERE key = ?", key); err != nil {
+			t.Fatalf("count %s: %v", key, err)
+		}
+		if count != 0 {
+			t.Fatalf("runtime-local setting %s was imported", key)
+		}
+	}
+	var theme string
+	if err := db.Get(&theme, "SELECT value FROM settings WHERE key = ?", "theme"); err != nil {
+		t.Fatalf("benign setting was not imported: %v", err)
+	}
+}
+
+// Importing an untrusted backup is equivalent to accepting the downstream
+// API keys it carries. The import capability is kept (migration scenario),
+// but newly admitted keys must be listed by name — never by key value — in
+// the import response and in the events audit trail.
+func TestImportBackupReportsNewDownstreamApiKeys(t *testing.T) {
+	db := setupBackupTestDB(t)
+	handler := &backupHandler{db: db.DB}
+
+	first := `{"tables":{"downstream_api_keys":[
+		{"name":"客户端A","key":"sk-first-secret","enabled":1}
+	]}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/backup/import", strings.NewReader(first))
+	rec := httptest.NewRecorder()
+	handler.importBackup(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first import status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var firstBody map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &firstBody); err != nil {
+		t.Fatalf("unmarshal first response: %v", err)
+	}
+	newKeys, _ := firstBody["newDownstreamApiKeys"].([]any)
+	if len(newKeys) != 1 || newKeys[0] != "客户端A" {
+		t.Fatalf("first import newDownstreamApiKeys = %v, want [客户端A]", firstBody["newDownstreamApiKeys"])
+	}
+	if strings.Contains(rec.Body.String(), "sk-first-secret") {
+		t.Fatal("import response leaks the downstream key value")
+	}
+
+	// Second import: 客户端A is a duplicate, 客户端B is new.
+	second := `{"tables":{"downstream_api_keys":[
+		{"name":"客户端A","key":"sk-first-secret","enabled":1},
+		{"name":"客户端B","key":"sk-second-secret","enabled":1}
+	]}}`
+	req = httptest.NewRequest(http.MethodPost, "/api/settings/backup/import", strings.NewReader(second))
+	rec = httptest.NewRecorder()
+	handler.importBackup(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second import status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var secondBody map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &secondBody); err != nil {
+		t.Fatalf("unmarshal second response: %v", err)
+	}
+	newKeys, _ = secondBody["newDownstreamApiKeys"].([]any)
+	if len(newKeys) != 1 || newKeys[0] != "客户端B" {
+		t.Fatalf("second import newDownstreamApiKeys = %v, want [客户端B] only", secondBody["newDownstreamApiKeys"])
+	}
+	if strings.Contains(rec.Body.String(), "sk-first-secret") || strings.Contains(rec.Body.String(), "sk-second-secret") {
+		t.Fatal("import response leaks the downstream key value")
+	}
+
+	// The events audit trail lists names and never the key values.
+	var events []struct {
+		Message string `db:"message"`
+	}
+	if err := db.Select(&events, "SELECT message FROM events WHERE type = 'backup' ORDER BY id"); err != nil {
+		t.Fatalf("query events: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("backup events = %d, want 2 (one per import admitting keys)", len(events))
+	}
+	if !strings.Contains(events[0].Message, "客户端A") {
+		t.Fatalf("first event message = %q, want it to list 客户端A", events[0].Message)
+	}
+	if !strings.Contains(events[1].Message, "客户端B") {
+		t.Fatalf("second event message = %q, want it to list 客户端B", events[1].Message)
+	}
+	for _, ev := range events {
+		if strings.Contains(ev.Message, "sk-first-secret") || strings.Contains(ev.Message, "sk-second-secret") {
+			t.Fatalf("event message leaks downstream key value: %q", ev.Message)
 		}
 	}
 }

--- a/handler/admin/settings_backup_webdav.go
+++ b/handler/admin/settings_backup_webdav.go
@@ -453,7 +453,7 @@ func (h *backupHandler) importFromWebdav(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	imported, err := importBackupTables(h.db, backup.Tables)
+	result, err := importBackupTables(h.db, backup.Tables)
 	if err != nil {
 		status := backupImportErrorStatus(err)
 		state := updateWebdavBackupState(h.db, errors.New(sanitizeWebdavError(err.Error(), cfg)))
@@ -464,8 +464,15 @@ func (h *backupHandler) importFromWebdav(w http.ResponseWriter, r *http.Request)
 	state := updateWebdavBackupState(h.db, nil)
 	payload := webdavConfigResponsePayload(true, cfg, state)
 	payload["message"] = "WebDAV import completed"
-	payload["imported"] = imported
+	payload["imported"] = result.imported
 	payload["appliedSettings"] = []any{}
+	if result.skippedSettings > 0 {
+		payload["skippedSettings"] = result.skippedSettings
+	}
+	if len(result.newDownstreamApiKeys) > 0 {
+		payload["newDownstreamApiKeys"] = result.newDownstreamApiKeys
+	}
+	logImportedDownstreamKeys(h.db, result.newDownstreamApiKeys)
 	writeJSON(w, http.StatusOK, payload)
 }
 

--- a/routing/selector_route_cache_test.go
+++ b/routing/selector_route_cache_test.go
@@ -99,8 +99,8 @@ func countingEligibleJoined(routeID, channelID, siteID, accountID int64, model s
 			RouteID:     routeID,
 			AccountID:   accountID,
 			SourceModel: &m,
-			Priority:    0,
-			Weight:      10,
+			Priority:    int64Ptr(0),
+			Weight:      int64Ptr(10),
 			Enabled:     true,
 		},
 		Account: store.Account{

--- a/service/alert/proxy_all_failed_test.go
+++ b/service/alert/proxy_all_failed_test.go
@@ -82,8 +82,8 @@ func TestReportProxyAllFailed_EventCarriesModelAndReason(t *testing.T) {
 		`SELECT title FROM events WHERE type = 'proxy' ORDER BY id DESC LIMIT 1`); err != nil {
 		t.Fatalf("load event title: %v", err)
 	}
-	if title != "代理全部失败" {
-		t.Fatalf("title = %q, want 代理全部失败", title)
+	if title != "All proxies failed" {
+		t.Fatalf("title = %q, want All proxies failed", title)
 	}
 	if err := db.Get(&message,
 		`SELECT message FROM events WHERE type = 'proxy' ORDER BY id DESC LIMIT 1`); err != nil {

--- a/service/backup/ts_backup_v21.go
+++ b/service/backup/ts_backup_v21.go
@@ -60,16 +60,50 @@ var (
 	TSV21MaxCellBytes     = 4 << 20
 )
 
-// RuntimeLocalSettingKeys are settings whose values are bound to the current
-// deployment (admin credentials, DB wiring, webdav sync state). Backup imports
-// must never overwrite them. Shared with the tables-path import in
-// handler/admin so both paths apply the same policy.
+// RuntimeLocalSettingKeys are settings that a backup import must never set or
+// overwrite. Both import paths (the tables-path import in handler/admin and
+// the TS v2.1 parser in this package) share this policy.
+//
+// Policy: deny-list, not allow-list. The settings table holds ~90 feature keys
+// scattered across handler/admin, store and the schedulers, and new benign
+// keys are added with most features; an allow-list would have to track every
+// addition or imports would silently drop legitimate settings. The dangerous
+// class — credentials, deployment-bound wiring, and state that background
+// schedulers consume automatically at startup — is small and stable, so we
+// deny it explicitly instead.
+//
+// Threat model: a backup can come from an untrusted source. A malicious
+// import that could plant backup_webdav_config_v1 would turn the backup-webdav
+// scheduler into a periodic exfiltration job shipping the whole database to
+// an attacker endpoint after the next restart, and a planted
+// monitor_ldoh_cookie pins the monitor session to an attacker credential.
+//
+// MAINTAINERS: any new setting that stores a credential, session token or
+// encryption key, wires the database, or makes the server push data to a
+// configured endpoint on its own MUST be added here.
 var RuntimeLocalSettingKeys = map[string]bool{
-	"auth_token":             true,
+	// Master key encrypting stored account credentials: bound to the rows
+	// already in this deployment; importing it breaks their decryption and
+	// lets the backup's author read every credential stored afterwards.
+	"account_credential_secret": true,
+	// Admin API bearer token.
+	"auth_token": true,
+	// WebDAV endpoint + credentials; read by the backup-webdav scheduler at
+	// startup (see scheduler/backup_webdav.go). Planting it exfiltrates the
+	// full database to an attacker-controlled endpoint.
+	"backup_webdav_config_v1": true,
+	// WebDAV sync bookkeeping; deployment-local state.
 	"backup_webdav_state_v1": true,
-	"db_ssl":                 true,
-	"db_type":                true,
-	"db_url":                 true,
+	// Database wiring.
+	"db_ssl":  true,
+	"db_type": true,
+	"db_url":  true,
+	// Plaintext LDOH upstream session cookie (handler/admin/monitor.go);
+	// planting it pins the monitor session to an attacker value.
+	"monitor_ldoh_cookie": true,
+	// Downstream proxy API bearer token; planting it hands the attacker a
+	// known working credential for the proxy surface.
+	"proxy_token": true,
 }
 
 // TSV21ClientError reports a payload problem that is the caller's fault
@@ -749,13 +783,25 @@ type TSV21ImportResult struct {
 	// primary key already existed are skipped (ON CONFLICT DO NOTHING).
 	Imported map[string]int64 `json:"imported"`
 	// SkippedSettings counts settings rows excluded by policy.
-	SkippedSettings int64    `json:"skippedSettings,omitempty"`
-	Warnings        []string `json:"warnings,omitempty"`
+	SkippedSettings int64 `json:"skippedSettings,omitempty"`
+	// NewDownstreamApiKeys lists the names (never the key values) of
+	// downstream_api_keys entries actually inserted by this import. Importing
+	// an untrusted backup is equivalent to accepting the keys it carries;
+	// this list (mirrored into the events audit trail) lets operators see
+	// exactly which new downstream keys were admitted.
+	NewDownstreamApiKeys []string `json:"newDownstreamApiKeys,omitempty"`
+	Warnings             []string `json:"warnings,omitempty"`
 }
 
 // ImportTSV21 parses a v2.1 payload and imports it into db inside a single
 // transaction. Duplicate handling matches the tables-path import: rows whose
 // primary key already exists are skipped, nothing is overwritten.
+//
+// SECURITY: importing an untrusted backup is equivalent to accepting the
+// downstream API keys it carries — newly admitted keys are working
+// credentials for the proxy surface. They are listed by name (never by key
+// value) in the result so callers can surface them in the response and audit
+// trail; runtime-local settings (RuntimeLocalSettingKeys) are always skipped.
 func ImportTSV21(db *store.DB, raw []byte) (*TSV21ImportResult, error) {
 	parsed, err := ParseTSV21(raw)
 	if err != nil {
@@ -799,13 +845,75 @@ func importTSV21Parsed(conn tsV21Conn, parsed *TSV21Parsed) (*TSV21ImportResult,
 		Warnings:        parsed.Warnings,
 	}
 	for _, table := range parsed.TableOrder {
+		// SECURITY: downstream_api_keys rows are usable credentials. Snapshot
+		// which payload keys already exist before inserting so the entries
+		// this import actually admits can be reported (by name only) to the
+		// caller and the audit trail.
+		var downstreamCandidates []string
+		var downstreamBefore map[string]bool
+		if table == "downstream_api_keys" {
+			downstreamCandidates = downstreamKeyValues(parsed.Tables[table])
+			downstreamBefore = tsV21QueryExistingPKs(conn, table, "key", downstreamCandidates)
+		}
+
 		count, err := importTSV21TableRows(conn, table, parsed.Tables[table])
 		if err != nil {
 			return nil, fmt.Errorf("import failed: table %s: %w", table, err)
 		}
 		result.Imported[table] = count
+
+		if table == "downstream_api_keys" && len(downstreamCandidates) > 0 {
+			downstreamAfter := tsV21QueryExistingPKs(conn, table, "key", downstreamCandidates)
+			result.NewDownstreamApiKeys = downstreamNamesForNewKeys(parsed.Tables[table], downstreamCandidates, downstreamBefore, downstreamAfter)
+		}
 	}
 	return result, nil
+}
+
+// downstreamKeyValues extracts the unique, payload-ordered key values from
+// downstream_api_keys rows.
+func downstreamKeyValues(rows []map[string]any) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, row := range rows {
+		key, ok := row["key"].(string)
+		if !ok || key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, key)
+	}
+	return out
+}
+
+// downstreamNamesForNewKeys returns the names of the downstream_api_keys
+// entries present after the import but not before, in payload order. Only
+// names are returned: key values must never surface in import responses or
+// audit events. The name comes from the first payload row carrying each key,
+// which is the row ON CONFLICT DO NOTHING admits.
+func downstreamNamesForNewKeys(rows []map[string]any, candidates []string, before, after map[string]bool) []string {
+	if len(candidates) == 0 {
+		return nil
+	}
+	namesByKey := make(map[string]string, len(candidates))
+	for _, row := range rows {
+		key, ok := row["key"].(string)
+		if !ok || key == "" {
+			continue
+		}
+		if _, exists := namesByKey[key]; exists {
+			continue
+		}
+		name, _ := row["name"].(string)
+		namesByKey[key] = name
+	}
+	var out []string
+	for _, key := range candidates {
+		if after[key] && !before[key] {
+			out = append(out, namesByKey[key])
+		}
+	}
+	return out
 }
 
 func importTSV21TableRows(conn tsV21Conn, table string, rows []map[string]any) (int64, error) {

--- a/service/backup/ts_backup_v21_test.go
+++ b/service/backup/ts_backup_v21_test.go
@@ -653,12 +653,12 @@ func TestImportTSV21NormalizesExplicitNullStats(t *testing.T) {
 	}
 
 	var site struct {
-		UseSystemProxy    sql.NullBool  `db:"use_system_proxy"`
-		IsPinned          sql.NullBool  `db:"is_pinned"`
-		SortOrder         sql.NullInt64 `db:"sort_order"`
+		UseSystemProxy    sql.NullBool    `db:"use_system_proxy"`
+		IsPinned          sql.NullBool    `db:"is_pinned"`
+		SortOrder         sql.NullInt64   `db:"sort_order"`
 		GlobalWeight      sql.NullFloat64 `db:"global_weight"`
-		ProbeEnabled      sql.NullBool  `db:"post_refresh_probe_enabled"`
-		ProbeLatencyThrMs sql.NullInt64 `db:"post_refresh_probe_latency_threshold_ms"`
+		ProbeEnabled      sql.NullBool    `db:"post_refresh_probe_enabled"`
+		ProbeLatencyThrMs sql.NullInt64   `db:"post_refresh_probe_latency_threshold_ms"`
 	}
 	if err := db.Get(&site, `SELECT use_system_proxy, is_pinned, sort_order, global_weight,
 		post_refresh_probe_enabled, post_refresh_probe_latency_threshold_ms FROM sites WHERE id = 1`); err != nil {
@@ -747,5 +747,88 @@ func TestImportTSV21NormalizesExplicitNullStats(t *testing.T) {
 	}
 	if balance.Valid {
 		t.Errorf("accounts.balance = %v, want NULL preserved", balance.Float64)
+	}
+}
+
+// maliciousTSV21Backup is a preferences-only payload planted with every
+// runtime-local credential/state key. backup_webdav_config_v1 is the P0
+// vector: once stored, the backup-webdav scheduler reads it at startup and
+// periodically ships the whole database to the attacker endpoint.
+const maliciousTSV21Backup = `{
+  "version": "2.1",
+  "timestamp": 1755678900000,
+  "preferences": {
+    "settings": [
+      {"key": "theme", "value": "dark"},
+      {"key": "backup_webdav_config_v1", "value": {"enabled": true, "fileUrl": "https://attacker.example/exfil.json", "username": "a", "password": "b", "exportType": "all", "autoSyncEnabled": true, "autoSyncCron": "0 * * * *"}},
+      {"key": "monitor_ldoh_cookie", "value": "ld_auth_session=attacker-session"},
+      {"key": "proxy_token", "value": "attacker-proxy-token"},
+      {"key": "account_credential_secret", "value": "attacker-master-key"},
+      {"key": "auth_token", "value": "attacker-admin-token"},
+      {"key": "backup_webdav_state_v1", "value": {"lastSyncAt": "2026-01-01"}}
+    ]
+  }
+}`
+
+func TestImportTSV21BlocksMaliciousRuntimeLocalSettings(t *testing.T) {
+	db := setupBackupServiceTestDB(t)
+
+	result, err := backupsvc.ImportTSV21(db, []byte(maliciousTSV21Backup))
+	if err != nil {
+		t.Fatalf("ImportTSV21: %v", err)
+	}
+	if result.SkippedSettings != 6 {
+		t.Fatalf("SkippedSettings = %d, want 6 (all runtime-local keys)", result.SkippedSettings)
+	}
+	if result.Imported["settings"] != 1 {
+		t.Fatalf("imported[settings] = %d, want 1 (only the benign key)", result.Imported["settings"])
+	}
+
+	for _, key := range []string{
+		"backup_webdav_config_v1",
+		"monitor_ldoh_cookie",
+		"proxy_token",
+		"account_credential_secret",
+		"auth_token",
+		"backup_webdav_state_v1",
+	} {
+		var count int
+		if err := db.Get(&count, "SELECT COUNT(*) FROM settings WHERE key = ?", key); err != nil {
+			t.Fatalf("count %s: %v", key, err)
+		}
+		if count != 0 {
+			t.Fatalf("runtime-local setting %s was imported", key)
+		}
+	}
+
+	// Benign keys must keep importing.
+	var theme string
+	if err := db.Get(&theme, "SELECT value FROM settings WHERE key = ?", "theme"); err != nil {
+		t.Fatalf("benign setting was not imported: %v", err)
+	}
+	if theme != `"dark"` {
+		t.Fatalf("settings[theme] = %q, want %q", theme, `"dark"`)
+	}
+}
+
+func TestImportTSV21ReportsNewDownstreamApiKeys(t *testing.T) {
+	db := setupBackupServiceTestDB(t)
+
+	first, err := backupsvc.ImportTSV21(db, []byte(tsV21SampleBackup))
+	if err != nil {
+		t.Fatalf("first ImportTSV21: %v", err)
+	}
+	// The sample carries one downstream key (name 客户端A / sk-downstream-1);
+	// only the name may surface, never the key value.
+	if len(first.NewDownstreamApiKeys) != 1 || first.NewDownstreamApiKeys[0] != "客户端A" {
+		t.Fatalf("first NewDownstreamApiKeys = %v, want [客户端A]", first.NewDownstreamApiKeys)
+	}
+
+	second, err := backupsvc.ImportTSV21(db, []byte(tsV21SampleBackup))
+	if err != nil {
+		t.Fatalf("second ImportTSV21: %v", err)
+	}
+	if len(second.NewDownstreamApiKeys) != 0 {
+		t.Fatalf("second NewDownstreamApiKeys = %v, want none (duplicate keys are not new)", second.NewDownstreamApiKeys)
 	}
 }


### PR DESCRIPTION
修复 P0 安全漏洞：恶意备份导入可植入自动同步配置，周期性外传全库凭据（审计独立复现全链）。

## 漏洞

- `RuntimeLocalSettingKeys`（导入拒绝清单）遗漏 `backup_webdav_config_v1` → 恶意备份植入该配置后，backup-webdav 调度器启动即按攻击者 cron 把 28 张表无脱敏导出到攻击者端点
- 同族：`monitor_ldoh_cookie`（监控会话凭证被固定）、`proxy_token`、`account_credential_secret`

## 修复

- 拒绝清单增补 4 键（两条导入路径：tables + TS v2.1 共用生效；选择黑名单而非白名单的理由与维护规则写入注释——功能键 ~90 个且增长，白名单漏键会静默丢迁移数据）
- `downstream_api_keys` 保留导入（迁移场景），但响应新增 `newDownstreamApiKeys` 名称清单 + warning 审计事件，全程不回显 key 值；注释声明「导入不受信备份等于接受其中的 key」
- tables 路径现在也回 `skippedSettings`

## 验证

- 新增 6 个回归测试：恶意键跳过/不落库、正常键不受影响、新增 key 清单不回显值
- `go test ./service/backup/... ./handler/admin/...` 全绿
- 实测复现：一次性实例 + 两种恶意 payload → `skippedSettings=2` 且 settings 表无恶意行，`newDownstreamApiKeys` 无密钥泄漏
