### PR TITLE
test(admin): fold 18 error-path tests into two data-row tables

### DIFF
--- a/handler/admin/account_tokens_test.go
+++ b/handler/admin/account_tokens_test.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
@@ -513,24 +514,6 @@ func TestTokens_Create_Local_WithGroup(t *testing.T) {
 	}
 }
 
-func TestTokens_Create_InvalidAccountID(t *testing.T) {
-	_, r := setupTokensTest(t)
-	body := map[string]any{"accountId": 0, "token": "sk-test"}
-	resp := doPostJSON(t, r, "/api/account-tokens", body)
-	if resp.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", resp.Code)
-	}
-}
-
-func TestTokens_Create_AccountNotFound(t *testing.T) {
-	_, r := setupTokensTest(t)
-	body := map[string]any{"accountId": 99999, "token": "sk-test"}
-	resp := doPostJSON(t, r, "/api/account-tokens", body)
-	if resp.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", resp.Code)
-	}
-}
-
 func TestTokens_Create_Upstream_APIKeyConnection(t *testing.T) {
 	db, r := setupTokensTest(t)
 	site := newSiteFixture(t, r, "AKCSite", "https://api.openai.com")
@@ -658,24 +641,6 @@ func TestTokens_Batch_MaskedPending_Enable(t *testing.T) {
 	}
 }
 
-func TestTokens_Batch_EmptyIDs(t *testing.T) {
-	_, r := setupTokensTest(t)
-	body := map[string]any{"ids": []int{}, "action": "enable"}
-	resp := doPostJSON(t, r, "/api/account-tokens/batch", body)
-	if resp.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", resp.Code)
-	}
-}
-
-func TestTokens_Batch_InvalidAction(t *testing.T) {
-	_, r := setupTokensTest(t)
-	body := map[string]any{"ids": []int{1}, "action": "reload"}
-	resp := doPostJSON(t, r, "/api/account-tokens/batch", body)
-	if resp.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", resp.Code)
-	}
-}
-
 func TestTokens_Batch_NestedAPIKeyConnection(t *testing.T) {
 	db, r := setupTokensTest(t)
 	site := newSiteFixture(t, r, "BatchAPIConn", "https://api.openai.com")
@@ -760,27 +725,6 @@ func TestTokens_Update_MaskedToken(t *testing.T) {
 	}
 }
 
-func TestTokens_Update_NotFound(t *testing.T) {
-	_, r := setupTokensTest(t)
-	body := map[string]any{"name": "ghost"}
-	resp := doPutJSON(t, r, "/api/account-tokens/99999", body)
-	if resp.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", resp.Code)
-	}
-}
-
-func TestTokens_Update_EmptyToken(t *testing.T) {
-	db, r := setupTokensTest(t)
-	_, accountID := tokenFixture(t, db, r)
-	tokID := createTokenFixture(t, db, accountID, "t1", "sk-old", "", true, false)
-
-	body := map[string]any{"token": ""}
-	resp := doPutJSON(t, r, "/api/account-tokens/"+itoa(tokID), body)
-	if resp.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", resp.Code)
-	}
-}
-
 // ---- Set Default ----
 
 func TestTokens_SetDefault(t *testing.T) {
@@ -808,14 +752,6 @@ func TestTokens_SetDefault_MaskedPending(t *testing.T) {
 	resp := doPostJSON(t, r, "/api/account-tokens/"+itoa(tokID)+"/default", nil)
 	if resp.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for masked default, got %d", resp.Code)
-	}
-}
-
-func TestTokens_SetDefault_NotFound(t *testing.T) {
-	_, r := setupTokensTest(t)
-	resp := doPostJSON(t, r, "/api/account-tokens/99999/default", nil)
-	if resp.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", resp.Code)
 	}
 }
 
@@ -918,14 +854,6 @@ func TestTokens_Delete_DefaultRepair(t *testing.T) {
 	}
 }
 
