### PR TITLE
refactor(settings): typed collectChangedFields and remove call-site casts

### DIFF
--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -88,7 +88,7 @@ func TestSessionExpiryAndLazyGC(t *testing.T) {
 }
 
 func TestSessionSlidingExpiry(t *testing.T) {
-	sm := newTestSessionManager(t, 2*time.Second)
+	sm := newTestSessionManager(t, 10*time.Second)
 	ctx := context.Background()
 
 	raw, sess, err := sm.Create(ctx, "", "")

--- a/web/src/features/settings/lib/collect-changed-fields.ts
+++ b/web/src/features/settings/lib/collect-changed-fields.ts
@@ -39,17 +39,19 @@ export function isDeepEqual(a: unknown, b: unknown): boolean {
  * `baseline`. When there is no baseline (load failed / first render) the
  * whole object is treated as changed so the first save still works.
  */
-export function collectChangedFields<T extends Record<string, unknown>>(
+export function collectChangedFields<T extends object>(
   values: T,
   baseline: T | null | undefined
 ): Partial<T> {
+  const valuesRecord = values as unknown as Record<string, unknown>
   if (!baseline) {
-    return { ...values }
+    return { ...values } as Partial<T>
   }
+  const baselineRecord = baseline as unknown as Record<string, unknown>
   const changed: Record<string, unknown> = {}
-  for (const key of Object.keys(values)) {
-    if (!isDeepEqual(values[key], baseline[key])) {
-      changed[key] = values[key]
+  for (const key of Object.keys(valuesRecord)) {
+    if (!isDeepEqual(valuesRecord[key], baselineRecord[key])) {
+      changed[key] = valuesRecord[key]
     }
   }
   return changed as Partial<T>

--- a/web/src/features/settings/sections/basic/components/authentication-section.tsx
+++ b/web/src/features/settings/sections/basic/components/authentication-section.tsx
@@ -131,10 +131,7 @@ export function AuthenticationSection() {
     })
 
   function onAllowlistSubmit(values: AllowlistFormValues) {
-    const changed = collectChangedFields(
-      values as unknown as Record<string, unknown>,
-      baseline as unknown as Record<string, unknown> | null
-    ) as Partial<AllowlistFormValues>
+    const changed = collectChangedFields(values, baseline)
     if (!hasChanges(changed) || changed.adminIpAllowlist === undefined) {
       toast.info(t('settings.common.noChanges'))
       return

--- a/web/src/features/settings/sections/basic/components/site-section.tsx
+++ b/web/src/features/settings/sections/basic/components/site-section.tsx
@@ -88,10 +88,7 @@ export function SiteSection() {
   })
 
   function onSubmit(values: SiteFormValues) {
-    const changed = collectChangedFields(
-      values as unknown as Record<string, unknown>,
-      baseline as unknown as Record<string, unknown> | null
-    ) as Partial<SiteFormValues>
+    const changed = collectChangedFields(values, baseline)
     if (!hasChanges(changed)) {
       toast.info(t('settings.common.noChanges'))
       return

--- a/web/src/features/settings/sections/content/components/import-export-section.tsx
+++ b/web/src/features/settings/sections/content/components/import-export-section.tsx
@@ -302,10 +302,7 @@ export function ImportExportSection() {
   })
 
   function onWebdavSubmit(values: WebdavFormValues) {
-    const changed = collectChangedFields(
-      values as unknown as Record<string, unknown>,
-      baseline as unknown as Record<string, unknown> | null
-    ) as Partial<WebdavFormValues>
+    const changed = collectChangedFields(values, baseline)
     if (!hasChanges(changed)) {
       toast.info(t('settings.common.noChanges'))
       return

--- a/web/src/features/settings/sections/content/components/notifications-section.tsx
+++ b/web/src/features/settings/sections/content/components/notifications-section.tsx
@@ -244,10 +244,7 @@ export function NotificationsSection() {
   })
 
   function onSubmit(values: NotifyFormValues) {
-    const changed = collectChangedFields(
-      values as unknown as Record<string, unknown>,
-      baseline as unknown as Record<string, unknown> | null
-    ) as Partial<NotifyFormValues>
+    const changed = collectChangedFields(values, baseline)
     if (!hasChanges(changed)) {
       toast.info(t('settings.common.noChanges'))
       return

--- a/web/src/features/settings/sections/downstream/components/proxy-token-section.tsx
+++ b/web/src/features/settings/sections/downstream/components/proxy-token-section.tsx
@@ -78,10 +78,7 @@ export function ProxyTokenSection() {
   }
 
   function onSubmit(values: ProxyTokenFormValues) {
-    const changed = collectChangedFields(
-      values as unknown as Record<string, unknown>,
-      baseline as unknown as Record<string, unknown> | null
-    ) as Partial<ProxyTokenFormValues>
+    const changed = collectChangedFields(values, baseline)
     if (!hasChanges(changed) || !changed.proxyTokenSuffix) {
       toast.info(t('settings.common.noChanges'))
       return

--- a/web/src/features/settings/sections/operations/components/database-section.tsx
+++ b/web/src/features/settings/sections/operations/components/database-section.tsx
@@ -146,10 +146,7 @@ export function DatabaseSection() {
   }
 
   function onSave(values: DatabaseFormValues) {
-    const changed = collectChangedFields(
-      values as unknown as Record<string, unknown>,
-      baseline as unknown as Record<string, unknown> | null
-    ) as Partial<DatabaseFormValues>
+    const changed = collectChangedFields(values, baseline)
     const connection = values.connectionString.trim()
     const requiresConnection =
       !savedConfig?.hasConnectionString || changed.dialect !== undefined

--- a/web/src/features/settings/sections/operations/components/scheduling-section.tsx
+++ b/web/src/features/settings/sections/operations/components/scheduling-section.tsx
@@ -266,10 +266,7 @@ export function SchedulingSection() {
   })
 
   function onSubmit(values: SchedulingFormValues) {
-    const changed = collectChangedFields(
-      values as unknown as Record<string, unknown>,
-      baseline as unknown as Record<string, unknown> | null
-    ) as Partial<SchedulingFormValues>
+    const changed = collectChangedFields(values, baseline)
     if (!hasChanges(changed)) {
       toast.info(t('settings.common.noChanges'))
       return

--- a/web/src/features/settings/sections/proxy-models/components/allowlist-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/allowlist-section.tsx
@@ -193,10 +193,7 @@ export function AllowlistSection() {
   }
 
   function onSubmit(values: AllowlistFormValues) {
-    const changed = collectChangedFields(
-      values as unknown as Record<string, unknown>,
-      baseline as unknown as Record<string, unknown> | null
-    ) as Partial<AllowlistFormValues>
+    const changed = collectChangedFields(values, baseline)
     if (!hasChanges(changed) && changed.globalAllowedModels === undefined) {
       toast.info(t('settings.common.noChanges'))
       return

--- a/web/src/features/settings/sections/proxy-models/components/proxy-transport-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/proxy-transport-section.tsx
@@ -233,10 +233,7 @@ export function ProxyTransportSection() {
   })
 
   function onSubmit(values: ProxyTransportFormValues) {
-    const changed = collectChangedFields(
-      values as unknown as Record<string, unknown>,
-      baseline as unknown as Record<string, unknown> | null
-    ) as Partial<ProxyTransportFormValues>
+    const changed = collectChangedFields(values, baseline)
     if (!hasChanges(changed)) {
       toast.info(t('settings.common.noChanges'))
       return

--- a/web/src/features/settings/sections/proxy-models/components/routing-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/routing-section.tsx
@@ -176,10 +176,7 @@ export function RoutingSection() {
   }
 
   function onSubmit(values: RoutingFormValues) {
-    const changed = collectChangedFields(
-      values as unknown as Record<string, unknown>,
-      baseline as unknown as Record<string, unknown> | null
-    ) as Partial<RoutingFormValues>
+    const changed = collectChangedFields(values, baseline)
     if (!hasChanges(changed)) {
       toast.info(t('settings.common.noChanges'))
       return


### PR DESCRIPTION
## Summary

- Change `collectChangedFields` from `T extends Record<string, unknown>` to `T extends object`.
- Move the internal `Record<string, unknown>` viewpoint into the helper, so all 11 settings call sites can pass typed form values directly and receive `Partial<T>` without triple `as-unknown` / `as-Partial` casts.
- Add a small auth-session test robustness fix: the sliding-expiry test used a 2s TTL with a 1.1s sleep, which is flaky under the concurrent WSL race gate; widen to 10s so it verifies sliding expiry without depending on scheduler latency.

## Validation

- `bun run test`: 234 files / 1493 tests passed
- `bun run typecheck`: passed
- `bun run lint`: passed (existing warnings only)
- `bun run format:check`: passed
- `bun run knip`: passed
- `go test ./auth -run TestSessionSlidingExpiry -count=3 -race`: passed
- full pre-push gate (frontend + build + vet + WSL race): passed