### PR TITLE
feat(api): errorCode resourceLoadFailed for the read-path load-failure family

### DIFF
--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -116,6 +116,7 @@ sites; this table is the registry and grows deliberately. Constants live in
 | `routeNotFound`         | 404    | `/api/routes*`                               | referenced token route does not exist |
 | `channelNotFound`       | 404    | `/api/channels/{channelId}`                  | referenced route channel id is missing/non-positive |
 | `siteNotFound`          | 404    | `/api/sites*`, `/api/accounts*`, `/api/site-announcements/sync` | referenced site does not exist |
+| `resourceLoadFailed`    | 500    | `/api/accounts*`, `/api/sites*`, `/api/channels*`, `/api/stats*`, `/api/token-routes*`, `/api/checkin/*`, `/api/downstream-keys*`, `/api/announcements*`, `/api/events*`, `/api/oauth*`, `/api/models/*`, `/api/tags*`, `/api/probe-history*`, `/api/resin*` | read-path query failed; entity data could not be loaded |
 
 Frontend note: the admin UI historically detected the same-target migration
 rejection by substring-matching the message text; it should migrate to

--- a/handler/admin/account_tokens.go
+++ b/handler/admin/account_tokens.go
@@ -60,7 +60,7 @@ func (h *accountTokensHandler) listTokens(w http.ResponseWriter, r *http.Request
 	tokens, err := service.ListTokensWithRelations(h.db, accountID)
 	if err != nil {
 		slog.Error("Failed to load tokens", "err", err)
-		writeError(w, http.StatusInternalServerError, "Failed to load tokens")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "Failed to load tokens")
 		return
 	}
 

--- a/handler/admin/account_tokens_sync.go
+++ b/handler/admin/account_tokens_sync.go
@@ -131,7 +131,7 @@ func (h *accountTokensHandler) getGroups(w http.ResponseWriter, r *http.Request)
 	)
 	if err != nil {
 		slog.Error("Failed to load token groups", "err", err, "account_id", accountID)
-		writeError(w, http.StatusInternalServerError, "Failed to load token groups")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "Failed to load token groups")
 		return
 	}
 

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -153,7 +153,7 @@ func (h *accountsHandler) listAccounts(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		slog.Error("Failed to load accounts", "err", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load accounts"})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load accounts", "errorCode": "resourceLoadFailed"})
 		return
 	}
 
@@ -227,7 +227,7 @@ func (h *accountsHandler) listAccountsPaginated(w http.ResponseWriter, r *http.R
 	accounts, total, err := service.ListAccountsWithSitesPaginated(h.db, pageSize, offset)
 	if err != nil {
 		slog.Error("Failed to load paginated accounts", "err", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load accounts"})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load accounts", "errorCode": "resourceLoadFailed"})
 		return
 	}
 
@@ -813,7 +813,7 @@ func (h *accountsHandler) loginAccount(w http.ResponseWriter, r *http.Request) {
 	var loginAcct store.Account
 	if err := h.db.Get(&loginAcct, h.db.Rebind("SELECT * FROM accounts WHERE site_id = ? AND username = ?"), body.SiteID, body.Username); err != nil {
 		slog.Error("Failed to load login account", "err", err, "site_id", body.SiteID)
-		writeErrorWithRequest(w, r, http.StatusInternalServerError, "Failed to load account.")
+		writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "Failed to load account.")
 		return
 	}
 	loginAcctMap := map[string]any{
@@ -1372,7 +1372,7 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 	updatedRow, err := service.GetAccountWithSiteByID(h.db, id)
 	if err != nil {
 		slog.Error("Failed to load updated account", "err", err, "account_id", id)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Failed to load updated account"})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "Failed to load updated account", "errorCode": "resourceLoadFailed"})
 		return
 	}
 	updated := updatedRow.Account

--- a/handler/admin/accounts_models.go
+++ b/handler/admin/accounts_models.go
@@ -38,7 +38,7 @@ func (h *accountsHandler) getAccountModels(w http.ResponseWriter, r *http.Reques
 	var modelRows []modelRow
 	if err := h.db.Select(&modelRows, h.db.Rebind("SELECT model_name, available, latency_ms, is_manual, checked_at FROM model_availability WHERE account_id = ? ORDER BY model_name ASC"), id); err != nil {
 		slog.Error("failed to load account model availability", "account_id", id, "err", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to load model availability"})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to load model availability", "errorCode": "resourceLoadFailed"})
 		return
 	}
 

--- a/handler/admin/announcements.go
+++ b/handler/admin/announcements.go
@@ -93,7 +93,7 @@ func (h *announcementsHandler) loadAnnouncements(enabledOnly bool) ([]map[string
 func (h *announcementsHandler) listAll(w http.ResponseWriter, r *http.Request) {
 	items, err := h.loadAnnouncements(false)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to load announcements"})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to load announcements", "errorCode": "resourceLoadFailed"})
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"items": items})
@@ -103,7 +103,7 @@ func (h *announcementsHandler) listAll(w http.ResponseWriter, r *http.Request) {
 func (h *announcementsHandler) listActive(w http.ResponseWriter, r *http.Request) {
 	items, err := h.loadAnnouncements(true)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to load announcements"})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to load announcements", "errorCode": "resourceLoadFailed"})
 		return
 	}
 	visible := make([]map[string]any, 0, len(items))
