### PR TITLE
fix(web): surface import non-transport failures + drop dead sites wrappers

### DIFF
--- a/docs/internal/progress/MASTER.md
+++ b/docs/internal/progress/MASTER.md
@@ -49,10 +49,6 @@
 - model-tester：models/channels 查询加载失败时静默空下拉 → 接入 QueryErrorBanner + Retry。
 - schedule-editor：daily/window/custom 的 time/cron 输入补 aria-label（en/zh 词条）。
 
-**剩余 P2（后续批）**
-- import 空响应、manual-checkin schema-parse 失败被 `catch {}` 静默吞。
-- site-form-dialog（EndpointsEditor）自定义组件未透传 id/aria（FormLabel htmlFor 悬空）。
-
 **Batch 4（本 PR）—— 死代码清理**
 - model-detail-sheet 移除从未传入的 `onTest` prop +「Test model」死按钮 + 图标 import + 死 i18n key。
 - token-routes/index.ts 删除空占位注释块（barrel stub 收敛为真实重导出）。
@@ -61,10 +57,16 @@
 - catalog-sources Switch aria-label、tokens-panel group placeholder 去硬编码 → i18n（`toggleEnabled` / `groupPlaceholder`）。
 - checkin 装饰性 CalendarRange 补 `aria-hidden`。
 
-**剩余 P3（后续批）**
-- test-response-viewer useEffect 缺依赖数组。
-- 硬编码 `$` 前缀、`#siteId` 回退未 i18n。
-- lib/api/sites.ts 4 个未用 wrapper；endpoints-editor URL 无可见 label。
+**Batch 6（本 PR）—— 死 wrapper 清理 + import 静默失败**
+- lib/api/sites.ts 移除 4 个未用 API wrapper + `SiteProbeNowResponse` 类型 + 测试 mock。
+- import wizard：非 axios 失败（如空响应体）补 `toast`（`import.submitFailed`），不再静默吞。
+
+**已知残差（记录，不作为待办）**
+- manual-checkin `catch {}`：用户可见失败均由 http-client 或结果分支覆盖，仅后端 schema 漂移的编程错误会静默；naive 补 toast 会对 `success:false` 二次提示。
+- `$` 前缀：定价固定 USD，`$` 为货币符号非界面文案，不属于 i18n 目录。
+- `#siteId` 回退：位于纯函数 `resolvePriceDetail`，需透传 `t` 才可本地化，低频残留。
+- test-response-viewer useEffect 无依赖：对话区每次渲染滚到底为流式跟随意图，非缺陷。
+- endpoints-editor URL：已有 `aria-label`，仅 WCAG 3.3.2 可见标签待补。
 
 ## Completed milestone — TS 兼容与迁移收官（2026-08-20 交付）
 

--- a/web/src/features/import/components/import-wizard-dialog.tsx
+++ b/web/src/features/import/components/import-wizard-dialog.tsx
@@ -7,6 +7,7 @@
 // imported/skipped/failed breakdown.
 
 import { useNavigate } from '@tanstack/react-router'
+import axios from 'axios'
 import {
   Check as CheckIcon,
   Minus as MinusIcon,
@@ -386,8 +387,13 @@ export function ImportWizardDialog({
       })
       setResult(importResult)
       setStep('done')
-    } catch {
-      // http-client toasted
+    } catch (error) {
+      // Transport failures (non-2xx) are toasted by the http-client error
+      // interceptor; a plain error thrown by the mutation (e.g. an empty
+      // response body) is not, so surface it instead of swallowing.
+      if (!axios.isAxiosError(error)) {
+        toast.error(t('import.submitFailed'))
+      }
     }
   }
 

--- a/web/src/features/sites/components/__tests__/site-probe-panel.test.tsx
+++ b/web/src/features/sites/components/__tests__/site-probe-panel.test.tsx
@@ -20,14 +20,12 @@ import type { SiteProbeResult } from '@/lib/api/sites'
 
 import { SiteProbePanel } from '../site-probe-panel'
 
