### PR TITLE
feat(web): expose upstream site restriction on downstream keys (#1026)

### DIFF
--- a/web/src/features/settings/sections/downstream/components/__tests__/keys-section-mobile.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/keys-section-mobile.test.tsx
@@ -34,6 +34,7 @@ vi.mock('@/lib/api', () => ({
     createDownstreamApiKey: vi.fn(),
     updateDownstreamApiKey: vi.fn(),
     deleteDownstreamApiKey: vi.fn(),
+    getSites: () => Promise.resolve([]),
   },
 }))
 

--- a/web/src/features/settings/sections/downstream/components/__tests__/keys-section-site-scope.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/keys-section-site-scope.test.tsx
@@ -1,0 +1,197 @@
+// Behavior test for the downstream key sheet's upstream site restriction
+// (#1026): the routing selector has always honored allowedSiteIds, but the
+// management UI never exposed it. These tests pin the round-trip:
+//   - edit mode pre-fills the checkbox list from item.allowedSiteIds
+//   - toggling a site and saving sends allowedSiteIds in the update payload
+//   - create mode sends the selected site scope as well
+// Empty selection means "no site restriction" (selector treats an empty
+// allow-list as unrestricted).
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import type { ReactElement } from 'react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+import { Sheet, SheetContent } from '@/components/ui/sheet'
+
+import { KeySheetForm } from '../keys-section'
+
+const { mockCreateKey, mockUpdateKey, mockGetSites } = vi.hoisted(() => ({
+  mockCreateKey: vi.fn(),
+  mockUpdateKey: vi.fn(),
+  mockGetSites: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    createDownstreamApiKey: mockCreateKey,
+    updateDownstreamApiKey: mockUpdateKey,
+    getSites: mockGetSites,
+  },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const sitesFixture = [
+  { id: 1, name: 'Primary site' },
+  { id: 2, name: 'Backup site' },
+]
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  mockCreateKey.mockReset()
+  mockUpdateKey.mockReset()
+  mockGetSites.mockReset()
+  mockGetSites.mockResolvedValue(sitesFixture)
+  mockCreateKey.mockResolvedValue({})
+  mockUpdateKey.mockResolvedValue({})
+})
+
+afterEach(() => cleanup())
+
+function renderKeySheetForm(
+  editingKey: Parameters<typeof KeySheetForm>[0]['editingKey']
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return render(
+    (
+      <QueryClientProvider client={queryClient}>
+        <Sheet open onOpenChange={() => {}}>
+          <SheetContent>
+            <KeySheetForm editingKey={editingKey} onDone={vi.fn()} />
+          </SheetContent>
+        </Sheet>
+      </QueryClientProvider>
+    ) as ReactElement
+  )
+}
+
+function siteCheckbox(name: string): HTMLInputElement {
+  return screen.getByLabelText(name) as HTMLInputElement
+}
+
+describe('downstream key site restriction (#1026)', () => {
+  it('edit mode pre-fills the site scope from the stored key', async () => {
+    renderKeySheetForm({
+      id: 7,
+      name: 'scoped-key',
+      enabled: true,
+      allowedSiteIds: [2],
+    })
+
+    await waitFor(() => {
+      expect(siteCheckbox('Primary site').checked).toBe(false)
+      expect(siteCheckbox('Backup site').checked).toBe(true)
+    })
+  })
+
+  it('saving an edited scope sends allowedSiteIds in the update payload', async () => {
+    renderKeySheetForm({
+      id: 7,
+      name: 'scoped-key',
+      enabled: true,
+      allowedSiteIds: [2],
+    })
+    await waitFor(() => {
+      expect(siteCheckbox('Backup site').checked).toBe(true)
+    })
+
+    fireEvent.click(siteCheckbox('Primary site'))
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      expect(mockUpdateKey).toHaveBeenCalledTimes(1)
+    })
+    const [id, payload] = mockUpdateKey.mock.calls[0] as [
+      number,
+      { allowedSiteIds?: number[] },
+    ]
+    expect(id).toBe(7)
+    expect(payload.allowedSiteIds).toEqual([1, 2])
+  })
+
+  it('create mode sends the selected site scope', async () => {
+    renderKeySheetForm(null)
+    await waitFor(() => {
+      expect(screen.getByTestId('site-scope-picker')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'new-key' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('sk-…'), {
+      target: { value: 'sk-abcdefgh12345678' },
+    })
+    fireEvent.click(siteCheckbox('Primary site'))
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => {
+      expect(mockCreateKey).toHaveBeenCalledTimes(1)
+    })
+    const payload = mockCreateKey.mock.calls[0][0] as {
+      allowedSiteIds?: number[]
+    }
+    expect(payload.allowedSiteIds).toEqual([1])
+  })
+
+  it('unchecking every site restores the unrestricted scope', async () => {
+    renderKeySheetForm({
+      id: 7,
+      name: 'scoped-key',
+      enabled: true,
+      allowedSiteIds: [2],
+    })
+    await waitFor(() => {
+      expect(siteCheckbox('Backup site').checked).toBe(true)
+    })
+
+    fireEvent.click(siteCheckbox('Backup site'))
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => {
+      expect(mockUpdateKey).toHaveBeenCalledTimes(1)
+    })
+    const payload = mockUpdateKey.mock.calls[0][1] as {
+      allowedSiteIds?: number[]
+    }
+    expect(payload.allowedSiteIds).toEqual([])
+  })
+})

