### PR TITLE
ci: retry transient bun install faults, fix the Dockerfile cache mount

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,10 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
-      - run: bun install --frozen-lockfile
+      # Never call `bun install` directly: scripts/bun-install.sh carries the
+      # transient-fault retry policy, and scripts/bun_install_wiring_test.go
+      # fails if a bare call reappears.
+      - run: sh ../scripts/bun-install.sh
       - run: bun run typecheck
       - run: bun run lint
       - run: bun run format:check
@@ -146,7 +149,7 @@ jobs:
           name: web-dist
           path: web/dist
       - name: Install web deps (playwright + axe-core)
-        run: bun install --frozen-lockfile
+        run: sh ../scripts/bun-install.sh
         working-directory: web
       - name: Cache Playwright browsers
         uses: actions/cache@v6
@@ -739,9 +742,12 @@ jobs:
             exit 1
           fi
           echo "release consistent: $GITHUB_REF_NAME / $pkg_ver"
+      - name: Install web deps for release binaries
+        run: sh ../scripts/bun-install.sh
+        working-directory: web
       - name: Build frontend for release binaries
         working-directory: web
-        run: bun install --frozen-lockfile && bun run build:web
+        run: bun run build:web
       - name: Build multi-platform release binaries
         run: |
           set -euo pipefail
@@ -836,7 +842,7 @@ jobs:
           name: web-dist
           path: web/dist
       - name: Install web deps (playwright + sharp + axe-core)
-        run: bun install --frozen-lockfile
+        run: sh ../scripts/bun-install.sh
         working-directory: web
       - name: Install CJK fonts (screenshots must render zh-CN glyphs)
         run: sudo apt-get update && sudo apt-get install -y fonts-noto-cjk
@@ -909,7 +915,7 @@ jobs:
           name: web-dist
           path: web/dist
       - name: Install web deps (playwright)
-        run: bun install --frozen-lockfile
+        run: sh ../scripts/bun-install.sh
         working-directory: web
       - name: Install CJK fonts (baselines render zh-CN glyphs)
         run: sudo apt-get update && sudo apt-get install -y fonts-noto-cjk

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,19 @@ ARG BUN_VERSION=1.3.14
 FROM oven/bun:${BUN_VERSION}-alpine AS web
 WORKDIR /app/web
 COPY web/package.json web/bun.lock ./
-# --mount=type=cache keeps the Bun install cache across builds so repeat
-# installs skip already-fetched tarballs.
-RUN --mount=type=cache,target=/root/.bun/install-cache \
-    bun install --frozen-lockfile
+# The install retry policy is shared with CI so the two cannot drift. It lives in
+# scripts/ rather than in a composite action because .dockerignore excludes
+# .github from the build context.
+COPY scripts/bun-install.sh /tmp/bun-install.sh
+# The cache mount target is bun's real install cache. It used to point at
+# /root/.bun/install-cache (hyphen) while bun reads and writes
+# /root/.bun/install/cache (slash) -- confirmed with `bun pm cache` -- so the
+# mount cached nothing at all and the comment above it was false: every image
+# build re-downloaded every tarball from scratch. That is also what made this
+# step the one most exposed to the registry/CDN integrity faults the shared
+# retry script exists to absorb.
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    sh /tmp/bun-install.sh
 COPY web ./
 RUN bun run build:web
 

