### PR TITLE
refactor(net): migrate control-plane outbound HTTP to internal/httpclient baseline

### DIFF
--- a/internal/httpclient/gate_test.go
+++ b/internal/httpclient/gate_test.go
@@ -21,9 +21,18 @@ import (
 // goroutines indefinitely. The baseline adopted for this repo mirrors the
 // axonhub HTTP client baseline (docs/internal/analysis/competitor-study-2026-08.md
 // section 3.2): dial 30s, TLS handshake 10s, MaxIdleConns 100,
-// IdleConnTimeout 90s. Transports are constructed in exactly one place:
-// this package, or the pooled transport cache in platform/site_proxy.go for
-// platform adapter traffic.
+// IdleConnTimeout 90s. Control-plane transports are constructed in
+// internal/httpclient, with named exceptions that keep their own literals
+// by design (all still satisfy R3/R4):
+//
+//   - platform/site_proxy.go — pooled transport cache for platform adapter
+//     traffic, operator-tunable via PROXY_*_TIMEOUT_SEC;
+//   - SSRF-hardened clients whose DialContext enforces dial-level target
+//     guards internal/httpclient does not model: notifyHTTPClient
+//     (service/notify, all webhook-style channels) and the WebDAV backup
+//     clients in handler/admin and scheduler;
+//   - proxy.NewStreamTransport — SSE data-plane stream relay; header phase
+//     bounded, whole-request timeout owned by the relay's idle guard.
 //
 // Rules enforced on every non-test .go file in the repository:
 //

--- a/internal/httpclient/httpclient.go
+++ b/internal/httpclient/httpclient.go
@@ -9,10 +9,10 @@
 //     PROXY_*_TIMEOUT_SEC env vars.
 //   - Every other outbound path (proxy executor, channel health probes,
 //     admin channel test harness, monitor LDOH proxy, notifications, pricing
-//     catalog fetch, Codex websocket dial, server healthcheck) builds its
-//     transport here so each client carries explicit dial / TLS-handshake /
-//     idle bounds and a sized connection pool instead of riding
-//     http.DefaultTransport.
+//     catalog fetch, OAuth token/session exchange, Codex websocket dial,
+//     server healthcheck) builds its transport here so each client carries
+//     explicit dial / TLS-handshake / idle bounds and a sized connection
+//     pool instead of riding http.DefaultTransport.
 //
 // Baseline values mirror the axonhub HTTP client baseline
 // (docs/internal/analysis/competitor-study-2026-08.md): dial 30s,
@@ -22,6 +22,7 @@ package httpclient
 import (
 	"net"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 )
@@ -54,7 +55,19 @@ type Options struct {
 	IdleConnTimeout       time.Duration
 	MaxIdleConns          int
 	MaxIdleConnsPerHost   int
+	// Proxy overrides the transport's proxy resolution. Nil keeps
+	// http.ProxyFromEnvironment, the behavior these paths historically
+	// inherited from http.DefaultTransport. Set NoProxy on paths that must
+	// never ride an operator-configured HTTP_PROXY (e.g. OAuth token
+	// exchange).
+	Proxy func(*http.Request) (*url.URL, error)
 }
+
+// NoProxy is an Options.Proxy value that disables proxy resolution
+// entirely: HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment variables are
+// ignored and every request dials its target directly. It is equivalent to
+// a nil Transport.Proxy but can be passed explicitly through Options.
+func NoProxy(*http.Request) (*url.URL, error) { return nil, nil }
 
 // NewTransport builds an *http.Transport with explicit phase timeouts and a
 // sized idle pool. Proxy resolution keeps http.ProxyFromEnvironment, the
@@ -80,8 +93,12 @@ func NewTransport(opts Options) *http.Transport {
 	if maxIdleConnsPerHost <= 0 {
 		maxIdleConnsPerHost = DefaultMaxIdleConnsPerHost
 	}
+	proxy := opts.Proxy
+	if proxy == nil {
+		proxy = http.ProxyFromEnvironment
+	}
 	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy: proxy,
 		DialContext: (&net.Dialer{
 			Timeout:   dialTimeout,
 			KeepAlive: DefaultKeepAlive,

--- a/internal/httpclient/httpclient_test.go
+++ b/internal/httpclient/httpclient_test.go
@@ -1,0 +1,52 @@
+package httpclient
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestNewTransportProxySelection(t *testing.T) {
+	t.Run("nil keeps environment resolution", func(t *testing.T) {
+		tr := NewTransport(Options{})
+		if tr.Proxy == nil {
+			t.Fatal("Options.Proxy nil must keep http.ProxyFromEnvironment, got nil Transport.Proxy")
+		}
+	})
+
+	t.Run("NoProxy ignores environment proxies", func(t *testing.T) {
+		t.Setenv("HTTP_PROXY", "http://proxy.invalid:3128")
+		t.Setenv("HTTPS_PROXY", "http://proxy.invalid:3128")
+		tr := NewTransport(Options{Proxy: NoProxy})
+		req, err := http.NewRequest(http.MethodGet, "http://example.invalid", nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		u, err := tr.Proxy(req)
+		if err != nil {
+			t.Fatalf("NoProxy returned error: %v", err)
+		}
+		if u != nil {
+			t.Fatalf("NoProxy resolved %v despite environment proxies", u)
+		}
+	})
+
+	t.Run("explicit proxy func is wired through", func(t *testing.T) {
+		fixed, err := url.Parse("http://proxy.invalid:3128")
+		if err != nil {
+			t.Fatalf("parse fixed proxy URL: %v", err)
+		}
+		tr := NewTransport(Options{Proxy: http.ProxyURL(fixed)})
+		req, err := http.NewRequest(http.MethodGet, "http://example.invalid", nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		u, err := tr.Proxy(req)
+		if err != nil {
+			t.Fatalf("proxy func returned error: %v", err)
+		}
+		if u == nil || u.String() != fixed.String() {
+			t.Fatalf("proxy func = %v, want %v", u, fixed)
+		}
+	})
+}

--- a/service/oauth/codex.go
+++ b/service/oauth/codex.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/internal/httpclient"
 	"github.com/deliciousbuding/metapi-go/platform"
 )
 
@@ -462,23 +462,29 @@ func doHTTP(req *http.Request, proxyURL *string, client *http.Client) (*http.Res
 	return client.Do(req)
 }
 
+// oauthHTTPTimeout bounds the whole OAuth control-plane request; the same
+// value caps the transport's response-header phase. It is passed explicitly
+// to the httpclient baseline so package defaults can never shadow it.
+const oauthHTTPTimeout = 30 * time.Second
+
 func newOAuthHTTPClient(proxy func(*http.Request) (*url.URL, error)) *http.Client {
-	return &http.Client{
-		Transport:     newOAuthHTTPTransport(proxy),
-		Timeout:       30 * time.Second,
-		CheckRedirect: platform.RejectCrossOriginRedirect,
-	}
+	return httpclient.NewClient(newOAuthHTTPTransport(proxy), oauthHTTPTimeout, platform.RejectCrossOriginRedirect)
 }
 
+// newOAuthHTTPTransport builds the OAuth control-plane transport on the
+// shared baseline with its historical phase bounds (dial 10s, TLS 10s,
+// header phase 30s, idle 30s). A nil proxy means NoProxy: OAuth token
+// exchange must never inherit HTTP_PROXY/HTTPS_PROXY from the operator
+// environment (locked by TestDoHTTPIgnoresEnvironmentProxyWithoutProxyURL).
 func newOAuthHTTPTransport(proxy func(*http.Request) (*url.URL, error)) *http.Transport {
-	return &http.Transport{
-		Proxy: proxy,
-		DialContext: (&net.Dialer{
-			Timeout:   10 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
-		IdleConnTimeout:       30 * time.Second,
+	if proxy == nil {
+		proxy = httpclient.NoProxy
 	}
+	return httpclient.NewTransport(httpclient.Options{
+		DialTimeout:           10 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: oauthHTTPTimeout,
+		IdleConnTimeout:       30 * time.Second,
+		Proxy:                 proxy,
+	})
 }

--- a/service/proxy_util.go
+++ b/service/proxy_util.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -11,36 +10,29 @@ import (
 	"github.com/deliciousbuding/metapi-go/platform"
 )
 
-// ProxyAwareHTTPClient creates an *http.Client that optionally routes through a proxy.
-// If proxyURL is empty, returns a standard client.
+// ProxyAwareHTTPClient creates an *http.Client that optionally routes through
+// a proxy. If proxyURL is empty or fails to parse, the client dials directly
+// and never consults HTTP_PROXY/HTTPS_PROXY environment variables.
 //
 // The client always wires platform.RejectCrossOriginRedirect so callers
 // (notably notify/telegram) cannot follow a public-origin 302 onto a
-// different host.
+// different host. Phase bounds keep this helper's historical values (dial
+// 10s, TLS 10s, response-header phase = timeout) on the shared httpclient
+// baseline; the whole-request timeout is the caller's value.
 func ProxyAwareHTTPClient(proxyURL string, timeout time.Duration) *http.Client {
-	transport := &http.Transport{
-		DialContext: (&net.Dialer{
-			Timeout:   10 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: timeout,
-		MaxIdleConns:          httpclient.DefaultMaxIdleConns,
-		MaxIdleConnsPerHost:   httpclient.DefaultMaxIdleConnsPerHost,
-		IdleConnTimeout:       httpclient.DefaultIdleConnTimeout,
-	}
-
+	proxy := httpclient.NoProxy
 	if proxyURL != "" {
-		proxyURL = strings.TrimSpace(proxyURL)
-		parsed, err := url.Parse(proxyURL)
-		if err == nil {
-			transport.Proxy = http.ProxyURL(parsed)
+		// Invalid proxy URLs fall back to direct requests, the historical
+		// behavior of this helper.
+		if parsed, err := url.Parse(strings.TrimSpace(proxyURL)); err == nil {
+			proxy = http.ProxyURL(parsed)
 		}
 	}
-
-	return &http.Client{
-		Transport:     transport,
-		Timeout:       timeout,
-		CheckRedirect: platform.RejectCrossOriginRedirect,
-	}
+	transport := httpclient.NewTransport(httpclient.Options{
+		DialTimeout:           10 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: timeout,
+		Proxy:                 proxy,
+	})
+	return httpclient.NewClient(transport, timeout, platform.RejectCrossOriginRedirect)
 }


### PR DESCRIPTION
## Wave 21 Lane N — 控制面出站 HTTP 迁移到 internal/httpclient 基线

把 Wave 18 #1058 建立的出站 HTTP 基线推广到剩余控制面调用点。行为保持第一原则：每个显式超时/头部/重定向值原样携带；基线无法表达既有语义的调用点保守不迁，逐条登记如下。

### internal/httpclient 变更（纯加法，契约不变）
- `Options.Proxy`：覆盖 transport 代理解析。零值保持 `http.ProxyFromEnvironment`（所有既有调用方的现状）。
- `NoProxy` 哨兵：绝不继承运维环境 HTTP_PROXY/HTTPS_PROXY 的路径使用。迁移 OAuth 所必需——旧 oauth transport 用 `Proxy: nil` 正是此语义，`TestDoHTTPIgnoresEnvironmentProxyWithoutProxyURL` 锁定。
- 新增单测锁定 Proxy 三分支（默认环境解析 / NoProxy 忽略环境变量 / 显式函数透传）。

### 调用点盘点（基线：bc51446，grep 全仓实证）

**本 PR 前已在基线上**（核实，未动）：

| 调用点 | 构造方式 |
|---|---|
| `cmd/server` healthcheck | SharedTransport + 5s |
| `service/notify/telegram` | SharedTransport / ProxyAwareHTTPClient + 30s |
| `service/pricingcatalog` | SharedTransport + 30s |
| `handler/admin/monitor` LDOH | NewTransport，RHT=LDOH_PROXY_TIMEOUT_SEC |
| `handler/admin/channel_test_harness` | NewTransport fallback，deadline 归调用方 ctx |
| `handler/proxy/channel_health_probe` | NewTransport fallback，deadline 归调用方 ctx |
| `handler/proxy/codex_ws_runtime` | SharedTransport（websocket upgrade） |
| `proxy/executor` 非流式 | NewTransport，RHT=requestTimeout |
| `handler/proxy/upstream` fallback | NewTransport + 90s |

**本 PR 迁移**：

| 调用点 | 迁移前 | 迁移后 |
|---|---|---|
| `service/oauth`（全部供应商经 doHTTP + Codex 模型发现） | 本地 `http.Client{Timeout:30s}` + Transport{dial 10s/TLS 10s/RHT 30s/idle 30s, Proxy:nil} | `httpclient.NewClient/NewTransport`，`oauthHTTPTimeout=30s` 显式传入，nil proxy→NoProxy，CheckRedirect 不变 |
| `service.ProxyAwareHTTPClient`（telegram 系统代理路径） | 本地 Transport{dial 10s/TLS 10s/RHT=timeout/idle 90s, Proxy 可选} + Client{Timeout:timeout} | `httpclient` 基线，timeout 显式传 RHT 与整请求；解析失败回退直连不变 |

**未迁移（残留登记 + 理由）**：

| 调用点 | 理由 |
|---|---|
| `proxy/executor` streamClient、`handler/proxy/upstream` 流式、`proxy.NewStreamTransport` | **数据面**：SSE 流式转发，设计上无整请求超时（由流 idle 守卫 PROXY_STREAM_IDLE_TIMEOUT_SEC 管活性），基线不适用 |
| `platform/site_proxy.go`（16 适配器控制面流量） | 平台 regime：池化 transport 缓存，PROXY_*_TIMEOUT_SEC 运维可调；gate 文档已列为合法第二构造点 |
| `service/notify/http.go`（bark/dingtalk/feishu/wecom/webhook/ntfy/serverchan 共用） | 比基线更严的 SSRF 加固客户端：DialContext 拨号级目标守卫、`Proxy: nil`、10s 上限；基线无法建模该守卫，迁移=安全回退 |
| `handler/admin` + `scheduler` WebDAV 备份客户端 | 同上模式（`ssrf.RejectUnsafeWebdavDialHost` + https→http 降级拒绝 + `Proxy: nil`） |
| `service/checkin`、`service/balance` | 全部经 `platform.DoWithProxy`（平台 regime），无自有 client |
| `service/notify/smtp.go` | net/smtp，非 HTTP |
| `service/catalogsync`、`service/backup` | 无直接出站（盘点零命中） |

### 门禁覆盖变化
- AST 门禁（`internal/httpclient/gate_test.go`）本身是**全仓扫描、无豁免清单**——两个新迁移包自动在覆盖内，无需扩名单；门禁跑绿（含 matcher sanity 反向验证）。
- 门禁头部文档更新为如实枚举具名残留 regime（platform site-proxy 池 / SSRF 加固 notify+WebDAV / SSE 流 transport）——它们仍全部满足 R3/R4，只是字面量按设计留在原处。门禁匹配逻辑零改动。

### 行为保持证据（超时值对照）
| 调用点 | 迁移前 | 迁移后 | 判定 |
|---|---|---|---|
| oauth | Timeout 30s / RHT 30s / dial 10s / TLS 10s / idle 30s / keepalive 30s | 同值，显式传入（30s 提为 `oauthHTTPTimeout` const） | 不变 |
| oauth 重定向 | platform.RejectCrossOriginRedirect | 同 | 不变 |
| oauth 代理 | Proxy:nil（忽略环境）/ doHTTP 覆盖 ProxyURL | NoProxy / doHTTP 覆盖逻辑原样 | 不变（有测试锁定） |
| ProxyAwareHTTPClient | Timeout=入参 / RHT=入参 / dial 10s / TLS 10s / idle 90s / keepalive 30s | 同值 | 不变 |
| ProxyAwareHTTPClient 重定向 | platform.RejectCrossOriginRedirect | 同 | 不变 |

池/协议基线差异（与所有已迁路径一致的基线属性，非逐请求语义）：oauth `MaxIdleConnsPerHost` 2→20（Go 默认→基线）；`ForceAttemptHTTP2` 启用。超时/头部/重定向/错误语义零漂移。

### 验证
- `go build ./cmd/server` ✓ / `go vet ./...` ✓
- WSL `go test ./... -count=1 -race -timeout 900s` 全包 ok（httpclient 5.8s · service/oauth 62.8s · service 31.7s · service/notify 1.5s）
- `golangci-lint v1.64.8`（CI 钉版）全仓 clean
- pre-push 全门禁（前端 + build + vet + race）绿
