### PR TITLE
fix(admin): stop echoing plaintext credentials on account write responses

### DIFF
--- a/docs/api/accounts.md
+++ b/docs/api/accounts.md
@@ -25,6 +25,8 @@ Get, update, delete an account.
 
 **`proxyUrl` update semantics**: field omitted → keep the stored proxy; present with a value → replace (same scheme validation as create); present empty (`""`) → delete `extraConfig.proxyUrl`.
 
+**Credential redaction**: the update response carries `accessTokenMasked` / `apiTokenMasked` instead of plaintext `accessToken` / `apiToken`, and `autoRelogin.passwordCipher` is stripped out of `extraConfig` — the same contract `GET /api/accounts` answers with, so a no-op update cannot be used to harvest what the list surface withholds. Revealing a stored secret stays an explicit act (`GET /api/account-tokens/{id}/value`). The credential-provisioning responses keep returning what they obtained — `POST /api/accounts/login` hands back the session token it just logged in with, `POST /api/accounts/verify-token` the API token it discovered — because in those two the caller never had it.
+
 ### GET /api/accounts/probe-history
 
 Recent background model-probe history per account — the data behind the row-level probe health bars on the accounts page. One bounded query covers every account that has history (windowed to the newest `limit` results each); accounts without probes are omitted from `items`. Rows recorded without a channel (account-level probes) are included here.
@@ -75,7 +77,7 @@ The account's proven model list (with site-disabled and operator-pinned flags) a
 Replace a session account's access token (session-credential rebind; Sub2API auth merges `refreshToken`/`tokenExpiresAt` into `extraConfig.sub2apiAuth`).
 
 **Body**: `{ "accessToken": "sk-...", "refreshToken": "...", "tokenExpiresAt": 1710000000 }` — `accessToken` is required (400 otherwise).
-**Response**: `{ success, account, tokenType: "session", credentialMode: "session", capabilities, apiTokenFound: false }`.
+**Response**: `{ success, account, tokenType: "session", credentialMode: "session", capabilities, apiTokenFound: false }` — `account` is redacted like the update response (`accessTokenMasked` / `apiTokenMasked`, no plaintext credentials): the caller supplied the new session token itself, and the stored `apiToken` is not this endpoint's to disclose.
 
 ---
 

--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -1127,6 +1127,10 @@ func (h *accountsHandler) rebindSession(w http.ResponseWriter, r *http.Request) 
 		"createdAt":      rebindAcct.CreatedAt,
 		"updatedAt":      rebindAcct.UpdatedAt,
 	}
+	// Masked like every other account surface: the caller supplied the new
+	// session token itself, and the stored apiToken is not this endpoint's to
+	// disclose (service.RedactAccountSecrets is the policy SSOT).
+	service.RedactAccountSecrets(rebindAcctMap)
 	routing.InvalidateCache()
 	globalAccountsCache.clear()
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -1442,6 +1446,11 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 			resp["message"] = "credential updated, but model refresh failed; account remains expired: " + modelRefreshErrorMessage(modelRefresh)
 		}
 	}
+	// Same credential policy as the list surface: without this, a no-op update
+	// ({"sortOrder": n}) answers with the plaintext accessToken/apiToken and the
+	// autoRelogin passwordCipher that GET /api/accounts masks — i.e. the write
+	// endpoint would be a harvest primitive around the read-side redaction.
+	service.RedactAccountSecrets(resp)
 	routing.InvalidateCache()
 	globalAccountsCache.clear()
 	writeJSON(w, http.StatusOK, resp)

--- a/handler/admin/admin_creds_test.go
+++ b/handler/admin/admin_creds_test.go
@@ -373,8 +373,8 @@ func TestMaskSecretFromFragments_ParityWithMaskSecret(t *testing.T) {
 		"",
 		"a",
 		"ab",
-		"abcd1234",     // exactly 8 -> "****"
-		"abcd12345",    // 9 -> first4+****+last4
+		"abcd1234",  // exactly 8 -> "****"
+		"abcd12345", // 9 -> first4+****+last4
 		"FAKE-access-secret-ABCDEF",
 		"FAKE-api-secret-XYZ12345",
 	}
