### PR TITLE
feat(admin): channels error summary + server-side status pagination

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -225,15 +225,21 @@ Channels for a specific route.
 
 ### GET /api/channels
 
-Full route-channel list (5-way JOIN) with a 30s snapshot cache; `?refresh=true` bypasses it.
+Full route-channel list (5-way JOIN) with a 10s snapshot cache; `?refresh=true` bypasses it.
 
-**Query params**: `page`/`pageSize` (when present the response is paginated; without them the bare full shape is returned and `pageSize` reports the real row count), `refresh`.
+**Query params**: `page`/`pageSize` (when present the response is paginated; without them the bare full shape is returned and `pageSize` reports the real row count), `refresh`, `status` (optional comma-separated subset of the four `status` values below; filtering loads the full row set to read in-memory routing/breaker state, then pages the filtered result).
 
 **Response** (200): `{ "items": [ { "id": 12, "routeId": 1, "name": "svc-1", "site": { "id": 3, "name": "anthropic" }, "type": "account", "status": "enabled", "models": "gpt-4o", "priority": 10, "weight": 20, "responseMs": 842, "cooldownUntil": null, "cooldownReasonCode": null, "cooldownReason": null, "cooldownReasonAt": null, "enabled": true, "manualOverride": false } ], "total": 1, "page": 1, "pageSize": 1 }`
 
 `type` is `account` | `token` | `oauth_unit`; `status` is `enabled` | `cooldown` | `breaker_open` | `manually_disabled`.
 
 **Cooldown reason fields**: `cooldownReasonCode` / `cooldownReason` / `cooldownReasonAt` describe why the channel entered cooldown. All three are `null` when no reason was recorded (rows cooled before the structured-reason schema existed). Codes are a stable, append-only vocabulary: `usage_limit` | `rate_limited` | `auth_error` | `upstream_error` | `client_error` | `timeout` | `network_error` | `probe_failure` | `unknown`. `cooldownReason` is a sanitized error summary truncated to 200 runes; `cooldownReasonAt` is the ISO-8601 UTC time the triggering failure was recorded.
+
+### GET /api/channels/error-summary
+
+Fleet-wide runtime status counts that cannot be derived from a SQL aggregate because circuit-breaker state lives in the routing in-memory health maps. `?refresh=true` bypasses the 10s cache; any `route_channels` mutation invalidates both this summary and the channel-list snapshot.
+
+**Response** (200): `{ "total": 16, "errorCount": 3, "byStatus": { "enabled": 10, "cooldown": 2, "breaker_open": 1, "manually_disabled": 3 } }` — `errorCount` counts only `cooldown` and `breaker_open`; `manually_disabled` is operator intent and is excluded.
 
 ### GET /api/channels/probe-history
 
