### PR TITLE
fix(accounts): persist the credential mode an operator saves (#1176)

### DIFF
--- a/handler/admin/accounts.go
+++ b/handler/admin/accounts.go
@@ -1176,6 +1176,21 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// #1176: credentialMode is an explicit operator choice on the edit form.
+	// Resolve it before the credential fields are touched so the api_token
+	// mirror (an apikey-mode convenience) cannot stamp a session credential as
+	// an API key, and so the mode that gets persisted is the one requested.
+	var requestedMode service.AccountCredentialMode
+	hasRequestedMode := false
+	if body.CredentialMode != nil {
+		mode := service.NormalizeCredentialMode(*body.CredentialMode)
+		if mode != service.CredentialModeSession && mode != service.CredentialModeAPIKey {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid credentialMode. Expected session or apikey."})
+			return
+		}
+		requestedMode, hasRequestedMode = mode, true
+	}
+
 	updates := map[string]any{}
 	pendingExtraConfig := row.Account.ExtraConfig
 	mergeExtraConfigUpdate := func(patch map[string]any) {
@@ -1189,10 +1204,13 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 		updates["username"] = *body.Username
 	}
 	mirrorAPIKeyToken := false
+	explicitSessionSwitch := hasRequestedMode && requestedMode == service.CredentialModeSession
 	if body.AccessToken != nil {
 		nextAccessToken := strings.TrimSpace(*body.AccessToken)
 		updates["accessToken"] = nextAccessToken
-		mirrorAPIKeyToken = shouldMirrorAPIKeyToken(row.Account, body.APIToken)
+		// A session JWT is not an API key: skip the apikey mirror when the
+		// operator explicitly moved this account to session mode (#1176).
+		mirrorAPIKeyToken = !explicitSessionSwitch && shouldMirrorAPIKeyToken(row.Account, body.APIToken)
 		if mirrorAPIKeyToken {
 			updates["apiToken"] = nextAccessToken
 		}
@@ -1284,6 +1302,12 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 		}
 		mergeExtraConfigUpdate(map[string]any{"proxyUrl": proxyPatch})
 	}
+	// credentialMode lives in extraConfig (same storage as the create path).
+	// Merged after body.ExtraConfig so the explicit top-level field wins over a
+	// nested copy in the same request, mirroring how proxyUrl is handled.
+	if hasRequestedMode {
+		mergeExtraConfigUpdate(map[string]any{"credentialMode": string(requestedMode)})
+	}
 	// PlatformUserID and skipModelFetch live in extraConfig (same storage as
 	// the create path); merge instead of dropping the form fields.
 	if body.PlatformUserID != nil {
@@ -1333,6 +1357,22 @@ func (h *accountsHandler) updateAccount(w http.ResponseWriter, r *http.Request) 
 			mergeExtraConfigUpdate(map[string]any{"sub2apiAuth": mergedAuth})
 		}
 	}
+	// Fail loud instead of persisting a mode the stored credential cannot back:
+	// such an account can never authenticate, and the edit dialog would keep
+	// showing a mode that lies about what is on the row (#1176).
+	if hasRequestedMode {
+		hasSession := strings.TrimSpace(nextAccount.AccessToken) != ""
+		hasAPIKey := nextAccount.APIToken != nil && strings.TrimSpace(*nextAccount.APIToken) != ""
+		if requestedMode == service.CredentialModeSession && !hasSession {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "credentialMode session requires a session credential: send accessToken in the same request."})
+			return
+		}
+		if requestedMode == service.CredentialModeAPIKey && !hasAPIKey {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "credentialMode apikey requires an API key: send apiToken in the same request."})
+			return
+		}
+	}
+
 	// Expired API-key recovery (p3-sites-accounts.md 594-602 / TS accounts.ts):
 	// when credentials change on an expired apikey account and status is not forced
 	// disabled, refresh models with allowInactive and reactivate only on success.