--- a/web/src/features/settings/sections/downstream/components/__tests__/keys-section.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/keys-section.test.tsx
@@ -41,13 +41,19 @@ import { KeyModelPolicyCell, KeySheetForm, KeyUsageCell } from '../keys-section'
 
 // vi.hoisted keeps the mock fn identities stable across the factory's
 // re-evaluation, so the vi.mock below can reference them by closure.
-const { mockCreateKey, mockUpdateKey, mockToastSuccess, mockToastError } =
-  vi.hoisted(() => ({
-    mockCreateKey: vi.fn(),
-    mockUpdateKey: vi.fn(),
-    mockToastSuccess: vi.fn(),
-    mockToastError: vi.fn(),
-  }))
+const {
+  mockCreateKey,
+  mockUpdateKey,
+  mockGetSites,
+  mockToastSuccess,
+  mockToastError,
+} = vi.hoisted(() => ({
+  mockCreateKey: vi.fn(),
+  mockUpdateKey: vi.fn(),
+  mockGetSites: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+}))
 
 // Mock only the two API methods KeySheetForm actually calls. The rest of the
 // `api` barrel stays absent because the form touches nothing else.
@@ -55,6 +61,7 @@ vi.mock('@/lib/api', () => ({
   api: {
     createDownstreamApiKey: mockCreateKey,
     updateDownstreamApiKey: mockUpdateKey,
+    getSites: mockGetSites,
   },
 }))
 
@@ -87,6 +94,8 @@ beforeAll(() => {
 beforeEach(() => {
   mockCreateKey.mockReset()
   mockUpdateKey.mockReset()
+  mockGetSites.mockReset()
+  mockGetSites.mockResolvedValue([])
   mockToastSuccess.mockReset()
   mockToastError.mockReset()
   // Both mutations resolve successfully so onSuccess → onDone fires.

--- a/web/src/features/settings/sections/downstream/components/keys-section.tsx
+++ b/web/src/features/settings/sections/downstream/components/keys-section.tsx
@@ -49,6 +49,7 @@ import {
 } from '@/components/ui/sheet'
 import { Spinner } from '@/components/ui/spinner'
 import { Switch } from '@/components/ui/switch'
+import { useSites } from '@/features/sites'
 import { api } from '@/lib/api'
 import { toast } from '@/lib/toast'
 
@@ -74,6 +75,7 @@ type DownstreamApiKeyItem = {
   usedRequests?: number | null
   supportedModels?: string[] | string | null
   allowedRouteIds?: number[] | string | null
+  allowedSiteIds?: number[] | string | null
   usage24h?: DownstreamKeyUsage24h
 }
 
@@ -113,6 +115,7 @@ const createKeySchema = z.object({
   expiresAt: z.string().optional(),
   description: z.string().optional(),
   supportedModels: z.array(z.string().trim().min(1)).default([]),
+  allowedSiteIds: z.array(z.number().int().positive()).default([]),
 })
 
 type CreateKeyFormValues = z.infer<typeof createKeySchema>
@@ -186,6 +189,29 @@ function normalizeRouteIds(value: unknown): number[] {
   ]
 }
 
+function normalizeSiteIds(value: unknown): number[] {
+  let rawSiteIds: unknown[] = []
+  if (Array.isArray(value)) {
+    rawSiteIds = value
+  } else if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value) as unknown
+      rawSiteIds = Array.isArray(parsed) ? parsed : []
+    } catch {
+      rawSiteIds = []
+    }
+  }
+
+  return [
+    ...new Set(
+      rawSiteIds.filter(
+        (siteId): siteId is number =>
+          typeof siteId === 'number' && Number.isInteger(siteId) && siteId > 0
+      )
+    ),
+  ]
+}
+
 function extractMarketplaceModelNames(result: unknown): string[] {
   let rows: unknown = []
   if (Array.isArray(result)) {
@@ -219,6 +245,7 @@ function blankKeyFormValues(): CreateKeyFormValues {
     expiresAt: '',
     description: '',
     supportedModels: [],
+    allowedSiteIds: [],
   }
 }
 
@@ -234,6 +261,7 @@ function keyFormValuesFromItem(
     enabled: item.enabled,
     expiresAt: isoToLocalDatetimeInput(item.expiresAt),
     supportedModels: normalizeModelRules(item.supportedModels),
+    allowedSiteIds: normalizeSiteIds(item.allowedSiteIds),
   }
 }
 
@@ -405,6 +433,49 @@ function ModelPolicyEditor({
   )
 }
 