@@ -1539,6 +1545,7 @@ Complete list of registered `/api` admin routes (generated from the router regis
 - `/api/announcements/active`
 - `/api/auth/session`
 - `/api/channels`
+- `/api/channels/error-summary`
 - `/api/checkin/logs`
 - `/api/debug/vars`
 - `/api/desktop/health`

--- a/handler/admin/channels.go
+++ b/handler/admin/channels.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -122,12 +123,14 @@ func (c *channelsSnapshotCache) getOrCompute(key string, compute func() ([]byte,
 }
 
 var globalChannelsCache = &channelsSnapshotCache{ttl: 10 * time.Second}
+var globalChannelsErrorSummaryCache = &channelsSnapshotCache{ttl: 10 * time.Second}
 
-// invalidateChannelsSnapshotCache clears the channels list snapshot cache.
-// Called from every route_channels mutation so a freshly edited fleet shows
-// up immediately instead of up to ttl (10s) later.
+// invalidateChannelsSnapshotCache clears the channels list snapshot cache and
+// the error-summary cache. Called from every route_channels mutation so a
+// freshly edited fleet shows up immediately instead of up to ttl (10s) later.
 func invalidateChannelsSnapshotCache() {
 	globalChannelsCache.clear()
+	globalChannelsErrorSummaryCache.clear()
 }
 
 // listChannels returns the aggregated, paginated, read-only channel list (#622).
@@ -156,23 +159,31 @@ func (h *tokenRoutesHandler) listChannels(w http.ResponseWriter, r *http.Request
 	page := clampInt(getQueryInt(r, "page", 1), 1, 1_000_000)
 	pageSize := clampInt(getQueryInt(r, "pageSize", 50), 1, 200)
 	forceRefresh := parseTruthyQuery(queryParams.Get("refresh"))
+	statusFilter, err := parseChannelStatusFilter(queryParams.Get("status"))
+	if err != nil {
+		writeErrorWithRequest(w, r, http.StatusBadRequest, err.Error())
+		return
+	}
 	var cacheKey string
 	if unbounded {
 		cacheKey = "unbounded"
+		if len(statusFilter) > 0 {
+			cacheKey += ":" + strings.Join(statusFilter, ",")
+		}
 	} else {
-		cacheKey = fmt.Sprintf("%d:%d", page, pageSize)
+		cacheKey = fmt.Sprintf("%d:%d:%s", page, pageSize, strings.Join(statusFilter, ","))
 	}
 
 	// Snapshot cache: a hit short-circuits; on a miss the single-flight group
 	// deduplicates concurrent computes for the same page so N admin sessions
 	// polling an expired entry share one 5-way JOIN run instead of running it
-	// N× (thundering herd). ?refresh=true clears the cache first so a force
+	// Nx (thundering herd). ?refresh=true clears the cache first so a force
 	// request always recomputes and repopulates.
 	if forceRefresh {
 		globalChannelsCache.clear()
 	}
 	data, cacheHit, err := globalChannelsCache.getOrCompute(cacheKey, func() ([]byte, error) {
-		return h.computeChannelsPage(r, page, pageSize, unbounded)
+		return h.computeChannelsPage(r, page, pageSize, unbounded, statusFilter)
 	})
 	if err != nil {
 		slog.Error("channels list failed", "error", err)
@@ -190,42 +201,99 @@ func (h *tokenRoutesHandler) listChannels(w http.ResponseWriter, r *http.Request
 	_, _ = w.Write(data)
 }
 
+const channelListBaseQuery = `
+	SELECT rc.id, rc.route_id, rc.account_id, rc.token_id, rc.oauth_route_unit_id,
+	       rc.source_model, rc.priority, rc.weight, rc.enabled, rc.manual_override,
+	       rc.success_count, rc.total_latency_ms, rc.cooldown_until,
+	       rc.cooldown_reason_code, rc.cooldown_reason, rc.cooldown_reason_at,
+	       COALESCE(a.username, '') AS username,
+	       a.site_id,
+	       COALESCE(s.name, '') AS site_name,
+	       COALESCE(tr.model_pattern, '') AS route_model_pattern,
+	       COALESCE(oru.name, '') AS oauth_unit_name,
+	       COALESCE(at.name, '') AS token_name,
+	       COUNT(*) OVER () AS total_count
+	FROM route_channels rc
+	LEFT JOIN accounts a ON rc.account_id = a.id
+	LEFT JOIN sites s ON a.site_id = s.id
+	LEFT JOIN token_routes tr ON rc.route_id = tr.id
+	LEFT JOIN oauth_route_units oru ON rc.oauth_route_unit_id = oru.id
+	LEFT JOIN account_tokens at ON rc.token_id = at.id
+	ORDER BY rc.id ASC`
+
+func (h *tokenRoutesHandler) loadAllChannelRows(r *http.Request) ([]channelListRow, error) {
+	var rows []channelListRow
+	err := h.db.SelectContext(r.Context(), &rows, h.db.Rebind(channelListBaseQuery))
+	return rows, err
+}
+
 // computeChannelsPage runs the 5-way JOIN channel list query (the cache-miss
 // path). Extracted from listChannels so the single-flight group can
 // deduplicate concurrent misses. Uses the caller's request context so a client
 // disconnect cancels the in-flight query; under single-flight the leader's
 // context is shared (followers arrive while the leader is already running, so
 // their own context is not on the critical path). When unbounded is true no
-// LIMIT/OFFSET is applied and total is the loaded row count. Returns the
-// marshaled JSON bytes; the caller (getOrCompute) stores them in the cache.
-func (h *tokenRoutesHandler) computeChannelsPage(r *http.Request, page, pageSize int, unbounded bool) ([]byte, error) {
-	baseQuery := `
-		SELECT rc.id, rc.route_id, rc.account_id, rc.token_id, rc.oauth_route_unit_id,
-		       rc.source_model, rc.priority, rc.weight, rc.enabled, rc.manual_override,
-		       rc.success_count, rc.total_latency_ms, rc.cooldown_until,
-		       rc.cooldown_reason_code, rc.cooldown_reason, rc.cooldown_reason_at,
-		       COALESCE(a.username, '') AS username,
-		       a.site_id,
-		       COALESCE(s.name, '') AS site_name,
-		       COALESCE(tr.model_pattern, '') AS route_model_pattern,
-		       COALESCE(oru.name, '') AS oauth_unit_name,
-		       COALESCE(at.name, '') AS token_name,
-		       COUNT(*) OVER () AS total_count
-		FROM route_channels rc
-		LEFT JOIN accounts a ON rc.account_id = a.id
-		LEFT JOIN sites s ON a.site_id = s.id
-		LEFT JOIN token_routes tr ON rc.route_id = tr.id
-		LEFT JOIN oauth_route_units oru ON rc.oauth_route_unit_id = oru.id
-		LEFT JOIN account_tokens at ON rc.token_id = at.id
-		ORDER BY rc.id ASC`
+// LIMIT/OFFSET is applied and total is the loaded row count. When a status
+// filter is present, runtime status must be derived from in-memory routing
+// health, so the complete row set is loaded first and pagination happens in
+// memory after the filter. Returns the marshaled JSON bytes; the caller
+// (getOrCompute) stores them in the cache.
+func (h *tokenRoutesHandler) computeChannelsPage(r *http.Request, page, pageSize int, unbounded bool, statusFilter []string) ([]byte, error) {
+	if len(statusFilter) > 0 {
+		allRows, err := h.loadAllChannelRows(r)
+		if err != nil {
+			return nil, err
+		}
+		var enabledChannels int64
+		filtered := make([]channelListRow, 0, len(allRows))
+		for _, row := range allRows {
+			if row.Enabled {
+				enabledChannels++
+			}
+			if channelStatusMatches(row, statusFilter) {
+				filtered = append(filtered, row)
+			}
+		}
+		shared.SetActiveChannels(enabledChannels)
+
+		total := int64(len(filtered))
+		start := (page - 1) * pageSize
+		if start < 0 {
+			start = 0
+		}
+		if start > len(filtered) {
+			start = len(filtered)
+		}
+		end := start + pageSize
+		if end > len(filtered) {
+			end = len(filtered)
+		}
+		items := make([]map[string]any, 0, end-start)
+		for _, row := range filtered[start:end] {
+			items = append(items, channelListItem(row))
+		}
+		respPageSize := pageSize
+		if unbounded {
+			// A single full filtered page: report the real row count instead
+			// of the paginated default so the envelope never lies about
+			// truncation.
+			respPageSize = int(total)
+		}
+		return json.Marshal(map[string]any{
+			"items":    normalizeSlice(items),
+			"total":    total,
+			"page":     page,
+			"pageSize": respPageSize,
+		})
+	}
 
 	var rows []channelListRow
 	var err error
 	if unbounded {
-		err = h.db.SelectContext(r.Context(), &rows, h.db.Rebind(baseQuery))
+		rows, err = h.loadAllChannelRows(r)
 	} else {
 		offset := (page - 1) * pageSize
-		err = h.db.SelectContext(r.Context(), &rows, h.db.Rebind(baseQuery+`
+		err = h.db.SelectContext(r.Context(), &rows, h.db.Rebind(channelListBaseQuery+`
 		LIMIT ? OFFSET ?`), pageSize, offset)
 	}
 	if err != nil {
@@ -271,6 +339,55 @@ func (h *tokenRoutesHandler) computeChannelsPage(r *http.Request, page, pageSize
 		"pageSize": respPageSize,
 	}
 	return json.Marshal(resp)
+}
+
+var validChannelStatuses = map[string]struct{}{
+	routing.ChannelStatusEnabled:          {},
+	routing.ChannelStatusCooldown:         {},
+	routing.ChannelStatusBreakerOpen:      {},
+	routing.ChannelStatusManuallyDisabled: {},
+}
+
+func parseChannelStatusFilter(raw string) ([]string, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	parts := strings.Split(raw, ",")
+	seen := make(map[string]struct{}, len(parts))
+	statuses := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("invalid channel status filter")
+		}
+		if _, ok := validChannelStatuses[part]; !ok {
+			return nil, fmt.Errorf("invalid channel status filter: %q", part)
+		}
+		if _, ok := seen[part]; ok {
+			continue
+		}
+		seen[part] = struct{}{}
+		statuses = append(statuses, part)
+	}
+	return statuses, nil
+}
+
+func channelStatusForRow(row channelListRow) string {
+	sourceModel := ""
+	if row.SourceModel != nil {
+		sourceModel = *row.SourceModel
+	}
+	return routing.ChannelRuntimeStatus(row.SiteID, sourceModel, row.Enabled, row.CooldownUntil)
+}
+
+func channelStatusMatches(row channelListRow, statusFilter []string) bool {
+	status := channelStatusForRow(row)
+	for _, wanted := range statusFilter {
+		if status == wanted {
+			return true
+		}
+	}
+	return false
 }
 
 func channelListItem(row channelListRow) map[string]any {
@@ -326,4 +443,79 @@ func channelListItem(row channelListRow) map[string]any {
 		"enabled":            row.Enabled,
 		"manualOverride":     row.ManualOverride,
 	}
+}
+
+type channelSummaryRow struct {
+	SiteID            int64   `db:"site_id"`
+	SourceModel       *string `db:"source_model"`
+	RouteModelPattern string  `db:"route_model_pattern"`
+	Enabled           bool    `db:"enabled"`
+	CooldownUntil     *string `db:"cooldown_until"`
+}
+
+// channelErrorSummary handles GET /api/channels/error-summary. The summary is
+// read-only and deliberately separate from the list page: it computes the
+// fleet-wide runtime status counts that cannot be derived from a SQL aggregate
+// because breaker state lives in the routing in-memory health maps.
+func (h *tokenRoutesHandler) channelErrorSummary(w http.ResponseWriter, r *http.Request) {
+	if parseTruthyQuery(r.URL.Query().Get("refresh")) {
+		globalChannelsErrorSummaryCache.clear()
+	}
+	data, cacheHit, err := globalChannelsErrorSummaryCache.getOrCompute("summary", func() ([]byte, error) {
+		return h.computeChannelErrorSummary(r)
+	})
+	if err != nil {
+		slog.Error("channels error summary failed", "error", err)
+		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load channel error summary")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if cacheHit {
+		w.Header().Set("x-channels-error-summary-cache", "hit")
+	} else {
+		w.Header().Set("x-channels-error-summary-cache", "miss")
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func (h *tokenRoutesHandler) computeChannelErrorSummary(r *http.Request) ([]byte, error) {
+	var rows []channelSummaryRow
+	err := h.db.SelectContext(r.Context(), &rows, h.db.Rebind(`
+		SELECT a.site_id, rc.source_model,
+		       COALESCE(tr.model_pattern, '') AS route_model_pattern,
+		       rc.enabled, rc.cooldown_until
+		FROM route_channels rc
+		LEFT JOIN accounts a ON rc.account_id = a.id
+		LEFT JOIN token_routes tr ON rc.route_id = tr.id`))
+	if err != nil {
+		return nil, err
+	}
+
+	byStatus := map[string]int64{
+		routing.ChannelStatusEnabled:          0,
+		routing.ChannelStatusCooldown:         0,
+		routing.ChannelStatusBreakerOpen:      0,
+		routing.ChannelStatusManuallyDisabled: 0,
+	}
+	var total int64
+	var errorCount int64
+	for _, row := range rows {
+		modelName := ""
+		if row.SourceModel != nil {
+			modelName = *row.SourceModel
+		}
+		status := routing.ChannelRuntimeStatus(row.SiteID, modelName, row.Enabled, row.CooldownUntil)
+		total++
+		byStatus[status]++
+		if status == routing.ChannelStatusCooldown || status == routing.ChannelStatusBreakerOpen {
+			errorCount++
+		}
+	}
+	return json.Marshal(map[string]any{
+		"total":      total,
+		"errorCount": errorCount,
+		"byStatus":   byStatus,
+	})
 }

--- a/handler/admin/channels_error_summary_test.go
+++ b/handler/admin/channels_error_summary_test.go
@@ -1,0 +1,94 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestChannelsErrorSummaryAndStatusFilter(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	globalChannelsCache.clear()
+	globalChannelsErrorSummaryCache.clear()
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+	ids := seedBatchUpdateChannels(t, db, routeID, accountID, tokenID, 3)
+
+	future := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	if _, err := db.Exec(`UPDATE route_channels SET enabled = false, manual_override = true WHERE id = ?`, ids[0]); err != nil {
+		t.Fatalf("disable fixture: %v", err)
+	}
+	if _, err := db.Exec(`UPDATE route_channels SET cooldown_until = ? WHERE id = ?`, future, ids[1]); err != nil {
+		t.Fatalf("cooldown fixture: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/channels/error-summary")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("error summary status = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+	var summary map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &summary); err != nil {
+		t.Fatalf("decode error summary: %v", err)
+	}
+	if summary["total"] != float64(3) {
+		t.Fatalf("summary total = %v, want 3", summary["total"])
+	}
+	if summary["errorCount"] != float64(1) {
+		t.Fatalf("summary errorCount = %v, want 1", summary["errorCount"])
+	}
+	byStatus, ok := summary["byStatus"].(map[string]any)
+	if !ok {
+		t.Fatalf("summary byStatus missing: %#v", summary["byStatus"])
+	}
+	if byStatus["cooldown"] != float64(1) || byStatus["manually_disabled"] != float64(1) || byStatus["enabled"] != float64(1) {
+		t.Fatalf("summary byStatus = %#v, want cooldown=1/manually_disabled=1/enabled=1", byStatus)
+	}
+	if byStatus["breaker_open"] != float64(0) {
+		t.Fatalf("summary breaker_open = %v, want 0", byStatus["breaker_open"])
+	}
+
+	filtered := decodePagedEnvelope(t, doGet(t, r, "/api/channels?page=1&pageSize=10&status=cooldown,breaker_open"))
+	if filtered.Total != 1 || len(filtered.Items) != 1 {
+		t.Fatalf("status filter envelope = total %d items %d, want 1/1", filtered.Total, len(filtered.Items))
+	}
+	if filtered.Items[0]["status"] != "cooldown" {
+		t.Fatalf("status filter item status = %v, want cooldown", filtered.Items[0]["status"])
+	}
+
+	bad := doGet(t, r, "/api/channels?page=1&status=not-a-status")
+	if bad.Code != http.StatusBadRequest {
+		t.Fatalf("invalid status filter code = %d, want 400; body=%s", bad.Code, bad.Body.String())
+	}
+}
+
+func TestChannelsErrorSummaryAndStatusFilterPostgres(t *testing.T) {
+	db, r := setupTokenRoutesPostgresTest(t)
+	globalChannelsCache.clear()
+	globalChannelsErrorSummaryCache.clear()
+	routeID, accountID, tokenID := seedRouteChannelRefs(t, db)
+	ids := seedBatchUpdateChannels(t, db, routeID, accountID, tokenID, 3)
+
+	future := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	if _, err := db.Exec(db.Rebind(`UPDATE route_channels SET enabled = false, manual_override = true WHERE id = ?`), ids[0]); err != nil {
+		t.Fatalf("disable fixture: %v", err)
+	}
+	if _, err := db.Exec(db.Rebind(`UPDATE route_channels SET cooldown_until = ? WHERE id = ?`), future, ids[1]); err != nil {
+		t.Fatalf("cooldown fixture: %v", err)
+	}
+
+	resp := doGet(t, r, "/api/channels/error-summary")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("pg error summary status = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+	var summary map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &summary); err != nil {
+		t.Fatalf("decode pg error summary: %v", err)
+	}
+	if summary["total"] != float64(3) || summary["errorCount"] != float64(1) {
+		t.Fatalf("pg summary total/error = %v/%v, want 3/1", summary["total"], summary["errorCount"])
+	}
+	filtered := decodePagedEnvelope(t, doGet(t, r, "/api/channels?page=1&pageSize=10&status=cooldown,breaker_open"))
+	if filtered.Total != 1 || len(filtered.Items) != 1 {
+		t.Fatalf("pg status filter envelope = total %d items %d, want 1/1", filtered.Total, len(filtered.Items))
+	}
+}

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -70,6 +70,7 @@ func RegisterTokenRoutesWithDeps(r chi.Router, db *sqlx.DB, deps TokenRoutesDeps
 
 	// Channel operations
 	r.Get("/api/channels", handler.listChannels)
+	r.Get("/api/channels/error-summary", handler.channelErrorSummary)
 	r.Get("/api/channels/probe-history", handler.channelProbeHistory)
 	r.Put("/api/channels/batch", handler.batchUpdateChannels)
 	r.Put("/api/channels/{channelId}", handler.updateChannel)

--- a/web/src/features/channels/__tests__/channels-envelope.test.ts
+++ b/web/src/features/channels/__tests__/channels-envelope.test.ts
@@ -7,7 +7,11 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { parseChannelsEnvelope } from '../api'
+import {
+  parseChannelsEnvelope,
+  parseChannelsErrorSummary,
+  parseChannelsPageEnvelope,
+} from '../api'
 
 const sampleItem = { id: 1, name: 'channel-1' }
 
@@ -50,5 +54,60 @@ describe('parseChannelsEnvelope', () => {
       'Invalid channels response'
     )
     expect(() => parseChannelsEnvelope(42)).toThrow('Invalid channels response')
+  })
+})
+
+describe('parseChannelsPageEnvelope', () => {
+  const sampleItem = { id: 11, name: 'channel-11' }
+
+  it('extracts a page and its authoritative total', () => {
+    expect(
+      parseChannelsPageEnvelope({ items: [sampleItem], total: 42 })
+    ).toEqual({ items: [sampleItem], total: 42 })
+  })
+
+  it('falls back to the page item count when total is absent', () => {
+    expect(parseChannelsPageEnvelope({ items: [sampleItem] })).toEqual({
+      items: [sampleItem],
+      total: 1,
+    })
+  })
+
+  it('rejects malformed page envelopes', () => {
+    expect(() => parseChannelsPageEnvelope(null)).toThrow(
+      'Invalid channels page response'
+    )
+    expect(() => parseChannelsPageEnvelope({ items: 'nope' })).toThrow(
+      'Invalid channels page response'
+    )
+    expect(() =>
+      parseChannelsPageEnvelope({ items: [], total: 'nope' })
+    ).toThrow('Invalid channels page response')
+  })
+})
+
+describe('parseChannelsErrorSummary', () => {
+  it('parses the fleet-wide error summary contract', () => {
+    const byStatus = {
+      enabled: 10,
+      cooldown: 2,
+      breaker_open: 1,
+      manually_disabled: 3,
+    }
+    expect(
+      parseChannelsErrorSummary({ total: 16, errorCount: 3, byStatus })
+    ).toEqual({ total: 16, errorCount: 3, byStatus })
+  })
+
+  it('rejects malformed error summaries', () => {
+    expect(() => parseChannelsErrorSummary(null)).toThrow(
+      'Invalid channels error summary response'
+    )
+    expect(() =>
+      parseChannelsErrorSummary({ total: 1, errorCount: 0 })
+    ).toThrow('Invalid channels error summary response')
+    expect(() =>
+      parseChannelsErrorSummary({ total: '1', errorCount: 0, byStatus: {} })
+    ).toThrow('Invalid channels error summary response')
   })
 })

--- a/web/src/features/channels/__tests__/channels-page-api.test.ts
+++ b/web/src/features/channels/__tests__/channels-page-api.test.ts
@@ -1,0 +1,93 @@
+// API adapter contract for server-side channels pagination and the
+// independent fleet-wide error summary. These tests pin the exact request
+// parameters (page is one-based at the transport boundary) and response
+// parsing so the page can switch from the legacy whole-list transfer to a
+// bounded server page without silently breaking the backend contract.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchChannelsPage, getChannelsErrorSummary } from '../api'
+
+const apiState = vi.hoisted(() => ({
+  getChannels: vi.fn(),
+  getChannelsErrorSummary: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: apiState,
+}))
+
+beforeEach(() => {
+  apiState.getChannels.mockReset()
+  apiState.getChannelsErrorSummary.mockReset()
+})
+
+describe('fetchChannelsPage', () => {
+  it('maps a zero-based table page to a one-based transport page', async () => {
+    apiState.getChannels.mockResolvedValue({
+      items: [{ id: 21, name: 'channel-21' }],
+      total: 21,
+    })
+
+    const result = await fetchChannelsPage({
+      pageIndex: 1,
+      pageSize: 50,
+      status: 'cooldown',
+    })
+
+    expect(apiState.getChannels).toHaveBeenCalledWith({
+      page: 2,
+      pageSize: 50,
+      status: 'cooldown',
+    })
+    expect(result).toEqual({
+      items: [{ id: 21, name: 'channel-21' }],
+      total: 21,
+    })
+  })
+
+  it('omits the status parameter when no status is scoped', async () => {
+    apiState.getChannels.mockResolvedValue({ items: [], total: 0 })
+
+    await fetchChannelsPage({ pageIndex: 0, pageSize: 20 })
+
+    expect(apiState.getChannels).toHaveBeenCalledWith({
+      page: 1,
+      pageSize: 20,
+    })
+  })
+
+  it('fails explicitly on a malformed page envelope', async () => {
+    apiState.getChannels.mockResolvedValue({ items: 'not-an-array' })
+
+    await expect(
+      fetchChannelsPage({ pageIndex: 0, pageSize: 20 })
+    ).rejects.toThrow('Invalid channels page response')
+  })
+})
+
+describe('getChannelsErrorSummary', () => {
+  it('passes through the backend count and status breakdown', async () => {
+    const payload = {
+      total: 12,
+      errorCount: 4,
+      byStatus: {
+        enabled: 8,
+        cooldown: 3,
+        breaker_open: 1,
+        manually_disabled: 0,
+      },
+    }
+    apiState.getChannelsErrorSummary.mockResolvedValue(payload)
+
+    await expect(getChannelsErrorSummary()).resolves.toEqual(payload)
+  })
+
+  it('fails explicitly on a malformed summary', async () => {
+    apiState.getChannelsErrorSummary.mockResolvedValue({ total: 12 })
+
+    await expect(getChannelsErrorSummary()).rejects.toThrow(
+      'Invalid channels error summary response'
+    )
+  })
+})

--- a/web/src/features/channels/__tests__/channels-page-drilldown.test.tsx
+++ b/web/src/features/channels/__tests__/channels-page-drilldown.test.tsx
@@ -20,6 +20,10 @@ const testState = vi.hoisted(() => ({
     channel: ChannelRow | null
     open: boolean
   } | null,
+  isLoading: false as boolean,
+  isFetching: false as boolean,
+  error: null as Error | null,
+  refetch: vi.fn(),
 }))
 
 vi.mock('@/components/common/use-probe-history', () => ({
@@ -38,6 +42,7 @@ vi.mock('@/components/data-table', () => ({
     onGlobalFilterChange: vi.fn(),
     columnFilters: [],
     onColumnFiltersChange: vi.fn(),
+    filters: { status: '' },
     pagination: { pageIndex: 0, pageSize: 20 },
     onPaginationChange: vi.fn(),
     sorting: [],
@@ -50,9 +55,39 @@ vi.mock('@/components/data-table', () => ({
 vi.mock('../api', () => ({
   useChannels: () => ({
     data: testState.channels,
+    isLoading: testState.isLoading,
+    isFetching: testState.isFetching,
+    error: testState.error,
+    refetch: testState.refetch,
+  }),
+  useChannelsPage: () => ({
+    data: {
+      items: testState.channels,
+      total: testState.channels.length,
+    },
+    isLoading: testState.isLoading,
+    isFetching: testState.isFetching,
+    error: testState.error,
+    refetch: testState.refetch,
+  }),
+  useChannelsErrorSummary: () => ({
+    data: {
+      total: testState.channels.length,
+      errorCount: testState.channels.filter(
+        (channel) =>
+          channel.status === 'cooldown' || channel.status === 'breaker_open'
+      ).length,
+      byStatus: {
+        enabled: 0,
+        cooldown: 0,
+        breaker_open: 0,
+        manually_disabled: 0,
+      },
+    },
     isLoading: false,
     isFetching: false,
     error: null,
+    refetch: vi.fn(),
   }),
 }))
 

--- a/web/src/features/channels/__tests__/channels-page-empty.test.tsx
+++ b/web/src/features/channels/__tests__/channels-page-empty.test.tsx
@@ -24,6 +24,10 @@ import type { ChannelRow } from '../types'
 const testState = vi.hoisted(() => ({
   channels: [] as ChannelRow[],
   navigate: vi.fn(),
+  isLoading: false as boolean,
+  isFetching: false as boolean,
+  error: null as Error | null,
+  refetch: vi.fn(),
 }))
 
 vi.mock('@/components/common/use-probe-history', () => ({
@@ -46,6 +50,7 @@ vi.mock('@/components/data-table', async (importOriginal) => {
       onGlobalFilterChange: vi.fn(),
       columnFilters: [],
       onColumnFiltersChange: vi.fn(),
+      filters: { status: '' },
       pagination: { pageIndex: 0, pageSize: 20 },
       onPaginationChange: vi.fn(),
       sorting: [],
@@ -58,9 +63,39 @@ vi.mock('@/components/data-table', async (importOriginal) => {
 vi.mock('../api', () => ({
   useChannels: () => ({
     data: testState.channels,
+    isLoading: testState.isLoading,
+    isFetching: testState.isFetching,
+    error: testState.error,
+    refetch: testState.refetch,
+  }),
+  useChannelsPage: () => ({
+    data: {
+      items: testState.channels,
+      total: testState.channels.length,
+    },
+    isLoading: testState.isLoading,
+    isFetching: testState.isFetching,
+    error: testState.error,
+    refetch: testState.refetch,
+  }),
+  useChannelsErrorSummary: () => ({
+    data: {
+      total: testState.channels.length,
+      errorCount: testState.channels.filter(
+        (channel) =>
+          channel.status === 'cooldown' || channel.status === 'breaker_open'
+      ).length,
+      byStatus: {
+        enabled: 0,
+        cooldown: 0,
+        breaker_open: 0,
+        manually_disabled: 0,
+      },
+    },
     isLoading: false,
     isFetching: false,
     error: null,
+    refetch: vi.fn(),
   }),
 }))
 

--- a/web/src/features/channels/__tests__/channels-page-error-banner.test.tsx
+++ b/web/src/features/channels/__tests__/channels-page-error-banner.test.tsx
@@ -24,6 +24,10 @@ const testState = vi.hoisted(() => ({
   channels: [] as ChannelRow[],
   navigate: vi.fn(),
   search: {} as Record<string, unknown>,
+  isLoading: false as boolean,
+  isFetching: false as boolean,
+  error: null as Error | null,
+  refetch: vi.fn(),
 }))
 
 vi.mock('@/components/common/use-probe-history', () => ({
@@ -46,6 +50,7 @@ vi.mock('@/components/data-table', async (importOriginal) => {
       onGlobalFilterChange: vi.fn(),
       columnFilters: [],
       onColumnFiltersChange: vi.fn(),
+      filters: { status: '' },
       pagination: { pageIndex: 0, pageSize: 20 },
       onPaginationChange: vi.fn(),
       sorting: [],
@@ -58,9 +63,39 @@ vi.mock('@/components/data-table', async (importOriginal) => {
 vi.mock('../api', () => ({
   useChannels: () => ({
     data: testState.channels,
+    isLoading: testState.isLoading,
+    isFetching: testState.isFetching,
+    error: testState.error,
+    refetch: testState.refetch,
+  }),
+  useChannelsPage: () => ({
+    data: {
+      items: testState.channels,
+      total: testState.channels.length,
+    },
+    isLoading: testState.isLoading,
+    isFetching: testState.isFetching,
+    error: testState.error,
+    refetch: testState.refetch,
+  }),
+  useChannelsErrorSummary: () => ({
+    data: {
+      total: testState.channels.length,
+      errorCount: testState.channels.filter(
+        (channel) =>
+          channel.status === 'cooldown' || channel.status === 'breaker_open'
+      ).length,
+      byStatus: {
+        enabled: 0,
+        cooldown: 0,
+        breaker_open: 0,
+        manually_disabled: 0,
+      },
+    },
     isLoading: false,
     isFetching: false,
     error: null,
+    refetch: vi.fn(),
   }),
 }))
 

--- a/web/src/features/channels/__tests__/channels-page-error-retry.test.tsx
+++ b/web/src/features/channels/__tests__/channels-page-error-retry.test.tsx
@@ -37,6 +37,7 @@ vi.mock('@/components/data-table', () => ({
     onGlobalFilterChange: vi.fn(),
     columnFilters: [],
     onColumnFiltersChange: vi.fn(),
+    filters: { status: '' },
     pagination: { pageIndex: 0, pageSize: 20 },
     onPaginationChange: vi.fn(),
     sorting: [],
@@ -53,6 +54,35 @@ vi.mock('../api', () => ({
     isFetching: testState.isFetching,
     error: testState.error,
     refetch: testState.refetch,
+  }),
+  useChannelsPage: () => ({
+    data: {
+      items: testState.channels,
+      total: testState.channels.length,
+    },
+    isLoading: testState.isLoading,
+    isFetching: testState.isFetching,
+    error: testState.error,
+    refetch: testState.refetch,
+  }),
+  useChannelsErrorSummary: () => ({
+    data: {
+      total: testState.channels.length,
+      errorCount: testState.channels.filter(
+        (channel) =>
+          channel.status === 'cooldown' || channel.status === 'breaker_open'
+      ).length,
+      byStatus: {
+        enabled: 0,
+        cooldown: 0,
+        breaker_open: 0,
+        manually_disabled: 0,
+      },
+    },
+    isLoading: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn(),
   }),
 }))
 

--- a/web/src/features/channels/__tests__/channels-status-facet.test.tsx
+++ b/web/src/features/channels/__tests__/channels-status-facet.test.tsx
@@ -28,6 +28,10 @@ const testState = vi.hoisted(() => ({
   columnFilters: [] as ColumnFiltersState,
   onColumnFiltersChange: vi.fn(),
   navigate: vi.fn(),
+  isLoading: false as boolean,
+  isFetching: false as boolean,
+  error: null as Error | null,
+  refetch: vi.fn(),
 }))
 
 vi.mock('@/components/common/use-probe-history', () => ({
@@ -52,6 +56,7 @@ vi.mock('@/components/data-table', async (importOriginal) => {
       onGlobalFilterChange: vi.fn(),
       columnFilters: testState.columnFilters,
       onColumnFiltersChange: testState.onColumnFiltersChange,
+      filters: { status: '' },
       pagination: { pageIndex: 0, pageSize: 20 },
       onPaginationChange: vi.fn(),
       sorting: [],
@@ -64,9 +69,39 @@ vi.mock('@/components/data-table', async (importOriginal) => {
 vi.mock('../api', () => ({
   useChannels: () => ({
     data: testState.channels,
+    isLoading: testState.isLoading,
+    isFetching: testState.isFetching,
+    error: testState.error,
+    refetch: testState.refetch,
+  }),
+  useChannelsPage: () => ({
+    data: {
+      items: testState.channels,
+      total: testState.channels.length,
+    },
+    isLoading: testState.isLoading,
+    isFetching: testState.isFetching,
+    error: testState.error,
+    refetch: testState.refetch,
+  }),
+  useChannelsErrorSummary: () => ({
+    data: {
+      total: testState.channels.length,
+      errorCount: testState.channels.filter(
+        (channel) =>
+          channel.status === 'cooldown' || channel.status === 'breaker_open'
+      ).length,
+      byStatus: {
+        enabled: 0,
+        cooldown: 0,
+        breaker_open: 0,
+        manually_disabled: 0,
+      },
+    },
     isLoading: false,
     isFetching: false,
     error: null,
+    refetch: vi.fn(),
   }),
 }))
 

--- a/web/src/features/channels/api.ts
+++ b/web/src/features/channels/api.ts
@@ -1,19 +1,23 @@
-// metapi-go/features/channels — TanStack Query hook wrapping `lib/api.ts`.
-// GET /api/channels returns a paginated envelope
-// `{items: ChannelRow[], total, page, pageSize}` (see handler/admin/channels.go),
-// so `useChannels` parses the envelope and surfaces only the `items` array as
-// the read-only list. The table still filters/sorts/pages client-side.
+// metapi-go/features/channels — TanStack Query hooks wrapping `lib/api.ts`.
+// The channels page is server-paginated (`GET /api/channels?page=&pageSize=`)
+// and the error banner uses the independent fleet-wide error-summary endpoint
+// so the count remains truthful even when only one page is loaded.
 
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 
 import { api } from '@/lib/api'
 
-import { channelsKeys, type ChannelRow } from './types'
+import {
+  channelsKeys,
+  type ChannelRow,
+  type ChannelsErrorSummary,
+  type ChannelsPageData,
+} from './types'
 
 /**
- * Parse the GET /api/channels envelope. Returns the `items` array when the
- * body is a well-formed `{items: [...]}` object; throws otherwise so a
- * malformed body fails the query explicitly instead of masquerading as an
+ * Parse the legacy/full GET /api/channels envelope. Returns the `items` array
+ * when the body is a well-formed `{items: [...]}` object; throws otherwise so
+ * a malformed body fails the query explicitly instead of masquerading as an
  * empty list.
  */
 export function parseChannelsEnvelope(result: unknown): ChannelRow[] {
@@ -24,8 +28,59 @@ export function parseChannelsEnvelope(result: unknown): ChannelRow[] {
   throw new Error('Invalid channels response')
 }
 
-/** Shared queryFn for the channels list (route loader + useChannels). */
-export async function getChannelsList(): Promise<ChannelRow[]> {
+/** Parse one server-side channels page envelope. */
+export function parseChannelsPageEnvelope(result: unknown): ChannelsPageData {
+  if (!result || typeof result !== 'object') {
+    throw new Error('Invalid channels page response')
+  }
+  const envelope = result as { items?: unknown; total?: unknown }
+  if (!Array.isArray(envelope.items)) {
+    throw new Error('Invalid channels page response')
+  }
+  let total: number
+  if (envelope.total === undefined) {
+    // Backward-compatible fallback for older payloads that omit the count.
+    total = envelope.items.length
+  } else if (
+    typeof envelope.total === 'number' &&
+    Number.isFinite(envelope.total)
+  ) {
+    total = envelope.total
+  } else {
+    throw new Error('Invalid channels page response')
+  }
+  return { items: envelope.items as ChannelRow[], total }
+}
+
+/** Parse the fleet-wide error summary response. */
+export function parseChannelsErrorSummary(
+  result: unknown
+): ChannelsErrorSummary {
+  if (!result || typeof result !== 'object') {
+    throw new Error('Invalid channels error summary response')
+  }
+  const envelope = result as {
+    total?: unknown
+    errorCount?: unknown
+    byStatus?: unknown
+  }
+  if (
+    typeof envelope.total !== 'number' ||
+    typeof envelope.errorCount !== 'number' ||
+    !envelope.byStatus ||
+    typeof envelope.byStatus !== 'object'
+  ) {
+    throw new Error('Invalid channels error summary response')
+  }
+  return {
+    total: envelope.total,
+    errorCount: envelope.errorCount,
+    byStatus: envelope.byStatus as ChannelsErrorSummary['byStatus'],
+  }
+}
+
+/** Shared queryFn for the legacy full channels list (one-shot drilldown). */
+async function getChannelsList(): Promise<ChannelRow[]> {
   const result = await api.getChannels()
   return parseChannelsEnvelope(result)
 }
@@ -41,5 +96,52 @@ export function useChannels(
     queryFn: getChannelsList,
     staleTime: 10 * 1000,
     ...queryOptions,
+  })
+}
+
+/** Fetch one server-side channels page by URL-owned table state. */
+export async function fetchChannelsPage(params: {
+  pageIndex: number
+  pageSize: number
+  status?: string
+}): Promise<ChannelsPageData> {
+  const result = await api.getChannels({
+    page: params.pageIndex + 1,
+    pageSize: params.pageSize,
+    status: params.status || undefined,
+  })
+  return parseChannelsPageEnvelope(result)
+}
+
+export function useChannelsPage(
+  params: { pageIndex: number; pageSize: number; status?: string },
+  options?: Omit<UseQueryOptions<ChannelsPageData>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery<ChannelsPageData>({
+    queryKey: channelsKeys.page(
+      params.pageIndex,
+      params.pageSize,
+      params.status
+    ),
+    queryFn: () => fetchChannelsPage(params),
+    placeholderData: (previous) => previous,
+    staleTime: 10 * 1000,
+    ...options,
+  })
+}
+
+/** Fetch the fleet-wide channel error summary. */
+export async function getChannelsErrorSummary(): Promise<ChannelsErrorSummary> {
+  return parseChannelsErrorSummary(await api.getChannelsErrorSummary())
+}
+
+export function useChannelsErrorSummary(
+  options?: Omit<UseQueryOptions<ChannelsErrorSummary>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery<ChannelsErrorSummary>({
+    queryKey: channelsKeys.errorSummary(),
+    queryFn: getChannelsErrorSummary,
+    staleTime: 10 * 1000,
+    ...options,
   })
 }

--- a/web/src/features/channels/components/channels-page.tsx
+++ b/web/src/features/channels/components/channels-page.tsx
@@ -24,10 +24,9 @@ import {
 import { Button } from '@/components/ui/button'
 import { asStringParam, parseSortingParam } from '@/lib/helpers/searchParams'
 
-import { useChannels } from '../api'
+import { useChannels, useChannelsErrorSummary, useChannelsPage } from '../api'
 import { channelsSearchSchema } from '../lib/channels-schema'
 import {
-  CHANNELS_ERROR_STATUSES,
   CHANNELS_ERROR_STATUS_FILTER,
   isErrorOnlyStatusFilter,
 } from '../lib/error-statuses'
@@ -128,12 +127,22 @@ export function ChannelsPage() {
   const { t } = useTranslation()
   const search = useSearch({ from: '/_authenticated/channels' })
   const navigate = useNavigate()
-  const channelsQuery = useChannels()
+  const urlState = useChannelsUrlState()
+  const channelsPageQuery = useChannelsPage({
+    pageIndex: urlState.pagination.pageIndex,
+    pageSize: urlState.pagination.pageSize,
+    status: urlState.filters.status || undefined,
+  })
+  // Legacy full-list query is enabled only for one-shot `?channelId=`
+  // drilldown; the normal page never transfers the whole fleet.
+  const channelsQuery = useChannels({
+    enabled: Boolean(search.channelId),
+  })
+  const errorSummaryQuery = useChannelsErrorSummary()
   // Row-level probe history is secondary decoration: fetched in ONE batch
   // (never per row) and rendered as health bars; a failed fetch only hides
   // the bars, never the channels table.
   const probeHistoryQuery = useProbeHistory('channels')
-  const urlState = useChannelsUrlState()
 
   // P1-4 closure (competitor-study-2026-08): the error banner doubles as
   // the filter entry. The count derives from the loaded list; the mode
@@ -168,10 +177,7 @@ export function ChannelsPage() {
     })
   }, [search, channelsQuery.isLoading, channelsQuery.data, navigate])
 
-  const allChannels = channelsQuery.data ?? []
-  const errorChannelCount = allChannels.filter((channel) =>
-    CHANNELS_ERROR_STATUSES.includes(channel.status)
-  ).length
+  const errorChannelCount = errorSummaryQuery.data?.errorCount ?? 0
   const showErrorOnly = isErrorOnlyStatusFilter(
     asStringParam(search.status) ?? ''
   )
@@ -203,7 +209,7 @@ export function ChannelsPage() {
   const columns = useChannelsColumns(columnActions, probeHistoryQuery.data)
 
   const { table } = useDataTable<ChannelRow>({
-    data: channelsQuery.data ?? [],
+    data: channelsPageQuery.data?.items ?? [],
     columns,
     enableColumnResizing: true,
     columnVisibilityStorageKey: CHANNELS_COLUMN_VISIBILITY_STORAGE_KEY,
@@ -218,6 +224,9 @@ export function ChannelsPage() {
     onColumnFiltersChange: urlState.onColumnFiltersChange,
     ensurePageInRange: urlState.ensurePageInRange,
     getRowId: (row) => String(row.id),
+    manualPagination: true,
+    manualSorting: true,
+    totalCount: channelsPageQuery.data?.total ?? 0,
   })
 
   return (
@@ -229,26 +238,38 @@ export function ChannelsPage() {
         </p>
       </div>
 
-      {channelsQuery.error ? (
+      {channelsPageQuery.error ? (
         <QueryErrorBanner
-          error={channelsQuery.error as Error | null}
+          error={channelsPageQuery.error as Error | null}
           messageKey='channels.page.loadError'
-          onRetry={() => channelsQuery.refetch()}
-          isRetrying={channelsQuery.isFetching}
+          onRetry={() => {
+            void channelsPageQuery.refetch()
+            void errorSummaryQuery.refetch()
+          }}
+          isRetrying={channelsPageQuery.isFetching}
         />
       ) : (
         <>
-          <ChannelsErrorBanner
-            errorCount={errorChannelCount}
-            showErrorOnly={showErrorOnly}
-            onFilterErrors={handleFilterErrors}
-            onExitErrorOnly={handleExitErrorOnly}
-          />
+          {errorSummaryQuery.error && !errorSummaryQuery.data ? (
+            <QueryErrorBanner
+              error={errorSummaryQuery.error as Error | null}
+              messageKey='channels.page.loadError'
+              onRetry={() => errorSummaryQuery.refetch()}
+              isRetrying={errorSummaryQuery.isFetching}
+            />
+          ) : (
+            <ChannelsErrorBanner
+              errorCount={errorChannelCount}
+              showErrorOnly={showErrorOnly}
+              onFilterErrors={handleFilterErrors}
+              onExitErrorOnly={handleExitErrorOnly}
+            />
+          )}
           <DataTablePage
             table={table}
             columns={columns}
-            isLoading={channelsQuery.isLoading}
-            isFetching={channelsQuery.isFetching}
+            isLoading={channelsPageQuery.isLoading}
+            isFetching={channelsPageQuery.isFetching}
             emptyTitle={t('channels.empty.title')}
             emptyDescription={t('channels.empty.description')}
             emptyAction={

--- a/web/src/features/channels/index.ts
+++ b/web/src/features/channels/index.ts
@@ -1,5 +1,5 @@
 // metapi-go/features/channels — barrel re-exports.
 export { channelsSearchSchema } from './lib/channels-schema'
-export { getChannelsList, useChannels } from './api'
+export { fetchChannelsPage, getChannelsErrorSummary, useChannels } from './api'
 export { channelsKeys } from './types'
 export type { ChannelRow } from './types'

--- a/web/src/features/channels/lib/error-statuses.ts
+++ b/web/src/features/channels/lib/error-statuses.ts
@@ -10,7 +10,7 @@ import type { ChannelStatus } from '../types'
  * intent rather than a failure, so it stays out of the error count and the
  * one-click filter.
  */
-export const CHANNELS_ERROR_STATUSES: readonly ChannelStatus[] = [
+const CHANNELS_ERROR_STATUSES: readonly ChannelStatus[] = [
   'cooldown',
   'breaker_open',
 ]

--- a/web/src/features/channels/types.ts
+++ b/web/src/features/channels/types.ts
@@ -36,10 +36,30 @@ export type ChannelRow = {
 }
 
 /**
- * TanStack Query key factory. The channels list is a single full-list query
- * (no server-side pagination), so one stable key is enough for invalidation.
+ * One server-side channels page returned by GET /api/channels when page/pageSize
+ * are present.
+ */
+export type ChannelsPageData = {
+  items: ChannelRow[]
+  total: number
+}
+
+/** Fleet-wide runtime status counts from GET /api/channels/error-summary. */
+export type ChannelsErrorSummary = {
+  total: number
+  errorCount: number
+  byStatus: Record<ChannelStatus, number>
+}
+
+/**
+ * TanStack Query key factory. The channels page now uses a server-paginated
+ * key (page/pageSize/status), while the legacy full-list key remains for the
+ * one-shot channel drilldown and any non-page consumers.
  */
 export const channelsKeys = {
   all: ['channels'] as const,
   list: () => [...channelsKeys.all, 'list'] as const,
+  page: (pageIndex: number, pageSize: number, status?: string) =>
+    [...channelsKeys.all, 'page', { pageIndex, pageSize, status }] as const,
+  errorSummary: () => [...channelsKeys.all, 'error-summary'] as const,
 }

--- a/web/src/lib/api/token-routes.ts
+++ b/web/src/lib/api/token-routes.ts
@@ -70,7 +70,13 @@ export const tokenRoutesApi = {
   getRoutesSummary: () => request('/api/routes/summary'),
   getRouteChannels: (routeId: number) =>
     request(`/api/routes/${routeId}/channels`),
-  getChannels: () => request('/api/channels'),
+  getChannels: (options?: {
+    page?: number
+    pageSize?: number
+    status?: string
+    refresh?: boolean
+  }) => request(`/api/channels${buildQueryString(options)}`),
+  getChannelsErrorSummary: () => request('/api/channels/error-summary'),
   batchAddChannels: (
     routeId: number,
     channels: Array<{

--- a/web/src/routes/_authenticated/channels.tsx
+++ b/web/src/routes/_authenticated/channels.tsx
@@ -1,22 +1,47 @@
 // metapi-go/routes — channels read-only list.
+//
+// The loader prefetches ONLY the server-paginated page pointed at by the URL
+// plus the independent fleet-wide error summary. The legacy full-list query
+// remains available lazily for one-shot `?channelId=` drilldown.
 
 import { createFileRoute } from '@tanstack/react-router'
 
 import {
   channelsKeys,
   channelsSearchSchema,
-  getChannelsList,
+  fetchChannelsPage,
+  getChannelsErrorSummary,
 } from '@/features/channels'
 import { ChannelsPage } from '@/features/channels/components/channels-page'
+import { asStringParam } from '@/lib/helpers/searchParams'
 
 export const Route = createFileRoute('/_authenticated/channels')({
   validateSearch: channelsSearchSchema,
   staticData: { title: 'channels.page.title' },
-  loader: async ({ context }) => {
-    await context.queryClient.prefetchQuery({
-      queryKey: channelsKeys.list(),
-      queryFn: () => getChannelsList(),
-    })
+  loader: async ({ context, location }) => {
+    const params = new URLSearchParams(location.searchStr)
+    const raw = {
+      page: params.get('page') ?? undefined,
+      pageSize: params.get('pageSize') ?? undefined,
+      status: params.get('status') ?? undefined,
+    }
+    const parsed = channelsSearchSchema.safeParse(raw)
+    const pageIndex = parsed.success ? (parsed.data.page ?? 0) : 0
+    const pageSize = parsed.success ? (parsed.data.pageSize ?? 20) : 20
+    const status = parsed.success
+      ? asStringParam(parsed.data.status) || undefined
+      : undefined
+
+    await Promise.all([
+      context.queryClient.prefetchQuery({
+        queryKey: channelsKeys.page(pageIndex, pageSize, status),
+        queryFn: () => fetchChannelsPage({ pageIndex, pageSize, status }),
+      }),
+      context.queryClient.prefetchQuery({
+        queryKey: channelsKeys.errorSummary(),
+        queryFn: getChannelsErrorSummary,
+      }),
+    ])
   },
   component: ChannelsPage,
 })


### PR DESCRIPTION
## Summary

- Add `GET /api/channels/error-summary`: fleet-wide runtime status counts (`total`, `errorCount`, `byStatus`) with a 10s cache, invalidated together with the channel-list snapshot on every `route_channels` mutation.
- Add optional comma-separated `status` filtering to `GET /api/channels` (`enabled` / `cooldown` / `breaker_open` / `manually_disabled`). Filtering reads the full row set to derive in-memory breaker state, then pages the filtered result with the true filtered `total`.
- Switch the channels page to server pagination (`page`/`pageSize` + status), while keeping the one-shot `?channelId=` drilldown on the legacy full-list query.
- The error banner now reads the independent fleet-wide summary, so the count stays truthful when only one page is loaded.
- Update `docs/api.md` contract, route inventory, and add SQLite/PG + frontend regression tests.

## Validation

- `bun run test`: 234 files / 1493 tests passed
- `bun run typecheck`: passed
- `bun run lint`: passed (existing warnings only)
- `bun run format:check`: passed
- `bun run knip`: passed
- `bun run build:web`: passed
- `go build ./cmd/server`: passed
- `go vet ./...`: passed
- `go test ./... -count=1 -race` (WSL): passed
- pre-push hook: all four gates passed