### PR TITLE
perf(proxy): zero-copy model swap + single-pass stream body rewrite

### DIFF
--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -294,6 +294,11 @@ func dispatchSelectedUpstream(
 	}
 
 	candidatePaths := resolveUpstreamCandidatePaths(upstreamPath, disableCrossProtocolFallback, sitePref)
+	// The shared body pre-scan for the stream rewrite is deferred until a
+	// candidate actually needs it, so surfaces without stream gates (embeddings,
+	// images, ...) keep the zero-body-touch path.
+	var streamHints bodyStreamHints
+	hintsReady := false
 	var lastPending *pendingUpstreamFailure
 	for i, path := range candidatePaths {
 		isLast := i >= len(candidatePaths)-1
@@ -304,11 +309,31 @@ func dispatchSelectedUpstream(
 			observeProxyTerminal(ctx, shared.OutcomeClientError, false, 0)
 			return true, nil
 		}
-		// Force stream=true for responses-only / stream-preferring sites (and codex/sub2api).
-		attemptBody, forcedStream := applyUpstreamStreamPreference(attemptBody, selected.Site.Platform, path, sitePref)
+		// Single-pass stream forcing + include_usage inject (replaces two full
+		// map[string]any decode/re-encode rounds per candidate path).
+		forceStream, injectUsage := upstreamStreamRewriteGates(selected.Site.Platform, path, sitePref)
+		var forcedStream, expectStreamUsage bool
+		if forceStream || injectUsage {
+			if !hintsReady {
+				// Shared pre-scan: all candidate paths reuse one look over the payload.
+				streamHints = scanBodyStreamHints(bodyBytes)
+				hintsReady = true
+			}
+			attemptHints := streamHints
+			if !sameByteSlice(attemptBody, bodyBytes) {
+				// Sanitize rewrote the body for this candidate; rescan it.
+				attemptHints = scanBodyStreamHints(attemptBody)
+			}
+			rewritten, forced, expect, rewriteOK := rewriteUpstreamStreamFlags(attemptBody, attemptHints, forceStream, ctx.IsStream, injectUsage)
+			if rewriteOK {
+				attemptBody, forcedStream, expectStreamUsage = rewritten, forced, expect
+			} else {
+				// Irregular body: keep exact legacy decode semantics.
+				attemptBody, forcedStream = applyUpstreamStreamPreference(attemptBody, selected.Site.Platform, path, sitePref)
+				attemptBody, expectStreamUsage = applyUpstreamStreamIncludeUsage(attemptBody, selected.Site.Platform, path, ctx.IsStream || forcedStream)
+			}
+		}
 		effectiveStream := ctx.IsStream || forcedStream
-		// OpenAI chat stream: ensure final SSE usage chunk via stream_options.include_usage (known limitation).
-		attemptBody, expectStreamUsage := applyUpstreamStreamIncludeUsage(attemptBody, selected.Site.Platform, path, effectiveStream)
 		finished, pending, cont := dispatchEndpointAttemptWithContinue(
 			w, r, ctx, cfg, selected, upstreamModel, proxyConfig,
 			path, contentType, attemptBody, firstByteTimeoutMs,
@@ -887,23 +912,48 @@ func relayBufferedUpstreamResponse(w http.ResponseWriter, resp *http.Response, b
 	_, _ = w.Write(bodyBytes)
 }
 
-// sanitizeUpstreamJSONBody applies Responses continuity/compact/reasoning-input
-// sanitization and official Gemini tool-history thoughtSignature inject for one
-// upstream attempt. Chat/messages candidates strip previous_response_id;
-// Responses platforms forward or strip per SupportsResponsesPreviousResponseID.
-// Multi-turn reasoning items get required content preserved/injected
-//. Native Gemini generateContent bodies (and gemini-cli
-// request envelopes) get NormalizeRequest / OpenAI→Gemini rebuild so functionCall
-// parts carry thoughtSignature.
-//
-// and
-//
+// swapModelInJSON rewrites the top-level "model" field of a JSON request body
+// to upstreamModel for one upstream attempt. The dominant no-mapping case (the
+// selected channel serves the requested model) short-circuits via an
+// allocation-free top-level scan and returns the original bytes untouched; a
+// real model_mapping splices only the model value span, keeping the rest of
+// the payload byte-identical. Irregular bodies fall back to the legacy
+// shallow re-encode (legacySwapModelInJSON).
 func swapModelInJSON(bodyBytes []byte, upstreamModel string) []byte {
 	if len(bodyBytes) == 0 {
 		// Empty body: synthesize a minimal JSON object with only the model field.
 		modelJSON, _ := json.Marshal(upstreamModel)
 		return append(append([]byte(`{"model":`), modelJSON...), '}')
 	}
+	s, found, ok := findTopLevelValue(bodyBytes, "model")
+	if ok {
+		if found {
+			if spanStringEquals(bodyBytes, s, upstreamModel) {
+				// Zero-copy short-circuit: the body already carries the target
+				// model (the no-mapping norm); no rewrite, no allocation.
+				return bodyBytes
+			}
+			// Real model_mapping: splice only the model value, keep the rest of
+			// the payload byte-identical.
+			modelJSON, _ := json.Marshal(upstreamModel)
+			return replaceSpan(bodyBytes, s, string(modelJSON))
+		}
+		// Clean object without a top-level model key (e.g. Gemini path-model
+		// bodies): insert it as the first entry. The scan above proves no
+		// escaped-key "model" hiding at the top level.
+		openIdx, empty, bracesOK := objectBraces(bodyBytes)
+		if bracesOK {
+			modelJSON, _ := json.Marshal(upstreamModel)
+			return insertTopLevelEntry(bodyBytes, openIdx, `"model":`+string(modelJSON), empty)
+		}
+	}
+	// Irregular body: exact legacy shallow re-encode semantics.
+	return legacySwapModelInJSON(bodyBytes, upstreamModel)
+}
+
+// legacySwapModelInJSON is the original shallow re-encode kept for irregular
+// bodies the allocation-free scanner declines to edit.
+func legacySwapModelInJSON(bodyBytes []byte, upstreamModel string) []byte {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(bodyBytes, &raw); err != nil {
 		// Body is already validated in PrepareCtx; fallback to original bytes.

--- a/handler/proxy/upstream_body_bench_test.go
+++ b/handler/proxy/upstream_body_bench_test.go
@@ -1,0 +1,79 @@
+package proxyhandler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/proxy"
+)
+
+// benchBuildChatBody returns a syntactically valid streaming chat/completions
+// JSON body of approximately size bytes (model first, large messages array).
+func benchBuildChatBody(size int) []byte {
+	content := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 6)
+	msg := `{"role":"user","content":"` + content + `"},`
+	var sb strings.Builder
+	sb.WriteString(`{"model":"gpt-4o","stream":true,"messages":[`)
+	for sb.Len() < size {
+		sb.WriteString(msg)
+	}
+	s := strings.TrimSuffix(sb.String(), ",")
+	s += `],"temperature":0.7}`
+	return []byte(s)
+}
+
+var benchSizes = map[string]int{"2KB": 2 << 10, "200KB": 200 << 10, "2MB": 2 << 20}
+
+// BenchmarkSwapModelInJSON_NoMapping covers the dominant production case: the
+// selected channel does not remap the model, so the body already carries the
+// target model value.
+func BenchmarkSwapModelInJSON_NoMapping(b *testing.B) {
+	for _, name := range []string{"2KB", "200KB", "2MB"} {
+		body := benchBuildChatBody(benchSizes[name])
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(body)))
+			for i := 0; i < b.N; i++ {
+				_ = swapModelInJSON(body, "gpt-4o")
+			}
+		})
+	}
+}
+
+// BenchmarkSwapModelInJSON_Mapped covers real model_mapping: the upstream model
+// differs from the body's model and a rewrite is unavoidable.
+func BenchmarkSwapModelInJSON_Mapped(b *testing.B) {
+	for _, name := range []string{"2KB", "200KB", "2MB"} {
+		body := benchBuildChatBody(benchSizes[name])
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(body)))
+			for i := 0; i < b.N; i++ {
+				_ = swapModelInJSON(body, "gpt-4o-2024-11-20")
+			}
+		})
+	}
+}
+
+// BenchmarkUpstreamBodyPipeline_NoMapping mirrors the per-attempt body
+// construction of dispatchSelectedUpstream for a streaming chat request with no
+// model mapping: model swap, responses/continuity sanitize gate, site stream
+// preference, and include_usage injection.
+func BenchmarkUpstreamBodyPipeline_NoMapping(b *testing.B) {
+	for _, name := range []string{"2KB", "200KB", "2MB"} {
+		body := benchBuildChatBody(benchSizes[name])
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(body)))
+			for i := 0; i < b.N; i++ {
+				swapped := swapModelInJSON(body, "gpt-4o")
+				sanitized, err := sanitizeUpstreamJSONBody(swapped, "openai", "/v1/chat/completions", "gpt-4o")
+				if err != nil {
+					b.Fatal(err)
+				}
+				streamed, _ := applyUpstreamStreamPreference(sanitized, "openai", "/v1/chat/completions", proxy.SiteProtocolPreference{})
+				_, _ = applyUpstreamStreamIncludeUsage(streamed, "openai", "/v1/chat/completions", true)
+			}
+		})
+	}
+}

