### PR TITLE
fix(i18n): 2 copy corrections from the visual QA wave

### DIFF
--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1689,7 +1689,7 @@
           }
         },
         "auditLogs": {
-          "title": "Admin Audit Logs",
+          "title": "Audit Logs",
           "description": "Read-only audit of admin write operations.",
           "allMethods": "All methods",
           "pathPlaceholder": "Search path…",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -1291,7 +1291,7 @@
             "disableCrossProtocolFallback": "禁用跨协议回退",
             "disableCrossProtocolFallbackHint": "失败时不重试其他协议。",
             "baseWeightFactor": "基础权重因子",
-            "baseWeightFactorHint": "每个候选通道的基础权重加数；调高可缩小通道间权重差距、分配更均衡。",
+            "baseWeightFactorHint": "每个候选通道的基础权重基数；调高可缩小通道间权重差距、分配更均衡。",
             "valueScoreFactor": "价值评分因子",
             "valueScoreFactorHint": "价值评分（成本/余额/用量综合）在路由贡献中的放大系数。",
             "costWeight": "成本权重",
@@ -1689,7 +1689,7 @@
           }
         },
         "auditLogs": {
-          "title": "管理员审计日志",
+          "title": "审计日志",
           "description": "管理端写操作的只读审计。",
           "allMethods": "全部方法",
           "pathPlaceholder": "搜索路径…",


### PR DESCRIPTION
视觉 QA 波经逐一源码核实后的真问题（其余报告项为识图噪声，源码文案正确）：

1. 基础权重「加数」→「基数」（baseWeightFactorHint）
2. 「管理员审计日志」→「审计日志」——7 字标题在窄侧边栏截断为「管理员审计...」；节描述已说明是只读管理审计，语义不丢