### PR TITLE
fix(proxy): say why no channel could serve the request (#1179)

### DIFF
--- a/handler/proxy/upstream.go
+++ b/handler/proxy/upstream.go
@@ -144,9 +144,17 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 			},
 		)
 		if err != nil || selected == nil {
+			// Ask why. Selection reports "nothing selectable" as (nil, nil), so
+			// without this the log line reads err=<nil> and the client gets a
+			// bare "No available channels" — no way to tell an unmatched route
+			// from unbound tokens, cooldown or a downstream key policy, which
+			// have three different fixes (#1179).
+			noChannelReason := proxy.ExplainNoChannel(
+				r.Context(), cfg.Router, ctx.RequestedModel, excludeChannelIDs, downstreamPolicy)
 			slog.Warn("channel selection failed",
 				"err", err,
 				"model", ctx.RequestedModel,
+				"reason", noChannelReason,
 				"retry", retry,
 				"request_id", requestID,
 			)
@@ -156,8 +164,14 @@ func dispatchUpstream(w http.ResponseWriter, r *http.Request, ctx *Ctx) {
 				observeProxyTerminal(ctx, pendingFailure.outcomeStatus(), ctx != nil && ctx.IsStream, time.Since(startedAt))
 				return
 			}
-			reportProxyAllFailedTerminal(ctx, "no available channels")
-			writeJSONErrorWithRequest(w, 503, "No available channels", "server_error", requestID)
+			eventReason := "no available channels"
+			message := "No available channels"
+			if noChannelReason != "" {
+				eventReason += ": " + noChannelReason
+				message += ": " + noChannelReason
+			}
+			reportProxyAllFailedTerminal(ctx, eventReason)
+			writeJSONErrorWithRequest(w, 503, message, "server_error", requestID)
 			observeProxyTerminal(ctx, shared.OutcomeUnavailable, ctx != nil && ctx.IsStream, time.Since(startedAt))
 			return
 		}

