### PR TITLE
fix(proxy): report broken streams as failures, unify endpoint fallback

### DIFF
--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -497,7 +497,7 @@ func dispatchEndpointAttemptWithContinue(
 		slog.Warn("upstream request construction failed",
 			"err", err, "url", upstreamURL, "model", upstreamModel,
 			"request_id", requestID, "retry", retry)
-		if !isLastEndpoint && !disableCrossProtocolFallback {
+		if shouldContinueEndpointFallback(http.StatusBadGateway, err.Error(), isLastEndpoint, disableCrossProtocolFallback, endpointFailureTransport) {
 			return false, nil, true
 		}
 		if retry < maxRetries {
@@ -533,7 +533,7 @@ func dispatchEndpointAttemptWithContinue(
 				"request_id", requestID,
 				"retry", retry,
 			)
-			if !isLastEndpoint && !disableCrossProtocolFallback {
+			if shouldContinueEndpointFallback(http.StatusRequestTimeout, err.Error(), isLastEndpoint, disableCrossProtocolFallback, endpointFailureFirstByteTimeout) {
 				return false, nil, true
 			}
 			// Terminal for this channel attempt.
@@ -550,11 +550,14 @@ func dispatchEndpointAttemptWithContinue(
 		slog.Warn("upstream request failed",
 			"err", err, "url", upstreamURL, "model", upstreamModel,
 			"channel_id", selected.Channel.ID, "request_id", requestID, "retry", retry)
-		if !isLastEndpoint && !disableCrossProtocolFallback {
+		errText := err.Error()
+		// Transport-level failures go through the same single decision function
+		// (and therefore the same same-site abort policy) as HTTP/content
+		// failures; the historical bare check let them bypass the abort policy.
+		if shouldContinueEndpointFallback(http.StatusBadGateway, errText, isLastEndpoint, disableCrossProtocolFallback, endpointFailureTransport) {
 			// Network error may still be protocol-local; allow next endpoint without poison.
 			return false, nil, true
 		}
-		errText := err.Error()
 		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, 0, errText)
 		writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, http.StatusBadGateway, effectiveStream, ParsedUsage{Source: usageSourceUnknown}, retry, requestID, errText)
 		if retry < maxRetries {
@@ -574,10 +577,10 @@ func dispatchEndpointAttemptWithContinue(
 				slog.Warn("failed to read upstream stream error response",
 					"err", readErr, "latency_ms", latencyMs, "status", resp.StatusCode,
 					"request_id", requestID, "retry", retry)
-				if !isLastEndpoint && !disableCrossProtocolFallback {
+				errText := readErr.Error()
+				if shouldContinueEndpointFallback(http.StatusBadGateway, errText, isLastEndpoint, disableCrossProtocolFallback, endpointFailureTransport) {
 					return false, nil, true
 				}
-				errText := readErr.Error()
 				recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, errText)
 				writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, http.StatusBadGateway, true, ParsedUsage{Source: usageSourceUnknown}, retry, requestID, errText)
 				if retry < maxRetries {
@@ -588,7 +591,7 @@ func dispatchEndpointAttemptWithContinue(
 				return true, nil, false
 			}
 			rawErrText := string(respBody)
-			if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback) {
+			if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback, endpointFailureResponse) {
 				return false, nil, true
 			}
 			// Best-effort usage from error JSON bodies (some gateways still include usage).
@@ -605,22 +608,43 @@ func dispatchEndpointAttemptWithContinue(
 		// Always close the upstream body, including early client disconnects.
 		var streamUsage ParsedUsage
 		var streamEnd streamOutcome
+		var streamVerdict *proxy.UpstreamVerdict
 		func() {
 			defer resp.Body.Close()
-			streamUsage, streamEnd = handleStreamUpstream(w, r, resp, latencyMs)
+			streamUsage, streamEnd, streamVerdict = handleStreamUpstream(w, r, resp, latencyMs)
 		}()
-		if streamEnd == streamEndedIdleTimeout {
-			// Upstream stopped sending chunks mid-stream. The client already
-			// received the relayed prefix plus a final SSE idle-timeout error
-			// event, so the response is terminal (no retry once streaming has
-			// begun). Record via the failure path — channel health, failure
-			// proxy_log and the timeout terminal outcome — with the full
-			// attempt duration, not just the header latency.
+		if status, errText, terminal, failed := streamFailureVerdict(streamEnd, int(streamIdleTimeout().Seconds())); failed {
+			// Any non-normal, non-client-driven ending is an upstream-side
+			// fault: idle timeout, mid-stream interruption or byte-limit
+			// truncation. The client already received the relayed prefix plus a
+			// final SSE error event, so the response is terminal (no retry once
+			// streaming has begun). Record via the failure path — channel
+			// health, failure proxy_log and the terminal outcome — with the
+			// full attempt duration, not just the header latency. Partial usage
+			// already extracted from the stream is still accounted.
 			totalLatencyMs := time.Since(startedAt).Milliseconds()
-			errText := fmt.Sprintf("SSE stream idle timeout: no upstream chunk within %ds", int(streamIdleTimeout().Seconds()))
-			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusRequestTimeout, errText)
-			writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, totalLatencyMs, http.StatusRequestTimeout, true, streamUsage, retry, requestID, truncateErrText(errText))
-			observeProxyTerminal(ctx, shared.OutcomeTimeout, true, time.Since(startedAt))
+			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, status, errText)
+			writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, totalLatencyMs, status, true, streamUsage, retry, requestID, truncateErrText(errText))
+			observeProxyTerminal(ctx, terminal, true, time.Since(startedAt))
+			return true, nil, false
+		}
+		if streamVerdict != nil && streamVerdict.Failed {
+			// Content-level failure on a stream that ended cleanly at the
+			// transport level: judged by the same pure judge the buffered path
+			// uses, so the two paths cannot disagree. Streaming already began,
+			// so this is terminal; partial usage is still accounted.
+			totalLatencyMs := time.Since(startedAt).Milliseconds()
+			slog.Warn("stream content-based failure recorded",
+				"code", string(streamVerdict.Code),
+				"reason", streamVerdict.Reason,
+				"model", upstreamModel,
+				"channel_id", selected.Channel.ID,
+				"request_id", requestID,
+				"latency_ms", totalLatencyMs,
+			)
+			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, streamVerdict.Status, streamVerdict.Reason)
+			writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, totalLatencyMs, streamVerdict.Status, true, streamUsage, retry, requestID, truncateErrText(streamVerdict.Reason))
+			observeProxyTerminal(ctx, shared.StatusFromHTTP(streamVerdict.Status), true, time.Since(startedAt))
 			return true, nil, false
 		}
 		// Observability only: include_usage was on the outbound body but SSE had no usable tokens.
@@ -640,10 +664,10 @@ func dispatchEndpointAttemptWithContinue(
 		slog.Warn("failed to read upstream response",
 			"err", readErr, "latency_ms", latencyMs, "channel_id", selected.Channel.ID,
 			"request_id", requestID, "retry", retry)
-		if !isLastEndpoint && !disableCrossProtocolFallback {
+		errText := readErr.Error()
+		if shouldContinueEndpointFallback(http.StatusBadGateway, errText, isLastEndpoint, disableCrossProtocolFallback, endpointFailureTransport) {
 			return false, nil, true
 		}
-		errText := readErr.Error()
 		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, http.StatusBadGateway, errText)
 		writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, http.StatusBadGateway, false, ParsedUsage{Source: usageSourceUnknown}, retry, requestID, errText)
 		if retry < maxRetries {
@@ -655,7 +679,7 @@ func dispatchEndpointAttemptWithContinue(
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		rawErrText := string(respBody)
-		if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback) {
+		if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback, endpointFailureResponse) {
 			return false, nil, true
 		}
 		// Non-stream HTTP errors: retain any usage object in the error body
@@ -671,8 +695,15 @@ func dispatchEndpointAttemptWithContinue(
 		return true, nil, false
 	}
 	usage := ParseUsageFromBody(respBody)
-	failure := proxy.DetectProxyFailure(string(respBody), usage.ToUsageSummary())
-	if failure != nil {
+	// Same single judge the streaming path calls (see judgeStreamContent), fed
+	// with the buffered facts this path already has.
+	verdict := proxy.JudgeUpstreamContent(proxy.UpstreamContentFacts{
+		StatusCode: resp.StatusCode,
+		RawText:    string(respBody),
+		Usage:      usage.ToUsageSummary(),
+	})
+	failure := &proxy.FailureResult{Status: verdict.Status, Reason: verdict.Reason}
+	if verdict.Failed {
 		slog.Warn("content-based failure detected",
 			"reason", failure.Reason,
 			"status", failure.Status,
@@ -682,7 +713,7 @@ func dispatchEndpointAttemptWithContinue(
 			"request_id", requestID,
 			"retry", retry,
 		)
-		if shouldContinueEndpointFallback(failure.Status, failure.Reason, isLastEndpoint, disableCrossProtocolFallback) {
+		if shouldContinueEndpointFallback(failure.Status, failure.Reason, isLastEndpoint, disableCrossProtocolFallback, endpointFailureResponse) {
 			return false, nil, true
 		}
 		// Content failures often still carry real usage (keyword match / empty-
@@ -705,15 +736,77 @@ func dispatchEndpointAttemptWithContinue(
 	return true, nil, false
 }
 
-func shouldContinueEndpointFallback(status int, rawErrText string, isLastEndpoint bool, disableCrossProtocolFallback bool) bool {
+// streamFailureVerdict is the single owner of "how a non-normal stream ending
+// is reported". It maps a streamOutcome to the HTTP status recorded on the
+// channel failure and the proxy_log row, the reason text, and the terminal
+// metric outcome, so channel health, logs and metrics can never disagree about
+// the same stream again.
+//
+// ok=false means the ending is not an upstream fault — clean EOF, or the
+// downstream client went away — and must be recorded through the success path.
+func streamFailureVerdict(end streamOutcome, idleTimeoutSec int) (status int, reason string, terminal string, ok bool) {
+	switch end {
+	case streamEndedIdleTimeout:
+		return http.StatusRequestTimeout,
+			fmt.Sprintf("SSE stream idle timeout: no upstream chunk within %ds", idleTimeoutSec),
+			shared.OutcomeTimeout, true
+	case streamEndedUpstreamFault:
+		return http.StatusBadGateway,
+			"SSE stream interrupted: upstream closed the connection before completing the response",
+			shared.OutcomeUpstreamError, true
+	case streamEndedTruncated:
+		return http.StatusBadGateway,
+			fmt.Sprintf("SSE stream truncated: response exceeded the configured byte limit (%d bytes)", streamResponseByteLimit()),
+			shared.OutcomeUpstreamError, true
+	case streamEndedNormally, streamEndedClientDisconnect:
+		return 0, "", "", false
+	}
+	return 0, "", "", false
+}
+
+// endpointFailureClass tells the single fallback decision function how the
+// failure was observed, so intentional policy differences are explicit
+// parameters instead of a second copy of the decision at the call site.
+type endpointFailureClass int
+
+const (
+	// endpointFailureResponse: the upstream answered with an HTTP status and a
+	// body, so both the same-site abort policy and the protocol-hint downgrade
+	// list apply.
+	endpointFailureResponse endpointFailureClass = iota
+	// endpointFailureTransport: no HTTP response at all (request construction,
+	// dial, or body read failure). The status passed in is the one the failure
+	// is reported with, so the same-site abort policy applies to transport
+	// errors exactly as it does to responses.
+	endpointFailureTransport
+	// endpointFailureFirstByteTimeout: the per-attempt budget expired before
+	// headers arrived. Intentionally exempt from the same-site abort policy —
+	// a first-byte timeout is a budget verdict about one attempt, not evidence
+	// the site is systemically down, so the next protocol candidate is still
+	// tried and the channel is not poisoned.
+	endpointFailureFirstByteTimeout
+)
+
+// shouldContinueEndpointFallback is the ONE owner of "try the next protocol
+// candidate?". Every fallback decision in the dispatch path — HTTP status,
+// content failure and transport-level errors alike — goes through it.
+func shouldContinueEndpointFallback(status int, rawErrText string, isLastEndpoint bool, disableCrossProtocolFallback bool, class endpointFailureClass) bool {
 	if isLastEndpoint || disableCrossProtocolFallback {
 		return false
 	}
-	if proxy.ShouldAbortSameSiteEndpointFallback(status, rawErrText) {
+	if class != endpointFailureFirstByteTimeout && proxy.ShouldAbortSameSiteEndpointFallback(status, rawErrText) {
 		return false
 	}
 	if proxy.ShouldDowngradeToNextEndpoint(status, rawErrText) {
 		return true
+	}
+	switch class {
+	case endpointFailureTransport, endpointFailureFirstByteTimeout:
+		// No HTTP answer means no protocol hint to match: the failure is not
+		// attributable to this endpoint shape, so the next candidate is still
+		// worth trying (unless the abort policy above said otherwise).
+		return true
+	case endpointFailureResponse:
 	}
 	// First-byte style status=0 should already be handled by error path; treat as continue.
 	if status == 0 {

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -702,29 +702,28 @@ func dispatchEndpointAttemptWithContinue(
 		RawText:    string(respBody),
 		Usage:      usage.ToUsageSummary(),
 	})
-	failure := &proxy.FailureResult{Status: verdict.Status, Reason: verdict.Reason}
 	if verdict.Failed {
 		slog.Warn("content-based failure detected",
-			"reason", failure.Reason,
-			"status", failure.Status,
+			"reason", verdict.Reason,
+			"status", verdict.Status,
 			"model", upstreamModel,
 			"channel_id", selected.Channel.ID,
 			"latency_ms", latencyMs,
 			"request_id", requestID,
 			"retry", retry,
 		)
-		if shouldContinueEndpointFallback(failure.Status, failure.Reason, isLastEndpoint, disableCrossProtocolFallback, endpointFailureResponse) {
+		if shouldContinueEndpointFallback(verdict.Status, verdict.Reason, isLastEndpoint, disableCrossProtocolFallback, endpointFailureResponse) {
 			return false, nil, true
 		}
 		// Content failures often still carry real usage (keyword match / empty-
 		// content edge cases with non-zero tokens). Persist failed row + tokens.
-		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, failure.Status, failure.Reason)
-		writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, failure.Status, false, usage, retry, requestID, failure.Reason)
-		if retry < maxRetries && proxy.ShouldRetryProxyRequest(failure.Status, failure.Reason) {
-			return false, jsonPendingUpstreamFailure(failure.Status, "Upstream returned an error response", "upstream_error"), false
+		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, verdict.Status, verdict.Reason)
+		writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, verdict.Status, false, usage, retry, requestID, verdict.Reason)
+		if retry < maxRetries && proxy.ShouldRetryProxyRequest(verdict.Status, verdict.Reason) {
+			return false, jsonPendingUpstreamFailure(verdict.Status, "Upstream returned an error response", "upstream_error"), false
 		}
-		writeJSONErrorWithRequest(w, failure.Status, "Upstream returned an error response", "upstream_error", requestID)
-		observeProxyTerminal(ctx, shared.StatusFromHTTP(failure.Status), false, time.Duration(latencyMs)*time.Millisecond)
+		writeJSONErrorWithRequest(w, verdict.Status, "Upstream returned an error response", "upstream_error", requestID)
+		observeProxyTerminal(ctx, shared.StatusFromHTTP(verdict.Status), false, time.Duration(latencyMs)*time.Millisecond)
 		return true, nil, false
 	}
 	recordUpstreamSuccess(r.Context(), cfg, selected, ctx.RequestedModel, upstreamModel, latencyMs, usage)

--- a/handler/proxy/upstream_stream.go
+++ b/handler/proxy/upstream_stream.go
@@ -17,26 +17,59 @@ import (
 
 // streamOutcome classifies how an SSE relay ended so the dispatcher can
 // record upstream faults distinctly from clean or client-driven endings.
+// Every value except streamEndedNormally and streamEndedClientDisconnect is an
+// upstream-side fault and MUST be recorded through the failure path.
 type streamOutcome int
 
 const (
-	// streamEndedNormally covers clean EOF, byte-limit termination, mid-stream
-	// read errors, downstream disconnects and writes — the historical paths.
+	// streamEndedNormally covers the clean EOF case: the upstream finished the
+	// stream and the whole body was relayed.
 	streamEndedNormally streamOutcome = iota
 	// streamEndedIdleTimeout means the upstream stopped sending chunks for
 	// longer than PROXY_STREAM_IDLE_TIMEOUT_SEC and the idle guard aborted
 	// the stream. The dispatcher records this via the failure path.
 	streamEndedIdleTimeout
+	// streamEndedUpstreamFault means the upstream body failed mid-stream
+	// (network reset, upstream crash, truncated transfer) after the relay had
+	// already begun. The client got a partial answer plus an SSE error event.
+	streamEndedUpstreamFault
+	// streamEndedTruncated means the relay hit PROXY_MAX_STREAM_RESPONSE_BYTES
+	// and stopped early, so the client received an incomplete answer.
+	streamEndedTruncated
+	// streamEndedClientDisconnect means the downstream client cancelled or its
+	// write side went away. Deliberately NOT an upstream fault: the channel
+	// answered correctly, so recording it as a failure would poison channel
+	// health with user cancel behaviour. Usage already extracted is still
+	// returned for accounting.
+	streamEndedClientDisconnect
 )
 
-func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Response, latencyMs int64) (ParsedUsage, streamOutcome) {
+// String keeps log lines and test failure messages readable now that the
+// classification has more than two members.
+func (o streamOutcome) String() string {
+	switch o {
+	case streamEndedNormally:
+		return "normally"
+	case streamEndedIdleTimeout:
+		return "idleTimeout"
+	case streamEndedUpstreamFault:
+		return "upstreamFault"
+	case streamEndedTruncated:
+		return "truncated"
+	case streamEndedClientDisconnect:
+		return "clientDisconnect"
+	}
+	return "unknown"
+}
+
+func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Response, latencyMs int64) (ParsedUsage, streamOutcome, *proxy.UpstreamVerdict) {
 	empty := ParsedUsage{Source: usageSourceUnknown}
 	if resp == nil || resp.Body == nil {
-		return empty, streamEndedNormally
+		return empty, streamEndedNormally, nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		relayUpstreamErrorResponse(w, resp, latencyMs)
-		return empty, streamEndedNormally
+		return empty, streamEndedNormally, nil
 	}
 
 	// Active SSE stream gauge: Inc when a real stream starts, Dec on every
@@ -77,8 +110,50 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 	sawStreamBytes := false
 	maxStreamBytes := streamResponseByteLimit()
 	var streamedBytes int64
-	idleTimedOut := false
+	outcome := streamEndedNormally
 	buf := make([]byte, 4096)
+
+	// endStream is the single exit for every relay ending: it runs the same
+	// pure content judge the buffered path calls over what the bounded analyzer
+	// kept, so no exit path can skip content judgement and the streaming path
+	// can no longer reach a different verdict than buffered for the same
+	// upstream content. logDetail keeps the historical post-stream warnings on
+	// the paths that always had them.
+	endStream := func(end streamOutcome, logDetail bool) (ParsedUsage, streamOutcome, *proxy.UpstreamVerdict) {
+		// Post-stream SSE analysis uses bounded incremental state instead of
+		// retaining the complete upstream body.
+		result := analyzer.Result()
+		if logDetail {
+			if result.DroppedOversizedEvent {
+				slog.Warn("SSE stream event exceeded analysis buffer",
+					"latency_ms", latencyMs,
+					"pending_limit_bytes", maxIncrementalSsePendingBytes,
+				)
+			}
+
+			// Log SSE error events at WARN level
+			if result.HasErrorEvent {
+				LogSseErrorEvents(result.ErrorEvents)
+			}
+		}
+		if end == streamEndedClientDisconnect {
+			// The client left before the upstream finished: there is no complete
+			// upstream answer to judge, and a content verdict here would be
+			// recorded against a channel that never got to finish. Still return
+			// any usage already extracted from earlier SSE events (best-effort
+			// partial) — never invent tokens.
+			if result.Usage.Found {
+				return result.Usage, end, nil
+			}
+			return empty, end, nil
+		}
+		verdict := judgeStreamContent(resp.StatusCode, result, latencyMs)
+		if result.Usage.Found {
+			return result.Usage, end, &verdict
+		}
+		return empty, end, &verdict
+	}
+
 	for {
 		select {
 		case <-r.Context().Done():
@@ -90,10 +165,7 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 				"latency_ms", latencyMs,
 				"streamed_bytes", streamedBytes,
 			)
-			if result := analyzer.Result(); result.Usage.Found {
-				return result.Usage, streamEndedNormally
-			}
-			return empty, streamEndedNormally
+			return endStream(streamEndedClientDisconnect, false)
 		default:
 		}
 
@@ -108,6 +180,7 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 					"streamed_bytes", streamedBytes,
 					"limit_bytes", maxStreamBytes,
 				)
+				outcome = streamEndedTruncated
 				break
 			}
 			exceededLimit := int64(len(chunk)) > remaining
@@ -128,10 +201,7 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 					)
 					// Downstream gone: keep any usage already extracted (including
 					// the chunk that failed to write). Never invent tokens.
-					if result := analyzer.Result(); result.Usage.Found {
-						return result.Usage, streamEndedNormally
-					}
-					return empty, streamEndedNormally
+					return endStream(streamEndedClientDisconnect, false)
 				}
 				streamedBytes += int64(len(chunk))
 			}
@@ -145,75 +215,98 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 					"streamed_bytes", streamedBytes,
 					"limit_bytes", maxStreamBytes,
 				)
+				outcome = streamEndedTruncated
 				break
 			}
 		}
 		if err != nil {
 			if err != io.EOF {
-				if idleBody.guard.fired.Load() && r.Context().Err() == nil {
+				switch {
+				case idleBody.guard.fired.Load() && r.Context().Err() == nil:
 					// Upstream stalled: the idle guard closed the body to
 					// unblock this read. Emit a distinct final SSE error event
 					// and report the idle outcome so the dispatcher records
-					// the failure. A concurrent downstream disconnect keeps
-					// its historical (non-idle) classification.
+					// the failure.
 					writeSSEStreamError(w, flusher, "upstream stream idle timeout", "upstream_error")
 					slog.Warn("SSE stream idle timeout: upstream sent no chunk within window",
 						"idle_timeout_sec", int(idleTimeout.Seconds()),
 						"latency_ms", latencyMs,
 						"streamed_bytes", streamedBytes,
 					)
-					idleTimedOut = true
-				} else {
+					outcome = streamEndedIdleTimeout
+				case r.Context().Err() != nil:
+					// Downstream went away while a read was in flight: this read
+					// error is a consequence of the client cancel, not an
+					// upstream fault. Classified separately so user cancels can
+					// never be recorded as channel failures.
+					slog.Debug("SSE stream read aborted by downstream disconnect",
+						"err", err,
+						"latency_ms", latencyMs,
+						"streamed_bytes", streamedBytes,
+					)
+					outcome = streamEndedClientDisconnect
+				default:
 					// Mid-stream upstream failure (network reset, upstream crash,
 					// truncated body): emit a final SSE error event so the client
 					// can surface the failure explicitly instead of inferring it
 					// from a missing [DONE] marker. Mirrors the byte-limit path.
 					writeSSEStreamError(w, flusher, "upstream stream interrupted", "upstream_error")
 					slog.Warn("SSE stream read error", "err", err, "latency_ms", latencyMs)
+					outcome = streamEndedUpstreamFault
 				}
 			}
 			break
 		}
 	}
 
