### PR TITLE
fix(web): model-tester query error state + schedule-editor input labels

### DIFF
--- a/docs/internal/progress/MASTER.md
+++ b/docs/internal/progress/MASTER.md
@@ -45,10 +45,13 @@
 - token-routes detail sheet footer 增「Edit」（gap-6），routes-page 接线（关 sheet → 开 edit dialog）；decision snapshot selected channel 显示 account 名。
 - transport.ts:151 硬编码中文流式错误 → 英文技术消息。
 
+**Batch 3（本 PR）—— model-tester 错误态 + schedule-editor 可访问标签**
+- model-tester：models/channels 查询加载失败时静默空下拉 → 接入 QueryErrorBanner + Retry。
+- schedule-editor：daily/window/custom 的 time/cron 输入补 aria-label（en/zh 词条）。
+
 **剩余 P2（后续批）**
-- model-tester 无 error 态（模型/渠道下拉静默为空）。
 - import 空响应、manual-checkin schema-parse 失败被 `catch {}` 静默吞。
-- schedule-editor / site-form-dialog 自定义组件未透传 id/aria（FormLabel htmlFor 悬空）。
+- site-form-dialog（EndpointsEditor）自定义组件未透传 id/aria（FormLabel htmlFor 悬空）。
 
 **剩余 P3（后续批）**
 - token-routes/index.ts barrel stub；model-detail-sheet onTest 死代码；test-response-viewer useEffect 缺依赖数组。

--- a/web/src/features/model-tester/components/test-form.tsx
+++ b/web/src/features/model-tester/components/test-form.tsx
@@ -16,6 +16,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
+import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
@@ -142,6 +143,18 @@ export function TestForm({
   return (
     <Form {...form}>
       <form onSubmit={handleSubmit} className='flex flex-col gap-4'>
+        <QueryErrorBanner
+          error={modelsQuery.error as Error | null}
+          messageKey='modelTester.form.modelsLoadError'
+          onRetry={() => modelsQuery.refetch()}
+          isRetrying={modelsQuery.isFetching}
+        />
+        <QueryErrorBanner
+          error={channelsQuery.error as Error | null}
+          messageKey='modelTester.form.channelsLoadError'
+          onRetry={() => channelsQuery.refetch()}
+          isRetrying={channelsQuery.isFetching}
+        />
         <FormItem>
           <FormLabel>{t('modelTester.template.label')}</FormLabel>
           <Select

--- a/web/src/features/settings/components/schedule-editor.tsx
+++ b/web/src/features/settings/components/schedule-editor.tsx
@@ -117,6 +117,7 @@ export function ScheduleEditor({
         {kind === 'daily' ? (
           <Input
             type='time'
+            aria-label={t('settings.common.schedule.dailyTimeLabel')}
             className='w-32 font-mono'
             value={spec.kind === 'daily' ? spec.time : '08:00'}
             disabled={disabled}
@@ -167,6 +168,7 @@ export function ScheduleEditor({
         <div className='flex flex-wrap items-center gap-2'>
           <Input
             type='time'
+            aria-label={t('settings.common.schedule.windowStartLabel')}
             className='w-32 font-mono'
             value={spec.kind === 'window' ? spec.windowStart : '00:00'}
             disabled={disabled}
@@ -182,6 +184,7 @@ export function ScheduleEditor({
           <span className='text-muted-foreground text-xs'>→</span>
           <Input
             type='time'
+            aria-label={t('settings.common.schedule.windowEndLabel')}
             className='w-32 font-mono'
             value={spec.kind === 'window' ? spec.windowEnd : '23:59'}
             disabled={disabled}
@@ -202,6 +205,7 @@ export function ScheduleEditor({
           className='w-full font-mono'
           value={spec.kind === 'custom' ? spec.cron : ''}
           disabled={disabled}
+          aria-label={t('settings.common.schedule.cronLabel')}
           placeholder='0 8 * * *'
           onChange={(event) =>
             onChange({

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -216,6 +216,8 @@
       "form": {
         "model": "Model",
         "modelLoading": "Loading models…",
+        "modelsLoadError": "Failed to load models: {{message}}",
+        "channelsLoadError": "Failed to load channels: {{message}}",
         "modelPlaceholder": "Select a model",
         "channel": "Channel",
         "channelNone": "No channel (default routing)",
@@ -949,6 +951,10 @@
           "everyHours_other": "Every {{count}} hours",
           "kindLabel": "Schedule kind",
           "intervalLabel": "Interval hours",
+          "dailyTimeLabel": "Daily time",
+          "windowStartLabel": "Window start",
+          "windowEndLabel": "Window end",
+          "cronLabel": "Cron expression",
           "kinds": {
             "daily": "Daily at",
             "interval": "Every N hours",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -216,6 +216,8 @@
       "form": {
         "model": "模型",
         "modelLoading": "加载模型中…",
+        "modelsLoadError": "加载模型失败：{{message}}",
+        "channelsLoadError": "加载渠道失败：{{message}}",
         "modelPlaceholder": "选择模型",
         "channel": "渠道",
         "channelNone": "不指定渠道（默认路由）",
@@ -949,6 +951,10 @@
           "everyHours_other": "每 {{count}} 小时",
           "kindLabel": "调度类型",
           "intervalLabel": "间隔小时数",
+          "dailyTimeLabel": "每日时间",
+          "windowStartLabel": "窗口开始",
+          "windowEndLabel": "窗口结束",
+          "cronLabel": "Cron 表达式",
           "kinds": {
             "daily": "每天固定时间",
             "interval": "每隔 N 小时",


### PR DESCRIPTION
## UI/UX 深修波 · Batch 3（model-tester + schedule-editor）

- **model-tester 错误态（P2）**：models/channels 查询加载失败时此前下拉静默为空、无反馈 → 表单顶部接入共享 QueryErrorBanner + Retry（en/zh 词条 \modelsLoadError\ / \channelsLoadError\）。
- **schedule-editor 可访问标签（P2）**：daily/window/custom 的 time/cron 输入此前无程序化标签 → 每个控件补 \ria-label\（\dailyTimeLabel\ / \windowStartLabel\ / \windowEndLabel\ / \cronLabel\，en/zh 词条）。
- MASTER.md 记录 Batch 3 完成。

验证：typecheck / lint（0 error）/ format:check / model-tester+i18n 9 test files 73 tests / settings+i18n 8 tests 全绿。