### PR TITLE
fix(settings): rehydrate every admin-writable setting and settle the log-retention regime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -241,6 +241,10 @@ ROUTE_REBUILD_PROBE_FILTER_INCLUDE_MODELS=
 ROUTE_REBUILD_PROBE_FILTER_EXCLUDE_MODELS=
 
 # ---- Log cleanup toggles ----
+# Off by default; the cleanup regime owns the log tables only when a toggle below is
+# explicitly true, or an admin-saved log-cleanup setting exists — otherwise the legacy
+# PROXY_LOG_RETENTION_DAYS pruner handles proxy logs. Retention/cron alone do not
+# switch the regime, and an explicit false never does. Startup logs the winner.
 LOG_CLEANUP_USAGE_LOGS_ENABLED=
 LOG_CLEANUP_PROGRAM_LOGS_ENABLED=
 LOG_CLEANUP_RETENTION_DAYS=30

--- a/config/config.go
+++ b/config/config.go
@@ -403,9 +403,12 @@ func (c *Config) PostgresSSLMode(dbSsl bool) string {
 	return ""
 }
 
-// §1.7 normalizeTokenRouterFailureCooldownMaxSec:
+// §1.7 NormalizeTokenRouterFailureCooldownMaxSec:
 // !finite || <= 0 → (0, false); trunc → clamp[1, ceiling] → (int, true).
-func normalizeTokenRouterFailureCooldownMaxSec(value float64) (int, bool) {
+// Exported so the settings-table hydration path (store.ApplyRuntimeSettings)
+// clamps a persisted cap exactly like the env path instead of growing a second
+// copy of the rule.
+func NormalizeTokenRouterFailureCooldownMaxSec(value float64) (int, bool) {
 	if math.IsInf(value, 0) || math.IsNaN(value) || value <= 0 {
 		return 0, false
 	}
@@ -678,7 +681,7 @@ func Load(env map[string]string) (*Config, *RuntimeSettings) {
 
 	// ---- §3.14 Proxy: Token Router ----
 	tokenRouterParsed := parseNumber(get("TOKEN_ROUTER_FAILURE_COOLDOWN_MAX_SEC"), float64(TokenRouterFailureCooldownMaxSecCeiling))
-	if val, ok := normalizeTokenRouterFailureCooldownMaxSec(tokenRouterParsed); ok {
+	if val, ok := NormalizeTokenRouterFailureCooldownMaxSec(tokenRouterParsed); ok {
 		rt.TokenRouterFailureCooldownMaxSec = val
 	} else {
 		rt.TokenRouterFailureCooldownMaxSec = TokenRouterFailureCooldownMaxSecCeiling

--- a/config/config.go
+++ b/config/config.go
@@ -90,7 +90,23 @@ type Config struct {
 	// production without losing Warn/Error signal.
 	LogLevel string
 
+	// LogCleanupConfigured reports whether the log_cleanup regime owns the log
+	// tables (true) or the legacy PROXY_LOG_RETENTION_DAYS pruner does (false).
+	// Resolved during startup settings hydration, not by Load.
 	LogCleanupConfigured bool
+
+	// LogCleanupEnvEnabled records that an env toggle explicitly asked for the
+	// log_cleanup regime: LOG_CLEANUP_USAGE_LOGS_ENABLED=true or
+	// LOG_CLEANUP_PROGRAM_LOGS_ENABLED=true. Startup hydration ORs it into
+	// LogCleanupConfigured so an env-driven deployment keeps its intent even
+	// with an empty settings table.
+	//
+	// Deliberately one-directional: neither LOG_CLEANUP_RETENTION_DAYS nor
+	// LOG_CLEANUP_CRON counts, and an explicit false does not count either.
+	// Claiming the regime while both toggles are off would run the new scheduler
+	// (which then skips for want of a target) and disable the legacy pruner, so
+	// nothing would ever be pruned.
+	LogCleanupEnvEnabled bool
 
 	// Resin sticky proxy pool (3 fields, env-only — no DDL for Tier 1).
 	// RESIN_URL carries the base URL + token, e.g. http://resin.local:2260/my-token.
@@ -550,7 +566,10 @@ func Load(env map[string]string) (*Config, *RuntimeSettings) {
 	rt.LogCleanupUsageLogsEnabled = parseBoolean(get("LOG_CLEANUP_USAGE_LOGS_ENABLED"), false)
 	rt.LogCleanupProgramLogsEnabled = parseBoolean(get("LOG_CLEANUP_PROGRAM_LOGS_ENABLED"), false)
 	rt.LogCleanupRetentionDays = max(1, int(math.Trunc(parseNumber(get("LOG_CLEANUP_RETENTION_DAYS"), 30))))
-	cfg.LogCleanupConfigured = false // set later during runtime settings hydration
+	// An env toggle set to true is an explicit ask for the log_cleanup regime;
+	// retention and cron alone are not (see Config.LogCleanupEnvEnabled).
+	cfg.LogCleanupEnvEnabled = rt.LogCleanupUsageLogsEnabled || rt.LogCleanupProgramLogsEnabled
+	cfg.LogCleanupConfigured = false // resolved at hydration: explicit DB keys OR the env toggle above
 
 	// ---- §3.6 Notify: Webhook ----
 	rt.WebhookUrl = firstNonEmpty(get("WEBHOOK_URL"), "")

--- a/config/log_cleanup_intent_test.go
+++ b/config/log_cleanup_intent_test.go
@@ -1,0 +1,86 @@
+package config
+
+import "testing"
+
+// TestLoadLogCleanupEnvIntent pins which env spellings count as an explicit ask
+// for the log_cleanup retention regime. store.LoadRuntimeSettings ORs this bit
+// into Config.LogCleanupConfigured, so it has to stay one-directional:
+//
+//   - a toggle set to true claims the regime (an env-only deployment has no
+//     admin-saved log-cleanup rows to claim it with);
+//   - LOG_CLEANUP_RETENTION_DAYS / LOG_CLEANUP_CRON do not, and neither does an
+//     explicit false. Claiming the regime while both toggles are off would run
+//     the new scheduler (which then skips for want of a target) and disable the
+//     legacy PROXY_LOG_RETENTION_DAYS pruner, so nothing would ever be pruned.
+func TestLoadLogCleanupEnvIntent(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{name: "unset", env: nil, want: false},
+		{
+			name: "both toggles explicit false",
+			env: map[string]string{
+				"LOG_CLEANUP_USAGE_LOGS_ENABLED":   "false",
+				"LOG_CLEANUP_PROGRAM_LOGS_ENABLED": "false",
+			},
+			want: false,
+		},
+		{name: "usage toggle true", env: map[string]string{"LOG_CLEANUP_USAGE_LOGS_ENABLED": "true"}, want: true},
+		{name: "program toggle true", env: map[string]string{"LOG_CLEANUP_PROGRAM_LOGS_ENABLED": "true"}, want: true},
+		{
+			name: "truthy spelling",
+			env:  map[string]string{"LOG_CLEANUP_USAGE_LOGS_ENABLED": "1"},
+			want: true,
+		},
+		{
+			name: "one toggle true, one false",
+			env: map[string]string{
+				"LOG_CLEANUP_USAGE_LOGS_ENABLED":   "true",
+				"LOG_CLEANUP_PROGRAM_LOGS_ENABLED": "false",
+			},
+			want: true,
+		},
+		{
+			name: "retention only",
+			env:  map[string]string{"LOG_CLEANUP_RETENTION_DAYS": "7"},
+			want: false,
+		},
+		{
+			name: "cron only",
+			env:  map[string]string{"LOG_CLEANUP_CRON": "30 4 * * *"},
+			want: false,
+		},
+		{
+			name: "retention and cron",
+			env: map[string]string{
+				"LOG_CLEANUP_RETENTION_DAYS": "7",
+				"LOG_CLEANUP_CRON":           "30 4 * * *",
+			},
+			want: false,
+		},
+		{
+			name: "unparsable toggle",
+			env:  map[string]string{"LOG_CLEANUP_USAGE_LOGS_ENABLED": "maybe"},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, rt := Load(tc.env)
+			if cfg.LogCleanupEnvEnabled != tc.want {
+				t.Fatalf("LogCleanupEnvEnabled = %v, want %v", cfg.LogCleanupEnvEnabled, tc.want)
+			}
+			// The regime itself is resolved during settings hydration, never here.
+			if cfg.LogCleanupConfigured {
+				t.Error("LogCleanupConfigured = true straight out of Load; hydration owns that decision")
+			}
+			// The bit must never contradict the toggles it is derived from.
+			if tc.want && !rt.LogCleanupUsageLogsEnabled && !rt.LogCleanupProgramLogsEnabled {
+				t.Error("LogCleanupEnvEnabled = true but no toggle is enabled")
+			}
+		})
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,7 @@ knob a deployment is likely to touch. Docker Compose users pass these via
 | `CHECKIN_WINDOW_START` / `CHECKIN_WINDOW_END` | `00:00` / `23:59` | Random-window mode bounds. |
 | `BALANCE_REFRESH_CRON` | `0 * * * *` | Balance refresh cron (hourly). |
 | `LOG_CLEANUP_CRON` | `0 6 * * *` | Retention pruning cron. |
-| `LOG_CLEANUP_USAGE_LOGS_ENABLED` / `LOG_CLEANUP_PROGRAM_LOGS_ENABLED` | auto | Which log families the cleanup prunes. |
+| `LOG_CLEANUP_USAGE_LOGS_ENABLED` / `LOG_CLEANUP_PROGRAM_LOGS_ENABLED` | `false` | Which log families the cleanup prunes. Off by default: the cleanup regime owns the log tables only when a toggle is `true` here or an admin-saved log-cleanup setting exists; otherwise the legacy `PROXY_LOG_RETENTION_DAYS` pruner handles proxy logs. `LOG_CLEANUP_RETENTION_DAYS` / `LOG_CLEANUP_CRON` alone do not switch the regime, and an explicit `false` never does. Startup logs the winner as `settings: log retention regime`. |
 | `LOG_CLEANUP_RETENTION_DAYS` | `30` | Proxy/program log retention. |
 | `USAGE_PROJECTION_INTERVAL_MS` | `5000` | Usage-aggregation projection cadence (`proxy_logs` → site/model rollups). Clamped to 1000–3600000 ms; raise it on small single-node deployments to trade dashboard freshness for fewer passes. |
 

--- a/handler/admin/settings_apply.go
+++ b/handler/admin/settings_apply.go
@@ -748,7 +748,12 @@ func (h *settingsHandler) applyFilterSettings(body map[string]any) *settingsAppl
 			}
 		}
 		config.UpdateRuntime(func(r *config.RuntimeSettings) { r.AdminIpAllowlist = list })
-		upsertSettingDB(h.db, "admin_ip_allowlist", list)
+		// A failed persist must not look like success: the allowlist would be
+		// live until the next restart and then silently revert to the env
+		// value, re-opening the admin API to every IP.
+		if err := upsertSettingDB(h.db, "admin_ip_allowlist", list); err != nil {
+			return failSettings(http.StatusInternalServerError, "failed to save admin IP allowlist")
+		}
 	}
 
 	// Global blocked brands
@@ -796,7 +801,11 @@ func (h *settingsHandler) applyFilterSettings(body map[string]any) *settingsAppl
 			}
 		}
 		config.UpdateRuntime(func(r *config.RuntimeSettings) { r.ProxyErrorKeywords = keywords })
-		upsertSettingDB(h.db, "proxy_error_keywords", keywords)
+		// Same reasoning as the allowlist above: the two neighbouring filters
+		// in this function already report persist failures.
+		if err := upsertSettingDB(h.db, "proxy_error_keywords", keywords); err != nil {
+			return failSettings(http.StatusInternalServerError, "failed to save proxy error keywords")
+		}
 	}
 
 	// Payload rules

--- a/handler/admin/settings_roundtrip_test.go
+++ b/handler/admin/settings_roundtrip_test.go
@@ -1,0 +1,168 @@
+package admin
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// TestSettingsRuntimeWritePathSurvivesRestart is the round-trip half of the
+// settings persistence contract: every value the admin API accepts must still
+// be in effect after a restart. The write side persists through
+// upsertSettingDB (JSON-encoded), the boot side reads through
+// store.ApplyRuntimeSettings, and the two halves used to disagree — a cleared
+// site name came back as the env value, and the routing/proxy/debug knobs were
+// not read back at all, so a restart silently reverted them.
+//
+// The key-coverage half of the contract (no persisted key may lack a hydration
+// case) is enforced by store/settings_rehydration_gate_test.go.
+func TestSettingsRuntimeWritePathSurvivesRestart(t *testing.T) {
+	db, r, _ := setupEdgeTest(t)
+
+	resp := doPutJSON(t, r, "/api/settings/runtime", map[string]any{
+		// Access control + failure judgement.
+		"adminIpAllowlist":   []any{"203.0.113.7", "198.51.100.9"},
+		"proxyErrorKeywords": []any{"rate limit", "overloaded"},
+		// Routing cost model.
+		"routingWeights":          map[string]any{"baseWeightFactor": 0.7, "costWeight": 0.2},
+		"routingFallbackUnitCost": 0.25,
+		// Proxy transport + token router.
+		"proxyFirstByteTimeoutSec":            45,
+		"tokenRouterFailureCooldownMaxSec":    3600,
+		"proxySessionChannelConcurrencyLimit": 4,
+		"proxySessionChannelQueueWaitMs":      2500,
+		// Fallback policy toggles.
+		"disableCrossProtocolFallback":               true,
+		"responsesCompactFallbackToResponsesEnabled": true,
+		"proxyEmptyContentFailEnabled":               true,
+		// Debug tracing.
+		"proxyDebugCaptureHeaders":      false,
+		"proxyDebugCaptureBodies":       true,
+		"proxyDebugCaptureStreamChunks": true,
+		"proxyDebugTargetSessionId":     "sess-round-trip",
+		"proxyDebugTargetClientKind":    "codex",
+		"proxyDebugTargetModel":         "gpt-5",
+		"proxyDebugRetentionHours":      12,
+		"proxyDebugMaxBodyBytes":        4096,
+		// Log cleanup: the write side uses underscore keys, the boot side used
+		// to look for dotted ones.
+		"logCleanupUsageLogsEnabled":   true,
+		"logCleanupProgramLogsEnabled": false,
+		"logCleanupRetentionDays":      9,
+		// Branding cleared on purpose: the restart env below sets all five, so
+		// a hydration path that drops explicit blanks resurrects them.
+		"systemName":    "",
+		"logo":          "",
+		"footer":        "",
+		"about":         "",
+		"serverAddress": "",
+		// Credential: persisted JSON-encoded, must be decoded on the way back.
+		"proxyToken": "sk-round-trip-token",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("PUT /api/settings/runtime: %d %s", resp.Code, resp.Body.String())
+	}
+	hot := *config.Runtime()
+
+	// Simulated restart: env resolves the deployment defaults (deliberately
+	// different from everything the operator just saved), then boot hydration
+	// reads back exactly the rows the write path persisted.
+	persisted := readAllPersistedSettings(t, db)
+	if len(persisted) == 0 {
+		t.Fatal("write path persisted no settings rows")
+	}
+	_, restarted := config.Load(map[string]string{
+		"ACCOUNT_CREDENTIAL_SECRET":        "restart-test-secret",
+		"PROXY_TOKEN":                      "sk-env-token",
+		"SYSTEM_NAME":                      "Metapi",
+		"LOGO":                             "https://cdn.example/env-logo.png",
+		"FOOTER":                           "env footer",
+		"ABOUT":                            "env about",
+		"SERVER_ADDRESS":                   "https://env.example.com",
+		"ADMIN_IP_ALLOWLIST":               "192.0.2.1",
+		"PROXY_ERROR_KEYWORDS":             "env keyword",
+		"LOG_CLEANUP_USAGE_LOGS_ENABLED":   "false",
+		"LOG_CLEANUP_PROGRAM_LOGS_ENABLED": "true",
+		"LOG_CLEANUP_RETENTION_DAYS":       "30",
+	})
+	store.ApplyRuntimeSettings(&config.Config{}, restarted, persisted)
+
+	checks := []struct {
+		name string
+		get  func(*config.RuntimeSettings) any
+	}{
+		{"AdminIpAllowlist", func(rt *config.RuntimeSettings) any { return rt.AdminIpAllowlist }},
+		{"ProxyErrorKeywords", func(rt *config.RuntimeSettings) any { return rt.ProxyErrorKeywords }},
+		{"RoutingWeights", func(rt *config.RuntimeSettings) any { return rt.RoutingWeights }},
+		{"RoutingFallbackUnitCost", func(rt *config.RuntimeSettings) any { return rt.RoutingFallbackUnitCost }},
+		{"ProxyFirstByteTimeoutSec", func(rt *config.RuntimeSettings) any { return rt.ProxyFirstByteTimeoutSec }},
+		{"TokenRouterFailureCooldownMaxSec", func(rt *config.RuntimeSettings) any { return rt.TokenRouterFailureCooldownMaxSec }},
+		{"ProxySessionChannelConcurrencyLimit", func(rt *config.RuntimeSettings) any { return rt.ProxySessionChannelConcurrencyLimit }},
+		{"ProxySessionChannelQueueWaitMs", func(rt *config.RuntimeSettings) any { return rt.ProxySessionChannelQueueWaitMs }},
+		{"DisableCrossProtocolFallback", func(rt *config.RuntimeSettings) any { return rt.DisableCrossProtocolFallback }},
+		{"ResponsesCompactFallbackToResponsesEnabled", func(rt *config.RuntimeSettings) any { return rt.ResponsesCompactFallbackToResponsesEnabled }},
+		{"ProxyEmptyContentFailEnabled", func(rt *config.RuntimeSettings) any { return rt.ProxyEmptyContentFailEnabled }},
+		{"ProxyDebugCaptureHeaders", func(rt *config.RuntimeSettings) any { return rt.ProxyDebugCaptureHeaders }},
+		{"ProxyDebugCaptureBodies", func(rt *config.RuntimeSettings) any { return rt.ProxyDebugCaptureBodies }},
+		{"ProxyDebugCaptureStreamChunks", func(rt *config.RuntimeSettings) any { return rt.ProxyDebugCaptureStreamChunks }},
+		{"ProxyDebugTargetSessionId", func(rt *config.RuntimeSettings) any { return rt.ProxyDebugTargetSessionId }},
+		{"ProxyDebugTargetClientKind", func(rt *config.RuntimeSettings) any { return rt.ProxyDebugTargetClientKind }},
+		{"ProxyDebugTargetModel", func(rt *config.RuntimeSettings) any { return rt.ProxyDebugTargetModel }},
+		{"ProxyDebugRetentionHours", func(rt *config.RuntimeSettings) any { return rt.ProxyDebugRetentionHours }},
+		{"ProxyDebugMaxBodyBytes", func(rt *config.RuntimeSettings) any { return rt.ProxyDebugMaxBodyBytes }},
+		{"LogCleanupUsageLogsEnabled", func(rt *config.RuntimeSettings) any { return rt.LogCleanupUsageLogsEnabled }},
+		{"LogCleanupProgramLogsEnabled", func(rt *config.RuntimeSettings) any { return rt.LogCleanupProgramLogsEnabled }},
+		{"LogCleanupRetentionDays", func(rt *config.RuntimeSettings) any { return rt.LogCleanupRetentionDays }},
+		{"SystemName", func(rt *config.RuntimeSettings) any { return rt.SystemName }},
+		{"Logo", func(rt *config.RuntimeSettings) any { return rt.Logo }},
+		{"Footer", func(rt *config.RuntimeSettings) any { return rt.Footer }},
+		{"About", func(rt *config.RuntimeSettings) any { return rt.About }},
+		{"ServerAddress", func(rt *config.RuntimeSettings) any { return rt.ServerAddress }},
+		{"ProxyToken", func(rt *config.RuntimeSettings) any { return rt.ProxyToken }},
+	}
+	for _, check := range checks {
+		want, got := check.get(&hot), check.get(restarted)
+		if !reflect.DeepEqual(want, got) {
+			t.Errorf("%s did not survive the restart: saved %#v, rehydrated %#v", check.name, want, got)
+		}
+	}
+
+	// Guard against a vacuous pass: the restart env above must actually
+	// disagree with what the operator saved, otherwise the comparison proves
+	// nothing.
+	if restarted.SystemName != "" {
+		t.Fatalf("SystemName = %q, want the cleared value (env said Metapi)", restarted.SystemName)
+	}
+	if restarted.ProxyToken != "sk-round-trip-token" {
+		t.Fatalf("ProxyToken = %q, want the saved token (env said sk-env-token)", restarted.ProxyToken)
+	}
+	if len(restarted.AdminIpAllowlist) != 2 {
+		t.Fatalf("AdminIpAllowlist = %#v, want the two saved entries (env said 192.0.2.1)", restarted.AdminIpAllowlist)
+	}
+}
+
+// readAllPersistedSettings returns the settings table exactly as boot
+// hydration sees it (raw JSON-encoded values keyed by setting name).
+func readAllPersistedSettings(t *testing.T, db *store.DB) map[string]string {
+	t.Helper()
+	rows, err := db.Query("SELECT key, value FROM settings")
+	if err != nil {
+		t.Fatalf("query settings: %v", err)
+	}
+	defer rows.Close()
+	out := map[string]string{}
+	for rows.Next() {
+		var key, value string
+		if err := rows.Scan(&key, &value); err != nil {
+			t.Fatalf("scan setting: %v", err)
+		}
+		out[key] = value
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("settings rows: %v", err)
+	}
+	return out
+}

--- a/store/settings.go
+++ b/store/settings.go
@@ -35,16 +35,58 @@ func LoadRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings) error {
 		ApplyRuntimeSettings(cfg, rt, settingsMap)
 	}
 
-	// Which log-retention regime owns the log tables is decided solely by
-	// explicit operator-written keys. It used to be inferred from
-	// "retention > 0", but config.Load floors retention at 1 day, so the
-	// inference fired as soon as the settings table held any row at all: it
-	// silently flipped an explicit LOG_CLEANUP_*_ENABLED=false to true and
-	// disabled the legacy proxy-log retention scheduler. Saving an unrelated
-	// setting (the site name, say) must not switch the retention regime.
-	cfg.LogCleanupConfigured = HasExplicitLogCleanupSettings(settingsMap)
+	// Which log-retention regime owns the log tables is decided by explicit
+	// operator intent only: an admin-saved log-cleanup setting, or an env
+	// toggle explicitly set to true (config.LogCleanupEnvEnabled). It used to
+	// be inferred from "retention > 0", but config.Load floors retention at 1
+	// day, so the inference fired as soon as the settings table held any row at
+	// all: it silently flipped an explicit LOG_CLEANUP_*_ENABLED=false to true
+	// and disabled the legacy proxy-log retention scheduler. Saving an
+	// unrelated setting (the site name, say) must not switch the regime, and
+	// an env-only deployment must not lose the regime it asked for either.
+	//
+	// The two sources are asymmetric on purpose: env can turn the regime ON but
+	// cannot "claim" it while off, because claiming it disables the legacy
+	// PROXY_LOG_RETENTION_DAYS pruner and would leave proxy_logs unpruned.
+	// Values still come from the settings table when it has them (hydration ran
+	// above); env only contributes the regime bit.
+	dbExplicit := HasExplicitLogCleanupSettings(settingsMap)
+	cfg.LogCleanupConfigured = dbExplicit || cfg.LogCleanupEnvEnabled
+
+	slog.Info("settings: log retention regime",
+		"regime", logRetentionRegime(cfg.LogCleanupConfigured),
+		"configured", cfg.LogCleanupConfigured,
+		"source", logRetentionRegimeSource(dbExplicit, cfg.LogCleanupEnvEnabled),
+		"usage_logs_enabled", rt.LogCleanupUsageLogsEnabled,
+		"program_logs_enabled", rt.LogCleanupProgramLogsEnabled,
+		"retention_days", rt.LogCleanupRetentionDays)
 
 	return nil
+}
+
+// logRetentionRegime names the scheduler that owns the log tables, for the
+// single startup line above: "log_cleanup" prunes usage/program logs on
+// LOG_CLEANUP_CRON, "legacy_fallback" leaves proxy_logs to the
+// PROXY_LOG_RETENTION_DAYS pruner.
+func logRetentionRegime(configured bool) string {
+	if configured {
+		return "log_cleanup"
+	}
+	return "legacy_fallback"
+}
+
+// logRetentionRegimeSource reports which kind of operator intent claimed the
+// regime. Admin-saved settings win over the env toggle because they are also
+// the source of the values, so the two never disagree about what is running.
+func logRetentionRegimeSource(dbExplicit, envEnabled bool) string {
+	switch {
+	case dbExplicit:
+		return "db_settings"
+	case envEnabled:
+		return "env_toggle"
+	default:
+		return "none"
+	}
 }
 
 // toSettingsMap converts flat settings rows into a nested map structure.

