### PR TITLE
feat(net): outbound HTTP client timeout/pool baseline + static gate (Wave 18 Lane C)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/deliciousbuding/metapi-go/app"
 	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/internal/httpclient"
 	"github.com/deliciousbuding/metapi-go/internal/version"
 	"github.com/deliciousbuding/metapi-go/router"
 	"github.com/deliciousbuding/metapi-go/store"
@@ -164,7 +165,7 @@ func runHealthcheck() int {
 		target = "http://127.0.0.1:" + port + path
 	}
 
-	client := http.Client{Timeout: 5 * time.Second}
+	client := http.Client{Timeout: 5 * time.Second, Transport: httpclient.SharedTransport()}
 	resp, err := client.Get(target)
 	if err != nil {
 		return 1

--- a/handler/admin/channel_test_harness.go
+++ b/handler/admin/channel_test_harness.go
@@ -14,13 +14,14 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/go-chi/chi/v5"
-	"github.com/jmoiron/sqlx"
 	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/internal/httpclient"
 	"github.com/deliciousbuding/metapi-go/platform"
 	"github.com/deliciousbuding/metapi-go/proxy"
 	"github.com/deliciousbuding/metapi-go/service"
 	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
 )
 
 const (
@@ -484,6 +485,12 @@ func harnessFail(target *channelTestTarget, mode, model, path, host string, stat
 	}
 }
 
