### PR TITLE
feat: batch-test closure loop - truthful batch updates + one-click disable of failed channels (P1-3)

### DIFF
--- a/handler/admin/channels_batch_update_test.go
+++ b/handler/admin/channels_batch_update_test.go
@@ -27,7 +27,7 @@ func seedBatchUpdateChannels(t *testing.T, db *store.DB, routeID, accountID, tok
 		id, err := execInsertID(db.DB,
 			`INSERT INTO route_channels
 				(route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-			 VALUES (?, ?, ?, ?, 3, 15, 1, 0)`,
+			 VALUES (?, ?, ?, ?, 3, 15, true, false)`,
 			routeID, accountID, tokenID, sourceModel,
 		)
 		if err != nil {

--- a/handler/admin/channels_batch_update_test.go
+++ b/handler/admin/channels_batch_update_test.go
@@ -1,0 +1,278 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// ---- PUT /api/channels/batch (Wave 17 P1-3: batch test closure loop) ----
+//
+// The model-tester batch comparison's "disable failed channels" action calls
+// this endpoint with `enabled:false` items. These tests pin the per-item
+// truth contract (successIds + failedItems), the validation surface, the
+// partial-update semantics (only present fields change), and the audit trail.
+
+func seedBatchUpdateChannels(t *testing.T, db *store.DB, routeID, accountID, tokenID int64, count int) []int64 {
+	t.Helper()
+	ids := []int64{}
+	for i := 0; i < count; i++ {
+		sourceModel := "gpt-4o"
+		if i > 0 {
+			sourceModel = "gpt-4o-mini-" + itoa(int64(i))
+		}
+		id, err := execInsertID(db.DB,
+			`INSERT INTO route_channels
+				(route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+			 VALUES (?, ?, ?, ?, 3, 15, 1, 0)`,
+			routeID, accountID, tokenID, sourceModel,
+		)
+		if err != nil {
+			t.Fatalf("insert channel %d: %v", i, err)
+		}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func putChannelsBatch(t *testing.T, r chi.Router, updates any) map[string]any {
+	t.Helper()
+	resp := doPutJSON(t, r, "/api/channels/batch", map[string]any{"updates": updates})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode envelope: %v (body=%s)", err, resp.Body.String())
+	}
+	return envelope
+}
+
+func TestBatchUpdateChannels_DisablesChannelsTruthfully(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+	ids := seedBatchUpdateChannels(t, db, routeID, accountID, tokenID, 2)
+
+	envelope := putChannelsBatch(t, r, []map[string]any{
+		{"id": ids[0], "enabled": false},
+		{"id": ids[1], "enabled": false},
+	})
+
+	if envelope["success"] != true {
+		t.Fatalf("success = %v, want true; envelope=%#v", envelope["success"], envelope)
+	}
+	successIDs, _ := envelope["successIds"].([]any)
+	if len(successIDs) != 2 {
+		t.Fatalf("successIds = %#v, want both channel ids", envelope["successIds"])
+	}
+	if failed, _ := envelope["failedItems"].([]any); len(failed) != 0 {
+		t.Fatalf("failedItems = %#v, want empty", envelope["failedItems"])
+	}
+
+	// DB truth: both rows disabled and marked manual_override so a route
+	// rebuild cannot silently re-enable them.
+	var enabledCount, overrideCount int
+	if err := db.Get(&enabledCount, "SELECT COUNT(*) FROM route_channels WHERE id IN (?, ?) AND enabled = 1", ids[0], ids[1]); err != nil {
+		t.Fatalf("count enabled: %v", err)
+	}
+	if enabledCount != 0 {
+		t.Fatalf("enabled rows = %d, want 0", enabledCount)
+	}
+	if err := db.Get(&overrideCount, "SELECT COUNT(*) FROM route_channels WHERE id IN (?, ?) AND manual_override = 1", ids[0], ids[1]); err != nil {
+		t.Fatalf("count manual_override: %v", err)
+	}
+	if overrideCount != 2 {
+		t.Fatalf("manual_override rows = %d, want 2", overrideCount)
+	}
+
+	// The channels list projection reports the manual disable.
+	list := doGet(t, r, "/api/channels")
+	var listBody struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(list.Body.Bytes(), &listBody); err != nil {
+		t.Fatalf("decode channels list: %v", err)
+	}
+	if len(listBody.Items) != 2 {
+		t.Fatalf("channels items = %d, want 2", len(listBody.Items))
+	}
+	for _, item := range listBody.Items {
+		if item["status"] != "manually_disabled" {
+			t.Fatalf("status = %v, want manually_disabled", item["status"])
+		}
+	}
+}
+
+func TestBatchUpdateChannels_PartialFailureReportsPerItemTruth(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+	ids := seedBatchUpdateChannels(t, db, routeID, accountID, tokenID, 1)
+
+	envelope := putChannelsBatch(t, r, []map[string]any{
+		{"id": ids[0], "enabled": false},
+		{"id": 999999, "enabled": false},
+	})
+
+	if envelope["success"] != false {
+		t.Fatalf("success = %v, want false on partial failure", envelope["success"])
+	}
+	successIDs, _ := envelope["successIds"].([]any)
+	if len(successIDs) != 1 || successIDs[0] != float64(ids[0]) {
+		t.Fatalf("successIds = %#v, want [%d]", envelope["successIds"], ids[0])
+	}
+	failed, _ := envelope["failedItems"].([]any)
+	if len(failed) != 1 {
+		t.Fatalf("failedItems = %#v, want exactly one entry", envelope["failedItems"])
+	}
+	failedItem, _ := failed[0].(map[string]any)
+	if failedItem["id"] != float64(999999) || failedItem["message"] != "channel not found" {
+		t.Fatalf("failedItems[0] = %#v, want id=999999 message=channel not found", failedItem)
+	}
+
+	// The valid item was still applied — partial failure must not roll back.
+	var enabled int
+	if err := db.Get(&enabled, "SELECT enabled FROM route_channels WHERE id = ?", ids[0]); err != nil {
+		t.Fatalf("read enabled: %v", err)
+	}
+	if enabled != 0 {
+		t.Fatalf("enabled = %d, want 0 (successful item applied despite sibling failure)", enabled)
+	}
+}
+
+func TestBatchUpdateChannels_ValidationFailures(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+	ids := seedBatchUpdateChannels(t, db, routeID, accountID, tokenID, 1)
+
+	// Empty batch is a request-shape error, not a per-item failure.
+	emptyResp := doPutJSON(t, r, "/api/channels/batch", map[string]any{"updates": []map[string]any{}})
+	if emptyResp.Code != http.StatusBadRequest {
+		t.Fatalf("empty batch status = %d, want 400", emptyResp.Code)
+	}
+
+	envelope := putChannelsBatch(t, r, []map[string]any{
+		{"id": 0, "enabled": false},
+		{"id": ids[0]}, // no updatable fields
+		{"id": ids[0], "enabled": true},
+		{"id": ids[0], "enabled": false}, // duplicate id
+	})
+
+	if envelope["success"] != false {
+		t.Fatalf("success = %v, want false", envelope["success"])
+	}
+	successIDs, _ := envelope["successIds"].([]any)
+	if len(successIDs) != 1 {
+		t.Fatalf("successIds = %#v, want exactly one applied item", envelope["successIds"])
+	}
+	failed, _ := envelope["failedItems"].([]any)
+	if len(failed) != 3 {
+		t.Fatalf("failedItems = %#v, want 3 entries (invalid id, no fields, duplicate)", envelope["failedItems"])
+	}
+	messages := map[string]bool{}
+	for _, raw := range failed {
+		item, _ := raw.(map[string]any)
+		msg, _ := item["message"].(string)
+		messages[msg] = true
+	}
+	for _, want := range []string{"invalid id", "no updatable fields (priority, weight or enabled required)", "duplicate id in payload"} {
+		if !messages[want] {
+			t.Fatalf("failedItems messages = %#v, want to include %q", messages, want)
+		}
+	}
+
+	// Oversized payloads are rejected before touching the database.
+	big := make([]map[string]any, 0, 1001)
+	for i := 0; i < 1001; i++ {
+		big = append(big, map[string]any{"id": i + 1, "enabled": false})
+	}
+	bigResp := doPutJSON(t, r, "/api/channels/batch", map[string]any{"updates": big})
+	if bigResp.Code != http.StatusBadRequest {
+		t.Fatalf("oversized batch status = %d, want 400", bigResp.Code)
+	}
+}
+
+func TestBatchUpdateChannels_AppliesOnlyPresentFields(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+	ids := seedBatchUpdateChannels(t, db, routeID, accountID, tokenID, 1)
+
+	putChannelsBatch(t, r, []map[string]any{
+		{"id": ids[0], "enabled": false},
+	})
+
+	var priority, weight, enabled int
+	if err := db.Get(&priority, "SELECT priority FROM route_channels WHERE id = ?", ids[0]); err != nil {
+		t.Fatalf("read priority: %v", err)
+	}
+	if err := db.Get(&weight, "SELECT weight FROM route_channels WHERE id = ?", ids[0]); err != nil {
+		t.Fatalf("read weight: %v", err)
+	}
+	if err := db.Get(&enabled, "SELECT enabled FROM route_channels WHERE id = ?", ids[0]); err != nil {
+		t.Fatalf("read enabled: %v", err)
+	}
+	if priority != 3 || weight != 15 {
+		t.Fatalf("priority/weight = %d/%d, want 3/15 untouched", priority, weight)
+	}
+	if enabled != 0 {
+		t.Fatalf("enabled = %d, want 0", enabled)
+	}
+}
+
+func TestBatchUpdateChannels_WriteIsAudited(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+	ids := seedBatchUpdateChannels(t, db, routeID, accountID, tokenID, 1)
+
+	// Mirror the production wiring (router mounts AuditMiddleware over the
+	// admin group) so the disable action's audit row is proven, not assumed.
+	wrapped := chi.NewRouter()
+	wrapped.Use(AuditMiddleware(db.DB))
+	wrapped.Mount("/", r)
+
+	resp := doPutJSON(t, wrapped, "/api/channels/batch", map[string]any{
+		"updates": []map[string]any{{"id": ids[0], "enabled": false}},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.Code)
+	}
+
+	var count int
+	if err := db.Get(&count, "SELECT COUNT(*) FROM admin_audit_logs WHERE method = ? AND path = ?", http.MethodPut, "/api/channels/batch"); err != nil {
+		t.Fatalf("count audit rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("audit rows for PUT /api/channels/batch = %d, want 1", count)
+	}
+	var status int
+	if err := db.Get(&status, "SELECT status FROM admin_audit_logs WHERE method = ? AND path = ?", http.MethodPut, "/api/channels/batch"); err != nil {
+		t.Fatalf("read audit status: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("audit status = %d, want 200", status)
+	}
+}
+
+func TestBatchUpdateChannels_Postgres_PartialFailure(t *testing.T) {
+	db, r := setupTokenRoutesPostgresTest(t)
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+	ids := seedBatchUpdateChannels(t, db, routeID, accountID, tokenID, 1)
+
+	envelope := putChannelsBatch(t, r, []map[string]any{
+		{"id": ids[0], "enabled": false},
+		{"id": 999999, "enabled": false},
+	})
+
+	if envelope["success"] != false {
+		t.Fatalf("success = %v, want false on partial failure", envelope["success"])
+	}
+	var enabled bool
+	if err := db.Get(&enabled, "SELECT enabled FROM route_channels WHERE id = ?", ids[0]); err != nil {
+		t.Fatalf("read enabled: %v", err)
+	}
+	if enabled {
+		t.Fatalf("enabled = true, want false (successful item applied)")
+	}
+}

--- a/handler/admin/token_routes_channels.go
+++ b/handler/admin/token_routes_channels.go
@@ -197,26 +197,97 @@ func (h *tokenRoutesHandler) clearCooldown(w http.ResponseWriter, r *http.Reques
 
 // ---- Batch Update Channels ----
 // PUT /api/channels/batch
+// Body: { "updates": [ { "id": 12, "enabled": false, "priority": 5, "weight": 20 } ] }
+//
+// Applies only the fields present on each item — the same partial-update
+// semantics as PUT /api/channels/:channelId, including manual_override=true
+// on any intentional edit. The response reports per-item truth: successIds
+// for applied rows and failedItems (id + message) for rejected or missing
+// ones, so a partial failure is never swallowed. `success` is true only when
+// the batch is non-empty and every item applied. `channels` echoes the
+// updated rows. The model-tester batch comparison's "disable failed
+// channels" action uses this endpoint with `enabled:false` items; the admin
+// AuditMiddleware records each call.
 func (h *tokenRoutesHandler) batchUpdateChannels(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Updates []struct {
-			ID       int64 `json:"id"`
-			Priority int64 `json:"priority"`
+			ID       int64  `json:"id"`
+			Priority *int64 `json:"priority"`
+			Weight   *int64 `json:"weight"`
+			Enabled  *bool  `json:"enabled"`
 		} `json:"updates"`
 	}
 	if err := decodeJSONRequest(r, &body); err != nil {
 		writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid request body: "+err.Error())
 		return
 	}
-
-	var updatedIDs []int64
-	for _, update := range body.Updates {
-		h.db.Exec(h.db.Rebind("UPDATE route_channels SET priority = ?, manual_override = ? WHERE id = ?"), update.Priority, true, update.ID)
-		updatedIDs = append(updatedIDs, update.ID)
+	if len(body.Updates) == 0 {
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "updates is required")
+		return
+	}
+	if len(body.Updates) > 1000 {
+		writeErrorWithRequest(w, r, http.StatusBadRequest, "too many items (max 1000)")
+		return
 	}
 
-	var updatedChannels []map[string]any
-	for _, cid := range updatedIDs {
+	successIDs := []int64{}
+	failedItems := []map[string]any{}
+	seen := map[int64]bool{}
+
+	for _, update := range body.Updates {
+		if update.ID <= 0 {
+			failedItems = append(failedItems, map[string]any{"id": update.ID, "message": "invalid id"})
+			continue
+		}
+
+		// Shape validation runs before the duplicate check: an item carrying
+		// no updatable fields is rejected on shape alone and must not consume
+		// the id, so a well-formed item for the same id can still apply.
+		sets := []string{}
+		args := []any{}
+		if update.Priority != nil {
+			sets = append(sets, "priority = ?")
+			args = append(args, *update.Priority)
+		}
+		if update.Weight != nil {
+			sets = append(sets, "weight = ?")
+			args = append(args, *update.Weight)
+		}
+		if update.Enabled != nil {
+			sets = append(sets, "enabled = ?")
+			args = append(args, *update.Enabled)
+		}
+		if len(sets) == 0 {
+			failedItems = append(failedItems, map[string]any{"id": update.ID, "message": "no updatable fields (priority, weight or enabled required)"})
+			continue
+		}
+		if seen[update.ID] {
+			failedItems = append(failedItems, map[string]any{"id": update.ID, "message": "duplicate id in payload"})
+			continue
+		}
+		seen[update.ID] = true
+		// Any intentional channel edit marks manual_override so a route
+		// rebuild cannot wipe operator tuning (mirrors the single-channel
+		// update path).
+		sets = append(sets, "manual_override = ?")
+		args = append(args, true)
+		args = append(args, update.ID)
+
+		res, err := h.db.Exec(h.db.Rebind("UPDATE route_channels SET "+strings.Join(sets, ", ")+" WHERE id = ?"), args...)
+		if err != nil {
+			failedItems = append(failedItems, map[string]any{"id": update.ID, "message": err.Error()})
+			continue
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			failedItems = append(failedItems, map[string]any{"id": update.ID, "message": "channel not found"})
+			continue
+		}
+		successIDs = append(successIDs, update.ID)
+	}
+
+	updatedChannels := []map[string]any{}
+	for _, cid := range successIDs {
 		ch := queryRow(h.db, "SELECT * FROM route_channels WHERE id = ?", cid)
 		if ch != nil {
 			updatedChannels = append(updatedChannels, ch)
@@ -226,8 +297,10 @@ func (h *tokenRoutesHandler) batchUpdateChannels(w http.ResponseWriter, r *http.
 	routing.InvalidateCache()
 	invalidateChannelsSnapshotCache()
 	writeJSON(w, http.StatusOK, map[string]any{
-		"success":  true,
-		"channels": normalizeSlice(updatedChannels),
+		"success":     len(failedItems) == 0,
+		"successIds":  successIDs,
+		"failedItems": failedItems,
+		"channels":    normalizeSlice(updatedChannels),
 	})
 }
 

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -59,7 +59,7 @@ func seedRouteChannelRefs(t *testing.T, db *store.DB) (routeID, accountID, token
 
 	res, err = db.Exec(
 		`INSERT INTO accounts (site_id, access_token, status, checkin_enabled, created_at, updated_at)
-		 VALUES (?, 'session-token', 'active', 1, ?, ?)`,
+		 VALUES (?, 'session-token', 'active', true, ?, ?)`,
 		siteID, now, now,
 	)
 	if err != nil {

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -47,7 +47,11 @@ func setupTokenRoutesPostgresTest(t *testing.T) (*store.DB, chi.Router) {
 func seedRouteChannelRefs(t *testing.T, db *store.DB) (routeID, accountID, tokenID int64) {
 	t.Helper()
 	now := time.Now().UTC().Format(time.RFC3339)
-	res, err := db.Exec(
+	// execInsertID keeps the helper dialect-safe: pgx does not support
+	// LastInsertId (it silently yields 0, breaking the FK chain), and the
+	// boolean literals keep PostgreSQL's strict BOOLEAN columns happy while
+	// SQLite accepts them too.
+	siteID, err := execInsertID(db.DB,
 		`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
 		 VALUES ('Route Site', 'https://route.example.com', 'openai', 'active', ?, ?)`,
 		now, now,
@@ -55,9 +59,8 @@ func seedRouteChannelRefs(t *testing.T, db *store.DB) (routeID, accountID, token
 	if err != nil {
 		t.Fatalf("insert site: %v", err)
 	}
-	siteID, _ := res.LastInsertId()
 
-	res, err = db.Exec(
+	accountID, err = execInsertID(db.DB,
 		`INSERT INTO accounts (site_id, access_token, status, checkin_enabled, created_at, updated_at)
 		 VALUES (?, 'session-token', 'active', true, ?, ?)`,
 		siteID, now, now,
@@ -65,27 +68,24 @@ func seedRouteChannelRefs(t *testing.T, db *store.DB) (routeID, accountID, token
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}
-	accountID, _ = res.LastInsertId()
 
-	res, err = db.Exec(
+	tokenID, err = execInsertID(db.DB,
 		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
-		 VALUES (?, 'route-token', 'sk-route-token', 'ready', 'manual', 1, 0, ?, ?)`,
+		 VALUES (?, 'route-token', 'sk-route-token', 'ready', 'manual', true, false, ?, ?)`,
 		accountID, now, now,
 	)
 	if err != nil {
 		t.Fatalf("insert token: %v", err)
 	}
-	tokenID, _ = res.LastInsertId()
 
-	res, err = db.Exec(
+	routeID, err = execInsertID(db.DB,
 		`INSERT INTO token_routes (model_pattern, enabled, created_at, updated_at)
-		 VALUES ('gpt-*', 1, ?, ?)`,
+		 VALUES ('gpt-*', true, ?, ?)`,
 		now, now,
 	)
 	if err != nil {
 		t.Fatalf("insert route: %v", err)
 	}
-	routeID, _ = res.LastInsertId()
 	return routeID, accountID, tokenID
 }
 

--- a/web/src/features/model-tester/__tests__/model-tester-disable-failed.test.tsx
+++ b/web/src/features/model-tester/__tests__/model-tester-disable-failed.test.tsx
@@ -1,0 +1,290 @@
+// Behavior test for the batch-test closure loop (Wave 17 P1-3): after a
+// comparison settles with failed rows, the bulk "disable failed channels"
+// action confirms with the operator, then PUTs /api/channels/batch with
+// `enabled:false` for exactly the failed channel ids and surfaces the
+// per-item truth envelope (full success vs partial failure) via toasts.
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+import type { ChannelRow } from '@/features/channels'
+import { toast } from '@/lib/toast'
+
+import { ModelTesterPage } from '../components/model-tester-page'
+import type { TesterFormValues } from '../lib/tester-schema'
+
+type SubmitFn = (values: TesterFormValues) => void | Promise<void>
+
+const testState = vi.hoisted(() => ({
+  testChatSync: vi.fn(),
+  batchUpdateChannels: vi.fn(),
+  submit: null as SubmitFn | null,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useSearch: () => ({}),
+  Link: ({ children }: { children?: ReactNode }) => <a>{children}</a>,
+}))
+
+vi.mock('@/features/channels', () => ({
+  useChannels: () => ({ data: channelsFixture }),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: { testChatSync: testState.testChatSync },
+}))
+
+vi.mock('@/lib/api/token-routes', () => ({
+  tokenRoutesApi: { batchUpdateChannels: testState.batchUpdateChannels },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    message: vi.fn(),
+  },
+}))
+
+vi.mock('../components/test-form', () => ({
+  TestForm: ({ onSubmit }: { isRunning: boolean; onSubmit: SubmitFn }) => {
+    testState.submit = onSubmit
+    return (
+      <button type='button' onClick={() => void onSubmit(comparisonValues)}>
+        run comparison
+      </button>
+    )
+  },
+}))
+
+vi.mock('../components/test-response-viewer', () => ({
+  TestResponseViewer: () => null,
+}))
+
+// Controllable stand-in: render an actionable dialog when open so the test
+// can drive confirm/cancel without radix focus plumbing.
+vi.mock('@/components/common/confirm-dialog', () => ({
+  ConfirmDialog: ({
+    open,
+    title,
+    onConfirm,
+    onCancel,
+  }: {
+    open: boolean
+    title: string
+    onConfirm: () => void
+    onCancel: () => void
+  }) =>
+    open ? (
+      <div role='dialog' aria-label={title}>
+        <button type='button' onClick={onConfirm}>
+          confirm-action
+        </button>
+        <button type='button' onClick={onCancel}>
+          cancel-action
+        </button>
+      </div>
+    ) : null,
+}))
+
+const channelsFixture: ChannelRow[] = [
+  {
+    id: 1,
+    routeId: 10,
+    name: 'Fast channel',
+    site: { id: 20, name: 'Primary site' },
+    type: 'account',
+    status: 'enabled',
+    models: 'gpt-5.5',
+    priority: 0,
+    weight: 10,
+    responseMs: null,
+    cooldownUntil: null,
+    cooldownReasonCode: null,
+    cooldownReason: null,
+    cooldownReasonAt: null,
+    enabled: true,
+    manualOverride: false,
+  },
+  {
+    id: 2,
+    routeId: 11,
+    name: 'Broken channel',
+    site: { id: 21, name: 'Backup site' },
+    type: 'account',
+    status: 'enabled',
+    models: 'gpt-5.5',
+    priority: 0,
+    weight: 10,
+    responseMs: null,
+    cooldownUntil: null,
+    cooldownReasonCode: null,
+    cooldownReason: null,
+    cooldownReasonAt: null,
+    enabled: true,
+    manualOverride: false,
+  },
+]
+
+const comparisonValues: TesterFormValues = {
+  model: 'gpt-5-mini',
+  compareChannels: true,
+  channelIds: [1, 2],
+  systemPrompt: '',
+  prompt: 'hello comparison',
+  targetFormat: 'openai',
+  temperature: 0,
+  topP: 1,
+  maxTokens: 0,
+}
+
+function successEnvelope(latencyMs: number): Response {
+  return new Response(
+    JSON.stringify({
+      success: true,
+      statusCode: 200,
+      latencyMs,
+      truncatedBody: JSON.stringify({
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      }),
+      error: null,
+    }),
+    { status: 200 }
+  )
+}
+
+function failureEnvelope(): Response {
+  return new Response(
+    JSON.stringify({
+      success: false,
+      statusCode: 500,
+      latencyMs: 30,
+      truncatedBody: '{}',
+      error: 'upstream down',
+    }),
+    { status: 200 }
+  )
+}
+
+function routeByChannel(payload: { channelId?: number }): Promise<Response> {
+  return Promise.resolve(
+    payload.channelId === 2 ? failureEnvelope() : successEnvelope(120)
+  )
+}
+
+beforeEach(() => {
+  testState.testChatSync.mockReset()
+  testState.batchUpdateChannels.mockReset()
+  vi.mocked(toast.success).mockClear()
+  vi.mocked(toast.warning).mockClear()
+  vi.mocked(toast.error).mockClear()
+})
+
+afterEach(() => cleanup())
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ModelTesterPage />
+    </QueryClientProvider>
+  )
+}
+
+async function runComparisonToSettled() {
+  testState.testChatSync.mockImplementation(routeByChannel)
+  renderPage()
+  fireEvent.click(screen.getByRole('button', { name: 'run comparison' }))
+  await waitFor(() => {
+    expect(screen.getByText('1 succeeded / 1 failed')).toBeInTheDocument()
+  })
+}
+
+describe('ModelTesterPage bulk disable of failed channels', () => {
+  it('disables exactly the failed channels after operator confirmation', async () => {
+    testState.batchUpdateChannels.mockResolvedValue({
+      success: true,
+      successIds: [2],
+      failedItems: [],
+      channels: [],
+    })
+    await runComparisonToSettled()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Disable failed channels' })
+    )
+
+    // Operator confirmation is mandatory before any write.
+    await screen.findByRole('dialog', {
+      name: 'Disable failed channels?',
+    })
+    expect(testState.batchUpdateChannels).not.toHaveBeenCalled()
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'confirm-action' })
+    )
+
+    await waitFor(() => {
+      expect(testState.batchUpdateChannels).toHaveBeenCalledWith([
+        { id: 2, enabled: false },
+      ])
+    })
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled()
+    })
+  })
+
+  it('surfaces per-item failures from the batch envelope', async () => {
+    testState.batchUpdateChannels.mockResolvedValue({
+      success: false,
+      successIds: [],
+      failedItems: [{ id: 2, message: 'channel not found' }],
+      channels: [],
+    })
+    await runComparisonToSettled()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Disable failed channels' })
+    )
+    await screen.findByRole('dialog', { name: 'Disable failed channels?' })
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'confirm-action' })
+    )
+
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalled()
+    })
+  })
+
+  it('cancelling the confirmation performs no write', async () => {
+    await runComparisonToSettled()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Disable failed channels' })
+    )
+    await screen.findByRole('dialog', { name: 'Disable failed channels?' })
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'cancel-action' })
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('dialog', { name: 'Disable failed channels?' })
+      ).not.toBeInTheDocument()
+    })
+    expect(testState.batchUpdateChannels).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/features/model-tester/components/batch-results.test.tsx
+++ b/web/src/features/model-tester/components/batch-results.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -101,5 +101,63 @@ describe('BatchResults', () => {
     expect(
       screen.getByText('0 succeeded / 0 failed / 1 stopped')
     ).toBeInTheDocument()
+  })
+})
+
+describe('BatchResults bulk disable of failed channels', () => {
+  const failure = {
+    channelId: 1,
+    status: 'failure',
+    latencyMs: 123,
+    error: 'upstream unavailable',
+  } as const
+  const success = {
+    channelId: 1,
+    status: 'success',
+    latencyMs: 123,
+    error: undefined,
+  } as const
+
+  it('offers the action only when at least one row failed', () => {
+    const onDisableFailed = vi.fn()
+    const { rerender } = render(
+      <BatchResults
+        channels={channels}
+        isRunning={false}
+        results={[success]}
+        onDisableFailed={onDisableFailed}
+      />
+    )
+    expect(
+      screen.queryByRole('button', { name: 'Disable failed channels' })
+    ).not.toBeInTheDocument()
+
+    rerender(
+      <BatchResults
+        channels={channels}
+        isRunning={false}
+        results={[failure]}
+        onDisableFailed={onDisableFailed}
+      />
+    )
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Disable failed channels' })
+    )
+    expect(onDisableFailed).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks the action while the bulk disable is in flight or comparing', () => {
+    render(
+      <BatchResults
+        channels={channels}
+        isRunning={false}
+        isDisablingFailed
+        results={[failure]}
+        onDisableFailed={vi.fn()}
+      />
+    )
+    expect(
+      screen.getByRole('button', { name: /Disable failed channels/ })
+    ).toBeDisabled()
   })
 })

--- a/web/src/features/model-tester/components/batch-results.tsx
+++ b/web/src/features/model-tester/components/batch-results.tsx
@@ -9,7 +9,7 @@
 // with a per-row pending spinner while the probe is in flight.
 
 import { Link } from '@tanstack/react-router'
-import { RefreshCw } from 'lucide-react'
+import { Ban, RefreshCw } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
@@ -28,6 +28,10 @@ type BatchResultsProps = {
   rerunningChannelIds?: ReadonlySet<number>
   /** Re-run one channel's probe with the comparison's original payload. */
   onRerunRow?: (channelId: number) => void
+  /** One-click disable of every failed channel (opens a confirmation). */
+  onDisableFailed?: () => void
+  /** The bulk disable request is in flight (button pending/disabled). */
+  isDisablingFailed?: boolean
 }
 
 function statusKeyFor(result: BatchProbeResult): string {
@@ -42,6 +46,8 @@ export function BatchResults({
   isRunning,
   rerunningChannelIds,
   onRerunRow,
+  onDisableFailed,
+  isDisablingFailed = false,
 }: BatchResultsProps) {
   const { t } = useTranslation()
   const channelById = new Map(channels.map((channel) => [channel.id, channel]))
@@ -57,13 +63,27 @@ export function BatchResults({
 
   return (
     <div className='flex h-full flex-col gap-3 p-4'>
-      <div>
-        <h2 className='text-base font-normal'>
-          {t('modelTester.compare.title')}
-        </h2>
-        <p className='text-muted-foreground text-sm' aria-live='polite'>
-          {t(summaryKey, { succeeded, failed, aborted })}
-        </p>
+      <div className='flex items-start justify-between gap-3'>
+        <div>
+          <h2 className='text-base font-normal'>
+            {t('modelTester.compare.title')}
+          </h2>
+          <p className='text-muted-foreground text-sm' aria-live='polite'>
+            {t(summaryKey, { succeeded, failed, aborted })}
+          </p>
+        </div>
+        {failed > 0 && onDisableFailed && (
+          <Button
+            type='button'
+            variant='destructive'
+            size='sm'
+            onClick={onDisableFailed}
+            disabled={isRunning || isDisablingFailed}
+          >
+            {isDisablingFailed ? <Spinner /> : <Ban className='size-3.5' />}
+            {t('modelTester.compare.disableFailed')}
+          </Button>
+        )}
       </div>
 
       {results.length === 0 ? (

--- a/web/src/features/model-tester/components/model-tester-page.tsx
+++ b/web/src/features/model-tester/components/model-tester-page.tsx
@@ -21,15 +21,18 @@
 // resulting `AbortError` is detected and surfaced as a "stopped" state
 // rather than a hard error.
 
+import { useQueryClient } from '@tanstack/react-query'
 import { useSearch } from '@tanstack/react-router'
 import { Trash2 as TrashIcon } from 'lucide-react'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ConfirmDialog } from '@/components/common/confirm-dialog'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { useChannels } from '@/features/channels'
+import { channelsKeys } from '@/features/channels/types'
+import { tokenRoutesApi } from '@/lib/api/token-routes'
 import { asStringParam } from '@/lib/helpers/searchParams'
 import { toast } from '@/lib/toast'
 
@@ -78,6 +81,9 @@ export function ModelTesterPage() {
   const [response, setResponse] = useState<TestResponse | null>(null)
   const [error, setError] = useState<string | undefined>(undefined)
   const [clearDialogOpen, setClearDialogOpen] = useState(false)
+  const [disableFailedDialogOpen, setDisableFailedDialogOpen] = useState(false)
+  const [isDisablingFailed, setIsDisablingFailed] = useState(false)
+  const queryClient = useQueryClient()
   const [comparison, setComparison] = useState<BatchProbeResult[] | null>(null)
   const [isComparing, setIsComparing] = useState(false)
   // Channels whose single-row re-run probe is in flight (per-row spinner in
@@ -292,6 +298,57 @@ export function ModelTesterPage() {
     toast.success(t('modelTester.toast.cleared'))
   }, [t])
 
+  // Channels whose comparison probe failed — the bulk disable action
+  // targets exactly these rows.
+  const failedChannelIds = useMemo(
+    () =>
+      (comparison ?? [])
+        .filter((result) => result.status === 'failure')
+        .map((result) => result.channelId),
+    [comparison]
+  )
+
+  // One-click closure for failed comparison rows: after the operator
+  // confirms, PUT /api/channels/batch disables exactly the failed channels
+  // (marked manual_override server-side so rebuilds keep it). The envelope
+  // reports per-item truth; a partial failure surfaces the precise
+  // breakdown instead of a generic toast. AuditMiddleware records the call.
+  const handleDisableFailedConfirmed = useCallback(async () => {
+    setDisableFailedDialogOpen(false)
+    if (failedChannelIds.length === 0 || isDisablingFailed) return
+    setIsDisablingFailed(true)
+    try {
+      const result = await tokenRoutesApi.batchUpdateChannels(
+        failedChannelIds.map((id) => ({ id, enabled: false }))
+      )
+      const succeededCount = result.successIds?.length ?? 0
+      const failedItems = result.failedItems ?? []
+      if (failedItems.length === 0) {
+        toast.success(
+          t('modelTester.disableFailed.success', { count: succeededCount })
+        )
+      } else {
+        const detail = failedItems
+          .map((item) => `#${item.id}: ${item.message}`)
+          .join('; ')
+        toast.warning(
+          t('modelTester.disableFailed.partial', {
+            succeeded: succeededCount,
+            failed: failedItems.length,
+            detail,
+          })
+        )
+      }
+      if (succeededCount > 0) {
+        queryClient.invalidateQueries({ queryKey: channelsKeys.list() })
+      }
+    } catch {
+      toast.error(t('modelTester.disableFailed.error'))
+    } finally {
+      setIsDisablingFailed(false)
+    }
+  }, [failedChannelIds, isDisablingFailed, queryClient, t])
+
   const isRunning =
     testModel.isPending || isComparing || rerunningChannelIds.size > 0
 
@@ -337,6 +394,8 @@ export function ModelTesterPage() {
                 isRunning={isComparing}
                 rerunningChannelIds={rerunningChannelIds}
                 onRerunRow={handleRerunRow}
+                onDisableFailed={() => setDisableFailedDialogOpen(true)}
+                isDisablingFailed={isDisablingFailed}
               />
             ) : (
               <TestResponseViewer
@@ -360,6 +419,21 @@ export function ModelTesterPage() {
         cancelLabel={t('modelTester.clear.cancel')}
         onConfirm={handleClearSession}
         onCancel={() => setClearDialogOpen(false)}
+      />
+
+      <ConfirmDialog
+        open={disableFailedDialogOpen}
+        title={t('modelTester.disableFailed.title')}
+        description={t('modelTester.disableFailed.description', {
+          count: failedChannelIds.length,
+        })}
+        confirmLabel={t('modelTester.disableFailed.confirm')}
+        cancelLabel={t('modelTester.disableFailed.cancel')}
+        destructive
+        onConfirm={() => {
+          void handleDisableFailedConfirmed()
+        }}
+        onCancel={() => setDisableFailedDialogOpen(false)}
       />
     </div>
   )

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -307,7 +307,8 @@
         "statusSuccess": "Success",
         "statusFailure": "Failed",
         "statusAborted": "Stopped",
-        "rerunRow": "Re-run probe for {{channel}}"
+        "rerunRow": "Re-run probe for {{channel}}",
+        "disableFailed": "Disable failed channels"
       },
       "page": {
         "title": "Model Tester",
@@ -346,6 +347,15 @@
         "description": "This removes all previous rounds from the conversation. The current model and parameter settings are kept.",
         "confirm": "Clear",
         "cancel": "Cancel"
+      },
+      "disableFailed": {
+        "title": "Disable failed channels?",
+        "description": "This disables {{count}} channels that failed the comparison and marks them manual override, so route rebuilds keep the change.",
+        "confirm": "Disable",
+        "cancel": "Cancel",
+        "success": "Disabled {{count}} channels.",
+        "partial": "Disabled {{succeeded}} channels; {{failed}} failed: {{detail}}",
+        "error": "Could not disable the failed channels."
       }
     },
     "oauth": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -307,7 +307,8 @@
         "statusSuccess": "成功",
         "statusFailure": "失败",
         "statusAborted": "已停止",
-        "rerunRow": "重跑「{{channel}}」的探测"
+        "rerunRow": "重跑「{{channel}}」的探测",
+        "disableFailed": "禁用失败渠道"
       },
       "page": {
         "title": "模型测试器",
@@ -346,6 +347,15 @@
         "description": "将删除对话中之前的所有轮次，当前模型与参数设置会保留。",
         "confirm": "清空",
         "cancel": "取消"
+      },
+      "disableFailed": {
+        "title": "禁用失败渠道？",
+        "description": "将禁用 {{count}} 个测试失败的渠道，并标记为人工覆盖，路由重建不会撤销该变更。",
+        "confirm": "禁用",
+        "cancel": "取消",
+        "success": "已禁用 {{count}} 个渠道。",
+        "partial": "已禁用 {{succeeded}} 个渠道，{{failed}} 个失败：{{detail}}",
+        "error": "禁用失败渠道时出错。"
       }
     },
     "oauth": {

--- a/web/src/lib/api/token-routes.ts
+++ b/web/src/lib/api/token-routes.ts
@@ -101,10 +101,23 @@ export const tokenRoutesApi = {
       method: 'PUT',
       body: JSON.stringify(data),
     }),
-  batchUpdateChannels: (updates: Array<{ id: number; priority: number }>) =>
+  // Partial-update semantics: each item applies only the fields present
+  // (priority / weight / enabled). The 200 envelope carries per-item truth
+  // (successIds + failedItems); skipBusinessError keeps a partial failure
+  // (success:false) from tripping the generic interceptor toast so the
+  // caller renders the precise per-item breakdown instead.
+  batchUpdateChannels: (
+    updates: Array<{
+      id: number
+      priority?: number
+      weight?: number
+      enabled?: boolean
+    }>
+  ) =>
     request('/api/channels/batch', {
       method: 'PUT',
       body: JSON.stringify({ updates }),
+      skipBusinessError: true,
     }),
   deleteChannel: (id: number) =>
     request(`/api/channels/${id}`, { method: 'DELETE' }),

--- a/web/src/lib/api/token-routes.ts
+++ b/web/src/lib/api/token-routes.ts
@@ -1,5 +1,13 @@
 import { request, buildQueryString } from './transport'
 
+/** PUT /api/channels/batch response envelope — per-item truth. */
+export type BatchUpdateChannelsResult = {
+  success: boolean
+  successIds: number[]
+  failedItems: Array<{ id: number; message: string }>
+  channels: Array<Record<string, unknown>>
+}
+
 export const tokenRoutesApi = {
   // Account tokens
   getAccountTokens: (accountId?: number) =>
@@ -114,7 +122,7 @@ export const tokenRoutesApi = {
       enabled?: boolean
     }>
   ) =>
-    request('/api/channels/batch', {
+    request<BatchUpdateChannelsResult>('/api/channels/batch', {
       method: 'PUT',
       body: JSON.stringify({ updates }),
       skipBusinessError: true,


### PR DESCRIPTION
Wave 17 P1-3: batch-test closure loop (competitor-study-2026-08). The model-tester comparison ended at the results table; acting on failed channels meant hand-editing each one. This closes the loop.

## Backend: truthful batch channel updates

PUT /api/channels/batch previously forced a priority-only update, ignored missing rows and always reported success:true. It now:

- applies **partial-update semantics** (enabled / weight / priority - only fields present), mirroring PUT /api/channels/:channelId
- validates the payload: empty batch, >1000 items, invalid id, duplicate id, item without updatable fields
- marks manual_override on every applied row (rebuilds keep operator tuning)
- reports **per-item truth**: successIds + failedItems(id, message); success is true only when the whole batch applied

## Frontend: one-click disable of failed comparison channels

- The batch results header shows a destructive **Disable failed channels** action whenever at least one row failed
- Operator confirmation dialog (count + manual-override notice) before any write
- PUTs /api/channels/batch with enabled:false for exactly the failed ids; surfaces full success vs partial-failure breakdown; refreshes the channels list
- AuditMiddleware records the write server-side; zh/en copy

## Tests

- Backend: contract incl. partial failure + audit trail (SQLite; PG variant skips without DSN)
- Frontend: button visibility/pending states + confirm -> api -> toast flow incl. partial failure and cancel

Full local gate (1385 web tests + typecheck + lint + oxfmt + knip + build, go vet, WSL race) passed pre-push.
