### PR TITLE
docs: stop hardcoding counts in the structure map that this wave falsified

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,14 +25,14 @@ Go rewrite of [Metapi](https://github.com/cita-777/metapi). Feature parity with 
 cmd/server/main.go      Entry point
 cmd/migrate/main.go     SQLite→PG migration tool
 config/                 env map → Config（完整变量清单见 docs/deployment.md + .env.example）
-store/                  DB layer (35 tables, sqlx; schema DDL in store/schema_ddl.go)
+store/                  DB layer (sqlx; table registry = store/tablesets.go, DDL = store/schema_ddl.go)
 auth/                   Admin + proxy auth + rate limiting
 routing/                TokenRouter (weighted random + Fibonacci cooldown + runtime breaker)
 proxy/                  转发编排（coordinator / executor / channel selection / retry policy）
-platform/               16 upstream adapters
+platform/               upstream adapters (registry = platform/registry.go)
 transform/              协议转换（openai completions/embeddings/images/responses + gemini + shared）
 service/                Domain workflows (sites/accounts/checkin/balance/notify/oauth/backup/pricing)
-scheduler/              16 background jobs
+scheduler/              background jobs (registered in app/services.go)
 handler/admin/          admin REST registrars（端点清单见 docs/api.md）
 handler/proxy/          proxy routes (OpenAI, Gemini, Claude, Codex, Files)
 web/dist/               Pre-built React SPA (embedded)

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,6 @@ migrate-build:
 clean:
 	rm -f metapi metapi.exe metapi-migrate metapi-migrate.exe
 	rm -rf web/dist
-	rm -rf electron/metapi electron/metapi.exe electron/dist electron/node_modules
 
 cascade-e2e:
 	go test ./e2e -count=1 -run 'CascadeIsolation' -timeout 60s


### PR DESCRIPTION
## What

The v0.18.0 reduction wave deleted four tables and three schedulers; `AGENTS.md`'s structure map still asserted the pre-deletion numbers.

| line said | reality on master |
|---|---|
| `store/ … (35 tables, …)` | the registry declares **33** (`store/tablesets.go`, pinned by `TestTableCount`) |
| `scheduler/ 16 background jobs` | `app/services.go` registers **15** |
| `platform/ 16 upstream adapters` | still 16 today — but equally unchecked |

A prose count is a claim nobody verifies. Each of these facts already has a machine gate (`TestTableCount` for the schema inventory, `TestAdapterPlatformNames`' anti-shrink cross-check for the adapter set, `scheduler_test`'s expected-name list for job names), but **no gate reads `AGENTS.md`** — verified before editing — so the three lines could only drift, and two of them had.

They now name the single source of truth instead of restating a number:

```
store/       DB layer (sqlx; table registry = store/tablesets.go, DDL = store/schema_ddl.go)
platform/    upstream adapters (registry = platform/registry.go)
scheduler/   background jobs (registered in app/services.go)
```

The next table, adapter or job changes no line here.

Also drops `rm -rf electron/metapi electron/metapi.exe electron/dist electron/node_modules` from `make clean` — `electron/` was deleted with the desktop shell (#1197), so that line removed nothing.

## Verification

`go test ./docs -count=1` → ok. Repo-wide scan for other stale references to deleted surfaces (`electron/`, `desktop-icon`, `scheduler/update_center`, `scheduler/admin_snapshot`, `scheduler/file_retention`, `handler/admin/update_center`, `update-center/tasks`, `api/test/proxy`, `test/chat/stream`) across `*.md` excluding `CHANGELOG.md`: **no hits**. The only remaining mentions of the deleted table names are in `handler/admin/settings_backup_tableset_test.go`, where `legacyBackupTables` deliberately keeps them as the historical upgrade gate (documented in that file and in the v0.18.0 notes).
