### PR TITLE
test(web): pin interpolation placeholder parity between en and zh-CN (S10)

### DIFF
--- a/web/src/i18n/__tests__/i18n-keys.test.ts
+++ b/web/src/i18n/__tests__/i18n-keys.test.ts
@@ -211,7 +211,7 @@ describe('i18n key coverage', () => {
   it('keeps interpolation placeholders identical between en and zh-CN', () => {
     const PLACEHOLDER_RE = /\{\{\s*([^}]+?)\s*\}\}/g
     const placeholders = (value: string): string[] =>
-      [...value.matchAll(PLACEHOLDER_RE)].map((m) => m[1]!.trim()).sort()
+      [...value.matchAll(PLACEHOLDER_RE)].map((m) => (m[1] ?? '').trim()).sort()
     const leafValue = (root: TranslationNode, key: string): string | null => {
       const value = resolveSegments(root, key)
       return typeof value === 'string' ? value : null

--- a/web/src/i18n/__tests__/i18n-keys.test.ts
+++ b/web/src/i18n/__tests__/i18n-keys.test.ts
@@ -203,4 +203,31 @@ describe('i18n key coverage', () => {
     expect([...zhKeys].filter((k) => !enKeys.has(k))).toEqual([])
     expect([...enKeys].filter((k) => !zhKeys.has(k))).toEqual([])
   })
+
+  // S10 bilingual CI: key-set parity alone cannot catch a translation that
+  // drops an interpolation variable (e.g. zh rendering "余额不足：relay ()"
+  // because {{amount}} was lost). Every leaf present in both locales must
+  // declare the same placeholder set, so a dropped variable fails CI.
+  it('keeps interpolation placeholders identical between en and zh-CN', () => {
+    const PLACEHOLDER_RE = /\{\{\s*([^}]+?)\s*\}\}/g
+    const placeholders = (value: string): string[] =>
+      [...value.matchAll(PLACEHOLDER_RE)].map((m) => m[1]!.trim()).sort()
+    const leafValue = (root: TranslationNode, key: string): string | null => {
+      const value = resolveSegments(root, key)
+      return typeof value === 'string' ? value : null
+    }
+
+    const mismatched: string[] = []
+    for (const key of enKeys) {
+      const enValue = leafValue(enRoot, key)
+      const zhValue = leafValue(zhRoot, key)
+      if (enValue === null || zhValue === null) continue
+      const enVars = placeholders(enValue)
+      const zhVars = placeholders(zhValue)
+      if (enVars.join('') !== zhVars.join('')) {
+        mismatched.push(`${key}  (en: ${enVars} | zh-CN: ${zhVars})`)
+      }
+    }
+    expect(mismatched).toEqual([])
+  })
 })


### PR DESCRIPTION
## 背景（#1035 S10 双语 CI）

i18n-keys 测试已保证：每个 `t()` 键在两个 locale 都存在、且 en/zh-CN 键集合双向一致。但**键集合 parity 抓不到译文丢失插值变量**——例如 zh-CN 把 `Low balance: {{name}} ({{amount}})` 译成「余额不足：{{name}}（）」，键依然存在、测试照样绿，用户看到的却是空占位。

## 改动

i18n-keys 测试新增一条断言：每个双语共有键的 `{{var}}` 占位符集合必须完全一致（叶级比对，排序后比较）。

## 现状

2493 键，0 失配——纯加固，零现状修复。随 frontend CI（vitest）运行。