### PR TITLE
fix(proxy): /v1 contract trio — write budget, header policy, data-plane dial guard

### DIFF
--- a/app/proxy_upstream.go
+++ b/app/proxy_upstream.go
@@ -40,14 +40,11 @@ func ConfigureProxyUpstream(cfg *config.Config) error {
 	// applied per attempt in handler/proxy sendUpstreamRequest.
 	// Keep client timeout at least as large as the first-byte window so the
 	// client does not pre-empt first-byte observation.
-	requestTimeout := 90 * time.Second
-	if firstByteMs := proxy.FirstByteTimeoutMs(config.Runtime().ProxyFirstByteTimeoutSec); firstByteMs > 0 {
-		fb := time.Duration(firstByteMs) * time.Millisecond
-		// Ceiling: max(90s, first-byte*2) so multi-endpoint fallback can still complete.
-		if doubled := fb * 2; doubled > requestTimeout {
-			requestTimeout = doubled
-		}
-	}
+	// Ceiling: max(90s, first-byte*2) so multi-endpoint fallback can still
+	// complete. proxy.RequestCeiling is the SSOT — router.ProxyWriteDeadline
+	// derives the server-side write budget from it so the write side can never
+	// invert the request side again.
+	requestTimeout := proxy.RequestCeiling(config.Runtime().ProxyFirstByteTimeoutSec)
 	auth.ConfigureSharedAdmissionFromRedisURL(cfg.RedisURL)
 
 	routingStore := service.NewProxyRoutingStore(db)
@@ -142,8 +139,8 @@ func ShutdownProxyLogBatchWriter(ctx context.Context) error {
 }
 
 var (
-	pricingCatalogMu       sync.Mutex
-	pricingCatalogManager  *catalogsync.Manager
+	pricingCatalogMu      sync.Mutex
+	pricingCatalogManager *catalogsync.Manager
 )
 
 // pricingCatalogResolver returns the process-global model-catalog manager

--- a/docs/api/conventions.md
+++ b/docs/api/conventions.md
@@ -155,6 +155,34 @@ The `/monitor-proxy/ldoh/*` admin surface proxies an upstream LDOH dashboard. Th
 
 **Error leakage**: Upstream request failures return a generic `"LDOH upstream request failed"` message to the browser. The full error (DNS/TLS/network details) is logged server-side via `slog` only, preventing upstream topology leakage to end users.
 
+### Site upstream SSRF hardening (proxy data plane)
+
+Site URLs are operator input, so they are guarded at two layers:
+
+1. **URL validation** on every write path — single-site create/update, bulk site
+   import, and both backup import formats (`IsForbiddenSiteTargetURL` /
+   `SanitizeImportedSiteRows`, applied to `url`, `externalCheckinUrl`,
+   `proxyUrl`, and every `site_api_endpoints.url`). Import preview uses the same
+   rule as the import itself, and rejected rows are reported explicitly instead
+   of being dropped silently.
+2. **Dial-time guard** on the data plane (`internal/ssrf.NewSiteDialContext`,
+   enabled through `httpclient.Options.SiteDialGuard` on the proxy executor,
+   the SSE stream transport, the fallback dispatch clients, and the channel
+   health probe transport). The hostname is resolved exactly once, every answer
+   is checked, and the connection is pinned to an already-validated IP — so a
+   hostname that passes validation and then re-resolves (DNS rebinding) cannot
+   reach a different address. Cross-origin and HTTPS→HTTP redirects are refused
+   separately by the shared redirect policy.
+
+Blocked: cloud metadata endpoints (`169.254.169.254`, `100.100.100.200`,
+`fd00:ec2::254`, and the `metadata` / `metadata.google.internal` aliases),
+link-local, multicast, and unspecified/reserved ranges.
+
+Deliberately allowed: loopback, RFC 1918, and IPv6 ULA. Self-hosted upstreams
+(a local new-api, one-api, sub2api, or LiteLLM gateway) are a first-class
+Metapi deployment shape, so the guard blocks metadata exfiltration without
+blocking operator infrastructure.
+
 ### WebDAV backup SSRF hardening
 
 WebDAV import/export URLs (`fileUrl`) are validated against SSRF at two layers:

--- a/docs/api/proxy.md
+++ b/docs/api/proxy.md
@@ -37,6 +37,72 @@ documented in [conventions.md](conventions.md); the two contracts never mix
 
 ---
 
+## Header policy (/v1 surface)
+
+The data plane rebuilds the upstream request instead of tunnelling the client
+request, so headers cross the proxy in both directions only by explicit policy.
+
+**Client → upstream (allow-list, fill-only).** Applied in this precedence order,
+lowest to highest:
+
+1. Allow-listed client protocol headers — `anthropic-version`, `anthropic-beta`,
+   `openai-beta`, `user-agent`, and the `x-stainless-*` SDK telemetry namespace.
+   Multi-value headers (e.g. several `anthropic-beta` flags) keep every value.
+2. Site `custom_headers` and the per-site anti-bot identity (`cf_clearance`,
+   browser UA override). Because step 1 is fill-only, a site-level value always
+   wins over the client's.
+3. The selected account token as `Authorization: Bearer …`. A client can never
+   override it.
+
+Credential-bearing client headers are never forwarded: `authorization`,
+`x-api-key`, `cookie`, `proxy-*`, hop-by-hop headers, and `x-forwarded-*`. The
+downstream key stays a Metapi secret and never reaches the upstream.
+
+Anthropic-native dispatch (`/v1/messages`, including the `/anthropic/v1/messages`
+gateway shape) requires `anthropic-version`; when the client does not send one
+the API default is used, so an OpenAI-surface request transformed into the
+Anthropic shape does not fail upstream validation.
+
+**Upstream → client (allow-list).** Buffered (non-SSE) responses relay only
+content-semantic headers: `Content-Type`, `Content-Disposition`,
+`Content-Encoding`, `Content-Language`, `Content-Range`, `Accept-Ranges`,
+`Cache-Control`, `ETag`, `Last-Modified`, `Location`, `Retry-After`.
+
+Everything else is dropped, which keeps the upstream's identity and state from
+leaking through Metapi: vendor fingerprint headers (`X-New-Api-Version` and
+similar), `Server` / `Via` / `X-Powered-By` / `Cf-Ray`, upstream `Set-Cookie`,
+framing headers (net/http re-frames the buffered body), and upstream
+`X-Request-Id` — Metapi's own request id stays authoritative so a client-side
+report can be correlated with the proxy log. Upstream rate-limit headers are
+dropped for the same reason: the only `X-Ratelimit-*` a client sees describes
+its Metapi key/IP budget.
+
+SSE responses are always re-framed by Metapi (`text/event-stream`,
+`Cache-Control: no-cache`, `X-Accel-Buffering: no`) and carry no upstream
+headers at all.
+
+## Timeouts (/v1 surface)
+
+| Phase | Control | Default |
+|---|---|---|
+| Request header read | `Server.ReadHeaderTimeout` | 10s |
+| Whole request (admin surface) | `Server.ReadTimeout` / `WriteTimeout` | 30s / 60s |
+| Upstream connect / TLS | transport dial + handshake | 30s / 10s |
+| Upstream first byte (observed) | `PROXY_FIRST_BYTE_TIMEOUT_SEC` | 0 = off |
+| Whole upstream request (buffered) | executor ceiling `max(90s, first-byte × 2)` | 90s |
+| Response write (proxy surface) | write budget = executor ceiling + 2m | 210s |
+| Stream chunk gap | `PROXY_STREAM_IDLE_TIMEOUT_SEC` | see `.env.example` |
+
+The proxy surface re-arms its own write deadline (`router.ProxyWriteDeadline`)
+from the same source of truth as the executor ceiling, so the write side can
+never be shorter than the request side: a buffered response that takes 61–90s
+upstream is delivered instead of being cut mid-write. Admin routes keep the
+strict 60s `WriteTimeout`.
+
+Streaming responses are not bounded by total elapsed time at all — the relay
+clears the write deadline and enforces liveness per chunk with the idle guard,
+so a long reasoning-model stream stays alive as long as chunks keep arriving.
+
 ## Proxy files (`/v1/files`)
 
 OpenAI-compatible Files surface (proxy auth required). Forwards to the selected upstream channel; does not persist customer file bytes on Metapi disk.

--- a/handler/proxy/channel_health_probe.go
+++ b/handler/proxy/channel_health_probe.go
@@ -319,7 +319,9 @@ func (p *ChannelHealthProbeExecutor) executeChatProbe(ctx context.Context, targe
 // that run without an injected transport or site proxy config. The deadline
 // is owned by the caller context (probe timeout is operator-tunable with no
 // fixed ceiling), so the response-header phase stays unbounded here.
-var probeFallbackTransport = httpclient.NewTransport(httpclient.Options{})
+// probeFallbackTransport dials operator-configured site URLs, so it carries the
+// same data-plane SSRF dial guard as the proxy executor transports.
+var probeFallbackTransport = httpclient.NewTransport(httpclient.Options{SiteDialGuard: true})
 
 func (p *ChannelHealthProbeExecutor) doRequest(ctx context.Context, req *http.Request, proxyCfg *platform.ProxyConfig) (*http.Response, error) {
 	if p.transport != nil {

--- a/handler/proxy/headers.go
+++ b/handler/proxy/headers.go
@@ -1,0 +1,126 @@
+package proxyhandler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/deliciousbuding/metapi-go/platform"
+	"github.com/deliciousbuding/metapi-go/proxy"
+)
+
+// clientProtocolHeaders are the downstream client headers that carry protocol
+// semantics for the upstream. The data plane builds a fresh upstream request
+// (Content-Type + site custom_headers + the selected account token), so without
+// this whitelist every client-side protocol switch was silently dropped —
+// Claude Code's anthropic-beta feature flags and OpenAI's openai-beta among
+// them, which made those clients degrade to baseline behavior.
+//
+// Applied fill-only (see applyClientProtocolHeaders): a site's custom_headers
+// and its anti-bot identity always win, and the selected token is set after
+// this call so a client can never override it. Auth-bearing client headers
+// (authorization, x-api-key, cookie) are deliberately absent — a downstream key
+// must never reach the upstream.
+var clientProtocolHeaders = []string{
+	"anthropic-version",
+	"anthropic-beta",
+	"openai-beta",
+	"user-agent",
+}
+
+// clientProtocolHeaderPrefixes forwards whole SDK telemetry namespaces that are
+// safe to pass verbatim and let upstreams attribute traffic (the stainless
+// headers every official OpenAI/Anthropic SDK sends: lang, package-version, os,
+// arch, runtime, retry-count, ...).
+var clientProtocolHeaderPrefixes = []string{"x-stainless-"}
+
+// applyClientProtocolHeaders copies the whitelisted client headers onto the
+// upstream request without overriding anything the site configuration already
+// put there. upstreamPath drives the Anthropic-native default below.
+func applyClientProtocolHeaders(req *http.Request, client http.Header, upstreamPath string) {
+	if req == nil || len(client) == 0 {
+		return
+	}
+	for _, name := range clientProtocolHeaders {
+		copyHeaderIfAbsent(req.Header, client, name)
+	}
+	// Prefix namespaces arrive with arbitrary suffixes, so they are matched on
+	// the canonical keys the client actually sent.
+	for canonical, values := range client {
+		if len(values) == 0 || !isClientProtocolPrefix(canonical) {
+			continue
+		}
+		copyHeaderIfAbsent(req.Header, client, canonical)
+	}
+	// Anthropic-native upstreams reject /v1/messages without anthropic-version.
+	// Clients that never send it (an OpenAI-surface request transformed into the
+	// Anthropic shape, curl, homegrown SDKs) get the same default the platform
+	// adapters use.
+	if endpoint, ok := proxy.EndpointFromPath(upstreamPath); ok && endpoint == proxy.EndpointMessages {
+		if req.Header.Get("anthropic-version") == "" {
+			req.Header.Set("anthropic-version", platform.ClaudeDefaultAnthropicVersion)
+		}
+	}
+}
+
+func isClientProtocolPrefix(canonical string) bool {
+	lower := strings.ToLower(canonical)
+	for _, prefix := range clientProtocolHeaderPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// copyHeaderIfAbsent copies every value of name from src to dst, keeping dst's
+// existing values untouched (fill-only precedence).
+func copyHeaderIfAbsent(dst http.Header, src http.Header, name string) {
+	canonical := http.CanonicalHeaderKey(name)
+	values := src.Values(name)
+	if len(values) == 0 || len(dst.Values(canonical)) > 0 {
+		return
+	}
+	dst[canonical] = append([]string(nil), values...)
+}
+
+// upstreamResponseHeaders is the whitelist of upstream response headers relayed
+// to the downstream client on buffered (non-SSE) responses.
+//
+// The relay used to copy every upstream header, which leaked the upstream's
+// identity and state into our response: vendor fingerprint headers
+// (X-New-Api-Version and friends, observable through metapi), Set-Cookie from
+// the upstream's own session, and an upstream X-Request-Id that clobbered ours
+// and broke cross-layer log correlation.
+//
+// Rate-limit headers are deliberately excluded so the only X-Ratelimit-* a
+// client sees is Metapi's own, and framing/hop-by-hop headers stay out because
+// the buffered body is re-framed by net/http. The SSE relay keeps its own
+// policy (writeSSEHeaders): a stream is always re-framed by us.
+var upstreamResponseHeaders = []string{
+	"Accept-Ranges",
+	"Cache-Control",
+	"Content-Disposition",
+	"Content-Encoding",
+	"Content-Language",
+	"Content-Range",
+	"Content-Type",
+	"ETag",
+	"Last-Modified",
+	"Location",
+	"Retry-After",
+}
+
+// relayUpstreamResponseHeaders copies the whitelisted upstream headers onto the
+// downstream response. Headers Metapi already set (X-Request-Id, security
+// headers, CORS) are never touched.
+func relayUpstreamResponseHeaders(w http.ResponseWriter, upstream http.Header) {
+	if w == nil || len(upstream) == 0 {
+		return
+	}
+	dst := w.Header()
+	for _, name := range upstreamResponseHeaders {
+		if values := upstream.Values(name); len(values) > 0 {
+			dst[name] = append([]string(nil), values...)
+		}
+	}
+}

--- a/handler/proxy/headers_test.go
+++ b/handler/proxy/headers_test.go
@@ -1,0 +1,164 @@
+package proxyhandler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/platform"
+)
+
+func clientHeaders() http.Header {
+	h := http.Header{}
+	h.Set("anthropic-version", "2023-06-01")
+	h.Add("anthropic-beta", "prompt-caching-2024-07-31")
+	h.Add("anthropic-beta", "fine-grained-tool-streaming-2025-05-14")
+	h.Set("openai-beta", "responses=experimental")
+	h.Set("user-agent", "claude-cli/1.0.60 (external, cli)")
+	h.Set("x-stainless-lang", "js")
+	h.Set("x-stainless-package-version", "0.69.0")
+	// Must never reach the upstream: the downstream credential and proxy hops.
+	h.Set("authorization", "Bearer sk-downstream-secret")
+	h.Set("x-api-key", "sk-downstream-secret")
+	h.Set("cookie", "session=downstream")
+	h.Set("x-forwarded-for", "203.0.113.9")
+	h.Set("accept-encoding", "gzip")
+	return h
+}
+
+func TestApplyClientProtocolHeaders_ForwardsWhitelistOnly(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://upstream.example/v1/messages", nil)
+	req.Header = http.Header{}
+
+	applyClientProtocolHeaders(req, clientHeaders(), "/v1/messages")
+
+	if got := req.Header.Get("anthropic-version"); got != "2023-06-01" {
+		t.Errorf("anthropic-version = %q, want the client value", got)
+	}
+	if got := req.Header.Values("anthropic-beta"); len(got) != 2 {
+		t.Errorf("anthropic-beta = %v, want both client values preserved", got)
+	}
+	if got := req.Header.Get("openai-beta"); got != "responses=experimental" {
+		t.Errorf("openai-beta = %q, want the client value", got)
+	}
+	if got := req.Header.Get("user-agent"); got != "claude-cli/1.0.60 (external, cli)" {
+		t.Errorf("user-agent = %q, want the client value", got)
+	}
+	if got := req.Header.Get("x-stainless-lang"); got != "js" {
+		t.Errorf("x-stainless-lang = %q, want SDK telemetry forwarded", got)
+	}
+	if got := req.Header.Get("x-stainless-package-version"); got != "0.69.0" {
+		t.Errorf("x-stainless-package-version = %q, want SDK telemetry forwarded", got)
+	}
+
+	for _, forbidden := range []string{"authorization", "x-api-key", "cookie", "x-forwarded-for", "accept-encoding"} {
+		if got := req.Header.Get(forbidden); got != "" {
+			t.Errorf("%s must not be forwarded upstream, got %q", forbidden, got)
+		}
+	}
+}
+
+// Site custom_headers (and the anti-bot identity they carry) are applied before
+// the client passthrough, so a site-level User-Agent must win.
+func TestApplyClientProtocolHeaders_IsFillOnly(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://upstream.example/v1/messages", nil)
+	req.Header = http.Header{}
+	req.Header.Set("user-agent", "Mozilla/5.0 (site anti-bot identity)")
+
+	applyClientProtocolHeaders(req, clientHeaders(), "/v1/messages")
+
+	if got := req.Header.Get("user-agent"); got != "Mozilla/5.0 (site anti-bot identity)" {
+		t.Errorf("site identity was overridden by the client header: %q", got)
+	}
+	if got := req.Header.Get("anthropic-version"); got != "2023-06-01" {
+		t.Errorf("unset headers must still be filled, got %q", got)
+	}
+}
+
+func TestApplyClientProtocolHeaders_DefaultsAnthropicVersionForMessagesOnly(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "https://upstream.example/v1/messages", nil)
+	req.Header = http.Header{}
+	applyClientProtocolHeaders(req, http.Header{"accept": []string{"application/json"}}, "/v1/messages")
+	if got := req.Header.Get("anthropic-version"); got != platform.ClaudeDefaultAnthropicVersion {
+		t.Errorf("anthropic-version = %q, want the platform default %q", got, platform.ClaudeDefaultAnthropicVersion)
+	}
+
+	chatReq := httptest.NewRequest(http.MethodPost, "https://upstream.example/v1/chat/completions", nil)
+	chatReq.Header = http.Header{}
+	applyClientProtocolHeaders(chatReq, http.Header{"accept": []string{"application/json"}}, "/v1/chat/completions")
+	if got := chatReq.Header.Get("anthropic-version"); got != "" {
+		t.Errorf("chat completions must not gain an anthropic-version header, got %q", got)
+	}
+
+	// A client-supplied value wins over the default.
+	explicit := httptest.NewRequest(http.MethodPost, "https://upstream.example/v1/messages", nil)
+	explicit.Header = http.Header{}
+	client := http.Header{}
+	client.Set("anthropic-version", "2030-01-01")
+	applyClientProtocolHeaders(explicit, client, "/anthropic/v1/messages")
+	if got := explicit.Header.Get("anthropic-version"); got != "2030-01-01" {
+		t.Errorf("anthropic-version = %q, want the explicit client value", got)
+	}
+}
+
+func TestRelayUpstreamResponseHeaders_KeepsContentSemanticsDropsIdentity(t *testing.T) {
+	upstream := http.Header{}
+	upstream.Set("Content-Type", "application/json")
+	upstream.Set("Retry-After", "7")
+	upstream.Set("Content-Disposition", `attachment; filename="report.json"`)
+	upstream.Set("Content-Length", "1234")
+	upstream.Set("Set-Cookie", "upstream_session=abc; Path=/")
+	upstream.Set("X-Request-Id", "upstream-request-id")
+	upstream.Set("X-New-Api-Version", "v1.2.3")
+	upstream.Set("Server", "nginx/1.27.0")
+	upstream.Set("Cf-Ray", "8f0a-CDG")
+	upstream.Set("X-Powered-By", "Express")
+	upstream.Set("X-Ratelimit-Limit", "5000")
+
+	recorder := httptest.NewRecorder()
+	recorder.Header().Set("X-Request-Id", "metapi-request-id")
+
+	relayUpstreamResponseHeaders(recorder, upstream)
+
+	if got := recorder.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want it relayed", got)
+	}
+	if got := recorder.Header().Get("Retry-After"); got != "7" {
+		t.Errorf("Retry-After = %q, want it relayed", got)
+	}
+	if got := recorder.Header().Get("Content-Disposition"); got == "" {
+		t.Error("Content-Disposition must be relayed for file downloads")
+	}
+	if got := recorder.Header().Get("X-Request-Id"); got != "metapi-request-id" {
+		t.Errorf("X-Request-Id = %q, want ours to stay authoritative", got)
+	}
+	for _, dropped := range []string{
+		"Set-Cookie", "X-New-Api-Version", "Server", "Cf-Ray", "X-Powered-By",
+		"Content-Length", "X-Ratelimit-Limit",
+	} {
+		if got := recorder.Header().Get(dropped); got != "" {
+			t.Errorf("%s must not be relayed from the upstream, got %q", dropped, got)
+		}
+	}
+}
+
+func TestRelayBufferedUpstreamResponse_DoesNotLeakUpstreamIdentity(t *testing.T) {
+	upstream := http.Header{}
+	upstream.Set("Content-Type", "application/json")
+	upstream.Set("X-Sub2Api-Version", "9.9.9")
+	upstream.Set("Set-Cookie", "leak=1")
+
+	recorder := httptest.NewRecorder()
+	recorder.Header().Set("X-Request-Id", "metapi-request-id")
+	relayBufferedUpstreamResponse(recorder, &http.Response{StatusCode: 200, Header: upstream}, []byte(`{"ok":true}`))
+
+	if got := recorder.Header().Get("X-Sub2Api-Version"); got != "" {
+		t.Errorf("upstream fingerprint header leaked: %q", got)
+	}
+	if got := recorder.Header().Get("Set-Cookie"); got != "" {
+		t.Errorf("upstream cookie leaked: %q", got)
+	}
+	if recorder.Code != 200 || recorder.Body.String() != `{"ok":true}` {
+		t.Errorf("status/body not relayed: %d %q", recorder.Code, recorder.Body.String())
+	}
+}

--- a/handler/proxy/surface.go
+++ b/handler/proxy/surface.go
@@ -23,7 +23,6 @@ type SurfConfig struct {
 	// /v1internal::streamGenerateContent where streaming is path-implied.
 	ForceStream   bool
 	Method        string
-	ExtraHeaders  map[string]string
 	MaxRetries    int
 	SurfaceFormat string // "openai", "claude", or empty
 }

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -51,8 +51,11 @@ var unconfiguredUpstreamLogOnce sync.Once
 // nil. Production deployments should always wire the Executor field via
 // SetUpstreamConfig.
 var defaultUpstreamClient = &http.Client{
-	Timeout:       90 * time.Second,
-	Transport:     httpclient.NewTransport(httpclient.Options{ResponseHeaderTimeout: 90 * time.Second}),
+	Timeout: proxy.DefaultRequestCeiling,
+	Transport: httpclient.NewTransport(httpclient.Options{
+		ResponseHeaderTimeout: proxy.DefaultRequestCeiling,
+		SiteDialGuard:         true, // data-plane dial guard, see proxy.NewStreamTransport
+	}),
 	CheckRedirect: platform.RejectCrossOriginRedirect,
 }
 
@@ -505,9 +508,12 @@ func dispatchEndpointAttemptWithContinue(
 		return true, nil, false
 	}
 	req.Header.Set("Content-Type", contentType)
-	// Custom headers first (deny-list skips Authorization/Host/hop-by-hop), then
-	// Bearer so site custom_headers can never override the selected token.
+	// Precedence, lowest to highest: client protocol headers (fill-only) →
+	// site custom_headers / anti-bot identity → the selected account token.
+	// The deny-list skips Authorization/Host/hop-by-hop so site custom_headers
+	// can never override the selected token.
 	applyProxyCustomHeaders(req, proxyConfig)
+	applyClientProtocolHeaders(req, r.Header, upstreamPath)
 	if selected.TokenValue != "" {
 		req.Header.Set("Authorization", "Bearer "+selected.TokenValue)
 	}
@@ -1000,12 +1006,7 @@ func writeStubResponse(w http.ResponseWriter, ctx *Ctx) {
 
 // Returns best-effort ParsedUsage from SSE events (may be zero/unknown).
 func relayBufferedUpstreamResponse(w http.ResponseWriter, resp *http.Response, bodyBytes []byte) {
-	for k, v := range resp.Header {
-		if k == "Content-Length" || k == "Transfer-Encoding" {
-			continue
-		}
-		w.Header()[k] = v
-	}
+	relayUpstreamResponseHeaders(w, resp.Header)
 	w.WriteHeader(resp.StatusCode)
 	_, _ = w.Write(bodyBytes)
 }

--- a/handler/proxy/upstream_stream.go
+++ b/handler/proxy/upstream_stream.go
@@ -251,12 +251,7 @@ func relayUpstreamErrorResponse(w http.ResponseWriter, resp *http.Response, late
 		return
 	}
 
-	for k, v := range resp.Header {
-		if k == "Content-Length" || k == "Transfer-Encoding" {
-			continue
-		}
-		w.Header()[k] = v
-	}
+	relayUpstreamResponseHeaders(w, resp.Header)
 	w.WriteHeader(resp.StatusCode)
 	_, _ = w.Write(bodyBytes)
 }

--- a/internal/httpclient/gate_test.go
+++ b/internal/httpclient/gate_test.go
@@ -30,7 +30,9 @@ import (
 //   - SSRF-hardened clients whose DialContext enforces dial-level target
 //     guards internal/httpclient does not model: notifyHTTPClient
 //     (service/notify, all webhook-style channels) and the WebDAV backup
-//     clients in handler/admin and scheduler;
+//     clients in handler/admin and scheduler. Transports built here opt into
+//     the shared site dial guard (internal/ssrf) with Options.SiteDialGuard —
+//     used by the proxy data plane and channel health probes;
 //   - proxy.NewStreamTransport — SSE data-plane stream relay; header phase
 //     bounded, whole-request timeout owned by the relay's idle guard.
 //

--- a/internal/httpclient/httpclient.go
+++ b/internal/httpclient/httpclient.go
@@ -25,6 +25,8 @@ import (
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/deliciousbuding/metapi-go/internal/ssrf"
 )
 
 // Baseline defaults shared by every outbound transport built in this package.
@@ -61,6 +63,19 @@ type Options struct {
 	// never ride an operator-configured HTTP_PROXY (e.g. OAuth token
 	// exchange).
 	Proxy func(*http.Request) (*url.URL, error)
+	// SiteDialGuard wraps DialContext with the shared SSRF site dial guard
+	// (internal/ssrf): the hostname is resolved exactly once, every answer is
+	// checked against the metadata / link-local / multicast / reserved deny
+	// set, and the connection is pinned to an already-validated IP — closing
+	// the DNS-rebinding window between validation and dial. Loopback, RFC1918
+	// and IPv6 ULA stay reachable because Metapi upstreams are commonly
+	// operator-hosted on private networks.
+	//
+	// Set it on transports whose target comes from operator-configured site
+	// URLs (proxy data plane, channel health probes). Note that when a proxy
+	// is resolved for the request, DialContext dials the proxy address, so the
+	// guard then validates the proxy rather than the final origin.
+	SiteDialGuard bool
 }
 
 // NoProxy is an Options.Proxy value that disables proxy resolution
@@ -97,12 +112,17 @@ func NewTransport(opts Options) *http.Transport {
 	if proxy == nil {
 		proxy = http.ProxyFromEnvironment
 	}
+	dialer := &net.Dialer{
+		Timeout:   dialTimeout,
+		KeepAlive: DefaultKeepAlive,
+	}
+	dialContext := dialer.DialContext
+	if opts.SiteDialGuard {
+		dialContext = ssrf.NewSiteDialContext(net.DefaultResolver, dialContext)
+	}
 	return &http.Transport{
-		Proxy: proxy,
-		DialContext: (&net.Dialer{
-			Timeout:   dialTimeout,
-			KeepAlive: DefaultKeepAlive,
-		}).DialContext,
+		Proxy:                 proxy,
+		DialContext:           dialContext,
 		ForceAttemptHTTP2:     true,
 		TLSHandshakeTimeout:   tlsHandshakeTimeout,
 		ResponseHeaderTimeout: opts.ResponseHeaderTimeout,

--- a/internal/httpclient/ssrf_guard_test.go
+++ b/internal/httpclient/ssrf_guard_test.go
@@ -1,0 +1,60 @@
+package httpclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewTransport_SiteDialGuardRefusesForbiddenTargets(t *testing.T) {
+	client := &http.Client{
+		Transport: NewTransport(Options{SiteDialGuard: true, Proxy: NoProxy}),
+		Timeout:   3 * time.Second,
+	}
+	for _, target := range []string{
+		"http://169.254.169.254/latest/meta-data/",
+		"http://100.100.100.200/latest/meta-data/",
+		"http://metadata/latest/meta-data/",
+	} {
+		resp, err := client.Get(target)
+		if err == nil {
+			resp.Body.Close()
+			t.Fatalf("%s: expected refusal, got a response", target)
+		}
+		if !strings.Contains(err.Error(), "forbidden") {
+			t.Errorf("%s: expected a forbidden-target error, got %v", target, err)
+		}
+	}
+}
+
+// Loopback and private-range upstreams must keep working: Metapi proxies
+// operator-hosted gateways on localhost/RFC1918 by design.
+func TestNewTransport_SiteDialGuardAllowsLoopback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	client := &http.Client{
+		Transport: NewTransport(Options{SiteDialGuard: true, Proxy: NoProxy}),
+		Timeout:   3 * time.Second,
+	}
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("loopback upstream must stay reachable: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestNewTransport_WithoutSiteDialGuardKeepsPlainDialer(t *testing.T) {
+	transport := NewTransport(Options{})
+	if transport.DialContext == nil {
+		t.Fatal("DialContext must always be set (gate R4)")
+	}
+}

--- a/platform/claude.go
+++ b/platform/claude.go
@@ -6,7 +6,11 @@ import (
 	"strings"
 )
 
-const claudeDefaultAnthropicVersion = "2023-06-01"
+// ClaudeDefaultAnthropicVersion is the anthropic-version header value used when
+// a caller does not supply one. Single source of truth for every path that
+// speaks the Anthropic-native protocol (platform adapters, OAuth flows, and the
+// /v1 proxy data plane).
+const ClaudeDefaultAnthropicVersion = "2023-06-01"
 
 // ClaudeAdapter handles api.anthropic.com platforms (native + OpenAI-compat gateways).
 type ClaudeAdapter struct {
@@ -35,7 +39,7 @@ func (c *ClaudeAdapter) GetModels(ctx context.Context, baseURL string, token str
 	// Try native Anthropic endpoint
 	claudeHeaders := map[string]string{
 		"x-api-key":         token,
-		"anthropic-version": claudeDefaultAnthropicVersion,
+		"anthropic-version": ClaudeDefaultAnthropicVersion,
 	}
 	models, err := c.fetchModelsFromStandardEndpoint(ctx, baseURL, claudeHeaders, proxy)
 	if err == nil && len(models) > 0 {

--- a/platform/claude_test.go
+++ b/platform/claude_test.go
@@ -73,7 +73,7 @@ func TestClaudeAdapter_InheritsStandardDefaults(t *testing.T) {
 }
 
 func TestClaudeDefaultAnthropicVersion(t *testing.T) {
-	if claudeDefaultAnthropicVersion != "2023-06-01" {
-		t.Errorf("expected anthropic version '2023-06-01', got %q", claudeDefaultAnthropicVersion)
+	if ClaudeDefaultAnthropicVersion != "2023-06-01" {
+		t.Errorf("expected anthropic version '2023-06-01', got %q", ClaudeDefaultAnthropicVersion)
 	}
 }

--- a/proxy/executor.go
+++ b/proxy/executor.go
@@ -57,6 +57,11 @@ const defaultStreamResponseHeaderTimeout = 30 * time.Second
 func NewStreamTransport() *http.Transport {
 	return httpclient.NewTransport(httpclient.Options{
 		ResponseHeaderTimeout: defaultStreamResponseHeaderTimeout,
+		// Data-plane dial guard: site URLs are operator input, and a hostname
+		// that resolves to a cloud metadata / link-local address must not be
+		// dialled even if it passed URL-level validation earlier (DNS
+		// rebinding). Private ranges stay allowed for self-hosted upstreams.
+		SiteDialGuard: true,
 	})
 }
 
@@ -83,7 +88,10 @@ func NewRuntimeExecutor(requestTimeout time.Duration) *RuntimeExecutor {
 			// (max(90s, first-byte*2) in app wiring, operator-influenced via
 			// PROXY_FIRST_BYTE_TIMEOUT_SEC) so it never pre-empts a request
 			// that would finish within its own deadline.
-			Transport:     httpclient.NewTransport(httpclient.Options{ResponseHeaderTimeout: requestTimeout}),
+			Transport: httpclient.NewTransport(httpclient.Options{
+				ResponseHeaderTimeout: requestTimeout,
+				SiteDialGuard:         true, // see NewStreamTransport
+			}),
 			CheckRedirect: rejectCrossOriginRedirect,
 		},
 		streamClient: &http.Client{

--- a/proxy/executor_ssrf_test.go
+++ b/proxy/executor_ssrf_test.go
@@ -1,0 +1,40 @@
+package proxy
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The executor dials operator-configured site URLs, so its transports carry the
+// shared site dial guard. A hostname/IP that resolves into the cloud metadata
+// range must be refused before any connection attempt, even though loopback and
+// RFC1918 upstreams stay reachable for self-hosted deployments.
+func TestRuntimeExecutor_RefusesMetadataTarget(t *testing.T) {
+	executor := NewRuntimeExecutor(2 * time.Second)
+	req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data/", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := executor.Do(req)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("expected the dial guard to refuse the metadata address")
+	}
+	if !strings.Contains(err.Error(), "forbidden") {
+		t.Errorf("expected a forbidden-target error, got %v", err)
+	}
+}
+
+func TestNewStreamTransport_RefusesMetadataTarget(t *testing.T) {
+	client := &http.Client{Transport: NewStreamTransport(), Timeout: 2 * time.Second}
+	resp, err := client.Get("http://metadata.google.internal/computeMetadata/v1/")
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("expected the dial guard to refuse the metadata hostname")
+	}
+	if !strings.Contains(err.Error(), "forbidden") {
+		t.Errorf("expected a forbidden-target error, got %v", err)
+	}
+}

--- a/proxy/timeouts.go
+++ b/proxy/timeouts.go
@@ -1,0 +1,47 @@
+package proxy
+
+import "time"
+
+// DefaultRequestCeiling is the whole-request timeout ceiling for buffered
+// (non-stream) upstream dispatch. It is a safety net for a hung upstream, not
+// the primary liveness control: the header phase is observed separately via
+// PROXY_FIRST_BYTE_TIMEOUT_SEC, and streams are governed per chunk by the
+// relay's idle guard (PROXY_STREAM_IDLE_TIMEOUT_SEC) instead of total elapsed
+// time.
+const DefaultRequestCeiling = 90 * time.Second
+
+// bufferedWriteSlack is the extra time a proxy response write gets on top of
+// the request ceiling. When the write starts the buffered body is already in
+// memory, so the slack only has to cover transmitting it to a slow client.
+const bufferedWriteSlack = 2 * time.Minute
+
+// RequestCeiling returns the whole-request timeout for buffered upstream
+// dispatch: max(DefaultRequestCeiling, firstByteTimeout*2). The doubling keeps
+// multi-endpoint fallback able to complete when an operator raises the
+// first-byte window above the default ceiling.
+//
+// This is the single source of truth shared by the executor wiring
+// (app.WireProxyUpstream) and the server-side write budget below, so the two
+// can never drift apart again.
+func RequestCeiling(firstByteTimeoutSec int) time.Duration {
+	ceiling := DefaultRequestCeiling
+	if ms := FirstByteTimeoutMs(firstByteTimeoutSec); ms > 0 {
+		if doubled := time.Duration(ms) * time.Millisecond * 2; doubled > ceiling {
+			ceiling = doubled
+		}
+	}
+	return ceiling
+}
+
+// WriteBudget returns the write-deadline budget for a proxy surface response.
+//
+// net/http arms the connection write deadline with Server.WriteTimeout (60s in
+// app.newHTTPServer) right after the request header is read, so that deadline
+// also covers the time the handler spends waiting for the upstream. With the
+// executor ceiling at 90s the two inverted: a buffered response that arrived
+// between 61s and 90s was killed while writing it back to the client. The
+// proxy surface therefore re-arms its own deadline (router.ProxyWriteDeadline)
+// from this budget, which is always >= RequestCeiling.
+func WriteBudget(firstByteTimeoutSec int) time.Duration {
+	return RequestCeiling(firstByteTimeoutSec) + bufferedWriteSlack
+}

--- a/proxy/timeouts_test.go
+++ b/proxy/timeouts_test.go
@@ -1,0 +1,46 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRequestCeiling_DefaultsToNinetySeconds(t *testing.T) {
+	for _, sec := range []int{0, -5} {
+		if got := RequestCeiling(sec); got != DefaultRequestCeiling {
+			t.Errorf("RequestCeiling(%d) = %v, want %v", sec, got, DefaultRequestCeiling)
+		}
+	}
+}
+
+func TestRequestCeiling_DoublesFirstByteWindowOnlyAboveDefault(t *testing.T) {
+	cases := []struct {
+		sec  int
+		want time.Duration
+	}{
+		{15, DefaultRequestCeiling}, // 30s < 90s: default wins
+		{45, DefaultRequestCeiling}, // 90s == 90s: default wins
+		{60, 120 * time.Second},     // 120s > 90s: doubled window wins
+		{300, 600 * time.Second},    // multi-endpoint fallback keeps headroom
+	}
+	for _, tc := range cases {
+		if got := RequestCeiling(tc.sec); got != tc.want {
+			t.Errorf("RequestCeiling(%d) = %v, want %v", tc.sec, got, tc.want)
+		}
+	}
+}
+
+// TestWriteBudget_NeverInvertsRequestCeiling locks the audit T1 invariant: the
+// server-side write budget must always be at least the whole-request ceiling,
+// otherwise a buffered response arriving late is killed while being written.
+func TestWriteBudget_NeverInvertsRequestCeiling(t *testing.T) {
+	for _, sec := range []int{-1, 0, 15, 45, 60, 120, 600, 3600} {
+		budget, ceiling := WriteBudget(sec), RequestCeiling(sec)
+		if budget <= ceiling {
+			t.Fatalf("WriteBudget(%d) = %v must exceed RequestCeiling = %v", sec, budget, ceiling)
+		}
+		if budget > ceiling+time.Hour {
+			t.Fatalf("WriteBudget(%d) = %v is unreasonably far above ceiling %v", sec, budget, ceiling)
+		}
+	}
+}

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/proxy"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 )
@@ -44,6 +45,39 @@ func corsOptions(allowedOrigins []string) cors.Options {
 		AllowCredentials: false,
 		MaxAge:           300,
 	}
+}
+
+// ProxyWriteDeadline re-arms the connection write deadline for the proxy
+// surface (/v1 plus the non-/v1 proxy aliases).
+//
+// net/http arms that deadline from Server.WriteTimeout (60s, see
+// app.newHTTPServer) immediately after the request header is read, so it also
+// covers the time the handler spends waiting for the upstream. That inverted
+// against the executor's whole-request ceiling (90s, or 2x the configured
+// first-byte window): a buffered response arriving between 61s and 90s was
+// killed while being written back to the client. proxy.WriteBudget is derived
+// from the same SSOT as the executor ceiling, so the write side can no longer
+// be shorter than the request side, while admin routes keep the strict 60s.
+//
+// SSE relays still clear the deadline outright (handler/proxy
+// relayUpstreamStream): a healthy stream is bounded per chunk by
+// PROXY_STREAM_IDLE_TIMEOUT_SEC rather than by total elapsed time.
+func ProxyWriteDeadline(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(proxyWriteBudget()))
+		next.ServeHTTP(w, r)
+	})
+}
+
+// proxyWriteBudget reads the first-byte window from the published runtime
+// settings. RuntimeSafe (not Runtime) because the middleware can be exercised
+// by tests that never publish config.
+func proxyWriteBudget() time.Duration {
+	firstByteSec := 0
+	if rt := config.RuntimeSafe(); rt != nil {
+		firstByteSec = rt.ProxyFirstByteTimeoutSec
+	}
+	return proxy.WriteBudget(firstByteSec)
 }
 
 // RequestLogger logs every incoming request using slog after it completes,

--- a/router/proxy_write_deadline_test.go
+++ b/router/proxy_write_deadline_test.go
@@ -1,0 +1,66 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/proxy"
+)
+
+// deadlineWriter records the write deadline a handler arms. httptest.Recorder
+// does not implement SetWriteDeadline, so the real server path needs a stand-in.
+type deadlineWriter struct {
+	http.ResponseWriter
+	called   bool
+	deadline time.Time
+}
+
+func (d *deadlineWriter) SetWriteDeadline(t time.Time) error {
+	d.called = true
+	d.deadline = t
+	return nil
+}
+
+// unwrapper mimics chi's middleware.WrapResponseWriter shape: the global
+// RequestLogger wraps every ResponseWriter, so the deadline must survive one
+// Unwrap() hop to reach the real connection.
+type unwrapper struct{ inner http.ResponseWriter }
+
+func (u unwrapper) Header() http.Header         { return u.inner.Header() }
+func (u unwrapper) Write(p []byte) (int, error) { return u.inner.Write(p) }
+func (u unwrapper) WriteHeader(code int)        { u.inner.WriteHeader(code) }
+func (u unwrapper) Unwrap() http.ResponseWriter { return u.inner }
+
+func TestProxyWriteDeadline_ArmsBudgetAboveExecutorCeiling(t *testing.T) {
+	before := time.Now()
+	writer := &deadlineWriter{ResponseWriter: httptest.NewRecorder()}
+
+	ProxyWriteDeadline(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})).
+		ServeHTTP(writer, httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil))
+
+	if !writer.called {
+		t.Fatal("proxy surface must re-arm the connection write deadline")
+	}
+	elapsed := writer.deadline.Sub(before)
+	ceiling := proxy.RequestCeiling(0)
+	if elapsed < ceiling {
+		t.Errorf("write budget %v is below the executor ceiling %v — the inversion is back", elapsed, ceiling)
+	}
+	if elapsed > ceiling+30*time.Minute {
+		t.Errorf("write budget %v is unbounded relative to ceiling %v", elapsed, ceiling)
+	}
+}
+
+func TestProxyWriteDeadline_ReachesWrappedWriter(t *testing.T) {
+	writer := &deadlineWriter{ResponseWriter: httptest.NewRecorder()}
+	wrapped := unwrapper{inner: writer}
+
+	ProxyWriteDeadline(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})).
+		ServeHTTP(wrapped, httptest.NewRequest(http.MethodPost, "/v1/messages", nil))
+
+	if !writer.called {
+		t.Error("deadline must be armed through a chi-style wrapped ResponseWriter")
+	}
+}

