### PR TITLE
refactor(web): centralize the list-page error contract in DataTablePage (S7)

### DIFF
--- a/web/src/components/common/__tests__/retry-icon-consistency.test.ts
+++ b/web/src/components/common/__tests__/retry-icon-consistency.test.ts
@@ -51,17 +51,24 @@ describe('retry button icon vocabulary', () => {
     expect(source).not.toMatch(/<RotateCcw/)
   })
 
-  it('the routes page load-error retry is delegated to QueryErrorBanner', () => {
-    // W19-T1 P2-o unification: the page no longer hand-rolls its own retry
-    // button; the glyph vocabulary is pinned on QueryErrorBanner itself (see
-    // the first test), so the page only needs to delegate, never regress to
-    // a reset-style icon.
+  it('the routes page load-error retry is delegated to DataTablePage → QueryErrorBanner', () => {
+    // W19-T1 P2-o unification → S7 centralization: the page no longer
+    // hand-rolls its own retry button nor renders QueryErrorBanner directly;
+    // it passes the error contract into DataTablePage, which renders the
+    // shared banner. The glyph vocabulary stays pinned on QueryErrorBanner
+    // itself (see the first test), so the page only delegates.
     const source = readSource(
       'src/features/token-routes/components/routes-page.tsx'
     )
 
-    expect(source).toMatch(/<QueryErrorBanner/)
+    expect(source).toMatch(/onErrorRetry=\{/)
+    expect(source).toMatch(/errorMessageKey=/)
     expect(source).not.toMatch(/<RotateCw/)
     expect(source).not.toMatch(/<RotateCcw/)
+
+    const tablePage = readSource(
+      'src/components/data-table/layout/data-table-page.tsx'
+    )
+    expect(tablePage).toMatch(/<QueryErrorBanner/)
   })
 })

--- a/web/src/components/data-table/layout/__tests__/data-table-page.test.tsx
+++ b/web/src/components/data-table/layout/__tests__/data-table-page.test.tsx
@@ -8,7 +8,7 @@ import {
   useReactTable,
   type ColumnDef,
 } from '@tanstack/react-table'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import '@/i18n/config'
@@ -86,5 +86,56 @@ describe('DataTablePage background refetch indicator', () => {
     expect(screen.getByText('alpha')).toBeInTheDocument()
     expect(container.querySelector('.pointer-events-none')).toBeNull()
     expect(container.querySelector('.opacity-80')).toBeNull()
+  })
+})
+
+describe('DataTablePage error contract (S7)', () => {
+  function renderWithError(options: {
+    placement?: 'replace' | 'inline'
+    onRetry?: () => void
+  }) {
+    function Harness() {
+      const table = useReactTable({
+        data: probeRows,
+        columns: probeColumns,
+        getCoreRowModel: getCoreRowModel(),
+      })
+      return (
+        <DataTablePage
+          table={table}
+          columns={probeColumns}
+          error={new Error('boom')}
+          errorMessageKey='sites.page.loadError'
+          onErrorRetry={options.onRetry}
+          errorPlacement={options.placement}
+          toolbarProps={null}
+          showPagination={false}
+        />
+      )
+    }
+    return render(<Harness />)
+  }
+
+  it('replace placement swaps the whole table region for the banner', () => {
+    renderWithError({})
+
+    expect(screen.getByRole('alert')).toHaveTextContent('boom')
+    // Stale rows must not read as current data.
+    expect(screen.queryByText('alpha')).not.toBeInTheDocument()
+  })
+
+  it('inline placement keeps the rows visible under the banner', () => {
+    renderWithError({ placement: 'inline' })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('boom')
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+  })
+
+  it('banner Retry invokes onErrorRetry', () => {
+    const onRetry = vi.fn()
+    renderWithError({ onRetry })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
   })
 })

--- a/web/src/components/data-table/layout/data-table-page.tsx
+++ b/web/src/components/data-table/layout/data-table-page.tsx
@@ -6,6 +6,7 @@ import type {
 } from '@tanstack/react-table'
 import * as React from 'react'
 
+import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import { useMediaQuery } from '@/hooks/use-media-query'
 import { TABLE_MOBILE_MEDIA_QUERY } from '@/lib/breakpoints'
 import { cn } from '@/lib/utils'
@@ -29,7 +30,44 @@ type DataTablePageToolbarProps<TData> = Omit<
   'table'
 >
 
