### PR TITLE
fix(web): same-target migration detection via errorCode instead of message substring (#1035 S4)

### DIFF
--- a/web/src/features/settings/sections/operations/components/__tests__/database-migration-section.test.tsx
+++ b/web/src/features/settings/sections/operations/components/__tests__/database-migration-section.test.tsx
@@ -5,8 +5,10 @@
 // migrating, the start button opens the destructive confirm dialog, and after
 // the backend accepts the job (202 + taskId) the task is polled through
 // api.getTask until a terminal status surfaces (success toast + row summary,
-// or error toast). The same-target 400 rejection is asserted to surface the
-// localized error instead of the raw server message.
+// or error toast). The same-target 400 rejection is asserted through the
+// #1065 errorCode contract: `sameMigrationTarget` surfaces the localized
+// error, bodies without a code (or with a different code) fall back to the
+// raw server message.
 
 import '@testing-library/jest-dom/vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -266,9 +268,17 @@ describe('DatabaseMigrationSection — form and confirm flow', () => {
     })
   })
 
-  it('surfaces the localized same-target rejection instead of the raw server message', async () => {
+  it('surfaces the localized same-target rejection via the sameMigrationTarget errorCode', async () => {
+    // Unified 400 envelope (#1065): the code, not the message text, pins
+    // the rejection class; the message stays the display fallback.
     mockStartMigration.mockRejectedValueOnce({
-      response: { data: { error: '目标数据库与当前运行库相同，无法迁移' } },
+      response: {
+        data: {
+          error:
+            'target database is the same as the running database; migration aborted',
+          errorCode: 'sameMigrationTarget',
+        },
+      },
     })
     renderMigrationSection()
 
@@ -280,6 +290,53 @@ describe('DatabaseMigrationSection — form and confirm flow', () => {
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith(
         'The target database is the same as the live runtime database; migration is not possible.'
+      )
+    })
+  })
+
+  it('falls back to the raw server message when the body carries no errorCode', async () => {
+    // Byte-compatible pre-#1065 body: no errorCode key at all.
+    mockStartMigration.mockRejectedValueOnce({
+      response: {
+        data: {
+          error:
+            'target database is the same as the running database; migration aborted',
+        },
+      },
+    })
+    renderMigrationSection()
+
+    await fillConnection('./data/metapi.db')
+    fireEvent.click(screen.getByRole('button', { name: 'Start migration' }))
+    await screen.findByText('Confirm data migration')
+    clickConfirmAction()
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        'target database is the same as the running database; migration aborted'
+      )
+    })
+  })
+
+  it('does not localize rejections carrying a different errorCode', async () => {
+    mockStartMigration.mockRejectedValueOnce({
+      response: {
+        data: {
+          error: 'unsupported database dialect',
+          errorCode: 'invalidDatabaseType',
+        },
+      },
+    })
+    renderMigrationSection()
+
+    await fillConnection('./data/metapi.db')
+    fireEvent.click(screen.getByRole('button', { name: 'Start migration' }))
+    await screen.findByText('Confirm data migration')
+    clickConfirmAction()
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        'unsupported database dialect'
       )
     })
   })

--- a/web/src/features/settings/sections/operations/components/database-migration-section.tsx
+++ b/web/src/features/settings/sections/operations/components/database-migration-section.tsx
@@ -34,6 +34,7 @@ import {
 import { toBcp47 } from '@/i18n/languages'
 import { api } from '@/lib/api'
 import { formatDateTime } from '@/lib/format'
+import { extractApiErrorBody, resolveResponseMessage } from '@/lib/http-client'
 import { toast } from '@/lib/toast'
 
 import { FormNavigationGuard } from '../../../components/form-navigation-guard'
@@ -122,25 +123,14 @@ const taskStatusBadgeVariant: Record<
 }
 
 /**
- * The migrate endpoint surfaces rejection reasons (e.g. a target that
- * resolves to the live runtime database) as a plain 400 `{error}` message;
- * there is no machine-readable detail classifier to match on.
+ * Registered errorCode for a migration whose target resolves to the live
+ * runtime database (#1065; registry: docs/api.md, backend constant:
+ * handler/admin/error_codes.go). This section used to substring-match the
+ * Chinese rejection text, which never fired against the Go backend's
+ * English body — the code is the contract now; the `error` message remains
+ * the display fallback for bodies without a code.
  */