+type SiteScopePickerProps = {
+  value: number[]
+  onChange: (siteIds: number[]) => void
+  sites: Array<{ id: number; name: string }>
+}
+
+// Checkbox list over the upstream sites: empty selection means "no site
+// restriction" (the routing selector treats an empty allow-list as
+// unrestricted), mirroring the model-policy empty-means-deny contrast.
+function SiteScopePicker({ value, onChange, sites }: SiteScopePickerProps) {
+  const selected = new Set(value)
+  return (
+    <div
+      className='border-border max-h-40 space-y-1 overflow-y-auto rounded-md border p-2'
+      data-testid='site-scope-picker'
+    >
+      {sites.length === 0
+        ? null
+        : sites.map((site) => (
+            <label
+              key={site.id}
+              className='flex cursor-pointer items-center gap-2 text-sm'
+            >
+              <input
+                type='checkbox'
+                checked={selected.has(site.id)}
+                onChange={(event) => {
+                  const next = new Set(selected)
+                  if (event.target.checked) {
+                    next.add(site.id)
+                  } else {
+                    next.delete(site.id)
+                  }
+                  onChange([...next].sort((left, right) => left - right))
+                }}
+              />
+              {site.name}
+            </label>
+          ))}
+    </div>
+  )
+}
+
 // Exported so the edit-mode behavior test can render it in isolation,
 // mirroring the AccountsRowActions export pattern. The whole KeysSection
 // remains the only public entry in the settings surface.
@@ -429,6 +500,7 @@ export function KeySheetForm({
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const isEdit = editingKey !== null
+  const { data: sites } = useSites()
 
   const form = useForm<CreateKeyFormValues>({
     resolver: zodResolver(
@@ -466,6 +538,7 @@ export function KeySheetForm({
         enabled: values.enabled,
         expiresAt: values.expiresAt,
         supportedModels: values.supportedModels,
+        allowedSiteIds: values.allowedSiteIds,
       })
     },
     onSuccess: (result, values) => {
@@ -608,6 +681,33 @@ export function KeySheetForm({
                     routeGrantCount={
                       normalizeRouteIds(editingKey?.allowedRouteIds).length
                     }
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name='allowedSiteIds'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {t('settings.downstream.keys.sites.fieldLabel', {
+                    defaultValue: 'Upstream site restriction',
+                  })}
+                </FormLabel>
+                <FormDescription>
+                  {t('settings.downstream.keys.sites.hint', {
+                    defaultValue:
+                      'Leave empty for no site restriction. Selecting sites limits this key to channels of the chosen upstream sites.',
+                  })}
+                </FormDescription>
+                <FormControl>
+                  <SiteScopePicker
+                    value={field.value ?? []}
+                    onChange={field.onChange}
+                    sites={sites ?? []}
                   />
                 </FormControl>
                 <FormMessage />

--- a/web/src/features/sites/index.ts
+++ b/web/src/features/sites/index.ts
@@ -10,3 +10,4 @@ export { sitesSearchSchema } from './lib/sites-schema'
 export { isValidEndpointUrl } from './lib/endpoints'
 
 export { sitesKeys } from './types'
+export { useSites } from './api'

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1324,7 +1324,11 @@
             "deleted": "API key deleted.",
             "deleteFailed": "Failed to delete API key."
           },
-          "connect": "Connect"
+          "connect": "Connect",
+          "sites": {
+            "fieldLabel": "Upstream site restriction",
+            "hint": "Leave empty for no site restriction. Selecting sites limits this key to channels of the chosen upstream sites."
+          }
         },
         "proxyToken": {
           "title": "Root downstream key (deprecated)",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1324,7 +1324,11 @@
             "deleted": "API 密钥已删除。",
             "deleteFailed": "删除 API 密钥失败。"
           },
-          "connect": "接入"
+          "connect": "接入",
+          "sites": {
+            "fieldLabel": "上游站点限制",
+            "hint": "留空表示不限制站点；勾选后该密钥只能访问所选上游站点的渠道。"
+          }
         },
         "proxyToken": {
           "title": "根下游密钥（已弃用）",


### PR DESCRIPTION
Closes the site dimension of #1026. The routing selector has always honored `downstream_api_keys.allowed_site_ids` (and the admin API persists and validates it), but the management UI never exposed the dimension, so operators wanting the TS-version multi-dimensional restriction (model / upstream / account) could only set it through the API.

## Behavior

- The downstream key create/edit sheet gains an **Upstream site restriction** checkbox list fed by the sites query.
- Empty selection = no site restriction, matching the selector's empty-allow-list semantics (contrast with the model policy where empty means deny).
- Edit mode round-trips `allowedSiteIds`; create and update payloads include it (the update keeps its PATCH semantics - only present fields change).

## Not included (honest residual)

The credential dimension (`allowedCredentialRefs`) stays API-only and remains tracked in #1026: its ref model is token/default-key level (site+account+token triples), which needs a site-account-token tree picker - a separate project, not a rushed field.

## Tests

- Behavior tests pin: edit pre-fill from stored scope, update payload after toggling, create payload with selection, and clear-to-unrestricted.
- Existing keys-section edit/mobile tests updated for the new sites query dependency.

Full local gate (frontend suite + typecheck + lint + oxfmt + knip + build, go vet, WSL race) passed pre-push.
