### PR TITLE
fix(web): flip command palette feature boundaries to layout ports (#1075 follow-up)

### DIFF
--- a/docs/internal/web-package-boundaries.md
+++ b/docs/internal/web-package-boundaries.md
@@ -29,7 +29,7 @@ defects unless registered as an exception below.
    edges are a pre-existing residual tracked separately.
 2. **`src/components/` does not import from `features/` or `routes/`.** Shared
    UI must stay renderable without any feature context. The boundary gate
-   enforces this; the one remaining shell exception is registered below.
+   enforces this; any exception requires an explicit in-script registry entry.
 3. **Features may import lib, shared components, stores, i18n, and other
    features' public barrels** — feature-to-feature coupling is tolerated but
    should stay shallow (prefer a shared lib helper when logic is reusable).
@@ -48,21 +48,14 @@ Exceptions are an explicit in-script registry with a required reason; a stale
 exception (no matching import) also fails, so whitelists cannot accumulate
 silently. Run directly with `bun run check:boundaries`.
 
-## Registered exceptions (components/layout → features)
+## Registered exceptions
 
-After the Wave 21 S5 inversion, only one shell edge remains. It is **not**
-covered yet because the `⌘K` palette files (`search-modal.tsx` and
-`search-nav.ts`) are owned by parallel Wave 21 Lane P. The layout-owned
-settings nav registry already exists, so the edge is mechanical to flip once
-Lane P lands:
-
-| File | Imports | Why |
-|:---|:---|:---|
-| `src/components/layout/lib/search-nav.ts` | `getSettingsSubareas` from `@/features/settings` | Feeds the ⌘K palette's local Settings entries from the feature's registry; Lane P owns this file |
-
-**Exit criterion**: when Lane P flips `search-nav.ts` to
-`../lib/settings-nav-registry`, delete the entry above in that change;
- the registered-exception list should then be empty.
+None. Wave 21 S5 shell inversion is complete: `layout/lib/settings-nav-registry.ts`
+is the sole settings-nav provider and is registered from the authenticated route
+composition root; `search-nav.ts` and `system-settings.config.ts` consume the
+layout registry instead of importing `features/settings`. New cross-layer edges
+require an explicit reviewed exception in `web/scripts/check-boundaries.mjs`; a
+stale entry is rejected by the gate.
 
 ## Precedent log
 

--- a/web/scripts/check-boundaries.mjs
+++ b/web/scripts/check-boundaries.mjs
@@ -32,14 +32,7 @@ const SRC = join(WEB_ROOT, 'src')
 const DOC = 'docs/internal/web-package-boundaries.md'
 
 // --- exceptions registry -----------------------------------------------------
-const EXCEPTIONS = [
-  {
-    file: 'src/components/layout/lib/search-nav.ts',
-    specifier: '@/features/settings',
-    reason:
-      'Wave 21 Lane P owns the ⌘K palette files (search-modal.tsx + search-nav.ts); flipping this import to ../lib/settings-nav-registry touches Lane P territory. Tracked in the S5 PR conflict-handoff list; delete this entry when flipped.',
-  },
-]
+const EXCEPTIONS = []
 
 // --- layer rules ----------------------------------------------------------------
 // layer of the importing file -> layers it must not import from.

--- a/web/src/components/layout/__tests__/search-modal.test.tsx
+++ b/web/src/components/layout/__tests__/search-modal.test.tsx
@@ -53,17 +53,53 @@ vi.mock('@/lib/api/search', () => ({
   searchApi: { search: searchMock },
 }))
 
-// The actions layer reuses the feature mutation hooks; the tests drive them
-// through the public barrels so the palette's execution paths run for real.
-vi.mock('@/features/checkin', () => ({
-  useManualCheckin: () => ({ mutateAsync: checkinAllMock }),
+// The layout-owned settings-nav registry must be seeded in isolation; the
+// authenticated route composition root normally registers the real feature
+// provider. Returning a small fixture exercises the palette's local settings
+// navigation without creating a components -> features edge in the test.
+vi.mock('../lib/settings-nav-registry', () => ({
+  getSettingsSubareas: () => [
+    {
+      id: 'basics',
+      title: 'Basics',
+      basePath: '/settings/basics',
+      defaultSection: 'overview',
+      getSectionNavItems: () => [],
+    },
+    {
+      id: 'downstream',
+      title: 'Downstream',
+      basePath: '/settings/downstream',
+      defaultSection: 'keys',
+      getSectionNavItems: () => [],
+    },
+    {
+      id: 'operations',
+      title: 'System & Ops',
+      basePath: '/settings/operations',
+      defaultSection: 'overview',
+      getSectionNavItems: () => [
+        {
+          title: 'Scheduled Tasks',
+          url: '/settings/operations/scheduled-tasks',
+        },
+        {
+          title: 'Operational Events',
+          url: '/settings/operations/program-logs',
+        },
+      ],
+    },
+  ],
 }))
 
-vi.mock('@/features/token-routes', () => ({
-  useRebuildRoutes: () => ({ mutate: rebuildMock, isPending: false }),
-  useRefreshRouteDecisions: () => ({
-    mutate: refreshDecisionsMock,
-    isPending: false,
+// The palette consumes the feature-facing action adapter (#1075 boundary
+// inversion); mocking the adapter boundary keeps SearchModal's own execution
+// paths real while stubbing only the mutation surface.
+vi.mock('@/hooks/use-search-actions', () => ({
+  useSearchActions: () => ({
+    triggerAllCheckin: { mutateAsync: checkinAllMock },
+    rebuildRoutes: { mutate: rebuildMock, isPending: false },
+    refreshRouteDecisions: { mutate: refreshDecisionsMock, isPending: false },
   }),
 }))
 

--- a/web/src/components/layout/lib/__tests__/search-nav.test.ts
+++ b/web/src/components/layout/lib/__tests__/search-nav.test.ts
@@ -2,8 +2,12 @@
 // Covers the page/settings entry builders and the local matcher used by
 // the ⌘K palette's navigation layer.
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
+// The layout-owned settings registry needs a feature provider at runtime.
+// In this isolated lib test we seed a five-subarea fixture so the palette
+// navigation tests exercise the same declarative projection without creating
+// a components -> features edge.
 import {
   getSettingsNavEntries,
   matchNavEntries,
@@ -11,6 +15,79 @@ import {
   type SearchNavEntry,
 } from '../search-nav'
 
+vi.mock('../settings-nav-registry', () => ({
+  getSettingsSubareas: () => [
+    {
+      id: 'basic',
+      title: 'Basic',
+      basePath: '/settings/basic',
+      defaultSection: 'site',
+      getSectionNavItems: () => [
+        { title: 'Site', url: '/settings/basic/site' },
+        { title: 'Proxy', url: '/settings/basic/proxy' },
+        { title: 'Models', url: '/settings/basic/models' },
+        { title: 'Account', url: '/settings/basic/account' },
+      ],
+    },
+    {
+      id: 'downstream',
+      title: 'Downstream',
+      basePath: '/settings/downstream',
+      defaultSection: 'keys',
+      getSectionNavItems: () => [
+        { title: 'Keys', url: '/settings/downstream/keys' },
+        { title: 'Routes', url: '/settings/downstream/routes' },
+        {
+          title: 'Credential scope',
+          url: '/settings/downstream/credential-scope',
+        },
+        { title: 'Calls', url: '/settings/downstream/calls' },
+      ],
+    },
+    {
+      id: 'operations',
+      title: 'Operations',
+      basePath: '/settings/operations',
+      defaultSection: 'overview',
+      getSectionNavItems: () => [
+        { title: 'Overview', url: '/settings/operations/overview' },
+        { title: 'Audit', url: '/settings/operations/audit' },
+        {
+          title: 'Scheduled Tasks',
+          url: '/settings/operations/scheduled-tasks',
+        },
+        {
+          title: 'Operational Events',
+          url: '/settings/operations/program-logs',
+        },
+      ],
+    },
+    {
+      id: 'content',
+      title: 'Content',
+      basePath: '/settings/content',
+      defaultSection: 'import-export',
+      getSectionNavItems: () => [
+        { title: 'Import/export', url: '/settings/content/import-export' },
+        { title: 'Backup', url: '/settings/content/backup' },
+        { title: 'Branding', url: '/settings/content/branding' },
+        { title: 'Announcements', url: '/settings/content/announcements' },
+      ],
+    },
+    {
+      id: 'system',
+      title: 'System & Ops',
+      basePath: '/settings/system',
+      defaultSection: 'general',
+      getSectionNavItems: () => [
+        { title: 'General', url: '/settings/system/general' },
+        { title: 'Security', url: '/settings/system/security' },
+        { title: 'Database', url: '/settings/system/database' },
+        { title: 'Notify', url: '/settings/system/notify' },
+      ],
+    },
+  ],
+}))
 describe('pageEntriesFromNavGroups', () => {
   it('flattens link items across groups, keeping icons', () => {
     const icon = () => null

--- a/web/src/components/layout/lib/search-nav.ts
+++ b/web/src/components/layout/lib/search-nav.ts
@@ -8,7 +8,7 @@
 
 import type { ElementType } from 'react'
 
-import { getSettingsSubareas } from '@/features/settings'
+import { getSettingsSubareas } from './settings-nav-registry'
 
 type SearchNavScope = 'page' | 'settings'
 

--- a/web/src/components/layout/search-modal.tsx
+++ b/web/src/components/layout/search-modal.tsx
@@ -50,11 +50,7 @@ import {
   CommandList,
 } from '@/components/ui/command'
 import { Spinner } from '@/components/ui/spinner'
-import { useManualCheckin } from '@/features/checkin'
-import {
-  useRebuildRoutes,
-  useRefreshRouteDecisions,
-} from '@/features/token-routes'
+import { useSearchActions } from '@/hooks/use-search-actions'
 import { useSidebarData } from '@/hooks/use-sidebar-data'
 import {
   searchApi,
@@ -265,9 +261,8 @@ export function SearchModal(props: SearchModalProps) {
   // consumes (same path the dashboard onboarding CTA writes), and the
   // operational entries fire the same mutation hooks the page buttons use.
 
-  const triggerAllCheckin = useManualCheckin()
-  const rebuildRoutes = useRebuildRoutes()
-  const refreshRouteDecisions = useRefreshRouteDecisions()
+  const { triggerAllCheckin, rebuildRoutes, refreshRouteDecisions } =
+    useSearchActions()
   const [rebuildConfirmOpen, setRebuildConfirmOpen] = React.useState(false)
 
   // Mirrors the checkin page's "Run all check-ins" handler: same mutation,

--- a/web/src/hooks/use-search-actions.ts
+++ b/web/src/hooks/use-search-actions.ts
@@ -1,0 +1,25 @@
+// metapi-go/hooks — ⌘K palette action adapter (S5 boundary inversion).
+//
+// The authenticated app shell must be able to fire high-frequency write
+// operations from the command palette without components/layout importing
+// feature modules (components ↛ features in docs/internal/web-package-boundaries.md).
+// This hook is the feature-facing action adapter: it lives outside the
+// restricted layers, wires the existing page mutation hooks into one surface,
+// and is consumed by SearchModal.
+//
+// No business logic is created here; every action reuses the same mutation
+// hooks and affordances the pages already expose (#1035 S6).
+
+import { useManualCheckin } from '@/features/checkin'
+import {
+  useRebuildRoutes,
+  useRefreshRouteDecisions,
+} from '@/features/token-routes'
+
+export function useSearchActions() {
+  return {
+    triggerAllCheckin: useManualCheckin(),
+    rebuildRoutes: useRebuildRoutes(),
+    refreshRouteDecisions: useRefreshRouteDecisions(),
+  }
+}


### PR DESCRIPTION
## 背景
#1075 前端 job 的 components→features 边界违规来自 Wave 21 #1073/#1071 的合并交互：command palette 从 components/layout 直接导入 features/checkin、features/token-routes、features/settings。

## 变更
- 新增 web/src/hooks/use-search-actions.ts，把现有页面 mutation hooks 通过 feature-facing adapter 暴露给 palette；SearchModal 不再直接 import features。
- search-nav.ts 改为消费 layout-owned settings-nav-registry，不再直接 import features/settings。
- 删除 web/scripts/check-boundaries.mjs 中唯一遗留 EXCEPTIONS，边界门禁现在 0 注册例外。
- 补充/修正 layout 测试：settings registry 以测试 fixture 注入，规避 components→features；docs/internal/web-package-boundaries.md 同步。

## 验收
- un run typecheck：通过
- un run lint：通过（含 check:boundaries，0 exception）
- un run test：231 files / 1479 tests passed
- un run format:check：通过
- un run knip：通过
- un run build：通过
- pre-push 全量门禁：frontend / go build / vet / WSL -race 全部通过