### PR TITLE
feat(settings): global kill switches for upstream account health monitoring (#1027)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,15 @@ CHECKIN_SCHEDULE_MODE=cron
 CHECKIN_INTERVAL_HOURS=6
 CHECKIN_WINDOW_START=00:00
 CHECKIN_WINDOW_END=23:59
+# Global kill switch for the automatic check-in scheduler (#1027).
+# Set false to stop all automatic check-in requests to upstream sites.
+# Runtime override: Settings -> Operations -> Scheduling -> checkinEnabled.
+CHECKIN_ENABLED=true
 BALANCE_REFRESH_CRON=0 * * * *
+# Global kill switch for the periodic balance-refresh scheduler (#1027).
+# Set false to stop scheduled upstream balance queries.
+# Runtime override: Settings -> Operations -> Scheduling -> balanceRefreshEnabled.
+BALANCE_REFRESH_ENABLED=true
 # Periodic upstream model-list sync. Code default is 04:00 daily
 # (DefaultModelSyncCron); DB setting model_sync_cron overrides this.
 MODEL_SYNC_CRON=0 4 * * *

--- a/app/services.go
+++ b/app/services.go
@@ -190,6 +190,35 @@ func UpdateBalanceCron(cronExpr string) error {
 	return activeScheduler.UpdateCron(cronExpr)
 }
 
+// UpdateCheckinEnabled hot-toggles the global check-in switch (#1027) on the
+// running scheduler. It is a no-op before background services have started.
+func UpdateCheckinEnabled(enabled bool) {
+	updateMu.Lock()
+	defer updateMu.Unlock()
+	servicesMu.RLock()
+	activeScheduler := checkinScheduler
+	servicesMu.RUnlock()
+	if activeScheduler == nil {
+		return
+	}
+	activeScheduler.SetEnabled(enabled)
+}
+
+// UpdateBalanceEnabled hot-toggles the global balance-refresh switch (#1027)
+// on the running scheduler. It is a no-op before background services have
+// started.
+func UpdateBalanceEnabled(enabled bool) error {
+	updateMu.Lock()
+	defer updateMu.Unlock()
+	servicesMu.RLock()
+	activeScheduler := balanceScheduler
+	servicesMu.RUnlock()
+	if activeScheduler == nil {
+		return nil
+	}
+	return activeScheduler.SetEnabled(enabled)
+}
+
 // UpdateModelSyncCron hot-reloads the running model-sync scheduler with a
 // newly persisted cron. It is a no-op before background services have started.
 func UpdateModelSyncCron(cronExpr string) error {

--- a/config/config.go
+++ b/config/config.go
@@ -111,8 +111,16 @@ type Config struct {
 	CheckinWindowStart string
 	CheckinWindowEnd   string
 	BalanceRefreshCron string
-	ModelSyncCron      string
-	LogCleanupCron     string
+	// Global kill switches for the two always-on periodic jobs that touch
+	// upstream accounts (check-in, balance refresh) — issue #1027. Defaults
+	// preserve historical behavior (both jobs on); operators turn either job
+	// off via env (CHECKIN_ENABLED / BALANCE_REFRESH_ENABLED) or the runtime
+	// settings of the same camelCase names. Stored inverted (zero value =
+	// enabled) so bare config literals keep the default-on behavior.
+	CheckinDisabled        bool
+	BalanceRefreshDisabled bool
+	ModelSyncCron          string
+	LogCleanupCron         string
 	// Site & Branding (5 fields) - empty defaults keep the embedded frontend
 	// branding and login-page copy unchanged. homePageContent was removed
 	// (Wave 8 Lane D): the value was stored but never rendered anywhere.
@@ -652,6 +660,11 @@ func Load(env map[string]string) *Config {
 		1, 24,
 	)
 	cfg.BalanceRefreshCron = firstNonEmpty(get("BALANCE_REFRESH_CRON"), DefaultBalanceRefreshCron)
+	// #1027: global enable switches for the upstream-touching account jobs.
+	// Absent/invalid env vars keep the historical defaults (both enabled).
+	// Stored inverted: zero value = enabled (see Config field comment).
+	cfg.CheckinDisabled = !parseBoolean(get("CHECKIN_ENABLED"), true)
+	cfg.BalanceRefreshDisabled = !parseBoolean(get("BALANCE_REFRESH_ENABLED"), true)
 	cfg.ModelSyncCron = firstNonEmpty(get("MODEL_SYNC_CRON"), DefaultModelSyncCron)
 	cfg.LogCleanupCron = firstNonEmpty(get("LOG_CLEANUP_CRON"), DefaultLogCleanupCron)
 

--- a/config/health_toggle_test.go
+++ b/config/health_toggle_test.go
@@ -1,0 +1,44 @@
+package config
+
+import "testing"
+
+// Focused tests for the issue #1027 upstream-account health-monitoring kill
+// switches (CHECKIN_ENABLED / BALANCE_REFRESH_ENABLED). Both default to
+// enabled (historical behavior) and are stored inverted internally so the
+// zero value of Config keeps the default-on semantics.
+
+func TestLoadAccountHealthSwitchesDefaultEnabled(t *testing.T) {
+	cfg := Load(map[string]string{})
+	if cfg.CheckinDisabled {
+		t.Fatal("CheckinDisabled = true, want false default (check-in on)")
+	}
+	if cfg.BalanceRefreshDisabled {
+		t.Fatal("BalanceRefreshDisabled = true, want false default (balance refresh on)")
+	}
+}
+
+func TestLoadAccountHealthSwitchesDisabled(t *testing.T) {
+	cfg := Load(map[string]string{
+		"CHECKIN_ENABLED":         "false",
+		"BALANCE_REFRESH_ENABLED": "false",
+	})
+	if !cfg.CheckinDisabled {
+		t.Fatal("CheckinDisabled = false, want true when CHECKIN_ENABLED=false")
+	}
+	if !cfg.BalanceRefreshDisabled {
+		t.Fatal("BalanceRefreshDisabled = false, want true when BALANCE_REFRESH_ENABLED=false")
+	}
+}
+
+func TestLoadAccountHealthSwitchesExplicitEnabled(t *testing.T) {
+	cfg := Load(map[string]string{
+		"CHECKIN_ENABLED":         "true",
+		"BALANCE_REFRESH_ENABLED": "true",
+	})
+	if cfg.CheckinDisabled {
+		t.Fatal("CheckinDisabled = true, want false when CHECKIN_ENABLED=true")
+	}
+	if cfg.BalanceRefreshDisabled {
+		t.Fatal("BalanceRefreshDisabled = true, want false when BALANCE_REFRESH_ENABLED=true")
+	}
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -738,6 +738,8 @@ Get all runtime settings as a flat JSON object. Sensitive values (proxyToken, to
 
 Update runtime settings. Partial update -- only send fields you want to change. Schedule updates atomically write both the legacy cron key and the corresponding v1 semantic mirror.
 
+**Upstream account health-monitoring kill switches** (#1027): `checkinEnabled` / `balanceRefreshEnabled` (boolean, default `true`) globally stop the two always-on jobs that contact upstream accounts -- automatic check-in and scheduled balance refresh. Changes persist to the `checkin_enabled` / `balance_refresh_enabled` settings and hot-apply to the running schedulers without a restart. Env equivalents: `CHECKIN_ENABLED` / `BALANCE_REFRESH_ENABLED` (read at startup). The per-account check-in switch (`checkinEnabled` on account rows) and `modelAvailabilityProbeEnabled` (Proxy & Models -> Proxy Transport) remain independent controls. Non-boolean values are rejected with `400`.
+
 **Status-code verdict policy** (P1-2): `proxyRetryStatusRanges` / `proxyDisableStatusRanges` take a comma-separated spec of single codes (`401`) and inclusive ranges (`500-599`); adjacent/overlapping ranges merge. Blank restores the defaults. Malformed specs are rejected with `400` and the config is left untouched.
 
 - `proxyRetryStatusRanges` — upstream statuses that count as retryable channel faults. Default (blank) reproduces the historical hardcoded verdicts: `401,403,408,409,425,429,500-599`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -120,7 +120,9 @@ root; the tables below list only what a deployment needs plus common options.
 | `DATA_DIR`                          | `./data`                      | Data directory (SQLite database and uploaded files). Code default is `./data` relative to the working directory; the container image sets `DATA_DIR=/app/data` via its `ENV`, and compose files pass it through explicitly |
 | `LOG_LEVEL`                         | `info`                        | slog threshold: `debug`/`info`/`warn`/`error`. Raise to `warn` to quiet hot-path logs.                                                                                                                                                                                                                                                                                                              |
 | `CHECKIN_CRON`                      | `0 8 * * *`                   | Daily checkin cron expression                                                                                                                                                                                                                                                                                                                                                                      |
+| `CHECKIN_ENABLED`                   | `true`                        | Global kill switch for the automatic check-in scheduler: `false` stops scheduled check-in requests to upstream sites. Runtime setting `checkinEnabled` wins when set (#1027)                                                                                                                                                                                                                       |
 | `BALANCE_REFRESH_CRON`              | `0 * * * *`                   | Hourly balance refresh cron                                                                                                                                                                                                                                                                                                                                                                        |
+| `BALANCE_REFRESH_ENABLED`           | `true`                        | Global kill switch for the balance-refresh scheduler: `false` stops scheduled upstream balance queries. Runtime setting `balanceRefreshEnabled` wins when set (#1027)                                                                                                                                                                                                                              |
 | `MODEL_SYNC_CRON`                   | `0 4 * * *`                   | Daily upstream model-list sync cron; DB setting `model_sync_cron` overrides                                                                                                                                                                                                                                                                                                                        |
 | `TZ`                                | system local time             | Timezone for cron scheduling. No code-level default; `.env.example` and the compose files preset `Asia/Shanghai`                                                                                                                                                                                                                                                                                   |
 | `DB_TYPE`                           | `sqlite`                      | Database type: `sqlite` or `postgres`; inferred as `postgres` when a PostgreSQL URL is provided                                                                                                                                                                                                                                          |
@@ -320,6 +322,42 @@ pg_dump -Fc 'postgres://<user>:<password>@<host>:5432/metapi?sslmode=require' > 
 - Startup exits before binding the HTTP port when database bootstrap, runtime settings load, or runtime schema migration fails.
 - Admin events are logged in the database `events` table
 - Proxy request logs are stored in `proxy_logs`
+
+## Disabling Upstream Account Health Monitoring
+
+Metapi runs three background jobs that actively contact upstream accounts
+("health monitoring"). Each one can be switched off independently; defaults
+keep the historical always-on behavior for check-in and balance refresh.
+
+| Job | What it does | How to turn it off |
+| --- | --- | --- |
+| Automatic check-in | Sends scheduled check-in requests to upstream accounts (cron or interval mode) | Settings -> Operations -> Scheduled Tasks: uncheck **Enable daily check-in** (global); per-account switches are on the Accounts page; env `CHECKIN_ENABLED=false` |
+| Balance refresh | Queries upstream account balances on a schedule | Settings -> Operations -> Scheduled Tasks: uncheck **Enable scheduled balance refresh**; env `BALANCE_REFRESH_ENABLED=false` |
+| Model availability probe | Actively probes channel models (off by default) | Settings -> Proxy & Models -> Proxy Transport: `modelAvailabilityProbeEnabled`; env `MODEL_AVAILABILITY_PROBE_ENABLED` |
+
+Notes:
+
+- The two global checkboxes apply hot (no container restart required) and are
+  persisted to the database, so they survive restarts and upgrades.
+- Environment variables only set the startup default; a persisted runtime
+  setting wins when present.
+- Status badges and probe-health columns on the Accounts page are passive
+  displays of past traffic; they never issue upstream requests themselves.
+
+Docker Compose example -- stop every automatic upstream request by adding the
+kill switches to your `.env` and recreating the container:
+
+```bash
+CHECKIN_ENABLED=false
+BALANCE_REFRESH_ENABLED=false
+```
+
+```bash
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Flipping the same two checkboxes in the admin UI achieves the identical result
+without any restart.
 
 ## Browser CORS
 

--- a/handler/admin/settings.go
+++ b/handler/admin/settings.go
@@ -46,6 +46,7 @@ func (h *settingsHandler) getRuntime(w http.ResponseWriter, r *http.Request) {
 		"checkinWindowStart":   cfg.CheckinWindowStart,
 		"checkinWindowEnd":     cfg.CheckinWindowEnd,
 		"checkinSchedule":      scheduleSpecForCheckin(cfg),
+		"checkinEnabled":       !cfg.CheckinDisabled,
 		// Site & Branding
 		"systemName":    cfg.SystemName,
 		"logo":          cfg.Logo,
@@ -55,6 +56,7 @@ func (h *settingsHandler) getRuntime(w http.ResponseWriter, r *http.Request) {
 		// Balance
 		"balanceRefreshCron":     cfg.BalanceRefreshCron,
 		"balanceRefreshSchedule": scheduler.CronToSchedule(cfg.BalanceRefreshCron),
+		"balanceRefreshEnabled":  !cfg.BalanceRefreshDisabled,
 		// Model sync (#1005) — plain cron, no v2 schedule mirror
 		"modelSyncCron": cfg.ModelSyncCron,
 		// Log cleanup

--- a/handler/admin/settings_apply.go
+++ b/handler/admin/settings_apply.go
@@ -63,6 +63,20 @@ func (h *settingsHandler) applyProxyAccessSettings(body map[string]any) *setting
 
 // applyCheckinSettings applies the checkin schedule fields.
 func (h *settingsHandler) applyCheckinSettings(body map[string]any) *settingsApplyError {
+	// #1027: global check-in kill switch. Persisted to the checkin_enabled
+	// setting and hot-applied to the running scheduler independently of the
+	// schedule fields below.
+	if v, ok := body["checkinEnabled"]; ok {
+		enabled, err := toBoolStrict(v)
+		if err != nil {
+			return failSettings(http.StatusBadRequest, "checkinEnabled must be a boolean (true/false)")
+		}
+		h.cfg.CheckinDisabled = !enabled
+		if err := upsertSettingDB(h.db, "checkin_enabled", enabled); err != nil {
+			return failSettings(http.StatusInternalServerError, "failed to save checkinEnabled")
+		}
+		app.UpdateCheckinEnabled(enabled)
+	}
 	if hasAnyKey(body, "checkinCron", "checkinScheduleMode", "checkinIntervalHours") {
 		patch := checkinSchedulePatch{}
 		if v, ok := body["checkinCron"]; ok {
@@ -128,6 +142,22 @@ func (h *settingsHandler) applyCheckinSettings(body map[string]any) *settingsApp
 
 // applyBalanceScheduleSettings applies the balance refresh cron/schedule.
 func (h *settingsHandler) applyBalanceScheduleSettings(body map[string]any) *settingsApplyError {
+	// #1027: global balance-refresh kill switch. Persisted to the
+	// balance_refresh_enabled setting and hot-applied to the running
+	// scheduler independently of the cron fields below.
+	if v, ok := body["balanceRefreshEnabled"]; ok {
+		enabled, err := toBoolStrict(v)
+		if err != nil {
+			return failSettings(http.StatusBadRequest, "balanceRefreshEnabled must be a boolean (true/false)")
+		}
+		h.cfg.BalanceRefreshDisabled = !enabled
+		if err := upsertSettingDB(h.db, "balance_refresh_enabled", enabled); err != nil {
+			return failSettings(http.StatusInternalServerError, "failed to save balanceRefreshEnabled")
+		}
+		if err := app.UpdateBalanceEnabled(enabled); err != nil {
+			slog.Warn("settings: balance refresh enable hot update failed", "error", err)
+		}
+	}
 	// Balance refresh cron
 	if v, ok := body["balanceRefreshCron"]; ok {
 		cron := normalizeString(v)
@@ -271,6 +301,14 @@ func (h *settingsHandler) applyFeatureToggleSettings(body map[string]any) *setti
 		}
 		h.cfg.ModelAvailabilityProbeEnabled = enabled
 		upsertSettingDB(h.db, "model_availability_probe_enabled", enabled)
+		// #1027: hot-apply the toggle to the running ticker. Before this the
+		// flag was only honored at scheduler Start, so toggling it off from
+		// the settings page kept probing until a restart.
+		if sched := scheduler.GetGlobalModelProbeScheduler(); sched != nil {
+			if err := sched.SetEnabled(enabled); err != nil {
+				slog.Warn("settings: model probe hot toggle failed", "error", err)
+			}
+		}
 	}
 
 	// Codex upstream websocket

--- a/handler/admin/settings_health_toggle_test.go
+++ b/handler/admin/settings_health_toggle_test.go
@@ -1,0 +1,103 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// Focused tests for the issue #1027 global kill switches exposed via
+// PUT /api/settings/runtime (checkinEnabled / balanceRefreshEnabled).
+
+func getRuntimeSettingJSON(t *testing.T, db *store.DB, key string) string {
+	t.Helper()
+	var value string
+	if err := db.QueryRow(db.Rebind("SELECT value FROM settings WHERE key = ?"), key).Scan(&value); err != nil {
+		t.Fatalf("query setting %s: %v", key, err)
+	}
+	return value
+}
+
+func TestSettingsRuntimeCheckinEnabledKillSwitch(t *testing.T) {
+	db, r, cfg := setupEdgeTest(t)
+
+	if cfg.CheckinDisabled {
+		t.Fatalf("fixture must start with check-in enabled")
+	}
+
+	// Disable.
+	resp := doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+		"checkinEnabled": false,
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("disable: %d %s", resp.Code, resp.Body.String())
+	}
+	if !cfg.CheckinDisabled {
+		t.Fatalf("PUT checkinEnabled=false must set cfg.CheckinDisabled")
+	}
+	if got := getRuntimeSettingJSON(t, db, "checkin_enabled"); got != "false" {
+		t.Fatalf("stored checkin_enabled = %q, want JSON false", got)
+	}
+
+	// GET reflects the toggle.
+	get := doGet(t, r, "/api/settings/runtime")
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET runtime: %d", get.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(get.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode GET body: %v", err)
+	}
+	if body["checkinEnabled"] != false {
+		t.Fatalf("GET checkinEnabled = %v, want false", body["checkinEnabled"])
+	}
+	if body["balanceRefreshEnabled"] != true {
+		t.Fatalf("GET balanceRefreshEnabled = %v, want true (untouched)", body["balanceRefreshEnabled"])
+	}
+
+	// Re-enable.
+	resp = doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+		"checkinEnabled": true,
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("re-enable: %d %s", resp.Code, resp.Body.String())
+	}
+	if cfg.CheckinDisabled {
+		t.Fatalf("PUT checkinEnabled=true must clear cfg.CheckinDisabled")
+	}
+	if got := getRuntimeSettingJSON(t, db, "checkin_enabled"); got != "true" {
+		t.Fatalf("stored checkin_enabled = %q, want JSON true", got)
+	}
+}
+
+func TestSettingsRuntimeBalanceRefreshEnabledKillSwitch(t *testing.T) {
+	db, r, cfg := setupEdgeTest(t)
+
+	resp := doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+		"balanceRefreshEnabled": false,
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("disable: %d %s", resp.Code, resp.Body.String())
+	}
+	if !cfg.BalanceRefreshDisabled {
+		t.Fatalf("PUT balanceRefreshEnabled=false must set cfg.BalanceRefreshDisabled")
+	}
+	if got := getRuntimeSettingJSON(t, db, "balance_refresh_enabled"); got != "false" {
+		t.Fatalf("stored balance_refresh_enabled = %q, want JSON false", got)
+	}
+}
+
+func TestSettingsRuntimeKillSwitchRejectsNonBoolean(t *testing.T) {
+	_, r, _ := setupEdgeTest(t)
+
+	for _, key := range []string{"checkinEnabled", "balanceRefreshEnabled"} {
+		resp := doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+			key: "yes",
+		})
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("%s non-boolean: status = %d body=%s, want 400", key, resp.Code, resp.Body.String())
+		}
+	}
+}

--- a/scheduler/balance.go
+++ b/scheduler/balance.go
@@ -24,8 +24,17 @@ func NewBalanceScheduler(cfg *config.Config) *BalanceScheduler {
 func (s *BalanceScheduler) Name() string { return "balance-refresh" }
 
 // Start begins periodic balance refresh. Loads the cron expression from DB
-// settings or falls back to config default.
+// settings or falls back to config default. Honors the global kill switch
+// (env BALANCE_REFRESH_ENABLED / runtime setting balanceRefreshEnabled,
+// issue #1027): when disabled, no cron job is scheduled at all.
 func (s *BalanceScheduler) Start(ctx context.Context) error {
+	enabled := resolveBooleanSetting("balance_refresh_enabled", !s.cfg.BalanceRefreshDisabled)
+	s.cfg.BalanceRefreshDisabled = !enabled
+	if s.cfg.BalanceRefreshDisabled {
+		slog.Info("balance scheduler disabled (balanceRefreshEnabled=false)")
+		return nil
+	}
+
 	activeCron := resolveCronSetting("balance_refresh_cron", s.cfg.BalanceRefreshCron)
 	s.cfg.BalanceRefreshCron = activeCron
 
@@ -66,6 +75,34 @@ func (s *BalanceScheduler) UpdateCron(cronExpr string) error {
 	}
 	s.cronRunner.start()
 	slog.Info("balance scheduler updated", "cron", cronExpr)
+	return nil
+}
+
+// SetEnabled hot-toggles the global balance-refresh switch (#1027).
+// Disabling stops the running cron job entirely; enabling (re)resolves the
+// cron from DB settings (same contract as Start) and schedules it. Callers
+// serialize this against other scheduler updates via app.updateMu.
+func (s *BalanceScheduler) SetEnabled(enabled bool) error {
+	s.cfg.BalanceRefreshDisabled = !enabled
+	if !enabled {
+		if s.cronRunner != nil {
+			s.cronRunner.stop()
+			s.cronRunner = nil
+		}
+		slog.Info("balance scheduler disabled (balanceRefreshEnabled=false)")
+		return nil
+	}
+	activeCron := resolveCronSetting("balance_refresh_cron", s.cfg.BalanceRefreshCron)
+	s.cfg.BalanceRefreshCron = activeCron
+	if s.cronRunner != nil {
+		s.cronRunner.stop()
+	}
+	s.cronRunner = newCronRunner()
+	if _, err := s.cronRunner.addJob(activeCron, s.runJob); err != nil {
+		return err
+	}
+	s.cronRunner.start()
+	slog.Info("balance scheduler enabled", "cron", activeCron)
 	return nil
 }
 

--- a/scheduler/checkin.go
+++ b/scheduler/checkin.go
@@ -89,6 +89,16 @@ func (s *CheckinScheduler) Start(ctx context.Context) error {
 	s.cfg.CheckinIntervalHours = activeIntervalHours
 	s.mode = activeMode
 
+	// #1027: global check-in kill switch (env CHECKIN_ENABLED or the
+	// checkin_enabled runtime setting). Default true keeps historical
+	// behavior; when disabled no schedule is armed at all.
+	enabled := resolveBooleanSetting("checkin_enabled", !s.cfg.CheckinDisabled)
+	s.cfg.CheckinDisabled = !enabled
+	if s.cfg.CheckinDisabled {
+		slog.Info("checkin scheduler disabled (checkinEnabled=false)")
+		return nil
+	}
+
 	s.startLocked()
 
 	slog.Info("checkin scheduler started",
@@ -328,8 +338,30 @@ func (s *CheckinScheduler) UpdateCheckinSchedule(mode, cronExpr string, interval
 	}
 	s.cfg.CheckinScheduleMode = mode
 	s.cfg.CheckinIntervalHours = config.ClampInt(intervalHours, 1, 24)
+	// #1027: a schedule update while check-in is globally disabled must
+	// persist the new schedule without silently re-arming the runner.
+	if s.cfg.CheckinDisabled {
+		return nil
+	}
 	s.startLocked()
 	return nil
+}
+
+// SetEnabled hot-toggles the global check-in switch (#1027). Disabling stops
+// the running cron/interval schedule; enabling restarts with the current mode
+// and schedule (same behavior as a fresh Start, including catch-up). Callers
+// serialize this against other scheduler updates via app.updateMu.
+func (s *CheckinScheduler) SetEnabled(enabled bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cfg.CheckinDisabled = !enabled
+	if !enabled {
+		s.stopLocked()
+		slog.Info("checkin scheduler disabled (checkinEnabled=false)")
+		return
+	}
+	s.startLocked()
+	slog.Info("checkin scheduler enabled", "mode", s.mode)
 }
 
 // ResetAttempts clears the interval attempt map (for tests).

--- a/scheduler/health_toggle_test.go
+++ b/scheduler/health_toggle_test.go
@@ -1,0 +1,224 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// Focused tests for the issue #1027 global kill switches on the
+// upstream-touching account schedulers (check-in, balance refresh, model
+// probe). Zero-value config means "enabled" everywhere (historical
+// behavior); the switches opt out.
+
+// TestCheckinScheduler_KillSwitchCronMode covers Start gating, the
+// no-re-arm guarantee on schedule updates while disabled, and hot toggling.
+func TestCheckinScheduler_KillSwitchCronMode(t *testing.T) {
+	store.OverrideDB(nil)
+	t.Cleanup(func() { store.OverrideDB(nil) })
+
+	cfg := &config.Config{
+		CheckinCron:         "0 8 * * *",
+		CheckinScheduleMode: "cron",
+		CheckinDisabled:     true,
+	}
+	s := NewCheckinScheduler(cfg)
+
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if s.cronRunner != nil || s.intervalTimer != nil {
+		t.Fatalf("disabled Start must not arm any runner")
+	}
+
+	// A schedule update while disabled persists the schedule but must not
+	// silently re-arm the runner.
+	if err := s.UpdateCheckinSchedule("cron", "0 9 * * *", 6, "00:00", "23:59"); err != nil {
+		t.Fatalf("UpdateCheckinSchedule: %v", err)
+	}
+	if cfg.CheckinCron != "0 9 * * *" {
+		t.Fatalf("cron = %q, want the updated value persisted", cfg.CheckinCron)
+	}
+	if s.cronRunner != nil {
+		t.Fatalf("schedule update must not re-arm a disabled scheduler")
+	}
+
+	// Enabling arms the cron runner with the persisted schedule.
+	s.SetEnabled(true)
+	if cfg.CheckinDisabled {
+		t.Fatalf("SetEnabled(true) must clear CheckinDisabled")
+	}
+	if s.cronRunner == nil {
+		t.Fatalf("SetEnabled(true) must arm the cron runner")
+	}
+
+	// Disabling stops it again.
+	s.SetEnabled(false)
+	if !cfg.CheckinDisabled {
+		t.Fatalf("SetEnabled(false) must set CheckinDisabled")
+	}
+	if s.cronRunner != nil {
+		t.Fatalf("SetEnabled(false) must stop the cron runner")
+	}
+}
+
+// TestCheckinScheduler_KillSwitchIntervalMode covers the interval-mode arm
+// path for the same switch.
+func TestCheckinScheduler_KillSwitchIntervalMode(t *testing.T) {
+	store.OverrideDB(nil)
+	t.Cleanup(func() { store.OverrideDB(nil) })
+
+	cfg := &config.Config{
+		CheckinScheduleMode:  "interval",
+		CheckinIntervalHours: 6,
+		CheckinDisabled:      true,
+	}
+	s := NewCheckinScheduler(cfg)
+
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if s.intervalStop != nil {
+		t.Fatalf("disabled Start must not arm the interval loop")
+	}
+
+	s.SetEnabled(true)
+	if s.intervalStop == nil {
+		t.Fatalf("SetEnabled(true) must arm the interval loop")
+	}
+
+	s.SetEnabled(false)
+	select {
+	case <-s.intervalStop:
+		// closed — the interval loop is stopped
+	default:
+		t.Fatalf("SetEnabled(false) must close the interval stop channel")
+	}
+}
+
+// TestCheckinScheduler_KillSwitchFromDBSetting verifies the checkin_enabled
+// DB setting wins over the config default at Start (dual-dialect safe: the
+// settings key/value table is identical on SQLite and PostgreSQL).
+func TestCheckinScheduler_KillSwitchFromDBSetting(t *testing.T) {
+	db := openSettingsTestDB(t)
+	store.OverrideDB(db)
+	t.Cleanup(func() { store.OverrideDB(nil) })
+
+	insertSetting(t, db, "checkin_enabled", "false")
+
+	cfg := &config.Config{CheckinCron: "0 8 * * *", CheckinScheduleMode: "cron"}
+	s := NewCheckinScheduler(cfg)
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !cfg.CheckinDisabled {
+		t.Fatalf("DB setting checkin_enabled=false must disable the scheduler")
+	}
+	if s.cronRunner != nil {
+		t.Fatalf("disabled-by-setting Start must not arm the cron runner")
+	}
+}
+
+// TestBalanceScheduler_KillSwitch covers Start gating and hot toggling for
+// the balance refresh scheduler.
+func TestBalanceScheduler_KillSwitch(t *testing.T) {
+	store.OverrideDB(nil)
+	t.Cleanup(func() { store.OverrideDB(nil) })
+
+	cfg := &config.Config{BalanceRefreshCron: "0 * * * *", BalanceRefreshDisabled: true}
+	s := NewBalanceScheduler(cfg)
+
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if s.cronRunner != nil {
+		t.Fatalf("disabled Start must not arm the cron runner")
+	}
+
+	// Hot enable arms the runner with the cfg cron (no DB setting present).
+	if err := s.SetEnabled(true); err != nil {
+		t.Fatalf("SetEnabled(true): %v", err)
+	}
+	if s.cronRunner == nil {
+		t.Fatalf("SetEnabled(true) must arm the cron runner")
+	}
+
+	if err := s.SetEnabled(false); err != nil {
+		t.Fatalf("SetEnabled(false): %v", err)
+	}
+	if s.cronRunner != nil {
+		t.Fatalf("SetEnabled(false) must stop the cron runner")
+	}
+}
+
+// TestBalanceScheduler_KillSwitchFromDBSetting verifies the
+// balance_refresh_enabled DB setting wins over the config default at Start.
+func TestBalanceScheduler_KillSwitchFromDBSetting(t *testing.T) {
+	db := openSettingsTestDB(t)
+	store.OverrideDB(db)
+	t.Cleanup(func() { store.OverrideDB(nil) })
+
+	insertSetting(t, db, "balance_refresh_enabled", "false")
+
+	cfg := &config.Config{BalanceRefreshCron: "0 * * * *"}
+	s := NewBalanceScheduler(cfg)
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !cfg.BalanceRefreshDisabled {
+		t.Fatalf("DB setting balance_refresh_enabled=false must disable the scheduler")
+	}
+	if s.cronRunner != nil {
+		t.Fatalf("disabled-by-setting Start must not arm the cron runner")
+	}
+}
+
+// TestModelProbeScheduler_SetEnabledHotToggle covers the runtime toggle that
+// previously only took effect at Start: enabling must start the ticker and
+// disabling must stop it without a restart.
+func TestModelProbeScheduler_SetEnabledHotToggle(t *testing.T) {
+	store.OverrideDB(nil)
+	t.Cleanup(func() { store.OverrideDB(nil) })
+
+	cfg := &config.Config{
+		ModelAvailabilityProbeEnabled:     false,
+		ModelAvailabilityProbeIntervalMs:  60_000,
+		ModelAvailabilityProbeTimeoutMs:   3000,
+		ModelAvailabilityProbeConcurrency: 1,
+	}
+	s := NewModelProbeScheduler(cfg)
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	runnerRunning := func() bool {
+		s.runner.mu.Lock()
+		defer s.runner.mu.Unlock()
+		return s.runner.running
+	}
+
+	if runnerRunning() {
+		t.Fatalf("probe ticker must not run while disabled")
+	}
+	if err := s.SetEnabled(true); err != nil {
+		t.Fatalf("SetEnabled(true): %v", err)
+	}
+	if !cfg.ModelAvailabilityProbeEnabled {
+		t.Fatalf("SetEnabled(true) must set the enabled flag")
+	}
+	if !runnerRunning() {
+		t.Fatalf("SetEnabled(true) must start the probe ticker")
+	}
+	if err := s.SetEnabled(false); err != nil {
+		t.Fatalf("SetEnabled(false): %v", err)
+	}
+	if runnerRunning() {
+		t.Fatalf("SetEnabled(false) must stop the probe ticker")
+	}
+	// Idempotent double-disable.
+	if err := s.SetEnabled(false); err != nil {
+		t.Fatalf("second SetEnabled(false): %v", err)
+	}
+}

--- a/scheduler/model_probe.go
+++ b/scheduler/model_probe.go
@@ -51,6 +51,10 @@ type ModelProbeScheduler struct {
 	mu            sync.Mutex
 	accountLeases map[int64]bool
 	runner        *intervalRunner
+	// ctx is the lifecycle context captured by Start so SetEnabled can
+	// (re)start the ticker with the same cancellation semantics. Defaults to
+	// context.Background() when SetEnabled runs before any Start.
+	ctx context.Context
 
 	probe    ChannelHealthProbe
 	recorder ChannelHealthRecorder
@@ -104,6 +108,10 @@ func (s *ModelProbeScheduler) Start(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// Capture the lifecycle context so SetEnabled can (re)start the ticker
+	// with the same cancellation semantics as the registry-driven Start.
+	s.ctx = ctx
+
 	// Always register for admin probe-now / recovery paths,
 	// even when the background ticker is disabled.
 	SetGlobalModelProbeScheduler(s)
@@ -129,6 +137,34 @@ func (s *ModelProbeScheduler) Start(ctx context.Context) error {
 
 func (s *ModelProbeScheduler) Stop() error {
 	return s.runner.stop()
+}
+
+// SetEnabled hot-toggles the model availability probe at runtime (#1027).
+// Mirrors the boolean-feature-toggle contract: the caller has already
+// persisted cfg.ModelAvailabilityProbeEnabled + the DB setting; this applies
+// the change to the running ticker without a restart. Disabling stops the
+// background probe loop; enabling restarts it (no immediate first run, same
+// as Start). Admin probe-now paths stay available either way.
+func (s *ModelProbeScheduler) SetEnabled(enabled bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cfg.ModelAvailabilityProbeEnabled = enabled
+	if !enabled {
+		slog.Info("model-probe: disabled at runtime (probe not enabled)")
+		return s.runner.stop()
+	}
+	intervalMs := int64(config.MaxInt(s.cfg.ModelAvailabilityProbeIntervalMs, 60_000))
+	interval := time.Duration(intervalMs) * time.Millisecond
+	ctx := s.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	slog.Info("model-probe scheduler enabled at runtime",
+		"interval_ms", intervalMs,
+		"timeout_ms", s.cfg.ModelAvailabilityProbeTimeoutMs,
+		"concurrency", s.cfg.ModelAvailabilityProbeConcurrency,
+	)
+	return s.runner.start(ctx, interval, false, s.runProbe)
 }
 
 // TryAcquireAccountLease attempts to acquire a lease for probing a specific account.

--- a/web/src/features/settings/lib/runtime-settings.ts
+++ b/web/src/features/settings/lib/runtime-settings.ts
@@ -34,12 +34,14 @@ export type RuntimeSettings = {
   currentAdminIp?: string
   adminIpAllowlist?: string[] | string
   // scheduling
+  checkinEnabled?: boolean
   checkinCron?: string
   checkinScheduleMode?: string
   checkinIntervalHours?: number
   checkinWindowStart?: string
   checkinWindowEnd?: string
   checkinSchedule?: ScheduleSpecV1
+  balanceRefreshEnabled?: boolean
   balanceRefreshCron?: string
   balanceRefreshSchedule?: ScheduleSpecV1
   modelSyncCron?: string

--- a/web/src/features/settings/sections/operations/components/scheduling-section.tsx
+++ b/web/src/features/settings/sections/operations/components/scheduling-section.tsx
@@ -82,7 +82,9 @@ const scheduleSpecSchema = z.discriminatedUnion('kind', [
 ])
 
 const schedulingSchema = z.object({
+  checkinEnabled: z.boolean(),
   checkinSchedule: scheduleSpecSchema,
+  balanceRefreshEnabled: z.boolean(),
   balanceRefreshSchedule: scheduleSpecSchema,
   modelSyncCron: z.string().min(1),
   logCleanupSchedule: scheduleSpecSchema,
@@ -94,7 +96,9 @@ const schedulingSchema = z.object({
 type SchedulingFormValues = z.infer<typeof schedulingSchema>
 
 const DEFAULT_VALUES: SchedulingFormValues = {
+  checkinEnabled: true,
   checkinSchedule: { version: 1, kind: 'daily', time: '08:00' },
+  balanceRefreshEnabled: true,
   balanceRefreshSchedule: { version: 1, kind: 'interval', everyHours: 1 },
   modelSyncCron: '0 4 * * *',
   logCleanupSchedule: { version: 1, kind: 'daily', time: '06:00' },
@@ -124,7 +128,9 @@ function deriveServerValues(
   const logCleanupSchedule =
     data.logCleanupSchedule ?? scheduleFromLegacy({ cron: data.logCleanupCron })
   return {
+    checkinEnabled: data.checkinEnabled ?? true,
     checkinSchedule,
+    balanceRefreshEnabled: data.balanceRefreshEnabled ?? true,
     balanceRefreshSchedule: balanceSchedule,
     modelSyncCron: data.modelSyncCron ?? '0 4 * * *',
     logCleanupSchedule,
@@ -169,6 +175,12 @@ function schedulingToPayload(
   changed: Partial<SchedulingFormValues>
 ): RuntimeSettingsPayload {
   const payload: RuntimeSettingsPayload = {}
+  if (changed.checkinEnabled !== undefined) {
+    payload.checkinEnabled = changed.checkinEnabled
+  }
+  if (changed.balanceRefreshEnabled !== undefined) {
+    payload.balanceRefreshEnabled = changed.balanceRefreshEnabled
+  }
   if (changed.checkinSchedule) {
     projectSchedule(payload, 'checkin', changed.checkinSchedule)
   }
@@ -313,6 +325,29 @@ export function SchedulingSection() {
       }
     >
       <MigrationCard />
+      {/* #1027: discoverability — map every upstream-touching monitoring job
+          to its off switch so the "how do I turn health monitoring off"
+          question is answered where users look for scheduling controls. */}
+      <div className='border-primary/30 bg-primary/5 mb-4 space-y-2 rounded-lg border p-4'>
+        <h3 className='text-sm font-medium'>
+          {t('settings.operations.scheduling.healthMonitoring.title')}
+        </h3>
+        <p className='text-muted-foreground mt-1 text-xs'>
+          {t('settings.operations.scheduling.healthMonitoring.description')}
+        </p>
+        <ul className='text-muted-foreground mt-2 list-inside list-disc space-y-1 text-xs'>
+          <li>
+            {t('settings.operations.scheduling.healthMonitoring.checkin')}
+          </li>
+          <li>
+            {t('settings.operations.scheduling.healthMonitoring.balance')}
+          </li>
+          <li>{t('settings.operations.scheduling.healthMonitoring.probe')}</li>
+          <li>
+            {t('settings.operations.scheduling.healthMonitoring.passive')}
+          </li>
+        </ul>
+      </div>
       <Form {...form}>
         <form
           id={FORM_ID}
@@ -323,6 +358,34 @@ export function SchedulingSection() {
             <h3 className='text-sm font-medium'>
               {t('settings.operations.scheduling.fields.checkinGroup')}
             </h3>
+            {/* #1027: global check-in kill switch (per-account switches live
+                on the Accounts page). */}
+            <FormField
+              control={form.control}
+              name='checkinEnabled'
+              render={({ field }) => (
+                <FormItem className='flex flex-row items-center gap-3'>
+                  <FormControl>
+                    <Checkbox
+                      checked={Boolean(field.value)}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <div className='space-y-1'>
+                    <FormLabel className='cursor-pointer'>
+                      {t(
+                        'settings.operations.scheduling.fields.checkinEnabled'
+                      )}
+                    </FormLabel>
+                    <FormDescription>
+                      {t(
+                        'settings.operations.scheduling.fields.checkinEnabledHint'
+                      )}
+                    </FormDescription>
+                  </div>
+                </FormItem>
+              )}
+            />
             <FormField
               control={form.control}
               name='checkinSchedule'
@@ -348,6 +411,33 @@ export function SchedulingSection() {
             <h3 className='text-sm font-medium'>
               {t('settings.operations.scheduling.fields.balanceGroup')}
             </h3>
+            {/* #1027: global balance-refresh kill switch. */}
+            <FormField
+              control={form.control}
+              name='balanceRefreshEnabled'
+              render={({ field }) => (
+                <FormItem className='flex flex-row items-center gap-3'>
+                  <FormControl>
+                    <Checkbox
+                      checked={Boolean(field.value)}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <div className='space-y-1'>
+                    <FormLabel className='cursor-pointer'>
+                      {t(
+                        'settings.operations.scheduling.fields.balanceRefreshEnabled'
+                      )}
+                    </FormLabel>
+                    <FormDescription>
+                      {t(
+                        'settings.operations.scheduling.fields.balanceRefreshEnabledHint'
+                      )}
+                    </FormDescription>
+                  </div>
+                </FormItem>
+              )}
+            />
             <FormField
               control={form.control}
               name='balanceRefreshSchedule'

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1516,6 +1516,14 @@
         "scheduling": {
           "title": "Scheduled Tasks",
           "description": "Check-in, balance refresh, and log cleanup schedules.",
+          "healthMonitoring": {
+            "title": "Upstream account health monitoring",
+            "description": "Automatic jobs that contact upstream accounts, and where to turn them off:",
+            "checkin": "Daily check-in — the \"Enable daily check-in\" switch below turns it off globally; per-account switches are on the Accounts page.",
+            "balance": "Scheduled balance refresh — the \"Enable scheduled balance refresh\" switch below turns it off globally.",
+            "probe": "Active model availability probing — off by default; if you enabled it, turn it off under Settings → Proxy & Models → Proxy Transport.",
+            "passive": "Status badges and probe-health columns on the Accounts page are passive displays of past traffic; they never contact upstream sites."
+          },
           "triggerCheckin": "Trigger check-in now",
           "viewProgramLogs": "View logs",
           "migration": {
@@ -1533,8 +1541,12 @@
             "logCleanupRetentionDays": "Log retention (days)",
             "logCleanupUsageLogsEnabled": "Purge usage logs",
             "checkinGroup": "Check-in",
+            "checkinEnabled": "Enable daily check-in",
+            "checkinEnabledHint": "When disabled, Metapi stops sending automatic check-in requests to upstream sites. Per-account check-in switches remain available on the Accounts page.",
             "checkinSchedule": "Check-in schedule",
             "balanceGroup": "Balance refresh",
+            "balanceRefreshEnabled": "Enable scheduled balance refresh",
+            "balanceRefreshEnabledHint": "When disabled, upstream account balances are no longer refreshed on schedule; displayed balances may gradually become stale.",
             "balanceRefreshSchedule": "Balance refresh schedule",
             "modelSyncGroup": "Model list sync",
             "modelSyncCron": "Model sync schedule (cron)",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1516,6 +1516,14 @@
         "scheduling": {
           "title": "定时任务",
           "description": "签到、余额刷新与日志清理计划。",
+          "healthMonitoring": {
+            "title": "上游账号健康监测",
+            "description": "会主动访问上游账号的自动任务及其关闭入口：",
+            "checkin": "每日签到——下方「启用每日签到」开关可全局关闭；账号级开关在「账号」页每行。",
+            "balance": "余额定时刷新——下方「启用余额定时刷新」开关可全局关闭。",
+            "probe": "模型可用性主动探测——默认关闭；如已开启，请到 设置 → 代理与模型 → 代理传输 关闭。",
+            "passive": "账号页的状态徽章与探测健康列是历史流量的被动展示，不会向上游发起请求。"
+          },
           "triggerCheckin": "立即签到",
           "viewProgramLogs": "查看日志",
           "triggering": "触发中…",
@@ -1534,8 +1542,12 @@
             "logCleanupUsageLogsEnabled": "清理用量日志",
             "logCleanupUsageLogsEnabledHint": "按计划删除累积的代理用量日志。",
             "checkinGroup": "签到",
+            "checkinEnabled": "启用每日签到",
+            "checkinEnabledHint": "关闭后系统不再自动向上游站点发起签到请求；账号级签到开关仍在「账号」页每行可用。",
             "checkinSchedule": "签到计划",
             "balanceGroup": "余额刷新",
+            "balanceRefreshEnabled": "启用余额定时刷新",
+            "balanceRefreshEnabledHint": "关闭后不再定时查询上游账号余额，页面显示的余额可能逐渐过期。",
             "balanceRefreshSchedule": "余额刷新计划",
             "modelSyncGroup": "模型列表同步",
             "modelSyncCron": "模型同步计划（cron）",

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -325,12 +325,14 @@ export type RuntimeSettingsPayload = {
   proxyDebugTargetModel?: string
   proxyDebugRetentionHours?: number
   proxyDebugMaxBodyBytes?: number
+  checkinEnabled?: boolean
   checkinCron?: string
   checkinScheduleMode?: 'cron' | 'interval' | 'window'
   checkinIntervalHours?: number
   checkinWindowStart?: string
   checkinWindowEnd?: string
   checkinSchedule?: ScheduleSpecV1
+  balanceRefreshEnabled?: boolean
   balanceRefreshCron?: string
   balanceRefreshSchedule?: ScheduleSpecV1
   modelSyncCron?: string


### PR DESCRIPTION
## Summary

Fixes #1027 — "健康监测关不掉/找不到入口".

Adds the missing **global kill switches** for the two always-on background jobs that contact upstream accounts, and makes the existing model-probe toggle apply without a restart.

## Inventory of "health monitoring" control points (as found in code)

| Behavior (contacts upstream accounts) | Control before | Status before -> after |
| --- | --- | --- |
| Global check-in scheduler (`CheckinScheduler`, default daily) | schedule only (cron/interval), no off switch | **new**: `checkinEnabled` runtime setting + `CHECKIN_ENABLED` env |
| Per-account check-in | `checkinEnabled` flag per account row (Accounts page) | unchanged (already existed) |
| Scheduled balance refresh (`BalanceScheduler`, default hourly) | cron only, no off switch | **new**: `balanceRefreshEnabled` runtime setting + `BALANCE_REFRESH_ENABLED` env |
| Model availability probe (`ModelProbeScheduler`, default off) | `modelAvailabilityProbeEnabled` setting | toggle now **hot-applies** to the running ticker (previously only honored at `Start()`) |
| Accounts-page status badges / probe-health columns | n/a | unchanged — passive display of past traffic; issues no upstream requests (now documented) |

Note: an empty cron string was never a valid way to disable check-in/balance jobs (`resolveCronSetting` falls back to the built-in default), which is why the issue reporter could not turn them off.

## Changes

**Go**
- `config`: new inverted fields `CheckinDisabled` / `BalanceRefreshDisabled` (zero value = enabled, so bare config literals keep historical defaults); parsed from `CHECKIN_ENABLED` / `BALANCE_REFRESH_ENABLED` (default `true`).
- `scheduler/checkin.go`, `scheduler/balance.go`: `Start()` honors the DB setting first, env fallback; disabled = no schedule armed at all. New `SetEnabled()` hot-toggles the running schedule. Check-in schedule updates while disabled persist but do not silently re-arm.
- `scheduler/model_probe.go`: `SetEnabled()` stops/starts the ticker at runtime.
- `app/services.go`: `UpdateCheckinEnabled` / `UpdateBalanceEnabled` hot-update entrypoints.
- `handler/admin/settings*.go`: GET exposes `checkinEnabled` / `balanceRefreshEnabled`; PUT validates strict booleans (400 otherwise), persists to `checkin_enabled` / `balance_refresh_enabled` settings, and hot-applies. Runtime setting wins over env when present.

**Web**
- Settings -> Operations -> Scheduled Tasks: two new checkboxes ("Enable daily check-in", "Enable scheduled balance refresh") plus a bilingual "Upstream account health monitoring" info box explaining every control and that status badges are passive. en + zh-CN keys added together.

**Docs**
- `docs/deployment.md`: env table rows + new "Disabling Upstream Account Health Monitoring" section (docker-compose example included).
- `docs/api.md`: kill-switch contract under `PUT /api/settings/runtime`.
- `.env.example`: both variables documented.

## Tests

- `config/health_toggle_test.go` — env parsing (default / disabled / explicit enabled).
- `scheduler/health_toggle_test.go` — check-in kill switch in cron + interval mode, DB-setting override, balance kill switch, model-probe hot toggle.
- `handler/admin/settings_health_toggle_test.go` — runtime API contract for both switches + non-boolean rejection.

Gates: `go build ./cmd/server`, `go vet ./...`, `go test ./... -count=1` green (one pre-existing `TestRedisCounter_IncrSetsTTL` flake under full-suite parallel load passed 5/5 in isolation and in package rerun); web `test` (220 files / 1405 tests), `typecheck`, `lint`, `format:check`, `knip`, `build` all green.
