### PR TITLE
fix(scheduler): panic recovery, in-flight race, and swallowed-error audit (W18)

### DIFF
--- a/scheduler/admin_snapshot.go
+++ b/scheduler/admin_snapshot.go
@@ -96,7 +96,9 @@ func (s *AdminSnapshotScheduler) runWarm() {
 		wg.Add(1)
 		go func(name string) {
 			defer wg.Done()
-			s.warmTarget(name)
+			// Boundary recovery: these are scheduler-owned goroutines; a
+			// panicking warm must not take the process down.
+			safeJob("admin-snapshot-warm", func() { s.warmTarget(name) })
 		}(target)
 	}
 	wg.Wait()

--- a/scheduler/admin_snapshot.go
+++ b/scheduler/admin_snapshot.go
@@ -50,10 +50,11 @@ func (s *AdminSnapshotScheduler) Stop() error {
 }
 
 // WarmOnce performs a single warm pass. Safe to call externally.
+// De-duplication happens under the mutex inside runWarm: reading inFlight
+// here without the lock raced the ticker path's writes (observed under
+// -race). Returns immediately when a pass is already in flight, same as
+// before.
 func (s *AdminSnapshotScheduler) WarmOnce() {
-	if s.inFlight {
-		return
-	}
 	s.runWarm()
 }
 

--- a/scheduler/backup_webdav.go
+++ b/scheduler/backup_webdav.go
@@ -223,7 +223,9 @@ func newBackupWebdavHTTPTransport() *http.Transport {
 func (s *BackupWebdavScheduler) updateState(store *store.SettingsStore, err error) {
 	previous := map[string]any{}
 	if raw, getErr := store.Get(backupWebdavStateSettingKey); getErr == nil && strings.TrimSpace(raw) != "" {
-		_ = json.Unmarshal([]byte(raw), &previous)
+		if unmarshalErr := json.Unmarshal([]byte(raw), &previous); unmarshalErr != nil {
+			slog.Warn("backup-webdav: previous state is corrupt, resetting", "error", unmarshalErr)
+		}
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	state := map[string]any{
@@ -236,8 +238,14 @@ func (s *BackupWebdavScheduler) updateState(store *store.SettingsStore, err erro
 	} else {
 		state["lastSyncAt"] = now
 	}
-	data, _ := json.Marshal(state)
-	store.Set(backupWebdavStateSettingKey, string(data))
+	data, marshalErr := json.Marshal(state)
+	if marshalErr != nil {
+		slog.Warn("backup-webdav: failed to marshal state", "error", marshalErr)
+		return
+	}
+	if setErr := store.Set(backupWebdavStateSettingKey, string(data)); setErr != nil {
+		slog.Warn("backup-webdav: failed to persist state", "error", setErr)
+	}
 }
 
 // loadBackupWebdavConfig reads and normalizes the WebDAV config from DB settings.
@@ -249,6 +257,9 @@ func loadBackupWebdavConfig(s *store.SettingsStore) (*BackupWebdavConfig, error)
 
 	var cfg BackupWebdavConfig
 	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		// The empty return below silently disables WebDAV backup; make the
+		// corrupt setting visible so operators can fix it.
+		slog.Warn("backup-webdav: stored config is corrupt, backup disabled until fixed", "error", err)
 		return &BackupWebdavConfig{}, nil
 	}
 

--- a/scheduler/channel_recovery.go
+++ b/scheduler/channel_recovery.go
@@ -179,10 +179,14 @@ func (s *ChannelRecoveryScheduler) loadCoolingCandidates(dbw *store.DB) []recove
 	}
 	defer rows.Close()
 
+	var scanErr error
 	for rows.Next() {
 		var c recoveryCandidate
 		c.source = "cooldown"
 		if err := rows.Scan(&c.channelID, &c.modelName); err != nil {
+			if scanErr == nil {
+				scanErr = err
+			}
 			continue
 		}
 		// Skip provider-directed cooldown (failCount<=0 && consecutiveFailCount<=0 && cooldownLevel<=0)
@@ -190,6 +194,12 @@ func (s *ChannelRecoveryScheduler) loadCoolingCandidates(dbw *store.DB) []recove
 		if c.modelName != "" {
 			candidates = append(candidates, c)
 		}
+	}
+	if err := rows.Err(); err != nil && scanErr == nil {
+		scanErr = err
+	}
+	if scanErr != nil {
+		slog.Warn("channel-recovery: cooling candidate rows degraded", "error", scanErr)
 	}
 	return candidates
 }
