### PR TITLE
feat(admin): emit accountNotFound errorCode; localize resource-not-found copy

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -107,6 +107,7 @@ sites; this table is the registry and grows deliberately. Constants live in
 | `authInvalidToken`      | 403    | all admin routes (auth middleware)             | Bearer master-token mismatch                                   |
 | `authIpBlocked`         | 403    | all admin routes (auth middleware)             | client IP not on the admin allowlist                           |
 | `authReauthRequired`    | 403    | sensitive admin routes (reauth gate)           | sensitive op needs master-token confirmation (`reauthRequired`) |
+| `accountNotFound`       | 404    | `/api/accounts*`, `/api/account-tokens*`, `/api/accounts/health/refresh` | referenced account does not exist |
 
 Frontend note: the admin UI historically detected the same-target migration
 rejection by substring-matching the message text; it should migrate to

--- a/handler/admin/account_tokens.go
+++ b/handler/admin/account_tokens.go
@@ -87,7 +87,7 @@ func (h *accountTokensHandler) createToken(w http.ResponseWriter, r *http.Reques
 	// Get account with site
 	row, err := service.GetAccountWithSiteByID(h.db, int64(body.AccountID))
 	if err != nil {
-		writeError(w, http.StatusNotFound, "account not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeAccountNotFound, "account not found")
 		return
 	}
 
@@ -396,11 +396,11 @@ func (h *accountTokensHandler) updateToken(w http.ResponseWriter, r *http.Reques
 
 	owner, err := service.GetAccountByID(h.db, existing.AccountID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "account not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeAccountNotFound, "account not found")
 		return
 	}
 	if owner == nil {
-		writeError(w, http.StatusNotFound, "account not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeAccountNotFound, "account not found")
 		return
 	}
 	if service.IsAPIKeyConnection(owner) {
@@ -519,11 +519,11 @@ func (h *accountTokensHandler) setDefault(w http.ResponseWriter, r *http.Request
 
 	owner, err := service.GetAccountByID(h.db, token.AccountID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "account not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeAccountNotFound, "account not found")
 		return
 	}
 	if owner == nil {
-		writeError(w, http.StatusNotFound, "account not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeAccountNotFound, "account not found")
 		return
 	}
 	if service.IsAPIKeyConnection(owner) {

--- a/handler/admin/account_tokens_sync.go
+++ b/handler/admin/account_tokens_sync.go
@@ -29,7 +29,7 @@ func (h *accountTokensHandler) syncAccount(w http.ResponseWriter, r *http.Reques
 
 	row, err := service.GetAccountWithSiteByID(h.db, accountID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "account not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeAccountNotFound, "account not found")
 		return
 	}
 
@@ -102,7 +102,7 @@ func (h *accountTokensHandler) getGroups(w http.ResponseWriter, r *http.Request)
 
 	row, err := service.GetAccountWithSiteByID(h.db, accountID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "account not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeAccountNotFound, "account not found")
 		return
 	}
 

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -1068,7 +1068,7 @@ func (h *accountsHandler) rebindSession(w http.ResponseWriter, r *http.Request) 
 
 	row, err := service.GetAccountWithSiteByID(h.db, accountID)
 	if err != nil {
-		writeErrorWithRequest(w, r, http.StatusNotFound, "account not found")
+		writeErrorCodeWithRequest(w, r, http.StatusNotFound, ErrorCodeAccountNotFound, "account not found")
 		return
 	}
 
@@ -1156,7 +1156,7 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 
 	row, err := service.GetAccountWithSiteByIDForUpdate(tx, id)
 	if err != nil {
-		writeErrorWithRequest(w, r, http.StatusNotFound, "account not found")
+		writeErrorCodeWithRequest(w, r, http.StatusNotFound, ErrorCodeAccountNotFound, "account not found")
 		return
 	}
 

--- a/handler/admin/accounts_health.go
+++ b/handler/admin/accounts_health.go
@@ -28,7 +28,7 @@ func (h *accountsHandler) healthRefresh(w http.ResponseWriter, r *http.Request) 
 		}
 		accountID := int64(*body.AccountID)
 		if _, err := service.GetAccountWithSiteByID(h.db, accountID); err != nil {
-			writeError(w, http.StatusNotFound, "account not found")
+			writeErrorCode(w, http.StatusNotFound, ErrorCodeAccountNotFound, "account not found")
 			return
 		}
 		accountIDs = []int64{accountID}

--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -2916,6 +2916,60 @@ func TestAccounts_ErrorResponsesUseStandardShape(t *testing.T) {
 	})
 }
 
+// errorCode contract: the account-not-found rejection carries the additive
+// machine-readable code the frontend maps to localized toast copy. The
+// endpoints span the files wired in #batch1 (accounts / account-tokens /
+// accounts-health); the message text stays the display fallback.
+func TestErrorCodeAccountNotFound(t *testing.T) {
+	db, r, cfg := setupAccountsTest(t)
+	RegisterAccountTokensRoutesWithConfig(r, db.DB, cfg)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   map[string]any
+	}{
+		{name: "account update", method: http.MethodPut, path: "/api/accounts/999999", body: map[string]any{"status": "active"}},
+		{name: "account token create", method: http.MethodPost, path: "/api/account-tokens", body: map[string]any{"accountId": 999999}},
+		{name: "account health refresh", method: http.MethodPost, path: "/api/accounts/health/refresh", body: map[string]any{"accountId": 999999}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var resp *httptest.ResponseRecorder
+			switch tc.method {
+			case http.MethodPut:
+				resp = doPutJSON(t, r, tc.path, tc.body)
+			case http.MethodPost:
+				if tc.body != nil {
+					resp = doPostJSON(t, r, tc.path, tc.body)
+				} else {
+					resp = doPostJSON(t, r, tc.path, map[string]any{})
+				}
+			default:
+				resp = doGet(t, r, tc.path)
+			}
+			wantStatus := http.StatusNotFound
+			if resp.Code != wantStatus {
+				t.Fatalf("status = %d, want %d (body=%s)", resp.Code, wantStatus, resp.Body.String())
+			}
+			var body struct {
+				Error     string `json:"error"`
+				ErrorCode string `json:"errorCode"`
+			}
+			if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal: %v (body=%s)", err, resp.Body.String())
+			}
+			if body.Error == "" {
+				t.Fatalf("expected human-readable error text, got %q", resp.Body.String())
+			}
+			if body.ErrorCode != "accountNotFound" {
+				t.Fatalf("errorCode = %q, want %q (body=%s)", body.ErrorCode, "accountNotFound", resp.Body.String())
+			}
+		})
+	}
+}
+
 // assertStandardErrorShape verifies a response uses the unified admin error
 // shape: non-2xx status, JSON body with an "error" key and no legacy
 // "success" or "message" keys (the markers of the pre-migration shapes).

--- a/handler/admin/error_codes.go
+++ b/handler/admin/error_codes.go
@@ -27,4 +27,9 @@ const (
 	// ErrorCodeSameMigrationTarget rejects a migration whose target resolves
 	// to the currently-running database (POST /api/settings/database/migrate).
 	ErrorCodeSameMigrationTarget = "sameMigrationTarget"
+
+	// ErrorCodeAccountNotFound rejects a request whose `{id}` path segment or
+	// body references an account that does not exist (accounts / account
+	// tokens / accounts-health route families).
+	ErrorCodeAccountNotFound = "accountNotFound"
 )

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -43,6 +43,9 @@
         "ipBlocked": "IP not allowed",
         "reauthRequired": "Sensitive operation requires master token confirmation"
       },
+      "api": {
+        "accountNotFound": "Account not found"
+      },
       "internalServerError": "Internal Server Error!",
       "serverError": "Server error ({{status}}). Please try again later.",
       "notFoundTitle": "Page not found",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -43,6 +43,9 @@
         "ipBlocked": "当前 IP 不在白名单内",
         "reauthRequired": "敏感操作需要主令牌确认"
       },
+      "api": {
+        "accountNotFound": "账号不存在"
+      },
       "internalServerError": "服务器内部错误！",
       "serverError": "服务器错误（{{status}}），请稍后重试。",
       "notFoundTitle": "页面不存在",

--- a/web/src/lib/__tests__/http-client.test.ts
+++ b/web/src/lib/__tests__/http-client.test.ts
@@ -292,6 +292,28 @@ describe('apiClient auth interceptor', () => {
     }
   })
 
