### PR TITLE
fix(config): clamp checkin_interval_hours like the env path, drop the dead HOME_PAGE_CONTENT key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,6 @@ SYSTEM_NAME=Metapi
 LOGO=
 FOOTER=
 ABOUT=
-HOME_PAGE_CONTENT=
 SERVER_ADDRESS=
 
 # Optional OAuth overrides. Fill the matching credentials when an override is enabled;

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -441,12 +441,11 @@ func TestLoadExplicitPoolOverridesProfile(t *testing.T) {
 
 func TestLoadParsesBrandingEnv(t *testing.T) {
 	_, rt := Load(map[string]string{
-		"SYSTEM_NAME":       "My Gateway",
-		"LOGO":              "https://example.com/logo.png",
-		"FOOTER":            "Powered by Metapi",
-		"ABOUT":             "About page copy",
-		"HOME_PAGE_CONTENT": "Welcome",
-		"SERVER_ADDRESS":    "https://gw.example.com",
+		"SYSTEM_NAME":    "My Gateway",
+		"LOGO":           "https://example.com/logo.png",
+		"FOOTER":         "Powered by Metapi",
+		"ABOUT":          "About page copy",
+		"SERVER_ADDRESS": "https://gw.example.com",
 	})
 	if rt.SystemName != "My Gateway" {
 		t.Fatalf("SystemName = %q", rt.SystemName)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,7 @@ out in full (no `SOME_PREFIX_*` shorthand) so they stay greppable.
 | `DATA_DIR` | `./data` | SQLite database and upload storage directory. |
 | `LOG_LEVEL` | `info` | slog threshold: `debug` / `info` / `warn` / `error`. |
 | `METAPI_HEALTHCHECK_URL` / `METAPI_HEALTHCHECK_PATH` | — / `/ready` | Override the container healthcheck target. |
-| `SYSTEM_NAME`, `LOGO`, `FOOTER`, `ABOUT`, `HOME_PAGE_CONTENT` | brand defaults | Optional site branding; runtime settings in the admin UI override these. |
+| `SYSTEM_NAME`, `LOGO`, `FOOTER`, `ABOUT` | brand defaults | Optional site branding; runtime settings in the admin UI override these. |
 | `SERVER_ADDRESS` | empty | Public base URL used when the server has to build an absolute link back to itself (OAuth callbacks, exported key/backup URLs). Empty = derived from the request's `X-Forwarded-Proto` / `X-Forwarded-Host` headers, falling back to the request host. |
 
 ## Database

--- a/docs/env_parity_test.go
+++ b/docs/env_parity_test.go
@@ -72,14 +72,7 @@ var readerREs = []*regexp.Regexp{
 // unreadEnvKeyAllowlist lists .env.example keys that have no reader in
 // non-test Go code. Each entry MUST carry a reason; an entry without a
 // real justification is a bug being hidden, not a bug being managed.
-var unreadEnvKeyAllowlist = map[string]string{
-	// Branding text is loaded into RuntimeSettings through the settings
-	// table, not through config.Load: the key is documented for operators
-	// migrating from the TypeScript release, but the Go binary does not
-	// read it. Reported to maintainers rather than silently deleted, since
-	// removing a key from .env.example is outside a docs change.
-	"HOME_PAGE_CONTENT": "documented for TS-parity; no reader in non-test Go code (tracked as a dead key, see .dev-local w4 R3-BLOCKED.md)",
-}
+var unreadEnvKeyAllowlist = map[string]string{}
 
 func TestEnvVarDocParity(t *testing.T) {
 	root := repoRoot(t)

--- a/store/settings.go
+++ b/store/settings.go
@@ -252,10 +252,14 @@ func ApplyRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings, settin
 				rt.CheckinScheduleMode = strings.ToLower(parseJSONSettingString(value))
 			}
 		case "checkin_interval_hours":
-			hours := parseInt(value, rt.CheckinIntervalHours)
-			if hours >= 1 && hours <= 24 {
-				rt.CheckinIntervalHours = hours
-			}
+			// config.Load resolves CHECKIN_INTERVAL_HOURS as
+			// ClampInt(trunc(parseNumber(n)), 1, 24), so this clamps with the
+			// same two-sided shape instead of guarding on the range. The guard
+			// dropped an out-of-range row: a persisted 30 left the process on
+			// the env-resolved 6, GET /api/settings/runtime echoed 6, and
+			// nothing was logged, because the key counted as handled.
+			rt.CheckinIntervalHours = config.ClampInt(
+				parseIntSetting(value, float64(rt.CheckinIntervalHours), 1), 1, 24)
 		// E1: random-window mode bounds (HH:mm, 24h).
 		case "checkin_window_start":
 			if v := parseJSONSettingString(value); v != "" {

--- a/store/settings_roundtrip_test.go
+++ b/store/settings_roundtrip_test.go
@@ -269,6 +269,28 @@ func TestApplyRuntimeSettingsClampsMatchConfigLoad(t *testing.T) {
 		get      func(*config.Config, *config.RuntimeSettings) any
 	}{
 		{
+			// config.Load resolves CHECKIN_INTERVAL_HOURS as
+			// ClampInt(trunc(n), 1, 24), so 30 becomes 24. The settings path
+			// used to drop an out-of-range row instead of clamping it, leaving
+			// the env-resolved value in the snapshot with nothing in the log.
+			name:     "checkin interval ceiling",
+			env:      map[string]string{"CHECKIN_INTERVAL_HOURS": "30"},
+			settings: map[string]string{"checkin_interval_hours": `30`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.CheckinIntervalHours },
+		},
+		{
+			name:     "checkin interval floor",
+			env:      map[string]string{"CHECKIN_INTERVAL_HOURS": "0"},
+			settings: map[string]string{"checkin_interval_hours": `0`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.CheckinIntervalHours },
+		},
+		{
+			name:     "checkin interval truncates",
+			env:      map[string]string{"CHECKIN_INTERVAL_HOURS": "12.9"},
+			settings: map[string]string{"checkin_interval_hours": `12.9`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.CheckinIntervalHours },
+		},
+		{
 			name:     "first byte timeout floor",
 			env:      map[string]string{"PROXY_FIRST_BYTE_TIMEOUT_SEC": "-5"},
 			settings: map[string]string{"proxy_first_byte_timeout_sec": `-5`},
@@ -402,6 +424,47 @@ func TestApplyRuntimeSettingsClampsMatchConfigLoad(t *testing.T) {
 			want, got := tc.get(envCfg, envRt), tc.get(setCfg, setRt)
 			if !reflect.DeepEqual(want, got) {
 				t.Fatalf("env path resolved %#v but the settings path resolved %#v", want, got)
+			}
+		})
+	}
+}
+
+// TestApplyRuntimeSettingsClampsCheckinIntervalHours pins the absolute
+// post-hydration value rather than only its parity with config.Load, so the
+// clamp cannot be replaced by a range check that silently keeps the previous
+// value. A persisted 30 used to leave the process on the env-resolved 6:
+// GET /api/settings/runtime echoed 6, the settings row still said 30, and no
+// log line explained the gap. Reachable through a backup import
+// (checkin_interval_hours is not in backup.RuntimeLocalSettingKeys, and the
+// import validates cell types only), a hand-edited row, or a row left behind
+// by an older version — the admin write path itself rejects out-of-range
+// values before persisting.
+func TestApplyRuntimeSettingsClampsCheckinIntervalHours(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  int
+	}{
+		{"above the ceiling clamps to 24", `30`, 24},
+		{"far above the ceiling clamps to 24", `1000`, 24},
+		{"zero clamps to 1", `0`, 1},
+		{"negative clamps to 1", `-5`, 1},
+		{"fraction truncates like the env path", `24.9`, 24},
+		{"lower bound passes through", `1`, 1},
+		{"in-range value passes through", `12`, 12},
+		{"upper bound passes through", `24`, 24},
+		{"unparsable keeps the resolved value", `"nonsense"`, config.DefaultCheckinIntervalHours},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := &config.RuntimeSettings{CheckinIntervalHours: config.DefaultCheckinIntervalHours}
+			ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
+				"checkin_interval_hours": tc.value,
+			})
+			if rt.CheckinIntervalHours != tc.want {
+				t.Fatalf("persisted checkin_interval_hours = %s rehydrated to %d, want %d",
+					tc.value, rt.CheckinIntervalHours, tc.want)
 			}
 		})
 	}

