### PR TITLE
feat(web): credential-ref tree picker for downstream keys (#1026)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -797,9 +797,12 @@ dimension (the column stores `NULL`). A non-empty list activates the gate:
 - Site and credential dimensions are independent gates — a candidate must pass
   both.
 
-> **UI status:** the credential-ref dimensions are **API-only**. The admin UI
-> has no tree picker for them yet (issue #1026 follow-up); manage these fields
-> via the API. `allowedSiteIds` has a UI picker (#1050).
+> **UI status:** the credential-ref dimensions now have a site → account →
+> token tree picker in the admin API-key sheet (issue #1026 follow-up,
+> #1064 contract). The sheet serializes real arrays on create/update and
+> parses the stored JSON strings when editing; the key list renders resolved
+> site/account/token names, with unresolved IDs shown explicitly. The site
+> picker (#1050) remains unchanged.
 
 **Credential ref shape.** Each ref is one of two kinds:
 

--- a/web/src/features/accounts/index.ts
+++ b/web/src/features/accounts/index.ts
@@ -11,7 +11,9 @@
 export { accountQueryKeys, useAccounts } from './api'
 
 // --- account entity types + runtime schemas ---
+export type { Account, AccountToken } from './types'
 
 // --- account form schema ---
 
 // --- tokens sub-module ---
+export { useAllAccountTokens } from './tokens/api'

--- a/web/src/features/accounts/tokens/api.ts
+++ b/web/src/features/accounts/tokens/api.ts
@@ -63,6 +63,31 @@ export function useAccountTokens(
 }
 
 // ---------------------------------------------------------------------------
+// useAllAccountTokens — GET /api/account-tokens (fleet-wide inventory)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fleet-wide token inventory (no accountId filter). Powers cross-account
+ * surfaces that need every token in one request — currently the downstream
+ * key credential-ref picker, which resolves account_token refs to names
+ * without fanning out per-account queries. Shares the list key factory
+ * (`list()` → ['account-tokens', 'list', 'all']).
+ */
+export function useAllAccountTokens(
+  options?: Omit<UseQueryOptions<AccountToken[]>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery({
+    queryKey: accountTokenQueryKeys.list(),
+    queryFn: async () => {
+      const raw = await api.getAccountTokens()
+      return normalizeTokenList(raw)
+    },
+    staleTime: 10 * 1000,
+    ...options,
+  })
+}
+
+// ---------------------------------------------------------------------------
 // useAccountTokenValue — GET /api/account-tokens/:id/value (reveal)
 // ---------------------------------------------------------------------------
 

--- a/web/src/features/settings/sections/downstream/components/__tests__/credential-ref-picker.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/credential-ref-picker.test.tsx
@@ -1,0 +1,149 @@
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { CredentialRefPicker } from '../credential-ref-picker'
+
+const { mockGetSites, mockGetAccountsSnapshot, mockGetAccountTokens } =
+  vi.hoisted(() => ({
+    mockGetSites: vi.fn(),
+    mockGetAccountsSnapshot: vi.fn(),
+    mockGetAccountTokens: vi.fn(),
+  }))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    getSites: mockGetSites,
+    getAccountsSnapshot: mockGetAccountsSnapshot,
+    getAccountTokens: mockGetAccountTokens,
+  },
+}))
+
+beforeEach(() => {
+  mockGetSites.mockReset()
+  mockGetAccountsSnapshot.mockReset()
+  mockGetAccountTokens.mockReset()
+  mockGetSites.mockResolvedValue([{ id: 1, name: 'Alpha' }])
+  mockGetAccountsSnapshot.mockResolvedValue({
+    generatedAt: '2026-08-29T00:00:00Z',
+    accounts: [
+      {
+        id: 11,
+        siteId: 1,
+        username: 'alice',
+        apiTokenMasked: 'sk-***abc',
+      },
+      { id: 12, siteId: 1, username: 'bob', apiTokenMasked: null },
+    ],
+    sites: [{ id: 1, name: 'Alpha' }],
+  })
+  mockGetAccountTokens.mockResolvedValue([
+    { id: 101, accountId: 11, name: 'Token A', tokenMasked: 'sk-***a' },
+  ])
+})
+
+afterEach(() => cleanup())
+
+function renderPicker(
+  value: Parameters<typeof CredentialRefPicker>[0]['value']
+) {
+  const onChange = vi.fn()
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  })
+  const result = render(
+    (
+      <QueryClientProvider client={queryClient}>
+        <CredentialRefPicker value={value} onChange={onChange} />
+      </QueryClientProvider>
+    ) as ReactElement
+  )
+  return { ...result, onChange }
+}
+
+async function expandAlpha() {
+  fireEvent.click(
+    await screen.findByRole('button', { name: 'Toggle accounts of Alpha' })
+  )
+}
+
+describe('CredentialRefPicker', () => {
+  it('selects an account default API key and emits a canonical ref', async () => {
+    const { onChange } = renderPicker([])
+    await expandAlpha()
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: /alice/ }))
+
+    expect(onChange).toHaveBeenCalledWith([
+      { kind: 'default_api_key', siteId: 1, accountId: 11 },
+    ])
+  })
+
+  it('disables the default-key checkbox when the account has no default key', async () => {
+    renderPicker([])
+    await expandAlpha()
+
+    const checkbox = await screen.findByRole('checkbox', { name: /bob/ })
+    expect(checkbox).toBeDisabled()
+  })
+
+  it('pre-fills account_token and default_api_key refs and expands the right branches', async () => {
+    renderPicker([
+      { kind: 'default_api_key', siteId: 1, accountId: 11 },
+      { kind: 'account_token', siteId: 1, accountId: 11, tokenId: 101 },
+    ])
+
+    const picker = await screen.findByTestId('credential-ref-picker')
+    const accountCheckbox = await within(picker).findByRole('checkbox', {
+      name: /alice/,
+    })
+    const tokenCheckbox = within(picker).getByRole('checkbox', {
+      name: /Token Token A/,
+    })
+
+    expect(accountCheckbox).toBeChecked()
+    expect(tokenCheckbox).toBeChecked()
+  })
+
+  it('surfaces unresolved refs and lets the operator remove them', async () => {
+    const { onChange } = renderPicker([
+      {
+        kind: 'account_token',
+        siteId: 90,
+        accountId: 91,
+        tokenId: 92,
+      },
+    ])
+
+    const remove = await screen.findByRole('button', {
+      name: 'Remove unresolved reference',
+    })
+    fireEvent.click(remove)
+
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
+  it('keeps the expander and picker controls keyboard-focusable', async () => {
+    renderPicker([])
+    await expandAlpha()
+
+    const expander = screen.getByRole('button', {
+      name: 'Toggle accounts of Alpha',
+    })
+    expander.focus()
+    expect(document.activeElement).toBe(expander)
+    expect(
+      await screen.findByRole('checkbox', { name: /alice/ })
+    ).toHaveAttribute('type', 'checkbox')
+  })
+})

--- a/web/src/features/settings/sections/downstream/components/__tests__/key-scope-cell.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/key-scope-cell.test.tsx
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import '@/i18n/config'
+
+import { KeyScopeCell, type ScopeNameMaps } from '../key-scope-cell'
+
+afterEach(() => cleanup())
+
+const names: ScopeNameMaps = {
+  sites: new Map([
+    [1, 'Alpha'],
+    [2, 'Beta'],
+  ]),
+  accounts: new Map([
+    [11, 'alice'],
+    [12, 'bob'],
+  ]),
+  tokens: new Map([[101, 'Token A']]),
+}
+
+function renderCell(item: Parameters<typeof KeyScopeCell>[0]['item']) {
+  return render((<KeyScopeCell item={item} names={names} />) as ReactElement)
+}
+
+describe('KeyScopeCell', () => {
+  it('renders unrestricted when no policy dimensions are configured', () => {
+    renderCell({})
+    expect(screen.getByText('Unrestricted')).toBeInTheDocument()
+  })
+
+  it('resolves site/account/token refs to human-readable names', () => {
+    renderCell({
+      allowedCredentialRefs: JSON.stringify([
+        { kind: 'account_token', siteId: 1, accountId: 11, tokenId: 101 },
+        { kind: 'default_api_key', siteId: 2, accountId: 12 },
+      ]),
+    })
+    expect(screen.getByText(/Alpha \/ alice \/ Token A/)).toBeInTheDocument()
+    expect(screen.getByText(/Beta \/ bob \/ default key/)).toBeInTheDocument()
+  })
+
+  it('shows allow and exclude dimensions separately', () => {
+    renderCell({
+      allowedSiteIds: '[1]',
+      excludedCredentialRefs: JSON.stringify([
+        { kind: 'default_api_key', siteId: 2, accountId: 12 },
+      ]),
+    })
+    expect(screen.getByText('Allowed sites:')).toBeInTheDocument()
+    expect(screen.getByText('Excluded credentials:')).toBeInTheDocument()
+  })
+
+  it('honestly renders missing mappings as unresolved IDs', () => {
+    renderCell({
+      allowedCredentialRefs: JSON.stringify([
+        { kind: 'account_token', siteId: 7, accountId: 8, tokenId: 9 },
+      ]),
+    })
+    expect(
+      screen.getByText(
+        /ID 7 \(unresolved\) \/ ID 8 \(unresolved\) \/ ID 9 \(unresolved\)/
+      )
+    ).toBeInTheDocument()
+  })
+})