--- a/router/router.go
+++ b/router/router.go
@@ -193,6 +193,7 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 	// auth since it needs the resolved auth source to know whether the request
 	// used the global PROXY_TOKEN (managed keys have their own RPM admission).
 	r.Route("/v1", func(r chi.Router) {
+		r.Use(ProxyWriteDeadline)
 		r.Use(CORS())
 		r.Use(auth.ProxyRateLimit(cfg.ProxyRateLimitRPM))
 		r.Use(auth.ProxyAuth())
@@ -211,6 +212,7 @@ func New(cfg *config.Config, webFS embed.FS) chi.Router {
 	// the exact registered proxy paths and does not shadow the SPA fallback.
 	// Same rate-limiting stack as /v1: per-IP before auth, global-token after.
 	r.Group(func(r chi.Router) {
+		r.Use(ProxyWriteDeadline)
 		r.Use(CORS())
 		r.Use(auth.ProxyRateLimit(cfg.ProxyRateLimitRPM))
 		r.Use(auth.ProxyAuth())

--- a/service/oauth/claude.go
+++ b/service/oauth/claude.go
@@ -11,15 +11,15 @@ import (
 	"time"
 
 	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/platform"
 )
 
 const (
-	claudeAuthURL                 = "https://claude.ai/oauth/authorize"
-	claudeLoopbackPort            = 54545
-	claudeLoopbackPath            = "/callback"
-	claudeLoopbackRedirectURI     = "http://localhost:54545/callback"
-	claudeUpstreamBaseURL         = "https://api.anthropic.com"
-	claudeDefaultAnthropicVersion = "2023-06-01"
+	claudeAuthURL             = "https://claude.ai/oauth/authorize"
+	claudeLoopbackPort        = 54545
+	claudeLoopbackPath        = "/callback"
+	claudeLoopbackRedirectURI = "http://localhost:54545/callback"
+	claudeUpstreamBaseURL     = "https://api.anthropic.com"
 )
 
 // claudeTokenURL is a package var (not a const) so tests can swap in a local
@@ -246,7 +246,7 @@ func refreshClaudeAccessToken(ctx context.Context, input RefreshTokenInput) (*To
 
 func buildClaudeProxyHeaders(ctx context.Context, input ProxyHeaderInput) map[string]string {
 	return map[string]string{
-		"anthropic-version": claudeDefaultAnthropicVersion,
+		"anthropic-version": platform.ClaudeDefaultAnthropicVersion,
 	}
 }
 

--- a/service/oauth/claude_flow_test.go
+++ b/service/oauth/claude_flow_test.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"encoding/json"
+	"github.com/deliciousbuding/metapi-go/platform"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -104,9 +105,9 @@ func TestParseClaudeExpiresAt_NilValue(t *testing.T) {
 
 func TestBuildClaudeProxyHeaders_SetsAnthropicVersion(t *testing.T) {
 	headers := buildClaudeProxyHeaders(context.Background(), ProxyHeaderInput{})
-	if headers["anthropic-version"] != claudeDefaultAnthropicVersion {
+	if headers["anthropic-version"] != platform.ClaudeDefaultAnthropicVersion {
 		t.Errorf("anthropic-version = %q, want %q",
-			headers["anthropic-version"], claudeDefaultAnthropicVersion)
+			headers["anthropic-version"], platform.ClaudeDefaultAnthropicVersion)
 	}
 	if len(headers) != 1 {
 		t.Errorf("claude proxy headers should set exactly one header, got %d", len(headers))
@@ -123,7 +124,7 @@ func TestBuildClaudeProxyHeaders_IgnoresOAuthContext(t *testing.T) {
 			Provider:   "claude",
 		},
 	})
-	if headers["anthropic-version"] != claudeDefaultAnthropicVersion {
+	if headers["anthropic-version"] != platform.ClaudeDefaultAnthropicVersion {
 		t.Errorf("anthropic-version = %q", headers["anthropic-version"])
 	}
 }

--- a/service/oauth/headers_test.go
+++ b/service/oauth/headers_test.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"github.com/deliciousbuding/metapi-go/platform"
 	"testing"
 
 	"github.com/deliciousbuding/metapi-go/store"
@@ -57,7 +58,7 @@ func TestBuildOauthProviderHeaders_ClaudeFromExtraConfig(t *testing.T) {
 	if len(headers) == 0 {
 		t.Fatal("expected non-empty headers for claude account")
 	}
-	if headers["anthropic-version"] != claudeDefaultAnthropicVersion {
+	if headers["anthropic-version"] != platform.ClaudeDefaultAnthropicVersion {
 		t.Errorf("anthropic-version = %q", headers["anthropic-version"])
 	}
 }


### PR DESCRIPTION
## What

Four audit follow-ups on the `/v1` data plane, one lane because they share the same files.

### T1 — write-deadline inversion (buffered responses cut mid-write)

`net/http` arms the connection write deadline from `Server.WriteTimeout` (60s) right after the request header is read, so that deadline also covered the time the handler spent waiting for the upstream. The executor ceiling is `max(90s, first-byte × 2)`, so any buffered response arriving between 61s and 90s was killed while being written back.

- `proxy.RequestCeiling` / `proxy.WriteBudget` (`proxy/timeouts.go`) are now the single source of truth: app wiring builds the executor from `RequestCeiling`, and the new `router.ProxyWriteDeadline` middleware re-arms the write deadline from `WriteBudget` (= ceiling + 2m) on both proxy groups.
- Admin routes keep the strict 60s `WriteTimeout`. SSE relays still clear the deadline outright and stay governed by the per-chunk idle guard (`PROXY_STREAM_IDLE_TIMEOUT_SEC`), so long reasoning streams are unaffected.
- Deadline is armed through `http.NewResponseController`, so it reaches the connection through the global `RequestLogger` wrapper (test covers the wrapped-writer hop).

### H1 — client protocol headers were dropped

The upstream request is rebuilt with only `Content-Type` + site `custom_headers` + the selected token, so every client-side protocol switch was silently lost: `anthropic-version`, `anthropic-beta`, `openai-beta`, `user-agent`, `x-stainless-*`. Claude Code feature flags (prompt caching, fine-grained tool streaming) never reached the upstream.

- New allow-list, applied **fill-only** so precedence stays: client protocol headers → site `custom_headers` / anti-bot identity → `Authorization: Bearer <selected token>`. A site-level `user-agent` still wins; a client can never override the token.
- Multi-value headers keep every value (`anthropic-beta` flags).
- Credential-bearing headers are never forwarded (`authorization`, `x-api-key`, `cookie`, `x-forwarded-*`, hop-by-hop).
- Anthropic-native dispatch (`/v1/messages`, incl. the `/anthropic/v1/messages` gateway shape) defaults `anthropic-version`, so an OpenAI-surface request transformed into the Anthropic shape no longer fails upstream validation.

### H2 — upstream response headers leaked through

Buffered relays copied **every** upstream header: vendor fingerprints (`X-New-Api-Version` observed live), upstream `Set-Cookie`, and an upstream `X-Request-Id` that clobbered ours and broke cross-layer log correlation.

- Now a content-semantic allow-list (`Content-Type`, `Content-Disposition`, `Content-Encoding`, `Content-Language`, `Content-Range`, `Accept-Ranges`, `Cache-Control`, `ETag`, `Last-Modified`, `Location`, `Retry-After`).
- Metapi's own `X-Request-Id` and `X-Ratelimit-*` stay authoritative; framing headers stay out because the buffered body is re-framed.
- The stream path's error relay uses the same policy; SSE relays keep re-framing everything (`writeSSEHeaders`).

### SSRF depth — dial-level guard on the data plane

#1139 closed the import-side gap; the transports themselves still dialled through a bare `net.Dialer`.

- `httpclient.Options.SiteDialGuard` opts a transport into `internal/ssrf.NewSiteDialContext`: hostname resolved exactly once, every answer checked, connection pinned to a validated IP (closes the DNS-rebinding window).
- Enabled on the proxy executor, the SSE stream transport, both fallback dispatch clients, and the channel health probe transport.
- Blocked: cloud metadata (`169.254.169.254`, `100.100.100.200`, `fd00:ec2::254`, `metadata*` aliases), link-local, multicast, unspecified/reserved. **Preserved**: loopback, RFC1918, IPv6 ULA — self-hosted upstreams stay a first-class deployment shape (covered by a test against a loopback server).

### Hygiene

- `SurfConfig.ExtraHeaders` removed (dead since introduction).
- `anthropic-version` default consolidated from three copies into `platform.ClaudeDefaultAnthropicVersion` (platform adapter, OAuth flow, and now the data plane).
- `internal/httpclient` gate doc updated: the site dial guard is now modelled in `Options`.

## Docs

- `docs/api/proxy.md`: new **Header policy (/v1 surface)** and **Timeouts (/v1 surface)** sections (both directions, precedence order, phase table).
- `docs/api/conventions.md`: new **Site upstream SSRF hardening (proxy data plane)** section (two layers, blocked vs deliberately allowed ranges).

## Verification (local, 2C/4G)

| Gate | Result |
|---|---|
| `go build ./...` | pass |
| `go vet ./...` | exit 0 |
| `go test ./... -count=1` | exit 0 — 43 packages ok, 0 FAIL |
| new tests | `proxy` ceiling/budget invariants + executor & stream-transport metadata refusal; `internal/httpclient` guard refusal + loopback allowed; `router` deadline armed above ceiling incl. wrapped writer; `handler/proxy` H1 allow-list/fill-only/anthropic default + H2 allow-list/no-identity-leak |
| `gofmt -l` (edited files) | clean |

No behaviour change for admin routes, streaming liveness, or self-hosted (loopback/RFC1918) upstreams.