### PR TITLE
refactor: delete uncalled helpers and tests that cannot fail

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -73,7 +73,7 @@ func TestShutdownDrainsBeforeCleanupAndRunsCleanupOnce(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = store.CloseDatabase()
-		setReadinessDrainingForTest(false)
+		markReadinessDraining(false)
 	})
 
 	started := make(chan struct{})

--- a/app/health.go
+++ b/app/health.go
@@ -53,10 +53,6 @@ func markReadinessDraining(draining bool) {
 	readinessDraining.Store(draining)
 }
 
-func setReadinessDrainingForTest(draining bool) {
-	markReadinessDraining(draining)
-}
-
 func writeHealthJSON(w http.ResponseWriter, statusCode int, status HealthStatus) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)

--- a/app/readiness_test.go
+++ b/app/readiness_test.go
@@ -26,10 +26,10 @@ func TestReadyReportsDrainingWhenShutdownStarts(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		_ = store.CloseDatabase()
-		setReadinessDrainingForTest(false)
+		markReadinessDraining(false)
 	})
 
-	setReadinessDrainingForTest(true)
+	markReadinessDraining(true)
 	rec := httptest.NewRecorder()
 	Ready(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
 

--- a/platform/gemini.go
+++ b/platform/gemini.go
@@ -87,11 +87,6 @@ func resolveGeminiNativeModelsURL(baseURL, apiToken string) string {
 	return listBase + sep + "key=" + url.QueryEscape(apiToken)
 }
 
-func stripModelPrefix(name string) string {
-	t := strings.TrimSpace(name)
-	return strings.TrimPrefix(t, "models/")
-}
-
 func normalizeModelList(models []string) []string {
 	return normalizeModelIDs(models)
 }

--- a/platform/gemini_test.go
+++ b/platform/gemini_test.go
@@ -80,23 +80,6 @@ func TestResolveGeminiNativeModelsURL(t *testing.T) {
 	}
 }
 
-func TestStripModelPrefix(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"models/gemini-pro", "gemini-pro"},
-		{"gemini-pro", "gemini-pro"},
-		{"  models/gpt-4  ", "gpt-4"},
-		{"", ""},
-	}
-	for _, tt := range tests {
-		if got := stripModelPrefix(tt.input); got != tt.expected {
-			t.Errorf("stripModelPrefix(%q) = %q, want %q", tt.input, got, tt.expected)
-		}
-	}
-}
-
 func TestNormalizeModelList(t *testing.T) {
 	models := []string{"models/gemini-pro", "gemini-pro", "models/gpt-4"}
 	result := normalizeModelList(models)

--- a/platform/oneapi_test.go
+++ b/platform/oneapi_test.go
@@ -28,40 +28,6 @@ func TestOneApiAdapter_Detect(t *testing.T) {
 	}
 }
 
-func TestOneApiAdapter_BalanceQuotaMinusUsed(t *testing.T) {
-	o := &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-api")}
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
-	// OneApi model B: quota=total, balance=quota-used
-	// Impossible to test balance without HTTP, but verify the struct has correct inheritance
-	_ = o
-	_ = ctx
-}
-
-func TestOneApiAdapter_BalanceParseLogic(t *testing.T) {
-	// Verify OneApi balance formula via the code pattern
-	// OneApi: balance = (quota - used) / 500000, quotaUSD = quota/500000, usedUSD = used/500000
-	// So with quota=1000000, used=500000: balance=1.0, quota=2.0, used=1.0
-
-	// This is a unit test of the balance formula
-	quota := 1000000.0
-	used := 500000.0
-	balance := (quota - used) / 500000
-	quotaUSD := quota / 500000
-	usedUSD := used / 500000
-
-	if balance != 1.0 {
-		t.Errorf("OneApi balance formula: %f, want 1.0", balance)
-	}
-	if quotaUSD != 2.0 {
-		t.Errorf("OneApi quotaUSD: %f, want 2.0", quotaUSD)
-	}
-	if usedUSD != 1.0 {
-		t.Errorf("OneApi usedUSD: %f, want 1.0", usedUSD)
-	}
-}
-
 func TestOneApiAdapter_DoubleDeleteStrategy(t *testing.T) {
 	o := &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-api")}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/platform/openai_test.go
+++ b/platform/openai_test.go
@@ -40,19 +40,6 @@ func TestOpenAiAdapter_PlatformName(t *testing.T) {
 	}
 }
 
-// TestOpenAiAdapter_GetModels calls fetchModelsFromStandardEndpoint which does HTTP -
-// will fail on non-existent URLs but should return empty slice without error
-func TestOpenAiAdapter_GetModels(t *testing.T) {
-	a := &OpenAiAdapter{StandardAdapter: NewStandardAdapter("openai")}
-	ctx := context.Background()
-
-	// Should fail gracefully on non-existent URL
-	models, err := a.GetModels(ctx, unreachableBaseURL(t), "sk-test", nil, nil)
-	// Either way, we get an error or empty models - both acceptable for this adapter
-	_ = models
-	_ = err
-}
-
 func TestOpenAiAdapter_InheritsStandardDefaults(t *testing.T) {
 	a := &OpenAiAdapter{StandardAdapter: NewStandardAdapter("openai")}
 	ctx := context.Background()

--- a/platform/registry_test.go
+++ b/platform/registry_test.go
@@ -145,19 +145,3 @@ func TestNormalizePlatformAlias_NewApiForks(t *testing.T) {
 		}
 	}
 }
