### PR TITLE
fix(accounts): honor form proxy/user ID and restore pagination

### DIFF
--- a/docs/internal/STATE.md
+++ b/docs/internal/STATE.md
@@ -1,6 +1,6 @@
 # STATE.md — Metapi Go product status
 
-**Last verified**: 2026-08-25
+**Last verified**: 2026-08-27
 
 > **Current state** (product repository). Only current facts and pointers, no narrative.
 > Deployment facts live in the deployment guide; open items → [`progress/MASTER.md`](progress/MASTER.md) · timeline → [`log.md`](log.md) · version narrative → root [`CHANGELOG.md`](../../CHANGELOG.md)
@@ -14,7 +14,7 @@
 | Release pipeline   | Single pipeline (`.github/workflows/main.yml`): PR / master push / SemVer tag all run the same 12-check suite; master push pushes the **linux/amd64 + linux/arm64** image (provenance + SBOM, tags latest+sha); SemVer-only tags (`vX.Y.Z`) additionally build **5-platform binaries + checksums.txt** (linux/darwin/windows × amd64/arm64), smoke `metapi-linux-amd64 --version`, and create the GitHub Release with notes extracted from the matching `CHANGELOG.md` section; tag must match `web/package.json` version or the release fails |
 | Versioning         | `metapi --version` reports the build version injected via `-ldflags -X .../internal/version.Version` (`dev` for local builds); Docker build arg `VERSION`; Makefile `VERSION` variable                                                                                                                                                                                                                                                                                                                                                         |
 | Dependency updates | Dependabot active — grouped Go/npm/Actions PRs weekly and Docker PRs monthly through the same 12-check CI; breaking major bumps need a manual migration PR                                                                                                                                                                                                                                                                                                                                                                                     |
-| Current focus      | **Wave 13 token sync UI 真值已收口（v0.16.14）**：账号创建/登录 toast 如实报告 token 同步四态（synced 真实计数 / empty / failed 部分初始化警告 / skipped 原文案）；下一波待需求驱动 |
+| Current focus      | **Wave 14 账号表单与分页修复（PR #1010）**：验证/创建路径使用未保存的 `platformUserId` 与 `proxyUrl`，显式代理覆盖站点/Resin/系统代理并持久化；Accounts URL 控制分页保持稳定；合入后按 patch-first 发布 v0.16.15 |
 | Local dev env      | **`.dev-local/`（gitignored，2026-08-23 建成）**：Windows 二进制 + 3 实例矩阵（4100 共享 / 4101 sites-form / 4102 accounts）+ `manage.py` + `smoke.mjs` + 仓库根 Playwright 全家桶；agent 全本地工作不再 ssh，手册见 `.dev-local/README.md`；aliyun2 工作区已移交（只读归档，实例已停） |
 | Open work          | 无执行中 wave；证据收口项（cascade 生产证明、#558 可选探针）见 [MASTER](progress/MASTER.md) Evidence closeout |
 | Stack              | Go 1.26.6 · React 19 + Bun + Rsbuild 2 + TanStack Router/Query/Table + Tailwind 4 + shadcn Base UI + OKLCH + i18next · dual dialect SQLite/PostgreSQL                                                                                                                                                                                                                                                                                                                                                                                          |

--- a/docs/internal/log.md
+++ b/docs/internal/log.md
@@ -5,6 +5,12 @@
 > Product milestone timeline (grouped by version). Not the current-state source of truth.
 > Current state → [`STATE.md`](STATE.md) · open items → [`progress/MASTER.md`](progress/MASTER.md) · detailed version narrative → root [`CHANGELOG.md`](../../CHANGELOG.md)
 
+## 2026-08-27 — Wave 14 账号表单与分页修复（PR #1010）
+
+- **#1007**：inline token verification 与账号创建现在使用表单中尚未保存的 `platformUserId` / `proxyUrl`；显式代理覆盖站点、Resin 与系统代理，创建后持久化 `extraConfig.proxyUrl`，并拒绝非法代理 URL。
+- **#1008**：Accounts 表格由 URL 单一控制分页，关闭 TanStack 自动页码重置；新增真实表格回归测试，验证第 2 页渲染 11–20 行。
+- **证据**：后端 NewAPI + HTTP proxy + `New-Api-User` 回归、前端分页回归、本地 frontend 191 文件/1,276 用例与 Go build/vet/WSL race 全部通过；GitHub required CI checks 完成前不合入。
+
 ## 2026-08-27 — Wave 13 token sync UI 真值 发布 v0.16.14
 
 - Lane A（#1002 UI 后续）：账号创建/登录 toast 如实报告后端 `tokenSyncStatus` 四态——synced 显示真实持久化计数、empty 提示无上游令牌、failed 降级为部分初始化警告（账号保留、令牌面板可重试）、skipped/旧响应保持原文案；所有状态保留 `/token-routes` CTA。