@@ -173,7 +173,7 @@ func (h *announcementsHandler) create(w http.ResponseWriter, r *http.Request) {
 	}
 	items, err := h.loadAnnouncements(false)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "created but failed to reload"})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "created but failed to reload", "errorCode": "resourceLoadFailed"})
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"success": true, "items": items})

--- a/handler/admin/channels.go
+++ b/handler/admin/channels.go
@@ -187,7 +187,7 @@ func (h *tokenRoutesHandler) listChannels(w http.ResponseWriter, r *http.Request
 	})
 	if err != nil {
 		slog.Error("channels list failed", "error", err)
-		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load channel list")
+		writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load channel list")
 		return
 	}
 
@@ -466,7 +466,7 @@ func (h *tokenRoutesHandler) channelErrorSummary(w http.ResponseWriter, r *http.
 	})
 	if err != nil {
 		slog.Error("channels error summary failed", "error", err)
-		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load channel error summary")
+		writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load channel error summary")
 		return
 	}
 

--- a/handler/admin/checkin_routes.go
+++ b/handler/admin/checkin_routes.go
@@ -180,7 +180,7 @@ func (h *checkinHandler) getLogs(w http.ResponseWriter, r *http.Request) {
 	qArgs = append(qArgs, limit, offset)
 	rows, err := queryRowsErr(h.db, query, qArgs...)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load checkin logs")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load checkin logs")
 		return
 	}
 

--- a/handler/admin/downstream_keys.go
+++ b/handler/admin/downstream_keys.go
@@ -67,7 +67,7 @@ func (h *downstreamKeysHandler) summary(w http.ResponseWriter, r *http.Request) 
 
 	rows, err := queryRowsErr(h.db, query, args...)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load downstream keys")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load downstream keys")
 		return
 	}
 
@@ -124,7 +124,7 @@ func (h *downstreamKeysHandler) listKeys(w http.ResponseWriter, r *http.Request)
 			"SELECT * FROM downstream_api_keys ORDER BY id DESC LIMIT ? OFFSET ?",
 			pageSize, offset)
 		if queryErr != nil {
-			writeError(w, http.StatusInternalServerError, "failed to load downstream keys")
+			writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load downstream keys")
 			return
 		}
 		if err := h.db.Get(&total, h.db.Rebind("SELECT COUNT(*) FROM downstream_api_keys")); err != nil {
@@ -134,7 +134,7 @@ func (h *downstreamKeysHandler) listKeys(w http.ResponseWriter, r *http.Request)
 	} else {
 		rows, queryErr = queryRowsErr(h.db, "SELECT * FROM downstream_api_keys ORDER BY id DESC")
 		if queryErr != nil {
-			writeError(w, http.StatusInternalServerError, "failed to load downstream keys")
+			writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load downstream keys")
 			return
 		}
 	}

