### PR TITLE
feat(admin): emit operationNotSupported/resourceDisabled errorCodes

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -107,6 +107,8 @@ sites; this table is the registry and grows deliberately. Constants live in
 | `authInvalidToken`      | 403    | all admin routes (auth middleware)             | Bearer master-token mismatch                                   |
 | `authIpBlocked`         | 403    | all admin routes (auth middleware)             | client IP not on the admin allowlist                           |
 | `authReauthRequired`    | 403    | sensitive admin routes (reauth gate)           | sensitive op needs master-token confirmation (`reauthRequired`) |
+| `operationNotSupported` | 400    | `/api/account-tokens*` (API-key connections)   | operation not supported for this connection type |
+| `resourceDisabled`     | 503    | `/api/routes/decision*`, `/api/models/verify-batch` (engine/scheduler not configured) | capability currently unavailable |
 | `operationNotImplemented` | 501    | `/api/test/*` (stream/jobs), `/api/update-center/*` (deploy/rollback/SSE) | honest residual — feature not implemented in this build (no fake stubs) |
 | `accountNotFound`       | 404    | `/api/accounts*`, `/api/account-tokens*`, `/api/accounts/health/refresh` | referenced account does not exist |
 | `tokenNotFound`         | 404    | `/api/account-tokens*`                        | referenced account token does not exist |

--- a/handler/admin/account_tokens.go
+++ b/handler/admin/account_tokens.go
@@ -92,7 +92,7 @@ func (h *accountTokensHandler) createToken(w http.ResponseWriter, r *http.Reques
 	}
 
 	if service.IsAPIKeyConnection(&row.Account) {
-		writeError(w, http.StatusBadRequest, "API key connections do not support creating account tokens")
+		writeErrorCode(w, http.StatusBadRequest, ErrorCodeOperationNotSupported, "API key connections do not support creating account tokens")
 		return
 	}
 
