### PR TITLE
perf(routing): serve hot-path route list from TTL cache, cache re: regex compiles

### DIFF
--- a/routing/cache.go
+++ b/routing/cache.go
@@ -35,9 +35,10 @@ func InvalidateCache() {
 	}
 }
 
-// RouteCache caches the routes list and per-route matches with TTL.
-// The routes list is used by handler/admin tests to assert cache invalidation
-// semantics; the selector itself reads routes straight from the DB.
+// RouteCache caches the routes list and per-route matches with TTL. The
+// selector serves both from cache on the hot path and falls back to the DB on
+// miss/expiry. Cached matches are immutable snapshots: patching clones (see
+// PatchCachedChannel), so lock-free readers never race the patcher.
 type RouteCache struct {
 	mu           sync.RWMutex
 	routesLoaded bool
@@ -113,20 +114,34 @@ func (c *RouteCache) SetMatch(routeID int64, match *RouteMatch) {
 	}
 }
 
-// PatchCachedChannel applies a mutation to a channel in all cached matches.
+// PatchCachedChannel applies a mutation to a channel across all cached
+// matches. Cached matches are treated as immutable snapshots: the mutation is
+// applied to a clone that atomically replaces the cached entry, so goroutines
+// holding a previously returned snapshot (GetMatch readers use the match
+// outside the cache lock) keep reading consistent data instead of racing the
+// patcher.
 func (c *RouteCache) PatchCachedChannel(channelID int64, apply func(ch *store.RouteChannel)) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	for _, entry := range c.matchCache {
+	for routeID, entry := range c.matchCache {
 		if entry.match == nil {
 			continue
 		}
+		idx := -1
 		for i := range entry.match.Channels {
 			if entry.match.Channels[i].Channel.ID == channelID {
-				apply(&entry.match.Channels[i].Channel)
+				idx = i
 				break
 			}
 		}
+		if idx < 0 {
+			continue
+		}
+		cloned := &RouteMatch{Route: entry.match.Route}
+		cloned.Channels = make([]RouteChannelCandidate, len(entry.match.Channels))
+		copy(cloned.Channels, entry.match.Channels)
+		apply(&cloned.Channels[idx].Channel)
+		c.matchCache[routeID] = &routeMatchEntry{loadedAt: entry.loadedAt, match: cloned}
 	}
 }
 

--- a/routing/matcher.go
+++ b/routing/matcher.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 // isRegexPrefix reports whether s starts with the "re:" prefix in any letter
@@ -23,6 +24,8 @@ func IsRegexModelPattern(pattern string) bool {
 }
 
 // ParseRegexModelPattern parses a "re:..." pattern into a compiled regexp.
