### PR TITLE
fix(dialect): PG dialect trap audit - boolean literals, LIKE case, gate coverage (w18)

### DIFF
--- a/auth/downstream_test.go
+++ b/auth/downstream_test.go
@@ -62,7 +62,7 @@ func TestGetManagedKeyByToken_Found(t *testing.T) {
 		 (name, key, enabled, expires_at, max_cost, used_cost, max_requests, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, NULL, NULL, 0, NULL, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, NULL, NULL, 0, NULL, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"test-found", "sk-crud-found", now, now,
 	)
 	if err != nil {
@@ -123,7 +123,7 @@ func TestDownstreamKeyCRUD_Insert(t *testing.T) {
 		 (name, key, enabled, max_cost, used_cost, max_requests, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, ?, ?, ?, ?, '["gpt-4"]', '[1,2]', '{"1":1.5}', '[3]', '[{"kind":"account_token","site_id":1,"account_id":2,"token_id":3}]', ?, ?)`,
+		 VALUES (?, ?, TRUE, ?, ?, ?, ?, '["gpt-4"]', '[1,2]', '{"1":1.5}', '[3]', '[{"kind":"account_token","site_id":1,"account_id":2,"token_id":3}]', ?, ?)`,
 		"crud-insert", "sk-crud-insert", 100.0, 0.0, int64(1000), int64(0), now, now,
 	)
 	if err != nil {
@@ -179,7 +179,7 @@ func TestDownstreamKeyCRUD_Update(t *testing.T) {
 		 (name, key, enabled, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"crud-update", "sk-crud-update", now, now,
 	)
 	if err != nil {
@@ -188,7 +188,7 @@ func TestDownstreamKeyCRUD_Update(t *testing.T) {
 
 	// Update name and enabled
 	_, err = db.Exec(
-		`UPDATE downstream_api_keys SET name = ?, enabled = 0, updated_at = ? WHERE key = ?`,
+		`UPDATE downstream_api_keys SET name = ?, enabled = FALSE, updated_at = ? WHERE key = ?`,
 		"crud-updated", now, "sk-crud-update",
 	)
 	if err != nil {
@@ -221,7 +221,7 @@ func TestDownstreamKeyCRUD_Delete(t *testing.T) {
 		 (name, key, enabled, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"crud-delete", "sk-crud-delete", now, now,
 	)
 	if err != nil {
@@ -263,7 +263,7 @@ func TestDownstreamKeyCRUD_UniqueConstraint(t *testing.T) {
 		 (name, key, enabled, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"crud-dup", "sk-crud-dup", now, now,
 	)
 	if err != nil {
@@ -276,7 +276,7 @@ func TestDownstreamKeyCRUD_UniqueConstraint(t *testing.T) {
 		 (name, key, enabled, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"crud-dup2", "sk-crud-dup", now, now,
 	)
 	if err == nil {
@@ -299,7 +299,7 @@ func TestExpiration_PastDate(t *testing.T) {
 		 (name, key, enabled, expires_at, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, ?, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, ?, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"exp-past", "sk-exp-past", expiredAt, now, now,
 	)
 	if err != nil {
@@ -326,7 +326,7 @@ func TestExpiration_FutureDate(t *testing.T) {
 		 (name, key, enabled, expires_at, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, ?, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, ?, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"exp-future", "sk-exp-future", futureExpiry, now, now,
 	)
 	if err != nil {
@@ -352,7 +352,7 @@ func TestExpiration_NilExpiresAt(t *testing.T) {
 		 (name, key, enabled, expires_at, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, NULL, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, NULL, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"exp-null", "sk-exp-null", now, now,
 	)
 	if err != nil {
@@ -376,7 +376,7 @@ func TestExpiration_InvalidDateFormat(t *testing.T) {
 		 (name, key, enabled, expires_at, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, ?, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, ?, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"exp-invalid", "sk-exp-invalid", invalidDate, now, now,
 	)
 	if err != nil {
@@ -405,7 +405,7 @@ func TestCostQuota_UnderLimit(t *testing.T) {
 		 (name, key, enabled, max_cost, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, ?, 50.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, ?, 50.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"cost-under", "sk-cost-under", maxCost, now, now,
 	)
 	if err != nil {
@@ -429,7 +429,7 @@ func TestCostQuota_AtLimit(t *testing.T) {
 		 (name, key, enabled, max_cost, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, ?, 50.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, ?, 50.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"cost-at", "sk-cost-at", maxCost, now, now,
 	)
 	if err != nil {
@@ -456,7 +456,7 @@ func TestCostQuota_OverLimit(t *testing.T) {
 		 (name, key, enabled, max_cost, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, ?, 100.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, ?, 100.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"cost-over", "sk-cost-over", maxCost, now, now,
 	)
 	if err != nil {
@@ -482,7 +482,7 @@ func TestCostQuota_NilMaxCost(t *testing.T) {
 		 (name, key, enabled, max_cost, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, NULL, 999999.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, NULL, 999999.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"cost-nil", "sk-cost-nil", now, now,
 	)
 	if err != nil {
@@ -511,7 +511,7 @@ func TestRequestQuota_UnderLimit(t *testing.T) {
 		 (name, key, enabled, used_cost, max_requests, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 0, ?, 500, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 0, ?, 500, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"req-under", "sk-req-under", maxReqs, now, now,
 	)
 	if err != nil {
@@ -535,7 +535,7 @@ func TestRequestQuota_AtLimit(t *testing.T) {
 		 (name, key, enabled, used_cost, max_requests, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 0, ?, 500, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 0, ?, 500, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"req-at", "sk-req-at", maxReqs, now, now,
 	)
 	if err != nil {
@@ -562,7 +562,7 @@ func TestRequestQuota_OverLimit(t *testing.T) {
 		 (name, key, enabled, used_cost, max_requests, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 0, ?, 200, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 0, ?, 200, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"req-over", "sk-req-over", maxReqs, now, now,
 	)
 	if err != nil {
@@ -592,7 +592,7 @@ func TestConsumeManagedKeyRequest_AtomicIncrement(t *testing.T) {
 		 (name, key, enabled, used_cost, max_requests, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 0, NULL, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 0, NULL, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"incr-req", "sk-incr-req", now, now,
 	)
 	if err != nil {
@@ -636,7 +636,7 @@ func TestConsumeManagedKeyRequest_RespectsMaxRequests(t *testing.T) {
 		 (name, key, enabled, used_cost, max_requests, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 0, 1, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 0, 1, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"incr-limited", "sk-incr-limited", now, now,
 	)
 	if err != nil {
@@ -673,7 +673,7 @@ func TestConsumeManagedKeyRequest_FromNull(t *testing.T) {
 		 (name, key, enabled, used_cost, max_requests, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 0, NULL, NULL, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 0, NULL, NULL, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"incr-null", "sk-incr-null", now, now,
 	)
 	if err != nil {
@@ -703,7 +703,7 @@ func TestRecordManagedKeyCostUsage_PositiveCost(t *testing.T) {
 		 (name, key, enabled, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 10.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 10.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"cost-incr", "sk-cost-incr", now, now,
 	)
 	if err != nil {
@@ -734,7 +734,7 @@ func TestRecordManagedKeyCostUsage_ZeroCost(t *testing.T) {
 		 (name, key, enabled, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 10.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 10.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"cost-zero", "sk-cost-zero", now, now,
 	)
 	if err != nil {
@@ -764,7 +764,7 @@ func TestRecordManagedKeyCostUsage_NegativeCost(t *testing.T) {
 		 (name, key, enabled, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 10.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 10.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"cost-neg", "sk-cost-neg", now, now,
 	)
 	if err != nil {
@@ -794,7 +794,7 @@ func TestRecordManagedKeyCostUsage_NaN(t *testing.T) {
 		 (name, key, enabled, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 10.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 10.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"cost-nan", "sk-cost-nan", now, now,
 	)
 	if err != nil {
@@ -825,7 +825,7 @@ func TestRecordManagedKeyCostUsage_Inf(t *testing.T) {
 		 (name, key, enabled, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, 10.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, 10.0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"cost-inf", "sk-cost-inf", now, now,
 	)
 	if err != nil {
@@ -862,7 +862,7 @@ func TestDisabledKey_Rejected(t *testing.T) {
 		 (name, key, enabled, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 0, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, FALSE, 0, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"disabled-key", "sk-disabled", now, now,
 	)
 	if err != nil {

--- a/auth/proxy_test.go
+++ b/auth/proxy_test.go
@@ -624,7 +624,7 @@ func TestAuthorizeDownstreamToken_ManagedKeyProxyURL(t *testing.T) {
 		 (name, key, enabled, expires_at, max_cost, used_cost, max_requests, used_requests, proxy_url,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, NULL, NULL, 0, NULL, 0, ?, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, NULL, NULL, 0, NULL, 0, ?, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"proxy-key", "sk-with-proxy", proxyURL, now, now,
 	)
 	if err != nil {
@@ -649,7 +649,7 @@ func TestAuthorizeDownstreamToken_ManagedKeyProxyURLWhitespaceInherits(t *testin
 		 (name, key, enabled, expires_at, max_cost, used_cost, max_requests, used_requests, proxy_url,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, NULL, NULL, 0, NULL, 0, '   ', '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, NULL, NULL, 0, NULL, 0, '   ', '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"proxy-blank", "sk-blank-proxy", now, now,
 	)
 	if err != nil {
@@ -678,7 +678,7 @@ func TestProxyAuthMiddleware_PropagatesKeyProxyURL(t *testing.T) {
 		 (name, key, enabled, expires_at, max_cost, used_cost, max_requests, used_requests, proxy_url,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, NULL, NULL, 0, NULL, 0, ?, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, NULL, NULL, 0, NULL, 0, ?, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"mw-proxy", "sk-mw-proxy", proxyURL, now, now,
 	)
 	if err != nil {
@@ -719,7 +719,7 @@ func insertTestKeyWithRPM(t *testing.T, key string, maxRequests *int64, usedRequ
 		  max_rpm, max_tpm,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, NULL, NULL, 0, ?, ?, ?, ?, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, NULL, NULL, 0, ?, ?, ?, ?, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		"test-key-"+key, key, maxRequests, usedRequests, maxRPM, maxTPM, now, now,
 	)
 	if err != nil {

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -165,7 +165,7 @@ func TestRunMigration_SQLiteToSQLite_PreservesData(t *testing.T) {
 	}
 	if _, err := srcDB.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		1, "testuser", "sk-test", "active", 1, now, now,
+		1, "testuser", "sk-test", "active", true, now, now,
 	); err != nil {
 		t.Fatalf("insert account: %v", err)
 	}

--- a/docs/pg_boolean_gate_test.go
+++ b/docs/pg_boolean_gate_test.go
@@ -89,7 +89,7 @@ func TestPgBooleanLiteralGateNoIntComparison(t *testing.T) {
 		t.Fatal("runtime.Caller failed")
 	}
 	repoRoot := filepath.Dir(filepath.Dir(thisFile)) // docs/ → repo root
-	dirs := []string{"handler", "service", "scheduler"}
+	dirs := []string{"app", "auth", "cmd", "config", "e2e", "handler", "platform", "proxy", "routing", "scheduler", "service", "store", "transform"}
 	var violations []string
 
 	for _, dir := range dirs {

--- a/docs/pg_rebind_gate_test.go
+++ b/docs/pg_rebind_gate_test.go
@@ -49,7 +49,7 @@ func TestPgRebindGateNoBareQuestionMarks(t *testing.T) {
 		t.Fatal("runtime.Caller failed")
 	}
 	repoRoot := filepath.Dir(filepath.Dir(thisFile)) // docs/ → repo root
-	dirs := []string{"handler", "service", "scheduler"}
+	dirs := []string{"app", "auth", "cmd", "config", "e2e", "handler", "platform", "proxy", "routing", "scheduler", "service", "store", "transform"}
 	var violations []string
 
 	for _, dir := range dirs {

--- a/e2e/e2e_backup_test.go
+++ b/e2e/e2e_backup_test.go
@@ -51,13 +51,13 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 	db.Exec(`INSERT INTO sites (id, name, url, platform, status, created_at, updated_at)
 		VALUES (1, 'Test Site A', 'https://api.openai.com', 'openai', 'active', ?, ?)`, now, now)
 	db.Exec(`INSERT INTO sites (id, name, url, platform, status, is_pinned, created_at, updated_at)
-		VALUES (2, 'Test Site B', 'https://api.anthropic.com', 'anthropic', 'active', 1, ?, ?)`, now, now)
+		VALUES (2, 'Test Site B', 'https://api.anthropic.com', 'anthropic', 'active', TRUE, ?, ?)`, now, now)
 
 	// Table 2: site_api_endpoints (2 rows, FK sites)
 	db.Exec(`INSERT INTO site_api_endpoints (id, site_id, url, enabled, created_at, updated_at)
-		VALUES (1, 1, 'https://api.openai.com/v1', 1, ?, ?)`, now, now)
+		VALUES (1, 1, 'https://api.openai.com/v1', TRUE, ?, ?)`, now, now)
 	db.Exec(`INSERT INTO site_api_endpoints (id, site_id, url, enabled, created_at, updated_at)
-		VALUES (2, 2, 'https://api.anthropic.com/v1', 1, ?, ?)`, now, now)
+		VALUES (2, 2, 'https://api.anthropic.com/v1', TRUE, ?, ?)`, now, now)
 
 	// Table 3: site_disabled_models (1 row, FK sites)
 	db.Exec(`INSERT INTO site_disabled_models (id, site_id, model_name, created_at)
@@ -71,11 +71,11 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 
 	// Table 5: account_tokens (3 rows, FK accounts)
 	db.Exec(`INSERT INTO account_tokens (id, account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
-		VALUES (1, 1, 'default', 'tk-a-default', 'ready', 'manual', 1, 1, ?, ?)`, now, now)
+		VALUES (1, 1, 'default', 'tk-a-default', 'ready', 'manual', TRUE, TRUE, ?, ?)`, now, now)
 	db.Exec(`INSERT INTO account_tokens (id, account_id, name, token, value_status, source, enabled, created_at, updated_at)
-		VALUES (2, 1, 'backup', 'tk-a-backup', 'ready', 'manual', 1, ?, ?)`, now, now)
+		VALUES (2, 1, 'backup', 'tk-a-backup', 'ready', 'manual', TRUE, ?, ?)`, now, now)
 	db.Exec(`INSERT INTO account_tokens (id, account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
-		VALUES (3, 2, 'default', 'tk-b-default', 'ready', 'manual', 1, 1, ?, ?)`, now, now)
+		VALUES (3, 2, 'default', 'tk-b-default', 'ready', 'manual', TRUE, TRUE, ?, ?)`, now, now)
 
 	// Table 6: checkin_logs (2 rows, FK accounts)
 	db.Exec(`INSERT INTO checkin_logs (id, account_id, status, message, reward, created_at)
@@ -85,21 +85,21 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 
 	// Table 7: model_availability (2 rows, FK accounts)
 	db.Exec(`INSERT INTO model_availability (id, account_id, model_name, available, is_manual, checked_at)
-		VALUES (1, 1, 'gpt-4', 1, 1, ?)`, now)
+		VALUES (1, 1, 'gpt-4', TRUE, TRUE, ?)`, now)
 	db.Exec(`INSERT INTO model_availability (id, account_id, model_name, available, is_manual, checked_at)
-		VALUES (2, 2, 'claude-3-opus', 1, 0, ?)`, now)
+		VALUES (2, 2, 'claude-3-opus', TRUE, FALSE, ?)`, now)
 
 	// Table 8: token_model_availability (2 rows, FK account_tokens)
 	db.Exec(`INSERT INTO token_model_availability (id, token_id, model_name, available, checked_at)
-		VALUES (1, 1, 'gpt-4', 1, ?)`, now)
+		VALUES (1, 1, 'gpt-4', TRUE, ?)`, now)
 	db.Exec(`INSERT INTO token_model_availability (id, token_id, model_name, available, checked_at)
-		VALUES (2, 3, 'claude-3-opus', 1, ?)`, now)
+		VALUES (2, 3, 'claude-3-opus', TRUE, ?)`, now)
 
 	// Table 9: token_routes (2 rows)
 	db.Exec(`INSERT INTO token_routes (id, model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
-		VALUES (1, 'gpt-4', 'GPT-4 Route', 'pattern', 'weighted', 1, ?, ?)`, now, now)
+		VALUES (1, 'gpt-4', 'GPT-4 Route', 'pattern', 'weighted', TRUE, ?, ?)`, now, now)
 	db.Exec(`INSERT INTO token_routes (id, model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
-		VALUES (2, 'claude-*', 'Claude Route', 'pattern', 'weighted', 1, ?, ?)`, now, now)
+		VALUES (2, 'claude-*', 'Claude Route', 'pattern', 'weighted', TRUE, ?, ?)`, now, now)
 
 	// Table 10: route_group_sources (2 rows, FK token_routes x2)
 	db.Exec(`INSERT INTO route_group_sources (id, group_route_id, source_route_id)
@@ -109,9 +109,9 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 
 	// Table 11: oauth_route_units (2 rows, FK sites)
 	db.Exec(`INSERT INTO oauth_route_units (id, site_id, provider, name, strategy, enabled, created_at, updated_at)
-		VALUES (1, 1, 'google', 'Google Unit', 'round_robin', 1, ?, ?)`, now, now)
+		VALUES (1, 1, 'google', 'Google Unit', 'round_robin', TRUE, ?, ?)`, now, now)
 	db.Exec(`INSERT INTO oauth_route_units (id, site_id, provider, name, strategy, enabled, created_at, updated_at)
-		VALUES (2, 2, 'github', 'GitHub Unit', 'round_robin', 1, ?, ?)`, now, now)
+		VALUES (2, 2, 'github', 'GitHub Unit', 'round_robin', TRUE, ?, ?)`, now, now)
 
 	// Table 12: oauth_route_unit_members (2 rows, FK oauth_route_units + accounts, UNIQUE account_id)
 	// Each account can only be in one unit, so distribute across units.
@@ -123,9 +123,9 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 	// Table 13: route_channels (2 rows, FK token_routes + accounts + account_tokens SET NULL)
 	// NOTE: route_channels has NO created_at/updated_at columns.
 	db.Exec(`INSERT INTO route_channels (id, route_id, account_id, token_id, weight, enabled)
-		VALUES (1, 1, 1, 1, 10, 1)`)
+		VALUES (1, 1, 1, 1, 10, TRUE)`)
 	db.Exec(`INSERT INTO route_channels (id, route_id, account_id, weight, enabled)
-		VALUES (2, 2, 2, 10, 1)`)
+		VALUES (2, 2, 2, 10, TRUE)`)
 
 	// Table 14: proxy_logs (2 rows)
 	db.Exec(`INSERT INTO proxy_logs (id, route_id, channel_id, account_id, model_requested, model_actual, status, created_at)
@@ -189,9 +189,9 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 
 	// Table 25: downstream_api_keys (2 rows)
 	db.Exec(`INSERT INTO downstream_api_keys (id, name, key, enabled, used_cost, used_requests, created_at, updated_at)
-		VALUES (1, 'Test Key A', 'sk-downstream-key-a', 1, 0, 0, ?, ?)`, now, now)
+		VALUES (1, 'Test Key A', 'sk-downstream-key-a', TRUE, 0, 0, ?, ?)`, now, now)
 	db.Exec(`INSERT INTO downstream_api_keys (id, name, key, expires_at, enabled, used_cost, used_requests, created_at, updated_at)
-		VALUES (2, 'Test Key B', 'sk-downstream-key-b', ?, 1, 0, 0, ?, ?)`, future, now, now)
+		VALUES (2, 'Test Key B', 'sk-downstream-key-b', ?, TRUE, 0, 0, ?, ?)`, future, now, now)
 
 	// Table 26: site_announcements (2 rows, FK sites)
 	db.Exec(`INSERT INTO site_announcements (id, site_id, platform, source_key, title, content, level, first_seen_at, last_seen_at)
@@ -203,7 +203,7 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 	db.Exec(`INSERT INTO events (id, type, title, message, level, created_at)
 		VALUES (1, 'info', 'System started', 'Metapi started successfully', 'info', ?)`, now)
 	db.Exec(`INSERT INTO events (id, type, title, message, level, read, created_at)
-		VALUES (2, 'warn', 'High latency', 'Proxy latency above threshold', 'warn', 0, ?)`, now)
+		VALUES (2, 'warn', 'High latency', 'Proxy latency above threshold', 'warn', FALSE, ?)`, now)
 
 	// ──────────────────────────────────────────────────────────────────────────
 	// Verify seed: check row counts for all 28 tables
@@ -714,7 +714,7 @@ func TestBackupSettingsJSONFidelity(t *testing.T) {
 
 	// Insert a downstream_api_key with JSON array fields.
 	db.Exec(`INSERT INTO downstream_api_keys (id, name, key, enabled, used_cost, used_requests, supported_models, allowed_route_ids, created_at, updated_at)
-		VALUES (1, 'Key With JSON', 'sk-json-fields', 1, 0, 0, '["gpt-4","gpt-3.5","claude-3-opus"]', '[1,2,3]', ?, ?)`, now, now)
+		VALUES (1, 'Key With JSON', 'sk-json-fields', TRUE, 0, 0, '["gpt-4","gpt-3.5","claude-3-opus"]', '[1,2,3]', ?, ?)`, now, now)
 
 	// Insert a site with nullable fields set.
 	db.Exec(`INSERT INTO sites (id, name, url, platform, status, custom_headers, created_at, updated_at)
@@ -786,11 +786,11 @@ func TestBackupRouteChannelTokenNullFK(t *testing.T) {
 	db.Exec(`INSERT INTO account_tokens (id, account_id, name, token, value_status, source, created_at, updated_at)
 		VALUES (1, 1, 'tk', 'val', 'ready', 'manual', ?, ?)`, now, now)
 	db.Exec(`INSERT INTO token_routes (id, model_pattern, routing_strategy, enabled, created_at, updated_at)
-		VALUES (1, 'gpt-4', 'weighted', 1, ?, ?)`, now, now)
+		VALUES (1, 'gpt-4', 'weighted', TRUE, ?, ?)`, now, now)
 
 	// Create route_channel WITH token_id set (no created_at column).
 	db.Exec(`INSERT INTO route_channels (id, route_id, account_id, token_id, weight, enabled)
-		VALUES (1, 1, 1, 1, 10, 1)`)
+		VALUES (1, 1, 1, 1, 10, TRUE)`)
 
 	// Export.
 	exportRec := doGet(t, r, "/api/settings/backup/export?type=all")

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -500,7 +500,7 @@ func TestDownstreamAuth(t *testing.T) {
 
 	// Valid key: enabled, not expired, unlimited.
 	_, err := db.Exec(`INSERT INTO downstream_api_keys (name, key, enabled, expires_at, max_cost, used_cost, max_requests, used_requests, supported_models, created_at, updated_at)
-		VALUES (?, ?, 1, ?, NULL, 0, NULL, 0, '["gpt-4","gpt-3.5"]', ?, ?)`,
+		VALUES (?, ?, TRUE, ?, NULL, 0, NULL, 0, '["gpt-4","gpt-3.5"]', ?, ?)`,
 		"test-valid-key", validToken, future, now, now)
 	if err != nil {
 		t.Fatalf("failed to insert valid key: %v", err)
@@ -508,7 +508,7 @@ func TestDownstreamAuth(t *testing.T) {
 
 	// Expired key.
 	_, err = db.Exec(`INSERT INTO downstream_api_keys (name, key, enabled, expires_at, max_cost, used_cost, max_requests, used_requests, supported_models, created_at, updated_at)
-		VALUES (?, ?, 1, ?, NULL, 0, NULL, 0, '["gpt-4"]', ?, ?)`,
+		VALUES (?, ?, TRUE, ?, NULL, 0, NULL, 0, '["gpt-4"]', ?, ?)`,
 		"test-expired-key", expiredToken, past, now, now)
 	if err != nil {
 		t.Fatalf("failed to insert expired key: %v", err)
@@ -516,7 +516,7 @@ func TestDownstreamAuth(t *testing.T) {
 
 	// Disabled key.
 	_, err = db.Exec(`INSERT INTO downstream_api_keys (name, key, enabled, expires_at, max_cost, used_cost, max_requests, used_requests, supported_models, created_at, updated_at)
-		VALUES (?, ?, 0, NULL, NULL, 0, NULL, 0, '["gpt-4"]', ?, ?)`,
+		VALUES (?, ?, FALSE, NULL, NULL, 0, NULL, 0, '["gpt-4"]', ?, ?)`,
 		"test-disabled-key", disabledToken, now, now)
 	if err != nil {
 		t.Fatalf("failed to insert disabled key: %v", err)

--- a/handler/admin/account_tokens_adapter_test.go
+++ b/handler/admin/account_tokens_adapter_test.go
@@ -147,7 +147,7 @@ func tokenFixtureWithPlatform(t *testing.T, db *store.DB, name, siteURL, platfor
 	res, err = db.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, status, is_pinned, sort_order,
 		 checkin_enabled, extra_config, created_at, updated_at)
-		 VALUES (?, ?, 'session-access-token', 'active', 0, 0, 1, ?, ?, ?)`,
+		 VALUES (?, ?, 'session-access-token', 'active', FALSE, 0, TRUE, ?, ?, ?)`,
 		siteID, &username, &extraConfig, now, now,
 	)
 	if err != nil {
@@ -323,7 +323,7 @@ func TestTokens_CreateUpstream_MissingAdapter(t *testing.T) {
 	extra := `{"credentialMode":"session"}`
 	res, _ = db.Exec(
 		`INSERT INTO accounts (site_id, access_token, status, checkin_enabled, extra_config, created_at, updated_at)
-		 VALUES (?, 'session-token', 'active', 1, ?, ?, ?)`,
+		 VALUES (?, 'session-token', 'active', TRUE, ?, ?, ?)`,
 		siteID, &extra, now, now,
 	)
 	accountID, _ := res.LastInsertId()
@@ -385,7 +385,7 @@ func TestTokens_GetGroups_LocalFallbackWhenUpstreamMissing(t *testing.T) {
 	extra := `{"credentialMode":"session"}`
 	res, err = db.Exec(
 		`INSERT INTO accounts (site_id, access_token, status, checkin_enabled, extra_config, created_at, updated_at)
-		 VALUES (?, 'session-token', 'active', 1, ?, ?, ?)`,
+		 VALUES (?, 'session-token', 'active', TRUE, ?, ?, ?)`,
 		siteID, &extra, now, now,
 	)
 	if err != nil {

--- a/handler/admin/accounts_expired_recovery_test.go
+++ b/handler/admin/accounts_expired_recovery_test.go
@@ -133,7 +133,7 @@ func TestAccounts_Update_ExpiredAPIKeyRecovery_Success(t *testing.T) {
 
 	var modelCount int
 	if err := db.QueryRow(
-		"SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND available = 1",
+		"SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND available = TRUE",
 		accountID,
 	).Scan(&modelCount); err != nil {
 		t.Fatalf("count models: %v", err)
@@ -346,7 +346,7 @@ func TestAccounts_Update_ExpiredAPIKeyRecovery_InjectableRefresh(t *testing.T) {
 		// Simulate successful model write without upstream (Wave 15 moved
 		// persistAccountModelAvailability into the service package).
 		if _, err := dbx.Exec(dbx.Rebind(
-			"INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, ?, 1, 0, ?)",
+			"INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, ?, TRUE, FALSE, ?)",
 		), id, "inject-model", time.Now().UTC().Format(time.RFC3339)); err != nil {
 			t.Fatalf("seed injected availability: %v", err)
 		}

--- a/handler/admin/accounts_health_test.go
+++ b/handler/admin/accounts_health_test.go
@@ -45,7 +45,7 @@ func insertHealthSiteRow(t *testing.T, db *store.DB, name, url, platform string)
 func insertHealthAccountRow(t *testing.T, db *store.DB, siteID int64, status, extraConfigJSON string) int64 {
 	t.Helper()
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
-	res, err := db.Exec(db.Rebind(`INSERT INTO accounts (site_id, access_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, 'sk-fixture', ?, 1, ?, ?, ?)`), siteID, status, extraConfigJSON, now, now)
+	res, err := db.Exec(db.Rebind(`INSERT INTO accounts (site_id, access_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, 'sk-fixture', ?, TRUE, ?, ?, ?)`), siteID, status, extraConfigJSON, now, now)
 	if err != nil {
 		t.Fatalf("insert account row: %v", err)
 	}

--- a/handler/admin/accounts_models_refresh_test.go
+++ b/handler/admin/accounts_models_refresh_test.go
@@ -120,10 +120,10 @@ func TestRefreshAccountModels_PersistsAvailability_RebuildAndInvalidateOnce(t *t
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	// Prior state: an operator-pinned manual row and a stale auto row.
-	if _, err := db.Exec(db.Rebind("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, 'manual-pin', 1, 1, ?)"), accountID, now); err != nil {
+	if _, err := db.Exec(db.Rebind("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, 'manual-pin', TRUE, TRUE, ?)"), accountID, now); err != nil {
 		t.Fatalf("seed manual row: %v", err)
 	}
-	if _, err := db.Exec(db.Rebind("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, 'stale-auto', 1, 0, ?)"), accountID, now); err != nil {
+	if _, err := db.Exec(db.Rebind("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, 'stale-auto', TRUE, FALSE, ?)"), accountID, now); err != nil {
 		t.Fatalf("seed stale row: %v", err)
 	}
 
@@ -179,7 +179,7 @@ func TestRefreshAccountModels_UpstreamFailure_NoFakeSuccessNoSideEffects(t *test
 	pointAccountSiteAt(t, db, accountID, upstream.URL)
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	if _, err := db.Exec(db.Rebind("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, 'keep-me', 1, 0, ?)"), accountID, now); err != nil {
+	if _, err := db.Exec(db.Rebind("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, 'keep-me', TRUE, FALSE, ?)"), accountID, now); err != nil {
 		t.Fatalf("seed row: %v", err)
 	}
 
@@ -227,7 +227,7 @@ func TestManualModels_AddRemove_ReadBack(t *testing.T) {
 
 	// Seed an auto row that a remove attempt must never touch.
 	now := time.Now().UTC().Format(time.RFC3339)
-	if _, err := db.Exec(db.Rebind("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, 'auto-keep', 1, 0, ?)"), accountID, now); err != nil {
+	if _, err := db.Exec(db.Rebind("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, 'auto-keep', TRUE, FALSE, ?)"), accountID, now); err != nil {
 		t.Fatalf("seed auto row: %v", err)
 	}
 
@@ -277,12 +277,12 @@ func TestGetAccountModels_HonestSourceAndAvailability(t *testing.T) {
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	seeds := []struct {
 		name      string
-		available int
-		isManual  int
+		available bool
+		isManual  bool
 	}{
-		{"auto-up", 1, 0},
-		{"auto-down", 0, 0},
-		{"manual-up", 1, 1},
+		{"auto-up", true, false},
+		{"auto-down", false, false},
+		{"manual-up", true, true},
 	}
 	for _, s := range seeds {
 		if _, err := db.Exec(db.Rebind("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, ?, ?, ?, ?)"), accountID, s.name, s.available, s.isManual, now); err != nil {
@@ -332,7 +332,7 @@ func TestGetAccountModels_HonestSourceAndAvailability(t *testing.T) {
 
 	// Empty account: models must be [] not null. Seed a second account on the
 	// same site directly (the fixture enforces one site per URL).
-	emptyRes, err := db.Exec(db.Rebind("INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, sort_order, created_at, updated_at) VALUES (?, 'lane-g-empty', 'sk-empty', 'active', 0, 0, ?, ?)"), siteID, now, now)
+	emptyRes, err := db.Exec(db.Rebind("INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, sort_order, created_at, updated_at) VALUES (?, 'lane-g-empty', 'sk-empty', 'active', FALSE, 0, ?, ?)"), siteID, now, now)
 	if err != nil {
 		t.Fatalf("seed empty account: %v", err)
 	}

--- a/handler/admin/accounts_sub2api_auth_test.go
+++ b/handler/admin/accounts_sub2api_auth_test.go
@@ -29,7 +29,7 @@ func setupSub2ApiAccountFixture(t *testing.T, db *store.DB, r chi.Router, extraC
 	siteID := int64(site["id"].(float64))
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	res, err := db.Exec(
-		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, 'active', 1, ?, ?, ?)",
+		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, 'active', TRUE, ?, ?, ?)",
 		siteID, "sub2api-user", "session-old", extraConfig, now, now,
 	)
 	if err != nil {

--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -145,7 +145,7 @@ func setupAccountFixtureWithSite(t *testing.T, db *store.DB, r chi.Router, siteN
 	siteID := int64(site["id"].(float64))
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	res, _ := db.Exec(
-		"INSERT INTO accounts (site_id, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'sk-fixture', 'active', 1, ?, ?)",
+		"INSERT INTO accounts (site_id, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'sk-fixture', 'active', TRUE, ?, ?)",
 		siteID, now, now,
 	)
 	accID, _ := res.LastInsertId()
@@ -173,7 +173,7 @@ func setupAnyRouterBalanceAccount(t *testing.T, db *store.DB, siteURL string) (i
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	siteID := insertAnyRouterBalanceSite(t, db, siteURL, now)
 	accRes, err := db.Exec(
-		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, ?, 'active', 1, ?, ?)",
+		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, ?, 'active', TRUE, ?, ?)",
 		siteID, "anyrouter-user", "session-token", now, now,
 	)
 	if err != nil {
@@ -191,7 +191,7 @@ func setupAnyRouterAPIKeyAccount(t *testing.T, db *store.DB, siteURL string) (in
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	siteID := insertAnyRouterBalanceSite(t, db, siteURL, now)
 	accRes, err := db.Exec(
-		"INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, ?, 'active', 0, ?, ?, ?)",
+		"INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, ?, 'active', FALSE, ?, ?, ?)",
 		siteID, nil, "anyrouter-api-key-token", "anyrouter-api-key-token", `{"credentialMode":"apikey"}`, now, now,
 	)
 	if err != nil {
@@ -2026,7 +2026,7 @@ func TestAccounts_HealthRefresh_Sync(t *testing.T) {
 
 	// Session-capable account (balance probe path).
 	accRes, err := db.Exec(
-		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, ?, 'active', 1, ?, ?)",
+		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, ?, 'active', TRUE, ?, ?)",
 		siteID, "anyrouter-user", "session-token", now, now,
 	)
 	if err != nil {
@@ -2039,7 +2039,7 @@ func TestAccounts_HealthRefresh_Sync(t *testing.T) {
 
 	// proxy-only apikey on same site should be skipped honestly
 	apiKeyRes, err := db.Exec(
-		"INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, ?, 'active', 0, ?, ?, ?)",
+		"INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, ?, 'active', FALSE, ?, ?, ?)",
 		siteID, nil, "anyrouter-api-key-token", "anyrouter-api-key-token", `{"credentialMode":"apikey"}`, now, now,
 	)
 	if err != nil {
@@ -2129,7 +2129,7 @@ func TestAccounts_HealthRefresh_SingleAccountID(t *testing.T) {
 	siteID := insertAnyRouterBalanceSite(t, db, server.URL, now)
 
 	accRes, err := db.Exec(
-		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, ?, 'active', 1, ?, ?)",
+		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, ?, 'active', TRUE, ?, ?)",
 		siteID, "anyrouter-user", "session-token", now, now,
 	)
 	if err != nil {
@@ -2141,7 +2141,7 @@ func TestAccounts_HealthRefresh_SingleAccountID(t *testing.T) {
 	}
 	// Second account on same site is intentionally not targeted by accountId.
 	if _, err := db.Exec(
-		"INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, ?, 'active', 0, ?, ?, ?)",
+		"INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, ?, 'active', FALSE, ?, ?, ?)",
 		siteID, nil, "anyrouter-api-key-token", "anyrouter-api-key-token", `{"credentialMode":"apikey"}`, now, now,
 	); err != nil {
 		t.Fatalf("insert other apikey account: %v", err)
@@ -2387,8 +2387,8 @@ func TestAccounts_GetModels(t *testing.T) {
 	_, accountID := setupAccountFixtureWithSite(t, db, r, "ModelSite", "https://api.openai.com")
 
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
-	db.Exec("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, 'gpt-4', 1, 0, ?)", accountID, now)
-	db.Exec("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, 'gpt-3.5', 1, 0, ?)", accountID, now)
+	db.Exec("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, 'gpt-4', TRUE, FALSE, ?)", accountID, now)
+	db.Exec("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, 'gpt-3.5', TRUE, FALSE, ?)", accountID, now)
 
 	resp := doGet(t, r, "/api/accounts/"+itoa(accountID)+"/models")
 	if resp.Code != http.StatusOK {
@@ -2442,7 +2442,7 @@ func TestAccounts_ManualModels(t *testing.T) {
 
 	// Verify models exist
 	var count int
-	db.QueryRow("SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND is_manual = 1", accountID).Scan(&count)
+	db.QueryRow("SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND is_manual = TRUE", accountID).Scan(&count)
 	if count != 2 {
 		t.Errorf("expected 2 manual models, got %d", count)
 	}
@@ -2470,7 +2470,7 @@ func TestAccounts_ManualModels_Deduplication(t *testing.T) {
 	}
 
 	var count int
-	db.QueryRow("SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND is_manual = 1", accountID).Scan(&count)
+	db.QueryRow("SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND is_manual = TRUE", accountID).Scan(&count)
 	if count != 1 {
 		t.Errorf("expected 1 model after dedup, got %d", count)
 	}
@@ -2670,7 +2670,7 @@ func TestListAccounts_RedactsAccessTokenAndAPIToken(t *testing.T) {
 	apiTok := "sk-api-token-XYZ12345"
 	res, err := db.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, api_token, balance, balance_used, quota, value_score, status, is_pinned, sort_order, checkin_enabled, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, 0, 0, 0, 0, 'active', 0, 0, 0, ?, ?)`,
+		 VALUES (?, ?, ?, ?, 0, 0, 0, 0, 'active', FALSE, 0, FALSE, ?, ?)`,
 		siteID, "redact-user", secret, apiTok, now, now,
 	)
 	if err != nil {
@@ -2719,7 +2719,7 @@ func TestAccounts_List_IncludesPerAccountTodayMetrics(t *testing.T) {
 	// Second account on the same active site, no rows today (real zero).
 	nowInsert := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	res, err := db.Exec(
-		"INSERT INTO accounts (site_id, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'sk-clean', 'active', 1, ?, ?)",
+		"INSERT INTO accounts (site_id, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'sk-clean', 'active', TRUE, ?, ?)",
 		siteID, nowInsert, nowInsert,
 	)
 	if err != nil {

--- a/handler/admin/admin_creds_test.go
+++ b/handler/admin/admin_creds_test.go
@@ -51,7 +51,7 @@ func seedCredentialedAccount(t *testing.T, db *store.DB) (accessSecret, apiSecre
 
 	res, err = db.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
-		 VALUES (?, 'cred-user', ?, ?, 'active', 1, ?, ?)`,
+		 VALUES (?, 'cred-user', ?, ?, 'active', TRUE, ?, ?)`,
 		siteID, accessSecret, apiSecret, now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
@@ -60,7 +60,7 @@ func seedCredentialedAccount(t *testing.T, db *store.DB) (accessSecret, apiSecre
 
 	res, err = db.Exec(
 		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
-		 VALUES (?, 'cred-token', ?, 'ready', 'manual', 1, 1, ?, ?)`,
+		 VALUES (?, 'cred-token', ?, 'ready', 'manual', TRUE, TRUE, ?, ?)`,
 		accountID, tokenSecret, now, now)
 	if err != nil {
 		t.Fatalf("insert account_token: %v", err)
@@ -68,7 +68,7 @@ func seedCredentialedAccount(t *testing.T, db *store.DB) (accessSecret, apiSecre
 	tokenID, _ = res.LastInsertId()
 
 	res, err = db.Exec(
-		`INSERT INTO token_routes (model_pattern, enabled, created_at, updated_at) VALUES ('gpt-*', 1, ?, ?)`, now, now)
+		`INSERT INTO token_routes (model_pattern, enabled, created_at, updated_at) VALUES ('gpt-*', TRUE, ?, ?)`, now, now)
 	if err != nil {
 		t.Fatalf("insert route: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestListRoutes_ResponseOmitsPlaintextCredentials(t *testing.T) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	if _, err := db.Exec(
 		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-		 VALUES (?, ?, ?, 'gpt-4o', 1, 10, 1, 0)`, routeID, accountID, tokenID); err != nil {
+		 VALUES (?, ?, ?, 'gpt-4o', 1, 10, TRUE, FALSE)`, routeID, accountID, tokenID); err != nil {
 		t.Fatalf("insert channel: %v", err)
 	}
 	_ = now
@@ -138,7 +138,7 @@ func TestGetRouteChannels_ResponseOmitsPlaintextCredentials(t *testing.T) {
 	accessSecret, apiSecret, _, routeID, accountID, tokenID := seedCredentialedAccount(t, db)
 	if _, err := db.Exec(
 		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-		 VALUES (?, ?, ?, 'gpt-4o', 1, 10, 1, 0)`, routeID, accountID, tokenID); err != nil {
+		 VALUES (?, ?, ?, 'gpt-4o', 1, 10, TRUE, FALSE)`, routeID, accountID, tokenID); err != nil {
 		t.Fatalf("insert channel: %v", err)
 	}
 
@@ -241,7 +241,7 @@ func TestChannels_PaginationReturnsCorrectTotal(t *testing.T) {
 		model := "gpt-pg-" + itoa(int64(i+1))
 		if _, err := db.Exec(
 			`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-			 VALUES (?, ?, ?, ?, 0, 10, 1, 0)`, routeID, accountID, tokenID, model); err != nil {
+			 VALUES (?, ?, ?, ?, 0, 10, TRUE, FALSE)`, routeID, accountID, tokenID, model); err != nil {
 			t.Fatalf("insert channel %d: %v", i, err)
 		}
 	}

--- a/handler/admin/admin_pagination_test.go
+++ b/handler/admin/admin_pagination_test.go
@@ -103,7 +103,7 @@ func TestListRoutes_PaginationScopesChannelBatchLoad(t *testing.T) {
 	// enriched on the page that contains it.
 	if _, err := db.Exec(
 		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-		 VALUES (?, ?, ?, 'gpt-4o', 1, 10, 1, 0)`,
+		 VALUES (?, ?, ?, 'gpt-4o', 1, 10, TRUE, FALSE)`,
 		routeID, accountID, tokenID,
 	); err != nil {
 		t.Fatalf("insert channel: %v", err)
@@ -139,7 +139,7 @@ func seedRoutes(t *testing.T, db *store.DB, count int, now string) {
 	for i := 0; i < count; i++ {
 		if _, err := db.Exec(
 			`INSERT INTO token_routes (model_pattern, enabled, sort_order, created_at, updated_at)
-			 VALUES (?, 1, ?, ?, ?)`,
+			 VALUES (?, TRUE, ?, ?, ?)`,
 			"model-"+strconv.Itoa(i)+"-*", i, now, now,
 		); err != nil {
 			t.Fatalf("seed route %d: %v", i, err)
@@ -167,7 +167,7 @@ func setupAccountsPaginationTest(t *testing.T) (*store.DB, chi.Router) {
 	for i := 0; i < 3; i++ {
 		if _, err := db.Exec(
 			`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
-			 VALUES (?, ?, ?, 'active', 1, ?, ?)`,
+			 VALUES (?, ?, ?, 'active', TRUE, ?, ?)`,
 			siteID, "user-"+strconv.Itoa(i), "token-"+strconv.Itoa(i), now, now,
 		); err != nil {
 			t.Fatalf("seed account %d: %v", i, err)
@@ -268,7 +268,7 @@ func setupDownstreamKeysPaginationTest(t *testing.T) (*store.DB, chi.Router) {
 	for i := 0; i < 3; i++ {
 		if _, err := db.Exec(
 			`INSERT INTO downstream_api_keys (name, key, enabled, created_at, updated_at)
-			 VALUES (?, ?, 1, ?, ?)`,
+			 VALUES (?, ?, TRUE, ?, ?)`,
 			"key-"+strconv.Itoa(i), "sk-key-"+strconv.Itoa(i), now, now,
 		); err != nil {
 			t.Fatalf("seed key %d: %v", i, err)

--- a/handler/admin/auth_settings.go
+++ b/handler/admin/auth_settings.go
@@ -88,8 +88,10 @@ func (h *authSettingsHandler) changeToken(w http.ResponseWriter, r *http.Request
 	clearMonitorAuthCookies(w, r)
 
 	// Log the change event
+	// read is a BOOLEAN column on PostgreSQL: bind FALSE, not the integer
+	// literal 0 (w18-pg-dialect: PG rejects integer literals for booleans).
 	h.db.Exec(`INSERT INTO events (type, title, message, level, related_type, created_at, read)
-		VALUES ('token', 'Admin login token updated', 'The admin login token was changed. Use the new token to log in.', 'warning', 'settings', ?, 0)`, now)
+		VALUES ('token', 'Admin login token updated', 'The admin login token was changed. Use the new token to log in.', 'warning', 'settings', ?, FALSE)`, now)
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success": true,

--- a/handler/admin/channel_test_harness_test.go
+++ b/handler/admin/channel_test_harness_test.go
@@ -55,21 +55,21 @@ func insertHarnessFixtures(t *testing.T, db *store.DB) (siteID, accountID, route
 
 	apiTok := "sk-harness-api-token-xyz"
 	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, 'active', 0, ?, ?)`, siteID, "harness-user", "session-token", apiTok, now, now)
+		VALUES (?, ?, ?, ?, 'active', FALSE, ?, ?)`, siteID, "harness-user", "session-token", apiTok, now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}
 	accountID, _ = res.LastInsertId()
 
 	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
-		VALUES (?, ?, 'standard', 'weighted', 1, ?, ?)`, "gpt-*", "Harness Route", now, now)
+		VALUES (?, ?, 'standard', 'weighted', TRUE, ?, ?)`, "gpt-*", "Harness Route", now, now)
 	if err != nil {
 		t.Fatalf("insert route: %v", err)
 	}
 	routeID, _ = res.LastInsertId()
 
 	res, err = db.Exec(`INSERT INTO route_channels (route_id, account_id, source_model, priority, weight, enabled)
-		VALUES (?, ?, ?, 10, 10, 1)`, routeID, accountID, "gpt-4o-mini")
+		VALUES (?, ?, ?, 10, 10, TRUE)`, routeID, accountID, "gpt-4o-mini")
 	if err != nil {
 		t.Fatalf("insert channel: %v", err)
 	}
@@ -396,21 +396,21 @@ func insertHarnessFixturesAtURL(t *testing.T, db *store.DB, siteURL string) (sit
 
 	apiTok := "sk-harness-api-token-xyz"
 	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, 'active', 0, ?, ?)`, siteID, "harness-user", "session-token", apiTok, now, now)
+		VALUES (?, ?, ?, ?, 'active', FALSE, ?, ?)`, siteID, "harness-user", "session-token", apiTok, now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}
 	accountID, _ = res.LastInsertId()
 
 	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
-		VALUES (?, ?, 'standard', 'weighted', 1, ?, ?)`, "gpt-*", "Harness Redirect Route", now, now)
+		VALUES (?, ?, 'standard', 'weighted', TRUE, ?, ?)`, "gpt-*", "Harness Redirect Route", now, now)
 	if err != nil {
 		t.Fatalf("insert route: %v", err)
 	}
 	routeID, _ = res.LastInsertId()
 
 	res, err = db.Exec(`INSERT INTO route_channels (route_id, account_id, source_model, priority, weight, enabled)
-		VALUES (?, ?, ?, 10, 10, 1)`, routeID, accountID, "gpt-4o-mini")
+		VALUES (?, ?, ?, 10, 10, TRUE)`, routeID, accountID, "gpt-4o-mini")
 	if err != nil {
 		t.Fatalf("insert channel: %v", err)
 	}

--- a/handler/admin/channels_batch_update_test.go
+++ b/handler/admin/channels_batch_update_test.go
@@ -75,13 +75,13 @@ func TestBatchUpdateChannels_DisablesChannelsTruthfully(t *testing.T) {
 	// DB truth: both rows disabled and marked manual_override so a route
 	// rebuild cannot silently re-enable them.
 	var enabledCount, overrideCount int
-	if err := db.Get(&enabledCount, "SELECT COUNT(*) FROM route_channels WHERE id IN (?, ?) AND enabled = 1", ids[0], ids[1]); err != nil {
+	if err := db.Get(&enabledCount, "SELECT COUNT(*) FROM route_channels WHERE id IN (?, ?) AND enabled = TRUE", ids[0], ids[1]); err != nil {
 		t.Fatalf("count enabled: %v", err)
 	}
 	if enabledCount != 0 {
 		t.Fatalf("enabled rows = %d, want 0", enabledCount)
 	}
-	if err := db.Get(&overrideCount, "SELECT COUNT(*) FROM route_channels WHERE id IN (?, ?) AND manual_override = 1", ids[0], ids[1]); err != nil {
+	if err := db.Get(&overrideCount, "SELECT COUNT(*) FROM route_channels WHERE id IN (?, ?) AND manual_override = TRUE", ids[0], ids[1]); err != nil {
 		t.Fatalf("count manual_override: %v", err)
 	}
 	if overrideCount != 2 {

--- a/handler/admin/channels_test.go
+++ b/handler/admin/channels_test.go
@@ -16,7 +16,7 @@ func TestChannels_ListProjection(t *testing.T) {
 	if _, err := db.Exec(
 		`INSERT INTO route_channels
 			(route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override, success_count, total_latency_ms)
-		 VALUES (?, ?, ?, 'gpt-4o', 5, 20, 1, 0, 2, 300)`,
+		 VALUES (?, ?, ?, 'gpt-4o', 5, 20, TRUE, FALSE, 2, 300)`,
 		routeID, accountID, tokenID,
 	); err != nil {
 		t.Fatalf("insert channel: %v", err)
@@ -85,7 +85,7 @@ func TestChannels_ManuallyDisabledStatus(t *testing.T) {
 	if _, err := db.Exec(
 		`INSERT INTO route_channels
 			(route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-		 VALUES (?, ?, ?, 'gpt-4o', 0, 10, 0, 1)`,
+		 VALUES (?, ?, ?, 'gpt-4o', 0, 10, FALSE, TRUE)`,
 		routeID, accountID, tokenID,
 	); err != nil {
 		t.Fatalf("insert channel: %v", err)
@@ -126,7 +126,7 @@ func TestChannels_List_UnboundedReturnsAllRows(t *testing.T) {
 		if _, err := db.Exec(
 			`INSERT INTO route_channels
 				(route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-			 VALUES (?, ?, ?, ?, 0, 10, 1, 0)`,
+			 VALUES (?, ?, ?, ?, 0, 10, TRUE, FALSE)`,
 			routeID, accountID, tokenID, "gpt-unbounded-"+itoa(int64(i))); err != nil {
 			t.Fatalf("insert channel %d: %v", i, err)
 		}

--- a/handler/admin/contract_envelope_test.go
+++ b/handler/admin/contract_envelope_test.go
@@ -148,7 +148,7 @@ func TestEnvelope_ChannelsList_PagedEnvelope(t *testing.T) {
 	if _, err := db.Exec(
 		`INSERT INTO route_channels
 			(route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-		 VALUES (?, ?, ?, 'gpt-4o', 0, 10, 1, 0)`,
+		 VALUES (?, ?, ?, 'gpt-4o', 0, 10, TRUE, FALSE)`,
 		routeID, accountID, tokenID,
 	); err != nil {
 		t.Fatalf("insert channel: %v", err)

--- a/handler/admin/contract_filters_test.go
+++ b/handler/admin/contract_filters_test.go
@@ -30,14 +30,10 @@ import (
 func seedDownstreamKeyFixture(t *testing.T, db *store.DB, name string, enabled bool) int64 {
 	t.Helper()
 	now := time.Now().UTC().Format(time.RFC3339)
-	enabledInt := 0
-	if enabled {
-		enabledInt = 1
-	}
 	res, err := db.Exec(
 		`INSERT INTO downstream_api_keys (name, key, enabled, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?)`,
-		name, "sk-test-"+name+"-secret-value", enabledInt, now, now,
+		name, "sk-test-"+name+"-secret-value", enabled, now, now,
 	)
 	if err != nil {
 		t.Fatalf("insert downstream key %s: %v", name, err)
@@ -60,7 +56,7 @@ func TestFilters_AccountTokens_AccountIDScopesList(t *testing.T) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	res, err := db.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
-		 VALUES (?, 'tokuser-b', 'sk-session-b', 'active', 1, ?, ?)`,
+		 VALUES (?, 'tokuser-b', 'sk-session-b', 'active', TRUE, ?, ?)`,
 		siteID, now, now,
 	)
 	if err != nil {

--- a/handler/admin/contract_pagination_bounds_test.go
+++ b/handler/admin/contract_pagination_bounds_test.go
@@ -156,7 +156,7 @@ func TestPaginationBounds_Channels_ExplicitPagingClampsAndCounts(t *testing.T) {
 		if _, err := db.Exec(
 			`INSERT INTO route_channels
 				(route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-			 VALUES (?, ?, ?, ?, 0, 10, 1, 0)`,
+			 VALUES (?, ?, ?, ?, 0, 10, TRUE, FALSE)`,
 			routeID, accountID, tokenID, "gpt-bound-"+itoa(int64(i)),
 		); err != nil {
 			t.Fatalf("insert channel %d: %v", i, err)

--- a/handler/admin/downstream_keys_test.go
+++ b/handler/admin/downstream_keys_test.go
@@ -139,7 +139,7 @@ func TestDownstreamKeysUpdatePartialPreservesPolicyFields(t *testing.T) {
 		(name, key, description, group_name, tags, enabled, expires_at, max_cost, used_cost, max_requests, used_requests,
 		 supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		 created_at, updated_at)
-		VALUES ('client-a', 'sk-client-a', 'desc', 'vip', '["alpha"]', 1, '2099-01-01T00:00:00Z',
+		VALUES ('client-a', 'sk-client-a', 'desc', 'vip', '["alpha"]', TRUE, '2099-01-01T00:00:00Z',
 		 12.5, 2.25, 99, 3, ?, ?, ?, ?, ?, ?, ?)`,
 		supportedModels, allowedRouteIds, siteWeightMultipliers, excludedSiteIds, excludedCredentialRefs, now, now,
 	)
@@ -991,7 +991,7 @@ func TestDownstreamKeysListUsage24hAggregatesProxyLogs(t *testing.T) {
 	insertKey := func(name, key string) int64 {
 		res, err := db.Exec(
 			`INSERT INTO downstream_api_keys (name, key, enabled, created_at, updated_at)
-			 VALUES (?, ?, 1, ?, ?)`,
+			 VALUES (?, ?, TRUE, ?, ?)`,
 			name, key, nowStr, nowStr,
 		)
 		if err != nil {

--- a/handler/admin/edge_cases_test.go
+++ b/handler/admin/edge_cases_test.go
@@ -457,7 +457,7 @@ func TestEdge_SQLiteConcurrentWrites_Accounts(t *testing.T) {
 			now := time.Now().UTC().Format(time.RFC3339)
 			_, err := db.Exec(
 				`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
-				 VALUES (?, ?, ?, 'active', 1, ?, ?)`,
+				 VALUES (?, ?, ?, 'active', TRUE, ?, ?)`,
 				siteID, "user-"+itoa(int64(gid)), "concurrent-token-"+itoa(int64(gid)), now, now,
 			)
 			if err != nil {
@@ -602,7 +602,7 @@ func TestEdge_NULLOptionalFieldsInAccount(t *testing.T) {
 		 balance_used, quota, unit_cost, value_score, status, is_pinned, sort_order,
 		 checkin_enabled, oauth_provider, oauth_account_key, oauth_project_id,
 		 extra_config, created_at, updated_at)
-		 VALUES (?, NULL, 'null-token', NULL, 0, 0, 0, NULL, 0, 'active', 0, 0, 1,
+		 VALUES (?, NULL, 'null-token', NULL, 0, 0, 0, NULL, 0, 'active', FALSE, 0, TRUE,
 		 NULL, NULL, NULL, NULL, ?, ?)`,
 		siteID, now, now,
 	)

--- a/handler/admin/events_write_regression_test.go
+++ b/handler/admin/events_write_regression_test.go
@@ -1,0 +1,55 @@
+package admin
+
+import (
+	"net/http"
+	"testing"
+)
+
+// Regression guards for the w18-pg-dialect incident class: event writers that
+// bound the INTEGER literal 0 to events.read. On SQLite (INTEGER column) the
+// row was written anyway, so these tests pass on both sides of the fix
+// locally; the PostgreSQL type-error proof lives in
+// store/boolean_bind_test.go (TestBooleanLiteralIntegerRejectedByPostgres),
+// and CI test-pg exercises the same statements against native BOOLEAN.
+// After the fix the writes use FALSE / Go-bool binds, which both dialects
+// accept, so these guards pin the observable behavior (event row exists)
+// rather than the dialect-specific failure mode.
+
+func TestAuthSettingsChange_SuccessWritesEventRow(t *testing.T) {
+	db, r, _ := setupAuthSettingsTest(t)
+
+	resp := doPostJSON(t, r, "/api/settings/auth/change", map[string]any{
+		"oldToken": "admin-auth-settings-token",
+		"newToken": "rotated-admin-token-events",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", resp.Code, resp.Body.String())
+	}
+
+	var n int
+	if err := db.Get(&n, "SELECT COUNT(*) FROM events WHERE type = 'token' AND related_type = 'settings'"); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("token-rotation events = %d, want 1 (event write must survive on both dialects)", n)
+	}
+}
+
+func TestSettingsRuntimeUpdate_WritesStatusEventRow(t *testing.T) {
+	db, r, _ := setupEdgeTest(t)
+
+	resp := doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+		"checkinIntervalHours": 8,
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("update runtime: %d %s", resp.Code, resp.Body.String())
+	}
+
+	var n int
+	if err := db.Get(&n, "SELECT COUNT(*) FROM events WHERE type = 'status' AND title = 'Runtime settings updated'"); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("runtime-settings events = %d, want 1 (event write must survive on both dialects)", n)
+	}
+}

--- a/handler/admin/model_price_compare_test.go
+++ b/handler/admin/model_price_compare_test.go
@@ -31,12 +31,12 @@ func TestStats_SQLiteModelPriceCompare_ObservedAndConfigured(t *testing.T) {
 	}
 
 	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, balance, unit_cost, checkin_enabled, created_at, updated_at)
-		VALUES (?, ?, ?, 'active', ?, NULL, 0, ?, ?)`, cheapSiteID, "cheap-user", "sk-cheap", 10.0, now, now)
+		VALUES (?, ?, ?, 'active', ?, NULL, FALSE, ?, ?)`, cheapSiteID, "cheap-user", "sk-cheap", 10.0, now, now)
 	if err != nil {
 		t.Fatalf("insert account1: %v", err)
 	}
 	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, balance, unit_cost, checkin_enabled, created_at, updated_at)
-		VALUES (?, ?, ?, 'active', ?, ?, 0, ?, ?)`, cfgSiteID, "cfg-user", "sk-cfg", 10.0, 0.55, now, now)
+		VALUES (?, ?, ?, 'active', ?, ?, FALSE, ?, ?)`, cfgSiteID, "cfg-user", "sk-cfg", 10.0, 0.55, now, now)
 	if err != nil {
 		t.Fatalf("insert account2: %v", err)
 	}
@@ -51,12 +51,12 @@ func TestStats_SQLiteModelPriceCompare_ObservedAndConfigured(t *testing.T) {
 
 	// Availability for both accounts.
 	_, err = db.Exec(`INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at)
-		VALUES (?, ?, 1, 0, ?)`, cheapAccID, "gpt-price-compare", now)
+		VALUES (?, ?, TRUE, FALSE, ?)`, cheapAccID, "gpt-price-compare", now)
 	if err != nil {
 		t.Fatalf("avail1: %v", err)
 	}
 	_, err = db.Exec(`INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at)
-		VALUES (?, ?, 1, 0, ?)`, cfgAccID, "gpt-price-compare", now)
+		VALUES (?, ?, TRUE, FALSE, ?)`, cfgAccID, "gpt-price-compare", now)
 	if err != nil {
 		t.Fatalf("avail2: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestStats_SQLiteModelPriceCompare_EmptyModelUsesTopTraffic(t *testing.T) {
 		t.Fatalf("site id: %v", err)
 	}
 	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, balance, checkin_enabled, created_at, updated_at)
-		VALUES (?, ?, ?, 'active', ?, 0, ?, ?)`, siteID, "top-user", "sk-top", 1.0, now, now)
+		VALUES (?, ?, ?, 'active', ?, FALSE, ?, ?)`, siteID, "top-user", "sk-top", 1.0, now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestStats_SQLiteModelPriceCompare_FallbackLabeledMissing(t *testing.T) {
 		t.Fatalf("site id: %v", err)
 	}
 	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, balance, checkin_enabled, created_at, updated_at)
-		VALUES (?, ?, ?, 'active', ?, 0, ?, ?)`, siteID, "empty-user", "sk-empty", 1.0, now, now)
+		VALUES (?, ?, ?, 'active', ?, FALSE, ?, ?)`, siteID, "empty-user", "sk-empty", 1.0, now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestStats_SQLiteModelPriceCompare_ExactModelExcludesFamilyMatches(t *testin
 		t.Fatalf("site id: %v", err)
 	}
 	_, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, balance, checkin_enabled, created_at, updated_at)
-		VALUES (?, ?, ?, 'active', ?, 0, ?, ?)`, siteID, "exact-user", "sk-exact", 1.0, now, now)
+		VALUES (?, ?, ?, 'active', ?, FALSE, ?, ?)`, siteID, "exact-user", "sk-exact", 1.0, now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}
@@ -248,7 +248,7 @@ func TestStats_SQLiteModelPriceCompare_ExactModelExcludesFamilyMatches(t *testin
 	}
 	for _, model := range []string{"gpt-4o", "gpt-4o-mini"} {
 		_, err = db.Exec(`INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at)
-			VALUES (?, ?, 1, 0, ?)`, accountID, model, now)
+			VALUES (?, ?, TRUE, FALSE, ?)`, accountID, model, now)
 		if err != nil {
 			t.Fatalf("insert availability %q: %v", model, err)
 		}

--- a/handler/admin/model_rates_test.go
+++ b/handler/admin/model_rates_test.go
@@ -25,14 +25,14 @@ func TestModelRates_AggregatesAllSurfaces(t *testing.T) {
 	siteID, _ := res.LastInsertId()
 
 	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, api_token, status, unit_cost, checkin_enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, 'active', 0.0042, 0, ?, ?)`, siteID, "rate-user", "sess", "sk-rate", now, now)
+		VALUES (?, ?, ?, ?, 'active', 0.0042, FALSE, ?, ?)`, siteID, "rate-user", "sess", "sk-rate", now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}
 	accountID, _ := res.LastInsertId()
 
 	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
-		VALUES (?, ?, 'standard', 'weighted', 1, ?, ?)`, "gpt-4o", "Rate Route", now, now)
+		VALUES (?, ?, 'standard', 'weighted', TRUE, ?, ?)`, "gpt-4o", "Rate Route", now, now)
 	if err != nil {
 		t.Fatalf("insert route: %v", err)
 	}

--- a/handler/admin/model_redirects.go
+++ b/handler/admin/model_redirects.go
@@ -274,7 +274,7 @@ func recordRedirectEvent(db *sqlx.DB, c service.RedirectFixCandidate) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	_, err := db.Exec(rebindAdminQuery(db, `
 		INSERT INTO events (type, title, message, level, related_id, related_type, created_at, read)
-		VALUES ('model_redirect_applied', ?, ?, 'info', ?, 'site', ?, 0)`),
+		VALUES ('model_redirect_applied', ?, ?, 'info', ?, 'site', ?, FALSE)`),
 		"Disabled model repaired (mapping auto-restored)",
 		"Disabled model "+c.ModelName+" on site "+c.SiteName+" was restored via mapping "+c.Canonical+" → "+c.Actual+".",
 		c.SiteID, now)

--- a/handler/admin/model_redirects_test.go
+++ b/handler/admin/model_redirects_test.go
@@ -24,7 +24,7 @@ func setupRedirectTest(t *testing.T) (*store.DB, chi.Router, int64, int64) {
 	}
 	siteID, _ := res.LastInsertId()
 	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, 'active', 0, ?, ?)`, siteID, "redirect-user", "sess", "sk-redirect", now, now)
+		VALUES (?, ?, ?, ?, 'active', FALSE, ?, ?)`, siteID, "redirect-user", "sess", "sk-redirect", now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}
@@ -34,11 +34,11 @@ func setupRedirectTest(t *testing.T) (*store.DB, chi.Router, int64, int64) {
 	_, _ = db.Exec(`INSERT INTO settings (key, value) VALUES ('global_allowed_models', ?)`,
 		`["claude-3-5-sonnet","claude-3-5-haiku","gpt-4o"]`)
 	_, _ = db.Exec(`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
-		VALUES (?, ?, 'standard', 'weighted', 1, ?, ?)`, "claude-3-5-sonnet", "Sonnet Route", now, now)
+		VALUES (?, ?, 'standard', 'weighted', TRUE, ?, ?)`, "claude-3-5-sonnet", "Sonnet Route", now, now)
 
 	// Available actual models (date-suffixed names).
 	_, _ = db.Exec(`INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at)
-		VALUES (?, ?, 1, 0, ?)`, accountID, "claude-3-5-sonnet-20241022", now)
+		VALUES (?, ?, TRUE, FALSE, ?)`, accountID, "claude-3-5-sonnet-20241022", now)
 
 	r := chi.NewRouter()
 	RegisterModelRedirectRoutes(r, db.DB)
@@ -175,7 +175,7 @@ func TestRedirects_GenerationRules(t *testing.T) {
 		"CLAUDE-3-5-SONNET-20250101",    // case-folded date suffix
 	} {
 		_, err := db.Exec(`INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at)
-			VALUES (?, ?, 1, 0, ?)`, accountID, m, now)
+			VALUES (?, ?, TRUE, FALSE, ?)`, accountID, m, now)
 		if err != nil {
 			t.Fatalf("insert availability %s: %v", m, err)
 		}

--- a/handler/admin/model_refresh_test.go
+++ b/handler/admin/model_refresh_test.go
@@ -34,7 +34,7 @@ func seedAccountAndToken(t *testing.T, db *sqlx.DB, tokenValue string) (accountI
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	res, err := db.Exec(
 		`INSERT INTO sites (name, url, platform, status, use_system_proxy, sort_order, global_weight, post_refresh_probe_enabled, created_at, updated_at)
-		 VALUES (?, ?, 'openai', 'active', 0, 0, 0, 0, ?, ?)`,
+		 VALUES (?, ?, 'openai', 'active', FALSE, 0, 0, FALSE, ?, ?)`,
 		"TokenBackfillSite", "https://api.example.com", now, now,
 	)
 	if err != nil {
@@ -44,7 +44,7 @@ func seedAccountAndToken(t *testing.T, db *sqlx.DB, tokenValue string) (accountI
 
 	accRes, err := db.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, sort_order, created_at, updated_at)
-		 VALUES (?, 'tester', ?, 'active', 1, 0, ?, ?)`,
+		 VALUES (?, 'tester', ?, 'active', TRUE, 0, ?, ?)`,
 		siteID, tokenValue, now, now,
 	)
 	if err != nil {
@@ -54,7 +54,7 @@ func seedAccountAndToken(t *testing.T, db *sqlx.DB, tokenValue string) (accountI
 
 	tokRes, err := db.Exec(
 		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
-		 VALUES (?, 'default', ?, 'ready', 'manual', 1, 1, ?, ?)`,
+		 VALUES (?, 'default', ?, 'ready', 'manual', TRUE, TRUE, ?, ?)`,
 		accountID, tokenValue, now, now,
 	)
 	if err != nil {
@@ -102,7 +102,7 @@ func TestRefreshAccountModels_TokenBackfillEndToEnd(t *testing.T) {
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	res, err := dbConn.Exec(
 		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
-		 VALUES (?, 'default', 'sk-backfill-token', 'ready', 'manual', 1, 1, ?, ?)`,
+		 VALUES (?, 'default', 'sk-backfill-token', 'ready', 'manual', TRUE, TRUE, ?, ?)`,
 		accountID, now, now,
 	)
 	if err != nil {
@@ -122,7 +122,7 @@ func TestRefreshAccountModels_TokenBackfillEndToEnd(t *testing.T) {
 	// Verify token_model_availability rows were written.
 	var availCount int
 	if err := dbConn.Get(&availCount,
-		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = 1`,
+		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = TRUE`,
 		tokenID,
 	); err != nil {
 		t.Fatalf("count token models: %v", err)
@@ -134,7 +134,7 @@ func TestRefreshAccountModels_TokenBackfillEndToEnd(t *testing.T) {
 	// Also verify account-level model_availability was written.
 	var accountModelCount int
 	if err := dbConn.Get(&accountModelCount,
-		`SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND available = 1`,
+		`SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND available = TRUE`,
 		accountID,
 	); err != nil {
 		t.Fatalf("count account models: %v", err)
@@ -188,7 +188,7 @@ func TestRefreshAccountModels_TokenBackfillSkipsWhenNoTokenMatch(t *testing.T) {
 	// Account-level should still be written.
 	var accountModelCount int
 	if err := dbConn.Get(&accountModelCount,
-		`SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND available = 1`,
+		`SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND available = TRUE`,
 		accountID,
 	); err != nil {
 		t.Fatalf("count account models: %v", err)

--- a/handler/admin/models_verify_test.go
+++ b/handler/admin/models_verify_test.go
@@ -46,14 +46,14 @@ func setupVerifyHarness(t *testing.T) (chi.Router, *store.DB, int64) {
 	siteID, _ := res.LastInsertId()
 
 	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, 'active', 0, ?, ?)`, siteID, "verify-user", "sess", "sk-verify", now, now)
+		VALUES (?, ?, ?, ?, 'active', FALSE, ?, ?)`, siteID, "verify-user", "sess", "sk-verify", now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}
 	accountID, _ := res.LastInsertId()
 
 	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
-		VALUES (?, ?, 'standard', 'weighted', 1, ?, ?)`, "verify-*", "Verify Route", now, now)
+		VALUES (?, ?, 'standard', 'weighted', TRUE, ?, ?)`, "verify-*", "Verify Route", now, now)
 	if err != nil {
 		t.Fatalf("insert route: %v", err)
 	}
@@ -62,7 +62,7 @@ func setupVerifyHarness(t *testing.T) (chi.Router, *store.DB, int64) {
 	// Two channels with different models on the same account.
 	for _, m := range []string{"verify-model-a", "verify-model-b"} {
 		_, err = db.Exec(`INSERT INTO route_channels (route_id, account_id, source_model, priority, weight, enabled)
-			VALUES (?, ?, ?, 10, 10, 1)`, routeID, accountID, m)
+			VALUES (?, ?, ?, 10, 10, TRUE)`, routeID, accountID, m)
 		if err != nil {
 			t.Fatalf("insert channel %s: %v", m, err)
 		}

--- a/handler/admin/oauth_routes_crud_test.go
+++ b/handler/admin/oauth_routes_crud_test.go
@@ -51,7 +51,7 @@ func insertOAuthAccountUnique(t *testing.T, db *store.DB, provider, suffix strin
 	siteURL := "https://chatgpt.com/backend-api/" + suffix
 	res, err := db.Exec(
 		`INSERT INTO sites (name, url, platform, status, use_system_proxy, is_pinned, global_weight, sort_order, created_at, updated_at)
-		 VALUES (?, ?, ?, 'active', 0, 0, 1, 0, ?, ?)`,
+		 VALUES (?, ?, ?, 'active', FALSE, FALSE, 1, 0, ?, ?)`,
 		"Codex OAuth Test "+suffix, siteURL, provider, now, now,
 	)
 	if err != nil {
@@ -67,7 +67,7 @@ func insertOAuthAccountUnique(t *testing.T, db *store.DB, provider, suffix strin
 	extra := `{"oauth":{"provider":"` + provider + `","accountId":"` + accountKey + `","accountKey":"` + accountKey + `","email":"` + email + `","refreshToken":"rt-test"}}`
 	res, err = db.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, checkin_enabled, status, oauth_provider, oauth_account_key, extra_config, is_pinned, sort_order, balance, balance_used, quota, value_score, created_at, updated_at)
-		 VALUES (?, ?, ?, 0, 'active', ?, ?, ?, 0, 0, 0, 0, 0, 0, ?, ?)`,
+		 VALUES (?, ?, ?, FALSE, 'active', ?, ?, ?, FALSE, 0, 0, 0, 0, 0, ?, ?)`,
 		siteID, email, "at-test", provider, accountKey, extra, now, now,
 	)
 	if err != nil {

--- a/handler/admin/oauth_routes_test.go
+++ b/handler/admin/oauth_routes_test.go
@@ -59,7 +59,7 @@ func insertOAuthAccount(t *testing.T, db *store.DB, provider string) int64 {
 	now := time.Now().UTC().Format(time.RFC3339)
 	res, err := db.Exec(
 		`INSERT INTO sites (name, url, platform, status, use_system_proxy, is_pinned, global_weight, sort_order, created_at, updated_at)
-		 VALUES (?, ?, ?, 'active', 0, 0, 1, 0, ?, ?)`,
+		 VALUES (?, ?, ?, 'active', FALSE, FALSE, 1, 0, ?, ?)`,
 		"Codex OAuth Test", "https://chatgpt.com/backend-api", provider, now, now,
 	)
 	if err != nil {
@@ -73,7 +73,7 @@ func insertOAuthAccount(t *testing.T, db *store.DB, provider string) int64 {
 	extra := `{"oauth":{"provider":"` + provider + `","accountId":"acc-1","accountKey":"acc-1","email":"user@example.com","refreshToken":"rt-test"}}`
 	res, err = db.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, checkin_enabled, status, oauth_provider, oauth_account_key, extra_config, is_pinned, sort_order, balance, balance_used, quota, value_score, created_at, updated_at)
-		 VALUES (?, ?, ?, 0, 'active', ?, ?, ?, 0, 0, 0, 0, 0, 0, ?, ?)`,
+		 VALUES (?, ?, ?, FALSE, 'active', ?, ?, ?, FALSE, 0, 0, 0, 0, 0, ?, ?)`,
 		siteID, "user@example.com", "at-test", provider, "acc-1", extra, now, now,
 	)
 	if err != nil {

--- a/handler/admin/probe_history_test.go
+++ b/handler/admin/probe_history_test.go
@@ -49,7 +49,7 @@ func seedProbeHistoryFixtures(t *testing.T, db *store.DB) (account1, account2, c
 
 	insertAccount := func(username string) int64 {
 		res, err := db.Exec(`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
-			VALUES (?, ?, 'session-token', 'sk-probe-api-token', 'active', 0, ?, ?)`, siteID, username, now, now)
+			VALUES (?, ?, 'session-token', 'sk-probe-api-token', 'active', FALSE, ?, ?)`, siteID, username, now, now)
 		if err != nil {
 			t.Fatalf("insert account: %v", err)
 		}
@@ -60,7 +60,7 @@ func seedProbeHistoryFixtures(t *testing.T, db *store.DB) (account1, account2, c
 	account2 = insertAccount("probe-user-2")
 
 	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
-		VALUES ('gpt-*', 'Probe Route', 'standard', 'weighted', 1, ?, ?)`, now, now)
+		VALUES ('gpt-*', 'Probe Route', 'standard', 'weighted', TRUE, ?, ?)`, now, now)
 	if err != nil {
 		t.Fatalf("insert route: %v", err)
 	}
@@ -68,7 +68,7 @@ func seedProbeHistoryFixtures(t *testing.T, db *store.DB) (account1, account2, c
 
 	insertChannel := func(accountID int64, model string) int64 {
 		res, err := db.Exec(`INSERT INTO route_channels (route_id, account_id, source_model, priority, weight, enabled)
-			VALUES (?, ?, ?, 10, 10, 1)`, routeID, accountID, model)
+			VALUES (?, ?, ?, 10, 10, TRUE)`, routeID, accountID, model)
 		if err != nil {
 			t.Fatalf("insert channel: %v", err)
 		}

--- a/handler/admin/scheduler_status_recent_runs_test.go
+++ b/handler/admin/scheduler_status_recent_runs_test.go
@@ -45,19 +45,19 @@ func TestSchedulerStatusModelProbeRecentRuns(t *testing.T) {
 	}
 	siteID, _ := res.LastInsertId()
 	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
-		VALUES (?, 'p-user', 'tok', 'active', 1, ?, ?)`, siteID, now, now)
+		VALUES (?, 'p-user', 'tok', 'active', TRUE, ?, ?)`, siteID, now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}
 	accountID, _ := res.LastInsertId()
 	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
-		VALUES ('all', 'pattern', 'weighted', 1, ?, ?)`, now, now)
+		VALUES ('all', 'pattern', 'weighted', TRUE, ?, ?)`, now, now)
 	if err != nil {
 		t.Fatalf("insert route: %v", err)
 	}
 	routeID, _ := res.LastInsertId()
 	_, err = db.Exec(`INSERT INTO route_channels (route_id, account_id, source_model, priority, weight, enabled, cooldown_until)
-		VALUES (?, ?, 'gpt-4o', 0, 10, 1, NULL)`, routeID, accountID)
+		VALUES (?, ?, 'gpt-4o', 0, 10, TRUE, NULL)`, routeID, accountID)
 	if err != nil {
 		t.Fatalf("insert channel: %v", err)
 	}

--- a/handler/admin/search.go
+++ b/handler/admin/search.go
@@ -89,12 +89,15 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 		perCategory = 10
 	}
 
-	likePattern := "%" + q + "%"
+	// SQLite LIKE is case-insensitive for ASCII but PostgreSQL LIKE is
+	// case-sensitive; normalize both sides with LOWER() so the same query
+	// matches the same rows on both dialects (w18-pg-dialect).
+	likePattern := "%" + strings.ToLower(q) + "%"
 
 	// Search sites. Each query surfaces its error so a DB failure yields an
 	// explicit HTTP 500 instead of an empty 200 (silent swallows from the old
 	// queryRows helper masked real outages as "no results").
-	sites, err := queryRowsErr(h.db, "SELECT "+service.SiteSelectColumns+" FROM sites WHERE name LIKE ? OR url LIKE ? OR platform LIKE ? LIMIT ?",
+	sites, err := queryRowsErr(h.db, "SELECT "+service.SiteSelectColumns+" FROM sites WHERE LOWER(name) LIKE ? OR LOWER(url) LIKE ? OR LOWER(platform) LIKE ? LIMIT ?",
 		likePattern, likePattern, likePattern, perCategory)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "search query failed")
@@ -111,7 +114,7 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 			credentialFragmentsSelect(h.db, "a.api_token", "api_token")+`,
 			s.name as site_name, s.platform as site_platform
 		 FROM accounts a INNER JOIN sites s ON a.site_id = s.id
-		 WHERE a.username LIKE ? OR s.name LIKE ? OR s.platform LIKE ?
+		 WHERE LOWER(a.username) LIKE ? OR LOWER(s.name) LIKE ? OR LOWER(s.platform) LIKE ?
 		 LIMIT ?`,
 		likePattern, likePattern, likePattern, perCategory)
 	if err != nil {
@@ -127,7 +130,7 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 		 FROM account_tokens at
 		 INNER JOIN accounts a ON at.account_id = a.id
 		 INNER JOIN sites s ON a.site_id = s.id
-		 WHERE at.name LIKE ? OR coalesce(at.token_group,'') LIKE ? OR a.username LIKE ? OR s.name LIKE ?
+		 WHERE LOWER(at.name) LIKE ? OR LOWER(coalesce(at.token_group,'')) LIKE ? OR LOWER(a.username) LIKE ? OR LOWER(s.name) LIKE ?
 		 ORDER BY at.updated_at DESC LIMIT ?`,
 		likePattern, likePattern, likePattern, likePattern, perCategory)
 	if err != nil {
@@ -140,7 +143,7 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 		`SELECT cl.*, a.username as account_username
 		 FROM checkin_logs cl
 		 INNER JOIN accounts a ON cl.account_id = a.id
-		 WHERE coalesce(cl.message,'') LIKE ?
+		 WHERE LOWER(coalesce(cl.message,'')) LIKE ?
 		 ORDER BY cl.created_at DESC LIMIT ?`,
 		likePattern, perCategory)
 	if err != nil {
@@ -150,7 +153,7 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 
 	// Search proxy logs
 	proxyLogs, err := queryRowsErr(h.db,
-		"SELECT * FROM proxy_logs WHERE coalesce(model_requested,'') LIKE ? ORDER BY created_at DESC LIMIT ?",
+		"SELECT * FROM proxy_logs WHERE LOWER(coalesce(model_requested,'')) LIKE ? ORDER BY created_at DESC LIMIT ?",
 		likePattern, perCategory)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "search query failed")
@@ -165,7 +168,7 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 		 INNER JOIN account_tokens at ON tma.token_id = at.id
 		 INNER JOIN accounts a ON at.account_id = a.id
 		 INNER JOIN sites s ON a.site_id = s.id
-		 WHERE tma.model_name LIKE ? AND tma.available = TRUE AND at.enabled = TRUE AND a.status = 'active'
+		 WHERE LOWER(tma.model_name) LIKE ? AND tma.available = TRUE AND at.enabled = TRUE AND a.status = 'active'
 		 GROUP BY tma.model_name
 		 ORDER BY account_count DESC LIMIT ?`,
 		likePattern, perCategory)

--- a/handler/admin/search_case_test.go
+++ b/handler/admin/search_case_test.go
@@ -1,0 +1,74 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// TestSearch_MixedCaseQueryMatchesMixedCaseRows guards the w18-pg-dialect
+// LIKE divergence fix: SQLite LIKE is case-insensitive for ASCII while
+// PostgreSQL LIKE is case-sensitive, so the shared search filters normalize
+// both sides with LOWER(). On SQLite this test passes before and after the
+// fix; the PostgreSQL half of the divergence is proven in
+// store/like_case_test.go, and CI test-pg re-runs the store suite against a
+// real server.
+func TestSearch_MixedCaseQueryMatchesMixedCaseRows(t *testing.T) {
+	globalChannelsCache.clear()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	r := chi.NewRouter()
+	RegisterSearchRoutes(r, db.DB)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := db.Exec(
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		 VALUES ('OpenAI SearchCaseProbe', 'https://searchcaseprobe.example.com', 'openai', 'active', ?, ?)`, now, now)
+	if err != nil {
+		t.Fatalf("insert site: %v", err)
+	}
+	siteID, _ := res.LastInsertId()
+
+	res, err = db.Exec(
+		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
+		 VALUES (?, 'SearchCaseProbeUser', 'sk-searchcaseprobe', 'active', TRUE, ?, ?)`,
+		siteID, now, now)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, _ := res.LastInsertId()
+
+	if _, err := db.Exec(
+		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
+		 VALUES (?, 'SearchCaseProbeToken', 'tok-searchcaseprobe', 'active', 'manual', TRUE, FALSE, ?, ?)`,
+		accountID, now, now); err != nil {
+		t.Fatalf("insert account token: %v", err)
+	}
+
+	// Lowercase query must match mixed-case site name, username and token
+	// name on BOTH dialects (the pre-fix PG behavior returned zero hits).
+	rec := doPostJSON(t, r, "/api/search", map[string]any{"query": "searchcaseprobe", "limit": 10})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, key := range []string{"sites", "accounts", "accountTokens"} {
+		items, _ := resp[key].([]any)
+		if len(items) == 0 {
+			t.Fatalf("search %q returned no %s hits; body=%s", "searchcaseprobe", key, rec.Body.String())
+		}
+	}
+}

--- a/handler/admin/settings.go
+++ b/handler/admin/settings.go
@@ -449,8 +449,10 @@ func stringSliceOrEmpty(in []string) []string {
 }
 
 func logSettingsEvent(db *sqlx.DB, eventType, title, message, level, createdAt string) {
+	// read is a BOOLEAN column on PostgreSQL: bind FALSE, not the integer
+	// literal 0 (w18-pg-dialect: PG rejects integer literals for booleans).
 	query := db.Rebind(`INSERT INTO events (type, title, message, level, related_type, created_at, "read")
-		VALUES (?, ?, ?, ?, 'settings', ?, 0)`)
+		VALUES (?, ?, ?, ?, 'settings', ?, FALSE)`)
 	if _, err := db.Exec(query, eventType, title, message, level, createdAt); err != nil {
 		slog.Warn("settings: failed to log settings event", "type", eventType, "error", err)
 	}

--- a/handler/admin/settings_maintenance_test.go
+++ b/handler/admin/settings_maintenance_test.go
@@ -47,7 +47,7 @@ func TestMaintenanceClearCache_RealInvalidationAndRealJob(t *testing.T) {
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	if _, err := db.Exec(`INSERT INTO token_routes (model_pattern, enabled, created_at, updated_at)
-		VALUES ('gpt-*', 1, ?, ?)`, now, now); err != nil {
+		VALUES ('gpt-*', TRUE, ?, ?)`, now, now); err != nil {
 		t.Fatalf("seed token_routes: %v", err)
 	}
 

--- a/handler/admin/sites_test.go
+++ b/handler/admin/sites_test.go
@@ -504,8 +504,8 @@ func TestSites_DeleteCascade(t *testing.T) {
 
 	// Create accounts under this site
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
-	db.Exec("INSERT INTO accounts (site_id, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'sk1', 'active', 1, ?, ?)", siteID, now, now)
-	db.Exec("INSERT INTO accounts (site_id, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'sk2', 'active', 1, ?, ?)", siteID, now, now)
+	db.Exec("INSERT INTO accounts (site_id, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'sk1', 'active', TRUE, ?, ?)", siteID, now, now)
+	db.Exec("INSERT INTO accounts (site_id, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'sk2', 'active', TRUE, ?, ?)", siteID, now, now)
 
 	// Delete site
 	resp := doDelete(t, r, "/api/sites/"+itoa(siteID))
@@ -680,13 +680,13 @@ func TestSites_AvailableModels_WithData(t *testing.T) {
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 
 	// Create an account
-	res, _ := db.Exec("INSERT INTO accounts (site_id, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'sk1', 'active', 1, ?, ?)", siteID, now, now)
+	res, _ := db.Exec("INSERT INTO accounts (site_id, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'sk1', 'active', TRUE, ?, ?)", siteID, now, now)
 	accountID, _ := res.LastInsertId()
 
 	// Add model availability
-	db.Exec("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, ?, 1, 0, ?)", accountID, "gpt-4", now)
-	db.Exec("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, ?, 1, 0, ?)", accountID, "gpt-3.5-turbo", now)
-	db.Exec("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, ?, 0, 0, ?)", accountID, "unavailable-model", now)
+	db.Exec("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, ?, TRUE, FALSE, ?)", accountID, "gpt-4", now)
+	db.Exec("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, ?, TRUE, FALSE, ?)", accountID, "gpt-3.5-turbo", now)
+	db.Exec("INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at) VALUES (?, ?, FALSE, FALSE, ?)", accountID, "unavailable-model", now)
 
 	resp := doGet(t, r, "/api/sites/"+itoa(siteID)+"/available-models")
 	if resp.Code != http.StatusOK {
@@ -895,7 +895,7 @@ func TestSites_StatusSideEffects_Disable(t *testing.T) {
 	siteID := int64(site["id"].(float64))
 
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
-	db.Exec("INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'acc1', 'sk1', 'active', 1, ?, ?)", siteID, now, now)
+	db.Exec("INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'acc1', 'sk1', 'active', TRUE, ?, ?)", siteID, now, now)
 
 	// Disable site via update
 	body := map[string]any{"status": "disabled"}
@@ -925,7 +925,7 @@ func TestSites_StatusSideEffects_Enable(t *testing.T) {
 	siteID := int64(site["id"].(float64))
 
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
-	db.Exec("INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'acc1', 'sk1', 'disabled', 1, ?, ?)", siteID, now, now)
+	db.Exec("INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'acc1', 'sk1', 'disabled', TRUE, ?, ?)", siteID, now, now)
 
 	// Enable site via update
 	body := map[string]any{"status": "active"}
@@ -957,7 +957,7 @@ func TestSites_BatchDisable_WithStatusSideEffects(t *testing.T) {
 	siteID := int64(site["id"].(float64))
 
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
-	db.Exec("INSERT INTO accounts (site_id, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'sk1', 'active', 1, ?, ?)", siteID, now, now)
+	db.Exec("INSERT INTO accounts (site_id, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, 'sk1', 'active', TRUE, ?, ?)", siteID, now, now)
 
 	body := map[string]any{"ids": []int{int(siteID)}, "action": "disable"}
 	resp := doPostJSON(t, r, "/api/sites/batch", body)

--- a/handler/admin/stats_test.go
+++ b/handler/admin/stats_test.go
@@ -609,7 +609,7 @@ func TestStats_SQLiteAttentionAggregatesExpiredLowBalanceDisabled(t *testing.T) 
 	}
 	// recent warning event
 	_, err = db.Exec(`INSERT INTO events (type, title, message, level, read, created_at)
-		VALUES (?, ?, ?, 'warning', 0, ?)`, "balance", "余额不足", "x", nowStr)
+		VALUES (?, ?, ?, 'warning', FALSE, ?)`, "balance", "余额不足", "x", nowStr)
 	if err != nil {
 		t.Fatalf("insert event: %v", err)
 	}
@@ -690,12 +690,12 @@ func TestStats_SQLiteAttentionUsesAnnouncementAndEventReadOwners(t *testing.T) {
 	// second attention item or compete with site_announcements.read_at.
 	_, err = db.Exec(`INSERT INTO events
 		(type, title, message, level, read, related_id, related_type, created_at)
-		VALUES ('site_notice', 'Maintenance window', 'details', 'warning', 0, ?, 'site_announcement', ?)`, announcementID, nowStr)
+		VALUES ('site_notice', 'Maintenance window', 'details', 'warning', FALSE, ?, 'site_announcement', ?)`, announcementID, nowStr)
 	if err != nil {
 		t.Fatalf("insert announcement event: %v", err)
 	}
 	_, err = db.Exec(`INSERT INTO events (type, title, message, level, read, created_at)
-		VALUES ('runtime', 'Upstream rate limited', 'details', 'warning', 0, ?)`, nowStr)
+		VALUES ('runtime', 'Upstream rate limited', 'details', 'warning', FALSE, ?)`, nowStr)
 	if err != nil {
 		t.Fatalf("insert unread event: %v", err)
 	}
@@ -704,7 +704,7 @@ func TestStats_SQLiteAttentionUsesAnnouncementAndEventReadOwners(t *testing.T) {
 		t.Fatalf("event id: %v", err)
 	}
 	_, err = db.Exec(`INSERT INTO events (type, title, message, level, read, created_at)
-		VALUES ('runtime', 'Already read', 'details', 'warning', 1, ?)`, nowStr)
+		VALUES ('runtime', 'Already read', 'details', 'warning', TRUE, ?)`, nowStr)
 	if err != nil {
 		t.Fatalf("insert read event: %v", err)
 	}
@@ -755,7 +755,7 @@ func TestStats_SQLiteAttentionUsesAnnouncementAndEventReadOwners(t *testing.T) {
 	if _, err := db.Exec("UPDATE site_announcements SET read_at = ? WHERE id = ?", nowStr, announcementID); err != nil {
 		t.Fatalf("mark announcement read: %v", err)
 	}
-	if _, err := db.Exec("UPDATE events SET read = 1 WHERE id = ?", eventID); err != nil {
+	if _, err := db.Exec("UPDATE events SET read = TRUE WHERE id = ?", eventID); err != nil {
 		t.Fatalf("mark event read: %v", err)
 	}
 	for _, raw := range readAttention() {
@@ -1116,7 +1116,7 @@ func seedModelsSurfacesFixture(t *testing.T, db *store.DB) (siteID, accountWithT
 	}
 
 	_, err = db.Exec(`INSERT INTO account_tokens (account_id, name, token, token_group, value_status, source, enabled, is_default, created_at, updated_at)
-		VALUES (?, ?, ?, NULL, 'ready', 'manual', 1, 1, ?, ?)`, accountWithToken, "default", "sk-ms-default", now, now)
+		VALUES (?, ?, ?, NULL, 'ready', 'manual', TRUE, TRUE, ?, ?)`, accountWithToken, "default", "sk-ms-default", now, now)
 	if err != nil {
 		t.Fatalf("insert account token: %v", err)
 	}
@@ -1126,28 +1126,28 @@ func seedModelsSurfacesFixture(t *testing.T, db *store.DB) (siteID, accountWithT
 
 	// Token-scoped availability for gpt-4o.
 	_, err = db.Exec(`INSERT INTO token_model_availability (token_id, model_name, available, latency_ms, checked_at)
-		VALUES (?, ?, 1, ?, ?)`, tokenID, "gpt-4o", 320, now)
+		VALUES (?, ?, TRUE, ?, ?)`, tokenID, "gpt-4o", 320, now)
 	if err != nil {
 		t.Fatalf("insert token model availability: %v", err)
 	}
 
 	// Account-level availability on bare account (no managed tokens).
 	_, err = db.Exec(`INSERT INTO model_availability (account_id, model_name, available, is_manual, latency_ms, checked_at)
-		VALUES (?, ?, 1, 0, ?, ?)`, accountWithoutToken, "claude-3-5-sonnet", 410, now)
+		VALUES (?, ?, TRUE, FALSE, ?, ?)`, accountWithoutToken, "claude-3-5-sonnet", 410, now)
 	if err != nil {
 		t.Fatalf("insert bare model availability: %v", err)
 	}
 
 	// Account-level availability on token account whose tokens lack group labels.
 	_, err = db.Exec(`INSERT INTO model_availability (account_id, model_name, available, is_manual, latency_ms, checked_at)
-		VALUES (?, ?, 1, 0, ?, ?)`, accountWithToken, "gpt-4o-mini", 280, now)
+		VALUES (?, ?, TRUE, FALSE, ?, ?)`, accountWithToken, "gpt-4o-mini", 280, now)
 	if err != nil {
 		t.Fatalf("insert grouped model availability: %v", err)
 	}
 
 	// Exact route so marketplace still lists a route-only model name.
 	_, err = db.Exec(`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
-		VALUES ('route-only-model', 'exact', 'weighted', 1, ?, ?)`, now, now)
+		VALUES ('route-only-model', 'exact', 'weighted', TRUE, ?, ?)`, now, now)
 	if err != nil {
 		t.Fatalf("insert exact route: %v", err)
 	}

--- a/handler/admin/tags_test.go
+++ b/handler/admin/tags_test.go
@@ -24,7 +24,7 @@ func setupTagsTest(t *testing.T) (*store.DB, chi.Router, int64, int64) {
 	siteID, _ := res.LastInsertId()
 
 	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, 'active', 0, ?, ?)`, siteID, "tag-user", "sess", "sk-tag", now, now)
+		VALUES (?, ?, ?, ?, 'active', FALSE, ?, ?)`, siteID, "tag-user", "sess", "sk-tag", now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -95,7 +95,7 @@ func TestTokenRoutes_Rebuild_InvalidatesCacheTruthfully(t *testing.T) {
 	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		 VALUES (?, 'gpt-4o', TRUE, ?)`, tokenID, now); err != nil {
 		t.Fatalf("seed availability: %v", err)
 	}
 	// Ensure pattern route exists (seed creates gpt-*)
@@ -316,7 +316,7 @@ func TestTokenRoutes_ManualChannelSurvivesRebuild(t *testing.T) {
 	// Availability for a different model so rebuild still has auto work to do.
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		 VALUES (?, 'gpt-4o', TRUE, ?)`, tokenID, now); err != nil {
 		t.Fatalf("seed availability: %v", err)
 	}
 
@@ -349,7 +349,7 @@ func TestTokenRoutes_ManualChannelSurvivesRebuild(t *testing.T) {
 	var manualCount int
 	if err := db.Get(&manualCount,
 		`SELECT COUNT(*) FROM route_channels
-		 WHERE id = ? AND source_model = 'Qwen/Qwen3-Embedding-8B' AND manual_override = 1
+		 WHERE id = ? AND source_model = 'Qwen/Qwen3-Embedding-8B' AND manual_override = TRUE
 		   AND priority = 7 AND weight = 3`, channelID); err != nil {
 		t.Fatalf("count manual: %v", err)
 	}
@@ -576,7 +576,7 @@ func TestTokenRoutes_PartialUpdatePreservesModelMapping(t *testing.T) {
 	// Manual channel still present.
 	var manualCount int
 	if err := db.Get(&manualCount,
-		`SELECT COUNT(*) FROM route_channels WHERE route_id = ? AND source_model = 'manual-model-x' AND manual_override = 1`,
+		`SELECT COUNT(*) FROM route_channels WHERE route_id = ? AND source_model = 'manual-model-x' AND manual_override = TRUE`,
 		routeID); err != nil {
 		t.Fatalf("count manual: %v", err)
 	}
@@ -966,25 +966,25 @@ func TestRouteDecision_WithSQLiteRouterFixture(t *testing.T) {
 	}
 	siteID, _ := siteRes.LastInsertId()
 	accRes, err := db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
-		VALUES (?, 'dec-user', 'sk-dec', 'active', 1, ?, ?)`, siteID, now, now)
+		VALUES (?, 'dec-user', 'sk-dec', 'active', TRUE, ?, ?)`, siteID, now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}
 	accountID, _ := accRes.LastInsertId()
 	tokRes, err := db.Exec(`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
-		VALUES (?, 'dec-token', 'sk-dec-token', 'ready', 'manual', 1, 1, ?, ?)`, accountID, now, now)
+		VALUES (?, 'dec-token', 'sk-dec-token', 'ready', 'manual', TRUE, TRUE, ?, ?)`, accountID, now, now)
 	if err != nil {
 		t.Fatalf("insert token: %v", err)
 	}
 	tokenID, _ := tokRes.LastInsertId()
 	routeRes, err := db.Exec(`INSERT INTO token_routes (model_pattern, routing_strategy, enabled, created_at, updated_at)
-		VALUES ('gpt-4o', 'weighted', 1, ?, ?)`, now, now)
+		VALUES ('gpt-4o', 'weighted', TRUE, ?, ?)`, now, now)
 	if err != nil {
 		t.Fatalf("insert route: %v", err)
 	}
 	routeID, _ := routeRes.LastInsertId()
 	if _, err := db.Exec(`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-		VALUES (?, ?, ?, 'gpt-4o', 0, 10, 1, 0)`, routeID, accountID, tokenID); err != nil {
+		VALUES (?, ?, ?, 'gpt-4o', 0, 10, TRUE, FALSE)`, routeID, accountID, tokenID); err != nil {
 		t.Fatalf("insert channel: %v", err)
 	}
 
@@ -1068,7 +1068,7 @@ func TestTokenRoutes_ChannelUpdatePreservesIntentionalConfig(t *testing.T) {
 	// Start as an auto-looking channel (simulate insert without override), then edit.
 	res, err := db.Exec(
 		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-		 VALUES (?, ?, ?, 'gpt-4o', 0, 10, 1, 0)`, routeID, accountID, tokenID)
+		 VALUES (?, ?, ?, 'gpt-4o', 0, 10, TRUE, FALSE)`, routeID, accountID, tokenID)
 	if err != nil {
 		t.Fatalf("seed auto channel: %v", err)
 	}
@@ -1097,7 +1097,7 @@ func TestTokenRoutes_ChannelUpdatePreservesIntentionalConfig(t *testing.T) {
 	// Availability for gpt-4o (original auto model) - rebuild would prefer this if override ignored.
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		 VALUES (?, 'gpt-4o', TRUE, ?)`, tokenID, now); err != nil {
 		t.Fatalf("seed avail: %v", err)
 	}
 
@@ -1109,7 +1109,7 @@ func TestTokenRoutes_ChannelUpdatePreservesIntentionalConfig(t *testing.T) {
 	var kept int
 	if err := db.Get(&kept,
 		`SELECT COUNT(*) FROM route_channels
-		 WHERE id = ? AND source_model = 'MiMo-V2-Flash-Free' AND manual_override = 1
+		 WHERE id = ? AND source_model = 'MiMo-V2-Flash-Free' AND manual_override = TRUE
 		   AND priority = 9 AND weight = 4`, channelID); err != nil {
 		t.Fatalf("count kept: %v", err)
 	}
@@ -1272,7 +1272,7 @@ func TestListRoutes_MultiRouteBatchChannelLoadAndRedaction(t *testing.T) {
 
 	accA, err := db.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
-		 VALUES (?, 'user-a', ?, ?, 'active', 1, ?, ?)`,
+		 VALUES (?, 'user-a', ?, ?, 'active', TRUE, ?, ?)`,
 		siteAID, secretA, apiA, now, now,
 	)
 	if err != nil {
@@ -1281,7 +1281,7 @@ func TestListRoutes_MultiRouteBatchChannelLoadAndRedaction(t *testing.T) {
 	accountAID, _ := accA.LastInsertId()
 	accB, err := db.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, created_at, updated_at)
-		 VALUES (?, 'user-b', ?, ?, 'active', 1, ?, ?)`,
+		 VALUES (?, 'user-b', ?, ?, 'active', TRUE, ?, ?)`,
 		siteBID, secretB, apiB, now, now,
 	)
 	if err != nil {
@@ -1291,7 +1291,7 @@ func TestListRoutes_MultiRouteBatchChannelLoadAndRedaction(t *testing.T) {
 
 	tokA, err := db.Exec(
 		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
-		 VALUES (?, 'token-a', 'sk-token-a', 'ready', 'manual', 1, 1, ?, ?)`,
+		 VALUES (?, 'token-a', 'sk-token-a', 'ready', 'manual', TRUE, TRUE, ?, ?)`,
 		accountAID, now, now,
 	)
 	if err != nil {
@@ -1300,7 +1300,7 @@ func TestListRoutes_MultiRouteBatchChannelLoadAndRedaction(t *testing.T) {
 	tokenAID, _ := tokA.LastInsertId()
 	tokB, err := db.Exec(
 		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
-		 VALUES (?, 'token-b', 'sk-token-b', 'ready', 'manual', 1, 1, ?, ?)`,
+		 VALUES (?, 'token-b', 'sk-token-b', 'ready', 'manual', TRUE, TRUE, ?, ?)`,
 		accountBID, now, now,
 	)
 	if err != nil {
@@ -1602,7 +1602,7 @@ func TestRouteChannels_IncludeRuntimeCounters(t *testing.T) {
 		`INSERT INTO route_channels
 			(route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override,
 			 success_count, fail_count, cooldown_until)
-		 VALUES (?, ?, ?, 'gpt-4o', 5, 20, 1, 0, 42, 7, ?)`,
+		 VALUES (?, ?, ?, 'gpt-4o', 5, 20, TRUE, FALSE, 42, 7, ?)`,
 		routeID, accountID, tokenID, cooldownUntil); err != nil {
 		t.Fatalf("insert channel: %v", err)
 	}
@@ -1737,7 +1737,7 @@ func TestTokenRoutes_SummaryBatchedCounts(t *testing.T) {
 	// Second route ('claude-*') and a third route ('empty-*') with no channels.
 	res, err := db.Exec(
 		`INSERT INTO token_routes (model_pattern, enabled, created_at, updated_at)
-		 VALUES ('claude-*', 1, ?, ?)`, now, now)
+		 VALUES ('claude-*', TRUE, ?, ?)`, now, now)
 	if err != nil {
 		t.Fatalf("insert claude route: %v", err)
 	}
@@ -1745,17 +1745,17 @@ func TestTokenRoutes_SummaryBatchedCounts(t *testing.T) {
 
 	res, err = db.Exec(
 		`INSERT INTO token_routes (model_pattern, enabled, created_at, updated_at)
-		 VALUES ('empty-*', 1, ?, ?)`, now, now)
+		 VALUES ('empty-*', TRUE, ?, ?)`, now, now)
 	if err != nil {
 		t.Fatalf("insert empty route: %v", err)
 	}
 	route3ID, _ := res.LastInsertId()
 
 	// Route 1: 3 channels (2 enabled, 1 disabled).
-	for _, enabled := range []int{1, 1, 0} {
+	for _, enabled := range []bool{true, true, false} {
 		if _, err := db.Exec(
 			`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-			 VALUES (?, ?, ?, 'gpt-4o', 0, 10, ?, 0)`,
+			 VALUES (?, ?, ?, 'gpt-4o', 0, 10, ?, FALSE)`,
 			route1ID, accountID, tokenID, enabled); err != nil {
 			t.Fatalf("insert route1 channel: %v", err)
 		}
@@ -1765,7 +1765,7 @@ func TestTokenRoutes_SummaryBatchedCounts(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		if _, err := db.Exec(
 			`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-			 VALUES (?, ?, ?, 'claude-3', 0, 10, 1, 0)`,
+			 VALUES (?, ?, ?, 'claude-3', 0, 10, TRUE, FALSE)`,
 			route2ID, accountID, tokenID); err != nil {
 			t.Fatalf("insert route2 channel: %v", err)
 		}
@@ -1831,7 +1831,7 @@ func TestTokenRoutes_Summary_PopulatesSiteNames(t *testing.T) {
 	// auto-populate side effect (deterministic, no model-availability seed).
 	res, err := db.Exec(
 		`INSERT INTO token_routes (model_pattern, enabled, created_at, updated_at)
-		 VALUES ('no-channel-*', 1, ?, ?)`, now, now)
+		 VALUES ('no-channel-*', TRUE, ?, ?)`, now, now)
 	if err != nil {
 		t.Fatalf("insert empty route: %v", err)
 	}
@@ -1843,7 +1843,7 @@ func TestTokenRoutes_Summary_PopulatesSiteNames(t *testing.T) {
 	for _, sourceModel := range []string{"gpt-4o", "gpt-4o-mini", "gpt-4.1"} {
 		if _, err := db.Exec(
 			`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-			 VALUES (?, ?, ?, ?, 0, 10, 1, 0)`,
+			 VALUES (?, ?, ?, ?, 0, 10, TRUE, FALSE)`,
 			linkedRouteID, accountID, tokenID, sourceModel); err != nil {
 			t.Fatalf("insert linked route channel %s: %v", sourceModel, err)
 		}
@@ -1907,7 +1907,7 @@ func TestTokenRoutes_Rebuild_RefreshModelsFalseSkipsSync(t *testing.T) {
 	routeID, _, tokenID := seedRouteChannelRefs(t, db)
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		 VALUES (?, 'gpt-4o', TRUE, ?)`, tokenID, now); err != nil {
 		t.Fatalf("seed availability: %v", err)
 	}
 

--- a/handler/proxy/managed_key_cost_test.go
+++ b/handler/proxy/managed_key_cost_test.go
@@ -40,7 +40,7 @@ func insertManagedKeyWithCost(t *testing.T, db *store.DB, name, key string, used
 		 (name, key, enabled, used_cost, used_requests,
 		  supported_models, allowed_route_ids, site_weight_multipliers, excluded_site_ids, excluded_credential_refs,
 		  created_at, updated_at)
-		 VALUES (?, ?, 1, ?, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
+		 VALUES (?, ?, TRUE, ?, 0, '[]', '[]', '{}', '[]', '[]', ?, ?)`,
 		name, key, usedCost, now, now,
 	)
 	if err != nil {

--- a/scheduler/model_probe_history_test.go
+++ b/scheduler/model_probe_history_test.go
@@ -17,12 +17,12 @@ func seedRouteChannel(t *testing.T, db *store.DB, suffix, model string, enabled 
 		t.Fatalf("insert site: %v", err)
 	}
 	siteID, _ := res.LastInsertId()
-	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, 'tok', 'active', 1, ?, ?)`, siteID, "u-"+suffix, now, now)
+	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, 'tok', 'active', TRUE, ?, ?)`, siteID, "u-"+suffix, now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}
 	accountID, _ := res.LastInsertId()
-	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`, "all", "pattern", "weighted", 1, now, now)
+	res, err = db.Exec(`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`, "all", "pattern", "weighted", true, now, now)
 	if err != nil {
 		t.Fatalf("insert route: %v", err)
 	}

--- a/scheduler/model_probe_results_test.go
+++ b/scheduler/model_probe_results_test.go
@@ -15,7 +15,7 @@ func seedProbeAccount(t *testing.T, db *store.DB, siteName, username string) (si
 		t.Fatalf("insert site: %v", err)
 	}
 	siteID, _ = res.LastInsertId()
-	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, 'tok', 'active', 1, ?, ?)`, siteID, username, now, now)
+	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, 'tok', 'active', TRUE, ?, ?)`, siteID, username, now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}

--- a/scheduler/usage_aggregation_test.go
+++ b/scheduler/usage_aggregation_test.go
@@ -212,11 +212,7 @@ func insertProjectionAccount(t *testing.T, db *store.DB, siteID int64, suffix, n
 	t.Helper()
 	query := `INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
 		VALUES (?, ?, ?, 'active', ?, ?, ?)`
-	checkinEnabled := any(1)
-	if db.Dialect == store.DialectPostgres {
-		checkinEnabled = true
-	}
-	args := []any{siteID, "usage-" + suffix, "sk-usage-" + suffix, checkinEnabled, now, now}
+	args := []any{siteID, "usage-" + suffix, "sk-usage-" + suffix, true, now, now}
 	if db.Dialect == store.DialectPostgres {
 		var id int64
 		if err := db.QueryRow(query+" RETURNING id", args...).Scan(&id); err != nil {

--- a/service/account_model_refresh_test.go
+++ b/service/account_model_refresh_test.go
@@ -35,7 +35,7 @@ func seedAccountAndToken(t *testing.T, db *sqlx.DB, tokenValue string) (accountI
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	res, err := db.Exec(
 		`INSERT INTO sites (name, url, platform, status, use_system_proxy, sort_order, global_weight, post_refresh_probe_enabled, created_at, updated_at)
-		 VALUES (?, ?, 'openai', 'active', 0, 0, 0, 0, ?, ?)`,
+		 VALUES (?, ?, 'openai', 'active', FALSE, 0, 0, FALSE, ?, ?)`,
 		"ModelRefreshSite-"+tokenValue, "https://api.example.com", now, now,
 	)
 	if err != nil {
@@ -53,7 +53,7 @@ func seedAccountOnSite(t *testing.T, db *sqlx.DB, siteID int64, username, tokenV
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	res, err := db.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, sort_order, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, 1, 0, ?, ?)`,
+		 VALUES (?, ?, ?, ?, TRUE, 0, ?, ?)`,
 		siteID, username, tokenValue, status, now, now,
 	)
 	if err != nil {
@@ -65,7 +65,7 @@ func seedAccountOnSite(t *testing.T, db *sqlx.DB, siteID int64, username, tokenV
 	}
 	tokRes, err := db.Exec(
 		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
-		 VALUES (?, 'default', ?, 'ready', 'manual', 1, 1, ?, ?)`,
+		 VALUES (?, 'default', ?, 'ready', 'manual', TRUE, TRUE, ?, ?)`,
 		accountID, tokenValue, now, now,
 	)
 	if err != nil {
@@ -81,7 +81,7 @@ func seedOpenAISite(t *testing.T, db *sqlx.DB, name, url string) int64 {
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	res, err := db.Exec(
 		`INSERT INTO sites (name, url, platform, status, use_system_proxy, sort_order, global_weight, post_refresh_probe_enabled, created_at, updated_at)
-		 VALUES (?, ?, 'openai', 'active', 0, 0, 0, 0, ?, ?)`,
+		 VALUES (?, ?, 'openai', 'active', FALSE, 0, 0, FALSE, ?, ?)`,
 		name, url, now, now,
 	)
 	if err != nil {
@@ -141,7 +141,7 @@ func TestPersistTokenModelAvailability_UpsertsAndMarksUnavailable(t *testing.T) 
 
 	var availCount int
 	if err := db.Get(&availCount,
-		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = 1`,
+		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = TRUE`,
 		tokenID,
 	); err != nil {
 		t.Fatalf("count available: %v", err)
@@ -155,7 +155,7 @@ func TestPersistTokenModelAvailability_UpsertsAndMarksUnavailable(t *testing.T) 
 		t.Fatalf("second persist: %v", err)
 	}
 	if err := db.Get(&availCount,
-		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = 1`,
+		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = TRUE`,
 		tokenID,
 	); err != nil {
 		t.Fatalf("count after second: %v", err)
@@ -165,7 +165,7 @@ func TestPersistTokenModelAvailability_UpsertsAndMarksUnavailable(t *testing.T) 
 	}
 	var unavailCount int
 	if err := db.Get(&unavailCount,
-		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = 0`,
+		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = FALSE`,
 		tokenID,
 	); err != nil {
 		t.Fatalf("count unavailable: %v", err)
@@ -205,7 +205,7 @@ func TestPersistTokenModelAvailability_ReAddsPreviouslyUnavailable(t *testing.T)
 	}
 	var availCount int
 	if err := db.Get(&availCount,
-		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = 1`,
+		`SELECT COUNT(*) FROM token_model_availability WHERE token_id = ? AND available = TRUE`,
 		tokenID,
 	); err != nil {
 		t.Fatalf("count available: %v", err)
@@ -287,7 +287,7 @@ func TestSyncAllAccountModels_BatchSemantics(t *testing.T) {
 	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
 	if res, err := db.Exec(
 		`INSERT INTO sites (name, url, platform, status, use_system_proxy, sort_order, global_weight, post_refresh_probe_enabled, created_at, updated_at)
-		 VALUES ('batch-no-adapter', 'https://nope.example.com', 'no-such-platform', 'active', 0, 0, 0, 0, ?, ?)`,
+		 VALUES ('batch-no-adapter', 'https://nope.example.com', 'no-such-platform', 'active', FALSE, 0, 0, FALSE, ?, ?)`,
 		now, now,
 	); err != nil {
 		t.Fatalf("insert no-adapter site: %v", err)
@@ -322,7 +322,7 @@ func TestSyncAllAccountModels_BatchSemantics(t *testing.T) {
 	// Availability for the successful accounts really landed in the store.
 	var availCount int
 	if err := db.Get(&availCount,
-		`SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND available = 1`,
+		`SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND available = TRUE`,
 		okAccount,
 	); err != nil {
 		t.Fatalf("count availability: %v", err)
@@ -381,7 +381,7 @@ func TestRefreshAccountModels_SkipRebuildPersistsWithoutSideEffects(t *testing.T
 
 	var availCount int
 	if err := db.Get(&availCount,
-		`SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND available = 1`,
+		`SELECT COUNT(*) FROM model_availability WHERE account_id = ? AND available = TRUE`,
 		accountID,
 	); err != nil {
 		t.Fatalf("count availability: %v", err)

--- a/service/account_mutation_test.go
+++ b/service/account_mutation_test.go
@@ -46,7 +46,7 @@ func createTestAccount(t *testing.T, db *store.DB, siteID int64, username *strin
 	res, err := db.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, status, is_pinned, sort_order,
 		 checkin_enabled, created_at, updated_at)
-		 VALUES (?, ?, ?, 'active', 0, 0, 1, ?, ?)`,
+		 VALUES (?, ?, ?, 'active', FALSE, 0, TRUE, ?, ?)`,
 		siteID, username, accessToken, now, now,
 	)
 	if err != nil {

--- a/service/account_token_adapter_helpers_test.go
+++ b/service/account_token_adapter_helpers_test.go
@@ -150,14 +150,14 @@ func TestGetTokenGroups_FallbackOnErrorEmptyNilAdapter(t *testing.T) {
 	accountID := createTestAccount(t, db, siteID, strPtr("u1"), "session-token")
 	if _, err := db.Exec(
 		`INSERT INTO account_tokens (account_id, name, token, token_group, value_status, source, enabled, is_default, created_at, updated_at)
-		 VALUES (?, 'a', 'sk-a', 'group-a', 'ready', 'manual', 1, 1, datetime('now'), datetime('now'))`,
+		 VALUES (?, 'a', 'sk-a', 'group-a', 'ready', 'manual', TRUE, TRUE, datetime('now'), datetime('now'))`,
 		accountID,
 	); err != nil {
 		t.Fatalf("insert local token: %v", err)
 	}
 	if _, err := db.Exec(
 		`INSERT INTO account_tokens (account_id, name, token, token_group, value_status, source, enabled, is_default, created_at, updated_at)
-		 VALUES (?, 'b', 'sk-b', 'group-b', 'ready', 'manual', 1, 0, datetime('now'), datetime('now'))`,
+		 VALUES (?, 'b', 'sk-b', 'group-b', 'ready', 'manual', TRUE, FALSE, datetime('now'), datetime('now'))`,
 		accountID,
 	); err != nil {
 		t.Fatalf("insert local token b: %v", err)

--- a/service/alert/enrich_test.go
+++ b/service/alert/enrich_test.go
@@ -25,7 +25,7 @@ func seedEnrichSite(t *testing.T, db *store.DB, siteName, accountName string) (s
 	siteID, _ = res.LastInsertId()
 	res, err = db.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
-		 VALUES (?, ?, 'tok', 'active', 1, ?, ?)`,
+		 VALUES (?, ?, 'tok', 'active', TRUE, ?, ?)`,
 		siteID, accountName, now, now,
 	)
 	if err != nil {
@@ -40,7 +40,7 @@ func seedEnrichAccount(t *testing.T, db *store.DB, siteID int64, accountName str
 	now := time.Now().UTC().Format(time.RFC3339)
 	res, err := db.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
-		 VALUES (?, ?, 'tok', 'active', 1, ?, ?)`,
+		 VALUES (?, ?, 'tok', 'active', TRUE, ?, ?)`,
 		siteID, accountName, now, now,
 	)
 	if err != nil {
@@ -53,14 +53,10 @@ func seedEnrichAccount(t *testing.T, db *store.DB, siteID int64, accountName str
 func seedEnrichRoute(t *testing.T, db *store.DB, pattern string, enabled bool) int64 {
 	t.Helper()
 	now := time.Now().UTC().Format(time.RFC3339)
-	enabledFlag := 0
-	if enabled {
-		enabledFlag = 1
-	}
 	res, err := db.Exec(
 		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
 		 VALUES (?, 'pattern', 'weighted', ?, ?, ?)`,
-		pattern, enabledFlag, now, now,
+		pattern, enabled, now, now,
 	)
 	if err != nil {
 		t.Fatalf("insert route %s: %v", pattern, err)
@@ -71,14 +67,10 @@ func seedEnrichRoute(t *testing.T, db *store.DB, pattern string, enabled bool) i
 
 func seedEnrichChannel(t *testing.T, db *store.DB, routeID, accountID int64, enabled bool) {
 	t.Helper()
-	enabledFlag := 0
-	if enabled {
-		enabledFlag = 1
-	}
 	_, err := db.Exec(
 		`INSERT INTO route_channels (route_id, account_id, priority, weight, enabled, manual_override)
-		 VALUES (?, ?, 0, 10, ?, 0)`,
-		routeID, accountID, enabledFlag,
+		 VALUES (?, ?, 0, 10, ?, FALSE)`,
+		routeID, accountID, enabled,
 	)
 	if err != nil {
 		t.Fatalf("insert channel route %d account %d: %v", routeID, accountID, err)

--- a/service/balance/balance_deeptest_test.go
+++ b/service/balance/balance_deeptest_test.go
@@ -52,7 +52,7 @@ func TestProbe_RefreshBalance_Sub2ApiUpstreamFailureMustNotZeroBalance(t *testin
 	// Account with a known stored balance and an expired status — both must
 	// survive a failed refresh untouched.
 	accountRes, err := db.Exec(
-		"INSERT INTO accounts (site_id, username, access_token, balance, quota, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, ?, 88.5, 100.0, 'expired', 0, ?, ?)",
+		"INSERT INTO accounts (site_id, username, access_token, balance, quota, status, checkin_enabled, created_at, updated_at) VALUES (?, ?, ?, 88.5, 100.0, 'expired', FALSE, ?, ?)",
 		siteID, "sub2api-user", "session-token", now, now,
 	)
 	if err != nil {

--- a/service/checkin/checkin_edge_test.go
+++ b/service/checkin/checkin_edge_test.go
@@ -467,7 +467,7 @@ func insertEdgeAccount(t *testing.T, db *store.DB, siteID int64, accessToken, ex
 	t.Helper()
 	now := time.Now().UTC().Format(time.RFC3339)
 	result, err := db.Exec(
-		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, 'active', 1, ?, ?, ?)",
+		"INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, 'active', TRUE, ?, ?, ?)",
 		siteID, "edge-user", accessToken, extraConfig, now, now,
 	)
 	if err != nil {

--- a/service/checkin/checkin_postgres_test.go
+++ b/service/checkin/checkin_postgres_test.go
@@ -164,11 +164,7 @@ func insertCheckinAccount(t *testing.T, db *store.DB, siteID int64, suffix, now 
 	t.Helper()
 	query := `INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
 		VALUES (?, ?, ?, 'active', ?, ?, ?)`
-	checkinEnabled := any(1)
-	if db.Dialect == store.DialectPostgres {
-		checkinEnabled = true
-	}
-	args := []any{siteID, "checkin-" + suffix, "sk-checkin-" + suffix, checkinEnabled, now, now}
+	args := []any{siteID, "checkin-" + suffix, "sk-checkin-" + suffix, true, now, now}
 	if db.Dialect == store.DialectPostgres {
 		var id int64
 		if err := db.QueryRow(query+" RETURNING id", args...).Scan(&id); err != nil {

--- a/service/model_redirects_test.go
+++ b/service/model_redirects_test.go
@@ -33,7 +33,7 @@ func TestReloadRedirectRegistry_LoadsFromDB(t *testing.T) {
 	siteID, _ := res.LastInsertId()
 
 	res, err = db.Exec(`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
-		VALUES (?, ?, 'tok', 'active', 1, ?, ?)`, siteID, "redirect-user", now, now)
+		VALUES (?, ?, 'tok', 'active', TRUE, ?, ?)`, siteID, "redirect-user", now, now)
 	if err != nil {
 		t.Fatalf("insert account: %v", err)
 	}

--- a/service/route_rebuild_probe_test.go
+++ b/service/route_rebuild_probe_test.go
@@ -26,7 +26,7 @@ func seedPatternRoute(t *testing.T, db *store.DB, pattern string) int64 {
 	now := time.Now().UTC().Format(time.RFC3339)
 	res, err := db.Exec(
 		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
-		 VALUES (?, 'pattern', 'weighted', 1, ?, ?)`, pattern, now, now,
+		 VALUES (?, 'pattern', 'weighted', TRUE, ?, ?)`, pattern, now, now,
 	)
 	if err != nil {
 		t.Fatalf("insert route: %v", err)
@@ -42,7 +42,7 @@ func TestRebuild_ProbeFailureExcludesChannel(t *testing.T) {
 	siteID := siteIDForAccount(t, db, accountID)
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		 VALUES (?, 'gpt-4o', TRUE, ?)`, tokenID, now); err != nil {
 		t.Fatalf("avail: %v", err)
 	}
 	routeID := seedPatternRoute(t, db, "gpt-*")
@@ -73,7 +73,7 @@ func TestRebuild_ProbeFilterDisabledKeepsProbeFailedChannel(t *testing.T) {
 	siteID := siteIDForAccount(t, db, accountID)
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		 VALUES (?, 'gpt-4o', TRUE, ?)`, tokenID, now); err != nil {
 		t.Fatalf("avail: %v", err)
 	}
 	seedPatternRoute(t, db, "gpt-*")
@@ -95,7 +95,7 @@ func TestRebuild_ProbeLatestSuccessWinsOverEarlierFailure(t *testing.T) {
 	siteID := siteIDForAccount(t, db, accountID)
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		 VALUES (?, 'gpt-4o', TRUE, ?)`, tokenID, now); err != nil {
 		t.Fatalf("avail: %v", err)
 	}
 	seedPatternRoute(t, db, "gpt-*")
@@ -119,7 +119,7 @@ func TestRebuild_ExcludeModelListFiltersChannel(t *testing.T) {
 	_, _, tokenID := seedSiteAccountToken(t, db, "exclude")
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'claude-3', 1, ?)`, tokenID, now); err != nil {
+		 VALUES (?, 'claude-3', TRUE, ?)`, tokenID, now); err != nil {
 		t.Fatalf("avail: %v", err)
 	}
 	routeID := seedPatternRoute(t, db, "*")
@@ -147,7 +147,7 @@ func TestRebuild_NoChangeShortCircuitSkipsCacheInvalidation(t *testing.T) {
 	_, _, tokenID := seedSiteAccountToken(t, db, "short")
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		 VALUES (?, 'gpt-4o', TRUE, ?)`, tokenID, now); err != nil {
 		t.Fatalf("avail: %v", err)
 	}
 	seedPatternRoute(t, db, "gpt-*")

--- a/service/route_rebuild_test.go
+++ b/service/route_rebuild_test.go
@@ -36,7 +36,7 @@ func seedSiteAccountToken(t *testing.T, db *store.DB, name string) (siteID, acco
 	siteID, _ = res.LastInsertId()
 	res, err = db.Exec(
 		`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
-		 VALUES (?, ?, 'tok', 'active', 1, ?, ?)`,
+		 VALUES (?, ?, 'tok', 'active', TRUE, ?, ?)`,
 		siteID, name+"-user", now, now,
 	)
 	if err != nil {
@@ -45,7 +45,7 @@ func seedSiteAccountToken(t *testing.T, db *store.DB, name string) (siteID, acco
 	accountID, _ = res.LastInsertId()
 	res, err = db.Exec(
 		`INSERT INTO account_tokens (account_id, name, token, value_status, source, enabled, is_default, created_at, updated_at)
-		 VALUES (?, 'default', 'sk-test', 'ready', 'manual', 1, 1, ?, ?)`,
+		 VALUES (?, 'default', 'sk-test', 'ready', 'manual', TRUE, TRUE, ?, ?)`,
 		accountID, now, now,
 	)
 	if err != nil {
@@ -65,25 +65,25 @@ func TestRebuildTokenRoutesFromAvailability_AddsMatchingChannels(t *testing.T) {
 	// Matching availability
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'gpt-4o', 1, ?)`, tokenMatch, now); err != nil {
+		 VALUES (?, 'gpt-4o', TRUE, ?)`, tokenMatch, now); err != nil {
 		t.Fatalf("token avail match: %v", err)
 	}
 	// Non-matching model
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'claude-3-opus', 1, ?)`, tokenOther, now); err != nil {
+		 VALUES (?, 'claude-3-opus', TRUE, ?)`, tokenOther, now); err != nil {
 		t.Fatalf("token avail other: %v", err)
 	}
 	// Account-level model availability that should also match
 	if _, err := db.Exec(
 		`INSERT INTO model_availability (account_id, model_name, available, is_manual, checked_at)
-		 VALUES (?, 'gpt-4o-mini', 1, 0, ?)`, accountMatch, now); err != nil {
+		 VALUES (?, 'gpt-4o-mini', TRUE, FALSE, ?)`, accountMatch, now); err != nil {
 		t.Fatalf("model avail: %v", err)
 	}
 
 	res, err := db.Exec(
 		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
-		 VALUES ('gpt-*', 'pattern', 'weighted', 1, ?, ?)`, now, now,
+		 VALUES ('gpt-*', 'pattern', 'weighted', TRUE, ?, ?)`, now, now,
 	)
 	if err != nil {
 		t.Fatalf("insert pattern route: %v", err)
@@ -93,7 +93,7 @@ func TestRebuildTokenRoutesFromAvailability_AddsMatchingChannels(t *testing.T) {
 	// explicit_group referencing a future exact route — should not get materialised channels
 	res, err = db.Exec(
 		`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
-		 VALUES ('my-group', 'my-group', 'explicit_group', 'weighted', 1, ?, ?)`, now, now,
+		 VALUES ('my-group', 'my-group', 'explicit_group', 'weighted', TRUE, ?, ?)`, now, now,
 	)
 	if err != nil {
 		t.Fatalf("insert group route: %v", err)
@@ -158,7 +158,7 @@ func TestRebuildTokenRoutesFromAvailability_PreservesManualOverride(t *testing.T
 
 	res, err := db.Exec(
 		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
-		 VALUES ('gpt-*', 'pattern', 'weighted', 1, ?, ?)`, now, now,
+		 VALUES ('gpt-*', 'pattern', 'weighted', TRUE, ?, ?)`, now, now,
 	)
 	if err != nil {
 		t.Fatalf("insert route: %v", err)
@@ -168,19 +168,19 @@ func TestRebuildTokenRoutesFromAvailability_PreservesManualOverride(t *testing.T
 	// Manual channel with a model that will NOT match after rebuild sources change
 	if _, err := db.Exec(
 		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-		 VALUES (?, ?, ?, 'manual-only-model', 5, 10, 1, 1)`, routeID, accountID, tokenID); err != nil {
+		 VALUES (?, ?, ?, 'manual-only-model', 5, 10, TRUE, TRUE)`, routeID, accountID, tokenID); err != nil {
 		t.Fatalf("insert manual channel: %v", err)
 	}
 	// Auto channel that becomes stale (no availability for it)
 	if _, err := db.Exec(
 		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-		 VALUES (?, ?, ?, 'stale-auto', 0, 10, 1, 0)`, routeID, accountID, tokenID); err != nil {
+		 VALUES (?, ?, ?, 'stale-auto', 0, 10, TRUE, FALSE)`, routeID, accountID, tokenID); err != nil {
 		t.Fatalf("insert auto channel: %v", err)
 	}
 	// Fresh availability
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		 VALUES (?, 'gpt-4o', TRUE, ?)`, tokenID, now); err != nil {
 		t.Fatalf("token avail: %v", err)
 	}
 
@@ -194,7 +194,7 @@ func TestRebuildTokenRoutesFromAvailability_PreservesManualOverride(t *testing.T
 
 	var manualCount int
 	if err := db.Get(&manualCount,
-		`SELECT COUNT(*) FROM route_channels WHERE route_id = ? AND source_model = 'manual-only-model' AND manual_override = 1`,
+		`SELECT COUNT(*) FROM route_channels WHERE route_id = ? AND source_model = 'manual-only-model' AND manual_override = TRUE`,
 		routeID); err != nil {
 		t.Fatalf("count manual: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestRebuildTokenRoutesFromAvailability_GroupSourcesExpandAtSelectTime(t *te
 
 	res, err := db.Exec(
 		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
-		 VALUES ('gpt-4o', 'pattern', 'weighted', 1, ?, ?)`, now, now,
+		 VALUES ('gpt-4o', 'pattern', 'weighted', TRUE, ?, ?)`, now, now,
 	)
 	if err != nil {
 		t.Fatalf("exact route: %v", err)
@@ -239,7 +239,7 @@ func TestRebuildTokenRoutesFromAvailability_GroupSourcesExpandAtSelectTime(t *te
 
 	res, err = db.Exec(
 		`INSERT INTO token_routes (model_pattern, display_name, route_mode, routing_strategy, enabled, created_at, updated_at)
-		 VALUES ('bundle', 'bundle', 'explicit_group', 'weighted', 1, ?, ?)`, now, now,
+		 VALUES ('bundle', 'bundle', 'explicit_group', 'weighted', TRUE, ?, ?)`, now, now,
 	)
 	if err != nil {
 		t.Fatalf("group route: %v", err)
@@ -255,7 +255,7 @@ func TestRebuildTokenRoutesFromAvailability_GroupSourcesExpandAtSelectTime(t *te
 	// New site/model becomes available → rebuild should attach to exact source route
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		 VALUES (?, 'gpt-4o', TRUE, ?)`, tokenID, now); err != nil {
 		t.Fatalf("avail: %v", err)
 	}
 
@@ -309,12 +309,12 @@ func TestRebuildRoutesBestEffort_ConcurrentSafe(t *testing.T) {
 	_, _, tokenID := seedSiteAccountToken(t, db, "conc")
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'gpt-4', 1, ?)`, tokenID, now); err != nil {
+		 VALUES (?, 'gpt-4', TRUE, ?)`, tokenID, now); err != nil {
 		t.Fatalf("avail: %v", err)
 	}
 	if _, err := db.Exec(
 		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
-		 VALUES ('gpt-*', 'pattern', 'weighted', 1, ?, ?)`, now, now); err != nil {
+		 VALUES ('gpt-*', 'pattern', 'weighted', TRUE, ?, ?)`, now, now); err != nil {
 		t.Fatalf("route: %v", err)
 	}
 
@@ -343,12 +343,12 @@ func TestPopulateRouteChannelsByModelPattern_InsertOnly(t *testing.T) {
 	_, accountID, tokenID := seedSiteAccountToken(t, db, "pop")
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		 VALUES (?, 'gpt-4o', TRUE, ?)`, tokenID, now); err != nil {
 		t.Fatalf("avail: %v", err)
 	}
 	res, err := db.Exec(
 		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
-		 VALUES ('gpt-*', 'pattern', 'weighted', 1, ?, ?)`, now, now,
+		 VALUES ('gpt-*', 'pattern', 'weighted', TRUE, ?, ?)`, now, now,
 	)
 	if err != nil {
 		t.Fatalf("route: %v", err)
@@ -358,7 +358,7 @@ func TestPopulateRouteChannelsByModelPattern_InsertOnly(t *testing.T) {
 	// Pre-existing manual channel
 	if _, err := db.Exec(
 		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-		 VALUES (?, ?, ?, 'manual-x', 1, 10, 1, 1)`, routeID, accountID, tokenID); err != nil {
+		 VALUES (?, ?, ?, 'manual-x', 1, 10, TRUE, TRUE)`, routeID, accountID, tokenID); err != nil {
 		t.Fatalf("manual: %v", err)
 	}
 
@@ -387,7 +387,7 @@ func TestRebuildTokenRoutesFromAvailability_PreservesManualPriorityWeight(t *tes
 
 	res, err := db.Exec(
 		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
-		 VALUES ('gpt-*', 'pattern', 'weighted', 1, ?, ?)`, now, now,
+		 VALUES ('gpt-*', 'pattern', 'weighted', TRUE, ?, ?)`, now, now,
 	)
 	if err != nil {
 		t.Fatalf("insert route: %v", err)
@@ -396,12 +396,12 @@ func TestRebuildTokenRoutesFromAvailability_PreservesManualPriorityWeight(t *tes
 
 	if _, err := db.Exec(
 		`INSERT INTO route_channels (route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
-		 VALUES (?, ?, ?, 'manual-tuned', 11, 22, 1, 1)`, routeID, accountID, tokenID); err != nil {
+		 VALUES (?, ?, ?, 'manual-tuned', 11, 22, TRUE, TRUE)`, routeID, accountID, tokenID); err != nil {
 		t.Fatalf("manual channel: %v", err)
 	}
 	if _, err := db.Exec(
 		`INSERT INTO token_model_availability (token_id, model_name, available, checked_at)
-		 VALUES (?, 'gpt-4o', 1, ?)`, tokenID, now); err != nil {
+		 VALUES (?, 'gpt-4o', TRUE, ?)`, tokenID, now); err != nil {
 		t.Fatalf("avail: %v", err)
 	}
 

--- a/service/routing_store_null_stats_test.go
+++ b/service/routing_store_null_stats_test.go
@@ -25,7 +25,7 @@ func insertNullSortOrderRoute(t *testing.T, db *store.DB, pattern string) int64 
 	now := nowISO()
 	res, err := db.Exec(
 		`INSERT INTO token_routes (model_pattern, route_mode, routing_strategy, enabled, created_at, updated_at)
-		 VALUES (?, 'pattern', 'weighted', 1, ?, ?)`, pattern, now, now)
+		 VALUES (?, 'pattern', 'weighted', TRUE, ?, ?)`, pattern, now, now)
 	if err != nil {
 		t.Fatalf("INSERT token_routes failed: %v", err)
 	}
@@ -39,7 +39,7 @@ func insertNullSortOrderRoute(t *testing.T, db *store.DB, pattern string) int64 
 func insertNullStatsRouteChannel(t *testing.T, db *store.DB, routeID, accountID int64) int64 {
 	t.Helper()
 	res, err := db.Exec(
-		`INSERT INTO route_channels (route_id, account_id, enabled) VALUES (?, ?, 1)`,
+		`INSERT INTO route_channels (route_id, account_id, enabled) VALUES (?, ?, TRUE)`,
 		routeID, accountID)
 	if err != nil {
 		t.Fatalf("INSERT route_channels failed: %v", err)
@@ -140,7 +140,7 @@ func TestLoadOAuthRouteUnitMembers_NullStatsDoNotError(t *testing.T) {
 	now := nowISO()
 	res, err := db.Exec(
 		`INSERT INTO oauth_route_units (site_id, provider, name, strategy, enabled, created_at, updated_at)
-		 VALUES (?, 'google', 'null-member-unit', 'round_robin', 1, ?, ?)`, siteID, now, now)
+		 VALUES (?, 'google', 'null-member-unit', 'round_robin', TRUE, ?, ?)`, siteID, now, now)
 	if err != nil {
 		t.Fatalf("INSERT oauth_route_units failed: %v", err)
 	}

--- a/store/boolean_bind_test.go
+++ b/store/boolean_bind_test.go
@@ -1,0 +1,136 @@
+package store
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Incident class under test (w18-pg-dialect audit): a shared statement binds
+// the INTEGER literal 0/1 to a BOOLEAN column. SQLite declares its boolean
+// columns as INTEGER (see schema_ddl.go), so the literal is silently accepted;
+// PostgreSQL uses native BOOLEAN and rejects the row with
+// "column ... is of type boolean but expression is of type integer".
+//
+// These tests pin both halves of the divergence and prove the dialect-safe
+// replacements used by the fixes: FALSE/TRUE literals and Go bool binds.
+
+func boolBindProbeNow() string {
+	return time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+}
+
+// insertEventsReadStmt builds an INSERT into events whose read column gets
+// readExpr verbatim (literal path) so each dialect sees the exact statement.
+func insertEventsReadStmt(readExpr string) string {
+	return "INSERT INTO events (type, title, message, level, related_type, created_at, read) " +
+		"VALUES ('test', 'bool-bind-probe', 'dialect trap probe', 'info', 'test', '" + boolBindProbeNow() + "', " + readExpr + ")"
+}
+
+// insertEventsReadPlaceholderStmt is the all-placeholder twin of
+// insertEventsReadStmt so the bound-bool form exercises identical columns.
+func insertEventsReadPlaceholderStmt() string {
+	return "INSERT INTO events (type, title, message, level, related_type, created_at, read) VALUES (?, ?, ?, ?, ?, ?, ?)"
+}
+
+// TestBooleanLiteralIntegerAcceptedBySQLite documents the hiding half of the
+// incident: on SQLite a literal 0/1 for a boolean column succeeds because the
+// column type is INTEGER.
+func TestBooleanLiteralIntegerAcceptedBySQLite(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+
+	if _, err := db.Exec(insertEventsReadStmt("0")); err != nil {
+		t.Fatalf("SQLite rejected integer literal 0 for boolean column: %v", err)
+	}
+	var n int
+	if err := db.Get(&n, "SELECT COUNT(*) FROM events WHERE title = 'bool-bind-probe'"); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("events count = %d, want 1", n)
+	}
+}
+
+// TestBooleanLiteralIntegerRejectedByPostgres proves the failing half of the
+// incident on a real PostgreSQL server (CI test-pg sets PG_TEST_DSN; skipped
+// locally without one). The exact statement shape that several shared seeds
+// and event writers used must fail with a type error on PG.
+func TestBooleanLiteralIntegerRejectedByPostgres(t *testing.T) {
+	db := openTestPG(t)
+
+	_, err := db.Exec(insertEventsReadStmt("0"))
+	if err == nil {
+		t.Fatal("PostgreSQL accepted integer literal 0 for boolean column; want type error")
+	}
+	low := strings.ToLower(err.Error())
+	if !strings.Contains(low, "boolean") && !strings.Contains(low, "integer") {
+		t.Fatalf("expected a boolean/integer type error, got: %v", err)
+	}
+}
+
+// TestEventsReadBooleanSafeFormsBothDialects verifies the dialect-safe forms
+// used by the fixes: FALSE/TRUE SQL literals and Go bool parameter binds,
+// including WHERE/UPDATE comparisons. Runs on SQLite locally and on
+// PostgreSQL under CI test-pg.
+func TestEventsReadBooleanSafeFormsBothDialects(t *testing.T) {
+	run := func(t *testing.T, db *DB) {
+		t.Helper()
+		// CI test-pg shares one database across packages (-p 1), so assert
+		// deltas on our probe title, not absolute counts.
+		baseline := 0
+		if err := db.Get(&baseline, db.Rebind("SELECT COUNT(*) FROM events WHERE title = ?"), "bool-bind-probe"); err != nil {
+			t.Fatalf("baseline count: %v", err)
+		}
+
+		// Literal FALSE is valid in both dialects (SQLite >= 3.23).
+		if _, err := db.Exec(insertEventsReadStmt("FALSE")); err != nil {
+			t.Fatalf("insert with FALSE literal: %v", err)
+		}
+		// Go bool parameter bind (the pattern used by service.CreateEvent).
+		if _, err := db.Exec(db.Rebind(insertEventsReadPlaceholderStmt()),
+			"test", "bool-bind-probe", "dialect trap probe", "info", "test", boolBindProbeNow(), false); err != nil {
+			t.Fatalf("insert with bound bool: %v", err)
+		}
+
+		var unread int
+		if err := db.Get(&unread, db.Rebind("SELECT COUNT(*) FROM events WHERE read = ? AND title = ?"), false, "bool-bind-probe"); err != nil {
+			t.Fatalf("count unread with bound bool: %v", err)
+		}
+		if unread != baseline+2 {
+			t.Fatalf("unread = %d, want %d (baseline %d)", unread, baseline+2, baseline)
+		}
+
+		if _, err := db.Exec(db.Rebind("UPDATE events SET read = ? WHERE read = ? AND title = ?"), true, false, "bool-bind-probe"); err != nil {
+			t.Fatalf("mark-read with bound bools: %v", err)
+		}
+		if err := db.Get(&unread, db.Rebind("SELECT COUNT(*) FROM events WHERE read = ? AND title = ?"), false, "bool-bind-probe"); err != nil {
+			t.Fatalf("re-count unread: %v", err)
+		}
+		if unread != 0 {
+			t.Fatalf("unread after mark-read = %d, want 0", unread)
+		}
+	}
+
+	t.Run("sqlite", func(t *testing.T) {
+		db, err := Open(DialectSQLite, ":memory:", false)
+		if err != nil {
+			t.Fatalf("open sqlite: %v", err)
+		}
+		defer db.Close()
+		if err := AutoMigrate(db); err != nil {
+			t.Fatalf("AutoMigrate: %v", err)
+		}
+		run(t, db)
+	})
+
+	t.Run("postgres", func(t *testing.T) {
+		db := openTestPG(t)
+		run(t, db)
+	})
+}

--- a/store/cooldown_reason_schema_test.go
+++ b/store/cooldown_reason_schema_test.go
@@ -50,12 +50,12 @@ func TestCooldownReasonColumnsRoundTripSQLite(t *testing.T) {
 	if _, err := db.Exec(`INSERT INTO accounts (id, site_id, username, access_token, status) VALUES (1, 1, 'u', 'tok', 'active')`); err != nil {
 		t.Fatalf("seed account: %v", err)
 	}
-	if _, err := db.Exec(`INSERT INTO token_routes (id, model_pattern, route_mode, enabled) VALUES (1, 'gpt-*', 'pattern', 1)`); err != nil {
+	if _, err := db.Exec(`INSERT INTO token_routes (id, model_pattern, route_mode, enabled) VALUES (1, 'gpt-*', 'pattern', TRUE)`); err != nil {
 		t.Fatalf("seed route: %v", err)
 	}
 	if _, err := db.Exec(`INSERT INTO route_channels
 		(id, route_id, account_id, enabled, cooldown_until, cooldown_reason_code, cooldown_reason, cooldown_reason_at)
-		VALUES (1, 1, 1, 1, '2026-08-28T10:00:00Z', 'upstream_error', 'boom', '2026-08-28T09:00:00Z')`); err != nil {
+		VALUES (1, 1, 1, TRUE, '2026-08-28T10:00:00Z', 'upstream_error', 'boom', '2026-08-28T09:00:00Z')`); err != nil {
 		t.Fatalf("insert channel with reason: %v", err)
 	}
 

--- a/store/like_case_test.go
+++ b/store/like_case_test.go
@@ -1,0 +1,101 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Dialect divergence under test (w18-pg-dialect audit): SQLite LIKE matches
+// case-insensitively for ASCII, PostgreSQL LIKE is case-sensitive. Shared
+// filters therefore must normalize both sides with LOWER() — otherwise the
+// same admin query returns rows on SQLite and nothing on PostgreSQL.
+
+// likeProbeSeedSite inserts a site whose name embeds probe (mixed case) so
+// each test owns a unique row even on the shared CI test-pg database.
+func likeProbeSeedSite(t *testing.T, db *DB, probe string) {
+	t.Helper()
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	name := "OpenAI " + probe
+	if _, err := db.Exec(db.Rebind(
+		"INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, 'openai', 'active', ?, ?)"),
+		name, "https://"+strings.ToLower(probe)+".example.com", now, now); err != nil {
+		t.Fatalf("seed site: %v", err)
+	}
+}
+
+// TestLikeCaseInsensitiveOnSQLite documents the SQLite half: a lowercase
+// pattern matches a mixed-case name without LOWER() normalization.
+func TestLikeCaseInsensitiveOnSQLite(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	probe := fmt.Sprintf("CaseProbe-sqlite-%d", time.Now().UnixNano())
+	likeProbeSeedSite(t, db, probe)
+
+	var n int
+	if err := db.Get(&n, db.Rebind("SELECT COUNT(*) FROM sites WHERE name LIKE ?"), "%"+strings.ToLower(probe)+"%"); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("SQLite LIKE matched %d rows, want 1 (case-insensitive ASCII LIKE)", n)
+	}
+}
+
+// TestLikeCaseSensitiveOnPostgres proves the divergent half on a real
+// PostgreSQL server (CI test-pg sets PG_TEST_DSN; skipped locally without
+// one): the identical un-normalized predicate returns zero rows.
+func TestLikeCaseSensitiveOnPostgres(t *testing.T) {
+	db := openTestPG(t)
+	probe := fmt.Sprintf("CaseProbe-pg-%d", time.Now().UnixNano())
+	likeProbeSeedSite(t, db, probe)
+
+	var n int
+	if err := db.Get(&n, db.Rebind("SELECT COUNT(*) FROM sites WHERE name LIKE ?"), "%"+strings.ToLower(probe)+"%"); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("PostgreSQL LIKE matched %d rows, want 0 (case-sensitive LIKE)", n)
+	}
+}
+
+// TestLowerNormalizedLikeMatchesBothDialects verifies the fix shape used by
+// the shared search/filter queries: LOWER(column) LIKE lowercased-pattern
+// matches on both dialects.
+func TestLowerNormalizedLikeMatchesBothDialects(t *testing.T) {
+	run := func(t *testing.T, db *DB) {
+		t.Helper()
+		probe := fmt.Sprintf("CaseProbe-%s-%d", strings.ReplaceAll(t.Name(), "/", "-"), time.Now().UnixNano())
+		likeProbeSeedSite(t, db, probe)
+		var n int
+		if err := db.Get(&n, db.Rebind("SELECT COUNT(*) FROM sites WHERE LOWER(name) LIKE ?"), "%"+strings.ToLower(probe)+"%"); err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		if n != 1 {
+			t.Fatalf("LOWER-normalized LIKE matched %d rows, want 1", n)
+		}
+	}
+
+	t.Run("sqlite", func(t *testing.T) {
+		db, err := Open(DialectSQLite, ":memory:", false)
+		if err != nil {
+			t.Fatalf("open sqlite: %v", err)
+		}
+		defer db.Close()
+		if err := AutoMigrate(db); err != nil {
+			t.Fatalf("AutoMigrate: %v", err)
+		}
+		run(t, db)
+	})
+
+	t.Run("postgres", func(t *testing.T) {
+		db := openTestPG(t)
+		run(t, db)
+	})
+}


### PR DESCRIPTION
## w18 — PG dialect trap audit & test-first fixes

Systematic audit for the SQLite<->PostgreSQL dialect trap classes behind the known `checkin_enabled` incident (integer literal into a BOOLEAN column: SQLite coerces, PG rejects). Test-first: each defect proven by a test, then fixed. **Zero schema migrations** (sc2_028 untouched), no new dependencies, no prod API behavior changes.

### Findings

| # | Trap class | Location | Evidence | Fix |
|---|---|---|---|---|
| 1 | Integer literals bound to BOOLEAN columns in test seeds (PG 42804/22P02; SQLite coerces silently) | ~244 INSERT/UPDATE literals across 48 test files (auth, e2e, handler, scheduler, service, store) | sweep dry-run: 264 rewrite sites; PG rejection proven by `store/boolean_bind_test.go` (PG half gated on PG_TEST_DSN -> CI test-pg) | Rewrite every boolean-column position to `TRUE`/`FALSE` literals (portable in both dialects); sweep re-run: 0 remaining |
| 2 | Go `int` args into boolean placeholders + `any(1)` dialect-switch dances | cmd/migrate/main_test.go, scheduler/model_probe_history_test.go, scheduler/usage_aggregation_test.go, service/checkin/checkin_postgres_test.go, service/alert/enrich_test.go, handler/admin/{contract_filters,token_routes,accounts_models_refresh}_test.go | int / dialect-branched values bound into enabled/checkin_enabled/available/is_manual columns | Bind Go `bool`; delete the dialect dances (single portable form works for both) |
| 3 | **Prod**: literal `0` written as `events.read` (PG: column "read" is of type boolean) | handler/admin/auth_settings.go, model_redirects.go, settings.go | events_write_regression_test.go; PG error class 22P02 | `0` -> `FALSE` (f94e197) |
| 4 | LIKE case-sensitivity divergence (SQLite ASCII-insensitive, PG sensitive) | handler/admin/search.go — 6 admin search queries | search_case_test.go; divergence shown in store/like_case_test.go | `LOWER()`-wrapped columns + lowercased patterns (f94e197), matching downstream_keys.go / checkin_routes.go |
| 5 | Static dialect gates only scanned 3 of 13 packages | docs/pg_boolean_gate_test.go, docs/pg_rebind_gate_test.go | dirs = {handler,service,scheduler}; prod SQL also lives in auth/store/app | Widen scan to all top-level Go packages; tree clean under widened scope (08c0299) |

### Audited clean (no defect)

- INSERT OR IGNORE / ON CONFLICT — all dialect-branched (settings_backup.go, usage_aggregation.go, additive.go)
- No strftime/julianday/typeof/GLOB in shared paths; `datetime('now')` only inside deliberately SQLite-only harnesses (service openTestDB, store/checksum_test.go)
- AUTOINCREMENT only in SQLite DDL branch; PRAGMA only in SQLite open branch
- All `$n` inside explicit PG-only paths (pgx advisory lease, *_pg_test.go, PG-gated backup tests); store.DB wrapper auto-Rebinds; no un-rebound `?` leaks
- COALESCE(...,0) only on INTEGER/REAL columns; timestamps TEXT RFC3339 in both dialects; LIMIT/OFFSET binds via Rebind
- PG BOOLEAN scanned into Go `int` only in SQLite-only test harnesses (channels_batch_update_test, ts_backup_v21_test)

### Verification

- `go build ./cmd/server` OK, `go vet ./...` OK
- `go test ./... -count=1 -race -timeout 300s` (WSL, SQLite): **all packages ok** (3,914 test functions; PG-only tests skip locally)
- CI test-pg (postgres:16, shared DB, -p 1) exercises the PG proof halves

### Residuals

1. `handler/admin/audit_logs.go:148` path LIKE left without LOWER() — URL paths are lowercase by construction (documented residual).
2. PG proof halves skip locally without PG_TEST_DSN; enforced by CI test-pg.
3. handler/admin runs ~294s under -race on this workstation (slow /mnt/d); the 300s default race gate timed out once under full-suite load — pushed with `METAPI_RACE_TIMEOUT_SECONDS=600` (the hook's own knob; CI's per-package default is 10min).
4. No schema migration needed — zero-migration fixes throughout; sc2_028 untouched.

### Test counts

- 4 new proof files, 9 test functions: store/boolean_bind_test.go (3), store/like_case_test.go (3), handler/admin/events_write_regression_test.go (2), handler/admin/search_case_test.go (1)
- Seed sweep + gate hardening: 53 files changed
- Repo total: 3,914 Test functions, all green locally

DO NOT MERGE — review only.
