### PR TITLE
fix(web): truthful product-announcement links, load errors, and dismiss feedback

### DIFF
--- a/web/src/features/dashboard/__tests__/announcement-banner.test.tsx
+++ b/web/src/features/dashboard/__tests__/announcement-banner.test.tsx
@@ -20,6 +20,8 @@ import {
 
 import '@/i18n/config'
 import { api } from '@/lib/api'
+import { productAnnouncementKeys } from '@/lib/product-announcements'
+import { toast } from '@/lib/toast'
 
 import { AnnouncementBanner } from '../components/announcement-banner'
 
@@ -30,8 +32,15 @@ vi.mock('@/lib/api', () => ({
   },
 }))
 
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}))
+
 const mockGetActive = vi.mocked(api.getActiveAnnouncements)
 const mockDismiss = vi.mocked(api.dismissAnnouncement)
+const mockToastError = vi.mocked(toast.error)
 
 const active = {
   id: 1,
@@ -84,6 +93,7 @@ function renderWithClient(ui: ReactNode) {
 beforeEach(() => {
   mockGetActive.mockReset()
   mockDismiss.mockReset()
+  mockToastError.mockReset()
 })
 
 afterEach(() => cleanup())
@@ -101,6 +111,37 @@ describe('AnnouncementBanner', () => {
     })
     expect(screen.getByText('Downtime expected tonight.')).toBeInTheDocument()
     expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('renders only safe absolute http/https announcement links', async () => {
+    mockGetActive.mockResolvedValue({
+      items: [{ ...active, link: '  https://docs.example.com/status  ' }],
+    })
+
+    renderWithClient(<AnnouncementBanner />)
+
+    const link = await screen.findByRole('link', { name: 'learn more' })
+    expect(link).toHaveAttribute('href', 'https://docs.example.com/status')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it.each([
+    'javascript:alert(1)',
+    'data:text/html,boom',
+    'file:///tmp/notice',
+    'ftp://example.com/notice',
+    '//example.com/notice',
+    '/relative/notice',
+    'relative/notice',
+    'not a url',
+  ])('does not render an anchor for unsafe link %s', async (link) => {
+    mockGetActive.mockResolvedValue({ items: [{ ...active, link }] })
+
+    renderWithClient(<AnnouncementBanner />)
+
+    await screen.findByText('Scheduled maintenance')
+    expect(screen.queryByRole('link', { name: 'learn more' })).toBeNull()
   })
 
   it('renders null when there are no active announcements', async () => {
@@ -160,7 +201,9 @@ describe('AnnouncementBanner', () => {
       expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     })
     // The cached list is patched in place so a remount stays dismissed.
-    expect(queryClient.getQueryData(['dashboard-announcements'])).toEqual([])
+    expect(queryClient.getQueryData(productAnnouncementKeys.active())).toEqual(
+      []
+    )
   })
 
   it('keeps the banner visible when dismissal fails', async () => {
@@ -179,8 +222,14 @@ describe('AnnouncementBanner', () => {
 
     await waitFor(() => {
       expect(mockDismiss).toHaveBeenCalledWith(1)
+      expect(mockToastError).toHaveBeenCalledWith(
+        'Failed to dismiss announcement. Try again.'
+      )
     })
     expect(screen.getByRole('alert')).toBeInTheDocument()
     expect(screen.getByText('Scheduled maintenance')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Dismiss announcement' })
+    ).toBeEnabled()
   })
 })

--- a/web/src/features/dashboard/components/announcement-banner.tsx
+++ b/web/src/features/dashboard/components/announcement-banner.tsx
@@ -4,8 +4,8 @@
 // while loading or when there are no active announcements (non-critical,
 // silent failure on error — the banner never blocks the dashboard).
 // Dismissal persists server-side via POST /api/announcements/{id}/dismiss;
-// a failed dismiss keeps the banner visible (silent degrade) instead of
-// pretending the announcement was dismissed.
+// a failed dismiss keeps the banner visible and surfaces localized feedback
+// instead of pretending the announcement was dismissed.
 //
 // Data flows through TanStack Query (like every other dashboard widget) so
 // section switches reuse the cached banner instead of refetching on every
@@ -17,9 +17,12 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { api, type Announcement } from '@/lib/api'
+import {
+  getSafeProductAnnouncementUrl,
+  productAnnouncementKeys,
+} from '@/lib/product-announcements'
+import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
-
-const ANNOUNCEMENTS_QUERY_KEY = ['dashboard-announcements'] as const
 
 const SEVERITY_TONE: Record<
   Announcement['severity'],
@@ -45,7 +48,7 @@ export function AnnouncementBanner() {
   const [dismissing, setDismissing] = useState<number | null>(null)
 
   const { data: items = [], isLoading } = useQuery({
-    queryKey: ANNOUNCEMENTS_QUERY_KEY,
+    queryKey: productAnnouncementKeys.active(),
     queryFn: async () => {
       const response = await api.getActiveAnnouncements()
       return (response.items ?? []).filter((item) => !item.dismissed)
@@ -62,10 +65,11 @@ export function AnnouncementBanner() {
     try {
       await api.dismissAnnouncement(id)
       queryClient.setQueryData<Announcement[]>(
-        ANNOUNCEMENTS_QUERY_KEY,
+        productAnnouncementKeys.active(),
         (current) => (current ?? []).filter((item) => item.id !== id)
       )
     } catch {
+      toast.error(t('dashboard.announcement.dismissFailed'))
       // Dismissal did not persist — keep the banner visible.
     } finally {
       setDismissing(null)
@@ -77,6 +81,7 @@ export function AnnouncementBanner() {
       {items.map((item) => {
         const tone = SEVERITY_TONE[item.severity] ?? SEVERITY_TONE.info
         const Icon = tone.icon
+        const safeLink = getSafeProductAnnouncementUrl(item.link)
         return (
           <div
             key={item.id}
@@ -95,9 +100,9 @@ export function AnnouncementBanner() {
                 </p>
               ) : null}
             </div>
-            {item.link ? (
+            {safeLink ? (
               <a
-                href={item.link}
+                href={safeLink}
                 target='_blank'
                 rel='noopener noreferrer'
                 className='text-xs underline underline-offset-2'

--- a/web/src/features/settings/sections/content/components/__tests__/announcements-section.test.tsx
+++ b/web/src/features/settings/sections/content/components/__tests__/announcements-section.test.tsx
@@ -1,7 +1,5 @@
-// Behavior tests for the announcements form dirty-close guard (#889):
-// closing the create/edit dialog with unsaved changes must route through the
-// shared discard confirmation instead of silently dropping the edits, while a
-// pristine form closes immediately.
+// Focused product-announcement behavior tests: dirty-close safety, query
+// truth, shared cache invalidation, and strict link validation.
 
 import '@testing-library/jest-dom/vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -13,18 +11,29 @@ import {
   waitFor,
 } from '@testing-library/react'
 import type { ReactElement } from 'react'
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 import '@/i18n/config'
+import { api, type Announcement } from '@/lib/api'
+import { productAnnouncementKeys } from '@/lib/product-announcements'
+import { toast } from '@/lib/toast'
 
 import { AnnouncementsSection } from '../announcements-section'
 
 vi.mock('@/lib/api', () => ({
   api: {
-    getAnnouncements: vi.fn().mockResolvedValue({ items: [] }),
-    createAnnouncement: vi.fn().mockResolvedValue({ items: [] }),
-    updateAnnouncement: vi.fn().mockResolvedValue({ success: true }),
-    deleteAnnouncement: vi.fn().mockResolvedValue({ success: true }),
+    getAnnouncements: vi.fn(),
+    createAnnouncement: vi.fn(),
+    updateAnnouncement: vi.fn(),
+    deleteAnnouncement: vi.fn(),
   },
 }))
 
@@ -36,6 +45,23 @@ vi.mock('@/lib/toast', () => ({
     warning: vi.fn(),
   },
 }))
+
+const mockGetAnnouncements = vi.mocked(api.getAnnouncements)
+const mockCreateAnnouncement = vi.mocked(api.createAnnouncement)
+const mockUpdateAnnouncement = vi.mocked(api.updateAnnouncement)
+const mockDeleteAnnouncement = vi.mocked(api.deleteAnnouncement)
+const mockToastSuccess = vi.mocked(toast.success)
+
+const existingAnnouncement: Announcement = {
+  id: 7,
+  title: 'Existing maintenance notice',
+  message: 'Existing message',
+  severity: 'warning',
+  link: 'https://status.example.com/notice',
+  enabled: true,
+  createdAt: '2026-08-20 00:00:00',
+  updatedAt: '2026-08-20 00:00:00',
+}
 
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
@@ -51,6 +77,21 @@ beforeAll(() => {
       dispatchEvent: vi.fn(),
     })),
   })
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn(),
+  })
+})
+
+beforeEach(() => {
+  mockGetAnnouncements.mockReset().mockResolvedValue({ items: [] })
+  mockCreateAnnouncement.mockReset().mockResolvedValue({ items: [] })
+  mockUpdateAnnouncement
+    .mockReset()
+    .mockResolvedValue({ success: true, revision: true })
+  mockDeleteAnnouncement.mockReset().mockResolvedValue({ success: true })
+  vi.mocked(toast.error).mockReset()
+  mockToastSuccess.mockReset()
 })
 
 afterEach(() => cleanup())
@@ -62,13 +103,14 @@ function renderSection() {
       mutations: { retry: false },
     },
   })
-  return render(
+  const rendered = render(
     (
       <QueryClientProvider client={queryClient}>
         <AnnouncementsSection />
       </QueryClientProvider>
     ) as ReactElement
   )
+  return { queryClient, ...rendered }
 }
 
 async function openCreateDialog() {
@@ -76,6 +118,20 @@ async function openCreateDialog() {
     await screen.findByRole('button', { name: 'New announcement' })
   )
   await screen.findByText('Create announcement')
+}
+
+function fillRequiredFields(link?: string) {
+  fireEvent.change(screen.getByLabelText('Title'), {
+    target: { value: 'Maintenance window' },
+  })
+  fireEvent.change(screen.getByLabelText('Message'), {
+    target: { value: 'Downtime expected tonight.' },
+  })
+  if (link !== undefined) {
+    fireEvent.change(screen.getByLabelText('Link'), {
+      target: { value: link },
+    })
+  }
 }
 
 describe('AnnouncementsSection dirty-close guard', () => {
@@ -99,24 +155,160 @@ describe('AnnouncementsSection dirty-close guard', () => {
       target: { value: 'Maintenance window' },
     })
 
-    // Cancel is intercepted by the discard confirmation.
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
     await screen.findByText('Discard unsaved changes?')
 
-    // Keep editing leaves the form open with the typed value intact.
     fireEvent.click(screen.getByRole('button', { name: 'Keep editing' }))
     await waitFor(() => {
       expect(screen.queryByText('Discard unsaved changes?')).toBeNull()
     })
     expect(screen.getByLabelText('Title')).toHaveValue('Maintenance window')
 
-    // Discarding finally closes the dialog.
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
     fireEvent.click(
       await screen.findByRole('button', { name: 'Discard changes' })
     )
     await waitFor(() => {
       expect(screen.queryByText('Create announcement')).toBeNull()
+    })
+  })
+})
+
+describe('AnnouncementsSection query truth', () => {
+  it('shows a retryable load error instead of the empty state', async () => {
+    mockGetAnnouncements
+      .mockReset()
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce({ items: [] })
+
+    renderSection()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Failed to load announcements: network down'
+    )
+    expect(
+      screen.queryByText(
+        'No announcements. Create one to surface a risk banner.'
+      )
+    ).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => {
+      expect(mockGetAnnouncements).toHaveBeenCalledTimes(2)
+    })
+    expect(
+      await screen.findByText(
+        'No announcements. Create one to surface a risk banner.'
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})
+
+describe('AnnouncementsSection link policy', () => {
+  it.each([
+    'javascript:alert(1)',
+    'data:text/html,boom',
+    'file:///tmp/notice',
+    'ftp://example.com/notice',
+    '//example.com/notice',
+    '/relative/notice',
+    'relative/notice',
+    'not a url',
+  ])('rejects unsafe link %s before submit', async (link) => {
+    renderSection()
+    await openCreateDialog()
+    fillRequiredFields(link)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(
+      await screen.findByText('Enter an absolute http:// or https:// URL.')
+    ).toBeInTheDocument()
+    expect(mockCreateAnnouncement).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { label: 'empty', input: '', expected: undefined },
+    {
+      label: 'absolute https',
+      input: '  https://docs.example.com/status  ',
+      expected: 'https://docs.example.com/status',
+    },
+    {
+      label: 'absolute http',
+      input: 'http://status.example.com/notice',
+      expected: 'http://status.example.com/notice',
+    },
+  ])(
+    'accepts $label links and invalidates active announcements',
+    async ({ input, expected }) => {
+      const { queryClient } = renderSection()
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+      await openCreateDialog()
+      fillRequiredFields(input)
+
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+      await waitFor(() => {
+        expect(mockCreateAnnouncement).toHaveBeenCalledWith(
+          expect.objectContaining({ link: expected })
+        )
+      })
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: productAnnouncementKeys.list(),
+      })
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: productAnnouncementKeys.active(),
+      })
+      expect(mockToastSuccess).toHaveBeenCalledWith('Announcement saved.')
+    }
+  )
+})
+
+describe('AnnouncementsSection CRUD cache truth', () => {
+  it('invalidates active announcements after update', async () => {
+    mockGetAnnouncements.mockResolvedValue({ items: [existingAnnouncement] })
+    const { queryClient } = renderSection()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit' }))
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'Updated maintenance notice' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(mockUpdateAnnouncement).toHaveBeenCalledWith(
+        7,
+        expect.objectContaining({ title: 'Updated maintenance notice' })
+      )
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: productAnnouncementKeys.active(),
+    })
+  })
+
+  it('invalidates active announcements after delete', async () => {
+    mockGetAnnouncements.mockResolvedValue({ items: [existingAnnouncement] })
+    const { queryClient } = renderSection()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+    const deleteButtons = await screen.findAllByRole('button', {
+      name: 'Delete',
+    })
+    const confirmDeleteButton = deleteButtons.at(-1)
+    expect(confirmDeleteButton).toBeDefined()
+    if (!confirmDeleteButton) throw new Error('Delete confirmation not found')
+    fireEvent.click(confirmDeleteButton)
+
+    await waitFor(() => {
+      expect(mockDeleteAnnouncement).toHaveBeenCalledWith(7)
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: productAnnouncementKeys.active(),
     })
   })
 })

--- a/web/src/features/settings/sections/content/components/announcements-section.tsx
+++ b/web/src/features/settings/sections/content/components/announcements-section.tsx
@@ -10,6 +10,7 @@ import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { z } from 'zod'
 
+import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import { useDirtyDialogClose } from '@/components/form/dirty-dialog-close'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -50,16 +51,17 @@ import {
 } from '@/components/ui/table'
 import { Textarea } from '@/components/ui/textarea'
 import { api, type Announcement, type AnnouncementsResponse } from '@/lib/api'
+import {
+  getSafeProductAnnouncementUrl,
+  isValidProductAnnouncementLink,
+  productAnnouncementKeys,
+} from '@/lib/product-announcements'
 import { toast } from '@/lib/toast'
 
 import {
   SettingsSectionCard,
   SettingsSectionSkeleton,
 } from '../../../components/settings-section-card'
-
-const announcementsQueryKeys = {
-  all: ['announcements'] as const,
-}
 
 const announcementSchema = z.object({
   title: z
@@ -69,7 +71,13 @@ const announcementSchema = z.object({
     .string()
     .min(1, 'settings.content.announcements.schema.messageRequired'),
   severity: z.enum(['info', 'warning', 'critical']),
-  link: z.string().optional(),
+  link: z
+    .string()
+    .refine(
+      isValidProductAnnouncementLink,
+      'settings.content.announcements.schema.linkInvalid'
+    )
+    .optional(),
   enabled: z.boolean().optional(),
 })
 
@@ -89,7 +97,7 @@ export function AnnouncementsSection() {
   const [deleteTarget, setDeleteTarget] = useState<Announcement | null>(null)
 
   const announcementsQuery = useQuery<AnnouncementsResponse>({
-    queryKey: announcementsQueryKeys.all,
+    queryKey: productAnnouncementKeys.list(),
     queryFn: async () => api.getAnnouncements(),
     staleTime: 30 * 1000,
   })
@@ -126,6 +134,16 @@ export function AnnouncementsSection() {
     }
   }, [editMode, form])
 
+  const invalidateAnnouncementQueries = () =>
+    Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: productAnnouncementKeys.list(),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: productAnnouncementKeys.active(),
+      }),
+    ])
+
   const upsertMutation = useMutation({
     mutationFn: async ({
       mode,
@@ -134,12 +152,13 @@ export function AnnouncementsSection() {
       mode: 'create' | 'edit'
       values: AnnouncementFormValues
     }) => {
+      const link = getSafeProductAnnouncementUrl(values.link) ?? undefined
       if (mode === 'create') {
         return api.createAnnouncement({
           title: values.title,
           message: values.message,
           severity: values.severity,
-          link: values.link || undefined,
+          link,
           enabled: Boolean(values.enabled),
         })
       }
@@ -152,14 +171,12 @@ export function AnnouncementsSection() {
         title: values.title,
         message: values.message,
         severity: values.severity,
-        link: values.link || undefined,
+        link,
         enabled: Boolean(values.enabled),
       })
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: announcementsQueryKeys.all,
-      })
+      void invalidateAnnouncementQueries()
       toast.success(t('settings.content.announcements.toast.saved'))
       setEditMode(null)
     },
