### PR TITLE
fix(security): close SSRF validation gap in site bulk import + backup imports

### DIFF
--- a/handler/admin/settings_backup.go
+++ b/handler/admin/settings_backup.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/service"
 	backupsvc "github.com/deliciousbuding/metapi-go/service/backup"
 	"github.com/deliciousbuding/metapi-go/store"
 	"github.com/go-chi/chi/v5"
@@ -159,6 +160,9 @@ func (h *backupHandler) importBackup(w http.ResponseWriter, r *http.Request) {
 	}
 	if result.skippedSettings > 0 {
 		response["skippedSettings"] = result.skippedSettings
+	}
+	if result.droppedForbiddenURLs > 0 {
+		response["droppedForbiddenSiteRows"] = result.droppedForbiddenURLs
 	}
 	if len(result.newDownstreamApiKeys) > 0 {
 		response["newDownstreamApiKeys"] = result.newDownstreamApiKeys
@@ -318,6 +322,12 @@ func previewBackupImportTables(db *sqlx.DB, tables map[string]json.RawMessage) (
 			}
 		}
 
+		// SECURITY: mirror the import path's SSRF target guard so the plan
+		// preview matches what the import will actually admit.
+		if kept, dropped := service.SanitizeImportedSiteRows(table, rows); dropped > 0 {
+			rows = kept
+		}
+
 		preview := backupImportPreview{Rows: int64(len(rows))}
 		pkCol := "id"
 		if table == "settings" {
@@ -413,6 +423,9 @@ type backupImportResult struct {
 	// skippedSettings counts settings rows excluded by policy (runtime-local
 	// keys from backupsvc.RuntimeLocalSettingKeys).
 	skippedSettings int64
+	// droppedForbiddenURLs counts site/endpoint rows rejected by the
+	// SSRF target guard (cloud metadata / link-local URLs).
+	droppedForbiddenURLs int64
 	// newDownstreamApiKeys lists the names (never the key values) of
 	// downstream_api_keys entries actually inserted by this import. Importing
 	// an untrusted backup is equivalent to accepting the keys it carries; the
@@ -481,6 +494,13 @@ func importBackupTablesWithConn(conn backupImportConn, tables map[string]json.Ra
 			return nil, backupImportClientError{
 				message: fmt.Sprintf("import failed: table %s exceeds the max rows of %d", table, backupImportMaxRowsPerTable),
 			}
+		}
+		// SECURITY: site/endpoint rows carry server-outbound target URLs.
+		// Enforce the same metadata/link-local guard the single-row create
+		// paths apply, so a crafted backup cannot plant SSRF targets.
+		if kept, dropped := service.SanitizeImportedSiteRows(table, rows); dropped > 0 {
+			rows = kept
+			result.droppedForbiddenURLs += int64(dropped)
 		}
 		if len(rows) == 0 {
 			continue

--- a/handler/admin/settings_backup_test.go
+++ b/handler/admin/settings_backup_test.go
@@ -1423,3 +1423,34 @@ func TestPreviewTSV21Endpoint(t *testing.T) {
 		t.Fatalf("preview wrote %d site rows, want 0", siteCount)
 	}
 }
+
+func TestImportBackupTablesDropsForbiddenSiteURLs(t *testing.T) {
+	db := setupBackupTestDB(t)
+
+	tables := map[string]json.RawMessage{
+		"sites": json.RawMessage(`[
+			{"id": 1, "name": "Clean", "url": "https://clean.example.com", "platform": "new-api", "status": "active"},
+			{"id": 2, "name": "Metadata", "url": "http://169.254.169.254/latest/meta-data/", "platform": "new-api", "status": "active"},
+			{"id": 3, "name": "LinkLocalEndpoint", "url": "https://ok.example.com", "external_checkin_url": "http://169.254.169.254/checkin", "platform": "new-api", "status": "active"}
+		]`),
+	}
+
+	result, err := importBackupTables(db.DB, tables)
+	if err != nil {
+		t.Fatalf("importBackupTables: %v", err)
+	}
+	if got := result.imported["sites"]; got != 1 {
+		t.Fatalf("imported[sites] = %d, want 1 (only the clean site)", got)
+	}
+	if result.droppedForbiddenURLs != 2 {
+		t.Fatalf("droppedForbiddenURLs = %d, want 2", result.droppedForbiddenURLs)
+	}
+
+	var count int
+	if err := db.Get(&count, "SELECT COUNT(*) FROM sites"); err != nil {
+		t.Fatalf("count sites: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("sites rows = %d, want 1", count)
+	}
+}

--- a/service/backup/ts_backup_v21.go
+++ b/service/backup/ts_backup_v21.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/service"
 	"github.com/deliciousbuding/metapi-go/store"
 	"github.com/jmoiron/sqlx"
 )
@@ -856,7 +857,17 @@ func importTSV21Parsed(conn tsV21Conn, parsed *TSV21Parsed) (*TSV21ImportResult,
 			downstreamBefore = tsV21QueryExistingPKs(conn, table, "key", downstreamCandidates)
 		}
 
-		count, err := importTSV21TableRows(conn, table, parsed.Tables[table])
+		// SECURITY: site/endpoint rows carry server-outbound target URLs.
+		// Enforce the same metadata/link-local guard the single-row create
+		// paths apply, so a crafted backup cannot plant SSRF targets.
+		tableRows := parsed.Tables[table]
+		if kept, dropped := service.SanitizeImportedSiteRows(table, tableRows); dropped > 0 {
+			tableRows = kept
+			result.Warnings = append(result.Warnings, fmt.Sprintf(
+				"ignored %d %s row(s): forbidden target URL (cloud metadata / link-local)", dropped, table))
+		}
+
+		count, err := importTSV21TableRows(conn, table, tableRows)
 		if err != nil {
 			return nil, fmt.Errorf("import failed: table %s: %w", table, err)
 		}

--- a/service/backup/ts_backup_v21_test.go
+++ b/service/backup/ts_backup_v21_test.go
@@ -832,3 +832,52 @@ func TestImportTSV21ReportsNewDownstreamApiKeys(t *testing.T) {
 		t.Fatalf("second NewDownstreamApiKeys = %v, want none (duplicate keys are not new)", second.NewDownstreamApiKeys)
 	}
 }
+
+const tsV21SSRFBackup = `{
+  "version": "2.1",
+  "timestamp": 1755678900000,
+  "type": "all",
+  "accounts": {
+    "sites": [
+      {"id": 1, "name": "Clean", "url": "https://clean.example.com", "platform": "new-api", "status": "active"},
+      {"id": 2, "name": "Metadata", "url": "http://169.254.169.254/latest/meta-data/", "platform": "new-api", "status": "active"},
+      {"id": 3, "name": "MetadataProxy", "url": "https://proxy.example.com", "proxyUrl": "http://169.254.169.254:8080", "platform": "new-api", "status": "active"}
+    ],
+    "siteApiEndpoints": [
+      {"id": 1, "siteId": 1, "url": "https://ep-clean.example.com", "enabled": true},
+      {"id": 2, "siteId": 1, "url": "http://169.254.169.254/ep", "enabled": true}
+    ]
+  }
+}`
+
+func TestImportTSV21DropsForbiddenSiteURLs(t *testing.T) {
+	db := setupBackupServiceTestDB(t)
+
+	result, err := backupsvc.ImportTSV21(db, []byte(tsV21SSRFBackup))
+	if err != nil {
+		t.Fatalf("ImportTSV21: %v", err)
+	}
+	if got := result.Imported["sites"]; got != 1 {
+		t.Fatalf("imported[sites] = %d, want 1 (only the clean site)", got)
+	}
+	if got := result.Imported["site_api_endpoints"]; got != 1 {
+		t.Fatalf("imported[site_api_endpoints] = %d, want 1", got)
+	}
+	warned := 0
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "forbidden target URL") {
+			warned++
+		}
+	}
+	if warned == 0 {
+		t.Fatalf("expected forbidden-URL warnings, got %v", result.Warnings)
+	}
+
+	var count int
+	if err := db.Get(&count, "SELECT COUNT(*) FROM sites"); err != nil {
+		t.Fatalf("count sites: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("sites rows = %d, want 1", count)
+	}
+}

