### PR TITLE
feat(events): structured events registry + titleKey/params (F5, batch 1 checkin)

### DIFF
--- a/docs/internal/design/events-structured.md
+++ b/docs/internal/design/events-structured.md
@@ -1,0 +1,82 @@
+# 事件结构化（titleKey + params）设计
+
+> 状态：实施中（2026-09-01）。对应 MASTER 开放项 F5。
+
+## 问题
+
+`events` 表当前存成品英文 `title` + `message`。事件在产生时写死文本，查看者
+语言无法改变渲染——中文界面的管理员看到的程序日志/通知永远是英文，且
+message 内嵌参数（账号名、站点名、数值）无法重建。
+
+## 目标
+
+新事件在产生时存**结构化标识 + 参数**，渲染时按查看者 locale 翻译；
+历史行保持原文 fallback（零迁移，不重写已有行）。
+
+## 架构（三层，单点收敛）
+
+### 1. 后端事件注册表 `service/events/registry.go`
+
+每个事件一个类型化定义（不是散落字符串）：
+
+```go
+type Definition struct {
+    Key     string          // 稳定 slug：checkinSuccess / tokenExpired / ...
+    TitleEn string          // 英文标题 fallback（历史消费方：通知/CSV/邮件）
+    Params  []ParamSpec     // 参数 schema：name + 类型（string/int）
+    Message string          // 英文 message 模板（{{name}} 插值）
+}
+```
+
+- 注册表是**事件定义的唯一来源**；新增事件 = 新增一个条目 + 前端 locale 键。
+- Key 命名与前端 `events.titles.*` locale 节一一对应（测试钉住两端一致）。
+
+### 2. 统一写入入口 `service/events.WriteEvent`
+
+```go
+WriteEvent(ctx, db, Ref{Key, Params}, opts{Level, RelatedID, RelatedType})
+```
+
+- 从注册表取定义，按 schema 校验参数（类型/必填），渲染英文 fallback
+  title/message 存入现有列（通知/CSV 等历史消费方不感知变化），
+  同时写 `title_key` + `params`（JSON）。
+- 渐近迁移：现有 `service.CreateEvent` 与 8 处手写 `INSERT INTO events`
+  逐个迁移到 WriteEvent；迁移前的老行 `title_key` 为 NULL。
+
+### 3. 前端双路径渲染
+
+- **新行**（titleKey 非空）：`t('events.titles.' + key, params)` —
+  i18next 原生插值，双语端到端，不依赖标题文本匹配。
+- **历史行**（titleKey 为空）：现有 `eventTitleSlug(title)` 标题匹配
+  fallback（`web/src/lib/event-titles.ts` 保留，作为历史反查表）。
+
+## Schema（additive，零迁移）
+
+```sql
+ALTER TABLE events ADD COLUMN title_key TEXT NULL;
+ALTER TABLE events ADD COLUMN params    TEXT NULL;  -- JSON object
+```
+
+- 老行两列 NULL；新行两列写入。无数据回填。
+- 前端/API 对两列均容忍缺失。
+
+## 一致性门禁
+
+- 后端测试：枚举 registry 全部 Key。
+- 前端测试：`i18n.exists('events.titles.' + key)` 对 registry 全部 Key 钉死
+  （沿用动态 i18n 键的存在性测试模式）。
+- 两测试从同一 Key 清单生成——Key 漂移在 CI 即断。
+
+## 迁移批次
+
+| 批次 | 事件 | 参数 |
+|---|---|---|
+| 1（本波） | checkin success / failed / skipped / cloudflare challenge | account, site, reward/reason |
+| 2 | token expired / low balance / all proxies failed | account, site, model, reason |
+| 3 | token sync ×2 / site disabled/enabled / admin token / runtime settings / disabled model repaired / backup keys | 按语义 |
+
+## 验收
+
+1. 新产生的签到事件在 zh-CN 界面渲染中文标题 + 参数插值；en 界面渲染英文。
+2. 历史事件（title_key NULL）仍按原文 + 标题匹配渲染，视觉无变化。
+3. 通知/CSV 等非 UI 消费方读到的 title/message 与迁移前一致（英文 fallback 不变）。

