### PR TITLE
docs: make the public reference reconcilable — env parity, route inventory, ownership architecture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,7 +53,8 @@ PROXY_TOKEN=change-me-proxy-sk-token
 # Default 20 MB (20971520). 0/negative/invalid falls back to default at Load time.
 PROXY_MAX_BUFFERED_RESPONSE_BYTES=20971520
 # Max total bytes relayed for a single SSE stream before a controlled termination.
-# Default 1 MB (1048576). 0/negative/invalid falls back to default at Load time.
+# Default 64 MB (67108864), matching DefaultProxyMaxStreamResponseBytes.
+# 0/negative/invalid falls back to the default at Load time.
 PROXY_MAX_STREAM_RESPONSE_BYTES=67108864
 # Test/demo only. Leave empty in production; unconfigured upstream forwarding returns 503.
 METAPI_ENABLE_PROXY_STUB=

--- a/README.md
+++ b/README.md
@@ -230,7 +230,9 @@ Claude 原生格式（`/v1/messages`）、Responses、Embeddings、Images、`/v1
 | [docs/api.md](docs/api.md)                               | HTTP API 端点清单                                     |
 | [docs/migration.md](docs/migration.md)                   | TS → Go 迁移（SQLite / PG / MySQL）                   |
 | [docs/faq.md](docs/faq.md)                               | 常见问题                                              |
-| [docs/architecture.md](docs/architecture.md)             | 包结构与请求路径（开发者）                            |
+| [docs/api/routes-inventory.md](docs/api/routes-inventory.md) | 已注册 `/api` 路由全量清单（由 `docs/api_inventory_parity_test.go` 与代码对账） |
+| [docs/configuration.md](docs/configuration.md)         | 每个环境变量的真实默认值与钳制规则（由 `docs/env_parity_test.go` 与 `.env.example`、`config/config.go` 对账） |
+| [docs/architecture.md](docs/architecture.md)             | 分层与所有权边界、一次 `/v1` 请求经过哪些阶段（改代码或排查归属前读） |
 | [CHANGELOG.md](CHANGELOG.md)                             | 版本变更                                              |
 
 ## 从 TypeScript 版迁移

--- a/README_EN.md
+++ b/README_EN.md
@@ -255,7 +255,9 @@ database); the Docker image ships `metapi healthcheck`, which probes `/ready`.
 | [docs/api.md](docs/api.md)                                   | HTTP API endpoint inventory                          |
 | [docs/migration.md](docs/migration.md)                       | TS → Go migration (SQLite / PG / MySQL)              |
 | [docs/faq.md](docs/faq.md)                                   | Frequently asked questions                           |
-| [docs/architecture.md](docs/architecture.md)                 | Package map & request paths (developers)             |
+| [docs/api/routes-inventory.md](docs/api/routes-inventory.md) | Full registered `/api` route list (kept in sync with the code by `docs/api_inventory_parity_test.go`) |
+| [docs/configuration.md](docs/configuration.md)               | Real default and clamp for every environment variable (kept in sync with `.env.example` and `config/config.go` by `docs/env_parity_test.go`) |
+| [docs/architecture.md](docs/architecture.md)                 | Layering, ownership boundaries, and the stages a `/v1` request passes through (read before moving code or deciding who owns a bug) |
 | [CHANGELOG.md](CHANGELOG.md)                                 | Release notes                                        |
 
 ## Migrating from the TypeScript version

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -74,8 +74,6 @@ Generate sync mappings idempotently (per account or all accounts), or apply redi
 
 ---
 
----
-
 ## Model catalog data sources & sync
 
 The merged model catalog is built from a DB-persisted registry
@@ -165,7 +163,7 @@ request per row. The query is written to run on both SQLite and PostgreSQL.
       "results": [
         {
           "id": 1041,
-          "status": "ok",
+          "status": "success",
           "latencyMs": 812.5,
           "httpStatus": 200,
           "errorText": null,
@@ -180,7 +178,8 @@ request per row. The query is written to run on both SQLite and PostgreSQL.
 
 The grouping key is `channelId` on the channels endpoint and `accountId` on the
 accounts endpoint. Within one entity, results are newest-first, so
-`results[0]` is the latest probe. `latencyMs`, `httpStatus` and `errorText` are
+`results[0]` is the latest probe. `status` shares the probe vocabulary used
+everywhere else: `success` | `failure` | `inconclusive` | `skipped`. `latencyMs`, `httpStatus` and `errorText` are
 nullable — a probe that never got a response has no latency or HTTP status.
 Entities with no probe results at all are simply absent from `items`.
 **Errors**: `500` `Failed to load probe history` on a query failure.

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -73,3 +73,114 @@ Generate sync mappings idempotently (per account or all accounts), or apply redi
 **Body** (apply): `{ "dryRun": false }` (default `true` = report only). Dry run: `{ success, dryRun: true, candidates, count }`; applied: `{ success, dryRun: false, removed, count }` — each removal writes a `model_redirect_applied` event.
 
 ---
+
+---
+
+## Model catalog data sources & sync
+
+The merged model catalog is built from a DB-persisted registry
+(`catalog_sources`), not from a single hardcoded feed. Sources are fetched in
+list order and **earlier sources override later ones**; per-source sync status
+(last success, last error, entry count) is recorded as it goes. Registered by
+`RegisterCatalogSourceRoutes`; the runtime side lives in `service/catalogsync`
+(`Manager`, `Store`).
+
+All routes below sit on the admin surface: same auth, error envelope and
+pagination conventions as everything else in [`conventions.md`](conventions.md).
+When `PRICING_CATALOG_ENABLED=false` there is no runtime manager, and the
+`catalog-sync` routes answer `409` with
+`{"message": "pricing catalog is disabled (PRICING_CATALOG_ENABLED=false)"}`;
+the `catalog-sources` CRUD routes keep working, because they talk to the store
+directly.
+
+### GET /api/models/catalog-sources
+
+**Response**: `{"sources": [...]}` in the order the merge is applied.
+**Errors**: `500` `failed to list catalog sources`.
+
+### POST /api/models/catalog-sources
+
+**Body**: `{ "name": "...", "url": "...", "type": "...", "enabled": true }`
+(`type` and `enabled` optional).
+**Response**: `{"source": {...}}`. When a runtime manager exists the registry is
+reloaded immediately, so the next merge sees the new source.
+**Errors**: `400` `{"message": "invalid JSON body"}` on malformed JSON; `400`
+with the store's validation message on a rejected source; `500`
+`failed to reload catalog sources` when the reload after a successful write
+fails.
+
+### PUT /api/models/catalog-sources/{id}, DELETE /api/models/catalog-sources/{id}
+
+Update (same body as create, partial) or remove one source; both reload the
+registry afterwards.
+**Errors**: `400` `{"message": "invalid source id"}` when `{id}` is not a
+positive integer; `404` `{"message": "source not found"}` when the row is gone;
+`500` on a store or reload failure.
+
+### POST /api/models/catalog-sync
+
+Triggers a sync now — all sources, or one when a body is given.
+**Body** (optional): `{"sourceId": 123}`; an absent or empty body syncs every
+source.
+**Errors**: `409` when the catalog is disabled (see above); `400`
+`{"message": "invalid JSON body"}` when a body is present but malformed.
+
+### GET /api/models/catalog-sync
+
+**Response**: the manager's status — the auto-sync flag plus per-source last
+success / last error / entry count.
+**Errors**: `409` with `{"message": ..., "autoSync": false}` when the catalog is
+disabled.
+
+### PUT /api/models/catalog-sync/config
+
+**Body**: `{"autoSync": true}` — the field is **required**.
+**Errors**: `400` `{"message": "invalid JSON body: autoSync required"}` when the
+body is malformed or `autoSync` is absent; `409` when the catalog is disabled.
+
+---
+
+## Probe history
+
+Read-only exposure of `model_probe_results` for the row-level health bars on
+the channels and accounts pages. The probe scheduler is the **only** writer, so
+these endpoints are empty unless `MODEL_AVAILABILITY_PROBE_ENABLED=true` has
+been running long enough to record something.
+
+Both endpoints answer one bounded window-function query per page render (the
+most recent N results *per entity*), which is why the tables do not issue a
+request per row. The query is written to run on both SQLite and PostgreSQL.
+
+### GET /api/channels/probe-history, GET /api/accounts/probe-history
+
+**Query params**: `limit` — results per entity, default `20`, capped at `50`.
+**Response**:
+
+```json
+{
+  "limit": 20,
+  "items": [
+    {
+      "channelId": 7,
+      "results": [
+        {
+          "id": 1041,
+          "status": "ok",
+          "latencyMs": 812.5,
+          "httpStatus": 200,
+          "errorText": null,
+          "modelName": "gpt-4o",
+          "createdAt": "2026-09-03T08:15:00Z"
+        }
+      ]
+    }
+  ]
+}
+```
+
+The grouping key is `channelId` on the channels endpoint and `accountId` on the
+accounts endpoint. Within one entity, results are newest-first, so
+`results[0]` is the latest probe. `latencyMs`, `httpStatus` and `errorText` are
+nullable — a probe that never got a response has no latency or HTTP status.
+Entities with no probe results at all are simply absent from `items`.
+**Errors**: `500` `Failed to load probe history` on a query failure.

--- a/docs/api/routes-inventory.md
+++ b/docs/api/routes-inventory.md
@@ -3,7 +3,9 @@
 > **Index**: back to [API Reference](../api.md). This file is the Full registered /api route inventory domain split out of the pre-`docs/api/` `docs/api.md`.
 
 ## Admin Route Inventory
-Complete list of registered `/api` admin routes (generated from the router registration). Path parameters use `:param` syntax.
+Complete list of registered `/api` admin routes. Path parameters use `:param` notation here; the code registers the chi `{param}` form, and the two are the same route.
+
+This list is checked against the routes reachable from `router.New` by `docs/api_inventory_parity_test.go`: a route registered in code but missing here, or listed here but not registered, fails CI. Request and response shapes live in the per-domain pages under [`docs/api/`](../api/); the shared error envelope, auth surfaces and pagination conventions are in [`conventions.md`](conventions.md).
 
 ### GET
 - `/api/about`
@@ -13,6 +15,7 @@ Complete list of registered `/api` admin routes (generated from the router regis
 - `/api/account-tokens/groups/:accountId`
 - `/api/accounts`
 - `/api/accounts/:id/models`
+- `/api/accounts/probe-history`
 - `/api/admin/audit-logs`
 - `/api/admin/ops/ws`
 - `/api/admin/resin/status`
@@ -21,6 +24,7 @@ Complete list of registered `/api` admin routes (generated from the router regis
 - `/api/auth/session`
 - `/api/channels`
 - `/api/channels/error-summary`
+- `/api/channels/probe-history`
 - `/api/checkin/logs`
 - `/api/debug/vars`
 - `/api/desktop/health`
@@ -32,6 +36,8 @@ Complete list of registered `/api` admin routes (generated from the router regis
 - `/api/events`
 - `/api/events/count`
 - `/api/model-redirects`
+- `/api/models/catalog-sources`
+- `/api/models/catalog-sync`
 - `/api/models/marketplace`
 - `/api/models/price-compare`
 - `/api/models/rates`
@@ -85,11 +91,7 @@ Complete list of registered `/api` admin routes (generated from the router regis
 - `/api/test/proxy/jobs/:jobId`
 - `/api/update-center/status`
 - `/api/update-center/tasks/:id/stream`
-
 ### POST
-- `/api/auth/login`
-- `/api/auth/logout`
-- `/api/auth/ws-ticket`
 - `/api/account-tokens`
 - `/api/account-tokens/:id/default`
 - `/api/account-tokens/batch`
@@ -106,6 +108,9 @@ Complete list of registered `/api` admin routes (generated from the router regis
 - `/api/admin/test-channel`
 - `/api/announcements`
 - `/api/announcements/:id/dismiss`
+- `/api/auth/login`
+- `/api/auth/logout`
+- `/api/auth/ws-ticket`
 - `/api/checkin/trigger`
 - `/api/checkin/trigger/:id`
 - `/api/debug/channel-probe`
@@ -116,6 +121,8 @@ Complete list of registered `/api` admin routes (generated from the router regis
 - `/api/events/read-all`
 - `/api/model-redirects/apply`
 - `/api/model-redirects/generate`
+- `/api/models/catalog-sources`
+- `/api/models/catalog-sync`
 - `/api/models/check/:accountId`
 - `/api/models/probe`
 - `/api/models/verify-batch`
@@ -168,7 +175,6 @@ Complete list of registered `/api` admin routes (generated from the router regis
 - `/api/update-center/check`
 - `/api/update-center/deploy`
 - `/api/update-center/rollback`
-
 ### PUT
 - `/api/account-tokens/:id`
 - `/api/accounts/:id`
@@ -179,6 +185,8 @@ Complete list of registered `/api` admin routes (generated from the router regis
 - `/api/checkin/schedule`
 - `/api/downstream-keys/:id`
 - `/api/model-redirects/:id`
+- `/api/models/catalog-sources/:id`
+- `/api/models/catalog-sync/config`
 - `/api/models/rates`
 - `/api/monitor/config`
 - `/api/routes/:id`
@@ -190,7 +198,6 @@ Complete list of registered `/api` admin routes (generated from the router regis
 - `/api/sites/:id/disabled-models`
 - `/api/sites/:id/tags`
 - `/api/update-center/config`
-
 ### PATCH
 - `/api/oauth/connections/:accountId/proxy`
 - `/api/oauth/route-units/:routeUnitId`
@@ -203,6 +210,7 @@ Complete list of registered `/api` admin routes (generated from the router regis
 - `/api/downstream-keys/:id`
 - `/api/events`
 - `/api/model-redirects/:id`
+- `/api/models/catalog-sources/:id`
 - `/api/monitor/session`
 - `/api/oauth/connections/:accountId`
 - `/api/oauth/route-units/:routeUnitId`

--- a/docs/api_inventory_parity_test.go
+++ b/docs/api_inventory_parity_test.go
@@ -1,0 +1,627 @@
+package docs_test
+
+// TestAPIRouteInventoryParity locks docs/api/routes-inventory.md to the
+// routes the Go code actually registers, so the published inventory cannot
+// drift when a handler is added, renamed or removed.
+//
+// Extraction is pure Go source parsing (go/parser + go/ast) — no shell, no
+// ripgrep, no committed fixture that can go stale on its own.
+//
+// How the live route set is rebuilt:
+//
+//  1. Every non-test .go file under router/ and handler/ is parsed and all
+//     top-level functions are indexed by name.
+//  2. The traversal starts at router.New — the only composition root — so a
+//     registrar that exists but is never wired is NOT counted as a live
+//     route. An unwired handler must not make the docs claim an endpoint.
+//  3. Inside each function, chi registrations on a router-shaped receiver
+//     are collected: the HTTP verbs (Get/Post/Put/Patch/Delete/Head/Options)
+//     plus Handle/HandleFunc (recorded as method ANY). Only string-literal
+//     paths that start with "/" count, which is what keeps header lookups
+//     such as r.Header.Get("Content-Type") and query lookups such as
+//     r.URL.Query().Get("page") out of the route set even though they share
+//     the receiver name.
+//  4. `r.Route("/prefix", func(r chi.Router){...})` and `r.Mount` scopes
+//     prefix everything registered inside them, and `r.Group`/`r.With` do
+//     not. Calls into other registrars (admin.RegisterSitesRoutes(r, db),
+//     proxyhandler.RegisterProxyRoutes(r), RegisterFilesRoutes(r)) are
+//     resolved by function name across files, inheriting the caller's
+//     prefix — this is what turns the relative "/chat/completions" inside
+//     RegisterProxyRoutes into "/v1/chat/completions" without a hardcoded
+//     mount table.
+//  5. Registrars are resolved per Go package: a qualified call
+//     admin.RegisterSitesRoutes(r, db) resolves through the calling file's
+//     import list, an unqualified RegisterFilesRoutes(r) resolves within the
+//     caller's own package. Indexing by (package, name) is what keeps common
+//     helper names that exist in both handler/admin and handler/proxy
+//     (writeJSON and friends) from colliding.
+//  6. Two route shapes are deliberately NOT enumerated, and both are static
+//     asset serving rather than API contracts (docs/architecture.md):
+//     paths built by concatenation (the SPA's root logo/favicon and
+//     bootstrap-script handlers) and the embedded dist subtrees mounted by
+//     router.mountStaticSubdir, whose route pattern arrives as a function
+//     argument ("/assets/*", "/static/*") instead of a literal.
+//
+// Path parameters are normalized before comparison: chi v5 accepts both
+// `:id` and `{id}`, this repository writes `{id}` in code while the
+// inventory documents `:id`, and `*` becomes `{wildcard}`.
+//
+// Scope: the inventory documents the /api admin surface, so parity is
+// asserted on /api routes. Every non-/api route still has to be owned by a
+// named document via nonAPIRouteAllowlist (TestNonAPIRoutesAreAccountedFor),
+// and both allowlists are checked for stale entries, so an allowlist cannot
+// accumulate routes that no longer exist.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// routeVerbs are the chi registration methods that create a route.
+var routeVerbs = map[string]string{
+	"Get": "GET", "Post": "POST", "Put": "PUT", "Patch": "PATCH",
+	"Delete": "DELETE", "Head": "HEAD", "Options": "OPTIONS",
+	"Handle": "ANY", "HandleFunc": "ANY",
+}
+
+// routerIdents are the receiver names used for chi routers in this repo.
+var routerIdents = map[string]bool{"r": true, "rr": true, "router": true, "sub": true, "mux": true}
+
+// inventoryAllowlist lists registered /api routes deliberately NOT published
+// in docs/api/routes-inventory.md. Each entry needs a reason; an entry that
+// no longer matches a live route fails TestAPIRouteInventoryParity, so this
+// map cannot rot into a hiding place.
+var inventoryAllowlist = map[string]string{}
+
+// nonAPIRouteAllowlist maps each registered non-/api route to the document
+// that owns its contract.
+var nonAPIRouteAllowlist = map[string]string{
+	// Public liveness / readiness / metrics — docs/deployment.md.
+	"GET /health":  "docs/deployment.md",
+	"GET /ready":   "docs/deployment.md",
+	"GET /metrics": "docs/deployment.md",
+
+	// /v1 proxy data plane — docs/api/proxy.md owns the contract.
+	"POST /v1/chat/completions":      "docs/api/proxy.md",
+	"POST /v1/messages":              "docs/api/proxy.md",
+	"POST /v1/messages/count_tokens": "docs/api/proxy.md",
+	"POST /v1/completions":           "docs/api/proxy.md",
+	"POST /v1/responses":             "docs/api/proxy.md",
+	"GET /v1/responses":              "docs/api/proxy.md",
+	"POST /v1/responses/compact":     "docs/api/proxy.md",
+	"GET /v1/models":                 "docs/api/proxy.md",
+	"POST /v1/embeddings":            "docs/api/proxy.md",
+	"POST /v1/rerank":                "docs/api/proxy.md",
+	"POST /v1/images/generations":    "docs/api/proxy.md",
+	"POST /v1/images/edits":          "docs/api/proxy.md",
+	"POST /v1/images/variations":     "docs/api/proxy.md",
+	"POST /v1/videos":                "docs/api/proxy.md",
+	"GET /v1/videos/{id}":            "docs/api/proxy.md",
+	"DELETE /v1/videos/{id}":         "docs/api/proxy.md",
+	"POST /v1/search":                "docs/api/proxy.md",
+	"POST /v1/files":                 "docs/api/proxy.md",
+	"GET /v1/files":                  "docs/api/proxy.md",
+	"GET /v1/files/{fileId}":         "docs/api/proxy.md",
+	"GET /v1/files/{fileId}/content": "docs/api/proxy.md",
+	"DELETE /v1/files/{fileId}":      "docs/api/proxy.md",
+	// Downstream-key-visible price catalog mounted under /v1 (inherits
+	// proxy auth), reusing the admin model-price data surface.
+	"GET /v1/models/price-compare": "docs/api/proxy.md",
+	"GET /v1/pricing":              "docs/api/proxy.md",
+
+	// Non-/v1 proxy aliases: Codex native paths and the Gemini surface.
+	"POST /chat/completions":                            "docs/api/proxy.md",
+	"POST /responses":                                   "docs/api/proxy.md",
+	"GET /responses":                                    "docs/api/proxy.md",
+	"POST /responses/{wildcard}":                        "docs/api/proxy.md",
+	"GET /responses/{wildcard}":                         "docs/api/proxy.md",
+	"GET /v1beta/models":                                "docs/api/proxy.md",
+	"POST /v1beta/models/{wildcard}":                    "docs/api/proxy.md",
+	"GET /gemini/{geminiApiVersion}/models":             "docs/api/proxy.md",
+	"POST /gemini/{geminiApiVersion}/models/{wildcard}": "docs/api/proxy.md",
+	"POST /v1internal::generateContent":                 "docs/api/proxy.md",
+	"POST /v1internal::streamGenerateContent":           "docs/api/proxy.md",
+	"POST /v1internal::countTokens":                     "docs/api/proxy.md",
+
+	// LDOH iframe proxy: cookie-authenticated, deliberately outside the
+	// bearer-token admin group — docs/api/monitor.md owns it.
+	"ANY /monitor-proxy/ldoh":            "docs/api/monitor.md",
+	"ANY /monitor-proxy/ldoh/":           "docs/api/monitor.md",
+	"ANY /monitor-proxy/ldoh/{wildcard}": "docs/api/monitor.md",
+}
+
+func TestAPIRouteInventoryParity(t *testing.T) {
+	root := repoRoot(t)
+	code := extractRegisteredRoutes(t, root)
+	codeRoutes, nonAPI := splitByScope(code)
+	if len(codeRoutes) == 0 {
+		t.Fatal("extractor sanity: no /api routes reachable from router.New — the extractor is broken, not the docs")
+	}
+	parsedDoc := parseRouteInventory(t, root)
+	if len(parsedDoc) == 0 {
+		t.Fatal("extractor sanity: docs/api/routes-inventory.md yielded no routes — the parser is broken")
+	}
+	// The inventory documents path parameters as :param while chi registers
+	// {param}; normalize before comparing (see normalizeRoutePath).
+	doc := normalizeDocKeys(parsedDoc)
+
+	if got := compareRouteSets(codeRoutes, doc); got != "" {
+		t.Fatalf("API route inventory drift:\n%s\nDocument the route (method, path, auth surface, request/response shape) or remove the stale entry. Do not relax this test.", got)
+	}
+
+	// Allowlist hygiene: an entry that matches no live route is dead weight
+	// and a possible hiding place for a removed-but-still-claimed exception.
+	var stale []string
+	for key := range inventoryAllowlist {
+		if _, ok := codeRoutes[key]; !ok {
+			stale = append(stale, key)
+		}
+	}
+	for key := range nonAPIRouteAllowlist {
+		if _, ok := nonAPI[key]; !ok {
+			stale = append(stale, key)
+		}
+	}
+	if len(stale) > 0 {
+		sort.Strings(stale)
+		t.Fatalf("allowlist entries that match no registered route (remove them or fix the path):\n  %s",
+			strings.Join(stale, "\n  "))
+	}
+}
+
+// TestNonAPIRoutesAreAccountedFor keeps the extractor honest about routes the
+// admin inventory deliberately does not cover: every non-/api route reachable
+// from router.New must name the document that owns it.
+func TestNonAPIRoutesAreAccountedFor(t *testing.T) {
+	root := repoRoot(t)
+	_, nonAPI := splitByScope(extractRegisteredRoutes(t, root))
+	var unowned []string
+	for key, where := range nonAPI {
+		if _, ok := nonAPIRouteAllowlist[key]; ok {
+			continue
+		}
+		unowned = append(unowned, key+"  (registered in "+where+")")
+	}
+	if len(unowned) > 0 {
+		sort.Strings(unowned)
+		t.Fatalf("non-/api routes with no owning document:\n  %s\nDocument them (docs/api/proxy.md for data-plane routes) and record the owner in nonAPIRouteAllowlist with a reason.",
+			strings.Join(unowned, "\n  "))
+	}
+}
+
+// TestRouteInventoryGateIsNotAVacuousPass proves the parity comparison can go
+// red in both directions, using the same compareRouteSets/normalizeRoutePath
+// code paths the real test uses. Without this, a broken inventory parser
+// would make TestAPIRouteInventoryParity pass forever while asserting nothing.
+func TestRouteInventoryGateIsNotAVacuousPass(t *testing.T) {
+	code := map[string]string{
+		"GET /api/sites":         "handler/admin/sites.go:RegisterSitesRoutes",
+		"POST /api/sites":        "handler/admin/sites.go:RegisterSitesRoutes",
+		"DELETE /api/sites/{id}": "handler/admin/sites.go:RegisterSitesRoutes",
+	}
+	clean := map[string]bool{
+		"GET /api/sites":        true,
+		"POST /api/sites":       true,
+		"DELETE /api/sites/:id": true, // inventory uses :param notation
+	}
+	if got := compareRouteSets(code, normalizeDocKeys(clean)); got != "" {
+		t.Fatalf("control sample must be clean, got:\n%s", got)
+	}
+
+	missing := normalizeDocKeys(map[string]bool{"GET /api/sites": true, "POST /api/sites": true})
+	got := compareRouteSets(code, missing)
+	if !strings.Contains(got, "DELETE /api/sites/{id}") || !strings.Contains(got, "MISSING") {
+		t.Fatalf("gate did not report an undocumented registered route:\n%s", got)
+	}
+
+	ghost := normalizeDocKeys(map[string]bool{
+		"GET /api/sites":        true,
+		"POST /api/sites":       true,
+		"DELETE /api/sites/:id": true,
+		"GET /api/sites/ghost":  true,
+	})
+	got = compareRouteSets(code, ghost)
+	if !strings.Contains(got, "GET /api/sites/ghost") || !strings.Contains(got, "NOT registered") {
+		t.Fatalf("gate did not report an invented documented route:\n%s", got)
+	}
+
+	// Notation normalization itself must be load-bearing.
+	if normalizeRoutePath("/api/sites/:id") != normalizeRoutePath("/api/sites/{id}") {
+		t.Fatal("normalizeRoutePath no longer treats :param and {param} as the same route")
+	}
+	if normalizeRoutePath("/responses/*") != "/responses/{wildcard}" {
+		t.Fatal("normalizeRoutePath no longer maps a chi wildcard to {wildcard}")
+	}
+}
+
+// compareRouteSets reports both drift directions: registered-but-undocumented
+// and documented-but-unregistered.
+func compareRouteSets(code map[string]string, doc map[string]bool) string {
+	var undocumented, invented []string
+	for key, where := range code {
+		if doc[key] {
+			continue
+		}
+		if _, ok := inventoryAllowlist[key]; ok {
+			continue
+		}
+		undocumented = append(undocumented, key+"  (registered in "+where+")")
+	}
+	for key := range doc {
+		if _, ok := code[key]; !ok {
+			invented = append(invented, key)
+		}
+	}
+	var b strings.Builder
+	if len(undocumented) > 0 {
+		sort.Strings(undocumented)
+		b.WriteString("  MISSING from docs/api/routes-inventory.md but registered in code (" +
+			strconv.Itoa(len(undocumented)) + "):\n    " + strings.Join(undocumented, "\n    ") + "\n")
+	}
+	if len(invented) > 0 {
+		sort.Strings(invented)
+		b.WriteString("  NOT registered in code but listed in docs/api/routes-inventory.md (" +
+			strconv.Itoa(len(invented)) + "):\n    " + strings.Join(invented, "\n    ") + "\n")
+	}
+	return b.String()
+}
+
+func normalizeDocKeys(doc map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(doc))
+	for key := range doc {
+		verb, path, ok := strings.Cut(key, " ")
+		if !ok {
+			continue
+		}
+		out[verb+" "+normalizeRoutePath(path)] = true
+	}
+	return out
+}
+
+// splitByScope separates the /api admin surface from everything else.
+func splitByScope(routes map[registeredRoute]bool) (api map[string]string, other map[string]string) {
+	api = map[string]string{}
+	other = map[string]string{}
+	for route := range routes {
+		key := route.method + " " + normalizeRoutePath(route.path)
+		if strings.HasPrefix(route.path, "/api/") || route.path == "/api" {
+			api[key] = route.where
+			continue
+		}
+		other[key] = route.where
+	}
+	return api, other
+}
+
+type registeredRoute struct {
+	method string
+	path   string
+	where  string
+}
+
+// pkgIndex holds every top-level function under router/ and handler/, keyed
+// by package directory then function name, plus each file's internal import
+// aliases so a qualified registrar call can be resolved to a package.
+type pkgIndex struct {
+	funcs   map[string]map[string]*ast.FuncDecl // dir -> func name -> decl
+	pkgName map[string]string                   // dir -> Go package name
+	imports map[string]map[string]string        // dir -> alias -> imported dir
+	file    map[string]map[string]string        // dir -> func name -> relative file
+}
+
+func extractRegisteredRoutes(t *testing.T, root string) map[registeredRoute]bool {
+	t.Helper()
+	idx := buildPkgIndex(t, root)
+	if len(idx.funcs) == 0 {
+		t.Fatal("extractor sanity: no Go functions indexed under router/ or handler/")
+	}
+	if idx.funcs["router"]["New"] == nil {
+		t.Fatal("extractor sanity: router.New not found — the composition root moved")
+	}
+
+	var out []registeredRoute
+	visited := map[string]bool{}
+	var walk func(dir, name, prefix string, depth int)
+	walk = func(dir, name, prefix string, depth int) {
+		key := dir + "|" + name + "|" + prefix
+		if depth > 16 || visited[key] {
+			return
+		}
+		visited[key] = true
+		fn := idx.funcs[dir][name]
+		if fn == nil || fn.Body == nil {
+			return
+		}
+		where := idx.file[dir][name] + ":" + name
+		scanBlock(fn.Body, prefix, where, idx, dir,
+			func(method, path, w string) {
+				out = append(out, registeredRoute{method: method, path: path, where: w})
+			},
+			walk)
+	}
+	walk("router", "New", "", 0)
+
+	set := map[registeredRoute]bool{}
+	for _, r := range out {
+		set[r] = true
+	}
+	return set
+}
+
+// scanBlock walks a block in lexical order, threading the chi Route/Mount
+// prefix through nested function literals and following calls into other
+// registrars.
+func scanBlock(block *ast.BlockStmt, prefix, where string, idx *pkgIndex, dir string,
+	emit func(method, path, where string), walk func(dir, name, prefix string, depth int)) {
+	for _, stmt := range block.List {
+		scanStmt(stmt, prefix, where, idx, dir, emit, walk, 0)
+	}
+}
+
+func scanStmt(n ast.Node, prefix, where string, idx *pkgIndex, dir string,
+	emit func(method, path, where string), walk func(dir, name, prefix string, depth int), depth int) {
+	ast.Inspect(n, func(node ast.Node) bool {
+		switch v := node.(type) {
+		case *ast.FuncLit:
+			// A nested handler literal cannot register routes at this level;
+			// Route/Group bodies are descended into explicitly instead.
+			return false
+		case *ast.CallExpr:
+			handleCall(v, prefix, where, idx, dir, emit, walk, depth)
+		}
+		return true
+	})
+}
+
+func handleCall(ce *ast.CallExpr, prefix, where string, idx *pkgIndex, dir string,
+	emit func(method, path, where string), walk func(dir, name, prefix string, depth int), depth int) {
+	sel, ok := ce.Fun.(*ast.SelectorExpr)
+	if !ok {
+		// Unqualified call: same package, e.g. RegisterFilesRoutes(r).
+		if id, ok := ce.Fun.(*ast.Ident); ok && hasRouterArg(ce) {
+			if idx.funcs[dir][id.Name] != nil {
+				walk(dir, id.Name, prefix, depth+1)
+			}
+		}
+		return
+	}
+	name := sel.Sel.Name
+
+	// Package-qualified call: admin.RegisterSitesRoutes(r, db.DB).
+	if pkgIdent, ok := sel.X.(*ast.Ident); ok {
+		if target, isPkg := idx.imports[dir][pkgIdent.Name]; isPkg {
+			if hasRouterArg(ce) && idx.funcs[target][name] != nil {
+				walk(target, name, prefix, depth+1)
+			}
+			return
+		}
+	}
+
+	if !isRouterExpr(sel.X) {
+		return
+	}
+	path, literal := firstStringArg(ce)
+	switch {
+	case (name == "Route" || name == "Mount") && literal && len(ce.Args) >= 2:
+		if fl, ok := ce.Args[1].(*ast.FuncLit); ok && fl.Body != nil {
+			inner := joinRoutePath(prefix, path)
+			for _, stmt := range fl.Body.List {
+				scanStmt(stmt, inner, where, idx, dir, emit, walk, depth)
+			}
+		}
+	case (name == "Group" || name == "With" || name == "Use") && len(ce.Args) >= 1:
+		if fl, ok := ce.Args[0].(*ast.FuncLit); ok && fl.Body != nil {
+			for _, stmt := range fl.Body.List {
+				scanStmt(stmt, prefix, where, idx, dir, emit, walk, depth)
+			}
+		}
+	default:
+		verb, isVerb := routeVerbs[name]
+		// Only literal paths starting with "/" are routes; this excludes
+		// r.Header.Get("Content-Type") and r.URL.Query().Get("page").
+		if isVerb && literal && strings.HasPrefix(path, "/") {
+			emit(verb, joinRoutePath(prefix, path), where)
+		}
+	}
+}
+
+func hasRouterArg(ce *ast.CallExpr) bool {
+	return len(ce.Args) > 0 && isRouterExpr(ce.Args[0])
+}
+
+// isRouterExpr reports whether an expression bottoms out in a router-named
+// identifier, so chained forms like r.With(CORS()).Get("/health", h) count.
+func isRouterExpr(e ast.Expr) bool {
+	for {
+		switch v := e.(type) {
+		case *ast.Ident:
+			return routerIdents[v.Name]
+		case *ast.SelectorExpr:
+			e = v.X
+		case *ast.CallExpr:
+			e = v.Fun
+		case *ast.ParenExpr:
+			e = v.X
+		default:
+			return false
+		}
+	}
+}
+
+func firstStringArg(ce *ast.CallExpr) (string, bool) {
+	if len(ce.Args) == 0 {
+		return "", false
+	}
+	lit, ok := ce.Args[0].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	s, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+func joinRoutePath(prefix, path string) string {
+	if prefix == "" {
+		return path
+	}
+	if path == "" || path == "/" {
+		return prefix
+	}
+	return strings.TrimSuffix(prefix, "/") + "/" + strings.TrimPrefix(path, "/")
+}
+
+// normalizeRoutePath collapses :param and {param} to {param} and a chi
+// wildcard to {wildcard} so doc notation and code notation compare equal.
+func normalizeRoutePath(p string) string {
+	p = strings.ReplaceAll(p, "*", "{wildcard}")
+	parts := strings.Split(p, "/")
+	for i, seg := range parts {
+		if strings.HasPrefix(seg, ":") && len(seg) > 1 {
+			parts[i] = "{" + seg[1:] + "}"
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
+// buildPkgIndex parses every non-test .go file under router/ and handler/
+// (one level of subpackages, which is where every registrar lives) and
+// indexes top-level functions per package directory.
+func buildPkgIndex(t *testing.T, root string) *pkgIndex {
+	t.Helper()
+	fset := token.NewFileSet()
+	idx := &pkgIndex{
+		funcs:   map[string]map[string]*ast.FuncDecl{},
+		pkgName: map[string]string{},
+		imports: map[string]map[string]string{},
+		file:    map[string]map[string]string{},
+	}
+
+	var files []string
+	for _, dir := range []string{"router", "handler"} {
+		for _, pattern := range []string{filepath.Join(root, dir, "*.go"), filepath.Join(root, dir, "*", "*.go")} {
+			matches, err := filepath.Glob(pattern)
+			if err != nil {
+				t.Fatal(err)
+			}
+			files = append(files, matches...)
+		}
+	}
+	if len(files) == 0 {
+		t.Fatal("extractor sanity: no Go files found under router/ or handler/")
+	}
+
+	type parsedFile struct {
+		dir string
+		rel string
+		ast *ast.File
+	}
+	var parsed []parsedFile
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		rel := strings.TrimPrefix(filepath.ToSlash(path), filepath.ToSlash(root)+"/")
+		dir := filepath.ToSlash(filepath.Dir(rel))
+		idx.pkgName[dir] = f.Name.Name
+		parsed = append(parsed, parsedFile{dir: dir, rel: rel, ast: f})
+	}
+
+	// Import aliases resolve after every package name is known, because the
+	// alias defaults to the imported package's name (handler/proxy declares
+	// package proxyhandler, not proxy).
+	for _, pf := range parsed {
+		if idx.imports[pf.dir] == nil {
+			idx.imports[pf.dir] = map[string]string{}
+		}
+		for _, spec := range pf.ast.Imports {
+			ipath, err := strconv.Unquote(spec.Path.Value)
+			if err != nil || !strings.HasPrefix(ipath, modulePath+"/") {
+				continue
+			}
+			target := strings.TrimPrefix(ipath, modulePath+"/")
+			alias := target[strings.LastIndex(target, "/")+1:]
+			if spec.Name != nil {
+				alias = spec.Name.Name
+			} else if known, ok := idx.pkgName[target]; ok {
+				alias = known
+			}
+			idx.imports[pf.dir][alias] = target
+		}
+	}
+
+	for _, pf := range parsed {
+		if idx.funcs[pf.dir] == nil {
+			idx.funcs[pf.dir] = map[string]*ast.FuncDecl{}
+			idx.file[pf.dir] = map[string]string{}
+		}
+		for _, decl := range pf.ast.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			// Methods are skipped: in this repository every chi registration
+			// literal lives in a top-level Register* function or router.New.
+			if !ok || fn.Recv != nil || fn.Body == nil {
+				continue
+			}
+			// A package may declare several init functions; they never
+			// register routes.
+			if fn.Name.Name == "init" || fn.Name.Name == "main" {
+				continue
+			}
+			idx.funcs[pf.dir][fn.Name.Name] = fn
+			idx.file[pf.dir][fn.Name.Name] = pf.rel
+		}
+	}
+	return idx
+}
+
+// parseRouteInventory reads the `### VERB` + "- `path`" bullet structure of
+// docs/api/routes-inventory.md into a "VERB /path" set.
+func parseRouteInventory(t *testing.T, root string) map[string]bool {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, "docs/api/routes-inventory.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]bool{}
+	verb := ""
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "### ") {
+			verb = strings.ToUpper(strings.TrimSpace(trimmed[4:]))
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") {
+			verb = ""
+			continue
+		}
+		if verb == "" || !strings.HasPrefix(trimmed, "- ") {
+			continue
+		}
+		entry := strings.TrimSpace(trimmed[2:])
+		if !strings.HasPrefix(entry, "`") {
+			continue
+		}
+		end := strings.Index(entry[1:], "`")
+		if end < 0 {
+			continue
+		}
+		path := entry[1 : 1+end]
+		if strings.HasPrefix(path, "/") {
+			out[verb+" "+path] = true
+		}
+	}
+	return out
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,27 +171,42 @@ A request then moves through stages that each have exactly one owner:
 
 | Stage | Owner | Decision made here |
 |:------|:------|:-------------------|
