### PR TITLE
fix(web): keyboard-accessible catalog source ordering

### DIFF
--- a/web/src/features/settings/sections/proxy-models/components/__tests__/catalog-sources-section.test.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/__tests__/catalog-sources-section.test.tsx
@@ -1,0 +1,254 @@
+// Behavior tests for the catalog-sources keyboard reorder alternative
+// (#1032): the row drag handle must be operable without a pointer — Enter or
+// Space grabs, ArrowUp/ArrowDown move the drop highlight, Space/Enter drops
+// (committing an absolute sortOrder through the existing PUT endpoint), and
+// Escape (or focus loss) cancels without mutating.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import type { ReactElement } from 'react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+
+import { CatalogSourcesSection } from '../catalog-sources-section'
+
+const {
+  mockGetCatalogSync,
+  mockUpdateCatalogSource,
+  mockSyncCatalog,
+  mockUpdateCatalogSyncConfig,
+  mockCreateCatalogSource,
+  mockDeleteCatalogSource,
+} = vi.hoisted(() => ({
+  mockGetCatalogSync: vi.fn(),
+  mockUpdateCatalogSource: vi.fn(),
+  mockSyncCatalog: vi.fn(),
+  mockUpdateCatalogSyncConfig: vi.fn(),
+  mockCreateCatalogSource: vi.fn(),
+  mockDeleteCatalogSource: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getCatalogSync: mockGetCatalogSync,
+    updateCatalogSource: mockUpdateCatalogSource,
+    syncCatalog: mockSyncCatalog,
+    updateCatalogSyncConfig: mockUpdateCatalogSyncConfig,
+    createCatalogSource: mockCreateCatalogSource,
+    deleteCatalogSource: mockDeleteCatalogSource,
+  },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+function makeSource(
+  id: number,
+  name: string,
+  sortOrder: number,
+  type: 'official' | 'custom' = 'official'
+) {
+  return {
+    id,
+    name,
+    url: `https://${name.toLowerCase().replaceAll(' ', '-')}.example.com/all.json`,
+    enabled: true,
+    type,
+    sortOrder,
+    lastSuccessAt: null,
+    lastError: null,
+    lastCount: 0,
+    lastAttemptAt: null,
+  }
+}
+
+beforeEach(() => {
+  mockGetCatalogSync.mockReset()
+  mockUpdateCatalogSource.mockReset()
+  mockSyncCatalog.mockReset()
+  mockUpdateCatalogSyncConfig.mockReset()
+  mockCreateCatalogSource.mockReset()
+  mockDeleteCatalogSource.mockReset()
+  mockGetCatalogSync.mockResolvedValue({
+    autoSync: true,
+    intervalMin: 720,
+    snapshot: { source: 'Mirror A', fetchedAt: null, models: 0 },
+    sources: [
+      makeSource(1, 'Mirror A', 0),
+      makeSource(2, 'Mirror B', 1, 'custom'),
+      makeSource(3, 'Mirror C', 2),
+    ],
+  })
+  mockUpdateCatalogSource.mockResolvedValue({
+    source: makeSource(1, 'Mirror A', 1),
+  })
+})
+
+afterEach(() => cleanup())
+
+function renderSection() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return render(
+    (
+      <QueryClientProvider client={queryClient}>
+        <CatalogSourcesSection />
+      </QueryClientProvider>
+    ) as ReactElement
+  )
+}
+
+async function findHandle(name: string) {
+  // The name may appear both in the merged-snapshot summary and the row.
+  await screen.findAllByText(name)
+  return screen.getByRole('button', { name: `Reorder ${name}` })
+}
+
+describe('CatalogSourcesSection keyboard reorder', () => {
+  it('exposes the keyboard pattern to assistive tech', async () => {
+    renderSection()
+    const handle = await findHandle('Mirror A')
+
+    expect(handle).toHaveAttribute(
+      'aria-keyshortcuts',
+      'Enter Space ArrowUp ArrowDown Escape'
+    )
+    expect(handle).toHaveAttribute('aria-pressed', 'false')
+    expect(handle).toHaveAttribute(
+      'aria-describedby',
+      'catalog-source-reorder-help'
+    )
+    expect(screen.getByText(/To reorder with the keyboard:/)).toBeTruthy()
+  })
+
+  it('Enter grabs, ArrowDown moves, Space drops the absolute index', async () => {
+    renderSection()
+    const handle = await findHandle('Mirror A')
+
+    fireEvent.keyDown(handle, { key: 'Enter' })
+    expect(handle).toHaveAttribute('aria-pressed', 'true')
+
+    fireEvent.keyDown(handle, { key: 'ArrowDown' })
+    fireEvent.keyDown(handle, { key: ' ' })
+
+    await waitFor(() => {
+      expect(mockUpdateCatalogSource).toHaveBeenCalledWith(1, {
+        sortOrder: 1,
+      })
+    })
+    expect(handle).toHaveAttribute('aria-pressed', 'false')
+
+    // Optimistic reorder: Mirror B now renders above Mirror A.
+    const rows = screen.getAllByRole('row')
+    expect(within(rows[1]).getByText('Mirror B')).toBeTruthy()
+    expect(within(rows[2]).getByText('Mirror A')).toBeTruthy()
+  })
+
+  it('Space also grabs and Enter also drops', async () => {
+    renderSection()
+    const handle = await findHandle('Mirror A')
+
+    fireEvent.keyDown(handle, { key: ' ' })
+    expect(handle).toHaveAttribute('aria-pressed', 'true')
+
+    fireEvent.keyDown(handle, { key: 'ArrowDown' })
+    fireEvent.keyDown(handle, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(mockUpdateCatalogSource).toHaveBeenCalledWith(1, {
+        sortOrder: 1,
+      })
+    })
+  })
+
+  it('ArrowUp on the first row clamps and drops nothing', async () => {
+    renderSection()
+    const handle = await findHandle('Mirror A')
+
+    fireEvent.keyDown(handle, { key: 'Enter' })
+    fireEvent.keyDown(handle, { key: 'ArrowUp' })
+    fireEvent.keyDown(handle, { key: ' ' })
+
+    expect(mockUpdateCatalogSource).not.toHaveBeenCalled()
+    expect(handle).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('ArrowDown on the last row clamps and drops nothing', async () => {
+    renderSection()
+    const handle = await findHandle('Mirror C')
+
+    fireEvent.keyDown(handle, { key: 'Enter' })
+    fireEvent.keyDown(handle, { key: 'ArrowDown' })
+    fireEvent.keyDown(handle, { key: ' ' })
+
+    expect(mockUpdateCatalogSource).not.toHaveBeenCalled()
+    expect(handle).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('Escape cancels the grab without committing', async () => {
+    renderSection()
+    const handle = await findHandle('Mirror A')
+
+    fireEvent.keyDown(handle, { key: 'Enter' })
+    fireEvent.keyDown(handle, { key: 'ArrowDown' })
+    fireEvent.keyDown(handle, { key: 'Escape' })
+
+    expect(mockUpdateCatalogSource).not.toHaveBeenCalled()
+    expect(handle).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('moving focus away cancels an active grab', async () => {
+    renderSection()
+    const handle = await findHandle('Mirror A')
+
+    fireEvent.keyDown(handle, { key: 'Enter' })
+    expect(handle).toHaveAttribute('aria-pressed', 'true')
+
+    fireEvent.blur(handle)
+
+    expect(mockUpdateCatalogSource).not.toHaveBeenCalled()
+    expect(handle).toHaveAttribute('aria-pressed', 'false')
+  })
+})

--- a/web/src/features/settings/sections/proxy-models/components/catalog-sources-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/catalog-sources-section.tsx
@@ -4,10 +4,12 @@
 // later ones), exposes per-source enable/URL edit/drag-reorder/delete +
 // "sync now", a global auto-sync toggle, and the merged-snapshot status.
 // Reorder is a pointer-drag on the row handle (Wave 9 Lane B: the retired
-// up/down arrow buttons); each drop writes the absolute target index through
-// PUT /api/models/catalog-sources/{id} { sortOrder } (the backend repositions
-// and renumbers contiguously). All mutations go through the
-// /api/models/catalog-sources + /api/models/catalog-sync admin endpoints.
+// up/down arrow buttons) with a keyboard alternative (Enter/Space grab, arrow
+// keys move, Space/Enter drop, Escape cancel); each drop writes the absolute
+// target index through PUT /api/models/catalog-sources/{id} { sortOrder }
+// (the backend repositions and renumbers contiguously). All mutations go
+// through the /api/models/catalog-sources + /api/models/catalog-sync admin
+// endpoints.
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
@@ -17,7 +19,12 @@ import {
   RefreshCw as RefreshCwIcon,
   Trash2 as Trash2Icon,
 } from 'lucide-react'
-import { useRef, useState, type PointerEvent as ReactPointerEvent } from 'react'
+import {
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ConfirmDialog } from '@/components/common/confirm-dialog'
@@ -113,14 +120,22 @@ export function CatalogSourcesSection() {
   const [deleteTarget, setDeleteTarget] = useState<CatalogSource | null>(null)
   const [syncingId, setSyncingId] = useState<number | 'all' | null>(null)
 
-  // --- pointer-drag reorder state (Wave 9 Lane B) ---
+  // --- reorder state (pointer drag Wave 9 Lane B + keyboard grab) ---
   // Declared with the other hooks — BEFORE the loading/error early returns —
-  // so the hook count stays stable across status states.
+  // so the hook count stays stable across status states. The keyboard path
+  // reuses the same visual/commit state machine: Enter/Space grabs, arrow
+  // keys move the drop highlight, Space/Enter drops, Escape cancels.
   const rowRefs = useRef<Array<HTMLTableRowElement | null>>([])
-  const dragState = useRef<{ index: number } | null>(null)
+  const dragState = useRef<{
+    index: number
+    mode: 'pointer' | 'keyboard'
+  } | null>(null)
   const overIndexRef = useRef<number | null>(null)
   const [dragIndex, setDragIndex] = useState<number | null>(null)
   const [overIndex, setOverIndex] = useState<number | null>(null)
+  const [keyboardGrabIndex, setKeyboardGrabIndex] = useState<number | null>(
+    null
+  )
 
   const statusQuery = useQuery<CatalogSyncStatus>({
     queryKey: catalogSyncKeys.status(),
@@ -285,11 +300,16 @@ export function CatalogSourcesSection() {
   const sources = status.sources ?? []
   const busy = syncingId !== null
 
-  // --- pointer-drag reorder helpers (Wave 9 Lane B) ---
-  // The row handle captures the pointer and tracks the row under the cursor;
-  // on release the drop index is committed as an absolute sortOrder. Storing
-  // the live target in a ref keeps the pointerup handler race-free even when
-  // the last pointermove and pointerup land in the same frame.
+  // --- reorder helpers ---
+  // Pointer path (Wave 9 Lane B): the row handle captures the pointer and
+  // tracks the row under the cursor; on release the drop index is committed
+  // as an absolute sortOrder. Storing the live target in a ref keeps the
+  // pointerup handler race-free even when the last pointermove and pointerup
+  // land in the same frame.
+  // Keyboard path (WCAG 2.1.1 alternative, APG keyboard-sortable pattern):
+  // Enter/Space grabs the focused handle, ArrowUp/ArrowDown move the drop
+  // highlight, Space/Enter drops, Escape cancels. The same endDrag() commit
+  // finishes both paths.
   function findRowIndexAt(clientY: number): number {
     const rows = rowRefs.current
     for (let i = 0; i < rows.length; i++) {
@@ -305,7 +325,16 @@ export function CatalogSourcesSection() {
     index: number
   ) {
     if (busy || reorderMutation.isPending) return
-    dragState.current = { index }
+    // A pointer drag takes over from an active keyboard grab; clear the
+    // keyboard-specific visual state so a click-without-move cannot commit
+    // the stale keyboard target.
+    if (dragState.current?.mode === 'keyboard') {
+      setKeyboardGrabIndex(null)
+      setDragIndex(null)
+      setOverIndex(null)
+      overIndexRef.current = null
+    }
+    dragState.current = { index, mode: 'pointer' }
     event.currentTarget.setPointerCapture(event.pointerId)
   }
 
@@ -320,12 +349,60 @@ export function CatalogSourcesSection() {
     overIndexRef.current = next
   }
 
-  function onDragHandlePointerEnd(commit: boolean) {
+  function onDragHandleKeyDown(
+    event: ReactKeyboardEvent<HTMLButtonElement>,
+    index: number
+  ) {
+    const state = dragState.current
+    const inKeyboardGrab = state?.mode === 'keyboard'
+    if (!inKeyboardGrab) {
+      if (event.key === ' ' || event.key === 'Enter') {
+        event.preventDefault()
+        dragState.current = { index, mode: 'keyboard' }
+        setKeyboardGrabIndex(index)
+        setDragIndex(index)
+        setOverIndex(index)
+        overIndexRef.current = index
+      }
+      return
+    }
+    // Grab in progress: the focused handle owns the interaction. Move only
+    // the drop highlight; the row order commits once on drop.
+    const pos = overIndexRef.current
+    if (pos === null) return
+    event.preventDefault()
+    switch (event.key) {
+      case 'ArrowDown': {
+        const next = Math.min(pos + 1, sources.length - 1)
+        overIndexRef.current = next
+        setOverIndex(next)
+        break
+      }
+      case 'ArrowUp': {
+        const next = Math.max(pos - 1, 0)
+        overIndexRef.current = next
+        setOverIndex(next)
+        break
+      }
+      case ' ':
+      case 'Enter':
+        endDrag(true)
+        break
+      case 'Escape':
+        endDrag(false)
+        break
+      default:
+        break
+    }
+  }
+
+  function endDrag(commit: boolean) {
     const state = dragState.current
     if (!state) return
     dragState.current = null
     setDragIndex(null)
     setOverIndex(null)
+    setKeyboardGrabIndex(null)
     const targetIndex = overIndexRef.current
     overIndexRef.current = null
     if (commit && targetIndex !== null && targetIndex !== state.index) {
@@ -425,152 +502,175 @@ export function CatalogSourcesSection() {
               {t('settings.proxyModels.catalogSources.toast.disabled')}
             </p>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  {/* Drag-handle column (reorder, Wave 9 Lane B). */}
-                  <TableHead className='w-7' />
-                  <TableHead>
-                    {t('settings.proxyModels.catalogSources.columns.source')}
-                  </TableHead>
-                  <TableHead>
-                    {t('settings.proxyModels.catalogSources.columns.type')}
-                  </TableHead>
-                  <TableHead>
-                    {t('settings.proxyModels.catalogSources.columns.url')}
-                  </TableHead>
-                  <TableHead>
-                    {t('settings.proxyModels.catalogSources.columns.enabled')}
-                  </TableHead>
-                  <TableHead>
-                    {t('settings.proxyModels.catalogSources.columns.lastSync')}
-                  </TableHead>
-                  <TableHead className='text-right'>
-                    {t('settings.proxyModels.catalogSources.columns.actions')}
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {sources.map((source, index) => (
-                  <TableRow
-                    key={source.id}
-                    ref={(row) => {
-                      rowRefs.current[index] = row
-                    }}
-                    className={cn(
-                      dragIndex !== null &&
-                        overIndex === index &&
-                        'bg-accent/60',
-                      dragIndex === index && 'opacity-40'
-                    )}
-                  >
-                    <TableCell className='w-7 px-0'>
-                      <Button
-                        type='button'
-                        variant='ghost'
-                        size='icon-sm'
-                        className={cn(
-                          'cursor-grab touch-none select-none',
-                          dragIndex === index && 'cursor-grabbing'
-                        )}
-                        disabled={busy || reorderMutation.isPending}
-                        onPointerDown={(event) =>
-                          onDragHandlePointerDown(event, index)
-                        }
-                        onPointerMove={onDragHandlePointerMove}
-                        onPointerUp={() => onDragHandlePointerEnd(true)}
-                        onPointerCancel={() => onDragHandlePointerEnd(false)}
-                        aria-label={t(
-                          'settings.proxyModels.catalogSources.dragToReorder'
-                        )}
-                        title={t(
-                          'settings.proxyModels.catalogSources.dragToReorder'
-                        )}
-                      >
-                        <GripVerticalIcon className='size-3.5' />
-                      </Button>
-                    </TableCell>
-                    <TableCell className='text-sm font-medium'>
-                      {source.name}
-                    </TableCell>
-                    <TableCell>
-                      <Badge
-                        variant={
-                          source.type === 'official' ? 'secondary' : 'outline'
-                        }
-                      >
-                        {source.type === 'official'
-                          ? t(
-                              'settings.proxyModels.catalogSources.typeOfficial'
-                            )
-                          : t('settings.proxyModels.catalogSources.typeCustom')}
-                      </Badge>
-                    </TableCell>
-                    <TableCell
-                      className='text-muted-foreground max-w-[16rem] truncate font-mono text-xs'
-                      title={source.url}
-                    >
-                      {source.url}
-                    </TableCell>
-                    <TableCell>
-                      <Switch
-                        checked={source.enabled}
-                        onCheckedChange={() =>
-                          toggleEnabledMutation.mutate(source)
-                        }
-                        disabled={toggleEnabledMutation.isPending}
-                        aria-label={t(
-                          'settings.proxyModels.catalogSources.toggleEnabled',
-                          {
-                            name: source.name,
-                          }
-                        )}
-                      />
-                    </TableCell>
-                    <TableCell>{<LastSyncCell source={source} />}</TableCell>
-                    <TableCell>
-                      <div className='flex justify-end gap-1'>
-                        <Button
-                          variant='ghost'
-                          size='icon-sm'
-                          disabled={busy}
-                          onClick={() => syncOneMutation.mutate(source.id)}
-                          aria-label={t(
-                            'settings.proxyModels.catalogSources.syncNow'
-                          )}
-                        >
-                          {syncingId === source.id ? (
-                            <Spinner className='size-3.5' />
-                          ) : (
-                            <RefreshCwIcon className='size-3.5' />
-                          )}
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='icon-sm'
-                          onClick={() => setDialog({ mode: 'edit', source })}
-                          aria-label={t(
-                            'settings.proxyModels.catalogSources.edit'
-                          )}
-                        >
-                          <PencilIcon className='size-3.5' />
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='icon-sm'
-                          onClick={() => setDeleteTarget(source)}
-                          aria-label={t(
-                            'settings.proxyModels.catalogSources.delete'
-                          )}
-                        >
-                          <Trash2Icon className='size-3.5' />
-                        </Button>
-                      </div>
-                    </TableCell>
+            <>
+              <p id='catalog-source-reorder-help' className='sr-only'>
+                {t('settings.proxyModels.catalogSources.reorderInstructions')}
+              </p>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    {/* Drag-handle column (reorder, Wave 9 Lane B). */}
+                    <TableHead className='w-7' />
+                    <TableHead>
+                      {t('settings.proxyModels.catalogSources.columns.source')}
+                    </TableHead>
+                    <TableHead>
+                      {t('settings.proxyModels.catalogSources.columns.type')}
+                    </TableHead>
+                    <TableHead>
+                      {t('settings.proxyModels.catalogSources.columns.url')}
+                    </TableHead>
+                    <TableHead>
+                      {t('settings.proxyModels.catalogSources.columns.enabled')}
+                    </TableHead>
+                    <TableHead>
+                      {t(
+                        'settings.proxyModels.catalogSources.columns.lastSync'
+                      )}
+                    </TableHead>
+                    <TableHead className='text-right'>
+                      {t('settings.proxyModels.catalogSources.columns.actions')}
+                    </TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {sources.map((source, index) => (
+                    <TableRow
+                      key={source.id}
+                      ref={(row) => {
+                        rowRefs.current[index] = row
+                      }}
+                      className={cn(
+                        dragIndex !== null &&
+                          overIndex === index &&
+                          'bg-accent/60',
+                        dragIndex === index && 'opacity-40'
+                      )}
+                    >
+                      <TableCell className='w-7 px-0'>
+                        <Button
+                          type='button'
+                          variant='ghost'
+                          size='icon-sm'
+                          className={cn(
+                            'cursor-grab touch-none select-none',
+                            dragIndex === index && 'cursor-grabbing'
+                          )}
+                          disabled={busy || reorderMutation.isPending}
+                          onPointerDown={(event) =>
+                            onDragHandlePointerDown(event, index)
+                          }
+                          onPointerMove={onDragHandlePointerMove}
+                          onPointerUp={() => endDrag(true)}
+                          onPointerCancel={() => endDrag(false)}
+                          onKeyDown={(event) =>
+                            onDragHandleKeyDown(event, index)
+                          }
+                          onBlur={() => {
+                            if (dragState.current?.mode === 'keyboard') {
+                              endDrag(false)
+                            }
+                          }}
+                          aria-label={t(
+                            'settings.proxyModels.catalogSources.reorderRow',
+                            { name: source.name }
+                          )}
+                          aria-keyshortcuts='Enter Space ArrowUp ArrowDown Escape'
+                          aria-pressed={keyboardGrabIndex === index}
+                          aria-describedby='catalog-source-reorder-help'
+                          title={t(
+                            'settings.proxyModels.catalogSources.dragToReorder'
+                          )}
+                        >
+                          <GripVerticalIcon className='size-3.5' />
+                        </Button>
+                      </TableCell>
+                      <TableCell className='text-sm font-medium'>
+                        {source.name}
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={
+                            source.type === 'official' ? 'secondary' : 'outline'
+                          }
+                        >
+                          {source.type === 'official'
+                            ? t(
+                                'settings.proxyModels.catalogSources.typeOfficial'
+                              )
+                            : t(
+                                'settings.proxyModels.catalogSources.typeCustom'
+                              )}
+                        </Badge>
+                      </TableCell>
+                      <TableCell
+                        className='text-muted-foreground max-w-[16rem] truncate font-mono text-xs'
+                        title={source.url}
+                      >
+                        {source.url}
+                      </TableCell>
+                      <TableCell>
+                        <Switch
+                          checked={source.enabled}
+                          onCheckedChange={() =>
+                            toggleEnabledMutation.mutate(source)
+                          }
+                          disabled={toggleEnabledMutation.isPending}
+                          aria-label={t(
+                            'settings.proxyModels.catalogSources.toggleEnabled',
+                            {
+                              name: source.name,
+                            }
+                          )}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <LastSyncCell source={source} />
+                      </TableCell>
+                      <TableCell>
+                        <div className='flex justify-end gap-1'>
+                          <Button
+                            variant='ghost'
+                            size='icon-sm'
+                            disabled={busy}
+                            onClick={() => syncOneMutation.mutate(source.id)}
+                            aria-label={t(
+                              'settings.proxyModels.catalogSources.syncNow'
+                            )}
+                          >
+                            {syncingId === source.id ? (
+                              <Spinner className='size-3.5' />
+                            ) : (
+                              <RefreshCwIcon className='size-3.5' />
+                            )}
+                          </Button>
+                          <Button
+                            variant='ghost'
+                            size='icon-sm'
+                            onClick={() => setDialog({ mode: 'edit', source })}
+                            aria-label={t(
+                              'settings.proxyModels.catalogSources.edit'
+                            )}
+                          >
+                            <PencilIcon className='size-3.5' />
+                          </Button>
+                          <Button
+                            variant='ghost'
+                            size='icon-sm'
+                            onClick={() => setDeleteTarget(source)}
+                            aria-label={t(
+                              'settings.proxyModels.catalogSources.delete'
+                            )}
+                          >
+                            <Trash2Icon className='size-3.5' />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </>
           )}
         </div>
       </SettingsSectionCard>

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1174,7 +1174,9 @@
             "loadFailed": "Failed to load sources: {{message}}",
             "disabled": "The pricing catalog is not enabled (PRICING_CATALOG_ENABLED=false)."
           },
-          "dragToReorder": "Drag to reorder"
+          "dragToReorder": "Drag to reorder",
+          "reorderRow": "Reorder {{name}}",
+          "reorderInstructions": "To reorder with the keyboard: focus a row's grab handle, press Enter or Space to grab, move with the Arrow Up/Down keys, press Space to drop, or press Escape to cancel."
         },
         "proxyTransport": {
           "title": "Proxy & Transport",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1174,7 +1174,9 @@
             "loadFailed": "加载数据源失败：{{message}}",
             "disabled": "价格目录未启用（PRICING_CATALOG_ENABLED=false）。"
           },
-          "dragToReorder": "拖拽调整顺序"
+          "dragToReorder": "拖拽调整顺序",
+          "reorderRow": "调整 {{name}} 顺序",
+          "reorderInstructions": "键盘调整顺序：聚焦某行的拖拽手柄，按 Enter 或空格键抓起，用上下方向键移动，按空格键放下，按 Esc 取消。"
         },
         "proxyTransport": {
           "title": "代理与传输",


### PR DESCRIPTION
Fixes #1032

## Problem

The catalog-sources reorder handles are pointer-only: a keyboard or assistive-tech user cannot reorder sources, violating WCAG 2.1.1 (Level A).

## Change

Adds a full keyboard path to each row's grab handle, reusing the existing `PUT /api/models/catalog-sources/{id} { sortOrder }` absolute-index semantics and sharing the pointer path's `endDrag` commit state machine:

- **Enter / Space** grabs the focused handle (`aria-pressed` becomes true)
- **ArrowUp / ArrowDown** moves the drop highlight (clamped at the first/last row)
- **Space / Enter** drops — commits the absolute sortOrder (only if the position changed)
- **Escape** or moving focus away cancels without any request

Pointer drag is unchanged; a pointer grab takes over from an active keyboard grab and clears its residual visual state so a click-without-move cannot commit a stale keyboard target.

## Accessibility

- `aria-label` now names the row: "Reorder {{name}}"
- `aria-keyshortcuts="Enter Space ArrowUp ArrowDown Escape"`
- `aria-describedby` points to a new sr-only instruction paragraph
- New i18n keys `reorderRow` + `reorderInstructions` added to both `en.json` and `zh-CN.json` (key sets stay identical)

## Verification

- New `catalog-sources-section.test.tsx` with 7 cases covering grab/move/drop, Space/Enter variants, boundary clamping, Escape cancel, and focus-loss cancel
- Red-on-old-code verified via `git stash` (7/7 failed against the pre-fix component), green after the fix (7/7)
- Full web suite: 198 files / 1326 tests pass; `lint` 0 errors, `typecheck`, `format:check`, `knip`, and `build:check` all pass
- Pre-push full CI (frontend gate + go build/vet/race) passed on push