### PR TITLE
fix(e2e): resolve the smoke suite's site by the key the backend dedupes on

### DIFF
--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -8,9 +8,10 @@
 #
 # Every step prints [PASS]/[FAIL]/[WARN] and accumulates a summary; the script
 # exits 1 when any step FAILs. FAILs print the truncated response body as
-# evidence. The script is re-runnable: sites/accounts/routes are looked up by
-# name before creation, and the downstream key has a fixed value so a 409
-# conflict is treated as "already exists".
+# evidence. The script is re-runnable: sites are resolved by name and then by
+# the backend's own uniqueness key (platform, canonical url), accounts/routes
+# are looked up by name before creation, and the downstream key has a fixed
+# value so a 409 conflict is treated as "already exists".
 #
 # Configuration (environment variables):
 #   METAPI_URL         admin base URL         (default http://127.0.0.1:4000)
@@ -151,6 +152,50 @@ sys.exit(4)
 ' "$1" "$2" "$3" "$4" < "$RESP_BODY"
 }
 
+# site_find_index NAME PLATFORM URL — index of the site row a create would
+# collide with: same name first, then the backend's real uniqueness key
+# (platform, canonical url). POST /api/sites dedupes on (platform, url), NOT on
+# name, so name-only resolution strands a re-run whenever the stored name
+# differs (SITE_NAME changed, or another suite seeded the same upstream).
+# Canonicalization mirrors service.CanonicalizeSiteURL: trim, drop query and
+# fragment, strip trailing slashes (scheme/host compared case-insensitively so
+# the fallback is a superset of the server's key, never a subset).
+site_find_index() {
+  python3 -c '
+import json, sys
+from urllib.parse import urlsplit, urlunsplit
+name, platform, url = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(3)
+if isinstance(data, dict) and isinstance(data.get("sites"), list):
+    data = data["sites"]
+if not isinstance(data, list):
+    sys.exit(4)
+
+def canon(raw):
+    s = str(raw or "").strip()
+    try:
+        p = urlsplit(s)
+        s = urlunsplit((p.scheme.lower(), p.netloc.lower(), p.path, "", ""))
+    except Exception:
+        pass
+    return s.rstrip("/")
+
+want = canon(url)
+for i, item in enumerate(data):
+    if isinstance(item, dict) and str(item.get("name")) == name:
+        print(i)
+        sys.exit(0)
+for i, item in enumerate(data):
+    if isinstance(item, dict) and str(item.get("platform")) == platform and canon(item.get("url")) == want:
+        print(i)
+        sys.exit(0)
+sys.exit(4)
+' "$1" "$2" "$3" < "$RESP_BODY"
+}
+
 # json_has_error_key — 0 when $RESP_BODY is valid JSON containing an "error" key.
 json_has_error_key() {
   python3 -c '
@@ -225,23 +270,32 @@ else
 fi
 
 # 4. site idempotent-create
+#
+# resolve_site_id re-reads the site list and resolves the row this run owns.
+# Both the pre-create lookup and the 409 fallback go through it so the two can
+# never disagree on the key: a 409 means "a site with this (platform, url)
+# already exists", and answering that with a name lookup is how a single name
+# mismatch used to cascade into every downstream step (login, verify, token,
+# route, proxy, logs) reporting FAIL.
 SITE_ID=""
-status="$(request GET "$METAPI_URL/api/sites" "" "$METAPI_AUTH_TOKEN")"
-if [ "$status" = "200" ]; then
-  if idx="$(json_find_index name "$SITE_NAME" 2>/dev/null)"; then
-    SITE_ID="$(json_value "[$idx].id" 2>/dev/null || true)"
-  fi
-fi
+resolve_site_id() {
+  local st idx
+  st="$(request GET "$METAPI_URL/api/sites" "" "$METAPI_AUTH_TOKEN")"
+  [ "$st" = "200" ] || return 1
+  idx="$(site_find_index "$SITE_NAME" "$PLATFORM" "$UPSTREAM_URL" 2>/dev/null)" || return 1
+  SITE_ID="$(json_value "[$idx].id" 2>/dev/null || true)"
+  [ -n "$SITE_ID" ]
+}
+resolve_site_id
 if [ -z "$SITE_ID" ]; then
   status="$(request POST "$METAPI_URL/api/sites" "{\"name\":\"$SITE_NAME\",\"url\":\"$UPSTREAM_URL\",\"platform\":\"$PLATFORM\"}" "$METAPI_AUTH_TOKEN")"
   if [ "$status" = "200" ] || [ "$status" = "201" ]; then
     SITE_ID="$(json_value id 2>/dev/null || true)"
   elif [ "$status" = "409" ]; then
-    # duplicate site exists (race between reads): re-read by name
-    request GET "$METAPI_URL/api/sites" "" "$METAPI_AUTH_TOKEN" >/dev/null
-    if idx="$(json_find_index name "$SITE_NAME" 2>/dev/null)"; then
-      SITE_ID="$(json_value "[$idx].id" 2>/dev/null || true)"
-    fi
+    # Duplicate (platform, url): another run created it between our read and our
+    # write, or it exists under a different name. Re-resolve on the same key the
+    # backend dedupes by.
+    resolve_site_id
   fi
 fi
 if [ -n "$SITE_ID" ]; then


### PR DESCRIPTION
## 改动摘要

`scripts/e2e/smoke.sh` 的站点解析改成按**后端真正去重的那把键**来认，修掉「一个名字对不上 → 七步连环 FAIL」。

`POST /api/sites` 的唯一性判定是 `(platform, canonical url)`（`handler/admin/sites.go` 的 duplicate check），**不是 name**。而脚本的 409 兜底是「重读列表 → 按 `SITE_NAME` 找 id」：只要库里那个站点叫别的名字（换过 `SITE_NAME`、或上游站点是别的套件建的），409 之后什么也找不到，`SITE_ID` 为空，后面 login / verify-token / account / models / balance / checkin 全部 skip 并报 FAIL。

改法：预创建查找与 409 兜底共用一个 `resolve_site_id`（两处再也不可能对「用哪把键」各说各话），先按 name 认（`SITE_NAME` 仍是文档化的复用旋钮），认不到再按 `(platform, canonical url)` 认；新增 `site_find_index` 的规范化对齐 `service.CanonicalizeSiteURL`（trim → 丢 query/fragment → 去尾斜杠），scheme/host 大小写不敏感，使兜底是后端键的**超集**而不是子集。脚本头部关于「可重复跑」的说明同步改成事实。

## 类型

- [x] fix（bug 修复）

## 测试验证

- [x] `bash -n scripts/e2e/smoke.sh` 通过
- [x] 解析器逐用例实测（用 sed 抽出真实函数体驱动，不是复制一份逻辑）：name 命中、name 不命中但 url 命中（含尾斜杠差异）、host 大小写不敏感、query/fragment 丢弃、platform 不符不命中、无命中 rc=4、`{"sites":[…]}` 包裹形状
- [x] **活体红→绿**（同一实例、同一上游、同一份环境变量，只用默认 `SITE_NAME=e2e-smoke`，库里站点实为别的名字）：
  - 改前：`== summary: 6 passed, 1 warned, 7 failed ==`（`site idempotent-create (no site id obtained)` 起连环 FAIL）
  - 改后：`== summary: 13 passed, 1 warned, 0 failed ==`（`site idempotent-create (siteId=1)` → login/verify-token/account/models/balance/checkin 全部 PASS）
  - 即：**不再需要**手工传 `SITE_NAME` 去对齐库里已有的名字
- [ ] `go vet` / `go test`（纯脚本改动，未触及 Go 代码）；CI 的 `test-e2e` 会用真实上游跑这条链

## 自查清单

- [x] 无密钥 / 内部路径泄漏
- [ ] 用户可见文案已走 i18n（无前端改动）
- [x] 行为变更已补充 / 更新测试（脚本自身即被测对象，附活体红绿）
- [ ] 需要时更新了 `CHANGELOG.md` / `docs/`（脚本注释即文档，已同步）

> 合并方式：Squash merge（master 受保护）。