-| HTTP surface | `handler/proxy` | Decode the inbound protocol shape, resolve the downstream key context, encode the response or the protocol-shaped error envelope. |
-| Orchestration | `proxy` (with `proxy/profiles`, `proxy/types`) | Which client profile this is, how many channel attempts are allowed, when a response counts as a failure, whether to retry the same channel, refresh its auth, or fail over. |
+| HTTP surface | `handler/proxy` | Decode the inbound protocol shape, resolve the downstream key context, relay the upstream body (buffered or SSE), encode the response or the protocol-shaped error envelope. |
+| Attempt loop | `handler/proxy` | Which endpoint candidate is tried next, how a stream relay ended, and how that ending is reported (recorded status, reason text, terminal metric outcome). |
+| Failure and fallback policy | `proxy` (with `proxy/profiles`, `proxy/types`) | Which client profile this is, how many channel attempts are allowed, and every reusable verdict: content-level failure judgement, same-site abort, downgrade to the next endpoint, retry the same channel, refresh its auth. |
 | Channel selection | `routing` | Which channel/account is eligible right now: weighting, cooldown, runtime breaker state. |
 | Protocol conversion | `transform` (`openai`, `gemini`, `shared`) | Rewriting between wire formats. Native conversion — there is no canonical intermediate representation. |
 | Upstream I/O | `platform` + `service` | Speaking to the actual provider, including outbound proxy and TLS behaviour. |
 | Persistence | `store` | Request/usage logging and every read the stages above need, with dialect differences hidden here. |
 
