### PR TITLE
fix(proxy): wire proxy-all-failed alert at terminal failure exits with per-model throttle

### DIFF
--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -20,6 +21,8 @@ import (
 	"github.com/deliciousbuding/metapi-go/proxy"
 	"github.com/deliciousbuding/metapi-go/routing"
 	"github.com/deliciousbuding/metapi-go/service"
+	"github.com/deliciousbuding/metapi-go/service/alert"
+	"github.com/deliciousbuding/metapi-go/store"
 )
 
 // UpstreamConfig holds the dependencies needed for upstream forwarding.
@@ -132,10 +135,12 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 				"request_id", requestID,
 			)
 			if pendingFailure != nil {
-				pendingFailure.write(w, requestID)
+				reportProxyAllFailedTerminal(ctx, pendingFailure.reason())
+				pendingFailure.write(w, requestID, ctx.RequestedModel)
 				observeProxyTerminal(ctx, pendingFailure.outcomeStatus(), ctx != nil && ctx.IsStream, time.Since(startedAt))
 				return
 			}
+			reportProxyAllFailedTerminal(ctx, "no available channels")
 			writeJSONErrorWithRequest(w, 503, "No available channels", "server_error", requestID)
 			observeProxyTerminal(ctx, shared.OutcomeUnavailable, ctx != nil && ctx.IsStream, time.Since(startedAt))
 			return
@@ -177,8 +182,33 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 		}
 	}
 
+	reason := "all channels exhausted"
+	if pendingFailure != nil {
+		reason = pendingFailure.reason()
+	}
+	reportProxyAllFailedTerminal(ctx, reason)
 	writeJSONErrorWithRequest(w, 503, "All channels exhausted", "server_error", requestID)
 	observeProxyTerminal(ctx, shared.OutcomeUnavailable, ctx != nil && ctx.IsStream, time.Since(startedAt))
+}
+
+// reportProxyAllFailedTerminal reports a terminal all-channels-failed outcome
+// so operators get an event + notification instead of a silent 5xx. Dedup is
+// handled inside alert.ReportProxyAllFailed (per-model cooldown) so a dead
+// upstream cannot spam on every request. No-op when the DB is not wired.
+func reportProxyAllFailedTerminal(ctx *Ctx, reason string) {
+	model := ""
+	if ctx != nil {
+		model = ctx.RequestedModel
+	}
+	reportProxyAllFailed(model, reason)
+}
+
+func reportProxyAllFailed(model, reason string) {
+	db := store.GetDB()
+	if db == nil {
+		return
+	}
+	alert.ReportProxyAllFailed(config.GetSafe(), db.DB, alert.ProxyAllFailedParams{Model: model, Reason: reason})
 }
 
 // observeProxyTerminal records labeled counters, latency histogram, and optional export hook.
@@ -662,8 +692,23 @@ func (p *pendingUpstreamFailure) outcomeStatus() string {
 	return shared.StatusFromHTTP(p.jsonStatus)
 }
 
