### PR TITLE
feat(auth): emit errorCode on admin auth rejections; map to i18n toasts

### DIFF
--- a/auth/admin.go
+++ b/auth/admin.go
@@ -70,7 +70,7 @@ func AdminAuth(sessions *SessionManager) func(http.Handler) http.Handler {
 			// ---- 1. Extract client IP ----
 			clientIP := extractClientIP(r)
 			if !isIPAllowed(clientIP, parsedAllowlist) {
-				writeJSON(w, http.StatusForbidden, jsonError("IP not allowed"))
+				writeJSON(w, http.StatusForbidden, jsonErrorWithCode("IP not allowed", ErrorCodeAuthIPBlocked))
 				return
 			}
 
@@ -92,10 +92,10 @@ func AdminAuth(sessions *SessionManager) func(http.Handler) http.Handler {
 				if cookieToken != "" {
 					// A cookie was presented but is unknown/expired: the
 					// session ended, say so (the frontend redirects to sign-in).
-					writeJSON(w, http.StatusUnauthorized, jsonError("Session expired"))
+					writeJSON(w, http.StatusUnauthorized, jsonErrorWithCode("Session expired", ErrorCodeAuthSessionExpired))
 					return
 				}
-				writeJSON(w, http.StatusUnauthorized, jsonError("Missing Authorization header"))
+				writeJSON(w, http.StatusUnauthorized, jsonErrorWithCode("Missing Authorization header", ErrorCodeAuthMissingCredential))
 				return
 			}
 
@@ -103,7 +103,7 @@ func AdminAuth(sessions *SessionManager) func(http.Handler) http.Handler {
 			// TS: token = auth.replace('Bearer ', '')
 			token := strings.Replace(auth, "Bearer ", "", 1)
 			if subtle.ConstantTimeCompare([]byte(token), []byte(config.Runtime().AuthToken)) != 1 {
-				writeJSON(w, http.StatusForbidden, jsonError("Invalid token"))
+				writeJSON(w, http.StatusForbidden, jsonErrorWithCode("Invalid token", ErrorCodeAuthInvalidToken))
 				return
 			}
 
@@ -337,12 +337,37 @@ func isIPAllowed(clientIP string, allowlist []parsedAllowlistEntry) bool {
 // JSON response helpers.
 // ---------------------------------------------------------------------------
 
+// Machine-readable errorCode values on auth-middleware rejections. Same
+// convention as handler/admin/error_codes.go: stable camelCase, optional and
+// additive — the human-readable "error" stays the display fallback, and the
+// frontend keeps its load-bearing substring match ("invalid token") working.
+// Registered in docs/api.md "errorCode convention and registry".
+const (
+	// ErrorCodeAuthSessionExpired: a cookie session was presented but is
+	// unknown/expired (401; the frontend redirects to sign-in).
+	ErrorCodeAuthSessionExpired = "authSessionExpired"
+	// ErrorCodeAuthMissingCredential: no Authorization header and no session
+	// cookie (401).
+	ErrorCodeAuthMissingCredential = "authMissingCredential"
+	// ErrorCodeAuthInvalidToken: Bearer master-token mismatch (403).
+	ErrorCodeAuthInvalidToken = "authInvalidToken"
+	// ErrorCodeAuthIPBlocked: client IP not on the admin allowlist (403).
+	ErrorCodeAuthIPBlocked = "authIpBlocked"
+)
+
 type jsonErrorBody struct {
 	Error string `json:"error"`
+	// ErrorCode is additive; empty means "no registered code" and the field
+	// is omitted from the wire body.
+	ErrorCode string `json:"errorCode,omitempty"`
 }
 
 func jsonError(msg string) jsonErrorBody {
 	return jsonErrorBody{Error: msg}
+}
+
+func jsonErrorWithCode(msg, code string) jsonErrorBody {
+	return jsonErrorBody{Error: msg, ErrorCode: code}
 }
 
 func writeJSON(w http.ResponseWriter, statusCode int, body any) {

--- a/auth/admin_session_test.go
+++ b/auth/admin_session_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -70,6 +71,8 @@ func TestAdminAuth_SessionCookieTrack(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: "forged-cookie-value"})
 	if rec := doAuthReq(t, h, req); rec.Code != http.StatusUnauthorized {
 		t.Fatalf("forged cookie status = %d, want 401", rec.Code)
+	} else if !strings.Contains(rec.Body.String(), ErrorCodeAuthSessionExpired) {
+		t.Fatalf("forged cookie body missing errorCode %q: %s", ErrorCodeAuthSessionExpired, rec.Body.String())
 	}
 
 	// Expired cookie → 401 and the row is gone.

--- a/auth/admin_test.go
+++ b/auth/admin_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -515,6 +516,43 @@ func TestAdminAuth_WrongToken(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "Invalid token") {
 		t.Errorf("expected 'Invalid token' in body, got %q", w.Body.String())
+	}
+}
+
+// errorCode contract: auth rejections carry the additive machine-readable
+// code the frontend maps to localized toast copy (the "error" text stays the
+// display fallback, so both fields are asserted here). The session-expired
+// case lives in admin_session_test.go (it needs the session harness).
+func TestAdminAuth_ErrorCodes(t *testing.T) {
+	cases := []struct {
+		name       string
+		bearer     string
+		remoteAddr string
+		allow      []string
+		wantCode   string
+	}{
+		{name: "wrong bearer token", bearer: "Bearer nope", wantCode: ErrorCodeAuthInvalidToken},
+		{name: "missing credentials", wantCode: ErrorCodeAuthMissingCredential},
+		{name: "ip not allowlisted", bearer: "Bearer my-secret-token", remoteAddr: "10.0.0.9:12345", allow: []string{"192.168.1.100"}, wantCode: ErrorCodeAuthIPBlocked},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := newTestConfig(t, "my-secret-token", tc.allow)
+			w := adminTestHelper(t, rt, "GET", "/api/sites", tc.bearer, tc.remoteAddr, "")
+			var body struct {
+				Error     string `json:"error"`
+				ErrorCode string `json:"errorCode"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+				t.Fatalf("response is not JSON: %v", err)
+			}
+			if body.Error == "" {
+				t.Errorf("expected human-readable error text, got %q", w.Body.String())
+			}
+			if body.ErrorCode != tc.wantCode {
+				t.Errorf("expected errorCode %q, got %q", tc.wantCode, body.ErrorCode)
+			}
+		})
 	}
 }
 

--- a/auth/reauth.go
+++ b/auth/reauth.go
@@ -66,7 +66,9 @@ func RequireReauth() func(http.Handler) http.Handler {
 			if rt == nil || confirm == "" || !constantTimeTokenEqual(confirm, rt.AuthToken) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusForbidden)
-				_, _ = w.Write([]byte(`{"error":"Sensitive operation requires master token confirmation","reauthRequired":true}`))
+				// errorCode is additive: the frontend branches on
+				// reauthRequired; the code only feeds the i18n toast map.
+				_, _ = w.Write([]byte(`{"error":"Sensitive operation requires master token confirmation","reauthRequired":true,"errorCode":"authReauthRequired"}`))
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -92,19 +92,30 @@ HTTP status codes: 200 (OK), 201 (Created), 202 (Accepted), 400 (Bad Request), 4
 `errorCode` values are stable **camelCase** identifiers (matching the
 project-wide camelCase JSON rule). Codes are only introduced for real call
 sites; this table is the registry and grows deliberately. Constants live in
-`handler/admin/error_codes.go` and are pinned by
-`handler/admin/error_codes_test.go`.
+`handler/admin/error_codes.go` (admin handlers) and `auth/admin.go` +
+`auth/reauth.go` (auth middleware) and are pinned by the respective
+`*_test.go`.
 
-| errorCode              | Status | Where                                          | Meaning                                                        |
-| ---------------------- | ------ | ---------------------------------------------- | -------------------------------------------------------------- |
-| `invalidId`            | 400    | any `/api/.../{id}` route (pathID helper)      | path ID missing, non-numeric or non-positive                   |
-| `invalidDatabaseType`  | 400    | `/api/settings/database/*`                     | runtime-database dialect is neither `sqlite` nor `postgres`    |
-| `emptyMigrationTarget` | 400    | `POST /api/settings/database/migrate`          | target connection string is blank                              |
-| `sameMigrationTarget`  | 400    | `POST /api/settings/database/migrate`          | target resolves to the currently-running database (rejected)   |
+| errorCode               | Status | Where                                          | Meaning                                                        |
+| ----------------------- | ------ | ---------------------------------------------- | -------------------------------------------------------------- |
+| `invalidId`             | 400    | any `/api/.../{id}` route (pathID helper)      | path ID missing, non-numeric or non-positive                   |
+| `invalidDatabaseType`   | 400    | `/api/settings/database/*`                     | runtime-database dialect is neither `sqlite` nor `postgres`    |
+| `emptyMigrationTarget`  | 400    | `POST /api/settings/database/migrate`          | target connection string is blank                              |
+| `sameMigrationTarget`   | 400    | `POST /api/settings/database/migrate`          | target resolves to the currently-running database (rejected)   |
+| `authSessionExpired`    | 401    | all admin routes (auth middleware)             | session cookie presented but unknown/expired                   |
+| `authMissingCredential` | 401    | all admin routes (auth middleware)             | no Authorization header and no session cookie                  |
+| `authInvalidToken`      | 403    | all admin routes (auth middleware)             | Bearer master-token mismatch                                   |
+| `authIpBlocked`         | 403    | all admin routes (auth middleware)             | client IP not on the admin allowlist                           |
+| `authReauthRequired`    | 403    | sensitive admin routes (reauth gate)           | sensitive op needs master-token confirmation (`reauthRequired`) |
 
 Frontend note: the admin UI historically detected the same-target migration
 rejection by substring-matching the message text; it should migrate to
 `errorCode === "sameMigrationTarget"`.
+
+Frontend note (auth): the interceptor keeps its load-bearing substring match
+on `"invalid token"` (clears session) and the `reauthRequired:true` flag
+(prompts for master token); the auth `errorCode` values above only feed the
+localized toast copy via the `errors.auth.*` i18n keys.
 
 ## Request Body Rules
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -36,6 +36,13 @@
         "serverUnreachable": "Unable to connect to the server.",
         "failed": "Login failed, please check the service status."
       },
+      "auth": {
+        "sessionExpired": "Session expired",
+        "missingCredential": "Missing credentials",
+        "invalidToken": "Invalid token",
+        "ipBlocked": "IP not allowed",
+        "reauthRequired": "Sensitive operation requires master token confirmation"
+      },
       "internalServerError": "Internal Server Error!",
       "serverError": "Server error ({{status}}). Please try again later.",
       "notFoundTitle": "Page not found",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -36,6 +36,13 @@
         "serverUnreachable": "无法连接到服务器。",
         "failed": "登录失败，请检查服务状态。"
       },
+      "auth": {
+        "sessionExpired": "会话已过期",
+        "missingCredential": "缺少访问凭据",
+        "invalidToken": "令牌无效",
+        "ipBlocked": "当前 IP 不在白名单内",
+        "reauthRequired": "敏感操作需要主令牌确认"
+      },
       "internalServerError": "服务器内部错误！",
       "serverError": "服务器错误（{{status}}），请稍后重试。",
       "notFoundTitle": "页面不存在",

--- a/web/src/lib/__tests__/http-client.test.ts
+++ b/web/src/lib/__tests__/http-client.test.ts
@@ -261,6 +261,68 @@ describe('apiClient auth interceptor', () => {
       id: `api-error:${expected}`,
     })
   })
+
+  it('renders the localized copy for a known errorCode instead of the English body', async () => {
+    // In the default (en) locale the auth ipBlocked translation is literally
+    // "IP not allowed", identical to the backend body — so switch to zh-CN to
+    // prove the map (not the raw body) is what renders.
+    const prevLng = i18n.language
+    await i18n.changeLanguage('zhCN')
+    try {
+      const expected = i18n.t('errors.auth.ipBlocked')
+      const enBody = 'IP not allowed'
+      // The zh-CN translation must differ from the English body.
+      expect(expected).not.toBe(enBody)
+
+      const adapterCalls: unknown[] = []
+      installStatusAdapter(adapterCalls, 403, {
+        error: enBody,
+        errorCode: 'authIpBlocked',
+      })
+
+      await expect(apiClient.get('/api/protected')).rejects.toThrow()
+
+      // errorCode wins over the raw English body message (auth rejections
+      // fire before any backend locale context exists).
+      expect(toastErrorMock).toHaveBeenCalledWith(expected, {
+        id: `api-error:${expected}`,
+      })
+    } finally {
+      await i18n.changeLanguage(prevLng)
+    }
+  })
+
+  it('falls back to the raw body message for an unregistered errorCode', async () => {
+    const adapterCalls: unknown[] = []
+    installStatusAdapter(adapterCalls, 403, {
+      error: 'IP not allowed',
+      errorCode: 'somethingNotMapped',
+    })
+
+    await expect(apiClient.get('/api/protected')).rejects.toThrow()
+
+    expect(toastErrorMock).toHaveBeenCalledWith('IP not allowed', {
+      id: 'api-error:IP not allowed',
+    })
+  })
+
+  it('maps every registered errorCode to an i18n key that actually exists', () => {
+    // The map's values are dynamic t(variable) keys — invisible to the
+    // static i18n-keys gate — so pin their existence here instead.
+    // Convention: authSessionExpired -> errors.auth.sessionExpired.
+    const codes = [
+      'authSessionExpired',
+      'authMissingCredential',
+      'authInvalidToken',
+      'authIpBlocked',
+      'authReauthRequired',
+    ]
+    for (const code of codes) {
+      const rest = code.replace(/^auth/, '')
+      const key = `errors.auth.${rest.charAt(0).toLowerCase()}${rest.slice(1)}`
+      expect(i18n.exists(key), `${code} -> ${key}`).toBe(true)
+    }
+  })
 })
 
 describe('resolveResponseErrorCode — unified error envelope (#1065)', () => {

--- a/web/src/lib/http-client.ts
+++ b/web/src/lib/http-client.ts
@@ -140,6 +140,29 @@ export function resolveResponseErrorCode(data: unknown): string | undefined {
 }
 
 /**
+ * errorCode → i18n key for codes the console should render localized instead
+ * of the backend's English fallback text (auth-middleware rejections are the
+ * highest-frequency toasts and fired long before any user locale context
+ * existed on the backend). Codes not listed here keep the raw body message —
+ * the map is additive per migrated endpoint family.
+ */
+const ERROR_CODE_I18N_KEYS: Record<string, string> = {
+  authSessionExpired: 'errors.auth.sessionExpired',
+  authMissingCredential: 'errors.auth.missingCredential',
+  authInvalidToken: 'errors.auth.invalidToken',
+  authIpBlocked: 'errors.auth.ipBlocked',
+  authReauthRequired: 'errors.auth.reauthRequired',
+}
+
+/** Localized copy for a known errorCode; undefined when unmapped. */
+function resolveErrorCodeMessage(data: unknown): string | undefined {
+  const code = resolveResponseErrorCode(data)
+  if (!code) return undefined
+  const key = ERROR_CODE_I18N_KEYS[code]
+  return key ? i18n.t(key) : undefined
+}
+
+/**
  * Unified error body of an axios-shaped rejection (`error.response.data`),
  * or null when the failure carries no JSON body (network error, timeout).
  */
@@ -151,16 +174,19 @@ export function extractApiErrorBody(error: unknown): ApiErrorBody | null {
 }
 
 /**
- * Resolve a user-facing message for a failed request. Precedence: the backend
- * body message, then a status-aware 5xx message (so a bare 502/503/504 no
- * longer leaks the raw "Request failed with status code 502"), then the
- * axios error message, then a generic fallback.
+ * Resolve a user-facing message for a failed request. Precedence: a known
+ * errorCode mapped to localized copy, then the backend body message, then a
+ * status-aware 5xx message (so a bare 502/503/504 no longer leaks the raw
+ * "Request failed with status code 502"), then the axios error message, then
+ * a generic fallback.
  */
 function resolveErrorMessage(
   data: unknown,
   error: unknown,
   status: number | undefined
 ): string {
+  const codeMessage = resolveErrorCodeMessage(data)
+  if (codeMessage) return codeMessage
   const dataMessage = resolveResponseMessage(data)
   if (dataMessage) return dataMessage
   if (status !== undefined && status >= 500) {


### PR DESCRIPTION
## What
Auth middleware is the highest-frequency toast source and fires before any backend locale context exists, so every rejection used to leak bare English into the Chinese admin UI.

**Backend** (additive, no contract break):
- `auth/admin.go`: `Session expired` / `Missing Authorization header` / `Invalid token` / `IP not allowed` now carry a machine-readable `errorCode` (`authSessionExpired` / `authMissingCredential` / `authInvalidToken` / `authIpBlocked`). `jsonErrorBody` gains an `omitempty` errorCode field; `jsonErrorWithCode` added.
- `auth/reauth.go`: the reauthRequired rejection adds `errorCode` `authReauthRequired` (the `reauthRequired:true` flag stays load-bearing).
- Tests pin the errorCode for all five rejections alongside the existing human-readable substring assertions.

**Frontend**:
- `http-client.ts` resolves a known `errorCode` to localized copy (`errors.auth.*`) before falling back to the backend's English body; unmapped codes degrade gracefully to the raw text. The load-bearing `"invalid token"` substring and `reauthRequired:true` special-cases are untouched.
- en/zh-CN `errors.auth.{sessionExpired,missingCredential,invalidToken,ipBlocked,reauthRequired}`.
- Tests cover the mapped path, the unmapped fallback, and an existence pin for every map key.

**Docs**: `conventions.md` errorCode registry gains the 5 auth codes.

## Note
First batch of the backend English-copy localization effort — extends the existing additive `errorCode` field (not a new field), keeping the camelCase convention per #1065.
