### PR TITLE
feat(store): sc2_029 — auto-normalize TS-era timestamps on takeover

### DIFF
--- a/store/additive.go
+++ b/store/additive.go
@@ -448,6 +448,27 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 			return EnsureColumn(db, "events", "params", "TEXT", "TEXT", "")
 		},
 	},
+	{
+		// TS takeover hygiene: drizzle datetime('now') wrote
+		// 'YYYY-MM-DD HH:MM:SS' while Go writes RFC3339 UTC. Mixed shapes in
+		// the same TEXT column break every lexicographic comparison (space
+		// sorts before 'T'), so TS-era rows read as older than they are —
+		// ORDER BY listings skew and the checkin sweep re-checkins every
+		// TS-era account on first Go boot. One-shot in-place rewrite to
+		// RFC3339; idempotent (see ts_timestamp_normalize.go).
+		Version:     "sc2_029_ts_timestamp_normalization",
+		Description: "rewrite TS-era 'YYYY-MM-DD HH:MM:SS' values in TEXT *_at/*_until columns to RFC3339 UTC ('...T...Z') so lexicographic ordering and range comparisons agree across takeover rows",
+		Apply: func(db *DB) error {
+			n, err := normalizeLegacyTimestamps(db)
+			if err != nil {
+				return err
+			}
+			if n > 0 {
+				slog.Info("store: normalized legacy TS timestamps", "rows", n, "dialect", db.Dialect)
+			}
+			return nil
+		},
+	},
 }
 
 // schemaMigrationsDDL creates the version bookkeeping table.

