### PR TITLE
chore(web): name i18n locale chunks + drop stale vitepress ignore (#1035 S9-1/S1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Frontend source dependencies (not needed for Go build)
 web/node_modules/
 web/build/
-web/docs/.vitepress/dist/
 
 # Frontend build output (built in CI/Docker, embedded via go:embed)
 web/dist/

--- a/web/src/i18n/config.ts
+++ b/web/src/i18n/config.ts
@@ -14,9 +14,13 @@ import { initReactI18next } from 'react-i18next'
 
 import { convertDetectedLanguage, toBcp47 } from './languages'
 
+// webpackChunkName pins stable semantic chunk names (locale-en / locale-zh-CN)
+// so the two locale bundles are individually visible in size reports and their
+// content-hashed URLs never depend on anonymous chunk ids.
 const localeLoaders = {
-  en: () => import('./locales/en.json'),
-  zhCN: () => import('./locales/zh-CN.json'),
+  en: () => import(/* webpackChunkName: 'locale-en' */ './locales/en.json'),
+  zhCN: () =>
+    import(/* webpackChunkName: 'locale-zh-CN' */ './locales/zh-CN.json'),
 } as const
 
 function normalizeLanguage(language: string): keyof typeof localeLoaders {


### PR DESCRIPTION
Lane F (Wave 21 build-perf) — #1035 S9-1 vendor-i18n + S1 residual sweep. Frontend-only, build layer; no runtime behavior change.

## Honesty first: the S9-1 vendor split already landed

The main S9-1 work was merged in #1053 (S1+S9 first half, shipped in v0.16.19): anonymous grab-bag chunk 6432 was split into `vendor-i18n` / `vendor-icons` / `vendor-core`, and the locale JSON moved out of the entry graph via the i18next custom-backend lazy loader. The task premise ("i18n resources still mixed into the main vendor") was stale against current master. This PR therefore does, with fresh measurements:

1. **Verified the S9-1 state on the current base**: `vendor-i18n.92e5ee2f3a.js` is byte-identical (same content hash) to the #1053 measurement, across the v0.16.19 release and three later merged PRs — direct evidence of cross-release cache stability.
2. **Closed the one remaining gap**: the two lazy locale bundles were still anonymous numeric chunks (`async/4855`, `async/6294`). Pinned `webpackChunkName` so they emit as `locale-en` / `locale-zh-CN` — individually visible in size reports, names independent of anonymous chunk ids.
3. **S1 residual sweep** (table below).

## Measured before/after (same machine, same command `bun run build`, zlib level 9)

| metric | before (base) | after (this PR) | delta |
|---|---:|---:|---:|
| dist total | 3,358,226 B (180 files) | 3,358,267 B (180 files) | +41 B |
| JS total raw | 2,774,107 B | 2,774,148 B | +41 B |
| JS total gz (L9) | 820,580 B | 820,596 B | +16 B |
| initial sync JS gz (L9) | 322,201 B | 322,217 B | +16 B |
| JS chunk count | 78 | 78 | 0 |
| rsbuild report Total | 3283.2 kB / 1182.7 kB gz | 3283.3 kB / 1182.7 kB gz | +0.1 kB / 0 |

Exact per-file diff — only 3 files changed; the other 177/180 dist files are byte-identical (same name + same size):

| before | after | note |
|---|---|---|
| `async/4855.5ad56e408c.js` (101,136 B) | `async/locale-zh-CN.3ae51d8394.js` (101,136 B) | raw identical |
| `async/6294.471ba9d516.js` (104,364 B) | `async/locale-en.43c98f3fa5.js` (104,364 B) | raw identical |
| `index.d3332ebabd.js` (130,054 B) | `index.9ee23aa4d1.js` (130,095 B) | chunk map: numeric ids -> semantic names, +41 B |

The +41 B is the runtime chunk map now carrying `locale-en`/`locale-zh-CN` instead of `4855`/`6294`. Determinism checks: baseline rebuilt and after rebuilt (post-format) each produced 0-diff full-file listings; warm/cold builds byte-identical.

Key vendor blocks (unchanged; hashes identical to #1053): vendor-i18n 57,935 B / 18,710 gz · vendor-core 182,408 / 55,222 · vendor-icons 35,696 / 10,084 · vendor-tanstack 174,834 / 52,420 · vendor-ui-primitives 272,691 / 89,755 · lib-react 189,023 / 59,607 · vendor-recharts (async) 378,766 / 100,173.

**go:embed safety**: `web/embed.go` embeds the whole `dist` directory (`//go:embed dist`) — no chunk-path assumptions; directory structure unchanged; Go side unaffected.

## S1 residual sweep results

| item | disposition |
|---|---|
| `.gitignore` `web/docs/.vitepress/dist/` | **removed** — `web/docs` does not exist anywhere in the tree; pure stale line |
| `web/AGENTS.md` "environment see `vite.config.ts`" | already fixed by #1053 (now `vitest.config.ts`) — verified, no action |
| `web/vite-env.d.ts` | kept — legitimate `vite/client` type reference (`import.meta.env` typing) |
| `vite-ui-theme` cookie (bootstrap.js, scripts, tests) | kept — runtime behavior; renaming would drop users' persisted theme |
| `VITE_` env prefixes (rsbuild.config.ts, build-shared.ts) | kept — frozen env-var parity contract, commented as such |
| `vite` + `@vitejs/plugin-react` devDeps | kept — vitest 4 runtime dependencies, not build leftovers |
| `router.go` `/assets/*` legacy Vite prefix compat | kept — documented runtime compatibility (deployment.md, verify-live-assets.sh) |
| CHANGELOG.md / log.md mentions | kept — append-only history |

## Gates

- `bun run typecheck` (tsgo -b): 0 errors
- `bun run lint` (oxlint): 0 errors (pre-existing warnings only, none in touched files)
- `bun run test`: route-tree guard OK (28 route files / 28 imports) + vitest **223 files / 1425 tests passed**
- `bun run knip`: exit 0
- `bun run format:check`: clean
- `bun run build`: pass (dist embedded unchanged)
- Full pre-push gate (frontend + go build + go vet + go test -race via WSL): **passed**, no `--no-verify`

No new dependencies. No business-component edits (scope: `web/src/i18n/config.ts` magic comments + one `.gitignore` line).

Ref: #1035 (S9-1 verified + locale-chunk finish; S9 pagination half remains open), #1053 (prior split this builds on).
