### PR TITLE
fix(web): P0 sidebar Routes navigation silently fails - URL-sync guard

### DIFF
--- a/web/src/components/data-table/hooks/__tests__/use-url-table-state.test.tsx
+++ b/web/src/components/data-table/hooks/__tests__/use-url-table-state.test.tsx
@@ -1,0 +1,139 @@
+// useUrlTableState — URL-sync guard regression tests.
+//
+// The P0 "sidebar Routes click snaps back" bug: a list page's table callbacks
+// fire while the router is navigating away (the useLocation searchStr
+// subscription re-renders the leaving page with the next location's search),
+// and the old guard compared hrefs against `window.location.pathname` — which
+// lags behind during an in-flight navigation because @tanstack/history
+// coalesces queued push/replace calls into one microtask. The guard must
+// compare against the router-side pathname instead. These tests pin the
+// guard's exact-match semantics against the three scenarios that matter.
+
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useUrlTableState, type UrlTableState, type UrlTableStateUpdate } from '../use-url-table-state'
+
+type Location = { searchStr: string; pathname: string }
+
+const locationState = vi.hoisted(() => ({
+  current: { searchStr: '?page=1&pageSize=20', pathname: '/channels' } as Location,
+  navigate: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useLocation: (opts: { select: (loc: Location) => string }) =>
+    opts.select(locationState.current),
+  useNavigate: () => locationState.navigate,
+}))
+
+type Filters = { status: string }
+
+function readSearch(searchString?: string): UrlTableState<Filters> {
+  const params = new URLSearchParams(searchString ?? '')
+  return {
+    q: params.get('q') ?? '',
+    pageIndex: Number(params.get('page') ?? 0),
+    pageSize: Number(params.get('pageSize') ?? 20),
+    sorting: [],
+    filters: { status: params.get('status') ?? '' },
+  }
+}
+
+function buildHref(next: UrlTableStateUpdate<Filters>): string {
+  const merged = { ...readSearch(locationState.current.searchStr), ...next }
+  const params = new URLSearchParams()
+  if (merged.q) params.set('q', merged.q)
+  if (merged.pageIndex > 0) params.set('page', String(merged.pageIndex))
+  if (merged.pageSize !== 20) params.set('pageSize', String(merged.pageSize))
+  if (merged.filters?.status) params.set('status', merged.filters.status)
+  const query = params.toString()
+  return query ? `/channels?${query}` : '/channels'
+}
+
+describe('useUrlTableState URL-sync guard', () => {
+  beforeEach(() => {
+    locationState.current = {
+      searchStr: '?page=1&pageSize=20',
+      pathname: '/channels',
+    }
+    locationState.navigate.mockClear()
+  })
+
+  function render() {
+    return renderHook(() =>
+      useUrlTableState<Filters>({
+        basePath: '/channels',
+        read: readSearch,
+        buildHref,
+        toColumnFilters: () => [],
+        fromColumnFilters: () => ({}),
+      })
+    )
+  }
+
+  it('writes back when still on this page', () => {
+    const { result } = render()
+    act(() => {
+      result.current.updateUrlState({ pageIndex: 2 })
+    })
+    expect(locationState.navigate).toHaveBeenCalledTimes(1)
+    expect(locationState.navigate).toHaveBeenCalledWith({
+      href: '/channels?page=2',
+      replace: true,
+    })
+  })
+
+  it('blocks a write-back while the router is already on the target page (in-flight navigation)', () => {
+    // The P0 repro: click sidebar "Routes" on /channels; the router location
+    // store moves to /token-routes at navigation start, the leaving /channels
+    // page re-renders with the target's search and its table callbacks fire.
+    // The write-back must be a no-op.
+    const { result, rerender } = render()
+    locationState.current = { searchStr: '', pathname: '/token-routes' }
+    rerender()
+    act(() => {
+      result.current.updateUrlState({ pageIndex: 0 })
+    })
+    expect(locationState.navigate).not.toHaveBeenCalled()
+  })
+
+  it('blocks leaving this page under any other target path', () => {
+    const { result, rerender } = render()
+    locationState.current = { searchStr: '', pathname: '/accounts' }
+    rerender()
+    act(() => {
+      result.current.updateUrlState({ pageIndex: 1 })
+    })
+    expect(locationState.navigate).not.toHaveBeenCalled()
+  })
+
+  it('exact path match — a sibling sharing a prefix is not this page', () => {
+    // Guards against the `startsWith` semantics of the old guard: an href for
+    // /channels-extra would have passed `startsWith('/channels')`.
+    const { result } = renderHook(() =>
+      useUrlTableState<Filters>({
+        basePath: '/channels',
+        read: readSearch,
+        buildHref: () => '/channels-extra?page=1',
+        toColumnFilters: () => [],
+        fromColumnFilters: () => ({}),
+      })
+    )
+    act(() => {
+      result.current.updateUrlState({ pageIndex: 1 })
+    })
+    expect(locationState.navigate).not.toHaveBeenCalled()
+  })
+
+  it('onPaginationChange routes through the guard and navigates when on page', () => {
+    const { result } = render()
+    act(() => {
+      result.current.onPaginationChange({ pageIndex: 3, pageSize: 50 })
+    })
+    expect(locationState.navigate).toHaveBeenCalledWith({
+      href: '/channels?page=3&pageSize=50',
+      replace: true,
+    })
+  })
+})

