### PR TITLE
fix(proxy): bound the video task cache and default retention to 7 days

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,7 +197,10 @@ PROXY_LOG_RETENTION_DAYS=30
 PROXY_LOG_RETENTION_PRUNE_INTERVAL_MINUTES=30
 PROXY_FILE_RETENTION_DAYS=30
 PROXY_FILE_RETENTION_PRUNE_INTERVAL_MINUTES=60
-PROXY_VIDEO_TASK_RETENTION_DAYS=0
+# Video task mappings (publicId -> upstream video id) retire after this many
+# days: prunes proxy_video_tasks rows and bounds the in-process rewrite cache.
+# 0 (or negative) disables pruning and keeps mappings forever.
+PROXY_VIDEO_TASK_RETENTION_DAYS=7
 PROXY_VIDEO_TASK_RETENTION_PRUNE_INTERVAL_MINUTES=60
 # Debug trace capture (off by default).
 PROXY_DEBUG_TRACE_ENABLED=

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -122,8 +122,11 @@ const (
 	DefaultProxyLogRetentionPruneIntervalMinutes  = 30
 	DefaultProxyFileRetentionDays                 = 30
 	DefaultProxyFileRetentionPruneIntervalMinutes = 60
-	// Video task mappings: default 0 = retention disabled (no silent mass delete).
-	DefaultProxyVideoTaskRetentionDays                 = 0
+	// Video task mappings are short-lived id rewrites, so they retire faster
+	// than proxy logs/files: 7 days. The same knob bounds the process-local
+	// rewrite cache in handler/proxy. <=0 remains an explicit operator opt-out
+	// (retention disabled), it is just no longer the default.
+	DefaultProxyVideoTaskRetentionDays                 = 7
 	DefaultProxyVideoTaskRetentionPruneIntervalMinutes = 60
 
 	// Proxy log batch writer (async INSERT batching). Default async=true so

--- a/config/video_task_retention_default_test.go
+++ b/config/video_task_retention_default_test.go
@@ -1,0 +1,61 @@
+package config
+
+import "testing"
+
+// TestLoadProxyVideoTaskRetentionDefaults pins the audit-driven default: video
+// task mappings (publicId -> upstream video id) are short-lived, so retention
+// must be on out of the box. The same knob drives the proxy_video_tasks pruner
+// and the TTL of the process-local rewrite cache in handler/proxy.
+func TestLoadProxyVideoTaskRetentionDefaults(t *testing.T) {
+	if DefaultProxyVideoTaskRetentionDays != 7 {
+		t.Fatalf("DefaultProxyVideoTaskRetentionDays = %d, want 7", DefaultProxyVideoTaskRetentionDays)
+	}
+	cfg, _ := Load(map[string]string{})
+	if cfg.ProxyVideoTaskRetentionDays != DefaultProxyVideoTaskRetentionDays {
+		t.Fatalf("ProxyVideoTaskRetentionDays = %d, want default %d",
+			cfg.ProxyVideoTaskRetentionDays, DefaultProxyVideoTaskRetentionDays)
+	}
+	if cfg.ProxyVideoTaskRetentionPruneIntervalMinutes != DefaultProxyVideoTaskRetentionPruneIntervalMinutes {
+		t.Fatalf("ProxyVideoTaskRetentionPruneIntervalMinutes = %d, want %d",
+			cfg.ProxyVideoTaskRetentionPruneIntervalMinutes, DefaultProxyVideoTaskRetentionPruneIntervalMinutes)
+	}
+}
+
+// TestLoadProxyVideoTaskRetentionExplicitDisable keeps the opt-out semantics:
+// 0 (or anything negative, clamped to 0) still means "operator disabled
+// retention" — the scheduler no-ops and the cache keeps lines until the
+// capacity guardrail trims them.
+func TestLoadProxyVideoTaskRetentionExplicitDisable(t *testing.T) {
+	for _, env := range []map[string]string{
+		{"PROXY_VIDEO_TASK_RETENTION_DAYS": "0"},
+		{"PROXY_VIDEO_TASK_RETENTION_DAYS": "-5"},
+	} {
+		cfg, _ := Load(env)
+		if cfg.ProxyVideoTaskRetentionDays != 0 {
+			t.Fatalf("Load(%v).ProxyVideoTaskRetentionDays = %d, want 0 (disabled)",
+				env, cfg.ProxyVideoTaskRetentionDays)
+		}
+	}
+}
+
+// TestLoadProxyVideoTaskRetentionExplicitValue verifies an operator-supplied
+// window wins over the default, and that an unparseable value falls back to the
+// default instead of silently disabling retention.
+func TestLoadProxyVideoTaskRetentionExplicitValue(t *testing.T) {
+	if cfg, _ := Load(map[string]string{"PROXY_VIDEO_TASK_RETENTION_DAYS": "not-a-number"}); cfg.ProxyVideoTaskRetentionDays != DefaultProxyVideoTaskRetentionDays {
+		t.Fatalf("invalid value = %d, want fallback default %d",
+			cfg.ProxyVideoTaskRetentionDays, DefaultProxyVideoTaskRetentionDays)
+	}
+
+	cfg, _ := Load(map[string]string{
+		"PROXY_VIDEO_TASK_RETENTION_DAYS":                   "3",
+		"PROXY_VIDEO_TASK_RETENTION_PRUNE_INTERVAL_MINUTES": "15",
+	})
+	if cfg.ProxyVideoTaskRetentionDays != 3 {
+		t.Fatalf("ProxyVideoTaskRetentionDays = %d, want 3", cfg.ProxyVideoTaskRetentionDays)
+	}
+	if cfg.ProxyVideoTaskRetentionPruneIntervalMinutes != 15 {
+		t.Fatalf("ProxyVideoTaskRetentionPruneIntervalMinutes = %d, want 15",
+			cfg.ProxyVideoTaskRetentionPruneIntervalMinutes)
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,7 +118,7 @@ default when `WEBHOOK_URL` is non-empty). Alert cooldown:
 | `PROXY_LOG_FLUSH_INTERVAL_MS` | `1000` | Flush period (1–60000 ms). |
 | `PROXY_LOG_RETENTION_DAYS` | `30` | Proxy log retention; `PROXY_LOG_RETENTION_PRUNE_INTERVAL_MINUTES` (30). |
 | `PROXY_FILE_RETENTION_DAYS` | `30` | Uploaded file retention; prune interval 60 min. |
-| `PROXY_VIDEO_TASK_RETENTION_DAYS` | `0` | Video task retention (0 = keep forever). |
+| `PROXY_VIDEO_TASK_RETENTION_DAYS` | `7` | Video task mapping retention: prunes `proxy_video_tasks` rows and bounds the in-process rewrite cache TTL; `0` = keep forever (explicit opt-out); prune interval 60 min. |
 
 ## Routing
 

--- a/handler/proxy/videos.go
+++ b/handler/proxy/videos.go
@@ -8,11 +8,13 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/config"
 	"github.com/deliciousbuding/metapi-go/routing"
 	"github.com/deliciousbuding/metapi-go/store"
 	"github.com/go-chi/chi/v5"
@@ -37,9 +39,62 @@ type ProxyVideoTask struct {
 	AccountID       int64  `json:"accountId"`
 }
 
+// The process-local video task cache has two owners with two lifetimes:
+//
+//   - videoTaskStore (below) is a rewrite cache: publicId -> upstream video id
+//     plus the channel/account pin used for sticky routing. It is not durable —
+//     a restart starts empty and re-warms from the table on the first cold GET.
+//   - proxy_video_tasks (DB) is the durable mapping shared across instances and
+//     restarts. Its rows are pruned by
+//     scheduler.NewProxyVideoTaskRetentionScheduler.
+//
+// Both age out on the same operator-visible dial
+// (PROXY_VIDEO_TASK_RETENTION_DAYS). The cache never deletes DB rows — pruning
+// durable state stays the scheduler's job, under its lease — and eviction here
+// is lazy: it rides along on inserts, so there is no background goroutine and
+// no per-request full scan.
+//
+// videoTaskEntry is one cache line. storedAt is when the mapping entered (or was
+// refreshed in) *this process's* cache, not the durable row's created_at. Reads
+// do not refresh it, so a mapping ages out on a fixed schedule whether or not
+// clients keep polling it.
+type videoTaskEntry struct {
+	task     *ProxyVideoTask
+	storedAt time.Time
+}
+
+const (
+	// videoTaskSweepEveryInserts bounds how many inserts may pass without a
+	// sweep (burst guard): the map can overshoot the capacity guardrail by at
+	// most this many lines between sweeps.
+	videoTaskSweepEveryInserts = 256
+	// videoTaskSweepMinInterval bounds how long an entry may sit past its TTL
+	// in a low-traffic process (idle guard): the first insert after the window
+	// sweeps even when the insert counter is nowhere near its threshold.
+	videoTaskSweepMinInterval = 5 * time.Minute
+	// videoTaskCacheHeadroomDivisor sets the batch-trim target: over the cap,
+	// the sweep evicts oldest-first down to cap-cap/16 rather than exactly cap,
+	// so the O(n log n) trim runs once per ~cap/16 inserts instead of on every
+	// insert at the cap.
+	videoTaskCacheHeadroomDivisor = 16
+)
+
 var (
-	videoTaskStore   = make(map[string]*ProxyVideoTask)
+	videoTaskStore   = make(map[string]*videoTaskEntry)
 	videoTaskStoreMu sync.RWMutex
+
+	// videoTaskCacheMaxEntries is the hard capacity guardrail on cache lines
+	// (~200 B each, so ~4 MB at 20k). It holds even when TTL eviction is
+	// explicitly disabled, because bounding process memory is not an
+	// operator-optional behaviour. Fixed in production; tests lower it.
+	videoTaskCacheMaxEntries = 20000
+	// videoTaskNow is the cache clock, injectable so eviction tests do not
+	// sleep. Production never reassigns it.
+	videoTaskNow = time.Now
+
+	// Sweep bookkeeping; both guarded by videoTaskStoreMu.
+	videoTaskInsertsSinceSweep int
+	videoTaskLastSweepAt       time.Time
 )
 
 // HandleVideosCreate handles POST /v1/videos.
@@ -167,7 +222,8 @@ func applyVideoTaskStickyPin(ctx *Ctx, task *ProxyVideoTask) {
 
 // SaveProxyVideoTask saves a video task mapping to the process-local cache and
 // dual-writes to proxy_video_tasks when a runtime DB is available.
-// Known limitation: durable rows have no TTL/GC currently
+// Both copies carry the same timestamp and both are bounded by
+// PROXY_VIDEO_TASK_RETENTION_DAYS (cache: lazy sweep; DB: retention scheduler).
 func SaveProxyVideoTask(task *ProxyVideoTask) {
 	if task == nil || strings.TrimSpace(task.PublicID) == "" {
 		return
@@ -177,11 +233,12 @@ func SaveProxyVideoTask(task *ProxyVideoTask) {
 	cp.PublicID = strings.TrimSpace(cp.PublicID)
 	cp.UpstreamVideoID = strings.TrimSpace(cp.UpstreamVideoID)
 
+	now := videoTaskNow().UTC()
 	videoTaskStoreMu.Lock()
-	videoTaskStore[cp.PublicID] = &cp
+	putVideoTaskEntryLocked(cp.PublicID, &cp, now)
 	videoTaskStoreMu.Unlock()
 
-	if err := upsertProxyVideoTaskDB(&cp); err != nil {
+	if err := upsertProxyVideoTaskDB(&cp, now); err != nil {
 		slog.Warn("proxy video task: durable upsert failed (memory cache still set)",
 			"public_id", cp.PublicID, "error", err)
 	}
@@ -189,15 +246,19 @@ func SaveProxyVideoTask(task *ProxyVideoTask) {
 
 // GetProxyVideoTaskByPublicID retrieves a video task by publicId.
 // Memory cache first; cold miss falls back to proxy_video_tasks.
+// A cache line past the retention TTL counts as a miss even before the next
+// (throttled) sweep deletes it; the durable table then decides exactly as it
+// would for a cold process, so a row the scheduler has not pruned yet re-warms
+// the line with a fresh storedAt.
 func GetProxyVideoTaskByPublicID(publicID string) *ProxyVideoTask {
 	publicID = strings.TrimSpace(publicID)
 	if publicID == "" {
 		return nil
 	}
 	videoTaskStoreMu.RLock()
-	task := videoTaskStore[publicID]
-	if task != nil {
-		cp := *task
+	entry := videoTaskStore[publicID]
+	if entry != nil && entry.task != nil && !videoTaskCacheEntryExpired(entry) {
+		cp := *entry.task
 		videoTaskStoreMu.RUnlock()
 		return &cp
 	}
@@ -211,9 +272,11 @@ func GetProxyVideoTaskByPublicID(publicID string) *ProxyVideoTask {
 	if loaded == nil {
 		return nil
 	}
-	// Warm process-local cache.
+	// Warm process-local cache (a warm load is an insert, so it stamps its own
+	// storedAt and takes part in sweep bookkeeping like a create does).
+	now := videoTaskNow().UTC()
 	videoTaskStoreMu.Lock()
-	videoTaskStore[loaded.PublicID] = loaded
+	putVideoTaskEntryLocked(loaded.PublicID, loaded, now)
 	videoTaskStoreMu.Unlock()
 	cp := *loaded
 	return &cp
@@ -234,7 +297,115 @@ func DeleteProxyVideoTaskByPublicID(publicID string) {
 	}
 }
 
-func upsertProxyVideoTaskDB(task *ProxyVideoTask) error {
+// putVideoTaskEntryLocked inserts or refreshes a cache line and runs the
+// amortized eviction check. Callers must hold videoTaskStoreMu for writing.
+func putVideoTaskEntryLocked(publicID string, task *ProxyVideoTask, now time.Time) {
+	videoTaskStore[publicID] = &videoTaskEntry{task: task, storedAt: now}
+	videoTaskInsertsSinceSweep++
+	maybeSweepVideoTaskCacheLocked(now)
+}
+
+// maybeSweepVideoTaskCacheLocked runs at most one sweep per
+// videoTaskSweepEveryInserts inserts or per videoTaskSweepMinInterval, which is
+// what keeps the insert path amortized O(1): the two thresholds bound (a) how
+// far the map can overshoot the cap during a burst and (b) how long an entry
+// can sit past its TTL in an idle-ish process. Callers must hold the write lock.
+func maybeSweepVideoTaskCacheLocked(now time.Time) {
+	due := videoTaskInsertsSinceSweep >= videoTaskSweepEveryInserts ||
+		now.Sub(videoTaskLastSweepAt) >= videoTaskSweepMinInterval
+	if !due {
+		return
+	}
+	videoTaskInsertsSinceSweep = 0
+	videoTaskLastSweepAt = now
+	sweepVideoTaskCacheLocked(now)
+}
+
+// sweepVideoTaskCacheLocked is the single eviction pass: one O(n) walk for TTL
+// expiry plus a capacity trim when the guardrail is exceeded. It never touches
+// the DB — proxy_video_tasks rows are the retention scheduler's to prune.
+// Callers must hold videoTaskStoreMu for writing.
+func sweepVideoTaskCacheLocked(now time.Time) {
+	var expired int
+	if ttl := videoTaskCacheTTL(); ttl > 0 {
+		cutoff := now.Add(-ttl)
+		for id, entry := range videoTaskStore {
+			if entry == nil || entry.storedAt.Before(cutoff) {
+				delete(videoTaskStore, id)
+				expired++
+			}
+		}
+	}
+	trimmed := trimVideoTaskCacheLocked()
+	if expired+trimmed > 0 {
+		slog.Debug("proxy video task cache: sweep",
+			"expired", expired,
+			"over_cap_trimmed", trimmed,
+			"remaining", len(videoTaskStore),
+		)
+	}
+}
+
+// trimVideoTaskCacheLocked enforces the hard capacity guardrail, evicting
+// oldest-first down to the headroom target so a cache pinned at the cap does
+// not pay for a trim on every insert. Returns the number of lines dropped.
+// Callers must hold videoTaskStoreMu for writing.
+func trimVideoTaskCacheLocked() int {
+	if len(videoTaskStore) <= videoTaskCacheMaxEntries {
+		return 0
+	}
+	target := videoTaskCacheMaxEntries - videoTaskCacheMaxEntries/videoTaskCacheHeadroomDivisor
+	drop := len(videoTaskStore) - target
+	if drop < 1 || drop > len(videoTaskStore) {
+		// Only reachable for a nonsensical (<= 0) cap, which means "hold nothing".
+		drop = len(videoTaskStore)
+	}
+	oldest := make([]videoTaskEntryRef, 0, len(videoTaskStore))
+	for id, entry := range videoTaskStore {
+		ref := videoTaskEntryRef{id: id}
+		if entry != nil {
+			ref.storedAt = entry.storedAt
+		}
+		oldest = append(oldest, ref)
+	}
+	slices.SortFunc(oldest, func(a, b videoTaskEntryRef) int { return a.storedAt.Compare(b.storedAt) })
+	for _, ref := range oldest[:drop] {
+		delete(videoTaskStore, ref.id)
+	}
+	return drop
+}
+
+// videoTaskEntryRef is a (id, storedAt) pair used to order lines for the
+// capacity trim without holding pointers into the map while deleting from it.
+type videoTaskEntryRef struct {
+	id       string
+	storedAt time.Time
+}
+
+// videoTaskCacheTTL reports how long a cache line may live, derived from the
+// same PROXY_VIDEO_TASK_RETENTION_DAYS knob that prunes proxy_video_tasks.
+// 0 means TTL eviction is off — either config is not loaded yet or an operator
+// explicitly disabled retention — and only the capacity guardrail applies.
+func videoTaskCacheTTL() time.Duration {
+	cfg := config.GetSafe()
+	if cfg == nil || cfg.ProxyVideoTaskRetentionDays <= 0 {
+		return 0
+	}
+	return time.Duration(cfg.ProxyVideoTaskRetentionDays) * 24 * time.Hour
+}
+
+// videoTaskCacheEntryExpired reports whether a line is past its TTL. Reads use
+// it to treat an expired line as a miss; deletion still belongs to the sweep,
+// so the read path never needs the write lock.
+func videoTaskCacheEntryExpired(entry *videoTaskEntry) bool {
+	ttl := videoTaskCacheTTL()
+	if ttl <= 0 || entry == nil {
+		return false
+	}
+	return videoTaskNow().UTC().Sub(entry.storedAt) >= ttl
+}
+
+func upsertProxyVideoTaskDB(task *ProxyVideoTask, at time.Time) error {
 	db := store.GetDB()
 	if db == nil || task == nil {
 		return nil
@@ -242,7 +413,7 @@ func upsertProxyVideoTaskDB(task *ProxyVideoTask) error {
 	if strings.TrimSpace(task.PublicID) == "" || strings.TrimSpace(task.UpstreamVideoID) == "" {
 		return nil
 	}
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := at.UTC().Format(time.RFC3339)
 	// store.DB rebinds ? → $N for postgres.
 	const q = `
 INSERT INTO proxy_video_tasks (

--- a/handler/proxy/videos_gc_test.go
+++ b/handler/proxy/videos_gc_test.go
@@ -1,0 +1,353 @@
+package proxyhandler
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// The process-local video task cache is bounded by lazy eviction: a TTL aligned
+// with PROXY_VIDEO_TASK_RETENTION_DAYS plus a hard capacity guardrail. These
+// tests pin the eviction contract — including the throttle, so a future edit
+// cannot quietly turn the insert path into a per-request full scan.
+
+// videoTaskCacheFixture isolates the cache for one GC test: empty map, neutral
+// sweep bookkeeping ("a sweep just ran at start"), pinned injectable clock and
+// capacity guardrail, and a published retention-days config. Everything is
+// restored on cleanup, so GC tests neither evict nor inherit lines owned by
+// other tests in this package.
+//
+// The returned advance func moves the pinned clock; call it only from the test
+// goroutine (never while cache goroutines are in flight).
+func videoTaskCacheFixture(t *testing.T, start time.Time, retentionDays, maxEntries int) func(time.Duration) time.Time {
+	t.Helper()
+
+	prevNow, prevMaxEntries, prevCfg := videoTaskNow, videoTaskCacheMaxEntries, config.Get()
+	now := start.UTC()
+	videoTaskNow = func() time.Time { return now }
+	videoTaskCacheMaxEntries = maxEntries
+	cfgCopy := *prevCfg
+	cfgCopy.ProxyVideoTaskRetentionDays = retentionDays
+	config.Set(&cfgCopy)
+
+	videoTaskStoreMu.Lock()
+	prevStore := videoTaskStore
+	prevInserts, prevSweepAt := videoTaskInsertsSinceSweep, videoTaskLastSweepAt
+	videoTaskStore = make(map[string]*videoTaskEntry)
+	videoTaskInsertsSinceSweep = 0
+	videoTaskLastSweepAt = now
+	videoTaskStoreMu.Unlock()
+
+	t.Cleanup(func() {
+		videoTaskStoreMu.Lock()
+		videoTaskStore = prevStore
+		videoTaskInsertsSinceSweep, videoTaskLastSweepAt = prevInserts, prevSweepAt
+		videoTaskStoreMu.Unlock()
+		videoTaskNow, videoTaskCacheMaxEntries = prevNow, prevMaxEntries
+		config.Set(prevCfg)
+	})
+
+	return func(d time.Duration) time.Time {
+		now = now.Add(d)
+		return now
+	}
+}
+
+// videoTaskCacheSnapshotForTest copies the cache keys with their storedAt plus
+// the sweep bookkeeping, so assertions run without holding the lock.
+func videoTaskCacheSnapshotForTest() (storedAt map[string]time.Time, insertsSinceSweep int, lastSweepAt time.Time) {
+	videoTaskStoreMu.RLock()
+	defer videoTaskStoreMu.RUnlock()
+	storedAt = make(map[string]time.Time, len(videoTaskStore))
+	for id, entry := range videoTaskStore {
+		if entry != nil {
+			storedAt[id] = entry.storedAt
+		}
+	}
+	return storedAt, videoTaskInsertsSinceSweep, videoTaskLastSweepAt
+}
+
+// seedVideoTaskCacheLineForTest inserts a line with an arbitrary storedAt,
+// bypassing the insert path (and its sweep accounting) to model a line that has
+// been sitting in the cache since before the test started.
+func seedVideoTaskCacheLineForTest(t *testing.T, publicID string, storedAt time.Time) {
+	t.Helper()
+	videoTaskStoreMu.Lock()
+	videoTaskStore[publicID] = &videoTaskEntry{
+		task:     &ProxyVideoTask{PublicID: publicID, UpstreamVideoID: "up_" + publicID},
+		storedAt: storedAt.UTC(),
+	}
+	videoTaskStoreMu.Unlock()
+}
+
+// forceVideoTaskSweepForTest runs one sweep immediately, bypassing the
+// throttle, and resets the bookkeeping the way a real sweep does.
+func forceVideoTaskSweepForTest(t *testing.T) {
+	t.Helper()
+	videoTaskStoreMu.Lock()
+	now := videoTaskNow().UTC()
+	videoTaskInsertsSinceSweep = 0
+	videoTaskLastSweepAt = now
+	sweepVideoTaskCacheLocked(now)
+	videoTaskStoreMu.Unlock()
+}
+
+// setVideoTaskSweepCounterForTest pretends n inserts already happened since the
+// last sweep, so a test can trip the count threshold with a single real insert.
+func setVideoTaskSweepCounterForTest(t *testing.T, n int) {
+	t.Helper()
+	videoTaskStoreMu.Lock()
+	videoTaskInsertsSinceSweep = n
+	videoTaskStoreMu.Unlock()
+}
+
+func TestVideoTaskCache_ExpiredLineIsLazyThenEvictedBySweep(t *testing.T) {
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	advance := videoTaskCacheFixture(t, base, 7, videoTaskCacheMaxEntries)
+
+	// A line stored 8 days ago is past the 7-day TTL but has not been swept yet.
+	seedVideoTaskCacheLineForTest(t, "v_aged", base.Add(-8*24*time.Hour))
+	// One insert inside the throttle window: no sweep may run.
+	SaveProxyVideoTask(&ProxyVideoTask{PublicID: "v_fresh", UpstreamVideoID: "up_fresh"})
+
+	storedAt, inserts, lastSweep := videoTaskCacheSnapshotForTest()
+	if _, ok := storedAt["v_aged"]; !ok {
+		t.Fatalf("expired line was removed without a sweep: %v", storedAt)
+	}
+	if len(storedAt) != 2 || inserts != 1 || !lastSweep.Equal(base) {
+		t.Fatalf("throttled insert ran a sweep: len=%d inserts=%d lastSweep=%v", len(storedAt), inserts, lastSweep)
+	}
+	// Reads still refuse to serve the expired line while it waits for the sweep.
+	if got := GetProxyVideoTaskByPublicID("v_aged"); got != nil {
+		t.Fatalf("expired line served from cache: %+v", got)
+	}
+	if got := GetProxyVideoTaskByPublicID("v_fresh"); got == nil || got.UpstreamVideoID != "up_fresh" {
+		t.Fatalf("fresh line = %+v", got)
+	}
+
+	forceVideoTaskSweepForTest(t)
+	storedAt, _, _ = videoTaskCacheSnapshotForTest()
+	if _, ok := storedAt["v_aged"]; ok {
+		t.Fatalf("sweep kept the expired line: %v", storedAt)
+	}
+	if _, ok := storedAt["v_fresh"]; !ok {
+		t.Fatalf("sweep evicted the in-window line: %v", storedAt)
+	}
+
+	// End to end: the next insert after the throttle window sweeps on its own.
+	advance(8 * 24 * time.Hour)
+	SaveProxyVideoTask(&ProxyVideoTask{PublicID: "v_newest", UpstreamVideoID: "up_newest"})
+	storedAt, inserts, _ = videoTaskCacheSnapshotForTest()
+	if _, ok := storedAt["v_fresh"]; ok {
+		t.Fatalf("insert-path sweep did not evict the now-expired line: %v", storedAt)
+	}
+	if _, ok := storedAt["v_newest"]; !ok {
+		t.Fatalf("insert-path sweep evicted the new line: %v", storedAt)
+	}
+	if inserts != 0 {
+		t.Fatalf("sweep bookkeeping not reset: inserts=%d", inserts)
+	}
+}
+
+func TestVideoTaskCache_RetentionDisabledKeepsLines(t *testing.T) {
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	advance := videoTaskCacheFixture(t, base, 0, videoTaskCacheMaxEntries)
+
+	seedVideoTaskCacheLineForTest(t, "v_kept", base.Add(-90*24*time.Hour))
+	advance(90 * 24 * time.Hour)
+	SaveProxyVideoTask(&ProxyVideoTask{PublicID: "v_new", UpstreamVideoID: "up_new"})
+	forceVideoTaskSweepForTest(t)
+
+	storedAt, _, _ := videoTaskCacheSnapshotForTest()
+	if len(storedAt) != 2 {
+		t.Fatalf("retention_days=0 must disable TTL eviction, got %v", storedAt)
+	}
+	// With TTL off the 90-day-old line is still served: "keep forever" is an
+	// explicit operator choice, and memory stays bounded by the capacity guard.
+	if got := GetProxyVideoTaskByPublicID("v_kept"); got == nil {
+		t.Fatal("expected the retained line to be served")
+	}
+}
+
+func TestVideoTaskCache_SweepIsThrottledBetweenThresholds(t *testing.T) {
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	advance := videoTaskCacheFixture(t, base, 1, videoTaskCacheMaxEntries)
+
+	seedVideoTaskCacheLineForTest(t, "v_aged", base.Add(-48*time.Hour))
+	// 10 inserts inside the throttle window (1 s apart, counter below 256).
+	for i := 0; i < 10; i++ {
+		advance(time.Second)
+		SaveProxyVideoTask(&ProxyVideoTask{PublicID: "v_throttle_" + itoa(int64(i))})
+	}
+
+	storedAt, inserts, lastSweep := videoTaskCacheSnapshotForTest()
+	if len(storedAt) != 11 || inserts != 10 || !lastSweep.Equal(base) {
+		t.Fatalf("sweep ran inside the throttle window: len=%d inserts=%d lastSweep=%v",
+			len(storedAt), inserts, lastSweep)
+	}
+	if _, ok := storedAt["v_aged"]; !ok {
+		t.Fatalf("expired line swept early: %v", storedAt)
+	}
+
+	// The count threshold trips exactly one sweep on the next insert.
+	setVideoTaskSweepCounterForTest(t, videoTaskSweepEveryInserts-1)
+	advance(time.Second)
+	SaveProxyVideoTask(&ProxyVideoTask{PublicID: "v_trigger"})
+
+	storedAt, inserts, lastSweep = videoTaskCacheSnapshotForTest()
+	if _, ok := storedAt["v_aged"]; ok {
+		t.Fatalf("count threshold did not evict the expired line: %v", storedAt)
+	}
+	if len(storedAt) != 11 || inserts != 0 {
+		t.Fatalf("post-sweep state len=%d inserts=%d lastSweep=%v", len(storedAt), inserts, lastSweep)
+	}
+	if want := base.Add(11 * time.Second); !lastSweep.Equal(want) {
+		t.Fatalf("lastSweep = %v, want %v", lastSweep, want)
+	}
+}
+
+func TestVideoTaskCache_CapacityGuardrailEvictsOldestFirst(t *testing.T) {
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	// TTL disabled so only the capacity guardrail can evict; cap 4 keeps the
+	// headroom target at exactly 4 (4 - 4/16).
+	advance := videoTaskCacheFixture(t, base, 0, 4)
+
+	for i := 1; i <= 6; i++ {
+		advance(time.Second)
+		SaveProxyVideoTask(&ProxyVideoTask{PublicID: "v_cap_" + itoa(int64(i))})
+	}
+	// Throttled inserts may overshoot the guardrail; the bound is cap+256.
+	if storedAt, _, _ := videoTaskCacheSnapshotForTest(); len(storedAt) != 6 {
+		t.Fatalf("expected throttled overshoot to 6 lines, got %v", storedAt)
+	}
+
+	// Count threshold trips a trim down to the cap, oldest first.
+	setVideoTaskSweepCounterForTest(t, videoTaskSweepEveryInserts-1)
+	advance(time.Second)
+	SaveProxyVideoTask(&ProxyVideoTask{PublicID: "v_cap_7"})
+	assertVideoTaskCacheKeys(t, "count-triggered trim", []string{"v_cap_4", "v_cap_5", "v_cap_6", "v_cap_7"})
+
+	// Interval threshold trips the next trim (counter is far from 256).
+	advance(videoTaskSweepMinInterval + time.Minute)
+	SaveProxyVideoTask(&ProxyVideoTask{PublicID: "v_cap_8"})
+	assertVideoTaskCacheKeys(t, "interval-triggered trim", []string{"v_cap_5", "v_cap_6", "v_cap_7", "v_cap_8"})
+
+	// A sweep resets the counter, including for the insert that triggered it.
+	storedAt, inserts, lastSweep := videoTaskCacheSnapshotForTest()
+	if want := base.Add(7*time.Second + videoTaskSweepMinInterval + time.Minute); inserts != 0 || !lastSweep.Equal(want) {
+		t.Fatalf("post-sweep bookkeeping inserts=%d lastSweep=%v want %v (len %d)",
+			inserts, lastSweep, want, len(storedAt))
+	}
+}
+
+func assertVideoTaskCacheKeys(t *testing.T, label string, want []string) {
+	t.Helper()
+	storedAt, _, _ := videoTaskCacheSnapshotForTest()
+	if len(storedAt) != len(want) {
+		t.Fatalf("%s: cache = %v, want %v", label, storedAt, want)
+	}
+	for _, id := range want {
+		if _, ok := storedAt[id]; !ok {
+			t.Fatalf("%s: missing %q, cache = %v", label, id, storedAt)
+		}
+	}
+}
+
+func TestVideoTaskCache_WarmLoadStampsItsOwnStoredAt(t *testing.T) {
+	db, err := store.Open(store.DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	store.OverrideDB(db)
+	t.Cleanup(func() { store.OverrideDB(nil) })
+
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	advance := videoTaskCacheFixture(t, base, 7, videoTaskCacheMaxEntries)
+
+	const publicID = "v_warm_load"
+	SaveProxyVideoTask(&ProxyVideoTask{PublicID: publicID, UpstreamVideoID: "up_warm"})
+	// Drop the cache line only (restart / other instance); the durable row stays.
+	videoTaskStoreMu.Lock()
+	delete(videoTaskStore, publicID)
+	videoTaskStoreMu.Unlock()
+
+	advance(2 * 24 * time.Hour)
+	if got := GetProxyVideoTaskByPublicID(publicID); got == nil || got.UpstreamVideoID != "up_warm" {
+		t.Fatalf("warm load = %+v", got)
+	}
+	// TTL counts from the warm load, not from the 2-day-old durable row.
+	storedAt, _, _ := videoTaskCacheSnapshotForTest()
+	if want := base.Add(2 * 24 * time.Hour); !storedAt[publicID].Equal(want) {
+		t.Fatalf("warm-load storedAt = %v, want %v", storedAt[publicID], want)
+	}
+
+	// 6 more days: 8 days past the durable row, 6 past the warm load → kept.
+	advance(6 * 24 * time.Hour)
+	forceVideoTaskSweepForTest(t)
+	if storedAt, _, _ := videoTaskCacheSnapshotForTest(); len(storedAt) != 1 {
+		t.Fatalf("warm-loaded line evicted inside its TTL: %v", storedAt)
+	}
+
+	// 2 more days put the warm load past the TTL: the cache line goes, the
+	// durable row stays for the retention scheduler to prune.
+	advance(2 * 24 * time.Hour)
+	forceVideoTaskSweepForTest(t)
+	if storedAt, _, _ := videoTaskCacheSnapshotForTest(); len(storedAt) != 0 {
+		t.Fatalf("expired warm-loaded line kept: %v", storedAt)
+	}
+	var rows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM proxy_video_tasks WHERE public_id = ?`, publicID).Scan(&rows); err != nil {
+		t.Fatalf("count durable rows: %v", err)
+	}
+	if rows != 1 {
+		t.Fatalf("cache sweep deleted durable rows: count=%d", rows)
+	}
+}
+
+func TestVideoTaskCache_ConcurrentInsertTrimAndSweep(t *testing.T) {
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	// Frozen clock (advanced only after the goroutines join) + a small guardrail
+	// so concurrent inserts keep tripping the capacity trim under -race.
+	advance := videoTaskCacheFixture(t, base, 1, 32)
+
+	const workers, iterations = 8, 40
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				id := "v_race_" + itoa(int64(w)) + "_" + itoa(int64(i))
+				SaveProxyVideoTask(&ProxyVideoTask{PublicID: id, UpstreamVideoID: "up_" + id})
+				_ = GetProxyVideoTaskByPublicID(id)
+				if i%4 == 0 {
+					DeleteProxyVideoTaskByPublicID(id)
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	storedAt, _, _ := videoTaskCacheSnapshotForTest()
+	if len(storedAt) > videoTaskCacheMaxEntries+videoTaskSweepEveryInserts {
+		t.Fatalf("cache overshot its documented bound: %d lines", len(storedAt))
+	}
+	forceVideoTaskSweepForTest(t)
+	if storedAt, _, _ := videoTaskCacheSnapshotForTest(); len(storedAt) > videoTaskCacheMaxEntries {
+		t.Fatalf("sweep left the cache over the guardrail: %d lines", len(storedAt))
+	}
+
+	// Everything ages out once the clock passes the TTL.
+	advance(2 * 24 * time.Hour)
+	forceVideoTaskSweepForTest(t)
+	if storedAt, _, _ := videoTaskCacheSnapshotForTest(); len(storedAt) != 0 {
+		t.Fatalf("expected an empty cache after TTL, got %d lines", len(storedAt))
+	}
+}

--- a/scheduler/video_task_retention.go
+++ b/scheduler/video_task_retention.go
@@ -5,7 +5,10 @@ import (
 )
 
 // ProxyVideoTaskRetentionScheduler periodically prunes aged proxy_video_tasks rows.
-// Disabled when ProxyVideoTaskRetentionDays <= 0 (default).
+// Runs by default (ProxyVideoTaskRetentionDays = 7); disabled only by an
+// explicit operator opt-out (<= 0). The same knob bounds the TTL of the
+// process-local rewrite cache in handler/proxy, so durable rows and cached
+// mappings retire together.
 // Implemented by the shared RetentionScheduler.
 type ProxyVideoTaskRetentionScheduler = RetentionScheduler
 
@@ -20,7 +23,7 @@ func NewProxyVideoTaskRetentionScheduler(cfg *config.Config) *RetentionScheduler
 		IntervalMinFn:      func(c *config.Config) int { return c.ProxyVideoTaskRetentionPruneIntervalMinutes },
 		DisabledFn: func(c *config.Config) (bool, string) {
 			if c.ProxyVideoTaskRetentionDays <= 0 {
-				return true, "retention_days=0"
+				return true, "retention_days<=0"
 			}
 			return false, ""
 		},


### PR DESCRIPTION
## What

Two audit findings on the video task mapping path, fixed together because they share one operator-visible dial.

### Unbounded process-local cache

`handler/proxy` kept `videoTaskStore` (publicId → upstream video id + sticky channel/account pin) as a package-level map with no eviction — the old comment admitted it. Every `POST /v1/videos` grew it forever, so a long-running process leaked memory proportional to lifetime video traffic.

Now bounded, lazily and without a background goroutine:

- **TTL from the existing dial** — cache lines age out on `PROXY_VIDEO_TASK_RETENTION_DAYS`, the same knob that prunes `proxy_video_tasks`. One operator dial governs memory and durable rows together.
- **Amortized sweep on insert** — at most one pass per 256 inserts *or* per 5 minutes (burst guard + idle guard), so the hot path stays O(1) amortized and a low-traffic process still retires entries.
- **Hard capacity guardrail (20 000 lines, ~4 MB)** — holds even when an operator explicitly disables retention, because bounding process memory is not optional. Over the cap the sweep trims oldest-first down to `cap - cap/16` so the ordering cost is amortized instead of per-insert.
- **Read path treats an expired line as a miss** (O(1), no write lock) and re-warms from the durable table exactly as a cold process would.
- Injectable clock (`videoTaskNow`) so eviction is tested without sleeping.

Ownership is unchanged and now documented: the cache never deletes DB rows — pruning durable state stays the retention scheduler's job under its lease.

### Retention defaulted to "keep forever"

`DefaultProxyVideoTaskRetentionDays` was `0`, which disabled the scheduler entirely, so `proxy_video_tasks` grew without bound on every deployment. Video task mappings are short-lived id rewrites, so the default is now **7 days** (shorter than the 30-day proxy log/file retention). `<= 0` remains an explicit operator opt-out; the scheduler's disabled-reason string is corrected to `retention_days<=0` (it claimed `=0` while also firing on negatives).

`.env.example` and `docs/configuration.md` document the new default and the fact that the same knob bounds the in-process cache.

## Tests

`handler/proxy/videos_gc_test.go` (6): TTL expiry + lazy window, no eviction when retention is disabled, throttling (both insert-count and interval triggers, no repeat sweeps), capacity guardrail evicting oldest-first, DB warm-load stamping its own `storedAt` while asserting a cache sweep never deletes DB rows, and concurrent insert/trim/sweep under `-race`.

`config/video_task_retention_default_test.go` (3): default is 7, explicit `0`/negative still disables, unparsable values fall back to the default instead of silently disabling retention.

## Verification (local, 2C/4G)

| Gate | Result |
|---|---|
| `go build ./...` | exit 0 |
| `go vet ./...` | exit 0 |
| `go test ./... -count=1` | exit 0 — 43 packages ok, 0 FAIL (baseline before the change was also green) |
| `go test ./handler/proxy/... ./config/... ./scheduler/... -race` | exit 0, no data races |
| `gofmt -l` (edited files) | clean |

## Notes / known limits

- Capacity, throttle thresholds and headroom divisor are package constants, not new env vars — no speculative configuration surface.
- The capacity trim is O(n log n) (sort), amortized to roughly once per `cap/16` inserts; documented as such rather than claimed O(n).
- Eviction is observable at debug log level only (no new metric).
- `storedAt` is insertion time, not last access: a hot mapping still ages out and pays one DB re-warm. Deliberate, so the read path only needs `RLock`.
- Cross-instance staleness is unchanged (another instance's `DELETE` removes the DB row; a local cache line can still hit until TTL/sweep) — this narrows that window from "forever" to the retention window.