### PR TITLE
perf(admin): give the channels snapshot cache bounded multi-key slots

### DIFF
--- a/handler/admin/channels.go
+++ b/handler/admin/channels.go
@@ -53,16 +53,63 @@ type channelListRow struct {
 	TotalCount int64 `db:"total_count"`
 }
 
-// channelsSnapshotCache is an in-memory TTL cache for GET /api/channels pages.
-// Mirrors globalAccountsCache: a short-TTL snapshot so a fleet-wide 5-way JOIN
-// list does not run on every dashboard poll. Entries are keyed by "page:pageSize"
-// so distinct page requests don't shadow each other. ?refresh=true bypasses.
-type channelsSnapshotCache struct {
-	mu        sync.RWMutex
-	key       string
+// channelsSnapshotMaxEntries bounds how many distinct snapshot keys the cache
+// keeps alive at once. See channelsSnapshotCache for the key space, the
+// eviction rule and the memory arithmetic behind this number.
+const channelsSnapshotMaxEntries = 16
+
+// channelsSnapshotEntry is one cached page payload plus its deadline and its
+// position in the insertion order (seq) that drives FIFO eviction.
+type channelsSnapshotEntry struct {
 	data      []byte
 	expiresAt time.Time
-	ttl       time.Duration
+	// seq is the value of channelsSnapshotCache.seq at insertion time: a
+	// monotonic counter, so "oldest entry" is well defined without depending
+	// on Go's deliberately randomized map iteration order.
+	seq uint64
+}
+
+// channelsSnapshotCache is an in-memory TTL cache for GET /api/channels pages.
+// Mirrors globalAccountsCache: a short-TTL snapshot so a fleet-wide 5-way JOIN
+// list does not run on every dashboard poll. ?refresh=true bypasses it.
+//
+// Key space (built in listChannels): the dashboard's unbounded view is
+// "unbounded"[:status,…] and every server-paged view is
+// "page:pageSize:status,…", so the cache must hold several keys at once —
+// a dashboard poll and an operator flipping pages or toggling a status filter
+// happen concurrently. The previous single-slot implementation keyed by the
+// same three-dimensional string but only ever remembered ONE key, so page=1
+// and page=2 evicted each other and nearly every request missed: the 10s TTL
+// never absorbed the polling it exists for, leaving only mutex + singleflight
+// overhead in front of the JOIN.
+//
+// This is therefore a bounded map of at most channelsSnapshotMaxEntries (16)
+// entries. 16 covers the hot subset of the key space with headroom — one
+// unbounded key per status filter actually in use, plus the handful of
+// page/pageSize combinations an operator browses — while keeping the footprint
+// computable: pageSize is clamped to 200 and a channel item serializes to
+// ~340 B of JSON, so a max-size page snapshot is ~66 KB and the paged slots
+// cost at most 15 × 66 KB ≈ 1 MB. Unbounded entries carry no LIMIT and scale
+// with fleet size (~340 KB per 1,000 channels, ~1.7 MB at 5,000) — a payload
+// the single-slot cache already held, so the bound only multiplies the *paged*
+// part. Worst case is ≲16 snapshots ≈ a few MB, never unbounded growth.
+//
+// Eviction is FIFO on insertion order: when a new key arrives and the map is
+// full, the entry with the lowest seq (oldest insertion) is dropped. FIFO —
+// not LRU — because it is deterministic and testable without touching
+// read-path bookkeeping: a read hit must not reorder the cache, and a bounded
+// snapshot cache gains little from recency tracking when every entry expires
+// after 10s anyway. Re-setting an existing key overwrites it in place and
+// stamps a fresh seq (it becomes the newest).
+//
+// clear() still empties the whole map: it is the "the data changed" invalidation
+// hook (invalidateChannelsSnapshotCache), not an eviction path.
+type channelsSnapshotCache struct {
+	mu      sync.RWMutex
+	entries map[string]channelsSnapshotEntry
+	ttl     time.Duration
+	// seq counts insertions monotonically; see channelsSnapshotEntry.seq.
+	seq uint64
 	// flight deduplicates concurrent cache-miss computes for the same page so
 	// N admin sessions polling an expired entry share one 5-way JOIN run
 	// instead of running it N× (thundering herd).
@@ -72,26 +119,59 @@ type channelsSnapshotCache struct {
 func (c *channelsSnapshotCache) get(key string) ([]byte, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	if c.data != nil && c.key == key && time.Now().Before(c.expiresAt) {
-		return c.data, true
+	entry, ok := c.entries[key]
+	if !ok || entry.data == nil || !time.Now().Before(entry.expiresAt) {
+		// Expired entries are left in place rather than deleted here (RLock):
+		// they read as a miss and are overwritten by the next set, or evicted
+		// once the map fills up. Bounded either way.
+		return nil, false
 	}
-	return nil, false
+	return entry.data, true
 }
 
 func (c *channelsSnapshotCache) set(key string, data []byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.key = key
-	c.data = data
-	c.expiresAt = time.Now().Add(c.ttl)
+	if c.entries == nil {
+		c.entries = make(map[string]channelsSnapshotEntry, channelsSnapshotMaxEntries)
+	}
+	if _, exists := c.entries[key]; !exists && len(c.entries) >= channelsSnapshotMaxEntries {
+		c.evictOldestLocked()
+	}
+	c.seq++
+	c.entries[key] = channelsSnapshotEntry{
+		data:      data,
+		expiresAt: time.Now().Add(c.ttl),
+		seq:       c.seq,
+	}
+}
+
+// evictOldestLocked drops the entry with the lowest insertion seq (FIFO). The
+// caller holds c.mu for writing. Scanning ≤16 entries is cheaper than keeping
+// a second ordered structure, and picking the minimum of a unique monotonic
+// counter is order-independent, so the randomized map iteration cannot change
+// which entry goes. A seq tie (uint64 wrap, ~584 million years at 1 insert/ns)
+// is broken by key so the choice stays deterministic.
+func (c *channelsSnapshotCache) evictOldestLocked() {
+	var (
+		oldestKey string
+		oldestSeq uint64
+		found     bool
+	)
+	for key, entry := range c.entries {
+		if !found || entry.seq < oldestSeq || (entry.seq == oldestSeq && key < oldestKey) {
+			oldestKey, oldestSeq, found = key, entry.seq, true
+		}
+	}
+	if found {
+		delete(c.entries, oldestKey)
+	}
 }
 
 func (c *channelsSnapshotCache) clear() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.data = nil
-	c.key = ""
-	c.expiresAt = time.Time{}
+	c.entries = nil
 }
 
 // getOrCompute returns the cached payload for key, or computes it via the

--- a/handler/admin/channels_cache_test.go
+++ b/handler/admin/channels_cache_test.go
@@ -1,0 +1,352 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// This file pins the snapshot-cache contract of GET /api/channels: the cache
+// must hold several three-dimensional keys (unbounded/paged × pageSize ×
+// status filter) at once, stay bounded, evict deterministically, keep the
+// ?refresh=true bypass and the mutation invalidation hook, and still run the
+// fleet-wide JOIN once per key under concurrency. Every assertion below is
+// driven through the real handler (router + response headers), never through
+// the cache struct's internals, so the expectations come from the documented
+// semantics rather than from the implementation.
+
+// seedChannelsCacheFleet inserts n route_channels rows on one shared
+// route/account/token triple and returns those ids (the mutation test needs
+// them to POST a new channel).
+func seedChannelsCacheFleet(t *testing.T, db *store.DB, n int) (routeID, accountID, tokenID int64) {
+	t.Helper()
+	routeID, accountID, tokenID = seedRouteChannelRefs(t, db)
+	for i := 0; i < n; i++ {
+		if _, err := db.Exec(
+			`INSERT INTO route_channels
+				(route_id, account_id, token_id, source_model, priority, weight, enabled, manual_override)
+			 VALUES (?, ?, ?, ?, 0, 10, TRUE, FALSE)`,
+			routeID, accountID, tokenID, "gpt-cache-"+strconv.Itoa(i)); err != nil {
+			t.Fatalf("insert channel %d: %v", i, err)
+		}
+	}
+	return routeID, accountID, tokenID
+}
+
+// requireCacheState drives GET path and asserts the x-channels-snapshot-cache
+// response header is want ("hit"/"miss"), returning the recorder so callers can
+// also inspect the payload.
+func requireCacheState(t *testing.T, r chi.Router, path, want string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := doGet(t, r, path)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s: status=%d body=%s", path, rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("x-channels-snapshot-cache"); got != want {
+		t.Fatalf("GET %s: x-channels-snapshot-cache=%q, want %q", path, got, want)
+	}
+	return rec
+}
+
+func channelsCacheEnvelope(t *testing.T, rec *httptest.ResponseRecorder) (items []any, total int, page int, pageSize int) {
+	t.Helper()
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body: %v (body=%s)", err, rec.Body.String())
+	}
+	items, _ = resp["items"].([]any)
+	toInt := func(key string) int {
+		v, _ := resp[key].(float64)
+		return int(v)
+	}
+	return items, toInt("total"), toInt("page"), toInt("pageSize")
+}
+
+// TestChannels_SnapshotCache_PagedKeysDoNotEvictEachOther is the endpoint-level
+// regression for the single-slot cache: alternating between two pages must hit
+// from the second round on. With one slot the second page evicts the first, so
+// every request misses and the fleet-wide 5-way JOIN runs every time — the 10s
+// TTL absorbs none of the polling it exists for.
+func TestChannels_SnapshotCache_PagedKeysDoNotEvictEachOther(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	seedChannelsCacheFleet(t, db, 120)
+
+	const (
+		page1 = "/api/channels?page=1&pageSize=50"
+		page2 = "/api/channels?page=2&pageSize=50"
+	)
+
+	// Round 1: both keys are cold → miss (and populate).
+	firstP1 := requireCacheState(t, r, page1, "miss")
+	firstP2 := requireCacheState(t, r, page2, "miss")
+
+	// Round 2: both keys are warm and inside the 10s TTL → hit.
+	secondP1 := requireCacheState(t, r, page1, "hit")
+	secondP2 := requireCacheState(t, r, page2, "hit")
+
+	// A hit must return the very same payload for that key (no key confusion,
+	// no cross-page shadowing).
+	if secondP1.Body.String() != firstP1.Body.String() {
+		t.Fatalf("page 1 hit body differs from its miss body")
+	}
+	if secondP2.Body.String() != firstP2.Body.String() {
+		t.Fatalf("page 2 hit body differs from its miss body")
+	}
+	if firstP1.Body.String() == firstP2.Body.String() {
+		t.Fatalf("page 1 and page 2 returned identical payloads; cache keys must differ")
+	}
+	items1, total1, pageEcho1, size1 := channelsCacheEnvelope(t, firstP1)
+	items2, total2, pageEcho2, size2 := channelsCacheEnvelope(t, secondP2)
+	if total1 != 120 || total2 != 120 {
+		t.Fatalf("total = %d/%d, want 120/120", total1, total2)
+	}
+	if pageEcho1 != 1 || pageEcho2 != 2 {
+		t.Fatalf("page echo = %d/%d, want 1/2", pageEcho1, pageEcho2)
+	}
+	if size1 != 50 || size2 != 50 {
+		t.Fatalf("pageSize = %d/%d, want 50/50", size1, size2)
+	}
+	if len(items1) != 50 || len(items2) != 50 {
+		t.Fatalf("items = %d/%d, want 50/50", len(items1), len(items2))
+	}
+}
+
+// TestChannels_SnapshotCache_UnboundedAndPagedViewsCoexist asserts the two
+// realistic traffic shapes — the dashboard's unbounded poll and an operator's
+// paged/filtered browsing — do not evict each other, including the status
+// dimension of the key.
+func TestChannels_SnapshotCache_UnboundedAndPagedViewsCoexist(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	seedChannelsCacheFleet(t, db, 120)
+
+	const (
+		unbounded  = "/api/channels"
+		filtered   = "/api/channels?status=enabled"
+		paged      = "/api/channels?page=2&pageSize=50"
+		pagedSmall = "/api/channels?page=1&pageSize=20"
+	)
+
+	unboundedMiss := requireCacheState(t, r, unbounded, "miss")
+	requireCacheState(t, r, paged, "miss")
+	requireCacheState(t, r, filtered, "miss")
+	requireCacheState(t, r, pagedSmall, "miss")
+
+	// Every one of the four keys must still be resident: the dashboard poll
+	// survives operator browsing, and a status filter is its own key.
+	unboundedHit := requireCacheState(t, r, unbounded, "hit")
+	requireCacheState(t, r, paged, "hit")
+	requireCacheState(t, r, filtered, "hit")
+	requireCacheState(t, r, pagedSmall, "hit")
+
+	if unboundedHit.Body.String() != unboundedMiss.Body.String() {
+		t.Fatalf("unbounded hit body differs from its miss body")
+	}
+	items, total, pageEcho, pageSize := channelsCacheEnvelope(t, unboundedHit)
+	if total != 120 || len(items) != 120 {
+		t.Fatalf("unbounded total=%d items=%d, want 120/120", total, len(items))
+	}
+	if pageEcho != 1 || pageSize != 120 {
+		t.Fatalf("unbounded envelope page=%d pageSize=%d, want 1/120 (single full page)", pageEcho, pageSize)
+	}
+	// The status-filtered unbounded view is a different key with a different
+	// (filtered) payload, so it must not have served the plain unbounded bytes.
+	filteredRec := requireCacheState(t, r, filtered, "hit")
+	if filteredRec.Body.String() == unboundedHit.Body.String() {
+		t.Fatalf("status-filtered view returned the unfiltered payload; keys must stay distinct")
+	}
+}
+
+// TestChannels_SnapshotCache_IsBoundedAndEvictsOldestFirst covers the capacity
+// contract: inserting more distinct keys than the cache may hold must not grow
+// it without bound, the entries that go must be the oldest inserted (FIFO, not
+// map-iteration luck), and the survivors must still hit.
+func TestChannels_SnapshotCache_IsBoundedAndEvictsOldestFirst(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	seedChannelsCacheFleet(t, db, 60)
+
+	// 16 is the documented bound: raising it is a memory/review decision, not a
+	// free parameter, so the test pins it instead of silently following it.
+	if channelsSnapshotMaxEntries != 16 {
+		t.Fatalf("channelsSnapshotMaxEntries = %d, want 16 (documented capacity bound)", channelsSnapshotMaxEntries)
+	}
+
+	const distinctKeys = 20 // > channelsSnapshotMaxEntries
+	pathFor := func(page int) string {
+		return "/api/channels?page=" + strconv.Itoa(page) + "&pageSize=1"
+	}
+
+	// Insert 20 distinct keys in a known order; each is cold, so each is a miss
+	// and each stamps the next insertion slot.
+	for page := 1; page <= distinctKeys; page++ {
+		requireCacheState(t, r, pathFor(page), "miss")
+	}
+
+	// Survivors first. Hits do not insert, so this loop cannot perturb the
+	// eviction order the next loop depends on. Inserts 17..20 evicted the four
+	// oldest entries (pages 1..4), leaving pages 5..20 resident.
+	for page := distinctKeys - channelsSnapshotMaxEntries + 1; page <= distinctKeys; page++ {
+		requireCacheState(t, r, pathFor(page), "hit")
+	}
+
+	// The evicted keys must miss again: that is the observable proof the map
+	// has an upper bound of channelsSnapshotMaxEntries live entries, and that
+	// the entries which left were the earliest inserted (deterministic FIFO).
+	for page := 1; page <= distinctKeys-channelsSnapshotMaxEntries; page++ {
+		requireCacheState(t, r, pathFor(page), "miss")
+	}
+}
+
+// TestChannels_SnapshotCache_RefreshBypassesThenRepopulates pins the
+// ?refresh=true bypass: the forced request recomputes (miss) and leaves the key
+// warm again (hit) for everyone else.
+func TestChannels_SnapshotCache_RefreshBypassesThenRepopulates(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	seedChannelsCacheFleet(t, db, 60)
+
+	const paged = "/api/channels?page=1&pageSize=10"
+
+	cold := requireCacheState(t, r, paged, "miss")
+	requireCacheState(t, r, paged, "hit")
+
+	forced := requireCacheState(t, r, paged+"&refresh=true", "miss")
+	if forced.Body.String() != cold.Body.String() {
+		t.Fatalf("forced refresh recomputed a different payload than the cold miss")
+	}
+
+	// The bypass must repopulate, not merely invalidate: the next plain request
+	// is served from cache again.
+	requireCacheState(t, r, paged, "hit")
+}
+
+// TestChannels_SnapshotCache_MutationInvalidatesEveryKey pins the invalidation
+// hook: a route_channels mutation clears the whole cache (it is the "the data
+// changed" entry point, not an eviction path), so every key — unbounded,
+// filtered and paged — misses afterwards and recomputes with the new row.
+func TestChannels_SnapshotCache_MutationInvalidatesEveryKey(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	routeID, accountID, tokenID := seedChannelsCacheFleet(t, db, 60)
+
+	const (
+		unbounded = "/api/channels"
+		filtered  = "/api/channels?status=enabled"
+		paged     = "/api/channels?page=1&pageSize=10"
+	)
+	requireCacheState(t, r, unbounded, "miss")
+	requireCacheState(t, r, filtered, "miss")
+	requireCacheState(t, r, paged, "miss")
+	// All three are warm now.
+	requireCacheState(t, r, unbounded, "hit")
+	requireCacheState(t, r, filtered, "hit")
+	requireCacheState(t, r, paged, "hit")
+
+	add := doPostJSON(t, r, "/api/routes/"+itoa(routeID)+"/channels", map[string]any{
+		"accountId":   accountID,
+		"tokenId":     tokenID,
+		"sourceModel": "gpt-cache-added",
+		"priority":    1,
+		"weight":      10,
+	})
+	if add.Code != http.StatusOK {
+		t.Fatalf("add channel: %d %s", add.Code, add.Body.String())
+	}
+
+	// Every key misses again — invalidation is whole-cache, not per-page.
+	afterUnbounded := requireCacheState(t, r, unbounded, "miss")
+	requireCacheState(t, r, filtered, "miss")
+	requireCacheState(t, r, paged, "miss")
+
+	// ... and the recomputed snapshot actually contains the new row.
+	_, total, _, _ := channelsCacheEnvelope(t, afterUnbounded)
+	if total != 61 {
+		t.Fatalf("post-mutation total = %d, want 61 (cache must not serve the stale snapshot)", total)
+	}
+}
+
+// TestChannels_SnapshotCache_ConcurrentMissesRunJoinOnce asserts the
+// singleflight half of the contract survives the multi-key map: N simultaneous
+// requests for one cold key must produce exactly one fleet-wide JOIN, with
+// identical bytes for every caller.
+func TestChannels_SnapshotCache_ConcurrentMissesRunJoinOnce(t *testing.T) {
+	db, r := setupTokenRoutesTest(t)
+	seedChannelsCacheFleet(t, db, 60)
+	globalChannelsCache.clear()
+
+	// SQLite is opened with MaxOpenConns(1), so holding the only pooled
+	// connection guarantees the leader's compute is still in flight when every
+	// follower arrives: without that barrier the leader could finish before the
+	// followers start, they would all read a warm cache and the test would pass
+	// even if singleflight were removed. The saturated pool is also the
+	// counter — database/sql bumps Stats().WaitCount for every query that has
+	// to wait for a connection, so with the only connection held here, each
+	// compute that reaches the DB adds exactly one wait. WaitCount delta is
+	// therefore the number of JOIN attempts.
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("acquire pooled connection: %v", err)
+	}
+	connClosed := false
+	defer func() {
+		if !connClosed {
+			_ = conn.Close()
+		}
+	}()
+
+	waitsBefore := db.Stats().WaitCount
+
+	const callers = 8
+	var wg sync.WaitGroup
+	recorders := make([]*httptest.ResponseRecorder, callers)
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/api/channels?page=1&pageSize=50", nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+			recorders[i] = rec
+		}(i)
+	}
+
+	// All callers are blocked behind the held connection now; give the
+	// goroutines time to actually pile up on the single-flight group, then
+	// release the connection so the (single) compute can run.
+	time.Sleep(250 * time.Millisecond)
+	connClosed = true
+	if err := conn.Close(); err != nil {
+		t.Fatalf("release pooled connection: %v", err)
+	}
+	wg.Wait()
+
+	if delta := db.Stats().WaitCount - waitsBefore; delta != 1 {
+		t.Fatalf("%d concurrent misses on one cold key attempted %d DB queries, want exactly 1 (singleflight must dedupe the fleet-wide JOIN)", callers, delta)
+	}
+
+	var wantBody string
+	for i, rec := range recorders {
+		if rec == nil {
+			t.Fatalf("caller %d produced no response", i)
+		}
+		if rec.Code != http.StatusOK {
+			t.Fatalf("caller %d: status=%d body=%s", i, rec.Code, rec.Body.String())
+		}
+		if i == 0 {
+			wantBody = rec.Body.String()
+			continue
+		}
+		if rec.Body.String() != wantBody {
+			t.Fatalf("caller %d got a different payload than caller 0", i)
+		}
+	}
+
+	// The key is warm afterwards, and still bounded to a single entry's worth
+	// of work: a plain follow-up request is a hit.
+	requireCacheState(t, r, "/api/channels?page=1&pageSize=50", "hit")
+}


