### PR TITLE
test(proxy): fold same-shape retry-policy and failure-judge cases into tables

### DIFF
--- a/proxy/failure_judge_test.go
+++ b/proxy/failure_judge_test.go
@@ -166,96 +166,35 @@ func TestJudgeUpstreamContent_EmptyContent(t *testing.T) {
 }
 
 func TestDetectHasUpstreamOutput(t *testing.T) {
-	t.Run("empty text", func(t *testing.T) {
-		if detectHasUpstreamOutput("") {
-			t.Error("expected false for empty text")
-		}
-	})
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{name: "empty text", text: "", want: false},
+		{name: "whitespace only", text: "   \n  ", want: false},
+		{name: "JSON with text content", text: `{"choices":[{"message":{"content":"hello"}}]}`, want: true},
+		{name: "JSON with no content", text: `{"id":"chat-123","created":123}`, want: false},
+		{name: "JSON with output_text", text: `{"output_text":"generated text"}`, want: true},
+		{name: "JSON with tool_calls", text: `{"choices":[{"delta":{"tool_calls":[{"function":{"name":"test"}}]}}]}`, want: true},
+		{name: "JSON with delta text", text: `{"choices":[{"delta":{"content":"partial"}}]}`, want: true},
+		{name: "SSE with [DONE] only", text: "data: [DONE]\n", want: false},
+		{name: "SSE with content events", text: "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\ndata: [DONE]\n", want: true},
+		{name: "SSE with non-JSON payload", text: "data: some raw text\n", want: true},
+		{name: "plain text (no JSON, no SSE)", text: "This is a plain text response", want: true},
+		{name: "JSON with output array containing text", text: `{"output":[{"type":"message","content":[{"type":"output_text","text":"result"}]}]}`, want: true},
+		{name: "JSON with content parts", text: `{"content":[{"type":"text","text":"Hello world"}]}`, want: true},
+		{name: "JSON with message refusal", text: `{"choices":[{"message":{"refusal":"I cannot do that"}}]}`, want: true},
+	}
 
