### PR TITLE
fix(web): repair accounts cache targeting and missing indirect i18n keys

### DIFF
--- a/web/src/features/accounts/__tests__/accounts-toggle-optimistic.test.tsx
+++ b/web/src/features/accounts/__tests__/accounts-toggle-optimistic.test.tsx
@@ -1,9 +1,14 @@
 // Behavior tests for the accounts row-toggle optimistic updates (issue #889
 // perf section). Pin / check-in / status toggles previously waited for the
-// server round-trip before the row flipped; they now follow the sites
-// feature pattern: onMutate patches the snapshot cache (instant flip),
-// onError rolls the cache back to the pre-mutation snapshot, and onSettled
-// invalidates so the server truth wins.
+// server round-trip before the row flipped; they now patch the cache in
+// onMutate (instant flip), roll every patched key back in onError, and
+// invalidate in onSettled so the server truth wins.
+//
+// The cache under test is the one the /accounts table ACTUALLY reads:
+// `accountQueryKeys.page(…)`. `page` and `snapshot` are sibling keys, so a
+// snapshot-only patch never reached the table (the row only moved after the
+// settle refetch) — and a snapshot-only test stayed green while it did. Both
+// caches are seeded and asserted here, with the paged one first.
 //
 // The real api.updateAccount is stubbed (network boundary); a controllable
 // deferred promise lets each case assert the cache state BEFORE the server
@@ -23,6 +28,7 @@ import {
   useToggleAccountCheckin,
   useToggleAccountPin,
   useToggleAccountStatus,
+  type AccountsPageData,
 } from '../api'
 import { accountSchema, type AccountsSnapshot } from '../types'
 
@@ -37,6 +43,46 @@ vi.mock('@/lib/toast', () => ({
 }))
 
 const mockUpdateAccount = vi.mocked(api.updateAccount)
+
+/**
+ * Two cached pages of the same fleet (different pagination + filters): the
+ * optimistic patch must reach EVERY page under the `['accounts','page']`
+ * prefix, because any of them can be the mounted table.
+ */
+const PAGE_KEYS = [
+  accountQueryKeys.page(0, 20, '', '', ''),
+  accountQueryKeys.page(1, 50, 'second', 'active', '1'),
+] as const
+
+type ToggleField = 'isPinned' | 'checkinEnabled' | 'status'
+
+const ACCOUNT_ROWS: Array<Record<string, unknown>> = [
+  {
+    id: 1,
+    siteId: 1,
+    username: 'first',
+    isPinned: false,
+    checkinEnabled: false,
+    status: 'active',
+  },
+  {
+    id: 2,
+    siteId: 1,
+    username: 'second',
+    isPinned: true,
+    checkinEnabled: true,
+    status: 'active',
+  },
+]
+
+function buildPage(): AccountsPageData {
+  return {
+    items: ACCOUNT_ROWS.map((row) => ({ ...row })),
+    total: ACCOUNT_ROWS.length,
+    sites: [],
+    generatedAt: '2026-08-20T00:00:00Z',
+  }
+}
 
 function buildSnapshot(): AccountsSnapshot {
   return {
@@ -63,14 +109,32 @@ function createQueryClient() {
       mutations: { retry: false },
     },
   })
+  for (const pageKey of PAGE_KEYS) {
+    queryClient.setQueryData(pageKey, buildPage())
+  }
   queryClient.setQueryData(accountQueryKeys.snapshot(), buildSnapshot())
   return queryClient
 }
 
