### PR TITLE
refactor: delete the dead pricing-override chain and an fmt.Errorf alias

### DIFF
--- a/routing/pricing_cost.go
+++ b/routing/pricing_cost.go
@@ -109,15 +109,6 @@ type UsageForCost struct {
 	PromptTokensIncludeCache *bool
 }
 
-// ProxyBillingPricingOverride supplies ratios from self-log metadata.
-type ProxyBillingPricingOverride struct {
-	ModelRatio         float64
-	CompletionRatio    float64
-	CacheRatio         *float64
-	CacheCreationRatio *float64
-	GroupRatio         *float64
-}
-
 // ProxyBillingDetails mirrors the TS ProxyBillingDetails shape (camelCase JSON).
 type ProxyBillingDetails struct {
 	QuotaType int                    `json:"quotaType"`
@@ -201,26 +192,6 @@ func ResolveCacheCreationRatio(modelName string, cacheCreationRatio *float64) fl
 		return *cacheCreationRatio
 	}
 	return DefaultCacheCreationRatioForModel(modelName)
-}
-
-// NormalizePricingRatio normalizes a raw ratio from an upstream pricing JSON
-// field. Missing/NaN/negative values fall back using the model-family default
-// selected by kind ("cache" | "cache_creation" | other→fallback).
-func NormalizePricingRatio(value any, modelName, kind string, fallback float64) float64 {
-	if n, ok := asFiniteNumber(value); ok && n >= 0 {
-		return n
-	}
-	switch kind {
-	case "cache":
-		return DefaultCacheRatioForModel(modelName)
-	case "cache_creation":
-		return DefaultCacheCreationRatioForModel(modelName)
-	default:
-		if isFiniteNonNeg(fallback) {
-			return fallback
-		}
-		return 1
-	}
 }
 
 // CalculateModelUsageBreakdown computes token-based billing details.
@@ -374,46 +345,6 @@ func CalculateModelUsageCost(
 	return detail.Breakdown.TotalCost
 }
 
