### PR TITLE
feat(admin): machine-readable errorCode on unified 400 errors (audit S4)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # Admin API Reference
 
-**Last updated**: 2026-08-23
+**Last updated**: 2026-08-29
 **Coverage note**: every `/api` route registered by the Go server gets a `### METHOD /path` detail section — the authoritative route list is the [Admin Route Inventory](#admin-route-inventory) at the bottom. Backward-compat aliases (e.g. `GET /api/stats/model-prices`) are documented as aliases rather than duplicating the canonical handler.
 
 Base URL: `http://localhost:4000/api`
@@ -64,16 +64,44 @@ body). The unified error body is:
 ```json
 {
   "error": "Error description",
+  "errorCode": "optional machine-readable identifier",
   "request_id": "optional correlation id"
 }
 ```
 
-`request_id` is additive and omitted when no request ID is present. A few
-legacy endpoints (some batch/500 paths under `/api/accounts`, sites import)
-still answer with the TS-era `{ "message": "Error description" }` shape; the
-frontend reads both keys, so both forms surface identically.
+- `error` is the human-readable message. It is for display only — clients
+  must never branch on its text when a registered `errorCode` exists.
+- `errorCode` is an **optional, additive** machine-readable identifier for
+  the failure class (see the registry below). It is present only on
+  endpoints that have registered a code; every other error body is
+  byte-identical to the pre-existing shape (no `errorCode` key at all).
+  Clients that ignore `errorCode` observe no change.
+- `request_id` is additive and omitted when no request ID is present.
+
+A few legacy endpoints (some batch/500 paths under `/api/accounts`, sites
+import) still answer with the TS-era `{ "message": "Error description" }`
+shape; the frontend reads both keys, so both forms surface identically.
 
 HTTP status codes: 200 (OK), 201 (Created), 202 (Accepted), 400 (Bad Request), 401 (Unauthorized), 404 (Not Found), 500 (Internal Server Error).
+
+#### errorCode convention and registry
+
+`errorCode` values are stable **camelCase** identifiers (matching the
+project-wide camelCase JSON rule). Codes are only introduced for real call
+sites; this table is the registry and grows deliberately. Constants live in
+`handler/admin/error_codes.go` and are pinned by
+`handler/admin/error_codes_test.go`.
+
+| errorCode              | Status | Where                                          | Meaning                                                        |
+| ---------------------- | ------ | ---------------------------------------------- | -------------------------------------------------------------- |
+| `invalidId`            | 400    | any `/api/.../{id}` route (pathID helper)      | path ID missing, non-numeric or non-positive                   |
+| `invalidDatabaseType`  | 400    | `/api/settings/database/*`                     | runtime-database dialect is neither `sqlite` nor `postgres`    |
+| `emptyMigrationTarget` | 400    | `POST /api/settings/database/migrate`          | target connection string is blank                              |
+| `sameMigrationTarget`  | 400    | `POST /api/settings/database/migrate`          | target resolves to the currently-running database (rejected)   |
+
+Frontend note: the admin UI historically detected the same-target migration
+rejection by substring-matching the message text; it should migrate to
+`errorCode === "sameMigrationTarget"`.
 
 ## Request Body Rules
 

--- a/handler/admin/contract_envelope_test.go
+++ b/handler/admin/contract_envelope_test.go
@@ -10,8 +10,11 @@ package admin
 //     {items,total,page,pageSize} (/api/channels),
 //     and {success,...} envelopes (/api/downstream-keys).
 //  2. Error responses: non-2xx with the unified camelCase {"error":"..."}
-//     body (shared.WriteError). A few TS-era paths still answer non-2xx with
-//     a legacy {"message":"..."} body; the frontend http-client reads both
+//     body (shared.WriteError). Endpoints with a registered machine-readable
+//     class add an additive optional "errorCode" (registry: docs/api.md;
+//     pins: error_codes_test.go); unregistered sites keep the exact legacy
+//     body. A few TS-era paths still answer non-2xx with a legacy
+//     {"message":"..."} body; the frontend http-client reads both
 //     (resolveResponseMessage), so that shape is pinned as-is rather than
 //     changed.
 //

