### PR TITLE
fix(web): UX quick-win batch from the frontend audit

### DIFF
--- a/web/src/components/data-table/layout/__tests__/mobile-empty-action.test.tsx
+++ b/web/src/components/data-table/layout/__tests__/mobile-empty-action.test.tsx
@@ -1,0 +1,83 @@
+// Regression test: `DataTablePage`'s `emptyAction` slot must reach the
+// mobile card list empty state (audit #1029 batch B). Previously the CTA
+// rendered on desktop only — mobile fell back to a plain empty state with
+// no action button, stranding empty-state CTAs on 8 entity pages.
+import '@testing-library/jest-dom/vitest'
+import {
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+} from '@tanstack/react-table'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { DataTablePage } from '../data-table-page'
+
+type ProbeRow = { id: number; name: string }
+
+const probeColumns: ColumnDef<ProbeRow, unknown>[] = [
+  { accessorKey: 'name', header: 'Name' },
+]
+
+function setMediaQuery(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+}
+
+afterEach(() => cleanup())
+
+function renderEmptyPage() {
+  function Harness() {
+    const table = useReactTable({
+      data: [] as ProbeRow[],
+      columns: probeColumns,
+      getCoreRowModel: getCoreRowModel(),
+    })
+    return (
+      <DataTablePage
+        table={table}
+        columns={probeColumns}
+        emptyTitle='No widgets'
+        emptyAction={<button type='button'>Create widget</button>}
+        toolbarProps={null}
+        showPagination={false}
+      />
+    )
+  }
+  return render(<Harness />)
+}
+
+describe('DataTablePage emptyAction on mobile', () => {
+  it('renders the empty action in the mobile card list', () => {
+    setMediaQuery(true)
+    renderEmptyPage()
+
+    expect(screen.getByText('No widgets')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Create widget' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the empty action on desktop', () => {
+    setMediaQuery(false)
+    renderEmptyPage()
+
+    expect(screen.getByText('No widgets')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Create widget' })
+    ).toBeInTheDocument()
+  })
+})

--- a/web/src/components/data-table/layout/data-table-page.tsx
+++ b/web/src/components/data-table/layout/data-table-page.tsx
@@ -328,6 +328,7 @@ function renderMobile<TData>(
         isLoading={props.isLoading}
         emptyTitle={props.emptyTitle}
         emptyDescription={props.emptyDescription}
+        emptyAction={props.emptyAction}
         getRowKey={props.mobileProps?.getRowKey}
         getRowClassName={mobileGetRowClassName}
       />

--- a/web/src/components/data-table/layout/mobile-card-list.tsx
+++ b/web/src/components/data-table/layout/mobile-card-list.tsx
@@ -22,6 +22,7 @@ interface MobileCardListProps<TData> {
   isLoading?: boolean
   emptyTitle?: string
   emptyDescription?: string
+  emptyAction?: React.ReactNode
   getRowKey?: (row: Row<TData>) => string | number
   getRowClassName?: (row: Row<TData>) => string | undefined
 }
@@ -84,6 +85,7 @@ export function MobileCardList<TData>(props: MobileCardListProps<TData>) {
     isLoading = false,
     emptyTitle,
     emptyDescription,
+    emptyAction,
     getRowKey,
     getRowClassName,
   } = props
@@ -119,6 +121,7 @@ export function MobileCardList<TData>(props: MobileCardListProps<TData>) {
             <EmptyTitle>{resolvedEmptyTitle}</EmptyTitle>
             <EmptyDescription>{resolvedEmptyDescription}</EmptyDescription>
           </EmptyHeader>
+          {emptyAction}
         </Empty>
       </div>
     )

--- a/web/src/features/accounts/__tests__/accounts-bulk-disable-confirm.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-bulk-disable-confirm.test.tsx
@@ -1,0 +1,160 @@
+// Regression test: the bulk "Disable" action fired immediately on click; it
+// must now open a confirmation dialog first (audit #1029 batch B) — matching
+// the destructive bulk-delete guard already in place.
+import '@testing-library/jest-dom/vitest'
+import type { ReactNode } from 'react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { AccountsPage } from '../components/accounts-page'
+
+const testState = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  batchMutateAsync: vi.fn(),
+}))
+
+vi.mock('@/components/common/use-probe-history', () => ({
+  useProbeHistory: () => ({ data: undefined }),
+}))
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => testState.navigate,
+  useSearch: () => ({ page: 1, pageSize: 20 }),
+}))
+
+vi.mock('@/components/data-table', () => ({
+  // Render the bulk action children so the Disable button is clickable.
+  DataTableBulkActions: (props: { children?: ReactNode }) => (
+    <div>{props.children}</div>
+  ),
+  DataTablePage: (props: { bulkActions?: ReactNode }) => (
+    <div>{props.bulkActions}</div>
+  ),
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    ensurePageInRange: vi.fn(),
+  }),
+  useDataTable: () => ({
+    table: {
+      // One selected account so the bulk action proceeds.
+      getFilteredSelectedRowModel: () => ({ rows: [{ original: { id: 5 } }] }),
+      resetRowSelection: vi.fn(),
+    },
+  }),
+}))
+
+vi.mock('@/features/import', () => ({
+  ImportWizardDialog: () => null,
+}))
+
+vi.mock('../api', () => ({
+  useAccounts: () => ({
+    data: { accounts: [], sites: [] },
+    error: null,
+    isLoading: false,
+    isFetching: false,
+  }),
+  useBatchUpdateAccounts: () => ({
+    mutateAsync: testState.batchMutateAsync,
+    isPending: false,
+  }),
+  useDeleteAccount: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRefreshAccount: () => ({ mutate: vi.fn(), isPending: false }),
+  useToggleAccountCheckin: () => ({ mutate: vi.fn(), isPending: false }),
+  useToggleAccountPin: () => ({ mutate: vi.fn(), isPending: false }),
+  useToggleAccountStatus: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+vi.mock('../components/account-detail-sheet', () => ({
+  AccountDetailSheet: () => null,
+}))
+
+vi.mock('../components/account-form-dialog', () => ({
+  AccountFormDialog: () => null,
+}))
+
+vi.mock('../components/accounts-columns', () => ({
+  useAccountsColumns: () => [],
+}))
+
+beforeAll(() => {
+  // base-ui AlertDialog queries matchMedia under jsdom.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  testState.navigate.mockReset()
+  testState.batchMutateAsync.mockReset()
+})
+
+afterEach(() => cleanup())
+
+// The dialog action shares its label with the trigger; the action button is
+// the last matching button in the tree once the dialog is open.
+function clickLastButtonNamed(name: string) {
+  const buttons = screen.getAllByRole('button', { name })
+  const button = buttons.at(-1)
+  if (!button) {
+    throw new Error(`Button "${name}" not found`)
+  }
+  fireEvent.click(button)
+}
+
+describe('AccountsPage bulk disable confirmation', () => {
+  it('opens a confirmation before bulk disabling', () => {
+    render(<AccountsPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Disable' }))
+
+    expect(screen.getByText('Disable selected accounts?')).toBeInTheDocument()
+    expect(testState.batchMutateAsync).not.toHaveBeenCalled()
+  })
+
+  it('bulk disables after confirming', async () => {
+    render(<AccountsPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Disable' }))
+    clickLastButtonNamed('Disable')
+
+    await waitFor(() => {
+      expect(testState.batchMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(testState.batchMutateAsync).toHaveBeenCalledWith({
+      ids: [5],
+      action: 'disable',
+    })
+  })
+
+  it('does not bulk disable when the confirmation is cancelled', () => {
+    render(<AccountsPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Disable' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(testState.batchMutateAsync).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/features/accounts/__tests__/accounts-bulk-disable-confirm.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-bulk-disable-confirm.test.tsx
@@ -2,7 +2,6 @@
 // must now open a confirmation dialog first (audit #1029 batch B) — matching
 // the destructive bulk-delete guard already in place.
 import '@testing-library/jest-dom/vitest'
-import type { ReactNode } from 'react'
 import {
   cleanup,
   fireEvent,
@@ -10,7 +9,16 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react'
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 import '@/i18n/config'
 

--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -26,6 +26,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { ConfirmDialog } from '@/components/common/confirm-dialog'
 import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import { useProbeHistory } from '@/components/common/use-probe-history'
 import {
@@ -677,6 +678,7 @@ function AccountsBulkActions({ table }: { table: Table<Account> }) {
   const { t } = useTranslation()
   const batchMutation = useBatchUpdateAccounts()
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
+  const [confirmDisableOpen, setConfirmDisableOpen] = useState(false)
 
   // Derived per render — `table` identity is stable across selection changes
   // (TanStack `useReactTable` memoizes the instance), so a `useMemo([table])`
@@ -757,7 +759,7 @@ function AccountsBulkActions({ table }: { table: Table<Account> }) {
         <Button
           size='sm'
           variant='outline'
-          onClick={() => runBatch('disable')}
+          onClick={() => setConfirmDisableOpen(true)}
           disabled={batchMutation.isPending}
         >
           {t('accounts.bulk.disable')}
@@ -802,6 +804,22 @@ function AccountsBulkActions({ table }: { table: Table<Account> }) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <ConfirmDialog
+        open={confirmDisableOpen}
+        title={t('accounts.bulk.disableConfirmTitle')}
+        description={t('accounts.bulk.disableConfirmDescription', {
+          count: selectedIds.length,
+        })}
+        confirmLabel={t('accounts.bulk.disableConfirmConfirm')}
+        cancelLabel={t('accounts.bulk.deleteConfirmCancel')}
+        destructive
+        onConfirm={() => {
+          setConfirmDisableOpen(false)
+          void runBatch('disable')
+        }}
+        onCancel={() => setConfirmDisableOpen(false)}
+      />
     </>
   )
 }

--- a/web/src/features/dashboard/sections/traffic/__tests__/traffic-section-chart-retry.test.tsx
+++ b/web/src/features/dashboard/sections/traffic/__tests__/traffic-section-chart-retry.test.tsx
@@ -3,10 +3,23 @@
 // owning query (audit #1029 batch B).
 import '@testing-library/jest-dom/vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import type { ReactNode } from 'react'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import type { ReactElement } from 'react'
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import type { ReactElement, ReactNode } from 'react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 import '@/i18n/config'
 

--- a/web/src/features/dashboard/sections/traffic/__tests__/traffic-section-chart-retry.test.tsx
+++ b/web/src/features/dashboard/sections/traffic/__tests__/traffic-section-chart-retry.test.tsx
@@ -1,0 +1,109 @@
+// Regression test: a failed traffic chart showed only an error message with
+// no way to retry. ChartError must offer a Retry button that refetches the
+// owning query (audit #1029 batch B).
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { TrafficSection } from '../traffic-section'
+
+const { mockIncomeOutcome, mockSiteTrend, mockSiteDistribution } = vi.hoisted(
+  () => ({
+    mockIncomeOutcome: vi.fn(),
+    mockSiteTrend: vi.fn(),
+    mockSiteDistribution: vi.fn(),
+  })
+)
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getBalanceIncomeOutcome: mockIncomeOutcome,
+    getSiteTrend: mockSiteTrend,
+    getSiteDistribution: mockSiteDistribution,
+  },
+}))
+
+vi.mock('../../components/chart-shell', () => ({
+  ChartShell: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('../../components/charts', () => ({
+  IncomeOutcomeChart: () => null,
+  SiteDistributionChart: () => null,
+  SiteTrendChart: () => null,
+}))
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  mockIncomeOutcome.mockReset()
+  mockSiteTrend.mockReset()
+  mockSiteDistribution.mockReset()
+  mockIncomeOutcome.mockRejectedValue(new Error('income boom'))
+  mockSiteTrend.mockRejectedValue(new Error('trend boom'))
+  mockSiteDistribution.mockRejectedValue(new Error('distribution boom'))
+})
+
+afterEach(() => cleanup())
+
+function renderSection() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return render(
+    (
+      <QueryClientProvider client={queryClient}>
+        <TrafficSection />
+      </QueryClientProvider>
+    ) as ReactElement
+  )
+}
+
+describe('TrafficSection chart error retry', () => {
+  it('renders a Retry button per failed chart', async () => {
+    renderSection()
+
+    expect(
+      await screen.findAllByText('Failed to load income/spend data.')
+    ).toHaveLength(3)
+    expect(screen.getAllByRole('button', { name: 'Retry' })).toHaveLength(3)
+  })
+
+  it('refetches the owning query when Retry is clicked', async () => {
+    renderSection()
+
+    const retryButtons = await screen.findAllByRole('button', { name: 'Retry' })
+    mockIncomeOutcome.mockResolvedValue({
+      days: 30,
+      points: [],
+      summary: { totalIncome: 0, totalOutcome: 0, net: 0 },
+    })
+    fireEvent.click(retryButtons[0] as HTMLElement)
+
+    await waitFor(() => {
+      expect(mockIncomeOutcome).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/web/src/features/dashboard/sections/traffic/traffic-section.tsx
+++ b/web/src/features/dashboard/sections/traffic/traffic-section.tsx
@@ -67,12 +67,7 @@ function ChartError({
       <TriangleAlert className='text-destructive/80 size-5' />
       <p className='text-destructive text-xs'>{message}</p>
       {onRetry ? (
-        <Button
-          type='button'
-          variant='outline'
-          size='sm'
-          onClick={onRetry}
-        >
+        <Button type='button' variant='outline' size='sm' onClick={onRetry}>
           {t('common.retry')}
         </Button>
       ) : null}

--- a/web/src/features/dashboard/sections/traffic/traffic-section.tsx
+++ b/web/src/features/dashboard/sections/traffic/traffic-section.tsx
@@ -11,6 +11,7 @@ import { Inbox, TriangleAlert } from 'lucide-react'
 import { useMemo, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { Button } from '@/components/ui/button'
 import { api } from '@/lib/api'
 
 import { ChartShell } from '../../components/chart-shell'
@@ -53,11 +54,28 @@ type SiteDistributionResponse = {
   }>
 }
 
-function ChartError({ message }: { message: string }) {
+function ChartError({
+  message,
+  onRetry,
+}: {
+  message: string
+  onRetry?: () => void
+}) {
+  const { t } = useTranslation()
   return (
     <div className='flex h-full w-full flex-col items-center justify-center gap-1.5'>
       <TriangleAlert className='text-destructive/80 size-5' />
       <p className='text-destructive text-xs'>{message}</p>
+      {onRetry ? (
+        <Button
+          type='button'
+          variant='outline'
+          size='sm'
+          onClick={onRetry}
+        >
+          {t('common.retry')}
+        </Button>
+      ) : null}
     </div>
   )
 }
@@ -151,14 +169,23 @@ export function TrafficSection() {
   )
 
   const renderChartBody = (
-    query: { isLoading: boolean; isError: boolean },
+    query: {
+      isLoading: boolean
+      isError: boolean
+      refetch: () => void
+    },
     isEmpty: boolean,
     emptyKey: string,
     chart: ReactNode
   ): ReactNode => {
     if (query.isLoading) return null
     if (query.isError) {
-      return <ChartError message={t('dashboard.traffic.loadError')} />
+      return (
+        <ChartError
+          message={t('dashboard.traffic.loadError')}
+          onRetry={() => void query.refetch()}
+        />
+      )
     }
     if (isEmpty) {
       return <ChartEmpty message={t(emptyKey)} />

--- a/web/src/features/models/components/__tests__/models-page-empty.test.tsx
+++ b/web/src/features/models/components/__tests__/models-page-empty.test.tsx
@@ -21,6 +21,7 @@ vi.mock('@tanstack/react-router', () => ({
 
 vi.mock('@tanstack/react-query', () => ({
   useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
 }))
 
 vi.mock('@/components/data-table', () => ({

--- a/web/src/features/models/components/__tests__/models-page-refresh-invalidate.test.tsx
+++ b/web/src/features/models/components/__tests__/models-page-refresh-invalidate.test.tsx
@@ -1,0 +1,109 @@
+// Regression test: refreshing the marketplace re-aggregates server-side, but
+// the list query's 10s staleTime kept serving the pre-refresh cache during
+// that window. The refresh mutation must invalidate the models query prefix
+// so the table refetches immediately (audit #1029 batch B).
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { ModelsPage } from '../models-page'
+
+const testState = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  mockGetModelsMarketplace: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => testState.navigate,
+}))
+
+vi.mock('@/components/data-table', () => ({
+  // Surface the toolbar's preActions so the refresh button is clickable.
+  DataTablePage: (props: {
+    toolbarProps?: { preActions?: ReactNode }
+    emptyAction?: ReactNode
+  }) => <div>{props.toolbarProps?.preActions ?? props.emptyAction}</div>,
+  encodeSorting: () => '',
+  useDataTable: () => ({ table: {} }),
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    sorting: [],
+    onSortingChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    ensurePageInRange: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/common/query-error-banner', () => ({
+  QueryErrorBanner: () => null,
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: { getModelsMarketplace: testState.mockGetModelsMarketplace },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}))
+
+vi.mock('../../api', () => ({
+  useModels: () => ({ data: [], isLoading: false, isFetching: false }),
+}))
+
+vi.mock('../model-detail-sheet', () => ({
+  ModelDetailSheet: () => null,
+}))
+
+vi.mock('../models-columns', () => ({
+  useModelsColumns: () => [],
+  buildBrandFilterOptions: () => [],
+  buildCapabilityFilterOptions: () => [],
+  buildEndpointTypeFilterOptions: () => [],
+}))
+
+beforeEach(() => {
+  testState.navigate.mockReset()
+  testState.mockGetModelsMarketplace.mockReset()
+  testState.mockGetModelsMarketplace.mockResolvedValue({ models: [] })
+})
+
+afterEach(() => cleanup())
+
+function renderModelsPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ModelsPage />
+    </QueryClientProvider>
+  )
+  return { invalidateSpy }
+}
+
+describe('ModelsPage marketplace refresh', () => {
+  it('invalidates the models queries after a successful refresh', async () => {
+    const { invalidateSpy } = renderModelsPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
+
+    await waitFor(() => {
+      expect(testState.mockGetModelsMarketplace).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['models'] })
+    })
+  })
+})

--- a/web/src/features/models/components/__tests__/models-page-refresh-invalidate.test.tsx
+++ b/web/src/features/models/components/__tests__/models-page-refresh-invalidate.test.tsx
@@ -4,8 +4,14 @@
 // so the table refetches immediately (audit #1029 batch B).
 import '@testing-library/jest-dom/vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '@/i18n/config'

--- a/web/src/features/models/components/models-page.tsx
+++ b/web/src/features/models/components/models-page.tsx
@@ -9,7 +9,7 @@
 // page works before the `/models` route file lands its own validateSearch.
 // Mobile cards are handled by `DataTablePage` via the column `meta` flags.
 
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import type { ColumnFiltersState } from '@tanstack/react-table'
 import {
@@ -42,7 +42,7 @@ import { toast } from '@/lib/toast'
 
 import { useModels } from '../api'
 import { modelsSearchSchema } from '../lib/models-schema'
-import type { ModelRow } from '../types'
+import { modelsKeys, type ModelRow } from '../types'
 import { ModelDetailSheet } from './model-detail-sheet'
 import { ModelVerifyDialog } from './model-verify-dialog'
 import {
@@ -183,6 +183,7 @@ function useModelsUrlState() {
 
 export function ModelsPage() {
   const { t } = useTranslation()
+  const queryClient = useQueryClient()
   const modelsQuery = useModels({ includePricing: true })
   const navigate = useNavigate()
 
@@ -256,13 +257,14 @@ export function ModelsPage() {
       await api.getModelsMarketplace({ refresh: true, includePricing: true })
     },
     onSuccess: () => {
+      // The refresh call re-aggregates the marketplace server-side. The list
+      // query has a 10s staleTime and would keep serving the pre-refresh
+      // cache during that window, so invalidate the models prefix explicitly
+      // to refetch immediately (list + capability selectors share it).
+      void queryClient.invalidateQueries({ queryKey: modelsKeys.all })
       toast.success(t('models.toast.refreshSucceeded'))
     },
   })
-
-  // The refresh call re-aggregates the marketplace server-side; the next
-  // render re-reads the (now fresh) `useModels` cache via its 10s staleTime,
-  // so no explicit query invalidation is needed for the list to update.
   const models = useMemo(() => modelsQuery.data ?? [], [modelsQuery.data])
   const brandFilterOptions = useMemo(
     () => buildBrandFilterOptions(models),

--- a/web/src/features/models/price-compare/components/__tests__/price-compare-page-empty-cta.test.tsx
+++ b/web/src/features/models/price-compare/components/__tests__/price-compare-page-empty-cta.test.tsx
@@ -4,7 +4,15 @@
 import '@testing-library/jest-dom/vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 import '@/i18n/config'
 

--- a/web/src/features/models/price-compare/components/__tests__/price-compare-page-empty-cta.test.tsx
+++ b/web/src/features/models/price-compare/components/__tests__/price-compare-page-empty-cta.test.tsx
@@ -1,0 +1,73 @@
+// Regression test: the price-compare empty state was a dead end. It must
+// offer a "Manage accounts" CTA pointing at /accounts, mirroring the models
+// page empty-state exit (audit #1029 batch B).
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { PriceComparePage } from '../price-compare-page'
+
+const testState = vi.hoisted(() => ({
+  navigate: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => testState.navigate,
+  Link: ({ children }: { children?: ReactNode }) => <a>{children}</a>,
+}))
+
+vi.mock('@/components/common/query-error-banner', () => ({
+  QueryErrorBanner: () => null,
+}))
+
+vi.mock('../../api', () => ({
+  usePriceCompare: () => ({
+    data: [],
+    isLoading: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}))
+
+vi.mock('../components/price-grade-badge', () => ({
+  PriceGradeBadge: () => null,
+}))
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  testState.navigate.mockReset()
+})
+
+afterEach(() => cleanup())
+
+describe('PriceComparePage empty-state CTA', () => {
+  it('offers a Manage accounts CTA that navigates to /accounts', () => {
+    render(<PriceComparePage />)
+
+    const cta = screen.getByRole('button', { name: 'Manage accounts' })
+    expect(cta).toBeInTheDocument()
+
+    fireEvent.click(cta)
+    expect(testState.navigate).toHaveBeenCalledTimes(1)
+    expect(testState.navigate).toHaveBeenCalledWith({ to: '/accounts' })
+  })
+})

--- a/web/src/features/models/price-compare/components/price-compare-page.tsx
+++ b/web/src/features/models/price-compare/components/price-compare-page.tsx
@@ -2,7 +2,7 @@
 // Groups the backend's cheaper-first candidate rows by model and surfaces the
 // provenance grade + best-channel recommendation for every source.
 
-import { Link } from '@tanstack/react-router'
+import { Link, useNavigate } from '@tanstack/react-router'
 import { ArrowRight, Search, Star } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -42,6 +42,7 @@ type ModelGroup = {
 
 export function PriceComparePage() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const [search, setSearch] = useState('')
   const [modelParam, setModelParam] = useState('')
 
@@ -119,6 +120,12 @@ export function PriceComparePage() {
               {t('priceCompare.page.emptyDescription')}
             </EmptyDescription>
           </EmptyHeader>
+          <Button
+            variant='outline'
+            onClick={() => void navigate({ to: '/accounts' })}
+          >
+            {t('priceCompare.page.emptyAction')}
+          </Button>
         </Empty>
       )}
 

--- a/web/src/features/oauth/components/__tests__/oauth-start-dialog-dirty-close.test.tsx
+++ b/web/src/features/oauth/components/__tests__/oauth-start-dialog-dirty-close.test.tsx
@@ -1,0 +1,173 @@
+// Regression test: closing the OAuth start form with unsaved edits silently
+// discarded them (Cancel / X / Escape all closed immediately). The form view
+// must now route through the shared dirty-close guard (audit #1029 batch B);
+// the pending panel keeps its own abandon confirmation.
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import type { ReactNode } from 'react'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+
+import { OAuthStartDialog } from '../oauth-start-dialog'
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    writable: true,
+    value: ResizeObserverStub,
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+afterAll(() => {
+  vi.restoreAllMocks()
+})
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children }: { children?: ReactNode }) => <a>{children}</a>,
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('../../api', () => ({
+  useOAuthProviders: () => ({
+    data: [
+      {
+        provider: 'openai',
+        label: 'OpenAI',
+        platform: 'openai',
+        enabled: true,
+        loginType: 'oauth',
+        requiresProjectId: false,
+        supportsDirectAccountRouting: true,
+        supportsCloudValidation: true,
+        supportsNativeProxy: true,
+      },
+    ],
+    isLoading: false,
+    isError: false,
+  }),
+  useStartOAuth: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useSubmitOAuthManualCallback: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}))
+
+vi.mock('../../lib/oauth-session-polling', () => ({
+  useOAuthSessionPolling: () => ({
+    session: undefined,
+    exhausted: false,
+    kick: vi.fn(),
+  }),
+  OAUTH_SESSION_POLL_MAX_ATTEMPTS: 100,
+}))
+
+function renderDialog(onOpenChange = vi.fn()) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+  return render(<OAuthStartDialog open onOpenChange={onOpenChange} />, {
+    wrapper: Wrapper,
+  })
+}
+
+/** Select the first provider — makes the form dirty. */
+async function makeFormDirty() {
+  fireEvent.mouseDown(screen.getByRole('combobox'))
+  const option = await screen.findByRole('option', { name: 'OpenAI' })
+  fireEvent.click(option)
+}
+
+describe('OAuthStartDialog dirty-close guard', () => {
+  it('asks for confirmation before closing a dirty form', async () => {
+    const onOpenChange = vi.fn()
+    renderDialog(onOpenChange)
+
+    await makeFormDirty()
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(
+      await screen.findByText('Discard unsaved changes?')
+    ).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  it('closes after confirming the discard', async () => {
+    const onOpenChange = vi.fn()
+    renderDialog(onOpenChange)
+
+    await makeFormDirty()
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    await screen.findByText('Discard unsaved changes?')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }))
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('keeps the form open when the discard is declined', async () => {
+    const onOpenChange = vi.fn()
+    renderDialog(onOpenChange)
+
+    await makeFormDirty()
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    await screen.findByText('Discard unsaved changes?')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Keep editing' }))
+
+    expect(onOpenChange).not.toHaveBeenCalled()
+    expect(screen.getByText(/Start authorization/)).toBeInTheDocument()
+  })
+})

--- a/web/src/features/oauth/components/__tests__/oauth-start-dialog-dirty-close.test.tsx
+++ b/web/src/features/oauth/components/__tests__/oauth-start-dialog-dirty-close.test.tsx
@@ -16,7 +16,6 @@ import {
   afterAll,
   afterEach,
   beforeAll,
-  beforeEach,
   describe,
   expect,
   it,

--- a/web/src/features/oauth/components/oauth-start-dialog.tsx
+++ b/web/src/features/oauth/components/oauth-start-dialog.tsx
@@ -28,6 +28,7 @@ import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
 import { ConfirmDialog } from '@/components/common/confirm-dialog'
+import { useDirtyDialogClose } from '@/components/form/dirty-dialog-close'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -114,6 +115,20 @@ export function OAuthStartDialog({
     [providersQuery.data]
   )
 
+  const form = useForm<OAuthStartValues>({
+    resolver: zodResolver(oauthStartSchema),
+    defaultValues: OAUTH_START_DEFAULT_VALUES,
+  })
+
+  // The form view closes silently on dirty edits otherwise; intercept the
+  // close and offer the shared discard confirmation (the pending panel has
+  // its own abandon flow, so the guard only applies to the form view).
+  const { handleOpenChange, guard: dirtyGuard } = useDirtyDialogClose({
+    enabled: !pendingState && form.formState.isDirty,
+    onDiscard: () => form.reset(),
+    onOpenChange,
+  })
+
   // The provider <Select> collapses three distinct non-ready states into an
   // empty dropdown otherwise. Branch on the query state so the user sees
   // why there is nothing to pick and how to recover, instead of clicking
@@ -123,11 +138,6 @@ export function OAuthStartDialog({
   const hasEnabledProviders = enabledProviders.length > 0
   const providersReady =
     !providersLoading && !providersError && hasEnabledProviders
-
-  const form = useForm<OAuthStartValues>({
-    resolver: zodResolver(oauthStartSchema),
-    defaultValues: OAUTH_START_DEFAULT_VALUES,
-  })
 
   useEffect(() => {
     if (!open) return
@@ -297,7 +307,7 @@ export function OAuthStartDialog({
       setConfirmAbandonOpen(true)
       return
     }
-    onOpenChange(false)
+    handleOpenChange(false)
   }
 
   return (
@@ -634,7 +644,7 @@ export function OAuthStartDialog({
                     <Button
                       type='button'
                       variant='outline'
-                      onClick={() => onOpenChange(false)}
+                      onClick={requestClose}
                       disabled={isSubmitting}
                     >
                       {t('oauth.form.cancel')}
@@ -671,6 +681,8 @@ export function OAuthStartDialog({
         }}
         onCancel={() => setConfirmAbandonOpen(false)}
       />
+
+      {dirtyGuard}
     </>
   )
 }

--- a/web/src/features/proxy-logs/components/__tests__/proxy-logs-page-empty-cta.test.tsx
+++ b/web/src/features/proxy-logs/components/__tests__/proxy-logs-page-empty-cta.test.tsx
@@ -1,0 +1,125 @@
+// Regression test: the proxy-logs empty state was a dead end — users staring
+// at "no logs" had no path forward. It must offer a "View routes" CTA that
+// navigates to the token-routes page (audit #1029 batch B).
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { ProxyLogsPage } from '../proxy-logs-page'
+
+const testState = vi.hoisted(() => ({
+  navigate: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => testState.navigate,
+}))
+
+vi.mock('@/components/common/query-error-banner', () => ({
+  QueryErrorBanner: () => null,
+}))
+
+vi.mock('@/components/data-table', () => ({
+  DataTablePage: (props: { emptyAction?: ReactNode }) => (
+    <div>{props.emptyAction}</div>
+  ),
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    filters: {
+      status: '',
+      siteId: '',
+      channelId: '',
+      client: '',
+      from: '',
+      to: '',
+      latencyMin: '',
+      latencyMax: '',
+    },
+  }),
+  useDataTable: () => ({ table: {} }),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: { getProxyLogsQuery: vi.fn() },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}))
+
+vi.mock('../../api', () => ({
+  useProxyLogs: () => ({
+    data: { items: [], total: 0 },
+    isLoading: false,
+    isFetching: false,
+    refetch: vi.fn(),
+  }),
+  useProxyLogsMeta: () => ({
+    data: undefined,
+    isFetching: false,
+    refetch: vi.fn(),
+  }),
+}))
+
+vi.mock('../../lib/use-proxy-logs-auto-refresh', () => ({
+  useProxyLogsAutoRefresh: () => ({ intervalMs: false, setIntervalMs: vi.fn() }),
+}))
+
+vi.mock('../proxy-logs-header-actions', () => ({
+  ProxyLogsHeaderActions: () => null,
+}))
+
+vi.mock('../proxy-log-detail-sheet', () => ({
+  ProxyLogDetailSheet: () => null,
+}))
+
+vi.mock('../proxy-logs-auto-refresh-toggle', () => ({
+  ProxyLogsAutoRefreshToggle: () => null,
+}))
+
+vi.mock('../proxy-logs-columns', () => ({
+  useProxyLogsColumns: () => [],
+}))
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  testState.navigate.mockReset()
+})
+
+afterEach(() => cleanup())
+
+describe('ProxyLogsPage empty-state CTA', () => {
+  it('offers a View routes CTA that navigates to /token-routes', () => {
+    render(<ProxyLogsPage />)
+
+    const cta = screen.getByRole('button', { name: 'View routes' })
+    expect(cta).toBeInTheDocument()
+
+    fireEvent.click(cta)
+    expect(testState.navigate).toHaveBeenCalledTimes(1)
+    expect(testState.navigate).toHaveBeenCalledWith({ to: '/token-routes' })
+  })
+})

--- a/web/src/features/proxy-logs/components/__tests__/proxy-logs-page-empty-cta.test.tsx
+++ b/web/src/features/proxy-logs/components/__tests__/proxy-logs-page-empty-cta.test.tsx
@@ -4,7 +4,15 @@
 import '@testing-library/jest-dom/vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 import '@/i18n/config'
 
@@ -68,7 +76,10 @@ vi.mock('../../api', () => ({
 }))
 
 vi.mock('../../lib/use-proxy-logs-auto-refresh', () => ({
-  useProxyLogsAutoRefresh: () => ({ intervalMs: false, setIntervalMs: vi.fn() }),
+  useProxyLogsAutoRefresh: () => ({
+    intervalMs: false,
+    setIntervalMs: vi.fn(),
+  }),
 }))
 
 vi.mock('../proxy-logs-header-actions', () => ({

--- a/web/src/features/proxy-logs/components/__tests__/proxy-logs-page-empty-cta.test.tsx
+++ b/web/src/features/proxy-logs/components/__tests__/proxy-logs-page-empty-cta.test.tsx
@@ -12,14 +12,16 @@ import { ProxyLogsPage } from '../proxy-logs-page'
 
 const testState = vi.hoisted(() => ({
   navigate: vi.fn(),
+  metaQuery: {
+    data: undefined,
+    error: null as Error | null,
+    isFetching: false,
+    refetch: vi.fn(),
+  },
 }))
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => testState.navigate,
-}))
-
-vi.mock('@/components/common/query-error-banner', () => ({
-  QueryErrorBanner: () => null,
 }))
 
 vi.mock('@/components/data-table', () => ({
@@ -62,11 +64,7 @@ vi.mock('../../api', () => ({
     isFetching: false,
     refetch: vi.fn(),
   }),
-  useProxyLogsMeta: () => ({
-    data: undefined,
-    isFetching: false,
-    refetch: vi.fn(),
-  }),
+  useProxyLogsMeta: () => testState.metaQuery,
 }))
 
 vi.mock('../../lib/use-proxy-logs-auto-refresh', () => ({
@@ -107,6 +105,10 @@ beforeAll(() => {
 
 beforeEach(() => {
   testState.navigate.mockReset()
+  testState.metaQuery.data = undefined
+  testState.metaQuery.error = null
+  testState.metaQuery.isFetching = false
+  testState.metaQuery.refetch.mockReset()
 })
 
 afterEach(() => cleanup())
@@ -121,5 +123,19 @@ describe('ProxyLogsPage empty-state CTA', () => {
     fireEvent.click(cta)
     expect(testState.navigate).toHaveBeenCalledTimes(1)
     expect(testState.navigate).toHaveBeenCalledWith({ to: '/token-routes' })
+  })
+})
+
+describe('ProxyLogsPage meta error banner', () => {
+  it('surfaces a meta query failure with a Retry action', () => {
+    testState.metaQuery.error = new Error('meta boom')
+    render(<ProxyLogsPage />)
+
+    expect(
+      screen.getByText(/Failed to load log summary: meta boom/)
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(testState.metaQuery.refetch).toHaveBeenCalledTimes(1)
   })
 })

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -3,6 +3,7 @@
 // i18n: all user-visible strings migrated to t() calls.
 
 import type { Row } from '@tanstack/react-table'
+import { useNavigate } from '@tanstack/react-router'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -159,6 +160,7 @@ function useProxyLogsUrlState() {
 
 export function ProxyLogsPage() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const {
     globalFilter,
     pagination,
@@ -430,6 +432,14 @@ export function ProxyLogsPage() {
         isFetching={logsQuery.isFetching}
         emptyTitle={t('proxyLogs.page.emptyTitle')}
         emptyDescription={t('proxyLogs.page.emptyDescription')}
+        emptyAction={
+          <Button
+            variant='outline'
+            onClick={() => void navigate({ to: '/token-routes' })}
+          >
+            {t('proxyLogs.page.emptyAction')}
+          </Button>
+        }
         skeletonKeyPrefix='proxy-log-skeleton'
         toolbarProps={{
           searchPlaceholder: t('proxyLogs.page.searchPlaceholder'),

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -2,8 +2,8 @@
 // metapi-go/features/proxy-logs/components — proxy logs list page.
 // i18n: all user-visible strings migrated to t() calls.
 
-import type { Row } from '@tanstack/react-table'
 import { useNavigate } from '@tanstack/react-router'
+import type { Row } from '@tanstack/react-table'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -417,6 +417,15 @@ export function ProxyLogsPage() {
         </div>
       )}
 
+      {/* The meta query owns the summary strip; surface its failure so the
+          missing strip reads as an error, not as "no data yet". */}
+      <QueryErrorBanner
+        error={metaQuery.error as Error | null}
+        messageKey='proxyLogs.page.metaLoadError'
+        onRetry={() => metaQuery.refetch()}
+        isRetrying={metaQuery.isFetching}
+      />
+
       <QueryErrorBanner
         error={logsQuery.error as Error | null}
         messageKey='proxyLogs.page.loadError'

--- a/web/src/features/settings/sections/content/components/__tests__/announcements-section.test.tsx
+++ b/web/src/features/settings/sections/content/components/__tests__/announcements-section.test.tsx
@@ -312,3 +312,32 @@ describe('AnnouncementsSection CRUD cache truth', () => {
     })
   })
 })
+
+describe('AnnouncementsSection submitting edit dialog', () => {
+  it('disables Cancel while the save is in flight', async () => {
+    // Hold the create mutation pending so the dialog stays in the saving
+    // state after clicking Save.
+    let release: (value: unknown) => void = () => {}
+    mockCreateAnnouncement.mockReset().mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve
+      })
+    )
+    renderSection()
+    await openCreateDialog()
+    fillRequiredFields()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => {
+      expect(mockCreateAnnouncement).toHaveBeenCalledTimes(1)
+    })
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+
+    // Resolving the save closes the dialog (setEditMode(null)).
+    release({ items: [] })
+    await waitFor(() => {
+      expect(screen.queryByText('Create announcement')).toBeNull()
+    })
+  })
+})

--- a/web/src/features/settings/sections/content/components/__tests__/announcements-section.test.tsx
+++ b/web/src/features/settings/sections/content/components/__tests__/announcements-section.test.tsx
@@ -22,7 +22,7 @@ import {
 } from 'vitest'
 
 import '@/i18n/config'
-import { api, type Announcement } from '@/lib/api'
+import { api, type Announcement, type AnnouncementsResponse } from '@/lib/api'
 import { productAnnouncementKeys } from '@/lib/product-announcements'
 import { toast } from '@/lib/toast'
 
@@ -317,7 +317,7 @@ describe('AnnouncementsSection submitting edit dialog', () => {
   it('disables Cancel while the save is in flight', async () => {
     // Hold the create mutation pending so the dialog stays in the saving
     // state after clicking Save.
-    let release: (value: unknown) => void = () => {}
+    let release: (value: AnnouncementsResponse) => void = () => {}
     mockCreateAnnouncement.mockReset().mockReturnValue(
       new Promise((resolve) => {
         release = resolve

--- a/web/src/features/settings/sections/content/components/__tests__/import-export-invalidate.test.tsx
+++ b/web/src/features/settings/sections/content/components/__tests__/import-export-invalidate.test.tsx
@@ -1,0 +1,192 @@
+// Regression test: backup imports must invalidate every cached domain
+// (sites / accounts / attention / settings / webdav) so list pages and
+// dashboard widgets refresh after the import lands (audit #1029 batch B).
+// Previously the success toast fired but stale queries kept showing
+// pre-import data until a manual refresh.
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+
+import { ImportExportSection } from '../import-export-section'
+
+const {
+  mockGetBackupWebdavConfig,
+  mockImportBackup,
+  mockImportBackupFromWebdav,
+  mockPreviewBackupImport,
+} = vi.hoisted(() => ({
+  mockGetBackupWebdavConfig: vi.fn(),
+  mockImportBackup: vi.fn(),
+  mockImportBackupFromWebdav: vi.fn(),
+  mockPreviewBackupImport: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getBackupWebdavConfig: mockGetBackupWebdavConfig,
+    importBackup: mockImportBackup,
+    importBackupFromWebdav: mockImportBackupFromWebdav,
+    previewBackupImport: mockPreviewBackupImport,
+    exportBackupRaw: vi.fn(),
+    exportBackupToWebdav: vi.fn(),
+    saveBackupWebdavConfig: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+// FormNavigationGuard is the only router consumer in this tree; stub the
+// blocker so the section renders without a router context.
+vi.mock('@tanstack/react-router', () => ({
+  useBlocker: () => ({ status: 'idle' }),
+}))
+
+const webdavConfig = {
+  enabled: true,
+  fileUrl: 'https://dav.example.com/backups/metapi.json',
+  username: 'dav-user',
+  hasPassword: true,
+  passwordMasked: '••••••••',
+  exportType: 'all',
+  autoSyncEnabled: false,
+  autoSyncCron: '0 */6 * * *',
+}
+
+beforeAll(() => {
+  // base-ui AlertDialog/Select query matchMedia under jsdom.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  mockGetBackupWebdavConfig.mockReset()
+  mockImportBackup.mockReset()
+  mockImportBackupFromWebdav.mockReset()
+  mockPreviewBackupImport.mockReset()
+  mockGetBackupWebdavConfig.mockResolvedValue({
+    success: true,
+    ...webdavConfig,
+    config: webdavConfig,
+    state: {},
+  })
+  mockImportBackup.mockResolvedValue({ success: true })
+  mockImportBackupFromWebdav.mockResolvedValue({ success: true })
+  mockPreviewBackupImport.mockResolvedValue({
+    success: true,
+    plan: { accounts: { rows: 1, toInsert: 1, duplicates: 0, skippedRows: 0 } },
+  })
+})
+
+afterEach(() => cleanup())
+
+function renderImportExportSection() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ImportExportSection />
+    </QueryClientProvider>
+  )
+  return { invalidateSpy }
+}
+
+// The confirm dialog action shares the trigger's label; the dialog's action
+// is the last matching button in the tree.
+function clickLastButtonNamed(name: string) {
+  const buttons = screen.getAllByRole('button', { name })
+  const button = buttons.at(-1)
+  if (!button) {
+    throw new Error(`Button "${name}" not found`)
+  }
+  fireEvent.click(button)
+}
+
+const EXPECTED_KEYS = [
+  ['sites', 'list'],
+  ['accounts'],
+  ['dashboard-attention'],
+  ['settings-auth-info'],
+  ['backup-webdav'],
+]
+
+function expectInvalidated(invalidateSpy: ReturnType<typeof vi.spyOn>) {
+  for (const key of EXPECTED_KEYS) {
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: key })
+  }
+}
+
+describe('ImportExportSection — cache invalidation after import', () => {
+  it('invalidates domain queries after a pasted backup import', async () => {
+    const { invalidateSpy } = renderImportExportSection()
+
+    fireEvent.change(screen.getByPlaceholderText('{ "version": "..." }'), {
+      target: { value: '{"version":1}' },
+    })
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Preview import' })
+    )
+
+    await screen.findByText('Confirm import?')
+    clickLastButtonNamed('Import')
+
+    await waitFor(() => {
+      expect(mockImportBackup).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => expectInvalidated(invalidateSpy))
+  })
+
+  it('invalidates domain queries after a WebDAV backup import', async () => {
+    const { invalidateSpy } = renderImportExportSection()
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Import from WebDAV' })
+    )
+    await screen.findByText('Import backup from WebDAV?')
+    clickLastButtonNamed('Import from WebDAV')
+
+    await waitFor(() => {
+      expect(mockImportBackupFromWebdav).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => expectInvalidated(invalidateSpy))
+  })
+})

--- a/web/src/features/settings/sections/content/components/announcements-section.tsx
+++ b/web/src/features/settings/sections/content/components/announcements-section.tsx
@@ -446,6 +446,7 @@ export function AnnouncementsSection() {
             <Button
               variant='outline'
               onClick={() => guardedEditOpenChange(false)}
+              disabled={upsertMutation.isPending}
             >
               {t('settings.common.cancel')}
             </Button>

--- a/web/src/features/settings/sections/content/components/import-export-section.tsx
+++ b/web/src/features/settings/sections/content/components/import-export-section.tsx
@@ -10,8 +10,6 @@ import { z } from 'zod'
 
 import { ConfirmDialog } from '@/components/common/confirm-dialog'
 import { Button } from '@/components/ui/button'
-import { accountQueryKeys } from '@/features/accounts'
-import { sitesKeys } from '@/features/sites'
 import {
   Form,
   FormControl,
@@ -31,6 +29,8 @@ import {
 } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
+import { accountQueryKeys } from '@/features/accounts'
+import { sitesKeys } from '@/features/sites'
 import {
   api,
   type BackupWebdavExportType,

--- a/web/src/features/settings/sections/content/components/import-export-section.tsx
+++ b/web/src/features/settings/sections/content/components/import-export-section.tsx
@@ -10,6 +10,8 @@ import { z } from 'zod'
 
 import { ConfirmDialog } from '@/components/common/confirm-dialog'
 import { Button } from '@/components/ui/button'
+import { accountQueryKeys } from '@/features/accounts'
+import { sitesKeys } from '@/features/sites'
 import {
   Form,
   FormControl,
@@ -160,6 +162,19 @@ export function ImportExportSection() {
       toast.error(t('settings.content.importExport.toast.exportFailed')),
   })
 
+  /**
+   * A backup import can replace sites, accounts, preferences, attention
+   * entries and the WebDAV config — invalidate every cached domain so list
+   * pages and dashboard widgets reflect the restored data immediately.
+   */
+  function invalidateAfterImport() {
+    void queryClient.invalidateQueries({ queryKey: sitesKeys.list() })
+    void queryClient.invalidateQueries({ queryKey: accountQueryKeys.all })
+    void queryClient.invalidateQueries({ queryKey: ['dashboard-attention'] })
+    void queryClient.invalidateQueries({ queryKey: ['settings-auth-info'] })
+    void queryClient.invalidateQueries({ queryKey: webdavQueryKeys.all })
+  }
+
   const previewMutation = useMutation({
     mutationFn: async (raw: string) => {
       const data = JSON.parse(raw) as unknown
@@ -180,6 +195,7 @@ export function ImportExportSection() {
       toast.success(t('settings.content.importExport.toast.imported'))
       setImportText('')
       setImportPlan(null)
+      invalidateAfterImport()
     },
     onError: () =>
       toast.error(t('settings.content.importExport.toast.importFailed')),
@@ -237,8 +253,10 @@ export function ImportExportSection() {
 
   const importWebdavMutation = useMutation({
     mutationFn: async () => api.importBackupFromWebdav(),
-    onSuccess: () =>
-      toast.success(t('settings.content.importExport.toast.webdavImported')),
+    onSuccess: () => {
+      toast.success(t('settings.content.importExport.toast.webdavImported'))
+      invalidateAfterImport()
+    },
     onError: () =>
       toast.error(t('settings.content.importExport.toast.webdavImportFailed')),
   })

--- a/web/src/features/settings/sections/proxy-models/components/__tests__/redirects-section-error.test.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/__tests__/redirects-section-error.test.tsx
@@ -1,0 +1,112 @@
+// Regression test: a failed redirects load used to fall through to the
+// empty-list branch, masquerading as "no redirects". The section must now
+// render SettingsSectionError with a Retry action (audit #1029 batch B) —
+// mirroring the allowlist section's error branch.
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { RedirectsSection } from '../redirects-section'
+
+const { mockGetRedirects } = vi.hoisted(() => ({
+  mockGetRedirects: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getModelRedirects: mockGetRedirects,
+    deleteModelRedirect: vi.fn(),
+    applyModelRedirects: vi.fn(),
+    generateModelRedirects: vi.fn(),
+    updateModelRedirect: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  mockGetRedirects.mockReset()
+})
+
+afterEach(() => cleanup())
+
+function renderSection() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return render(
+    (
+      <QueryClientProvider client={queryClient}>
+        <RedirectsSection />
+      </QueryClientProvider>
+    ) as ReactElement
+  )
+}
+
+describe('RedirectsSection load error', () => {
+  it('renders the section error instead of a fake empty list', async () => {
+    mockGetRedirects.mockRejectedValue(new Error('boom'))
+
+    renderSection()
+
+    await screen.findByText(/Failed to load settings/)
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+    // The empty-list copy must not masquerade as the failure state.
+    expect(screen.queryByText(/No model redirects/)).not.toBeInTheDocument()
+  })
+
+  it('recovers to the list after Retry', async () => {
+    mockGetRedirects.mockRejectedValueOnce(new Error('boom'))
+    mockGetRedirects.mockResolvedValue({
+      items: [
+        {
+          id: 7,
+          accountId: 1,
+          username: 'ops',
+          canonical: 'gpt-5.5',
+          actual: 'gpt-5.4',
+          source: 'manual',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ],
+    })
+
+    renderSection()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('gpt-5.5')).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/features/settings/sections/proxy-models/components/__tests__/redirects-section-error.test.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/__tests__/redirects-section-error.test.tsx
@@ -4,9 +4,23 @@
 // mirroring the allowlist section's error branch.
 import '@testing-library/jest-dom/vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import type { ReactElement } from 'react'
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 import '@/i18n/config'
 

--- a/web/src/features/settings/sections/proxy-models/components/__tests__/redirects-section.test.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/__tests__/redirects-section.test.tsx
@@ -189,3 +189,23 @@ describe('RedirectsSection dangerous-op confirmations', () => {
     })
   })
 })
+
+describe('RedirectsSection empty-state CTA', () => {
+  it('offers a Generate CTA in the empty state', async () => {
+    mockGetRedirects.mockResolvedValue({ items: [] })
+    renderSection()
+
+    expect(await screen.findByText(/No model redirects/)).toBeInTheDocument()
+
+    // The header actions carry a Generate button too; the empty-state CTA is
+    // the last one in the tree.
+    const generateButtons = screen.getAllByRole('button', { name: 'Generate' })
+    const ctaButton = generateButtons.at(-1)
+    if (!ctaButton) throw new Error('empty-state Generate CTA not rendered')
+    fireEvent.click(ctaButton)
+
+    await waitFor(() => {
+      expect(mockGenerateRedirects).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/web/src/features/settings/sections/proxy-models/components/redirects-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/redirects-section.tsx
@@ -171,9 +171,19 @@ export function RedirectsSection() {
       }
     >
       {items.length === 0 ? (
-        <p className='text-muted-foreground py-8 text-center text-sm'>
-          {t('settings.proxyModels.redirects.empty')}
-        </p>
+        <div className='flex flex-col items-center gap-3 py-8 text-center'>
+          <p className='text-muted-foreground text-sm'>
+            {t('settings.proxyModels.redirects.empty')}
+          </p>
+          <Button
+            size='sm'
+            variant='outline'
+            disabled={generateMutation.isPending}
+            onClick={() => generateMutation.mutate()}
+          >
+            {t('settings.proxyModels.redirects.generate')}
+          </Button>
+        </div>
       ) : (
         <Table>
           <TableHeader>

--- a/web/src/features/settings/sections/proxy-models/components/redirects-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/redirects-section.tsx
@@ -29,6 +29,7 @@ import {
   SettingsSectionCard,
   SettingsSectionSkeleton,
 } from '../../../components/settings-section-card'
+import { SettingsSectionError } from '../../../components/settings-section-error'
 
 const modelRedirectsQueryKeys = {
   all: ['model-redirects'] as const,
@@ -126,6 +127,15 @@ export function RedirectsSection() {
 
   if (isLoading) {
     return <SettingsSectionSkeleton />
+  }
+
+  if (redirectsQuery.isError || !redirectsQuery.data) {
+    return (
+      <SettingsSectionError
+        title={t('settings.proxyModels.redirects.title')}
+        onRetry={() => void redirectsQuery.refetch()}
+      />
+    )
   }
 
   return (

--- a/web/src/features/site-announcements/__tests__/site-announcements-page.test.tsx
+++ b/web/src/features/site-announcements/__tests__/site-announcements-page.test.tsx
@@ -207,6 +207,22 @@ describe('SiteAnnouncementsPage — list rendering', () => {
     ).toBeInTheDocument()
   })
 
+  it('empty state offers a Sync now CTA that triggers the sync', async () => {
+    mockApi.getSiteAnnouncements.mockResolvedValue([])
+    mockApi.syncSiteAnnouncements.mockResolvedValue({ taskId: 5 })
+    renderPage()
+
+    expect(await screen.findByText('No announcements yet')).toBeInTheDocument()
+    // The header carries a Sync now button too; the empty-state CTA is the
+    // last one in the tree.
+    const syncButtons = screen.getAllByRole('button', { name: 'Sync now' })
+    fireEvent.click(syncButtons.at(-1) as HTMLElement)
+
+    await waitFor(() => {
+      expect(mockApi.syncSiteAnnouncements).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('surfaces API failures in an error banner with a working Retry', async () => {
     mockApi.getSiteAnnouncements
       .mockRejectedValueOnce(new Error('boom'))

--- a/web/src/features/site-announcements/components/site-announcements-page.tsx
+++ b/web/src/features/site-announcements/components/site-announcements-page.tsx
@@ -484,6 +484,22 @@ export function SiteAnnouncementsPage() {
               ? t('siteAnnouncements.empty.filteredDescription')
               : t('siteAnnouncements.empty.description')}
           </p>
+          {!isFiltered ? (
+            <Button
+              variant='outline'
+              size='sm'
+              className='mt-2'
+              disabled={syncMutation.isPending || syncIsActive}
+              onClick={() => syncMutation.mutate()}
+            >
+              {syncMutation.isPending || syncIsActive ? (
+                <Spinner />
+              ) : (
+                <RefreshCw className='size-3.5' />
+              )}
+              {t('siteAnnouncements.actions.sync')}
+            </Button>
+          ) : null}
         </div>
       ) : null}
 

--- a/web/src/features/token-routes/components/__tests__/routes-page-confirm-dialogs.test.tsx
+++ b/web/src/features/token-routes/components/__tests__/routes-page-confirm-dialogs.test.tsx
@@ -1,0 +1,187 @@
+// Regression tests for destructive-adjacent route actions: the header
+// "Auto-rebuild" action and the bulk "Disable" action both fired immediately;
+// they must now open a confirmation dialog first (audit #1029 batch B).
+import '@testing-library/jest-dom/vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { RoutesPage } from '../routes-page'
+
+const testState = vi.hoisted(() => ({
+  rebuildMutate: vi.fn(),
+  batchMutateAsync: vi.fn(),
+}))
+
+vi.mock('@/components/data-table', () => ({
+  // Render the bulk action children so the Disable button is clickable.
+  DataTableBulkActions: (props: { children?: ReactNode }) => (
+    <div>{props.children}</div>
+  ),
+  DataTablePage: (props: { bulkActions?: ReactNode }) => (
+    <div>{props.bulkActions}</div>
+  ),
+  useUrlTableState: () => ({
+    globalFilter: '',
+    onGlobalFilterChange: vi.fn(),
+    columnFilters: [],
+    onColumnFiltersChange: vi.fn(),
+    pagination: { pageIndex: 0, pageSize: 20 },
+    onPaginationChange: vi.fn(),
+    sorting: [],
+    onSortingChange: vi.fn(),
+    filters: { enabled: '', accountId: '', siteId: '', routeId: '' },
+  }),
+  useDataTable: () => ({
+    table: {
+      // One selected route with a real id so the bulk action proceeds.
+      getFilteredSelectedRowModel: () => ({
+        rows: [{ original: { id: 7 } }],
+      }),
+      resetRowSelection: vi.fn(),
+    },
+  }),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useSearch: () => ({}),
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock('@/features/accounts/api', () => ({
+  useAccounts: () => ({ data: undefined }),
+}))
+vi.mock('@/features/sites/api', () => ({
+  useSites: () => ({ data: undefined }),
+}))
+vi.mock('@/features/channels/api', () => ({
+  useChannels: () => ({ data: [] }),
+}))
+
+vi.mock('../../api', () => ({
+  useRoutes: () => ({ data: [], error: null, isLoading: false, isFetching: false }),
+  useModelTokenCandidates: () => ({ data: undefined }),
+  useDeleteRoute: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateRoute: () => ({ mutate: vi.fn(), isPending: false }),
+  useClearRouteCooldown: () => ({ mutate: vi.fn(), isPending: false }),
+  useRebuildRoutes: () => ({ mutate: testState.rebuildMutate, isPending: false }),
+  useRefreshRouteDecisions: () => ({ mutate: vi.fn(), isPending: false }),
+  useBatchUpdateRoutes: () => ({
+    mutateAsync: testState.batchMutateAsync,
+    isPending: false,
+  }),
+  useZeroChannelRoutes: (routes: unknown[]) => routes ?? [],
+}))
+
+vi.mock('../routes-columns', () => ({
+  useRoutesColumns: () => [],
+}))
+
+vi.mock('../route-form-dialog', () => ({
+  RouteFormDialog: () => null,
+}))
+
+vi.mock('../route-detail-sheet', () => ({
+  RouteDetailSheet: () => null,
+}))
+
+beforeAll(() => {
+  // base-ui AlertDialog queries matchMedia under jsdom.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  testState.rebuildMutate.mockReset()
+  testState.batchMutateAsync.mockReset()
+})
+
+afterEach(() => cleanup())
+
+// The dialog action shares its label with the trigger; the action button is
+// the last matching button in the tree once the dialog is open.
+function clickLastButtonNamed(name: string) {
+  const buttons = screen.getAllByRole('button', { name })
+  const button = buttons.at(-1)
+  if (!button) {
+    throw new Error(`Button "${name}" not found`)
+  }
+  fireEvent.click(button)
+}
+
+describe('RoutesPage rebuild confirmation', () => {
+  it('opens a confirmation before rebuilding routes', () => {
+    render(<RoutesPage />)
+
+    clickLastButtonNamed('Auto-rebuild')
+
+    expect(screen.getByText('Rebuild routes?')).toBeInTheDocument()
+    expect(testState.rebuildMutate).not.toHaveBeenCalled()
+  })
+
+  it('rebuilds after confirming', async () => {
+    render(<RoutesPage />)
+
+    clickLastButtonNamed('Auto-rebuild')
+    clickLastButtonNamed('Auto-rebuild')
+
+    await waitFor(() => {
+      expect(testState.rebuildMutate).toHaveBeenCalledTimes(1)
+    })
+    expect(testState.rebuildMutate).toHaveBeenCalledWith({ refreshModels: true })
+  })
+
+  it('does not rebuild when the confirmation is cancelled', () => {
+    render(<RoutesPage />)
+
+    clickLastButtonNamed('Auto-rebuild')
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(testState.rebuildMutate).not.toHaveBeenCalled()
+  })
+})
+
+describe('RoutesPage bulk disable confirmation', () => {
+  it('opens a confirmation before bulk disabling', () => {
+    render(<RoutesPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Disable' }))
+
+    expect(screen.getByText('Disable selected routes?')).toBeInTheDocument()
+    expect(testState.batchMutateAsync).not.toHaveBeenCalled()
+  })
+
+  it('bulk disables after confirming', async () => {
+    render(<RoutesPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Disable' }))
+    clickLastButtonNamed('Disable')
+
+    await waitFor(() => {
+      expect(testState.batchMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(testState.batchMutateAsync).toHaveBeenCalledWith({
+      ids: [7],
+      action: 'disable',
+    })
+  })
+})

--- a/web/src/features/token-routes/components/__tests__/routes-page-confirm-dialogs.test.tsx
+++ b/web/src/features/token-routes/components/__tests__/routes-page-confirm-dialogs.test.tsx
@@ -10,7 +10,15 @@ import {
   waitFor,
 } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 import '@/i18n/config'
 
@@ -67,12 +75,20 @@ vi.mock('@/features/channels/api', () => ({
 }))
 
 vi.mock('../../api', () => ({
-  useRoutes: () => ({ data: [], error: null, isLoading: false, isFetching: false }),
+  useRoutes: () => ({
+    data: [],
+    error: null,
+    isLoading: false,
+    isFetching: false,
+  }),
   useModelTokenCandidates: () => ({ data: undefined }),
   useDeleteRoute: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useUpdateRoute: () => ({ mutate: vi.fn(), isPending: false }),
   useClearRouteCooldown: () => ({ mutate: vi.fn(), isPending: false }),
-  useRebuildRoutes: () => ({ mutate: testState.rebuildMutate, isPending: false }),
+  useRebuildRoutes: () => ({
+    mutate: testState.rebuildMutate,
+    isPending: false,
+  }),
   useRefreshRouteDecisions: () => ({ mutate: vi.fn(), isPending: false }),
   useBatchUpdateRoutes: () => ({
     mutateAsync: testState.batchMutateAsync,
@@ -147,7 +163,9 @@ describe('RoutesPage rebuild confirmation', () => {
     await waitFor(() => {
       expect(testState.rebuildMutate).toHaveBeenCalledTimes(1)
     })
-    expect(testState.rebuildMutate).toHaveBeenCalledWith({ refreshModels: true })
+    expect(testState.rebuildMutate).toHaveBeenCalledWith({
+      refreshModels: true,
+    })
   })
 
   it('does not rebuild when the confirmation is cancelled', () => {

--- a/web/src/features/token-routes/components/routes-page.tsx
+++ b/web/src/features/token-routes/components/routes-page.tsx
@@ -8,6 +8,7 @@ import { Plus, Power, RefreshCw, Zap } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { ConfirmDialog } from '@/components/common/confirm-dialog'
 import {
   DataTableBulkActions,
   DataTablePage,
@@ -246,6 +247,7 @@ export function RoutesPage() {
   const [deleteRouteState, setDeleteRoute] = useState<RouteSummaryRow | null>(
     null
   )
+  const [rebuildConfirmOpen, setRebuildConfirmOpen] = useState(false)
 
   // One-shot route drilldown (proxy-log detail -> `?routeId=N`): wait for
   // the list, open the detail sheet for the referenced route, then strip
@@ -421,7 +423,7 @@ export function RoutesPage() {
           </p>
         </div>
         <RoutesHeaderActions
-          onRebuild={() => rebuildMutation.mutate({ refreshModels: true })}
+          onRebuild={() => setRebuildConfirmOpen(true)}
           isRebuildPending={rebuildMutation.isPending}
           onRefreshDecisions={() => refreshDecisionsMutation.mutate()}
           isRefreshDecisionsPending={refreshDecisionsMutation.isPending}
@@ -476,7 +478,7 @@ export function RoutesPage() {
               </Button>
               <Button
                 variant='outline'
-                onClick={() => rebuildMutation.mutate({ refreshModels: true })}
+                onClick={() => setRebuildConfirmOpen(true)}
                 disabled={rebuildMutation.isPending}
               >
                 {rebuildMutation.isPending ? <Spinner /> : <Zap />}
@@ -579,6 +581,20 @@ export function RoutesPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <ConfirmDialog
+        open={rebuildConfirmOpen}
+        title={t('tokenRoutes.page.rebuildConfirmTitle')}
+        description={t('tokenRoutes.page.rebuildConfirmDescription')}
+        confirmLabel={t('tokenRoutes.page.rebuild')}
+        cancelLabel={t('common.cancel')}
+        destructive
+        onConfirm={() => {
+          setRebuildConfirmOpen(false)
+          rebuildMutation.mutate({ refreshModels: true })
+        }}
+        onCancel={() => setRebuildConfirmOpen(false)}
+      />
     </div>
   )
 }
@@ -586,6 +602,7 @@ export function RoutesPage() {
 function RoutesBulkActions({ table }: { table: Table<RouteSummaryRow> }) {
   const { t } = useTranslation()
   const batchMutation = useBatchUpdateRoutes()
+  const [confirmDisableOpen, setConfirmDisableOpen] = useState(false)
 
   // Derived per render — `table` identity is stable across selection changes
   // then a `useMemo([table])` would freeze the ids at their mount-time value
@@ -606,28 +623,46 @@ function RoutesBulkActions({ table }: { table: Table<RouteSummaryRow> }) {
   }
 
   return (
-    <DataTableBulkActions
-      table={table}
-      entityName={t('tokenRoutes.page.bulkEntityName')}
-    >
-      <Button
-        size='sm'
-        variant='outline'
-        onClick={() => runBatch('enable')}
-        disabled={batchMutation.isPending}
+    <>
+      <DataTableBulkActions
+        table={table}
+        entityName={t('tokenRoutes.page.bulkEntityName')}
       >
-        <Power />
-        {t('tokenRoutes.page.bulkEnable')}
-      </Button>
-      <Button
-        size='sm'
-        variant='outline'
-        onClick={() => runBatch('disable')}
-        disabled={batchMutation.isPending}
-      >
-        {t('tokenRoutes.page.bulkDisable')}
-      </Button>
-    </DataTableBulkActions>
+        <Button
+          size='sm'
+          variant='outline'
+          onClick={() => runBatch('enable')}
+          disabled={batchMutation.isPending}
+        >
+          <Power />
+          {t('tokenRoutes.page.bulkEnable')}
+        </Button>
+        <Button
+          size='sm'
+          variant='outline'
+          onClick={() => setConfirmDisableOpen(true)}
+          disabled={batchMutation.isPending}
+        >
+          {t('tokenRoutes.page.bulkDisable')}
+        </Button>
+      </DataTableBulkActions>
+
+      <ConfirmDialog
+        open={confirmDisableOpen}
+        title={t('tokenRoutes.page.bulkDisableConfirmTitle')}
+        description={t('tokenRoutes.page.bulkDisableConfirmDescription', {
+          count: selectedIds.length,
+        })}
+        confirmLabel={t('tokenRoutes.page.bulkDisable')}
+        cancelLabel={t('common.cancel')}
+        destructive
+        onConfirm={() => {
+          setConfirmDisableOpen(false)
+          void runBatch('disable')
+        }}
+        onCancel={() => setConfirmDisableOpen(false)}
+      />
+    </>
   )
 }
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2359,6 +2359,7 @@
         "summaryFailed": "Failed",
         "summaryCost": "Total cost (filtered)",
         "loadError": "Failed to load proxy logs: {{message}}",
+        "metaLoadError": "Failed to load log summary: {{message}}",
         "emptyTitle": "No proxy logs",
         "emptyDescription": "Adjust the filter conditions or refresh to view proxy request records.",
         "emptyAction": "View routes",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1758,7 +1758,10 @@
         "deleteConfirmTitle": "Delete selected accounts?",
         "deleteConfirmDescription": "This will delete the {{count}} selected account(s). This action cannot be undone.",
         "deleteConfirmConfirm": "Delete",
-        "deleteConfirmCancel": "Cancel"
+        "deleteConfirmCancel": "Cancel",
+        "disableConfirmTitle": "Disable selected accounts?",
+        "disableConfirmDescription": "The {{count}} selected account(s) will stop serving requests until re-enabled.",
+        "disableConfirmConfirm": "Disable"
       },
       "form": {
         "invalid": "Please check the highlighted form fields",
@@ -2020,9 +2023,13 @@
         "showZeroChannel": "Show zero-channel models (accounts have models but no routes generated)",
         "deleteTitle": "Delete route",
         "deleteDescription": "Delete route \"{{name}}\"? This action cannot be undone, and associated channels will be removed.",
+        "rebuildConfirmTitle": "Rebuild routes?",
+        "rebuildConfirmDescription": "Channels of existing routes will be recomposed from current model availability. Live routing may change.",
         "bulkEntityName": "route",
         "bulkEnable": "Enable",
-        "bulkDisable": "Disable"
+        "bulkDisable": "Disable",
+        "bulkDisableConfirmTitle": "Disable selected routes?",
+        "bulkDisableConfirmDescription": "The {{count}} selected route(s) will stop serving requests until re-enabled."
       },
       "form": {
         "invalid": "Please check the highlighted form fields",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2361,6 +2361,7 @@
         "loadError": "Failed to load proxy logs: {{message}}",
         "emptyTitle": "No proxy logs",
         "emptyDescription": "Adjust the filter conditions or refresh to view proxy request records.",
+        "emptyAction": "View routes",
         "searchPlaceholder": "Search model / account / token…",
         "filterStatusPlaceholder": "Status",
         "filterSitePlaceholder": "Site",
@@ -2832,7 +2833,8 @@
         "description": "Cross-site effective model pricing with price sources and recommendations (lowest effective cost per model).",
         "searchPlaceholder": "Filter by model…",
         "loadError": "Failed to load price comparison: {{message}}",
-        "emptyDescription": "No price data yet. Connect accounts or run traffic to see effective pricing."
+        "emptyDescription": "No price data yet. Connect accounts or run traffic to see effective pricing.",
+        "emptyAction": "Manage accounts"
       },
       "group": {
         "description": "Effective price per source site, cheapest first. Source priority: billing > observed > configured > fallback (first available wins)."

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1758,7 +1758,10 @@
         "deleteConfirmTitle": "删除选中的账号？",
         "deleteConfirmDescription": "将删除选中的 {{count}} 个账号，此操作不可撤销。",
         "deleteConfirmConfirm": "删除",
-        "deleteConfirmCancel": "取消"
+        "deleteConfirmCancel": "取消",
+        "disableConfirmTitle": "停用选中的账号？",
+        "disableConfirmDescription": "选中的 {{count}} 个账号将停止响应请求，直到重新启用。",
+        "disableConfirmConfirm": "停用"
       },
       "form": {
         "invalid": "请检查表单标红字段",
@@ -2020,9 +2023,13 @@
         "showZeroChannel": "显示零通道模型（账号有模型但未生成路由）",
         "deleteTitle": "删除路由",
         "deleteDescription": "确定删除路由「{{name}}」？该操作不可撤销，相关通道将一并清除。",
+        "rebuildConfirmTitle": "重建路由？",
+        "rebuildConfirmDescription": "将根据当前模型可用性重组现有路由的通道，实时路由可能发生变化。",
         "bulkEntityName": "路由",
         "bulkEnable": "启用",
-        "bulkDisable": "停用"
+        "bulkDisable": "停用",
+        "bulkDisableConfirmTitle": "停用选中的路由？",
+        "bulkDisableConfirmDescription": "选中的 {{count}} 条路由将停止响应请求，直到重新启用。"
       },
       "form": {
         "invalid": "请检查表单标红字段",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2361,6 +2361,7 @@
         "loadError": "加载代理日志失败：{{message}}",
         "emptyTitle": "暂无代理日志",
         "emptyDescription": "调整筛选条件或稍后刷新以查看代理请求记录。",
+        "emptyAction": "查看路由",
         "searchPlaceholder": "搜索模型 / 账号 / 令牌…",
         "filterStatusPlaceholder": "状态",
         "filterSitePlaceholder": "站点",
@@ -2832,7 +2833,8 @@
         "description": "跨站点有效模型价格，含价格来源与推荐（同模型最低有效成本）。",
         "searchPlaceholder": "按模型筛选…",
         "loadError": "加载价格对比失败：{{message}}",
-        "emptyDescription": "暂无价格数据。连接账号或产生流量后即可查看有效价格。"
+        "emptyDescription": "暂无价格数据。连接账号或产生流量后即可查看有效价格。",
+        "emptyAction": "管理账号"
       },
       "group": {
         "description": "按来源站点的有效价格从低到高。来源优先级：计费明细 > 观测 > 已配置 > 兜底，取可用且优先级最高者。"

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2359,6 +2359,7 @@
         "summaryFailed": "失败",
         "summaryCost": "筛选结果总成本",
         "loadError": "加载代理日志失败：{{message}}",
+        "metaLoadError": "加载日志摘要失败：{{message}}",
         "emptyTitle": "暂无代理日志",
         "emptyDescription": "调整筛选条件或稍后刷新以查看代理请求记录。",
         "emptyAction": "查看路由",


### PR DESCRIPTION
Refs #1029（批 B）

- MobileCardList 空态新增 emptyAction 槽位并由 DataTablePage 透传，8 个实体页的移动端空态 CTA 不再丢失
- 备份导入（粘贴 JSON / WebDAV）成功后 invalidate sites/accounts/attention/settings/webdav 查询，列表与仪表盘立即刷新
- models 刷新市场 onSuccess 补 invalidateQueries，不再受 10s staleTime 窗口影响
- 账号/路由批量禁用与路由重建改为 ConfirmDialog 确认后才执行，避免误触改动实时路由
- redirects 区块加载失败渲染 SettingsSectionError（不再伪装成空列表）
- 四处空态补 CTA：proxy-logs 指向路由页、site-announcements 触发同步、price-compare 指向账号管理、redirects 直接 Generate
- ChartError 增加 Retry 重试；proxy-logs meta 查询失败显示错误横幅
- announcements 弹窗提交中禁用 Cancel；OAuth 启动弹窗表单接入 useDirtyDialogClose 防脏关闭

en/zh i18n 双键齐补；各项均有测试佐证（触及面 84 文件 536 测试全绿）；lint/typecheck/format 全绿。