### PR TITLE
fix(web): clear a11y residuals (double main, redundant alt, empty table header)

### DIFF
--- a/web/src/components/layout/components/app-header.tsx
+++ b/web/src/components/layout/components/app-header.tsx
@@ -76,7 +76,7 @@ export function AppHeader({
         >
           <img
             src={metapiIdentity.logoPath}
-            alt={metapiIdentity.name}
+            alt=''
             className='size-6 shrink-0 rounded-sm'
           />
           <span className='truncate text-sm font-semibold tracking-tight'>

--- a/web/src/components/layout/components/app-sidebar.tsx
+++ b/web/src/components/layout/components/app-sidebar.tsx
@@ -71,7 +71,7 @@ function SidebarMobileHeader() {
       <div className='flex min-w-0 items-center gap-2'>
         <img
           src={metapiIdentity.logoPath}
-          alt={metapiIdentity.name}
+          alt=''
           className='size-6 shrink-0 rounded-sm'
         />
         <span className='truncate text-sm font-semibold tracking-tight'>

--- a/web/src/features/auth/components/sign-in-page.tsx
+++ b/web/src/features/auth/components/sign-in-page.tsx
@@ -57,7 +57,7 @@ export function SignInPage({ redirectTo, noticeReason }: SignInPageProps) {
         <CardHeader className='gap-2 text-center'>
           <img
             src={metapiIdentity.logoPath}
-            alt={metapiIdentity.name}
+            alt=''
             className='mx-auto size-12'
           />
           <h1 className='text-2xl font-normal tracking-tight'>

--- a/web/src/features/dashboard/components/dashboard-page.tsx
+++ b/web/src/features/dashboard/components/dashboard-page.tsx
@@ -85,7 +85,7 @@ export function DashboardPage({
         </TabsList>
       </Tabs>
 
-      <main className='min-w-0 flex-1'>{content}</main>
+      <div className='min-w-0 flex-1'>{content}</div>
     </div>
   )
 }

--- a/web/src/features/observability/components/observability-page.tsx
+++ b/web/src/features/observability/components/observability-page.tsx
@@ -76,9 +76,9 @@ export function ObservabilityPage({
           </TabsList>
         </Tabs>
 
-        <main className='min-w-0 flex-1'>
+        <div className='min-w-0 flex-1'>
           {getObservabilitySectionContent(sectionId)}
-        </main>
+        </div>
       </div>
     </ObservabilityAutoRefreshProvider>
   )

--- a/web/src/features/settings/components/settings-page.tsx
+++ b/web/src/features/settings/components/settings-page.tsx
@@ -45,7 +45,7 @@ export function SettingsPage({ subarea, activeSection }: SettingsPageProps) {
           </p>
         ) : null}
       </header>
-      <main className='min-w-0 flex-1'>
+      <div className='min-w-0 flex-1'>
         {/* Single Suspense boundary catches the React.lazy sections emitted
             by each subarea registry's build(). On the first visit to a
             section its chunk suspends and the settings-shaped skeleton
@@ -54,7 +54,7 @@ export function SettingsPage({ subarea, activeSection }: SettingsPageProps) {
         <Suspense fallback={<SettingsSectionSkeleton />}>
           {subarea.getSectionContent(activeSection)}
         </Suspense>
-      </main>
+      </div>
     </div>
   )
 }

--- a/web/src/features/settings/sections/proxy-models/components/catalog-sources-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/catalog-sources-section.tsx
@@ -514,8 +514,16 @@ export function CatalogSourcesSection() {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    {/* Drag-handle column (reorder, Wave 9 Lane B). */}
-                    <TableHead className='w-7' />
+                    {/* Drag-handle column (reorder, Wave 9 Lane B). The
+                        header cell carries an sr-only label so table scans do
+                        not read an empty th (axe empty-table-header). */}
+                    <TableHead className='w-7'>
+                      <span className='sr-only'>
+                        {t(
+                          'settings.proxyModels.catalogSources.columns.reorderColumn'
+                        )}
+                      </span>
+                    </TableHead>
                     <TableHead>
                       {t('settings.proxyModels.catalogSources.columns.source')}
                     </TableHead>

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1180,6 +1180,7 @@
           "syncAllPending": "Syncing…",
           "add": "Add source",
           "columns": {
+            "reorderColumn": "Reorder",
             "source": "Source",
             "type": "Type",
             "url": "URL",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1180,6 +1180,7 @@
           "syncAllPending": "同步中…",
           "add": "添加数据源",
           "columns": {
+            "reorderColumn": "排序",
             "source": "数据源",
             "type": "类型",
             "url": "URL",


### PR DESCRIPTION
## What
- **landmark-no-duplicate-main**: demote page-level `<main>` to `<div>` in dashboard / observability / settings pages — the layout shell (SidebarInset) already renders the canonical `<main id="content">`, so every route had two main landmarks.
- **image-redundant-alt**: brand logo `alt="Metapi"` adjacent to identical visible text (app-header, sidebar mobile header, sign-in) → `alt=""` decorative.
- **empty-table-header**: catalog-sources drag-handle column `<TableHead>` now carries an sr-only "Reorder"/"排序" label (new i18n key `settings.proxyModels.catalogSources.columns.reorderColumn`).

## Region residual
Investigated and judged **no violation**: no `role="region"` exists in src; unnamed `<section>` elements are generic containers inside main/dialog (not landmarks, not flagged by axe region rule); skip link is axe-exempt (`#content` resolves). Likely stemmed from the double-main structure, now moot.

## Verification
- Local gates: format:check ✓ oxlint ✓ (no new errors) typecheck ✓ knip ✓
- vitest full suite: 242 files / 1560 tests ✓
- i18n key parity tests ✓

These are moderate/minor axe findings — the CI a11y gate only fails on serious/critical, so these fixes are preventative.