-function accountField(
+/** Field value in a cached server page — the /accounts table's read path. */
+function pageField(
+  queryClient: QueryClient,
+  pageKey: readonly unknown[],
+  accountId: number,
+  field: ToggleField
+): unknown {
+  const page = queryClient.getQueryData<AccountsPageData>(pageKey)
+  const row = page?.items.find(
+    (item) => Number((item as { id?: unknown }).id) === accountId
+  ) as Record<string, unknown> | undefined
+  return row?.[field]
+}
+
+/** Field value in the snapshot cache (its own consumers on other pages). */
+function snapshotField(
   queryClient: QueryClient,
   accountId: number,
-  field: 'isPinned' | 'checkinEnabled' | 'status'
+  field: ToggleField
 ): unknown {
   const snapshot = queryClient.getQueryData<AccountsSnapshot>(
     accountQueryKeys.snapshot()
@@ -107,7 +171,7 @@ describe('accounts toggle mutations — optimistic updates', () => {
     vi.restoreAllMocks()
   })
 
-  it('flips isPinned in the cache before the server answers', async () => {
+  it('flips isPinned in every cached accounts page before the server answers', async () => {
     const deferred = createDeferred()
     mockUpdateAccount.mockReturnValue(deferred.promise)
 
@@ -117,12 +181,19 @@ describe('accounts toggle mutations — optimistic updates', () => {
       result.current.mutate({ id: 1, isPinned: true })
     })
 
-    // Optimistic: the cache flips while the request is still in flight.
+    // Optimistic: the paged cache the table renders flips while the request is
+    // still in flight — and it flips on EVERY cached page, not just one.
     await waitFor(() => {
-      expect(accountField(queryClient, 1, 'isPinned')).toBe(true)
+      for (const pageKey of PAGE_KEYS) {
+        expect(pageField(queryClient, pageKey, 1, 'isPinned')).toBe(true)
+      }
     })
     // Sibling rows stay untouched.
-    expect(accountField(queryClient, 2, 'isPinned')).toBe(true)
+    for (const pageKey of PAGE_KEYS) {
+      expect(pageField(queryClient, pageKey, 2, 'isPinned')).toBe(true)
+    }
+    // The snapshot (other pages' consumer) stays coherent with the table.
+    expect(snapshotField(queryClient, 1, 'isPinned')).toBe(true)
 
     await act(async () => {
       deferred.resolve({ success: true })
@@ -130,10 +201,12 @@ describe('accounts toggle mutations — optimistic updates', () => {
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true)
     })
-    expect(accountField(queryClient, 1, 'isPinned')).toBe(true)
+    for (const pageKey of PAGE_KEYS) {
+      expect(pageField(queryClient, pageKey, 1, 'isPinned')).toBe(true)
+    }
   })
 
-  it('rolls the pin flip back when the request fails', async () => {
+  it('rolls the pin flip back in the paged caches when the request fails', async () => {
     const deferred = createDeferred()
     mockUpdateAccount.mockReturnValue(deferred.promise)
 
@@ -144,7 +217,7 @@ describe('accounts toggle mutations — optimistic updates', () => {
     })
 
     await waitFor(() => {
-      expect(accountField(queryClient, 1, 'isPinned')).toBe(true)
+      expect(pageField(queryClient, PAGE_KEYS[0], 1, 'isPinned')).toBe(true)
     })
 
     await act(async () => {
@@ -153,9 +226,12 @@ describe('accounts toggle mutations — optimistic updates', () => {
     await waitFor(() => {
       expect(result.current.isError).toBe(true)
     })
-    // Rolled back to the pre-mutation snapshot.
-    expect(accountField(queryClient, 1, 'isPinned')).toBe(false)
-    expect(accountField(queryClient, 2, 'isPinned')).toBe(true)
+    // Rolled back to the pre-mutation payload on every patched page.
+    for (const pageKey of PAGE_KEYS) {
+      expect(pageField(queryClient, pageKey, 1, 'isPinned')).toBe(false)
+      expect(pageField(queryClient, pageKey, 2, 'isPinned')).toBe(true)
+    }
+    expect(snapshotField(queryClient, 1, 'isPinned')).toBe(false)
   })
 
   it('flips checkinEnabled optimistically and rolls back on failure', async () => {
@@ -172,7 +248,9 @@ describe('accounts toggle mutations — optimistic updates', () => {
     })
 
     await waitFor(() => {
-      expect(accountField(queryClient, 1, 'checkinEnabled')).toBe(true)
+      for (const pageKey of PAGE_KEYS) {
+        expect(pageField(queryClient, pageKey, 1, 'checkinEnabled')).toBe(true)
+      }
     })
 
     await act(async () => {
@@ -181,9 +259,12 @@ describe('accounts toggle mutations — optimistic updates', () => {
     await waitFor(() => {
       expect(result.current.isError).toBe(true)
     })
-    expect(accountField(queryClient, 1, 'checkinEnabled')).toBe(false)
-    // Unrelated rows keep their value through the rollback.
-    expect(accountField(queryClient, 2, 'checkinEnabled')).toBe(true)
+    for (const pageKey of PAGE_KEYS) {
+      expect(pageField(queryClient, pageKey, 1, 'checkinEnabled')).toBe(false)
+      // Unrelated rows keep their value through the rollback.
+      expect(pageField(queryClient, pageKey, 2, 'checkinEnabled')).toBe(true)
+    }
+    expect(snapshotField(queryClient, 1, 'checkinEnabled')).toBe(false)
   })
 
   it('flips the account status optimistically and keeps it on success', async () => {
@@ -197,7 +278,9 @@ describe('accounts toggle mutations — optimistic updates', () => {
     })
 
     await waitFor(() => {
-      expect(accountField(queryClient, 2, 'status')).toBe('disabled')
+      for (const pageKey of PAGE_KEYS) {
+        expect(pageField(queryClient, pageKey, 2, 'status')).toBe('disabled')
+      }
     })
 
     await act(async () => {
@@ -206,7 +289,40 @@ describe('accounts toggle mutations — optimistic updates', () => {
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true)
     })
-    expect(accountField(queryClient, 2, 'status')).toBe('disabled')
-    expect(accountField(queryClient, 1, 'status')).toBe('active')
+    for (const pageKey of PAGE_KEYS) {
+      expect(pageField(queryClient, pageKey, 2, 'status')).toBe('disabled')
+      expect(pageField(queryClient, pageKey, 1, 'status')).toBe('active')
+    }
+    expect(snapshotField(queryClient, 2, 'status')).toBe('disabled')
+  })
+
+  it('leaves an untouched page cache alone (no row is invented)', async () => {
+    const deferred = createDeferred()
+    mockUpdateAccount.mockReturnValue(deferred.promise)
+
+    // A page that does not contain the toggled account must keep its payload
+    // byte-for-byte (identity), so unrelated tables do not re-render.
+    const otherPageKey = accountQueryKeys.page(3, 20, '', 'disabled', '')
+    const otherPage: AccountsPageData = {
+      items: [{ id: 99, siteId: 2, username: 'other' }],
+      total: 1,
+      sites: [],
+      generatedAt: '2026-08-20T00:00:00Z',
+    }
+    queryClient.setQueryData(otherPageKey, otherPage)
+
+    const { result } = renderHook(() => useToggleAccountStatus(), { wrapper })
+
+    act(() => {
+      result.current.mutate({ id: 2, status: 'disabled' })
+    })
+
+    await waitFor(() => {
+      expect(pageField(queryClient, PAGE_KEYS[0], 2, 'status')).toBe('disabled')
+    })
+    expect(queryClient.getQueryData(otherPageKey)).toBe(otherPage)
+    expect(
+      (queryClient.getQueryData<AccountsPageData>(otherPageKey)?.items ?? [])[0]
+    ).toEqual({ id: 99, siteId: 2, username: 'other' })
   })
 })

--- a/web/src/features/accounts/api.ts
+++ b/web/src/features/accounts/api.ts
@@ -1,7 +1,13 @@
 // metapi-go features/accounts/api — TanStack Query hooks for the accounts
 // domain. Establishes the query-key conventions for the rewrite:
-//   ['accounts']               — snapshot list (GET /api/accounts)
+//   ['accounts']                — factory root; the invalidation prefix
+//   ['accounts','snapshot']     — snapshot list (GET /api/accounts)
+//   ['accounts','page',{…}]     — one server-paged table page: what the
+//                                 /accounts table actually renders
+//   ['accounts','detail',id]    — a single account
 //   ['account-tokens', id]      — tokens for an account (see tokens/api.ts)
+// `page` and `snapshot` are siblings, so cache writes that must reach the
+// table go through `accountQueryKeys.pages()` (or `.all`), never `.snapshot()`.
 //
 // Mutations wrap the flat `api` object from @/lib/api. The shared axios layer
 // in @/lib/http-client already toasts business errors ({success:false}) and
@@ -39,6 +45,15 @@ import type {
 export const accountQueryKeys = {
   all: ['accounts'] as const,
   snapshot: () => [...accountQueryKeys.all, 'snapshot'] as const,
+  /**
+   * Prefix of every server-paged table cache produced by `page(…)`.
+   *
+   * `page` and `snapshot` are SIBLINGS under `all`, so neither is a prefix of
+   * the other: anything that has to reach the /accounts table (invalidation,
+   * optimistic patching) targets `all` or `pages()` — never `snapshot()`
+   * alone, which the table does not read.
+   */
+  pages: () => [...accountQueryKeys.all, 'page'] as const,
   page: (
     pageIndex: number,
     pageSize: number,
@@ -397,15 +412,67 @@ export function useBatchUpdateAccounts() {
 // ---------------------------------------------------------------------------
 // Field-level toggle mutations
 //
-// All three toggles run the sites-feature optimistic pattern: onMutate
-// patches the snapshot row in place (instant flip), onError rolls the cache
-// back to the pre-mutation snapshot, and onSettled invalidates so the server
-// truth wins either way. The row stays interactive — the optimistic flip IS
-// the feedback; the accounts page keeps its mutation-derived per-row pending
-// spinner for the status toggle.
+// All three toggles run the oauth-connections optimistic pattern: onMutate
+// snapshots every cache it is about to touch, patches the row in all of them
+// (instant flip), onError restores each patched key from that snapshot, and
+// onSettled invalidates so the server truth wins either way. The row stays
+// interactive — the optimistic flip IS the feedback; the accounts page keeps
+// its mutation-derived per-row pending spinner for the status toggle.
+//
+// The /accounts table reads `accountQueryKeys.page(…)`, so the PAGED caches are
+// the ones that must flip; the snapshot is patched as well because it has its
+// own mounted consumers (sites / check-in / routes / downstream-keys pages)
+// rendering the same three fields.
 // ---------------------------------------------------------------------------
 
-type AccountToggleContext = { previous: AccountsSnapshot | undefined }
+type AccountToggleContext = {
+  previousPages: Array<[readonly unknown[], AccountsPageData | undefined]>
+  previousSnapshot: AccountsSnapshot | undefined
+}
+
+function isAccountRow(row: unknown, accountId: number): boolean {
+  return (
+    typeof row === 'object' &&
+    row !== null &&
+    Number((row as { id?: unknown }).id) === accountId
+  )
+}
+
+/**
+ * Flip one account row inside every cached page payload. Page rows are the raw
+ * server objects the table parses per render (`parseAccountRow`), so the patch
+ * builds a NEW row object — the WeakMap parse cache keys off object identity
+ * and re-parses the patched copy instead of returning the stale parse.
+ */
+function patchAccountInPages(
+  queryClient: QueryClient,
+  accountId: number,
+  patch: Partial<Account>
+) {
+  queryClient.setQueriesData<AccountsPageData>(
+    { queryKey: accountQueryKeys.pages() },
+    (current) => {
+      if (!current) return current
+      const patchRows = (rows: object[]): object[] =>
+        rows.map((row) =>
+          isAccountRow(row, accountId)
+            ? { ...(row as Record<string, unknown>), ...patch }
+            : row
+        )
+      return {
+        ...current,
+        // Legacy snapshot-shaped fixtures carry `accounts` instead of `items`
+        // (the page reads `items ?? accounts`), so patch whichever exists.
+        ...(Array.isArray(current.items)
+          ? { items: patchRows(current.items) }
+          : {}),
+        ...(Array.isArray(current.accounts)
+          ? { accounts: patchRows(current.accounts) }
+          : {}),
+      }
+    }
+  )
+}
 
 function patchAccountInSnapshot(
   queryClient: QueryClient,
@@ -426,12 +493,41 @@ function patchAccountInSnapshot(
   )
 }
 
-function rollbackSnapshot(
+/**
+ * Cancel in-flight fetches for both caches, remember their current payloads
+ * (per page key — there is one cache per filter/pagination combination) and
+ * apply the optimistic patch. Returns the rollback context.
+ */
+async function beginAccountToggle(
+  queryClient: QueryClient,
+  accountId: number,
+  patch: Partial<Account>
+): Promise<AccountToggleContext> {
+  await queryClient.cancelQueries({ queryKey: accountQueryKeys.pages() })
+  await queryClient.cancelQueries({ queryKey: accountQueryKeys.snapshot() })
+  const previousPages = queryClient.getQueriesData<AccountsPageData>({
+    queryKey: accountQueryKeys.pages(),
+  })
+  const previousSnapshot = queryClient.getQueryData<AccountsSnapshot>(
+    accountQueryKeys.snapshot()
+  )
+  patchAccountInPages(queryClient, accountId, patch)
+  patchAccountInSnapshot(queryClient, accountId, patch)
+  return { previousPages, previousSnapshot }
+}
+
+function rollbackAccountToggle(
   queryClient: QueryClient,
   context: AccountToggleContext | undefined
 ) {
-  if (context?.previous) {
-    queryClient.setQueryData(accountQueryKeys.snapshot(), context.previous)
+  for (const [queryKey, previous] of context?.previousPages ?? []) {
+    queryClient.setQueryData(queryKey, previous)
+  }
+  if (context?.previousSnapshot) {
+    queryClient.setQueryData(
+      accountQueryKeys.snapshot(),
+      context.previousSnapshot
+    )
   }
 }
 
@@ -442,16 +538,10 @@ export function useToggleAccountPin() {
       const result = await api.updateAccount(id, { isPinned })
       return assertBusinessOk(result, 'accounts.toast.pinFailed')
     },
-    onMutate: async ({ id, isPinned }) => {
-      await queryClient.cancelQueries({ queryKey: accountQueryKeys.snapshot() })
-      const previous = queryClient.getQueryData<AccountsSnapshot>(
-        accountQueryKeys.snapshot()
-      )
-      patchAccountInSnapshot(queryClient, id, { isPinned })
-      return { previous }
-    },
+    onMutate: ({ id, isPinned }) =>
+      beginAccountToggle(queryClient, id, { isPinned }),
     onError: (_error, _variables, context) => {
-      rollbackSnapshot(queryClient, context)
+      rollbackAccountToggle(queryClient, context)
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: accountQueryKeys.all })
@@ -472,16 +562,10 @@ export function useToggleAccountStatus() {
       const result = await api.updateAccount(id, { status })
       return assertBusinessOk(result, 'accounts.toast.statusFailed')
     },
-    onMutate: async ({ id, status }) => {
-      await queryClient.cancelQueries({ queryKey: accountQueryKeys.snapshot() })
-      const previous = queryClient.getQueryData<AccountsSnapshot>(
-        accountQueryKeys.snapshot()
-      )
-      patchAccountInSnapshot(queryClient, id, { status })
-      return { previous }
-    },
+    onMutate: ({ id, status }) =>
+      beginAccountToggle(queryClient, id, { status }),
     onError: (_error, _variables, context) => {
-      rollbackSnapshot(queryClient, context)
+      rollbackAccountToggle(queryClient, context)
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: accountQueryKeys.all })
@@ -502,16 +586,10 @@ export function useToggleAccountCheckin() {
       const result = await api.updateAccount(id, { checkinEnabled })
       return assertBusinessOk(result, 'accounts.toast.checkinFailed')
     },
-    onMutate: async ({ id, checkinEnabled }) => {
-      await queryClient.cancelQueries({ queryKey: accountQueryKeys.snapshot() })
-      const previous = queryClient.getQueryData<AccountsSnapshot>(
-        accountQueryKeys.snapshot()
-      )
-      patchAccountInSnapshot(queryClient, id, { checkinEnabled })
-      return { previous }
-    },
+    onMutate: ({ id, checkinEnabled }) =>
+      beginAccountToggle(queryClient, id, { checkinEnabled }),
     onError: (_error, _variables, context) => {
-      rollbackSnapshot(queryClient, context)
+      rollbackAccountToggle(queryClient, context)
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: accountQueryKeys.all })

--- a/web/src/features/accounts/models/__tests__/models-failure-copy.test.ts
+++ b/web/src/features/accounts/models/__tests__/models-failure-copy.test.ts
@@ -1,0 +1,75 @@
+// Failure-copy contract for the account Models panel mutations.
+//
+// `assertBusinessOk` throws `i18n.t(fallbackKey)` when the backend answers
+// `success:false` WITHOUT a message, and the panel injects that message into
+// `accounts.models.refreshFailedInline` / `manualFailedInline`. Both fallback
+// keys shipped missing from the locales, so the failure path rendered the raw
+// key ("Refresh failed: accounts.models.refreshFailed") — invisible to a
+// `t('literal')` scan because the key never sits inside a `t(` call.
+//
+// These cases pin the whole chain (guard → thrown message → inline copy) in
+// BOTH languages, reading the bundles directly so the en fallback cannot mask
+// a missing zh-CN entry.
+
+import { describe, expect, it } from 'vitest'
+
+import i18n from '@/i18n/config'
+import { assertBusinessOk } from '@/lib/assert-business-ok'
+
+const CASES = [
+  {
+    fallbackKey: 'accounts.models.refreshFailed',
+    inlineKey: 'accounts.models.refreshFailedInline',
+  },
+  {
+    fallbackKey: 'accounts.models.manualFailed',
+    inlineKey: 'accounts.models.manualFailedInline',
+  },
+] as const
+
+/** Run the guard against a message-less failure envelope; return its throw. */
+function thrownMessage(fallbackKey: string): string {
+  try {
+    assertBusinessOk({ success: false }, fallbackKey)
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error)
+  }
+  throw new Error(
+    `assertBusinessOk accepted a failure envelope (fallback ${fallbackKey})`
+  )
+}
+
+describe('account models failure copy', () => {
+  it('renders translated inline copy when the backend omits the reason', async () => {
+    // Locale bundles are lazy-loaded per language — load both before reading.
+    await i18n.changeLanguage('zhCN')
+
+    for (const language of ['en', 'zhCN']) {
+      await i18n.changeLanguage(language)
+      for (const { fallbackKey, inlineKey } of CASES) {
+        expect(
+          i18n.getResource(language, 'translation', fallbackKey),
+          `${language} missing ${fallbackKey}`
+        ).toBeTruthy()
+
+        const message = thrownMessage(fallbackKey)
+        // The guard must translate, never echo the key it was handed.
+        expect(message, `${language}: ${fallbackKey}`).not.toBe(fallbackKey)
+        expect(message, `${language}: untranslated fallback`).not.toContain(
+          'accounts.models.'
+        )
+
+        const inline = i18n.t(inlineKey, { message })
+        expect(inline, `${language}: ${inlineKey}`).toContain(message)
+        expect(inline, `${language}: unresolved placeholder`).not.toContain(
+          '{{message}}'
+        )
+        expect(inline, `${language}: raw key in panel copy`).not.toContain(
+          'accounts.models.'
+        )
+      }
+    }
+
+    await i18n.changeLanguage('en')
+  })
+})

--- a/web/src/features/import/__tests__/import-cache-invalidation.test.tsx
+++ b/web/src/features/import/__tests__/import-cache-invalidation.test.tsx
@@ -1,0 +1,185 @@
+// Cache-contract tests for the import commit mutation.
+//
+// The wizard can be opened from /sites AND from /accounts, and both hosts keep
+// their table mounted while it runs. The accounts table reads the server-paged
+// key (`accountQueryKeys.page(…)`) — the snapshot key has no observer there —
+// so invalidating only `accountQueryKeys.snapshot()` left the mounted reader
+// untouched: an import "succeeded" and the table did not change until the user
+// edited a filter or navigated away and back (no refetchOnWindowFocus, no
+// polling, and staleTime expiry alone never triggers a fetch).
+//
+// These tests pin the contract at the cache layer: after the mutation settles,
+// every cached variant of both resources is invalidated, and a mounted paged
+// reader actually refetches so imported rows appear.
+
+import '@testing-library/jest-dom/vitest'
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { accountQueryKeys, fetchAccountsPage } from '@/features/accounts'
+import { sitesKeys } from '@/features/sites'
+import { api } from '@/lib/api'
+
+import { useImportSites } from '../api'
+import type { ImportSitesPayload } from '../types'
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    importSites: vi.fn(),
+    getAccountsPage: vi.fn(),
+  },
+}))
+
+const mockImportSites = vi.mocked(api.importSites)
+const mockGetAccountsPage = vi.mocked(api.getAccountsPage)
+
+/** Table state the /accounts route owns: first page, no filters. */
+const PAGE_PARAMS = {
+  pageIndex: 0,
+  pageSize: 20,
+  q: '',
+  status: '',
+  site: '',
+}
+const PAGE_KEY = accountQueryKeys.page(
+  PAGE_PARAMS.pageIndex,
+  PAGE_PARAMS.pageSize,
+  PAGE_PARAMS.q,
+  PAGE_PARAMS.status,
+  PAGE_PARAMS.site
+)
+
+const IMPORT_PAYLOAD: ImportSitesPayload = {
+  items: [{ name: 'Imported', url: 'https://imported.example.com' }],
+  duplicateStrategy: 'skip',
+}
+
+const IMPORT_RESULT = {
+  imported: 1,
+  skipped: 0,
+  failed: 0,
+  results: [{ name: 'Imported', status: 'imported' as const, siteId: 2 }],
+}
+
+function pageResponse(usernames: string[]) {
+  return {
+    items: usernames.map((username, index) => ({
+      id: index + 1,
+      siteId: 1,
+      username,
+    })),
+    total: usernames.length,
+    sites: [],
+    generatedAt: '2026-09-02T00:00:00Z',
+  }
+}
+
+describe('useImportSites — cache invalidation', () => {
+  let queryClient: QueryClient
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockImportSites.mockResolvedValue(IMPORT_RESULT)
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: 0, refetchOnWindowFocus: false },
+        mutations: { retry: false },
+      },
+    })
+  })
+
+  it('invalidates the paged accounts key the table reads, plus sites', async () => {
+    // Seed every cached variant of the two resources the import touches:
+    // the server-paged table page (the /accounts read path), the snapshot
+    // (its own consumers on other pages) and the sites list.
+    queryClient.setQueryData(PAGE_KEY, pageResponse(['existing']))
+    queryClient.setQueryData(accountQueryKeys.snapshot(), {
+      generatedAt: '2026-09-02T00:00:00Z',
+      accounts: [{ id: 1, siteId: 1, username: 'existing' }],
+      sites: [],
+    })
+    queryClient.setQueryData(sitesKeys.list(), [{ id: 1, name: 'Existing' }])
+    queryClient.setQueryData(sitesKeys.detail(1), { id: 1, name: 'Existing' })
+
+    const { result } = renderHook(() => useImportSites(), { wrapper })
+    await act(async () => {
+      result.current.mutate(IMPORT_PAYLOAD)
+    })
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    // The regression: this key stayed untouched while only `snapshot()` was
+    // invalidated, so the mounted table never learned about the import.
+    expect(
+      queryClient.getQueryState(PAGE_KEY)?.isInvalidated,
+      'paged accounts cache must be invalidated'
+    ).toBe(true)
+    expect(
+      queryClient.getQueryState(accountQueryKeys.snapshot())?.isInvalidated,
+      'accounts snapshot must stay invalidated for its own consumers'
+    ).toBe(true)
+    expect(queryClient.getQueryState(sitesKeys.list())?.isInvalidated).toBe(
+      true
+    )
+    expect(queryClient.getQueryState(sitesKeys.detail(1))?.isInvalidated).toBe(
+      true
+    )
+  })
+
+  it('refetches a mounted accounts page so imported rows appear', async () => {
+    mockGetAccountsPage.mockResolvedValue(pageResponse(['existing']))
+
+    const { result } = renderHook(
+      () => ({
+        // Same key + queryFn the /accounts table uses (useAccountsPage).
+        page: useQuery({
+          queryKey: PAGE_KEY,
+          queryFn: () => fetchAccountsPage(PAGE_PARAMS),
+          staleTime: 10 * 1000,
+        }),
+        importSites: useImportSites(),
+      }),
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      expect(result.current.page.isSuccess).toBe(true)
+    })
+    expect(result.current.page.data?.items).toHaveLength(1)
+    expect(mockGetAccountsPage).toHaveBeenCalledTimes(1)
+
+    // The backend now returns the imported account on the same page.
+    mockGetAccountsPage.mockResolvedValue(
+      pageResponse(['existing', 'imported'])
+    )
+
+    await act(async () => {
+      result.current.importSites.mutate(IMPORT_PAYLOAD)
+    })
+    await waitFor(() => {
+      expect(result.current.importSites.isSuccess).toBe(true)
+    })
+
+    // Invalidation must reach the ACTIVE observer — a refetch, not just a
+    // stale flag — otherwise the table keeps rendering the pre-import page.
+    await waitFor(() => {
+      expect(mockGetAccountsPage).toHaveBeenCalledTimes(2)
+    })
+    await waitFor(() => {
+      expect(result.current.page.data?.items).toHaveLength(2)
+    })
+  })
+})

--- a/web/src/features/import/api.ts
+++ b/web/src/features/import/api.ts
@@ -2,8 +2,9 @@
 //
 // Detection is per-URL (matching the backend /api/sites/detect contract), and
 // the final commit is a single idempotent POST /api/sites/import. Import
-// invalidates the sites list + accounts snapshot so list pages refresh after
-// the wizard closes.
+// invalidates the sites + accounts query ROOTS so every cached variant of both
+// resources (the server-paged accounts table, the snapshot consumers, the
+// sites list and detail sheets) refreshes after the wizard closes.
 
 import {
   useMutation,
@@ -73,8 +74,14 @@ export function useImportSites(
       return result
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: sitesKeys.list() })
-      queryClient.invalidateQueries({ queryKey: accountQueryKeys.snapshot() })
+      // Invalidate the factory roots, never a single variant: /accounts reads
+      // `accountQueryKeys.page(…)` (the snapshot has no observer there) and
+      // /sites reads `sitesKeys.list()` while detail sheets read
+      // `sitesKeys.detail(id)`. A variant-scoped invalidation misses whichever
+      // reader is mounted, so freshly imported rows would only appear after a
+      // filter change or a navigate-away-and-back.
+      queryClient.invalidateQueries({ queryKey: sitesKeys.all })
+      queryClient.invalidateQueries({ queryKey: accountQueryKeys.all })
     },
     ...options,
   })

--- a/web/src/features/model-tester/__tests__/api.test.ts
+++ b/web/src/features/model-tester/__tests__/api.test.ts
@@ -8,6 +8,8 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import i18n from '@/i18n/config'
+
 import {
   buildChatPayload,
   resolveTestResponseError,
@@ -133,6 +135,38 @@ describe('resolveTestResponseError', () => {
   it('falls back to HTTP status when the body is not JSON', async () => {
     const response = new Response('plain text body', { status: 500 })
     expect(await resolveTestResponseError(response)).toBe('plain text body')
+  })
+
+  it('only returns keys that BOTH locales translate (no raw key in the UI)', async () => {
+    // model-tester-page.tsx hands these strings to `t(rawMessage)`, so a key
+    // missing from a locale renders literally in the error panel: the 401/403
+    // branch shipped `modelTester.error.sessionExpired` with no locale entry
+    // at all, and the 501 branch working hid it. `getResource` reads the
+    // bundle directly because `t()` would mask a missing zh-CN entry behind
+    // the en fallback.
+    const keys = [
+      await resolveTestResponseError(new Response('{}', { status: 401 })),
+      await resolveTestResponseError(new Response('{}', { status: 403 })),
+      await resolveTestResponseError(new Response('{}', { status: 501 })),
+    ]
+
+    // Locale bundles are lazy-loaded per language — load both before reading.
+    await i18n.changeLanguage('zhCN')
+    await i18n.changeLanguage('en')
+
+    for (const key of keys) {
+      expect(key.startsWith('modelTester.')).toBe(true)
+      expect(
+        i18n.getResource('en', 'translation', key),
+        `en.json missing ${key}`
+      ).toBeTruthy()
+      expect(
+        i18n.getResource('zhCN', 'translation', key),
+        `zh-CN.json missing ${key}`
+      ).toBeTruthy()
+      // And the active language really renders copy, not the key echoed back.
+      expect(i18n.t(key)).not.toBe(key)
+    }
   })
 })
 

--- a/web/src/i18n/__tests__/i18n-keys.test.ts
+++ b/web/src/i18n/__tests__/i18n-keys.test.ts
@@ -2,6 +2,17 @@
 // Scans every t() / i18n.t() call in web/src and verifies each key exists in
 // BOTH en.json and zh-CN.json (translation namespace). Replaces the retired
 // MutationObserver-dictionary coverage test from the pre-rewrite i18n stack.
+//
+// A `t('literal')` scan alone is not enough: two channels hand i18n keys to
+// the translator INDIRECTLY, so the literal never sits inside a `t(` call —
+//   1. `assertBusinessOk(result, 'feature.area.key')` — the shared envelope
+//      guard renders its fallback through `i18n.t(fallbackI18nKey)`
+//      (lib/assert-business-ok.ts);
+//   2. modules that RETURN a key for a component to translate, e.g. the
+//      model-tester error resolver (`return 'modelTester.error.notAvailable'`)
+//      whose value the page feeds to `t(rawMessage)`.
+// Both channels are covered below by collecting every locale-rooted,
+// key-shaped string literal in the source tree.
 
 import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -26,11 +37,46 @@ const STRING_RE = {
   '`': /`((?:[^`\\]|\\.)*)`/,
 } as const
 
+// --- indirect key channels -------------------------------------------------
+
+/**
+ * A string literal that looks like an i18n key: lowercase-led, dotted, with
+ * identifier-shaped segments (`accounts.toast.pinFailed`). Deliberately strict
+ * — no spaces, slashes, colons or leading digits — so URLs, MIME types,
+ * CSS-ish tokens and `object.property` prose do not qualify.
+ */
+const KEY_SHAPED_RE = /^[a-z][A-Za-z0-9]*(?:\.[A-Za-z0-9_-]+)+$/
+
+/**
+ * Top-level locale namespaces (`accounts`, `modelTester`, `settings`, …).
+ * A key-shaped literal only counts as an i18n key when its first segment is
+ * one of these, which keeps the wide source scan free of false positives
+ * (sentence-shaped top-level keys such as `No Data` can never match
+ * KEY_SHAPED_RE's first segment anyway).
+ */
+const LOCALE_ROOTS = new Set(
+  Object.keys(en.translation).filter((root) => /^[a-z][A-Za-z0-9]*$/.test(root))
+)
+
+/** Any single/double-quoted string literal (backticks are template literals). */
+const ANY_STRING_RE = /(['"])((?:(?!\1)[^\\\n]|\\.)*)\1/g
+
+/**
+ * `assertBusinessOk(result, 'feature.area.key')` — the fallback key argument.
+ * The argument list is matched without nested parens (every call site passes
+ * plain identifiers + a literal), and `<…>` type arguments are skipped.
+ */
+const ASSERT_BUSINESS_OK_RE =
+  /(?<![A-Za-z0-9_$])assertBusinessOk\s*(?:<[^<>]*>)?\s*\(([^()]*)\)/g
+
 type TranslationNode = Record<string, unknown>
+
+type UsageKind = 't-call' | 'assertBusinessOk-fallback' | 'key-literal'
 
 interface Usage {
   rawKey: string
   location: string
+  kind: UsageKind
 }
 
 /** Flatten a translation object into dotted leaf keys (`translation.` prefix excluded). */
@@ -77,9 +123,31 @@ function collectSourceFiles(): string[] {
   return files
 }
 
-function extractUsages(): Usage[] {
+/** Line number (1-based) of a character offset inside a whole-file string. */
+function lineOfOffset(text: string, offset: number): number {
+  let line = 1
+  for (let index = 0; index < offset && index < text.length; index++) {
+    if (text[index] === '\n') line++
+  }
+  return line
+}
+
+/** True when the literal sits in a comment (doc examples are not call sites). */
+function isCommentContext(line: string, literalOffsetInLine: number): boolean {
+  const trimmed = line.trimStart()
+  if (
+    trimmed.startsWith('*') ||
+    trimmed.startsWith('//') ||
+    trimmed.startsWith('/*')
+  ) {
+    return true
+  }
+  return line.slice(0, literalOffsetInLine).includes('//')
+}
+
+function extractTCallUsages(files: string[]): Usage[] {
   const usages: Usage[] = []
-  for (const filePath of collectSourceFiles()) {
+  for (const filePath of files) {
     const lines = readFileSync(filePath, 'utf8').split('\n')
     lines.forEach((line, index) => {
       for (const match of line.matchAll(T_CALL_RE)) {
@@ -103,7 +171,71 @@ function extractUsages(): Usage[] {
         usages.push({
           rawKey: stringMatch[1],
           location: `${filePath.replaceAll('\\', '/')}:${index + 1}`,
+          kind: 't-call',
         })
+      }
+    })
+  }
+  return usages
+}
+
+/**
+ * Collect keys that reach the translator WITHOUT a `t('literal')` call site:
+ * `assertBusinessOk(…, 'key')` fallbacks (tagged separately so the gate can
+ * prove that channel is still scanned) plus every other locale-rooted,
+ * key-shaped string literal in the tree — which is how returned/propagated
+ * keys (model-tester error resolver) get caught.
+ */
+function extractIndirectUsages(files: string[]): Usage[] {
+  const usages: Usage[] = []
+  const seen = new Set<string>()
+  const push = (rawKey: string, location: string, kind: UsageKind): void => {
+    const id = `${location}::${rawKey}`
+    if (seen.has(id)) return
+    seen.add(id)
+    usages.push({ rawKey, location, kind })
+  }
+
+  for (const filePath of files) {
+    const relative = filePath.replaceAll('\\', '/')
+    const text = readFileSync(filePath, 'utf8')
+    const lines = text.split('\n')
+
+    // Channel 1: assertBusinessOk fallback keys (may span several lines).
+    for (const match of text.matchAll(ASSERT_BUSINESS_OK_RE)) {
+      const startLine = lineOfOffset(text, match.index)
+      const args = match[1] ?? ''
+      const argsOffsetInLine = (lines[startLine - 1] ?? '').indexOf(
+        'assertBusinessOk'
+      )
+      if (isCommentContext(lines[startLine - 1] ?? '', argsOffsetInLine)) {
+        continue
+      }
+      for (const literal of args.matchAll(ANY_STRING_RE)) {
+        const candidate = literal[2] ?? ''
+        if (!KEY_SHAPED_RE.test(candidate)) continue
+        if (!LOCALE_ROOTS.has(candidate.split('.')[0] ?? '')) continue
+        // `args` starts on `startLine`, so the literal's own line is the
+        // relative offset inside the argument list.
+        const literalLine =
+          lineOfOffset(args, literal.index ?? 0) + startLine - 1
+        push(
+          candidate,
+          `${relative}:${literalLine}`,
+          'assertBusinessOk-fallback'
+        )
+      }
+    }
+
+    // Channel 2: every locale-rooted key-shaped literal (returned keys,
+    // constants handed to a component that calls `t(value)`).
+    lines.forEach((line, index) => {
+      for (const literal of line.matchAll(ANY_STRING_RE)) {
+        if (isCommentContext(line, literal.index)) continue
+        const candidate = literal[2] ?? ''
+        if (!KEY_SHAPED_RE.test(candidate)) continue
+        if (!LOCALE_ROOTS.has(candidate.split('.')[0] ?? '')) continue
+        push(candidate, `${relative}:${index + 1}`, 'key-literal')
       }
     })
   }
@@ -116,6 +248,13 @@ function extractUsages(): Usage[] {
 // Currently empty: the sole entry ('No option found.') belonged to the
 // removed ui/combobox-input.tsx default prop.
 const DYNAMIC_KEY_ALLOWLIST: string[] = []
+
+// Deliberate exceptions for the wide literal scan: strings that are shaped
+// like `localeRoot.something` but are NOT i18n keys (e.g. an identifier used
+// as a storage/event name). Entries are skipped by the coverage check; keep
+// each one commented with the reason it is not a key.
+// Currently empty — every locale-rooted literal in web/src is a real key.
+const NON_KEY_LITERAL_ALLOWLIST: string[] = []
 
 /**
  * Normalize a raw key into the form the locales are checked against:
@@ -142,19 +281,47 @@ describe('i18n key coverage', () => {
   const zhRoot = zhCN.translation as TranslationNode
   const enKeys = flattenLeaves(enRoot)
   const zhKeys = flattenLeaves(zhRoot)
-  const usages = extractUsages()
+  const sourceFiles = collectSourceFiles()
+  const tCallUsages = extractTCallUsages(sourceFiles)
+  const indirectUsages = extractIndirectUsages(sourceFiles)
+  const usages = [...tCallUsages, ...indirectUsages]
 
   it('scans a meaningful number of t() call sites (no vacuous pass)', () => {
-    expect(usages.length).toBeGreaterThan(1000)
+    expect(tCallUsages.length).toBeGreaterThan(1000)
   })
 
-  it('defines every t() key in both en.json and zh-CN.json', () => {
-    const allowlisted = new Set(DYNAMIC_KEY_ALLOWLIST)
+  it('scans the indirect key channels (no vacuous pass)', () => {
+    const fallbacks = indirectUsages.filter(
+      (usage) => usage.kind === 'assertBusinessOk-fallback'
+    )
+    // The envelope guard is the single indirect entry point for mutation
+    // failure copy — if this count collapses, the regex stopped matching and
+    // every fallback key would silently escape the gate again.
+    expect(fallbacks.length).toBeGreaterThanOrEqual(15)
+    expect(indirectUsages.length).toBeGreaterThan(100)
+    // Regression pin for channel 2: the model-tester resolver RETURNS its keys
+    // (model-tester-page.tsx feeds them to `t(rawMessage)`), so a scan limited
+    // to `t('…')` literals never sees them.
+    expect(
+      indirectUsages.some(
+        (usage) =>
+          usage.rawKey === 'modelTester.error.notAvailable' &&
+          usage.kind === 'key-literal'
+      ),
+      'model-tester resolver keys must stay inside the scanned surface'
+    ).toBe(true)
+  })
+
+  it('defines every referenced i18n key in both en.json and zh-CN.json', () => {
+    const allowlisted = new Set([
+      ...DYNAMIC_KEY_ALLOWLIST,
+      ...NON_KEY_LITERAL_ALLOWLIST,
+    ])
     const missingInEn: string[] = []
     const missingInZh: string[] = []
     const seen = new Set<string>()
 
-    for (const { rawKey, location } of usages) {
+    for (const { rawKey, location, kind } of usages) {
       if (allowlisted.has(rawKey)) continue
       const key = normalizeKey(rawKey, enRoot)
       if (key === null) {
@@ -176,10 +343,10 @@ describe('i18n key coverage', () => {
         keys.has(`${key}_one`) ||
         keys.has(`${key}_other`)
       if (!covered(enRoot, enKeys)) {
-        missingInEn.push(`${key}  (${location})`)
+        missingInEn.push(`${key}  (${kind} @ ${location})`)
       }
       if (!covered(zhRoot, zhKeys)) {
-        missingInZh.push(`${key}  (${location})`)
+        missingInZh.push(`${key}  (${kind} @ ${location})`)
       }
     }
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -312,7 +312,8 @@
       "error": {
         "stopped": "Request was stopped.",
         "unknown": "An unknown error occurred.",
-        "notAvailable": "Model testing isn't available yet: select a channel to run a test through the forced-channel harness."
+        "notAvailable": "Model testing isn't available yet: select a channel to run a test through the forced-channel harness.",
+        "sessionExpired": "Session expired, please sign in again."
       },
       "viewer": {
         "title": "Response",
@@ -2125,7 +2126,9 @@
         "unavailableBadge": "Unavailable",
         "disabledBadge": "Disabled",
         "removeAria": "Remove {{name}}",
+        "refreshFailed": "the server returned no failure reason",
         "refreshFailedInline": "Refresh failed: {{message}}",
+        "manualFailed": "the server returned no failure reason",
         "manualFailedInline": "Manual models update failed: {{message}}",
         "placeholder": "Model name, e.g. gpt-4o",
         "inputAria": "New manual model name",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -312,7 +312,8 @@
       "error": {
         "stopped": "请求已停止。",
         "unknown": "发生未知错误。",
-        "notAvailable": "模型测试暂不可用：请选择渠道，通过强制渠道测试通道发起测试。"
+        "notAvailable": "模型测试暂不可用：请选择渠道，通过强制渠道测试通道发起测试。",
+        "sessionExpired": "会话已过期，请重新登录。"
       },
       "viewer": {
         "title": "响应",
@@ -2125,7 +2126,9 @@
         "unavailableBadge": "不可用",
         "disabledBadge": "已停用",
         "removeAria": "移除 {{name}}",
+        "refreshFailed": "服务端未返回失败原因",
         "refreshFailedInline": "刷新失败：{{message}}",
+        "manualFailed": "服务端未返回失败原因",
         "manualFailedInline": "手动模型更新失败：{{message}}",
         "placeholder": "模型名称，如 gpt-4o",
         "inputAria": "新手动模型名称",


### PR DESCRIPTION
## 改动摘要

四个「界面看起来对、实际读的不是那份数据」的缺陷，都在 accounts/import/i18n 这条动线上：

1. **批量导入后 `/accounts` 不刷新**：导入 mutation 的 `onSettled` 失效的是 `sitesKeys.list()` + `accountQueryKeys.snapshot()`，而 `/accounts` 表格读的是 `accountQueryKeys.page(...)`（snapshot 在该页没有 observer）。导入成功后表格纹丝不动，直到改分页/筛选或离开再回来；同一个向导在 `/sites` 却会刷新——两个宿主页对同一动作给两套答案。改为失效**工厂根**（`sitesKeys.all` / `accountQueryKeys.all`），覆盖分页、快照、列表、详情全部变体。
2. **三个行内 toggle 的乐观更新打在页面不读的键上**：置顶/启停/签到的 `onMutate` 只 patch `snapshot()` 并 `cancelQueries(snapshot())`，而表格行数据来自 `page(...)`。结果是点击后行不即时翻转（要等 `onSettled` 的网络往返），同时把「只被用来取名字」的 snapshot 改成客户端猜测值，污染 sites / 签到 / 路由 / 下游密钥四页。改为照抄仓内既有正确范式（`features/oauth/api.ts`）：`getQueriesData` + `setQueriesData` 按 `pages()` 前缀 patch 所有分页、逐键回滚；snapshot 仍单独 patch，因为它自己有 6 个挂载消费者渲染同样三个字段。分页行是表格按渲染解析的原始服务端对象，所以 patch 生成**新对象**（解析缓存按对象身份命中，否则会返回旧解析结果），并兼容 legacy `accounts` 形状。
3. **两处 i18n 缺键把裸 key 渲染给用户**：`modelTester.error.sessionExpired`（401/403 分支，最常见的 admin token 过期场景）与 `assertBusinessOk` 的两个 fallback（`accounts.models.refreshFailed` / `manualFailed`，后端业务失败且不带 message 时）在**两个 locale 都不存在**，i18next 缺键返回 key 本身。补齐双语；F4 的两个键按渲染路径写成「原因从句」（它们只会被塞进 `Refresh failed: {{message}}` / 「刷新失败：{{message}}」），避免整句重复。
4. **门禁看不见第 3 类缺陷**：`i18n-keys.test.ts` 只扫同行 `t('字面量')`，而这两条路径都是「函数返回长得像 key 的字符串」+「`t(变量)`」。新增两条间接扫描面：`assertBusinessOk(...)` 的 fallback 实参，以及 `web/src` 内所有以已知 locale 根开头的 key 形状字符串字面量；带注释上下文排除、`NON_KEY_LITERAL_ALLOWLIST` 逃生口，以及两条防空跑断言（间接命中数下限 + 钉住一个已知键必须留在扫描面内）。

## 类型

- [x] fix（bug 修复）

## 测试验证

- [x] `cd web && bun run typecheck` 通过
- [x] `cd web && bun run lint` 0 error（oxlint + `check:boundaries`：673 文件、0 跨层边）
- [x] `cd web && bun run format:check` 通过（仅格式化本次触碰的 7 个文件）
- [x] `cd web && bun run knip` 通过
- [x] `cd web && bunx vitest run` 全量全绿：**253 文件 / 1618 测试**
- [x] 新增/改写测试，全部先红后绿：
  - `features/import/__tests__/import-cache-invalidation.test.tsx`（新）：seed **分页**缓存 + snapshot + sites 列表 + site 详情，断言 mutation settle 后全部失效；第二个用例挂载真实分页 reader，断言它 refetch（导入的行会真的出现）
  - `features/accounts/__tests__/accounts-toggle-optimistic.test.tsx`：改为 seed/断言页面真正读的分页键（两种分页 + 筛选变体）并与 snapshot 并列；断言服务端应答前所有分页都翻转、失败时逐页回滚、兄弟行不受影响、无关分页 payload 保持对象身份
  - `features/model-tester/__tests__/api.test.ts`：断言错误解析器返回的每个 key 在**两个** locale 都能翻译（直接读 resource，避免 `en` fallback 掩盖 zh-CN 缺键）
  - `features/accounts/models/__tests__/models-failure-copy.test.ts`（新）：驱动真实 `assertBusinessOk({success:false}, …)` 路径，断言抛出的 message 与合成后的 `*Inline` 文案在双语下都无裸 key、无未解析的 `{{message}}`
  - `i18n/__tests__/i18n-keys.test.ts`：门禁先对未改动的 master 源码报出恰好三个缺键（带来源标签与文件行号），补键后转绿
- 未运行视觉回归；`web/visual-baselines/` 未触碰
- 未触碰后端与 API 形状

## 自查清单

- [x] 无密钥/内部路径泄漏（gitleaks 会在 CI 检查）
- [x] 用户可见文案已走 i18n（`t()`），且新增键双语齐备
- [x] 行为变更已补充/更新测试
- [x] 无需 CHANGELOG（随下一版汇总）