-	outcome := streamEndedNormally
-	if idleTimedOut {
-		outcome = streamEndedIdleTimeout
+	return endStream(outcome, sawStreamBytes)
+}
+
+// judgeStreamContent feeds the streaming path parsed facts into the same pure
+// content judge the buffered path calls (proxy.JudgeUpstreamContent). It
+// replaces the historical log-only parallel implementation that merely warned
+// about missing data events while the dispatcher still recorded a success.
+func judgeStreamContent(statusCode int, result incrementalSseAnalysisResult, latencyMs int64) proxy.UpstreamVerdict {
+	verdict := proxy.JudgeUpstreamContent(proxy.UpstreamContentFacts{
+		StatusCode: statusCode,
+		Streaming:  true,
+		RawText:    sseErrorEventText(result.ErrorEvents),
+		HasOutput:  result.HasDataEvent,
+		Usage:      result.Usage.ToUsageSummary(),
+	})
+	if verdict.Failed {
+		slog.Warn("stream content-based failure detected",
+			"code", string(verdict.Code),
+			"reason", verdict.Reason,
+			"status", verdict.Status,
+			"latency_ms", latencyMs,
+			"event_count", result.EventCount,
+			"has_done_marker", result.HasDoneMarker,
+		)
+	} else if !result.HasDataEvent {
+		slog.Debug("SSE stream contained no data events",
+			"latency_ms", latencyMs,
+			"event_count", result.EventCount,
+			"has_done_marker", result.HasDoneMarker,
+		)
 	}
+	return verdict
+}
 
