### PR TITLE
fix(api): align /v1 auth & rate-limit errors with the OpenAI error envelope

### DIFF
--- a/auth/downstream.go
+++ b/auth/downstream.go
@@ -127,9 +127,11 @@ func AuthorizeDownstreamToken(token string, rt *config.RuntimeSettings) Downstre
 
 		// Check max cost
 		if managed.MaxCost != nil && managed.UsedCost >= *managed.MaxCost {
+			// 429 insufficient_quota (OpenAI convention for exhausted
+			// per-key budget), not 403.
 			return DownstreamTokenAuthResult{
 				OK:         false,
-				StatusCode: 403,
+				StatusCode: 429,
 				Error:      "API key has exceeded max cost",
 				Reason:     "over_cost",
 			}
@@ -137,9 +139,11 @@ func AuthorizeDownstreamToken(token string, rt *config.RuntimeSettings) Downstre
 
 		// Check max requests
 		if managed.MaxRequests != nil && managed.UsedRequests >= *managed.MaxRequests {
+			// 429 insufficient_quota (OpenAI convention for exhausted
+			// per-key budget), not 403.
 			return DownstreamTokenAuthResult{
 				OK:         false,
-				StatusCode: 403,
+				StatusCode: 429,
 				Error:      "API key has exceeded max requests",
 				Reason:     "over_requests",
 			}
@@ -169,9 +173,11 @@ func AuthorizeDownstreamToken(token string, rt *config.RuntimeSettings) Downstre
 	}
 
 	// ---- No match ----
+	// 401 (not 403): OpenAI/SDK convention treats an unknown key as an
+	// authentication failure; 403 signals a non-retryable permission problem.
 	return DownstreamTokenAuthResult{
 		OK:         false,
-		StatusCode: 403,
+		StatusCode: 401,
 		Error:      "Invalid API key",
 		Reason:     "invalid",
 	}
@@ -265,11 +271,14 @@ func ConsumeManagedKeyRequest(keyID int64) bool {
 
 // SQL:
 
-//	UPDATE downstream_api_keys
-//	SET used_requests = COALESCE(used_requests, 0) + 1,
-//	 last_used_at = ?, updated_at = ?
-//	WHERE id = ?
-//	 AND (max_requests IS NULL OR COALESCE(used_requests, 0) < max_requests)
+// UPDATE downstream_api_keys
+// SET used_requests = COALESCE(used_requests, 0) + 1,
+//
+//	last_used_at = ?, updated_at = ?
+//
+// WHERE id = ?
+//
+//	AND (max_requests IS NULL OR COALESCE(used_requests, 0) < max_requests)
 func consumeManagedKeyRequest(keyID int64) bool {
 	db := store.GetDB()
 	if db == nil {

--- a/auth/proxy.go
+++ b/auth/proxy.go
@@ -37,9 +37,8 @@ func ProxyAuth() func(http.Handler) http.Handler {
 			token := extractProxyToken(r)
 
 			if token == "" {
-				writeJSON(w, http.StatusUnauthorized, jsonError(
-					"Missing Authorization, x-api-key, x-goog-api-key, or key query parameter",
-				))
+				writeProxyError(w, http.StatusUnauthorized, "authentication_error", "missing_api_key",
+					"Missing Authorization, x-api-key, x-goog-api-key, or key query parameter")
 				return
 			}
 
@@ -47,7 +46,8 @@ func ProxyAuth() func(http.Handler) http.Handler {
 			result := AuthorizeDownstreamToken(token, config.Runtime())
 
 			if !result.OK {
-				writeJSON(w, result.StatusCode, jsonError(result.Error))
+				errType, code := proxyAuthErrorClass(result.Reason)
+				writeProxyError(w, result.StatusCode, errType, code, result.Error)
 				return
 			}
 
@@ -60,7 +60,7 @@ func ProxyAuth() func(http.Handler) http.Handler {
 					if denyReason == "ip_blocked" {
 						msg = "IP address is blocked for this API key"
 					}
-					writeJSON(w, http.StatusForbidden, jsonError(msg))
+					writeProxyError(w, http.StatusForbidden, "permission_error", denyReason, msg)
 					return
 				}
 			}
@@ -93,12 +93,16 @@ func ProxyAuth() func(http.Handler) http.Handler {
 						sec = 1
 					}
 					w.Header().Set("Retry-After", strconv.Itoa(sec))
-					writeJSON(w, http.StatusTooManyRequests, jsonError(msg))
+					errType, code := proxyAuthErrorClass(adm.Reason)
+					writeProxyError(w, http.StatusTooManyRequests, errType, code, msg)
 					return
 				}
 				// Atomic max_requests gate - only after admission allows.
 				if !consumeManagedKeyRequest(result.Key.ID) {
-					writeJSON(w, http.StatusForbidden, jsonError("API key has exceeded max requests"))
+					// 429 insufficient_quota, matching AuthorizeDownstreamToken's
+					// over_requests verdict for the same exhausted budget.
+					writeProxyError(w, http.StatusTooManyRequests, "insufficient_quota", "insufficient_quota",
+						"API key has exceeded max requests")
 					return
 				}
 			}
@@ -164,7 +168,6 @@ func extractProxyToken(r *http.Request) string {
 
 	return ""
 }
-
 
 // isWebsocketUpgradeRequest mirrors proxyhandler.IsWebsocketUpgradeRequest
 // without importing that package (auth must stay free of handler deps).

--- a/auth/proxy_errors.go
+++ b/auth/proxy_errors.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// proxyAuthErrorClass maps downstream auth Reason values onto the OpenAI SDK
+// error taxonomy (type) plus a stable snake_case machine code. The /v1 error
+// envelope is {"error":{"message","type","code"?}} — the same shape the
+// handler layer already emits (handler/proxy/router.go
+// writeJSONErrorWithRequest), so one /v1 surface has exactly one error format
+// whether the failure happened in middleware or in the handler.
+//
+// Status codes live on DownstreamTokenAuthResult (auth/downstream.go):
+//   - missing/invalid            → 401 (OpenAI convention: an unknown key is
+//     an authentication failure, not a permission one — SDKs treat 403 as
+//     non-retryable permission errors and skip the key-rotation path)
+//   - disabled/expired/IP policy → 403
+//   - over_cost/over_requests    → 429 (OpenAI reports exhausted quota as
+//     insufficient_quota on 429)
+func proxyAuthErrorClass(reason string) (errType, code string) {
+	switch reason {
+	case "missing":
+		return "authentication_error", "missing_api_key"
+	case "invalid":
+		return "authentication_error", "invalid_api_key"
+	case "disabled":
+		return "permission_error", "key_disabled"
+	case "expired":
+		return "permission_error", "key_expired"
+	case "over_cost", "over_requests":
+		return "insufficient_quota", "insufficient_quota"
+	case "ip_blocked":
+		return "permission_error", "ip_blocked"
+	case "ip_not_allowed":
+		return "permission_error", "ip_not_allowed"
+	case "over_rpm":
+		return "rate_limit_error", "over_rpm"
+	case "over_tpm":
+		return "rate_limit_error", "over_tpm"
+	default:
+		return "authentication_error", reason
+	}
+}
+
+// writeProxyError writes the OpenAI-shaped /v1 error envelope. The ingress
+// request id (when the middleware already set X-Request-Id) is mirrored into
+// the body exactly like the handler layer does.
+func writeProxyError(w http.ResponseWriter, status int, errType, code, message string) {
+	body := map[string]any{
+		"message": message,
+		"type":    errType,
+	}
+	if code != "" {
+		body["code"] = code
+	}
+	if rid := w.Header().Get("X-Request-Id"); rid != "" {
+		body["request_id"] = rid
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{"error": body})
+}

--- a/auth/proxy_test.go
+++ b/auth/proxy_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -276,8 +277,8 @@ func TestAuthorizeDownstreamToken_UnknownToken(t *testing.T) {
 	if result.OK {
 		t.Error("expected OK=false for unknown token")
 	}
-	if result.StatusCode != 403 {
-		t.Errorf("expected 403, got %d", result.StatusCode)
+	if result.StatusCode != 401 {
+		t.Errorf("expected 401, got %d", result.StatusCode)
 	}
 	if result.Reason != "invalid" {
 		t.Errorf("expected reason=invalid, got %q", result.Reason)
@@ -402,8 +403,8 @@ func TestAuthorizeDownstreamToken_ManagedKeyOverCost(t *testing.T) {
 	if result.OK {
 		t.Error("expected OK=false for over-cost key")
 	}
-	if result.StatusCode != 403 {
-		t.Errorf("expected 403, got %d", result.StatusCode)
+	if result.StatusCode != 429 {
+		t.Errorf("expected 429, got %d", result.StatusCode)
 	}
 	if result.Reason != "over_cost" {
 		t.Errorf("expected reason=over_cost, got %q", result.Reason)
@@ -438,8 +439,8 @@ func TestAuthorizeDownstreamToken_ManagedKeyOverRequests(t *testing.T) {
 	if result.OK {
 		t.Error("expected OK=false for over-requests key")
 	}
-	if result.StatusCode != 403 {
-		t.Errorf("expected 403, got %d", result.StatusCode)
+	if result.StatusCode != 429 {
+		t.Errorf("expected 429, got %d", result.StatusCode)
 	}
 	if result.Reason != "over_requests" {
 		t.Errorf("expected reason=over_requests, got %q", result.Reason)
@@ -543,8 +544,23 @@ func TestProxyAuthMiddleware_UnknownToken(t *testing.T) {
 	w := proxyAuthMiddlewareHelper(t, cfg, map[string]string{
 		"Authorization": "Bearer unknown-token",
 	}, "")
-	if w.Code != http.StatusForbidden {
-		t.Errorf("expected 403 for unknown token, got %d", w.Code)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for unknown token (OpenAI convention), got %d", w.Code)
+	}
+	// The /v1 auth surface must answer with the OpenAI error envelope, not a
+	// bare string: SDKs and upstream-relay integrations parse error.message.
+	var body struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal error body: %v (body=%q)", err, w.Body.String())
+	}
+	if body.Error.Message == "" || body.Error.Type != "authentication_error" || body.Error.Code != "invalid_api_key" {
+		t.Errorf("error envelope = %+v, want authentication_error/invalid_api_key", body.Error)
 	}
 }
 

--- a/auth/ratelimit.go
+++ b/auth/ratelimit.go
@@ -272,7 +272,8 @@ func ProxyRateLimit(rpm int) func(http.Handler) http.Handler {
 					sec = 1
 				}
 				w.Header().Set("Retry-After", strconv.Itoa(sec))
-				writeJSON(w, http.StatusTooManyRequests, jsonError("Too many requests"))
+				writeProxyError(w, http.StatusTooManyRequests, "rate_limit_error", "rate_limit_exceeded",
+					"Too many requests")
 				return
 			}
 			next.ServeHTTP(w, r)
@@ -362,7 +363,8 @@ func ProxyGlobalTokenRateLimit(rpm int) func(http.Handler) http.Handler {
 					sec = 1
 				}
 				w.Header().Set("Retry-After", strconv.Itoa(sec))
-				writeJSON(w, http.StatusTooManyRequests, jsonError("Global proxy token rate limit exceeded"))
+				writeProxyError(w, http.StatusTooManyRequests, "rate_limit_error", "global_token_rate_exceeded",
+					"Global proxy token rate limit exceeded")
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/auth/ratelimit_proxy_test.go
+++ b/auth/ratelimit_proxy_test.go
@@ -164,12 +164,13 @@ func TestProxyRateLimit_429HasJSONErrorBody(t *testing.T) {
 	if !strings.Contains(ct, "application/json") {
 		t.Fatalf("Content-Type = %q, want application/json", ct)
 	}
-	var body map[string]string
+	var body map[string]any
 	if err := json.Unmarshal(rec2.Body.Bytes(), &body); err != nil {
 		t.Fatalf("unmarshal 429 body: %v (body=%q)", err, rec2.Body.String())
 	}
-	if body["error"] == "" {
-		t.Fatalf("429 body missing error field: %s", rec2.Body.String())
+	errObj, ok := body["error"].(map[string]any)
+	if !ok || errObj["message"] == nil || errObj["type"] != "rate_limit_error" {
+		t.Fatalf("429 body is not the OpenAI error envelope: %s", rec2.Body.String())
 	}
 }
 
@@ -372,12 +373,13 @@ func TestProxyGlobalTokenRateLimit_429HasJSONBody(t *testing.T) {
 	if rec2.Code != http.StatusTooManyRequests {
 		t.Fatalf("status = %d, want %d", rec2.Code, http.StatusTooManyRequests)
 	}
-	var body map[string]string
+	var body map[string]any
 	if err := json.Unmarshal(rec2.Body.Bytes(), &body); err != nil {
 		t.Fatalf("unmarshal body: %v (body=%q)", err, rec2.Body.String())
 	}
-	if body["error"] == "" {
-		t.Fatalf("429 body missing error field: %s", rec2.Body.String())
+	errObj, ok := body["error"].(map[string]any)
+	if !ok || errObj["message"] == nil || errObj["type"] != "rate_limit_error" {
+		t.Fatalf("429 body is not the OpenAI error envelope: %s", rec2.Body.String())
 	}
 }
 

--- a/docs/api/proxy.md
+++ b/docs/api/proxy.md
@@ -2,6 +2,41 @@
 
 > **Index**: back to [API Reference](../api.md). This file is the /v1/files & /v1/pricing domain split out of the pre-`docs/api/` `docs/api.md`.
 
+## Error shape (/v1 surface)
+
+All `/v1` surface failures — auth middleware, rate limits, body limit, and
+handler errors — use one OpenAI-compatible envelope so SDKs and upstream-relay
+integrations (e.g. new-api consuming Metapi as a channel) parse them uniformly:
+
+```json
+{
+  "error": {
+    "message": "Invalid API key",
+    "type": "authentication_error",
+    "code": "invalid_api_key",
+    "request_id": "present when the ingress middleware set one"
+  }
+}
+```
+
+Status conventions (OpenAI-aligned):
+
+| Case | Status | `type` | `code` |
+|------|--------|--------|--------|
+| Missing credential | 401 | `authentication_error` | `missing_api_key` |
+| Unknown/invalid key | 401 | `authentication_error` | `invalid_api_key` |
+| Key disabled / expired | 403 | `permission_error` | `key_disabled` / `key_expired` |
+| Key IP policy denied | 403 | `permission_error` | `ip_blocked` / `ip_not_allowed` |
+| RPM/TPM rate limit | 429 + `Retry-After` | `rate_limit_error` | `over_rpm` / `over_tpm` / `rate_limit_exceeded` / `global_token_rate_exceeded` |
+| Budget exhausted (`maxCost` / `maxRequests`) | 429 | `insufficient_quota` | `insufficient_quota` |
+| Body too large | 413 | `invalid_request_error` | — |
+
+The admin surface (`/api/*`) keeps the flat `{"error", "errorCode"}` body
+documented in [conventions.md](conventions.md); the two contracts never mix
+(the global body-limit middleware picks the shape by path prefix).
+
+---
+
 ## Proxy files (`/v1/files`)
 
 OpenAI-compatible Files surface (proxy auth required). Forwards to the selected upstream channel; does not persist customer file bytes on Metapi disk.

--- a/e2e/e2e_flow_test.go
+++ b/e2e/e2e_flow_test.go
@@ -431,8 +431,8 @@ func TestSiteCreateToProxyFlow_UnauthorizedAccess(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer wrong-proxy-token")
 		rec := httptest.NewRecorder()
 		r.ServeHTTP(rec, req)
-		if rec.Code != 403 {
-			t.Errorf("expected 403 with wrong proxy token, got %d: %s", rec.Code, rec.Body.String())
+		if rec.Code != 401 {
+			t.Errorf("expected 401 with wrong proxy token, got %d: %s", rec.Code, rec.Body.String())
 		}
 	})
 
@@ -441,8 +441,8 @@ func TestSiteCreateToProxyFlow_UnauthorizedAccess(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer "+adminToken)
 		rec := httptest.NewRecorder()
 		r.ServeHTTP(rec, req)
-		if rec.Code != 403 {
-			t.Errorf("expected 403 with admin token on proxy endpoint, got %d: %s", rec.Code, rec.Body.String())
+		if rec.Code != 401 {
+			t.Errorf("expected 401 with admin token on proxy endpoint, got %d: %s", rec.Code, rec.Body.String())
 		}
 	})
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -19,13 +19,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/deliciousbuding/metapi-go/auth"
 	"github.com/deliciousbuding/metapi-go/config"
 	"github.com/deliciousbuding/metapi-go/handler/proxy"
 	"github.com/deliciousbuding/metapi-go/proxy"
 	"github.com/deliciousbuding/metapi-go/routing"
 	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
 )
 
 // TestMain sets up the global config + runtime singletons before any tests run.
@@ -226,9 +226,9 @@ func injectAuthManaged(token string, supportedModels []string) func(http.Handler
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			pac := &auth.ProxyAuthContext{
-				Token:  token,
-				Source: "managed",
-				KeyID:  &id,
+				Token:   token,
+				Source:  "managed",
+				KeyID:   &id,
 				KeyName: "test-managed-key",
 				Policy: auth.DownstreamRoutingPolicy{
 					SupportedModels:        supportedModels,
@@ -258,9 +258,9 @@ func makeChannel(id int64, upstreamURL string, actualModel string) *routing.Sele
 		},
 		Site: store.Site{
 			ID:       id,
-			Name:    fmt.Sprintf("site-%d", id),
-			URL:     upstreamURL,
-			Status:  "active",
+			Name:     fmt.Sprintf("site-%d", id),
+			URL:      upstreamURL,
+			Status:   "active",
 			Platform: "openai",
 		},
 		TokenValue:  "test-upstream-token",
@@ -531,9 +531,9 @@ func TestDownstreamAuth(t *testing.T) {
 	// Use real ProxyAuth middleware with the seeded DB.
 	mockUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeJSONHelper(w, 200, map[string]any{
-			"id":      "chatcmpl-auth",
-			"object":  "chat.completion",
-			"model":   "gpt-4",
+			"id":     "chatcmpl-auth",
+			"object": "chat.completion",
+			"model":  "gpt-4",
 			"choices": []map[string]any{
 				{
 					"index":   0,
@@ -595,8 +595,9 @@ func TestDownstreamAuth(t *testing.T) {
 		}
 	})
 
-	// Test 3: Unknown key should get 403.
-	t.Run("unknown key gets 403", func(t *testing.T) {
+	// Test 3: Unknown key gets 401 with the OpenAI error envelope (SDK
+	// convention: unknown key = authentication failure, not permission).
+	t.Run("unknown key gets 401", func(t *testing.T) {
 		req := httptest.NewRequest("POST", "/chat/completions",
 			strings.NewReader(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`))
 		req.Header.Set("Content-Type", "application/json")
@@ -604,8 +605,12 @@ func TestDownstreamAuth(t *testing.T) {
 		rec := httptest.NewRecorder()
 		r.ServeHTTP(rec, req)
 
-		if rec.Code != 403 {
-			t.Errorf("expected 403 for unknown key, got %d: %s", rec.Code, rec.Body.String())
+		if rec.Code != 401 {
+			t.Errorf("expected 401 for unknown key, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), `"type":"authentication_error"`) ||
+			!strings.Contains(rec.Body.String(), `"code":"invalid_api_key"`) {
+			t.Errorf("expected OpenAI error envelope, got %s", rec.Body.String())
 		}
 	})
 
@@ -652,9 +657,9 @@ func TestModelMatching(t *testing.T) {
 		json.Unmarshal(body, &reqBody)
 
 		writeJSONHelper(w, 200, map[string]any{
-			"id":      "chatcmpl-model",
-			"object":  "chat.completion",
-			"model":   reqBody["model"],
+			"id":     "chatcmpl-model",
+			"object": "chat.completion",
+			"model":  reqBody["model"],
 			"choices": []map[string]any{
 				{
 					"index":   0,
@@ -887,9 +892,9 @@ func TestRateLimit(t *testing.T) {
 		// Simulate processing time.
 		time.Sleep(50 * time.Millisecond)
 		writeJSONHelper(w, 200, map[string]any{
-			"id":      fmt.Sprintf("chatcmpl-%d", requestCount.Load()),
-			"object":  "chat.completion",
-			"model":   "gpt-4",
+			"id":     fmt.Sprintf("chatcmpl-%d", requestCount.Load()),
+			"object": "chat.completion",
+			"model":  "gpt-4",
 			"choices": []map[string]any{
 				{
 					"index":   0,
@@ -988,9 +993,9 @@ func TestNonStreamingWithStreamFalse(t *testing.T) {
 			t.Log("stream field present in upstream body")
 		}
 		writeJSONHelper(w, 200, map[string]any{
-			"id":      "chatcmpl-ns",
-			"object":  "chat.completion",
-			"model":   "gpt-4",
+			"id":     "chatcmpl-ns",
+			"object": "chat.completion",
+			"model":  "gpt-4",
 			"choices": []map[string]any{
 				{
 					"index":   0,

--- a/router/body_limit_test.go
+++ b/router/body_limit_test.go
@@ -33,12 +33,13 @@ func TestBodyLimitPathAware_Returns413OnOversizedContentLength(t *testing.T) {
 	if !strings.Contains(ct, "application/json") {
 		t.Fatalf("Content-Type = %q, want application/json", ct)
 	}
-	var body map[string]string
+	var body map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("unmarshal 413 body: %v (body=%q)", err, rec.Body.String())
 	}
-	if body["error"] == "" {
-		t.Fatalf("413 body missing error field: %s", rec.Body.String())
+	errObj, ok := body["error"].(map[string]any)
+	if !ok || errObj["message"] == nil || errObj["type"] != "invalid_request_error" {
+		t.Fatalf("413 body is not the OpenAI error envelope: %s", rec.Body.String())
 	}
 }
 
@@ -156,8 +157,8 @@ func TestV1ProxyRateLimitReturns429(t *testing.T) {
 		// very low limit for fast testing,
 	}
 	config.SetRuntime(&config.RuntimeSettings{
-		AuthToken:         "admin-token",
-		ProxyToken:        "proxy-token",
+		AuthToken:  "admin-token",
+		ProxyToken: "proxy-token",
 	})
 	t.Cleanup(func() { config.SetRuntime(nil) })
 	r := New(cfg, web.Dist)
@@ -192,12 +193,13 @@ func TestV1ProxyRateLimitReturns429(t *testing.T) {
 	if got := rec.Header().Get("Retry-After"); got == "" {
 		t.Fatal("Retry-After header missing on 429")
 	}
-	var body map[string]string
+	var body map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("unmarshal 429 body: %v (body=%q)", err, rec.Body.String())
 	}
-	if body["error"] == "" {
-		t.Fatalf("429 body missing error field: %s", rec.Body.String())
+	errObj, ok := body["error"].(map[string]any)
+	if !ok || errObj["message"] == nil || errObj["type"] != "rate_limit_error" {
+		t.Fatalf("429 body is not the OpenAI error envelope: %s", rec.Body.String())
 	}
 }
 
@@ -208,8 +210,8 @@ func TestV1ProxyRateLimitDisabledWhenRPMZero(t *testing.T) {
 		// disabled,
 	}
 	config.SetRuntime(&config.RuntimeSettings{
-		AuthToken:         "admin-token",
-		ProxyToken:        "proxy-token",
+		AuthToken:  "admin-token",
+		ProxyToken: "proxy-token",
 	})
 	t.Cleanup(func() { config.SetRuntime(nil) })
 	r := New(cfg, web.Dist)
@@ -232,8 +234,8 @@ func TestV1ProxyRateLimitPerIPIsolation(t *testing.T) {
 		ProxyRateLimitRPM: 1,
 	}
 	config.SetRuntime(&config.RuntimeSettings{
-		AuthToken:         "admin-token",
-		ProxyToken:        "proxy-token",
+		AuthToken:  "admin-token",
+		ProxyToken: "proxy-token",
 	})
 	t.Cleanup(func() { config.SetRuntime(nil) })
 	r := New(cfg, web.Dist)
@@ -265,8 +267,8 @@ func TestV1BodyLimitReturns413OnOversizedRequest(t *testing.T) {
 		// 1 KB — tiny limit for testing,
 	}
 	config.SetRuntime(&config.RuntimeSettings{
-		AuthToken:        "admin-token",
-		ProxyToken:       "proxy-token",
+		AuthToken:  "admin-token",
+		ProxyToken: "proxy-token",
 	})
 	t.Cleanup(func() { config.SetRuntime(nil) })
 	r := New(cfg, web.Dist)
@@ -287,16 +289,16 @@ func TestV1BodyLimitReturns413OnOversizedRequest(t *testing.T) {
 
 func TestV1FileUploadRouteUsesHigherBodyLimit(t *testing.T) {
 	cfg := &config.Config{
-		RequestBodyLimit:    1 * 1024,
+		RequestBodyLimit: 1 * 1024,
 		// 1 KB general
 		FileUploadLimitBytes: 100 * 1024,
 		// 100 KB for uploads
-		ProxyRateLimitRPM:   0,
+		ProxyRateLimitRPM: 0,
 		// disable rate limiting for this test,
 	}
 	config.SetRuntime(&config.RuntimeSettings{
-		AuthToken:           "admin-token",
-		ProxyToken:          "proxy-token",
+		AuthToken:  "admin-token",
+		ProxyToken: "proxy-token",
 	})
 	t.Cleanup(func() { config.SetRuntime(nil) })
 	r := New(cfg, web.Dist)

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -237,11 +237,18 @@ func isFileUploadPath(path string) bool {
 
 // writeBodyLimitError emits a 413 Request Entity Too Large response with a
 // JSON error body, so clients receive a clean rejection instead of a silently
-// truncated body.
-func writeBodyLimitError(w http.ResponseWriter) {
+// truncated body. The body limit is mounted globally, so the shape follows
+// the surface: /api and /auth keep the flat {"error": "..."} admin contract,
+// everything else (the /v1 proxy surface and its aliases) gets the
+// OpenAI-shaped envelope the proxy auth middleware and handlers emit.
+func writeBodyLimitError(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusRequestEntityTooLarge)
-	_, _ = w.Write([]byte(`{"error":"Request body too large"}`))
+	if strings.HasPrefix(r.URL.Path, "/api") || strings.HasPrefix(r.URL.Path, "/auth") {
+		_, _ = w.Write([]byte(`{"error":"Request body too large"}`))
+		return
+	}
+	_, _ = w.Write([]byte(`{"error":{"message":"Request body too large","type":"invalid_request_error"}}`))
 }
 
 // BodyLimitPathAware enforces a maximum request body size, selecting between a
@@ -262,7 +269,7 @@ func BodyLimitPathAware(defaultLimitBytes, fileUploadLimitBytes int) func(http.H
 			}
 			if limit > 0 {
 				if r.ContentLength > int64(limit) {
-					writeBodyLimitError(w)
+					writeBodyLimitError(w, r)
 					return
 				}
 				r.Body = http.MaxBytesReader(w, r.Body, int64(limit))


### PR DESCRIPTION
## Problem

The /v1 surface had **two error shapes**: auth/rate-limit middleware wrote bare `{"error":"..."}` strings while handlers wrote the OpenAI envelope `{"error":{message,type,request_id}}`. OpenAI SDKs and upstream-relay integrations (new-api consuming metapi as a channel) parse `error.message`/`error.type` — bare strings degrade parsing and break error classification.

Status codes also diverged from convention:
- invalid key → **403** (SDKs treat 403 as non-retryable permission errors and skip the key-rotation path; OpenAI answers 401 `invalid_api_key`)
- exhausted budget (`maxCost`/`maxRequests`) → **403** (OpenAI convention: 429 `insufficient_quota`)

Found by the API/network domain audit (top-3 fix list).

## Changes (proxy surface only — /api admin, /auth, /oauth contracts untouched)

| Piece | Before | After |
|---|---|---|
| missing token | 401 bare string | 401 envelope `authentication_error`/`missing_api_key` |
| unknown/invalid key | 403 bare string | **401** envelope `authentication_error`/`invalid_api_key` |
| key disabled/expired | 403 bare string | 403 envelope `permission_error`/`key_disabled`/`key_expired` |
| key IP policy | 403 bare string | 403 envelope `permission_error`/`ip_blocked`/`ip_not_allowed` |
| RPM/TPM admission | 429 bare string | 429 envelope `rate_limit_error`/`over_rpm`/`over_tpm` (+Retry-After kept) |
| max_requests gate | 403 bare string | **429** envelope `insufficient_quota` |
| ProxyRateLimit / GlobalTokenRateLimit | 429 bare string | 429 envelope `rate_limit_error` |
| global body limit 413 (mounted on every path) | bare string everywhere | path-aware: /api,/auth keep flat admin contract; proxy paths get envelope `invalid_request_error` |

- New `auth/proxy_errors.go`: envelope writer (mirrors `request_id` from `X-Request-Id` like the handler layer) + reason→(type, code) map.
- `docs/api/proxy.md`: new **Error shape (/v1 surface)** section with the full status/type/code table.

## Tests

Updated to pin the new contract (auth proxy/ratelimit body assertions, router 413/429 assertions, e2e unknown-token 401+envelope, e2e-flow wrong-token 401s). Admin-surface assertions deliberately unchanged. Full local suite green after rebase on master (43 pkgs ok, exit 0).