### PR TITLE
fix(router): drop the dead /assets mount and pin the embedded SPA layout

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -255,18 +255,28 @@ func setupSPAFallback(r chi.Router, distFS fs.FS) {
 		distFS = rootedFS
 	}
 
-	// /assets/* → legacy Vite asset layout, kept for compatibility with older
-	// builds that still emit dist/assets.
-	mountStaticSubdir(r, distFS, "assets", "/assets/*", "/assets/")
-
 	// /static/* → Rsbuild output: /static/js/*.js (incl. async chunks),
 	// /static/css/*.css and /static/font/*.woff2. index.html references these
 	// paths; without this mount the SPA fallback answered 200 text/html and
 	// nosniff browsers refused the assets (blank embedded UI).
+	//
+	// This is the only asset subtree mounted, and the only one the embedded
+	// build emits. A second mount for /assets/* used to sit here, documented as
+	// "legacy Vite asset layout, kept for compatibility with older builds that
+	// still emit dist/assets" — but the frontend is baked in with //go:embed at
+	// compile time, so a binary carries exactly one dist, built from this
+	// commit. There is no older build to stay compatible with, the embedded
+	// tree has had no assets/ directory since the Rsbuild migration, and the
+	// guard on that mount therefore fired on every startup of every
+	// deployment: a WARN reading "serving disabled" when nothing had been
+	// disabled, sitting on the same line a genuine /static failure would use.
+	// spa_layout_test.go pins the real contract instead — every asset path the
+	// built index.html references must be served as that asset and never as the
+	// fallback HTML — which catches the next layout rename in either direction.
 	mountStaticSubdir(r, distFS, "static", "/static/*", "/static/")
 
 	// Root public files (logo, favicons) copied from web/public into the dist
