### PR TITLE
ci: stop the sqlite shards from reporting green with zero tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,20 +210,45 @@ jobs:
           name: web-dist
           path: web/dist
       - name: Run tests (shard ${{ matrix.shard }}/${{ matrix.total }})
+        env:
+          # The matrix values are bound to the environment rather than inlined
+          # into the script body. Inlined as bare `matrix.total`, the arithmetic
+          # below became a bash syntax error; because it sat in an `if`
+          # condition it was exempt from `set -e`, so every package was skipped,
+          # the "no packages in shard" branch exited 0, and all four shards
+          # reported success while running zero tests. `set -u` plus the guards
+          # below make any recurrence loud instead of green.
+          SHARD: ${{ matrix.shard }}
+          SHARD_TOTAL: ${{ matrix.total }}
         run: |
           set -euo pipefail
           mapfile -t pkgs < <(go list ./...)
+          if [ "${#pkgs[@]}" -lt "$SHARD_TOTAL" ]; then
+            echo "ERROR: go list returned ${#pkgs[@]} package(s), fewer than the $SHARD_TOTAL shards"
+            exit 1
+          fi
           shard_pkgs=()
           for i in "${!pkgs[@]}"; do
-            if (( i % matrix.total == matrix.shard )); then
+            # Standalone assignment, not an `if (( ... ))` condition: a broken
+            # selector aborts the step under set -e instead of being swallowed.
+            slot=$(( i % SHARD_TOTAL ))
+            if [ "$slot" -eq "$SHARD" ]; then
               shard_pkgs+=("${pkgs[i]}")
             fi
           done
