### PR TITLE
feat(admin): emit token/route/channel notFound errorCodes; localize copy

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -108,6 +108,9 @@ sites; this table is the registry and grows deliberately. Constants live in
 | `authIpBlocked`         | 403    | all admin routes (auth middleware)             | client IP not on the admin allowlist                           |
 | `authReauthRequired`    | 403    | sensitive admin routes (reauth gate)           | sensitive op needs master-token confirmation (`reauthRequired`) |
 | `accountNotFound`       | 404    | `/api/accounts*`, `/api/account-tokens*`, `/api/accounts/health/refresh` | referenced account does not exist |
+| `tokenNotFound`         | 404    | `/api/account-tokens*`                        | referenced account token does not exist |
+| `routeNotFound`         | 404    | `/api/routes*`                               | referenced token route does not exist |
+| `channelNotFound`       | 404    | `/api/channels/{channelId}`                  | referenced route channel id is missing/non-positive |
 
 Frontend note: the admin UI historically detected the same-target migration
 rejection by substring-matching the message text; it should migrate to

--- a/handler/admin/account_tokens.go
+++ b/handler/admin/account_tokens.go
@@ -390,7 +390,7 @@ func (h *accountTokensHandler) updateToken(w http.ResponseWriter, r *http.Reques
 
 	existing, err := service.GetTokenByID(h.db, tokenID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "token not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeTokenNotFound, "token not found")
 		return
 	}
 
@@ -513,7 +513,7 @@ func (h *accountTokensHandler) setDefault(w http.ResponseWriter, r *http.Request
 
 	token, err := service.GetTokenByID(h.db, tokenID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "token not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeTokenNotFound, "token not found")
 		return
 	}
 
@@ -541,7 +541,7 @@ func (h *accountTokensHandler) setDefault(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if !defaultSet {
-		writeError(w, http.StatusNotFound, "token not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeTokenNotFound, "token not found")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})
@@ -557,17 +557,17 @@ func (h *accountTokensHandler) getTokenValue(w http.ResponseWriter, r *http.Requ
 
 	token, err := service.GetTokenByID(h.db, tokenID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "token not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeTokenNotFound, "token not found")
 		return
 	}
 
 	owner, err := service.GetAccountByID(h.db, token.AccountID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "token not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeTokenNotFound, "token not found")
 		return
 	}
 	if owner == nil {
-		writeError(w, http.StatusNotFound, "token not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeTokenNotFound, "token not found")
 		return
 	}
 	if service.IsAPIKeyConnection(owner) {
@@ -612,17 +612,17 @@ func (h *accountTokensHandler) deleteToken(w http.ResponseWriter, r *http.Reques
 
 	token, err := service.GetTokenByID(h.db, tokenID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "token not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeTokenNotFound, "token not found")
 		return
 	}
 
 	owner, err := service.GetAccountByID(h.db, token.AccountID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "token not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeTokenNotFound, "token not found")
 		return
 	}
 	if owner == nil {
-		writeError(w, http.StatusNotFound, "token not found")
+		writeErrorCode(w, http.StatusNotFound, ErrorCodeTokenNotFound, "token not found")
 		return
 	}
 	if service.IsAPIKeyConnection(owner) {

--- a/handler/admin/error_codes.go
+++ b/handler/admin/error_codes.go
@@ -32,4 +32,16 @@ const (
 	// body references an account that does not exist (accounts / account
 	// tokens / accounts-health route families).
 	ErrorCodeAccountNotFound = "accountNotFound"
+
+	// ErrorCodeTokenNotFound rejects an account-token operation whose
+	// referenced token does not exist (account-tokens route family).
+	ErrorCodeTokenNotFound = "tokenNotFound"
+
+	// ErrorCodeRouteNotFound rejects a token-route operation whose
+	// referenced route does not exist (routes family).
+	ErrorCodeRouteNotFound = "routeNotFound"
+
+	// ErrorCodeChannelNotFound rejects a route-channels operation whose
+	// referenced channel does not exist (routes/{id}/channels family).
+	ErrorCodeChannelNotFound = "channelNotFound"
 )

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -504,7 +504,7 @@ func (h *tokenRoutesHandler) updateRoute(w http.ResponseWriter, r *http.Request)
 
 	existing := queryRow(h.db, "SELECT * FROM token_routes WHERE id = ?", id)
 	if existing == nil {
-		writeErrorWithRequest(w, r, http.StatusNotFound, "route not found")
+		writeErrorCodeWithRequest(w, r, http.StatusNotFound, ErrorCodeRouteNotFound, "route not found")
 		return
 	}
 

--- a/handler/admin/token_routes_channels.go
+++ b/handler/admin/token_routes_channels.go
@@ -376,7 +376,7 @@ func (h *tokenRoutesHandler) updateChannel(w http.ResponseWriter, r *http.Reques
 	idStr := chi.URLParam(r, "channelId")
 	channelID, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil || channelID <= 0 {
-		writeErrorWithRequest(w, r, http.StatusNotFound, "channel not found")
+		writeErrorCodeWithRequest(w, r, http.StatusNotFound, ErrorCodeChannelNotFound, "channel not found")
 		return
 	}
 

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/config"
 	"github.com/deliciousbuding/metapi-go/routing"
 	"github.com/deliciousbuding/metapi-go/store"
 	"github.com/go-chi/chi/v5"
@@ -1995,5 +1996,48 @@ func TestTokenRoutes_Rebuild_ZeroRoutesTruthfulEnvelope(t *testing.T) {
 	}
 	if result["changed"] != false {
 		t.Fatalf("changed = %v, want false: %v", result["changed"], result)
+	}
+}
+
+// errorCode contract: the resource-not-found rejections across account
+// tokens / routes / channels carry the additive machine-readable code the
+// frontend maps to localized toast copy (batch 3). Message text stays the
+// display fallback.
+func TestErrorCodeResourceNotFound(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	cfg := &config.Config{AccountCredentialSecret: "test-secret-for-accounts"}
+	RegisterAccountTokensRoutesWithConfig(r, db.DB, cfg)
+
+	cases := []struct {
+		name     string
+		method   string
+		path     string
+		body     map[string]any
+		wantCode string
+	}{
+		{name: "account token update", method: http.MethodPut, path: "/api/account-tokens/999999", body: map[string]any{"enabled": true}, wantCode: "tokenNotFound"},
+		{name: "route update", method: http.MethodPut, path: "/api/routes/999999", body: map[string]any{"name": "n"}, wantCode: "routeNotFound"},
+		{name: "channel update invalid id", method: http.MethodPut, path: "/api/channels/0", body: map[string]any{"priority": 1}, wantCode: "channelNotFound"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := doPutJSON(t, r, tc.path, tc.body)
+			if resp.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404 (body=%s)", resp.Code, resp.Body.String())
+			}
+			var body struct {
+				Error     string `json:"error"`
+				ErrorCode string `json:"errorCode"`
+			}
+			if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal: %v (body=%s)", err, resp.Body.String())
+			}
+			if body.Error == "" {
+				t.Fatalf("expected human-readable error text, got %q", resp.Body.String())
+			}
+			if body.ErrorCode != tc.wantCode {
+				t.Fatalf("errorCode = %q, want %q (body=%s)", body.ErrorCode, tc.wantCode, resp.Body.String())
+			}
+		})
 	}
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -44,7 +44,10 @@
         "reauthRequired": "Sensitive operation requires master token confirmation"
       },
       "api": {
-        "accountNotFound": "Account not found"
+        "accountNotFound": "Account not found",
+        "tokenNotFound": "Token not found",
+        "routeNotFound": "Route not found",
+        "channelNotFound": "Channel not found"
       },
       "internalServerError": "Internal Server Error!",
       "serverError": "Server error ({{status}}). Please try again later.",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -44,7 +44,10 @@
         "reauthRequired": "敏感操作需要主令牌确认"
       },
       "api": {
-        "accountNotFound": "账号不存在"
+        "accountNotFound": "账号不存在",
+        "tokenNotFound": "令牌不存在",
+        "routeNotFound": "路由不存在",
+        "channelNotFound": "渠道不存在"
       },
       "internalServerError": "服务器内部错误！",
       "serverError": "服务器错误（{{status}}），请稍后重试。",

--- a/web/src/lib/__tests__/http-client.test.ts
+++ b/web/src/lib/__tests__/http-client.test.ts
@@ -339,12 +339,14 @@ describe('apiClient auth interceptor', () => {
       'authIpBlocked',
       'authReauthRequired',
       'accountNotFound',
+      'tokenNotFound',
+      'routeNotFound',
+      'channelNotFound',
     ]
     for (const code of codes) {
-      const expectedKey =
-        code === 'accountNotFound'
-          ? 'errors.api.accountNotFound'
-          : `errors.auth.${code.replace(/^auth/, '').replace(/^./, (c) => c.toLowerCase())}`
+      const expectedKey = code.startsWith('auth')
+        ? `errors.auth.${code.replace(/^auth/, '').replace(/^./, (c) => c.toLowerCase())}`
+        : `errors.api.${code}`
       expect(i18n.exists(expectedKey), `${code} -> ${expectedKey}`).toBe(true)
     }
   })

--- a/web/src/lib/http-client.ts
+++ b/web/src/lib/http-client.ts
@@ -153,6 +153,9 @@ const ERROR_CODE_I18N_KEYS: Record<string, string> = {
   authIpBlocked: 'errors.auth.ipBlocked',
   authReauthRequired: 'errors.auth.reauthRequired',
   accountNotFound: 'errors.api.accountNotFound',
+  tokenNotFound: 'errors.api.tokenNotFound',
+  routeNotFound: 'errors.api.routeNotFound',
+  channelNotFound: 'errors.api.channelNotFound',
 }
 
 /** Localized copy for a known errorCode; undefined when unmapped. */


### PR DESCRIPTION
## What
Batch 3 of the backend English-copy localization effort (template: batch 1 `accountNotFound` / #1109).

11 sites across account-tokens / token-routes / route-channels now carry the additive machine-readable `errorCode` on the unified error body; message text unchanged (byte-identical display fallback).

**Backend**:
- `error_codes.go`: `ErrorCodeTokenNotFound` / `RouteNotFound` / `ChannelNotFound`.
- `account_tokens.go` (9 update paths), `token_routes.go` (route update), `token_routes_channels.go` (channel id parse): `writeError(WithRequest)` → `writeErrorCode(WithRequest)`.
- `token_routes_test.go`: `TestErrorCodeResourceNotFound` pins all three codes (token update / route update / channel invalid id).

**Frontend**:
- `ERROR_CODE_I18N_KEYS`: `tokenNotFound` / `routeNotFound` / `channelNotFound` → `errors.api.*` (en + zh-CN); existence pin extended.

**Docs**: `conventions.md` three registry rows.

## Note
Squash-merge order with #1110 (siteNotFound) is independent — the branches touch disjoint files (siteNotFound lands in sites/accounts/site-announcements; this one in account-tokens/routes).