--- a/web/src/components/data-table/hooks/__tests__/use-url-table-state.test.tsx
+++ b/web/src/components/data-table/hooks/__tests__/use-url-table-state.test.tsx
@@ -12,12 +12,19 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { useUrlTableState, type UrlTableState, type UrlTableStateUpdate } from '../use-url-table-state'
+import {
+  useUrlTableState,
+  type UrlTableState,
+  type UrlTableStateUpdate,
+} from '../use-url-table-state'
 
 type Location = { searchStr: string; pathname: string }
 
 const locationState = vi.hoisted(() => ({
-  current: { searchStr: '?page=1&pageSize=20', pathname: '/channels' } as Location,
+  current: {
+    searchStr: '?page=1&pageSize=20',
+    pathname: '/channels',
+  } as Location,
   navigate: vi.fn(),
 }))
 

--- a/web/src/components/data-table/hooks/use-url-table-state.ts
+++ b/web/src/components/data-table/hooks/use-url-table-state.ts
@@ -30,7 +30,7 @@
 // functions are read through a ref so inline definitions do not break the
 // contract.
 
-import { useLocation, useNavigate } from '@tanstack/react-router'
+import { useLocation, useNavigate, useRouterState } from '@tanstack/react-router'
 import type {
   ColumnFiltersState,
   PaginationState,
@@ -109,6 +109,20 @@ export function useUrlTableState<TFilters>(
   const navigate = useNavigate()
   // Subscribe to the router location so search-only navigation re-renders.
   const searchStr = useLocation({ select: (loc) => loc.searchStr })
+  // The router-side *current* pathname. This is the source of truth for the
+  // URL-sync guard below: the router's location store moves to the target
+  // route at the *start* of a navigation, while `window.location.pathname`
+  // (browser history) does not update until the route commits — so for a
+  // code-split page the pending window leaves `window.location` on the old
+  // page. The old page re-renders with the next location's search (the
+  // `searchStr` subscription above), its table callbacks fire, and with the
+  // lagging history pathname the old guard let them navigate straight back —
+  // the "clicked a sidebar link but the page snapped back" bug. Comparing
+  // against the router location (already at the target) makes any write-back
+  // from a leaving page a no-op.
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  })
   const resetPageIndexOnFilterChange =
     options.resetPageIndexOnFilterChange ?? false
 
