### PR TITLE
fix(web): drop the redundant Minus icon from the unavailable balance delta

### DIFF
--- a/web/src/features/dashboard/components/today-snapshot.tsx
+++ b/web/src/features/dashboard/components/today-snapshot.tsx
@@ -143,12 +143,13 @@ export function TodaySnapshotStrip() {
     if (balanceLoading) return null
     const delta = trend.deltaPercent
     if (delta === undefined || !Number.isFinite(delta)) {
+      // Unavailable: the em-dash alone is the value placeholder — the Minus
+      // icon next to it read as a doubled "— —" glyph run.
       return (
         <div
           className='text-muted-foreground flex items-center gap-1 text-xs'
           title={t('dashboard.overview.snapshot.vs7dUnavailable')}
         >
-          <Minus className='size-3' />
           <span className='tabular-nums'>—</span>
           <span>{t('dashboard.overview.snapshot.vs7d')}</span>
         </div>


### PR DESCRIPTION
今日快照余额 7 天 delta 的不可用态渲染 Minus 图标 + 「—」占位 + 「较 7 天前」标签，视觉上读作「— — 较 7 天前」（图标与占位符同为横线字形，双重）。不可用态只留 em-dash 占位 + 标签；delta 可用分支不动（零 delta 仍用 Minus 图标）。交互截图审计发现（chrome-notifications 场景左下角快照卡）。