### PR TITLE
feat(web): localize attention labels via shared attention-label module (F3)

### DIFF
--- a/web/src/components/layout/__tests__/attention-bell.test.tsx
+++ b/web/src/components/layout/__tests__/attention-bell.test.tsx
@@ -310,6 +310,32 @@ describe('attention bell', () => {
     await waitFor(() => expect(indicatorOf(container)).toBeNull())
   })
 
+  it('re-localizes labels through attention params in the active language', async () => {
+    // F3: the backend keeps an English label for API compat and ships params
+    // so the bell renders the same item in the operator's language.
+    mockGetAttention.mockResolvedValue({
+      items: [
+        attentionItem({
+          severity: 'warning',
+          category: 'balance_unknown',
+          label: 'Balance unknown: svc-onea',
+          target: '/accounts?accountId=9',
+          params: { username: 'svc-onea' },
+        }),
+      ],
+      total: 1,
+    })
+    // Open while the UI is still English (openBell finds the trigger by its
+    // English accessible name), then switch — the open popover re-renders.
+    await openBell()
+    await i18n.changeLanguage('zhCN')
+
+    expect(
+      await screen.findByRole('button', { name: /余额未知：svc-onea/ })
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/Balance unknown/)).not.toBeInTheDocument()
+  })
+
   it('shows a relative timestamp and links to the availability panel', async () => {
     mockGetAttention.mockResolvedValue({
       items: [

--- a/web/src/components/layout/components/attention-bell.tsx
+++ b/web/src/components/layout/components/attention-bell.tsx
@@ -31,6 +31,11 @@ import { Separator } from '@/components/ui/separator'
 import { Skeleton } from '@/components/ui/skeleton'
 import { toBcp47 } from '@/i18n/languages'
 import { api } from '@/lib/api'
+import {
+  attentionLabel,
+  type AttentionItem,
+  type AttentionResponse,
+} from '@/lib/attention-label'
 import { formatAbsoluteDateTime, formatRelativeTime } from '@/lib/format'
 import { cn } from '@/lib/utils'
 
@@ -43,22 +48,7 @@ const BADGE_COUNT_CEILING = 9
 /** The popover is a peek surface; "view all" leads to the full panel. */
 const POPOVER_ITEM_LIMIT = 6
 
-type AttentionSeverity = 'critical' | 'warning' | 'info'
-
-type AttentionItem = {
-  severity: AttentionSeverity
-  category: string
-  label: string
-  target: string
-  createdAt: string
-  params?: Record<string, string | number>
-}
-
-/** Attention response (GET /api/stats/attention?limit=20). */
-type AttentionResponse = {
-  items: AttentionItem[]
-  total: number
-}
+type AttentionSeverity = AttentionItem['severity']
 
 const SEVERITY_BADGE_VARIANT: Record<
   AttentionSeverity,
@@ -141,7 +131,7 @@ function AttentionList(props: AttentionListProps) {
                 {t(`attention.severity.${item.severity}`)}
               </Badge>
               <span className='min-w-0 flex-1 truncate text-sm'>
-                {item.label}
+                {attentionLabel(item, t)}
               </span>
               {relativeTime ? (
                 <time

--- a/web/src/features/dashboard/sections/availability/availability-section.tsx
+++ b/web/src/features/dashboard/sections/availability/availability-section.tsx
@@ -33,6 +33,11 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { toBcp47 } from '@/i18n/languages'
 import { api } from '@/lib/api'
 import {
+  attentionLabel,
+  type AttentionItem,
+  type AttentionResponse,
+} from '@/lib/attention-label'
+import {
   formatAbsoluteDateTime,
   formatRelativeTime,
   formatTimeOfDay,
@@ -47,27 +52,6 @@ import {
 } from './attention-target'
 
 const SPARK_BARS = 60
-
-/** One attention item from GET /api/stats/attention. */
-type AttentionItem = {
-  severity: 'critical' | 'warning' | 'info'
-  category: string
-  label: string
-  target: string
-  createdAt: string
-  /**
-   * Structured label params from the backend (username / site name /
-   * numeric balance) so the label can be rendered through i18n. Absent on
-   * items from old backends → raw `label` is rendered instead.
-   */
-  params?: Record<string, string | number>
-}
-
-/** Attention response (GET /api/stats/attention). */
-type AttentionResponse = {
-  items: AttentionItem[]
-  total: number
-}
 
 const SEVERITY_TONE: Record<
   'critical' | 'warning' | 'info',
@@ -89,70 +73,6 @@ const SEVERITY_TONE: Record<
 
 function formatRate(rate: number): string {
   return `${(rate * 100).toFixed(1)}%`
-}
-
-/**
- * Backend event titles are English strings taken verbatim from the events
- * table (alert.go writes "All proxies failed"). Known titles map to
- * localized keys so the panel reads in the active language; unknown titles
- * fall through as-is.
- */
-const EVENT_TITLE_KEYS: Record<string, string> = {
-  'All proxies failed': 'dashboard.availability.monitors.eventAllProxiesFailed',
-}
-
-/**
- * Localized label for an attention item. The backend keeps an English
- * `label` for API compat and sends structured `params` alongside; when the
- * params a category needs are missing (old backend, malformed payload) the
- * raw label is used instead of a string with empty placeholders.
- */
-function attentionLabel(
-  item: AttentionItem,
-  t: (key: string, options?: Record<string, unknown>) => string
-): string {
-  switch (item.category) {
-    case 'expired_account': {
-      const name = item.params?.username
-      return typeof name === 'string' && name !== ''
-        ? t('dashboard.availability.monitors.expiredAccount', { name })
-        : item.label
-    }
-    case 'low_balance': {
-      const name = item.params?.username
-      const balance = item.params?.balance
-      return typeof name === 'string' && name !== '' && balance != null
-        ? t('dashboard.availability.monitors.lowBalance', {
-            name,
-            amount: Number(balance).toFixed(2),
-          })
-        : item.label
-    }
-    case 'disabled_site': {
-      const name = item.params?.name
-      return typeof name === 'string' && name !== ''
-        ? t('dashboard.availability.monitors.disabledSite', { name })
-        : item.label
-    }
-    case 'balance_unknown': {
-      const name = item.params?.username
-      return typeof name === 'string' && name !== ''
-        ? t('dashboard.availability.monitors.balanceUnknown', { name })
-        : item.label
-    }
-    case 'site_announcement': {
-      const title = item.params?.title
-      return typeof title === 'string' && title !== ''
-        ? t('dashboard.availability.monitors.siteAnnouncement', { title })
-        : item.label
-    }
-    case 'event': {
-      const key = EVENT_TITLE_KEYS[item.label]
-      return key ? t(key) : item.label
-    }
-    default:
-      return item.label
-  }
 }
 
 /**

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -914,6 +914,13 @@
           "balanceUnknown": "Balance unknown: {{name}}",
           "siteAnnouncement": "Upstream announcement: {{title}}",
           "eventAllProxiesFailed": "All proxies failed",
+          "eventLowBalance": "Low balance",
+          "eventTokenExpired": "Token expired",
+          "eventSiteDisabled": "Site disabled",
+          "eventCheckinFailed": "Check-in failed",
+          "eventCheckinFailedCloudflare": "Check-in failed (Cloudflare challenge)",
+          "eventCheckinSkipped": "Check-in skipped",
+          "eventTokenSyncFailed": "Account token sync failed",
           "mergedCount": "{{count}} merged events",
           "severity": {
             "critical": "critical",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -914,6 +914,13 @@
           "balanceUnknown": "余额未知：{{name}}",
           "siteAnnouncement": "上游公告：{{title}}",
           "eventAllProxiesFailed": "全部代理失败",
+          "eventLowBalance": "余额不足",
+          "eventTokenExpired": "令牌已过期",
+          "eventSiteDisabled": "站点已禁用",
+          "eventCheckinFailed": "签到失败",
+          "eventCheckinFailedCloudflare": "签到失败（Cloudflare 验证）",
+          "eventCheckinSkipped": "已跳过签到",
+          "eventTokenSyncFailed": "账号令牌同步失败",
           "mergedCount": "合并 {{count}} 条事件",
           "severity": {
             "critical": "严重",

--- a/web/src/lib/__tests__/attention-label.test.ts
+++ b/web/src/lib/__tests__/attention-label.test.ts
@@ -1,0 +1,126 @@
+// metapi-go/lib — attention-label tests (F3).
+//
+// The backend keeps an English `label` for API compat and ships structured
+// `params` so the SPA can re-localize. These tests pin the re-localization
+// contract: known categories render through i18n in the active language,
+// missing params and unknown categories/event titles fall back to the raw
+// label (honest residual — never a half-translation).
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import i18n from '@/i18n/config'
+
+import { attentionLabel, type AttentionItem } from '../attention-label'
+
+function item(overrides: Partial<AttentionItem>): AttentionItem {
+  return {
+    severity: 'warning',
+    category: 'event',
+    label: 'raw label',
+    target: '/x',
+    createdAt: '2026-08-30T00:00:00Z',
+    ...overrides,
+  }
+}
+
+beforeEach(async () => {
+  await i18n.changeLanguage('zhCN')
+})
+
+describe('attentionLabel', () => {
+  it('re-localizes a known category through params in the active language', async () => {
+    await i18n.changeLanguage('zhCN')
+    expect(
+      attentionLabel(
+        item({
+          category: 'balance_unknown',
+          label: 'Balance unknown: svc-onea',
+          params: { username: 'svc-onea' },
+        }),
+        i18n.t.bind(i18n)
+      )
+    ).toBe('余额未知：svc-onea')
+
+    await i18n.changeLanguage('en')
+    expect(
+      attentionLabel(
+        item({
+          category: 'balance_unknown',
+          label: 'Balance unknown: svc-onea',
+          params: { username: 'svc-onea' },
+        }),
+        i18n.t.bind(i18n)
+      )
+    ).toBe('Balance unknown: svc-onea')
+  })
+
+  it('formats low_balance amounts to two decimals', async () => {
+    await i18n.changeLanguage('en')
+    expect(
+      attentionLabel(
+        item({
+          category: 'low_balance',
+          label: 'Low balance: relay (0.5)',
+          params: { username: 'relay', balance: 0.5 },
+        }),
+        i18n.t.bind(i18n)
+      )
+    ).toBe('Low balance: relay (0.50)')
+  })
+
+  it('maps known persisted event titles to their i18n keys', async () => {
+    await i18n.changeLanguage('zhCN')
+    expect(
+      attentionLabel(
+        item({ category: 'event', label: 'All proxies failed' }),
+        i18n.t.bind(i18n)
+      )
+    ).toBe('全部代理失败')
+    expect(
+      attentionLabel(
+        item({ category: 'event', label: 'checkin failed' }),
+        i18n.t.bind(i18n)
+      )
+    ).toBe('签到失败')
+  })
+
+  it('falls back to the raw label for unknown event titles', async () => {
+    await i18n.changeLanguage('zhCN')
+    expect(
+      attentionLabel(
+        item({ category: 'event', label: 'Upstream rate limited' }),
+        i18n.t.bind(i18n)
+      )
+    ).toBe('Upstream rate limited')
+  })
+
+  it('falls back to the raw label when params are missing or empty', async () => {
+    await i18n.changeLanguage('zhCN')
+    expect(
+      attentionLabel(
+        item({ category: 'expired_account', label: 'Account expired: ops' }),
+        i18n.t.bind(i18n)
+      )
+    ).toBe('Account expired: ops')
+    expect(
+      attentionLabel(
+        item({
+          category: 'disabled_site',
+          label: 'Site disabled: edge',
+          params: { name: '' },
+        }),
+        i18n.t.bind(i18n)
+      )
+    ).toBe('Site disabled: edge')
+  })
+
+  it('falls back to the raw label for unknown categories', async () => {
+    await i18n.changeLanguage('zhCN')
+    expect(
+      attentionLabel(
+        item({ category: 'something_new', label: 'A future category' }),
+        i18n.t.bind(i18n)
+      )
+    ).toBe('A future category')
+  })
+})

--- a/web/src/lib/attention-label.ts
+++ b/web/src/lib/attention-label.ts
@@ -1,0 +1,102 @@
+// metapi-go/lib — shared attention-item label localization (F3).
+//
+// The backend attention API (`GET /api/stats/attention`) keeps an English
+// `label` for API compat and ships structured `params` alongside (username /
+// site name / balance / announcement title) so the SPA can re-localize. Both
+// consumers — the header bell popover and the dashboard availability panel —
+// must render through `attentionLabel`; never render `item.label` verbatim.
+// When the params a category needs are missing (old backend, malformed
+// payload) the raw label is used instead of a string with empty
+// placeholders.
+
+/** One attention item from GET /api/stats/attention. */
+export type AttentionItem = {
+  severity: 'critical' | 'warning' | 'info'
+  category: string
+  label: string
+  target: string
+  createdAt: string
+  /**
+   * Structured label params from the backend (username / site name /
+   * numeric balance) so the label can be rendered through i18n. Absent on
+   * items from old backends → raw `label` is rendered instead.
+   */
+  params?: Record<string, string | number>
+}
+
+/** Attention response envelope. */
+export type AttentionResponse = {
+  items: AttentionItem[]
+  total: number
+}
+
+/**
+ * Event titles are persisted English strings (events.title) — the event row
+ * is written once at emission time and never re-localized server-side, so
+ * the known producer titles map to i18n keys at render time. Unknown titles
+ * fall through to the raw label (honest residual, never a half-translation).
+ */
+const EVENT_TITLE_KEYS: Record<string, string> = {
+  'All proxies failed': 'dashboard.availability.monitors.eventAllProxiesFailed',
+  'Low balance': 'dashboard.availability.monitors.eventLowBalance',
+  'Token expired': 'dashboard.availability.monitors.eventTokenExpired',
+  'Site disabled': 'dashboard.availability.monitors.eventSiteDisabled',
+  'checkin failed': 'dashboard.availability.monitors.eventCheckinFailed',
+  'checkin failed (cloudflare challenge)':
+    'dashboard.availability.monitors.eventCheckinFailedCloudflare',
+  'checkin skipped': 'dashboard.availability.monitors.eventCheckinSkipped',
+  'account token sync failed':
+    'dashboard.availability.monitors.eventTokenSyncFailed',
+}
+
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
+
+/**
+ * Localized label for an attention item, keyed off `category` + `params`.
+ * The raw English `label` is the explicit fallback for unknown categories
+ * and missing params.
+ */
+export function attentionLabel(item: AttentionItem, t: TranslateFn): string {
+  switch (item.category) {
+    case 'expired_account': {
+      const name = item.params?.username
+      return typeof name === 'string' && name !== ''
+        ? t('dashboard.availability.monitors.expiredAccount', { name })
+        : item.label
+    }
+    case 'low_balance': {
+      const name = item.params?.username
+      const balance = item.params?.balance
+      return typeof name === 'string' && name !== '' && balance != null
+        ? t('dashboard.availability.monitors.lowBalance', {
+            name,
+            amount: Number(balance).toFixed(2),
+          })
+        : item.label
+    }
+    case 'balance_unknown': {
+      const name = item.params?.username
+      return typeof name === 'string' && name !== ''
+        ? t('dashboard.availability.monitors.balanceUnknown', { name })
+        : item.label
+    }
+    case 'disabled_site': {
+      const name = item.params?.name
+      return typeof name === 'string' && name !== ''
+        ? t('dashboard.availability.monitors.disabledSite', { name })
+        : item.label
+    }
+    case 'site_announcement': {
+      const title = item.params?.title
+      return typeof title === 'string' && title !== ''
+        ? t('dashboard.availability.monitors.siteAnnouncement', { title })
+        : item.label
+    }
+    case 'event': {
+      const key = EVENT_TITLE_KEYS[item.label]
+      return key ? t(key) : item.label
+    }
+    default:
+      return item.label
+  }
+}


### PR DESCRIPTION
## 问题

后端 attention API 为 API 兼容保留英文 `label`，同时下发结构化 `params`（username / 站点名 / 余额 / 公告标题）供 SPA 再本地化。dashboard availability 面板此前已通过本地 `attentionLabel` 做了再本地化，但**顶栏通知铃铛弹层裸渲染 `item.label`**——中文用户在通知弹层看到「Balance unknown: svc-onea…」「Site disabled: …」英文告警裸奔（截图证据见 W22 审计记录）。

## 方案

- 新增共享模块 `web/src/lib/attention-label.ts`：`AttentionItem` / `AttentionResponse` 类型、持久化事件标题 → i18n 键映射（8 个已知生产端标题）、`attentionLabel(item, t)`。params 缺失、未知 category / 未知事件标题一律回退裸 label（诚实残留，绝不半翻译）。
- `attention-bell.tsx` 与 `availability-section.tsx` 共用该模块，删除两份本地副本（类型 + 63 行 helper）。
- en / zh-CN 补齐 7 个事件标题键（low balance / token expired / site disabled / check-in failed(+cloudflare) / check-in skipped / token sync failed）。

## 测试

- 新增 lib 级单元测试：再本地化、金额两位小数格式化、事件标题映射、三类回退路径。
- bell 测试新增一条钉：带 params 的 `balance_unknown` 项在 zh-CN 下渲染「余额未知：svc-onea」且不再出现英文。
- 全量 vitest 1551 绿；lint / typecheck / knip / boundaries 全过。

## 端到端截图验证（seeded 4100 实例）

- zh-CN：铃铛弹层 + availability 面板均渲染「余额未知：svc-oneapi-02」「站点已停用：OpenAI 兼容网关」
- en：英文文案保持正确，无回归

MASTER F3 行验收标准「双语告警事件端到端」达成。