### PR TITLE
feat(admin): emit siteNotFound errorCode; localize site-not-found copy

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -108,6 +108,7 @@ sites; this table is the registry and grows deliberately. Constants live in
 | `authIpBlocked`         | 403    | all admin routes (auth middleware)             | client IP not on the admin allowlist                           |
 | `authReauthRequired`    | 403    | sensitive admin routes (reauth gate)           | sensitive op needs master-token confirmation (`reauthRequired`) |
 | `accountNotFound`       | 404    | `/api/accounts*`, `/api/account-tokens*`, `/api/accounts/health/refresh` | referenced account does not exist |
+| `siteNotFound`          | 404    | `/api/sites*`, `/api/accounts*`, `/api/site-announcements/sync` | referenced site does not exist |
 
 Frontend note: the admin UI historically detected the same-target migration
 rejection by substring-matching the message text; it should migrate to

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -726,7 +726,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 	// Get site
 	var site store.Site
 	if err := h.db.Get(&site, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), body.SiteID); err != nil {
-		writeErrorWithRequest(w, r, http.StatusNotFound, "site not found")
+		writeErrorCodeWithRequest(w, r, http.StatusNotFound, ErrorCodeSiteNotFound, "site not found")
 		return
 	}
 
@@ -883,7 +883,7 @@ func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 	// Get site
 	var site store.Site
 	if err := h.db.Get(&site, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), body.SiteID); err != nil {
-		writeErrorWithRequest(w, r, http.StatusNotFound, "site not found")
+		writeErrorCodeWithRequest(w, r, http.StatusNotFound, ErrorCodeSiteNotFound, "site not found")
 		return
 	}
 

--- a/handler/admin/error_codes.go
+++ b/handler/admin/error_codes.go
@@ -32,4 +32,9 @@ const (
 	// body references an account that does not exist (accounts / account
 	// tokens / accounts-health route families).
 	ErrorCodeAccountNotFound = "accountNotFound"
+
+	// ErrorCodeSiteNotFound rejects a request whose `{id}` path segment or
+	// body references a site that does not exist (sites / accounts / site
+	// announcements route families).
+	ErrorCodeSiteNotFound = "siteNotFound"
 )

--- a/handler/admin/site_announcements.go
+++ b/handler/admin/site_announcements.go
@@ -230,7 +230,7 @@ func (h *siteAnnouncementsHandler) syncAnnouncements(w http.ResponseWriter, r *h
 		err := h.db.Get(&exists, h.db.Rebind(`SELECT 1 FROM sites WHERE id = ?`), *siteID)
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
-			writeErrorWithRequest(w, r, http.StatusNotFound, "Site not found.")
+			writeErrorCodeWithRequest(w, r, http.StatusNotFound, ErrorCodeSiteNotFound, "Site not found.")
 			return
 		case err != nil:
 			slog.Error("site-announcement sync: failed to validate site", "siteId", *siteID, "error", err)

--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -299,7 +299,7 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 	var existing store.Site
 	err := h.db.Get(&existing, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), id)
 	if err == sql.ErrNoRows {
-		writeErrorWithRequest(w, r, http.StatusNotFound, "Site not found")
+		writeErrorCodeWithRequest(w, r, http.StatusNotFound, ErrorCodeSiteNotFound, "Site not found")
 		return
 	} else if err != nil {
 		slog.Error("Failed to load site for update", "err", err, "site_id", id)
@@ -675,7 +675,7 @@ func (h *sitesHandler) getDisabledModels(w http.ResponseWriter, r *http.Request)
 
 	var existing store.Site
 	if err := h.db.Get(&existing, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), id); err != nil {
-		writeErrorWithRequest(w, r, http.StatusNotFound, "Site not found")
+		writeErrorCodeWithRequest(w, r, http.StatusNotFound, ErrorCodeSiteNotFound, "Site not found")
 		return
 	}
 
@@ -702,7 +702,7 @@ func (h *sitesHandler) updateDisabledModels(w http.ResponseWriter, r *http.Reque
 
 	var existing store.Site
 	if err := h.db.Get(&existing, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), id); err != nil {
-		writeErrorWithRequest(w, r, http.StatusNotFound, "Site not found")
+		writeErrorCodeWithRequest(w, r, http.StatusNotFound, ErrorCodeSiteNotFound, "Site not found")
 		return
 	}
 
@@ -742,7 +742,7 @@ func (h *sitesHandler) getAvailableModels(w http.ResponseWriter, r *http.Request
 
 	var existing store.Site
 	if err := h.db.Get(&existing, h.db.Rebind("SELECT "+service.SiteSelectColumns+" FROM sites WHERE id = ?"), id); err != nil {
-		writeErrorWithRequest(w, r, http.StatusNotFound, "Site not found")
+		writeErrorCodeWithRequest(w, r, http.StatusNotFound, ErrorCodeSiteNotFound, "Site not found")
 		return
 	}
 

--- a/handler/admin/sites_test.go
+++ b/handler/admin/sites_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/config"
 	"github.com/go-chi/chi/v5"
 	"github.com/deliciousbuding/metapi-go/store"
 )
