### PR TITLE
fix(accounts): server-side q/status/site filters + full Reset + site quick jump (#1108)

### DIFF
--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -213,18 +214,29 @@ func sitesOrEmpty(sites []store.Site) []store.Site {
 	return sites
 }
 
-// listAccountsPaginated serves GET /api/accounts?page=&pageSize= with a bounded
-// LIMIT/OFFSET query. The snapshot cache is intentionally bypassed: a paged
-// request is an explicit opt-out of the snapshot, and caching every page combo
-// would multiply the cache surface. Today metrics are still enriched for the
-// accounts on the current page. Response shape mirrors /api/channels:
-// {items, total, page, pageSize, generatedAt, sites}.
+// listAccountsPaginated serves GET /api/accounts?page=&pageSize=&status=&site=
+// with a bounded LIMIT/OFFSET query. The snapshot cache is intentionally
+// bypassed: a paged request is an explicit opt-out of the snapshot, and
+// caching every page combo would multiply the cache surface. `status` and
+// `site` are optional comma-separated server-side filters (issue #1108):
+// they filter the whole fleet, so rows on other pages are matched — unlike
+// the previous client-side filters over the returned page only. Today
+// metrics are still enriched for the accounts on the current page. Response
+// shape mirrors /api/channels: {items, total, page, pageSize, generatedAt, sites}.
 func (h *accountsHandler) listAccountsPaginated(w http.ResponseWriter, r *http.Request) {
 	page := clampInt(getQueryInt(r, "page", 1), 1, 1_000_000)
 	pageSize := clampInt(getQueryInt(r, "pageSize", 50), 1, 200)
 	offset := (page - 1) * pageSize
 
-	accounts, total, err := service.ListAccountsWithSitesPaginated(h.db, pageSize, offset)
+	filter, err := parseAccountListFilter(r)
+	if err != nil {
+		// Invalid filter params only come from hand-edited URLs — no client
+		// branches on this rejection, so it stays a plain (unregistered) 400.
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	accounts, total, err := service.ListAccountsWithSitesPaginated(h.db, pageSize, offset, filter)
 	if err != nil {
 		slog.Error("Failed to load paginated accounts", "err", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to load accounts", "errorCode": "resourceLoadFailed"})
@@ -1603,3 +1615,61 @@ func (h *accountsHandler) refreshBalance(w http.ResponseWriter, r *http.Request)
 }
 
 // ---- Account Models ----
+
+// validAccountStatuses whitelists the `status` filter values accepted by the
+// paginated accounts list (the same domain the UI filter exposes: active /
+// disabled / expired).
+var validAccountStatuses = map[string]struct{}{
+	"active":   {},
+	"disabled": {},
+	"expired":  {},
+}
+
+// parseAccountListFilter reads the optional comma-separated `status` and
+// `site` query params into a service.AccountListFilter. Invalid values are
+// rejected explicitly (mirroring parseChannelStatusFilter) instead of being
+// silently dropped.
+func parseAccountListFilter(r *http.Request) (service.AccountListFilter, error) {
+	var filter service.AccountListFilter
+
+	rawStatus := strings.TrimSpace(r.URL.Query().Get("status"))
+	if rawStatus != "" {
+		seen := make(map[string]struct{}, 4)
+		for _, part := range strings.Split(rawStatus, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				return filter, fmt.Errorf("invalid account status filter")
+			}
+			if _, ok := validAccountStatuses[part]; !ok {
+				return filter, fmt.Errorf("invalid account status filter: %q", part)
+			}
+			if _, ok := seen[part]; ok {
+				continue
+			}
+			seen[part] = struct{}{}
+			filter.Statuses = append(filter.Statuses, part)
+		}
+	}
+
+	rawSite := strings.TrimSpace(r.URL.Query().Get("site"))
+	if rawSite != "" {
+		seen := make(map[int64]struct{}, 4)
+		for _, part := range strings.Split(rawSite, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				return filter, fmt.Errorf("invalid account site filter")
+			}
+			id, err := strconv.ParseInt(part, 10, 64)
+			if err != nil || id <= 0 {
+				return filter, fmt.Errorf("invalid account site filter: %q", part)
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			filter.SiteIDs = append(filter.SiteIDs, id)
+		}
+	}
+
+	return filter, nil
+}

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -1625,12 +1625,14 @@ var validAccountStatuses = map[string]struct{}{
 	"expired":  {},
 }
 
-// parseAccountListFilter reads the optional comma-separated `status` and
-// `site` query params into a service.AccountListFilter. Invalid values are
-// rejected explicitly (mirroring parseChannelStatusFilter) instead of being
-// silently dropped.
+// parseAccountListFilter reads the optional `q`, comma-separated `status` and
+// comma-separated `site` query params into a service.AccountListFilter.
+// Invalid status/site values are rejected explicitly (mirroring
+// parseChannelStatusFilter) instead of being silently dropped.
 func parseAccountListFilter(r *http.Request) (service.AccountListFilter, error) {
 	var filter service.AccountListFilter
+
+	filter.Query = strings.TrimSpace(r.URL.Query().Get("q"))
 
 	rawStatus := strings.TrimSpace(r.URL.Query().Get("status"))
 	if rawStatus != "" {

--- a/handler/admin/admin_pagination_test.go
+++ b/handler/admin/admin_pagination_test.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"strconv"
 	"testing"
 	"time"
@@ -316,10 +317,10 @@ func TestListKeys_PaginationReturnsSubsetAndTotal(t *testing.T) {
 		t.Fatalf("status = %d; body=%s", resp.Code, resp.Body.String())
 	}
 	var page struct {
-		Items []map[string]any `json:"items"`
-		Total int              `json:"total"`
-		Page  int              `json:"page"`
-		PageSize int           `json:"pageSize"`
+		Items    []map[string]any `json:"items"`
+		Total    int              `json:"total"`
+		Page     int              `json:"page"`
+		PageSize int              `json:"pageSize"`
 	}
 	if err := json.Unmarshal(resp.Body.Bytes(), &page); err != nil {
 		t.Fatalf("decode paginated envelope: %v; body=%s", err, resp.Body.String())
@@ -478,6 +479,23 @@ func TestListAccounts_ServerSideFilters(t *testing.T) {
 	_, items, total = fetch("&site=" + strconv.FormatInt(siteAID, 10) + "&status=active")
 	if total != 1 || len(items) != 1 {
 		t.Fatalf("site=A&status=active: total=%d items=%d, want 1/1", total, len(items))
+	}
+
+	// q: substring match over username + site name/platform/url.
+	_, items, total = fetch("&q=filter-b-1")
+	if total != 1 || len(items) != 1 {
+		t.Fatalf("q=filter-b-1: total=%d items=%d, want 1/1", total, len(items))
+	}
+	_, items, total = fetch("&q=filter-a")
+	if total != 2 {
+		t.Fatalf("q=filter-a: total=%d, want 2 (both site A usernames match)", total)
+	}
+	// LIKE wildcards match literally (escaped), never as patterns: with the
+	// escape in place the literal % matches no seeded username (a wildcard
+	// interpretation would match all three filter-*-1 accounts).
+	_, items, total = fetch("&q=" + url.QueryEscape("filter-%-1"))
+	if total != 0 {
+		t.Fatalf("q=filter-%%-1 literal: total=%d, want 0 (escaped literal %%)", total)
 	}
 	_ = items
 }

--- a/handler/admin/admin_pagination_test.go
+++ b/handler/admin/admin_pagination_test.go
@@ -368,3 +368,135 @@ func TestListKeys_PaginationReturnsSubsetAndTotal(t *testing.T) {
 		t.Fatalf("paginated response leaked plaintext key: %#v", rawKey)
 	}
 }
+
+// setupAccountsFilterTest seeds a fleet where status/site filters can be
+// proven to match rows across pages: two sites (site A with two accounts,
+// site B with one), one account disabled.
+func setupAccountsFilterTest(t *testing.T) (*store.DB, chi.Router) {
+	t.Helper()
+	db, r, _ := setupAccountsTest(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	var siteA, siteB int64
+	for i, name := range []string{"Filter Site A", "Filter Site B"} {
+		res, err := db.Exec(
+			`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+			 VALUES (?, ?, 'openai', 'active', ?, ?)`,
+			name, "https://filter-"+strconv.Itoa(i)+".example.com", now, now,
+		)
+		if err != nil {
+			t.Fatalf("insert site %d: %v", i, err)
+		}
+		id, _ := res.LastInsertId()
+		if i == 0 {
+			siteA = id
+		} else {
+			siteB = id
+		}
+	}
+
+	seeds := []struct {
+		site   int64
+		user   string
+		status string
+	}{
+		{siteA, "filter-a-1", "active"},
+		{siteA, "filter-a-2", "disabled"},
+		{siteB, "filter-b-1", "active"},
+	}
+	for _, s := range seeds {
+		if _, err := db.Exec(
+			`INSERT INTO accounts (site_id, username, access_token, status, checkin_enabled, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, TRUE, ?, ?)`,
+			s.site, s.user, "token-"+s.user, s.status, now, now,
+		); err != nil {
+			t.Fatalf("seed account %s: %v", s.user, err)
+		}
+	}
+	return db, r
+}
+
+// TestListAccounts_ServerSideFilters covers issue #1108: `status` and `site`
+// filter the whole fleet server-side (not just the loaded page), and `total`
+// is the filtered count.
+func TestListAccounts_ServerSideFilters(t *testing.T) {
+	db, r := setupAccountsFilterTest(t)
+
+	fetch := func(query string) (int, []map[string]any, int) {
+		t.Helper()
+		resp := doGet(t, r, "/api/accounts?page=1&pageSize=10"+query)
+		if resp.Code != http.StatusOK {
+			t.Fatalf("query %s: status = %d; body=%s", query, resp.Code, resp.Body.String())
+		}
+		var page struct {
+			Items []map[string]any `json:"items"`
+			Total int              `json:"total"`
+		}
+		if err := json.Unmarshal(resp.Body.Bytes(), &page); err != nil {
+			t.Fatalf("decode %s: %v; body=%s", query, err, resp.Body.String())
+		}
+		return resp.Code, page.Items, page.Total
+	}
+
+	// status filter: disabled matches exactly the one disabled account.
+	_, items, total := fetch("&status=disabled")
+	if total != 1 || len(items) != 1 {
+		t.Fatalf("status=disabled: total=%d items=%d, want 1/1", total, len(items))
+	}
+
+	// multi-status: active+disabled = all three.
+	_, items, total = fetch("&status=active,disabled")
+	if total != 3 || len(items) != 3 {
+		t.Fatalf("status=active,disabled: total=%d items=%d, want 3/3", total, len(items))
+	}
+
+	// Site filter: site B holds exactly one active account. site B is the
+	// second seeded site — its id is not 1 (setupAccountsTest's own seed site),
+	// proving the filter reads the fleet, not the seed's page-one rows.
+	var siteBID int64
+	if err := db.Get(&siteBID,
+		`SELECT id FROM sites WHERE name = 'Filter Site B'`); err != nil {
+		t.Fatalf("resolve site B id: %v", err)
+	}
+	_, items, total = fetch("&site=" + strconv.FormatInt(siteBID, 10))
+	if total != 1 || len(items) != 1 {
+		t.Fatalf("site=B: total=%d items=%d, want 1/1", total, len(items))
+	}
+
+	// Combination: site B + disabled → zero rows (its only account is active).
+	_, _, total = fetch("&site=" + strconv.FormatInt(siteBID, 10) + "&status=disabled")
+	if total != 0 {
+		t.Fatalf("site=B&status=disabled: total=%d, want 0", total)
+	}
+
+	// Combination: site A + active → exactly one row (the other is disabled).
+	var siteAID int64
+	if err := db.Get(&siteAID,
+		`SELECT id FROM sites WHERE name = 'Filter Site A'`); err != nil {
+		t.Fatalf("resolve site A id: %v", err)
+	}
+	_, items, total = fetch("&site=" + strconv.FormatInt(siteAID, 10) + "&status=active")
+	if total != 1 || len(items) != 1 {
+		t.Fatalf("site=A&status=active: total=%d items=%d, want 1/1", total, len(items))
+	}
+	_ = items
+}
+
+// TestListAccounts_ServerSideFiltersInvalidParams rejects malformed filter
+// values with an explicit 400 (never silently drops them).
+func TestListAccounts_ServerSideFiltersInvalidParams(t *testing.T) {
+	_, r := setupAccountsFilterTest(t)
+
+	for _, query := range []string{
+		"&status=bogus",
+		"&status=active,,disabled",
+		"&site=abc",
+		"&site=0",
+		"&site=1,,2",
+	} {
+		resp := doGet(t, r, "/api/accounts?page=1&pageSize=10"+query)
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("query %q: status = %d, want 400 (body=%s)", query, resp.Code, resp.Body.String())
+		}
+	}
+}

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -704,19 +704,34 @@ func ListAccountsWithSites(db *sqlx.DB) ([]map[string]any, error) {
 	return result, scanErr
 }
 
+// AccountListFilter narrows the paginated accounts list server-side so the
+// admin UI filters the whole fleet, not just the loaded page (issue #1108:
+// client-side filters over a server-paginated table could never match rows
+// on other pages).
+type AccountListFilter struct {
+	// Statuses is a whitelisted subset of the account status domain
+	// (active / disabled / expired). Empty means "no status filter".
+	Statuses []string
+	// SiteIDs narrows to the given sites. Empty means "all sites".
+	SiteIDs []int64
+}
+
 // ListAccountsWithSitesPaginated returns a single page of accounts joined with
-// their sites, plus the total row count matching the same join. Enrichment is
+// their sites, plus the total row count matching the same join (and the same
+// optional filter, so `total` is the true filtered count). Enrichment is
 // identical to ListAccountsWithSites so a paginated page is byte-compatible
 // with a slice of the unpaginated snapshot. Used by GET /api/accounts?page=...
 // to bound the admin list response when the fleet grows (defensive pagination,
 // same envelope as /api/channels and /api/checkin/logs).
-func ListAccountsWithSitesPaginated(db *sqlx.DB, limit, offset int) ([]map[string]any, int64, error) {
+func ListAccountsWithSitesPaginated(db *sqlx.DB, limit, offset int, filter AccountListFilter) ([]map[string]any, int64, error) {
+	where, args := buildAccountListFilter(filter)
+
 	rows, err := db.Queryx(db.Rebind(
 		`SELECT a.*, s.id as site_id_val, s.name as site_name, s.url as site_url,
 		        s.platform as site_platform, s.status as site_status
-		 FROM accounts a INNER JOIN sites s ON a.site_id = s.id
+		 FROM accounts a INNER JOIN sites s ON a.site_id = s.id`+where+`
 		 ORDER BY a.sort_order, a.id
-		 LIMIT ? OFFSET ?`), limit, offset)
+		 LIMIT ? OFFSET ?`), append(args, limit, offset)...)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -739,10 +754,36 @@ func ListAccountsWithSitesPaginated(db *sqlx.DB, limit, offset int) ([]map[strin
 
 	var total int64
 	if err := db.Get(&total, db.Rebind(
-		`SELECT COUNT(*) FROM accounts a INNER JOIN sites s ON a.site_id = s.id`)); err != nil {
+		`SELECT COUNT(*) FROM accounts a INNER JOIN sites s ON a.site_id = s.id`+where), args...); err != nil {
 		return result, 0, err
 	}
 	return result, total, scanErr
+}
+
+// buildAccountListFilter assembles the WHERE clause + args for the account
+// list filter. All values are parameterized (never interpolated), and the
+// status/site conditions are mutually ANDed.
+func buildAccountListFilter(filter AccountListFilter) (string, []any) {
+	var clauses []string
+	var args []any
+	if len(filter.Statuses) > 0 {
+		query, inArgs, err := sqlx.In(`a.status IN (?)`, filter.Statuses)
+		if err == nil && len(inArgs) > 0 {
+			clauses = append(clauses, query)
+			args = append(args, inArgs...)
+		}
+	}
+	if len(filter.SiteIDs) > 0 {
+		query, inArgs, err := sqlx.In(`a.site_id IN (?)`, filter.SiteIDs)
+		if err == nil && len(inArgs) > 0 {
+			clauses = append(clauses, query)
+			args = append(args, inArgs...)
+		}
+	}
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	return " WHERE " + strings.Join(clauses, " AND "), args
 }
 
 // enrichAccountOverviewRow attaches admin-list overview fields used by the UI.

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -714,6 +714,10 @@ type AccountListFilter struct {
 	Statuses []string
 	// SiteIDs narrows to the given sites. Empty means "all sites".
 	SiteIDs []int64
+	// Query is a case-insensitive substring match over username and site
+	// name/url/platform (mirrors the frontend's old client-side haystack).
+	// Empty means "no search filter".
+	Query string
 }
 
 // ListAccountsWithSitesPaginated returns a single page of accounts joined with
@@ -762,10 +766,21 @@ func ListAccountsWithSitesPaginated(db *sqlx.DB, limit, offset int, filter Accou
 
 // buildAccountListFilter assembles the WHERE clause + args for the account
 // list filter. All values are parameterized (never interpolated), and the
-// status/site conditions are mutually ANDed.
+// query/status/site conditions are mutually ANDed.
 func buildAccountListFilter(filter AccountListFilter) (string, []any) {
 	var clauses []string
 	var args []any
+	if q := strings.TrimSpace(filter.Query); q != "" {
+		pattern := "%" + escapeLikePattern(q) + "%"
+		// Same haystack the frontend's client-side search used to match:
+		// username + site name/platform/url. Keep the LIKE ESCAPE so a user
+		// search containing % or _ matches literally.
+		clauses = append(clauses, `(LOWER(a.username) LIKE LOWER(?) ESCAPE '\' OR
+		 LOWER(s.name) LIKE LOWER(?) ESCAPE '\' OR
+		 LOWER(s.platform) LIKE LOWER(?) ESCAPE '\' OR
+		 LOWER(s.url) LIKE LOWER(?) ESCAPE '\')`)
+		args = append(args, pattern, pattern, pattern, pattern)
+	}
 	if len(filter.Statuses) > 0 {
 		query, inArgs, err := sqlx.In(`a.status IN (?)`, filter.Statuses)
 		if err == nil && len(inArgs) > 0 {
@@ -784,6 +799,15 @@ func buildAccountListFilter(filter AccountListFilter) (string, []any) {
 		return "", nil
 	}
 	return " WHERE " + strings.Join(clauses, " AND "), args
+}
+
+// escapeLikePattern escapes LIKE wildcards (% and _) so operator search
+// terms match literally.
+func escapeLikePattern(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
 }
 
 // enrichAccountOverviewRow attaches admin-list overview fields used by the UI.

--- a/web/src/components/common/safe-external-link.tsx
+++ b/web/src/components/common/safe-external-link.tsx
@@ -1,0 +1,65 @@
+// metapi-go/components/common — safe external-link cell shared by list
+// columns that expose operator URLs (sites name/URL cells #985, accounts
+// site cells #1108). One implementation of the render ladder: unsafe /
+// non-http(s) / forbidden-target URLs degrade to plain text instead of
+// rendering a clickable link.
+
+import { ExternalLink as ExternalLinkIcon } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+import { isValidEndpointUrl } from '@/lib/url-validation'
+import { cn } from '@/lib/utils'
+
+export type SafeExternalLinkProps = {
+  url: string
+  children: ReactNode
+  className?: string
+  title?: string
+}
+
+/**
+ * Renders `children` as an external link when `url` is a valid http(s)
+ * endpoint the backend would allow; otherwise renders plain truncated text.
+ * The link is keyboard-focusable with the standard focus ring, opens a new
+ * tab (`noopener noreferrer`), and stops propagation so row-click handlers
+ * (detail sheets) are not hijacked.
+ */
+export function SafeExternalLink({
+  url,
+  children,
+  className,
+  title,
+}: SafeExternalLinkProps) {
+  const href = url.trim()
+  const content = <span className='min-w-0 truncate'>{children}</span>
+  const isSafeExternalURL =
+    /^https?:\/\//i.test(href) && isValidEndpointUrl(href)
+
+  if (!isSafeExternalURL) {
+    return (
+      <span className={cn('block truncate', className)} title={title}>
+        {children}
+      </span>
+    )
+  }
+
+  return (
+    <a
+      href={href}
+      target='_blank'
+      rel='noopener noreferrer'
+      className={cn(
+        'group inline-flex min-w-0 items-center gap-1 rounded-sm underline-offset-4 hover:text-primary hover:underline focus-visible:text-primary focus-visible:underline focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-inset focus-visible:outline-none',
+        className
+      )}
+      title={title}
+      onClick={(event) => event.stopPropagation()}
+    >
+      {content}
+      <ExternalLinkIcon
+        aria-hidden='true'
+        className='size-3.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100'
+      />
+    </a>
+  )
+}

--- a/web/src/components/data-table/hooks/__tests__/use-url-table-state.test.tsx
+++ b/web/src/components/data-table/hooks/__tests__/use-url-table-state.test.tsx
@@ -144,3 +144,63 @@ describe('useUrlTableState URL-sync guard', () => {
     })
   })
 })
+
+describe('useUrlTableState back-to-back updates (#1108 Reset race)', () => {
+  // Two table callbacks firing in the same tick (Reset clearing column
+  // filters AND the global filter) used to build both hrefs from the same
+  // stale window.location snapshot — @tanstack/history coalesces same-tick
+  // replaces to the LAST href, so the first update was silently dropped.
+  // The hook now chains each update off the previous href.
+  it('chains two same-tick updates so both land in the final href', async () => {
+    locationState.current = {
+      searchStr: '?q=x&status=active',
+      pathname: '/channels',
+    }
+    locationState.navigate.mockClear()
+
+    const buildHrefSpy = vi.fn(
+      (next: UrlTableStateUpdate<Filters>, currentSearch?: string) => {
+        const base = new URLSearchParams(
+          currentSearch ?? locationState.current.searchStr
+        )
+        if (next.q !== undefined) {
+          if (next.q) base.set('q', next.q)
+          else base.delete('q')
+        }
+        if (next.filters?.status !== undefined) {
+          if (next.filters.status) base.set('status', next.filters.status)
+          else base.delete('status')
+        }
+        const query = base.toString()
+        return query ? `/channels?${query}` : '/channels'
+      }
+    )
+
+    const { result } = renderHook(() =>
+      useUrlTableState<Filters>({
+        basePath: '/channels',
+        read: readSearch,
+        buildHref: buildHrefSpy,
+        toColumnFilters: () => [],
+        fromColumnFilters: () => ({ filters: {} }),
+      })
+    )
+
+    // Reset sequence: column filters first, then the global filter.
+    act(() => {
+      result.current.updateUrlState({ filters: { status: '' } })
+      result.current.updateUrlState({ q: '' })
+    })
+
+    // The second navigate must carry BOTH updates — the chained href has no
+    // q and no status (a full reset), not a half-reset.
+    const lastNavigate = locationState.navigate.mock.calls.at(-1) as
+      | [{ href: string }]
+      | undefined
+    expect(lastNavigate?.[0]?.href).toBe('/channels')
+    // And the second buildHref received the first update's href as its
+    // currentSearch (so it merged over the fresh state, not the stale URL).
+    const secondBuildCall = buildHrefSpy.mock.calls[1]
+    expect(secondBuildCall?.[1]).toBe('?q=x')
+  })
+})

--- a/web/src/components/data-table/hooks/use-url-table-state.ts
+++ b/web/src/components/data-table/hooks/use-url-table-state.ts
@@ -64,8 +64,16 @@ export type UrlTableStateOptions<TFilters> = {
   basePath: string
   /** Parse the validated URL state from a raw search string. */
   read: (searchString: string) => UrlTableState<TFilters>
-  /** Serialize a partial state update back to a full href (path + query). */
-  buildHref: (next: UrlTableStateUpdate<TFilters>) => string
+  /**
+   * Serialize a state update back to an href. The optional second parameter
+   * carries the latest known search string so back-to-back updates chain off
+   * each other instead of re-reading the (possibly stale) window.location
+   * snapshot — see latestHrefRef in useUrlTableState (#1108 Reset race).
+   */
+  buildHref: (
+    next: UrlTableStateUpdate<TFilters>,
+    currentSearch?: string
+  ) => string
   /** Map page filter values to table column filters. */
   toColumnFilters: (filters: TFilters) => ColumnFiltersState
   /** Map table column filters back to page filter values. */
@@ -165,10 +173,29 @@ export function useUrlTableState<TFilters>(
   // built on this page's own path, so a match is exactly "still on this
   // page", and a sibling that merely shares a prefix (e.g. `/channels` vs
   // `/channels-foo`) can never sneak a write-back through.
+  // Serialized href tracking (#1108): two table callbacks firing back-to-back
+  // (e.g. Reset clearing column filters AND the global filter) each built
+  // their href from the same stale `window.location.search` snapshot, and
+  // @tanstack/history coalesces same-tick replaces down to the LAST href —
+  // so the first update (column filters) was silently dropped and Reset only
+  // cleared the search input. Each updateUrlState now chains off the
+  // previous href (ref), and the ref re-syncs to the router-committed URL
+  // whenever the location actually changes.
+  const latestHrefRef = React.useRef<string | null>(null)
+  React.useEffect(() => {
+    latestHrefRef.current = `${pathname}${searchStr}`
+  }, [pathname, searchStr])
+
   const updateUrlState = React.useCallback(
     (next: UrlTableStateUpdate<TFilters>) => {
-      const href = buildHrefRef.current(next)
+      const prevHref = latestHrefRef.current
+      const prevSearch =
+        prevHref && pathnameOf(prevHref) === pathname
+          ? prevHref.slice(pathnameOf(prevHref).length)
+          : undefined
+      const href = buildHrefRef.current(next, prevSearch)
       if (pathnameOf(href) !== pathname) return
+      latestHrefRef.current = href
       navigate({ href, replace: true })
     },
     [navigate, pathname]

--- a/web/src/features/accounts/__tests__/accounts-bulk-disable-confirm.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-bulk-disable-confirm.test.tsx
@@ -50,6 +50,7 @@ vi.mock('@/components/data-table', () => ({
     onGlobalFilterChange: vi.fn(),
     columnFilters: [],
     onColumnFiltersChange: vi.fn(),
+    filters: { status: '', site: '' },
     pagination: { pageIndex: 0, pageSize: 20 },
     onPaginationChange: vi.fn(),
     ensurePageInRange: vi.fn(),

--- a/web/src/features/accounts/__tests__/accounts-page-add-button-loading.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-page-add-button-loading.test.tsx
@@ -45,6 +45,7 @@ vi.mock('@/components/data-table', () => ({
     onGlobalFilterChange: vi.fn(),
     columnFilters: [],
     onColumnFiltersChange: vi.fn(),
+    filters: { status: '', site: '' },
     pagination: { pageIndex: 0, pageSize: 20 },
     onPaginationChange: vi.fn(),
     ensurePageInRange: vi.fn(),

--- a/web/src/features/accounts/__tests__/accounts-page-deep-link.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-page-deep-link.test.tsx
@@ -66,6 +66,7 @@ vi.mock('@/components/data-table', () => ({
     onGlobalFilterChange: vi.fn(),
     columnFilters: [],
     onColumnFiltersChange: vi.fn(),
+    filters: { status: '', site: '' },
     pagination: { pageIndex: 0, pageSize: 20 },
     onPaginationChange: vi.fn(),
     ensurePageInRange: vi.fn(),

--- a/web/src/features/accounts/__tests__/accounts-page-error-retry.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-page-error-retry.test.tsx
@@ -57,6 +57,7 @@ vi.mock('@/components/data-table', async () => {
       onGlobalFilterChange: vi.fn(),
       columnFilters: [],
       onColumnFiltersChange: vi.fn(),
+      filters: { status: '', site: '' },
       pagination: { pageIndex: 0, pageSize: 20 },
       onPaginationChange: vi.fn(),
       ensurePageInRange: vi.fn(),

--- a/web/src/features/accounts/__tests__/accounts-page-import-entry.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-page-import-entry.test.tsx
@@ -37,6 +37,7 @@ vi.mock('@/components/data-table', () => ({
     onGlobalFilterChange: vi.fn(),
     columnFilters: [],
     onColumnFiltersChange: vi.fn(),
+    filters: { status: '', site: '' },
     pagination: { pageIndex: 0, pageSize: 20 },
     onPaginationChange: vi.fn(),
     ensurePageInRange: vi.fn(),

--- a/web/src/features/accounts/__tests__/accounts-pagination-api.test.ts
+++ b/web/src/features/accounts/__tests__/accounts-pagination-api.test.ts
@@ -24,9 +24,21 @@ describe('fetchAccountsPage', () => {
       generatedAt: '2026-08-29T00:00:00Z',
     })
 
-    const page = await fetchAccountsPage({ pageIndex: 1, pageSize: 10 })
+    const page = await fetchAccountsPage({
+      pageIndex: 1,
+      pageSize: 10,
+      q: '',
+      status: '',
+      site: '',
+    })
 
-    expect(getAccountsPageMock).toHaveBeenCalledWith({ page: 2, pageSize: 10 })
+    expect(getAccountsPageMock).toHaveBeenCalledWith({
+      page: 2,
+      pageSize: 10,
+      q: '',
+      status: '',
+      site: '',
+    })
     expect(page.items).toEqual([{ id: 3, username: 'alice' }])
     expect(page.total).toBe(27)
     expect(page.sites).toEqual([{ id: 1, name: 'Site' }])
@@ -35,7 +47,13 @@ describe('fetchAccountsPage', () => {
   it('degrades a missing total to the returned page length', async () => {
     getAccountsPageMock.mockResolvedValue({ items: [{ id: 1 }] })
 
-    const page = await fetchAccountsPage({ pageIndex: 0, pageSize: 10 })
+    const page = await fetchAccountsPage({
+      pageIndex: 0,
+      pageSize: 10,
+      q: '',
+      status: '',
+      site: '',
+    })
 
     expect(page.total).toBe(1)
   })

--- a/web/src/features/accounts/__tests__/accounts-site-link.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-site-link.test.tsx
@@ -1,0 +1,98 @@
+// Behavior tests for #1108: the accounts list site cell exposes a safe,
+// keyboard-focusable external link (quick jump to the upstream site) while
+// missing/invalid stored URLs degrade to plain text — same ladder as the
+// sites page columns (#985).
+
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import '@/i18n/config'
+
+import { useAccountsColumns } from '../components/accounts-columns'
+import type { Account, AccountRowActions } from '../types'
+
+const noopActions: AccountRowActions = {
+  onEdit: () => {},
+  onDelete: () => {},
+  onRefresh: () => {},
+  onViewDetail: () => {},
+  onTogglePin: () => {},
+  onToggleCheckin: () => {},
+  onToggleStatus: () => {},
+}
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    id: 1,
+    siteId: 7,
+    username: 'user@example.com',
+    status: 'active',
+    checkinEnabled: true,
+    tags: [],
+    site: {
+      id: 7,
+      name: 'Primary site',
+      url: 'https://primary.example',
+      platform: 'new-api',
+      status: 'active',
+    },
+    ...overrides,
+  } as unknown as Account
+}
+
+function SiteCell({ account }: { account: Account }) {
+  const columns = useAccountsColumns(noopActions)
+  const column = columns.find((entry) => entry.id === 'site')
+  if (!column?.cell) throw new Error('site column cell missing')
+  const cell = column.cell as unknown as (context: {
+    row: { original: Account }
+  }) => ReactElement
+  return cell({ row: { original: account } })
+}
+
+describe('accounts site cell quick jump (#1108)', () => {
+  it('renders the site name as an external link for a valid http(s) URL', () => {
+    const { container } = render(<SiteCell account={makeAccount()} />)
+    const link = container.querySelector('a')
+    expect(link).not.toBeNull()
+    expect(link).toHaveAttribute('href', 'https://primary.example')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(screen.getByText('Primary site')).toBeInTheDocument()
+  })
+
+  it('degrades to plain text when the stored URL is not a valid http(s) endpoint', () => {
+    const { container } = render(
+      <SiteCell
+        account={makeAccount({
+          site: {
+            id: 7,
+            name: 'Broken site',
+            url: 'javascript:alert(1)',
+            platform: 'openai',
+            status: 'active',
+          },
+        })}
+      />
+    )
+    expect(container.querySelector('a')).toBeNull()
+    expect(screen.getByText('Broken site')).toBeInTheDocument()
+  })
+
+  it('renders a dash when the account has no site', () => {
+    const { container } = render(
+      <SiteCell account={makeAccount({ site: undefined as never })} />
+    )
+    expect(container.querySelector('a')).toBeNull()
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+})
+
+// Silence the router probe: no navigation happens in these cell tests.
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+  useSearch: () => ({}),
+  useLocation: () => ({ searchStr: '', pathname: '/accounts' }),
+}))

--- a/web/src/features/accounts/__tests__/accounts-toggle-feedback.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-toggle-feedback.test.tsx
@@ -39,6 +39,7 @@ vi.mock('@/components/data-table', () => ({
     onGlobalFilterChange: vi.fn(),
     columnFilters: [],
     onColumnFiltersChange: vi.fn(),
+    filters: { status: '', site: '' },
     pagination: { pageIndex: 0, pageSize: 20 },
     onPaginationChange: vi.fn(),
     sorting: [],

--- a/web/src/features/accounts/__tests__/accounts-toggle-pending.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-toggle-pending.test.tsx
@@ -51,6 +51,7 @@ vi.mock('@/components/data-table', () => ({
     onGlobalFilterChange: vi.fn(),
     columnFilters: [],
     onColumnFiltersChange: vi.fn(),
+    filters: { status: '', site: '' },
     pagination: { pageIndex: 0, pageSize: 20 },
     onPaginationChange: vi.fn(),
     sorting: [],

--- a/web/src/features/accounts/api.ts
+++ b/web/src/features/accounts/api.ts
@@ -39,8 +39,24 @@ import type {
 export const accountQueryKeys = {
   all: ['accounts'] as const,
   snapshot: () => [...accountQueryKeys.all, 'snapshot'] as const,
-  page: (pageIndex: number, pageSize: number) =>
-    [...accountQueryKeys.all, 'page', { pageIndex, pageSize }] as const,
+  page: (
+    pageIndex: number,
+    pageSize: number,
+    q?: string,
+    status?: string,
+    site?: string
+  ) =>
+    [
+      ...accountQueryKeys.all,
+      'page',
+      {
+        pageIndex,
+        pageSize,
+        q: q || undefined,
+        status: status || undefined,
+        site: site || undefined,
+      },
+    ] as const,
   detail: (id: number) => ['accounts', 'detail', id] as const,
 }
 
@@ -61,17 +77,25 @@ export type AccountsPageData = {
 /**
  * Fetch + shape one server-side page. The page-gated endpoint keeps the same
  * account/site projection as the snapshot and slices before JSON encoding,
- * so large fleets no longer transfer every row to the browser. A missing or
- * malformed total degrades to the returned page length (the pager then shows
- * one page rather than an invented total).
+ * so large fleets no longer transfer every row to the browser. `q` / `status`
+ * / `site` are pushed server-side (#1108): the filters match the whole fleet,
+ * not just the loaded page. A missing or malformed total degrades to the
+ * returned page length (the pager then shows one page rather than an
+ * invented total).
  */
 export async function fetchAccountsPage(params: {
   pageIndex: number
   pageSize: number
+  q: string
+  status: string
+  site: string
 }): Promise<AccountsPageData> {
   const response = await api.getAccountsPage({
     page: params.pageIndex + 1,
     pageSize: params.pageSize,
+    q: params.q,
+    status: params.status,
+    site: params.site,
   })
   const items = Array.isArray(response.items)
     ? (response.items as object[])
@@ -90,17 +114,28 @@ export async function fetchAccountsPage(params: {
 }
 
 /**
- * Fetch one server-side accounts page by URL-owned table state. The page is
- * keyed by pageIndex/pageSize so filters/sorting stay client-side over the
- * returned page only (backend has no accounts filter/sort params), while the
- * pager's page count comes from the true fleet total.
+ * Fetch one server-side accounts page by URL-owned table state. The query is
+ * keyed by pageIndex/pageSize AND the server-side filters (q/status/site), so
+ * a filter change refetches a freshly-filtered page from the backend (#1108).
  */
 export function useAccountsPage(
-  params: { pageIndex: number; pageSize: number },
+  params: {
+    pageIndex: number
+    pageSize: number
+    q: string
+    status: string
+    site: string
+  },
   options?: Omit<UseQueryOptions<AccountsPageData>, 'queryKey' | 'queryFn'>
 ) {
   return useQuery<AccountsPageData>({
-    queryKey: accountQueryKeys.page(params.pageIndex, params.pageSize),
+    queryKey: accountQueryKeys.page(
+      params.pageIndex,
+      params.pageSize,
+      params.q,
+      params.status,
+      params.site
+    ),
     queryFn: () => fetchAccountsPage(params),
     placeholderData: (previous) => previous,
     staleTime: 10 * 1000,

--- a/web/src/features/accounts/components/accounts-columns.tsx
+++ b/web/src/features/accounts/components/accounts-columns.tsx
@@ -30,6 +30,7 @@ import {
   ProbeHealthBar,
   type ProbeHistoryMap,
 } from '@/components/common/probe-health-bar'
+import { SafeExternalLink } from '@/components/common/safe-external-link'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -380,9 +381,17 @@ export function useAccountsColumns(
           if (!site) return <span className='text-muted-foreground'>—</span>
           return (
             <div className='flex flex-col'>
-              <span className='max-w-[160px] truncate'>
+              {/* Quick jump to the upstream site (#1108): the site name is a
+                  safe external link when the stored URL is a valid http(s)
+                  endpoint, plain text otherwise (same ladder as the sites
+                  page columns, #985). */}
+              <SafeExternalLink
+                url={site.url ?? ''}
+                className='max-w-[160px] text-sm'
+                title={site.url ?? undefined}
+              >
                 {site.name || site.url || `#${site.id}`}
-              </span>
+              </SafeExternalLink>
               {site.platform && (
                 <span className='text-muted-foreground text-[11px]'>
                   {site.platform}

--- a/web/src/features/accounts/components/accounts-page.tsx
+++ b/web/src/features/accounts/components/accounts-page.tsx
@@ -246,6 +246,12 @@ export function AccountsPage() {
   const accountsPageQuery = useAccountsPage({
     pageIndex: urlState.pagination.pageIndex,
     pageSize: urlState.pagination.pageSize,
+    // Server-side filters (#1108): q/status/site narrow the whole fleet in
+    // SQL, so rows on other pages match — unlike the old client-side
+    // filters over the loaded page only.
+    q: urlState.globalFilter,
+    status: urlState.filters.status,
+    site: urlState.filters.site,
   })
   const { data, isLoading, isFetching, error, refetch } = accountsPageQuery
   const probeHistoryQuery = useProbeHistory('accounts')
@@ -521,11 +527,13 @@ export function AccountsPage() {
     data: accounts,
     columns,
     enableRowSelection: true,
-    // Server-side pagination: URL pagination drives a page query and the
-    // true fleet total drives the pager. Sorting and filtering remain
-    // client-side over the current page (documented backend gap).
+    // Server-side pagination + filtering (#1108): URL pagination drives a
+    // page query and the true fleet total drives the pager; q/status/site
+    // are SQL filters so a page only ever holds already-matching rows.
+    // Sorting stays client-side over the current page.
     manualPagination: true,
     manualSorting: true,
+    manualFiltering: true,
     totalCount: data?.total ?? data?.accounts?.length ?? 0,
     globalFilter: urlState.globalFilter,
     onGlobalFilterChange: urlState.onGlobalFilterChange,

--- a/web/src/features/sites/components/sites-columns.tsx
+++ b/web/src/features/sites/components/sites-columns.tsx
@@ -9,7 +9,6 @@
 
 import type { ColumnDef } from '@tanstack/react-table'
 import {
-  ExternalLink as ExternalLinkIcon,
   Eye as EyeIcon,
   MoreHorizontal as MoreHorizontalIcon,
   Pencil as PencilIcon,
@@ -20,6 +19,7 @@ import {
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import { SafeExternalLink } from '@/components/common/safe-external-link'
 import { DataTableColumnHeader } from '@/components/data-table'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -40,7 +40,6 @@ import {
 } from '@/lib/format'
 import { cn } from '@/lib/utils'
 
-import { isValidEndpointUrl } from '../lib/endpoints'
 import { resolveSiteBalanceUsd } from '../lib/site-balance'
 import type { Site, SiteStatus } from '../types'
 
@@ -67,56 +66,11 @@ function StatusBadge({ status }: { status: SiteStatus | undefined }) {
   )
 }
 
-function SiteExternalLink({
-  url,
-  children,
-  className,
-  title,
-}: {
-  url: string
-  children: React.ReactNode
-  className?: string
-  title: string
-}) {
-  const href = url.trim()
-  const content = <span className='min-w-0 truncate'>{children}</span>
-  const isSafeExternalURL =
-    /^https?:\/\//i.test(href) && isValidEndpointUrl(href)
-
-  if (!isSafeExternalURL) {
-    return (
-      <span className={cn('block truncate', className)} title={title}>
-        {children}
-      </span>
-    )
-  }
-
-  return (
-    <a
-      href={href}
-      target='_blank'
-      rel='noopener noreferrer'
-      className={cn(
-        'group inline-flex min-w-0 items-center gap-1 rounded-sm underline-offset-4 hover:text-primary hover:underline focus-visible:text-primary focus-visible:underline focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-inset focus-visible:outline-none',
-        className
-      )}
-      title={title}
-      onClick={(event) => event.stopPropagation()}
-    >
-      {content}
-      <ExternalLinkIcon
-        aria-hidden='true'
-        className='size-3.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100'
-      />
-    </a>
-  )
-}
-
 function TruncatedUrl({ url }: { url: string }) {
   return (
-    <SiteExternalLink url={url} className='max-w-[18rem] text-sm' title={url}>
+    <SafeExternalLink url={url} className='max-w-[18rem] text-sm' title={url}>
       {url}
-    </SiteExternalLink>
+    </SafeExternalLink>
   )
 }
 
@@ -182,13 +136,13 @@ export function useSitesColumns(
             {site.isPinned && (
               <PinIcon className='text-muted-foreground size-3.5 shrink-0' />
             )}
-            <SiteExternalLink
+            <SafeExternalLink
               url={site.url}
               className='max-w-[220px] font-medium'
               title={site.name}
             >
               {site.name}
-            </SiteExternalLink>
+            </SafeExternalLink>
           </div>
         )
       },

--- a/web/src/features/sites/lib/endpoints.ts
+++ b/web/src/features/sites/lib/endpoints.ts
@@ -11,6 +11,13 @@
 // `IsValidAPIEndpointURL`, `IsForbiddenSiteTargetURL`) so the dialog rejects
 // client-side without a server round-trip.
 
+import { isValidEndpointUrl } from '@/lib/url-validation'
+
+export {
+  isForbiddenEndpointTargetHost,
+  isValidEndpointUrl,
+} from '@/lib/url-validation'
+
 import type { SiteApiEndpoint } from '../types'
 
 /** One parsed endpoint line — matches `SiteFormPayload.apiEndpoints` items. */
@@ -29,15 +36,6 @@ export type EndpointsTextError =
 export type EndpointsParseResult =
   | { endpoints: ParsedEndpoint[] }
   | { error: EndpointsTextError }
-
-const FORBIDDEN_METADATA_HOSTS = new Set([
-  'metadata.google.internal',
-  'metadata',
-  'instance-data',
-])
-
-/** Matches a full IPv4 address (also usable for ::ffff:1.2.3.4 tails). */
-const IPV4_RE = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
 
 /** http(s) URL check shared by the site form URL fields and the editor. */
 export function isHttpUrl(value: string): boolean {
@@ -64,45 +62,6 @@ export function normalizeEndpointBaseUrl(raw: string): string {
     return parsed.toString().replace(/\/+$/, '')
   } catch {
     return trimmed.replace(/\/+$/, '')
-  }
-}
-
-/**
- * Cloud metadata / link-local targets the backend rejects as a first-hop
- * SSRF risk. Mirrors Go `IsForbiddenSiteTargetURL` — RFC1918 private and
- * localhost stay allowed for lab/docker operators.
- */
-export function isForbiddenEndpointTargetHost(hostname: string): boolean {
-  const bare = hostname
-    .trim()
-    .toLowerCase()
-    .replaceAll(/^\[|\]$/g, '')
-  if (FORBIDDEN_METADATA_HOSTS.has(bare)) return true
-  const ipv4Tail = /::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(bare)
-  const v4 = ipv4Tail
-    ? (ipv4Tail[1] as string).split('.')
-    : IPV4_RE.exec(bare)?.slice(1)
-  if (v4) {
-    // Link-local IPv4 169.254.0.0/16 (includes AWS/GCP/Azure metadata).
-    return Number(v4[0]) === 169 && Number(v4[1]) === 254
-  }
-  // IPv6 link-local unicast fe80::/10: the first hextet is fe8 */fe9 */fea */feb *.
-  const firstSegment = bare.split(':')[0] ?? ''
-  return /^fe[89ab][0-9a-f]$/.test(firstSegment)
-}
-
-/** Valid endpoint URL: http(s) and not a forbidden metadata/link-local target. */
-export function isValidEndpointUrl(raw: string): boolean {
-  const trimmed = raw.trim()
-  if (trimmed === '') return false
-  try {
-    const parsed = new URL(trimmed)
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      return false
-    }
-    return !isForbiddenEndpointTargetHost(parsed.hostname)
-  } catch {
-    return false
   }
 }
 

--- a/web/src/lib/api/accounts.ts
+++ b/web/src/lib/api/accounts.ts
@@ -17,11 +17,23 @@ export const accountsApi = {
       accounts: unknown[]
       sites: unknown[]
     }>,
-  getAccountsPage: (params: { page: number; pageSize: number }) =>
+  getAccountsPage: (params: {
+    page: number
+    pageSize: number
+    /** Server-side global search (matches username/site name/platform/url). */
+    q?: string
+    /** Comma-separated status whitelist (active/disabled/expired). */
+    status?: string
+    /** Comma-separated site ids. */
+    site?: string
+  }) =>
     request(
       `/api/accounts${buildQueryString({
         page: params.page,
         pageSize: params.pageSize,
+        q: params.q || undefined,
+        status: params.status || undefined,
+        site: params.site || undefined,
       })}`
     ) as Promise<{
       items?: unknown[]

--- a/web/src/lib/url-validation.ts
+++ b/web/src/lib/url-validation.ts
@@ -1,0 +1,54 @@
+// metapi-go/lib — shared URL safety helpers used by list columns and
+// forms across features (sites external links, accounts site cells, checkin
+// sheets). Extracted from features/sites/lib/endpoints.ts (#1108 accounts
+// quick jump) so both features consume one implementation instead of
+// duplicating the validation ladder.
+
+/** Hostnames the backend rejects as a first-hop SSRF risk (cloud metadata). */
+const FORBIDDEN_METADATA_HOSTS = new Set([
+  'metadata.google.internal',
+  'metadata',
+  'instance-data',
+])
+
+/** Matches a full IPv4 address (also usable for ::ffff:1.2.3.4 tails). */
+const IPV4_RE = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
+
+/**
+ * Cloud metadata / link-local targets the backend rejects as a first-hop
+ * SSRF risk. Mirrors Go `IsForbiddenSiteTargetURL` — RFC1918 private and
+ * localhost stay allowed for lab/docker operators.
+ */
+export function isForbiddenEndpointTargetHost(hostname: string): boolean {
+  const bare = hostname
+    .trim()
+    .toLowerCase()
+    .replaceAll(/^\[|\]$/g, '')
+  if (FORBIDDEN_METADATA_HOSTS.has(bare)) return true
+  const ipv4Tail = /::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(bare)
+  const v4 = ipv4Tail
+    ? (ipv4Tail[1] as string).split('.')
+    : IPV4_RE.exec(bare)?.slice(1)
+  if (v4) {
+    // Link-local IPv4 169.254.0.0/16 (includes AWS/GCP/Azure metadata).
+    return Number(v4[0]) === 169 && Number(v4[1]) === 254
+  }
+  // IPv6 link-local unicast fe80::/10: the first hextet is fe8 */fe9 */fea */feb *.
+  const firstSegment = bare.split(':')[0] ?? ''
+  return /^fe[89ab][0-9a-f]$/.test(firstSegment)
+}
+
+/** Valid endpoint URL: http(s) and not a forbidden metadata/link-local target. */
+export function isValidEndpointUrl(raw: string): boolean {
+  const trimmed = raw.trim()
+  if (trimmed === '') return false
+  try {
+    const parsed = new URL(trimmed)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return false
+    }
+    return !isForbiddenEndpointTargetHost(parsed.hostname)
+  } catch {
+    return false
+  }
+}

--- a/web/src/routes/_authenticated/accounts.tsx
+++ b/web/src/routes/_authenticated/accounts.tsx
@@ -73,9 +73,15 @@ export const Route = createFileRoute('/_authenticated/accounts')({
       Number.isFinite(rawPageSize) && rawPageSize > 0
         ? Math.min(100, Math.max(1, rawPageSize))
         : 20
+    // Server-side filters prefetched with the same keys the page query uses
+    // (#1108): q/status/site straight from the deep-linked URL.
+    const q = params.get('q') ?? ''
+    const status = params.get('status') ?? ''
+    const site = params.get('site') ?? ''
     await context.queryClient.prefetchQuery({
-      queryKey: accountQueryKeys.page(pageIndex, pageSize),
-      queryFn: () => fetchAccountsPage({ pageIndex, pageSize }),
+      queryKey: accountQueryKeys.page(pageIndex, pageSize, q, status, site),
+      queryFn: () =>
+        fetchAccountsPage({ pageIndex, pageSize, q, status, site }),
     })
   },
   component: AccountsPage,


### PR DESCRIPTION
## 概要

Issue #1108 三个缺陷全部修复：

1. **站点筛选缺页**——分页是服务端、筛选却是客户端（只过滤已加载页），翻页后站点永远筛不出来。后端 `GET /api/accounts` 新增 `q`/`status`/`site` 参数（参数化 SQL WHERE + sqlx.In + LIKE ESCAPE 字面转义），筛选全舰队；`total` 是筛选后计数；非法值显式 400。
2. **重置不全**——Reset 连发两次 table 状态更新产生两次导航，TanStack 同 tick coalesce 只留最后一个 href，第一个更新被静默丢弃。useUrlTableState 改为链式：每次 update 基于上一次 href（ref 串行化），所有 URL-synced 列表页受益。
3. **快捷跳转**——账号页站点单元格改为安全外链（同 sites 页 #985 阶梯）。提取共享 SafeExternalLink 组件 + @/lib/url-validation，sites/accounts 共用一份实现。

## 验证

- 后端：新增 TestListAccounts_ServerSideFilters（status/site/q 组合 + 字面 % 转义）+ InvalidParams（bogus/空段/非数字 400）；全量 handler+service 测试绿
- 前端：useUrlTableState 串行化回归测试（同 tick 双更新链式合并）+ accounts site link 3 测试；全量 166+ 测试绿 + 四件套门禁
- 实测 API：q=alpha 命中 1、q=公益站 命中 3、status=disabled 命中 0、bogus 返回 400
