### PR TITLE
chore(testing): raise race-gate per-package timeout default to 900s

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Testing Strategy and Real-Platform Testbed
 
-**Last verified**: 2026-08-16
+**Last verified**: 2026-08-29
 
 > Public, environment-agnostic test guidance. Product state lives in [`STATE.md`](internal/STATE.md); open outcomes live in [`progress/MASTER.md`](internal/progress/MASTER.md).
 
@@ -14,6 +14,38 @@
 | Real-service CI           | `.github/workflows/main.yml`                                                         | New API, One API, Sub2API and CLIProxyAPI detect/login/route/proxy chains in service containers, plus cross-OS binary runtime smoke (`runtime-smoke-matrix`) |
 | Frontend acceptance       | [`../web/scripts/acceptance-e2e.mjs`](../web/scripts/acceptance-e2e.mjs) (+ [`acceptance-probe-header-quirk.mjs`](../web/scripts/acceptance-probe-header-quirk.mjs) for the fresh-site accounts-page race) | Real-browser user journeys (Playwright) against a live metapi + real upstream; operator-gated, not a PR check |
 | Operator runtime evidence | `scripts/e2e/*.sh` and focused staging procedures                                    | Compatibility that requires real credentials, topology, or upstream behavior |
+
+## Race-detector budget (local push gate)
+
+The pre-push gate (`scripts/go-race.sh`, chained from
+`.githooks/pre-push-project`) runs the full suite under `-race` with a
+per-package timeout. The default is **900s**; override it with
+`METAPI_RACE_TIMEOUT_SECONDS=<seconds>` when a host needs more headroom.
+
+Why 900s (measured, August 2026):
+
+- Six independent development lanes hit the old 300s default on
+  `handler/admin` while parallel lanes contended for an 8GB WSL VM on a slow
+  `/mnt/d` 9p mount. Isolated measurements of `handler/admin` under
+  `-race` range **217-364s** depending on host load; the master baseline is
+  equally critical.
+- CI gives each package ~10 minutes (Go's default `go test` timeout) inside
+  30-minute shard jobs, so 900s matches both CI headroom and the measured
+  worst cases.
+
+Operational guidance:
+
+- Stagger push gates: keep race lanes to **4 or fewer concurrent** on one dev
+  host. Beyond that, per-package times inflate and gates time out for
+  environmental reasons, not code regressions.
+- On a timeout the gate prints a one-line hint; raise the knob (for example
+  `METAPI_RACE_TIMEOUT_SECONDS=1500`) rather than skipping the gate.
+  `git push --no-verify` is emergency-only.
+
+CI is unaffected by this default: `.github/workflows/main.yml` never calls
+`go-race.sh`. It shards packages across four runners and runs `go test
+-race` with Go's default 10-minute per-package timeout, so raising the local
+gate default cannot weaken CI.
 
 ## Golden snapshot suites (protocol conversion)
 

--- a/scripts/go-race.sh
+++ b/scripts/go-race.sh
@@ -1,11 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-timeout_seconds="${METAPI_RACE_TIMEOUT_SECONDS:-300}"
+# Per-package budget for the race gate. Default 900s: handler/admin -race was
+# measured at 217-364s on contended dev hosts (8GB WSL VM, /mnt/d 9p) across
+# six Wave 18 lanes, and CI gives each package ~10 min (Go's default test
+# timeout). Override with METAPI_RACE_TIMEOUT_SECONDS=<seconds>; see
+# docs/testing.md "Race-detector budget".
+timeout_seconds="${METAPI_RACE_TIMEOUT_SECONDS:-900}"
 if [[ ! "$timeout_seconds" =~ ^[0-9]+$ ]] || (( timeout_seconds < 1 )); then
   echo "race: METAPI_RACE_TIMEOUT_SECONDS must be a positive integer." >&2
   exit 2
 fi
+
+race_log="$(mktemp)"
+trap 'rm -f "$race_log"' EXIT
+
+# Stream the race run while keeping a copy; if it fails on a per-package
+# timeout, point the operator at the budget knob.
+run_race() {
+  if "$@" 2>&1 | tee "$race_log"; then
+    return 0
+  fi
+  if grep -q "test timed out" "$race_log"; then
+    echo "race: a package exceeded the ${timeout_seconds}s per-package budget; raise it with METAPI_RACE_TIMEOUT_SECONDS=<seconds>." >&2
+  fi
+  return 1
+}
 
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*)
@@ -15,10 +35,11 @@ case "$(uname -s)" in
     fi
     windows_repo="$(pwd -W)"
     echo "race: Windows detected; running the Go race detector inside WSL"
-    MSYS_NO_PATHCONV=1 wsl.exe --cd "$windows_repo" -- \
+    export MSYS_NO_PATHCONV=1
+    run_race wsl.exe --cd "$windows_repo" -- \
       bash -lc "go test ./... -count=1 -race -timeout ${timeout_seconds}s"
     ;;
   *)
-    go test ./... -count=1 -race -timeout "${timeout_seconds}s"
+    run_race go test ./... -count=1 -race -timeout "${timeout_seconds}s"
     ;;
 esac


### PR DESCRIPTION
Milestone C3: fix the race-gate timeout budget problem proven across Wave 18.

## Problem

Six independent lanes hit the pre-push race gate's default **300s** per-package timeout on `handler/admin` while parallel lanes contended for the 8GB WSL VM on the slow `/mnt/d` 9p filesystem. Every lane worked around it with the official `METAPI_RACE_TIMEOUT_SECONDS` knob (600/900/1500/1800). Master baseline is equally critical.

## Change (chore, minimal diff: 2 files, +57/-4)

- `scripts/go-race.sh`: raise the per-package timeout default **300s → 900s** (matches CI headroom and measured worst cases); the `METAPI_RACE_TIMEOUT_SECONDS` override is unchanged.
- `scripts/go-race.sh`: when a package times out, the gate now prints a one-line hint pointing at the knob.
- `docs/testing.md`: new **Race-detector budget (local push gate)** section — rationale with measured numbers, the knob, and the operational guidance *stagger push gates / ≤4 concurrent race lanes*.

No new dependencies, `go.mod` untouched, no change to which packages run under `-race`.

## Measurements

| Measurement | Value |
| :--- | :--- |
| Old gate default | 300s |
| Isolated `handler/admin -race` (Wave 18 lanes, load-dependent) | 217–364s |
| Verification run, `METAPI_RACE_TIMEOUT_SECONDS=900`, `handler/admin` | 222.5s |
| Real pre-push gate run (this PR), `handler/admin` | 279.7s |
| **New default** | **900s** |
| CI per-package budget (Go default `go test` timeout, 30-min shard jobs) | ~10 min |

## CI cannot be weakened by this change

`.github/workflows/main.yml` never calls `go-race.sh`. The `test-sqlite-shard` job shards packages across four runners and runs `go test -race` with Go's default 10-minute per-package timeout, so raising the local gate default does not touch CI behavior.

## Verification

- `METAPI_RACE_TIMEOUT_SECONDS=900 bash scripts/go-race.sh` end-to-end in the worktree: all packages green, exit 0 (~7.5 min).
- Real pre-push gate on push: frontend (1425 tests) + `go build ./cmd/server` + `go vet ./...` + race gate all green via the Windows→WSL path.
- Shim-based functional checks: default-with-no-knob resolves to 900s; knob override passes through verbatim; timeout path prints the hint and exits 1; plain test failures exit 1 with no hint; invalid knob still exits 2.