### PR TITLE
fix(security): externalize inline bootstrap scripts and drop CSP unsafe-inline

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -258,6 +258,28 @@ func setupSPAFallback(r chi.Router, distFS fs.FS) {
 		})))
 	}
 
+	// Bootstrap scripts (web/public/bootstrap.js, theme-init.js) copied into
+	// the dist root. They must resolve to a real JS content type — otherwise
+	// the SPA fallback answers 200 text/html and nosniff browsers refuse to
+	// execute them (the same failure mode as rootFiles above). Unlike the
+	// /static/* assets their names are NOT content-hashed, so they must NOT
+	// get the immutable cache header: no-cache keeps deploys propagating to
+	// already-visited clients without a hard refresh.
+	rootScripts := []string{"bootstrap.js", "theme-init.js"}
+	for _, name := range rootScripts {
+		fileName := name
+		r.Get("/"+fileName, withGzip(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			data, err := fs.ReadFile(distFS, fileName)
+			if err != nil {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "text/javascript; charset=utf-8")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Write(data)
+		})))
+	}
+
 	// SPA fallback: non-API paths → index.html; API → 404 JSON
 	r.NotFound(withGzip(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/api/") || strings.HasPrefix(r.URL.Path, "/v1/") {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -58,7 +58,7 @@ func assertSecurityHeaders(t *testing.T, rec *httptest.ResponseRecorder) {
 		"X-Frame-Options":         "DENY",
 		"Referrer-Policy":         "strict-origin-when-cross-origin",
 		"Permissions-Policy":      "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
-		"Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://api.dicebear.com; connect-src 'self'; frame-src 'self' https://check.linux.do; frame-ancestors 'none'",
+		"Content-Security-Policy": "default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://api.dicebear.com; connect-src 'self'; frame-src 'self' https://check.linux.do; frame-ancestors 'none'",
 	}
 	for header, want := range expected {
 		if got := rec.Header().Get(header); got != want {
@@ -279,6 +279,8 @@ func TestRootPublicFilesServedBeforeSPAFallback(t *testing.T) {
 		{name: "/favicon-64.png", wantCT: "image/png"},
 		{name: "/logo.svg", wantCT: "image/svg+xml"},
 		{name: "/favicon.svg", wantCT: "image/svg+xml"},
+		{name: "/bootstrap.js", wantCT: "text/javascript; charset=utf-8"},
+		{name: "/theme-init.js", wantCT: "text/javascript; charset=utf-8"},
 	}
 	for _, tc := range cases {
 		rec := httptest.NewRecorder()

--- a/router/security.go
+++ b/router/security.go
@@ -10,7 +10,7 @@ func SecurityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=(), usb=()")
-		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://api.dicebear.com; connect-src 'self'; frame-src 'self' https://check.linux.do; frame-ancestors 'none'")
+		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://api.dicebear.com; connect-src 'self'; frame-src 'self' https://check.linux.do; frame-ancestors 'none'")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/web/index.html
+++ b/web/index.html
@@ -19,109 +19,34 @@
 
     <!--
       FOUC bootstrap: resolve theme BEFORE first paint to avoid flash.
-      Cookie-based (vite-ui-theme, 1y) to align with newapi next-themes cookie
-      storage; falls back to system preference. Legacy themeBootstrap.ts removed.
+      The script lives in web/public/bootstrap.js and is loaded synchronously
+      (no defer/async) so it runs before the first frame — the same timing as
+      the former inline script, but as a static asset so the CSP can drop
+      'unsafe-inline' for scripts. Cookie-based (vite-ui-theme, 1y) to align
+      with newapi next-themes cookie storage; falls back to system preference.
+      Legacy themeBootstrap.ts removed.
       Tailwind 4 dark mode is class-based: <html class="dark"> / class="light".
     -->
-    <script>
-      ;(function () {
-        try {
-          var COOKIE_NAME = 'vite-ui-theme'
-          var theme = null
-          // Read theme from cookie (matches next-themes cookieStorage convention)
-          var match = document.cookie.match(
-            '(?:^|; )' + COOKIE_NAME + '=([^;]*)'
-          )
-          var stored = match ? decodeURIComponent(match[1]) : ''
-          if (stored === 'light' || stored === 'dark') {
-            theme = stored
-          } else if (stored === 'system' || !stored) {
-            theme = window.matchMedia('(prefers-color-scheme: dark)').matches
-              ? 'dark'
-              : 'light'
-          }
-          var root = document.documentElement
-          root.classList.remove('light', 'dark')
-          root.classList.add(theme)
-          root.style.colorScheme = theme
-          // Use the design token as soon as CSS is available, with a matching
-          // light/dark fallback before the stylesheet finishes loading.
-          var bg = theme === 'dark' ? '#1d1d1d' : '#ffffff'
-          root.style.setProperty('--bootstrap-background', bg)
-          root.style.backgroundColor =
-            'var(--background, var(--bootstrap-background))'
-          var themeColor = document.querySelector('meta[name="theme-color"]')
-          if (themeColor) themeColor.setAttribute('content', bg)
-        } catch (e) {
-          /* cookie / matchMedia unavailable — leave browser defaults */
-        }
-      })()
-    </script>
-    <!-- Fonts are bundled locally — no Google Fonts CDN. -->
+    <script src="/bootstrap.js"></script>
+    <!-- Fonts are bundled locally — no Google Fonts CDN. Preload the latin
+         Public Sans face (the UI default) so first paint skips the font
+         discovery round-trip. Path matches the content-hashed asset emitted
+         by Rsbuild into /static/font/. -->
+    <link
+      rel="preload"
+      href="/static/font/public-sans-latin-wght-normal.035c7fe496.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
   </head>
 
   <body translate="no" class="notranslate min-h-screen">
-    <script>
-      ;(function () {
-        try {
-          function readCookie(name) {
-            var match = document.cookie.match('(?:^|; )' + name + '=([^;]*)')
-            return match ? decodeURIComponent(match[1]) : ''
-          }
-
-          var body = document.body
-          var preset = readCookie('theme_preset')
-          var presets = [
-            'anthropic',
-            'simple-large',
-            'underground',
-            'rose-garden',
-            'lake-view',
-            'sunset-glow',
-            'forest-whisper',
-            'ocean-breeze',
-            'lavender-dream',
-          ]
-          if (presets.indexOf(preset) !== -1) {
-            body.setAttribute('data-theme-preset', preset)
-          }
-
-          var font = readCookie('theme_font')
-          body.setAttribute(
-            'data-theme-font',
-            font === 'serif' ? 'serif' : 'sans'
-          )
-
-          var radius = readCookie('theme_radius')
-          if (['none', 'sm', 'md', 'lg', 'xl'].indexOf(radius) !== -1) {
-            body.setAttribute('data-theme-radius', radius)
-          }
-
-          var scale = readCookie('theme_scale')
-          if (['sm', 'lg', 'xl'].indexOf(scale) !== -1) {
-            body.setAttribute('data-theme-scale', scale)
-          }
-
-          var contentLayout = readCookie('theme_content_layout')
-          body.setAttribute(
-            'data-theme-content-layout',
-            contentLayout === 'centered' ? 'centered' : 'full'
-          )
-
-          window.requestAnimationFrame(function () {
-            var background = getComputedStyle(body)
-              .getPropertyValue('--background')
-              .trim()
-            var themeColor = document.querySelector('meta[name="theme-color"]')
-            if (background && themeColor) {
-              themeColor.setAttribute('content', background)
-            }
-          })
-        } catch (e) {
-          /* cookie access unavailable — providers apply defaults after boot */
-        }
-      })()
-    </script>
+    <!-- Theme customization bootstrap (web/public/theme-init.js): apply
+         cookie-backed preset/font/radius/scale as body data attributes before
+         React mounts. Synchronous (no defer/async), same timing as the former
+         inline script. -->
+    <script src="/theme-init.js"></script>
     <div id="root"></div>
   </body>
 </html>

--- a/web/knip.config.ts
+++ b/web/knip.config.ts
@@ -5,6 +5,12 @@ const config: KnipConfig = {
     // Type declaration files for JS modules under shared/ — knip cannot trace
     // .d.ts consumers via the .js import path, so these show as unused files.
     'shared/**/*.d.ts',
+    // index.html loads these bootstrap entry scripts through synchronous
+    // <script src> tags (FOUC theme bootstrap + body data-attribute
+    // hydration). knip only traces import graphs, so it flags them as unused
+    // files even though the HTML references them directly.
+    'public/bootstrap.js',
+    'public/theme-init.js',
     // One-off probes archived under web/scripts/oneoff/ — kept for reference
     // with no package.json entry and no importer, so knip would (correctly)
     // flag them as unused. The live inventory lives in

--- a/web/public/bootstrap.js
+++ b/web/public/bootstrap.js
@@ -1,0 +1,38 @@
+// FOUC bootstrap: resolve theme BEFORE first paint to avoid flash.
+// Loaded synchronously from index.html <head> (no defer/async) so it runs
+// before the first frame, exactly like the former inline script. Must stay
+// dependency-free: it executes before any bundled module loads.
+//
+// Cookie-based (vite-ui-theme, 1y) to align with newapi next-themes cookie
+// storage; falls back to system preference. Legacy themeBootstrap.ts removed.
+// Tailwind 4 dark mode is class-based: <html class="dark"> / class="light".
+;(function () {
+  try {
+    const COOKIE_NAME = 'vite-ui-theme'
+    let theme = null
+    // Read theme from cookie (matches next-themes cookieStorage convention)
+    const match = document.cookie.match('(?:^|; )' + COOKIE_NAME + '=([^;]*)')
+    const stored = match ? decodeURIComponent(match[1]) : ''
+    if (stored === 'light' || stored === 'dark') {
+      theme = stored
+    } else if (stored === 'system' || !stored) {
+      theme = window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light'
+    }
+    const root = document.documentElement
+    root.classList.remove('light', 'dark')
+    root.classList.add(theme)
+    root.style.colorScheme = theme
+    // Use the design token as soon as CSS is available, with a matching
+    // light/dark fallback before the stylesheet finishes loading.
+    const bg = theme === 'dark' ? '#1d1d1d' : '#ffffff'
+    root.style.setProperty('--bootstrap-background', bg)
+    root.style.backgroundColor =
+      'var(--background, var(--bootstrap-background))'
+    const themeColor = document.querySelector('meta[name="theme-color"]')
+    if (themeColor) themeColor.setAttribute('content', bg)
+  } catch {
+    /* cookie / matchMedia unavailable — leave browser defaults */
+  }
+})()

--- a/web/public/bootstrap.js
+++ b/web/public/bootstrap.js
@@ -11,7 +11,7 @@
     const COOKIE_NAME = 'vite-ui-theme'
     let theme = null
     // Read theme from cookie (matches next-themes cookieStorage convention)
-    const match = document.cookie.match('(?:^|; )' + COOKIE_NAME + '=([^;]*)')
+    const match = document.cookie.match(`(?:^|; )${COOKIE_NAME}=([^;]*)`)
     const stored = match ? decodeURIComponent(match[1]) : ''
     if (stored === 'light' || stored === 'dark') {
       theme = stored

--- a/web/public/theme-init.js
+++ b/web/public/theme-init.js
@@ -6,7 +6,7 @@
 ;(function () {
   try {
     function readCookie(name) {
-      const match = document.cookie.match('(?:^|; )' + name + '=([^;]*)')
+      const match = document.cookie.match(`(?:^|; )${name}=([^;]*)`)
       return match ? decodeURIComponent(match[1]) : ''
     }
 
@@ -23,7 +23,7 @@
       'ocean-breeze',
       'lavender-dream',
     ]
-    if (presets.indexOf(preset) !== -1) {
+    if (presets.includes(preset)) {
       body.setAttribute('data-theme-preset', preset)
     }
 
@@ -31,12 +31,12 @@
     body.setAttribute('data-theme-font', font === 'serif' ? 'serif' : 'sans')
 
     const radius = readCookie('theme_radius')
-    if (['none', 'sm', 'md', 'lg', 'xl'].indexOf(radius) !== -1) {
+    if (['none', 'sm', 'md', 'lg', 'xl'].includes(radius)) {
       body.setAttribute('data-theme-radius', radius)
     }
 
     const scale = readCookie('theme_scale')
-    if (['sm', 'lg', 'xl'].indexOf(scale) !== -1) {
+    if (['sm', 'lg', 'xl'].includes(scale)) {
       body.setAttribute('data-theme-scale', scale)
     }
 

--- a/web/public/theme-init.js
+++ b/web/public/theme-init.js
@@ -1,0 +1,61 @@
+// Theme customization bootstrap: apply cookie-backed preset/font/radius/scale
+// as body data attributes before React mounts, so the first render already
+// carries the user's customization (no post-mount reflow). Loaded
+// synchronously from index.html <body> (no defer/async), exactly like the
+// former inline script, so document.body is available when it runs.
+;(function () {
+  try {
+    function readCookie(name) {
+      const match = document.cookie.match('(?:^|; )' + name + '=([^;]*)')
+      return match ? decodeURIComponent(match[1]) : ''
+    }
+
+    const body = document.body
+    const preset = readCookie('theme_preset')
+    const presets = [
+      'anthropic',
+      'simple-large',
+      'underground',
+      'rose-garden',
+      'lake-view',
+      'sunset-glow',
+      'forest-whisper',
+      'ocean-breeze',
+      'lavender-dream',
+    ]
+    if (presets.indexOf(preset) !== -1) {
+      body.setAttribute('data-theme-preset', preset)
+    }
+
+    const font = readCookie('theme_font')
+    body.setAttribute('data-theme-font', font === 'serif' ? 'serif' : 'sans')
+
+    const radius = readCookie('theme_radius')
+    if (['none', 'sm', 'md', 'lg', 'xl'].indexOf(radius) !== -1) {
+      body.setAttribute('data-theme-radius', radius)
+    }
+
+    const scale = readCookie('theme_scale')
+    if (['sm', 'lg', 'xl'].indexOf(scale) !== -1) {
+      body.setAttribute('data-theme-scale', scale)
+    }
+
+    const contentLayout = readCookie('theme_content_layout')
+    body.setAttribute(
+      'data-theme-content-layout',
+      contentLayout === 'centered' ? 'centered' : 'full'
+    )
+
+    window.requestAnimationFrame(function () {
+      const background = getComputedStyle(body)
+        .getPropertyValue('--background')
+        .trim()
+      const themeColor = document.querySelector('meta[name="theme-color"]')
+      if (background && themeColor) {
+        themeColor.setAttribute('content', background)
+      }
+    })
+  } catch {
+    /* cookie access unavailable — providers apply defaults after boot */
+  }
+})()

--- a/web/scripts/a11y-scan.mjs
+++ b/web/scripts/a11y-scan.mjs
@@ -69,7 +69,12 @@ async function scanLocale(locale) {
       .goto(BASE_URL + path, { waitUntil: 'networkidle' })
       .catch(() => {})
     await page.waitForTimeout(500)
-    await page.addScriptTag({ path: AXE_SOURCE })
+    // CSP script-src is 'self' (no 'unsafe-inline') since #1033, so an inline
+    // <script> injection via addScriptTag is blocked by the browser. Execute
+    // the axe bundle through page.evaluate instead — CDP Runtime.evaluate is
+    // not subject to the page CSP — which leaves window.axe available
+    // regardless.
+    await page.evaluate(readFileSync(AXE_SOURCE, 'utf-8'))
     const violations = await page.evaluate(async () => {
       const result = await window.axe.run(document, {
         resultTypes: ['violations'],

--- a/web/src/lib/__tests__/theme-bootstrap-parity.test.ts
+++ b/web/src/lib/__tests__/theme-bootstrap-parity.test.ts
@@ -1,10 +1,10 @@
-// metapi-go/lib — index.html theme bootstrap parity guard.
+// metapi-go/lib — theme bootstrap preset whitelist parity guard.
 //
-// The FOUC bootstrap script in index.html carries its own hardcoded copy of
-// the preset whitelist (it must run before any bundled module loads, so it
-// cannot import the TS constants). This test fails when the two lists drift:
-// every non-default preset in lib/theme-customization.ts must appear in the
-// bootstrap list and vice versa.
+// The theme bootstrap script (web/public/theme-init.js) carries its own
+// hardcoded copy of the preset whitelist (it must run before any bundled
+// module loads, so it cannot import the TS constants). This test fails when
+// the two lists drift: every non-default preset in lib/theme-customization.ts
+// must appear in the bootstrap list and vice versa.
 
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -14,19 +14,19 @@ import { describe, expect, it } from 'vitest'
 import { THEME_PRESETS, THEME_PRESET_VALUES } from '../theme-customization'
 
 // Tests always run from the web/ project root (`bun run test`).
-const INDEX_HTML_PATH = resolve(process.cwd(), 'index.html')
+const THEME_INIT_PATH = resolve(process.cwd(), 'public/theme-init.js')
 
-function extractBootstrapPresetList(html: string): string[] {
-  const listMatch = html.match(/var presets = \[([\s\S]*?)\]/)
+function extractBootstrapPresetList(script: string): string[] {
+  const listMatch = script.match(/const presets = \[([\s\S]*?)\]/)
   if (!listMatch) {
-    throw new Error('preset whitelist not found in index.html bootstrap')
+    throw new Error('preset whitelist not found in public/theme-init.js')
   }
   return [...listMatch[1].matchAll(/'([^']+)'/g)].map((match) => match[1])
 }
 
-describe('index.html theme bootstrap preset whitelist', () => {
-  const html = readFileSync(INDEX_HTML_PATH, 'utf-8')
-  const bootstrapPresets = extractBootstrapPresetList(html)
+describe('theme-init.js bootstrap preset whitelist', () => {
+  const script = readFileSync(THEME_INIT_PATH, 'utf-8')
+  const bootstrapPresets = extractBootstrapPresetList(script)
 
   it('lists each preset exactly once', () => {
     expect(bootstrapPresets.length).toBeGreaterThan(0)

--- a/web/src/styles/__tests__/fouc-bootstrap.test.ts
+++ b/web/src/styles/__tests__/fouc-bootstrap.test.ts
@@ -1,9 +1,9 @@
 // metapi-go FOUC bootstrap alignment gate.
-// index.html ships inline bootstrap scripts that set `data-theme-*` attributes
-// before first paint. The hardcoded allowlists in those scripts must stay in
-// sync with the theme constants (`THEME_PRESETS` / radius / scale) — a new
-// value added to the constants but forgotten here would flash the default
-// theme for one frame before React mounts.
+// public/theme-init.js (loaded synchronously from index.html) sets
+// `data-theme-*` attributes before first paint. The hardcoded allowlists in
+// that script must stay in sync with the theme constants (`THEME_PRESETS` /
+// radius / scale) — a new value added to the constants but forgotten here
+// would flash the default theme for one frame before React mounts.
 
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
@@ -18,11 +18,11 @@ import {
 } from '../../lib/theme-customization'
 
 const WEB_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
-const indexHtml = readFileSync(join(WEB_ROOT, 'index.html'), 'utf8')
+const themeInit = readFileSync(join(WEB_ROOT, 'public/theme-init.js'), 'utf8')
 
 /** Extract the string literals of the first capture group of `regex`. */
 function extractStringList(regex: RegExp): string[] {
-  const match = indexHtml.match(regex)
+  const match = themeInit.match(regex)
   expect(match).toBeTruthy()
   const body = match?.[1] ?? ''
   return [...body.matchAll(/'([^']+)'/g)].map((m) => m[1])
@@ -32,7 +32,7 @@ const isNotDefault = (value: string) => value !== 'default'
 
 describe('FOUC bootstrap ↔ theme constants', () => {
   it('preset allowlist matches THEME_PRESETS minus the default preset', () => {
-    const bootstrapPresets = extractStringList(/var presets = \[([\s\S]*?)\]/)
+    const bootstrapPresets = extractStringList(/const presets = \[([\s\S]*?)\]/)
     const expected = THEME_PRESETS.map((p) => p.value).filter(isNotDefault)
     expect(bootstrapPresets).toEqual(expected)
   })

--- a/web/src/styles/__tests__/fouc-bootstrap.test.ts
+++ b/web/src/styles/__tests__/fouc-bootstrap.test.ts
@@ -39,7 +39,7 @@ describe('FOUC bootstrap ↔ theme constants', () => {
 
   it('radius allowlist matches THEME_RADIUS_VALUES minus default', () => {
     const bootstrapRadii = extractStringList(
-      /\[('none'[^\]]*)\]\.indexOf\(radius\)/
+      /\[('none'[^\]]*)\]\.includes\(radius\)/
     )
     const expected = [...THEME_RADIUS_VALUES].filter(isNotDefault)
     expect(bootstrapRadii).toEqual(expected)
@@ -47,7 +47,7 @@ describe('FOUC bootstrap ↔ theme constants', () => {
 
   it('scale allowlist matches THEME_SCALE_VALUES minus default', () => {
     const bootstrapScales = extractStringList(
-      /\[('sm'[^\]]*)\]\.indexOf\(scale\)/
+      /\[('sm'[^\]]*)\]\.includes\(scale\)/
     )
     const expected = [...THEME_SCALE_VALUES].filter(isNotDefault)
     expect(bootstrapScales).toEqual(expected)

--- a/web/src/styles/__tests__/typography-contract.test.ts
+++ b/web/src/styles/__tests__/typography-contract.test.ts
@@ -40,10 +40,15 @@ describe('typography design contract', () => {
   })
 
   it('hydrates persisted visual axes before the app mounts', () => {
-    const html = read('index.html')
+    const script = read('public/theme-init.js')
 
-    expect(html).toContain("readCookie('theme_preset')")
-    expect(html).toContain("readCookie('theme_font')")
-    expect(html).toContain("'var(--background, var(--bootstrap-background))'")
+    expect(script).toContain("readCookie('theme_preset')")
+    expect(script).toContain("readCookie('theme_font')")
+  })
+
+  it('paints the boot background through the design token with a fallback', () => {
+    const script = read('public/bootstrap.js')
+
+    expect(script).toContain("'var(--background, var(--bootstrap-background))'")
   })
 })


### PR DESCRIPTION
Fixes #1033

## 改动

- 两段内联引导脚本外链化为 `web/public/bootstrap.js`（head，防 FOUC）与 `web/public/theme-init.js`（body，主题定制属性），index.html 改为同步 `<script src>` 引用——首帧前执行时序与原内联完全一致
- CSP `script-src` 去掉 `'unsafe-inline'`（`style-src` 因 Tailwind 保持现状；`https://static.cloudflareinsights.com` 保留）
- router 为两个脚本新增显式路由：`text/javascript; charset=utf-8` + `no-cache`（文件名无 content hash，不能复用 rootFiles 的 immutable 缓存，否则部署无法及时传播）
- 顺带完成批 D preload 项：`public-sans-latin` woff2 加 `<link rel="preload" as="font" crossorigin>`（路径对齐 dist 产物 `/static/font/public-sans-latin-wght-normal.035c7fe496.woff2`）
- 同步测试：CSP 头断言、root 静态文件 case、三个主题引导契约测试改读 `web/public/theme-init.js` / `bootstrap.js`

两段脚本不依赖 rsbuild define（无 METAPI_WEB_VERSION 等构建常量），外链化无构建期替换问题；脚本内容经 oxfmt 后 `var`→`const/let`、`catch (e)`→`catch {}`（现代浏览器目标下行为等价）。

## 验证

**实测（Playwright 4 场景 11/11 通过）**
1. 无 cookie + 浅色系统偏好 → system 回退 `html.light` + 背景 token ✓
2. dark + 全套定制 cookie（系统仍浅色）→ **DOMContentLoaded 时** `html.dark`、背景 token、`data-theme-preset/font/radius/scale/layout` 全部就位（首帧前无闪）✓；React 挂载后仍 dark ✓
3. UI 主题切换：Customize appearance 面板切 Dark→`html.dark`+cookie `vite-ui-theme=dark`，切 Light→`html.light`+cookie 同步 ✓
4. 刷新后 cookie 主题保持，全程 console 无 CSP 违规 ✓

**响应头（curl 实测）**
- `Content-Security-Policy: ... script-src 'self' https://static.cloudflareinsights.com; ...`（无 unsafe-inline）
- `/bootstrap.js`、`/theme-init.js` → 200 `text/javascript; charset=utf-8` + `no-cache`

**CI**
- `go build ./cmd/server` / `go vet ./...` / `go test ./router/... ./handler/... -count=1` 全绿
- 全量 `go test ./... -race`：仅 `store.TestProbeSQLiteWritableNonWritableDir` 失败——master 基线同样失败（Windows 非可写目录探测语义），与本次改动无关，Linux CI 不受影响
- web：vitest 197 文件 1320 测试全绿；oxlint / tsgo typecheck / oxfmt format:check 全绿