-func TestTokens_Delete_NotFound(t *testing.T) {
-	_, r := setupTokensTest(t)
-	resp := doDelete(t, r, "/api/account-tokens/99999")
-	if resp.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", resp.Code)
-	}
-}
-
 // ---- Sync Account ----
 
 func TestTokens_SyncAccount(t *testing.T) {
@@ -948,14 +876,6 @@ func TestTokens_SyncAccount(t *testing.T) {
 	}
 	if result["reason"] != "no_upstream_tokens" && result["reason"] != "unsupported_platform" {
 		t.Errorf("expected skip reason no_upstream_tokens/unsupported_platform, got %v", result["reason"])
-	}
-}
-
-func TestTokens_SyncAccount_NotFound(t *testing.T) {
-	_, r := setupTokensTest(t)
-	resp := doPostJSON(t, r, "/api/account-tokens/sync/99999", nil)
-	if resp.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", resp.Code)
 	}
 }
 
@@ -1122,6 +1042,53 @@ func TestTokens_GetAccountDefault_NotFound(t *testing.T) {
 	json.Unmarshal(resp.Body.Bytes(), &result)
 	if result["token"] != nil {
 		t.Error("expected token=nil for non-existent account")
+	}
+}
+
+// ---- Error status codes ----
+
+func TestTokens_ErrorStatusCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		seed       string
+		method     string
+		path       string
+		body       any
+		wantStatus int
+	}{
+		{name: "Create_InvalidAccountID", method: http.MethodPost, path: "/api/account-tokens", body: map[string]any{"accountId": 0, "token": "sk-test"}, wantStatus: http.StatusBadRequest},
+		{name: "Create_AccountNotFound", method: http.MethodPost, path: "/api/account-tokens", body: map[string]any{"accountId": 99999, "token": "sk-test"}, wantStatus: http.StatusNotFound},
+		{name: "Update_NotFound", method: http.MethodPut, path: "/api/account-tokens/99999", body: map[string]any{"name": "ghost"}, wantStatus: http.StatusNotFound},
+		{name: "Update_EmptyToken", seed: "existing-token", method: http.MethodPut, path: "/api/account-tokens/{id}", body: map[string]any{"token": ""}, wantStatus: http.StatusBadRequest},
+		{name: "SetDefault_NotFound", method: http.MethodPost, path: "/api/account-tokens/99999/default", wantStatus: http.StatusNotFound},
+		{name: "Delete_NotFound", method: http.MethodDelete, path: "/api/account-tokens/99999", wantStatus: http.StatusNotFound},
+		{name: "SyncAccount_NotFound", method: http.MethodPost, path: "/api/account-tokens/sync/99999", wantStatus: http.StatusNotFound},
+		{name: "Batch_EmptyIDs", method: http.MethodPost, path: "/api/account-tokens/batch", body: map[string]any{"ids": []int{}, "action": "enable"}, wantStatus: http.StatusBadRequest},
+		{name: "Batch_InvalidAction", method: http.MethodPost, path: "/api/account-tokens/batch", body: map[string]any{"ids": []int{1}, "action": "reload"}, wantStatus: http.StatusBadRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, r := setupTokensTest(t)
+			path := tt.path
+			switch tt.seed {
+			case "existing-token":
+				_, accountID := tokenFixture(t, db, r)
+				tokID := createTokenFixture(t, db, accountID, "t1", "sk-old", "", true, false)
+				path = strings.ReplaceAll(path, "{id}", itoa(tokID))
+			}
+			var resp *httptest.ResponseRecorder
+			switch tt.method {
+			case http.MethodDelete:
+				resp = doDelete(t, r, path)
+			case http.MethodPost:
+				resp = doPostJSON(t, r, path, tt.body)
+			case http.MethodPut:
+				resp = doPutJSON(t, r, path, tt.body)
+			}
+			if resp.Code != tt.wantStatus {
+				t.Fatalf("expected %d, got %d", tt.wantStatus, resp.Code)
+			}
+		})
 	}
 }
 

