### PR TITLE
fix(web): build quick-win batch from the frontend audit

### DIFF
--- a/web/rsbuild.config.ts
+++ b/web/rsbuild.config.ts
@@ -35,6 +35,10 @@ export default defineConfig(({ envMode }) => {
   ) as Record<string, { target: string; changeOrigin: boolean }>
 
   return {
+    // optimize stays false: rsbuild's default minifier already runs
+    // lightningcss, and enabling pluginTailwindcss `optimize` re-runs it on
+    // the Tailwind output — measured +3.1 kB raw / +0.8 kB gzip on the CSS
+    // bundle (179,325 → 182,456 B raw), so it buys nothing.
     plugins: [pluginReact(), pluginTailwindcss({ optimize: false })],
     // Rsbuild 2: replaces deprecated `performance.chunkSplit` (RSPack 2 aligned)
     splitChunks: {
@@ -57,6 +61,13 @@ export default defineConfig(({ envMode }) => {
         'vendor-tanstack': {
           test: /node_modules[\\/]@tanstack[\\/]/,
           name: 'vendor-tanstack',
+          chunks: 'all',
+          priority: 0,
+          enforce: true,
+        },
+        'vendor-recharts': {
+          test: /node_modules[\\/](recharts|d3-.*|victory-vendor)[\\/]/,
+          name: 'vendor-recharts',
           chunks: 'all',
           priority: 0,
           enforce: true,
@@ -106,7 +117,10 @@ export default defineConfig(({ envMode }) => {
     performance: {
       // Remove console.log in production (keep warn/error for diagnostics)
       removeConsole: isProd ? ['log'] : false,
-      buildCache: false,
+      // Persistent module cache (node_modules/.cache/rspack). Speeds up
+      // incremental rebuilds; output bytes stay identical between a cold and
+      // a warm build (verified by hashing dist/ twice).
+      buildCache: true,
     },
     tools: {
       rspack: {

--- a/web/src/components/layout/components/attention-bell.tsx
+++ b/web/src/components/layout/components/attention-bell.tsx
@@ -8,9 +8,11 @@
 // page that resolves it.
 //
 // The data source is the dashboard's existing attention query — same
-// `['dashboard-attention', 20]` key, same `api.getAttention(20)` wrapper and
-// the same 10s poll as the availability panel — so TanStack Query dedupes the
-// request and shares one cache entry instead of opening a second data source.
+// `['dashboard-attention', 20]` key, same `api.getAttention(20)` wrapper —
+// so TanStack Query dedupes the request and shares one cache entry instead of
+// opening a second data source. The poll is slower than the availability
+// panel's (15s vs 10s): the header badge tolerates lag, and while the panel is
+// open its 10s poll keeps the shared entry fresh anyway.
 
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link, useNavigate } from '@tanstack/react-router'
@@ -34,8 +36,8 @@ import { cn } from '@/lib/utils'
 
 /** Matches the dashboard attention query so the cache entry is shared. */
 const ATTENTION_LIMIT = 20
-/** Same cadence as the availability panel — no more aggressive polling. */
-const ATTENTION_REFETCH_INTERVAL_MS = 10 * 1000
+/** Slower than the availability panel's 10s poll — the badge tolerates lag. */
+const ATTENTION_REFETCH_INTERVAL_MS = 15 * 1000
 /** Counts above this render as "9+" so the badge never widens the trigger. */
 const BADGE_COUNT_CEILING = 9
 /** The popover is a peek surface; "view all" leads to the full panel. */

--- a/web/src/features/dashboard/components/charts.tsx
+++ b/web/src/features/dashboard/components/charts.tsx
@@ -87,29 +87,37 @@ function parseDayLabel(value: string | number): Date | null {
 function useDateTickFormatter(): (value: string | number) => string {
   const { i18n } = useTranslation()
   const locale = toBcp47(i18n.language || 'en')
-  return (value) => {
-    const date = parseDayLabel(value)
-    if (!date) return String(value)
-    return new Intl.DateTimeFormat(locale, {
+  // Intl.DateTimeFormat construction is expensive; memoize per locale so the
+  // axis re-render only reuses the formatter instead of re-parsing options.
+  return useMemo(() => {
+    const formatter = new Intl.DateTimeFormat(locale, {
       month: 'short',
       day: 'numeric',
-    }).format(date)
-  }
+    })
+    return (value: string | number): string => {
+      const date = parseDayLabel(value)
+      if (!date) return String(value)
+      return formatter.format(date)
+    }
+  }, [locale])
 }
 
 /** Hook returning a locale-aware "Aug 21, 2026" formatter for tooltip headers. */
 function useDateTooltipFormatter(): (value: string | number) => string {
   const { i18n } = useTranslation()
   const locale = toBcp47(i18n.language || 'en')
-  return (value) => {
-    const date = parseDayLabel(value)
-    if (!date) return String(value)
-    return new Intl.DateTimeFormat(locale, {
+  return useMemo(() => {
+    const formatter = new Intl.DateTimeFormat(locale, {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
-    }).format(date)
-  }
+    })
+    return (value: string | number): string => {
+      const date = parseDayLabel(value)
+      if (!date) return String(value)
+      return formatter.format(date)
+    }
+  }, [locale])
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #1029（批 D）

前端审计快赢批 D：5 项构建/性能小修，全部带实测数据。

## 改动

- rsbuild.config.ts: 新增 `vendor-recharts` cacheGroup（test: `recharts|d3-.*|victory-vendor`，enforce），recharts 3.x + victory-vendor 从路由 chunk 拆为独立 async chunk，路由更新不再连带重下图表库
- rsbuild.config.ts: `pluginTailwindcss({ optimize: true })` A/B 实测无收益，保留 `false` 并在配置内留注释说明
- rsbuild.config.ts: 开启 `buildCache: true`（冷/热两次构建产物字节级一致，见下）
- attention-bell.tsx: 轮询 10s → 15s（header badge 容忍滞后；availability panel 打开时其 10s 轮询仍刷新共享缓存条目）
- charts.tsx: `useDateTickFormatter` / `useDateTooltipFormatter` 按 locale 用 `useMemo` 记忆化 `Intl.DateTimeFormat` 实例

## 构建体积实测（bun run build）

| 指标 | 基线（master 6ad786f） | 本 PR | 变化 |
|---|---|---|---|
| 总 raw | 3272.1 kB | 3270.9 kB | -1.2 kB |
| 总 gzip | 1187.0 kB | 1184.3 kB | -2.7 kB |
| CSS（index.*.css） | 179,325 B | 179,325 B | 不变 |
| vendor-recharts chunk | 无（混在 2829.*.js 340 kB） | 378.8 kB raw / 100.4 kB gzip 独立 async chunk | 拆分 |

## optimize A/B 结论

`optimize: true` 使 CSS 179,325 B → 182,456 B（+3.1 kB raw / +0.8 kB gzip）：rsbuild 默认 minify 已用 lightningcss，plugin 的 optimize 只对 Tailwind 输出重复优化一轮且重排变量声明，无收益。保留 `false`。

## buildCache 结论

- 冷构建 6.05s vs 热构建 5.97s
- 两次构建产物（静态图片除外全文件 md5 聚合哈希）均为 `5dd08a72426c864a88eab9d127d04dba`，字节级一致 → 保留 `true`
- 缓存目录 node_modules/.cache/rspack（~94 MB），已被 gitignore；CI 全新环境不受益也不受影响，收益在本地增量重建

## 验证

- `tsgo -b` typecheck 通过
- vitest 全量 197 文件 / 1319 用例通过
- 触及面测试（attention-bell + dashboard）15 文件 / 86 用例通过
- oxlint 无新增告警；`oxfmt --check` 通过