### PR TITLE
feat(admin): emit invalidSettingsValue on settings-apply validation funnel

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -107,6 +107,7 @@ sites; this table is the registry and grows deliberately. Constants live in
 | `authInvalidToken`      | 403    | all admin routes (auth middleware)             | Bearer master-token mismatch                                   |
 | `authIpBlocked`         | 403    | all admin routes (auth middleware)             | client IP not on the admin allowlist                           |
 | `authReauthRequired`    | 403    | sensitive admin routes (reauth gate)           | sensitive op needs master-token confirmation (`reauthRequired`) |
+| `invalidSettingsValue` | 400    | `PUT /api/settings/runtime` (apply validation funnel) | settings body carries an invalid field value |
 | `operationNotSupported` | 400    | `/api/account-tokens*` (API-key connections)   | operation not supported for this connection type |
 | `resourceDisabled`     | 503    | `/api/routes/decision*`, `/api/models/verify-batch` (engine/scheduler not configured) | capability currently unavailable |
 | `operationNotImplemented` | 501    | `/api/test/*` (stream/jobs), `/api/update-center/*` (deploy/rollback/SSE) | honest residual — feature not implemented in this build (no fake stubs) |

--- a/handler/admin/error_codes.go
+++ b/handler/admin/error_codes.go
@@ -63,4 +63,9 @@ const (
 	// currently unavailable — engine not configured, probe scheduler not
 	// running, or the like.
 	ErrorCodeResourceDisabled = "resourceDisabled"
+
+	// ErrorCodeInvalidSettingsValue rejects a runtime-settings apply whose body
+	// carries an invalid field value (the settings_apply validation funnel);
+	// 5xx apply failures intentionally carry no code.
+	ErrorCodeInvalidSettingsValue = "invalidSettingsValue"
 )

--- a/handler/admin/settings.go
+++ b/handler/admin/settings.go
@@ -186,7 +186,15 @@ func (h *settingsHandler) updateRuntime(w http.ResponseWriter, r *http.Request) 
 		h.applySiteBrandingSettings,
 	} {
 		if err := apply(body); err != nil {
-			writeError(w, err.status, err.msg)
+			// Single funnel (scout §settings_apply): 400-class apply failures
+			// are user-side validation errors, so they carry the machine-
+			// readable invalidSettingsValue code; 5xx internals keep the raw
+			// message with no code (backend text stays the display fallback).
+			code := ""
+			if err.status == http.StatusBadRequest {
+				code = ErrorCodeInvalidSettingsValue
+			}
+			writeErrorCode(w, err.status, code, err.msg)
 			return
 		}
 	}

--- a/handler/admin/settings_runtime_test.go
+++ b/handler/admin/settings_runtime_test.go
@@ -511,3 +511,31 @@ func TestSettingsRuntimeNotifyTogglesPersistAsJSONObject(t *testing.T) {
 		t.Fatalf("stored toggles = %#v", toggles)
 	}
 }
+
+// errorCode contract: the settings-apply validation funnel emits the
+// additive machine-readable invalidSettingsValue code on 400-class apply
+// failures (the largest single validation family — scout §settings_apply);
+// 5xx apply failures intentionally carry no code. The message text stays
+// the display fallback.
+func TestSettingsRuntimeApplyValidationCarriesCode(t *testing.T) {
+	_, r, _ := setupEdgeTest(t)
+	resp := doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+		"checkinCron": "bad cron",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s, want 400", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Error     string `json:"error"`
+		ErrorCode string `json:"errorCode"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v (body=%s)", err, resp.Body.String())
+	}
+	if body.Error == "" {
+		t.Fatalf("expected human-readable error text, got %q", resp.Body.String())
+	}
+	if body.ErrorCode != "invalidSettingsValue" {
+		t.Fatalf("errorCode = %q, want %q (body=%s)", body.ErrorCode, "invalidSettingsValue", resp.Body.String())
+	}
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -51,7 +51,8 @@
         "channelNotFound": "Channel not found",
         "siteNotFound": "Site not found",
         "operationNotSupported": "This operation is not supported for this connection type",
-        "resourceDisabled": "This capability is currently unavailable"
+        "resourceDisabled": "This capability is currently unavailable",
+        "invalidSettingsValue": "Invalid value in the settings form; please check and save again"
       },
       "internalServerError": "Internal Server Error!",
       "serverError": "Server error ({{status}}). Please try again later.",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -51,7 +51,8 @@
         "channelNotFound": "渠道不存在",
         "siteNotFound": "站点不存在",
         "operationNotSupported": "该连接类型不支持此操作",
-        "resourceDisabled": "该能力当前不可用"
+        "resourceDisabled": "该能力当前不可用",
+        "invalidSettingsValue": "设置项包含无效值，请检查后重新保存"
       },
       "internalServerError": "服务器内部错误！",
       "serverError": "服务器错误（{{status}}），请稍后重试。",

--- a/web/src/lib/__tests__/http-client.test.ts
+++ b/web/src/lib/__tests__/http-client.test.ts
@@ -346,6 +346,7 @@ describe('apiClient auth interceptor', () => {
       'siteNotFound',
       'operationNotSupported',
       'resourceDisabled',
+      'invalidSettingsValue',
     ]
     for (const code of codes) {
       const expectedKey = code.startsWith('auth')

--- a/web/src/lib/http-client.ts
+++ b/web/src/lib/http-client.ts
@@ -159,6 +159,7 @@ const ERROR_CODE_I18N_KEYS: Record<string, string> = {
   siteNotFound: 'errors.api.siteNotFound',
   operationNotSupported: 'errors.api.operationNotSupported',
   resourceDisabled: 'errors.api.resourceDisabled',
+  invalidSettingsValue: 'errors.api.invalidSettingsValue',
   operationNotImplemented: 'errors.api.operationNotImplemented',
 }
 


### PR DESCRIPTION
## What
Batch 6 of the backend English-copy localization — the largest single validation family (scout: ~50 settings_apply literals funneled through one `writeError` at settings.go).

The funnel now derives the additive machine-readable `errorCode` from the apply status: 400-class failures (user-side validation — invalid cron / fractional interval / out-of-range numbers) carry `invalidSettingsValue`; 5xx internals keep the raw message with no code. One-site change covers the whole family; the ~50 per-field English messages stay as the display fallback.

**Backend**: `error_codes.go` constant; `settings.go` funnel `writeError` → `writeErrorCode` (code derived by status).
**Frontend**: `ERROR_CODE_I18N_KEYS` + `invalidSettingsValue → errors.api.invalidSettingsValue` (en + zh-CN); existence pin extended.
**Docs**: `conventions.md` registry row.