@@ -220,19 +230,30 @@ func (s *ChannelRecoveryScheduler) loadActiveCandidates(dbw *store.DB) []recover
 		LIMIT 50
 	`)
 	if err != nil {
+		slog.Error("channel-recovery: failed to load active candidates", "error", err)
 		return nil
 	}
 	defer rows.Close()
 
+	var scanErr error
 	for rows.Next() {
 		var c recoveryCandidate
 		c.source = "active"
 		if err := rows.Scan(&c.channelID, &c.modelName); err != nil {
+			if scanErr == nil {
+				scanErr = err
+			}
 			continue
 		}
 		if c.modelName != "" {
 			candidates = append(candidates, c)
 		}
+	}
+	if err := rows.Err(); err != nil && scanErr == nil {
+		scanErr = err
+	}
+	if scanErr != nil {
+		slog.Warn("channel-recovery: active candidate rows degraded", "error", scanErr)
 	}
 	return candidates
 }
@@ -273,16 +294,26 @@ func (s *ChannelRecoveryScheduler) loadActiveCandidatesFromIDs(dbw *store.DB, id
 
 	// Preserve provider order where possible.
 	byID := make(map[int64]recoveryCandidate, len(ids))
+	var scanErr error
 	for rows.Next() {
 		var c recoveryCandidate
 		c.source = "active"
 		if err := rows.Scan(&c.channelID, &c.modelName); err != nil {
+			if scanErr == nil {
+				scanErr = err
+			}
 			continue
 		}
 		c.modelName = strings.TrimSpace(c.modelName)
 		if c.modelName != "" {
 			byID[c.channelID] = c
 		}
+	}
+	if err := rows.Err(); err != nil && scanErr == nil {
+		scanErr = err
+	}
+	if scanErr != nil {
+		slog.Warn("channel-recovery: active candidate rows degraded (provider IDs)", "error", scanErr)
 	}
 
 	candidates := make([]recoveryCandidate, 0, len(byID))

--- a/scheduler/checkin.go
+++ b/scheduler/checkin.go
@@ -399,12 +399,22 @@ func (s *CheckinScheduler) runIntervalPassLocked(dbw *store.DB) {
 	defer rows.Close()
 
 	var candidates []intervalCandidate
+	var scanErr error
 	for rows.Next() {
 		var c intervalCandidate
 		if err := rows.Scan(&c.id, &c.lastCheckinAt); err != nil {
+			if scanErr == nil {
+				scanErr = err
+			}
 			continue
 		}
 		candidates = append(candidates, c)
+	}
+	if err := rows.Err(); err != nil && scanErr == nil {
+		scanErr = err
+	}
+	if scanErr != nil {
+		slog.Warn("checkin interval: candidate rows degraded", "error", scanErr)
 	}
 
 	dueIDs := s.filterDue(candidates, now)

--- a/scheduler/checkin.go
+++ b/scheduler/checkin.go
@@ -124,7 +124,10 @@ func (s *CheckinScheduler) startLocked() {
 			for {
 				select {
 				case <-s.intervalTimer.C:
-					s.runIntervalPass()
+					// Boundary panic recovery: this goroutine is not
+					// covered by cronRunner's wrapper; an unrecovered
+					// panic here would crash the process.
+					safeJob("checkin-interval", s.runIntervalPass)
 				case <-s.intervalStop:
 					return
 				}
@@ -202,13 +205,15 @@ func (s *CheckinScheduler) maybeCatchUpCheckin() {
 
 	if shouldCatchUpCheckin(now, s.cfg.CheckinCron, ranToday > 0, enabled) {
 		slog.Info("checkin: missed today's scheduled time, compensating with immediate run", "spec", s.cfg.CheckinCron)
-		go s.runCronJob()
+		// Bare goroutine: cronRunner's recover only covers cron-fired
+		// runs, so the boundary wrapper must protect this one too.
+		go safeJob("checkin-catchup", s.runCronJob)
 		return
 	}
 
 	// Per-account catch-up (issue #669). Runs in a goroutine so startup is
 	// not blocked; pacing and the per-account lease are reused via CheckinAll.
-	go s.runStaleAccountCatchUp(dbw)
+	go safeJob("checkin-stale-catchup", func() { s.runStaleAccountCatchUp(dbw) })
 }
 
 // runStaleAccountCatchUp enqueues an immediate checkin for every enabled,

--- a/scheduler/cron.go
+++ b/scheduler/cron.go
@@ -124,6 +124,22 @@ func ParseCronExpr(expr string) error {
 	return err
 }
 
+// safeJob runs fn with panic recovery at the scheduler boundary. Every
+// goroutine the scheduler package launches job code in must go through this
+// wrapper (or cronRunner.addJob's equivalent for cron-triggered runs): an
+// unrecovered panic in any of them crashes the entire server process, not
+// just the job. Recovery logs in the same shape as cronRunner.addJob and
+// returns normally so the surrounding runner (tick loop, drain WaitGroup,
+// worker pool) keeps functioning.
+func safeJob(name string, fn func()) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			slog.Error("scheduler job panicked", "name", name, "panic", rec)
+		}
+	}()
+	fn()
+}
+
 // cronRunner wraps a robfig/cron scheduler with panic-safe job execution.
 type cronRunner struct {
 	cron *cron.Cron
@@ -218,6 +234,11 @@ func (r *intervalRunner) start(ctx context.Context, interval time.Duration, imme
 	if r.running {
 		return nil
 	}
+	// Boundary panic recovery: runs execute in bare goroutines (immediate
+	// run and every tick), so a panicking job would otherwise crash the
+	// whole process. Wrap once here so both paths are covered without
+	// per-job ceremony.
+	safeRun := func() { safeJob("interval-runner", run) }
 	r.ticker = time.NewTicker(interval)
 	r.stopCh = make(chan struct{})
 	r.running = true
@@ -240,7 +261,7 @@ func (r *intervalRunner) start(ctx context.Context, interval time.Duration, imme
 					return
 				}
 			}
-			run()
+			safeRun()
 		}()
 	}
 
@@ -248,7 +269,7 @@ func (r *intervalRunner) start(ctx context.Context, interval time.Duration, imme
 		for {
 			select {
 			case <-r.ticker.C:
-				r.launch(run)
+				r.launch(safeRun)
 			case <-r.stopCh:
 				return
 			case <-ctx.Done():

--- a/scheduler/error_surface_test.go
+++ b/scheduler/error_surface_test.go
@@ -1,0 +1,200 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// Error-surfacing tests.
+//
+// Observed defect: channel_recovery.loadActiveCandidates returned nil on a
+// query error without any log (its sibling loadCoolingCandidates logs), so a
+// broken candidate query was invisible in production. The fix must surface
+// the error via structured logging consistent with the package style.
+
+// captureHandler is a minimal slog.Handler that records record messages so
+// tests can assert structured log emission without parsing text output.
+type captureHandler struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.msgs = append(h.msgs, r.Message)
+	return nil
+}
+
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *captureHandler) contains(substr string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, m := range h.msgs {
+		if strings.Contains(m, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *captureHandler) all() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]string, len(h.msgs))
+	copy(out, h.msgs)
+	return out
+}
+
+// installCaptureLog swaps the default slog logger for a capturing handler and
+// restores the previous logger on test cleanup.
+func installCaptureLog(t *testing.T) *captureHandler {
+	t.Helper()
+	h := &captureHandler{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return h
+}
+
+// TestChannelRecoveryLoadActiveCandidatesLogsQueryError forces the fallback
+// SQL query to fail (closed DB) and asserts the error is surfaced via
+// structured logging. Before the fix the error was swallowed silently.
+func TestChannelRecoveryLoadActiveCandidatesLogsQueryError(t *testing.T) {
+	// Force the SQL fallback path (no coordinator provider registered).
+	SetActiveChannelIDsProvider(nil)
+	t.Cleanup(func() { SetActiveChannelIDsProvider(nil) })
+
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	// Close immediately: every subsequent Query fails with
+	// "sql: database is closed", which is exactly the error shape a broken
+	// runtime DB produces in production.
+	if err := db.Close(); err != nil {
+		t.Fatalf("close sqlite: %v", err)
+	}
+
+	h := installCaptureLog(t)
+
+	s := NewChannelRecoveryScheduler(testConfig())
+	if got := s.loadActiveCandidates(db); got != nil {
+		t.Fatalf("expected nil candidates from a closed DB, got %v", got)
+	}
+
+	if !h.contains("failed to load active candidates") {
+		t.Fatalf("query error was swallowed: no structured log emitted; captured messages: %v", h.all())
+	}
+}
+
+// TestChannelRecoveryLoadCoolingCandidatesLogsQueryError pins the existing
+// (correct) behavior of the sibling loader so the fix stays consistent with
+// it: query errors are logged, not returned silently.
+func TestChannelRecoveryLoadCoolingCandidatesLogsQueryError(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close sqlite: %v", err)
+	}
+
+	h := installCaptureLog(t)
+
+	s := NewChannelRecoveryScheduler(testConfig())
+	if got := s.loadCoolingCandidates(db); got != nil {
+		t.Fatalf("expected nil candidates from a closed DB, got %v", got)
+	}
+
+	if !h.contains("failed to load cooling candidates") {
+		t.Fatalf("cooling-candidate query error not logged; captured messages: %v", h.all())
+	}
+}
+
+// TestBackupWebdavCorruptConfigLogsWarning forces a corrupt stored config and
+// asserts the fallback-to-disabled path is surfaced. Before the fix the
+// unmarshal error was swallowed, so WebDAV backup silently stopped working
+// with zero log trail.
+func TestBackupWebdavCorruptConfigLogsWarning(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("auto-migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ss := store.NewSettingsStore(db)
+	if err := ss.Set(backupWebdavConfigSettingKey, "{not-json"); err != nil {
+		t.Fatalf("seed corrupt config: %v", err)
+	}
+
+	h := installCaptureLog(t)
+
+	cfg, err := loadBackupWebdavConfig(ss)
+	if err != nil {
+		t.Fatalf("expected nil error fallback, got %v", err)
+	}
+	if cfg.Enabled {
+		t.Fatalf("corrupt config must fall back to disabled")
+	}
+	if !h.contains("stored config is corrupt") {
+		t.Fatalf("corrupt config was swallowed: no structured log emitted; captured messages: %v", h.all())
+	}
+}
+
+// TestBackupWebdavUpdateStateLogsPersistFailure forces the state write to
+// fail (closed DB) and asserts the failure is logged. Before the fix
+// store.Set's error was discarded.
+func TestBackupWebdavUpdateStateLogsPersistFailure(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	ss := store.NewSettingsStore(db)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close sqlite: %v", err)
+	}
+
+	h := installCaptureLog(t)
+
+	s := NewBackupWebdavScheduler(testConfig())
+	s.updateState(ss, nil)
+
+	if !h.contains("failed to persist state") {
+		t.Fatalf("state persist error was swallowed; captured messages: %v", h.all())
+	}
+}
+
+// TestModelProbePersistResultLogsWriteFailure forces the history insert to
+// fail (closed DB) and asserts the write failure is logged at debug level.
+// Before the fix the Exec error was discarded.
+func TestModelProbePersistResultLogsWriteFailure(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close sqlite: %v", err)
+	}
+
+	h := installCaptureLog(t)
+
+	s := NewModelProbeScheduler(testConfig())
+	s.persistProbeResult(db, ProbeTarget{ChannelID: 1, ModelName: "test-model"}, "success", ProbeOutcome{Status: "success"})
+
+	if !h.contains("failed to persist probe result") {
+		t.Fatalf("probe persist error was swallowed; captured messages: %v", h.all())
+	}
+}

--- a/scheduler/inflight_race_test.go
+++ b/scheduler/inflight_race_test.go
@@ -1,0 +1,106 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// In-flight flag race tests (run under -race).
+//
+// Observed defect: RunProjectionPass read projectionInFlight without holding
+// the mutex while runPass writes it under the mutex, and WarmOnce read
+// inFlight lock-free while runWarm writes it under the mutex. Both read
+// paths are called from other schedulers' goroutines in production
+// (admin-snapshot warms every 20s while usage-aggregation ticks every 5s),
+// so the unsynchronized read/write pair is a real data race, not a
+// theoretical one.
+
+// TestRunProjectionPassInFlightReadIsSynchronized races the external entry
+// point against the ticker path. Before the fix the race detector reports
+// the lock-free projectionInFlight read vs the under-mutex write.
+func TestRunProjectionPassInFlightReadIsSynchronized(t *testing.T) {
+	// Keep store.GetDB() nil so runPass stays a fast no-op after the
+	// in-flight bookkeeping (no lease/DB machinery in the loop).
+	store.OverrideDB(nil)
+	t.Cleanup(func() { store.OverrideDB(nil) })
+
+	s := NewUsageAggregationScheduler(testConfig())
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				s.runPass(context.Background())
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				s.RunProjectionPass()
+			}
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	close(done)
+	wg.Wait()
+}
+
+// TestWarmOnceInFlightReadIsSynchronized races the external entry point
+// against the ticker warm path. Before the fix the race detector reports the
+// lock-free inFlight read in WarmOnce vs the under-mutex write in runWarm.
+func TestWarmOnceInFlightReadIsSynchronized(t *testing.T) {
+	store.OverrideDB(nil)
+	t.Cleanup(func() { store.OverrideDB(nil) })
+
+	s := NewAdminSnapshotScheduler(testConfig(), nil)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				s.runWarm()
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				s.WarmOnce()
+			}
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	close(done)
+	wg.Wait()
+}

--- a/scheduler/model_probe.go
+++ b/scheduler/model_probe.go
@@ -245,10 +245,12 @@ func (s *ModelProbeScheduler) TriggerNow(sync bool) ProbeRunSummary {
 		return ProbeRunSummary{}
 	}
 	if sync {
-		s.runProbe()
+		safeJob("model-probe-now", s.runProbe)
 		return s.LastRunSummary()
 	}
-	go s.runProbe()
+	// Bare goroutine: the boundary wrapper protects the process from a
+	// panicking probe pass (the sync path runs on the caller's stack).
+	go safeJob("model-probe-now", s.runProbe)
 	return s.LastRunSummary()
 }
 
@@ -357,19 +359,24 @@ func (s *ModelProbeScheduler) runProbeLocked(dbw *store.DB) {
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			outcome := s.probeOne(target, timeoutMs, dbw)
-			mu.Lock()
-			switch outcome {
-			case "success":
-				summary.Success++
-			case "failure":
-				summary.Failed++
-			case "inconclusive":
-				summary.Inconclusive++
-			default:
-				summary.Skipped++
-			}
-			mu.Unlock()
+			// Boundary recovery: a panicking probe (e.g. adapter nil
+			// dereference) must not take the process down; the wg/sem
+			// defers above still run, so the pass drains normally.
+			safeJob("model-probe-target", func() {
+				outcome := s.probeOne(target, timeoutMs, dbw)
+				mu.Lock()
+				switch outcome {
+				case "success":
+					summary.Success++
+				case "failure":
+					summary.Failed++
+				case "inconclusive":
+					summary.Inconclusive++
+				default:
+					summary.Skipped++
+				}
+				mu.Unlock()
+			})
 		}()
 	}
 	wg.Wait()

--- a/scheduler/model_probe.go
+++ b/scheduler/model_probe.go
@@ -510,12 +510,18 @@ func (s *ModelProbeScheduler) persistProbeResult(dbw *store.DB, target ProbeTarg
 		errPtr = &e
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
-	_, _ = dbw.Exec(
+	if _, err := dbw.Exec(
 		`INSERT INTO model_probe_results
 			(channel_id, account_id, site_id, model_name, status, latency_ms, http_status, error_text, created_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		target.ChannelID, target.AccountID, target.SiteID, target.ModelName, status, latencyPtr, httpPtr, errPtr, now,
-	)
+	); err != nil {
+		// Best-effort history persistence: probing must continue regardless,
+		// but the write failure must not be invisible. Debug level because
+		// probe runs are high-frequency and the row is non-critical.
+		slog.Debug("model-probe: failed to persist probe result",
+			"channel_id", target.ChannelID, "model", target.ModelName, "error", err)
+	}
 }
 
 // loadProbeTargets selects a budgeted set of active route channels for probing.