--- a/handler/admin/error_code_load_failed_test.go
+++ b/handler/admin/error_code_load_failed_test.go
@@ -1,0 +1,82 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// errorCode contract: the whole "Failed to load …" read-path family carries
+// the additive resourceLoadFailed code so the console can render one
+// localized toast instead of 20+ English variants. All three response
+// shapes are covered (writeError / writeErrorWithRequest / writeJSON legacy
+// `{message}`); the per-entity English message stays the display fallback.
+func TestErrorCodeResourceLoadFailed(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("failed to open SQLite: %v", err)
+	}
+	defer db.Close()
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+
+	r := chi.NewRouter()
+	RegisterSitesRoutes(r, db.DB)
+	RegisterStatsRoutes(r, db.DB)
+	RegisterAccountsRoutes(r, db.DB, &config.Config{AccountCredentialSecret: "test-secret-for-load-fail"})
+
+	// A closed DB makes every read fail without needing fixtures; the
+	// response must NOT be a 200 with partial data.
+	db.Close()
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		status int
+	}{
+		// writeJSON legacy `{message}` shape (accounts snapshot).
+		{name: "accounts snapshot", method: http.MethodGet, path: "/api/accounts"},
+		// writeErrorWithRequest shape (sites list).
+		{name: "sites list", method: http.MethodGet, path: "/api/sites"},
+		// writeError shape (stats dashboard, writeErrorCodeWithRequest).
+		{name: "stats dashboard", method: http.MethodGet, path: "/api/stats/dashboard"},
+		// stats heatmap writeError path.
+		{name: "usage heatmap", method: http.MethodGet, path: "/api/stats/usage-heatmap"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+			if rec.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want 500 (body=%s)", rec.Code, rec.Body.String())
+			}
+			var body struct {
+				Error     string `json:"error"`
+				Message   string `json:"message"`
+				ErrorCode string `json:"errorCode"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal: %v (body=%s)", err, rec.Body.String())
+			}
+			msg := body.Error
+			if msg == "" {
+				msg = body.Message
+			}
+			if msg == "" && tc.name == "accounts snapshot" {
+				// The snapshot path populates a partial cache on failures in
+				// some versions; the error envelope is still authoritative.
+			}
+			if body.ErrorCode != "resourceLoadFailed" {
+				t.Fatalf("errorCode = %q, want %q (body=%s)", body.ErrorCode, "resourceLoadFailed", rec.Body.String())
+			}
+		})
+	}
+}

--- a/handler/admin/error_codes.go
+++ b/handler/admin/error_codes.go
@@ -68,4 +68,11 @@ const (
 	// carries an invalid field value (the settings_apply validation funnel);
 	// 5xx apply failures intentionally carry no code.
 	ErrorCodeInvalidSettingsValue = "invalidSettingsValue"
+
+	// ErrorCodeResourceLoadFailed marks a 5xx read-path failure where entity
+	// data could not be loaded (accounts / announcements / events / channels /
+	// site announcements / stats / token routes). One code for the whole
+	// load-failure family; the per-entity English message stays the display
+	// fallback.
+	ErrorCodeResourceLoadFailed = "resourceLoadFailed"
 )

--- a/handler/admin/events.go
+++ b/handler/admin/events.go
@@ -57,7 +57,7 @@ func (h *eventsHandler) listEvents(w http.ResponseWriter, r *http.Request) {
 	rows, err := h.db.Queryx(h.db.Rebind(query), args...)
 	if err != nil {
 		slog.Error("Failed to load events", "err", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load events"})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load events", "errorCode": "resourceLoadFailed"})
 		return
 	}
 	defer rows.Close()
@@ -67,7 +67,7 @@ func (h *eventsHandler) listEvents(w http.ResponseWriter, r *http.Request) {
 		row := make(map[string]any)
 		if err := rows.MapScan(row); err != nil {
 			slog.Error("Failed to read event row", "err", err)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load events"})
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load events", "errorCode": "resourceLoadFailed"})
 			return
 		}
 		events = append(events, row)
@@ -86,7 +86,7 @@ func (h *eventsHandler) countUnread(w http.ResponseWriter, r *http.Request) {
 	err := h.db.Get(&count, h.db.Rebind("SELECT COUNT(*) FROM events WHERE read = ?"), false)
 	if err != nil {
 		slog.Error("Failed to count unread events", "err", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load events"})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load events", "errorCode": "resourceLoadFailed"})
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]int{"count": count})

--- a/handler/admin/model_price_compare.go
+++ b/handler/admin/model_price_compare.go
@@ -36,7 +36,7 @@ func (h *statsHandler) modelPriceCompare(w http.ResponseWriter, r *http.Request)
 		var err error
 		models, err = h.topModelsForPriceCompare(topModels, since)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to load top models")
+			writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load top models")
 			return
 		}
 	}
@@ -45,7 +45,7 @@ func (h *statsHandler) modelPriceCompare(w http.ResponseWriter, r *http.Request)
 	for _, modelName := range models {
 		inputs, err := h.loadPriceCompareInputs(modelName, since, exactModel)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to load price compare inputs")
+			writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load price compare inputs")
 			return
 		}
 		for _, in := range inputs {

--- a/handler/admin/model_rates.go
+++ b/handler/admin/model_rates.go
@@ -118,7 +118,7 @@ func (h *modelRatesHandler) rates(w http.ResponseWriter, r *http.Request) {
 		ORDER BY COALESCE(a.unit_cost, 0) DESC, a.id ASC
 	`)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load rate overview")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load rate overview")
 		return
 	}
 	accounts := make([]map[string]any, 0, len(accRows))
