### PR TITLE
fix(web): let the accounts page header action wrap below on narrow viewports

### DIFF
--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -555,7 +555,10 @@ export function AccountsPage() {
 
   return (
     <div className='flex h-full flex-col gap-3 p-4'>
-      <div className='flex items-center justify-between'>
+      {/* flex-wrap + gap-3: on narrow viewports the action button wraps
+          below the title block instead of squeezing the description column
+          (aligns with the checkin/routes page-header pattern). */}
+      <div className='flex flex-wrap items-center justify-between gap-3'>
         <div>
           <h1 className='text-lg font-normal'>{t('accounts.page.title')}</h1>
           <p className='text-muted-foreground text-sm'>


### PR DESCRIPTION
375px 下页头 `flex items-center justify-between`（无 wrap/gap）让「+ 添加账号」按钮挤压描述列、截断首行文本（截图证据：修复前描述首行在按钮处被切断）。

修复：对齐 checkin/routes 页头模式 `flex flex-wrap items-center justify-between gap-3`——窄屏下按钮换行独立成行，描述全宽换行。已用 375×812 真机视口截图复核（修复后描述完整两行 + 按钮独立行）。

注：此提交原随 #1084 推送，因 gh merge --delete-branch 抽空本地分支导致推送失败，现独立成 PR（cherry-pick 内容不变）。