### PR TITLE
fix(scripts): verify-live-assets matches rsbuild /static/ output and fails closed

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -362,4 +362,9 @@ bash web/scripts/verify-live-assets.sh http://127.0.0.1:4000
 # verify-live-assets OK: N referenced assets all 200
 ```
 
+The script discovers entry assets from index.html (both the rsbuild `/static/`
+and legacy Vite `/assets/` prefixes) plus the lazy async chunks listed in the
+runtime chunk map, and fails closed (exit 1) if it discovers zero assets or any
+asset is missing/swallowed — an empty set never passes.
+
 The script needs only bash + curl (no node on the target).

--- a/web/scripts/verify-live-assets.sh
+++ b/web/scripts/verify-live-assets.sh
@@ -3,10 +3,21 @@
 #
 # Replays the browser asset graph against a live Metapi instance:
 #   1. index.html entry assets must answer 200 with a real content type
-#   2. lazy chunks referenced by entry bundles must answer 200
+#   2. lazy chunks listed in the runtime chunk map must answer 200
 #   3. any asset answered as text/html = SPA fallback swallowed it (fail)
+#   4. zero discovered assets = fail-closed (an empty set proves nothing)
+#
+# Entry assets match both the rsbuild output prefix (/static/...) and the
+# legacy Vite prefix (/assets/...). Lazy chunks are discovered from the
+# rspack runtime chunk-id->content-hash map inside each entry bundle
+# (c.u=e=>"static/js/async/"+e+"."+({ID:"HASH",...})[e]+".js"); minified
+# rsbuild output contains no import() literals, so parsing bundle text for
+# them (the old approach) can never find anything.
 #
 # Usage: bash scripts/verify-live-assets.sh [baseUrl]   (default http://127.0.0.1:4000)
+#
+# All curl calls use --noproxy '*': this is a localhost smoke test, and a
+# host-level proxy (~/.curlrc, http_proxy) would falsify the result.
 set -u
 
 BASE="${1:-http://127.0.0.1:4000}"
@@ -19,25 +30,27 @@ fail=0
 fetch_ok() { # url -> 0 ok / 1 missing / 2 swallowed-by-spa
   local url="$1" ct
   local code
-  code="$(curl -s -o "$TMP/body" -w '%{http_code}' "$url")"
+  code="$(curl --noproxy '*' -s -o "$TMP/body" -w '%{http_code}' "$url")"
   [ "$code" = "200" ] || { echo "  MISSING [$code] $url"; return 1; }
-  ct="$(curl -sI "$url" | grep -i '^content-type:' | sed 's/.*: //' | tr -d '\r')"
+  ct="$(curl --noproxy '*' -sI "$url" | grep -i '^content-type:' | sed 's/.*: //' | tr -d '\r')"
   case "$ct" in
     text/html*) echo "  SWALLOWED $url answered text/html"; return 2 ;;
   esac
   return 0
 }
 
-# 1) entry assets from index.html
-refs="$(curl -s "$BASE/" | grep -oE '(src|href)="(/assets/[^"]+)"' | sed -E 's/.*"(\/assets\/[^"]+)".*/\1/' | sort -u)"
+# 1) entry assets from index.html (rsbuild emits /static/, Vite emitted /assets/)
+refs="$(curl --noproxy '*' -s "$BASE/" | grep -oE '(src|href)="(/(static|assets)/[^"]+)"' | sed -E 's/.*"(\/(static|assets)\/[^"]+)".*/\1/' | sort -u)"
 
-# 2) lazy chunks from every JS bundle (extend the ref set, then check)
+# 2) lazy chunks from every entry JS bundle (extend the ref set, then check)
 for rel in $refs; do
   case "$rel" in
     *.js)
-      curl -s "$BASE$rel" -o "$TMP/$(basename "$rel")"
-      newrefs="$(grep -oE 'import\(`\./[^`]+`\)' "$TMP/$(basename "$rel")" | sed -E 's/import\(`\.\/([^`]+)`\)/\/assets\/\1/' || true)"
-      refs="$(printf '%s\n%s\n' "$refs" "$newrefs" | sort -u)"
+      curl --noproxy '*' -s "$BASE$rel" -o "$TMP/$(basename "$rel")"
+      newrefs="$(grep -oE '"static/js/async/"[^{]*\{[^}]+\}' "$TMP/$(basename "$rel")" \
+        | grep -oE '[0-9]+:"[0-9a-f]+"' \
+        | sed -E 's|([0-9]+):"([0-9a-f]+)"|/static/js/async/\1.\2.js|' || true)"
+      refs="$(printf '%s\n%s\n' "$refs" "$newrefs" | grep -v '^$' | sort -u)"
       ;;
   esac
 done
@@ -47,6 +60,14 @@ for rel in $refs; do
   total=$((total + 1))
   if ! fetch_ok "$BASE$rel"; then fail=1; fi
 done
+
+# Fail-closed: an empty ref set means nothing was verified (wrong BASE,
+# index.html unreachable, or the asset prefix changed again). Never report
+# OK on an empty set.
+if [ "$total" -eq 0 ]; then
+  echo "verify-live-assets FAIL: no /static/ or /assets/ entry assets discovered at $BASE/ (nothing verified)"
+  exit 1
+fi
 
 if [ "$fail" = 1 ]; then
   echo "verify-live-assets FAIL ($total referenced assets, errors above)"


### PR DESCRIPTION
修复部署文档指定的升级后验证脚本恒空通过（假绿灯）：脚本自 Vite 时代引入后未随 rsbuild 迁移更新。

- 入口资产提取同时匹配 `/static/`（rsbuild）与 `/assets/`（legacy）
- 懒 chunk 发现改为从 entry bundle 提取 rspack runtime 的 chunk-id→hash map（不再解析 bundle 内 `import()` 字面量）
- **Fail-closed**：发现资产数为 0 时输出 FAIL 并 exit 1（不再报 OK）
- 所有 curl 加 `--noproxy '*'`（防 .curlrc 代理劫持 localhost 冒烟）
- docs/deployment.md 同步双前缀发现与 fail-closed 说明

实测（临时实例）：正向 72 资产全 200 exit 0；负向删 async chunk → MISSING + exit 1；空发现 → FAIL + exit 1；legacy /assets/ 布局回归 exit 0。