@@ -146,7 +146,7 @@ func (h *modelRatesHandler) rates(w http.ResponseWriter, r *http.Request) {
 		ORDER BY rc.weight DESC, rc.id ASC
 	`)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load rate overview")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load rate overview")
 		return
 	}
 	channels := make([]map[string]any, 0, len(chRows))
@@ -169,7 +169,7 @@ func (h *modelRatesHandler) rates(w http.ResponseWriter, r *http.Request) {
 		FROM sites ORDER BY global_weight DESC, id ASC
 	`)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load rate overview")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load rate overview")
 		return
 	}
 	sites := make([]map[string]any, 0, len(siteRows))
@@ -188,7 +188,7 @@ func (h *modelRatesHandler) rates(w http.ResponseWriter, r *http.Request) {
 		ORDER BY COALESCE(key_weight, 1.0) DESC, id ASC
 	`)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load rate overview")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load rate overview")
 		return
 	}
 	keys := make([]map[string]any, 0, len(keyRows))
@@ -212,7 +212,7 @@ func (h *modelRatesHandler) rates(w http.ResponseWriter, r *http.Request) {
 		ORDER BY spend DESC, model ASC
 	`, time.Now().UTC().AddDate(0, 0, -29).Format("2006-01-02"))
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load rate overview")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load rate overview")
 		return
 	}
 	models := make([]map[string]any, 0, len(modelRows))

--- a/handler/admin/model_redirects.go
+++ b/handler/admin/model_redirects.go
@@ -172,7 +172,7 @@ func (h *modelRedirectHandler) generate(w http.ResponseWriter, r *http.Request) 
 			// Deterministic order: insertion order ≈ upstream return order.
 			rows, err := queryRowsErr(h.db, "SELECT model_name FROM model_availability WHERE account_id = ? AND available = true ORDER BY id ASC", body.AccountID)
 			if err != nil {
-				writeError(w, http.StatusInternalServerError, "failed to load account models")
+				writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load account models")
 				return
 			}
 			for _, row := range rows {

--- a/handler/admin/models_verify.go
+++ b/handler/admin/models_verify.go
@@ -99,7 +99,7 @@ func (h *statsHandler) verifyBatch(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := queryRowsErr(h.db, q, args...)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load verification targets")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load verification targets")
 		return
 	}
 	targets := make([]scheduler.ProbeTarget, 0, len(rows))
@@ -200,7 +200,7 @@ func (h *statsHandler) verifyHistory(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := queryRowsErr(h.db, q, args...)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load verification history")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load verification history")
 		return
 	}
 	items := make([]map[string]any, 0, len(rows))

--- a/handler/admin/monitor_health.go
+++ b/handler/admin/monitor_health.go
@@ -35,12 +35,12 @@ func (h *monitorHealthHandler) health(w http.ResponseWriter, r *http.Request) {
 	}
 	sites, err := h.statusCounts("sites")
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load status counts")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load status counts")
 		return
 	}
 	accounts, err := h.statusCounts("accounts")
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load status counts")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load status counts")
 		return
 	}
 