--- a/handler/admin/sites_test.go
+++ b/handler/admin/sites_test.go
@@ -300,52 +300,6 @@ func TestSites_Postgres_CreateUpdateAndDisabledModels(t *testing.T) {
 	}
 }
 
-func TestSites_Create_Duplicate(t *testing.T) {
-	_, r := setupSitesTest(t)
-	newSiteFixture(t, r, "Site1", "https://api.openai.com")
-
-	body := map[string]any{
-		"name": "Site2",
-		"url":  "https://api.openai.com",
-	}
-	resp := doPostJSON(t, r, "/api/sites", body)
-	if resp.Code != http.StatusConflict {
-		t.Fatalf("expected 409 conflict, got %d: %s", resp.Code, resp.Body.String())
-	}
-	var err map[string]string
-	json.Unmarshal(resp.Body.Bytes(), &err)
-	if !strings.Contains(err["error"], "already exists") {
-		t.Errorf("expected 'already exists' in error, got %q", err["error"])
-	}
-}
-
-func TestSites_Create_EmptyName(t *testing.T) {
-	_, r := setupSitesTest(t)
-	body := map[string]any{"name": "  ", "url": "https://api.openai.com"}
-	resp := doPostJSON(t, r, "/api/sites", body)
-	if resp.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", resp.Code)
-	}
-}
-
-func TestSites_Create_EmptyURL(t *testing.T) {
-	_, r := setupSitesTest(t)
-	body := map[string]any{"name": "Test", "url": ""}
-	resp := doPostJSON(t, r, "/api/sites", body)
-	if resp.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", resp.Code)
-	}
-}
-
-func TestSites_CannotDetectPlatform(t *testing.T) {
-	_, r := setupSitesTest(t)
-	body := map[string]any{"name": "Unknown", "url": "https://completely-unknown-llm.example.com"}
-	resp := doPostJSON(t, r, "/api/sites", body)
-	if resp.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for undetectable platform, got %d: %s", resp.Code, resp.Body.String())
-	}
-}
-
 func TestSites_CreateDetectsAnyRouter(t *testing.T) {
 	_, r := setupSitesTest(t)
 	body := map[string]any{
@@ -430,15 +384,6 @@ func TestSites_Update(t *testing.T) {
 	}
 }
 
-func TestSites_Update_NotFound(t *testing.T) {
-	_, r := setupSitesTest(t)
-	body := map[string]any{"name": "Ghost"}
-	resp := doPutJSON(t, r, "/api/sites/99999", body)
-	if resp.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", resp.Code)
-	}
-}
-
 func TestSites_Update_APIEndpointsFullReplace(t *testing.T) {
 	_, r := setupSitesTest(t)
 	site := newSiteFixture(t, r, "EPSite", "https://api.openai.com")
@@ -471,18 +416,6 @@ func TestSites_Update_APIEndpointsFullReplace(t *testing.T) {
 	eps, _ := updated["apiEndpoints"].([]any)
 	if len(eps) != 1 {
 		t.Errorf("expected 1 endpoint after full replace, got %d", len(eps))
-	}
-}
-
-func TestSites_Update_InvalidStatus(t *testing.T) {
-	_, r := setupSitesTest(t)
-	site := newSiteFixture(t, r, "StatusTest", "https://api.openai.com")
-	siteID := int64(site["id"].(float64))
-
-	body := map[string]any{"status": "invalid-status"}
-	resp := doPutJSON(t, r, "/api/sites/"+itoa(siteID), body)
-	if resp.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", resp.Code, resp.Body.String())
 	}
 }
 
@@ -573,15 +506,6 @@ func TestSites_Detect_Unknown(t *testing.T) {
 	}
 }
 
