### PR TITLE
feat(token-routes): tooltip on channel ratio badge explains M/N semantics

### DIFF
--- a/web/src/features/token-routes/components/routes-columns.tsx
+++ b/web/src/features/token-routes/components/routes-columns.tsx
@@ -63,6 +63,8 @@ function resolveChannelSummary(
   label: string
   variant: 'success' | 'warning' | 'secondary'
   hint?: string
+  /** Native tooltip clarifying the M/N channel ratio. */
+  enabledSummary?: string
 } {
   if (isReadOnlyRoute(route)) {
     return {
@@ -96,6 +98,10 @@ function resolveChannelSummary(
             count: total - enabled,
           })
         : undefined,
+    enabledSummary: t('tokenRoutes.columns.channelEnabledSummary', {
+      enabled,
+      total,
+    }),
   }
 }
 
@@ -278,7 +284,10 @@ export function useRoutesColumns(
         const summary = resolveChannelSummary(route, t)
         return (
           <div className='flex flex-col'>
-            <Badge variant={summary.variant}>
+            <Badge
+              variant={summary.variant}
+              title={summary.enabledSummary ?? undefined}
+            >
               <span className='tabular-nums'>{summary.label}</span>
             </Badge>
             {summary.hint && (

--- a/web/src/features/token-routes/components/routes-columns.tsx
+++ b/web/src/features/token-routes/components/routes-columns.tsx
@@ -26,6 +26,12 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Spinner } from '@/components/ui/spinner'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { toBcp47 } from '@/i18n/languages'
 import { formatDateTime } from '@/lib/format'
 import { cn } from '@/lib/utils'
@@ -63,7 +69,7 @@ function resolveChannelSummary(
   label: string
   variant: 'success' | 'warning' | 'secondary'
   hint?: string
-  /** Native tooltip clarifying the M/N channel ratio. */
+  /** Tooltip clarifying the M/N channel ratio (repo Tooltip convention). */
   enabledSummary?: string
 } {
   if (isReadOnlyRoute(route)) {
@@ -89,19 +95,21 @@ function resolveChannelSummary(
       hint: t('tokenRoutes.columns.channelAllDisabled'),
     }
   }
+  const partial = enabled < total
   return {
     label: `${enabled}/${total}`,
-    variant: enabled === total ? 'success' : 'warning',
-    hint:
-      enabled < total
-        ? t('tokenRoutes.columns.channelDisabledCount', {
-            count: total - enabled,
-          })
-        : undefined,
-    enabledSummary: t('tokenRoutes.columns.channelEnabledSummary', {
-      enabled,
-      total,
-    }),
+    variant: partial ? 'warning' : 'success',
+    hint: partial
+      ? t('tokenRoutes.columns.channelDisabledCount', {
+          count: total - enabled,
+        })
+      : undefined,
+    enabledSummary: t(
+      partial
+        ? 'tokenRoutes.columns.channelPartialSummary'
+        : 'tokenRoutes.columns.channelEnabledSummary',
+      partial ? { enabled, total, count: total - enabled } : { enabled, total }
+    ),
   }
 }
 
@@ -284,12 +292,30 @@ export function useRoutesColumns(
         const summary = resolveChannelSummary(route, t)
         return (
           <div className='flex flex-col'>
-            <Badge
-              variant={summary.variant}
-              title={summary.enabledSummary ?? undefined}
-            >
-              <span className='tabular-nums'>{summary.label}</span>
-            </Badge>
+            {summary.enabledSummary ? (
+              <TooltipProvider delay={200}>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={(props) => (
+                      <Badge
+                        {...props}
+                        data-slot='badge'
+                        variant={summary.variant}
+                      >
+                        <span className='tabular-nums'>{summary.label}</span>
+                      </Badge>
+                    )}
+                  />
+                  <TooltipContent side='top'>
+                    {summary.enabledSummary}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : (
+              <Badge variant={summary.variant}>
+                <span className='tabular-nums'>{summary.label}</span>
+              </Badge>
+            )}
             {summary.hint && (
               <span className='text-muted-foreground text-[11px]'>
                 {summary.hint}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2180,6 +2180,7 @@
         "channelZeroNeedChannelsHint": "Channels needed",
         "channelAllDisabled": "All disabled",
         "channelDisabledCount": "{{count}} disabled",
+        "channelEnabledSummary": "{{enabled}}/{{total}} channels enabled",
         "rowActions": "Route actions",
         "selectAll": "Select all",
         "selectRow": "Select row",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -2181,6 +2181,7 @@
         "channelAllDisabled": "All disabled",
         "channelDisabledCount": "{{count}} disabled",
         "channelEnabledSummary": "{{enabled}}/{{total}} channels enabled",
+        "channelPartialSummary": "{{enabled}}/{{total}} channels enabled ({{count}} disabled)",
         "rowActions": "Route actions",
         "selectAll": "Select all",
         "selectRow": "Select row",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2181,6 +2181,7 @@
         "channelAllDisabled": "全部禁用",
         "channelDisabledCount": "{{count}} 个禁用",
         "channelEnabledSummary": "{{enabled}}/{{total}} 个通道已启用",
+        "channelPartialSummary": "已启用 {{enabled}}/{{total}} 个通道（{{count}} 个禁用）",
         "rowActions": "路由操作",
         "selectAll": "全选",
         "selectRow": "选择此行",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -2180,6 +2180,7 @@
         "channelZeroNeedChannelsHint": "需补齐通道",
         "channelAllDisabled": "全部禁用",
         "channelDisabledCount": "{{count}} 个禁用",
+        "channelEnabledSummary": "{{enabled}}/{{total}} 个通道已启用",
         "rowActions": "路由操作",
         "selectAll": "全选",
         "selectRow": "选择此行",


### PR DESCRIPTION
## 概要

路由表的「通道」列 M/N 徽章（2/2、1/1、2/3）无任何语义释义——悬停无提示，管理员无法直接理解分子分母含义（其实 = 启用通道数/通道总数）。

- `resolveChannelSummary` 新增 `enabledSummary` 字段，M/N 徽章渲染 `title`（原生 tooltip）
- 新 i18n 键 `channelEnabledSummary`（zh: {{enabled}}/{{total}} 个通道已启用 / en: channels enabled）
- 0 通道 / 全禁用分支的 label 本身是文字（0 通道/全部禁用），无需 tooltip

## 验证

- 本地 playwright probe：所有路由 badge title 实际渲染（2/2 → '2/2 个通道已启用'）
- typecheck + lint + oxfmt 全绿
- token-routes 测试 136/136 通过