-	t.Run("whitespace only", func(t *testing.T) {
-		if detectHasUpstreamOutput("   \n  ") {
-			t.Error("expected false for whitespace")
-		}
-	})
-
-	t.Run("JSON with text content", func(t *testing.T) {
-		if !detectHasUpstreamOutput(`{"choices":[{"message":{"content":"hello"}}]}`) {
-			t.Error("expected true for JSON with choices content")
-		}
-	})
-
-	t.Run("JSON with no content", func(t *testing.T) {
-		if detectHasUpstreamOutput(`{"id":"chat-123","created":123}`) {
-			t.Error("expected false for JSON with no content")
-		}
-	})
-
-	t.Run("JSON with output_text", func(t *testing.T) {
-		if !detectHasUpstreamOutput(`{"output_text":"generated text"}`) {
-			t.Error("expected true for JSON with output_text")
-		}
-	})
-
-	t.Run("JSON with tool_calls", func(t *testing.T) {
-		if !detectHasUpstreamOutput(`{"choices":[{"delta":{"tool_calls":[{"function":{"name":"test"}}]}}]}`) {
-			t.Error("expected true for JSON with tool_calls")
-		}
-	})
-
-	t.Run("JSON with delta text", func(t *testing.T) {
-		if !detectHasUpstreamOutput(`{"choices":[{"delta":{"content":"partial"}}]}`) {
-			t.Error("expected true for JSON with delta content")
-		}
-	})
-
-	t.Run("SSE with [DONE] only", func(t *testing.T) {
-		if detectHasUpstreamOutput("data: [DONE]\n") {
-			t.Error("expected false for [DONE]-only SSE")
-		}
-	})
-
-	t.Run("SSE with content events", func(t *testing.T) {
-		text := "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\ndata: [DONE]\n"
-		if !detectHasUpstreamOutput(text) {
-			t.Error("expected true for SSE with content")
-		}
-	})
-
-	t.Run("SSE with non-JSON payload", func(t *testing.T) {
-		text := "data: some raw text\n"
-		if !detectHasUpstreamOutput(text) {
-			t.Error("expected true for SSE with raw text")
-		}
-	})
-
-	t.Run("plain text (no JSON, no SSE)", func(t *testing.T) {
-		if !detectHasUpstreamOutput("This is a plain text response") {
-			t.Error("expected true for plain text")
-		}
-	})
-
-	t.Run("JSON with output array containing text", func(t *testing.T) {
-		json := `{"output":[{"type":"message","content":[{"type":"output_text","text":"result"}]}]}`
-		if !detectHasUpstreamOutput(json) {
-			t.Error("expected true for output array with text content")
-		}
-	})
-
-	t.Run("JSON with content parts", func(t *testing.T) {
-		json := `{"content":[{"type":"text","text":"Hello world"}]}`
-		if !detectHasUpstreamOutput(json) {
-			t.Error("expected true for content parts with text")
-		}
-	})
-
-	t.Run("JSON with message refusal", func(t *testing.T) {
-		json := `{"choices":[{"message":{"refusal":"I cannot do that"}}]}`
-		if !detectHasUpstreamOutput(json) {
-			t.Error("expected true for refusal (considered output)")
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectHasUpstreamOutput(tt.text); got != tt.want {
+				t.Errorf("detectHasUpstreamOutput(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
 }
-
 func TestJudgeUpstreamContent_Combined(t *testing.T) {
 	t.Run("keyword takes priority over empty content", func(t *testing.T) {
 		setupFailureCfg([]string{"quota"}, true)
@@ -280,59 +219,28 @@ func TestJudgeUpstreamContent_Combined(t *testing.T) {
 		}
 	})
 }
-
 func TestHasCompletionContentFromPayload(t *testing.T) {
-	t.Run("nil payload", func(t *testing.T) {
-		if hasCompletionContentFromPayload(nil) {
-			t.Error("expected false for nil")
-		}
-	})
+	tests := []struct {
+		name    string
+		payload any
+		want    bool
+	}{
+		{name: "nil payload", payload: nil, want: false},
+		{name: "non-map payload", payload: []string{"test"}, want: false},
+		{name: "empty map", payload: map[string]any{}, want: false},
+		{name: "direct text field", payload: map[string]any{"text": "hello"}, want: true},
+		{name: "empty text field", payload: map[string]any{"text": ""}, want: false},
+		{name: "delta text", payload: map[string]any{"delta": "content"}, want: true},
+		{name: "function_call key", payload: map[string]any{"function_call": map[string]any{"name": "test"}}, want: true},
+		{name: "tool_calls array", payload: map[string]any{"tool_calls": []any{map[string]any{"name": "test"}}}, want: true},
+		{name: "outputText field", payload: map[string]any{"outputText": "result"}, want: true},
+	}
 
-	t.Run("non-map payload", func(t *testing.T) {
-		if hasCompletionContentFromPayload([]string{"test"}) {
-			t.Error("expected false for non-map")
-		}
-	})
-
-	t.Run("empty map", func(t *testing.T) {
-		if hasCompletionContentFromPayload(map[string]any{}) {
-			t.Error("expected false for empty map")
-		}
-	})
-
-	t.Run("direct text field", func(t *testing.T) {
-		if !hasCompletionContentFromPayload(map[string]any{"text": "hello"}) {
-			t.Error("expected true for direct text")
-		}
-	})
-
-	t.Run("empty text field", func(t *testing.T) {
-		if hasCompletionContentFromPayload(map[string]any{"text": ""}) {
-			t.Error("expected false for empty text")
-		}
-	})
-
-	t.Run("delta text", func(t *testing.T) {
-		if !hasCompletionContentFromPayload(map[string]any{"delta": "content"}) {
-			t.Error("expected true for delta string")
-		}
-	})
-
-	t.Run("function_call key", func(t *testing.T) {
-		if !hasCompletionContentFromPayload(map[string]any{"function_call": map[string]any{"name": "test"}}) {
-			t.Error("expected true for function_call")
-		}
-	})
-
-	t.Run("tool_calls array", func(t *testing.T) {
-		if !hasCompletionContentFromPayload(map[string]any{"tool_calls": []any{map[string]any{"name": "test"}}}) {
-			t.Error("expected true for tool_calls")
-		}
-	})
-
-	t.Run("outputText field", func(t *testing.T) {
-		if !hasCompletionContentFromPayload(map[string]any{"outputText": "result"}) {
-			t.Error("expected true for outputText")
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasCompletionContentFromPayload(tt.payload); got != tt.want {
+				t.Errorf("hasCompletionContentFromPayload(%v) = %v, want %v", tt.payload, got, tt.want)
+			}
+		})
+	}
 }

--- a/proxy/retry_policy_test.go
+++ b/proxy/retry_policy_test.go
@@ -3,432 +3,182 @@ package proxy
 import "testing"
 
 func TestShouldRetryProxyRequest_StatusCodes(t *testing.T) {
-	t.Run(">= 500 always retryable", func(t *testing.T) {
-		for _, status := range []int{500, 502, 503, 504, 599} {
-			if !ShouldRetryProxyRequest(status, "") {
-				t.Errorf("expected retryable for status %d", status)
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{name: "500 always retryable", status: 500, want: true},
+		{name: "502 always retryable", status: 502, want: true},
+		{name: "503 always retryable", status: 503, want: true},
+		{name: "504 always retryable", status: 504, want: true},
+		{name: "599 always retryable", status: 599, want: true},
+		{name: "408 always retryable", status: 408, want: true},
+		{name: "409 always retryable", status: 409, want: true},
+		{name: "425 always retryable", status: 425, want: true},
+		{name: "429 always retryable", status: 429, want: true},
+		{name: "401 retryable (OAuth refresh)", status: 401, want: true},
+		{name: "403 retryable (OAuth refresh)", status: 403, want: true},
+		{name: "400 non-retryable by default", status: 400, want: false},
+		{name: "404 non-retryable by default", status: 404, want: false},
+		{name: "422 non-retryable by default", status: 422, want: false},
+		{name: "other status non-retryable", status: 302, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldRetryProxyRequest(tt.status, tt.body); got != tt.want {
+				t.Errorf("ShouldRetryProxyRequest(%d, %q) = %v, want %v", tt.status, tt.body, got, tt.want)
 			}
-		}
-	})
-
-	t.Run("408 always retryable", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(408, "") {
-			t.Error("expected retryable for 408")
-		}
-	})
-
-	t.Run("409 always retryable", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(409, "") {
-			t.Error("expected retryable for 409")
-		}
-	})
-
-	t.Run("425 always retryable", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(425, "") {
-			t.Error("expected retryable for 425")
-		}
-	})
-
-	t.Run("429 always retryable", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(429, "") {
-			t.Error("expected retryable for 429")
-		}
-	})
-
-	t.Run("401 retryable (OAuth refresh)", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(401, "") {
-			t.Error("expected retryable for 401")
-		}
-	})
-
-	t.Run("403 retryable (OAuth refresh)", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(403, "") {
-			t.Error("expected retryable for 403")
-		}
-	})
-
-	t.Run("400 non-retryable by default", func(t *testing.T) {
-		if ShouldRetryProxyRequest(400, "") {
-			t.Error("expected non-retryable for 400")
-		}
-	})
-
-	t.Run("404 non-retryable by default", func(t *testing.T) {
-		if ShouldRetryProxyRequest(404, "") {
-			t.Error("expected non-retryable for 404")
-		}
-	})
-
-	t.Run("422 non-retryable by default", func(t *testing.T) {
-		if ShouldRetryProxyRequest(422, "") {
-			t.Error("expected non-retryable for 422")
-		}
-	})
-
-	t.Run("other status non-retryable", func(t *testing.T) {
-		if ShouldRetryProxyRequest(302, "") {
-			t.Error("expected non-retryable for 302")
-		}
-	})
+		})
+	}
 }
 
 func TestShouldRetryProxyRequest_ModelUnsupportedPatterns(t *testing.T) {
-	t.Run("model not supported", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "model not supported") {
-			t.Error("expected retryable for model-unsupported error")
-		}
-	})
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{name: "model not supported", status: 400, body: "model not supported", want: true},
+		{name: "does not support the model", status: 400, body: "This endpoint does not support the model gpt-5", want: true},
+		{name: "does not support model (without 'the')", status: 400, body: "OpenAI does not support model gpt-5", want: true},
+		{name: "model not found", status: 400, body: "model_not_found", want: true},
+		{name: "unknown model", status: 400, body: "unknown model: gpt-5", want: true},
+		{name: "invalid model", status: 400, body: "invalid model specified", want: true},
+		{name: "do not have access to the model", status: 400, body: "you do not have access to the model gpt-4", want: true},
+		{name: "Chinese model unsupported", status: 400, body: "当前 api 不支持所选模型", want: true},
+		{name: "Chinese model not supported (variant)", status: 400, body: "不支持所选模型", want: true},
+		{name: "no such model", status: 400, body: "no such model", want: true},
+		{name: "unknown provider for model", status: 400, body: "unknown provider for model: gpt-4", want: true},
+	}
 
