### PR TITLE
feat(admin): mark honest 501 residuals with operationNotImplemented errorCode

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -107,6 +107,7 @@ sites; this table is the registry and grows deliberately. Constants live in
 | `authInvalidToken`      | 403    | all admin routes (auth middleware)             | Bearer master-token mismatch                                   |
 | `authIpBlocked`         | 403    | all admin routes (auth middleware)             | client IP not on the admin allowlist                           |
 | `authReauthRequired`    | 403    | sensitive admin routes (reauth gate)           | sensitive op needs master-token confirmation (`reauthRequired`) |
+| `operationNotImplemented` | 501    | `/api/test/*` (stream/jobs), `/api/update-center/*` (deploy/rollback/SSE) | honest residual — feature not implemented in this build (no fake stubs) |
 | `accountNotFound`       | 404    | `/api/accounts*`, `/api/account-tokens*`, `/api/accounts/health/refresh` | referenced account does not exist |
 
 Frontend note: the admin UI historically detected the same-target migration

--- a/handler/admin/error_codes.go
+++ b/handler/admin/error_codes.go
@@ -32,4 +32,9 @@ const (
 	// body references an account that does not exist (accounts / account
 	// tokens / accounts-health route families).
 	ErrorCodeAccountNotFound = "accountNotFound"
+
+	// ErrorCodeOperationNotImplemented marks an honest 501 residual surface
+	// (a known unimplemented feature — never a fake stub success). Emitted on
+	// the residual 501 bodies via writeNotImplementedResidual.
+	ErrorCodeOperationNotImplemented = "operationNotImplemented"
 )

--- a/handler/admin/test.go
+++ b/handler/admin/test.go
@@ -266,9 +266,10 @@ func contentToPrompt(raw json.RawMessage) string {
 // Never use this helper to invent fake success, stream chunks, or job ids.
 func writeNotImplementedResidual(w http.ResponseWriter, message, residual string) {
 	writeJSON(w, http.StatusNotImplemented, map[string]any{
-		"success":  false,
-		"message":  message,
-		"residual": residual,
+		"success":    false,
+		"message":    message,
+		"errorCode":  ErrorCodeOperationNotImplemented,
+		"residual":   residual,
 	})
 }
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -44,7 +44,8 @@
         "reauthRequired": "Sensitive operation requires master token confirmation"
       },
       "api": {
-        "accountNotFound": "Account not found"
+        "accountNotFound": "Account not found",
+        "operationNotImplemented": "This feature is not implemented yet"
       },
       "internalServerError": "Internal Server Error!",
       "serverError": "Server error ({{status}}). Please try again later.",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -44,7 +44,8 @@
         "reauthRequired": "敏感操作需要主令牌确认"
       },
       "api": {
-        "accountNotFound": "账号不存在"
+        "accountNotFound": "账号不存在",
+        "operationNotImplemented": "该功能尚未实现"
       },
       "internalServerError": "服务器内部错误！",
       "serverError": "服务器错误（{{status}}），请稍后重试。",

--- a/web/src/lib/__tests__/http-client.test.ts
+++ b/web/src/lib/__tests__/http-client.test.ts
@@ -339,6 +339,7 @@ describe('apiClient auth interceptor', () => {
       'authIpBlocked',
       'authReauthRequired',
       'accountNotFound',
+      'operationNotImplemented',
     ]
     for (const code of codes) {
       const expectedKey =

--- a/web/src/lib/http-client.ts
+++ b/web/src/lib/http-client.ts
@@ -153,6 +153,7 @@ const ERROR_CODE_I18N_KEYS: Record<string, string> = {
   authIpBlocked: 'errors.auth.ipBlocked',
   authReauthRequired: 'errors.auth.reauthRequired',
   accountNotFound: 'errors.api.accountNotFound',
+  operationNotImplemented: 'errors.api.operationNotImplemented',
 }
 
 /** Localized copy for a known errorCode; undefined when unmapped. */


### PR DESCRIPTION
## What
Batch 4 of the backend English-copy localization. `writeNotImplementedResidual` — the shared honest-501 helper backing all 8 residual surfaces (proxy/chat stream + jobs, update-center deploy/rollback/SSE) — now emits the additive machine-readable `errorCode` `operationNotImplemented` on the residual body.

The body keeps its legacy shape (`message` + `residual` hint + `success:false`), so the residual-audit tests and the honest-no-fake-stub contract are untouched; the frontend reads the new code first and renders localized copy.

**Backend**: `error_codes.go` constant; `test.go` helper body gains `"errorCode"`.

**Frontend**: `ERROR_CODE_I18N_KEYS` + `operationNotImplemented → errors.api.operationNotImplemented` (en "This feature is not implemented yet" / zh-CN "该功能尚未实现"); existence pin extended.

**Docs**: `conventions.md` registry row (501 residual surfaces).
