### PR TITLE
fix(store): keep configured values when a settings row cannot be read

### DIFF
--- a/store/settings.go
+++ b/store/settings.go
@@ -247,9 +247,26 @@ func ApplyRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings, settin
 			// = enabled), mirroring config.Load's CHECKIN_ENABLED handling.
 			rt.CheckinDisabled = !parseBoolSetting(value, !rt.CheckinDisabled)
 		case "checkin_schedule_mode":
-			switch strings.ToLower(parseJSONSettingString(value)) {
+			// config.Load resolves CHECKIN_SCHEDULE_MODE through the same
+			// three-value enum, and RuntimeSettings.Validate reports anything
+			// else as a critical boot error, so an unreadable row must keep the
+			// resolved mode instead of poisoning the snapshot. Keeping it
+			// silently left the row and GET /api/settings/runtime disagreeing
+			// forever: scheduler/settings.go re-reads the row and falls back the
+			// same way, so nothing ever surfaced the stale value. Reachable
+			// through a backup import (the tables path validates only the cell
+			// type), a hand edit, or a legacy row service/settingsmigration
+			// leaves behind without validating the mode.
+			mode := strings.ToLower(parseJSONSettingString(value))
+			switch mode {
 			case "cron", "interval", "window":
-				rt.CheckinScheduleMode = strings.ToLower(parseJSONSettingString(value))
+				rt.CheckinScheduleMode = mode
+			default:
+				reason := fmt.Sprintf("%q is not cron, interval or window", mode)
+				if mode == "" {
+					reason = "value carries no mode"
+				}
+				warnUnreadableSettingRow("checkin_schedule_mode", reason, rt.CheckinScheduleMode)
 			}
 		case "checkin_interval_hours":
 			// config.Load resolves CHECKIN_INTERVAL_HOURS as
@@ -481,10 +498,28 @@ func ApplyRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings, settin
 			} else {
 				slog.Warn("settings: ignoring invalid global_allowed_models value")
 			}
+		// Non-destructive: a row hydration cannot read means the persisted
+		// intent is unrecoverable, not that the operator asked for no rules.
+		// Both branches used to assign the parse result directly, and
+		// config.ParseJsonValue encodes failure as nil, so one bad row emptied
+		// a configured rule set on the next restart with nothing in the log.
+		// An explicit clear still works: the admin write path persists JSON
+		// null or `[]` (upsertSettingDB normalizes a nil body value to an empty
+		// slice), both of which parse.
 		case "payload_rules":
-			rt.PayloadRules = config.ParseJsonValue(value)
+			if rules, err := parseJSONValueSetting(value); err == nil {
+				rt.PayloadRules = rules
+			} else {
+				warnUnreadableSettingRow("payload_rules", err.Error(),
+					describeJSONSettingValue(rt.PayloadRules))
+			}
 		case "openai_service_tier_rules":
-			cfg.OpenAiServiceTierRules = config.ParseJsonValue(value)
+			if rules, err := parseJSONValueSetting(value); err == nil {
+				cfg.OpenAiServiceTierRules = rules
+			} else {
+				warnUnreadableSettingRow("openai_service_tier_rules", err.Error(),
+					describeJSONSettingValue(cfg.OpenAiServiceTierRules))
+			}
 
 		// N7: prompt-cache ratio fallback overrides (0 = use code default).
 		case "cache_ratio_default":
@@ -522,16 +557,24 @@ func ApplyRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings, settin
 		// Stored as {"token_expired":true,"low_balance":false,...}; missing
 		// keys default to enabled (backward-compatible). nil/empty = all enabled.
 		case "notify_task_toggles":
-			if value != "" {
-				toggles := map[string]bool{}
-				if err := json.Unmarshal([]byte(value), &toggles); err == nil {
-					if rt.NotifyTaskToggles == nil {
-						rt.NotifyTaskToggles = map[string]bool{}
-					}
-					for k, v := range toggles {
-						rt.NotifyTaskToggles[k] = v
-					}
+			// service/notify gates each alert type on this map and treats a
+			// missing key as enabled, so a row hydration cannot read must not
+			// become "every alert type is unmuted": keep the resolved toggles
+			// and say so. The admin write path marshals whatever the request
+			// carried without checking that it is an object of booleans
+			// (handler/admin/settings_apply.go), so a wrong-shaped row is
+			// reachable without hand-editing the table. The loop above already
+			// skipped empty cells, which carry no intent.
+			if toggles, err := parseNotifyTaskTogglesSetting(value); err == nil {
+				if rt.NotifyTaskToggles == nil {
+					rt.NotifyTaskToggles = map[string]bool{}
 				}
+				for k, v := range toggles {
+					rt.NotifyTaskToggles[k] = v
+				}
+			} else {
+				warnUnreadableSettingRow("notify_task_toggles", err.Error(),
+					fmt.Sprintf("%d toggles", len(rt.NotifyTaskToggles)))
 			}
 
 		default:
@@ -721,4 +764,85 @@ func parseJSONSettingString(value string) string {
 		return strings.TrimSpace(decoded)
 	}
 	return strings.TrimSpace(value)
+}
+
+// parseJSONValueSetting decodes a settings row that holds arbitrary JSON. An
+// empty cell, or one encoding/json cannot read, means the persisted intent is
+// unrecoverable: the caller must keep the value it already resolved instead of
+// assigning the failure result, because config.ParseJsonValue encodes that
+// failure as nil and a direct assignment turned one unreadable row into an
+// empty rule set. A readable JSON null IS intent ("no rules") and comes back as
+// (nil, nil).
+func parseJSONValueSetting(raw string) (any, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, fmt.Errorf("value is empty")
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(trimmed), &decoded); err != nil {
+		return nil, fmt.Errorf("not valid JSON: %v", err)
+	}
+	return decoded, nil
+}
+
+// parseNotifyTaskTogglesSetting decodes the per-alert-type mute map. Only a
+// JSON object of booleans — or null, meaning "no per-type overrides" — carries
+// a readable intent; an array, a bare scalar or a non-boolean flag is a row the
+// caller must refuse to apply.
+func parseNotifyTaskTogglesSetting(raw string) (map[string]bool, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, fmt.Errorf("value is empty")
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(trimmed), &decoded); err != nil {
+		return nil, fmt.Errorf("not valid JSON: %v", err)
+	}
+	switch v := decoded.(type) {
+	case nil:
+		return map[string]bool{}, nil
+	case map[string]any:
+		toggles := make(map[string]bool, len(v))
+		for name, flag := range v {
+			enabled, ok := flag.(bool)
+			if !ok {
+				return nil, fmt.Errorf("toggle %q is %s, want a boolean",
+					name, describeJSONSettingValue(flag))
+			}
+			toggles[name] = enabled
+		}
+		return toggles, nil
+	default:
+		return nil, fmt.Errorf("JSON %s, want an object of booleans", describeJSONSettingValue(decoded))
+	}
+}
+
+// warnUnreadableSettingRow logs the one line an operator needs when hydration
+// refuses a persisted row: which key, why, and which value the process keeps.
+// A refusal the log does not mention leaves the settings table and
+// GET /api/settings/runtime disagreeing with nothing to explain the gap.
+func warnUnreadableSettingRow(key, reason string, kept any) {
+	slog.Warn("settings: persisted value not applied, keeping the resolved value",
+		"key", key, "reason", reason, "kept", kept)
+}
+
+// describeJSONSettingValue names the shape of a resolved JSON setting so a
+// warning can say what the process keeps without echoing the whole blob.
+func describeJSONSettingValue(v any) string {
+	switch value := v.(type) {
+	case nil:
+		return "null"
+	case map[string]any:
+		return fmt.Sprintf("object with %d keys", len(value))
+	case []any:
+		return fmt.Sprintf("array with %d items", len(value))
+	case string:
+		return "string"
+	case bool:
+		return fmt.Sprintf("bool %t", value)
+	case float64:
+		return "number"
+	default:
+		return fmt.Sprintf("%T", v)
+	}
 }

