### PR TITLE
fix(accounts): tell the operator what AnyRouter credentials need (#1133)

### DIFF
--- a/handler/admin/accounts_auth.go
+++ b/handler/admin/accounts_auth.go
@@ -226,7 +226,7 @@ func (h *accountsHandler) verifyToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if result == nil || result.TokenType == "" || result.TokenType == "unknown" {
-		writeErrorWithRequest(w, r, http.StatusBadRequest, "token verification failed")
+		writeErrorWithRequest(w, r, http.StatusBadRequest, credentialVerificationFailureMessage(site.Platform))
 		return
 	}
 

--- a/handler/admin/accounts_create.go
+++ b/handler/admin/accounts_create.go
@@ -216,6 +216,18 @@ func (e *accountCreateError) Error() string {
 	return e.Message
 }
 
+// credentialVerificationFailureMessage explains what a session-credential bind
+// needs when VerifyToken returns nil / empty / unknown. The copy is platform
+// specific where the upstream contract differs (AnyRouter is cookie/session-only
+// and rejects standard access tokens); otherwise it keeps the pre-existing
+// generic guidance plus a minimal shape hint.
+func credentialVerificationFailureMessage(platformName string) string {
+	if strings.EqualFold(platformName, "anyrouter") {
+		return "token verification failed: AnyRouter does not support Access Token/API key binding. Use session mode and paste session=<value> or the full Cookie: header into Access Token / Cookie. Platform User ID is required only if the site enforces New-Api-User/User-id headers. Click \"Verify Token\" first, then bind the account only after verification returns tokenType=session."
+	}
+	return "token verification failed; click \"Verify Token\" first, then bind the account after verification succeeds. For session platforms paste session=<value> or the full Cookie: header; for API-key platforms use API Key mode."
+}
+
 // createAccountOutcome holds metadata from a successful createSingleAccount call.
 type createAccountOutcome struct {
 	ID               int64
@@ -307,7 +319,7 @@ func (h *accountsHandler) createSingleAccount(ctx context.Context, body payloads
 		}
 		if result == nil || result.TokenType == "" || result.TokenType == "unknown" {
 			return nil, &accountCreateError{
-				Message:              "token verification failed; click \"Verify Token\" first, then bind the account after verification succeeds",
+				Message:              credentialVerificationFailureMessage(site.Platform),
 				RequiresVerification: true,
 			}
 		}

--- a/handler/admin/accounts_test.go
+++ b/handler/admin/accounts_test.go
@@ -517,6 +517,9 @@ func TestAccounts_Create_RejectsUnknownToken(t *testing.T) {
 	if !strings.Contains(msg, "verification failed") {
 		t.Fatalf("message = %q, want verify failure", msg)
 	}
+	if !strings.Contains(msg, "AnyRouter does not support Access Token/API key binding") {
+		t.Fatalf("message = %q, want AnyRouter cookie/session guidance", msg)
+	}
 	var count int
 	if err := db.QueryRow("SELECT COUNT(*) FROM accounts WHERE site_id = ?", siteID).Scan(&count); err != nil {
 		t.Fatalf("count accounts: %v", err)


### PR DESCRIPTION
## The bug

#1133: an operator configures an AnyRouter site, pastes the cookie that demonstrably works against the upstream, and gets `token verification failed` with no hint about what the platform actually wants.

The adapter is not missing. `AnyRouterAdapter` (`platform/anyrouter.go`) embeds `NewApiAdapter`, so cookie/session verification is already attempted — but it deliberately disables token management (`GetAPIToken` returns `nil, nil`) because AnyRouter's API-key workflow is not the New API `/api/token/` contract. When verification therefore comes back `nil` / empty / `unknown` (`platform/newapi.go:357`), both the bind path (`handler/admin/accounts_create.go`) and the verify path (`handler/admin/accounts_auth.go`) threw that signal away and returned one generic sentence for every platform.

## The fix

One helper, `credentialVerificationFailureMessage(platform)`, used at both sites:

- **AnyRouter**: states that access-token/API-key binding is not supported, that session mode is required, that the field takes `session=<value>` or a full `Cookie:` header (the field is literally labelled *Access Token / Cookie*, and `buildCookieCandidates` + the `session=` extractor in `platform/newapi_userid.go:126-131` already accept both shapes), that Platform User ID is only needed when the upstream enforces `New-Api-User`/`User-id` (the retry path at `platform/newapi.go:285-300`), and that verify must succeed with `tokenType=session` before binding.
- **Every other platform**: the previous guidance, plus the same shape hint (session platforms → `session=<value>` or full cookie header; API-key platforms → API Key mode).

No adapter logic, no schema, no new setting, no new abstraction, no frontend change: 17 insertions and 2 deletions across two handler files plus one assertion.

## Verification

The existing `TestAccounts_Create_RejectsUnknownToken` already builds an `anyrouter` site and asserts on the failure message, so it gained one assertion on the actionable substring rather than a new test function:

```
go test ./handler/admin -count=1 -run 'TestAccounts_Create_RejectsUnknownToken|TestAccounts_VerifyToken' -v
--- PASS: TestAccounts_Create_RejectsUnknownToken (0.06s)
--- PASS: TestAccounts_VerifyToken (0.05s)
--- PASS: TestAccounts_VerifyToken_UsesFormUserIDAndProxy (0.05s)
--- PASS: TestAccounts_VerifyToken_EmptyToken (0.05s)
--- PASS: TestAccounts_VerifyToken_SiteNotFound (0.04s)

go test ./handler/admin -count=1     → ok  48.087s
go vet ./handler/admin/...           → clean
gofmt -l <touched files>             → empty
```

Reverse check: reverting the helper to the old generic string makes the new assertion fail, so the copy is gated, not decorative.