### PR TITLE
feat(web): add actions layer to the command palette (#1035 S6)

### DIFF
--- a/web/src/components/layout/__tests__/search-modal.test.tsx
+++ b/web/src/components/layout/__tests__/search-modal.test.tsx
@@ -1,8 +1,10 @@
 // metapi-go/layout — command palette tests.
-// Covers the local navigation layer (quick entries + settings matching)
-// and the filtered deep links for check-in / proxy-log entity results.
+// Covers the local navigation layer (quick entries + settings matching),
+// the actions layer (registry rendering, keyboard execution, confirmation
+// gate, mutation feedback) and the filtered deep links for entity results.
 
 import '@testing-library/jest-dom/vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import {
   afterAll,
@@ -19,9 +21,24 @@ import i18n from '@/i18n/config'
 
 import { SearchModal } from '../search-modal'
 
-const { navigateMock, searchMock } = vi.hoisted(() => ({
+const {
+  navigateMock,
+  searchMock,
+  onOpenChangeMock,
+  checkinAllMock,
+  rebuildMock,
+  refreshDecisionsMock,
+  toastSuccessMock,
+  toastErrorMock,
+} = vi.hoisted(() => ({
   navigateMock: vi.fn(),
   searchMock: vi.fn(),
+  onOpenChangeMock: vi.fn(),
+  checkinAllMock: vi.fn(),
+  rebuildMock: vi.fn(),
+  refreshDecisionsMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
 }))
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
@@ -34,6 +51,29 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 
 vi.mock('@/lib/api/search', () => ({
   searchApi: { search: searchMock },
+}))
+
+// The actions layer reuses the feature mutation hooks; the tests drive them
+// through the public barrels so the palette's execution paths run for real.
+vi.mock('@/features/checkin', () => ({
+  useManualCheckin: () => ({ mutateAsync: checkinAllMock }),
+}))
+
+vi.mock('@/features/token-routes', () => ({
+  useRebuildRoutes: () => ({ mutate: rebuildMock, isPending: false }),
+  useRefreshRouteDecisions: () => ({
+    mutate: refreshDecisionsMock,
+    isPending: false,
+  }),
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: toastSuccessMock,
+    error: toastErrorMock,
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
 }))
 
 // The dialog primitive probes browser APIs jsdom does not implement; cmdk
@@ -79,14 +119,21 @@ const EMPTY_RESPONSE = {
   models: [],
 }
 
+const PLACEHOLDER = 'Search pages, settings, actions, sites, accounts, logs…'
+
 function renderModal() {
-  return render(<SearchModal open onOpenChange={vi.fn()} />)
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SearchModal open onOpenChange={onOpenChangeMock} />
+    </QueryClientProvider>
+  )
 }
 
 async function typeQuery(value: string) {
-  const input = screen.getByPlaceholderText(
-    'Search pages, settings, sites, accounts, logs…'
-  )
+  const input = screen.getByPlaceholderText(PLACEHOLDER)
   fireEvent.change(input, { target: { value } })
   // Wait for the ~250 ms debounce + mocked backend round-trip to settle.
   await vi.waitFor(() => {
@@ -96,6 +143,15 @@ async function typeQuery(value: string) {
 
 beforeEach(async () => {
   navigateMock.mockReset()
+  onOpenChangeMock.mockReset()
+  rebuildMock.mockReset()
+  refreshDecisionsMock.mockReset()
+  toastSuccessMock.mockReset()
+  toastErrorMock.mockReset()
+  checkinAllMock.mockReset().mockResolvedValue({
+    success: true,
+    summary: { total: 2, success: 2, failed: 0, skipped: 0 },
+  })
   searchMock.mockReset().mockResolvedValue(EMPTY_RESPONSE)
   await i18n.changeLanguage('en')
 })
@@ -123,9 +179,7 @@ describe('search palette navigation layer', () => {
   it('matches settings sections locally while typing', async () => {
     renderModal()
 
-    const input = screen.getByPlaceholderText(
-      'Search pages, settings, sites, accounts, logs…'
-    )
+    const input = screen.getByPlaceholderText(PLACEHOLDER)
     fireEvent.change(input, { target: { value: 'schedul' } })
 
     await vi.waitFor(() => {
@@ -138,9 +192,7 @@ describe('search palette navigation layer', () => {
   it('navigates to the matched settings section on select', async () => {
     renderModal()
 
-    const input = screen.getByPlaceholderText(
-      'Search pages, settings, sites, accounts, logs…'
-    )
+    const input = screen.getByPlaceholderText(PLACEHOLDER)
     fireEvent.change(input, { target: { value: 'operational events' } })
 
     const entry = await screen.findByText('Operational Events')
@@ -149,6 +201,142 @@ describe('search palette navigation layer', () => {
     expect(navigateMock).toHaveBeenCalledWith({
       to: '/settings/operations/program-logs',
     })
+  })
+})
+
+describe('search palette actions layer', () => {
+  it('lists every registered action under the Actions heading on an empty query', () => {
+    renderModal()
+
+    expect(screen.getByText('Actions')).toBeInTheDocument()
+    expect(screen.getByText('Add site')).toBeInTheDocument()
+    expect(screen.getByText('Run all check-ins')).toBeInTheDocument()
+    expect(screen.getByText('Auto-rebuild routes')).toBeInTheDocument()
+    expect(screen.getByText('Refresh route decisions')).toBeInTheDocument()
+    // Navigation quick entries keep rendering alongside the actions layer.
+    expect(screen.getByText('Pages')).toBeInTheDocument()
+  })
+
+  it('renders bilingual action titles in zh-CN', async () => {
+    // i18next resources are keyed by the interface code `zhCN`.
+    await i18n.changeLanguage('zhCN')
+    renderModal()
+
+    expect(screen.getByText('操作')).toBeInTheDocument()
+    expect(screen.getByText('添加站点')).toBeInTheDocument()
+    expect(screen.getByText('运行所有签到')).toBeInTheDocument()
+    expect(screen.getByText('自动重建路由')).toBeInTheDocument()
+    expect(screen.getByText('刷新路由决策')).toBeInTheDocument()
+  })
+
+  it('deep-links the add-site action through the one-shot create param via keyboard', async () => {
+    renderModal()
+
+    const input = screen.getByPlaceholderText(PLACEHOLDER)
+    fireEvent.change(input, { target: { value: 'add site' } })
+    await screen.findByText('Add site')
+
+    // Keyboard flow: the matched action is the selected item, Enter runs it.
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: '/sites',
+      search: { create: true },
+    })
+    expect(onOpenChangeMock).toHaveBeenCalledWith(false)
+  })
+
+  it('matches actions by bilingual keywords the English label lacks', async () => {
+    renderModal()
+
+    const input = screen.getByPlaceholderText(PLACEHOLDER)
+    fireEvent.change(input, { target: { value: '签到' } })
+
+    const entry = await screen.findByText('Run all check-ins')
+    fireEvent.click(entry)
+
+    await vi.waitFor(() => {
+      expect(checkinAllMock).toHaveBeenCalledTimes(1)
+    })
+    expect(onOpenChangeMock).toHaveBeenCalledWith(false)
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      'Check-in execution complete',
+      expect.objectContaining({
+        description: 'Total 2 accounts: 2 succeeded, 0 failed, 0 skipped',
+      })
+    )
+  })
+
+  it('reports a partial check-in failure as an error toast with the summary', async () => {
+    checkinAllMock.mockResolvedValue({
+      success: false,
+      summary: { total: 3, success: 2, failed: 1, skipped: 0 },
+    })
+    renderModal()
+
+    const input = screen.getByPlaceholderText(PLACEHOLDER)
+    fireEvent.change(input, { target: { value: 'checkin' } })
+
+    const entry = await screen.findByText('Run all check-ins')
+    fireEvent.click(entry)
+
+    await vi.waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        'Check-in partially failed',
+        expect.objectContaining({
+          description: 'Total 3 accounts: 2 succeeded, 1 failed, 0 skipped',
+        })
+      )
+    })
+  })
+
+  it('opens the rebuild confirmation before mutating (keyboard path)', async () => {
+    renderModal()
+
+    const input = screen.getByPlaceholderText(PLACEHOLDER)
+    fireEvent.change(input, { target: { value: 'rebuild' } })
+    await screen.findByText('Auto-rebuild routes')
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    // The palette closes and the same confirmation the routes page uses
+    // takes over — the mutation must NOT have fired yet.
+    await screen.findByText('Rebuild routes?')
+    expect(onOpenChangeMock).toHaveBeenCalledWith(false)
+    expect(rebuildMock).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Auto-rebuild' }))
+
+    expect(rebuildMock).toHaveBeenCalledWith({ refreshModels: true })
+  })
+
+  it('cancelling the rebuild confirmation never mutates', async () => {
+    renderModal()
+
+    const input = screen.getByPlaceholderText(PLACEHOLDER)
+    fireEvent.change(input, { target: { value: 'rebuild' } })
+    const entry = await screen.findByText('Auto-rebuild routes')
+    fireEvent.click(entry)
+
+    await screen.findByText('Rebuild routes?')
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(rebuildMock).not.toHaveBeenCalled()
+    expect(screen.queryByText('Rebuild routes?')).not.toBeInTheDocument()
+  })
+
+  it('fires refresh-route-decisions directly, without a confirmation', async () => {
+    renderModal()
+
+    const input = screen.getByPlaceholderText(PLACEHOLDER)
+    fireEvent.change(input, { target: { value: 'decisions' } })
+
+    const entry = await screen.findByText('Refresh route decisions')
+    fireEvent.click(entry)
+
+    expect(refreshDecisionsMock).toHaveBeenCalledTimes(1)
+    expect(onOpenChangeMock).toHaveBeenCalledWith(false)
+    expect(screen.queryByText('Rebuild routes?')).not.toBeInTheDocument()
   })
 })
 

--- a/web/src/components/layout/lib/__tests__/search-actions.test.ts
+++ b/web/src/components/layout/lib/__tests__/search-actions.test.ts
@@ -1,0 +1,127 @@
+// metapi-go/layout — command palette action registry tests.
+// Covers the registry contract (stable ids, bilingual title coverage,
+// keyword discipline) and the local matcher the palette uses while typing.
+
+import { describe, expect, it } from 'vitest'
+
+import en from '../../../../i18n/locales/en.json'
+import zhCN from '../../../../i18n/locales/zh-CN.json'
+import {
+  matchActionEntries,
+  SEARCH_ACTION_ENTRIES,
+  type SearchActionEntry,
+} from '../search-actions'
+
+type TranslationNode = Record<string, unknown>
+
+function resolveKey(root: TranslationNode, dottedKey: string): unknown {
+  let current: unknown = root
+  for (const segment of dottedKey.split('.')) {
+    if (current === null || typeof current !== 'object') return undefined
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current
+}
+
+describe('SEARCH_ACTION_ENTRIES registry', () => {
+  it('registers exactly the audited high-frequency actions with stable ids', () => {
+    expect(SEARCH_ACTION_ENTRIES.map((entry) => entry.id)).toEqual([
+      'add-site',
+      'run-checkin-all',
+      'rebuild-routes',
+      'refresh-route-decisions',
+    ])
+  })
+
+  it('uses unique ids, action-namespaced title keys and an icon per entry', () => {
+    const ids = SEARCH_ACTION_ENTRIES.map((entry) => entry.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    for (const entry of SEARCH_ACTION_ENTRIES) {
+      expect(entry.titleKey).toMatch(/^search\.actions\./)
+      expect(entry.icon).toBeDefined()
+      expect(entry.keywords.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('resolves every title key to a non-empty string in both locales', () => {
+    for (const entry of SEARCH_ACTION_ENTRIES) {
+      const enLabel = resolveKey(en.translation, entry.titleKey)
+      const zhLabel = resolveKey(zhCN.translation, entry.titleKey)
+      expect(typeof enLabel === 'string' && enLabel.length > 0).toBe(true)
+      expect(typeof zhLabel === 'string' && zhLabel.length > 0).toBe(true)
+    }
+  })
+})
+
+describe('matchActionEntries', () => {
+  const labels: Record<string, string> = {
+    'search.actions.addSite': 'Add site',
+    'search.actions.runCheckinAll': 'Run all check-ins',
+    'search.actions.rebuildRoutes': 'Auto-rebuild routes',
+    'search.actions.refreshRouteDecisions': 'Refresh route decisions',
+  }
+  const resolveLabel = (key: string) => labels[key] ?? key
+
+  it('returns every entry in registry order for an empty query', () => {
+    expect(
+      matchActionEntries(SEARCH_ACTION_ENTRIES, '  ', resolveLabel)
+    ).toEqual([...SEARCH_ACTION_ENTRIES])
+  })
+
+  it('matches translated labels case-insensitively', () => {
+    const matched = matchActionEntries(
+      SEARCH_ACTION_ENTRIES,
+      'REBUILD',
+      resolveLabel
+    )
+    expect(matched.map((entry) => entry.id)).toContain('rebuild-routes')
+  })
+
+  it('matches bilingual keywords the label alone does not contain', () => {
+    // "签到" does not appear in the English label "Run all check-ins".
+    const byZhKeyword = matchActionEntries(
+      SEARCH_ACTION_ENTRIES,
+      '签到',
+      resolveLabel
+    )
+    expect(byZhKeyword.map((entry) => entry.id)).toContain('run-checkin-all')
+
+    // "new site" is a synonym of the "Add site" label.
+    const bySynonym = matchActionEntries(
+      SEARCH_ACTION_ENTRIES,
+      'new site',
+      resolveLabel
+    )
+    expect(bySynonym.map((entry) => entry.id)).toContain('add-site')
+  })
+
+  it('ranks starts-with matches before contains matches', () => {
+    const entries: SearchActionEntry[] = [
+      {
+        id: 'rebuild-routes',
+        titleKey: 'contains.only',
+        keywords: ['route rebuild special'],
+        icon: SEARCH_ACTION_ENTRIES[0].icon,
+      },
+      {
+        id: 'add-site',
+        titleKey: 'starts.with',
+        keywords: ['rebuild'],
+        icon: SEARCH_ACTION_ENTRIES[0].icon,
+      },
+    ]
+    const matched = matchActionEntries(entries, 'rebuild', (key) =>
+      key === 'starts.with' ? 'Something else' : 'Another thing'
+    )
+    expect(matched.map((entry) => entry.id)).toEqual([
+      'add-site',
+      'rebuild-routes',
+    ])
+  })
+
+  it('returns no entries when the query matches nothing', () => {
+    expect(
+      matchActionEntries(SEARCH_ACTION_ENTRIES, 'zzz', resolveLabel)
+    ).toEqual([])
+  })
+})

--- a/web/src/components/layout/lib/search-actions.ts
+++ b/web/src/components/layout/lib/search-actions.ts
@@ -1,0 +1,128 @@
+// metapi-go/layout — action registry for the global search palette.
+//
+// The ⌘K palette's action layer: high-frequency WRITE actions, alongside
+// (not replacing) the navigation and entity layers. Each entry points at an
+// affordance that already exists in the product — the registry only carries
+// stable identity, i18n title keys, match keywords and icons. Execution
+// lives in `search-modal.tsx`, where the router and mutation hooks are
+// available.
+//
+// Selection audit (Wave 21, #1035 S6) — every entry reuses an existing
+// dialog/mutation, no new business logic:
+//   - add-site: the sites page already consumes a one-shot `?create=1`
+//     deep link (the dashboard onboarding and the sites guided flow write
+//     one), so the palette drives the exact same dialog-opening path.
+//   - run-checkin-all: the same `useManualCheckin` mutation the checkin
+//     page's "Run all check-ins" button fires.
+//   - rebuild-routes: the same `useRebuildRoutes` mutation the routes page
+//     fires, behind the same ConfirmDialog wording (the page gates it).
+//   - refresh-route-decisions: the same `useRefreshRouteDecisions` mutation
+//     the routes page header button fires.
+//
+// Rejected candidates (evaluated against the code, not invented):
+//   - add account: the accounts page only consumes a one-shot create
+//     deep link together with a valid siteId; a standalone `?create=1`
+//     never opens the dialog.
+//   - add route: the routes page has no `create` deep link, only `edit`.
+//   - add channel: channels are never created manually (read-only list;
+//     channels are composed by route rebuild / the route channel editor).
+//   - retest channel: no such operation exists anywhere in web/src.
+//   - refresh balances: only per-row and selection-scoped batch refresh
+//     exist; a palette-wide variant would be a new operation.
+//   - backup export: confirm-token + export-type + download flow (#1034),
+//     a settings section, not a palette-sized action.
+//   - clear cache / usage data: ConfirmDialog-gated maintenance ops,
+//     reachable through the settings entries of the navigation layer.
+//   - single-account check-in: needs the account picker dialog, which stays
+//     on the checkin page; the all-accounts trigger covers the quick case.
+
+import {
+  CalendarCheck,
+  RefreshCw,
+  Server,
+  Zap,
+  type LucideIcon,
+} from 'lucide-react'
+
+export type SearchActionId =
+  | 'add-site'
+  | 'run-checkin-all'
+  | 'rebuild-routes'
+  | 'refresh-route-decisions'
+
+export type SearchActionEntry = {
+  /** Stable identity for cmdk item keys and the execution switch. */
+  id: SearchActionId
+  /** i18n key of the action title (verb phrase, en + zh-CN). */
+  titleKey: string
+  /** Lowercase bilingual aliases matched in addition to the title. */
+  keywords: readonly string[]
+  /** Icon rendered instead of the group icon. */
+  icon: LucideIcon
+}
+
+/**
+ * Registry order is the quick-entry render order: the creation action
+ * first (the most common onboarding write), then operational triggers.
+ */
+export const SEARCH_ACTION_ENTRIES: readonly SearchActionEntry[] = [
+  {
+    id: 'add-site',
+    titleKey: 'search.actions.addSite',
+    keywords: ['new site', 'create site', '新建站点', '创建站点', '站点'],
+    icon: Server,
+  },
+  {
+    id: 'run-checkin-all',
+    titleKey: 'search.actions.runCheckinAll',
+    keywords: ['checkin', 'check-in', 'check in', '签到', '打卡'],
+    icon: CalendarCheck,
+  },
+  {
+    id: 'rebuild-routes',
+    titleKey: 'search.actions.rebuildRoutes',
+    keywords: ['rebuild', '重建', '重建路由'],
+    icon: Zap,
+  },
+  {
+    id: 'refresh-route-decisions',
+    titleKey: 'search.actions.refreshRouteDecisions',
+    keywords: ['decisions', '决策', '刷新决策'],
+    icon: RefreshCw,
+  },
+]
+
+/**
+ * Local case-insensitive substring match over the translated action titles
+ * plus their bilingual keyword aliases. Starts-with matches rank before
+ * contains matches (label and keywords share the ranking); the registry
+ * order is kept within a rank. Empty query returns every entry
+ * (quick-entry mode).
+ */
+export function matchActionEntries(
+  entries: readonly SearchActionEntry[],
+  query: string,
+  resolveLabel: (titleKey: string) => string
+): SearchActionEntry[] {
+  const needle = query.trim().toLowerCase()
+  if (!needle) return [...entries]
+
+  const scored: Array<{ entry: SearchActionEntry; rank: number }> = []
+  for (const entry of entries) {
+    let rank = Number.POSITIVE_INFINITY
+    const candidates = [
+      resolveLabel(entry.titleKey).toLowerCase(),
+      ...entry.keywords,
+    ]
+    for (const candidate of candidates) {
+      if (candidate.startsWith(needle)) {
+        rank = Math.min(rank, 0)
+      } else if (candidate.includes(needle)) {
+        rank = Math.min(rank, 1)
+      }
+    }
+    if (Number.isFinite(rank)) scored.push({ entry, rank })
+  }
+  scored.sort((left, right) => left.rank - right.rank)
+  return scored.map((item) => item.entry)
+}

--- a/web/src/components/layout/search-modal.tsx
+++ b/web/src/components/layout/search-modal.tsx
@@ -1,10 +1,13 @@
 // metapi-go/layout — global search command palette (⌘K / Ctrl+K).
 //
-// A cmdk-based palette with two result layers:
+// A cmdk-based palette with three result layers:
 //   - a local navigation layer over the primary pages (root sidebar data)
 //     and the Settings workspace (5 subareas + sections from the settings
 //     registry): quick entries when the query is empty, local fuzzy
 //     matching while typing,
+//   - a local actions layer over high-frequency write operations
+//     (registry in `lib/search-actions.ts`): every action reuses an
+//     existing dialog deep link or page mutation — no new business logic,
 //   - the backend entity layer over `POST /api/search` (six categories).
 //
 // The trigger button lives in `app-header.tsx`; this component is mounted
@@ -13,13 +16,14 @@
 //   - the global ⌘K/Ctrl+K toggle (registered once, never hijacked inside
 //     editable targets),
 //   - a ~250 ms debounced search against `searchApi.search`,
-//   - grouped rendering of navigation + entity results.
+//   - grouped rendering of navigation + actions + entity results.
 //
 // cmdk's own filtering is disabled (`shouldFilter={false}`): results are
 // already filtered locally / by the backend, so empty/loading states are
 // rendered explicitly instead of relying on cmdk's Empty semantics.
 
 import { useNavigate } from '@tanstack/react-router'
+import axios from 'axios'
 import {
   Boxes,
   CalendarCheck,
@@ -30,11 +34,13 @@ import {
   Search as SearchIcon,
   Settings,
   UserRound,
+  Zap,
   type LucideIcon,
 } from 'lucide-react'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { ConfirmDialog } from '@/components/common/confirm-dialog'
 import {
   Command,
   CommandDialog,
@@ -44,6 +50,11 @@ import {
   CommandList,
 } from '@/components/ui/command'
 import { Spinner } from '@/components/ui/spinner'
+import { useManualCheckin } from '@/features/checkin'
+import {
+  useRebuildRoutes,
+  useRefreshRouteDecisions,
+} from '@/features/token-routes'
 import { useSidebarData } from '@/hooks/use-sidebar-data'
 import {
   searchApi,
@@ -55,7 +66,13 @@ import {
   type SearchResponse,
   type SearchSite,
 } from '@/lib/api/search'
+import { toast } from '@/lib/toast'
 
+import {
+  matchActionEntries,
+  SEARCH_ACTION_ENTRIES,
+  type SearchActionId,
+} from './lib/search-actions'
 import {
   getSettingsNavEntries,
   matchNavEntries,
@@ -239,6 +256,102 @@ export function SearchModal(props: SearchModalProps) {
     },
     [closeAndNavigate, trimmedQuery]
   )
+
+  // ---- Actions layer -------------------------------------------------------
+  //
+  // High-frequency write actions (registry: lib/search-actions.ts). Every
+  // action reuses an affordance the pages already expose: the add-site /
+  // add-site navigates the one-shot `?create=1` deep link the sites page
+  // consumes (same path the dashboard onboarding CTA writes), and the
+  // operational entries fire the same mutation hooks the page buttons use.
+
+  const triggerAllCheckin = useManualCheckin()
+  const rebuildRoutes = useRebuildRoutes()
+  const refreshRouteDecisions = useRefreshRouteDecisions()
+  const [rebuildConfirmOpen, setRebuildConfirmOpen] = React.useState(false)
+
+  // Mirrors the checkin page's "Run all check-ins" handler: same mutation,
+  // same honest summary toast (partial failures reported as errors, not
+  // swallowed). The palette closes first; the mutation + toast complete in
+  // the background while the user is back on the page.
+  const runCheckinAll = React.useCallback(async () => {
+    props.onOpenChange(false)
+    try {
+      const result = await triggerAllCheckin.mutateAsync()
+      const summary = result.summary
+      if (summary) {
+        const description = t('checkin.toast.summary', {
+          total: summary.total,
+          success: summary.success,
+          failed: summary.failed,
+          skipped: summary.skipped,
+        })
+        if (summary.failed > 0) {
+          toast.error(t('checkin.toast.partialFailed'), { description })
+        } else {
+          toast.success(t('checkin.toast.complete'), { description })
+        }
+      } else {
+        toast.success(result.message || t('checkin.toast.complete'))
+      }
+    } catch (error) {
+      // Transport failures (non-2xx) are already toasted by the http-client
+      // error interceptor; envelope failures thrown by the parser are not,
+      // so they get their own honest error toast.
+      if (!axios.isAxiosError(error)) {
+        toast.error(
+          error instanceof Error && error.message
+            ? error.message
+            : t('checkin.toast.triggerFailed')
+        )
+      }
+    }
+  }, [props, t, triggerAllCheckin])
+
+  const executeAction = React.useCallback(
+    (id: SearchActionId) => {
+      switch (id) {
+        case 'add-site':
+          closeAndNavigate({ to: '/sites', search: { create: true } })
+          return
+        case 'run-checkin-all':
+          void runCheckinAll()
+          return
+        case 'rebuild-routes':
+          // The routes page gates this mutation behind a ConfirmDialog; the
+          // palette keeps the same discipline with the same wording.
+          props.onOpenChange(false)
+          setRebuildConfirmOpen(true)
+          return
+        case 'refresh-route-decisions':
+          props.onOpenChange(false)
+          refreshRouteDecisions.mutate()
+          return
+      }
+    },
+    [closeAndNavigate, props, refreshRouteDecisions, runCheckinAll]
+  )
+
+  const actionGroups = React.useMemo((): SearchGroup[] => {
+    const matched = hasQuery
+      ? matchActionEntries(SEARCH_ACTION_ENTRIES, trimmedQuery, (key) => t(key))
+      : [...SEARCH_ACTION_ENTRIES]
+    if (matched.length === 0) return []
+    return [
+      {
+        key: 'actions',
+        heading: t('search.groups.actions'),
+        icon: Zap,
+        items: matched.map((entry) => ({
+          key: `action-${entry.id}`,
+          label: t(entry.titleKey),
+          description: null,
+          icon: entry.icon,
+          onSelect: () => executeAction(entry.id),
+        })),
+      },
+    ]
+  }, [hasQuery, trimmedQuery, t, executeAction])
 
   // ---- Local navigation layer --------------------------------------------
 
@@ -460,70 +573,88 @@ export function SearchModal(props: SearchModalProps) {
     navigateToQueryPage,
   ])
 
-  const groups = [...navigationGroups, ...entityGroups]
+  const groups = [...navigationGroups, ...actionGroups, ...entityGroups]
   const showEmpty = hasQuery && !isSearching && groups.length === 0
 
   return (
-    <CommandDialog
-      modal
-      open={props.open}
-      onOpenChange={props.onOpenChange}
-      title={t('search.title')}
-      description={t('search.description')}
-      className='sm:max-w-xl'
-    >
-      <Command shouldFilter={false}>
-        <CommandInput
-          autoFocus
-          value={query}
-          onValueChange={setQuery}
-          placeholder={t('search.placeholder')}
-          aria-label={t('search.title')}
-        />
-        <CommandList className='max-h-[min(60svh,28rem)]'>
-          {isSearching && (
-            <div className='text-muted-foreground flex items-center justify-center gap-2 px-2 py-4 text-sm'>
-              <Spinner />
-              <span>{t('search.searching')}</span>
-            </div>
-          )}
-          {showEmpty && (
-            <div className='flex flex-col items-center gap-1 px-4 py-10 text-center'>
-              <SearchIcon className='text-muted-foreground/60 size-5' />
-              <p className='text-sm font-medium'>
-                {t('search.noResults.title')}
-              </p>
-              <p className='text-muted-foreground text-xs'>
-                {t('search.noResults.description', { query: trimmedQuery })}
-              </p>
-            </div>
-          )}
-          {groups.map((group) => (
-            <CommandGroup key={group.key} heading={group.heading}>
-              {group.items.map((item) => {
-                const ItemIcon = item.icon ?? group.icon
-                return (
-                  <CommandItem
-                    key={item.key}
-                    value={item.key}
-                    onSelect={item.onSelect}
-                  >
-                    <ItemIcon className='text-muted-foreground size-4 shrink-0' />
-                    <span className='flex min-w-0 flex-1 flex-col'>
-                      <span className='truncate'>{item.label}</span>
-                      {item.description ? (
-                        <span className='text-muted-foreground truncate text-xs'>
-                          {item.description}
-                        </span>
-                      ) : null}
-                    </span>
-                  </CommandItem>
-                )
-              })}
-            </CommandGroup>
-          ))}
-        </CommandList>
-      </Command>
-    </CommandDialog>
+    <>
+      <CommandDialog
+        modal
+        open={props.open}
+        onOpenChange={props.onOpenChange}
+        title={t('search.title')}
+        description={t('search.description')}
+        className='sm:max-w-xl'
+      >
+        <Command shouldFilter={false}>
+          <CommandInput
+            autoFocus
+            value={query}
+            onValueChange={setQuery}
+            placeholder={t('search.placeholder')}
+            aria-label={t('search.title')}
+          />
+          <CommandList className='max-h-[min(60svh,28rem)]'>
+            {isSearching && (
+              <div className='text-muted-foreground flex items-center justify-center gap-2 px-2 py-4 text-sm'>
+                <Spinner />
+                <span>{t('search.searching')}</span>
+              </div>
+            )}
+            {showEmpty && (
+              <div className='flex flex-col items-center gap-1 px-4 py-10 text-center'>
+                <SearchIcon className='text-muted-foreground/60 size-5' />
+                <p className='text-sm font-medium'>
+                  {t('search.noResults.title')}
+                </p>
+                <p className='text-muted-foreground text-xs'>
+                  {t('search.noResults.description', { query: trimmedQuery })}
+                </p>
+              </div>
+            )}
+            {groups.map((group) => (
+              <CommandGroup key={group.key} heading={group.heading}>
+                {group.items.map((item) => {
+                  const ItemIcon = item.icon ?? group.icon
+                  return (
+                    <CommandItem
+                      key={item.key}
+                      value={item.key}
+                      onSelect={item.onSelect}
+                    >
+                      <ItemIcon className='text-muted-foreground size-4 shrink-0' />
+                      <span className='flex min-w-0 flex-1 flex-col'>
+                        <span className='truncate'>{item.label}</span>
+                        {item.description ? (
+                          <span className='text-muted-foreground truncate text-xs'>
+                            {item.description}
+                          </span>
+                        ) : null}
+                      </span>
+                    </CommandItem>
+                  )
+                })}
+              </CommandGroup>
+            ))}
+          </CommandList>
+        </Command>
+      </CommandDialog>
+      {/* Confirmation for the rebuild-routes action. Same wording as the
+          routes page's own gate; the palette is already closed at this
+          point, so the dialog takes over the screen alone. */}
+      <ConfirmDialog
+        open={rebuildConfirmOpen}
+        title={t('tokenRoutes.page.rebuildConfirmTitle')}
+        description={t('tokenRoutes.page.rebuildConfirmDescription')}
+        confirmLabel={t('tokenRoutes.page.rebuild')}
+        cancelLabel={t('common.cancel')}
+        destructive
+        onConfirm={() => {
+          setRebuildConfirmOpen(false)
+          rebuildRoutes.mutate({ refreshModels: true })
+        }}
+        onCancel={() => setRebuildConfirmOpen(false)}
+      />
+    </>
   )
 }

--- a/web/src/features/checkin/index.ts
+++ b/web/src/features/checkin/index.ts
@@ -8,7 +8,7 @@
 // --- page + components ---
 
 // --- checkin hooks + query keys ---
-export { checkinQueryKeys, fetchCheckinLogs } from './api'
+export { checkinQueryKeys, fetchCheckinLogs, useManualCheckin } from './api'
 
 // --- URL search schema + helpers ---
 export {

--- a/web/src/features/token-routes/index.ts
+++ b/web/src/features/token-routes/index.ts
@@ -5,5 +5,9 @@
 //
 // `export type` is used for all type-only re-exports (isolatedModules-safe).
 
-export { routeQueryKeys } from './api'
+export {
+  routeQueryKeys,
+  useRebuildRoutes,
+  useRefreshRouteDecisions,
+} from './api'
 export { routesSearchSchema } from './lib/routes-schema'

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -3057,9 +3057,9 @@
     },
     "search": {
       "trigger": "Search…",
-      "placeholder": "Search pages, settings, sites, accounts, logs…",
+      "placeholder": "Search pages, settings, actions, sites, accounts, logs…",
       "title": "Global search",
-      "description": "Search pages and settings, or find sites, accounts, tokens, models, check-in and proxy logs.",
+      "description": "Search pages and settings, run common actions, or find sites, accounts, tokens, models, check-in and proxy logs.",
       "searching": "Searching…",
       "unknown": "Unknown",
       "modelTokens": "{{count}} tokens",
@@ -3070,12 +3070,19 @@
       "groups": {
         "pages": "Pages",
         "settings": "Settings",
+        "actions": "Actions",
         "sites": "Sites",
         "accounts": "Accounts",
         "tokens": "Tokens",
         "checkinLogs": "Check-in logs",
         "proxyLogs": "Proxy logs",
         "models": "Models"
+      },
+      "actions": {
+        "addSite": "Add site",
+        "runCheckinAll": "Run all check-ins",
+        "rebuildRoutes": "Auto-rebuild routes",
+        "refreshRouteDecisions": "Refresh route decisions"
       }
     },
     "userMenu": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -3057,9 +3057,9 @@
     },
     "search": {
       "trigger": "搜索…",
-      "placeholder": "搜索页面、设置、站点、账号、日志…",
+      "placeholder": "搜索页面、设置、操作、站点、账号、日志…",
       "title": "全局搜索",
-      "description": "搜索页面与设置，或查找站点、账号、令牌、模型、签到与代理日志。",
+      "description": "搜索页面与设置、执行常用操作，或查找站点、账号、令牌、模型、签到与代理日志。",
       "searching": "搜索中…",
       "unknown": "未知",
       "modelTokens": "{{count}} 个令牌",
@@ -3070,12 +3070,19 @@
       "groups": {
         "pages": "页面",
         "settings": "设置",
+        "actions": "操作",
         "sites": "站点",
         "accounts": "账号",
         "tokens": "令牌",
         "checkinLogs": "签到日志",
         "proxyLogs": "代理日志",
         "models": "模型"
+      },
+      "actions": {
+        "addSite": "添加站点",
+        "runCheckinAll": "运行所有签到",
+        "rebuildRoutes": "自动重建路由",
+        "refreshRouteDecisions": "刷新路由决策"
       }
     },
     "userMenu": {


### PR DESCRIPTION
## 目标

给全局搜索命令面板（⌘K / Ctrl+K）新增第三层「动作」，让高频写操作也能通过键盘直达。导航层、实体层既有行为保持不变，动作层只复用产品中已存在的深链、mutation 与确认门禁。

## 入选动作及理由

| 动作 | 稳定 ID | 实现 | 为什么高频 |
| --- | --- | --- | --- |
| 添加站点 | `add-site` | 复用站点页既有一次性 `?create=1` 深链，跳转后自动打开创建对话框 | 新站点是产品入口级高频写操作，现有 Dashboard 引导也已走同一路径 |
| 运行所有签到 | `run-checkin-all` | 复用签到页 `useManualCheckin`，关闭面板后后台执行并复用页面同款汇总 toast | 手动签到 / 日常补签是最常用运维写操作之一 |
| 自动重建路由 | `rebuild-routes` | 复用路由页 `useRebuildRoutes`，面板先关闭并打开与路由页一致文案 / 样式的 ConfirmDialog | 新增站点 / 账号 / 渠道后常需重建路由，但不能绕过确认 |
| 刷新路由决策 | `refresh-route-decisions` | 复用路由页头部 `useRefreshRouteDecisions`，立即执行并复用页面 toast | 路由决策刷新为常用非破坏性运维动作，页面已有同款按钮 |

## 落选清单（评估过但不做）

- **添加账号**：accounts 页的一次性创建深链必须携带有效 `siteId`，单独的 `?create=1` 不会打开表单；在不改页面行为的前提下无法提供可靠面板入口。
- **新建路由**：仅存在 `edit` 深链，没有独立的 `create` 入口。
- **新建渠道**：渠道不是手动创建对象；由路由重建 / 路由渠道编辑器合成。
- **重测渠道**：web/src 中不存在该操作。
- **刷新余额**：只有行级和选中批量刷新，没有 refresh-all 语义；新增全局操作会发明功能。
- **备份导出**：Confirm Token + 导出类型 + 下载流程在设置区（#1034），不适合面板级动作。
- **清缓存 / 清数据**：属于 ConfirmDialog 门禁的运维项，保留在设置导航层更安全。
- **单账号签到**：需要账号选择器对话框，保留在签到页；全部签到已覆盖快速场景。

## 键盘流

1. `Ctrl/Cmd+K` 打开面板；空查询直接显示全部动作。
2. 输入动作关键词（中英文别名均支持，例如 `add site`、`签到`、`rebuild`）。
3. `↑/↓` 在导航 / 动作 / 实体三层结果中选择。
4. `Enter` 执行：
   - 添加站点：跳转站点页并自动打开创建对话框；
   - 运行所有签到：关闭面板并后台执行，完成后显示汇总 toast；
   - 自动重建路由：关闭面板并打开确认对话框，确认后才执行；
   - 刷新路由决策：关闭面板并立即执行，完成后显示 toast。

全程无需鼠标。

## 测试与门禁

- 动作注册表单测：稳定 ID、双语 title key、关键词匹配、排序。
- search-modal 测试：动作层渲染、双语标题、键盘 Enter 执行、确认门禁、签到部分失败 toast。
- web 全量：224 test files / 1441 tests 通过；typecheck、lint、knip、build 通过。
- pre-push 本地全门禁：frontend + `go build` + `go vet` + Go `-race` 全部通过。