-	// Post-stream SSE analysis uses bounded incremental state instead of
-	// retaining the complete upstream body.
-	result := analyzer.Result()
-	if sawStreamBytes {
-		if result.DroppedOversizedEvent {
-			slog.Warn("SSE stream event exceeded analysis buffer",
-				"latency_ms", latencyMs,
-				"pending_limit_bytes", maxIncrementalSsePendingBytes,
-			)
-		}
-
-		// Log SSE error events at WARN level
-		if result.HasErrorEvent {
-			LogSseErrorEvents(result.ErrorEvents)
-		}
-
-		// Check for empty content (stream ended with no data events).
-		// ProxyEmptyContentFailEnabled is read from the startup-loaded config
-		// singleton instead of os.Getenv per stream request.
-		if !result.HasDataEvent {
-			if rt := config.RuntimeSafe(); rt != nil && rt.ProxyEmptyContentFailEnabled {
-				slog.Warn("SSE stream contained no data events",
-					"latency_ms", latencyMs,
-					"event_count", result.EventCount,
-					"has_done_marker", result.HasDoneMarker,
-				)
-			}
-		}
-		if result.Usage.Found {
-			return result.Usage, outcome
+// sseErrorEventText joins the SSE error-event payloads the analyzer kept. The
+// bounded analyzer never retains the raw stream body, so error events are the
+// only content signal the streaming path can hand to the shared judge.
+func sseErrorEventText(events []SseEvent) string {
+	if len(events) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(events))
+	for _, ev := range events {
+		if data := strings.TrimSpace(ev.Data); data != "" {
+			parts = append(parts, data)
 		}
 	}
-	return empty, outcome
+	return strings.Join(parts, "\n")
 }
 
 // streamResponseByteLimit returns the configured max SSE stream response size

--- a/handler/proxy/upstream_stream_honesty_test.go
+++ b/handler/proxy/upstream_stream_honesty_test.go
@@ -1,0 +1,485 @@
+package proxyhandler
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/proxy"
+	"github.com/deliciousbuding/metapi-go/routing"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// The tests in this file pin the PRODUCTION dispatch path
+// (HandleChatCompletions -> dispatchEndpointAttemptWithContinue ->
+// handleStreamUpstream). They deliberately do not exercise the parallel
+// fallback implementation, which is not what serves traffic.
+
+// abruptSSEUpstream writes a partial SSE answer over a hijacked connection and
+// then closes it without the terminating zero-length chunk. Chunked framing is
+// what makes the client see a read ERROR instead of a clean EOF — that is the
+// difference between "upstream finished" and "upstream died mid-stream".
+func abruptSSEUpstream(prefix string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, bufrw, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		_, _ = bufrw.WriteString("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n")
+		writeSSEChunk(bufrw, prefix)
+		_ = bufrw.Flush()
+		_ = conn.Close()
+	}))
+}
+
+func writeSSEChunk(bufrw *bufio.ReadWriter, payload string) {
+	_, _ = fmt.Fprintf(bufrw, "%x\r\n%s\r\n", len(payload), payload)
+}
+
+// sseChunkUpstream streams the given events with flushes and then ends the
+// response cleanly (proper chunked terminator).
+func sseChunkUpstream(events []string, stallAfter time.Duration) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for _, ev := range events {
+			_, _ = w.Write([]byte(ev))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		if stallAfter > 0 {
+			time.Sleep(stallAfter)
+		}
+	}))
+}
+
+// runStreamDispatch drives one streaming chat completion through the production
+// handler and returns everything the three observability surfaces recorded:
+// channel health (router.failures / router.successes), the proxy_logs rows and
+// the downstream response.
+func runStreamDispatch(t *testing.T, upstreamURL string, cfgMutator func(*config.Config)) (*upstreamTestRouter, *[]proxy.ProxyLogEntry, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	prevCfg := config.GetSafe()
+	cfg := &config.Config{ProxyMaxChannelAttempts: 1}
+	if cfgMutator != nil {
+		cfgMutator(cfg)
+	}
+	config.Set(cfg)
+	t.Cleanup(func() { config.Set(prevCfg) })
+
+	prevRt := config.RuntimeSafe()
+	config.UpdateRuntime(func(r *config.RuntimeSettings) { r.DisableCrossProtocolFallback = false })
+	t.Cleanup(func() { config.SetRuntime(prevRt) })
+
+	router := &upstreamTestRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: upstreamURL, Status: "active"},
+		TokenValue:  "upstream-token",
+		ActualModel: "gpt-4o",
+	}}
+	logs := &[]proxy.ProxyLogEntry{}
+	SetUpstreamConfig(&UpstreamConfig{
+		Router:   router,
+		Executor: proxy.NewRuntimeExecutor(10 * time.Second),
+		LogProxy: func(_ context.Context, entry proxy.ProxyLogEntry) error {
+			*logs = append(*logs, entry)
+			return nil
+		},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+	return router, logs, rec
+}
+
+// assertFailureSurface checks the three surfaces agree the attempt failed:
+// channel health got a failure (and no success), and the proxy_logs row is a
+// failure row with a non-200 http_status. This is the exact lie the fix
+// removes: a broken stream used to record success + 200 + outcome=success.
+func assertFailureSurface(t *testing.T, router *upstreamTestRouter, logs *[]proxy.ProxyLogEntry, wantStatus int, wantReasonPart string) {
+	t.Helper()
+	if len(router.failures) != 1 {
+		t.Fatalf("recordUpstreamFailure calls = %d (%#v), want exactly 1", len(router.failures), router.failures)
+	}
+	if len(router.successes) != 0 {
+		t.Fatalf("recordUpstreamSuccess calls = %#v, want none for a broken stream", router.successes)
+	}
+	f := router.failures[0]
+	if f.channelID != 42 {
+		t.Fatalf("failure channelID = %d, want 42", f.channelID)
+	}
+	if f.status == nil || *f.status != wantStatus {
+		t.Fatalf("failure status = %v, want %d", f.status, wantStatus)
+	}
+	if f.errorText == nil || !strings.Contains(*f.errorText, wantReasonPart) {
+		t.Fatalf("failure errorText = %v, want it to contain %q", f.errorText, wantReasonPart)
+	}
+	if len(*logs) == 0 {
+		t.Fatal("no proxy_logs row written for the failed stream")
+	}
+	entry := (*logs)[len(*logs)-1]
+	if entry.Status == "success" {
+		t.Fatalf("proxy_logs status = %q, want a failure state", entry.Status)
+	}
+	if entry.HTTPStatus == http.StatusOK {
+		t.Fatalf("proxy_logs http_status = 200, want non-200 for a broken stream")
+	}
+	if entry.HTTPStatus != wantStatus {
+		t.Fatalf("proxy_logs http_status = %d, want %d", entry.HTTPStatus, wantStatus)
+	}
+	if entry.ErrorMessage == nil || !strings.Contains(*entry.ErrorMessage, wantReasonPart) {
+		t.Fatalf("proxy_logs error message = %v, want it to contain %q", entry.ErrorMessage, wantReasonPart)
+	}
+	if entry.IsStream == nil || !*entry.IsStream {
+		t.Fatalf("proxy_logs is_stream = %v, want true", entry.IsStream)
+	}
+}
+
+// TestDispatchStreamMidstreamUpstreamFaultIsRecordedAsFailure is nail ①: the
+// upstream relays a partial answer and then dies. Channel health, proxy_logs
+// and the terminal metric must all say failure.
+func TestDispatchStreamMidstreamUpstreamFaultIsRecordedAsFailure(t *testing.T) {
+	upstream := abruptSSEUpstream("data: {\"choices\":[{\"delta\":{\"content\":\"partial answer\"}}]}\n\n")
+	t.Cleanup(upstream.Close)
+
+	router, logs, rec := runStreamDispatch(t, upstream.URL, nil)
+
+	if body := rec.Body.String(); !strings.Contains(body, "partial answer") {
+		t.Fatalf("relayed prefix lost; body = %q", body)
+	}
+	if !strings.Contains(rec.Body.String(), "upstream stream interrupted") {
+		t.Fatalf("client got no SSE error event; body = %q", rec.Body.String())
+	}
+	assertFailureSurface(t, router, logs, http.StatusBadGateway, "interrupted")
+}
+
+// TestDispatchStreamByteLimitTruncationIsRecordedAsFailure is nail ②: the
+// answer is cut short by PROXY_MAX_STREAM_RESPONSE_BYTES, so the client
+// received an incomplete answer and the attempt must be recorded as a failure.
+func TestDispatchStreamByteLimitTruncationIsRecordedAsFailure(t *testing.T) {
+	upstream := sseChunkUpstream([]string{
+		"data: {\"choices\":[{\"delta\":{\"content\":\"AAAAAAAAAAAAAAAAAAAA\"}}]}\n\n",
+		"data: {\"choices\":[{\"delta\":{\"content\":\"BBBBBBBBBBBBBBBBBBBB\"}}]}\n\n",
+		"data: {\"choices\":[{\"delta\":{\"content\":\"CCCCCCCCCCCCCCCCCCCC\"}}]}\n\n",
+		"data: [DONE]\n\n",
+	}, 0)
+	t.Cleanup(upstream.Close)
+
+	router, logs, rec := runStreamDispatch(t, upstream.URL, func(c *config.Config) {
+		c.ProxyMaxStreamResponseBytes = 80
+	})
+
+	if !strings.Contains(rec.Body.String(), "exceeded configured byte limit") {
+		t.Fatalf("client got no byte-limit SSE error event; body = %q", rec.Body.String())
+	}
+	assertFailureSurface(t, router, logs, http.StatusBadGateway, "truncated")
+}
+
+// TestDispatchStreamIdleTimeoutKeepsFailureRecording is nail ③, the regression
+// nail: the idle path already recorded a failure before this change and must
+// keep doing exactly that (408 + failure row), unchanged.
+func TestDispatchStreamIdleTimeoutKeepsFailureRecording(t *testing.T) {
+	upstream := sseChunkUpstream([]string{
+		"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
+	}, 3*time.Second)
+	t.Cleanup(upstream.Close)
+
+	router, logs, rec := runStreamDispatch(t, upstream.URL, func(c *config.Config) {
+		c.ProxyStreamIdleTimeoutSec = 1
+	})
+
+	if !strings.Contains(rec.Body.String(), "upstream stream idle timeout") {
+		t.Fatalf("client got no idle-timeout SSE error event; body = %q", rec.Body.String())
+	}
+	assertFailureSurface(t, router, logs, http.StatusRequestTimeout, "idle timeout")
+}
+
+// TestDispatchStreamCleanEOFStillRecordsSuccess is nail ④: a stream that ends
+// cleanly is still a success — the fix must not turn honest answers into
+// failures.
+func TestDispatchStreamCleanEOFStillRecordsSuccess(t *testing.T) {
+	upstream := sseChunkUpstream([]string{
+		"data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n",
+		"data: {\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":4,\"total_tokens\":7}}\n\n",
+		"data: [DONE]\n\n",
+	}, 0)
+	t.Cleanup(upstream.Close)
+
+	router, logs, rec := runStreamDispatch(t, upstream.URL, nil)
+
+	if !strings.Contains(rec.Body.String(), "hello") {
+		t.Fatalf("clean stream not relayed; body = %q", rec.Body.String())
+	}
+	if len(router.failures) != 0 {
+		t.Fatalf("recordUpstreamFailure calls = %#v, want none for a clean stream", router.failures)
+	}
+	if len(router.successes) != 1 {
+		t.Fatalf("recordUpstreamSuccess calls = %#v, want exactly 1", router.successes)
+	}
+	if len(*logs) == 0 {
+		t.Fatal("no proxy_logs row written for the clean stream")
+	}
+	entry := (*logs)[len(*logs)-1]
+	if entry.HTTPStatus != http.StatusOK {
+		t.Fatalf("proxy_logs http_status = %d, want 200 for a clean stream", entry.HTTPStatus)
+	}
+	if entry.ErrorMessage != nil {
+		t.Fatalf("proxy_logs error = %q, want none for a clean stream", *entry.ErrorMessage)
+	}
+	if entry.TotalTokens == nil || *entry.TotalTokens != 7 {
+		t.Fatalf("proxy_logs total_tokens = %v, want 7 (stream usage still accounted)", entry.TotalTokens)
+	}
+}
+
+// TestStreamFailureVerdictIsTheSingleOwnerOfStreamEndings pins the mapping
+// itself: every non-normal, non-client-driven ending yields a failure status,
+// a reason and a terminal outcome; clean EOF and downstream disconnect do not.
+func TestStreamFailureVerdictIsTheSingleOwnerOfStreamEndings(t *testing.T) {
+	cases := []struct {
+		end          streamOutcome
+		wantFailed   bool
+		wantStatus   int
+		wantTerminal string
+		wantReason   string
+	}{
+		{streamEndedNormally, false, 0, "", ""},
+		{streamEndedClientDisconnect, false, 0, "", ""},
+		{streamEndedIdleTimeout, true, http.StatusRequestTimeout, "timeout", "idle timeout"},
+		{streamEndedUpstreamFault, true, http.StatusBadGateway, "upstream_error", "interrupted"},
+		{streamEndedTruncated, true, http.StatusBadGateway, "upstream_error", "truncated"},
+	}
+	for _, tc := range cases {
+		status, reason, terminal, failed := streamFailureVerdict(tc.end, 30)
+		if failed != tc.wantFailed {
+			t.Fatalf("%v: failed = %v, want %v", tc.end, failed, tc.wantFailed)
+		}
+		if !failed {
+			if status != 0 || reason != "" || terminal != "" {
+				t.Fatalf("%v: non-failure ending must stay empty, got %d/%q/%q", tc.end, status, reason, terminal)
+			}
+			continue
+		}
+		if status != tc.wantStatus {
+			t.Fatalf("%v: status = %d, want %d", tc.end, status, tc.wantStatus)
+		}
+		if terminal != tc.wantTerminal {
+			t.Fatalf("%v: terminal = %q, want %q", tc.end, terminal, tc.wantTerminal)
+		}
+		if !strings.Contains(reason, tc.wantReason) {
+			t.Fatalf("%v: reason = %q, want it to contain %q", tc.end, reason, tc.wantReason)
+		}
+		if status == http.StatusOK {
+			t.Fatalf("%v: a failed stream must never be reported with http_status 200", tc.end)
+		}
+	}
+}
+
+// TestContentJudgeAgreesAcrossBufferedAndStreamPaths proves the single content
+// judge gives the SAME verdict for the same upstream answer on both paths: the
+// buffered facts upstream.go builds and the streaming facts the bounded SSE
+// analyzer produces are fed to one function, so judgement strength can no
+// longer diverge.
+func TestContentJudgeAgreesAcrossBufferedAndStreamPaths(t *testing.T) {
+	prevRt := config.RuntimeSafe()
+	config.SetRuntime(&config.RuntimeSettings{
+		ProxyErrorKeywords:           []string{"overloaded"},
+		ProxyEmptyContentFailEnabled: true,
+	})
+	t.Cleanup(func() { config.SetRuntime(prevRt) })
+
+	fixtures := []struct {
+		name string
+		// bufferedBody is the raw body the buffered path hands the judge.
+		bufferedBody string
+		// sseBody is the same upstream answer as the streaming path sees it.
+		sseBody string
+		// completion tokens both paths agree the upstream reported.
+		completionTokens int
+		wantFailed       bool
+		wantCode         proxy.FailureCode
+	}{
+		{
+			name:             "keyword failure in an error payload",
+			bufferedBody:     `{"error":{"message":"server is overloaded"}}`,
+			sseBody:          "data: {\"error\":{\"message\":\"server is overloaded\"}}\n\n",
+			completionTokens: 0,
+			wantFailed:       true,
+			wantCode:         proxy.FailureCodeErrorKeyword,
+		},
+		{
+			name:             "no completion output at all",
+			bufferedBody:     `{"id":"chatcmpl_empty"}`,
+			sseBody:          "",
+			completionTokens: 0,
+			wantFailed:       true,
+			wantCode:         proxy.FailureCodeEmptyContent,
+		},
+		{
+			name:             "healthy answer with content",
+			bufferedBody:     `{"choices":[{"message":{"content":"hello"}}]}`,
+			sseBody:          "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\ndata: [DONE]\n\n",
+			completionTokens: 3,
+			wantFailed:       false,
+			wantCode:         proxy.FailureCodeNone,
+		},
+	}
+
+	for _, tc := range fixtures {
+		t.Run(tc.name, func(t *testing.T) {
+			usage := &proxy.UsageSummary{CompletionTokens: tc.completionTokens, TotalTokens: tc.completionTokens}
+
+			// Buffered path: exactly the facts handler/proxy/upstream.go builds.
+			buffered := proxy.JudgeUpstreamContent(proxy.UpstreamContentFacts{
+				StatusCode: http.StatusOK,
+				RawText:    tc.bufferedBody,
+				Usage:      usage,
+			})
+
+			// Stream path: run the real bounded analyzer over the SSE encoding of
+			// the same answer, then judge through the same production helper.
+			analyzer := newIncrementalSseAnalyzer()
+			if tc.sseBody != "" {
+				analyzer.Push([]byte(tc.sseBody))
+			}
+			result := analyzer.Result()
+			result.Usage.CompletionTokens = int64(tc.completionTokens)
+			streamed := judgeStreamContent(http.StatusOK, result, 1)
+
+			if buffered != streamed {
+				t.Fatalf("verdicts diverge for the same upstream content:\n buffered = %+v\n stream   = %+v", buffered, streamed)
+			}
+			if buffered.Failed != tc.wantFailed {
+				t.Fatalf("failed = %v, want %v (verdict %+v)", buffered.Failed, tc.wantFailed, buffered)
+			}
+			if buffered.Code != tc.wantCode {
+				t.Fatalf("code = %q, want %q", buffered.Code, tc.wantCode)
+			}
+			if tc.wantFailed && buffered.Status == http.StatusOK {
+				t.Fatalf("a content failure must never carry http_status 200, got %+v", buffered)
+			}
+		})
+	}
+}
+
+// TestShouldContinueEndpointFallbackSingleOwnerFourQuadrants pins the one
+// decision function: transport-level errors now consult the same-site abort
+// policy (they used to bypass it via a bare "not the last endpoint" check),
+// intentionally different first-byte-timeout class is expressed as a parameter
+// instead of a second implementation at the call site.
+func TestShouldContinueEndpointFallbackSingleOwnerFourQuadrants(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		errText  string
+		isLast   bool
+		disable  bool
+		class    endpointFailureClass
+		wantCont bool
+	}{
+		// Four quadrants for transport errors with candidates remaining.
+		{"transport error, candidates remain, policy allows", http.StatusBadGateway, "dial tcp 10.0.0.1:443: no route to host", false, false, endpointFailureTransport, true},
+		{"transport error, candidates remain, abort policy fires", http.StatusBadGateway, "dial tcp 10.0.0.1:443: connect: connection refused", false, false, endpointFailureTransport, false},
+		{"transport error, no candidates remain", http.StatusBadGateway, "dial tcp 10.0.0.1:443: no route to host", true, false, endpointFailureTransport, false},
+		{"transport error, cross-protocol fallback disabled", http.StatusBadGateway, "dial tcp 10.0.0.1:443: no route to host", false, true, endpointFailureTransport, false},
+		// Body read failures share the transport class.
+		{"read error, connection reset, abort policy fires", http.StatusBadGateway, "read tcp: connection reset by peer", false, false, endpointFailureTransport, false},
+		{"read error, generic, candidates remain", http.StatusBadGateway, "unexpected EOF", false, false, endpointFailureTransport, true},
+		// The intentional difference, expressed as a parameter.
+		{"first-byte timeout is exempt from the abort policy", http.StatusRequestTimeout, "first byte timeout", false, false, endpointFailureFirstByteTimeout, true},
+		{"first-byte timeout still respects the last-candidate guard", http.StatusRequestTimeout, "first byte timeout", true, false, endpointFailureFirstByteTimeout, false},
+		// Response class must keep its historical verdicts.
+		{"systemic 503 aborts endpoint fallback", http.StatusServiceUnavailable, "service unavailable", false, false, endpointFailureResponse, false},
+		{"protocol hint downgrades to the next endpoint", http.StatusBadRequest, "please use /v1/messages", false, false, endpointFailureResponse, true},
+		{"404 on a protocol path downgrades", http.StatusNotFound, "not found", false, false, endpointFailureResponse, true},
+		{"plain 400 does not continue", http.StatusBadRequest, "invalid request body", false, false, endpointFailureResponse, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldContinueEndpointFallback(tc.status, tc.errText, tc.isLast, tc.disable, tc.class)
+			if got != tc.wantCont {
+				t.Fatalf("shouldContinueEndpointFallback(%d, %q, isLast=%v, disable=%v, class=%d) = %v, want %v",
+					tc.status, tc.errText, tc.isLast, tc.disable, tc.class, got, tc.wantCont)
+			}
+		})
+	}
+}
+
+// TestTransportErrorFallbackGoesThroughTheSingleDecisionFunction is the
+// end-to-end half of the F3 nail: a transport-level "connection refused" on the
+// primary protocol path is covered by the same-site abort policy, so the
+// dispatcher must stop walking the protocol candidate list and report the
+// failure for the PRIMARY path. Historically transport errors bypassed the
+// abort policy: the dispatcher silently walked every remaining candidate and
+// only reported the last one.
+func TestTransportErrorFallbackGoesThroughTheSingleDecisionFunction(t *testing.T) {
+	// A port nobody listens on: the dial fails with "connection refused", which
+	// the same-site abort policy covers.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	deadURL := "http://" + ln.Addr().String()
+	_ = ln.Close()
+
+	prevCfg := config.GetSafe()
+	config.Set(&config.Config{ProxyMaxChannelAttempts: 1})
+	t.Cleanup(func() { config.Set(prevCfg) })
+	prevRt := config.RuntimeSafe()
+	config.UpdateRuntime(func(r *config.RuntimeSettings) { r.DisableCrossProtocolFallback = false })
+	t.Cleanup(func() { config.SetRuntime(prevRt) })
+
+	router := &upstreamTestRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        store.Site{ID: 3, URL: deadURL, Status: "active"},
+		TokenValue:  "upstream-token",
+		ActualModel: "gpt-4o",
+	}}
+	logs := &[]proxy.ProxyLogEntry{}
+	SetUpstreamConfig(&UpstreamConfig{
+		Router:   router,
+		Executor: proxy.NewRuntimeExecutor(10 * time.Second),
+		LogProxy: func(_ context.Context, entry proxy.ProxyLogEntry) error {
+			*logs = append(*logs, entry)
+			return nil
+		},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions", `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if len(router.failures) != 1 {
+		t.Fatalf("recordUpstreamFailure calls = %d (%#v), want exactly 1", len(router.failures), router.failures)
+	}
+	if router.failures[0].errorText == nil || !strings.Contains(*router.failures[0].errorText, "connection refused") {
+		t.Fatalf("failure errorText = %v, want a connection-refused transport error", router.failures[0].errorText)
+	}
+	if len(*logs) != 1 {
+		t.Fatalf("proxy_logs rows = %d, want exactly 1", len(*logs))
+	}
+	if (*logs)[0].UpstreamPath == nil || *(*logs)[0].UpstreamPath != "/v1/chat/completions" {
+		t.Fatalf("failure reported for upstream_path = %q, want the primary /v1/chat/completions: the abort policy must stop the candidate walk on the first transport failure", *(*logs)[0].UpstreamPath)
+	}
+	if rec.Code == http.StatusOK {
+		t.Fatalf("downstream status = 200, want a failure for a refused upstream")
+	}
+}

