### PR TITLE
chore(web): remove dead model-detail onTest path + tidy token-routes barrel

### DIFF
--- a/docs/internal/progress/MASTER.md
+++ b/docs/internal/progress/MASTER.md
@@ -53,8 +53,12 @@
 - import 空响应、manual-checkin schema-parse 失败被 `catch {}` 静默吞。
 - site-form-dialog（EndpointsEditor）自定义组件未透传 id/aria（FormLabel htmlFor 悬空）。
 
+**Batch 4（本 PR）—— 死代码清理**
+- model-detail-sheet 移除从未传入的 `onTest` prop +「Test model」死按钮 + 图标 import + 死 i18n key。
+- token-routes/index.ts 删除空占位注释块（barrel stub 收敛为真实重导出）。
+
 **剩余 P3（后续批）**
-- token-routes/index.ts barrel stub；model-detail-sheet onTest 死代码；test-response-viewer useEffect 缺依赖数组。
+- test-response-viewer useEffect 缺依赖数组。
 - 硬编码 `$` 前缀、`#siteId` 回退、"enabled"/"default" aria/placeholder 未 i18n。
 - lib/api/sites.ts 4 个未用 wrapper；checkin CalendarRange 缺 aria-hidden；endpoints-editor URL 无可见 label。
 

--- a/web/src/features/models/components/model-detail-sheet.tsx
+++ b/web/src/features/models/components/model-detail-sheet.tsx
@@ -7,10 +7,7 @@
 // so an operator can probe a model straight from the marketplace.
 
 import { useNavigate } from '@tanstack/react-router'
-import {
-  ArrowRight as ArrowRightIcon,
-  FlaskConical as FlaskConicalIcon,
-} from 'lucide-react'
+import { ArrowRight as ArrowRightIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { BrandIcon } from '@/assets/brand-icons/BrandIcon'
@@ -40,7 +37,6 @@ type ModelDetailSheetProps = {
   model: ModelRow | null
   open: boolean
   onOpenChange: (open: boolean) => void
-  onTest?: (model: ModelRow) => void
 }
 
 function GroupPricingRow({
@@ -72,7 +68,6 @@ export function ModelDetailSheet({
   model,
   open,
   onOpenChange,
-  onTest,
 }: ModelDetailSheetProps) {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -233,12 +228,6 @@ export function ModelDetailSheet({
             <Separator />
 
             <section className='flex flex-col gap-2'>
-              {onTest && (
-                <Button variant='default' onClick={() => onTest(model)}>
-                  <FlaskConicalIcon className='size-4' />
-                  {t('models.detail.testModel')}
-                </Button>
-              )}
               <Button variant='outline' onClick={goToTester}>
                 {t('models.detail.openTester')}
                 <ArrowRightIcon className='size-4' />

--- a/web/src/features/token-routes/index.ts
+++ b/web/src/features/token-routes/index.ts
@@ -5,14 +5,5 @@
 //
 // `export type` is used for all type-only re-exports (isolatedModules-safe).
 
-// --- page + components ---
-
-// --- route hooks + query keys ---
 export { routeQueryKeys } from './api'
-
-// --- route entity types + runtime schemas ---
-
-// --- pattern + presentation helpers ---
-
-// --- route form schema ---
 export { routesSearchSchema } from './lib/routes-schema'

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -158,7 +158,6 @@
         "outputPrice": "out ${{price}}/M",
         "unknownUser": "Unknown user",
         "availableAccounts": "Available accounts",
-        "testModel": "Test model",
         "openTester": "Open tester"
       },
       "columns": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -158,7 +158,6 @@
         "outputPrice": "输出 ${{price}}/M",
         "unknownUser": "未知用户",
         "availableAccounts": "可用账号",
-        "testModel": "测试模型",
         "openTester": "打开测试器"
       },
       "columns": {


### PR DESCRIPTION
## UI/UX 深修波 · Batch 4（死代码清理，neat-freak）

- **model-detail-sheet**：移除从未被 models-page 传入的 \onTest\ prop、其死「Test model」按钮、随之无用的 \FlaskConical\ 图标 import，以及死 \models.detail.testModel\ i18n key。
- **token-routes/index.ts**：删除空占位注释块，barrel 收敛为真实重导出（\outeQueryKeys\ / \outesSearchSchema\）。
- MASTER.md 记录 Batch 4 完成。

验证：typecheck / lint（0 error）/ format:check / models+i18n 6 test files 30 tests 全绿。