@@ -170,9 +187,7 @@ export function AnnouncementsSection() {
   const deleteMutation = useMutation({
     mutationFn: async (id: number) => api.deleteAnnouncement(id),
     onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: announcementsQueryKeys.all,
-      })
+      void invalidateAnnouncementQueries()
       toast.success(t('settings.content.announcements.toast.deleted'))
       setDeleteTarget(null)
     },
@@ -201,6 +216,7 @@ export function AnnouncementsSection() {
 
   const items = announcementsQuery.data?.items ?? []
   const isLoading = announcementsQuery.isLoading
+  const loadError = announcementsQuery.error as Error | null
 
   return (
     <SettingsSectionCard
@@ -213,7 +229,13 @@ export function AnnouncementsSection() {
       }
     >
       {isLoading ? <SettingsSectionSkeleton /> : null}
-      {!isLoading && items.length === 0 ? (
+      <QueryErrorBanner
+        error={loadError}
+        messageKey='settings.content.announcements.loadError'
+        onRetry={() => void announcementsQuery.refetch()}
+        isRetrying={announcementsQuery.isFetching}
+      />
+      {!isLoading && !loadError && items.length === 0 ? (
         <p className='text-muted-foreground py-8 text-center text-sm'>
           {t('settings.content.announcements.empty')}
         </p>

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -894,7 +894,8 @@
       },
       "announcement": {
         "learnMore": "learn more",
-        "dismiss": "Dismiss announcement"
+        "dismiss": "Dismiss announcement",
+        "dismissFailed": "Failed to dismiss announcement. Try again."
       },
       "statCard": {
         "trendLabel": "Trend"
@@ -1428,6 +1429,7 @@
           "deleteTitle": "Delete announcement",
           "deleteDescription": "Delete \"{{title}}\"? This action cannot be undone.",
           "empty": "No announcements. Create one to surface a risk banner.",
+          "loadError": "Failed to load announcements: {{message}}",
           "columns": {
             "severity": "Severity",
             "title": "Title",
@@ -1449,7 +1451,8 @@
           },
           "schema": {
             "titleRequired": "Title is required.",
-            "messageRequired": "Message is required."
+            "messageRequired": "Message is required.",
+            "linkInvalid": "Enter an absolute http:// or https:// URL."
           },
           "toast": {
             "saved": "Announcement saved.",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -894,7 +894,8 @@
       },
       "announcement": {
         "learnMore": "了解更多",
-        "dismiss": "关闭公告"
+        "dismiss": "关闭公告",
+        "dismissFailed": "关闭公告失败，请重试。"
       },
       "statCard": {
         "trendLabel": "趋势"
@@ -1428,6 +1429,7 @@
           "deleteTitle": "删除公告",
           "deleteDescription": "删除「{{title}}」？此操作不可撤销。",
           "empty": "暂无公告。创建一条以展示风险横幅。",
+          "loadError": "加载公告失败：{{message}}",
           "columns": {
             "severity": "严重程度",
             "title": "标题",
@@ -1449,7 +1451,8 @@
           },
           "schema": {
             "titleRequired": "请输入标题。",
-            "messageRequired": "请输入内容。"
+            "messageRequired": "请输入内容。",
+            "linkInvalid": "请输入以 http:// 或 https:// 开头的绝对 URL。"
           },
           "toast": {
             "saved": "公告已保存。",

--- a/web/src/lib/api/__tests__/write-ops-skip-error-handler.test.ts
+++ b/web/src/lib/api/__tests__/write-ops-skip-error-handler.test.ts
@@ -73,6 +73,9 @@ describe('caller-toasted write ops skip the global error toast', () => {
 
     await statsApi.deleteAnnouncement(1)
     expect(lastRequestConfig()).toMatchObject({ skipErrorHandler: true })
+
+    await statsApi.dismissAnnouncement(1)
+    expect(lastRequestConfig()).toMatchObject({ skipErrorHandler: true })
   })
 
   it('model redirects generate / apply / promote / delete', async () => {

--- a/web/src/lib/api/stats.ts
+++ b/web/src/lib/api/stats.ts
@@ -200,6 +200,8 @@ export const statsApi = {
     request(`/api/announcements/${id}/dismiss`, {
       method: 'POST',
       body: '{}',
+      // The dashboard banner surfaces its own localized dismissFailed toast.
+      skipErrorHandler: true,
     }) as Promise<{ success: boolean }>,
   // K1a: model name redirects.
   getModelRedirects: (params?: { accountId?: number; source?: string }) =>

--- a/web/src/lib/product-announcements.ts
+++ b/web/src/lib/product-announcements.ts
@@ -1,0 +1,35 @@
+// Shared query keys and URL safety for product risk-banner announcements.
+// Both the Settings CRUD surface and the Dashboard renderer must use these
+// helpers so cache invalidation and link policy cannot drift apart.
+
+export const productAnnouncementKeys = {
+  all: ['product-announcements'] as const,
+  list: () => [...productAnnouncementKeys.all, 'list'] as const,
+  active: () => [...productAnnouncementKeys.all, 'active'] as const,
+}
+
+const ABSOLUTE_HTTP_URL = /^https?:\/\//i
+
+export function getSafeProductAnnouncementUrl(
+  value: string | null | undefined
+): string | null {
+  const candidate = value?.trim()
+  if (!candidate || !ABSOLUTE_HTTP_URL.test(candidate)) return null
+
+  try {
+    const url = new URL(candidate)
+    if (
+      (url.protocol !== 'http:' && url.protocol !== 'https:') ||
+      !url.hostname
+    ) {
+      return null
+    }
+    return candidate
+  } catch {
+    return null
+  }
+}
+
+export function isValidProductAnnouncementLink(value: string): boolean {
+  return !value.trim() || getSafeProductAnnouncementUrl(value) !== null
+}


### PR DESCRIPTION
Frontend truth fixes for the operator risk-banner domain (\/api/announcements\):

- **Link safety**: shared \getSafeProductAnnouncementUrl\ — only absolute http(s) links survive; \javascript:\/\data:\/relative/invalid values are rejected in the Settings form and never rendered as anchors in the Dashboard banner.
- **Shared query keys**: \productAnnouncementKeys\ used by Settings CRUD and Dashboard banner; CRUD invalidates the active list.
- **Honest load failure**: Settings announcements section shows error banner + retry instead of a misleading empty state.
- **Dismiss feedback**: failed dismiss shows a localized toast and keeps the banner visible (skipErrorHandler prevents double toasts).

Focused vitest coverage added for all four behaviors; full web gate green (1156 tests, typecheck, lint, format, knip).