--- a/scheduler/panic_recovery_test.go
+++ b/scheduler/panic_recovery_test.go
@@ -1,0 +1,72 @@
+package scheduler
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Panic-recovery boundary tests.
+//
+// Observed defect: cronRunner.addJob wraps every cron-triggered run in a
+// recover, but intervalRunner (9 schedulers) launched each run in a bare
+// goroutine with no recover, and several schedulers spawn additional bare
+// goroutines (checkin interval loop + catch-ups, model-probe TriggerNow,
+// per-target probe workers, admin-snapshot warm workers, sub2api-refresh
+// per-account workers). An unrecovered panic in any of them crashes the
+// entire server process, not just the job. usage_aggregation carries its own
+// in-pass recover with a comment acknowledging exactly this hazard
+// ("Re-panicking would crash the entire server") — proof the boundary gap
+// was known but only patched for one job.
+
+// TestIntervalRunnerPanickingJobSurvivesAndKeepsTicking starts an interval
+// runner whose immediate first run panics and asserts the runner survives
+// and keeps producing runs. Before the fix the panic is unrecovered in the
+// run goroutine, so the entire test binary (like the server process in
+// production) crashes — that crash is the failing evidence.
+func TestIntervalRunnerPanickingJobSurvivesAndKeepsTicking(t *testing.T) {
+	r := &intervalRunner{jitter: func(time.Duration) time.Duration { return 0 }}
+	var runs atomic.Int64
+	if err := r.start(context.Background(), 10*time.Millisecond, true, func() {
+		if runs.Add(1) == 1 {
+			panic("boom: first run panics")
+		}
+	}); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	t.Cleanup(func() { _ = r.stop() })
+
+	deadline := time.Now().Add(10 * time.Second)
+	for runs.Load() < 3 {
+		if time.Now().After(deadline) {
+			t.Fatalf("runner stopped ticking after a panicking run: only %d runs observed", runs.Load())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestIntervalRunnerTickRunPanickingJobSurvives covers the tick-fired path
+// (not just the immediate run): a panicking tick run must not kill the
+// runner or stop future ticks.
+func TestIntervalRunnerTickRunPanickingJobSurvives(t *testing.T) {
+	r := &intervalRunner{jitter: func(time.Duration) time.Duration { return 0 }}
+	var runs atomic.Int64
+	// No immediate run: the first execution is tick-fired after ~15ms.
+	if err := r.start(context.Background(), 15*time.Millisecond, false, func() {
+		if runs.Add(1) == 1 {
+			panic("boom: tick run panics")
+		}
+	}); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	t.Cleanup(func() { _ = r.stop() })
+
+	deadline := time.Now().Add(10 * time.Second)
+	for runs.Load() < 3 {
+		if time.Now().After(deadline) {
+			t.Fatalf("runner stopped ticking after a panicking tick run: only %d runs observed", runs.Load())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/scheduler/safe_job_test.go
+++ b/scheduler/safe_job_test.go
@@ -1,0 +1,22 @@
+package scheduler
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+// TestSafeJobRecoversPanic proves the scheduler-boundary recovery helper:
+// a panicking job must not propagate the panic to the caller's goroutine and
+// the wrapped function must have run. Before the fix safeJob does not exist
+// (compile failure) and every bare-goroutine job site can take the process
+// down with a single panic.
+func TestSafeJobRecoversPanic(t *testing.T) {
+	var ran atomic.Bool
+	safeJob("test-job", func() {
+		ran.Store(true)
+		panic("boom: test panic")
+	})
+	if !ran.Load() {
+		t.Fatal("safeJob did not run the wrapped function")
+	}
+}

--- a/scheduler/site_announcement.go
+++ b/scheduler/site_announcement.go
@@ -154,10 +154,14 @@ func (s *SiteAnnouncementScheduler) runResidualScan(dbw *store.DB) {
 	defer rows.Close()
 
 	count := 0
+	var scanErr error
 	for rows.Next() {
 		var id int64
 		var platform, url string
 		if err := rows.Scan(&id, &platform, &url); err != nil {
+			if scanErr == nil {
+				scanErr = err
+			}
 			continue
 		}
 		_ = id
@@ -165,6 +169,12 @@ func (s *SiteAnnouncementScheduler) runResidualScan(dbw *store.DB) {
 		_ = url
 		// Known limitation: site row is counted only. No adapter / DB write.
 		count++
+	}
+	if err := rows.Err(); err != nil && scanErr == nil {
+		scanErr = err
+	}
+	if scanErr != nil {
+		slog.Warn("site-announcement: residual scan rows degraded", "error", scanErr)
 	}
 
 	slog.Info("site-announcement: residual scan complete (no announcements written)", "sites", count)

--- a/scheduler/site_probe_admin.go
+++ b/scheduler/site_probe_admin.go
@@ -127,18 +127,22 @@ loop:
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			outcome := s.probeOne(target, timeoutMs)
-			// Don't stream to a cancelled caller — the client is gone and
-			// writing would just block / error downstream. The probe still
-			// ran to completion and any health mutation already happened.
-			if ctx.Err() != nil {
-				return
-			}
-			onResult(ProbeSiteResult{
-				ChannelID: target.ChannelID,
-				AccountID: target.AccountID,
-				Model:     target.ModelName,
-				Status:    outcome,
+			// Boundary recovery: a panicking probe must not take the
+			// process down; the wg/sem defers above still run.
+			safeJob("site-probe-target", func() {
+				outcome := s.probeOne(target, timeoutMs)
+				// Don't stream to a cancelled caller — the client is gone and
+				// writing would just block / error downstream. The probe still
+				// ran to completion and any health mutation already happened.
+				if ctx.Err() != nil {
+					return
+				}
+				onResult(ProbeSiteResult{
+					ChannelID: target.ChannelID,
+					AccountID: target.AccountID,
+					Model:     target.ModelName,
+					Status:    outcome,
+				})
 			})
 		}()
 	}

--- a/scheduler/sub2api_refresh.go
+++ b/scheduler/sub2api_refresh.go
@@ -107,10 +107,14 @@ func (s *Sub2APIRefreshScheduler) runPassLocked(dbw *store.DB) {
 
 	var scanned int
 	var eligible []candidate
+	var scanErr error
 	for rows.Next() {
 		var id int64
 		var extraConfig *string
 		if err := rows.Scan(&id, &extraConfig); err != nil {
+			if scanErr == nil {
+				scanErr = err
+			}
 			continue
 		}
 		scanned++
@@ -118,6 +122,12 @@ func (s *Sub2APIRefreshScheduler) runPassLocked(dbw *store.DB) {
 			continue
 		}
 		eligible = append(eligible, candidate{id: id})
+	}
+	if err := rows.Err(); err != nil && scanErr == nil {
+		scanErr = err
+	}
+	if scanErr != nil {
+		slog.Warn("sub2api-refresh: account rows degraded", "error", scanErr)
 	}
 
 	if len(eligible) == 0 {

--- a/scheduler/sub2api_refresh.go
+++ b/scheduler/sub2api_refresh.go
@@ -146,14 +146,18 @@ func (s *Sub2APIRefreshScheduler) runPassLocked(dbw *store.DB) {
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			_, err := balance.RefreshBalance(s.cfg, dbw.DB, c.id)
-			if err != nil {
-				failed.Add(1)
-				slog.Warn("sub2api-refresh: RefreshBalance failed",
-					"account_id", c.id, "error", err)
-				return
-			}
-			refreshed.Add(1)
+			// Boundary recovery: a panicking upstream adapter must not
+			// take the process down; the wg/sem defers above still run.
+			safeJob("sub2api-refresh-account", func() {
+				_, err := balance.RefreshBalance(s.cfg, dbw.DB, c.id)
+				if err != nil {
+					failed.Add(1)
+					slog.Warn("sub2api-refresh: RefreshBalance failed",
+						"account_id", c.id, "error", err)
+					return
+				}
+				refreshed.Add(1)
+			})
 		}()
 	}
 	wg.Wait()

--- a/scheduler/usage_aggregation.go
+++ b/scheduler/usage_aggregation.go
@@ -66,12 +66,11 @@ type ProjectionPassResult struct {
 }
 
 // RunProjectionPass executes a single projection pass.
-// Safe to call externally (e.g., from admin snapshot).
+// Safe to call externally (e.g., from admin snapshot). De-duplication
+// happens under the mutex inside runPass: reading projectionInFlight here
+// without the lock raced the ticker path's writes (observed under -race).
+// Returns nil when a pass is already in flight, same as before.
 func (s *UsageAggregationScheduler) RunProjectionPass() *ProjectionPassResult {
-	if s.projectionInFlight {
-		// De-duplicate: return nil to signal in-flight
-		return nil
-	}
 	return s.runPass(context.Background())
 }
 


### PR DESCRIPTION
## Summary

Audit and hardening of the `scheduler/` package (16 background jobs on robfig/cron/v3), covering panic recovery, job overlap, shutdown, error handling, and dialect-unsafe SQL. Every real defect below was proven with a failing test before fixing. No new dependencies, no speculative abstractions, zero schema migration, JSON camelCase and env names untouched.

## Audit findings

| Category | Finding | Evidence (RED) | Action |
|---|---|---|---|
| 1. Panic recovery | **Defect.** `intervalRunner` executes jobs in bare goroutines with no recover, and several schedulers spawn their own uncovered goroutines: checkin interval loop + catchups, model-probe `TriggerNow` + per-target workers, site-probe workers, admin-snapshot warm workers, sub2api-refresh per-account workers. Only cron-fired runs (`cronRunner.addJob`) and `usage_aggregation.runPass` recovered. One panicking job crashed the whole server process. | `panic: boom: first run panics` from `scheduler.(*intervalRunner).start.func1` (cron.go:243) in the new panic tests; `undefined: safeJob` compile failure before the fix | Single `safeJob(name, fn)` wrapper at the scheduler boundary (cron.go), applied at every bare-goroutine job site. Cron-fired runs keep their existing recovery; no per-job ceremony |
| 2. Overlap | **No defect.** Every job is already serialized: mutex-guarded in-flight flags (admin_snapshot, channel_recovery, oauth_refresh, site_announcement, sub2api_refresh, update_center, usage_aggregation, checkin interval) or name-scoped `runWithSchedulerLease` (PG `pg_try_advisory_lock` / SQLite process-local map) for retention x4, model-probe, and all cron jobs | Code inspection: lease.go + per-scheduler guards; `lease_test.go` green under -race | None (extra single-flight layering would be redundant abstraction) |
| 3. Shutdown | **No defect (bounded-drain by design).** Bounded drains (`stopDrainBudget`=5s, `registryStopBudget`=10s), `StopBackgroundServices` before `store.CloseDatabase` in `onClose`, lifecycle-ctx cancellation for retention/oauth/checkin | Existing `graceful_stop_test.go` + `shutdown_cancel_test.go` green under -race | None; residual documented below |
| 4. Error handling | **Defect.** Swallowed DB errors: `channel_recovery.loadActiveCandidates` returned nil on query error with no log (sibling `loadCoolingCandidates` logged); scan loops silently `continue`d without `rows.Err()` in channel_recovery (x3 loaders), checkin interval pass, site_announcement residual scan, sub2api_refresh; `backup_webdav` discarded a corrupt stored config (silently disabling backup) and ignored state marshal/persist failures; `model_probe` discarded the probe-history INSERT error | RED: `TestChannelRecoveryLoadActiveCandidatesLogsQueryError` failed with "captured messages: []"; the three webdav/probe error-surface tests fail against HEAD sources (stash-verified) | Structured `slog` surfacing in existing package style: Error for failed candidate loads, Warn for degraded scans / corrupt config / persist failures, Debug for best-effort probe history |
| 5. Dialect-unsafe SQL | **No defect.** Portable SQL throughout; `?` placeholders are rebound to `$N` for PG by the store.DB helpers (store/open.go:33); the only dialect split (`usage_aggregation` ensureQuery: `INSERT OR IGNORE` vs `ON CONFLICT DO NOTHING`) is already branched | grep of scheduler/ + store rebind contract | None |

## Files changed

- `scheduler/cron.go` — `safeJob` helper + intervalRunner boundary wrap
- `scheduler/checkin.go` — interval loop + catchup goroutine wraps; interval scan error surfacing
- `scheduler/model_probe.go` — TriggerNow + probe worker wraps; probe-history persist error surfacing
- `scheduler/site_probe_admin.go` — probe worker wrap
- `scheduler/admin_snapshot.go` — warm worker wrap; WarmOnce de-dup moved under the mutex
- `scheduler/sub2api_refresh.go` — account worker wrap; scan error surfacing
- `scheduler/usage_aggregation.go` — RunProjectionPass de-dup moved under the mutex
- `scheduler/channel_recovery.go` — active-loader query error logging; scan/rows.Err surfacing in all three loaders
- `scheduler/site_announcement.go` — residual scan error surfacing
- `scheduler/backup_webdav.go` — corrupt-config warning; state marshal/persist error surfacing
- `scheduler/panic_recovery_test.go`, `scheduler/safe_job_test.go`, `scheduler/inflight_race_test.go`, `scheduler/error_surface_test.go` — new tests

## Test evidence

RED (before fixes):
- Panic: `panic: boom: first run panics` via `intervalRunner.start.func1` (cron.go:243); `undefined: safeJob` build failure
- Race: `WARNING: DATA RACE ... Write ... runPass() usage_aggregation.go:84 ... Previous read ... RunProjectionPass() usage_aggregation.go:71`
- Errors: `error_surface_test.go: query error was swallowed: no structured log emitted; captured messages: []`; webdav corrupt-config / state-persist / probe-persist tests FAIL against HEAD sources

GREEN (after fixes):
- `go test ./scheduler/ -count=1 -race` green (62.4s), including all new tests
- Full pre-push gate green: frontend 220 files / 1405 tests, `go build ./cmd/server`, `go vet ./...`, and full `go test ./... -count=1 -race` all ok (scheduler 47.8s; handler/admin 235.3s)

## Residuals

1. 10 schedulers still derive their job context from `context.Background()` — bounded-drain design (`stopDrainBudget`/`registryStopBudget`); shutdown tests cover the lifecycle-aware paths.
2. `usage_aggregation.runPass` intentionally keeps its inner recover: it releases the lease on panic (comment in code).
3. `handler/admin` sits near the race-gate's 300s budget in the local WSL environment (~235-285s; master baseline 281s vs this branch 285s in isolation, i.e. unchanged by this PR). The push used the hook's own `METAPI_RACE_TIMEOUT_SECONDS=600` knob for that environment; GitHub Actions remains the final verification gate.
4. The mid-stream row-degradation paths (`scanErr`) cannot be unit-induced with a real driver without a faulty-rows mock; they follow the package's existing `selectStaleCheckinAccountIDs`/`queryProbeTargets` style and are pinned by compile + race suite.