### PR TITLE
fix(web): collapse duplicated day in log timestamp detail line

### DIFF
--- a/web/src/features/proxy-logs/components/proxy-logs-columns.tsx
+++ b/web/src/features/proxy-logs/components/proxy-logs-columns.tsx
@@ -20,8 +20,7 @@ import {
 import { toBcp47 } from '@/i18n/languages'
 import {
   formatDateTime,
-  formatRelativeTime,
-  formatShortDate,
+  formatLogDateDetail,
   formatTimeOfDay,
 } from '@/lib/format'
 import { cn } from '@/lib/utils'
@@ -73,8 +72,7 @@ export function useProxyLogsColumns(
               {formatTimeOfDay(createdAt, locale)}
             </span>
             <span className='text-muted-foreground text-[10px]'>
-              {formatShortDate(createdAt, locale)} ·{' '}
-              {formatRelativeTime(createdAt, locale)}
+              {formatLogDateDetail(createdAt, locale)}
             </span>
           </div>
         )

--- a/web/src/lib/__tests__/format.test.ts
+++ b/web/src/lib/__tests__/format.test.ts
@@ -12,6 +12,7 @@ import {
   formatInt,
   formatLatency,
   formatPrice,
+  formatLogDateDetail,
   formatRelativeTime,
   formatShortDate,
   formatSuccessRate,
@@ -213,5 +214,27 @@ describe('formatRelativeTime', () => {
   it('returns an empty string for missing input', () => {
     expect(formatRelativeTime(null, 'en-US')).toBe('')
     expect(formatRelativeTime('', 'en-US')).toBe('')
+  })
+})
+
+describe('formatLogDateDetail', () => {
+  it('combines short date + relative time inside the relative window', () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000)
+    const detail = formatLogDateDetail(twoHoursAgo, 'en-US')
+    expect(detail).toContain('·')
+    expect(detail).toContain('2 hours ago')
+  })
+
+  it('collapses to the absolute date past the relative window (no duplicate day)', () => {
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000)
+    const detail = formatLogDateDetail(eightDaysAgo, 'zh-CN')
+    // "2026年8月23日" — must NOT be prefixed with the short date again.
+    expect(detail).not.toContain('·')
+    expect(detail).toBe(formatRelativeTime(eightDaysAgo, 'zh-CN'))
+  })
+
+  it('returns an empty string for missing input', () => {
+    expect(formatLogDateDetail(null, 'en-US')).toBe('')
+    expect(formatLogDateDetail('', 'en-US')).toBe('')
   })
 })

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -343,6 +343,26 @@ export function formatRelativeTime(
 }
 
 /**
+ * Detail line for log-table timestamps (the muted second line under the time
+ * of day). Within the relative window: "8月23日 · 3 天前" (short date +
+ * relative). Past the window, formatRelativeTime already renders an absolute
+ * date, so the short date is dropped — otherwise the line duplicates the day
+ * ("8月23日 · 2026年8月23日"). Empty string for null/invalid input.
+ */
+export function formatLogDateDetail(
+  value: string | number | Date | null | undefined,
+  locale: string
+): string {
+  const timestamp = toTimestamp(value)
+  if (timestamp === null) return ''
+  const ageSeconds = Math.abs(Math.round((timestamp - Date.now()) / 1000))
+  if (ageSeconds >= ABSOLUTE_THRESHOLD_SECONDS) {
+    return formatRelativeTime(value, locale)
+  }
+  return `${formatShortDate(value, locale)} · ${formatRelativeTime(value, locale)}`
+}
+
+/**
  * Format a timestamp as a localized absolute date+time for a `title`
  * tooltip (e.g. "Jan 15, 2026, 10:00 AM"). Returns an empty string for
  * null / empty / invalid input so the caller can omit the attribute. Uses


### PR DESCRIPTION
vision QA 发现：proxy-logs 时间列第二行在相对窗口外读作「8月23日 · 2026年8月23日」——formatRelativeTime 超 7 天回退绝对日期后与 formatShortDate 撞车。新增 `formatLogDateDetail`（窗口内 shortDate+relative、超窗只留绝对日期），3 条单测钉住。seeded 实例截图证据附于提交信息。