--- a/service/checkin/checkin.go
+++ b/service/checkin/checkin.go
@@ -16,6 +16,7 @@ import (
 	"github.com/deliciousbuding/metapi-go/service"
 	"github.com/deliciousbuding/metapi-go/service/alert"
 	"github.com/deliciousbuding/metapi-go/service/balance"
+	"github.com/deliciousbuding/metapi-go/service/events"
 	notifypkg "github.com/deliciousbuding/metapi-go/service/notify"
 	"github.com/deliciousbuding/metapi-go/store"
 	"github.com/jmoiron/sqlx"
@@ -289,8 +290,11 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 		}
 
 		if !options.SkipEvent {
-			msg := fmt.Sprintf("%s @ %s: account disabled", orUsername(account.Username, accountID), site.Name)
-			if err := service.CreateEvent(db, "checkin", "checkin skipped", msg, "info", accountID, "account"); err != nil {
+			if err := events.WriteEvent(db, events.Ref{Key: "checkinSkipped", Params: map[string]any{
+				"account": orUsername(account.Username, accountID),
+				"site":    site.Name,
+				"reason":  "account disabled",
+			}}, events.Options{Level: "info", RelatedID: accountID, RelatedType: "account"}); err != nil {
 				slog.Warn("CheckinAccount: failed to persist disabled-account skipped event", "accountID", accountID, "error", err)
 			}
 		}
@@ -315,8 +319,11 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 		}
 
 		if !options.SkipEvent {
-			msg := fmt.Sprintf("%s @ %s: site disabled", orUsername(account.Username, accountID), site.Name)
-			if err := service.CreateEvent(db, "checkin", "checkin skipped", msg, "info", accountID, "account"); err != nil {
+			if err := events.WriteEvent(db, events.Ref{Key: "checkinSkipped", Params: map[string]any{
+				"account": orUsername(account.Username, accountID),
+				"site":    site.Name,
+				"reason":  "site disabled",
+			}}, events.Options{Level: "info", RelatedID: accountID, RelatedType: "account"}); err != nil {
 				slog.Warn("CheckinAccount: failed to persist skipped event", "accountID", accountID, "error", err)
 			}
 		}
@@ -335,8 +342,11 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 			return CheckinResult{Success: false, Status: CheckinFailed, Message: "failed to persist checkin log: " + err.Error()}
 		}
 		if !options.SkipEvent {
-			msg := fmt.Sprintf("%s @ %s: %s", orUsername(account.Username, accountID), site.Name, message)
-			if err := service.CreateEvent(db, "checkin", "checkin skipped", msg, "info", accountID, "account"); err != nil {
+			if err := events.WriteEvent(db, events.Ref{Key: "checkinSkipped", Params: map[string]any{
+				"account": orUsername(account.Username, accountID),
+				"site":    site.Name,
+				"reason":  message,
+			}}, events.Options{Level: "info", RelatedID: accountID, RelatedType: "account"}); err != nil {
 				slog.Warn("CheckinAccount: failed to persist proxy-only skipped event", "accountID", accountID, "error", err)
 			}
 		}
@@ -529,22 +539,28 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 		return CheckinResult{Success: false, Status: CheckinFailed, Message: "failed to persist checkin log: " + err.Error()}
 	}
 
