### PR TITLE
fix(web): accounts - checkin badge toggle, sort persistence, credential i18n

### DIFF
--- a/web/src/features/accounts/components/__tests__/accounts-checkin-badge.test.tsx
+++ b/web/src/features/accounts/components/__tests__/accounts-checkin-badge.test.tsx
@@ -1,0 +1,173 @@
+// Behavior tests for the inline check-in toggle badge in the accounts list
+// (Wave 7 L4 finding: the check-in badge looked clickable but was a static
+// <Badge> — dead click). The cell must now render a real button that keeps
+// the badge look, calls actions.onToggleCheckin with the account, shows a
+// per-row spinner while the mutation is pending, and stays a plain muted
+// "Not supported" text when the account cannot check in.
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
+import i18n from '@/i18n/config'
+
+import type { Account, AccountRowActions } from '../../types'
+import { useAccountsColumns } from '../accounts-columns'
+
+function makeAccount(overrides: Partial<Account>): Account {
+  return {
+    id: 42,
+    siteId: 1,
+    username: 'smoke-account',
+    status: 'active',
+    isPinned: false,
+    checkinEnabled: true,
+    credentialMode: 'session',
+    capabilities: {
+      canCheckin: true,
+      canRefreshBalance: false,
+      proxyOnly: false,
+    },
+    ...overrides,
+  } as Account
+}
+
+function buildActions(): AccountRowActions {
+  return {
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    onRefresh: vi.fn(),
+    onViewDetail: vi.fn(),
+    onTogglePin: vi.fn(),
+    onToggleCheckin: vi.fn(),
+    onToggleStatus: vi.fn(),
+  }
+}
+
+function Harness({
+  account,
+  actions,
+  pendingCheckinId = null,
+}: {
+  account: Account
+  actions: AccountRowActions
+  pendingCheckinId?: number | null
+}) {
+  const columns = useAccountsColumns(actions, null, pendingCheckinId)
+  const table = useReactTable({
+    data: [account],
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  })
+  const row = table.getRowModel().rows[0]
+  return (
+    <div>
+      {row
+        .getVisibleCells()
+        .map((cell) =>
+          flexRender(cell.column.columnDef.cell, cell.getContext())
+        )}
+    </div>
+  )
+}
+
+beforeAll(() => {
+  // jsdom does not ship matchMedia; Base UI components read it on mount.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(async () => {
+  // i18next resolves the zh variant to the registered 'zhCN' language id
+  // (see web/src/i18n/languages.ts convertDetectedLanguage).
+  await i18n.changeLanguage('zhCN')
+})
+
+afterEach(() => cleanup())
+
+describe('accounts check-in badge toggle', () => {
+  it('renders a real button labeled with the on state and the turn-off action', async () => {
+    render(<Harness account={makeAccount({ checkinEnabled: true })} actions={buildActions()} />)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '关闭签到' })).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: '关闭签到' })).toHaveTextContent('已开启')
+  })
+
+  it('renders the turn-on action label when check-in is off', async () => {
+    render(<Harness account={makeAccount({ checkinEnabled: false })} actions={buildActions()} />)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '开启签到' })).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: '开启签到' })).toHaveTextContent('未开启')
+  })
+
+  it('clicking the badge calls onToggleCheckin with the account', async () => {
+    const actions = buildActions()
+    const account = makeAccount({ checkinEnabled: true })
+    render(<Harness account={account} actions={actions} />)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '关闭签到' })).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: '关闭签到' }))
+    expect(actions.onToggleCheckin).toHaveBeenCalledTimes(1)
+    expect(actions.onToggleCheckin).toHaveBeenCalledWith(account)
+  })
+
+  it('disables only the pending row badge (per-row spinner contract)', async () => {
+    const account = makeAccount({ checkinEnabled: false })
+    render(<Harness account={account} actions={buildActions()} pendingCheckinId={42} />)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '开启签到' })).toBeDisabled()
+    })
+  })
+
+  it('keeps the plain muted "unsupported" text (no button) when canCheckin is false', async () => {
+    render(
+      <Harness
+        account={makeAccount({ capabilities: { canCheckin: false, canRefreshBalance: false, proxyOnly: false } })}
+        actions={buildActions()}
+      />
+    )
+    await waitFor(() => {
+      expect(screen.getByText('不支持')).toBeInTheDocument()
+    })
+    // No check-in toggle button (the harness also renders the row-actions
+    // Power/⋮ buttons, so scope the negative assertion to check-in labels).
+    expect(screen.queryByRole('button', { name: '关闭签到' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '开启签到' })).not.toBeInTheDocument()
+  })
+
+  it('localizes the credential mode badge from the i18n resources (en)', async () => {
+    await i18n.changeLanguage('en')
+    render(
+      <Harness
+        account={makeAccount({ credentialMode: 'apikey' })}
+        actions={buildActions()}
+      />
+    )
+    await waitFor(() => {
+      expect(
+        screen.getByText(i18n.t('accounts.columns.credentialModeApiKey'))
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/features/accounts/components/__tests__/accounts-checkin-badge.test.tsx
+++ b/web/src/features/accounts/components/__tests__/accounts-checkin-badge.test.tsx
@@ -5,7 +5,18 @@
 // per-row spinner while the mutation is pending, and stays a plain muted
 // "Not supported" text when the account cannot check in.
 import '@testing-library/jest-dom/vitest'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import {
   afterEach,
   beforeAll,
@@ -15,7 +26,7 @@ import {
   it,
   vi,
 } from 'vitest'
-import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
+
 import i18n from '@/i18n/config'
 
 import type { Account, AccountRowActions } from '../../types'
@@ -105,19 +116,37 @@ afterEach(() => cleanup())
 
 describe('accounts check-in badge toggle', () => {
   it('renders a real button labeled with the on state and the turn-off action', async () => {
-    render(<Harness account={makeAccount({ checkinEnabled: true })} actions={buildActions()} />)
+    render(
+      <Harness
+        account={makeAccount({ checkinEnabled: true })}
+        actions={buildActions()}
+      />
+    )
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: '关闭签到' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: '关闭签到' })
+      ).toBeInTheDocument()
     })
-    expect(screen.getByRole('button', { name: '关闭签到' })).toHaveTextContent('已开启')
+    expect(screen.getByRole('button', { name: '关闭签到' })).toHaveTextContent(
+      '已开启'
+    )
   })
 
   it('renders the turn-on action label when check-in is off', async () => {
-    render(<Harness account={makeAccount({ checkinEnabled: false })} actions={buildActions()} />)
+    render(
+      <Harness
+        account={makeAccount({ checkinEnabled: false })}
+        actions={buildActions()}
+      />
+    )
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: '开启签到' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: '开启签到' })
+      ).toBeInTheDocument()
     })