-// EstimateProxyCostFromModel is a pure cost estimate given an already-resolved
-// pricing model (catalog row or self-log override). Prefer this over inventing
-// prices when the catalog is unavailable — callers should use FallbackTokenCost.
-func EstimateProxyCostFromModel(model PricingModel, usage UsageForCost, groupRatio map[string]float64) float64 {
-	return CalculateModelUsageCost(model, usage, groupRatio)
-}
-
-// BuildPricingOverrideModel builds a token-quota PricingModel from self-log
-// billing metadata. Missing Claude cache ratios receive Anthropic defaults.
-func BuildPricingOverrideModel(modelName string, override ProxyBillingPricingOverride) (PricingModel, map[string]float64) {
-	group := 1.0
-	if override.GroupRatio != nil && isFiniteNonNeg(*override.GroupRatio) && *override.GroupRatio > 0 {
-		group = *override.GroupRatio
-	}
-
-	modelRatio := override.ModelRatio
-	if modelRatio <= 0 || !isFiniteFloat(modelRatio) {
-		modelRatio = 1
-	}
-	completionRatio := override.CompletionRatio
-	if completionRatio <= 0 || !isFiniteFloat(completionRatio) {
-		completionRatio = 1
-	}
-
-	// Materialize resolved ratios so billing_details always shows the applied
-	// values (including Claude-aware fallbacks when the override omitted them).
-	cacheRatio := ResolveCacheRatio(modelName, override.CacheRatio)
-	cacheCreationRatio := ResolveCacheCreationRatio(modelName, override.CacheCreationRatio)
-
-	return PricingModel{
-		ModelName:          modelName,
-		QuotaType:          0,
-		ModelRatio:         modelRatio,
-		CompletionRatio:    completionRatio,
-		CacheRatio:         &cacheRatio,
-		CacheCreationRatio: &cacheCreationRatio,
-		EnableGroups:       []string{"default"},
-	}, map[string]float64{"default": group}
-}
-
 // FallbackTokenCost is the last-resort estimate when no pricing catalog is
 // available. Mirrors TS fallbackTokenCost (veloera uses 1e6 divisor, others 5e5).
 func FallbackTokenCost(totalTokens int64, platform string) float64 {
@@ -551,38 +482,6 @@ func toPositiveInt64(v int64) int64 {
 
 func isFiniteNonNeg(v float64) bool {
 	return isFiniteFloat(v) && v >= 0
-}
-
-func asFiniteNumber(value any) (float64, bool) {
-	switch n := value.(type) {
-	case float64:
-		if isFiniteFloat(n) {
-			return n, true
-		}
-	case float32:
-		f := float64(n)
-		if isFiniteFloat(f) {
-			return f, true
-		}
-	case int:
-		return float64(n), true
-	case int64:
-		return float64(n), true
-	case int32:
-		return float64(n), true
-	case jsonNumber:
-		f, err := n.Float64()
-		if err == nil && isFiniteFloat(f) {
-			return f, true
-		}
-	}
-	return 0, false
-}
-
-// jsonNumber is satisfied by encoding/json.Number without importing encoding/json
-// into every call site of asFiniteNumber.
-type jsonNumber interface {
-	Float64() (float64, error)
 }
 
 func containsString(items []string, target string) bool {

--- a/routing/pricing_cost_test.go
+++ b/routing/pricing_cost_test.go
@@ -73,24 +73,6 @@ func TestResolveCacheRatio_ExplicitPresentWins(t *testing.T) {
 	}
 }
 
-func TestNormalizePricingRatio_KindAware(t *testing.T) {
-	// Missing cache fields on Claude → Anthropic defaults.
-	if got := NormalizePricingRatio(nil, "claude-opus-4-7", "cache", 1); got != ClaudeCacheRatio {
-		t.Fatalf("cache kind: got %v", got)
-	}
-	if got := NormalizePricingRatio(nil, "claude-opus-4-7", "cache_creation", 1); got != ClaudeCacheCreationRatio {
-		t.Fatalf("cache_creation kind: got %v", got)
-	}
-	// Present value wins.
-	if got := NormalizePricingRatio(0.05, "claude-opus-4-7", "cache", 1); got != 0.05 {
-		t.Fatalf("present cache ratio: got %v", got)
-	}
-	// Non-Claude missing → 1.0
-	if got := NormalizePricingRatio(nil, "gpt-4o", "cache", 1); got != 1 {
-		t.Fatalf("non-claude missing: got %v", got)
-	}
-}
-
 func TestCalculateModelUsageBreakdown_WithExplicitCacheRatio(t *testing.T) {
 	// Mirrors TS modelPricingService.test.ts "splits cache read and cache creation"
 	model := PricingModel{
@@ -265,31 +247,6 @@ func TestCalculateModelUsageCost_ZeroCacheRatio(t *testing.T) {
 	if detail.Breakdown.TotalCost != 0 {
 		// billable prompt = 0, cache cost = 0
 		t.Fatalf("totalCost=%v want 0", detail.Breakdown.TotalCost)
-	}
-}
-
-func TestBuildPricingOverrideModel_ClaudeMissingCache(t *testing.T) {
-	model, groups := BuildPricingOverrideModel("claude-haiku-4-5", ProxyBillingPricingOverride{
-		ModelRatio:      2.5,
-		CompletionRatio: 5,
-		// CacheRatio / CacheCreationRatio omitted
-	})
-	if model.CacheRatio == nil || *model.CacheRatio != ClaudeCacheRatio {
-		t.Fatalf("override cacheRatio=%v want %v", model.CacheRatio, ClaudeCacheRatio)
-	}
-	if model.CacheCreationRatio == nil || *model.CacheCreationRatio != ClaudeCacheCreationRatio {
-		t.Fatalf("override cacheCreationRatio=%v want %v", model.CacheCreationRatio, ClaudeCacheCreationRatio)
-	}
-	cost := CalculateModelUsageCost(model, UsageForCost{
-		PromptTokens:             146638,
-		CompletionTokens:         172,
-		TotalTokens:              146810,
-		CacheReadTokens:          145692,
-		CacheCreationTokens:      945,
-		PromptTokensIncludeCache: boolPtr(true),
-	}, groups)
-	if math.Abs(cost-0.083057) > 1e-9 {
-		t.Fatalf("override cost=%v want 0.083057", cost)
 	}
 }
 
@@ -470,24 +427,6 @@ func TestCalculateModelUsageFullPrice_NoCacheMatchesBreakdownMath(t *testing.T) 
 	}
 	if fullPrice.Breakdown.OutputCost != breakdown.Breakdown.OutputCost {
 		t.Fatalf("outputCost fullPrice=%v breakdown=%v", fullPrice.Breakdown.OutputCost, breakdown.Breakdown.OutputCost)
-	}
-}
-
-func TestEstimateProxyCostFromModel_MatchesCalculateModelUsageCost(t *testing.T) {
-	// EstimateProxyCostFromModel is a thin alias over CalculateModelUsageCost;
-	// pin the equivalence so the public entry point cannot drift from the
-	// canonical math.
-	model := PricingModel{ModelName: "probe-estimate", QuotaType: 0, ModelRatio: 2, CompletionRatio: 6}
-	usage := UsageForCost{PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500}
-	groupRatio := map[string]float64{"default": 1.5}
-
-	got := EstimateProxyCostFromModel(model, usage, groupRatio)
-	want := CalculateModelUsageCost(model, usage, groupRatio)
-	if got != want {
-		t.Fatalf("EstimateProxyCostFromModel = %v, want %v (alias must match)", got, want)
-	}
-	if got <= 0 {
-		t.Fatalf("expected a positive cost, got %v", got)
 	}
 }
 

--- a/scheduler/balance.go
+++ b/scheduler/balance.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/deliciousbuding/metapi-go/config"
@@ -63,7 +64,7 @@ func (s *BalanceScheduler) Stop() error {
 // UpdateCron updates the cron expression at runtime.
 func (s *BalanceScheduler) UpdateCron(cronExpr string) error {
 	if !ValidateCronExpr(cronExpr) {
-		return formatErr("invalid cron expression: %s", cronExpr)
+		return fmt.Errorf("invalid cron expression: %s", cronExpr)
 	}
 	config.UpdateRuntime(func(r *config.RuntimeSettings) { r.BalanceRefreshCron = cronExpr })
 	if s.cronRunner != nil {

--- a/scheduler/checkin.go
+++ b/scheduler/checkin.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -325,13 +326,13 @@ func (s *CheckinScheduler) stopLocked() {
 func (s *CheckinScheduler) UpdateCheckinSchedule(mode, cronExpr string, intervalHours int, windowStart, windowEnd string) error {
 	mode = stringsTrimLower(mode)
 	if mode != "cron" && mode != "interval" && mode != "window" {
-		return formatErr("invalid checkin schedule mode: %s", mode)
+		return fmt.Errorf("invalid checkin schedule mode: %s", mode)
 	}
 	if mode == "cron" && !ValidateCronExpr(cronExpr) {
-		return formatErr("invalid cron expression: %s", cronExpr)
+		return fmt.Errorf("invalid cron expression: %s", cronExpr)
 	}
 	if mode == "interval" && (intervalHours < 1 || intervalHours > 24) {
-		return formatErr("invalid interval hours: %d (must be 1-24)", intervalHours)
+		return fmt.Errorf("invalid interval hours: %d (must be 1-24)", intervalHours)
 	}
 	if mode == "window" {
 		if _, err := RandomCronInWindow(windowStart, windowEnd); err != nil {

--- a/scheduler/helpers.go
+++ b/scheduler/helpers.go
@@ -1,7 +1,6 @@
 package scheduler
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -12,9 +11,4 @@ func stringsTrimLower(s string) string {
 		return "active"
 	}
 	return strings.ToLower(t)
-}
-
-// formatErr is a shorthand for fmt.Errorf.
-func formatErr(f string, args ...any) error {
-	return fmt.Errorf(f, args...)
 }

--- a/scheduler/log_cleanup.go
+++ b/scheduler/log_cleanup.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -71,7 +72,7 @@ func (s *LogCleanupScheduler) Stop() error {
 
 func (s *LogCleanupScheduler) UpdateSettings(cronExpr string, usageEnabled, programEnabled bool, retentionDays int) error {
 	if !ValidateCronExpr(cronExpr) {
-		return formatErr("invalid cron expression: %s", cronExpr)
+		return fmt.Errorf("invalid cron expression: %s", cronExpr)
 	}
 
 	clamped := config.ClampInt(retentionDays, 1, 3650)

--- a/scheduler/model_sync.go
+++ b/scheduler/model_sync.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/deliciousbuding/metapi-go/config"
@@ -56,7 +57,7 @@ func (s *ModelSyncScheduler) Stop() error {
 // UpdateCron updates the cron expression at runtime.
 func (s *ModelSyncScheduler) UpdateCron(cronExpr string) error {
 	if !ValidateCronExpr(cronExpr) {
-		return formatErr("invalid cron expression: %s", cronExpr)
+		return fmt.Errorf("invalid cron expression: %s", cronExpr)
 	}
 	config.UpdateRuntime(func(r *config.RuntimeSettings) { r.ModelSyncCron = cronExpr })
 	if s.cronRunner != nil {

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -319,16 +319,6 @@ func TestStringsTrimLower(t *testing.T) {
 	}
 }
 
-func TestFormatErr(t *testing.T) {
-	err := formatErr("invalid value: %d", 42)
-	if err == nil {
-		t.Fatal("expected non-nil error")
-	}
-	if err.Error() != "invalid value: 42" {
-		t.Errorf("unexpected error message: %s", err.Error())
-	}
-}
-
 func TestMaxInt(t *testing.T) {
 	tests := []struct {
 		a, b, expected int


### PR DESCRIPTION
## What

Two indirections with nothing on the other side. **8 files, +10 / −184.**

### 1. The dead pricing-override chain (`routing/pricing_cost.go`)

| symbol | non-test references on master |
|---|---|
| `NormalizePricingRatio` | its own definition + its own doc comment |
| `EstimateProxyCostFromModel` | its own definition + its own doc comment |
| `BuildPricingOverrideModel` | its own definition + its own doc comment |
| `asFiniteNumber` | one call — from `NormalizePricingRatio` |
| `jsonNumber` (interface) | one type-switch case — in `asFiniteNumber` |
| `ProxyBillingPricingOverride` (struct) | one parameter — of `BuildPricingOverrideModel` |

So the three exported functions are unreachable, and the three private symbols are reachable only *through* them. All six go.

`jsonNumber`'s own comment claimed it existed to avoid "importing encoding/json into every call site of asFiniteNumber" — an import lives in one file, not in call sites, so it bought nothing. It is moot regardless: `UseNumber()` is called in exactly one place repo-wide (`handler/admin/site_announcements.go`), so no `json.Number` could ever reach that type switch.

Three tests went with the code they exercised. `TestEstimateProxyCostFromModel_MatchesCalculateModelUsageCost` asserted that an alias returns what the thing it aliases returns — its own comment read *"EstimateProxyCostFromModel is a thin alias over CalculateModelUsageCost"*.

The surviving pricing API is untouched and still covered: `FallbackTokenCost`, `CalculateModelUsage{Breakdown,FullPrice,Cost}`, `ResolveCacheRatio`, `ResolveCacheCreationRatio`, `DefaultCacheRatioForModel`, `DefaultCacheCreationRatioForModel`, `SetCacheRatioDefaults`, `IsClaudeModel`, `CacheAwarePerMillionRates`, `isFiniteNonNeg`, `containsString`.

### 2. `formatErr` (`scheduler/helpers.go`)

```go
// formatErr is a shorthand for fmt.Errorf.
func formatErr(f string, args ...any) error { return fmt.Errorf(f, args...) }
```

Six call sites (`balance.go`, `checkin.go` ×3, `log_cleanup.go`, `model_sync.go`) now call `fmt.Errorf` directly; `TestFormatErr`, which tested the wrapper, goes with it. `helpers.go` keeps `stringsTrimLower` — real logic (trim + lowercase + `"active"` default) with two production callers.

## Verification

```
go build ./...                                   ok
go test ./routing/... ./scheduler/... -count=1   ok  (routing 3.8s, scheduler 16.9s)
gofmt -l <touched files>                         no new hunks
```

`routing/pricing_cost.go` carries pre-existing gofmt alignment drift (a `var` block and a struct field block). This commit adds no new gofmt hunks — verified by diffing `gofmt -d` output for this branch's file against master's; both produce the same hunks. Untouched lines were not reformatted.

No dangling references remain: `grep -rn` for all six deleted symbols across `*.go`, `*.md`, `*.ts`, `*.tsx`, `*.json` returns only an unrelated test-case *label* (`"seconds jsonNumber"` in `service/account_extra_config_test.go`, which uses the stdlib `json.Number`).