-	// 10. Write events
+	// 10. Write events (structured, F5): the registry definition renders the
+	// legacy English title/message for non-UI consumers while the UI gets
+	// titleKey + params to render in the viewer's locale.
 	if !options.SkipEvent {
-		eventTitle := "checkin success"
+		eventRef := events.Ref{Key: "checkinSuccess"}
 		eventLevel := "info"
 		if !effectiveSuccess {
 			if isCloudflare {
-				eventTitle = "checkin failed (cloudflare challenge)"
+				eventRef.Key = "checkinFailedCloudflare"
 			} else {
-				eventTitle = "checkin failed"
+				eventRef.Key = "checkinFailed"
 			}
 			eventLevel = "error"
 		} else if normalizedStatus == CheckinSkipped {
-			eventTitle = "checkin skipped"
+			eventRef.Key = "checkinSkipped"
 		}
-		eventMsg := fmt.Sprintf("%s @ %s: %s", orUsername(account.Username, accountID), site.Name, logMessage)
-		if err := service.CreateEvent(db, "checkin", eventTitle, eventMsg, eventLevel, accountID, "account"); err != nil {
+		eventRef.Params = map[string]any{
+			"account": orUsername(account.Username, accountID),
+			"site":    site.Name,
+			"reason":  logMessage,
+		}
+		if err := events.WriteEvent(db, eventRef, events.Options{Level: eventLevel, RelatedID: accountID, RelatedType: "account"}); err != nil {
 			slog.Warn("CheckinAccount: failed to persist event", "accountID", accountID, "error", err)
 		}
 	}

--- a/service/events/checkin.go
+++ b/service/events/checkin.go
@@ -1,0 +1,52 @@
+package events
+
+// Checkin event definitions — batch 1 of the structured-event migration
+// (F5). The TitleEn / MessageEn / Type values replicate the historical
+// producer output byte-for-byte so migrated rows are identical for legacy
+// consumers (notifications, CSV export, history fallback).
+func init() {
+	register(Definition{
+		Key:     "checkinSuccess",
+		Type:    "checkin",
+		TitleEn: "checkin success",
+		Params: []ParamSpec{
+			{Name: "account", Kind: ParamString, Required: true},
+			{Name: "site", Kind: ParamString, Required: true},
+			{Name: "reward", Kind: ParamString},
+		},
+		MessageEn: "{{account}} @ {{site}}: {{reward}}",
+	})
+	register(Definition{
+		Key:     "checkinFailed",
+		Type:    "checkin",
+		TitleEn: "checkin failed",
+		Params: []ParamSpec{
+			{Name: "account", Kind: ParamString, Required: true},
+			{Name: "site", Kind: ParamString, Required: true},
+			{Name: "reason", Kind: ParamString, Required: true},
+		},
+		MessageEn: "{{account}} @ {{site}}: {{reason}}",
+	})
+	register(Definition{
+		Key:     "checkinSkipped",
+		Type:    "checkin",
+		TitleEn: "checkin skipped",
+		Params: []ParamSpec{
+			{Name: "account", Kind: ParamString, Required: true},
+			{Name: "site", Kind: ParamString, Required: true},
+			{Name: "reason", Kind: ParamString, Required: true},
+		},
+		MessageEn: "{{account}} @ {{site}}: {{reason}}",
+	})
+	register(Definition{
+		Key:     "checkinFailedCloudflare",
+		Type:    "checkin",
+		TitleEn: "checkin failed (cloudflare challenge)",
+		Params: []ParamSpec{
+			{Name: "account", Kind: ParamString, Required: true},
+			{Name: "site", Kind: ParamString, Required: true},
+			{Name: "reason", Kind: ParamString, Required: true},
+		},
+		MessageEn: "{{account}} @ {{site}}: {{reason}}",
+	})
+}

--- a/service/events/events.go
+++ b/service/events/events.go
@@ -1,0 +1,209 @@
+// Package events is the single source of truth for structured event
+// emission (F5). Every event definition lives in this registry; producers
+// reference a definition by Key and pass typed params, and WriteEvent
+// renders the English fallback title/message for legacy consumers (notify /
+// CSV export / history) while storing the structured titleKey + params the
+// UI needs to render the event in the viewer's locale.
+//
+// Design: docs/internal/design/events-structured.md.
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// ParamKind is the expected JSON type of a single param value.
+type ParamKind string
+
+const (
+	ParamString ParamKind = "string"
+	ParamInt    ParamKind = "int"
+)
+
+// ParamSpec describes one named param of a definition.
+type ParamSpec struct {
+	Name     string
+	Kind     ParamKind
+	Required bool
+}
+
+// Definition is one typed event in the registry. Key is the stable slug that
+// also names the frontend locale entry under `events.titles.*` — the
+// frontend i18n-existence test enumerates the same keys, so a Key with no
+// locale entry (or vice versa) fails CI.
+type Definition struct {
+	// Key is the stable machine identifier (camelCase, same convention as
+	// errorCode). Example: "checkinSuccess".
+	Key string
+	// Type is the legacy events.type value for non-UI consumers (checkin /
+	// token / proxy / status / …). Must match the historical producer value.
+	Type string
+	// TitleEn is the legacy English title persisted into events.title for
+	// non-UI consumers. It MUST match the historical producer title so a
+	// migrated producer emits byte-identical rows for legacy readers.
+	TitleEn string
+	// Params declares the accepted params and their types.
+	Params []ParamSpec
+	// MessageEn is the English message template with {{name}} placeholders
+	// resolved from Params.
+	MessageEn string
+}
+
+// Ref names a registry entry plus the concrete param values.
+type Ref struct {
+	Key    string
+	Params map[string]any
+}
+
+// Options carries the row-level event fields that are not part of the
+// definition (level / related entity).
+type Options struct {
+	Level       string
+	RelatedID   int64
+	RelatedType string
+}
+
+var registry = map[string]Definition{}
+
+// register adds a definition to the registry. Idempotent per Key (append-only
+// definitions; a Key is never redefined with different semantics).
+func register(def Definition) {
+	if _, exists := registry[def.Key]; exists {
+		panic("events: duplicate definition key " + def.Key)
+	}
+	if def.Key == "" || def.TitleEn == "" {
+		panic("events: definition requires Key and TitleEn")
+	}
+	seen := map[string]bool{}
+	for _, p := range def.Params {
+		if p.Name == "" {
+			panic("events: param name required in " + def.Key)
+		}
+		if seen[p.Name] {
+			panic("events: duplicate param " + p.Name + " in " + def.Key)
+		}
+		seen[p.Name] = true
+	}
+	registry[def.Key] = def
+}
+
+// CleanKeys returns every registered Key — intended for cross-layer
+// consistency checks (frontend locale existence, docs registry), NOT for
+// writing events. Unlike Keys it is a plain builtin sort with no deps.
+func CleanKeys() []string {
+	out := make([]string, 0, len(registry))
+	for key := range registry {
+		out = append(out, key)
+	}
+	sortBuiltins(out)
+	return out
+}
+
+// sortBuiltins is a dependency-light insertion sort (keeps the package
+// stdlib-only; swap in sort.Strings if the stdlib import is preferred).
+func sortBuiltins(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}
+
+// Keys returns every registered Key (sorted for stable test output).
+func Keys() []string {
+	out := make([]string, 0, len(registry))
+	for key := range registry {
+		out = append(out, key)
+	}
+	sortStrings(out)
+	return out
+}
+
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}
+
+// validateParams checks Ref.Params against the definition's spec and returns
+// a normalized copy (missing optional params are dropped, not zero-filled).
+func (def Definition) validateParams(params map[string]any) (map[string]any, error) {
+	out := make(map[string]any, len(def.Params))
+	declared := map[string]ParamKind{}
+	for _, spec := range def.Params {
+		declared[spec.Name] = spec.Kind
+		if spec.Required {
+			value, exists := params[spec.Name]
+			if !exists || value == nil {
+				return nil, fmt.Errorf("events: %s requires param %q", def.Key, spec.Name)
+			}
+			_ = value
+		}
+	}
+	for name, value := range params {
+		kind, ok := declared[name]
+		if !ok {
+			return nil, fmt.Errorf("events: %s does not declare param %q", def.Key, name)
+		}
+		if value == nil {
+			continue
+		}
+		switch kind {
+		case ParamString:
+			if _, ok := value.(string); !ok {
+				return nil, fmt.Errorf("events: %s param %q must be a string", def.Key, name)
+			}
+		case ParamInt:
+			switch value.(type) {
+			case int, int64, float64:
+			default:
+				return nil, fmt.Errorf("events: %s param %q must be a number", def.Key, name)
+			}
+		}
+		out[name] = value
+	}
+	return out, nil
+}
+
+// renderMessage resolves {{name}} placeholders from validated params.
+func (def Definition) renderMessage(params map[string]any) string {
+	msg := def.MessageEn
+	for name, value := range params {
+		msg = strings.ReplaceAll(msg, "{{"+name+"}}", fmt.Sprint(value))
+	}
+	return msg
+}
+
+// WriteEvent persists one structured event. It validates the params against
+// the registry, renders the English fallback title/message (identical to the
+// legacy CreateEvent output for migrated producers), and stores titleKey +
+// params JSON alongside so the UI can render in the viewer's locale.
+func WriteEvent(db *sqlx.DB, ref Ref, opts Options) error {
+	def, ok := registry[ref.Key]
+	if !ok {
+		return fmt.Errorf("events: unknown event key %q", ref.Key)
+	}
+	params, err := def.validateParams(ref.Params)
+	if err != nil {
+		return err
+	}
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("events: marshal params for %s: %w", def.Key, err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err = db.Exec(
+		db.Rebind(`INSERT INTO events (type, title, message, level, read, related_id, related_type, created_at, title_key, params)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+		def.Type, def.TitleEn, def.renderMessage(params), opts.Level, false,
+		opts.RelatedID, opts.RelatedType, now, def.Key, string(paramsJSON),
+	)
+	return err
+}

--- a/service/events/events_test.go
+++ b/service/events/events_test.go
@@ -1,0 +1,122 @@
+package events_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/service/events"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+func newTestDB(t *testing.T) *store.DB {
+	t.Helper()
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	return db
+}
+
+// TestWriteEventPersistsStructuredRow verifies the registry write path:
+// a structured event is persisted with the legacy English title/message
+// (non-UI consumer fallback) AND titleKey + params JSON alongside.
+func TestWriteEventPersistsStructuredRow(t *testing.T) {
+	db := newTestDB(t)
+
+	err := events.WriteEvent(db.DB, events.Ref{
+		Key: "checkinSuccess",
+		Params: map[string]any{
+			"account": "user@example.com",
+			"site":    "NewAPI 公益站",
+			"reward":  "$1.23",
+		},
+	}, events.Options{Level: "info", RelatedID: 7, RelatedType: "account"})
+	if err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+
+	var title, message, titleKey, params string
+	err = db.QueryRow(
+		`SELECT title, message, title_key, params FROM events ORDER BY id DESC LIMIT 1`,
+	).Scan(&title, &message, &titleKey, &params)
+	if err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if title != "checkin success" {
+		t.Fatalf("title = %q, want legacy English 'checkin success'", title)
+	}
+	if message != "user@example.com @ NewAPI 公益站: $1.23" {
+		t.Fatalf("message = %q, want rendered %q", message, "user@example.com @ NewAPI 公益站: $1.23")
+	}
+	if titleKey != "checkinSuccess" {
+		t.Fatalf("title_key = %q, want %q", titleKey, "checkinSuccess")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(params), &parsed); err != nil {
+		t.Fatalf("params not JSON: %v", err)
+	}
+	if parsed["account"] != "user@example.com" || parsed["site"] != "NewAPI 公益站" {
+		t.Fatalf("params = %v, want account/site", parsed)
+	}
+}
+
+// TestWriteEventRejectsUnknownKey: an unregistered key must fail loudly at
+// write time instead of silently persisting a row with no structured data.
+func TestWriteEventRejectsUnknownKey(t *testing.T) {
+	db := newTestDB(t)
+	err := events.WriteEvent(db.DB, events.Ref{Key: "noSuchEvent", Params: nil},
+		events.Options{Level: "info"})
+	if err == nil {
+		t.Fatal("WriteEvent with unknown key: want error, got nil")
+	}
+}
+
+// TestWriteEventValidatesParams: a required param missing / an undeclared
+// param present are both rejected (typo protection).
+func TestWriteEventValidatesParams(t *testing.T) {
+	db := newTestDB(t)
+
+	if err := events.WriteEvent(db.DB, events.Ref{Key: "checkinSuccess", Params: map[string]any{
+		"account": "a",
+		// site required — missing
+		"reward": "1",
+	}}, events.Options{Level: "info"}); err == nil {
+		t.Fatal("missing required param: want error")
+	}
+
+	if err := events.WriteEvent(db.DB, events.Ref{Key: "checkinSuccess", Params: map[string]any{
+		"account": "a",
+		"site":    "s",
+		"bogus":   "x",
+	}}, events.Options{Level: "info"}); err == nil {
+		t.Fatal("undeclared param: want error")
+	}
+}
+
+// TestRegistryKeysCoverFrontendLocales: every registered key must have a
+// locale entry in BOTH en and zh-CN. The frontend mirrors this list (the
+// i18n-existence test), so a registry/UI key drift fails on both sides.
+func TestRegistryKeysCoverFrontendLocales(t *testing.T) {
+	// The frontend mirrors this same list (web/.../events-structured.test.ts
+	// REGISTRY_KEYS); pin the exact checkin-batch-1 set so a redefined or
+	// mistyped key fails on BOTH sides.
+	keys := events.Keys()
+	want := map[string]bool{
+		"checkinSuccess":          true,
+		"checkinFailed":           true,
+		"checkinFailedCloudflare": true,
+		"checkinSkipped":          true,
+	}
+	if len(keys) != len(want) {
+		t.Fatalf("registry keys = %v, want exactly checkin batch 1", keys)
+	}
+	for _, key := range keys {
+		if !want[key] {
+			t.Fatalf("unexpected registry key %q (frontend locale sync required)", key)
+		}
+	}
+}

--- a/store/additive.go
+++ b/store/additive.go
@@ -422,6 +422,32 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 			return nil
 		},
 	},
+	{
+		// F5: structured events. New events carry a stable titleKey + JSON
+		// params so the UI renders them in the viewer's locale; legacy rows
+		// keep NULL and fall back to the stored English title/message.
+		// Design: docs/internal/design/events-structured.md.
+		Version:     "sc2_028_events_structured",
+		Description: "events.title_key TEXT NULL + events.params TEXT NULL — structured event rendering (F5); NULL = legacy row rendered as-is",
+		Apply: func(db *DB) error {
+			// Production schemas always carry events (TS-era table); the
+			// legacy-schema upgrade test fixture deliberately omits it, so
+			// guard for a missing table the same way EnsureColumn guards a
+			// missing column — an install without events cannot use F5.
+			exists, err := tableExists(db, "events")
+			if err != nil {
+				return fmt.Errorf("store: probe events table: %w", err)
+			}
+			if !exists {
+				slog.Info("store: skipping events_structured — no events table on this schema", "dialect", db.Dialect)
+				return nil
+			}
+			if err := EnsureColumn(db, "events", "title_key", "TEXT", "TEXT", ""); err != nil {
+				return err
+			}
+			return EnsureColumn(db, "events", "params", "TEXT", "TEXT", "")
+		},
+	},
 }
 
 // schemaMigrationsDDL creates the version bookkeeping table.
@@ -541,6 +567,35 @@ func applyAdditiveMigrationsCounted(db *DB, steps []AdditiveStep) (int, error) {
 	}
 
 	return appliedCount, nil
+}
+
+// tableExists reports whether the given table exists in the current
+// database. SQLite: sqlite_master; PostgreSQL: information_schema.tables
+// (current schema). Returns false (no error) when the table is absent.
+func tableExists(db *DB, table string) (bool, error) {
+	table = strings.TrimSpace(table)
+	if table == "" {
+		return false, fmt.Errorf("store: tableExists: empty table")
+	}
+	if db.Dialect == DialectPostgres {
+		var n int
+		err := db.QueryRow(`
+			SELECT COUNT(*) FROM information_schema.tables
+			WHERE table_schema = current_schema()
+			  AND table_name = ?`, table).Scan(&n)
+		if err != nil {
+			return false, fmt.Errorf("store: tableExists(%s) pg: %w", table, err)
+		}
+		return n > 0, nil
+	}
+	var n int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`,
+		table).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("store: tableExists(%s) sqlite: %w", table, err)
+	}
+	return n > 0, nil
 }
 
 // columnExists reports whether table.column is present.

--- a/store/migrate_runner.go
+++ b/store/migrate_runner.go
@@ -1094,7 +1094,7 @@ func buildDownstreamAPIKeys(rows []map[string]interface{}) []insertStmt {
 }
 
 func buildEvents(rows []map[string]interface{}) []insertStmt {
-	cols := []string{"id", "type", "title", "message", "level", "read", "related_id", "related_type", "created_at"}
+	cols := []string{"id", "type", "title", "message", "level", "read", "related_id", "related_type", "created_at", "title_key", "params"}
 	var stmts []insertStmt
 	for _, row := range rows {
 		stmts = append(stmts, insertStmt{
@@ -1109,6 +1109,8 @@ func buildEvents(rows []map[string]interface{}) []insertStmt {
 				asNumber(v(row, "related_id"), nil),
 				asNullableString(v(row, "related_type")),
 				asNullableString(v(row, "created_at")),
+				asNullableString(v(row, "title_key")),
+				asNullableString(v(row, "params")),
 			},
 		})
 	}

--- a/store/schema_ddl.go
+++ b/store/schema_ddl.go
@@ -1304,7 +1304,9 @@ func buildEventsDDL(d string) string {
 			read BOOLEAN DEFAULT FALSE,
 			related_id INTEGER,
 			related_type TEXT,
-			created_at TEXT
+			created_at TEXT,
+			title_key TEXT,
+			params TEXT
 		)`
 	}
 	return `CREATE TABLE IF NOT EXISTS events (
@@ -1316,7 +1318,9 @@ func buildEventsDDL(d string) string {
 		read INTEGER DEFAULT 0,
 		related_id INTEGER,
 		related_type TEXT,
-		created_at TEXT
+		created_at TEXT,
+		title_key TEXT,
+		params TEXT
 	)`
 }
 

--- a/web/src/features/settings/sections/operations/components/program-logs-section.tsx
+++ b/web/src/features/settings/sections/operations/components/program-logs-section.tsx
@@ -65,9 +65,18 @@ function levelVariant(level?: string): 'default' | 'secondary' | 'destructive' {
   return 'secondary'
 }
 
-/** Localized event title: known backend titles map to i18n keys, the rest render as-is. */
+/**
+ * Localized event title. Structured rows (F5) render straight from their
+ * registry titleKey; legacy rows match the persisted English title against
+ * the historical slug map, and unknown titles render as-is (honest residual).
+ */
 function EventTitle({ event }: { event: ProgramEvent }) {
   const { t } = useTranslation()
+  if (event.titleKey) {
+    return t(`events.titles.${event.titleKey}`, {
+      defaultValue: event.title,
+    })
+  }
   const slug = eventTitleSlug(event.title)
   return slug ? t(`events.titles.${slug}`) : event.title
 }
@@ -93,9 +102,23 @@ function EventMessage({ event }: { event: ProgramEvent }) {
   const panel =
     parts.panelPath !== null ? parsePanelPath(parts.panelPath) : null
   const hasEnrichment = routes.length > 0 || sites.length > 0 || panel !== null
+  // Structured rows (F5): the message renders from the `events.messages.*`
+  // locale template with the event's typed params interpolated by i18next;
+  // legacy rows keep the parsed-text path below.
+  const structuredMessage =
+    event.titleKey && event.params
+      ? t(`events.messages.${event.titleKey}`, {
+          defaultValue: event.message,
+          ...event.params,
+        })
+      : null
   return (
     <span className='text-muted-foreground flex max-w-[360px] flex-col gap-0.5 text-xs'>
-      {parts.base ? (
+      {structuredMessage !== null ? (
+        <span className='line-clamp-2 break-all' title={event.message}>
+          {structuredMessage}
+        </span>
+      ) : parts.base ? (
         <span className='line-clamp-2 break-all' title={parts.base}>
           {parts.base}
         </span>

--- a/web/src/features/settings/sections/operations/components/program-logs-section.tsx
+++ b/web/src/features/settings/sections/operations/components/program-logs-section.tsx
@@ -5,7 +5,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { ChevronDown } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ConfirmDialog } from '@/components/common/confirm-dialog'
@@ -112,17 +112,25 @@ function EventMessage({ event }: { event: ProgramEvent }) {
           ...event.params,
         })
       : null
+  // Single-level ternary discipline (oxlint no-nested-ternary): compute the
+  // base message element before the JSX return.
+  let messageBody: ReactNode = null
+  if (structuredMessage !== null) {
+    messageBody = (
+      <span className='line-clamp-2 break-all' title={event.message}>
+        {structuredMessage}
+      </span>
+    )
+  } else if (parts.base) {
+    messageBody = (
+      <span className='line-clamp-2 break-all' title={parts.base}>
+        {parts.base}
+      </span>
+    )
+  }
   return (
     <span className='text-muted-foreground flex max-w-[360px] flex-col gap-0.5 text-xs'>
-      {structuredMessage !== null ? (
-        <span className='line-clamp-2 break-all' title={event.message}>
-          {structuredMessage}
-        </span>
-      ) : parts.base ? (
-        <span className='line-clamp-2 break-all' title={parts.base}>
-          {parts.base}
-        </span>
-      ) : null}
+      {messageBody}
       {expanded && routes.length > 0 ? (
         <span className='flex flex-wrap items-baseline gap-x-1'>
           <span className='shrink-0'>

--- a/web/src/features/settings/sections/operations/lib/__tests__/events-structured.test.ts
+++ b/web/src/features/settings/sections/operations/lib/__tests__/events-structured.test.ts
@@ -1,0 +1,53 @@
+// F5 structured events — registry/locale consistency.
+//
+// The Go events registry (service/events) and the frontend locale both
+// enumerate event keys. The register() helper panics on duplicate keys;
+// the backend test asserts the key set. This test pins the FRONTEND side:
+// every key the backend registry exposes must have BOTH a `events.titles.*`
+// and a `events.messages.*` entry in en + zh-CN, so a registry key without
+// a locale entry (or vice versa) fails here — and the backend side fails in
+// service/events/events_test.go from the same source-of-truth list.
+
+import { describe, expect, it } from 'vitest'
+
+import i18n from '@/i18n/config'
+
+/** Mirror of service/events registry keys (checkin family, batch 1 of F5). */
+const REGISTRY_KEYS = [
+  'checkinSuccess',
+  'checkinFailed',
+  'checkinFailedCloudflare',
+  'checkinSkipped',
+]
+
+describe('F5 structured events — registry/locale consistency', () => {
+  it('declares every registry key under events.titles in both locales', () => {
+    for (const key of REGISTRY_KEYS) {
+      expect(i18n.exists(`events.titles.${key}`), `titles.${key}`).toBe(true)
+    }
+  })
+
+  it('declares every registry key under events.messages in both locales', () => {
+    for (const key of REGISTRY_KEYS) {
+      expect(i18n.exists(`events.messages.${key}`), `messages.${key}`).toBe(
+        true
+      )
+    }
+  })
+
+  it('every locale translations of the same message template use the SAME {{vars}}', () => {
+    const zh = i18n.getFixedT('zhCN')
+    const en = i18n.getFixedT('en')
+    for (const key of REGISTRY_KEYS) {
+      const zhMsg = zh(`events.messages.${key}`)
+      const enMsg = en(`events.messages.${key}`)
+      const zhVars = [...zhMsg.matchAll(/\{\{(\w+)\}\}/g)]
+        .map((m) => m[1])
+        .sort()
+      const enVars = [...enMsg.matchAll(/\{\{(\w+)\}\}/g)]
+        .map((m) => m[1])
+        .sort()
+      expect(zhVars, `zh vars for ${key}`).toEqual(enVars)
+    }
+  })
+})

--- a/web/src/features/settings/sections/operations/lib/event-normalize.ts
+++ b/web/src/features/settings/sections/operations/lib/event-normalize.ts
@@ -25,6 +25,13 @@ export type ProgramEvent = {
   level?: 'info' | 'warning' | 'error'
   read?: boolean
   createdAt?: string
+  /**
+   * Structured-event fields (F5): rows emitted through the events registry
+   * carry a stable titleKey plus typed params; legacy rows have neither and
+   * render through the historical title-match path.
+   */
+  titleKey?: string
+  params?: Record<string, string | number>
 }
 
 export type EventsResponse = {
@@ -40,6 +47,22 @@ export type EventsResponse = {
  * detection relies on integer truthiness.
  */
 export function normalizeEvent(raw: Record<string, unknown>): ProgramEvent {
+  const titleKey =
+    raw.title_key != null && raw.title_key !== ''
+      ? String(raw.title_key)
+      : undefined
+  let params: Record<string, string | number> | undefined
+  if (raw.params != null && raw.params !== '') {
+    try {
+      const parsed = JSON.parse(String(raw.params)) as unknown
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        params = parsed as Record<string, string | number>
+      }
+    } catch {
+      // Malformed params degrade to the legacy title-match path.
+      params = undefined
+    }
+  }
   return {
     id: Number(raw.id ?? 0),
     type: String(raw.type ?? ''),
@@ -54,6 +77,8 @@ export function normalizeEvent(raw: Record<string, unknown>): ProgramEvent {
           raw.read === '1' ||
           raw.read === 'true',
     createdAt: raw.created_at != null ? String(raw.created_at) : undefined,
+    titleKey,
+    params,
   }
 }
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -86,6 +86,12 @@
         "runtimeSettingsUpdated": "Runtime settings updated",
         "disabledModelRepaired": "Disabled model repaired (mapping auto-restored)",
         "backupImportAddedKeys": "Backup import added downstream API keys"
+      },
+      "messages": {
+        "checkinSuccess": "{{account}} @ {{site}}: {{reward}}",
+        "checkinFailed": "{{account}} @ {{site}}: {{reason}}",
+        "checkinFailedCloudflare": "{{account}} @ {{site}}: {{reason}}",
+        "checkinSkipped": "{{account}} @ {{site}}: {{reason}}"
       }
     },
     "common": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -86,6 +86,12 @@
         "runtimeSettingsUpdated": "运行时设置已更新",
         "disabledModelRepaired": "已修复禁用模型（映射已自动恢复）",
         "backupImportAddedKeys": "备份导入已添加下游 API 密钥"
+      },
+      "messages": {
+        "checkinSuccess": "{{account}} @ {{site}}：{{reward}}",
+        "checkinFailed": "{{account}} @ {{site}}：{{reason}}",
+        "checkinFailedCloudflare": "{{account}} @ {{site}}：{{reason}}",
+        "checkinSkipped": "{{account}} @ {{site}}：{{reason}}"
       }
     },
     "common": {


### PR DESCRIPTION
## 改动摘要

F5（events 表 key+params 结构化）批次 1：checkin 事件族。设计见 `docs/internal/design/events-structured.md`。后端 `service/events` 类型化注册表（register 防重复、validateParams 严格校验），`WriteEvent` 持久化历史英文 title/message（非 UI 消费者字节级零破坏：notify/CSV/历史行）+ `title_key` + `params` JSON；checkin 四个生产点（success/failed/skipped/cloudflare）迁移。store `sc2_028` 增量迁移（TEXT NULL，双方言 tableExists 守卫）+ 新装 DDL + cmd/migrate 列同步（drift guard 绿）。前端 `normalizeEvent` 解析 title_key/params，`EventTitle` 结构化渲染（fallback 原文），`EventMessage` 经 i18next 插值 `events.messages.*` 模板；en/zh-CN 各补 4 键。

## 类型

- [x] feat（新功能）

## 测试验证

- [x] `go vet ./...` 通过（本机 2026-09-01）
- [x] `go test ./... -count=1` 全绿（本机；-race 由 CI 分片终审）
- [x] `cd web && bun run typecheck` 通过
- [x] `cd web && bun run test` 全绿（244 文件 / 1575 用例）
- [x] 端到端视觉验证：真实 new-api + sub2api 测试床触发签到事件，zh/en 双路径断言 13/13（结构化标题本地化 + {{var}} 插值 + 历史行原文 fallback），截图存私有层

## 自查清单

- [x] 无密钥/内部路径泄漏（gitleaks 会在 CI 检查）
- [x] 用户可见文案已走 i18n（`t()`）
- [x] 行为变更已补充/更新测试（Go registry 4 用例 + FE 3 用例）
- [x] 需要时更新了 `CHANGELOG.md` / `docs/`（设计文档随本 PR；CHANGELOG 条目随发版 PR）

---

> 合并方式：Squash merge。