-    expect(screen.getByRole('button', { name: '开启签到' })).toHaveTextContent('未开启')
+    expect(screen.getByRole('button', { name: '开启签到' })).toHaveTextContent(
+      '未开启'
+    )
   })
 
   it('clicking the badge calls onToggleCheckin with the account', async () => {
@@ -125,7 +154,9 @@ describe('accounts check-in badge toggle', () => {
     const account = makeAccount({ checkinEnabled: true })
     render(<Harness account={account} actions={actions} />)
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: '关闭签到' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: '关闭签到' })
+      ).toBeInTheDocument()
     })
     fireEvent.click(screen.getByRole('button', { name: '关闭签到' }))
     expect(actions.onToggleCheckin).toHaveBeenCalledTimes(1)
@@ -134,7 +165,13 @@ describe('accounts check-in badge toggle', () => {
 
   it('disables only the pending row badge (per-row spinner contract)', async () => {
     const account = makeAccount({ checkinEnabled: false })
-    render(<Harness account={account} actions={buildActions()} pendingCheckinId={42} />)
+    render(
+      <Harness
+        account={account}
+        actions={buildActions()}
+        pendingCheckinId={42}
+      />
+    )
     await waitFor(() => {
       expect(screen.getByRole('button', { name: '开启签到' })).toBeDisabled()
     })
@@ -143,7 +180,13 @@ describe('accounts check-in badge toggle', () => {
   it('keeps the plain muted "unsupported" text (no button) when canCheckin is false', async () => {
     render(
       <Harness
-        account={makeAccount({ capabilities: { canCheckin: false, canRefreshBalance: false, proxyOnly: false } })}
+        account={makeAccount({
+          capabilities: {
+            canCheckin: false,
+            canRefreshBalance: false,
+            proxyOnly: false,
+          },
+        })}
         actions={buildActions()}
       />
     )
@@ -152,8 +195,12 @@ describe('accounts check-in badge toggle', () => {
     })
     // No check-in toggle button (the harness also renders the row-actions
     // Power/⋮ buttons, so scope the negative assertion to check-in labels).
-    expect(screen.queryByRole('button', { name: '关闭签到' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: '开启签到' })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: '关闭签到' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: '开启签到' })
+    ).not.toBeInTheDocument()
   })
 
   it('localizes the credential mode badge from the i18n resources (en)', async () => {

--- a/web/src/features/accounts/components/account-detail-sheet.tsx
+++ b/web/src/features/accounts/components/account-detail-sheet.tsx
@@ -124,7 +124,9 @@ export function AccountDetailSheet({
                 account.credentialMode === 'session' ? 'default' : 'secondary'
               }
             >
-              {account.credentialMode === 'session' ? 'Session' : 'API Key'}
+              {account.credentialMode === 'session'
+                ? t('accounts.columns.credentialModeSession')
+                : t('accounts.columns.credentialModeApiKey')}
             </Badge>
           </SheetTitle>
         </SheetHeader>

--- a/web/src/features/accounts/components/accounts-columns.tsx
+++ b/web/src/features/accounts/components/accounts-columns.tsx
@@ -267,7 +267,8 @@ export const AccountsRowActions = memo(function AccountsRowActions({
 
 export function useAccountsColumns(
   actions: AccountRowActions,
-  pendingStatusId: number | null = null
+  pendingStatusId: number | null = null,
+  pendingCheckinId: number | null = null
 ): ColumnDef<Account>[] {
   const { t } = useTranslation()
   const resolveHealth = useResolveHealth()
@@ -320,7 +321,9 @@ export function useAccountsColumns(
                       : 'secondary'
                   }
                 >
-                  {account.credentialMode === 'session' ? 'Session' : 'API Key'}
+                  {account.credentialMode === 'session'
+                    ? t('accounts.columns.credentialModeSession')
+                    : t('accounts.columns.credentialModeApiKey')}
                 </Badge>
               </div>
               {account.tags && account.tags.length > 0 && (
@@ -465,12 +468,46 @@ export function useAccountsColumns(
               </span>
             )
           }
+          // The badge reads as clickable, so it must BE clickable (like the
+          // original TS Accounts page): a button that keeps the badge look
+          // (pill, same default/outline colors) and toggles check-in inline.
+          // size='xs' is h-6 = 24px, the WCAG 2.5.8 minimum hit target.
+          const isPending = pendingCheckinId === account.id
+          const label = account.checkinEnabled
+            ? t('accounts.columns.checkinOn')
+            : t('accounts.columns.checkinOff')
+          const actionLabel = account.checkinEnabled
+            ? t('accounts.columns.disableCheckin')
+            : t('accounts.columns.enableCheckin')
           return (
-            <Badge variant={account.checkinEnabled ? 'default' : 'outline'}>
-              {account.checkinEnabled
-                ? t('accounts.columns.checkinOn')
-                : t('accounts.columns.checkinOff')}
-            </Badge>
+            <TooltipProvider delay={200}>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant={account.checkinEnabled ? 'default' : 'outline'}
+                      size='xs'
+                      className='rounded-4xl px-2.5 font-medium'
+                      aria-label={actionLabel}
+                      data-hit-area
+                      disabled={isPending}
+                      onClick={() => actions.onToggleCheckin(account)}
+                    >
+                      {isPending ? <Spinner /> : label}
+                    </Button>
+                  }
+                >
+                  {account.checkinEnabled
+                    ? t('accounts.columns.checkinTooltipOn')
+                    : t('accounts.columns.checkinTooltipOff')}
+                </TooltipTrigger>
+                <TooltipContent side='top'>
+                  {account.checkinEnabled
+                    ? t('accounts.columns.checkinTooltipOn')
+                    : t('accounts.columns.checkinTooltipOff')}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )
         },
         meta: { mobileOrder: 3 },
@@ -494,6 +531,6 @@ export function useAccountsColumns(
         meta: { pinned: 'right' },
       },
     ],
-    [actions, pendingStatusId, resolveHealth, resolveDisplayName, t]
+    [actions, pendingStatusId, pendingCheckinId, resolveHealth, resolveDisplayName, t]
   )
 }

--- a/web/src/features/accounts/components/accounts-columns.tsx
+++ b/web/src/features/accounts/components/accounts-columns.tsx
@@ -531,6 +531,13 @@ export function useAccountsColumns(
         meta: { pinned: 'right' },
       },
     ],
-    [actions, pendingStatusId, pendingCheckinId, resolveHealth, resolveDisplayName, t]
+    [
+      actions,
+      pendingStatusId,
+      pendingCheckinId,
+      resolveHealth,
+      resolveDisplayName,
+      t,
+    ]
   )
 }

--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -421,7 +421,11 @@ export function AccountsPage() {
     ? (checkinMutation.variables?.id ?? null)
     : null
 
-  const columns = useAccountsColumns(rowActions, pendingStatusId, pendingCheckinId)
+  const columns = useAccountsColumns(
+    rowActions,
+    pendingStatusId,
+    pendingCheckinId
+  )
 
   const { table } = useDataTable({
     data: accounts,

--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -250,7 +250,11 @@ export function AccountsPage() {
   // re-trigger the render loop). The mutate fn identity itself is stable,
   // so a top-level const keeps both the linter and the memo happy.
   const toggleStatusMutate = statusMutation.mutate
-  const { mutate: toggleAccountCheckin } = useToggleAccountCheckin()
+  // Same shape as statusMutation: keep the full mutation object so the inline
+  // check-in badge button can derive `pendingCheckinId` for a per-row spinner
+  // (mirrors the Power button's pendingStatusId flow).
+  const checkinMutation = useToggleAccountCheckin()
+  const toggleCheckinMutate = checkinMutation.mutate
 
   // --- dialog state ---
   const [formOpen, setFormOpen] = useState(false)
@@ -375,7 +379,7 @@ export function AccountsPage() {
           status: account.status === 'active' ? 'disabled' : 'active',
         }),
       onToggleCheckin: (account) =>
-        toggleAccountCheckin(
+        toggleCheckinMutate(
           {
             id: account.id,
             checkinEnabled: !account.checkinEnabled,
@@ -399,7 +403,7 @@ export function AccountsPage() {
       refreshAccount,
       toggleAccountPin,
       toggleStatusMutate,
-      toggleAccountCheckin,
+      toggleCheckinMutate,
       t,
     ]
   )
@@ -413,8 +417,11 @@ export function AccountsPage() {
   const pendingStatusId = statusMutation.isPending
     ? (statusMutation.variables?.id ?? null)
     : null
+  const pendingCheckinId = checkinMutation.isPending
+    ? (checkinMutation.variables?.id ?? null)
+    : null
 
-  const columns = useAccountsColumns(rowActions, pendingStatusId)
+  const columns = useAccountsColumns(rowActions, pendingStatusId, pendingCheckinId)
 
   const { table } = useDataTable({
     data: accounts,
@@ -426,6 +433,8 @@ export function AccountsPage() {
     onColumnFiltersChange: urlState.onColumnFiltersChange,
     pagination: urlState.pagination,
     onPaginationChange: urlState.onPaginationChange,
+    sorting: urlState.sorting,
+    onSortingChange: urlState.onSortingChange,
     ensurePageInRange: urlState.ensurePageInRange,
     globalFilterFn: accountsGlobalFilterFn,
   })

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1674,7 +1674,11 @@
         "checkinUnsupported": "Not supported",
         "checkinOn": "On",
         "checkinOff": "Off",
-        "healthDetail": "Health detail"
+        "healthDetail": "Health detail",
+          "credentialModeSession": "Session",
+          "credentialModeApiKey": "API Key",
+          "checkinTooltipOn": "Click to turn off check-in; daily check-ins skip this account",
+          "checkinTooltipOff": "Click to turn on check-in; the account joins daily check-ins"
       },
       "detail": {
         "fallbackApiKey": "API Key connection",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1675,10 +1675,10 @@
         "checkinOn": "On",
         "checkinOff": "Off",
         "healthDetail": "Health detail",
-          "credentialModeSession": "Session",
-          "credentialModeApiKey": "API Key",
-          "checkinTooltipOn": "Click to turn off check-in; daily check-ins skip this account",
-          "checkinTooltipOff": "Click to turn on check-in; the account joins daily check-ins"
+        "credentialModeSession": "Session",
+        "credentialModeApiKey": "API Key",
+        "checkinTooltipOn": "Click to turn off check-in; daily check-ins skip this account",
+        "checkinTooltipOff": "Click to turn on check-in; the account joins daily check-ins"
       },
       "detail": {
         "fallbackApiKey": "API Key connection",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1674,7 +1674,11 @@
         "checkinUnsupported": "不支持",
         "checkinOn": "已开启",
         "checkinOff": "未开启",
-        "healthDetail": "健康详情"
+        "healthDetail": "健康详情",
+          "credentialModeSession": "Session",
+          "credentialModeApiKey": "API Key",
+          "checkinTooltipOn": "点击关闭签到，全部签到将忽略此账号",
+          "checkinTooltipOff": "点击开启签到，账号将参与每日签到"
       },
       "detail": {
         "fallbackApiKey": "API Key 连接",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1606,7 +1606,7 @@
         "credentialMode": "凭证模式",
         "modeSession": "Session",
         "modeApiKey": "API Key",
-        "modePassword": "密码登录",
+        "modePassword": "Password",
         "connectionName": "连接名称（可选）",
         "connectionNamePlaceholder": "留空则使用站点用户名",
         "status": "状态",
@@ -1675,10 +1675,10 @@
         "checkinOn": "已开启",
         "checkinOff": "未开启",
         "healthDetail": "健康详情",
-          "credentialModeSession": "Session",
-          "credentialModeApiKey": "API Key",
-          "checkinTooltipOn": "点击关闭签到，全部签到将忽略此账号",
-          "checkinTooltipOff": "点击开启签到，账号将参与每日签到"
+        "credentialModeSession": "Session",
+        "credentialModeApiKey": "API Key",
+        "checkinTooltipOn": "点击关闭签到，全部签到将忽略此账号",
+        "checkinTooltipOff": "点击开启签到，账号将参与每日签到"
       },
       "detail": {
         "fallbackApiKey": "API Key 连接",


### PR DESCRIPTION
Wave 7 前端体验波（v0.16.9 候选）。审查-核实-修复-实测闭环，详见 docs/internal/log.md。