--- a/docs/internal/progress/MASTER.md
+++ b/docs/internal/progress/MASTER.md
@@ -1,20 +1,19 @@
 # Roadmap
 
-**Last verified**: 2026-08-25
+**Last verified**: 2026-08-27
 
-**Release**: [v0.16.14](https://github.com/DeliciousBuding/metapi-go/releases/tag/v0.16.14) · released on master; production promotion follows the release and soak gate
+**Release**: [v0.16.14](https://github.com/DeliciousBuding/metapi-go/releases/tag/v0.16.14) · released on master; Wave 14 patch release v0.16.15 follows PR #1010
 
 > This is the only execution plan. It contains open work, order, ownership, and acceptance criteria. Current facts → [`../STATE.md`](../STATE.md) · product positioning → [`../benchmark.md`](../benchmark.md) · timeline → [`../log.md`](../log.md).
 
-## Current active work — Wave 12 demand truth
+## Current active work — Wave 14 account form and pagination fixes
 
-权威分析与拆分：[`../analysis/wave12-demand-truth.md`](../analysis/wave12-demand-truth.md)。执行分两次 patch-first 发布：
+执行分支为 [`PR #1010`](https://github.com/DeliciousBuding/metapi-go/pull/1010)，目标是修复 #1007 与 #1008；全部 required CI checks 通过后 squash merge，再按 patch-first 发布 v0.16.15。
 
-- **Wave 12A → v0.16.12**：#996 Sites 分页、#999 API key 模型策略 UI、#1001 账号表单站点搜索、#1000 公告进入 attention + #997 待处理语义澄清、截图数据 profile 真值门禁（已合入）。
-- **Wave 12B → v0.16.13**：#1002 session 账号创建后 service-owned token sync（失败不回滚账号）→ #998 上游模型刷新/手工模型管理/创建后持久化；周期 scheduler 延后到明确需求（已合入）。
-- **共享写点唯一归属**：locale、CHANGELOG、package version、STATE/MASTER/log 仅 integration lane 修改；实现 lane 不并发改共享文件。
-- **Wave 13 → v0.16.14**：token sync UI 真值——账号创建/登录 toast 报告后端同步报告四态（synced 真实计数 / empty / failed 部分初始化警告 / skipped 原文案），保留 `/token-routes` CTA（已合入）。
-- **当前阶段**：Wave 12A/12B/13 均已合入（→ v0.16.12 / v0.16.13 / v0.16.14）；无执行中波次，下一波待需求驱动。
+- **#1007 站点验证/创建参数真值**：表单未保存的 `platformUserId` 与 `proxyUrl` 贯穿 inline verification 和账号创建；显式表单代理覆盖已保存站点代理、Resin 与系统代理，创建后写入 `extraConfig.proxyUrl`；非法代理 URL fail-closed。
+- **#1008 Accounts 分页**：URL 是分页单一所有者，关闭 TanStack 自动 page reset，并以真实表格回归测试验证第 2 页稳定渲染 11–20 行。
+- **证据**：PR 内含后端 NewAPI + HTTP proxy + `New-Api-User` 端到端回归、前端分页回归；本地 frontend 191 文件/1,276 用例、typecheck/lint/format/knip/build、Go build/vet、WSL race 均已通过；GitHub CI 仍以所有 required checks 为合入门禁。
+- **前序发布**：Wave 12A/12B/13 已分别合入并发布 v0.16.12 / v0.16.13 / v0.16.14；本波合入后将把 Wave 14 移入已收口项，下一波待需求驱动。
 
 历史完成冻结：Round 1 #887 → v0.16.3、Round 2 #889 → v0.16.4、#887 补遗 + E2E → v0.16.5、Round 3 修复波 → v0.16.6、Wave 4 综合质量波 → v0.16.7、Wave 5+6 开发 + 深审计波 → v0.16.8、Wave 7+8+9 前端体验/语义/设置/catalog/移动端审计波 → v0.16.9、Wave 10 Sites demand batch → v0.16.10 、Wave 11 UX 真值波 → v0.16.11 均已发布。
 

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -312,6 +312,15 @@ func (h *accountsHandler) createAccount(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	if body.ProxyURL != nil {
+		normalizedProxyURL := strings.TrimSpace(*body.ProxyURL)
+		if normalizedProxyURL != "" && !service.IsValidProxyURL(normalizedProxyURL) {
+			writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid proxyUrl. Expected a valid http(s)/socks proxy URL.")
+			return
+		}
+		body.ProxyURL = &normalizedProxyURL
+	}
+
 	// Resolve credential mode
 	credentialMode := service.ResolveRequestedCredentialMode(body.CredentialMode)
 	if len(body.AccessTokens) > 0 {
@@ -507,7 +516,11 @@ func (h *accountsHandler) createSingleAccount(ctx context.Context, body payloads
 	}
 
 	skipModelFetch := body.SkipModelFetch != nil && *body.SkipModelFetch
-	proxyCfg := service.BuildPlatformProxyConfigForToken(h.cfg, &site, rawAccessToken)
+	proxyOverride := ""
+	if body.ProxyURL != nil {
+		proxyOverride = *body.ProxyURL
+	}
+	proxyCfg := service.BuildPlatformProxyConfigForTokenWithProxyURL(h.cfg, &site, rawAccessToken, proxyOverride)
 
 	resolvedUsername := strings.TrimSpace(coalescePtr(username, ""))
 	usernameProvided := resolvedUsername != ""
@@ -631,6 +644,9 @@ func (h *accountsHandler) createSingleAccount(ctx context.Context, body payloads
 
 	extraConfig := map[string]any{
 		"credentialMode": string(resolvedCredentialMode),
+	}
+	if body.ProxyURL != nil && strings.TrimSpace(*body.ProxyURL) != "" {
+		extraConfig["proxyUrl"] = strings.TrimSpace(*body.ProxyURL)
 	}
 	if resolvedPlatformUserID != nil {
 		extraConfig["platformUserId"] = *resolvedPlatformUserID
@@ -854,6 +870,15 @@ func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if body.ProxyURL != nil {
+		normalizedProxyURL := strings.TrimSpace(*body.ProxyURL)
+		if normalizedProxyURL != "" && !service.IsValidProxyURL(normalizedProxyURL) {
+			writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid proxyUrl. Expected a valid http(s)/socks proxy URL.")
+			return
+		}
+		body.ProxyURL = &normalizedProxyURL
+	}
+
 	// Get site
 	var site store.Site
 	if err := h.db.Get(&site, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), body.SiteID); err != nil {
@@ -869,7 +894,7 @@ func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
-	result, err := adp.VerifyToken(ctx, site.URL, accessToken, body.PlatformUserID, service.BuildPlatformProxyConfigForToken(h.cfg, &site, accessToken))
+	result, err := adp.VerifyToken(ctx, site.URL, accessToken, body.PlatformUserID, service.BuildPlatformProxyConfigForTokenWithProxyURL(h.cfg, &site, accessToken, coalescePtr(body.ProxyURL, "")))
 	if err != nil {
 		writeErrorWithRequest(w, r, http.StatusBadRequest, err.Error())
 		return

--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1185,6 +1186,106 @@ func TestAccounts_VerifyToken(t *testing.T) {
 	}
 	if result["modelCount"] != float64(2) {
 		t.Errorf("expected modelCount=2, got %v", result["modelCount"])
+	}
+}
+
+func TestAccounts_VerifyToken_UsesFormUserIDAndProxy(t *testing.T) {
+	_, r, _ := setupAccountsTest(t)
+
+	var proxyRequests atomic.Int32
+	var userIDHeaderSeen atomic.Bool
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		proxyRequests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		switch req.URL.Path {
+		case "/v1/models":
+			// Force the session path instead of the API-key fast path.
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"not an api key"}`))
+		case "/api/user/self":
+			if req.Header.Get("New-Api-User") != "42" {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"success":false,"message":"Unauthorized, New-Api-User header not provided"}`))
+				return
+			}
+			userIDHeaderSeen.Store(true)
+			_, _ = w.Write([]byte(`{"success":true,"data":{"id":42,"username":"proxy-user"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"success":false}`))
+		}
+	}))
+	t.Cleanup(proxy.Close)
+
+	// The upstream host is intentionally unroutable from the test process. A
+	// successful response therefore proves the unsaved form proxy was used.
+	siteResp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "Verify NewAPI",
+		"url":      "http://newapi.invalid",
+		"platform": "newapi",
+	})
+	if siteResp.Code != http.StatusOK {
+		t.Fatalf("create site: %d %s", siteResp.Code, siteResp.Body.String())
+	}
+	var site map[string]any
+	if err := json.Unmarshal(siteResp.Body.Bytes(), &site); err != nil {
+		t.Fatalf("decode site: %v", err)
+	}
+	siteID := int64(site["id"].(float64))
+
+	resp := doPostJSON(t, r, "/api/accounts/verify-token", map[string]any{
+		"siteId":         siteID,
+		"accessToken":    "session-token",
+		"credentialMode": "session",
+		"platformUserId": 42,
+		"proxyUrl":       proxy.URL,
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("verify token: %d %s", resp.Code, resp.Body.String())
+	}
+	if proxyRequests.Load() == 0 {
+		t.Fatal("proxy received no verification requests")
+	}
+	if !userIDHeaderSeen.Load() {
+		t.Fatal("verification did not send New-Api-User: 42 from the form")
+	}
+}
+
+func TestAccounts_Create_PersistsFormProxyURL(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	site := newSiteFixture(t, r, "Persist Proxy", "https://api.openai.com")
+	siteID := int64(site["id"].(float64))
+
+	resp := doPostJSON(t, r, "/api/accounts", map[string]any{
+		"siteId":         siteID,
+		"accessToken":    "sk-persist-proxy",
+		"credentialMode": "apikey",
+		"platformUserId": 106,
+		"proxyUrl":       "socks5://proxy.example:1080",
+		"skipModelFetch": true,
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("create account: %d %s", resp.Code, resp.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	accountID := int64(created["id"].(float64))
+
+	var extraConfig string
+	if err := db.QueryRow("SELECT extra_config FROM accounts WHERE id = ?", accountID).Scan(&extraConfig); err != nil {
+		t.Fatalf("load extra_config: %v", err)
+	}
+	var extra map[string]any
+	if err := json.Unmarshal([]byte(extraConfig), &extra); err != nil {
+		t.Fatalf("decode extra_config: %v", err)
+	}
+	if extra["proxyUrl"] != "socks5://proxy.example:1080" {
+		t.Fatalf("proxyUrl = %#v, want form value", extra["proxyUrl"])
+	}
+	if extra["platformUserId"] != float64(106) {
+		t.Fatalf("platformUserId = %#v, want 106", extra["platformUserId"])
 	}
 }
 

--- a/handler/admin/payloads/accounts.go
+++ b/handler/admin/payloads/accounts.go
@@ -8,6 +8,7 @@ type AccountCreatePayload struct {
 	AccessTokens   []string `json:"accessTokens,omitempty"`
 	APIToken       *string  `json:"apiToken,omitempty"`
 	PlatformUserID *int     `json:"platformUserId,omitempty"`
+	ProxyURL       *string  `json:"proxyUrl,omitempty"`
 	CheckinEnabled *bool    `json:"checkinEnabled,omitempty"`
 	CredentialMode *string  `json:"credentialMode,omitempty"`
 	RefreshToken   *string  `json:"refreshToken,omitempty"`
@@ -57,6 +58,7 @@ type AccountVerifyTokenPayload struct {
 	SiteID         int     `json:"siteId"`
 	AccessToken    *string `json:"accessToken,omitempty"`
 	PlatformUserID *int    `json:"platformUserId,omitempty"`
+	ProxyURL       *string `json:"proxyUrl,omitempty"`
 	CredentialMode *string `json:"credentialMode,omitempty"`
 }
 

--- a/handler/admin/payloads/accounts_test.go
+++ b/handler/admin/payloads/accounts_test.go
@@ -12,7 +12,7 @@ func TestAccountCreatePayload_Decode(t *testing.T) {
 	cases := []sitesRoundTripCase{
 		{
 			name:  "full valid single token",
-			input: `{"siteId":5,"username":"u","accessToken":"tok","apiToken":"sk","platformUserId":9,"checkinEnabled":true,"credentialMode":"session","refreshToken":"rt","tokenExpiresAt":1700000000,"skipModelFetch":true}`,
+			input: `{"siteId":5,"username":"u","accessToken":"tok","apiToken":"sk","platformUserId":9,"proxyUrl":"socks5://proxy:1080","checkinEnabled":true,"credentialMode":"session","refreshToken":"rt","tokenExpiresAt":1700000000,"skipModelFetch":true}`,
 			check: func(t *testing.T, d any) {
 				p := d.(*AccountCreatePayload)
 				if p.SiteID != 5 {
@@ -29,6 +29,9 @@ func TestAccountCreatePayload_Decode(t *testing.T) {
 				}
 				if p.PlatformUserID == nil || *p.PlatformUserID != 9 {
 					t.Fatalf("platformUserId = %#v", p.PlatformUserID)
+				}
+				if p.ProxyURL == nil || *p.ProxyURL != "socks5://proxy:1080" {
+					t.Fatalf("proxyUrl = %#v", p.ProxyURL)
 				}
 				if p.CheckinEnabled == nil || !*p.CheckinEnabled {
 					t.Fatalf("checkinEnabled = %#v", p.CheckinEnabled)
@@ -58,8 +61,8 @@ func TestAccountCreatePayload_Decode(t *testing.T) {
 			},
 		},
 		{
-			name:    "empty object leaves siteId zero",
-			input:   `{}`,
+			name:  "empty object leaves siteId zero",
+			input: `{}`,
 			check: func(t *testing.T, d any) {
 				p := d.(*AccountCreatePayload)
 				if p.SiteID != 0 || len(p.AccessTokens) != 0 {
@@ -120,8 +123,8 @@ func TestAccountUpdatePayload_Decode(t *testing.T) {
 			},
 		},
 		{
-			name:    "empty object",
-			input:   `{}`,
+			name:  "empty object",
+			input: `{}`,
 			check: func(t *testing.T, d any) {
 				p := d.(*AccountUpdatePayload)
 				if p.Status != nil || p.SortOrder != nil {
@@ -166,8 +169,8 @@ func TestAccountBatchPayload_Decode(t *testing.T) {
 			},
 		},
 		{
-			name:    "empty object",
-			input:   `{}`,
+			name:  "empty object",
+			input: `{}`,
 			check: func(t *testing.T, d any) {
 				p := d.(*AccountBatchPayload)
 				if len(p.IDs) != 0 || p.Action != "" {
@@ -204,8 +207,8 @@ func TestAccountLoginPayload_Decode(t *testing.T) {
 			},
 		},
 		{
-			name:    "empty object leaves fields zero",
-			input:   `{}`,
+			name:  "empty object leaves fields zero",
+			input: `{}`,
 			check: func(t *testing.T, d any) {
 				p := d.(*AccountLoginPayload)
 				if p.SiteID != 0 || p.Username != "" || p.Password != "" {
@@ -233,17 +236,20 @@ func TestAccountVerifyTokenPayload_Decode(t *testing.T) {
 	cases := []sitesRoundTripCase{
 		{
 			name:  "valid verify",
-			input: `{"siteId":1,"accessToken":"tok","platformUserId":7,"credentialMode":"api"}`,
+			input: `{"siteId":1,"accessToken":"tok","platformUserId":7,"proxyUrl":"http://proxy:8080","credentialMode":"api"}`,
 			check: func(t *testing.T, d any) {
 				p := d.(*AccountVerifyTokenPayload)
 				if p.SiteID != 1 || *p.AccessToken != "tok" || *p.PlatformUserID != 7 || *p.CredentialMode != "api" {
 					t.Fatalf("verify = %+v", p)
 				}
+				if p.ProxyURL == nil || *p.ProxyURL != "http://proxy:8080" {
+					t.Fatalf("proxyUrl = %#v", p.ProxyURL)
+				}
 			},
 		},
 		{
-			name:    "empty object",
-			input:   `{}`,
+			name:  "empty object",
+			input: `{}`,
 			check: func(t *testing.T, d any) {
 				p := d.(*AccountVerifyTokenPayload)
 				if p.SiteID != 0 || p.AccessToken != nil {
@@ -286,8 +292,8 @@ func TestAccountRebindSessionPayload_Decode(t *testing.T) {
 			},
 		},
 		{
-			name:    "empty object",
-			input:   `{}`,
+			name:  "empty object",
+			input: `{}`,
 			check: func(t *testing.T, d any) {
 				p := d.(*AccountRebindSessionPayload)
 				if p.AccessToken != nil || p.TokenExpiresAt != nil {
@@ -327,8 +333,8 @@ func TestAccountHealthRefreshPayload_Decode(t *testing.T) {
 			},
 		},
 		{
-			name:    "empty object",
-			input:   `{}`,
+			name:  "empty object",
+			input: `{}`,
 			check: func(t *testing.T, d any) {
 				p := d.(*AccountHealthRefreshPayload)
 				if p.AccountID != nil || p.Wait != nil {
@@ -365,8 +371,8 @@ func TestAccountManualModelsPayload_Decode(t *testing.T) {
 			},
 		},
 		{
-			name:    "empty object",
-			input:   `{}`,
+			name:  "empty object",
+			input: `{}`,
 			check: func(t *testing.T, d any) {
 				if len(d.(*AccountManualModelsPayload).Models) != 0 {
 					t.Fatalf("expected empty models")

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/deliciousbuding/metapi-go/config"
 	"github.com/deliciousbuding/metapi-go/platform"
 	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/jmoiron/sqlx"
 )
 
 // AccountCredentialMode is the credential mode for an account.
@@ -343,6 +343,28 @@ func BuildPlatformProxyConfigForToken(cfg *config.Config, site *store.Site, rawT
 	return normalizePlatformProxyConfig(proxyCfg)
 }
 
+// BuildPlatformProxyConfigForTokenWithProxyURL is the pre-account proxy
+// builder for unsaved account-form values. A non-empty request override must
+// win over the saved site proxy, Resin, and system proxy for the verification
+// or create request; empty input keeps the normal site-level precedence.
+func BuildPlatformProxyConfigForTokenWithProxyURL(cfg *config.Config, site *store.Site, rawToken, proxyURL string) *platform.ProxyConfig {
+	proxyURL = strings.TrimSpace(proxyURL)
+	if proxyURL == "" {
+		return BuildPlatformProxyConfigForToken(cfg, site, rawToken)
+	}
+
+	// Build the site-derived headers/UA/cookie/uTLS settings without resolving
+	// Resin or the saved site proxy, then apply the explicit unsaved override.
+	proxyCfg := BuildPlatformProxyConfig(cfg, nil, site)
+	if proxyCfg == nil {
+		proxyCfg = &platform.ProxyConfig{}
+	}
+	proxyCfg.ProxyURL = proxyURL
+	proxyCfg.UseSystemProxy = false
+	proxyCfg.ResinAccount = ""
+	return normalizePlatformProxyConfig(proxyCfg)
+}
+
 func normalizePlatformProxyConfig(proxyCfg *platform.ProxyConfig) *platform.ProxyConfig {
 	if proxyCfg == nil {
 		return nil
@@ -484,7 +506,7 @@ func getAccountWithSiteBy(q accountQueryExecer, id int64, forUpdate bool) (*Acco
 			ExtraConfig        *string  `db:"extra_config"`
 			CreatedAt          string   `db:"created_at"`
 			UpdatedAt          string   `db:"updated_at"`
-			Remark             *string `db:"remark"`
+			Remark             *string  `db:"remark"`
 		} `db:"accounts"`
 		Sites struct {
 			ID                                  int64   `db:"id"`

--- a/service/account_service_test.go
+++ b/service/account_service_test.go
@@ -168,6 +168,36 @@ func TestBuildPlatformProxyConfigForToken_PropagatesUTLS(t *testing.T) {
 	}
 }
 
+// TestBuildPlatformProxyConfigForTokenWithProxyURL_OverridesSiteProxy verifies
+// that unsaved account-form proxy input is used for pre-account verification
+// instead of the persisted site proxy.
+func TestBuildPlatformProxyConfigForTokenWithProxyURL_OverridesSiteProxy(t *testing.T) {
+	siteProxy := "http://saved-proxy.example:8080"
+	site := &store.Site{
+		ID:       1,
+		Name:     "test",
+		URL:      "https://example.com",
+		Platform: "newapi",
+		ProxyURL: &siteProxy,
+	}
+
+	result := BuildPlatformProxyConfigForTokenWithProxyURL(
+		&config.Config{},
+		site,
+		"raw-token",
+		"  socks5://form-proxy.example:1080  ",
+	)
+	if result == nil {
+		t.Fatal("BuildPlatformProxyConfigForTokenWithProxyURL returned nil")
+	}
+	if result.ProxyURL != "socks5://form-proxy.example:1080" {
+		t.Fatalf("ProxyURL = %q, want form override", result.ProxyURL)
+	}
+	if result.UseSystemProxy {
+		t.Fatal("UseSystemProxy = true, want false for explicit form proxy")
+	}
+}
+
 // TestNormalizePlatformProxyConfig_KeepsUTLS verifies that a ProxyConfig with
 // only UseUTLS=true (no proxy URL, headers, or cookies) is NOT stripped to nil
 // by normalizePlatformProxyConfig — otherwise global uTLS opt-in with no other

--- a/web/src/features/accounts/__tests__/accounts-schema.test.ts
+++ b/web/src/features/accounts/__tests__/accounts-schema.test.ts
@@ -424,6 +424,24 @@ describe('buildAccountVerifyPayload', () => {
     })
   })
 
+  it('passes unsaved platform user id and proxy values through verification', () => {
+    const result = buildAccountVerifyPayload({
+      ...validSessionForm(),
+      platformUserId: 106,
+      proxyUrl: '  socks5://proxy.example:1080  ',
+    })
+    expect(result).toEqual({
+      ok: true,
+      payload: {
+        siteId: 1,
+        accessToken: 'sk-1',
+        platformUserId: 106,
+        proxyUrl: 'socks5://proxy.example:1080',
+        credentialMode: 'session',
+      },
+    })
+  })
+
   it('returns a site error when siteId is missing or non-positive', () => {
     expect(
       buildAccountVerifyPayload({ ...validSessionForm(), siteId: 0 })

--- a/web/src/features/accounts/api.ts
+++ b/web/src/features/accounts/api.ts
@@ -171,6 +171,8 @@ export function useVerifyAccountToken() {
     mutationFn: async (payload: {
       siteId: number
       accessToken: string
+      platformUserId?: number
+      proxyUrl?: string
       credentialMode: 'session' | 'apikey'
     }) => {
       const result = await api.verifyToken(payload, { skipErrorHandler: true })

--- a/web/src/features/accounts/components/__tests__/accounts-page-pagination.test.tsx
+++ b/web/src/features/accounts/components/__tests__/accounts-page-pagination.test.tsx
@@ -1,0 +1,208 @@
+// Regression coverage for GitHub #1008: Accounts pagination is URL-controlled.
+// The accounts page uses a fresh URL-derived filter array on every render; the
+// table must not let TanStack reset an explicit page click back to page 1.
+import '@testing-library/jest-dom/vitest'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+
+import { AccountsPage } from '../accounts-page'
+
+type RouterLocation = {
+  pathname: string
+  searchStr: string
+}
+
+const routerState = vi.hoisted(() => {
+  let location: RouterLocation = { pathname: '/accounts', searchStr: '' }
+  const listeners = new Set<() => void>()
+
+  const commitHref = (href: string) => {
+    const url = new URL(href, window.location.origin)
+    location = { pathname: url.pathname, searchStr: url.search }
+    window.history.replaceState({}, '', `${url.pathname}${url.search}`)
+    for (const listener of listeners) listener()
+  }
+
+  return {
+    getLocation: () => location,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    navigate: vi.fn((options: { href?: string }) => {
+      if (options.href) commitHref(options.href)
+    }),
+    reset: (href: string) => commitHref(href),
+  }
+})
+
+const testState = vi.hoisted(() => ({
+  accounts: [] as Array<Record<string, unknown>>,
+  columns: [{ accessorKey: 'username', header: 'Username' }],
+}))
+
+vi.mock('@tanstack/react-router', async () => {
+  const React = await import('react')
+
+  return {
+    useLocation: <T,>({
+      select,
+    }: {
+      select: (location: RouterLocation) => T
+    }) =>
+      React.useSyncExternalStore(
+        routerState.subscribe,
+        () => select(routerState.getLocation()),
+        () => select(routerState.getLocation())
+      ),
+    useNavigate: () => routerState.navigate,
+    useSearch: () => ({}),
+  }
+})
+
+vi.mock('@/features/import', () => ({
+  ImportWizardDialog: () => null,
+}))
+
+vi.mock('../../api', () => ({
+  useAccounts: () => ({
+    data: {
+      accounts: testState.accounts,
+      sites: [
+        {
+          id: 1,
+          name: 'Site 01',
+          url: 'https://site.example.com',
+          platform: 'newapi',
+          status: 'active',
+        },
+      ],
+      generatedAt: '',
+    },
+    error: null,
+    isLoading: false,
+    isFetching: false,
+    refetch: vi.fn(),
+  }),
+  useDeleteAccount: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRefreshAccount: () => ({ mutate: vi.fn(), isPending: false }),
+  useToggleAccountPin: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    variables: undefined,
+  }),
+  useToggleAccountStatus: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    variables: undefined,
+  }),
+  useToggleAccountCheckin: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    variables: undefined,
+  }),
+  useBatchUpdateAccounts: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+vi.mock('../accounts-columns', () => ({
+  useAccountsColumns: () => testState.columns,
+}))
+
+vi.mock('../account-created-toast', () => ({
+  showAccountCreatedToast: vi.fn(),
+  showAccountLoginToast: vi.fn(),
+}))
+
+vi.mock('../account-detail-sheet', () => ({
+  AccountDetailSheet: () => null,
+}))
+
+vi.mock('../account-form-dialog', () => ({
+  AccountFormDialog: () => null,
+}))
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  localStorage.clear()
+  routerState.navigate.mockClear()
+  routerState.reset('/accounts?pageSize=10')
+  testState.accounts = Array.from({ length: 25 }, (_, index) => ({
+    id: index + 1,
+    siteId: 1,
+    username: `Account ${String(index + 1).padStart(2, '0')}`,
+    status: 'active',
+    credentialMode: 'session',
+    site: {
+      id: 1,
+      name: 'Site 01',
+      url: 'https://site.example.com',
+      platform: 'newapi',
+      status: 'active',
+    },
+  }))
+})
+
+afterEach(() => cleanup())
+
+describe('AccountsPage URL-controlled pagination', () => {
+  it('keeps page 2 selected and renders rows 11-20', async () => {
+    render(<AccountsPage />)
+
+    expect(screen.getByText('Account 01')).toBeInTheDocument()
+    expect(screen.getByText('Account 10')).toBeInTheDocument()
+    expect(screen.queryByText('Account 11')).not.toBeInTheDocument()
+
+    // TanStack arms auto-reset after the initial render. A real user click
+    // necessarily happens after that microtask; flush it so the regression is
+    // observable under jsdom too.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Go to page 2/ }))
+
+    // Flush the queued reset before asserting the URL and rendered row model.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    })
+
+    const search = new URLSearchParams(window.location.search)
+    expect(search.get('page')).toBe('2')
+    expect(search.get('pageSize')).toBe('10')
+    for (let index = 11; index <= 20; index += 1) {
+      expect(
+        screen.getByText(`Account ${String(index).padStart(2, '0')}`)
+      ).toBeInTheDocument()
+    }
+    for (let index = 1; index <= 10; index += 1) {
+      expect(
+        screen.queryByText(`Account ${String(index).padStart(2, '0')}`)
+      ).not.toBeInTheDocument()
+    }
+  })
+})

--- a/web/src/features/accounts/components/account-form-dialog.tsx
+++ b/web/src/features/accounts/components/account-form-dialog.tsx
@@ -217,10 +217,20 @@ export function AccountFormDialog({
   const watchedSiteId = form.watch('siteId')
   const watchedAccessToken = form.watch('accessToken')
   const watchedApiToken = form.watch('apiToken')
+  const watchedPlatformUserId = form.watch('platformUserId')
+  const watchedProxyUrl = form.watch('proxyUrl')
   useEffect(() => {
     verificationRequestId.current += 1
     setVerification({ status: 'idle' })
-  }, [open, watchedSiteId, credentialMode, watchedAccessToken, watchedApiToken])
+  }, [
+    open,
+    watchedSiteId,
+    credentialMode,
+    watchedAccessToken,
+    watchedApiToken,
+    watchedPlatformUserId,
+    watchedProxyUrl,
+  ])
 
   const handleVerify = async () => {
     const resolved = buildAccountVerifyPayload(form.getValues())

--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -496,6 +496,9 @@ export function AccountsPage() {
     sorting: urlState.sorting,
     onSortingChange: urlState.onSortingChange,
     ensurePageInRange: urlState.ensurePageInRange,
+    // URL state owns pagination. A fresh URL-derived filters array must not
+    // let TanStack bounce an explicit page selection back to page 0.
+    autoResetPageIndex: false,
     globalFilterFn: accountsGlobalFilterFn,
   })
 

--- a/web/src/features/accounts/lib/accounts-schema.ts
+++ b/web/src/features/accounts/lib/accounts-schema.ts
@@ -221,6 +221,8 @@ function extractProxyUrl(extraConfig: string | null | undefined): string {
 type AccountVerifyPayload = {
   siteId: number
   accessToken: string
+  platformUserId?: number
+  proxyUrl?: string
   credentialMode: 'session' | 'apikey'
 }
 
@@ -247,11 +249,19 @@ export function buildAccountVerifyPayload(
   if (!token || !token.trim()) {
     return { ok: false, error: 'token' }
   }
+  const platformUserId =
+    values.platformUserId && values.platformUserId > 0
+      ? values.platformUserId
+      : undefined
+  const proxyUrl = values.proxyUrl?.trim() || undefined
+
   return {
     ok: true,
     payload: {
       siteId: values.siteId,
       accessToken: token.trim(),
+      ...(platformUserId === undefined ? {} : { platformUserId }),
+      ...(proxyUrl === undefined ? {} : { proxyUrl }),
       credentialMode: values.credentialMode === 'apikey' ? 'apikey' : 'session',
     },
   }

--- a/web/src/lib/api/accounts.ts
+++ b/web/src/lib/api/accounts.ts
@@ -33,6 +33,7 @@ export const accountsApi = {
       siteId: number
       accessToken: string
       platformUserId?: number
+      proxyUrl?: string
       credentialMode?: 'auto' | 'session' | 'apikey'
     },
     options?: { skipErrorHandler?: boolean }


### PR DESCRIPTION
## Summary\n\n- pass the account form's platformUserId and proxyUrl through inline token verification\n- validate and apply the unsaved proxy for verification/create, then persist it in account extraConfig\n- prevent TanStack from resetting URL-controlled Accounts pagination after a page click\n- add frontend and backend regression coverage for #1007 and #1008\n\n## Validation\n\n- frontend: 191 test files / 1,276 tests passed\n- frontend typecheck, lint, format, knip, and production build passed\n- Go build and vet passed\n- WSL-backed full Go race suite passed\n\nFixes #1007\nFixes #1008