--- a/handler/admin/oauth_routes.go
+++ b/handler/admin/oauth_routes.go
@@ -212,7 +212,7 @@ func (h *oauthHandler) listConnections(w http.ResponseWriter, r *http.Request) {
 		 ORDER BY a.id ASC LIMIT ? OFFSET ?`,
 		limit, offset)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load oauth connections")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load oauth connections")
 		return
 	}
 

--- a/handler/admin/probe_history.go
+++ b/handler/admin/probe_history.go
@@ -90,7 +90,7 @@ func toProbeHistoryResult(row probeHistoryRow) probeHistoryResult {
 func writeProbeHistoryResponse(w http.ResponseWriter, db *sqlx.DB, entityColumn string, groupKey string, limit int) {
 	rows, err := queryProbeHistory(db, entityColumn, limit)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "Failed to load probe history")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "Failed to load probe history")
 		return
 	}
 

--- a/handler/admin/resin.go
+++ b/handler/admin/resin.go
@@ -56,7 +56,7 @@ func (h *resinHandler) status(w http.ResponseWriter, r *http.Request) {
 	activeLeases := service.ActiveLeases()
 	perSiteOverrides, err := h.perSiteOverrides()
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load resin per-site overrides")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load resin per-site overrides")
 		return
 	}
 

--- a/handler/admin/site_announcements.go
+++ b/handler/admin/site_announcements.go
@@ -112,7 +112,7 @@ func (h *siteAnnouncementsHandler) listAnnouncements(w http.ResponseWriter, r *h
 	rows, err := h.db.Queryx(h.db.Rebind(query), args...)
 	if err != nil {
 		slog.Error("Failed to load announcements", "err", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load announcements"})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load announcements", "errorCode": "resourceLoadFailed"})
 		return
 	}
 	defer rows.Close()

--- a/handler/admin/sites.go
+++ b/handler/admin/sites.go
@@ -52,7 +52,7 @@ func (h *sitesHandler) listSites(w http.ResponseWriter, r *http.Request) {
 	sites, err := service.ListSites(h.db)
 	if err != nil {
 		slog.Error("Failed to load sites", "err", err)
-		writeErrorWithRequest(w, r, http.StatusInternalServerError, "Failed to load sites")
+		writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "Failed to load sites")
 		return
 	}
 	writeJSON(w, http.StatusOK, sites)
@@ -303,7 +303,7 @@ func (h *sitesHandler) updateSite(w http.ResponseWriter, r *http.Request) {
 		return
 	} else if err != nil {
 		slog.Error("Failed to load site for update", "err", err, "site_id", id)
-		writeErrorWithRequest(w, r, http.StatusInternalServerError, "Failed to load site")
+		writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "Failed to load site")
 		return
 	}
 

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -636,7 +636,7 @@ func parseDashboardForceRefresh(raw string) bool {
 
 func (h *statsHandler) dashboardError(w http.ResponseWriter, operation string, err error) {
 	slog.Error("dashboard stats query failed", "operation", operation, "error", err)
-	writeError(w, http.StatusInternalServerError, "Failed to load dashboard statistics")
+	writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "Failed to load dashboard statistics")
 }
 
 // ---- Proxy Logs ----
@@ -799,7 +799,7 @@ func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 		qArgs = append(qArgs, limit, offset)
 		items, err := queryRowsErr(h.db, query, qArgs...)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to load proxy logs")
+			writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load proxy logs")
 			return
 		}
 		queryPayload["items"] = normalizeSlice(items)
@@ -851,7 +851,7 @@ func (h *statsHandler) proxyLogs(w http.ResponseWriter, r *http.Request) {
 
 		sites, err := queryRowsErr(h.db, "SELECT id, name, status FROM sites")
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to load sites")
+			writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load sites")
 			return
 		}
 		metaPayload["sites"] = normalizeSlice(sites)
@@ -957,7 +957,7 @@ func (h *statsHandler) debugTraces(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := queryRowsErr(h.db, "SELECT * FROM proxy_debug_traces ORDER BY created_at DESC LIMIT ?", limit)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load debug traces")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load debug traces")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"items": normalizeSlice(rows)})
@@ -980,7 +980,7 @@ func (h *statsHandler) debugTraceDetail(w http.ResponseWriter, r *http.Request) 
 	// Load related attempts
 	attempts, err := queryRowsErr(h.db, "SELECT * FROM proxy_debug_attempts WHERE trace_id = ? ORDER BY attempt_index ASC", id)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load debug trace attempts")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load debug trace attempts")
 		return
 	}
 	row["attempts"] = normalizeSlice(attempts)
@@ -1022,7 +1022,7 @@ func (h *statsHandler) siteDistribution(w http.ResponseWriter, r *http.Request) 
 		ORDER BY total_spend DESC, s.name ASC
 	`, fromDay)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load site distribution")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load site distribution")
 		return
 	}
 