--- a/handler/admin/error_codes.go
+++ b/handler/admin/error_codes.go
@@ -1,0 +1,30 @@
+package admin
+
+// Machine-readable errorCode values carried on unified admin error bodies
+// ({"error", "errorCode", ...}). Contract + registry table: docs/api.md.
+//
+// Convention: errorCode values are stable camelCase identifiers. The field
+// is OPTIONAL and additive — endpoints without a registered code omit it
+// entirely, and the human-readable "error" message stays the source of
+// truth for display. Clients must never substring-match on "error" when a
+// code exists for their case.
+//
+// New codes are added only for real call sites (no speculative taxonomy);
+// register every new constant in the docs/api.md registry table.
+const (
+	// ErrorCodeInvalidID rejects a URL path ID that is missing, non-numeric
+	// or non-positive (pathID helper; every /api route with an {id} segment).
+	ErrorCodeInvalidID = "invalidId"
+
+	// ErrorCodeInvalidDatabaseType rejects a runtime-database dialect that is
+	// neither sqlite nor postgres (/api/settings/database/* endpoints).
+	ErrorCodeInvalidDatabaseType = "invalidDatabaseType"
+
+	// ErrorCodeEmptyMigrationTarget rejects a migration request whose target
+	// connection string is blank (POST /api/settings/database/migrate).
+	ErrorCodeEmptyMigrationTarget = "emptyMigrationTarget"
+
+	// ErrorCodeSameMigrationTarget rejects a migration whose target resolves
+	// to the currently-running database (POST /api/settings/database/migrate).
+	ErrorCodeSameMigrationTarget = "sameMigrationTarget"
+)

