### PR TITLE
fix(accounts): make site-token sync idempotent (#1193)

### DIFF
--- a/service/account_token_adapter_helpers_test.go
+++ b/service/account_token_adapter_helpers_test.go
@@ -228,3 +228,41 @@ func containsAllStrings(haystack []string, needles ...string) bool {
 	}
 	return true
 }
+
+func TestSyncTokensFromUpstream_MaskedKeySyncIsIdempotent(t *testing.T) {
+	db := openTestDB(t)
+	siteID := createTestSite(t, db, "MaskedIdempotentSite", "https://masked-idem.example.com", "one-api")
+	accountID := createTestAccount(t, db, siteID, strPtr("masked-user"), "session-token")
+
+	adapter := &stubTokenAdapter{tokens: []platform.ApiTokenInfo{
+		{Name: "masked-relay", Key: "sk-abc***xyz", Enabled: true, TokenGroup: "default"},
+	}}
+	tokens, err := FetchUpstreamAPITokens(context.Background(), adapter, "https://masked-idem.example.com", "session-token", nil, nil)
+	if err != nil {
+		t.Fatalf("FetchUpstreamAPITokens: %v", err)
+	}
+
+	first, err := SyncTokensFromUpstream(db.DB, accountID, tokens)
+	if err != nil {
+		t.Fatalf("first SyncTokensFromUpstream: %v", err)
+	}
+	if first.Created != 1 {
+		t.Fatalf("first sync created = %d, want 1", first.Created)
+	}
+
+	second, err := SyncTokensFromUpstream(db.DB, accountID, tokens)
+	if err != nil {
+		t.Fatalf("second SyncTokensFromUpstream: %v", err)
+	}
+	if second.Created != 0 {
+		t.Fatalf("second sync created = %d, want 0 (masked keys must be deduped, not re-added)", second.Created)
+	}
+
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM account_tokens WHERE account_id = ?", accountID).Scan(&count); err != nil {
+		t.Fatalf("count account_tokens: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("account_tokens row count = %d, want 1 (sync must be idempotent)", count)
+	}
+}

--- a/service/account_token_service.go
+++ b/service/account_token_service.go
@@ -610,32 +610,45 @@ func SyncTokensFromUpstream(db *sqlx.DB, accountID int64, upstreamTokens []Upstr
 			nextValueStatus = TokenValueStatusMaskedPending
 		}
 
-		// Match existing ready token by exact key value.
+		// Match an existing token by exact key value. Prefer a ready row so a
+		// hydrated upstream key keeps reconciling into the same usable row.
+		// Fall back to a masked-pending row when the upstream still returns
+		// the masked display key (platforms with no full-key endpoint): those
+		// rows were previously never matched, so every sync re-inserted them.
 		var byToken *store.AccountToken
 		for i := range existing {
-			if existing[i].Token == tokenValue && ResolveAccountTokenValueStatus(&existing[i]) == TokenValueStatusReady {
+			if existing[i].Token != tokenValue {
+				continue
+			}
+			if ResolveAccountTokenValueStatus(&existing[i]) == TokenValueStatusReady {
 				byToken = &existing[i]
 				break
 			}
+			if byToken == nil {
+				byToken = &existing[i]
+			}
 		}
 		if byToken != nil {
-			// Preserve local enable state; keep operator-set name when present.
+			// Preserve local enable state and the row's resolved value status
+			// (ready stays ready; masked stays masked_pending). Keep
+			// operator-set name when present.
 			preservedName := byToken.Name
 			if strings.TrimSpace(preservedName) == "" {
 				preservedName = tokenName
 			}
 			preservedEnabled := byToken.Enabled
+			preservedValueStatus := ResolveAccountTokenValueStatus(byToken)
 			if _, err := db.Exec(
 				db.Rebind(`UPDATE account_tokens SET name = ?, token_group = ?, value_status = ?, source = ?, enabled = ?, updated_at = ?
 				 WHERE id = ?`),
-				preservedName, tokenGroup, TokenValueStatusReady, "sync", preservedEnabled, now, byToken.ID,
+				preservedName, tokenGroup, preservedValueStatus, "sync", preservedEnabled, now, byToken.ID,
 			); err != nil {
 				return nil, err
 			}
 			byToken.Name = preservedName
 			groupCopy := tokenGroup
 			byToken.TokenGroup = &groupCopy
-			byToken.ValueStatus = TokenValueStatusReady
+			byToken.ValueStatus = preservedValueStatus
 			byToken.Enabled = preservedEnabled
 			byToken.Source = "sync"
 			byToken.UpdatedAt = now


### PR DESCRIPTION
## The bug

#1193: 账号详情 → 「同步站点令牌」 re-adds tokens that are already there. Expected: existing tokens are skipped, only new ones are added.

`SyncTokensFromUpstream` (`service/account_token_service.go`) deduped only against **ready** rows:

```go
if existing[i].Token == tokenValue && ResolveAccountTokenValueStatus(&existing[i]) == TokenValueStatusReady {
```

Upstreams that mask relay keys in their token list (New API and friends return `sk-abc***xyz`) produce rows whose resolved status is `masked_pending`. Those rows could never match on the next sync, so every sync took the INSERT path (`service/account_token_service.go:~665`) and added another copy of the same token — exactly what the reporter saw, once per click.

Master already removed the *source* of masked rows for New API (#1187 hydrates real keys through `/api/token/batch/keys` before sync). What was left is the dedup rule itself, which still fails for platforms with no full-key endpoint (`one-api` / `onehub` / `donehub`) and for rows stored before #1187.

## The fix

Match an existing row by exact key value, **prefer** a ready row (so a hydrated key keeps reconciling into the same usable row), and **fall back** to a masked-pending row. The UPDATE now preserves the matched row's resolved `value_status` instead of forcing `ready` — a masked row stays honestly masked; we do not claim to hold a key we do not have.

+18/−5 in one function. No schema change, no UNIQUE constraint, no new abstraction, no new hydration path, no frontend change.

## Known residual (documented, not fixed here)

An account bound **before** #1187 can hold a `masked_pending` row for a token whose real key a later sync now retrieves. The values differ (`sk-abc***xyz` vs the full key), so the sync inserts the usable row and leaves the old masked one behind — a one-time, visibly-labelled, non-routable duplicate the operator can delete. Reconciling it would mean comparing `MaskToken(fullKey, platform)` against stored masked text, which needs the platform inside a service function that does not have it; that is more machinery than a one-time cosmetic row justifies.

## Verification

New regression test `TestSyncTokensFromUpstream_MaskedKeySyncIsIdempotent`: sync the same masked-key list twice, assert `Created == 0` on the second sync and that `account_tokens` still holds exactly one row.

Gate proof (red before, green after):

```
# with the masked-pending fallback disabled (`if false && byToken == nil`)
--- FAIL: TestSyncTokensFromUpstream_MaskedKeySyncIsIdempotent (0.04s)
    account_token_adapter_helpers_test.go:258: second sync created = 1, want 0 (masked keys must be deduped, not re-added)
FAIL	github.com/deliciousbuding/metapi-go/service	0.055s
# restored byte-identically: sha256sum -c → OK, git status --short → empty
```

```
go test ./service -count=1        → ok  6.452s
go test ./handler/admin -count=1  → ok  41.6s
go test ./platform -count=1       → ok  14.6s
go test ./docs -count=1           → ok  5.3s
go vet ./service/... ./handler/admin/... ./platform/...  → clean
gofmt -l <touched files>          → empty
```