-Streaming and non-streaming responses take different paths through
-orchestration: non-streaming upstream bodies are buffered up to
-`PROXY_MAX_BUFFERED_RESPONSE_BYTES`, while a stream is relayed with a
-chunk-gap guard (`PROXY_STREAM_IDLE_TIMEOUT_SEC`) and a total byte bound
-(`PROXY_MAX_STREAM_RESPONSE_BYTES`). Failure classification for a stream —
-what counts as a failed attempt versus a successful-but-truncated one — and
-cross-protocol fallback are owned by the orchestration stage, not by the HTTP
-surface or by `transform`.
+Streaming and non-streaming responses take different paths through the attempt
+loop. A non-streaming body is buffered up to `PROXY_MAX_BUFFERED_RESPONSE_BYTES`
+and judged once; a stream is relayed under a chunk-gap guard
+(`PROXY_STREAM_IDLE_TIMEOUT_SEC`) and a total byte bound
+(`PROXY_MAX_STREAM_RESPONSE_BYTES`), then classified by how the relay ended:
+clean end of stream, idle timeout, upstream fault mid-stream, byte-limit
+truncation, or downstream disconnect.
 
-> **Note**: the data-plane stage table above is deliberately written at the
-> level of "which package owns which semantic". It is scheduled for one
-> re-read after the in-flight streaming-failure / protocol-fallback ownership
-> work lands; the package names and the environment-variable names quoted here
-> are the stable part.
+Two rules keep that classification honest:
+
+- **One judge for content.** Whether an upstream answer counts as a failure on
+  its content — a configured `PROXY_ERROR_KEYWORDS` hit, or an empty completion
+  when `PROXY_EMPTY_CONTENT_FAIL` is on — is decided by a single pure function
+  in `proxy`, fed by both paths: the buffered body directly, the stream through
+  the bounded SSE analyser. The two paths cannot reach different verdicts for
+  the same upstream content.
+- **A downstream disconnect is not an upstream fault.** The channel answered
+  correctly, so recording the cancel against it would poison channel health
+  with user behaviour. Usage already extracted from earlier SSE events is still
+  accounted; tokens are never invented for content that did not arrive.
+
+Every other ending — an idle upstream, a mid-stream reset, a truncated relay —
+goes through the failure path, whose status, reason text and terminal metric
+outcome come from one owner so channel health, request logs and metrics cannot
+disagree about the same request. Which candidate is tried next is likewise a
+single decision function in the attempt loop: HTTP statuses, content failures
+and transport errors all ask it, instead of each call site re-deriving the
+policy. `transform` owns none of this.
 
 ### Non-`/v1` proxy aliases
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,17 @@
 # Architecture Overview
 