-
-// --- ListAdapters ---
-
-func TestListAdapters_Copy(t *testing.T) {
-	original := ListAdapters()
-	// Modify the returned slice
-	if len(original) > 0 {
-		original[0] = nil
-	}
-	// Original registry should be unaffected
-	again := ListAdapters()
-	if len(again) != len(original) || again[0] == nil {
-		// Actually ListAdapters creates a copy, so modification won't persist
-		// This just ensures it doesn't panic
-	}
-}

--- a/platform/standard.go
+++ b/platform/standard.go
@@ -109,34 +109,3 @@ func normalizeBaseURL(raw string) string {
 	result := parsed.Scheme + "://" + parsed.Host
 	return result
 }
-
-func normalizeURLForDetection(raw string) string {
-	u := strings.TrimSpace(raw)
-	if u == "" {
-		return u
-	}
-	if !strings.Contains(u, "://") {
-		u = "https://" + u
-	}
-	parsed, err := url.Parse(u)
-	if err != nil {
-		return strings.TrimSuffix(strings.TrimSuffix(u, "/"), "\\")
-	}
-	path := strings.TrimSuffix(parsed.Path, "/")
-	return parsed.Scheme + "://" + parsed.Host + path
-}
-
-func normalizeURLProtocol(raw string) string {
-	u := strings.TrimSpace(raw)
-	if u == "" {
-		return u
-	}
-	if !strings.Contains(u, "://") {
-		u = "https://" + u
-	}
-	parsed, err := url.Parse(u)
-	if err != nil {
-		return strings.TrimSuffix(strings.TrimSuffix(raw, "/"), "\\")
-	}
-	return parsed.Scheme + "://" + parsed.Host
-}

--- a/platform/standard_test.go
+++ b/platform/standard_test.go
@@ -130,38 +130,6 @@ func TestNormalizeBaseURL(t *testing.T) {
 	}
 }
 
-func TestNormalizeURLForDetection(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"example.com/path/", "https://example.com/path"},
-		{"http://example.com/path/", "http://example.com/path"},
-		{"https://example.com", "https://example.com"},
-	}
-	for _, tt := range tests {
-		if got := normalizeURLForDetection(tt.input); got != tt.expected {
-			t.Errorf("normalizeURLForDetection(%q) = %q, want %q", tt.input, got, tt.expected)
-		}
-	}
-}
-
-func TestNormalizeURLProtocol(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"example.com", "https://example.com"},
-		{"http://example.com/path", "http://example.com"},
-		{"https://example.com/path/", "https://example.com"},
-	}
-	for _, tt := range tests {
-		if got := normalizeURLProtocol(tt.input); got != tt.expected {
-			t.Errorf("normalizeURLProtocol(%q) = %q, want %q", tt.input, got, tt.expected)
-		}
-	}
-}
-
 func TestVersionedPathRE(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
## What

Deletes three helpers with zero non-test callers, one pass-through test wrapper, and four tests that cannot fail. Net **-155 / +3** across 10 files. No behaviour change.

## Ablation evidence

**Dead helpers (zero production callers — `git grep` on master, definition + its own test are the only hits):**

| symbol | file | refs on master |
|---|---|---|
| `stripModelPrefix` | `platform/gemini.go:90` | definition + `platform/gemini_test.go` only |
| `normalizeURLForDetection` | `platform/standard.go:113` | definition + `platform/standard_test.go` only |
| `normalizeURLProtocol` | `platform/standard.go:129` | definition + `platform/standard_test.go` only |

Their tests are deleted with them: a test that only exercises an unreachable function gates nothing.

**Pass-through wrapper:** `setReadinessDrainingForTest` (`app/health.go:56`) was a one-line forward to `markReadinessDraining`. Both live in package `app`, and both callers are `app` tests, so the tests now call `markReadinessDraining` directly. Same behaviour, one fewer indirection.

**Vacuous tests (each cannot fail regardless of production behaviour):**

| test | why it is vacuous |
|---|---|
| `TestOneApiAdapter_BalanceQuotaMinusUsed` | no assertion at all — body is `_ = o; _ = ctx` |
| `TestOneApiAdapter_BalanceParseLogic` | asserts arithmetic on local literals (`(1000000-500000)/500000 == 1.0`); calls no product code |
| `TestOpenAiAdapter_GetModels` | accepts every outcome — `_ = models; _ = err` |
| `TestListAdapters_Copy` | the only `if` has an empty body; comment admits "This just ensures it doesn't panic" |

## What was deliberately kept

`itoa` (`handler/proxy/messages.go:43`) stays. The audit that produced this lane listed it as dead; that was wrong — it has ~40 same-package test callers (`account_tokens_test.go`, `token_routes_test.go`, `tags_test.go`, `search_test.go`, `videos*_test.go`) plus its own gate in `handler/proxy/helpers_test.go`. (`service/checkin/round_aggregation_test.go:92` defines a separate local `itoa`; unrelated.)

## Known coverage gap (honest)

Deleting `TestOpenAiAdapter_GetModels` and `TestListAdapters_Copy` leaves `OpenAiAdapter.GetModels` and `ListAdapters` without a direct unit gate. Both were *not* gated before either — those tests accepted any result — so no real coverage is lost, but the gap is now visible instead of hidden behind a green checkmark. A real gate for `GetModels` needs an httptest upstream, which is a separate change.

## Verification

```
GOGC=30 nice -n 19 go test ./app/... ./platform/...
ok  github.com/deliciousbuding/metapi-go/app                 1.294s
ok  github.com/deliciousbuding/metapi-go/app/observability   0.021s
ok  github.com/deliciousbuding/metapi-go/platform           14.354s
```

Green compile also proves the removed helpers were not keeping `net/url` / `strings` imports alive in `platform/standard.go`.