@@ -1196,5 +1197,52 @@ func TestSites_MaxConcurrencyRoundTrip(t *testing.T) {
 	})
 	if resp.Code != http.StatusBadRequest {
 		t.Fatalf("negative maxConcurrency: expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+// errorCode contract: the site-not-found rejection carries the additive
+// machine-readable code the frontend maps to localized toast copy. The
+// endpoints span the three files wired in batch 2 (sites / accounts /
+// site-announcements); the message text stays the display fallback.
+func TestErrorCodeSiteNotFound(t *testing.T) {
+	db, r := setupSitesTest(t)
+	RegisterSiteAnnouncementsRoutes(r, db.DB)
+	RegisterAccountsRoutes(r, db.DB, &config.Config{AccountCredentialSecret: "test-secret-for-accounts"})
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   map[string]any
+	}{
+		{name: "site update", method: http.MethodPut, path: "/api/sites/999999", body: map[string]any{"name": "n"}},
+		{name: "account login", method: http.MethodPost, path: "/api/accounts/login", body: map[string]any{"siteId": 999999, "username": "u", "password": "p"}},
+		{name: "announcement sync", method: http.MethodPost, path: "/api/site-announcements/sync", body: map[string]any{"siteId": 999999}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var resp *httptest.ResponseRecorder
+			if tc.method == http.MethodPut {
+				resp = doPutJSON(t, r, tc.path, tc.body)
+			} else {
+				resp = doPostJSON(t, r, tc.path, tc.body)
+			}
+			if resp.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404 (body=%s)", resp.Code, resp.Body.String())
+			}
+			var body struct {
+				Error     string `json:"error"`
+				ErrorCode string `json:"errorCode"`
+			}
+			if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal: %v (body=%s)", err, resp.Body.String())
+			}
+			if body.Error == "" {
+				t.Fatalf("expected human-readable error text, got %q", resp.Body.String())
+			}
+			if body.ErrorCode != "siteNotFound" {
+				t.Fatalf("errorCode = %q, want %q (body=%s)", body.ErrorCode, "siteNotFound", resp.Body.String())
+			}
+		})
 	}
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -44,7 +44,8 @@
         "reauthRequired": "Sensitive operation requires master token confirmation"
       },
       "api": {
-        "accountNotFound": "Account not found"
+        "accountNotFound": "Account not found",
+        "siteNotFound": "Site not found"
       },
       "internalServerError": "Internal Server Error!",
       "serverError": "Server error ({{status}}). Please try again later.",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -44,7 +44,8 @@
         "reauthRequired": "敏感操作需要主令牌确认"
       },
       "api": {
-        "accountNotFound": "账号不存在"
+        "accountNotFound": "账号不存在",
+        "siteNotFound": "站点不存在"
       },
       "internalServerError": "服务器内部错误！",
       "serverError": "服务器错误（{{status}}），请稍后重试。",

--- a/web/src/lib/__tests__/http-client.test.ts
+++ b/web/src/lib/__tests__/http-client.test.ts
@@ -339,11 +339,12 @@ describe('apiClient auth interceptor', () => {
       'authIpBlocked',
       'authReauthRequired',
       'accountNotFound',
+      'siteNotFound',
     ]
     for (const code of codes) {
       const expectedKey =
-        code === 'accountNotFound'
-          ? 'errors.api.accountNotFound'
+        code === 'accountNotFound' || code === 'siteNotFound'
+          ? `errors.api.${code}`
           : `errors.auth.${code.replace(/^auth/, '').replace(/^./, (c) => c.toLowerCase())}`
       expect(i18n.exists(expectedKey), `${code} -> ${expectedKey}`).toBe(true)
     }

--- a/web/src/lib/http-client.ts
+++ b/web/src/lib/http-client.ts
@@ -153,6 +153,7 @@ const ERROR_CODE_I18N_KEYS: Record<string, string> = {
   authIpBlocked: 'errors.auth.ipBlocked',
   authReauthRequired: 'errors.auth.reauthRequired',
   accountNotFound: 'errors.api.accountNotFound',
+  siteNotFound: 'errors.api.siteNotFound',
 }
 
 /** Localized copy for a known errorCode; undefined when unmapped. */


### PR DESCRIPTION
## What
Batch 2 of the backend English-copy localization effort (template: batch 1 `accountNotFound` / #1109).

7 sites across handlers/admin now carry the additive machine-readable `errorCode` on the unified error body; the message text is unchanged (byte-identical display fallback).

**Backend**:
- `error_codes.go`: `ErrorCodeSiteNotFound = "siteNotFound"`.
- `sites.go` (update + 3 more), `accounts.go` (create/login site lookup), `site_announcements.go` (sync site validation): `writeErrorWithRequest` → `writeErrorCodeWithRequest`, 7 sites.
- `sites_test.go`: `TestErrorCodeSiteNotFound` pins the code across three real endpoints (site update / account login / announcement sync).

**Frontend**:
- `http-client.ts` `ERROR_CODE_I18N_KEYS` + `siteNotFound → errors.api.siteNotFound`.
- en `"Site not found"` / zh-CN `"站点不存在"`; existence pin extended.

**Docs**: `conventions.md` registry row for `siteNotFound`.