--- a/service/import_url_guard.go
+++ b/service/import_url_guard.go
@@ -1,0 +1,42 @@
+package service
+
+// importURLColumns lists, per table, the columns whose values become
+// server-initiated outbound request targets. Rows admitted through bulk site
+// import or backup import must satisfy the same IsForbiddenSiteTargetURL
+// rules that the single-row create/update endpoints enforce (sites.go,
+// site_endpoint_service.go); otherwise a crafted import payload can plant
+// cloud-metadata / link-local targets that the data plane later dials
+// (first-hop SSRF), bypassing the config-layer validation.
+var importURLColumns = map[string][]string{
+	"sites":              {"url", "external_checkin_url", "proxy_url"},
+	"site_api_endpoints": {"url"},
+}
+
+// SanitizeImportedSiteRows drops imported rows whose outbound-target URL
+// columns point at forbidden targets (cloud metadata / link-local). Empty or
+// absent values pass (nullable columns; IsForbiddenSiteTargetURL is
+// empty-tolerant). Returns the surviving rows and how many were dropped.
+// Tables without guarded columns are returned unchanged.
+func SanitizeImportedSiteRows(table string, rows []map[string]any) ([]map[string]any, int) {
+	cols := importURLColumns[table]
+	if len(cols) == 0 {
+		return rows, 0
+	}
+	kept := make([]map[string]any, 0, len(rows))
+	dropped := 0
+	for _, row := range rows {
+		forbidden := false
+		for _, col := range cols {
+			if v, ok := row[col].(string); ok && IsForbiddenSiteTargetURL(v) {
+				forbidden = true
+				break
+			}
+		}
+		if forbidden {
+			dropped++
+			continue
+		}
+		kept = append(kept, row)
+	}
+	return kept, dropped
+}