-	t.Run("does not support the model", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "This endpoint does not support the model gpt-5") {
-			t.Error("expected retryable for 'does not support the model'")
-		}
-	})
-
-	t.Run("does not support model (without 'the')", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "OpenAI does not support model gpt-5") {
-			t.Error("expected retryable for 'does not support model'")
-		}
-	})
-
-	t.Run("model not found", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "model_not_found") {
-			t.Error("expected retryable for 'model_not_found'")
-		}
-	})
-
-	t.Run("unknown model", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "unknown model: gpt-5") {
-			t.Error("expected retryable for 'unknown model'")
-		}
-	})
-
-	t.Run("invalid model", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "invalid model specified") {
-			t.Error("expected retryable for 'invalid model'")
-		}
-	})
-
-	t.Run("do not have access to the model", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "you do not have access to the model gpt-4") {
-			t.Error("expected retryable for access denied to model")
-		}
-	})
-
-	t.Run("Chinese model unsupported", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "当前 api 不支持所选模型") {
-			t.Error("expected retryable for Chinese model unsupported")
-		}
-	})
-
-	t.Run("Chinese model not supported (variant)", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "不支持所选模型") {
-			t.Error("expected retryable for Chinese model unsupported variant")
-		}
-	})
-
-	t.Run("no such model", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "no such model") {
-			t.Error("expected retryable for 'no such model'")
-		}
-	})
-
-	t.Run("unknown provider for model", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "unknown provider for model: gpt-4") {
-			t.Error("expected retryable for unknown provider")
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldRetryProxyRequest(tt.status, tt.body); got != tt.want {
+				t.Errorf("ShouldRetryProxyRequest(%d, %q) = %v, want %v", tt.status, tt.body, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestShouldRetryProxyRequest_NonRetryableRequestPatterns(t *testing.T) {
-	t.Run("invalid request body blocks retry", func(t *testing.T) {
-		if ShouldRetryProxyRequest(400, "invalid request body") {
-			t.Error("expected non-retryable for 'invalid request body'")
-		}
-	})
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{name: "invalid request body blocks retry", status: 400, body: "invalid request body", want: false},
+		{name: "validation error blocks retry", status: 400, body: "validation error: field x is required", want: false},
+		{name: "malformed request blocks retry", status: 400, body: "malformed request", want: false},
+		{name: "invalid json blocks retry", status: 400, body: "invalid json in request body", want: false},
+		{name: "cannot parse blocks retry", status: 400, body: "cannot parse request", want: false},
+		{name: "500 status always retryable regardless of text", status: 500, body: "invalid request body", want: true},
+		{name: "non-retryable patterns take priority over UNSUPPORTED MODEL patterns", status: 400, body: "does not support the model but also validation error", want: true},
+	}
 
-	t.Run("validation error blocks retry", func(t *testing.T) {
-		if ShouldRetryProxyRequest(400, "validation error: field x is required") {
-			t.Error("expected non-retryable for validation error")
-		}
-	})
-
-	t.Run("malformed request blocks retry", func(t *testing.T) {
-		if ShouldRetryProxyRequest(400, "malformed request") {
-			t.Error("expected non-retryable for malformed request")
-		}
-	})
-
-	t.Run("invalid json blocks retry", func(t *testing.T) {
-		if ShouldRetryProxyRequest(400, "invalid json in request body") {
-			t.Error("expected non-retryable for invalid json")
-		}
-	})
-
-	t.Run("cannot parse blocks retry", func(t *testing.T) {
-		if ShouldRetryProxyRequest(400, "cannot parse request") {
-			t.Error("expected non-retryable for cannot parse")
-		}
-	})
-
-	t.Run("500 status always retryable regardless of text", func(t *testing.T) {
-		// Status >= 500 always retryable - checked BEFORE text patterns
-		if !ShouldRetryProxyRequest(500, "invalid request body") {
-			t.Error("expected retryable for 500 (status >= 500 always retryable)")
-		}
-	})
-
-	t.Run("non-retryable patterns take priority over UNSUPPORTED MODEL patterns", func(t *testing.T) {
-		// The non-retryable check comes BEFORE model-unsupported check in flow
-		// Wait - actually re-reading the code: model_unsupported is checked FIRST
-		// Let me verify...
-		// Looking at ShouldRetryProxyRequest:
-		// 1. status >= 500 -> true (returns immediately)
-		// 2. 408/409/425/429 -> true
-		// 3. 401/403 -> true
-		// 4. model_unsupported text -> true (returns before non-retryable check)
-		// 5. non_retryable_request text -> false
-		// ...
-		// So if text matches BOTH model_unsupported AND non_retryable, model_unsupported wins
-		if !ShouldRetryProxyRequest(400, "does not support the model but also validation error") {
-			t.Error("model unsupported pattern wins over non-retryable patterns")
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldRetryProxyRequest(tt.status, tt.body); got != tt.want {
+				t.Errorf("ShouldRetryProxyRequest(%d, %q) = %v, want %v", tt.status, tt.body, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestShouldRetryProxyRequest_RetryableChannelLocalPatterns(t *testing.T) {
-	t.Run("invalid api key", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "invalid api key") {
-			t.Error("expected retryable for 'invalid api key'")
-		}
-	})
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{name: "invalid api key", status: 400, body: "invalid api key", want: true},
+		{name: "forbidden", status: 400, body: "forbidden", want: true},
+		{name: "rate limit", status: 400, body: "rate limit exceeded", want: true},
+		{name: "quota exceeded", status: 400, body: "quota exceeded", want: true},
+		{name: "bad gateway", status: 400, body: "bad gateway error", want: true},
+		{name: "gateway timeout", status: 400, body: "gateway timeout", want: true},
+		{name: "gateway time-out pattern", status: 400, body: "gateway time-out", want: true},
+		{name: "service unavailable", status: 400, body: "service unavailable", want: true},
+		{name: "please use /v1/responses", status: 400, body: "please use /v1/responses", want: true},
+		{name: "please use /v1/messages", status: 400, body: "please use /v1/messages", want: true},
+		{name: "please use /v1/chat/completions", status: 400, body: "please use /v1/chat/completions", want: true},
+		{name: "unsupported endpoint", status: 400, body: "unsupported endpoint", want: true},
+		{name: "cpu overloaded", status: 400, body: "cpu overloaded", want: true},
+		{name: "invalid access token", status: 400, body: "invalid access token", want: true},
+		{name: "unsupported legacy protocol", status: 400, body: "unsupported legacy protocol", want: true},
+		{name: "unrecognized request url", status: 400, body: "unrecognized request url", want: true},
+		{name: "no route matched", status: 400, body: "no route matched", want: true},
+		{name: "connection timed out", status: 400, body: "connection timed out", want: true},
+		{name: "request timed out", status: 400, body: "request timed out", want: true},
+		{name: "read timeout", status: 400, body: "read timeout", want: true},
+		{name: "timed out", status: 400, body: "the operation timed out", want: true},
+	}
 
-	t.Run("forbidden", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "forbidden") {
-			t.Error("expected retryable for 'forbidden'")
-		}
-	})
-
-	t.Run("rate limit", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "rate limit exceeded") {
-			t.Error("expected retryable for 'rate limit'")
-		}
-	})
-
-	t.Run("quota exceeded", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "quota exceeded") {
-			t.Error("expected retryable for 'quota exceeded'")
-		}
-	})
-
-	t.Run("bad gateway", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "bad gateway error") {
-			t.Error("expected retryable for 'bad gateway'")
-		}
-	})
-
-	t.Run("gateway timeout", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "gateway timeout") {
-			t.Error("expected retryable for 'gateway timeout'")
-		}
-	})
-
-	t.Run("gateway time-out pattern", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "gateway time-out") {
-			t.Error("expected retryable for 'gateway time-out'")
-		}
-	})
-
-	t.Run("service unavailable", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "service unavailable") {
-			t.Error("expected retryable for 'service unavailable'")
-		}
-	})
-
-	t.Run("please use /v1/responses", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "please use /v1/responses") {
-			t.Error("expected retryable for protocol switch hint")
-		}
-	})
-
-	t.Run("please use /v1/messages", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "please use /v1/messages") {
-			t.Error("expected retryable for messages switch hint")
-		}
-	})
-
-	t.Run("please use /v1/chat/completions", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "please use /v1/chat/completions") {
-			t.Error("expected retryable for chat/completions switch hint")
-		}
-	})
-
-	t.Run("unsupported endpoint", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "unsupported endpoint") {
-			t.Error("expected retryable for unsupported endpoint")
-		}
-	})
-
-	t.Run("cpu overloaded", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "cpu overloaded") {
-			t.Error("expected retryable for cpu overloaded")
-		}
-	})
-
-	t.Run("invalid access token", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "invalid access token") {
-			t.Error("expected retryable for invalid access token")
-		}
-	})
-
-	t.Run("unsupported legacy protocol", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "unsupported legacy protocol") {
-			t.Error("expected retryable for unsupported legacy protocol")
-		}
-	})
-
-	t.Run("unrecognized request url", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "unrecognized request url") {
-			t.Error("expected retryable for unrecognized request url")
-		}
-	})
-
-	t.Run("no route matched", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "no route matched") {
-			t.Error("expected retryable for no route matched")
-		}
-	})
-
-	t.Run("connection timed out", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "connection timed out") {
-			t.Error("expected retryable for connection timed out")
-		}
-	})
-
-	t.Run("request timed out", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "request timed out") {
-			t.Error("expected retryable for request timed out")
-		}
-	})
-
-	t.Run("read timeout", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "read timeout") {
-			t.Error("expected retryable for read timeout")
-		}
-	})
-
-	t.Run("timed out", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "the operation timed out") {
-			t.Error("expected retryable for 'timed out'")
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldRetryProxyRequest(tt.status, tt.body); got != tt.want {
+				t.Errorf("ShouldRetryProxyRequest(%d, %q) = %v, want %v", tt.status, tt.body, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestShouldRetryProxyRequest_EdgeCases(t *testing.T) {
-	t.Run("400 with retryable channel-local text", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "quota exceeded on this channel") {
-			t.Error("expected retryable for 400 with retryable text")
-		}
-	})
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{name: "400 with retryable channel-local text", status: 400, body: "quota exceeded on this channel", want: true},
+		{name: "400 without any retryable text", status: 400, body: "some generic error", want: false},
+		{name: "404 without any retryable text", status: 404, body: "not found", want: false},
+		{name: "422 without any retryable text", status: 422, body: "unprocessable", want: false},
+		{name: "empty error text", status: 400, body: "", want: false},
+		{name: "case-insensitive matching", status: 400, body: "Model Not Supported", want: true},
+	}
 
-	t.Run("400 without any retryable text", func(t *testing.T) {
-		if ShouldRetryProxyRequest(400, "some generic error") {
-			t.Error("expected non-retryable for 400 with generic text")
-		}
-	})
-
-	t.Run("404 without any retryable text", func(t *testing.T) {
-		if ShouldRetryProxyRequest(404, "not found") {
-			t.Error("expected non-retryable for 404 with generic text")
-		}
-	})
-
-	t.Run("422 without any retryable text", func(t *testing.T) {
-		if ShouldRetryProxyRequest(422, "unprocessable") {
-			t.Error("expected non-retryable for 422 with generic text")
-		}
-	})
-
-	t.Run("empty error text", func(t *testing.T) {
-		if ShouldRetryProxyRequest(400, "") {
-			t.Error("expected non-retryable for 400 with empty text")
-		}
-	})
-
-	t.Run("case-insensitive matching", func(t *testing.T) {
-		if !ShouldRetryProxyRequest(400, "Model Not Supported") {
-			t.Error("expected retryable with case-insensitive model unsupported")
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldRetryProxyRequest(tt.status, tt.body); got != tt.want {
+				t.Errorf("ShouldRetryProxyRequest(%d, %q) = %v, want %v", tt.status, tt.body, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestShouldAbortSameSiteEndpointFallback(t *testing.T) {
-	t.Run("500 with retryable pattern", func(t *testing.T) {
-		if !ShouldAbortSameSiteEndpointFallback(500, "service unavailable") {
-			t.Error("expected abort for 500 + service unavailable")
-		}
-	})
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{name: "500 with retryable pattern", status: 500, body: "service unavailable", want: true},
+		{name: "429 with rate limit", status: 429, body: "rate limit exceeded", want: true},
+		{name: "408 with timeout", status: 408, body: "connection timed out", want: true},
+		{name: "400 should not abort", status: 400, body: "rate limit exceeded", want: false},
+		{name: "503 with matching pattern", status: 503, body: "bad gateway", want: true},
+		{name: "502 with non-matching text does not abort", status: 502, body: "some other error", want: false},
+		{name: "502 with matching pattern does abort", status: 502, body: "service unavailable", want: true},
+		{name: "connection reset", status: 500, body: "connection reset by peer", want: true},
+		{name: "connection refused", status: 500, body: "connection refused", want: true},
+		{name: "econnreset", status: 500, body: "econnreset", want: true},
+		{name: "temporarily unavailable", status: 500, body: "service temporarily unavailable", want: true},
+	}
 
-	t.Run("429 with rate limit", func(t *testing.T) {
-		if !ShouldAbortSameSiteEndpointFallback(429, "rate limit exceeded") {
-			t.Error("expected abort for 429 + rate limit")
-		}
-	})
-
-	t.Run("408 with timeout", func(t *testing.T) {
-		if !ShouldAbortSameSiteEndpointFallback(408, "connection timed out") {
-			t.Error("expected abort for 408 + timeout")
-		}
-	})
-
-	t.Run("400 should not abort", func(t *testing.T) {
-		if ShouldAbortSameSiteEndpointFallback(400, "rate limit exceeded") {
-			t.Error("expected NO abort for 400 even with rate limit text")
-		}
-	})
-
-	t.Run("503 with matching pattern", func(t *testing.T) {
-		if !ShouldAbortSameSiteEndpointFallback(503, "bad gateway") {
-			t.Error("expected abort for 503 + bad gateway")
-		}
-	})
-
-	t.Run("502 with non-matching text does not abort", func(t *testing.T) {
-		// Both status and pattern must match
-		if ShouldAbortSameSiteEndpointFallback(502, "some other error") {
-			t.Error("expected NO abort for 502 with non-matching pattern")
-		}
-	})
-
-	t.Run("502 with matching pattern does abort", func(t *testing.T) {
-		if !ShouldAbortSameSiteEndpointFallback(502, "service unavailable") {
-			t.Error("expected abort for 502 + service unavailable")
-		}
-	})
-
-	t.Run("connection reset", func(t *testing.T) {
-		if !ShouldAbortSameSiteEndpointFallback(500, "connection reset by peer") {
-			t.Error("expected abort for connection reset")
-		}
-	})
-
-	t.Run("connection refused", func(t *testing.T) {
-		if !ShouldAbortSameSiteEndpointFallback(500, "connection refused") {
-			t.Error("expected abort for connection refused")
-		}
-	})
-
-	t.Run("econnreset", func(t *testing.T) {
-		if !ShouldAbortSameSiteEndpointFallback(500, "econnreset") {
-			t.Error("expected abort for econnreset")
-		}
-	})
-
-	t.Run("temporarily unavailable", func(t *testing.T) {
-		if !ShouldAbortSameSiteEndpointFallback(500, "service temporarily unavailable") {
-			t.Error("expected abort for temporarily unavailable")
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldAbortSameSiteEndpointFallback(tt.status, tt.body); got != tt.want {
+				t.Errorf("ShouldAbortSameSiteEndpointFallback(%d, %q) = %v, want %v", tt.status, tt.body, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestGetProxyMaxChannelAttempts(t *testing.T) {
@@ -457,11 +207,11 @@ func TestGetProxyMaxChannelRetries(t *testing.T) {
 		attempts int
 		expected int
 	}{
-		{1, 0},  // 1 attempt, 0 retries
-		{2, 1},  // 2 attempts, 1 retry
-		{3, 2},  // 3 attempts, 2 retries
-		{5, 4},  // 5 attempts, 4 retries
-		{0, 0},  // 0 attempts -> 0 retries (min)
+		{1, 0}, // 1 attempt, 0 retries
+		{2, 1}, // 2 attempts, 1 retry
+		{3, 2}, // 3 attempts, 2 retries
+		{5, 4}, // 5 attempts, 4 retries
+		{0, 0}, // 0 attempts -> 0 retries (min)
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

Folds same-shape `t.Run` blocks in two `proxy` test files into table-driven tests. **2 files, +209 / −551 (−342 LOC).** No assertion is lost and no test function is renamed.

| file | LOC | `t.Run` blocks | decision cases |
|---|---|---|---|
| `proxy/retry_policy_test.go` | 473 → 223 | 67 → 6 (one loop per folded func) | 71 → **71** |
| `proxy/failure_judge_test.go` | 338 → 246 | 37 → 16 | 23 folded → **23**, 14 different-shape cases untouched |

The six retry-policy funcs stay separate — each documents a different decision input (status codes, model-unsupported patterns, non-retryable request patterns, channel-local patterns, edge cases, same-site fallback), and merging them into one mega-table would hide which input drove which expectation.

Case count went 67 `t.Run` → 71 rows because `">= 500 always retryable"` looped over `{500,502,503,504,599}` inside a single subtest; those are now 5 discrete rows, each individually named when it fails.

**Zero assertion loss was checked mechanically, not by eye:** every `ShouldRetryProxyRequest(...)` / `ShouldAbortSameSiteEndpointFallback(...)` input→expected tuple was extracted from the original file and compared as a set against the new table rows — `71 = 71`, both difference sets empty. Same for `TestDetectHasUpstreamOutput` (14 = 14) and `TestHasCompletionContentFromPayload` (9 = 9).

Left alone on purpose: the three `TestJudgeUpstreamContent_*` funcs (14 `t.Run`) assert fields of an `UpstreamVerdict` struct after a `setupFailureCfg` call — a different shape, so folding them would have meant inventing a shared harness for three callers. `TestGetProxyMaxChannelAttempts` / `TestGetProxyMaxChannelRetries` are already table-driven.

## Proof the gate gates

Mutation probe on production code — in `proxy/retry_policy.go`, the retryable channel-local pattern `forbidden` → `access\s+denied`:

```
=== RUN   TestShouldRetryProxyRequest_RetryableChannelLocalPatterns/forbidden
    retry_policy_test.go:125: ShouldRetryProxyRequest(400, "forbidden") = false, want true
--- FAIL: TestShouldRetryProxyRequest_RetryableChannelLocalPatterns (0.00s)
```

Restored from a pre-mutation copy, `sha256sum -c` → `proxy/retry_policy.go: OK` (`3a4196dd…`), suite green again.

## Verification

```
go test ./proxy -count=1     ok  (1.68s)
gofmt -l <both files>        clean
```

One incidental line: `retry_policy_test.go` was pre-existing gofmt-dirty (a comment column in `TestGetProxyMaxChannelRetries`); since this PR edits the file, that one line is now formatted so the file is clean. No other untouched line was reformatted.
