### PR TITLE
fix(accounts): socks5 account proxy support + clear-on-save (issue #1009 residuals)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,8 @@ PROXY_MAX_BUFFERED_RESPONSE_BYTES=20971520
 PROXY_MAX_STREAM_RESPONSE_BYTES=1048576
 # Test/demo only. Leave empty in production; unconfigured upstream forwarding returns 503.
 METAPI_ENABLE_PROXY_STUB=
+# Optional outbound system proxy for upstream requests (http://, https://,
+# socks5:// or socks5h://). Empty = direct connection.
 SYSTEM_PROXY_URL=
 WEBHOOK_URL=
 BARK_URL=

--- a/docs/api.md
+++ b/docs/api.md
@@ -503,9 +503,13 @@ Global tag system: per-row writes and the aggregated index driving the Accounts/
 
 List all accounts. Create a new account.
 
+**Body** (create, optional): `proxyUrl` — per-account egress proxy stored in `extraConfig.proxyUrl`; accepted schemes are `http://`, `https://`, `socks5://`, `socks5h://` (SOCKS5 runs natively on Go's `net/http` transport). Invalid schemes return `400`.
+
 ### GET /api/accounts/:id, PUT /api/accounts/:id, DELETE /api/accounts/:id
 
 Get, update, delete an account.
+
+**`proxyUrl` update semantics**: field omitted → keep the stored proxy; present with a value → replace (same scheme validation as create); present empty (`""`) → delete `extraConfig.proxyUrl`.
 
 ### GET /api/accounts/probe-history
 

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -1253,9 +1253,20 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 		updates["sortOrder"] = int64(*so)
 	}
 	if body.ProxyURL != nil {
-		mergeExtraConfigUpdate(map[string]any{
-			"proxyUrl": service.NormalizeNullable(body.ProxyURL),
-		})
+		normalizedProxyURL := strings.TrimSpace(*body.ProxyURL)
+		if normalizedProxyURL != "" && !service.IsValidProxyURL(normalizedProxyURL) {
+			writeErrorWithRequest(w, r, http.StatusBadRequest, "Invalid proxyUrl. Expected a valid http(s)/socks proxy URL.")
+			return
+		}
+		// An explicitly cleared proxyUrl must persist as a deletion (issue
+		// #1009 residual). MergeExtraConfig deletes keys whose patch value is
+		// an untyped nil, so build the patch with a nil interface rather than
+		// a typed (*string)(nil), which would marshal to "proxyUrl": null.
+		var proxyPatch any
+		if normalizedProxyURL != "" {
+			proxyPatch = normalizedProxyURL
+		}
+		mergeExtraConfigUpdate(map[string]any{"proxyUrl": proxyPatch})
 	}
 	// PlatformUserID and skipModelFetch live in extraConfig (same storage as
 	// the create path); merge instead of dropping the form fields.

--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -2654,6 +2654,93 @@ func TestAccounts_Update_ExtraConfigAndProxyURLMergeTogether(t *testing.T) {
 	}
 }
 