+// Compiled bodies are cached process-wide (regexCompileCache), so repeated
+// calls with the same pattern reuse one compiled, goroutine-safe instance.
 func ParseRegexModelPattern(pattern string) *regexp.Regexp {
 	raw := strings.TrimSpace(pattern)
 	if !isRegexPrefix(raw) {
@@ -34,10 +37,35 @@ func ParseRegexModelPattern(pattern string) *regexp.Regexp {
 	if reBody == "" {
 		return nil
 	}
-	re, err := regexp.Compile(reBody)
-	if err != nil {
-		return nil
+	return compileRegexCached(reBody)
+}
+
+// regexCompileCache maps regex bodies (the pattern with its "re:" prefix
+// trimmed) to compiled *regexp.Regexp instances so hot routing paths stop
+// recompiling identical patterns on every request/retry. regexp.Regexp values
+// are immutable and safe for concurrent use, so sharing one compiled instance
+// across goroutines is safe. Invalid bodies are cached as nil so a bad
+// operator-authored pattern pays the compile-error cost once, not per request.
+//
+// Capacity: keys are operator-authored pattern bodies (route model patterns,
+// downstream-policy supported models, model-mapping keys); the entry count is
+// bounded by configuration size (roughly the route count), not by traffic, so
+// no eviction is needed.
+var regexCompileCache sync.Map
+
+// compileRegexCached returns the shared compiled regexp for body, compiling
+// and caching it on first use. It returns nil (and caches the failure) for
+// invalid bodies.
+func compileRegexCached(body string) *regexp.Regexp {
+	if v, ok := regexCompileCache.Load(body); ok {
+		re, _ := v.(*regexp.Regexp)
+		return re
 	}
+	re, err := regexp.Compile(body)
+	if err != nil {
+		re = nil
+	}
+	regexCompileCache.Store(body, re)
 	return re
 }
 

--- a/routing/selector.go
+++ b/routing/selector.go
@@ -413,8 +413,38 @@ func softFilterCandidatesStrict(
 	return healthy
 }
 
-func (s *ChannelSelector) findRoute(ctx context.Context, model string, policy DownstreamRoutingPolicy) (*RouteMatch, error) {
+// loadEnabledRoutes returns enabled routes, serving them from the route cache
+// while it is fresh (IsRoutesFresh/GetRoutes) and falling back to the DB only
+// on a miss, then repopulating the cache (SetRoutes). Every route-mutation
+// path (route/channel CRUD, rebuild, account/site changes, failure-state
+// recovery) funnels through routing.InvalidateCache -> InvalidateAll, which
+// clears the cached list; worst-case staleness is therefore bounded by TTL.
+// The returned slice is shared across goroutines and must be treated as
+// read-only (findRoute only copies elements out of it).
+func (s *ChannelSelector) loadEnabledRoutes(ctx context.Context) ([]store.TokenRoute, error) {
+	if s.cache != nil && s.cache.IsRoutesFresh() {
+		if routes := s.cache.GetRoutes(); routes != nil {
+			return routes, nil
+		}
+	}
 	routes, err := s.db.LoadEnabledRoutes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if s.cache != nil {
+		if routes == nil {
+			// Cache empty results too (as a non-nil slice): GetRoutes uses
+			// nil to signal miss/stale, and a deployment with zero enabled
+			// routes must not re-query on every request.
+			routes = []store.TokenRoute{}
+		}
+		s.cache.SetRoutes(routes)
+	}
+	return routes, nil
+}
+
+func (s *ChannelSelector) findRoute(ctx context.Context, model string, policy DownstreamRoutingPolicy) (*RouteMatch, error) {
+	routes, err := s.loadEnabledRoutes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("findRoute: load routes: %w", err)
 	}
@@ -444,35 +474,42 @@ func (s *ChannelSelector) findRoute(ctx context.Context, model string, policy Do
 	// Match priority: 1) explicit_group displayName exact, 2) exact model pattern,
 	// 3) displayName exact, 4) wildcard. Within the first non-empty bucket,
 	// multi-tier context may re-rank when RequestedContextTokens > 0.
-	collect := func(pred func(*store.TokenRoute) bool) []store.TokenRoute {
-		out := make([]store.TokenRoute, 0)
-		for i := range routes {
-			r := &routes[i]
-			if pred(r) {
-				out = append(out, *r)
+	// Buckets 1-3 share a single pass over routes (cheap predicates); the
+	// wildcard/regex bucket is scanned only when all three cheap buckets came
+	// back empty, preserving the original priority order and early exit while
+	// cutting up to four full scans down to at most two.
+	var explicitGroupBucket, exactPatternBucket, displayNameBucket []store.TokenRoute
+	for i := range routes {
+		r := &routes[i]
+		if IsExplicitGroupRoute(r.RouteMode) {
+			if IsRouteDisplayNameMatch(model, r.DisplayName) {
+				explicitGroupBucket = append(explicitGroupBucket, *r)
 			}
+			continue
 		}
-		return out
+		if IsExactRouteModelPattern(r.ModelPattern) && strings.TrimSpace(r.ModelPattern) == model {
+			exactPatternBucket = append(exactPatternBucket, *r)
+		}
+		if IsRouteDisplayNameMatch(model, r.DisplayName) {
+			displayNameBucket = append(displayNameBucket, *r)
+		}
 	}
 
 	var bucket []store.TokenRoute
-	bucket = collect(func(r *store.TokenRoute) bool {
-		return IsExplicitGroupRoute(r.RouteMode) && IsRouteDisplayNameMatch(model, r.DisplayName)
-	})
-	if len(bucket) == 0 {
-		bucket = collect(func(r *store.TokenRoute) bool {
-			return !IsExplicitGroupRoute(r.RouteMode) && IsExactRouteModelPattern(r.ModelPattern) && strings.TrimSpace(r.ModelPattern) == model
-		})
-	}
-	if len(bucket) == 0 {
-		bucket = collect(func(r *store.TokenRoute) bool {
-			return !IsExplicitGroupRoute(r.RouteMode) && IsRouteDisplayNameMatch(model, r.DisplayName)
-		})
-	}
-	if len(bucket) == 0 {
-		bucket = collect(func(r *store.TokenRoute) bool {
-			return !IsExplicitGroupRoute(r.RouteMode) && MatchesModelPattern(model, r.ModelPattern)
-		})
+	switch {
+	case len(explicitGroupBucket) > 0:
+		bucket = explicitGroupBucket
+	case len(exactPatternBucket) > 0:
+		bucket = exactPatternBucket
+	case len(displayNameBucket) > 0:
+		bucket = displayNameBucket
+	default:
+		for i := range routes {
+			r := &routes[i]
+			if !IsExplicitGroupRoute(r.RouteMode) && MatchesModelPattern(model, r.ModelPattern) {
+				bucket = append(bucket, *r)
+			}
+		}
 	}
 
 	if len(bucket) == 0 {
@@ -607,7 +644,7 @@ func (s *ChannelSelector) loadFallbackSourceModelByRouteID(ctx context.Context, 
 	}
 
 	// Load enabled routes and map model patterns for every source route ID.
-	routes, err := s.db.LoadEnabledRoutes(ctx)
+	routes, err := s.loadEnabledRoutes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("loadRouteMatch: load source route patterns: %w", err)
 	}

--- a/routing/selector_route_cache_test.go
+++ b/routing/selector_route_cache_test.go
@@ -1,0 +1,485 @@
+package routing
+
+// Route-list cache wiring tests (perf: routing hot path). The selector must
+// serve LoadEnabledRoutes from the TTL route cache, re-query the DB after
+// invalidation, stay safe under concurrency, and reflect route CRUD changes
+// immediately once the mutation path calls routing.InvalidateCache().
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// countingRoutesDB embeds preferredDB and counts LoadEnabledRoutes calls.
+// LoadRouteChannels is filtered by the requested route IDs so each route only
+// ever sees its own channels.
+type countingRoutesDB struct {
+	*preferredDB
+	loadCalls atomic.Int64
+	failures  atomic.Int64
+}
+
+func (db *countingRoutesDB) LoadEnabledRoutes(ctx context.Context) ([]store.TokenRoute, error) {
+	db.loadCalls.Add(1)
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	out := make([]store.TokenRoute, len(db.routes))
+	copy(out, db.routes)
+	return out, nil
+}
+
+func (db *countingRoutesDB) LoadRouteChannels(ctx context.Context, routeIDs []int64) ([]struct {
+	Channel store.RouteChannel
+	Account store.Account
+	Site    store.Site
+	Token   *store.AccountToken
+}, error) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	want := make(map[int64]bool, len(routeIDs))
+	for _, id := range routeIDs {
+		want[id] = true
+	}
+	var out []struct {
+		Channel store.RouteChannel
+		Account store.Account
+		Site    store.Site
+		Token   *store.AccountToken
+	}
+	for _, j := range db.joined {
+		if want[j.Channel.RouteID] {
+			out = append(out, j)
+		}
+	}
+	return out, nil
+}
+
+func (db *countingRoutesDB) setRoutes(routes []store.TokenRoute) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.routes = routes
+}
+
+func (db *countingRoutesDB) setJoined(rows ...struct {
+	Channel store.RouteChannel
+	Account store.Account
+	Site    store.Site
+	Token   *store.AccountToken
+}) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.joined = rows
+}
+
+// countingEligibleJoined builds an eligible channel/account/site row for the
+// given route (preferredEligibleJoined hardcodes RouteID 1).
+func countingEligibleJoined(routeID, channelID, siteID, accountID int64, model string) struct {
+	Channel store.RouteChannel
+	Account store.Account
+	Site    store.Site
+	Token   *store.AccountToken
+} {
+	m := model
+	token := "tok-" + strconv.FormatInt(accountID, 10)
+	return struct {
+		Channel store.RouteChannel
+		Account store.Account
+		Site    store.Site
+		Token   *store.AccountToken
+	}{
+		Channel: store.RouteChannel{
+			ID:          channelID,
+			RouteID:     routeID,
+			AccountID:   accountID,
+			SourceModel: &m,
+			Priority:    0,
+			Weight:      10,
+			Enabled:     true,
+		},
+		Account: store.Account{
+			ID:       accountID,
+			SiteID:   siteID,
+			Status:   "active",
+			APIToken: &token,
+			Balance:  ptrFloat(100),
+		},
+		Site: store.Site{
+			ID:     siteID,
+			Status: "active",
+		},
+	}
+}
+
+func newCountingSelector(db *countingRoutesDB, cache *RouteCache) *ChannelSelector {
+	return NewChannelSelector(db, cache, 3600, defaultRoutingWeights(), nil, 1.0, nil)
+}
+
+func resetHealthForCacheTest(t *testing.T) {
+	t.Helper()
+	ResetSiteRuntimeHealthState()
+	siteRuntimeHealthLoaded = true
+	t.Cleanup(ResetSiteRuntimeHealthState)
+}
+
+func countingTestRoute(id int64, pattern string) store.TokenRoute {
+	return store.TokenRoute{
+		ID:              id,
+		ModelPattern:    pattern,
+		RouteMode:       "pattern",
+		RoutingStrategy: "weighted",
+		Enabled:         true,
+	}
+}
+
+// TestSelectChannel_CacheHitSkipsDB proves repeated selections serve the
+// route list from the cache without re-querying the DB.
+func TestSelectChannel_CacheHitSkipsDB(t *testing.T) {
+	resetHealthForCacheTest(t)
+
+	model := "gpt-cache-hit"
+	db := &countingRoutesDB{preferredDB: &preferredDB{
+		routes: []store.TokenRoute{countingTestRoute(1, model)},
+	}}
+	db.setJoined(countingEligibleJoined(1, 101, 10, 1001, model))
+	selector := newCountingSelector(db, NewRouteCache(60_000))
+
+	for i := 0; i < 5; i++ {
+		sel, err := selector.SelectChannel(context.Background(), model, EmptyDownstreamRoutingPolicy)
+		if err != nil {
+			t.Fatalf("SelectChannel #%d error: %v", i, err)
+		}
+		if sel == nil || sel.Channel.ID != 101 {
+			t.Fatalf("SelectChannel #%d = %+v, want channel 101", i, sel)
+		}
+	}
+	if got := db.loadCalls.Load(); got != 1 {
+		t.Fatalf("LoadEnabledRoutes called %d times for 5 selections, want 1 (cache hits must not query DB)", got)
+	}
+}
+
+// TestSelectChannel_InvalidationForcesReload proves routing.InvalidateCache()
+// (the entry point used by every admin/service mutation path) drops the cached
+// route list so the next selection re-queries the DB and sees new routes.
+func TestSelectChannel_InvalidationForcesReload(t *testing.T) {
+	resetHealthForCacheTest(t)
+
+	cache := NewRouteCache(60_000)
+	globalCacheMu.RLock()
+	prev := globalCache
+	globalCacheMu.RUnlock()
+	SetGlobalCache(cache)
+	t.Cleanup(func() { SetGlobalCache(prev) })
+
+	db := &countingRoutesDB{preferredDB: &preferredDB{
+		routes: []store.TokenRoute{countingTestRoute(1, "gpt-old")},
+	}}
+	db.setJoined(countingEligibleJoined(1, 101, 10, 1001, "gpt-old"))
+	selector := newCountingSelector(db, cache)
+
+	sel, err := selector.SelectChannel(context.Background(), "gpt-old", EmptyDownstreamRoutingPolicy)
+	if err != nil || sel == nil || sel.Channel.ID != 101 {
+		t.Fatalf("initial select = %+v, err=%v; want channel 101", sel, err)
+	}
+	if got := db.loadCalls.Load(); got != 1 {
+		t.Fatalf("loadCalls = %d, want 1", got)
+	}
+
+	// Admin adds a route; the handler calls routing.InvalidateCache().
+	db.setRoutes([]store.TokenRoute{
+		countingTestRoute(1, "gpt-old"),
+		countingTestRoute(2, "gpt-new"),
+	})
+	db.setJoined(
+		countingEligibleJoined(1, 101, 10, 1001, "gpt-old"),
+		countingEligibleJoined(2, 201, 20, 2001, "gpt-new"),
+	)
+	InvalidateCache()
+
+	sel, err = selector.SelectChannel(context.Background(), "gpt-new", EmptyDownstreamRoutingPolicy)
+	if err != nil || sel == nil || sel.Channel.ID != 201 {
+		t.Fatalf("post-invalidation select = %+v, err=%v; want channel 201", sel, err)
+	}
+	if got := db.loadCalls.Load(); got != 2 {
+		t.Fatalf("loadCalls = %d after invalidation, want 2", got)
+	}
+}
+
+// TestSelectChannel_TTLExpiryRefetches proves a stale cache falls back to the
+// DB (TTL is the staleness backstop even without explicit invalidation).
+func TestSelectChannel_TTLExpiryRefetches(t *testing.T) {
+	resetHealthForCacheTest(t)
+
+	model := "gpt-ttl-expiry"
+	db := &countingRoutesDB{preferredDB: &preferredDB{
+		routes: []store.TokenRoute{countingTestRoute(1, model)},
+	}}
+	db.setJoined(countingEligibleJoined(1, 101, 10, 1001, model))
+	selector := newCountingSelector(db, NewRouteCache(100)) // minimum TTL
+
+	if _, err := selector.SelectChannel(context.Background(), model, EmptyDownstreamRoutingPolicy); err != nil {
+		t.Fatal(err)
+	}
+	if got := db.loadCalls.Load(); got != 1 {
+		t.Fatalf("loadCalls = %d, want 1", got)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	sel, err := selector.SelectChannel(context.Background(), model, EmptyDownstreamRoutingPolicy)
+	if err != nil || sel == nil {
+		t.Fatalf("post-expiry select = %+v, err=%v", sel, err)
+	}
+	if got := db.loadCalls.Load(); got != 2 {
+		t.Fatalf("loadCalls = %d after TTL expiry, want 2", got)
+	}
+}
+
+// TestSelectChannel_ConcurrentSafe hammers the selector from many goroutines:
+// warm-cache reads must not re-query the DB, and mixed invalidate/read traffic
+// must stay race- and panic-free. Run with -race.
+func TestSelectChannel_ConcurrentSafe(t *testing.T) {
+	resetHealthForCacheTest(t)
+
+	model := "gpt-concurrent"
+	db := &countingRoutesDB{preferredDB: &preferredDB{
+		routes: []store.TokenRoute{countingTestRoute(1, model)},
+	}}
+	db.setJoined(countingEligibleJoined(1, 101, 10, 1001, model))
+	cache := NewRouteCache(60_000)
+	selector := newCountingSelector(db, cache)
+
+	// Warm the cache so the concurrent phase is pure cache-hit.
+	if sel, err := selector.SelectChannel(context.Background(), model, EmptyDownstreamRoutingPolicy); err != nil || sel == nil {
+		t.Fatalf("warm-up select = %+v, err=%v", sel, err)
+	}
+	if got := db.loadCalls.Load(); got != 1 {
+		t.Fatalf("warm-up loadCalls = %d, want 1", got)
+	}
+
+	const goroutines = 16
+	const iters = 25
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				sel, err := selector.SelectChannel(context.Background(), model, EmptyDownstreamRoutingPolicy)
+				if err != nil || sel == nil || sel.Channel.ID != 101 {
+					db.failures.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if f := db.failures.Load(); f != 0 {
+		t.Fatalf("%d concurrent selections failed", f)
+	}
+	if got := db.loadCalls.Load(); got != 1 {
+		t.Fatalf("loadCalls = %d during %d concurrent cache-hit selections, want 1", got, goroutines*iters)
+	}
+
+	// Mixed invalidation + reads: must stay race-free and keep serving.
+	stop := make(chan struct{})
+	var writer sync.WaitGroup
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				cache.InvalidateAll()
+			}
+		}
+	}()
+	var readers sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			deadline := time.Now().Add(50 * time.Millisecond)
+			for time.Now().Before(deadline) {
+				sel, err := selector.SelectChannel(context.Background(), model, EmptyDownstreamRoutingPolicy)
+				if err != nil || sel == nil {
+					db.failures.Add(1)
+				}
+			}
+		}()
+	}
+	readers.Wait()
+	close(stop)
+	writer.Wait()
+	if f := db.failures.Load(); f != 0 {
+		t.Fatalf("%d selections failed during concurrent invalidation", f)
+	}
+}
+
+// TestSelectChannel_ReflectsRouteCRUDAfterInvalidation is the behavior
+// regression: route create/update/delete take effect on the very next
+// selection once the mutation path invalidates (as every CRUD handler does).
+func TestSelectChannel_ReflectsRouteCRUDAfterInvalidation(t *testing.T) {
+	resetHealthForCacheTest(t)
+
+	cache := NewRouteCache(60_000)
+	globalCacheMu.RLock()
+	prev := globalCache
+	globalCacheMu.RUnlock()
+	SetGlobalCache(cache)
+	t.Cleanup(func() { SetGlobalCache(prev) })
+
+	db := &countingRoutesDB{preferredDB: &preferredDB{}}
+	selector := newCountingSelector(db, cache)
+	ctx := context.Background()
+
+	// Create: route appears -> immediately selectable.
+	db.setRoutes([]store.TokenRoute{countingTestRoute(1, "gpt-crud")})
+	db.setJoined(countingEligibleJoined(1, 101, 10, 1001, "gpt-crud"))
+	InvalidateCache()
+	sel, err := selector.SelectChannel(ctx, "gpt-crud", EmptyDownstreamRoutingPolicy)
+	if err != nil || sel == nil || sel.Channel.ID != 101 {
+		t.Fatalf("after create: select = %+v, err=%v; want channel 101", sel, err)
+	}
+
+	// Update: model_pattern changes (and the rebuild refreshes the channel's
+	// source model) -> old name stops routing, new name routes.
+	db.setRoutes([]store.TokenRoute{countingTestRoute(1, "gpt-crud-v2")})
+	db.setJoined(countingEligibleJoined(1, 101, 10, 1001, "gpt-crud-v2"))
+	InvalidateCache()
+	if sel, err := selector.SelectChannel(ctx, "gpt-crud", EmptyDownstreamRoutingPolicy); err != nil || sel != nil {
+		t.Fatalf("after update: stale name select = %+v, err=%v; want nil", sel, err)
+	}
+	sel, err = selector.SelectChannel(ctx, "gpt-crud-v2", EmptyDownstreamRoutingPolicy)
+	if err != nil || sel == nil || sel.Channel.ID != 101 {
+		t.Fatalf("after update: new name select = %+v, err=%v; want channel 101", sel, err)
+	}
+
+	// Delete: route removed -> model no longer routes.
+	db.setRoutes(nil)
+	db.setJoined()
+	InvalidateCache()
+	if sel, err := selector.SelectChannel(ctx, "gpt-crud-v2", EmptyDownstreamRoutingPolicy); err != nil || sel != nil {
+		t.Fatalf("after delete: select = %+v, err=%v; want nil", sel, err)
+	}
+
+	// Each invalidation forced exactly one reload on the next selection.
+	if got := db.loadCalls.Load(); got != 3 {
+		t.Fatalf("loadCalls = %d across create/update/delete, want 3", got)
+	}
+}
+
+// TestParseRegexModelPattern_CachedCompile proves re: patterns compile once
+// per body and reuse the shared instance (including across prefix casings),
+// and that invalid bodies cache their failure instead of recompiling.
+func TestParseRegexModelPattern_CachedCompile(t *testing.T) {
+	re1 := ParseRegexModelPattern("re:^claude-3-[0-9]+$")
+	re2 := ParseRegexModelPattern("re:^claude-3-[0-9]+$")
+	if re1 == nil {
+		t.Fatal("expected compiled regexp")
+	}
+	if re1 != re2 {
+		t.Fatal("expected the same cached *regexp.Regexp instance for identical bodies")
+	}
+	if !re1.MatchString("claude-3-20240101") {
+		t.Fatal("cached regexp must still match")
+	}
+
+	// Prefix casing differs, body identical -> same cache entry.
+	if re3 := ParseRegexModelPattern("RE:^claude-3-[0-9]+$"); re3 != re1 {
+		t.Fatal("expected body-level caching regardless of re: prefix casing")
+	}
+
+	// Invalid body -> nil, stable across calls.
+	if ParseRegexModelPattern("re:[unclosed") != nil {
+		t.Fatal("expected nil for invalid body")
+	}
+	if ParseRegexModelPattern("re:[unclosed") != nil {
+		t.Fatal("expected cached nil for invalid body")
+	}
+}
+
+// BenchmarkMatchesModelPattern_Regex measures the cached hot path.
+func BenchmarkMatchesModelPattern_Regex(b *testing.B) {
+	const pattern = "re:^claude-3-[a-z0-9-]+$"
+	const model = "claude-3-5-sonnet-20241022"
+	if !MatchesModelPattern(model, pattern) {
+		b.Fatal("pattern must match")
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		MatchesModelPattern(model, pattern)
+	}
+}
+
+// BenchmarkMatchesModelPattern_RegexCompilePerCall is the pre-fix reference:
+// MatchesModelPattern recompiled the pattern on every call.
+func BenchmarkMatchesModelPattern_RegexCompilePerCall(b *testing.B) {
+	const model = "claude-3-5-sonnet-20241022"
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		re, err := regexp.Compile(`^claude-3-[a-z0-9-]+$`)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = re.MatchString(model)
+	}
+}
+
+// BenchmarkFindRoute_RouteListCached measures the hot findRoute path with a
+// warm route cache over 100 routes (99 re: patterns + one exact match).
+func BenchmarkFindRoute_RouteListCached(b *testing.B) {
+	routes := make([]store.TokenRoute, 0, 100)
+	for i := 0; i < 100; i++ {
+		if i == 50 {
+			routes = append(routes, countingTestRoute(int64(i+1), "gpt-bench"))
+			continue
+		}
+		routes = append(routes, countingTestRoute(int64(i+1), "re:^bench-model-"+strconv.Itoa(i)+"$"))
+	}
+	db := &countingRoutesDB{preferredDB: &preferredDB{routes: routes}}
+	db.setJoined(countingEligibleJoined(51, 101, 10, 1001, "gpt-bench"))
+	selector := newCountingSelector(db, NewRouteCache(60_000))
+	ctx := context.Background()
+
+	if _, err := selector.findRoute(ctx, "gpt-bench", EmptyDownstreamRoutingPolicy); err != nil {
+		b.Fatalf("warm-up findRoute: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = selector.findRoute(ctx, "gpt-bench", EmptyDownstreamRoutingPolicy)
+	}
+}
+
+// BenchmarkFindRoute_RouteListCold is the legacy-equivalent path: the route
+// list is reloaded every call (cache invalidated each iteration).
+func BenchmarkFindRoute_RouteListCold(b *testing.B) {
+	routes := make([]store.TokenRoute, 0, 100)
+	for i := 0; i < 100; i++ {
+		if i == 50 {
+			routes = append(routes, countingTestRoute(int64(i+1), "gpt-bench"))
+			continue
+		}
+		routes = append(routes, countingTestRoute(int64(i+1), "re:^bench-model-"+strconv.Itoa(i)+"$"))
+	}
+	db := &countingRoutesDB{preferredDB: &preferredDB{routes: routes}}
+	db.setJoined(countingEligibleJoined(51, 101, 10, 1001, "gpt-bench"))
+	selector := newCountingSelector(db, NewRouteCache(60_000))
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		selector.cache.InvalidateAll()
+		_, _ = selector.findRoute(ctx, "gpt-bench", EmptyDownstreamRoutingPolicy)
+	}
+}


### PR DESCRIPTION
路由热路径每请求查库 + 正则重复编译（审计实测：100 路由 783µs/94KB/2353allocs 每请求）。

- **TTL 缓存接线**：既有 cache.go（IsRoutesFresh/GetRoutes/SetRoutes，生产零引用死代码）接入 findRoute 与群组路由热路径；TTL 沿用 TOKEN_ROUTER_CACHE_TTL_MS（默认 1500ms）；空列表归一化防零路由部署每请求查库
- **正则缓存**：进程级 sync.Map（re: 匹配 79.9µs/64allocs → 2.1µs/0allocs）
- **bucket 合并**：4 轮全扫 → 至多 2 轮（桶 4 惰性），优先级与早退语义不变
- **失效链核查**：路由/通道 CRUD、重建、站点/账号变更、故障恢复 13+ 路径全覆盖（InvalidateCache→InvalidateAll）
- **附带修复**：并发测试暴露既有数据竞争——PatchCachedChannel 缓存锁内原地改写，改不可变快照（-race 全绿）

Bench：findRoute 热命中 28.8µs/320B/2allocs（0 SQL）。新测试：命中计数/失效重查/TTL 过期/16 协程 -race/CRUD 即时反映。
