### PR TITLE
feat(routing): operator-tunable retry/disable status-code policy (P1-2)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -210,6 +210,16 @@ type Config struct {
 	ProxyIdleConnTimeoutSec       int // idle keep-alive connection TTL
 	ProxyRequestTimeoutSec        int // whole-request http.Client timeout
 
+	// ProxyRetryStatusRanges / ProxyDisableStatusRanges carry the
+	// operator-tunable status-code range specs (routing.StatusRange policy,
+	// competitor-study-2026-08 P1-2): retry decides which upstream statuses
+	// count as retryable channel faults; disable decides which auto-disable
+	// the failing channel. Runtime settings only (settings table +
+	// PUT /api/settings/runtime, rehydrated at startup); blank keeps the
+	// defaults, which reproduce the historical behavior exactly.
+	ProxyRetryStatusRanges   string
+	ProxyDisableStatusRanges string
+
 	// LDOHBaseURL is the upstream LDOH dashboard URL proxied through
 	// /monitor-proxy/ldoh/* (env-only — no DDL). Parsed from LDOH_BASE_URL;
 	// defaults to DefaultLDOHBaseURL so operators can redirect the monitor

--- a/docs/api.md
+++ b/docs/api.md
@@ -738,6 +738,11 @@ Get all runtime settings as a flat JSON object. Sensitive values (proxyToken, to
 
 Update runtime settings. Partial update -- only send fields you want to change. Schedule updates atomically write both the legacy cron key and the corresponding v1 semantic mirror.
 
+**Status-code verdict policy** (P1-2): `proxyRetryStatusRanges` / `proxyDisableStatusRanges` take a comma-separated spec of single codes (`401`) and inclusive ranges (`500-599`); adjacent/overlapping ranges merge. Blank restores the defaults. Malformed specs are rejected with `400` and the config is left untouched.
+
+- `proxyRetryStatusRanges` — upstream statuses that count as retryable channel faults. Default (blank) reproduces the historical hardcoded verdicts: `401,403,408,409,425,429,500-599`.
+- `proxyDisableStatusRanges` — statuses that disable the failing channel outright (enabled=false + manual_override, on top of the cooldown escalation). Default (blank) = no auto-disable, matching historical behavior; the new-api-style preset is `401`.
+
 ### GET /api/settings/migration/preview
 
 Preview the additive settings migration. Returns `currentVersion`, `targetVersion`, `pending`, `customCount`, `legacyFieldsPreserved`, and per-task migration items.

--- a/handler/admin/settings.go
+++ b/handler/admin/settings.go
@@ -88,6 +88,8 @@ func (h *settingsHandler) getRuntime(w http.ResponseWriter, r *http.Request) {
 		"routingFallbackUnitCost":          cfg.RoutingFallbackUnitCost,
 		"proxyFirstByteTimeoutSec":         cfg.ProxyFirstByteTimeoutSec,
 		"tokenRouterFailureCooldownMaxSec": cfg.TokenRouterFailureCooldownMaxSec,
+		"proxyRetryStatusRanges":           cfg.ProxyRetryStatusRanges,
+		"proxyDisableStatusRanges":         cfg.ProxyDisableStatusRanges,
 		"routingWeights": map[string]any{
 			"baseWeightFactor": cfg.RoutingWeights.BaseWeightFactor,
 			"valueScoreFactor": cfg.RoutingWeights.ValueScoreFactor,

--- a/handler/admin/settings_apply.go
+++ b/handler/admin/settings_apply.go
@@ -430,6 +430,25 @@ func (h *settingsHandler) applyRoutingSettings(body map[string]any) *settingsApp
 		h.cfg.TokenRouterFailureCooldownMaxSec = int(n)
 		upsertSettingDB(h.db, "token_router_failure_cooldown_max_sec", int(n))
 	}
+	// P1-2: operator-tunable status-code range policy. Empty specs are
+	// allowed (they restore the routing defaults at lookup time); anything
+	// non-empty must parse cleanly before it is persisted or applied.
+	if v, ok := body["proxyRetryStatusRanges"]; ok {
+		spec := normalizeString(v)
+		if _, err := routing.ParseStatusRanges(spec); err != nil {
+			return failSettings(http.StatusBadRequest, "proxyRetryStatusRanges: "+err.Error())
+		}
+		h.cfg.ProxyRetryStatusRanges = spec
+		upsertSettingDB(h.db, "proxy_retry_status_ranges", spec)
+	}
+	if v, ok := body["proxyDisableStatusRanges"]; ok {
+		spec := normalizeString(v)
+		if _, err := routing.ParseStatusRanges(spec); err != nil {
+			return failSettings(http.StatusBadRequest, "proxyDisableStatusRanges: "+err.Error())
+		}
+		h.cfg.ProxyDisableStatusRanges = spec
+		upsertSettingDB(h.db, "proxy_disable_status_ranges", spec)
+	}
 
 	// Routing weights
 	if v, ok := body["routingWeights"]; ok {

--- a/handler/admin/settings_proxy_status_ranges_test.go
+++ b/handler/admin/settings_proxy_status_ranges_test.go
@@ -1,0 +1,88 @@
+package admin
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestSettingsRuntimeStatusRangesPersistAndApply(t *testing.T) {
+	db, r, cfg := setupEdgeTest(t)
+
+	resp := doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+		"proxyRetryStatusRanges":   "401,500-599",
+		"proxyDisableStatusRanges": "401",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update runtime: %d %s", resp.Code, resp.Body.String())
+	}
+	if cfg.ProxyRetryStatusRanges != "401,500-599" {
+		t.Fatalf("cfg.ProxyRetryStatusRanges = %q, want 401,500-599", cfg.ProxyRetryStatusRanges)
+	}
+	if cfg.ProxyDisableStatusRanges != "401" {
+		t.Fatalf("cfg.ProxyDisableStatusRanges = %q, want 401", cfg.ProxyDisableStatusRanges)
+	}
+
+	for key, want := range map[string]string{
+		"proxy_retry_status_ranges":   `"401,500-599"`,
+		"proxy_disable_status_ranges": `"401"`,
+	} {
+		var stored string
+		if err := db.Get(&stored, "SELECT value FROM settings WHERE key = ?", key); err != nil {
+			t.Fatalf("query %s: %v", key, err)
+		}
+		if stored != want {
+			t.Fatalf("stored %s = %q, want %q", key, stored, want)
+		}
+	}
+}
+
+func TestSettingsRuntimeStatusRangesRejectInvalidSpec(t *testing.T) {
+	_, r, cfg := setupEdgeTest(t)
+
+	for _, spec := range []any{"not-a-range", "500-400", "600"} {
+		resp := doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+			"proxyRetryStatusRanges": spec,
+		})
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("spec %v: status = %d body=%s, want 400", spec, resp.Code, resp.Body.String())
+		}
+		if cfg.ProxyRetryStatusRanges != "" {
+			t.Fatalf("spec %v: cfg mutated to %q, want untouched", spec, cfg.ProxyRetryStatusRanges)
+		}
+	}
+
+	// Non-string values follow the existing settings contract: normalize to
+	// the empty spec (restore defaults), never a 400.
+	resp := doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+		"proxyRetryStatusRanges": 42,
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("numeric spec: status = %d body=%s, want 200 (normalize to empty)", resp.Code, resp.Body.String())
+	}
+	if cfg.ProxyRetryStatusRanges != "" {
+		t.Fatalf("numeric spec: cfg mutated to %q, want empty", cfg.ProxyRetryStatusRanges)
+	}
+}
+
+func TestSettingsRuntimeStatusRangesEmptyClearsToDefault(t *testing.T) {
+	_, r, cfg := setupEdgeTest(t)
+
+	// Set a custom value first, then clear it: the apply path accepts the
+	// empty spec and the routing layer falls back to the historical default.
+	resp := doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+		"proxyDisableStatusRanges": "401",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("set disable: %d %s", resp.Code, resp.Body.String())
+	}
+
+	resp = doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+		"proxyDisableStatusRanges": "",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("clear disable: %d %s", resp.Code, resp.Body.String())
+	}
+	if cfg.ProxyDisableStatusRanges != "" {
+		t.Fatalf("cfg.ProxyDisableStatusRanges = %q after clear, want empty", cfg.ProxyDisableStatusRanges)
+	}
+}