+func readAccountExtraConfig(t *testing.T, db *store.DB, accountID int64) map[string]any {
+	t.Helper()
+	var extraConfig *string
+	if err := db.QueryRow("SELECT extra_config FROM accounts WHERE id = ?", accountID).Scan(&extraConfig); err != nil {
+		t.Fatalf("read extra_config: %v", err)
+	}
+	cfg := map[string]any{}
+	if extraConfig != nil && strings.TrimSpace(*extraConfig) != "" {
+		if err := json.Unmarshal([]byte(*extraConfig), &cfg); err != nil {
+			t.Fatalf("decode extra_config %q: %v", *extraConfig, err)
+		}
+	}
+	return cfg
+}
+
+// Issue #1009 residual: clearing the account proxy field and saving must
+// persist the clear. The update contract is: proxyUrl omitted -> keep the
+// stored value; present with a value -> replace; present empty -> delete
+// extraConfig.proxyUrl.
+func TestAccounts_Update_ProxyURL_ClearWithEmptyString(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	_, accountID := setupAccountFixtureWithSite(t, db, r, "ProxyClearSite", "https://api.openai.com")
+	url := "/api/accounts/" + itoa(accountID)
+
+	// Seed: set a socks5 proxy plus an unrelated extraConfig key.
+	resp := doPutJSON(t, r, url, map[string]any{
+		"extraConfig": map[string]any{"useSystemProxy": true},
+		"proxyUrl":    "socks5://proxy.example:1080",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("seed proxy: %d %s", resp.Code, resp.Body.String())
+	}
+	if got := readAccountExtraConfig(t, db, accountID)["proxyUrl"]; got != "socks5://proxy.example:1080" {
+		t.Fatalf("seeded proxyUrl = %#v, want socks5://proxy.example:1080", got)
+	}
+
+	// Clear with an explicit empty string.
+	resp = doPutJSON(t, r, url, map[string]any{"proxyUrl": ""})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("clear proxy: %d %s", resp.Code, resp.Body.String())
+	}
+	cfg := readAccountExtraConfig(t, db, accountID)
+	if _, stillSet := cfg["proxyUrl"]; stillSet {
+		t.Fatalf("proxyUrl = %#v after clear, want deleted from extraConfig", cfg["proxyUrl"])
+	}
+	if cfg["useSystemProxy"] != true {
+		t.Fatalf("useSystemProxy = %#v, want unrelated extraConfig keys preserved on clear", cfg["useSystemProxy"])
+	}
+
+	// Omitting proxyUrl entirely keeps the stored value.
+	resp = doPutJSON(t, r, url, map[string]any{"proxyUrl": "http://kept-proxy:8080"})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("reset proxy: %d %s", resp.Code, resp.Body.String())
+	}
+	resp = doPutJSON(t, r, url, map[string]any{"checkinEnabled": true})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("unrelated update: %d %s", resp.Code, resp.Body.String())
+	}
+	if got := readAccountExtraConfig(t, db, accountID)["proxyUrl"]; got != "http://kept-proxy:8080" {
+		t.Fatalf("proxyUrl = %#v after omitted-field update, want preserved", got)
+	}
+}
+
+func TestAccounts_Update_ProxyURL_SchemeValidation(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	_, accountID := setupAccountFixtureWithSite(t, db, r, "ProxySchemeSite", "https://api.openai.com")
+	url := "/api/accounts/" + itoa(accountID)
+
+	for _, valid := range []string{"socks5://proxy.example:1080", "socks5h://proxy.example:1080", "https://proxy.example:8443"} {
+		resp := doPutJSON(t, r, url, map[string]any{"proxyUrl": valid})
+		if resp.Code != http.StatusOK {
+			t.Fatalf("update %q: %d %s", valid, resp.Code, resp.Body.String())
+		}
+		if got := readAccountExtraConfig(t, db, accountID)["proxyUrl"]; got != valid {
+			t.Fatalf("proxyUrl = %#v, want %q", got, valid)
+		}
+	}
+
+	resp := doPutJSON(t, r, url, map[string]any{"proxyUrl": "ftp://not-supported"})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("invalid scheme: %d %s, want 400", resp.Code, resp.Body.String())
+	}
+	if got := readAccountExtraConfig(t, db, accountID)["proxyUrl"]; got != "https://proxy.example:8443" {
+		t.Fatalf("proxyUrl = %#v after rejected update, want previous value kept", got)
+	}
+}
+
 func TestListAccounts_RedactsAccessTokenAndAPIToken(t *testing.T) {
 	db, _, _ := setupAccountsTest(t)
 	now := time.Now().UTC().Format(time.RFC3339)

--- a/platform/site_proxy_socks_test.go
+++ b/platform/site_proxy_socks_test.go
@@ -1,0 +1,246 @@
+package platform
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// socks5TestServer is a minimal in-process RFC 1928 SOCKS5 server (no auth,
+// CONNECT only) used to prove that the account/site proxy path speaks SOCKS5
+// through Go's net/http transport natively (bundled SOCKS5 client since
+// Go 1.9) — no extra dependency required.
+type socks5TestServer struct {
+	t        *testing.T
+	listener net.Listener
+	// resolve maps a requested host to the host that should actually be
+	// dialed; nil dials the requested host as-is.
+	resolve func(host string) string
+
+	mu      sync.Mutex
+	targets []string
+}
+
+func startSocks5TestServer(t *testing.T, resolve func(host string) string) *socks5TestServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen socks5 test server: %v", err)
+	}
+	s := &socks5TestServer{t: t, listener: ln, resolve: resolve}
+	go s.acceptLoop()
+	t.Cleanup(func() { _ = ln.Close() })
+	return s
+}
+
+func (s *socks5TestServer) addr() string { return s.listener.Addr().String() }
+
+// connectTargets returns every CONNECT target (as requested by the client)
+// observed by the proxy, in order.
+func (s *socks5TestServer) connectTargets() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.targets...)
+}
+
+func (s *socks5TestServer) acceptLoop() {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return // listener closed
+		}
+		go s.handleConn(conn)
+	}
+}
+
+func (s *socks5TestServer) handleConn(conn net.Conn) {
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+
+	// Greeting: VER NMETHODS METHODS... — pick "no auth required" (0x00).
+	greeting := make([]byte, 2)
+	if _, err := io.ReadFull(conn, greeting); err != nil {
+		return
+	}
+	if greeting[0] != 0x05 {
+		return
+	}
+	methods := make([]byte, int(greeting[1]))
+	if _, err := io.ReadFull(conn, methods); err != nil {
+		return
+	}
+	noAuth := false
+	for _, m := range methods {
+		if m == 0x00 {
+			noAuth = true
+		}
+	}
+	if !noAuth {
+		_, _ = conn.Write([]byte{0x05, 0xFF}) // no acceptable methods
+		return
+	}
+	if _, err := conn.Write([]byte{0x05, 0x00}); err != nil {
+		return
+	}
+
+	// Request: VER CMD RSV ATYP DST.ADDR DST.PORT — CONNECT only.
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(conn, header); err != nil {
+		return
+	}
+	if header[0] != 0x05 || header[1] != 0x01 {
+		_, _ = conn.Write([]byte{0x05, 0x07, 0x00, 0x01, 0, 0, 0, 0, 0, 0}) // command not supported
+		return
+	}
+	var host string
+	switch header[3] {
+	case 0x01: // IPv4
+		ip := make([]byte, 4)
+		if _, err := io.ReadFull(conn, ip); err != nil {
+			return
+		}
+		host = net.IP(ip).String()
+	case 0x03: // FQDN — the socks5h proxy-side-resolution path
+		lenByte := make([]byte, 1)
+		if _, err := io.ReadFull(conn, lenByte); err != nil {
+			return
+		}
+		domain := make([]byte, int(lenByte[0]))
+		if _, err := io.ReadFull(conn, domain); err != nil {
+			return
+		}
+		host = string(domain)
+	case 0x04: // IPv6
+		ip := make([]byte, 16)
+		if _, err := io.ReadFull(conn, ip); err != nil {
+			return
+		}
+		host = net.IP(ip).String()
+	default:
+		_, _ = conn.Write([]byte{0x05, 0x08, 0x00, 0x01, 0, 0, 0, 0, 0, 0}) // address type not supported
+		return
+	}
+	portBytes := make([]byte, 2)
+	if _, err := io.ReadFull(conn, portBytes); err != nil {
+		return
+	}
+	port := strconv.Itoa(int(portBytes[0])<<8 | int(portBytes[1]))
+
+	s.mu.Lock()
+	s.targets = append(s.targets, net.JoinHostPort(host, port))
+	s.mu.Unlock()
+
+	dialHost := host
+	if s.resolve != nil {
+		dialHost = s.resolve(host)
+	}
+	upstream, err := net.DialTimeout("tcp", net.JoinHostPort(dialHost, port), 5*time.Second)
+	if err != nil {
+		_, _ = conn.Write([]byte{0x05, 0x05, 0x00, 0x01, 0, 0, 0, 0, 0, 0}) // connection refused
+		return
+	}
+	defer upstream.Close()
+	// Success reply with a dummy BND address (CONNECT clients ignore it).
+	if _, err := conn.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
+		return
+	}
+
+	_ = conn.SetDeadline(time.Time{})
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(upstream, conn); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(conn, upstream); done <- struct{}{} }()
+	<-done
+}
+
+// TestSiteProxy_Socks5AccountProxy_EndToEnd proves that an account-level
+// socks5:// proxy (extraConfig.proxyUrl -> ProxyConfig.ProxyURL) works end
+// to end through the same dispatch the platform adapters use: Go's net/http
+// transport handles socks5:// natively, so no extra dependency is needed.
+func TestSiteProxy_Socks5AccountProxy_EndToEnd(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hello via socks5"))
+	}))
+	defer backend.Close()
+
+	socks := startSocks5TestServer(t, nil)
+	sp := NewSiteProxy("")
+
+	req, err := http.NewRequest(http.MethodGet, backend.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := sp.Do(context.Background(), req, &ProxyConfig{ProxyURL: "socks5://" + socks.addr()})
+	if err != nil {
+		t.Fatalf("Do via socks5 proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK || string(body) != "hello via socks5" {
+		t.Fatalf("response = %d %q, want 200 %q", resp.StatusCode, body, "hello via socks5")
+	}
+
+	targets := socks.connectTargets()
+	if len(targets) != 1 {
+		t.Fatalf("socks5 CONNECT count = %d, want exactly 1 (request must traverse the proxy)", len(targets))
+	}
+	if !strings.HasPrefix(targets[0], "127.0.0.1:") {
+		t.Fatalf("socks5 CONNECT target = %q, want the backend address", targets[0])
+	}
+}
+
+// TestDoWithProxy_Socks5H_ResolvesAtProxy proves socks5h:// support: the
+// request hostname reaches the proxy unresolved (FQDN address type) and the
+// proxy performs the resolution — the exact socks5h contract.
+func TestDoWithProxy_Socks5H_ResolvesAtProxy(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hello via socks5h"))
+	}))
+	defer backend.Close()
+	// backend.URL is http://127.0.0.1:port — keep only the port so the fake
+	// hostname can be mapped back to the loopback backend by the proxy.
+	backendHostPort := strings.TrimPrefix(backend.URL, "http://")
+	_, backendPort, err := net.SplitHostPort(backendHostPort)
+	if err != nil {
+		t.Fatalf("split backend hostport: %v", err)
+	}
+
+	const fakeHost = "socks5h-target.invalid"
+	socks := startSocks5TestServer(t, func(host string) string {
+		if host == fakeHost {
+			return "127.0.0.1"
+		}
+		return host
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "http://"+net.JoinHostPort(fakeHost, backendPort)+"/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := DoWithProxy(context.Background(), req, &ProxyConfig{ProxyURL: "socks5h://" + socks.addr()})
+	if err != nil {
+		t.Fatalf("DoWithProxy via socks5h proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK || string(body) != "hello via socks5h" {
+		t.Fatalf("response = %d %q, want 200 %q", resp.StatusCode, body, "hello via socks5h")
+	}
+
+	targets := socks.connectTargets()
+	if len(targets) != 1 || targets[0] != net.JoinHostPort(fakeHost, backendPort) {
+		t.Fatalf("socks5h CONNECT targets = %v, want [%s] (hostname must reach the proxy unresolved)", targets, net.JoinHostPort(fakeHost, backendPort))
+	}
+}

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -150,6 +150,8 @@ func DecryptPassword(cfg *config.Config, cipherText string) string {
 // ---- ExtraConfig helpers ----
 
 // MergeExtraConfig merges a patch into an existing extraConfig JSON string.
+// A nil patch value (untyped nil) deletes the key; callers must not pass a
+// typed nil pointer, which would marshal to JSON null instead of deleting.
 func MergeExtraConfig(existing *string, patch map[string]any) *string {
 	base := ParseExtraConfig(existing)
 	if base == nil {

--- a/web/src/features/accounts/__tests__/accounts-schema.test.ts
+++ b/web/src/features/accounts/__tests__/accounts-schema.test.ts
@@ -216,21 +216,17 @@ describe('getAccountFormSchema — siteId', () => {
 // ---------------------------------------------------------------------------
 
 describe('getAccountFormSchema — proxyUrl', () => {
-  it('accepts an empty / http / https proxyUrl', () => {
-    expect(
-      getAccountFormSchema().safeParse({ ...validSessionForm(), proxyUrl: '' })
-        .success
-    ).toBe(true)
-    expect(
-      getAccountFormSchema().safeParse({
-        ...validSessionForm(),
-        proxyUrl: 'http://p',
-      }).success
-    ).toBe(true)
+  it.each([
+    ['empty', ''],
+    ['http', 'http://p'],
+    ['https', 'https://p'],
+    ['socks5', 'socks5://proxy.example:1080'],
+    ['socks5h', 'socks5h://proxy.example:1080'],
+  ])('accepts a %s proxyUrl', (_label, proxyUrl) => {
     expect(
       getAccountFormSchema().safeParse({
         ...validSessionForm(),
-        proxyUrl: 'https://p',
+        proxyUrl,
       }).success
     ).toBe(true)
   })
@@ -238,6 +234,7 @@ describe('getAccountFormSchema — proxyUrl', () => {
   it.each([
     ['ftp scheme', 'ftp://x'],
     ['bare protocol with no host', 'https://'],
+    ['socks5 with no host', 'socks5://'],
     ['plain string', 'not a url'],
   ])('rejects %s with the dedicated message', (_label, proxyUrl) => {
     const result = getAccountFormSchema().safeParse({
@@ -246,7 +243,10 @@ describe('getAccountFormSchema — proxyUrl', () => {
     })
     expect(result.success).toBe(false)
     if (result.success) return
-    expectLocalized(result.error.issues[0]?.message, '代理地址需为合法 URL')
+    expectLocalized(
+      result.error.issues[0]?.message,
+      '代理地址需以 http://、https://、socks5:// 或 socks5h:// 开头'
+    )
   })
 })
 
@@ -264,15 +264,52 @@ describe('transformFormToPayload', () => {
     return payload as AccountPayload
   }
 
-  it('folds proxyUrl into extraConfig for session mode', () => {
+  it('sends proxyUrl as the single top-level field for session mode', () => {
     const payload = expectPayload({
       ...validSessionForm(),
       proxyUrl: 'http://p',
     })
-    expect(payload.extraConfig).toBe('{"proxyUrl":"http://p"}')
+    expect(payload.proxyUrl).toBe('http://p')
     expect(payload.credentialMode).toBe('session')
     expect(payload.accessToken).toBe('sk-1')
     expect(payload.skipModelFetch).toBeUndefined()
+  })
+
+  it('sends proxyUrl for apikey mode', () => {
+    const payload = transformFormToPayload(
+      {
+        ...validApikeyForm(),
+        proxyUrl: 'socks5://proxy.example:1080',
+      },
+      'create'
+    )
+    expect(payload?.proxyUrl).toBe('socks5://proxy.example:1080')
+  })
+
+  it('omits proxyUrl on create when the field is empty', () => {
+    const payload = expectPayload({ ...validSessionForm(), proxyUrl: '' })
+    expect(payload.proxyUrl).toBeUndefined()
+  })
+
+  it('sends an explicit empty proxyUrl on update so the backend clears it', () => {
+    const session = transformFormToPayload(
+      { ...validSessionForm(), proxyUrl: '' },
+      'update'
+    )
+    expect(session?.proxyUrl).toBe('')
+    const apikey = transformFormToPayload(
+      { ...validApikeyForm(), proxyUrl: '' },
+      'update'
+    )
+    expect(apikey?.proxyUrl).toBe('')
+  })
+
+  it('keeps sending the proxy value on update', () => {
+    const payload = transformFormToPayload(
+      { ...validSessionForm(), proxyUrl: 'socks5h://proxy.example:1080' },
+      'update'
+    )
+    expect(payload?.proxyUrl).toBe('socks5h://proxy.example:1080')
   })
 
   it('sends a single-entry accessTokens array for apikey mode', () => {

--- a/web/src/features/accounts/components/account-form-dialog.tsx
+++ b/web/src/features/accounts/components/account-form-dialog.tsx
@@ -633,7 +633,7 @@ export function AccountFormDialog({
                   <FormLabel>{t('accounts.form.proxyUrl')}</FormLabel>
                   <FormControl>
                     <Input
-                      placeholder='https://proxy.example.com'
+                      placeholder='https://proxy.example.com or socks5://proxy.example.com:1080'
                       {...field}
                       value={field.value ?? ''}
                     />

--- a/web/src/features/accounts/lib/accounts-schema.ts
+++ b/web/src/features/accounts/lib/accounts-schema.ts
@@ -42,7 +42,7 @@ export function getAccountFormSchema(requireCredential = true) {
         .string()
         .trim()
         .optional()
-        .refine((value) => !value || /^https?:\/\/.+/.test(value), {
+        .refine((value) => !value || /^(https?|socks5h?):\/\/.+/.test(value), {
           message: 'accounts.schema.invalidProxyUrl',
         }),
       refreshToken: z.string().trim().optional(),
@@ -142,9 +142,15 @@ export function transformFormToPayload(
   if (values.credentialMode === 'password') return undefined
 
   const tags = parseTagsInput(values.tags)
-  const extraConfig = values.proxyUrl
-    ? JSON.stringify({ proxyUrl: values.proxyUrl })
-    : undefined
+  // proxyUrl is the single carrier for extraConfig.proxyUrl: the backend
+  // merges the top-level field into extraConfig on both create and update.
+  // On update the field is sent unconditionally — an explicit empty string
+  // deletes the stored proxy, while an omitted field would keep it (issue
+  // #1009 residual: clearing the form field and saving kept the old value).
+  const proxyUrl =
+    operation === 'update'
+      ? (values.proxyUrl ?? '')
+      : values.proxyUrl || undefined
 
   if (values.credentialMode === 'session') {
     return {
@@ -156,11 +162,10 @@ export function transformFormToPayload(
       status: values.status,
       checkinEnabled: values.checkinEnabled,
       unitCost: values.unitCost,
-      proxyUrl: values.proxyUrl || undefined,
+      proxyUrl,
       refreshToken: values.refreshToken || undefined,
       tokenExpiresAt: values.tokenExpiresAt,
       tags,
-      extraConfig,
     }
   }
 
@@ -175,9 +180,9 @@ export function transformFormToPayload(
     status: values.status,
     checkinEnabled: values.checkinEnabled,
     unitCost: values.unitCost,
+    proxyUrl,
     skipModelFetch: values.skipModelFetch,
     tags,
-    extraConfig,
   }
 }
 

--- a/web/src/features/accounts/types.ts
+++ b/web/src/features/accounts/types.ts
@@ -160,7 +160,6 @@ export interface AccountPayload {
   tokenExpiresAt?: number
   skipModelFetch?: boolean
   tags?: string[]
-  extraConfig?: string
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1929,7 +1929,7 @@
       },
       "schema": {
         "siteRequired": "Please select a site",
-        "invalidProxyUrl": "Proxy URL must be a valid URL",
+        "invalidProxyUrl": "Proxy URL must start with http://, https://, socks5:// or socks5h://",
         "accessTokenRequired": "Please enter the Access Token / Cookie",
         "apiKeyRequired": "Please enter the API Key",
         "usernameRequired": "Please enter the site username",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1929,7 +1929,7 @@
       },
       "schema": {
         "siteRequired": "请选择站点",
-        "invalidProxyUrl": "代理地址需为合法 URL",
+        "invalidProxyUrl": "代理地址需以 http://、https://、socks5:// 或 socks5h:// 开头",
         "accessTokenRequired": "请填写 Access Token / Cookie",
         "apiKeyRequired": "请填写 API Key",
         "usernameRequired": "请填写站点用户名",


### PR DESCRIPTION
## Summary

Closes the two remaining #1009 residuals for account-level proxy: SOCKS5 support and clear-on-save.

## Root causes found

1. **SOCKS5 blocked at the form only.** The backend already fully supports SOCKS proxies (`service.IsValidProxyURL` accepts http/https/socks/socks5/socks5h; `platform.supportedProxySchemes` likewise; `http.Transport.Proxy` natively speaks SOCKS5 via Go's bundled client since Go 1.9). The web form's zod refine (`/^https?:\/\/.+/`) rejected `socks5://` / `socks5h://` even though the user report confirms socks5 works upstream.

2. **Clear-on-save bug — two independent causes:**
   - *Frontend*: `transformFormToPayload` sent `proxyUrl` only when truthy (and apikey mode never sent the top-level field at all), so a cleared field was omitted from the PUT and the backend kept the stored value. The `extraConfig` JSON-string field it sent instead is dead weight: the create payload has no `extraConfig` field and the update handler only merges `extraConfig` **objects** — the string was silently ignored on both paths.
   - *Backend*: even when an empty `proxyUrl` was sent, `NormalizeNullable` returns a typed `(*string)(nil)`, and `MergeExtraConfig`'s delete branch checks `v == nil`, which a typed nil does not satisfy — the key would have been stored as `"proxyUrl": null` instead of deleted. (This is why backend-side proof tests were needed, not just a frontend fix.)
   - *Latent gap*: `updateAccount` applied no scheme validation (create/verify-token do).

## Changes

**Go**
- `platform/site_proxy_socks_test.go` (new): minimal in-process RFC 1928 SOCKS5 server (no new dependencies) proving end-to-end SOCKS5 through the exact dispatch account proxies use — `socks5://` CONNECT round-trip via `SiteProxy.Do`, and `socks5h://` proxy-side hostname resolution (FQDN address type reaches the proxy unresolved).
- `handler/admin/accounts.go`: `updateAccount` now validates `proxyUrl` (same `IsValidProxyURL` gate + error message as create) and builds the merge patch with an untyped nil so an explicitly cleared `proxyUrl` deletes `extraConfig.proxyUrl` (backend-authoritative).
- `service/account_service.go`: documented the `MergeExtraConfig` nil contract (untyped nil deletes; typed nil marshals to null).
- `handler/admin/accounts_test.go`: clear-with-empty-string deletes the key while preserving unrelated `extraConfig` keys; omitted field keeps the stored value; socks5/socks5h/https accepted on update; `ftp://` rejected with 400 and prior value kept.

**Web**
- `accounts-schema.ts`: zod refine widened to `^(https?|socks5h?):\/\/.+`; `transformFormToPayload` now uses top-level `proxyUrl` as the single carrier — sent unconditionally on update (empty string clears), omitted-on-create when blank, for **both** session and apikey modes; dead `extraConfig` string dropped.
- i18n `accounts.schema.invalidProxyUrl` updated (en + zh-CN) to name the accepted schemes; form placeholder shows a socks5 example.
- `accounts-schema.test.ts`: socks5/socks5h acceptance, socks5-no-host rejection, create-omit, update-clear (session + apikey), update-replace.

**Docs**
- `docs/api.md`: account `proxyUrl` contract — accepted schemes, storage in `extraConfig.proxyUrl`, PUT semantics (omitted keeps / value replaces / empty clears).
- `.env.example`: `SYSTEM_PROXY_URL` schemes documented (same transport path).

## Test evidence

- **Go**: `go build ./cmd/server` + `go build ./cmd/migrate` ✓ · `go vet ./...` ✓ · `go test ./... -count=1 -race -timeout 900s` all packages **ok** (via WSL), including the new socks5/socks5h tests and 2 new handler tests; new/changed handler tests also run standalone ✓. Note: `handler/admin` is CPU-bound on shared dev hardware (~250–320s with -race; a master baseline measured 319s under contention) — the first push attempt hit the default 300s package timeout purely due to machine contention, and the retried push passed the full pre-push gate cleanly (handler/admin 248.7s).
- **Web** (full pre-push gate, ran 3x): `vitest run` **220 files / 1414 tests passed** · `tsgo -b` ✓ · `oxlint` ✓ (pre-existing warnings only) · `oxfmt --check` ✓ · `knip` ✓ · `rsbuild build` ✓.
- **Pre-push hook**: `pre-push OK — all checks passed` on the successful push (no `--no-verify`).

## Residuals

- `platform.supportedProxySchemes` still lists `socks`/`socks4`/`socks4a`, which Go's transport does not natively dial (they'd be misrouted as HTTP CONNECT at runtime). Pre-existing, out of scope; forms/validation now steer users to socks5/socks5h.
- Go's net/http treats `socks5://` the same as `socks5h://` (hostname always resolved at the proxy) — documented Go behavior, both accepted.