--- a/store/settings_rehydration_gate_test.go
+++ b/store/settings_rehydration_gate_test.go
@@ -413,3 +413,375 @@ func sortedSet(m map[string]bool) []string {
 	sort.Strings(out)
 	return out
 }
+
+// ---- R4/R5: hydration must not assign a parse failure ----
+//
+// R4  every value parser ApplyRuntimeSettings calls is registered in
+//     settingsGateHydrationParsers with the reason its failure mode cannot
+//     destroy a configured value, and no registration is stale;
+// R5  a json.Unmarshal inside the hydration switch inspects its error at the
+//     call site.
+//
+// The defect these rules close: `rt.PayloadRules = config.ParseJsonValue(value)`
+// assigned the parse result directly, and ParseJsonValue encodes "cannot read"
+// as nil, so one unreadable row emptied a configured rule set at the next
+// restart. "I cannot read this row" is not "the operator wants the zero
+// value"; the branch must keep the resolved value and say so at WARN.
+
+// settingsGateHydrationParsers registers the parsers the hydration switch may
+// call. An entry means: this helper either carries the resolved value as its
+// fallback or reports failure through a second return value the compiler
+// forces the branch to check, so its result can never turn an unreadable row
+// into an empty setting.
+var settingsGateHydrationParsers = map[string]string{
+	"parseInt":                      "returns the fallback when the cell is not an integer",
+	"parseBoolSetting":              "blank keeps the fallback and any other text resolves to false, exactly like config.parseBoolean",
+	"parseFloatSetting":             "returns the fallback on a parse error, NaN, Inf or a negative",
+	"parseIntSetting":               "max(lo, trunc(n)) with n defaulting to the fallback: the clamp config.Load applies",
+	"parseNumberSetting":            "returns the fallback on a parse error, NaN or Inf",
+	"parseJSONSettingString":        "returns the trimmed raw cell when it is not a JSON string, never a zero value",
+	"parseStringListSetting":        "reports an unusable cell through ok=false, which the branch must check",
+	"parseJSONValueSetting":         "reports an unreadable cell through err, which the branch must check",
+	"parseNotifyTaskTogglesSetting": "reports an unreadable cell through err, which the branch must check",
+}
+
+type settingsGateCall struct {
+	name    string // last selector segment: "ParseJsonValue", "parseBoolSetting"
+	qual    string // selector prefix, empty for a plain call: "config", "json"
+	pos     token.Position
+	checked bool // result consumed by an if/switch init or condition, or a 2-value define
+}
+
+func (c settingsGateCall) label() string {
+	if c.qual == "" {
+		return c.name
+	}
+	return c.qual + "." + c.name
+}
+
+// settingsGateInterestingCall reports whether a call is one the R4/R5 rules
+// govern: a parse-named value parser, or a json.Unmarshal whose error must be
+// inspected at the call site.
+func settingsGateInterestingCall(name, qual string) bool {
+	if strings.HasPrefix(strings.ToLower(name), "parse") {
+		return true
+	}
+	return name == "Unmarshal" && qual == "json"
+}
+
+func settingsGateCallName(call *ast.CallExpr) (name, qual string) {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name, ""
+	case *ast.SelectorExpr:
+		if pkg, ok := fn.X.(*ast.Ident); ok {
+			return fn.Sel.Name, pkg.Name
+		}
+		return fn.Sel.Name, ""
+	default:
+		return "", ""
+	}
+}
+
+// settingsGateMarkChecked records the call positions whose failure result the
+// surrounding branch inspects: an if/switch init or condition, or the right
+// hand side of a two-value short declaration (`list, ok := …`, `v, err := …`).
+func settingsGateMarkChecked(checked map[token.Pos]bool, node ast.Node) {
+	if node == nil {
+		return
+	}
+	ast.Inspect(node, func(n ast.Node) bool {
+		if call, ok := n.(*ast.CallExpr); ok {
+			checked[call.Pos()] = true
+		}
+		return true
+	})
+}
+
+// settingsGateHydrationCalls collects the governed calls inside the case
+// bodies of ApplyRuntimeSettings' `switch key`, each flagged with whether its
+// failure result is checked at the call site.
+func settingsGateHydrationCalls(t *testing.T, path string) []settingsGateCall {
+	t.Helper()
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, src, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	var calls []settingsGateCall
+	collect := func(clauses []ast.Stmt) {
+		checked := map[token.Pos]bool{}
+		for _, stmt := range clauses {
+			ast.Inspect(stmt, func(n ast.Node) bool {
+				switch s := n.(type) {
+				case *ast.IfStmt:
+					settingsGateMarkChecked(checked, s.Init)
+					settingsGateMarkChecked(checked, s.Cond)
+				case *ast.SwitchStmt:
+					settingsGateMarkChecked(checked, s.Init)
+					settingsGateMarkChecked(checked, s.Tag)
+				case *ast.AssignStmt:
+					if s.Tok == token.DEFINE && len(s.Lhs) >= 2 {
+						for _, rhs := range s.Rhs {
+							settingsGateMarkChecked(checked, rhs)
+						}
+					}
+				}
+				return true
+			})
+		}
+		for _, stmt := range clauses {
+			ast.Inspect(stmt, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				name, qual := settingsGateCallName(call)
+				if !settingsGateInterestingCall(name, qual) {
+					return true
+				}
+				calls = append(calls, settingsGateCall{
+					name:    name,
+					qual:    qual,
+					pos:     fset.Position(call.Pos()),
+					checked: checked[call.Pos()],
+				})
+				return true
+			})
+		}
+	}
+
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "ApplyRuntimeSettings" {
+			continue
+		}
+		ast.Inspect(fn, func(n ast.Node) bool {
+			sw, ok := n.(*ast.SwitchStmt)
+			if !ok {
+				return true
+			}
+			tag, ok := sw.Tag.(*ast.Ident)
+			if !ok || tag.Name != "key" {
+				return true
+			}
+			for _, stmt := range sw.Body.List {
+				clause, ok := stmt.(*ast.CaseClause)
+				if !ok {
+					continue
+				}
+				collect(clause.Body)
+			}
+			return false
+		})
+	}
+	return calls
+}
+
+// settingsGateEvaluateCalls applies R4 and R5 to a collected call set. It is
+// shared by the gate over the real source and the counter-example test below,
+// so the rules themselves are falsifiable and not only the extractor.
+func settingsGateEvaluateCalls(calls []settingsGateCall, parsers map[string]string) (unregistered, unchecked, stale []string) {
+	seen := map[string]bool{}
+	for _, call := range calls {
+		if call.name == "Unmarshal" {
+			// Governed by R5 only: encoding/json reports failure through its
+			// error, never through the destination value.
+			if !call.checked {
+				unchecked = append(unchecked, fmt.Sprintf("%s at %s:%d", call.label(),
+					settingsGateRel(call.pos.Filename), call.pos.Line))
+			}
+			continue
+		}
+		seen[call.name] = true
+		reason, registered := parsers[call.name]
+		switch {
+		case !registered:
+			unregistered = append(unregistered, fmt.Sprintf("%s at %s:%d", call.label(),
+				settingsGateRel(call.pos.Filename), call.pos.Line))
+		case strings.TrimSpace(reason) == "":
+			unregistered = append(unregistered, fmt.Sprintf("%s (registered without a reason)", call.label()))
+		}
+	}
+	for name, reason := range parsers {
+		if !seen[name] {
+			stale = append(stale, name)
+		}
+		if strings.TrimSpace(reason) == "" {
+			stale = append(stale, fmt.Sprintf("%s (registered without a reason)", name))
+		}
+	}
+	sort.Strings(unregistered)
+	sort.Strings(unchecked)
+	sort.Strings(stale)
+	return unregistered, unchecked, stale
+}
+
+func TestApplyRuntimeSettingsNeverAssignsAnUncheckedParseFailure(t *testing.T) {
+	dir := settingsGateDir(t)
+	path := filepath.Join(dir, "settings.go")
+	calls := settingsGateHydrationCalls(t, path)
+	if len(calls) == 0 {
+		t.Fatal("call extractor found nothing; the matcher is broken")
+	}
+	for _, probe := range []string{"parseJSONSettingString", "parseBoolSetting"} {
+		found := false
+		for _, call := range calls {
+			found = found || call.name == probe
+		}
+		if !found {
+			t.Fatalf("call extractor missed %q; the matcher is broken", probe)
+		}
+	}
+
+	unregistered, unchecked, stale := settingsGateEvaluateCalls(calls, settingsGateHydrationParsers)
+	if len(unregistered) > 0 {
+		t.Errorf("R4: ApplyRuntimeSettings calls a value parser that is not registered:\n  %s\n"+
+			"A parser used here must either carry the resolved value as its fallback or report failure "+
+			"through a second return value the branch checks. Register it in settingsGateHydrationParsers "+
+			"with the reason it cannot turn an unreadable row into an empty setting — or keep the resolved "+
+			"value and log a WARN naming the key, the reason and what was kept.",
+			strings.Join(unregistered, "\n  "))
+	}
+	if len(unchecked) > 0 {
+		t.Errorf("R5: json.Unmarshal inside the hydration switch does not inspect its error:\n  %s\n"+
+			"Ignoring the error and assigning the destination anyway turns an unreadable row into a "+
+			"half-written or zeroed setting.",
+			strings.Join(unchecked, "\n  "))
+	}
+	if len(stale) > 0 {
+		t.Errorf("R4: stale settingsGateHydrationParsers entries no longer called by ApplyRuntimeSettings: %s",
+			strings.Join(stale, ", "))
+	}
+}
+
+// TestSettingsHydrationCallGateMatcherSanity locks the extractor and the rules
+// with counter-examples, so a refactor cannot quietly empty the call set and
+// turn R4/R5 into a no-op. The payload_rules case is the defect that was
+// fixed: it must be collected, must not be registrable, and the bare
+// json.Unmarshal must be reported as unchecked.
+func TestSettingsHydrationCallGateMatcherSanity(t *testing.T) {
+	src := `package store
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func ApplyRuntimeSettings(cfg *config.Config, rt *config.RuntimeSettings, settingsMap map[string]string) {
+	for key, value := range settingsMap {
+		switch key {
+		case "payload_rules":
+			rt.PayloadRules = config.ParseJsonValue(value)
+		case "checkin_enabled":
+			rt.CheckinDisabled = !parseBoolSetting(value, !rt.CheckinDisabled)
+		case "checkin_interval_hours":
+			rt.CheckinIntervalHours = config.ClampInt(parseIntSetting(value, 6, 1), 1, 24)
+		case "admin_ip_allowlist":
+			if list, ok := parseStringListSetting(value); ok {
+				rt.AdminIpAllowlist = list
+			}
+		case "routing_weights":
+			weights := rt.RoutingWeights
+			if err := json.Unmarshal([]byte(value), &weights); err != nil {
+				println("warn")
+			} else {
+				rt.RoutingWeights = weights
+			}
+		case "checkin_schedule_mode":
+			mode := strings.ToLower(parseJSONSettingString(value))
+			switch mode {
+			case "cron":
+				rt.CheckinScheduleMode = mode
+			}
+		case "sneaky":
+			var decoded map[string]bool
+			json.Unmarshal([]byte(value), &decoded)
+			rt.NotifyTaskToggles = decoded
+		}
+	}
+}
+`
+	path := filepath.Join(t.TempDir(), "settings.go")
+	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	calls := settingsGateHydrationCalls(t, path)
+
+	want := map[string]bool{ // label -> at least one call checked
+		"config.ParseJsonValue":  false,
+		"parseBoolSetting":       false,
+		"parseIntSetting":        false,
+		"parseStringListSetting": true,
+		"parseJSONSettingString": false,
+		"json.Unmarshal":         true, // the routing_weights one; the sneaky one stays unchecked
+	}
+	got := map[string][]settingsGateCall{}
+	for _, call := range calls {
+		got[call.label()] = append(got[call.label()], call)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("extractor returned labels %v, want %v", sortedCallLabels(got), sortedWantLabels(want))
+	}
+	for label, wantChecked := range want {
+		found, ok := got[label]
+		if !ok {
+			t.Fatalf("extractor missed %q (got %v)", label, sortedCallLabels(got))
+		}
+		anyChecked := false
+		for _, call := range found {
+			anyChecked = anyChecked || call.checked
+		}
+		if anyChecked != wantChecked {
+			t.Fatalf("%q checked = %v, want %v", label, anyChecked, wantChecked)
+		}
+	}
+	if len(got["json.Unmarshal"]) != 2 {
+		t.Fatalf("json.Unmarshal calls = %d, want 2 (one checked, one bare)", len(got["json.Unmarshal"]))
+	}
+
+	// The rules must fire on this source: the unregistered destructive parse
+	// and the bare json.Unmarshal.
+	unregistered, unchecked, stale := settingsGateEvaluateCalls(calls, map[string]string{
+		"parseBoolSetting":       "reason",
+		"parseIntSetting":        "reason",
+		"parseStringListSetting": "reason",
+		"parseJSONSettingString": "reason",
+	})
+	if len(unregistered) != 1 || !strings.Contains(unregistered[0], "config.ParseJsonValue") {
+		t.Fatalf("R4 did not flag the destructive parse: %v", unregistered)
+	}
+	if len(unchecked) != 1 || !strings.Contains(unchecked[0], "json.Unmarshal") {
+		t.Fatalf("R5 did not flag the bare json.Unmarshal: %v", unchecked)
+	}
+	if len(stale) != 0 {
+		t.Fatalf("R4 reported stale entries for parsers the fixture does call: %v", stale)
+	}
+	// The defect helper must never become registrable by accident.
+	if _, registered := settingsGateHydrationParsers["ParseJsonValue"]; registered {
+		t.Fatal("ParseJsonValue must never be registered: it encodes an unreadable cell as nil")
+	}
+}
+
+func sortedCallLabels(m map[string][]settingsGateCall) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedWantLabels(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/store/settings_roundtrip_test.go
+++ b/store/settings_roundtrip_test.go
@@ -263,10 +263,14 @@ func TestApplyRuntimeSettingsRejectsInvalidCrons(t *testing.T) {
 // different products depending on where a number was typed.
 func TestApplyRuntimeSettingsClampsMatchConfigLoad(t *testing.T) {
 	cases := []struct {
-		name     string
-		env      map[string]string
-		settings map[string]string
-		get      func(*config.Config, *config.RuntimeSettings) any
+		name string
+		env  map[string]string
+		// settingsEnv seeds the settings-path config.Load. Rows that must be
+		// read on top of an env-resolved value set it to the same env; every
+		// other row leaves it nil and compares against the built-in defaults.
+		settingsEnv map[string]string
+		settings    map[string]string
+		get         func(*config.Config, *config.RuntimeSettings) any
 	}{
 		{
 			// config.Load resolves CHECKIN_INTERVAL_HOURS as
@@ -413,12 +417,76 @@ func TestApplyRuntimeSettingsClampsMatchConfigLoad(t *testing.T) {
 			settings: map[string]string{"proxy_debug_target_model": `"  gpt-5  "`},
 			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.ProxyDebugTargetModel },
 		},
+		{
+			// Both paths decode the same cell text. An unreadable value must
+			// leave the settings path on what env resolved (nil here) instead
+			// of inventing a value of its own, and a readable one must produce
+			// an identical structure.
+			name:     "payload rules unparsable",
+			env:      map[string]string{"PAYLOAD_RULES": "[{not json"},
+			settings: map[string]string{"payload_rules": "[{not json"},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.PayloadRules },
+		},
+		{
+			name:     "payload rules object",
+			env:      map[string]string{"PAYLOAD_RULES": `{"gpt-4o":{"stream":false}}`},
+			settings: map[string]string{"payload_rules": `{"gpt-4o":{"stream":false}}`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.PayloadRules },
+		},
+		{
+			name:     "service tier rules unparsable",
+			env:      map[string]string{"OPENAI_SERVICE_TIER_RULES": "[{not json"},
+			settings: map[string]string{"openai_service_tier_rules": "[{not json"},
+			get:      func(cfg *config.Config, _ *config.RuntimeSettings) any { return cfg.OpenAiServiceTierRules },
+		},
+		{
+			name:     "service tier rules object",
+			env:      map[string]string{"OPENAI_SERVICE_TIER_RULES": `{"gpt-5":"priority"}`},
+			settings: map[string]string{"openai_service_tier_rules": `{"gpt-5":"priority"}`},
+			get:      func(cfg *config.Config, _ *config.RuntimeSettings) any { return cfg.OpenAiServiceTierRules },
+		},
+		{
+			// CHECKIN_SCHEDULE_MODE is a raw word in env and a JSON string in
+			// the settings table; both resolve through the same three-value
+			// enum, and an unknown mode keeps the "cron" fallback on both paths
+			// instead of reaching the snapshot, where RuntimeSettings.Validate
+			// would turn it into a critical boot error.
+			name:     "checkin schedule mode unknown",
+			env:      map[string]string{"CHECKIN_SCHEDULE_MODE": "every-5-minutes"},
+			settings: map[string]string{"checkin_schedule_mode": `"every-5-minutes"`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.CheckinScheduleMode },
+		},
+		{
+			name:     "checkin schedule mode window",
+			env:      map[string]string{"CHECKIN_SCHEDULE_MODE": "window"},
+			settings: map[string]string{"checkin_schedule_mode": `"window"`},
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.CheckinScheduleMode },
+		},
+		{
+			// The destructive half of the contract, and the only parity shape
+			// that catches it: the settings path is seeded with the same env,
+			// so this compares "garbage row on top of a configured value" with
+			// "the configured value alone". Assigning the parse result directly
+			// used to make the row win with nil.
+			name:        "payload rules garbage row keeps the env value",
+			env:         map[string]string{"PAYLOAD_RULES": `{"gpt-4o":{"stream":false}}`},
+			settingsEnv: map[string]string{"PAYLOAD_RULES": `{"gpt-4o":{"stream":false}}`},
+			settings:    map[string]string{"payload_rules": "[{not json"},
+			get:         func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.PayloadRules },
+		},
+		{
+			name:        "service tier rules garbage row keeps the env value",
+			env:         map[string]string{"OPENAI_SERVICE_TIER_RULES": `{"gpt-5":"priority"}`},
+			settingsEnv: map[string]string{"OPENAI_SERVICE_TIER_RULES": `{"gpt-5":"priority"}`},
+			settings:    map[string]string{"openai_service_tier_rules": "[{not json"},
+			get:         func(cfg *config.Config, _ *config.RuntimeSettings) any { return cfg.OpenAiServiceTierRules },
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			envCfg, envRt := config.Load(quietSecretEnv(tc.env))
-			setCfg, setRt := config.Load(quietSecretEnv(nil))
+			setCfg, setRt := config.Load(quietSecretEnv(tc.settingsEnv))
 			ApplyRuntimeSettings(setCfg, setRt, tc.settings)
 
 			want, got := tc.get(envCfg, envRt), tc.get(setCfg, setRt)

--- a/store/settings_silent_drops_test.go
+++ b/store/settings_silent_drops_test.go
@@ -1,0 +1,404 @@
+package store
+
+import (
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/config"
+)
+
+// Settings hydration must not translate "this row cannot be read" into "the
+// operator asked for the zero value".
+//
+// The destructive instance of that mistake was payload_rules /
+// openai_service_tier_rules: both assigned config.ParseJsonValue(value)
+// directly, and ParseJsonValue returns nil for an unparseable cell, so a
+// single bad row — planted by a backup import, a hand edit, or left behind by
+// an older version — emptied a configured rule set on the next restart with
+// nothing in the log. The silent (non-destructive) instance was
+// checkin_schedule_mode and notify_task_toggles, whose guards dropped an
+// unreadable row without saying so: the settings table and
+// GET /api/settings/runtime then disagreed forever with no line to explain
+// the gap.
+//
+// The contract asserted here for every key that stores JSON:
+//
+//	C1 an unreadable row keeps the value hydration already resolved, and the
+//	   process says so at WARN with the key, the reason and what it kept;
+//	C2 a readable row is applied — including the explicit clears (JSON null,
+//	   the empty array the admin write path persists when the UI clears the
+//	   field), which are intent and must stay destructive;
+//	C3 the settings path and the env path reach the same conclusion for the
+//	   same cell text (parity table in settings_roundtrip_test.go).
+
+// settingsWarnForKey returns the single WARN line naming key, failing when the
+// count is not exactly one: a missing line is the silent drop, a duplicated
+// one means the branch fired twice for a single row.
+func settingsWarnForKey(t *testing.T, output, key string) string {
+	t.Helper()
+	var matches []string
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, "level=WARN") && strings.Contains(line, key) {
+			matches = append(matches, line)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one WARN line naming %q, got %d in:\n%s", key, len(matches), output)
+	}
+	return matches[0]
+}
+
+// settingsNoWarnForKey fails when hydration warned about a row it could read.
+func settingsNoWarnForKey(t *testing.T, output, key string) {
+	t.Helper()
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, "level=WARN") && strings.Contains(line, key) {
+			t.Fatalf("a readable row must not warn, got:\n%s", output)
+		}
+	}
+}
+
+// ---- C1: unreadable JSON rule rows keep the configured rules ----
+
+// unreadableJSONRows are cells that survive the settings-table write paths but
+// carry no readable intent: a truncated export, a value column planted by the
+// tables-path backup import (validateBackupImportCellValue checks only the
+// scalar type and the byte limit), or a hand edit.
+var unreadableJSONRows = []string{
+	`[{not json`,
+	`not json at all`,
+	`{"match":}`,
+	`{"a":1,}`,
+	`[1,2`,
+	`{"rules":[1,2,]}`,
+}
+
+func TestApplyRuntimeSettingsUnreadablePayloadRulesRowKeepsConfiguredRules(t *testing.T) {
+	configured := map[string]any{"gpt-4o": map[string]any{"stream": false}}
+	for _, row := range unreadableJSONRows {
+		t.Run(strings.ReplaceAll(row, " ", "_"), func(t *testing.T) {
+			rt := &config.RuntimeSettings{PayloadRules: configured}
+			buf := captureSettingsLogs(t, slog.LevelWarn)
+			ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{"payload_rules": row})
+
+			if rt.PayloadRules == nil {
+				t.Fatalf("row %s wiped the configured payload rules to nil", row)
+			}
+			if !reflect.DeepEqual(rt.PayloadRules, configured) {
+				t.Fatalf("row %s changed the payload rules to %#v, want the configured %#v",
+					row, rt.PayloadRules, configured)
+			}
+			line := settingsWarnForKey(t, buf.String(), "payload_rules")
+			if !strings.Contains(line, "reason=") || !strings.Contains(line, "kept=") {
+				t.Fatalf("warning must carry the reason and the kept value: %s", line)
+			}
+		})
+	}
+}
+
+func TestApplyRuntimeSettingsUnreadableServiceTierRulesRowKeepsConfiguredRules(t *testing.T) {
+	configured := map[string]any{"gpt-5": "priority"}
+	for _, row := range unreadableJSONRows {
+		t.Run(strings.ReplaceAll(row, " ", "_"), func(t *testing.T) {
+			cfg := &config.Config{OpenAiServiceTierRules: configured}
+			buf := captureSettingsLogs(t, slog.LevelWarn)
+			ApplyRuntimeSettings(cfg, &config.RuntimeSettings{}, map[string]string{"openai_service_tier_rules": row})
+
+			if cfg.OpenAiServiceTierRules == nil {
+				t.Fatalf("row %s wiped the configured service tier rules to nil", row)
+			}
+			if !reflect.DeepEqual(cfg.OpenAiServiceTierRules, configured) {
+				t.Fatalf("row %s changed the service tier rules to %#v, want the configured %#v",
+					row, cfg.OpenAiServiceTierRules, configured)
+			}
+			line := settingsWarnForKey(t, buf.String(), "openai_service_tier_rules")
+			if !strings.Contains(line, "reason=") || !strings.Contains(line, "kept=") {
+				t.Fatalf("warning must carry the reason and the kept value: %s", line)
+			}
+		})
+	}
+}
+
+// ---- C2: readable rows are applied, explicit clears stay destructive ----
+
+func TestApplyRuntimeSettingsAppliesReadablePayloadRulesRow(t *testing.T) {
+	cases := []struct {
+		name string
+		row  string
+		want any
+	}{
+		{"object", `{"gpt-4o":{"stream":false}}`, map[string]any{"gpt-4o": map[string]any{"stream": false}}},
+		{"array", `[{"match":"gpt-4o"}]`, []any{map[string]any{"match": "gpt-4o"}}},
+		{"explicit null clears", `null`, nil},
+		// upsertSettingDB normalizes a nil body value to []string{}, so this is
+		// what the admin write path persists when the UI clears the textarea.
+		{"explicit empty array clears", `[]`, []any{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := &config.RuntimeSettings{PayloadRules: map[string]any{"stale": true}}
+			buf := captureSettingsLogs(t, slog.LevelWarn)
+			ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{"payload_rules": tc.row})
+			if !reflect.DeepEqual(rt.PayloadRules, tc.want) {
+				t.Fatalf("row %s rehydrated to %#v, want %#v", tc.row, rt.PayloadRules, tc.want)
+			}
+			settingsNoWarnForKey(t, buf.String(), "payload_rules")
+		})
+	}
+}
+
+func TestApplyRuntimeSettingsAppliesReadableServiceTierRulesRow(t *testing.T) {
+	cases := []struct {
+		name string
+		row  string
+		want any
+	}{
+		{"object", `{"gpt-5":"priority"}`, map[string]any{"gpt-5": "priority"}},
+		{"explicit null clears", `null`, nil},
+		{"explicit empty object clears", `{}`, map[string]any{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{OpenAiServiceTierRules: map[string]any{"stale": "flex"}}
+			buf := captureSettingsLogs(t, slog.LevelWarn)
+			ApplyRuntimeSettings(cfg, &config.RuntimeSettings{}, map[string]string{"openai_service_tier_rules": tc.row})
+			if !reflect.DeepEqual(cfg.OpenAiServiceTierRules, tc.want) {
+				t.Fatalf("row %s rehydrated to %#v, want %#v", tc.row, cfg.OpenAiServiceTierRules, tc.want)
+			}
+			settingsNoWarnForKey(t, buf.String(), "openai_service_tier_rules")
+		})
+	}
+}
+
+// ---- C1/C2: checkin_schedule_mode ----
+
+func TestApplyRuntimeSettingsUnreadableCheckinScheduleModeRowKeepsResolvedMode(t *testing.T) {
+	for _, row := range []string{`"every-5-minutes"`, `every-5-minutes`, `"CRON_JOB"`, `123`, `null`, `""`} {
+		t.Run(row, func(t *testing.T) {
+			rt := &config.RuntimeSettings{CheckinScheduleMode: "window", CheckinWindowStart: "01:00", CheckinWindowEnd: "05:00"}
+			buf := captureSettingsLogs(t, slog.LevelWarn)
+			ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{"checkin_schedule_mode": row})
+
+			if rt.CheckinScheduleMode != "window" {
+				t.Fatalf("row %s changed the schedule mode to %q, want the resolved %q",
+					row, rt.CheckinScheduleMode, "window")
+			}
+			// config/validate.go:384 treats an unknown mode as a critical boot
+			// error, so the kept value must stay one Validate accepts.
+			for _, err := range rt.Validate() {
+				if strings.Contains(err.Error(), "checkin_schedule_mode") {
+					t.Fatalf("hydration left a schedule mode that fails Validate: %v", err)
+				}
+			}
+			line := settingsWarnForKey(t, buf.String(), "checkin_schedule_mode")
+			if !strings.Contains(line, "reason=") || !strings.Contains(line, "kept=") {
+				t.Fatalf("warning must carry the reason and the kept value: %s", line)
+			}
+		})
+	}
+}
+
+func TestApplyRuntimeSettingsAppliesReadableCheckinScheduleModes(t *testing.T) {
+	for row, want := range map[string]string{
+		`"interval"`: "interval",
+		`"window"`:   "window",
+		`"cron"`:     "cron",
+		`"WINDOW"`:   "window",
+		`window`:     "window", // legacy unencoded cell
+	} {
+		t.Run(row, func(t *testing.T) {
+			rt := &config.RuntimeSettings{CheckinScheduleMode: "cron"}
+			buf := captureSettingsLogs(t, slog.LevelWarn)
+			ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{"checkin_schedule_mode": row})
+			if rt.CheckinScheduleMode != want {
+				t.Fatalf("row %s rehydrated to %q, want %q", row, rt.CheckinScheduleMode, want)
+			}
+			settingsNoWarnForKey(t, buf.String(), "checkin_schedule_mode")
+		})
+	}
+}
+
+// ---- C1/C2: notify_task_toggles ----
+
+// service/notify gates each alert type on this map and treats a missing key as
+// enabled, so a dropped row unmutes every alert type the operator had muted.
+func TestApplyRuntimeSettingsUnreadableNotifyTaskTogglesRowKeepsMutes(t *testing.T) {
+	muted := map[string]bool{"low_balance": false, "token_expired": false}
+	for _, row := range []string{`{"low_balance":"no"}`, `[1,2]`, `"all"`, `{"low_balance":`, `123`, `{"a":1}`} {
+		t.Run(strings.ReplaceAll(row, " ", "_"), func(t *testing.T) {
+			rt := &config.RuntimeSettings{NotifyTaskToggles: map[string]bool{"low_balance": false, "token_expired": false}}
+			buf := captureSettingsLogs(t, slog.LevelWarn)
+			ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{"notify_task_toggles": row})
+
+			if !reflect.DeepEqual(rt.NotifyTaskToggles, muted) {
+				t.Fatalf("row %s changed the toggles to %#v, want the configured %#v", row, rt.NotifyTaskToggles, muted)
+			}
+			line := settingsWarnForKey(t, buf.String(), "notify_task_toggles")
+			if !strings.Contains(line, "reason=") || !strings.Contains(line, "kept=") {
+				t.Fatalf("warning must carry the reason and the kept value: %s", line)
+			}
+		})
+	}
+}
+
+func TestApplyRuntimeSettingsAppliesReadableNotifyTaskToggles(t *testing.T) {
+	t.Run("object merges", func(t *testing.T) {
+		rt := &config.RuntimeSettings{NotifyTaskToggles: map[string]bool{"low_balance": false}}
+		buf := captureSettingsLogs(t, slog.LevelWarn)
+		ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{
+			"notify_task_toggles": `{"token_expired":false,"daily_summary":true}`,
+		})
+		want := map[string]bool{"low_balance": false, "token_expired": false, "daily_summary": true}
+		if !reflect.DeepEqual(rt.NotifyTaskToggles, want) {
+			t.Fatalf("NotifyTaskToggles = %#v, want %#v", rt.NotifyTaskToggles, want)
+		}
+		settingsNoWarnForKey(t, buf.String(), "notify_task_toggles")
+	})
+
+	t.Run("json null means no per-type overrides", func(t *testing.T) {
+		rt := &config.RuntimeSettings{}
+		buf := captureSettingsLogs(t, slog.LevelWarn)
+		ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{"notify_task_toggles": `null`})
+		if rt.NotifyTaskToggles == nil || len(rt.NotifyTaskToggles) != 0 {
+			t.Fatalf("NotifyTaskToggles = %#v, want an empty non-nil map", rt.NotifyTaskToggles)
+		}
+		settingsNoWarnForKey(t, buf.String(), "notify_task_toggles")
+	})
+
+	t.Run("empty object clears every mute it names", func(t *testing.T) {
+		rt := &config.RuntimeSettings{NotifyTaskToggles: map[string]bool{"low_balance": false}}
+		buf := captureSettingsLogs(t, slog.LevelWarn)
+		ApplyRuntimeSettings(&config.Config{}, rt, map[string]string{"notify_task_toggles": `{}`})
+		if !reflect.DeepEqual(rt.NotifyTaskToggles, map[string]bool{"low_balance": false}) {
+			t.Fatalf("NotifyTaskToggles = %#v, want the merge semantics to keep unmentioned keys", rt.NotifyTaskToggles)
+		}
+		settingsNoWarnForKey(t, buf.String(), "notify_task_toggles")
+	})
+}
+
+// ---- The whole family: an unreadable row never wipes a configured value ----
+
+// TestApplyRuntimeSettingsUnreadableRowsNeverWipeConfiguredValues is the
+// family gate. Every settings key that stores a list, an object or an enum has
+// a non-empty value the process resolved before hydration; for each of them an
+// unreadable row must leave that value untouched and must be reported. Add a
+// row here when a new key of that shape is hydrated.
+func TestApplyRuntimeSettingsUnreadableRowsNeverWipeConfiguredValues(t *testing.T) {
+	cases := []struct {
+		key      string
+		row      string
+		baseline func(*config.Config, *config.RuntimeSettings)
+		get      func(*config.Config, *config.RuntimeSettings) any
+	}{
+		{
+			key:      "admin_ip_allowlist",
+			row:      `{"oops":true}`,
+			baseline: func(_ *config.Config, rt *config.RuntimeSettings) { rt.AdminIpAllowlist = []string{"203.0.113.7"} },
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.AdminIpAllowlist },
+		},
+		{
+			key:      "global_blocked_brands",
+			row:      `{"oops":true}`,
+			baseline: func(_ *config.Config, rt *config.RuntimeSettings) { rt.GlobalBlockedBrands = []string{"acme"} },
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.GlobalBlockedBrands },
+		},
+		{
+			key:      "global_allowed_models",
+			row:      `{"oops":true}`,
+			baseline: func(_ *config.Config, rt *config.RuntimeSettings) { rt.GlobalAllowedModels = []string{"gpt-4o"} },
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.GlobalAllowedModels },
+		},
+		{
+			key:      "proxy_error_keywords",
+			row:      `{"oops":true}`,
+			baseline: func(_ *config.Config, rt *config.RuntimeSettings) { rt.ProxyErrorKeywords = []string{"rate limit"} },
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.ProxyErrorKeywords },
+		},
+		{
+			key: "routing_weights",
+			row: `{"BaseWeightFactor":`,
+			baseline: func(_ *config.Config, rt *config.RuntimeSettings) {
+				rt.RoutingWeights = config.RoutingWeights{BaseWeightFactor: 0.7}
+			},
+			get: func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.RoutingWeights },
+		},
+		{
+			key: "payload_rules",
+			row: `[{"match":`,
+			baseline: func(_ *config.Config, rt *config.RuntimeSettings) {
+				rt.PayloadRules = []any{map[string]any{"match": "gpt-4o"}}
+			},
+			get: func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.PayloadRules },
+		},
+		{
+			key: "openai_service_tier_rules",
+			row: `[{"tier":`,
+			baseline: func(cfg *config.Config, _ *config.RuntimeSettings) {
+				cfg.OpenAiServiceTierRules = map[string]any{"gpt-5": "priority"}
+			},
+			get: func(cfg *config.Config, _ *config.RuntimeSettings) any { return cfg.OpenAiServiceTierRules },
+		},
+		{
+			key: "notify_task_toggles",
+			row: `{"low_balance":"no"}`,
+			baseline: func(_ *config.Config, rt *config.RuntimeSettings) {
+				rt.NotifyTaskToggles = map[string]bool{"low_balance": false}
+			},
+			get: func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.NotifyTaskToggles },
+		},
+		{
+			key:      "checkin_schedule_mode",
+			row:      `"every-5-minutes"`,
+			baseline: func(_ *config.Config, rt *config.RuntimeSettings) { rt.CheckinScheduleMode = "window" },
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.CheckinScheduleMode },
+		},
+		{
+			key:      "checkin_cron",
+			row:      `"not a cron"`,
+			baseline: func(_ *config.Config, rt *config.RuntimeSettings) { rt.CheckinCron = config.DefaultCheckinCron },
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.CheckinCron },
+		},
+		{
+			key: "balance_refresh_cron",
+			row: `"not a cron"`,
+			baseline: func(_ *config.Config, rt *config.RuntimeSettings) {
+				rt.BalanceRefreshCron = config.DefaultBalanceRefreshCron
+			},
+			get: func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.BalanceRefreshCron },
+		},
+		{
+			key:      "model_sync_cron",
+			row:      `"not a cron"`,
+			baseline: func(_ *config.Config, rt *config.RuntimeSettings) { rt.ModelSyncCron = config.DefaultModelSyncCron },
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.ModelSyncCron },
+		},
+		{
+			key:      "log_cleanup_cron",
+			row:      `"not a cron"`,
+			baseline: func(_ *config.Config, rt *config.RuntimeSettings) { rt.LogCleanupCron = config.DefaultLogCleanupCron },
+			get:      func(_ *config.Config, rt *config.RuntimeSettings) any { return rt.LogCleanupCron },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			cfg, rt := &config.Config{}, &config.RuntimeSettings{}
+			tc.baseline(cfg, rt)
+			want := tc.get(cfg, rt)
+
+			buf := captureSettingsLogs(t, slog.LevelWarn)
+			ApplyRuntimeSettings(cfg, rt, map[string]string{tc.key: tc.row})
+
+			if got := tc.get(cfg, rt); !reflect.DeepEqual(got, want) {
+				t.Fatalf("row %s for %s changed the resolved value to %#v, want it kept as %#v",
+					tc.row, tc.key, got, want)
+			}
+			if got := tc.get(cfg, rt); got == nil {
+				t.Fatalf("row %s for %s wiped the resolved value to nil", tc.row, tc.key)
+			}
+			settingsWarnForKey(t, buf.String(), tc.key)
+		})
+	}
+}


