### PR TITLE
fix(checkin,oauth): make the waits between upstream calls cancellable

### DIFF
--- a/handler/admin/checkin_routes.go
+++ b/handler/admin/checkin_routes.go
@@ -31,8 +31,14 @@ type checkinHandler struct {
 }
 
 // POST /api/checkin/trigger
+//
+// The round carries the request context: if the caller goes away the same-site
+// pacing wait ends and the remaining accounts are skipped instead of being
+// checked in for a response nobody will read. Every account already processed
+// keeps its own checkin_logs row, so a cancelled round leaves an honest partial
+// result rather than a half-written one.
 func (h *checkinHandler) triggerAll(w http.ResponseWriter, r *http.Request) {
-	results := checkinservice.CheckinAll(h.cfg, h.db, nil, "manual")
+	results := checkinservice.CheckinAllContext(r.Context(), h.cfg, h.db, nil, "manual")
 	summary := summarizeCheckinResults(results)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"success": summary.Failed == 0,

--- a/scheduler/checkin.go
+++ b/scheduler/checkin.go
@@ -42,9 +42,12 @@ type CheckinScheduler struct {
 	cancel context.CancelFunc
 
 	// checkinAll is the checkin execution function. Defaults to
-	// checkin.CheckinAll; overridable in tests to inject a mock that records
-	// calls without touching real upstreams.
-	checkinAll func(cfg *config.Config, db *sqlx.DB, accountIDs []int64, scheduleMode string) []checkin.CheckinAllResult
+	// checkin.CheckinAllContext, so the round carries the job ctx (derived from
+	// the lifecycle ctx) and its same-site pacing wait ends when Stop() is
+	// called instead of sleeping out the remaining accounts; overridable in
+	// tests to inject a mock that records calls without touching real
+	// upstreams.
+	checkinAll func(ctx context.Context, cfg *config.Config, db *sqlx.DB, accountIDs []int64, scheduleMode string) []checkin.CheckinAllResult
 }
 
 // NewCheckinScheduler creates a new checkin scheduler.
@@ -53,7 +56,7 @@ func NewCheckinScheduler(cfg *config.Config) *CheckinScheduler {
 		cfg:              cfg,
 		mode:             config.Runtime().CheckinScheduleMode,
 		attemptByAccount: make(map[int64]int64),
-		checkinAll:       checkin.CheckinAll,
+		checkinAll:       checkin.CheckinAllContext,
 		ctx:              context.Background(),
 	}
 }
