### PR TITLE
feat(web): sr-only data summaries for the latency charts (S10, #1035)

### DIFF
--- a/web/src/features/dashboard/sections/models/__tests__/models-section-chart-summary.test.tsx
+++ b/web/src/features/dashboard/sections/models/__tests__/models-section-chart-summary.test.tsx
@@ -1,6 +1,6 @@
-// S10 (#1035): the model-cost donut exposes an sr-only data summary table
-// built from the already-loaded cost rows (series x key points: cost,
-// requests, tokens, share). Latency charts keep text-only empty states.
+// S10 (#1035): the model-cost donut and both latency charts expose sr-only
+// data summary tables built from the already-loaded rows (series x key
+// points; histogram → bucket x count, trend → series x latest/window avg).
 import '@testing-library/jest-dom/vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, render, screen } from '@testing-library/react'
@@ -121,5 +121,63 @@ describe('ModelsSection cost data summary (S10)', () => {
 
     await screen.findAllByText('Failed to load model / latency data.')
     expect(screen.queryByRole('table')).toBeNull()
+  })
+})
+
+describe('ModelsSection latency chart summaries (S10)', () => {
+  it('exposes bucket × count rows for the latency histogram', async () => {
+    mockHistogram.mockResolvedValue({
+      buckets: [
+        { label: '0-100ms', count: 5 },
+        { label: '100-300ms', count: 3 },
+      ],
+    })
+    renderSection()
+
+    const table = await screen.findByRole('table', {
+      name: 'Latency histogram',
+    })
+    expect(table).toHaveClass('sr-only')
+    expect(table).toHaveTextContent('Latency bucket')
+    expect(table).toHaveTextContent('Calls')
+    expect(table).toHaveTextContent('0-100ms')
+    expect(table).toHaveTextContent('100-300ms')
+  })
+
+  it('exposes latest-day and window-average values for the latency trend', async () => {
+    mockTrend.mockResolvedValue({
+      points: [
+        { date: '2026-08-28', avgLatencyMs: 100, p95LatencyMs: 200 },
+        { date: '2026-08-29', avgLatencyMs: 300, p95LatencyMs: 500 },
+      ],
+    })
+    renderSection()
+
+    const table = await screen.findByRole('table', { name: 'Latency trend' })
+    expect(table).toHaveClass('sr-only')
+    // avg series: latest 300ms, window mean (100+300)/2 = 200ms
+    // p95 series: latest 500ms, window mean (200+500)/2 = 350ms
+    expect(table).toHaveTextContent('300ms')
+    expect(table).toHaveTextContent('200ms')
+    expect(table).toHaveTextContent('500ms')
+    expect(table).toHaveTextContent('350ms')
+    expect(table).toHaveTextContent('Latest day')
+    expect(table).toHaveTextContent('Average')
+  })
+
+  it('renders no latency summary while the latency queries fail', async () => {
+    mockHistogram.mockRejectedValue(new Error('hist boom'))
+    mockTrend.mockRejectedValue(new Error('trend boom'))
+    renderSection()
+
+    await screen.findAllByText('Failed to load model / latency data.')
+    expect(
+      screen.queryByRole('table', { name: 'Latency histogram' })
+    ).toBeNull()
+    expect(screen.queryByRole('table', { name: 'Latency trend' })).toBeNull()
+    // The cost summary is independent — its query still resolves.
+    expect(
+      screen.getByRole('table', { name: 'Cost distribution' })
+    ).toBeInTheDocument()
   })
 })

--- a/web/src/features/dashboard/sections/models/models-section.tsx
+++ b/web/src/features/dashboard/sections/models/models-section.tsx
@@ -14,7 +14,7 @@ import { useMemo, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { api } from '@/lib/api'
-import { formatInt } from '@/lib/format'
+import { formatInt, formatLatency } from '@/lib/format'
 
 import { ChartDataTable } from '../../components/chart-data-table'
 import { ChartShell } from '../../components/chart-shell'
@@ -154,6 +154,55 @@ export function ModelsSection() {
     return rows
   }, [trendQuery.data, metricAvg, metricP95])
 