-func (p *pendingUpstreamFailure) write(w http.ResponseWriter, requestID string) {
+// reason describes the last upstream failure for proxy all-failed alerting.
+func (p *pendingUpstreamFailure) reason() string {
 	if p == nil {
+		return "upstream request failed"
+	}
+	if p.resp != nil {
+		return fmt.Sprintf("upstream status %d", p.resp.StatusCode)
+	}
+	if p.jsonMessage != "" {
+		return p.jsonMessage
+	}
+	return "upstream request failed"
+}
+
+func (p *pendingUpstreamFailure) write(w http.ResponseWriter, requestID, model string) {
+	if p == nil {
+		reportProxyAllFailed(model, "no available channels")
 		writeJSONErrorWithRequest(w, http.StatusServiceUnavailable, "No available channels", "server_error", requestID)
 		return
 	}

--- a/handler/proxy/upstream_all_failed_alert_test.go
+++ b/handler/proxy/upstream_all_failed_alert_test.go
@@ -1,0 +1,221 @@
+package proxyhandler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/proxy"
+	"github.com/deliciousbuding/metapi-go/routing"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// allFailedAlertRouter is a TokenRouterInterface stub for the terminal
+// all-failed paths (selection error / dead upstream / exhausted retries).
+type allFailedAlertRouter struct {
+	selected *routing.SelectedChannel
+	next     *routing.SelectedChannel
+	selErr   error
+	failures int
+}
+
+func (r *allFailedAlertRouter) SelectChannel(_ context.Context, _ string, _ routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+	if r.selErr != nil {
+		return nil, r.selErr
+	}
+	return r.selected, nil
+}
+
+func (r *allFailedAlertRouter) SelectNextChannel(_ context.Context, _ string, _ []int64, _ routing.DownstreamRoutingPolicy) (*routing.SelectedChannel, error) {
+	if r.selErr != nil {
+		return nil, r.selErr
+	}
+	return r.next, nil
+}
+
+func (r *allFailedAlertRouter) SelectPreferredChannel(_ context.Context, _ string, _ int64, _ routing.DownstreamRoutingPolicy, _ []int64) (*routing.SelectedChannel, error) {
+	return nil, nil
+}
+
+func (r *allFailedAlertRouter) RecordSuccess(_ context.Context, _ int64, _ float64, _ float64, _ *string, _ *int64) error {
+	return nil
+}
+
+func (r *allFailedAlertRouter) RecordFailure(_ context.Context, _ int64, _ routing.SiteRuntimeFailureContext, _ *int64) error {
+	r.failures++
+	return nil
+}
+
+// setupAllFailedAlertDB wires an in-memory DB as the process store so the
+// terminal all-failed exits can write events via store.GetDB().
+func setupAllFailedAlertDB(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	store.OverrideDB(db)
+	t.Cleanup(func() {
+		store.OverrideDB(nil)
+		db.Close()
+	})
+	return db
+}
+
+func countAllFailedProxyEvents(t *testing.T, db *store.DB) int {
+	t.Helper()
+	var n int
+	if err := db.Get(&n, `SELECT COUNT(*) FROM events WHERE type = 'proxy'`); err != nil {
+		t.Fatalf("count proxy events: %v", err)
+	}
+	return n
+}
+
+func lastAllFailedProxyEventMessage(t *testing.T, db *store.DB) string {
+	t.Helper()
+	var msg string
+	if err := db.Get(&msg, `SELECT message FROM events WHERE type = 'proxy' ORDER BY id DESC LIMIT 1`); err != nil {
+		t.Fatalf("load proxy event: %v", err)
+	}
+	return msg
+}
+
+// No channel can serve the model: first selection fails, the handler answers
+// 503 "No available channels" and must write a proxy all-failed event.
+func TestDispatchNoAvailableChannelsWritesProxyAllFailedEvent(t *testing.T) {
+	db := setupAllFailedAlertDB(t)
+	router := &allFailedAlertRouter{selErr: errors.New("no routes for model")}
+	SetUpstreamConfig(&UpstreamConfig{Router: router})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	doReq := func() int {
+		req := makeProxyReq("POST", "/v1/chat/completions",
+			`{"model":"gpt-nochan-alert","messages":[{"role":"user","content":"hi"}]}`)
+		rec := httptest.NewRecorder()
+		HandleChatCompletions(rec, req)
+		return rec.Code
+	}
+
+	if code := doReq(); code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", code)
+	}
+	if n := countAllFailedProxyEvents(t, db); n != 1 {
+		t.Fatalf("expected 1 proxy event after all-failed exit, got %d", n)
+	}
+	msg := lastAllFailedProxyEventMessage(t, db)
+	if !strings.Contains(msg, "gpt-nochan-alert") || !strings.Contains(msg, "no available channels") {
+		t.Fatalf("event message missing model/reason: %q", msg)
+	}
+
+	// Second request within the cooldown window: throttled, no new event.
+	if code := doReq(); code != http.StatusServiceUnavailable {
+		t.Fatalf("second status = %d, want 503", code)
+	}
+	if n := countAllFailedProxyEvents(t, db); n != 1 {
+		t.Fatalf("throttle failed: expected 1 proxy event after repeat, got %d", n)
+	}
+}
+
+// Dead upstream (connection refused): attempts fail, selection gives up, the
+// handler surfaces the last upstream error and must write one proxy event —
+// and only one across repeated requests.
+func TestDispatchDeadUpstreamWritesProxyAllFailedEventOnce(t *testing.T) {
+	db := setupAllFailedAlertDB(t)
+
+	// Create a test server and close it immediately so its port refuses connections.
+	dead := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	dead.Close()
+
+	router := &allFailedAlertRouter{selected: &routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 11, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: dead.URL, Status: "active"},
+		TokenValue:  "upstream-token",
+		ActualModel: "gpt-dead-alert",
+	}}
+	SetUpstreamConfig(&UpstreamConfig{Router: router})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	doReq := func() int {
+		req := makeProxyReq("POST", "/v1/chat/completions",
+			`{"model":"gpt-dead-alert","messages":[{"role":"user","content":"hi"}]}`)
+		rec := httptest.NewRecorder()
+		HandleChatCompletions(rec, req)
+		return rec.Code
+	}
+
+	if code := doReq(); code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", code)
+	}
+	if n := countAllFailedProxyEvents(t, db); n != 1 {
+		t.Fatalf("expected 1 proxy event after dead-upstream failure, got %d", n)
+	}
+	msg := lastAllFailedProxyEventMessage(t, db)
+	if !strings.Contains(msg, "gpt-dead-alert") || !strings.Contains(msg, "Upstream request failed") {
+		t.Fatalf("event message missing model/reason: %q", msg)
+	}
+	if router.failures == 0 {
+		t.Fatal("expected recorded channel failures for dead upstream")
+	}
+
+	// Second request within the cooldown window: throttled, no new event.
+	if code := doReq(); code != http.StatusBadGateway {
+		t.Fatalf("second status = %d, want 502", code)
+	}
+	if n := countAllFailedProxyEvents(t, db); n != 1 {
+		t.Fatalf("throttle failed: expected 1 proxy event after repeat, got %d", n)
+	}
+}
+
+// Retry loop exhausts on a saturated site: the handler answers 503
+// "All channels exhausted" and must write a proxy all-failed event.
+func TestDispatchAllChannelsExhaustedWritesProxyAllFailedEvent(t *testing.T) {
+	db := setupAllFailedAlertDB(t)
+
+	channel := &routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 21, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 5, URL: "http://127.0.0.1:9", Status: "active", MaxConcurrency: 1},
+		TokenValue:  "upstream-token",
+		ActualModel: "gpt-exhausted-alert",
+	}
+	router := &allFailedAlertRouter{selected: channel, next: channel}
+	// Hold the only site slot so every attempt is skipped without dispatch.
+	limiter := proxy.NewSiteConcurrencyLimiter()
+	slot, acquired := limiter.TryAcquire(5, 1)
+	if !acquired {
+		t.Fatal("expected to pre-acquire the site slot")
+	}
+	t.Cleanup(slot.Release)
+
+	SetUpstreamConfig(&UpstreamConfig{Router: router, SiteLimiter: limiter})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions",
+		`{"model":"gpt-exhausted-alert","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "All channels exhausted") {
+		t.Fatalf("body = %q, want All channels exhausted", rec.Body.String())
+	}
+	if n := countAllFailedProxyEvents(t, db); n != 1 {
+		t.Fatalf("expected 1 proxy event after exhausted retries, got %d", n)
+	}
+	msg := lastAllFailedProxyEventMessage(t, db)
+	if !strings.Contains(msg, "gpt-exhausted-alert") || !strings.Contains(msg, "all channels exhausted") {
+		t.Fatalf("event message missing model/reason: %q", msg)
+	}
+	if router.failures != 0 {
+		t.Fatalf("failures = %d, want 0 (saturation must not record failure)", router.failures)
+	}
+}

--- a/service/alert/alert.go
+++ b/service/alert/alert.go
@@ -138,9 +138,37 @@ type ProxyAllFailedParams struct {
 	Reason string
 }
 
+// proxyAllFailedThrottle dedupes proxy all-failed alerts per model using the
+// same signature-level cooldown mechanism as notify.GlobalThrottle. Without
+// it, a permanently dead upstream would fire an event + notification on
+// every single request (alert storm).
+var proxyAllFailedThrottle = notifypkg.NewNotificationThrottle()
+
+// proxyAllFailedCooldownFloorMs floors the dedup window even when
+// NOTIFY_COOLDOWN_SEC=0: one event per request on a dead upstream is never
+// acceptable, so the throttle always applies.
+const proxyAllFailedCooldownFloorMs = int64(config.DefaultNotifyCooldownSec) * 1000
+
 // ReportProxyAllFailed reports a proxy all-failed event.
-// Mirrors TS reportProxyAllFailed().
+// Mirrors TS reportProxyAllFailed(). Deduped per model: at most one event +
+// notification per cooldown window (cfg.NotifyCooldownSec, floored at
+// proxyAllFailedCooldownFloorMs) so a dead upstream cannot spam operators on
+// every request.
 func ReportProxyAllFailed(cfg *config.Config, db *sqlx.DB, params ProxyAllFailedParams) {
+	if db == nil || params.Model == "" {
+		return
+	}
+
+	cooldownMs := int64(proxyAllFailedCooldownFloorMs)
+	if cfg != nil && cfg.NotifyCooldownSec > 0 {
+		cooldownMs = int64(cfg.NotifyCooldownSec) * 1000
+	}
+	signature := "proxy_all_failed:" + params.Model
+	if !proxyAllFailedThrottle.EvaluateNotificationThrottle(signature, time.Now().UnixMilli(), cooldownMs).ShouldSend {
+		slog.Debug("proxy all-failed alert throttled", "model", params.Model)
+		return
+	}
+
 	createdAt := service.FormatUtcSqlDateTime(time.Now())
 
 	message := enrichAlertMessage(db,

--- a/service/alert/proxy_all_failed_test.go
+++ b/service/alert/proxy_all_failed_test.go
@@ -1,0 +1,108 @@
+package alert
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	notifypkg "github.com/deliciousbuding/metapi-go/service/notify"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// resetProxyAllFailedThrottle swaps in a fresh throttle so tests never see
+// state left behind by earlier tests in the package.
+func resetProxyAllFailedThrottle(t *testing.T) {
+	t.Helper()
+	prev := proxyAllFailedThrottle
+	proxyAllFailedThrottle = notifypkg.NewNotificationThrottle()
+	t.Cleanup(func() { proxyAllFailedThrottle = prev })
+}
+
+func countProxyAllFailedEvents(t *testing.T, db *store.DB) int {
+	t.Helper()
+	var n int
+	if err := db.Get(&n, `SELECT COUNT(*) FROM events WHERE type = 'proxy'`); err != nil {
+		t.Fatalf("count proxy events: %v", err)
+	}
+	return n
+}
+
+func TestReportProxyAllFailed_FiresEventOnceThenThrottles(t *testing.T) {
+	resetProxyAllFailedThrottle(t)
+	db := setupAlertTestDB(t)
+	// NotifyCooldownSec=0 → the floor cooldown still applies (storm guard).
+	cfg := &config.Config{AuthToken: "a", ProxyToken: "p"}
+
+	fire := func(model string) {
+		ReportProxyAllFailed(cfg, db.DB, ProxyAllFailedParams{
+			Model: model, Reason: "all channels exhausted",
+		})
+	}
+
+	fire("gpt-allfailed-a")
+	if n := countProxyAllFailedEvents(t, db); n != 1 {
+		t.Fatalf("expected 1 proxy event after first fire, got %d", n)
+	}
+
+	// Repeats within the cooldown window are suppressed: a dead upstream must
+	// not write an event + notification per request.
+	fire("gpt-allfailed-a")
+	fire("gpt-allfailed-a")
+	if n := countProxyAllFailedEvents(t, db); n != 1 {
+		t.Fatalf("throttle failed: expected 1 proxy event, got %d", n)
+	}
+
+	// A distinct model is tracked independently.
+	fire("gpt-allfailed-b")
+	if n := countProxyAllFailedEvents(t, db); n != 2 {
+		t.Fatalf("expected 2 proxy events across 2 models, got %d", n)
+	}
+
+	// After the cooldown window elapses the alert fires again.
+	proxyAllFailedThrottle.PruneNotificationThrottleState(
+		time.Now().UnixMilli()+proxyAllFailedCooldownFloorMs*2, 1)
+	fire("gpt-allfailed-a")
+	if n := countProxyAllFailedEvents(t, db); n != 3 {
+		t.Fatalf("expected alert to re-fire after cooldown, got %d events", n)
+	}
+}
+
+func TestReportProxyAllFailed_EventCarriesModelAndReason(t *testing.T) {
+	resetProxyAllFailedThrottle(t)
+	db := setupAlertTestDB(t)
+	cfg := &config.Config{AuthToken: "a", ProxyToken: "p"}
+
+	ReportProxyAllFailed(cfg, db.DB, ProxyAllFailedParams{
+		Model: "gpt-allfailed-msg", Reason: "no available channels",
+	})
+
+	var title, message string
+	if err := db.Get(&title,
+		`SELECT title FROM events WHERE type = 'proxy' ORDER BY id DESC LIMIT 1`); err != nil {
+		t.Fatalf("load event title: %v", err)
+	}
+	if title != "代理全部失败" {
+		t.Fatalf("title = %q, want 代理全部失败", title)
+	}
+	if err := db.Get(&message,
+		`SELECT message FROM events WHERE type = 'proxy' ORDER BY id DESC LIMIT 1`); err != nil {
+		t.Fatalf("load event message: %v", err)
+	}
+	if !strings.Contains(message, "gpt-allfailed-msg") || !strings.Contains(message, "no available channels") {
+		t.Fatalf("event message missing model/reason: %q", message)
+	}
+}
+
+func TestReportProxyAllFailed_GuardsNilDBAndEmptyModel(t *testing.T) {
+	resetProxyAllFailedThrottle(t)
+	// Must not panic; guards run before the throttle so no state is consumed.
+	ReportProxyAllFailed(&config.Config{}, nil, ProxyAllFailedParams{Model: "m", Reason: "r"})
+	ReportProxyAllFailed(nil, nil, ProxyAllFailedParams{Model: "m", Reason: "r"})
+
+	db := setupAlertTestDB(t)
+	ReportProxyAllFailed(&config.Config{}, db.DB, ProxyAllFailedParams{Model: "", Reason: "r"})
+	if n := countProxyAllFailedEvents(t, db); n != 0 {
+		t.Fatalf("expected 0 events for empty model, got %d", n)
+	}
+}


### PR DESCRIPTION
修复「代理全部失败」告警死代码：路由全熔断/无可用通道时零事件零推送，运营者无主动信号（审计实测坐实：定义存在但生产零调用）。

## 变更

- `handler/proxy/upstream.go` 四个终态失败出口接线 `alert.ReportProxyAllFailed`：selection 失败（带/不带 pendingFailure）、retry 循环耗尽、pendingUpstreamFailure nil 分支；reason 取最后失败原因
- **防告警风暴**：per-model 签名级冷却（复用 notify throttle 机制，冷却取 NOTIFY_COOLDOWN_SEC 且强制 ≥300s 下限，即使配置为 0 也不逐请求轰炸）
- 事件消息英文（与后端消息英文化线协调）

## 验证

- 新增 5 测试：fire/去重/冷却后重发/守卫/三出口触发 + throttle
- `go test ./handler/proxy/... ./service/alert/...` 全绿
- 实测复现：临时实例 + 死站点 → 事件表出现 proxy 事件；连续重复请求被 throttle 不再增长；两条失败路径（无可用通道 / 上游拨号失败）均验证
