### PR TITLE
perf: proxy-logs single-pass summary + singleflight cache + covering index

### DIFF
--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -166,6 +166,122 @@ func (c *dashboardSummaryCache) getOrCompute(view string, compute func() ([]byte
 
 var globalDashboardCache = &dashboardSummaryCache{ttl: 10 * time.Second}
 
+// proxyLogsSummary is the five-way aggregate behind the proxy-logs summary
+// strip (total/success/failed counts + cost + effective tokens). It is the
+// most expensive query on the page — five SUM/CASE passes over the filtered
+// proxy_logs table (~0.6-1.0s at 500k rows on the audit fixture) — so it is
+// cached per filter fingerprint below.
+type proxyLogsSummary struct {
+	TotalCount     int     `db:"total_count"`
+	SuccessCount   int     `db:"success_count"`
+	FailedCount    int     `db:"failed_count"`
+	TotalCost      float64 `db:"total_cost"`
+	TotalTokensAll int64   `db:"total_tokens_all"`
+}
+
+// proxyLogsSummaryCacheMaxEntries bounds the fingerprint map. Entries expire
+// after the TTL anyway; the cap only protects against a burst of distinct
+// filter combinations inside one TTL window. On overflow the expired entries
+// are pruned first, then the whole map is dropped (a 10s-TTL cache rebuilds
+// quickly; bounded memory beats LRU bookkeeping here).
+const proxyLogsSummaryCacheMaxEntries = 128
+
+// proxyLogsSummaryCache is a short-TTL in-memory cache for the proxy-logs
+// summary aggregate, keyed by the request's filter fingerprint (every query
+// param that shapes the WHERE clause; limit/offset excluded). Mirrors the
+// dashboardSummaryCache pattern: RWMutex-guarded entries + single-flight
+// dedup so N admin sessions polling an expired fingerprint share one
+// aggregation run instead of running it N× (thundering herd).
+//
+// Keying by fingerprint (not by view) is the point: pagination only changes
+// offset, and the list page's split view=query + view=meta fetches carry the
+// same filters, so one TTL window computes the summary once per filter set —
+// the pre-fix page computed it twice per load (full + meta) plus once per
+// page turn. Only successful computes are cached; errors bypass the cache.
+// ?force=1 / ?refresh=1 clears it (admin "force refresh").
+type proxyLogsSummaryCache struct {
+	mu      sync.RWMutex
+	entries map[string]proxyLogsSummaryEntry
+	ttl     time.Duration
+	// flight deduplicates concurrent cache-miss computes for the same
+	// fingerprint (see dashboardSummaryCache.flight).
+	flight singleflight.Group
+}
+
+type proxyLogsSummaryEntry struct {
+	summary   proxyLogsSummary
+	expiresAt time.Time
+}
+
+func (c *proxyLogsSummaryCache) get(key string) (proxyLogsSummary, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.entries[key]
+	if !ok || time.Now().After(e.expiresAt) {
+		return proxyLogsSummary{}, false
+	}
+	return e.summary, true
+}
+
+func (c *proxyLogsSummaryCache) set(key string, summary proxyLogsSummary) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.entries == nil {
+		c.entries = make(map[string]proxyLogsSummaryEntry)
+	}
+	if len(c.entries) >= proxyLogsSummaryCacheMaxEntries {
+		now := time.Now()
+		for k, e := range c.entries {
+			if now.After(e.expiresAt) {
+				delete(c.entries, k)
+			}
+		}
+		if len(c.entries) >= proxyLogsSummaryCacheMaxEntries {
+			// All entries still live: drop the lot rather than grow unbounded.
+			c.entries = make(map[string]proxyLogsSummaryEntry)
+		}
+	}
+	c.entries[key] = proxyLogsSummaryEntry{summary: summary, expiresAt: time.Now().Add(c.ttl)}
+}
+
+func (c *proxyLogsSummaryCache) clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = nil
+}
+
+// getOrCompute returns the cached summary for key, or computes it via the
+// supplied function under single-flight dedup. Returns (summary, hit, err):
+// hit reports whether the fast-path cache served the value (for the
+// x-proxy-logs-summary-cache response header). A single-flight-shared
+// compute is reported as a miss since this request did not get an instant
+// cached response — only successful computes are stored, so errors never
+// poison the cache.
+func (c *proxyLogsSummaryCache) getOrCompute(key string, compute func() (proxyLogsSummary, error)) (proxyLogsSummary, bool, error) {
+	if cached, hit := c.get(key); hit {
+		return cached, true, nil
+	}
+	result, err, _ := c.flight.Do(key, func() (any, error) {
+		// Re-check: a concurrent leader may have populated the cache while we
+		// waited for the single-flight slot.
+		if cached, hit := c.get(key); hit {
+			return cached, nil
+		}
+		summary, err := compute()
+		if err != nil {
+			return proxyLogsSummary{}, err
+		}
+		c.set(key, summary)
+		return summary, nil
+	})
+	if err != nil {
+		return proxyLogsSummary{}, false, err
+	}
+	return result.(proxyLogsSummary), false, nil
+}
+
+var globalProxyLogsSummaryCache = &proxyLogsSummaryCache{ttl: 10 * time.Second}
+
 // ---- Dashboard ----
 // GET /api/stats/dashboard?force=&view=
 func (h *statsHandler) dashboard(w http.ResponseWriter, r *http.Request) {
@@ -553,6 +669,32 @@ func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 	latencyMin := getQueryInt(r, "latencyMin", 0)
 	latencyMax := getQueryInt(r, "latencyMax", 0)
 
+	// ?force=1 / ?refresh=1 is the admin "force refresh" hook (the meta
+	// client speaks `refresh`, the dashboard convention is `force`; both are
+	// honored): invalidate every cached summary fingerprint so this request
+	// recomputes from the DB.
+	if parseDashboardForceRefresh(r.URL.Query().Get("force")) ||
+		parseDashboardForceRefresh(r.URL.Query().Get("refresh")) {
+		globalProxyLogsSummaryCache.clear()
+	}
+
+	// Fingerprint keys the summary cache: every filter that shapes the WHERE
+	// clause, spelled the same way the conditions below parse them. limit and
+	// offset are deliberately excluded — the summary is page-independent, so
+	// pagination and the split view=query + view=meta fetches all reuse one
+	// cached aggregate per filter set per TTL window.
+	fingerprint := strings.Join([]string{
+		"status=" + status,
+		"search=" + search,
+		"siteId=" + strconv.Itoa(siteID),
+		"channelId=" + strconv.Itoa(channelID),
+		"client=" + client,
+		"from=" + from,
+		"to=" + to,
+		"latencyMin=" + strconv.Itoa(latencyMin),
+		"latencyMax=" + strconv.Itoa(latencyMax),
+	}, "&")
+
 	var conditions []string
 	var args []any
 
@@ -650,33 +792,42 @@ func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 		queryPayload["items"] = normalizeSlice(items)
 
 		var total int
-		countQuery := "SELECT COUNT(*) FROM proxy_logs pl LEFT JOIN accounts a ON pl.account_id = a.id LEFT JOIN sites s ON a.site_id = s.id" + where
+		// The aggregate COUNT runs off the conditional FROM (no accounts/sites
+		// join unless the site filter needs s.id) — at 500k rows the join
+		// roughly doubled the count time on the audit fixture.
+		countQuery := "SELECT COUNT(*) " + proxyLogsAggregateFrom(siteID) + where
 		h.db.Get(&total, rebindAdminQuery(h.db, countQuery), args...)
 		queryPayload["total"] = total
 	}
 
