### PR TITLE
fix: quickfix batch from multi-domain audit (routing/PG/SSE/dialect)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,7 @@ PROXY_TOKEN=change-me-proxy-sk-token
 PROXY_MAX_BUFFERED_RESPONSE_BYTES=20971520
 # Max total bytes relayed for a single SSE stream before a controlled termination.
 # Default 1 MB (1048576). 0/negative/invalid falls back to default at Load time.
-PROXY_MAX_STREAM_RESPONSE_BYTES=1048576
+PROXY_MAX_STREAM_RESPONSE_BYTES=67108864
 # Test/demo only. Leave empty in production; unconfigured upstream forwarding returns 503.
 METAPI_ENABLE_PROXY_STUB=
 # Optional outbound system proxy for upstream requests (http://, https://,

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -137,11 +137,11 @@ const (
 	DefaultProxyDebugMaxBodyBytes   = 262144
 
 	// DefaultProxyMaxStreamResponseBytes caps the total bytes relayed for a
-	// single SSE stream before a controlled termination (1 MB). Parsed from
+	// single SSE stream before a controlled termination (64 MB). Parsed from
 	// PROXY_MAX_STREAM_RESPONSE_BYTES; 0/negative/invalid falls back to this
 	// default. Read once at startup via config.Load — the stream handler reads
 	// the resolved value from the config singleton, not os.Getenv per request.
-	DefaultProxyMaxStreamResponseBytes = 1 << 20 // 1 MB
+	DefaultProxyMaxStreamResponseBytes = 64 << 20 // 64 MB
 
 	// DefaultProxyMaxBufferedResponseBytes caps the total bytes read for a
 	// single non-streaming upstream response before a controlled termination

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,7 @@ default when `WEBHOOK_URL` is non-empty). Alert cooldown:
 | `PROXY_GLOBAL_TOKEN_RPM` | `0` | Global cap across all IPs for `PROXY_TOKEN`; safety net if a token leaks. |
 | `PROXY_MAX_CHANNEL_ATTEMPTS` | `3` | Max retry/failover channel attempts per request. |
 | `PROXY_MAX_BUFFERED_RESPONSE_BYTES` | `20971520` | Non-streaming upstream response buffer cap (20 MiB); over → 502. |
-| `PROXY_MAX_STREAM_RESPONSE_BYTES` | `1048576` | Bytes relayed per SSE stream before controlled termination. |
+| `PROXY_MAX_STREAM_RESPONSE_BYTES` | `67108864` | Bytes relayed per SSE stream before controlled termination. |
 | `PROXY_FIRST_BYTE_TIMEOUT_SEC` | unset | First upstream response byte timeout. |
 | `PROXY_EMPTY_CONTENT_FAIL` | empty | Treat empty upstream content as failure. |
 | `PROXY_ERROR_KEYWORDS` | empty | Extra keywords marking upstream responses as errors. |

--- a/handler/admin/audit_logs.go
+++ b/handler/admin/audit_logs.go
@@ -152,8 +152,10 @@ func (h *auditLogsHandler) list(w http.ResponseWriter, r *http.Request) {
 		args = append(args, method)
 	}
 	if pathFilter != "" {
-		where = append(where, "path LIKE ?")
-		args = append(args, "%"+pathFilter+"%")
+		// LOWER() on both sides: SQLite LIKE is ASCII case-insensitive but
+		// Postgres LIKE is not — keep the filter parity across dialects.
+		where = append(where, "LOWER(path) LIKE ?")
+		args = append(args, "%"+strings.ToLower(pathFilter)+"%")
 	}
 
 	var total int