@@ -1068,7 +1068,7 @@ func (h *statsHandler) siteTrend(w http.ResponseWriter, r *http.Request) {
 		ORDER BY u.local_day ASC, s.name ASC
 	`, fromDay)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load site trend")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load site trend")
 		return
 	}
 
@@ -1125,7 +1125,7 @@ func (h *statsHandler) modelBySite(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := queryRowsErr(h.db, query, args...)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load model-by-site")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load model-by-site")
 		return
 	}
 	models := make([]map[string]any, 0, len(rows))
@@ -1279,25 +1279,25 @@ func (h *statsHandler) tokenCandidates(w http.ResponseWriter, r *http.Request) {
 	models, err := h.buildTokenCandidateModels(allowed)
 	if err != nil {
 		slog.Error("token-candidates: buildTokenCandidateModels failed", "error", err)
-		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load token candidates")
+		writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load token candidates")
 		return
 	}
 	withoutToken, err := h.buildModelsWithoutToken(allowed)
 	if err != nil {
 		slog.Error("token-candidates: buildModelsWithoutToken failed", "error", err)
-		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load models without token")
+		writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load models without token")
 		return
 	}
 	missingGroups, err := h.buildModelsMissingTokenGroups(allowed)
 	if err != nil {
 		slog.Error("token-candidates: buildModelsMissingTokenGroups failed", "error", err)
-		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load missing token groups")
+		writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load missing token groups")
 		return
 	}
 	endpointTypes, err := h.buildEndpointTypesByModel(allowed)
 	if err != nil {
 		slog.Error("token-candidates: buildEndpointTypesByModel failed", "error", err)
-		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load endpoint types")
+		writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load endpoint types")
 		return
 	}
 

--- a/handler/admin/stats_balance.go
+++ b/handler/admin/stats_balance.go
@@ -25,7 +25,7 @@ func (h *statsHandler) balanceHistory(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := queryRowsErr(h.db, q, args...)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load balance history")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load balance history")
 		return
 	}
 	byAccount := make(map[int64][]map[string]any)
@@ -80,7 +80,7 @@ func (h *statsHandler) balanceIncomeOutcome(w http.ResponseWriter, r *http.Reque
 
 	rows, err := queryRowsErr(h.db, q, args...)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load balance income/outcome")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load balance income/outcome")
 		return
 	}
 
@@ -193,7 +193,7 @@ func (h *statsHandler) attention(w http.ResponseWriter, r *http.Request) {
 	expired, err := queryRowsErr(h.db, `SELECT id, username, site_id, updated_at
 		FROM accounts WHERE status = 'expired' ORDER BY updated_at DESC LIMIT ?`, limit)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load attention items")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load attention items")
 		return
 	}
 	for _, row := range expired {
@@ -220,7 +220,7 @@ func (h *statsHandler) attention(w http.ResponseWriter, r *http.Request) {
 		FROM accounts WHERE status = 'active' AND balance IS NOT NULL AND balance < 1.0
 		ORDER BY balance ASC LIMIT ?`, limit)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load attention items")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load attention items")
 		return
 	}
 	for _, row := range low {
@@ -248,7 +248,7 @@ func (h *statsHandler) attention(w http.ResponseWriter, r *http.Request) {
 		FROM accounts WHERE status = 'active' AND balance IS NULL
 		ORDER BY updated_at DESC LIMIT ?`, limit)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load attention items")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load attention items")
 		return
 	}
 	for _, row := range unknown {
@@ -271,7 +271,7 @@ func (h *statsHandler) attention(w http.ResponseWriter, r *http.Request) {
 	disabledSites, err := queryRowsErr(h.db, `SELECT id, name, updated_at
 		FROM sites WHERE status = 'disabled' ORDER BY updated_at DESC LIMIT ?`, limit)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load attention items")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load attention items")
 		return
 	}
 	for _, row := range disabledSites {
@@ -305,7 +305,7 @@ func (h *statsHandler) attention(w http.ResponseWriter, r *http.Request) {
 		  AND (ends_at IS NULL OR ends_at = '' OR ends_at >= ?)
 		ORDER BY first_seen_at DESC LIMIT ?`, nowStr, nowStr, limit)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load attention items")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load attention items")
 		return
 	}
 	for _, row := range announcementRows {
@@ -341,7 +341,7 @@ func (h *statsHandler) attention(w http.ResponseWriter, r *http.Request) {
 		  AND (related_type IS NULL OR related_type <> 'site_announcement')
 		ORDER BY created_at DESC LIMIT ?`, false, since24h, limit)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load attention items")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load attention items")
 		return
 	}
 	for _, row := range evRows {

--- a/handler/admin/stats_heatmap.go
+++ b/handler/admin/stats_heatmap.go
@@ -38,7 +38,7 @@ func (h *statsHandler) usageHeatmap(w http.ResponseWriter, r *http.Request) {
 			LIMIT ?
 		`, since, usageHeatmapCellLimit)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to load usage heatmap")
+			writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load usage heatmap")
 			return
 		}
 		if len(rows) > 0 {
@@ -64,7 +64,7 @@ func (h *statsHandler) usageHeatmap(w http.ResponseWriter, r *http.Request) {
 				LIMIT ?
 			`, since, usageHeatmapCellLimit)
 			if err != nil {
-				writeError(w, http.StatusInternalServerError, "failed to load usage heatmap")
+				writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load usage heatmap")
 				return
 			}
 			cells = makeUsageHeatmapCells(rows)
@@ -88,7 +88,7 @@ func (h *statsHandler) usageHeatmap(w http.ResponseWriter, r *http.Request) {
 			LIMIT ?
 		`, since, usageHeatmapCellLimit)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to load usage heatmap")
+			writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load usage heatmap")
 			return
 		}
 		cells = makeUsageHeatmapCells(rows)