+// harnessFallbackTransport bounds the dial/TLS/idle phases for channel-test
+// requests that run without an injected transport or site proxy config. The
+// deadline is owned by the caller context (per-test timeout), so the
+// response-header phase stays unbounded here.
+var harnessFallbackTransport = httpclient.NewTransport(httpclient.Options{})
+
 func (h *channelTestHandler) doRequest(ctx context.Context, req *http.Request, proxyCfg *platform.ProxyConfig) (*http.Response, error) {
 	if h.transport != nil {
 		return h.transport.RoundTrip(req.WithContext(ctx))
@@ -495,6 +502,7 @@ func (h *channelTestHandler) doRequest(ctx context.Context, req *http.Request, p
 	// site URL cannot 302 into metadata/loopback (shared platform policy).
 	client := &http.Client{
 		Timeout:       0,
+		Transport:     harnessFallbackTransport,
 		CheckRedirect: platform.RejectCrossOriginRedirect,
 	}
 	return client.Do(req.WithContext(ctx))

--- a/handler/admin/monitor.go
+++ b/handler/admin/monitor.go
@@ -11,9 +11,11 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/internal/httpclient"
 	"github.com/deliciousbuding/metapi-go/proxy"
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
@@ -53,6 +55,28 @@ func RegisterMonitorProxyRoutes(r chi.Router, db *sqlx.DB, cfg *config.Config) {
 type monitorHandler struct {
 	db  *sqlx.DB
 	cfg *config.Config
+
+	ldohClientOnce sync.Once
+	ldohHTTPClient *http.Client
+}
+
+// ldohClient returns the shared LDOH proxy client, building it lazily on
+// first use. LDOH_PROXY_TIMEOUT_SEC is parsed once at startup (no runtime
+// retune), so a sync.Once-built client is safe and keeps one pooled,
+// phase-bounded transport instead of a fresh transport-less client per
+// proxied request.
+func (h *monitorHandler) ldohClient() *http.Client {
+	h.ldohClientOnce.Do(func() {
+		timeout := time.Duration(h.cfg.LDOHProxyTimeoutSec) * time.Second
+		h.ldohHTTPClient = &http.Client{
+			Timeout:   timeout,
+			Transport: httpclient.NewTransport(httpclient.Options{ResponseHeaderTimeout: timeout}),
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+	})
+	return h.ldohHTTPClient
 }
 
 const ldohCookieSettingKey = "monitor_ldoh_cookie"
@@ -274,12 +298,7 @@ func (h *monitorHandler) ldohProxy(w http.ResponseWriter, r *http.Request) {
 		upstreamReq.Header.Set("Referer", strings.ReplaceAll(referer, "/monitor-proxy/ldoh", ""))
 	}
 
-	client := &http.Client{
-		Timeout: time.Duration(h.cfg.LDOHProxyTimeoutSec) * time.Second,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	client := h.ldohClient()
 	upstreamResp, err := client.Do(upstreamReq)
 	if err != nil {
 		slog.Error("LDOH upstream request failed",

--- a/handler/proxy/channel_health_probe.go
+++ b/handler/proxy/channel_health_probe.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/internal/httpclient"
 	"github.com/deliciousbuding/metapi-go/platform"
 	"github.com/deliciousbuding/metapi-go/proxy"
 	"github.com/deliciousbuding/metapi-go/scheduler"
@@ -322,6 +323,12 @@ func (p *ChannelHealthProbeExecutor) executeChatProbe(ctx context.Context, targe
 	}, nil
 }
 
+// probeFallbackTransport bounds the dial/TLS/idle phases for probe requests
+// that run without an injected transport or site proxy config. The deadline
+// is owned by the caller context (probe timeout is operator-tunable with no
+// fixed ceiling), so the response-header phase stays unbounded here.
+var probeFallbackTransport = httpclient.NewTransport(httpclient.Options{})
+
 func (p *ChannelHealthProbeExecutor) doRequest(ctx context.Context, req *http.Request, proxyCfg *platform.ProxyConfig) (*http.Response, error) {
 	if p.transport != nil {
 		return p.transport.RoundTrip(req.WithContext(ctx))
@@ -333,6 +340,7 @@ func (p *ChannelHealthProbeExecutor) doRequest(ctx context.Context, req *http.Re
 	// site URL cannot 302 into metadata/loopback (shared platform policy).
 	client := &http.Client{
 		Timeout:       0,
+		Transport:     probeFallbackTransport,
 		CheckRedirect: platform.RejectCrossOriginRedirect,
 	}
 	return client.Do(req.WithContext(ctx))

--- a/handler/proxy/codex_ws_runtime.go
+++ b/handler/proxy/codex_ws_runtime.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/internal/httpclient"
 	"github.com/deliciousbuding/metapi-go/service"
 )
 
@@ -606,10 +607,10 @@ func SendCodexWebsocketRequest(ctx context.Context, input CodexWebsocketSendInpu
 
 	for {
 		result, err := sendCodexWSSessionAttempt(ctx, session, CodexWebsocketSendInput{
-			SessionID:    sessionID,
-			RequestURL:   input.RequestURL,
-			Headers:      input.Headers,
-			Body:         currentBody,
+			SessionID:     sessionID,
+			RequestURL:    input.RequestURL,
+			Headers:       input.Headers,
+			Body:          currentBody,
 			ResinAccount:  input.ResinAccount,
 			ResinPlatform: input.ResinPlatform,
 		})
@@ -693,6 +694,9 @@ func sendCodexWSSessionAttempt(ctx context.Context, session *codexWSSocketSessio
 		dialCtx, cancel := context.WithTimeout(ctx, codexWSDialTimeout)
 		next, _, err := websocket.Dial(dialCtx, wsURL, &websocket.DialOptions{
 			HTTPHeader: httpHeader,
+			// Bound the upgrade's dial/TLS phases on the pooled baseline
+			// transport; the dial context remains the deadline owner.
+			HTTPClient: &http.Client{Transport: httpclient.SharedTransport()},
 		})
 		cancel()
 		if err != nil {

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -17,6 +17,7 @@ import (
 	"github.com/deliciousbuding/metapi-go/auth"
 	"github.com/deliciousbuding/metapi-go/config"
 	"github.com/deliciousbuding/metapi-go/handler/shared"
+	"github.com/deliciousbuding/metapi-go/internal/httpclient"
 	"github.com/deliciousbuding/metapi-go/platform"
 	"github.com/deliciousbuding/metapi-go/proxy"
 	"github.com/deliciousbuding/metapi-go/routing"
@@ -51,6 +52,7 @@ var unconfiguredUpstreamLogOnce sync.Once
 // SetUpstreamConfig.
 var defaultUpstreamClient = &http.Client{
 	Timeout:       90 * time.Second,
+	Transport:     httpclient.NewTransport(httpclient.Options{ResponseHeaderTimeout: 90 * time.Second}),
 	CheckRedirect: platform.RejectCrossOriginRedirect,
 }
 

--- a/internal/httpclient/gate_test.go
+++ b/internal/httpclient/gate_test.go
@@ -1,0 +1,376 @@
+package httpclient
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Outbound HTTP client gate.
+//
+// Background: outbound requests that ride http.DefaultClient /
+// http.DefaultTransport (or an http.Transport literal without phase
+// timeouts) inherit no response-header bound and no explicit dial/TLS/idle
+// bounds, so a silently-accepting upstream can hold connections and
+// goroutines indefinitely. The baseline adopted for this repo mirrors the
+// axonhub HTTP client baseline (docs/internal/analysis/competitor-study-2026-08.md
+// section 3.2): dial 30s, TLS handshake 10s, MaxIdleConns 100,
+// IdleConnTimeout 90s. Transports are constructed in exactly one place:
+// this package, or the pooled transport cache in platform/site_proxy.go for
+// platform adapter traffic.
+//
+// Rules enforced on every non-test .go file in the repository:
+//
+//	R1  http.DefaultClient / http.DefaultTransport are forbidden.
+//	R2  package-level http.Get/Post/PostForm/Head are forbidden (they ride
+//	    http.DefaultClient, which has no timeout at all).
+//	R3  every http.Client literal must set an explicit Transport or a
+//	    non-zero Timeout.
+//	R4  every http.Transport literal must set DialContext/DialTLSContext,
+//	    TLSHandshakeTimeout and IdleConnTimeout. ResponseHeaderTimeout is
+//	    deliberately not required: context-driven paths (SSE relays, probe
+//	    and channel-test fallbacks) leave the header phase to the caller
+//	    deadline on purpose.
+//
+// The matcher is AST-based (go/parser), so comments mentioning the
+// forbidden identifiers cannot trip it, and import aliases of net/http are
+// honored. This mirrors the docs/pg_rebind_gate_test.go pattern: a repo
+// scan plus a sanity test that locks matcher behaviour with counter-examples.
+
+// auditSource inspects one Go source file for outbound HTTP constructions
+// that bypass the timeout/pool baseline. It parses without type checking,
+// so it runs on any syntactically valid file regardless of dependencies.
+func auditSource(filename string, src []byte) ([]string, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, src, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve the local name of the net/http import; files without one
+	// cannot construct http.* values.
+	httpName := ""
+	for _, imp := range file.Imports {
+		if imp.Path.Value == `"net/http"` {
+			httpName = "http"
+			if imp.Name != nil {
+				httpName = imp.Name.Name
+			}
+		}
+	}
+	if httpName == "" {
+		return nil, nil
+	}
+
+	var violations []string
+	report := func(n ast.Node, msg string) {
+		violations = append(violations, fmt.Sprintf("%s: %s", fset.Position(n.Pos()), msg))
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.SelectorExpr:
+			ident, ok := node.X.(*ast.Ident)
+			if !ok || ident.Name != httpName {
+				return true
+			}
+			switch node.Sel.Name {
+			case "DefaultClient", "DefaultTransport":
+				report(node, fmt.Sprintf(
+					"http.%s carries no outbound phase bounds; build the client/transport via internal/httpclient or the platform site-proxy pool",
+					node.Sel.Name))
+			}
+		case *ast.CallExpr:
+			sel, ok := node.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok || ident.Name != httpName {
+				return true
+			}
+			switch sel.Sel.Name {
+			case "Get", "Post", "PostForm", "Head":
+				report(node, fmt.Sprintf(
+					"http.%s uses http.DefaultClient (no timeout); construct a client via internal/httpclient instead",
+					sel.Sel.Name))
+			}
+		case *ast.CompositeLit:
+			sel, ok := node.Type.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok || ident.Name != httpName {
+				return true
+			}
+			switch sel.Sel.Name {
+			case "Client":
+				hasTransport, hasTimeout := false, false
+				for _, elt := range node.Elts {
+					kv, ok := elt.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					key, ok := kv.Key.(*ast.Ident)
+					if !ok {
+						continue
+					}
+					switch key.Name {
+					case "Transport":
+						hasTransport = true
+					case "Timeout":
+						if !isZeroLiteral(kv.Value) {
+							hasTimeout = true
+						}
+					}
+				}
+				if !hasTransport && !hasTimeout {
+					report(node, "http.Client literal without Transport and without a non-zero Timeout rides http.DefaultTransport with no deadline; set an explicit Transport (internal/httpclient) and/or Timeout")
+				}
+			case "Transport":
+				var missing []string
+				if !transportHasField(node, "DialContext", "DialTLSContext") {
+					missing = append(missing, "DialContext/DialTLSContext")
+				}
+				if !transportHasField(node, "TLSHandshakeTimeout") {
+					missing = append(missing, "TLSHandshakeTimeout")
+				}
+				if !transportHasField(node, "IdleConnTimeout") {
+					missing = append(missing, "IdleConnTimeout")
+				}
+				if len(missing) > 0 {
+					report(node, fmt.Sprintf(
+						"http.Transport literal missing %s; build it via internal/httpclient.NewTransport or mirror the baseline (dial 30s / TLS 10s / idle 90s / pool 100)",
+						strings.Join(missing, ", ")))
+				}
+			}
+		}
+		return true
+	})
+	return violations, nil
+}
+
+func transportHasField(lit *ast.CompositeLit, names ...string) bool {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		for _, name := range names {
+			if key.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isZeroLiteral(expr ast.Expr) bool {
+	lit, ok := expr.(*ast.BasicLit)
+	return ok && lit.Kind == token.INT && lit.Value == "0"
+}
+
+func TestOutboundHTTPClientGateNoBareClients(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// internal/httpclient -> internal -> repo root
+	repoRoot := filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+	skipDirs := map[string]bool{
+		".git": true, ".github": true, ".worktrees": true,
+		"web": true, "docs": true, "vendor": true, "node_modules": true,
+	}
+
+	var violations []string
+	scanned := 0
+	err := filepath.WalkDir(repoRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		src, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		rel, relErr := filepath.Rel(repoRoot, path)
+		if relErr != nil {
+			rel = path
+		}
+		v, auditErr := auditSource(rel, src)
+		if auditErr != nil {
+			// Unparseable files already fail the build before this gate runs.
+			return nil
+		}
+		scanned++
+		violations = append(violations, v...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo root: %v", err)
+	}
+	if scanned == 0 {
+		t.Fatalf("gate scanned no files; repo root resolution is broken (%s)", repoRoot)
+	}
+	if len(violations) > 0 {
+		t.Fatalf(
+			"outbound HTTP construction bypasses the timeout/pool baseline "+
+				"(build clients/transports via internal/httpclient or the platform site-proxy pool):\n%s",
+			strings.Join(violations, "\n"),
+		)
+	}
+}
+
+// TestOutboundHTTPClientGateMatcherSanity locks the matcher behaviour with
+// counter-examples: bare constructions must be flagged, bounded ones must
+// pass. This is the reverse-validation half of the gate (the repo scan
+// above is the forward half).
+func TestOutboundHTTPClientGateMatcherSanity(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		flag bool
+	}{
+		{
+			name: "bare http.DefaultClient",
+			src: `package p
+
+import "net/http"
+
+var c = http.DefaultClient
+`,
+			flag: true,
+		},
+		{
+			name: "bare http.DefaultTransport",
+			src: `package p
+
+import "net/http"
+
+var tr = http.DefaultTransport
+`,
+			flag: true,
+		},
+		{
+			name: "aliased net/http DefaultClient",
+			src: `package p
+
+import nhttp "net/http"
+
+var c = nhttp.DefaultClient
+`,
+			flag: true,
+		},
+		{
+			name: "package-level http.Get",
+			src: `package p
+
+import "net/http"
+
+func f() { _, _ = http.Get("http://example.com") }
+`,
+			flag: true,
+		},
+		{
+			name: "client literal without timeout or transport",
+			src: `package p
+
+import "net/http"
+
+var c = &http.Client{}
+`,
+			flag: true,
+		},
+		{
+			name: "client literal with zero timeout",
+			src: `package p
+
+import "net/http"
+
+var c = &http.Client{Timeout: 0}
+`,
+			flag: true,
+		},
+		{
+			name: "transport literal missing idle bound",
+			src: `package p
+
+import "net/http"
+
+var tr = &http.Transport{DialContext: d, TLSHandshakeTimeout: t}
+`,
+			flag: true,
+		},
+		{
+			name: "client with timeout",
+			src: `package p
+
+import ("net/http"; "time")
+
+var c = &http.Client{Timeout: 30 * time.Second}
+`,
+			flag: false,
+		},
+		{
+			name: "client with transport and zero timeout",
+			src: `package p
+
+import "net/http"
+
+var c = &http.Client{Transport: tr, Timeout: 0}
+`,
+			flag: false,
+		},
+		{
+			name: "transport with DialTLSContext instead of DialContext",
+			src: `package p
+
+import "net/http"
+
+var tr = &http.Transport{DialTLSContext: d, TLSHandshakeTimeout: t, IdleConnTimeout: i}
+`,
+			flag: false,
+		},
+		{
+			name: "complete transport",
+			src: `package p
+
+import "net/http"
+
+var tr = &http.Transport{DialContext: d, TLSHandshakeTimeout: t, IdleConnTimeout: i}
+`,
+			flag: false,
+		},
+	}
+	for _, tc := range cases {
+		violations, err := auditSource("sanity.go", []byte(tc.src))
+		if err != nil {
+			t.Fatalf("%s: audit parse error: %v", tc.name, err)
+		}
+		if tc.flag && len(violations) == 0 {
+			t.Errorf("%s: matcher must flag this construction, got clean", tc.name)
+		}
+		if !tc.flag && len(violations) > 0 {
+			t.Errorf("%s: matcher must not flag this construction, got: %v", tc.name, violations)
+		}
+	}
+}

--- a/internal/httpclient/httpclient.go
+++ b/internal/httpclient/httpclient.go
@@ -1,0 +1,127 @@
+// Package httpclient is the shared construction point for outbound HTTP
+// transports and clients outside the platform site-proxy regime.
+//
+// Two regimes coexist by design:
+//
+//   - Platform adapter traffic (login/checkin/balance/model calls through
+//     platform.DoWithProxy) uses the pooled transport cache in
+//     platform/site_proxy.go, whose timeouts are operator-tunable via the
+//     PROXY_*_TIMEOUT_SEC env vars.
+//   - Every other outbound path (proxy executor, channel health probes,
+//     admin channel test harness, monitor LDOH proxy, notifications, pricing
+//     catalog fetch, Codex websocket dial, server healthcheck) builds its
+//     transport here so each client carries explicit dial / TLS-handshake /
+//     idle bounds and a sized connection pool instead of riding
+//     http.DefaultTransport.
+//
+// Baseline values mirror the axonhub HTTP client baseline
+// (docs/internal/analysis/competitor-study-2026-08.md): dial 30s,
+// TLS handshake 10s, MaxIdleConns 100, IdleConnTimeout 90s.
+package httpclient
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Baseline defaults shared by every outbound transport built in this package.
+const (
+	DefaultDialTimeout           = 30 * time.Second
+	DefaultKeepAlive             = 30 * time.Second
+	DefaultTLSHandshakeTimeout   = 10 * time.Second
+	DefaultIdleConnTimeout       = 90 * time.Second
+	DefaultMaxIdleConns          = 100
+	DefaultMaxIdleConnsPerHost   = 20
+	DefaultExpectContinueTimeout = 1 * time.Second
+
+	// sharedResponseHeaderTimeout caps the header phase on SharedTransport.
+	// It must stay at or above the whole-request timeout of every client that
+	// rides SharedTransport (all are <= 30s today) so it never pre-empts a
+	// request that would otherwise finish within its own timeout.
+	sharedResponseHeaderTimeout = 60 * time.Second
+)
+
+// Options configures NewTransport. Zero values select the baseline defaults.
+// ResponseHeaderTimeout 0 leaves the header phase unbounded: use that only
+// where a caller context or the client Timeout already owns the deadline
+// (SSE stream relays, context-driven probes).
+type Options struct {
+	DialTimeout           time.Duration
+	TLSHandshakeTimeout   time.Duration
+	ResponseHeaderTimeout time.Duration
+	IdleConnTimeout       time.Duration
+	MaxIdleConns          int
+	MaxIdleConnsPerHost   int
+}
+
+// NewTransport builds an *http.Transport with explicit phase timeouts and a
+// sized idle pool. Proxy resolution keeps http.ProxyFromEnvironment, the
+// behavior these paths historically inherited from http.DefaultTransport.
+func NewTransport(opts Options) *http.Transport {
+	dialTimeout := opts.DialTimeout
+	if dialTimeout <= 0 {
+		dialTimeout = DefaultDialTimeout
+	}
+	tlsHandshakeTimeout := opts.TLSHandshakeTimeout
+	if tlsHandshakeTimeout <= 0 {
+		tlsHandshakeTimeout = DefaultTLSHandshakeTimeout
+	}
+	idleConnTimeout := opts.IdleConnTimeout
+	if idleConnTimeout <= 0 {
+		idleConnTimeout = DefaultIdleConnTimeout
+	}
+	maxIdleConns := opts.MaxIdleConns
+	if maxIdleConns <= 0 {
+		maxIdleConns = DefaultMaxIdleConns
+	}
+	maxIdleConnsPerHost := opts.MaxIdleConnsPerHost
+	if maxIdleConnsPerHost <= 0 {
+		maxIdleConnsPerHost = DefaultMaxIdleConnsPerHost
+	}
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   dialTimeout,
+			KeepAlive: DefaultKeepAlive,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		TLSHandshakeTimeout:   tlsHandshakeTimeout,
+		ResponseHeaderTimeout: opts.ResponseHeaderTimeout,
+		ExpectContinueTimeout: DefaultExpectContinueTimeout,
+		MaxIdleConns:          maxIdleConns,
+		MaxIdleConnsPerHost:   maxIdleConnsPerHost,
+		IdleConnTimeout:       idleConnTimeout,
+	}
+}
+
+// NewClient wraps transport with a whole-request timeout and a redirect
+// policy. A zero timeout leaves the total request unbounded (streaming
+// callers); the transport's phase timeouts still apply.
+func NewClient(transport http.RoundTripper, timeout time.Duration, checkRedirect func(*http.Request, []*http.Request) error) *http.Client {
+	return &http.Client{
+		Transport:     transport,
+		Timeout:       timeout,
+		CheckRedirect: checkRedirect,
+	}
+}
+
+var (
+	sharedOnce      sync.Once
+	sharedTransport *http.Transport
+)
+
+// SharedTransport returns the process-wide baseline transport for outbound
+// clients whose whole-request timeout is at most sharedResponseHeaderTimeout
+// (telegram notifications, pricing catalog fetch, Codex websocket upgrade,
+// server healthcheck). Callers needing a different header-phase cap must
+// build their own transport via NewTransport instead of mutating this one.
+func SharedTransport() *http.Transport {
+	sharedOnce.Do(func() {
+		sharedTransport = NewTransport(Options{
+			ResponseHeaderTimeout: sharedResponseHeaderTimeout,
+		})
+	})
+	return sharedTransport
+}

--- a/platform/site_proxy.go
+++ b/platform/site_proxy.go
@@ -308,6 +308,9 @@ func (sp *SiteProxy) buildClients() {
 		TLSHandshakeTimeout:   timeouts.tlsHandshake,
 		ResponseHeaderTimeout: timeouts.responseHeader,
 		ExpectContinueTimeout: 1 * time.Second,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   20,
+		IdleConnTimeout:       timeouts.idleConn,
 	}
 
 	sp.httpClient = &http.Client{
@@ -323,6 +326,9 @@ func (sp *SiteProxy) buildClients() {
 		ResponseHeaderTimeout: timeouts.responseHeader,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   20,
+		IdleConnTimeout:       timeouts.idleConn,
 	}
 
 	sp.httpClientNoTLS = &http.Client{

--- a/proxy/executor.go
+++ b/proxy/executor.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/internal/httpclient"
 	"github.com/deliciousbuding/metapi-go/platform"
 )
 
@@ -47,14 +48,16 @@ type ExecutorDispatchResult struct {
 // upstream that accepts but never answers from holding a connection forever.
 const defaultStreamResponseHeaderTimeout = 30 * time.Second
 
-// NewStreamTransport returns a clone of http.DefaultTransport with a
+// NewStreamTransport returns the shared baseline transport with a
 // ResponseHeaderTimeout bound for the SSE header phase. Used by the
 // executor's stream client and by fallback stream clients that must not cap
 // a flowing stream's total duration while still bounding the header wait.
+// Dial/TLS/idle bounds and the idle pool come from the internal/httpclient
+// baseline instead of an unconfigured default transport.
 func NewStreamTransport() *http.Transport {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.ResponseHeaderTimeout = defaultStreamResponseHeaderTimeout
-	return transport
+	return httpclient.NewTransport(httpclient.Options{
+		ResponseHeaderTimeout: defaultStreamResponseHeaderTimeout,
+	})
 }
 
 // RuntimeExecutor dispatches upstream HTTP requests.
@@ -75,7 +78,12 @@ type RuntimeExecutor struct {
 func NewRuntimeExecutor(requestTimeout time.Duration) *RuntimeExecutor {
 	return &RuntimeExecutor{
 		client: &http.Client{
-			Timeout:       requestTimeout,
+			Timeout: requestTimeout,
+			// The header phase tracks the whole-request timeout
+			// (max(90s, first-byte*2) in app wiring, operator-influenced via
+			// PROXY_FIRST_BYTE_TIMEOUT_SEC) so it never pre-empts a request
+			// that would finish within its own deadline.
+			Transport:     httpclient.NewTransport(httpclient.Options{ResponseHeaderTimeout: requestTimeout}),
 			CheckRedirect: rejectCrossOriginRedirect,
 		},
 		streamClient: &http.Client{

--- a/service/notify/telegram.go
+++ b/service/notify/telegram.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/internal/httpclient"
 	"github.com/deliciousbuding/metapi-go/platform"
 	"github.com/deliciousbuding/metapi-go/service"
 )
@@ -52,7 +53,7 @@ func (c *TelegramChannel) Send(cfg *config.Config, title, message, level, timeFo
 	if cfg.TelegramUseSystemProxy && cfg.SystemProxyUrl != "" {
 		client = service.ProxyAwareHTTPClient(cfg.SystemProxyUrl, 30*time.Second)
 	} else {
-		client = &http.Client{Timeout: 30 * time.Second}
+		client = &http.Client{Timeout: 30 * time.Second, Transport: httpclient.SharedTransport()}
 	}
 	client.CheckRedirect = platform.RejectCrossOriginRedirect
 

--- a/service/pricingcatalog/provider.go
+++ b/service/pricingcatalog/provider.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/deliciousbuding/metapi-go/internal/httpclient"
 )
 
 // maxCatalogPayloadBytes bounds the catalog payload read (the datasets are
@@ -178,7 +180,7 @@ func NewProvider(opts Options) *Provider {
 	}
 	httpClient := opts.HTTPClient
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 30 * time.Second}
+		httpClient = &http.Client{Timeout: 30 * time.Second, Transport: httpclient.SharedTransport()}
 	}
 	logger := opts.Logger
 	if logger == nil {

--- a/service/proxy_util.go
+++ b/service/proxy_util.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/internal/httpclient"
 	"github.com/deliciousbuding/metapi-go/platform"
 )
 
@@ -24,6 +25,9 @@ func ProxyAwareHTTPClient(proxyURL string, timeout time.Duration) *http.Client {
 		}).DialContext,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ResponseHeaderTimeout: timeout,
+		MaxIdleConns:          httpclient.DefaultMaxIdleConns,
+		MaxIdleConnsPerHost:   httpclient.DefaultMaxIdleConnsPerHost,
+		IdleConnTimeout:       httpclient.DefaultIdleConnTimeout,
 	}
 
 	if proxyURL != "" {


### PR DESCRIPTION
## Wave 18 Lane C — 出站 HTTP 客户端超时与连接配置完备化

背景：竞品研究（`docs/internal/analysis/competitor-study-2026-08.md` §3.2）确定 axonhub HTTP 客户端基线 = **dial 30s / TLS 握手 10s / MaxIdleConns 100 / IdleConnTimeout 90s**。本 PR 将 `platform/` 16 个上游适配器与其他全部出站路径收敛到该基线，并加静态门禁防回归。

### 收敛点
所有出站客户端统一到 `internal/httpclient`（复用既有共享构造点，未新造）：
- `NewTransport(Options)` 基线：dial 30s / TLS 10s / IdleConnTimeout 90s / MaxIdleConns 100 / MaxIdleConnsPerHost 20 / ProxyFromEnvironment
- `SharedTransport()` singleton（ResponseHeaderTimeout 60s），供整体超时 ≤30s 的一次性出站路径复用
- SSE 流式转发路径只保留 header 超时（30s），body 读取仍由 `PROXY_STREAM_IDLE_TIMEOUT_SEC` 管 chunk 间隔，未误伤

### 盘点表（调用点 × 前后配置）
| 调用点 | 前 | 后 |
|---|---|---|
| platform 适配器（DoWithProxy 池） | 已达标（2s/10s/30s/90s/100/20） | 不变 |
| `platform/site_proxy.go` buildClients ×2 | 无池/无 idle | +MaxIdleConns 100 / +PerHost 20 / +IdleConnTimeout |
| `proxy/executor.go` 非流 client | 无 Transport（落 DefaultTransport） | NewTransport（RHT=requestTimeout，随整体超时） |
| `proxy.NewStreamTransport` | DefaultTransport.Clone()+RHT 30s | httpclient.NewTransport（RHT=30s） |
| `handler/proxy/upstream.go` defaultUpstreamClient | 无 Transport | +NewTransport（RHT 90s） |
| `handler/proxy/channel_health_probe.go` fallback | Timeout:0 无 Transport | probeFallbackTransport=NewTransport（RHT 0，deadline 由 caller ctx 持有） |
| `handler/admin/channel_test_harness.go` fallback | 同上 | harnessFallbackTransport 同模式 |
| `handler/proxy/codex_ws_runtime.go` websocket.Dial | 无 HTTPClient | HTTPClient:{Transport: SharedTransport()} |
| `service/notify/telegram.go` 非代理分支 | 裸 30s | +SharedTransport |
| `service/proxy_util.go` ProxyAwareHTTPClient | 无 idle/池 | +3 个 httpclient 池化常量 |
| `service/pricingcatalog/provider.go` 默认 | 裸 30s | +SharedTransport |
| `handler/admin/monitor.go` LDOH | 无 Transport，每请求新建 client | sync.Once ldohClient()，RHT=cfg 超时（默认 30s） |
| `cmd/server/main.go` healthcheck | 裸 5s | +SharedTransport |
| oauth/codex.go、notify/http.go、backup_webdav ×2 | 已完备（5-10s dial/TLS + RHT + idle） | 不变 |

### 静态门禁（仿 store pg_rebind_gate_test.go 模式）
`internal/httpclient/gate_test.go` — AST 级门禁（比 regex 可靠）：
- **R1** 禁 `http.DefaultClient` / `http.DefaultTransport`
- **R2** 禁 `http.Get/Post/PostForm/Head`（隐式 DefaultClient）
- **R3** `http.Client` 字面量必须带 Transport 或非零 Timeout
- **R4** `http.Transport` 字面量必须带 DialContext/DialTLSContext + TLSHandshakeTimeout + IdleConnTimeout（ResponseHeaderTimeout 不强制——ctx 主导路径可省）
- 尊重 import 别名；跳 `.git/.github/.worktrees/web/docs/vendor/node_modules` 与 `_test.go`；含 11 个正反例的 matcher sanity 测试

**反向验证（真实拦截证明）**：临时构造 `app/zz_gate_counterexample.go`（含 4 类违规），门禁精确失败后删除反例恢复全绿：
```
--- FAIL: TestOutboundHTTPClientGateNoBareClients (0.32s)
    app\zz_gate_counterexample.go:8:33: http.DefaultClient carries no outbound phase bounds...
    app\zz_gate_counterexample.go:10:36: http.Transport literal missing DialContext/DialTLSContext, TLSHandshakeTimeout, IdleConnTimeout...
    app\zz_gate_counterexample.go:12:37: http.Client literal without Transport and without a non-zero Timeout...
    app\zz_gate_counterexample.go:15:9: http.Get uses http.DefaultClient (no timeout)...
FAIL (exit 1) → 删除反例后恢复 PASS
```

### 兼容性
- 无新增 env；不改任何既有 env 名 / API 契约；JSON 字段不变
- 超时值全部宽于正常上游响应（30s/60s/90s 级），默认行为与现状一致或更安全
- 未触碰 `internal/ssrf` 守卫语义（只复用，不重写）

### 验证
- `go build ./cmd/server` ✅
- `go vet ./...` ✅
- `go test ./platform/... ./internal/... ./proxy/... -count=1` ✅（含门禁两测试）
- pre-push 全门禁（前端 + build + vet + WSL race）✅