--- a/handler/proxy/upstream_stream_idle_test.go
+++ b/handler/proxy/upstream_stream_idle_test.go
@@ -102,7 +102,7 @@ func TestHandleStreamUpstreamIdleTimeoutAbortsStalledStream(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 
 	start := time.Now()
-	usage, outcome := handleStreamUpstream(rec, req, resp, 5)
+	usage, outcome, _ := handleStreamUpstream(rec, req, resp, 5)
 	elapsed := time.Since(start)
 
 	if outcome != streamEndedIdleTimeout {
@@ -146,7 +146,7 @@ func TestHandleStreamUpstreamFlowingStreamCompletesNormally(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 
-	_, outcome := handleStreamUpstream(rec, req, resp, 5)
+	_, outcome, _ := handleStreamUpstream(rec, req, resp, 5)
 	if outcome != streamEndedNormally {
 		t.Fatalf("outcome = %v, want streamEndedNormally", outcome)
 	}

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -822,11 +822,11 @@ func TestStreamSuccessExtractsFinalUsageAndPersistsProxyLog(t *testing.T) {
 	}
 }
 
-func TestDetectProxyFailureReceivesParsedUsageFromBody(t *testing.T) {
+func TestContentJudgeReceivesParsedUsageFromBody(t *testing.T) {
 	// When empty-content-fail is enabled and completion tokens are present,
-	// DetectProxyFailure must not treat the response as empty even without text.
+	// the content judge must not treat the response as empty even without text.
 	t.Setenv("PROXY_EMPTY_CONTENT_FAIL", "1")
-	// config.Get() may already be loaded; DetectProxyFailure reads config singleton.
+	// config.Get() may already be loaded; the judge reads the config singleton.
 	// Prefer direct unit path: ParseUsageFromBody -> ToUsageSummary.
 	body := []byte(`{"choices":[{"message":{"content":""}}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`)
 	usage := ParseUsageFromBody(body)
@@ -1348,7 +1348,7 @@ func TestNonStreamHTTPErrorPersistsUsageTokensToFailedProxyLog(t *testing.T) {
 func TestNonStreamContentFailurePersistsParsedUsageToFailedProxyLog(t *testing.T) {
 	// Keyword-matched content failure must still persist usage extracted from the body.
 	t.Setenv("PROXY_ERROR_KEYWORDS", "content_policy_violation")
-	// DetectProxyFailure reads the runtime snapshot; publish the keyword list.
+	// The content judge reads the runtime snapshot; publish the keyword list.
 	config.UpdateRuntime(func(r *config.RuntimeSettings) {
 		r.ProxyErrorKeywords = []string{"content_policy_violation"}
 	})

--- a/handler/proxy/upstream_test.go
+++ b/handler/proxy/upstream_test.go
@@ -1081,7 +1081,17 @@ func TestHandleStreamUpstreamClientDisconnectPreservesUsage(t *testing.T) {
 
 	rec := &disconnectAfterNWriter{ResponseRecorder: httptest.NewRecorder(), n: 2}
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
-	usage, _ := handleStreamUpstream(rec, req, resp, 12)
+	usage, end, verdict := handleStreamUpstream(rec, req, resp, 12)
+	// A downstream disconnect is its own ending class: it must never be
+	// reported as an upstream fault, or user cancels would poison channel
+	// health. No content verdict is produced for an answer the client never
+	// let the upstream finish.
+	if end != streamEndedClientDisconnect {
+		t.Fatalf("outcome = %v, want streamEndedClientDisconnect", end)
+	}
+	if verdict != nil {
+		t.Fatalf("client disconnect must not carry a content verdict, got %+v", verdict)
+	}
 	if !usage.Found {
 		t.Fatal("expected usage retained after client disconnect on usage chunk")
 	}
@@ -1121,7 +1131,12 @@ func TestHandleStreamUpstreamContextCancelPreservesPartialUsage(t *testing.T) {
 	resp.Header.Set("Content-Type", "text/event-stream")
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
-	usage, _ := handleStreamUpstream(rec, req, resp, 1)
+	usage, end, _ := handleStreamUpstream(rec, req, resp, 1)
+	// Whichever side of the race wins, a canceled downstream context can never
+	// be classified as an upstream fault.
+	if end != streamEndedClientDisconnect && end != streamEndedNormally {
+		t.Fatalf("outcome = %v, want clientDisconnect or normally", end)
+	}
 	// Pre-canceled before any read: must not invent usage.
 	if usage.Found {
 		// If runtime read wins the race and extracts, that is also correct — accept either.

--- a/proxy/failure_judge.go
+++ b/proxy/failure_judge.go
@@ -20,16 +20,74 @@ type UsageSummary struct {
 	TotalTokens      int
 }
 
-// DetectProxyFailure detects proxy failures from response content.
-// This is PURELY content-based — it does NOT look at HTTP status codes.
-// Called AFTER a non-stream response body is received.
+// FailureCode names why the single content judge declared a failure. Buffered
+// and streaming paths surface exactly this set, so one code means the same
+// thing wherever it is logged, stored or alerted on.
+type FailureCode string
+
+const (
+	// FailureCodeNone means the content judgement found no failure.
+	FailureCodeNone FailureCode = ""
+	// FailureCodeErrorKeyword means the upstream content matched an operator
+	// configured PROXY_ERROR_KEYWORDS entry.
+	FailureCodeErrorKeyword FailureCode = "upstream_error_keyword"
+	// FailureCodeEmptyContent means PROXY_EMPTY_CONTENT_FAIL is enabled and the
+	// upstream produced neither completion output nor completion tokens.
+	FailureCodeEmptyContent FailureCode = "upstream_empty_content"
+)
+
+// UpstreamContentFacts is the protocol-agnostic description of what an upstream
+// actually returned. Each call path fills it from data it already has: the
+// buffered path from the raw response body, the streaming path from the bounded
+// incremental SSE analyzer (which never retains the raw body).
+type UpstreamContentFacts struct {
+	// StatusCode is the HTTP status the upstream answered with. The judgement
+	// itself stays status-agnostic (callers only judge 2xx answers); it is
+	// carried so a verdict can be traced back to its attempt.
+	StatusCode int
+	// Streaming marks the SSE path, which has no raw body to inspect.
+	Streaming bool
+	// RawText is the content to keyword-scan. Buffered: the full response body.
+	// Streaming: the concatenated SSE error-event payloads, the only content
+	// signal the bounded analyzer keeps.
+	RawText string
+	// HasOutput reports whether the upstream produced completion content.
+	// Streaming callers set it from the analyzer data-event flag; the buffered
+	// path leaves it false and the judge derives it from RawText.
+	HasOutput bool
+	// Usage is the parsed usage summary (nil when the upstream sent none).
+	Usage *UsageSummary
+}
+
+// UpstreamVerdict is the single content judgement result.
+type UpstreamVerdict struct {
+	Failed bool
+	Code   FailureCode
+	Status int
+	Reason string
+}
+
+// JudgeUpstreamContent is the ONE owner of content-level failure judgement.
+// Both the buffered and the streaming dispatch path call it, so the two can no
+// longer drift apart in judgement strength — the historical split (buffered
+// judged, stream only logged) is what let a failed upstream answer be recorded
+// as a success.
+//
+// Pure: no I/O, no *http.Response, no protocol plumbing. Same facts in, same
+// verdict out.
 //
 // Detection:
-// 1. Keyword matching: if config.ProxyErrorKeywords is non-empty, checks case-insensitive
+// 1. Keyword matching: if config.ProxyErrorKeywords is non-empty, case-insensitive
 // 2. Empty content check: if ProxyEmptyContentFailEnabled and no completion tokens + no output
-func DetectProxyFailure(rawText string, usage *UsageSummary) *FailureResult {
-	rt := config.Runtime()
-	rawText = strings.TrimSpace(rawText)
+func JudgeUpstreamContent(facts UpstreamContentFacts) UpstreamVerdict {
+	pass := UpstreamVerdict{Code: FailureCodeNone}
+	rt := config.RuntimeSafe()
+	if rt == nil {
+		// No published runtime snapshot: nothing is configured, so nothing can
+		// be judged. Never invent a failure (and never panic on a request path).
+		return pass
+	}
+	rawText := strings.TrimSpace(facts.RawText)
 
 	// 1. Keyword matching
 	if len(rt.ProxyErrorKeywords) > 0 {
@@ -40,7 +98,9 @@ func DetectProxyFailure(rawText string, usage *UsageSummary) *FailureResult {
 				continue
 			}
 			if strings.Contains(normalizedText, kw) {
-				return &FailureResult{
+				return UpstreamVerdict{
+					Failed: true,
+					Code:   FailureCodeErrorKeyword,
 					Status: 502,
 					Reason: "Upstream response matched failure keyword: " + kw,
 				}
@@ -51,19 +111,38 @@ func DetectProxyFailure(rawText string, usage *UsageSummary) *FailureResult {
 	// 2. Empty content check
 	if rt.ProxyEmptyContentFailEnabled {
 		compTokens := 0
-		if usage != nil {
-			compTokens = usage.CompletionTokens
+		if facts.Usage != nil {
+			compTokens = facts.Usage.CompletionTokens
 		}
-		hasOutput := detectHasUpstreamOutput(rawText)
+		hasOutput := facts.HasOutput
+		if !facts.Streaming {
+			hasOutput = detectHasUpstreamOutput(rawText)
+		}
 		if !hasOutput && compTokens <= 0 {
-			return &FailureResult{
+			return UpstreamVerdict{
+				Failed: true,
+				Code:   FailureCodeEmptyContent,
 				Status: 502,
 				Reason: "Upstream returned empty content",
 			}
 		}
 	}
 
-	return nil
+	return pass
+}
+
+// DetectProxyFailure detects proxy failures from response content.
+// This is PURELY content-based — it does NOT look at HTTP status codes.
+//
+// Kept as the buffered-path shaped wrapper over JudgeUpstreamContent so there
+// is still exactly one implementation of the judgement; callers that already
+// have parsed content should prefer JudgeUpstreamContent directly.
+func DetectProxyFailure(rawText string, usage *UsageSummary) *FailureResult {
+	verdict := JudgeUpstreamContent(UpstreamContentFacts{RawText: rawText, Usage: usage})
+	if !verdict.Failed {
+		return nil
+	}
+	return &FailureResult{Status: verdict.Status, Reason: verdict.Reason}
 }
 
 // detectHasUpstreamOutput checks if raw text contains actual upstream output.

--- a/proxy/failure_judge.go
+++ b/proxy/failure_judge.go
@@ -7,12 +7,6 @@ import (
 	"github.com/deliciousbuding/metapi-go/config"
 )
 
-// FailureResult is a content-based failure detection result.
-type FailureResult struct {
-	Status int
-	Reason string
-}
-
 // UsageSummary is a lightweight usage summary for failure detection.
 type UsageSummary struct {
 	PromptTokens     int
@@ -129,20 +123,6 @@ func JudgeUpstreamContent(facts UpstreamContentFacts) UpstreamVerdict {
 	}
 
 	return pass
-}
-
-// DetectProxyFailure detects proxy failures from response content.
-// This is PURELY content-based — it does NOT look at HTTP status codes.
-//
-// Kept as the buffered-path shaped wrapper over JudgeUpstreamContent so there
-// is still exactly one implementation of the judgement; callers that already
-// have parsed content should prefer JudgeUpstreamContent directly.
-func DetectProxyFailure(rawText string, usage *UsageSummary) *FailureResult {
-	verdict := JudgeUpstreamContent(UpstreamContentFacts{RawText: rawText, Usage: usage})
-	if !verdict.Failed {
-		return nil
-	}
-	return &FailureResult{Status: verdict.Status, Reason: verdict.Reason}
 }
 
 // detectHasUpstreamOutput checks if raw text contains actual upstream output.

--- a/proxy/failure_judge_test.go
+++ b/proxy/failure_judge_test.go
@@ -8,7 +8,7 @@ import (
 
 func setupFailureCfg(keywords []string, emptyContentFail bool) {
 	cfg, rt := config.Load(map[string]string{
-		"PORT":                    "8080",
+		"PORT":                     "8080",
 		"PROXY_EMPTY_CONTENT_FAIL": boolToString(emptyContentFail),
 	})
 	if len(keywords) > 0 {
@@ -26,12 +26,21 @@ func boolToString(b bool) string {
 	return "false"
 }
 
-func TestDetectProxyFailure_KeywordMatching(t *testing.T) {
+// judgeBuffered is the buffered-shaped call of the single content judge: these
+// keyword / empty-content cases only have a raw body and a parsed usage
+// summary, which is exactly the fact set the buffered dispatch path hands over.
+// The verdict is a struct (not a pointer), so "no failure" reads as
+// !result.Failed — there is no second nil-shaped vocabulary for the same idea.
+func judgeBuffered(rawText string, usage *UsageSummary) UpstreamVerdict {
+	return JudgeUpstreamContent(UpstreamContentFacts{RawText: rawText, Usage: usage})
+}
+
+func TestJudgeUpstreamContent_KeywordMatching(t *testing.T) {
 	t.Run("matches error keyword", func(t *testing.T) {
 		setupFailureCfg([]string{"overloaded", "blocked"}, false)
 
-		result := DetectProxyFailure("The server is overloaded, please try later", nil)
-		if result == nil {
+		result := judgeBuffered("The server is overloaded, please try later", nil)
+		if !result.Failed {
 			t.Fatal("expected failure detected via keyword")
 		}
 		if result.Status != 502 {
@@ -45,8 +54,8 @@ func TestDetectProxyFailure_KeywordMatching(t *testing.T) {
 	t.Run("case-insensitive matching", func(t *testing.T) {
 		setupFailureCfg([]string{"OVERLOADED"}, false)
 
-		result := DetectProxyFailure("Server is overloaded", nil)
-		if result == nil {
+		result := judgeBuffered("Server is overloaded", nil)
+		if !result.Failed {
 			t.Fatal("expected case-insensitive match")
 		}
 	})
@@ -54,8 +63,8 @@ func TestDetectProxyFailure_KeywordMatching(t *testing.T) {
 	t.Run("multiple keywords, matches first", func(t *testing.T) {
 		setupFailureCfg([]string{"error", "blocked", "unavailable"}, false)
 
-		result := DetectProxyFailure("This API is blocked", nil)
-		if result == nil {
+		result := judgeBuffered("This API is blocked", nil)
+		if !result.Failed {
 			t.Fatal("expected keyword match")
 		}
 	})
@@ -63,8 +72,8 @@ func TestDetectProxyFailure_KeywordMatching(t *testing.T) {
 	t.Run("no keyword match", func(t *testing.T) {
 		setupFailureCfg([]string{"overloaded"}, false)
 
-		result := DetectProxyFailure("Everything is fine", nil)
-		if result != nil {
+		result := judgeBuffered("Everything is fine", nil)
+		if result.Failed {
 			t.Errorf("expected no failure, got reason: %s", result.Reason)
 		}
 	})
@@ -72,8 +81,8 @@ func TestDetectProxyFailure_KeywordMatching(t *testing.T) {
 	t.Run("empty keyword list", func(t *testing.T) {
 		setupFailureCfg([]string{}, false)
 
-		result := DetectProxyFailure("Some error occurred", nil)
-		if result != nil {
+		result := judgeBuffered("Some error occurred", nil)
+		if result.Failed {
 			t.Errorf("expected no failure with empty keywords, got reason: %s", result.Reason)
 		}
 	})
@@ -81,8 +90,8 @@ func TestDetectProxyFailure_KeywordMatching(t *testing.T) {
 	t.Run("empty keyword (whitespace only) skips", func(t *testing.T) {
 		setupFailureCfg([]string{"  ", "blocked"}, false)
 
-		result := DetectProxyFailure("The user is blocked", nil)
-		if result == nil {
+		result := judgeBuffered("The user is blocked", nil)
+		if !result.Failed {
 			t.Fatal("expected match for non-empty keyword")
 		}
 	})
@@ -90,8 +99,8 @@ func TestDetectProxyFailure_KeywordMatching(t *testing.T) {
 	t.Run("empty text input", func(t *testing.T) {
 		setupFailureCfg([]string{"error"}, false)
 
-		result := DetectProxyFailure("", nil)
-		if result != nil {
+		result := judgeBuffered("", nil)
+		if result.Failed {
 			t.Errorf("expected no failure for empty text, got: %s", result.Reason)
 		}
 	})
@@ -99,23 +108,23 @@ func TestDetectProxyFailure_KeywordMatching(t *testing.T) {
 	t.Run("whitespace-only text input", func(t *testing.T) {
 		setupFailureCfg([]string{"error"}, false)
 
-		result := DetectProxyFailure("   \n  ", nil)
-		if result != nil {
+		result := judgeBuffered("   \n  ", nil)
+		if result.Failed {
 			t.Errorf("expected no failure for whitespace text, got: %s", result.Reason)
 		}
 	})
 }
 
-func TestDetectProxyFailure_EmptyContent(t *testing.T) {
+func TestJudgeUpstreamContent_EmptyContent(t *testing.T) {
 	t.Run("empty content fail enabled, no tokens, no output", func(t *testing.T) {
 		setupFailureCfg([]string{}, true)
 
-		result := DetectProxyFailure(`{"id":"test"}`, &UsageSummary{
+		result := judgeBuffered(`{"id":"test"}`, &UsageSummary{
 			PromptTokens:     100,
 			CompletionTokens: 0,
 			TotalTokens:      100,
 		})
-		if result == nil {
+		if !result.Failed {
 			t.Fatal("expected failure for empty content")
 		}
 		if result.Status != 502 {
@@ -126,11 +135,11 @@ func TestDetectProxyFailure_EmptyContent(t *testing.T) {
 	t.Run("empty content fail enabled, has completion tokens", func(t *testing.T) {
 		setupFailureCfg([]string{}, true)
 
-		result := DetectProxyFailure("{}", &UsageSummary{
+		result := judgeBuffered("{}", &UsageSummary{
 			CompletionTokens: 50,
 			TotalTokens:      150,
 		})
-		if result != nil {
+		if result.Failed {
 			t.Errorf("expected no failure (has completion tokens)")
 		}
 	})
@@ -138,8 +147,8 @@ func TestDetectProxyFailure_EmptyContent(t *testing.T) {
 	t.Run("empty content fail enabled, nil usage", func(t *testing.T) {
 		setupFailureCfg([]string{}, true)
 
-		result := DetectProxyFailure(`{}`, nil)
-		if result == nil {
+		result := judgeBuffered(`{}`, nil)
+		if !result.Failed {
 			t.Fatal("expected failure (nil usage, no output)")
 		}
 	})
@@ -147,10 +156,10 @@ func TestDetectProxyFailure_EmptyContent(t *testing.T) {
 	t.Run("empty content fail disabled", func(t *testing.T) {
 		setupFailureCfg([]string{}, false)
 
-		result := DetectProxyFailure(`{}`, &UsageSummary{
+		result := judgeBuffered(`{}`, &UsageSummary{
 			CompletionTokens: 0,
 		})
-		if result != nil {
+		if result.Failed {
 			t.Errorf("expected no failure when empty content fail disabled")
 		}
 	})
@@ -247,14 +256,14 @@ func TestDetectHasUpstreamOutput(t *testing.T) {
 	})
 }
 
-func TestDetectProxyFailure_Combined(t *testing.T) {
+func TestJudgeUpstreamContent_Combined(t *testing.T) {
 	t.Run("keyword takes priority over empty content", func(t *testing.T) {
 		setupFailureCfg([]string{"quota"}, true)
 
-		result := DetectProxyFailure("quota exceeded", &UsageSummary{
+		result := judgeBuffered("quota exceeded", &UsageSummary{
 			CompletionTokens: 0,
 		})
-		if result == nil {
+		if !result.Failed {
 			t.Fatal("expected failure from keyword")
 		}
 		if result.Status != 502 {
@@ -265,8 +274,8 @@ func TestDetectProxyFailure_Combined(t *testing.T) {
 	t.Run("no keyword, has content, empty content check skipped", func(t *testing.T) {
 		setupFailureCfg([]string{}, true)
 
-		result := DetectProxyFailure("This is fine", nil)
-		if result != nil {
+		result := judgeBuffered("This is fine", nil)
+		if result.Failed {
 			t.Errorf("expected no failure (plain text detected as output)")
 		}
 	})


### PR DESCRIPTION
## 改动摘要

数据面「诚实性」三连修：流式请求的中断 / 截断 / 空内容不再被记成成功，内容级失败判定只有一个所有者，跨协议回落只有一个决策函数。

**改之前**：`handleStreamUpstream` 只区分「idle 超时」与「其它一律 `streamEndedNormally`」，而流式路径对内容的判定只写日志（`slog.Warn`）不参与记账 —— 于是上游中途断连、被 `PROXY_MAX_STREAM_RESPONSE_BYTES` 截断、或返回命中 `PROXY_ERROR_KEYWORDS` 的错误体时，渠道健康度、`proxy_logs`、终端指标全部按成功记账；同时 5 处 `!isLastEndpoint && !disableCrossProtocolFallback` 裸判断绕过了 same-site abort 策略。

**改之后**：

- `proxy.JudgeUpstreamContent(UpstreamContentFacts) → UpstreamVerdict`：纯函数、无 I/O、无 `*http.Response`，是内容级失败判定（关键字 + 空内容两条规则）的唯一实现，带 `FailureCode` 原因码；buffered 与 streaming 两条路径喂同一份事实，用结构体全等断言钉住「同一份上游内容不可能得出两个结论」。缺 runtime 快照时判「无失败」而不是在请求路径上 panic。
- `streamOutcome` 从 2 值扩到 5 值：`normally / idleTimeout / upstreamFault / truncated / clientDisconnect`；读错误三分（idle guard 触发 / 下游 ctx 取消 / 上游故障），`endStream` 成为唯一出口（原先有一处 log-only 的平行实现）。
- `streamFailureVerdict`：「非正常结束如何上报」的唯一所有者 —— status、reason、终端指标 outcome 同源，渠道健康度 / 日志 / 指标不会再对同一条流各说各话。
- `shouldContinueEndpointFallback`：所有回落决策（HTTP 状态、内容失败、传输错误）的唯一入口；新增 `endpointFailureClass` 让「首字节超时故意豁免 same-site abort」成为显式参数，而不是调用点上的第二份判断。

**客户端主动断开不算上游失败**：`clientDisconnect` 仍走成功记账（不拿用户取消行为毒化渠道健康度），但不再与干净 EOF 混为一类；已提取到的 usage 照常返回用于计费，绝不凭空造 token。

顺带删掉 `DetectProxyFailure` / `FailureResult`：判定收口后它们零生产调用方，只剩自己的测试在维持「同一决策的第二个名字」。

## 类型

- [x] fix（bug 修复）
- [x] refactor（重构，行为不变）

## 测试验证

- [x] `go vet ./proxy/... ./handler/proxy/...` 通过
- [x] `go test ./proxy/... ./handler/proxy/... -count=1 -race` 通过
- [x] 基线对比：`--- PASS` 517 → **525**（+8 = 新增用例数），`--- SKIP` **0 → 0**（无新增跳过），`--- FAIL` 0
- 新增 `handler/proxy/upstream_stream_honesty_test.go`（485 行 / 8 个顶层用例），全部钉**生产路径** `HandleChatCompletions → dispatchEndpointAttemptWithContinue → handleStreamUpstream`，不给并行 fallback 实现刷覆盖率
- 三条主修各自「先红后绿」：① 把分发器改回「只有 idle 走失败」→ 3 个用例 FAIL；② 让流式路径不调共享判官 → 双路径一致性用例 FAIL；③ 把一处传输错误改回裸判断 → 单决策函数用例 FAIL；三次还原后与改前逐字节一致
- `rg -n '!isLastEndpoint' handler/proxy/ proxy/` → 0 命中（连注释里的字面量都改写掉，门禁不被污染）

## 自查清单

- [x] 无密钥 / 内部路径泄漏
- [ ] 用户可见文案已走 i18n（本 PR 无前端文案）
- [x] 行为变更已补充 / 更新测试
- [ ] 需要时更新了 `CHANGELOG.md` / `docs/`（发版时统一补 CHANGELOG）

### 本 PR 刻意不做（避免顺手活把 diff 撑大）

- 不给 `proxy_logs` 加 `stream_end_reason` 列（需要 migration，属另一条改动的地界）。当前 5 值区分落在 `status` / `http_status`（408 idle、502 fault+truncated）/ `error_summary` 三种文案上；按「断流 vs 截断」做精确聚合需要 LIKE 匹配，粒度略粗，留作后续裁决。
- abort / 重试策略的两份协议提示语清单（`proxy/endpoint_flow.go` 的内联子串表 vs `proxy/retry_policy.go` 的 `retryableChannelLocalPatterns` 正则表）语义重叠、形式不同，本轮未合并。
- 并行 fallback（Executor）路径仍几乎无测试覆盖，本 PR 不假装覆盖它。

> 合并方式：Squash merge（master 受保护）。
