### PR TITLE
fix(web): guard sites createdAt column against invalid zhCN Intl locale

### DIFF
--- a/web/src/features/sites/__tests__/sites-columns-locale.test.tsx
+++ b/web/src/features/sites/__tests__/sites-columns-locale.test.tsx
@@ -1,0 +1,119 @@
+// Regression test for the zhCN locale crash (#1030): the createdAt column
+// must pass the active i18n language through toBcp47() before handing it to
+// the Intl-based formatters. `i18n.language` is `zhCN` (not a valid BCP-47
+// tag), and `new Intl.DateTimeFormat('zhCN')` throws RangeError, which used
+// to crash the whole /sites table for Chinese users.
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import i18n from '@/i18n/config'
+
+import { useSitesColumns } from '../components/sites-columns'
+import type { Site } from '../types'
+
+const noopActions = {
+  onEdit: () => {},
+  onView: () => {},
+  onToggleStatus: () => {},
+  onTogglePin: () => {},
+  onDelete: () => {},
+}
+
+function makeSite(overrides: Partial<Site>): Site {
+  return {
+    id: 1,
+    name: 'OpenAI',
+    url: 'https://api.openai.com',
+    status: 'active',
+    isPinned: false,
+    ...overrides,
+  }
+}
+
+function CreatedAtCell({ site }: { site: Site }) {
+  const columns = useSitesColumns(noopActions, null)
+  const column = columns.find((entry) => entry.id === 'createdAt')
+  if (!column?.cell) throw new Error('createdAt column cell missing')
+  const cell = column.cell as unknown as (context: {
+    row: { original: Site }
+  }) => ReactElement
+  return cell({ row: { original: site } })
+}
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    writable: true,
+    value: ResizeObserverStub,
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  void i18n.changeLanguage('en')
+})
+
+afterAll(() => {
+  vi.restoreAllMocks()
+})
+
+describe('sites createdAt column locale handling', () => {
+  it('renders without RangeError when the language is zhCN', async () => {
+    await i18n.changeLanguage('zhCN')
+    expect(i18n.language).toBe('zhCN')
+
+    const site = makeSite({
+      createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    })
+
+    // Before the fix, `formatRelativeTime(createdAt, 'zhCN')` threw
+    // `RangeError: Incorrect locale information provided` here.
+    let container: HTMLElement | undefined
+    expect(() => {
+      container = render(<CreatedAtCell site={site} />).container
+    }).not.toThrow()
+
+    const span = container?.querySelector('span[title]')
+    // The absolute-date tooltip comes from formatAbsoluteDateTime, which must
+    // also survive the zhCN -> zh-CN conversion.
+    expect(span?.getAttribute('title')).toBeTruthy()
+    expect(span?.textContent).toBeTruthy()
+  })
+
+  it('still renders for a plain en locale', () => {
+    const site = makeSite({
+      createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    })
+
+    expect(() => render(<CreatedAtCell site={site} />)).not.toThrow()
+  })
+})

--- a/web/src/features/sites/components/sites-columns.tsx
+++ b/web/src/features/sites/components/sites-columns.tsx
@@ -32,6 +32,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Spinner } from '@/components/ui/spinner'
+import { toBcp47 } from '@/i18n/languages'
 import {
   formatAbsoluteDateTime,
   formatCurrency,
@@ -396,9 +397,12 @@ export function useSitesColumns(
         return (
           <span
             className='text-muted-foreground text-sm whitespace-nowrap'
-            title={formatAbsoluteDateTime(createdAt, i18n.language)}
+            title={formatAbsoluteDateTime(
+              createdAt,
+              toBcp47(i18n.language || 'en')
+            )}
           >
-            {formatRelativeTime(createdAt, i18n.language)}
+            {formatRelativeTime(createdAt, toBcp47(i18n.language || 'en'))}
           </span>
         )
       },


### PR DESCRIPTION
## 背景

2026-08-28 前端深度体检 P1 之一（#1028 修复计划）：中文用户打开 `/sites` 站点列表页即触发渲染崩溃。

## 根因

`web/src/features/sites/components/sites-columns.tsx` createdAt 列把原始 `i18n.language`（中文下值为 `zhCN`）直接传给 `formatAbsoluteDateTime` / `formatRelativeTime`，二者内部构造 `new Intl.DateTimeFormat('zhCN')` 抛 `RangeError: Incorrect locale information provided`。全仓其余 63 处调用均规范走 `toBcp47()`，仅此两处漏网。

## 改动

- createdAt 列两处调用包 `toBcp47(i18n.language || 'en')`
- 新增回归测试 `sites-columns-locale.test.tsx`：切 zhCN 语言渲染该列，断言不抛错且 tooltip/文本正常产出

## 验证

- [x] 新测试在旧代码下红（真实复现 RangeError）、修复后绿（反向验证过）
- [x] web 全量测试 195 文件 / 1306 用例通过
- [x] `bun run lint`（0 error）/ `format:check`（633 文件全过）/ `typecheck` 通过
- [x] `go build ./cmd/server && go vet ./...` 通过（改动不涉及 Go）

Fixes #1030

