### PR TITLE
feat(web): undo tier for leaf single-row deletes (S7)

### DIFF
--- a/docs/internal/design/DESIGN.md
+++ b/docs/internal/design/DESIGN.md
@@ -142,6 +142,19 @@ State-management rules for URL-synced tables and filters (single URL owner, stab
 
 New UI must start from shadcn Base UI primitives when possible. Import via `@/components/ui/*`.
 
+### 4.1 Destructive-action tiers（破坏性操作四档）
+
+Every destructive action maps to exactly one tier; never hand-roll a variant:
+
+| 档 | 形态 | 适用 | 实现 |
+|---|---|---|---|
+| 直达 | 无确认 | 可逆切换（启用/停用、置顶、刷新） | 直接 mutation |
+| 删除+undo | 无弹窗；行即消失 + 6s 可撤销 toast | 叶子实体单行删除（redirects、catalog sources、routes、downstream keys、account tokens） | `useUndoableDelete`（`@/lib/undoable-delete`） |
+| 批量确认 | 计数确认弹窗 | 批量操作、清空、跨页应用 | `ConfirmDialog`（含 count 文案） |
+| typed-confirm | 倒计时 + 输入确认词 | 不可逆/级联重操作（factory reset、站点/账号级联删除） | danger-zone 模式（倒计时 + 确认词） |
+
+例外必须注释标注（例：OAuth 连接删除用 ConfirmDialog + 既有跨页乐观回滚 hook，不移交 undo helper）。
+
 ---
 
 ## 5. Visual acceptance

--- a/web/src/features/accounts/tokens/__tests__/tokens-panel-delete.test.tsx
+++ b/web/src/features/accounts/tokens/__tests__/tokens-panel-delete.test.tsx
@@ -1,7 +1,8 @@
-// Behavior test for the tokens-panel delete flow (#889): the confirmation
-// used to close immediately after firing the mutation ("先关后删"), hiding
-// the pending state. The dialog must now stay open — Cancel disabled, confirm
-// spinner — until the mutation settles, and close on success.
+// Behavior test for the tokens-panel delete flow — S7 删除+undo 档:
+// the row action no longer opens a dialog; it triggers the shared
+// undoable-delete helper with the account's token-list query key. The
+// helper's own contract (optimistic removal / undo restore / deferred
+// commit) is pinned in lib/__tests__/undoable-delete.test.tsx.
 
 import '@testing-library/jest-dom/vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
@@ -22,8 +23,8 @@ import type { AccountToken } from '../../types'
 import { TokensPanel } from '../components/tokens-panel'
 
 const mockState = vi.hoisted(() => ({
-  deleteCalls: [] as Array<{ id: number; onSuccess?: () => void }>,
-  deletePending: { value: false },
+  undoableDelete: vi.fn(),
+  deleteAccountToken: vi.fn(),
   sampleToken: {
     id: 9,
     accountId: 1,
@@ -41,22 +42,34 @@ const mockState = vi.hoisted(() => ({
 }))
 
 vi.mock('../api', () => ({
+  accountTokenQueryKeys: {
+    all: ['account-tokens'] as const,
+    list: (accountId?: number) =>
+      ['account-tokens', 'list', accountId ?? 'all'] as const,
+  },
   useAccountTokens: () => ({
     data: [mockState.sampleToken],
     isLoading: false,
   }),
   useCreateAccountToken: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useUpdateAccountToken: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useDeleteAccountToken: () => ({
-    mutate: (id: number, options?: { onSuccess?: () => void }) => {
-      mockState.deletePending.value = true
-      mockState.deleteCalls.push({ id, onSuccess: options?.onSuccess })
-    },
-    isPending: mockState.deletePending.value,
-  }),
   useSetDefaultAccountToken: () => ({ mutate: vi.fn(), isPending: false }),
   useSyncAccountTokens: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useToggleAccountTokenEnabled: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+vi.mock('../../api', () => ({
+  accountQueryKeys: { all: ['accounts'] as const },
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    deleteAccountToken: mockState.deleteAccountToken,
+  },
+}))
+
+vi.mock('@/lib/undoable-delete', () => ({
+  useUndoableDelete: () => mockState.undoableDelete,
 }))
 
 vi.mock('@/lib/toast', () => ({
@@ -85,8 +98,9 @@ beforeAll(() => {
 })
 
 beforeEach(() => {
-  mockState.deleteCalls = []
-  mockState.deletePending.value = false
+  mockState.undoableDelete.mockClear()
+  mockState.deleteAccountToken.mockReset()
+  mockState.deleteAccountToken.mockResolvedValue({ success: true })
 })
 
 afterEach(() => cleanup())
@@ -95,34 +109,47 @@ afterAll(() => {
   vi.restoreAllMocks()
 })
 
-describe('TokensPanel delete dialog', () => {
-  it('stays open while the delete is pending and closes on success', () => {
-    const { rerender } = render(<TokensPanel accountId={1} />)
+describe('TokensPanel delete (undo tier)', () => {
+  it('triggers the undoable delete with the token and its list query key — no dialog', async () => {
+    render(<TokensPanel accountId={1} />)
 
-    // Open the delete confirmation from the row action.
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
-    expect(screen.getByText('Delete token?')).toBeInTheDocument()
 
-    // Confirm — the mutation fires but the dialog must stay open.
-    const deleteButtons = screen.getAllByRole('button', { name: 'Delete' })
-    const confirmButton = deleteButtons.at(-1)
-    if (!confirmButton) throw new Error('confirm button not rendered')
-    fireEvent.click(confirmButton)
+    // No confirmation dialog at all.
+    expect(screen.queryByText('Delete token?')).not.toBeInTheDocument()
 
-    expect(mockState.deleteCalls).toHaveLength(1)
-    expect(mockState.deleteCalls[0]?.id).toBe(9)
+    expect(mockState.undoableDelete).toHaveBeenCalledTimes(1)
+    const params = mockState.undoableDelete.mock.calls[0]?.[0] as {
+      item: AccountToken
+      queryKey: readonly unknown[]
+      removeFromCache: (
+        data: AccountToken[],
+        item: AccountToken
+      ) => AccountToken[]
+      deleteFn: (item: AccountToken) => Promise<unknown>
+      title: string
+      undoLabel: string
+      errorTitle: string
+      alsoInvalidate: Array<readonly unknown[]>
+    }
+    expect(params.item.id).toBe(9)
+    expect(params.queryKey).toEqual(['account-tokens', 'list', 1])
+    expect(params.title).toBe('Token deleted')
+    expect(params.undoLabel).toBe('Undo')
+    expect(params.alsoInvalidate).toEqual([['account-tokens'], ['accounts']])
 
-    // Re-render so the hook picks up the pending flag (TanStack Query would
-    // trigger this re-render in production).
-    rerender(<TokensPanel accountId={1} />)
-    expect(screen.getByText('Delete token?')).toBeInTheDocument()
-    // While pending, Cancel is disabled so the dialog can't be dismissed.
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+    // The pure cache reducer drops exactly this token.
+    expect(
+      params
+        .removeFromCache(
+          [mockState.sampleToken, { ...mockState.sampleToken, id: 10 }],
+          mockState.sampleToken
+        )
+        .map((row) => row.id)
+    ).toEqual([10])
 
-    // Settle the mutation — the dialog closes.
-    mockState.deletePending.value = false
-    mockState.deleteCalls[0]?.onSuccess?.()
-    rerender(<TokensPanel accountId={1} />)
-    expect(screen.queryByText('Delete token?')).toBeNull()
+    // The deferred DELETE goes to the real api with the token id.
+    await params.deleteFn(mockState.sampleToken)
+    expect(mockState.deleteAccountToken).toHaveBeenCalledWith(9)
   })
 })

--- a/web/src/features/accounts/tokens/api.ts
+++ b/web/src/features/accounts/tokens/api.ts
@@ -23,7 +23,7 @@ import { accountQueryKeys } from '../api'
 import { type AccountToken, accountTokenSchema } from '../types'
 import type { AccountTokenPayload } from './lib/tokens-schema'
 
-const accountTokenQueryKeys = {
+export const accountTokenQueryKeys = {
   all: ['account-tokens'] as const,
   list: (accountId?: number) =>
     ['account-tokens', 'list', accountId ?? 'all'] as const,
@@ -135,27 +135,6 @@ export function useUpdateAccountToken() {
       })
       void queryClient.invalidateQueries({ queryKey: accountQueryKeys.all })
       toast.success(i18n.t('accounts.tokens.toast.updated'))
-    },
-  })
-}
-
-// ---------------------------------------------------------------------------
-// useDeleteAccountToken — DELETE /api/account-tokens/:id
-// ---------------------------------------------------------------------------
-
-export function useDeleteAccountToken() {
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: async (id: number) => {
-      const result = await api.deleteAccountToken(id)
-      return assertBusinessOk(result, 'accounts.tokens.toast.deleteFailed')
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: accountTokenQueryKeys.all,
-      })
-      void queryClient.invalidateQueries({ queryKey: accountQueryKeys.all })
-      toast.success(i18n.t('accounts.tokens.toast.deleted'))
     },
   })
 }

--- a/web/src/features/accounts/tokens/components/tokens-panel.tsx
+++ b/web/src/features/accounts/tokens/components/tokens-panel.tsx
@@ -14,14 +14,6 @@ import { ConfirmDialog } from '@/components/common/confirm-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import {
   Form,
   FormControl,
   FormDescription,
@@ -35,14 +27,18 @@ import { SecretField } from '@/components/ui/secret-field'
 import { Separator } from '@/components/ui/separator'
 import { Spinner } from '@/components/ui/spinner'
 import { Switch } from '@/components/ui/switch'
+import { api } from '@/lib/api'
+import { assertBusinessOk } from '@/lib/assert-business-ok'
 import { toast } from '@/lib/toast'
+import { useUndoableDelete } from '@/lib/undoable-delete'
 import { cn } from '@/lib/utils'
 
+import { accountQueryKeys } from '../../api'
 import type { AccountToken } from '../../types'
 import {
+  accountTokenQueryKeys,
   useAccountTokens,
   useCreateAccountToken,
-  useDeleteAccountToken,
   useSetDefaultAccountToken,
   useSyncAccountTokens,
   useToggleAccountTokenEnabled,
@@ -71,13 +67,30 @@ export function TokensPanel({
   const { t } = useTranslation()
   const { data: tokens = [], isLoading } = useAccountTokens(accountId)
   const syncMutation = useSyncAccountTokens()
-  const deleteMutation = useDeleteAccountToken()
   const setDefaultMutation = useSetDefaultAccountToken()
   const toggleEnabledMutation = useToggleAccountTokenEnabled()
 
   const [formOpen, setFormOpen] = useState(false)
   const [editingToken, setEditingToken] = useState<AccountToken | null>(null)
-  const [deletingToken, setDeletingToken] = useState<AccountToken | null>(null)
+
+  // S7 删除+undo 档: token delete is leaf — no confirm dialog; the row
+  // leaves immediately and a 6s undo toast gates the real DELETE.
+  const undoableDelete = useUndoableDelete()
+  const deleteToken = (token: AccountToken) =>
+    undoableDelete<AccountToken[], AccountToken>({
+      item: token,
+      queryKey: accountTokenQueryKeys.list(accountId),
+      removeFromCache: (data, target) =>
+        data.filter((entry) => entry.id !== target.id),
+      deleteFn: async (target) => {
+        const result = await api.deleteAccountToken(target.id)
+        assertBusinessOk(result, 'accounts.tokens.toast.deleteFailed')
+      },
+      title: t('accounts.tokens.toast.deleted'),
+      undoLabel: t('common.undo'),
+      errorTitle: t('accounts.tokens.toast.deleteFailed'),
+      alsoInvalidate: [accountTokenQueryKeys.all, accountQueryKeys.all],
+    })
 
   const openCreateForm = () => {
     setEditingToken(null)
@@ -154,64 +167,16 @@ export function TokensPanel({
               key={token.id}
               token={token}
               onEdit={() => openEditForm(token)}
-              onDelete={() => setDeletingToken(token)}
+              onDelete={() => deleteToken(token)}
               onSetDefault={() => setDefaultMutation.mutate(token.id)}
               onToggleEnabled={(enabled) =>
                 toggleEnabledMutation.mutate({ id: token.id, enabled })
               }
-              isDeleting={deleteMutation.isPending}
               isToggling={toggleEnabledMutation.isPending}
             />
           ))}
         </ul>
       )}
-
-      <Dialog
-        open={deletingToken !== null}
-        onOpenChange={(open) => {
-          // Keep the dialog open until the delete settles: closing early
-          // hides the pending state and the failure toast would arrive with
-          // no visible context.
-          if (!open && !deleteMutation.isPending) {
-            setDeletingToken(null)
-          }
-        }}
-      >
-        <DialogContent className='sm:max-w-md'>
-          <DialogHeader>
-            <DialogTitle>
-              {t('accounts.tokens.deleteConfirm.title')}
-            </DialogTitle>
-            <DialogDescription>
-              {t('accounts.tokens.deleteConfirm.description', {
-                name: deletingToken?.name || t('accounts.tokens.unnamed'),
-              })}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant='outline'
-              onClick={() => setDeletingToken(null)}
-              disabled={deleteMutation.isPending}
-            >
-              {t('accounts.tokens.deleteConfirm.cancel')}
-            </Button>
-            <Button
-              variant='destructive'
-              disabled={deleteMutation.isPending}
-              onClick={() => {
-                if (!deletingToken) return
-                deleteMutation.mutate(deletingToken.id, {
-                  onSuccess: () => setDeletingToken(null),
-                })
-              }}
-            >
-              {deleteMutation.isPending && <Spinner />}
-              {t('accounts.tokens.deleteConfirm.confirm')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   )
 }
@@ -226,7 +191,6 @@ interface TokenRowProps {
   onDelete: () => void
   onSetDefault: () => void
   onToggleEnabled: (enabled: boolean) => void
-  isDeleting: boolean
   isToggling: boolean
 }
 
@@ -236,7 +200,6 @@ function TokenRow({
   onDelete,
   onSetDefault,
   onToggleEnabled,
-  isDeleting,
   isToggling,
 }: TokenRowProps) {
   const { t } = useTranslation()
@@ -293,7 +256,6 @@ function TokenRow({
           variant='ghost'
           size='icon-sm'
           onClick={onDelete}
-          disabled={isDeleting}
           className={cn('text-muted-foreground hover:text-destructive')}
           title={t('accounts.tokens.delete')}
           aria-label={t('accounts.tokens.delete')}

--- a/web/src/features/settings/sections/downstream/components/keys-section.tsx
+++ b/web/src/features/settings/sections/downstream/components/keys-section.tsx
@@ -11,7 +11,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import type { ColumnDef } from '@tanstack/react-table'
 import { Pencil } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -22,21 +22,13 @@ import { DataTablePage, useDataTable } from '@/components/data-table'
 import { useDirtyDialogClose } from '@/components/form/dirty-dialog-close'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
-import { Spinner } from '@/components/ui/spinner'
 import { Switch } from '@/components/ui/switch'
 import { useAccounts, useAllAccountTokens } from '@/features/accounts'
 import { useSites } from '@/features/sites'
 import { api } from '@/lib/api'
 import { toast } from '@/lib/toast'
+import { useUndoableDelete } from '@/lib/undoable-delete'
 
 import { SettingsSectionCard } from '../../../components/settings-section-card'
 import { SettingsSectionError } from '../../../components/settings-section-error'
@@ -59,9 +51,6 @@ export function KeysSection() {
   const queryClient = useQueryClient()
   const [createOpen, setCreateOpen] = useState(false)
   const [formDirty, setFormDirty] = useState(false)
-  const [deleteTarget, setDeleteTarget] = useState<DownstreamApiKeyItem | null>(
-    null
-  )
   const [exportTarget, setExportTarget] =
     useState<CredentialExportTarget | null>(null)
 
@@ -159,18 +148,25 @@ export function KeysSection() {
       toast.error(t('settings.downstream.keys.toast.updateFailed')),
   })
 
-  const deleteMutation = useMutation({
-    mutationFn: async (id: number) => api.deleteDownstreamApiKey(id),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: downstreamKeysQueryKeys.all,
-      })
-      toast.success(t('settings.downstream.keys.toast.deleted'))
-      setDeleteTarget(null)
-    },
-    onError: () =>
-      toast.error(t('settings.downstream.keys.toast.deleteFailed')),
-  })
+  // S7 删除+undo 档: key revoke is leaf (no cascade) — no confirm dialog;
+  // the row leaves immediately and a 6s undo toast gates the real DELETE.
+  const undoableDelete = useUndoableDelete()
+  const deleteKey = useCallback(
+    (item: DownstreamApiKeyItem) =>
+      undoableDelete<DownstreamKeysResponse, DownstreamApiKeyItem>({
+        item,
+        queryKey: downstreamKeysQueryKeys.list(),
+        removeFromCache: (data, target) => ({
+          ...data,
+          items: data.items.filter((entry) => entry.id !== target.id),
+        }),
+        deleteFn: (target) => api.deleteDownstreamApiKey(target.id),
+        title: t('settings.downstream.keys.toast.deleted'),
+        undoLabel: t('common.undo'),
+        errorTitle: t('settings.downstream.keys.toast.deleteFailed'),
+      }),
+    [undoableDelete, t]
+  )
 
   const items = keysQuery.data?.items ?? []
   const isLoading = keysQuery.isLoading
@@ -289,7 +285,7 @@ export function KeysSection() {
               type='button'
               variant='ghost'
               size='sm'
-              onClick={() => setDeleteTarget(row.original)}
+              onClick={() => deleteKey(row.original)}
             >
               {t('settings.common.delete')}
             </Button>
@@ -297,7 +293,7 @@ export function KeysSection() {
         ),
       },
     ],
-    [t, toggleKeyPending, toggleKeyMutate, scopeNames]
+    [t, toggleKeyPending, toggleKeyMutate, scopeNames, deleteKey]
   )
 
   const { table } = useDataTable<DownstreamApiKeyItem>({
@@ -358,49 +354,6 @@ export function KeysSection() {
           {sheetDirtyGuard}
         </SheetContent>
       </Sheet>
-
-      <Dialog
-        open={deleteTarget !== null}
-        onOpenChange={(open) => {
-          if (!open) {
-            setDeleteTarget(null)
-          }
-        }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              {t('settings.downstream.keys.deleteTitle')}
-            </DialogTitle>
-            <DialogDescription>
-              {t('settings.downstream.keys.deleteDescription', {
-                name: deleteTarget?.name ?? '',
-              })}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant='outline'
-              onClick={() => setDeleteTarget(null)}
-              disabled={deleteMutation.isPending}
-            >
-              {t('settings.common.cancel')}
-            </Button>
-            <Button
-              variant='destructive'
-              disabled={deleteMutation.isPending}
-              onClick={() => {
-                if (deleteTarget) {
-                  deleteMutation.mutate(deleteTarget.id)
-                }
-              }}
-            >
-              {deleteMutation.isPending && <Spinner />}
-              {t('settings.common.delete')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
 
       <CredentialExportDialog
         target={exportTarget}

--- a/web/src/features/settings/sections/proxy-models/components/__tests__/redirects-section.test.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/__tests__/redirects-section.test.tsx
@@ -1,6 +1,7 @@
-// Behavior tests for the redirects section dangerous-op confirmations (#889):
-// row delete and Apply both require an explicit ConfirmDialog step before the
-// mutation fires, while Generate / Preview stay one-click.
+// Behavior tests for the redirects section dangerous-op tiers (#889, S7):
+// row delete is the 删除+undo tier — no dialog; the row leaves immediately
+// and the real DELETE fires only when the undo toast closes without 撤销.
+// Apply keeps an explicit ConfirmDialog; Generate / Preview stay one-click.
 
 import '@testing-library/jest-dom/vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -48,11 +49,19 @@ vi.mock('@/lib/api', () => ({
   },
 }))
 
+const { mockToastMessage } = vi.hoisted(() => ({
+  mockToastMessage: vi.fn(
+    (_title: unknown, _options?: unknown) => 'undo-toast-id'
+  ),
+}))
+
 vi.mock('@/lib/toast', () => ({
   toast: {
     success: vi.fn(),
     error: vi.fn(),
     info: vi.fn(),
+    message: mockToastMessage,
+    dismiss: vi.fn(),
   },
 }))
 
@@ -73,6 +82,7 @@ beforeAll(() => {
 })
 
 beforeEach(() => {
+  mockToastMessage.mockClear()
   mockGetRedirects.mockReset()
   mockDeleteRedirect.mockReset()
   mockApplyRedirects.mockReset()
@@ -119,37 +129,51 @@ function renderSection() {
 }
 
 describe('RedirectsSection dangerous-op confirmations', () => {
-  it('row delete opens a confirmation and only deletes after confirm', async () => {
+  it('row delete removes the row immediately and commits when the undo window closes', async () => {
     renderSection()
 
-    const deleteButton = await screen.findByRole('button', { name: 'Delete' })
-    fireEvent.click(deleteButton)
+    await screen.findByText('gpt-5.5')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
 
-    // No delete before confirmation.
-    expect(mockDeleteRedirect).not.toHaveBeenCalled()
-
-    // The dialog confirm button is the last "Delete" on screen (row action
-    // first, dialog action last).
-    const deleteButtons = await screen.findAllByRole('button', {
-      name: 'Delete',
+    // 删除+undo 档: no dialog, no immediate DELETE — the row is optimistically
+    // gone and the undo toast carries the commit callbacks.
+    await waitFor(() => {
+      expect(screen.queryByText('gpt-5.5')).not.toBeInTheDocument()
     })
-    const confirmDeleteButton = deleteButtons.at(-1)
-    if (!confirmDeleteButton) throw new Error('confirm button not rendered')
-    fireEvent.click(confirmDeleteButton)
+    expect(mockDeleteRedirect).not.toHaveBeenCalled()
+    expect(mockToastMessage).toHaveBeenCalledTimes(1)
+    const options = mockToastMessage.mock.calls[0]?.[1] as {
+      action: { label: string; onClick: () => void }
+      onAutoClose: () => void
+    }
+    expect(options.action.label).toBe('Undo')
+
+    options.onAutoClose()
 
     await waitFor(() => {
       expect(mockDeleteRedirect).toHaveBeenCalledWith(7)
     })
   })
 
-  it('row delete cancel does not call the delete api', async () => {
+  it('undo restores the row and the delete never fires', async () => {
     renderSection()
 
-    const deleteButton = await screen.findByRole('button', { name: 'Delete' })
-    fireEvent.click(deleteButton)
+    await screen.findByText('gpt-5.5')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => {
+      expect(screen.queryByText('gpt-5.5')).not.toBeInTheDocument()
+    })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    const options = mockToastMessage.mock.calls[0]?.[1] as {
+      action: { label: string; onClick: () => void }
+      onAutoClose: () => void
+    }
+    options.action.onClick()
 
+    // Snapshot restored…
+    await screen.findByText('gpt-5.5')
+    // …and the window closing afterwards must not fire the delete.
+    options.onAutoClose()
     expect(mockDeleteRedirect).not.toHaveBeenCalled()
   })
 

--- a/web/src/features/settings/sections/proxy-models/components/catalog-sources-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/catalog-sources-section.tsx
@@ -27,7 +27,6 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { ConfirmDialog } from '@/components/common/confirm-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -61,6 +60,7 @@ import { toBcp47 } from '@/i18n/languages'
 import { api, type CatalogSource, type CatalogSyncStatus } from '@/lib/api'
 import { formatDateTime } from '@/lib/format'
 import { toast } from '@/lib/toast'
+import { useUndoableDelete } from '@/lib/undoable-delete'
 import { cn } from '@/lib/utils'
 
 import {
@@ -117,7 +117,7 @@ export function CatalogSourcesSection() {
   const locale = toBcp47(i18n.language || 'en')
   const queryClient = useQueryClient()
   const [dialog, setDialog] = useState<SourceDialogState | null>(null)
-  const [deleteTarget, setDeleteTarget] = useState<CatalogSource | null>(null)
+  const undoableDelete = useUndoableDelete()
   const [syncingId, setSyncingId] = useState<number | 'all' | null>(null)
 
   // --- reorder state (pointer drag Wave 9 Lane B + keyboard grab) ---
@@ -266,25 +266,24 @@ export function CatalogSourcesSection() {
     },
   })
 
-  const deleteMutation = useMutation({
-    mutationFn: async (id: number) => api.deleteCatalogSource(id),
-    onSuccess: (_result, id) => {
-      const status = statusQuery.data
-      if (status) {
-        refreshStatus({
-          ...status,
-          sources: status.sources.filter((row) => row.id !== id),
-        })
-      }
-      toast.success(t('settings.proxyModels.catalogSources.toast.deleted'))
-    },
-    onError: (error: Error) =>
-      toast.error(
+  // S7 删除+undo 档: leaf single-row delete — no confirm dialog; the row
+  // leaves immediately and a 6s undo toast gates the real DELETE.
+  const deleteSource = (source: CatalogSource) =>
+    undoableDelete<CatalogSyncStatus, CatalogSource>({
+      item: source,
+      queryKey: catalogSyncKeys.status(),
+      removeFromCache: (data, item) => ({
+        ...data,
+        sources: data.sources.filter((row) => row.id !== item.id),
+      }),
+      deleteFn: (item) => api.deleteCatalogSource(item.id),
+      title: t('settings.proxyModels.catalogSources.toast.deleted'),
+      undoLabel: t('common.undo'),
+      errorTitle: (error) =>
         t('settings.proxyModels.catalogSources.toast.deleteFailed', {
-          message: error.message,
-        })
-      ),
-  })
+          message: error instanceof Error ? error.message : String(error),
+        }),
+    })
 
   if (statusQuery.isLoading) {
     return <SettingsSectionSkeleton />
@@ -663,7 +662,7 @@ export function CatalogSourcesSection() {
                           <Button
                             variant='ghost'
                             size='icon-sm'
-                            onClick={() => setDeleteTarget(source)}
+                            onClick={() => deleteSource(source)}
                             aria-label={t(
                               'settings.proxyModels.catalogSources.delete'
                             )}
@@ -695,22 +694,6 @@ export function CatalogSourcesSection() {
           }}
         />
       ) : null}
-
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title={t('settings.proxyModels.catalogSources.deleteTitle')}
-        description={t('settings.proxyModels.catalogSources.deleteDescription')}
-        confirmLabel={t('settings.proxyModels.catalogSources.delete')}
-        cancelLabel={t('settings.proxyModels.catalogSources.cancel')}
-        destructive
-        onConfirm={() => {
-          if (deleteTarget) {
-            deleteMutation.mutate(deleteTarget.id)
-          }
-          setDeleteTarget(null)
-        }}
-        onCancel={() => setDeleteTarget(null)}
-      />
     </div>
   )
 }

--- a/web/src/features/settings/sections/proxy-models/components/redirects-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/redirects-section.tsx
@@ -24,6 +24,7 @@ import {
   type RedirectApplyResponse,
 } from '@/lib/api'
 import { toast } from '@/lib/toast'
+import { useUndoableDelete } from '@/lib/undoable-delete'
 
 import {
   SettingsSectionCard,
@@ -41,7 +42,7 @@ type RedirectPreview = RedirectApplyResponse
 export function RedirectsSection() {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
-  const [deleteTarget, setDeleteTarget] = useState<ModelRedirect | null>(null)
+  const undoableDelete = useUndoableDelete()
   const [applyConfirmOpen, setApplyConfirmOpen] = useState(false)
 
   const redirectsQuery = useQuery<ModelRedirectsResponse>({
@@ -110,17 +111,21 @@ export function RedirectsSection() {
       toast.error(t('settings.proxyModels.redirects.toast.promoteFailed')),
   })
 
-  const deleteMutation = useMutation({
-    mutationFn: async (id: number) => api.deleteModelRedirect(id),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: modelRedirectsQueryKeys.all,
-      })
-      toast.success(t('settings.proxyModels.redirects.toast.deleted'))
-    },
-    onError: () =>
-      toast.error(t('settings.proxyModels.redirects.toast.deleteFailed')),
-  })
+  // S7 删除+undo 档: leaf single-row delete — no confirm dialog; the row
+  // leaves immediately and a 6s undo toast gates the real DELETE.
+  const deleteRedirect = (redirect: ModelRedirect) =>
+    undoableDelete<ModelRedirectsResponse, ModelRedirect>({
+      item: redirect,
+      queryKey: modelRedirectsQueryKeys.list(),
+      removeFromCache: (data, item) => ({
+        ...data,
+        items: data.items.filter((entry) => entry.id !== item.id),
+      }),
+      deleteFn: (item) => api.deleteModelRedirect(item.id),
+      title: t('settings.proxyModels.redirects.toast.deleted'),
+      undoLabel: t('common.undo'),
+      errorTitle: t('settings.proxyModels.redirects.toast.deleteFailed'),
+    })
 
   const items = redirectsQuery.data?.items ?? []
   const isLoading = redirectsQuery.isLoading
@@ -249,8 +254,7 @@ export function RedirectsSection() {
                       type='button'
                       variant='ghost'
                       size='sm'
-                      disabled={deleteMutation.isPending}
-                      onClick={() => setDeleteTarget(redirect)}
+                      onClick={() => deleteRedirect(redirect)}
                     >
                       {t('settings.common.delete')}
                     </Button>
@@ -261,25 +265,6 @@ export function RedirectsSection() {
           </TableBody>
         </Table>
       )}
-
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        title={t('settings.proxyModels.redirects.deleteTitle')}
-        description={t('settings.proxyModels.redirects.deleteDescription', {
-          canonical: deleteTarget?.canonical ?? '',
-          actual: deleteTarget?.actual ?? '',
-        })}
-        confirmLabel={t('settings.common.delete')}
-        cancelLabel={t('settings.common.cancel')}
-        destructive
-        onConfirm={() => {
-          if (deleteTarget) {
-            deleteMutation.mutate(deleteTarget.id)
-          }
-          setDeleteTarget(null)
-        }}
-        onCancel={() => setDeleteTarget(null)}
-      />
 
       <ConfirmDialog
         open={applyConfirmOpen}

--- a/web/src/features/token-routes/__tests__/routes-page-drilldown.test.tsx
+++ b/web/src/features/token-routes/__tests__/routes-page-drilldown.test.tsx
@@ -92,6 +92,11 @@ vi.mock('../api', () => ({
   useBatchUpdateRoutes: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useZeroChannelRoutes: (routes: RouteSummaryRow[]) => routes,
 }))
+// The page's row-delete path uses the shared undo helper; tests stub it so
+// no QueryClientProvider is required.
+vi.mock('@/lib/undoable-delete', () => ({
+  useUndoableDelete: () => vi.fn(),
+}))
 
 vi.mock('../components/route-detail-sheet', () => ({
   RouteDetailSheet: (props: {

--- a/web/src/features/token-routes/api.ts
+++ b/web/src/features/token-routes/api.ts
@@ -189,24 +189,6 @@ export function useUpdateRoute() {
 }
 
 // ---------------------------------------------------------------------------
-// useDeleteRoute
-// ---------------------------------------------------------------------------
-
-export function useDeleteRoute() {
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: async (id: number) => {
-      const result = await api.deleteRoute(id)
-      return assertBusinessOk(result, 'tokenRoutes.toast.deleteFailed')
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: routeQueryKeys.all })
-      toast.success(i18n.t('tokenRoutes.toast.deleted'))
-    },
-  })
-}
-
-// ---------------------------------------------------------------------------
 // useBatchUpdateRoutes
 // ---------------------------------------------------------------------------
 

--- a/web/src/features/token-routes/components/__tests__/routes-page-chain-context.test.tsx
+++ b/web/src/features/token-routes/components/__tests__/routes-page-chain-context.test.tsx
@@ -81,6 +81,11 @@ vi.mock('../../api', () => ({
   useBatchUpdateRoutes: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useZeroChannelRoutes: (routes: unknown[]) => routes ?? [],
 }))
+// The page's row-delete path uses the shared undo helper; tests stub it so
+// no QueryClientProvider is required.
+vi.mock('@/lib/undoable-delete', () => ({
+  useUndoableDelete: () => vi.fn(),
+}))
 
 vi.mock('../routes-columns', () => ({
   useRoutesColumns: () => [],

--- a/web/src/features/token-routes/components/__tests__/routes-page-confirm-dialogs.test.tsx
+++ b/web/src/features/token-routes/components/__tests__/routes-page-confirm-dialogs.test.tsx
@@ -96,6 +96,11 @@ vi.mock('../../api', () => ({
   }),
   useZeroChannelRoutes: (routes: unknown[]) => routes ?? [],
 }))
+// The page's row-delete path uses the shared undo helper; tests stub it so
+// no QueryClientProvider is required.
+vi.mock('@/lib/undoable-delete', () => ({
+  useUndoableDelete: () => vi.fn(),
+}))
 
 vi.mock('../routes-columns', () => ({
   useRoutesColumns: () => [],

--- a/web/src/features/token-routes/components/__tests__/routes-page-zero-channel-toggle.test.tsx
+++ b/web/src/features/token-routes/components/__tests__/routes-page-zero-channel-toggle.test.tsx
@@ -117,6 +117,12 @@ vi.mock('../../api', async () => {
   }
 })
 
+// The page's row-delete path uses the shared undo helper; tests stub it so
+// no QueryClientProvider is required.
+vi.mock('@/lib/undoable-delete', () => ({
+  useUndoableDelete: () => vi.fn(),
+}))
+
 vi.mock('../routes-columns', () => ({
   useRoutesColumns: () => [],
 }))

--- a/web/src/features/token-routes/components/__tests__/routes-page.test.tsx
+++ b/web/src/features/token-routes/components/__tests__/routes-page.test.tsx
@@ -111,6 +111,11 @@ vi.mock('../../api', () => ({
   useBatchUpdateRoutes: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useZeroChannelRoutes: (routes: unknown[]) => routes ?? [],
 }))
+// The page's row-delete path uses the shared undo helper; tests stub it so
+// no QueryClientProvider is required.
+vi.mock('@/lib/undoable-delete', () => ({
+  useUndoableDelete: () => vi.fn(),
+}))
 
 vi.mock('../routes-columns', () => ({
   useRoutesColumns: () => [],

--- a/web/src/features/token-routes/components/routes-page.tsx
+++ b/web/src/features/token-routes/components/routes-page.tsx
@@ -18,26 +18,21 @@ import {
   useUrlTableState,
 } from '@/components/data-table'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
 import { Spinner } from '@/components/ui/spinner'
 import { Switch } from '@/components/ui/switch'
 import { useAccounts } from '@/features/accounts/api'
 import { useChannels } from '@/features/channels/api'
 import { useSites } from '@/features/sites/api'
+import { api } from '@/lib/api'
+import { assertBusinessOk } from '@/lib/assert-business-ok'
 import { asStringParam } from '@/lib/helpers/searchParams'
+import { useUndoableDelete } from '@/lib/undoable-delete'
 
 import {
+  routeQueryKeys,
   type BatchRouteAction,
   useBatchUpdateRoutes,
   useClearRouteCooldown,
-  useDeleteRoute,
   useModelTokenCandidates,
   useRebuildRoutes,
   useRefreshRouteDecisions,
@@ -48,11 +43,7 @@ import {
 import { routesSearchSchema } from '../lib/routes-schema'
 import { useShowZeroChannelPreference } from '../lib/use-show-zero-channel'
 import type { RouteRowActions, RouteSummaryRow } from '../types'
-import {
-  isExplicitGroupRoute,
-  isExactModelPattern,
-  resolveRouteTitle,
-} from '../utils'
+import { isExplicitGroupRoute, isExactModelPattern } from '../utils'
 import { RouteDetailSheet } from './route-detail-sheet'
 import { RouteFormDialog, type RouteAccountOption } from './route-form-dialog'
 import { useRoutesColumns } from './routes-columns'
@@ -201,7 +192,6 @@ export function RoutesPage() {
   } = useRoutes()
   const candidatesQuery = useModelTokenCandidates()
 
-  const deleteMutation = useDeleteRoute()
   const updateMutation = useUpdateRoute()
   const clearCooldownMutation = useClearRouteCooldown()
   const rebuildMutation = useRebuildRoutes()
@@ -243,10 +233,6 @@ export function RoutesPage() {
   const [editRoute, setEditRoute] = useState<RouteSummaryRow | null>(null)
   const [detailOpen, setDetailOpen] = useState(false)
   const [detailRoute, setDetailRoute] = useState<RouteSummaryRow | null>(null)
-  const [deleteOpen, setDeleteOpen] = useState(false)
-  const [deleteRouteState, setDeleteRoute] = useState<RouteSummaryRow | null>(
-    null
-  )
   const [rebuildConfirmOpen, setRebuildConfirmOpen] = useState(false)
 
   // One-shot route drilldown (proxy-log detail -> `?routeId=N`): wait for
@@ -309,14 +295,32 @@ export function RoutesPage() {
     })
   }, [routerSearch, isLoading, routes, navigate, openEdit])
 
+  // S7 删除+undo 档: single route delete — no dialog; the row leaves
+  // immediately and a 6s undo toast gates the real DELETE.
+  const undoableDelete = useUndoableDelete()
+  const deleteRouteUndoable = useCallback(
+    (route: RouteSummaryRow) =>
+      undoableDelete<RouteSummaryRow[], RouteSummaryRow>({
+        item: route,
+        queryKey: routeQueryKeys.summary(),
+        removeFromCache: (data, item) =>
+          data.filter((entry) => entry.id !== item.id),
+        deleteFn: async (item) => {
+          const result = await api.deleteRoute(item.id)
+          assertBusinessOk(result, 'tokenRoutes.toast.deleteFailed')
+        },
+        title: t('tokenRoutes.toast.deleted'),
+        undoLabel: t('common.undo'),
+        errorTitle: t('tokenRoutes.toast.deleteFailed'),
+      }),
+    [undoableDelete, t]
+  )
+
   // Memoized so the column defs keep a stable identity across renders.
   const rowActions = useMemo<RouteRowActions>(
     () => ({
       onEdit: openEdit,
-      onDelete: (route) => {
-        setDeleteRoute(route)
-        setDeleteOpen(true)
-      },
+      onDelete: deleteRouteUndoable,
       onToggleEnabled: (route) =>
         updateMutation.mutate({
           id: route.id,
@@ -333,7 +337,13 @@ export function RoutesPage() {
         refreshDecisionsMutation.mutate()
       },
     }),
-    [openEdit, updateMutation, clearCooldownMutation, refreshDecisionsMutation]
+    [
+      openEdit,
+      deleteRouteUndoable,
+      updateMutation,
+      clearCooldownMutation,
+      refreshDecisionsMutation,
+    ]
   )
 
   const columns = useRoutesColumns(
@@ -401,17 +411,6 @@ export function RoutesPage() {
     const match = sitesList?.find((s) => s.id === siteId)
     return match?.name ?? `#${siteId}`
   }, [siteId, sitesList])
-
-  const confirmDelete = async () => {
-    if (!deleteRouteState) return
-    try {
-      await deleteMutation.mutateAsync(deleteRouteState.id)
-      setDeleteOpen(false)
-      setDeleteRoute(null)
-    } catch {
-      // http-client toasted
-    }
-  }
 
   return (
     <div className='flex h-full flex-col gap-3 p-4'>
@@ -533,38 +532,6 @@ export function RoutesPage() {
           openEdit(route)
         }}
       />
-
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t('tokenRoutes.page.deleteTitle')}</DialogTitle>
-            <DialogDescription>
-              {t('tokenRoutes.page.deleteDescription', {
-                name: deleteRouteState
-                  ? resolveRouteTitle(deleteRouteState)
-                  : '',
-              })}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant='outline'
-              onClick={() => setDeleteOpen(false)}
-              disabled={deleteMutation.isPending}
-            >
-              {t('common.cancel')}
-            </Button>
-            <Button
-              variant='destructive'
-              onClick={confirmDelete}
-              disabled={deleteMutation.isPending}
-            >
-              {deleteMutation.isPending && <Spinner />}
-              {t('common.delete')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
 
       <ConfirmDialog
         open={rebuildConfirmOpen}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -56,6 +56,7 @@
       "cancel": "Cancel",
       "save": "Save",
       "delete": "Delete",
+      "undo": "Undo",
       "loading": "Loading…",
       "noResults": "No results",
       "noResultsDescription": "No records match your current filters.",
@@ -1085,8 +1086,6 @@
           "apply": "Apply",
           "applyTitle": "Apply redirects?",
           "applyDescription": "Applying removes stale redirects from routing. This cannot be undone.",
-          "deleteTitle": "Delete redirect",
-          "deleteDescription": "This removes the redirect {{canonical}} → {{actual}}. This cannot be undone.",
           "promote": "To manual",
           "empty": "No model redirects. Click Generate to scan accounts.",
           "columns": {
@@ -1196,8 +1195,6 @@
           "enabledLabel": "Enabled",
           "save": "Save",
           "cancel": "Cancel",
-          "deleteTitle": "Delete source?",
-          "deleteDescription": "Once deleted, the source no longer participates in catalog merging. This action cannot be undone.",
           "snapshot": {
             "title": "Current merged snapshot",
             "source": "Source",
@@ -1315,8 +1312,6 @@
           "requests": "Requests: {{used}} / {{max}}",
           "cost": "Cost: {{used}} / {{max}}",
           "usage24h": "24h: {{requests}} req · {{tokens}} tok · ${{cost}}",
-          "deleteTitle": "Delete API key",
-          "deleteDescription": "Delete key \"{{name}}\"? This action cannot be undone.",
           "columns": {
             "name": "Name",
             "group": "Group",
@@ -2034,12 +2029,6 @@
         "toggleEnabled": "Enable/disable token",
         "edit": "Edit",
         "delete": "Delete",
-        "deleteConfirm": {
-          "title": "Delete token?",
-          "description": "This will delete token \"{{name}}\". This action cannot be undone.",
-          "confirm": "Delete",
-          "cancel": "Cancel"
-        },
         "form": {
           "invalid": "Please check the token form",
           "name": "Token name",
@@ -2123,8 +2112,6 @@
         "filterStatusEnabled": "Enabled",
         "filterStatusDisabled": "Disabled",
         "showZeroChannel": "Show zero-channel models (accounts have models but no routes generated)",
-        "deleteTitle": "Delete route",
-        "deleteDescription": "Delete route \"{{name}}\"? This action cannot be undone, and associated channels will be removed.",
         "rebuildConfirmTitle": "Rebuild routes?",
         "rebuildConfirmDescription": "Channels of existing routes will be recomposed from current model availability. Live routing may change.",
         "bulkEntityName": "route",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -56,6 +56,7 @@
       "cancel": "取消",
       "save": "保存",
       "delete": "删除",
+      "undo": "撤销",
       "loading": "加载中…",
       "noResults": "无匹配结果",
       "noResultsDescription": "没有符合当前筛选条件的记录。",
@@ -1085,8 +1086,6 @@
           "apply": "应用",
           "applyTitle": "应用重定向？",
           "applyDescription": "应用后将从路由中移除失效的重定向。此操作无法撤销。",
-          "deleteTitle": "删除重定向",
-          "deleteDescription": "将删除重定向 {{canonical}} → {{actual}}。此操作无法撤销。",
           "promote": "转手动",
           "empty": "暂无模型重定向。点击「生成」扫描账号。",
           "columns": {
@@ -1196,8 +1195,6 @@
           "enabledLabel": "启用",
           "save": "保存",
           "cancel": "取消",
-          "deleteTitle": "删除数据源？",
-          "deleteDescription": "删除后该源不再参与目录合并。此操作不可撤销。",
           "snapshot": {
             "title": "当前合并快照",
             "source": "来源",
@@ -1315,8 +1312,6 @@
           "requests": "请求：{{used}} / {{max}}",
           "cost": "成本：{{used}} / {{max}}",
           "usage24h": "24h：{{requests}} 次 · {{tokens}} tokens · ${{cost}}",
-          "deleteTitle": "删除 API 密钥",
-          "deleteDescription": "删除密钥「{{name}}」？此操作不可撤销。",
           "columns": {
             "name": "名称",
             "group": "分组",
@@ -2034,12 +2029,6 @@
         "toggleEnabled": "启用/禁用令牌",
         "edit": "编辑",
         "delete": "删除",
-        "deleteConfirm": {
-          "title": "删除令牌？",
-          "description": "将删除令牌「{{name}}」，此操作不可撤销。",
-          "confirm": "删除",
-          "cancel": "取消"
-        },
         "form": {
           "invalid": "请检查令牌表单",
           "name": "令牌名称",
@@ -2123,8 +2112,6 @@
         "filterStatusEnabled": "启用",
         "filterStatusDisabled": "停用",
         "showZeroChannel": "显示零通道模型（账号有模型但未生成路由）",
-        "deleteTitle": "删除路由",
-        "deleteDescription": "确定删除路由「{{name}}」？该操作不可撤销，相关通道将一并清除。",
         "rebuildConfirmTitle": "重建路由？",
         "rebuildConfirmDescription": "将根据当前模型可用性重组现有路由的通道，实时路由可能发生变化。",
         "bulkEntityName": "路由",

--- a/web/src/lib/__tests__/undoable-delete.test.tsx
+++ b/web/src/lib/__tests__/undoable-delete.test.tsx
@@ -1,0 +1,177 @@
+// metapi-go/lib — undoable-delete tests (S7 删除+undo 档).
+//
+// Pins the deferred-delete contract: optimistic removal on trigger, commit
+// only when the window closes (auto-close or dismiss), snapshot restore on
+// undo, snapshot restore + error toast on commit failure, and idempotence
+// (undo after commit / commit after undo never double-fires).
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  useUndoableDelete,
+  type UndoableDeleteParams,
+} from '../undoable-delete'
+
+const { mockToastMessage, mockToastError, mockToastDismiss } = vi.hoisted(
+  () => ({
+    mockToastMessage: vi.fn((_title: unknown, _options?: unknown) => 42),
+    mockToastError: vi.fn(),
+    mockToastDismiss: vi.fn(),
+  })
+)
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    message: mockToastMessage,
+    error: mockToastError,
+    dismiss: mockToastDismiss,
+  },
+}))
+
+type Row = { id: number; name: string }
+
+const QUERY_KEY = ['rows'] as const
+const ROWS: Row[] = [
+  { id: 1, name: 'alpha' },
+  { id: 2, name: 'beta' },
+]
+
+function setup() {
+  const queryClient = new QueryClient()
+  queryClient.setQueryData(QUERY_KEY, ROWS)
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  const { result } = renderHook(() => useUndoableDelete(), { wrapper })
+  return { queryClient, trigger: result.current }
+}
+
+function params(
+  overrides: Partial<UndoableDeleteParams<Row[], Row>> = {}
+): UndoableDeleteParams<Row[], Row> {
+  return {
+    item: ROWS[1] as Row,
+    queryKey: QUERY_KEY,
+    removeFromCache: (data: Row[], item: Row) =>
+      data.filter((row) => row.id !== item.id),
+    deleteFn: vi.fn(async () => ({ success: true })),
+    title: 'Deleted',
+    undoLabel: 'Undo',
+    errorTitle: 'Delete failed',
+    ...overrides,
+  }
+}
+
+function toastOptions() {
+  return mockToastMessage.mock.calls[0]?.[1] as {
+    action: { label: string; onClick: () => void }
+    onAutoClose: () => void
+    onDismiss: () => void
+  }
+}
+
+beforeEach(() => {
+  mockToastMessage.mockClear()
+  mockToastError.mockClear()
+  mockToastDismiss.mockClear()
+})
+
+describe('useUndoableDelete', () => {
+  it('removes the row optimistically and commits on auto-close', async () => {
+    const { queryClient, trigger } = setup()
+    const p = params()
+
+    act(() => trigger(p))
+
+    expect(queryClient.getQueryData(QUERY_KEY)).toEqual([ROWS[0]])
+    expect(p.deleteFn).not.toHaveBeenCalled()
+    expect(mockToastMessage).toHaveBeenCalledWith(
+      'Deleted',
+      expect.objectContaining({ duration: 6000 })
+    )
+
+    await act(async () => toastOptions().onAutoClose())
+
+    expect(p.deleteFn).toHaveBeenCalledWith(ROWS[1])
+  })
+
+  it('dismiss (swipe) also commits', async () => {
+    const { trigger } = setup()
+    const p = params()
+
+    act(() => trigger(p))
+    await act(async () => toastOptions().onDismiss())
+
+    expect(p.deleteFn).toHaveBeenCalledWith(ROWS[1])
+  })
+
+  it('undo restores the snapshot, dismisses the toast, and blocks the commit', async () => {
+    const { queryClient, trigger } = setup()
+    const p = params()
+
+    act(() => trigger(p))
+    await act(async () => toastOptions().action.onClick())
+
+    expect(queryClient.getQueryData(QUERY_KEY)).toEqual(ROWS)
+    expect(mockToastDismiss).toHaveBeenCalledWith(42)
+
+    await act(async () => toastOptions().onAutoClose())
+    await act(async () => toastOptions().onDismiss())
+    expect(p.deleteFn).not.toHaveBeenCalled()
+  })
+
+  it('undo after commit does not resurrect the row', async () => {
+    const { queryClient, trigger } = setup()
+    const p = params()
+
+    act(() => trigger(p))
+    await act(async () => toastOptions().onAutoClose())
+    await act(async () => toastOptions().action.onClick())
+
+    expect(p.deleteFn).toHaveBeenCalledTimes(1)
+    expect(queryClient.getQueryData(QUERY_KEY)).toEqual([ROWS[0]])
+  })
+
+  it('restores the snapshot and toasts the error when the commit rejects', async () => {
+    const { queryClient, trigger } = setup()
+    const p = params({
+      deleteFn: vi.fn(async () => {
+        throw new Error('boom')
+      }),
+      errorTitle: (error: unknown) => `failed: ${(error as Error).message}`,
+    })
+
+    act(() => trigger(p))
+    await act(async () => toastOptions().onAutoClose())
+    // flush the rejection handler
+    await act(async () => {})
+
+    expect(queryClient.getQueryData(QUERY_KEY)).toEqual(ROWS)
+    expect(mockToastError).toHaveBeenCalledWith('failed: boom')
+  })
+
+  it('invalidates the primary and extra query keys after commit', async () => {
+    const { queryClient, trigger } = setup()
+    const spy = vi.spyOn(queryClient, 'invalidateQueries')
+    const p = params({ alsoInvalidate: [['other'], ['parent', 'all']] })
+
+    act(() => trigger(p))
+    await act(async () => toastOptions().onAutoClose())
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: QUERY_KEY })
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['other'] })
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['parent', 'all'] })
+  })
+
+  it('honours a custom undo window', () => {
+    const { trigger } = setup()
+    act(() => trigger(params({ windowMs: 50 })))
+    expect(mockToastMessage).toHaveBeenCalledWith(
+      'Deleted',
+      expect.objectContaining({ duration: 50 })
+    )
+  })
+})

--- a/web/src/lib/undoable-delete.ts
+++ b/web/src/lib/undoable-delete.ts
@@ -1,0 +1,120 @@
+// metapi-go/lib — undoable delete (S7 删除+undo 档).
+//
+// Gmail-style deferred delete: the row leaves the list immediately
+// (optimistic cache update) and a toast offers 撤销 for a short window;
+// the real DELETE fires only when the toast auto-closes or is swiped away.
+// Clicking 撤销 restores the exact cache snapshot — nothing was ever
+// deleted server-side, so undo is always safe. If the commit fails, the
+// snapshot is restored and the error toast explains why.
+//
+// Use this for leaf single-row deletes (announcements, redirects, catalog
+// sources, routes, keys, tokens). Cascading deletes (site → accounts,
+// account → tokens) and bulk/irreversible ops keep their confirm dialogs —
+// those are the 批量确认 / typed-confirm tiers, not this one.
+
+import { useQueryClient } from '@tanstack/react-query'
+import { useCallback } from 'react'
+
+import { toast } from '@/lib/toast'
+
+/** Default undo window. Long enough to notice, short enough to not stall. */
+const UNDO_WINDOW_MS = 6000
+
+export type UndoableDeleteParams<TCache, TItem> = {
+  /** The row being deleted (passed to removeFromCache + deleteFn). */
+  item: TItem
+  /** List query whose cached payload is optimistically updated. */
+  queryKey: readonly unknown[]
+  /** Pure: return the cache payload without the item. */
+  removeFromCache: (data: TCache, item: TItem) => TCache
+  /** The real DELETE (fires only after the undo window closes). */
+  deleteFn: (item: TItem) => Promise<unknown>
+  /** Toast text — the caller's localized "deleted" message. */
+  title: string
+  /** Undo action label (t('common.undo')). */
+  undoLabel: string
+  /** Failure toast text shown when the deferred DELETE rejects. */
+  errorTitle: string | ((error: unknown) => string)
+  /**
+   * Extra query keys to invalidate after the commit lands (e.g. a parent
+   * list that derives counts from the deleted row). The primary queryKey is
+   * always invalidated.
+   */
+  alsoInvalidate?: Array<readonly unknown[]>
+  /** Overrides the 6s window (tests). */
+  windowMs?: number
+}
+
+export function useUndoableDelete() {
+  const queryClient = useQueryClient()
+
+  // Stable identity so callers can drop the trigger into memo dep arrays
+  // (column defs, row-action maps) without re-creating them every render.
+  return useCallback(
+    function triggerUndoableDelete<TCache, TItem>(
+      params: UndoableDeleteParams<TCache, TItem>
+    ): void {
+      const {
+        item,
+        queryKey,
+        removeFromCache,
+        deleteFn,
+        title,
+        undoLabel,
+        errorTitle,
+        alsoInvalidate = [],
+        windowMs = UNDO_WINDOW_MS,
+      } = params
+
+      const snapshot = queryClient.getQueryData<TCache>(queryKey)
+      queryClient.setQueryData<TCache>(queryKey, (current) =>
+        current === undefined ? current : removeFromCache(current, item)
+      )
+
+      let settled = false
+
+      const undo = (toastId: string | number) => {
+        if (settled) return
+        settled = true
+        if (snapshot !== undefined) {
+          queryClient.setQueryData(queryKey, snapshot)
+        }
+        toast.dismiss(toastId)
+      }
+
+      const commit = () => {
+        if (settled) return
+        settled = true
+        deleteFn(item)
+          .then(() => {
+            void queryClient.invalidateQueries({ queryKey })
+            for (const extra of alsoInvalidate) {
+              void queryClient.invalidateQueries({ queryKey: extra })
+            }
+          })
+          .catch((error: unknown) => {
+            // Restore the row and say so — a silent resurrect would read as
+            // a ghost; the error toast owns the explanation.
+            if (snapshot !== undefined) {
+              queryClient.setQueryData(queryKey, snapshot)
+            }
+            toast.error(
+              typeof errorTitle === 'function' ? errorTitle(error) : errorTitle
+            )
+          })
+      }
+
+      const toastId = toast.message(title, {
+        duration: windowMs,
+        action: {
+          label: undoLabel,
+          onClick: () => undo(toastId),
+        },
+        onAutoClose: commit,
+        // Swipe/× dismiss = accepting the delete (Gmail semantics).
+        onDismiss: commit,
+      })
+    },
+    [queryClient]
+  )
+}


### PR DESCRIPTION
## 背景（#1035 S7：破坏性操作四档 + undo）

叶子实体的单行删除此前一律走确认弹窗。按四档分级（直达 / 删除+undo / 批量确认 / typed-confirm），叶子删除应是无弹窗 + 可撤销。

## 方案

新增共享 helper `web/src/lib/undoable-delete.ts`（Gmail 式延迟删除）：
- 行立即从列表消失（乐观缓存更新），toast 提供 **6 秒撤销窗**
- 真实 DELETE 仅在 toast 自动关闭或被划走时触发；点「撤销」精确恢复快照（服务端从未删除，undo 恒安全）
- 提交失败恢复快照 + 错误 toast；`alsoInvalidate` 覆盖父列表（如账号令牌计数）
- hook 返回稳定引用（可直接入 memo deps）

**接入 5 个叶子删除流**（删确认弹窗）：模型重定向、目录源、令牌路由、下游 API 密钥、账号令牌。

**保留原档**：批量操作（计数确认）、factory reset（typed-confirm+倒计时）、站点/账号级联删除（确认弹窗）、OAuth 连接（确认 + 既有跨页乐观回滚 hook，例外已注释）。四档规约写入 `DESIGN.md §4.1`。

## 测试

- lib 契约测试 ×7（乐观移除 / 撤销恢复 / auto-close 与 dismiss 双提交路径 / 失败恢复 / 幂等 / 额外失效键 / 自定义窗口）
- 各流测试从弹窗断言改写为 undo 契约（redirects 两条、tokens-panel 一条）；token-routes 5 个测试文件补 helper mock
- 死 locale 键清理（redirects/catalogSources/keys/tokenRoutes/tokens 的 deleteTitle 系列），新增 `common.undo` 双语
- 全量 vitest 1560 绿

## 截图验证（seeded 4100）

路由页行删除：行即消失 +「路由已删除 · 撤销」toast；点撤销行恢复（4→3→4 行实测）。