### PR DESCRIPTION
## 改动摘要

配置面水合的**破坏性静默丢弃**：`store.ApplyRuntimeSettings` 里有两条分支把解析结果**直接赋值**，而 `config.ParseJsonValue` 用 `nil` 编码失败——于是库里一条读不出来的行，会在下次重启时把**已经配置好的规则集清空**，日志里一个字都没有。另有两条分支丢弃坏行时不告警，行与 `GET /api/settings/runtime` 从此长期互相矛盾。

第一性原理：**水合的职责是「把库里存的意图还原成运行时值」；「读不出来」意味着意图不可恢复，不等于「运维想要空」**。把前者翻译成后者，是配置面最贵的一类静默失败。

| 键 | 改前 | 改后 |
|---|---|---|
| `payload_rules` | `rt.PayloadRules = config.ParseJsonValue(value)` → 坏行清空规则 | 读得懂才赋值；读不懂保留既有值 + WARN（键名 / 原因 / 保留值的**形状**，不回显整块 blob） |
| `openai_service_tier_rules` | 同上（`cfg.` 侧） | 同上 |
| `checkin_schedule_mode` | 枚举守卫静默丢弃 | 保留已解析的 mode + WARN。**保留不是偷懒而是必须**：`config/validate.go` 把未知 mode 判为 critical（启动即退出），把坏行灌进快照等于把一条坏数据升级成启动失败 |
| `notify_task_toggles` | `json.Unmarshal` 失败静默丢弃 | 保留既有 toggles + WARN。`service/notify` 是「缺键=放行」，所以静默丢弃 = 重启后所有静音失效 |