@@ -405,5 +405,109 @@ func TestMaskSecretFromFragments_ParityWithMaskSecret(t *testing.T) {
 		if secret != "" && len(secret) > 8 && strings.Contains(got, secret) {
 			t.Errorf("secret=%q: masked form leaked plaintext: %q", secret, got)
 		}
+	}
+}
+
+// TestUpdateAccount_ResponseOmitsPlaintextCredentials guards PUT /api/accounts/{id}.
+// The list surface masks accessToken/apiToken and strips autoRelogin.passwordCipher,
+// so a no-op update must not become a credential-harvest primitive that answers
+// with the plaintext the list surface deliberately withholds. Revealing a secret
+// stays an explicit act (GET /api/account-tokens/{id}/value).
+func TestUpdateAccount_ResponseOmitsPlaintextCredentials(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	accessSecret, apiSecret, _, _, accountID, _ := seedCredentialedAccount(t, db)
+	cipher := "enc:v1:FAKE-CIPHERTEXT-DO-NOT-LEAK"
+	if _, err := db.Exec(
+		`UPDATE accounts SET extra_config = ? WHERE id = ?`,
+		`{"credentialMode":"session","autoRelogin":{"username":"cred-user","passwordCipher":"`+cipher+`"}}`,
+		accountID); err != nil {
+		t.Fatalf("seed extra_config: %v", err)
+	}
+
+	resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{"sortOrder": 7})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	body := resp.Body.String()
+	for _, secret := range []string{accessSecret, apiSecret, cipher} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("update account leaked plaintext secret %q: %s", secret, body)
+		}
+	}
+
+	var updated map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := updated["accessToken"]; ok {
+		t.Fatalf("accessToken key present: %#v", updated["accessToken"])
+	}
+	if _, ok := updated["apiToken"]; ok {
+		t.Fatalf("apiToken key present: %#v", updated["apiToken"])
+	}
+	if updated["accessTokenMasked"] != maskSecret(accessSecret) {
+		t.Fatalf("accessTokenMasked=%#v want %q", updated["accessTokenMasked"], maskSecret(accessSecret))
+	}
+	if updated["apiTokenMasked"] != maskSecret(apiSecret) {
+		t.Fatalf("apiTokenMasked=%#v want %q", updated["apiTokenMasked"], maskSecret(apiSecret))
+	}
+
+	// Redaction is response-only: the write itself must still land.
+	var sortOrder int64
+	if err := db.QueryRow(`SELECT sort_order FROM accounts WHERE id = ?`, accountID).Scan(&sortOrder); err != nil {
+		t.Fatalf("read sort_order: %v", err)
+	}
+	if sortOrder != 7 {
+		t.Fatalf("sort_order = %d, want 7", sortOrder)
+	}
+}
+
+// TestRebindSession_ResponseOmitsPlaintextCredentials guards
+// POST /api/accounts/{id}/rebind-session: the response carries the stored
+// apiToken (which the caller never supplied) plus the freshly bound session
+// token, so it answers with the same masked contract as the list surface.
+func TestRebindSession_ResponseOmitsPlaintextCredentials(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	_, apiSecret, _, _, accountID, _ := seedCredentialedAccount(t, db)
+	newSecret := "FAKE-rebound-PLAINTEXT-DDDD4444"
+
+	resp := doPostJSON(t, r, "/api/accounts/"+itoa(accountID)+"/rebind-session", map[string]any{"accessToken": newSecret})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	body := resp.Body.String()
+	for _, secret := range []string{newSecret, apiSecret} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("rebind session leaked plaintext secret %q: %s", secret, body)
+		}
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	account, ok := result["account"].(map[string]any)
+	if !ok {
+		t.Fatalf("account object missing: %s", body)
+	}
+	if _, ok := account["accessToken"]; ok {
+		t.Fatalf("accessToken key present: %#v", account["accessToken"])
+	}
+	if _, ok := account["apiToken"]; ok {
+		t.Fatalf("apiToken key present: %#v", account["apiToken"])
+	}
+	if account["accessTokenMasked"] != maskSecret(newSecret) {
+		t.Fatalf("accessTokenMasked=%#v want %q", account["accessTokenMasked"], maskSecret(newSecret))
+	}
+	if account["apiTokenMasked"] != maskSecret(apiSecret) {
+		t.Fatalf("apiTokenMasked=%#v want %q", account["apiTokenMasked"], maskSecret(apiSecret))
+	}
+
+	var stored string
+	if err := db.QueryRow(`SELECT access_token FROM accounts WHERE id = ?`, accountID).Scan(&stored); err != nil {
+		t.Fatalf("read access_token: %v", err)
+	}
+	if stored != newSecret {
+		t.Fatalf("access_token = %q, want the rebound token persisted", stored)
 	}
 }

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -854,39 +854,73 @@ func enrichAccountOverviewRow(account map[string]any) map[string]any {
 	delete(account, "siteUrl")
 	delete(account, "sitePlatform")
 	delete(account, "siteStatus")
-	// List/overview must not return plaintext secrets. Create/update/rebind
-	// responses may still echo once; those paths build maps outside this helper.
-	redactAccountSecrets(account)
+	// One credential policy for every admin surface (see RedactAccountSecrets):
+	// plaintext secrets never leave the process on a read or a write response.
+	RedactAccountSecrets(account)
 	return account
 }
 
