### PR TITLE
refactor(web): unify event-title localization into one shared map + namespace

### DIFF
--- a/web/src/features/settings/__tests__/program-event-normalize.test.ts
+++ b/web/src/features/settings/__tests__/program-event-normalize.test.ts
@@ -7,7 +7,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  eventTitleKey,
+  eventTitleSlug,
   formatTimestamp,
   normalizeEvent,
   parseEventMessage,
@@ -68,19 +68,27 @@ describe('formatTimestamp', () => {
   })
 })
 
-describe('eventTitleKey', () => {
-  it('maps known backend titles to localized i18n keys', () => {
-    expect(eventTitleKey('All proxies failed')).toBe('allProxiesFailed')
-    expect(eventTitleKey('Token expired')).toBe('tokenExpired')
-    expect(eventTitleKey('Low balance')).toBe('lowBalance')
-    expect(eventTitleKey('checkin failed (cloudflare challenge)')).toBe(
+describe('eventTitleSlug (shared lib/event-titles map)', () => {
+  it('maps known backend titles to stable slugs', () => {
+    expect(eventTitleSlug('All proxies failed')).toBe('allProxiesFailed')
+    expect(eventTitleSlug('Token expired')).toBe('tokenExpired')
+    expect(eventTitleSlug('Low balance')).toBe('lowBalance')
+    expect(eventTitleSlug('checkin failed (cloudflare challenge)')).toBe(
       'checkinFailedCloudflare'
+    )
+    // Daily-frequency producers pinned by the F3 scout inventory.
+    expect(eventTitleSlug('checkin success')).toBe('checkinSuccess')
+    expect(eventTitleSlug('Site enabled')).toBe('siteEnabled')
+    expect(eventTitleSlug('Account token sync completed')).toBe(
+      'tokenSyncCompleted'
     )
   })
 
   it('returns undefined for unknown titles so they render as-is', () => {
-    expect(eventTitleKey('Some new event')).toBeUndefined()
-    expect(eventTitleKey('')).toBeUndefined()
+    expect(eventTitleSlug('Some new event')).toBeUndefined()
+    expect(eventTitleSlug('')).toBeUndefined()
+    // Dynamic upstream-pushed titles are intentionally unmapped.
+    expect(eventTitleSlug('Site announcement: OneAPI')).toBeUndefined()
   })
 })
 

--- a/web/src/features/settings/sections/operations/components/program-logs-section.tsx
+++ b/web/src/features/settings/sections/operations/components/program-logs-section.tsx
@@ -36,7 +36,7 @@ import {
 } from '../../../components/settings-section-card'
 import { SettingsSectionError } from '../../../components/settings-section-error'
 import {
-  eventTitleKey,
+  eventTitleSlug,
   formatTimestamp,
   normalizeEvent,
   parseEventMessage,
@@ -66,10 +66,8 @@ function levelVariant(level?: string): 'default' | 'secondary' | 'destructive' {
 /** Localized event title: known backend titles map to i18n keys, the rest render as-is. */
 function EventTitle({ event }: { event: ProgramEvent }) {
   const { t } = useTranslation()
-  const key = eventTitleKey(event.title)
-  return key
-    ? t(`settings.operations.programLogs.eventTitles.${key}`)
-    : event.title
+  const slug = eventTitleSlug(event.title)
+  return slug ? t(`events.titles.${slug}`) : event.title
 }
 
 /**

--- a/web/src/features/settings/sections/operations/lib/event-normalize.ts
+++ b/web/src/features/settings/sections/operations/lib/event-normalize.ts
@@ -5,6 +5,10 @@
 import i18n from 'i18next'
 
 import { toBcp47 } from '@/i18n/languages'
+// Single source of truth for backend event title → i18n slug lives in
+// lib/event-titles (shared with the attention pipeline); re-exported here so
+// existing imports keep working.
+export { eventTitleSlug } from '@/lib/event-titles'
 import { formatDateTime } from '@/lib/format'
 
 /**
@@ -61,24 +65,6 @@ export function normalizeEvent(raw: Record<string, unknown>): ProgramEvent {
 export function formatTimestamp(value?: string): string {
   if (!value) return '—'
   return formatDateTime(value, toBcp47(i18n.language || 'en'))
-}
-
-/**
- * Map backend event titles (written in English by the alert/checkin services)
- * to localized i18n keys. Unknown titles render as-is.
- */
-const EVENT_TITLE_KEYS: Record<string, string> = {
-  'Token expired': 'tokenExpired',
-  'Low balance': 'lowBalance',
-  'All proxies failed': 'allProxiesFailed',
-  'checkin success': 'checkinSuccess',
-  'checkin skipped': 'checkinSkipped',
-  'checkin failed': 'checkinFailed',
-  'checkin failed (cloudflare challenge)': 'checkinFailedCloudflare',
-}
-
-export function eventTitleKey(title: string): string | undefined {
-  return EVENT_TITLE_KEYS[title]
 }
 
 /** Structured parts of an enriched event message. */

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -50,6 +50,25 @@
       "searchParamDescription": "This link contains outdated or malformed parameters. Reset it to open the page with default settings.",
       "searchParamReset": "Reset URL"
     },
+    "events": {
+      "titles": {
+        "allProxiesFailed": "All proxies failed",
+        "lowBalance": "Low balance",
+        "tokenExpired": "Token expired",
+        "siteDisabled": "Site disabled",
+        "siteEnabled": "Site enabled",
+        "checkinSuccess": "Check-in succeeded",
+        "checkinFailed": "Check-in failed",
+        "checkinFailedCloudflare": "Check-in failed (Cloudflare challenge)",
+        "checkinSkipped": "Check-in skipped",
+        "tokenSyncFailed": "Account token sync failed",
+        "tokenSyncCompleted": "Account token sync completed",
+        "adminTokenUpdated": "Admin login token updated",
+        "runtimeSettingsUpdated": "Runtime settings updated",
+        "disabledModelRepaired": "Disabled model repaired (mapping auto-restored)",
+        "backupImportAddedKeys": "Backup import added downstream API keys"
+      }
+    },
     "common": {
       "skipToMain": "Skip to main content",
       "confirm": "Confirm",
@@ -914,14 +933,6 @@
           "disabledSite": "Site disabled: {{name}}",
           "balanceUnknown": "Balance unknown: {{name}}",
           "siteAnnouncement": "Upstream announcement: {{title}}",
-          "eventAllProxiesFailed": "All proxies failed",
-          "eventLowBalance": "Low balance",
-          "eventTokenExpired": "Token expired",
-          "eventSiteDisabled": "Site disabled",
-          "eventCheckinFailed": "Check-in failed",
-          "eventCheckinFailedCloudflare": "Check-in failed (Cloudflare challenge)",
-          "eventCheckinSkipped": "Check-in skipped",
-          "eventTokenSyncFailed": "Account token sync failed",
           "mergedCount": "{{count}} merged events",
           "severity": {
             "critical": "critical",
@@ -1639,15 +1650,6 @@
           "clearTitle": "Clear operational events?",
           "clearDescription": "All operational events will be permanently deleted. This cannot be undone.",
           "empty": "No operational events.",
-          "eventTitles": {
-            "tokenExpired": "Token expired",
-            "lowBalance": "Low balance",
-            "allProxiesFailed": "All proxies failed",
-            "checkinSuccess": "Check-in succeeded",
-            "checkinSkipped": "Check-in skipped",
-            "checkinFailed": "Check-in failed",
-            "checkinFailedCloudflare": "Check-in failed (Cloudflare challenge)"
-          },
           "messageParts": {
             "affectedRoutes": "Affected routes",
             "alternativeSites": "Alternative sites",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -50,6 +50,25 @@
       "searchParamDescription": "链接中包含过期或格式错误的参数。重置链接后将使用默认设置打开页面。",
       "searchParamReset": "重置链接"
     },
+    "events": {
+      "titles": {
+        "allProxiesFailed": "全部代理失败",
+        "lowBalance": "余额不足",
+        "tokenExpired": "令牌已过期",
+        "siteDisabled": "站点已禁用",
+        "siteEnabled": "站点已启用",
+        "checkinSuccess": "签到成功",
+        "checkinFailed": "签到失败",
+        "checkinFailedCloudflare": "签到失败（Cloudflare 验证）",
+        "checkinSkipped": "签到已跳过",
+        "tokenSyncFailed": "账号令牌同步失败",
+        "tokenSyncCompleted": "账号令牌同步完成",
+        "adminTokenUpdated": "管理员登录令牌已更新",
+        "runtimeSettingsUpdated": "运行时设置已更新",
+        "disabledModelRepaired": "已修复禁用模型（映射已自动恢复）",
+        "backupImportAddedKeys": "备份导入已添加下游 API 密钥"
+      }
+    },
     "common": {
       "skipToMain": "跳转到主要内容",
       "confirm": "确定",
@@ -914,14 +933,6 @@
           "disabledSite": "站点已停用：{{name}}",
           "balanceUnknown": "余额未知：{{name}}",
           "siteAnnouncement": "上游公告：{{title}}",
-          "eventAllProxiesFailed": "全部代理失败",
-          "eventLowBalance": "余额不足",
-          "eventTokenExpired": "令牌已过期",
-          "eventSiteDisabled": "站点已禁用",
-          "eventCheckinFailed": "签到失败",
-          "eventCheckinFailedCloudflare": "签到失败（Cloudflare 验证）",
-          "eventCheckinSkipped": "已跳过签到",
-          "eventTokenSyncFailed": "账号令牌同步失败",
           "mergedCount": "合并 {{count}} 条事件",
           "severity": {
             "critical": "严重",
@@ -1639,15 +1650,6 @@
           "clearTitle": "清空运行事件？",
           "clearDescription": "所有运行事件将被永久删除。此操作无法撤销。",
           "empty": "暂无运行事件。",
-          "eventTitles": {
-            "tokenExpired": "令牌失效",
-            "lowBalance": "余额不足",
-            "allProxiesFailed": "代理全部失败",
-            "checkinSuccess": "签到成功",
-            "checkinSkipped": "签到已跳过",
-            "checkinFailed": "签到失败",
-            "checkinFailedCloudflare": "签到失败（Cloudflare 验证）"
-          },
           "messageParts": {
             "affectedRoutes": "受影响路由",
             "alternativeSites": "替代站点",

--- a/web/src/lib/attention-label.ts
+++ b/web/src/lib/attention-label.ts
@@ -24,29 +24,12 @@ export type AttentionItem = {
   params?: Record<string, string | number>
 }
 
+import { eventTitleSlug } from './event-titles'
+
 /** Attention response envelope. */
 export type AttentionResponse = {
   items: AttentionItem[]
   total: number
-}
-
-/**
- * Event titles are persisted English strings (events.title) — the event row
- * is written once at emission time and never re-localized server-side, so
- * the known producer titles map to i18n keys at render time. Unknown titles
- * fall through to the raw label (honest residual, never a half-translation).
- */
-const EVENT_TITLE_KEYS: Record<string, string> = {
-  'All proxies failed': 'dashboard.availability.monitors.eventAllProxiesFailed',
-  'Low balance': 'dashboard.availability.monitors.eventLowBalance',
-  'Token expired': 'dashboard.availability.monitors.eventTokenExpired',
-  'Site disabled': 'dashboard.availability.monitors.eventSiteDisabled',
-  'checkin failed': 'dashboard.availability.monitors.eventCheckinFailed',
-  'checkin failed (cloudflare challenge)':
-    'dashboard.availability.monitors.eventCheckinFailedCloudflare',
-  'checkin skipped': 'dashboard.availability.monitors.eventCheckinSkipped',
-  'account token sync failed':
-    'dashboard.availability.monitors.eventTokenSyncFailed',
 }
 
 type TranslateFn = (key: string, options?: Record<string, unknown>) => string
@@ -93,8 +76,11 @@ export function attentionLabel(item: AttentionItem, t: TranslateFn): string {
         : item.label
     }
     case 'event': {
-      const key = EVENT_TITLE_KEYS[item.label]
-      return key ? t(key) : item.label
+      // Persisted event titles map through the shared slug → `events.titles.*`
+      // namespace (same source as the program-logs page). Unknown/dynamic
+      // titles fall through to the raw label.
+      const slug = eventTitleSlug(item.label)
+      return slug ? t(`events.titles.${slug}`) : item.label
     }
     default:
       return item.label

--- a/web/src/lib/event-titles.ts
+++ b/web/src/lib/event-titles.ts
@@ -1,0 +1,45 @@
+// metapi-go/lib — shared event-title → i18n slug map.
+//
+// Backend event titles are persisted English strings (events.title — the row
+// is written once at emission time and never re-localized server-side), and
+// TWO surfaces translate them at render time: the program-logs page and the
+// attention pipeline (bell popover + availability panel). They share this
+// single map so a newly introduced producer title is mapped once, not twice.
+//
+// Unknown titles fall through to the raw label at the call site (honest
+// residual, never a half-translation). Dynamic titles (e.g. "Site
+// announcement: <site name>" — upstream-pushed foreign data) are
+// intentionally NOT mapped.
+//
+// The slug resolves under the shared `events.titles.*` locale section.
+
+/** All known persisted producer titles → stable slug. */
+const EVENT_TITLE_SLUGS: Record<string, string> = {
+  'All proxies failed': 'allProxiesFailed',
+  'Low balance': 'lowBalance',
+  'Token expired': 'tokenExpired',
+  'Site disabled': 'siteDisabled',
+  'Site enabled': 'siteEnabled',
+  'checkin success': 'checkinSuccess',
+  'checkin failed': 'checkinFailed',
+  'checkin failed (cloudflare challenge)': 'checkinFailedCloudflare',
+  'checkin skipped': 'checkinSkipped',
+  'account token sync failed': 'tokenSyncFailed',
+  'Account token sync completed': 'tokenSyncCompleted',
+  'Admin login token updated': 'adminTokenUpdated',
+  'Runtime settings updated': 'runtimeSettingsUpdated',
+  'Disabled model repaired (mapping auto-restored)': 'disabledModelRepaired',
+  'Backup import added downstream API keys': 'backupImportAddedKeys',
+}
+
+/**
+ * Slug for a persisted event title, or undefined for unknown/dynamic titles
+ * (caller renders the raw label).
+ *
+ * Call sites must use a literal template key — `t(`events.titles.${slug}`)` —
+ * so the i18n key-coverage gate statically verifies the `events.titles`
+ * prefix (a function-built key would be invisible to the scanner).
+ */
+export function eventTitleSlug(title: string): string | undefined {
+  return EVENT_TITLE_SLUGS[title]
+}


### PR DESCRIPTION
## 背景

两个界面在渲染时翻译持久化的英文事件标题，却各带一份映射表 + 各自 locale 节——漂移源。F3 后端文案清点（scout 报告）实证：7 个生产者标题（checkin success、Site enabled、Account token sync completed、Runtime settings updated、Admin login token updated、Disabled model repaired、Backup import added keys）**两边都没映射**，中文 UI 里程序日志页和 attention 管线对这些高频事件裸渲染英文。

## 改动

- 新增 `web/src/lib/event-titles.ts`：单一 title → slug 映射（15 个已知生产者；上游推送的动态标题刻意不映射），两个界面共用。
- 单一 locale 节 `events.titles.*`（15 键，en + zh-CN）取代 `settings.operations.programLogs.eventTitles.*` 与 `dashboard.availability.monitors.event*`——同一标题一份措辞，不再双份翻译。
- `attention-label.ts` 的 event 分支与 program-logs 的 EventTitle 都经 `eventTitleSlug` + 字面量模板 ``events.titles.${slug}`` 解析（字面量形式让 i18n 键覆盖门禁静态校验前缀）。

## 验证

- 全量 vitest 1560 绿；lint/typecheck/knip 全过
- seeded 实例程序日志页 zh-CN：「全部代理失败」经共享 namespace 渲染（截图复核），en 无回归

后续大件（后端 events 表 key+params 结构化）已登记 MASTER F5。