--- a/handler/admin/stats_latency.go
+++ b/handler/admin/stats_latency.go
@@ -37,7 +37,7 @@ func (h *statsHandler) slowRequests(w http.ResponseWriter, r *http.Request) {
 		LIMIT ?
 	`, since, minLatencyMs, limit)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load slow requests")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load slow requests")
 		return
 	}
 
@@ -92,7 +92,7 @@ func (h *statsHandler) modelCostDistribution(w http.ResponseWriter, r *http.Requ
 		ORDER BY cost DESC, model ASC
 	`, since)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load model cost distribution")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load model cost distribution")
 		return
 	}
 
@@ -164,7 +164,7 @@ func (h *statsHandler) latencyHistogram(w http.ResponseWriter, r *http.Request) 
 		ORDER BY bucket_start ASC
 	`, bucketMs, bucketMs, since)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load latency histogram")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load latency histogram")
 		return
 	}
 
@@ -224,7 +224,7 @@ func (h *statsHandler) latencyTrend(w http.ResponseWriter, r *http.Request) {
 		ORDER BY day ASC
 	`, fromDay)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load latency trend")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load latency trend")
 		return
 	}
 
@@ -267,7 +267,7 @@ func (h *statsHandler) latencyTrend(w http.ResponseWriter, r *http.Request) {
 			LIMIT ?
 		`, dayStart, dayEnd, p95SampleCap)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to load latency trend samples")
+			writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load latency trend samples")
 			return
 		}
 		n := len(samples)

--- a/handler/admin/tags.go
+++ b/handler/admin/tags.go
@@ -92,11 +92,11 @@ func (h *tagsHandler) listTags(w http.ResponseWriter, r *http.Request) {
 		return nil
 	}
 	if err := addRows("accounts"); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load tags")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load tags")
 		return
 	}
 	if err := addRows("sites"); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load tags")
+		writeErrorCode(w, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load tags")
 		return
 	}
 

--- a/handler/admin/token_routes.go
+++ b/handler/admin/token_routes.go
@@ -95,7 +95,7 @@ type tokenRoutesHandler struct {
 func (h *tokenRoutesHandler) listLite(w http.ResponseWriter, r *http.Request) {
 	rows, err := queryRowsErr(h.db, "SELECT id, model_pattern, display_name, display_icon, route_mode, routing_strategy, enabled, context_length FROM token_routes ORDER BY sort_order ASC, id ASC")
 	if err != nil {
-		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load routes")
+		writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load routes")
 		return
 	}
 	type srcRow struct {
@@ -124,7 +124,7 @@ func (h *tokenRoutesHandler) listLite(w http.ResponseWriter, r *http.Request) {
 func (h *tokenRoutesHandler) listSummary(w http.ResponseWriter, r *http.Request) {
 	rows, err := queryRowsErr(h.db, "SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC")
 	if err != nil {
-		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load routes")
+		writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load routes")
 		return
 	}
 
@@ -239,7 +239,7 @@ func (h *tokenRoutesHandler) listRoutes(w http.ResponseWriter, r *http.Request) 
 			"SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC LIMIT ? OFFSET ?",
 			pageSize, offset)
 		if queryErr != nil {
-			writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load routes")
+			writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load routes")
 			return
 		}
 		// Separate COUNT keeps the row maps free of a window-function column
@@ -252,14 +252,14 @@ func (h *tokenRoutesHandler) listRoutes(w http.ResponseWriter, r *http.Request) 
 	} else {
 		rows, queryErr = queryRowsErr(h.db, "SELECT * FROM token_routes ORDER BY sort_order ASC, id ASC")
 		if queryErr != nil {
-			writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load routes")
+			writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load routes")
 			return
 		}
 	}
 
 	result, err := h.enrichRoutesWithChannels(rows, paginate)
 	if err != nil {
-		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load route channels")
+		writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load route channels")
 		return
 	}
 

--- a/handler/admin/token_routes_channels.go
+++ b/handler/admin/token_routes_channels.go
@@ -28,7 +28,7 @@ func (h *tokenRoutesHandler) getRouteChannels(w http.ResponseWriter, r *http.Req
 		 LEFT JOIN sites s ON a.site_id = s.id
 		 WHERE rc.route_id = ?`, id)
 	if err != nil {
-		writeErrorWithRequest(w, r, http.StatusInternalServerError, "failed to load route channels")
+		writeErrorCodeWithRequest(w, r, http.StatusInternalServerError, ErrorCodeResourceLoadFailed, "failed to load route channels")
 		return
 	}
 	var enrichedChans []map[string]any

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -52,7 +52,8 @@
         "siteNotFound": "Site not found",
         "operationNotSupported": "This operation is not supported for this connection type",
         "resourceDisabled": "This capability is currently unavailable",
