### PR TITLE
fix(backup): derive the backup table set from the schema registry

### DIFF
--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -75,9 +75,33 @@ database currently in use is refused).
 
 Export all settings and data as JSON.
 
+**Response**: `{ metadata: { exported_at, version, excluded_tables }, type, tables: { "<table>": [rows] } }`.
+
+`type=all` carries every table the schema registry creates except the ones excluded by name in
+`store.BackupExcludedTables()`; the set is derived (`store.BackupTableNames()`), not hand-copied, so a table added to
+the schema ships in every full backup until somebody excludes it with a recorded reason. Rows are ordered
+parents-before-children so an import can replay them in one pass. `metadata.excluded_tables` maps every registry table
+this payload does **not** carry to the reason, so a backup file states its own gaps:
+
+| Table | Why a backup does not carry it |
+| --- | --- |
+| `admin_sessions` | Session credential material. An import must never plant admin session token hashes, so a restored deployment requires a fresh login instead of reviving the source deployment's cookies. |
+| `admin_audit_logs` | Append-only audit trail of the source deployment's admin writes. Replaying it into another database makes that database's audit record assert operations that never happened there, and no retention job bounds its size. |
+| `model_probe_results` | High-frequency background probe telemetry that route rebuild reads as its latest-per-model signal; stale rows from another deployment would steer routing. The prober regenerates them after a restore. |
+| `catalog_sources` | Each row's `url` is fetched server-side by the catalog sync, and the import URL guard (`sites` / `site_api_endpoints` only) does not cover this table yet, so a crafted backup could plant an SSRF fetch target. |
+
+`type=accounts` and `type=preferences` are scoped exports; `metadata.excluded_tables` additionally lists the tables
+outside that scope. Limits: 50,000 rows per table, 4 MiB per cell, 64 MiB per payload — exceeding one fails the export
+with `413` instead of truncating silently.
+
 ### POST /api/settings/backup/import
 
-Import settings and data from JSON. Runtime-local settings such as `auth_token`, database connection settings, and WebDAV sync state are skipped.
+Import settings and data from JSON. Runtime-local settings such as `auth_token`, database connection settings, and WebDAV
+sync state are skipped.
+
+Tables absent from the payload are skipped, so a backup written by an older build (which carried fewer tables) still
+imports. A payload naming a table the backup set excludes — or any table outside the schema registry — is rejected with
+`400 unknown table <name>`; the exclusion is enforced on import, not just omitted on export.
 
 ### GET /api/settings/backup/webdav
 
@@ -133,7 +157,7 @@ Restore the clean-install state: wipe every business table and restart the auto-
 
 The table set is derived from the schema registry (`store.FactoryResetTableNames()`), not a hand-copied list, so a table added to the schema is wiped by a factory reset until it is explicitly excluded with a recorded reason. The single exclusion is the additive-migration journal (`schema_migrations`): wiping it would replay every migration step against an already-converged schema. Deletion runs in one transaction in FK-safe order (children before parents), so a failure leaves the database untouched rather than half wiped.
 