--- a/handler/admin/downstream_pricing_routes_test.go
+++ b/handler/admin/downstream_pricing_routes_test.go
@@ -1,0 +1,41 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Regression for the double-prefix routing bug: RegisterDownstreamPricingRoutes
+// registered absolute "/v1/..." paths while production mounts it inside the
+// router group at /v1, so the documented GET /v1/pricing 404'd and only
+// /v1/v1/pricing reached the handler (an unauthenticated probe could not see
+// this: group middleware answers 401 before matching). Paths must be relative
+// to the mount group.
+func TestRegisterDownstreamPricingRoutes_MountsUnderV1(t *testing.T) {
+	db := setupBackupTestDB(t)
+
+	r := chi.NewRouter()
+	r.Route("/v1", func(r chi.Router) {
+		RegisterDownstreamPricingRoutes(r, db.DB)
+	})
+
+	for _, path := range []string{"/v1/pricing", "/v1/models/price-compare"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		r.ServeHTTP(rec, req)
+		if rec.Code == http.StatusNotFound {
+			t.Fatalf("%s status = 404: route unreachable (double-prefix regression)", path)
+		}
+	}
+
+	// The doubled prefix must no longer resolve.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/v1/pricing", nil)
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("/v1/v1/pricing status = %d, want 404", rec.Code)
+	}
+}