--- a/service/import_url_guard_test.go
+++ b/service/import_url_guard_test.go
@@ -1,0 +1,49 @@
+package service
+
+import "testing"
+
+func TestSanitizeImportedSiteRows_DropsForbiddenTargets(t *testing.T) {
+	rows := []map[string]any{
+		{"id": int64(1), "url": "https://a.example.com", "name": "clean"},
+		{"id": int64(2), "url": "http://169.254.169.254/latest/meta-data/", "name": "metadata"},
+		{"id": int64(3), "url": "https://b.example.com", "proxy_url": "http://[fd00::1]:8080", "name": "ula-proxy-allowed"},
+		{"id": int64(4), "url": "https://c.example.com", "external_checkin_url": "http://100.100.100.200/latest/meta-data", "name": "metadata-checkin"},
+		{"id": int64(5), "url": "http://127.0.0.1:11434/v1", "name": "localhost-allowed"},
+		{"id": int64(6), "url": nil, "name": "null-url-allowed"},
+	}
+	kept, dropped := SanitizeImportedSiteRows("sites", rows)
+	if dropped != 2 {
+		t.Fatalf("dropped = %d, want 2 (kept=%v)", dropped, kept)
+	}
+	if len(kept) != 4 {
+		t.Fatalf("kept = %d rows, want 4", len(kept))
+	}
+	// ULA proxies and localhost stay allowed (operator-hosted upstreams);
+	// metadata targets (169.254.169.254, 100.100.100.200) are dropped.
+	wantKept := map[int64]bool{1: true, 3: true, 5: true, 6: true}
+	for _, row := range kept {
+		id, _ := row["id"].(int64)
+		if !wantKept[id] {
+			t.Fatalf("unexpected kept row id=%d: %v", id, row)
+		}
+	}
+}
+
+func TestSanitizeImportedSiteRows_EndpointURLs(t *testing.T) {
+	rows := []map[string]any{
+		{"id": int64(1), "site_id": int64(1), "url": "https://ep.example.com"},
+		{"id": int64(2), "site_id": int64(1), "url": "http://169.254.169.254/"},
+	}
+	kept, dropped := SanitizeImportedSiteRows("site_api_endpoints", rows)
+	if dropped != 1 || len(kept) != 1 {
+		t.Fatalf("kept=%d dropped=%d, want 1/1", len(kept), dropped)
+	}
+}
+
+func TestSanitizeImportedSiteRows_UnguardedTablesUntouched(t *testing.T) {
+	rows := []map[string]any{{"key": "anything", "value": "http://169.254.169.254/"}}
+	kept, dropped := SanitizeImportedSiteRows("settings", rows)
+	if dropped != 0 || len(kept) != 1 {
+		t.Fatalf("unguarded table must pass through: kept=%d dropped=%d", len(kept), dropped)
+	}
+}