-export type DataTablePageProps<TData> = {
+/**
+ * Unified list-page error contract (S7): pass the list query's error and the
+ * banner renders via the shared {@link QueryErrorBanner}. The union enforces
+ * that `errorMessageKey` accompanies `error` at compile time.
+ */
+type DataTablePageErrorProps =
+  | {
+      error?: null
+      errorMessageKey?: undefined
+      onErrorRetry?: undefined
+      isErrorRetrying?: undefined
+      errorPlacement?: undefined
+    }
+  | {
+      /**
+       * List-query error. Non-null renders the shared QueryErrorBanner:
+       * 'replace' (default) swaps the whole table region for the banner;
+       * 'inline' keeps stale rows visible under the banner.
+       */
+      error: Error | null
+      /**
+       * i18n key whose template interpolates `{{message}}`
+       * (e.g. `accounts.page.loadError`).
+       */
+      errorMessageKey: string
+      /** Retry handler for the banner — typically `() => query.refetch()`. */
+      onErrorRetry?: () => void
+      /** True while the retry request is in flight. */
+      isErrorRetrying?: boolean
+      /**
+       * 'replace' (default): banner replaces toolbar/table/pagination.
+       * 'inline': banner renders above the table so placeholderData rows
+       * stay visible (e.g. oauth, proxy-logs).
+       */
+      errorPlacement?: 'replace' | 'inline'
+    }
+
+export type DataTablePageProps<TData> = DataTablePageErrorProps & {
   /**
    * TanStack Table instance returned from `useReactTable`.
    */
@@ -218,6 +256,10 @@ export type DataTablePageProps<TData> = {
  *   columns={columns}
  *   isLoading={isLoading}
  *   isFetching={isFetching}
+ *   error={query.error as Error | null}
+ *   errorMessageKey='x.page.loadError'
+ *   onErrorRetry={() => query.refetch()}
+ *   isErrorRetrying={query.isFetching}
  *   emptyTitle={t('No X Found')}
  *   toolbarProps={{ searchPlaceholder: t('Filter...'), filters }}
  *   bulkActions={<MyBulkActions table={table} />}
@@ -235,6 +277,22 @@ export function DataTablePage<TData>(props: DataTablePageProps<TData>) {
   const isMobile = useMediaQuery(TABLE_MOBILE_MEDIA_QUERY)
   const showMobile = isMobile && !props.hideMobile
 
+  const errorBanner = props.error ? (
+    <QueryErrorBanner
+      error={props.error}
+      messageKey={props.errorMessageKey}
+      onRetry={props.onErrorRetry}
+      isRetrying={props.isErrorRetrying}
+    />
+  ) : null
+
+  // Replace placement (default): the failed load swaps the whole region —
+  // toolbar, table, and pagination — so a stale cache can never read as
+  // current data. Inline placement keeps the table under the banner.
+  if (errorBanner && props.errorPlacement !== 'inline') {
+    return errorBanner
+  }
+
   const toolbarNode = renderToolbar(props)
   const mobile_node = renderMobile(props, showMobile)
   const desktopNode = renderDesktop(props, showMobile)
@@ -242,6 +300,7 @@ export function DataTablePage<TData>(props: DataTablePageProps<TData>) {
 
   return (
     <>
+      {errorBanner}
       <div
         className={cn(
           props.fixedHeight !== false

--- a/web/src/features/accounts/__tests__/accounts-page-error-retry.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-page-error-retry.test.tsx
@@ -29,25 +29,46 @@ vi.mock('@tanstack/react-router', () => ({
   useSearch: () => testState.search,
 }))
 
-vi.mock('@/components/data-table', () => ({
-  DataTableBulkActions: () => null,
-  DataTablePage: () => <div data-testid='data-table-page' />,
-  useUrlTableState: () => ({
-    globalFilter: '',
-    onGlobalFilterChange: vi.fn(),
-    columnFilters: [],
-    onColumnFiltersChange: vi.fn(),
-    pagination: { pageIndex: 0, pageSize: 20 },
-    onPaginationChange: vi.fn(),
-    ensurePageInRange: vi.fn(),
-  }),
-  useDataTable: () => ({
-    table: {
-      getFilteredSelectedRowModel: () => ({ rows: [] }),
-      resetRowSelection: vi.fn(),
-    },
-  }),
-}))
+vi.mock('@/components/data-table', async () => {
+  const { QueryErrorBanner } =
+    await import('@/components/common/query-error-banner')
+  // The S7 error contract lives in the real DataTablePage; the stub honors it
+  // so the page-level test verifies the page wires error/refetch correctly.
+  return {
+    DataTableBulkActions: () => null,
+    DataTablePage: (props: {
+      error?: Error | null
+      errorMessageKey?: string
+      onErrorRetry?: () => void
+      isErrorRetrying?: boolean
+    }) =>
+      props.error ? (
+        <QueryErrorBanner
+          error={props.error}
+          messageKey={props.errorMessageKey ?? ''}
+          onRetry={props.onErrorRetry}
+          isRetrying={props.isErrorRetrying}
+        />
+      ) : (
+        <div data-testid='data-table-page' />
+      ),
+    useUrlTableState: () => ({
+      globalFilter: '',
+      onGlobalFilterChange: vi.fn(),
+      columnFilters: [],
+      onColumnFiltersChange: vi.fn(),
+      pagination: { pageIndex: 0, pageSize: 20 },
+      onPaginationChange: vi.fn(),
+      ensurePageInRange: vi.fn(),
+    }),
+    useDataTable: () => ({
+      table: {
+        getFilteredSelectedRowModel: () => ({ rows: [] }),
+        resetRowSelection: vi.fn(),
+      },
+    }),
+  }
+})
 
 vi.mock('@/features/import', () => ({
   ImportWizardDialog: () => null,

--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -29,7 +29,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ConfirmDialog } from '@/components/common/confirm-dialog'
-import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import { useProbeHistory } from '@/components/common/use-probe-history'
 import {
   DataTableBulkActions,
@@ -578,78 +577,73 @@ export function AccountsPage() {
         </Button>
       </div>
 
-      {error ? (
-        <QueryErrorBanner
-          error={error as Error | null}
-          messageKey='accounts.page.loadError'
-          onRetry={() => refetch()}
-          isRetrying={isFetching}
-        />
-      ) : (
-        <DataTablePage
-          table={table}
-          columns={columns}
-          isLoading={isLoading}
-          isFetching={isFetching}
-          emptyTitle={t('accounts.page.emptyTitle')}
-          emptyDescription={t('accounts.page.emptyDescription')}
-          emptyAction={
-            <Button onClick={() => setImportOpen(true)}>
+      <DataTablePage
+        table={table}
+        columns={columns}
+        isLoading={isLoading}
+        isFetching={isFetching}
+        error={error as Error | null}
+        errorMessageKey='accounts.page.loadError'
+        onErrorRetry={() => refetch()}
+        isErrorRetrying={isFetching}
+        emptyTitle={t('accounts.page.emptyTitle')}
+        emptyDescription={t('accounts.page.emptyDescription')}
+        emptyAction={
+          <Button onClick={() => setImportOpen(true)}>
+            <UploadIcon className='size-4' />
+            {t('accounts.page.emptyImport')}
+          </Button>
+        }
+        skeletonKeyPrefix='accounts-skeleton'
+        toolbarProps={{
+          searchPlaceholder: t('accounts.page.searchPlaceholder'),
+          searchDebounceMs: 300,
+          // The wizard was only reachable from the empty-state CTA, i.e.
+          // unreachable once the first account existed. The accounts toolbar
+          // keeps a permanent Import entry (same batch site+account path the
+          // sites page exposes), reusing the already-mounted setImportOpen.
+          preActions: (
+            <Button variant='outline' onClick={() => setImportOpen(true)}>
               <UploadIcon className='size-4' />
-              {t('accounts.page.emptyImport')}
+              {t('accounts.page.toolbarImport')}
             </Button>
-          }
-          skeletonKeyPrefix='accounts-skeleton'
-          toolbarProps={{
-            searchPlaceholder: t('accounts.page.searchPlaceholder'),
-            searchDebounceMs: 300,
-            // The wizard was only reachable from the empty-state CTA, i.e.
-            // unreachable once the first account existed. The accounts toolbar
-            // keeps a permanent Import entry (same batch site+account path the
-            // sites page exposes), reusing the already-mounted setImportOpen.
-            preActions: (
-              <Button variant='outline' onClick={() => setImportOpen(true)}>
-                <UploadIcon className='size-4' />
-                {t('accounts.page.toolbarImport')}
-              </Button>
-            ),
-            filters: [
-              {
-                columnId: 'status',
-                title: t('accounts.page.filterStatusTitle'),
-                singleSelect: true,
-                options: [
+          ),
+          filters: [
+            {
+              columnId: 'status',
+              title: t('accounts.page.filterStatusTitle'),
+              singleSelect: true,
+              options: [
+                {
+                  label: t('accounts.page.filterStatusActive'),
+                  value: 'active',
+                },
+                {
+                  label: t('accounts.page.filterStatusDisabled'),
+                  value: 'disabled',
+                },
+                {
+                  label: t('accounts.page.filterStatusExpired'),
+                  value: 'expired',
+                },
+              ],
+            },
+            ...(sites.length > 0
+              ? [
                   {
-                    label: t('accounts.page.filterStatusActive'),
-                    value: 'active',
+                    columnId: 'site',
+                    title: t('accounts.page.filterSiteTitle'),
+                    options: sites.map((site) => ({
+                      label: site.name || site.url || `#${site.id}`,
+                      value: String(site.id),
+                    })),
                   },
-                  {
-                    label: t('accounts.page.filterStatusDisabled'),
-                    value: 'disabled',
-                  },
-                  {
-                    label: t('accounts.page.filterStatusExpired'),
-                    value: 'expired',
-                  },
-                ],
-              },
-              ...(sites.length > 0
-                ? [
-                    {
-                      columnId: 'site',
-                      title: t('accounts.page.filterSiteTitle'),
-                      options: sites.map((site) => ({
-                        label: site.name || site.url || `#${site.id}`,
-                        value: String(site.id),
-                      })),
-                    },
-                  ]
-                : []),
-            ],
-          }}
-          bulkActions={<AccountsBulkActions table={table} />}
-        />
-      )}
+                ]
+              : []),
+          ],
+        }}
+        bulkActions={<AccountsBulkActions table={table} />}
+      />
 
       <ImportWizardDialog open={importOpen} onOpenChange={setImportOpen} />
 

--- a/web/src/features/channels/__tests__/channels-page-error-retry.test.tsx
+++ b/web/src/features/channels/__tests__/channels-page-error-retry.test.tsx
@@ -29,23 +29,44 @@ vi.mock('@tanstack/react-router', () => ({
   useSearch: () => testState.search,
 }))
 
-vi.mock('@/components/data-table', () => ({
-  DataTablePage: () => <div data-testid='data-table-page' />,
-  encodeSorting: () => '',
-  useUrlTableState: () => ({
-    globalFilter: '',
-    onGlobalFilterChange: vi.fn(),
-    columnFilters: [],
-    onColumnFiltersChange: vi.fn(),
-    filters: { status: '' },
-    pagination: { pageIndex: 0, pageSize: 20 },
-    onPaginationChange: vi.fn(),
-    sorting: [],
-    onSortingChange: vi.fn(),
-    ensurePageInRange: vi.fn(),
-  }),
-  useDataTable: () => ({ table: {} }),
-}))
+vi.mock('@/components/data-table', async () => {
+  const { QueryErrorBanner } =
+    await import('@/components/common/query-error-banner')
+  // The S7 error contract lives in the real DataTablePage; the stub honors it
+  // so the page-level test verifies the page wires error/refetch correctly.
+  return {
+    DataTablePage: (props: {
+      error?: Error | null
+      errorMessageKey?: string
+      onErrorRetry?: () => void
+      isErrorRetrying?: boolean
+    }) =>
+      props.error ? (
+        <QueryErrorBanner
+          error={props.error}
+          messageKey={props.errorMessageKey ?? ''}
+          onRetry={props.onErrorRetry}
+          isRetrying={props.isErrorRetrying}
+        />
+      ) : (
+        <div data-testid='data-table-page' />
+      ),
+    encodeSorting: () => '',
+    useUrlTableState: () => ({
+      globalFilter: '',
+      onGlobalFilterChange: vi.fn(),
+      columnFilters: [],
+      onColumnFiltersChange: vi.fn(),
+      filters: { status: '' },
+      pagination: { pageIndex: 0, pageSize: 20 },
+      onPaginationChange: vi.fn(),
+      sorting: [],
+      onSortingChange: vi.fn(),
+      ensurePageInRange: vi.fn(),
+    }),
+    useDataTable: () => ({ table: {} }),
+  }
+})
 
 vi.mock('../api', () => ({
   useChannels: () => ({

--- a/web/src/features/channels/components/channels-page.tsx
+++ b/web/src/features/channels/components/channels-page.tsx
@@ -238,67 +238,64 @@ export function ChannelsPage() {
         </p>
       </div>
 
-      {channelsPageQuery.error ? (
-        <QueryErrorBanner
-          error={channelsPageQuery.error as Error | null}
-          messageKey='channels.page.loadError'
-          onRetry={() => {
-            void channelsPageQuery.refetch()
-            void errorSummaryQuery.refetch()
-          }}
-          isRetrying={channelsPageQuery.isFetching}
-        />
-      ) : (
-        <>
-          {errorSummaryQuery.error && !errorSummaryQuery.data ? (
-            <QueryErrorBanner
-              error={errorSummaryQuery.error as Error | null}
-              messageKey='channels.page.loadError'
-              onRetry={() => errorSummaryQuery.refetch()}
-              isRetrying={errorSummaryQuery.isFetching}
-            />
-          ) : (
-            <ChannelsErrorBanner
-              errorCount={errorChannelCount}
-              showErrorOnly={showErrorOnly}
-              onFilterErrors={handleFilterErrors}
-              onExitErrorOnly={handleExitErrorOnly}
-            />
-          )}
-          <DataTablePage
-            table={table}
-            columns={columns}
-            isLoading={channelsPageQuery.isLoading}
-            isFetching={channelsPageQuery.isFetching}
-            emptyTitle={t('channels.empty.title')}
-            emptyDescription={t('channels.empty.description')}
-            emptyAction={
-              <Button
-                variant='outline'
-                onClick={() => void navigate({ to: '/accounts' })}
-              >
-                <Users className='size-4' />
-                {t('channels.empty.manageAccounts')}
-              </Button>
-            }
-            skeletonKeyPrefix='channel-skeleton'
-            toolbarProps={{
-              searchPlaceholder: t('channels.toolbar.searchPlaceholder'),
-              searchDebounceMs: 400,
-              filters: [
-                {
-                  columnId: 'status',
-                  title: t('channels.columns.status'),
-                  options: CHANNELS_STATUS_FILTER_OPTIONS.map((option) => ({
-                    label: t(option.labelKey),
-                    value: option.value,
-                  })),
-                },
-              ],
-            }}
+      {/* S7: the main list-query error is owned by DataTablePage (replace
+          placement); the error-summary strip only shows when the list itself
+          loaded, matching the pre-S7 else-branch behavior. */}
+      {!channelsPageQuery.error &&
+        (errorSummaryQuery.error && !errorSummaryQuery.data ? (
+          <QueryErrorBanner
+            error={errorSummaryQuery.error as Error | null}
+            messageKey='channels.page.loadError'
+            onRetry={() => errorSummaryQuery.refetch()}
+            isRetrying={errorSummaryQuery.isFetching}
           />
-        </>
-      )}
+        ) : (
+          <ChannelsErrorBanner
+            errorCount={errorChannelCount}
+            showErrorOnly={showErrorOnly}
+            onFilterErrors={handleFilterErrors}
+            onExitErrorOnly={handleExitErrorOnly}
+          />
+        ))}
+      <DataTablePage
+        table={table}
+        columns={columns}
+        isLoading={channelsPageQuery.isLoading}
+        isFetching={channelsPageQuery.isFetching}
+        error={channelsPageQuery.error as Error | null}
+        errorMessageKey='channels.page.loadError'
+        onErrorRetry={() => {
+          void channelsPageQuery.refetch()
+          void errorSummaryQuery.refetch()
+        }}
+        isErrorRetrying={channelsPageQuery.isFetching}
+        emptyTitle={t('channels.empty.title')}
+        emptyDescription={t('channels.empty.description')}
+        emptyAction={
+          <Button
+            variant='outline'
+            onClick={() => void navigate({ to: '/accounts' })}
+          >
+            <Users className='size-4' />
+            {t('channels.empty.manageAccounts')}
+          </Button>
+        }
+        skeletonKeyPrefix='channel-skeleton'
+        toolbarProps={{
+          searchPlaceholder: t('channels.toolbar.searchPlaceholder'),
+          searchDebounceMs: 400,
+          filters: [
+            {
+              columnId: 'status',
+              title: t('channels.columns.status'),
+              options: CHANNELS_STATUS_FILTER_OPTIONS.map((option) => ({
+                label: t(option.labelKey),
+                value: option.value,
+              })),
+            },
+          ],
+        }}
+      />
 
       <CooldownReasonDialog
         channel={reasonChannel}

--- a/web/src/features/checkin/__tests__/checkin-page-error-contract.test.tsx
+++ b/web/src/features/checkin/__tests__/checkin-page-error-contract.test.tsx
@@ -26,27 +26,48 @@ vi.mock('@tanstack/react-router', () => ({
 }))
 
 // Render a probe in place of the table so presence/absence is assertable.
-vi.mock('@/components/data-table', () => ({
-  DataTablePage: () => <div data-testid='checkin-table' />,
-  useDataTable: () => ({ table: {} }),
-  useUrlTableState: () => ({
-    globalFilter: '',
-    onGlobalFilterChange: vi.fn(),
-    pagination: { pageIndex: 0, pageSize: 20 },
-    onPaginationChange: vi.fn(),
-    columnFilters: [],
-    onColumnFiltersChange: vi.fn(),
-    filters: {
-      status: '',
-      reason: '',
-      site: '',
-      accountId: '',
-      from: '',
-      to: '',
-    },
-    updateUrlState: vi.fn(),
-  }),
-}))
+// The S7 error contract lives in the real DataTablePage; the stub honors it
+// so the page-level test verifies the page wires error/refetch correctly.
+vi.mock('@/components/data-table', async () => {
+  const { QueryErrorBanner } =
+    await import('@/components/common/query-error-banner')
+  return {
+    DataTablePage: (props: {
+      error?: Error | null
+      errorMessageKey?: string
+      onErrorRetry?: () => void
+      isErrorRetrying?: boolean
+    }) =>
+      props.error ? (
+        <QueryErrorBanner
+          error={props.error}
+          messageKey={props.errorMessageKey ?? ''}
+          onRetry={props.onErrorRetry}
+          isRetrying={props.isErrorRetrying}
+        />
+      ) : (
+        <div data-testid='checkin-table' />
+      ),
+    useDataTable: () => ({ table: {} }),
+    useUrlTableState: () => ({
+      globalFilter: '',
+      onGlobalFilterChange: vi.fn(),
+      pagination: { pageIndex: 0, pageSize: 20 },
+      onPaginationChange: vi.fn(),
+      columnFilters: [],
+      onColumnFiltersChange: vi.fn(),
+      filters: {
+        status: '',
+        reason: '',
+        site: '',
+        accountId: '',
+        from: '',
+        to: '',
+      },
+      updateUrlState: vi.fn(),
+    }),
+  }
+})
 
 vi.mock('@/features/accounts', () => ({
   useAccounts: () => ({

--- a/web/src/features/checkin/components/checkin-page.tsx
+++ b/web/src/features/checkin/components/checkin-page.tsx
@@ -20,7 +20,6 @@ import { CalendarRange, RotateCw, Users, Zap } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import {
   DataTablePage,
   type UrlTableState,
@@ -425,196 +424,192 @@ export function CheckinPage() {
         </div>
       </div>
 
-      {/* Unified list-page error contract (W19-T1 P2-o): the failed load
+      {/* Unified list-page error contract (W19-T1 P2-o → S7): the failed load
           replaces the filters + table instead of stacking over them, so a
-          stale cache can never read as current data. */}
-      {error ? (
-        <QueryErrorBanner
-          error={error as Error | null}
-          messageKey='checkin.page.loadError'
-          onRetry={() => refetch()}
-          isRetrying={isFetching}
-        />
-      ) : (
-        <>
-          <div className='flex flex-wrap items-center gap-2'>
-            <CalendarRange
-              aria-hidden='true'
-              className='text-muted-foreground size-4'
-            />
-            <Input
-              type='datetime-local'
-              value={from}
-              onChange={(event) => {
-                updateUrlState({
-                  filters: { from: event.target.value },
-                  pageIndex: 0,
-                })
-              }}
-              className='w-[200px]'
-              aria-label={t('checkin.page.startTime')}
-            />
-            <span className='text-muted-foreground text-sm'>
-              {t('checkin.page.to')}
-            </span>
-            <Input
-              type='datetime-local'
-              value={to}
-              onChange={(event) => {
-                updateUrlState({
-                  filters: { to: event.target.value },
-                  pageIndex: 0,
-                })
-              }}
-              className='w-[200px]'
-              aria-label={t('checkin.page.endTime')}
-            />
-            <Select
-              value={accountId ? String(accountId) : ACCOUNT_FILTER_ALL}
-              onValueChange={(value) => {
-                updateUrlState({
-                  filters: {
-                    accountId:
-                      !value || value === ACCOUNT_FILTER_ALL ? '' : value,
-                  },
-                  pageIndex: 0,
-                })
-              }}
-            >
-              <SelectTrigger
-                aria-label={t('checkin.page.filterAccountTitle')}
-                className='w-[200px]'
-              >
-                <SelectValue>
-                  {(selected) => {
-                    if (!selected || selected === ACCOUNT_FILTER_ALL) {
-                      return t('checkin.page.allAccounts')
-                    }
-                    const account = accountOptions.find(
-                      (item) => String(item.id) === selected
-                    )
-                    return account
-                      ? account.username || `#${account.id}`
-                      : String(selected)
-                  }}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={ACCOUNT_FILTER_ALL}>
-                  {t('checkin.page.allAccounts')}
-                </SelectItem>
-                {accountOptions.map((account) => (
-                  <SelectItem key={account.id} value={String(account.id)}>
-                    {account.username || `#${account.id}`}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {hasActiveFilters && (
-              <Button variant='ghost' size='sm' onClick={handleResetFilters}>
-                {t('checkin.page.resetFilters')}
-              </Button>
-            )}
-          </div>
-
-          <DataTablePage
-            table={table}
-            columns={columns}
-            isLoading={isLoading}
-            isFetching={isFetching}
-            emptyTitle={t('checkin.page.emptyTitle')}
-            emptyDescription={t('checkin.page.emptyDescription')}
-            emptyAction={
-              // With accounts present the CTA reuses the header's manual
-              // check-in flow (same dialog, same mutation) to generate logs;
-              // only a LOADED-AND-EMPTY account library points to the accounts
-              // page instead — while the snapshot is still fetching the CTA
-              // stays manual check-in and picks up the accounts as they land
-              // (otherwise it flashed "Manage accounts" then back).
-              !accountsLoading && accountOptions.length === 0 ? (
-                <Button
-                  variant='outline'
-                  onClick={() => void navigate({ to: '/accounts' })}
-                >
-                  <Users className='size-4' />
-                  {t('checkin.page.manageAccounts')}
-                </Button>
-              ) : (
-                <Button onClick={() => setManualOpen(true)}>
-                  <Zap className='size-4' />
-                  {t('checkin.page.manualCheckin')}
-                </Button>
-              )
-            }
-            skeletonKeyPrefix='checkin-skeleton'
-            toolbarProps={{
-              searchPlaceholder: t('checkin.page.searchPlaceholder'),
-              searchDebounceMs: 300,
-              filters: [
-                {
-                  columnId: 'status',
-                  title: t('checkin.page.filterStatusTitle'),
-                  singleSelect: true,
-                  options: [
-                    {
-                      label: t('checkin.page.filterStatusSuccess'),
-                      value: 'success',
-                    },
-                    {
-                      label: t('checkin.page.filterStatusFailed'),
-                      value: 'failed',
-                    },
-                    {
-                      label: t('checkin.page.filterStatusSkipped'),
-                      value: 'skipped',
-                    },
-                  ],
-                },
-                {
-                  columnId: 'reason',
-                  title: t('checkin.page.filterReasonTitle'),
-                  options: [
-                    {
-                      label: t('checkin.page.filterReasonVerification'),
-                      value: 'verification',
-                    },
-                    {
-                      label: t('checkin.page.filterReasonAuth'),
-                      value: 'auth',
-                    },
-                    {
-                      label: t('checkin.page.filterReasonNetwork'),
-                      value: 'network',
-                    },
-                    {
-                      label: t('checkin.page.filterReasonSite'),
-                      value: 'site',
-                    },
-                    {
-                      label: t('checkin.page.filterReasonState'),
-                      value: 'state',
-                    },
-                    {
-                      label: t('checkin.page.filterReasonUnknown'),
-                      value: 'unknown',
-                    },
-                  ],
-                },
-                ...(siteOptions.length > 0
-                  ? [
-                      {
-                        columnId: 'site',
-                        title: t('checkin.page.filterSiteTitle'),
-                        options: siteOptions,
-                      },
-                    ]
-                  : []),
-              ],
-              onReset: handleResetFilters,
-            }}
+          stale cache can never read as current data. The banner itself is
+          owned by DataTablePage; the custom filter bar gates on !error. */}
+      {!error && (
+        <div className='flex flex-wrap items-center gap-2'>
+          <CalendarRange
+            aria-hidden='true'
+            className='text-muted-foreground size-4'
           />
-        </>
+          <Input
+            type='datetime-local'
+            value={from}
+            onChange={(event) => {
+              updateUrlState({
+                filters: { from: event.target.value },
+                pageIndex: 0,
+              })
+            }}
+            className='w-[200px]'
+            aria-label={t('checkin.page.startTime')}
+          />
+          <span className='text-muted-foreground text-sm'>
+            {t('checkin.page.to')}
+          </span>
+          <Input
+            type='datetime-local'
+            value={to}
+            onChange={(event) => {
+              updateUrlState({
+                filters: { to: event.target.value },
+                pageIndex: 0,
+              })
+            }}
+            className='w-[200px]'
+            aria-label={t('checkin.page.endTime')}
+          />
+          <Select
+            value={accountId ? String(accountId) : ACCOUNT_FILTER_ALL}
+            onValueChange={(value) => {
+              updateUrlState({
+                filters: {
+                  accountId:
+                    !value || value === ACCOUNT_FILTER_ALL ? '' : value,
+                },
+                pageIndex: 0,
+              })
+            }}
+          >
+            <SelectTrigger
+              aria-label={t('checkin.page.filterAccountTitle')}
+              className='w-[200px]'
+            >
+              <SelectValue>
+                {(selected) => {
+                  if (!selected || selected === ACCOUNT_FILTER_ALL) {
+                    return t('checkin.page.allAccounts')
+                  }
+                  const account = accountOptions.find(
+                    (item) => String(item.id) === selected
+                  )
+                  return account
+                    ? account.username || `#${account.id}`
+                    : String(selected)
+                }}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ACCOUNT_FILTER_ALL}>
+                {t('checkin.page.allAccounts')}
+              </SelectItem>
+              {accountOptions.map((account) => (
+                <SelectItem key={account.id} value={String(account.id)}>
+                  {account.username || `#${account.id}`}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {hasActiveFilters && (
+            <Button variant='ghost' size='sm' onClick={handleResetFilters}>
+              {t('checkin.page.resetFilters')}
+            </Button>
+          )}
+        </div>
       )}
+
+      <DataTablePage
+        table={table}
+        columns={columns}
+        isLoading={isLoading}
+        isFetching={isFetching}
+        error={error as Error | null}
+        errorMessageKey='checkin.page.loadError'
+        onErrorRetry={() => refetch()}
+        isErrorRetrying={isFetching}
+        emptyTitle={t('checkin.page.emptyTitle')}
+        emptyDescription={t('checkin.page.emptyDescription')}
+        emptyAction={
+          // With accounts present the CTA reuses the header's manual
+          // check-in flow (same dialog, same mutation) to generate logs;
+          // only a LOADED-AND-EMPTY account library points to the accounts
+          // page instead — while the snapshot is still fetching the CTA
+          // stays manual check-in and picks up the accounts as they land
+          // (otherwise it flashed "Manage accounts" then back).
+          !accountsLoading && accountOptions.length === 0 ? (
+            <Button
+              variant='outline'
+              onClick={() => void navigate({ to: '/accounts' })}
+            >
+              <Users className='size-4' />
+              {t('checkin.page.manageAccounts')}
+            </Button>
+          ) : (
+            <Button onClick={() => setManualOpen(true)}>
+              <Zap className='size-4' />
+              {t('checkin.page.manualCheckin')}
+            </Button>
+          )
+        }
+        skeletonKeyPrefix='checkin-skeleton'
+        toolbarProps={{
+          searchPlaceholder: t('checkin.page.searchPlaceholder'),
+          searchDebounceMs: 300,
+          filters: [
+            {
+              columnId: 'status',
+              title: t('checkin.page.filterStatusTitle'),
+              singleSelect: true,
+              options: [
+                {
+                  label: t('checkin.page.filterStatusSuccess'),
+                  value: 'success',
+                },
+                {
+                  label: t('checkin.page.filterStatusFailed'),
+                  value: 'failed',
+                },
+                {
+                  label: t('checkin.page.filterStatusSkipped'),
+                  value: 'skipped',
+                },
+              ],
+            },
+            {
+              columnId: 'reason',
+              title: t('checkin.page.filterReasonTitle'),
+              options: [
+                {
+                  label: t('checkin.page.filterReasonVerification'),
+                  value: 'verification',
+                },
+                {
+                  label: t('checkin.page.filterReasonAuth'),
+                  value: 'auth',
+                },
+                {
+                  label: t('checkin.page.filterReasonNetwork'),
+                  value: 'network',
+                },
+                {
+                  label: t('checkin.page.filterReasonSite'),
+                  value: 'site',
+                },
+                {
+                  label: t('checkin.page.filterReasonState'),
+                  value: 'state',
+                },
+                {
+                  label: t('checkin.page.filterReasonUnknown'),
+                  value: 'unknown',
+                },
+              ],
+            },
+            ...(siteOptions.length > 0
+              ? [
+                  {
+                    columnId: 'site',
+                    title: t('checkin.page.filterSiteTitle'),
+                    options: siteOptions,
+                  },
+                ]
+              : []),
+          ],
+          onReset: handleResetFilters,
+        }}
+      />
 
       <CheckinDetailSheet
         row={detailRow}

--- a/web/src/features/models/__tests__/models-page-error-contract.test.tsx
+++ b/web/src/features/models/__tests__/models-page-error-contract.test.tsx
@@ -27,24 +27,45 @@ vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn(),
 }))
 
-vi.mock('@/components/data-table', () => ({
-  DataTablePage: () => <div data-testid='models-table' />,
-  useUrlTableState: () => ({
-    globalFilter: '',
-    onGlobalFilterChange: vi.fn(),
-    columnFilters: [],
-    onColumnFiltersChange: vi.fn(),
-    pagination: { pageIndex: 0, pageSize: 20 },
-    onPaginationChange: vi.fn(),
-    ensurePageInRange: vi.fn(),
-  }),
-  useDataTable: () => ({
-    table: {
-      getFilteredSelectedRowModel: () => ({ rows: [] }),
-      resetRowSelection: vi.fn(),
-    },
-  }),
-}))
+vi.mock('@/components/data-table', async () => {
+  const { QueryErrorBanner } =
+    await import('@/components/common/query-error-banner')
+  // The S7 error contract lives in the real DataTablePage; the stub honors it
+  // so the page-level test verifies the page wires error/refetch correctly.
+  return {
+    DataTablePage: (props: {
+      error?: Error | null
+      errorMessageKey?: string
+      onErrorRetry?: () => void
+      isErrorRetrying?: boolean
+    }) =>
+      props.error ? (
+        <QueryErrorBanner
+          error={props.error}
+          messageKey={props.errorMessageKey ?? ''}
+          onRetry={props.onErrorRetry}
+          isRetrying={props.isErrorRetrying}
+        />
+      ) : (
+        <div data-testid='models-table' />
+      ),
+    useUrlTableState: () => ({
+      globalFilter: '',
+      onGlobalFilterChange: vi.fn(),
+      columnFilters: [],
+      onColumnFiltersChange: vi.fn(),
+      pagination: { pageIndex: 0, pageSize: 20 },
+      onPaginationChange: vi.fn(),
+      ensurePageInRange: vi.fn(),
+    }),
+    useDataTable: () => ({
+      table: {
+        getFilteredSelectedRowModel: () => ({ rows: [] }),
+        resetRowSelection: vi.fn(),
+      },
+    }),
+  }
+})
 
 vi.mock('../api', () => ({
   useModelsPage: () => testState.modelsQuery,

--- a/web/src/features/models/components/models-page.tsx
+++ b/web/src/features/models/components/models-page.tsx
@@ -20,7 +20,6 @@ import {
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import {
   DataTablePage,
   encodeSorting,
@@ -300,83 +299,78 @@ export function ModelsPage() {
         </p>
       </div>
 
-      {/* Unified list-page error contract (W19-T1 P2-o): the failed load
+      {/* Unified list-page error contract (W19-T1 P2-o → S7): the failed load
           replaces the table instead of stacking over it, so a stale cache can
           never read as current data. Query object is the S9 server-side
           paged one (modelsPageQuery). */}
-      {modelsPageQuery.error ? (
-        <QueryErrorBanner
-          error={modelsPageQuery.error as Error | null}
-          messageKey='models.page.loadError'
-          onRetry={() => modelsPageQuery.refetch()}
-          isRetrying={modelsPageQuery.isFetching}
-        />
-      ) : (
-        <DataTablePage
-          table={table}
-          columns={columns}
-          isLoading={modelsPageQuery.isLoading}
-          isFetching={modelsPageQuery.isFetching}
-          emptyTitle={t('models.empty.title')}
-          emptyDescription={t('models.empty.description')}
-          emptyAction={
-            <Button
-              variant='outline'
-              onClick={() => void navigate({ to: '/accounts' })}
-            >
-              <UsersIcon className='size-4' />
-              {t('models.empty.manageAccounts')}
-            </Button>
-          }
-          skeletonKeyPrefix='model-skeleton'
-          toolbarProps={{
-            searchPlaceholder: t('models.toolbar.searchPlaceholder'),
-            searchDebounceMs: 400,
-            filters: [
-              {
-                columnId: 'brand',
-                title: t('models.columns.brand'),
-                options: brandFilterOptions,
-              },
-              {
-                columnId: 'endpointTypes',
-                title: t('models.columns.endpointTypes'),
-                options: endpointTypeFilterOptions,
-              },
-              {
-                columnId: 'capabilities',
-                title: t('models.columns.capabilities'),
-                options: capabilityFilterOptions,
-              },
-            ],
-            preActions: (
-              <>
-                <Button
-                  variant='outline'
-                  size='sm'
-                  onClick={() => setVerifyOpen(true)}
-                >
-                  <FlaskConicalIcon className='size-3.5' />
-                  {t('models.toolbar.batchProbe')}
-                </Button>
-                <Button
-                  variant='outline'
-                  size='sm'
-                  onClick={() => refreshMutation.mutate()}
-                  disabled={refreshMutation.isPending}
-                >
-                  {refreshMutation.isPending ? (
-                    <Spinner />
-                  ) : (
-                    <RefreshCwIcon className='size-3.5' />
-                  )}
-                  {t('models.toolbar.refresh')}
-                </Button>
-              </>
-            ),
-          }}
-        />
-      )}
+      <DataTablePage
+        table={table}
+        columns={columns}
+        isLoading={modelsPageQuery.isLoading}
+        isFetching={modelsPageQuery.isFetching}
+        error={modelsPageQuery.error as Error | null}
+        errorMessageKey='models.page.loadError'
+        onErrorRetry={() => modelsPageQuery.refetch()}
+        isErrorRetrying={modelsPageQuery.isFetching}
+        emptyTitle={t('models.empty.title')}
+        emptyDescription={t('models.empty.description')}
+        emptyAction={
+          <Button
+            variant='outline'
+            onClick={() => void navigate({ to: '/accounts' })}
+          >
+            <UsersIcon className='size-4' />
+            {t('models.empty.manageAccounts')}
+          </Button>
+        }
+        skeletonKeyPrefix='model-skeleton'
+        toolbarProps={{
+          searchPlaceholder: t('models.toolbar.searchPlaceholder'),
+          searchDebounceMs: 400,
+          filters: [
+            {
+              columnId: 'brand',
+              title: t('models.columns.brand'),
+              options: brandFilterOptions,
+            },
+            {
+              columnId: 'endpointTypes',
+              title: t('models.columns.endpointTypes'),
+              options: endpointTypeFilterOptions,
+            },
+            {
+              columnId: 'capabilities',
+              title: t('models.columns.capabilities'),
+              options: capabilityFilterOptions,
+            },
+          ],
+          preActions: (
+            <>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => setVerifyOpen(true)}
+              >
+                <FlaskConicalIcon className='size-3.5' />
+                {t('models.toolbar.batchProbe')}
+              </Button>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => refreshMutation.mutate()}
+                disabled={refreshMutation.isPending}
+              >
+                {refreshMutation.isPending ? (
+                  <Spinner />
+                ) : (
+                  <RefreshCwIcon className='size-3.5' />
+                )}
+                {t('models.toolbar.refresh')}
+              </Button>
+            </>
+          ),
+        }}
+      />
 
       <ModelDetailSheet
         model={viewingModel}

--- a/web/src/features/oauth/components/oauth-page.tsx
+++ b/web/src/features/oauth/components/oauth-page.tsx
@@ -21,7 +21,6 @@ import { Plus as PlusIcon } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import {
   DataTablePage,
   encodeSorting,
@@ -302,17 +301,16 @@ export function OAuthPage() {
         </p>
       </div>
 
-      <QueryErrorBanner
-        error={connectionsQuery.error as Error | null}
-        messageKey='oauth.page.loadError'
-        onRetry={() => connectionsQuery.refetch()}
-        isRetrying={connectionsQuery.isFetching}
-      />
       <DataTablePage
         table={table}
         columns={columns}
         isLoading={connectionsQuery.isLoading}
         isFetching={connectionsQuery.isFetching}
+        error={connectionsQuery.error as Error | null}
+        errorMessageKey='oauth.page.loadError'
+        onErrorRetry={() => connectionsQuery.refetch()}
+        isErrorRetrying={connectionsQuery.isFetching}
+        errorPlacement='inline'
         emptyTitle={t('oauth.empty.title')}
         emptyDescription={t('oauth.empty.description')}
         emptyAction={

--- a/web/src/features/proxy-logs/components/proxy-logs-page.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-page.tsx
@@ -439,19 +439,17 @@ export function ProxyLogsPage() {
         isRetrying={metaQuery.isFetching}
       />
 
-      <QueryErrorBanner
-        error={logsQuery.error as Error | null}
-        messageKey='proxyLogs.page.loadError'
-        onRetry={() => logsQuery.refetch()}
-        isRetrying={logsQuery.isFetching}
-      />
-
       <DataTablePage
         table={table}
         columns={columns}
         renderRow={renderRow}
         isLoading={logsQuery.isLoading}
         isFetching={logsQuery.isFetching}
+        error={logsQuery.error as Error | null}
+        errorMessageKey='proxyLogs.page.loadError'
+        onErrorRetry={() => logsQuery.refetch()}
+        isErrorRetrying={logsQuery.isFetching}
+        errorPlacement='inline'
         emptyTitle={t('proxyLogs.page.emptyTitle')}
         emptyDescription={t('proxyLogs.page.emptyDescription')}
         emptyAction={

--- a/web/src/features/sites/components/__tests__/sites-page.test.tsx
+++ b/web/src/features/sites/components/__tests__/sites-page.test.tsx
@@ -39,33 +39,54 @@ vi.mock('@tanstack/react-router', () => ({
   useSearch: () => testState.search,
 }))
 
-vi.mock('@/components/data-table', () => ({
-  DataTableBulkActions: () => null,
-  // Sentinel component so the error-state test can assert the table page is
-  // NOT rendered (and therefore the empty-state CTA inside it is absent).
-  DataTablePage: () => {
-    testState.dataTableRendered = true
-    return null
-  },
-  useUrlTableState: () => ({
-    globalFilter: '',
-    onGlobalFilterChange: vi.fn(),
-    columnFilters: [],
-    onColumnFiltersChange: vi.fn(),
-    pagination: { pageIndex: 0, pageSize: 20 },
-    onPaginationChange: vi.fn(),
-    sorting: [],
-    onSortingChange: vi.fn(),
-    ensurePageInRange: vi.fn(),
-  }),
-  useDataTable: () => ({
-    table: {
-      getFilteredSelectedRowModel: () => ({ rows: [] }),
-      resetRowSelection: vi.fn(),
+vi.mock('@/components/data-table', async () => {
+  const { QueryErrorBanner } =
+    await import('@/components/common/query-error-banner')
+  return {
+    DataTableBulkActions: () => null,
+    // Sentinel component so the error-state test can assert the table page is
+    // NOT rendered (and therefore the empty-state CTA inside it is absent).
+    // The S7 error contract lives in the real DataTablePage; the stub honors
+    // it so the page-level test verifies the error/refetch wiring.
+    DataTablePage: (props: {
+      error?: Error | null
+      errorMessageKey?: string
+      onErrorRetry?: () => void
+      isErrorRetrying?: boolean
+    }) => {
+      if (props.error) {
+        return (
+          <QueryErrorBanner
+            error={props.error}
+            messageKey={props.errorMessageKey ?? ''}
+            onRetry={props.onErrorRetry}
+            isRetrying={props.isErrorRetrying}
+          />
+        )
+      }
+      testState.dataTableRendered = true
+      return null
     },
-  }),
-  encodeSorting: () => '',
-}))
+    useUrlTableState: () => ({
+      globalFilter: '',
+      onGlobalFilterChange: vi.fn(),
+      columnFilters: [],
+      onColumnFiltersChange: vi.fn(),
+      pagination: { pageIndex: 0, pageSize: 20 },
+      onPaginationChange: vi.fn(),
+      sorting: [],
+      onSortingChange: vi.fn(),
+      ensurePageInRange: vi.fn(),
+    }),
+    useDataTable: () => ({
+      table: {
+        getFilteredSelectedRowModel: () => ({ rows: [] }),
+        resetRowSelection: vi.fn(),
+      },
+    }),
+    encodeSorting: () => '',
+  }
+})
 
 vi.mock('@/features/accounts', () => ({
   useAccounts: () => ({ data: { accounts: [] }, isLoading: false }),

--- a/web/src/features/sites/components/sites-page.tsx
+++ b/web/src/features/sites/components/sites-page.tsx
@@ -19,7 +19,6 @@ import {
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import {
   DataTableBulkActions,
   DataTablePage,
@@ -463,112 +462,107 @@ export function SitesPage() {
         </p>
       </div>
 
-      {sitesQuery.error ? (
-        <QueryErrorBanner
-          error={sitesQuery.error as Error | null}
-          messageKey='sites.page.loadError'
-          onRetry={() => sitesQuery.refetch()}
-          isRetrying={sitesQuery.isFetching}
-        />
-      ) : (
-        <DataTablePage
-          table={table}
-          columns={columns}
-          isLoading={sitesQuery.isLoading}
-          isFetching={sitesQuery.isFetching}
-          emptyTitle={t('sites.empty.title')}
-          emptyDescription={t('sites.empty.description')}
-          emptyAction={
+      <DataTablePage
+        table={table}
+        columns={columns}
+        isLoading={sitesQuery.isLoading}
+        isFetching={sitesQuery.isFetching}
+        error={sitesQuery.error as Error | null}
+        errorMessageKey='sites.page.loadError'
+        onErrorRetry={() => sitesQuery.refetch()}
+        isErrorRetrying={sitesQuery.isFetching}
+        emptyTitle={t('sites.empty.title')}
+        emptyDescription={t('sites.empty.description')}
+        emptyAction={
+          <>
+            <Button onClick={() => setImportOpen(true)}>
+              <UploadIcon className='size-4' />
+              {t('sites.empty.import')}
+            </Button>
+            <Button variant='outline' onClick={handleAddSite}>
+              <PlusIcon className='size-4' />
+              {t('sites.empty.addSite')}
+            </Button>
+          </>
+        }
+        skeletonKeyPrefix='site-skeleton'
+        toolbarProps={{
+          searchPlaceholder: t('sites.toolbar.searchPlaceholder'),
+          searchDebounceMs: 400,
+          filters: [
+            {
+              columnId: 'status',
+              title: t('sites.columns.status'),
+              options: statusFilters,
+              singleSelect: true,
+            },
+          ],
+          preActions: (
             <>
-              <Button onClick={() => setImportOpen(true)}>
-                <UploadIcon className='size-4' />
-                {t('sites.empty.import')}
-              </Button>
-              <Button variant='outline' onClick={handleAddSite}>
+              <Button onClick={handleAddSite}>
                 <PlusIcon className='size-4' />
-                {t('sites.empty.addSite')}
+                {t('sites.toolbar.addSite')}
               </Button>
-            </>
-          }
-          skeletonKeyPrefix='site-skeleton'
-          toolbarProps={{
-            searchPlaceholder: t('sites.toolbar.searchPlaceholder'),
-            searchDebounceMs: 400,
-            filters: [
-              {
-                columnId: 'status',
-                title: t('sites.columns.status'),
-                options: statusFilters,
-                singleSelect: true,
-              },
-            ],
-            preActions: (
-              <>
-                <Button onClick={handleAddSite}>
-                  <PlusIcon className='size-4' />
-                  {t('sites.toolbar.addSite')}
-                </Button>
-                {/* The wizard was only reachable from the empty-state CTA,
+              {/* The wizard was only reachable from the empty-state CTA,
                     i.e. unreachable once the first site existed — keep a
                     permanent toolbar entry. The wizard is the only flow that
                     creates sites together with their accounts in one batch. */}
-                <Button variant='outline' onClick={() => setImportOpen(true)}>
-                  <UploadIcon className='size-4' />
-                  {t('sites.toolbar.import')}
-                </Button>
-              </>
-            ),
-          }}
-          bulkActions={
-            <DataTableBulkActions
-              table={table}
-              entityName={t('sites.entityName')}
+              <Button variant='outline' onClick={() => setImportOpen(true)}>
+                <UploadIcon className='size-4' />
+                {t('sites.toolbar.import')}
+              </Button>
+            </>
+          ),
+        }}
+        bulkActions={
+          <DataTableBulkActions
+            table={table}
+            entityName={t('sites.entityName')}
+          >
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={() => handleBulkAction('enable')}
+              disabled={batchUpdateSites.isPending}
             >
-              <Button
-                variant='outline'
-                size='sm'
-                onClick={() => handleBulkAction('enable')}
-                disabled={batchUpdateSites.isPending}
-              >
-                {t('sites.bulk.enable')}
-              </Button>
-              <Button
-                variant='outline'
-                size='sm'
-                onClick={() => handleBulkAction('disable')}
-                disabled={batchUpdateSites.isPending}
-              >
-                {t('sites.bulk.disable')}
-              </Button>
-              <Button
-                variant='outline'
-                size='sm'
-                onClick={() => handleBulkAction('enableSystemProxy')}
-                disabled={batchUpdateSites.isPending}
-              >
-                {t('sites.bulk.enableSystemProxy')}
-              </Button>
-              <Button
-                variant='outline'
-                size='sm'
-                onClick={() => handleBulkAction('disableSystemProxy')}
-                disabled={batchUpdateSites.isPending}
-              >
-                {t('sites.bulk.disableSystemProxy')}
-              </Button>
-              <Button
-                variant='destructive'
-                size='sm'
-                onClick={() => handleBulkAction('delete')}
-                disabled={batchUpdateSites.isPending}
-              >
-                <Trash2Icon className='size-3.5' />
-                {t('sites.bulk.delete')}
-              </Button>
-            </DataTableBulkActions>
-          }
-        />
-      )}
+              {t('sites.bulk.enable')}
+            </Button>
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={() => handleBulkAction('disable')}
+              disabled={batchUpdateSites.isPending}
+            >
+              {t('sites.bulk.disable')}
+            </Button>
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={() => handleBulkAction('enableSystemProxy')}
+              disabled={batchUpdateSites.isPending}
+            >
+              {t('sites.bulk.enableSystemProxy')}
+            </Button>
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={() => handleBulkAction('disableSystemProxy')}
+              disabled={batchUpdateSites.isPending}
+            >
+              {t('sites.bulk.disableSystemProxy')}
+            </Button>
+            <Button
+              variant='destructive'
+              size='sm'
+              onClick={() => handleBulkAction('delete')}
+              disabled={batchUpdateSites.isPending}
+            >
+              <Trash2Icon className='size-3.5' />
+              {t('sites.bulk.delete')}
+            </Button>
+          </DataTableBulkActions>
+        }
+      />
 
       <SiteFormSheet
         open={formOpen}

--- a/web/src/features/token-routes/components/__tests__/routes-page.test.tsx
+++ b/web/src/features/token-routes/components/__tests__/routes-page.test.tsx
@@ -37,31 +37,53 @@ const testState = vi.hoisted(() => ({
   previousFormOpen: undefined as boolean | undefined,
 }))
 
-vi.mock('@/components/data-table', () => ({
-  DataTableBulkActions: () => null,
-  DataTablePage: (props: { emptyAction?: ReactNode }) => {
-    testState.dataTableRendered = true
-    testState.capturedEmptyAction = props.emptyAction ?? null
-    return null
-  },
-  useUrlTableState: () => ({
-    globalFilter: '',
-    onGlobalFilterChange: vi.fn(),
-    columnFilters: [],
-    onColumnFiltersChange: vi.fn(),
-    pagination: { pageIndex: 0, pageSize: 20 },
-    onPaginationChange: vi.fn(),
-    sorting: [],
-    onSortingChange: vi.fn(),
-    filters: { enabled: '', accountId: '', siteId: '', routeId: '' },
-  }),
-  useDataTable: () => ({
-    table: {
-      getFilteredSelectedRowModel: () => ({ rows: [] }),
-      resetRowSelection: vi.fn(),
+vi.mock('@/components/data-table', async () => {
+  const { QueryErrorBanner } =
+    await import('@/components/common/query-error-banner')
+  return {
+    DataTableBulkActions: () => null,
+    // The S7 error contract lives in the real DataTablePage; the stub honors
+    // it so the page-level test verifies the error/refetch wiring.
+    DataTablePage: (props: {
+      emptyAction?: ReactNode
+      error?: Error | null
+      errorMessageKey?: string
+      onErrorRetry?: () => void
+      isErrorRetrying?: boolean
+    }) => {
+      if (props.error) {
+        return (
+          <QueryErrorBanner
+            error={props.error}
+            messageKey={props.errorMessageKey ?? ''}
+            onRetry={props.onErrorRetry}
+            isRetrying={props.isErrorRetrying}
+          />
+        )
+      }
+      testState.dataTableRendered = true
+      testState.capturedEmptyAction = props.emptyAction ?? null
+      return null
     },
-  }),
-}))
+    useUrlTableState: () => ({
+      globalFilter: '',
+      onGlobalFilterChange: vi.fn(),
+      columnFilters: [],
+      onColumnFiltersChange: vi.fn(),
+      pagination: { pageIndex: 0, pageSize: 20 },
+      onPaginationChange: vi.fn(),
+      sorting: [],
+      onSortingChange: vi.fn(),
+      filters: { enabled: '', accountId: '', siteId: '', routeId: '' },
+    }),
+    useDataTable: () => ({
+      table: {
+        getFilteredSelectedRowModel: () => ({ rows: [] }),
+        resetRowSelection: vi.fn(),
+      },
+    }),
+  }
+})
 
 vi.mock('@tanstack/react-router', () => ({
   useSearch: () => ({}),

--- a/web/src/features/token-routes/components/routes-page.tsx
+++ b/web/src/features/token-routes/components/routes-page.tsx
@@ -9,7 +9,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ConfirmDialog } from '@/components/common/confirm-dialog'
-import { QueryErrorBanner } from '@/components/common/query-error-banner'
 import {
   DataTableBulkActions,
   DataTablePage,
@@ -445,80 +444,75 @@ export function RoutesPage() {
         </div>
       )}
 
-      {error ? (
-        <QueryErrorBanner
-          error={error as Error | null}
-          messageKey='tokenRoutes.page.loadError'
-          onRetry={() => refetch()}
-          isRetrying={isFetching}
-        />
-      ) : (
-        <DataTablePage
-          table={table}
-          columns={columns}
-          isLoading={isLoading}
-          isFetching={isFetching}
-          emptyTitle={t('tokenRoutes.page.emptyTitle')}
-          emptyDescription={t('tokenRoutes.page.emptyDescription')}
-          emptyAction={
-            <div className='flex items-center gap-2'>
-              <Button onClick={openCreate}>
-                <Plus />
-                {t('tokenRoutes.page.addButton')}
-              </Button>
-              <Button
-                variant='outline'
-                onClick={() => setRebuildConfirmOpen(true)}
-                disabled={rebuildMutation.isPending}
-              >
-                {rebuildMutation.isPending ? <Spinner /> : <Zap />}
-                {t('tokenRoutes.page.rebuild')}
-              </Button>
-            </div>
-          }
-          skeletonKeyPrefix='routes-skeleton'
-          toolbarProps={{
-            searchPlaceholder: t('tokenRoutes.page.searchPlaceholder'),
-            searchDebounceMs: 300,
-            viewToggle: (
-              // min-w-0 + truncated span so the long "显示零通道模型…" label
-              // can shrink on narrow viewports instead of pushing the View
-              // Options button past the toolbar edge (375px overflow fix).
-              <label
-                className='text-muted-foreground flex min-w-0 items-center gap-1.5 text-sm'
-                title={t('tokenRoutes.page.showZeroChannel')}
-              >
-                <Switch
-                  className='shrink-0'
-                  checked={showZeroChannel}
-                  onCheckedChange={setShowZeroChannel}
-                />
-                <span className='max-w-[150px] min-w-0 truncate sm:max-w-[280px]'>
-                  {t('tokenRoutes.page.showZeroChannel')}
-                </span>
-              </label>
-            ),
-            filters: [
-              {
-                columnId: 'enabled',
-                title: t('tokenRoutes.page.filterStatusTitle'),
-                singleSelect: true,
-                options: [
-                  {
-                    label: t('tokenRoutes.page.filterStatusEnabled'),
-                    value: 'enabled',
-                  },
-                  {
-                    label: t('tokenRoutes.page.filterStatusDisabled'),
-                    value: 'disabled',
-                  },
-                ],
-              },
-            ],
-          }}
-          bulkActions={<RoutesBulkActions table={table} />}
-        />
-      )}
+      <DataTablePage
+        table={table}
+        columns={columns}
+        isLoading={isLoading}
+        isFetching={isFetching}
+        error={error as Error | null}
+        errorMessageKey='tokenRoutes.page.loadError'
+        onErrorRetry={() => refetch()}
+        isErrorRetrying={isFetching}
+        emptyTitle={t('tokenRoutes.page.emptyTitle')}
+        emptyDescription={t('tokenRoutes.page.emptyDescription')}
+        emptyAction={
+          <div className='flex items-center gap-2'>
+            <Button onClick={openCreate}>
+              <Plus />
+              {t('tokenRoutes.page.addButton')}
+            </Button>
+            <Button
+              variant='outline'
+              onClick={() => setRebuildConfirmOpen(true)}
+              disabled={rebuildMutation.isPending}
+            >
+              {rebuildMutation.isPending ? <Spinner /> : <Zap />}
+              {t('tokenRoutes.page.rebuild')}
+            </Button>
+          </div>
+        }
+        skeletonKeyPrefix='routes-skeleton'
+        toolbarProps={{
+          searchPlaceholder: t('tokenRoutes.page.searchPlaceholder'),
+          searchDebounceMs: 300,
+          viewToggle: (
+            // min-w-0 + truncated span so the long "显示零通道模型…" label
+            // can shrink on narrow viewports instead of pushing the View
+            // Options button past the toolbar edge (375px overflow fix).
+            <label
+              className='text-muted-foreground flex min-w-0 items-center gap-1.5 text-sm'
+              title={t('tokenRoutes.page.showZeroChannel')}
+            >
+              <Switch
+                className='shrink-0'
+                checked={showZeroChannel}
+                onCheckedChange={setShowZeroChannel}
+              />
+              <span className='max-w-[150px] min-w-0 truncate sm:max-w-[280px]'>
+                {t('tokenRoutes.page.showZeroChannel')}
+              </span>
+            </label>
+          ),
+          filters: [
+            {
+              columnId: 'enabled',
+              title: t('tokenRoutes.page.filterStatusTitle'),
+              singleSelect: true,
+              options: [
+                {
+                  label: t('tokenRoutes.page.filterStatusEnabled'),
+                  value: 'enabled',
+                },
+                {
+                  label: t('tokenRoutes.page.filterStatusDisabled'),
+                  value: 'disabled',
+                },
+              ],
+            },
+          ],
+        }}
+        bulkActions={<RoutesBulkActions table={table} />}
+      />
 
       <RouteFormDialog
         open={formOpen}


### PR DESCRIPTION
## 背景

#1035 S7 的「三态契约集中化」：8 个 DataTablePage 列表页各自手写 `{error ? <QueryErrorBanner/> : <DataTablePage/>}` 分支（W19 统一的是组件，不是挂载点）。本 PR 把第三态收进 DataTablePage 底座。

随车一项小修：accounts 页头窄视口挤压（375px 下「+ 添加账号」按钮截断描述首行）→ flex-wrap + gap-3 对齐 checkin/routes 模式（commit 57e9183，已截图验证）。

## 改动

- **底座**：`DataTablePage` 新增 `error / errorMessageKey / onErrorRetry / isErrorRetrying / errorPlacement`（判别联合：传 error 必传 errorMessageKey，编译期强制）。`replace`（默认）= 横幅替换整个表格区（沿用 W19「stale cache 不可读作现行数据」语义）；`inline` = 横幅悬于表格上方（placeholderData 行保持可见）。
- **迁移 8 页**：sites / models / accounts / routes / checkin（自定义过滤条改 `{!error && ...}` 门控）/ channels（errorSummary 条不动，主查询分支迁移）/ oauth（inline）/ proxy-logs（logsQuery inline；metaQuery 独立横幅不动）。非 DataTablePage 页继续直接共用 QueryErrorBanner。
- **测试分层**：组件级新增 replace/inline/retry 三钉（真组件、真 i18n）；6 个页面级错误契约测试的 DataTablePage stub 改为兑现委托契约（吃 error props 渲染真 QueryErrorBanner）；retry-icon-consistency 静态守卫改断言新委托形态。
- **零行为变化**：替换式/内联式逐页对齐原分支语义；全量 vitest 1541 绿 + format/lint/knip/typecheck 全过 + 8 页双视口截图人工复核无回归。