--- a/store/settings_runtime_test.go
+++ b/store/settings_runtime_test.go
@@ -30,7 +30,12 @@ func TestApplyRuntimeSettingsAppliesCheckinSchedule(t *testing.T) {
 	}
 }
 
-func TestApplyRuntimeSettingsIgnoresInvalidCheckinInterval(t *testing.T) {
+// An out-of-range interval is clamped to the nearest bound, the same two-sided
+// clamp config.Load applies to CHECKIN_INTERVAL_HOURS — it is not dropped.
+// This test used to assert the drop (48 kept the env-resolved fallback), which
+// pinned the defect as a contract: the row said 48, the snapshot said 6, and
+// GET /api/settings/runtime echoed the stale number with nothing in the log.
+func TestApplyRuntimeSettingsClampsOutOfRangeCheckinInterval(t *testing.T) {
 	rt := &config.RuntimeSettings{
 		CheckinCron:          config.DefaultCheckinCron,
 		CheckinScheduleMode:  "cron",
@@ -41,8 +46,8 @@ func TestApplyRuntimeSettingsIgnoresInvalidCheckinInterval(t *testing.T) {
 		"checkin_interval_hours": `48`,
 	})
 
-	if rt.CheckinIntervalHours != config.DefaultCheckinIntervalHours {
-		t.Fatalf("CheckinIntervalHours = %d, want fallback %d", rt.CheckinIntervalHours, config.DefaultCheckinIntervalHours)
+	if rt.CheckinIntervalHours != 24 {
+		t.Fatalf("CheckinIntervalHours = %d, want the clamped ceiling 24", rt.CheckinIntervalHours)
 	}
 }
 


### PR DESCRIPTION
## 改动摘要

配置面两处“文档/实现不一致”，都是实测可达的，不是洁癖：

**① `checkin_interval_hours`：范围检查即静默丢弃。** `store.ApplyRuntimeSettings` 此前写的是 `hours := parseInt(value, rt.CheckinIntervalHours); if hours >= 1 && hours <= 24 { rt.CheckinIntervalHours = hours }` —— 越界行**不赋值、不告警、还算“已处理”**。而 `config.Load` 对同一个语义的 env 键走的是 `ClampInt(trunc(parseNumber(n)), 1, 24)`。两条路径形状不同 ⇒ 库里存一个 `30`，进程留在 env 解析出的 `6`，`GET /api/settings/runtime` 回显 `6`，运维看不到任何线索。现改为与 env 同形的双侧钳制（复用既有的 `parseIntSetting` + `config.ClampInt`，没有新造第三套语义）。顺带修掉同一行的第二个偏差：`parseInt` = `strconv.Atoi`，`12.9` 解析失败静默落回旧值；env 侧是 `int(math.Trunc(parseNumber(...)))` → `12`。

可达路径已复核为真：admin 写路径 `handler/admin/checkin_schedule.go` 确实先校验 1..24 才落库（UI 产不出越界行），**但备份导入这条路不校验语义**——`service/backup/ts_backup_v21.go` 的 `RuntimeLocalSettingKeys` 不含该键，`handler/admin/settings_backup.go` 的 `validateBackupImportCellValue` 只校验 JSON 标量类型与字节上限。手工改行、跨版本残留行同理。

**② `HOME_PAGE_CONTENT`：一个没有任何读取点的 env 键。** 非测试 Go 代码零引用；DB 侧孪生键 `home_page_content` 早已因“存了但渲染不出来”在 Wave 8 删除（`config/runtime_settings.go` 与 `store/settings.go` 的 `nonHydratedSettingKeys` 都写着这条历史），前端字段也一并下线（#1103）。`.env.example` 与 `docs/configuration.md` 却仍在承诺它，靠 `docs/env_parity_test.go` 白名单里一条“documented for TS-parity”豁免撑着。**这是撤回一条文档承诺**：`SYSTEM_NAME`/`LOGO`/`FOOTER`/`ABOUT` 不是等价能力（站名/logo/页脚/关于页 ≠ 首页正文）。将来要真做首页正文，等于新建一条全栈能力，不是恢复一个键。

## 类型

- [x] fix（bug 修复：①）
- [x] docs / chore（②：删死键 + 清空对应白名单条目）

## 行为变更（需要进 CHANGELOG）

- `checkin_interval_hours` 的**库内越界值现在被钳制到 1..24 并生效**（此前静默丢弃、进程留在 env 值）。小数按 env 同形截断（`24.9 → 24`）。合法值（1..24 整数）行为完全不变。
- `.env.example` 不再列 `HOME_PAGE_CONTENT`；设置该环境变量的部署不会报错，但它本来就什么都没做。

## 测试验证

- [x] `go vet ./...` 通过；`go build ./...` 通过
- [x] `gofmt -l` 对本 PR 触及的 5 个 `.go` 文件为空（仓库既有漂移文件未碰）
- [x] `go test ./store/... ./config/... ./docs/... -count=1 -tags=integration -p 1`（带 `PG_TEST_DSN`）全绿：`store 7.4s / config 0.3s / docs 1.8s`
- [x] `go test ./store/ -run 'CheckinInterval|ApplyRuntimeSettings' -count=1 -race` 绿
- [x] 门禁加强而不是放宽：`store/settings_roundtrip_test.go` 的 env↔settings parity 表新增 3 行越界值（`30`/`0`/`12.9`，双路对打）+ 9 行绝对值断言；`store/settings_runtime_test.go` 里那条把缺陷钉成契约的旧用例（`TestApplyRuntimeSettingsIgnoresInvalidCheckinInterval`，断言 `48 → 保留 6`）改写并重命名为 `…ClampsOutOfRangeCheckinInterval`（断言 `48 → 24`），全仓 grep 确认无其它引用旧名
- [x] **变异探针 red → green（两处，均由集成方独立复跑）**：
  - ①：把 `store/settings.go` 还原成范围检查形状 → 8 条子用例逐字变红（`env path resolved 24 but the settings path resolved 6`、`= 30 rehydrated to 6, want 24`、`= 24.9 rehydrated to 6, want 24`、`CheckinIntervalHours = 6, want the clamped ceiling 24`）；`git checkout --` 还原后 `sha256sum -c` 一致、复跑全绿
  - ②：只把 `HOME_PAGE_CONTENT=` 加回 `.env.example`（白名单条目已删）→ `TestEnvVarDocParity` 红：`in .env.example with no reader in non-test Go code (dead key; allowlist with reason required)`；还原后绿
- [x] `docs/env_parity_test.go` 的**判定逻辑零改动**，只删了 `unreadEnvKeyAllowlist` 里唯一那条（现为空 map）

## 自查清单

- [x] 无密钥/内部路径泄漏（注释一律仓库相对路径）
- [x] 无新增用户可见文案，不涉及 i18n
- [x] 行为变更已补测试并在本描述中列出 CHANGELOG 条目
- [x] `.env.example` 与 `docs/configuration.md` 同步

## 同批扫描结论（顺手活的边界）

按“抽 case 标签 → 找被条件包住的赋值 → 逐个与 env 路径对读 → 反向核对 env 侧全部 7 个 `ClampInt` 键”的四步扫了 `ApplyRuntimeSettings` 的 **91 个键 / 18 个守卫分支**：**“数值范围检查即丢弃”同形反模式全仓仅此一处**；env 侧另外 6 个双侧钳制键（`REQUEST_BODY_LIMIT_MB`、`FILE_UPLOAD_LIMIT_MB`、`MODEL_AVAILABILITY_PROBE_CONCURRENCY`、`PROXY_LOG_BATCH_SIZE`、`PROXY_LOG_FLUSH_INTERVAL_MS`、`USAGE_PROJECTION_INTERVAL_MS`）都没有 settings 键（env-only），不存在“漏钳的第二个”。

## 已知遗留（本 PR 不做，已记录）

- 同类**不同形**的静默丢弃仍在：`checkin_schedule_mode`（枚举守卫，无告警）、`notify_task_toggles`（JSON 解析失败，无告警），以及两处**破坏性**的静默丢弃 `payload_rules` / `openai_service_tier_rules`（`ParseJsonValue` 失败返回 nil 并被直接赋值 ⇒ 一条坏行清空已配置规则；消费者在 `proxy/**`）。
- 数值键 floor 偏差 4 条（`notify_cooldown_sec` 绕过 env 的 0 下限、`port` 的 `Atoi` vs `trunc`、`proxy_max_channel_attempts` settings 比 env 严、`smtp_port` 已一致）。
- `docs/env_parity_test.go` **没有“过期白名单”检查**：`detectDrift` 只在遍历 `.env.example` 键时查 allowlist，孤儿条目永远访问不到（对比 `docProseTokens` 有 shadow 检查）。所以“留着白名单条目会红”不成立——删它是清噪音，不是消红。加这个检查属于改判定逻辑，建议单独一个 PR（含自证伪用例）。