-**Last updated**: 2026-08-16
+**Last updated**: 2026-09-03
 
-> **Navigation**: full docs map in [`docs/README.md`](README.md) · open items in [`progress/MASTER.md`](internal/progress/MASTER.md).
+> **Navigation**: full docs map in [`docs/README.md`](README.md) · route list in [`api/routes-inventory.md`](api/routes-inventory.md) · environment variables in [`configuration.md`](configuration.md).
+>
+> Every structural claim below names the package or exported symbol that owns
+> it, so it can be checked with a search instead of trusted. The dependency
+> rules in [Ownership and boundary map](#ownership-and-boundary-map) are
+> enforced by `docs/package_boundary_test.go`; the route claims are enforced
+> by `docs/api_inventory_parity_test.go`; the environment-variable claims are
+> enforced by `docs/env_parity_test.go`.
 
-Metapi Go is a ground-up rewrite of the TypeScript Metapi proxy gateway in Go. This document describes the **as-built** package layout, request paths, and key design decisions. Design philosophy and package dependency rules live in [`docs/internal/design/BACKEND.md`](internal/design/BACKEND.md).
+Metapi Go is a ground-up rewrite of the TypeScript Metapi proxy gateway in Go. This document describes the **as-built** package layout, request paths, and key design decisions. Package dependency rules are stated in full below and machine-enforced by [`docs/package_boundary_test.go`](package_boundary_test.go).
 
 > **Naming truth:** There is **no** `proxycore/` or `protocol/` package in this repository. The proxy engine is `proxy/` (with `proxy/profiles` and `proxy/types`). Protocol conversion is `transform/` (with `openai` [completions/embeddings/images/responses], `gemini`, and `shared`). There is **no** `transform/canonical` intermediate layer — cross-protocol conversion is native (e.g. OpenAI→Gemini) and bypasses any canonical representation. Older docs or TS-era names that say “ProxyCore package” or “protocol package” refer to these real packages.
 
@@ -56,6 +63,163 @@ Metapi Go is a ground-up rewrite of the TypeScript Metapi proxy gateway in Go. T
          │    SQLite (dev) / PG (prod)   │
          └──────────────────────────────┘
 ```
+
+## Ownership and boundary map
+
+The layering is a **denylist of import edges**, not a file inventory: each
+package owns one decision, and the test named below fails the build if a
+package reaches outside its decision. `docs/package_boundary_test.go` is the
+authoritative, executable form of this table — when the two disagree, the test
+is right and this page is stale.
+
+| Package | Decision it owns | Must NOT import |
+|:--------|:-----------------|:----------------|
+| `config` | Env parsing, defaults, clamping, validation. Nothing else reads `os.Getenv` for a documented knob. | (leaf) |
+| `store` | Persistence and dialect differences (SQLite / PostgreSQL), placeholder rebinding. | `handler`, `proxy`, `routing`, `service`, `scheduler`, `router`, `auth` |
+| `platform` | One adapter per upstream provider family; the leaf that actually talks to upstreams. | `store`, `handler`, `proxy`, `router`, `scheduler` (`config` and `proxy/profiles` are allowed) |
+| `transform` | Wire-format conversion between protocols (native OpenAI ⇄ Gemini, no intermediate canonical form). | `handler`, `store`, `proxy`, `routing`, `service`, `auth` |
+| `routing` | Which channel/account serves a request: selection, cooldown, runtime breaker. | `proxy`, `handler` |
+| `service` | Domain logic that spans stores and platforms. | `handler`, `router`, `proxy` |
+| `scheduler` | When background work runs (cron, interval, window). | `handler`, `router`, `proxy` |
+| `handler/*` | HTTP surface only: decode, authorize, call a service/proxy entrypoint, encode. | `router` (the router mounts handlers, never the reverse) |
+| `router` | Mount points, middleware order, SPA fallback, static asset serving. | — |
+| `cmd/server` | Composition root; may import anything. | — |
+
+Approved exceptions are enumerated in the header comment of
+`docs/package_boundary_test.go` (for example `handler/admin → scheduler` for
+cron validation, `app → handler/proxy` for the upstream composition helper,
+`platform → proxy/profiles` for client detection, `handler/proxy →
+transform/*` for one-way protocol wiring). The rule for adding one is: move
+the import to an allowed edge first; only if that is impossible, add the
+exception to the test with a written justification.
+
+`proxycore/` and `protocol/` do not exist and must not be reintroduced — the
+test rejects those TypeScript-era names.
+
+## Request paths: stages and single owners
+
+Two independent auth surfaces share one chi router built by `router.New`, the
+only composition root. Registrars take a `chi.Router` and register absolute
+`/api/...` paths, so each can also be exercised on a standalone router in
+tests.
+
+### Middleware applied to every request (`router.New`, in order)
+
+`WithRequestID` → `SecurityHeaders` → `TrustedRealIP(cfg)` → `RequestLogger`
+→ `Recoverer` → `BodyLimitPathAware(cfg.RequestBodyLimit, cfg.FileUploadLimitBytes)`.
+
+`TrustedRealIP` runs before the logger so the logged client IP is already the
+policy-approved one, and it only honours `X-Forwarded-For` / `X-Real-IP` from
+peers inside `TRUSTED_PROXY_CIDRS`. `BodyLimitPathAware` takes two limits
+because the multipart upload surfaces (`/v1/files`, `/v1/images/*`) need a
+larger cap than the JSON surfaces.
+
+### `/health`, `/ready`, `/metrics`
+
+Registered with `r.With(CORS())` **before** the admin group, so they never
+pass through admin auth — a container orchestrator or a load balancer cannot
+present a token. Handlers live in `app` (`app.Health`, `app.Ready`,
+`app.PrometheusHandler`).
+
+### Admin surface (`/api/*`)
+
+One `r.Group` owns the whole admin surface, and the order inside it is
+load-bearing:
+
+1. `AdminCORS(cfg)`
+2. `auth.AdminRateLimit` — per-IP bucket for all `/api/*`
+3. `auth.AuthRateLimit` — stricter bucket, `/api/auth/*` only, because login is
+   the only surface that accepts the master token
+4. `auth.OAuthRateLimit` — stricter bucket, `/api/oauth/*` only
+5. `auth.AdminAuth(sessions)` — dual track: server-side session cookie (UI) or
+   bearer master token (scripts)
+6. `auth.RequireReauth()` — sensitive operations must re-present the master
+   token in `X-Admin-Confirm-Token`
+7. `admin.AuditMiddleware(db.DB)` — audit trail for admin writes
+
+Rate limiting deliberately runs **before** authentication: a rejected login
+consumes the per-IP bucket instead of bypassing it, so credential brute force
+is capped like any other admin traffic.
+
+Registrars that need a database are mounted inside
+`if db := store.GetDB(); db != nil`. When the database is unavailable those
+routes are simply not registered and the router logs
+`router: database not initialized, P3 routes skipped`; the session manager is
+`nil` and the session handlers fail closed rather than allowing traffic.
+`/api/about` and the session lifecycle routes are mounted outside that guard
+because every field they serve comes from the linker, the Go runtime, or a
+fail-closed handler.
+
+### Data plane (`/v1/*`)
+
+`r.Route("/v1", ...)` owns the proxy surface, in this order:
+
+1. `ProxyWriteDeadline`
+2. `CORS()`
+3. `auth.ProxyRateLimit(cfg.ProxyRateLimitRPM)` — per-IP, **before** auth so an
+   unauthenticated flood is dropped without a database lookup
+4. `auth.ProxyAuth()` — resolves the caller (global `PROXY_TOKEN` or a managed
+   downstream key) and puts the result in the request context
+5. `auth.ProxyGlobalTokenRateLimit(cfg.ProxyGlobalTokenRPM)` — **after** auth,
+   because the global cap only applies once the resolved auth source is known
+   to be the shared token; managed keys have their own admission
+6. `proxyhandler.RegisterProxyRoutes(r)` — the surface itself
+7. `admin.RegisterDownstreamPricingRoutes(r, db.DB)` — the downstream-key-visible
+   price catalog, mounted here so it inherits proxy auth instead of admin auth
+
+A request then moves through stages that each have exactly one owner:
+
+| Stage | Owner | Decision made here |
+|:------|:------|:-------------------|
+| HTTP surface | `handler/proxy` | Decode the inbound protocol shape, resolve the downstream key context, encode the response or the protocol-shaped error envelope. |
+| Orchestration | `proxy` (with `proxy/profiles`, `proxy/types`) | Which client profile this is, how many channel attempts are allowed, when a response counts as a failure, whether to retry the same channel, refresh its auth, or fail over. |
+| Channel selection | `routing` | Which channel/account is eligible right now: weighting, cooldown, runtime breaker state. |
+| Protocol conversion | `transform` (`openai`, `gemini`, `shared`) | Rewriting between wire formats. Native conversion — there is no canonical intermediate representation. |
+| Upstream I/O | `platform` + `service` | Speaking to the actual provider, including outbound proxy and TLS behaviour. |
+| Persistence | `store` | Request/usage logging and every read the stages above need, with dialect differences hidden here. |
+
+Streaming and non-streaming responses take different paths through
+orchestration: non-streaming upstream bodies are buffered up to
+`PROXY_MAX_BUFFERED_RESPONSE_BYTES`, while a stream is relayed with a
+chunk-gap guard (`PROXY_STREAM_IDLE_TIMEOUT_SEC`) and a total byte bound
+(`PROXY_MAX_STREAM_RESPONSE_BYTES`). Failure classification for a stream —
+what counts as a failed attempt versus a successful-but-truncated one — and
+cross-protocol fallback are owned by the orchestration stage, not by the HTTP
+surface or by `transform`.
+
+> **Note**: the data-plane stage table above is deliberately written at the
+> level of "which package owns which semantic". It is scheduled for one
+> re-read after the in-flight streaming-failure / protocol-fallback ownership
+> work lands; the package names and the environment-variable names quoted here
+> are the stable part.
+
+### Non-`/v1` proxy aliases
+
+Codex native paths (`/chat/completions`, `/responses`, `/responses/*`) and the
+Gemini surface (`/v1beta/models`, `/gemini/{geminiApiVersion}/models`,
+`/v1internal::*`) are mounted in an `r.Group` carrying the same middleware
+stack as `/v1`. A group is used instead of `Route("/")` so proxy auth applies
+only to the exact registered paths and never shadows the SPA fallback.
+
+### Two surfaces that are intentionally outside the admin group
+
+- **`/monitor-proxy/ldoh*`** — registered via `r.HandleFunc` outside the bearer
+  group, because an iframe's sub-resource requests cannot carry an
+  `Authorization` header. The handler enforces its own HttpOnly cookie auth
+  scoped to `/monitor-proxy/` and rejects `..` traversal.
+- **`/api/admin/ops/ws`** (`admin.RegisterOpsWSRoutes`) — mounted after the
+  admin group for the same browser limitation: a WebSocket handshake cannot
+  set headers, so it redeems a one-time ticket minted by
+  `POST /api/auth/ws-ticket` instead of ever seeing the master token.
+
+### Static assets and SPA fallback
+
+`router.setupSPAFallback` serves the embedded `web/dist` tree: content-hashed
+subtrees under `/assets/` and `/static/` get an immutable cache header, while
+root files whose names are not hashed (`bootstrap.js`, `theme-init.js`, logos
+and favicons) get `no-cache` so deploys propagate without a hard refresh. The
+fallback answers `index.html` for non-API paths and a JSON 404 body for
+`/api/*` and `/v1/*`.
 
 ## Package Layout (as-built)
 
@@ -213,7 +377,9 @@ Routing isolates bad channels instead of cascading:
 
 ## Package dependency overview
 
-High-level allowed direction (see [`docs/internal/design/BACKEND.md`](internal/design/BACKEND.md) for forbidden edges):
+Allowed direction (forbidden edges are the denylist in
+[Ownership and boundary map](#ownership-and-boundary-map), enforced by
+[`docs/package_boundary_test.go`](package_boundary_test.go)):
 
 ```
 cmd → app, router, config, store, …
@@ -229,7 +395,10 @@ store → config
 config, web, handler/shared → leaves
 ```
 
-**Package ownership inventory:** as-built public entrypoints, import edges, approved exceptions, and recommended cleanups live in [`docs/internal/analysis/package-boundaries.md`](internal/analysis/package-boundaries.md). Prefer that file when deciding where new code belongs or whether an import edge is intentional.
+**Where new code belongs:** decide from the ownership table above, then prove
+it by running `go test ./docs -run TestPackageBoundaries`. That test is the
+specification; a new edge either passes it or needs a written exception in its
+header comment.
 
 ## S.U.P.E.R. Compliance
 
@@ -241,8 +410,10 @@ config, web, handler/shared → leaves
 
 ## Related docs
 
-- [`docs/internal/design/BACKEND.md`](internal/design/BACKEND.md) — backend design philosophy, dependency rules, forbidden imports
-- [`docs/internal/analysis/package-boundaries.md`](internal/analysis/package-boundaries.md) — package ownership inventory, public entrypoints, import exceptions
-- [`docs/api.md`](api.md) — admin API reference
+- [`docs/package_boundary_test.go`](package_boundary_test.go) — the executable dependency denylist and its approved exceptions; read this before moving an import
+- [`docs/api.md`](api.md) — admin API reference index; [`docs/api/routes-inventory.md`](api/routes-inventory.md) is the complete registered `/api` route list, checked against the code by [`docs/api_inventory_parity_test.go`](api_inventory_parity_test.go)
+- [`docs/api/conventions.md`](api/conventions.md) — auth surfaces, error envelope, pagination: read before calling any `/api` route
+- [`docs/api/proxy.md`](api/proxy.md) — the `/v1` data-plane contract
+- [`docs/configuration.md`](configuration.md) — every environment variable with its real default and clamp, checked against `.env.example` and `config/config.go` by [`docs/env_parity_test.go`](env_parity_test.go)
 - [`docs/deployment.md`](deployment.md) — deploy guide
 - [`docs/migration.md`](migration.md) — TS → Go migration notes

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,12 +125,12 @@ silent until their URL/key is set. Every other provider needs its
 | `PROXY_IDLE_CONN_TIMEOUT_SEC` | `90` | Idle keep-alive connection TTL in the pooled outbound transports. |
 | `PROXY_REQUEST_TIMEOUT_SEC` | `30` | Whole-request client timeout. |
 | `PROXY_STREAM_IDLE_TIMEOUT_SEC` | `300` | Chunk-gap guard for a flowing SSE stream: every relayed chunk resets the window, and a gap longer than this aborts the stream and records it as an upstream timeout fault. It does **not** cap total stream duration. |
+| `METAPI_ENABLE_PROXY_STUB` | empty | Test/demo-only local stub; leave empty in production (unconfigured forwarding returns an honest 503). |
+| `SYSTEM_PROXY_URL` | empty | Outbound HTTP proxy for upstream calls. |
 
 All six `*_SEC` timeouts share one clamp (`config.parseTimeoutSec`): unset,
 blank, invalid, zero or negative values fall back to the listed default, so a
 typo can never disable a timeout entirely.
-| `METAPI_ENABLE_PROXY_STUB` | empty | Test/demo-only local stub; leave empty in production (unconfigured forwarding returns an honest 503). |
-| `SYSTEM_PROXY_URL` | empty | Outbound HTTP proxy for upstream calls. |
 
 ### Proxy log writer & retention
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,11 +1,16 @@
 # Configuration Reference
 
-**Last updated**: 2026-08-22
+**Last updated**: 2026-09-03
 
 Complete environment-variable reference. The single machine-readable source
 is [`.env.example`](../.env.example); this page groups and explains every
 knob a deployment is likely to touch. Docker Compose users pass these via
 `environment:` (see [`deployment.md`](deployment.md)).
+
+Every variable listed here is checked against `.env.example` and against the
+keys `config.Load` actually reads, by `docs/env_parity_test.go`. If you add a
+knob, add it in all three places or that test fails — names must be written
+out in full (no `SOME_PREFIX_*` shorthand) so they stay greppable.
 
 > **How to read this page**: first-time deployment only needs the two
 > [Required](#required) variables (plus the
@@ -39,6 +44,7 @@ knob a deployment is likely to touch. Docker Compose users pass these via
 | `LOG_LEVEL` | `info` | slog threshold: `debug` / `info` / `warn` / `error`. |
 | `METAPI_HEALTHCHECK_URL` / `METAPI_HEALTHCHECK_PATH` | — / `/ready` | Override the container healthcheck target. |
 | `SYSTEM_NAME`, `LOGO`, `FOOTER`, `ABOUT`, `HOME_PAGE_CONTENT` | brand defaults | Optional site branding; runtime settings in the admin UI override these. |
+| `SERVER_ADDRESS` | empty | Public base URL used when the server has to build an absolute link back to itself (OAuth callbacks, exported key/backup URLs). Empty = derived from the request's `X-Forwarded-Proto` / `X-Forwarded-Host` headers, falling back to the request host. |
 
 ## Database
 
@@ -48,11 +54,11 @@ knob a deployment is likely to touch. Docker Compose users pass these via
 | `DATABASE_URL` / `DB_URL` | empty | PostgreSQL connection string (or SQLite file path). `DB_URL` wins; `DATABASE_URL` exists for platform compatibility. Empty = single-node SQLite at `DATA_DIR/hub.db`. |
 | `DB_SSLMODE` | empty | PostgreSQL TLS mode: `disable` / `allow` / `prefer` / `require` / `verify-ca` / `verify-full`; overrides the DSN `sslmode` when set. |
 | `DB_SSL` | empty | Coarse PG TLS toggle; prefer `DB_SSLMODE`. |
-| `DB_PROFILE` | `normal` | Pool preset: `shared-tiny` (2/1) / `normal` (10/3) / `dedicated` (20/5). |
+| `DB_PROFILE` / `METAPI_DB_PROFILE` | `normal` | Pool preset: `shared-tiny` (2/1) / `normal` (10/3) / `dedicated` (20/5). `DB_PROFILE` wins when both are set; unknown values fall back to `normal`. |
 | `DB_MAX_OPEN_CONNS` / `DB_MAX_IDLE_CONNS` | per profile | Explicit PostgreSQL pool budget; overrides the profile. Must respect your database role connection limit. |
 | `DB_CONN_MAX_LIFETIME_SEC` | `1800` | PostgreSQL connection max lifetime (seconds). |
 | `DB_CONN_MAX_IDLE_TIME_SEC` | `300` | PostgreSQL idle connection reaper (seconds). |
-| `DB_APPLICATION_NAME` | `metapi-<hostname>` | `application_name` shown in `pg_stat_activity`. |
+| `DB_APPLICATION_NAME` / `METAPI_DB_APPLICATION_NAME` | `metapi-<hostname>` | `application_name` shown in `pg_stat_activity`. `DB_APPLICATION_NAME` wins when both are set. |
 | `REDIS_URL` / `METAPI_REDIS_URL` | empty | Optional Redis for **multi-instance shared RPM/TPM admission** of downstream keys. Empty = process-local counters only. Unreachable Redis fails open back to process-local windows. Sticky sessions remain process-local regardless of Redis. |
 
 ## Scheduling
@@ -60,10 +66,13 @@ knob a deployment is likely to touch. Docker Compose users pass these via
 | Variable | Default | Description |
 |:---------|:--------|:------------|
 | `CHECKIN_CRON` | `0 8 * * *` | Daily check-in cron. |
+| `CHECKIN_ENABLED` | `true` | Global kill switch for the automatic check-in scheduler. `false` stops every automatic check-in request to upstream sites; the admin UI (Settings → Operations → Scheduling) can override it at runtime. |
 | `CHECKIN_SCHEDULE_MODE` | `cron` | `cron`, `interval`, or `window` scheduling modes (other values are rejected at startup). |
 | `CHECKIN_INTERVAL_HOURS` | `6` | Interval-mode period. |
 | `CHECKIN_WINDOW_START` / `CHECKIN_WINDOW_END` | `00:00` / `23:59` | Random-window mode bounds. |
 | `BALANCE_REFRESH_CRON` | `0 * * * *` | Balance refresh cron (hourly). |
+| `BALANCE_REFRESH_ENABLED` | `true` | Global kill switch for the periodic balance-refresh scheduler. `false` stops scheduled upstream balance queries; runtime-overridable in the admin UI. |
+| `MODEL_SYNC_CRON` | `0 4 * * *` | Periodic upstream model-list sync. The stored `model_sync_cron` setting overrides this value once an admin has saved one. |
 | `LOG_CLEANUP_CRON` | `0 6 * * *` | Retention pruning cron. |
 | `LOG_CLEANUP_USAGE_LOGS_ENABLED` / `LOG_CLEANUP_PROGRAM_LOGS_ENABLED` | `false` | Which log families the cleanup prunes. Off by default: the cleanup regime owns the log tables only when a toggle is `true` here or an admin-saved log-cleanup setting exists; otherwise the legacy `PROXY_LOG_RETENTION_DAYS` pruner handles proxy logs. `LOG_CLEANUP_RETENTION_DAYS` / `LOG_CLEANUP_CRON` alone do not switch the regime, and an explicit `false` never does. Startup logs the winner as `settings: log retention regime`. |
 | `LOG_CLEANUP_RETENTION_DAYS` | `30` | Proxy/program log retention. |
@@ -71,15 +80,17 @@ knob a deployment is likely to touch. Docker Compose users pass these via
 
 ## Notifications
 
-All providers are disabled unless their toggle/URL is set (webhook enabled by
-default when `WEBHOOK_URL` is non-empty). Alert cooldown:
+`WEBHOOK_ENABLED`, `BARK_ENABLED` and `SERVERCHAN_ENABLED` all default to
+`true`, so those three providers have no separate opt-in flag: they stay
+silent until their URL/key is set. Every other provider needs its
+`*_ENABLED` toggle *and* its URL/key. Alert cooldown:
 `NOTIFY_COOLDOWN_SEC` (default `300`).
 
 | Provider | Variables |
 |:---------|:----------|
-| Webhook | `WEBHOOK_URL` |
-| Bark | `BARK_URL` |
-| ServerChan | `SERVERCHAN_KEY` |
+| Webhook | `WEBHOOK_ENABLED`, `WEBHOOK_URL` |
+| Bark | `BARK_ENABLED`, `BARK_URL` |
+| ServerChan | `SERVERCHAN_ENABLED`, `SERVERCHAN_KEY` |
 | Telegram | `TELEGRAM_ENABLED`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `TELEGRAM_MESSAGE_THREAD_ID`, `TELEGRAM_USE_SYSTEM_PROXY` |
 | Feishu | `FEISHU_ENABLED`, `FEISHU_WEBHOOK`, `FEISHU_SECRET` (HMAC signing) |
 | DingTalk | `DINGTALK_ENABLED`, `DINGTALK_WEBHOOK`, `DINGTALK_SECRET` (HMAC signing) |
@@ -106,7 +117,18 @@ default when `WEBHOOK_URL` is non-empty). Alert cooldown:
 | `PROXY_STICKY_SESSION_TTL_MS` | `1800000` | Sticky binding TTL. |
 | `PROXY_SESSION_CHANNEL_CONCURRENCY_LIMIT` | `2` | Concurrent streams per session-channel lease. |
 | `PROXY_SESSION_CHANNEL_QUEUE_WAIT_MS` | `1500` | Queue wait for a busy session channel. |
-| `PROXY_SESSION_CHANNEL_LEASE_TTL_MS` / `..._KEEPALIVE_MS` | `90000` / `15000` | Session channel lease lifetime / keepalive. |
+| `PROXY_SESSION_CHANNEL_LEASE_TTL_MS` | `90000` | Session-channel lease lifetime in ms. |
+| `PROXY_SESSION_CHANNEL_LEASE_KEEPALIVE_MS` | `15000` | Keepalive interval that renews an in-use session-channel lease; floored at 1000 ms. |
+| `PROXY_CONNECT_TIMEOUT_SEC` | `2` | TCP dial (connect) timeout for outbound upstream requests. |
+| `PROXY_TLS_HANDSHAKE_TIMEOUT_SEC` | `10` | TLS handshake timeout. |
+| `PROXY_RESPONSE_HEADER_TIMEOUT_SEC` | `30` | How long to wait for upstream response headers. |
+| `PROXY_IDLE_CONN_TIMEOUT_SEC` | `90` | Idle keep-alive connection TTL in the pooled outbound transports. |
+| `PROXY_REQUEST_TIMEOUT_SEC` | `30` | Whole-request client timeout. |
+| `PROXY_STREAM_IDLE_TIMEOUT_SEC` | `300` | Chunk-gap guard for a flowing SSE stream: every relayed chunk resets the window, and a gap longer than this aborts the stream and records it as an upstream timeout fault. It does **not** cap total stream duration. |
+
+All six `*_SEC` timeouts share one clamp (`config.parseTimeoutSec`): unset,
+blank, invalid, zero or negative values fall back to the listed default, so a
+typo can never disable a timeout entirely.
 | `METAPI_ENABLE_PROXY_STUB` | empty | Test/demo-only local stub; leave empty in production (unconfigured forwarding returns an honest 503). |
 | `SYSTEM_PROXY_URL` | empty | Outbound HTTP proxy for upstream calls. |
 
@@ -117,9 +139,29 @@ default when `WEBHOOK_URL` is non-empty). Alert cooldown:
 | `PROXY_LOG_ASYNC` | `true` | Batched async INSERTs (production latency win); set `false` for tests needing write-through. |
 | `PROXY_LOG_BATCH_SIZE` | `50` | Flush threshold rows (1–1000). |
 | `PROXY_LOG_FLUSH_INTERVAL_MS` | `1000` | Flush period (1–60000 ms). |
-| `PROXY_LOG_RETENTION_DAYS` | `30` | Proxy log retention; `PROXY_LOG_RETENTION_PRUNE_INTERVAL_MINUTES` (30). |
-| `PROXY_FILE_RETENTION_DAYS` | `30` | Uploaded file retention; prune interval 60 min. |
-| `PROXY_VIDEO_TASK_RETENTION_DAYS` | `7` | Video task mapping retention: prunes `proxy_video_tasks` rows and bounds the in-process rewrite cache TTL; `0` = keep forever (explicit opt-out); prune interval 60 min. |
+| `PROXY_LOG_RETENTION_DAYS` | `30` | Proxy log retention in days (`0` = keep forever). |
+| `PROXY_LOG_RETENTION_PRUNE_INTERVAL_MINUTES` | `30` | How often the proxy-log pruner runs; floored at 1 minute. |
+| `PROXY_FILE_RETENTION_DAYS` | `30` | Uploaded file retention in days (`0` = keep forever). |
+| `PROXY_FILE_RETENTION_PRUNE_INTERVAL_MINUTES` | `60` | How often the uploaded-file pruner runs; floored at 1 minute. |
+| `PROXY_VIDEO_TASK_RETENTION_DAYS` | `7` | Video task mapping retention: prunes `proxy_video_tasks` rows and bounds the in-process rewrite cache TTL; `0` = keep forever (explicit opt-out). |
+| `PROXY_VIDEO_TASK_RETENTION_PRUNE_INTERVAL_MINUTES` | `60` | How often the video-task pruner runs; floored at 1 minute. |
+
+### Proxy debug tracing
+
+Capture surfaces for reproducing an upstream failure. All of it is off unless
+`PROXY_DEBUG_TRACE_ENABLED` is set, and captured rows are pruned on a timer.
+
+| Variable | Default | Description |
+|:---------|:--------|:------------|
+| `PROXY_DEBUG_TRACE_ENABLED` | `false` | Master switch for debug trace capture. |
+| `PROXY_DEBUG_CAPTURE_HEADERS` | `true` | Store request/response headers on a captured trace (only meaningful while capture is on). |
+| `PROXY_DEBUG_CAPTURE_BODIES` | `false` | Store request/response bodies. |
+| `PROXY_DEBUG_CAPTURE_STREAM_CHUNKS` | `false` | Store individual SSE chunks of a streamed response. |
+| `PROXY_DEBUG_TARGET_SESSION_ID` | empty | Capture only this session id; empty = no session filter. |
+| `PROXY_DEBUG_TARGET_CLIENT_KIND` | empty | Capture only this detected client kind; empty = no client filter. |
+| `PROXY_DEBUG_TARGET_MODEL` | empty | Capture only this model; empty = no model filter. |
+| `PROXY_DEBUG_MAX_BODY_BYTES` | `262144` | Per-body capture cap in bytes; floored at 1024. |
+| `PROXY_DEBUG_RETENTION_HOURS` | `24` | How long captured traces are kept; floored at 1 hour. |
 
 ## Routing
 
@@ -132,10 +174,16 @@ default when `WEBHOOK_URL` is non-empty). Alert cooldown:
 | `TOKEN_ROUTER_FAILURE_COOLDOWN_MAX_SEC` | — | Upper bound for failure cooldown. |
 | `PRICING_CATALOG_ENABLED` | on | models.dev catalog as cold-start price signal; third-party relays are always labeled `catalog_estimate`. |
 | `PRICING_CATALOG_REFRESH_MIN` / `PRICING_CATALOG_URL` | — | Catalog refresh period / mirror. |
-| `MODEL_AVAILABILITY_PROBE_ENABLED` | `false` | Background channel health probing; interval/timeout/concurrency via `MODEL_AVAILABILITY_PROBE_*` (floor 60 s / 3 s, concurrency 1–16). |
-| `ROUTE_REBUILD_PROBE_FILTER_ENABLED` | empty | Rebuild only routes whose probe status changed; include/exclude model lists available. |
+| `MODEL_AVAILABILITY_PROBE_ENABLED` | `false` | Background channel health probing (off by default). |
+| `MODEL_AVAILABILITY_PROBE_INTERVAL_MS` | `1800000` | Probe period; floored at 60000 ms (60 s). |
+| `MODEL_AVAILABILITY_PROBE_TIMEOUT_MS` | `15000` | Per-probe timeout; floored at 3000 ms (3 s). |
+| `MODEL_AVAILABILITY_PROBE_CONCURRENCY` | `1` | Parallel probes; clamped to 1–16. |
+| `ROUTE_REBUILD_PROBE_FILTER_ENABLED` | empty | Rebuild only routes whose probe status changed. |
+| `ROUTE_REBUILD_PROBE_FILTER_INCLUDE_MODELS` | empty | CSV allowlist restricting the probe-filter rebuild to these models; empty = no restriction. |
+| `ROUTE_REBUILD_PROBE_FILTER_EXCLUDE_MODELS` | empty | CSV denylist removing these models from the probe-filter rebuild. |
 | `PAYLOAD_RULES` / `PAYLOAD_RULES_JSON` | empty | Per-model payload rewrite rules. |
-| `OPENAI_SERVICE_TIER_RULES(_JSON)` | empty | service_tier injection rules. |
+| `OPENAI_SERVICE_TIER_RULES` | empty | Per-model `service_tier` injection rules (JSON document). |
+| `OPENAI_SERVICE_TIER_RULES_JSON` | empty | Legacy alias for `OPENAI_SERVICE_TIER_RULES`; wins when both are set. |
 
 ## Security & network
 
@@ -143,6 +191,9 @@ default when `WEBHOOK_URL` is non-empty). Alert cooldown:
 |:---------|:--------|:------------|
 | `ADMIN_IP_ALLOWLIST` | empty | CSV of allowed admin IPs/CIDRs. |
 | `ADMIN_RATE_LIMIT_RPS` / `ADMIN_RATE_LIMIT_BURST` | `100` / `200` | Admin per-IP token bucket. |
+| `AUTH_RATE_LIMIT_RPS` / `AUTH_RATE_LIMIT_BURST` | `10` / `20` | Stricter per-IP token bucket applied only to `/api/auth/*`, which is the only surface accepting the master token. Values ≤ 0 fall back to the defaults at mount time. |
+| `ADMIN_SESSION_TTL_MINUTES` | `720` | Sliding TTL of the server-side admin UI session minted by `POST /api/auth/login`; floored at 1 minute. |
+| `ADMIN_SESSION_COOKIE_SECURE` | `auto` | `Secure` flag of the `metapi_session` cookie. Accepted values: `true`/`1`/`yes` → always secure, `false`/`0`/`no` → never secure, anything else (including `auto`) → `auto`, which follows the request protocol. |
 | `OAUTH_RATE_LIMIT_RPS` / `OAUTH_RATE_LIMIT_BURST` | `10` / `20` | OAuth per-IP token bucket. |
 | `TRUSTED_PROXY_CIDRS` | empty | Reverse-proxy CIDRs allowed to supply `X-Forwarded-For` / `X-Real-IP`; empty ignores forwarded headers. |
 | `ADMIN_CORS_ALLOWED_ORIGINS` | empty | Exact `http(s)` origins allowed for `/api/*`; empty = same-origin admin UI only (`*` rejected). |
@@ -170,7 +221,8 @@ default when `WEBHOOK_URL` is non-empty). Alert cooldown:
 | `CODEX_UPSTREAM_WEBSOCKET_ENABLED` | empty | Codex upstream WebSocket transport (C3); non-upgrade GETs get an honest 426. |
 | `CODEX_RESPONSES_WEBSOCKET_BETA` | empty | Responses-over-WS beta header. |
 | `RESPONSES_COMPACT_FALLBACK_TO_RESPONSES_ENABLED` | empty | Compact → Responses fallback. |
-| `CODEX_HEADER_DEFAULTS_USER_AGENT` / `..._BETA_FEATURES` | — | Header defaults for Codex upstreams. |
+| `CODEX_HEADER_DEFAULTS_USER_AGENT` | empty | `User-Agent` sent to Codex upstreams; empty keeps the built-in default. |
+| `CODEX_HEADER_DEFAULTS_BETA_FEATURES` | empty | Anthropic `anthropic-beta`-style feature header value sent to Codex upstreams; empty keeps the built-in default. |
 
 ## Misc
 

--- a/docs/env_parity_test.go
+++ b/docs/env_parity_test.go
@@ -1,0 +1,380 @@
+package docs_test
+
+// TestEnvVarDocParity locks the three-way agreement between the environment
+// variables a deployment can set and the two places that document them:
+//
+//	.env.example           — key + inline comment (the machine-readable source)
+//	docs/configuration.md  — grouped table (variable / default / description)
+//	config/config.go       — what config.Load actually reads, plus clamps
+//
+// Why a test and not a checklist: the three files drift independently, and a
+// drifted default is worse than a missing one because an operator who reads
+// the doc and trusts it configures the wrong thing. This gate turns that
+// drift into a red CI run instead of a support ticket.
+//
+// Directions asserted (all must be empty):
+//  1. every key in .env.example is documented in docs/configuration.md
+//  2. every variable named in docs/configuration.md exists in .env.example
+//  3. every key read by config.Load's get("X") helper exists in .env.example
+//  4. every key in .env.example has a real reader somewhere in non-test Go
+//     code (get("X"), os.Getenv, os.LookupEnv or a direct env-map index)
+//
+// Direction 4 is the one that catches dead keys — a variable shipped in
+// .env.example that no code path ever reads. Keys with no reader must be
+// listed in unreadEnvKeyAllowlist with a reason; the list is deliberately
+// tiny and every entry is a known wart, not a convenience.
+//
+// Parsing note: the doc side extracts every backticked ALL-CAPS token, not
+// just table first-columns, because docs/configuration.md legitimately packs
+// several variables into one cell (`A` / `B`). That is over-eager on purpose:
+// a prose token like `TLS` in backticks fails the test loudly and is fixed by
+// dropping the backticks, whereas a too-narrow parser would silently pass
+// while a real variable went undocumented. Failure direction matters more
+// than precision here.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// envKeyRE matches a KEY=... assignment line in .env.example (comments and
+// blank lines are skipped by the caller).
+var envKeyRE = regexp.MustCompile(`^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=`)
+
+// docVarRE matches a backticked ALL-CAPS token inside Markdown — the shape of
+// every environment variable in this repository, including short ones without
+// underscores (`TZ`, `LOGO`, `FOOTER`, `ABOUT`).
+var docVarRE = regexp.MustCompile("`([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*)`")
+
+// docProseTokens are backticked ALL-CAPS tokens in docs/configuration.md that
+// are prose (formats, protocols, units), not environment variables. Each
+// entry carries a reason, and TestEnvVarDocParity fails if any entry is also
+// a real key in .env.example — so this list cannot be used to hide an
+// undocumented variable.
+var docProseTokens = map[string]string{}
+
+// configGetRE matches the get("KEY") helper calls inside config.Load.
+var configGetRE = regexp.MustCompile(`get\("([A-Z0-9_]+)"\)`)
+
+// readerREs match every other way a key can be read from the environment in
+// this repository.
+var readerREs = []*regexp.Regexp{
+	regexp.MustCompile(`get\("([A-Z0-9_]+)"\)`),
+	regexp.MustCompile(`os\.Getenv\("([A-Z0-9_]+)"\)`),
+	regexp.MustCompile(`os\.LookupEnv\("([A-Z0-9_]+)"\)`),
+	regexp.MustCompile(`env\["([A-Z0-9_]+)"\]`),
+}
+
+// unreadEnvKeyAllowlist lists .env.example keys that have no reader in
+// non-test Go code. Each entry MUST carry a reason; an entry without a
+// real justification is a bug being hidden, not a bug being managed.
+var unreadEnvKeyAllowlist = map[string]string{
+	// Branding text is loaded into RuntimeSettings through the settings
+	// table, not through config.Load: the key is documented for operators
+	// migrating from the TypeScript release, but the Go binary does not
+	// read it. Reported to maintainers rather than silently deleted, since
+	// removing a key from .env.example is outside a docs change.
+	"HOME_PAGE_CONTENT": "documented for TS-parity; no reader in non-test Go code (tracked as a dead key, see .dev-local w4 R3-BLOCKED.md)",
+}
+
+func TestEnvVarDocParity(t *testing.T) {
+	root := repoRoot(t)
+
+	envContent := readRepoFile(t, root, ".env.example")
+	docContent := readRepoFile(t, root, "docs/configuration.md")
+	cfgContent := readRepoFile(t, root, "config/config.go")
+
+	envKeys := parseEnvExampleKeys(envContent)
+	if len(envKeys) == 0 {
+		t.Fatal("parser sanity: .env.example yielded 0 keys — the parser is broken, not the docs")
+	}
+	docVars := parseDocVars(docContent)
+	if len(docVars) == 0 {
+		t.Fatal("parser sanity: docs/configuration.md yielded 0 variables — the parser is broken, not the docs")
+	}
+	cfgKeys := parseConfigGetKeys(cfgContent)
+	if len(cfgKeys) == 0 {
+		t.Fatal("parser sanity: config/config.go yielded 0 get(\"X\") keys — the parser is broken, not the docs")
+	}
+	readers := collectEnvReaders(t, root)
+	if len(readers) == 0 {
+		t.Fatal("parser sanity: no environment readers found in Go sources — the scan is broken")
+	}
+
+	// The prose allowlist must never shadow a real variable.
+	var shadowed []string
+	for tok := range docProseTokens {
+		for _, k := range envKeys {
+			if k == tok {
+				shadowed = append(shadowed, tok)
+			}
+		}
+	}
+	if len(shadowed) > 0 {
+		sort.Strings(shadowed)
+		t.Fatalf("docProseTokens shadows real .env.example keys %s — remove them from the prose allowlist; they must be documented as variables", strings.Join(shadowed, ", "))
+	}
+
+	undocumented := diffKeys(envKeys, docVars)
+	invented := diffKeys(docVars, envKeys)
+	missingFromExample := diffKeys(cfgKeys, envKeys)
+
+	var dead []string
+	for _, k := range envKeys {
+		if readers[k] {
+			continue
+		}
+		if _, ok := unreadEnvKeyAllowlist[k]; ok {
+			continue
+		}
+		dead = append(dead, k)
+	}
+
+	var b strings.Builder
+	reportDiff(&b, "in .env.example but NOT documented in docs/configuration.md", undocumented)
+	reportDiff(&b, "in docs/configuration.md but NOT present in .env.example", invented)
+	reportDiff(&b, "read by config.Load but NOT present in .env.example", missingFromExample)
+	reportDiff(&b, "in .env.example with no reader in non-test Go code (dead key; allowlist with reason required)", dead)
+	if b.Len() > 0 {
+		t.Fatalf("environment-variable documentation drift:\n%s\nFix the docs (or .env.example) — do not relax this test.", b.String())
+	}
+}
+
+// TestEnvParityGateIsNotAVacuousPass proves the gate above can actually go
+// red. It feeds deliberately violating samples through the same parsers and
+// comparators used on the real files, and requires each violation to be
+// detected. Without this, a typo in a regexp would make TestEnvVarDocParity
+// pass forever while documenting nothing.
+func TestEnvParityGateIsNotAVacuousPass(t *testing.T) {
+	const goodEnv = "PORT=4000\n# a comment\nAUTH_TOKEN=change-me-admin-token\n"
+	const goodDoc = "| `PORT` | `4000` | HTTP listen port. |\n| `AUTH_TOKEN` | `change-me-admin-token` | Admin token. |\n"
+	const goodCfg = "func Load(env map[string]string) {\n\tcfg.Port = get(\"PORT\")\n\trt.AuthToken = get(\"AUTH_TOKEN\")\n}\n"
+
+	base := detectDrift(parseEnvExampleKeys(goodEnv), parseDocVars(goodDoc), parseConfigGetKeys(goodCfg),
+		map[string]bool{"PORT": true, "AUTH_TOKEN": true}, nil)
+	if base != "" {
+		t.Fatalf("control sample must be clean, got:\n%s", base)
+	}
+
+	cases := []struct {
+		name       string
+		env        string
+		doc        string
+		cfg        string
+		readers    map[string]bool
+		allowlist  map[string]string
+		wantSubstr string
+	}{
+		{
+			name:       "documented variable dropped from the doc",
+			env:        goodEnv,
+			doc:        "| `PORT` | `4000` | HTTP listen port. |\n",
+			cfg:        goodCfg,
+			readers:    map[string]bool{"PORT": true, "AUTH_TOKEN": true},
+			wantSubstr: "AUTH_TOKEN",
+		},
+		{
+			name:       "doc invents a variable that .env.example does not ship",
+			env:        goodEnv,
+			doc:        goodDoc + "| `ZZZ_INVENTED_KNOB` | empty | Not real. |\n",
+			cfg:        goodCfg,
+			readers:    map[string]bool{"PORT": true, "AUTH_TOKEN": true},
+			wantSubstr: "ZZZ_INVENTED_KNOB",
+		},
+		{
+			name:       "code reads a key that .env.example never shipped",
+			env:        goodEnv,
+			doc:        goodDoc,
+			cfg:        goodCfg + "\tcfg.X = get(\"ZZZ_UNSHIPPED_KEY\")\n",
+			readers:    map[string]bool{"PORT": true, "AUTH_TOKEN": true},
+			wantSubstr: "ZZZ_UNSHIPPED_KEY",
+		},
+		{
+			name:       "shipped key has no reader anywhere (dead key)",
+			env:        goodEnv + "ZZZ_DOC_PARITY_PROBE=\n",
+			doc:        goodDoc + "| `ZZZ_DOC_PARITY_PROBE` | empty | Probe. |\n",
+			cfg:        goodCfg,
+			readers:    map[string]bool{"PORT": true, "AUTH_TOKEN": true},
+			allowlist:  map[string]string{},
+			wantSubstr: "ZZZ_DOC_PARITY_PROBE",
+		},
+		{
+			name:      "same dead key is tolerated once it carries a reasoned allowlist entry",
+			env:       goodEnv + "ZZZ_DOC_PARITY_PROBE=\n",
+			doc:       goodDoc + "| `ZZZ_DOC_PARITY_PROBE` | empty | Probe. |\n",
+			cfg:       goodCfg,
+			readers:   map[string]bool{"PORT": true, "AUTH_TOKEN": true},
+			allowlist: map[string]string{"ZZZ_DOC_PARITY_PROBE": "probe"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			allow := tc.allowlist
+			if allow == nil {
+				allow = map[string]string{}
+			}
+			got := detectDrift(parseEnvExampleKeys(tc.env), parseDocVars(tc.doc), parseConfigGetKeys(tc.cfg), tc.readers, allow)
+			if tc.wantSubstr == "" {
+				if got != "" {
+					t.Fatalf("expected clean, got:\n%s", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatalf("gate did not fire on a deliberate violation (%s) — it is vacuous", tc.name)
+			}
+			if !strings.Contains(got, tc.wantSubstr) {
+				t.Fatalf("gate fired but did not name %q:\n%s", tc.wantSubstr, got)
+			}
+		})
+	}
+}
+
+// detectDrift is the pure comparison core shared by the real-file test and
+// the self-proof test, so the self-proof exercises exactly the same logic.
+func detectDrift(envKeys, docVars, cfgKeys []string, readers map[string]bool, allowlist map[string]string) string {
+	var b strings.Builder
+	reportDiff(&b, "in .env.example but NOT documented in docs/configuration.md", diffKeys(envKeys, docVars))
+	reportDiff(&b, "in docs/configuration.md but NOT present in .env.example", diffKeys(docVars, envKeys))
+	reportDiff(&b, "read by config.Load but NOT present in .env.example", diffKeys(cfgKeys, envKeys))
+
+	var dead []string
+	for _, k := range envKeys {
+		if readers[k] {
+			continue
+		}
+		if _, ok := allowlist[k]; ok {
+			continue
+		}
+		dead = append(dead, k)
+	}
+	reportDiff(&b, "in .env.example with no reader in non-test Go code (dead key; allowlist with reason required)", dead)
+	return b.String()
+}
+
+func parseEnvExampleKeys(content string) []string {
+	var keys []string
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if m := envKeyRE.FindStringSubmatch(line); m != nil {
+			keys = append(keys, m[1])
+		}
+	}
+	return dedupeSorted(keys)
+}
+
+func parseDocVars(content string) []string {
+	var keys []string
+	for _, m := range docVarRE.FindAllStringSubmatch(content, -1) {
+		if _, prose := docProseTokens[m[1]]; prose {
+			continue
+		}
+		keys = append(keys, m[1])
+	}
+	return dedupeSorted(keys)
+}
+
+func parseConfigGetKeys(content string) []string {
+	return dedupeSorted(firstGroups(configGetRE.FindAllStringSubmatch(content, -1)))
+}
+
+func firstGroups(matches [][]string) []string {
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// collectEnvReaders returns the set of environment keys read anywhere in
+// non-test Go source, so a key shipped in .env.example that nothing reads is
+// reported instead of silently documented forever.
+func collectEnvReaders(t *testing.T, root string) map[string]bool {
+	t.Helper()
+	readers := map[string]bool{}
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", "node_modules", "dist", ".dev-local", ".worktrees", "web":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		src := string(data)
+		for _, re := range readerREs {
+			for _, m := range re.FindAllStringSubmatch(src, -1) {
+				readers[m[1]] = true
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return readers
+}
+
+func diffKeys(a, b []string) []string {
+	inB := map[string]bool{}
+	for _, k := range b {
+		inB[k] = true
+	}
+	var out []string
+	for _, k := range a {
+		if !inB[k] {
+			out = append(out, k)
+		}
+	}
+	return dedupeSorted(out)
+}
+
+func reportDiff(b *strings.Builder, label string, keys []string) {
+	if len(keys) == 0 {
+		return
+	}
+	b.WriteString("  " + label + " (" + itoa(len(keys)) + "):\n")
+	for _, k := range keys {
+		b.WriteString("    - " + k + "\n")
+	}
+}
+
+func dedupeSorted(in []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func readRepoFile(t *testing.T, root, rel string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
## 改动摘要

把对外文档从「散文式介绍」改成可对账的技术参考，并给两份最容易烂的契约（环境变量、路由清单）各加一道**会自证伪**的门禁。

**三份差集归零**（基线 → 交付）：

| 方向 | 基线 | 交付 |
|:--|:--|:--|
| `.env.example` 有、`docs/configuration.md` 没写 | **39** | **0** |
| `docs/configuration.md` 写了、`.env.example` 没有（文档编造） | 0 | **0** |
| `config.Load` 读了、`.env.example` 没发 | 0 | **0** |
| 代码注册了、`docs/api/routes-inventory.md` 没列 | **9** | **0** |
| inventory 列了、代码没注册 | 0 | **0** |

- `docs/configuration.md`：补齐 39 个未文档化变量，把不可 grep 的简写（`PROXY_*`、`..._KEEPALIVE_MS`、`RULES(_JSON)`）展开成全名；默认值与钳制规则一律照抄 `config.Load` / `config/defaults.go`，不照抄旧散文。修掉一处注释与代码不符：`PROXY_MAX_STREAM_RESPONSE_BYTES` 的注释写「Default 1 MB (1048576)」，实际值 67108864、常量 `DefaultProxyMaxStreamResponseBytes = 64 << 20`。
- `docs/api/routes-inventory.md` + `docs/api/models.md`：补上 9 条已注册但未公开的路由（catalog sources CRUD、catalog-sync 触发 / 状态 / 配置、channels 与 accounts 的 probe-history），逐条写请求体、响应形状、错误文案（错误文案与 handler 里的字面量逐字一致），错误信封引用 `conventions.md` 而不复述。
- `docs/architecture.md`：骨架从「文件清单」换成「所有权与边界」——每个包拥有哪个决策、禁止哪些 import 边（与 `docs/package_boundary_test.go` 互为镜像，并明说不一致时以测试为准）、一次请求经过哪些阶段。数据面一节按刚落地的流式失败判定 / 跨协议回落改动重读过：attempt loop 与流结束分类归 `handler/proxy`，可复用裁决（内容判定、same-site abort、降级、重试、刷新鉴权）归 `proxy`。
- `README.md` / `README_EN.md`：文档表指针加信息气味（有什么 + 何时该读），补 routes-inventory / configuration 两个入口，形成店面 → 上手 → 结构 → 契约 → 运维的一步可达链。

**两道新门禁**（`docs/env_parity_test.go`、`docs/api_inventory_parity_test.go`）：

- env 三方对账：`.env.example` ⇄ `docs/configuration.md` ⇄ `config.Load` 的 `get("...")`，外加**死键检测**（`.env.example` 发了但非测试 Go 代码里没有任何读取点）。
- 路由对账：用 `go/ast` 从 `router.New` 出发重建真实路由集（跨包跟踪 `Register*Routes`，处理 `Route`/`Mount` 前缀拼接与同名函数撞名），与 inventory 双向对账；文档 `:param` 与 chi `{param}` 归一化后判等；42 条非 `/api` 路由由 `TestNonAPIRoutesAreAccountedFor` 强制指名归属文档，两份白名单都被「过期条目检查」守着，不能烂成藏身处。
- 两道门禁各自带一个 `...IsNotAVacuousPass` 用例：把故意违规的样本喂进**与真检查同一份**判定代码，确认门禁真的会红。

## 类型

- [x] docs / chore（文档或工程维护）

## 测试验证

- [x] `go test ./docs -count=1` 全绿：**13** 个用例（4 个既有门禁文件零改动 + 2 道新门禁 + 2 个自证伪用例 + 既有 hygiene / 链接 / 边界门禁）
- [x] 新门禁「真文件红 → 绿」四探针：`.env.example` 加假键 → FAIL；把真键从文档改名 → FAIL（双向都报）；inventory 编造一条假路由 → FAIL；删掉一条真路由 → FAIL；四次全部还原后 `ok`
- [x] `.env.example` 的 diff 只有两行注释，键与值零改动
- [ ] `cd web && bun run *`（本 PR 无前端改动）

## 自查清单

- [x] 无密钥 / 内部路径泄漏（`TestPublicMarkdownHygiene` 覆盖全部公开 md）
- [ ] 用户可见文案已走 i18n（本 PR 无前端文案）
- [x] 行为变更已补充 / 更新测试（本 PR 只加测试，不改业务代码）
- [x] 需要时更新了 `CHANGELOG.md` / `docs/`（docs 本身）

### 已知遗留（不在本 PR 修）

- `HOME_PAGE_CONTENT` 是死键：非测试 Go 代码零读取点，但 `.env.example` 与文档都承诺它能改首页文案。本 PR 只许改注释、不许删键，因此把它进带理由的白名单钉在明面上，留待代码侧裁决（实现读取点，或删键 + 删文档承诺）。
- 「`.env.example` 注释里的数值 == `config` 默认常量」还没做成门禁：本次只锁键集合三方一致 + 死键。校验自然语言注释里的数字误报率高，正确解法是让注释引用常量名而不是复述数值（本 PR 修 `PROXY_MAX_STREAM_RESPONSE_BYTES` 时已按这个写法改）。
- `docs/**` 各页之间的入口链只在 README 与 architecture.md 两头补齐；`api.md` / `getting-started.md` / `deployment.md` 内部的指针气味未逐页审，跨文件术语表未建。

> 合并方式：Squash merge（master 受保护）。