-const { mockStreamSiteProbe, mockProbeSiteNow } = vi.hoisted(() => ({
+const { mockStreamSiteProbe } = vi.hoisted(() => ({
   mockStreamSiteProbe: vi.fn(),
-  mockProbeSiteNow: vi.fn(),
 }))
 
 vi.mock('@/lib/api/sites', () => ({
   sitesApi: {
-    probeSiteNow: mockProbeSiteNow,
     streamSiteProbe: mockStreamSiteProbe,
   },
 }))
@@ -49,7 +47,6 @@ let streamPromise: Promise<void> | null = null
 
 beforeEach(() => {
   mockStreamSiteProbe.mockReset()
-  mockProbeSiteNow.mockReset()
   captured = null
   streamPromise = null
   mockStreamSiteProbe.mockImplementation(

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2607,6 +2607,7 @@
       "back": "Back",
       "next": "Next",
       "submit": "Import",
+      "submitFailed": "Import failed",
       "stepper": {
         "progressLabel": "Import progress"
       },

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2607,6 +2607,7 @@
       "back": "上一步",
       "next": "下一步",
       "submit": "导入",
+      "submitFailed": "导入失败",
       "stepper": {
         "progressLabel": "导入进度"
       },

--- a/web/src/lib/api/sites.ts
+++ b/web/src/lib/api/sites.ts
@@ -14,19 +14,6 @@ export type SiteProbeResult = {
   error?: string
 }
 
-/** Synchronous probe-now response (POST /api/sites/{id}/probe-now). */
-export type SiteProbeNowResponse = {
-  success: boolean
-  totalModels: number
-  available: number
-  unavailable: number
-  results: SiteProbeResult[]
-  /** False when the probe pass was aborted (timeout / client disconnect). */
-  complete: boolean
-  truncated?: boolean
-  reason?: string
-}
-
 /** Incremental probe-stream complete payload. */
 export type SiteProbeCompletePayload = {
   totalModels: number
@@ -63,28 +50,6 @@ export const sitesApi = {
       method: 'POST',
       body: JSON.stringify(data),
     }),
-  getSiteDisabledModels: (siteId: number) =>
-    request(`/api/sites/${siteId}/disabled-models`),
-  updateSiteDisabledModels: (siteId: number, models: string[]) =>
-    request(`/api/sites/${siteId}/disabled-models`, {
-      method: 'PUT',
-      body: JSON.stringify({ models }),
-    }),
-  getSiteAvailableModels: (siteId: number) =>
-    request(`/api/sites/${siteId}/available-models`),
-  probeSiteNow: (
-    siteId: number,
-    options?: {
-      scope?: 'single' | 'all'
-      modelName?: string
-      latencyThresholdMs?: number
-    }
-  ) =>
-    request(`/api/sites/${siteId}/probe-now`, {
-      method: 'POST',
-      body: JSON.stringify(options || {}),
-      timeoutMs: options?.scope === 'all' ? 120_000 : 30_000,
-    }) as Promise<SiteProbeNowResponse>,
   /**
    * Live probe pass (GET /api/sites/{id}/probe-stream, SSE). Each run of the
    * stream performs its own probe pass; results arrive incrementally as


### PR DESCRIPTION
## UI/UX 深修波 · Batch 6（收尾）

- **import 静默失败（P2）**：导入向导的空 \catch {}\ 曾吞掉非 axios 失败（如空响应体）；现按 \xios.isAxiosError\ 判别，非传输错误补 \	oast(import.submitFailed)\。
- **死代码（P3）**：\lib/api/sites.ts\ 移除 4 个未用 wrapper（disabled-models ×2、available-models、probe-now）+ 死类型 \SiteProbeNowResponse\ + 测试里未用的 mock。
- MASTER.md：记录 Batch 6，并把剩余可议项改为「已知残差」记录（manual-checkin 二次 toast 风险、USD \$ 货币符号、#siteId 纯函数回退、useEffect 无依赖意图、endpoints-editor 可见标签）。

验证：typecheck / lint（0 error）/ format:check / import+sites+i18n 9 test files 74 tests 全绿。