### PR TITLE
fix(sharedcount): make the compensating rollback a single atomic server operation

### DIFF
--- a/internal/sharedcount/counter.go
+++ b/internal/sharedcount/counter.go
@@ -541,59 +541,96 @@ func (r *RedisCounter) Incr(ctx context.Context, key string, window time.Duratio
 
 func (r *RedisCounter) Decr(ctx context.Context, key string, window time.Duration) (int64, error) {
 	_ = window // compensating rollback must not refresh TTL
+	return r.rollback(ctx, key, -1)
+}
+
+// rollbackScript applies a compensating decrement and drops the key when the
+// window total is no longer positive, as one atomic server-side operation.
+//
+// The rollback used to be a DECR round trip followed by a conditional DEL. The
+// server executed them separately, so an INCR that another instance landed in
+// between was deleted together with the stale key: the shared window silently
+// undercounted and the key was admitted more traffic than its configured limit.
+// A script runs as a single command, which is the only way to express
+// "decrement, then remove if the total is not positive" without a race.
+//
+// Dropping a non-positive key is still the right self-heal: a rollback that
+// lands after the window expired re-creates the key with no TTL and a negative
+// value, and INCR only arms PEXPIRE when its result is exactly 1, so such a key
+// would otherwise linger and undercount the next window. A non-positive total
+// means no instance holds a live reservation, so nothing is lost.
+const rollbackScript = `local total = redis.call('INCRBY', KEYS[1], ARGV[1])
+if total <= 0 then
+  redis.call('DEL', KEYS[1])
+  return 0
+end
+return total`
+
+// rollback runs rollbackScript for a negative delta and returns the window total
+// afterwards, or 0 when the key was dropped.
+func (r *RedisCounter) rollback(ctx context.Context, key string, delta int64) (int64, error) {
+	if delta >= 0 {
+		return 0, fmt.Errorf("sharedcount: rollback delta must be negative, got %d", delta)
+	}
+	deltaArg := strconv.FormatInt(delta, 10)
 	var count int64
 	err := r.withConn(ctx, func(conn net.Conn) error {
-		n, err := redisDoInt(conn, "DECR", key)
+		n, err := redisDoInt(conn, "EVAL", rollbackScript, "1", key, deltaArg)
 		if err != nil {
-			return err
-		}
-		count = n
-		if n <= 0 {
-			// Self-heal: a rollback that lands after the window expired
-			// re-created the key with no TTL and a non-positive value. Such a
-			// key lingers (INCR only arms PEXPIRE when its result is exactly 1,
-			// so a stale -1 needs two increments to become mortal again) and
-			// undercounts the next window. Dropping it loses nothing: a
-			// non-positive total means no instance holds a live reservation.
-			// Best-effort — the rollback itself already landed.
-			if derr := redisDo(conn, "DEL", key); derr == nil {
-				count = 0
+			if !isScriptUnsupportedError(err) {
+				return err
+			}
+			// The server has no EVAL. Apply the decrement on its own and skip
+			// the self-heal: an immortal non-positive key undercounts one
+			// window, whereas a non-atomic DEL discards live reservations.
+			n, err = redisDoInt(conn, "INCRBY", key, deltaArg)
+			if err != nil {
+				return err
 			}
 		}
+		count = n
 		return nil
 	})
 	return count, err
+}
+
+// isScriptUnsupportedError reports a server that does not implement EVAL, as
+// opposed to a script that ran and failed.
+func isScriptUnsupportedError(err error) bool {
+	var re *replyError
+	if !errors.As(err, &re) {
+		return false
+	}
+	msg := strings.ToLower(re.msg)
+	return strings.Contains(msg, "unknown command") || strings.Contains(msg, "unsupported command")
 }
 
 func (r *RedisCounter) IncrBy(ctx context.Context, key string, delta int64, window time.Duration) (int64, error) {
 	if window <= 0 {
 		window = time.Minute
 	}
-	if delta == 0 {
+	switch {
+	case delta == 0:
 		// No reservation — read current total without changing TTL.
 		return r.Get(ctx, key)
+	case delta < 0:
+		// Compensating rollback: same atomic self-heal as Decr. It never arms
+		// PEXPIRE, so a rollback cannot extend the window it is compensating.
+		return r.rollback(ctx, key, delta)
 	}
 	var count int64
 	err := r.withConn(ctx, func(conn net.Conn) error {
-		// Fixed-window approximation: INCRBY + PEXPIRE when this is the first positive write
-		// in the window (post-increment equals delta ⇒ key was absent/0).
-		// Negative delta is a compensating rollback and must not refresh TTL.
 		n, err := redisDoInt(conn, "INCRBY", key, strconv.FormatInt(delta, 10))
 		if err != nil {
 			return err
 		}
 		count = n
-		switch {
-		case delta > 0 && n == delta:
+		if n == delta {
+			// First positive write in the window (post-increment equals delta
+			// ⇒ the key was absent/0): arm the expiry.
 			ms := strconv.FormatInt(window.Milliseconds(), 10)
 			if err := redisDo(conn, "PEXPIRE", key, ms); err != nil {
 				return err
-			}
-		case delta < 0 && n <= 0:
-			// Same self-heal as Decr: never leave an immortal non-positive key
-			// behind when a compensating rollback lands after expiry.
-			if derr := redisDo(conn, "DEL", key); derr == nil {
-				count = 0
 			}
 		}
 		return nil

--- a/internal/sharedcount/redis_test.go
+++ b/internal/sharedcount/redis_test.go
@@ -20,7 +20,8 @@ import (
 // fakeRedis is a minimal in-memory RESP server for exercising RedisCounter
 // over a real TCP loopback connection (so NewRedisCounter + net.DialTimeout
 // are covered end-to-end). It supports AUTH, SELECT, INCR, DECR, INCRBY, GET
-// PEXPIRE and DEL with real TTL expiry.
+// PEXPIRE, DEL and the single EVAL script the counter uses, with real TTL
+// expiry.
 type fakeRedis struct {
 	mu       sync.Mutex
 	data     map[string]int64
@@ -41,6 +42,15 @@ type fakeRedis struct {
 
 	// delayMs is an artificial per-command latency (0 = none).
 	delayMs atomic.Int64
+
+	// hookMu guards beforeCommand and evalDisabled.
+	hookMu sync.Mutex
+	// beforeCommand, when set, runs after a command has been parsed but before it
+	// is handled — the client is still waiting for the reply, so this is the gap
+	// in which a test can land another connection's command.
+	beforeCommand func(cmd, key string)
+	// evalDisabled makes EVAL answer the way a server without scripting does.
+	evalDisabled bool
 }
 
 func newFakeRedis(tb testing.TB) *fakeRedis {
@@ -76,6 +86,50 @@ func (f *fakeRedis) close() {
 // setDelay makes every command sleep d before it is handled.
 func (f *fakeRedis) setDelay(d time.Duration) {
 	f.delayMs.Store(d.Milliseconds())
+}
+
+// setBeforeCommand installs a callback fired before a command is handled, while
+// the issuing client is still blocked on the reply. A second counter writing
+// from inside the callback therefore lands in the middle of the first one's
+// operation, which is where a non-atomic multi-command sequence can be caught.
+func (f *fakeRedis) setBeforeCommand(fn func(cmd, key string)) {
+	f.hookMu.Lock()
+	defer f.hookMu.Unlock()
+	f.beforeCommand = fn
+}
+
+// disableEval makes the double answer EVAL with the error a server without
+// scripting support returns.
+func (f *fakeRedis) disableEval() {
+	f.hookMu.Lock()
+	defer f.hookMu.Unlock()
+	f.evalDisabled = true
+}
+
+// fireBeforeCommand runs the installed callback, if any, outside the datastore
+// lock so the callback may issue commands on another connection.
+func (f *fakeRedis) fireBeforeCommand(cmd, key string) {
+	f.hookMu.Lock()
+	fn := f.beforeCommand
+	f.hookMu.Unlock()
+	if fn != nil {
+		fn(cmd, key)
+	}
+}
+
+// commandKey extracts the key a command operates on, so the interleave hook can
+// be filtered per key. EVAL carries it after the script and the numkeys count.
+func commandKey(cmd string, parts []string) string {
+	if cmd == "EVAL" {
+		if len(parts) >= 4 {
+			return parts[3]
+		}
+		return ""
+	}
+	if len(parts) >= 2 {
+		return parts[1]
+	}
+	return ""
 }
 
 // closeConns closes every live connection but keeps the listener accepting, i.e.
@@ -180,6 +234,7 @@ func (f *fakeRedis) handle(conn net.Conn) {
 				writeError(conn, "NOAUTH Authentication required")
 				return
 			}
+			f.fireBeforeCommand(cmd, commandKey(cmd, parts))
 			if !f.handleCommand(conn, cmd, parts) {
 				return
 			}
@@ -261,6 +316,49 @@ func (f *fakeRedis) handleCommand(conn net.Conn, cmd string, parts []string) boo
 		f.ttl[key] = time.Now().Add(time.Duration(ms) * time.Millisecond)
 		f.mu.Unlock()
 		writeInt(conn, 1)
+	case "EVAL":
+		// The counter sends exactly one script: the atomic rollback
+		// (INCRBY plus a conditional DEL). Redis executes a script as a single
+		// command, so the double applies the whole thing under one lock hold —
+		// that atomicity is the property under test, and it is why no other
+		// connection can observe (or lose) a write in the middle.
+		f.hookMu.Lock()
+		disabled := f.evalDisabled
+		f.hookMu.Unlock()
+		if disabled {
+			writeError(conn, "ERR unknown command 'EVAL'")
+			return true
+		}
+		if len(parts) < 5 {
+			writeError(conn, "ERR wrong number of arguments for 'eval' command")
+			return true
+		}
+		if !strings.Contains(parts[1], "INCRBY") || !strings.Contains(parts[1], "DEL") {
+			writeError(conn, "ERR test double implements only the atomic rollback script")
+			return true
+		}
+		if numKeys, err := strconv.Atoi(parts[2]); err != nil || numKeys != 1 {
+			writeError(conn, "ERR test double implements exactly one KEYS entry")
+			return true
+		}
+		key := parts[3]
+		delta, err := strconv.ParseInt(parts[4], 10, 64)
+		if err != nil {
+			writeError(conn, "ERR value is not an integer or out of range")
+			return true
+		}
+		f.mu.Lock()
+		f.expireLocked(key)
+		v := f.data[key] + delta
+		if v <= 0 {
+			delete(f.data, key)
+			delete(f.ttl, key)
+			v = 0
+		} else {
+			f.data[key] = v
+		}
+		f.mu.Unlock()
+		writeInt(conn, v)
 	case "DEL":
 		if len(parts) < 2 {
 			writeError(conn, "ERR wrong number of arguments")

--- a/internal/sharedcount/rollback_atomicity_test.go
+++ b/internal/sharedcount/rollback_atomicity_test.go
@@ -1,0 +1,169 @@
+package sharedcount
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A compensating rollback is not a private operation: while one instance rolls a
+// reservation back, other instances keep reserving against the same window key.
+// These tests pin that a rollback can never discard somebody else's reservation,
+// and that the self-heal (dropping a key whose total is no longer positive)
+// survives on servers with and without scripting support.
+
+// rollbackDuringReservation drives one rollback while a second counter — a
+// separate connection pool, i.e. a second instance — reserves the same key at
+// the moment the rollback is about to decide whether the window key is dropped:
+// the test double runs the callback after parsing that command and before
+// handling it, so the concurrent write is already on the server when the
+// rollback executes. It returns the window total observed afterwards.
+func rollbackDuringReservation(t *testing.T, rollback func(ctx context.Context, c *RedisCounter) error) (total int64, interleaved bool) {
+	t.Helper()
+
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+	other := newCounterAt(t, f.addr())
+	ctx := context.Background()
+
+	const key = "rpm:shared"
+	// One live reservation, which the rollback below compensates.
+	if _, err := c.Incr(ctx, key, time.Minute); err != nil {
+		t.Fatalf("seed Incr: %v", err)
+	}
+
+	var fired, reserved atomic.Int64
+	f.setBeforeCommand(func(cmd, gotKey string) {
+		// The interesting command is the one that may drop the key: the atomic
+		// rollback script, or — for a two-command rollback — its separate DEL.
+		if gotKey != key || (cmd != "EVAL" && cmd != "DEL") || fired.Swap(1) == 1 {
+			return
+		}
+		// Another instance reserves the same window at that exact moment. A
+		// rollback that already decremented and now deletes in a second round
+		// trip removes this reservation together with the stale key; a single
+		// atomic command counts it instead of discarding it.
+		if _, err := other.Incr(ctx, key, time.Minute); err != nil {
+			t.Errorf("concurrent Incr: %v", err)
+			return
+		}
+		reserved.Store(1)
+	})
+
+	if err := rollback(ctx, c); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if fired.Load() == 0 {
+		t.Fatal("the rollback never reached the test double, so nothing was interleaved")
+	}
+	if reserved.Load() == 0 {
+		t.Fatal("the concurrent reservation did not complete before the rollback answered")
+	}
+
+	total, err := c.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get after rollback: %v", err)
+	}
+	return total, true
+}
+
+func TestRedisCounter_DecrDoesNotDiscardConcurrentReservation(t *testing.T) {
+	t.Parallel()
+	total, _ := rollbackDuringReservation(t, func(ctx context.Context, c *RedisCounter) error {
+		_, err := c.Decr(ctx, "rpm:shared", time.Minute)
+		return err
+	})
+	if total != 1 {
+		t.Fatalf("window total = %d, want 1: the reservation made during the rollback was discarded", total)
+	}
+}
+
+func TestRedisCounter_NegativeIncrByDoesNotDiscardConcurrentReservation(t *testing.T) {
+	t.Parallel()
+	total, _ := rollbackDuringReservation(t, func(ctx context.Context, c *RedisCounter) error {
+		_, err := c.IncrBy(ctx, "rpm:shared", -1, time.Minute)
+		return err
+	})
+	if total != 1 {
+		t.Fatalf("window total = %d, want 1: the reservation made during the rollback was discarded", total)
+	}
+}
+
+// TestRedisCounter_RollbackIsASingleServerOperation pins the mechanism, not just
+// the outcome: the decrement and the conditional delete must reach the server as
+// one command, otherwise the guarantees above depend on timing again.
+func TestRedisCounter_RollbackIsASingleServerOperation(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+	ctx := context.Background()
+
+	var commands atomic.Int64
+	f.setBeforeCommand(func(cmd, key string) {
+		if key == "rpm:single" {
+			commands.Add(1)
+		}
+	})
+
+	if _, err := c.Decr(ctx, "rpm:single", time.Minute); err != nil {
+		t.Fatalf("Decr on missing key: %v", err)
+	}
+	if got := commands.Load(); got != 1 {
+		t.Fatalf("rollback issued %d server commands, want 1 (a multi-command rollback reopens the race)", got)
+	}
+}
+
+// TestRedisCounter_RollbackWithoutScriptSupport covers a server that answers
+// EVAL the way a build without scripting does. The decrement must still be
+// applied and must not surface as an error; the self-heal is skipped rather than
+// deleting a key non-atomically.
+func TestRedisCounter_RollbackWithoutScriptSupport(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	f.disableEval()
+	c := newCounterAt(t, f.addr())
+	ctx := context.Background()
+
+	if _, err := c.Incr(ctx, "rpm:live", time.Minute); err != nil {
+		t.Fatalf("Incr 1: %v", err)
+	}
+	if _, err := c.Incr(ctx, "rpm:live", time.Minute); err != nil {
+		t.Fatalf("Incr 2: %v", err)
+	}
+
+	n, err := c.Decr(ctx, "rpm:live", time.Minute)
+	if err != nil {
+		t.Fatalf("Decr without EVAL support: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("Decr = %d, want 1", n)
+	}
+	if got, err := c.Get(ctx, "rpm:live"); err != nil || got != 1 {
+		t.Fatalf("Get = %d, %v, want 1", got, err)
+	}
+
+	// The TPM path takes the same branch.
+	if _, err := c.IncrBy(ctx, "tpm:live", 500, time.Minute); err != nil {
+		t.Fatalf("IncrBy(+500): %v", err)
+	}
+	if n, err := c.IncrBy(ctx, "tpm:live", -200, time.Minute); err != nil || n != 300 {
+		t.Fatalf("IncrBy(-200) = %d, %v, want 300", n, err)
+	}
+}
+
+// TestRedisCounter_RollbackRejectsPositiveDelta guards the internal contract: a
+// positive delta must go through Incr/IncrBy so the window TTL is armed.
+func TestRedisCounter_RollbackRejectsPositiveDelta(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	c := newCounterAt(t, f.addr())
+
+	if _, err := c.rollback(context.Background(), "rpm:bad", 1); err == nil {
+		t.Fatal("rollback with a positive delta = nil error, want a contract error")
+	}
+}


### PR DESCRIPTION
## 改动摘要

Redis 侧补偿回滚（admission 预占的 rollback）过去是**两个往返**：先 `DECR`，若返回值非正再 `DEL`（自愈：回滚落在窗口过期之后会把键以「无 TTL + 负值」重新造出来，`INCR` 只在结果恰为 1 时才 arm PEXPIRE，这种键会赖着不走并少算下一个窗口）。服务器把它们当两条独立命令执行，所以**另一个实例在这两条命令之间落地的 `INCR` 会连同旧键一起被删掉**：共享窗口在剩余生命周期里静默少算，该密钥被放行的流量超过配置的 RPM/TPM 上限——而且恰好发生在共享计数器存在的意义所在（多实例并发准入）的场景里。调用方是密钥准入的预占回滚，请求数与预估 token 两个计数器都走这条路。

- 两条命令合并进一个 `EVAL` 脚本：Redis 把脚本当**单条命令**执行，条件删除再也无法观察到（或丢弃）并发写入。`Decr` 与 `IncrBy` 的负 delta 分支共用这条路径，且都不 arm 过期，所以回滚依然不会延长它正在补偿的窗口。返回值语义不变（减后总量，键被丢弃时为 0）。
- 不支持脚本的服务器有明确降级：单独执行 `INCRBY` 完成减量、**跳过自愈**。理由：留下一个不死的非正键只少算一个窗口，而非原子的 `DEL` 会丢弃活着的预占。

## 类型

- [x] fix（bug 修复）

## 测试验证

- [x] `go build ./...` / `go vet ./...` 通过
- [x] `go test ./internal/sharedcount/ -count=20 -race` 全绿（83.7s）
- [x] 新增 `internal/sharedcount/rollback_atomicity_test.go`：
  - **两条确定性交织测试**（`Decr` 与负 `IncrBy`）：用第二个计数器（独立连接池 = 第二个实例）在测试替身「已解析该命令、尚未执行」的时刻写入同一个 key，断言这次预占必须存活
  - **机制测试**：回滚必须以**恰好一条**服务器命令完成，防止将来重构悄悄把竞态放回来
  - 无脚本支持的降级测试（减量仍生效、错误不外泄）+ 非负 delta 的契约测试
- [x] 先红后绿证据：把回滚临时改回「`INCRBY` + 独立 `DEL`」后，两条交织测试报 `window total = 0, want 1: the reservation made during the rollback was discarded`，机制测试报 `rollback issued 2 server commands, want 1`；恢复后全绿。既有三条自愈测试在**改动前后都通过**，说明它们没有覆盖这条竞态
- [x] 这个 bug 由 CI 的 `test-pg` 分片偶然暴露（`TestRedisCounter_PoolIsConcurrencySafe` 报 `mixed total = 478, want 480`）。该压力测试保留不动，现在稳定通过
- 测试替身实现计数器唯一使用的那个脚本，并在**一次持锁**内完成，以还原 Redis 的原子性；对任何其它脚本一律报错，这样脚本一旦变更就必须同步更新替身
- 未触碰 API 形状与前端

## 自查清单

- [x] 无密钥/内部路径泄漏（gitleaks 会在 CI 检查）
- [x] 行为变更已补充/更新测试
- [x] 无需 CHANGELOG（随下一版汇总）
- [x] `MemoryCounter`（无 Redis 部署）路径未改动，单实例语义零漂移
