### PR TITLE
fix(web): theme contrast fixes (6 audit items) + 320-pair contrast gate

### DIFF
--- a/docs/internal/design/DESIGN.md
+++ b/docs/internal/design/DESIGN.md
@@ -78,7 +78,7 @@ Each maps a Tailwind alias `--color-*` (e.g. `--color-background: var(--backgrou
 | `--neutral`                                            | `oklch(0.708 0 0)`                                           | `oklch(0.76 0 0)`                                            | Cool gray secondary                 |
 | `--sidebar` / `--sidebar-primary` / `--sidebar-accent` | derived from background/primary                              | derived from background/primary                              | Sidebar canvas, brand, active tones |
 
-Presets replace `--primary`/`--background` per `data-theme-preset` (e.g. Anthropic clay `oklch(0.685 0.142 38)` on cream `oklch(0.984 0.005 95)`).
+Presets replace `--primary`/`--background` per `data-theme-preset` (e.g. Anthropic clay `oklch(0.57 0.15 38)` on cream `oklch(0.984 0.005 95)`).
 
 ### 2.4 Status semantics
 
@@ -86,7 +86,7 @@ Presets replace `--primary`/`--background` per `data-theme-preset` (e.g. Anthrop
 | -------------------------------------------- | ------------------------------------------------ | ------------------------------------------------ | ------------------ |
 | `--success` / `--success-foreground`         | `oklch(0.53 0.145 163.225)` / `oklch(0.985 0 0)` | `oklch(0.696 0.17 162.48)` / `oklch(0.145 0 0)`  | Healthy / active   |
 | `--warning` / `--warning-foreground`         | `oklch(0.62 0.162 75.834)` / `oklch(0.145 0 0)`  | `oklch(0.769 0.188 70.08)` / `oklch(0.145 0 0)`  | Degraded / pending |
-| `--destructive` / `--destructive-foreground` | `oklch(0.577 0.245 27.325)` / `oklch(0.985 0 0)` | `oklch(0.704 0.191 22.216)` / `oklch(0.985 0 0)` | Errors, deletes    |
+| `--destructive` / `--destructive-foreground` | `oklch(0.577 0.245 27.325)` / `oklch(0.985 0 0)` | `oklch(0.575 0.19 25)` / `oklch(0.985 0 0)`     | Errors, deletes    |
 | `--info` / `--info-foreground`               | `oklch(0.53 0.158 241.966)` / `oklch(0.985 0 0)` | `oklch(0.613 0.14 239.919)` / `oklch(0.145 0 0)` | Informational      |
 
 Badge pattern: solid on soft fill (e.g. `bg-success/10 text-success`); each status also maps a `--color-*` Tailwind alias.

--- a/docs/internal/design/a11y-checklist.md
+++ b/docs/internal/design/a11y-checklist.md
@@ -3,7 +3,7 @@
 **Product**: Metapi admin
 **Scope**: accessibility checklist
 **Related source of truth**: `docs/internal/design/DESIGN.md`, `web/src/styles/theme.css`
-**Last updated**: 2026-08-21
+**Last updated**: 2026-08-23
 **Status**: living acceptance checklist; known limitations are documented, not an implicit backlog
 
 This document records keyboard, name, contrast, and responsive expectations. Known limitations are evidence only unless promoted to [`../progress/MASTER.md`](../progress/MASTER.md) or a scoped GitHub issue.
@@ -107,7 +107,7 @@ This document records keyboard, name, contrast, and responsive expectations. Kno
 
 ## 4. Contrast notes (primary text / surfaces)
 
-Ratios computed 2026-08-12 from the shipped `web/src/styles/theme.css` OKLCH values (WCAG 2.x relative luminance; token map in `DESIGN.md` §2). The light-theme primary CTA uses ink `--primary-foreground` on `--primary` (7.28:1, AAA) by design.
+Ratios computed 2026-08-12 from the shipped `web/src/styles/theme.css` OKLCH values (WCAG 2.x relative luminance; token map in `DESIGN.md` §2); preset pairs re-audited and fixed 2026-08-23 (OKLCH→sRGB→WCAG pipeline, pinned by `web/src/styles/__tests__/contrast-gate.test.ts`). The light-theme primary CTA uses ink `--primary-foreground` on `--primary` (7.28:1, AAA) by design.
 
 ### 4.1 Light theme
 
@@ -118,7 +118,7 @@ Ratios computed 2026-08-12 from the shipped `web/src/styles/theme.css` OKLCH val
 | `--secondary-foreground` on `--secondary`                             | 11.8:1  | Pass                 | Nested wells                                                                                                                                           |
 | `--primary-foreground` on `--primary`                                 | 7.28:1  | Pass                 | Light-theme CTA — ink-on-brand (`--primary-foreground` = `oklch(0.145 0 0)` on the brand primary), AAA by design                                                          |
 | White text on `--destructive`                                         | 4.8:1   | Pass                 | Errors, deletes                                                                                                                                        |
-| Soft-badge text (`--success` / `--info` / `--warning`) on `/10` fills | ≥ 4.5:1 | Pass                 | 12px soft badges — light `--success`/`--info`/`--warning` lightness lowered (0.53 / 0.53 / 0.62) 2026-08-14; `*-soft-fg` tokens ship the readable tone |
+| Soft-badge text (`--success` / `--info` / `--warning` / `--destructive`) on `/10` fills | ≥ 4.5:1 | Pass                 | 12px soft badges — light `--success`/`--info`/`--warning` lightness lowered (0.53 / 0.53 / 0.62) 2026-08-14; `*-soft-fg` tokens ship the readable tone. 2026-08-23: light `--destructive-soft-fg` is now a standalone darker ink `oklch(0.5 0.2 27)` (aliasing `--destructive` only reached 3.84–3.99:1 on the tint; now 4.93–5.70 across presets) |
 
 ### 4.2 Dark theme
 
@@ -129,6 +129,8 @@ Ratios computed 2026-08-12 from the shipped `web/src/styles/theme.css` OKLCH val
 | `--muted-foreground` on `--card`          | 7.2:1  | Pass                 | Labels / secondary text |
 | `--secondary-foreground` on `--secondary` | 8.9:1  | Pass                 | Nested wells            |
 | White text on `--primary`                 | 5.0:1  | Pass                 | CTA                     |
+| White text on `--destructive`             | 4.6:1  | Pass                 | 2026-08-23: darkened to `oklch(0.575 0.19 25)` (was 2.77:1); attention-bell critical badge |
+| Soft-badge text on `/10` fills            | ≥ 5.2:1 | Pass                | 2026-08-23: dark `--info-soft-fg` lifted to `oklch(0.72 0.12 245)` (was 3.45–3.74 on card surfaces) |
 
 ### 4.3 Contrast rules for implementers
 
@@ -209,7 +211,7 @@ This section lists open residuals only. Closure history lives in [`../log.md`](.
 1. **Charts keyboard series access** — recharts renders series as non-focusable SVG; assistive tech relies on the text axes, legends, and rich text tooltips (balance/cost, accounts, calls, tokens, share) that already carry the data. Non-color status encoding (text labels on availability buckets, attention badges) is in place; no color-only status.
 2. **Global focus-ring utility** — chrome controls share the `--ring` recipe; a single shared rule for every page-level action grid is not yet in place (`.modal-close-button:focus-visible` uses a primary outline).
 3. **Hex hygiene** — no new brand hex is allowed in pages (see [`DESIGN.md`](./DESIGN.md) §1 Principles). Existing brand assets and other justified exceptions are reviewed when their owning surface changes; this is not a standalone sweep.
-4. **Preset contrast (audit-only)** — the default theme passes AA/AAA; user-chosen presets are explicit choices and out of scope. Underground/rose-garden/sunset-glow pass with white; forest-whisper, ocean-breeze, and lavender-dream remain below AA on white text — a preset-specific fix is deferred until a real user need appears.
+4. **Preset contrast** — 2026-08-23: a static WCAG audit (OKLCH→sRGB→WCAG ratio pipeline) found and **fixed** six sub-AA defects; all fixed pairs are pinned by `web/src/styles/__tests__/contrast-gate.test.ts`. New baselines: rose-garden dark `--secondary` 1.50→7.64 (dark rose surface `oklch(0.4 0.08 8)`); default dark solid `--destructive` 2.77→4.61 (`oklch(0.575 0.19 25)`, attention-bell critical badge); white CTA text on five preset dark primaries — forest-whisper 3.59→4.81, ocean-breeze 3.68→4.72, lavender-dream 3.68→4.72, rose-garden 3.68→4.71, sunset-glow 3.69→4.72 (L lowered 0.06–0.07); anthropic light clay `--primary` 2.91→4.64 (`oklch(0.57 0.15 38)`) and sky `--info` 2.85→4.62 (`oklch(0.55 0.075 248)`); soft-badge foregrounds — light `--destructive-soft-fg` standalone `oklch(0.5 0.2 27)` (3.84–3.99→4.93–5.70) and dark `--info-soft-fg` `oklch(0.72 0.12 245)` (3.45–3.74→5.17–5.70); sidebar active item — default light `--sidebar-accent-foreground` 3.95→5.38 and the lake-view dark pure-black override deleted (1.75→8.95). Remaining documented sub-AA preset residuals (exemption list in the gate): forest-whisper dark `--secondary` 3.12, ocean-breeze light `--secondary` 4.47, simple-large/anthropic dark bespoke `--destructive` 2.97/2.79, anthropic light olive `--success` 3.83 (soft 4.48); the `bg-sidebar-primary` pairs (3.40/4.11) are a dormant token no component consumes.
 
 ---
 

--- a/web/src/lib/theme-customization.ts
+++ b/web/src/lib/theme-customization.ts
@@ -13,7 +13,7 @@ export const THEME_PRESETS = [
     // with clay/coral as the single accent.
     value: 'anthropic',
     name: 'Anthropic',
-    swatches: ['oklch(0.984 0.005 95)', 'oklch(0.685 0.142 38)'],
+    swatches: ['oklch(0.984 0.005 95)', 'oklch(0.57 0.15 38)'],
   },
   {
     value: 'simple-large',

--- a/web/src/styles/__tests__/contrast-gate.test.ts
+++ b/web/src/styles/__tests__/contrast-gate.test.ts
@@ -1,0 +1,450 @@
+// Theme contrast gate.
+//
+// Statically parses the OKLCH tokens from theme.css / theme-presets.css,
+// resolves the cascade (base -> preset block -> semantic surface bridge),
+// converts OKLCH -> OKLab -> linear sRGB -> gamma sRGB, and computes WCAG
+// 2.x contrast ratios (same pipeline as the 2026-08-23 theme audit and
+// scripts/dark-contrast-probe.mjs luminance math). Every tracked
+// foreground/background pair must clear AA 4.5:1 across all 10 presets x
+// {light, dark}, except a small documented exemption list of known
+// residuals (a11y-checklist.md §7).
+//
+// Locks in the 2026-08-23 contrast fixes:
+//   1. rose-garden dark --secondary (was 1.50:1, lowest ratio shipped)
+//   2. default dark --destructive (solid destructive, was 2.77:1)
+//   3. five preset dark --primary CTAs (were 3.59-3.69:1 with white text)
+//   4. anthropic light clay --primary + sky --info (were 2.91 / 2.85:1)
+//   5. light --destructive-soft-fg + dark --info-soft-fg soft badges
+//   6. default light --sidebar-accent-foreground + the removed pure-black
+//      lake-view dark override (were 3.95 / 1.75:1)
+
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const WEB_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+const read = (path: string) => readFileSync(join(WEB_ROOT, path), 'utf8')
+
+const AA = 4.5
+
+// ---------- color math (OKLCH -> sRGB -> WCAG) ----------
+
+type Oklch = { l: number; c: number; h: number; a: number }
+type Rgb = [number, number, number]
+
+function oklchToLinearRgb({ l, c, h }: Oklch): Rgb {
+  const hr = (h * Math.PI) / 180
+  const a = c * Math.cos(hr)
+  const b = c * Math.sin(hr)
+  const l_ = l + 0.3963377774 * a + 0.2158037573 * b
+  const m_ = l - 0.1055613458 * a - 0.0638541728 * b
+  const s_ = l - 0.0894841775 * a - 1.291485548 * b
+  const L = l_ ** 3
+  const M = m_ ** 3
+  const S = s_ ** 3
+  return [
+    4.0767416621 * L - 3.3077115913 * M + 0.2309699292 * S,
+    -1.2684380046 * L + 2.6097574011 * M - 0.3413193965 * S,
+    -0.0041960863 * L - 0.7034186147 * M + 1.707614701 * S,
+  ]
+}
+
+function clamp01(v: number): number {
+  return Math.min(1, Math.max(0, v))
+}
+
+function linearToGamma(v: number): number {
+  const c = clamp01(v)
+  return c <= 0.0031308 ? 12.92 * c : 1.055 * c ** (1 / 2.4) - 0.055
+}
+
+function oklchToSrgb(color: Oklch): Rgb {
+  const [r, g, b] = oklchToLinearRgb(color)
+  return [linearToGamma(r), linearToGamma(g), linearToGamma(b)]
+}
+
+function wcagLuminance([r, g, b]: Rgb): number {
+  const f = (v: number) => {
+    const c = clamp01(v)
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+  }
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b)
+}
+
+function contrastRatio(fg: Rgb, bg: Rgb): number {
+  const l1 = wcagLuminance(fg)
+  const l2 = wcagLuminance(bg)
+  const hi = Math.max(l1, l2)
+  const lo = Math.min(l1, l2)
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+/** Alpha-composite fg over bg in gamma sRGB (how browsers stack bg-x/NN). */
+function composite(fg: Rgb, alpha: number, bg: Rgb): Rgb {
+  return [
+    alpha * fg[0] + (1 - alpha) * bg[0],
+    alpha * fg[1] + (1 - alpha) * bg[1],
+    alpha * fg[2] + (1 - alpha) * bg[2],
+  ]
+}
+
+/** color-mix(in oklch, A p%, B): L/C linear; hue from the chromatic side. */
+function mixOklch(a: Oklch, p: number, b: Oklch): Oklch {
+  const l = p * a.l + (1 - p) * b.l
+  const c = p * a.c + (1 - p) * b.c
+  let h: number
+  if (a.c <= 1e-9) h = b.h
+  else if (b.c <= 1e-9) h = a.h
+  else {
+    let d = (b.h - a.h) % 360
+    if (d > 180) d -= 360
+    h = (a.h + p * d + 360) % 360
+  }
+  return { l, c, h, a: p * a.a + (1 - p) * b.a }
+}
+
+// ---------- CSS parsing ----------
+
+const OKLCH_RE =
+  /^oklch\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)\s*(?:\/\s*([\d.]+)(%?))?\s*\)$/
+const VAR_RE = /^var\(\s*(--[\w-]+)\s*\)$/
+const MIX_RE =
+  /^color-mix\(\s*in oklch,\s*var\(\s*(--[\w-]+)\s*\)\s*([\d.]+)%\s*,\s*var\(\s*(--[\w-]+)\s*\)\s*\)$/
+
+type BlockKind =
+  | 'root'
+  | 'dark'
+  | 'preset'
+  | 'preset-dark'
+  | 'bridge'
+  | 'bridge-dark'
+type TokenMap = Record<string, string>
+
+function parseBlocks(
+  css: string
+): Array<{ selector: string; decls: TokenMap }> {
+  const stripped = css.replaceAll(/\/\*[\s\S]*?\*\//g, '')
+  const blocks: Array<{ selector: string; decls: TokenMap }> = []
+  let i = 0
+  while (i < stripped.length) {
+    const brace = stripped.indexOf('{', i)
+    if (brace === -1) break
+    const selector = stripped.slice(i, brace).trim()
+    let depth = 1
+    let j = brace + 1
+    while (j < stripped.length && depth > 0) {
+      if (stripped[j] === '{') depth += 1
+      else if (stripped[j] === '}') depth -= 1
+      j += 1
+    }
+    const body = stripped.slice(brace + 1, j - 1)
+    const decls: TokenMap = {}
+    for (const m of body.matchAll(/(--[\w-]+)\s*:\s*([^;{}]+);/g)) {
+      decls[m[1]] = m[2].split(/\s+/).join(' ')
+    }
+    if (Object.keys(decls).length > 0) blocks.push({ selector, decls })
+    i = j
+  }
+  return blocks
+}
+
+function classify(selector: string): {
+  kind: BlockKind | null
+  preset: string | null
+} {
+  const s = selector.split(/\s+/).join(' ')
+  const presetMatch = s.match(/\[data-theme-preset='([\w-]+)'\]/)
+  if (presetMatch && !s.includes(':not(')) {
+    return {
+      kind: s.startsWith('.dark') ? 'preset-dark' : 'preset',
+      preset: presetMatch[1],
+    }
+  }
+  if (s.includes(":not([data-theme-preset='default'])")) {
+    return {
+      kind: s.startsWith('.dark') ? 'bridge-dark' : 'bridge',
+      preset: null,
+    }
+  }
+  if (s === ':root') return { kind: 'root', preset: null }
+  if (s === '.dark') return { kind: 'dark', preset: null }
+  return { kind: null, preset: null }
+}
+
+const PRESETS = [
+  'default',
+  'underground',
+  'rose-garden',
+  'lake-view',
+  'sunset-glow',
+  'forest-whisper',
+  'ocean-breeze',
+  'lavender-dream',
+  'simple-large',
+  'anthropic',
+]
+
+// Presets tinted by the semantic surface bridge in theme-presets.css.
+const BRIDGE_PRESETS = new Set([
+  'underground',
+  'rose-garden',
+  'lake-view',
+  'sunset-glow',
+  'forest-whisper',
+  'ocean-breeze',
+  'lavender-dream',
+])
+
+function loadTokenData() {
+  const data: Record<BlockKind, Record<string, TokenMap>> = {
+    root: { '': {} },
+    dark: { '': {} },
+    preset: {},
+    'preset-dark': {},
+    bridge: { '': {} },
+    'bridge-dark': { '': {} },
+  }
+  for (const file of ['src/styles/theme.css', 'src/styles/theme-presets.css']) {
+    for (const { selector, decls } of parseBlocks(read(file))) {
+      const { kind, preset } = classify(selector)
+      if (!kind) continue
+      if (kind === 'preset' || kind === 'preset-dark') {
+        data[kind][preset ?? ''] = { ...data[kind][preset ?? ''], ...decls }
+      } else {
+        data[kind][''] = { ...data[kind][''], ...decls }
+      }
+    }
+  }
+  return data
+}
+
+const DATA = loadTokenData()
+
+/** Effective raw token map for preset x mode, honoring cascade specificity:
+ * bridge (0,3,0) > preset block (0,2,0) > theme.css base (0,1,0). */
+function effectiveTokens(preset: string, mode: 'light' | 'dark'): TokenMap {
+  const tokens: TokenMap = {
+    ...(mode === 'dark' ? DATA.dark[''] : DATA.root['']),
+  }
+  const bridgeKeys = new Set<string>()
+  if (BRIDGE_PRESETS.has(preset)) {
+    const bridge = DATA[mode === 'dark' ? 'bridge-dark' : 'bridge']['']
+    Object.assign(tokens, bridge)
+    for (const key of Object.keys(bridge)) bridgeKeys.add(key)
+  }
+  const block = DATA[mode === 'dark' ? 'preset-dark' : 'preset'][preset] ?? {}
+  for (const [key, value] of Object.entries(block)) {
+    if (!bridgeKeys.has(key)) tokens[key] = value
+  }
+  return tokens
+}
+
+function resolveValue(
+  raw: string | undefined,
+  tokens: TokenMap,
+  depth = 0
+): Oklch | null {
+  if (!raw || depth > 12) return null
+  const mix = raw.match(MIX_RE)
+  if (mix) {
+    const a = resolveValue(tokens[mix[1]], tokens, depth + 1)
+    const b = resolveValue(tokens[mix[3]], tokens, depth + 1)
+    if (a && b) return mixOklch(a, Number(mix[2]) / 100, b)
+    return null
+  }
+  const varRef = raw.match(VAR_RE)
+  if (varRef) return resolveValue(tokens[varRef[1]], tokens, depth + 1)
+  const oklch = raw.match(OKLCH_RE)
+  if (oklch) {
+    const alpha = oklch[4] ? Number(oklch[4]) / (oklch[5] ? 100 : 1) : 1
+    return {
+      l: Number(oklch[1]),
+      c: Number(oklch[2]),
+      h: Number(oklch[3]),
+      a: alpha,
+    }
+  }
+  return null
+}
+
+function tokenRgb(
+  preset: string,
+  mode: 'light' | 'dark',
+  token: string
+): Rgb | null {
+  const tokens = effectiveTokens(preset, mode)
+  const color = resolveValue(tokens[`--${token}`], tokens)
+  if (!color) return null
+  return oklchToSrgb(color)
+}
+
+function pairRatio(
+  preset: string,
+  mode: 'light' | 'dark',
+  fg: string,
+  bg: string
+): number | null {
+  const f = tokenRgb(preset, mode, fg)
+  const b = tokenRgb(preset, mode, bg)
+  if (!f || !b) return null
+  return contrastRatio(f, b)
+}
+
+/** Soft badges render text-<tone>-soft-fg on bg-<tone>/10 (destructive uses
+ * /20 in dark per badge.tsx/button.tsx) composited over the card surface. */
+function softRatio(
+  preset: string,
+  mode: 'light' | 'dark',
+  tone: string
+): number | null {
+  const tokens = effectiveTokens(preset, mode)
+  const fg = resolveValue(tokens[`--${tone}-soft-fg`], tokens)
+  const base = resolveValue(tokens[`--${tone}`], tokens)
+  const card = resolveValue(tokens['--card'], tokens)
+  if (!fg || !base || !card) return null
+  const alpha = tone === 'destructive' && mode === 'dark' ? 0.2 : 0.1
+  const fill = composite(oklchToSrgb(base), alpha, oklchToSrgb(card))
+  return contrastRatio(oklchToSrgb(fg), fill)
+}
+
+// ---------- audit surface ----------
+
+const SOLID_PAIRS: Array<[string, string]> = [
+  ['primary-foreground', 'primary'],
+  ['secondary-foreground', 'secondary'],
+  ['destructive-foreground', 'destructive'],
+  ['info-foreground', 'info'],
+  ['success-foreground', 'success'],
+  ['warning-foreground', 'warning'],
+  ['foreground', 'background'],
+  ['foreground', 'card'],
+  ['muted-foreground', 'card'],
+  ['accent-foreground', 'accent'],
+  ['sidebar-accent-foreground', 'sidebar-accent'],
+  ['sidebar-primary-foreground', 'sidebar-primary'],
+]
+const SOFT_TONES = ['destructive', 'info', 'success', 'warning']
+
+/** Known residuals outside the 2026-08-23 fix scope (a11y-checklist §7).
+ * Key: `${preset}|${mode}|${label}`. */
+const EXEMPTIONS: Record<string, string> = {
+  // Dormant token pair: no component consumes bg-sidebar-primary today.
+  'default|light|sidebar-primary-foreground on sidebar-primary':
+    'dormant: bg-sidebar-primary unused by components',
+  'default|dark|sidebar-primary-foreground on sidebar-primary':
+    'dormant: bg-sidebar-primary unused by components',
+  'forest-whisper|dark|secondary-foreground on secondary':
+    'preset residual deferred per a11y-checklist §7.4',
+  'ocean-breeze|light|secondary-foreground on secondary':
+    'preset residual (4.47) deferred per a11y-checklist §7.4',
+  'simple-large|dark|destructive-foreground on destructive':
+    'preset bespoke destructive deferred per a11y-checklist §7.4',
+  'anthropic|dark|destructive-foreground on destructive':
+    'preset bespoke destructive deferred per a11y-checklist §7.4',
+  'anthropic|light|success-foreground on success':
+    'olive success preset residual deferred per a11y-checklist §7.4',
+  'anthropic|light|success-soft-fg on success/10':
+    'olive success preset residual deferred per a11y-checklist §7.4',
+}
+
+describe('theme contrast gate (WCAG AA 4.5:1)', () => {
+  it('every tracked pair passes AA across 10 presets x both modes (or is a documented exemption)', () => {
+    const failures: string[] = []
+    for (const preset of PRESETS) {
+      for (const mode of ['light', 'dark'] as const) {
+        for (const [fg, bg] of SOLID_PAIRS) {
+          const label = `${fg} on ${bg}`
+          const ratio = pairRatio(preset, mode, fg, bg)
+          if (ratio === null) {
+            failures.push(`${preset} ${mode}: ${label} could not be resolved`)
+            continue
+          }
+          const key = `${preset}|${mode}|${label}`
+          if (ratio < AA && !(key in EXEMPTIONS)) {
+            failures.push(
+              `${preset} ${mode}: ${label} = ${ratio.toFixed(2)} (< ${AA})`
+            )
+          }
+        }
+        for (const tone of SOFT_TONES) {
+          const alpha = tone === 'destructive' && mode === 'dark' ? 20 : 10
+          const label = `${tone}-soft-fg on ${tone}/${alpha}`
+          const ratio = softRatio(preset, mode, tone)
+          if (ratio === null) {
+            failures.push(`${preset} ${mode}: ${label} could not be resolved`)
+            continue
+          }
+          const key = `${preset}|${mode}|${label}`
+          if (ratio < AA && !(key in EXEMPTIONS)) {
+            failures.push(
+              `${preset} ${mode}: ${label} = ${ratio.toFixed(2)} (< ${AA})`
+            )
+          }
+        }
+      }
+    }
+    expect(failures).toEqual([])
+  })
+
+  it('exemptions still reference pairs that exist and stay below 6:1 (no silent scope creep)', () => {
+    for (const key of Object.keys(EXEMPTIONS)) {
+      const [preset, mode, label] = key.split('|') as [
+        string,
+        'light' | 'dark',
+        string,
+      ]
+      const match = label.match(/^(.+?) on (.+)$/)
+      expect(match, `exemption key malformed: ${key}`).not.toBeNull()
+      if (!match) continue
+      const [, fg, bg] = match
+      const ratio = bg.includes('/')
+        ? softRatio(preset, mode, bg.split('/')[0])
+        : pairRatio(preset, mode, fg, bg)
+      expect(ratio, `exemption no longer resolves: ${key}`).not.toBeNull()
+      if (ratio !== null) expect(ratio).toBeLessThan(6)
+    }
+  })
+
+  it('the six 2026-08-23 fixes keep their committed token values', () => {
+    const val = (preset: string, mode: 'light' | 'dark', token: string) => {
+      const tokens = effectiveTokens(preset, mode)
+      return resolveValue(tokens[`--${token}`], tokens)
+    }
+    const close = (actual: Oklch | null, l: number, c: number, h: number) => {
+      expect(actual, 'token resolves').not.toBeNull()
+      if (!actual) return
+      expect(actual.l).toBeCloseTo(l, 4)
+      expect(actual.c).toBeCloseTo(c, 4)
+      expect(actual.h).toBeCloseTo(h, 2)
+    }
+    // 1. rose-garden dark secondary: dark rose surface, was light pink 1.50:1
+    close(val('rose-garden', 'dark', 'secondary'), 0.4, 0.08, 8)
+    // 2. default dark destructive darkened for white foreground
+    close(val('default', 'dark', 'destructive'), 0.575, 0.19, 25)
+    // 3. five preset dark primaries darkened for white CTA text
+    close(val('forest-whisper', 'dark', 'primary'), 0.529, 0.12, 180.39)
+    close(val('ocean-breeze', 'dark', 'primary'), 0.563, 0.188, 259.81)
+    close(val('lavender-dream', 'dark', 'primary'), 0.5759, 0.1699, 307.95)
+    close(val('rose-garden', 'dark', 'primary'), 0.5876, 0.2348, 10.36)
+    close(val('sunset-glow', 'dark', 'primary'), 0.5787, 0.1822, 23.51)
+    // 4. anthropic light clay + sky darkened for AA
+    close(val('anthropic', 'light', 'primary'), 0.57, 0.15, 38)
+    close(val('anthropic', 'light', 'info'), 0.55, 0.075, 248)
+    // 5. independent soft-badge foregrounds
+    close(val('default', 'light', 'destructive-soft-fg'), 0.5, 0.2, 27)
+    close(val('default', 'dark', 'info-soft-fg'), 0.72, 0.12, 245)
+    // 6. sidebar active item: darkened default light foreground; the
+    //    pure-black lake-view dark override was deleted (falls back to
+    //    theme.css dark).
+    close(
+      val('default', 'light', 'sidebar-accent-foreground'),
+      0.505,
+      0.18,
+      256
+    )
+    const lakeViewDark = DATA['preset-dark']['lake-view'] ?? {}
+    expect(lakeViewDark['--sidebar-accent-foreground']).toBeUndefined()
+  })
+})

--- a/web/src/styles/__tests__/token-hygiene.test.ts
+++ b/web/src/styles/__tests__/token-hygiene.test.ts
@@ -76,14 +76,16 @@ describe('design-token hygiene', () => {
     expect(css).toContain('var(--shadow-card-hover)')
   })
 
-  it('theme.css defines destructive-soft-fg in both themes (dark contrast fix)', () => {
+  it('theme.css defines destructive-soft-fg in both themes (contrast fixes)', () => {
     const theme = read('src/styles/theme.css')
     expect(theme).toContain(
       '--color-destructive-soft-fg: var(--destructive-soft-fg)'
     )
-    // light aliases to --destructive; dark uses a lighter readable value so
-    // soft-destructive text on dark surfaces keeps AA contrast.
-    expect(theme).toMatch(/--destructive-soft-fg: var\(--destructive\)/)
+    // Light ships a standalone darker ink (aliasing --destructive only
+    // reached ~4.0:1 on the destructive/10 tint); dark keeps the lighter
+    // readable value so soft-destructive text clears AA on dark surfaces.
+    // Pinned by contrast-gate.test.ts; see a11y-checklist.md §4/§7.
+    expect(theme).toMatch(/--destructive-soft-fg: oklch\(0\.5 0\.2 27\)/)
     expect(theme).toMatch(/--destructive-soft-fg: oklch\(0\.8 0\.15 22\)/)
   })
 })

--- a/web/src/styles/theme-presets.css
+++ b/web/src/styles/theme-presets.css
@@ -67,20 +67,23 @@
   --radius: 1rem;
 }
 .dark [data-theme-preset='rose-garden'] {
-  --primary: oklch(0.6476 0.2348 10.36);
+  /* Darkened (L −0.06) so white CTA text clears WCAG AA 4.5:1. */
+  --primary: oklch(0.5876 0.2348 10.36);
   --primary-foreground: oklch(1 0 0);
-  --secondary: oklch(0.8131 0.1129 5.67);
+  /* Dark rose surface for dark mode (light mode's pale pink with a
+   * near-white foreground measured 1.50:1 — the lowest ratio shipped). */
+  --secondary: oklch(0.4 0.08 8);
   --secondary-foreground: oklch(0.9227 0.0029 34.49);
-  --ring: oklch(0.6476 0.2348 10.36);
-  --chart-1: oklch(0.6476 0.2348 10.36);
+  --ring: oklch(0.5876 0.2348 10.36);
+  --chart-1: oklch(0.5876 0.2348 10.36);
   --chart-2: oklch(0.8938 0.0563 3.77);
   --chart-3: oklch(0.7135 0.1879 7.69);
   --chart-4: oklch(0.8131 0.1129 5.67);
   --chart-5: oklch(0.9429 0.0283 5.52);
-  --sidebar-primary: oklch(0.6476 0.2348 10.36);
+  --sidebar-primary: oklch(0.5876 0.2348 10.36);
   --sidebar-primary-foreground: oklch(1 0 0);
   --sidebar-accent-foreground: oklch(1 0 0);
-  --sidebar-ring: oklch(0.6476 0.2348 10.36);
+  --sidebar-ring: oklch(0.5876 0.2348 10.36);
 }
 
 /* ── Lake View ────────────────────────────────────────────────────────── */
@@ -113,7 +116,9 @@
   --chart-5: oklch(0.95 0.052 163.05);
   --sidebar-primary: oklch(0.765 0.177 163.22);
   --sidebar-primary-foreground: oklch(0 0 0);
-  --sidebar-accent-foreground: oklch(0 0 0);
+  /* No --sidebar-accent-foreground override here: the theme.css dark value
+   * (light blue ink) is used. The previous pure-black override measured
+   * 1.75:1 on the dark accent surface. */
   --sidebar-ring: oklch(0.765 0.177 163.22);
 }
 
@@ -135,22 +140,23 @@
   --radius: 1rem;
 }
 .dark [data-theme-preset='sunset-glow'] {
-  --primary: oklch(0.6387 0.1822 23.51);
+  /* Darkened (L −0.06) so white CTA text clears WCAG AA 4.5:1. */
+  --primary: oklch(0.5787 0.1822 23.51);
   --primary-foreground: oklch(1 0 0);
   /* Darkened to match the other presets' dark strategy: a muted surface
    * with light text, instead of the light mode's bright secondary. */
   --secondary: oklch(0.42 0.08 42.42);
   --secondary-foreground: oklch(1 0 0);
-  --ring: oklch(0.6387 0.1822 23.51);
-  --chart-1: oklch(0.6387 0.1822 23.51);
+  --ring: oklch(0.5787 0.1822 23.51);
+  --chart-1: oklch(0.5787 0.1822 23.51);
   --chart-2: oklch(0.7938 0.1248 42.42);
   --chart-3: oklch(0.809 0.0875 17.95);
   --chart-4: oklch(0.8964 0.0724 43.73);
   --chart-5: oklch(0.9381 0.0241 16.66);
-  --sidebar-primary: oklch(0.6387 0.1822 23.51);
+  --sidebar-primary: oklch(0.5787 0.1822 23.51);
   --sidebar-primary-foreground: oklch(1 0 0);
   --sidebar-accent-foreground: oklch(1 0 0);
-  --sidebar-ring: oklch(0.6387 0.1822 23.51);
+  --sidebar-ring: oklch(0.5787 0.1822 23.51);
 }
 
 /* ── Forest Whisper ───────────────────────────────────────────────────── */
@@ -171,20 +177,22 @@
   --radius: 0.5rem;
 }
 .dark [data-theme-preset='forest-whisper'] {
-  --primary: oklch(0.5991 0.1318 180.39);
+  /* Darkened (L −0.07, C trimmed to stay in sRGB gamut at the lower
+   * lightness) so white CTA text clears WCAG AA 4.5:1. */
+  --primary: oklch(0.529 0.12 180.39);
   --primary-foreground: oklch(1 0 0);
   --secondary: oklch(0.6578 0.0485 247.35);
   --secondary-foreground: oklch(1 0 0);
-  --ring: oklch(0.5991 0.1318 180.39);
-  --chart-1: oklch(0.5991 0.1318 180.39);
+  --ring: oklch(0.529 0.12 180.39);
+  --chart-1: oklch(0.529 0.12 180.39);
   --chart-2: oklch(0.6578 0.0485 247.35);
   --chart-3: oklch(0.7741 0.1676 178.16);
   --chart-4: oklch(0.7294 0.0416 244.67);
   --chart-5: oklch(0.9511 0.0547 177.24);
-  --sidebar-primary: oklch(0.5991 0.1318 180.39);
+  --sidebar-primary: oklch(0.529 0.12 180.39);
   --sidebar-primary-foreground: oklch(1 0 0);
   --sidebar-accent-foreground: oklch(1 0 0);
-  --sidebar-ring: oklch(0.5991 0.1318 180.39);
+  --sidebar-ring: oklch(0.529 0.12 180.39);
 }
 
 /* ── Ocean Breeze ─────────────────────────────────────────────────────── */
@@ -205,20 +213,21 @@
   --radius: 0.3rem;
 }
 .dark [data-theme-preset='ocean-breeze'] {
-  --primary: oklch(0.623 0.188 259.81);
+  /* Darkened (L −0.06) so white CTA text clears WCAG AA 4.5:1. */
+  --primary: oklch(0.563 0.188 259.81);
   --primary-foreground: oklch(1 0 0);
   --secondary: oklch(0.5854 0.2041 277.12);
   --secondary-foreground: oklch(0 0 0);
-  --ring: oklch(0.623 0.188 259.81);
-  --chart-1: oklch(0.623 0.188 259.81);
+  --ring: oklch(0.563 0.188 259.81);
+  --chart-1: oklch(0.563 0.188 259.81);
   --chart-2: oklch(0.5854 0.2041 277.12);
   --chart-3: oklch(0.809 0.0922 251.81);
   --chart-4: oklch(0.785 0.1007 274.72);
   --chart-5: oklch(0.932 0.0281 255.58);
-  --sidebar-primary: oklch(0.623 0.188 259.81);
+  --sidebar-primary: oklch(0.563 0.188 259.81);
   --sidebar-primary-foreground: oklch(1 0 0);
   --sidebar-accent-foreground: oklch(1 0 0);
-  --sidebar-ring: oklch(0.623 0.188 259.81);
+  --sidebar-ring: oklch(0.563 0.188 259.81);
 }
 
 /* ── Lavender Dream ───────────────────────────────────────────────────── */
@@ -239,22 +248,23 @@
   --radius: 1rem;
 }
 .dark [data-theme-preset='lavender-dream'] {
-  --primary: oklch(0.6359 0.1699 307.95);
+  /* Darkened (L −0.06) so white CTA text clears WCAG AA 4.5:1. */
+  --primary: oklch(0.5759 0.1699 307.95);
   --primary-foreground: oklch(1 0 0);
   /* Darkened to match the other presets' dark strategy: a muted surface
    * with light text, instead of the light mode's bright secondary. */
   --secondary: oklch(0.4 0.045 201.14);
   --secondary-foreground: oklch(1 0 0);
-  --ring: oklch(0.6359 0.1699 307.95);
-  --chart-1: oklch(0.6359 0.1699 307.95);
+  --ring: oklch(0.5759 0.1699 307.95);
+  --chart-1: oklch(0.5759 0.1699 307.95);
   --chart-2: oklch(0.811 0.0589 201.14);
   --chart-3: oklch(0.8281 0.078 309.73);
   --chart-4: oklch(0.8611 0.0504 198.03);
   --chart-5: oklch(0.947 0.0212 309.77);
-  --sidebar-primary: oklch(0.6359 0.1699 307.95);
+  --sidebar-primary: oklch(0.5759 0.1699 307.95);
   --sidebar-primary-foreground: oklch(1 0 0);
   --sidebar-accent-foreground: oklch(1 0 0);
-  --sidebar-ring: oklch(0.6359 0.1699 307.95);
+  --sidebar-ring: oklch(0.5759 0.1699 307.95);
 }
 
 /* ── Simple ───────────────────────────────────────────────────────────── */
@@ -445,7 +455,8 @@
  *
  * OKLCH hue 95 = warm yellow-cream (matches #faf9f5 family);
  * OKLCH hue 60 = warm slate (matches #141413 family);
- * OKLCH hue 38 = clay/coral (matches #d97757).
+ * OKLCH hue 38 = clay/coral (#d97757 family; light-mode lightness darkened
+ * for WCAG AA contrast with the cream foreground).
  */
 [data-theme-preset='anthropic'] {
   /* Canvas + ink — the defining pair. */
@@ -459,8 +470,10 @@
   --popover: oklch(0.97 0.006 92); /* slight cream lift */
   --popover-foreground: oklch(0.205 0.005 60);
 
-  /* Clay/coral — Anthropic's signature accent, used scarcely on CTAs. */
-  --primary: oklch(0.685 0.142 38); /* ≈ #d97757 */
+  /* Clay/coral — Anthropic's signature accent, used scarcely on CTAs.
+   * Darkened from the brand's #d97757 (oklch 0.685 0.142 38) so the cream
+   * foreground clears WCAG AA 4.5:1 on solid CTA surfaces (was 2.91:1). */
+  --primary: oklch(0.57 0.15 38);
   --primary-foreground: oklch(0.99 0.005 95);
 
   --secondary: oklch(0.925 0.008 92);
@@ -477,7 +490,9 @@
   --success-foreground: oklch(0.985 0 0);
   --warning: oklch(0.78 0.13 70); /* kraft amber */
   --warning-foreground: oklch(0.205 0.005 60);
-  --info: oklch(0.67 0.075 248); /* sky #6a9bcc */
+  --info: oklch(
+    0.55 0.075 248
+  ); /* sky — darkened from #6a9bcc so white foreground clears AA (was 2.85:1) */
   --info-foreground: oklch(0.985 0 0);
   --neutral: oklch(0.51 0.006 75);
   --neutral-foreground: oklch(0.205 0.005 60);
@@ -485,23 +500,23 @@
   /* Hairline borders — warm gray, not coral. */
   --border: oklch(0.895 0.008 92); /* ≈ #e8e6dc */
   --input: oklch(0.895 0.008 92);
-  --ring: oklch(0.685 0.142 38);
+  --ring: oklch(0.57 0.15 38);
 
   /* Chart palette uses Anthropic's dormant accent swatches. */
-  --chart-1: oklch(0.685 0.142 38); /* clay */
+  --chart-1: oklch(0.57 0.15 38); /* clay (AA-darkened, matches --primary) */
   --chart-2: oklch(0.59 0.082 130); /* olive */
-  --chart-3: oklch(0.67 0.075 248); /* sky */
+  --chart-3: oklch(0.55 0.075 248); /* sky (AA-darkened, matches --info) */
   --chart-4: oklch(0.7 0.115 0); /* fig */
   --chart-5: oklch(0.83 0.027 175); /* cactus */
 
   --sidebar: oklch(0.955 0.008 92);
   --sidebar-foreground: oklch(0.255 0.005 60);
-  --sidebar-primary: oklch(0.685 0.142 38);
+  --sidebar-primary: oklch(0.57 0.15 38);
   --sidebar-primary-foreground: oklch(0.99 0.005 95);
   --sidebar-accent: oklch(0.915 0.009 92);
   --sidebar-accent-foreground: oklch(0.205 0.005 60);
   --sidebar-border: oklch(0.895 0.008 92);
-  --sidebar-ring: oklch(0.685 0.142 38);
+  --sidebar-ring: oklch(0.57 0.15 38);
 
   --skeleton-base: oklch(0.93 0.008 92);
   --skeleton-highlight: oklch(0.96 0.006 92);

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -104,7 +104,9 @@
   --accent-foreground: oklch(0.145 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.985 0 0);
-  --destructive-soft-fg: var(--destructive);
+  /* Independent of `--destructive`: the base red on a `destructive/10` tint
+   * only reaches ~4.0:1; this darker ink clears AA on soft badges. */
+  --destructive-soft-fg: oklch(0.5 0.2 27);
   --success: oklch(0.53 0.145 163.225);
   --success-foreground: oklch(0.985 0 0);
   --warning: oklch(0.62 0.162 75.834);
@@ -134,7 +136,9 @@
   --sidebar-primary: oklch(0.64 0.197 253.892);
   --sidebar-primary-foreground: oklch(1 0 0);
   --sidebar-accent: color-mix(in oklch, var(--primary) 12%, var(--background));
-  --sidebar-accent-foreground: oklch(0.579 0.196 255.909);
+  /* Darkened from oklch(0.579 0.196 255.909): the active sidebar item must
+   * clear WCAG AA (4.5:1) on the 12% primary-tinted accent surface. */
+  --sidebar-accent-foreground: oklch(0.505 0.18 256);
   --sidebar-border: oklch(0.93 0 0);
   --sidebar-ring: oklch(0.58 0.2 250);
   --skeleton-base: oklch(0.97 0 0);
@@ -191,7 +195,10 @@
   --muted-foreground: oklch(0.78 0 0);
   --accent: color-mix(in oklch, var(--primary) 20%, var(--background));
   --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
+  /* Darkened from oklch(0.704 0.191 22.216): white foreground on the old
+   * value only reached 2.77:1; solid destructive surfaces (e.g. the
+   * attention bell's critical badge) must clear WCAG AA. */
+  --destructive: oklch(0.575 0.19 25);
   --destructive-foreground: oklch(0.985 0 0);
   --destructive-soft-fg: oklch(0.8 0.15 22);
   --success: oklch(0.696 0.17 162.48);
@@ -200,11 +207,12 @@
   --warning-foreground: oklch(0.145 0 0);
   --info: oklch(0.613 0.14 239.919);
   --info-foreground: oklch(0.145 0 0);
-  /* Soft-tint foregrounds match the light, readable tones; dark mode already
-     passes AA so these mirror the base tones. */
+  /* Soft-tint foregrounds: warning/success mirror their base tones (dark
+   * mode already passes AA there); info is lifted lighter than `--info` so
+   * 12px text on `bg-info/10` clears WCAG AA on dark card surfaces. */
   --warning-soft-fg: oklch(0.769 0.188 70.08);
   --success-soft-fg: oklch(0.696 0.17 162.48);
-  --info-soft-fg: oklch(0.613 0.14 239.919);
+  --info-soft-fg: oklch(0.72 0.12 245);
   --neutral: oklch(0.76 0 0);
   --neutral-foreground: oklch(0.155 0 0);
   --border: oklch(1 0 0 / 10%);


### PR DESCRIPTION
主题对比度 6 项修复（WCAG 数值管线全量验证，审计坐实）：

| 配对 | 前 | 后 |
|---|---|---|
| rose-garden 暗 secondary（全仓最低） | 1.50 | 7.64 |
| default 暗 destructive 实底 | 2.77 | 4.61 |
| 5 preset 暗白字 CTA | 3.59–3.69 | 4.71–4.81 |
| anthropic 亮 clay/info | 2.91/2.85 | 4.64/4.62 |
| 亮 destructive-soft / 暗 info-soft | 3.84/3.45 | 4.93/5.17 |
| sidebar 激活（default 亮 / lake-view 暗） | 3.95/1.75 | 5.38/8.95 |

- 修复前先复现审计数值（OKLCH→sRGB→WCAG 管线）；数值偏差按管线说了算（如暗 destructive 0.60 只到 4.15 → 用 0.575）
- **新增静态守卫** `contrast-gate.test.ts`：解析两级 theme CSS（含 color-mix 级联），320 配对全量断言 ≥4.5，8 个存量残留显式豁免表 + 6 项修复精确值 tripwire
- a11y-checklist §7.4/§4 与 DESIGN.md 同步更新；颜色语义不变（只压亮度/微调彩度）

测试：样式守卫 18 tests + 全量 991 tests 全绿。
