### PR TITLE
perf(sharedcount): negotiate the rollback script once instead of per rollback

### DIFF
--- a/internal/sharedcount/counter.go
+++ b/internal/sharedcount/counter.go
@@ -2,8 +2,11 @@ package sharedcount
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"strconv"
 	"strings"
@@ -184,6 +187,11 @@ type RedisCounter struct {
 	timeout  time.Duration
 	// dial is injectable for tests.
 	dial func(network, address string, timeout time.Duration) (net.Conn, error)
+
+	// scriptRefusalWarned keeps the "scripting refused" WARN to one line per
+	// counter. Rollbacks run on the reject and compensation paths, so a
+	// misconfigured ACL would otherwise log on every refused request.
+	scriptRefusalWarned sync.Once
 
 	// pool is lazily built, so a RedisCounter created as a struct literal (tests)
 	// needs no constructor.
@@ -554,6 +562,9 @@ func (r *RedisCounter) Decr(ctx context.Context, key string, window time.Duratio
 // A script runs as a single command, which is the only way to express
 // "decrement, then remove if the total is not positive" without a race.
 //
+// The script is sent as EVALSHA once the server holds it (see
+// rollbackScriptSHA), with a single EVAL fallback on NOSCRIPT.
+//
 // Dropping a non-positive key is still the right self-heal: a rollback that
 // lands after the window expired re-creates the key with no TTL and a negative
 // value, and INCR only arms PEXPIRE when its result is exactly 1, so such a key
@@ -566,8 +577,25 @@ if total <= 0 then
 end
 return total`
 
+// rollbackScriptSHA is the digest Redis identifies a cached script by, computed
+// once per process. Rollbacks sit on the rate-limit-reject and the failure
+// compensation paths, so sending EVALSHA (40 hex bytes) instead of the whole
+// script body keeps both the upload and the server-side parse off the hot path;
+// the body only travels again when a server reports it does not hold the script.
+var rollbackScriptSHA = func() string {
+	sum := sha1.Sum([]byte(rollbackScript))
+	return hex.EncodeToString(sum[:])
+}()
+
 // rollback runs rollbackScript for a negative delta and returns the window total
 // afterwards, or 0 when the key was dropped.
+//
+// The script is negotiated per attempt instead of being uploaded every time:
+// EVALSHA first, and one EVAL fallback when the server answers NOSCRIPT (which
+// both runs the script and re-caches it). No "the server has it" flag is kept:
+// such a flag would have to be invalidated on exactly the events that produce
+// NOSCRIPT — a restart, SCRIPT FLUSH, a failover to a replica — and the fallback
+// already costs one extra round trip only when it is genuinely needed.
 func (r *RedisCounter) rollback(ctx context.Context, key string, delta int64) (int64, error) {
 	if delta >= 0 {
 		return 0, fmt.Errorf("sharedcount: rollback delta must be negative, got %d", delta)
@@ -575,18 +603,31 @@ func (r *RedisCounter) rollback(ctx context.Context, key string, delta int64) (i
 	deltaArg := strconv.FormatInt(delta, 10)
 	var count int64
 	err := r.withConn(ctx, func(conn net.Conn) error {
-		n, err := redisDoInt(conn, "EVAL", rollbackScript, "1", key, deltaArg)
-		if err != nil {
-			if !isScriptUnsupportedError(err) {
-				return err
-			}
-			// The server has no EVAL. Apply the decrement on its own and skip
-			// the self-heal: an immortal non-positive key undercounts one
-			// window, whereas a non-atomic DEL discards live reservations.
-			n, err = redisDoInt(conn, "INCRBY", key, deltaArg)
-			if err != nil {
-				return err
-			}
+		n, err := redisDoInt(conn, "EVALSHA", rollbackScriptSHA, "1", key, deltaArg)
+		kind := classifyScriptRefusal(err)
+		if kind == scriptRefusalNotCached {
+			// The server does not hold the digest: send the body once, which runs
+			// it and puts it back in the server-side cache.
+			n, err = redisDoInt(conn, "EVAL", rollbackScript, "1", key, deltaArg)
+			kind = classifyScriptRefusal(err)
+		}
+		if err == nil {
+			count = n
+			return nil
+		}
+		if kind != scriptRefusalPermission && kind != scriptRefusalUnsupported {
+			// Anything else — a transport failure, or a script the server ran and
+			// that then errored — is a real error. Degrading on it would hide a
+			// broken script or a broken connection behind a weaker rollback.
+			return err
+		}
+		// This connection may not run scripts. Apply the decrement on its own and
+		// skip the self-heal: an immortal non-positive key undercounts one window,
+		// whereas a non-atomic DEL discards live reservations.
+		r.warnScriptRefused(kind, err)
+		n, incrErr := redisDoInt(conn, "INCRBY", key, deltaArg)
+		if incrErr != nil {
+			return incrErr
 		}
 		count = n
 		return nil
@@ -594,15 +635,66 @@ func (r *RedisCounter) rollback(ctx context.Context, key string, delta int64) (i
 	return count, err
 }
 
-// isScriptUnsupportedError reports a server that does not implement EVAL, as
-// opposed to a script that ran and failed.
-func isScriptUnsupportedError(err error) bool {
+// scriptRefusal says why a scripting command (EVALSHA / EVAL) did not run. Only
+// these shapes are recognised; anything else is a transport failure or a script
+// that ran and errored, and has to reach the caller as an error.
+type scriptRefusal int
+
+const (
+	// scriptRefusalNone means the failure says nothing about script support.
+	scriptRefusalNone scriptRefusal = iota
+	// scriptRefusalNotCached: "-NOSCRIPT No matching script" — the server does
+	// not hold this digest (restart, SCRIPT FLUSH, a replica that never saw it).
+	// Recoverable by sending the body with EVAL.
+	scriptRefusalNotCached
+	// scriptRefusalPermission: "-NOPERM this user has no permissions to run the
+	// 'evalsha' command" — the ACL user may not run scripts. Scripting exists,
+	// this connection may not use it: degrade and tell the operator what to fix.
+	scriptRefusalPermission
+	// scriptRefusalUnsupported: "-ERR unknown command 'EVALSHA'", or a
+	// compatible server's "unsupported command" — the build has no scripting at
+	// all: degrade.
+	scriptRefusalUnsupported
+)
+
+// classifyScriptRefusal maps a Redis error reply to a scriptRefusal. NOSCRIPT and
+// NOPERM are matched on the leading error code, which the protocol fixes, rather
+// than on the prose that follows it. Only the "no scripting in this build" case
+// has to match wording, because Redis reports an unknown command as a plain
+// "-ERR ..." with no code of its own.
+func classifyScriptRefusal(err error) scriptRefusal {
 	var re *replyError
 	if !errors.As(err, &re) {
-		return false
+		return scriptRefusalNone
 	}
-	msg := strings.ToLower(re.msg)
-	return strings.Contains(msg, "unknown command") || strings.Contains(msg, "unsupported command")
+	msg := strings.ToLower(strings.TrimSpace(re.msg))
+	code, _, _ := strings.Cut(msg, " ")
+	switch {
+	case code == "noscript":
+		return scriptRefusalNotCached
+	case code == "noperm":
+		return scriptRefusalPermission
+	case strings.Contains(msg, "unknown command"), strings.Contains(msg, "unsupported command"):
+		return scriptRefusalUnsupported
+	}
+	return scriptRefusalNone
+}
+
+// warnScriptRefused logs the degradation once per counter, naming the two
+// refusals differently because only one of them is fixable from this side of the
+// connection: a permission refusal means an ACL to correct, while a build
+// without scripting is simply what the server is.
+func (r *RedisCounter) warnScriptRefused(kind scriptRefusal, err error) {
+	r.scriptRefusalWarned.Do(func() {
+		switch kind {
+		case scriptRefusalPermission:
+			slog.Warn("sharedcount: Redis refused scripting for this connection (ACL); compensating rollbacks degrade to INCRBY and skip the atomic self-heal — grant eval/evalsha to this user, or accept that a rollback landing after its window leaves a non-positive key behind for one window",
+				"error", err)
+		case scriptRefusalUnsupported:
+			slog.Warn("sharedcount: Redis server runs no scripting at all; compensating rollbacks degrade to INCRBY and skip the atomic self-heal",
+				"error", err)
+		}
+	})
 }
 
 func (r *RedisCounter) IncrBy(ctx context.Context, key string, delta int64, window time.Duration) (int64, error) {

--- a/internal/sharedcount/redis_test.go
+++ b/internal/sharedcount/redis_test.go
@@ -3,6 +3,8 @@ package sharedcount
 import (
 	"bufio"
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -20,8 +22,8 @@ import (
 // fakeRedis is a minimal in-memory RESP server for exercising RedisCounter
 // over a real TCP loopback connection (so NewRedisCounter + net.DialTimeout
 // are covered end-to-end). It supports AUTH, SELECT, INCR, DECR, INCRBY, GET
-// PEXPIRE, DEL and the single EVAL script the counter uses, with real TTL
-// expiry.
+// PEXPIRE, DEL and the single script the counter uses (EVAL plus the EVALSHA /
+// NOSCRIPT negotiation around it), with real TTL expiry.
 type fakeRedis struct {
 	mu       sync.Mutex
 	data     map[string]int64
@@ -43,14 +45,31 @@ type fakeRedis struct {
 	// delayMs is an artificial per-command latency (0 = none).
 	delayMs atomic.Int64
 
-	// hookMu guards beforeCommand and evalDisabled.
+	// hookMu guards beforeCommand and the script-support switches.
 	hookMu sync.Mutex
 	// beforeCommand, when set, runs after a command has been parsed but before it
 	// is handled — the client is still waiting for the reply, so this is the gap
 	// in which a test can land another connection's command.
 	beforeCommand func(cmd, key string)
-	// evalDisabled makes EVAL answer the way a server without scripting does.
+	// evalDisabled makes EVAL/EVALSHA answer the way a server without scripting
+	// does ("ERR unknown command").
 	evalDisabled bool
+	// scriptsDenied makes EVAL/EVALSHA answer the way an ACL user without
+	// scripting permission does ("NOPERM ...").
+	scriptsDenied bool
+	// scriptFailure, when set, is the error reply EVAL/EVALSHA answer with — a
+	// stand-in for a script that the server accepted and then failed to run.
+	scriptFailure string
+	// scripts is the server-side script cache (sha1 hex -> body): EVAL populates
+	// it, EVALSHA reads it and answers NOSCRIPT for a digest it does not hold,
+	// exactly like a real server after a restart or SCRIPT FLUSH.
+	scripts map[string]string
+
+	// cmdLog is the wire log: every command the double was asked to run, in
+	// order, so a test can pin the negotiation sequence (EVALSHA before EVAL, no
+	// script body on the hot path).
+	cmdLogMu sync.Mutex
+	cmdLog   [][]string
 }
 
 func newFakeRedis(tb testing.TB) *fakeRedis {
@@ -98,12 +117,112 @@ func (f *fakeRedis) setBeforeCommand(fn func(cmd, key string)) {
 	f.beforeCommand = fn
 }
 
-// disableEval makes the double answer EVAL with the error a server without
-// scripting support returns.
+// disableEval makes the double answer EVAL and EVALSHA with the error a server
+// without scripting support returns.
 func (f *fakeRedis) disableEval() {
 	f.hookMu.Lock()
 	defer f.hookMu.Unlock()
 	f.evalDisabled = true
+}
+
+// denyScripts makes the double answer EVAL and EVALSHA the way an ACL user
+// without scripting permission is answered: the server can run scripts, this
+// connection may not.
+func (f *fakeRedis) denyScripts() {
+	f.hookMu.Lock()
+	defer f.hookMu.Unlock()
+	f.scriptsDenied = true
+}
+
+// failScripts makes the double answer EVAL and EVALSHA with the given error
+// reply, standing in for a script the server accepted and then failed to run.
+func (f *fakeRedis) failScripts(msg string) {
+	f.hookMu.Lock()
+	defer f.hookMu.Unlock()
+	f.scriptFailure = msg
+}
+
+// scriptSwitches snapshots the scripting switches for one command.
+func (f *fakeRedis) scriptSwitches() (disabled, denied bool, failure string) {
+	f.hookMu.Lock()
+	defer f.hookMu.Unlock()
+	return f.evalDisabled, f.scriptsDenied, f.scriptFailure
+}
+
+// preloadScript puts a script body in the server-side cache without running it —
+// the double's stand-in for SCRIPT LOAD, or for a server that has already seen
+// the script. A test that asserts the hot path (one EVALSHA, no body upload)
+// needs this, because a cold server legitimately costs one NOSCRIPT round trip.
+func (f *fakeRedis) preloadScript(body string) {
+	f.hookMu.Lock()
+	defer f.hookMu.Unlock()
+	if f.scripts == nil {
+		f.scripts = make(map[string]string)
+	}
+	f.scripts[fakeScriptSHA(body)] = body
+}
+
+// cacheScript records a script the way EVAL does on a real server, so a later
+// EVALSHA can run it without the body travelling again.
+func (f *fakeRedis) cacheScript(body string) {
+	f.hookMu.Lock()
+	defer f.hookMu.Unlock()
+	if f.scripts == nil {
+		f.scripts = make(map[string]string)
+	}
+	f.scripts[fakeScriptSHA(body)] = body
+}
+
+// lookupScript resolves a digest against the server-side cache.
+func (f *fakeRedis) lookupScript(sha string) (string, bool) {
+	f.hookMu.Lock()
+	defer f.hookMu.Unlock()
+	body, ok := f.scripts[sha]
+	return body, ok
+}
+
+// fakeScriptSHA is the digest the RESP scripting protocol defines for a script
+// body: SHA1 of the exact bytes an EVAL would upload.
+func fakeScriptSHA(body string) string {
+	sum := sha1.Sum([]byte(body))
+	return hex.EncodeToString(sum[:])
+}
+
+// recordCommand appends a copy of a parsed command to the wire log.
+func (f *fakeRedis) recordCommand(parts []string) {
+	f.cmdLogMu.Lock()
+	defer f.cmdLogMu.Unlock()
+	f.cmdLog = append(f.cmdLog, append([]string(nil), parts...))
+}
+
+// recordedCommands returns a copy of the wire log (post-AUTH/SELECT commands, in
+// order).
+func (f *fakeRedis) recordedCommands() [][]string {
+	f.cmdLogMu.Lock()
+	defer f.cmdLogMu.Unlock()
+	out := make([][]string, len(f.cmdLog))
+	for i, parts := range f.cmdLog {
+		out[i] = append([]string(nil), parts...)
+	}
+	return out
+}
+
+// countCommands counts how many times a command name was sent.
+func (f *fakeRedis) countCommands(cmd string) int {
+	n := 0
+	for _, parts := range f.recordedCommands() {
+		if len(parts) > 0 && strings.EqualFold(parts[0], cmd) {
+			n++
+		}
+	}
+	return n
+}
+
+// resetCommandLog clears the wire log so a test can measure one operation.
+func (f *fakeRedis) resetCommandLog() {
+	f.cmdLogMu.Lock()
+	defer f.cmdLogMu.Unlock()
+	f.cmdLog = nil
 }
 
 // fireBeforeCommand runs the installed callback, if any, outside the datastore
@@ -118,9 +237,10 @@ func (f *fakeRedis) fireBeforeCommand(cmd, key string) {
 }
 
 // commandKey extracts the key a command operates on, so the interleave hook can
-// be filtered per key. EVAL carries it after the script and the numkeys count.
+// be filtered per key. EVAL and EVALSHA carry it after the script (or its
+// digest) and the numkeys count.
 func commandKey(cmd string, parts []string) string {
-	if cmd == "EVAL" {
+	if cmd == "EVAL" || cmd == "EVALSHA" {
 		if len(parts) >= 4 {
 			return parts[3]
 		}
@@ -234,6 +354,7 @@ func (f *fakeRedis) handle(conn net.Conn) {
 				writeError(conn, "NOAUTH Authentication required")
 				return
 			}
+			f.recordCommand(parts)
 			f.fireBeforeCommand(cmd, commandKey(cmd, parts))
 			if !f.handleCommand(conn, cmd, parts) {
 				return
@@ -316,37 +437,67 @@ func (f *fakeRedis) handleCommand(conn net.Conn, cmd string, parts []string) boo
 		f.ttl[key] = time.Now().Add(time.Duration(ms) * time.Millisecond)
 		f.mu.Unlock()
 		writeInt(conn, 1)
-	case "EVAL":
+	case "EVAL", "EVALSHA":
 		// The counter sends exactly one script: the atomic rollback
 		// (INCRBY plus a conditional DEL). Redis executes a script as a single
 		// command, so the double applies the whole thing under one lock hold —
 		// that atomicity is the property under test, and it is why no other
 		// connection can observe (or lose) a write in the middle.
-		f.hookMu.Lock()
-		disabled := f.evalDisabled
-		f.hookMu.Unlock()
+		//
+		// EVALSHA resolves the digest against the server-side cache and answers
+		// NOSCRIPT for one it does not hold; EVAL runs the body and caches it, so
+		// the next EVALSHA resolves.
+		disabled, denied, failure := f.scriptSwitches()
+		lowerCmd := strings.ToLower(cmd)
 		if disabled {
-			writeError(conn, "ERR unknown command 'EVAL'")
+			// A build without scripting knows neither command.
+			writeError(conn, "ERR unknown command '"+cmd+"'")
 			return true
 		}
-		if len(parts) < 5 {
-			writeError(conn, "ERR wrong number of arguments for 'eval' command")
+		if denied {
+			// Scripting exists, this connection may not use it.
+			writeError(conn, "NOPERM this user has no permissions to run the '"+lowerCmd+"' command")
 			return true
 		}
-		if !strings.Contains(parts[1], "INCRBY") || !strings.Contains(parts[1], "DEL") {
+		if failure != "" {
+			writeError(conn, failure)
+			return true
+		}
+		if len(parts) < 2 {
+			writeError(conn, "ERR wrong number of arguments for '"+lowerCmd+"' command")
+			return true
+		}
+		var body string
+		if cmd == "EVAL" {
+			body = parts[1]
+		} else {
+			cached, known := f.lookupScript(parts[1])
+			if !known {
+				writeError(conn, "NOSCRIPT No matching script")
+				return true
+			}
+			body = cached
+		}
+		tail := parts[2:] // numkeys, key..., argv...
+		if !strings.Contains(body, "INCRBY") || !strings.Contains(body, "DEL") {
 			writeError(conn, "ERR test double implements only the atomic rollback script")
 			return true
 		}
-		if numKeys, err := strconv.Atoi(parts[2]); err != nil || numKeys != 1 {
+		if len(tail) < 3 {
+			writeError(conn, "ERR wrong number of arguments for '"+lowerCmd+"' command")
+			return true
+		}
+		if numKeys, err := strconv.Atoi(tail[0]); err != nil || numKeys != 1 {
 			writeError(conn, "ERR test double implements exactly one KEYS entry")
 			return true
 		}
-		key := parts[3]
-		delta, err := strconv.ParseInt(parts[4], 10, 64)
+		key := tail[1]
+		delta, err := strconv.ParseInt(tail[2], 10, 64)
 		if err != nil {
 			writeError(conn, "ERR value is not an integer or out of range")
 			return true
 		}
+		f.cacheScript(body)
 		f.mu.Lock()
 		f.expireLocked(key)
 		v := f.data[key] + delta

--- a/internal/sharedcount/rollback_atomicity_test.go
+++ b/internal/sharedcount/rollback_atomicity_test.go
@@ -24,6 +24,11 @@ func rollbackDuringReservation(t *testing.T, rollback func(ctx context.Context, 
 
 	f := newFakeRedis(t)
 	defer f.close()
+	// Warm the server-side script cache: the interleave below has to land on the
+	// command that actually executes the rollback, not on a NOSCRIPT rejection of
+	// a cold-start EVALSHA (that negotiation is covered by
+	// TestRedisCounter_RollbackFallsBackToEvalOnceOnNoScript).
+	f.preloadScript(rollbackScript)
 	c := newCounterAt(t, f.addr())
 	other := newCounterAt(t, f.addr())
 	ctx := context.Background()
@@ -37,8 +42,9 @@ func rollbackDuringReservation(t *testing.T, rollback func(ctx context.Context, 
 	var fired, reserved atomic.Int64
 	f.setBeforeCommand(func(cmd, gotKey string) {
 		// The interesting command is the one that may drop the key: the atomic
-		// rollback script, or — for a two-command rollback — its separate DEL.
-		if gotKey != key || (cmd != "EVAL" && cmd != "DEL") || fired.Swap(1) == 1 {
+		// rollback script (by body or by digest), or — for a two-command
+		// rollback — its separate DEL.
+		if gotKey != key || (cmd != "EVAL" && cmd != "EVALSHA" && cmd != "DEL") || fired.Swap(1) == 1 {
 			return
 		}
 		// Another instance reserves the same window at that exact moment. A
@@ -98,6 +104,10 @@ func TestRedisCounter_RollbackIsASingleServerOperation(t *testing.T) {
 	t.Parallel()
 	f := newFakeRedis(t)
 	defer f.close()
+	// A server that already holds the script: this pins the hot path. A cold
+	// server legitimately costs one extra NOSCRIPT round trip, which
+	// TestRedisCounter_RollbackFallsBackToEvalOnceOnNoScript covers.
+	f.preloadScript(rollbackScript)
 	c := newCounterAt(t, f.addr())
 	ctx := context.Background()
 

--- a/internal/sharedcount/rollback_script_negotiation_test.go
+++ b/internal/sharedcount/rollback_script_negotiation_test.go
@@ -1,0 +1,230 @@
+package sharedcount
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A compensating rollback runs on the reject and failure-compensation paths, so
+// the script negotiation has to be paid once and not per rollback: EVALSHA
+// carries a 40-byte digest instead of the script body, and only a NOSCRIPT
+// answer (a server that restarted, flushed its script cache, or a replica that
+// never saw the script) justifies uploading the body again.
+//
+// Capability detection matters for the same reason: an ACL that forbids scripts
+// answers NOPERM, which is neither "the digest is unknown" nor "the connection
+// broke". Treating it as a transport error fails every rollback and leaves the
+// shared window counting high; treating it as "no scripting" degrades to a plain
+// INCRBY and says so in the log.
+
+// wantRollbackScriptSHA derives the digest the RESP scripting protocol defines
+// for rollbackScript — SHA1 of the exact bytes an EVAL would upload — without
+// reading it back from the client.
+func wantRollbackScriptSHA() string {
+	sum := sha1.Sum([]byte(rollbackScript))
+	return hex.EncodeToString(sum[:])
+}
+
+// seedReservations puts n live reservations on key so a rollback has something
+// to compensate.
+func seedReservations(t *testing.T, c *RedisCounter, key string, n int) {
+	t.Helper()
+	ctx := context.Background()
+	for i := 0; i < n; i++ {
+		if _, err := c.Incr(ctx, key, time.Minute); err != nil {
+			t.Fatalf("seed Incr %d: %v", i, err)
+		}
+	}
+}
+
+// TestRedisCounter_RollbackNegotiatesScriptByDigest pins the hot path: one
+// command, sent as EVALSHA with the digest of rollbackScript, and the script
+// body never travels.
+func TestRedisCounter_RollbackNegotiatesScriptByDigest(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	f.preloadScript(rollbackScript) // a server that already holds the script
+	c := newCounterAt(t, f.addr())
+	ctx := context.Background()
+
+	seedReservations(t, c, "rpm:negotiate", 2)
+	f.resetCommandLog()
+
+	n, err := c.Decr(ctx, "rpm:negotiate", time.Minute)
+	if err != nil {
+		t.Fatalf("Decr: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("Decr = %d, want 1", n)
+	}
+
+	cmds := f.recordedCommands()
+	if len(cmds) != 1 {
+		t.Fatalf("rollback sent %d commands %v, want exactly one", len(cmds), cmds)
+	}
+	if !strings.EqualFold(cmds[0][0], "EVALSHA") {
+		t.Fatalf("rollback sent %v, want EVALSHA <sha> 1 <key> <delta>", cmds[0])
+	}
+	if got, want := cmds[0][1], wantRollbackScriptSHA(); got != want {
+		t.Fatalf("EVALSHA digest = %q, want %q (the digest of the script the fallback would upload)", got, want)
+	}
+	for _, arg := range cmds[0] {
+		if strings.Contains(arg, "redis.call") {
+			t.Fatalf("the script body travelled on the hot path: %v", cmds[0])
+		}
+	}
+}
+
+// TestRedisCounter_RollbackFallsBackToEvalOnceOnNoScript pins the cold path: a
+// NOSCRIPT answer reloads the script with exactly one EVAL, the rollback still
+// succeeds atomically, and the next rollback runs on the digest alone.
+func TestRedisCounter_RollbackFallsBackToEvalOnceOnNoScript(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close() // the double starts with an empty script cache
+	c := newCounterAt(t, f.addr())
+	ctx := context.Background()
+
+	seedReservations(t, c, "rpm:cold", 3)
+	f.resetCommandLog()
+
+	n, err := c.Decr(ctx, "rpm:cold", time.Minute)
+	if err != nil {
+		t.Fatalf("Decr on a server without the script cached: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("Decr = %d, want 2", n)
+	}
+	if got := f.countCommands("EVALSHA"); got != 1 {
+		t.Fatalf("EVALSHA calls = %d, want 1 (the digest is tried first). wire=%v", got, f.recordedCommands())
+	}
+	if got := f.countCommands("EVAL"); got != 1 {
+		t.Fatalf("EVAL calls = %d, want exactly one reload. wire=%v", got, f.recordedCommands())
+	}
+	if got := f.countCommands("INCRBY"); got != 0 {
+		t.Fatalf("INCRBY calls = %d, want 0: NOSCRIPT is not a reason to drop the atomic self-heal. wire=%v", got, f.recordedCommands())
+	}
+
+	// The reload stuck: the next rollback is a single EVALSHA again.
+	f.resetCommandLog()
+	if n, err := c.Decr(ctx, "rpm:cold", time.Minute); err != nil || n != 1 {
+		t.Fatalf("second Decr = %d, %v, want 1", n, err)
+	}
+	if got := f.countCommands("EVAL"); got != 0 {
+		t.Fatalf("EVAL calls on the second rollback = %d, want 0 (the body was uploaded again). wire=%v", got, f.recordedCommands())
+	}
+	if got := f.countCommands("EVALSHA"); got != 1 {
+		t.Fatalf("EVALSHA calls on the second rollback = %d, want 1. wire=%v", got, f.recordedCommands())
+	}
+}
+
+// TestRedisCounter_RollbackDegradesWhenACLRefusesScripting covers the refusal
+// that is a permission, not a missing capability: the rollback must still apply
+// its decrement (fail-closed on the count, never a surfaced error), skip the
+// self-heal it can no longer do atomically, and say in the log that an ACL is
+// what needs fixing.
+//
+// Not parallel: it captures the process-wide slog default to read the WARN.
+func TestRedisCounter_RollbackDegradesWhenACLRefusesScripting(t *testing.T) {
+	f := newFakeRedis(t)
+	defer f.close()
+	f.denyScripts()
+	c := newCounterAt(t, f.addr())
+	ctx := context.Background()
+
+	var logs bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(original) })
+
+	seedReservations(t, c, "rpm:acl", 2)
+	f.resetCommandLog()
+
+	n, err := c.Decr(ctx, "rpm:acl", time.Minute)
+	if err != nil {
+		t.Fatalf("Decr = %v, want nil: an ACL refusal must degrade, not fail the rollback", err)
+	}
+	if n != 1 {
+		t.Fatalf("Decr = %d, want 1 (the decrement must still be applied)", n)
+	}
+	if got := f.countCommands("INCRBY"); got != 1 {
+		t.Fatalf("INCRBY calls = %d, want 1 (the degraded path). wire=%v", got, f.recordedCommands())
+	}
+	if got, err := c.Get(ctx, "rpm:acl"); err != nil || got != 1 {
+		t.Fatalf("window total = %d, %v, want 1", got, err)
+	}
+
+	logged := logs.String()
+	if !strings.Contains(logged, "WARN") {
+		t.Fatalf("no WARN logged for a permission refusal; log = %q", logged)
+	}
+	if !strings.Contains(logged, "ACL") && !strings.Contains(strings.ToLower(logged), "permission") {
+		t.Fatalf("WARN does not say the refusal is a permission/ACL problem an operator can fix; log = %q", logged)
+	}
+}
+
+// TestRedisCounter_RollbackWithoutScriptSupportStillDegrades is the sibling
+// refusal: a build with no scripting at all takes the same degraded path.
+func TestRedisCounter_RollbackWithoutScriptSupportStillDegrades(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	f.disableEval()
+	c := newCounterAt(t, f.addr())
+	ctx := context.Background()
+
+	seedReservations(t, c, "rpm:noscripting", 2)
+	f.resetCommandLog()
+
+	n, err := c.Decr(ctx, "rpm:noscripting", time.Minute)
+	if err != nil {
+		t.Fatalf("Decr without scripting support: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("Decr = %d, want 1", n)
+	}
+	if got := f.countCommands("INCRBY"); got != 1 {
+		t.Fatalf("INCRBY calls = %d, want 1 (the degraded path). wire=%v", got, f.recordedCommands())
+	}
+}
+
+// TestRedisCounter_RollbackSurfacesScriptRuntimeError guards the other
+// direction: a script the server accepted and then failed to run is a real
+// error. Degrading on it would hide a broken script behind a silently weaker
+// rollback.
+func TestRedisCounter_RollbackSurfacesScriptRuntimeError(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	defer f.close()
+	f.failScripts("ERR Error running script (call to f_9d1c0): @user_script:2: user_script:2: attempt to perform arithmetic on a nil value")
+	c := newCounterAt(t, f.addr())
+	ctx := context.Background()
+
+	if _, err := c.Decr(ctx, "rpm:crash", time.Minute); err == nil {
+		t.Fatal("Decr = nil error, want the script failure surfaced")
+	}
+	if got := f.countCommands("INCRBY"); got != 0 {
+		t.Fatalf("INCRBY calls = %d, want 0: a script that ran and failed must not degrade silently", got)
+	}
+}
+
+// TestRedisCounter_RollbackSurfacesTransportFailure is the same guard for a
+// connection that cannot be established: no capability may be inferred from it.
+func TestRedisCounter_RollbackSurfacesTransportFailure(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis(t)
+	addr := f.addr()
+	f.close() // nothing listens any more
+
+	c := newCounterAt(t, addr)
+	if _, err := c.Decr(context.Background(), "rpm:down", time.Minute); err == nil {
+		t.Fatal("Decr against a dead server = nil error, want the transport failure surfaced")
+	}
+}


### PR DESCRIPTION
## 改动摘要

共享计数器的补偿回滚每次都把整段 Lua 脚本体上行一遍。回滚不是冷路径：它挂在**限流拒绝**与**失败补偿**两条路上，也就是说每次密钥撞上 RPM/TPM 上限、每次上游失败要退回预扣量，都会把 `local total = redis.call('INCRBY', …)` 这段文本发给服务器并让它重新解析一次。

现在脚本按摘要协商：包级 `rollbackScriptSHA`（`sha1.Sum` → hex，进程内算一次），回滚先发 `EVALSHA <40 hex bytes>`，**只在**服务器答 `NOSCRIPT` 时回退一次 `EVAL`（这一次既运行脚本、又把它放回服务端缓存）。刻意**不保存「服务器已经有了」这个标志**：这种标志恰恰要在产生 `NOSCRIPT` 的那些事件上失效（重启、`SCRIPT FLUSH`、故障切到副本），而回退本身只在真的需要时才多花一个往返——留一份需要维护的缓存状态是净亏。

拒绝分类同时收紧（原 `isScriptUnsupportedError` 删除，换成 `classifyScriptRefusal`）：

- `NOSCRIPT` / `NOPERM` 按**协议错误码首词**匹配，不再靠子串猜测；
- `unknown command` / `unsupported command` 收敛成同一类「这个 build 没有 scripting」；
- `NOPERM`（ACL 限制了 `eval`）走**既有的** `INCRBY` 降级路径，并按 counter 打一次 WARN，明说是 ACL 权限问题——此前它直接把 `redis error: NOPERM …` 当成回滚失败抛给调用方；
- 其余错误原样上报：脚本运行期错误与连接失败**必须报错**，不许静默降级成「只减量、不自愈」。

无新依赖（`crypto/sha1` + `encoding/hex`，`service/resin.go` 已在用 sha1），连接抽象照用。

## 类型

- [x] perf（热路径不再上行脚本体 + 服务端不再重复解析）
- [x] fix（`NOPERM` 此前把可降级的 ACL 限制当成回滚失败）

## 行为变更（需要进 CHANGELOG）

- Redis 回滚走 `EVALSHA`，仅 `NOSCRIPT` 时回退一次 `EVAL`。语义（原子减量 + 非正数即删键自愈）完全不变。
- ACL 禁掉 scripting 的 Redis（`NOPERM`）现在降级为 `INCRBY`（只减量、不自愈）并 WARN 一次，而不是让回滚失败。
- 「build 无 scripting」的判定不再依赖具体错误文案措辞。

## 测试验证

- [x] `go build ./...` 通过；`go vet ./internal/sharedcount/...` 通过；`gofmt -l` 对触及文件为空
- [x] `go test ./internal/sharedcount/... -count=1` 绿（0.43s）；`-count=1 -race` 绿（4.2s）
- [x] 替身（fake Redis）长出**服务端脚本缓存**：`EVAL` 写入 / `EVALSHA` 读取 / 冷启动答 `NOSCRIPT No matching script`；新增 `denyScripts()`（NOPERM）、`failScripts()`（脚本运行期错误）、`disableEval()` 覆盖 EVALSHA；wire log 记录每条命令，`commandKey` 认 EVALSHA
- [x] 新增 `internal/sharedcount/rollback_script_negotiation_test.go`（230 行）：4 条主用例（热路径只发摘要 · 冷启动 EVALSHA→EVAL 各一次且第二次回滚只发 EVALSHA · NOPERM 降级 + WARN · 无 scripting 的 build 走既有降级）+ **2 条守卫**（脚本运行期错误、连接失败必须报错，不得静默降级）
- [x] `rollback_atomicity_test.go` 的 hook 过滤加 EVALSHA 并 `preloadScript(rollbackScript)`——否则交错用例会打在冷启动被拒的 EVALSHA 上，测的就不是原子性了
- [x] **变异探针 red → green（集成方独立复跑）**：把热路径的 `EVALSHA <sha>` 换回 `EVAL <脚本体>` → 2 条 FAIL：`EVALSHA calls = 0, want 1 (the digest is tried first)`、`rollback sent [EVAL local total = redis.call('INCRBY', KEYS[1], ARGV[1])…]`；`git checkout --` 还原后 `sha256sum -c` 一致、`grep B4B-MUTATION` 零命中、复跑全绿
- [x] 交付方另做「从已提交状态真·revert」的一致性校验（`git checkout master -- internal/sharedcount/counter.go` → 3 条 FAIL 原文复现 → 还原后 sha256 一致、`git diff HEAD` 空）

## 自查清单

- [x] 无密钥/内部路径泄漏
- [x] 无用户可见文案变更（WARN 面向运维，指明是 ACL）
- [x] 行为变更已补测试
- [x] 无 schema 变更、无新依赖、无新 env 变量

## 故意没做（已记录）

1. **连接期 `SCRIPT LOAD` 预热**：那样就得维护「服务器已有脚本」的状态并处理它的失效，与「简单、可测优先」冲突；现在最坏情况是每个服务器生命周期多一个往返。
2. **sharedcount 指标**（回滚次数 / 降级次数暴露到可观测面）：本 PR 只做协商，指标属另一件事。
3. **interface 文档措辞**的顺手套话修改：未做。