-          if [ "${#shard_pkgs[@]}" -eq 0 ]; then
-            echo "no packages in shard; nothing to run"
-            exit 0
+          # Round-robin over N packages into T shards owes shard S exactly
+          # ceil((N - S) / T) of them. Asserting the number catches a selector
+          # that quietly picks too few, not only one that picks none.
+          want=$(( ( ${#pkgs[@]} - SHARD + SHARD_TOTAL - 1 ) / SHARD_TOTAL ))
+          if [ "${#shard_pkgs[@]}" -ne "$want" ]; then
+            echo "ERROR: shard $SHARD/$SHARD_TOTAL selected ${#shard_pkgs[@]} package(s); round-robin over ${#pkgs[@]} requires $want"
+            exit 1
           fi
-          echo "shard ${{ matrix.shard }} running ${#shard_pkgs[@]} packages:"
+          if [ "${#shard_pkgs[@]}" -eq 0 ]; then
+            echo "ERROR: shard $SHARD/$SHARD_TOTAL selected no packages; refusing to report green"
+            exit 1
+          fi
+          echo "shard $SHARD/$SHARD_TOTAL running ${#shard_pkgs[@]} of ${#pkgs[@]} packages:"
           printf '  %s\n' "${shard_pkgs[@]}"
           go test "${shard_pkgs[@]}" -count=1 -race
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -47,6 +47,25 @@ CI is unaffected by this default: `.github/workflows/main.yml` never calls
 -race` with Go's default 10-minute per-package timeout, so raising the local
 gate default cannot weaken CI.
 
+Shard selection is guarded rather than trusted, because a required check that
+runs nothing still reports green. Each `test-sqlite-shard` job binds
+`matrix.shard` / `matrix.total` through the environment, computes its
+round-robin slot in a standalone `$(( ))` assignment, and then asserts the
+number of packages it owes — `ceil((N - S) / T)` over `N = go list ./...`. A
+shard that selects fewer than it owes, or none at all, fails loudly. The
+slot computation is deliberately *not* an `if (( ... ))` condition: a command
+in an `if` condition is exempt from `set -e`, so a malformed selector there is
+swallowed instead of aborting the step.
+
+That guard is load-bearing, not decorative. The revision that introduced the
+shard matrix inlined the matrix values into the arithmetic without `${{ }}`,
+so bash saw `i % matrix.total`, errored once per package, selected nothing,
+and took the `no packages in shard; nothing to run` branch to `exit 0`. All
+four shards and the aggregated `test-sqlite` required check reported success
+while executing zero tests, from v0.14.0 through v0.17.0. `test-pg` (which
+runs `go test ./...` unsharded) was the only job actually executing the Go
+suite in that window, and it does not pass `-race`.
+
 ## Golden snapshot suites (protocol conversion)
 
 Multi-protocol conversion is the most regression-prone surface of the proxy, so


### PR DESCRIPTION
## 改动摘要

`test-sqlite-shard` 是**必选状态检查 `test-sqlite` 的全部实现**，而它从被引入的那天起就没跑过一个测试：分片算术里把 `matrix.total` / `matrix.shard` 当裸字面量写进了 bash，缺了 `${{ }}`。bash 看到 `i % matrix.total` 后每个包报一次语法错误——但那个 `(( ))` 位于 `if` 条件里，**`set -e` 对条件命令不生效**，于是错误被吞掉、`shard_pkgs` 始终为空，最后走进 `no packages in shard; nothing to run` 分支 `exit 0`。

四个分片全绿、聚合出来的 `test-sqlite` 必选检查全绿，**执行的测试数量是 0**。影响范围实测：`git tag --contains 06025d53`（引入分片矩阵的那个提交）= **30 个 tag，v0.14.0 到 v0.17.0**。

这个窗口里唯一真的在跑 Go 套件的 job 是 `test-pg`（`go test ./... -tags=integration -p 1`，不分片），而它**不带 `-race`** ⇒ 竞态检测在这三周里从 CI 完全消失。本地逃生阀也指望不上：`scripts/go-race.sh` 本身是好的（不分片、全量 `-race`），但小节点约定 `git push --no-verify`，所以本地 race 门同样没跑。**结论：v0.14.0–v0.17.0 这 30 个发布版本没有任何一道竞态门真正执行过。**

修复分三层，每一层都是为了让「静默变绿」在结构上不可能再发生：

1. **绑定方式**：两个 matrix 值改由 `env` 传入（`SHARD` / `SHARD_TOTAL`）。配合 `set -u`，将来谁再把 `${{ }}` 弄丢，报的是 `unbound variable` 而不是安静地少选包。
2. **计算位置**：轮转槽位改成独立赋值 `slot=$(( i % SHARD_TOTAL ))`，**不再是 `if (( ... ))` 条件**。这是本次事故的根因形态——条件里的算术错误对 `set -e` 免疫；挪出来之后任何畸形选择器都会直接中止 step。
3. **数量断言**：N 个包轮转进 T 个分片，第 S 片应得 `ceil((N - S) / T)` 个。实测数量不等于应得数量就红。这一条抓的是「悄悄少选」，不只是「一个没选」；空分片同时从 `exit 0` 改成 `exit 1`（**一个选不到包的分片是选择器坏了，不是一次免费通过**）。

## 类型

- [x] fix（bug 修复：必选检查空转报绿）
- [x] chore（CI 工程维护）

## 测试验证

- [x] YAML 可解析（`yaml.safe_load` 通过，`strategy.matrix` 与 `env` 绑定读出正确）
- [x] **正向覆盖证明**（用真实 `go list ./...` 的 49 个包，把 `go test` 换成打点后逐片回放）：四片分别选到 **13 / 12 / 12 / 12**，**并集 == 全量 49 个包，重复 0、遗漏 0**
- [x] **四条守卫逐一挑发，全部非零退出**：
  - `SHARD_TOTAL` 未设 ⇒ `exit 1`，`unbound variable`
  - `SHARD_TOTAL=matrix.total`（**即本次原始故障**）⇒ `exit 1`，`integer expression expected` + 算术语法错误
  - `SHARD=9`（越界）⇒ `exit 1`，`shard 9/4 selected 0 package(s); round-robin over 49 requires 10`
  - `SHARD_TOTAL=999`（分片多于包）⇒ `exit 1`，`go list returned 49 package(s), fewer than the 999 shards`
- [x] **改前红的复现**：把修复前的脚本对同一份包列表回放，仍然打印 `no packages in shard; nothing to run` 并 `exit 0` —— 静默绿被原地复现，证明诊断而非猜测
- [x] `go test ./docs -run TestPublicMarkdownHygiene -count=1` 通过（本 PR 改了 `docs/testing.md`）
- [ ] `go test ./... -count=1 -race` 通过 —— **本 PR 自己就是这道门的复活**，见下

## 关于「复活后会不会变红」

这正是本 PR 要回答的问题，也是它必须先于任何后续功能波合并的理由：三周没有竞态门，谁都不知道底下积了什么。本 PR 的 CI 会第一次真的执行这四片，**红就是真实发现，不是回归**。我同时在节点上跑全量 `go test ./... -count=1 -race` 做交叉验证；若 CI 或本地任一处报 race，会在合并前于本 PR 内补齐或另开修复 PR，**不会为了让检查变绿而弱化断言**。

## 自查清单

- [x] 无密钥/内部路径泄漏（`docs/testing.md` 只写公开 tag 号与 job 名）
- [x] 行为变更已补充/更新测试（本 PR 的「测试」就是 CI 选择器本身，已用真实包列表逐片回放 + 四守卫挑发）
- [x] 需要时更新了 `docs/`：`docs/testing.md` 增补「分片选择受守卫而非被信任」一节，写明不变量（`ceil((N-S)/T)`）、为什么槽位计算不能放在 `if` 条件里、以及受影响的发布区间 v0.14.0–v0.17.0
- [x] 未改任何必选检查的 job 名（分支保护按名依赖 12 个 job id，`test-sqlite-shard` / `test-sqlite` 名称原样保留）

## 未做（已记录）

- `visual-regression` 与 `docker-push` 近两天各挂过一次 bun 安装期的 registry 完整性错误（`@base-ui/react` / `@oxlint/binding-linux-x64-gnu` / `lightningcss-linux-arm64-musl`），属上游 CDN 抖动、重跑即绿。**给 `bun install` 加重试**是独立改进，不混进本 PR。
- 给 CI 增加 `actionlint`（其内置 shellcheck 很可能在引入当时就报出这条算术错误）作为这一整类故障的持久守卫 —— 需先评估它对现存 workflow 的噪声量，另开 PR。
