### PR TITLE
perf(store): admin read-path indexes (sc2_027) + proxy-logs/marketplace query fixes [Wave 18 Lane D]

### DIFF
--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -886,8 +886,21 @@ func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 // the COUNT. With either active the joins stay (and the summary query's
 // CASE/COALESCE never needs the join for row preservation: it is a LEFT JOIN
 // on primary keys).
+//
+// Site filter (siteID > 0): accounts and sites join as INNER, not LEFT. The
+// WHERE clause `s.id = ?` already discards any row whose account/site join did
+// not match, so INNER returns the identical row set while freeing the planner
+// to reorder the join. LEFT pinned the scan to proxy_logs first (a full scan of
+// the largest table, then join); INNER lets SQLite drive from the site's small
+// account set (accounts_site_id_idx) into proxy_logs_account_created_at_idx —
+// ~10x faster for the COUNT/summary on the 300k-row audit fixture. The
+// downstream_api_keys join stays LEFT because only the search filter reads it
+// and it must not drop rows for the row-preserving summary CASEs.
 func proxyLogsAggregateFrom(siteID int, search string) string {
-	if siteID > 0 || search != "" {
+	if siteID > 0 {
+		return "FROM proxy_logs pl INNER JOIN accounts a ON pl.account_id = a.id INNER JOIN sites s ON a.site_id = s.id LEFT JOIN downstream_api_keys dk ON pl.downstream_api_key_id = dk.id"
+	}
+	if search != "" {
 		return "FROM proxy_logs pl LEFT JOIN accounts a ON pl.account_id = a.id LEFT JOIN sites s ON a.site_id = s.id LEFT JOIN downstream_api_keys dk ON pl.downstream_api_key_id = dk.id"
 	}
 	return "FROM proxy_logs pl"

--- a/handler/admin/stats_marketplace.go
+++ b/handler/admin/stats_marketplace.go
@@ -76,6 +76,38 @@ func (h *statsHandler) buildMarketplaceModels() ([]map[string]any, error) {
 		return acc
 	}
 
+	// Enabled, non-expired tokens for every account in ONE query (Wave 18
+	// N+1 fix): the previous shape re-ran the per-account token query inside
+	// the accountRows loop below — once per model×account availability row,
+	// i.e. hundreds of identical-round-trip queries per marketplace render.
+	// account_tokens is fleet-bounded (a handful of tokens per account), so a
+	// single scan grouped in Go is safe on both dialects. Rows arrive ordered
+	// (account_id, is_default DESC, id ASC), so each account's slice keeps
+	// exactly the ordering the legacy per-account query produced.
+	enabledTokensByAccount := make(map[int64][]map[string]any)
+	enabledTokenRows, err := queryRowsErr(h.db, `
+		SELECT id, account_id, name, is_default
+		FROM account_tokens
+		WHERE enabled = true
+			AND (value_status IS NULL OR value_status <> 'expired')
+		ORDER BY account_id ASC, is_default DESC, id ASC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	for _, tr := range enabledTokenRows {
+		tid := coerceInt64(tr["id"])
+		if tid <= 0 {
+			continue
+		}
+		accountID := coerceInt64(tr["accountId"])
+		enabledTokensByAccount[accountID] = append(enabledTokensByAccount[accountID], map[string]any{
+			"id":        tid,
+			"name":      coerceString(tr["name"]),
+			"isDefault": coerceInt(tr["isDefault"]) == 1 || coerceString(tr["isDefault"]) == "true" || coerceString(tr["isDefault"]) == "1",
+		})
+	}
+
 	// Account-level availability.
 	accountRows, err := queryRowsErr(h.db, `
 		SELECT
@@ -115,32 +147,15 @@ func (h *statsHandler) buildMarketplaceModels() ([]map[string]any, error) {
 			coerceFloat(row["balance"]),
 			latency,
 		)
-		// Attach enabled tokens for this account (may also appear via token availability).
-		tokenRows, err := queryRowsErr(h.db, `
-			SELECT id, name, is_default
-			FROM account_tokens
-			WHERE account_id = ?
-				AND enabled = true
-				AND (value_status IS NULL OR value_status <> 'expired')
-			ORDER BY is_default DESC, id ASC
-		`, acc.ID)
-		if err != nil {
-			return nil, err
-		}
-		for _, tr := range tokenRows {
-			tid := coerceInt64(tr["id"])
-			if tid <= 0 {
-				continue
-			}
+		// Attach enabled tokens for this account (may also appear via token
+		// availability) from the single pre-loaded batch above.
+		for _, token := range enabledTokensByAccount[acc.ID] {
+			tid := coerceInt64(token["id"])
 			if _, exists := acc.tokenIDs[tid]; exists {
 				continue
 			}
 			acc.tokenIDs[tid] = struct{}{}
-			acc.Tokens = append(acc.Tokens, map[string]any{
-				"id":        tid,
-				"name":      coerceString(tr["name"]),
-				"isDefault": coerceInt(tr["isDefault"]) == 1 || coerceString(tr["isDefault"]) == "true" || coerceString(tr["isDefault"]) == "1",
-			})
+			acc.Tokens = append(acc.Tokens, token)
 		}
 	}
 

--- a/handler/admin/stats_proxy_logs_cache_test.go
+++ b/handler/admin/stats_proxy_logs_cache_test.go
@@ -306,13 +306,24 @@ func TestStats_ProxyLogsAggregateSQL_NoJoinWithoutSiteID(t *testing.T) {
 		}
 	}
 
-	// With a siteId the WHERE references s.id, so the join must stay.
+	// With a siteId the WHERE references s.id, so the accounts/sites joins
+	// must stay — as INNER joins (Wave 18 index audit): s.id = ? already
+	// discards non-matching rows, and INNER lets the planner drive from the
+	// site's accounts into the proxy_logs indexes instead of scanning
+	// proxy_logs first. The dk join stays LEFT because only the search filter
+	// reads it and it must not drop rows.
 	fromSite := proxyLogsAggregateFrom(3, "")
-	if !strings.Contains(fromSite, "LEFT JOIN accounts a ON pl.account_id = a.id") {
-		t.Fatalf("aggregate FROM with siteId must join accounts, got %q", fromSite)
+	if !strings.Contains(fromSite, "INNER JOIN accounts a ON pl.account_id = a.id") {
+		t.Fatalf("aggregate FROM with siteId must inner-join accounts, got %q", fromSite)
 	}
-	if !strings.Contains(fromSite, "LEFT JOIN sites s ON a.site_id = s.id") {
-		t.Fatalf("aggregate FROM with siteId must join sites, got %q", fromSite)
+	if !strings.Contains(fromSite, "INNER JOIN sites s ON a.site_id = s.id") {
+		t.Fatalf("aggregate FROM with siteId must inner-join sites, got %q", fromSite)
+	}
+	if !strings.Contains(fromSite, "LEFT JOIN downstream_api_keys dk ON pl.downstream_api_key_id = dk.id") {
+		t.Fatalf("aggregate FROM with siteId must keep the LEFT downstream_api_keys join, got %q", fromSite)
+	}
+	if strings.Contains(fromSite, "LEFT JOIN accounts") || strings.Contains(fromSite, "LEFT JOIN sites") {
+		t.Fatalf("aggregate FROM with siteId must not LEFT JOIN accounts/sites, got %q", fromSite)
 	}
 	summarySite := proxyLogsSummaryQuerySQL(fromSite, " WHERE s.id = ?")
 	if !strings.Contains(summarySite, "JOIN") {
@@ -366,20 +377,29 @@ func TestStats_SQLiteProxyLogsAggregatePlan_NoJoinWithoutSiteID(t *testing.T) {
 		}
 	}
 
-	// Sanity check the other direction: with a siteId the plan does join
-	// (SQLite reports the joined tables by alias, e.g. "SEARCH s ... LEFT-JOIN").
+	// Sanity check the other direction: with a siteId the plan joins
+	// accounts/sites (INNER since the Wave 18 index audit) and keeps the
+	// LEFT downstream_api_keys join.
 	planRows, err := queryRowsErr(db.DB, "EXPLAIN QUERY PLAN "+proxyLogsSummaryQuerySQL(proxyLogsAggregateFrom(1, ""), " WHERE s.id = 1"))
 	if err != nil {
 		t.Fatalf("explain siteId summary: %v", err)
 	}
 	joined := false
+	touchesAccounts := false
 	for _, row := range planRows {
-		if detail, _ := row["detail"].(string); strings.Contains(detail, "LEFT-JOIN") {
+		detail, _ := row["detail"].(string)
+		if strings.Contains(detail, "LEFT-JOIN") {
 			joined = true
+		}
+		if strings.Contains(detail, "accounts") || strings.HasPrefix(detail, "SEARCH a ") || strings.HasPrefix(detail, "SCAN a ") {
+			touchesAccounts = true
 		}
 	}
 	if !joined {
-		t.Fatalf("siteId summary plan should keep the LEFT JOIN: %v", planRows)
+		t.Fatalf("siteId summary plan should keep the LEFT downstream_api_keys join: %v", planRows)
+	}
+	if !touchesAccounts {
+		t.Fatalf("siteId summary plan should join accounts: %v", planRows)
 	}
 }
 

--- a/handler/admin/stats_test.go
+++ b/handler/admin/stats_test.go
@@ -1251,6 +1251,91 @@ func TestStats_SQLiteMarketplaceFromAvailability(t *testing.T) {
 		t.Fatalf("bare account %d missing from claude accounts: %#v", accountWithoutToken, claude["accounts"])
 	}
 }
+// TestStats_SQLiteMarketplaceTokensBatchedAcrossModels is the Wave 18 N+1
+// regression: enabled tokens must attach to every model entry of an account
+// from ONE batched account_tokens load (the pre-fix shape fired one token
+// query per model×account availability row). The test pins the exact token
+// set and the legacy ordering (is_default DESC, id ASC), and proves
+// disabled/expired tokens stay out on every model the account serves.
+func TestStats_SQLiteMarketplaceTokensBatchedAcrossModels(t *testing.T) {
+	db, r := setupStatsSQLiteTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	mustExec(t, db, `INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', ?, ?)`, "batch-site", "https://batch.example.test", "openai", now, now)
+	var siteID int64
+	if err := db.Get(&siteID, "SELECT id FROM sites WHERE name = ?", "batch-site"); err != nil {
+		t.Fatalf("site id: %v", err)
+	}
+	mustExec(t, db, `INSERT INTO accounts (site_id, username, access_token, status, balance, checkin_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, 'active', 1.0, FALSE, ?, ?)`, siteID, "batch-user", "sk-batch", now, now)
+	var accountID int64
+	if err := db.Get(&accountID, "SELECT id FROM accounts WHERE username = ?", "batch-user"); err != nil {
+		t.Fatalf("account id: %v", err)
+	}
+
+	// Tokens: one default + one plain enabled, plus one disabled and one
+	// expired that must NOT be attached.
+	mustExec(t, db, `INSERT INTO account_tokens (account_id, name, token, enabled, is_default, value_status, created_at, updated_at)
+		VALUES (?, 'tok-default', 'sk-d', 1, 1, 'ready', ?, ?)`, accountID, now, now)
+	mustExec(t, db, `INSERT INTO account_tokens (account_id, name, token, enabled, is_default, value_status, created_at, updated_at)
+		VALUES (?, 'tok-plain', 'sk-p', 1, 0, 'ready', ?, ?)`, accountID, now, now)
+	mustExec(t, db, `INSERT INTO account_tokens (account_id, name, token, enabled, is_default, value_status, created_at, updated_at)
+		VALUES (?, 'tok-disabled', 'sk-x', 0, 0, 'ready', ?, ?)`, accountID, now, now)
+	mustExec(t, db, `INSERT INTO account_tokens (account_id, name, token, enabled, is_default, value_status, created_at, updated_at)
+		VALUES (?, 'tok-expired', 'sk-e', 1, 0, 'expired', ?, ?)`, accountID, now, now)
+
+	// Two models available on the same account — the old N+1 fired the
+	// per-account token query once per row here.
+	for _, model := range []string{"batch-model-1", "batch-model-2"} {
+		mustExec(t, db, `INSERT INTO model_availability (account_id, model_name, available, is_manual, latency_ms, checked_at)
+			VALUES (?, ?, 1, 0, 200, ?)`, accountID, model, now)
+	}
+
+	resp := doGet(t, r, "/api/models/marketplace")
+	if resp.Code != 200 {
+		t.Fatalf("marketplace returned %d: %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	models, _ := body["models"].([]any)
+	checked := 0
+	for _, raw := range models {
+		m := raw.(map[string]any)
+		name, _ := m["name"].(string)
+		if name != "batch-model-1" && name != "batch-model-2" {
+			continue
+		}
+		checked++
+		accounts, _ := m["accounts"].([]any)
+		var acc map[string]any
+		for _, araw := range accounts {
+			if am := araw.(map[string]any); int64(am["id"].(float64)) == accountID {
+				acc = am
+			}
+		}
+		if acc == nil {
+			t.Fatalf("%s: account %d missing: %#v", name, accountID, m["accounts"])
+		}
+		tokens, _ := acc["tokens"].([]any)
+		if len(tokens) != 2 {
+			t.Fatalf("%s: tokens = %#v, want exactly the 2 enabled tokens", name, tokens)
+		}
+		first := tokens[0].(map[string]any)
+		second := tokens[1].(map[string]any)
+		if first["name"] != "tok-default" || first["isDefault"] != true {
+			t.Fatalf("%s: first token = %#v, want tok-default isDefault=true", name, first)
+		}
+		if second["name"] != "tok-plain" || second["isDefault"] != false {
+			t.Fatalf("%s: second token = %#v, want tok-plain isDefault=false", name, second)
+		}
+	}
+	if checked != 2 {
+		t.Fatalf("checked %d batch models, want 2 (fixture models missing from marketplace)", checked)
+	}
+}
 
 func TestStats_SQLiteTokenCandidatesMaps(t *testing.T) {
 	db, r := setupStatsSQLiteTest(t)

--- a/store/additive.go
+++ b/store/additive.go
@@ -365,6 +365,47 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 			return nil
 		},
 	},
+	{
+		// Wave 18 index audit (admin high-frequency read paths). Pure additive
+		// indexes on base-schema columns, measured on a 300k-proxy_logs audit
+		// fixture before adoption (SQLite EXPLAIN QUERY PLAN + timing):
+		//   - proxy_logs_channel_id_created_at_idx: the proxy-logs page
+		//     "channelId" filter ("why is this channel failing") degraded from
+		//     an ORDER BY created_at scan-until-match into a direct SEARCH
+		//     (~18ms median / >1s tail on sparse channels -> <1ms).
+		//   - proxy_logs_created_at_covering_summary_idx: covering index for
+		//     the range-filtered proxy-logs summary aggregate (COUNT + five
+		//     SUMs); created_at leads so range filters SEARCH, and the
+		//     aggregate columns are satisfied from the index alone instead of
+		//     heap lookups (~3x faster at 300k rows).
+		//   - checkin_logs_status_created_at_idx: the checkin-history status
+		//     filter previously matched on status then re-sorted all matches
+		//     by created_at (temp B-tree); the composite index serves the
+		//     ORDER BY ... DESC LIMIT page directly.
+		// Fresh installs also receive these via this step (AutoMigrate runs
+		// the additive registry after buildIndexes); EnsureIndex uses CREATE
+		// INDEX IF NOT EXISTS so re-runs are no-ops on both dialects.
+		Version:     "sc2_027_admin_read_path_indexes",
+		Description: "indexes for admin read paths: proxy_logs (channel_id, created_at), proxy_logs covering (created_at, status, estimated_cost, total_tokens, prompt_tokens, completion_tokens), checkin_logs (status, created_at)",
+		Apply: func(db *DB) error {
+			for _, idx := range []struct {
+				name string
+				sql  string
+			}{
+				{"proxy_logs_channel_id_created_at_idx",
+					`CREATE INDEX IF NOT EXISTS proxy_logs_channel_id_created_at_idx ON proxy_logs (channel_id, created_at)`},
+				{"proxy_logs_created_at_covering_summary_idx",
+					`CREATE INDEX IF NOT EXISTS proxy_logs_created_at_covering_summary_idx ON proxy_logs (created_at, status, estimated_cost, total_tokens, prompt_tokens, completion_tokens)`},
+				{"checkin_logs_status_created_at_idx",
+					`CREATE INDEX IF NOT EXISTS checkin_logs_status_created_at_idx ON checkin_logs (status, created_at)`},
+			} {
+				if err := EnsureIndex(db, idx.name, idx.sql); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	},
 }
 
 // schemaMigrationsDDL creates the version bookkeeping table.

--- a/store/additive_test.go
+++ b/store/additive_test.go
@@ -349,3 +349,45 @@ func TestPostgresEnsureColumnAndMigrations(t *testing.T) {
 		t.Errorf("expected 1 bookkeeping row, got %d", cnt)
 	}
 }
+
+// TestSC2027AdminReadPathIndexes verifies the Wave 18 admin read-path indexes
+// land on a fresh SQLite install via AutoMigrate (which runs the additive
+// registry after buildIndexes) and survive a second AutoMigrate run unchanged
+// — the CREATE INDEX IF NOT EXISTS + schema_migrations bookkeeping must make
+// the step idempotent.
+func TestSC2027AdminReadPathIndexes(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+	// Idempotent re-run (restart simulation).
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("second AutoMigrate failed: %v", err)
+	}
+
+	for _, name := range []string{
+		"proxy_logs_channel_id_created_at_idx",
+		"proxy_logs_created_at_covering_summary_idx",
+		"checkin_logs_status_created_at_idx",
+	} {
+		var found string
+		if err := db.QueryRow(`SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?`, name).Scan(&found); err != nil {
+			t.Fatalf("index %s missing after AutoMigrate: %v", name, err)
+		}
+	}
+
+	// The step itself is recorded exactly once in schema_migrations.
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations WHERE version = 'sc2_027_admin_read_path_indexes'`).Scan(&n); err != nil {
+		t.Fatalf("schema_migrations lookup failed: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("sc2_027 recorded %d times, want 1", n)
+	}
+}
+

--- a/store/additive_upgrade_test.go
+++ b/store/additive_upgrade_test.go
@@ -83,14 +83,18 @@ func additiveColumns() []additiveColumnSpec {
 // legacySchemaDDL is the pre-additive shape of the tables touched by
 // enterpriseAdditiveSteps. It intentionally omits every additive column so the
 // test exercises the real ALTER TABLE ADD COLUMN upgrade path against an old
-// database, rather than the fresh-install no-op path.
+// database, rather than the fresh-install no-op path. Base columns that
+// additive steps reference without adding (e.g. the sc2_027 read-path indexes
+// over proxy_logs.channel_id / status / token-cost columns and
+// checkin_logs.status) mirror the real TS drizzle schema, which always
+// carried them (store/testdata/ts-source/hub.db).
 var legacySchemaDDL = []string{
 	"CREATE TABLE downstream_api_keys (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, key TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)",
 	"CREATE TABLE sites (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, url TEXT NOT NULL, platform TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)",
 	"CREATE TABLE token_routes (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)",
-	"CREATE TABLE proxy_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, created_at TEXT NOT NULL)",
+	"CREATE TABLE proxy_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, channel_id INTEGER, status TEXT, estimated_cost REAL, total_tokens INTEGER, prompt_tokens INTEGER, completion_tokens INTEGER, created_at TEXT NOT NULL)",
 	"CREATE TABLE accounts (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)",
-	"CREATE TABLE checkin_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, account_id INTEGER NOT NULL, created_at TEXT NOT NULL)",
+	"CREATE TABLE checkin_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, account_id INTEGER NOT NULL, status TEXT NOT NULL DEFAULT 'success', created_at TEXT NOT NULL)",
 	"CREATE TABLE route_channels (id INTEGER PRIMARY KEY AUTOINCREMENT, route_id INTEGER NOT NULL, account_id INTEGER NOT NULL, created_at TEXT NOT NULL)",
 	"CREATE TABLE oauth_route_unit_members (id INTEGER PRIMARY KEY AUTOINCREMENT, unit_id INTEGER NOT NULL, account_id INTEGER NOT NULL, created_at TEXT NOT NULL)",
 	"CREATE TABLE account_tokens (id INTEGER PRIMARY KEY AUTOINCREMENT, account_id INTEGER NOT NULL, name TEXT NOT NULL, token TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL)",

--- a/store/postgres_test.go
+++ b/store/postgres_test.go
@@ -214,6 +214,12 @@ func TestPostgresIndexesCreated(t *testing.T) {
 		"accounts_site_id_idx",
 		"proxy_logs_created_at_idx",
 		"events_created_at_idx",
+		// Wave 18 admin read-path indexes (additive step sc2_027): asserting
+		// them here proves the step's plain CREATE INDEX form applies on the
+		// PostgreSQL dialect too.
+		"proxy_logs_channel_id_created_at_idx",
+		"proxy_logs_created_at_covering_summary_idx",
+		"checkin_logs_status_created_at_idx",
 	}
 
 	for _, idxName := range sampleIndexes {


### PR DESCRIPTION
## What — Wave 18 Lane D: admin high-frequency read-path index & N+1 audit (dual-dialect)

Audited every admin list/aggregate SQL shape (channels, accounts, proxy-logs, dashboard traffic, routes/token_routes, sites, checkin history, model catalog) against a seeded 300k-`proxy_logs` SQLite fixture using `EXPLAIN QUERY PLAN` + timing. Ships **3 indexes** (additive step `sc2_027`) + **2 query-shape fixes** — all with measured before/after evidence; candidates without measurable gain were dropped.

## Query inventory × finding × disposition

| # | Endpoint / query | Finding (300k-row fixture) | Disposition |
|---|---|---|---|
| 1 | `GET /api/stats/proxy-logs` list (default) | `SCAN ... USING proxy_logs_created_at_idx` — already ordered | no action |
| 2 | … `status=success` | `SEARCH (status, created_at)` ✓ | no action |
| 3 | … `channelId=` | scan-until-match on `created_at`; **17.9ms median, >1.2s tail** on sparse channels | ✅ new `proxy_logs_channel_id_created_at_idx` → `SEARCH`, **0.5ms** |
| 4 | … `siteId=` list page | ordered scan + join filter (~4ms typical; degrades on low-traffic sites) | kept (no `proxy_logs.site_id` column; INNER rewrite unsafe for `ORDER BY+LIMIT` list) |
| 5 | … `client=` / `from/to` | existing composite indexes ✓ | no action |
| 6 | proxy-logs **COUNT** with `siteId` | full `SCAN pl` of 300k rows — **107ms** | ✅ LEFT→INNER rewrite → **10.8ms** (~10x) |
| 7 | proxy-logs **summary** with `siteId` | same full-scan shape | ✅ same rewrite → **12.8ms** |
| 8 | proxy-logs **summary with range** | `created_at` SEARCH + per-row heap lookups — **247ms** (slowest audited query) | ✅ covering index → **77ms** (~3.2x) |
| 9 | proxy-logs summary (no filter) | existing `proxy_logs_summary_covering_idx` ✓ | no action |
| 10 | dashboard proxy24h / perf60s / site-availability | planner drives sites→accounts→`proxy_logs_account_created_at_idx` ✓ | no action |
| 11 | dashboard spend/trend/model usage | `*_day_usage` unique `(local_day, ...)` indexes ✓ | no action |
| 12 | `GET /api/accounts` list `ORDER BY sort_order, id` | temp B-tree sort, ~1ms at fleet scale | ❌ evaluated `accounts (sort_order, id)` — no measurable gain (small table), dropped |
| 13 | per-account today proxy aggregate | `(account_id, created_at)` multi-range scan ✓ | no action |
| 14 | `GET /api/checkin/logs` default / `accountId=` | `created_at` / `(account_id, created_at)` ✓ | no action |
| 15 | … `status=` filter | `SEARCH status_idx` + **USE TEMP B-TREE FOR ORDER BY**; 2.5ms | ✅ new `checkin_logs_status_created_at_idx` → `SEARCH`, **0.5ms** |
| 16 | `GET /api/routes` list | `token_routes_sort_order_id_idx` ✓ (sc2_006) | no action |
| 17 | `GET /api/channels` 5-way join | small table, PK joins ✓ | no action |
| 18 | marketplace account/token availability | thousands of rows, small temp sorts | ❌ evaluated — below measurable threshold, dropped |
| 19 | marketplace **token attachment** | 🔴 **N+1**: one `account_tokens` query **per model×account row** (hundreds per render) | ✅ single ordered batch query, Go-side grouping |
| 20 | `GET /api/channels/probe-history` window | temp B-tree window sort, 3k-row table | ❌ evaluated `(channel_id/account_id, id DESC)` — SQLite window materializes regardless; neutral, dropped |
| 21 | balance history / events / attention items / downstream-key usage | existing unique `(local_day, account_id)`, `(read, created_at)`, `status`, covering key indexes ✓ | no action |
| 22 | proxy-auth hot path `WHERE key = ?` | inline `UNIQUE (key)` constraint = implicit unique index ✓ | no action |

## EXPLAIN QUERY PLAN evidence (SQLite, 300k `proxy_logs`)

**#3 channel filter**
```
before: SCAN pl USING INDEX proxy_logs_created_at_idx
after:  SEARCH pl USING INDEX proxy_logs_channel_id_created_at_idx (channel_id=?)
```

**#6/#7 siteId COUNT/summary** (query-shape change, no new index — uses existing `accounts_site_id_idx` + `proxy_logs_account_created_at_idx`)
```
before: SEARCH s ... (rowid=?)
        SCAN pl                                    <- full 300k scan
        BLOOM FILTER ON a (id=?)
        SEARCH a ... (rowid=?) LEFT-JOIN
after:  SEARCH s ... (rowid=?)
        SEARCH a USING COVERING INDEX accounts_site_id_idx (site_id=?)
        SEARCH pl USING INDEX proxy_logs_account_created_at_idx (account_id=?)
        SEARCH dk ... (rowid=?) LEFT-JOIN
```

**#8 range summary**
```
before: SEARCH pl USING INDEX proxy_logs_created_at_idx (created_at>?)   + heap lookup per row
after:  SEARCH pl USING COVERING INDEX proxy_logs_created_at_covering_summary_idx (created_at>?)
```

**#15 checkin status filter**
```
before: SEARCH cl USING INDEX checkin_logs_status_idx (status=?)
        USE TEMP B-TREE FOR ORDER BY
after:  SEARCH cl USING INDEX checkin_logs_status_created_at_idx (status=?)
```

**Timing** (median of 5, warm):

| query | before | after |
|---|---|---|
| proxy-logs list channelId | 17.9ms (max 1260ms) | 0.5ms |
| proxy-logs COUNT siteId | 107ms | 10.8ms |
| proxy-logs summary range | 247ms | 77ms |
| checkin logs status=failed | 2.5ms | 0.5ms |
| marketplace tokens | N queries/render (1 per model×account row) | 1 batch query |

## Changes

1. **`sc2_027_admin_read_path_indexes`** (`store/additive.go`) — pure additive, idempotent (`CREATE INDEX IF NOT EXISTS`), plain dual-dialect DDL, recorded in `schema_migrations`; carried by the server AutoMigrate path and `cmd/migrate` targets (`openTargetDB` → `AutoMigrate`). One-time cost ≈2.0s on the 300k-row fixture. Naming follows the existing 70-index `<table>_<cols>_idx` convention (task brief's `idx_<table>_<cols>` shorthand yielded to repo consistency).
2. **`proxyLogsAggregateFrom`** (`handler/admin/stats.go`) — with `siteId`, accounts/sites joins switch LEFT→INNER; `s.id = ?` already discards non-matching rows, so results are identical (guarded by `TestStats_ProxyLogsSummaryCache_SiteIdFilterStillAggregates`); the `downstream_api_keys` join stays LEFT (search-only consumer, row-preserving).
3. **Marketplace N+1** (`handler/admin/stats_marketplace.go`) — enabled/non-expired tokens pre-loaded in ONE ordered query (`account_id, is_default DESC, id ASC`), grouped in Go; token set, order, dedup and JSON shape unchanged (new regression test pins the exact enabled set across two models).

## Tests

- `store`: `TestSC2027AdminReadPathIndexes` (fresh + idempotent re-run + single bookkeeping row); `TestPostgresIndexesCreated` gains the 3 names → CI `test-pg` proves the PG dialect; legacy-upgrade fixture gains the base columns the new indexes reference (mirrors the real TS schema in `store/testdata/ts-source/hub.db`).
- `handler/admin`: aggregate FROM shape + planner assertions updated for the INNER site filter; new marketplace token-batch regression test.
- Local: `go build ./cmd/server` ✓ · `go vet ./...` ✓ · `go test ./... -count=1` ✓ (all packages).
- Note: `TestProbeSQLiteWritableNonWritableDir` fails on **clean master** in this Windows admin environment (unrelated pre-existing; skipped in local runs, unchanged by this PR).

## Guardrails honored

No table-structure changes · no API field/semantic changes · no ordering/pagination behavior changes · only indexes with measured gain · migration idempotent on both dialects · `sc2_026` untouched.

## Local gate note

First push attempt hit the pre-push race gate's default 300s **per-package** timeout on `handler/admin` (300.073s kill; isolated re-measure: 308.5s with race under WSL+/mnt/d — this package has been growing past the default budget on slow local FS mounts, unrelated to this change; the delta here is one millisecond-scale test). Retried with the gate script's official `METAPI_RACE_TIMEOUT_SECONDS=900` knob (no `--no-verify`): full frontend gate + build + vet + complete `-race` suite all green, `handler/admin` finished at 357.6s. GitHub Actions runners (native Linux FS) are not affected.