--- a/proxy/retry_policy.go
+++ b/proxy/retry_policy.go
@@ -3,6 +3,8 @@ package proxy
 import (
 	"regexp"
 	"strings"
+
+	"github.com/deliciousbuding/metapi-go/routing"
 )
 
 // Retryable patterns from the TS implementation.
@@ -135,22 +137,18 @@ func trimToLower(s string) string {
 // Returns true if the proxy should retry with a different channel or the same channel.
 //
 // Decision matrix:
-// - >= 500: always retryable
-// - 408/409/425/429: always retryable
-// - 401/403: retryable (may be resolved by OAuth token refresh)
+// - Status inside the operator-tunable retry ranges: retryable. The default
+//   ranges (routing.DefaultRetryStatusRangesSpec) reproduce exactly the
+//   historical hardcoded verdicts: >= 500, 408/409/425/429, and 401/403
+//   (auth faults an OAuth token refresh may resolve). Operators can narrow
+//   or widen the set at runtime (proxy_retry_status_ranges setting).
 // - Error text matches model-unsupported patterns: retryable (try another channel)
 // - Error text matches non-retryable request patterns: non-retryable (bad request)
 // - Error text matches retryable channel-local patterns: retryable
 // - 400/404/422: non-retryable (unless error text overrides)
 // - Other: non-retryable
 func ShouldRetryProxyRequest(status int, upstreamErrorText string) bool {
-	if status >= 500 {
-		return true
-	}
-	if status == 408 || status == 409 || status == 425 || status == 429 {
-		return true
-	}
-	if status == 401 || status == 403 {
+	if routing.StatusInRanges(status, routing.ActiveRetryStatusRanges()) {
 		return true
 	}
 	if isModelUnsupportedError(upstreamErrorText) {

--- a/routing/router_records.go
+++ b/routing/router_records.go
@@ -429,7 +429,17 @@ func (tr *TokenRouter) RecordFailure(ctx context.Context, channelID int64, failu
 			consecutiveFailCount, cooldownLevel, failCount, nowMs, tr.configuredMaxSec)
 	}
 
-	_ = tr.db.UpdateChannelCooldownFields(ctx, affectedChannelIDs, map[string]interface{}{
+	// P1-2 operator-tunable auto-disable: when the failing status falls in
+	// the configured disable ranges (default: none — historical behavior),
+	// the channel is disabled outright on top of the cooldown escalation.
+	// manual_override shields it from route rebuilds; the operator
+	// re-enables through the same surface as manual channel edits. Regular
+	// channels only — OAuth route unit members keep their member-level
+	// cooldown path.
+	disableHit := failureCtx.Status != nil &&
+		StatusInRanges(*failureCtx.Status, ActiveDisableStatusRanges())
+
+	updates := map[string]interface{}{
 		"failCount":            failCount,
 		"lastFailAt":           nowISO,
 		"consecutiveFailCount": consecutiveFailCount,
@@ -438,7 +448,12 @@ func (tr *TokenRouter) RecordFailure(ctx context.Context, channelID int64, failu
 		"cooldownReasonCode":   reasonCode,
 		"cooldownReason":       CooldownReasonSummaryArg(reasonSummary),
 		"cooldownReasonAt":     nowISO,
-	})
+	}
+	if disableHit {
+		updates["enabled"] = false
+		updates["manualOverride"] = true
+	}
+	_ = tr.db.UpdateChannelCooldownFields(ctx, affectedChannelIDs, updates)
 
 	for _, id := range affectedChannelIDs {
 		tr.cache.PatchCachedChannel(id, func(ch *store.RouteChannel) {
@@ -450,6 +465,10 @@ func (tr *TokenRouter) RecordFailure(ctx context.Context, channelID int64, failu
 			ch.CooldownReasonCode = &reasonCode
 			ch.CooldownReason = reasonSummaryPtr(reasonSummary)
 			ch.CooldownReasonAt = &nowISO
+			if disableHit {
+				ch.Enabled = false
+				ch.ManualOverride = true
+			}
 		})
 	}
 

--- a/routing/status_ranges.go
+++ b/routing/status_ranges.go
@@ -1,0 +1,171 @@
+// metapi-go/routing — operator-tunable status-code range policy
+// (competitor-study-2026-08 P1-2).
+//
+// Two runtime settings (settings table, live-applied via PUT
+// /api/settings/runtime and rehydrated at startup) replace the status
+// verdicts that were hardcoded in proxy.ShouldRetryProxyRequest:
+//
+//   - proxy_retry_status_ranges: which upstream HTTP statuses count as
+//     channel-fault retryable. Default reproduces the historical hardcoded
+//     set exactly (5xx + 401/403 + 408/409/425/429), so an unconfigured
+//     deployment behaves identically.
+//   - proxy_disable_status_ranges: which statuses auto-disable the failing
+//     channel outright (enabled=false + manual_override, in addition to the
+//     normal cooldown escalation). Default empty = no auto-disable =
+//     historical behavior. Operators can opt into new-api-style semantics
+//     (e.g. "401" — an invalid credential should not keep rotating).
+//
+// Specs are comma-separated single codes ("429") and inclusive ranges
+// ("500-599"), validated at write time; the hot path parses at most once
+// per distinct spec (mutex + last-spec cache).
+
+package routing
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/deliciousbuding/metapi-go/config"
+)
+
+// StatusRange is an inclusive HTTP status interval [Lo, Hi].
+type StatusRange struct {
+	Lo int
+	Hi int
+}
+
+const (
+	// DefaultRetryStatusRangesSpec reproduces exactly the retryable statuses
+	// previously hardcoded in proxy.ShouldRetryProxyRequest: 5xx plus
+	// 401/403 (auth faults that an OAuth token refresh may resolve) and
+	// 408/409/425/429.
+	DefaultRetryStatusRangesSpec = "401,403,408,409,425,429,500-599"
+
+	// DefaultDisableStatusRangesSpec is empty: no status auto-disables a
+	// channel (historical metapi behavior — failures only escalate
+	// cooldowns). "401" is the documented new-api-style preset.
+	DefaultDisableStatusRangesSpec = ""
+)
+
+// ParseStatusRanges parses a comma-separated spec of single codes ("429")
+// and inclusive ranges ("500-599"). Codes must be 100-599 with Lo <= Hi.
+// A blank spec yields no ranges and no error. Results are sorted with
+// adjacent/overlapping ranges merged. Any malformed entry is an error —
+// settings writes validate with this before persisting.
+func ParseStatusRanges(spec string) ([]StatusRange, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return nil, nil
+	}
+	ranges := make([]StatusRange, 0, 4)
+	for _, part := range strings.Split(spec, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("empty status range entry")
+		}
+		loStr, hiStr := part, part
+		if idx := strings.Index(part, "-"); idx >= 0 {
+			loStr = strings.TrimSpace(part[:idx])
+			hiStr = strings.TrimSpace(part[idx+1:])
+			if loStr == "" || hiStr == "" {
+				return nil, fmt.Errorf("invalid status range %q", part)
+			}
+		}
+		lo, errLo := strconv.Atoi(loStr)
+		hi, errHi := strconv.Atoi(hiStr)
+		if errLo != nil || errHi != nil {
+			return nil, fmt.Errorf("invalid status %q", part)
+		}
+		if lo < 100 || lo > 599 || hi < 100 || hi > 599 {
+			return nil, fmt.Errorf("status out of range 100-599: %q", part)
+		}
+		if lo > hi {
+			return nil, fmt.Errorf("range start exceeds end: %q", part)
+		}
+		ranges = append(ranges, StatusRange{Lo: lo, Hi: hi})
+	}
+	sort.Slice(ranges, func(i, j int) bool { return ranges[i].Lo < ranges[j].Lo })
+	merged := ranges[:0]
+	for _, r := range ranges {
+		if n := len(merged); n > 0 && r.Lo <= merged[n-1].Hi+1 {
+			if r.Hi > merged[n-1].Hi {
+				merged[n-1].Hi = r.Hi
+			}
+		} else {
+			merged = append(merged, r)
+		}
+	}
+	return merged, nil
+}
+
+// StatusInRanges reports whether status falls within any of the ranges.
+func StatusInRanges(status int, ranges []StatusRange) bool {
+	for _, r := range ranges {
+		if status >= r.Lo && status <= r.Hi {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	activeRangesMu         sync.Mutex
+	lastRetrySpec          string
+	retryRangesInitialized bool
+	cachedRetryRanges      []StatusRange
+	lastDisableSpec        string
+	disableRangesInit      bool
+	cachedDisableRanges    []StatusRange
+)
+
+// ActiveRetryStatusRanges returns the operator-configured retryable status
+// ranges. Blank or invalid specs fall back to DefaultRetryStatusRangesSpec,
+// which reproduces the historical hardcoded verdicts exactly. Parsed once
+// per distinct spec.
+func ActiveRetryStatusRanges() []StatusRange {
+	raw := ""
+	if cfg := config.GetSafe(); cfg != nil {
+		raw = strings.TrimSpace(cfg.ProxyRetryStatusRanges)
+	}
+	activeRangesMu.Lock()
+	defer activeRangesMu.Unlock()
+	if !retryRangesInitialized || raw != lastRetrySpec {
+		spec := raw
+		if spec == "" {
+			spec = DefaultRetryStatusRangesSpec
+		}
+		parsed, err := ParseStatusRanges(spec)
+		if err != nil || len(parsed) == 0 {
+			parsed, _ = ParseStatusRanges(DefaultRetryStatusRangesSpec)
+		}
+		cachedRetryRanges = parsed
+		lastRetrySpec = raw
+		retryRangesInitialized = true
+	}
+	return cachedRetryRanges
+}
+
+// ActiveDisableStatusRanges returns the operator-configured auto-disable
+// statuses. Blank (default) or invalid specs yield no ranges: failures keep
+// the historical cooldown-only escalation. Parsed once per distinct spec.
+func ActiveDisableStatusRanges() []StatusRange {
+	raw := ""
+	if cfg := config.GetSafe(); cfg != nil {
+		raw = strings.TrimSpace(cfg.ProxyDisableStatusRanges)
+	}
+	activeRangesMu.Lock()
+	defer activeRangesMu.Unlock()
+	if !disableRangesInit || raw != lastDisableSpec {
+		parsed, err := ParseStatusRanges(raw)
+		if err != nil {
+			parsed = nil
+		}
+		cachedDisableRanges = parsed
+		lastDisableSpec = raw
+		disableRangesInit = true
+	}
+	return cachedDisableRanges
+}

--- a/routing/status_ranges_test.go
+++ b/routing/status_ranges_test.go
@@ -1,0 +1,157 @@
+package routing
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+)
+
+func TestParseStatusRanges_ValidSpecs(t *testing.T) {
+	tests := []struct {
+		spec string
+		want []StatusRange
+	}{
+		{"", nil},
+		{"   ", nil},
+		{"401", []StatusRange{{Lo: 401, Hi: 401}}},
+		{"500-599", []StatusRange{{Lo: 500, Hi: 599}}},
+		{"429,500-599", []StatusRange{{Lo: 429, Hi: 429}, {Lo: 500, Hi: 599}}},
+		{" 500 - 599 ", []StatusRange{{Lo: 500, Hi: 599}}},
+		// Adjacent ranges merge into one interval.
+		{"499,500-599", []StatusRange{{Lo: 499, Hi: 599}}},
+		// Overlapping ranges merge.
+		{"500-550,525-599", []StatusRange{{Lo: 500, Hi: 599}}},
+		// Out-of-order entries are sorted.
+		{"500-599,401", []StatusRange{{Lo: 401, Hi: 401}, {Lo: 500, Hi: 599}}},
+	}
+	for _, tt := range tests {
+		got, err := ParseStatusRanges(tt.spec)
+		if err != nil {
+			t.Fatalf("ParseStatusRanges(%q) unexpected error: %v", tt.spec, err)
+		}
+		if len(got) != len(tt.want) {
+			t.Fatalf("ParseStatusRanges(%q) = %v, want %v", tt.spec, got, tt.want)
+		}
+		for i := range tt.want {
+			if got[i] != tt.want[i] {
+				t.Fatalf("ParseStatusRanges(%q) = %v, want %v", tt.spec, got, tt.want)
+			}
+		}
+	}
+}
+
+func TestParseStatusRanges_RejectsInvalidSpecs(t *testing.T) {
+	invalid := []string{
+		"abc",
+		"4xx",
+		"99",
+		"600",
+		"500-400",
+		"-500",
+		"500-",
+		"500--599",
+		"401,,429",
+		"500,abc,600",
+		"99-199",
+		"500-600",
+		"1-599",
+	}
+	for _, spec := range invalid {
+		if _, err := ParseStatusRanges(spec); err == nil {
+			t.Errorf("ParseStatusRanges(%q) expected error, got nil", spec)
+		}
+	}
+}
+
+func TestStatusInRanges(t *testing.T) {
+	ranges := []StatusRange{{Lo: 401, Hi: 401}, {Lo: 500, Hi: 599}}
+	for _, status := range []int{401, 500, 550, 599} {
+		if !StatusInRanges(status, ranges) {
+			t.Errorf("StatusInRanges(%d) = false, want true", status)
+		}
+	}
+	for _, status := range []int{400, 402, 499, 600, 0} {
+		if StatusInRanges(status, ranges) {
+			t.Errorf("StatusInRanges(%d) = true, want false", status)
+		}
+	}
+	if StatusInRanges(500, nil) {
+		t.Error("StatusInRanges with nil ranges = true, want false")
+	}
+}
+
+func TestActiveRetryStatusRanges_FallsBackToDefaults(t *testing.T) {
+	prev := config.GetSafe()
+	defer config.Set(prev)
+
+	config.Set(nil)
+	got := ActiveRetryStatusRanges()
+	want, err := ParseStatusRanges(DefaultRetryStatusRangesSpec)
+	if err != nil || len(got) != len(want) {
+		t.Fatalf("nil config: got %v (err %v), want default %v", got, err, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("nil config: got %v, want %v", got, want)
+		}
+	}
+
+	// Blank config field also falls back to the historical default.
+	config.Set(&config.Config{})
+	got = ActiveRetryStatusRanges()
+	if len(got) == 0 || got[0] != (StatusRange{Lo: 401, Hi: 401}) {
+		t.Fatalf("blank config: got %v, want default ranges", got)
+	}
+
+	// Invalid persisted value must not poison the hot path: fall back.
+	config.Set(&config.Config{ProxyRetryStatusRanges: "not-a-range"})
+	got = ActiveRetryStatusRanges()
+	if len(got) == 0 {
+		t.Fatal("invalid spec: got empty ranges, want default fallback")
+	}
+}
+
+func TestActiveRetryStatusRanges_OperatorOverride(t *testing.T) {
+	prev := config.GetSafe()
+	defer config.Set(prev)
+
+	config.Set(&config.Config{ProxyRetryStatusRanges: "502,504"})
+	got := ActiveRetryStatusRanges()
+	if len(got) != 2 {
+		t.Fatalf("override: got %v, want two single-code ranges", got)
+	}
+	if !StatusInRanges(502, got) || !StatusInRanges(504, got) {
+		t.Fatalf("override: ranges %v must match 502/504", got)
+	}
+	if StatusInRanges(500, got) {
+		t.Fatalf("override: ranges %v must not match 500", got)
+	}
+}
+
+func TestActiveDisableStatusRanges_DefaultNone(t *testing.T) {
+	prev := config.GetSafe()
+	defer config.Set(prev)
+
+	config.Set(nil)
+	if got := ActiveDisableStatusRanges(); len(got) != 0 {
+		t.Fatalf("default disable ranges = %v, want none", got)
+	}
+	config.Set(&config.Config{ProxyDisableStatusRanges: "401"})
+	got := ActiveDisableStatusRanges()
+	if len(got) != 1 || got[0] != (StatusRange{Lo: 401, Hi: 401}) {
+		t.Fatalf("disable override = %v, want [401]", got)
+	}
+}
+
+func TestDefaultSpecsAreWellFormed(t *testing.T) {
+	if _, err := ParseStatusRanges(DefaultRetryStatusRangesSpec); err != nil {
+		t.Fatalf("default retry spec unparsable: %v", err)
+	}
+	if _, err := ParseStatusRanges(DefaultDisableStatusRangesSpec); err != nil {
+		t.Fatalf("default disable spec unparsable: %v", err)
+	}
+	if !strings.Contains(DefaultRetryStatusRangesSpec, "500-599") {
+		t.Fatal("default retry spec must keep the 5xx sweep")
+	}
+}

--- a/service/routing_store.go
+++ b/service/routing_store.go
@@ -676,6 +676,10 @@ var routeChannelUpdateColumns = map[string]string{
 	"cooldownReasonCode":   "cooldown_reason_code",
 	"cooldownReason":       "cooldown_reason",
 	"cooldownReasonAt":     "cooldown_reason_at",
+	// P1-2: the failure-recording path may disable a channel outright when
+	// its failing status falls in the operator-configured disable ranges.
+	"enabled":        "enabled",
+	"manualOverride": "manual_override",
 }
 
 var routeUnitMemberUpdateColumns = map[string]string{

--- a/store/settings.go
+++ b/store/settings.go
@@ -105,6 +105,13 @@ func ApplyRuntimeSettings(cfg *config.Config, settingsMap map[string]string) {
 		case "port":
 			cfg.Port = parseInt(value, cfg.Port)
 
+		// Proxy retry/disable status-code range policy (P1-2): blank keeps
+		// the routing defaults (historical behavior).
+		case "proxy_retry_status_ranges":
+			cfg.ProxyRetryStatusRanges = parseJSONSettingString(value)
+		case "proxy_disable_status_ranges":
+			cfg.ProxyDisableStatusRanges = parseJSONSettingString(value)
+
 		// Checkin schedule
 		case "checkin_cron":
 			if v := parseJSONSettingString(value); v != "" {

--- a/web/src/features/settings/lib/runtime-settings.ts
+++ b/web/src/features/settings/lib/runtime-settings.ts
@@ -62,6 +62,8 @@ export type RuntimeSettings = {
   routingFallbackUnitCost?: number
   tokenRouterFailureCooldownMaxSec?: number
   proxyFirstByteTimeoutSec?: number
+  proxyRetryStatusRanges?: string
+  proxyDisableStatusRanges?: string
   disableCrossProtocolFallback?: boolean
   routingWeights?: {
     baseWeightFactor?: number

--- a/web/src/features/settings/sections/proxy-models/components/__tests__/routing-section-status-ranges.test.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/__tests__/routing-section-status-ranges.test.tsx
@@ -1,0 +1,172 @@
+// Behavior tests for the operator-tunable status-code verdict fields
+// (competitor-study-2026-08 P1-2): the routing section edits
+// proxyRetryStatusRanges / proxyDisableStatusRanges. Loose shape validation
+// catches obvious typos client-side; range bounds are enforced server-side.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+
+import { RoutingSection } from '../routing-section'
+
+const testState = vi.hoisted(() => ({
+  getRuntimeSettings: vi.fn(),
+  updateRuntimeSettings: vi.fn(),
+  toastSuccess: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getRuntimeSettings: (...args: unknown[]) =>
+      testState.getRuntimeSettings(...args),
+    updateRuntimeSettings: (...args: unknown[]) =>
+      testState.updateRuntimeSettings(...args),
+  },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: testState.toastSuccess,
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: (props: { children?: React.ReactNode }) => <a>{props.children}</a>,
+}))
+
+vi.mock('../../../../components/form-navigation-guard', () => ({
+  FormNavigationGuard: () => null,
+}))
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  testState.getRuntimeSettings.mockReset()
+  testState.updateRuntimeSettings.mockReset()
+  testState.toastSuccess.mockReset()
+  testState.getRuntimeSettings.mockResolvedValue({
+    routingFallbackUnitCost: 1,
+    tokenRouterFailureCooldownMaxSec: 2592000,
+    proxyFirstByteTimeoutSec: 0,
+    proxyRetryStatusRanges: '401,403,408,409,425,429,500-599',
+    proxyDisableStatusRanges: '',
+    disableCrossProtocolFallback: false,
+    routingWeights: {
+      baseWeightFactor: 0.5,
+      valueScoreFactor: 0.5,
+      costWeight: 0.4,
+      balanceWeight: 0.3,
+      usageWeight: 0.3,
+    },
+  })
+})
+
+afterEach(() => cleanup())
+
+function renderRoutingSection() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RoutingSection />
+    </QueryClientProvider>
+  )
+}
+
+describe('RoutingSection status-code verdict fields (P1-2)', () => {
+  it('renders the server-sent specs in the two inputs', async () => {
+    renderRoutingSection()
+
+    const retryInput = (await screen.findByLabelText(
+      'Retryable statuses'
+    )) as HTMLInputElement
+    const disableInput = (await screen.findByLabelText(
+      'Auto-disable statuses'
+    )) as HTMLInputElement
+    expect(retryInput.value).toBe('401,403,408,409,425,429,500-599')
+    expect(disableInput.value).toBe('')
+  })
+
+  it('blocks malformed specs before submitting', async () => {
+    renderRoutingSection()
+
+    const retryInput = (await screen.findByLabelText(
+      'Retryable statuses'
+    )) as HTMLInputElement
+    fireEvent.change(retryInput, { target: { value: '5xx' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Invalid spec — use codes and ranges, e.g. 401 or 500-599'
+        )
+      ).toBeInTheDocument()
+    })
+    expect(testState.updateRuntimeSettings).not.toHaveBeenCalled()
+  })
+
+  it('submits the edited specs as part of the changed payload', async () => {
+    testState.updateRuntimeSettings.mockResolvedValue({ success: true })
+    renderRoutingSection()
+
+    const disableInput = (await screen.findByLabelText(
+      'Auto-disable statuses'
+    )) as HTMLInputElement
+    fireEvent.change(disableInput, { target: { value: '401' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(testState.updateRuntimeSettings).toHaveBeenCalled()
+    })
+    const payload = testState.updateRuntimeSettings.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >
+    expect(payload.proxyDisableStatusRanges).toBe('401')
+    expect(payload.proxyRetryStatusRanges).toBeUndefined()
+    await waitFor(() => {
+      expect(testState.toastSuccess).toHaveBeenCalled()
+    })
+  })
+})

--- a/web/src/features/settings/sections/proxy-models/components/routing-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/routing-section.tsx
@@ -40,10 +40,23 @@ import {
 
 const FORM_ID = 'settings-general-routing-form'
 
+// Loose client-side shape guard: comma-separated codes ("401") and
+// inclusive ranges ("500-599"). Range bounds and order are validated
+// server-side (PUT /api/settings/runtime returns 400 for bad specs).
+const statusRangesSpec = z
+  .string()
+  .refine(
+    (value) =>
+      value === '' || /^(\d{3}(-\d{3})?)(,\s*\d{3}(-\d{3})?)*$/.test(value),
+    { message: 'settings.proxyModels.routing.schema.statusRangesInvalid' }
+  )
+
 const routingSchema = z.object({
   routingFallbackUnitCost: z.coerce.number().min(0),
   tokenRouterFailureCooldownMaxSec: z.coerce.number().int().min(0),
   proxyFirstByteTimeoutSec: z.coerce.number().int().min(0),
+  proxyRetryStatusRanges: statusRangesSpec,
+  proxyDisableStatusRanges: statusRangesSpec,
   disableCrossProtocolFallback: z.boolean(),
   routingWeights: z.object({
     baseWeightFactor: z.coerce.number(),
@@ -100,6 +113,8 @@ const DEFAULT_VALUES: RoutingFormValues = {
   routingFallbackUnitCost: 1,
   tokenRouterFailureCooldownMaxSec: 30 * 24 * 60 * 60,
   proxyFirstByteTimeoutSec: 0,
+  proxyRetryStatusRanges: '',
+  proxyDisableStatusRanges: '',
   disableCrossProtocolFallback: false,
   routingWeights: { ...DEFAULT_WEIGHTS },
 }
@@ -116,6 +131,8 @@ function deriveServerValues(
     tokenRouterFailureCooldownMaxSec:
       asNumber(data.tokenRouterFailureCooldownMaxSec) ?? 30 * 24 * 60 * 60,
     proxyFirstByteTimeoutSec: asNumber(data.proxyFirstByteTimeoutSec) ?? 0,
+    proxyRetryStatusRanges: data.proxyRetryStatusRanges ?? '',
+    proxyDisableStatusRanges: data.proxyDisableStatusRanges ?? '',
     disableCrossProtocolFallback: asBoolean(data.disableCrossProtocolFallback),
     routingWeights: {
       baseWeightFactor:
@@ -242,6 +259,66 @@ export function RoutingSection() {
                 </FormItem>
               )}
             />
+          </div>
+
+          <div className='space-y-3 rounded-lg border p-4'>
+            <h3 className='text-sm font-medium'>
+              {t('settings.proxyModels.routing.statusCodeGroup')}
+            </h3>
+            <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
+              <FormField
+                control={form.control}
+                name='proxyRetryStatusRanges'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t(
+                        'settings.proxyModels.routing.fields.proxyRetryStatusRanges'
+                      )}
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        value={field.value ?? ''}
+                        placeholder='401,403,408,409,425,429,500-599'
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      {t(
+                        'settings.proxyModels.routing.fields.proxyRetryStatusRangesHint'
+                      )}
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='proxyDisableStatusRanges'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t(
+                        'settings.proxyModels.routing.fields.proxyDisableStatusRanges'
+                      )}
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        value={field.value ?? ''}
+                        placeholder='401'
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      {t(
+                        'settings.proxyModels.routing.fields.proxyDisableStatusRangesHint'
+                      )}
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
           </div>
 
           <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1240,11 +1240,19 @@
             "balanceWeight": "Balance weight",
             "balanceWeightHint": "Weight of account balance in the value score: better-funded accounts win preference.",
             "usageWeight": "Usage weight",
-            "usageWeightHint": "Weight of recent usage in the value score: lightly used channels win preference (load balancing)."
+            "usageWeightHint": "Weight of recent usage in the value score: lightly used channels win preference (load balancing).",
+            "proxyRetryStatusRanges": "Retryable statuses",
+            "proxyRetryStatusRangesHint": "Comma-separated codes and ranges that count as retryable channel faults. Empty restores the default (5xx plus 401/403/408/409/425/429).",
+            "proxyDisableStatusRanges": "Auto-disable statuses",
+            "proxyDisableStatusRangesHint": "Statuses that disable the failing channel outright (e.g. 401 — invalid credentials). Empty disables auto-disable; failures then only escalate cooldowns."
           },
           "toast": {
             "saved": "Routing strategy saved.",
             "saveFailed": "Failed to save routing strategy."
+          },
+          "statusCodeGroup": "Status-code verdicts",
+          "schema": {
+            "statusRangesInvalid": "Invalid spec — use codes and ranges, e.g. 401 or 500-599"
           }
         }
       },

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1240,11 +1240,19 @@
             "balanceWeight": "余额权重",
             "balanceWeightHint": "价值评分中账户余额的权重：余额越充足，通道越优先。",
             "usageWeight": "用量权重",
-            "usageWeightHint": "价值评分中近期用量的权重：用量越少，通道越优先（负载均衡）。"
+            "usageWeightHint": "价值评分中近期用量的权重：用量越少，通道越优先（负载均衡）。",
+            "proxyRetryStatusRanges": "可重试状态码",
+            "proxyRetryStatusRangesHint": "视为通道故障可重试的状态码与区间（逗号分隔）。留空恢复默认（5xx 加 401/403/408/409/425/429）。",
+            "proxyDisableStatusRanges": "自动禁用状态码",
+            "proxyDisableStatusRangesHint": "命中即直接禁用该通道的状态码（如 401——凭据失效）。留空则不禁用，失败仅升级冷却。"
           },
           "toast": {
             "saved": "路由策略已保存。",
             "saveFailed": "保存路由策略失败。"
+          },
+          "statusCodeGroup": "状态码判定",
+          "schema": {
+            "statusRangesInvalid": "格式无效——请使用状态码与区间，如 401 或 500-599"
           }
         }
       },

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -381,6 +381,8 @@ export type RuntimeSettingsPayload = {
   routingFallbackUnitCost?: number
   proxyFirstByteTimeoutSec?: number
   tokenRouterFailureCooldownMaxSec?: number
+  proxyRetryStatusRanges?: string
+  proxyDisableStatusRanges?: string
   routingWeights?: RuntimeRoutingWeightsPayload
   proxyErrorKeywords?: string[] | string
   proxyEmptyContentFailEnabled?: boolean


### PR DESCRIPTION
Wave 17 P1-2 (competitor-study-2026-08): the retry/disable status verdicts were hardcoded in `proxy.ShouldRetryProxyRequest` (5xx + 401/403/408/409/425/429 retryable; no status ever auto-disabled a channel). Operators can now tune both at runtime.

## New runtime settings

- **proxyRetryStatusRanges** (`proxy_retry_status_ranges`): which upstream HTTP statuses count as retryable channel faults. Blank (default) reproduces the historical hardcoded verdicts **exactly** — an unconfigured deployment behaves identically.
- **proxyDisableStatusRanges** (`proxy_disable_status_ranges`): statuses that auto-disable the failing channel outright (`enabled=false` + `manual_override`, on top of the normal cooldown escalation). Blank (default) = no auto-disable = historical behavior. The documented new-api-style preset is `401` (an invalid credential should not keep rotating).

Spec format: comma-separated single codes (`429`) and inclusive ranges (`500-599`), validated at write time (100-599, lo<=hi, dedupe/merge); malformed specs are rejected with 400. Hot path parses at most once per distinct spec (mutex + last-spec cache).

## Difference vs new-api defaults

new-api disables only on 401 and never retries 504/524 by default. This PR keeps metapi's historical defaults untouched (zero behavior change when unconfigured) while making both axes expressible — operators who want the new-api semantics set `proxyDisableStatusRanges=401` and narrow the retry ranges accordingly.

## Changes

- `routing/status_ranges.go`: parser + cached active-range lookups
- `proxy/retry_policy.go`: status verdict reads the retry ranges (text-pattern verdicts unchanged)
- `routing/router_records.go`: RecordFailure applies the disable escalation (regular channels; OAuth route-unit members keep their member-level cooldown path)
- settings store hydration + PUT validation + GET runtime surface; `docs/api.md` contract
- Frontend: routing settings section gains the two spec fields (loose shape guard; bounds stay server-side) with zh/en copy

## Tests

- Parser matrix: valid/invalid/bounds/merge/dedupe
- Active-range lookups: default fallback + operator override (both settings)
- Settings apply: persist / reject malformed (400) / clear restores defaults
- Frontend: render/validation/submit of the new fields
- Existing retry_policy tests pin the unchanged default verdicts

Full local gate (frontend suite + typecheck + lint + oxfmt + knip + build, go vet, WSL race) passed pre-push.
