### PR TITLE
fix(web): UX flow polish — wizard entry/deep-link, keys mobile card, check-in button

### DIFF
--- a/web/src/features/accounts/__tests__/accounts-page-import-entry.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-page-import-entry.test.tsx
@@ -1,0 +1,115 @@
+// Pins the import-wizard toolbar entry on the accounts page — mirror of the
+// sites page regression: with a non-empty account list the empty-state CTA
+// (the only former wizard entry) never renders, so the toolbar keeps a
+// permanent Import button reusing the already-mounted setImportOpen.
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { AccountsPage } from '../components/accounts-page'
+import type { Account } from '../types'
+
+const testState = vi.hoisted(() => ({
+  importOpen: false,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+  useSearch: () => ({ page: 1, pageSize: 20 }),
+}))
+
+// Render only the toolbar preActions slot: the regression is about toolbar
+// reachability with a NON-EMPTY list, where the empty-state CTA never shows.
+vi.mock('@/components/data-table', () => ({
+  DataTableBulkActions: () => null,
+  DataTablePage: (props: {
+    toolbarProps?: { preActions?: ReactNode } | null
+  }) => <div>{props.toolbarProps?.preActions}</div>,
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    ensurePageInRange: vi.fn(),
+  }),
+  useDataTable: () => ({
+    table: {
+      getFilteredSelectedRowModel: () => ({ rows: [] }),
+      resetRowSelection: vi.fn(),
+    },
+  }),
+}))
+
+vi.mock('@/features/import', () => ({
+  ImportWizardDialog: (props: { open: boolean }) => {
+    testState.importOpen = props.open
+    return null
+  },
+}))
+
+vi.mock('../api', () => ({
+  // Non-empty library: exactly the state where the empty-state CTA disappears.
+  useAccounts: () => ({
+    data: {
+      generatedAt: '',
+      accounts: [
+        { id: 3, siteId: 7, username: 'account-3', status: 'active' },
+      ] as Array<Partial<Account>>,
+      sites: [{ id: 7, name: 'Primary site', url: 'https://primary.example' }],
+    },
+    isLoading: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useBatchUpdateAccounts: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteAccount: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRefreshAccount: () => ({ mutate: vi.fn(), isPending: false }),
+  useToggleAccountCheckin: () => ({ mutate: vi.fn(), isPending: false }),
+  useToggleAccountPin: () => ({ mutate: vi.fn(), isPending: false }),
+  useToggleAccountStatus: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+vi.mock('../components/account-detail-sheet', () => ({
+  AccountDetailSheet: () => null,
+}))
+
+vi.mock('../components/account-form-dialog', () => ({
+  AccountFormDialog: () => null,
+}))
+
+vi.mock('../components/accounts-columns', () => ({
+  useAccountsColumns: () => [],
+}))
+
+afterEach(() => cleanup())
+
+beforeEach(() => {
+  testState.importOpen = false
+})
+
+const IMPORT_BUTTON_NAME = 'Import sites'
+
+describe('AccountsPage toolbar import entry', () => {
+  it('renders an Import button in the toolbar when the list is non-empty', () => {
+    render(<AccountsPage />)
+
+    expect(
+      screen.getByRole('button', { name: IMPORT_BUTTON_NAME })
+    ).toBeInTheDocument()
+  })
+
+  it('opens the import wizard from the toolbar button', () => {
+    render(<AccountsPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: IMPORT_BUTTON_NAME }))
+
+    expect(testState.importOpen).toBe(true)
+  })
+})

--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -489,6 +489,16 @@ export function AccountsPage() {
         toolbarProps={{
           searchPlaceholder: t('accounts.page.searchPlaceholder'),
           searchDebounceMs: 300,
+          // The wizard was only reachable from the empty-state CTA, i.e.
+          // unreachable once the first account existed. The accounts toolbar
+          // keeps a permanent Import entry (same batch site+account path the
+          // sites page exposes), reusing the already-mounted setImportOpen.
+          preActions: (
+            <Button variant='outline' onClick={() => setImportOpen(true)}>
+              <UploadIcon className='size-4' />
+              {t('accounts.page.toolbarImport')}
+            </Button>
+          ),
           filters: [
             {
               columnId: 'status',

--- a/web/src/features/checkin/__tests__/checkin-page-manual-checkin-loading.test.tsx
+++ b/web/src/features/checkin/__tests__/checkin-page-manual-checkin-loading.test.tsx
@@ -1,0 +1,199 @@
+// Pins the checkin page's fetch-window behavior for the manual check-in
+// entry points. While the accounts snapshot is still fetching,
+// `accountOptions` is `[]`, and pinning the header button's `disabled` and
+// the empty-state CTA branch to that raw array made the button gray for the
+// whole fetch window and flashed "Manage accounts" before snapping back.
+// Same fix pattern as the accounts page's Add account button: only the
+// LOADED-AND-EMPTY state disables/redirects.
+
+import '@testing-library/jest-dom/vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { CheckinPage } from '../components/checkin-page'
+
+const MANUAL_CHECKIN_NAME = 'Manual check-in'
+const MANAGE_ACCOUNTS_NAME = 'Manage accounts'
+
+const testState = vi.hoisted(() => ({
+  accountsQuery: {
+    data: undefined as
+      | {
+          generatedAt: string
+          accounts: Array<{ id: number; username: string }>
+        }
+      | undefined,
+    isLoading: true,
+  },
+  manualOpen: false,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+// Surface the empty-state CTA so the branch can be asserted directly; the
+// table itself is irrelevant to this regression.
+vi.mock('@/components/data-table', () => ({
+  DataTablePage: (props: { emptyAction?: ReactNode }) => (
+    <div data-testid='checkin-empty-action'>{props.emptyAction}</div>
+  ),
+  useDataTable: () => ({ table: {} }),
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    filters: {
+      status: '',
+      reason: '',
+      site: '',
+      accountId: '',
+      from: '',
+      to: '',
+    },
+    updateUrlState: vi.fn(),
+  }),
+}))
+
+vi.mock('@/features/accounts', () => ({
+  useAccounts: () => testState.accountsQuery,
+}))
+
+vi.mock('@/features/sites/api', () => ({
+  useSites: () => ({ data: [] }),
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+
+vi.mock('../api', () => ({
+  useCheckinLogs: () => ({
+    data: { items: [], total: 0 },
+    isLoading: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useManualCheckin: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCheckinAccount: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    variables: null,
+  }),
+}))
+
+vi.mock('../components/checkin-columns', () => ({
+  useCheckinColumns: () => [],
+}))
+
+vi.mock('../components/checkin-detail-sheet', () => ({
+  CheckinDetailSheet: () => null,
+}))
+
+vi.mock('../components/manual-checkin-dialog', () => ({
+  ManualCheckinDialog: (props: { open: boolean }) => {
+    testState.manualOpen = props.open
+    return null
+  },
+}))
+
+afterEach(() => cleanup())
+
+beforeEach(() => {
+  testState.accountsQuery = { data: undefined, isLoading: true }
+  testState.manualOpen = false
+})
+
+describe('CheckinPage manual check-in while the accounts snapshot loads', () => {
+  it('keeps the header button enabled and clickable during loading', () => {
+    render(<CheckinPage />)
+
+    const buttons = screen.getAllByRole('button', {
+      name: MANUAL_CHECKIN_NAME,
+    })
+    for (const button of buttons) {
+      expect(button).not.toBeDisabled()
+    }
+
+    // Clicking the header button opens the manual check-in dialog even
+    // though the account list has not landed yet.
+    fireEvent.click(buttons[0])
+    expect(testState.manualOpen).toBe(true)
+  })
+
+  it('keeps the empty-state CTA on manual check-in during loading (no Manage accounts flash)', () => {
+    render(<CheckinPage />)
+
+    const emptyAction = screen.getByTestId('checkin-empty-action')
+    expect(
+      within(emptyAction).getByRole('button', { name: MANUAL_CHECKIN_NAME })
+    ).toBeInTheDocument()
+    expect(
+      within(emptyAction).queryByRole('button', { name: MANAGE_ACCOUNTS_NAME })
+    ).toBeNull()
+  })
+})
+
+describe('CheckinPage manual check-in once the snapshot has loaded', () => {
+  it('disables the header button for a genuinely empty account library', () => {
+    testState.accountsQuery = {
+      data: { generatedAt: '', accounts: [] },
+      isLoading: false,
+    }
+
+    render(<CheckinPage />)
+
+    expect(
+      screen.getByRole('button', { name: MANUAL_CHECKIN_NAME })
+    ).toBeDisabled()
+  })
+
+  it('points the empty-state CTA to the accounts page when the library is empty', () => {
+    testState.accountsQuery = {
+      data: { generatedAt: '', accounts: [] },
+      isLoading: false,
+    }
+
+    render(<CheckinPage />)
+
+    const emptyAction = screen.getByTestId('checkin-empty-action')
+    expect(
+      within(emptyAction).getByRole('button', { name: MANAGE_ACCOUNTS_NAME })
+    ).toBeInTheDocument()
+    expect(
+      within(emptyAction).queryByRole('button', { name: MANUAL_CHECKIN_NAME })
+    ).toBeNull()
+  })
+
+  it('enables the header button once accounts exist', () => {
+    testState.accountsQuery = {
+      data: {
+        generatedAt: '',
+        accounts: [{ id: 1, username: 'primary-account' }],
+      },
+      isLoading: false,
+    }
+
+    render(<CheckinPage />)
+
+    const buttons = screen.getAllByRole('button', {
+      name: MANUAL_CHECKIN_NAME,
+    })
+    for (const button of buttons) {
+      expect(button).not.toBeDisabled()
+    }
+  })
+})

--- a/web/src/features/checkin/components/checkin-page.tsx
+++ b/web/src/features/checkin/components/checkin-page.tsx
@@ -196,7 +196,12 @@ export function CheckinPage() {
     updateUrlState,
   } = useCheckinUrlState()
 
-  const { data: accountsSnapshot } = useAccounts()
+  // `isLoading` distinguishes "snapshot still fetching" from "genuinely no
+  // accounts": during the fetch window `accountOptions` is `[]`, and pinning
+  // the manual check-in button / empty CTA to that raw array kept them
+  // flashing disabled-then-enabled (same fix as the accounts page's Add
+  // account button — see the comment there).
+  const { data: accountsSnapshot, isLoading: accountsLoading } = useAccounts()
   const accountOptions = accountsSnapshot?.accounts ?? []
   const { data: sitesData } = useSites()
   const siteOptions = useMemo(
@@ -405,7 +410,7 @@ export function CheckinPage() {
           <Button
             variant='outline'
             onClick={() => setManualOpen(true)}
-            disabled={accountOptions.length === 0}
+            disabled={!accountsLoading && accountOptions.length === 0}
           >
             <Zap />
             {t('checkin.page.manualCheckin')}
@@ -513,20 +518,22 @@ export function CheckinPage() {
         emptyAction={
           // With accounts present the CTA reuses the header's manual
           // check-in flow (same dialog, same mutation) to generate logs;
-          // without accounts there is nothing to check in, so the exit
-          // points to the accounts page instead of a disabled button.
-          accountOptions.length > 0 ? (
-            <Button onClick={() => setManualOpen(true)}>
-              <Zap className='size-4' />
-              {t('checkin.page.manualCheckin')}
-            </Button>
-          ) : (
+          // only a LOADED-AND-EMPTY account library points to the accounts
+          // page instead — while the snapshot is still fetching the CTA
+          // stays manual check-in and picks up the accounts as they land
+          // (otherwise it flashed "Manage accounts" then back).
+          !accountsLoading && accountOptions.length === 0 ? (
             <Button
               variant='outline'
               onClick={() => void navigate({ to: '/accounts' })}
             >
               <Users className='size-4' />
               {t('checkin.page.manageAccounts')}
+            </Button>
+          ) : (
+            <Button onClick={() => setManualOpen(true)}>
+              <Zap className='size-4' />
+              {t('checkin.page.manualCheckin')}
             </Button>
           )
         }

--- a/web/src/features/import/__tests__/import-wizard-dialog.test.tsx
+++ b/web/src/features/import/__tests__/import-wizard-dialog.test.tsx
@@ -368,23 +368,28 @@ describe('ImportWizardDialog', () => {
 // the backend, so the done step must hand the operator the next actions:
 // rebuild routes (primary), add an account (secondary), or just close.
 describe('ImportWizardDialog — done step next steps', () => {
-  async function advanceToDoneStep(onOpenChange: (open: boolean) => void) {
+  async function advanceToDoneStep(
+    onOpenChange: (open: boolean) => void,
+    importResult?: Parameters<typeof mockImportMutate.mockResolvedValue>[0]
+  ) {
     mockDetectMutate.mockResolvedValue({
       platform: 'new-api',
       confidence: 0.9,
     })
-    mockImportMutate.mockResolvedValue({
-      imported: 1,
-      skipped: 0,
-      failed: 0,
-      results: [
-        {
-          name: 'a.com',
-          url: 'https://a.com',
-          status: 'imported',
-        },
-      ],
-    })
+    mockImportMutate.mockResolvedValue(
+      importResult ?? {
+        imported: 1,
+        skipped: 0,
+        failed: 0,
+        results: [
+          {
+            name: 'a.com',
+            url: 'https://a.com',
+            status: 'imported',
+          },
+        ],
+      }
+    )
 
     render(<ImportWizardDialog open onOpenChange={onOpenChange} />)
 
@@ -476,14 +481,171 @@ describe('ImportWizardDialog — done step next steps', () => {
     ).toBeInTheDocument()
   })
 
-  it('navigates to /accounts and closes the wizard on Add account', async () => {
+  it('deep-links /accounts with create (no site to preselect) when the single imported row has no siteId, and closes the wizard', async () => {
     const onOpenChange = vi.fn()
 
     await advanceToDoneStep(onOpenChange)
 
     fireEvent.click(screen.getByRole('button', { name: 'Add account' }))
 
-    expect(mockNavigate).toHaveBeenCalledWith({ to: '/accounts' })
+    // The batch succeeded, so the accounts page must at least open its
+    // create flow — a bare jump (the old behavior) dropped the intent.
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/accounts',
+      search: { create: true },
+      replace: true,
+    })
     expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})
+
+// Done-step → accounts deep link. Mirrors the manual site-created modal's
+// exit (`/accounts?siteId=…&create=1`) so the accounts page's one-shot
+// consumption (resolveDeepLinkPreselect) can preselect the imported site.
+// Three branches: exactly one imported/merged row WITH siteId carries it;
+// any other successful batch at least carries create; an all-skipped/failed
+// batch keeps the plain navigation.
+describe('ImportWizardDialog — done step accounts deep link', () => {
+  async function advanceWithResult(
+    importResult: Parameters<typeof mockImportMutate.mockResolvedValue>[0]
+  ) {
+    // Reuse the shared walker from the next-steps suite by re-driving the
+    // same steps here with a caller-controlled import outcome.
+    mockDetectMutate.mockResolvedValue({
+      platform: 'new-api',
+      confidence: 0.9,
+    })
+    mockImportMutate.mockResolvedValue(importResult)
+
+    render(<ImportWizardDialog open onOpenChange={() => {}} />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Site URLs')).toBeInTheDocument()
+    })
+    fireEvent.change(screen.getByLabelText('Site URLs'), {
+      target: { value: 'https://a.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('new-api')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await waitFor(() => {
+      expect(screen.getByRole('switch')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    await waitFor(() => {
+      expect(screen.getByRole('spinbutton')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }))
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Add account' })
+      ).toBeInTheDocument()
+    })
+  }
+
+  it('carries siteId + create for exactly one imported row with a siteId', async () => {
+    await advanceWithResult({
+      imported: 1,
+      skipped: 0,
+      failed: 0,
+      results: [
+        {
+          name: 'a.com',
+          url: 'https://a.com',
+          status: 'imported',
+          siteId: 9,
+        },
+      ],
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add account' }))
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/accounts',
+      search: { siteId: 9, create: true },
+      replace: true,
+    })
+  })
+
+  it('also treats a single merged row with a siteId as preselectable', async () => {
+    await advanceWithResult({
+      imported: 0,
+      skipped: 0,
+      failed: 0,
+      results: [
+        {
+          name: 'a.com',
+          url: 'https://a.com',
+          status: 'merged',
+          siteId: 12,
+        },
+      ],
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add account' }))
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/accounts',
+      search: { siteId: 12, create: true },
+      replace: true,
+    })
+  })
+
+  it('carries at least create:true for a multi-site batch', async () => {
+    await advanceWithResult({
+      imported: 2,
+      skipped: 0,
+      failed: 0,
+      results: [
+        {
+          name: 'a.com',
+          url: 'https://a.com',
+          status: 'imported',
+          siteId: 9,
+        },
+        {
+          name: 'b.com',
+          url: 'https://b.com',
+          status: 'imported',
+          siteId: 10,
+        },
+      ],
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add account' }))
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/accounts',
+      search: { create: true },
+      replace: true,
+    })
+  })
+
+  it('keeps the plain navigation when every row was skipped or failed', async () => {
+    await advanceWithResult({
+      imported: 0,
+      skipped: 1,
+      failed: 1,
+      results: [
+        {
+          name: 'a.com',
+          url: 'https://a.com',
+          status: 'skipped',
+          reason: 'duplicate',
+        },
+        {
+          name: 'b.com',
+          url: 'https://b.com',
+          status: 'failed',
+          reason: 'platform unsupported',
+        },
+      ],
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add account' }))
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/accounts' })
   })
 })

--- a/web/src/features/import/components/import-wizard-dialog.tsx
+++ b/web/src/features/import/components/import-wizard-dialog.tsx
@@ -409,9 +409,38 @@ export function ImportWizardDialog({
     })
   }
 
+  // Mirror the manual site-created modal's exit (site-created-modal.tsx):
+  // land the accounts page with the one-shot `siteId`/`create` deep link so
+  // the create dialog opens with the imported site preselected. Exactly one
+  // imported/merged row with a siteId carries it; any other successful
+  // batch at least opens the create flow; an all-skipped/failed batch keeps
+  // the plain navigation (nothing to preselect).
   function handleGoToAccounts() {
+    const results = result?.results ?? []
+    const successful = results.filter(
+      (item) => item.status === 'imported' || item.status === 'merged'
+    )
+    const withSiteId = successful.filter(
+      (item) => typeof item.siteId === 'number' && item.siteId > 0
+    )
     reset()
     onOpenChange(false)
+    if (successful.length === 1 && withSiteId.length === 1) {
+      navigate({
+        to: '/accounts',
+        search: { siteId: withSiteId[0].siteId, create: true },
+        replace: true,
+      })
+      return
+    }
+    if (successful.length > 0) {
+      navigate({
+        to: '/accounts',
+        search: { create: true },
+        replace: true,
+      })
+      return
+    }
     navigate({ to: '/accounts' })
   }
 

--- a/web/src/features/settings/sections/downstream/components/__tests__/keys-section-mobile.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/keys-section-mobile.test.tsx
@@ -1,0 +1,163 @@
+// Pins the downstream-keys mobile contract. The section used to render a
+// bare <Table> that horizontally scrolled the whole row set on phones,
+// pushing Connect/Delete off-screen. It now participates in the shared
+// DataTablePage contract: ≤640px (TABLE_MOBILE_MEDIA_QUERY) renders the
+// MobileCardList driven by column meta (mobileTitle = name, mobileBadge =
+// enable switch); above it the desktop table stays.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+import { TABLE_MOBILE_MEDIA_QUERY } from '@/lib/breakpoints'
+
+import { KeysSection } from '../keys-section'
+
+const { mockGetKeys } = vi.hoisted(() => ({
+  mockGetKeys: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getDownstreamApiKeys: mockGetKeys,
+    createDownstreamApiKey: vi.fn(),
+    updateDownstreamApiKey: vi.fn(),
+    deleteDownstreamApiKey: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+// Configurable media query: flip `mobileMatches` to emulate the 375px
+// viewport (mobile card list) or a desktop viewport (table).
+let mobileMatches = false
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === TABLE_MOBILE_MEDIA_QUERY ? mobileMatches : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  mobileMatches = false
+  mockGetKeys.mockReset()
+  mockGetKeys.mockResolvedValue({
+    items: [
+      {
+        id: 1,
+        name: 'prod key',
+        keyMasked: 'sk-…abc',
+        groupName: 'default',
+        enabled: true,
+        usedRequests: 10,
+        maxRequests: 100,
+        usedCost: 2,
+        maxCost: 50,
+      },
+      {
+        id: 2,
+        name: 'dev key',
+        keyMasked: 'sk-…def',
+        enabled: false,
+      },
+    ],
+  })
+})
+
+afterEach(() => cleanup())
+
+function renderKeysSection() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return render(
+    (
+      <QueryClientProvider client={queryClient}>
+        <KeysSection />
+      </QueryClientProvider>
+    ) as ReactElement
+  )
+}
+
+describe('KeysSection — mobile (375px) rendering', () => {
+  beforeEach(() => {
+    mobileMatches = true
+  })
+
+  it('renders the card list instead of the desktop table', async () => {
+    renderKeysSection()
+
+    await waitFor(() => {
+      expect(screen.getByText('prod key')).toBeInTheDocument()
+    })
+
+    // The bare <Table> must be gone on mobile: no table element, no
+    // column headers.
+    expect(document.querySelector('table')).toBeNull()
+    expect(screen.queryByRole('columnheader')).toBeNull()
+
+    // Card content: name (mobileTitle), masked key, enable switch
+    // (mobileBadge), and the Connect/Edit/Delete actions all reachable.
+    expect(screen.getByText('sk-…abc')).toBeInTheDocument()
+    expect(screen.getByText('dev key')).toBeInTheDocument()
+    expect(
+      screen.getByRole('switch', { name: 'Toggle enabled for prod key' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('switch', { name: 'Toggle enabled for dev key' })
+    ).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Connect' })).toHaveLength(2)
+    expect(screen.getAllByRole('button', { name: 'Delete' })).toHaveLength(2)
+    expect(
+      screen.getByRole('button', { name: 'Edit prod key' })
+    ).toBeInTheDocument()
+  })
+})
+
+describe('KeysSection — desktop rendering', () => {
+  it('keeps the desktop table above the mobile breakpoint', async () => {
+    renderKeysSection()
+
+    await waitFor(() => {
+      expect(screen.getByText('prod key')).toBeInTheDocument()
+    })
+
+    // Desktop keeps the table with its column headers.
+    expect(
+      screen.getByRole('columnheader', { name: 'Group' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('columnheader', { name: 'Usage' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('switch', { name: 'Toggle enabled for prod key' })
+    ).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Connect' })).toHaveLength(2)
+  })
+})

--- a/web/src/features/settings/sections/downstream/components/keys-section.tsx
+++ b/web/src/features/settings/sections/downstream/components/keys-section.tsx
@@ -6,8 +6,9 @@
 
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { ColumnDef } from '@tanstack/react-table'
 import { Pencil } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { z } from 'zod'
@@ -16,6 +17,7 @@ import {
   CredentialExportDialog,
   type CredentialExportTarget,
 } from '@/components/common/credential-export-dialog'
+import { DataTablePage, useDataTable } from '@/components/data-table'
 import { useDirtyDialogClose } from '@/components/form/dirty-dialog-close'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -47,21 +49,10 @@ import {
 } from '@/components/ui/sheet'
 import { Spinner } from '@/components/ui/spinner'
 import { Switch } from '@/components/ui/switch'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
 import { api } from '@/lib/api'
 import { toast } from '@/lib/toast'
 
-import {
-  SettingsSectionCard,
-  SettingsSectionSkeleton,
-} from '../../../components/settings-section-card'
+import { SettingsSectionCard } from '../../../components/settings-section-card'
 import { SettingsSectionError } from '../../../components/settings-section-error'
 
 type DownstreamKeyUsage24h = {
@@ -579,6 +570,118 @@ export function KeysSection() {
   const items = keysQuery.data?.items ?? []
   const isLoading = keysQuery.isLoading
 
+  // Stable top-level refs for the columns memo (same pattern as the
+  // accounts page's toggleStatusMutate): the mutation object's identity
+  // changes every render, the memo only needs the stable mutate fn plus the
+  // derived pending flag.
+  const toggleKeyMutate = toggleMutation.mutate
+  const toggleKeyPending = toggleMutation.isPending
+
+  // One column set serves the desktop table and the ≤640px card list — the
+  // same DataTablePage contract every list page uses: `mobileTitle` lifts
+  // the key name into the card header, `mobileBadge` docks the enable
+  // switch beside it, and the `actions` column id renders the
+  // Connect/Edit/Delete buttons at the card bottom. Before this migration
+  // the section rendered a bare <Table> that horizontally scrolled the
+  // whole row set on phones, pushing Connect/Delete off-screen.
+  const columns = useMemo<ColumnDef<DownstreamApiKeyItem, unknown>[]>(
+    () => [
+      {
+        id: 'name',
+        header: t('settings.downstream.keys.columns.name'),
+        meta: { mobileTitle: true },
+        cell: ({ row }) => (
+          <div className='flex flex-col'>
+            <span className='font-medium'>{row.original.name}</span>
+            {row.original.keyMasked ? (
+              <code className='text-muted-foreground text-xs'>
+                {row.original.keyMasked}
+              </code>
+            ) : null}
+          </div>
+        ),
+      },
+      {
+        id: 'group',
+        header: t('settings.downstream.keys.columns.group'),
+        cell: ({ row }) =>
+          row.original.groupName ? (
+            <Badge variant='secondary'>{row.original.groupName}</Badge>
+          ) : (
+            <span className='text-muted-foreground'>—</span>
+          ),
+      },
+      {
+        id: 'enabled',
+        header: t('settings.downstream.keys.columns.enabled'),
+        meta: { mobileBadge: true },
+        cell: ({ row }) => (
+          <Switch
+            checked={row.original.enabled}
+            disabled={toggleKeyPending}
+            onCheckedChange={(checked) =>
+              toggleKeyMutate({ id: row.original.id, enabled: checked })
+            }
+            aria-label={t('settings.downstream.keys.columns.enabledAria', {
+              name: row.original.name,
+            })}
+          />
+        ),
+      },
+      {
+        id: 'usage',
+        header: t('settings.downstream.keys.columns.usage'),
+        cell: ({ row }) => (
+          <div className='text-muted-foreground text-xs'>
+            <KeyUsageCell item={row.original} />
+          </div>
+        ),
+      },
+      {
+        id: 'actions',
+        header: t('settings.downstream.keys.columns.actions'),
+        cell: ({ row }) => (
+          <div className='flex justify-end gap-1'>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              onClick={() => setExportTarget(row.original)}
+            >
+              {t('settings.downstream.keys.connect')}
+            </Button>
+            <Button
+              type='button'
+              variant='ghost'
+              size='icon-sm'
+              aria-label={t('settings.downstream.keys.columns.editAria', {
+                name: row.original.name,
+              })}
+              onClick={() => openEdit(row.original)}
+            >
+              <Pencil />
+            </Button>
+            <Button
+              type='button'
+              variant='ghost'
+              size='sm'
+              onClick={() => setDeleteTarget(row.original)}
+            >
+              {t('settings.common.delete')}
+            </Button>
+          </div>
+        ),
+      },
+    ],
+    [t, toggleKeyPending, toggleKeyMutate]
+  )
+
+  const { table } = useDataTable<DownstreamApiKeyItem>({
+    data: items,
+    columns,
+    getRowId: (row) => String(row.id),
+  })
+
   return (
     <SettingsSectionCard
       title={t('settings.downstream.keys.title')}
@@ -589,117 +692,30 @@ export function KeysSection() {
         </Button>
       }
     >
-      {isLoading ? <SettingsSectionSkeleton /> : null}
       {keysQuery.isError ? (
         <SettingsSectionError
           title={t('settings.downstream.keys.title')}
           onRetry={() => void keysQuery.refetch()}
         />
-      ) : null}
-      {!isLoading && !keysQuery.isError && items.length === 0 ? (
-        <div className='flex flex-col items-center gap-3 py-8'>
-          <p className='text-muted-foreground text-sm'>
-            {t('settings.downstream.keys.empty')}
-          </p>
-          <Button size='sm' onClick={() => openCreate()}>
-            {t('settings.downstream.keys.create')}
-          </Button>
-        </div>
-      ) : null}
-      {!isLoading && !keysQuery.isError && items.length > 0 ? (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>
-                {t('settings.downstream.keys.columns.name')}
-              </TableHead>
-              <TableHead>
-                {t('settings.downstream.keys.columns.group')}
-              </TableHead>
-              <TableHead>
-                {t('settings.downstream.keys.columns.enabled')}
-              </TableHead>
-              <TableHead>
-                {t('settings.downstream.keys.columns.usage')}
-              </TableHead>
-              <TableHead className='text-right'>
-                {t('settings.downstream.keys.columns.actions')}
-              </TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {items.map((item) => (
-              <TableRow key={item.id}>
-                <TableCell>
-                  <div className='flex flex-col'>
-                    <span className='font-medium'>{item.name}</span>
-                    {item.keyMasked ? (
-                      <code className='text-muted-foreground text-xs'>
-                        {item.keyMasked}
-                      </code>
-                    ) : null}
-                  </div>
-                </TableCell>
-                <TableCell>
-                  {item.groupName ? (
-                    <Badge variant='secondary'>{item.groupName}</Badge>
-                  ) : (
-                    <span className='text-muted-foreground'>—</span>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <Switch
-                    checked={item.enabled}
-                    disabled={toggleMutation.isPending}
-                    onCheckedChange={(checked) =>
-                      toggleMutation.mutate({ id: item.id, enabled: checked })
-                    }
-                    aria-label={t(
-                      'settings.downstream.keys.columns.enabledAria',
-                      { name: item.name }
-                    )}
-                  />
-                </TableCell>
-                <TableCell className='text-muted-foreground text-xs'>
-                  <KeyUsageCell item={item} />
-                </TableCell>
-                <TableCell className='text-right'>
-                  <div className='flex justify-end gap-1'>
-                    <Button
-                      type='button'
-                      variant='ghost'
-                      size='sm'
-                      onClick={() => setExportTarget(item)}
-                    >
-                      {t('settings.downstream.keys.connect')}
-                    </Button>
-                    <Button
-                      type='button'
-                      variant='ghost'
-                      size='icon-sm'
-                      aria-label={t(
-                        'settings.downstream.keys.columns.editAria',
-                        { name: item.name }
-                      )}
-                      onClick={() => openEdit(item)}
-                    >
-                      <Pencil />
-                    </Button>
-                    <Button
-                      type='button'
-                      variant='ghost'
-                      size='sm'
-                      onClick={() => setDeleteTarget(item)}
-                    >
-                      {t('settings.common.delete')}
-                    </Button>
-                  </div>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      ) : null}
+      ) : (
+        <DataTablePage
+          table={table}
+          columns={columns}
+          isLoading={isLoading}
+          emptyTitle={t('settings.downstream.keys.empty')}
+          emptyAction={
+            <Button size='sm' onClick={() => openCreate()}>
+              {t('settings.downstream.keys.create')}
+            </Button>
+          }
+          toolbarProps={null}
+          fixedHeight={false}
+          skeletonKeyPrefix='downstream-keys-skeleton'
+        />
+      )}
+      {/* The mobile empty state carries no action button (MobileCardList
+          contract) — the section header's Create action stays visible on
+          every viewport, so the empty flow loses nothing. */}
 
       <Sheet open={createOpen} onOpenChange={guardedSheetOpenChange}>
         {/* Mobile contract comes from the SheetContent base: full-width panel

--- a/web/src/features/sites/__tests__/sites-page-import-entry.test.tsx
+++ b/web/src/features/sites/__tests__/sites-page-import-entry.test.tsx
@@ -1,0 +1,131 @@
+// Pins the import-wizard toolbar entry on the sites page. The wizard used to
+// be reachable only from the DataTablePage empty-state CTA — once the first
+// site existed the empty state stopped rendering and the only batch
+// site+account path became unreachable. The toolbar's preActions must keep a
+// permanent Import entry that opens the same (already mounted) wizard.
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { SitesPage } from '../components/sites-page'
+
+const testState = vi.hoisted(() => ({
+  importOpen: false,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+  useSearch: () => ({}),
+}))
+
+// Render only the toolbar preActions slot: the regression is about toolbar
+// reachability with a NON-EMPTY list, where the empty-state CTA never shows.
+vi.mock('@/components/data-table', () => ({
+  DataTableBulkActions: () => null,
+  DataTablePage: (props: {
+    toolbarProps?: { preActions?: ReactNode } | null
+  }) => <div>{props.toolbarProps?.preActions}</div>,
+  encodeSorting: () => '',
+  useDataTable: () => ({
+    table: {
+      getFilteredSelectedRowModel: () => ({ rows: [] }),
+      resetRowSelection: vi.fn(),
+    },
+  }),
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    sorting: [],
+    onSortingChange: vi.fn(),
+    ensurePageInRange: vi.fn(),
+  }),
+}))
+
+vi.mock('@/features/accounts', () => ({
+  useAccounts: () => ({ data: undefined }),
+}))
+
+vi.mock('@/features/import', () => ({
+  ImportWizardDialog: (props: { open: boolean }) => {
+    testState.importOpen = props.open
+    return null
+  },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('../api', () => ({
+  // Non-empty library: this is exactly the state where the empty-state CTA
+  // disappears and the toolbar entry is the only way into the wizard.
+  useSites: () => ({
+    data: [
+      {
+        id: 1,
+        name: 'Primary site',
+        url: 'https://primary.example',
+        platform: 'openai',
+        status: 'active',
+      },
+    ],
+    isLoading: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useDeleteSite: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateSite: () => ({ mutate: vi.fn(), isPending: false, variables: null }),
+  useBatchUpdateSites: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+vi.mock('../components/site-form-dialog', () => ({
+  SiteFormDialog: () => null,
+}))
+
+vi.mock('../components/site-detail-sheet', () => ({
+  SiteDetailSheet: () => null,
+}))
+
+vi.mock('../components/site-created-modal', () => ({
+  SiteCreatedModal: () => null,
+}))
+
+vi.mock('../components/sites-columns', () => ({
+  useSitesColumns: () => [],
+  SITES_STATUS_FILTER_OPTIONS: [],
+}))
+
+afterEach(() => cleanup())
+
+beforeEach(() => {
+  testState.importOpen = false
+})
+
+const IMPORT_BUTTON_NAME = 'Import sites'
+
+describe('SitesPage toolbar import entry', () => {
+  it('renders an Import button in the toolbar when the list is non-empty', () => {
+    render(<SitesPage />)
+
+    expect(
+      screen.getByRole('button', { name: IMPORT_BUTTON_NAME })
+    ).toBeInTheDocument()
+  })
+
+  it('opens the import wizard from the toolbar button', () => {
+    render(<SitesPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: IMPORT_BUTTON_NAME }))
+
+    expect(testState.importOpen).toBe(true)
+  })
+})

--- a/web/src/features/sites/components/sites-page.tsx
+++ b/web/src/features/sites/components/sites-page.tsx
@@ -441,10 +441,20 @@ export function SitesPage() {
               },
             ],
             preActions: (
-              <Button onClick={handleAddSite}>
-                <PlusIcon className='size-4' />
-                {t('sites.toolbar.addSite')}
-              </Button>
+              <>
+                <Button onClick={handleAddSite}>
+                  <PlusIcon className='size-4' />
+                  {t('sites.toolbar.addSite')}
+                </Button>
+                {/* The wizard was only reachable from the empty-state CTA,
+                    i.e. unreachable once the first site existed — keep a
+                    permanent toolbar entry. The wizard is the only flow that
+                    creates sites together with their accounts in one batch. */}
+                <Button variant='outline' onClick={() => setImportOpen(true)}>
+                  <UploadIcon className='size-4' />
+                  {t('sites.toolbar.import')}
+                </Button>
+              </>
             ),
           }}
           bulkActions={

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -469,7 +469,8 @@
       },
       "toolbar": {
         "searchPlaceholder": "Search sites…",
-        "addSite": "Add site"
+        "addSite": "Add site",
+        "import": "Import sites"
       },
       "entityName": "Site",
       "bulk": {
@@ -1517,7 +1518,8 @@
         "filterSiteTitle": "Site",
         "deleteTitle": "Delete account",
         "deleteDescription": "Delete account \"{{name}}\"? This action cannot be undone, and associated tokens will be removed.",
-        "emptyImport": "Import sites"
+        "emptyImport": "Import sites",
+        "toolbarImport": "Import sites"
       },
       "bulk": {
         "entityName": "account",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -469,7 +469,8 @@
       },
       "toolbar": {
         "searchPlaceholder": "搜索站点…",
-        "addSite": "添加站点"
+        "addSite": "添加站点",
+        "import": "导入站点"
       },
       "entityName": "站点",
       "bulk": {
@@ -1517,7 +1518,8 @@
         "filterSiteTitle": "站点",
         "deleteTitle": "删除账号",
         "deleteDescription": "确定删除账号「{{name}}」？该操作不可撤销，相关令牌将一并清除。",
-        "emptyImport": "导入站点"
+        "emptyImport": "导入站点",
+        "toolbarImport": "导入站点"
       },
       "bulk": {
         "entityName": "账号",


### PR DESCRIPTION
UX 动线打磨四项（审计坐实，全部有 file:line 证据）：

1. **导入向导入口找回**：首站建立后向导不可达（仅挂空态）——sites/accounts 工具栏 preActions 加 secondary Import（复用已挂载 setImportOpen）
2. **向导完成步深链**：裸跳 /accounts 丢弃 siteId/create → 按 result.results 聚合：唯一 imported 带 siteId → `{siteId, create:true}`（对齐手工建站出口与 accounts 页一次性深链消费机制）；多站点 → 至少 create:true；全跳过 → 维持现状
3. **Downstream Keys 移动端**：裸 5 列表 ≤640px 横滚 Connect 出屏 → 迁入 DataTablePage 契约（mobileTitle=名称、mobileBadge=Switch、actions 底排）
4. **签到页手动签到**：快照加载窗口全程灰掉 → isLoading 门禁（对齐 accounts-page 既定模式与注释）

新增 5 测试文件 16 例全绿；typecheck/lint/format/i18n parity 全绿；深链三分支逐一验证。