@@ -404,7 +404,7 @@ func (h *accountTokensHandler) updateToken(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if service.IsAPIKeyConnection(owner) {
-		writeError(w, http.StatusBadRequest, "API key connections do not support managing account tokens")
+		writeErrorCode(w, http.StatusBadRequest, ErrorCodeOperationNotSupported, "API key connections do not support managing account tokens")
 		return
 	}
 
@@ -527,7 +527,7 @@ func (h *accountTokensHandler) setDefault(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if service.IsAPIKeyConnection(owner) {
-		writeError(w, http.StatusBadRequest, "API key connections do not support managing account tokens")
+		writeErrorCode(w, http.StatusBadRequest, ErrorCodeOperationNotSupported, "API key connections do not support managing account tokens")
 		return
 	}
 	if service.IsMaskedPendingAccountToken(token) {
@@ -571,7 +571,7 @@ func (h *accountTokensHandler) getTokenValue(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	if service.IsAPIKeyConnection(owner) {
-		writeError(w, http.StatusBadRequest, "API key connections do not support managing account tokens")
+		writeErrorCode(w, http.StatusBadRequest, ErrorCodeOperationNotSupported, "API key connections do not support managing account tokens")
 		return
 	}
 
@@ -626,7 +626,7 @@ func (h *accountTokensHandler) deleteToken(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if service.IsAPIKeyConnection(owner) {
-		writeError(w, http.StatusBadRequest, "API key connections do not support managing account tokens")
+		writeErrorCode(w, http.StatusBadRequest, ErrorCodeOperationNotSupported, "API key connections do not support managing account tokens")
 		return
 	}
 

--- a/handler/admin/account_tokens_sync.go
+++ b/handler/admin/account_tokens_sync.go
@@ -107,7 +107,7 @@ func (h *accountTokensHandler) getGroups(w http.ResponseWriter, r *http.Request)
 	}
 
 	if service.IsAPIKeyConnection(&row.Account) {
-		writeError(w, http.StatusBadRequest, "API key connections do not support fetching account token groups")
+		writeErrorCode(w, http.StatusBadRequest, ErrorCodeOperationNotSupported, "API key connections do not support fetching account token groups")
 		return
 	}
 

--- a/handler/admin/error_codes.go
+++ b/handler/admin/error_codes.go
@@ -48,8 +48,19 @@ const (
 	// ErrorCodeChannelNotFound rejects a route-channels operation whose
 	// referenced channel does not exist (routes/{id}/channels family).
 	ErrorCodeChannelNotFound = "channelNotFound"
+
 	// ErrorCodeSiteNotFound rejects a request whose `{id}` path segment or
 	// body references a site that does not exist (sites / accounts / site
 	// announcements route families).
 	ErrorCodeSiteNotFound = "siteNotFound"
+
+	// ErrorCodeOperationNotSupported rejects an operation that the account
+	// connection type does not support (e.g. API-key connections managing
+	// account tokens).
+	ErrorCodeOperationNotSupported = "operationNotSupported"
+
+	// ErrorCodeResourceDisabled marks a failure caused by a capability being
+	// currently unavailable — engine not configured, probe scheduler not
+	// running, or the like.
+	ErrorCodeResourceDisabled = "resourceDisabled"
 )

--- a/handler/admin/models_verify.go
+++ b/handler/admin/models_verify.go
@@ -38,7 +38,7 @@ func nullableFloat64(v float64) any {
 func (h *statsHandler) verifyBatch(w http.ResponseWriter, r *http.Request) {
 	sched := scheduler.GetGlobalModelProbeScheduler()
 	if sched == nil {
-		writeError(w, http.StatusServiceUnavailable, "model probe scheduler is not running (start schedulers)")
+		writeErrorCode(w, http.StatusServiceUnavailable, ErrorCodeResourceDisabled, "model probe scheduler is not running (start schedulers)")
 		return
 	}
 

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -1334,7 +1334,7 @@ func (h *statsHandler) modelCheck(w http.ResponseWriter, r *http.Request) {
 func (h *statsHandler) modelProbe(w http.ResponseWriter, r *http.Request) {
 	sched := scheduler.GetGlobalModelProbeScheduler()
 	if sched == nil {
-		writeError(w, http.StatusServiceUnavailable, "model probe scheduler is not running (enable MODEL_AVAILABILITY_PROBE_ENABLED or start schedulers)")
+		writeErrorCode(w, http.StatusServiceUnavailable, ErrorCodeResourceDisabled, "model probe scheduler is not running (enable MODEL_AVAILABILITY_PROBE_ENABLED or start schedulers)")
 		return
 	}
 	jobID := fmt.Sprintf("probe-%d", time.Now().UTC().UnixNano())

--- a/handler/admin/token_routes_decisions.go
+++ b/handler/admin/token_routes_decisions.go
@@ -18,7 +18,7 @@ func (h *tokenRoutesHandler) routeDecision(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if h.router == nil {
-		writeError(w, http.StatusServiceUnavailable, routeDecisionRouterUnavailable)
+		writeErrorCode(w, http.StatusServiceUnavailable, ErrorCodeResourceDisabled, routeDecisionRouterUnavailable)
 		return
 	}
 
@@ -55,7 +55,7 @@ func (h *tokenRoutesHandler) routeDecisionBatch(w http.ResponseWriter, r *http.R
 		return
 	}
 	if h.router == nil {
-		writeError(w, http.StatusServiceUnavailable, routeDecisionRouterUnavailable)
+		writeErrorCode(w, http.StatusServiceUnavailable, ErrorCodeResourceDisabled, routeDecisionRouterUnavailable)
 		return
 	}
 
@@ -100,7 +100,7 @@ func (h *tokenRoutesHandler) routeDecisionByRouteBatch(w http.ResponseWriter, r 
 		return
 	}
 	if h.router == nil {
-		writeError(w, http.StatusServiceUnavailable, routeDecisionRouterUnavailable)
+		writeErrorCode(w, http.StatusServiceUnavailable, ErrorCodeResourceDisabled, routeDecisionRouterUnavailable)
 		return
 	}
 
@@ -152,7 +152,7 @@ func (h *tokenRoutesHandler) routeDecisionRouteWideBatch(w http.ResponseWriter, 
 		return
 	}
 	if h.router == nil {
-		writeError(w, http.StatusServiceUnavailable, routeDecisionRouterUnavailable)
+		writeErrorCode(w, http.StatusServiceUnavailable, ErrorCodeResourceDisabled, routeDecisionRouterUnavailable)
 		return
 	}
 

--- a/handler/admin/token_routes_test.go
+++ b/handler/admin/token_routes_test.go
@@ -2041,3 +2041,30 @@ func TestErrorCodeResourceNotFound(t *testing.T) {
 		})
 	}
 }
+
+// errorCode contract: the disabled/not-supported rejections carry the
+// additive machine-readable code the frontend maps to localized copy
+// (batch 5 — operationNotSupported / resourceDisabled). The
+// route-decision engine-unconfigured path is the stable, dependency-free
+// representative; other sites of the family share the same helper shape
+// and are covered by their existing status/message assertions.
+func TestErrorCodeResourceDisabledDecisionEngine(t *testing.T) {
+	_, r := setupTokenRoutesTest(t)
+	resp := doGet(t, r, "/api/routes/decision?model=gpt-4")
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 (body=%s)", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Error     string `json:"error"`
+		ErrorCode string `json:"errorCode"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v (body=%s)", err, resp.Body.String())
+	}
+	if body.Error == "" {
+		t.Fatalf("expected human-readable error text, got %q", resp.Body.String())
+	}
+	if body.ErrorCode != "resourceDisabled" {
+		t.Fatalf("errorCode = %q, want %q (body=%s)", body.ErrorCode, "resourceDisabled", resp.Body.String())
+	}
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -49,7 +49,9 @@
         "tokenNotFound": "Token not found",
         "routeNotFound": "Route not found",
         "channelNotFound": "Channel not found",
-        "siteNotFound": "Site not found"
+        "siteNotFound": "Site not found",
+        "operationNotSupported": "This operation is not supported for this connection type",
+        "resourceDisabled": "This capability is currently unavailable"
       },
       "internalServerError": "Internal Server Error!",
       "serverError": "Server error ({{status}}). Please try again later.",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -49,7 +49,9 @@
         "tokenNotFound": "令牌不存在",
         "routeNotFound": "路由不存在",
         "channelNotFound": "渠道不存在",
-        "siteNotFound": "站点不存在"
+        "siteNotFound": "站点不存在",
+        "operationNotSupported": "该连接类型不支持此操作",
+        "resourceDisabled": "该能力当前不可用"
       },
       "internalServerError": "服务器内部错误！",
       "serverError": "服务器错误（{{status}}），请稍后重试。",

--- a/web/src/lib/__tests__/http-client.test.ts
+++ b/web/src/lib/__tests__/http-client.test.ts
@@ -344,6 +344,8 @@ describe('apiClient auth interceptor', () => {
       'routeNotFound',
       'channelNotFound',
       'siteNotFound',
+      'operationNotSupported',
+      'resourceDisabled',
     ]
     for (const code of codes) {
       const expectedKey = code.startsWith('auth')

--- a/web/src/lib/http-client.ts
+++ b/web/src/lib/http-client.ts
@@ -157,6 +157,8 @@ const ERROR_CODE_I18N_KEYS: Record<string, string> = {
   routeNotFound: 'errors.api.routeNotFound',
   channelNotFound: 'errors.api.channelNotFound',
   siteNotFound: 'errors.api.siteNotFound',
+  operationNotSupported: 'errors.api.operationNotSupported',
+  resourceDisabled: 'errors.api.resourceDisabled',
   operationNotImplemented: 'errors.api.operationNotImplemented',
 }
 


### PR DESCRIPTION
## What
Batch 5 of the backend English-copy localization. 13 sites now carry the additive machine-readable `errorCode` on the unified error body; message text unchanged (byte-identical display fallback).

**Backend**:
- `error_codes.go`: `ErrorCodeOperationNotSupported` / `ErrorCodeResourceDisabled`.
- `account_tokens.go` (5) + `account_tokens_sync.go` (1): API-key connection rejection family → `operationNotSupported`.
- `token_routes_decisions.go` (4 `routeDecisionRouterUnavailable` sites), `models_verify.go` (1), `stats.go` (1): engine-unconfigured / scheduler-not-running → `resourceDisabled`.
- `token_routes_test.go`: pins the stable dependency-free path (route decision with unconfigured engine).

**Frontend**: `ERROR_CODE_I18N_KEYS` + `operationNotSupported` / `resourceDisabled` → `errors.api.*` (en + zh-CN); existence pin extended.

**Docs**: `conventions.md` two registry rows.
