### PR TITLE
test(platform): fold 15 per-adapter PlatformName tests into one registry gate

### DIFF
--- a/platform/antigravity_test.go
+++ b/platform/antigravity_test.go
@@ -32,13 +32,6 @@ func TestAntigravityAdapter_Detect(t *testing.T) {
 	}
 }
 
-func TestAntigravityAdapter_PlatformName(t *testing.T) {
-	a := &AntigravityAdapter{StandardAdapter: NewStandardAdapter("antigravity")}
-	if a.PlatformName() != "antigravity" {
-		t.Errorf("PlatformName: %q", a.PlatformName())
-	}
-}
-
 func TestAntigravityAdapter_LoginUnspported(t *testing.T) {
 	a := &AntigravityAdapter{StandardAdapter: NewStandardAdapter("antigravity")}
 	ctx := context.Background()

--- a/platform/anyrouter_test.go
+++ b/platform/anyrouter_test.go
@@ -8,15 +8,6 @@ import (
 	"time"
 )
 
-func TestAnyRouterAdapter_PlatformName(t *testing.T) {
-	a := &AnyRouterAdapter{
-		NewApiAdapter: &NewApiAdapter{BaseAdapter: NewBaseAdapter("anyrouter")},
-	}
-	if a.PlatformName() != "anyrouter" {
-		t.Errorf("PlatformName: %q", a.PlatformName())
-	}
-}
-
 func TestAnyRouterAdapter_Detect(t *testing.T) {
 	a := &AnyRouterAdapter{
 		NewApiAdapter: &NewApiAdapter{BaseAdapter: NewBaseAdapter("anyrouter")},

--- a/platform/claude_test.go
+++ b/platform/claude_test.go
@@ -32,13 +32,6 @@ func TestClaudeAdapter_Detect(t *testing.T) {
 	}
 }
 
-func TestClaudeAdapter_PlatformName(t *testing.T) {
-	a := &ClaudeAdapter{StandardAdapter: NewStandardAdapter("claude")}
-	if a.PlatformName() != "claude" {
-		t.Errorf("PlatformName: %q", a.PlatformName())
-	}
-}
-
 func TestResolveOpenAICompatibleBaseURL(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/platform/cliproxyapi_test.go
+++ b/platform/cliproxyapi_test.go
@@ -43,17 +43,6 @@ func TestCliProxyApiAdapter_Detect(t *testing.T) {
 	}
 }
 
-func TestCliProxyApiAdapter_PlatformName(t *testing.T) {
-	a := &CliProxyApiAdapter{StandardAdapter: &StandardAdapter{
-		BaseAdapter:               NewBaseAdapter("cliproxyapi"),
-		LoginUnsupportedMessage:   "msg",
-		CheckinUnsupportedMessage: "msg",
-	}}
-	if a.PlatformName() != "cliproxyapi" {
-		t.Errorf("PlatformName: %q", a.PlatformName())
-	}
-}
-
 func TestCliProxyApiAdapter_CustomMessages(t *testing.T) {
 	a := &CliProxyApiAdapter{StandardAdapter: &StandardAdapter{
 		BaseAdapter:               NewBaseAdapter("cliproxyapi"),

--- a/platform/codex_test.go
+++ b/platform/codex_test.go
@@ -32,13 +32,6 @@ func TestCodexAdapter_Detect(t *testing.T) {
 	}
 }
 
-func TestCodexAdapter_PlatformName(t *testing.T) {
-	a := &CodexAdapter{StandardAdapter: &StandardAdapter{BaseAdapter: NewBaseAdapter("codex"), LoginUnsupportedMessage: "codex oauth login is managed via OAuth flow", CheckinUnsupportedMessage: "codex oauth connections do not support checkin"}}
-	if a.PlatformName() != "codex" {
-		t.Errorf("PlatformName: %q", a.PlatformName())
-	}
-}
-
 func TestCodexAdapter_LoginUnspported(t *testing.T) {
 	a := &CodexAdapter{StandardAdapter: &StandardAdapter{BaseAdapter: NewBaseAdapter("codex"), LoginUnsupportedMessage: "codex oauth login is managed via OAuth flow", CheckinUnsupportedMessage: "codex oauth connections do not support checkin"}}
 	ctx := context.Background()

--- a/platform/donehub_test.go
+++ b/platform/donehub_test.go
@@ -9,17 +9,6 @@ import (
 	"time"
 )
 
-func TestDoneHubAdapter_PlatformName(t *testing.T) {
-	d := &DoneHubAdapter{
-		OneHubAdapter: &OneHubAdapter{
-			OneApiAdapter: &OneApiAdapter{BaseAdapter: NewBaseAdapter("done-hub")},
-		},
-	}
-	if d.PlatformName() != "done-hub" {
-		t.Errorf("PlatformName: %q", d.PlatformName())
-	}
-}
-
 func TestDoneHubAdapter_Detect(t *testing.T) {
 	d := &DoneHubAdapter{
 		OneHubAdapter: &OneHubAdapter{

--- a/platform/gemini_cli_test.go
+++ b/platform/gemini_cli_test.go
@@ -34,15 +34,6 @@ func TestGeminiCliAdapter_Detect(t *testing.T) {
 	}
 }
 
-func TestGeminiCliAdapter_PlatformName(t *testing.T) {
-	a := &GeminiCliAdapter{
-		GeminiAdapter: &GeminiAdapter{StandardAdapter: NewStandardAdapter("gemini-cli")},
-	}
-	if a.PlatformName() != "gemini-cli" {
-		t.Errorf("PlatformName: %q", a.PlatformName())
-	}
-}
-
 func TestGeminiCliAdapter_DoesNotMatchGenericGemini(t *testing.T) {
 	// GeminiCliAdapter should NOT match generativelanguage.googleapis.com (only GeminiAdapter does)
 	a := &GeminiCliAdapter{

--- a/platform/gemini_test.go
+++ b/platform/gemini_test.go
@@ -32,13 +32,6 @@ func TestGeminiAdapter_Detect(t *testing.T) {
 	}
 }
 
-func TestGeminiAdapter_PlatformName(t *testing.T) {
-	a := &GeminiAdapter{StandardAdapter: NewStandardAdapter("gemini")}
-	if a.PlatformName() != "gemini" {
-		t.Errorf("PlatformName: %q", a.PlatformName())
-	}
-}
-
 func TestIsOpenAICompatGeminiBase(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/platform/grok_test.go
+++ b/platform/grok_test.go
@@ -16,13 +16,6 @@ func newGrokAdapterForTest() *GrokAdapter {
 	}}
 }
 
-func TestGrokAdapter_PlatformName(t *testing.T) {
-	a := newGrokAdapterForTest()
-	if a.PlatformName() != "grok" {
-		t.Errorf("PlatformName: %q, want %q", a.PlatformName(), "grok")
-	}
-}
-
 func TestGrokAdapter_Detect(t *testing.T) {
 	a := newGrokAdapterForTest()
 	ctx := context.Background()

--- a/platform/newapi_test.go
+++ b/platform/newapi_test.go
@@ -29,13 +29,6 @@ func TestNewApiAdapter_Detect(t *testing.T) {
 	}
 }
 
-func TestNewApiAdapter_PlatformName(t *testing.T) {
-	n := &NewApiAdapter{BaseAdapter: NewBaseAdapter("new-api")}
-	if n.PlatformName() != "new-api" {
-		t.Errorf("PlatformName: %q", n.PlatformName())
-	}
-}
-
 func TestNewApiAdapter_ExtractLikelyUserIDs_RE2Boundaries(t *testing.T) {
 	n := &NewApiAdapter{BaseAdapter: NewBaseAdapter("new-api")}
 	tests := []struct {

--- a/platform/oneapi_test.go
+++ b/platform/oneapi_test.go
@@ -6,13 +6,6 @@ import (
 	"time"
 )
 
-func TestOneApiAdapter_PlatformName(t *testing.T) {
-	o := &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-api")}
-	if o.PlatformName() != "one-api" {
-		t.Errorf("PlatformName: %q", o.PlatformName())
-	}
-}
-
 func TestOneApiAdapter_Detect(t *testing.T) {
 	o := &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-api")}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/platform/onehub_test.go
+++ b/platform/onehub_test.go
@@ -5,15 +5,6 @@ import (
 	"testing"
 )
 
-func TestOneHubAdapter_PlatformName(t *testing.T) {
-	o := &OneHubAdapter{
-		OneApiAdapter: &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-hub")},
-	}
-	if o.PlatformName() != "one-hub" {
-		t.Errorf("PlatformName: %q", o.PlatformName())
-	}
-}
-
 func TestOneHubAdapter_Detect(t *testing.T) {
 	o := &OneHubAdapter{
 		OneApiAdapter: &OneApiAdapter{BaseAdapter: NewBaseAdapter("one-hub")},

--- a/platform/openai_test.go
+++ b/platform/openai_test.go
@@ -33,13 +33,6 @@ func TestOpenAiAdapter_Detect(t *testing.T) {
 	}
 }
 
-func TestOpenAiAdapter_PlatformName(t *testing.T) {
-	a := &OpenAiAdapter{StandardAdapter: NewStandardAdapter("openai")}
-	if a.PlatformName() != "openai" {
-		t.Errorf("PlatformName: %q", a.PlatformName())
-	}
-}
-
 func TestOpenAiAdapter_InheritsStandardDefaults(t *testing.T) {
 	a := &OpenAiAdapter{StandardAdapter: NewStandardAdapter("openai")}
 	ctx := context.Background()

--- a/platform/registry_test.go
+++ b/platform/registry_test.go
@@ -145,3 +145,62 @@ func TestNormalizePlatformAlias_NewApiForks(t *testing.T) {
 		}
 	}
 }
+
+// TestAdapterPlatformNames asserts every registered adapter reports its
+// canonical platform name. Each expectation (wantName) is an explicit literal
+// — never derived from the adapter or the registry — so a production wiring
+// regression fails this test. After the table runs, an anti-shrink cross-check
+// asserts the table's adapter set exactly equals the set the registry exposes
+// (ListAdapters), so adding an adapter without a row (or deleting a row)
+// makes the gate go red.
+func TestAdapterPlatformNames(t *testing.T) {
+	tests := []struct {
+		adapter  PlatformAdapter
+		wantName string
+	}{
+		{adapter: buildAdapter("openai"), wantName: "openai"},
+		{adapter: buildAdapter("codex"), wantName: "codex"},
+		{adapter: buildAdapter("claude"), wantName: "claude"},
+		{adapter: buildAdapter("gemini"), wantName: "gemini"},
+		{adapter: buildAdapter("gemini-cli"), wantName: "gemini-cli"},
+		{adapter: buildAdapter("antigravity"), wantName: "antigravity"},
+		{adapter: buildAdapter("grok"), wantName: "grok"},
+		{adapter: buildAdapter("cliproxyapi"), wantName: "cliproxyapi"},
+		{adapter: buildAdapter("sensetime"), wantName: "sensetime"},
+		{adapter: buildAdapter("anyrouter"), wantName: "anyrouter"},
+		{adapter: buildAdapter("done-hub"), wantName: "done-hub"},
+		{adapter: buildAdapter("one-hub"), wantName: "one-hub"},
+		{adapter: buildAdapter("veloera"), wantName: "veloera"},
+		{adapter: buildAdapter("new-api"), wantName: "new-api"},
+		{adapter: buildAdapter("sub2api"), wantName: "sub2api"},
+		{adapter: buildAdapter("one-api"), wantName: "one-api"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.wantName, func(t *testing.T) {
+			if got := tt.adapter.PlatformName(); got != tt.wantName {
+				t.Errorf("PlatformName() = %q, want %q", got, tt.wantName)
+			}
+		})
+	}
+
+	// Anti-shrink gate: the table must cover exactly the registry's adapters.
+	tableNames := make(map[string]bool, len(tests))
+	for _, tt := range tests {
+		tableNames[tt.wantName] = true
+	}
+	registryNames := make(map[string]bool)
+	for _, a := range ListAdapters() {
+		registryNames[a.PlatformName()] = true
+	}
+	for name := range tableNames {
+		if !registryNames[name] {
+			t.Errorf("table row %q is not exposed by the registry", name)
+		}
+	}
+	for name := range registryNames {
+		if !tableNames[name] {
+			t.Errorf("registry adapter %q is missing from the table", name)
+		}
+	}
+}

--- a/platform/sub2api_test.go
+++ b/platform/sub2api_test.go
@@ -9,13 +9,6 @@ import (
 	"time"
 )
 
-func TestSub2ApiAdapter_PlatformName(t *testing.T) {
-	s := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
-	if s.PlatformName() != "sub2api" {
-		t.Errorf("PlatformName: %q", s.PlatformName())
-	}
-}
-
 func TestSub2ApiAdapter_Detect_URLKeyword(t *testing.T) {
 	s := &Sub2ApiAdapter{BaseAdapter: NewBaseAdapter("sub2api")}
 	ctx := context.Background()

--- a/platform/veloera_test.go
+++ b/platform/veloera_test.go
@@ -6,13 +6,6 @@ import (
 	"time"
 )
 
-func TestVeloeraAdapter_PlatformName(t *testing.T) {
-	v := &VeloeraAdapter{BaseAdapter: NewBaseAdapter("veloera")}
-	if v.PlatformName() != "veloera" {
-		t.Errorf("PlatformName: %q", v.PlatformName())
-	}
-}
-
 func TestVeloeraAdapter_Detect(t *testing.T) {
 	v := &VeloeraAdapter{BaseAdapter: NewBaseAdapter("veloera")}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)


### PR DESCRIPTION
## What

Fifteen per-adapter copies of the same one-assertion test collapse into one table-driven gate in `platform/registry_test.go`. **16 files, +59 / −119 (−60 LOC).**

Every `platform/<x>_test.go` carried its own `Test<Adapter>Adapter_PlatformName` asserting one string. `TestAdapterPlatformNames` now holds all of them as rows, and gains coverage: `sensetime` had no per-file test at all (it was only asserted indirectly via `TestGetAdapter_SenseTime`), so the table covers **16 adapters where 15 were directly asserted before**.

Two properties, deliberately separate:

- **Correctness** — each row's `wantName` is an explicit literal, never derived from the adapter or a registry lookup, so a production rename fails the row. Rows are built with the pre-existing production `buildAdapter(name)` (`platform/registry.go:79`) — no new helper, no new abstraction.
- **Completeness** — after the rows run, an anti-shrink cross-check asserts the table's name set equals the registry's (`ListAdapters()`) in both directions. Adding an adapter without a row fails; deleting a row fails.

## Proof the gate gates — both halves probed

**(a) production rename** (`registry.go`: `NewBaseAdapter("grok")` → `NewBaseAdapter("grokk")`):

```
registry_test.go:182: PlatformName() = "grokk", want "grok"
registry_test.go:198: table row "grok" is not exposed by the registry
registry_test.go:203: registry adapter "grokk" is missing from the table
--- FAIL: TestAdapterPlatformNames/grok (0.00s)
```

**(b) shrink the table** (delete the `grok` row) — proves the anti-shrink half is not decoration:

```
registry_test.go:202: registry adapter "grok" is missing from the table
--- FAIL: TestAdapterPlatformNames (0.00s)
```

Both files restored byte-identical from pre-mutation copies, `sha256sum -c` → `OK` (`registry.go 0f7a9e2f…`, `registry_test.go 706f8f3d…`), suite green again.

## Verification

```
go test ./platform -count=1                        ok  (14.4s)
go test ./platform -run PlatformName -v            TestAdapterPlatformNames: 16 subtests PASS
```

`gofmt -l` still lists `platform/oneapi_test.go`; that file is already gofmt-dirty on master (pre-existing struct-alignment drift, unrelated to the 7 lines removed here) and was deliberately not reformatted.