+  it('renders the localized resource-not-found copy for accountNotFound', async () => {
+    const prevLng = i18n.language
+    await i18n.changeLanguage('zhCN')
+    try {
+      const expected = i18n.t('errors.api.accountNotFound')
+      expect(expected).toBe('账号不存在')
+
+      const adapterCalls: unknown[] = []
+      installStatusAdapter(adapterCalls, 404, {
+        error: 'account not found',
+        errorCode: 'accountNotFound',
+      })
+
+      await expect(apiClient.get('/api/protected')).rejects.toThrow()
+      expect(toastErrorMock).toHaveBeenCalledWith(expected, {
+        id: `api-error:${expected}`,
+      })
+    } finally {
+      await i18n.changeLanguage(prevLng)
+    }
+  })
+
   it('falls back to the raw body message for an unregistered errorCode', async () => {
     const adapterCalls: unknown[] = []
     installStatusAdapter(adapterCalls, 403, {
@@ -316,11 +338,14 @@ describe('apiClient auth interceptor', () => {
       'authInvalidToken',
       'authIpBlocked',
       'authReauthRequired',
+      'accountNotFound',
     ]
     for (const code of codes) {
-      const rest = code.replace(/^auth/, '')
-      const key = `errors.auth.${rest.charAt(0).toLowerCase()}${rest.slice(1)}`
-      expect(i18n.exists(key), `${code} -> ${key}`).toBe(true)
+      const expectedKey =
+        code === 'accountNotFound'
+          ? 'errors.api.accountNotFound'
+          : `errors.auth.${code.replace(/^auth/, '').replace(/^./, (c) => c.toLowerCase())}`
+      expect(i18n.exists(expectedKey), `${code} -> ${expectedKey}`).toBe(true)
     }
   })
 })

--- a/web/src/lib/http-client.ts
+++ b/web/src/lib/http-client.ts
@@ -152,6 +152,7 @@ const ERROR_CODE_I18N_KEYS: Record<string, string> = {
   authInvalidToken: 'errors.auth.invalidToken',
   authIpBlocked: 'errors.auth.ipBlocked',
   authReauthRequired: 'errors.auth.reauthRequired',
+  accountNotFound: 'errors.api.accountNotFound',
 }
 
 /** Localized copy for a known errorCode; undefined when unmapped. */


### PR DESCRIPTION
## What
Batch 1 of the backend English-copy localization effort. The account-not-found rejection family across accounts / account-tokens / accounts-health handlers now carries the additive machine-readable `errorCode` on the unified error body; the message text is unchanged (byte-identical display fallback), so the checkinservice internal string compare is untouched.

**Backend** (10 call sites):
- `error_codes.go`: `ErrorCodeAccountNotFound = "accountNotFound"`.
- `accounts.go` (update + rebind), `accounts_health.go` (health refresh), `account_tokens.go` (create + 4 more), `account_tokens_sync.go`: `writeError(WithRequest)` → `writeErrorCode(WithRequest)`.
- `accounts_test.go`: `TestErrorCodeAccountNotFound` pins the code across three real endpoints (account update / token create / health refresh) alongside the human-readable text assertion.

**Frontend**:
- `http-client.ts` `ERROR_CODE_I18N_KEYS` + `accountNotFound → errors.api.accountNotFound`.
- en `"Account not found"` / zh-CN `"账号不存在"`.
- Tests: zh-CN rendering pin for the mapped copy; existence pin for every map key.

**Docs**: `conventions.md` errorCode registry row for `accountNotFound`.

## Pattern
This batch is the repeatable template for the remaining error families (site/token/channel/route not-found, validation, disabled, internal-failure) — per-family batches keep diffs reviewable and the additive errorCode keeps every intermediate state backward-compatible.
