### PR TITLE
fix(web): route detail Edit action + named decision channel + stream error i18n

### DIFF
--- a/docs/internal/progress/MASTER.md
+++ b/docs/internal/progress/MASTER.md
@@ -36,16 +36,18 @@
 
 > 2026-08-24 三轮只读探索（token-routes/models/model-tester · settings/sites/accounts/channels · dashboard/observability/checkin/oauth/import + 全局横切）产出证据化清单，按优先级分批落地，每批带回归测试与门禁。
 
-**Batch 1（本 PR）—— 错误态一致性 + i18n + 文档漂移**
+**Batch 1（已合入 #975）—— 错误态一致性 + i18n + 文档漂移**
 - accounts/channels 页 load error 时同时渲染 QueryErrorBanner 与 DataTablePage 空态（含误导 CTA）→ 镜像 sites 页三元分支抑制 table（+ 回归测试）。
 - import stepper `aria-label` 硬编码英文 → `t('import.stepper.progressLabel')`（en/zh 词条补齐）。
 - a11y-checklist §7「preset contrast」残留清单过时（Wave 9 已清零）→ 改为 0 豁免现状。
 
+**Batch 2（本 PR）—— token-routes Edit + decision 语义 + stream i18n**
+- token-routes detail sheet footer 增「Edit」（gap-6），routes-page 接线（关 sheet → 开 edit dialog）；decision snapshot selected channel 显示 account 名。
+- transport.ts:151 硬编码中文流式错误 → 英文技术消息。
+
 **剩余 P2（后续批）**
-- token-routes detail sheet footer 缺 Edit（gap-6）；decision snapshot 显示 raw channelId。
 - model-tester 无 error 态（模型/渠道下拉静默为空）。
 - import 空响应、manual-checkin schema-parse 失败被 `catch {}` 静默吞。
-- transport.ts:151 硬编码中文错误串。
 - schedule-editor / site-form-dialog 自定义组件未透传 id/aria（FormLabel htmlFor 悬空）。
 
 **剩余 P3（后续批）**

--- a/web/src/features/token-routes/__tests__/routes-page-drilldown.test.tsx
+++ b/web/src/features/token-routes/__tests__/routes-page-drilldown.test.tsx
@@ -8,7 +8,7 @@
 // A stale id strips silently in both flows.
 
 import '@testing-library/jest-dom/vitest'
-import { cleanup, render, waitFor } from '@testing-library/react'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -26,6 +26,7 @@ const testState = vi.hoisted(() => ({
   detailSheetProps: null as {
     route: RouteSummaryRow | null
     open: boolean
+    onEdit?: (route: RouteSummaryRow) => void
   } | null,
   formDialogProps: null as {
     route: RouteSummaryRow | null
@@ -284,5 +285,30 @@ describe('RoutesPage edit drilldown', () => {
     rerender(<RoutesPage />)
 
     expect(testState.navigate).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('RoutesPage detail sheet Edit action', () => {
+  it('closes the sheet and opens the edit dialog when onEdit fires', async () => {
+    testState.routeIdParam = '5'
+    testState.routerSearch = { routeId: 5 }
+    testState.routes = [makeRoute(5)]
+
+    render(<RoutesPage />)
+
+    await waitFor(() => {
+      expect(testState.detailSheetProps?.open).toBe(true)
+    })
+    const onEdit = testState.detailSheetProps?.onEdit
+    expect(onEdit).toBeTypeOf('function')
+
+    act(() => onEdit?.(makeRoute(5)))
+
+    await waitFor(() => {
+      expect(testState.detailSheetProps?.open).toBe(false)
+    })
+    expect(testState.formDialogProps?.open).toBe(true)
+    expect(testState.formDialogProps?.mode).toBe('edit')
+    expect(testState.formDialogProps?.route?.id).toBe(5)
   })
 })

--- a/web/src/features/token-routes/components/route-detail-sheet.tsx
+++ b/web/src/features/token-routes/components/route-detail-sheet.tsx
@@ -4,7 +4,7 @@
 // `routingStrategyLabel()` returns an i18n key; wrapped with `t()`.
 
 import { useQueries } from '@tanstack/react-query'
-import { RefreshCw, Snowflake } from 'lucide-react'
+import { Pencil, RefreshCw, Snowflake } from 'lucide-react'
 import { useMemo, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -53,6 +53,7 @@ interface RouteDetailSheetProps {
   route: RouteSummaryRow | null
   open: boolean
   onOpenChange: (open: boolean) => void
+  onEdit?: (route: RouteSummaryRow) => void
 }
 
 type PriceQueryState = {
@@ -84,6 +85,7 @@ export function RouteDetailSheet({
   route,
   open,
   onOpenChange,
+  onEdit,
 }: RouteDetailSheetProps) {
   const { t, i18n } = useTranslation()
   const locale = toBcp47(i18n.language || 'en')
@@ -319,6 +321,12 @@ export function RouteDetailSheet({
         </div>
 
         <SheetFooter>
+          {!isReadOnly && onEdit ? (
+            <Button variant='outline' onClick={() => onEdit(route)}>
+              <Pencil className='size-4' />
+              {t('common.edit')}
+            </Button>
+          ) : null}
           <Button onClick={handleRebuild} variant='default'>
             <RefreshCw
               className={rebuildMutation.isPending ? 'animate-spin' : undefined}
@@ -571,7 +579,18 @@ function DecisionSnapshotSection({
           {candidates.length}
         </DetailField>
         <DetailField label={t('tokenRoutes.detail.decisionSelectedChannel')}>
-          {decision.selectedChannelId ?? '—'}
+          {(() => {
+            const selected = candidates.find(
+              (candidate) => candidate.channelId === decision.selectedChannelId
+            )
+            if (selected?.username) return selected.username
+            if (decision.selectedChannelId != null) {
+              return t('tokenRoutes.detail.fallbackAccount', {
+                id: decision.selectedChannelId,
+              })
+            }
+            return '—'
+          })()}
         </DetailField>
       </dl>
       {reasonText && (

--- a/web/src/features/token-routes/components/routes-page.tsx
+++ b/web/src/features/token-routes/components/routes-page.tsx
@@ -541,6 +541,10 @@ export function RoutesPage() {
         route={detailRoute}
         open={detailOpen}
         onOpenChange={setDetailOpen}
+        onEdit={(route) => {
+          setDetailOpen(false)
+          openEdit(route)
+        }}
       />
 
       <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>

--- a/web/src/lib/api/transport.ts
+++ b/web/src/lib/api/transport.ts
@@ -148,7 +148,7 @@ export async function streamSse(
     throw new Error(await extractResponseErrorMessage(response))
   }
   if (!response.body) {
-    throw new Error('响应未返回流式内容')
+    throw new Error('Stream response body is missing')
   }
 
   const decoder = new TextDecoder()


### PR DESCRIPTION
## UI/UX 深修波 · Batch 2（token-routes + transport）

- **Edit 动作（P2，audit gap-6）**：token-routes detail sheet footer 现增加「Edit」按钮，从 routes-page 接线（关闭 sheet → 打开 edit dialog，复用 openEdit 同一状态），只读路由不显示。
- **decision snapshot 语义（P3）**：selected channel 由 raw channelId 数字改为 account 名（candidates 反查 username，未命中回退 \allbackAccount\）。
- **i18n（P2）**：transport.ts 硬编码中文流式错误串改为英文技术消息，不再无视语言设置显示中文。
- 新增回归测试：sheet Edit → edit dialog 交接。

验证：typecheck / lint（0 error）/ format:check / token-routes 15 test files 126 tests 全绿。