### PR TITLE
refactor(web): consolidate USD billing formatters + document quota currency

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -58,6 +58,16 @@ Admin JSON requests must contain one JSON value. Duplicate object keys and trail
 
 ---
 
+## Billing & Currency
+
+All money fields are denominated in **US dollars (USD)** — `balance`, `quota`, `balanceUsed`, `todayIncome`, `todayQuotaConsumption`, `unitCost`, `estimatedCost`, and the per-million pricing rates. There is no RMB path or multi-tenant wallet; the admin console renders `$` as a fixed currency symbol (not translatable interface copy).
+
+Upstream balance semantics: NewAPI/OneAPI-family platforms expose integer `quota` where **1 USD = 500000 quota**; the `veloera` adapter uses **1 USD = 1000000 quota**. Platform adapters normalize to USD at the boundary (`quota / divisor`), so the API and frontend never carry raw upstream quota.
+
+Pricing is ratio-based: `modelRatio` / `completionRatio` / `groupRatio` are multipliers over a base rate. At ratio 1, input costs **$2 per 1M tokens** (the NewAPI `0.002`/1K convention); output uses `modelRatio × completionRatio`, and prompt-cache tiers use `cacheRatio` / `cacheCreationRatio` (Claude defaults 0.10 / 1.25). Per-million rates and `estimatedCost` are estimates, never account-priced; `unitCost` is a display/planning field.
+
+---
+
 ## Stats & Dashboard
 
 ### GET /api/stats/dashboard

--- a/docs/internal/log.md
+++ b/docs/internal/log.md
@@ -5,6 +5,12 @@
 > Product milestone timeline (grouped by version). Not the current-state source of truth.
 > Current state → [`STATE.md`](STATE.md) · open items → [`progress/MASTER.md`](progress/MASTER.md) · detailed version narrative → root [`CHANGELOG.md`](../../CHANGELOG.md)
 
+## 2026-08-24 — 计费货币整理（USD 收口）
+
+- 明确计费货币：全链路 USD（`balance`/`quota`/`used`/`todayIncome`/`unitCost`/`estimatedCost`/每百万价），无 RMB / 多租户钱包路径。上游 NewAPI/OneAPI 族 `quota` 为整数额度（1 USD = 500000 quota；veloera 1 USD = 1000000 quota），platform 适配器在边界 `quota/divisor` 归一为 USD，前端永不接触原始 quota。
+- 前端收口：`lib/format` 新增单一 `USD_SYMBOL`，`formatCurrency`（金额，千分位 + 固定小数位）与 `formatPrice`（每百万价，自适应或显式小数位）收敛全部货币渲染；删除重复/分散的 `formatUsd`、accounts `formatAmount`、token-routes `formatRoutePrice`、price-compare 本地 `formatPerMillion`/`formatSampleCost`、charts `$` 拼接。
+- docs/api.md 新增 “Billing & Currency” 约定节，MASTER 已知残差 `$` 项改记为已收口。前端 typecheck/lint/format 全绿，vitest 171 文件 1131 用例通过。
+
 ## 2026-08-24 — Wave 9 发布 v0.16.9
 
 - PR #972（Wave 9，mobile audit + entry-chunk split + contrast zero-exemption）squash 合入 master（9d864bf）。

--- a/docs/internal/progress/MASTER.md
+++ b/docs/internal/progress/MASTER.md
@@ -63,7 +63,7 @@
 
 **已知残差（记录，不作为待办）**
 - manual-checkin `catch {}`：用户可见失败均由 http-client 或结果分支覆盖，仅后端 schema 漂移的编程错误会静默；naive 补 toast 会对 `success:false` 二次提示。
-- `$` 前缀：定价固定 USD，`$` 为货币符号非界面文案，不属于 i18n 目录。
+- `$` 前缀：已收口 — `lib/format` 单一 `USD_SYMBOL`，`formatCurrency`/`formatPrice` 统一金额与每百万价，删除 `formatUsd`/`formatAmount`/`formatRoutePrice` 及本地 `$` 拼接；定价固定 USD（见 log 2026-08-24）。
 - `#siteId` 回退：位于纯函数 `resolvePriceDetail`，需透传 `t` 才可本地化，低频残留。
 - test-response-viewer useEffect 无依赖：对话区每次渲染滚到底为流式跟随意图，非缺陷。
 - endpoints-editor URL：已有 `aria-label`，仅 WCAG 3.3.2 可见标签待补。