--- a/store/settings.go
+++ b/store/settings.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -24,27 +26,23 @@ func LoadRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings) error {
 		return err
 	}
 
-	if len(all) == 0 {
-		slog.Info("settings: no runtime settings found in DB")
-		return nil
-	}
-
 	settingsMap := toSettingsMap(all)
-	slog.Info("settings: loaded runtime settings", "count", len(settingsMap))
-
-	// Apply runtime overrides to the static + runtime drafts.
-	ApplyRuntimeSettings(cfg, rt, settingsMap)
-
-	// Track whether log cleanup was explicitly configured via DB settings.
-	cfg.LogCleanupConfigured = HasExplicitLogCleanupSettings(settingsMap)
-
-	// Auto-enable log cleanup if retention > 0 and not previously configured.
-	if !cfg.LogCleanupConfigured && rt.LogCleanupRetentionDays > 0 {
-		rt.LogCleanupUsageLogsEnabled = true
-		rt.LogCleanupProgramLogsEnabled = true
-		cfg.LogCleanupConfigured = true
-		slog.Info("settings: auto-enabled log cleanup", "retention_days", rt.LogCleanupRetentionDays)
+	if len(settingsMap) == 0 {
+		slog.Info("settings: no runtime settings found in DB")
+	} else {
+		slog.Info("settings: loaded runtime settings", "count", len(settingsMap))
+		// Apply runtime overrides to the static + runtime drafts.
+		ApplyRuntimeSettings(cfg, rt, settingsMap)
 	}
+
+	// Which log-retention regime owns the log tables is decided solely by
+	// explicit operator-written keys. It used to be inferred from
+	// "retention > 0", but config.Load floors retention at 1 day, so the
+	// inference fired as soon as the settings table held any row at all: it
+	// silently flipped an explicit LOG_CLEANUP_*_ENABLED=false to true and
+	// disabled the legacy proxy-log retention scheduler. Saving an unrelated
+	// setting (the site name, say) must not switch the retention regime.
+	cfg.LogCleanupConfigured = HasExplicitLogCleanupSettings(settingsMap)
 
 	return nil
 }
@@ -56,17 +54,30 @@ func toSettingsMap(rows map[string]string) map[string]string {
 	return rows
 }
 
+// logCleanupExplicitKeys are the settings keys whose presence proves the
+// operator configured log cleanup themselves, so startup must neither infer
+// nor override anything for that subsystem.
+//
+// The underscore spellings are what the admin write path persists
+// (handler/admin/settings_apply.go). The dotted spellings are deprecated
+// read-only aliases: no release ever wrote them, they only matter for
+// hand-edited or externally imported rows, and they can be dropped once such
+// rows are extinct.
+var logCleanupExplicitKeys = []string{
+	"log_cleanup_usage_logs_enabled",
+	"log_cleanup_program_logs_enabled",
+	"log_cleanup_retention_days",
+	"log_cleanup.enabled",
+	"log_cleanup.usage_logs_enabled",
+	"log_cleanup.program_logs_enabled",
+	"log_cleanup.retention_days",
+}
+
 // HasExplicitLogCleanupSettings checks whether log cleanup was explicitly
