### PR TITLE
fix(web): security quick-win batch from the frontend audit

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,3 +1,17 @@
+# Repository-specific gitleaks rules on top of the default rule set.
+# Keep this conservative: the docs ship placeholder tokens like
+# `AUTH_TOKEN=your-admin-token`, so literal-name rules false-positive. The
+# default rule set (generic high-entropy detection) already covers admin
+# token leaks; this file only adds the product-specific `sk-` downstream key
+# shape that the defaults do not know about.
+
+[[rules]]
+id = "metapi-downstream-api-key"
+description = "Metapi downstream API key (sk- prefixed secret)"
+regex = '''\bsk-[a-zA-Z0-9_-]{20,}\b'''
+entropy = 3.8
+keywords = ["sk-"]
+
 [allowlist]
 description = "Repository-specific false positives"
 paths = [

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,6 +4,10 @@
 # default rule set (generic high-entropy detection) already covers admin
 # token leaks; this file only adds the product-specific `sk-` downstream key
 # shape that the defaults do not know about.
+#
+# Go/e2e test fixtures use synthetic `sk-` tokens extensively (see the
+# allowlist below); real keys must never appear there, and the default rule
+# set still scans those files — only this custom rule steps aside.
 
 [[rules]]
 id = "metapi-downstream-api-key"
@@ -11,6 +15,12 @@ description = "Metapi downstream API key (sk- prefixed secret)"
 regex = '''\bsk-[a-zA-Z0-9_-]{20,}\b'''
 entropy = 3.8
 keywords = ["sk-"]
+[rules.allowlist]
+paths = [
+  '''_test\.go$''',
+  '''\.test\.[cm]?[jt]s$''',
+  '''e2e/''',
+]
 
 [allowlist]
 description = "Repository-specific false positives"

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -66,16 +66,12 @@
   },
   "overrides": {
     "brace-expansion": "2.1.1",
-    "dompurify": "3.4.11",
     "fast-uri": "3.1.2",
     "hono": "4.12.22",
     "ip-address": "10.2.0",
-    "js-cookie": "3.0.7",
-    "mermaid": "11.15.0",
     "minimist": "1.2.8",
     "postcss": "8.5.15",
     "qs": "6.15.2",
-    "uuid": "14.0.0",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "https://registry.npmmirror.com/@adobe/css-tools/-/css-tools-4.5.0.tgz", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],

--- a/web/package.json
+++ b/web/package.json
@@ -113,16 +113,12 @@
   },
   "overrides": {
     "brace-expansion": "2.1.1",
-    "dompurify": "3.4.11",
     "fast-uri": "3.1.2",
     "hono": "4.12.22",
     "ip-address": "10.2.0",
-    "js-cookie": "3.0.7",
-    "mermaid": "11.15.0",
     "minimist": "1.2.8",
     "postcss": "8.5.15",
-    "qs": "6.15.2",
-    "uuid": "14.0.0"
+    "qs": "6.15.2"
   },
   "engines": {
     "bun": ">= 1.0"

--- a/web/src/components/layout/__tests__/user-menu.test.tsx
+++ b/web/src/components/layout/__tests__/user-menu.test.tsx
@@ -21,7 +21,15 @@ import i18n from '@/i18n/config'
 
 import { UserMenu } from '../components/user-menu'
 
-const { navigateMock } = vi.hoisted(() => ({ navigateMock: vi.fn() }))
+const { navigateMock, clearMonitorSessionMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  clearMonitorSessionMock: vi.fn().mockResolvedValue(undefined),
+}))
+
+// user-menu only consumes the monitor-session clearer from the api barrel.
+vi.mock('@/lib/api', () => ({
+  api: { clearMonitorSession: clearMonitorSessionMock },
+}))
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
@@ -75,6 +83,7 @@ afterAll(() => {
 
 beforeEach(async () => {
   navigateMock.mockReset()
+  clearMonitorSessionMock.mockClear()
   localStorage.clear()
   await i18n.changeLanguage('en')
 })
@@ -118,8 +127,22 @@ describe('user menu', () => {
     await openMenu()
     fireEvent.click(screen.getByRole('menuitem', { name: /Sign out/ }))
 
+    // The HttpOnly monitor cookie is cleared server-side while the Bearer
+    // token is still valid; local storage is cleared afterwards.
+    expect(clearMonitorSessionMock).toHaveBeenCalledTimes(1)
     expect(localStorage.getItem('auth_token')).toBeNull()
     expect(localStorage.getItem('auth_token_expires_at')).toBeNull()
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/sign-in' })
+  })
+
+  it('still signs out when the monitor session cleanup fails', async () => {
+    clearMonitorSessionMock.mockRejectedValueOnce(new Error('network down'))
+    localStorage.setItem('auth_token', 'test-token')
+
+    await openMenu()
+    fireEvent.click(screen.getByRole('menuitem', { name: /Sign out/ }))
+
+    expect(localStorage.getItem('auth_token')).toBeNull()
     expect(navigateMock).toHaveBeenCalledWith({ to: '/sign-in' })
   })
 })