-func TestSites_Detect_EmptyURL(t *testing.T) {
-	_, r := setupSitesTest(t)
-	body := map[string]string{"url": ""}
-	resp := doPostJSON(t, r, "/api/sites/detect", body)
-	if resp.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", resp.Code)
-	}
-}
-
 // ---- Disabled Models Tests ----
 
 func TestSites_DisabledModels_CRUD(t *testing.T) {
@@ -653,14 +577,6 @@ func TestSites_DisabledModels_Deduplication(t *testing.T) {
 	}
 }
 
-func TestSites_DisabledModels_NotFound(t *testing.T) {
-	_, r := setupSitesTest(t)
-	resp := doGet(t, r, "/api/sites/99999/disabled-models")
-	if resp.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", resp.Code)
-	}
-}
-
 // ---- Available Models Tests ----
 
 func TestSites_AvailableModels_Empty(t *testing.T) {
@@ -724,14 +640,6 @@ func TestSites_ProbeNow(t *testing.T) {
 	json.Unmarshal(resp.Body.Bytes(), &result)
 	if result["success"] != true {
 		t.Errorf("expected success=true, got %v", result["success"])
-	}
-}
-
-func TestSites_ProbeNow_InvalidID(t *testing.T) {
-	_, r := setupSitesTest(t)
-	resp := doPostJSON(t, r, "/api/sites/not-a-number/probe-now", map[string]any{})
-	if resp.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d", resp.Code)
 	}
 }
 
@@ -1146,6 +1054,64 @@ func itoa(i int64) string {
 		return "0"
 	}
 	return s