-	// root. They are NOT under /assets/ or /static/, so serve them explicitly
+	// root. They are NOT under /static/, so serve them explicitly
 	// here — otherwise the SPA fallback answers 200 text/html and <img>
 	// renders blank.
 	rootFiles := map[string]string{

--- a/router/spa_layout_test.go
+++ b/router/spa_layout_test.go
@@ -1,0 +1,159 @@
+package router
+
+import (
+	"context"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/deliciousbuding/metapi-go/web"
+)
+
+// A released binary carries exactly one frontend: //go:embed dist bakes in the
+// build produced from this same commit. The contract between that build's
+// output layout and the router's mounts is therefore fixed at compile time and
+// nothing re-checks it at runtime -- which is how it broke once already. When
+// the frontend moved from Vite to Rsbuild the bundles relocated from
+// dist/assets to dist/static, the router was still mounting /assets/*, and
+// every script and stylesheet request was answered by the SPA fallback with
+// 200 text/html. nosniff browsers then refused to execute them and the
+// embedded UI rendered blank behind a status code that looked fine.
+//
+// These tests pin the contract from the side that matters: every root-relative
+// asset the built index.html references must be served as that asset, never as
+// the fallback HTML, and mounting the dist this commit actually ships must not
+// warn. They run against the real embedded dist -- the jobs that execute Go
+// tests download the web-dist artifact the frontend job built -- so a rename,
+// a new output directory or a dropped root file fails here instead of in a
+// browser.
+
+// assetRefPattern picks every src/href target out of the built index.html.
+var assetRefPattern = regexp.MustCompile(`(?:src|href)="([^"]+)"`)
+
+// embeddedDist returns the embedded frontend subtree rooted at web/dist.
+//
+// The CI embed placeholder (web/dist/placeholder.txt, created so //go:embed
+// type-checks on a fresh checkout) has no index.html and is skipped with an
+// explicit reason. Anything else that lacks index.html is a real problem and
+// fails: silently skipping would let this gate pass without ever looking at a
+// SPA, which is the failure mode it exists to prevent.
+func embeddedDist(t *testing.T) fs.FS {
+	t.Helper()
+
+	sub, err := fs.Sub(web.Dist, "dist")
+	if err != nil {
+		t.Fatalf("web.Dist has no dist subtree: %v", err)
+	}
+	if _, err := fs.ReadFile(sub, "index.html"); err != nil {
+		if _, placeholderErr := fs.ReadFile(sub, "placeholder.txt"); placeholderErr == nil {
+			t.Skip("embedded dist is the CI embed placeholder (placeholder.txt, no index.html); the jobs that run Go tests download the real web-dist artifact, so there is no SPA to check here")
+		}
+		t.Fatalf("embedded dist has no index.html and is not the CI placeholder: %v", err)
+	}
+	return sub
+}
+
+func TestEmbeddedSpaReferencesAreServedAsAssets(t *testing.T) {
+	dist := embeddedDist(t)
+
+	indexHTML, err := fs.ReadFile(dist, "index.html")
+	if err != nil {
+		t.Fatalf("read embedded index.html: %v", err)
+	}
+
+	var refs []string
+	seen := make(map[string]bool)
+	for _, m := range assetRefPattern.FindAllStringSubmatch(string(indexHTML), -1) {
+		ref := m[1]
+		// Only root-relative references are this router's business. Absolute
+		// URLs, protocol-relative URLs, data: URIs and in-page anchors are
+		// somebody else's contract.
+		if !strings.HasPrefix(ref, "/") || strings.HasPrefix(ref, "//") {
+			continue
+		}
+		if seen[ref] {
+			continue
+		}
+		seen[ref] = true
+		refs = append(refs, ref)
+	}
+
+	if len(refs) == 0 {
+		t.Fatal("the embedded index.html references no root-relative assets: either the frontend build changed shape or the embedded dist is not the real one. This gate must not pass vacuously.")
+	}
+
+	r := chi.NewRouter()
+	r.Use(SecurityHeaders)
+	setupSPAFallback(r, web.Dist)
+
+	for _, ref := range refs {
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, ref, nil))
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s: got %d, want 200 — the embedded SPA references an asset this router does not serve", ref, rec.Code)
+			continue
+		}
+		// 200 alone is not the contract. The SPA fallback answers 200
+		// text/html for every unmounted path, which is precisely how the
+		// Vite→Rsbuild relocation hid a blank UI behind a green status code.
+		if ct := rec.Header().Get("Content-Type"); strings.HasPrefix(ct, "text/html") {
+			t.Errorf("%s: served as %s — the SPA fallback answered instead of the asset; browsers with X-Content-Type-Options: nosniff refuse to execute it and the UI renders blank", ref, ct)
+			continue
+		}
+		if rec.Body.Len() == 0 {
+			t.Errorf("%s: served 200 %s with an empty body", ref, rec.Header().Get("Content-Type"))
+		}
+	}
+
+	t.Logf("%d root-relative asset references in the embedded index.html all resolve to real assets", len(refs))
+}
+
+// warnRecorder collects WARN-and-above messages so a test can assert on what
+// startup logging claims.
+type warnRecorder struct{ messages []string }
+
+func (w *warnRecorder) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= slog.LevelWarn
+}
+
+func (w *warnRecorder) Handle(_ context.Context, r slog.Record) error {
+	if r.Level >= slog.LevelWarn {
+		w.messages = append(w.messages, r.Message)
+	}
+	return nil
+}
+
+func (w *warnRecorder) WithAttrs([]slog.Attr) slog.Handler { return w }
+func (w *warnRecorder) WithGroup(string) slog.Handler      { return w }
+
+// Mounting the dist this commit ships must be silent. The removed /assets/*
+// mount logged "embedded web/dist subtree not readable, serving disabled" on
+// every startup of every deployment, because the embedded tree has not
+// contained an assets/ directory since the Rsbuild migration. An unconditional
+// WARN is worse than none: it teaches operators to ignore the level, and it
+// sits on the same line a genuine /static failure would use.
+func TestSetupSPAFallbackIsQuietAboutTheShippedDist(t *testing.T) {
+	dist := embeddedDist(t)
+	if _, err := fs.ReadDir(dist, "static"); err != nil {
+		t.Fatalf("the embedded dist has no static/ subtree, so the router has nothing to mount: %v", err)
+	}
+
+	recorder := &warnRecorder{}
+	previous := slog.Default()
+	slog.SetDefault(slog.New(recorder))
+	defer slog.SetDefault(previous)
+
+	r := chi.NewRouter()
+	setupSPAFallback(r, web.Dist)
+
+	for _, msg := range recorder.messages {
+		t.Errorf("setupSPAFallback warned while mounting the dist this commit ships: %q", msg)
+	}
+}


### PR DESCRIPTION
## 改动摘要

`setupSPAFallback` 挂了**两个**静态子树：`/static/*`（Rsbuild 前端真正产出的布局）与 `/assets/*`（Vite 布局），后者的注释写着「legacy Vite asset layout, kept for compatibility with older builds that still emit dist/assets」。

**这个「兼容」在构造上不可能成立。** 前端是 `//go:embed dist` 在编译期烘进二进制的，所以一个二进制只携带**一份** dist、由**本提交**构建——画面里根本不存在「更旧的构建」。自 Rsbuild 迁移以来内嵌树里就没有 `assets/` 目录，于是那个挂载永远不可达，而它的 `ReadDir` 守卫**在每一个部署的每一次启动上都会触发**：

```
WARN embedded web/dist subtree not readable, serving disabled dir=assets error="open .: file does not exist"
```