--- a/handler/admin/accounts_credential_mode_update_test.go
+++ b/handler/admin/accounts_credential_mode_update_test.go
@@ -1,0 +1,160 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// #1176 — the account edit form sends credentialMode on every save and the
+// update handler dropped the field: switching an existing API-key account to
+// session mode reported success, but reopening the dialog still showed API key
+// because extraConfig.credentialMode was never written. These tests pin the
+// persisted mode plus the fail-loud behaviour when the stored credential cannot
+// back the requested mode.
+
+// setupCredentialModeAccountFixture seeds one site + one account whose stored
+// credential shape is explicit, so a mode switch has something to switch from.
+func setupCredentialModeAccountFixture(t *testing.T, db *store.DB, r chi.Router, extraConfig, accessToken string, apiToken *string) (int64, int64) {
+	t.Helper()
+	siteResp := doPostJSON(t, r, "/api/sites", map[string]any{
+		"name":     "Credential Mode Site",
+		"url":      "https://credmode.example.com",
+		"platform": "new-api",
+	})
+	if siteResp.Code != http.StatusOK {
+		t.Fatalf("create site: %d %s", siteResp.Code, siteResp.Body.String())
+	}
+	var site map[string]any
+	if err := json.Unmarshal(siteResp.Body.Bytes(), &site); err != nil {
+		t.Fatalf("decode site: %v", err)
+	}
+	siteID := int64(site["id"].(float64))
+
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	res, err := db.Exec(
+		"INSERT INTO accounts (site_id, username, access_token, api_token, status, checkin_enabled, extra_config, created_at, updated_at) VALUES (?, ?, ?, ?, 'active', FALSE, ?, ?, ?)",
+		siteID, "cred-user", accessToken, apiToken, extraConfig, now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert account: %v", err)
+	}
+	accountID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("account LastInsertId: %v", err)
+	}
+	return siteID, accountID
+}
+
+func storedCredentialMode(t *testing.T, db *store.DB, accountID int64) string {
+	t.Helper()
+	var extra *string
+	if err := db.QueryRow("SELECT extra_config FROM accounts WHERE id = ?", accountID).Scan(&extra); err != nil {
+		t.Fatalf("read extra_config: %v", err)
+	}
+	if extra == nil {
+		return ""
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(*extra), &cfg); err != nil {
+		t.Fatalf("decode extra_config %q: %v", *extra, err)
+	}
+	mode, _ := cfg["credentialMode"].(string)
+	return mode
+}
+
+func TestAccounts_Update_PersistsRequestedCredentialMode(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	_, accountID := setupCredentialModeAccountFixture(t, db, r,
+		`{"credentialMode":"apikey"}`, "", strPtrCredMode("sk-ant-key-1"))
+
+	resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"credentialMode": "session",
+		"accessToken":    "session-jwt-1",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("switch apikey -> session: %d %s", resp.Code, resp.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := body["credentialMode"]; got != "session" {
+		t.Fatalf("response credentialMode = %#v, want session", got)
+	}
+	if got := storedCredentialMode(t, db, accountID); got != "session" {
+		t.Fatalf("stored credentialMode = %q, want session", got)
+	}
+
+	// And back again: the api token supplied in the same save backs the mode.
+	resp = doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"credentialMode": "apikey",
+		"apiToken":       "sk-ant-key-2",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("switch session -> apikey: %d %s", resp.Code, resp.Body.String())
+	}
+	if got := storedCredentialMode(t, db, accountID); got != "apikey" {
+		t.Fatalf("stored credentialMode = %q, want apikey", got)
+	}
+}
+
+func TestAccounts_Update_CredentialModeWithoutBackingCredentialIsRejected(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	_, accountID := setupCredentialModeAccountFixture(t, db, r,
+		`{"credentialMode":"apikey"}`, "", strPtrCredMode("sk-ant-key-1"))
+
+	// No session credential anywhere on the row: a silent switch would leave an
+	// account that reports session mode while holding nothing to authenticate
+	// with, so the handler must refuse instead of persisting a broken state.
+	resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"credentialMode": "session",
+	})
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("session switch without credential: got %d, want 400 (%s)", resp.Code, resp.Body.String())
+	}
+	if got := storedCredentialMode(t, db, accountID); got != "apikey" {
+		t.Fatalf("stored credentialMode = %q, want unchanged apikey", got)
+	}
+}
+
+func TestAccounts_Update_InvalidCredentialModeIsRejected(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	_, accountID := setupCredentialModeAccountFixture(t, db, r,
+		`{"credentialMode":"apikey"}`, "", strPtrCredMode("sk-ant-key-1"))
+
+	for _, mode := range []string{"password", "auto", "browser", ""} {
+		resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+			"credentialMode": mode,
+			"accessToken":    "session-jwt-1",
+		})
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("credentialMode %q: got %d, want 400 (%s)", mode, resp.Code, resp.Body.String())
+		}
+	}
+	if got := storedCredentialMode(t, db, accountID); got != "apikey" {
+		t.Fatalf("stored credentialMode = %q, want unchanged apikey", got)
+	}
+}
+
+func TestAccounts_Update_OmittedCredentialModeLeavesStoredModeAlone(t *testing.T) {
+	db, r, _ := setupAccountsTest(t)
+	_, accountID := setupCredentialModeAccountFixture(t, db, r,
+		`{"credentialMode":"session","proxyUrl":"http://proxy.local"}`, "session-jwt-1", nil)
+
+	resp := doPutJSON(t, r, "/api/accounts/"+itoa(accountID), map[string]any{
+		"remark": "no mode in this patch",
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("partial update: %d %s", resp.Code, resp.Body.String())
+	}
+	if got := storedCredentialMode(t, db, accountID); got != "session" {
+		t.Fatalf("stored credentialMode = %q, want preserved session", got)
+	}
+}
+
+func strPtrCredMode(s string) *string { return &s }

--- a/handler/admin/payloads/accounts.go
+++ b/handler/admin/payloads/accounts.go
@@ -36,6 +36,10 @@ type AccountUpdatePayload struct {
 	PlatformUserID *int `json:"platformUserId,omitempty"`
 	// SkipModelFetch is merged into extraConfig (same storage as create).
 	SkipModelFetch *bool `json:"skipModelFetch,omitempty"`
+	// CredentialMode is the mode the edit form saves (session | apikey). It was
+	// absent from this payload, so the handler never saw it and a saved switch
+	// silently kept the old mode (#1176).
+	CredentialMode *string `json:"credentialMode,omitempty"`
 	// Tags is stored in accounts.tags as a JSON array text (see tags.go).
 	Tags *[]string `json:"tags,omitempty"`
 }


### PR DESCRIPTION
## What

Closes #1176.

The account edit dialog offers three credential modes and sends `credentialMode` on every save. `AccountUpdatePayload` had no such field, so the handler decoded the request without it and the saved switch vanished: create an account as **API key**, edit it to **session**, get a success toast, reopen the dialog and API key is selected again.

## Fix

1. `credentialMode` joins the update payload and is merged into `extraConfig` — the same storage the create path writes, and the first thing `ResolveStoredCredentialMode` reads.
2. The requested mode is resolved **before** the credential fields are touched. `shouldMirrorAPIKeyToken` looks at the *stored* mode, so an explicit switch to session mode used to copy the session credential into `api_token`; a session credential is not an API key, and the proxy's credential fallback would then send it as one.
3. A mode the stored credential cannot back is rejected with `400` instead of persisted: `session` without any `accessToken`, or `apikey` without any `apiToken`, produces an account that can never authenticate while its row claims otherwise.

## Gate

`handler/admin/accounts_credential_mode_update_test.go` — four cases (persist both directions, reject an unbackable switch and prove the stored mode did not move, reject invalid mode strings, and prove an omitted field still leaves the stored mode alone). Verified red before the handler change (`response credentialMode = "apikey", want session`, `got 200, want 400`) and green after.

Full local run: `go build ./...`, `go test ./handler/admin/ ./service/... ./handler/proxy/` — all packages ok.