### PR TITLE
fix(runtime): self-heal non-positive Redis rollback keys, lock-free GetDB, tunable usage projection cadence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ BALANCE_REFRESH_ENABLED=true
 MODEL_SYNC_CRON=0 4 * * *
 # Code default is 06:00 daily (DefaultLogCleanupCron).
 LOG_CLEANUP_CRON=0 6 * * *
+# Usage aggregation projects proxy_logs into the site/model rollups every 5s by
+# default (clamped to 1000-3600000 ms). Small single-node deployments can raise
+# it (e.g. 30000) to trade dashboard freshness for fewer projection passes.
+USAGE_PROJECTION_INTERVAL_MS=5000
 
 # Optional site branding overrides. Runtime settings can override these values.
 SYSTEM_NAME=Metapi

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,11 @@ Thumbs.db
 # Golden TS fixture for the migration-compat tests — intentionally tracked
 # (dummy data, built by scripts/regen-ts-fixture.sh).
 !store/testdata/ts-source/hub.db
+# SQLite WAL sidecars materialise next to the golden fixture whenever something
+# opens it in place (sqlite3 CLI, an ad-hoc query). The fixture bytes never
+# change; keep the sidecars out of `git status`.
+store/testdata/ts-source/hub.db-shm
+store/testdata/ts-source/hub.db-wal
 
 # Build
 /tmp/

--- a/config/config.go
+++ b/config/config.go
@@ -274,6 +274,11 @@ type Config struct {
 	ProxyLogBatchSize       int
 	ProxyLogFlushIntervalMs int
 
+	// Usage aggregation (1 field). USAGE_PROJECTION_INTERVAL_MS is the cadence
+	// of the proxy_logs -> site_day_usage / site_hour_usage / model_day_usage
+	// projection pass. Clamped to [1000, 3600000] ms.
+	UsageProjectionIntervalMs int
+
 	OpenAiServiceTierRules any
 }
 
