### PR TITLE
test: make the PostgreSQL-gated suites repeatable on a reused database

### DIFF
--- a/handler/admin/accounts_models_refresh_test.go
+++ b/handler/admin/accounts_models_refresh_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/internal/pgtest"
 	"github.com/deliciousbuding/metapi-go/service"
 	"github.com/deliciousbuding/metapi-go/store"
 )
@@ -359,6 +360,12 @@ func TestAccountModels_Postgres(t *testing.T) {
 		t.Fatalf("open postgres: %v", err)
 	}
 	t.Cleanup(func() { dbx.Close() })
+
+	// Empty the database before migrating so this test starts from the same
+	// state CI gives it: a local loop reuses one PG database, and the
+	// previous run's rows turn fixed-identity fixtures into duplicate-key
+	// failures and whole-table counts into "want 3, got 4".
+	pgtest.Reset(t, dbx.DB)
 	if err := store.AutoMigrate(dbx); err != nil {
 		t.Fatalf("automigrate: %v", err)
 	}

--- a/handler/admin/downstream_keys_test.go
+++ b/handler/admin/downstream_keys_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/internal/pgtest"
 	"github.com/deliciousbuding/metapi-go/store"
 	"github.com/go-chi/chi/v5"
 )
@@ -44,6 +45,12 @@ func setupDownstreamKeysPostgresTest(t *testing.T) (*store.DB, chi.Router) {
 		t.Fatalf("failed to open PostgreSQL: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
+
+	// Empty the database before migrating so this test starts from the same
+	// state CI gives it: a local loop reuses one PG database, and the
+	// previous run's rows turn fixed-identity fixtures into duplicate-key
+	// failures and whole-table counts into "want 3, got 4".
+	pgtest.Reset(t, db.DB)
 
 	if err := store.AutoMigrate(db); err != nil {
 		t.Fatalf("AutoMigrate failed: %v", err)

--- a/handler/admin/settings_backup_test.go
+++ b/handler/admin/settings_backup_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/internal/pgtest"
 	backupsvc "github.com/deliciousbuding/metapi-go/service/backup"
 	"github.com/deliciousbuding/metapi-go/store"
 )
@@ -1112,6 +1113,12 @@ func setupBackupPostgresTestDB(t *testing.T) *store.DB {
 		t.Fatalf("open postgres: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
+
+	// Empty the database before migrating so this test starts from the same
+	// state CI gives it: a local loop reuses one PG database, and the
+	// previous run's rows turn fixed-identity fixtures into duplicate-key
+	// failures and whole-table counts into "want 3, got 4".
+	pgtest.Reset(t, db.DB)
 
 	if err := store.AutoMigrate(db); err != nil {
 		t.Fatalf("migrate postgres: %v", err)

--- a/handler/admin/sites_test.go
+++ b/handler/admin/sites_test.go
@@ -12,8 +12,9 @@ import (
 	"time"
 
 	"github.com/deliciousbuding/metapi-go/config"
-	"github.com/go-chi/chi/v5"
+	"github.com/deliciousbuding/metapi-go/internal/pgtest"
 	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
 )
 
 // setupSitesTest creates an in-memory SQLite DB with chi router for sites.
@@ -47,6 +48,12 @@ func setupSitesPostgresTest(t *testing.T) (*store.DB, chi.Router) {
 		t.Fatalf("failed to open PostgreSQL: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
+
+	// Empty the database before migrating so this test starts from the same
+	// state CI gives it: a local loop reuses one PG database, and the
+	// previous run's rows turn fixed-identity fixtures into duplicate-key
+	// failures and whole-table counts into "want 3, got 4".
+	pgtest.Reset(t, db.DB)
 
 	if err := store.AutoMigrate(db); err != nil {
 		t.Fatalf("AutoMigrate failed: %v", err)

--- a/handler/admin/stats_marketplace_pg_test.go
+++ b/handler/admin/stats_marketplace_pg_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/deliciousbuding/metapi-go/internal/pgtest"
 	"github.com/deliciousbuding/metapi-go/store"
 )
 
@@ -40,6 +41,12 @@ func TestStatsMarketplaceBuildersPostgres(t *testing.T) {
 		t.Fatalf("open postgres: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
+
+	// Empty the database before migrating so this test starts from the same
+	// state CI gives it: a local loop reuses one PG database, and the
+	// previous run's rows turn fixed-identity fixtures into duplicate-key
+	// failures and whole-table counts into "want 3, got 4".
+	pgtest.Reset(t, db.DB)
 	if err := store.AutoMigrate(db); err != nil {
 		t.Fatalf("auto-migrate: %v", err)
 	}

--- a/handler/admin/stats_test.go
+++ b/handler/admin/stats_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/internal/pgtest"
 	"github.com/deliciousbuding/metapi-go/store"
 	"github.com/go-chi/chi/v5"
 )
@@ -30,6 +31,12 @@ func setupStatsPostgresTest(t *testing.T) (*store.DB, chi.Router) {
 		t.Fatalf("failed to open PostgreSQL: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
+
+	// Empty the database before migrating so this test starts from the same
+	// state CI gives it: a local loop reuses one PG database, and the
+	// previous run's rows turn fixed-identity fixtures into duplicate-key
+	// failures and whole-table counts into "want 3, got 4".
+	pgtest.Reset(t, db.DB)
 
 	if err := store.AutoMigrate(db); err != nil {
 		t.Fatalf("AutoMigrate failed: %v", err)
@@ -1251,6 +1258,7 @@ func TestStats_SQLiteMarketplaceFromAvailability(t *testing.T) {
 		t.Fatalf("bare account %d missing from claude accounts: %#v", accountWithoutToken, claude["accounts"])
 	}
 }
+
 // TestStats_SQLiteMarketplaceTokensBatchedAcrossModels is the Wave 18 N+1
 // regression: enabled tokens must attach to every model entry of an account
 // from ONE batched account_tokens load (the pre-fix shape fired one token

--- a/internal/pgtest/pgtest.go
+++ b/internal/pgtest/pgtest.go
@@ -1,0 +1,74 @@
+// Package pgtest is a test-only helper for the PostgreSQL-gated suites
+// (PG_TEST_DSN). It is imported exclusively from _test.go files, so it never
+// becomes part of the production dependency graph, and it depends on nothing
+// but sqlx so even the store package's own tests can use it.
+//
+// Why it exists: CI runs every PG-gated test against a freshly created
+// database, while a local development loop reuses one. Fixtures with a fixed
+// identity — a site keyed on the unique (platform, url) pair, a downstream key
+// with a constant value — then collide with the previous run's leftovers, and
+// whole-table assertions count rows nobody seeded in this run. The failures are
+// real red herrings: they say "duplicate key" or "total = 4, want 3" about
+// state, not about the code under test. The documented escape hatch was "drop
+// and recreate the database by hand before trusting a result", which is exactly
+// the kind of tribal knowledge that makes a suite nobody dares to run twice.
+//
+// Reset makes the local loop match CI: every PG-gated test starts from an empty
+// database, so a suite is repeatable by construction and a second run of the
+// same command is evidence rather than noise.
+//
+// Run the PG suite the way CI does — serialized, one database:
+//
+//	PG_TEST_DSN=... go test ./... -count=1 -tags=integration -p 1
+//
+// -p 1 is not optional: packages share one database, so parallel packages race
+// each other on AutoMigrate and on this truncation (the CI workflow carries the
+// same note). Tests inside a package already run sequentially.
+package pgtest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// schemaMigrationsTable is the additive-migration bookkeeping table written by
+// store.AutoMigrate. It is deliberately preserved: emptying it would make every
+// test re-apply the whole additive migration ladder, and the ladder is not the
+// subject of these tests.
+const schemaMigrationsTable = "schema_migrations"
+
+// Reset empties every user table in the current schema — except the migration
+// bookkeeping table — and restarts identity sequences, so fixture primary keys
+// are deterministic across runs. Call it right after opening the database and
+// before AutoMigrate.
+//
+// CASCADE is required because the schema is a web of foreign keys (sites →
+// accounts → account_tokens → route_channels → …); enumerating a deletion order
+// per test would be a second source of truth about the schema. Only tables
+// outside pg_catalog/information_schema are touched, and the statement is built
+// from quoted identifiers returned by PostgreSQL itself.
+func Reset(t testing.TB, db *sqlx.DB) {
+	t.Helper()
+	if db == nil {
+		t.Fatal("pgtest.Reset: nil database handle")
+	}
+
+	var tables []string
+	const listTables = `SELECT format('%I.%I', schemaname, tablename)
+		FROM pg_tables
+		WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+		  AND tablename <> $1
+		ORDER BY tablename`
+	if err := db.Select(&tables, listTables, schemaMigrationsTable); err != nil {
+		t.Fatalf("pgtest.Reset: list tables: %v", err)
+	}
+	if len(tables) == 0 {
+		// Fresh database: AutoMigrate has not created anything yet.
+		return
+	}
+	if _, err := db.Exec("TRUNCATE " + strings.Join(tables, ", ") + " RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("pgtest.Reset: truncate %d tables: %v", len(tables), err)
+	}
+}

--- a/service/balance/balance_pg_test.go
+++ b/service/balance/balance_pg_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/deliciousbuding/metapi-go/internal/pgtest"
 	"github.com/deliciousbuding/metapi-go/store"
 )
 
@@ -28,6 +29,12 @@ func TestRecordBalanceSnapshotPostgres(t *testing.T) {
 		t.Fatalf("open postgres: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
+
+	// Empty the database before migrating so this test starts from the same
+	// state CI gives it: a local loop reuses one PG database, and the
+	// previous run's rows turn fixed-identity fixtures into duplicate-key
+	// failures and whole-table counts into "want 3, got 4".
+	pgtest.Reset(t, db.DB)
 	if err := store.AutoMigrate(db); err != nil {
 		t.Fatalf("auto-migrate: %v", err)
 	}


### PR DESCRIPTION
## 改动摘要

让 PG 门禁用例在**复用的数据库**上可重复跑：新增 `internal/pgtest`，在每个 PG setup 打开库之后、`AutoMigrate` 之前清空业务表并重置自增序列。

CI 给每个 PG 用例一个全新数据库，本地开发循环复用同一个。于是「固定身份」的夹具会撞上上一轮的残留行，全表计数会数到本轮没人播种的行 —— 五个用例第二次跑必红，而红的原因与被测代码无关：

```
account_tokens_test.go:252        fixture POST https://api.openai.com returned 409:
                                  A openai site with URL https://api.openai.com already exists.
channels_error_summary_test.go:88 pg summary total/error = 4/1, want 3/1
model_rates_test.go:266           insert site: duplicate key value violates unique
                                  constraint "sites_platform_url_unique" (SQLSTATE 23505)
stats_income_outcome_test.go:262  insert site: duplicate key … (同一约束)
balance_pg_test.go:39             seed site: duplicate key … (同一约束)
```

此前唯一的解法是口口相传的「信结果之前先手工 DROP/CREATE 一次库」—— 正是这种规矩让一套门禁变成「没人敢连跑两遍」的东西，也让人宁愿相信假红是环境问题。

`pgtest.Reset` 清空当前 schema 下所有用户表（保留 `schema_migrations` 日志，否则每个用例都要重跑整条 additive 阶梯）、`RESTART IDENTITY` 让夹具主键跨轮次确定、`CASCADE` 交给数据库处理外键顺序（不再需要第二份「删除顺序」真相）。它只依赖 sqlx，因此连 `store` 自己的测试也能用。本 PR 接进 `handler/admin`（6 处 setup）与 `service/balance`（1 处）。

## 类型

- [x] refactor（重构，行为不变）
- [x] docs / chore（工程维护：测试基建）

## 测试验证

- [x] `go build ./...` / `go vet ./...` 通过；`gofmt -l` 本 PR 触及的 Go 文件为空（仓库既有漂移文件未顺手格式化）
- [x] **红→绿**：上述五个用例在一个已经积累残留行的库上连跑三轮，改前第一轮就红、改后三轮全绿
  ```
  ##### targeted PG run #1/#2/#3 #####
  ok  github.com/deliciousbuding/metapi-go/handler/admin    8.389s / 1.741s / 2.447s
  ok  github.com/deliciousbuding/metapi-go/service/balance  0.507s / 0.435s / 0.524s
  ```
- [x] 全量串行跑（CI 的调用方式）绿：`PG_TEST_DSN=… go test ./handler/... ./service/... ./store/... ./scheduler/... ./internal/... -count=1 -tags=integration -p 1` → 18 个包 `ok`，0 FAIL
- [x] 非 PG 路径不受影响：`go test ./handler/... ./service/... ./internal/... -count=1`（不设 `PG_TEST_DSN`）全绿，PG 用例照旧 skip
- [x] `-p 1` 在包 doc 里写成硬要求并给了理由（多包共享一个库时并行会互相 truncate / 竞争 AutoMigrate —— CI 工作流里本来就带同一条注释）

## 自查清单

- [x] 无密钥 / 内部路径泄漏（DSN 只从 `PG_TEST_DSN` 读，不出现在任何文件里）
- [ ] 用户可见文案已走 i18n（无前端改动）
- [x] 行为变更已补充 / 更新测试（本 PR 就是测试基建）
- [ ] 需要时更新了 `CHANGELOG.md` / `docs/`（`docs/testing.md` 若已有「先重建库」的说法，后续一并删掉；本 PR 未触及）

### 刻意不做

- 不给每个用例造独立 database / schema（需要 CREATEDB 或每连接 `search_path`，代价与脆弱度都高于清表）。
- 不改任何夹具身份（保留 `https://api.openai.com` 这类真实形状，平台探测行为不变）：清库已经消除了冲突原因，把夹具改成随机 URL 会顺手改掉被测语义。
- 其余 6 处 PG setup（`scheduler`、`service/catalogsync`、`service/checkin`、`service/oauth`、`store`）本 PR 不接，留作后续（同一行改动，但要各自跑一遍门禁）。

> 合并方式：Squash merge（master 受保护）。
