### PR TITLE
feat(web): migrate site form from centered Dialog to right Sheet

### DIFF
--- a/web/src/features/sites/__tests__/form-focus-first-invalid.test.tsx
+++ b/web/src/features/sites/__tests__/form-focus-first-invalid.test.tsx
@@ -23,7 +23,7 @@ import {
 
 import '@/i18n/config'
 
-import { SiteFormDialog } from '../components/site-form-dialog'
+import { SiteFormSheet } from '../components/site-form-sheet'
 
 const { mockToastError } = vi.hoisted(() => ({ mockToastError: vi.fn() }))
 
@@ -72,9 +72,9 @@ beforeEach(() => {
 
 afterEach(() => cleanup())
 
-describe('SiteFormDialog focus-first-invalid', () => {
+describe('SiteFormSheet focus-first-invalid', () => {
   it('focuses the first invalid field when submitting an empty form', async () => {
-    render(<SiteFormDialog open onOpenChange={() => {}} editingSite={null} />)
+    render(<SiteFormSheet open onOpenChange={() => {}} editingSite={null} />)
 
     const submitButton = await screen.findByRole('button', { name: 'Create' })
     fireEvent.click(submitButton)

--- a/web/src/features/sites/__tests__/sites-page-import-entry.test.tsx
+++ b/web/src/features/sites/__tests__/sites-page-import-entry.test.tsx
@@ -87,8 +87,8 @@ vi.mock('../api', () => ({
   useBatchUpdateSites: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }))
 
-vi.mock('../components/site-form-dialog', () => ({
-  SiteFormDialog: () => null,
+vi.mock('../components/site-form-sheet', () => ({
+  SiteFormSheet: () => null,
 }))
 
 vi.mock('../components/site-detail-sheet', () => ({

--- a/web/src/features/sites/components/__tests__/site-form-sheet-endpoints.test.tsx
+++ b/web/src/features/sites/components/__tests__/site-form-sheet-endpoints.test.tsx
@@ -3,7 +3,7 @@
 // toggle), advanced-mode textarea compatibility, untouched-preserve
 // semantics and validation-error rendering. Mocks only the sites api +
 // toast; keeps the real RHF + Zod + dirty-close-guard + i18n code paths
-// under test (same pattern as site-form-dialog.test.tsx).
+// under test (same pattern as site-form-sheet.test.tsx).
 import '@testing-library/jest-dom/vitest'
 import {
   cleanup,
@@ -25,7 +25,7 @@ import {
 import '@/i18n/config'
 
 import type { Site, SiteFormPayload } from '../../types'
-import { SiteFormDialog } from '../site-form-dialog'
+import { SiteFormSheet } from '../site-form-sheet'
 
 const { mockCreateMutate, mockUpdateMutate, mockDetectMutate, mockToastError } =
   vi.hoisted(() => ({
@@ -105,7 +105,7 @@ function openAdvanced() {
 
 /** Renders the create dialog with the mandatory fields filled. */
 async function renderCreateDialog(): Promise<void> {
-  render(<SiteFormDialog open onOpenChange={vi.fn()} editingSite={null} />)
+  render(<SiteFormSheet open onOpenChange={vi.fn()} editingSite={null} />)
   await waitFor(() => {
     expect(screen.getByLabelText('Name')).toBeInTheDocument()
   })
@@ -117,7 +117,7 @@ function lastCreatePayload(): SiteFormPayload {
   return mockCreateMutate.mock.calls[0]?.[0] as SiteFormPayload
 }
 
-describe('SiteFormDialog apiEndpoints structured editor interaction', () => {
+describe('SiteFormSheet apiEndpoints structured editor interaction', () => {
   it('adds rows and sends url/enabled/positional sortOrder on create', async () => {
     mockCreateMutate.mockResolvedValue({
       id: 42,
@@ -159,7 +159,7 @@ describe('SiteFormDialog apiEndpoints structured editor interaction', () => {
     mockUpdateMutate.mockResolvedValue({ ...EDITING_SITE, name: 'Renamed' })
 
     render(
-      <SiteFormDialog open onOpenChange={vi.fn()} editingSite={EDITING_SITE} />
+      <SiteFormSheet open onOpenChange={vi.fn()} editingSite={EDITING_SITE} />
     )
     await waitFor(() => {
       expect(screen.getByLabelText('Endpoint URL 1')).toBeInTheDocument()
@@ -195,7 +195,7 @@ describe('SiteFormDialog apiEndpoints structured editor interaction', () => {
     mockUpdateMutate.mockResolvedValue({ ...EDITING_SITE })
 
     render(
-      <SiteFormDialog open onOpenChange={vi.fn()} editingSite={EDITING_SITE} />
+      <SiteFormSheet open onOpenChange={vi.fn()} editingSite={EDITING_SITE} />
     )
     await waitFor(() => {
       expect(screen.getByLabelText('Endpoint URL 1')).toBeInTheDocument()
@@ -244,12 +244,12 @@ describe('SiteFormDialog apiEndpoints structured editor interaction', () => {
   })
 })
 
-describe('SiteFormDialog apiEndpoints untouched-preserve semantics', () => {
+describe('SiteFormSheet apiEndpoints untouched-preserve semantics', () => {
   it('passes the original endpoints through on name-only edits', async () => {
     mockUpdateMutate.mockResolvedValue({ ...EDITING_SITE, name: 'Renamed' })
 
     render(
-      <SiteFormDialog open onOpenChange={vi.fn()} editingSite={EDITING_SITE} />
+      <SiteFormSheet open onOpenChange={vi.fn()} editingSite={EDITING_SITE} />
     )
     await waitFor(() => {
       expect(screen.getByLabelText('Name')).toBeInTheDocument()
@@ -276,7 +276,7 @@ describe('SiteFormDialog apiEndpoints untouched-preserve semantics', () => {
   it('marks the form dirty for the dirty-close guard when only the editor changes', async () => {
     const onOpenChange = vi.fn()
     render(
-      <SiteFormDialog
+      <SiteFormSheet
         open
         onOpenChange={onOpenChange}
         editingSite={EDITING_SITE}
@@ -296,7 +296,7 @@ describe('SiteFormDialog apiEndpoints untouched-preserve semantics', () => {
   })
 })
 
-describe('SiteFormDialog apiEndpoints validation errors', () => {
+describe('SiteFormSheet apiEndpoints validation errors', () => {
   it('renders the invalid-URL error and short-circuits the create mutation', async () => {
     mockCreateMutate.mockResolvedValue({
       id: 45,
@@ -396,11 +396,7 @@ describe('SiteFormDialog apiEndpoints validation errors', () => {
     mockUpdateMutate.mockResolvedValue({ ...siteWithStatus })
 
     render(
-      <SiteFormDialog
-        open
-        onOpenChange={vi.fn()}
-        editingSite={siteWithStatus}
-      />
+      <SiteFormSheet open onOpenChange={vi.fn()} editingSite={siteWithStatus} />
     )
     await waitFor(() => {
       expect(screen.getByLabelText('Endpoint URL 1')).toBeInTheDocument()

--- a/web/src/features/sites/components/__tests__/site-form-sheet.test.tsx
+++ b/web/src/features/sites/components/__tests__/site-form-sheet.test.tsx
@@ -24,7 +24,7 @@ import {
 import '@/i18n/config'
 
 import type { Site } from '../../types'
-import { SiteFormDialog } from '../site-form-dialog'
+import { SiteFormSheet } from '../site-form-sheet'
 
 const { mockCreateMutate, mockUpdateMutate, mockDetectMutate, mockToastError } =
   vi.hoisted(() => ({
@@ -81,9 +81,9 @@ function typeField(label: string, value: string) {
   fireEvent.change(screen.getByLabelText(label), { target: { value } })
 }
 
-describe('SiteFormDialog Zod submission errors', () => {
+describe('SiteFormSheet Zod submission errors', () => {
   it('renders the nameRequired error when submitting with an empty name', async () => {
-    render(<SiteFormDialog open onOpenChange={vi.fn()} editingSite={null} />)
+    render(<SiteFormSheet open onOpenChange={vi.fn()} editingSite={null} />)
 
     await waitFor(() => {
       expect(screen.getByLabelText('Name')).toBeInTheDocument()
@@ -100,7 +100,7 @@ describe('SiteFormDialog Zod submission errors', () => {
   })
 })
 
-describe('SiteFormDialog create payload', () => {
+describe('SiteFormSheet create payload', () => {
   it('calls onCreated with the created site after a valid submit', async () => {
     const createdSite: Site = {
       id: 42,
@@ -113,7 +113,7 @@ describe('SiteFormDialog create payload', () => {
     const onCreated = vi.fn()
 
     render(
-      <SiteFormDialog
+      <SiteFormSheet
         open
         onOpenChange={vi.fn()}
         editingSite={null}
@@ -147,7 +147,7 @@ describe('SiteFormDialog create payload', () => {
   })
 })
 
-describe('SiteFormDialog platform picker', () => {
+describe('SiteFormSheet platform picker', () => {
   // Canonical adapter platforms from platform/registry.go `orderedPlatformNames`.
   const CANONICAL_PLATFORMS = [
     'openai',
@@ -169,7 +169,7 @@ describe('SiteFormDialog platform picker', () => {
   ]
 
   it('lists the 16 canonical platforms in the platform select', async () => {
-    render(<SiteFormDialog open onOpenChange={vi.fn()} editingSite={null} />)
+    render(<SiteFormSheet open onOpenChange={vi.fn()} editingSite={null} />)
 
     const platformSelect = await screen.findByRole('combobox', {
       name: 'Platform',
@@ -193,7 +193,7 @@ describe('SiteFormDialog platform picker', () => {
       status: 'active',
     })
 
-    render(<SiteFormDialog open onOpenChange={vi.fn()} editingSite={null} />)
+    render(<SiteFormSheet open onOpenChange={vi.fn()} editingSite={null} />)
 
     await waitFor(() => {
       expect(screen.getByLabelText('Name')).toBeInTheDocument()
@@ -235,7 +235,7 @@ describe('SiteFormDialog platform picker', () => {
       status: 'active',
     })
 
-    render(<SiteFormDialog open onOpenChange={vi.fn()} editingSite={null} />)
+    render(<SiteFormSheet open onOpenChange={vi.fn()} editingSite={null} />)
 
     await waitFor(() => {
       expect(screen.getByLabelText('Name')).toBeInTheDocument()
@@ -263,7 +263,7 @@ describe('SiteFormDialog platform picker', () => {
   })
 })
 
-describe('SiteFormDialog post-refresh probe latency threshold (gap-11)', () => {
+describe('SiteFormSheet post-refresh probe latency threshold (gap-11)', () => {
   it('renders the latency threshold field when probe is enabled and round-trips the value into the payload', async () => {
     // A successful create resolves with a minimal site object; only the
     // payload contract is asserted, not the created echo.
@@ -275,7 +275,7 @@ describe('SiteFormDialog post-refresh probe latency threshold (gap-11)', () => {
       status: 'active',
     })
 
-    render(<SiteFormDialog open onOpenChange={vi.fn()} editingSite={null} />)
+    render(<SiteFormSheet open onOpenChange={vi.fn()} editingSite={null} />)
 
     await waitFor(() => {
       expect(screen.getByLabelText('Name')).toBeInTheDocument()
@@ -319,7 +319,7 @@ describe('SiteFormDialog post-refresh probe latency threshold (gap-11)', () => {
   })
 })
 
-describe('SiteFormDialog edit round-trip (gap-1)', () => {
+describe('SiteFormSheet edit round-trip (gap-1)', () => {
   it('checks the override-headers switch when editing a site with it enabled', async () => {
     const editingSite: Site = {
       id: 7,
@@ -332,7 +332,7 @@ describe('SiteFormDialog edit round-trip (gap-1)', () => {
     }
 
     render(
-      <SiteFormDialog open onOpenChange={vi.fn()} editingSite={editingSite} />
+      <SiteFormSheet open onOpenChange={vi.fn()} editingSite={editingSite} />
     )
 
     const overrideSwitch = await screen.findByRole('switch', {
@@ -345,9 +345,9 @@ describe('SiteFormDialog edit round-trip (gap-1)', () => {
   })
 })
 
-describe('SiteFormDialog dirty-close guard', () => {
+describe('SiteFormSheet dirty-close guard', () => {
   it('opens the discard confirm when closing with unsaved edits', async () => {
-    render(<SiteFormDialog open onOpenChange={vi.fn()} editingSite={null} />)
+    render(<SiteFormSheet open onOpenChange={vi.fn()} editingSite={null} />)
 
     await waitFor(() => {
       expect(screen.getByLabelText('Name')).toBeInTheDocument()
@@ -367,7 +367,7 @@ describe('SiteFormDialog dirty-close guard', () => {
   it('opens the discard confirm when Cancel is clicked with unsaved edits', async () => {
     const onOpenChange = vi.fn()
     render(
-      <SiteFormDialog open onOpenChange={onOpenChange} editingSite={null} />
+      <SiteFormSheet open onOpenChange={onOpenChange} editingSite={null} />
     )
 
     await waitFor(() => {

--- a/web/src/features/sites/components/__tests__/sites-page-pagination.test.tsx
+++ b/web/src/features/sites/components/__tests__/sites-page-pagination.test.tsx
@@ -106,8 +106,8 @@ vi.mock('../site-detail-sheet', () => ({
   SiteDetailSheet: () => null,
 }))
 
-vi.mock('../site-form-dialog', () => ({
-  SiteFormDialog: () => null,
+vi.mock('../site-form-sheet', () => ({
+  SiteFormSheet: () => null,
 }))
 
 vi.mock('../sites-columns', () => ({

--- a/web/src/features/sites/components/__tests__/sites-page.test.tsx
+++ b/web/src/features/sites/components/__tests__/sites-page.test.tsx
@@ -91,8 +91,8 @@ vi.mock('../site-detail-sheet', () => ({
   SiteDetailSheet: () => null,
 }))
 
-vi.mock('../site-form-dialog', () => ({
-  SiteFormDialog: (props: {
+vi.mock('../site-form-sheet', () => ({
+  SiteFormSheet: (props: {
     open: boolean
     editingSite?: { id: number } | null
   }) => {

--- a/web/src/features/sites/components/site-form-sheet.tsx
+++ b/web/src/features/sites/components/site-form-sheet.tsx
@@ -1,9 +1,9 @@
-// metapi-go/features/sites — add/edit site form dialog (RHF + Zod + shadcn).
+// metapi-go/features/sites — add/edit site form sheet (RHF + Zod + shadcn).
 //
-// One dialog serves both create and edit. The `editingSite` prop selects the
-// mode; when null the dialog is in "add" mode and a successful submit
+// One sheet serves both create and edit. The `editingSite` prop selects the
+// mode; when null the sheet is in "add" mode and a successful submit
 // triggers `onCreated(createdSite)` so the page can open the guided
-// `SiteCreatedModal`. On edit, the form preserves fields the dialog does
+// `SiteCreatedModal`. On edit, the form preserves fields the sheet does
 // not expose (notably `customHeaders` when untouched) by passing the
 // original values through to the payload — editing the name must not wipe
 // the endpoint list. `apiEndpoints` IS exposed: the structured endpoint row
@@ -23,14 +23,6 @@ import { useTranslation } from 'react-i18next'
 import { useDirtyDialogClose } from '@/components/form/dirty-dialog-close'
 import { Button } from '@/components/ui/button'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import {
   Form,
   FormControl,
   FormDescription,
@@ -48,6 +40,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
 import { Spinner } from '@/components/ui/spinner'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
@@ -68,7 +68,7 @@ import {
 import type { Site, SiteFormPayload, SiteProbeScope } from '../types'
 import { EndpointsEditor } from './endpoints-editor'
 
-type SiteFormDialogProps = {
+type SiteFormSheetProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
   editingSite: Site | null
@@ -180,12 +180,12 @@ function buildPayload(
   }
 }
 
-export function SiteFormDialog({
+export function SiteFormSheet({
   open,
   onOpenChange,
   editingSite,
   onCreated,
-}: SiteFormDialogProps) {
+}: SiteFormSheetProps) {
   const { t } = useTranslation()
   const isEditing = editingSite !== null
 
@@ -314,25 +314,25 @@ export function SiteFormDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className='sm:max-w-2xl'>
-        <DialogHeader>
-          <DialogTitle>
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetContent className='gap-0 sm:max-w-2xl' showMobileCloseBar={false}>
+        <SheetHeader>
+          <SheetTitle>
             {isEditing ? t('sites.form.editTitle') : t('sites.form.addTitle')}
-          </DialogTitle>
-          <DialogDescription>
+          </SheetTitle>
+          <SheetDescription>
             {isEditing
               ? t('sites.form.editDescription')
               : t('sites.form.addDescription')}
-          </DialogDescription>
-        </DialogHeader>
+          </SheetDescription>
+        </SheetHeader>
 
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(onSubmit, () =>
               toast.error(t('sites.form.invalid'))
             )}
-            className='grid gap-4'
+            className='grid gap-4 px-4'
           >
             <div className='grid gap-4 sm:grid-cols-2'>
               <FormField
@@ -896,7 +896,7 @@ export function SiteFormDialog({
               )}
             </div>
 
-            <DialogFooter showCloseButton={false}>
+            <SheetFooter className='bg-background sticky bottom-0 -mx-4 mt-4 flex-row justify-end gap-2 border-t px-4 py-3'>
               <Button
                 type='button'
                 variant='outline'
@@ -909,11 +909,11 @@ export function SiteFormDialog({
                 {isSubmitting && <Spinner />}
                 {isEditing ? t('sites.form.save') : t('sites.form.create')}
               </Button>
-            </DialogFooter>
+            </SheetFooter>
           </form>
         </Form>
-      </DialogContent>
+      </SheetContent>
       {guard}
-    </Dialog>
+    </Sheet>
   )
 }

--- a/web/src/features/sites/components/sites-page.tsx
+++ b/web/src/features/sites/components/sites-page.tsx
@@ -54,7 +54,7 @@ import { sitesSearchSchema } from '../lib/sites-schema'
 import type { Site, SiteBatchAction } from '../types'
 import { SiteCreatedModal } from './site-created-modal'
 import { SiteDetailSheet } from './site-detail-sheet'
-import { SiteFormDialog } from './site-form-dialog'
+import { SiteFormSheet } from './site-form-sheet'
 import { SITES_STATUS_FILTER_OPTIONS, useSitesColumns } from './sites-columns'
 
 const SITES_COLUMN_VISIBILITY_STORAGE_KEY = 'metapi-go:sites:column-visibility'
@@ -570,7 +570,7 @@ export function SitesPage() {
         />
       )}
 
-      <SiteFormDialog
+      <SiteFormSheet
         open={formOpen}
         onOpenChange={setFormOpen}
         editingSite={editingSite}


### PR DESCRIPTION
## 概述

最大的表单（919 行添加/编辑站点）从居中 Dialog 迁到右侧 Sheet，对齐 accounts-form 既有形态——同为大表单，站内容器统一。

## 改动

- `Dialog` → `Sheet` 壳替换；`sm:max-w-2xl` 宽度保持（两列网格不塌）
- `SheetFooter` sticky bottom + 不透明底 + 顶边线——长表单滚动时取消/提交常驻可达（对齐 Dialog viewport 契约）
- `showMobileCloseBar={false}`（W21-B 表单 Sheet 豁免规则：footer 已有取消/提交，不再叠「关闭」同义出口）
- 组件改名 `SiteFormSheet`（语义诚实），8 个引用点 45 处符号更新；3 个文件 git mv（rename 可追溯）
- dirty 守卫 `useDirtyDialogClose` 零改动（Sheet 底座即 base-ui Dialog，onOpenChange 语义一致）

## 验证

- sites 域 **18 文件 / 132 测试零改动全绿**（role 语义不变：Sheet 底座 = Dialog）
- typecheck / lint（0 error）/ format / knip 全绿
- 截图证据：desktop 右侧抽屉两列布局 + sticky footer、mobile 全宽单列 + 底部提交可达、校验红标场景 26/26 OK（`.dev-local/screenshots/f2-sheet/`）