@@ -141,14 +155,16 @@ export function useUrlTableState<TFilters>(
   // the *next* location's search string). Without the pathname check the
   // callback would navigate straight back, hijacking the in-flight
   // navigation — the "clicked a sidebar link but the page snapped back"
-  // bug. Only sync when we are still on this page.
+  // bug. Only sync when we are still on this page; the router pathname (not
+  // `window.location.pathname`, which lags behind during a pending
+  // transition for code-split routes) says whether that is true.
   const updateUrlState = React.useCallback(
     (next: UrlTableStateUpdate<TFilters>) => {
       const href = buildHrefRef.current(next)
-      if (!href.startsWith(window.location.pathname)) return
+      if (!href.startsWith(pathname)) return
       navigate({ href, replace: true })
     },
-    [navigate]
+    [navigate, pathname]
   )
 
   const onGlobalFilterChange = React.useCallback(

--- a/web/src/components/data-table/hooks/use-url-table-state.ts
+++ b/web/src/components/data-table/hooks/use-url-table-state.ts
@@ -30,7 +30,7 @@
 // functions are read through a ref so inline definitions do not break the
 // contract.
 
-import { useLocation, useNavigate, useRouterState } from '@tanstack/react-router'
+import { useLocation, useNavigate } from '@tanstack/react-router'
 import type {
   ColumnFiltersState,
   PaginationState,
@@ -97,6 +97,12 @@ export function encodeSorting(sorting: SortingState): string {
     .join(',')
 }
 
+/** The pathname part of an href string (drops search/hash, trailing slash). */
+function pathnameOf(href: string): string {
+  const cut = href.search(/[?#]/)
+  return (cut === -1 ? href : href.slice(0, cut)).replace(/\/+$/, '')
+}
+
 /**
  * Controlled table state whose source of truth is the URL search string.
  * Re-exported fields plug straight into `useDataTable`; `filters` +
@@ -107,22 +113,12 @@ export function useUrlTableState<TFilters>(
   options: UrlTableStateOptions<TFilters>
 ) {
   const navigate = useNavigate()
-  // Subscribe to the router location so search-only navigation re-renders.
+  // Subscribe to the router location so search-only navigation re-renders,
+  // and so the URL-sync guard below can compare against the router-side
+  // *current* pathname. (Separate primitive selectors — a compound object
+  // selector would break useSyncExternalStore snapshot identity.)
   const searchStr = useLocation({ select: (loc) => loc.searchStr })
-  // The router-side *current* pathname. This is the source of truth for the
-  // URL-sync guard below: the router's location store moves to the target
-  // route at the *start* of a navigation, while `window.location.pathname`
-  // (browser history) does not update until the route commits — so for a
-  // code-split page the pending window leaves `window.location` on the old
-  // page. The old page re-renders with the next location's search (the
-  // `searchStr` subscription above), its table callbacks fire, and with the
-  // lagging history pathname the old guard let them navigate straight back —
-  // the "clicked a sidebar link but the page snapped back" bug. Comparing
-  // against the router location (already at the target) makes any write-back
-  // from a leaving page a no-op.
-  const pathname = useRouterState({
-    select: (state) => state.location.pathname,
-  })
+  const pathname = useLocation({ select: (loc) => loc.pathname })
   const resetPageIndexOnFilterChange =
     options.resetPageIndexOnFilterChange ?? false
 
@@ -155,13 +151,24 @@ export function useUrlTableState<TFilters>(
   // the *next* location's search string). Without the pathname check the
   // callback would navigate straight back, hijacking the in-flight
   // navigation — the "clicked a sidebar link but the page snapped back"
-  // bug. Only sync when we are still on this page; the router pathname (not
-  // `window.location.pathname`, which lags behind during a pending
-  // transition for code-split routes) says whether that is true.
+  // bug. Only sync when we are still on this page.
+  //
+  // Must compare against the router-side pathname, never
+  // `window.location.pathname`: @tanstack/history coalesces push/replace
+  // calls queued within the same tick (a microtask flush applies only the
+  // last href, keeping the push), so while the browser URL still shows this
+  // page, the router location store has already moved to the target route.
+  // The router pathname is the source of truth for whether a write-back is
+  // still on the page it belongs to.
+  //
+  // Exact path match (not a `startsWith` prefix test): hrefs are always
+  // built on this page's own path, so a match is exactly "still on this
+  // page", and a sibling that merely shares a prefix (e.g. `/channels` vs
+  // `/channels-foo`) can never sneak a write-back through.
   const updateUrlState = React.useCallback(
     (next: UrlTableStateUpdate<TFilters>) => {
       const href = buildHrefRef.current(next)
-      if (!href.startsWith(pathname)) return
+      if (pathnameOf(href) !== pathname) return
       navigate({ href, replace: true })
     },
     [navigate, pathname]


### PR DESCRIPTION
Wave 7 前端体验波（v0.16.9 候选）。审查-核实-修复-实测闭环，详见 docs/internal/log.md。