**显式清空仍然可用，而且被测试锁住**：JSON `null` 与 `[]` 是**可读的意图**（"no rules"），照常赋值。UI 清空 textarea 走的是 `null`，而 `upsertSettingDB` 把 nil body 值归一成 `[]string{}` 落库，所以真实落库形状是 `[]` —— 这条路径专门有用例。

**可达性复核为真**（不是纯理论）：备份导入的 tables 路径只校验单元格标量类型与字节上限、不校验语义（`validateBackupImportCellValue`），而这 4 个键都**不在** `RuntimeLocalSettingKeys` 的跳过集里，插入是 `ON CONFLICT DO NOTHING` ⇒ 导入可以**新种**坏行；`notify_task_toggles` 更直接——admin 写路径只 marshal 不校验形状，直连 API 发 `{"notifyTaskToggles":"all"}` 得 200 并落库，而随后的 re-hydrate 因 Unmarshal 失败不更新 runtime ⇒ **落库值与 runtime 长期不一致、全程无日志**，不需要手改表就能复现；`service/settingsmigration` 读 legacy mode 不校验，坏 legacy 行会永久留在表里。

## 类型

- [x] fix（bug 修复：坏行清空已配置值 / 行与快照长期矛盾且无日志）
- [x] test（两条机械门禁，让这一族回不来）