+	// summaryCacheHit is reported via the x-proxy-logs-summary-cache response
+	// header for meta/full views (the views that compute the summary).
+	summaryCacheHit := false
 	if view == "meta" || view == "full" {
-		// Use effective token expression so partial logs are not under-counted,
-		// and never sum prompt+completion on top of total_tokens.
-		summaryQuery := `SELECT COUNT(*) as total_count,
-			COALESCE(SUM(CASE WHEN pl.status = 'success' THEN 1 ELSE 0 END), 0) as success_count,
-			COALESCE(SUM(CASE WHEN COALESCE(pl.status, '') <> 'success' THEN 1 ELSE 0 END), 0) as failed_count,
-			COALESCE(SUM(COALESCE(pl.estimated_cost, 0)), 0) as total_cost,
-			COALESCE(SUM(` + service.EffectiveProxyTokensSQL + `), 0) as total_tokens_all
-			FROM proxy_logs pl
-			LEFT JOIN accounts a ON pl.account_id = a.id
-			LEFT JOIN sites s ON a.site_id = s.id` + where
-		metaArgs := make([]any, len(args))
-		copy(metaArgs, args)
-
-		var summary struct {
-			TotalCount     int     `db:"total_count"`
-			SuccessCount   int     `db:"success_count"`
-			FailedCount    int     `db:"failed_count"`
-			TotalCost      float64 `db:"total_cost"`
-			TotalTokensAll int64   `db:"total_tokens_all"`
+		// The five-way summary aggregate is the expensive part of this
+		// endpoint (~0.6-1.0s at 500k rows): it is cached per filter
+		// fingerprint with single-flight dedup, mirroring the dashboard
+		// summary cache. The list page's view=query + view=meta split carries
+		// the same fingerprint, so the summary computes once per filter set
+		// per TTL window instead of twice per page load.
+		summary, cacheHit, summaryErr := globalProxyLogsSummaryCache.getOrCompute(fingerprint, func() (proxyLogsSummary, error) {
+			// Use effective token expression so partial logs are not under-counted,
+			// and never sum prompt+completion on top of total_tokens.
+			summaryQuery := proxyLogsSummaryQuerySQL(proxyLogsAggregateFrom(siteID), where)
+			var s proxyLogsSummary
+			if err := h.db.Get(&s, rebindAdminQuery(h.db, summaryQuery), args...); err != nil {
+				return proxyLogsSummary{}, err
+			}
+			return s, nil
+		})
+		if summaryErr != nil {
+			// Fail-open preserves the pre-cache behavior: a failed summary
+			// degraded silently to zeroes rather than blanking the whole list
+			// page. Errors are never cached, so the next request retries the DB.
+			slog.Error("proxy logs summary query failed; degrading to zero summary", "error", summaryErr)
+			summary = proxyLogsSummary{}
 		}
-		h.db.Get(&summary, rebindAdminQuery(h.db, summaryQuery), metaArgs...)
+		summaryCacheHit = cacheHit
 		metaPayload["summary"] = map[string]any{
 			"totalCount":     summary.TotalCount,
 			"successCount":   summary.SuccessCount,
@@ -695,7 +846,15 @@ func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 
 	if view == "query" {
 		writeJSON(w, http.StatusOK, queryPayload)
-	} else if view == "meta" {
+		return
+	}
+
+	if summaryCacheHit {
+		w.Header().Set("x-proxy-logs-summary-cache", "hit")
+	} else {
+		w.Header().Set("x-proxy-logs-summary-cache", "miss")
+	}
+	if view == "meta" {
 		writeJSON(w, http.StatusOK, metaPayload)
 	} else {
 		result := queryPayload
@@ -704,6 +863,32 @@ func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 		result["sites"] = metaPayload["sites"]
 		writeJSON(w, http.StatusOK, result)
 	}
+}
+
+// proxyLogsAggregateFrom returns the FROM clause for the proxy-logs COUNT and
+// summary aggregates. The site filter is the only condition that references a
+// joined table (s.id), so without a siteId the aggregates run straight off
+// proxy_logs — at 500k rows the audit measured the LEFT JOINs adding ~90ms to
+// the summary and ~100ms to the COUNT. With a siteId the WHERE needs s.id, so
+// the join stays (and the summary query's CASE/COALESCE never needs the join
+// for row preservation: it is a LEFT JOIN on primary keys).
+func proxyLogsAggregateFrom(siteID int) string {
+	if siteID > 0 {
+		return "FROM proxy_logs pl LEFT JOIN accounts a ON pl.account_id = a.id LEFT JOIN sites s ON a.site_id = s.id"
+	}
+	return "FROM proxy_logs pl"
+}
+
+// proxyLogsSummaryQuerySQL builds the five-way summary aggregate over the
+// given FROM clause + WHERE suffix. Kept a pure string builder (no db handle)
+// so tests can assert the join-free shape without a live database.
+func proxyLogsSummaryQuerySQL(from, where string) string {
+	return `SELECT COUNT(*) as total_count,
+		COALESCE(SUM(CASE WHEN pl.status = 'success' THEN 1 ELSE 0 END), 0) as success_count,
+		COALESCE(SUM(CASE WHEN COALESCE(pl.status, '') <> 'success' THEN 1 ELSE 0 END), 0) as failed_count,
+		COALESCE(SUM(COALESCE(pl.estimated_cost, 0)), 0) as total_cost,
+		COALESCE(SUM(` + service.EffectiveProxyTokensSQL + `), 0) as total_tokens_all
+		` + from + where
 }
 
 // ---- Proxy Log Detail ----

--- a/handler/admin/stats_proxy_logs_cache_test.go
+++ b/handler/admin/stats_proxy_logs_cache_test.go
@@ -1,0 +1,415 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// seedProxyLogsCacheFixture inserts three standalone proxy_logs rows (two
+// success, one failed) with distinct costs/token counts so summary
+// aggregates have non-trivial expected values:
+//
+//	totalCount=3, successCount=2, failedCount=1,
+//	totalCost=0.30, totalTokensAll=100+25+15=140 (the third row exercises the
+//	prompt+completion fallback of EffectiveProxyTokensSQL).
+func seedProxyLogsCacheFixture(t *testing.T, db *store.DB) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	rows := []struct {
+		model              string
+		status             string
+		prompt, completion int
+		totalTokens        any
+		cost               float64
+	}{
+		{"cache-a", "success", 0, 0, 100, 0.10},
+		{"cache-b", "success", 25, 15, nil, 0.05},
+		{"cache-c", "failed", 10, 10, 50, 0.15},
+	}
+	for _, row := range rows {
+		if row.totalTokens == nil {
+			mustExec(t, db, `INSERT INTO proxy_logs (model_requested, model_actual, status, prompt_tokens, completion_tokens, estimated_cost, created_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?)`, row.model, row.model, row.status, row.prompt, row.completion, row.cost, now)
+		} else {
+			mustExec(t, db, `INSERT INTO proxy_logs (model_requested, model_actual, status, prompt_tokens, completion_tokens, total_tokens, estimated_cost, created_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, row.model, row.model, row.status, row.prompt, row.completion, row.totalTokens, row.cost, now)
+		}
+	}
+}
+
+// proxyLogsSummaryBody decodes the summary block of a meta/full response.
+type proxyLogsSummaryBody struct {
+	TotalCount     int     `json:"totalCount"`
+	SuccessCount   int     `json:"successCount"`
+	FailedCount    int     `json:"failedCount"`
+	TotalCost      float64 `json:"totalCost"`
+	TotalTokensAll int64   `json:"totalTokensAll"`
+}
+
+func fetchProxyLogsSummaryBody(t *testing.T, r chi.Router, query string) (proxyLogsSummaryBody, map[string]any) {
+	t.Helper()
+	resp := doGet(t, r, "/api/stats/proxy-logs?"+query)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("GET /api/stats/proxy-logs?%s status=%d body=%s", query, resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal %s: %v", query, err)
+	}
+	raw, ok := body["summary"].(map[string]any)
+	if !ok {
+		t.Fatalf("GET /api/stats/proxy-logs?%s missing summary: %s", query, resp.Body.String())
+	}
+	rawJSON, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("re-marshal summary: %v", err)
+	}
+	var summary proxyLogsSummaryBody
+	if err := json.Unmarshal(rawJSON, &summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	return summary, body
+}
+
+// TestStats_SQLiteProxyLogsQueryViewOmitsSummary locks in the view=query
+// contract the list page relies on after the perf split: the list-only view
+// returns items/total/page/pageSize and NOTHING else — no summary, sites, or
+// clientOptions — so a page load never computes the five-way summary twice
+// (once in the list fetch, once in the meta fetch).
+func TestStats_SQLiteProxyLogsQueryViewOmitsSummary(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedProxyLogsCacheFixture(t, db)
+
+	resp := doGet(t, r, "/api/stats/proxy-logs?view=query")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("view=query status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, want := range []string{"items", "total", "page", "pageSize"} {
+		if _, ok := body[want]; !ok {
+			t.Fatalf("view=query response missing %q: %v", want, body)
+		}
+	}
+	for _, absent := range []string{"summary", "sites", "clientOptions"} {
+		if _, ok := body[absent]; ok {
+			t.Fatalf("view=query response must NOT contain %q (summary travels via view=meta): %v", absent, body)
+		}
+	}
+	if got := int(body["total"].(float64)); got != 3 {
+		t.Fatalf("view=query total = %d, want 3", got)
+	}
+	if items, ok := body["items"].([]any); !ok || len(items) != 3 {
+		t.Fatalf("view=query items = %#v, want 3 rows", body["items"])
+	}
+}
+
+// TestStats_ProxyLogsSummaryCache_MissThenHit verifies the core dedup
+// contract: the first meta request misses (and populates), the second
+// identical request hits and returns the same summary values.
+func TestStats_ProxyLogsSummaryCache_MissThenHit(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedProxyLogsCacheFixture(t, db)
+
+	first := doGet(t, r, "/api/stats/proxy-logs?view=meta")
+	if first.Code != http.StatusOK {
+		t.Fatalf("first meta: %d %s", first.Code, first.Body.String())
+	}
+	if got := first.Header().Get("x-proxy-logs-summary-cache"); got != "miss" {
+		t.Fatalf("first request cache header = %q, want miss", got)
+	}
+
+	second := doGet(t, r, "/api/stats/proxy-logs?view=meta")
+	if got := second.Header().Get("x-proxy-logs-summary-cache"); got != "hit" {
+		t.Fatalf("second request cache header = %q, want hit", got)
+	}
+	if first.Body.String() != second.Body.String() {
+		t.Fatalf("cache hit body differs from miss body.\nmiss: %s\nhit:  %s", first.Body.String(), second.Body.String())
+	}
+}
+
+// TestStats_ProxyLogsSummaryCache_StaleThenForce verifies the TTL semantics:
+// a data change within the TTL window is NOT visible to plain requests (the
+// cached aggregate serves), but ?force=1 (and the meta client's ?refresh=1)
+// invalidate and recompute. Mirrors TestDashboardCache_ForceRefreshBypassesAndInvalidates.
+func TestStats_ProxyLogsSummaryCache_StaleThenForce(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedProxyLogsCacheFixture(t, db)
+
+	if got := doGet(t, r, "/api/stats/proxy-logs?view=meta").Header().Get("x-proxy-logs-summary-cache"); got != "miss" {
+		t.Fatalf("first request should miss, got %q", got)
+	}
+
+	// Mutate the data: a fourth log makes a fresh compute differ.
+	now := time.Now().UTC().Format(time.RFC3339)
+	mustExec(t, db, `INSERT INTO proxy_logs (model_requested, model_actual, status, total_tokens, estimated_cost, created_at)
+		VALUES ('cache-d', 'cache-d', 'success', 7, 0.01, ?)`, now)
+
+	// A plain request still hits the stale cache.
+	stale := doGet(t, r, "/api/stats/proxy-logs?view=meta")
+	if stale.Header().Get("x-proxy-logs-summary-cache") != "hit" {
+		t.Fatalf("expected hit from stale cache, got %q", stale.Header().Get("x-proxy-logs-summary-cache"))
+	}
+	var staleBody map[string]any
+	if err := json.Unmarshal(stale.Body.Bytes(), &staleBody); err != nil {
+		t.Fatalf("unmarshal stale: %v", err)
+	}
+	staleSummary := staleBody["summary"].(map[string]any)
+	if got := int(staleSummary["totalCount"].(float64)); got != 3 {
+		t.Fatalf("stale cached totalCount = %d, want 3 (cache served pre-insert aggregate)", got)
+	}
+
+	// force=1 bypasses + invalidates, recomputing from the DB.
+	forced := doGet(t, r, "/api/stats/proxy-logs?view=meta&force=1")
+	if got := forced.Header().Get("x-proxy-logs-summary-cache"); got != "miss" {
+		t.Fatalf("force=1 should report miss, got %q", got)
+	}
+	var forcedBody map[string]any
+	if err := json.Unmarshal(forced.Body.Bytes(), &forcedBody); err != nil {
+		t.Fatalf("unmarshal forced: %v", err)
+	}
+	forcedSummary := forcedBody["summary"].(map[string]any)
+	if got := int(forcedSummary["totalCount"].(float64)); got != 4 {
+		t.Fatalf("forced totalCount = %d, want 4 (force did not recompute)", got)
+	}
+
+	// A subsequent plain request hits the freshly-populated cache.
+	after := doGet(t, r, "/api/stats/proxy-logs?view=meta")
+	if after.Header().Get("x-proxy-logs-summary-cache") != "hit" {
+		t.Fatalf("post-force request should hit repopulated cache, got %q", after.Header().Get("x-proxy-logs-summary-cache"))
+	}
+	if after.Body.String() != forced.Body.String() {
+		t.Fatal("post-force cache hit did not return the freshly-populated body")
+	}
+
+	// The meta client speaks `refresh` rather than `force`; it must invalidate
+	// exactly the same way. Mutate again so a fresh compute differs.
+	mustExec(t, db, `INSERT INTO proxy_logs (model_requested, model_actual, status, total_tokens, estimated_cost, created_at)
+		VALUES ('cache-e', 'cache-e', 'failed', 3, 0.02, ?)`, now)
+	refreshed := doGet(t, r, "/api/stats/proxy-logs?view=meta&refresh=1")
+	if got := refreshed.Header().Get("x-proxy-logs-summary-cache"); got != "miss" {
+		t.Fatalf("refresh=1 should report miss, got %q", got)
+	}
+	var refreshedBody map[string]any
+	if err := json.Unmarshal(refreshed.Body.Bytes(), &refreshedBody); err != nil {
+		t.Fatalf("unmarshal refreshed: %v", err)
+	}
+	refreshedSummary := refreshedBody["summary"].(map[string]any)
+	if got := int(refreshedSummary["totalCount"].(float64)); got != 5 {
+		t.Fatalf("refresh=1 totalCount = %d, want 5", got)
+	}
+}
+
+// TestStats_ProxyLogsSummaryCache_FingerprintKeying verifies the cache is
+// keyed by the filter fingerprint: a different filter is a different entry,
+// and the split view=query + view=meta page load shares one entry (view/query
+// params like limit/offset do not fork the key).
+func TestStats_ProxyLogsSummaryCache_FingerprintKeying(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	seedProxyLogsCacheFixture(t, db)
+
+	// Populate the status=success fingerprint.
+	if got := doGet(t, r, "/api/stats/proxy-logs?view=meta&status=success").Header().Get("x-proxy-logs-summary-cache"); got != "miss" {
+		t.Fatalf("status=success first should miss, got %q", got)
+	}
+	// The unfiltered fingerprint is a different key: must miss.
+	if got := doGet(t, r, "/api/stats/proxy-logs?view=meta").Header().Get("x-proxy-logs-summary-cache"); got != "miss" {
+		t.Fatalf("unfiltered first should miss (fingerprint-keyed cache), got %q", got)
+	}
+	// Both now hit independently.
+	if got := doGet(t, r, "/api/stats/proxy-logs?view=meta&status=success").Header().Get("x-proxy-logs-summary-cache"); got != "hit" {
+		t.Fatal("status=success should hit after population")
+	}
+	if got := doGet(t, r, "/api/stats/proxy-logs?view=meta").Header().Get("x-proxy-logs-summary-cache"); got != "hit" {
+		t.Fatal("unfiltered should hit after population")
+	}
+
+	// view=full with the same filters shares the meta fingerprint — the page's
+	// legacy full-view load must not recompute a summary the meta fetch cached.
+	if got := doGet(t, r, "/api/stats/proxy-logs?view=full").Header().Get("x-proxy-logs-summary-cache"); got != "hit" {
+		t.Fatal("view=full should hit the fingerprint cached by view=meta")
+	}
+	// Pagination params (limit/offset) are part of the list query but NOT the
+	// fingerprint: page 2 of the same filters reuses the cached summary.
+	if got := doGet(t, r, "/api/stats/proxy-logs?view=full&limit=1&offset=1").Header().Get("x-proxy-logs-summary-cache"); got != "hit" {
+		t.Fatal("page-turn (limit/offset change) should hit the same fingerprint")
+	}
+}
+
+// TestStats_ProxyLogsSummaryCache_SiteIdFilterStillAggregates guards the
+// conditional-join path: with siteId set the aggregate FROM keeps the
+// accounts/sites join (the WHERE references s.id) and the summary must still
+// count only the filtered site's logs.
+func TestStats_ProxyLogsSummaryCache_SiteIdFilterStillAggregates(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	mustExec(t, db, `INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "agg-site", "https://agg.example.test", "openai", now, now)
+	var siteID int64
+	if err := db.Get(&siteID, "SELECT id FROM sites WHERE name = ?", "agg-site"); err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+	mustExec(t, db, `INSERT INTO accounts (site_id, username, access_token, status, balance, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, FALSE, ?, ?)`, siteID, "agg-user", "sk-agg", 1.0, now, now)
+	var accountID int64
+	if err := db.Get(&accountID, "SELECT id FROM accounts WHERE username = ?", "agg-user"); err != nil {
+		t.Fatalf("account id: %v", err)
+	}
+	mustExec(t, db, `INSERT INTO proxy_logs (account_id, model_requested, model_actual, status, total_tokens, estimated_cost, created_at)
+		VALUES (?, 'agg-linked', 'agg-linked', 'success', 30, 0.2, ?)`, accountID, now)
+	// A standalone row (no account) must NOT count toward the site filter.
+	mustExec(t, db, `INSERT INTO proxy_logs (model_requested, model_actual, status, total_tokens, estimated_cost, created_at)
+		VALUES ('agg-orphan', 'agg-orphan', 'success', 99, 0.9, ?)`, now)
+
+	summary, _ := fetchProxyLogsSummaryBody(t, r, "view=full&siteId="+itoa(siteID))
+	if summary.TotalCount != 1 {
+		t.Fatalf("siteId summary.totalCount = %d, want 1 (only the linked row)", summary.TotalCount)
+	}
+	if summary.TotalTokensAll != 30 {
+		t.Fatalf("siteId summary.totalTokensAll = %d, want 30", summary.TotalTokensAll)
+	}
+}
+
+// TestStats_ProxyLogsAggregateSQL_NoJoinWithoutSiteID asserts the join-free
+// aggregate shape at the SQL level (the regression the 500k-row audit
+// measured: the LEFT JOINs added ~90ms to the summary and ~100ms to the
+// COUNT). Pure string assertions — no database needed.
+func TestStats_ProxyLogsAggregateSQL_NoJoinWithoutSiteID(t *testing.T) {
+	from := proxyLogsAggregateFrom(0)
+	if strings.Contains(from, "JOIN") {
+		t.Fatalf("aggregate FROM without siteId must be join-free, got %q", from)
+	}
+	if !strings.Contains(from, "FROM proxy_logs pl") {
+		t.Fatalf("aggregate FROM without siteId must scan proxy_logs directly, got %q", from)
+	}
+
+	countQuery := "SELECT COUNT(*) " + proxyLogsAggregateFrom(0) + " WHERE pl.status = 'success'"
+	if strings.Contains(countQuery, "JOIN") {
+		t.Fatalf("COUNT query without siteId must be join-free, got %q", countQuery)
+	}
+
+	summaryQuery := proxyLogsSummaryQuerySQL(proxyLogsAggregateFrom(0), "")
+	if strings.Contains(summaryQuery, "JOIN") {
+		t.Fatalf("summary query without siteId must be join-free, got %q", summaryQuery)
+	}
+	for _, alias := range []string{"total_count", "success_count", "failed_count", "total_cost", "total_tokens_all"} {
+		if !strings.Contains(summaryQuery, alias) {
+			t.Fatalf("summary query missing aggregate %q: %s", alias, summaryQuery)
+		}
+	}
+
+	// With a siteId the WHERE references s.id, so the join must stay.
+	fromSite := proxyLogsAggregateFrom(3)
+	if !strings.Contains(fromSite, "LEFT JOIN accounts a ON pl.account_id = a.id") {
+		t.Fatalf("aggregate FROM with siteId must join accounts, got %q", fromSite)
+	}
+	if !strings.Contains(fromSite, "LEFT JOIN sites s ON a.site_id = s.id") {
+		t.Fatalf("aggregate FROM with siteId must join sites, got %q", fromSite)
+	}
+	summarySite := proxyLogsSummaryQuerySQL(fromSite, " WHERE s.id = ?")
+	if !strings.Contains(summarySite, "JOIN") {
+		t.Fatalf("summary query with siteId must keep the join, got %q", summarySite)
+	}
+}
+
+// TestStats_SQLiteProxyLogsAggregatePlan_NoJoinWithoutSiteID strengthens the
+// string assertion with SQLite's query planner: the executed COUNT and summary
+// plans must not touch accounts/sites when no siteId filter is set.
+func TestStats_SQLiteProxyLogsAggregatePlan_NoJoinWithoutSiteID(t *testing.T) {
+	db, _ := setupStatsSQLiteTest(t)
+	seedProxyLogsCacheFixture(t, db)
+
+	for label, sql := range map[string]string{
+		"count":   "SELECT COUNT(*) " + proxyLogsAggregateFrom(0),
+		"summary": proxyLogsSummaryQuerySQL(proxyLogsAggregateFrom(0), ""),
+	} {
+		planRows, err := queryRowsErr(db.DB, "EXPLAIN QUERY PLAN "+sql)
+		if err != nil {
+			t.Fatalf("explain %s: %v", label, err)
+		}
+		if len(planRows) == 0 {
+			t.Fatalf("explain %s returned no plan rows", label)
+		}
+		for _, row := range planRows {
+			detail, _ := row["detail"].(string)
+			// Joined tables appear as "SEARCH a/s ... LEFT-JOIN" (alias-based);
+			// also guard against full table names in case the planner spells
+			// them out on another SQLite version.
+			if strings.Contains(detail, "LEFT-JOIN") || strings.Contains(detail, "accounts") || strings.Contains(detail, "sites") {
+				t.Fatalf("%s plan touches accounts/sites without a siteId filter: %v", label, planRows)
+			}
+		}
+	}
+
+	// Sanity check the other direction: with a siteId the plan does join
+	// (SQLite reports the joined tables by alias, e.g. "SEARCH s ... LEFT-JOIN").
+	planRows, err := queryRowsErr(db.DB, "EXPLAIN QUERY PLAN "+proxyLogsSummaryQuerySQL(proxyLogsAggregateFrom(1), " WHERE s.id = 1"))
+	if err != nil {
+		t.Fatalf("explain siteId summary: %v", err)
+	}
+	joined := false
+	for _, row := range planRows {
+		if detail, _ := row["detail"].(string); strings.Contains(detail, "LEFT-JOIN") {
+			joined = true
+		}
+	}
+	if !joined {
+		t.Fatalf("siteId summary plan should keep the LEFT JOIN: %v", planRows)
+	}
+}
+
+// TestStats_PostgresProxyLogsSummaryCache_MissThenHit is the PostgreSQL
+// dialect twin of the miss→hit contract (skipped without PG_TEST_DSN).
+func TestStats_PostgresProxyLogsSummaryCache_MissThenHit(t *testing.T) {
+	db, r := setupStatsPostgresTest(t)
+
+	suffix := "-" + time.Now().UTC().Format("150405.000000000")
+	now := time.Now().UTC().Format(time.RFC3339)
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM proxy_logs WHERE model_requested LIKE 'pg-proxylogs-cache%'")
+	})
+	for _, row := range []struct {
+		model  string
+		status string
+	}{
+		{"pg-proxylogs-cache-a" + suffix, "success"},
+		{"pg-proxylogs-cache-b" + suffix, "failed"},
+	} {
+		if _, err := db.Exec(`INSERT INTO proxy_logs (model_requested, model_actual, status, total_tokens, estimated_cost, created_at)
+			VALUES (?, ?, ?, 10, 0.05, ?)`, row.model, row.model, row.status, now); err != nil {
+			t.Fatalf("insert %s: %v", row.model, err)
+		}
+	}
+
+	// Filter by the unique model so concurrent CI runs on the shared database
+	// don't perturb the fingerprint's aggregate.
+	q := "view=meta&search=pg-proxylogs-cache-a" + suffix
+	first := doGet(t, r, "/api/stats/proxy-logs?"+q)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first meta: %d %s", first.Code, first.Body.String())
+	}
+	if got := first.Header().Get("x-proxy-logs-summary-cache"); got != "miss" {
+		t.Fatalf("first request cache header = %q, want miss", got)
+	}
+	second := doGet(t, r, "/api/stats/proxy-logs?"+q)
+	if got := second.Header().Get("x-proxy-logs-summary-cache"); got != "hit" {
+		t.Fatalf("second request cache header = %q, want hit", got)
+	}
+	if first.Body.String() != second.Body.String() {
+		t.Fatalf("cache hit body differs from miss body.\nmiss: %s\nhit:  %s", first.Body.String(), second.Body.String())
+	}
+
+	// The join-free aggregate must also hold on PG: no siteId → no join in the
+	// executed SQL (string-level check is dialect-neutral).
+	if strings.Contains(proxyLogsAggregateFrom(0), "JOIN") {
+		t.Fatal("aggregate FROM without siteId must be join-free on every dialect")
+	}
+}