--- a/web/src/features/accounts/components/account-detail-sheet.tsx
+++ b/web/src/features/accounts/components/account-detail-sheet.tsx
@@ -27,9 +27,9 @@ import { toBcp47 } from '@/i18n/languages'
 import {
   EM_DASH,
   formatAbsoluteDateTime,
+  formatCurrency,
   formatPrice,
   formatRelativeTime,
-  formatUsd,
 } from '@/lib/format'
 
 import { useRefreshAccount } from '../api'
@@ -153,16 +153,18 @@ export function AccountDetailSheet({
               {site?.platform || '—'}
             </DetailField>
             <DetailField label={t('accounts.detail.balance')}>
-              {formatAmount(account.balance)}
+              {formatCurrency(account.balance)}
             </DetailField>
             <DetailField label={t('accounts.detail.used')}>
-              {formatAmount(account.balanceUsed)}
+              {formatCurrency(account.balanceUsed)}
             </DetailField>
             <DetailField label={t('accounts.detail.todayReward')}>
-              {formatAmount(account.todayReward, '+$')}
+              {account.todayReward === null || account.todayReward === undefined
+                ? EM_DASH
+                : `+${formatCurrency(account.todayReward)}`}
             </DetailField>
             <DetailField label={t('accounts.detail.todaySpend')}>
-              {formatAmount(account.todaySpend)}
+              {formatCurrency(account.todaySpend)}
             </DetailField>
             <DetailField label={t('accounts.detail.checkin')}>
               {account.capabilities?.canCheckin
@@ -179,7 +181,9 @@ export function AccountDetailSheet({
             </DetailField>
             <DetailField label={t('accounts.detail.quota')}>
               {(account.quota ?? 0) > 0 ? (
-                <span className='tabular-nums'>{formatUsd(account.quota)}</span>
+                <span className='tabular-nums'>
+                  {formatCurrency(account.quota)}
+                </span>
               ) : (
                 '—'
               )}
@@ -279,16 +283,4 @@ export function AccountDetailSheet({
       </SheetContent>
     </Sheet>
   )
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-// A null amount means "never refreshed", not zero — rendering $0.00 would
-// misreport a missing value. Show a bare em dash (no currency prefix),
-// matching lib/format's null-display convention.
-function formatAmount(value: number | undefined | null, prefix = '$'): string {
-  if (value === undefined || value === null) return EM_DASH
-  return `${prefix}${value.toFixed(2)}`
 }

--- a/web/src/features/dashboard/components/charts-currency.ts
+++ b/web/src/features/dashboard/components/charts-currency.ts
@@ -1,4 +1,4 @@
-import { EM_DASH } from '@/lib/format'
+import { EM_DASH, USD_SYMBOL } from '@/lib/format'
 
 /**
  * Adaptive currency formatting for chart axes/tooltips. One precision per
@@ -10,6 +10,6 @@ import { EM_DASH } from '@/lib/format'
 export function formatChartCurrency(value: number): string {
   if (!Number.isFinite(value)) return EM_DASH
   const magnitude = Math.abs(value)
-  if (magnitude >= 1000) return `$${value.toFixed(2)}`
-  return `$${value.toFixed(3)}`
+  if (magnitude >= 1000) return `${USD_SYMBOL}${value.toFixed(2)}`
+  return `${USD_SYMBOL}${value.toFixed(3)}`
 }

--- a/web/src/features/models/price-compare/components/price-compare-page.tsx
+++ b/web/src/features/models/price-compare/components/price-compare-page.tsx
@@ -28,18 +28,11 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { formatCurrency, formatPrice } from '@/lib/format'
 
 import { usePriceCompare } from '../api'
 import type { PriceCompareItem } from '../types'
 import { PriceGradeBadge } from './price-grade-badge'
-
-function formatPerMillion(value: number): string {
-  return '$' + value.toFixed(4)
-}
-
-function formatSampleCost(value: number): string {
-  return '$' + value.toFixed(6)
-}
 
 type ModelGroup = {
   key: string
@@ -210,10 +203,10 @@ export function PriceRow({ row }: { row: PriceCompareItem }) {
         <PriceGradeBadge grade={row.source} />
       </TableCell>
       <TableCell className='text-right tabular-nums'>
-        {formatPerMillion(row.inputPerMillion)}
+        {formatPrice(row.inputPerMillion, { fractionDigits: 4 })}
       </TableCell>
       <TableCell className='hidden text-right tabular-nums sm:table-cell'>
-        {formatPerMillion(row.outputPerMillion)}
+        {formatPrice(row.outputPerMillion, { fractionDigits: 4 })}
       </TableCell>
       <TableCell
         className='hidden text-right tabular-nums sm:table-cell'
@@ -223,7 +216,9 @@ export function PriceRow({ row }: { row: PriceCompareItem }) {
             : t('priceCompare.effectiveCostPrecision')
         }
       >
-        {row.missingPrice ? '—' : formatSampleCost(row.estimatedCostSample)}
+        {row.missingPrice
+          ? '—'
+          : formatCurrency(row.estimatedCostSample, { fractionDigits: 6 })}
       </TableCell>
       <TableCell>
         <PriceRowStatus row={row} />

--- a/web/src/features/sites/components/site-detail-sheet.tsx
+++ b/web/src/features/sites/components/site-detail-sheet.tsx
@@ -27,8 +27,8 @@ import {
 import { toBcp47 } from '@/i18n/languages'
 import {
   formatAbsoluteDateTime,
+  formatCurrency,
   formatRelativeTime,
-  formatUsd,
 } from '@/lib/format'
 
 import { resolveSiteBalanceUsd } from '../lib/site-balance'
@@ -276,7 +276,7 @@ function SiteBalanceSection({ site, locale }: { site: Site; locale: string }) {
         <dl className='mt-2 grid grid-cols-2 gap-x-3 gap-y-2 text-sm'>
           {balanceUsd !== null && (
             <DetailField label={t('sites.detail.balance')}>
-              <span className='tabular-nums'>{formatUsd(balanceUsd)}</span>
+              <span className='tabular-nums'>{formatCurrency(balanceUsd)}</span>
             </DetailField>
           )}
           {planNames.length > 0 && (
@@ -293,9 +293,9 @@ function SiteBalanceSection({ site, locale }: { site: Site; locale: string }) {
           {typeof summary?.totalUsedUsd === 'number' && (
             <DetailField label={t('sites.detail.monthlyUsage')}>
               <span className='tabular-nums'>
-                {formatUsd(summary.totalUsedUsd)}
+                {formatCurrency(summary.totalUsedUsd)}
                 {typeof summary.totalMonthlyLimitUsd === 'number'
-                  ? ` / ${formatUsd(summary.totalMonthlyLimitUsd)}`
+                  ? ` / ${formatCurrency(summary.totalMonthlyLimitUsd)}`
                   : ''}
               </span>
             </DetailField>
@@ -303,7 +303,7 @@ function SiteBalanceSection({ site, locale }: { site: Site; locale: string }) {
           {showRemainingRow && (
             <DetailField label={t('sites.detail.remaining')}>
               <span className='tabular-nums'>
-                {formatUsd(summary?.totalRemainingUsd)}
+                {formatCurrency(summary?.totalRemainingUsd)}
               </span>
             </DetailField>
           )}

--- a/web/src/features/sites/components/sites-columns.tsx
+++ b/web/src/features/sites/components/sites-columns.tsx
@@ -33,8 +33,8 @@ import {
 import { Spinner } from '@/components/ui/spinner'
 import {
   formatAbsoluteDateTime,
+  formatCurrency,
   formatRelativeTime,
-  formatUsd,
 } from '@/lib/format'
 import { cn } from '@/lib/utils'
 
@@ -250,7 +250,7 @@ export function useSitesColumns(
       ),
       cell: ({ row }) => (
         <span className='text-sm tabular-nums'>
-          {formatUsd(resolveSiteBalanceUsd(row.original))}
+          {formatCurrency(resolveSiteBalanceUsd(row.original))}
         </span>
       ),
     },

--- a/web/src/features/token-routes/__tests__/route-price-truth.test.ts
+++ b/web/src/features/token-routes/__tests__/route-price-truth.test.ts
@@ -12,7 +12,6 @@ import type { PriceCompareItem } from '@/features/models/price-compare/types'
 
 import {
   calculateRouteChannelAllocations,
-  formatRoutePrice,
   formatRouteWeightShare,
   resolveConcreteModelForChannel,
   resolveDistinctConcreteModels,
@@ -211,11 +210,6 @@ describe('resolveRouteChannelPriceTruth', () => {
 })
 
 describe('format helpers', () => {
-  it('formats price to four decimals or an em dash for null', () => {
-    expect(formatRoutePrice(2.5)).toBe('2.5000')
-    expect(formatRoutePrice(null)).toBe('—')
-  })
-
   it('formats weight share as a percentage or an em dash for null', () => {
     expect(formatRouteWeightShare(0.25)).toBe('25.0%')
     expect(formatRouteWeightShare(null)).toBe('—')

--- a/web/src/features/token-routes/components/route-detail-sheet.tsx
+++ b/web/src/features/token-routes/components/route-detail-sheet.tsx
@@ -24,7 +24,7 @@ import { priceCompareQueryOptions } from '@/features/models/price-compare/api'
 import { PriceGradeBadge } from '@/features/models/price-compare/components/price-grade-badge'
 import type { PriceCompareItem } from '@/features/models/price-compare/types'
 import { toBcp47 } from '@/i18n/languages'
-import { formatDateTime, formatInt } from '@/lib/format'
+import { formatDateTime, formatInt, formatPrice } from '@/lib/format'
 
 import {
   useClearRouteCooldown,
@@ -33,7 +33,6 @@ import {
 } from '../api'
 import {
   calculateRouteChannelAllocations,
-  formatRoutePrice,
   formatRouteWeightShare,
   normalizeModelKey,
   resolveDistinctConcreteModels,
@@ -471,7 +470,7 @@ function ChannelMetric({
 function PriceValue({ value }: { value: number | null }) {
   return (
     <span className='tabular-nums'>
-      {value === null ? '—' : `$${formatRoutePrice(value)}`}
+      {formatPrice(value, { fractionDigits: 4 })}
     </span>
   )
 }

--- a/web/src/features/token-routes/lib/route-price-truth.ts
+++ b/web/src/features/token-routes/lib/route-price-truth.ts
@@ -174,11 +174,6 @@ export function resolveRouteChannelPriceTruth(
   }
 }
 
-export function formatRoutePrice(value: number | null): string {
-  if (value === null || !Number.isFinite(value)) return EM_DASH
-  return value.toFixed(4)
-}
-
 export function formatRouteWeightShare(value: number | null): string {
   if (value === null || !Number.isFinite(value)) return EM_DASH
   return `${(value * 100).toFixed(1)}%`

--- a/web/src/lib/__tests__/format.test.ts
+++ b/web/src/lib/__tests__/format.test.ts
@@ -16,7 +16,6 @@ import {
   formatShortDate,
   formatSuccessRate,
   formatTimeOfDay,
-  formatUsd,
 } from '../format'
 
 // Renders the epoch with the same Intl options a formatter under test uses,
@@ -72,6 +71,12 @@ describe('formatPrice', () => {
     expect(formatPrice(0)).toBe('$0')
     expect(formatPrice(0.005)).toBe('$0.0050')
     expect(formatPrice(2.5)).toBe('$2.50')
+  })
+
+  it('supports a fixed decimal count for cross-site price comparison', () => {
+    expect(formatPrice(2.5, { fractionDigits: 4 })).toBe('$2.5000')
+    expect(formatPrice(0.5123, { fractionDigits: 4 })).toBe('$0.5123')
+    expect(formatPrice(1234.5, { fractionDigits: 4 })).toBe('$1,234.5000')
   })
 
   it('renders null / undefined / NaN as an em dash', () => {
@@ -208,24 +213,5 @@ describe('formatRelativeTime', () => {
   it('returns an empty string for missing input', () => {
     expect(formatRelativeTime(null, 'en-US')).toBe('')
     expect(formatRelativeTime('', 'en-US')).toBe('')
-  })
-})
-
-describe('formatUsd', () => {
-  it('formats whole and fractional dollar amounts with two decimals', () => {
-    expect(formatUsd(1234.5)).toBe('$1234.50')
-    expect(formatUsd(0.05)).toBe('$0.05')
-    expect(formatUsd(100)).toBe('$100.00')
-  })
-
-  it('keeps a real zero balance honest instead of hiding it', () => {
-    expect(formatUsd(0)).toBe('$0.00')
-  })
-
-  it('renders an em dash for null, undefined, and non-finite input', () => {
-    expect(formatUsd(null)).toBe('—')
-    expect(formatUsd(undefined)).toBe('—')
-    expect(formatUsd(Number.NaN)).toBe('—')
-    expect(formatUsd(Number.POSITIVE_INFINITY)).toBe('—')
   })
 })

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -16,9 +16,20 @@ export function formatInt(value: number | null | undefined): string {
 }
 
 /**
- * Format a USD amount (balance / cost / spend): "$" + locale grouping +
- * fixed fraction digits (default 2). Returns "—" for null/undefined/NaN so
- * missing money is never rendered as $0.
+ * Currency convention: every money field the backend returns — balance,
+ * quota, used, todayIncome, unitCost, estimatedCost, and the per-million
+ * pricing rates — is denominated in US dollars (USD). NewAPI/OneAPI-family
+ * upstreams expose integer `quota` (1 USD = 500000 quota; Veloera uses
+ * 1 USD = 1000000 quota); the platform adapters normalize to USD at the
+ * boundary, so the frontend never renders raw quota or RMB. `$` is a
+ * currency symbol, not translatable interface copy (see docs/api.md).
+ */
+export const USD_SYMBOL = '$'
+
+/**
+ * Format a USD amount (balance / cost / spend / quota): "$" + locale
+ * grouping + fixed fraction digits (default 2). Returns "—" for
+ * null/undefined/NaN so missing money is never rendered as $0.
  */
 export function formatCurrency(
   value: number | null | undefined,
@@ -32,7 +43,7 @@ export function formatCurrency(
   }
   const fractionDigits = options?.fractionDigits ?? 2
   const sign = value < 0 ? '-' : ''
-  return `${sign}$${Math.abs(value).toLocaleString(undefined, {
+  return `${sign}${USD_SYMBOL}${Math.abs(value).toLocaleString(undefined, {
     minimumFractionDigits: fractionDigits,
     maximumFractionDigits: fractionDigits,
   })}`
@@ -59,25 +70,33 @@ export function formatRatio(
   return formatPercent(numerator / denominator, fractionDigits)
 }
 
-/** Format a US dollar amount: 1234.5 -> "$1234.50"; "—" for null/NaN. */
-export function formatUsd(value: number | null | undefined): string {
-  if (value === null || value === undefined || !Number.isFinite(value)) {
-    return EM_DASH
-  }
-  return '$' + value.toFixed(2)
-}
-
 /**
- * Format a per-million USD price with adaptive precision, currency symbol
- * included so zero prices align with their non-zero neighbours.
+ * Format a per-million USD price/rate. Adaptive precision by default so zero
+ * and sub-cent rates stay readable ($0, $0.0050, $2.50); pass `fractionDigits`
+ * for a fixed decimal count (price-compare / route pricing keep 4 decimals to
+ * preserve tiny cross-site differences).
  */
-export function formatPrice(price: number | null | undefined): string {
+export function formatPrice(
+  price: number | null | undefined,
+  options?: {
+    /** Fixed fraction digits; when omitted, adaptive (4 for <0.01 else 2). */
+    fractionDigits?: number
+  }
+): string {
   if (price === null || price === undefined || !Number.isFinite(price)) {
     return EM_DASH
   }
-  if (price === 0) return '$0'
-  if (price < 0.01) return `$${price.toFixed(4)}`
-  return `$${price.toFixed(2)}`
+  const digits = options?.fractionDigits
+  if (digits !== undefined) {
+    const sign = price < 0 ? '-' : ''
+    return `${sign}${USD_SYMBOL}${Math.abs(price).toLocaleString(undefined, {
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    })}`
+  }
+  if (price === 0) return `${USD_SYMBOL}0`
+  if (price < 0.01) return `${USD_SYMBOL}${price.toFixed(4)}`
+  return `${USD_SYMBOL}${price.toFixed(2)}`
 }
 
 /** Format latency in milliseconds. */


### PR DESCRIPTION
## What

收口计费/货币语义：明确 **全链路 USD，无 RMB**，并把前端散落的 `$` 硬编码收敛为 `lib/format` 单一来源。

## Decision

- Billing currency is **USD**. NewAPI/OneAPI-family upstream `quota` is an integer quota — **1 USD = 500000 quota** (Veloera: 1 USD = 1000000). Platform adapters normalize at the boundary (`quota/divisor`), so the API/frontend never carry raw quota or RMB.
- `$` is a fixed currency symbol, **not** translatable interface copy (aligns with existing `MASTER.md` stance).

## Changes

- `web/src/lib/format.ts`: single `USD_SYMBOL`; drop redundant `formatUsd` (merged into `formatCurrency`); add `formatPrice` `fractionDigits` option for fixed-decimal per-million rates.
- Remove per-feature `$` hardcoding:
  - accounts `formatAmount` helper (incl. `+$` reward prefix)
  - price-compare local `formatPerMillion` / `formatSampleCost`
  - token-routes `formatRoutePrice` + `PriceValue` `$` prefix
  - dashboard `charts-currency.ts` `$` literals
- `docs/api.md`: new **Billing & Currency** convention section (quota divisor, ratio-based pricing, no RMB).
- `docs/internal/`: MASTER residual `$` item → resolved; log.md closeout entry.

## Verification

- `bun run typecheck` / `lint` (0 error) / `format:check` / vitest **171 files, 1131 tests** pass.
- `go build ./cmd/server` + `go vet ./...` + `go test ./docs` pass. (Full `go test -race` on Windows hits the known TSan allocation env failure; Linux CI is authoritative.)