## 行为变更（需要进 CHANGELOG）

- 库里一条**读不出来**的 `payload_rules` / `openai_service_tier_rules` / `checkin_schedule_mode` / `notify_task_toggles` 行不再清空/覆盖已生效的值：运行时保留既有值，并打一条 WARN 说明键名、原因与保留值的形状。显式的 `null` / `[]` 仍然按「清空」生效。
- 启动/水合日志因此可能新增 WARN 行——那是此前静默的不一致第一次变得可见。

## 测试验证

- [x] `go build ./...` / `go vet ./...` 通过；`gofmt -l` 对 4 个触及文件为空
- [x] `go test ./store/... ./config/... ./docs ./service/notify/... ./handler/admin/ -count=1 -tags=integration -p 1`（带 `PG_TEST_DSN`，集成方复跑）全绿：`store 13.9s · config 0.3s · docs 1.9s · service/notify 0.04s · handler/admin 56.8s`
- [x] `go test ./store/ -count=1 -race` 绿（138.9s）
- [x] 新增 `store/settings_silent_drops_test.go`（404 行 / 9 个顶层测试 / 83 个子测试）：每个键「坏行 → 保留 + 恰好一条 WARN 点名该键 + 值非 nil」与「好行 → 照常生效」各一组，外加一张 13 个 JSON/list/enum 键的家族表断言「坏行永不清空且必被报告」
- [x] **两条机械门禁**（`store/settings_rehydration_gate_test.go` +372 行）：
  - **R4**：水合 switch 里每个值解析器必须登记在 `settingsGateHydrationParsers` 并写明「它的失败模式为何不能毁掉已配置值」；登记项失效（不再被调用）也红。`config.ParseJsonValue` 被测试**显式断言永不可登记**——它就是那个用 nil 编码失败的解析器
  - **R5**：`json.Unmarshal` 必须在调用点检查 err
  - 门禁自身有反例自证伪用例（fixture 含一条裸 `json.Unmarshal` 与一条 checked 的，断言恰好收集 2 个、1 个 checked、并真的产出 1 条 R4 + 1 条 R5 违规），该用例改前改后都绿；既有 10 个已 WARN 的分支零误伤（R4 只登记解析器名，不干涉分支形状）