### PR DESCRIPTION
## 改动摘要

`GET /api/channels` 的快照缓存 `channelsSnapshotCache` 是**单槽**的（`key` / `data` / `expiresAt`），但它的键空间从来就是多键的：仪表盘的无界视图是 `"unbounded"[:status,…]`，每个服务端分页视图是 `"page:pageSize:status,…"`。单槽只记得住最后一个键 ⇒ `page=1` 与 `page=2`（或“仪表盘轮询”与“运维翻页/切状态筛选”）**互相逐出**，10s TTL 从来没吸收掉它存在是为了吸收的那些轮询：几乎每个请求都是 miss，那条 fleet-wide 5-way JOIN + `COUNT(*) OVER ()` 照跑，缓存只剩下 mutex + singleflight 的开销。

本 PR 把单槽换成**有界 map（容量 16，FIFO 淘汰，单调 `seq` 定序）**。对外语义一字未改：TTL、`?refresh=true` 绕过、`x-channels-snapshot-cache: hit|miss|bypass` 响应头、singleflight 去重、`clear()` 作为“数据变了”的失效入口，全部保持原样；`:57-59` 那段与实现相反的注释（声称“keyed by page:pageSize 所以不同页不会互相遮蔽”）重写成事实。

**容量与内存上界是实测出来的，不是拍的**：一条 channel item 序列化 ≈ 340 B，`pageSize` 被 clamp 到 200 ⇒ 一页快照 ≈ 66 KB（实测 200 行 = 67,629 B），15 个分页槽 ≲ 1 MB；unbounded 键无 LIMIT、随 fleet 线性增长（≈340 KB / 1,000 条，5,000 条 ≈1.7 MB），而这份 payload 单槽时代本来就要装 —— 容量只把**分页部分**乘了 ≤16，最坏 ≲16 份快照 ≈ 几 MB，不存在无界增长。这些数字已写进代码注释。