-function extractServerErrorMessage(error: unknown): string | null {
-  const responseData = (error as { response?: { data?: unknown } } | null)
-    ?.response?.data
-  if (!responseData || typeof responseData !== 'object') return null
-  const record = responseData as Record<string, unknown>
-  if (typeof record.error === 'string' && record.error) return record.error
-  if (typeof record.message === 'string' && record.message) {
-    return record.message
-  }
-  return null
-}
-
-function isSameMigrationTargetError(message: string): boolean {
-  return message.includes('相同')
-}
+const ERROR_CODE_SAME_MIGRATION_TARGET = 'sameMigrationTarget'
 
 type MigrationResultSummaryProps = {
   result: MigrationTaskResult
@@ -312,18 +302,18 @@ export function DatabaseMigrationSection() {
     },
     onError: (error) => {
       setConfirmOpen(false)
-      const serverMessage = extractServerErrorMessage(error)
-      if (serverMessage && isSameMigrationTargetError(serverMessage)) {
+      const errorBody = extractApiErrorBody(error)
+      if (errorBody?.errorCode === ERROR_CODE_SAME_MIGRATION_TARGET) {
         toast.error(
           t('settings.operations.database.migration.toast.sameTarget')
         )
-      } else if (serverMessage) {
-        toast.error(serverMessage)
-      } else {
-        toast.error(
-          t('settings.operations.database.migration.toast.startFailed')
-        )
+        return
       }
+      const serverMessage = resolveResponseMessage(errorBody)
+      toast.error(
+        serverMessage ??
+          t('settings.operations.database.migration.toast.startFailed')
+      )
     },
   })
 

--- a/web/src/lib/__tests__/http-client.test.ts
+++ b/web/src/lib/__tests__/http-client.test.ts
@@ -12,7 +12,11 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { apiClient } from '../http-client'
+import {
+  apiClient,
+  extractApiErrorBody,
+  resolveResponseErrorCode,
+} from '../http-client'
 
 const toastErrorMock = vi.fn()
 
@@ -221,5 +225,60 @@ describe('apiClient auth interceptor', () => {
     expect(storage.has(TOKEN_KEY)).toBe(true)
     expect(replaceMock).not.toHaveBeenCalled()
     expect(toastErrorMock).toHaveBeenCalledWith('IP not allowed')
+  })
+})
+
+describe('resolveResponseErrorCode — unified error envelope (#1065)', () => {
+  it('returns the errorCode carried by a unified error body', () => {
+    expect(
+      resolveResponseErrorCode({
+        error:
+          'target database is the same as the running database; migration aborted',
+        errorCode: 'sameMigrationTarget',
+      })
+    ).toBe('sameMigrationTarget')
+  })
+
+  it('returns undefined for byte-compatible legacy bodies without errorCode', () => {
+    // Endpoints without a registered code omit the key entirely.
+    expect(
+      resolveResponseErrorCode({ error: 'some rejection reason' })
+    ).toBeUndefined()
+    // Legacy TS-era `{ message }` shape.
+    expect(
+      resolveResponseErrorCode({ message: 'legacy error shape' })
+    ).toBeUndefined()
+  })
+
+  it('returns undefined for non-string or empty errorCode values', () => {
+    expect(
+      resolveResponseErrorCode({ error: 'x', errorCode: '' })
+    ).toBeUndefined()
+    expect(
+      resolveResponseErrorCode({ error: 'x', errorCode: 42 })
+    ).toBeUndefined()
+  })
+
+  it('returns undefined for non-object bodies', () => {
+    expect(resolveResponseErrorCode(undefined)).toBeUndefined()
+    expect(resolveResponseErrorCode(null)).toBeUndefined()
+    expect(resolveResponseErrorCode('error text')).toBeUndefined()
+  })
+})
+
+describe('extractApiErrorBody — axios rejection shape', () => {
+  it('extracts the unified error body from an axios-shaped rejection', () => {
+    expect(
+      extractApiErrorBody({
+        response: { data: { error: 'invalid id', errorCode: 'invalidId' } },
+      })
+    ).toEqual({ error: 'invalid id', errorCode: 'invalidId' })
+  })
+
+  it('returns null when the failure carries no JSON body', () => {
+    expect(extractApiErrorBody(new Error('Network Error'))).toBeNull()
+    expect(extractApiErrorBody({ response: {} })).toBeNull()
+    expect(extractApiErrorBody({ response: { data: 'not json' } })).toBeNull()
+    expect(extractApiErrorBody(null)).toBeNull()
   })
 })

