### PR TITLE
chore(testing): raise race-gate per-package timeout default to 900s (MASTER C3)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Testing Strategy and Real-Platform Testbed
 
-**Last verified**: 2026-08-16
+**Last verified**: 2026-08-29
 
 > Public, environment-agnostic test guidance. Product state lives in [`STATE.md`](internal/STATE.md); open outcomes live in [`progress/MASTER.md`](internal/progress/MASTER.md).
 
@@ -14,6 +14,38 @@
 | Real-service CI           | `.github/workflows/main.yml`                                                         | New API, One API, Sub2API and CLIProxyAPI detect/login/route/proxy chains in service containers, plus cross-OS binary runtime smoke (`runtime-smoke-matrix`) |
 | Frontend acceptance       | [`../web/scripts/acceptance-e2e.mjs`](../web/scripts/acceptance-e2e.mjs) (+ [`acceptance-probe-header-quirk.mjs`](../web/scripts/acceptance-probe-header-quirk.mjs) for the fresh-site accounts-page race) | Real-browser user journeys (Playwright) against a live metapi + real upstream; operator-gated, not a PR check |
 | Operator runtime evidence | `scripts/e2e/*.sh` and focused staging procedures                                    | Compatibility that requires real credentials, topology, or upstream behavior |
+
+## Race-detector budget (local push gate)
+
+The pre-push gate (`scripts/go-race.sh`, chained from
+`.githooks/pre-push-project`) runs the full suite under `-race` with a
+per-package timeout. The default is **900s**; override it with
+`METAPI_RACE_TIMEOUT_SECONDS=<seconds>` when a host needs more headroom.
+
+Why 900s (measured, August 2026):
+
+- Six independent development lanes hit the old 300s default on
+  `handler/admin` while parallel lanes contended for an 8GB WSL VM on a slow
+  `/mnt/d` 9p mount. Isolated measurements of `handler/admin` under
+  `-race` range **217-364s** depending on host load; the master baseline is
+  equally critical.
+- CI gives each package ~10 minutes (Go's default `go test` timeout) inside
+  30-minute shard jobs, so 900s matches both CI headroom and the measured
+  worst cases.
+
+Operational guidance:
+
+- Stagger push gates: keep race lanes to **4 or fewer concurrent** on one dev
+  host. Beyond that, per-package times inflate and gates time out for
+  environmental reasons, not code regressions.
+- On a timeout the gate prints a one-line hint; raise the knob (for example
+  `METAPI_RACE_TIMEOUT_SECONDS=1500`) rather than skipping the gate.
+  `git push --no-verify` is emergency-only.
+
+CI is unaffected by this default: `.github/workflows/main.yml` never calls
+`go-race.sh`. It shards packages across four runners and runs `go test
+-race` with Go's default 10-minute per-package timeout, so raising the local
+gate default cannot weaken CI.
 
 ## Golden snapshot suites (protocol conversion)
 

--- a/scripts/go-race.sh
+++ b/scripts/go-race.sh
@@ -1,11 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-timeout_seconds="${METAPI_RACE_TIMEOUT_SECONDS:-300}"
+# Per-package budget for the race gate. Default 900s: handler/admin -race was
+# measured at 217-364s on contended dev hosts (8GB WSL VM, /mnt/d 9p) across
+# six Wave 18 lanes, and CI gives each package ~10 min (Go's default test
+# timeout). Override with METAPI_RACE_TIMEOUT_SECONDS=<seconds>; see
+# docs/testing.md "Race-detector budget".
+timeout_seconds="${METAPI_RACE_TIMEOUT_SECONDS:-900}"
 if [[ ! "$timeout_seconds" =~ ^[0-9]+$ ]] || (( timeout_seconds < 1 )); then
   echo "race: METAPI_RACE_TIMEOUT_SECONDS must be a positive integer." >&2
   exit 2
 fi
+
+race_log="$(mktemp)"
+trap 'rm -f "$race_log"' EXIT
+
+# Stream the race run while keeping a copy; if it fails on a per-package
+# timeout, point the operator at the budget knob.
+run_race() {
+  if "$@" 2>&1 | tee "$race_log"; then
+    return 0
+  fi
+  if grep -q "test timed out" "$race_log"; then
+    echo "race: a package exceeded the ${timeout_seconds}s per-package budget; raise it with METAPI_RACE_TIMEOUT_SECONDS=<seconds>." >&2
+  fi
+  return 1
+}
 
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*)
@@ -15,10 +35,11 @@ case "$(uname -s)" in
     fi
     windows_repo="$(pwd -W)"
     echo "race: Windows detected; running the Go race detector inside WSL"
-    MSYS_NO_PATHCONV=1 wsl.exe --cd "$windows_repo" -- \
+    export MSYS_NO_PATHCONV=1
+    run_race wsl.exe --cd "$windows_repo" -- \
       bash -lc "go test ./... -count=1 -race -timeout ${timeout_seconds}s"
     ;;
   *)
-    go test ./... -count=1 -race -timeout "${timeout_seconds}s"
+    run_race go test ./... -count=1 -race -timeout "${timeout_seconds}s"
     ;;
 esac


### PR DESCRIPTION
Race gate budget: raise per-package timeout default 300s -> 900s + operational docs (MASTER C3).

## Why

Wave 18 ran 6+ concurrent lanes; `handler/admin` under `-race` was measured at **217-364s** on contended dev hosts (8GB WSL VM, `/mnt/d` 9p), repeatedly tripping the old 300s default for environmental reasons, not code regressions. CI shards packages with Go's default ~10min per-package budget, so 900s aligns the local gate with both CI headroom and measured worst cases.

## What

- `scripts/go-race.sh`: default `METAPI_RACE_TIMEOUT_SECONDS` 300 -> 900; on a per-package timeout the gate now prints a one-line hint pointing at the knob instead of a bare timeout.
- `docs/testing.md`: new **Race-detector budget** section -- the measurements above, stagger guidance (<=4 concurrent race lanes per dev host), and proof that CI is unaffected (`main.yml` never calls `go-race.sh`).

## Evidence

This very branch passed the full pre-push gate under the new default: frontend 1425 tests + build/vet + WSL race all packages ok (`handler/admin` 225.7s).

Partially closes MASTER C3 (raise-default option chosen over package splitting).