--- a/handler/admin/error_codes_test.go
+++ b/handler/admin/error_codes_test.go
@@ -1,0 +1,193 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+)
+
+// Audit S4: machine-readable errorCode on admin 400 responses.
+//
+// These tests pin the errorCode contract so it cannot silently regress:
+//
+//  1. Envelope semantics — "error" stays the human-readable message and
+//     "errorCode" is additive camelCase, present exactly on registered sites
+//     and absent everywhere else (byte-identical legacy body).
+//  2. Code pins — every code the frontend's message-substring matching
+//     migrates onto (sameMigrationTarget first) is asserted with its exact
+//     identifier and status on the real handler.
+//  3. Regression guard — assertErrorCodeBody fails the moment a registered
+//     site falls back to a message-only body, and the registry-stability
+//     test fails on any drive-by rename of a public identifier.
+
+// assertErrorCodeBody pins the unified error envelope for a coded site: the
+// body must carry exactly wantCode plus a non-empty human-readable "error".
+// A failure here means the site regressed to message-only (or drifted to an
+// unregistered code), breaking the docs/api.md registry contract.
+func assertErrorCodeBody(t *testing.T, raw []byte, wantCode string) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("error body is not valid JSON: %v raw=%s", err, string(raw))
+	}
+	if got, _ := body["errorCode"].(string); got != wantCode {
+		t.Fatalf("errorCode = %q, want %q (site regressed or drifted; body: %s)", got, wantCode, string(raw))
+	}
+	if msg, _ := body["error"].(string); strings.TrimSpace(msg) == "" {
+		t.Fatalf("human-readable error message missing alongside errorCode %q: %s", wantCode, string(raw))
+	}
+	if success, has := body["success"]; has && success == true {
+		t.Fatalf("error body must not claim success=true: %s", string(raw))
+	}
+	return body
+}
+
+// ---- Registry stability: the literal values are a public contract ----
+
+func TestErrorCodeRegistry_StableIdentifiers(t *testing.T) {
+	// docs/api.md publishes these identifiers and API clients (soon the admin
+	// UI) branch on them. Renaming one is a breaking change: update the
+	// registry table and consumers deliberately, never as a side effect.
+	pinned := map[string]string{
+		"invalidId":            ErrorCodeInvalidID,
+		"invalidDatabaseType":  ErrorCodeInvalidDatabaseType,
+		"emptyMigrationTarget": ErrorCodeEmptyMigrationTarget,
+		"sameMigrationTarget":  ErrorCodeSameMigrationTarget,
+	}
+	for want, got := range pinned {
+		if got != want {
+			t.Errorf("registered errorCode drifted: got %q, want %q", got, want)
+		}
+	}
+}
+
+// ---- Frontend-matched flagship: same-target migration rejection ----
+
+// newMigrationHandlerForTest builds a databaseHandler whose migration source
+// is a file-backed SQLite runtime DB (the settings DB backing the handler is
+// a separate in-memory store).
+func newMigrationHandlerForTest(t *testing.T, sourcePath string) *databaseHandler {
+	t.Helper()
+	settingsDB := setupBackupTestDB(t)
+	cfg := config.Load(map[string]string{
+		"DB_TYPE": "sqlite",
+		"DB_URL":  sourcePath,
+	})
+	return &databaseHandler{db: settingsDB.DB, cfg: cfg}
+}
+
+func doPostMigration(t *testing.T, h *databaseHandler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/database/migrate", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.migrate(rec, req)
+	return rec
+}
+
+// TestErrorCode_MigrateSameTarget pins the rejection the admin UI historically
+// detected by substring-matching the message text (message.includes("相同"));
+// the UI migrates to errorCode == "sameMigrationTarget".
+func TestErrorCode_MigrateSameTarget_PinnedCodeAndMessage(t *testing.T) {
+	resetBackgroundTasksForTests()
+	t.Cleanup(func() { resetBackgroundTasksForTests() })
+
+	h := newMigrationHandlerForTest(t, "C:/data/hub.db")
+	rec := doPostMigration(t, h, `{
+		"dialect": "sqlite",
+		"connectionString": "sqlite://C:/data/hub.db"
+	}`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	body := assertErrorCodeBody(t, rec.Body.Bytes(), ErrorCodeSameMigrationTarget)
+	// The human message is still toasted verbatim by UIs that have not
+	// adopted the code; it must not change shape under this contract.
+	if msg := body["error"].(string); !strings.Contains(msg, "same as the running database") {
+		t.Fatalf("human-readable message changed: %q", msg)
+	}
+}
+
+func TestErrorCode_MigrateEmptyConnectionString_PinnedCode(t *testing.T) {
+	resetBackgroundTasksForTests()
+	t.Cleanup(func() { resetBackgroundTasksForTests() })
+
+	h := newMigrationHandlerForTest(t, "C:/data/hub.db")
+	rec := doPostMigration(t, h, `{"dialect": "sqlite", "connectionString": "   "}`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	assertErrorCodeBody(t, rec.Body.Bytes(), ErrorCodeEmptyMigrationTarget)
+}
+
+func TestErrorCode_MigrateInvalidDialect_PinnedCode(t *testing.T) {
+	resetBackgroundTasksForTests()
+	t.Cleanup(func() { resetBackgroundTasksForTests() })
+
+	h := newMigrationHandlerForTest(t, "C:/data/hub.db")
+	rec := doPostMigration(t, h, `{"dialect": "mysql", "connectionString": "x"}`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	assertErrorCodeBody(t, rec.Body.Bytes(), ErrorCodeInvalidDatabaseType)
+}
+
+// ---- pathID choke point: every {id} route rejection ----
+
+func TestErrorCode_PathID_PinnedCode(t *testing.T) {
+	_, r := setupSitesTest(t)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"non-numeric id on update", http.MethodPut, "/api/sites/not-a-number"},
+		{"zero id on update", http.MethodPut, "/api/sites/0"},
+		{"non-numeric id on delete", http.MethodDelete, "/api/sites/abc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(`{"name":"x"}`))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+			}
+			assertErrorCodeBody(t, rec.Body.Bytes(), ErrorCodeInvalidID)
+		})
+	}
+}
+
+// ---- Absent-semantics: uncoded sites keep the legacy body ----
+
+// TestErrorCode_UncodedSite_OmitsField guards the non-breaking half of the
+// contract: 400 sites without a registered code must NOT gain an errorCode
+// key (no errorCode:null, no errorCode:""), so existing clients observe the
+// exact pre-existing body.
+func TestErrorCode_UncodedSite_OmitsField(t *testing.T) {
+	_, r := setupSitesTest(t)
+	resp := doPostJSON(t, r, "/api/sites", map[string]any{"name": "", "url": ""})
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v raw=%s", err, resp.Body.String())
+	}
+	if raw := resp.Body.String(); strings.Contains(raw, "errorCode") {
+		t.Fatalf("uncoded site must not emit errorCode, got body %s", raw)
+	}
+	if msg, _ := body["error"].(string); strings.TrimSpace(msg) == "" {
+		t.Fatalf("human-readable error message missing: %s", resp.Body.String())
+	}
+}

