### PR TITLE
feat(web): channels error banner doubles as one-click failing filter (P1-4)

### DIFF
--- a/web/src/features/channels/__tests__/channels-error-banner.test.tsx
+++ b/web/src/features/channels/__tests__/channels-error-banner.test.tsx
@@ -1,0 +1,82 @@
+// Behavior tests for the channels error banner (competitor-study-2026-08
+// P1-4): the "N failing" banner doubles as the one-click filter entry and
+// flips into a clearable error-only indicator once the URL status facet is
+// scoped to failing statuses.
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { ChannelsErrorBanner } from '../components/channels-error-banner'
+import {
+  CHANNELS_ERROR_STATUS_FILTER,
+  isErrorOnlyStatusFilter,
+} from '../lib/error-statuses'
+
+afterEach(() => cleanup())
+
+describe('isErrorOnlyStatusFilter', () => {
+  it.each([
+    ['', false],
+    ['cooldown', true],
+    ['breaker_open', true],
+    ['cooldown,breaker_open', true],
+    ['cooldown,enabled', false],
+    ['enabled,manually_disabled', false],
+  ])('classifies %j as %s', (input, expected) => {
+    expect(isErrorOnlyStatusFilter(input)).toBe(expected)
+  })
+})
+
+describe('ChannelsErrorBanner', () => {
+  it('renders nothing without failing channels', () => {
+    const { container } = render(
+      <ChannelsErrorBanner
+        errorCount={0}
+        showErrorOnly={false}
+        onFilterErrors={vi.fn()}
+        onExitErrorOnly={vi.fn()}
+      />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('offers the one-click filter when channels are failing', () => {
+    const onFilterErrors = vi.fn()
+    render(
+      <ChannelsErrorBanner
+        errorCount={3}
+        showErrorOnly={false}
+        onFilterErrors={onFilterErrors}
+        onExitErrorOnly={vi.fn()}
+      />
+    )
+    expect(
+      screen.getByText('3 channels are failing (cooldown or circuit breaker).')
+    ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Show failing' }))
+    expect(onFilterErrors).toHaveBeenCalledTimes(1)
+  })
+
+  it('switches to the clearable error-only indicator', () => {
+    const onExitErrorOnly = vi.fn()
+    render(
+      <ChannelsErrorBanner
+        errorCount={2}
+        showErrorOnly
+        onFilterErrors={vi.fn()}
+        onExitErrorOnly={onExitErrorOnly}
+      />
+    )
+    expect(
+      screen.getByText('Showing failing channels only.')
+    ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Show all' }))
+    expect(onExitErrorOnly).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes the canonical failing-status filter value', () => {
+    expect(CHANNELS_ERROR_STATUS_FILTER).toBe('cooldown,breaker_open')
+  })
+})

--- a/web/src/features/channels/__tests__/channels-page-error-banner.test.tsx
+++ b/web/src/features/channels/__tests__/channels-page-error-banner.test.tsx
@@ -1,0 +1,181 @@
+// Page-level wiring for the channels error banner (P1-4 closure): the
+// banner counts runtime-failing channels (cooldown / breaker_open — never
+// manually_disabled, which is operator intent) from the loaded list, its
+// filter action writes the shareable `?status=` facet, and an error-only
+// URL scope flips it into the clearable indicator.
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+
+import { ChannelsPage } from '../components/channels-page'
+import type { ChannelRow } from '../types'
+
+const testState = vi.hoisted(() => ({
+  channels: [] as ChannelRow[],
+  navigate: vi.fn(),
+  search: {} as Record<string, unknown>,
+}))
+
+vi.mock('@/components/common/use-probe-history', () => ({
+  useProbeHistory: () => ({ data: undefined }),
+}))
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => testState.navigate,
+  useSearch: () => testState.search,
+  useLocation: () => ({ href: '/channels', searchStr: '' }),
+  Link: ({ children }: { children?: unknown }) => children,
+}))
+
+vi.mock('@/components/data-table', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/components/data-table')>()
+  return {
+    ...actual,
+    useUrlTableState: () => ({
+      globalFilter: '',
+      onGlobalFilterChange: vi.fn(),
+      columnFilters: [],
+      onColumnFiltersChange: vi.fn(),
+      pagination: { pageIndex: 0, pageSize: 20 },
+      onPaginationChange: vi.fn(),
+      sorting: [],
+      onSortingChange: vi.fn(),
+      ensurePageInRange: vi.fn(),
+    }),
+  }
+})
+
+vi.mock('../api', () => ({
+  useChannels: () => ({
+    data: testState.channels,
+    isLoading: false,
+    isFetching: false,
+    error: null,
+  }),
+}))
+
+vi.mock('../components/channel-detail-sheet', () => ({
+  ChannelDetailSheet: () => null,
+}))
+
+vi.mock('../components/cooldown-reason-dialog', () => ({
+  CooldownReasonDialog: () => null,
+}))
+
+function makeChannel(overrides: Partial<ChannelRow>): ChannelRow {
+  return {
+    id: 1,
+    routeId: 1,
+    name: 'probe-channel',
+    site: { id: 1, name: 'Probe site' },
+    type: 'account',
+    status: 'enabled',
+    models: 'gpt-*',
+    priority: 1,
+    weight: 1,
+    responseMs: null,
+    cooldownUntil: null,
+    cooldownReasonCode: null,
+    cooldownReason: null,
+    cooldownReasonAt: null,
+    enabled: true,
+    manualOverride: false,
+    ...overrides,
+  }
+}
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    writable: true,
+    value: ResizeObserverStub,
+  })
+})
+
+beforeEach(() => {
+  testState.channels = []
+  testState.search = {}
+  testState.navigate.mockReset()
+})
+
+afterEach(() => cleanup())
+
+describe('ChannelsPage error banner filter loop', () => {
+  it('counts runtime failures and writes the status facet on filter', () => {
+    testState.channels = [
+      makeChannel({ id: 1, status: 'cooldown' }),
+      makeChannel({ id: 2, status: 'breaker_open' }),
+      makeChannel({ id: 3, status: 'enabled' }),
+      // Operator intent, not a failure: excluded from the count.
+      makeChannel({ id: 4, status: 'manually_disabled' }),
+    ]
+    render(<ChannelsPage />)
+
+    expect(
+      screen.getByText('2 channels are failing (cooldown or circuit breaker).')
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show failing' }))
+    expect(testState.navigate).toHaveBeenCalledTimes(1)
+    const call = testState.navigate.mock.calls[0][0] as {
+      to: string
+      search: Record<string, unknown>
+    }
+    expect(call.to).toBe('/channels')
+    expect(call.search.status).toBe('cooldown,breaker_open')
+    expect(call.search.page).toBe(0)
+  })
+
+  it('shows the clearable indicator when the URL already scopes to errors', () => {
+    testState.channels = [
+      makeChannel({ id: 1, status: 'cooldown' }),
+      makeChannel({ id: 2, status: 'enabled' }),
+    ]
+    testState.search = { status: 'cooldown,breaker_open' }
+    render(<ChannelsPage />)
+
+    expect(
+      screen.getByText('Showing failing channels only.')
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show all' }))
+    const call = testState.navigate.mock.calls[0][0] as {
+      search: Record<string, unknown>
+    }
+    expect(call.search.status).toBeUndefined()
+  })
+
+  it('renders no banner when every channel is healthy', () => {
+    testState.channels = [makeChannel({ id: 1, status: 'enabled' })]
+    render(<ChannelsPage />)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/features/channels/components/channels-error-banner.tsx
+++ b/web/src/features/channels/components/channels-error-banner.tsx
@@ -1,0 +1,68 @@
+// metapi-go/features/channels — error-count banner that doubles as a
+// one-click filter entry (competitor-study-2026-08 P1-4: axonhub turns the
+// "N failing" banner into the filter entry so the error state and the action
+// state are one surface). When the loaded list contains failing channels,
+// the banner counts them and offers a single action that narrows the table
+// to exactly those rows; once the URL filter is scoped to failing statuses
+// it switches to a clearable "error-only" indicator with an exit action.
+//
+// URL semantics follow docs/internal/design/state-stability.md R1: the filter
+// is URL-owned persistent state (the existing shareable `?status=` facet),
+// not a one-shot deep-link param. One-shot consumption (the `?channelId=`
+// drilldown pattern) is reserved for transient UI such as dialogs and
+// sheets; a filter must stay shareable, survive back/forward, and remain
+// clearable through the toolbar facet. The banner therefore never strips
+// the param — it derives its mode from it.
+
+import { Filter, TriangleAlert, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+
+type ChannelsErrorBannerProps = {
+  /** Number of failing channels in the loaded list; renders nothing at 0. */
+  errorCount: number
+  /** True when the URL filter already scopes the view to failing channels. */
+  showErrorOnly: boolean
+  /** Narrows the table to the failing channels (single URL transaction). */
+  onFilterErrors: () => void
+  /** Clears the error-only filter back to the full list. */
+  onExitErrorOnly: () => void
+}
+
+export function ChannelsErrorBanner({
+  errorCount,
+  showErrorOnly,
+  onFilterErrors,
+  onExitErrorOnly,
+}: ChannelsErrorBannerProps) {
+  const { t } = useTranslation()
+  if (errorCount === 0) return null
+
+  return (
+    <div
+      role='alert'
+      className='border-warning/40 bg-warning/10 text-warning-soft-fg flex items-center justify-between gap-3 rounded-lg border p-3 text-sm'
+    >
+      <div className='flex items-start gap-2'>
+        <TriangleAlert className='mt-0.5 size-4 shrink-0' />
+        <span>
+          {showErrorOnly
+            ? t('channels.errorBanner.errorOnlyMode')
+            : t('channels.errorBanner.message', { count: errorCount })}
+        </span>
+      </div>
+      {showErrorOnly ? (
+        <Button variant='outline' size='sm' onClick={onExitErrorOnly}>
+          <X className='size-3.5' />
+          {t('channels.errorBanner.exitButton')}
+        </Button>
+      ) : (
+        <Button variant='outline' size='sm' onClick={onFilterErrors}>
+          <Filter className='size-3.5' />
+          {t('channels.errorBanner.filterButton')}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/web/src/features/channels/components/channels-page.tsx
+++ b/web/src/features/channels/components/channels-page.tsx
@@ -8,7 +8,7 @@
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import type { ColumnFiltersState } from '@tanstack/react-table'
 import { Users } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { QueryErrorBanner } from '@/components/common/query-error-banner'
@@ -26,6 +26,11 @@ import { asStringParam, parseSortingParam } from '@/lib/helpers/searchParams'
 
 import { useChannels } from '../api'
 import { channelsSearchSchema } from '../lib/channels-schema'
+import {
+  CHANNELS_ERROR_STATUSES,
+  CHANNELS_ERROR_STATUS_FILTER,
+  isErrorOnlyStatusFilter,
+} from '../lib/error-statuses'
 import type { ChannelRow } from '../types'
 import { ChannelDetailSheet } from './channel-detail-sheet'
 import {
@@ -33,6 +38,7 @@ import {
   useChannelsColumns,
   type ChannelsColumnActions,
 } from './channels-columns'
+import { ChannelsErrorBanner } from './channels-error-banner'
 import { CooldownReasonDialog } from './cooldown-reason-dialog'
 
 const CHANNELS_COLUMN_VISIBILITY_STORAGE_KEY =
@@ -128,6 +134,11 @@ export function ChannelsPage() {
   // the bars, never the channels table.
   const probeHistoryQuery = useProbeHistory('channels')
   const urlState = useChannelsUrlState()
+
+  // P1-4 closure (competitor-study-2026-08): the error banner doubles as
+  // the filter entry. The count derives from the loaded list; the mode
+  // derives from the URL status facet — persistent, shareable state per
+  // state-stability.md R1, never a one-shot param the page strips.
   const [detailChannel, setDetailChannel] = useState<ChannelRow | null>(null)
   const [detailOpen, setDetailOpen] = useState(false)
   const [reasonChannel, setReasonChannel] = useState<ChannelRow | null>(null)
@@ -156,6 +167,28 @@ export function ChannelsPage() {
       replace: true,
     })
   }, [search, channelsQuery.isLoading, channelsQuery.data, navigate])
+
+  const allChannels = channelsQuery.data ?? []
+  const errorChannelCount = allChannels.filter((channel) =>
+    CHANNELS_ERROR_STATUSES.includes(channel.status)
+  ).length
+  const showErrorOnly = isErrorOnlyStatusFilter(
+    asStringParam(search.status) ?? ''
+  )
+
+  const handleFilterErrors = useCallback(() => {
+    void navigate({
+      to: '/channels',
+      search: { ...search, status: CHANNELS_ERROR_STATUS_FILTER, page: 0 },
+    })
+  }, [navigate, search])
+
+  const handleExitErrorOnly = useCallback(() => {
+    void navigate({
+      to: '/channels',
+      search: { ...search, status: undefined, page: 0 },
+    })
+  }, [navigate, search])
 
   const columnActions: ChannelsColumnActions = {
     onView: (channel) => {
@@ -204,38 +237,46 @@ export function ChannelsPage() {
           isRetrying={channelsQuery.isFetching}
         />
       ) : (
-        <DataTablePage
-          table={table}
-          columns={columns}
-          isLoading={channelsQuery.isLoading}
-          isFetching={channelsQuery.isFetching}
-          emptyTitle={t('channels.empty.title')}
-          emptyDescription={t('channels.empty.description')}
-          emptyAction={
-            <Button
-              variant='outline'
-              onClick={() => void navigate({ to: '/accounts' })}
-            >
-              <Users className='size-4' />
-              {t('channels.empty.manageAccounts')}
-            </Button>
-          }
-          skeletonKeyPrefix='channel-skeleton'
-          toolbarProps={{
-            searchPlaceholder: t('channels.toolbar.searchPlaceholder'),
-            searchDebounceMs: 400,
-            filters: [
-              {
-                columnId: 'status',
-                title: t('channels.columns.status'),
-                options: CHANNELS_STATUS_FILTER_OPTIONS.map((option) => ({
-                  label: t(option.labelKey),
-                  value: option.value,
-                })),
-              },
-            ],
-          }}
-        />
+        <>
+          <ChannelsErrorBanner
+            errorCount={errorChannelCount}
+            showErrorOnly={showErrorOnly}
+            onFilterErrors={handleFilterErrors}
+            onExitErrorOnly={handleExitErrorOnly}
+          />
+          <DataTablePage
+            table={table}
+            columns={columns}
+            isLoading={channelsQuery.isLoading}
+            isFetching={channelsQuery.isFetching}
+            emptyTitle={t('channels.empty.title')}
+            emptyDescription={t('channels.empty.description')}
+            emptyAction={
+              <Button
+                variant='outline'
+                onClick={() => void navigate({ to: '/accounts' })}
+              >
+                <Users className='size-4' />
+                {t('channels.empty.manageAccounts')}
+              </Button>
+            }
+            skeletonKeyPrefix='channel-skeleton'
+            toolbarProps={{
+              searchPlaceholder: t('channels.toolbar.searchPlaceholder'),
+              searchDebounceMs: 400,
+              filters: [
+                {
+                  columnId: 'status',
+                  title: t('channels.columns.status'),
+                  options: CHANNELS_STATUS_FILTER_OPTIONS.map((option) => ({
+                    label: t(option.labelKey),
+                    value: option.value,
+                  })),
+                },
+              ],
+            }}
+          />
+        </>
       )}
 
       <CooldownReasonDialog

--- a/web/src/features/channels/lib/error-statuses.ts
+++ b/web/src/features/channels/lib/error-statuses.ts
@@ -1,0 +1,34 @@
+// metapi-go/features/channels — failing-status vocabulary shared by the
+// error banner, the page filter wiring and their tests (kept out of the
+// component file so fast-refresh stays component-only).
+
+import type { ChannelStatus } from '../types'
+
+/**
+ * Runtime-failing statuses: cooldown (temporarily pulled from rotation) and
+ * breaker_open (circuit tripped). `manually_disabled` is deliberate operator
+ * intent rather than a failure, so it stays out of the error count and the
+ * one-click filter.
+ */
+export const CHANNELS_ERROR_STATUSES: readonly ChannelStatus[] = [
+  'cooldown',
+  'breaker_open',
+]
+
+/** The comma-separated `?status=` value the filter action writes. */
+export const CHANNELS_ERROR_STATUS_FILTER = CHANNELS_ERROR_STATUSES.join(',')
+
+/**
+ * True when the URL status filter is scoped to failing statuses only (any
+ * non-empty subset of CHANNELS_ERROR_STATUSES). Mixed or healthy selections
+ * keep the banner in its normal count mode.
+ */
+export function isErrorOnlyStatusFilter(statusFilter: string): boolean {
+  const values = statusFilter.split(',').filter(Boolean)
+  return (
+    values.length > 0 &&
+    values.every((value) =>
+      (CHANNELS_ERROR_STATUSES as readonly string[]).includes(value)
+    )
+  )
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2952,6 +2952,12 @@
         "editRouteHint": "Open the parent token route",
         "enabledLabel": "Enabled state",
         "manualOverrideSetActive": "Manually set"
+      },
+      "errorBanner": {
+        "message": "{{count}} channels are failing (cooldown or circuit breaker).",
+        "filterButton": "Show failing",
+        "errorOnlyMode": "Showing failing channels only.",
+        "exitButton": "Show all"
       }
     },
     "probeHealth": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2952,6 +2952,12 @@
         "editRouteHint": "打开所属令牌路由",
         "enabledLabel": "启用状态",
         "manualOverrideSetActive": "已手动设置"
+      },
+      "errorBanner": {
+        "message": "{{count}} 个渠道处于失败状态（冷却或熔断）。",
+        "filterButton": "只看失败",
+        "errorOnlyMode": "当前仅显示失败渠道。",
+        "exitButton": "显示全部"
       }
     },
     "probeHealth": {


### PR DESCRIPTION
Wave 17 P1-4 (competitor-study-2026-08): the channels page error banner now doubles as a one-click filter entry.

## Behavior

- The banner appears whenever loaded channels are failing (**cooldown / breaker_open**); `manually_disabled` is deliberate operator intent and stays excluded from the count and the filter.
- Its single action narrows the table to exactly the failing rows through the existing shareable `?status=` facet; the banner flips into a clearable error-only indicator while the facet is scoped to failing statuses, and "Show all" clears it.
- URL semantics follow `docs/internal/design/state-stability.md` R1: the filter is URL-owned persistent state (shareable, back/forward-safe, clearable through the toolbar facet) — never a one-shot deep-link param.
- Keyboard reachable + aria (role=alert, labelled buttons); zh/en copy.

## Tests

- Component: no-failure renders nothing, filter action fires, error-only mode exit, filter value classification
- Page wiring: count derivation (runtime failures only), facet write on filter, error-only deep-link mode, healthy no-banner
- Full local gate (frontend suite + typecheck + lint + oxfmt + knip + build, go vet, WSL race) passed pre-push.
