### PR TITLE
fix(store): normalize numeric boolean defaults so legacy PostgreSQL databases can start

### DIFF
--- a/store/additive.go
+++ b/store/additive.go
@@ -216,7 +216,7 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 			if err := EnsureColumn(db, "sites", "proxy_url", "TEXT", "TEXT", ""); err != nil {
 				return err
 			}
-			if err := EnsureColumn(db, "sites", "use_system_proxy", "INTEGER", "BOOLEAN", "DEFAULT 0"); err != nil {
+			if err := EnsureColumn(db, "sites", "use_system_proxy", "INTEGER", "BOOLEAN", "DEFAULT FALSE"); err != nil {
 				return err
 			}
 			if err := EnsureColumn(db, "sites", "custom_headers", "TEXT", "TEXT", ""); err != nil {
@@ -232,7 +232,7 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 		Version:     "sc2_018_site_post_refresh_probe",
 		Description: "sites post-refresh probe columns (TS 0025/0026) — post_refresh_probe_enabled / _model / _scope / _latency_threshold_ms",
 		Apply: func(db *DB) error {
-			if err := EnsureColumn(db, "sites", "post_refresh_probe_enabled", "INTEGER", "BOOLEAN", "DEFAULT 0"); err != nil {
+			if err := EnsureColumn(db, "sites", "post_refresh_probe_enabled", "INTEGER", "BOOLEAN", "DEFAULT FALSE"); err != nil {
 				return err
 			}
 			if err := EnsureColumn(db, "sites", "post_refresh_probe_model", "TEXT", "TEXT", "DEFAULT ''"); err != nil {
@@ -340,7 +340,7 @@ var enterpriseAdditiveSteps = []AdditiveStep{
 		Version:     "sc2_024_model_availability_is_manual",
 		Description: "model_availability.is_manual (TS 0009) — manual availability override flag",
 		Apply: func(db *DB) error {
-			return EnsureColumn(db, "model_availability", "is_manual", "INTEGER", "BOOLEAN", "DEFAULT 0")
+			return EnsureColumn(db, "model_availability", "is_manual", "INTEGER", "BOOLEAN", "DEFAULT FALSE")
 		},
 	},
 	{
@@ -676,6 +676,47 @@ func quoteIdentSQLite(name string) string {
 	return `"` + name + `"`
 }
 
+// normalizeBooleanDefault rewrites numeric boolean literals (DEFAULT 0 / DEFAULT 1)
+// into the SQL-standard DEFAULT FALSE / DEFAULT TRUE when the column type is
+// BOOLEAN. SQLite stores booleans as INTEGER and accepts either spelling, but
+// PostgreSQL type-checks the default expression against the column and rejects
+// `ADD COLUMN flag BOOLEAN DEFAULT 0` with "column is of type boolean but
+// default expression is of type integer" (SQLSTATE 42804) — which aborts
+// AutoMigrate and stops a legacy database from starting at all. Registry entries
+// are written once for both dialects, so the numeric spelling is normalized here
+// instead of relying on every call site remembering the difference.
+//
+// Any trailing modifiers (e.g. NOT NULL) are preserved. Non-boolean column types
+// and defaults that are not a bare 0/1 literal are returned untouched.
+func normalizeBooleanDefault(colType, defaultClause string) string {
+	if defaultClause == "" || !strings.EqualFold(strings.TrimSpace(colType), "BOOLEAN") {
+		return defaultClause
+	}
+	fields := strings.Fields(defaultClause)
+	if len(fields) < 2 || !strings.EqualFold(fields[0], "DEFAULT") {
+		return defaultClause
+	}
+	switch fields[1] {
+	case "0":
+		fields[1] = "FALSE"
+	case "1":
+		fields[1] = "TRUE"
+	default:
+		return defaultClause
+	}
+	return strings.Join(fields, " ")
+}
+
+// buildAddColumnDDL renders the ALTER TABLE statement EnsureColumn executes.
+// Split out from the execution path so the exact DDL for a dialect can be
+// asserted without a live database.
+func buildAddColumnDDL(table, column, colType, defaultClause string) string {
+	if defaultClause == "" {
+		return fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s`, table, column, colType)
+	}
+	return fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s %s`, table, column, colType, defaultClause)
+}
+
 // EnsureColumn adds table.column if missing. Types are dialect-specific
 // fragments (e.g. sqliteType="TEXT", pgType="TEXT", or INTEGER vs BOOLEAN).
 // defaultClause is optional SQL after the type (e.g. "DEFAULT 0" or "DEFAULT FALSE");
@@ -705,13 +746,8 @@ func EnsureColumn(db *DB, table, column, sqliteType, pgType, defaultClause strin
 		return fmt.Errorf("store: EnsureColumn: invalid identifier %q.%q", table, column)
 	}
 
-	def := strings.TrimSpace(defaultClause)
-	var ddl string
-	if def == "" {
-		ddl = fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s`, table, column, colType)
-	} else {
-		ddl = fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s %s`, table, column, colType, def)
-	}
+	def := normalizeBooleanDefault(colType, strings.TrimSpace(defaultClause))
+	ddl := buildAddColumnDDL(table, column, colType, def)
 
 	if _, err := db.Exec(ddl); err != nil {
 		// Race / concurrent startup: column may already exist.

--- a/store/additive_boolean_default_test.go
+++ b/store/additive_boolean_default_test.go
@@ -1,0 +1,435 @@
+package store
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// This file pins the boolean-default dialect contract for the additive
+// migration registry.
+//
+// Registry entries are written once and executed on both dialects. SQLite
+// stores booleans as INTEGER and accepts either spelling of a default, while
+// PostgreSQL type-checks the default expression against the column: a legacy
+// database that still needs `ADD COLUMN flag BOOLEAN DEFAULT 0` fails with
+// "column is of type boolean but default expression is of type integer"
+// (SQLSTATE 42804), which aborts AutoMigrate and stops the process from
+// starting. Fresh installs never hit it because CREATE TABLE already carries
+// the column, so the failure only surfaces when upgrading an old database —
+// exactly the path the tests below exercise.
+
+func TestNormalizeBooleanDefault(t *testing.T) {
+	cases := []struct {
+		name    string
+		colType string
+		in      string
+		want    string
+	}{
+		{"boolean numeric zero", "BOOLEAN", "DEFAULT 0", "DEFAULT FALSE"},
+		{"boolean numeric one", "BOOLEAN", "DEFAULT 1", "DEFAULT TRUE"},
+		{"lowercase column type", "boolean", "DEFAULT 0", "DEFAULT FALSE"},
+		{"padded clause", " BOOLEAN ", "  DEFAULT   0  ", "DEFAULT FALSE"},
+		{"trailing modifiers preserved", "BOOLEAN", "DEFAULT 0 NOT NULL", "DEFAULT FALSE NOT NULL"},
+		{"standard spelling untouched", "BOOLEAN", "DEFAULT FALSE", "DEFAULT FALSE"},
+		{"empty clause untouched", "BOOLEAN", "", ""},
+		{"integer column untouched", "INTEGER", "DEFAULT 0", "DEFAULT 0"},
+		{"text column untouched", "TEXT", "DEFAULT 0", "DEFAULT 0"},
+		{"quoted literal untouched", "BOOLEAN", "DEFAULT 'off'", "DEFAULT 'off'"},
+		{"missing default keyword untouched", "BOOLEAN", "NOT NULL", "NOT NULL"},
+		{"bare literal without keyword untouched", "BOOLEAN", "0", "0"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeBooleanDefault(tc.colType, tc.in); got != tc.want {
+				t.Errorf("normalizeBooleanDefault(%q, %q) = %q, want %q", tc.colType, tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildAddColumnDDL(t *testing.T) {
+	cases := []struct {
+		name    string
+		table   string
+		column  string
+		colType string
+		def     string
+		want    string
+	}{
+		{
+			name:    "with default",
+			table:   "sites",
+			column:  "use_system_proxy",
+			colType: "BOOLEAN",
+			def:     "DEFAULT FALSE",
+			want:    "ALTER TABLE sites ADD COLUMN use_system_proxy BOOLEAN DEFAULT FALSE",
+		},
+		{
+			name:    "nullable without default",
+			table:   "sites",
+			column:  "resin_enabled",
+			colType: "BOOLEAN",
+			def:     "",
+			want:    "ALTER TABLE sites ADD COLUMN resin_enabled BOOLEAN",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := buildAddColumnDDL(tc.table, tc.column, tc.colType, tc.def); got != tc.want {
+				t.Errorf("buildAddColumnDDL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBooleanColumnDDLIsDialectSafe walks the boolean shapes used by the
+// registry and asserts the statement each dialect would execute. The numeric
+// spelling must never reach a PostgreSQL BOOLEAN column.
+func TestBooleanColumnDDLIsDialectSafe(t *testing.T) {
+	cases := []struct {
+		column        string
+		sqliteType    string
+		pgType        string
+		defaultClause string
+		wantSQLite    string
+		wantPG        string
+	}{
+		{
+			column:        "use_system_proxy",
+			sqliteType:    "INTEGER",
+			pgType:        "BOOLEAN",
+			defaultClause: "DEFAULT 0",
+			wantSQLite:    "ALTER TABLE sites ADD COLUMN use_system_proxy INTEGER DEFAULT 0",
+			wantPG:        "ALTER TABLE sites ADD COLUMN use_system_proxy BOOLEAN DEFAULT FALSE",
+		},
+		{
+			column:        "post_refresh_probe_enabled",
+			sqliteType:    "INTEGER",
+			pgType:        "BOOLEAN",
+			defaultClause: "DEFAULT 0",
+			wantSQLite:    "ALTER TABLE sites ADD COLUMN post_refresh_probe_enabled INTEGER DEFAULT 0",
+			wantPG:        "ALTER TABLE sites ADD COLUMN post_refresh_probe_enabled BOOLEAN DEFAULT FALSE",
+		},
+		{
+			column:        "is_manual",
+			sqliteType:    "INTEGER",
+			pgType:        "BOOLEAN",
+			defaultClause: "DEFAULT 1",
+			wantSQLite:    "ALTER TABLE model_availability ADD COLUMN is_manual INTEGER DEFAULT 1",
+			wantPG:        "ALTER TABLE model_availability ADD COLUMN is_manual BOOLEAN DEFAULT TRUE",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.column, func(t *testing.T) {
+			table := "sites"
+			if tc.column == "is_manual" {
+				table = "model_availability"
+			}
+
+			gotSQLite := buildAddColumnDDL(table, tc.column,
+				strings.TrimSpace(tc.sqliteType),
+				normalizeBooleanDefault(strings.TrimSpace(tc.sqliteType), strings.TrimSpace(tc.defaultClause)))
+			if gotSQLite != tc.wantSQLite {
+				t.Errorf("sqlite DDL = %q, want %q", gotSQLite, tc.wantSQLite)
+			}
+
+			gotPG := buildAddColumnDDL(table, tc.column,
+				strings.TrimSpace(tc.pgType),
+				normalizeBooleanDefault(strings.TrimSpace(tc.pgType), strings.TrimSpace(tc.defaultClause)))
+			if gotPG != tc.wantPG {
+				t.Errorf("postgres DDL = %q, want %q", gotPG, tc.wantPG)
+			}
+			if strings.Contains(gotPG, "BOOLEAN DEFAULT 0") || strings.Contains(gotPG, "BOOLEAN DEFAULT 1") {
+				t.Errorf("postgres DDL carries a numeric boolean default: %q", gotPG)
+			}
+		})
+	}
+}
+
+// TestEnsureColumnBooleanNumericDefaultSQLite exercises the normalization on a
+// live SQLite database, including the "BOOLEAN" column spelling, and pins that
+// a repeated call stays a no-op.
+func TestEnsureColumnBooleanNumericDefaultSQLite(t *testing.T) {
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE boolean_probe (id INTEGER PRIMARY KEY, name TEXT NOT NULL)`); err != nil {
+		t.Fatalf("create probe table: %v", err)
+	}
+
+	if err := EnsureColumn(db, "boolean_probe", "flag", "BOOLEAN", "BOOLEAN", "DEFAULT 0"); err != nil {
+		t.Fatalf("EnsureColumn with numeric boolean default failed: %v", err)
+	}
+	if err := EnsureColumn(db, "boolean_probe", "flag", "BOOLEAN", "BOOLEAN", "DEFAULT 0"); err != nil {
+		t.Fatalf("EnsureColumn re-run failed: %v", err)
+	}
+
+	if _, err := db.Exec(`INSERT INTO boolean_probe (name) VALUES ('legacy')`); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+	var flag bool
+	if err := db.QueryRow(`SELECT flag FROM boolean_probe WHERE name = ?`, "legacy").Scan(&flag); err != nil {
+		t.Fatalf("read flag: %v", err)
+	}
+	if flag {
+		t.Errorf("flag = true, want false (DEFAULT 0 must land as false)")
+	}
+}
+
+// TestAdditiveRegistryAvoidsNumericBooleanDefaults is a source gate over the
+// registry: a BOOLEAN column must not be declared with a numeric default. The
+// runtime normalizer already makes such a call safe, but the registry is read
+// by humans reasoning about schema, so the two spellings are kept consistent.
+func TestAdditiveRegistryAvoidsNumericBooleanDefaults(t *testing.T) {
+	src, err := os.ReadFile("additive.go")
+	if err != nil {
+		t.Fatalf("read additive.go: %v", err)
+	}
+
+	callRe := regexp.MustCompile(`EnsureColumn\(\s*db\s*,\s*"([^"]+)"\s*,\s*"([^"]+)"\s*,\s*"([^"]*)"\s*,\s*"([^"]*)"\s*,\s*"([^"]*)"\s*\)`)
+	matches := callRe.FindAllStringSubmatch(string(src), -1)
+	if len(matches) < 20 {
+		t.Fatalf("source gate matched only %d EnsureColumn call sites; the regexp no longer fits the registry", len(matches))
+	}
+
+	for _, m := range matches {
+		table, column, sqliteType, pgType, defaultClause := m[1], m[2], m[3], m[4], m[5]
+		for _, dialect := range []struct {
+			name    string
+			colType string
+		}{{"sqlite", sqliteType}, {"postgres", pgType}} {
+			if !strings.EqualFold(strings.TrimSpace(dialect.colType), "BOOLEAN") {
+				continue
+			}
+			literal := strings.ToUpper(strings.TrimSpace(defaultClause))
+			if literal == "DEFAULT 0" || literal == "DEFAULT 1" {
+				t.Errorf("%s.%s: %s BOOLEAN column declared with numeric default %q; use DEFAULT FALSE/TRUE",
+					table, column, dialect.name, defaultClause)
+			}
+		}
+	}
+}
+
+// pgScratchDSN derives a dedicated database from PG_TEST_DSN so a legacy-shape
+// probe never collides with the converged schema the rest of the PG suite
+// builds in the shared integration database.
+func pgScratchDSN(t *testing.T, suffix string) string {
+	t.Helper()
+	skipIfNoPG(t)
+
+	base := pgDSN()
+	u, err := url.Parse(base)
+	if err != nil {
+		t.Fatalf("parse PG_TEST_DSN: %v", err)
+	}
+	dbName := strings.TrimPrefix(u.Path, "/") + suffix
+	if dbName == suffix || strings.ContainsAny(dbName, `"`+"`"+`'`) {
+		t.Fatalf("unsafe derived db name %q", dbName)
+	}
+
+	admin, err := Open(DialectPostgres, base, false)
+	if err != nil {
+		t.Fatalf("open admin PG connection: %v", err)
+	}
+	defer admin.Close()
+
+	var exists bool
+	if err := admin.QueryRow(
+		`SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = ?)`,
+		dbName,
+	).Scan(&exists); err != nil {
+		t.Fatalf("check pg_database for %s: %v", dbName, err)
+	}
+	if !exists {
+		if _, err := admin.Exec(fmt.Sprintf(`CREATE DATABASE "%s"`, dbName)); err != nil {
+			t.Fatalf("create scratch database %s: %v — the PG_TEST_DSN user needs CREATEDB", dbName, err)
+		}
+	}
+
+	u.Path = "/" + dbName
+	return u.String()
+}
+
+// TestPostgresEnsureColumnBooleanNumericDefaultNormalized is the live probe for
+// the safety net: a legacy-shaped PostgreSQL table plus the numeric spelling a
+// SQLite-first registry entry would carry. Before normalization this failed
+// with SQLSTATE 42804 and the process could not start.
+func TestPostgresEnsureColumnBooleanNumericDefaultNormalized(t *testing.T) {
+	skipIfNoPG(t)
+
+	db, err := Open(DialectPostgres, pgDSN(), false)
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	const table = "boolean_default_probe"
+	if _, err := db.Exec(`DROP TABLE IF EXISTS ` + table + ` CASCADE`); err != nil {
+		t.Fatalf("drop probe table: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(`DROP TABLE IF EXISTS ` + table + ` CASCADE`) })
+
+	if _, err := db.Exec(`CREATE TABLE ` + table + ` (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL)`); err != nil {
+		t.Fatalf("create probe table: %v", err)
+	}
+
+	if err := EnsureColumn(db, table, "flag", "INTEGER", "BOOLEAN", "DEFAULT 0"); err != nil {
+		t.Fatalf("EnsureColumn BOOLEAN + numeric default failed on postgres: %v", err)
+	}
+	if err := EnsureColumn(db, table, "flag", "INTEGER", "BOOLEAN", "DEFAULT 0"); err != nil {
+		t.Fatalf("EnsureColumn re-run failed on postgres: %v", err)
+	}
+
+	var colType, colDefault string
+	if err := db.QueryRow(
+		`SELECT data_type, column_default FROM information_schema.columns
+		 WHERE table_schema = current_schema() AND table_name = ? AND column_name = ?`,
+		table, "flag").Scan(&colType, &colDefault); err != nil {
+		t.Fatalf("read column metadata: %v", err)
+	}
+	if colType != "boolean" {
+		t.Errorf("column type = %q, want boolean", colType)
+	}
+	if colDefault != "false" {
+		t.Errorf("column default = %q, want false", colDefault)
+	}
+
+	if _, err := db.Exec(`INSERT INTO ` + table + ` (name) VALUES ('legacy')`); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+	var flag bool
+	if err := db.QueryRow(`SELECT flag FROM `+table+` WHERE name = ?`, "legacy").Scan(&flag); err != nil {
+		t.Fatalf("read flag: %v", err)
+	}
+	if flag {
+		t.Errorf("flag = true, want false")
+	}
+}
+
+// TestPostgresLegacyBooleanColumnsConverge replays the real registry steps that
+// declare boolean columns against a PostgreSQL database shaped like an old
+// install (tables present, additive columns absent). This is the upgrade path
+// that could not start before the numeric defaults were normalized.
+func TestPostgresLegacyBooleanColumnsConverge(t *testing.T) {
+	dsn := pgScratchDSN(t, "_legacy_boolean")
+
+	db, err := Open(DialectPostgres, dsn, false)
+	if err != nil {
+		t.Fatalf("open scratch postgres database: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	legacy := []string{
+		`DROP TABLE IF EXISTS sites CASCADE`,
+		`DROP TABLE IF EXISTS model_availability CASCADE`,
+		// Pre-additive shapes: the columns every boolean step adds are absent.
+		`CREATE TABLE sites (
+			id BIGSERIAL PRIMARY KEY,
+			name TEXT NOT NULL,
+			url TEXT NOT NULL,
+			platform TEXT NOT NULL DEFAULT '',
+			created_at TEXT NOT NULL DEFAULT '',
+			updated_at TEXT NOT NULL DEFAULT ''
+		)`,
+		`CREATE TABLE model_availability (
+			id BIGSERIAL PRIMARY KEY,
+			account_id BIGINT NOT NULL,
+			model_name TEXT NOT NULL,
+			available BOOLEAN,
+			checked_at TEXT
+		)`,
+	}
+	for _, ddl := range legacy {
+		if _, err := db.Exec(ddl); err != nil {
+			t.Fatalf("prepare legacy schema (%s): %v", firstLine(ddl), err)
+		}
+	}
+
+	if _, err := db.Exec(`INSERT INTO sites (name, url, platform) VALUES ('legacy-site', 'https://example.com', 'openai')`); err != nil {
+		t.Fatalf("insert legacy site: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO model_availability (account_id, model_name, available) VALUES (1, 'gpt-4o', true)`); err != nil {
+		t.Fatalf("insert legacy availability row: %v", err)
+	}
+
+	steps := []string{
+		"sc2_017_ts_legacy_sites_columns",
+		"sc2_018_site_post_refresh_probe",
+		"sc2_024_model_availability_is_manual",
+	}
+	for _, version := range steps {
+		step := findAdditiveStep(t, version)
+		if err := step.Apply(db); err != nil {
+			t.Fatalf("apply %s on a legacy postgres database: %v", version, err)
+		}
+		// Idempotent re-run: a crash between DDL and bookkeeping must not wedge
+		// the next startup.
+		if err := step.Apply(db); err != nil {
+			t.Fatalf("re-apply %s on a legacy postgres database: %v", version, err)
+		}
+	}
+
+	wantBoolean := []struct{ table, column string }{
+		{"sites", "use_system_proxy"},
+		{"sites", "post_refresh_probe_enabled"},
+		{"model_availability", "is_manual"},
+	}
+	for _, col := range wantBoolean {
+		var colType, colDefault string
+		if err := db.QueryRow(
+			`SELECT data_type, column_default FROM information_schema.columns
+			 WHERE table_schema = current_schema() AND table_name = ? AND column_name = ?`,
+			col.table, col.column).Scan(&colType, &colDefault); err != nil {
+			t.Fatalf("read %s.%s metadata: %v", col.table, col.column, err)
+		}
+		if colType != "boolean" {
+			t.Errorf("%s.%s type = %q, want boolean", col.table, col.column, colType)
+		}
+		if colDefault != "false" {
+			t.Errorf("%s.%s default = %q, want false", col.table, col.column, colDefault)
+		}
+	}
+
+	var useSystemProxy, probeEnabled, isManual bool
+	if err := db.QueryRow(`SELECT use_system_proxy, post_refresh_probe_enabled FROM sites WHERE name = ?`, "legacy-site").
+		Scan(&useSystemProxy, &probeEnabled); err != nil {
+		t.Fatalf("read legacy site booleans: %v", err)
+	}
+	if useSystemProxy || probeEnabled {
+		t.Errorf("legacy site booleans = %v/%v, want false/false", useSystemProxy, probeEnabled)
+	}
+	if err := db.QueryRow(`SELECT is_manual FROM model_availability WHERE model_name = ?`, "gpt-4o").Scan(&isManual); err != nil {
+		t.Fatalf("read legacy availability boolean: %v", err)
+	}
+	if isManual {
+		t.Errorf("model_availability.is_manual = true, want false")
+	}
+}
+
+func findAdditiveStep(t *testing.T, version string) AdditiveStep {
+	t.Helper()
+	for _, step := range enterpriseAdditiveSteps {
+		if step.Version == version {
+			return step
+		}
+	}
+	t.Fatalf("additive step %q not found in the registry", version)
+	return AdditiveStep{}
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
+}

--- a/store/boolean_bind_test.go
+++ b/store/boolean_bind_test.go
@@ -82,7 +82,14 @@ func TestEventsReadBooleanSafeFormsBothDialects(t *testing.T) {
 	run := func(t *testing.T, db *DB) {
 		t.Helper()
 		// CI test-pg shares one database across packages (-p 1), so assert
-		// deltas on our probe title, not absolute counts.
+		// deltas on our probe title, not absolute counts. A reused database
+		// also still holds probe rows from earlier runs — inserted, then
+		// marked read — which inflate the baseline without contributing any
+		// unread row, so the second run of the same database fails. Clear the
+		// probe slate first; the delta assertions below are unchanged.
+		if _, err := db.Exec(db.Rebind("DELETE FROM events WHERE title = ?"), "bool-bind-probe"); err != nil {
+			t.Fatalf("clear probe rows: %v", err)
+		}
 		baseline := 0
 		if err := db.Get(&baseline, db.Rebind("SELECT COUNT(*) FROM events WHERE title = ?"), "bool-bind-probe"); err != nil {
 			t.Fatalf("baseline count: %v", err)


### PR DESCRIPTION
## 改动摘要

additive 迁移注册表里有三处 BOOLEAN 列写的是数字默认值（`"INTEGER", "BOOLEAN", "DEFAULT 0"`）：`sites.use_system_proxy`、`sites.post_refresh_probe_enabled`、`model_availability.is_manual`。SQLite 把布尔存成 INTEGER，两种写法都吃；PostgreSQL 会对默认值表达式做类型检查，`ALTER TABLE ... ADD COLUMN ... BOOLEAN DEFAULT 0` 直接报 `column "..." is of type boolean but default expression is of type integer`（SQLSTATE 42804）。`AutoMigrate` 遇首个错误即中止，所以**已有 PG 库（表早于这些列）在启动阶段直接失败**；而全新安装看起来完全健康——CREATE TABLE 已带上这些列，`EnsureColumn` 走 exists 分支 no-op，坏 DDL 根本不会被发出。故障只在升级路径上出现，而升级路径恰恰是运维跳不过去的那条。

两端同时收口：

- `EnsureColumn` 内新增 `normalizeBooleanDefault`：解析后的列类型为 BOOLEAN 时把 `DEFAULT 0/1` 归一为 `DEFAULT FALSE/TRUE`，保留 `NOT NULL` 等尾随修饰符。这是所有注册表条目唯一的收口点，将来再有人按 SQLite 习惯写数字默认值也不会把 PG 升级卡死。DDL 拼装同时抽成 `buildAddColumnDDL`，可以在不起数据库的情况下断言各方言实际执行的语句。
- 注册表三处改为 `DEFAULT FALSE`，与同文件既有先例（`custom_headers_override_request_headers`）拼写一致。

## 类型

- [x] fix（bug 修复）

## 测试验证

- [x] `go build ./...` 通过
- [x] `go vet ./...` 通过
- [x] `go test ./... -count=1` 全绿（`PG_TEST_DSN` 指向本地 PG16，PG-gated 用例全部真跑，非 skip）
- [x] `go test ./store/... ./config/... -count=1 -race` 全绿（store 93.9s）
- [x] 新增 `store/additive_boolean_default_test.go`：
  - `normalizeBooleanDefault` / `buildAddColumnDDL` 表驱动单测 + 方言矩阵（断言数字写法绝不会到达 PG 的 BOOLEAN 列）
  - SQLite 活体探针（BOOLEAN 列拼写、重复调用 no-op、落库值读回 false）
  - 注册表**源码门禁**：BOOLEAN 列不得声明数字默认值（防两种拼写再次漂移）
  - 两个 PG-gated 探针（无 `PG_TEST_DSN` 时 skip，与本包既有风格一致）：一个用 legacy 形状表驱动 `EnsureColumn` 的数字写法；一个在**独立派生库**里按老库形状建 `sites` / `model_availability`，重放三条真实注册表步骤，断言列落为 `boolean DEFAULT false`、老行存活且读回 false、重跑幂等
- [x] 先红后绿证据：把归一化临时短路 + 三处还原为 `DEFAULT 0` 后，两个 PG 探针均以 `SQLSTATE 42804` 失败、源码门禁报出违规条目；恢复后全绿
- [x] 顺手修 `store/boolean_bind_test.go` 的一个**既有**缺陷（独立 commit）：该探针每轮插 2 行再标记已读却从不清理，CI 的一次性库 baseline 恒为 0 所以看不出来，但本地复用同一个 PG 库跑第二轮就会 `unread = N, want N+2` 假失败。改为取 baseline 前先删探针行，断言逻辑不变，重复跑收敛
- 未触碰前端与 API 形状

## 自查清单

- [x] 无密钥/内部路径泄漏（gitleaks 会在 CI 检查）
- [x] 行为变更已补充/更新测试
- [x] 无需 CHANGELOG（随下一版汇总）
- [x] SQLite 语义零漂移（`INTEGER DEFAULT 0` 保持原样，仅 BOOLEAN 列被归一）