--- a/handler/proxy/upstream_body_rewrite.go
+++ b/handler/proxy/upstream_body_rewrite.go
@@ -1,0 +1,512 @@
+package proxyhandler
+
+import (
+	"bytes"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Allocation-free top-level JSON object editing for the proxy hot path.
+//
+// Every proxied request used to pay two or three full decode/re-encode rounds
+// over the request body (model swap, stream forcing, include_usage inject),
+// each unmarshalling the whole payload into map[string]any or
+// map[string]json.RawMessage and marshalling it back. The hot path only ever
+// needs to inspect or patch a handful of TOP-LEVEL keys ("model", "stream",
+// "stream_options"), so a depth- and escape-aware byte scan can answer those
+// questions and splice the bytes directly, touching each payload byte once and
+// allocating only the (single) rewritten output.
+//
+// All scan routines are fail-safe: on any irregularity (malformed structure,
+// escaped top-level key, non-object body) they report failure and callers fall
+// back to the legacy full-decode implementation, preserving exact semantics.
+// Known limitation: duplicate top-level keys resolve to the FIRST occurrence
+// here while encoding/json keeps the last; duplicate top-level keys are not
+// emitted by any known client and RFC 8259 leaves their handling undefined.
+// ---------------------------------------------------------------------------
+
+// jsonSpan is a [start, end) byte range inside a request body.
+type jsonSpan struct{ start, end int }
+
+// Pre-allocated key markers keep the hot-path scans allocation-free.
+var (
+	streamKeyMarker  = []byte(`"stream"`)
+	streamOptsMarker = []byte(`"stream_options"`)
+)
+
+// containsLongMarker is a drop-in bytes.Contains replacement that stays on
+// the SIMD-accelerated bytes.Index fast path for needles longer than 8 bytes
+// (bytes.Index drops long needles to the slow Rabin-Karp fallback). The 8-byte
+// prefix locates candidates; the full needle is verified at each rare hit.
+func containsLongMarker(body, needle []byte) bool {
+	if len(needle) <= 8 {
+		return bytes.Contains(body, needle)
+	}
+	prefix := needle[:8]
+	rest := body
+	for {
+		i := bytes.Index(rest, prefix)
+		if i < 0 {
+			return false
+		}
+		if i+len(needle) <= len(rest) && bytes.Equal(rest[i:i+len(needle)], needle) {
+			return true
+		}
+		rest = rest[i+1:]
+	}
+}
+
+func isJSONSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+// bytesEqualString compares b to s without allocating.
+func bytesEqualString(b []byte, s string) bool {
+	if len(b) != len(s) {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if b[i] != s[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// skipJSONString advances *i past the JSON string starting at body[*i]=='"'.
+func skipJSONString(body []byte, i *int) bool {
+	j := *i + 1
+	for j < len(body) {
+		switch body[j] {
+		case '\\':
+			j += 2
+		case '"':
+			*i = j + 1
+			return true
+		default:
+			j++
+		}
+	}
+	return false
+}
+
+func skipJSONLiteral(body []byte, i *int, lit string) bool {
+	end := *i + len(lit)
+	if end > len(body) {
+		return false
+	}
+	for k := 0; k < len(lit); k++ {
+		if body[*i+k] != lit[k] {
+			return false
+		}
+	}
+	*i = end
+	return true
+}
+
+func skipJSONNumber(body []byte, i *int) bool {
+	j := *i
+	if j < len(body) && body[j] == '-' {
+		j++
+	}
+	digits := 0
+	for j < len(body) && body[j] >= '0' && body[j] <= '9' {
+		j++
+		digits++
+	}
+	if digits == 0 {
+		return false
+	}
+	if j < len(body) && body[j] == '.' {
+		j++
+		frac := 0
+		for j < len(body) && body[j] >= '0' && body[j] <= '9' {
+			j++
+			frac++
+		}
+		if frac == 0 {
+			return false
+		}
+	}
+	if j < len(body) && (body[j] == 'e' || body[j] == 'E') {
+		j++
+		if j < len(body) && (body[j] == '+' || body[j] == '-') {
+			j++
+		}
+		exp := 0
+		for j < len(body) && body[j] >= '0' && body[j] <= '9' {
+			j++
+			exp++
+		}
+		if exp == 0 {
+			return false
+		}
+	}
+	*i = j
+	return true
+}
+
+// skipJSONContainer advances *i past one balanced {...} or [...] container
+// starting at body[*i], ignoring delimiters inside strings.
+func skipJSONContainer(body []byte, i *int) bool {
+	depth := 0
+	j := *i
+	for j < len(body) {
+		switch body[j] {
+		case '"':
+			if !skipJSONString(body, &j) {
+				return false
+			}
+			continue
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+			if depth == 0 {
+				*i = j + 1
+				return true
+			}
+		}
+		j++
+	}
+	return false
+}
+
+// skipJSONValue advances *i past one JSON value starting at body[*i].
+func skipJSONValue(body []byte, i *int) bool {
+	if *i >= len(body) {
+		return false
+	}
+	switch body[*i] {
+	case '"':
+		return skipJSONString(body, i)
+	case '{', '[':
+		return skipJSONContainer(body, i)
+	case 't':
+		return skipJSONLiteral(body, i, "true")
+	case 'f':
+		return skipJSONLiteral(body, i, "false")
+	case 'n':
+		return skipJSONLiteral(body, i, "null")
+	case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		return skipJSONNumber(body, i)
+	}
+	return false
+}
+
+// findTopLevelValue locates the first top-level occurrence of key in the JSON
+// object body and returns its value span. found=false when the object is clean
+// but lacks the key. ok=false when the body is not a cleanly scannable
+// top-level JSON object (malformed, non-object, trailing garbage, or an
+// escaped top-level key that byte comparison cannot resolve); callers must
+// then use the legacy full-decode behavior for exact semantics.
+func findTopLevelValue(body []byte, key string) (s jsonSpan, found, ok bool) {
+	i := 0
+	for i < len(body) && isJSONSpace(body[i]) {
+		i++
+	}
+	if i >= len(body) || body[i] != '{' {
+		return jsonSpan{}, false, false
+	}
+	i++
+	for {
+		for i < len(body) && isJSONSpace(body[i]) {
+			i++
+		}
+		if i >= len(body) {
+			return jsonSpan{}, false, false
+		}
+		if body[i] == '}' {
+			return jsonSpan{}, found, trailingWhitespaceOnly(body, i+1)
+		}
+		if body[i] != '"' {
+			return jsonSpan{}, false, false
+		}
+		keyStart := i + 1
+		if !skipJSONString(body, &i) {
+			return jsonSpan{}, false, false
+		}
+		keyEnd := i - 1
+		escaped := false
+		for k := keyStart; k < keyEnd; k++ {
+			if body[k] == '\\' {
+				escaped = true
+				break
+			}
+		}
+		for i < len(body) && isJSONSpace(body[i]) {
+			i++
+		}
+		if i >= len(body) || body[i] != ':' {
+			return jsonSpan{}, false, false
+		}
+		i++
+		for i < len(body) && isJSONSpace(body[i]) {
+			i++
+		}
+		vStart := i
+		if !skipJSONValue(body, &i) {
+			return jsonSpan{}, false, false
+		}
+		if escaped {
+			return jsonSpan{}, false, false
+		}
+		if bytesEqualString(body[keyStart:keyEnd], key) {
+			return jsonSpan{vStart, i}, true, true
+		}
+		for i < len(body) && isJSONSpace(body[i]) {
+			i++
+		}
+		if i >= len(body) {
+			return jsonSpan{}, false, false
+		}
+		if body[i] == ',' {
+			i++
+			continue
+		}
+		if body[i] == '}' {
+			return jsonSpan{}, found, trailingWhitespaceOnly(body, i+1)
+		}
+		return jsonSpan{}, false, false
+	}
+}
+
+func trailingWhitespaceOnly(body []byte, from int) bool {
+	for k := from; k < len(body); k++ {
+		if !isJSONSpace(body[k]) {
+			return false
+		}
+	}
+	return true
+}
+
+// objectBraces validates that body is framed as a single top-level JSON
+// object ({...} with optional surrounding whitespace) and returns the opening
+// brace index and whether the object is empty.
+func objectBraces(body []byte) (openIdx int, empty, ok bool) {
+	i := 0
+	for i < len(body) && isJSONSpace(body[i]) {
+		i++
+	}
+	if i >= len(body) || body[i] != '{' {
+		return 0, false, false
+	}
+	openIdx = i
+	j := len(body) - 1
+	for j > i && isJSONSpace(body[j]) {
+		j--
+	}
+	if j <= i || body[j] != '}' {
+		return 0, false, false
+	}
+	empty = true
+	for k := i + 1; k < j; k++ {
+		if !isJSONSpace(body[k]) {
+			empty = false
+			break
+		}
+	}
+	return openIdx, empty, true
+}
+
+// spanStringEquals reports whether the span holds the JSON string "want"
+// encoded without escape sequences.
+func spanStringEquals(body []byte, s jsonSpan, want string) bool {
+	v := body[s.start:s.end]
+	if len(v) != len(want)+2 || v[0] != '"' || v[len(v)-1] != '"' {
+		return false
+	}
+	return bytesEqualString(v[1:len(v)-1], want)
+}
+
+// spanIsObject reports whether the value span starts a JSON object.
+func spanIsObject(body []byte, s jsonSpan) bool {
+	for k := s.start; k < s.end; k++ {
+		if isJSONSpace(body[k]) {
+			continue
+		}
+		return body[k] == '{'
+	}
+	return false
+}
+
+// insertTopLevelEntry splices entry (e.g. `"stream":true`) in as the first
+// member of the top-level object whose opening brace is at openIdx.
+func insertTopLevelEntry(body []byte, openIdx int, entry string, emptyObject bool) []byte {
+	out := make([]byte, 0, len(body)+len(entry)+1)
+	out = append(out, body[:openIdx+1]...)
+	out = append(out, entry...)
+	if !emptyObject {
+		out = append(out, ',')
+	}
+	out = append(out, body[openIdx+1:]...)
+	return out
+}
+
+// insertIntoObjectSpan splices entry in as the first member of the object
+// value at s; subOpen/subEmpty come from objectBraces(body[s.start:s.end]).
+func insertIntoObjectSpan(body []byte, s jsonSpan, subOpen int, entry string, subEmpty bool) []byte {
+	pos := s.start + subOpen + 1
+	out := make([]byte, 0, len(body)+len(entry)+1)
+	out = append(out, body[:pos]...)
+	out = append(out, entry...)
+	if !subEmpty {
+		out = append(out, ',')
+	}
+	out = append(out, body[pos:]...)
+	return out
+}
+
+// replaceSpan returns body with the span replaced by repl (single allocation).
+func replaceSpan(body []byte, s jsonSpan, repl string) []byte {
+	out := make([]byte, 0, len(body)-(s.end-s.start)+len(repl))
+	out = append(out, body[:s.start]...)
+	out = append(out, repl...)
+	out = append(out, body[s.end:]...)
+	return out
+}
+
+// sameByteSlice reports whether two slices cover the identical backing region.
+func sameByteSlice(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	return &a[0] == &b[0]
+}
+
+// bodyStreamHints carries cheaply pre-scanned facts about a JSON request body
+// so multiple candidate paths can share one look over the payload.
+type bodyStreamHints struct {
+	valid         bool // body is framed as a single top-level JSON object
+	emptyObject   bool // body is exactly {} (modulo whitespace)
+	openIdx       int  // index of the opening brace when valid
+	hasStreamKey  bool // byte pattern "stream" present anywhere
+	hasStreamOpts bool // byte pattern "stream_options" present anywhere
+}
+
+func scanBodyStreamHints(bodyBytes []byte) bodyStreamHints {
+	var h bodyStreamHints
+	h.hasStreamKey = bytes.Contains(bodyBytes, streamKeyMarker)
+	h.hasStreamOpts = containsLongMarker(bodyBytes, streamOptsMarker)
+	h.openIdx, h.emptyObject, h.valid = objectBraces(bodyBytes)
+	return h
+}
+
+// streamValueAlreadyTrue mirrors the legacy check: JSON true or the exact
+// strings "true" / "1" mean the client already streams (no rewrite, no force).
+func streamValueAlreadyTrue(body []byte, s jsonSpan) bool {
+	v := body[s.start:s.end]
+	if len(v) == 4 && bytesEqualString(v, "true") {
+		return true
+	}
+	if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+		inner := v[1 : len(v)-1]
+		return bytesEqualString(inner, "true") || bytesEqualString(inner, "1")
+	}
+	return false
+}
+
+// includeUsageTruthy mirrors jsonTruthyBool for a raw value span.
+func includeUsageTruthy(body []byte, s jsonSpan) bool {
+	v := body[s.start:s.end]
+	if len(v) == 4 && bytesEqualString(v, "true") {
+		return true
+	}
+	if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+		t := strings.TrimSpace(strings.ToLower(string(v[1 : len(v)-1])))
+		return t == "true" || t == "1" || t == "yes"
+	}
+	return false
+}
+
+// rewriteUpstreamStreamFlags applies site stream forcing (stream=true) and the
+// OpenAI stream_options.include_usage inject to a JSON request body in one
+// scan + splice. forceStream and injectUsage are the caller-computed gates;
+// clientStream is ctx.IsStream. Returns the (possibly original) body, whether
+// stream was forced, whether the outbound body is expected to yield a final
+// usage chunk, and ok=false when the body is irregular and the caller must use
+// the legacy decode path instead.
+func rewriteUpstreamStreamFlags(bodyBytes []byte, hints bodyStreamHints, forceStream, clientStream, injectUsage bool) (out []byte, forced, expectUsage, ok bool) {
+	body := bodyBytes
+
+	// Stage 1: force stream=true for responses-only / stream-preferring sites.
+	if forceStream {
+		if len(body) == 0 {
+			body = []byte(`{"stream":true}`)
+			forced = true
+		} else if !hints.valid {
+			return nil, false, false, false
+		} else if !hints.hasStreamKey {
+			body = insertTopLevelEntry(body, hints.openIdx, `"stream":true`, hints.emptyObject)
+			forced = true
+		} else {
+			s, found, scanOK := findTopLevelValue(body, "stream")
+			if !scanOK {
+				return nil, false, false, false
+			}
+			if found && streamValueAlreadyTrue(body, s) {
+				forced = false // client already streams; leave body untouched
+			} else if found {
+				body = replaceSpan(body, s, "true")
+				forced = true
+			} else {
+				// "stream" byte hit was nested only; no top-level key.
+				body = insertTopLevelEntry(body, hints.openIdx, `"stream":true`, hints.emptyObject)
+				forced = true
+			}
+		}
+	}
+
+	// Stage 2: ensure stream_options.include_usage=true on accepting paths.
+	if injectUsage && (clientStream || forced) {
+		if len(body) == 0 {
+			return body, forced, false, true
+		}
+		emptyNow := hints.emptyObject && !forced
+		if !hints.hasStreamOpts {
+			if !hints.valid {
+				return nil, false, false, false
+			}
+			body = insertTopLevelEntry(body, hints.openIdx, `"stream_options":{"include_usage":true}`, emptyNow)
+			expectUsage = true
+		} else {
+			s, found, scanOK := findTopLevelValue(body, "stream_options")
+			if !scanOK {
+				return nil, false, false, false
+			}
+			if !found {
+				// Byte hit was nested only; no top-level stream_options.
+				body = insertTopLevelEntry(body, hints.openIdx, `"stream_options":{"include_usage":true}`, emptyNow)
+				expectUsage = true
+			} else if !spanIsObject(body, s) {
+				body = replaceSpan(body, s, `{"include_usage":true}`)
+				expectUsage = true
+			} else {
+				sub := body[s.start:s.end]
+				subOpen, subEmpty, subOK := objectBraces(sub)
+				if !subOK {
+					return nil, false, false, false
+				}
+				is, iFound, iOK := findTopLevelValue(sub, "include_usage")
+				if !iOK {
+					return nil, false, false, false
+				}
+				switch {
+				case !iFound:
+					body = insertIntoObjectSpan(body, s, subOpen, `"include_usage":true`, subEmpty)
+					expectUsage = true
+				case includeUsageTruthy(sub, is):
+					expectUsage = true // already requested; body untouched
+				default:
+					abs := jsonSpan{s.start + is.start, s.start + is.end}
+					body = replaceSpan(body, abs, "true")
+					expectUsage = true
+				}
+			}
+		}
+	}
+	return body, forced, expectUsage, true
+}

--- a/handler/proxy/upstream_body_rewrite_test.go
+++ b/handler/proxy/upstream_body_rewrite_test.go
@@ -1,0 +1,280 @@
+package proxyhandler
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/proxy"
+)
+
+// ---------------------------------------------------------------------------
+// findTopLevelValue / scanner primitives
+// ---------------------------------------------------------------------------
+
+func TestFindTopLevelValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		key       string
+		wantFound bool
+		wantOK    bool
+		wantValue string // raw value bytes when found
+	}{
+		{name: "first key", body: `{"model":"gpt-4o","x":1}`, key: "model", wantFound: true, wantOK: true, wantValue: `"gpt-4o"`},
+		{name: "later key", body: `{"a":1,"stream":false}`, key: "stream", wantFound: true, wantOK: true, wantValue: `false`},
+		{name: "absent key", body: `{"a":1}`, key: "stream", wantFound: false, wantOK: true},
+		{name: "nested key not matched", body: `{"a":{"stream":true}}`, key: "stream", wantFound: false, wantOK: true},
+		{name: "key inside string value", body: `{"a":"\"stream\":true","b":2}`, key: "stream", wantFound: false, wantOK: true},
+		{name: "braces inside string", body: `{"a":"}}}{{","model":"x"}`, key: "model", wantFound: true, wantOK: true, wantValue: `"x"`},
+		{name: "escaped quote in string", body: `{"a":"say \"hi\"","stream":true}`, key: "stream", wantFound: true, wantOK: true, wantValue: `true`},
+		{name: "pretty printed", body: "  {\n\t\"model\" : \"gpt-4o\" ,\n\"b\" : [ 1 , 2 ]\n} ", key: "model", wantFound: true, wantOK: true, wantValue: `"gpt-4o"`},
+		{name: "escaped top-level key aborts", body: "{\"\\u0073tream\":true}", key: "stream", wantFound: false, wantOK: false},
+		{name: "escaped key after target ok", body: "{\"stream\":true,\"\\u0078\":1}", key: "stream", wantFound: true, wantOK: true, wantValue: `true`},
+		{name: "non-object array", body: `[1,2,3]`, key: "model", wantFound: false, wantOK: false},
+		{name: "malformed missing colon", body: `{"a" 1}`, key: "a", wantFound: false, wantOK: false},
+		{name: "malformed dangling comma", body: `{"a":1,,}`, key: "a", wantFound: true, wantOK: true, wantValue: `1`},
+		{name: "trailing garbage after early match", body: `{"a":1} garbage`, key: "a", wantFound: true, wantOK: true, wantValue: `1`},
+		{name: "trailing garbage without match", body: `{"a":1} garbage`, key: "b", wantFound: false, wantOK: false},
+		{name: "empty object", body: `{}`, key: "model", wantFound: false, wantOK: true},
+		{name: "whitespace object", body: " \t{}\n", key: "model", wantFound: false, wantOK: true},
+		{name: "number formats", body: `{"n":-1.5e10,"stream":true}`, key: "stream", wantFound: true, wantOK: true, wantValue: `true`},
+		{name: "literal values", body: `{"a":null,"b":false,"stream":true}`, key: "stream", wantFound: true, wantOK: true, wantValue: `true`},
+		{name: "first occurrence wins", body: `{"model":"a","x":1,"model":"b"}`, key: "model", wantFound: true, wantOK: true, wantValue: `"a"`},
+		{name: "unterminated string", body: `{"a":"x}`, key: "a", wantFound: false, wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, found, ok := findTopLevelValue([]byte(tt.body), tt.key)
+			if ok != tt.wantOK || found != tt.wantFound {
+				t.Fatalf("findTopLevelValue = (found=%v, ok=%v), want (found=%v, ok=%v)", found, ok, tt.wantFound, tt.wantOK)
+			}
+			if found && string([]byte(tt.body)[s.start:s.end]) != tt.wantValue {
+				t.Fatalf("value span = %q, want %q", []byte(tt.body)[s.start:s.end], tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestObjectBraces(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantOK    bool
+		wantEmpty bool
+	}{
+		{name: "simple", body: `{"a":1}`, wantOK: true, wantEmpty: false},
+		{name: "empty", body: `{}`, wantOK: true, wantEmpty: true},
+		{name: "empty with space", body: `{ }`, wantOK: true, wantEmpty: true},
+		{name: "padded", body: "\n {\"a\":1} \t", wantOK: true, wantEmpty: false},
+		{name: "not object", body: `[1]`, wantOK: false},
+		{name: "empty body", body: ``, wantOK: false},
+		{name: "missing close", body: `{"a":1`, wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, empty, ok := objectBraces([]byte(tt.body))
+			if ok != tt.wantOK || (ok && empty != tt.wantEmpty) {
+				t.Fatalf("objectBraces(%q) = (empty=%v, ok=%v), want (empty=%v, ok=%v)", tt.body, empty, ok, tt.wantEmpty, tt.wantOK)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// swapModelInJSON
+// ---------------------------------------------------------------------------
+
+func TestSwapModelInJSON_ShortCircuitNoMapping(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"stream":true}`)
+	out := swapModelInJSON(body, "gpt-4o")
+	if !sameByteSlice(out, body) {
+		t.Fatalf("expected zero-copy passthrough, got %s", out)
+	}
+	if n := testing.AllocsPerRun(10, func() { _ = swapModelInJSON(body, "gpt-4o") }); n != 0 {
+		t.Fatalf("no-mapping swap allocates %.1f times, want 0", n)
+	}
+}
+
+func TestSwapModelInJSON_MappedSplicesOnlyModel(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"keep <me> & bytes"}],"n":1.5}`)
+	out := swapModelInJSON(body, "gpt-4o-upstream")
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output not valid JSON: %v (%s)", err, out)
+	}
+	if got["model"] != "gpt-4o-upstream" {
+		t.Fatalf("model = %v, want gpt-4o-upstream", got["model"])
+	}
+	// Non-model bytes stay verbatim (no HTML re-escaping, no key reordering).
+	if !strings.Contains(string(out), `"keep <me> & bytes"`) {
+		t.Fatalf("content bytes not preserved verbatim: %s", out)
+	}
+	if !strings.Contains(string(out), `"messages":[`) || !strings.Contains(string(out), `"n":1.5`) {
+		t.Fatalf("unexpected rewrite beyond model: %s", out)
+	}
+}
+
+func TestSwapModelInJSON_EdgeCases(t *testing.T) {
+	// Empty body synthesizes a model-only object.
+	if got := string(swapModelInJSON(nil, "m1")); got != `{"model":"m1"}` {
+		t.Fatalf("empty body = %s", got)
+	}
+	// Body without top-level model gets the key inserted.
+	out := swapModelInJSON([]byte(`{"contents":[]}`), "gemini-x")
+	var parsed map[string]any
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("insert output invalid: %v (%s)", err, out)
+	}
+	if parsed["model"] != "gemini-x" {
+		t.Fatalf("model = %v, want gemini-x", parsed["model"])
+	}
+	// Nested "model" only: top-level key still inserted.
+	out = swapModelInJSON([]byte(`{"messages":[{"model":"inner"}]}`), "top")
+	if err := json.Unmarshal(out, &parsed); err != nil || parsed["model"] != "top" {
+		t.Fatalf("nested-only model: %v (%s)", err, out)
+	}
+	// Non-string model value is replaced.
+	out = swapModelInJSON([]byte(`{"model":123,"x":1}`), "m2")
+	if err := json.Unmarshal(out, &parsed); err != nil || parsed["model"] != "m2" {
+		t.Fatalf("non-string model: %v (%s)", err, out)
+	}
+	// Malformed body: legacy fallback returns original bytes (unmarshal fails).
+	bad := []byte(`{not json`)
+	if got := swapModelInJSON(bad, "m3"); !sameByteSlice(got, bad) {
+		t.Fatalf("malformed body changed: %s", got)
+	}
+	// Escaped top-level key: scanner declines, legacy fallback still rewrites.
+	esc := []byte("{\"\\u006dodel\":\"old\",\"x\":1}")
+	out = swapModelInJSON(esc, "new")
+	if err := json.Unmarshal(out, &parsed); err != nil || parsed["model"] != "new" {
+		t.Fatalf("escaped key model: %v (%s)", err, out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// rewriteUpstreamStreamFlags fast path vs legacy decode chain equivalence
+// ---------------------------------------------------------------------------
+
+// legacyStreamChain mirrors the pre-fix dispatch chain semantics.
+func legacyStreamChain(body []byte, force, clientStream, injectUsage bool) ([]byte, bool, bool) {
+	forced := false
+	if force {
+		body, forced = legacyApplyStreamPreference(body)
+	}
+	expect := false
+	if injectUsage && (clientStream || forced) && len(body) > 0 {
+		body, expect = legacyApplyStreamIncludeUsage(body)
+	}
+	return body, forced, expect
+}
+
+func jsonDeepEqual(t *testing.T, a, b []byte) {
+	t.Helper()
+	var da, db any
+	if err := json.Unmarshal(a, &da); err != nil {
+		t.Fatalf("invalid JSON A: %v (%s)", err, a)
+	}
+	if err := json.Unmarshal(b, &db); err != nil {
+		t.Fatalf("invalid JSON B: %v (%s)", err, b)
+	}
+	if !reflect.DeepEqual(da, db) {
+		t.Fatalf("semantic mismatch:\n fast:   %s\n legacy: %s", a, b)
+	}
+}
+
+func TestRewriteUpstreamStreamFlags_MatchesLegacyChain(t *testing.T) {
+	bodies := map[string]string{
+		"plain streaming chat":     `{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"hi"}]}`,
+		"stream false":             `{"model":"gpt-4o","stream":false,"messages":[]}`,
+		"no stream key":            `{"model":"gpt-4o","messages":[]}`,
+		"stream string true":       `{"stream":"true","model":"x"}`,
+		"stream string 1":          `{"stream":"1","model":"x"}`,
+		"stream string TRUE":       `{"stream":"TRUE","model":"x"}`,
+		"stream number 1":          `{"stream":1,"model":"x"}`,
+		"stream null":              `{"stream":null,"model":"x"}`,
+		"opts include_usage true":  `{"stream":true,"stream_options":{"include_usage":true}}`,
+		"opts include_usage false": `{"stream":true,"stream_options":{"include_usage":false,"foo":"bar"}}`,
+		"opts include_usage str":   `{"stream":true,"stream_options":{"include_usage":"yes"}}`,
+		"opts include_usage zero":  `{"stream":true,"stream_options":{"include_usage":0}}`,
+		"opts empty object":        `{"stream":true,"stream_options":{}}`,
+		"opts non-object":          `{"stream":true,"stream_options":"weird"}`,
+		"opts null":                `{"stream":true,"stream_options":null}`,
+		"opts array":               `{"stream":true,"stream_options":[1,2]}`,
+		"nested stream keys":       `{"model":"x","messages":[{"stream":"in-msg","stream_options":{"include_usage":true}}]}`,
+		"pretty printed":           "{\n  \"model\": \"x\",\n  \"stream\": false,\n  \"messages\": []\n}",
+		"escapes in strings":       `{"model":"x","messages":[{"content":"{\"stream\": false } and \\\" }"}],"stream":true}`,
+		"empty object":             `{}`,
+	}
+	flags := []struct {
+		name        string
+		force       bool
+		client      bool
+		injectUsage bool
+	}{
+		{"inject only", false, true, true},
+		{"force only", true, false, false},
+		{"force + inject", true, true, true},
+		{"force + non-stream client", true, false, true},
+		{"nothing", false, false, false},
+		{"inject non-stream client", false, false, true},
+	}
+	for bName, body := range bodies {
+		for _, f := range flags {
+			t.Run(bName+"/"+f.name, func(t *testing.T) {
+				in := []byte(body)
+				fast, fForced, fExpect, ok := rewriteUpstreamStreamFlags(in, scanBodyStreamHints(in), f.force, f.client, f.injectUsage)
+				if !ok {
+					t.Fatalf("fast path declined a regular body")
+				}
+				lOut, lForced, lExpect := legacyStreamChain(in, f.force, f.client, f.injectUsage)
+				if fForced != lForced {
+					t.Fatalf("forced = %v, legacy %v (fast=%s legacy=%s)", fForced, lForced, fast, lOut)
+				}
+				if fExpect != lExpect {
+					t.Fatalf("expectUsage = %v, legacy %v (fast=%s legacy=%s)", fExpect, lExpect, fast, lOut)
+				}
+				jsonDeepEqual(t, fast, lOut)
+			})
+		}
+	}
+}
+
+func TestRewriteUpstreamStreamFlags_EmptyBody(t *testing.T) {
+	// Force on empty body synthesizes a stream-only object (legacy parity).
+	out, forced, expect, ok := rewriteUpstreamStreamFlags(nil, scanBodyStreamHints(nil), true, false, false)
+	if !ok || !forced || expect || string(out) != `{"stream":true}` {
+		t.Fatalf("empty+force = (%s, %v, %v, %v)", out, forced, expect, ok)
+	}
+	// Inject on empty body: unchanged, no expectation.
+	out, forced, expect, ok = rewriteUpstreamStreamFlags(nil, scanBodyStreamHints(nil), false, true, true)
+	if !ok || forced || expect || len(out) != 0 {
+		t.Fatalf("empty+inject = (%s, %v, %v, %v)", out, forced, expect, ok)
+	}
+}
+
+func TestRewriteUpstreamStreamFlags_IrregularDeclined(t *testing.T) {
+	for _, body := range []string{`{not json`, `{"stream" 1}`, `[1,2]`, `{"stream":true`} {
+		in := []byte(body)
+		_, _, _, ok := rewriteUpstreamStreamFlags(in, scanBodyStreamHints(in), true, true, true)
+		if ok {
+			t.Fatalf("fast path accepted irregular body %q", body)
+		}
+	}
+}
+
+// Wrapper passthrough guarantees: unchanged bodies keep identical bytes.
+func TestStreamWrappers_PassthroughIdentity(t *testing.T) {
+	in := []byte(`{"model":"x","stream":true,"messages":[]}`)
+	// No force gate -> identical slice.
+	if out, forced := applyUpstreamStreamPreference(in, "", "/v1/responses", proxy.SiteProtocolPreference{}); forced || !sameByteSlice(out, in) {
+		t.Fatalf("preference passthrough altered body (forced=%v)", forced)
+	}
+	// include_usage already true -> identical slice, expect=true.
+	inOpts := []byte(`{"stream":true,"stream_options":{"include_usage":true,"foo":1}}`)
+	out, expect := applyUpstreamStreamIncludeUsage(inOpts, "openai", "/v1/chat/completions", true)
+	if !expect || !sameByteSlice(out, inOpts) {
+		t.Fatalf("include_usage noop altered body (expect=%v)", expect)
+	}
+}

--- a/handler/proxy/upstream_responses.go
+++ b/handler/proxy/upstream_responses.go
@@ -42,7 +42,22 @@ func bodyLooksResponsesShaped(bodyBytes []byte) bool {
 	return false
 }
 
+// upstreamStreamRewriteGates computes the per-candidate gates for the
+// single-pass stream rewrite: stream forcing (responses-only / stream-
+// preferring sites, codex/sub2api platforms) and include_usage injection
+// (OpenAI-compatible chat/completions paths on accepting platforms).
+func upstreamStreamRewriteGates(sitePlatform, upstreamPath string, pref proxy.SiteProtocolPreference) (forceStream, injectUsage bool) {
+	pathLower := strings.ToLower(upstreamPath)
+	isCompact := strings.Contains(pathLower, "/responses/compact")
+	forceStream = responses.ShouldForceResponsesUpstreamStream(sitePlatform, isCompact) ||
+		proxy.ShouldForceUpstreamStream(pref, upstreamPath, isCompact)
+	injectUsage = acceptsOpenAIStreamIncludeUsagePath(upstreamPath) && !rejectsOpenAIStreamOptions(sitePlatform)
+	return forceStream, injectUsage
+}
+
 // applyUpstreamStreamPreference forces stream=true when site/platform requires it.
+// The rewrite is a single allocation-free scan + splice; irregular bodies fall
+// back to the legacy full-decode path for exact semantics.
 func applyUpstreamStreamPreference(bodyBytes []byte, sitePlatform, upstreamPath string, pref proxy.SiteProtocolPreference) ([]byte, bool) {
 	pathLower := strings.ToLower(upstreamPath)
 	isCompact := strings.Contains(pathLower, "/responses/compact")
@@ -52,6 +67,16 @@ func applyUpstreamStreamPreference(bodyBytes []byte, sitePlatform, upstreamPath 
 	if !force {
 		return bodyBytes, false
 	}
+	out, forced, _, ok := rewriteUpstreamStreamFlags(bodyBytes, scanBodyStreamHints(bodyBytes), true, false, false)
+	if ok {
+		return out, forced
+	}
+	return legacyApplyStreamPreference(bodyBytes)
+}
+
+// legacyApplyStreamPreference is the original map[string]any implementation,
+// retained as the fallback for bodies the allocation-free scanner declines.
+func legacyApplyStreamPreference(bodyBytes []byte) ([]byte, bool) {
 	if len(bodyBytes) == 0 {
 		return []byte(`{"stream":true}`), true
 	}
@@ -84,6 +109,8 @@ func applyUpstreamStreamPreference(bodyBytes []byte, sitePlatform, upstreamPath 
 // chat/completions and legacy /v1/completions stream bodies so upstream SSE emits a final usage chunk (known limitation).
 // Platform-safe: skips non-chat endpoints and platforms known to reject stream_options (codex/sub2api).
 // Does not invent tokens; only asks the provider to include usage when streaming.
+// The rewrite is a single allocation-free scan + splice; irregular bodies fall
+// back to the legacy full-decode path for exact semantics.
 
 // The bool is true when the outbound stream body is expected to carry usage via include_usage
 // (we injected it, or the client already set include_usage=true on an accepting path). Callers
@@ -98,12 +125,18 @@ func applyUpstreamStreamIncludeUsage(bodyBytes []byte, sitePlatform, upstreamPat
 	if rejectsOpenAIStreamOptions(sitePlatform) {
 		return bodyBytes, false
 	}
+	out, _, expect, ok := rewriteUpstreamStreamFlags(bodyBytes, scanBodyStreamHints(bodyBytes), false, isStream, true)
+	if ok {
+		return out, expect
+	}
+	return legacyApplyStreamIncludeUsage(bodyBytes)
+}
+
+// legacyApplyStreamIncludeUsage is the original map[string]any implementation,
+// retained as the fallback for bodies the allocation-free scanner declines.
+func legacyApplyStreamIncludeUsage(bodyBytes []byte) ([]byte, bool) {
 	var body map[string]any
 	if err := json.Unmarshal(bodyBytes, &body); err != nil {
-		return bodyBytes, false
-	}
-	// Only when this attempt is streaming (client or forced).
-	if !jsonTruthyBool(body["stream"]) && !isStream {
 		return bodyBytes, false
 	}
 	opts, _ := body["stream_options"].(map[string]any)

--- a/handler/proxy/upstream_sanitize.go
+++ b/handler/proxy/upstream_sanitize.go
@@ -10,6 +10,19 @@ import (
 	"github.com/deliciousbuding/metapi-go/transform/openai/responses"
 )
 
+// Sanitize gate markers; long needles go through the SIMD-friendly
+// containsLongMarker instead of bytes.Contains (Rabin-Karp slowdown).
+var (
+	previousResponseIDMarker = []byte(`"previous_response_id"`)
+	reasoningTightMarker     = []byte(`"type":"reasoning"`)
+	reasoningSpacedMarker    = []byte(`"type": "reasoning"`)
+	encryptedContentMarker   = []byte(`"encrypted_content"`)
+	inputKeyMarker           = []byte(`"input"`)
+	functionCallMarker       = []byte(`"functionCall"`)
+	functionCallSnakeMarker  = []byte(`"function_call"`)
+	toolCallsMarker          = []byte(`"tool_calls"`)
+)
+
 func sanitizeUpstreamJSONBody(bodyBytes []byte, sitePlatform, upstreamPath, upstreamModel string) ([]byte, error) {
 	if len(bodyBytes) == 0 {
 		return bodyBytes, nil
@@ -20,16 +33,16 @@ func sanitizeUpstreamJSONBody(bodyBytes []byte, sitePlatform, upstreamPath, upst
 	pathLower := strings.ToLower(upstreamPath)
 	needsCompact := strings.Contains(pathLower, "/responses/compact")
 	isResponsesPath := needsCompact || strings.Contains(pathLower, "/responses")
-	needsContinuity := bytes.Contains(bodyBytes, []byte(`"previous_response_id"`))
+	needsContinuity := containsLongMarker(bodyBytes, previousResponseIDMarker)
 	// Multi-turn Hermes/Codex ():
 	// 1) Exact compact markers (common client encoding).
 	// 2) Responses path + "input" always parse - covers pretty-printed /
 	// spaced JSON where "type" : "reasoning" does not match contiguous bytes.
 	// 3) encrypted_content anywhere (continuity payload even without type key).
-	needsReasoningInput := bytes.Contains(bodyBytes, []byte(`"type":"reasoning"`)) ||
-		bytes.Contains(bodyBytes, []byte(`"type": "reasoning"`)) ||
-		bytes.Contains(bodyBytes, []byte(`"encrypted_content"`)) ||
-		(isResponsesPath && bytes.Contains(bodyBytes, []byte(`"input"`)))
+	needsReasoningInput := containsLongMarker(bodyBytes, reasoningTightMarker) ||
+		containsLongMarker(bodyBytes, reasoningSpacedMarker) ||
+		containsLongMarker(bodyBytes, encryptedContentMarker) ||
+		(isResponsesPath && bytes.Contains(bodyBytes, inputKeyMarker))
 	needsGeminiThought := needsGeminiThoughtSignatureSanitize(sitePlatform, upstreamPath, bodyBytes)
 	if !needsCompact && !needsContinuity && !needsReasoningInput && !needsGeminiThought {
 		return bodyBytes, nil
@@ -83,9 +96,9 @@ func needsGeminiThoughtSignatureSanitize(sitePlatform, upstreamPath string, body
 		return false
 	}
 	// Tool-history markers only (functionCall native or OpenAI tool_calls).
-	return bytes.Contains(bodyBytes, []byte(`"functionCall"`)) ||
-		bytes.Contains(bodyBytes, []byte(`"function_call"`)) ||
-		bytes.Contains(bodyBytes, []byte(`"tool_calls"`))
+	return containsLongMarker(bodyBytes, functionCallMarker) ||
+		containsLongMarker(bodyBytes, functionCallSnakeMarker) ||
+		containsLongMarker(bodyBytes, toolCallsMarker)
 }
 
 func isGeminiThoughtSignaturePlatform(sitePlatform string) bool {
@@ -200,10 +213,10 @@ func cloneJSONMapShallow(in map[string]any) map[string]any {
 	return out
 }
 
-// swapModelInJSON performs a shallow JSON re-encode to replace the "model" field.
-// It uses json.RawMessage to avoid deep-unmarshalling nested values, then sets
-// the model key and marshals once. This replaces the previous approach of:
-
-//	cloneAndSetModel(ctx.Body) -> json.Marshal
-
-// which allocated a full map copy PLUS serialized the deep structure twice.
+// swapModelInJSON (upstream.go) short-circuits with an allocation-free
+// top-level scan when the body already carries the target model (the
+// no-mapping norm) and otherwise splices only the model value span, keeping
+// the rest of the payload byte-identical. The previous shallow re-encode
+// (map[string]json.RawMessage round-trip) survives only as the fallback for
+// irregular bodies, alongside the stream-forcing / include_usage single-pass
+// splice in upstream_body_rewrite.go.


### PR DESCRIPTION
代理热路径每请求 2~3 次全量 JSON 解码+重编码（审计实测：200KB 会话 ~19.4ms/1.28MB 分配）。

- **零拷贝短路**：顶层 model 相等直接返回原 body（无映射常态）；映射场景只拼 model 值 span（200KB：6.0ms→0.2ms）
- **单遍重写**：stream 强制 + include_usage 注入合并为单次扫描+拼接；hints 移出候选循环共享
- **等价性保障**：畸形/转义键 body 回退旧 decode 实现；19 种 body × 6 标志组合深比较套件 + AllocsPerRun==0 断言

Bench（无映射）：完整管线 2KB 156µs→9.7µs、200KB 19.4ms→1.0ms（分配 8991→1）、2MB 241ms→30-42ms。
`go test ./handler/proxy/... ./proxy/...` 全绿（含 model_mapping 与 /v1/responses sanitize 回归）。