-`admin_sessions` is part of the set on purpose — session validation reads that table on every authenticated request, so emptying it revokes every cookie issued before the reset. **Sign in again after a successful factory reset.** Audit history (`admin_audit_logs`) and probe history (`model_probe_results`) are wiped as well; that is what "restore factory settings" means here. Export a backup first (`GET /api/settings/backup/export`) if you need them.
+`admin_sessions` is part of the set on purpose — session validation reads that table on every authenticated request, so emptying it revokes every cookie issued before the reset. **Sign in again after a successful factory reset.** Audit history (`admin_audit_logs`) and probe history (`model_probe_results`) are wiped as well; that is what "restore factory settings" means here. A backup export does **not** preserve them — both are excluded by name with a recorded reason (see [Settings - Backup](#settings---backup)), so dump them with your own database tooling before resetting if you need to keep them.
 
 ---
 

--- a/e2e/e2e_backup_test.go
+++ b/e2e/e2e_backup_test.go
@@ -15,10 +15,14 @@ import (
 )
 
 // ──────────────────────────────────────────────────────────────────────────────
-// Test: Backup Export-Import Roundtrip (all 28 tables)
+// Test: Backup Export-Import Roundtrip (seeded tables)
 // ──────────────────────────────────────────────────────────────────────────────
-// Full roundtrip: seed all 28 tables -> export JSON -> factory-reset ->
+// Full roundtrip: seed tables -> export JSON -> factory-reset ->
 // import JSON -> verify all data intact (re-export and compare).
+// The export carries every registry-derived backup table
+// (store.BackupTableNames()); this test seeds the subset in expectedCounts and
+// asserts the rest come back empty. No table count is spelled out here on
+// purpose: the seeded set and the carried set are both owned elsewhere.
 // Uses SQLite :memory: for the DB.
 
 func TestBackupExportImportRoundtrip(t *testing.T) {
@@ -44,7 +48,7 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 	future := time.Now().UTC().Add(30 * 24 * time.Hour).Format("2006-01-02T15:04:05.000Z")
 
 	// ══════════════════════════════════════════════════════════════════════════
-	// Phase 2: Seed all 28 tables with test data (FK-safe order)
+	// Phase 2: Seed the asserted tables with test data (FK-safe order)
 	// ══════════════════════════════════════════════════════════════════════════
 
 	// Table 1: sites (2 rows)
@@ -206,7 +210,7 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 		VALUES (2, 'warn', 'High latency', 'Proxy latency above threshold', 'warn', FALSE, ?)`, now)
 
 	// ──────────────────────────────────────────────────────────────────────────
-	// Verify seed: check row counts for all 28 tables
+	// Verify seed: check row counts for every seeded table
 	// ──────────────────────────────────────────────────────────────────────────
 	expectedCounts := map[string]int{
 		"sites":                            2,
@@ -260,7 +264,7 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 		t.Fatalf("export: expected 'tables' key in payload, got %T", exportPayload["tables"])
 	}
 
-	// Check all 28 tables are present in export.
+	// Check every seeded table is present in the export with its row count.
 	for table, expectedCount := range expectedCounts {
 		rows, ok := tablesRaw[table].([]any)
 		if !ok {
@@ -290,7 +294,8 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 		t.Errorf("export: expected type 'all', got %q", exportType)
 	}
 
-	t.Logf("export: all 28 tables exported successfully")
+	t.Logf("export: %d registry-derived backup tables carried, all %d seeded tables present",
+		len(tablesRaw), len(expectedCounts))
 
 	// ══════════════════════════════════════════════════════════════════════════
 	// Phase 4: Factory reset via /api/settings/maintenance/factory-reset
@@ -330,7 +335,7 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 		t.Errorf("after reset: expected max(sites.id)=0, got %d", nextSiteID)
 	}
 
-	t.Log("factory-reset: all 28 tables truncated, auto-increment reset")
+	t.Logf("factory-reset: all %d seeded tables truncated, auto-increment reset", len(expectedCounts))
 
 	// ══════════════════════════════════════════════════════════════════════════
 	// Phase 5: Import JSON via /api/settings/backup/import
@@ -369,7 +374,7 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 		}
 	}
 
-	t.Log("import: all 28 tables imported successfully")
+	t.Logf("import: all %d seeded tables imported successfully", len(expectedCounts))
 
 	// Admitting new downstream API keys is security-relevant, so an import
 	// that admits one or more keys appends exactly one warning audit event
@@ -470,7 +475,8 @@ func TestBackupExportImportRoundtrip(t *testing.T) {
 	// 6d. Verify foreign key integrity: route_channels -> accounts, sites, etc.
 	verifyForeignKeyIntegrity(t, db)
 
-	t.Log("roundtrip: all 28 tables verified — data fully preserved through export->reset->import cycle")
+	t.Logf("roundtrip: all %d seeded tables verified — data fully preserved through export->reset->import cycle",
+		len(expectedCounts))
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -643,9 +649,26 @@ func TestBackupEmptyDatabaseRoundtrip(t *testing.T) {
 	json.Unmarshal(exportRec.Body.Bytes(), &exportPayload)
 	tables, _ := exportPayload["tables"].(map[string]any)
 
-	// All 28 tables present but with empty arrays.
-	if len(tables) != 28 {
-		t.Errorf("empty export: expected 28 tables, got %d", len(tables))
+	// Every registry-derived backup table is present with an empty array. The
+	// expectation comes from store.BackupTableNames() instead of a literal: a
+	// hardcoded count here was the fourth hand-copied table list in the repo,
+	// and it pinned this assertion to the pre-registry export set. Deriving it
+	// means a newly registered table changes the export and the expectation
+	// together.
+	wantTables := store.BackupTableNames()
+	if len(tables) != len(wantTables) {
+		t.Errorf("empty export: expected %d registry-derived backup tables, got %d",
+			len(wantTables), len(tables))
+	}
+	for _, name := range wantTables {
+		rows, ok := tables[name].([]any)
+		if !ok {
+			t.Errorf("empty export: registry backup table %q missing from payload", name)
+			continue
+		}
+		if len(rows) != 0 {
+			t.Errorf("empty export: table %q expected 0 rows, got %d", name, len(rows))
+		}
 	}
 
 	// Factory reset (should succeed even on empty DB).

--- a/handler/admin/settings_backup.go
+++ b/handler/admin/settings_backup.go
@@ -62,9 +62,12 @@ type webdavBackupConfig struct {
 	AutoSyncCron    string `json:"autoSyncCron"`
 }
 
-// allTables is the backup export/import table list (service/backup.AllTables).
-// It is NOT the factory-reset set: that one is derived from the store schema
-// registry so a new table is covered without editing a second list here.
+// allTables is the backup export/import table list (service/backup.AllTables),
+// derived from the store schema registry minus store.BackupExcludedTables() —
+// the same single source of truth the factory-reset set comes from, so a table
+// added to the schema is exported and re-imported without editing a list here.
+// An excluded table is refused as unknown on import, which is what makes the
+// exclusion enforceable rather than advisory.
 var allTables = backupsvc.AllTables
 
 // GET /api/settings/backup/export?type=

--- a/handler/admin/settings_backup_tableset_test.go
+++ b/handler/admin/settings_backup_tableset_test.go
@@ -1,0 +1,386 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// The backup table set is derived from the store schema registry minus
+// store.BackupExcludedTables(). These tests pin the two halves of that
+// contract end to end through the real export/import code path:
+//
+//   - a table that used to be missing (product_announcements,
+//     announcement_dismissals, model_name_redirects, balance_history,
+//     model_verify_history) survives export → wipe → import;
+//   - a deliberately excluded table (admin_sessions, admin_audit_logs,
+//     model_probe_results, catalog_sources) is not in the payload, is not
+//     restored, and is refused when a caller hands it over anyway;
+//   - a pre-change backup that carries none of the new tables still imports.
+
+// newlyIncludedBackupTables are the registry tables the hand-copied
+// service/backup.AllTables list dropped before the set was derived.
+var newlyIncludedBackupTables = []string{
+	"product_announcements",
+	"announcement_dismissals",
+	"model_name_redirects",
+	"balance_history",
+	"model_verify_history",
+}
+
+func insertBackupFixtureID(t *testing.T, db *store.DB, query string, args ...any) int64 {
+	t.Helper()
+	if db.Dialect == store.DialectPostgres {
+		// pgx does not support LastInsertId.
+		var id int64
+		if err := db.QueryRow(db.Rebind(query+" RETURNING id"), args...).Scan(&id); err != nil {
+			t.Fatalf("insert fixture: %v", err)
+		}
+		return id
+	}
+	res, err := db.Exec(db.Rebind(query), args...)
+	if err != nil {
+		t.Fatalf("insert fixture: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("fixture id: %v", err)
+	}
+	return id
+}
+
+func countBackupFixtureRows(t *testing.T, db *store.DB, query string, args ...any) int {
+	t.Helper()
+	var n int
+	if err := db.Get(&n, db.Rebind(query), args...); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	return n
+}
+
+// seedBackupTableSetFixture writes one identifiable row into every table under
+// test and returns the values the assertions look for after the round trip.
+func seedBackupTableSetFixture(t *testing.T, db *store.DB) map[string]string {
+	t.Helper()
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 36)
+	now := time.Now().UTC().Format(time.RFC3339)
+	fx := map[string]string{"suffix": suffix, "now": now}
+
+	siteID := insertBackupFixtureID(t, db,
+		`INSERT INTO sites (name, url, platform, status, created_at, updated_at) VALUES (?, ?, 'sub2api', 'active', ?, ?)`,
+		"backup-roundtrip-"+suffix, "https://backup-roundtrip-"+suffix+".example.com", now, now)
+	accountID := insertBackupFixtureID(t, db,
+		`INSERT INTO accounts (site_id, username, access_token, status, is_pinned, sort_order,
+		 checkin_enabled, extra_config, created_at, updated_at)
+		 VALUES (?, ?, 'sk-backup-roundtrip', 'active', FALSE, 0, TRUE, '{}', ?, ?)`,
+		siteID, "backup-user-"+suffix, now, now)
+	fx["siteID"] = strconv.FormatInt(siteID, 10)
+	fx["accountID"] = strconv.FormatInt(accountID, 10)
+
+	// Tables the hand-copied list dropped.
+	fx["announcementTitle"] = "backup-roundtrip-banner-" + suffix
+	announcementID := insertBackupFixtureID(t, db,
+		`INSERT INTO product_announcements (title, message, severity, link, enabled, created_at, updated_at)
+		 VALUES (?, 'restored banner', 'info', NULL, TRUE, ?, ?)`, fx["announcementTitle"], now, now)
+	execBackupFixture(t, db,
+		`INSERT INTO announcement_dismissals (announcement_id, dismissed_at) VALUES (?, ?)`, announcementID, now)
+	fx["redirectCanonical"] = "claude-roundtrip-" + suffix
+	fx["redirectActual"] = "claude-roundtrip-20260903-" + suffix
+	execBackupFixture(t, db,
+		`INSERT INTO model_name_redirects (account_id, canonical, actual, source, last_seen_at, created_at, updated_at)
+		 VALUES (?, ?, ?, 'manual', ?, ?, ?)`, accountID, fx["redirectCanonical"], fx["redirectActual"], now, now, now)
+	fx["balanceDay"] = "2026-09-03"
+	execBackupFixture(t, db,
+		`INSERT INTO balance_history (account_id, balance, balance_used, quota, local_day, captured_at, created_at)
+		 VALUES (?, 12.5, 3.25, 100, ?, ?, ?)`, accountID, fx["balanceDay"], now, now)
+	fx["verifyBatch"] = "backup-roundtrip-batch-" + suffix
+	execBackupFixture(t, db,
+		`INSERT INTO model_verify_history (batch_id, model_name, channel_id, account_id, site_id, status,
+		 latency_ms, http_status, error_text, created_at)
+		 VALUES (?, ?, NULL, ?, ?, 'success', 12.5, 200, NULL, ?)`,
+		fx["verifyBatch"], "gpt-roundtrip-"+suffix, accountID, siteID, now)
+
+	// Tables the backup deliberately excludes: seeded so the assertions can
+	// prove they are dropped rather than merely absent from an empty database.
+	fx["sessionHash"] = "backup-roundtrip-session-" + suffix
+	execBackupFixture(t, db,
+		`INSERT INTO admin_sessions (token_hash, created_at, last_seen_at, expires_at, client_ip, user_agent)
+		 VALUES (?, ?, ?, ?, '203.0.113.7', 'roundtrip')`, fx["sessionHash"], now, now, now)
+	execBackupFixture(t, db,
+		`INSERT INTO admin_audit_logs (actor, method, path, status, request_id, remote_ip, created_at)
+		 VALUES ('roundtrip-actor', 'POST', '/api/roundtrip', 200, ?, '203.0.113.7', ?)`,
+		"roundtrip-"+suffix, now)
+	execBackupFixture(t, db,
+		`INSERT INTO model_probe_results (channel_id, account_id, site_id, model_name, status, latency_ms,
+		 http_status, error_text, created_at)
+		 VALUES (NULL, ?, ?, ?, 'success', 12.5, 200, NULL, ?)`, accountID, siteID, "gpt-roundtrip-"+suffix, now)
+	execBackupFixture(t, db,
+		`INSERT INTO catalog_sources (name, url, enabled, type, sort_order, last_success_at, last_error,
+		 last_count, last_attempt_at, created_at, updated_at)
+		 VALUES (?, ?, TRUE, 'custom', 0, NULL, NULL, 0, NULL, ?, ?)`,
+		"roundtrip-source-"+suffix, "https://catalog-roundtrip-"+suffix+".example.com/models.json", now, now)
+
+	return fx
+}
+
+func execBackupFixture(t *testing.T, db *store.DB, query string, args ...any) {
+	t.Helper()
+	if _, err := db.Exec(db.Rebind(query), args...); err != nil {
+		t.Fatalf("seed fixture: %v", err)
+	}
+}
+
+// runBackupTableSetRoundTrip exports everything, wipes the database in FK-safe
+// order, imports the payload and asserts what came back — and what did not.
+func runBackupTableSetRoundTrip(t *testing.T, db *store.DB) {
+	t.Helper()
+	fx := seedBackupTableSetFixture(t, db)
+
+	payload, err := buildBackupPayload(db.DB, "all")
+	if err != nil {
+		t.Fatalf("buildBackupPayload: %v", err)
+	}
+	tables, ok := payload["tables"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload tables = %#v, want object", payload["tables"])
+	}
+	for _, table := range newlyIncludedBackupTables {
+		if _, carried := tables[table]; !carried {
+			t.Fatalf("export payload omits %s, which the registry-derived backup set must carry", table)
+		}
+	}
+	for table, reason := range store.BackupExcludedTables() {
+		if _, carried := tables[table]; carried {
+			t.Fatalf("export payload carries %s, which is excluded (%q)", table, reason)
+		}
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	importBody, err := decodeBackupImportBodyFrom(raw)
+	if err != nil {
+		t.Fatalf("decode own export: %v", err)
+	}
+
+	// Wipe in the registry's FK-safe delete order: this is the "restored onto a
+	// fresh instance" half of the round trip.
+	for _, table := range store.ClearTableNames() {
+		if _, err := db.Exec(fmt.Sprintf(`DELETE FROM %q`, table)); err != nil {
+			t.Fatalf("wipe %s: %v", table, err)
+		}
+	}
+	if n := countBackupFixtureRows(t, db, `SELECT COUNT(*) FROM product_announcements`); n != 0 {
+		t.Fatalf("product_announcements still has %d rows after the wipe", n)
+	}
+
+	result, err := importBackupTables(db.DB, importBody)
+	if err != nil {
+		t.Fatalf("importBackupTables: %v", err)
+	}
+	for _, table := range newlyIncludedBackupTables {
+		if result.imported[table] != 1 {
+			t.Fatalf("imported[%s] = %d, want 1 (imported map: %v)", table, result.imported[table], result.imported)
+		}
+	}
+
+	// The rows are back, with their content, not just their row count.
+	if n := countBackupFixtureRows(t, db,
+		`SELECT COUNT(*) FROM product_announcements WHERE title = ?`, fx["announcementTitle"]); n != 1 {
+		t.Fatalf("product_announcements title %q rows = %d, want 1", fx["announcementTitle"], n)
+	}
+	if n := countBackupFixtureRows(t, db,
+		`SELECT COUNT(*) FROM announcement_dismissals d JOIN product_announcements p ON p.id = d.announcement_id
+		 WHERE p.title = ?`, fx["announcementTitle"]); n != 1 {
+		t.Fatalf("announcement_dismissals rows for the restored banner = %d, want 1", n)
+	}
+	var actual string
+	if err := db.Get(&actual, db.Rebind(
+		`SELECT actual FROM model_name_redirects WHERE canonical = ?`), fx["redirectCanonical"]); err != nil {
+		t.Fatalf("read restored model_name_redirects: %v", err)
+	}
+	if actual != fx["redirectActual"] {
+		t.Fatalf("model_name_redirects actual = %q, want %q", actual, fx["redirectActual"])
+	}
+	if n := countBackupFixtureRows(t, db,
+		`SELECT COUNT(*) FROM balance_history WHERE local_day = ? AND account_id = ?`,
+		fx["balanceDay"], fx["accountID"]); n != 1 {
+		t.Fatalf("balance_history rows = %d, want 1", n)
+	}
+	if n := countBackupFixtureRows(t, db,
+		`SELECT COUNT(*) FROM model_verify_history WHERE batch_id = ?`, fx["verifyBatch"]); n != 1 {
+		t.Fatalf("model_verify_history rows = %d, want 1", n)
+	}
+
+	// The deliberate exclusions stay excluded: a restore must not resurrect
+	// session credentials, another deployment's audit trail, its probe
+	// telemetry or its catalog fetch targets.
+	for table := range store.BackupExcludedTables() {
+		if n := countBackupFixtureRows(t, db, fmt.Sprintf(`SELECT COUNT(*) FROM %q`, table)); n != 0 {
+			t.Fatalf("%s has %d rows after the round trip, want 0 (it is excluded from backups)", table, n)
+		}
+	}
+	if n := countBackupFixtureRows(t, db,
+		`SELECT COUNT(*) FROM admin_sessions WHERE token_hash = ?`, fx["sessionHash"]); n != 0 {
+		t.Fatalf("the pre-wipe admin session survived the restore (%d rows), want 0", n)
+	}
+}
+
+func TestBackupTableSetRoundTrip(t *testing.T) {
+	runBackupTableSetRoundTrip(t, setupBackupTestDB(t))
+}
+
+func TestBackupTableSetRoundTripPostgres(t *testing.T) {
+	runBackupTableSetRoundTrip(t, setupBackupPostgresTestDB(t))
+}
+
+// TestImportAcceptsBackupWithoutTheNewTables is the backward-compatibility
+// gate: a payload written before the table set was derived carries none of the
+// newly included tables, and a missing table must be skipped, not an error.
+func TestImportAcceptsBackupWithoutTheNewTables(t *testing.T) {
+	db := setupBackupTestDB(t)
+	handler := &backupHandler{db: db.DB}
+
+	legacy := map[string]any{"metadata": map[string]any{
+		"exported_at": "2026-01-01T00:00:00Z",
+		"version":     "1.0",
+	}}
+	legacyTables := map[string]any{}
+	for _, table := range legacyBackupTables {
+		legacyTables[table] = []any{}
+	}
+	legacyTables["settings"] = []any{map[string]any{"key": "legacy_roundtrip_key", "value": `"dark"`}}
+	legacy["tables"] = legacyTables
+	legacy["type"] = "all"
+	raw, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal legacy payload: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/backup/import", strings.NewReader(string(raw)))
+	rec := httptest.NewRecorder()
+	handler.importBackup(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	imported, ok := body["imported"].(map[string]any)
+	if !ok {
+		t.Fatalf("imported = %#v, want object; body = %s", body["imported"], rec.Body.String())
+	}
+	if got := imported["settings"]; got != float64(1) {
+		t.Fatalf("imported.settings = %v, want 1; body = %s", got, rec.Body.String())
+	}
+	for _, table := range newlyIncludedBackupTables {
+		if _, present := imported[table]; present {
+			t.Fatalf("imported reports %s from a legacy payload that does not carry it", table)
+		}
+	}
+}
+
+// legacyBackupTables is the 28-table set the hand-copied list carried before it
+// was derived from the registry; a backup written by that build has exactly
+// these keys.
+var legacyBackupTables = []string{
+	"sites", "site_api_endpoints", "site_disabled_models", "accounts", "account_tokens",
+	"checkin_logs", "model_availability", "token_model_availability", "token_routes",
+	"route_group_sources", "oauth_route_units", "oauth_route_unit_members", "route_channels",
+	"proxy_logs", "proxy_debug_traces", "proxy_debug_attempts", "proxy_video_tasks",
+	"admin_background_tasks", "proxy_files", "settings", "admin_snapshots",
+	"analytics_projection_checkpoints", "site_day_usage", "site_hour_usage", "model_day_usage",
+	"downstream_api_keys", "site_announcements", "events",
+}
+
+// TestImportRefusesBackupExcludedTables pins the exclusion on the import side:
+// a payload that hand-crafts an excluded table is rejected as unknown, so the
+// exclusion cannot be bypassed by a caller who writes the JSON themselves.
+func TestImportRefusesBackupExcludedTables(t *testing.T) {
+	for table := range store.BackupExcludedTables() {
+		t.Run(table, func(t *testing.T) {
+			db := setupBackupTestDB(t)
+			handler := &backupHandler{db: db.DB}
+
+			payload := fmt.Sprintf(`{"tables":{%s:[]}}`, strconv.Quote(table))
+			req := httptest.NewRequest(http.MethodPost, "/api/settings/backup/import", strings.NewReader(payload))
+			rec := httptest.NewRecorder()
+			handler.importBackup(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), "unknown table "+table) {
+				t.Fatalf("body = %s, want an unknown-table rejection naming %s", rec.Body.String(), table)
+			}
+		})
+	}
+}
+
+// TestExportResponseDisclosesExcludedTables is the operator-visibility gate at
+// the HTTP boundary: the export response states which registry tables the
+// backup does not carry and why, without changing the pre-existing fields.
+func TestExportResponseDisclosesExcludedTables(t *testing.T) {
+	db := setupBackupTestDB(t)
+	handler := &backupHandler{db: db.DB}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/settings/backup/export?type=all", nil)
+	rec := httptest.NewRecorder()
+	handler.exportBackup(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+
+	var payload struct {
+		Metadata map[string]json.RawMessage `json:"metadata"`
+		Type     string                     `json:"type"`
+		Tables   map[string]json.RawMessage `json:"tables"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal export response: %v", err)
+	}
+	if payload.Type != "all" {
+		t.Fatalf("type = %q, want all", payload.Type)
+	}
+	if _, ok := payload.Metadata["exported_at"]; !ok {
+		t.Fatalf("metadata lost exported_at: %v", payload.Metadata)
+	}
+	var version string
+	if err := json.Unmarshal(payload.Metadata["version"], &version); err != nil || version != "1.0" {
+		t.Fatalf("metadata.version = %s (%v), want \"1.0\"", payload.Metadata["version"], err)
+	}
+	excludedRaw, ok := payload.Metadata["excluded_tables"]
+	if !ok {
+		t.Fatalf("metadata has no excluded_tables: %v", payload.Metadata)
+	}
+	var excluded map[string]string
+	if err := json.Unmarshal(excludedRaw, &excluded); err != nil {
+		t.Fatalf("excluded_tables = %s, want an object of table -> reason: %v", excludedRaw, err)
+	}
+	want := store.BackupExcludedTables()
+	if len(excluded) != len(want) {
+		t.Fatalf("excluded_tables has %d entries (%s), want the %d deliberate exclusions",
+			len(excluded), excludedRaw, len(want))
+	}
+	for table, reason := range want {
+		if excluded[table] != reason {
+			t.Fatalf("excluded_tables[%s] = %q, want %q", table, excluded[table], reason)
+		}
+		if _, carried := payload.Tables[table]; carried {
+			t.Fatalf("payload carries %s while metadata lists it as excluded", table)
+		}
+	}
+	for _, table := range newlyIncludedBackupTables {
+		if _, carried := payload.Tables[table]; !carried {
+			t.Fatalf("export response omits %s", table)
+		}
+	}
+}

--- a/service/backup/backup_tableset_test.go
+++ b/service/backup/backup_tableset_test.go
@@ -1,0 +1,168 @@
+package backup_test
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	backupsvc "github.com/deliciousbuding/metapi-go/service/backup"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// TestAllTablesCoversSchemaRegistry is the backup drift guard: every table the
+// schema registry creates must either ship in a type=all backup or be excluded
+// by name in store.BackupExcludedTables() with a recorded reason. A table that
+// is in neither is a silent gap — its rows are dropped by every export and the
+// restore looks complete while it is not.
+func TestAllTablesCoversSchemaRegistry(t *testing.T) {
+	inBackup := map[string]bool{}
+	for _, table := range backupsvc.AllTables {
+		if inBackup[table] {
+			t.Fatalf("backup table set lists %s twice", table)
+		}
+		inBackup[table] = true
+	}
+	excluded := store.BackupExcludedTables()
+
+	var silent []string
+	for _, table := range store.SchemaTableNames() {
+		if inBackup[table] {
+			if reason, ok := excluded[table]; ok {
+				t.Fatalf("%s is both exported and excluded (%q); pick one", table, reason)
+			}
+			continue
+		}
+		if _, ok := excluded[table]; !ok {
+			silent = append(silent, table)
+		}
+	}
+	sort.Strings(silent)
+	if len(silent) > 0 {
+		t.Fatalf("%d schema table(s) are silently dropped by the backup export: %v — "+
+			"add each one to backupExcludedTables in store/tablesets.go with the reason it must "+
+			"not be carried, or it ships in every type=all backup by default", len(silent), silent)
+	}
+}
+
+// TestAllTablesIsDerivedFromTheRegistry pins the absence of a second copy: the
+// exported set must be exactly store.BackupTableNames(), in the same FK-safe
+// order, so a schema addition cannot be missed by forgetting to edit a list.
+func TestAllTablesIsDerivedFromTheRegistry(t *testing.T) {
+	if got, want := backupsvc.AllTables, store.BackupTableNames(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("backup.AllTables = %v, want store.BackupTableNames() = %v", got, want)
+	}
+}
+
+// TestAccountsTablesScopeIsKnownAndSubset keeps the type=accounts scope honest:
+// every member must be a registry table that a full backup also carries, and
+// the order must be the registry's FK-safe order (one ordering owner).
+func TestAccountsTablesScopeIsKnownAndSubset(t *testing.T) {
+	registry := map[string]bool{}
+	for _, table := range store.SchemaTableNames() {
+		registry[table] = true
+	}
+	inBackup := map[string]bool{}
+	for _, table := range backupsvc.AllTables {
+		inBackup[table] = true
+	}
+	for _, table := range backupsvc.AccountsTables {
+		if !registry[table] {
+			t.Fatalf("accounts export scope lists %s, which is not in the schema registry", table)
+		}
+		if !inBackup[table] {
+			t.Fatalf("accounts export scope lists %s, which the full backup set excludes", table)
+		}
+	}
+
+	pos := map[string]int{}
+	for i, table := range backupsvc.AllTables {
+		pos[table] = i
+	}
+	for i := 1; i < len(backupsvc.AccountsTables); i++ {
+		prev, cur := pos[backupsvc.AccountsTables[i-1]], pos[backupsvc.AccountsTables[i]]
+		if prev > cur {
+			t.Fatalf("accounts export order puts %s (pos %d) after %s (pos %d); "+
+				"it must follow the registry FK-safe order",
+				backupsvc.AccountsTables[i-1], prev, backupsvc.AccountsTables[i], cur)
+		}
+	}
+}
+
+// TestBuildPayloadMetadataListsExcludedTables is the operator-visibility gate:
+// the export payload must state which registry tables it does not carry, with a
+// non-empty reason, and must not claim a gap for a table it does carry.
+func TestBuildPayloadMetadataListsExcludedTables(t *testing.T) {
+	db := setupBackupServiceTestDB(t)
+
+	for _, exportType := range []string{"all", "accounts", "preferences"} {
+		payload, err := backupsvc.BuildPayload(db.DB, exportType)
+		if err != nil {
+			t.Fatalf("BuildPayload(%s): %v", exportType, err)
+		}
+		metadata, ok := payload["metadata"].(map[string]any)
+		if !ok {
+			t.Fatalf("metadata = %#v, want object", payload["metadata"])
+		}
+		if _, ok := metadata["exported_at"].(string); !ok {
+			t.Fatalf("metadata.exported_at = %#v, want the pre-existing RFC3339 string", metadata["exported_at"])
+		}
+		if got := metadata["version"]; got != "1.0" {
+			t.Fatalf("metadata.version = %#v, want the pre-existing \"1.0\"", got)
+		}
+		excluded, ok := metadata["excluded_tables"].(map[string]string)
+		if !ok {
+			t.Fatalf("metadata.excluded_tables = %#v, want map[table]reason", metadata["excluded_tables"])
+		}
+
+		tables, ok := payload["tables"].(map[string]any)
+		if !ok {
+			t.Fatalf("tables = %#v, want object", payload["tables"])
+		}
+		for carried := range tables {
+			if reason, claimed := excluded[carried]; claimed {
+				t.Fatalf("type=%s payload carries %s but metadata.excluded_tables claims it is missing (%q)",
+					exportType, carried, reason)
+			}
+		}
+		for table, reason := range excluded {
+			if strings.TrimSpace(reason) == "" {
+				t.Fatalf("type=%s metadata.excluded_tables[%s] has an empty reason", exportType, table)
+			}
+		}
+
+		// The deliberate exclusions are reported for every export type.
+		for table, wantReason := range store.BackupExcludedTables() {
+			got, ok := excluded[table]
+			if !ok {
+				t.Fatalf("type=%s metadata.excluded_tables omits %s, which the backup never carries", exportType, table)
+			}
+			if got != wantReason {
+				t.Fatalf("type=%s excluded reason for %s = %q, want the recorded %q", exportType, table, got, wantReason)
+			}
+		}
+		if exportType == "all" {
+			if len(excluded) != len(store.BackupExcludedTables()) {
+				t.Fatalf("type=all metadata.excluded_tables = %d entries (%v), want exactly the %d deliberate exclusions",
+					len(excluded), keysOf(excluded), len(store.BackupExcludedTables()))
+			}
+			continue
+		}
+		// A scoped export must also disclose the tables outside its scope.
+		if _, ok := excluded["settings"]; exportType == "accounts" && !ok {
+			t.Fatalf("type=accounts metadata.excluded_tables omits settings, which that scope does not carry")
+		}
+		if _, ok := excluded["accounts"]; exportType == "preferences" && !ok {
+			t.Fatalf("type=preferences metadata.excluded_tables omits accounts, which that scope does not carry")
+		}
+	}
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/service/backup/export.go
+++ b/service/backup/export.go
@@ -6,62 +6,58 @@ import (
 	"strings"
 	"time"
 
+	"github.com/deliciousbuding/metapi-go/store"
 	"github.com/jmoiron/sqlx"
 )
 
 // AllTables is the full backup/export order, with parent tables before
-// children so imports can replay it safely.
-var AllTables = []string{
-	"sites",
-	"site_api_endpoints",
-	"site_disabled_models",
-	"accounts",
-	"account_tokens",
-	"checkin_logs",
-	"model_availability",
-	"token_model_availability",
-	"token_routes",
-	"route_group_sources",
-	"oauth_route_units",
-	"oauth_route_unit_members",
-	"route_channels",
-	"proxy_logs",
-	"proxy_debug_traces",
-	"proxy_debug_attempts",
-	"proxy_video_tasks",
-	"admin_background_tasks",
-	"proxy_files",
-	"settings",
-	"admin_snapshots",
-	"analytics_projection_checkpoints",
-	"site_day_usage",
-	"site_hour_usage",
-	"model_day_usage",
-	"downstream_api_keys",
-	"site_announcements",
-	"events",
+// children so imports can replay it safely. It is derived from the store
+// schema registry minus store.BackupExcludedTables() — the same single source
+// of truth that drives AutoMigrate, cmd/migrate and the factory reset — so a
+// table added to the schema ships in every type=all backup until somebody
+// excludes it by name with a recorded reason. This used to be a hand-copied
+// list that had drifted to 28 of 37 tables: product_announcements,
+// announcement_dismissals, model_name_redirects, balance_history and
+// model_verify_history were silently dropped from every export.
+var AllTables = store.BackupTableNames()
+
+// accountsExportScope names the tables an export of type=accounts carries. It
+// is a scope declaration, not an ordering: AccountsTables below intersects it
+// with the registry-derived backup order, so there is one FK-safe order owner.
+var accountsExportScope = map[string]bool{
+	"sites":                    true,
+	"site_api_endpoints":       true,
+	"site_disabled_models":     true,
+	"accounts":                 true,
+	"account_tokens":           true,
+	"checkin_logs":             true,
+	"model_availability":       true,
+	"token_model_availability": true,
+	"token_routes":             true,
+	"route_group_sources":      true,
+	"oauth_route_units":        true,
+	"oauth_route_unit_members": true,
+	"route_channels":           true,
+	"proxy_video_tasks":        true,
+	"admin_background_tasks":   true,
+	"proxy_files":              true,
+	"downstream_api_keys":      true,
+	"site_announcements":       true,
 }
 
-// AccountsTables is the subset exported when type=accounts.
-var AccountsTables = []string{
-	"sites",
-	"site_api_endpoints",
-	"site_disabled_models",
-	"accounts",
-	"account_tokens",
-	"checkin_logs",
-	"model_availability",
-	"token_model_availability",
-	"token_routes",
-	"route_group_sources",
-	"oauth_route_units",
-	"oauth_route_unit_members",
-	"route_channels",
-	"proxy_video_tasks",
-	"admin_background_tasks",
-	"proxy_files",
-	"downstream_api_keys",
-	"site_announcements",
+// AccountsTables is the subset exported when type=accounts, in the same
+// FK-safe order as AllTables.
+var AccountsTables = filterTables(AllTables, accountsExportScope)
+
+// filterTables keeps the members of scope in the order given by tables.
+func filterTables(tables []string, scope map[string]bool) []string {
+	out := make([]string, 0, len(scope))
+	for _, t := range tables {
+		if scope[t] {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 var ErrInvalidExportType = errors.New("invalid export type; only all/accounts/preferences are supported")
@@ -101,12 +97,43 @@ func BuildPayload(db *sqlx.DB, exportType string) (map[string]any, error) {
 
 	return map[string]any{
 		"metadata": map[string]any{
-			"exported_at": time.Now().UTC().Format(time.RFC3339Nano),
-			"version":     "1.0",
+			"exported_at":     time.Now().UTC().Format(time.RFC3339Nano),
+			"version":         "1.0",
+			"excluded_tables": excludedTablesFor(exportType, tables),
 		},
 		"type":   exportType,
 		"tables": result,
 	}, nil
+}
+
+// excludedTablesFor reports every schema-registry table this payload does NOT
+// carry, keyed by table name with the reason. Two kinds of gap are surfaced:
+// the deliberate backup exclusions (store.BackupExcludedTables) and, for a
+// scoped export type, the tables outside that scope.
+//
+// It lands in metadata.excluded_tables so a backup file states its own gaps
+// instead of leaving an operator to discover them after a restore. The field
+// is purely additive: exported_at and version keep their shape, and both
+// importers (the tables path and the TS v2.1 path) ignore metadata entirely,
+// so existing payloads and existing consumers are unaffected.
+func excludedTablesFor(exportType string, exported []string) map[string]string {
+	inPayload := make(map[string]bool, len(exported))
+	for _, t := range exported {
+		inPayload[t] = true
+	}
+	reasons := store.BackupExcludedTables()
+	out := map[string]string{}
+	for _, t := range store.SchemaTableNames() {
+		if inPayload[t] {
+			continue
+		}
+		if reason, ok := reasons[t]; ok {
+			out[t] = reason
+			continue
+		}
+		out[t] = fmt.Sprintf("not part of the %q export scope", exportType)
+	}
+	return out
 }
 
 func TablesForExportType(exportType string) (string, []string, error) {

--- a/store/backup_tablesets_test.go
+++ b/store/backup_tablesets_test.go
@@ -1,0 +1,89 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBackupExcludedTablesAreRegistryMembersWithReasons guards the exclusion
+// side of the backup set: an entry naming a table the registry does not create
+// is dead weight that hides a rename, and an entry without a reason is exactly
+// the "forgot to add it" failure mode the derived set exists to prevent. The
+// reason is also what operators see in metadata.excluded_tables, so it must say
+// something.
+func TestBackupExcludedTablesAreRegistryMembersWithReasons(t *testing.T) {
+	registry := map[string]bool{}
+	for _, table := range SchemaTableNames() {
+		registry[table] = true
+	}
+	for table, reason := range backupExcludedTables {
+		if !registry[table] {
+			t.Fatalf("backupExcludedTables names %q, which the schema registry does not create; "+
+				"remove the orphan or fix the name (an orphan exclusion silently un-guards the real table)", table)
+		}
+		if len(strings.TrimSpace(reason)) < 20 {
+			t.Fatalf("backupExcludedTables[%q] reason = %q; it is shown to operators in "+
+				"metadata.excluded_tables and must state why the table is not carried", table, reason)
+		}
+	}
+	if len(backupExcludedTables) != len(BackupExcludedTables()) {
+		t.Fatalf("BackupExcludedTables() returned %d entries, want %d (it must copy the whole set)",
+			len(BackupExcludedTables()), len(backupExcludedTables))
+	}
+}
+
+// TestBackupTableNamesAreFKSafe replays the import contract: a backup is
+// imported in payload order inside one transaction, so every parent must
+// precede the children that reference it or the restore dies on a foreign key.
+func TestBackupTableNamesAreFKSafe(t *testing.T) {
+	if err := schemaRegistryErr(); err != nil {
+		t.Fatalf("schema registry: %v", err)
+	}
+	f := facts()
+	names := BackupTableNames()
+	pos := make(map[string]int, len(names))
+	for i, name := range names {
+		pos[name] = i
+	}
+	for _, name := range names {
+		for _, parent := range f.parents[name] {
+			p, ok := pos[parent]
+			if !ok {
+				continue // parent excluded from backups: no ordering constraint inside the set
+			}
+			if p > pos[name] {
+				t.Fatalf("BackupTableNames() puts %s (pos %d) before its parent %s (pos %d); "+
+					"an import replaying this order violates the foreign key", name, pos[name], parent, p)
+			}
+		}
+	}
+}
+
+// TestBackupTableNamesPreserveRegistryOrder pins the derivation: the backup set
+// must be AllTableNames() minus the exclusions, in the same order, so there is
+// one topological order owner instead of a second hand-sorted list.
+func TestBackupTableNamesPreserveRegistryOrder(t *testing.T) {
+	excluded := map[string]bool{}
+	for table := range backupExcludedTables {
+		excluded[table] = true
+	}
+	var want []string
+	for _, table := range AllTableNames() {
+		if !excluded[table] {
+			want = append(want, table)
+		}
+	}
+	got := BackupTableNames()
+	if len(got) != len(want) {
+		t.Fatalf("BackupTableNames() returned %d tables, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("BackupTableNames()[%d] = %s, want %s (registry order)", i, got[i], want[i])
+		}
+	}
+	if len(got)+len(backupExcludedTables) != len(SchemaTableNames()) {
+		t.Fatalf("backup set (%d) + exclusions (%d) != registry (%d): every registry table must be "+
+			"accounted for exactly once", len(got), len(backupExcludedTables), len(SchemaTableNames()))
+	}
+}

--- a/store/tablesets.go
+++ b/store/tablesets.go
@@ -90,6 +90,45 @@ var factoryResetExcludedTables = map[string]string{
 	"schema_migrations": "additive-migration journal: bookkeeping, not business data; wiping it replays every step",
 }
 
+// backupExcludedTables names schema tables a backup export must NOT carry,
+// with the operator-facing reason. Everything else in the registry ships in a
+// type=all backup and is replayed by the import endpoints, so a table is left
+// out of backups by an entry here — never by being absent from a hand-written
+// list, which is how service/backup.AllTables drifted to 28 of 37 tables and
+// silently dropped product_announcements, model_name_redirects and friends.
+//
+// The reasons are emitted verbatim into the export payload
+// (metadata.excluded_tables) so a backup file states its own gaps; keep each
+// one to a single sentence and put the long form in docs/api/settings.md.
+var backupExcludedTables = map[string]string{
+	// Session credential material. A backup is semi-trusted input (see
+	// backupsvc.RuntimeLocalSettingKeys for the same threat model applied to
+	// settings rows): importing token hashes would let a cookie issued on the
+	// source deployment authenticate against this one. A restored deployment
+	// must require a fresh login instead.
+	"admin_sessions": "session credential material: an import must never plant admin session token hashes, so a restored deployment requires a fresh login",
+	// One row per authenticated admin write, appended forever (no retention job
+	// prunes it). Beyond volume, the rows describe operations performed against
+	// the source deployment; replaying them into another database makes that
+	// database's audit trail assert events that never happened there, which
+	// destroys the only property an audit log has.
+	"admin_audit_logs": "append-only audit trail of the source deployment's admin writes; replaying it into another database forges that database's audit record (and no retention job bounds its size)",
+	// Appended by the background prober on every pass, and read back by
+	// service/route_rebuild.go (latest row per account_id+model_name) to steer
+	// routing. Imported probe rows from another deployment would therefore
+	// drive this deployment's route rebuild on stale evidence; the prober
+	// re-populates the table within one interval after a restore.
+	"model_probe_results": "high-frequency background probe telemetry that route rebuild reads as its latest-per-model signal; stale rows from another deployment would steer routing, and the prober regenerates them after a restore",
+	// Every row's url is fetched server-side by the catalog sync
+	// (service/pricingcatalog provider on httpclient.SharedTransport, which
+	// carries no dial-level SSRF guard), while the import URL guard
+	// (service/import_url_guard.go importURLColumns) covers only sites and
+	// site_api_endpoints today. Admitting these rows through a semi-trusted
+	// backup would let a crafted payload plant a cloud-metadata / link-local
+	// fetch target. Extend that guard, then delete this entry.
+	"catalog_sources": "each row's url is fetched server-side by the catalog sync and the import URL guard does not cover this table yet, so a crafted backup could plant an SSRF fetch target",
+}
+
 // Column kinds reported by schemaColumns. They drive value coercion in the
 // generic copy builder and the boolean-default parity assertions.
 const (
@@ -408,6 +447,33 @@ func FactoryResetTableNames() []string {
 			continue
 		}
 		out = append(out, t)
+	}
+	return out
+}
+
+// BackupTableNames returns the tables a backup export carries, ordered
+// parents-before-children so an import can replay the payload in one pass
+// without violating a foreign key. It is the schema registry minus
+// backupExcludedTables; service/backup must not keep its own copy of the list.
+func BackupTableNames() []string {
+	out := make([]string, 0, len(schemaTables))
+	for _, t := range AllTableNames() {
+		if _, skip := backupExcludedTables[t]; skip {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// BackupExcludedTables returns a copy of the backup exclusion set: table name
+// to the reason it is not carried. Callers surface it to operators
+// (metadata.excluded_tables in the export payload) and the drift guard checks
+// it against the registry, so an exclusion can never be silent or orphaned.
+func BackupExcludedTables() map[string]string {
+	out := make(map[string]string, len(backupExcludedTables))
+	for t, reason := range backupExcludedTables {
+		out[t] = reason
 	}
 	return out
 }


### PR DESCRIPTION
## 改动摘要

`service/backup.AllTables` 是仓库里**第三份**手抄表清单（前两份已在 #1165 消灭），它漂移到了 37 张表里的 28 张。差集是实测的 9 张，其中 **5 张是用户可见状态**，每次 `type=all` 导出都静默丢弃它们，而导入端回 200 报成功：

| 被静默丢弃的表 | 恢复到空库会缺什么 |
|---|---|
| `product_announcements` | 运营撰写的产品横幅全部消失 |
| `announcement_dismissals` | 用户的「已忽略」状态丢失 ⇒ 已读公告重新弹出 |
| `model_name_redirects` | `source=manual` 的行是运营手写、目录同步永不重生成 ⇒ 手工改名规则全丢，上游模型名解析回退 |
| `balance_history` | 余额趋势从恢复日起空白；过去某天的上游余额**永远无法回看** |
| `model_verify_history` | 运营发起的批量校验历史消失，不会自动重生成 |

现在备份集从 schema 注册表派生：`store.BackupTableNames()` = 注册表 − `backupExcludedTables`（**4 项，每项一句运维可读的理由**），`service/backup.AllTables` 直接等于它，`AccountsTables` 从「第二份排序清单」改成「scope 集合 ∩ 注册表拓扑序」——排序只剩一个主人。导出 payload 的 `metadata` 新增 `excluded_tables`（`map[表名]理由`），**备份文件自己陈述自己的缺口**；`docs/api/settings.md` 写出派生规则、4 条排除的理由表、限制与 400 语义。

剩下 4 张**显式排除**（不是忘记加，每项都带理由、进 metadata、进 docs，并被门禁钉住）：

- `admin_sessions`：会话凭据材料。备份是半可信输入（与 `RuntimeLocalSettingKeys` 同一威胁模型），导入 token hash 会让源站签发的 cookie 在本站生效；恢复后要求重新登录才是正确语义。
- `admin_audit_logs`：源站 admin 写操作的 append-only 轨迹（且无 retention job 限界）。灌进另一个库等于让该库的审计记录断言从未发生过的操作，毁掉审计日志唯一的属性。
- `model_probe_results`：后台探针每 tick 重建，且 `service/route_rebuild.go` 取每 (account, model) **最新一行**决定路由 ⇒ 他库陈旧探测会直接操纵本库路由重建；恢复后一个周期内自动重填。
- `catalog_sources`：每行的 `url` 由目录同步**服务端抓取**（`service/pricingcatalog` provider 走 `httpclient.SharedTransport()`，该 transport 不带 dial 级 SSRF 守卫），而导入 URL 闸 `service/import_url_guard.go` 的 `importURLColumns` 今天只覆盖 `sites` / `site_api_endpoints`。让半可信备份写入这张表 = 可以被植入 cloud-metadata / link-local 抓取目标。**扩展那道闸之后删掉这一条即自动纳入**（理由已写进代码注释与 docs）。

## 类型

- [x] fix（bug 修复：备份静默丢 5 张用户可见状态表）
- [x] refactor（第三份手抄清单消灭，排序单一主人）

## 行为变更（需要进 CHANGELOG）

- `GET /api/settings/backup/export`（`type=all`）现在多携带 5 张表：`product_announcements`、`announcement_dismissals`、`model_name_redirects`、`balance_history`、`model_verify_history`。备份文件因此变大（`balance_history` / `model_verify_history` 是历史表，量随运行时长增长）。
- 导出 payload 的 `metadata` 新增 `excluded_tables`（`map[表名]理由`）。**只加字段**：`exported_at` / `version` / `type` / `tables` 形状一字未改，两条导入路径都完全忽略 `metadata`，所以 WebDAV 往返与 TS v2.1 兼容层不受影响。
- 导入请求若点名要一张被排除的表 → 400（此前是静默忽略）。
- 旧备份（不含新纳入的表）导入照常成功：缺表 = 跳过，不是错误。

## 测试验证

- [x] `go build ./...` / `go vet ./...` 通过；`gofmt -l` 对触及的 6 个 `.go` 文件为空（仓库历史漂移文件一个没碰）
- [x] PG 门禁**连跑两遍**均绿（复用同一个库，`-p 1 -tags=integration`，集成方复跑）：`service/backup 0.75s/0.70s · store 14.1s/14.0s · handler/admin 62.3s/58.8s · docs 1.5s/1.8s`
- [x] 新增 4 类门禁：
  - **漂移守卫**：注册表里出现一张既不在备份集、也不在排除 map 里的表 → 红，且错误信息直接说该做什么（`add each one to backupExcludedTables in store/tablesets.go with the reason it must not be carried, or it ships in every type=all backup by default`）
  - **排除集守卫**：孤儿排除项 → 红（`an orphan exclusion silently un-guards the real table`）；理由必须非空；备份集与排除集不得重叠；33 + 4 = 37 完整性
  - **FK 序守卫** + 与注册表序一致性
  - **往返 / 兼容 / 可见性**：SQLite + PG 双跑「导出 → FK 序清空 → 导入」断言数据真的回来了；旧备份兼容；排除表被 400 拒；`metadata.excluded_tables` 在 HTTP 响应里可见
- [x] **变异探针 red → green（交付方 4 发 4 中 + 集成方独立复跑 1 发）**：
  - 集成方 M1（最强的那一发）：把 `product_announcements` **带着理由**塞进排除 map（漂移守卫抓不到这种「过度排除」）→ 3 条 FAIL：`TestBackupTableSetRoundTrip` 与 `TestBackupTableSetRoundTripPostgres` 均 `export payload omits product_announcements, which the registry-derived backup set must carry`、`TestExportResponseDisclosesExcludedTables` `export response omits product_announcements`；`git checkout --` 还原后 `sha256sum -c` 双文件一致、`grep B6-MUTATION` 零命中、复跑全绿
  - 交付方另有：偷偷 `continue` 掉一张表（漂移守卫红）· 排除 map 加孤儿项（孤儿守卫红）· 从 payload 摘掉 `metadata.excluded_tables`（可见性 + 单元测试双红，且证明 `version` 原始字节仍是 `"1.0"`）
- [x] 改前红的量化原文：`9 schema table(s) are silently dropped by the backup export: [admin_audit_logs admin_sessions announcement_dismissals balance_history catalog_sources model_name_redirects model_probe_results model_verify_history product_announcements]`；实现后守卫升级为「排除必须显式」时中间态红 `4 schema table(s)…`，再转绿——证明 4 项排除是被守卫识别的，不是漏网
- [x] TS v2.1 兼容：fixture 全部内联在 `service/backup/ts_backup_v21_test.go`（仓库无 testdata 字节文件），**一个字节未改**，随 `./service/backup` 全绿

## 自查清单

- [x] 无密钥/内部路径泄漏（注释一律仓库相对路径）
- [x] 无新增 env 变量、无 schema 变更、无新依赖
- [x] 行为变更已补测试并在本描述中列出 CHANGELOG 条目
- [x] `docs/api/settings.md` 同步（备份段 + 一处必要更正，见下）

## 一处对 #1165 文档的更正（请复核）

#1165 给恢复出厂那段写的退路是 `Export a backup first (GET /api/settings/backup/export) if you need them`——**这句话在写下的时候就是假的**：备份从来不含 `admin_audit_logs` 与 `model_probe_results`，等于引导运营走一条不存在的退路。本 PR 把它改成明确说明「备份不保留它们 + 理由见备份段 + 需要就自己用数据库工具 dump」。同一次改动使同文件的另一句成真，属必要更正；若要求零越界，回滚这一句不影响代码与门禁。

## 已知遗留（本 PR 不做，已记录）

1. **`catalog_sources` 的纳入差一行 SSRF 闸**（写集外）：`service/import_url_guard.go` 的 `importURLColumns` 加 `"catalog_sources": {"url"}`，然后删掉排除项即自动纳入（往返测试的排除断言由 map 驱动，会随之收紧）。更深一层：`httpclient.SharedTransport()` 不带 `SiteDialGuard`，即目录同步的抓取路径本身缺 dial 级守卫——建议单独一条 lane 一起做。
2. **PG 导入不重置自增序列**（既有缺陷，与本 PR 无关但同源可见）：`handler/admin/settings_backup.go` 的 `importBackupTablesWithConn` 全程无 `setval` / `sqlite_sequence` 处理（`cmd/migrate` 是有的）。把带显式 id 的备份恢复到空 PG 库后，序列仍停在 1，下一次不带 id 的 INSERT 会与恢复行撞主键。这对改前那 28 张表同样成立；修它要动导入事务的形状，风险面比本 lane 大。