-// redactAccountSecrets removes plaintext credentials from admin list/overview rows.
-// Sets accessTokenMasked / apiTokenMasked when a value was present.
-func redactAccountSecrets(account map[string]any) {
+// RedactAccountSecrets removes plaintext credentials from an admin account
+// response map, setting accessTokenMasked / apiTokenMasked when a value was
+// present, and strips autoRelogin.passwordCipher out of extraConfig.
+//
+// This is the single credential-policy SSOT for account surfaces. Both the
+// list/overview rows (buildAccountMap) and the write responses
+// (PUT /api/accounts/{id}, POST /api/accounts/{id}/rebind-session) answer
+// through it, so a no-op write can never harvest what the list surface
+// deliberately withholds. Revealing a secret stays an explicit, separately
+// routed act (GET /api/account-tokens/{id}/value, downstream-key export), and
+// the credential-provisioning responses that hand back a secret the caller did
+// not supply (password login, verify-token discovery) build their own maps.
+//
+// Values arrive either scanned from the DB (string / []byte / nil) or built by
+// a handler from a typed struct row (*string), so secretValue() normalizes both
+// instead of letting fmt.Sprint render a pointer address as the "secret".
+func RedactAccountSecrets(account map[string]any) {
 	if account == nil {
 		return
 	}
-	if v := asString(account["accessToken"]); strings.TrimSpace(v) != "" {
+	if v := secretValue(account["accessToken"]); v != "" {
 		account["accessTokenMasked"] = maskSecretTail(v)
 	}
 	delete(account, "accessToken")
-	if v := asString(account["apiToken"]); strings.TrimSpace(v) != "" {
+	if v := secretValue(account["apiToken"]); v != "" {
 		account["apiTokenMasked"] = maskSecretTail(v)
 	}
 	delete(account, "apiToken")
-	// Never leak passwordCipher from extraConfig on list surfaces.
-	if ec := asStringPtr(account["extraConfig"]); ec != nil && strings.Contains(*ec, "passwordCipher") {
+	// Never leak passwordCipher from extraConfig on an admin response.
+	if ec := secretValue(account["extraConfig"]); strings.Contains(ec, "passwordCipher") {
 		var m map[string]any
-		if err := json.Unmarshal([]byte(*ec), &m); err == nil {
+		if err := json.Unmarshal([]byte(ec), &m); err == nil {
 			if auto, ok := m["autoRelogin"].(map[string]any); ok {
 				delete(auto, "passwordCipher")
 				m["autoRelogin"] = auto
 				if b, err := json.Marshal(m); err == nil {
-					s := string(b)
-					account["extraConfig"] = s
+					account["extraConfig"] = string(b)
 				}
 			}
 		}
+	}
+}
+
+// secretValue reads a credential-bearing response value that may be a string,
+// a []byte from a DB scan, a *string from a typed struct row, or nil. Empty
+// (including a nil pointer) normalizes to "" so callers mask nothing.
+func secretValue(v any) string {
+	switch typed := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(typed)
+	case *string:
+		if typed == nil {
+			return ""
+		}
+		return strings.TrimSpace(*typed)
+	case []byte:
+		return strings.TrimSpace(string(typed))
+	default:
+		return strings.TrimSpace(asString(v))
 	}
 }
 


### PR DESCRIPTION
## 改动摘要

🟠 安全一致性：账号**写路径**不再回显明文凭据。读路径（`GET /api/accounts`）早就把 `accessToken`/`apiToken` 换成 `accessTokenMasked`/`apiTokenMasked`、并从 `extraConfig` 里剥掉 `autoRelogin.passwordCipher`；而 `PUT /api/accounts/{id}` 与 `POST /api/accounts/{id}/rebind-session` 原样返回明文 —— 于是那层脱敏只值一次空操作更新：

```
PUT /api/accounts/{id}  {"sortOrder": 7}      → accessToken 明文（实测 389 字符会话令牌）
GET /api/accounts?page=1&pageSize=1           → 无 accessToken，只有 accessTokenMasked "eyJh****I9z4"
```

任何能调 PUT 的会话（含只该看到掩码的场景）都能把整库凭据连同加密的重登录口令一并读出，而 `credentialFragmentsSelect()` 专门让明文不跨 DB→Go 边界、`admin_creds_test.go` 专门守着 routes/channels/search 三个面 —— 写路径是这套策略上唯一的缺口。

**改法**：两个写响应走**与列表同一份**策略函数（导出为 `service.RedactAccountSecrets`，作为账号面凭据策略的唯一所有者），并让它能读 handler 从类型化行构造出的 `*string`（原 `asString` 遇到 `*string` 会 `fmt.Sprint` 出指针地址当「密钥」，所以新增 `secretValue()` 归一 string / []byte / *string / nil）。

**凭据发放面刻意保留回显**（并在 `docs/api/accounts.md` 写明规则）：`POST /api/accounts/login` 返回它刚用密码换来的会话令牌（`scripts/e2e/smoke.sh` 正是消费这个字段跑通整条链），`POST /api/accounts/verify-token` 返回它在上游发现的 API token —— 这两种情况下调用方本来没有那个密钥。取回**已存**密钥仍然是显式动作（`GET /api/account-tokens/{id}/value`、下游密钥导出）。

## 类型

- [x] fix（bug 修复）
- [x] refactor（策略收口到唯一所有者）

## 测试验证

- [x] `go vet ./...` 通过；`go build ./...` 通过
- [x] `go test ./handler/admin/ ./service/ -count=1` 通过
- [x] `go test ./docs -count=1` 通过（13 个门禁，含 #1160 新落地的 env / 路由对账门禁）
- [x] 新增两个门禁用例（`handler/admin/admin_creds_test.go`，与既有 routes/channels/search 三条同族）：
  - `TestUpdateAccount_ResponseOmitsPlaintextCredentials`：播种明文 access/api 密钥 + `passwordCipher`，发一次 `{"sortOrder":7}` 空操作更新，断言响应体不含三个明文中的任何一个、`accessToken`/`apiToken` 键不存在、两个 `*Masked` 等于 `maskSecret(...)`，并断言 `sort_order` 真的写进去了（脱敏是响应层的事，不许顺手把写也跳过）
  - `TestRebindSession_ResponseOmitsPlaintextCredentials`：断言响应不含调用方刚提交的新令牌、也不含库里原有的 `apiToken`（后者调用方从未提供），`account` 子对象只有掩码键，且新令牌确实落库
- [x] **红→绿**：两个用例在改前均 FAIL（`rebind session leaked plaintext secret "FAKE-rebound-PLAINTEXT-DDDD4444": {"account":{"accessToken":"FAKE-rebound-PLAINTEXT-DDDD4444","apiToken":"FAKE-api-PLAINTEXT-BBBB2222",…}`），改后 PASS
- [x] 前端零改动即可：`useUpdateAccount` / `useRebindAccountSession` 只 invalidate 查询、不消费这两个字段；`Account` schema 本来就把 `accessToken`/`accessTokenMasked` 都声明为 nullish

## 自查清单

- [x] 无密钥 / 内部路径泄漏（用例里的密钥都是 `FAKE-…` 形状的显式假值）
- [ ] 用户可见文案已走 i18n（无前端文案）
- [x] 行为变更已补充 / 更新测试
- [x] 需要时更新了 `CHANGELOG.md` / `docs/`（`docs/api/accounts.md` 写清两个面的响应契约与「哪些面仍然回显、为什么」）

### 刻意不做

- 不改 `POST /api/accounts`（create）与 `POST /api/accounts/login` 的回显：前者是调用方自己提交的值、后者是调用方没有的值，两者都不构成绕过读侧脱敏的取回原语；规则已写进 `service.RedactAccountSecrets` 的 doc 与 API 文档，避免下一个人再靠猜。
- 不引入「按需解密返回明文」的新端点：显式取回已经有 `GET /api/account-tokens/{id}/value`。

> 合并方式：Squash merge（master 受保护）。