- [x] parity 表扩 8 行，并给表加 `settingsEnv` 字段——**只有「同一份 env 之上盖一条坏行」对比「仅 env」这个形状能抓住破坏性**（原表形状在缺陷存在时也通过，这是交付过程中发现并修正的）
- [x] **变异探针 red → green（交付方两轮 + 集成方独立复跑一轮）**：集成方把 `payload_rules` 还原成 `rt.PayloadRules = config.ParseJsonValue(value)` → 4 个测试族同时红：R4 门禁 `calls a value parser that is not registered`、parity `env path resolved map[…"gpt-4o"…] but the settings path resolved <nil>`、silent-drops 6 个子测试 `row … wiped the configured payload rules to nil`、家族表；`git checkout --` 还原后 `sha256sum -c` 一致、`grep B7-MUTATION` 零命中、复跑全绿
- [x] 改前红的规模：34 条 `FAIL:`（原文在维护者工作区）

## 自查清单

- [x] 无密钥/内部路径泄漏（注释一律仓库相对路径）；WARN **不回显整块 blob**，只描述形状
- [x] 无新增/删除 env 变量，`.env.example` 未碰；无 schema 变更、无新依赖
- [x] 用户可见面只有日志（WARN），无新增 i18n 文案
- [x] 写集 = 4 个 `store/settings*` 文件，越界零命中

