### PR TITLE
fix(routing): read lazy-load flag under healthStateMu to remove data race

### DIFF
--- a/routing/runtime_health_load_race_test.go
+++ b/routing/runtime_health_load_race_test.go
@@ -1,0 +1,55 @@
+package routing
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestEnsureSiteRuntimeHealthStateLoadedConcurrent reproduces the unsynchronized
+// fast-path read of siteRuntimeHealthLoaded: the lazy-load check runs on every
+// SelectChannel hot path while ResetSiteRuntimeHealthState (and the slow-path
+// load) write the flag under healthStateMu. Run with -race; before the fix the
+// lock-free read races the locked writes.
+func TestEnsureSiteRuntimeHealthStateLoadedConcurrent(t *testing.T) {
+	ResetSiteRuntimeHealthState()
+	t.Cleanup(ResetSiteRuntimeHealthState)
+
+	stop := make(chan struct{})
+	var writers sync.WaitGroup
+	var readers sync.WaitGroup
+
+	// Writers: reset flips siteRuntimeHealthLoaded back to false under
+	// healthStateMu, mirroring the reset path.
+	for i := 0; i < 2; i++ {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					ResetSiteRuntimeHealthState()
+				}
+			}
+		}()
+	}
+
+	// Readers: the hot-path lazy-load fast path.
+	for i := 0; i < 4; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for j := 0; j < 5000; j++ {
+				if err := EnsureSiteRuntimeHealthStateLoaded(); err != nil {
+					t.Errorf("EnsureSiteRuntimeHealthStateLoaded: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	readers.Wait()
+	close(stop)
+	writers.Wait()
+}

--- a/routing/runtime_health_persist.go
+++ b/routing/runtime_health_persist.go
@@ -259,7 +259,10 @@ func ClearRuntimeHealthStatesForChannels(rows []ChannelRuntimeHealthRow) bool {
 
 // EnsureSiteRuntimeHealthStateLoaded lazy-loads health state from settings.
 func EnsureSiteRuntimeHealthStateLoaded() error {
-	if siteRuntimeHealthLoaded {
+	healthStateMu.RLock()
+	loaded := siteRuntimeHealthLoaded
+	healthStateMu.RUnlock()
+	if loaded {
 		return nil
 	}
 	healthStateMu.Lock()


### PR DESCRIPTION
## Summary

Lane B (Wave 18 concurrency audit) fix: removes a confirmed data race in routing runtime-health lazy loading.

## The race

`EnsureSiteRuntimeHealthStateLoaded` fast path read `siteRuntimeHealthLoaded` with **no lock**, while `ResetSiteRuntimeHealthState` and the slow-path load write the flag under `healthStateMu`. The lazy-load check runs on every `SelectChannel` / `SelectNextChannel` / `SelectPreferredChannel` hot path (selector.go) and in router_records/router_explain, so concurrent reset/load raced the lock-free read.

Reproduced under `-race`:
- Write at runtime_health_persist.go:206 (`ResetSiteRuntimeHealthState`, under lock)
- Previous read at runtime_health_persist.go:262 (fast path, unlocked)

## Fix

Fast path now reads the flag under `RLock` (4 lines). Behavior unchanged — the double-checked slow path is untouched.

## Test

`routing/runtime_health_load_race_test.go`: concurrent reset writers + hot-path readers. Fails with `WARNING: DATA RACE` before the fix, green with `-race` after.

## Verification

- `go build ./cmd/server` + `go vet ./...` pass
- `go test ./routing/ ./proxy/... ./scheduler/ ./auth/ -race -count=1` all green
- Full pre-push gate passed (frontend + build + vet + full suite `-race`; run with `METAPI_RACE_TIMEOUT_SECONDS=900` because `handler/admin` -race takes ~364s on WSL — verified identical 363.5s on base a88ded9, pre-existing and unrelated to this change)

## Audit context (full report in the lane handoff)

The broader routing/proxy/scheduler/auth audit found this to be the only -race-confirmable defect in scope. One systemic issue was escalated without fixing (needs a design decision): runtime-settings handlers and schedulers mutate fields of the shared `*config.Config` singleton (e.g. `ProxyToken`, `AuthToken`, `ProxyRetryStatusRanges`, checkin schedule fields) while hot paths read them unsynchronized — `config.cfgMu` only guards pointer publication. A complete fix requires a config runtime-layer redesign (snapshot swap or guarded accessors) and is flagged as a follow-up milestone.