--- a/web/src/features/settings/sections/downstream/components/__tests__/keys-section-credential-scope.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/keys-section-credential-scope.test.tsx
@@ -1,0 +1,243 @@
+// End-to-end behavior for the downstream key credential-ref form wiring
+// (#1026 UI follow-up): GET strings parse into form state, submit serializes
+// real arrays, empty dimensions send [] (unrestricted), and backend 400
+// messages reach the operator.
+
+import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import type { ReactElement } from 'react'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import '@/i18n/config'
+import { Sheet, SheetContent } from '@/components/ui/sheet'
+
+import { KeySheetForm } from '../keys-section'
+
+const {
+  mockCreateKey,
+  mockUpdateKey,
+  mockGetSites,
+  mockGetAccountsSnapshot,
+  mockGetAccountTokens,
+  mockToastError,
+  mockToastSuccess,
+} = vi.hoisted(() => ({
+  mockCreateKey: vi.fn(),
+  mockUpdateKey: vi.fn(),
+  mockGetSites: vi.fn(),
+  mockGetAccountsSnapshot: vi.fn(),
+  mockGetAccountTokens: vi.fn(),
+  mockToastError: vi.fn(),
+  mockToastSuccess: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    createDownstreamApiKey: mockCreateKey,
+    updateDownstreamApiKey: mockUpdateKey,
+    getSites: mockGetSites,
+    getAccountsSnapshot: mockGetAccountsSnapshot,
+    getAccountTokens: mockGetAccountTokens,
+  },
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: mockToastSuccess, error: mockToastError },
+}))
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+beforeEach(() => {
+  mockCreateKey.mockReset()
+  mockUpdateKey.mockReset()
+  mockGetSites.mockReset()
+  mockGetAccountsSnapshot.mockReset()
+  mockGetAccountTokens.mockReset()
+  mockToastError.mockReset()
+  mockToastSuccess.mockReset()
+  mockGetSites.mockResolvedValue([{ id: 1, name: 'Alpha' }])
+  mockGetAccountsSnapshot.mockResolvedValue({
+    generatedAt: '2026-08-29T00:00:00Z',
+    accounts: [
+      { id: 11, siteId: 1, username: 'alice', apiTokenMasked: 'sk-***a' },
+    ],
+    sites: [{ id: 1, name: 'Alpha' }],
+  })
+  mockGetAccountTokens.mockResolvedValue([
+    { id: 101, accountId: 11, name: 'Token A', tokenMasked: 'sk-***t' },
+  ])
+  mockCreateKey.mockResolvedValue({})
+  mockUpdateKey.mockResolvedValue({})
+})
+
+afterEach(() => cleanup())
+
+function renderKeySheetForm(
+  editingKey: Parameters<typeof KeySheetForm>[0]['editingKey']
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return render(
+    (
+      <QueryClientProvider client={queryClient}>
+        <Sheet open onOpenChange={() => {}}>
+          <SheetContent>
+            <KeySheetForm editingKey={editingKey} onDone={vi.fn()} />
+          </SheetContent>
+        </Sheet>
+      </QueryClientProvider>
+    ) as ReactElement
+  )
+}
+
+function bothPickers() {
+  return screen.getAllByTestId('credential-ref-picker')
+}
+
+describe('downstream key credential refs (#1026)', () => {
+  it('parses stored JSON strings back into the allow/exclude tree pickers', async () => {
+    renderKeySheetForm({
+      id: 7,
+      name: 'scoped-key',
+      enabled: true,
+      allowedCredentialRefs: JSON.stringify([
+        { kind: 'account_token', siteId: 1, accountId: 11, tokenId: 101 },
+      ]),
+      excludedCredentialRefs: JSON.stringify([
+        { kind: 'default_api_key', siteId: 1, accountId: 11 },
+      ]),
+    })
+
+    await waitFor(() => {
+      expect(
+        within(bothPickers()[0]).getByRole('checkbox', {
+          name: /Token Token A/,
+        })
+      ).toBeChecked()
+      expect(
+        within(bothPickers()[1]).getByRole('checkbox', { name: /alice/ })
+      ).toBeChecked()
+    })
+  })
+
+  it('serializes both dimensions as canonical arrays on update', async () => {
+    renderKeySheetForm({
+      id: 7,
+      name: 'scoped-key',
+      enabled: true,
+      allowedCredentialRefs: JSON.stringify([
+        { kind: 'account_token', siteId: 1, accountId: 11, tokenId: 101 },
+      ]),
+      excludedCredentialRefs: JSON.stringify([
+        { kind: 'default_api_key', siteId: 1, accountId: 11 },
+      ]),
+    })
+    await waitFor(() => {
+      expect(
+        within(bothPickers()[0]).getByRole('checkbox', {
+          name: /Token Token A/,
+        })
+      ).toBeChecked()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => expect(mockUpdateKey).toHaveBeenCalledTimes(1))
+    const [, payload] = mockUpdateKey.mock.calls[0] as [
+      number,
+      {
+        allowedCredentialRefs?: unknown[]
+        excludedCredentialRefs?: unknown[]
+      },
+    ]
+    expect(payload.allowedCredentialRefs).toEqual([
+      { kind: 'account_token', siteId: 1, accountId: 11, tokenId: 101 },
+    ])
+    expect(payload.excludedCredentialRefs).toEqual([
+      { kind: 'default_api_key', siteId: 1, accountId: 11 },
+    ])
+  })
+
+  it('sends empty arrays for both dimensions in create mode (unrestricted)', async () => {
+    renderKeySheetForm(null)
+    await waitFor(() => expect(bothPickers()).toHaveLength(2))
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'new-key' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('sk-…'), {
+      target: { value: 'sk-abcdefgh12345678' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => expect(mockCreateKey).toHaveBeenCalledTimes(1))
+    const payload = mockCreateKey.mock.calls[0][0] as {
+      allowedCredentialRefs?: unknown[]
+      excludedCredentialRefs?: unknown[]
+    }
+    expect(payload.allowedCredentialRefs).toEqual([])
+    expect(payload.excludedCredentialRefs).toEqual([])
+  })
+
+  it('surfaces backend 400 messages containing the malformed entry index', async () => {
+    mockCreateKey.mockRejectedValue({
+      response: {
+        status: 400,
+        data: {
+          error:
+            'allowedCredentialRefs: credentialRefs[0] (account_token) requires a positive tokenId',
+        },
+      },
+    })
+    renderKeySheetForm(null)
+    await waitFor(() => expect(bothPickers()).toHaveLength(2))
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'bad-key' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('sk-…'), {
+      target: { value: 'sk-abcdefgh12345678' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        'allowedCredentialRefs: credentialRefs[0] (account_token) requires a positive tokenId'
+      )
+    })
+  })
+})

--- a/web/src/features/settings/sections/downstream/components/__tests__/keys-section-mobile.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/keys-section-mobile.test.tsx
@@ -35,6 +35,9 @@ vi.mock('@/lib/api', () => ({
     updateDownstreamApiKey: vi.fn(),
     deleteDownstreamApiKey: vi.fn(),
     getSites: () => Promise.resolve([]),
+    getAccountsSnapshot: () =>
+      Promise.resolve({ accounts: [], sites: [], generatedAt: '' }),
+    getAccountTokens: () => Promise.resolve([]),
   },
 }))
 