--- a/handler/admin/helpers.go
+++ b/handler/admin/helpers.go
@@ -224,11 +224,13 @@ func clampInt(v, lo, hi int) int {
 
 // pathID parses the chi "id" URL param as a positive int64 and writes a
 // unified 400 error when invalid. Callers must return when ok is false.
+// The rejection carries ErrorCodeInvalidID so clients can distinguish a
+// malformed path ID from payload validation failures.
 func pathID(w http.ResponseWriter, r *http.Request) (int64, bool) {
 	idStr := strings.TrimSpace(chi.URLParam(r, "id"))
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || id <= 0 {
-		writeErrorWithRequest(w, r, http.StatusBadRequest, "invalid ID")
+		writeErrorCodeWithRequest(w, r, http.StatusBadRequest, ErrorCodeInvalidID, "invalid ID")
 		return 0, false
 	}
 	return id, true

--- a/handler/admin/response_errors.go
+++ b/handler/admin/response_errors.go
@@ -35,3 +35,24 @@ func writeErrorWithRequest(w http.ResponseWriter, r *http.Request, code int, mes
 		RequestID: requestID,
 	})
 }
+
+// writeErrorCode writes a unified admin API error carrying a machine-readable
+// errorCode (stable camelCase identifier; registry in docs/api.md) alongside
+// the human-readable message. The field is additive: clients that ignore it
+// see the exact pre-existing body. Use it instead of writeError at any 400-class
+// site a client may need to branch on programmatically.
+func writeErrorCode(w http.ResponseWriter, code int, errorCode, message string) {
+	shared.WriteErrorCode(w, code, errorCode, message)
+}
+
+// writeErrorCodeWithRequest is writeErrorCode plus the request-id correlation
+// behaviour of writeErrorWithRequest.
+func writeErrorCodeWithRequest(w http.ResponseWriter, r *http.Request, code int, errorCode, message string) {
+	requestID := middleware.GetReqID(r.Context())
+	shared.WriteAPIError(w, &shared.APIError{
+		Code:      code,
+		Message:   message,
+		ErrorCode: errorCode,
+		RequestID: requestID,
+	})
+}

