### PR TITLE
fix(proxy): keep upstream compression encoding honest on the data plane

### DIFF
--- a/docs/api/proxy.md
+++ b/docs/api/proxy.md
@@ -58,6 +58,13 @@ Credential-bearing client headers are never forwarded: `authorization`,
 `x-api-key`, `cookie`, `proxy-*`, hop-by-hop headers, and `x-forwarded-*`. The
 downstream key stays a Metapi secret and never reaches the upstream.
 
+`Accept-Encoding` is never forwarded either — not from the client and not from a
+site's `custom_headers`. The outbound request reaches the transport without it,
+so net/http negotiates `gzip` itself and transparently decodes the answer, which
+is what keeps the body readable for usage accounting, `PROXY_ERROR_KEYWORDS` and
+the empty-content rule (see
+[configuration.md](../configuration.md#upstream-content-encoding)).
+
 Anthropic-native dispatch (`/v1/messages`, including the `/anthropic/v1/messages`
 gateway shape) requires `anthropic-version`; when the client does not send one
 the API default is used, so an OpenAI-surface request transformed into the
@@ -67,6 +74,10 @@ Anthropic shape does not fail upstream validation.
 content-semantic headers: `Content-Type`, `Content-Disposition`,
 `Content-Encoding`, `Content-Language`, `Content-Range`, `Accept-Ranges`,
 `Cache-Control`, `ETag`, `Last-Modified`, `Location`, `Retry-After`.
+`Content-Encoding` only ever describes bytes Metapi actually forwarded: an
+encoding Metapi decodes (`gzip`, `deflate`) is re-framed and the header is
+dropped, so it survives only when the answer was relayed verbatim because Metapi
+does not decode that codec.
 
 Everything else is dropped, which keeps the upstream's identity and state from
 leaking through Metapi: vendor fingerprint headers (`X-New-Api-Version` and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,6 +132,31 @@ All six `*_SEC` timeouts share one clamp (`config.parseTimeoutSec`): unset,
 blank, invalid, zero or negative values fall back to the listed default, so a
 typo can never disable a timeout entirely.
 
+### Upstream content encoding
+
+`gzip` and `deflate` answers are decoded with the standard library before Metapi
+parses them, so usage accounting, `PROXY_ERROR_KEYWORDS` and
+`PROXY_EMPTY_CONTENT_FAIL` read the same text the client reads; the response is
+then re-framed without `Content-Encoding`.
+
+An encoding Metapi does not decode (`br`, `zstd`, a stacked encoding list), or a
+decode that fails on a corrupt or oversized body, leaves the answer unreadable on
+purpose: it is relayed to the client verbatim under its own `Content-Encoding`,
+it is never parsed, its usage is recorded as `unknown` instead of invented, and
+neither the keyword rule nor the empty-content rule can fire on bytes nobody
+read. Each such response logs one WARN with a stable message:
+`upstream response uses a content encoding metapi does not decode; usage
+accounting and content-failure judgement were skipped`.
+
+`Accept-Encoding` is not site-configurable. An entry in a site's
+`custom_headers` is dropped when the proxy config is assembled
+(`service.filterPlatformCustomHeaders`, `platform.IsDeniedCustomHeader`) and
+stripped again from the outbound request, because that single header decides
+whether net/http transparently decodes the answer — i.e. whether Metapi can read
+the body it is about to bill for, judge and health-check. The strip logs one WARN
+per site/channel/value (`site custom_headers set Accept-Encoding on a data-plane
+upstream request; …`), since it describes a static misconfiguration.
+
 ### Proxy log writer & retention
 
 | Variable | Default | Description |

--- a/handler/proxy/headers.go
+++ b/handler/proxy/headers.go
@@ -96,6 +96,12 @@ func copyHeaderIfAbsent(dst http.Header, src http.Header, name string) {
 // client sees is Metapi's own, and framing/hop-by-hop headers stay out because
 // the buffered body is re-framed by net/http. The SSE relay keeps its own
 // policy (writeSSEHeaders): a stream is always re-framed by us.
+//
+// Content-Encoding stays on the list, but it can only ever describe the bytes we
+// actually relay: net/http removes it when it transparently decoded a negotiated
+// gzip answer, and normalizeBufferedUpstreamBody removes it when we decoded the
+// body ourselves. The single case where it survives is a body we could not
+// decode, which is relayed verbatim — see upstream_encoding.go.
 var upstreamResponseHeaders = []string{
 	"Accept-Ranges",
 	"Cache-Control",

--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -514,6 +514,11 @@ func dispatchEndpointAttemptWithContinue(
 	// can never override the selected token.
 	applyProxyCustomHeaders(req, proxyConfig)
 	applyClientProtocolHeaders(req, r.Header, upstreamPath)
+	// The value of this header decides whether net/http transparently decodes
+	// the answer, i.e. whether we can read the body we are about to bill for and
+	// health-check — so it is never site/adapter configurable. Must run after
+	// both header builders above (see stripUpstreamAcceptEncoding).
+	stripUpstreamAcceptEncoding(req, proxyConfig, selected.Site.ID, selected.Channel.ID)
 	if selected.TokenValue != "" {
 		req.Header.Set("Authorization", "Bearer "+selected.TokenValue)
 	}
@@ -590,12 +595,21 @@ func dispatchEndpointAttemptWithContinue(
 				observeProxyTerminal(ctx, shared.OutcomeUpstreamError, true, time.Duration(latencyMs)*time.Millisecond)
 				return true, nil, false
 			}
+			errBody := normalizeBufferedUpstreamBody(resp, respBody, upstreamBodyIdent{
+				siteID:    selected.Site.ID,
+				channelID: selected.Channel.ID,
+				requestID: requestID,
+				stream:    true,
+			})
+			respBody = errBody.bytes
 			rawErrText := string(respBody)
 			if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback, endpointFailureResponse) {
 				return false, nil, true
 			}
-			// Best-effort usage from error JSON bodies (some gateways still include usage).
-			failUsage := ParseUsageFromBody(respBody)
+			// Best-effort usage from error JSON bodies (some gateways still
+			// include usage). Only from bytes we could actually read: an
+			// undecodable body yields the explicit unknown source.
+			failUsage := errBody.parseUsage()
 			recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
 			writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, true, failUsage, retry, requestID, truncateErrText(rawErrText))
 			if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
@@ -677,6 +691,16 @@ func dispatchEndpointAttemptWithContinue(
 		observeProxyTerminal(ctx, shared.OutcomeUpstreamError, false, time.Duration(latencyMs)*time.Millisecond)
 		return true, nil, false
 	}
+	// Single encoding decision for this body: it fixes resp.Header (a decoded
+	// body loses its Content-Encoding) and tells us whether the bytes may be
+	// parsed at all. Everything below — usage, the content judge and the relay —
+	// consumes that one answer.
+	body := normalizeBufferedUpstreamBody(resp, respBody, upstreamBodyIdent{
+		siteID:    selected.Site.ID,
+		channelID: selected.Channel.ID,
+		requestID: requestID,
+	})
+	respBody = body.bytes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		rawErrText := string(respBody)
 		if shouldContinueEndpointFallback(resp.StatusCode, rawErrText, isLastEndpoint, disableCrossProtocolFallback, endpointFailureResponse) {
@@ -684,7 +708,7 @@ func dispatchEndpointAttemptWithContinue(
 		}
 		// Non-stream HTTP errors: retain any usage object in the error body
 		// (measurable under-count after disconnect partial).
-		failUsage := ParseUsageFromBody(respBody)
+		failUsage := body.parseUsage()
 		recordUpstreamFailure(r.Context(), cfg, selected, upstreamModel, resp.StatusCode, rawErrText)
 		writeFailureProxyLog(r.Context(), cfg, selected, ctx, upstreamModel, upstreamPath, latencyMs, resp.StatusCode, false, failUsage, retry, requestID, truncateErrText(rawErrText))
 		if retry < maxRetries && proxy.ShouldRetryProxyRequest(resp.StatusCode, rawErrText) {
@@ -694,14 +718,11 @@ func dispatchEndpointAttemptWithContinue(
 		observeProxyTerminal(ctx, shared.StatusFromHTTP(resp.StatusCode), false, time.Duration(latencyMs)*time.Millisecond)
 		return true, nil, false
 	}
-	usage := ParseUsageFromBody(respBody)
+	usage := body.parseUsage()
 	// Same single judge the streaming path calls (see judgeStreamContent), fed
-	// with the buffered facts this path already has.
-	verdict := proxy.JudgeUpstreamContent(proxy.UpstreamContentFacts{
-		StatusCode: resp.StatusCode,
-		RawText:    string(respBody),
-		Usage:      usage.ToUsageSummary(),
-	})
+	// with the buffered facts this path already has. When the body could not be
+	// decoded the facts say so explicitly and the judge declines to rule.
+	verdict := proxy.JudgeUpstreamContent(body.judgeFacts(resp.StatusCode, usage))
 	if verdict.Failed {
 		slog.Warn("content-based failure detected",
 			"reason", verdict.Reason,

--- a/handler/proxy/upstream_encoding.go
+++ b/handler/proxy/upstream_encoding.go
@@ -1,0 +1,247 @@
+package proxyhandler
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/deliciousbuding/metapi-go/platform"
+	"github.com/deliciousbuding/metapi-go/proxy"
+)
+
+// This file owns the data plane's compression-encoding honesty: what we put on
+// the wire decides whether we can read the answer, and what we can read decides
+// whether we may account usage and judge content at all.
+//
+// Two invariants, both enforced here and nowhere else:
+//
+//  1. Outbound: a data-plane request never carries a site/adapter-configured
+//     Accept-Encoding (stripUpstreamAcceptEncoding). That header is not
+//     identity or protocol semantics an operator may choose — its value decides
+//     whether net/http transparently decodes the answer, i.e. whether Metapi can
+//     read the body it is about to bill for and health-check.
+//  2. Inbound: bytes we cannot decode are never parsed, never judged and never
+//     turned into tokens (normalizeBufferedUpstreamBody /
+//     prepareStreamUpstreamBody). They are relayed verbatim with their
+//     Content-Encoding, and the accounting gap is made visible through
+//     proxy.UpstreamEncodingSkippedMessage.
+
+// upstreamAcceptEncodingDroppedMessage is the STABLE warn text for invariant 1.
+const upstreamAcceptEncodingDroppedMessage = "site custom_headers set Accept-Encoding on a data-plane upstream request; the header was dropped so net/http can keep transparently decoding upstream bodies"
+
+// upstreamAcceptEncodingWarnDedupeCap bounds the dedupe set below. The warning
+// describes a static misconfiguration, so it is logged once per
+// (site, channel, value) instead of once per request; the cap only exists so a
+// pathological fleet of misconfigured sites cannot grow the set without bound.
+// Beyond it new keys are silently suppressed — the first N are already on the
+// record.
+const upstreamAcceptEncodingWarnDedupeCap = 512
+
+var (
+	upstreamAcceptEncodingWarnMu     sync.Mutex
+	upstreamAcceptEncodingWarnedKeys = map[string]struct{}{}
+)
+
+// stripUpstreamAcceptEncoding removes Accept-Encoding from an outbound
+// data-plane request.
+//
+// Why: the outbound request is built from a whitelist (client protocol headers)
+// plus site custom_headers plus the selected account token, and the client's own
+// Accept-Encoding is deliberately not on that whitelist. When the request
+// reaches the transport with no Accept-Encoding, net/http adds "gzip" itself,
+// transparently decompresses the answer and removes Content-Encoding /
+// Content-Length from resp.Header — so the body the usage parser and the content
+// judge see is the real content. A site custom_headers entry silently switched
+// that off: the body then arrived as compressed bytes, usage extraction found no
+// tokens (billing under-count), the keyword scan read noise, and with
+// PROXY_EMPTY_CONTENT_FAIL enabled a perfectly good answer could be recorded as
+// an empty-content 502 — a false failure that poisons channel health.
+//
+// proxyConfig is cleared at the source as well, not just req.Header: the
+// site-proxy path (platform.DoWithProxy / SiteProxy.Do) re-applies
+// proxyConfig.CustomHeaders to the request after we built it, so a value left
+// in that map would come straight back onto the wire. The config is rebuilt per
+// attempt by service.BuildPlatformProxyConfig, so removing the key is scoped to
+// this one dispatch.
+func stripUpstreamAcceptEncoding(req *http.Request, proxyConfig *platform.ProxyConfig, siteID, channelID int64) {
+	dropped := deleteAcceptEncodingCustomHeader(proxyConfig)
+	if req != nil && req.Header != nil {
+		if values := req.Header.Values("Accept-Encoding"); len(values) > 0 {
+			req.Header.Del("Accept-Encoding")
+			dropped = append(dropped, values...)
+		}
+	}
+	if len(dropped) == 0 {
+		return
+	}
+	warnUpstreamAcceptEncodingDropped(siteID, channelID, strings.Join(dropped, ","))
+}
+
+// deleteAcceptEncodingCustomHeader removes every Accept-Encoding key (any
+// casing) from a site's custom_headers map and returns the values it carried.
+func deleteAcceptEncodingCustomHeader(proxyConfig *platform.ProxyConfig) []string {
+	if proxyConfig == nil || len(proxyConfig.CustomHeaders) == 0 {
+		return nil
+	}
+	var dropped []string
+	for name, value := range proxyConfig.CustomHeaders {
+		if strings.EqualFold(strings.TrimSpace(name), "accept-encoding") {
+			dropped = append(dropped, value)
+			delete(proxyConfig.CustomHeaders, name)
+		}
+	}
+	return dropped
+}
+
+// warnUpstreamAcceptEncodingDropped logs invariant 1 at most once per
+// (site, channel, dropped value).
+func warnUpstreamAcceptEncodingDropped(siteID, channelID int64, dropped string) {
+	key := fmt.Sprintf("%d|%d|%s", siteID, channelID, dropped)
+	upstreamAcceptEncodingWarnMu.Lock()
+	if _, seen := upstreamAcceptEncodingWarnedKeys[key]; seen {
+		upstreamAcceptEncodingWarnMu.Unlock()
+		return
+	}
+	if len(upstreamAcceptEncodingWarnedKeys) >= upstreamAcceptEncodingWarnDedupeCap {
+		upstreamAcceptEncodingWarnMu.Unlock()
+		return
+	}
+	upstreamAcceptEncodingWarnedKeys[key] = struct{}{}
+	upstreamAcceptEncodingWarnMu.Unlock()
+
+	slog.Warn(upstreamAcceptEncodingDroppedMessage,
+		"site_id", siteID,
+		"channel_id", channelID,
+		"dropped_accept_encoding", dropped,
+	)
+}
+
+// resetUpstreamAcceptEncodingWarnings clears the dedupe set. Test-only: the
+// warning is once-per-configuration on purpose, so tests that assert on it need
+// a clean slate.
+func resetUpstreamAcceptEncodingWarnings() {
+	upstreamAcceptEncodingWarnMu.Lock()
+	upstreamAcceptEncodingWarnedKeys = map[string]struct{}{}
+	upstreamAcceptEncodingWarnMu.Unlock()
+}
+
+// upstreamBodyIdent names the attempt a body-level warning belongs to, so an
+// operator can trace an accounting gap back to a site, a channel and a request.
+type upstreamBodyIdent struct {
+	siteID    int64
+	channelID int64
+	requestID string
+	stream    bool
+}
+
+// bufferedUpstreamBody is the data plane's view of a buffered upstream body
+// after the single encoding decision (proxy.NormalizeUpstreamBufferedBody) has
+// been applied. readable=false means the bytes are still encoded and were
+// relayed verbatim: no parsing, no judging, no tokens.
+type bufferedUpstreamBody struct {
+	bytes    []byte
+	readable bool
+}
+
+// parseUsage extracts usage only from bytes we can actually read. An
+// undecodable body yields the explicit unknown source — never invented tokens.
+func (b bufferedUpstreamBody) parseUsage() ParsedUsage {
+	if !b.readable {
+		return ParsedUsage{Source: usageSourceUnknown}
+	}
+	return ParseUsageFromBody(b.bytes)
+}
+
+// judgeFacts builds the content-judge facts for this body. Unreadable bytes are
+// handed over as an explicit "no evidence" fact rather than as noise the judge
+// would have to guess about, so the single judge stays the single owner of the
+// verdict.
+func (b bufferedUpstreamBody) judgeFacts(statusCode int, usage ParsedUsage) proxy.UpstreamContentFacts {
+	facts := proxy.UpstreamContentFacts{
+		StatusCode: statusCode,
+		Usage:      usage.ToUsageSummary(),
+		Unreadable: !b.readable,
+	}
+	if b.readable {
+		facts.RawText = string(b.bytes)
+	}
+	return facts
+}
+
+// normalizeBufferedUpstreamBody applies the encoding decision to a buffered
+// upstream body and returns the bytes the caller may parse and relay. It also
+// owns the honest-abandonment warning: resp.Header has already been corrected
+// by proxy.NormalizeUpstreamBufferedBody when the body was decoded, so the
+// existing relay whitelist can only forward a Content-Encoding that still
+// describes the bytes we are about to write.
+func normalizeBufferedUpstreamBody(resp *http.Response, body []byte, ident upstreamBodyIdent) bufferedUpstreamBody {
+	if resp == nil {
+		return bufferedUpstreamBody{bytes: body, readable: true}
+	}
+	normalized := proxy.NormalizeUpstreamBufferedBody(resp.Header, body)
+	if !normalized.Readable {
+		warnUpstreamEncodingSkipped(resp, normalized.Encoding, normalized.DecodeErr, ident)
+	}
+	return bufferedUpstreamBody{bytes: normalized.Bytes, readable: normalized.Readable}
+}
+
+// prepareStreamUpstreamBody applies the same encoding decision to a streaming
+// upstream body. The streaming path must not grow its own semantics: a codec we
+// implement is decoded inline (we re-frame every chunk, so no Content-Encoding
+// goes downstream), and a body we cannot read is relayed verbatim with the
+// upstream's own Content-Encoding — the one case where the SSE response does
+// carry it, because in that case we rewrote nothing and the header is true.
+func prepareStreamUpstreamBody(resp *http.Response, w http.ResponseWriter, ident upstreamBodyIdent) (readable bool) {
+	if resp == nil {
+		return true
+	}
+	prepared := proxy.WrapUpstreamStreamBody(resp.Header, resp.Body)
+	if prepared.Reader != nil {
+		resp.Body = prepared.Reader
+	}
+	if prepared.Readable {
+		return true
+	}
+	if prepared.Encoding.RelayHeader() {
+		// Verbatim passthrough: the bytes we relay are exactly the encoded bytes
+		// the upstream sent, so keeping its Content-Encoding is the truthful
+		// framing (and it lets the client decode what we could not).
+		w.Header().Set("Content-Encoding", prepared.Encoding.Value)
+	}
+	warnUpstreamEncodingSkipped(resp, prepared.Encoding, nil, ident)
+	return false
+}
+
+// warnUpstreamEncodingSkipped emits the stable operator-facing warning for a
+// body we could not read. One line per affected response: the accounting gap is
+// real and per-request, so it must not be deduped into silence.
+func warnUpstreamEncodingSkipped(resp *http.Response, enc proxy.UpstreamEncoding, decodeErr error, ident upstreamBodyIdent) {
+	upstreamHost := ""
+	if resp != nil && resp.Request != nil && resp.Request.URL != nil {
+		upstreamHost = resp.Request.URL.Host
+	}
+	errText := ""
+	if decodeErr != nil {
+		errText = decodeErr.Error()
+	}
+	attrs := []any{
+		"content_encoding", enc.Value,
+		"encoding_class", enc.String(),
+		"decode_err", errText,
+		"upstream_host", upstreamHost,
+		"stream", ident.stream,
+		"usage_source", usageSourceUnknown,
+		"request_id", ident.requestID,
+	}
+	// The streaming relay does not carry the routing selection, so a zero id
+	// means "unknown here" and is left out rather than logged as a fake 0.
+	if ident.siteID != 0 {
+		attrs = append(attrs, "site_id", ident.siteID)
+	}
+	if ident.channelID != 0 {
+		attrs = append(attrs, "channel_id", ident.channelID)
+	}
+	slog.Warn(proxy.UpstreamEncodingSkippedMessage, attrs...)
+}

--- a/handler/proxy/upstream_encoding_honesty_test.go
+++ b/handler/proxy/upstream_encoding_honesty_test.go
@@ -1,0 +1,636 @@
+package proxyhandler
+
+import (
+	"bytes"
+	"compress/gzip"
+	"compress/zlib"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+	"github.com/deliciousbuding/metapi-go/proxy"
+	"github.com/deliciousbuding/metapi-go/routing"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// These tests pin compression-encoding honesty on the PRODUCTION dispatch path
+// (HandleChatCompletions -> dispatchSelectedUpstream ->
+// dispatchEndpointAttemptWithContinue -> buffered relay / handleStreamUpstream).
+// They deliberately assert on what reached the wire and on the three
+// observability surfaces (channel health, proxy_logs, the downstream response)
+// rather than on private helpers.
+
+const encodingTestCompletionJSON = `{"id":"chatcmpl-enc","object":"chat.completion","model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"hello there"},"finish_reason":"stop"}],"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}}`
+
+const encodingTestStreamBody = `{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"hi"}]}`
+
+const encodingTestBufferedBody = `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`
+
+// undecodableStreamPayload stands in for a brotli body. The stdlib has no
+// brotli encoder and this lane must not add a dependency, so the fixture uses
+// gzip bytes labelled "br": equally opaque to us, and the contract under test is
+// "we do not decode br and we do not pretend we did", not the codec itself.
+var undecodableStreamPayload = mustGzip([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hello there\"}}]}\n\ndata: [DONE]\n\n"))
+
+// lockedBuffer is a slog sink safe against a concurrently logging test in the
+// same package (the -race gate must stay clean).
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// captureWarnLogs redirects the default logger at WARN+ and restores it on
+// cleanup.
+func captureWarnLogs(t *testing.T) *lockedBuffer {
+	t.Helper()
+	out := &lockedBuffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(out, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return out
+}
+
+// upstreamRequestRecorder records, per wire request, the Accept-Encoding the
+// upstream actually saw and the path it was asked for. Mutex-guarded because the
+// httptest server handler runs on its own goroutine.
+type upstreamRequestRecorder struct {
+	mu              sync.Mutex
+	acceptEncodings []string
+	paths           []string
+	errors          []string
+}
+
+func (c *upstreamRequestRecorder) record(r *http.Request) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.acceptEncodings = append(c.acceptEncodings, r.Header.Get("Accept-Encoding"))
+	c.paths = append(c.paths, r.URL.Path)
+}
+
+func (c *upstreamRequestRecorder) encodings() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.acceptEncodings...)
+}
+
+func (c *upstreamRequestRecorder) hits() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.paths)
+}
+
+// negotiatingGzipUpstream behaves like a normal gateway: it gzip-encodes only
+// when the request asked for gzip.
+func negotiatingGzipUpstream(rec *upstreamRequestRecorder, body []byte) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		w.Header().Set("Content-Type", "application/json")
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			_, _ = w.Write(body)
+			return
+		}
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write(mustGzip(body))
+	}))
+}
+
+// fixedEncodingUpstream ignores negotiation entirely and always answers with the
+// given Content-Encoding and raw bytes — the "gateway that compresses no matter
+// what we asked for" case.
+func fixedEncodingUpstream(rec *upstreamRequestRecorder, contentType, contentEncoding string, raw []byte) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		w.Header().Set("Content-Type", contentType)
+		w.Header().Set("Content-Encoding", contentEncoding)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(raw)
+	}))
+}
+
+func mustGzip(raw []byte) []byte {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(raw); err != nil {
+		panic(err)
+	}
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+func mustZlib(raw []byte) []byte {
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	if _, err := zw.Write(raw); err != nil {
+		panic(err)
+	}
+	if err := zw.Close(); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+// runEncodingDispatch drives one chat completion through the production handler
+// and returns the three observability surfaces plus the downstream response.
+// Cross-protocol fallback is disabled so exactly one upstream attempt happens
+// and the assertions stay single-valued.
+func runEncodingDispatch(
+	t *testing.T,
+	upstreamURL string,
+	requestBody string,
+	siteCustomHeaders map[string]string,
+	runtimeMutator func(*config.RuntimeSettings),
+) (*upstreamTestRouter, *[]proxy.ProxyLogEntry, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	return runEncodingDispatchWith(t, upstreamURL, "", requestBody, siteCustomHeaders, runtimeMutator)
+}
+
+// runEncodingDispatchWithProxyURL is the site-proxy variant: the site carries a
+// ProxyURL, which routes the dispatch through platform.DoWithProxy instead of
+// the executor.
+func runEncodingDispatchWithProxyURL(
+	t *testing.T,
+	upstreamURL string,
+	proxyURL string,
+	requestBody string,
+	siteCustomHeaders map[string]string,
+) (*upstreamTestRouter, *[]proxy.ProxyLogEntry, *httptest.ResponseRecorder) {
+	t.Helper()
+	return runEncodingDispatchWith(t, upstreamURL, proxyURL, requestBody, siteCustomHeaders, nil)
+}
+
+func runEncodingDispatchWith(
+	t *testing.T,
+	upstreamURL string,
+	proxyURL string,
+	requestBody string,
+	siteCustomHeaders map[string]string,
+	runtimeMutator func(*config.RuntimeSettings),
+) (*upstreamTestRouter, *[]proxy.ProxyLogEntry, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	prevCfg := config.GetSafe()
+	config.Set(&config.Config{ProxyMaxChannelAttempts: 1})
+	t.Cleanup(func() { config.Set(prevCfg) })
+
+	prevRt := config.RuntimeSafe()
+	config.SetRuntime(&config.RuntimeSettings{DisableCrossProtocolFallback: true})
+	if runtimeMutator != nil {
+		config.UpdateRuntime(runtimeMutator)
+	}
+	t.Cleanup(func() { config.SetRuntime(prevRt) })
+
+	site := store.Site{ID: 3, URL: upstreamURL, Status: "active"}
+	if proxyURL != "" {
+		site.ProxyURL = &proxyURL
+	}
+	if len(siteCustomHeaders) > 0 {
+		var sb strings.Builder
+		sb.WriteString("{")
+		first := true
+		for k, v := range siteCustomHeaders {
+			if !first {
+				sb.WriteString(",")
+			}
+			first = false
+			sb.WriteString(`"` + k + `":"` + v + `"`)
+		}
+		sb.WriteString("}")
+		raw := sb.String()
+		site.CustomHeaders = &raw
+	}
+
+	router := &upstreamTestRouter{selected: routing.SelectedChannel{
+		Channel:     store.RouteChannel{ID: 42, Enabled: true},
+		Account:     store.Account{ID: 7, Status: "active"},
+		Site:        site,
+		TokenValue:  "upstream-token",
+		ActualModel: "gpt-4o",
+	}}
+	logs := &[]proxy.ProxyLogEntry{}
+	SetUpstreamConfig(&UpstreamConfig{
+		Router:   router,
+		Executor: proxy.NewRuntimeExecutor(10 * time.Second),
+		LogProxy: func(_ context.Context, entry proxy.ProxyLogEntry) error {
+			*logs = append(*logs, entry)
+			return nil
+		},
+	})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions", requestBody)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+	return router, logs, rec
+}
+
+// describeFailures renders the recorded channel failures readably so a red run
+// names the exact status/reason that poisoned the channel.
+func describeFailures(router *upstreamTestRouter) string {
+	parts := make([]string, 0, len(router.failures))
+	for _, f := range router.failures {
+		status := "nil"
+		if f.status != nil {
+			status = strconv.Itoa(*f.status)
+		}
+		text := "nil"
+		if f.errorText != nil {
+			text = strconv.Quote(*f.errorText)
+		}
+		parts = append(parts, fmt.Sprintf("{channelID:%d status:%s errorText:%s}", f.channelID, status, text))
+	}
+	return strings.Join(parts, " ")
+}
+
+// describeLogs renders the proxy_log rows readably for the same reason.
+func describeLogs(logs *[]proxy.ProxyLogEntry) string {
+	parts := make([]string, 0, len(*logs))
+	for _, e := range *logs {
+		total := "nil"
+		if e.TotalTokens != nil {
+			total = strconv.FormatInt(*e.TotalTokens, 10)
+		}
+		parts = append(parts, fmt.Sprintf("{status:%q http_status:%d usage_source:%q total_tokens:%s}", e.Status, e.HTTPStatus, e.UsageSource, total))
+	}
+	return strings.Join(parts, " ")
+}
+
+// assertNoFailureRecorded is the core anti-false-failure assertion: the channel
+// was not poisoned and the proxy_log row is a success row.
+func assertNoFailureRecorded(t *testing.T, router *upstreamTestRouter, logs *[]proxy.ProxyLogEntry) {
+	t.Helper()
+	if len(router.failures) != 0 {
+		t.Fatalf("recordUpstreamFailure calls = %d (%s), want 0 — an unreadable/encoded body must never be recorded as an upstream failure; proxy_logs = %s",
+			len(router.failures), describeFailures(router), describeLogs(logs))
+	}
+	if len(router.successes) != 1 {
+		t.Fatalf("recordUpstreamSuccess calls = %d (%#v), want exactly 1", len(router.successes), router.successes)
+	}
+	if len(*logs) != 1 {
+		t.Fatalf("proxy_logs rows = %d (%s), want exactly 1", len(*logs), describeLogs(logs))
+	}
+	entry := (*logs)[0]
+	if entry.Status != "success" {
+		t.Fatalf("proxy_logs status = %q, want %q", entry.Status, "success")
+	}
+	if entry.HTTPStatus != http.StatusOK {
+		t.Fatalf("proxy_logs http_status = %d, want 200", entry.HTTPStatus)
+	}
+}
+
+// assertUsageUnknown pins "never invent tokens": the row must carry the explicit
+// unknown source and zeroed token counters.
+func assertUsageUnknown(t *testing.T, logs *[]proxy.ProxyLogEntry) {
+	t.Helper()
+	entry := (*logs)[0]
+	if entry.UsageSource != "unknown" {
+		t.Fatalf("proxy_logs usage_source = %q, want %q (tokens must never be invented for a body we could not read)", entry.UsageSource, "unknown")
+	}
+	for name, got := range map[string]*int64{
+		"prompt_tokens":     entry.PromptTokens,
+		"completion_tokens": entry.CompletionTokens,
+		"total_tokens":      entry.TotalTokens,
+	} {
+		if got != nil && *got != 0 {
+			t.Fatalf("proxy_logs %s = %d, want 0/unknown", name, *got)
+		}
+	}
+}
+
+// assertUsageAccounted pins the opposite: a body we could read must be billed.
+func assertUsageAccounted(t *testing.T, logs *[]proxy.ProxyLogEntry) {
+	t.Helper()
+	entry := (*logs)[0]
+	if entry.UsageSource != "upstream" {
+		t.Fatalf("usage was not accounted from a readable body: proxy_logs = %s, want usage_source %q with 11/7/18 tokens", describeLogs(logs), "upstream")
+	}
+	if entry.PromptTokens == nil || *entry.PromptTokens != 11 {
+		t.Fatalf("proxy_logs prompt_tokens = %v, want 11", entry.PromptTokens)
+	}
+	if entry.CompletionTokens == nil || *entry.CompletionTokens != 7 {
+		t.Fatalf("proxy_logs completion_tokens = %v, want 7", entry.CompletionTokens)
+	}
+	if entry.TotalTokens == nil || *entry.TotalTokens != 18 {
+		t.Fatalf("proxy_logs total_tokens = %v, want 18", entry.TotalTokens)
+	}
+}
+
+// ---- 1. transparent-gzip invariant (regression anchor, green before & after) ----
+
+func TestUpstreamTransparentGzipIsDecodedJudgedAndAccounted(t *testing.T) {
+	rec := &upstreamRequestRecorder{}
+	upstream := negotiatingGzipUpstream(rec, []byte(encodingTestCompletionJSON))
+	t.Cleanup(upstream.Close)
+
+	// PROXY_EMPTY_CONTENT_FAIL is on so this test also proves the content judge
+	// saw the DECOMPRESSED body: a healthy answer must not be judged empty.
+	warns := captureWarnLogs(t)
+	router, logs, resp := runEncodingDispatch(t, upstream.URL, encodingTestBufferedBody, nil,
+		func(rt *config.RuntimeSettings) { rt.ProxyEmptyContentFailEnabled = true })
+
+	encodings := rec.encodings()
+	if len(encodings) != 1 {
+		t.Fatalf("upstream hits = %d (%v), want exactly 1", len(encodings), encodings)
+	}
+	if encodings[0] != "gzip" {
+		t.Fatalf("outbound Accept-Encoding = %q, want %q (net/http must add it itself so it transparently decodes)", encodings[0], "gzip")
+	}
+	if resp.Code != http.StatusOK {
+		t.Fatalf("downstream status = %d, want 200", resp.Code)
+	}
+	if got := resp.Body.String(); got != encodingTestCompletionJSON {
+		t.Fatalf("downstream body = %q, want the decompressed upstream JSON", got)
+	}
+	if got := resp.Header().Get("Content-Encoding"); got != "" {
+		t.Fatalf("downstream Content-Encoding = %q, want empty (net/http re-frames the decoded body)", got)
+	}
+	assertNoFailureRecorded(t, router, logs)
+	assertUsageAccounted(t, logs)
+	if strings.Contains(warns.String(), "content encoding metapi does not decode") {
+		t.Fatalf("transparent gzip must not warn about an undecodable body:\n%s", warns.String())
+	}
+}
+
+// ---- 2. site custom_headers must never set the outbound Accept-Encoding ----
+
+func TestSiteCustomAcceptEncodingNeverReachesTheUpstream(t *testing.T) {
+	rec := &upstreamRequestRecorder{}
+	upstream := negotiatingGzipUpstream(rec, []byte(encodingTestCompletionJSON))
+	t.Cleanup(upstream.Close)
+
+	_, logs, _ := runEncodingDispatch(t, upstream.URL, encodingTestBufferedBody,
+		map[string]string{"Accept-Encoding": "br", "X-Site-Header": "keep-me"}, nil)
+
+	encodings := rec.encodings()
+	if len(encodings) != 1 {
+		t.Fatalf("upstream hits = %d (%v), want exactly 1", len(encodings), encodings)
+	}
+	// The site-configured value must never reach the wire: it decides whether we
+	// can read the answer at all. What does reach the wire is net/http's own
+	// "gzip", re-added exactly because our outbound request no longer carries an
+	// explicit Accept-Encoding.
+	if strings.Contains(strings.ToLower(encodings[0]), "br") {
+		t.Fatalf("outbound Accept-Encoding = %q — the site's custom_headers value reached the upstream, which switches off transparent decoding", encodings[0])
+	}
+	if encodings[0] != "gzip" {
+		t.Fatalf("outbound Accept-Encoding = %q, want %q", encodings[0], "gzip")
+	}
+	// Proving the strip did not collateral-damage the rest of custom_headers is
+	// done by the unit test; here we only need the accounting to stay correct.
+	assertUsageAccounted(t, logs)
+}
+
+// ---- 3. the false failure: an undecodable STREAM body must not be recorded as one ----
+
+func TestUndecodableStreamBodyIsNotRecordedAsFailure(t *testing.T) {
+	rec := &upstreamRequestRecorder{}
+	upstream := fixedEncodingUpstream(rec, "text/event-stream", "br", undecodableStreamPayload)
+	t.Cleanup(upstream.Close)
+
+	warns := captureWarnLogs(t)
+	router, logs, resp := runEncodingDispatch(t, upstream.URL, encodingTestStreamBody, nil,
+		func(rt *config.RuntimeSettings) { rt.ProxyEmptyContentFailEnabled = true })
+
+	// Core invariant first: a body nobody could read is not evidence of an
+	// upstream failure, so the channel must not be poisoned by it.
+	assertNoFailureRecorded(t, router, logs)
+	assertUsageUnknown(t, logs)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("downstream status = %d, want 200 (the stream already began)", resp.Code)
+	}
+	if !bytes.Equal(resp.Body.Bytes(), undecodableStreamPayload) {
+		t.Fatalf("downstream body = %d bytes, want the upstream's %d bytes relayed verbatim", resp.Body.Len(), len(undecodableStreamPayload))
+	}
+	if got := resp.Header().Get("Content-Encoding"); got != "br" {
+		t.Fatalf("downstream Content-Encoding = %q, want %q (verbatim passthrough must keep the upstream's truthful framing so the client can still decode it)", got, "br")
+	}
+	if !strings.Contains(warns.String(), "content encoding metapi does not decode") {
+		t.Fatalf("expected the stable undecodable-encoding WARN, got:\n%s", warns.String())
+	}
+	if !strings.Contains(warns.String(), "content_encoding=br") {
+		t.Fatalf("WARN must name the encoding, got:\n%s", warns.String())
+	}
+}
+
+// ---- 4. an undecodable BUFFERED body is relayed verbatim, judged as nothing ----
+
+func TestUndecodableBufferedBodyIsRelayedVerbatimWithoutFailure(t *testing.T) {
+	payload := mustGzip([]byte(encodingTestCompletionJSON))
+	rec := &upstreamRequestRecorder{}
+	upstream := fixedEncodingUpstream(rec, "application/json", "br", payload)
+	t.Cleanup(upstream.Close)
+
+	warns := captureWarnLogs(t)
+	router, logs, resp := runEncodingDispatch(t, upstream.URL, encodingTestBufferedBody, nil,
+		func(rt *config.RuntimeSettings) { rt.ProxyEmptyContentFailEnabled = true })
+
+	assertNoFailureRecorded(t, router, logs)
+	assertUsageUnknown(t, logs)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("downstream status = %d, want 200", resp.Code)
+	}
+	if !bytes.Equal(resp.Body.Bytes(), payload) {
+		t.Fatalf("downstream body = %d bytes, want the upstream's %d bytes relayed verbatim", resp.Body.Len(), len(payload))
+	}
+	if got := resp.Header().Get("Content-Encoding"); got != "br" {
+		t.Fatalf("downstream Content-Encoding = %q, want %q", got, "br")
+	}
+	if !strings.Contains(warns.String(), "content encoding metapi does not decode") {
+		t.Fatalf("expected the stable undecodable-encoding WARN, got:\n%s", warns.String())
+	}
+}
+
+// ---- 5. forced gzip body: usage and judgement must run on the DECODED content ----
+
+func TestForcedGzipBodyIsDecodedForUsageAndJudgement(t *testing.T) {
+	rec := &upstreamRequestRecorder{}
+	upstream := fixedEncodingUpstream(rec, "application/json", "gzip", mustGzip([]byte(encodingTestCompletionJSON)))
+	t.Cleanup(upstream.Close)
+
+	router, logs, resp := runEncodingDispatch(t, upstream.URL, encodingTestBufferedBody, nil,
+		func(rt *config.RuntimeSettings) { rt.ProxyEmptyContentFailEnabled = true })
+
+	// Accounting first: a body we could read must be billed for what it says.
+	assertNoFailureRecorded(t, router, logs)
+	assertUsageAccounted(t, logs)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("downstream status = %d, want 200", resp.Code)
+	}
+	if got := resp.Body.String(); got != encodingTestCompletionJSON {
+		t.Fatalf("downstream body = %q, want the decompressed upstream JSON", got)
+	}
+	if got := resp.Header().Get("Content-Encoding"); got != "" {
+		t.Fatalf("downstream Content-Encoding = %q, want empty (we re-frame the decoded body)", got)
+	}
+}
+
+// ---- 6. forced deflate body: net/http never decodes deflate, so this pins our own decoder ----
+
+func TestForcedDeflateBodyIsDecodedForUsageAndJudgement(t *testing.T) {
+	rec := &upstreamRequestRecorder{}
+	upstream := fixedEncodingUpstream(rec, "application/json", "deflate", mustZlib([]byte(encodingTestCompletionJSON)))
+	t.Cleanup(upstream.Close)
+
+	router, logs, resp := runEncodingDispatch(t, upstream.URL, encodingTestBufferedBody, nil,
+		func(rt *config.RuntimeSettings) { rt.ProxyEmptyContentFailEnabled = true })
+
+	// net/http never decodes "deflate", so this is the case where OUR decoder is
+	// the only thing standing between the upstream's tokens and the bill.
+	assertNoFailureRecorded(t, router, logs)
+	assertUsageAccounted(t, logs)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("downstream status = %d, want 200", resp.Code)
+	}
+	if got := resp.Body.String(); got != encodingTestCompletionJSON {
+		t.Fatalf("downstream body = %q, want the inflated upstream JSON", got)
+	}
+	if got := resp.Header().Get("Content-Encoding"); got != "" {
+		t.Fatalf("downstream Content-Encoding = %q, want empty (we re-frame the decoded body)", got)
+	}
+}
+
+// ---- 7. keyword judgement must see through an encoded body (no false success) ----
+
+func TestErrorKeywordInsideEncodedBodyIsStillJudged(t *testing.T) {
+	errBody := []byte(`{"error":{"message":"quota exhausted upstream","type":"rate_limit_error"}}`)
+	rec := &upstreamRequestRecorder{}
+	upstream := fixedEncodingUpstream(rec, "application/json", "deflate", mustZlib(errBody))
+	t.Cleanup(upstream.Close)
+
+	router, logs, resp := runEncodingDispatch(t, upstream.URL, encodingTestBufferedBody, nil,
+		func(rt *config.RuntimeSettings) { rt.ProxyErrorKeywords = []string{"quota exhausted"} })
+
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("downstream status = %d, want 502 — the keyword scan must see through the encoded body", resp.Code)
+	}
+	if len(router.failures) != 1 {
+		t.Fatalf("recordUpstreamFailure calls = %d (%#v), want exactly 1", len(router.failures), router.failures)
+	}
+	f := router.failures[0]
+	if f.status == nil || *f.status != http.StatusBadGateway {
+		t.Fatalf("failure status = %v, want 502", f.status)
+	}
+	if f.errorText == nil || !strings.Contains(*f.errorText, "quota exhausted") {
+		t.Fatalf("failure errorText = %v, want it to name the matched keyword", f.errorText)
+	}
+	if len(*logs) != 1 {
+		t.Fatalf("proxy_logs rows = %d (%#v), want exactly 1", len(*logs), *logs)
+	}
+	if (*logs)[0].Status == "success" {
+		t.Fatal("proxy_logs recorded a success for an upstream answer that matched a failure keyword")
+	}
+}
+
+// forwardingProxyUpstream is a minimal HTTP forward proxy: it records the
+// headers that actually left our process and relays the request to the real
+// upstream. DisableCompression keeps the proxy from adding an Accept-Encoding of
+// its own or decoding the answer, so what it records is exactly what the data
+// plane put on the wire and what comes back is still the upstream's framing.
+func forwardingProxyUpstream(rec *upstreamRequestRecorder, target *httptest.Server) *httptest.Server {
+	transport := &http.Transport{DisableCompression: true}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r)
+		outReq, err := http.NewRequest(r.Method, r.URL.String(), r.Body)
+		if err != nil {
+			t_Errorf(rec, "proxy build request: %v", err)
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		outReq.Header = r.Header.Clone()
+		outReq.Header.Set("X-Forwarded-By", "b3-test-proxy")
+		upstreamResp, err := transport.RoundTrip(outReq)
+		if err != nil {
+			t_Errorf(rec, "proxy roundtrip: %v", err)
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		defer upstreamResp.Body.Close()
+		for name, values := range upstreamResp.Header {
+			for _, v := range values {
+				w.Header().Add(name, v)
+			}
+		}
+		w.WriteHeader(upstreamResp.StatusCode)
+		_, _ = io.Copy(w, upstreamResp.Body)
+	}))
+}
+
+// t_Errorf stores a proxy-side error on the recorder: the proxy handler runs on
+// its own goroutine, where t.Fatalf is not allowed.
+func t_Errorf(rec *upstreamRequestRecorder, format string, args ...any) {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	rec.errors = append(rec.errors, fmt.Sprintf(format, args...))
+}
+
+func (c *upstreamRequestRecorder) errorText() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strings.Join(c.errors, "; ")
+}
+
+// TestSiteCustomAcceptEncodingNeverReachesTheUpstreamViaSiteProxy covers the
+// site-proxy dispatch branch (platform.DoWithProxy), which re-applies
+// proxyConfig.CustomHeaders to the request AFTER the data plane built it. That
+// re-apply is why the strip has to clear the custom_headers map at the source
+// and not just req.Header.
+func TestSiteCustomAcceptEncodingNeverReachesTheUpstreamViaSiteProxy(t *testing.T) {
+	target := negotiatingGzipUpstream(&upstreamRequestRecorder{}, []byte(encodingTestCompletionJSON))
+	t.Cleanup(target.Close)
+
+	rec := &upstreamRequestRecorder{}
+	proxySrv := forwardingProxyUpstream(rec, target)
+	t.Cleanup(proxySrv.Close)
+
+	router, logs, resp := runEncodingDispatchWithProxyURL(t, target.URL, proxySrv.URL, encodingTestBufferedBody,
+		map[string]string{"Accept-Encoding": "br", "X-Site-Header": "keep-me"})
+
+	if errs := rec.errorText(); errs != "" {
+		t.Fatalf("forward proxy errors: %s", errs)
+	}
+	encodings := rec.encodings()
+	if len(encodings) != 1 {
+		t.Fatalf("proxy hits = %d (%v), want exactly 1", len(encodings), encodings)
+	}
+	if strings.Contains(strings.ToLower(encodings[0]), "br") {
+		t.Fatalf("outbound Accept-Encoding through the site proxy = %q — platform re-applied the site's custom_headers value after our strip", encodings[0])
+	}
+	if encodings[0] != "gzip" {
+		t.Fatalf("outbound Accept-Encoding through the site proxy = %q, want %q", encodings[0], "gzip")
+	}
+	if resp.Code != http.StatusOK {
+		t.Fatalf("downstream status = %d, want 200", resp.Code)
+	}
+	if got := resp.Body.String(); got != encodingTestCompletionJSON {
+		t.Fatalf("downstream body = %q, want the upstream JSON", got)
+	}
+	assertNoFailureRecorded(t, router, logs)
+	assertUsageAccounted(t, logs)
+}

