### PR TITLE
test(web): fold same-shape zod schema cases into tables

### DIFF
--- a/web/src/features/accounts/__tests__/accounts-schema.test.ts
+++ b/web/src/features/accounts/__tests__/accounts-schema.test.ts
@@ -57,7 +57,7 @@ function validPasswordForm(): AccountFormValues {
 function expectInvalid(
   values: AccountFormValues,
   path?: Array<string | number>,
-  message?: string,
+  message?: string
 ): void {
   const result = getAccountFormSchema().safeParse(values)
   expect(result.success).toBe(false)
@@ -72,13 +72,43 @@ function expectInvalid(
 
 describe('getAccountFormSchema — superRefine', () => {
   const blankCredentialCases: Array<
-    [string, () => AccountFormValues, Partial<AccountFormValues>, (Array<string | number> | undefined)?, (string | undefined)?]
+    [
+      string,
+      () => AccountFormValues,
+      Partial<AccountFormValues>,
+      (Array<string | number> | undefined)?,
+      (string | undefined)?,
+    ]
   > = [
-    ['accessToken empty', validSessionForm, { accessToken: '' }, ['accessToken'], '请填写 Access Token / Cookie'],
+    [
+      'accessToken empty',
+      validSessionForm,
+      { accessToken: '' },
+      ['accessToken'],
+      '请填写 Access Token / Cookie',
+    ],
     ['accessToken whitespace', validSessionForm, { accessToken: '   ' }],
-    ['apiToken empty', validApikeyForm, { apiToken: '' }, ['apiToken'], '请填写 API Key'],
-    ['username empty', validPasswordForm, { username: '' }, ['username'], '请填写站点用户名'],
-    ['password empty', validPasswordForm, { password: '' }, ['password'], '请填写站点密码'],
+    [
+      'apiToken empty',
+      validApikeyForm,
+      { apiToken: '' },
+      ['apiToken'],
+      '请填写 API Key',
+    ],
+    [
+      'username empty',
+      validPasswordForm,
+      { username: '' },
+      ['username'],
+      '请填写站点用户名',
+    ],
+    [
+      'password empty',
+      validPasswordForm,
+      { password: '' },
+      ['password'],
+      '请填写站点密码',
+    ],
   ]
 
   it.each(blankCredentialCases)(
@@ -397,18 +427,56 @@ describe('getAccountFormDefaultValues', () => {
 
 describe('buildAccountVerifyPayload', () => {
   it.each([
-    ['a session payload with the trimmed access token', () => ({ ...validSessionForm(), accessToken: '  sk-1  ' }), { siteId: 1, accessToken: 'sk-1', credentialMode: 'session' }],
-    ['an apikey payload from apiToken', validApikeyForm, { siteId: 1, accessToken: 'k', credentialMode: 'apikey' }],
-    ['unsaved platform user id and proxy values through verification', () => ({ ...validSessionForm(), platformUserId: 106, proxyUrl: '  socks5://proxy.example:1080  ' }), { siteId: 1, accessToken: 'sk-1', platformUserId: 106, proxyUrl: 'socks5://proxy.example:1080', credentialMode: 'session' }],
+    [
+      'a session payload with the trimmed access token',
+      () => ({ ...validSessionForm(), accessToken: '  sk-1  ' }),
+      { siteId: 1, accessToken: 'sk-1', credentialMode: 'session' },
+    ],
+    [
+      'an apikey payload from apiToken',
+      validApikeyForm,
+      { siteId: 1, accessToken: 'k', credentialMode: 'apikey' },
+    ],
+    [
+      'unsaved platform user id and proxy values through verification',
+      () => ({
+        ...validSessionForm(),
+        platformUserId: 106,
+        proxyUrl: '  socks5://proxy.example:1080  ',
+      }),
+      {
+        siteId: 1,
+        accessToken: 'sk-1',
+        platformUserId: 106,
+        proxyUrl: 'socks5://proxy.example:1080',
+        credentialMode: 'session',
+      },
+    ],
   ])('builds %s', (_label, build, payload) => {
     expect(buildAccountVerifyPayload(build())).toEqual({ ok: true, payload })
   })
 
   it.each([
-    ['a site error when siteId is missing or non-positive', { ...validSessionForm(), siteId: 0 }, { ok: false, error: 'site' }],
-    ['a token error when a session credential is blank', { ...validSessionForm(), accessToken: '  ' }, { ok: false, error: 'token' }],
-    ['a token error when an apiToken is empty', { ...validApikeyForm(), apiToken: '' }, { ok: false, error: 'token' }],
-    ['no inline payload for password mode', validPasswordForm(), { ok: false, error: 'token' }],
+    [
+      'a site error when siteId is missing or non-positive',
+      { ...validSessionForm(), siteId: 0 },
+      { ok: false, error: 'site' },
+    ],
+    [
+      'a token error when a session credential is blank',
+      { ...validSessionForm(), accessToken: '  ' },
+      { ok: false, error: 'token' },
+    ],
+    [
+      'a token error when an apiToken is empty',
+      { ...validApikeyForm(), apiToken: '' },
+      { ok: false, error: 'token' },
+    ],
+    [
+      'no inline payload for password mode',
+      validPasswordForm(),
+      { ok: false, error: 'token' },
+    ],
   ])('returns %s', (_label, values, expected) => {
     expect(buildAccountVerifyPayload(values)).toEqual(expected)
   })

--- a/web/src/features/accounts/__tests__/accounts-schema.test.ts
+++ b/web/src/features/accounts/__tests__/accounts-schema.test.ts
@@ -51,65 +51,42 @@ function validPasswordForm(): AccountFormValues {
   }
 }
 
+// Asserts that `values` fails schema validation, optionally checking the first
+// issue's path and its localized message. Both are optional so a row that only
+// needs the success-false contract (e.g. whitespace trimming) stays explicit.
+function expectInvalid(
+  values: AccountFormValues,
+  path?: Array<string | number>,
+  message?: string,
+): void {
+  const result = getAccountFormSchema().safeParse(values)
+  expect(result.success).toBe(false)
+  if (result.success) return
+  if (path) expect(result.error.issues[0]?.path).toEqual(path)
+  if (message) expectLocalized(result.error.issues[0]?.message, message)
+}
+
 // ---------------------------------------------------------------------------
 // superRefine cross-field rules
 // ---------------------------------------------------------------------------
 
 describe('getAccountFormSchema — superRefine', () => {
-  it('requires an accessToken in session mode', () => {
-    const result = getAccountFormSchema().safeParse({
-      ...validSessionForm(),
-      accessToken: '',
-    })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.path).toEqual(['accessToken'])
-    expectLocalized(
-      result.error.issues[0]?.message,
-      '请填写 Access Token / Cookie'
-    )
-  })
+  const blankCredentialCases: Array<
+    [string, () => AccountFormValues, Partial<AccountFormValues>, (Array<string | number> | undefined)?, (string | undefined)?]
+  > = [
+    ['accessToken empty', validSessionForm, { accessToken: '' }, ['accessToken'], '请填写 Access Token / Cookie'],
+    ['accessToken whitespace', validSessionForm, { accessToken: '   ' }],
+    ['apiToken empty', validApikeyForm, { apiToken: '' }, ['apiToken'], '请填写 API Key'],
+    ['username empty', validPasswordForm, { username: '' }, ['username'], '请填写站点用户名'],
+    ['password empty', validPasswordForm, { password: '' }, ['password'], '请填写站点密码'],
+  ]
 
-  it('treats a whitespace-only accessToken as empty after trimming', () => {
-    const result = getAccountFormSchema().safeParse({
-      ...validSessionForm(),
-      accessToken: '   ',
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it('requires an apiToken in apikey mode', () => {
-    const result = getAccountFormSchema().safeParse({
-      ...validApikeyForm(),
-      apiToken: '',
-    })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.path).toEqual(['apiToken'])
-    expectLocalized(result.error.issues[0]?.message, '请填写 API Key')
-  })
-
-  it('requires a username in password mode', () => {
-    const result = getAccountFormSchema().safeParse({
-      ...validPasswordForm(),
-      username: '',
-    })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.path).toEqual(['username'])
-    expectLocalized(result.error.issues[0]?.message, '请填写站点用户名')
-  })
-
-  it('requires a password in password mode', () => {
-    const result = getAccountFormSchema().safeParse({
-      ...validPasswordForm(),
-      password: '',
-    })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.path).toEqual(['password'])
-    expectLocalized(result.error.issues[0]?.message, '请填写站点密码')
-  })
+  it.each(blankCredentialCases)(
+    'rejects a blank secret-field credential (%s)',
+    (_label, base, overrides, path, message) => {
+      expectInvalid({ ...base(), ...overrides }, path, message)
+    }
+  )
 
   it('flags both username and password when both are blank', () => {
     const result = getAccountFormSchema().safeParse({
@@ -141,22 +118,12 @@ describe('getAccountFormSchema — superRefine', () => {
     expect(result.success).toBe(true)
   })
 
-  it('accepts a fully valid password form', () => {
-    expect(getAccountFormSchema().safeParse(validPasswordForm()).success).toBe(
-      true
-    )
-  })
-
-  it('accepts a fully valid session form', () => {
-    expect(getAccountFormSchema().safeParse(validSessionForm()).success).toBe(
-      true
-    )
-  })
-
-  it('accepts a fully valid apikey form', () => {
-    expect(getAccountFormSchema().safeParse(validApikeyForm()).success).toBe(
-      true
-    )
+  it.each([
+    ['password', validPasswordForm()],
+    ['session', validSessionForm()],
+    ['apikey', validApikeyForm()],
+  ])('accepts a fully valid %s form', (_mode, values) => {
+    expect(getAccountFormSchema().safeParse(values).success).toBe(true)
   })
 
   it('allows redacted credentials when validating an existing account', () => {
@@ -180,30 +147,14 @@ describe('getAccountFormSchema — superRefine', () => {
 // ---------------------------------------------------------------------------
 
 describe('getAccountFormSchema — siteId', () => {
-  it('rejects siteId 0 with the dedicated message', () => {
+  it.each([
+    ['zero', 0],
+    ['string', 'abc' as unknown as number],
+    ['fractional', 1.5],
+  ])('rejects an invalid siteId (%s)', (_label, siteId) => {
     const result = getAccountFormSchema().safeParse({
       ...validSessionForm(),
-      siteId: 0,
-    })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expectLocalized(result.error.issues[0]?.message, '请选择站点')
-  })
-
-  it('rejects a string siteId (no coerce)', () => {
-    const result = getAccountFormSchema().safeParse({
-      ...validSessionForm(),
-      siteId: 'abc' as unknown as number,
-    })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expectLocalized(result.error.issues[0]?.message, '请选择站点')
-  })
-
-  it('rejects a fractional siteId', () => {
-    const result = getAccountFormSchema().safeParse({
-      ...validSessionForm(),
-      siteId: 1.5,
+      siteId,
     })
     expect(result.success).toBe(false)
     if (result.success) return
@@ -445,61 +396,20 @@ describe('getAccountFormDefaultValues', () => {
 // ---------------------------------------------------------------------------
 
 describe('buildAccountVerifyPayload', () => {
-  it('builds a session payload with the trimmed access token', () => {
-    const result = buildAccountVerifyPayload({
-      ...validSessionForm(),
-      accessToken: '  sk-1  ',
-    })
-    expect(result).toEqual({
-      ok: true,
-      payload: { siteId: 1, accessToken: 'sk-1', credentialMode: 'session' },
-    })
+  it.each([
+    ['a session payload with the trimmed access token', () => ({ ...validSessionForm(), accessToken: '  sk-1  ' }), { siteId: 1, accessToken: 'sk-1', credentialMode: 'session' }],
+    ['an apikey payload from apiToken', validApikeyForm, { siteId: 1, accessToken: 'k', credentialMode: 'apikey' }],
+    ['unsaved platform user id and proxy values through verification', () => ({ ...validSessionForm(), platformUserId: 106, proxyUrl: '  socks5://proxy.example:1080  ' }), { siteId: 1, accessToken: 'sk-1', platformUserId: 106, proxyUrl: 'socks5://proxy.example:1080', credentialMode: 'session' }],
+  ])('builds %s', (_label, build, payload) => {
+    expect(buildAccountVerifyPayload(build())).toEqual({ ok: true, payload })
   })
 
-  it('builds an apikey payload from apiToken', () => {
-    const result = buildAccountVerifyPayload(validApikeyForm())
-    expect(result).toEqual({
-      ok: true,
-      payload: { siteId: 1, accessToken: 'k', credentialMode: 'apikey' },
-    })
-  })
-
-  it('passes unsaved platform user id and proxy values through verification', () => {
-    const result = buildAccountVerifyPayload({
-      ...validSessionForm(),
-      platformUserId: 106,
-      proxyUrl: '  socks5://proxy.example:1080  ',
-    })
-    expect(result).toEqual({
-      ok: true,
-      payload: {
-        siteId: 1,
-        accessToken: 'sk-1',
-        platformUserId: 106,
-        proxyUrl: 'socks5://proxy.example:1080',
-        credentialMode: 'session',
-      },
-    })
-  })
-
-  it('returns a site error when siteId is missing or non-positive', () => {
-    expect(
-      buildAccountVerifyPayload({ ...validSessionForm(), siteId: 0 })
-    ).toEqual({ ok: false, error: 'site' })
-  })
-
-  it('returns a token error when the credential is blank', () => {
-    expect(
-      buildAccountVerifyPayload({ ...validSessionForm(), accessToken: '  ' })
-    ).toEqual({ ok: false, error: 'token' })
-    expect(
-      buildAccountVerifyPayload({ ...validApikeyForm(), apiToken: '' })
-    ).toEqual({ ok: false, error: 'token' })
-  })
-
-  it('never builds a payload for password mode (no inline verification)', () => {
-    const result = buildAccountVerifyPayload(validPasswordForm())
-    expect(result.ok).toBe(false)
-    expect(result).toEqual({ ok: false, error: 'token' })
+  it.each([
+    ['a site error when siteId is missing or non-positive', { ...validSessionForm(), siteId: 0 }, { ok: false, error: 'site' }],
+    ['a token error when a session credential is blank', { ...validSessionForm(), accessToken: '  ' }, { ok: false, error: 'token' }],
+    ['a token error when an apiToken is empty', { ...validApikeyForm(), apiToken: '' }, { ok: false, error: 'token' }],
+    ['no inline payload for password mode', validPasswordForm(), { ok: false, error: 'token' }],
+  ])('returns %s', (_label, values, expected) => {
+    expect(buildAccountVerifyPayload(values)).toEqual(expected)
   })
 })

--- a/web/src/features/checkin/__tests__/checkin-schema.test.ts
+++ b/web/src/features/checkin/__tests__/checkin-schema.test.ts
@@ -13,24 +13,20 @@ import {
 // ---------------------------------------------------------------------------
 
 describe('checkinSearchSchema', () => {
-  it('applies page / pageSize defaults to an empty input', () => {
-    const result = checkinSearchSchema.parse({})
-    expect(result.page).toBe(1)
-    expect(result.pageSize).toBe(20)
-    expect(result.accountId).toBeUndefined()
-    expect(result.status).toBeUndefined()
-    expect(result.q).toBeUndefined()
-  })
+  const parseShapeCases: Array<
+    [string, Record<string, unknown>, { page: number; pageSize: number; accountId?: number | undefined; status?: string | undefined; q?: string | number | undefined }]
+  > = [
+    ['applies page / pageSize defaults to an empty input', {}, { page: 1, pageSize: 20, accountId: undefined, status: undefined, q: undefined }],
+    ['coerces string numerics from a URL query string shape', { page: '2', pageSize: '50', accountId: '7' }, { page: 2, pageSize: 50, accountId: 7 }],
+  ]
 
-  it('coerces string numerics from a URL query string shape', () => {
-    const result = checkinSearchSchema.parse({
-      page: '2',
-      pageSize: '50',
-      accountId: '7',
-    })
-    expect(result.page).toBe(2)
-    expect(result.pageSize).toBe(50)
-    expect(result.accountId).toBe(7)
+  it.each(parseShapeCases)('%s', (_label, input, expected) => {
+    const result = checkinSearchSchema.parse(input as Record<string, unknown>)
+    expect(result.page).toBe(expected.page)
+    expect(result.pageSize).toBe(expected.pageSize)
+    expect(result.accountId).toBe(expected.accountId)
+    expect(result.status).toBe(expected.status)
+    expect(result.q).toBe(expected.q)
   })
 
   it.each([
@@ -112,23 +108,13 @@ describe('parseFilterValues', () => {
 // ---------------------------------------------------------------------------
 
 describe('parseCheckinSearch', () => {
-  it('parses a query string with a leading question mark', () => {
-    const result = parseCheckinSearch('?page=3&status=ok,fail')
-    expect(result.page).toBe(3)
-    expect(result.status).toBe('ok,fail')
-  })
-
-  it('parses a query string without a leading question mark', () => {
-    const result = parseCheckinSearch('page=2&pageSize=50&accountId=7')
-    expect(result.page).toBe(2)
-    expect(result.pageSize).toBe(50)
-    expect(result.accountId).toBe(7)
-  })
-
-  it('falls back to defaults on malformed input', () => {
-    const result = parseCheckinSearch('page=abc&pageSize=999')
-    expect(result.page).toBe(1)
-    expect(result.pageSize).toBe(20)
+  it.each([
+    ['a query string with a leading question mark', '?page=3&status=ok,fail', { page: 3, status: 'ok,fail' }],
+    ['a query string without a leading question mark', 'page=2&pageSize=50&accountId=7', { page: 2, pageSize: 50, accountId: 7 }],
+    ['malformed input', 'page=abc&pageSize=999', { page: 1, pageSize: 20 }],
+  ])('parses %s', (_label, input, expected) => {
+    const result = parseCheckinSearch(input)
+    expect(result).toMatchObject(expected)
   })
 
   it('falls back to defaults on an empty string', () => {

--- a/web/src/features/checkin/__tests__/checkin-schema.test.ts
+++ b/web/src/features/checkin/__tests__/checkin-schema.test.ts
@@ -14,10 +14,34 @@ import {
 
 describe('checkinSearchSchema', () => {
   const parseShapeCases: Array<
-    [string, Record<string, unknown>, { page: number; pageSize: number; accountId?: number | undefined; status?: string | undefined; q?: string | number | undefined }]
+    [
+      string,
+      Record<string, unknown>,
+      {
+        page: number
+        pageSize: number
+        accountId?: number | undefined
+        status?: string | undefined
+        q?: string | number | undefined
+      },
+    ]
   > = [
-    ['applies page / pageSize defaults to an empty input', {}, { page: 1, pageSize: 20, accountId: undefined, status: undefined, q: undefined }],
-    ['coerces string numerics from a URL query string shape', { page: '2', pageSize: '50', accountId: '7' }, { page: 2, pageSize: 50, accountId: 7 }],
+    [
+      'applies page / pageSize defaults to an empty input',
+      {},
+      {
+        page: 1,
+        pageSize: 20,
+        accountId: undefined,
+        status: undefined,
+        q: undefined,
+      },
+    ],
+    [
+      'coerces string numerics from a URL query string shape',
+      { page: '2', pageSize: '50', accountId: '7' },
+      { page: 2, pageSize: 50, accountId: 7 },
+    ],
   ]
 
   it.each(parseShapeCases)('%s', (_label, input, expected) => {
@@ -109,8 +133,16 @@ describe('parseFilterValues', () => {
 
 describe('parseCheckinSearch', () => {
   it.each([
-    ['a query string with a leading question mark', '?page=3&status=ok,fail', { page: 3, status: 'ok,fail' }],
-    ['a query string without a leading question mark', 'page=2&pageSize=50&accountId=7', { page: 2, pageSize: 50, accountId: 7 }],
+    [
+      'a query string with a leading question mark',
+      '?page=3&status=ok,fail',
+      { page: 3, status: 'ok,fail' },
+    ],
+    [
+      'a query string without a leading question mark',
+      'page=2&pageSize=50&accountId=7',
+      { page: 2, pageSize: 50, accountId: 7 },
+    ],
     ['malformed input', 'page=abc&pageSize=999', { page: 1, pageSize: 20 }],
   ])('parses %s', (_label, input, expected) => {
     const result = parseCheckinSearch(input)

--- a/web/src/features/model-tester/__tests__/tester-schema.test.ts
+++ b/web/src/features/model-tester/__tests__/tester-schema.test.ts
@@ -47,28 +47,21 @@ describe('testerSchema — happy path', () => {
 // ---------------------------------------------------------------------------
 
 describe('testerSchema — required fields', () => {
-  it('rejects an empty model with the modelRequired key', () => {
-    const result = testerSchema.safeParse({ ...validInput(), model: '' })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'modelTester.form.errors.modelRequired'
-    )
-  })
+  const requiredCases: Array<[string, Partial<TesterFormValues>, string | undefined]> = [
+    ['an empty model', { model: '' }, 'modelTester.form.errors.modelRequired'],
+    ['a whitespace-only model', { model: '   ' }, undefined],
+    ['an empty prompt', { prompt: '' }, 'modelTester.form.errors.promptRequired'],
+  ]
 
-  it('rejects a whitespace-only model after trimming', () => {
-    const result = testerSchema.safeParse({ ...validInput(), model: '   ' })
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects an empty prompt with the promptRequired key', () => {
-    const result = testerSchema.safeParse({ ...validInput(), prompt: '' })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'modelTester.form.errors.promptRequired'
-    )
-  })
+  it.each(requiredCases)(
+    'rejects %s with a required-field error',
+    (_label, overrides, message) => {
+      const result = testerSchema.safeParse({ ...validInput(), ...overrides })
+      expect(result.success).toBe(false)
+      if (result.success) return
+      if (message) expect(result.error.issues[0]?.message).toBe(message)
+    }
+  )
 })
 
 // ---------------------------------------------------------------------------
@@ -76,28 +69,16 @@ describe('testerSchema — required fields', () => {
 // ---------------------------------------------------------------------------
 
 describe('testerSchema — length bounds', () => {
-  it('rejects a systemPrompt over 4000 chars', () => {
-    const result = testerSchema.safeParse({
-      ...validInput(),
-      systemPrompt: 'x'.repeat(4001),
-    })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'modelTester.form.errors.systemTooLong'
-    )
-  })
+  const tooLongCases: Array<[string, Partial<TesterFormValues>, string]> = [
+    ['a systemPrompt over 4000 chars', { systemPrompt: 'x'.repeat(4001) }, 'modelTester.form.errors.systemTooLong'],
+    ['a prompt over 16000 chars', { prompt: 'x'.repeat(16001) }, 'modelTester.form.errors.promptTooLong'],
+  ]
 
-  it('rejects a prompt over 16000 chars', () => {
-    const result = testerSchema.safeParse({
-      ...validInput(),
-      prompt: 'x'.repeat(16001),
-    })
+  it.each(tooLongCases)('rejects %s', (_label, overrides, message) => {
+    const result = testerSchema.safeParse({ ...validInput(), ...overrides })
     expect(result.success).toBe(false)
     if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'modelTester.form.errors.promptTooLong'
-    )
+    expect(result.error.issues[0]?.message).toBe(message)
   })
 
   it('accepts exactly 4000-char systemPrompt and 16000-char prompt', () => {
@@ -119,64 +100,20 @@ describe('testerSchema — length bounds', () => {
 // ---------------------------------------------------------------------------
 
 describe('testerSchema — numeric bounds', () => {
-  it('rejects temperature above 2 with the temperatureMax key', () => {
-    const result = testerSchema.safeParse({ ...validInput(), temperature: 2.5 })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'modelTester.form.errors.temperatureMax'
-    )
-  })
+  const numericBoundCases: Array<[string, Partial<TesterFormValues>, string]> = [
+    ['temperature above 2', { temperature: 2.5 }, 'modelTester.form.errors.temperatureMax'],
+    ['temperature below 0', { temperature: -0.1 }, 'modelTester.form.errors.temperatureMin'],
+    ['topP above 1', { topP: 1.1 }, 'modelTester.form.errors.topPMax'],
+    ['maxTokens above 128000', { maxTokens: 128001 }, 'modelTester.form.errors.maxTokensMax'],
+    ['a non-integer maxTokens', { maxTokens: 1.5 }, 'modelTester.form.errors.maxTokensInteger'],
+    ['a negative maxTokens', { maxTokens: -1 }, 'modelTester.form.errors.maxTokensMin'],
+  ]
 
-  it('rejects temperature below 0 with the temperatureMin key', () => {
-    const result = testerSchema.safeParse({
-      ...validInput(),
-      temperature: -0.1,
-    })
+  it.each(numericBoundCases)('rejects %s', (_label, overrides, message) => {
+    const result = testerSchema.safeParse({ ...validInput(), ...overrides })
     expect(result.success).toBe(false)
     if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'modelTester.form.errors.temperatureMin'
-    )
-  })
-
-  it('rejects topP above 1 with the topPMax key', () => {
-    const result = testerSchema.safeParse({ ...validInput(), topP: 1.1 })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'modelTester.form.errors.topPMax'
-    )
-  })
-
-  it('rejects maxTokens above 128000 with the maxTokensMax key', () => {
-    const result = testerSchema.safeParse({
-      ...validInput(),
-      maxTokens: 128001,
-    })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'modelTester.form.errors.maxTokensMax'
-    )
-  })
-
-  it('rejects a non-integer maxTokens with the maxTokensInteger key', () => {
-    const result = testerSchema.safeParse({ ...validInput(), maxTokens: 1.5 })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'modelTester.form.errors.maxTokensInteger'
-    )
-  })
-
-  it('rejects a negative maxTokens with the maxTokensMin key', () => {
-    const result = testerSchema.safeParse({ ...validInput(), maxTokens: -1 })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'modelTester.form.errors.maxTokensMin'
-    )
+    expect(result.error.issues[0]?.message).toBe(message)
   })
 })
 
@@ -185,11 +122,13 @@ describe('testerSchema — numeric bounds', () => {
 // ---------------------------------------------------------------------------
 
 describe('testerSchema — no coercion + enum', () => {
-  it('rejects a string temperature (no coerce)', () => {
-    const result = testerSchema.safeParse({
-      ...validInput(),
-      temperature: '0.7' as unknown as number,
-    })
+  const noCoerceCases: Array<[string, Partial<TesterFormValues>]> = [
+    ['a string temperature (no coerce)', { temperature: '0.7' as unknown as number }],
+    ['a non-integer channelId (no coerce)', { channelId: '42' as unknown as number }],
+  ]
+
+  it.each(noCoerceCases)('rejects %s', (_label, overrides) => {
+    const result = testerSchema.safeParse({ ...validInput(), ...overrides })
     expect(result.success).toBe(false)
   })
 
@@ -201,14 +140,6 @@ describe('testerSchema — no coercion + enum', () => {
     expect(result.success).toBe(false)
     if (result.success) return
     expect(result.error.issues[0]?.message).toContain('Invalid option')
-  })
-
-  it('rejects a non-integer channelId (no coerce)', () => {
-    const result = testerSchema.safeParse({
-      ...validInput(),
-      channelId: '42' as unknown as number,
-    })
-    expect(result.success).toBe(false)
   })
 
   it('accepts an omitted channelId (optional channel targeting)', () => {

--- a/web/src/features/model-tester/__tests__/tester-schema.test.ts
+++ b/web/src/features/model-tester/__tests__/tester-schema.test.ts
@@ -47,10 +47,16 @@ describe('testerSchema — happy path', () => {
 // ---------------------------------------------------------------------------
 
 describe('testerSchema — required fields', () => {
-  const requiredCases: Array<[string, Partial<TesterFormValues>, string | undefined]> = [
+  const requiredCases: Array<
+    [string, Partial<TesterFormValues>, string | undefined]
+  > = [
     ['an empty model', { model: '' }, 'modelTester.form.errors.modelRequired'],
     ['a whitespace-only model', { model: '   ' }, undefined],
-    ['an empty prompt', { prompt: '' }, 'modelTester.form.errors.promptRequired'],
+    [
+      'an empty prompt',
+      { prompt: '' },
+      'modelTester.form.errors.promptRequired',
+    ],
   ]
 
   it.each(requiredCases)(
@@ -70,8 +76,16 @@ describe('testerSchema — required fields', () => {
 
 describe('testerSchema — length bounds', () => {
   const tooLongCases: Array<[string, Partial<TesterFormValues>, string]> = [
-    ['a systemPrompt over 4000 chars', { systemPrompt: 'x'.repeat(4001) }, 'modelTester.form.errors.systemTooLong'],
-    ['a prompt over 16000 chars', { prompt: 'x'.repeat(16001) }, 'modelTester.form.errors.promptTooLong'],
+    [
+      'a systemPrompt over 4000 chars',
+      { systemPrompt: 'x'.repeat(4001) },
+      'modelTester.form.errors.systemTooLong',
+    ],
+    [
+      'a prompt over 16000 chars',
+      { prompt: 'x'.repeat(16001) },
+      'modelTester.form.errors.promptTooLong',
+    ],
   ]
 
   it.each(tooLongCases)('rejects %s', (_label, overrides, message) => {
@@ -100,14 +114,35 @@ describe('testerSchema — length bounds', () => {
 // ---------------------------------------------------------------------------
 
 describe('testerSchema — numeric bounds', () => {
-  const numericBoundCases: Array<[string, Partial<TesterFormValues>, string]> = [
-    ['temperature above 2', { temperature: 2.5 }, 'modelTester.form.errors.temperatureMax'],
-    ['temperature below 0', { temperature: -0.1 }, 'modelTester.form.errors.temperatureMin'],
-    ['topP above 1', { topP: 1.1 }, 'modelTester.form.errors.topPMax'],
-    ['maxTokens above 128000', { maxTokens: 128001 }, 'modelTester.form.errors.maxTokensMax'],
-    ['a non-integer maxTokens', { maxTokens: 1.5 }, 'modelTester.form.errors.maxTokensInteger'],
-    ['a negative maxTokens', { maxTokens: -1 }, 'modelTester.form.errors.maxTokensMin'],
-  ]
+  const numericBoundCases: Array<[string, Partial<TesterFormValues>, string]> =
+    [
+      [
+        'temperature above 2',
+        { temperature: 2.5 },
+        'modelTester.form.errors.temperatureMax',
+      ],
+      [
+        'temperature below 0',
+        { temperature: -0.1 },
+        'modelTester.form.errors.temperatureMin',
+      ],
+      ['topP above 1', { topP: 1.1 }, 'modelTester.form.errors.topPMax'],
+      [
+        'maxTokens above 128000',
+        { maxTokens: 128001 },
+        'modelTester.form.errors.maxTokensMax',
+      ],
+      [
+        'a non-integer maxTokens',
+        { maxTokens: 1.5 },
+        'modelTester.form.errors.maxTokensInteger',
+      ],
+      [
+        'a negative maxTokens',
+        { maxTokens: -1 },
+        'modelTester.form.errors.maxTokensMin',
+      ],
+    ]
 
   it.each(numericBoundCases)('rejects %s', (_label, overrides, message) => {
     const result = testerSchema.safeParse({ ...validInput(), ...overrides })
@@ -123,8 +158,14 @@ describe('testerSchema — numeric bounds', () => {
 
 describe('testerSchema — no coercion + enum', () => {
   const noCoerceCases: Array<[string, Partial<TesterFormValues>]> = [
-    ['a string temperature (no coerce)', { temperature: '0.7' as unknown as number }],
-    ['a non-integer channelId (no coerce)', { channelId: '42' as unknown as number }],
+    [
+      'a string temperature (no coerce)',
+      { temperature: '0.7' as unknown as number },
+    ],
+    [
+      'a non-integer channelId (no coerce)',
+      { channelId: '42' as unknown as number },
+    ],
   ]
 
   it.each(noCoerceCases)('rejects %s', (_label, overrides) => {

--- a/web/src/features/sites/__tests__/sites-schema.test.ts
+++ b/web/src/features/sites/__tests__/sites-schema.test.ts
@@ -44,53 +44,33 @@ describe('siteFormSchema — happy path', () => {
 // ---------------------------------------------------------------------------
 
 describe('siteFormSchema — name', () => {
-  it('rejects an empty name with nameRequired', () => {
-    const result = siteFormSchema.safeParse({ ...validSiteForm(), name: '' })
+  const nameCases: Array<[string, string, string | undefined]> = [
+    ['empty', '', 'sites.form.errors.nameRequired'],
+    ['whitespace-only after trimming', '   ', undefined],
+    ['over 120 chars', 'x'.repeat(121), 'sites.form.errors.nameTooLong'],
+  ]
+
+  it.each(nameCases)('rejects a %s name', (_label, name, message) => {
+    const result = siteFormSchema.safeParse({ ...validSiteForm(), name })
     expect(result.success).toBe(false)
     if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'sites.form.errors.nameRequired'
-    )
-  })
-
-  it('rejects a whitespace-only name after trimming', () => {
-    expect(
-      siteFormSchema.safeParse({ ...validSiteForm(), name: '   ' }).success
-    ).toBe(false)
-  })
-
-  it('rejects a name over 120 chars', () => {
-    const result = siteFormSchema.safeParse({
-      ...validSiteForm(),
-      name: 'x'.repeat(121),
-    })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'sites.form.errors.nameTooLong'
-    )
+    if (message) expect(result.error.issues[0]?.message).toBe(message)
   })
 })
 
 describe('siteFormSchema — url', () => {
-  it('rejects an empty url with urlRequired', () => {
-    const result = siteFormSchema.safeParse({ ...validSiteForm(), url: '' })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'sites.form.errors.urlRequired'
-    )
-  })
+  const badUrlCases: Array<[string, string, string]> = [
+    ['empty', '', 'sites.form.errors.urlRequired'],
+    ['ftp scheme', 'ftp://example.com', 'sites.form.errors.invalidUrl'],
+    ['plain string', 'not a url', 'sites.form.errors.invalidUrl'],
+    ['javascript scheme', 'javascript:alert(1)', 'sites.form.errors.invalidUrl'],
+  ]
 
-  it.each([
-    ['ftp scheme', 'ftp://example.com'],
-    ['plain string', 'not a url'],
-    ['javascript scheme', 'javascript:alert(1)'],
-  ])('rejects %s with invalidUrl', (_label, url) => {
+  it.each(badUrlCases)('rejects an invalid url (%s)', (_label, url, message) => {
     const result = siteFormSchema.safeParse({ ...validSiteForm(), url })
     expect(result.success).toBe(false)
     if (result.success) return
-    expect(result.error.issues[0]?.message).toBe('sites.form.errors.invalidUrl')
+    expect(result.error.issues[0]?.message).toBe(message)
   })
 
   it('accepts http and https', () => {
@@ -136,19 +116,12 @@ describe('siteFormSchema — optional URLs', () => {
 // ---------------------------------------------------------------------------
 
 describe('siteFormSchema — customHeaders', () => {
-  it('accepts an empty string', () => {
+  it.each([
+    ['an empty string', ''],
+    ['a plain JSON object', '{"a":1}'],
+  ])('accepts %s', (_label, customHeaders) => {
     expect(
-      siteFormSchema.safeParse({ ...validSiteForm(), customHeaders: '' })
-        .success
-    ).toBe(true)
-  })
-
-  it('accepts a plain JSON object', () => {
-    expect(
-      siteFormSchema.safeParse({
-        ...validSiteForm(),
-        customHeaders: '{"a":1}',
-      }).success
+      siteFormSchema.safeParse({ ...validSiteForm(), customHeaders }).success
     ).toBe(true)
   })
 
@@ -176,28 +149,20 @@ describe('siteFormSchema — customHeaders', () => {
 // ---------------------------------------------------------------------------
 
 describe('siteFormSchema — numerics + enum', () => {
-  it('rejects a negative globalWeight', () => {
-    const result = siteFormSchema.safeParse({
-      ...validSiteForm(),
-      globalWeight: -1,
-    })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'sites.form.errors.globalWeightMin'
-    )
-  })
+  const numericBoundCases: Array<[string, Partial<SiteFormValues>, string]> = [
+    ['a negative globalWeight', { globalWeight: -1 }, 'sites.form.errors.globalWeightMin'],
+    ['a non-integer maxConcurrency', { maxConcurrency: 1.5 }, 'sites.form.errors.maxConcurrencyInteger'],
+    ['a non-integer latency threshold', { postRefreshProbeLatencyThresholdMs: 1.5 }, 'sites.form.errors.latencyInteger'],
+  ]
 
-  it('rejects a non-integer maxConcurrency', () => {
+  it.each(numericBoundCases)('rejects %s', (_label, overrides, message) => {
     const result = siteFormSchema.safeParse({
       ...validSiteForm(),
-      maxConcurrency: 1.5,
+      ...overrides,
     })
     expect(result.success).toBe(false)
     if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'sites.form.errors.maxConcurrencyInteger'
-    )
+    expect(result.error.issues[0]?.message).toBe(message)
   })
 
   it('accepts postRefreshProbeScope "all" and rejects unknown values', () => {
@@ -215,18 +180,6 @@ describe('siteFormSchema — numerics + enum', () => {
     expect(result.success).toBe(false)
     if (result.success) return
     expect(result.error.issues[0]?.message).toContain('Invalid option')
-  })
-
-  it('rejects a non-integer latency threshold', () => {
-    const result = siteFormSchema.safeParse({
-      ...validSiteForm(),
-      postRefreshProbeLatencyThresholdMs: 1.5,
-    })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(
-      'sites.form.errors.latencyInteger'
-    )
   })
 })
 
@@ -263,20 +216,13 @@ describe('sitesSearchSchema', () => {
 // ---------------------------------------------------------------------------
 
 describe('sitesSearchSchema — create deep-link', () => {
-  it('coerces the router-parsed `?create=1` (number) to true', () => {
-    expect(sitesSearchSchema.parse({ create: 1 }).create).toBe(true)
-  })
-
-  it('coerces a literal boolean true to true', () => {
-    expect(sitesSearchSchema.parse({ create: true }).create).toBe(true)
-  })
-
-  it('omits create (undefined) when the param is absent', () => {
-    expect(sitesSearchSchema.parse({}).create).toBeUndefined()
-  })
-
-  it('coerces 0 to false so a `?create=0` deep link never opens the dialog', () => {
-    expect(sitesSearchSchema.parse({ create: 0 }).create).toBe(false)
+  it.each([
+    ['?create=1 (number) to true', { create: 1 }, true],
+    ['a literal boolean true to true', { create: true }, true],
+    ['an absent param to undefined', {}, undefined],
+    ['?create=0 (number) to false', { create: 0 }, false],
+  ])('coerces %s', (_label, input, expected) => {
+    expect(sitesSearchSchema.parse(input).create).toBe(expected)
   })
 
   it('does not throw on a malformed create value (graceful fallback)', () => {

--- a/web/src/features/sites/__tests__/sites-schema.test.ts
+++ b/web/src/features/sites/__tests__/sites-schema.test.ts
@@ -63,15 +63,22 @@ describe('siteFormSchema — url', () => {
     ['empty', '', 'sites.form.errors.urlRequired'],
     ['ftp scheme', 'ftp://example.com', 'sites.form.errors.invalidUrl'],
     ['plain string', 'not a url', 'sites.form.errors.invalidUrl'],
-    ['javascript scheme', 'javascript:alert(1)', 'sites.form.errors.invalidUrl'],
+    [
+      'javascript scheme',
+      'javascript:alert(1)',
+      'sites.form.errors.invalidUrl',
+    ],
   ]
 
-  it.each(badUrlCases)('rejects an invalid url (%s)', (_label, url, message) => {
-    const result = siteFormSchema.safeParse({ ...validSiteForm(), url })
-    expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error.issues[0]?.message).toBe(message)
-  })
+  it.each(badUrlCases)(
+    'rejects an invalid url (%s)',
+    (_label, url, message) => {
+      const result = siteFormSchema.safeParse({ ...validSiteForm(), url })
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.issues[0]?.message).toBe(message)
+    }
+  )
 
   it('accepts http and https', () => {
     expect(
@@ -150,9 +157,21 @@ describe('siteFormSchema — customHeaders', () => {
 
 describe('siteFormSchema — numerics + enum', () => {
   const numericBoundCases: Array<[string, Partial<SiteFormValues>, string]> = [
-    ['a negative globalWeight', { globalWeight: -1 }, 'sites.form.errors.globalWeightMin'],
-    ['a non-integer maxConcurrency', { maxConcurrency: 1.5 }, 'sites.form.errors.maxConcurrencyInteger'],
-    ['a non-integer latency threshold', { postRefreshProbeLatencyThresholdMs: 1.5 }, 'sites.form.errors.latencyInteger'],
+    [
+      'a negative globalWeight',
+      { globalWeight: -1 },
+      'sites.form.errors.globalWeightMin',
+    ],
+    [
+      'a non-integer maxConcurrency',
+      { maxConcurrency: 1.5 },
+      'sites.form.errors.maxConcurrencyInteger',
+    ],
+    [
+      'a non-integer latency threshold',
+      { postRefreshProbeLatencyThresholdMs: 1.5 },
+      'sites.form.errors.latencyInteger',
+    ],
   ]
 
   it.each(numericBoundCases)('rejects %s', (_label, overrides, message) => {


### PR DESCRIPTION
## What

Four frontend schema suites repeated the same one-assertion-per-input shape:

| file | lines |
|---|---|
| `web/src/features/accounts/__tests__/accounts-schema.test.ts` | 505 → 415 |
| `web/src/features/checkin/__tests__/checkin-schema.test.ts` | 184 → 170 |
| `web/src/features/model-tester/__tests__/tester-schema.test.ts` | 285 → 216 |
| `web/src/features/sites/__tests__/sites-schema.test.ts` | 287 → 233 |

Each family now states its shape once and lists inputs as `it.each` rows. Net −227 lines, no new abstraction, no production code touched.

## Why

A repeated `it(...)` block per input hides the invariant being tested and makes the suite expensive to read and to extend. The table is the same assertion the copies made; adding an input is one row.

## Case parity (runtime, from vitest)

| file | before | after |
|---|---|---|
| accounts-schema | 46 | 47 |
| sites-schema | 30 | 30 |
| tester-schema | 24 | 24 |
| checkin-schema | 21 | 21 |

The single gain: the blank-credential payload case that covered session mode and api-key mode inside one test now runs as two rows, so a regression in one mode cannot hide behind the other.

No assertion was dropped. Rows that previously asserted only `success === false` still assert exactly that; message expectations were carried over verbatim where the original had one.

## Verification

```
bunx vitest run src/features/accounts/__tests__/accounts-schema.test.ts \
  src/features/sites/__tests__/sites-schema.test.ts \
  src/features/model-tester/__tests__/tester-schema.test.ts \
  src/features/checkin/__tests__/checkin-schema.test.ts
 Test Files  4 passed (4)
      Tests  122 passed (122)
```

`bun run typecheck` (tsgo -b) exit 0.

Ablation evidence: removing one table row removed exactly that named case from the vitest run (47 → 46, the row's label absent), then the row was restored byte-identically.