+}
+
+// ---- Error status codes ----
+
+func TestSites_ErrorStatusCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		seed       string
+		method     string
+		path       string
+		body       any
+		wantStatus int
+		wantErr    string
+	}{
+		{name: "Create_Duplicate", seed: "duplicate-site", method: http.MethodPost, path: "/api/sites", body: map[string]any{"name": "Site2", "url": "https://api.openai.com"}, wantStatus: http.StatusConflict, wantErr: "already exists"},
+		{name: "Create_EmptyName", method: http.MethodPost, path: "/api/sites", body: map[string]any{"name": "  ", "url": "https://api.openai.com"}, wantStatus: http.StatusBadRequest},
+		{name: "Create_EmptyURL", method: http.MethodPost, path: "/api/sites", body: map[string]any{"name": "Test", "url": ""}, wantStatus: http.StatusBadRequest},
+		{name: "CannotDetectPlatform", method: http.MethodPost, path: "/api/sites", body: map[string]any{"name": "Unknown", "url": "https://completely-unknown-llm.example.com"}, wantStatus: http.StatusBadRequest},
+		{name: "Update_NotFound", method: http.MethodPut, path: "/api/sites/99999", body: map[string]any{"name": "Ghost"}, wantStatus: http.StatusNotFound},
+		{name: "Update_InvalidStatus", seed: "existing-site", method: http.MethodPut, path: "/api/sites/{id}", body: map[string]any{"status": "invalid-status"}, wantStatus: http.StatusBadRequest},
+		{name: "DisabledModels_NotFound", method: http.MethodGet, path: "/api/sites/99999/disabled-models", wantStatus: http.StatusNotFound},
+		{name: "ProbeNow_InvalidID", method: http.MethodPost, path: "/api/sites/not-a-number/probe-now", body: map[string]any{}, wantStatus: http.StatusBadRequest},
+		{name: "Detect_EmptyURL", method: http.MethodPost, path: "/api/sites/detect", body: map[string]string{"url": ""}, wantStatus: http.StatusBadRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, r := setupSitesTest(t)
+			path := tt.path
+			switch tt.seed {
+			case "duplicate-site":
+				newSiteFixture(t, r, "Site1", "https://api.openai.com")
+			case "existing-site":
+				site := newSiteFixture(t, r, "StatusTest", "https://api.openai.com")
+				path = strings.ReplaceAll(path, "{id}", itoa(int64(site["id"].(float64))))
+			}
+			var resp *httptest.ResponseRecorder
+			switch tt.method {
+			case http.MethodGet:
+				resp = doGet(t, r, path)
+			case http.MethodDelete:
+				resp = doDelete(t, r, path)
+			case http.MethodPost:
+				resp = doPostJSON(t, r, path, tt.body)
+			case http.MethodPut:
+				resp = doPutJSON(t, r, path, tt.body)
+			}
+			if resp.Code != tt.wantStatus {
+				t.Fatalf("expected %d, got %d: %s", tt.wantStatus, resp.Code, resp.Body.String())
+			}
+			if tt.wantErr != "" {
+				var err map[string]string
+				json.Unmarshal(resp.Body.Bytes(), &err)
+				if !strings.Contains(err["error"], tt.wantErr) {
+					t.Errorf("expected %q in error, got %q", tt.wantErr, err["error"])
+				}
+			}
+		})
+	}
 }
 
 func TestSites_MaxConcurrencyRoundTrip(t *testing.T) {


### PR DESCRIPTION
## What

Eighteen near-identical error-path tests in `handler/admin` — each "seed a DB, fire one request, assert a status code" — become **two data-row tables**. **2 files, +106 / −173 (−67 LOC)**, 18 scenarios → 18 subtests, names preserved (`TestSites_ErrorStatusCodes/Create_EmptyName` etc.).

| file | deleted funcs | new table | rows |
|---|---|---|---|
| `handler/admin/sites_test.go` | 9 (`Create_Duplicate`, `Create_EmptyName`, `Create_EmptyURL`, `CannotDetectPlatform`, `Update_NotFound`, `Update_InvalidStatus`, `DisabledModels_NotFound`, `ProbeNow_InvalidID`, `Detect_EmptyURL`) | `TestSites_ErrorStatusCodes` | 9 |
| `handler/admin/account_tokens_test.go` | 9 (`Create_InvalidAccountID`, `Create_AccountNotFound`, `Update_NotFound`, `Update_EmptyToken`, `SetDefault_NotFound`, `Delete_NotFound`, `SyncAccount_NotFound`, `Batch_EmptyIDs`, `Batch_InvalidAction`) | `TestTokens_ErrorStatusCodes` | 9 |

Rows are **pure data** — `{name, seed, method, path, body, wantStatus, wantErr}` — with one loop body that seeds, substitutes `{id}`, dispatches on method to the existing `doGet`/`doPostJSON`/`doPutJSON`/`doDelete` helpers, and asserts. No closures per row, no new helper, no harness: this matches the table style already merged in #1189 (accounts), #1202 (proxy) and #1203 (platform).

Message fragments survive where they existed (`Create_Duplicate` still asserts `"already exists"` via `wantErr`). Postgres twins are untouched on purpose — they use a different dialect harness, and mixing SQLite rows into them would blur which dialect a failure came from.

## Proof the gate gates

Two mutation probes, one per file, each flipping a production validation status:

- `handler/admin/sites.go`, empty-name validation 400 → 404:
  ```
  sites_test.go:1111: expected 400, got 404: {"error":"Invalid name. Expected non-empty string."}
  --- FAIL: TestSites_ErrorStatusCodes/Create_EmptyName
  ```
- `handler/admin/account_tokens.go`, batch invalid-action 400 → 404:
  ```
  account_tokens_test.go:1097: expected 400, got 404
  --- FAIL: TestTokens_ErrorStatusCodes/Batch_InvalidAction
  ```

Both production files restored byte-identical from pre-mutation copies, `sha256sum -c` → `OK`. (Probing with 200 instead of 404 does not work here: `shared.WriteAPIError` coerces any status < 400 to 400, so the mutation would have been invisible — 404 is a genuine behaviour change.)

## Verification

```
go test ./handler/admin -count=1     ok  (41.5s)
gofmt: no new hunks
```

`handler/admin/account_tokens_test.go` is gofmt-dirty on master already (one import-ordering hunk); `gofmt -d` produces exactly one hunk for both master's copy and this branch's, i.e. no new dirt was added and unrelated lines were not reformatted.