@@ -253,7 +256,7 @@ func (s *CheckinScheduler) runStaleAccountCatchUp(dbw *store.DB) {
 	jobCtx, cancel := context.WithTimeout(s.ctx, checkinJobTimeout)
 	defer cancel()
 	runWithSchedulerLease(jobCtx, dbw, s.Name(), func() {
-		results := checkin.CheckinAll(s.cfg, dbw.DB, staleIDs, "catchup")
+		results := checkin.CheckinAllContext(jobCtx, s.cfg, dbw.DB, staleIDs, "catchup")
 		ok, bad := countResults(results)
 		slog.Info("checkin: stale account catch-up done", "enqueued", len(staleIDs), "success", ok, "failed", bad)
 	})
@@ -400,7 +403,7 @@ func (s *CheckinScheduler) runCronJob() {
 	jobCtx, cancel := context.WithTimeout(s.ctx, checkinJobTimeout)
 	defer cancel()
 	runWithSchedulerLease(jobCtx, dbw, s.Name(), func() {
-		results := checkin.CheckinAll(s.cfg, dbw.DB, nil, "cron")
+		results := checkin.CheckinAllContext(jobCtx, s.cfg, dbw.DB, nil, "cron")
 		ok, bad := countResults(results)
 		slog.Info("checkin: cron job done", "success", ok, "failed", bad)
 	})
@@ -417,11 +420,15 @@ func (s *CheckinScheduler) runIntervalPass() {
 	jobCtx, cancel := context.WithTimeout(s.ctx, checkinJobTimeout)
 	defer cancel()
 	runWithSchedulerLease(jobCtx, dbw, s.Name(), func() {
-		s.runIntervalPassLocked(dbw)
+		s.runIntervalPassLocked(jobCtx, dbw)
 	})
 }
 
-func (s *CheckinScheduler) runIntervalPassLocked(dbw *store.DB) {
+// runIntervalPassLocked runs one interval pass. ctx is the job ctx (derived
+// from the lifecycle ctx): it is what the checkin round's pacing wait is
+// cancellable by, so Stop() ends a pass instead of leaving it sleeping between
+// accounts of the same site.
+func (s *CheckinScheduler) runIntervalPassLocked(ctx context.Context, dbw *store.DB) {
 	now := time.Now()
 
 	// Query all account+site pairs
@@ -463,7 +470,7 @@ func (s *CheckinScheduler) runIntervalPassLocked(dbw *store.DB) {
 		return
 	}
 
-	results := s.checkinAll(s.cfg, dbw.DB, dueIDs, "interval")
+	results := s.checkinAll(ctx, s.cfg, dbw.DB, dueIDs, "interval")
 
 	nowMs := now.UnixMilli()
 	s.mu.Lock()

--- a/scheduler/checkin_test.go
+++ b/scheduler/checkin_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -20,8 +21,8 @@ func strPtr(s string) *string { return &s }
 
 // newTestCheckinScheduler builds a CheckinScheduler in interval mode with the
 // given interval hours. The checkinAll hook is left at its production default
-// (checkin.CheckinAll); tests that need to inject a mock override it after
-// construction.
+// (checkin.CheckinAllContext); tests that need to inject a mock override it
+// after construction.
 func newTestCheckinScheduler(t *testing.T, intervalHours int) *CheckinScheduler {
 	t.Helper()
 	config.SetRuntime(&config.RuntimeSettings{
@@ -174,7 +175,7 @@ func TestFilterDue_ClampsIntervalHours(t *testing.T) {
 	s := &CheckinScheduler{
 		cfg:              &config.Config{},
 		attemptByAccount: make(map[int64]int64),
-		checkinAll:       checkin.CheckinAll,
+		checkinAll:       checkin.CheckinAllContext,
 	}
 	got := s.filterDue([]intervalCandidate{{id: 1, lastCheckinAt: strPtr(recent)}}, now)
 	if len(got) != 0 {
@@ -352,7 +353,7 @@ func TestRunIntervalPassLocked_CallsCheckinForDueAccountsOnly(t *testing.T) {
 		calledIDs []int64
 		callCount int32
 	)
-	s.checkinAll = func(_ *config.Config, _ *sqlx.DB, ids []int64, mode string) []checkin.CheckinAllResult {
+	s.checkinAll = func(_ context.Context, _ *config.Config, _ *sqlx.DB, ids []int64, mode string) []checkin.CheckinAllResult {
 		atomic.AddInt32(&callCount, 1)
 		calledIDs = make([]int64, len(ids))
 		copy(calledIDs, ids)
@@ -369,7 +370,7 @@ func TestRunIntervalPassLocked_CallsCheckinForDueAccountsOnly(t *testing.T) {
 		return results
 	}
 
-	s.runIntervalPassLocked(db)
+	s.runIntervalPassLocked(context.Background(), db)
 
 	if callCount != 1 {
 		t.Fatalf("checkinAll called %d times, want 1", callCount)
@@ -404,12 +405,12 @@ func TestRunIntervalPassLocked_NoDueAccountsDoesNotCallCheckin(t *testing.T) {
 	s := NewCheckinScheduler(&config.Config{})
 
 	var callCount int32
-	s.checkinAll = func(_ *config.Config, _ *sqlx.DB, _ []int64, _ string) []checkin.CheckinAllResult {
+	s.checkinAll = func(_ context.Context, _ *config.Config, _ *sqlx.DB, _ []int64, _ string) []checkin.CheckinAllResult {
 		atomic.AddInt32(&callCount, 1)
 		return nil
 	}
 
-	s.runIntervalPassLocked(db)
+	s.runIntervalPassLocked(context.Background(), db)
 
 	if callCount != 0 {
 		t.Fatalf("checkinAll called %d times, want 0 (no due accounts)", callCount)
@@ -435,7 +436,7 @@ func TestRunIntervalPassLocked_FailedResultsStillUpdateAttemptMap(t *testing.T) 
 	t.Cleanup(func() { config.SetRuntime(nil) })
 	s := NewCheckinScheduler(&config.Config{})
 
-	s.checkinAll = func(_ *config.Config, _ *sqlx.DB, ids []int64, _ string) []checkin.CheckinAllResult {
+	s.checkinAll = func(_ context.Context, _ *config.Config, _ *sqlx.DB, ids []int64, _ string) []checkin.CheckinAllResult {
 		results := make([]checkin.CheckinAllResult, 0, len(ids))
 		for _, id := range ids {
 			results = append(results, checkin.CheckinAllResult{
@@ -446,7 +447,7 @@ func TestRunIntervalPassLocked_FailedResultsStillUpdateAttemptMap(t *testing.T) 
 		return results
 	}
 
-	s.runIntervalPassLocked(db)
+	s.runIntervalPassLocked(context.Background(), db)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -478,7 +479,7 @@ func TestRunIntervalPass_OverridesDBAndCallsCheckin(t *testing.T) {
 	s := NewCheckinScheduler(&config.Config{})
 
 	var calledIDs []int64
-	s.checkinAll = func(_ *config.Config, _ *sqlx.DB, ids []int64, _ string) []checkin.CheckinAllResult {
+	s.checkinAll = func(_ context.Context, _ *config.Config, _ *sqlx.DB, ids []int64, _ string) []checkin.CheckinAllResult {
 		calledIDs = append(calledIDs, ids...)
 		return nil
 	}
@@ -487,5 +488,66 @@ func TestRunIntervalPass_OverridesDBAndCallsCheckin(t *testing.T) {
 
 	if len(calledIDs) != 1 || calledIDs[0] != dueID {
 		t.Fatalf("calledIDs = %v, want [%d]", calledIDs, dueID)
+	}
+}
+
+// ---- the round ctx is the lifecycle ctx, not a bare Background ----
+//
+// checkin.CheckinAllContext exists so a round's same-site pacing wait can end
+// when the scheduler stops. That is only true if the callers actually hand it a
+// ctx derived from the lifecycle: runIntervalPass builds jobCtx from s.ctx, and
+// the mock below asserts the derivation from inside the round (after
+// runIntervalPass returns, its deferred cancel has already fired, so an
+// assertion on the outside would pass for the wrong reason).
+func TestRunIntervalPass_RoundContextDiesWithTheSchedulerLifecycle(t *testing.T) {
+	db := setupIntervalTestDB(t)
+	store.OverrideDB(db)
+	t.Cleanup(func() { store.OverrideDB(nil) })
+
+	activeSite := insertIntervalTestSite(t, db, "lifecycle-site", "active")
+	insertIntervalTestAccount(t, db, activeSite, "lifecycle-due", "active", "", true)
+
+	config.SetRuntime(&config.RuntimeSettings{
+		CheckinScheduleMode:  "interval",
+		CheckinIntervalHours: 6,
+	})
+	t.Cleanup(func() { config.SetRuntime(nil) })
+
+	s := NewCheckinScheduler(&config.Config{})
+	lifeCtx, lifeCancel := context.WithCancel(context.Background())
+	defer lifeCancel()
+	s.ctx = lifeCtx
+	s.cancel = lifeCancel
+
+	problems := make(chan string, 4)
+	called := make(chan struct{}, 1)
+	s.checkinAll = func(ctx context.Context, _ *config.Config, _ *sqlx.DB, _ []int64, _ string) []checkin.CheckinAllResult {
+		called <- struct{}{}
+		if ctx == nil || ctx == context.Background() {
+			problems <- "the round ran on a bare context.Background(): Stop() cannot end its pacing wait"
+			return nil
+		}
+		if _, hasJobTimeout := ctx.Deadline(); !hasJobTimeout {
+			problems <- "the round ctx carries no job timeout (want it derived from context.WithTimeout(s.ctx, checkinJobTimeout))"
+		}
+		lifeCancel() // exactly what Stop() does to an in-flight pass
+		select {
+		case <-ctx.Done():
+		case <-time.After(2 * time.Second):
+			problems <- "cancelling the lifecycle ctx did not reach the round ctx"
+		}
+		return nil
+	}
+
+	s.runIntervalPass()
+
+	select {
+	case <-called:
+	default:
+		t.Fatal("checkinAll was never called; the pass did not reach the round")
+	}
+	close(problems)
+	for problem := range problems {
+		t.Error(problem)
 	}
 }

--- a/service/checkin/cancellable_waits_test.go
+++ b/service/checkin/cancellable_waits_test.go
@@ -1,0 +1,241 @@
+package checkin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/config"
+)
+
+// Every wait that sits between two network calls has to be cancellable,
+// otherwise a shutdown or an exhausted budget still pays the full sleep and the
+// upstream call that follows it. This package has two such waits: the
+// transient-retry backoff inside CheckinAccount (2-3s) and the same-site pacing
+// inside a CheckinAll round (~1s per account). Both used to be a bare
+// time.Sleep.
+//
+// Each test below drives the real entry point against an httptest upstream and
+// pins three properties: the wait is cut short, the outcome carries ctx.Err()
+// semantics, and no further upstream call is made after the cancellation.
+
+// upstreamHit records one request the test upstream served.
+type upstreamHit struct {
+	path string
+	at   time.Time
+}
+
+// hitLog collects upstream hits so a test can assert both how many calls
+// happened and whether any of them landed after the ctx ended.
+type hitLog struct {
+	mu   sync.Mutex
+	hits []upstreamHit
+}
+
+func (l *hitLog) record(path string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.hits = append(l.hits, upstreamHit{path: path, at: time.Now()})
+}
+
+func (l *hitLog) count(path string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	n := 0
+	for _, h := range l.hits {
+		if h.path == path {
+			n++
+		}
+	}
+	return n
+}
+
+// after reports how many hits landed at or after the given instant.
+func (l *hitLog) after(cutoff time.Time) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	n := 0
+	for _, h := range l.hits {
+		if !h.at.Before(cutoff) {
+			n++
+		}
+	}
+	return n
+}
+
+func (l *hitLog) snapshot() []upstreamHit {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]upstreamHit(nil), l.hits...)
+}
+
+// newTransientCheckinServer answers /api/user/checkin with a 429, which
+// classifies as a transient failure and therefore makes CheckinAccount enter its
+// retry backoff. Every request is recorded with its arrival time.
+func newTransientCheckinServer(t *testing.T) (*httptest.Server, *hitLog) {
+	t.Helper()
+	log := &hitLog{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.record(r.URL.Path)
+		if r.URL.Path != "/api/user/checkin" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"success":false,"message":"rate limited"}`))
+	}))
+	t.Cleanup(server.Close)
+	return server, log
+}
+
+// TestCheckinAccount_TransientRetryBackoffHonoursContext pins the backoff before
+// the single transient retry. checkinTimeout is the budget of the ctx that
+// CheckinAccount derives for the account, so shrinking it below the 2s floor of
+// transientRetryBackoff makes the wait expire mid-backoff: a cancellable wait
+// ends the checkin at ~400ms with the ctx error and no retry, a bare sleep runs
+// the full 2-3s and then issues the retried upstream call anyway.
+func TestCheckinAccount_TransientRetryBackoffHonoursContext(t *testing.T) {
+	db := openCheckinEdgeTestDB(t)
+	cfg := &config.Config{AccountCredentialSecret: "edge-test-secret"}
+
+	original := checkinTimeout
+	checkinTimeout = 400 * time.Millisecond
+	t.Cleanup(func() { checkinTimeout = original })
+	budget := checkinTimeout
+
+	upstream, hits := newTransientCheckinServer(t)
+	siteID := insertEdgeSite(t, db, upstream.URL, "new-api")
+	accountID := insertEdgeAccount(t, db, siteID, "some-token", buildEdgeExtraConfig(t, 1, "", ""))
+
+	start := time.Now()
+	result := CheckinAccount(cfg, db.DB, accountID, &CheckinOptions{
+		SkipEvent: true, SkipNotification: true, ScheduleMode: "manual",
+	})
+	elapsed := time.Since(start)
+
+	// 1. The wait was interrupted instead of running its 2-3s course.
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("elapsed = %v, want < 1.5s (the transient-retry backoff ignored the account ctx and slept it out)", elapsed)
+	}
+	// 2. The outcome carries the ctx failure, and keeps the upstream message the
+	//    failure classifier reads.
+	if result.Success {
+		t.Fatalf("result = %+v, want a failure", result)
+	}
+	if result.Status != CheckinFailed {
+		t.Fatalf("status = %v, want %v", result.Status, CheckinFailed)
+	}
+	if !strings.Contains(result.Message, context.DeadlineExceeded.Error()) {
+		t.Fatalf("result.Message = %q, want it to carry %q", result.Message, context.DeadlineExceeded.Error())
+	}
+	if !strings.Contains(result.Message, "rate limited") {
+		t.Fatalf("result.Message = %q, want it to keep the original upstream failure", result.Message)
+	}
+	// 3. No upstream call after the budget expired — the retry must not run.
+	if late := hits.after(start.Add(budget + 250*time.Millisecond)); late != 0 {
+		t.Fatalf("%d upstream call(s) landed after the ctx expired; a cancelled backoff must not retry. hits=%v", late, hits.snapshot())
+	}
+	if got := hits.count("/api/user/checkin"); got != 1 {
+		t.Fatalf("checkin calls = %d, want 1 (the retry ran despite the cancelled ctx). hits=%v", got, hits.snapshot())
+	}
+}
+
+// newCountingCheckinServer answers /api/user/checkin with a success and counts
+// the calls, so a round test can tell how many accounts actually reached the
+// upstream.
+func newCountingCheckinServer(t *testing.T) (*httptest.Server, *hitLog) {
+	t.Helper()
+	log := &hitLog{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.record(r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/user/checkin":
+			_, _ = w.Write([]byte(`{"success":true,"message":"checkin success","data":{"reward":"5"}}`))
+		case "/api/user/self":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"username":"edge-user","id":1}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, log
+}
+
+// TestCheckinAllContext_SameSitePacingHonoursContext pins the pacing wait inside
+// a round. Two accounts on one site cost one pacing delay (~1s) between them;
+// cancelling the round ctx during that delay must stop the round there, so the
+// second account never reaches the upstream and the round returns in a fraction
+// of the delay.
+func TestCheckinAllContext_SameSitePacingHonoursContext(t *testing.T) {
+	db := openCheckinEdgeTestDB(t)
+	cfg := &config.Config{AccountCredentialSecret: "edge-test-secret"}
+	swapNotifySend(t)
+
+	upstream, hits := newCountingCheckinServer(t)
+	siteID := insertEdgeSite(t, db, upstream.URL, "new-api")
+	insertEdgeAccount(t, db, siteID, "token-1", buildEdgeExtraConfig(t, 1, "", ""))
+	insertEdgeAccount(t, db, siteID, "token-2", buildEdgeExtraConfig(t, 2, "", ""))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		// The first account is checked in within milliseconds, so this lands in
+		// the middle of the pacing wait that precedes the second one.
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	results := CheckinAllContext(ctx, cfg, db.DB, nil, "manual")
+	elapsed := time.Since(start)
+
+	// 1. The pacing wait was cut short instead of running its ~1s course.
+	if elapsed > 900*time.Millisecond {
+		t.Fatalf("elapsed = %v, want < 900ms (the same-site pacing wait ignored the round ctx)", elapsed)
+	}
+	// 2. The round reports the ctx outcome rather than pretending every account
+	//    was processed.
+	if len(results) != 1 {
+		t.Fatalf("results = %+v, want exactly the one account processed before the cancellation", results)
+	}
+	// 3. The second account never reached the upstream.
+	if got := hits.count("/api/user/checkin"); got != 1 {
+		t.Fatalf("upstream checkin calls = %d, want 1 (the round kept going after cancellation). hits=%v", got, hits.snapshot())
+	}
+}
+
+// TestCheckinAllContext_KeepsPacingWhenNotCancelled is the counterpart: making
+// the wait cancellable must not shorten it. An uncancelled round still spaces
+// the two same-site accounts by the pacing delay and processes both.
+func TestCheckinAllContext_KeepsPacingWhenNotCancelled(t *testing.T) {
+	db := openCheckinEdgeTestDB(t)
+	cfg := &config.Config{AccountCredentialSecret: "edge-test-secret"}
+	swapNotifySend(t)
+
+	upstream, hits := newCountingCheckinServer(t)
+	siteID := insertEdgeSite(t, db, upstream.URL, "new-api")
+	insertEdgeAccount(t, db, siteID, "token-1", buildEdgeExtraConfig(t, 1, "", ""))
+	insertEdgeAccount(t, db, siteID, "token-2", buildEdgeExtraConfig(t, 2, "", ""))
+
+	start := time.Now()
+	results := CheckinAllContext(context.Background(), cfg, db.DB, nil, "manual")
+	elapsed := time.Since(start)
+
+	// sameSitePacingDelay() floors at 1s; allow a little slack for timer
+	// granularity but never accept a round that skipped the pacing.
+	if elapsed < 950*time.Millisecond {
+		t.Fatalf("elapsed = %v, want >= ~1s (the pacing delay must stay as long as before)", elapsed)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %+v, want both accounts", results)
+	}
+	if got := hits.count("/api/user/checkin"); got != 2 {
+		t.Fatalf("upstream checkin calls = %d, want 2", got)
+	}
+}

--- a/service/checkin/checkin.go
+++ b/service/checkin/checkin.go
@@ -98,6 +98,30 @@ func checkinContext(parent context.Context) (context.Context, context.CancelFunc
 	return context.WithTimeout(parent, checkinTimeout)
 }
 
+// sleepCtx waits for d and returns nil, or returns ctx.Err() as soon as ctx
+// ends. It is the cancellable form of time.Sleep for the waits that sit between
+// upstream calls in this package (the transient-retry backoff and the same-site
+// pacing): a bare sleep keeps the worker asleep — and keeps the upstream call
+// after it alive — once a shutdown or an exhausted budget has already decided
+// the work is over. The duration semantics are unchanged, only the wait became
+// interruptible; service/oauth/retry.go guards its backoff the same way.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 // IsSiteDisabled checks if a site status represents "disabled".
 func IsSiteDisabled(status string) bool {
 	normalized := strings.TrimSpace(status)
@@ -412,10 +436,20 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 	// from a single transient blip. Auth/billing/model/validation failures
 	// are NOT retried — they require operator intervention. Max 1 retry.
 	if shouldRetryTransient(result) {
-		time.Sleep(transientRetryBackoff())
-		result, err = adp.Checkin(ctx, site.URL, activeAccessToken, platformUserIDPtr(platformUserID), proxyConfig)
-		if err != nil {
-			result = &platform.CheckinResult{Success: false, Message: err.Error()}
+		// The backoff is cancellable: the ctx already bounds the retry below, so
+		// sleeping it out after the budget expired only delayed the verdict and
+		// then paid for one more upstream call on top of it.
+		if waitErr := sleepCtx(ctx, transientRetryBackoff()); waitErr != nil {
+			slog.Warn("[checkin] transient-retry backoff interrupted; skipping the retry",
+				"accountID", account.ID, "error", waitErr)
+			// Keep the upstream message (the failure classifier and checkin_logs
+			// read it) and record why the retry never happened.
+			result.Message = fmt.Sprintf("%s; transient retry skipped: %v", result.Message, waitErr)
+		} else {
+			result, err = adp.Checkin(ctx, site.URL, activeAccessToken, platformUserIDPtr(platformUserID), proxyConfig)
+			if err != nil {
+				result = &platform.CheckinResult{Success: false, Message: err.Error()}
+			}
 		}
 	}
 
@@ -618,6 +652,21 @@ func CheckinAccount(cfg *config.Config, db *sqlx.DB, accountID int64, options *C
 // the end (issue #667): a 50-account failure burst now yields a single
 // "Checkin round <id>: N ok, M failed" alert instead of 50 separate ones.
 func CheckinAll(cfg *config.Config, db *sqlx.DB, accountIDs []int64, scheduleMode string) []CheckinAllResult {
+	return CheckinAllContext(context.Background(), cfg, db, accountIDs, scheduleMode)
+}
+
+// CheckinAllContext is CheckinAll with a caller-supplied context. The same-site
+// pacing wait between two accounts of one site is the only place a round blocks
+// without an upstream in flight, so it is where a cancellation has to land: a
+// finished ctx stops the round there instead of paying the pacing delay plus the
+// next upstream call for every remaining account. CheckinAll keeps its signature
+// (and its context.Background() behaviour) for the callers that have no ctx to
+// hand yet.
+//
+// A per-account checkin still derives its own budget inside CheckinAccount,
+// which has no ctx-taking variant: cancelling the round therefore stops the next
+// account, while the in-flight one finishes inside its own checkinTimeout.
+func CheckinAllContext(ctx context.Context, cfg *config.Config, db *sqlx.DB, accountIDs []int64, scheduleMode string) []CheckinAllResult {
 	query := `SELECT a.id AS "accounts.id", a.site_id AS "accounts.site_id", a.username AS "accounts.username",
 		a.access_token AS "accounts.access_token", a.balance AS "accounts.balance",
 		a.balance_used AS "accounts.balance_used", a.quota AS "accounts.quota",
@@ -679,16 +728,23 @@ func CheckinAll(cfg *config.Config, db *sqlx.DB, accountIDs []int64, scheduleMod
 
 	// Different sites: parallel. Same site: serial.
 	var wg sync.WaitGroup
-	for _, indices := range grouped {
+	for siteID, indices := range grouped {
 		wg.Add(1)
-		go func(indices []int) {
+		go func(siteID int64, indices []int) {
 			defer wg.Done()
 			for i, idx := range indices {
 				if i > 0 {
 					// Same-site pacing: space consecutive checkins on the same site
 					// to avoid tripping upstream rate limits (429). Cross-site
 					// parallelism is preserved by the per-site goroutine above.
-					time.Sleep(sameSitePacingDelay())
+					// The wait is cancellable so a finished round ctx stops the
+					// site here instead of paying the delay plus the next
+					// account's upstream call.
+					if err := sleepCtx(ctx, sameSitePacingDelay()); err != nil {
+						slog.Warn("CheckinAll: round context ended during same-site pacing; stopping this site",
+							"siteID", siteID, "accountsLeft", len(indices)-i, "error", err)
+						return
+					}
 				}
 				row := rows[idx]
 				result := CheckinAccount(cfg, db, row.Accounts.ID, &CheckinOptions{
@@ -711,7 +767,7 @@ func CheckinAll(cfg *config.Config, db *sqlx.DB, accountIDs []int64, scheduleMod
 				})
 				mu.Unlock()
 			}
-		}(indices)
+		}(siteID, indices)
 	}
 	wg.Wait()
 

--- a/service/oauth/antigravity.go
+++ b/service/oauth/antigravity.go
@@ -189,7 +189,7 @@ func exchangeAntigravityAuthorizationCode(ctx context.Context, input ExchangeCod
 	}
 
 	email, _ := fetchAntigravityUserEmail(token.AccessToken, input.ProxyURL)
-	projectID, _ := fetchAntigravityProjectID(token.AccessToken, input.ProxyURL)
+	projectID, _ := fetchAntigravityProjectID(ctx, token.AccessToken, input.ProxyURL)
 
 	return &TokenSet{
 		AccessToken:    token.AccessToken,
@@ -223,7 +223,7 @@ func refreshAntigravityAccessToken(ctx context.Context, input RefreshTokenInput)
 	if input.OAuth != nil && input.OAuth.ProjectID != "" {
 		projectID = input.OAuth.ProjectID
 	} else {
-		projectID, _ = fetchAntigravityProjectID(token.AccessToken, input.ProxyURL)
+		projectID, _ = fetchAntigravityProjectID(ctx, token.AccessToken, input.ProxyURL)
 	}
 
 	return &TokenSet{
@@ -284,9 +284,9 @@ func extractAntigravityDefaultTierID(payload *antigravityLoadCodeAssistPayload) 
 	return "legacy-tier"
 }
 
-func callAntigravityInternalAPI(accessToken, method string, body map[string]interface{}, proxyURL *string) (map[string]interface{}, error) {
+func callAntigravityInternalAPI(ctx context.Context, accessToken, method string, body map[string]interface{}, proxyURL *string) (map[string]interface{}, error) {
 	bodyBytes, _ := json.Marshal(body)
-	req, err := http.NewRequest("POST",
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		fmt.Sprintf("%s/%s:%s", antigravityUpstreamBaseURL, antigravityInternalAPIVersion, method),
 		bytes.NewReader(bodyBytes))
 	if err != nil {
@@ -347,9 +347,14 @@ func fetchAntigravityUserEmail(accessToken string, proxyURL *string) (string, er
 	return strings.TrimSpace(payload.Email), nil
 }
 
-func fetchAntigravityProjectID(accessToken string, proxyURL *string) (string, error) {
+// fetchAntigravityProjectID resolves the project for an antigravity token,
+// onboarding the user while the upstream has not picked one yet. Upstream
+// failures stay swallowed — an unresolved project must not fail an otherwise
+// good token exchange — but a finished ctx is not an upstream condition, so the
+// cancellation is returned instead of hiding behind an empty project.
+func fetchAntigravityProjectID(ctx context.Context, accessToken string, proxyURL *string) (string, error) {
 	metadata := buildAntigravityMetadata()
-	resp, err := callAntigravityInternalAPI(accessToken, "loadCodeAssist", map[string]interface{}{
+	resp, err := callAntigravityInternalAPI(ctx, accessToken, "loadCodeAssist", map[string]interface{}{
 		"metadata": metadata,
 	}, proxyURL)
 	if err != nil || resp == nil {
@@ -371,7 +376,7 @@ func fetchAntigravityProjectID(accessToken string, proxyURL *string) (string, er
 
 	tierID := extractAntigravityDefaultTierID(payload)
 	for attempt := 0; attempt < antigravityOnboardMaxAttempts; attempt++ {
-		onboardResp, err := callAntigravityInternalAPI(accessToken, "onboardUser", map[string]interface{}{
+		onboardResp, err := callAntigravityInternalAPI(ctx, accessToken, "onboardUser", map[string]interface{}{
 			"tierId":   tierID,
 			"metadata": metadata,
 		}, proxyURL)
@@ -385,7 +390,9 @@ func fetchAntigravityProjectID(accessToken string, proxyURL *string) (string, er
 			return "", nil
 		}
 		if attempt+1 < antigravityOnboardMaxAttempts {
-			time.Sleep(time.Duration(antigravityOnboardPollIntervalMs) * time.Millisecond)
+			if err := sleepCtx(ctx, time.Duration(antigravityOnboardPollIntervalMs)*time.Millisecond); err != nil {
+				return "", err
+			}
 		}
 	}
 

--- a/service/oauth/antigravity_flow_test.go
+++ b/service/oauth/antigravity_flow_test.go
@@ -208,7 +208,7 @@ func TestCallAntigravityInternalAPI_Non200ReturnsNilNoError(t *testing.T) {
 	defer server.Close()
 	withAntigravityEndpointSwap(t, "", "", server.URL)
 
-	result, err := callAntigravityInternalAPI("ag-access", "loadCodeAssist", map[string]interface{}{}, nil)
+	result, err := callAntigravityInternalAPI(context.Background(), "ag-access", "loadCodeAssist", map[string]interface{}{}, nil)
 	if err != nil {
 		t.Fatalf("non-200 should not return transport error, got %v", err)
 	}
@@ -235,7 +235,7 @@ func TestCallAntigravityInternalAPI_Success(t *testing.T) {
 	defer server.Close()
 	withAntigravityEndpointSwap(t, "", "", server.URL)
 
-	result, err := callAntigravityInternalAPI("ag-access", "loadCodeAssist", map[string]interface{}{}, nil)
+	result, err := callAntigravityInternalAPI(context.Background(), "ag-access", "loadCodeAssist", map[string]interface{}{}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -257,7 +257,7 @@ func TestFetchAntigravityProjectID_LoadReturnsProject(t *testing.T) {
 	defer server.Close()
 	withAntigravityEndpointSwap(t, "", "", server.URL)
 
-	projectID, _ := fetchAntigravityProjectID("ag-access", nil)
+	projectID, _ := fetchAntigravityProjectID(context.Background(), "ag-access", nil)
 	if projectID != "load-project-123" {
 		t.Errorf("projectID = %q, want load-project-123", projectID)
 	}
@@ -279,7 +279,7 @@ func TestFetchAntigravityProjectID_OnboardCompletes(t *testing.T) {
 	defer server.Close()
 	withAntigravityEndpointSwap(t, "", "", server.URL)
 
-	projectID, _ := fetchAntigravityProjectID("ag-access", nil)
+	projectID, _ := fetchAntigravityProjectID(context.Background(), "ag-access", nil)
 	if projectID != "onboarded-project" {
 		t.Errorf("projectID = %q, want onboarded-project", projectID)
 	}
@@ -295,7 +295,7 @@ func TestFetchAntigravityProjectID_OnboardNeverCompletes(t *testing.T) {
 	defer server.Close()
 	withAntigravityEndpointSwap(t, "", "", server.URL)
 
-	projectID, _ := fetchAntigravityProjectID("ag-access", nil)
+	projectID, _ := fetchAntigravityProjectID(context.Background(), "ag-access", nil)
 	if projectID != "" {
 		t.Errorf("projectID = %q, want empty when onboarding never completes", projectID)
 	}

--- a/service/oauth/gemini_cli.go
+++ b/service/oauth/gemini_cli.go
@@ -22,7 +22,6 @@ const (
 	geminiCliLoopbackPort              = 8085
 	geminiCliLoopbackPath              = "/oauth2callback"
 	geminiCliLoopbackRedirectURI       = "http://localhost:8085/oauth2callback"
-	geminiCliUpstreamBaseURL           = "https://cloudcode-pa.googleapis.com"
 	geminiCliGoogleAPIClient           = "google-genai-sdk/1.41.0 gl-node/v22.19.0"
 	geminiCliUserAgent                 = "GeminiCLI/0.31.0/unknown (win32; x64)"
 	geminiCliRequiredService           = "cloudaicompanion.googleapis.com"
@@ -32,6 +31,11 @@ const (
 	geminiCliOnboardPollIntervalMs     = 5000
 	geminiCliOnboardMaxAttempts        = 6
 )
+
+// geminiCliUpstreamBaseURL is a package var (not a const) so tests can point the
+// cloudcode internal API at a local httptest server, mirroring the
+// antigravityUpstreamBaseURL / grok endpoint seams.
+var geminiCliUpstreamBaseURL = "https://cloudcode-pa.googleapis.com"
 
 var geminiCliScopes = []string{
 	"https://www.googleapis.com/auth/cloud-platform",
@@ -198,7 +202,7 @@ func exchangeGeminiCliAuthorizationCode(ctx context.Context, input ExchangeCodeI
 		return nil, err
 	}
 
-	resolvedProjectID, err := ensureGeminiProjectAndOnboard(token.AccessToken, input.ProjectID, input.ProxyURL)
+	resolvedProjectID, err := ensureGeminiProjectAndOnboard(ctx, token.AccessToken, input.ProjectID, input.ProxyURL)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +248,7 @@ func refreshGeminiCliAccessToken(ctx context.Context, input RefreshTokenInput) (
 		nextProjectID = input.OAuth.ProjectID
 	} else {
 		var err error
-		nextProjectID, err = ensureGeminiProjectAndOnboard(token.AccessToken, "", input.ProxyURL)
+		nextProjectID, err = ensureGeminiProjectAndOnboard(ctx, token.AccessToken, "", input.ProxyURL)
 		if err != nil {
 			return nil, err
 		}
@@ -344,9 +348,9 @@ func isSameGeminiProjectID(a, b string) bool {
 	return strings.EqualFold(strings.TrimSpace(a), strings.TrimSpace(b))
 }
 
-func callGeminiCliInternalAPI(accessToken, method string, body map[string]interface{}, proxyURL *string) (map[string]interface{}, error) {
+func callGeminiCliInternalAPI(ctx context.Context, accessToken, method string, body map[string]interface{}, proxyURL *string) (map[string]interface{}, error) {
 	bodyBytes, _ := json.Marshal(body)
-	req, err := http.NewRequest("POST",
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		fmt.Sprintf("%s/%s:%s", geminiCliUpstreamBaseURL, geminiCliInternalAPIVersion, method),
 		bytes.NewReader(bodyBytes))
 	if err != nil {
@@ -513,7 +517,7 @@ func checkCloudAIAPIEnabled(accessToken, projectID string, proxyURL *string) err
 	return fmt.Errorf("project activation required: HTTP %d", enableResp.StatusCode)
 }
 
-func performGeminiCliSetup(accessToken, requestedProjectID string, proxyURL *string) (string, error) {
+func performGeminiCliSetup(ctx context.Context, accessToken, requestedProjectID string, proxyURL *string) (string, error) {
 	trimmedRequest := strings.TrimSpace(requestedProjectID)
 	explicitProject := trimmedRequest != ""
 	metadata := buildGeminiCliMetadata()
@@ -523,7 +527,7 @@ func performGeminiCliSetup(accessToken, requestedProjectID string, proxyURL *str
 		loadBody["cloudaicompanionProject"] = trimmedRequest
 	}
 
-	loadResp, err := callGeminiCliInternalAPI(accessToken, "loadCodeAssist", loadBody, proxyURL)
+	loadResp, err := callGeminiCliInternalAPI(ctx, accessToken, "loadCodeAssist", loadBody, proxyURL)
 	if err != nil {
 		return "", err
 	}
@@ -544,7 +548,7 @@ func performGeminiCliSetup(accessToken, requestedProjectID string, proxyURL *str
 
 	if projectID == "" {
 		for attempt := 0; attempt < geminiCliAutoOnboardMaxAttempts; attempt++ {
-			onboardResp, err := callGeminiCliInternalAPI(accessToken, "onboardUser", map[string]interface{}{
+			onboardResp, err := callGeminiCliInternalAPI(ctx, accessToken, "onboardUser", map[string]interface{}{
 				"tierId":   tierID,
 				"metadata": metadata,
 			}, proxyURL)
@@ -558,7 +562,9 @@ func performGeminiCliSetup(accessToken, requestedProjectID string, proxyURL *str
 				break
 			}
 			if attempt+1 < geminiCliAutoOnboardMaxAttempts {
-				time.Sleep(time.Duration(geminiCliAutoOnboardPollIntervalMs) * time.Millisecond)
+				if err := sleepCtx(ctx, time.Duration(geminiCliAutoOnboardPollIntervalMs)*time.Millisecond); err != nil {
+					return "", err
+				}
 			}
 		}
 	}
@@ -569,7 +575,7 @@ func performGeminiCliSetup(accessToken, requestedProjectID string, proxyURL *str
 
 	finalProjectID := projectID
 	for attempt := 0; attempt < geminiCliOnboardMaxAttempts; attempt++ {
-		onboardResp, err := callGeminiCliInternalAPI(accessToken, "onboardUser", map[string]interface{}{
+		onboardResp, err := callGeminiCliInternalAPI(ctx, accessToken, "onboardUser", map[string]interface{}{
 			"tierId":                  tierID,
 			"metadata":                metadata,
 			"cloudaicompanionProject": projectID,
@@ -599,7 +605,9 @@ func performGeminiCliSetup(accessToken, requestedProjectID string, proxyURL *str
 			return finalProjectID, nil
 		}
 		if attempt+1 < geminiCliOnboardMaxAttempts {
-			time.Sleep(time.Duration(geminiCliOnboardPollIntervalMs) * time.Millisecond)
+			if err := sleepCtx(ctx, time.Duration(geminiCliOnboardPollIntervalMs)*time.Millisecond); err != nil {
+				return "", err
+			}
 		}
 	}
 
@@ -609,10 +617,10 @@ func performGeminiCliSetup(accessToken, requestedProjectID string, proxyURL *str
 	return "", fmt.Errorf("gemini cli: onboarding timed out")
 }
 
-func ensureGeminiProjectAndOnboard(accessToken, requestedProjectID string, proxyURL *string) (string, error) {
+func ensureGeminiProjectAndOnboard(ctx context.Context, accessToken, requestedProjectID string, proxyURL *string) (string, error) {
 	explicitProject := strings.TrimSpace(requestedProjectID)
 	if explicitProject != "" {
-		return performGeminiCliSetup(accessToken, explicitProject, proxyURL)
+		return performGeminiCliSetup(ctx, accessToken, explicitProject, proxyURL)
 	}
 
 	projects, err := fetchGcpProjects(accessToken, proxyURL)
@@ -622,7 +630,7 @@ func ensureGeminiProjectAndOnboard(accessToken, requestedProjectID string, proxy
 	if len(projects) == 0 {
 		return "", fmt.Errorf("no Google Cloud projects available for this account")
 	}
-	return performGeminiCliSetup(accessToken, projects[0], proxyURL)
+	return performGeminiCliSetup(ctx, accessToken, projects[0], proxyURL)
 }
 
 func parseInt64Safe(s string) (int64, error) {

--- a/service/oauth/onboard_poll_ctx_test.go
+++ b/service/oauth/onboard_poll_ctx_test.go
@@ -1,0 +1,229 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The gemini-cli and antigravity onboarding flows poll an upstream until it
+// reports done, sleeping between attempts (2s / 5s / 2s). Those waits and the
+// requests around them used to be ctx-free, so a cancelled exchange or refresh
+// still ran the whole poll budget — up to maxAttempts x interval — and the
+// upstream calls on that chain could not be cancelled either.
+//
+// These tests drive the real functions against a local upstream and pin, per
+// poll loop: the wait is cut short, ctx.Err() surfaces, and no further poll
+// reaches the upstream after the cancellation.
+
+// withGeminiCliUpstreamSwap points the cloudcode internal API at a local server
+// for the duration of the test, mirroring withAntigravityEndpointSwap.
+func withGeminiCliUpstreamSwap(t *testing.T, upstreamURL string) {
+	t.Helper()
+	original := geminiCliUpstreamBaseURL
+	geminiCliUpstreamBaseURL = upstreamURL
+	t.Cleanup(func() { geminiCliUpstreamBaseURL = original })
+}
+
+// newOnboardPollServer answers loadCodeAssist with a tier list and no project
+// (which is what makes both flows enter their onboarding poll loop) and answers
+// onboardUser with the given payload, counting the polls.
+func newOnboardPollServer(t *testing.T, onboardResponse string) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var onboardCalls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "loadCodeAssist"):
+			_, _ = w.Write([]byte(`{"allowedTiers":[{"id":"free-tier","isDefault":true}]}`))
+		case strings.Contains(r.URL.Path, "onboardUser"):
+			onboardCalls.Add(1)
+			_, _ = w.Write([]byte(onboardResponse))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, &onboardCalls
+}
+
+func cancelAfter(cancel context.CancelFunc, d time.Duration) {
+	go func() {
+		time.Sleep(d)
+		cancel()
+	}()
+}
+
+// TestPerformGeminiCliSetup_AutoOnboardPollHonoursContext covers the project
+// discovery loop (geminiCliAutoOnboardMaxAttempts x 2s): onboarding never
+// reports done, so an uncancelled run would poll for up to 30s.
+func TestPerformGeminiCliSetup_AutoOnboardPollHonoursContext(t *testing.T) {
+	server, onboardCalls := newOnboardPollServer(t, `{"done":false}`)
+	withGeminiCliUpstreamSwap(t, server.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cancelAfter(cancel, 150*time.Millisecond)
+
+	start := time.Now()
+	projectID, err := performGeminiCliSetup(ctx, "gem-access", "", nil)
+	elapsed := time.Since(start)
+
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("elapsed = %v, want < 1.5s (the auto-onboard poll slept its 2s interval despite the cancelled ctx)", elapsed)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want %v", err, context.Canceled)
+	}
+	if projectID != "" {
+		t.Fatalf("projectID = %q, want empty on a cancelled onboard", projectID)
+	}
+	if got := onboardCalls.Load(); got != 1 {
+		t.Fatalf("onboardUser polls = %d, want 1 (the loop kept polling after cancellation)", got)
+	}
+}
+
+// TestPerformGeminiCliSetup_OnboardPollHonoursContext covers the second loop —
+// the one that polls with an explicit project (geminiCliOnboardMaxAttempts x 5s,
+// i.e. up to 30s of uninterruptible waiting before the fix).
+func TestPerformGeminiCliSetup_OnboardPollHonoursContext(t *testing.T) {
+	server, onboardCalls := newOnboardPollServer(t, `{"done":false}`)
+	withGeminiCliUpstreamSwap(t, server.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cancelAfter(cancel, 150*time.Millisecond)
+
+	start := time.Now()
+	projectID, err := performGeminiCliSetup(ctx, "gem-access", "explicit-project", nil)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Fatalf("elapsed = %v, want < 2s (the onboard poll slept its 5s interval despite the cancelled ctx)", elapsed)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want %v", err, context.Canceled)
+	}
+	if projectID != "" {
+		t.Fatalf("projectID = %q, want empty on a cancelled onboard", projectID)
+	}
+	if got := onboardCalls.Load(); got != 1 {
+		t.Fatalf("onboardUser polls = %d, want 1 (the loop kept polling after cancellation)", got)
+	}
+}
+
+// TestPerformGeminiCliSetup_OnboardCompletesWithoutCancellation is the
+// counterpart: a live ctx must not change the outcome — the loops still poll and
+// still resolve the project the upstream reports.
+func TestPerformGeminiCliSetup_OnboardCompletesWithoutCancellation(t *testing.T) {
+	server, _ := newOnboardPollServer(t, `{"done":true,"response":{"cloudaicompanionProject":"onboarded-project"}}`)
+	withGeminiCliUpstreamSwap(t, server.URL)
+
+	start := time.Now()
+	projectID, err := performGeminiCliSetup(context.Background(), "gem-access", "", nil)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("performGeminiCliSetup: %v", err)
+	}
+	if projectID != "onboarded-project" {
+		t.Fatalf("projectID = %q, want onboarded-project", projectID)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("elapsed = %v, want no polling wait when the first attempt is done", elapsed)
+	}
+}
+
+// TestFetchAntigravityProjectID_OnboardPollHonoursContext is the same property
+// for the antigravity flow (antigravityOnboardMaxAttempts x 2s). The function
+// swallows upstream failures by design, but a finished ctx is not an upstream
+// condition: it must surface so the caller can tell an abort from "no project".
+func TestFetchAntigravityProjectID_OnboardPollHonoursContext(t *testing.T) {
+	server, onboardCalls := newOnboardPollServer(t, `{"done":false}`)
+	withAntigravityEndpointSwap(t, "", "", server.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cancelAfter(cancel, 150*time.Millisecond)
+
+	start := time.Now()
+	projectID, err := fetchAntigravityProjectID(ctx, "ag-access", nil)
+	elapsed := time.Since(start)
+
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("elapsed = %v, want < 1.5s (the onboard poll slept its 2s interval despite the cancelled ctx)", elapsed)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want %v", err, context.Canceled)
+	}
+	if projectID != "" {
+		t.Fatalf("projectID = %q, want empty on a cancelled onboard", projectID)
+	}
+	if got := onboardCalls.Load(); got != 1 {
+		t.Fatalf("onboardUser polls = %d, want 1 (the loop kept polling after cancellation)", got)
+	}
+}
+
+// TestCallGeminiCliInternalAPI_HonoursContext pins the other half of the gap: an
+// already-finished ctx must not produce an upstream round trip at all.
+func TestCallGeminiCliInternalAPI_HonoursContext(t *testing.T) {
+	var hits atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+	withGeminiCliUpstreamSwap(t, server.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := callGeminiCliInternalAPI(ctx, "gem-access", "loadCodeAssist", map[string]interface{}{}, nil)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want %v", err, context.Canceled)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0 (the request ignored the cancelled ctx)", got)
+	}
+	if elapsed > 250*time.Millisecond {
+		t.Fatalf("elapsed = %v, want an immediate failure", elapsed)
+	}
+}
+
+// TestCallAntigravityInternalAPI_HonoursContext is the antigravity counterpart.
+func TestCallAntigravityInternalAPI_HonoursContext(t *testing.T) {
+	var hits atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+	withAntigravityEndpointSwap(t, "", "", server.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := callAntigravityInternalAPI(ctx, "ag-access", "loadCodeAssist", map[string]interface{}{}, nil)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want %v", err, context.Canceled)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("upstream hits = %d, want 0 (the request ignored the cancelled ctx)", got)
+	}
+	if elapsed > 250*time.Millisecond {
+		t.Fatalf("elapsed = %v, want an immediate failure", elapsed)
+	}
+}

--- a/service/oauth/retry.go
+++ b/service/oauth/retry.go
@@ -70,11 +70,8 @@ func RefreshWithRetry[T any](ctx context.Context, fn func() (T, error)) (T, erro
 	var lastErr error
 	for attempt := 0; attempt <= MaxRefreshRetries; attempt++ {
 		if attempt > 0 {
-			backoff := retryBackoffFn(attempt - 1)
-			select {
-			case <-ctx.Done():
-				return zero, ctx.Err()
-			case <-time.After(backoff):
+			if err := sleepCtx(ctx, retryBackoffFn(attempt-1)); err != nil {
+				return zero, err
 			}
 		}
 
@@ -91,4 +88,27 @@ func RefreshWithRetry[T any](ctx context.Context, fn func() (T, error)) (T, erro
 		lastErr = fmt.Errorf("refresh failed after %d attempts", MaxRefreshRetries+1)
 	}
 	return zero, lastErr
+}
+
+// sleepCtx waits for d and returns nil, or returns ctx.Err() as soon as ctx ends
+// (an already-finished ctx returns immediately instead of racing the timer).
+// Every wait between two upstream calls in this package goes through it, so a
+// cancelled exchange or refresh stops at the wait instead of paying the full
+// interval plus the next round trip. The duration semantics are unchanged: only
+// the wait became interruptible.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }


### PR DESCRIPTION
## 改动摘要

四处「夹在两次网络调用之间」的等待不看 ctx：进程关机或预算已经耗尽之后，worker 仍然把整段 sleep 睡完，**并且把睡完之后的那次上游调用照发**。等待时长语义一律未动，只加可取消性（`sleepCtx` = 既有的 select 姿势，`RefreshWithRetry` 本来就在用，现在共用一份）。

- **签到 transient 重试退避（2–3s）**：每账号预算过期后仍睡完退避、然后照发重试。现在等待随 ctx 结束，重试被跳过——上游消息保留（失败分类器与 `checkin_logs` 读的就是它），并记下「为什么没有重试」。
- **签到同站点节奏等待（~1s）**：一轮里剩下的每个账号都要付一遍。新增 `CheckinAllContext(ctx, …)` 接住轮次 ctx 并在等待处停下该站点；`CheckinAll` 保留签名、delegate `context.Background()`，所以没有任何调用方被迫改。
- **OAuth gemini-cli 自动 onboard（15×2s）与 onboard（6×5s）轮询**：此前整条链端到端不可中断，而且链上的函数**根本不带 ctx**，所以它们的上游调用也无法取消。ctx 现在从 exchange/refresh 一路贯通 `ensureGeminiProjectAndOnboard` / `performGeminiCliSetup` / `fetchAntigravityProjectID` 到 `callGeminiCliInternalAPI` / `callAntigravityInternalAPI`（`http.NewRequestWithContext`）。
- **OAuth antigravity onboard 轮询（5×2s）**：同上；取消时返回 `ctx.Err()`（该函数原本吞掉上游错误，已加注释说明区别）。

实测（改前 → 改后）：三个轮询 `28.3s → 0.16s`、`25.2s → 0.16s`、`8.1s → 0.16s`；签到退避 `2.21s → 0.47s`；轮次节奏等待 `1.17s → 0.21s`。

**第二个提交把接线补完**：`CheckinAllContext` 落地时两个生产调用方仍走无 ctx 的 `checkin.CheckinAll`，等于这条缝没有调用方——停掉的调度器照样把同站点节奏等待睡完。现在 `scheduler` 的 `checkinAll` 钩子带 ctx 且默认 `checkin.CheckinAllContext`，`runIntervalPassLocked` 接住 jobCtx（派生自生命周期 ctx）并往下传，catch-up 与 cron 两条本来就已经为租约构造了 jobCtx 的路径也把它交给轮次；`POST /api/checkin/trigger` 的手动轮次跑在请求 ctx 上——调用方走了就停下节奏等待，不再为没人读的响应把剩下的账号签一遍，已处理的每个账号仍保留自己的 `checkin_logs` 行，所以取消留下的是诚实的部分结果。

## 类型

- [x] fix（bug 修复：关机/取消后仍付费等待并发起上游调用）
- [x] perf（取消传播后的收尾时延，实测数字见上）

## 行为变更（需要进 CHANGELOG）

- 关机（调度器 `Stop()`、进程 ctx 取消）与每账号预算耗尽现在会**立刻**结束签到轮次的等待并跳过后续上游调用；此前会睡完再发。等待时长本身没变。
- `POST /api/checkin/trigger` 在客户端断开时停止该轮剩余账号（每个已处理账号的结果已落库）。
- OAuth gemini-cli / antigravity 的 onboard 轮询可被取消，且其上游请求随 ctx 取消。
- 内部：`geminiCliUpstreamBaseURL` 由 const 改为 package var（默认值不变），这是让两个轮询可测的唯一缝（antigravity / grok 早就是 var），否则只能写假测试。

## 测试验证

- [x] `go build ./...` / `go vet ./...` 通过；`gofmt -l` 对本次触及文件为空（`scheduler/checkin_test.go`、`handler/admin/checkin_routes.go` 是仓库既有漂移文件，漂移区域与本次改动无关，未顺手重排）
- [x] `go test ./service/checkin/... ./service/oauth/... ./scheduler/... -count=1` 全绿（`checkin 4.6s · oauth 14.4s · scheduler 19.8s`）
- [x] `go test ./handler/admin/ -count=1 -tags=integration -p 1`（带 `PG_TEST_DSN`）绿（56.8s）
- [x] `go test ./service/checkin/... -count=1 -race` 绿
- [x] 新增 `service/checkin/cancellable_waits_test.go`（241 行）与 `service/oauth/onboard_poll_ctx_test.go`（229 行）：每处等待都钉三条——等待被截短、`ctx.Err()` 浮出、取消之后**不再有上游往返**；并各配一条对照用例证明未取消时节奏/轮询次数与改前完全一致
- [x] **变异探针 red → green（集成方独立复跑）**：
  - M1 把 `service/checkin.sleepCtx` 降级回 `time.Sleep` → 2 条 FAIL，数字与交付方改前实测一致：`elapsed = 2.278951498s, want < 1.5s`、`elapsed = 1.080085022s, want < 900ms`
  - M2 把 `runIntervalPass` 传给轮次的 jobCtx 换回 `context.Background()` → 新增的接线用例 FAIL：`the round ran on a bare context.Background(): Stop() cannot end its pacing wait`
  - 两次还原 `sha256sum -c` 一致、`grep B4-MUTATION` 零命中、`git status` 干净、复跑全绿
- [x] 接线用例的断言写在**轮次内部**：`runIntervalPass` 返回后它的 `defer cancel()` 已经触发，在外面断言会因为错误的原因通过
- [x] 交付方另做过两次「从已提交状态真·revert」的一致性校验（`git checkout master -- internal/sharedcount/counter.go` 与把 `sleepCtx` 降级），红证据原文复现

## 自查清单

- [x] 无密钥/内部路径泄漏
- [x] 无用户可见文案变更
- [x] 行为变更已补测试
- [x] 无 schema 变更、无新依赖、无新 env 变量

## 故意没做（已记录）

1. **per-account 取消传播**：需要 `CheckinAccountContext` + `handler/admin/checkin_routes.go` 的单账号触发迁移；在飞的账号仍受自身 30s 预算约束，本 PR 不动。
2. **同链其余无 ctx 的 OAuth helper**（`postGeminiToken` / `fetchGcpProjects` / `fetchGeminiUserEmail` / `checkCloudAIAPIEnabled` / `postAntigravityToken` / `fetchAntigravityUserEmail`）：它们不含等待，属既有的 ctx 贯通剩余面；补进去会把 diff 从「4 处等待」扩成整条 OAuth 控制面。
3. **`sleepCtx` 提到公共 `internal/**` 复用**：现在 `service/checkin` 与 `service/oauth` 各一份（各 12 行）。提取要动两个包之外的文件，留作后续卫生项。
4. **等待时长可配置化**、连接期 `SCRIPT LOAD` 预热、sharedcount 指标：均为顺手活，未做。