-// configured via the settings table. Mirrors TS behavior: checks for
-// specific setting keys that indicate user-intended log cleanup config.
+// configured via the settings table. Mirrors TS behavior: checks for specific
+// setting keys that indicate user-intended log cleanup config.
 func HasExplicitLogCleanupSettings(settingsMap map[string]string) bool {
-	explicitKeys := []string{
-		"log_cleanup.enabled",
-		"log_cleanup.usage_logs_enabled",
-		"log_cleanup.program_logs_enabled",
-		"log_cleanup.retention_days",
-	}
-	for _, key := range explicitKeys {
+	for _, key := range logCleanupExplicitKeys {
 		if _, ok := settingsMap[key]; ok {
 			return true
 		}
@@ -74,36 +85,103 @@ func HasExplicitLogCleanupSettings(settingsMap map[string]string) bool {
 	return false
 }
 
+// nonHydratedSettingKeys are settings that legitimately live in the settings
+// table but are deliberately NOT folded into the startup snapshot by
+// ApplyRuntimeSettings, each with the reason why. Two shapes belong here: keys
+// whose consumer reads the settings table itself at use time (and re-validates
+// what it reads), and keys whose value is consumed before hydration runs.
+//
+// Everything else the admin API can persist must have a case in
+// ApplyRuntimeSettings. settings_rehydration_gate_test.go fails when it does
+// not, because a persisted key that nothing reads back means the operator's
+// change evaporates on the next restart.
+var nonHydratedSettingKeys = map[string]string{
+	// Resolved by store.EnsureRuntimeDatabase from the env-derived snapshot:
+	// the database is already open (and is the very thing being read) by the
+	// time LoadRuntimeSettings runs.
+	"db_type": "consumed by store.EnsureRuntimeDatabase before hydration runs",
+	"db_url":  "consumed by store.EnsureRuntimeDatabase before hydration runs",
+	"db_ssl":  "consumed by store.EnsureRuntimeDatabase before hydration runs",
+	// v2 ScheduleSpec mirrors of the cron keys, read by the schedule
+	// migration service and the admin schedule endpoints.
+	"checkin_schedule_v2":         "read by service/settingsmigration + handler/admin/checkin_schedule.go",
+	"balance_refresh_schedule_v2": "read by service/settingsmigration",
+	"log_cleanup_schedule_v2":     "read by service/settingsmigration",
+	// Secret read at use time by its own handler; never published to the
+	// runtime snapshot, where a stale copy would outlive rotation.
+	"monitor_ldoh_cookie": "read at use time by handler/admin/monitor.go",
+	// Backup destination + resume cursor, read at use time by the scheduler.
+	"backup_webdav_config_v1": "read at use time by scheduler/backup_webdav.go",
+	"backup_webdav_state_v1":  "read at use time by scheduler/backup_webdav.go",
+	// Read at use time by the daily-summary scheduler.
+	"daily_summary_cron": "read at use time by scheduler/daily_summary.go",
+	// Removed setting (Wave 8 Lane D): it was stored but never rendered.
+	// Legacy rows are intentionally ignored, and listed here so they do not
+	// trip the unknown-key warning on every boot.
+	"home_page_content": "setting removed; legacy rows intentionally ignored",
+}
+
+// unknownKeyLogLimit bounds the aggregated unknown-key warning so a database
+// carrying many legacy rows cannot produce an unbounded log line.
+const unknownKeyLogLimit = 20
+
 // ApplyRuntimeSettings applies DB-backed settings overrides to the config.
 // Each known key overrides the corresponding config field.
 
 // Mirrors TS runtime settings application logic. Settings stored in the
 // settings table are JSON-encoded; this function parses and applies them.
+// Numeric keys are clamped exactly like the env path in config.Load, so a
+// value persisted through the admin API cannot bypass a floor the same value
+// would hit when it arrives through env.
 func ApplyRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings, settingsMap map[string]string) {
+	var unknown []string
 	for key, rawValue := range settingsMap {
 		value := strings.TrimSpace(rawValue)
 		if value == "" {
+			// A NULL/absent row carries no operator intent. An explicit clear
+			// is the two-character JSON string `""`, which the per-key cases
+			// below decide on individually.
 			continue
 		}
 
 		switch key {
-		// Auth
+		// Auth. These keep their non-empty guard on purpose: a blank persisted
+		// value must never replace a credential that env (or an earlier
+		// rotation) already configured, or a restart would silently downgrade
+		// the deployment to the built-in default token. The branding keys
+		// below are the opposite case and do accept an explicit blank.
+		//
+		// The values are JSON-encoded like every other setting (the admin
+		// write path marshals them), so they must be decoded like every other
+		// string setting: reading the raw row used to rehydrate the token with
+		// its surrounding quotes, which made a token rotated through the admin
+		// API stop authenticating after the next restart.
 		case "auth_token":
-			if v := parseOptionalString(value); v != "" {
+			if v := parseJSONSettingString(value); v != "" {
 				rt.AuthToken = v
 			}
 		case "proxy_token":
-			if v := parseOptionalString(value); v != "" {
+			if v := parseJSONSettingString(value); v != "" {
 				rt.ProxyToken = v
 			}
 		case "account_credential_secret":
-			if v := parseOptionalString(value); v != "" {
+			if v := parseJSONSettingString(value); v != "" {
 				cfg.AccountCredentialSecret = v
 			}
 
 		// Server
 		case "port":
 			cfg.Port = parseInt(value, cfg.Port)
+
+		// Admin access control. An empty list means "every IP may reach the
+		// admin API", so an unparseable value must not wipe a persisted
+		// allowlist: that would silently re-open the control plane on restart.
+		case "admin_ip_allowlist":
+			if list, ok := parseStringListSetting(value); ok {
+				rt.AdminIpAllowlist = list
+			} else {
+				slog.Warn("settings: ignoring invalid admin_ip_allowlist value")
+			}
 
 		// Proxy retry/disable status-code range policy (P1-2): blank keeps
 		// the routing defaults (historical behavior).
@@ -114,9 +192,18 @@ func ApplyRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings, settin
 
 		// Checkin schedule
 		case "checkin_cron":
-			if v := parseJSONSettingString(value); v != "" {
+			// Validated like the env path (config.Validate rejects an
+			// unparseable CHECKIN_CRON): an invalid expression must keep the
+			// resolved default instead of becoming the scheduler's fallback.
+			if v := parseJSONSettingString(value); config.ValidateCronExpr(v) {
 				rt.CheckinCron = v
+			} else {
+				slog.Warn("settings: ignoring invalid checkin_cron value")
 			}
+		case "checkin_enabled":
+			// Persisted as the positive switch, published inverted (zero value
+			// = enabled), mirroring config.Load's CHECKIN_ENABLED handling.
+			rt.CheckinDisabled = !parseBoolSetting(value, !rt.CheckinDisabled)
 		case "checkin_schedule_mode":
 			switch strings.ToLower(parseJSONSettingString(value)) {
 			case "cron", "interval", "window":
@@ -137,29 +224,43 @@ func ApplyRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings, settin
 				rt.CheckinWindowEnd = v
 			}
 
-		// Site & Branding (empty values keep the embedded defaults)
+		// Periodic job schedules and kill switches. Each scheduler re-resolves
+		// its own keys from the settings table when it starts; hydrating them
+		// here keeps the published snapshot (and GET /api/settings/runtime)
+		// truthful before that happens, and gives the schedulers a valid
+		// fallback instead of an env value the operator already overrode.
+		case "balance_refresh_cron":
+			if v := parseJSONSettingString(value); config.ValidateCronExpr(v) {
+				rt.BalanceRefreshCron = v
+			} else {
+				slog.Warn("settings: ignoring invalid balance_refresh_cron value")
+			}
+		case "balance_refresh_enabled":
+			rt.BalanceRefreshDisabled = !parseBoolSetting(value, !rt.BalanceRefreshDisabled)
+		case "model_sync_cron":
+			if v := parseJSONSettingString(value); config.ValidateCronExpr(v) {
+				rt.ModelSyncCron = v
+			} else {
+				slog.Warn("settings: ignoring invalid model_sync_cron value")
+			}
+
+		// Site & Branding. An explicit blank is honored: the embedded defaults
+		// are empty strings and the admin write path persists whatever the
+		// operator typed (including ""), so dropping empty values here made a
+		// cleared site name/logo/footer/about/server address reappear as the
+		// env value after a restart — while clearing a webhook URL in the same
+		// form stuck. Both write paths now share one empty-value semantics.
 		case "system_name":
-			if v := parseJSONSettingString(value); v != "" {
-				rt.SystemName = v
-			}
+			rt.SystemName = parseJSONSettingString(value)
 		case "logo":
-			if v := parseJSONSettingString(value); v != "" {
-				rt.Logo = v
-			}
+			rt.Logo = parseJSONSettingString(value)
 		case "footer":
-			if v := parseJSONSettingString(value); v != "" {
-				rt.Footer = v
-			}
+			rt.Footer = parseJSONSettingString(value)
 		case "about":
-			if v := parseJSONSettingString(value); v != "" {
-				rt.About = v
-			}
-		// home_page_content was removed (Wave 8 Lane D): the setting was stored
-		// but never rendered. Legacy rows are intentionally ignored here.
+			rt.About = parseJSONSettingString(value)
 		case "server_address":
-			if v := parseJSONSettingString(value); v != "" {
-				rt.ServerAddress = v
-			}
+			rt.ServerAddress = parseJSONSettingString(value)
+
 		// Notify
 		case "webhook_url":
 			rt.WebhookUrl = parseJSONSettingString(value)
@@ -212,19 +313,80 @@ func ApplyRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings, settin
 		case "smtp_secure":
 			rt.SmtpSecure = parseBoolSetting(value, rt.SmtpSecure)
 
-		// Log cleanup
-		case "log_cleanup.usage_logs_enabled":
+		// Log cleanup. The admin write path persists the underscore keys; the
+		// dotted spellings are deprecated read-only aliases (see
+		// logCleanupExplicitKeys). Hydration used to read only the dotted
+		// spellings, which nothing ever wrote, so this whole block was dead
+		// code and persisted log-cleanup settings never reached the snapshot.
+		case "log_cleanup_cron":
+			if v := parseJSONSettingString(value); config.ValidateCronExpr(v) {
+				rt.LogCleanupCron = v
+			} else {
+				slog.Warn("settings: ignoring invalid log_cleanup_cron value")
+			}
+		case "log_cleanup_usage_logs_enabled", "log_cleanup.usage_logs_enabled":
 			rt.LogCleanupUsageLogsEnabled = parseBoolSetting(value, rt.LogCleanupUsageLogsEnabled)
-		case "log_cleanup.program_logs_enabled":
+		case "log_cleanup_program_logs_enabled", "log_cleanup.program_logs_enabled":
 			rt.LogCleanupProgramLogsEnabled = parseBoolSetting(value, rt.LogCleanupProgramLogsEnabled)
-		case "log_cleanup.retention_days":
-			rt.LogCleanupRetentionDays = config.MaxInt(1, parseInt(value, rt.LogCleanupRetentionDays))
+		case "log_cleanup_retention_days", "log_cleanup.retention_days":
+			// config.Load floors the env value at 1 day; the settings path
+			// must not be able to bypass that floor.
+			rt.LogCleanupRetentionDays = parseIntSetting(value, float64(rt.LogCleanupRetentionDays), 1)
 
 		// Proxy settings
 		case "proxy_max_channel_attempts":
 			cfg.ProxyMaxChannelAttempts = config.MaxInt(1, parseInt(value, cfg.ProxyMaxChannelAttempts))
-		case "proxy_debug_trace_enabled":
-			rt.ProxyDebugTraceEnabled = parseBoolSetting(value, rt.ProxyDebugTraceEnabled)
+		case "proxy_first_byte_timeout_sec":
+			// config.Load: max(0, trunc(n)); 0 disables the observed
+			// first-byte timeout.
+			rt.ProxyFirstByteTimeoutSec = parseIntSetting(value, float64(rt.ProxyFirstByteTimeoutSec), 0)
+		case "proxy_empty_content_fail_enabled":
+			rt.ProxyEmptyContentFailEnabled = parseBoolSetting(value, rt.ProxyEmptyContentFailEnabled)
+
+		// Proxy: token router. Same normalization as config.Load §3.14 — a
+		// non-finite or non-positive value keeps the env-resolved cap instead
+		// of silently disabling failure cooldowns.
+		case "token_router_failure_cooldown_max_sec":
+			if v, ok := config.NormalizeTokenRouterFailureCooldownMaxSec(parseNumberSetting(value, 0)); ok {
+				rt.TokenRouterFailureCooldownMaxSec = v
+			} else {
+				slog.Warn("settings: ignoring invalid token_router_failure_cooldown_max_sec value")
+			}
+
+		// Proxy: session channel limits (config.Load: max(0, trunc(n))).
+		case "proxy_session_channel_concurrency_limit":
+			rt.ProxySessionChannelConcurrencyLimit = parseIntSetting(value, float64(rt.ProxySessionChannelConcurrencyLimit), 0)
+		case "proxy_session_channel_queue_wait_ms":
+			rt.ProxySessionChannelQueueWaitMs = parseIntSetting(value, float64(rt.ProxySessionChannelQueueWaitMs), 0)
+
+		// Proxy: fallback policy toggles.
+		case "disable_cross_protocol_fallback":
+			rt.DisableCrossProtocolFallback = parseBoolSetting(value, rt.DisableCrossProtocolFallback)
+		case "responses_compact_fallback_to_responses_enabled":
+			rt.ResponsesCompactFallbackToResponsesEnabled = parseBoolSetting(value, rt.ResponsesCompactFallbackToResponsesEnabled)
+
+		// Routing cost model. config.Load floors the fallback unit cost at
+		// 1e-6 so an unpriced model can never route as free.
+		case "routing_fallback_unit_cost":
+			rt.RoutingFallbackUnitCost = math.Max(1e-6, parseNumberSetting(value, rt.RoutingFallbackUnitCost))
+		case "routing_weights":
+			// Persisted as a whole config.RoutingWeights object. Decode into a
+			// copy of the env-resolved weights so a partial or legacy row
+			// cannot zero the components it does not mention.
+			weights := rt.RoutingWeights
+			if err := json.Unmarshal([]byte(value), &weights); err != nil {
+				slog.Warn("settings: ignoring invalid routing_weights value")
+			} else {
+				rt.RoutingWeights = weights
+			}
+		// Failure-judgement keywords: an unparseable value must not wipe the
+		// persisted list, or upstream failures would stop being detected.
+		case "proxy_error_keywords":
+			if list, ok := parseStringListSetting(value); ok {
+				rt.ProxyErrorKeywords = list
+			} else {
+				slog.Warn("settings: ignoring invalid proxy_error_keywords value")
+			}
 
 		// Model probe
 		case "model_availability_probe_enabled":
@@ -233,6 +395,30 @@ func ApplyRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings, settin
 		// Codex
 		case "codex_upstream_websocket_enabled":
 			rt.CodexUpstreamWebsocketEnabled = parseBoolSetting(value, rt.CodexUpstreamWebsocketEnabled)
+
+		// Proxy: debug tracing. The master toggle was already hydrated but the
+		// capture/target/retention knobs it depends on were not, so a restart
+		// left tracing enabled with env-default capture rules.
+		case "proxy_debug_trace_enabled":
+			rt.ProxyDebugTraceEnabled = parseBoolSetting(value, rt.ProxyDebugTraceEnabled)
+		case "proxy_debug_capture_headers":
+			rt.ProxyDebugCaptureHeaders = parseBoolSetting(value, rt.ProxyDebugCaptureHeaders)
+		case "proxy_debug_capture_bodies":
+			rt.ProxyDebugCaptureBodies = parseBoolSetting(value, rt.ProxyDebugCaptureBodies)
+		case "proxy_debug_capture_stream_chunks":
+			rt.ProxyDebugCaptureStreamChunks = parseBoolSetting(value, rt.ProxyDebugCaptureStreamChunks)
+		case "proxy_debug_target_session_id":
+			rt.ProxyDebugTargetSessionId = parseJSONSettingString(value)
+		case "proxy_debug_target_client_kind":
+			rt.ProxyDebugTargetClientKind = parseJSONSettingString(value)
+		case "proxy_debug_target_model":
+			rt.ProxyDebugTargetModel = parseJSONSettingString(value)
+		case "proxy_debug_retention_hours":
+			// config.Load: max(1, trunc(n)).
+			rt.ProxyDebugRetentionHours = parseIntSetting(value, float64(rt.ProxyDebugRetentionHours), 1)
+		case "proxy_debug_max_body_bytes":
+			// config.Load: max(1024, trunc(n)).
+			rt.ProxyDebugMaxBodyBytes = parseIntSetting(value, float64(rt.ProxyDebugMaxBodyBytes), 1024)
 
 		// Generic JSON settings
 		case "global_blocked_brands":
@@ -303,10 +489,31 @@ func ApplyRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings, settin
 			}
 
 		default:
-			// Unknown setting — silently skip.
-			// Future: routing weights, admin_ip_allowlist, etc.
+			// Keys listed in nonHydratedSettingKeys are resolved by their own
+			// consumer; anything else that reached the table without a case
+			// above is a round-trip defect worth one aggregated warning.
+			if _, ok := nonHydratedSettingKeys[key]; !ok {
+				unknown = append(unknown, key)
+			}
 		}
 	}
+
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		slog.Warn("settings: persisted keys not applied at startup hydration",
+			"count", len(unknown),
+			"keys", strings.Join(truncateKeyList(unknown, unknownKeyLogLimit), ","))
+	}
+}
+
+// truncateKeyList caps a key list destined for a single log line, appending a
+// "+N more" marker when it had to cut entries.
+func truncateKeyList(keys []string, limit int) []string {
+	if len(keys) <= limit {
+		return keys
+	}
+	out := append([]string{}, keys[:limit]...)
+	return append(out, fmt.Sprintf("(+%d more)", len(keys)-limit))
 }
 
 // parseStringListSetting decodes a settings-table value into a trimmed,
@@ -404,6 +611,31 @@ func normalizeStringList(parts ...string) []string {
 	return out
 }
 
+// parseNumberSetting decodes a JSON number setting. The admin write path
+// marshals ints and floats with encoding/json, so values arrive as "30" or
+// "0.25". Unlike parseFloatSetting it keeps negative numbers, letting each
+// case apply the exact clamp config.Load uses for the matching env var instead
+// of silently substituting the fallback. Unparseable or non-finite values keep
+// the fallback.
+func parseNumberSetting(raw string, fallback float64) float64 {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return fallback
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
+		return fallback
+	}
+	return v
+}
+
+// parseIntSetting mirrors the "max(lo, trunc(n))" shape config.Load uses for
+// its integer settings, so a number persisted through the admin API is clamped
+// identically to the same number supplied through env.
+func parseIntSetting(raw string, fallback float64, lo int) int {
+	return config.MaxInt(lo, int(math.Trunc(parseNumberSetting(raw, fallback))))
+}
+
 // parseBoolSetting parses a boolean setting value.
 func parseBoolSetting(value string, fallback bool) bool {
 	normalized := strings.ToLower(strings.TrimSpace(value))
@@ -434,11 +666,6 @@ func parseFloatSetting(value string, fallback float64) float64 {
 
 func isNaNOrInf(v float64) bool {
 	return v != v || v > 1e308 || v < -1e308
-}
-
-// parseOptionalString returns the value if non-empty, empty string otherwise.
-func parseOptionalString(value string) string {
-	return strings.TrimSpace(value)
 }
 
 func parseJSONSettingString(value string) string {

--- a/store/settings_rehydration_gate_test.go
+++ b/store/settings_rehydration_gate_test.go
@@ -1,0 +1,415 @@
+package store
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Settings rehydration gate.
+//
+// A runtime setting is only real if it survives a restart: the admin API
+// persists it to the settings table, and the next boot must read it back into
+// the config snapshot the consumers use. When one half is missing the operator
+// sees a 200, sees the new value in GET /api/settings/runtime, and then loses
+// it on the next deploy/crash/OOM restart — with no log line to explain it.
+// The security-relevant instance of this defect was admin_ip_allowlist, which
+// fell back to the (empty = allow every IP) env value after a restart.
+//
+// Rules enforced here:
+//
+//	R1  every settings key the admin write side can persist must either have a
+//	    case in ApplyRuntimeSettings or be listed in nonHydratedSettingKeys
+//	    with a reason;
+//	R2  a key must not be both hydrated and allowlisted (a stale allowlist
+//	    entry hides the case that actually applies it);
+//	R3  every allowlist entry carries a non-empty reason.
+//
+// Both sides are extracted from source with go/parser (the house idiom: see
+// internal/httpclient/gate_test.go and docs/pg_rebind_gate_test.go), so the
+// lists cannot drift from the code they describe. When this test fails, add a
+// hydration case — do not relax the test, and only allowlist a key when its
+// consumer genuinely reads the settings table itself.
+
+// settingsGatePersistHelpers maps a write-side helper to the argument
+// positions that carry the settings key.
+var settingsGatePersistHelpers = map[string][]int{
+	"upsertSettingDB":         {1},
+	"upsertSettingTx":         {2},
+	"applyStringSettingDB":    {3},
+	"applyBoolSettingDB":      {3},
+	"persistDualSchedule":     {1, 3},
+	"saveBackupSettingString": {1},
+}
+
+// SQL-embedded key spellings, e.g. `WHERE key = 'auth_token'` and
+// `WHERE key IN ('db_type', 'db_url')`.
+var (
+	settingsGateSQLEq  = regexp.MustCompile(`key\s*=\s*'([a-zA-Z0-9_.]+)'`)
+	settingsGateSQLIn  = regexp.MustCompile(`key\s+IN\s*\(([^)]*)\)`)
+	settingsGateSQLLit = regexp.MustCompile(`'([a-zA-Z0-9_.]+)'`)
+)
+
+// settingsGateDir resolves a path relative to this test file, so the gate
+// works from any working directory (go test runs with cwd = package dir).
+func settingsGateDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Dir(thisFile)
+}
+
+// settingsGateStringConsts collects package-level `const name = "value"` and
+// `var name = "value"` bindings so a key passed as an identifier
+// (const ldohCookieSettingKey = "monitor_ldoh_cookie") still resolves.
+func settingsGateStringConsts(files []*ast.File) map[string]string {
+	out := map[string]string{}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || (gen.Tok != token.CONST && gen.Tok != token.VAR) {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok || len(vs.Names) != 1 || len(vs.Values) != 1 {
+					continue
+				}
+				if lit, ok := vs.Values[0].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+					if v, err := strconv.Unquote(lit.Value); err == nil {
+						out[vs.Names[0].Name] = v
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// settingsGateWriteKeys extracts every settings key the admin write side can
+// persist, from helper-call arguments and from keys embedded in SQL literals.
+func settingsGateWriteKeys(fset *token.FileSet, files []*ast.File) map[string]string {
+	consts := settingsGateStringConsts(files)
+	keys := map[string]string{} // key -> first file that persists it
+	add := func(pos token.Position, key string) {
+		if key == "" {
+			return
+		}
+		if _, seen := keys[key]; !seen {
+			keys[key] = fmt.Sprintf("%s:%d", settingsGateRel(pos.Filename), pos.Line)
+		}
+	}
+	literal := func(expr ast.Expr) (string, bool) {
+		switch node := expr.(type) {
+		case *ast.BasicLit:
+			if node.Kind != token.STRING {
+				return "", false
+			}
+			v, err := strconv.Unquote(node.Value)
+			return v, err == nil
+		case *ast.Ident:
+			v, ok := consts[node.Name]
+			return v, ok
+		}
+		return "", false
+	}
+
+	for _, file := range files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name := ""
+			switch fun := call.Fun.(type) {
+			case *ast.Ident:
+				name = fun.Name
+			case *ast.SelectorExpr:
+				name = fun.Sel.Name
+			}
+			if positions, ok := settingsGatePersistHelpers[name]; ok {
+				for _, idx := range positions {
+					if idx < len(call.Args) {
+						if key, ok := literal(call.Args[idx]); ok {
+							add(fset.Position(call.Args[idx].Pos()), key)
+						}
+					}
+				}
+			}
+			// Keys spelled inside SQL text (raw Exec/Get paths).
+			for _, arg := range call.Args {
+				lit, ok := arg.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				text, err := strconv.Unquote(lit.Value)
+				if err != nil || !strings.Contains(text, "settings") {
+					continue
+				}
+				pos := fset.Position(arg.Pos())
+				for _, m := range settingsGateSQLEq.FindAllStringSubmatch(text, -1) {
+					add(pos, m[1])
+				}
+				for _, group := range settingsGateSQLIn.FindAllStringSubmatch(text, -1) {
+					for _, m := range settingsGateSQLLit.FindAllStringSubmatch(group[1], -1) {
+						add(pos, m[1])
+					}
+				}
+			}
+			return true
+		})
+	}
+	return keys
+}
+
+// settingsGateRel trims the repository prefix from an absolute source path so
+// gate failures quote repo-relative file:line positions.
+func settingsGateRel(path string) string {
+	if idx := strings.Index(path, string(filepath.Separator)+"handler"+string(filepath.Separator)); idx >= 0 {
+		return path[idx+1:]
+	}
+	if idx := strings.Index(path, string(filepath.Separator)+"store"+string(filepath.Separator)); idx >= 0 {
+		return path[idx+1:]
+	}
+	return filepath.Base(path)
+}
+
+// settingsGateHydratedKeys extracts the settings keys ApplyRuntimeSettings
+// handles, i.e. the string literals in the case clauses of its `switch key`.
+// Nested switches (checkin_schedule_mode's "cron"/"interval"/"window") carry a
+// different tag and are therefore excluded.
+func settingsGateHydratedKeys(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, src, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	keys := map[string]bool{}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "ApplyRuntimeSettings" {
+			continue
+		}
+		ast.Inspect(fn, func(n ast.Node) bool {
+			sw, ok := n.(*ast.SwitchStmt)
+			if !ok {
+				return true
+			}
+			tag, ok := sw.Tag.(*ast.Ident)
+			if !ok || tag.Name != "key" {
+				return true
+			}
+			for _, stmt := range sw.Body.List {
+				clause, ok := stmt.(*ast.CaseClause)
+				if !ok {
+					continue
+				}
+				for _, expr := range clause.List {
+					lit, ok := expr.(*ast.BasicLit)
+					if !ok || lit.Kind != token.STRING {
+						continue
+					}
+					if v, err := strconv.Unquote(lit.Value); err == nil {
+						keys[v] = true
+					}
+				}
+			}
+			return false
+		})
+	}
+	return keys
+}
+
+func TestSettingsRehydrationGateCoversEveryAdminWritableKey(t *testing.T) {
+	dir := settingsGateDir(t)
+	adminDir := filepath.Join(dir, "..", "handler", "admin")
+	entries, err := os.ReadDir(adminDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", adminDir, err)
+	}
+	fset := token.NewFileSet()
+	var files []*ast.File
+	parsed := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(adminDir, name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		files = append(files, file)
+		parsed++
+	}
+	if parsed == 0 {
+		t.Fatalf("gate parsed no files; admin dir resolution is broken (%s)", adminDir)
+	}
+
+	writeKeys := settingsGateWriteKeys(fset, files)
+	hydrated := settingsGateHydratedKeys(t, filepath.Join(dir, "settings.go"))
+	if len(writeKeys) == 0 {
+		t.Fatal("write-side extractor found no settings keys; the matcher is broken")
+	}
+	for _, probe := range []string{"system_name", "proxy_token"} {
+		if _, ok := writeKeys[probe]; !ok {
+			t.Fatalf("write-side extractor missed %q; the matcher is broken", probe)
+		}
+	}
+	if len(hydrated) == 0 {
+		t.Fatal("hydration-side extractor found no case keys; the matcher is broken")
+	}
+	for _, probe := range []string{"system_name", "admin_ip_allowlist"} {
+		if !hydrated[probe] {
+			t.Fatalf("hydration-side extractor missed %q; the matcher is broken", probe)
+		}
+	}
+
+	var missing, both []string
+	for key := range writeKeys {
+		if hydrated[key] {
+			if _, allowlisted := nonHydratedSettingKeys[key]; allowlisted {
+				both = append(both, key)
+			}
+			continue
+		}
+		if _, allowlisted := nonHydratedSettingKeys[key]; !allowlisted {
+			missing = append(missing, fmt.Sprintf("%s (persisted at %s)", key, writeKeys[key]))
+		}
+	}
+	for key, reason := range nonHydratedSettingKeys {
+		if strings.TrimSpace(reason) == "" {
+			missing = append(missing, fmt.Sprintf("%s (allowlisted without a reason)", key))
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(both)
+
+	if len(both) > 0 {
+		t.Errorf("R2: keys both hydrated and allowlisted — drop the stale allowlist entry: %s",
+			strings.Join(both, ", "))
+	}
+	if len(missing) > 0 {
+		t.Fatalf("R1/R3: settings the admin API persists but startup hydration never reads back "+
+			"(the operator's change is lost on the next restart):\n  %s\n"+
+			"Fix: add a case to ApplyRuntimeSettings (clamped exactly like config.Load), or — only if the "+
+			"consumer really reads the settings table itself — list the key in nonHydratedSettingKeys with a reason.",
+			strings.Join(missing, "\n  "))
+	}
+}
+
+// TestSettingsRehydrationGateMatcherSanity locks the extractor behaviour with
+// counter-examples, so a refactor of the write side cannot silently empty the
+// key set and turn the gate above into a no-op.
+func TestSettingsRehydrationGateMatcherSanity(t *testing.T) {
+	src := `package admin
+
+const someKeyConst = "monitor_ldoh_cookie"
+
+func examples(db *sqlx.DB, body map[string]any) {
+	upsertSettingDB(db, "admin_ip_allowlist", nil)
+	upsertSettingTx(db, tx, "checkin_cron", "0 8 * * *")
+	applyStringSettingDB(db, body, "systemName", "system_name", nil)
+	applyBoolSettingDB(db, body, "webhookEnabled", "webhook_enabled", nil)
+	persistDualSchedule(db, "log_cleanup_cron", cron, "log_cleanup_schedule_v2", spec)
+	saveBackupSettingString(db, someKeyConst, data)
+	db.Exec(db.Rebind("UPDATE settings SET value = ? WHERE key = 'auth_token'"), v)
+	db.Query("SELECT key, value FROM settings WHERE key IN ('db_type', 'db_url')")
+	// Not a settings write: must not be collected.
+	upsertSettingDB(db, dynamicKey, nil)
+	notify("log_cleanup_retention_days is not persisted here")
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "examples.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse counter-example source: %v", err)
+	}
+	got := settingsGateWriteKeys(fset, []*ast.File{file})
+	want := []string{
+		"admin_ip_allowlist", "auth_token", "checkin_cron", "db_type", "db_url",
+		"log_cleanup_cron", "log_cleanup_schedule_v2", "monitor_ldoh_cookie",
+		"system_name", "webhook_enabled",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("extractor returned %d keys (%v), want %d (%v)", len(got), sortedKeys(got), len(want), want)
+	}
+	for _, key := range want {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("extractor missed %q (got %v)", key, sortedKeys(got))
+		}
+	}
+
+	hydrateSrc := `package store
+
+func ApplyRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings, settingsMap map[string]string) {
+	for key, value := range settingsMap {
+		switch key {
+		case "system_name":
+			rt.SystemName = value
+		case "log_cleanup_retention_days", "log_cleanup.retention_days":
+			rt.LogCleanupRetentionDays = 1
+		case "checkin_schedule_mode":
+			switch value {
+			case "cron", "interval":
+				rt.CheckinScheduleMode = value
+			}
+		}
+	}
+}
+`
+	hydratePath := filepath.Join(t.TempDir(), "settings.go")
+	if err := os.WriteFile(hydratePath, []byte(hydrateSrc), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	gotHydrated := settingsGateHydratedKeys(t, hydratePath)
+	wantHydrated := []string{"system_name", "log_cleanup_retention_days", "log_cleanup.retention_days", "checkin_schedule_mode"}
+	if len(gotHydrated) != len(wantHydrated) {
+		t.Fatalf("hydration extractor returned %v, want %v", sortedSet(gotHydrated), wantHydrated)
+	}
+	for _, key := range wantHydrated {
+		if !gotHydrated[key] {
+			t.Fatalf("hydration extractor missed %q (got %v)", key, sortedSet(gotHydrated))
+		}
+	}
+	// The nested switch's value literals are not settings keys.
+	for _, notAKey := range []string{"cron", "interval"} {
+		if gotHydrated[notAKey] {
+			t.Fatalf("hydration extractor collected %q from a nested switch", notAKey)
+		}
+	}
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedSet(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/store/settings_roundtrip_test.go
+++ b/store/settings_roundtrip_test.go
@@ -409,11 +409,35 @@ func TestApplyRuntimeSettingsClampsMatchConfigLoad(t *testing.T) {
 
 // ---- Unknown keys are reported, not silently skipped ----
 
-func TestApplyRuntimeSettingsWarnsAboutKeysNothingReadsBack(t *testing.T) {
+// captureSettingsLogs routes slog output into a buffer for the duration of the
+// test so a startup log line can be asserted on instead of eyeballed.
+func captureSettingsLogs(t *testing.T, level slog.Level) *bytes.Buffer {
+	t.Helper()
 	var buf bytes.Buffer
 	previous := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: level})))
 	t.Cleanup(func() { slog.SetDefault(previous) })
+	return &buf
+}
+
+// settingsLogLine returns the single line carrying msg, failing when the count
+// is not exactly one (a duplicated or missing startup line is the defect).
+func settingsLogLine(t *testing.T, output, msg string) string {
+	t.Helper()
+	var matches []string
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, msg) {
+			matches = append(matches, line)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one %q line, got %d in:\n%s", msg, len(matches), output)
+	}
+	return matches[0]
+}
+
+func TestApplyRuntimeSettingsWarnsAboutKeysNothingReadsBack(t *testing.T) {
+	buf := captureSettingsLogs(t, slog.LevelWarn)
 
 	ApplyRuntimeSettings(&config.Config{}, &config.RuntimeSettings{}, map[string]string{
 		"zeta_unknown":      `1`,
@@ -423,10 +447,8 @@ func TestApplyRuntimeSettingsWarnsAboutKeysNothingReadsBack(t *testing.T) {
 	})
 
 	out := buf.String()
-	if got := strings.Count(out, "persisted keys not applied at startup hydration"); got != 1 {
-		t.Fatalf("expected exactly one aggregated warning, got %d in:\n%s", got, out)
-	}
-	if !strings.Contains(out, "count=2") {
+	line := settingsLogLine(t, out, "persisted keys not applied at startup hydration")
+	if !strings.Contains(line, "count=2") {
 		t.Errorf("warning does not report the key count:\n%s", out)
 	}
 	if !strings.Contains(out, "keys=alpha_unknown,zeta_unknown") {
@@ -491,34 +513,233 @@ func TestHasExplicitLogCleanupSettingsIgnoresUnrelatedKeys(t *testing.T) {
 // The reported defect end to end: LOG_CLEANUP_*_ENABLED=false in env used to be
 // flipped to true at boot as soon as the settings table held any row at all,
 // because "configured" was inferred from retention > 0 and config.Load floors
-// retention at 1 day.
+// retention at 1 day. An explicit false and an unset variable are the same
+// case: neither asks for the regime, so the legacy pruner keeps proxy_logs.
 func TestLoadRuntimeSettingsKeepsEnvDisabledLogCleanup(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+	}{
+		{
+			name: "explicit false",
+			env: map[string]string{
+				"LOG_CLEANUP_USAGE_LOGS_ENABLED":   "false",
+				"LOG_CLEANUP_PROGRAM_LOGS_ENABLED": "false",
+			},
+		},
+		{name: "unset", env: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			settings := hydrateTestDB(t)
+			if err := settings.Set("system_name", `"Ops Gateway"`); err != nil {
+				t.Fatalf("persist unrelated setting: %v", err)
+			}
+
+			env := map[string]string{"SYSTEM_NAME": "Metapi"}
+			for key, value := range tc.env {
+				env[key] = value
+			}
+			cfg, rt := config.Load(quietSecretEnv(env))
+			if rt.LogCleanupUsageLogsEnabled || rt.LogCleanupProgramLogsEnabled {
+				t.Fatal("precondition failed: env already enabled log cleanup")
+			}
+			if err := LoadRuntimeSettings(cfg, rt); err != nil {
+				t.Fatalf("LoadRuntimeSettings: %v", err)
+			}
+
+			if rt.LogCleanupUsageLogsEnabled || rt.LogCleanupProgramLogsEnabled {
+				t.Fatalf("boot flipped a disabled toggle to true (usage=%v program=%v)",
+					rt.LogCleanupUsageLogsEnabled, rt.LogCleanupProgramLogsEnabled)
+			}
+			if cfg.LogCleanupConfigured {
+				t.Fatal("an unrelated setting switched the log retention regime (LogCleanupConfigured = true)")
+			}
+			if rt.SystemName != "Ops Gateway" {
+				t.Fatalf("SystemName = %q, want the persisted value", rt.SystemName)
+			}
+		})
+	}
+}
+
+// The mirror case: an env-driven deployment has no admin-saved log-cleanup
+// rows, and its explicit true must still claim the regime — otherwise the
+// cleanup job skips every run ("legacy fallback mode active") and the legacy
+// pruner is disabled by nothing, so the documented env toggle does nothing.
+func TestLoadRuntimeSettingsEnvToggleClaimsRegimeWithoutAdminRows(t *testing.T) {
+	cases := []struct {
+		name       string
+		env        map[string]string
+		wantUsage  bool
+		wantProg   bool
+		wantSource string
+	}{
+		{
+			name:       "usage toggle",
+			env:        map[string]string{"LOG_CLEANUP_USAGE_LOGS_ENABLED": "true"},
+			wantUsage:  true,
+			wantProg:   false,
+			wantSource: "env_toggle",
+		},
+		{
+			name:       "program toggle",
+			env:        map[string]string{"LOG_CLEANUP_PROGRAM_LOGS_ENABLED": "true"},
+			wantUsage:  false,
+			wantProg:   true,
+			wantSource: "env_toggle",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logs := captureSettingsLogs(t, slog.LevelInfo)
+			settings := hydrateTestDB(t)
+			// Only unrelated rows: nothing in the table mentions log cleanup.
+			if err := settings.Set("system_name", `"Ops Gateway"`); err != nil {
+				t.Fatalf("persist unrelated setting: %v", err)
+			}
+
+			cfg, rt := config.Load(quietSecretEnv(tc.env))
+			if err := LoadRuntimeSettings(cfg, rt); err != nil {
+				t.Fatalf("LoadRuntimeSettings: %v", err)
+			}
+
+			if !cfg.LogCleanupConfigured {
+				t.Fatal("LogCleanupConfigured = false, want the env toggle to claim the regime")
+			}
+			if !cfg.LogCleanupEnvEnabled {
+				t.Fatal("LogCleanupEnvEnabled = false, want the explicit env true recorded")
+			}
+			if rt.LogCleanupUsageLogsEnabled != tc.wantUsage || rt.LogCleanupProgramLogsEnabled != tc.wantProg {
+				t.Fatalf("toggles = (%v, %v), want (%v, %v) — hydration must not drop the env intent",
+					rt.LogCleanupUsageLogsEnabled, rt.LogCleanupProgramLogsEnabled, tc.wantUsage, tc.wantProg)
+			}
+			line := settingsLogLine(t, logs.String(), "settings: log retention regime")
+			if !strings.Contains(line, "source="+tc.wantSource) {
+				t.Errorf("regime line does not report source=%s:\n%s", tc.wantSource, line)
+			}
+		})
+	}
+}
+
+// Admin-saved settings keep precedence for the values: env can claim the
+// regime, but a persisted false is what the operator last said, so the cleanup
+// job runs and skips for want of a target instead of pruning against env.
+func TestLoadRuntimeSettingsDbExplicitWinsOverEnvToggle(t *testing.T) {
+	settings := hydrateTestDB(t)
+	if err := settings.Set("log_cleanup_usage_logs_enabled", "false"); err != nil {
+		t.Fatalf("persist log cleanup toggle: %v", err)
+	}
+	if err := settings.Set("log_cleanup_retention_days", "9"); err != nil {
+		t.Fatalf("persist log cleanup retention: %v", err)
+	}
+
+	cfg, rt := config.Load(quietSecretEnv(map[string]string{
+		"LOG_CLEANUP_USAGE_LOGS_ENABLED": "true",
+		"LOG_CLEANUP_RETENTION_DAYS":     "30",
+	}))
+	if err := LoadRuntimeSettings(cfg, rt); err != nil {
+		t.Fatalf("LoadRuntimeSettings: %v", err)
+	}
+
+	if !cfg.LogCleanupConfigured {
+		t.Error("LogCleanupConfigured = false, want true (both env and DB claim the regime)")
+	}
+	if rt.LogCleanupUsageLogsEnabled {
+		t.Error("LogCleanupUsageLogsEnabled = true, want the persisted false to win over env")
+	}
+	if rt.LogCleanupRetentionDays != 9 {
+		t.Errorf("LogCleanupRetentionDays = %d, want the persisted 9", rt.LogCleanupRetentionDays)
+	}
+}
+
+// Retention and cron alone are not intent: the toggles default to false, so
+// "configured" would mean the new scheduler runs, skips for want of a target,
+// and the legacy PROXY_LOG_RETENTION_DAYS pruner is disabled — nothing would
+// ever be pruned.
+func TestLoadRuntimeSettingsEnvRetentionAloneDoesNotClaimRegime(t *testing.T) {
 	settings := hydrateTestDB(t)
 	if err := settings.Set("system_name", `"Ops Gateway"`); err != nil {
 		t.Fatalf("persist unrelated setting: %v", err)
 	}
 
 	cfg, rt := config.Load(quietSecretEnv(map[string]string{
-		"SYSTEM_NAME":                      "Metapi",
-		"LOG_CLEANUP_USAGE_LOGS_ENABLED":   "false",
-		"LOG_CLEANUP_PROGRAM_LOGS_ENABLED": "false",
+		"LOG_CLEANUP_RETENTION_DAYS": "7",
+		"LOG_CLEANUP_CRON":           "30 4 * * *",
 	}))
-	if rt.LogCleanupUsageLogsEnabled || rt.LogCleanupProgramLogsEnabled {
-		t.Fatal("precondition failed: env already enabled log cleanup")
+	if cfg.LogCleanupEnvEnabled {
+		t.Fatal("LogCleanupEnvEnabled = true for retention/cron only")
 	}
 	if err := LoadRuntimeSettings(cfg, rt); err != nil {
 		t.Fatalf("LoadRuntimeSettings: %v", err)
 	}
-
-	if rt.LogCleanupUsageLogsEnabled || rt.LogCleanupProgramLogsEnabled {
-		t.Fatalf("boot flipped an explicit env false to true (usage=%v program=%v)",
-			rt.LogCleanupUsageLogsEnabled, rt.LogCleanupProgramLogsEnabled)
-	}
 	if cfg.LogCleanupConfigured {
-		t.Fatal("an unrelated setting switched the log retention regime (LogCleanupConfigured = true)")
+		t.Fatal("LogCleanupConfigured = true, want retention/cron alone to leave the legacy pruner in charge")
 	}
-	if rt.SystemName != "Ops Gateway" {
-		t.Fatalf("SystemName = %q, want the persisted value", rt.SystemName)
+	if rt.LogCleanupRetentionDays != 7 || rt.LogCleanupCron != "30 4 * * *" {
+		t.Fatalf("retention/cron = (%d, %q), want the env values carried through",
+			rt.LogCleanupRetentionDays, rt.LogCleanupCron)
+	}
+}
+
+// Exactly one startup line names the winning regime, so an operator upgrading
+// past the removed auto-enable inference can see what now owns the log tables.
+func TestLoadRuntimeSettingsLogsTheWinningLogRetentionRegime(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		rows map[string]string
+		want []string
+	}{
+		{
+			name: "admin-saved settings",
+			rows: map[string]string{
+				"log_cleanup_usage_logs_enabled": "true",
+				"log_cleanup_retention_days":     "9",
+				"log_cleanup_cron":               `"30 4 * * *"`,
+			},
+			want: []string{
+				"regime=log_cleanup", "configured=true", "source=db_settings",
+				"usage_logs_enabled=true", "program_logs_enabled=false", "retention_days=9",
+			},
+		},
+		{
+			name: "env toggle",
+			env:  map[string]string{"LOG_CLEANUP_PROGRAM_LOGS_ENABLED": "true"},
+			rows: map[string]string{"system_name": `"Ops Gateway"`},
+			want: []string{
+				"regime=log_cleanup", "configured=true", "source=env_toggle",
+				"usage_logs_enabled=false", "program_logs_enabled=true",
+			},
+		},
+		{
+			name: "no intent anywhere",
+			rows: map[string]string{"system_name": `"Ops Gateway"`},
+			want: []string{
+				"regime=legacy_fallback", "configured=false", "source=none",
+				"usage_logs_enabled=false", "program_logs_enabled=false", "retention_days=30",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logs := captureSettingsLogs(t, slog.LevelInfo)
+			settings := hydrateTestDB(t)
+			for key, value := range tc.rows {
+				if err := settings.Set(key, value); err != nil {
+					t.Fatalf("persist %s: %v", key, err)
+				}
+			}
+			cfg, rt := config.Load(quietSecretEnv(tc.env))
+			if err := LoadRuntimeSettings(cfg, rt); err != nil {
+				t.Fatalf("LoadRuntimeSettings: %v", err)
+			}
+			line := settingsLogLine(t, logs.String(), "settings: log retention regime")
+			for _, want := range tc.want {
+				if !strings.Contains(line, want) {
+					t.Errorf("regime line is missing %q:\n%s", want, line)
+				}
+			}
+		})
 	}
 }
 

--- a/store/settings_roundtrip_test.go
+++ b/store/settings_roundtrip_test.go
@@ -1,0 +1,679 @@
+package store
+
+import (
+	"bytes"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+)
+
+// Settings round-trip tests: what the admin API persists must come back out of
+// startup hydration with the same meaning, clamped exactly like the same value
+// would be clamped when it arrives through env. The key-coverage half of this
+// contract lives in settings_rehydration_gate_test.go.
+
+// hydrateTestDB publishes a fresh in-memory SQLite DB as the process-wide
+// store DB so LoadRuntimeSettings (which reads through GetDB) can be exercised
+// end to end. The singleton is package-private, so these tests must not run in
+// parallel with each other.
+func hydrateTestDB(t *testing.T) *SettingsStore {
+	t.Helper()
+	db, err := Open(DialectSQLite, ":memory:", false)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	if err := AutoMigrate(db); err != nil {
+		db.Close()
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+	previous := activeDB.Swap(db)
+	t.Cleanup(func() {
+		activeDB.Store(previous)
+		db.Close()
+	})
+	return NewSettingsStore(db)
+}
+
+// quietSecretEnv keeps config.Load from emitting its "insecure default
+// credential secret" warning on every call; the secret is unrelated to the
+// round-trip behavior under test.
+func quietSecretEnv(extra map[string]string) map[string]string {
+	env := map[string]string{"ACCOUNT_CREDENTIAL_SECRET": "round-trip-test-secret"}
+	for key, value := range extra {
+		env[key] = value
+	}
+	return env
+}
+
+// ---- Startup hydration: keys that used to be persisted but never read back ----
+
+func TestApplyRuntimeSettingsHydratesAdminIpAllowlist(t *testing.T) {
+	rt := &config.RuntimeSettings{AdminIpAllowlist: []string{"203.0.113.9"}}
+	ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
+		"admin_ip_allowlist": `["203.0.113.7"," 198.51.100.9 ","203.0.113.7"]`,
+	})
+	want := []string{"203.0.113.7", "198.51.100.9"}
+	if !reflect.DeepEqual(rt.AdminIpAllowlist, want) {
+		t.Fatalf("AdminIpAllowlist = %#v, want %#v", rt.AdminIpAllowlist, want)
+	}
+}
+
+func TestApplyRuntimeSettingsAdminIpAllowlistExplicitEmptyClears(t *testing.T) {
+	rt := &config.RuntimeSettings{AdminIpAllowlist: []string{"203.0.113.7"}}
+	ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
+		"admin_ip_allowlist": `[]`,
+	})
+	if rt.AdminIpAllowlist == nil || len(rt.AdminIpAllowlist) != 0 {
+		t.Fatalf("AdminIpAllowlist = %#v, want empty non-nil slice", rt.AdminIpAllowlist)
+	}
+}
+
+// An unparseable row must never wipe a persisted allowlist: an empty list
+// means "every IP may reach the admin API".
+func TestApplyRuntimeSettingsAdminIpAllowlistInvalidDoesNotWipe(t *testing.T) {
+	rt := &config.RuntimeSettings{AdminIpAllowlist: []string{"203.0.113.7"}}
+	ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
+		"admin_ip_allowlist": `{"oops":true}`,
+	})
+	if !reflect.DeepEqual(rt.AdminIpAllowlist, []string{"203.0.113.7"}) {
+		t.Fatalf("invalid value wiped the allowlist: %#v", rt.AdminIpAllowlist)
+	}
+}
+
+func TestApplyRuntimeSettingsHydratesProxyErrorKeywords(t *testing.T) {
+	rt := &config.RuntimeSettings{}
+	ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
+		"proxy_error_keywords": `["rate limit","overloaded"]`,
+	})
+	want := []string{"rate limit", "overloaded"}
+	if !reflect.DeepEqual(rt.ProxyErrorKeywords, want) {
+		t.Fatalf("ProxyErrorKeywords = %#v, want %#v", rt.ProxyErrorKeywords, want)
+	}
+}
+
+func TestApplyRuntimeSettingsHydratesRoutingKeys(t *testing.T) {
+	rt := &config.RuntimeSettings{
+		RoutingFallbackUnitCost:          1,
+		TokenRouterFailureCooldownMaxSec: config.TokenRouterFailureCooldownMaxSecCeiling,
+		ProxyFirstByteTimeoutSec:         0,
+		RoutingWeights:                   config.RoutingWeights{BaseWeightFactor: 0.5, ValueScoreFactor: 0.5, CostWeight: 0.4, BalanceWeight: 0.3, UsageWeight: 0.3},
+	}
+	ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
+		"routing_fallback_unit_cost":            `0.25`,
+		"token_router_failure_cooldown_max_sec": `3600`,
+		"proxy_first_byte_timeout_sec":          `45`,
+		"routing_weights":                       `{"BaseWeightFactor":0.7,"CostWeight":0.2}`,
+	})
+	if rt.RoutingFallbackUnitCost != 0.25 {
+		t.Errorf("RoutingFallbackUnitCost = %v, want 0.25", rt.RoutingFallbackUnitCost)
+	}
+	if rt.TokenRouterFailureCooldownMaxSec != 3600 {
+		t.Errorf("TokenRouterFailureCooldownMaxSec = %d, want 3600", rt.TokenRouterFailureCooldownMaxSec)
+	}
+	if rt.ProxyFirstByteTimeoutSec != 45 {
+		t.Errorf("ProxyFirstByteTimeoutSec = %d, want 45", rt.ProxyFirstByteTimeoutSec)
+	}
+	// Weights are persisted as a whole object and merged into the
+	// env-resolved vector: components the row does not mention survive.
+	want := config.RoutingWeights{BaseWeightFactor: 0.7, ValueScoreFactor: 0.5, CostWeight: 0.2, BalanceWeight: 0.3, UsageWeight: 0.3}
+	if rt.RoutingWeights != want {
+		t.Errorf("RoutingWeights = %+v, want %+v", rt.RoutingWeights, want)
+	}
+}
+
+// A cooldown cap that config.Load would reject must keep the env-resolved cap
+// instead of silently disabling failure cooldowns.
+func TestApplyRuntimeSettingsRejectsInvalidCooldownCap(t *testing.T) {
+	for _, value := range []string{`-5`, `0`, `nonsense`} {
+		rt := &config.RuntimeSettings{TokenRouterFailureCooldownMaxSec: 900}
+		ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
+			"token_router_failure_cooldown_max_sec": value,
+		})
+		if rt.TokenRouterFailureCooldownMaxSec != 900 {
+			t.Errorf("value %s: TokenRouterFailureCooldownMaxSec = %d, want the env-resolved 900",
+				value, rt.TokenRouterFailureCooldownMaxSec)
+		}
+	}
+}
+
+func TestApplyRuntimeSettingsHydratesProxyPolicyToggles(t *testing.T) {
+	rt := &config.RuntimeSettings{}
+	ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
+		"disable_cross_protocol_fallback":                 `true`,
+		"responses_compact_fallback_to_responses_enabled": `true`,
+		"proxy_empty_content_fail_enabled":                `true`,
+		"proxy_session_channel_concurrency_limit":         `4`,
+		"proxy_session_channel_queue_wait_ms":             `2500`,
+	})
+	if !rt.DisableCrossProtocolFallback {
+		t.Error("DisableCrossProtocolFallback = false, want true")
+	}
+	if !rt.ResponsesCompactFallbackToResponsesEnabled {
+		t.Error("ResponsesCompactFallbackToResponsesEnabled = false, want true")
+	}
+	if !rt.ProxyEmptyContentFailEnabled {
+		t.Error("ProxyEmptyContentFailEnabled = false, want true")
+	}
+	if rt.ProxySessionChannelConcurrencyLimit != 4 {
+		t.Errorf("ProxySessionChannelConcurrencyLimit = %d, want 4", rt.ProxySessionChannelConcurrencyLimit)
+	}
+	if rt.ProxySessionChannelQueueWaitMs != 2500 {
+		t.Errorf("ProxySessionChannelQueueWaitMs = %d, want 2500", rt.ProxySessionChannelQueueWaitMs)
+	}
+}
+
+func TestApplyRuntimeSettingsHydratesProxyDebugKnobs(t *testing.T) {
+	rt := &config.RuntimeSettings{ProxyDebugCaptureHeaders: true}
+	ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
+		"proxy_debug_capture_headers":       `false`,
+		"proxy_debug_capture_bodies":        `true`,
+		"proxy_debug_capture_stream_chunks": `true`,
+		"proxy_debug_target_session_id":     `"sess-1"`,
+		"proxy_debug_target_client_kind":    `"codex"`,
+		"proxy_debug_target_model":          `"gpt-5"`,
+		"proxy_debug_retention_hours":       `12`,
+		"proxy_debug_max_body_bytes":        `4096`,
+	})
+	if rt.ProxyDebugCaptureHeaders {
+		t.Error("ProxyDebugCaptureHeaders = true, want false")
+	}
+	if !rt.ProxyDebugCaptureBodies || !rt.ProxyDebugCaptureStreamChunks {
+		t.Errorf("capture bodies/chunks = %v/%v, want true/true",
+			rt.ProxyDebugCaptureBodies, rt.ProxyDebugCaptureStreamChunks)
+	}
+	if rt.ProxyDebugTargetSessionId != "sess-1" || rt.ProxyDebugTargetClientKind != "codex" || rt.ProxyDebugTargetModel != "gpt-5" {
+		t.Errorf("debug targets = (%q, %q, %q), want (sess-1, codex, gpt-5)",
+			rt.ProxyDebugTargetSessionId, rt.ProxyDebugTargetClientKind, rt.ProxyDebugTargetModel)
+	}
+	if rt.ProxyDebugRetentionHours != 12 {
+		t.Errorf("ProxyDebugRetentionHours = %d, want 12", rt.ProxyDebugRetentionHours)
+	}
+	if rt.ProxyDebugMaxBodyBytes != 4096 {
+		t.Errorf("ProxyDebugMaxBodyBytes = %d, want 4096", rt.ProxyDebugMaxBodyBytes)
+	}
+}
+
+func TestApplyRuntimeSettingsHydratesSchedulerKillSwitches(t *testing.T) {
+	rt := &config.RuntimeSettings{
+		CheckinCron:        config.DefaultCheckinCron,
+		BalanceRefreshCron: config.DefaultBalanceRefreshCron,
+		ModelSyncCron:      config.DefaultModelSyncCron,
+		LogCleanupCron:     config.DefaultLogCleanupCron,
+	}
+	ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
+		"checkin_enabled":         `false`,
+		"balance_refresh_enabled": `false`,
+		"balance_refresh_cron":    `"15 3 * * *"`,
+		"model_sync_cron":         `"25 2 * * *"`,
+		"log_cleanup_cron":        `"30 4 * * *"`,
+	})
+	// Persisted as the positive switch, published inverted (zero value =
+	// enabled), exactly like config.Load's CHECKIN_ENABLED handling.
+	if !rt.CheckinDisabled {
+		t.Error("CheckinDisabled = false, want true after checkin_enabled=false")
+	}
+	if !rt.BalanceRefreshDisabled {
+		t.Error("BalanceRefreshDisabled = false, want true after balance_refresh_enabled=false")
+	}
+	if rt.BalanceRefreshCron != "15 3 * * *" || rt.ModelSyncCron != "25 2 * * *" || rt.LogCleanupCron != "30 4 * * *" {
+		t.Errorf("crons = (%q, %q, %q), want the persisted expressions",
+			rt.BalanceRefreshCron, rt.ModelSyncCron, rt.LogCleanupCron)
+	}
+}
+
+// An invalid cron must keep the resolved default: the schedulers use the
+// snapshot value as their fallback, so a bad row would otherwise take the
+// whole job down at Start.
+func TestApplyRuntimeSettingsRejectsInvalidCrons(t *testing.T) {
+	rt := &config.RuntimeSettings{
+		CheckinCron:        config.DefaultCheckinCron,
+		BalanceRefreshCron: config.DefaultBalanceRefreshCron,
+		ModelSyncCron:      config.DefaultModelSyncCron,
+		LogCleanupCron:     config.DefaultLogCleanupCron,
+	}
+	ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
+		"checkin_cron":         `"not a cron"`,
+		"balance_refresh_cron": `""`,
+		"model_sync_cron":      `"* * * * * * *"`,
+		"log_cleanup_cron":     `"61 0 * * *"`,
+	})
+	if rt.CheckinCron != config.DefaultCheckinCron {
+		t.Errorf("CheckinCron = %q, want the default %q", rt.CheckinCron, config.DefaultCheckinCron)
+	}
+	if rt.BalanceRefreshCron != config.DefaultBalanceRefreshCron {
+		t.Errorf("BalanceRefreshCron = %q, want the default %q", rt.BalanceRefreshCron, config.DefaultBalanceRefreshCron)
+	}
+	if rt.ModelSyncCron != config.DefaultModelSyncCron {
+		t.Errorf("ModelSyncCron = %q, want the default %q", rt.ModelSyncCron, config.DefaultModelSyncCron)
+	}
+	if rt.LogCleanupCron != config.DefaultLogCleanupCron {
+		t.Errorf("LogCleanupCron = %q, want the default %q", rt.LogCleanupCron, config.DefaultLogCleanupCron)
+	}
+}
+
+// ---- Startup hydration must clamp exactly like config.Load ----
+
+// TestApplyRuntimeSettingsClampsMatchConfigLoad feeds the same value through
+// both configuration paths — env into config.Load, and the JSON-encoded
+// settings row into ApplyRuntimeSettings — and requires identical results. A
+// settings-path shortcut around a clamp is how an operator ends up with two
+// different products depending on where a number was typed.
+func TestApplyRuntimeSettingsClampsMatchConfigLoad(t *testing.T) {
+	cases := []struct {
+		name     string
+		env      map[string]string
+		settings map[string]string
+		get      func(*config.Config, *config.RuntimeSettings) any
+	}{
+		{
+			name:     "first byte timeout floor",
+			env:      map[string]string{"PROXY_FIRST_BYTE_TIMEOUT_SEC": "-5"},
+			settings: map[string]string{"proxy_first_byte_timeout_sec": `-5`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.ProxyFirstByteTimeoutSec },
+		},
+		{
+			name:     "first byte timeout truncates",
+			env:      map[string]string{"PROXY_FIRST_BYTE_TIMEOUT_SEC": "45.9"},
+			settings: map[string]string{"proxy_first_byte_timeout_sec": `45.9`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.ProxyFirstByteTimeoutSec },
+		},
+		{
+			name:     "first byte timeout unparsable",
+			env:      map[string]string{"PROXY_FIRST_BYTE_TIMEOUT_SEC": "nonsense"},
+			settings: map[string]string{"proxy_first_byte_timeout_sec": `nonsense`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.ProxyFirstByteTimeoutSec },
+		},
+		{
+			name:     "log cleanup retention floor",
+			env:      map[string]string{"LOG_CLEANUP_RETENTION_DAYS": "0"},
+			settings: map[string]string{"log_cleanup_retention_days": `0`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.LogCleanupRetentionDays },
+		},
+		{
+			name:     "log cleanup retention truncates",
+			env:      map[string]string{"LOG_CLEANUP_RETENTION_DAYS": "45.9"},
+			settings: map[string]string{"log_cleanup_retention_days": `45.9`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.LogCleanupRetentionDays },
+		},
+		{
+			name:     "proxy debug retention floor",
+			env:      map[string]string{"PROXY_DEBUG_RETENTION_HOURS": "-3"},
+			settings: map[string]string{"proxy_debug_retention_hours": `-3`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.ProxyDebugRetentionHours },
+		},
+		{
+			name:     "proxy debug capture size floor",
+			env:      map[string]string{"PROXY_DEBUG_MAX_BODY_BYTES": "10"},
+			settings: map[string]string{"proxy_debug_max_body_bytes": `10`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.ProxyDebugMaxBodyBytes },
+		},
+		{
+			name:     "session concurrency floor",
+			env:      map[string]string{"PROXY_SESSION_CHANNEL_CONCURRENCY_LIMIT": "-3"},
+			settings: map[string]string{"proxy_session_channel_concurrency_limit": `-3`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.ProxySessionChannelConcurrencyLimit },
+		},
+		{
+			name:     "session queue wait floor",
+			env:      map[string]string{"PROXY_SESSION_CHANNEL_QUEUE_WAIT_MS": "-3"},
+			settings: map[string]string{"proxy_session_channel_queue_wait_ms": `-3`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.ProxySessionChannelQueueWaitMs },
+		},
+		{
+			name:     "fallback unit cost floor",
+			env:      map[string]string{"ROUTING_FALLBACK_UNIT_COST": "-1"},
+			settings: map[string]string{"routing_fallback_unit_cost": `-1`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.RoutingFallbackUnitCost },
+		},
+		{
+			name:     "cooldown cap rejects non-positive",
+			env:      map[string]string{"TOKEN_ROUTER_FAILURE_COOLDOWN_MAX_SEC": "-5"},
+			settings: map[string]string{"token_router_failure_cooldown_max_sec": `-5`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.TokenRouterFailureCooldownMaxSec },
+		},
+		{
+			name:     "cooldown cap ceiling",
+			env:      map[string]string{"TOKEN_ROUTER_FAILURE_COOLDOWN_MAX_SEC": "99999999"},
+			settings: map[string]string{"token_router_failure_cooldown_max_sec": `99999999`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.TokenRouterFailureCooldownMaxSec },
+		},
+		{
+			name:     "cooldown cap accepted",
+			env:      map[string]string{"TOKEN_ROUTER_FAILURE_COOLDOWN_MAX_SEC": "3600"},
+			settings: map[string]string{"token_router_failure_cooldown_max_sec": `3600`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.TokenRouterFailureCooldownMaxSec },
+		},
+		{
+			name:     "admin ip allowlist list shape",
+			env:      map[string]string{"ADMIN_IP_ALLOWLIST": "203.0.113.7, 198.51.100.9"},
+			settings: map[string]string{"admin_ip_allowlist": `["203.0.113.7","198.51.100.9"]`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.AdminIpAllowlist },
+		},
+		{
+			name:     "proxy error keywords list shape",
+			env:      map[string]string{"PROXY_ERROR_KEYWORDS": "rate limit,overloaded"},
+			settings: map[string]string{"proxy_error_keywords": `["rate limit","overloaded"]`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.ProxyErrorKeywords },
+		},
+		{
+			name: "routing weights vector",
+			env: map[string]string{
+				"BASE_WEIGHT_FACTOR": "0.7", "VALUE_SCORE_FACTOR": "0.11", "COST_WEIGHT": "0.22",
+				"BALANCE_WEIGHT": "0.33", "USAGE_WEIGHT": "0.44",
+			},
+			settings: map[string]string{"routing_weights": `{"BaseWeightFactor":0.7,"ValueScoreFactor":0.11,"CostWeight":0.22,"BalanceWeight":0.33,"UsageWeight":0.44}`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.RoutingWeights },
+		},
+		{
+			name:     "cross protocol fallback toggle",
+			env:      map[string]string{"DISABLE_CROSS_PROTOCOL_FALLBACK": "true"},
+			settings: map[string]string{"disable_cross_protocol_fallback": `true`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.DisableCrossProtocolFallback },
+		},
+		{
+			name:     "empty content fail toggle",
+			env:      map[string]string{"PROXY_EMPTY_CONTENT_FAIL": "true"},
+			settings: map[string]string{"proxy_empty_content_fail_enabled": `true`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.ProxyEmptyContentFailEnabled },
+		},
+		{
+			name:     "debug capture headers toggle",
+			env:      map[string]string{"PROXY_DEBUG_CAPTURE_HEADERS": "false"},
+			settings: map[string]string{"proxy_debug_capture_headers": `false`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.ProxyDebugCaptureHeaders },
+		},
+		{
+			name:     "debug target model trims",
+			env:      map[string]string{"PROXY_DEBUG_TARGET_MODEL": "  gpt-5  "},
+			settings: map[string]string{"proxy_debug_target_model": `"  gpt-5  "`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.ProxyDebugTargetModel },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			envCfg, envRt := config.Load(quietSecretEnv(tc.env))
+			setCfg, setRt := config.Load(quietSecretEnv(nil))
+			ApplyRuntimeSettings(setCfg, setRt, tc.settings)
+
+			want, got := tc.get(envCfg, envRt), tc.get(setCfg, setRt)
+			if !reflect.DeepEqual(want, got) {
+				t.Fatalf("env path resolved %#v but the settings path resolved %#v", want, got)
+			}
+		})
+	}
+}
+
+// ---- Unknown keys are reported, not silently skipped ----
+
+func TestApplyRuntimeSettingsWarnsAboutKeysNothingReadsBack(t *testing.T) {
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	ApplyRuntimeSettings(&config.Config{}, &config.RuntimeSettings{}, map[string]string{
+		"zeta_unknown":      `1`,
+		"alpha_unknown":     `2`,
+		"db_type":           `"postgres"`,   // allowlisted: resolved before hydration
+		"home_page_content": `"legacy row"`, // allowlisted: setting was removed
+	})
+
+	out := buf.String()
+	if got := strings.Count(out, "persisted keys not applied at startup hydration"); got != 1 {
+		t.Fatalf("expected exactly one aggregated warning, got %d in:\n%s", got, out)
+	}
+	if !strings.Contains(out, "count=2") {
+		t.Errorf("warning does not report the key count:\n%s", out)
+	}
+	if !strings.Contains(out, "keys=alpha_unknown,zeta_unknown") {
+		t.Errorf("warning does not list the unknown keys sorted:\n%s", out)
+	}
+	for _, allowlisted := range []string{"db_type", "home_page_content"} {
+		if strings.Contains(out, allowlisted) {
+			t.Errorf("allowlisted key %q must not be reported as unknown:\n%s", allowlisted, out)
+		}
+	}
+}
+
+func TestTruncateKeyListCapsLongLists(t *testing.T) {
+	keys := make([]string, 0, unknownKeyLogLimit+5)
+	for i := 0; i < unknownKeyLogLimit+5; i++ {
+		keys = append(keys, "key")
+	}
+	got := truncateKeyList(keys, unknownKeyLogLimit)
+	if len(got) != unknownKeyLogLimit+1 {
+		t.Fatalf("len = %d, want %d", len(got), unknownKeyLogLimit+1)
+	}
+	if got[len(got)-1] != "(+5 more)" {
+		t.Fatalf("marker = %q, want (+5 more)", got[len(got)-1])
+	}
+	if short := truncateKeyList([]string{"a", "b"}, unknownKeyLogLimit); len(short) != 2 {
+		t.Fatalf("short list changed: %#v", short)
+	}
+}
+
+// ---- Log cleanup: one key namespace, no inference over explicit intent ----
+
+func TestHasExplicitLogCleanupSettingsReadsTheKeysTheAdminApiWrites(t *testing.T) {
+	for _, key := range []string{
+		"log_cleanup_usage_logs_enabled",
+		"log_cleanup_program_logs_enabled",
+		"log_cleanup_retention_days",
+	} {
+		if !HasExplicitLogCleanupSettings(map[string]string{key: `false`}) {
+			t.Errorf("%s: HasExplicitLogCleanupSettings = false, want true", key)
+		}
+	}
+	// Deprecated dotted spellings still count during the compatibility window.
+	if !HasExplicitLogCleanupSettings(map[string]string{"log_cleanup.retention_days": `7`}) {
+		t.Error("dotted legacy key: HasExplicitLogCleanupSettings = false, want true")
+	}
+}
+
+// Saving an unrelated setting must not switch the log retention regime.
+func TestHasExplicitLogCleanupSettingsIgnoresUnrelatedKeys(t *testing.T) {
+	if HasExplicitLogCleanupSettings(map[string]string{
+		"system_name":         `"Ops Gateway"`,
+		"log_cleanup_cron":    `"30 4 * * *"`,
+		"monitor_ldoh_cookie": `"ld_auth_session=x"`,
+	}) {
+		t.Fatal("HasExplicitLogCleanupSettings = true for unrelated settings")
+	}
+	if HasExplicitLogCleanupSettings(map[string]string{}) {
+		t.Fatal("HasExplicitLogCleanupSettings = true for an empty settings table")
+	}
+}
+
+// The reported defect end to end: LOG_CLEANUP_*_ENABLED=false in env used to be
+// flipped to true at boot as soon as the settings table held any row at all,
+// because "configured" was inferred from retention > 0 and config.Load floors
+// retention at 1 day.
+func TestLoadRuntimeSettingsKeepsEnvDisabledLogCleanup(t *testing.T) {
+	settings := hydrateTestDB(t)
+	if err := settings.Set("system_name", `"Ops Gateway"`); err != nil {
+		t.Fatalf("persist unrelated setting: %v", err)
+	}
+
+	cfg, rt := config.Load(quietSecretEnv(map[string]string{
+		"SYSTEM_NAME":                      "Metapi",
+		"LOG_CLEANUP_USAGE_LOGS_ENABLED":   "false",
+		"LOG_CLEANUP_PROGRAM_LOGS_ENABLED": "false",
+	}))
+	if rt.LogCleanupUsageLogsEnabled || rt.LogCleanupProgramLogsEnabled {
+		t.Fatal("precondition failed: env already enabled log cleanup")
+	}
+	if err := LoadRuntimeSettings(cfg, rt); err != nil {
+		t.Fatalf("LoadRuntimeSettings: %v", err)
+	}
+
+	if rt.LogCleanupUsageLogsEnabled || rt.LogCleanupProgramLogsEnabled {
+		t.Fatalf("boot flipped an explicit env false to true (usage=%v program=%v)",
+			rt.LogCleanupUsageLogsEnabled, rt.LogCleanupProgramLogsEnabled)
+	}
+	if cfg.LogCleanupConfigured {
+		t.Fatal("an unrelated setting switched the log retention regime (LogCleanupConfigured = true)")
+	}
+	if rt.SystemName != "Ops Gateway" {
+		t.Fatalf("SystemName = %q, want the persisted value", rt.SystemName)
+	}
+}
+
+// The same boot path with the log-cleanup keys actually persisted: the values
+// win over env, and the log_cleanup regime owns retention.
+func TestLoadRuntimeSettingsHydratesPersistedLogCleanup(t *testing.T) {
+	settings := hydrateTestDB(t)
+	// Exactly the encoding handler/admin/settings_apply.go persists.
+	for key, value := range map[string]string{
+		"log_cleanup_usage_logs_enabled":   "true",
+		"log_cleanup_program_logs_enabled": "false",
+		"log_cleanup_retention_days":       "9",
+		"log_cleanup_cron":                 `"30 4 * * *"`,
+	} {
+		if err := settings.Set(key, value); err != nil {
+			t.Fatalf("persist %s: %v", key, err)
+		}
+	}
+
+	cfg, rt := config.Load(quietSecretEnv(map[string]string{
+		"LOG_CLEANUP_USAGE_LOGS_ENABLED": "false",
+		"LOG_CLEANUP_RETENTION_DAYS":     "30",
+		"LOG_CLEANUP_CRON":               "0 6 * * *",
+	}))
+	if err := LoadRuntimeSettings(cfg, rt); err != nil {
+		t.Fatalf("LoadRuntimeSettings: %v", err)
+	}
+
+	if !rt.LogCleanupUsageLogsEnabled {
+		t.Error("LogCleanupUsageLogsEnabled = false, want the persisted true")
+	}
+	if rt.LogCleanupProgramLogsEnabled {
+		t.Error("LogCleanupProgramLogsEnabled = true, want the persisted false")
+	}
+	if rt.LogCleanupRetentionDays != 9 {
+		t.Errorf("LogCleanupRetentionDays = %d, want 9", rt.LogCleanupRetentionDays)
+	}
+	if rt.LogCleanupCron != "30 4 * * *" {
+		t.Errorf("LogCleanupCron = %q, want the persisted cron", rt.LogCleanupCron)
+	}
+	if !cfg.LogCleanupConfigured {
+		t.Error("LogCleanupConfigured = false, want true once log cleanup is explicitly configured")
+	}
+}
+
+// ---- Empty-value semantics: one rule for both write paths ----
+
+// The reported defect end to end: clearing the branding in the admin UI stuck
+// until the next restart, which brought the env value back.
+func TestLoadRuntimeSettingsHonorsExplicitlyClearedBranding(t *testing.T) {
+	settings := hydrateTestDB(t)
+	for key, value := range map[string]string{
+		"system_name":    `""`,
+		"logo":           `""`,
+		"footer":         `""`,
+		"about":          `""`,
+		"server_address": `""`,
+	} {
+		if err := settings.Set(key, value); err != nil {
+			t.Fatalf("persist %s: %v", key, err)
+		}
+	}
+
+	cfg, rt := config.Load(quietSecretEnv(map[string]string{
+		"SYSTEM_NAME":    "Metapi",
+		"LOGO":           "https://cdn.example/env-logo.png",
+		"FOOTER":         "env footer",
+		"ABOUT":          "env about",
+		"SERVER_ADDRESS": "https://env.example.com",
+	}))
+	if err := LoadRuntimeSettings(cfg, rt); err != nil {
+		t.Fatalf("LoadRuntimeSettings: %v", err)
+	}
+
+	for name, got := range map[string]string{
+		"SystemName":    rt.SystemName,
+		"Logo":          rt.Logo,
+		"Footer":        rt.Footer,
+		"About":         rt.About,
+		"ServerAddress": rt.ServerAddress,
+	} {
+		if got != "" {
+			t.Errorf("%s = %q, want the explicitly cleared empty value", name, got)
+		}
+	}
+}
+
+// Credentials are the deliberate exception: a blank persisted value must not
+// replace a configured token, or a restart would silently downgrade the
+// deployment to the built-in default.
+func TestApplyRuntimeSettingsBlankCredentialsDoNotOverrideConfigured(t *testing.T) {
+	cfg := &config.Config{AccountCredentialSecret: "configured-secret"}
+	rt := &config.RuntimeSettings{AuthToken: "configured-auth-token", ProxyToken: "sk-configured"}
+	ApplyRuntimeSettings(cfg, rt, map[string]string{
+		"auth_token":                `""`,
+		"proxy_token":               `""`,
+		"account_credential_secret": `""`,
+	})
+	if rt.AuthToken != "configured-auth-token" {
+		t.Errorf("AuthToken = %q, want the configured token preserved", rt.AuthToken)
+	}
+	if rt.ProxyToken != "sk-configured" {
+		t.Errorf("ProxyToken = %q, want the configured token preserved", rt.ProxyToken)
+	}
+	if cfg.AccountCredentialSecret != "configured-secret" {
+		t.Errorf("AccountCredentialSecret = %q, want the configured secret preserved", cfg.AccountCredentialSecret)
+	}
+}
+
+// Settings rows are JSON-encoded, so a persisted token must be decoded like
+// every other string setting. Reading the raw row used to rehydrate the token
+// with its surrounding quotes, which broke admin/proxy auth after a restart
+// following a token rotation through the API.
+func TestApplyRuntimeSettingsDecodesPersistedCredentials(t *testing.T) {
+	cfg := &config.Config{}
+	rt := &config.RuntimeSettings{}
+	ApplyRuntimeSettings(cfg, rt, map[string]string{
+		"auth_token":                `"rotated-admin-token"`,
+		"proxy_token":               `"sk-rotated"`,
+		"account_credential_secret": `"rotated-secret"`,
+	})
+	if rt.AuthToken != "rotated-admin-token" {
+		t.Errorf("AuthToken = %q, want the decoded token", rt.AuthToken)
+	}
+	if rt.ProxyToken != "sk-rotated" {
+		t.Errorf("ProxyToken = %q, want the decoded token", rt.ProxyToken)
+	}
+	if cfg.AccountCredentialSecret != "rotated-secret" {
+		t.Errorf("AccountCredentialSecret = %q, want the decoded secret", cfg.AccountCredentialSecret)
+	}
+}
+
+// A legacy row written without JSON encoding still hydrates (the decoder falls
+// back to the raw value), so the fix above cannot strand existing databases.
+func TestApplyRuntimeSettingsAcceptsLegacyUnencodedCredentials(t *testing.T) {
+	rt := &config.RuntimeSettings{}
+	ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
+		"proxy_token": `sk-legacy-plain`,
+	})
+	if rt.ProxyToken != "sk-legacy-plain" {
+		t.Fatalf("ProxyToken = %q, want the legacy plain value", rt.ProxyToken)
+	}
+}
+
+// An empty settings table must leave the resolved config untouched.
+func TestLoadRuntimeSettingsEmptyTableIsANoOp(t *testing.T) {
+	hydrateTestDB(t)
+	cfg, rt := config.Load(quietSecretEnv(map[string]string{"SYSTEM_NAME": "Metapi"}))
+	if err := LoadRuntimeSettings(cfg, rt); err != nil {
+		t.Fatalf("LoadRuntimeSettings: %v", err)
+	}
+	if rt.SystemName != "Metapi" {
+		t.Errorf("SystemName = %q, want the env value", rt.SystemName)
+	}
+	if cfg.LogCleanupConfigured {
+		t.Error("LogCleanupConfigured = true for an empty settings table")
+	}
+}

--- a/store/settings_runtime_test.go
+++ b/store/settings_runtime_test.go
@@ -138,13 +138,29 @@ func TestApplyRuntimeSettingsAppliesBranding(t *testing.T) {
 	}
 }
 
-func TestApplyRuntimeSettingsIgnoresEmptyBranding(t *testing.T) {
+// An explicitly persisted blank is an operator decision (the admin write path
+// stores whatever was typed, including ""), not an absent value: dropping it
+// here made a cleared site name reappear as the env value after a restart.
+// Credentials are the deliberate exception and keep their non-empty guard —
+// see TestApplyRuntimeSettingsBlankCredentialsDoNotOverrideConfigured.
+func TestApplyRuntimeSettingsBrandingExplicitEmptyClears(t *testing.T) {
 	rt := &config.RuntimeSettings{SystemName: "keep"}
 	ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
 		"system_name": `""`,
 	})
+	if rt.SystemName != "" {
+		t.Fatalf("SystemName = %q, want the explicit clear honored", rt.SystemName)
+	}
+}
+
+// A NULL/absent row still means "no opinion" and must not clear anything.
+func TestApplyRuntimeSettingsNullRowKeepsBranding(t *testing.T) {
+	rt := &config.RuntimeSettings{SystemName: "keep"}
+	ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
+		"system_name": "",
+	})
 	if rt.SystemName != "keep" {
-		t.Fatalf("SystemName = %q, want preserved", rt.SystemName)
+		t.Fatalf("SystemName = %q, want preserved for an empty row", rt.SystemName)
 	}
 }
 


### PR DESCRIPTION
## 改动摘要

管理员在 UI 里改过的运行时设置，有一大批**重启后就静默回到 env 值**：写侧（`handler/admin`）把键持久化进 settings 表，读侧（`store.ApplyRuntimeSettings`）却没有对应的 `case`。实测 `fa195a97` 上写侧有 **33 个键没有水合分支**——补了 **27 个**，另外 6 个（`db_type`/`db_url`/`db_ssl` 在水合之前就被 bootstrap 消费，三个 `*_schedule_v2` 由迁移服务与排班端点自己读）进带理由的白名单。最贵的一条是 `admin_ip_allowlist`：重启后控制面 IP 限制消失、对全网重新开放。数值键一律复用 `config.Load` 同款钳制（`max(lo, trunc(n))`、`math.Max(1e-6,·)`、`NormalizeTokenRouterFailureCooldownMaxSec`——为此把该 helper 导出，签名不变），不再长第二份规则；`default:` 分支从「每键一行 warn」改为**一条聚合 warn**（排序 + 截断 20 个）。

顺带在同一批行里发现两个报告没列的缺陷：

- **凭据键读侧不解 JSON**：`auth_token` / `proxy_token` / `account_credential_secret` 写侧是 JSON 编码入库，读侧却只 `TrimSpace` → 重启后 token 带着引号进快照，常量时间比较必然失配。**通过管理 API 轮换过的 token，重启后即失效**。改用 `parseJSONSettingString`，非 JSON 的历史行仍按原样解码（只解一层，避免把合法含引号的凭据弄坏）。
- **`log_cleanup` 键命名空间分裂**：水合侧读点号拼写（`log_cleanup.enabled`），而写侧从来只写下划线拼写（`log_cleanup_enabled`）→ 整块是死码，持久化的日志清理设置永远到不了快照。统一到写侧拼写，点号保留为**只读兼容别名**（手改/外部导入的行仍可读），并注明弃用窗口。

**日志清理体制判定**（`LogCleanupConfigured` 决定「新 cleanup 调度器」还是「legacy `PROXY_LOG_RETENTION_DAYS` pruner」拥有日志表）原来是「`retention > 0` 且未曾配置就自动开启」；而 `config.Load` 把 retention 下限钉在 1 天，于是**只要 settings 表里有任意一行**（存过站点名也算）推断就会触发：静默把显式 `LOG_CLEANUP_*_ENABLED=false` 翻成 true，并顺手禁用 legacy pruner。现改为只认**显式意图**，且两个来源**故意不对称**：

```
LogCleanupConfigured = 存在 admin 保存的 log-cleanup 设置  ||  env 任一 toggle 显式为 true
```

env 可以把体制打开，但不能在关着的时候「认领」它——认领会禁用 legacy pruner，`proxy_logs` 就无人清理了。`LOG_CLEANUP_RETENTION_DAYS` / `LOG_CLEANUP_CRON` 单独不构成意图（两个 toggle 默认 false，"已配置"将意味着新调度器跑起来、因无目标而跳过、同时 legacy 已被禁用 = 什么都不清）；显式 `false` 也不构成意图（这正是当初阻止重启把已禁用部署翻回开启的那条）。值仍由 settings 表优先（hydration 先跑），env 只贡献体制位。启动时**恰好一条** `settings: log retention regime` 说明胜者（`regime` / `configured` / `source=db_settings|env_toggle|none` / 两个 toggle / retention 天数），因为那个静默推断已经删掉，升级的运维没有别的途径知道现在谁在清日志。

写侧另修两处被丢弃的持久化错误：`admin_ip_allowlist` 与 `proxy_error_keywords` 的 `upsertSettingDB` 失败原本返回 200——持久化失败的 allowlist 就是「重启后限制消失」的另一条路径，现与同函数内 `global_blocked_brands` / `global_allowed_models` 一致返回 500。

**空值语义**：branding 五键（`system_name`/`logo`/`footer`/`about`/`server_address`）去掉 `v != ""` 守卫——内嵌默认本就是空串、写侧存的就是运维输入的内容，丢弃空值会让「清空的站点名」重启后变回 env 值，而同一个表单里清空的 webhook URL 却能存住；三个凭据键**保留**守卫（空值不得覆盖已配置凭据，理由写进注释）。cron 类键从「非空即接受」改为 `config.ValidateCronExpr` 校验后接受（空/非法保留 env 默认 + warn），否则非法值会变成调度器的 fallback。

## 类型

- [x] fix（bug 修复）
- [x] docs / chore（`docs/configuration.md` 一行 + `.env.example` 四行注释同步真实规则）

## 测试验证

- [x] `go build ./...` 通过 · `go vet ./...`（全仓）通过 · `gofmt -l` 仅本次触碰的 8 个文件（历史基线漂移文件未碰）
- [x] `go test ./store/... ./config/... ./handler/... ./scheduler/... ./docs/... -count=1` 全绿，且 `PG_TEST_DSN` 指向真实 PG16（PG-gated 用例真跑非 skip）：store 18.3s · config 0.3s · handler/admin 47.7s · handler/proxy 5.0s · scheduler 20.6s · docs 2.2s
- [x] `go test ./docs -run TestPublicMarkdownHygiene -count=1` 通过（docs 表格/行长约定未破格）
- [x] **再水合门禁**（`store/settings_rehydration_gate_test.go`，AST 驱动）：扫 `handler/admin/*.go` 提取写侧键集（`upsertSettingDB/Tx`、`applyString|BoolSettingDB`、`persistDualSchedule`、`saveBackupSettingString` 的键位实参 + 包级 const 标识符解析 + settings SQL 文本里的 `key = '…'`/`key IN (…)`），扫 `store/settings.go` 的 `switch key` case 字面量作为水合侧键集，断言 **写侧 − 水合侧 − 白名单 = ∅**、同一键不得既水合又在白名单、白名单每项必须有非空理由；失败信息直接给出 `键名 (persisted at handler/admin/xxx.go:NNN)`。另有匹配器反例自证（嵌套 switch 的 `cron/interval` 不是设置键、非字面量 key 不收集、非 settings SQL 不收集）防止提取器空转把门禁变成 no-op。**负向对照已跑**：临时插入一个未水合的新写侧键 → 门禁立刻红并指出文件行号
- [x] **钳制一致性**：同一个值分别喂 `config.Load(env)` 与 `ApplyRuntimeSettings(settings 行)`，要求结果**逐字段相等**（20 个子用例：负数/0/小数/垃圾字符串/列表形状/权重向量/布尔/trim）
- [x] **写路径→模拟重启**（handler 级）：走真实 `PUT /api/settings/runtime` 写 28 个字段（含清空 branding、轮换 `proxyToken`），再用与所存值**故意不同**的 env 基线 `config.Load` 出新草稿、从 settings 表原样读回并 hydrate，逐字段 `reflect.DeepEqual` 比对「热快照 vs 重启后」，附三条防空跑断言。**负向对照已跑**：把 branding 守卫与 token 解码改回旧写法 → 该测试报 `SystemName saved "" rehydrated "Metapi"`、`ProxyToken saved "sk-…" rehydrated "\"sk-…\""`
- [x] **日志体制**：四种 env/DB 组合（env true + 只有无关行 / env true 对上 DB 显式 false（DB 值赢）/ env 显式 false 与未设 / 只有 retention+cron）+ 启动行「恰好一条、source 正确、字段齐全」+ config 侧意图位真值表（10 子用例，并断言 `Load` 绝不自己下结论）。**负向对照已跑**：去掉 `|| cfg.LogCleanupEnvEnabled` → 两条 env_toggle 用例立刻红
- 未触碰前端与 API 形状

## 有意的行为变更（请复核）

1. **日志清理不再「settings 表非空即自动开启」**。依赖旧推断的部署重启后新 cleanup 会停、回落到 legacy `PROXY_LOG_RETENTION_DAYS`（默认 30 天）体制；env 显式 `=true` 或 admin 保存过 log-cleanup 设置的部署不受影响。启动日志会明说胜者，`docs/configuration.md` 与 `.env.example` 已同步（原文案把默认值写作 `auto`，既不真实也一直含糊）。
2. **cron 键现在校验**：非法/空的 `checkin_cron`、`balance_refresh_cron`、`model_sync_cron`、`log_cleanup_cron` 不再写进快照（保留 env 默认 + warn）；旧行为会把非法值喂给调度器 fallback。
3. **branding 显式空串现在生效**（清空即清空）；凭据键的空值守卫保留。

## 自查清单

- [x] 无密钥/内部路径泄漏（gitleaks 会在 CI 检查）
- [x] 行为变更已补充/更新测试（含三组负向对照）
- [x] 需要时更新了 `docs/configuration.md` / `.env.example`；无需 CHANGELOG（随下一版汇总）
- [x] 未处理项已在下方列明，不混进本 PR

## 已知未处理（越界或需独立复核）

- `handler/admin/settings_apply.go` 仍有 **24 处** `upsertSettingDB` 丢弃错误（如 proxy_token、log_cleanup 三项、routing_weights、payload_rules）；每处修掉都会把 200 变 500，值得单独一条 commit 逐一复核（`.golangci.yml` 对 `handler/admin/**` 排除 errcheck，CI 不会催）
- `adminIpAllowlist` / `proxyErrorKeywords` 写侧**类型校验过松**：body 值不是数组或字符串时 `list` 保持 nil → 发布 nil 且持久化 `[]`（= 放行所有 IP），不像邻居 `globalBlockedBrands` 对 null 返回 400。属校验缺陷而非往返缺陷，未改
- 门禁只扫 `handler/admin` 包（写侧目前都集中在那里）；将来若在别的包写 settings，需要把扫描根扩到全仓
- `routing_weights` 按 `config.RoutingWeights` 的 PascalCase JSON 键解码（与写侧持久化格式一致）；若历史行是 camelCase 则不命中任何字段 → 保留 env 值（不崩、也不生效）。未给结构体加 json tag，因为那会改变写侧持久化格式
- 「接了水合 ≠ 有消费者」：被判为死配置的几个字段（`proxy_session_channel_queue_wait_ms`、`responses_compact_fallback_to_responses_enabled`、`payload_rules`、`global_blocked_brands` 等）现在能持久往返，但行为上仍无消费者，属另一条 backlog