--- a/scripts/bun-install.sh
+++ b/scripts/bun-install.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Bounded retry around `bun install --frozen-lockfile`.
+#
+# WHY THIS EXISTS
+# bun fetches tarballs from the npm registry through a CDN, and a corrupt or
+# truncated download surfaces as "Integrity check failed for tarball: <pkg>" /
+# "Fail extracting tarball from <pkg>". That is not a property of this
+# repository -- the same commit installs cleanly on a rerun -- but it fails a
+# required check and blocks a merge. Observed on 2026-09-03 alone, four
+# different packages across three different jobs: recharts (a11y),
+# @base-ui/react and @oxlint/binding-linux-x64-gnu (visual-regression), and
+# lightningcss-linux-arm64-musl (docker-push, inside the image build).
+#
+# WHAT IT DELIBERATELY DOES NOT DO
+# Retry anything else. A frozen-lockfile mismatch, a missing manifest or a
+# lifecycle-script error is a real defect; retrying it three times only delays
+# the truth and burns runner minutes. The classifier below is the whole point of
+# this script -- a blanket retry would be indistinguishable from hiding
+# breakage.
+#
+# The install cache is cleared before each retry. Without that, a corrupt
+# tarball bun already wrote to its cache would be re-read on every attempt and
+# the retry would fail identically three times, i.e. not be a retry at all.
+#
+# Shared by CI (every web-deps step in .github/workflows/main.yml) and the
+# image build (Dockerfile stage 1) on purpose: one retry policy, so the two
+# cannot drift. scripts/bun_install_wiring_test.go is the gate that keeps them
+# pointing here -- a bare `bun install` in a workflow or the Dockerfile turns it
+# red. POSIX sh only: the alpine bun image has no bash, so no arrays, no
+# PIPESTATUS, no [[ ]].
+set -u
+
+MAX_ATTEMPTS="${BUN_INSTALL_MAX_ATTEMPTS:-3}"
+TRANSIENT='Integrity check failed|IntegrityCheckFailed|Fail extracting tarball|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|socket hang up|fetch failed'
+
+attempt=1
+while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+  log="$(mktemp)"
+  bun install --frozen-lockfile >"$log" 2>&1
+  rc=$?
+  cat "$log"
+
+  if [ "$rc" -eq 0 ]; then
+    rm -f "$log"
+    if [ "$attempt" -gt 1 ]; then
+      echo "bun install succeeded on attempt $attempt of $MAX_ATTEMPTS"
+    fi
+    exit 0
+  fi
+
+  if grep -qE "$TRANSIENT" "$log" && [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+    echo "::warning::bun install hit a transient registry/CDN fault (attempt $attempt of $MAX_ATTEMPTS); clearing the install cache and retrying"
+    grep -E 'Integrity check failed|Fail extracting tarball|^error:' "$log" | head -5 | sed 's/^/    /'
+    rm -f "$log"
+    bun pm cache rm >/dev/null 2>&1 || true
+    sleep $((attempt * 5))
+    attempt=$((attempt + 1))
+    continue
+  fi
+
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "::error::bun install still failing after $attempt attempts"
+  else
+    echo "::error::bun install failed with a non-transient error; not retrying"
+  fi
+  rm -f "$log"
+  exit "$rc"
+done

--- a/scripts/bun_install_wiring_test.go
+++ b/scripts/bun_install_wiring_test.go
@@ -1,0 +1,106 @@
+package scripts
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Every bun install in this repository must go through scripts/bun-install.sh.
+//
+// Two defects motivated this gate and neither was visible in a green build:
+//
+//   - A bare `bun install --frozen-lockfile` has no retry. bun downloads
+//     tarballs through the npm CDN, and a corrupt or truncated one surfaces as
+//     "Integrity check failed for tarball: <pkg>". That is not a property of
+//     this commit -- a rerun installs cleanly -- but it fails a required check
+//     and blocks a merge. On 2026-09-03 alone it hit four different packages
+//     across three jobs: recharts (a11y), @base-ui/react and
+//     @oxlint/binding-linux-x64-gnu (visual-regression), and
+//     lightningcss-linux-arm64-musl (docker-push, inside the image build).
+//   - The Dockerfile's cache mount pointed at /root/.bun/install-cache while bun
+//     reads and writes /root/.bun/install/cache, so the mount cached nothing and
+//     the comment claiming otherwise was false. Every image build re-downloaded
+//     every tarball, which is also what made it the step most exposed to the
+//     fault above.
+//
+// The retry policy deliberately does NOT blanket-retry: a frozen-lockfile
+// mismatch or a lifecycle-script failure must still fail on the first attempt,
+// so the script's non-transient branch is asserted here too.
+func TestBunInstallWiring(t *testing.T) {
+	scriptsDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(scriptsDir, "..")
+	read := func(rel string) string {
+		t.Helper()
+		b, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		return string(b)
+	}
+
+	t.Run("policy script keeps both branches", func(t *testing.T) {
+		script := read("scripts/bun-install.sh")
+		for _, want := range []string{
+			"bun install --frozen-lockfile",
+			"Integrity check failed",
+			"Fail extracting tarball",
+			// The retry must be bounded and must give up loudly.
+			"MAX_ATTEMPTS",
+			"still failing after",
+			// Without this the retry is decorative: a corrupt tarball bun
+			// already cached would be re-read identically every attempt.
+			"bun pm cache rm",
+			// A real defect must not be retried into obscurity.
+			"non-transient error; not retrying",
+		} {
+			if !strings.Contains(script, want) {
+				t.Errorf("scripts/bun-install.sh no longer contains %q; the retry policy has been gutted", want)
+			}
+		}
+	})
+
+	t.Run("no workflow step calls bun install directly", func(t *testing.T) {
+		workflow := read(".github/workflows/main.yml")
+		// Comments are allowed to say "bun install" (this policy is documented
+		// inline); an executable run: line is not.
+		bare := regexp.MustCompile(`(?m)^\s*(?:-\s*)?run:\s*(?:\|.*)?bun install`)
+		for i, line := range strings.Split(workflow, "\n") {
+			if bare.MatchString(line) {
+				t.Errorf(".github/workflows/main.yml:%d calls bun install without the retry policy: %s", i+1, strings.TrimSpace(line))
+			}
+		}
+		got := strings.Count(workflow, "sh ../scripts/bun-install.sh")
+		const want = 5 // frontend, a11y, release, ui-screenshots, visual-regression
+		if got != want {
+			t.Errorf(".github/workflows/main.yml routes %d web-deps installs through scripts/bun-install.sh, want %d; a new job that installs web deps must use it too", got, want)
+		}
+	})
+
+	t.Run("Dockerfile uses the shared policy and the real cache path", func(t *testing.T) {
+		dockerfile := read("Dockerfile")
+		if !strings.Contains(dockerfile, "sh /tmp/bun-install.sh") {
+			t.Error("Dockerfile no longer runs scripts/bun-install.sh; the image build has lost the retry policy and drifted from CI")
+		}
+		if !strings.Contains(dockerfile, "target=/root/.bun/install/cache") {
+			t.Error("Dockerfile cache mount is not bun's real install cache (/root/.bun/install/cache, per `bun pm cache`); the mount would cache nothing")
+		}
+		for i, line := range strings.Split(dockerfile, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "#") {
+				continue // the wrong path is named in a comment on purpose
+			}
+			if strings.Contains(trimmed, "install-cache") {
+				t.Errorf("Dockerfile:%d uses the non-existent cache path /root/.bun/install-cache (bun uses install/cache): %s", i+1, trimmed)
+			}
+			if strings.HasPrefix(trimmed, "bun install") || strings.Contains(trimmed, "&& bun install") {
+				t.Errorf("Dockerfile:%d calls bun install directly instead of the shared retry script: %s", i+1, trimmed)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## 改动摘要

两个缺陷，**都在绿色构建里看不见**，都在实际吃掉合并。

**① `bun install` 对瞬时 registry 故障零重试。** bun 经 npm CDN 拉 tarball，一个损坏/截断的下载会报 `Integrity check failed for tarball: <pkg>`。这**不是被测提交的属性**——重跑就装得上——但它会挂掉一个必选检查、挡住一次合并。**仅 2026-09-03 一天就命中四个不同包、跨三个 job**：

| job | 包 | 后果 |
|---|---|---|
| `a11y` | `recharts` | **master 变红**（commit `1ce7a928`，纯 docs 提交） |
| `visual-regression` | `@base-ui/react` + `@oxlint/binding-linux-x64-gnu` | 挡住 #1172 合并 |
| `docker-push`（镜像构建内） | `lightningcss-linux-arm64-musl` | master `cebb374c` 的 push 管道失败 |

**② Dockerfile 的 cache mount 从来没缓存过任何东西。** 它挂在 `/root/.bun/install-cache`，而 bun 读写的是 `/root/.bun/install/cache`（`bun pm cache` 实测确认）——**一个连字符 vs 一个斜杠**。于是那句注释「keeps the Bun install cache across builds so repeat installs skip already-fetched tarballs」是假的，**每次镜像构建都从零重新下载全部 tarball**，而这恰恰使它成为对缺陷 ① 暴露最重的那一步。

两个调用点现在共用 `scripts/bun-install.sh` 里的**一份**策略。它放在 `scripts/` 而不是做成 composite action，因为 `.dockerignore` 把 `.github` 排除在构建上下文之外，action 无法与镜像构建共享。**共享是关键**：两份重试策略必然漂移。

**重试刻意做得很窄。** 只对瞬时故障重试——tarball 完整性与解压失败、连接重置/超时、DNS 与 fetch 错误。`--frozen-lockfile` 不匹配、manifest 缺失、404、生命周期脚本报错**一律第一次就失败**：把一个真缺陷重试三遍只是把真相推迟、白烧 runner 分钟数。每次重试前清安装缓存（`bun pm cache rm`）——不清的话 bun 已缓存的坏 tarball 会被每次原样重读，那就不叫重试了。

`scripts/bun_install_wiring_test.go` 把这一切钉住：任何 workflow 的 `run:` 行都不得直接调 `bun install`、**恰好 5 处** web-deps 安装必须走该脚本、Dockerfile 必须调它且必须挂 bun 真实的缓存路径、脚本必须保留「有界尝试 / 清缓存 / 非瞬时不重试」三个分支。

## 类型

- [x] fix（bug 修复：cache mount 路径错 ⇒ 从未生效；瞬时故障无重试 ⇒ 白挡合并）
- [x] chore（CI 工程维护）
- [x] test（新增布线门禁）

## 测试验证

- [x] `go build ./...` / `go vet ./...` 通过；`gofmt -l` 对新增 `.go` 文件为空；`go test ./scripts/ ./docs -count=1` 全绿
- [x] **行为验证**（scenario 驱动的 `bun` 桩，`BUN_INSTALL_MAX_ATTEMPTS=3`）：

  | 场景 | rc | install 次数 | 清缓存次数 | 判定 |
  |---|---|---|---|---|
  | 首次即成功 | 0 | 1 | 0 | PASS |
  | 瞬时故障 → 第 3 次成功 | 0 | 3 | 2 | PASS（并打印 `succeeded on attempt 3 of 3`）|
  | 瞬时故障恒失败 | 1 | 3 | 2 | PASS（`still failing after 3 attempts`）|
  | **`--frozen-lockfile` 不匹配** | 1 | **1** | **0** | PASS（`non-transient error; not retrying`）|

- [x] **分类器验证**：今天四条真实报错串（共 8 种瞬时形态）**全部命中**；7 条真实缺陷**全部不命中**——含 `lockfile had changes, but lockfile is frozen`、`MissingPackageJSON`、`404 Not Found`、`postinstall script … exited with code 1`，以及最微妙的一条 **`Incorrect integrity: expected sha512-… for a package you pinned`**：pin 住的完整性不匹配是**真问题**（有人动了 lockfile，或 registry 供了别的版本），必须第一次就失败，正则里没有裸 `integrity` 正是为此
- [x] **真实 bun 快路径**：`cd web && sh ../scripts/bun-install.sh` → `613 packages installed [1.88s]`、rc=0、**`web/bun.lock` 与 `web/package.json` 零改动**（`git status --porcelain` 为空）
- [x] **变异探针 4 发 4 中**，每发都红、随后 `sha256sum -c` 三文件逐字节还原、门禁复绿：
  1. 把 `visual-regression` 那处改回裸 `bun install` → 红，且**同时**报出「只剩 4 处走脚本，应为 5」（两条断言互相独立地抓住同一次回退）
  2. Dockerfile 缓存路径改回连字符形态 → 红（两条断言：mount 目标 + 逐行扫描非注释行）
  3. 删掉 `bun pm cache rm`（让重试变成装饰）→ 红：`the retry policy has been gutted`
  4. Dockerfile 改回直接 `bun install` → 红
- [x] `actionlint` 对改后的 workflow **零 findings**

## 自查清单

- [x] 无密钥/内部路径泄漏（注释只写包名、job 名与仓库相对路径）
- [x] 无新增依赖（`scripts/bun-install.sh` 是 POSIX sh，alpine bun 镜像无 bash，故不用数组 / `PIPESTATUS` / `[[ ]]`）
- [x] 无 schema 变更、无 env 变量新增（`BUN_INSTALL_MAX_ATTEMPTS` 是脚本内可选覆盖，默认 3，未进 `.env.example`，因为它不是产品配置）
- [x] 用户可见面零变更 ⇒ 无 i18n、无 CHANGELOG 条目（CI/构建工程，非运维可见契约）
- [x] 未改任何必选检查的 job 名（分支保护按名依赖）

## 一处需要维护者知道的行为变化

`release` job 原来的 `Build frontend for release binaries` 一步是 `bun install --frozen-lockfile && bun run build:web`，现拆成两步（`Install web deps for release binaries` + `Build frontend for release binaries`）。**job 名与必选检查名未变**，只是 step 数 +1；这样安装失败与构建失败在日志里可分别定位，也让安装那一步能走共享重试。
