### PR TITLE
docs(agents): a gate must be proven to gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,11 @@ golangci-lint run --timeout=3m        # Lint check
 
 - **Do not push if local CI fails**: all pushes must pass `go vet ./... && go test ./... -count=1 -race` first
 - The global hook-kit chains `.githooks/pre-push-project` and automatically blocks pushes that fail local CI; `.githooks/pre-push` is only the standalone compatibility entrypoint
-- Emergency skip: `git push --no-verify`
+- Emergency skip: `git push --no-verify`. Know what it costs: on a host that uses it, **CI is the only gate that ran**, so CI's own integrity is load-bearing rather than somebody else's problem.
 - GitHub Actions is the final verification gate, not a debug environment
+- **A gate must be proven to gate.** Before trusting a check — new or long-standing — delete the fix it is supposed to protect (or feed it a known-bad input), confirm it goes red, then restore byte-identically and confirm with `sha256sum -c`. A check that cannot fail is worse than no check, because it spends trust while looking like coverage. This repo has shipped two: `test-sqlite-shard` selected zero packages and reported success for **30 tags** while `-race` never ran (#1175), and a verification script's "which build is running" line was printing `{"error":"Missing Authorization header"}` and being read as an answer.
+- **"Reruns green" proves a fault is transient, not that it needs no fix.** Four npm-CDN tarball-integrity failures across three jobs in one day were first filed as environmental noise and shelved; the missing retry was the actual defect (#1181).
+- Same rule for prose: a comment that describes what a mechanism does is a claim. Check it. `--mount=type=cache,target=/root/.bun/install-cache` claimed to persist bun's install cache while bun uses `install/cache`, so every image build re-downloaded everything (#1181).
 
 ## Specs & Docs
 


### PR DESCRIPTION
## 改动摘要

`AGENTS.md` 的 CI Discipline 说了「GitHub Actions 是终审门」，也给了 `--no-verify` 这个逃生阀，但**没有记下这个交换的代价，也没记下怎么分辨一道真门禁和一道装饰**。同一天里同一类故障出现了三次以上——按知识卫生的毕业判据（同一教训第三次出现 / 内容是在解释系统怎么工作），它该进**常驻层**而不是留在某一波的复盘里。

四件事，全是**「一段机制不做它声称做的事，而没有任何东西检查它」**：

| 事故 | 声称 | 实际 |
|---|---|---|
| #1175 | 必选检查 `test-sqlite`（四分片跑 `-race`） | 分片算术缺 `${{ }}`，选到 **0 个包**、`exit 0`，**连续 30 个 tag 全绿而 `-race` 从未执行** |
| 私有层复验脚本 | `/api/about` 那行用来证明「当前跑的是哪个构建」 | 裸调缺 admin bearer，打印 `{"error":"Missing Authorization header"}` 就被当成答案往下走 |
| #1181（重试） | 四次 `bun install` 完整性失败被记作「环境噪音（非代码）」搁进 backlog | **缺重试才是缺陷**；「重跑即绿」只证明故障瞬时，不证明它不用修 |
| #1181（缓存） | 注释称 `--mount=type=cache` 「keeps the Bun install cache across builds」 | 挂在 `/root/.bun/install-cache`，bun 用的是 `/root/.bun/install/cache`——**差一个字符 ⇒ 从未缓存过任何东西**，每次镜像构建重下全部 tarball |

新增四条规则（`## CI Discipline`，103 → 106 行）：

1. **门禁必须先被证明能失败**：信任一道检查之前，把它本该守住的那个修复摘掉（或喂一个已知坏输入），确认它变红，再逐字节还原并用 `sha256sum -c` 核对。**一道不会失败的检查比没有检查更糟——它一边消耗信任一边看起来像覆盖率。**
2. **「重跑即绿」证明故障是瞬时的，不证明它不需要修。**
3. `--no-verify` 的代价要写明：用了它的主机上，**CI 是唯一真跑过的门** ⇒ CI 自身的完整性是承重结构，不是别人的问题。
4. **描述机制的注释是一条断言**，要去核对。

## 类型

- [x] docs（agent 规则常驻层）

## 测试验证

- [x] `go test ./docs -count=1` 通过（`TestPublicMarkdownHygiene` 覆盖 `AGENTS.md`：链接可达、无私有路径、无内部主机事实）
- [x] `CLAUDE.md` 是 11 字节的 `@AGENTS.md` include，**无需同步**（已核对内容）
- [x] 尺寸预算：`AGENTS.md` 103 → **106 行**，远低于 300 行上限；新增 4 条均为规则式祈使句 + 一个 PR 号指针，**不是变更日志**（细节留在 `docs/internal/log.md` 与各 PR）
- [x] 无代码改动 ⇒ build / vet / race / 前端不受影响
- [x] 四条规则的每一条都有本轮的实测出处，可直接复核：`gh run view 33688065152`（#1172 的 `test-pg` 红而四分片绿）· `git tag --contains 06025d53 | wc -l` = 30 · `bun pm cache` 输出真实缓存路径 · #1181 的 4 发变异探针

## 自查清单

- [x] 无密钥/内部路径泄漏（只写公开 job 名、公开 PR 号、仓库相对路径；私有层那例只描述行为、不落路径与主机名）
- [x] 无用户可见文案变更 ⇒ 无 i18n
- [x] 无需改 `CHANGELOG.md`：agent 规则不是运维可见契约，按 patch-first 也不构成发版理由
- [x] 未与既有规则冲突：`docs/internal/git-workflow.md:110` 让人在 worktree 里跑**不带** `--frozen-lockfile` 的 `bun install` 来重新生成 lockfile，那是刻意不同的用途，规则 1 约束的是「信任一道检查之前先证明它能失败」，不是禁止直接调 bun