--- a/handler/proxy/upstream_no_channel_reason_test.go
+++ b/handler/proxy/upstream_no_channel_reason_test.go
@@ -1,0 +1,186 @@
+package proxyhandler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/deliciousbuding/metapi-go/proxy"
+	"github.com/deliciousbuding/metapi-go/routing"
+)
+
+// #1179 — "部署后基本用不了": every routing failure answered with a bare
+// "No available channels" and a server log line of `channel selection failed
+// err=<nil>`. An operator could not tell an unmatched route from a fleet of
+// channels whose tokens were never bound, from cooldown, or from a downstream
+// key policy — the three have completely different fixes. The router already
+// knows (routing.TokenRouter.ExplainSelection, the same source the route
+// decision panel reads); the failure path just never asked.
+
+// explainingRouter is the all-failed stub plus the optional explanation
+// capability routing.TokenRouter has in production.
+type explainingRouter struct {
+	allFailedAlertRouter
+	explanation routing.RouteDecisionExplanation
+	explainErr  error
+	explained   int
+}
+
+func (r *explainingRouter) ExplainSelection(_ context.Context, _ string, _ []int64, _ routing.DownstreamRoutingPolicy) (routing.RouteDecisionExplanation, error) {
+	r.explained++
+	return r.explanation, r.explainErr
+}
+
+func TestDispatchNoAvailableChannelsCarriesTheRealReason(t *testing.T) {
+	db := setupAllFailedAlertDB(t)
+	router := &explainingRouter{
+		allFailedAlertRouter: allFailedAlertRouter{}, // selects nothing, no error
+		explanation: routing.RouteDecisionExplanation{
+			RequestedModel: "gpt-reason",
+			ActualModel:    "gpt-reason",
+			Matched:        true,
+			Summary: []string{
+				"命中路由：gpt-*",
+				"没有可用通道（全部被禁用、站点不可用、冷却或令牌不可用）",
+			},
+			Candidates: []routing.RouteDecisionCandidate{
+				{ChannelID: 1, Eligible: false, Reason: "令牌不可用"},
+				{ChannelID: 2, Eligible: false, Reason: "令牌不可用"},
+				{ChannelID: 3, Eligible: false, Reason: "冷却中"},
+			},
+		},
+	}
+	SetUpstreamConfig(&UpstreamConfig{Router: router})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions",
+		`{"model":"gpt-reason","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body = %s", rec.Code, rec.Body.String())
+	}
+	var envelope struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode body %q: %v", rec.Body.String(), err)
+	}
+	msg := envelope.Error.Message
+	if !strings.Contains(msg, "No available channels") {
+		t.Fatalf("message = %q, want it to keep the stable %q prefix", msg, "No available channels")
+	}
+	// The dominant per-candidate reason is the actionable part: two channels had
+	// no usable token, one was cooling down.
+	if !strings.Contains(msg, "令牌不可用") {
+		t.Fatalf("message = %q, want the dominant candidate reason 令牌不可用", msg)
+	}
+	if router.explained == 0 {
+		t.Fatal("the failure path never asked the router why nothing was selectable")
+	}
+
+	// The same reason reaches the operator-facing event feed, not only the wire.
+	eventMsg := lastAllFailedProxyEventMessage(t, db)
+	if !strings.Contains(eventMsg, "no available channels") {
+		t.Fatalf("event message = %q, want the stable reason label", eventMsg)
+	}
+	if !strings.Contains(eventMsg, "令牌不可用") {
+		t.Fatalf("event message = %q, want the explanation too", eventMsg)
+	}
+}
+
+func TestDispatchNoAvailableChannelsWithoutExplainerKeepsTheOldMessage(t *testing.T) {
+	// Unit stubs do not implement SelectionExplainer. A missing reason must
+	// degrade to the previous message, never into a harder failure.
+	setupAllFailedAlertDB(t)
+	SetUpstreamConfig(&UpstreamConfig{Router: &allFailedAlertRouter{}})
+	t.Cleanup(func() { SetUpstreamConfig(nil) })
+
+	req := makeProxyReq("POST", "/v1/chat/completions",
+		`{"model":"gpt-no-explainer","messages":[{"role":"user","content":"hi"}]}`)
+	rec := httptest.NewRecorder()
+	HandleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body = %s", rec.Code, rec.Body.String())
+	}
+	var envelope struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode body %q: %v", rec.Body.String(), err)
+	}
+	if envelope.Error.Message != "No available channels" {
+		t.Fatalf("message = %q, want the unchanged %q", envelope.Error.Message, "No available channels")
+	}
+}
+
+func TestExplainNoChannelRendersVerdictAndDominantReason(t *testing.T) {
+	cases := []struct {
+		name        string
+		explanation routing.RouteDecisionExplanation
+		explainErr  error
+		noExplainer bool
+		want        string
+	}{
+		{
+			name:        "no route matched",
+			explanation: routing.RouteDecisionExplanation{Summary: []string{"未匹配到启用的路由"}},
+			want:        "未匹配到启用的路由",
+		},
+		{
+			name: "route matched, every candidate rejected",
+			explanation: routing.RouteDecisionExplanation{
+				Summary: []string{"命中路由：gpt-*", "没有可用通道（全部被禁用、站点不可用、冷却或令牌不可用）"},
+				Candidates: []routing.RouteDecisionCandidate{
+					{Eligible: false, Reason: "冷却中"},
+					{Eligible: false, Reason: "令牌不可用"},
+					{Eligible: false, Reason: "令牌不可用"},
+				},
+			},
+			want: "没有可用通道（全部被禁用、站点不可用、冷却或令牌不可用）：令牌不可用",
+		},
+		{
+			name: "eligible candidates are not a rejection reason",
+			explanation: routing.RouteDecisionExplanation{
+				Summary:    []string{"命中路由：gpt-*"},
+				Candidates: []routing.RouteDecisionCandidate{{Eligible: true, Reason: ""}},
+			},
+			want: "命中路由：gpt-*",
+		},
+		{
+			name:       "explanation failed",
+			explainErr: context.DeadlineExceeded,
+			want:       "",
+		},
+		{
+			name:        "router cannot explain",
+			noExplainer: true,
+			want:        "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var router proxy.TokenRouterInterface = &explainingRouter{
+				explanation: tc.explanation,
+				explainErr:  tc.explainErr,
+			}
+			if tc.noExplainer {
+				router = &allFailedAlertRouter{}
+			}
+			got := proxy.ExplainNoChannel(context.Background(), router, "gpt-x", nil, routing.DownstreamRoutingPolicy{})
+			if got != tc.want {
+				t.Fatalf("ExplainNoChannel = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/proxy/channel_selection.go
+++ b/proxy/channel_selection.go
@@ -40,7 +40,7 @@ type ChannelSelectionInput struct {
 
 // Tester header constants.
 const (
-	TesterRequestHeader     = "x-metapi-tester-request"
+	TesterRequestHeader       = "x-metapi-tester-request"
 	TesterForcedChannelHeader = "x-metapi-tester-forced-channel-id"
 )
 
@@ -175,4 +175,76 @@ func SelectProxyChannelForAttempt(
 	}
 
 	return selected, err
+}
+
+// SelectionExplainer is the optional capability routing.TokenRouter brings to a
+// failed selection: why nothing was selectable. Unit stubs may omit it, and then
+// the failure is reported without a reason instead of failing harder — the same
+// optional-interface idiom AvailableModelsSource uses for model listing.
+type SelectionExplainer interface {
+	ExplainSelection(ctx context.Context, requestedModel string, excludeChannelIDs []int64, policy routing.DownstreamRoutingPolicy) (routing.RouteDecisionExplanation, error)
+}
+
+// ExplainNoChannel renders one compact line describing why no channel could
+// serve requestedModel, for the 503 body, the server log and the operator-facing
+// all-failed event. It returns "" when the router cannot explain or the
+// explanation itself fails: a missing reason must never become a harder failure.
+//
+// The route decision panel already reads ExplainSelection; this is the same
+// source, asked at the moment an operator actually needs it (#1179 — a bare "No
+// available channels" plus `channel selection failed err=<nil>` gave no way to
+// tell an unmatched route from unbound tokens, cooldown or a downstream policy).
+func ExplainNoChannel(
+	ctx context.Context,
+	router TokenRouterInterface,
+	requestedModel string,
+	excludeChannelIDs []int64,
+	policy routing.DownstreamRoutingPolicy,
+) string {
+	explainer, ok := router.(SelectionExplainer)
+	if !ok || explainer == nil {
+		return ""
+	}
+	explanation, err := explainer.ExplainSelection(ctx, requestedModel, excludeChannelIDs, policy)
+	if err != nil {
+		return ""
+	}
+
+	reason := ""
+	if n := len(explanation.Summary); n > 0 {
+		reason = strings.TrimSpace(explanation.Summary[n-1])
+	}
+
+	// A matched route whose every candidate was rejected reports a generic
+	// verdict; the per-candidate reason is the actionable part, so surface the
+	// most common one (ties keep first-seen order).
+	counts := map[string]int{}
+	order := make([]string, 0, len(explanation.Candidates))
+	for _, candidate := range explanation.Candidates {
+		if candidate.Eligible {
+			continue
+		}
+		candidateReason := strings.TrimSpace(candidate.Reason)
+		if candidateReason == "" {
+			continue
+		}
+		if _, seen := counts[candidateReason]; !seen {
+			order = append(order, candidateReason)
+		}
+		counts[candidateReason]++
+	}
+	dominant := ""
+	for _, candidateReason := range order {
+		if dominant == "" || counts[candidateReason] > counts[dominant] {
+			dominant = candidateReason
+		}
+	}
+	if dominant != "" {
+		if reason == "" {
+			reason = dominant
+		} else {
+			reason += "：" + dominant
+		}
+	}
+	return strings.TrimSpace(reason)
 }


### PR DESCRIPTION
## What

Part of #1179.

Channel selection reports "nothing selectable" as `(nil, nil)`, so the failure path logged

```
level=WARN msg="channel selection failed" err=<nil> model=… retry=0
```

and answered `503 {"error":{"message":"No available channels"}}`. Three completely different operator problems produce that identical output:

- no enabled route matches the model;
- a route matched but every channel's token is unbound/disabled (令牌不可用);
- every channel is cooling down, or the downstream key's policy excludes the sites.

The reporter's follow-up comment — "我看上面显示令牌未绑定，但是不知道在哪里绑定令牌" — is what that costs: the UI told them a token was unbound and nothing told them where or why it mattered.

The router already knows the answer: `routing.TokenRouter.ExplainSelection` is the same source the route decision panel reads, and it already renders per-candidate rejection reasons. The failure path just never asked.

## Fix

- `proxy.ExplainNoChannel(...)` renders one compact line: the explanation's verdict, plus the dominant per-candidate reason when a route matched but nothing was eligible (`没有可用通道（…）：令牌不可用`).
- It reaches the router through an optional `SelectionExplainer` interface — the same idiom `AvailableModelsSource` already uses for model listing — so unit stubs that cannot explain degrade to the previous message instead of failing harder, and an explanation that errors yields no reason rather than a second failure.
- The reason is added to the 503 body (the stable `No available channels` prefix is kept), to the WARN log as `reason=`, and to the operator-facing all-failed event.

## Gate

`handler/proxy/upstream_no_channel_reason_test.go`:

- `TestDispatchNoAvailableChannelsCarriesTheRealReason` — full handler dispatch through `HandleChatCompletions`; asserts the 503 message keeps its prefix *and* carries 令牌不可用, that the router was actually asked, and that the event feed carries it too. Red before wiring: `message = "No available channels", want the dominant candidate reason 令牌不可用`.
- `TestDispatchNoAvailableChannelsWithoutExplainerKeepsTheOldMessage` — a router without the capability must produce byte-identical old behaviour.
- `TestExplainNoChannelRendersVerdictAndDominantReason` — five table cases: unmatched route, matched-but-all-rejected (dominant reason wins over the minority one), eligible candidates are not a rejection reason, explanation error → "", non-explainer router → "".

Local: `go build ./...`, `go test ./handler/proxy/ ./proxy/` — ok.