**FIFO 而非 LRU**：确定且可测。读命中不改写缓存次序（不给读路径加写锁或簿记），淘汰对象 = 单调 `seq` 最小者，取最小值与 map 迭代顺序无关；uint64 回绕的理论 tie 用 key 字典序兜底，仍是确定选择。每条 TTL 只有 10s，recency 追踪收益极低，≤16 条线性扫描比维护第二套有序结构便宜。重设同键原地覆盖并盖新 `seq`（成为最新），因此容量判断只在“新键 + 已满”时执行。

## 类型

- [x] perf（性能优化：把命中率从≈0 修到设计值）
- [x] fix（实现与注释/意图不符）

## 测试验证

- [x] `go vet ./handler/admin/` 通过；`go build ./...` 通过
- [x] `gofmt -l` 对两个文件为空
- [x] PG 门禁**连跑两遍**均绿（复用同一个库）：`go test ./handler/admin/ -count=1 -tags=integration -p 1` → `ok 106.0s` / `ok 58.4s`
- [x] 新增 `handler/admin/channels_cache_test.go`（6 条**端点级**契约测试，全部驱动真实 handler + router + 响应头，不碰缓存结构内部）：分页键互不逐出 · unbounded/带状态筛选/分页三视图共存 · 容量上界 + FIFO 顺序 · `?refresh=true` 绕过后回填 · 变更后 `clear()` 钩子清掉所有键 · N 并发同键只跑一次 JOIN。期望值由语义推出（轮次 1 两键必 miss、轮次 2 必 hit；20 个键插入后存活集合 = 第 5..20 个，先验存活键 hit 再验被淘汰键 miss，避免验证动作本身扰动插入序），不是照抄实现
- [x] 并发达例**非空转**：`sql.DBStats` 没有 QueryCount，改为握住 SQLite 唯一池连接（`store.Open` 对 SQLite 设 `MaxOpenConns(1)`）——既保证 leader 的 compute 在 follower 到达时仍在飞，又让 `Stats().WaitCount` 成为“每次触达 DB 的 compute 计一次”的计数器，delta 即 JOIN 尝试次数
- [x] **变异探针 red → green（集成方独立复跑）**：`channelsSnapshotMaxEntries` 16 → 1（等价单槽）⇒ 4 条用例红：
  `x-channels-snapshot-cache="miss", want "hit"`（分页键互不逐出 / 三视图共存 / 变更失效）+ `channelsSnapshotMaxEntries = 1, want 16 (documented capacity bound)`；`git checkout --` 还原后 `sha256sum -c` 双文件一致、`grep` 零临时残留、复跑全绿。交付方另跑过两个红变体：还原到 git HEAD 的真实单槽实现（4 红）、把 singleflight 键打散（并发达例红：`8 concurrent misses on one cold key attempted 8 DB queries, want exactly 1`）

## 自查清单

- [x] 无密钥/内部路径泄漏
- [x] 无用户可见文案变更（响应头契约不变）
- [x] 行为变更已补测试
- [x] 不涉及前端 / DB schema / env，无需 CHANGELOG 之外的文档同步

## 故意没做（出界或需单独裁决）

1. `handler/admin/accounts.go` 的 `globalAccountsCache` 是**同形单槽**——不顺手改（文件属别的 lane，且需要独立判断其键空间）。**建议下一波单开一条 lane。**
2. `?refresh=true` 仍整表 `clear()`：一次强制刷新会连带丢掉其它键的常驻条目。这是既有的文档化行为，改成按键失效是行为变更，需单独裁决。
3. 5-way JOIN / `COUNT(*) OVER ()` 本身未优化（明确出界）。
4. 容量未做成 env 旋钮——内部实现细节，配置面等于又一处文档 + 门禁负担。
5. 过期条目不在读路径主动删除（`get` 持 RLock）：读作 miss，随后被覆盖或淘汰，16 条 / 10s TTL 下加清扫器不值得。