--- a/handler/admin/stats.go
+++ b/handler/admin/stats.go
@@ -71,8 +71,10 @@ func RegisterStatsRoutes(r chi.Router, db *sqlx.DB) {
 // Mounted under /v1/* so it inherits ProxyAuth + CORS from the /v1 route group.
 func RegisterDownstreamPricingRoutes(r chi.Router, db *sqlx.DB) {
 	handler := &statsHandler{db: db}
-	r.Get("/v1/pricing", handler.modelPriceCompare)
-	r.Get("/v1/models/price-compare", handler.modelPriceCompare)
+	// Paths are relative: this router is mounted inside r.Route("/v1", ...),
+	// so absolute "/v1/..." here would double the prefix.
+	r.Get("/pricing", handler.modelPriceCompare)
+	r.Get("/models/price-compare", handler.modelPriceCompare)
 }
 
 type statsHandler struct {

--- a/handler/proxy/surface.go
+++ b/handler/proxy/surface.go
@@ -203,11 +203,14 @@ func isStreamFromBody(body map[string]any) bool {
 	return false
 }
 
-// writeSSEHeaders sets SSE response headers.
+// writeSSEHeaders sets SSE response headers. X-Accel-Buffering disables
+// response buffering in nginx-style reverse proxies so first tokens are not
+// held in proxy buffers (new-api and sub2api set the same header).
 func writeSSEHeaders(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
 }
 
 // sseEvent formats an SSE data event.

--- a/service/catalogsync/catalogsync_test.go
+++ b/service/catalogsync/catalogsync_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -265,4 +267,44 @@ func TestManager_SyncAllAndSingleSourceMerge(t *testing.T) {
 	if status2.AutoSync {
 		t.Error("autoSync toggle not restored after rebuild")
 	}
+}
+
+// TestStore_CreateSource_PostgresInsertID pins the PG branch of CreateSource:
+// pgx's stdlib driver does not implement LastInsertId, so the id must come
+// from a RETURNING clause. Without PG_TEST_DSN this skips (CI integration job
+// supplies the DSN).
+func TestStore_CreateSource_PostgresInsertID(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("PG_TEST_DSN"))
+	if dsn == "" {
+		t.Skip("PG_TEST_DSN not set; skipping PostgreSQL integration test")
+	}
+	db, err := store.Open(store.DialectPostgres, dsn, false)
+	if err != nil {
+		t.Fatalf("open pg: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	s := NewStore(db.DB)
+	ctx := context.Background()
+	enabled := true
+	src, err := s.CreateSource(ctx, SourceInput{
+		Name:    "pg-returning-id-test",
+		URL:     "https://example.com/models.json",
+		Enabled: &enabled,
+		Type:    SourceTypeCustom,
+	})
+	if err != nil {
+		t.Fatalf("CreateSource on PG: %v", err)
+	}
+	if src.ID <= 0 {
+		t.Fatalf("CreateSource returned id = %d, want > 0", src.ID)
+	}
+	t.Cleanup(func() {
+		if _, err := db.Exec(db.Rebind("DELETE FROM catalog_sources WHERE id = ?"), src.ID); err != nil {
+			t.Logf("cleanup source %d: %v", src.ID, err)
+		}
+	})
 }

--- a/service/catalogsync/store.go
+++ b/service/catalogsync/store.go
@@ -203,16 +203,28 @@ func (s *Store) CreateSource(ctx context.Context, in SourceInput) (Source, error
 	}
 	order := maxOrder + 1
 
-	result, err := s.db.ExecContext(ctx, s.db.Rebind(
+	query := s.db.Rebind(
 		`INSERT INTO catalog_sources (name, url, enabled, type, sort_order, last_count, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, 0, ?, ?)`),
-		strings.TrimSpace(in.Name), strings.TrimSpace(in.URL), enabled, in.Type, order, now, now)
-	if err != nil {
-		return Source{}, fmt.Errorf("catalogsync: create source: %w", err)
-	}
-	id, err := result.LastInsertId()
-	if err != nil {
-		return Source{}, fmt.Errorf("catalogsync: create source id: %w", err)
+		 VALUES (?, ?, ?, ?, ?, 0, ?, ?)`)
+	args := []any{strings.TrimSpace(in.Name), strings.TrimSpace(in.URL), enabled, in.Type, order, now, now}
+
+	// pgx's stdlib driver does not implement LastInsertId; use RETURNING on
+	// Postgres (same split as handler/admin/token_routes.go execInsertID).
+	var id int64
+	if s.db.DriverName() == "pgx" {
+		if err := s.db.QueryRowxContext(ctx, query+" RETURNING id", args...).Scan(&id); err != nil {
+			return Source{}, fmt.Errorf("catalogsync: create source id: %w", err)
+		}
+	} else {
+		result, err := s.db.ExecContext(ctx, query, args...)
+		if err != nil {
+			return Source{}, fmt.Errorf("catalogsync: create source: %w", err)
+		}
+		insertedID, err := result.LastInsertId()
+		if err != nil {
+			return Source{}, fmt.Errorf("catalogsync: create source id: %w", err)
+		}
+		id = insertedID
 	}
 	return s.getSource(ctx, id)
 }


### PR DESCRIPTION
Five small independent fixes surfaced by the parallel domain audits (product, API/network, database). No behavior change beyond the fixes themselves.

## 1. `/v1/pricing` double-prefix routing bug
`RegisterDownstreamPricingRoutes` registered **absolute** `/v1/...` paths while production mounts it inside the `/v1` route group — so the documented `GET /v1/pricing` answered 404 and only `/v1/v1/pricing` reached the handler. The existing router test couldn't catch it (group middleware answers 401 before matching). Paths are now relative; a new mount-shape regression test pins both routes and asserts the doubled prefix is gone.

## 2. `catalogsync.CreateSource` always failed on Postgres
`result.LastInsertId()` is unimplemented by pgx's stdlib driver → creating a model-catalog source errored on every PG deployment (SQLite-only tests missed it). Added the `RETURNING id` dialect branch (same split as `execInsertID` elsewhere) + a `PG_TEST_DSN`-gated integration test that runs in the CI PG job.

## 3. SSE responses lacked `X-Accel-Buffering: no`
Behind nginx-style reverse proxies, first tokens were held in proxy buffers. new-api and sub2api both set this header; now we do too (`writeSSEHeaders`).

## 4. Audit-log path filter dialect parity
`path LIKE ?` is ASCII case-insensitive on SQLite but case-sensitive on Postgres. Now `LOWER(path) LIKE ?` with a lowercased argument — same pattern as the rest of the repo's LIKE filters.

## 5. Default SSE stream cap 1MB → 64MB
`PROXY_MAX_STREAM_RESPONSE_BYTES` defaulted to 1MB — reasoning-model and long-code streams routinely exceed that and were cut mid-answer with a custom error event most SDKs silently swallow (stream just "ends"). The cap remains a runaway guard at 64MB; `.env.example` + `docs/configuration.md` updated.

## Verification (local, rebased on master)
- `go build ./...` + `go vet ./...` green
- Full `go test ./...` green (43 pkgs, exit 0); targeted re-run post-rebase green (handler/admin 35s, catalogsync, config, router)