--- a/web/src/lib/http-client.ts
+++ b/web/src/lib/http-client.ts
@@ -97,14 +97,57 @@ function isInvalidTokenMessage(message: string | undefined): boolean {
   return !!message && message.toLowerCase().includes('invalid token')
 }
 
-function resolveResponseMessage(data: unknown): string | undefined {
+/**
+ * Unified non-2xx error body sent by the Go backend (#1065; contract:
+ * docs/api.md "Error (non-2xx)"): `{ error, errorCode?, request_id? }`.
+ * A few legacy TS-era endpoints still answer `{ message }`, so both display
+ * keys are read by `resolveResponseMessage`.
+ *
+ * `errorCode` is optional and additive: only endpoints with a registered
+ * code send it (registry: docs/api.md "errorCode convention and registry";
+ * backend constants: handler/admin/error_codes.go). When a code exists for
+ * a failure class, clients must branch on it — never on `error` text.
+ */
+export type ApiErrorBody = {
+  error?: string
+  errorCode?: string
+  request_id?: string
+  /** Legacy TS-era error shape still answered by a few endpoints. */
+  message?: string
+}
+
+export function resolveResponseMessage(data: unknown): string | undefined {
   if (data && typeof data === 'object') {
-    const message = (data as { message?: unknown }).message
-    if (typeof message === 'string' && message) return message
-    const error = (data as { error?: unknown }).error
-    if (typeof error === 'string' && error) return error
+    const body = data as ApiErrorBody
+    if (typeof body.message === 'string' && body.message) return body.message
+    if (typeof body.error === 'string' && body.error) return body.error
   }
   return undefined
+}
+
+/**
+ * Machine-readable `errorCode` of a unified error body (#1065). Returns
+ * undefined when the body carries no code — the field is optional and only
+ * endpoints with a registered code send it, so callers must keep the
+ * human-readable message as their display fallback.
+ */
+export function resolveResponseErrorCode(data: unknown): string | undefined {
+  if (data && typeof data === 'object') {
+    const errorCode = (data as ApiErrorBody).errorCode
+    if (typeof errorCode === 'string' && errorCode) return errorCode
+  }
+  return undefined
+}
+
+/**
+ * Unified error body of an axios-shaped rejection (`error.response.data`),
+ * or null when the failure carries no JSON body (network error, timeout).
+ */
+export function extractApiErrorBody(error: unknown): ApiErrorBody | null {
+  const data = (error as { response?: { data?: unknown } } | null)?.response
+    ?.data
+  if (!data || typeof data !== 'object') return null
+  return data as ApiErrorBody
 }
 
 /** True when a response body asks for master-token re-confirmation. */
@@ -131,9 +174,7 @@ class ReauthRequiredError extends Error {
  */
 export function isReauthRequired(error: unknown): boolean {
   if (error instanceof ReauthRequiredError) return true
-  const data = (error as { response?: { data?: unknown } } | null)?.response
-    ?.data
-  return isReauthRequiredBody(data)
+  return isReauthRequiredBody(extractApiErrorBody(error))
 }
 
 apiClient.interceptors.response.use(


### PR DESCRIPTION
Adopt the #1065 unified error envelope contract on the frontend error chokepoint:
- http-client: add ApiErrorBody and shared response-error extractors; isReauthRequired reuses it.
- database-migration-section: branch on errorCode === 'sameMigrationTarget' instead of message substring.
- Tests: envelope parsing plus migration-section coverage for code hit / no code / different code.

Part of #1035 S4. PR opened by captain after agent completed implementation; all backend work was already merged via #1065.
