### PR TITLE
perf(auth): move Redis admission counting out of the lock, shard it, pool connections

### DIFF
--- a/auth/key_admission.go
+++ b/auth/key_admission.go
@@ -5,30 +5,66 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/deliciousbuding/metapi-go/internal/sharedcount"
 )
 
+// admissionShards is the number of lock stripes guarding the process-local
+// windows: keyID % admissionShards picks the stripe, so unrelated keys never wait
+// on each other. No stripe is ever held across a shared-counter round trip.
+const admissionShards = 64
+
+// shardPadBytes pads admissionShard out to a 64-byte cache line
+// (sync.Mutex 8 + map header 8 + 48) so a hot stripe does not bounce the line of
+// its neighbours.
+const shardPadBytes = 48
+
 // KeyAdmissionLimiter is an in-process sliding-window RPM/TPM gate for
 // managed downstream keys. Default unlimited when limits are nil/<=0.
 // Multi-instance deployments optionally share RPM/TPM via WindowCounter.
 // Snapshot() remains process-local (known limitation).
+//
+// Locking model:
+//   - shards[keyID%admissionShards].mu guards the local window data and is only
+//     ever held for in-memory work (prune / check / append);
+//   - keyWindow.sharedMu serializes the shared-counter round trips of one key, so
+//     an Incr and its compensating Decr can never be reordered by a concurrent
+//     request for the same key;
+//   - nesting is always sharedMu -> shard mu, never the reverse (the shard lock is
+//     released before sharedMu is taken), so slow Redis I/O blocks neither another
+//     key nor a shard, and the two locks cannot deadlock.
 type KeyAdmissionLimiter struct {
-	mu   sync.Mutex
-	keys map[int64]*keyWindow
+	shards [admissionShards]admissionShard
+	// cfgMu serializes the read-modify-write of counters in the setters.
+	cfgMu sync.Mutex
+	// counters is swapped as a whole so Allow reads RPM+TPM with one lock-free
+	// load. nil = memory-only.
+	counters atomic.Pointer[sharedCounters]
 	// nowFn is injectable for tests.
 	nowFn func() time.Time
-	// sharedRPM is optional multi-instance counter. nil = memory-only.
-	// Fail-open: Redis errors fall back to local window.
-	sharedRPM sharedcount.WindowCounter
-	// sharedTPM is optional multi-instance token counter. nil = memory-only.
-	// Typically the same RedisCounter instance as sharedRPM.
-	// Fail-open: Redis errors fall back to local tokenEvents.
-	sharedTPM sharedcount.WindowCounter
+}
+
+// sharedCounters bundles the optional multi-instance counters.
+// Fail-open: Redis errors fall back to the process-local window.
+// Both fields are typically the same RedisCounter instance (distinct key
+// namespaces); either may be nil to keep that dimension memory-only.
+type sharedCounters struct {
+	rpm sharedcount.WindowCounter
+	tpm sharedcount.WindowCounter
+}
+
+type admissionShard struct {
+	mu   sync.Mutex
+	keys map[int64]*keyWindow
+	_    [shardPadBytes]byte
 }
 
 type keyWindow struct {
+	// sharedMu serializes this key's shared-counter round trips. Only the shared
+	// path takes it; the memory-only path and Snapshot never do.
+	sharedMu sync.Mutex
 	// request timestamps (unix ms) within the last 60s
 	reqTimes []int64
 	// token events: {atMs, tokens}
@@ -40,14 +76,72 @@ type tokenEvent struct {
 	tokens int64
 }
 
+// localWindow is a consistent snapshot of the process-local window taken under
+// the shard lock. retryRPM/retryTPM are the Retry-After values the local deny
+// paths report, computed from that same snapshot.
+type localWindow struct {
+	usedRPM  int64
+	usedTPM  int64
+	retryRPM time.Duration
+	retryTPM time.Duration
+}
+
+// sharedVerdict is the outcome of one dimension's shared-counter round trip.
+type sharedVerdict struct {
+	// counted reports that the shared counter answered, which makes its count
+	// authoritative and skips the local check for that dimension.
+	counted bool
+	count   int64
+}
+
 // GlobalKeyAdmission is the process-wide limiter used by ProxyAuth.
 var GlobalKeyAdmission = NewKeyAdmissionLimiter()
 
 // NewKeyAdmissionLimiter creates an empty limiter.
 func NewKeyAdmissionLimiter() *KeyAdmissionLimiter {
 	return &KeyAdmissionLimiter{
-		keys:  make(map[int64]*keyWindow),
 		nowFn: time.Now,
+	}
+}
+
+// shard returns the lock stripe owning keyID.
+func (l *KeyAdmissionLimiter) shard(keyID int64) *admissionShard {
+	return &l.shards[uint64(keyID)%admissionShards]
+}
+
+// windowLocked returns (creating if needed) the window for keyID.
+// Caller must hold sh.mu.
+func (sh *admissionShard) windowLocked(keyID int64) *keyWindow {
+	w := sh.keys[keyID]
+	if w == nil {
+		if sh.keys == nil {
+			sh.keys = make(map[int64]*keyWindow)
+		}
+		w = &keyWindow{}
+		sh.keys[keyID] = w
+	}
+	return w
+}
+
+// snapshotLocked prunes the window and reads local usage plus the Retry-After
+// values the local deny paths would report. Caller must hold the shard lock.
+func (w *keyWindow) snapshotLocked(windowStart, nowMs int64) localWindow {
+	w.reqTimes = pruneTimes(w.reqTimes, windowStart)
+	w.tokenEvents = pruneTokenEvents(w.tokenEvents, windowStart)
+	return localWindow{
+		usedRPM:  int64(len(w.reqTimes)),
+		usedTPM:  sumTokens(w.tokenEvents),
+		retryRPM: time.Duration(retryAfterMs(w.reqTimes, nowMs)) * time.Millisecond,
+		retryTPM: time.Duration(retryAfterTokenMs(w.tokenEvents, nowMs)) * time.Millisecond,
+	}
+}
+
+// reserveLocked records an admitted request in the process-local window.
+// Caller must hold the shard lock.
+func (w *keyWindow) reserveLocked(nowMs, tpmLimit, estimatedTokens int64) {
+	w.reqTimes = append(w.reqTimes, nowMs)
+	if estimatedTokens > 0 && tpmLimit > 0 {
+		w.tokenEvents = append(w.tokenEvents, tokenEvent{atMs: nowMs, tokens: estimatedTokens})
 	}
 }
 
@@ -57,9 +151,14 @@ func (l *KeyAdmissionLimiter) SetSharedRPMCounter(c sharedcount.WindowCounter) {
 	if l == nil {
 		return
 	}
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.sharedRPM = c
+	l.cfgMu.Lock()
+	defer l.cfgMu.Unlock()
+	next := sharedCounters{}
+	if cur := l.counters.Load(); cur != nil {
+		next = *cur
+	}
+	next.rpm = c
+	l.counters.Store(&next)
 }
 
 // SetSharedTPMCounter wires an optional multi-instance token counter.
@@ -69,9 +168,14 @@ func (l *KeyAdmissionLimiter) SetSharedTPMCounter(c sharedcount.WindowCounter) {
 	if l == nil {
 		return
 	}
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.sharedTPM = c
+	l.cfgMu.Lock()
+	defer l.cfgMu.Unlock()
+	next := sharedCounters{}
+	if cur := l.counters.Load(); cur != nil {
+		next = *cur
+	}
+	next.tpm = c
+	l.counters.Store(&next)
 }
 
 // ConfigureSharedAdmissionFromRedisURL enables Redis-backed RPM+TPM counting when url is non-empty.
@@ -113,6 +217,11 @@ type AdmissionDecision struct {
 // Allow checks and records a request against optional RPM/TPM limits.
 // estimatedTokens is reserved against TPM when maxTPM is set; pass 0 to skip TPM accounting.
 // When allowed, the request is recorded immediately (admission reservation).
+//
+// Shared-counter round trips never run under a shard lock, so a slow or
+// unreachable Redis costs latency only for its own key. Decisions keep the exact
+// order they had under the previous single lock: shared RPM -> local RPM fallback
+// -> shared TPM -> local TPM fallback -> reservation.
 func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimatedTokens int64) AdmissionDecision {
 	if l == nil || keyID <= 0 {
 		return AdmissionDecision{Allowed: true}
@@ -133,111 +242,164 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 	nowMs := now.UnixMilli()
 	windowStart := nowMs - 60_000
 
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	w := l.keys[keyID]
-	if w == nil {
-		w = &keyWindow{}
-		l.keys[keyID] = w
+	var rpmCounter, tpmCounter sharedcount.WindowCounter
+	if sc := l.counters.Load(); sc != nil {
+		rpmCounter, tpmCounter = sc.rpm, sc.tpm
 	}
-	// prune
-	w.reqTimes = pruneTimes(w.reqTimes, windowStart)
-	w.tokenEvents = pruneTokenEvents(w.tokenEvents, windowStart)
+	useSharedRPM := rpmLimit > 0 && rpmCounter != nil
+	useSharedTPM := tpmLimit > 0 && estimatedTokens > 0 && tpmCounter != nil
 
-	usedRPM := int64(len(w.reqTimes))
-	usedTPM := sumTokens(w.tokenEvents)
-
-	// Optional multi-instance RPM. Fail-open on errors.
-	// On deny, compensating Decr so denied requests do not occupy the window.
-	sharedRPMCounted := false
-	rpmKey := rpmSharedKey(keyID)
-	if rpmLimit > 0 && l.sharedRPM != nil {
-		n, err := l.sharedRPM.Incr(context.Background(), rpmKey, time.Minute)
-		if err != nil {
-			slog.Debug("redis admission: fail-open on error", "key_id", keyID, "error", err)
-		} else {
-			sharedRPMCounted = true
-			usedRPM = n
-			if n > rpmLimit {
-				if _, rerr := l.sharedRPM.Decr(context.Background(), rpmKey, time.Minute); rerr != nil {
-					slog.Debug("redis admission: rpm rollback failed", "key_id", keyID, "error", rerr)
-				}
-				return AdmissionDecision{
-					Allowed:    false,
-					Reason:     "over_rpm",
-					RetryAfter: time.Second,
-					UsedRPM:    usedRPM,
-					UsedTPM:    usedTPM,
-				}
+	sh := l.shard(keyID)
+	if !useSharedRPM && !useSharedTPM {
+		// Memory-only: nothing to move out of the lock, so decide and reserve in a
+		// single shard-lock hold (exact under concurrency, as before).
+		sh.mu.Lock()
+		defer sh.mu.Unlock()
+		w := sh.windowLocked(keyID)
+		loc := w.snapshotLocked(windowStart, nowMs)
+		if rpmLimit > 0 && loc.usedRPM >= rpmLimit {
+			return AdmissionDecision{
+				Allowed:    false,
+				Reason:     "over_rpm",
+				RetryAfter: loc.retryRPM,
+				UsedRPM:    loc.usedRPM,
+				UsedTPM:    loc.usedTPM,
 			}
+		}
+		if tpmLimit > 0 && estimatedTokens > 0 && loc.usedTPM+estimatedTokens > tpmLimit {
+			return AdmissionDecision{
+				Allowed:    false,
+				Reason:     "over_tpm",
+				RetryAfter: loc.retryTPM,
+				UsedRPM:    loc.usedRPM,
+				UsedTPM:    loc.usedTPM,
+			}
+		}
+		// reserve (process-local known limitation for Snapshot)
+		w.reserveLocked(nowMs, tpmLimit, estimatedTokens)
+		return AdmissionDecision{
+			Allowed: true,
+			UsedRPM: loc.usedRPM + 1,
+			UsedTPM: loc.usedTPM + max64z(estimatedTokens, 0),
 		}
 	}
 
-	if !sharedRPMCounted && rpmLimit > 0 && usedRPM >= rpmLimit {
-		retry := retryAfterMs(w.reqTimes, nowMs)
-		return AdmissionDecision{
-			Allowed:    false,
-			Reason:     "over_rpm",
-			RetryAfter: time.Duration(retry) * time.Millisecond,
-			UsedRPM:    usedRPM,
-			UsedTPM:    usedTPM,
+	// Take the window and read local usage, then release the shard lock: every
+	// Redis round trip below happens with no shard lock held.
+	sh.mu.Lock()
+	w := sh.windowLocked(keyID)
+	loc := w.snapshotLocked(windowStart, nowMs)
+	sh.mu.Unlock()
+
+	// Serialize the shared round trips for this key only. Holding it across the
+	// local fallback checks keeps check-and-reserve atomic for this key, which is
+	// what the old global lock gave us.
+	w.sharedMu.Lock()
+	defer w.sharedMu.Unlock()
+
+	ctx := context.Background()
+	rpmKey := rpmSharedKey(keyID)
+	tpmKey := tpmSharedKey(keyID)
+	var rpm, tpm sharedVerdict
+
+	// Optional multi-instance RPM. Fail-open on errors.
+	// On deny, compensating Decr so denied requests do not occupy the window.
+	if useSharedRPM {
+		n, err := rpmCounter.Incr(ctx, rpmKey, time.Minute)
+		if err != nil {
+			slog.Debug("redis admission: fail-open on error", "key_id", keyID, "error", err)
+		} else if n > rpmLimit {
+			if _, rerr := rpmCounter.Decr(ctx, rpmKey, time.Minute); rerr != nil {
+				slog.Debug("redis admission: rpm rollback failed", "key_id", keyID, "error", rerr)
+			}
+			return AdmissionDecision{
+				Allowed:    false,
+				Reason:     "over_rpm",
+				RetryAfter: time.Second,
+				UsedRPM:    n,
+				UsedTPM:    loc.usedTPM,
+			}
+		} else {
+			rpm = sharedVerdict{counted: true, count: n}
+		}
+	}
+
+	// Local RPM verdict, only when the shared counter did not answer for RPM.
+	// Re-read under the shard lock — the snapshot above is stale once we have
+	// waited on Redis. Denying here happens before the TPM round trip, matching
+	// the old order: an RPM deny never reserves TPM.
+	if !rpm.counted && rpmLimit > 0 {
+		loc = sh.snapshot(w, windowStart, nowMs)
+		if loc.usedRPM >= rpmLimit {
+			return AdmissionDecision{
+				Allowed:    false,
+				Reason:     "over_rpm",
+				RetryAfter: loc.retryRPM,
+				UsedRPM:    loc.usedRPM,
+				UsedTPM:    loc.usedTPM,
+			}
 		}
 	}
 
 	// Optional multi-instance TPM. Fail-open on errors.
 	// On deny, roll back TPM (and RPM if already reserved) so the window stays free.
-	sharedTPMCounted := false
-	tpmKey := tpmSharedKey(keyID)
-	if tpmLimit > 0 && estimatedTokens > 0 && l.sharedTPM != nil {
-		n, err := l.sharedTPM.IncrBy(context.Background(), tpmKey, estimatedTokens, time.Minute)
+	if useSharedTPM {
+		n, err := tpmCounter.IncrBy(ctx, tpmKey, estimatedTokens, time.Minute)
 		if err != nil {
 			slog.Debug("redis admission tpm: fail-open on error", "key_id", keyID, "error", err)
-		} else {
-			sharedTPMCounted = true
-			usedTPM = n
-			if n > tpmLimit {
-				if _, rerr := l.sharedTPM.IncrBy(context.Background(), tpmKey, -estimatedTokens, time.Minute); rerr != nil {
-					slog.Debug("redis admission: tpm rollback failed", "key_id", keyID, "error", rerr)
-				}
-				if sharedRPMCounted {
-					if _, rerr := l.sharedRPM.Decr(context.Background(), rpmKey, time.Minute); rerr != nil {
-						slog.Debug("redis admission: rpm rollback after tpm deny failed", "key_id", keyID, "error", rerr)
-					}
-				}
-				return AdmissionDecision{
-					Allowed:    false,
-					Reason:     "over_tpm",
-					RetryAfter: time.Second,
-					UsedRPM:    usedRPM,
-					UsedTPM:    usedTPM,
+		} else if n > tpmLimit {
+			if _, rerr := tpmCounter.IncrBy(ctx, tpmKey, -estimatedTokens, time.Minute); rerr != nil {
+				slog.Debug("redis admission: tpm rollback failed", "key_id", keyID, "error", rerr)
+			}
+			if rpm.counted {
+				if _, rerr := rpmCounter.Decr(ctx, rpmKey, time.Minute); rerr != nil {
+					slog.Debug("redis admission: rpm rollback after tpm deny failed", "key_id", keyID, "error", rerr)
 				}
 			}
+			usedRPM := loc.usedRPM
+			if rpm.counted {
+				usedRPM = rpm.count
+			}
+			return AdmissionDecision{
+				Allowed:    false,
+				Reason:     "over_tpm",
+				RetryAfter: time.Second,
+				UsedRPM:    usedRPM,
+				UsedTPM:    n,
+			}
+		} else {
+			tpm = sharedVerdict{counted: true, count: n}
 		}
 	}
 
-	if !sharedTPMCounted && tpmLimit > 0 && estimatedTokens > 0 && usedTPM+estimatedTokens > tpmLimit {
-		retry := retryAfterTokenMs(w.tokenEvents, nowMs)
+	// Local TPM verdict (when the shared counter did not answer for TPM) plus the
+	// reservation, in one shard-lock hold so check-and-record stay atomic.
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	loc = w.snapshotLocked(windowStart, nowMs)
+	usedRPM, usedTPM := loc.usedRPM, loc.usedTPM
+	if rpm.counted {
+		usedRPM = rpm.count
+	}
+	if tpm.counted {
+		usedTPM = tpm.count
+	} else if tpmLimit > 0 && estimatedTokens > 0 && usedTPM+estimatedTokens > tpmLimit {
 		return AdmissionDecision{
 			Allowed:    false,
 			Reason:     "over_tpm",
-			RetryAfter: time.Duration(retry) * time.Millisecond,
+			RetryAfter: loc.retryTPM,
 			UsedRPM:    usedRPM,
 			UsedTPM:    usedTPM,
 		}
 	}
-
 	// reserve (process-local known limitation for Snapshot)
-	w.reqTimes = append(w.reqTimes, nowMs)
-	if estimatedTokens > 0 && tpmLimit > 0 {
-		w.tokenEvents = append(w.tokenEvents, tokenEvent{atMs: nowMs, tokens: estimatedTokens})
-	}
+	w.reserveLocked(nowMs, tpmLimit, estimatedTokens)
 	outRPM := usedRPM
-	if !sharedRPMCounted {
+	if !rpm.counted {
 		outRPM = usedRPM + 1
 	}
 	outTPM := usedTPM
-	if !sharedTPMCounted {
+	if !tpm.counted {
 		outTPM = usedTPM + max64z(estimatedTokens, 0)
 	}
 	return AdmissionDecision{
@@ -247,6 +409,13 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 	}
 }
 
+// snapshot reads the local window for w under the shard lock.
+func (sh *admissionShard) snapshot(w *keyWindow, windowStart, nowMs int64) localWindow {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	return w.snapshotLocked(windowStart, nowMs)
+}
+
 // Snapshot returns current window usage for admin display.
 func (l *KeyAdmissionLimiter) Snapshot(keyID int64) (usedRPM, usedTPM int64) {
 	if l == nil || keyID <= 0 {
@@ -254,15 +423,15 @@ func (l *KeyAdmissionLimiter) Snapshot(keyID int64) (usedRPM, usedTPM int64) {
 	}
 	nowMs := l.nowFn().UTC().UnixMilli()
 	windowStart := nowMs - 60_000
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	w := l.keys[keyID]
+	sh := l.shard(keyID)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	w := sh.keys[keyID]
 	if w == nil {
 		return 0, 0
 	}
-	w.reqTimes = pruneTimes(w.reqTimes, windowStart)
-	w.tokenEvents = pruneTokenEvents(w.tokenEvents, windowStart)
-	return int64(len(w.reqTimes)), sumTokens(w.tokenEvents)
+	loc := w.snapshotLocked(windowStart, nowMs)
+	return loc.usedRPM, loc.usedTPM
 }
 
 func pruneTimes(in []int64, windowStart int64) []int64 {

--- a/auth/key_admission_bench_test.go
+++ b/auth/key_admission_bench_test.go
@@ -1,0 +1,141 @@
+package auth
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// benchWindow stands in for the shared Redis counter with an injectable
+// round-trip latency. Totals are atomic and nothing is held across the sleep, so
+// the numbers reflect the limiter's own serialization rather than the fake's.
+// This file deliberately touches only the public admission surface, so the same
+// benchmark compiles and runs against both the pre-refactor and post-refactor
+// limiter (that is how the before/after numbers were produced).
+type benchWindow struct {
+	delay time.Duration
+	rpm   atomic.Int64
+	tpm   atomic.Int64
+}
+
+func (c *benchWindow) roundTrip() {
+	if c.delay > 0 {
+		time.Sleep(c.delay)
+	}
+}
+
+func (c *benchWindow) isTPM(key string) bool { return strings.HasPrefix(key, "metapi:tpm:") }
+
+func (c *benchWindow) Incr(ctx context.Context, key string, window time.Duration) (int64, error) {
+	_ = ctx
+	_ = window
+	c.roundTrip()
+	if c.isTPM(key) {
+		return c.tpm.Add(1), nil
+	}
+	return c.rpm.Add(1), nil
+}
+
+func (c *benchWindow) Decr(ctx context.Context, key string, window time.Duration) (int64, error) {
+	_ = ctx
+	_ = window
+	c.roundTrip()
+	if c.isTPM(key) {
+		return c.tpm.Add(-1), nil
+	}
+	return c.rpm.Add(-1), nil
+}
+
+func (c *benchWindow) IncrBy(ctx context.Context, key string, delta int64, window time.Duration) (int64, error) {
+	_ = ctx
+	_ = window
+	c.roundTrip()
+	if c.isTPM(key) {
+		return c.tpm.Add(delta), nil
+	}
+	return c.rpm.Add(delta), nil
+}
+
+func (c *benchWindow) Get(ctx context.Context, key string) (int64, error) {
+	_ = ctx
+	if c.isTPM(key) {
+		return c.tpm.Load(), nil
+	}
+	return c.rpm.Load(), nil
+}
+
+// reportLatency reports the observed per-call latency distribution.
+func reportLatency(b *testing.B, d []time.Duration) {
+	if len(d) == 0 {
+		return
+	}
+	sort.Slice(d, func(i, j int) bool { return d[i] < d[j] })
+	at := func(p float64) float64 {
+		idx := int(float64(len(d)-1) * p)
+		return float64(d[idx].Microseconds()) / 1000
+	}
+	b.ReportMetric(float64(len(d)), "calls")
+	b.ReportMetric(at(0.50), "p50-ms")
+	b.ReportMetric(at(0.99), "p99-ms")
+	b.ReportMetric(at(1.00), "max-ms")
+}
+
+// runAllowBench drives Allow from GOMAXPROCS goroutines (set with -cpu) and
+// reports throughput plus the latency each caller observed. keyFor maps a worker
+// to the key it hammers.
+func runAllowBench(b *testing.B, setup func(l *KeyAdmissionLimiter), keyFor func(worker int64) int64) {
+	b.Helper()
+	l := NewKeyAdmissionLimiter()
+	setup(l)
+	// High enough that nothing is denied: every call is exactly one shared round
+	// trip (no compensating Decr), which is the steady-state admission path.
+	limit := int64(1_000_000_000)
+	var seq atomic.Int64
+	var mu sync.Mutex
+	var all []time.Duration
+	begin := time.Now()
+	b.RunParallel(func(pb *testing.PB) {
+		keyID := keyFor(seq.Add(1))
+		durs := make([]time.Duration, 0, 4096)
+		for pb.Next() {
+			t0 := time.Now()
+			l.Allow(keyID, &limit, nil, 0)
+			durs = append(durs, time.Since(t0))
+		}
+		mu.Lock()
+		all = append(all, durs...)
+		mu.Unlock()
+	})
+	elapsed := time.Since(begin)
+	b.ReportMetric(float64(b.N)/elapsed.Seconds(), "calls/s")
+	reportLatency(b, all)
+}
+
+// BenchmarkAllowSharedManyKeys is the audit scenario: REDIS_URL configured, many
+// managed keys, ~2ms per shared round trip. The old code held one global mutex
+// across that round trip, so every key queued behind every other key.
+func BenchmarkAllowSharedManyKeys(b *testing.B) {
+	runAllowBench(b, func(l *KeyAdmissionLimiter) {
+		l.SetSharedRPMCounter(&benchWindow{delay: 2 * time.Millisecond})
+	}, func(worker int64) int64 { return worker })
+}
+
+// BenchmarkAllowSharedOneKey is the control: one hot key. Admissions for a single
+// key must stay serialized (an Incr and its compensating Decr may not be
+// reordered), so this number is expected to be latency-bound before and after.
+func BenchmarkAllowSharedOneKey(b *testing.B) {
+	runAllowBench(b, func(l *KeyAdmissionLimiter) {
+		l.SetSharedRPMCounter(&benchWindow{delay: 2 * time.Millisecond})
+	}, func(worker int64) int64 { return 1 })
+}
+
+// BenchmarkAllowMemoryOnlyManyKeys isolates the sharding win for the default
+// deployment (no REDIS_URL): same in-memory work, but the global mutex is now 64
+// stripes.
+func BenchmarkAllowMemoryOnlyManyKeys(b *testing.B) {
+	runAllowBench(b, func(l *KeyAdmissionLimiter) {}, func(worker int64) int64 { return worker })
+}

--- a/auth/key_admission_lock_test.go
+++ b/auth/key_admission_lock_test.go
@@ -1,0 +1,334 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// slowWindow is a WindowCounter that simulates a shared (Redis) round trip with a
+// fixed latency. Totals live in atomics and no lock is held across the delay, so
+// whatever serialization a test measures comes from the limiter, not the fake.
+//
+// hook (optional) runs inside the simulated round trip, i.e. while Allow is in its
+// shared-counter section, which is what makes "no limiter lock is held here"
+// directly observable. ops (optional) records the call sequence per key for
+// ordering assertions.
+type slowWindow struct {
+	delay time.Duration
+	err   error
+	hook  func(key string)
+	rpm   atomic.Int64
+	tpm   atomic.Int64
+
+	recordOps bool
+	mu        sync.Mutex
+	ops       []string
+}
+
+func (c *slowWindow) isTPM(key string) bool { return strings.HasPrefix(key, "metapi:tpm:") }
+
+func (c *slowWindow) wait() {
+	if c.delay > 0 {
+		time.Sleep(c.delay)
+	}
+}
+
+func (c *slowWindow) log(op string) {
+	if !c.recordOps {
+		return
+	}
+	c.mu.Lock()
+	c.ops = append(c.ops, op)
+	c.mu.Unlock()
+}
+
+func (c *slowWindow) Incr(ctx context.Context, key string, window time.Duration) (int64, error) {
+	_ = ctx
+	_ = window
+	c.wait()
+	if c.hook != nil {
+		c.hook(key)
+	}
+	if c.err != nil {
+		return 0, c.err
+	}
+	if c.isTPM(key) {
+		n := c.tpm.Add(1)
+		c.log("INCR")
+		return n, nil
+	}
+	n := c.rpm.Add(1)
+	c.log("INCR")
+	return n, nil
+}
+
+func (c *slowWindow) Decr(ctx context.Context, key string, window time.Duration) (int64, error) {
+	_ = ctx
+	_ = window
+	c.wait()
+	if c.err != nil {
+		return 0, c.err
+	}
+	if c.isTPM(key) {
+		n := c.tpm.Add(-1)
+		c.log("DECR")
+		return n, nil
+	}
+	n := c.rpm.Add(-1)
+	c.log("DECR")
+	return n, nil
+}
+
+func (c *slowWindow) IncrBy(ctx context.Context, key string, delta int64, window time.Duration) (int64, error) {
+	_ = ctx
+	_ = window
+	c.wait()
+	if c.err != nil {
+		return 0, c.err
+	}
+	if c.isTPM(key) {
+		n := c.tpm.Add(delta)
+		c.log("INCRBY")
+		return n, nil
+	}
+	n := c.rpm.Add(delta)
+	c.log("INCRBY")
+	return n, nil
+}
+
+func (c *slowWindow) Get(ctx context.Context, key string) (int64, error) {
+	_ = ctx
+	if c.isTPM(key) {
+		return c.tpm.Load(), c.err
+	}
+	return c.rpm.Load(), c.err
+}
+
+// withinTimeout fails the test unless fn returns in time. Used to turn "the
+// limiter is blocked" into a test failure instead of a hung suite.
+func withinTimeout(t *testing.T, d time.Duration, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("%s did not finish within %v — admission is blocked", what, d)
+	}
+}
+
+// TestKeyAdmission_SharedCounterRunsOutsideShardLock is the direct proof for the
+// refactor: from inside a shared-counter round trip (where the old code sat inside
+// the global mutex) we run a full Allow for a *different key in the same shard
+// stripe* plus a Snapshot for both keys. Any limiter lock held across the Redis
+// I/O would deadlock here.
+func TestKeyAdmission_SharedCounterRunsOutsideShardLock(t *testing.T) {
+	t.Parallel()
+	l := NewKeyAdmissionLimiter()
+	const keyA = int64(7)
+	keyB := keyA + admissionShards // different window, same shard stripe
+	limit := int64(1000)
+
+	var hookRan atomic.Int64
+	// The hook runs on the goroutine that is inside Allow, which may still be
+	// parked there when this test times out, so failures are recorded instead of
+	// reported through t from a foreign goroutine.
+	var hookErr atomic.Value // string
+	fail := func(format string, args ...any) { hookErr.Store(fmt.Sprintf(format, args...)) }
+	c := &slowWindow{delay: 5 * time.Millisecond}
+	c.hook = func(key string) {
+		if key != rpmSharedKey(keyA) {
+			return // the nested Allow below shares this counter
+		}
+		hookRan.Add(1)
+		// Nested admission for another key in the SAME shard stripe.
+		if d := l.Allow(keyB, &limit, nil, 0); !d.Allowed {
+			fail("nested Allow denied: %#v", d)
+		}
+		// Snapshot takes the shard lock but must never take the per-key shared
+		// mutex, so it works for the key whose round trip is in flight too.
+		if used, _ := l.Snapshot(keyB); used != 1 {
+			fail("nested Snapshot(keyB) = %d, want 1", used)
+		}
+		if used, _ := l.Snapshot(keyA); used != 0 {
+			fail("Snapshot(keyA) during its own round trip = %d, want 0", used)
+		}
+	}
+	l.SetSharedRPMCounter(c)
+
+	var d AdmissionDecision
+	withinTimeout(t, 10*time.Second, "Allow with a slow shared counter", func() {
+		d = l.Allow(keyA, &limit, nil, 0)
+	})
+	if hookRan.Load() == 0 {
+		t.Fatal("shared counter hook never ran — test did not exercise the shared path")
+	}
+	if msg, ok := hookErr.Load().(string); ok {
+		t.Fatal(msg)
+	}
+	if !d.Allowed {
+		t.Fatalf("outer Allow denied: %#v", d)
+	}
+}
+
+// TestKeyAdmission_DistinctKeysNotSerializedBySharedCounter quantifies the same
+// property: with a 25ms shared round trip, 16 distinct keys must finish well under
+// the 400ms a single global lock would need. The bound is half of that serial cost,
+// which the parallel version clears by ~6x even on a loaded box (sleeping
+// goroutines need no CPU, so the assertion is not scheduler-sensitive).
+func TestKeyAdmission_DistinctKeysNotSerializedBySharedCounter(t *testing.T) {
+	t.Parallel()
+	const keys = 16
+	const delay = 25 * time.Millisecond
+	l := NewKeyAdmissionLimiter()
+	l.SetSharedRPMCounter(&slowWindow{delay: delay})
+	limit := int64(1_000_000)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < keys; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			if d := l.Allow(int64(i+1), &limit, nil, 0); !d.Allowed {
+				t.Errorf("key %d denied: %#v", i+1, d)
+			}
+		}(i)
+	}
+	begin := time.Now()
+	close(start)
+	wg.Wait()
+	elapsed := time.Since(begin)
+	serial := time.Duration(keys) * delay
+	if elapsed >= serial/2 {
+		t.Fatalf("%d distinct keys took %v; a serialized limiter needs %v", keys, elapsed, serial)
+	}
+}
+
+// TestKeyAdmission_DenyCompensationStaysOrderedPerKey pins the ordering guarantee
+// that replaces the global lock: for one key the compensating DECR of a denied
+// request can never be reordered against another request's INCR, so the shared
+// window does not drift and exactly the limit is admitted.
+func TestKeyAdmission_DenyCompensationStaysOrderedPerKey(t *testing.T) {
+	t.Parallel()
+	l := NewKeyAdmissionLimiter()
+	c := &slowWindow{delay: time.Millisecond, recordOps: true}
+	l.SetSharedRPMCounter(c)
+	limit := int64(3)
+	const requests = 40
+
+	decisions := make([]AdmissionDecision, requests)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < requests; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			decisions[i] = l.Allow(101, &limit, nil, 0)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	allowed := 0
+	for _, d := range decisions {
+		if d.Allowed {
+			allowed++
+			continue
+		}
+		if d.Reason != "over_rpm" || d.RetryAfter != time.Second {
+			t.Fatalf("denied decision = %#v, want over_rpm + 1s", d)
+		}
+	}
+	if allowed != int(limit) {
+		t.Fatalf("allowed = %d, want exactly %d", allowed, limit)
+	}
+	if got := c.rpm.Load(); got != limit {
+		t.Fatalf("shared counter = %d after %d requests, want %d (compensation drifted)", got, requests, limit)
+	}
+	// Every DECR must directly follow the INCR it compensates: no other request
+	// may interleave between them.
+	c.mu.Lock()
+	ops := append([]string(nil), c.ops...)
+	c.mu.Unlock()
+	if len(ops) != requests+(requests-allowed) {
+		t.Fatalf("op log length = %d, want %d (%#v)", len(ops), requests+(requests-allowed), ops)
+	}
+	for i, op := range ops {
+		switch op {
+		case "INCR":
+		case "DECR":
+			if i == 0 || ops[i-1] != "INCR" {
+				t.Fatalf("DECR at %d is not adjacent to its INCR: %v", i, ops)
+			}
+		default:
+			t.Fatalf("unexpected op %q in log", op)
+		}
+	}
+	// Denied requests must not occupy the process-local window either.
+	if used, _ := l.Snapshot(101); used != int64(limit) {
+		t.Fatalf("local window = %d, want %d", used, limit)
+	}
+}
+
+// TestKeyAdmission_SharedFailOpenKeepsLocalLimitExact guards the fail-open path
+// under concurrency: when Redis errors, the local window still enforces the limit
+// exactly (no overshoot from moving the I/O out of the lock).
+func TestKeyAdmission_SharedFailOpenKeepsLocalLimitExact(t *testing.T) {
+	t.Parallel()
+	l := NewKeyAdmissionLimiter()
+	l.SetSharedRPMCounter(&slowWindow{delay: time.Millisecond, err: errors.New("redis down")})
+	limit := int64(50)
+	const requests = 100
+
+	var allowed atomic.Int64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < requests; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if d := l.Allow(202, &limit, nil, 0); d.Allowed {
+				allowed.Add(1)
+			} else if d.Reason != "over_rpm" {
+				t.Errorf("fail-open deny reason = %q, want over_rpm", d.Reason)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if allowed.Load() != limit {
+		t.Fatalf("fail-open allowed = %d, want exactly %d", allowed.Load(), limit)
+	}
+	if used, _ := l.Snapshot(202); used != limit {
+		t.Fatalf("local window = %d, want %d", used, limit)
+	}
+}
+
+// TestKeyAdmission_ShardMapping documents the striping: keys one modulus apart
+// share a stripe, neighbours do not.
+func TestKeyAdmission_ShardMapping(t *testing.T) {
+	t.Parallel()
+	l := NewKeyAdmissionLimiter()
+	if admissionShards < 2 {
+		t.Fatalf("admissionShards = %d, want striping", admissionShards)
+	}
+	if l.shard(1) != l.shard(1+admissionShards) {
+		t.Fatal("keys one modulus apart must share a stripe")
+	}
+	if l.shard(1) == l.shard(2) {
+		t.Fatal("neighbouring keys must not share a stripe")
+	}
+}

--- a/internal/sharedcount/bench_test.go
+++ b/internal/sharedcount/bench_test.go
@@ -1,0 +1,50 @@
+package sharedcount
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// BenchmarkRedisCounterIncr measures one INCR against the fake server with AUTH
+// and a non-zero SELECT configured, i.e. the handshake shape production uses.
+// Per call the unpooled client paid connect + AUTH + SELECT + INCR + close; the
+// pooled client pays INCR alone. peak-conns/auths show the difference directly.
+func BenchmarkRedisCounterIncr(b *testing.B) { benchRedisCounterIncr(b, 0) }
+
+// BenchmarkRedisCounterIncrDelayed2ms adds a 2ms per-command server latency so the
+// handshake round trips (which pooling removes) are visible as wall time.
+func BenchmarkRedisCounterIncrDelayed2ms(b *testing.B) {
+	benchRedisCounterIncr(b, 2*time.Millisecond)
+}
+
+func benchRedisCounterIncr(b *testing.B, delay time.Duration) {
+	b.Helper()
+	f := newFakeRedisWithAuth(b, "bench-pw")
+	f.setDelay(delay)
+	defer f.close()
+	c, err := NewRedisCounter("redis://:bench-pw@" + f.addr() + "/2")
+	if err != nil {
+		b.Fatalf("NewRedisCounter: %v", err)
+	}
+	c.timeout = 10 * time.Second
+	ctx := context.Background()
+	// Warm-up is intentionally skipped: the first call's connect+AUTH+SELECT is
+	// part of what the two implementations differ on.
+	b.ResetTimer()
+	begin := time.Now()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := c.Incr(ctx, "bench", time.Minute); err != nil {
+				b.Errorf("Incr: %v", err)
+				return
+			}
+		}
+	})
+	elapsed := time.Since(begin)
+	b.StopTimer()
+	b.ReportMetric(float64(b.N)/elapsed.Seconds(), "incrs/s")
+	b.ReportMetric(float64(f.peakConns()), "peak-conns")
+	b.ReportMetric(float64(f.auths.Load()), "auths")
+	b.ReportMetric(float64(f.selects.Load()), "selects")
+}

--- a/internal/sharedcount/counter.go
+++ b/internal/sharedcount/counter.go
@@ -2,6 +2,7 @@ package sharedcount
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -159,8 +160,20 @@ func (m *MemoryCounter) Get(ctx context.Context, key string) (int64, error) {
 	return int64(n), nil
 }
 
+// maxRedisConns bounds one RedisCounter's connection pool: at most this many
+// connections are open at once and callers block (bounded by ctx) while all of
+// them are in flight. Redis itself is single-threaded, so a handful of
+// connections is already enough to keep the round trips pipelined behind the
+// admission path while the FD footprint stays small.
+const maxRedisConns = 8
+
 // RedisCounter is a minimal RESP client (INCR + PEXPIRE / GET) over TCP.
 // No third-party dependency. Failures return errors for callers to fail-open.
+//
+// Connections are pooled and reused: AUTH/SELECT run once per connection instead
+// of once per command, a connection the server closed while it sat idle is
+// replaced transparently, and every operation honors ctx cancellation/deadline on
+// top of the per-operation timeout. Safe for concurrent use.
 type RedisCounter struct {
 	addr     string // host:port
 	password string
@@ -168,6 +181,59 @@ type RedisCounter struct {
 	timeout  time.Duration
 	// dial is injectable for tests.
 	dial func(network, address string, timeout time.Duration) (net.Conn, error)
+
+	// pool is lazily built, so a RedisCounter created as a struct literal (tests)
+	// needs no constructor.
+	pool redisPool
+}
+
+// redisPool keeps a RedisCounter's reusable connections.
+//
+// sem bounds concurrent operations to maxRedisConns, which keeps the FD footprint
+// flat when admission is bursty; idle is a LIFO free list, so the warmest
+// connection is reused first and one the server dropped while idle is picked up by
+// the retry in withConn. The mutex is held only for the slice push/pop, never
+// across I/O.
+type redisPool struct {
+	once sync.Once
+	sem  chan struct{}
+	mu   sync.Mutex
+	idle []net.Conn
+}
+
+// enter claims a connection slot, blocking until one is free or ctx ends.
+func (p *redisPool) enter(ctx context.Context) error {
+	p.once.Do(func() { p.sem = make(chan struct{}, maxRedisConns) })
+	select {
+	case p.sem <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// leave releases a connection slot.
+func (p *redisPool) leave() { <-p.sem }
+
+// take pops the most recently used idle connection, if any.
+func (p *redisPool) take() net.Conn {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	n := len(p.idle)
+	if n == 0 {
+		return nil
+	}
+	conn := p.idle[n-1]
+	p.idle[n-1] = nil // drop the reference before shrinking
+	p.idle = p.idle[:n-1]
+	return conn
+}
+
+// put parks a connection for reuse.
+func (p *redisPool) put(conn net.Conn) {
+	p.mu.Lock()
+	p.idle = append(p.idle, conn)
+	p.mu.Unlock()
 }
 
 // ParseRedisURL parses redis://[:password@]host:port[/db] into RedisCounter fields.
@@ -232,28 +298,219 @@ func NewRedisCounter(redisURL string) (*RedisCounter, error) {
 	}, nil
 }
 
-func (r *RedisCounter) withConn(ctx context.Context, fn func(net.Conn) error) error {
-	_ = ctx
-	if r.dial == nil {
-		r.dial = net.DialTimeout
+// acquire claims a pool slot and returns a ready-to-use connection. pooled
+// reports whether it came from the free list and may therefore have been closed by
+// the server while idle. Blocks until a slot is free, bounded by ctx.
+func (r *RedisCounter) acquire(ctx context.Context) (conn net.Conn, pooled bool, err error) {
+	if err := r.pool.enter(ctx); err != nil {
+		return nil, false, err
 	}
-	conn, err := r.dial("tcp", r.addr, r.timeout)
+	if conn := r.pool.take(); conn != nil {
+		return conn, true, nil
+	}
+	conn, err = r.dialConn(ctx)
 	if err != nil {
-		return err
+		r.pool.leave()
+		return nil, false, err
 	}
-	defer conn.Close()
-	_ = conn.SetDeadline(time.Now().Add(r.timeout))
+	return conn, false, nil
+}
+
+// release returns a connection to the pool, or drops it when it is no longer
+// usable, and gives the pool slot back either way.
+func (r *RedisCounter) release(conn net.Conn, reuse bool) {
+	if reuse {
+		r.pool.put(conn)
+	} else {
+		_ = conn.Close()
+	}
+	r.pool.leave()
+}
+
+// dialConn opens a connection and applies AUTH/SELECT once for its lifetime.
+func (r *RedisCounter) dialConn(ctx context.Context) (net.Conn, error) {
+	dial := r.dial
+	if dial == nil {
+		dial = net.DialTimeout
+	}
+	conn, err := dial("tcp", r.addr, r.timeout)
+	if err != nil {
+		return nil, err
+	}
+	_ = conn.SetDeadline(r.deadline(ctx))
 	if r.password != "" {
 		if err := redisDo(conn, "AUTH", r.password); err != nil {
-			return err
+			_ = conn.Close()
+			return nil, err
 		}
 	}
 	if r.db != 0 {
 		if err := redisDo(conn, "SELECT", strconv.Itoa(r.db)); err != nil {
+			_ = conn.Close()
+			return nil, err
+		}
+	}
+	return conn, nil
+}
+
+// deadline bounds one operation: the counter timeout, tightened by ctx when ctx
+// expires sooner.
+func (r *RedisCounter) deadline(ctx context.Context) time.Time {
+	d := time.Now().Add(r.timeout)
+	if dl, ok := ctx.Deadline(); ok && dl.Before(d) {
+		return dl
+	}
+	return d
+}
+
+// attempt runs fn on conn with the operation deadline applied and ctx
+// cancellation wired to the connection, and reports whether conn may be reused.
+func (r *RedisCounter) attempt(ctx context.Context, conn net.Conn, fn func(net.Conn) error) (reuse bool, err error) {
+	deadline := r.deadline(ctx)
+	// deadlineFromCtx records that the bound we are about to enforce is the ctx
+	// deadline, which lets a connection timeout be reported as the ctx error even
+	// when the ctx timer goroutine has not marked it done yet.
+	_, deadlineFromCtx := ctx.Deadline()
+	_ = conn.SetDeadline(deadline)
+	var g connGuard
+	g.conn = conn
+	if ctx.Done() != nil {
+		// A blocked Read/Write cannot observe cancellation by itself, so close the
+		// connection out from under it. connGuard guarantees that never closes a
+		// connection the operation already finished with.
+		g.stop = make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				g.abort()
+			case <-g.stop:
+			}
+		}()
+	}
+	err = fn(conn)
+	g.finish()
+	if err != nil {
+		// Report cancellation/deadline rather than a transport detail such as
+		// "use of closed connection".
+		switch {
+		case ctx.Err() != nil:
+			err = ctx.Err()
+		case deadlineFromCtx && isTimeoutError(err):
+			// The connection deadline came from ctx and fired a hair before the
+			// ctx timer goroutine ran; the cause is the same, so report it as such
+			// (otherwise callers see a bare net timeout instead of the ctx error).
+			err = context.DeadlineExceeded
+		}
+		return false, err
+	}
+	return !g.aborted(), nil
+}
+
+// isTimeoutError reports a connection deadline hit.
+func isTimeoutError(err error) bool {
+	var nerr net.Error
+	return errors.As(err, &nerr) && nerr.Timeout()
+}
+
+// withConn runs fn on a pooled connection.
+//
+// A connection taken from the free list may have been closed by the server while
+// it sat idle (idle timeout, restart, failover). Such a transport failure is
+// retried, and because every failure discards its connection the free list drains
+// after at most maxRedisConns attempts and a fresh one is dialed. Only transport
+// failures are retried: a Redis error reply (rejected AUTH, unknown command, ...)
+// comes back as-is because a new connection would fail identically, and a failure
+// on a freshly dialed connection comes back as-is because there is nothing stale
+// to replace.
+//
+// A retry can double-apply a non-idempotent INCR in the rare case the server ran
+// the command but the reply was lost. For admission counters that is the safe
+// direction (over-count costs one extra 429), whereas surfacing the error would
+// fail open and under-count the window.
+func (r *RedisCounter) withConn(ctx context.Context, fn func(net.Conn) error) error {
+	if err := ctx.Err(); err != nil {
+		return ctx.Err()
+	}
+	var lastErr error
+	for attempt := 0; attempt <= maxRedisConns; attempt++ {
+		conn, pooled, err := r.acquire(ctx)
+		if err != nil {
+			if lastErr != nil {
+				return lastErr
+			}
+			return err
+		}
+		reuse, err := r.attempt(ctx, conn, fn)
+		r.release(conn, reuse)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		// Retry only a transport failure on a connection that came from the free
+		// list: an error reply would fail identically on a fresh connection, a
+		// freshly dialed connection has nothing stale to replace, and a finished
+		// ctx must not be turned into another round trip.
+		if !pooled || isReplyError(err) || isCtxError(err) || ctx.Err() != nil {
 			return err
 		}
 	}
-	return fn(conn)
+	return lastErr
+}
+
+// connGuard lets ctx cancellation interrupt in-flight I/O without ever closing a
+// connection that has already been handed back to the pool.
+type connGuard struct {
+	mu     sync.Mutex
+	conn   net.Conn
+	done   bool // operation finished — the watcher must not close conn
+	closed bool // watcher closed conn — the caller must not reuse it
+	stop   chan struct{}
+}
+
+// abort closes the connection to unblock a pending Read/Write. No-op once the
+// operation has finished.
+func (g *connGuard) abort() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.done {
+		return
+	}
+	g.closed = true
+	_ = g.conn.Close()
+}
+
+// finish disarms the watcher.
+func (g *connGuard) finish() {
+	g.mu.Lock()
+	g.done = true
+	g.mu.Unlock()
+	if g.stop != nil {
+		close(g.stop)
+	}
+}
+
+// aborted reports whether the watcher closed the connection.
+func (g *connGuard) aborted() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.closed
+}
+
+// replyError is a Redis protocol error reply ("-ERR ..."). It is never retried on
+// a fresh connection: the server answered, so the failure is not transport-level.
+type replyError struct{ msg string }
+
+func (e *replyError) Error() string { return "redis error: " + e.msg }
+
+func isReplyError(err error) bool {
+	var re *replyError
+	return errors.As(err, &re)
+}
+
+// isCtxError reports a cancellation/deadline outcome, including the case where
+// the connection deadline fired just before the ctx timer goroutine did.
+func isCtxError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func (r *RedisCounter) Incr(ctx context.Context, key string, window time.Duration) (int64, error) {
@@ -401,7 +658,7 @@ func redisRead(conn net.Conn) (string, error) {
 			}
 		case '-':
 			if i := indexCRLF(buf); i >= 0 {
-				return "", fmt.Errorf("redis error: %s", string(buf[1:i]))
+				return "", &replyError{msg: string(buf[1:i])}
 			}
 		case ':':
 			if i := indexCRLF(buf); i >= 0 {

--- a/internal/sharedcount/pool_test.go
+++ b/internal/sharedcount/pool_test.go
@@ -1,0 +1,457 @@
+package sharedcount
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countDial wraps a dialer and counts how many connections were opened, which is
+// how these tests observe pooling (one dial for many commands) and reconnects
+// (exactly one extra dial after the server drops a connection).
+type countDial struct {
+	calls atomic.Int64
+	next  func(network, address string, timeout time.Duration) (net.Conn, error)
+}
+
+func (d *countDial) dial(network, address string, timeout time.Duration) (net.Conn, error) {
+	d.calls.Add(1)
+	return d.next(network, address, timeout)
+}
+
+func (d *countDial) install(c *RedisCounter) {
+	d.next = net.DialTimeout
+	c.dial = d.dial
+}
+
+// silentServer accepts connections and never replies, so only ctx (or the
+// connection deadline) can end an operation.
+type silentServer struct {
+	ln    net.Listener
+	mu    sync.Mutex
+	conns []net.Conn
+	done  chan struct{}
+}
+
+func newSilentServer(t *testing.T) *silentServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("silent server listen: %v", err)
+	}
+	s := &silentServer{ln: ln, done: make(chan struct{})}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			s.mu.Lock()
+			s.conns = append(s.conns, c)
+			s.mu.Unlock()
+		}
+	}()
+	return s
+}
+
+func (s *silentServer) addr() string { return s.ln.Addr().String() }
+
+func (s *silentServer) close() {
+	_ = s.ln.Close()
+	s.mu.Lock()
+	conns := s.conns
+	s.conns = nil
+	s.mu.Unlock()
+	for _, c := range conns {
+		_ = c.Close()
+	}
+}
+
+// TestRedisCounter_PoolsConnectionAndHandshake is the core of the pooling change:
+// twenty commands must cost one connection, one AUTH and one SELECT — not twenty.
+func TestRedisCounter_PoolsConnectionAndHandshake(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedisWithAuth(t, "bench-pw")
+	defer f.close()
+	c, err := NewRedisCounter("redis://:bench-pw@" + f.addr() + "/3")
+	if err != nil {
+		t.Fatalf("NewRedisCounter: %v", err)
+	}
+	c.timeout = 5 * time.Second
+	var d countDial
+	d.install(c)
+
+	ctx := context.Background()
+	for i := int64(1); i <= 20; i++ {
+		n, err := c.Incr(ctx, "pooled", time.Minute)
+		if err != nil {
+			t.Fatalf("Incr %d: %v", i, err)
+		}
+		if n != i {
+			t.Fatalf("Incr %d = %d, want %d", i, n, i)
+		}
+	}
+	if got := d.calls.Load(); got != 1 {
+		t.Fatalf("dials = %d for 20 commands, want 1 (connection must be reused)", got)
+	}
+	if got := f.auths.Load(); got != 1 {
+		t.Fatalf("AUTH sent %d times, want once per connection", got)
+	}
+	if got := f.selects.Load(); got != 1 {
+		t.Fatalf("SELECT sent %d times, want once per connection", got)
+	}
+}
+
+// TestRedisCounter_RedialsAfterServerDropsConnection covers automatic reconnect:
+// a connection the server closed while it sat idle must be replaced transparently,
+// repeatedly, without surfacing an error to the caller.
+func TestRedisCounter_RedialsAfterServerDropsConnection(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+	var d countDial
+	d.install(c)
+
+	ctx := context.Background()
+	want := int64(0)
+	for round := 1; round <= 3; round++ {
+		want++
+		n, err := c.Incr(ctx, "reconnect", time.Minute)
+		if err != nil || n != want {
+			t.Fatalf("round %d before drop: Incr = %d, %v, want %d", round, n, err, want)
+		}
+		// Server drops the idle pooled connection.
+		f.closeConns()
+		want++
+		n, err = c.Incr(ctx, "reconnect", time.Minute)
+		if err != nil {
+			t.Fatalf("round %d after drop: Incr error = %v (reconnect failed)", round, err)
+		}
+		if n != want {
+			t.Fatalf("round %d after drop: Incr = %d, want %d", round, n, want)
+		}
+	}
+	if got, wantDials := d.calls.Load(), int64(4); got != wantDials {
+		t.Fatalf("dials = %d, want %d (1 initial + 3 reconnects)", got, wantDials)
+	}
+}
+
+// TestRedisCounter_RecoversFromWholePoolDrop covers a server restart or failover:
+// every parked connection dies at once, and the very next call must still succeed
+// because the retry drains the dead free list instead of surfacing a fail-open
+// error to the admission path.
+func TestRedisCounter_RecoversFromWholePoolDrop(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	f.setDelay(5 * time.Millisecond)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+
+	// Fill the pool: concurrent commands force several connections to be dialed
+	// and then parked idle.
+	var wg sync.WaitGroup
+	ctx := context.Background()
+	for i := 0; i < maxRedisConns; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := c.Incr(ctx, "before-restart", time.Minute); err != nil {
+				t.Errorf("Incr before drop: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	parked := f.peakConns()
+	if parked < 2 {
+		t.Fatalf("pool only reached %d connections, test cannot exercise a mass drop", parked)
+	}
+
+	// Every idle connection dies at once.
+	f.closeConns()
+	if _, err := c.Incr(ctx, "after-restart", time.Minute); err != nil {
+		t.Fatalf("first call after the whole pool was dropped: %v", err)
+	}
+	// And the counter keeps working normally afterwards.
+	for i := 0; i < 5; i++ {
+		if _, err := c.Incr(ctx, "after-restart", time.Minute); err != nil {
+			t.Fatalf("Incr %d after recovery: %v", i, err)
+		}
+	}
+	if n, err := c.Get(ctx, "after-restart"); err != nil || n != 6 {
+		t.Fatalf("count after recovery = %d, %v, want 6", n, err)
+	}
+}
+
+// TestRedisCounter_PoolBoundsAndUsesSeveralConnections pins both halves of the
+// pool contract: concurrency is bounded by maxRedisConns (no FD blow-up) and the
+// pool really is parallel (not one mutex-serialized connection).
+func TestRedisCounter_PoolBoundsAndUsesSeveralConnections(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	f.setDelay(2 * time.Millisecond)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+
+	const workers = 32
+	const perWorker = 8
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	var failures atomic.Int64
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			ctx := context.Background()
+			for j := 0; j < perWorker; j++ {
+				if _, err := c.Incr(ctx, "bounded", time.Minute); err != nil {
+					failures.Add(1)
+				}
+			}
+		}(i)
+	}
+	begin := time.Now()
+	close(start)
+	wg.Wait()
+	elapsed := time.Since(begin)
+
+	if n := failures.Load(); n != 0 {
+		t.Fatalf("%d/%d pooled operations failed", n, workers*perWorker)
+	}
+	peak := f.peakConns()
+	if peak > maxRedisConns {
+		t.Fatalf("peak connections = %d, want <= maxRedisConns (%d)", peak, maxRedisConns)
+	}
+	if peak < 2 {
+		t.Fatalf("peak connections = %d, want the pool to run in parallel", peak)
+	}
+	// Wall-clock throughput is deliberately not asserted here: on a shared 2-core
+	// box the effective parallelism is whatever the scheduler can run, so the
+	// number measures CPU availability rather than the pool. The structural
+	// assertions above (bounded peak, no failures, exact total) are the contract;
+	// throughput is measured in BenchmarkRedisCounterIncr.
+	t.Logf("%d commands over %d peak connections in %v", workers*perWorker, peak, elapsed)
+	total, err := c.Get(context.Background(), "bounded")
+	if err != nil || total != workers*perWorker {
+		t.Fatalf("total = %d, %v, want %d", total, err, workers*perWorker)
+	}
+}
+
+// TestRedisCounter_ReplyErrorIsNotRetried keeps reconnect-retry from turning a
+// rejected AUTH (or any Redis error reply) into repeated connection storms.
+func TestRedisCounter_ReplyErrorIsNotRetried(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedisWithAuth(t, "right-secret")
+	defer f.close()
+	c := newCounterWithAuth(t, f.addr(), "wrong-secret")
+	var d countDial
+	d.install(c)
+
+	if _, err := c.Incr(context.Background(), "k", time.Minute); err == nil {
+		t.Fatal("expected AUTH error, got nil")
+	} else if !isReplyError(err) {
+		t.Fatalf("error = %v (%T), want a redis reply error", err, err)
+	}
+	if got := d.calls.Load(); got != 1 {
+		t.Fatalf("dials = %d, want 1 (an error reply must not trigger a reconnect retry)", got)
+	}
+}
+
+// TestRedisCounter_SlotIsReleasedAfterDialFailure proves the pool cannot leak
+// slots: after repeated dial failures every slot is still available, otherwise
+// callers would block forever once maxRedisConns failures had piled up.
+func TestRedisCounter_SlotIsReleasedAfterDialFailure(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+	var attempts atomic.Int64
+	c.dial = func(network, address string, timeout time.Duration) (net.Conn, error) {
+		if attempts.Add(1) <= 3 {
+			return nil, errors.New("dial boom")
+		}
+		return net.DialTimeout(network, address, timeout)
+	}
+
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if _, err := c.Incr(ctx, "leaky", time.Minute); err == nil {
+			t.Fatalf("Incr %d: expected dial error, got nil", i)
+		}
+	}
+	// Now that dialing works, a full pool's worth of concurrent callers must all
+	// get through: a leaked slot would deadlock here.
+	const workers = maxRedisConns * 4
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := c.Incr(ctx, "leaky", time.Minute)
+			if err != nil {
+				errs <- err
+			}
+		}()
+	}
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("pool deadlocked after dial failures — slots were not released")
+	}
+	close(errs)
+	for err := range errs {
+		t.Fatalf("Incr after recovery: %v", err)
+	}
+	if n, err := c.Get(ctx, "leaky"); err != nil || n != workers {
+		t.Fatalf("count after recovery = %d, %v, want %d", n, err, workers)
+	}
+}
+
+// TestRedisCounter_ContextCancelInterruptsBlockingIO is the ctx half of the
+// contract: a cancelled context must end an in-flight command against a server
+// that never replies, and must report context.Canceled.
+func TestRedisCounter_ContextCancelInterruptsBlockingIO(t *testing.T) {
+	t.Parallel()
+	s := newSilentServer(t)
+	defer s.close()
+	c := newCounterAt(t, s.addr())
+	c.timeout = 30 * time.Second // long on purpose: only ctx may end this
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() {
+		_, err := c.Incr(ctx, "cancel", time.Minute)
+		errc <- err
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-errc:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context.Canceled", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Incr did not return after the context was cancelled")
+	}
+	// The aborted connection must have been dropped, not lost: the pool still
+	// hands out slots, so a bounded call returns instead of blocking forever.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel2()
+	begin := time.Now()
+	// The silent server never replies, so the ctx-derived deadline ends the call;
+	// what matters here is that it ends at all (no slot was lost) and stays bounded.
+	if _, err := c.Get(ctx2, "cancel"); err == nil {
+		t.Fatal("post-cancel Get against a silent server should fail")
+	}
+	if elapsed := time.Since(begin); elapsed > 5*time.Second {
+		t.Fatalf("post-cancel Get took %v — a pool slot was lost", elapsed)
+	}
+}
+
+// TestRedisCounter_ContextDeadlineIsHonored checks deadline propagation: the
+// operation must end at the ctx deadline, well before the counter's own timeout.
+func TestRedisCounter_ContextDeadlineIsHonored(t *testing.T) {
+	t.Parallel()
+	s := newSilentServer(t)
+	defer s.close()
+	c := newCounterAt(t, s.addr())
+	c.timeout = 30 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	begin := time.Now()
+	_, err := c.Incr(ctx, "deadline", time.Minute)
+	elapsed := time.Since(begin)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want context.DeadlineExceeded", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("operation took %v, want it bounded by the 100ms ctx deadline", elapsed)
+	}
+}
+
+// TestRedisCounter_CancelledContextShortCircuits: an already-cancelled context
+// must not even open a connection.
+func TestRedisCounter_CancelledContextShortCircuits(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+	var d countDial
+	d.install(c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := c.Incr(ctx, "short", time.Minute); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Incr with cancelled ctx = %v, want context.Canceled", err)
+	}
+	if _, err := c.Decr(ctx, "short", time.Minute); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Decr with cancelled ctx = %v, want context.Canceled", err)
+	}
+	if _, err := c.IncrBy(ctx, "short", 5, time.Minute); !errors.Is(err, context.Canceled) {
+		t.Fatalf("IncrBy with cancelled ctx = %v, want context.Canceled", err)
+	}
+	if _, err := c.Get(ctx, "short"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Get with cancelled ctx = %v, want context.Canceled", err)
+	}
+	if got := d.calls.Load(); got != 0 {
+		t.Fatalf("dials = %d with a cancelled context, want 0", got)
+	}
+}
+
+// TestRedisCounter_PoolIsConcurrencySafe hammers one counter from many goroutines
+// with a mix of operations; run under -race this is the pool's safety net.
+func TestRedisCounter_PoolIsConcurrencySafe(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+	ctx := context.Background()
+	const workers = 24
+	const perWorker = 25
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			for j := 0; j < perWorker; j++ {
+				if _, err := c.Incr(ctx, "mixed", time.Minute); err != nil {
+					t.Errorf("Incr: %v", err)
+					return
+				}
+				if j%5 == 0 {
+					if _, err := c.IncrBy(ctx, "mixed-tpm", 10, time.Minute); err != nil {
+						t.Errorf("IncrBy: %v", err)
+						return
+					}
+					if _, err := c.Decr(ctx, "mixed", time.Minute); err != nil {
+						t.Errorf("Decr: %v", err)
+						return
+					}
+				}
+				if _, err := c.Get(ctx, "mixed"); err != nil {
+					t.Errorf("Get: %v", err)
+					return
+				}
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	// Every Incr is paired with a Decr on every 5th iteration.
+	decrs := int64(workers * perWorker / 5)
+	incs := int64(workers * perWorker)
+	if n, err := c.Get(ctx, "mixed"); err != nil || n != incs-decrs {
+		t.Fatalf("mixed total = %d, %v, want %d", n, err, incs-decrs)
+	}
+}

--- a/internal/sharedcount/redis_test.go
+++ b/internal/sharedcount/redis_test.go
@@ -28,18 +28,31 @@ type fakeRedis struct {
 	authPass string
 	ln       net.Listener
 	wg       sync.WaitGroup
+
+	// conns tracks live connections: a pooling client parks idle connections, so
+	// the handler goroutines must be unblocked explicitly on shutdown.
+	connsMu sync.Mutex
+	conns   map[net.Conn]struct{}
+	peak    int
+
+	// auths/selects count handshake commands (asserted once per connection).
+	auths   atomic.Int64
+	selects atomic.Int64
+
+	// delayMs is an artificial per-command latency (0 = none).
+	delayMs atomic.Int64
 }
 
-func newFakeRedis(t *testing.T) *fakeRedis {
-	t.Helper()
-	return newFakeRedisWithAuth(t, "")
+func newFakeRedis(tb testing.TB) *fakeRedis {
+	tb.Helper()
+	return newFakeRedisWithAuth(tb, "")
 }
 
-func newFakeRedisWithAuth(t *testing.T, password string) *fakeRedis {
-	t.Helper()
+func newFakeRedisWithAuth(tb testing.TB, password string) *fakeRedis {
+	tb.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Fatalf("fake redis listen: %v", err)
+		tb.Fatalf("fake redis listen: %v", err)
 	}
 	f := &fakeRedis{
 		data:     make(map[string]int64),
@@ -56,7 +69,53 @@ func (f *fakeRedis) addr() string { return f.ln.Addr().String() }
 
 func (f *fakeRedis) close() {
 	_ = f.ln.Close()
+	f.closeConns()
 	f.wg.Wait()
+}
+
+// setDelay makes every command sleep d before it is handled.
+func (f *fakeRedis) setDelay(d time.Duration) {
+	f.delayMs.Store(d.Milliseconds())
+}
+
+// closeConns closes every live connection but keeps the listener accepting, i.e.
+// it simulates a server (or an idle-timeout/firewall) dropping connections that
+// a pooling client still believes are usable.
+func (f *fakeRedis) closeConns() {
+	f.connsMu.Lock()
+	conns := make([]net.Conn, 0, len(f.conns))
+	for c := range f.conns {
+		conns = append(conns, c)
+	}
+	f.connsMu.Unlock()
+	for _, c := range conns {
+		_ = c.Close()
+	}
+}
+
+// peakConns returns the highest number of simultaneously live connections.
+func (f *fakeRedis) peakConns() int {
+	f.connsMu.Lock()
+	defer f.connsMu.Unlock()
+	return f.peak
+}
+
+func (f *fakeRedis) track(c net.Conn) {
+	f.connsMu.Lock()
+	defer f.connsMu.Unlock()
+	if f.conns == nil {
+		f.conns = make(map[net.Conn]struct{})
+	}
+	f.conns[c] = struct{}{}
+	if len(f.conns) > f.peak {
+		f.peak = len(f.conns)
+	}
+}
+
+func (f *fakeRedis) untrack(c net.Conn) {
+	f.connsMu.Lock()
+	defer f.connsMu.Unlock()
+	delete(f.conns, c)
 }
 
 func (f *fakeRedis) serve() {
@@ -64,11 +123,15 @@ func (f *fakeRedis) serve() {
 	for {
 		conn, err := f.ln.Accept()
 		if err != nil {
+			// Listener gone: unblock handlers parked on idle pooled connections.
+			f.closeConns()
 			return
 		}
+		f.track(conn)
 		f.wg.Add(1)
 		go func(c net.Conn) {
 			defer f.wg.Done()
+			defer f.untrack(c)
 			f.handle(c)
 		}(conn)
 	}
@@ -94,9 +157,13 @@ func (f *fakeRedis) handle(conn net.Conn) {
 		if len(parts) == 0 {
 			continue
 		}
+		if d := f.delayMs.Load(); d > 0 {
+			time.Sleep(time.Duration(d) * time.Millisecond)
+		}
 		cmd := strings.ToUpper(parts[0])
 		switch cmd {
 		case "AUTH":
+			f.auths.Add(1)
 			if f.authPass != "" && (len(parts) < 2 || parts[1] != f.authPass) {
 				writeError(conn, "ERR invalid password")
 				return
@@ -104,6 +171,7 @@ func (f *fakeRedis) handle(conn net.Conn) {
 			authed = true
 			writeOK(conn)
 		case "SELECT":
+			f.selects.Add(1)
 			writeOK(conn)
 		case "PING":
 			writeOK(conn)


### PR DESCRIPTION
## Problem

With `REDIS_URL` configured, managed-key admission was effectively single-threaded:

- `KeyAdmissionLimiter.Allow()` held **one global mutex across the shared RPM/TPM round trips**, so every key queued behind every other key's Redis latency, and the compensating `Decr` on a deny happened inside the same critical section.
- `RedisCounter` **opened a new TCP connection per command** (dial + `AUTH` + `SELECT` + close) and ignored `ctx` entirely, so each request also paid a handshake — inside that lock.

Measured with a 2 ms shared round trip at 32 workers over many keys: **117 admissions/s**, p50 259 ms, p99 360 ms.

## Design

**`auth/key_admission.go`**

- The single mutex becomes **64 cache-line-padded shards** (`keyID % 64`), each with its own window map. Shard locks guard in-memory work only (prune / check / append) and are **never held across I/O**.
- A key's shared round trips serialize on its own `keyWindow.sharedMu`, which keeps an `Incr` and its compensating `Decr` ordered per key. Lock nesting is always `sharedMu → shard mu` (the shard lock is released before `sharedMu` is taken), so slow Redis blocks neither another key nor another shard, and the two locks cannot deadlock.
- `sharedMu` deliberately spans the local fallback verdicts and the reservation — that is exactly the check-and-reserve atomicity the old global lock provided, so fail-open under concurrency cannot over-admit (test: Redis fully down, 100 concurrent requests, limit 50 → exactly 50 admitted).
- Decision order preserved: shared RPM → local RPM fallback → shared TPM → local TPM fallback → reserve. A local RPM deny still happens **before** the TPM round trip, so denied requests never leave a TPM reservation behind.
- Counters move to an `atomic.Pointer[sharedCounters]`, read with one lock-free load so RPM+TPM are always a consistent pair. Setter signatures unchanged; `Snapshot()` now locks only its own shard.

**`internal/sharedcount/counter.go`**

- Connections are pooled: a semaphore bounds concurrency at 8, a LIFO free list reuses them, and `AUTH`/`SELECT` run **once per connection** instead of once per command. The injectable dial seam and the 800 ms default timeout are kept; no new dependency (`go.mod` untouched).
- Reconnect: a transport failure on a pooled connection discards it and retries, draining the free list after a mass drop (server restart / failover). Redis *error replies* are never retried — a fresh connection would fail identically, and retrying would cause a connection storm.
- `ctx` is honored: the operation deadline is `min(timeout, ctx deadline)`, pool acquisition blocks on `ctx`, and a watcher closes the connection on cancel so a blocked read/write cannot outlive it (never closing a connection already returned to the pool). When the deadline came from `ctx`, callers deterministically get `context.DeadlineExceeded` rather than a bare `i/o timeout` — a race that `-race` caught and that was fixed properly, not by relaxing the test.

## Semantics unchanged

Fail-open on Redis errors · `over_rpm` / `over_tpm` reasons · `Retry-After` values · `UsedRPM` / `UsedTPM` · `AdmissionDecision` shape · `metapi:rpm:{id}` / `metapi:tpm:{id}` key namespaces · every env var name · `Allow` / `Snapshot` / setter signatures · the memory-only path. No API, dependency, or JSON change.

## Evidence

`Allow()` with a 2 ms shared round trip (identical benchmark file compiled against both trees, 3 alternating rounds × `-count=2`, medians; the machine was shared, so absolute values are pessimistic but the A/B ratio is not):

| Benchmark | Before | After | Δ | p50 / p99 before → after |
|---|---|---|---|---|
| shared, many keys, 32 workers | 117 /s | **3 137 /s** | **26.8×** | 259 / 360 ms → **10 / 40 ms** |
| shared, many keys, 8 workers | 110 /s | 848 /s | 7.7× | 68 / 118 ms → 9.5 / 31 ms |
| shared, one hot key, 32 workers | 113 /s | 103 /s | 1.0× (by design — one key's Incr/Decr must stay ordered) | — |
| memory-only, 32 workers | 829 k/s | 1 379 k/s | 1.7× | 1428 → 873 ns/op |

`RedisCounter.Incr` against a real TCP fake server with `AUTH` + `SELECT`: **465 µs → 54 µs** per increment (8.5×), `AUTH` commands **3 530 → 1**, peak connections **15 → 8** (now bounded).

Manual smoke against a real local Redis (throwaway script, not committed): 400 concurrent requests over 16 keys **146 ms → 33 ms**; 200 sequential `Allow` **467 µs → 183 µs**; `CLIENT LIST` delta **0 → 8** (bounded reuse); identical admission verdicts, compensating rollback, and window TTLs.

The new tests have teeth: with the shard lock deliberately held across I/O (mutation), the lock-ordering test dies on its watchdog; run unchanged against the pre-refactor tree, `SharedCounterRunsOutsideShardLock` and `DistinctKeysNotSerialized` both FAIL, while the semantic-preservation tests PASS on both sides.

## Tests

- `auth/key_admission_lock_test.go` (5): shared I/O provably outside the shard lock (a fake counter calls back into `Allow`/`Snapshot` mid-round-trip — the old code deadlocks), cross-key parallelism, per-key `Decr` adjacency, fail-open exactness under concurrency, shard mapping.
- `internal/sharedcount/pool_test.go` (10): connection + handshake reuse (20 commands = 1 dial / 1 AUTH / 1 SELECT), reconnect, mass-drop recovery, pool bounds, no retry on error replies, no slot leak after dial failure, ctx cancel interrupting blocked I/O, ctx deadline, already-cancelled ctx short-circuit, concurrent mixed operations.
- Benchmarks in both packages; the existing fake Redis harness gained connection tracking (required: a pooled client parks idle connections server-side, so the old teardown hung).

## Verification

| Gate | Result |
|---|---|
| `go build ./...` | exit 0 |
| `go vet ./...` | exit 0 |
| `go test ./... -count=1` | exit 0, 0 FAIL (baseline before the change was also green) |
| `go test ./auth/... ./internal/sharedcount/... -count=1 -race` | exit 0, no data races (auth 129–169 s) |
| `gofmt -l` (changed files) | clean |

## Follow-ups (not in this PR)

- `Allow()` still takes no `ctx`, so request cancellation does not propagate into admission I/O (bounded by the 800 ms counter timeout). Threading `r.Context()` through is a one-line wiring change plus a signature change at the single call site — deliberately kept out so this PR stays a pure performance/locking change.
- Two pre-existing quirks were preserved rather than silently changed: a shared-RPM increment is not rolled back when the *local* TPM fallback denies (behaviour identical to before), and a compensating `Decr` landing after key expiry can leave a short-lived negative counter that self-heals on the next `Incr`.