--- a/service/site_import.go
+++ b/service/site_import.go
@@ -110,6 +110,11 @@ func importOneSite(db *sqlx.DB, item ImportSiteInput, strategy ImportDuplicateSt
 		base.Status = "failed"
 		return base
 	}
+	if IsForbiddenSiteTargetURL(rawURL) {
+		base.Reason = "Invalid url. Cloud metadata / link-local targets are not allowed."
+		base.Status = "failed"
+		return base
+	}
 
 	platform := strings.TrimSpace(strings.ToLower(item.Platform))
 	if platform == "" {

--- a/service/site_import_test.go
+++ b/service/site_import_test.go
@@ -98,3 +98,27 @@ func TestImportSites_FailsOnUnknownPlatform(t *testing.T) {
 		t.Fatalf("failed=%d want 1 (results=%+v)", res.Failed, res.Results)
 	}
 }
+
+func TestImportSites_RejectsForbiddenTargetURLs(t *testing.T) {
+	db := openImportTestDB(t)
+
+	items := []ImportSiteInput{
+		{Name: "Metadata", URL: "http://169.254.169.254/latest/meta-data/", Platform: "openai"},
+		{Name: "Clean", URL: "https://api.openai.com/v1", Platform: "openai"},
+	}
+
+	res, err := ImportSites(db.DB, items, ImportDuplicateSkip)
+	if err != nil {
+		t.Fatalf("ImportSites: %v", err)
+	}
+	if res.Imported != 1 || res.Failed != 1 {
+		t.Fatalf("imported=%d failed=%d, want 1/1", res.Imported, res.Failed)
+	}
+	for _, r := range res.Results {
+		if r.Name == "Metadata" {
+			if r.Status != "failed" || r.Reason == "" {
+				t.Fatalf("metadata item status=%q reason=%q, want failed with reason", r.Status, r.Reason)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`IsForbiddenSiteTargetURL` (cloud-metadata / link-local rejection) was enforced on every single-row site/endpoint write — but **not** on the three bulk admission paths:

| Path | Gap |
|---|---|
| `POST /api/sites/import` | only `IsValidHTTPURL` checked |
| native backup import (`/api/settings/backup/import`) | `sites`/`site_api_endpoints` rows inserted verbatim |
| TS v2.1 backup import (TS→Go takeover path) | same |

**Reachable chain**: import a crafted backup carrying a site with `url=http://169.254.169.254/latest/meta-data/` plus a working downstream key → one `/v1` request exfiltrates cloud metadata/IAM content through the data plane. Found by a dedicated security audit of all outbound surfaces.

## Fix

- New `service.SanitizeImportedSiteRows(table, rows)` — guards the outbound-target columns per table:
  - `sites`: `url`, `external_checkin_url`, `proxy_url`
  - `site_api_endpoints`: `url`
  - Semantics identical to the single-row guard: metadata aliases (`metadata`, `instance-data`, `metadata.google.internal`), `169.254.0.0/16`, explicit metadata IPs (`100.100.100.200` Alibaba, `fd00:ec2::254` AWS IMDSv6), multicast/unspecified. **RFC1918, loopback and IPv6 ULA stay allowed** (operator-hosted upstreams), and empty/null values pass.
- Wired into all three import paths + the **import-plan preview** (so previews match what imports actually admit).
- Dropped rows are surfaced, not silently eaten: TSV21 `warnings`, native import response `droppedForbiddenSiteRows`.

## Tests (all green)

- `TestSanitizeImportedSiteRows_*` — metadata / Alibaba-metadata drop, ULA-allowed, null-allowed, endpoint table, unguarded tables untouched.
- `TestImportSites_RejectsForbiddenTargetURLs` — batch import marks the item failed.
- `TestImportTSV21DropsForbiddenSiteURLs` — clean site imported, metadata site + metadata endpoint dropped, warning emitted.
- `TestImportBackupTablesDropsForbiddenSiteURLs` — native import drops 2/3 rows and reports the count.
- Full `./service/...` + `./handler/...` suites pass.

## Follow-up (separate PR)

Defense-in-depth dial-level guard on the data-plane transport (`proxy/executor.go` / `handler/proxy/upstream.go`, mirroring `internal/ssrf.NewSiteDialContext` used by the checkin plane) — bigger hot-path change, handled separately.