--- a/store/ts_timestamp_normalize.go
+++ b/store/ts_timestamp_normalize.go
@@ -1,0 +1,186 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TS-era datetime normalization (sc2_029).
+//
+// The TypeScript implementation (drizzle datetime('now')) wrote timestamps as
+// 'YYYY-MM-DD HH:MM:SS' (space separator, no zone marker) while the Go
+// implementation writes RFC3339 UTC ('YYYY-MM-DDTHH:MM:SSZ'). A takeover
+// database carries both shapes in the same TEXT columns, and every
+// lexicographic comparison the Go code makes is skewed by the mix: a space
+// (0x20) sorts before 'T' (0x54), so TS-era rows always compare as older
+// than Go-era rows regardless of their real dates. That distorts
+// ORDER BY created_at listings and created_at >= ? range filters, and the
+// checkin sweep (last_checkin_at < cutoff) treats every TS-era account as
+// expired on first Go boot — a burst of re-checkins against upstreams.
+//
+// normalizeLegacyTimestamps rewrites TS-shaped values in place:
+//
+//	'YYYY-MM-DD HH:MM:SS[.fff]'  ->  'YYYY-MM-DDTHH:MM:SS[.fff]Z'
+//
+// drizzle wrote these values in UTC, so appending 'Z' is a faithful
+// conversion. Values already containing 'T' (Go rows), NULLs, and
+// non-matching shapes are untouched. Re-runs match zero rows (idempotent).
+//
+// Candidate columns are discovered by schema introspection — every TEXT
+// column whose name follows the *_at / *_until convention, in every user
+// table — so TS-takeover schemas get the same treatment for columns the Go
+// DDL never declares. On Postgres, columns with a native timestamp type are
+// skipped: they compare chronologically already.
+
+// legacyTimestampPattern matches 'YYYY-MM-DD HH:MM:SS' with any fractional
+// part; the _ wildcards pin the shape without constraining digits.
+const legacyTimestampPattern = "____-__-__ __:__:__%"
+
+type tableColumn struct {
+	table  string
+	column string
+}
+
+// isTimestampColumnName reports whether a column name follows the repo-wide
+// timestamp convention (created_at, last_checkin_at, cooldown_until, ...).
+func isTimestampColumnName(name string) bool {
+	return strings.HasSuffix(name, "_at") || strings.HasSuffix(name, "_until")
+}
+
+// quoteIdentTSNorm double-quotes an identifier after validating it is
+// alphanumeric/underscore. Names come from schema introspection, never from
+// user input, but the validation keeps the fmt-built SQL injection-proof.
+func quoteIdentTSNorm(name string) (string, bool) {
+	if name == "" {
+		return "", false
+	}
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+			continue
+		}
+		return "", false
+	}
+	return `"` + name + `"`, true
+}
+
+// legacyTimestampColumns lists (table, column) candidates for normalization.
+func legacyTimestampColumns(db *DB) ([]tableColumn, error) {
+	var out []tableColumn
+
+	if db.Dialect == DialectPostgres {
+		rows, err := db.Query(`
+			SELECT table_name, column_name
+			FROM information_schema.columns
+			WHERE table_schema = current_schema()
+			  AND data_type = 'text'
+			  AND table_name <> 'schema_migrations'
+			ORDER BY table_name, ordinal_position`)
+		if err != nil {
+			return nil, fmt.Errorf("store: list pg columns: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var table, column string
+			if err := rows.Scan(&table, &column); err != nil {
+				return nil, fmt.Errorf("store: scan pg column: %w", err)
+			}
+			if isTimestampColumnName(column) {
+				out = append(out, tableColumn{table: table, column: column})
+			}
+		}
+		return out, rows.Err()
+	}
+
+	// SQLite: every user table, then PRAGMA table_info for TEXT-affinity
+	// columns. Declared types in the wild include TEXT, '', 'datetime'
+	// (drizzle) — all TEXT affinity. INTEGER/REAL/BLOB/NUMERIC are skipped.
+	tableRows, err := db.Query(
+		`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name <> 'schema_migrations'`)
+	if err != nil {
+		return nil, fmt.Errorf("store: list sqlite tables: %w", err)
+	}
+	var tables []string
+	for tableRows.Next() {
+		var name string
+		if err := tableRows.Scan(&name); err != nil {
+			tableRows.Close()
+			return nil, fmt.Errorf("store: scan sqlite table: %w", err)
+		}
+		tables = append(tables, name)
+	}
+	if err := tableRows.Err(); err != nil {
+		tableRows.Close()
+		return nil, err
+	}
+	tableRows.Close()
+
+	for _, table := range tables {
+		quoted, ok := quoteIdentTSNorm(table)
+		if !ok {
+			continue
+		}
+		colRows, err := db.Query(fmt.Sprintf(`PRAGMA table_info(%s)`, quoted))
+		if err != nil {
+			return nil, fmt.Errorf("store: table_info(%s): %w", table, err)
+		}
+		for colRows.Next() {
+			var cid, notNull, pk int
+			var name, colType string
+			var dflt *string
+			if err := colRows.Scan(&cid, &name, &colType, &notNull, &dflt, &pk); err != nil {
+				colRows.Close()
+				return nil, fmt.Errorf("store: table_info(%s) scan: %w", table, err)
+			}
+			if !isTimestampColumnName(name) {
+				continue
+			}
+			upper := strings.ToUpper(strings.TrimSpace(colType))
+			switch {
+			case upper == "", upper == "TEXT",
+				strings.Contains(upper, "CHAR"),
+				strings.Contains(upper, "TEXT"),
+				strings.Contains(upper, "DATE"),
+				strings.Contains(upper, "TIME"):
+				out = append(out, tableColumn{table: table, column: name})
+			}
+		}
+		if err := colRows.Err(); err != nil {
+			colRows.Close()
+			return nil, err
+		}
+		colRows.Close()
+	}
+	return out, nil
+}
+
+// normalizeLegacyTimestamps rewrites every TS-shaped timestamp value and
+// returns the number of rows changed.
+func normalizeLegacyTimestamps(db *DB) (int64, error) {
+	candidates, err := legacyTimestampColumns(db)
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for _, tc := range candidates {
+		quotedTable, ok := quoteIdentTSNorm(tc.table)
+		if !ok {
+			continue
+		}
+		quotedColumn, ok := quoteIdentTSNorm(tc.column)
+		if !ok {
+			continue
+		}
+		// Both dialects implement replace() and || with the same semantics.
+		query := fmt.Sprintf(
+			`UPDATE %s SET %s = replace(%s, ' ', 'T') || 'Z' WHERE %s LIKE ?`,
+			quotedTable, quotedColumn, quotedColumn, quotedColumn)
+		result, err := db.Exec(db.Rebind(query), legacyTimestampPattern)
+		if err != nil {
+			return total, fmt.Errorf("store: normalize %s.%s: %w", tc.table, tc.column, err)
+		}
+		if n, err := result.RowsAffected(); err == nil {
+			total += n
+		}
+	}
+	return total, nil
+}

--- a/store/ts_timestamp_normalize_test.go
+++ b/store/ts_timestamp_normalize_test.go
@@ -1,0 +1,173 @@
+package store
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestNormalizeLegacyTimestamps_SQLite seeds TS-shaped (drizzle
+// datetime('now')) values next to Go-shaped RFC3339 values in real takeover
+// columns and verifies the sc2_029 rewrite: TS rows convert, Go rows stay,
+// NULLs stay, re-runs are no-ops, and mixed-shape ordering becomes
+// chronologically correct.
+func TestNormalizeLegacyTimestamps_SQLite(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+
+	// TS-era site: created_at/updated_at in drizzle shape.
+	if _, err := db.Exec(`INSERT INTO sites (id, name, url, platform, status, created_at, updated_at)
+		VALUES (1, 'ts-site', 'https://ts.example.com', 'openai', 'active', '2026-08-20 12:31:20', '2026-08-21 09:00:00')`); err != nil {
+		t.Fatalf("seed ts site: %v", err)
+	}
+	// Go-era site created AFTER the TS one in real time: RFC3339 shape.
+	if _, err := db.Exec(`INSERT INTO sites (id, name, url, platform, status, created_at, updated_at)
+		VALUES (2, 'go-site', 'https://go.example.com', 'openai', 'active', '2026-09-01T08:00:00Z', '2026-09-01T08:00:00Z')`); err != nil {
+		t.Fatalf("seed go site: %v", err)
+	}
+	// TS-era account with a drizzle-shaped last_checkin_at plus a NULL column.
+	if _, err := db.Exec(`INSERT INTO accounts (id, site_id, username, access_token, status, created_at, updated_at, last_checkin_at)
+		VALUES (1, 1, 'ts-acct', 'tok', 'active', '2026-08-20 12:31:21', '2026-08-20 12:31:21', '2026-08-30 23:59:59')`); err != nil {
+		t.Fatalf("seed ts account: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO accounts (id, site_id, username, access_token, status, created_at, updated_at)
+		VALUES (2, 1, 'go-acct', 'tok2', 'active', '2026-09-01T08:00:01Z', '2026-09-01T08:00:01Z')`); err != nil {
+		t.Fatalf("seed go account: %v", err)
+	}
+	// Fractional-seconds variant (some drizzle paths wrote .SSS).
+	if _, err := db.Exec(`INSERT INTO sites (id, name, url, platform, status, created_at, updated_at)
+		VALUES (3, 'ts-frac', 'https://frac.example.com', 'openai', 'active', '2026-08-20 12:31:20.500', '2026-08-20 12:31:20.500')`); err != nil {
+		t.Fatalf("seed frac site: %v", err)
+	}
+
+	changed, err := normalizeLegacyTimestamps(db)
+	if err != nil {
+		t.Fatalf("normalizeLegacyTimestamps: %v", err)
+	}
+	// Row-updates: sites.created_at (id 1,3) + sites.updated_at (id 1,3) = 4,
+	// accounts.created_at + updated_at + last_checkin_at (id 1) = 3.
+	if changed != 7 {
+		t.Fatalf("changed = %d, want 7", changed)
+	}
+
+	var got string
+	mustGet := func(query string, args ...any) string {
+		t.Helper()
+		if err := db.QueryRow(db.Rebind(query), args...).Scan(&got); err != nil {
+			t.Fatalf("query %q: %v", query, err)
+		}
+		return got
+	}
+
+	if v := mustGet(`SELECT created_at FROM sites WHERE id = 1`); v != "2026-08-20T12:31:20Z" {
+		t.Errorf("ts site created_at = %q, want RFC3339", v)
+	}
+	if v := mustGet(`SELECT updated_at FROM sites WHERE id = 1`); v != "2026-08-21T09:00:00Z" {
+		t.Errorf("ts site updated_at = %q, want RFC3339", v)
+	}
+	if v := mustGet(`SELECT created_at FROM sites WHERE id = 2`); v != "2026-09-01T08:00:00Z" {
+		t.Errorf("go site created_at = %q, must stay untouched", v)
+	}
+	if v := mustGet(`SELECT created_at FROM sites WHERE id = 3`); v != "2026-08-20T12:31:20.500Z" {
+		t.Errorf("frac site created_at = %q, want RFC3339 with millis", v)
+	}
+	if v := mustGet(`SELECT last_checkin_at FROM accounts WHERE id = 1`); v != "2026-08-30T23:59:59Z" {
+		t.Errorf("ts account last_checkin_at = %q, want RFC3339", v)
+	}
+	if v := mustGet(`SELECT COALESCE(last_checkin_at, 'NULL') FROM accounts WHERE id = 2`); v != "NULL" {
+		t.Errorf("go account last_checkin_at = %q, NULL must stay NULL", v)
+	}
+
+	// Ordering: the Go-era site is newer in real time; DESC must list it
+	// first now that both rows speak RFC3339 (before normalization the space
+	// separator sorted TS rows first regardless of date).
+	rows, err := db.Query(`SELECT name FROM sites ORDER BY created_at DESC LIMIT 2`)
+	if err != nil {
+		t.Fatalf("order query: %v", err)
+	}
+	defer rows.Close()
+	var order []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		order = append(order, name)
+	}
+	if len(order) != 2 || order[0] != "go-site" {
+		t.Errorf("ORDER BY created_at DESC = %v, want go-site first", order)
+	}
+
+	// Idempotent: a second pass rewrites nothing.
+	changed2, err := normalizeLegacyTimestamps(db)
+	if err != nil {
+		t.Fatalf("second normalize: %v", err)
+	}
+	if changed2 != 0 {
+		t.Errorf("second pass changed %d rows, want 0", changed2)
+	}
+}
+
+// TestNormalizeLegacyTimestamps_StepRegistered pins the step into the
+// production registry so a fresh AutoMigrate applies and books it.
+func TestNormalizeLegacyTimestamps_StepRegistered(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	var n int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM schema_migrations WHERE version = 'sc2_029_ts_timestamp_normalization'`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("sc2_029 bookkeeping rows = %d, want 1", n)
+	}
+}
+
+// TestNormalizeLegacyTimestamps_Postgres exercises the PG introspection path
+// (information_schema + text-type filter). Gated like the other PG tests.
+func TestNormalizeLegacyTimestamps_Postgres(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("PG_TEST_DSN"))
+	if dsn == "" {
+		t.Skip("PG_TEST_DSN not set; skipping PostgreSQL integration test")
+	}
+	db, err := Open(DialectPostgres, dsn, false)
+	if err != nil {
+		t.Fatalf("Open pg: %v", err)
+	}
+	defer db.Close()
+	if err := AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	if _, err := db.Exec(db.Rebind(`INSERT INTO sites (id, name, url, platform, status, created_at, updated_at)
+		VALUES (990001, 'ts-pg', 'https://ts-pg.example.com', 'openai', 'active', '2026-08-20 12:31:20', '2026-08-20 12:31:20')`)); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	defer func() {
+		if _, err := db.Exec(db.Rebind(`DELETE FROM sites WHERE id = 990001`)); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	}()
+
+	if _, err := normalizeLegacyTimestamps(db); err != nil {
+		t.Fatalf("normalizeLegacyTimestamps pg: %v", err)
+	}
+	var got string
+	if err := db.QueryRow(db.Rebind(`SELECT created_at FROM sites WHERE id = 990001`)).Scan(&got); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if got != "2026-08-20T12:31:20Z" {
+		t.Errorf("pg created_at = %q, want RFC3339", got)
+	}
+}


### PR DESCRIPTION
## Why

The TS→Go takeover story works (golden-fixture + PG batch verified), but the two generations write **different timestamp shapes into the same TEXT columns**:

- TS (drizzle `datetime('now')`): `2026-08-20 12:31:20` — space separator, no zone marker
- Go: `2026-09-01T08:00:00Z` — RFC3339 UTC

Every lexicographic comparison the Go code makes is skewed by the mix (space 0x20 sorts before 'T' 0x54), so **TS-era rows always read as older than Go-era rows regardless of real dates**:

- `ORDER BY created_at DESC` listings interleave wrongly
- `created_at >= ?` range filters distort at boundaries
- the checkin sweep (`last_checkin_at < cutoff`) flags **every** TS-era account as expired on first Go boot → a re-checkin burst against upstreams

Found by the database/migration domain audit (P2 #2).

## What

New additive step **`sc2_029_ts_timestamp_normalization`` rewrites TS-shaped values in place:

```
'YYYY-MM-DD HH:MM:SS[.fff]'  ->  'YYYY-MM-DDTHH:MM:SS[.fff]Z'
```

drizzle wrote UTC, so appending `Z` is a faithful conversion; fractional seconds are preserved.

Design:
- **Introspection-driven**: every TEXT column named `*_at` / `*_until` in every user table — takeover schemas get columns normalized that the Go DDL never declares. No hardcoded table list to drift.
- **Postgres-safe**: only `data_type='text'` columns are touched; native `timestamp` columns compare chronologically already and are skipped.
- **Idempotent**: Go-era values (contain 'T'), NULLs and non-matching shapes are untouched; re-runs match zero rows; the `schema_migrations` ledger books the step once.
- **Fresh installs**: no-op pass.

## Tests

- SQLite seed test: TS/Go/NULL/fractional rows across `sites` + `accounts` → rewrite assertions, `ORDER BY created_at DESC` chronologically correct after normalization, second pass changes 0 rows.
- Registry booking test (`sc2_029` appears in `schema_migrations` exactly once after AutoMigrate).
- `PG_TEST_DSN`-gated PG introspection test (runs in the CI PG job).
- The existing **TestTSTakeoverAutoMigrate** golden-fixture suite (real TS `hub.db`, copied to tmp — fixture untouched) passes with the step live.
- Full local `go test ./...` green (43 pkgs, exit 0).