### PR TITLE
refactor(auth): thread the request context through key admission

### DIFF
--- a/auth/key_admission.go
+++ b/auth/key_admission.go
@@ -218,13 +218,22 @@ type AdmissionDecision struct {
 // estimatedTokens is reserved against TPM when maxTPM is set; pass 0 to skip TPM accounting.
 // When allowed, the request is recorded immediately (admission reservation).
 //
+// ctx bounds the shared-counter round trips: a client that goes away cancels its
+// own Redis wait instead of holding the per-key serialization mutex for the full
+// counter timeout. Pass the request context (nil is treated as Background). A
+// cancelled round trip is an error, so it takes the existing fail-open path —
+// the request is already gone, and the window self-heals on expiry.
+//
 // Shared-counter round trips never run under a shard lock, so a slow or
 // unreachable Redis costs latency only for its own key. Decisions keep the exact
 // order they had under the previous single lock: shared RPM -> local RPM fallback
 // -> shared TPM -> local TPM fallback -> reservation.
-func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimatedTokens int64) AdmissionDecision {
+func (l *KeyAdmissionLimiter) Allow(ctx context.Context, keyID int64, maxRPM, maxTPM *int64, estimatedTokens int64) AdmissionDecision {
 	if l == nil || keyID <= 0 {
 		return AdmissionDecision{Allowed: true}
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	rpmLimit := int64(0)
 	tpmLimit := int64(0)
@@ -297,7 +306,6 @@ func (l *KeyAdmissionLimiter) Allow(keyID int64, maxRPM, maxTPM *int64, estimate
 	w.sharedMu.Lock()
 	defer w.sharedMu.Unlock()
 
-	ctx := context.Background()
 	rpmKey := rpmSharedKey(keyID)
 	tpmKey := tpmSharedKey(keyID)
 	var rpm, tpm sharedVerdict

--- a/auth/key_admission_bench_test.go
+++ b/auth/key_admission_bench_test.go
@@ -103,7 +103,7 @@ func runAllowBench(b *testing.B, setup func(l *KeyAdmissionLimiter), keyFor func
 		durs := make([]time.Duration, 0, 4096)
 		for pb.Next() {
 			t0 := time.Now()
-			l.Allow(keyID, &limit, nil, 0)
+			l.Allow(context.Background(), keyID, &limit, nil, 0)
 			durs = append(durs, time.Since(t0))
 		}
 		mu.Lock()

--- a/auth/key_admission_ctx_test.go
+++ b/auth/key_admission_ctx_test.go
@@ -1,0 +1,144 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// blockingWindow is a WindowCounter whose Incr parks until the caller's context
+// is done (or release is closed), so a test can observe cancellation instead of
+// waiting out the counter's own timeout.
+type blockingWindow struct {
+	release chan struct{}
+	started chan struct{}
+
+	mu       chan struct{} // closed once; guards lastErr writes below
+	lastErr  error
+	lastKey  string
+	incrHits int
+}
+
+func newBlockingWindow() *blockingWindow {
+	return &blockingWindow{
+		release: make(chan struct{}),
+		started: make(chan struct{}, 8),
+		mu:      make(chan struct{}, 1),
+	}
+}
+
+func (b *blockingWindow) record(key string, err error) {
+	b.mu <- struct{}{}
+	defer func() { <-b.mu }()
+	b.lastKey = key
+	b.lastErr = err
+	b.incrHits++
+}
+
+func (b *blockingWindow) Incr(ctx context.Context, key string, window time.Duration) (int64, error) {
+	select {
+	case b.started <- struct{}{}:
+	default:
+	}
+	select {
+	case <-ctx.Done():
+		b.record(key, ctx.Err())
+		return 0, ctx.Err()
+	case <-b.release:
+		b.record(key, nil)
+		return 1, nil
+	}
+}
+
+func (b *blockingWindow) Decr(context.Context, string, time.Duration) (int64, error) { return 0, nil }
+
+func (b *blockingWindow) IncrBy(context.Context, string, int64, time.Duration) (int64, error) {
+	return 0, nil
+}
+
+func (b *blockingWindow) Get(context.Context, string) (int64, error) { return 0, nil }
+
+func (b *blockingWindow) err() error {
+	b.mu <- struct{}{}
+	defer func() { <-b.mu }()
+	return b.lastErr
+}
+
+// TestKeyAdmission_AllowCancelledContextFailsOpenFast pins the ctx contract: a
+// client that goes away cancels its own shared-counter round trip instead of
+// holding the per-key serialization mutex for the full counter timeout. The
+// cancelled round trip is an error, so it takes the existing fail-open path and
+// the local window still records the reservation.
+func TestKeyAdmission_AllowCancelledContextFailsOpenFast(t *testing.T) {
+	l := NewKeyAdmissionLimiter()
+	bw := newBlockingWindow()
+	l.SetSharedRPMCounter(bw)
+	limit := int64(5)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-bw.started
+		cancel()
+	}()
+
+	start := time.Now()
+	d := l.Allow(ctx, 1, &limit, nil, 0)
+	elapsed := time.Since(start)
+
+	if !d.Allowed {
+		t.Fatalf("cancelled shared round trip = %+v, want fail-open allow", d)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("Allow took %v after cancellation, want prompt return", elapsed)
+	}
+	if !errors.Is(bw.err(), context.Canceled) {
+		t.Fatalf("counter error = %v, want context.Canceled", bw.err())
+	}
+	if used, _ := l.Snapshot(1); used != 1 {
+		t.Fatalf("local usedRPM after fail-open = %d, want 1 (fallback still reserves)", used)
+	}
+}
+
+// TestKeyAdmission_AllowPreCancelledContext covers the already-gone client: the
+// decision must not block on a shared round trip at all.
+func TestKeyAdmission_AllowPreCancelledContext(t *testing.T) {
+	l := NewKeyAdmissionLimiter()
+	bw := newBlockingWindow()
+	l.SetSharedRPMCounter(bw)
+	limit := int64(5)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	d := l.Allow(ctx, 2, &limit, nil, 0)
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("pre-cancelled Allow took %v, want immediate", elapsed)
+	}
+	if !d.Allowed {
+		t.Fatalf("pre-cancelled decision = %+v, want fail-open allow", d)
+	}
+	if !errors.Is(bw.err(), context.Canceled) {
+		t.Fatalf("counter error = %v, want context.Canceled", bw.err())
+	}
+}
+
+// TestKeyAdmission_AllowNilContextIsBackground keeps the exported method safe
+// for callers that have no request context (CLI, scheduler-driven probes).
+func TestKeyAdmission_AllowNilContextIsBackground(t *testing.T) {
+	l := NewKeyAdmissionLimiter()
+	fw := &fakeWindow{}
+	l.SetSharedRPMCounter(fw)
+	limit := int64(1)
+
+	//lint:ignore SA1012 nil ctx is an explicitly supported input here.
+	if d := l.Allow(nil, 3, &limit, nil, 0); !d.Allowed {
+		t.Fatalf("nil ctx decision = %+v, want allow", d)
+	}
+	//lint:ignore SA1012 nil ctx is an explicitly supported input here.
+	if d := l.Allow(nil, 3, &limit, nil, 0); d.Allowed || d.Reason != "over_rpm" {
+		t.Fatalf("second nil ctx decision = %+v, want over_rpm", d)
+	}
+}

--- a/auth/key_admission_lock_test.go
+++ b/auth/key_admission_lock_test.go
@@ -151,7 +151,7 @@ func TestKeyAdmission_SharedCounterRunsOutsideShardLock(t *testing.T) {
 		}
 		hookRan.Add(1)
 		// Nested admission for another key in the SAME shard stripe.
-		if d := l.Allow(keyB, &limit, nil, 0); !d.Allowed {
+		if d := l.Allow(context.Background(), keyB, &limit, nil, 0); !d.Allowed {
 			fail("nested Allow denied: %#v", d)
 		}
 		// Snapshot takes the shard lock but must never take the per-key shared
@@ -167,7 +167,7 @@ func TestKeyAdmission_SharedCounterRunsOutsideShardLock(t *testing.T) {
 
 	var d AdmissionDecision
 	withinTimeout(t, 10*time.Second, "Allow with a slow shared counter", func() {
-		d = l.Allow(keyA, &limit, nil, 0)
+		d = l.Allow(context.Background(), keyA, &limit, nil, 0)
 	})
 	if hookRan.Load() == 0 {
 		t.Fatal("shared counter hook never ran — test did not exercise the shared path")
@@ -200,7 +200,7 @@ func TestKeyAdmission_DistinctKeysNotSerializedBySharedCounter(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-start
-			if d := l.Allow(int64(i+1), &limit, nil, 0); !d.Allowed {
+			if d := l.Allow(context.Background(), int64(i+1), &limit, nil, 0); !d.Allowed {
 				t.Errorf("key %d denied: %#v", i+1, d)
 			}
 		}(i)
@@ -235,7 +235,7 @@ func TestKeyAdmission_DenyCompensationStaysOrderedPerKey(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-start
-			decisions[i] = l.Allow(101, &limit, nil, 0)
+			decisions[i] = l.Allow(context.Background(), 101, &limit, nil, 0)
 		}(i)
 	}
 	close(start)
@@ -300,7 +300,7 @@ func TestKeyAdmission_SharedFailOpenKeepsLocalLimitExact(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			if d := l.Allow(202, &limit, nil, 0); d.Allowed {
+			if d := l.Allow(context.Background(), 202, &limit, nil, 0); d.Allowed {
 				allowed.Add(1)
 			} else if d.Reason != "over_rpm" {
 				t.Errorf("fail-open deny reason = %q, want over_rpm", d.Reason)

--- a/auth/key_admission_shared_test.go
+++ b/auth/key_admission_shared_test.go
@@ -88,13 +88,13 @@ func TestKeyAdmission_SharedRPM(t *testing.T) {
 	fw := &fakeWindow{}
 	l.SetSharedRPMCounter(fw)
 	limit := int64(2)
-	if d := l.Allow(1, &limit, nil, 0); !d.Allowed {
+	if d := l.Allow(context.Background(), 1, &limit, nil, 0); !d.Allowed {
 		t.Fatalf("1: %#v", d)
 	}
-	if d := l.Allow(1, &limit, nil, 0); !d.Allowed {
+	if d := l.Allow(context.Background(), 1, &limit, nil, 0); !d.Allowed {
 		t.Fatalf("2: %#v", d)
 	}
-	if d := l.Allow(1, &limit, nil, 0); d.Allowed || d.Reason != "over_rpm" {
+	if d := l.Allow(context.Background(), 1, &limit, nil, 0); d.Allowed || d.Reason != "over_rpm" {
 		t.Fatalf("3 should deny: %#v", d)
 	}
 	// #513: over_rpm rolls back the denied Incr so the window stays at the limit.
@@ -107,7 +107,7 @@ func TestKeyAdmission_SharedRPM(t *testing.T) {
 	if _, err := fw.Decr(context.Background(), "metapi:rpm:1", time.Minute); err != nil {
 		t.Fatal(err)
 	}
-	if d := l.Allow(1, &limit, nil, 0); !d.Allowed {
+	if d := l.Allow(context.Background(), 1, &limit, nil, 0); !d.Allowed {
 		t.Fatalf("after free slot should allow: %#v", d)
 	}
 	if fw.n != 2 {
@@ -121,7 +121,7 @@ func TestKeyAdmission_SharedRPM_FailOpen(t *testing.T) {
 	l.SetSharedRPMCounter(fw)
 	limit := int64(100)
 	// Should not hard-fail; local path allows.
-	if d := l.Allow(2, &limit, nil, 0); !d.Allowed {
+	if d := l.Allow(context.Background(), 2, &limit, nil, 0); !d.Allowed {
 		t.Fatalf("fail-open expected allow: %#v", d)
 	}
 }
@@ -131,7 +131,7 @@ func TestKeyAdmission_SharedTPM(t *testing.T) {
 	fw := &fakeWindow{}
 	l.SetSharedTPMCounter(fw)
 	tpm := int64(1000)
-	d := l.Allow(11, nil, &tpm, 600)
+	d := l.Allow(context.Background(), 11, nil, &tpm, 600)
 	if !d.Allowed {
 		t.Fatalf("1: %#v", d)
 	}
@@ -139,10 +139,10 @@ func TestKeyAdmission_SharedTPM(t *testing.T) {
 		t.Fatalf("used tpm want 600 got %d", d.UsedTPM)
 	}
 	// 400 fits (600+400=1000); shared IncrBy-before-check semantics (same as RPM).
-	if d := l.Allow(11, nil, &tpm, 400); !d.Allowed {
+	if d := l.Allow(context.Background(), 11, nil, &tpm, 400); !d.Allowed {
 		t.Fatalf("2 should allow 400 after 600: %#v", d)
 	}
-	if d := l.Allow(11, nil, &tpm, 1); d.Allowed || d.Reason != "over_tpm" {
+	if d := l.Allow(context.Background(), 11, nil, &tpm, 1); d.Allowed || d.Reason != "over_tpm" {
 		t.Fatalf("3 should deny over_tpm: %#v", d)
 	}
 	// #513: over_tpm rolls back the denied IncrBy.
@@ -160,11 +160,11 @@ func TestKeyAdmission_SharedTPM_FailOpen(t *testing.T) {
 	l.SetSharedTPMCounter(fw)
 	tpm := int64(1000)
 	// Fail-open to local tokenEvents — first 600 should allow.
-	if d := l.Allow(12, nil, &tpm, 600); !d.Allowed {
+	if d := l.Allow(context.Background(), 12, nil, &tpm, 600); !d.Allowed {
 		t.Fatalf("fail-open expected allow: %#v", d)
 	}
 	// Local path still enforces after fail-open.
-	if d := l.Allow(12, nil, &tpm, 500); d.Allowed || d.Reason != "over_tpm" {
+	if d := l.Allow(context.Background(), 12, nil, &tpm, 500); d.Allowed || d.Reason != "over_tpm" {
 		t.Fatalf("local over_tpm after fail-open: %#v", d)
 	}
 }
@@ -178,14 +178,14 @@ func TestKeyAdmission_SharedRPM_ThenTPM_CompoundRollback(t *testing.T) {
 	rpm := int64(10)
 	tpm := int64(100)
 	// Fill TPM almost full.
-	if d := l.Allow(21, &rpm, &tpm, 90); !d.Allowed {
+	if d := l.Allow(context.Background(), 21, &rpm, &tpm, 90); !d.Allowed {
 		t.Fatalf("seed allow: %#v", d)
 	}
 	if fw.n != 1 || fw.tokens != 90 {
 		t.Fatalf("seed state n=%d tokens=%d", fw.n, fw.tokens)
 	}
 	// Next: RPM would succeed (2<=10) but TPM 90+20=110 > 100 → deny both.
-	if d := l.Allow(21, &rpm, &tpm, 20); d.Allowed || d.Reason != "over_tpm" {
+	if d := l.Allow(context.Background(), 21, &rpm, &tpm, 20); d.Allowed || d.Reason != "over_tpm" {
 		t.Fatalf("compound deny expected over_tpm: %#v", d)
 	}
 	if fw.n != 1 {
@@ -195,7 +195,7 @@ func TestKeyAdmission_SharedRPM_ThenTPM_CompoundRollback(t *testing.T) {
 		t.Fatalf("TPM reservation must roll back: tokens=%d want 90", fw.tokens)
 	}
 	// Capacity remains usable for a fitting request.
-	if d := l.Allow(21, &rpm, &tpm, 10); !d.Allowed {
+	if d := l.Allow(context.Background(), 21, &rpm, &tpm, 10); !d.Allowed {
 		t.Fatalf("fitting request after compound deny: %#v", d)
 	}
 	if fw.n != 2 || fw.tokens != 100 {
@@ -216,14 +216,14 @@ func TestKeyAdmission_SharedMemoryCounter_Parity(t *testing.T) {
 	rpm := int64(2)
 	tpm := int64(100)
 
-	if d := l.Allow(31, &rpm, &tpm, 40); !d.Allowed {
+	if d := l.Allow(context.Background(), 31, &rpm, &tpm, 40); !d.Allowed {
 		t.Fatalf("1: %#v", d)
 	}
-	if d := l.Allow(31, &rpm, &tpm, 40); !d.Allowed {
+	if d := l.Allow(context.Background(), 31, &rpm, &tpm, 40); !d.Allowed {
 		t.Fatalf("2: %#v", d)
 	}
 	// RPM deny: should roll back so used RPM stays 2.
-	if d := l.Allow(31, &rpm, &tpm, 1); d.Allowed || d.Reason != "over_rpm" {
+	if d := l.Allow(context.Background(), 31, &rpm, &tpm, 1); d.Allowed || d.Reason != "over_rpm" {
 		t.Fatalf("over_rpm: %#v", d)
 	}
 	// Free one RPM via Decr directly on the counter, then hit TPM deny compound.
@@ -231,7 +231,7 @@ func TestKeyAdmission_SharedMemoryCounter_Parity(t *testing.T) {
 		t.Fatal(err)
 	}
 	// tokens currently 80; request 30 → 110 > 100, both roll back.
-	if d := l.Allow(31, &rpm, &tpm, 30); d.Allowed || d.Reason != "over_tpm" {
+	if d := l.Allow(context.Background(), 31, &rpm, &tpm, 30); d.Allowed || d.Reason != "over_tpm" {
 		t.Fatalf("over_tpm compound: %#v", d)
 	}
 	// After compound rollback, RPM should still be 1 (post-decr) and TPM 80.

--- a/auth/key_admission_test.go
+++ b/auth/key_admission_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -12,9 +13,9 @@ func TestKeyAdmissionLimiter_RPM(t *testing.T) {
 	l.nowFn = func() time.Time { return now }
 
 	limit := int64(2)
-	d1 := l.Allow(1, &limit, nil, 0)
-	d2 := l.Allow(1, &limit, nil, 0)
-	d3 := l.Allow(1, &limit, nil, 0)
+	d1 := l.Allow(context.Background(), 1, &limit, nil, 0)
+	d2 := l.Allow(context.Background(), 1, &limit, nil, 0)
+	d3 := l.Allow(context.Background(), 1, &limit, nil, 0)
 	if !d1.Allowed || !d2.Allowed {
 		t.Fatalf("first two should allow: %#v %#v", d1, d2)
 	}
@@ -27,7 +28,7 @@ func TestKeyAdmissionLimiter_RPM(t *testing.T) {
 
 	// Advance past window — should allow again.
 	now = base.Add(61 * time.Second)
-	d4 := l.Allow(1, &limit, nil, 0)
+	d4 := l.Allow(context.Background(), 1, &limit, nil, 0)
 	if !d4.Allowed {
 		t.Fatalf("after window reset expected allow: %#v", d4)
 	}
@@ -40,14 +41,14 @@ func TestKeyAdmissionLimiter_TPM(t *testing.T) {
 	l.nowFn = func() time.Time { return now }
 
 	tpm := int64(1000)
-	if d := l.Allow(7, nil, &tpm, 600); !d.Allowed {
+	if d := l.Allow(context.Background(), 7, nil, &tpm, 600); !d.Allowed {
 		t.Fatalf("first tpm allow: %#v", d)
 	}
-	if d := l.Allow(7, nil, &tpm, 500); d.Allowed || d.Reason != "over_tpm" {
+	if d := l.Allow(context.Background(), 7, nil, &tpm, 500); d.Allowed || d.Reason != "over_tpm" {
 		t.Fatalf("expected over_tpm: %#v", d)
 	}
 	// Small residual still ok
-	if d := l.Allow(7, nil, &tpm, 400); !d.Allowed {
+	if d := l.Allow(context.Background(), 7, nil, &tpm, 400); !d.Allowed {
 		t.Fatalf("400 should fit after 600: %#v", d)
 	}
 }
@@ -55,7 +56,7 @@ func TestKeyAdmissionLimiter_TPM(t *testing.T) {
 func TestKeyAdmissionLimiter_Unlimited(t *testing.T) {
 	l := NewKeyAdmissionLimiter()
 	for i := 0; i < 100; i++ {
-		if d := l.Allow(9, nil, nil, 100); !d.Allowed {
+		if d := l.Allow(context.Background(), 9, nil, nil, 100); !d.Allowed {
 			t.Fatalf("unlimited denied: %#v", d)
 		}
 	}
@@ -67,7 +68,7 @@ func TestKeyAdmissionLimiter_Concurrent(t *testing.T) {
 	done := make(chan AdmissionDecision, 100)
 	for i := 0; i < 100; i++ {
 		go func() {
-			done <- l.Allow(3, &limit, nil, 0)
+			done <- l.Allow(context.Background(), 3, &limit, nil, 0)
 		}()
 	}
 	allowed := 0

--- a/auth/proxy.go
+++ b/auth/proxy.go
@@ -82,7 +82,7 @@ func ProxyAuth() func(http.Handler) http.Handler {
 				if result.Key.MaxTPM != nil && *result.Key.MaxTPM > 0 {
 					estimatedTokens = estimateAdmissionTokens(r)
 				}
-				adm := GlobalKeyAdmission.Allow(result.Key.ID, result.Key.MaxRPM, result.Key.MaxTPM, estimatedTokens)
+				adm := GlobalKeyAdmission.Allow(r.Context(), result.Key.ID, result.Key.MaxRPM, result.Key.MaxTPM, estimatedTokens)
 				if !adm.Allowed {
 					msg := "API key rate limit exceeded"
 					if adm.Reason == "over_tpm" {

--- a/auth/proxy_test.go
+++ b/auth/proxy_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -840,7 +841,7 @@ func TestProxyAuthMiddleware_AdmissionDenyFromZeroDoesNotIncrement(t *testing.T)
 	id := insertTestKeyWithRPM(t, "sk-adm-prefill", &maxRequests, 0, &maxRPM, nil)
 
 	// Saturate admission window for this key id without consuming DB quota.
-	if d := GlobalKeyAdmission.Allow(id, &maxRPM, nil, 0); !d.Allowed {
+	if d := GlobalKeyAdmission.Allow(context.Background(), id, &maxRPM, nil, 0); !d.Allowed {
 		t.Fatalf("prefill should allow once: %#v", d)
 	}
 

--- a/auth/tpm_estimate_test.go
+++ b/auth/tpm_estimate_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -156,7 +157,7 @@ func TestKeyAdmissionLimiter_TPM_WithEstimateHelper(t *testing.T) {
 	if est1 != 600 {
 		t.Fatalf("est1 = %d, want 600", est1)
 	}
-	if d := l.Allow(42, nil, &tpm, est1); !d.Allowed {
+	if d := l.Allow(context.Background(), 42, nil, &tpm, est1); !d.Allowed {
 		t.Fatalf("first allow: %#v", d)
 	}
 
@@ -167,7 +168,7 @@ func TestKeyAdmissionLimiter_TPM_WithEstimateHelper(t *testing.T) {
 	if est2 != 500 {
 		t.Fatalf("est2 = %d, want 500", est2)
 	}
-	if d := l.Allow(42, nil, &tpm, est2); d.Allowed || d.Reason != "over_tpm" {
+	if d := l.Allow(context.Background(), 42, nil, &tpm, est2); d.Allowed || d.Reason != "over_tpm" {
 		t.Fatalf("expected over_tpm: %#v (est2=%d)", d, est2)
 	}
 }
@@ -176,7 +177,7 @@ func TestKeyAdmissionLimiter_MaxTPMNil_Unchanged(t *testing.T) {
 	// maxTPM nil: estimatedTokens ignored — unlimited TPM path.
 	l := NewKeyAdmissionLimiter()
 	for i := 0; i < 5; i++ {
-		if d := l.Allow(99, nil, nil, 100_000); !d.Allowed {
+		if d := l.Allow(context.Background(), 99, nil, nil, 100_000); !d.Allowed {
 			t.Fatalf("nil maxTPM should allow: %#v", d)
 		}
 	}


### PR DESCRIPTION
## 改动摘要

`KeyAdmissionLimiter.Allow()` 之前自己造 `context.Background()` 去跑共享计数器（Redis）往返，所以**客户端已经断开**的请求仍会把整个计数器超时耗完，而这段时间它正持有「每密钥串行化互斥锁」——同一密钥的其它请求全排在一次没人在等的往返后面。

现在 `Allow` 接收调用方 ctx（`nil` 视作 `Background`，方便 CLI/调度器类调用者），`/v1` 中间件传 `r.Context()`。取消的往返以计数器错误形式浮出，走的正是既有 fail-open 路径：本地窗口照常记账，所以单实例语义零漂移，共享窗口靠过期自愈。唯一残留是「取消恰好落在 `Incr` 与补偿 `Decr` 之间」时可能多计 1 个单位，固定窗口滚动即丢弃。

## 类型

- [x] refactor（重构，行为不变）
- [x] perf（性能优化）

## 测试验证

- [x] `go build ./...` 通过
- [x] `go vet ./auth/...` 通过
- [x] `go test ./auth/... -count=1` 全绿（9.2s，含既有共享/锁序/TPM 估算/bench 套件）
- [x] 新增 `auth/key_admission_ctx_test.go` 钉住三条腿：
  - 途中取消 → 迅速返回 + fail-open + 本地兜底仍预占（`Snapshot` usedRPM=1）
  - 已取消的 ctx → 完全不阻塞在往返上（<500ms）
  - `nil` ctx → 等价 `Background`（第一次放行、第二次 `over_rpm`）
- 未触碰前端、API 形状、DB

## 自查清单

- [x] 无密钥/内部路径泄漏
- [x] 行为变更已补测试
- [x] 无需 CHANGELOG（随下一版汇总）/ 无用户可见文案变化
- [x] 36 处测试调用点同步更新（`context.Background()` 显式传入），保持「测试里也要看得见 ctx 契约」
