### PR TITLE
feat(settings): drop duplicated card header copy on single-card sections (#1104 residue)

### DIFF
--- a/docs/internal/design/DESIGN.md
+++ b/docs/internal/design/DESIGN.md
@@ -158,7 +158,7 @@ Every destructive action maps to exactly one tier; never hand-roll a variant:
 ### 4.2 Settings page skeleton（设置页骨架）
 
 - 单 h1 在 `SettingsPage` 页头，文案来自 section meta 的 i18n 键；侧栏树是唯一导航面（wave 8 lane C 之后无页内面包屑/侧栏）。
-- `SettingsSectionCard` **无 `actions` 时不渲染 CardHeader**——同一组 title/description i18n 键已在页头渲染，卡头再渲染就是逐字重复。带 header actions（测试/保存/批量按钮）的卡保留卡头：按钮需要宿主，h2 让多内容页内卡片可辨识。
+- `SettingsSectionCard` **无 `actions` 时不渲染 CardHeader**——同一组 title/description i18n 键已在页头渲染，卡头再渲染就是逐字重复。带 header actions（测试/保存/批量按钮）的卡保留卡头（按钮需要宿主），但**单卡 section 传 `hideHeaderCopy`**：页头同题文案已在页面顶层，h2 重复无辨识价值；h2 只保留给多内容页内需区分的卡片。
 - 危险/前置警告信息放卡内正文顶部 banner（`border-warning/40 bg-warning/5` + `TriangleAlert`），不藏在 description 里（参考：数据迁移节的 wipe/重启警告）。
 
 ---

--- a/web/src/features/settings/components/settings-section-card.tsx
+++ b/web/src/features/settings/components/settings-section-card.tsx
@@ -19,6 +19,14 @@ type SettingsSectionCardProps = {
   children: ReactNode
   /** Optional right-aligned actions in the header (test/save buttons). */
   actions?: ReactNode
+  /**
+   * Single-card sections: the page header (SettingsPage) already renders the
+   * section's unique h1 + description, so a card header that repeats the
+   * same title/description is verbatim duplication. When true, the actions
+   * row still renders (buttons need a host) but the title/description copy
+   * is dropped. Multi-card sections that need a per-card h2 omit this.
+   */
+  hideHeaderCopy?: boolean
 }
 
 /**
@@ -30,29 +38,32 @@ type SettingsSectionCardProps = {
  * single h1, fed from the same i18n keys), so a headerless card avoids the
  * duplicated "title / same description twice" stack that single-card
  * sections used to show. Cards with actions keep their header — the buttons
- * need a host and the h2 keeps the card identifiable when it shares the
- * page with other content.
+ * need a host — but single-card sections pass `hideHeaderCopy` so the h2
+ * does not re-state copy the page header already rendered (see DESIGN.md 4.2).
  */
 export function SettingsSectionCard({
   title,
   description,
   children,
   actions,
+  hideHeaderCopy = false,
 }: SettingsSectionCardProps) {
   return (
     <Card>
       {actions ? (
         <CardHeader className='flex flex-row items-start justify-between gap-4'>
-          <div className='space-y-1'>
-            {/* h2: the unique page-level h1 lives in the SettingsPage header
-                (single-h1 discipline, wave 8 lane C); card titles are L2. */}
-            <h2 className='text-base leading-snug font-medium group-data-[size=sm]/card:text-sm'>
-              {title}
-            </h2>
-            {description ? (
-              <CardDescription>{description}</CardDescription>
-            ) : null}
-          </div>
+          {hideHeaderCopy ? null : (
+            <div className='space-y-1'>
+              {/* h2: the unique page-level h1 lives in the SettingsPage header
+                  (single-h1 discipline, wave 8 lane C); card titles are L2. */}
+              <h2 className='text-base leading-snug font-medium group-data-[size=sm]/card:text-sm'>
+                {title}
+              </h2>
+              {description ? (
+                <CardDescription>{description}</CardDescription>
+              ) : null}
+            </div>
+          )}
           <div className='flex shrink-0 gap-2'>{actions}</div>
         </CardHeader>
       ) : null}

--- a/web/src/features/settings/sections/content/components/announcements-section.tsx
+++ b/web/src/features/settings/sections/content/components/announcements-section.tsx
@@ -222,6 +222,7 @@ export function AnnouncementsSection() {
     <SettingsSectionCard
       title={t('settings.content.announcements.title')}
       description={t('settings.content.announcements.description')}
+      hideHeaderCopy
       actions={
         <Button size='sm' onClick={() => setEditMode({ kind: 'create' })}>
           {t('settings.content.announcements.create')}

--- a/web/src/features/settings/sections/content/components/notifications-section.tsx
+++ b/web/src/features/settings/sections/content/components/notifications-section.tsx
@@ -285,6 +285,7 @@ export function NotificationsSection() {
     <SettingsSectionCard
       title={t('settings.content.notifications.title')}
       description={t('settings.content.notifications.description')}
+      hideHeaderCopy
       actions={
         <Button
           type='button'

--- a/web/src/features/settings/sections/downstream/components/keys-section.tsx
+++ b/web/src/features/settings/sections/downstream/components/keys-section.tsx
@@ -306,6 +306,7 @@ export function KeysSection() {
     <SettingsSectionCard
       title={t('settings.downstream.keys.title')}
       description={t('settings.downstream.keys.description')}
+      hideHeaderCopy
       actions={
         <Button size='sm' onClick={() => openCreate()}>
           {t('settings.downstream.keys.create')}

--- a/web/src/features/settings/sections/operations/components/program-logs-section.tsx
+++ b/web/src/features/settings/sections/operations/components/program-logs-section.tsx
@@ -265,6 +265,7 @@ export function ProgramLogsSection() {
     <SettingsSectionCard
       title={t('settings.operations.programLogs.title')}
       description={t('settings.operations.programLogs.description')}
+      hideHeaderCopy
       actions={
         <div className='flex flex-wrap gap-2'>
           <Button

--- a/web/src/features/settings/sections/operations/components/scheduling-section.tsx
+++ b/web/src/features/settings/sections/operations/components/scheduling-section.tsx
@@ -313,6 +313,7 @@ export function SchedulingSection() {
     <SettingsSectionCard
       title={t('settings.operations.scheduling.title')}
       description={t('settings.operations.scheduling.description')}
+      hideHeaderCopy
       actions={
         <Button
           type='button'

--- a/web/src/features/settings/sections/proxy-models/components/catalog-sources-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/catalog-sources-section.tsx
@@ -423,6 +423,7 @@ export function CatalogSourcesSection() {
       <SettingsSectionCard
         title={t('settings.proxyModels.catalogSources.title')}
         description={t('settings.proxyModels.catalogSources.description')}
+        hideHeaderCopy
         actions={
           <>
             <Button

--- a/web/src/features/settings/sections/proxy-models/components/proxy-transport-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/proxy-transport-section.tsx
@@ -276,6 +276,7 @@ export function ProxyTransportSection() {
     <SettingsSectionCard
       title={t('settings.proxyModels.proxyTransport.title')}
       description={t('settings.proxyModels.proxyTransport.description')}
+      hideHeaderCopy
       actions={
         <Button
           type='button'

--- a/web/src/features/settings/sections/proxy-models/components/redirects-section.tsx
+++ b/web/src/features/settings/sections/proxy-models/components/redirects-section.tsx
@@ -147,6 +147,7 @@ export function RedirectsSection() {
     <SettingsSectionCard
       title={t('settings.proxyModels.redirects.title')}
       description={t('settings.proxyModels.redirects.description')}
+      hideHeaderCopy
       actions={
         <div className='flex gap-2'>
           <Button


### PR DESCRIPTION
## 概要

#1104 只收敛了无 actions 的卡。8 个**单卡** settings section（program-logs / scheduling / notifications / announcements / keys / catalog-sources / proxy-transport / redirects）的 CardHeader h2+description 与 SettingsPage 页头 h1+description **逐字重复**。

- `SettingsSectionCard` 新增 `hideHeaderCopy`：actions 行仍渲染（按钮需宿主），title/description 省略
- 8 个单卡调用点启用；多卡内容页的 h2 保留
- DESIGN.md 4.2 规约同步

## 验证

- 本地全量：test（338s 全绿）+ lint + typecheck + format:check
- 视觉：三页截图（program-logs / notifications / scheduling）页头单标题、卡头重复消失
- 双标题收敛后无回归（112 张全量截图重截）