--- a/web/src/features/settings/sections/downstream/components/__tests__/keys-section-site-scope.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/keys-section-site-scope.test.tsx
@@ -43,6 +43,10 @@ vi.mock('@/lib/api', () => ({
     createDownstreamApiKey: mockCreateKey,
     updateDownstreamApiKey: mockUpdateKey,
     getSites: mockGetSites,
+    getAccountsSnapshot: vi
+      .fn()
+      .mockResolvedValue({ accounts: [], sites: [], generatedAt: '' }),
+    getAccountTokens: vi.fn().mockResolvedValue([]),
   },
 }))
 

--- a/web/src/features/settings/sections/downstream/components/__tests__/keys-section.test.tsx
+++ b/web/src/features/settings/sections/downstream/components/__tests__/keys-section.test.tsx
@@ -62,6 +62,10 @@ vi.mock('@/lib/api', () => ({
     createDownstreamApiKey: mockCreateKey,
     updateDownstreamApiKey: mockUpdateKey,
     getSites: mockGetSites,
+    getAccountsSnapshot: vi
+      .fn()
+      .mockResolvedValue({ accounts: [], sites: [], generatedAt: '' }),
+    getAccountTokens: vi.fn().mockResolvedValue([]),
   },
 }))
 

--- a/web/src/features/settings/sections/downstream/components/credential-ref-picker.tsx
+++ b/web/src/features/settings/sections/downstream/components/credential-ref-picker.tsx
@@ -1,0 +1,358 @@
+// metapi-go/features/settings/sections/downstream/components — tree picker
+// over site → account → (default API key | tokens) for the downstream key
+// credential-ref policy dimensions (allowedCredentialRefs /
+// excludedCredentialRefs, #1026 UI follow-up). Contract SSOT: docs/api.md →
+// Downstream API Keys → Credential & site scope. One picker instance is
+// rendered per dimension; an empty selection means "unrestricted".
+//
+// Interaction model mirrors the Wave 17 SiteScopePicker: plain checkbox
+// inputs (native keyboard support) inside a bordered scroll area, extended
+// with collapsible site/account groups so the tree stays navigable on large
+// fleets.
+
+import { ChevronRight, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
+import {
+  useAccounts,
+  useAllAccountTokens,
+  type Account,
+  type AccountToken,
+} from '@/features/accounts'
+import { useSites, type Site } from '@/features/sites'
+import { cn } from '@/lib/utils'
+
+import { accountDisplayName, tokenDisplayName } from '../lib/credential-display'
+import {
+  credentialRefKey,
+  serializeCredentialRefs,
+  type CredentialRef,
+} from '../lib/credential-refs'
+
+type CredentialRefPickerProps = {
+  value: CredentialRef[]
+  onChange: (refs: CredentialRef[]) => void
+}
+
+/** Machine-readable description for refs whose upstream object is gone. */
+function describeUnresolvedRef(ref: CredentialRef): string {
+  const base = `${ref.kind} · siteId ${ref.siteId} · accountId ${ref.accountId}`
+  return ref.kind === 'account_token'
+    ? `${base} · tokenId ${ref.tokenId}`
+    : base
+}
+
+export function CredentialRefPicker(props: CredentialRefPickerProps) {
+  const { t } = useTranslation()
+  const sitesQuery = useSites()
+  const accountsQuery = useAccounts()
+  const tokensQuery = useAllAccountTokens()
+
+  const selectedKeys = useMemo(
+    () => new Set(props.value.map(credentialRefKey)),
+    [props.value]
+  )
+
+  // Sites (and token lists) holding a selection start expanded so edit mode
+  // reveals the checked rows immediately. Mount-only state: the hosting form
+  // remounts per sheet open, so a stale expansion set never leaks across
+  // keys.
+  const [expandedSiteIds, setExpandedSiteIds] = useState<Set<number>>(
+    () => new Set(props.value.map((ref) => ref.siteId))
+  )
+  const [expandedTokenAccounts, setExpandedTokenAccounts] = useState<
+    Set<number>
+  >(
+    () =>
+      new Set(
+        props.value
+          .filter((ref) => ref.kind === 'account_token')
+          .map((ref) => ref.accountId)
+      )
+  )
+
+  const sites = useMemo(() => sitesQuery.data ?? [], [sitesQuery.data])
+
+  const accountsBySite = useMemo(() => {
+    const map = new Map<number, Account[]>()
+    for (const account of accountsQuery.data?.accounts ?? []) {
+      const list = map.get(account.siteId) ?? []
+      list.push(account)
+      map.set(account.siteId, list)
+    }
+    return map
+  }, [accountsQuery.data])
+
+  const tokensByAccount = useMemo(() => {
+    const map = new Map<number, AccountToken[]>()
+    for (const token of tokensQuery.data ?? []) {
+      // accountId is nullish in the defensive token schema; rows without a
+      // positive accountId cannot anchor a credential ref — skip them.
+      const accountId = token.accountId
+      if (accountId === null || accountId <= 0) continue
+      const list = map.get(accountId) ?? []
+      list.push(token)
+      map.set(accountId, list)
+    }
+    return map
+  }, [tokensQuery.data])
+
+  function toggleSite(siteId: number) {
+    setExpandedSiteIds((previous) => {
+      const next = new Set(previous)
+      if (next.has(siteId)) {
+        next.delete(siteId)
+      } else {
+        next.add(siteId)
+      }
+      return next
+    })
+  }
+
+  function toggleTokenList(accountId: number) {
+    setExpandedTokenAccounts((previous) => {
+      const next = new Set(previous)
+      if (next.has(accountId)) {
+        next.delete(accountId)
+      } else {
+        next.add(accountId)
+      }
+      return next
+    })
+  }
+
+  function toggleRef(ref: CredentialRef, checked: boolean) {
+    const key = credentialRefKey(ref)
+    const next = props.value.filter((item) => credentialRefKey(item) !== key)
+    if (checked) next.push(ref)
+    props.onChange(serializeCredentialRefs(next))
+  }
+
+  if (
+    sitesQuery.isPending ||
+    accountsQuery.isPending ||
+    tokensQuery.isPending
+  ) {
+    return (
+      <div
+        data-testid='credential-ref-picker'
+        className='text-muted-foreground flex items-center gap-2 rounded-md border p-3 text-sm'
+      >
+        <Spinner />
+        {t('settings.downstream.keys.credentials.loading')}
+      </div>
+    )
+  }
+
+  if (sitesQuery.isError || accountsQuery.isError || tokensQuery.isError) {
+    return (
+      <div
+        data-testid='credential-ref-picker'
+        className='text-destructive rounded-md border p-3 text-xs'
+      >
+        {t('settings.downstream.keys.credentials.loadFailed')}
+      </div>
+    )
+  }
+
+  // Dangling refs: stored refs whose site/account/token no longer exists.
+  // They never match a candidate (a dangling allow ref fails closed) and the
+  // backend rejects writing them back, so surface them for explicit removal
+  // instead of hiding them inside the tree.
+  const knownSiteIds = new Set(sites.map((site) => site.id))
+  const knownAccountIds = new Set(
+    (accountsQuery.data?.accounts ?? []).map((account) => account.id)
+  )
+  const knownTokenIds = new Set(
+    (tokensQuery.data ?? []).map((token) => token.id)
+  )
+  const unresolvedRefs = props.value.filter((ref) => {
+    if (!knownSiteIds.has(ref.siteId)) return true
+    if (!knownAccountIds.has(ref.accountId)) return true
+    return ref.kind === 'account_token' && !knownTokenIds.has(ref.tokenId)
+  })
+
+  function renderAccount(site: Site, account: Account) {
+    const accountTokens = tokensByAccount.get(account.id) ?? []
+    const tokensExpanded = expandedTokenAccounts.has(account.id)
+    // The snapshot redacts apiToken to apiTokenMasked, so the masked field
+    // is the honest "account has a default API key" indicator.
+    const hasDefaultKey = Boolean(account.apiTokenMasked)
+    const defaultRef: CredentialRef = {
+      kind: 'default_api_key',
+      siteId: site.id,
+      accountId: account.id,
+    }
+    const accountName = accountDisplayName(account)
+
+    return (
+      <div key={account.id}>
+        <div className='flex items-center gap-1'>
+          {accountTokens.length > 0 ? (
+            <Button
+              type='button'
+              variant='ghost'
+              size='icon-sm'
+              aria-expanded={tokensExpanded}
+              aria-label={t(
+                'settings.downstream.keys.credentials.expandTokensAria',
+                { account: accountName }
+              )}
+              onClick={() => toggleTokenList(account.id)}
+            >
+              <ChevronRight
+                aria-hidden='true'
+                className={cn(
+                  'transition-transform',
+                  tokensExpanded && 'rotate-90'
+                )}
+              />
+            </Button>
+          ) : (
+            <span aria-hidden='true' className='w-8 shrink-0' />
+          )}
+          <label className='flex min-w-0 flex-1 cursor-pointer items-center gap-2 py-1 text-sm'>
+            <input
+              type='checkbox'
+              checked={selectedKeys.has(credentialRefKey(defaultRef))}
+              disabled={!hasDefaultKey}
+              onChange={(event) => toggleRef(defaultRef, event.target.checked)}
+            />
+            <span className='truncate'>{accountName}</span>
+            <span className='text-muted-foreground shrink-0 text-xs'>
+              {hasDefaultKey
+                ? t('settings.downstream.keys.credentials.defaultApiKey')
+                : t('settings.downstream.keys.credentials.noDefaultKey')}
+            </span>
+          </label>
+        </div>
+        {tokensExpanded
+          ? accountTokens.map((token) => {
+              const tokenRef: CredentialRef = {
+                kind: 'account_token',
+                siteId: site.id,
+                accountId: account.id,
+                tokenId: token.id,
+              }
+              return (
+                <label
+                  key={token.id}
+                  className='text-muted-foreground ml-9 flex cursor-pointer items-center gap-2 py-0.5 text-xs'
+                >
+                  <input
+                    type='checkbox'
+                    checked={selectedKeys.has(credentialRefKey(tokenRef))}
+                    onChange={(event) =>
+                      toggleRef(tokenRef, event.target.checked)
+                    }
+                  />
+                  <span className='truncate'>
+                    {t('settings.downstream.keys.credentials.tokenPrefix')}{' '}
+                    {tokenDisplayName(token)}
+                  </span>
+                </label>
+              )
+            })
+          : null}
+      </div>
+    )
+  }
+
+  function renderSite(site: Site) {
+    const siteAccounts = accountsBySite.get(site.id) ?? []
+    const expanded = expandedSiteIds.has(site.id)
+    const selectedCount = props.value.filter(
+      (ref) => ref.siteId === site.id
+    ).length
+
+    return (
+      <div key={site.id} className='border-border border-b last:border-b-0'>
+        <button
+          type='button'
+          aria-expanded={expanded}
+          aria-label={t('settings.downstream.keys.credentials.expandSiteAria', {
+            site: site.name,
+          })}
+          onClick={() => toggleSite(site.id)}
+          className='hover:bg-accent flex w-full items-center gap-2 px-2 py-1.5 text-sm'
+        >
+          <ChevronRight
+            aria-hidden='true'
+            className={cn(
+              'shrink-0 transition-transform',
+              expanded && 'rotate-90'
+            )}
+          />
+          <span className='flex-1 truncate text-left'>{site.name}</span>
+          {selectedCount > 0 ? (
+            <Badge variant='secondary'>
+              {t('settings.downstream.keys.credentials.selectedCount', {
+                count: selectedCount,
+              })}
+            </Badge>
+          ) : null}
+        </button>
+        {expanded ? (
+          <div className='space-y-0.5 px-2 pb-2'>
+            {siteAccounts.length === 0 ? (
+              <p className='text-muted-foreground ps-9 text-xs'>
+                {t('settings.downstream.keys.credentials.noAccounts')}
+              </p>
+            ) : (
+              siteAccounts.map((account) => renderAccount(site, account))
+            )}
+          </div>
+        ) : null}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      data-testid='credential-ref-picker'
+      className='border-border max-h-56 overflow-y-auto rounded-md border'
+    >
+      {sites.length === 0 ? (
+        <p className='text-muted-foreground p-2 text-xs'>
+          {t('settings.downstream.keys.credentials.noSites')}
+        </p>
+      ) : (
+        sites.map(renderSite)
+      )}
+      {unresolvedRefs.length > 0 ? (
+        <div className='border-border border-t p-2'>
+          <p className='text-xs font-medium'>
+            {t('settings.downstream.keys.credentials.unresolvedTitle')}
+          </p>
+          <ul className='mt-1 space-y-1'>
+            {unresolvedRefs.map((ref) => (
+              <li
+                key={credentialRefKey(ref)}
+                className='text-muted-foreground flex items-center gap-2 text-xs'
+              >
+                <span className='flex-1 truncate font-mono'>
+                  {describeUnresolvedRef(ref)}
+                </span>
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='icon-sm'
+                  aria-label={t(
+                    'settings.downstream.keys.credentials.unresolvedRemoveAria'
+                  )}
+                  onClick={() => toggleRef(ref, false)}
+                >
+                  <X aria-hidden='true' />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/web/src/features/settings/sections/downstream/components/key-scope-cell.tsx
+++ b/web/src/features/settings/sections/downstream/components/key-scope-cell.tsx
@@ -1,0 +1,110 @@
+// metapi-go/features/settings/sections/downstream/components — human-readable
+// routing-scope cell for the downstream key list (#1026 UI follow-up).
+//
+// Renders every configured policy dimension (allowed/excluded sites and
+// credential refs) with resolved names instead of raw IDs. Name maps come
+// from the section-level sites/accounts/tokens queries; an ID that no longer
+// resolves renders as `#id (unresolved)` — the contract's honest fallback
+// (refs are only validated at write time; deletes do not cascade).
+
+import { useTranslation } from 'react-i18next'
+
+import {
+  parseCredentialRefs,
+  parseIdArray,
+  type CredentialRef,
+} from '../lib/credential-refs'
+
+export type ScopeNameMaps = {
+  sites: Map<number, string>
+  accounts: Map<number, string>
+  tokens: Map<number, string>
+}
+
+type KeyScopeCellProps = {
+  item: {
+    allowedSiteIds?: number[] | string | null
+    excludedSiteIds?: number[] | string | null
+    allowedCredentialRefs?: string | unknown[] | null
+    excludedCredentialRefs?: string | unknown[] | null
+  }
+  names: ScopeNameMaps
+}
+
+export function KeyScopeCell(props: KeyScopeCellProps) {
+  const { t } = useTranslation()
+  const { item, names } = props
+
+  function resolveName(
+    map: Map<number, string>,
+    id: number | undefined
+  ): string {
+    if (id === undefined) {
+      return t('settings.downstream.keys.scope.unknownId', { id: 0 })
+    }
+    return map.get(id) ?? t('settings.downstream.keys.scope.unknownId', { id })
+  }
+
+  function describeRef(ref: CredentialRef): string {
+    const site = resolveName(names.sites, ref.siteId)
+    const account = resolveName(names.accounts, ref.accountId)
+    if (ref.kind === 'account_token') {
+      const token = resolveName(names.tokens, ref.tokenId)
+      return `${site} / ${account} / ${token}`
+    }
+    return `${site} / ${account} / ${t(
+      'settings.downstream.keys.scope.defaultKey'
+    )}`
+  }
+
+  const rows: Array<{ label: string; text: string }> = []
+
+  const allowedSites = parseIdArray(item.allowedSiteIds)
+  if (allowedSites.length > 0) {
+    rows.push({
+      label: t('settings.downstream.keys.scope.sitesAllow'),
+      text: allowedSites.map((id) => resolveName(names.sites, id)).join(', '),
+    })
+  }
+  const excludedSites = parseIdArray(item.excludedSiteIds)
+  if (excludedSites.length > 0) {
+    rows.push({
+      label: t('settings.downstream.keys.scope.sitesExclude'),
+      text: excludedSites.map((id) => resolveName(names.sites, id)).join(', '),
+    })
+  }
+
+  const allowedRefs = parseCredentialRefs(item.allowedCredentialRefs)
+  if (allowedRefs.length > 0) {
+    rows.push({
+      label: t('settings.downstream.keys.scope.credsAllow'),
+      text: allowedRefs.map(describeRef).join('; '),
+    })
+  }
+  const excludedRefs = parseCredentialRefs(item.excludedCredentialRefs)
+  if (excludedRefs.length > 0) {
+    rows.push({
+      label: t('settings.downstream.keys.scope.credsExclude'),
+      text: excludedRefs.map(describeRef).join('; '),
+    })
+  }
+
+  if (rows.length === 0) {
+    return (
+      <span className='text-muted-foreground text-xs'>
+        {t('settings.downstream.keys.scope.unrestricted')}
+      </span>
+    )
+  }
+
+  return (
+    <div className='space-y-0.5 text-xs' data-testid='key-scope-cell'>
+      {rows.map((row) => (
+        <div key={row.label}>
+          <span className='text-muted-foreground'>{row.label}: </span>
+          {row.text}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/src/features/settings/sections/downstream/components/keys-section.tsx
+++ b/web/src/features/settings/sections/downstream/components/keys-section.tsx
@@ -49,12 +49,22 @@ import {
 } from '@/components/ui/sheet'
 import { Spinner } from '@/components/ui/spinner'
 import { Switch } from '@/components/ui/switch'
+import { useAccounts, useAllAccountTokens } from '@/features/accounts'
 import { useSites } from '@/features/sites'
 import { api } from '@/lib/api'
 import { toast } from '@/lib/toast'
 
 import { SettingsSectionCard } from '../../../components/settings-section-card'
 import { SettingsSectionError } from '../../../components/settings-section-error'
+import { accountDisplayName, tokenDisplayName } from '../lib/credential-display'
+import {
+  credentialRefSchema,
+  parseCredentialRefs,
+  parseIdArray,
+  serializeCredentialRefs,
+} from '../lib/credential-refs'
+import { CredentialRefPicker } from './credential-ref-picker'
+import { KeyScopeCell, type ScopeNameMaps } from './key-scope-cell'
 
 type DownstreamKeyUsage24h = {
   requests?: number
@@ -76,6 +86,11 @@ type DownstreamApiKeyItem = {
   supportedModels?: string[] | string | null
   allowedRouteIds?: number[] | string | null
   allowedSiteIds?: number[] | string | null
+  excludedSiteIds?: number[] | string | null
+  // Credential-ref columns: GET returns the stored columns verbatim — a raw
+  // JSON string (or null); parsed with parseCredentialRefs before use.
+  allowedCredentialRefs?: string | unknown[] | null
+  excludedCredentialRefs?: string | unknown[] | null
   usage24h?: DownstreamKeyUsage24h
 }
 
@@ -97,6 +112,22 @@ const downstreamKeysQueryKeys = {
 
 const CREATE_FORM_ID = 'settings-downstream-keys-create-form'
 
+// Extract the backend error message from an axios rejection. Admin API
+// errors serialize as { error: "..." } (handler/shared/errors.go APIError);
+// .message is checked too, mirroring the http-client resolveResponseMessage
+// order. Returns undefined for shapes without a usable string.
+function resolveApiErrorMessage(error: unknown): string | undefined {
+  const data = (error as { response?: { data?: unknown } } | null)?.response
+    ?.data
+  if (data && typeof data === 'object') {
+    const message = (data as { message?: unknown }).message
+    if (typeof message === 'string' && message.trim()) return message
+    const errorField = (data as { error?: unknown }).error
+    if (typeof errorField === 'string' && errorField.trim()) return errorField
+  }
+  return undefined
+}
+
 function generateDownstreamSkSuffix(): string {
   const bytes = new Uint8Array(48)
   crypto.getRandomValues(bytes)
@@ -116,6 +147,8 @@ const createKeySchema = z.object({
   description: z.string().optional(),
   supportedModels: z.array(z.string().trim().min(1)).default([]),
   allowedSiteIds: z.array(z.number().int().positive()).default([]),
+  allowedCredentialRefs: z.array(credentialRefSchema).default([]),
+  excludedCredentialRefs: z.array(credentialRefSchema).default([]),
 })
 
 type CreateKeyFormValues = z.infer<typeof createKeySchema>
@@ -164,54 +197,6 @@ function normalizeModelRules(value: unknown): string[] {
   return rules
 }
 
-function normalizeRouteIds(value: unknown): number[] {
-  let rawRouteIds: unknown[] = []
-  if (Array.isArray(value)) {
-    rawRouteIds = value
-  } else if (typeof value === 'string' && value.trim()) {
-    try {
-      const parsed = JSON.parse(value) as unknown
-      rawRouteIds = Array.isArray(parsed) ? parsed : []
-    } catch {
-      rawRouteIds = []
-    }
-  }
-
-  return [
-    ...new Set(
-      rawRouteIds.filter(
-        (routeId): routeId is number =>
-          typeof routeId === 'number' &&
-          Number.isInteger(routeId) &&
-          routeId > 0
-      )
-    ),
-  ]
-}
-
-function normalizeSiteIds(value: unknown): number[] {
-  let rawSiteIds: unknown[] = []
-  if (Array.isArray(value)) {
-    rawSiteIds = value
-  } else if (typeof value === 'string' && value.trim()) {
-    try {
-      const parsed = JSON.parse(value) as unknown
-      rawSiteIds = Array.isArray(parsed) ? parsed : []
-    } catch {
-      rawSiteIds = []
-    }
-  }
-
-  return [
-    ...new Set(
-      rawSiteIds.filter(
-        (siteId): siteId is number =>
-          typeof siteId === 'number' && Number.isInteger(siteId) && siteId > 0
-      )
-    ),
-  ]
-}
-
 function extractMarketplaceModelNames(result: unknown): string[] {
   let rows: unknown = []
   if (Array.isArray(result)) {
@@ -246,6 +231,8 @@ function blankKeyFormValues(): CreateKeyFormValues {
     description: '',
     supportedModels: [],
     allowedSiteIds: [],
+    allowedCredentialRefs: [],
+    excludedCredentialRefs: [],
   }
 }
 
@@ -261,7 +248,11 @@ function keyFormValuesFromItem(
     enabled: item.enabled,
     expiresAt: isoToLocalDatetimeInput(item.expiresAt),
     supportedModels: normalizeModelRules(item.supportedModels),
-    allowedSiteIds: normalizeSiteIds(item.allowedSiteIds),
+    allowedSiteIds: parseIdArray(item.allowedSiteIds),
+    // GET returns the stored ref columns as raw JSON strings — parse them
+    // back into typed refs for the tree pickers (round-trip contract).
+    allowedCredentialRefs: parseCredentialRefs(item.allowedCredentialRefs),
+    excludedCredentialRefs: parseCredentialRefs(item.excludedCredentialRefs),
   }
 }
 
@@ -527,8 +518,18 @@ export function KeySheetForm({
 
   const submitMutation = useMutation({
     mutationFn: async (values: CreateKeyFormValues) => {
+      // Canonical wire format for the credential-ref dimensions: real arrays
+      // (create/update bodies never carry the stored JSON-string form).
+      const policy = {
+        allowedCredentialRefs: serializeCredentialRefs(
+          values.allowedCredentialRefs
+        ),
+        excludedCredentialRefs: serializeCredentialRefs(
+          values.excludedCredentialRefs
+        ),
+      }
       if (!editingKey) {
-        return api.createDownstreamApiKey(values)
+        return api.createDownstreamApiKey({ ...values, ...policy })
       }
       return api.updateDownstreamApiKey(editingKey.id, {
         name: values.name,
@@ -539,6 +540,7 @@ export function KeySheetForm({
         expiresAt: values.expiresAt,
         supportedModels: values.supportedModels,
         allowedSiteIds: values.allowedSiteIds,
+        ...policy,
       })
     },
     onSuccess: (result, values) => {
@@ -569,12 +571,18 @@ export function KeySheetForm({
       }
       onDone()
     },
-    onError: () =>
+    onError: (error) => {
+      // skipErrorHandler owns this call's feedback: surface the backend's
+      // own message when present (400s carry the offending credentialRefs
+      // entry index / unknown id), fall back to the generic toast.
+      const serverMessage = resolveApiErrorMessage(error)
       toast.error(
-        isEdit
-          ? t('settings.downstream.keys.toast.updateFailed')
-          : t('settings.downstream.keys.toast.createFailed')
-      ),
+        serverMessage ??
+          (isEdit
+            ? t('settings.downstream.keys.toast.updateFailed')
+            : t('settings.downstream.keys.toast.createFailed'))
+      )
+    },
   })
 
   function onSubmit(values: CreateKeyFormValues) {
@@ -679,7 +687,7 @@ export function KeySheetForm({
                     onChange={field.onChange}
                     candidateModels={candidateModels}
                     routeGrantCount={
-                      normalizeRouteIds(editingKey?.allowedRouteIds).length
+                      parseIdArray(editingKey?.allowedRouteIds).length
                     }
                   />
                 </FormControl>
@@ -708,6 +716,48 @@ export function KeySheetForm({
                     value={field.value ?? []}
                     onChange={field.onChange}
                     sites={sites ?? []}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name='allowedCredentialRefs'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {t('settings.downstream.keys.credentials.fieldLabelAllow')}
+                </FormLabel>
+                <FormDescription>
+                  {t('settings.downstream.keys.credentials.hintAllow')}
+                </FormDescription>
+                <FormControl>
+                  <CredentialRefPicker
+                    value={field.value ?? []}
+                    onChange={field.onChange}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name='excludedCredentialRefs'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {t('settings.downstream.keys.credentials.fieldLabelExclude')}
+                </FormLabel>
+                <FormDescription>
+                  {t('settings.downstream.keys.credentials.hintExclude')}
+                </FormDescription>
+                <FormControl>
+                  <CredentialRefPicker
+                    value={field.value ?? []}
+                    onChange={field.onChange}
                   />
                 </FormControl>
                 <FormMessage />
@@ -851,7 +901,7 @@ export function KeyModelPolicyCell({
 }) {
   const { t } = useTranslation()
   const rules = normalizeModelRules(supportedModels)
-  const routeGrantCount = normalizeRouteIds(allowedRouteIds).length
+  const routeGrantCount = parseIdArray(allowedRouteIds).length
   if (rules.includes('*')) {
     return (
       <Badge variant='success'>
@@ -950,6 +1000,34 @@ export function KeysSection() {
   const candidateModels = useMemo(
     () => extractMarketplaceModelNames(modelInventoryQuery.data),
     [modelInventoryQuery.data]
+  )
+
+  // Routing-scope display resolves raw site/account/token IDs to names.
+  // These share their query keys with the sites/accounts/tokens surfaces
+  // (and with the credential pickers inside the edit sheet), so the list
+  // pays at most one extra fetch per inventory dimension.
+  const scopeSitesQuery = useSites()
+  const scopeAccountsQuery = useAccounts()
+  const scopeTokensQuery = useAllAccountTokens()
+  const scopeNames = useMemo<ScopeNameMaps>(
+    () => ({
+      sites: new Map(
+        (scopeSitesQuery.data ?? []).map((site) => [site.id, site.name])
+      ),
+      accounts: new Map(
+        (scopeAccountsQuery.data?.accounts ?? []).map((account) => [
+          account.id,
+          accountDisplayName(account),
+        ])
+      ),
+      tokens: new Map(
+        (scopeTokensQuery.data ?? []).map((token) => [
+          token.id,
+          tokenDisplayName(token),
+        ])
+      ),
+    }),
+    [scopeSitesQuery.data, scopeAccountsQuery.data, scopeTokensQuery.data]
   )
 
   const [editingKey, setEditingKey] = useState<DownstreamApiKeyItem | null>(
@@ -1066,6 +1144,13 @@ export function KeysSection() {
         ),
       },
       {
+        id: 'scope',
+        header: t('settings.downstream.keys.columns.scope'),
+        cell: ({ row }) => (
+          <KeyScopeCell item={row.original} names={scopeNames} />
+        ),
+      },
+      {
         id: 'enabled',
         header: t('settings.downstream.keys.columns.enabled'),
         meta: { mobileBadge: true },
@@ -1127,7 +1212,7 @@ export function KeysSection() {
         ),
       },
     ],
-    [t, toggleKeyPending, toggleKeyMutate]
+    [t, toggleKeyPending, toggleKeyMutate, scopeNames]
   )
 
   const { table } = useDataTable<DownstreamApiKeyItem>({

--- a/web/src/features/settings/sections/downstream/lib/__tests__/credential-refs.test.ts
+++ b/web/src/features/settings/sections/downstream/lib/__tests__/credential-refs.test.ts
@@ -1,0 +1,107 @@
+// Contract tests for downstream-key credential-ref parsing/serialization
+// (#1026 UI follow-up). The backend GET endpoints return stored columns as
+// raw JSON strings (or null), while create/update request bodies use real
+// arrays — these helpers own that boundary.
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  parseCredentialRefs,
+  parseIdArray,
+  serializeCredentialRefs,
+} from '../credential-refs'
+
+describe('parseCredentialRefs', () => {
+  it('parses the raw JSON string returned by GET endpoints', () => {
+    expect(
+      parseCredentialRefs(
+        '[{"kind":"account_token","siteId":1,"accountId":2,"tokenId":7},{"kind":"default_api_key","siteId":1,"accountId":2}]'
+      )
+    ).toEqual([
+      { kind: 'account_token', siteId: 1, accountId: 2, tokenId: 7 },
+      { kind: 'default_api_key', siteId: 1, accountId: 2 },
+    ])
+  })
+
+  it('treats null, empty string and empty array as unrestricted', () => {
+    expect(parseCredentialRefs(null)).toEqual([])
+    expect(parseCredentialRefs('')).toEqual([])
+    expect(parseCredentialRefs([])).toEqual([])
+  })
+
+  it('drops malformed entries instead of crashing', () => {
+    expect(
+      parseCredentialRefs([
+        null,
+        42,
+        { kind: 'account_token', siteId: 1, accountId: 2 },
+        { kind: 'wat', siteId: 1, accountId: 2 },
+        {
+          kind: 'account_token',
+          siteId: 0,
+          accountId: 2,
+          tokenId: 7,
+        },
+      ])
+    ).toEqual([])
+  })
+
+  it('treats legacy entries without kind as default_api_key', () => {
+    expect(parseCredentialRefs([{ siteId: 1, accountId: 2 }])).toEqual([
+      { kind: 'default_api_key', siteId: 1, accountId: 2 },
+    ])
+  })
+
+  it('deduplicates equivalent refs while preserving stable uniqueness', () => {
+    expect(
+      parseCredentialRefs([
+        { kind: 'account_token', siteId: 1, accountId: 2, tokenId: 7 },
+        { kind: 'account_token', siteId: 1, accountId: 2, tokenId: 7 },
+      ])
+    ).toEqual([{ kind: 'account_token', siteId: 1, accountId: 2, tokenId: 7 }])
+  })
+})
+
+describe('serializeCredentialRefs', () => {
+  it('round-trips a canonical list with no extra tokenId on default refs', () => {
+    const refs = [
+      {
+        kind: 'default_api_key' as const,
+        siteId: 1,
+        accountId: 2,
+        tokenId: 99,
+      } as { kind: 'default_api_key'; siteId: number; accountId: number },
+      { kind: 'account_token' as const, siteId: 1, accountId: 2, tokenId: 7 },
+    ]
+    expect(serializeCredentialRefs(refs)).toEqual([
+      { kind: 'account_token', siteId: 1, accountId: 2, tokenId: 7 },
+      { kind: 'default_api_key', siteId: 1, accountId: 2 },
+    ])
+  })
+
+  it('sorts, canonicalizes and dedupes wire entries', () => {
+    expect(
+      serializeCredentialRefs([
+        { kind: 'account_token', siteId: 2, accountId: 1, tokenId: 9 },
+        { kind: 'account_token', siteId: 1, accountId: 2, tokenId: 7 },
+        { kind: 'account_token', siteId: 2, accountId: 1, tokenId: 9 },
+      ])
+    ).toEqual([
+      { kind: 'account_token', siteId: 1, accountId: 2, tokenId: 7 },
+      { kind: 'account_token', siteId: 2, accountId: 1, tokenId: 9 },
+    ])
+  })
+})
+
+describe('parseIdArray', () => {
+  it('parses JSON strings and arrays for site/route ID columns', () => {
+    expect(parseIdArray('[1,2]')).toEqual([1, 2])
+    expect(parseIdArray([2, 1])).toEqual([2, 1])
+  })
+
+  it('returns empty for null, malformed JSON and invalid IDs', () => {
+    expect(parseIdArray(null)).toEqual([])
+    expect(parseIdArray('not-json')).toEqual([])
+    expect(parseIdArray([1, -2, 0, '3'])).toEqual([1])
+  })
+})

--- a/web/src/features/settings/sections/downstream/lib/credential-display.ts
+++ b/web/src/features/settings/sections/downstream/lib/credential-display.ts
@@ -1,0 +1,14 @@
+// metapi-go/features/settings/sections/downstream/lib — display helpers for
+// upstream account/token rows used by the credential-ref tree picker and the
+// key scope cell. Kept outside component files so React fast refresh only
+// sees components in .tsx modules.
+
+import type { Account, AccountToken } from '@/features/accounts/types'
+
+export function accountDisplayName(account: Account): string {
+  return account.username?.trim() || `#${account.id}`
+}
+
+export function tokenDisplayName(token: AccountToken): string {
+  return token.name?.trim() || token.tokenMasked?.trim() || `#${token.id}`
+}

--- a/web/src/features/settings/sections/downstream/lib/credential-refs.ts
+++ b/web/src/features/settings/sections/downstream/lib/credential-refs.ts
@@ -1,0 +1,183 @@
+// metapi-go/features/settings/sections/downstream/lib — credential-ref
+// policy helpers for downstream API keys (#1026 UI follow-up).
+//
+// Contract SSOT: docs/api.md → Downstream API Keys → Credential & site scope.
+//   - a ref is {kind, siteId, accountId, tokenId?} with
+//     kind ∈ account_token | default_api_key
+//   - GET responses return the stored columns as raw JSON strings (or null)
+//     → parseCredentialRefs
+//   - create/update request bodies use real arrays → serializeCredentialRefs
+//   - empty/omitted means "unrestricted" for that dimension
+
+import { z } from 'zod'
+
+/**
+ * Form-level schema (create/edit sheet). The discriminated union encodes the
+ * two legal shapes: account_token requires a positive tokenId,
+ * default_api_key carries none. The picker only produces conforming refs;
+ * the schema keeps hand-imported/legacy values honest before submit.
+ */
+export const credentialRefSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('account_token'),
+    siteId: z.number().int().positive(),
+    accountId: z.number().int().positive(),
+    tokenId: z.number().int().positive(),
+  }),
+  z.object({
+    kind: z.literal('default_api_key'),
+    siteId: z.number().int().positive(),
+    accountId: z.number().int().positive(),
+  }),
+])
+
+/** Single source of truth: the type is exactly the schema's inference. */
+export type CredentialRef = z.infer<typeof credentialRefSchema>
+
+/** Stable identity used for dedupe and selection bookkeeping. */
+export function credentialRefKey(ref: CredentialRef): string {
+  return ref.kind === 'account_token'
+    ? `account_token:${ref.siteId}:${ref.accountId}:${ref.tokenId}`
+    : `default_api_key:${ref.siteId}:${ref.accountId}`
+}
+
+function toPositiveInt(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+    ? value
+    : null
+}
+
+/**
+ * Normalize one stored entry. Invalid entries return null (dropped on READ —
+ * the backend rejects them on WRITE, so a stored row can only carry garbage
+ * from pre-validation legacy data; the UI must not crash on it). Entries
+ * persisted by the legacy TS version without a kind are treated with
+ * default_api_key semantics, mirroring the backend's read compatibility.
+ */
+function normalizeEntry(raw: unknown): CredentialRef | null {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null
+  }
+  const entry = raw as Record<string, unknown>
+  const siteId = toPositiveInt(entry.siteId)
+  const accountId = toPositiveInt(entry.accountId)
+  if (siteId === null || accountId === null) return null
+
+  const kind =
+    entry.kind === undefined || entry.kind === null
+      ? 'default_api_key'
+      : entry.kind
+  if (kind === 'account_token') {
+    const tokenId = toPositiveInt(entry.tokenId)
+    if (tokenId === null) return null
+    return { kind, siteId, accountId, tokenId }
+  }
+  if (kind === 'default_api_key') {
+    return { kind, siteId, accountId }
+  }
+  return null
+}
+
+/**
+ * Parse the stored column value into refs. Accepts null/undefined/empty
+ * (→ unrestricted → []), a parsed array, or the raw JSON string the GET
+ * endpoints return. Malformed entries are dropped; duplicates collapse.
+ */
+export function parseCredentialRefs(value: unknown): CredentialRef[] {
+  let rows: unknown[] = []
+  if (Array.isArray(value)) {
+    rows = value
+  } else if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value) as unknown
+      rows = Array.isArray(parsed) ? parsed : []
+    } catch {
+      rows = []
+    }
+  }
+
+  const seen = new Set<string>()
+  const refs: CredentialRef[] = []
+  for (const row of rows) {
+    const ref = normalizeEntry(row)
+    if (!ref) continue
+    const key = credentialRefKey(ref)
+    if (seen.has(key)) continue
+    seen.add(key)
+    refs.push(ref)
+  }
+  return refs
+}
+
+/**
+ * Canonicalize refs for the wire: dedupe, stable order (siteId, accountId,
+ * kind, tokenId), and exact shapes (no tokenId key on default_api_key).
+ * An empty result means "unrestricted" — callers send it as [] and the
+ * backend stores NULL.
+ */
+export function serializeCredentialRefs(
+  refs: readonly CredentialRef[]
+): CredentialRef[] {
+  const seen = new Set<string>()
+  const unique: CredentialRef[] = []
+  for (const ref of refs) {
+    const key = credentialRefKey(ref)
+    if (seen.has(key)) continue
+    seen.add(key)
+    unique.push(
+      ref.kind === 'account_token'
+        ? {
+            kind: ref.kind,
+            siteId: ref.siteId,
+            accountId: ref.accountId,
+            tokenId: ref.tokenId,
+          }
+        : { kind: ref.kind, siteId: ref.siteId, accountId: ref.accountId }
+    )
+  }
+  return unique.sort((left, right) => {
+    if (left.siteId !== right.siteId) return left.siteId - right.siteId
+    if (left.accountId !== right.accountId) {
+      return left.accountId - right.accountId
+    }
+    if (left.kind !== right.kind) return left.kind.localeCompare(right.kind)
+    return credentialRefTokenId(left) - credentialRefTokenId(right)
+  })
+}
+
+function credentialRefTokenId(ref: CredentialRef): number {
+  return ref.kind === 'account_token' ? ref.tokenId : 0
+}
+
+/**
+ * Parse a stored ID-array column (allowedSiteIds / excludedSiteIds /
+ * allowedRouteIds). GET responses return these as raw JSON strings (or
+ * null); legacy rows may already be arrays. Invalid / non-positive entries
+ * are dropped; duplicates collapse. Mirrors the previous keys-section
+ * normalizeSiteIds/normalizeRouteIds behavior.
+ */
+export function parseIdArray(value: unknown): number[] {
+  let rows: unknown[] = []
+  if (Array.isArray(value)) {
+    rows = value
+  } else if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value) as unknown
+      rows = Array.isArray(parsed) ? parsed : []
+    } catch {
+      rows = []
+    }
+  }
+
+  const seen = new Set<number>()
+  const ids: number[] = []
+  for (const row of rows) {
+    if (typeof row !== 'number' || !Number.isInteger(row) || row <= 0) {
+      continue
+    }
+    if (seen.has(row)) continue
+    seen.add(row)
+    ids.push(row)
+  }
+  return ids
+}

--- a/web/src/features/sites/index.ts
+++ b/web/src/features/sites/index.ts
@@ -9,5 +9,5 @@ export { sitesSearchSchema } from './lib/sites-schema'
 // cross-feature detail sheets that render site-provided URLs as links.
 export { isValidEndpointUrl } from './lib/endpoints'
 
-export { sitesKeys } from './types'
+export { sitesKeys, type Site } from './types'
 export { useSites } from './api'

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1298,7 +1298,8 @@
             "editAria": "Edit {{name}}",
             "usage": "Usage",
             "actions": "Actions",
-            "models": "Models"
+            "models": "Models",
+            "scope": "Scope"
           },
           "models": {
             "fieldLabel": "Model access",
@@ -1344,6 +1345,34 @@
           "sites": {
             "fieldLabel": "Upstream site restriction",
             "hint": "Leave empty for no site restriction. Selecting sites limits this key to channels of the chosen upstream sites."
+          },
+          "credentials": {
+            "fieldLabelAllow": "Allowed credentials",
+            "hintAllow": "Leave empty for no credential restriction. When set, only the selected site/account credentials may serve this key.",
+            "fieldLabelExclude": "Excluded credentials",
+            "hintExclude": "Excluded credentials never serve this key. Exclusion wins when the same credential is also allowed.",
+            "loading": "Loading sites, accounts and tokens…",
+            "loadFailed": "Failed to load the upstream inventory (sites/accounts/tokens).",
+            "noSites": "No upstream sites configured.",
+            "noAccounts": "No accounts on this site.",
+            "expandSiteAria": "Toggle accounts of {{site}}",
+            "expandTokensAria": "Toggle tokens of {{account}}",
+            "defaultApiKey": "Default API key",
+            "noDefaultKey": "no default key",
+            "tokenPrefix": "Token",
+            "selectedCount_one": "{{count}} selected",
+            "selectedCount_other": "{{count}} selected",
+            "unresolvedTitle": "Unresolved references (upstream object no longer exists)",
+            "unresolvedRemoveAria": "Remove unresolved reference"
+          },
+          "scope": {
+            "unrestricted": "Unrestricted",
+            "sitesAllow": "Allowed sites",
+            "sitesExclude": "Excluded sites",
+            "credsAllow": "Allowed credentials",
+            "credsExclude": "Excluded credentials",
+            "defaultKey": "default key",
+            "unknownId": "ID {{id}} (unresolved)"
           }
         },
         "proxyToken": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1298,7 +1298,8 @@
             "editAria": "编辑 {{name}}",
             "usage": "用量",
             "actions": "操作",
-            "models": "模型"
+            "models": "模型",
+            "scope": "作用域"
           },
           "models": {
             "fieldLabel": "模型授权",
@@ -1344,6 +1345,34 @@
           "sites": {
             "fieldLabel": "上游站点限制",
             "hint": "留空表示不限制站点；勾选后该密钥只能访问所选上游站点的渠道。"
+          },
+          "credentials": {
+            "fieldLabelAllow": "允许的凭证",
+            "hintAllow": "留空表示不限制凭证；勾选后仅被选中的站点/账号凭证可为该密钥提供服务。",
+            "fieldLabelExclude": "排除的凭证",
+            "hintExclude": "被排除的凭证永不服务该密钥；同一凭证同时出现在允许与排除时，排除优先。",
+            "loading": "正在加载站点、账号与令牌…",
+            "loadFailed": "加载上游清单（站点/账号/令牌）失败。",
+            "noSites": "尚未配置上游站点。",
+            "noAccounts": "该站点下暂无账号。",
+            "expandSiteAria": "展开或收起 {{site}} 的账号",
+            "expandTokensAria": "展开或收起 {{account}} 的令牌",
+            "defaultApiKey": "默认 API 密钥",
+            "noDefaultKey": "无默认密钥",
+            "tokenPrefix": "令牌",
+            "selectedCount_one": "已选 {{count}} 项",
+            "selectedCount_other": "已选 {{count}} 项",
+            "unresolvedTitle": "未解析引用（上游对象已不存在）",
+            "unresolvedRemoveAria": "移除未解析引用"
+          },
+          "scope": {
+            "unrestricted": "不限制",
+            "sitesAllow": "允许站点",
+            "sitesExclude": "排除站点",
+            "credsAllow": "允许凭证",
+            "credsExclude": "排除凭证",
+            "defaultKey": "默认密钥",
+            "unknownId": "ID {{id}}（未解析）"
           }
         },
         "proxyToken": {


### PR DESCRIPTION
## Summary

Lane C2 (credential UI): implement the #1026 follow-up tree picker for downstream API key credential refs, wiring create/edit serialization plus list display against the #1064 backend contract. Frontend only; no backend changes and no new endpoints.

## Selector interaction

- Two independent tree pickers are rendered in the create/edit sheet: **Allowed credentials** and **Excluded credentials**.
- Tree hierarchy: **site → account → default API key / tokens**. Site headers expand/collapse accounts; account rows expose a native checkbox for the account default key (disabled when the account has no non-empty `apiTokenMasked`), and a chevron expands the account's tokens.
- Controls are native checkboxes/buttons (keyboard reachable), bilingual (en/zh-CN), empty selection is labeled as unrestricted, and selection counts are shown per site.
- Edit mode opens previously selected sites/accounts expanded so checked values are visible immediately.
- Stored refs whose site/account/token no longer resolves are shown in an "Unresolved references" section with explicit ID text and a remove action (fail-closed dangling allow refs remain visible rather than hidden).

## Parse / serialize contract

- `GET` returns `allowedCredentialRefs` / `excludedCredentialRefs` as raw JSON strings (or `null`); `parseCredentialRefs` parses them, tolerates pre-parsed arrays, drops malformed entries without crashing, and treats legacy refs without `kind` as `default_api_key` (matching backend read compatibility).
- Submit serializes canonical arrays `{kind, siteId, accountId, tokenId?}`; empty arrays are sent and mean unrestricted. `default_api_key` refs never include `tokenId`; entries are deduped and sorted.
- Backend 400 bodies (`{"error": "credentialRefs[0] ..."}`) are surfaced verbatim through the existing form error toast; generic fallback remains for non-JSON errors.

## List display

- New `Scope` column renders allowed/excluded sites and credential refs with resolved site/account/token names (`Site / Account / default key` or `Site / Account / Token`).
- Missing mappings render as `ID n (unresolved)`, never as raw-only labels.

## Component structure

- `web/src/features/settings/sections/downstream/lib/credential-refs.ts` — schema, parse/serialize/parseIdArray helpers (pure, unit tested).
- `web/src/features/settings/sections/downstream/lib/credential-display.ts` — account/token display helpers.
- `web/src/features/settings/sections/downstream/components/credential-ref-picker.tsx` — tree picker.
- `web/src/features/settings/sections/downstream/components/key-scope-cell.tsx` — list scope rendering.
- `web/src/features/settings/sections/downstream/components/keys-section.tsx` — form wiring, query/name maps, error handling.
- `web/src/features/accounts/tokens/api.ts` / `accounts/index.ts` — fleet-wide token inventory hook reuse.
- `web/src/features/sites/index.ts` — `Site` type barrel export used by picker.

## Tests

New/updated component and unit tests (7 downstream files, 41 cases):

- `credential-refs.test.ts` — raw JSON string parse, null/empty unrestricted, malformed/legacy handling, dedupe, canonical serialization round-trip, `parseIdArray`.
- `credential-ref-picker.test.tsx` — default-key selection, token selection, no-default disables, edit prefill, unresolved removal, keyboard focus.
- `key-scope-cell.test.tsx` — unrestricted, resolved names, allow/exclude dimensions, unresolved IDs.
- `keys-section-credential-scope.test.tsx` — parse backfill, update/create serialization, empty=unrestricted, 400 message display.
- Existing site-scope, edit/mobile tests updated for the new inventory query mocks.

## Verification

- Frontend: `tsgo` 0 errors, oxlint 0 errors (existing warnings only), knip clean, oxfmt clean, Rsbuild build pass.
- Full test: `bun run test` — route tree guard OK, 227 files / 1447 tests passed.
- Pre-push hook: frontend gate + `go build ./cmd/server` + `go vet ./...` + WSL `go test ./... -count=1 -race -timeout 900s` all passed.
- `docs/api.md` UI-status section updated to reflect the new picker.