### PR TITLE
fix(web): full-alpha ring-ring focus rings, autoComplete audit, Select/Tabs/Toaster axe gates (#1029 residuals, #1035 S10)

### DIFF
--- a/web/src/components/common/probe-health-bar.tsx
+++ b/web/src/components/common/probe-health-bar.tsx
@@ -129,7 +129,7 @@ export function ProbeHealthBar({
             <span
               tabIndex={0}
               aria-label={ariaLabel}
-              className='focus-visible:ring-ring flex h-4 items-stretch gap-[2px] rounded-sm outline-none focus-visible:ring-2'
+              className='focus-visible:ring-focus-ring flex h-4 items-stretch gap-[2px] rounded-sm outline-none focus-visible:ring-2'
             />
           }
         >

--- a/web/src/components/skip-to-main.tsx
+++ b/web/src/components/skip-to-main.tsx
@@ -14,7 +14,7 @@ export function SkipToMain() {
       href='#content'
       className={cn(
         'bg-background text-foreground',
-        'focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2',
+        'focus-visible:ring-focus-ring focus-visible:ring-2 focus-visible:ring-offset-2',
         'pointer-events-none absolute left-4 top-4 z-[100]',
         '-translate-y-20 rounded-md border px-4 py-2 text-sm font-medium shadow-md',
         'transition-transform duration-150',

--- a/web/src/components/ui/__tests__/axe-select.test.tsx
+++ b/web/src/components/ui/__tests__/axe-select.test.tsx
@@ -1,0 +1,73 @@
+// Component-level axe gate for the Select primitive: a named select must
+// produce zero structural violations closed and open — the trigger is a
+// named combobox, the popup exposes a single listbox, and every item is an
+// option with selectable state (jsdom skips color-contrast — that stays
+// with the browser-level a11y-scan gate).
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import axe from 'axe-core'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import '@/i18n/config'
+
+function renderSelect() {
+  return render(
+    <Select defaultValue='postgres'>
+      <SelectTrigger aria-label='Database dialect'>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value='sqlite'>SQLite</SelectItem>
+        <SelectItem value='postgres'>PostgreSQL</SelectItem>
+      </SelectContent>
+    </Select>
+  )
+}
+
+async function openListbox() {
+  fireEvent.click(screen.getByRole('combobox', { name: 'Database dialect' }))
+  await screen.findByRole('listbox')
+}
+
+afterEach(() => cleanup())
+
+describe('Select axe gate', () => {
+  it('closed select produces zero axe violations', async () => {
+    const { container } = renderSelect()
+
+    const results = await axe.run(container)
+    expect(results.violations).toEqual([])
+  })
+
+  it('open select produces zero axe violations', async () => {
+    const { container } = renderSelect()
+    await openListbox()
+
+    const results = await axe.run(container)
+    expect(results.violations).toEqual([])
+  })
+
+  it('exposes combobox/listbox semantics with a selected option', async () => {
+    renderSelect()
+
+    const trigger = screen.getByRole('combobox', { name: 'Database dialect' })
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox')
+
+    await openListbox()
+
+    const options = screen.getAllByRole('option')
+    expect(options).toHaveLength(2)
+    const selected = options.filter(
+      (option) => option.getAttribute('aria-selected') === 'true'
+    )
+    expect(selected).toHaveLength(1)
+    expect(selected[0]).toHaveTextContent('PostgreSQL')
+  })
+})

--- a/web/src/components/ui/__tests__/axe-tabs.test.tsx
+++ b/web/src/components/ui/__tests__/axe-tabs.test.tsx
@@ -1,0 +1,57 @@
+// Component-level axe gate for the Tabs primitive: a tab group must produce
+// zero structural violations — tabs are named inside a tablist, the active
+// tab is announced as selected, and the visible panel is labelled by its
+// tab (jsdom skips color-contrast — that stays with the browser-level
+// a11y-scan gate).
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import axe from 'axe-core'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import '@/i18n/config'
+
+function renderTabs() {
+  return render(
+    <Tabs defaultValue='overview'>
+      <TabsList>
+        <TabsTrigger value='overview'>Overview</TabsTrigger>
+        <TabsTrigger value='billing'>Billing</TabsTrigger>
+      </TabsList>
+      <TabsContent value='overview'>Usage summary for this site.</TabsContent>
+      <TabsContent value='billing'>Invoices and balances.</TabsContent>
+    </Tabs>
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('Tabs axe gate', () => {
+  it('tab group produces zero axe violations', async () => {
+    const { container } = renderTabs()
+
+    const results = await axe.run(container)
+    expect(results.violations).toEqual([])
+  })
+
+  it('ships tablist semantics with a selected tab and a labelled panel', () => {
+    renderTabs()
+
+    expect(screen.getByRole('tablist')).not.toBeNull()
+
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs).toHaveLength(2)
+    const selected = tabs.filter(
+      (tab) => tab.getAttribute('aria-selected') === 'true'
+    )
+    expect(selected).toHaveLength(1)
+    expect(selected[0]).toHaveTextContent('Overview')
+
+    const panel = screen.getByRole('tabpanel')
+    expect(panel).toHaveTextContent('Usage summary for this site.')
+    const named =
+      (panel.getAttribute('aria-labelledby') ?? '') !== '' ||
+      (panel.getAttribute('aria-label') ?? '') !== ''
+    expect(named).toBe(true)
+  })
+})

--- a/web/src/components/ui/__tests__/axe-toast.test.tsx
+++ b/web/src/components/ui/__tests__/axe-toast.test.tsx
@@ -1,0 +1,60 @@
+// Component-level axe gate for the Sonner toaster wrapper: a rendered toast
+// must produce zero structural violations — the notification lives inside
+// sonner's named aria-live region and list markup (jsdom skips
+// color-contrast — that stays with the browser-level a11y-scan gate).
+import '@testing-library/jest-dom/vitest'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import axe from 'axe-core'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { Toaster } from '@/components/ui/sonner'
+import { toast } from '@/lib/toast'
+import '@/i18n/config'
+
+beforeAll(() => {
+  // sonner probes prefers-color-scheme under jsdom; report a static query.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+afterEach(() => cleanup())
+
+describe('Toaster axe gate', () => {
+  it('rendered success toast produces zero axe violations', async () => {
+    const { container } = render(<Toaster />)
+
+    act(() => {
+      toast.success('Site saved')
+    })
+    await screen.findByText('Site saved')
+
+    const results = await axe.run(container)
+    expect(results.violations).toEqual([])
+  })
+
+  it('announces toasts inside a named live region', async () => {
+    const { container } = render(<Toaster />)
+
+    act(() => {
+      toast.error('Check-in failed')
+    })
+    const message = await screen.findByText('Check-in failed')
+
+    // Sonner wraps the toast list in a named section with aria-live.
+    const region = container.querySelector('section[aria-label]')
+    expect(region).not.toBeNull()
+    expect(region!.getAttribute('aria-live')).toBe('polite')
+    expect(region).toContainElement(message)
+  })
+})

--- a/web/src/features/dashboard/components/stat-card.tsx
+++ b/web/src/features/dashboard/components/stat-card.tsx
@@ -189,7 +189,7 @@ export function StatCard(props: StatCardProps) {
     return (
       <Link
         to={props.to}
-        className='focus-visible:ring-ring block h-full rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-offset-2'
+        className='focus-visible:ring-focus-ring block h-full rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-offset-2'
       >
         {card}
       </Link>

--- a/web/src/features/oauth/components/oauth-start-dialog.tsx
+++ b/web/src/features/oauth/components/oauth-start-dialog.tsx
@@ -458,6 +458,10 @@ export function OAuthStartDialog({
                       setCallbackInvalid(false)
                     }}
                     placeholder={t('oauth.session.callbackPlaceholder')}
+                    // Not a user credential: a pasted OAuth callback URL.
+                    // 'off' is conforming here (WHATWG only forbids it on
+                    // login/password fields) and keeps managers from
+                    // corrupting the pasted value (#1029 batch A evaluation).
                     autoComplete='off'
                     spellCheck={false}
                     aria-invalid={callbackInvalid || undefined}

--- a/web/src/features/settings/sections/downstream/components/keys-section.tsx
+++ b/web/src/features/settings/sections/downstream/components/keys-section.tsx
@@ -364,7 +364,7 @@ function ModelPolicyEditor({
               {rule}
               <button
                 type='button'
-                className='focus-visible:ring-ring rounded-full outline-none focus-visible:ring-2'
+                className='focus-visible:ring-focus-ring rounded-full outline-none focus-visible:ring-2'
                 aria-label={t(
                   'settings.downstream.keys.models.removeRuleAria',
                   { rule, defaultValue: 'Remove model rule {{rule}}' }

--- a/web/src/features/settings/sections/operations/components/database-migration-section.tsx
+++ b/web/src/features/settings/sections/operations/components/database-migration-section.tsx
@@ -441,6 +441,10 @@ export function DatabaseMigrationSection() {
                       {...field}
                       value={field.value ?? ''}
                       className='font-mono'
+                      // Infrastructure DSN, not a user credential — WCAG 1.3.5
+                      // input purposes do not apply, and 'off' keeps password
+                      // managers from capturing or autofilling connection
+                      // strings (#1029 batch A evaluation).
                       autoComplete='off'
                       spellCheck={false}
                       disabled={busy}

--- a/web/src/features/settings/sections/operations/components/database-section.tsx
+++ b/web/src/features/settings/sections/operations/components/database-section.tsx
@@ -272,6 +272,10 @@ export function DatabaseSection() {
                       {...field}
                       value={field.value ?? ''}
                       className='font-mono'
+                      // Infrastructure DSN, not a user credential — WCAG 1.3.5
+                      // input purposes do not apply, and 'off' keeps password
+                      // managers from capturing or autofilling connection
+                      // strings (#1029 batch A evaluation).
                       autoComplete='off'
                       spellCheck={false}
                       placeholder={connectionPlaceholder}


### PR DESCRIPTION
Wave 21 Lane U — #1029 残留 ×2 + #1035 S10 左移收口。

> 开工时 origin/master 已含 #1055（b3d4125）——该 PR 覆盖了任务书点名的 `input.tsx` `ring-ring/50` 迁移与 login-form autoComplete 评估（均已验证在 HEAD）。本 PR 清扫其上仍残留的部分。

## 1. #1029 批 C 残留 — 全 alpha `ring-ring` 焦点环

#1055 把所有 `focus-visible:ring-ring/50` 换成了 `--focus-ring` token，但 4 个焦点指示器仍在用**全 alpha `--ring`**，同样不过 WCAG 1.4.11（3:1 非文本）：

| 文件 | 元素 |
| --- | --- |
| `components/common/probe-health-bar.tsx` | 可聚焦 tooltip trigger 健康条 |
| `components/skip-to-main.tsx` | 跳转链接 |
| `features/dashboard/components/stat-card.tsx` | 可点击卡片链接 |
| `features/settings/sections/downstream/components/keys-section.tsx` | 模型规则删除按钮（`--secondary` badge 面上） |

**对比度计算**（与 `contrast-gate.test.ts` 同款 OKLCH→sRGB→WCAG 管线）：

Before（`--ring` 全 alpha）：
- 浅色默认：background/card 2.58:1 · secondary 2.23:1 —— 不达标
- 深色默认：background 3.49:1 · card 3.00:1 · secondary 2.51:1 —— secondary 面不达标（keys-section badge）
- 最差 preset：lake-view 浅色 1.93:1 —— 不达标

After（`--focus-ring`，无 preset override → 全 preset 一致）：
- 浅色：background/card 4.28:1 · secondary 3.70:1 —— 达标
- 深色：background 4.58:1 · card 3.95:1 · secondary 3.30:1 —— 达标
- 最差 preset：anthropic 浅色 4.09:1 —— 达标

修法同 #1055 的单 token 替换（`ring-ring` → `ring-focus-ring`），无布局变更；既有对比度门禁测试已把 focus-ring ≥3:1 钉死在全部 10 presets × 双模式的 background+card 上。浅色/深色双主题均 ≥3:1，焦点环只向达标方向加深/提亮，视觉不回退。

## 2. #1029 批 A 残留 — autoComplete 审计

- `login-form.tsx`：**#1055 已落实** —— 保留 `autoComplete='current-password'`（密码管理器只填充、不覆盖；`off` 在密码字段可被 UA 忽略且阻断管理器；`username` 不适用——token-only 登录无用户名字段），评估注释在代码里，本 PR 仅验证。
- 全仓扫出其余 3 处 `autoComplete='off'`，评估后**全部保留**并落注释：
  1. `oauth-start-dialog.tsx` 手动回调 URL —— 粘贴的 OAuth 回调 URL，非用户凭证；`off` 合规（WHATWG 仅禁止在登录/密码字段用 `off`），且防管理器污染粘贴值。
  2. `database-section.tsx` / `database-migration-section.tsx` 的 `connectionString` —— 基础设施 DSN，非用户凭证；WCAG 1.3.5 输入目的不适用；`off` 防密码管理器捕获/自动填充连接串。
  判断依据以代码注释记录在各字段旁（同 #1055 login-form 注释风格）。

## 3. #1035 S10 左移 — axe 组件门禁扩展

批 C 的 vitest axe 基建（Dialog / Form / DataTable）之上扩展到 3 个常用组件，新增 7 个测试：

- `axe-select.test.tsx` —— Select 关闭态 + 打开态 listbox 零违规；combobox/listbox 语义、恰好一个 `aria-selected` option。
- `axe-tabs.test.tsx` —— tablist 语义、恰好一个选中 tab、面板由其 tab 命名。
- `axe-toast.test.tsx` —— 真实 `Toaster` + `toast.success/error` 零违规；toast 位于 sonner 命名 `aria-live=polite` region 内。

## 门禁

`cd web`：typecheck ✓ · lint ✓ · test ✓（226 文件 / 1432 测试，含新增 7 个）· knip ✓ · build ✓
pre-push 全门禁：绿（见推送输出）