--- a/web/src/components/layout/components/user-menu.tsx
+++ b/web/src/components/layout/components/user-menu.tsx
@@ -22,6 +22,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { ABOUT_INFO } from '@/features/about/api'
+import { api } from '@/lib/api'
 import { clearAuthSession } from '@/lib/auth-session'
 import { useAuthStore } from '@/stores/auth-store'
 
@@ -30,6 +31,11 @@ export function UserMenu() {
   const navigate = useNavigate()
 
   const handleSignOut = () => {
+    // Clear the HttpOnly `meta_monitor_auth` cookie server-side while the
+    // Bearer token is still valid — the JS cookie clear inside
+    // clearAuthSession cannot touch HttpOnly cookies. Fire-and-forget: a
+    // failed monitor cleanup must not block sign-out.
+    void api.clearMonitorSession().catch(() => {})
     clearAuthSession()
     useAuthStore.getState().auth.reset()
     navigate({ to: '/sign-in' })

--- a/web/src/features/accounts/tokens/components/tokens-panel.tsx
+++ b/web/src/features/accounts/tokens/components/tokens-panel.tsx
@@ -437,6 +437,8 @@ function AccountTokenForm({
                 <FormLabel>{t('accounts.tokens.form.value')}</FormLabel>
                 <FormControl>
                   <Input
+                    type='password'
+                    autoComplete='new-password'
                     className='font-mono text-xs'
                     placeholder={
                       isEdit

--- a/web/src/features/checkin/components/checkin-detail-sheet.tsx
+++ b/web/src/features/checkin/components/checkin-detail-sheet.tsx
@@ -16,6 +16,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet'
+import { isValidEndpointUrl } from '@/features/sites'
 import { toBcp47 } from '@/i18n/languages'
 
 import { formatCheckinLogTime } from '../lib/checkin-time'
@@ -99,14 +100,21 @@ export function CheckinDetailSheet({
             </DetailField>
             {site?.url && (
               <DetailField label={t('checkin.detail.siteUrl')}>
-                <a
-                  href={site.url}
-                  target='_blank'
-                  rel='noopener noreferrer'
-                  className='text-primary underline-offset-4 hover:underline'
-                >
-                  {site.url}
-                </a>
+                {/^https?:\/\//i.test(site.url) &&
+                isValidEndpointUrl(site.url) ? (
+                  <a
+                    href={site.url}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    className='text-primary underline-offset-4 hover:underline'
+                  >
+                    {site.url}
+                  </a>
+                ) : (
+                  <span className='text-muted-foreground break-all'>
+                    {site.url}
+                  </span>
+                )}
               </DetailField>
             )}
             <DetailField

--- a/web/src/features/sites/components/site-detail-sheet.tsx
+++ b/web/src/features/sites/components/site-detail-sheet.tsx
@@ -31,7 +31,7 @@ import {
   formatRelativeTime,
 } from '@/lib/format'
 
-import { isHttpUrl } from '../lib/endpoints'
+import { isHttpUrl, isValidEndpointUrl } from '../lib/endpoints'
 import { resolveSiteBalanceUsd } from '../lib/site-balance'
 import type { Site, SiteApiEndpoint, SiteStatus } from '../types'
 import { SiteProbePanel } from './site-probe-panel'
@@ -145,15 +145,24 @@ export function SiteDetailSheet({
                   full
                   title={site.externalCheckinUrl}
                 >
-                  <a
-                    href={site.externalCheckinUrl}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    className='text-primary inline-flex max-w-full items-center gap-1 hover:underline'
-                  >
-                    <span className='truncate'>{site.externalCheckinUrl}</span>
-                    <ExternalLinkIcon className='size-4 shrink-0' />
-                  </a>
+                  {/^https?:\/\//i.test(site.externalCheckinUrl) &&
+                  isValidEndpointUrl(site.externalCheckinUrl) ? (
+                    <a
+                      href={site.externalCheckinUrl}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='text-primary inline-flex max-w-full items-center gap-1 hover:underline'
+                    >
+                      <span className='truncate'>
+                        {site.externalCheckinUrl}
+                      </span>
+                      <ExternalLinkIcon className='size-4 shrink-0' />
+                    </a>
+                  ) : (
+                    <span className='text-muted-foreground truncate'>
+                      {site.externalCheckinUrl}
+                    </span>
+                  )}
                 </DetailField>
               ) : null}
               {site.platform ? (

--- a/web/src/features/sites/index.ts
+++ b/web/src/features/sites/index.ts
@@ -5,5 +5,8 @@
 // deep linking (the SiteCreatedModal → /accounts handoff).
 
 export { sitesSearchSchema } from './lib/sites-schema'
+// Endpoint URL guard (http/https + forbidden-host check) reused by
+// cross-feature detail sheets that render site-provided URLs as links.
+export { isValidEndpointUrl } from './lib/endpoints'
 
 export { sitesKeys } from './types'

--- a/web/src/lib/api/system.ts
+++ b/web/src/lib/api/system.ts
@@ -16,7 +16,6 @@ export const systemApi = {
       method: 'PUT',
       body: JSON.stringify(data),
     }),
-  initMonitorSession: () => request('/api/monitor/session', { method: 'POST' }),
   // Clears the HttpOnly `meta_monitor_auth` cookie (Path=/monitor-proxy/);
   // must be called while Bearer auth is still valid.
   clearMonitorSession: () =>

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -71,11 +71,14 @@ function RootComponent() {
   useDocumentTitle()
 
   // Clear the query cache when the auth session changes (login/logout/tab
-  // sync) so stale user-scoped data never leaks across sessions.
+  // sync) so stale user-scoped data never leaks across sessions. The token
+  // model has no server-side session (`auth.session` stays null), so key the
+  // reset on the access token itself: login sets it, logout clears it, and a
+  // token rotation replaces it.
   useEffect(
     () =>
       useAuthStore.subscribe((state, previousState) => {
-        if (state.auth.session?.sid !== previousState.auth.session?.sid) {
+        if (state.auth.accessToken !== previousState.auth.accessToken) {
           queryClient.clear()
         }
       }),


### PR DESCRIPTION
## 背景

体检修复计划 #1028 波次 1 的**批 A（安全加固）**，来自 2026-08-28 前端深度体检（#1029 快赢清单的安全部分）。7 项独立小改，一次打包。

## 改动

| # | 改动 | 位置 |
|---|---|---|
| 1 | 登出先 fire-and-forget `clearMonitorSession()` 再清本地（HttpOnly cookie 的 JS 清理必然无效，残留会话最长 2h；清理失败不阻塞登出） | `web/src/components/layout/components/user-menu.tsx` |
| 2 | 查询缓存清理条件 `session.sid`（恒 null 死代码）→ `accessToken` 变化触发 | `web/src/routes/__root.tsx` |
| 3 | 删除零调用者 `initMonitorSession` 死代码 | `web/src/lib/api/system.ts` |
| 4 | 两处数据驱动 `href` 套 `isValidEndpointUrl` 守卫（`javascript:` 协议不再能成为可点击链接；守卫经 sites 桶导出，跨域不加深路径） | `checkin-detail-sheet.tsx` / `site-detail-sheet.tsx` / `sites/index.ts` |
| 5 | 账号 token 输入框 `type='password'` + `autoComplete='new-password'` | `tokens-panel.tsx` |
| 6 | 删 4 个孤儿 override（bun.lock 实测零解析条目：dompurify/mermaid/uuid/js-cookie）+ bun.lock 镜像同步 | `web/package.json` / `web/bun.lock` |
| 7 | gitleaks 自定义规则：`sk-` 下游密钥形态（全仓 grep 验证零误报；admin-token 规则因 docs 占位符形态误报而放弃，默认规则集的高熵检测已覆盖） | `.gitleaks.toml` |

## 验证

- [x] 触及面测试全绿（user-menu 新增 2 断言：登出调 monitor 清理 + 清理失败仍可登出）
- [x] web 全量 1305 用例通过；lint 0 error / format / typecheck 全过
- [x] 孤儿 override 与 sk- 误报均本地 grep 实证后再动手

Refs #1029（批 A），修复计划 #1028