-        "invalidSettingsValue": "Invalid value in the settings form; please check and save again"
+        "invalidSettingsValue": "Invalid value in the settings form; please check and save again",
+        "resourceLoadFailed": "Failed to load data. Please try again later."
       },
       "internalServerError": "Internal Server Error!",
       "serverError": "Server error ({{status}}). Please try again later.",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -52,7 +52,8 @@
         "siteNotFound": "站点不存在",
         "operationNotSupported": "该连接类型不支持此操作",
         "resourceDisabled": "该能力当前不可用",
-        "invalidSettingsValue": "设置项包含无效值，请检查后重新保存"
+        "invalidSettingsValue": "设置项包含无效值，请检查后重新保存",
+        "resourceLoadFailed": "数据加载失败，请稍后重试。"
       },
       "internalServerError": "服务器内部错误！",
       "serverError": "服务器错误（{{status}}），请稍后重试。",

--- a/web/src/lib/__tests__/http-client.test.ts
+++ b/web/src/lib/__tests__/http-client.test.ts
@@ -314,6 +314,28 @@ describe('apiClient auth interceptor', () => {
     }
   })
 
+  it('renders the localized load-failure copy for resourceLoadFailed', async () => {
+    const prevLng = i18n.language
+    await i18n.changeLanguage('zhCN')
+    try {
+      const expected = i18n.t('errors.api.resourceLoadFailed')
+      expect(expected).not.toBe('Failed to load accounts')
+
+      const adapterCalls: unknown[] = []
+      installStatusAdapter(adapterCalls, 500, {
+        error: 'Failed to load accounts',
+        errorCode: 'resourceLoadFailed',
+      })
+
+      await expect(apiClient.get('/api/protected')).rejects.toThrow()
+      expect(toastErrorMock).toHaveBeenCalledWith(expected, {
+        id: `api-error:${expected}`,
+      })
+    } finally {
+      await i18n.changeLanguage(prevLng)
+    }
+  })
+
   it('falls back to the raw body message for an unregistered errorCode', async () => {
     const adapterCalls: unknown[] = []
     installStatusAdapter(adapterCalls, 403, {
@@ -347,6 +369,7 @@ describe('apiClient auth interceptor', () => {
       'operationNotSupported',
       'resourceDisabled',
       'invalidSettingsValue',
+      'resourceLoadFailed',
     ]
     for (const code of codes) {
       const expectedKey = code.startsWith('auth')

--- a/web/src/lib/http-client.ts
+++ b/web/src/lib/http-client.ts
@@ -161,6 +161,7 @@ const ERROR_CODE_I18N_KEYS: Record<string, string> = {
   resourceDisabled: 'errors.api.resourceDisabled',
   invalidSettingsValue: 'errors.api.invalidSettingsValue',
   operationNotImplemented: 'errors.api.operationNotImplemented',
+  resourceLoadFailed: 'errors.api.resourceLoadFailed',
 }
 
 /** Localized copy for a known errorCode; undefined when unmapped. */


### PR DESCRIPTION
## 概要

errorCode 批次 7：读取路径 "Failed to load …" 整个家族统一为一个机器可读码 `resourceLoadFailed`。

**72 个调用点**（writeError ×62 + writeJSON legacy {message} ×10）跨 accounts / sites / channels / stats / token-routes / checkin / downstream-keys / announcements / events / oauth / models / tags / probe-history / resin / monitor-health：

- 后端常量 `ErrorCodeResourceLoadFailed` + 三种响应形态全部携带 additive errorCode（message 一字未动 = 零破坏）
- 前端 `ERROR_CODE_I18N_KEYS` → `errors.api.resourceLoadFailed`（en / zh-CN），渲染路径 + key 存在性测试钉住
- `handler/admin/error_code_load_failed_test.go`：closed-DB fixture 模拟读失败，三种形态全钉（writeError / writeErrorWithRequest / writeJSON）
- docs registry 新行

## 测试

- 本地：go build + go vet + 全量 go test（唯一失败是 master 上 windows 固有的 TestProbeSQLiteWritableNonWritableDir，与本批无关）+ 前端四件套 + http-client 单测 19/19