--- a/handler/admin/stats_test.go
+++ b/handler/admin/stats_test.go
@@ -14,9 +14,10 @@ import (
 
 func setupStatsPostgresTest(t *testing.T) (*store.DB, chi.Router) {
 	t.Helper()
-	// Process-global cache must start empty per test so a prior test's cached
-	// summary never leaks in (especially for the DB-closed 500 test).
+	// Process-global caches must start empty per test so a prior test's
+	// cached payload never leaks in (especially for the DB-closed 500 test).
 	globalDashboardCache.clear()
+	globalProxyLogsSummaryCache.clear()
 
 	dsn := strings.TrimSpace(os.Getenv("PG_TEST_DSN"))
 	if dsn == "" {
@@ -40,9 +41,10 @@ func setupStatsPostgresTest(t *testing.T) (*store.DB, chi.Router) {
 
 func setupStatsSQLiteTest(t *testing.T) (*store.DB, chi.Router) {
 	t.Helper()
-	// Process-global cache must start empty per test so a prior test's cached
-	// summary never leaks in (especially for the DB-closed 500 test).
+	// Process-global caches must start empty per test so a prior test's
+	// cached payload never leaks in (especially for the DB-closed 500 test).
 	globalDashboardCache.clear()
+	globalProxyLogsSummaryCache.clear()
 	db, err := store.Open(store.DialectSQLite, ":memory:", false)
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)

--- a/store/indexes.go
+++ b/store/indexes.go
@@ -1,6 +1,6 @@
 package store
 
-// buildIndexes returns all 69 non-UNIQUE index creation statements.
+// buildIndexes returns all 70 non-UNIQUE index creation statements.
 // Both SQLite and PostgreSQL support CREATE INDEX IF NOT EXISTS syntax.
 // UNIQUE constraints are already handled inside CREATE TABLE via CONSTRAINT... UNIQUE.
 func buildIndexes() []struct {
@@ -65,6 +65,16 @@ func buildIndexes() []struct {
 		{"proxy_logs_downstream_api_key_created_at_idx", `CREATE INDEX IF NOT EXISTS proxy_logs_downstream_api_key_created_at_idx ON proxy_logs (downstream_api_key_id, created_at)`},
 		{"proxy_logs_client_app_id_created_at_idx", `CREATE INDEX IF NOT EXISTS proxy_logs_client_app_id_created_at_idx ON proxy_logs (client_app_id, created_at)`},
 		{"proxy_logs_client_family_created_at_idx", `CREATE INDEX IF NOT EXISTS proxy_logs_client_family_created_at_idx ON proxy_logs (client_family, created_at)`},
+		// proxy_logs_summary_covering_idx covers the proxy-logs summary aggregate
+		// (COUNT + success/failed CASEs on status, SUM of estimated_cost, and the
+		// effective-token CASE over total_tokens with prompt/completion fallback),
+		// letting SQLite/PostgreSQL satisfy the five SUMs from the index alone
+		// instead of scanning the heap (~1s at 500k rows; the covering scan
+		// measured ~40% faster than the table scan on the audit fixture). All
+		// five columns are base-schema columns, so fresh AND existing installs
+		// converge via this normal buildIndexes pass (no additive step needed,
+		// unlike proxy_logs_request_id_created_at_idx whose column is additive).
+		{"proxy_logs_summary_covering_idx", `CREATE INDEX IF NOT EXISTS proxy_logs_summary_covering_idx ON proxy_logs (status, estimated_cost, total_tokens, prompt_tokens, completion_tokens)`},
 		// proxy_logs_request_id_created_at_idx is created by additive step
 		// sc2_004_proxy_logs_request_id (after the request_id column exists).
 		// proxy_debug_traces

--- a/web/src/features/proxy-logs/__tests__/proxy-logs-query-payload.test.tsx
+++ b/web/src/features/proxy-logs/__tests__/proxy-logs-query-payload.test.tsx
@@ -1,7 +1,10 @@
 // Behavior test for the useProxyLogs query payload. Mocks the shared
 // axios instance (http-client) so the real `request()` transport runs end
 // to end and the request URL can be inspected — asserting the latency
-// bounds added to ProxyLogsQuery are serialized server-side.
+// bounds added to ProxyLogsQuery are serialized server-side, and that the
+// list fetch uses the list-only `view=query` endpoint (the five-way summary
+// aggregate travels exclusively via useProxyLogsMeta — fetching it in the
+// list payload too was the double-compute perf regression).
 //
 // The original bug kept `latencyMin`/`latencyMax` OUT of the page's query
 // payload (filtering client-side), so `total` (server, unfiltered) and
@@ -90,6 +93,27 @@ function firstRequestedUrl(): string {
   }
   return url
 }
+
+describe('useProxyLogs — list-only view contract', () => {
+  it('requests view=query so the list fetch never recomputes the summary', async () => {
+    const params: ProxyLogsQuery = { limit: 20, offset: 0 }
+    const queryClient = createQueryClient()
+    renderHook(() => useProxyLogs(params), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => {
+      expect(mockApiClientGet).toHaveBeenCalledTimes(1)
+    })
+
+    const requestedUrl = firstRequestedUrl()
+    expect(requestedUrl).toContain('/api/stats/proxy-logs')
+    // view=query returns items/total only — summary/sites/clientOptions are
+    // owned by useProxyLogsMeta (view=meta). A default (full) fetch here
+    // would double the summary aggregate work per page load.
+    expect(requestedUrl).toContain('view=query')
+  })
+})
 
 describe('useProxyLogs — latency filter payload', () => {
   it('serializes latencyMin and latencyMax into the request URL when set', async () => {

--- a/web/src/features/proxy-logs/api.ts
+++ b/web/src/features/proxy-logs/api.ts
@@ -1,11 +1,13 @@
 // metapi-go/features/proxy-logs — TanStack Query hooks wrapping `lib/api.ts`.
 //
-// The proxy-logs backend is server-paginated (`getProxyLogs` returns
-// items + total + page + pageSize), so `useProxyLogs` accepts the full
-// `ProxyLogsQuery` (limit/offset/status/search/client/siteId/from/to) and
-// the list page drives it from the URL-synced filter state. `useProxyLog`
-// fetches the detail payload by id. `useProxyLogsMeta` returns the
-// clientOptions / summary / sites facets used by the toolbar.
+// The proxy-logs backend is server-paginated. The list and the facets are
+// split across two endpoints so the expensive five-way summary aggregate is
+// computed exactly once per page load: `useProxyLogs` hits `view=query`
+// (items + total only — no summary/sites/clientOptions payload), while
+// `useProxyLogsMeta` (view=meta) is the single owner of the summary strip +
+// toolbar facets. The previous wiring fetched the default `full` view (which
+// embeds the summary) AND `view=meta`, running the aggregate twice per load.
+// `useProxyLog` fetches the detail payload by id.
 
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 
@@ -16,21 +18,23 @@ import { proxyLogsKeys, type ProxyLogDetail } from './types'
 // Resolve the data type returned by each backend method. The methods return
 // `Promise<T>`; `Awaited<...>` unwraps the promise so the query data type is
 // the parsed payload, not the promise wrapper.
-type ProxyLogsResponseData = Awaited<ReturnType<typeof api.getProxyLogs>>
+type ProxyLogsQueryData = Awaited<ReturnType<typeof api.getProxyLogsQuery>>
 type ProxyLogsMetaData = Awaited<ReturnType<typeof api.getProxyLogsMeta>>
 
 /**
- * Fetch a page of proxy logs. The query key embeds the full filter object so
- * cache reuse is exact; the page passes a stable `ProxyLogsQuery` (built
- * from URL state) so re-renders with the same filters don't refetch.
+ * Fetch a page of proxy logs via the list-only `view=query` endpoint
+ * (items/total/page/pageSize — the summary aggregate travels exclusively via
+ * `useProxyLogsMeta`). The query key embeds the full filter object so cache
+ * reuse is exact; the page passes a stable `ProxyLogsQuery` (built from URL
+ * state) so re-renders with the same filters don't refetch.
  */
 export function useProxyLogs(
   params: ProxyLogsQuery,
-  options?: Omit<UseQueryOptions<ProxyLogsResponseData>, 'queryKey' | 'queryFn'>
+  options?: Omit<UseQueryOptions<ProxyLogsQueryData>, 'queryKey' | 'queryFn'>
 ) {
   return useQuery({
     queryKey: proxyLogsKeys.list(params),
-    queryFn: async () => api.getProxyLogs(params),
+    queryFn: async () => api.getProxyLogsQuery(params),
     placeholderData: (previous) => previous,
     ...options,
   })

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -228,7 +228,12 @@ export function ProxyLogsPage() {
   const logsQuery = useProxyLogs(queryPayload, {
     refetchInterval: intervalMs === false ? false : intervalMs,
   })
-  const metaQuery = useProxyLogsMeta(metaPayload)
+  // The meta query is the single owner of the summary aggregate (the list
+  // fetch is view=query and carries no summary) — refetch it on the same
+  // interval so auto-refresh keeps the summary strip as fresh as the rows.
+  const metaQuery = useProxyLogsMeta(metaPayload, {
+    refetchInterval: intervalMs === false ? false : intervalMs,
+  })
   const rawItems = useMemo(() => logsQuery.data?.items ?? [], [logsQuery.data])
   const total = logsQuery.data?.total ?? 0
 
@@ -269,7 +274,7 @@ export function ProxyLogsPage() {
     totalCount: total,
   })
 
-  const summary = logsQuery.data?.summary
+  const summary = metaQuery.data?.summary
   const clientOptions = metaQuery.data?.clientOptions ?? []
   const siteOptions = metaQuery.data?.sites ?? []
 
@@ -298,7 +303,7 @@ export function ProxyLogsPage() {
         limit: PROXY_LOGS_CSV_EXPORT_LIMIT,
         offset: 0,
       }
-      const response = await api.getProxyLogs(exportPayload)
+      const response = await api.getProxyLogsQuery(exportPayload)
       const rows = response.items ?? []
       const csv = proxyLogsToCsv(rows, t)
       const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
@@ -338,8 +343,13 @@ export function ProxyLogsPage() {
           <ProxyLogsHeaderActions
             onExport={handleExportCsv}
             isExporting={isExporting}
-            onRefresh={() => logsQuery.refetch()}
-            isRefreshing={logsQuery.isFetching}
+            onRefresh={() => {
+              // Refresh both halves of the split fetch: the list (view=query)
+              // and the meta facets/summary (view=meta).
+              logsQuery.refetch()
+              metaQuery.refetch()
+            }}
+            isRefreshing={logsQuery.isFetching || metaQuery.isFetching}
           />
         </div>
       </div>

--- a/web/src/routes/_authenticated/proxy-logs.tsx
+++ b/web/src/routes/_authenticated/proxy-logs.tsx
@@ -87,7 +87,9 @@ export const Route = createFileRoute('/_authenticated/proxy-logs')({
     await Promise.all([
       context.queryClient.prefetchQuery({
         queryKey: proxyLogsKeys.list(queryPayload),
-        queryFn: () => api.getProxyLogs(queryPayload),
+        // List-only view=query: the summary aggregate is owned by the meta
+        // prefetch below, so a route load computes it once, not twice.
+        queryFn: () => api.getProxyLogsQuery(queryPayload),
       }),
       context.queryClient.prefetchQuery({
         queryKey: proxyLogsKeys.meta(metaPayload),


### PR DESCRIPTION
proxy-logs 页每次打开 3 次过滤全扫 + summary 聚合重复两遍（审计实测 500k 行 ≈1.2-2.4s DB CPU/次浏览）。

- **前端**：列表走 view=query，summary/sites/clientOptions 归 meta 独占——每次加载 summary 只算一遍（路由 loader 预取/摘要条/CSV 导出/Refresh 全接线）
- **后端**：summary 10s-TTL singleflight 缓存（过滤指纹为键，翻页共享；`?force=1/?refresh=1` 穿透；错误不缓存）
- **后端**：无 siteId 时 COUNT/summary 去 join；5 列 covering 索引（EXPLAIN 确认 covering scan——实测修正了 3 列方案不覆盖的问题）

测试：SQLite + 本地 PG16 双方言全绿；新增 view/缓存/EXPLAIN/join 断言；前端 49/49。