--- a/handler/admin/settings_database.go
+++ b/handler/admin/settings_database.go
@@ -180,7 +180,7 @@ func (h *databaseHandler) saveRuntime(w http.ResponseWriter, r *http.Request) {
 	if body.Dialect != nil {
 		dialect, ok := normalizeRuntimeDatabaseDialect(*body.Dialect)
 		if !ok {
-			writeError(w, http.StatusBadRequest, "database type must be sqlite or postgres")
+			writeErrorCode(w, http.StatusBadRequest, ErrorCodeInvalidDatabaseType, "database type must be sqlite or postgres")
 			return
 		}
 		upsertSettingDB(h.db, "db_type", dialect)
@@ -217,7 +217,7 @@ func (h *databaseHandler) testConnection(w http.ResponseWriter, r *http.Request)
 
 	dialect, ok := normalizeRuntimeDatabaseDialect(body.Dialect)
 	if !ok {
-		writeError(w, http.StatusBadRequest, "database type must be sqlite or postgres")
+		writeErrorCode(w, http.StatusBadRequest, ErrorCodeInvalidDatabaseType, "database type must be sqlite or postgres")
 		return
 	}
 
@@ -269,13 +269,13 @@ func (h *databaseHandler) migrate(w http.ResponseWriter, r *http.Request) {
 
 	targetDialect, ok := normalizeRuntimeDatabaseDialect(body.Dialect)
 	if !ok {
-		writeError(w, http.StatusBadRequest, "database type must be sqlite or postgres")
+		writeErrorCode(w, http.StatusBadRequest, ErrorCodeInvalidDatabaseType, "database type must be sqlite or postgres")
 		return
 	}
 
 	targetURL := strings.TrimSpace(body.ConnectionString)
 	if targetURL == "" {
-		writeError(w, http.StatusBadRequest, "target database connection string must not be empty")
+		writeErrorCode(w, http.StatusBadRequest, ErrorCodeEmptyMigrationTarget, "target database connection string must not be empty")
 		return
 	}
 
@@ -287,8 +287,10 @@ func (h *databaseHandler) migrate(w http.ResponseWriter, r *http.Request) {
 
 	// Refuse to migrate onto the live runtime database: overwriting the DB
 	// the server is currently using would be destructive mid-request.
+	// errorCode pins the rejection for clients (the admin UI historically
+	// substring-matched the message text; see docs/api.md registry).
 	if sameMigrationTarget(sourceURL, sourceDialect, targetURL, targetDialect) {
-		writeError(w, http.StatusBadRequest, "target database is the same as the running database; migration aborted")
+		writeErrorCode(w, http.StatusBadRequest, ErrorCodeSameMigrationTarget, "target database is the same as the running database; migration aborted")
 		return
 	}
 

--- a/handler/shared/errors.go
+++ b/handler/shared/errors.go
@@ -11,12 +11,15 @@ import (
 // APIError represents a structured JSON error response.
 // Message is safe for public consumption; Internal is logged but never sent.
 // JSON field names are camelCase-compatible public keys used by the admin UI:
-// - error (string message)
-// - detail (optional classifier / subtype)
+// - error (string message; human-readable, never matched by clients)
+// - errorCode (optional machine-readable identifier; stable camelCase value
+//   from the registry in docs/api.md — additive, omitted when unset)
+// - detail (optional free-form classifier / subtype; NOT a stable contract)
 // - request_id (optional ingress correlation id, snake_case for log/ops tools)
 type APIError struct {
 	Code      int    `json:"-"`
 	Message   string `json:"error"`
+	ErrorCode string `json:"errorCode,omitempty"`
 	Detail    string `json:"detail,omitempty"`
 	RequestID string `json:"request_id,omitempty"`
 	Internal  error  `json:"-"`
@@ -38,6 +41,14 @@ func (e *APIError) Error() string {
 // Callers must use a non-2xx status for failures — never HTTP 200 with an error body.
 func WriteError(w http.ResponseWriter, code int, message string) {
 	WriteAPIError(w, &APIError{Code: code, Message: message})
+}
+
+// WriteErrorCode writes a structured JSON error response carrying a
+// machine-readable errorCode in addition to the human-readable message.
+// errorCode must be a stable camelCase identifier from the registry
+// documented in docs/api.md; message stays the user-facing text.
+func WriteErrorCode(w http.ResponseWriter, code int, errorCode, message string) {
+	WriteAPIError(w, &APIError{Code: code, Message: message, ErrorCode: errorCode})
 }
 
 // WriteAPIError writes the public fields of APIError with the given status.
@@ -64,6 +75,7 @@ func WriteAPIError(w http.ResponseWriter, err *APIError) {
 	w.WriteHeader(code)
 	if encErr := json.NewEncoder(w).Encode(APIError{
 		Message:   err.Message,
+		ErrorCode: err.ErrorCode,
 		Detail:    err.Detail,
 		RequestID: err.RequestID,
 	}); encErr != nil {

--- a/handler/shared/errors_test.go
+++ b/handler/shared/errors_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -30,6 +31,51 @@ func TestWriteError_StatusAndCamelCaseJSON(t *testing.T) {
 	}
 	if _, ok := body["success"]; ok {
 		t.Fatalf("unexpected success field in unified error body: %#v", body)
+	}
+	if _, ok := body["errorCode"]; ok {
+		t.Fatalf("errorCode must be omitted when unset (additive contract): %#v", body)
+	}
+}
+
+func TestWriteAPIError_IncludesErrorCode(t *testing.T) {
+	rec := httptest.NewRecorder()
+	WriteErrorCode(rec, http.StatusBadRequest, "sameMigrationTarget", "target database is the same as the running database; migration aborted")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, rec.Body.String())
+	}
+	// camelCase key is the contract; clients match on this, never on "error".
+	if body["errorCode"] != "sameMigrationTarget" {
+		t.Fatalf("errorCode = %v, want sameMigrationTarget", body["errorCode"])
+	}
+	// Human-readable message stays present and untouched (non-breaking).
+	if body["error"] != "target database is the same as the running database; migration aborted" {
+		t.Fatalf("error = %v", body["error"])
+	}
+	if _, ok := body["message"]; ok {
+		t.Fatalf("unexpected message field in unified error body: %#v", body)
+	}
+}
+
+func TestWriteAPIError_OmitsEmptyErrorCode(t *testing.T) {
+	rec := httptest.NewRecorder()
+	WriteAPIError(rec, &APIError{Code: http.StatusBadRequest, Message: "plain rejection"})
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, rec.Body.String())
+	}
+	// Sites without a registered code must serialize the pre-existing body
+	// byte-for-byte (no errorCode:null, no errorCode:"").
+	if raw := rec.Body.String(); strings.Contains(raw, "errorCode") {
+		t.Fatalf("errorCode key must be absent when empty, got body %s", raw)
+	}
+	if body["error"] != "plain rejection" {
+		t.Fatalf("error = %v", body["error"])
 	}
 }
 


### PR DESCRIPTION
## What

Audit item **S4 (backend half)**: add an **optional, machine-readable `errorCode`** to the unified admin error envelope so clients can stop substring-matching human-readable messages.

```json
{
  "error": "human-readable message (unchanged)",
  "errorCode": "sameMigrationTarget",
  "request_id": "optional correlation id"
}
```

**Non-breaking by construction:** `errorCode` is additive and `omitempty` — every endpoint without a registered code serializes a byte-identical body to before (pinned by test); `error` stays the display string; clients that ignore the field see no change. Convention: values are stable **camelCase** identifiers (project-wide camelCase JSON rule), documented in the registry below.

## Why

Inventory of frontend message-substring matching (`web/src`, read-only):

| Frontend site | Match | Backend reality |
|---|---|---|
| `features/settings/sections/operations/components/database-migration-section.tsx:142` | `message.includes('相同')` | Go backend emits English `"target database is the same as the running database; migration aborted"` → the match **never fires** today (TS-era latent bug); UI falls back to toasting the raw message |
| `lib/http-client.ts:97` + `classify403` | `'invalid token'` / `"reauthrequired":true` | auth-plane **403** bodies (`auth/admin.go`, `auth/reauth.go`) — out of this PR's 400-class scope, listed as follow-up |

The `sameMigrationTarget` code is the flagship the UI migrates onto.

## Code registry (docs/api.md)

| errorCode | Status | Where | Meaning |
|---|---|---|---|
| `sameMigrationTarget` | 400 | `POST /api/settings/database/migrate` | target resolves to the running database (rejected) — frontend-matched |
| `emptyMigrationTarget` | 400 | `POST /api/settings/database/migrate` | target connection string blank |
| `invalidDatabaseType` | 400 | `/api/settings/database/*` | dialect neither sqlite nor postgres |
| `invalidId` | 400 | every `/api/.../{id}` route via `pathID` | path ID missing/non-numeric/non-positive (one helper = 42 routes) |

**Sweep discipline:** handler/admin has ~178 unified 400 sites; codes were assigned only where cheap mechanisms (shared helpers) or frontend-facing validation surfaces justify them — no speculative taxonomy. Remaining sites keep working unchanged and gain codes when a real consumer needs one.

## Changes

- `handler/shared/errors.go` — `APIError.ErrorCode` (`errorCode,omitempty`), `WriteErrorCode` helper
- `handler/admin/response_errors.go` — `writeErrorCode` / `writeErrorCodeWithRequest`
- `handler/admin/error_codes.go` — registry constants (single source of truth)
- `handler/admin/settings_database.go` — 5 coded sites (flagship + same-surface validations)
- `handler/admin/helpers.go` — `pathID` choke point → `invalidId`
- `docs/api.md` — envelope contract + registry table
- tests: `handler/shared/errors_test.go`, new `handler/admin/error_codes_test.go`

## Test evidence

- Envelope shape: `errorCode` present with exact value when set; **absent key** (not null/empty) when unset — both pinned in `handler/shared`
- Code pins on real handlers: same-target / empty-target / invalid-dialect migration rejections + `invalidId` on sites PUT/DELETE
- Regression guards: `assertErrorCodeBody` fails if a registered site falls back to message-only; `TestErrorCodeRegistry_StableIdentifiers` fails on any identifier rename; uncoded-site test fails if legacy bodies gain the key
- Full gate green on push: frontend suite + `go build ./cmd/server` + `go vet ./...` + `go test ./... -count=1 -race` (all packages ok, e.g. `handler/admin 256s`, `e2e 106s`)

## Residuals / follow-ups

1. **Frontend consumption (later lane, per task split):** switch `database-migration-section.tsx` from `message.includes('相同')` to `errorCode === 'sameMigrationTarget'`; add `errorCode` to `resolveResponseMessage`-adjacent typing in `web/src/lib/http-client.ts`.
2. **Auth-plane 403s** (out of 400-class scope): `invalid token` (`auth/admin.go:103`, `session_routes.go:64`) and `reauthRequired` (`auth/reauth.go:68`) — the other two frontend substring matches; envelope already supports codes there when that wave lands.
3. **Remaining ~170 uncoded admin 400 sites** (payload validation, batch endpoints, legacy `{"message":...}` TS-era paths): code per real consumer demand, no speculative taxonomy.
