### PR TITLE
docs: closeout sync for #1099 (event-titles unification; F5 registered)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to Metapi-Go will be documented in this file.
 
 ### Changed
 
+- **事件标题 i18n 统一为单一映射 + 单一词条节（#1099）**：程序日志页与 attention 管线此前各带一份事件标题映射表和 locale 节（漂移源），7 个高频生产者标题（签到成功、站点启用、令牌同步完成、运行时设置更新、管理员令牌更新、模型修复、备份导入）两边均未映射而在中文界面裸显英文。现收敛为共享 `lib/event-titles.ts`（15 个已知生产者标题 → slug）+ 单一 locale 节 `events.titles.*`；未知/动态标题仍原文渲染（诚实残留）。
+
+
 - **section-registry 三克隆合一（#1095，#1035 S8）**：settings/dashboard/observability 各自的 `createSectionRegistry` 收敛为共享 `web/src/lib/section-registry.ts`（`urlStyle` 承载 path/query 两种 URL 形态）；行为不变，净 -101 行。
 
 

--- a/docs/internal/log.md
+++ b/docs/internal/log.md
@@ -5,6 +5,12 @@
 > Product milestone timeline (grouped by version). Not the current-state source of truth.
 > Current state → [`STATE.md`](STATE.md) · open items → [`progress/MASTER.md`](progress/MASTER.md) · detailed version narrative → root [`CHANGELOG.md`](../../CHANGELOG.md)
 
+## 2026-08-30 — 事件标题 i18n 统一（一份 map 一个 namespace）
+
+- **#1099**：两个界面（程序日志页 eventTitleKey、attention 管线 attention-label）各带一份事件标题映射 + 各自 locale 节——漂移源被 F3 scout 清点实证：7 个生产者标题（checkin success / Site enabled / token sync completed / runtime settings / admin token / model repaired / backup import）两边都没映射，中文 UI 裸渲染英文。收敛为 `web/src/lib/event-titles.ts` 单一 title→slug 映射（15 生产者；动态上游标题刻意不映射）+ 单一 locale 节 `events.titles.*`（删 programLogs.eventTitles.* 与 monitors.event* 两处重复翻译）。seeded 程序日志页双语截图验证。
+- **F3 scout 调研报告归档**（alert-i18n-scout-v2）：events 表存成品英文 title+message 的完整清单（17 写入点）、locale 来源查证（后端无 locale 上下文）、方案对比（推荐 A：产生时存 key+params、渲染时按 viewer locale；title 列保留为历史 fallback 零迁移）→ 登记 MASTER 开放项 **F5**（3-4 天评估，不阻塞）。
+- **backend-string-scout 清点报告归档**：attention 6 类 params 全部齐全（前端结构健康）；无 errorCode 硬编码英文错误 top 采样（admin toast 面 ~10 条 vs proxy 协议层明确不 i18n）；推送类文案（daily summary/checkin round/test notification）维持英文为设计边界。
+
 ## 2026-08-30 — S7 undo 档收官，#1035 S1–S10 全部关闭
 
 - **删除+undo 档（#1097）**：新增共享 `web/src/lib/undoable-delete.ts`——Gmail 式延迟删除（乐观移除 + 6s 撤销 toast + 快照恢复；真实 DELETE 仅在窗口关闭后触发；失败恢复快照 + 错误 toast；`alsoInvalidate` 覆盖父列表）。接入五处叶子删除：模型重定向、目录源、令牌路由、下游 API 密钥、账号令牌（各删确认弹窗）。保留原档：批量（计数确认）、factory reset（typed-confirm）、站点/账号级联删除（确认）、OAuth 连接（确认 + 既有跨页乐观回滚，注释例外）。四档规约入 DESIGN.md §4.1。lib 契约测试 ×7 + 各流改写为 undo 契约钉；seeded 实例端到端验证（行 4→3→4）。

--- a/docs/internal/progress/MASTER.md
+++ b/docs/internal/progress/MASTER.md
@@ -15,6 +15,7 @@
 | # | 内容 | 建议验收 |
 |---|---|---|
 | C4 | ~~#1035 结构性专题 S1–S10~~ **全部交付，issue 已关闭**（S7 收官 #1097：undo 档 helper + 五处叶子删除接入 + DESIGN.md §4.1 四档规约） | — |
+| F5 | **events 表 key+params 结构化**（P3，后端架构改动）：事件当前存成品英文 title+message，message 内嵌参数无法重建；方案 = 产生时存 titleKey+params(JSON)、渲染时前端按 viewer locale 翻译（title 列保留为历史 fallback，零迁移）。调研报告已产出（17 写入点清单 + 方案对比 + 3-4 天评估），见 log.md 2026-08-30 条 | 新事件双语端到端 + 历史行原文 fallback |
 
 F3（后端告警文案 i18n）已交付（#1091，2026-08-30）：新增共享模块 `web/src/lib/attention-label.ts`（AttentionItem/AttentionResponse 类型 + 8 事件标题键映射 + attentionLabel），attention-bell 与 availability-section 共用、删两份本地副本；en/zh-CN 补 7 事件标题键；params 缺失/未知类别回退裸 label（诚实残留）。双语端到端截图验证通过（铃铛弹层 + availability 面板 zh-CN/en）。F2（site-form 抽屉迁移）已交付（#1082）：居中 Dialog → 右侧 Sheet。F4（docs/api.md 超预算拆分）已交付（2026-08-30）：`docs/api.md` 保留为索引，按域拆为 `docs/api/*.md` 17 个文件，全部原有 H2/H3 标题以 stub 承接、旧 anchor 落位。
 


### PR DESCRIPTION
事件标题统一销项 + 两份 scout 报告归档（F3 方案 A → MASTER F5 登记、后端文案清点结论）；log.md 条目 + CHANGELOG Unreleased 登记。