@@ -787,6 +792,12 @@ func Load(env map[string]string) (*Config, *RuntimeSettings) {
 	cfg.ProxyLogFlushIntervalMs = ClampInt(
 		int(math.Trunc(parseNumber(get("PROXY_LOG_FLUSH_INTERVAL_MS"), float64(DefaultProxyLogFlushIntervalMs)))),
 		1, 60000,
+	)
+
+	// ---- §3.21c Usage Aggregation Projection ----
+	cfg.UsageProjectionIntervalMs = ClampInt(
+		int(math.Trunc(parseNumber(get("USAGE_PROJECTION_INTERVAL_MS"), float64(DefaultUsageProjectionIntervalMs)))),
+		1000, 3600000,
 	)
 
 	// ---- §3.22 Routing Weights ----

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -136,6 +136,11 @@ const (
 	DefaultProxyLogBatchSize       = 50
 	DefaultProxyLogFlushIntervalMs = 1000
 
+	// Usage aggregation projects proxy_logs into the site/model rollups. 5s
+	// keeps admin dashboards near-real-time; small single-node deployments
+	// (2 vCPU class) can relax it to trade freshness for fewer passes.
+	DefaultUsageProjectionIntervalMs = 5000
+
 	DefaultProxyDebugRetentionHours = 24
 	DefaultProxyDebugMaxBodyBytes   = 262144
 

--- a/config/usage_projection_interval_test.go
+++ b/config/usage_projection_interval_test.go
@@ -1,0 +1,52 @@
+package config
+
+import "testing"
+
+// TestLoadUsageProjectionIntervalDefault pins the 5s default: admin dashboards
+// read the site/model rollups, so the projection pass stays near-real-time out
+// of the box.
+func TestLoadUsageProjectionIntervalDefault(t *testing.T) {
+	if DefaultUsageProjectionIntervalMs != 5000 {
+		t.Fatalf("DefaultUsageProjectionIntervalMs = %d, want 5000", DefaultUsageProjectionIntervalMs)
+	}
+	cfg, _ := Load(map[string]string{})
+	if cfg.UsageProjectionIntervalMs != DefaultUsageProjectionIntervalMs {
+		t.Fatalf("UsageProjectionIntervalMs = %d, want default %d",
+			cfg.UsageProjectionIntervalMs, DefaultUsageProjectionIntervalMs)
+	}
+}
+
+// TestLoadUsageProjectionIntervalClamped verifies the floor/ceiling: tiny or
+// negative values clamp to 1s (the pass must never spin), huge values clamp to
+// 1h, and an unparseable value falls back to the default instead of clamping.
+func TestLoadUsageProjectionIntervalClamped(t *testing.T) {
+	for _, env := range []map[string]string{
+		{"USAGE_PROJECTION_INTERVAL_MS": "0"},
+		{"USAGE_PROJECTION_INTERVAL_MS": "-5"},
+		{"USAGE_PROJECTION_INTERVAL_MS": "1"},
+	} {
+		cfg, _ := Load(env)
+		if cfg.UsageProjectionIntervalMs != 1000 {
+			t.Fatalf("Load(%v).UsageProjectionIntervalMs = %d, want clamp floor 1000",
+				env, cfg.UsageProjectionIntervalMs)
+		}
+	}
+	cfg, _ := Load(map[string]string{"USAGE_PROJECTION_INTERVAL_MS": "99999999"})
+	if cfg.UsageProjectionIntervalMs != 3600000 {
+		t.Fatalf("UsageProjectionIntervalMs = %d, want clamp ceiling 3600000", cfg.UsageProjectionIntervalMs)
+	}
+	cfg, _ = Load(map[string]string{"USAGE_PROJECTION_INTERVAL_MS": "not-a-number"})
+	if cfg.UsageProjectionIntervalMs != DefaultUsageProjectionIntervalMs {
+		t.Fatalf("invalid value = %d, want fallback default %d",
+			cfg.UsageProjectionIntervalMs, DefaultUsageProjectionIntervalMs)
+	}
+}
+
+// TestLoadUsageProjectionIntervalExplicit verifies an operator-supplied cadence
+// wins over the default (small single-node deployments relax it to cut passes).
+func TestLoadUsageProjectionIntervalExplicit(t *testing.T) {
+	cfg, _ := Load(map[string]string{"USAGE_PROJECTION_INTERVAL_MS": "30000"})
+	if cfg.UsageProjectionIntervalMs != 30000 {
+		t.Fatalf("UsageProjectionIntervalMs = %d, want 30000", cfg.UsageProjectionIntervalMs)
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,7 @@ knob a deployment is likely to touch. Docker Compose users pass these via
 | `LOG_CLEANUP_CRON` | `0 6 * * *` | Retention pruning cron. |
 | `LOG_CLEANUP_USAGE_LOGS_ENABLED` / `LOG_CLEANUP_PROGRAM_LOGS_ENABLED` | auto | Which log families the cleanup prunes. |
 | `LOG_CLEANUP_RETENTION_DAYS` | `30` | Proxy/program log retention. |
+| `USAGE_PROJECTION_INTERVAL_MS` | `5000` | Usage-aggregation projection cadence (`proxy_logs` → site/model rollups). Clamped to 1000–3600000 ms; raise it on small single-node deployments to trade dashboard freshness for fewer passes. |
 
 ## Notifications
 

--- a/internal/sharedcount/counter.go
+++ b/internal/sharedcount/counter.go
@@ -18,11 +18,14 @@ type WindowCounter interface {
 	// Implementations may approximate sliding windows with fixed TTL buckets.
 	Incr(ctx context.Context, key string, window time.Duration) (count int64, err error)
 	// Decr decrements key by 1 (compensating rollback for a prior Incr,).
-	// Does not extend/refresh TTL. Count is floored at 0 for memory; Redis DECR may go negative.
+	// Does not extend/refresh TTL. Count is floored at 0 for memory; Redis DECR
+	// may go negative, and a rollback that lands after the window expired drops
+	// the re-created non-positive key instead of leaving it behind without a TTL.
 	Decr(ctx context.Context, key string, window time.Duration) (count int64, err error)
 	// IncrBy increments key by delta within window and returns the new total.
 	// Used for TPM token reservations. delta==0 returns the current total.
-	// Negative delta is a compensating rollback and does not refresh TTL.
+	// Negative delta is a compensating rollback and does not refresh TTL; like
+	// Decr it removes the key when the rollback takes the total to <= 0.
 	IncrBy(ctx context.Context, key string, delta int64, window time.Duration) (count int64, err error)
 	// Get returns the current count without incrementing.
 	Get(ctx context.Context, key string) (count int64, err error)
@@ -545,6 +548,18 @@ func (r *RedisCounter) Decr(ctx context.Context, key string, window time.Duratio
 			return err
 		}
 		count = n
+		if n <= 0 {
+			// Self-heal: a rollback that lands after the window expired
+			// re-created the key with no TTL and a non-positive value. Such a
+			// key lingers (INCR only arms PEXPIRE when its result is exactly 1,
+			// so a stale -1 needs two increments to become mortal again) and
+			// undercounts the next window. Dropping it loses nothing: a
+			// non-positive total means no instance holds a live reservation.
+			// Best-effort — the rollback itself already landed.
+			if derr := redisDo(conn, "DEL", key); derr == nil {
+				count = 0
+			}
+		}
 		return nil
 	})
 	return count, err
@@ -568,10 +583,17 @@ func (r *RedisCounter) IncrBy(ctx context.Context, key string, delta int64, wind
 			return err
 		}
 		count = n
-		if delta > 0 && n == delta {
+		switch {
+		case delta > 0 && n == delta:
 			ms := strconv.FormatInt(window.Milliseconds(), 10)
 			if err := redisDo(conn, "PEXPIRE", key, ms); err != nil {
 				return err
+			}
+		case delta < 0 && n <= 0:
+			// Same self-heal as Decr: never leave an immortal non-positive key
+			// behind when a compensating rollback lands after expiry.
+			if derr := redisDo(conn, "DEL", key); derr == nil {
+				count = 0
 			}
 		}
 		return nil

--- a/internal/sharedcount/redis_test.go
+++ b/internal/sharedcount/redis_test.go
@@ -20,7 +20,7 @@ import (
 // fakeRedis is a minimal in-memory RESP server for exercising RedisCounter
 // over a real TCP loopback connection (so NewRedisCounter + net.DialTimeout
 // are covered end-to-end). It supports AUTH, SELECT, INCR, DECR, INCRBY, GET
-// and PEXPIRE with real TTL expiry.
+// PEXPIRE and DEL with real TTL expiry.
 type fakeRedis struct {
 	mu       sync.Mutex
 	data     map[string]int64
@@ -261,6 +261,23 @@ func (f *fakeRedis) handleCommand(conn net.Conn, cmd string, parts []string) boo
 		f.ttl[key] = time.Now().Add(time.Duration(ms) * time.Millisecond)
 		f.mu.Unlock()
 		writeInt(conn, 1)
+	case "DEL":
+		if len(parts) < 2 {
+			writeError(conn, "ERR wrong number of arguments")
+			return true
+		}
+		key := parts[1]
+		f.mu.Lock()
+		f.expireLocked(key)
+		_, existed := f.data[key]
+		delete(f.data, key)
+		delete(f.ttl, key)
+		f.mu.Unlock()
+		if existed {
+			writeInt(conn, 1)
+		} else {
+			writeInt(conn, 0)
+		}
 	case "QUIT":
 		writeOK(conn)
 		return false
@@ -782,5 +799,123 @@ func TestNewRedisCounter_BuildsFields(t *testing.T) {
 	}
 	if c.dial == nil {
 		t.Fatal("dial should default to net.DialTimeout")
+	}
+}
+
+// snapshotKeys returns the live (non-expired) keys the fake server holds.
+func (f *fakeRedis) snapshotKeys() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.data))
+	for k := range f.data {
+		f.expireLocked(k)
+		if _, ok := f.data[k]; ok {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// hasTTL reports whether key currently carries an expiry.
+func (f *fakeRedis) hasTTL(key string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.ttl[key]
+	return ok
+}
+
+// TestRedisCounter_RollbackAfterExpiryLeavesNoImmortalKey pins the self-heal: a
+// compensating DECR that lands after the window expired re-creates the key with
+// no TTL and a negative value. INCR only arms PEXPIRE when its result is exactly
+// 1, so such a key would linger and undercount the next window; the rollback
+// drops it instead and the following INCR starts a fresh, mortal window.
+func TestRedisCounter_RollbackAfterExpiryLeavesNoImmortalKey(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+	ctx := context.Background()
+
+	n, err := c.Decr(ctx, "rpm:gone", time.Minute)
+	if err != nil {
+		t.Fatalf("Decr on missing key: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("Decr on missing key = %d, want 0 (key dropped)", n)
+	}
+	if keys := f.snapshotKeys(); len(keys) != 0 {
+		t.Fatalf("keys after rollback self-heal = %v, want none", keys)
+	}
+
+	if n, err = c.Incr(ctx, "rpm:gone", time.Minute); err != nil || n != 1 {
+		t.Fatalf("Incr after self-heal = %d, %v, want 1", n, err)
+	}
+	if !f.hasTTL("rpm:gone") {
+		t.Fatal("key re-created after self-heal carries no TTL")
+	}
+}
+
+// TestRedisCounter_RollbackKeepsPositiveWindow guards the other side: while the
+// window total stays positive the rollback must leave the key (and its TTL)
+// alone, so concurrent instances keep counting against the same window.
+func TestRedisCounter_RollbackKeepsPositiveWindow(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		if _, err := c.Incr(ctx, "rpm:live", time.Minute); err != nil {
+			t.Fatalf("Incr %d: %v", i, err)
+		}
+	}
+	n, err := c.Decr(ctx, "rpm:live", time.Minute)
+	if err != nil || n != 1 {
+		t.Fatalf("Decr = %d, %v, want 1", n, err)
+	}
+	if keys := f.snapshotKeys(); len(keys) != 1 || keys[0] != "rpm:live" {
+		t.Fatalf("keys after positive rollback = %v, want [rpm:live]", keys)
+	}
+	if !f.hasTTL("rpm:live") {
+		t.Fatal("positive window lost its TTL")
+	}
+	if got, err := c.Get(ctx, "rpm:live"); err != nil || got != 1 {
+		t.Fatalf("Get = %d, %v, want 1", got, err)
+	}
+}
+
+// TestRedisCounter_NegativeIncrByRollbackDropsNonPositiveKey covers the TPM
+// path: a negative IncrBy (token reservation rollback) that takes the total to
+// zero or below gets the same treatment as Decr.
+func TestRedisCounter_NegativeIncrByRollbackDropsNonPositiveKey(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+	ctx := context.Background()
+
+	if n, err := c.IncrBy(ctx, "tpm:full", 600, time.Minute); err != nil || n != 600 {
+		t.Fatalf("IncrBy(+600) = %d, %v, want 600", n, err)
+	}
+	if n, err := c.IncrBy(ctx, "tpm:full", -600, time.Minute); err != nil || n != 0 {
+		t.Fatalf("IncrBy(-600) = %d, %v, want 0", n, err)
+	}
+	if n, err := c.IncrBy(ctx, "tpm:missing", -50, time.Minute); err != nil || n != 0 {
+		t.Fatalf("IncrBy(-50) on missing key = %d, %v, want 0", n, err)
+	}
+	if keys := f.snapshotKeys(); len(keys) != 0 {
+		t.Fatalf("keys after negative rollbacks = %v, want none", keys)
+	}
+
+	// A partial rollback keeps the remaining reservation alive.
+	if _, err := c.IncrBy(ctx, "tpm:part", 500, time.Minute); err != nil {
+		t.Fatalf("IncrBy(+500): %v", err)
+	}
+	if n, err := c.IncrBy(ctx, "tpm:part", -200, time.Minute); err != nil || n != 300 {
+		t.Fatalf("IncrBy(-200) = %d, %v, want 300", n, err)
+	}
+	if !f.hasTTL("tpm:part") {
+		t.Fatal("partial rollback dropped the window TTL")
 	}
 }

--- a/scheduler/usage_aggregation.go
+++ b/scheduler/usage_aggregation.go
@@ -15,11 +15,13 @@ import (
 )
 
 const (
-	usageProjectionIntervalMs = 5_000   // 5s
-	usageProjectionLeaseMs    = 600_000 // 10min lease
-	usageProjectionBatchSize  = 1_000   // rows per batch
-	usageProjectionMaxBatches = 120     // max batches per pass
-	usageProjectorKey         = "usage-aggregates-v1"
+	// fallback for callers that build config.Config by hand (tests, embedders)
+	// and leave UsageProjectionIntervalMs zero; config.Load always fills it in.
+	defaultUsageProjectionIntervalMs = 5_000
+	usageProjectionLeaseMs           = 600_000 // 10min lease
+	usageProjectionBatchSize         = 1_000   // rows per batch
+	usageProjectionMaxBatches        = 120     // max batches per pass
+	usageProjectorKey                = "usage-aggregates-v1"
 )
 
 // UsageAggregationScheduler incrementally projects proxy_logs into
@@ -40,13 +42,23 @@ func NewUsageAggregationScheduler(cfg *config.Config) *UsageAggregationScheduler
 func (s *UsageAggregationScheduler) Name() string { return "usage-aggregation" }
 
 func (s *UsageAggregationScheduler) Start(ctx context.Context) error {
+	intervalMs := s.projectionIntervalMs()
 	slog.Info("usage-aggregation scheduler started",
-		"interval_ms", usageProjectionIntervalMs,
+		"interval_ms", intervalMs,
 		"lease_ms", usageProjectionLeaseMs,
 	)
-	return s.runner.start(ctx, time.Duration(usageProjectionIntervalMs)*time.Millisecond, true, func() {
+	return s.runner.start(ctx, time.Duration(intervalMs)*time.Millisecond, true, func() {
 		s.runPass(ctx)
 	})
+}
+
+// projectionIntervalMs resolves the pass cadence from USAGE_PROJECTION_INTERVAL_MS,
+// falling back to the package default when the field is unset.
+func (s *UsageAggregationScheduler) projectionIntervalMs() int {
+	if s.cfg != nil && s.cfg.UsageProjectionIntervalMs > 0 {
+		return s.cfg.UsageProjectionIntervalMs
+	}
+	return defaultUsageProjectionIntervalMs
 }
 
 func (s *UsageAggregationScheduler) Stop() error {

--- a/scheduler/usage_projection_interval_test.go
+++ b/scheduler/usage_projection_interval_test.go
@@ -1,0 +1,24 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+)
+
+// TestUsageAggregationProjectionInterval covers the resolution order: the
+// configured cadence wins, and callers that build config.Config by hand (tests,
+// embedders) or pass nil fall back to the package default instead of spinning at
+// a zero interval.
+func TestUsageAggregationProjectionInterval(t *testing.T) {
+	if got := NewUsageAggregationScheduler(&config.Config{}).projectionIntervalMs(); got != defaultUsageProjectionIntervalMs {
+		t.Fatalf("zero-value config interval = %d, want default %d", got, defaultUsageProjectionIntervalMs)
+	}
+	if got := NewUsageAggregationScheduler(nil).projectionIntervalMs(); got != defaultUsageProjectionIntervalMs {
+		t.Fatalf("nil config interval = %d, want default %d", got, defaultUsageProjectionIntervalMs)
+	}
+	cfg, _ := config.Load(map[string]string{"USAGE_PROJECTION_INTERVAL_MS": "30000"})
+	if got := NewUsageAggregationScheduler(cfg).projectionIntervalMs(); got != 30000 {
+		t.Fatalf("configured interval = %d, want 30000", got)
+	}
+}

--- a/store/bootstrap.go
+++ b/store/bootstrap.go
@@ -6,23 +6,25 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/deliciousbuding/metapi-go/config"
 )
 
 var (
-	activeDB    *DB
-	initialized bool
-	mu          sync.Mutex
+	// activeDB is the process-wide database singleton. Readers go through an
+	// atomic pointer because GetDB sits on every request path and must not
+	// contend on a global mutex; writers still serialise on mu, which guards the
+	// multi-step open / migrate / switch sequences (not the pointer itself).
+	activeDB atomic.Pointer[DB]
+	mu       sync.Mutex
 )
 
 // GetDB returns the current active database connection.
 // Returns nil if the database has not been initialized.
 func GetDB() *DB {
-	mu.Lock()
-	defer mu.Unlock()
-	return activeDB
+	return activeDB.Load()
 }
 
 // EnsureRuntimeDatabase creates the data directory, opens the database,
@@ -32,7 +34,7 @@ func EnsureRuntimeDatabase(cfg *config.Config, rt *config.RuntimeSettings) error
 	mu.Lock()
 	defer mu.Unlock()
 
-	if initialized && activeDB != nil {
+	if activeDB.Load() != nil {
 		// Already initialized — idempotent (mirrors TS module-level singleton).
 		return nil
 	}
@@ -90,8 +92,7 @@ func EnsureRuntimeDatabase(cfg *config.Config, rt *config.RuntimeSettings) error
 		warnTSSchemaDrift(db)
 	}
 
-	activeDB = db
-	initialized = true
+	activeDB.Store(db)
 
 	logAttrs := []any{"dialect", dialect}
 	if dialect == DialectPostgres {
@@ -161,11 +162,8 @@ func resolvePostgresApplicationName(cfg *config.Config) string {
 func CloseDatabase() error {
 	mu.Lock()
 	defer mu.Unlock()
-	if activeDB != nil {
-		err := activeDB.Close()
-		activeDB = nil
-		initialized = false
-		return err
+	if db := activeDB.Swap(nil); db != nil {
+		return db.Close()
 	}
 	return nil
 }
@@ -175,8 +173,7 @@ func CloseDatabase() error {
 func OverrideDB(db *DB) {
 	mu.Lock()
 	defer mu.Unlock()
-	activeDB = db
-	initialized = db != nil
+	activeDB.Store(db)
 }
 
 // maskDSN redacts the password portion of a PostgreSQL connection string for logging.

--- a/store/switch.go
+++ b/store/switch.go
@@ -76,8 +76,7 @@ func SwitchDatabase(cfg *config.Config, nextDialect, nextDsn string, nextSsl boo
 
 	// Set active DB.
 	mu.Lock()
-	activeDB = newDB
-	initialized = true
+	activeDB.Store(newDB)
 	mu.Unlock()
 
 	slog.Info("switch: database switch complete", "dialect", nextDialect)
@@ -116,8 +115,7 @@ func rollbackSwitch(cfg *config.Config, dialect, dsn string, ssl bool, originalE
 	}
 
 	mu.Lock()
-	activeDB = rollbackDB
-	initialized = true
+	activeDB.Store(rollbackDB)
 	mu.Unlock()
 
 	return fmt.Errorf("database switch failed: %w", originalErr)

--- a/store/switch_test.go
+++ b/store/switch_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // resetActiveDBForTest closes any active DB singleton so each SwitchDatabase
-// test starts from a clean global state. The activeDB/initialized globals are
+// test starts from a clean global state. The activeDB singleton is
 // package-private, so tests cannot run in parallel with each other.
 func resetActiveDBForTest(t *testing.T) {
 	t.Helper()
@@ -193,9 +193,6 @@ func TestSwitchDatabase_RollbackAlsoFails(t *testing.T) {
 	// activeDB must be nil — the singleton must not hold a stale/broken handle.
 	if GetDB() != nil {
 		t.Fatalf("GetDB() != nil after rollback failure; expected nil activeDB")
-	}
-	if initialized {
-		t.Fatal("initialized flag still true after rollback failure; expected false")
 	}
 
 	// Config is best-effort restored to the original values by rollbackSwitch


### PR DESCRIPTION
## 改动摘要

三项互不相关的运行时卫生修复，正常路径行为零漂移：

1. **Redis 补偿回滚不再留下「无 TTL 的非正数键」**（`internal/sharedcount`）：限流拒绝时的补偿 `DECR` / 负 `INCRBY` 如果落在窗口已过期之后，会把键以「无 TTL + 负值」重新建出来；而 `INCR` 只在结果恰好为 1 时才武装 `PEXPIRE`，于是这个键要等计数从 -1 爬回 1 才重新变成有寿命的，期间每个窗口都少算。现在回滚把总数打到 `<= 0` 时顺手 `DEL`（best-effort，回滚本身已经落地）：总数非正说明没有任何实例持有活的预占，删掉不丢信息。正数窗口与其 TTL 完全不碰——部分回滚仍保留剩余额度继续计数。
2. **数据库单例改原子指针**（`store`）：`GetDB()` 在每条请求路径上，之前每次都要抢一把全局 `sync.Mutex`。改成 `atomic.Pointer[DB]` 后读者无锁；写者（open / migrate / switch 的多步序列）仍在 `mu` 下串行。顺带删掉冗余的 `initialized` 标志——指针为 nil 就是这个状态。
3. **usage 投影节奏可调**（`scheduler` + `config`）：`proxy_logs` → 站点/模型汇总表的投影 pass 之前硬编码 5s。新增 `USAGE_PROJECTION_INTERVAL_MS`（钳制 1000–3600000，默认值不变），小型单机部署可以用「仪表盘新鲜度」换更少的 pass。手工构造的 `config.Config` 与 nil config 回落到包内默认值，不会以 0 间隔空转。
4. **`.gitignore`**：TS 迁移兼容测试的固定样本库旁边，只要有任何东西就地打开它就会生成 SQLite WAL 边车文件（`-shm` / `-wal`），把 `git status` 弄脏；样本库字节本身仍被跟踪且不变。

## 类型

- [x] fix（bug 修复）
- [x] perf（性能优化）
- [x] refactor（重构，行为不变）
- [x] docs / chore（文档或工程维护）

## 测试验证

- [x] `go vet`（`./config/... ./store/... ./scheduler/... ./internal/sharedcount/... ./auth/...`）通过
- [x] `go build ./...` 通过
- [x] `go test ./internal/sharedcount/... ./config/...` 全绿（0.7s / 0.3s）
- [x] `go test ./store/... ./scheduler/...` 全绿（7.3s / 19.2s）
- [x] `go test ./docs -run TestPublicMarkdownHygiene` 通过
- [x] 新增测试：回滚自愈（缺失键 / 正数窗口 / 部分回滚 / 负 `INCRBY`）打真实 TCP 环回上的进程内 RESP fake；间隔钳制与回落；投影节奏解析顺序
- 未触碰前端与 API/DB 契约（无迁移、无接口形状变化）

## 自查清单

- [x] 无密钥/内部路径泄漏
- [x] 行为变更已补充测试（回滚自愈 + 新旋钮钳制）
- [x] 新旋钮已同步 `docs/configuration.md`（Scheduling 表）与 `.env.example`
- [x] 用户可见文案无变化（无需 i18n）