+  // S10 (#1035): sr-only summaries for the two latency charts — same contract
+  // as the cost donut above (bucket bars → bucket x count; dual-line trend →
+  // series x latest/window-average).
+  const histogramSummary = useMemo(() => {
+    if (histogramData.length === 0) return undefined
+    return (
+      <ChartDataTable
+        caption={t('dashboard.models.latencyHistogram.title')}
+        seriesLabel={t('dashboard.chartSummary.bucketColumn')}
+        columns={[t('dashboard.chartSummary.callsColumn')]}
+        rows={histogramData.map((bucket) => ({
+          name: bucket.label,
+          values: [formatInt(bucket.count)],
+        }))}
+      />
+    )
+  }, [histogramData, t])
+
+  const trendSummary = useMemo(() => {
+    if (trendData.length === 0) return undefined
+    const series = [metricAvg, metricP95]
+      .map((metric) => {
+        const values = trendData
+          .filter((row) => row.metric === metric)
+          .map((row) => row.latency)
+        if (values.length === 0) return null
+        const latest = values.at(-1)
+        if (latest === undefined) return null
+        const mean = values.reduce((sum, v) => sum + v, 0) / values.length
+        return {
+          name: metric,
+          values: [formatLatency(latest), formatLatency(mean)],
+        }
+      })
+      .filter((row): row is { name: string; values: string[] } => row !== null)
+    if (series.length === 0) return undefined
+    return (
+      <ChartDataTable
+        caption={t('dashboard.models.latencyTrend.title')}
+        seriesLabel={t('dashboard.chartSummary.seriesColumn')}
+        columns={[
+          t('dashboard.chartSummary.latestColumn'),
+          t('dashboard.chartSummary.averageColumn'),
+        ]}
+        rows={series}
+      />
+    )
+  }, [trendData, metricAvg, metricP95, t])
+
   const costTooltipLabels = useMemo(
     () => ({
       cost: t('dashboard.models.costDistribution.tooltip.cost'),
@@ -212,6 +261,7 @@ export function ModelsSection() {
         description={t('dashboard.models.latencyHistogram.description')}
         height={300}
         loading={histogramQuery.isLoading}
+        summary={summaryWhenLoaded(histogramQuery, histogramSummary)}
       >
         {renderChartBody(
           histogramQuery.isLoading,
@@ -228,6 +278,7 @@ export function ModelsSection() {
         height={300}
         className='lg:col-span-2'
         loading={trendQuery.isLoading}
+        summary={summaryWhenLoaded(trendQuery, trendSummary)}
       >
         {renderChartBody(
           trendQuery.isLoading,

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -944,6 +944,8 @@
         "seriesColumn": "Series",
         "totalColumn": "Total",
         "latestColumn": "Latest day",
+        "bucketColumn": "Latency bucket",
+        "averageColumn": "Average",
         "netRow": "Net",
         "spendColumn": "Spend",
         "callsColumn": "Calls"

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -944,6 +944,8 @@
         "seriesColumn": "序列",
         "totalColumn": "合计",
         "latestColumn": "最近一天",
+        "bucketColumn": "延迟区间",
+        "averageColumn": "平均值",
         "netRow": "净额",
         "spendColumn": "花费",
         "callsColumn": "请求数"


### PR DESCRIPTION
## 背景

#1035 S10「图表无障碍替代层」：dashboard 六图里 latency histogram / latency trend 是最后两个没有 sr-only 数据摘要表的图表（cost donut 与 traffic 三图已有 ChartDataTable 接线）。recharts SVG 对屏幕阅读器不透明。

## 改动

- **延迟直方图**：sr-only 摘要表 = 延迟区间 × 调用数（bucket × count）。
- **延迟趋势**：avg / p95 双 series × 最新日 + 窗口均值（formatLatency 格式化）。
- **i18n**：`dashboard.chartSummary` 新增 `bucketColumn` / `averageColumn` 双语键。
- **门控一致**：沿用 `summaryWhenLoaded`——查询 loading/error 时不渲染摘要；新测试覆盖直方图行、趋势数值（300/200/500/350ms）、失败门控（cost 摘要独立存活）。

全量 vitest + format/lint/typecheck/knip 本地全绿。