--- a/handler/proxy/upstream_encoding_test.go
+++ b/handler/proxy/upstream_encoding_test.go
@@ -1,0 +1,201 @@
+package proxyhandler
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/platform"
+)
+
+// These unit tests pin the two data-plane glue helpers directly; the end-to-end
+// behaviour on the production dispatch path is pinned in
+// upstream_encoding_honesty_test.go.
+
+func TestStripUpstreamAcceptEncoding(t *testing.T) {
+	t.Cleanup(resetUpstreamAcceptEncodingWarnings)
+	resetUpstreamAcceptEncodingWarnings()
+
+	cases := []struct {
+		name   string
+		header map[string][]string
+	}{
+		{name: "canonical single value", header: map[string][]string{"Accept-Encoding": {"br"}}},
+		{name: "lowercase key", header: map[string][]string{"accept-encoding": {"gzip"}}},
+		{name: "multi value", header: map[string][]string{"Accept-Encoding": {"gzip", "br"}}},
+		{name: "mixed case value", header: map[string][]string{"Accept-Encoding": {"GZIP"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			warns := captureWarnLogs(t)
+			req, err := http.NewRequest(http.MethodPost, "https://upstream.example/v1/chat/completions", nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			for k, values := range tc.header {
+				for _, v := range values {
+					req.Header.Add(k, v)
+				}
+			}
+
+			stripUpstreamAcceptEncoding(req, nil, 3, 42)
+
+			if got := req.Header.Values("Accept-Encoding"); len(got) != 0 {
+				t.Fatalf("Accept-Encoding after strip = %v, want it gone: this header decides whether net/http transparently decodes the answer, so it is never site-configurable", got)
+			}
+			out := warns.String()
+			if !strings.Contains(out, "Accept-Encoding") {
+				t.Fatalf("expected the stable drop WARN, got:\n%s", out)
+			}
+			if !strings.Contains(out, "site_id=3") || !strings.Contains(out, "channel_id=42") {
+				t.Fatalf("WARN must name the misconfigured site and channel, got:\n%s", out)
+			}
+		})
+	}
+
+	t.Run("absent header is a silent no-op", func(t *testing.T) {
+		warns := captureWarnLogs(t)
+		req, err := http.NewRequest(http.MethodPost, "https://upstream.example/v1/chat/completions", nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		stripUpstreamAcceptEncoding(req, nil, 3, 42)
+		if got := warns.String(); got != "" {
+			t.Fatalf("unexpected WARN for the healthy default path:\n%s", got)
+		}
+	})
+
+	t.Run("other site custom headers survive", func(t *testing.T) {
+		resetUpstreamAcceptEncodingWarnings()
+		req, err := http.NewRequest(http.MethodPost, "https://upstream.example/v1/chat/completions", nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		req.Header.Set("Accept-Encoding", "br")
+		req.Header.Set("X-Site-Header", "keep-me")
+		req.Header.Set("Anthropic-Beta", "fine-grained-tool-streaming-2025-05-14")
+
+		stripUpstreamAcceptEncoding(req, nil, 3, 42)
+
+		if got := req.Header.Get("X-Site-Header"); got != "keep-me" {
+			t.Fatalf("X-Site-Header = %q, want %q", got, "keep-me")
+		}
+		if got := req.Header.Get("Anthropic-Beta"); got != "fine-grained-tool-streaming-2025-05-14" {
+			t.Fatalf("Anthropic-Beta = %q, want it untouched", got)
+		}
+	})
+
+	t.Run("warns once per site/channel/value", func(t *testing.T) {
+		resetUpstreamAcceptEncodingWarnings()
+		warns := captureWarnLogs(t)
+		for i := 0; i < 5; i++ {
+			req, err := http.NewRequest(http.MethodPost, "https://upstream.example/v1/chat/completions", nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req.Header.Set("Accept-Encoding", "br")
+			stripUpstreamAcceptEncoding(req, nil, 3, 42)
+		}
+		if got := strings.Count(warns.String(), "site_id=3"); got != 1 {
+			t.Fatalf("WARN emitted %d times for one static misconfiguration, want exactly 1:\n%s", got, warns.String())
+		}
+
+		// A different channel on the same site is a different fix, so it gets its
+		// own single line.
+		req, err := http.NewRequest(http.MethodPost, "https://upstream.example/v1/chat/completions", nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		req.Header.Set("Accept-Encoding", "br")
+		stripUpstreamAcceptEncoding(req, nil, 3, 43)
+		if got := strings.Count(warns.String(), "channel_id=43"); got != 1 {
+			t.Fatalf("WARN for channel 43 emitted %d times, want 1:\n%s", got, warns.String())
+		}
+	})
+}
+
+// TestBufferedUpstreamBodyUnreadableContract pins the glue contract the dispatch
+// path relies on: unreadable bytes yield the explicit unknown usage source and an
+// explicit "no evidence" fact for the single content judge — never invented
+// tokens and never noise handed to a keyword scan.
+func TestBufferedUpstreamBodyUnreadableContract(t *testing.T) {
+	unreadable := bufferedUpstreamBody{bytes: []byte{0x8b, 0x21, 0xff}, readable: false}
+
+	usage := unreadable.parseUsage()
+	if usage.Source != usageSourceUnknown || usage.Found {
+		t.Fatalf("parseUsage() = %+v, want the explicit unknown source", usage)
+	}
+	if usage.PromptTokens != 0 || usage.CompletionTokens != 0 || usage.TotalTokens != 0 {
+		t.Fatalf("parseUsage() invented tokens: %+v", usage)
+	}
+
+	facts := unreadable.judgeFacts(http.StatusOK, usage)
+	if !facts.Unreadable {
+		t.Fatal("judgeFacts().Unreadable = false, want the judge to be told there is no evidence")
+	}
+	if facts.RawText != "" {
+		t.Fatalf("judgeFacts().RawText = %q, want empty: undecodable bytes must not reach the keyword scan", facts.RawText)
+	}
+
+	readable := bufferedUpstreamBody{
+		bytes:    []byte(`{"choices":[{"message":{"content":"hi"}}],"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}}`),
+		readable: true,
+	}
+	if got := readable.parseUsage(); got.Source != usageSourceUpstream || got.TotalTokens != 18 {
+		t.Fatalf("readable parseUsage() = %+v, want upstream/18", got)
+	}
+	if got := readable.judgeFacts(http.StatusOK, readable.parseUsage()); got.Unreadable || got.RawText == "" {
+		t.Fatalf("readable judgeFacts() = %+v, want a readable fact set", got)
+	}
+}
+
+// TestStripUpstreamAcceptEncodingClearsCustomHeadersSource pins the source-level
+// half of the strip: platform.DoWithProxy / SiteProxy.Do re-apply
+// proxyConfig.CustomHeaders to the request after the data plane built it, so the
+// value has to leave the map too — clearing req.Header alone would leak it back
+// onto the wire on the site-proxy path.
+func TestStripUpstreamAcceptEncodingClearsCustomHeadersSource(t *testing.T) {
+	t.Cleanup(resetUpstreamAcceptEncodingWarnings)
+	resetUpstreamAcceptEncodingWarnings()
+	warns := captureWarnLogs(t)
+
+	proxyConfig := &platform.ProxyConfig{
+		CustomHeaders: map[string]string{
+			"accept-encoding": "br",
+			"X-Site-Header":   "keep-me",
+		},
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://upstream.example/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	platform.ApplyCustomHeadersWithOptions(req, proxyConfig.CustomHeaders, platform.ApplyCustomHeadersOptions{})
+
+	stripUpstreamAcceptEncoding(req, proxyConfig, 3, 42)
+
+	if got := req.Header.Values("Accept-Encoding"); len(got) != 0 {
+		t.Fatalf("request Accept-Encoding = %v, want it gone", got)
+	}
+	for name := range proxyConfig.CustomHeaders {
+		if strings.EqualFold(strings.TrimSpace(name), "accept-encoding") {
+			t.Fatalf("custom_headers still carries %q — platform would re-apply it on the site-proxy path", name)
+		}
+	}
+	if got := proxyConfig.CustomHeaders["X-Site-Header"]; got != "keep-me" {
+		t.Fatalf("custom_headers X-Site-Header = %q, want %q (the strip must not collateral-damage other site headers)", got, "keep-me")
+	}
+	if got := req.Header.Get("X-Site-Header"); got != "keep-me" {
+		t.Fatalf("request X-Site-Header = %q, want %q", got, "keep-me")
+	}
+	if !strings.Contains(warns.String(), "site_id=3") {
+		t.Fatalf("expected one drop WARN naming the site, got:\n%s", warns.String())
+	}
+
+	// Idempotent: a second attempt for the same dispatch shape finds nothing to
+	// strip and stays quiet.
+	before := warns.String()
+	stripUpstreamAcceptEncoding(req, proxyConfig, 3, 42)
+	if warns.String() != before {
+		t.Fatalf("second strip logged again:\n%s", warns.String())
+	}
+}

--- a/handler/proxy/upstream_stream.go
+++ b/handler/proxy/upstream_stream.go
@@ -79,6 +79,19 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 	shared.IncActiveStreams()
 	defer shared.DecActiveStreams()
 
+	// The same single encoding decision the buffered path applies (see
+	// normalizeBufferedUpstreamBody): a codec the stdlib implements is decoded
+	// inline so every chunk we re-frame is real SSE text, and a body we cannot
+	// read is relayed verbatim under its own Content-Encoding with judgement
+	// abandoned. writeSSEHeaders deliberately never copies Content-Encoding — a
+	// stream is re-framed chunk by chunk, so relaying the upstream's encoding
+	// would be a lie. The verbatim branch above is the single exception, and it
+	// sets the header itself precisely because there we rewrote nothing.
+	bodyReadable := prepareStreamUpstreamBody(resp, w, upstreamBodyIdent{
+		requestID: proxy.RequestIDFromContext(r.Context()),
+		stream:    true,
+	})
+
 	writeSSEHeaders(w)
 	w.WriteHeader(200)
 
@@ -147,7 +160,7 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 			}
 			return empty, end, nil
 		}
-		verdict := judgeStreamContent(resp.StatusCode, result, latencyMs)
+		verdict := judgeStreamContent(resp.StatusCode, result, latencyMs, !bodyReadable)
 		if result.Usage.Found {
 			return result.Usage, end, &verdict
 		}
@@ -192,7 +205,12 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 			if len(chunk) > 0 {
 				// Extract usage before downstream write so client disconnect
 				// on the final usage-bearing chunk still counts tokens.
-				analyzer.Push(chunk)
+				// Undecodable bytes are never fed to the analyzer: it would
+				// "analyze" noise, find no data events and hand the judge an
+				// empty-content fact for a perfectly healthy answer.
+				if bodyReadable {
+					analyzer.Push(chunk)
+				}
 				if _, writeErr := w.Write(chunk); writeErr != nil {
 					slog.Warn("SSE downstream write failed",
 						"err", writeErr,
@@ -266,13 +284,20 @@ func handleStreamUpstream(w http.ResponseWriter, r *http.Request, resp *http.Res
 // content judge the buffered path calls (proxy.JudgeUpstreamContent). It
 // replaces the historical log-only parallel implementation that merely warned
 // about missing data events while the dispatcher still recorded a success.
-func judgeStreamContent(statusCode int, result incrementalSseAnalysisResult, latencyMs int64) proxy.UpstreamVerdict {
+//
+// bodyUnreadable is the streaming half of the encoding-honesty contract: when
+// the upstream used a Content-Encoding we do not decode, the analyzer saw bytes
+// nobody could parse, so HasOutput=false here means "no evidence" and not "empty
+// answer". It is passed to the judge as an explicit Unreadable fact rather than
+// being special-cased here, keeping one owner of the verdict.
+func judgeStreamContent(statusCode int, result incrementalSseAnalysisResult, latencyMs int64, bodyUnreadable bool) proxy.UpstreamVerdict {
 	verdict := proxy.JudgeUpstreamContent(proxy.UpstreamContentFacts{
 		StatusCode: statusCode,
 		Streaming:  true,
 		RawText:    sseErrorEventText(result.ErrorEvents),
 		HasOutput:  result.HasDataEvent,
 		Usage:      result.Usage.ToUsageSummary(),
+		Unreadable: bodyUnreadable,
 	})
 	if verdict.Failed {
 		slog.Warn("stream content-based failure detected",

--- a/handler/proxy/upstream_stream_honesty_test.go
+++ b/handler/proxy/upstream_stream_honesty_test.go
@@ -360,7 +360,7 @@ func TestContentJudgeAgreesAcrossBufferedAndStreamPaths(t *testing.T) {
 			}
 			result := analyzer.Result()
 			result.Usage.CompletionTokens = int64(tc.completionTokens)
-			streamed := judgeStreamContent(http.StatusOK, result, 1)
+			streamed := judgeStreamContent(http.StatusOK, result, 1, false)
 
 			if buffered != streamed {
 				t.Fatalf("verdicts diverge for the same upstream content:\n buffered = %+v\n stream   = %+v", buffered, streamed)

--- a/platform/custom_headers.go
+++ b/platform/custom_headers.go
@@ -8,8 +8,8 @@ import (
 )
 
 // IsDeniedCustomHeader reports whether a site custom_headers entry must not be
-// forwarded upstream. Blocks identity, framing, hop-by-hop, cookies, Proxy-*,
-// and Metapi control preference headers.
+// forwarded upstream. Blocks identity, framing, content-coding, hop-by-hop,
+// cookies, Proxy-*, and Metapi control preference headers.
 //
 // Security: custom Authorization must never override the Bearer set from the
 // selected account token; Host/Connection/etc. must not be attacker-controlled.
@@ -30,6 +30,13 @@ func IsDeniedCustomHeader(name string) bool {
 		"host",
 		"content-length",
 		"transfer-encoding",
+		// Accept-Encoding decides whether net/http transparently decodes the
+		// answer, i.e. whether the caller can read the body it is about to
+		// parse, bill for and health-check. It is not site-configurable
+		// identity or protocol semantics, so it never comes from
+		// custom_headers; the data plane strips it as well
+		// (handler/proxy.stripUpstreamAcceptEncoding) and warns.
+		"accept-encoding",
 		"connection",
 		"cookie",
 		// RFC 7230 hop-by-hop (beyond Connection / Transfer-Encoding).

--- a/platform/custom_headers_test.go
+++ b/platform/custom_headers_test.go
@@ -15,6 +15,12 @@ func TestIsDeniedCustomHeader(t *testing.T) {
 		"Host",
 		"Content-Length",
 		"Transfer-Encoding",
+		// Accept-Encoding decides whether the answer stays readable for usage
+		// accounting, content judgement and health checks; it is not
+		// site-configurable. See TestReservedPlatformCustomHeadersStayInStep-
+		// WithPlatformDenyList in package service for the cross-guard drift test.
+		"Accept-Encoding",
+		" accept-encoding ",
 		"Connection",
 		"Cookie",
 		"Proxy-Authorization",
@@ -45,15 +51,15 @@ func TestApplyCustomHeaders_DeniesSensitiveAllowsCustom(t *testing.T) {
 	req.Host = "example.test"
 
 	ApplyCustomHeaders(req, map[string]string{
-		"Authorization":         "Bearer attacker",
-		"Host":                  "evil.example",
-		"Content-Length":        "999",
-		"Transfer-Encoding":     "chunked",
-		"Connection":            "close",
-		"Cookie":                "session=stolen",
-		"Proxy-Authorization":   "Basic evil",
+		"Authorization":           "Bearer attacker",
+		"Host":                    "evil.example",
+		"Content-Length":          "999",
+		"Transfer-Encoding":       "chunked",
+		"Connection":              "close",
+		"Cookie":                  "session=stolen",
+		"Proxy-Authorization":     "Basic evil",
 		"X-Metapi-Responses-Only": "1",
-		"X-Custom":              "ok",
+		"X-Custom":                "ok",
 	})
 
 	if got := req.Header.Get("Authorization"); got != "Bearer original-token" {
@@ -140,9 +146,9 @@ func TestApplyCustomHeaders_RequestWinsDefault(t *testing.T) {
 
 	// Default ApplyCustomHeaders = request-wins.
 	ApplyCustomHeaders(req, map[string]string{
-		"User-Agent":     "site-forced-ua",
-		"X-Site-Only":    "site",
-		"X-Only-Client":  "site-should-not-win",
+		"User-Agent":    "site-forced-ua",
+		"X-Site-Only":   "site",
+		"X-Only-Client": "site-should-not-win",
 	})
 
 	if got := req.Header.Get("User-Agent"); got != "client-sdk/1.0" {

--- a/proxy/failure_judge.go
+++ b/proxy/failure_judge.go
@@ -51,6 +51,14 @@ type UpstreamContentFacts struct {
 	HasOutput bool
 	// Usage is the parsed usage summary (nil when the upstream sent none).
 	Usage *UsageSummary
+	// Unreadable reports that the bytes behind these facts could not be read at
+	// all — an upstream Content-Encoding we do not decode (br/zstd/a stacked
+	// list), or a codec we do implement that failed on this body. It is the
+	// caller's honest admission that it has NO content evidence, and it short-
+	// circuits the whole judgement: a body we cannot parse must never be turned
+	// into a failure, because that records a 502 against a channel whose answer
+	// may have been perfectly good (see proxy/upstream_encoding.go).
+	Unreadable bool
 }
 
 // UpstreamVerdict is the single content judgement result.
@@ -71,10 +79,20 @@ type UpstreamVerdict struct {
 // verdict out.
 //
 // Detection:
+// 0. Unreadable body: no judgement at all (see UpstreamContentFacts.Unreadable)
 // 1. Keyword matching: if config.ProxyErrorKeywords is non-empty, case-insensitive
 // 2. Empty content check: if ProxyEmptyContentFailEnabled and no completion tokens + no output
 func JudgeUpstreamContent(facts UpstreamContentFacts) UpstreamVerdict {
 	pass := UpstreamVerdict{Code: FailureCodeNone}
+	if facts.Unreadable {
+		// No readable content evidence: neither the keyword scan nor the
+		// empty-content rule may run. Both would be guessing at bytes nobody
+		// parsed, and the empty-content rule in particular would report a
+		// healthy-but-encoded answer as a 502 — a false failure that poisons
+		// channel health. The caller surfaces the gap through
+		// UpstreamEncodingSkippedMessage instead.
+		return pass
+	}
 	rt := config.RuntimeSafe()
 	if rt == nil {
 		// No published runtime snapshot: nothing is configured, so nothing can

--- a/proxy/upstream_encoding.go
+++ b/proxy/upstream_encoding.go
@@ -1,0 +1,277 @@
+package proxy
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"compress/zlib"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// UpstreamEncodingSkippedMessage is the STABLE warn text the data plane emits
+// whenever it holds upstream body bytes it cannot decode. Stability matters:
+// operators alert on it, and it is the only surface that makes the resulting
+// account/reality gap ("we recorded a success but no tokens") visible instead
+// of silent. Never reword it without treating that as an operator-facing
+// contract change.
+const UpstreamEncodingSkippedMessage = "upstream response uses a content encoding metapi does not decode; usage accounting and content-failure judgement were skipped"
+
+// UpstreamEncodingKind classifies an upstream Content-Encoding by what it means
+// for our ability to READ the body. That ability — not the header itself — is
+// what decides whether usage may be accounted and whether the content judge may
+// run at all.
+type UpstreamEncodingKind int
+
+const (
+	// UpstreamEncodingIdentity means the bytes we hold are the content: no
+	// Content-Encoding, or the explicit "identity" token. Everything downstream
+	// (usage extraction, keyword scan, empty-content rule) may run.
+	UpstreamEncodingIdentity UpstreamEncodingKind = iota
+	// UpstreamEncodingDecodable means a stdlib codec can turn the bytes back
+	// into identity (gzip / deflate). The caller decodes, parses the decoded
+	// bytes and re-frames the response WITHOUT Content-Encoding.
+	UpstreamEncodingDecodable
+	// UpstreamEncodingUndecodable means we cannot read the bytes at all (br,
+	// zstd, a multi-layer stack, or a codec that failed mid-decode). The caller
+	// MUST NOT parse, judge or account them, and MUST relay them verbatim
+	// together with their Content-Encoding so the client — which may well be
+	// able to decode them — still gets an intact response.
+	UpstreamEncodingUndecodable
+)
+
+// UpstreamEncoding is the classification of one upstream response body.
+type UpstreamEncoding struct {
+	// Value is the raw Content-Encoding header value ("" when absent).
+	Value string
+	// Kind is the readability classification of Value.
+	Kind UpstreamEncodingKind
+}
+
+// Readable reports whether the bytes the caller holds (after Decode for a
+// decodable encoding) may be parsed as content. When false, usage extraction
+// and content judgement must both be skipped: unreadable bytes carry no
+// evidence, and inventing a failure from them is what poisons channel health
+// with perfectly healthy upstream answers.
+func (e UpstreamEncoding) Readable() bool { return e.Kind != UpstreamEncodingUndecodable }
+
+// Decodable reports whether a stdlib codec can turn the body into identity.
+func (e UpstreamEncoding) Decodable() bool { return e.Kind == UpstreamEncodingDecodable }
+
+// RelayHeader reports whether the upstream Content-Encoding must stay on the
+// response relayed to the downstream client. True exactly when the bytes are
+// relayed verbatim and therefore still encoded; false once we decoded them (we
+// re-frame the body ourselves, so keeping the header would be a lie) and false
+// when there is no header to relay.
+func (e UpstreamEncoding) RelayHeader() bool {
+	return e.Kind == UpstreamEncodingUndecodable && e.Value != ""
+}
+
+// String keeps log lines readable.
+func (e UpstreamEncoding) String() string {
+	switch e.Kind {
+	case UpstreamEncodingIdentity:
+		return "identity"
+	case UpstreamEncodingDecodable:
+		return "decodable(" + e.Value + ")"
+	case UpstreamEncodingUndecodable:
+		return "undecodable(" + e.Value + ")"
+	}
+	return "unknown"
+}
+
+// decodableContentEncodings are the codecs the Go standard library provides.
+// brotli and zstd are deliberately absent: decoding them would need a new
+// dependency, and guessing at bytes we cannot decode is exactly the dishonesty
+// this file exists to prevent.
+var decodableContentEncodings = map[string]bool{
+	"gzip":    true,
+	"x-gzip":  true,
+	"deflate": true,
+}
+
+// ClassifyUpstreamEncoding is the ONE owner of "can we read this upstream
+// body?". Both the buffered and the streaming dispatch path classify through
+// it, so the two can never disagree about what an encoding means.
+//
+// net/http already handles the dominant case before we get here: when the
+// outbound request carried no explicit Accept-Encoding, the transport adds
+// "gzip" itself, transparently decompresses a gzip answer and deletes
+// Content-Encoding / Content-Length from resp.Header — which lands here as
+// identity. This function therefore only ever sees an encoding the transport
+// refused to touch: a codec it does not implement (deflate/br/zstd), a
+// multi-layer stack, or a gzip answer that arrived on a transport which did
+// not negotiate it.
+func ClassifyUpstreamEncoding(h http.Header) UpstreamEncoding {
+	value := ""
+	if h != nil {
+		value = strings.TrimSpace(h.Get("Content-Encoding"))
+	}
+	if value == "" || strings.EqualFold(value, "identity") {
+		return UpstreamEncoding{Value: value, Kind: UpstreamEncodingIdentity}
+	}
+	// A single codec token only. RFC 9110 allows a stacked list ("gzip, br"),
+	// and peeling a stack we only partly understand would leave the body in a
+	// state neither we nor the client can describe — so a stack is treated as
+	// undecodable and relayed verbatim.
+	if !strings.Contains(value, ",") && decodableContentEncodings[strings.ToLower(value)] {
+		return UpstreamEncoding{Value: value, Kind: UpstreamEncodingDecodable}
+	}
+	return UpstreamEncoding{Value: value, Kind: UpstreamEncodingUndecodable}
+}
+
+// UpstreamBufferedBody is the buffered-body view the data plane parses and
+// relays. It is the single answer to "what do the bytes I just read mean?".
+type UpstreamBufferedBody struct {
+	// Bytes is what the caller must parse AND relay. Identity or freshly
+	// decoded bytes when Readable; the untouched encoded bytes otherwise.
+	Bytes []byte
+	// Readable reports whether Bytes is actual content. When false the caller
+	// MUST skip usage extraction and content judgement, record usage as
+	// unknown, and relay Bytes together with the upstream Content-Encoding.
+	Readable bool
+	// Encoding is the classification, for logging.
+	Encoding UpstreamEncoding
+	// DecodeErr carries the stdlib failure when a codec we do implement could
+	// not actually decode the body (corrupt, truncated, or the decoded size
+	// exceeded the buffered limit). Logging only — the honesty contract is the
+	// same as for an unsupported codec.
+	DecodeErr error
+}
+
+// NormalizeUpstreamBufferedBody applies the encoding decision to a buffered
+// upstream body. resp.Header is mutated exactly when the body was decoded: the
+// Content-Encoding is deleted so the existing relay whitelist cannot forward a
+// header that no longer describes the bytes we are about to write.
+func NormalizeUpstreamBufferedBody(h http.Header, body []byte) UpstreamBufferedBody {
+	enc := ClassifyUpstreamEncoding(h)
+	if !enc.Decodable() {
+		return UpstreamBufferedBody{Bytes: body, Readable: enc.Readable(), Encoding: enc}
+	}
+	decoded, err := decodeBufferedBody(enc.Value, body, MaxBufferedResponseBodyBytes())
+	if err != nil {
+		// We implement the codec but could not read this body. Same contract as
+		// an unsupported codec: never judge bytes we cannot parse, and hand the
+		// client exactly what the upstream sent.
+		return UpstreamBufferedBody{Bytes: body, Readable: false, Encoding: enc, DecodeErr: err}
+	}
+	if h != nil {
+		h.Del("Content-Encoding")
+	}
+	return UpstreamBufferedBody{Bytes: decoded, Readable: true, Encoding: enc}
+}
+
+// decodeBufferedBody decodes a whole buffered body, bounded by limit so a
+// highly-compressible upstream cannot turn a size-capped read into an unbounded
+// allocation.
+func decodeBufferedBody(codec string, body []byte, limit int64) ([]byte, error) {
+	switch strings.ToLower(codec) {
+	case "gzip", "x-gzip":
+		return readBounded(body, limit, func(r io.Reader) (io.ReadCloser, error) { return gzip.NewReader(r) })
+	case "deflate":
+		// HTTP "deflate" is zlib-wrapped (RFC 9110) in practice, but servers do
+		// emit raw DEFLATE (RFC 1951). Try zlib first, then raw flate — both are
+		// stdlib, and both verify their own trailing checksum on EOF.
+		decoded, err := readBounded(body, limit, func(r io.Reader) (io.ReadCloser, error) { return zlib.NewReader(r) })
+		if err == nil {
+			return decoded, nil
+		}
+		return readBounded(body, limit, func(r io.Reader) (io.ReadCloser, error) {
+			return flate.NewReader(r), nil
+		})
+	}
+	return nil, fmt.Errorf("proxy: no decoder for content encoding %q", codec)
+}
+
+func readBounded(body []byte, limit int64, newReader func(io.Reader) (io.ReadCloser, error)) ([]byte, error) {
+	reader, err := newReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	decoded, err := io.ReadAll(io.LimitReader(reader, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(decoded)) > limit {
+		return nil, fmt.Errorf("proxy: decoded upstream body exceeded buffered limit %d bytes", limit)
+	}
+	return decoded, nil
+}
+
+// UpstreamStreamBody is the streaming counterpart of UpstreamBufferedBody: the
+// same classification, plus a replacement reader when the codec is one we
+// implement.
+type UpstreamStreamBody struct {
+	// Reader replaces the upstream body when the stream must be decoded. Nil
+	// means "keep the body you already have" (identity, or undecodable).
+	Reader io.ReadCloser
+	// Readable reports whether the relayed chunks are actual SSE content. When
+	// false the SSE analyzer must not be fed and the content judge must not
+	// run; the chunks are relayed verbatim with the upstream Content-Encoding.
+	Readable bool
+	// Encoding is the classification, for logging.
+	Encoding UpstreamEncoding
+}
+
+// WrapUpstreamStreamBody applies the encoding decision to a streaming upstream
+// body. Decoding is lazy: the codec header is read on the first Read so this
+// call never blocks before the downstream SSE headers go out.
+func WrapUpstreamStreamBody(h http.Header, body io.ReadCloser) UpstreamStreamBody {
+	enc := ClassifyUpstreamEncoding(h)
+	if !enc.Decodable() {
+		return UpstreamStreamBody{Readable: enc.Readable(), Encoding: enc}
+	}
+	return UpstreamStreamBody{
+		Reader:   &lazyDecodeReader{codec: strings.ToLower(enc.Value), src: body},
+		Readable: true,
+		Encoding: enc,
+	}
+}
+
+// lazyDecodeReader decodes a stream on first Read. A single goroutine (the SSE
+// relay loop) ever touches it, so no locking is needed. Close always closes the
+// underlying body: the relay's idle guard closes through this reader to
+// interrupt a stalled Read, and the upstream connection must not leak.
+type lazyDecodeReader struct {
+	codec string
+	src   io.ReadCloser
+	dec   io.Reader
+	err   error
+}
+
+func (l *lazyDecodeReader) Read(p []byte) (int, error) {
+	if l.dec == nil && l.err == nil {
+		l.dec, l.err = newStreamDecoder(l.codec, l.src)
+	}
+	if l.err != nil {
+		return 0, l.err
+	}
+	return l.dec.Read(p)
+}
+
+func (l *lazyDecodeReader) Close() error {
+	if closer, ok := l.dec.(io.Closer); ok && closer != nil {
+		_ = closer.Close()
+	}
+	if l.src != nil {
+		return l.src.Close()
+	}
+	return nil
+}
+
+func newStreamDecoder(codec string, src io.Reader) (io.Reader, error) {
+	switch codec {
+	case "gzip", "x-gzip":
+		return gzip.NewReader(src)
+	case "deflate":
+		reader, err := zlib.NewReader(src)
+		if err == nil {
+			return reader, nil
+		}
+		return flate.NewReader(src), nil
+	}
+	return nil, fmt.Errorf("proxy: no decoder for content encoding %q", codec)
+}

--- a/proxy/upstream_encoding_test.go
+++ b/proxy/upstream_encoding_test.go
@@ -1,0 +1,334 @@
+package proxy
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"compress/zlib"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+)
+
+// The tests in this file pin the single encoding owner both dispatch paths
+// classify through, plus the judge's honest-abandonment short-circuit. The
+// end-to-end behaviour on the production dispatch path is pinned in
+// handler/proxy/upstream_encoding_honesty_test.go.
+
+func gzipBytes(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(raw); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func zlibBytes(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	if _, err := zw.Write(raw); err != nil {
+		t.Fatalf("zlib write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zlib close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func rawDeflateBytes(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	fw, err := flate.NewWriter(&buf, flate.DefaultCompression)
+	if err != nil {
+		t.Fatalf("flate writer: %v", err)
+	}
+	if _, err := fw.Write(raw); err != nil {
+		t.Fatalf("flate write: %v", err)
+	}
+	if err := fw.Close(); err != nil {
+		t.Fatalf("flate close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func headerWithEncoding(value string) http.Header {
+	h := http.Header{}
+	if value != "" {
+		h.Set("Content-Encoding", value)
+	}
+	h.Set("Content-Type", "application/json")
+	return h
+}
+
+func TestClassifyUpstreamEncoding(t *testing.T) {
+	cases := []struct {
+		value        string
+		wantKind     UpstreamEncodingKind
+		wantReadable bool
+		wantRelay    bool
+	}{
+		{value: "", wantKind: UpstreamEncodingIdentity, wantReadable: true, wantRelay: false},
+		{value: "identity", wantKind: UpstreamEncodingIdentity, wantReadable: true, wantRelay: false},
+		{value: "gzip", wantKind: UpstreamEncodingDecodable, wantReadable: true, wantRelay: false},
+		{value: "GZIP", wantKind: UpstreamEncodingDecodable, wantReadable: true, wantRelay: false},
+		{value: "  gzip  ", wantKind: UpstreamEncodingDecodable, wantReadable: true, wantRelay: false},
+		{value: "x-gzip", wantKind: UpstreamEncodingDecodable, wantReadable: true, wantRelay: false},
+		{value: "deflate", wantKind: UpstreamEncodingDecodable, wantReadable: true, wantRelay: false},
+		// Codecs the stdlib does not provide: never pretend to read them.
+		{value: "br", wantKind: UpstreamEncodingUndecodable, wantReadable: false, wantRelay: true},
+		{value: "zstd", wantKind: UpstreamEncodingUndecodable, wantReadable: false, wantRelay: true},
+		{value: "snappy", wantKind: UpstreamEncodingUndecodable, wantReadable: false, wantRelay: true},
+		// A stacked list is only partly understandable to us, so it is relayed
+		// verbatim rather than half-peeled.
+		{value: "gzip, br", wantKind: UpstreamEncodingUndecodable, wantReadable: false, wantRelay: true},
+		{value: "deflate, gzip", wantKind: UpstreamEncodingUndecodable, wantReadable: false, wantRelay: true},
+	}
+	for _, tc := range cases {
+		t.Run("value="+tc.value, func(t *testing.T) {
+			got := ClassifyUpstreamEncoding(headerWithEncoding(tc.value))
+			if got.Kind != tc.wantKind {
+				t.Fatalf("Kind = %v, want %v", got.Kind, tc.wantKind)
+			}
+			if got.Readable() != tc.wantReadable {
+				t.Fatalf("Readable() = %v, want %v", got.Readable(), tc.wantReadable)
+			}
+			if got.RelayHeader() != tc.wantRelay {
+				t.Fatalf("RelayHeader() = %v, want %v", got.RelayHeader(), tc.wantRelay)
+			}
+		})
+	}
+
+	t.Run("nil header is identity", func(t *testing.T) {
+		if got := ClassifyUpstreamEncoding(nil); got.Kind != UpstreamEncodingIdentity || !got.Readable() {
+			t.Fatalf("ClassifyUpstreamEncoding(nil) = %+v, want a readable identity", got)
+		}
+	})
+}
+
+func TestNormalizeUpstreamBufferedBody(t *testing.T) {
+	payload := []byte(`{"choices":[{"message":{"content":"hi"}}],"usage":{"total_tokens":18}}`)
+
+	t.Run("gzip is decoded and the header is dropped", func(t *testing.T) {
+		h := headerWithEncoding("gzip")
+		got := NormalizeUpstreamBufferedBody(h, gzipBytes(t, payload))
+		if !got.Readable {
+			t.Fatalf("Readable = false, want true (decode error: %v)", got.DecodeErr)
+		}
+		if !bytes.Equal(got.Bytes, payload) {
+			t.Fatalf("Bytes = %q, want the decoded payload", got.Bytes)
+		}
+		// The relay whitelist copies from resp.Header, so the header must be gone
+		// once the bytes it described are gone.
+		if v := h.Get("Content-Encoding"); v != "" {
+			t.Fatalf("Content-Encoding after decode = %q, want empty", v)
+		}
+	})
+
+	t.Run("zlib-wrapped deflate is decoded", func(t *testing.T) {
+		h := headerWithEncoding("deflate")
+		got := NormalizeUpstreamBufferedBody(h, zlibBytes(t, payload))
+		if !got.Readable || !bytes.Equal(got.Bytes, payload) {
+			t.Fatalf("got %+v (err %v), want the decoded payload", got, got.DecodeErr)
+		}
+		if v := h.Get("Content-Encoding"); v != "" {
+			t.Fatalf("Content-Encoding after decode = %q, want empty", v)
+		}
+	})
+
+	t.Run("raw deflate is decoded", func(t *testing.T) {
+		h := headerWithEncoding("deflate")
+		got := NormalizeUpstreamBufferedBody(h, rawDeflateBytes(t, payload))
+		if !got.Readable || !bytes.Equal(got.Bytes, payload) {
+			t.Fatalf("got %+v (err %v), want the decoded payload", got, got.DecodeErr)
+		}
+	})
+
+	t.Run("undecodable bytes are relayed verbatim under their header", func(t *testing.T) {
+		opaque := []byte{0x8b, 0x21, 0x00, 0xff, 'n', 'o', 't', ' ', 'j', 's', 'o', 'n'}
+		h := headerWithEncoding("br")
+		got := NormalizeUpstreamBufferedBody(h, opaque)
+		if got.Readable {
+			t.Fatal("Readable = true for a br body — we must never pretend to read bytes we cannot decode")
+		}
+		if !bytes.Equal(got.Bytes, opaque) {
+			t.Fatalf("Bytes = %v, want the original bytes untouched", got.Bytes)
+		}
+		if v := h.Get("Content-Encoding"); v != "br" {
+			t.Fatalf("Content-Encoding = %q, want it preserved for the verbatim relay", v)
+		}
+		if !got.Encoding.RelayHeader() {
+			t.Fatal("RelayHeader() = false, want true")
+		}
+	})
+
+	t.Run("a corrupt gzip body is unreadable, not half-decoded", func(t *testing.T) {
+		broken := gzipBytes(t, payload)
+		broken[len(broken)-3] ^= 0xff
+		h := headerWithEncoding("gzip")
+		got := NormalizeUpstreamBufferedBody(h, broken)
+		if got.Readable {
+			t.Fatal("Readable = true for a corrupt gzip body")
+		}
+		if got.DecodeErr == nil {
+			t.Fatal("DecodeErr = nil, want the stdlib failure for logging")
+		}
+		if !bytes.Equal(got.Bytes, broken) {
+			t.Fatal("Bytes were mutated; the verbatim relay must keep exactly what the upstream sent")
+		}
+		if v := h.Get("Content-Encoding"); v != "gzip" {
+			t.Fatalf("Content-Encoding = %q, want it preserved (the bytes are still encoded)", v)
+		}
+	})
+
+	t.Run("a decode that exceeds the buffered limit stays unreadable", func(t *testing.T) {
+		prev := config.GetSafe()
+		config.Set(&config.Config{ProxyMaxBufferedResponseBytes: 16})
+		t.Cleanup(func() { config.Set(prev) })
+
+		h := headerWithEncoding("gzip")
+		got := NormalizeUpstreamBufferedBody(h, gzipBytes(t, payload))
+		if got.Readable {
+			t.Fatalf("Readable = true although the decoded body (%d bytes) exceeds the 16-byte limit", len(got.Bytes))
+		}
+		if got.DecodeErr == nil || !strings.Contains(got.DecodeErr.Error(), "buffered limit") {
+			t.Fatalf("DecodeErr = %v, want the limit error", got.DecodeErr)
+		}
+	})
+
+	t.Run("identity bodies are untouched", func(t *testing.T) {
+		h := headerWithEncoding("")
+		got := NormalizeUpstreamBufferedBody(h, payload)
+		if !got.Readable || !bytes.Equal(got.Bytes, payload) {
+			t.Fatalf("got %+v, want the identity payload readable", got)
+		}
+	})
+}
+
+func TestWrapUpstreamStreamBody(t *testing.T) {
+	events := []byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n")
+
+	t.Run("a gzip stream is decoded inline", func(t *testing.T) {
+		wrapped := WrapUpstreamStreamBody(headerWithEncoding("gzip"), io.NopCloser(bytes.NewReader(gzipBytes(t, events))))
+		if wrapped.Reader == nil {
+			t.Fatal("Reader = nil, want a decoding reader")
+		}
+		if !wrapped.Readable {
+			t.Fatal("Readable = false, want true")
+		}
+		got, err := io.ReadAll(wrapped.Reader)
+		if err != nil {
+			t.Fatalf("read decoded stream: %v", err)
+		}
+		if !bytes.Equal(got, events) {
+			t.Fatalf("decoded stream = %q, want %q", got, events)
+		}
+	})
+
+	t.Run("a deflate stream is decoded inline", func(t *testing.T) {
+		wrapped := WrapUpstreamStreamBody(headerWithEncoding("deflate"), io.NopCloser(bytes.NewReader(zlibBytes(t, events))))
+		if wrapped.Reader == nil || !wrapped.Readable {
+			t.Fatalf("got %+v, want a readable decoding reader", wrapped)
+		}
+		got, err := io.ReadAll(wrapped.Reader)
+		if err != nil {
+			t.Fatalf("read decoded stream: %v", err)
+		}
+		if !bytes.Equal(got, events) {
+			t.Fatalf("decoded stream = %q, want %q", got, events)
+		}
+	})
+
+	t.Run("an undecodable stream keeps the original body and stays unreadable", func(t *testing.T) {
+		wrapped := WrapUpstreamStreamBody(headerWithEncoding("br"), io.NopCloser(bytes.NewReader(events)))
+		if wrapped.Reader != nil {
+			t.Fatal("Reader != nil — the relay must keep the upstream body verbatim")
+		}
+		if wrapped.Readable {
+			t.Fatal("Readable = true for a br stream")
+		}
+		if !wrapped.Encoding.RelayHeader() {
+			t.Fatal("RelayHeader() = false, want the verbatim passthrough to keep Content-Encoding")
+		}
+	})
+
+	t.Run("closing the decoder closes the underlying body", func(t *testing.T) {
+		src := &closeCountingReader{Reader: bytes.NewReader(gzipBytes(t, events))}
+		wrapped := WrapUpstreamStreamBody(headerWithEncoding("gzip"), src)
+		if _, err := io.ReadAll(wrapped.Reader); err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if err := wrapped.Reader.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+		if src.closes != 1 {
+			t.Fatalf("underlying Close calls = %d, want exactly 1 (the SSE idle guard closes through this reader)", src.closes)
+		}
+	})
+}
+
+type closeCountingReader struct {
+	io.Reader
+	closes int
+}
+
+func (c *closeCountingReader) Close() error {
+	c.closes++
+	return nil
+}
+
+// TestJudgeUpstreamContent_UnreadableBody pins the honest-abandonment rule on the
+// single content judge: no readable content evidence means no verdict, however
+// aggressive the operator's detection settings are.
+func TestJudgeUpstreamContent_UnreadableBody(t *testing.T) {
+	setupFailureCfg([]string{"overloaded", "blocked"}, true)
+
+	t.Run("empty-content rule must not fire on unreadable bytes", func(t *testing.T) {
+		got := JudgeUpstreamContent(UpstreamContentFacts{
+			StatusCode: http.StatusOK,
+			HasOutput:  false,
+			Usage:      &UsageSummary{},
+			Unreadable: true,
+		})
+		if got.Failed {
+			t.Fatalf("verdict = %+v, want pass: an undecodable body is not evidence of an empty answer", got)
+		}
+		if got.Code != FailureCodeNone {
+			t.Fatalf("code = %q, want %q", got.Code, FailureCodeNone)
+		}
+	})
+
+	t.Run("keyword rule must not fire on unreadable bytes", func(t *testing.T) {
+		got := JudgeUpstreamContent(UpstreamContentFacts{
+			StatusCode: http.StatusOK,
+			RawText:    "blocked",
+			Unreadable: true,
+		})
+		if got.Failed {
+			t.Fatalf("verdict = %+v, want pass: the caller must not hand noise to the keyword scan", got)
+		}
+	})
+
+	t.Run("streaming facts with no data events are still judged when readable", func(t *testing.T) {
+		// Guard against the short-circuit leaking into the readable stream path:
+		// the very same facts minus Unreadable MUST fail under
+		// PROXY_EMPTY_CONTENT_FAIL, otherwise the flag would be dead.
+		got := JudgeUpstreamContent(UpstreamContentFacts{
+			StatusCode: http.StatusOK,
+			Streaming:  true,
+			HasOutput:  false,
+			Usage:      &UsageSummary{},
+		})
+		if !got.Failed || got.Code != FailureCodeEmptyContent {
+			t.Fatalf("verdict = %+v, want an empty-content failure", got)
+		}
+	})
+}

--- a/service/account_service.go
+++ b/service/account_service.go
@@ -401,9 +401,18 @@ func filterPlatformCustomHeaders(headers map[string]string) map[string]string {
 	return filtered
 }
 
+// isReservedPlatformCustomHeader is the assembly-side filter for site
+// custom_headers: what a site may not inject into the platform proxy config.
+// It is deliberately narrower than platform.IsDeniedCustomHeader (it also
+// reserves content-type and new-api-user, which the data plane owns) but the
+// security-critical set must stay in step with it — see
+// TestReservedPlatformCustomHeadersStayInStepWithPlatformDenyList.
 func isReservedPlatformCustomHeader(name string) bool {
 	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "authorization", "cookie", "new-api-user", "content-type", "content-length", "host":
+	// accept-encoding decides whether the response body stays readable for
+	// usage accounting, content-failure judgement and health checks, so it is
+	// not site-configurable (same rule as platform.IsDeniedCustomHeader).
+	case "authorization", "cookie", "new-api-user", "content-type", "content-length", "host", "accept-encoding":
 		return true
 	default:
 		return false

--- a/service/custom_headers_filter_test.go
+++ b/service/custom_headers_filter_test.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/platform"
+)
+
+// The assembly-side filter and the data-plane deny list are two guards over the
+// same site-supplied map. They are allowed to differ in scope (the assembly side
+// also reserves content-type and new-api-user, which the data plane owns), but a
+// header that is security- or correctness-critical must be denied by BOTH: if
+// only one of them denies it, whichever path builds the request last wins. That
+// is exactly how Accept-Encoding used to slip through — it reached the outbound
+// request via platform.SiteProxy.Do re-applying custom_headers after the data
+// plane had stripped it, which switched off transparent decoding and turned a
+// healthy upstream answer into unreadable bytes (zero-token billing, blind
+// keyword scan, and a false "empty content" 502 on the SSE path).
+func TestReservedPlatformCustomHeadersStayInStepWithPlatformDenyList(t *testing.T) {
+	t.Parallel()
+	shared := []string{
+		"authorization",
+		"cookie",
+		"host",
+		"content-length",
+		"accept-encoding",
+	}
+	for _, name := range shared {
+		for _, variant := range []string{name, upper(name), "  " + name + " "} {
+			if !isReservedPlatformCustomHeader(variant) {
+				t.Errorf("isReservedPlatformCustomHeader(%q) = false, want true (assembly-side filter must deny it)", variant)
+			}
+			if !platform.IsDeniedCustomHeader(variant) {
+				t.Errorf("platform.IsDeniedCustomHeader(%q) = false, want true (data-plane deny list must deny it)", variant)
+			}
+		}
+	}
+}
+
+func TestFilterPlatformCustomHeadersDropsReservedKeepsSiteOwn(t *testing.T) {
+	t.Parallel()
+	filtered := filterPlatformCustomHeaders(map[string]string{
+		"Authorization":   "Bearer site-supplied",
+		"Cookie":          "session=hijacked",
+		"Accept-Encoding": "br",
+		"Content-Type":    "text/plain",
+		"Host":            "attacker.example",
+		"Content-Length":  "17",
+		"New-Api-User":    "4242",
+		"X-Site-Header":   "kept",
+	})
+	if got := filtered["X-Site-Header"]; got != "kept" {
+		t.Errorf("a site's own header must survive the filter, got %q", got)
+	}
+	for _, denied := range []string{"Authorization", "Cookie", "Accept-Encoding", "Content-Type", "Host", "Content-Length", "New-Api-User"} {
+		if _, ok := filtered[denied]; ok {
+			t.Errorf("%s survived filterPlatformCustomHeaders, want it dropped", denied)
+		}
+	}
+	if len(filtered) != 1 {
+		t.Errorf("filtered map has %d entries (%v), want exactly the 1 site-owned header", len(filtered), filtered)
+	}
+	if got := filterPlatformCustomHeaders(nil); got != nil {
+		t.Errorf("filterPlatformCustomHeaders(nil) = %v, want nil", got)
+	}
+	if got := filterPlatformCustomHeaders(map[string]string{"Authorization": "x"}); got != nil {
+		t.Errorf("a map whose every entry is reserved must collapse to nil, got %v", got)
+	}
+}
+
+func upper(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}


### PR DESCRIPTION
## 改动摘要

一个站点 `custom_headers` 里的 `Accept-Encoding` 就能让数据面对上游答案**读不见**，而这个头是站点可配的。net/http 只在「请求没有显式 `Accept-Encoding`」时才自己协商 `gzip` 并透明解压；一旦该头出现在出站请求上，透明解压就关掉了，答案以压缩字节进入我们的解析：

- **漏账**：用量提取找不到 token ⇒ 记 `usage_source=unknown`、`total_tokens=0`，一次真实调用计零费；
- **假成功**：`PROXY_ERROR_KEYWORDS` 扫的是压缩噪声，命中不了；
- **假失败**（最严重）：SSE 路径的有界分析器读不到任何 `data:` 事件 ⇒ `HasOutput=false`，开了 `PROXY_EMPTY_CONTENT_FAIL` 时一个完全健康的 200 流被记成 502「空内容」失败，**毒化渠道健康度**；
- 反向也漏：上游忽略协商、或用我们不实现的编码（`br`/`zstd`）时，buffered 中继可能转发一个已经不再描述我们所重构字节的 `Content-Encoding`，而流式中继会去重构它根本读不懂的字节。

`proxy/upstream_encoding.go` 现在是这个判定的**唯一所有者**，两条分发路径都通过它分类：

- `gzip` / `deflate` 用标准库解码（先 zlib，再退回部分服务器发出的 raw DEFLATE），解码后才解析、判定、重构，且不再带 `Content-Encoding`。**零新依赖**：`br` / `zstd` 刻意不解码。
- 解不了的（`br`、`zstd`、多层编码栈、或在损坏/超大 body 上解码失败）分类为**不可读**：原样连同它自己的 `Content-Encoding` 转发给客户端（客户端仍能解），**绝不解析、绝不折算 token**（用量记为显式的 `unknown`）。
- `UpstreamContentFacts` 新增 `Unreadable`，`JudgeUpstreamContent` 在它上面**直接 pass**：关键字规则与空内容规则都不许在没人读过的字节上开火。#1159 建立的唯一判官仍是唯一判官，流式路径喂同一份事实，没有长出平行规则。
- 数据面既剥出站请求上的 `Accept-Encoding`，**也剥构造它的那份 `custom_headers` map**（站点代理路径会在请求构造完之后再次 apply 该 map），并按 site/channel/value 去重打一次 WARN——它描述的是一个静态配置错误。
- 账实差距通过一条稳定文案的 WARN 变可见，不再静默：`upstream response uses a content encoding metapi does not decode; usage accounting and content-failure judgement were skipped`。

**第二个提交把根治补到准入侧**（数据面之外，两处过滤清单都不知道这条规则，剥头因此曾是唯一防线）：`platform.IsDeniedCustomHeader` 与 `service.isReservedPlatformCustomHeader` 现在都拒绝 `accept-encoding`，并新增一个跨包门禁把两份清单的**安全关键交集**钉在一起，防止再次漂移。纵深生效的实证：摘掉数据面的 map 剥离后，走真实 forward proxy 的站点代理端到端用例**仍然绿**（准入侧接住了），只有单元级守卫红——两层各尽其职。

## 类型

- [x] fix（bug 修复：漏账 / 假成功 / 假失败）
- [x] refactor（编码判定收口到唯一所有者）

## 行为变更（需要进 CHANGELOG）

- 上游返回 `gzip` / `deflate` 时，Metapi 解码后再判定与计费，转发给客户端的响应**不再带** `Content-Encoding`（字节由 Metapi 重构）。
- 上游返回 Metapi 不解码的编码时：body 与它的 `Content-Encoding` **原样转发**，用量记 `unknown`（不凭空造 token），不触发关键字/空内容失败判定，并打一条 WARN。此前这种响应在流式路径上会被记成 502 失败。
- 站点 `custom_headers` 里的 `Accept-Encoding` 不再生效（装配侧过滤 + 出站剥离，各一次 WARN）。
- `docs/configuration.md` 新增「Upstream content encoding」节，`docs/api/proxy.md` 的头策略两个方向都写明该头的处置。

## 测试验证

- [x] `go build ./...` / `go vet ./...` 通过；`gofmt -l` 对本 PR 触及的 `.go` 文件为空（`platform/custom_headers_test.go` 是仓库既有漂移文件，因为本次要在其中加断言，顺手把它整成 gofmt-clean，多出的是 10 行纯空白对齐）
- [x] `go test ./handler/proxy/... ./proxy/... ./platform/... ./service/ ./docs/ -count=1 -tags=integration -p 1`（带 `PG_TEST_DSN`）全绿：`handler/proxy 7.9s · proxy 1.7s · platform 14.2s · service 3.7s · docs 1.9s`
- [x] `go test ./handler/proxy/... ./proxy/... -count=1 -race` 全绿（`handler/proxy 41.2s`）
- [x] 新增测试 1171 行 + 准入侧 2 条：8 条走 `HandleChatCompletions` 生产分发路径（含真实 forward proxy + `Site.ProxyURL` 的站点代理路径）、2 条数据面胶水、4 条纯函数、2 条跨守卫漂移门禁。用例数 525 → 540（+15），SKIP 0 → 0，FAIL 0
- [x] **变异探针 red → green（交付方 5 条 + 集成方独立复跑 2 条）**：
  - 集成方 M1：摘掉数据面的 `custom_headers` map 剥离 → `TestStripUpstreamAcceptEncodingClearsCustomHeadersSource` FAIL（`custom_headers still carries "accept-encoding" — platform would re-apply it on the site-proxy path`）
  - 集成方 M2：摘掉 `JudgeUpstreamContent` 的 `Unreadable` 短路 → 3 条 FAIL：纯函数层 `{Failed:true Code:upstream_empty_content Status:502}` 与 `{... upstream_error_keyword ...}` 均 want pass，端到端层 `TestUndecodableStreamBodyIsNotRecordedAsFailure` 与 `TestUndecodableBufferedBodyIsRelayedVerbatimWithoutFailure` 均为 `recordUpstreamFailure calls = 1 … want 0`
  - 交付方另有：出站 `Accept-Encoding: br` 真的上了线（改前红）、`deflate` body 漏账（改前 `usage_source:"unknown" total_tokens:0`，改后 11/7/18 入账）、编码 body 里的错误关键字扫不出来（改前 200，改后 502）
  - 两次还原均 `sha256sum -c` 一致、`grep B3-MUTATION` 零命中、复跑全绿
- [x] **锚点用例改前改后都绿**（证明默认路径本来就没坏，本 PR 不是把好用例改绿）：透明 gzip 路径断言出站确实带 Go 自加的 `gzip`、body 被透明解压、11/7/18 入账、下游无 `Content-Encoding`
- [x] 一处对派单前提的实测校正：`PROXY_EMPTY_CONTENT_FAIL` 的假失败在 **buffered 路径改前并不触发**（`detectHasUpstreamOutput` 对「非 JSON 且不含 `data:`」的二进制字节返回 true），100% 可复现的是**流式路径**；buffered 路径改前的真实损害是漏账 + 关键字失明 + 静默无 WARN。修复后 buffered 不可读时 `RawText` 被显式置空，所以 `Unreadable` 短路在 buffered 路径上同样承重（M2 已证）

## 自查清单

- [x] 无密钥/内部路径泄漏（注释一律仓库相对路径）
- [x] 无新增用户可见文案（WARN 是运维日志，文案稳定以便告警匹配）
- [x] 行为变更已补测试 + 已同步 `docs/configuration.md` 与 `docs/api/proxy.md`
- [x] 无 schema 变更、无新依赖、无新 env 变量

## 故意没做（已记录）

1. **不解码 `br` / `zstd`**：需要新依赖。改为诚实分类 + 原样转发 + WARN + 用量记 `unknown`。
2. **`handler/proxy/channel_health_probe.go` 不改**：探测只看状态码，body 是 `io.Copy(io.Discard, LimitReader(…, 8KiB))` 丢掉的，不判定/不计费/不写日志 ⇒ 无假失败与漏账风险；且准入侧根治后它自动被覆盖。
3. **不清洗不可解码 error body 写进 `proxy_logs.error_message` 的二进制字节**（既有行为，本 PR 未加剧；可解码的情形已被修成可读文本）。若要修需在该处对不可读用占位文案——涉及 DB 可见语义，留待裁决。
4. `proxy/executor.go` 的 `Dispatch` / `WithObservedFirstByte` 不改：生产路径无调用方（只有其自身测试用），数据面走 `DoWithObservedFirstByte` / `DoStreamWithObservedFirstByte`。
5. `internal/httpclient/**` 经查**无越界事实**：全仓 `DisableCompression` 零命中，`NewTransport` 不设 `Accept-Encoding`；非测试代码里唯一自设该头的是 `router/gzip.go`（下游 SPA 静态资源压缩，与出站无关）。