这不是推演——是在**已发布的 release 二进制**上实测到的（把 v0.17.0 的 `metapi-linux-amd64` 换进真实上游测试床启动即出现）。

无条件的 WARN 比没有 WARN 更糟：它训练运维忽略这个级别，而且它占用的是**真正的 `/static` 故障会用的同一句话**——等到那次真的发生时，这行字早已是背景噪音。

挂载删掉。取而代之的是 `router/spa_layout_test.go`，从**真正要紧的那一侧**把契约钉住，并且跑在**真实的内嵌 dist** 上（执行 Go 测试的两个 job 都下载 frontend job 产出的 `web-dist` artifact）：

- 构建出的 `index.html` 里每一个 root-relative 的 `src` / `href` 都必须回 200，**且不得以 `text/html` 回来**。只看状态码不构成契约：SPA fallback 对每一个未挂载路径都答 `200 text/html`，而这正是 Vite→Rsbuild 迁移当初把白屏 UI 藏在一个看起来正常的状态码后面的方式（`730bb9c2`）。nosniff 浏览器拒绝把 HTML 当脚本执行，所以任何只断言 200 的检查都看不见这个故障。
- 挂载本提交实际交付的 dist 必须**产生 0 条 WARN**。
- **「一条引用都没找到」判失败而不是判通过**——这道门不许有空转的可能。CI 的 embed 占位物（只有 `placeholder.txt`、无 `index.html`）带明确理由 skip；既无 `index.html` 又无占位物的 dist 直接 fail，不 skip。

## 类型

- [x] fix（bug 修复：每个部署每次启动一条假 WARN，且与真故障共用同一句话）
- [x] test（新增两道门禁，把前端布局 ↔ 路由挂载的契约钉住）

## 测试验证

- [x] `go build ./...` / `go vet ./...` 通过；`gofmt -l` 对 2 个触及文件为空
- [x] `go test ./router/ ./web/... -count=1` 全绿；新用例实测 **14 条 root-relative 引用全部解析为真资产**
- [x] **变异探针 red → green（两发两中，均 `sha256sum -c` 逐字节还原、`grep SPALAYOUT-PROBE` 零命中）**：
  - **P1**：把 `/assets/*` 挂载加回去 → `TestSetupSPAFallbackIsQuietAboutTheShippedDist` 红，错误信息就是线上那句原文 `embedded web/dist subtree not readable, serving disabled`
  - **P2**：把 `/static/*` 挂载摘掉 → `TestEmbeddedSpaReferencesAreServedAsAssets` 对全部 11 条 `/static/...` 引用报红，每条都是 `served as text/html; charset=utf-8 — the SPA fallback answered instead of the asset ... the UI renders blank`，即**历史白屏缺陷被按需复现**（注意状态码全是 200，只有 content-type 出卖了它）
- [x] 活体交叉验证：v0.17.0 发布二进制在测试床上对自己 `index.html` 引用的 14 条路径逐条 curl，13 条返回正确 content-type、主包 `index.7340ee69cd.js` 200 / `text/javascript` / 141242 B ⇒ **发布产物的 SPA 是健康的**，本 PR 修的是日志诚实性与防回归门禁，不是白屏
- [x] 未新增依赖、未改 schema、未改 env；无用户可见文案变更 ⇒ 无 i18n 影响

## 自查清单

- [x] 无密钥/内部路径泄漏（注释与测试一律仓库相对路径；PR 描述里的实测环境不落到代码里）
- [x] 行为变更已补测试（本 PR 的「行为变更」就是启动日志少一条假 WARN，已由 P1 门禁钉住）
- [x] `docs/` 无需改动：`docs/testing.md` 讲的是竞态门与分片不变量，本 PR 的门禁属于「前端布局 ↔ 路由挂载」契约，注释即文档；若维护者希望把这条契约也写进 `docs/testing.md`，可在本 PR 内补

## 一处顺带更正

`rootFiles` 上方那句注释写的是「They are NOT under /assets/ or /static/」——`/assets/` 这个前缀在本 PR 之后不再由本路由器挂载，故改为「NOT under /static/」。同一次改动使同文件的另一句成真，属必要更正。

## 已知遗留（本 PR 不做）

- 私有层测试床脚本 `verify-all-postmerge.sh` 走 `make build`，而 `make build` **不重建前端**（Makefile 无前端目标），于是它把磁盘上**任意龄期**的 `web/dist` 烘进二进制——本轮实测本地 dist 的 `index.html` 引用 `index.bfd4430f47.js`，而 v0.17.0 发布产物引用 `index.7340ee69cd.js`，两者不同源。**这意味着此前几次「合并后复验」验的是陈旧 UI**。属私有层脚本，另修（不属本公开仓 PR 的写集）。