## 这一族在 `store` 包内是否清零？——**是**

扫描方法（与上一批 #1166 同法，AST + gofmt 缩进双扫 `ApplyRuntimeSettings` 的 `switch key`）：抽 case 标签 → 找被条件包住的 `rt.` / `cfg.` 赋值 → 逐个与 env 路径对读 → 用登记表白名单 + 反例反向核对。覆盖面数字：**case 子句 89 / 键 91 / 赋值 88 / 被条件包住的赋值 19**；19 条中 **14 条带 WARN**（原 10 + 本 PR 4），剩 5 条无 WARN 且都是注释写明的故意守卫（3 个凭据键的空值不得覆盖已配置凭据、2 个 window 边界键与 env 的 `firstNonEmpty` 同语义）。**破坏性「解析失败 → 赋零值」形状 = 0**，且由 R4 机械保证（水合 switch 内可调用的解析器只剩 9 个登记项）。与上一批对账：上批 18 条含 `checkin_interval_hours`（#1166 后已变无条件 clamp）→ 17；本 PR 把 2 条无条件破坏性赋值改成有条件 + WARN → 19 ✓；带 WARN 10 → 14 ✓。

## 已知遗留（本 PR 不做，需裁决 / 建议单独 lane）

1. **`PayloadRules` 在 Go 侧没有任何运行时消费者**（全仓只有 `config` 写入与声明、`store` 水合、`handler/admin` 回显给 UI）；**`OpenAiServiceTierRules` 零读者**（连回显都没有）。所以坏行清空的线上表现是「`GET /api/settings` 的 `payloadRules` 变 null + 设置页 textarea 变空」，**不改流量行为**；而 `docs/configuration.md` 把它写成 "Per-model payload rewrite rules" —— **文档超前于实现**（与 #1166 删掉的 `HOME_PAGE_CONTENT` 同一类，只是这次有个 UI 在读写它）。裁决：改文档说实情，还是另开 lane 落地规则引擎。
2. **`notify_task_toggles` 的写路径缺语义校验**：`handler/admin/settings_apply.go` 只 marshal 不校验形状 ⇒ 直连 API 能落一条坏行并拿到 200。本 PR 让它不再毁掉 runtime，但**写入侧应当返 400**（`handler/**` 不在本 lane 写集）。
3. **第三族**：不可解析的**数值**行「静默保留 fallback」约 20 个分支（`parseInt` / `parseIntSetting` / `parseFloatSetting` 路径）。不破坏，但同样「表里一行 vs 快照一个值，日志无话」。建议在解析器的失败路径做**一次聚合 WARN**（键名 + 原值 + fallback），而不是逐分支加。
4. **4 条数值键 floor 偏差现状未变**（本 PR 只确认，未改）：`port`（`Atoi` 不 trunc / 无 floor vs env 的 `int(math.Trunc(parseNumber))`）· `notify_cooldown_sec`（settings 可为负，绕过 env 的 0 下限）· `proxy_max_channel_attempts`（settings 比 env 严）· `smtp_port`（已一致）。
5. `proxy_retry_status_ranges` / `proxy_disable_status_ranges` 把不可解析的原文**透传**给消费者（不是「赋零值」族，与 env 的 `get()` 同形）——是否要在此校验区间语法，请裁决。
