### PR TITLE
fix(e2e): converge an existing account instead of skipping it (#1209)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -639,6 +639,49 @@ jobs:
           SITE_NAME=e2e-smoke-sub2api TOKEN_NAME=e2e-smoke-sub2api-token \
           bash scripts/e2e/verify-token-import.sh
 
+          echo "===== sub2api re-run against an aged STORED credential (#1209) ====="
+          # The scripts promise to be re-runnable, so prove it the way the defect
+          # actually appeared: age the credential that is STORED -- not the one in
+          # the environment -- then re-run the same chain with the same token. A
+          # script that merely skips an existing account leaves the stale value in
+          # place; verify-token still passes because it uses the fresh token from
+          # the environment, and the run dies on balance, two steps away from what
+          # it is testing. Reverting the account step to create-or-skip turns this
+          # block red, which is the only reason it is worth its runtime.
+          aged_account_id="$(curl -sS -H "Authorization: Bearer e2e-admin-token" \
+            http://127.0.0.1:4010/api/accounts | python3 -c '
+          import json, sys
+          payload = json.load(sys.stdin)
+          for account in payload.get("accounts") or []:
+              if account.get("username") == "e2e-token-import":
+                  print(account["id"])
+                  break
+          ')"
+          if [ -z "$aged_account_id" ]; then
+            echo "FATAL: no e2e-token-import account to age; the chain above did not create one"
+            exit 1
+          fi
+          # Check the probe's own premise: an aging PUT that silently failed would
+          # leave a valid credential stored and the re-run below would prove
+          # nothing while still going green.
+          aging_status="$(curl -sS -o /dev/null -w '%{http_code}' -X PUT \
+            -H "Authorization: Bearer e2e-admin-token" -H "Content-Type: application/json" \
+            -d '{"accessToken":"aged-by-ci-not-a-real-credential","credentialMode":"session"}' \
+            "http://127.0.0.1:4010/api/accounts/$aged_account_id")"
+          if [ "$aging_status" != "200" ]; then
+            echo "FATAL: aging the stored credential returned HTTP $aging_status"
+            exit 1
+          fi
+          echo "aged the stored credential of account $aged_account_id"
+          METAPI_URL=http://127.0.0.1:4010 \
+          METAPI_AUTH_TOKEN=e2e-admin-token \
+          UPSTREAM_URL=http://127.0.0.1:3004 \
+          UPSTREAM_TOKEN="$SUB2API_ACCESS_TOKEN" \
+          PLATFORM=sub2api CREDENTIAL_MODE=session \
+          SKIP_MODEL_FETCH=true \
+          SITE_NAME=e2e-smoke-sub2api TOKEN_NAME=e2e-smoke-sub2api-token \
+          bash scripts/e2e/verify-token-import.sh
+
           echo "===== cliproxyapi token-import chain ====="
           METAPI_URL=http://127.0.0.1:4010 \
           METAPI_AUTH_TOKEN=e2e-admin-token \

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -112,8 +112,8 @@ Regeneration discipline:
 ## Public testbed assets
 
 - [`../testbed/compose.template.yml`](../testbed/compose.template.yml): sanitized loopback-only service template for Metapi, New API, One API, and optional adapter targets.
-- [`../scripts/e2e/smoke.sh`](../scripts/e2e/smoke.sh): idempotent password-login chain from health and site detection through `/v1` proxying.
-- [`../scripts/e2e/verify-token-import.sh`](../scripts/e2e/verify-token-import.sh): equivalent chain for session JWTs, API keys, and management keys.
+- [`../scripts/e2e/smoke.sh`](../scripts/e2e/smoke.sh): idempotent password-login chain from health and site detection through `/v1` proxying. Re-runs converge: `POST /api/accounts/login` upserts, so the login step refreshes the stored credential on every run.
+- [`../scripts/e2e/verify-token-import.sh`](../scripts/e2e/verify-token-import.sh): equivalent chain for session JWTs, API keys, and management keys. Re-runs converge as well (#1209): an account that already exists is re-bound to the credential this run holds instead of being skipped, and a reused downstream key has its relay policy re-asserted when this script owns the record. A short-lived upstream credential left stored by the previous run used to pass `verify-token` and then fail the chain two steps later on `balance`.
 - Operator-gated multi-channel cascade evidence procedure (see `scripts/verify-cascade-prod.sh` and the P0-585 verification test).
 
 ## Run a real-platform chain

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -393,6 +393,17 @@ else
 fi
 
 # 7. account idempotent-create
+#
+# Unlike verify-token-import.sh this step may safely create-or-skip (#1209): the
+# login in step 5 is itself the converge. POST /api/accounts/login upserts -- for
+# an account that already exists it runs
+#   UPDATE accounts SET access_token = <fresh credential>, status = 'active', ...
+# (handler/admin/accounts_auth.go, the reused-account branch), and on New API the
+# adapter has already promoted the short-lived v1 login JWT to the durable
+# dashboard PAT before it is stored. So the stored credential is refreshed on
+# every run by the step that owns it, and a PUT here would only rewrite the same
+# value. The token-paste chain has no login step, which is why it has to converge
+# explicitly.
 ACCOUNT_ID=""
 if [ -n "$SITE_ID" ]; then
   status="$(request GET "$METAPI_URL/api/accounts" "" "$METAPI_AUTH_TOKEN")"

--- a/scripts/e2e/verify-token-import.sh
+++ b/scripts/e2e/verify-token-import.sh
@@ -11,9 +11,21 @@
 #
 # Every step prints [PASS]/[FAIL]/[WARN] and accumulates a summary; the script
 # exits 1 when any step FAILs. FAILs print the truncated response body as
-# evidence. The script is re-runnable: sites/accounts/routes are looked up by
-# name before creation, and the downstream key has a fixed value so a 409
-# conflict is treated as "already exists".
+# evidence.
+#
+# Re-runnable means CONVERGE, not skip (#1209). Every resource is looked up
+# before it is created, and when it already exists this script re-asserts the
+# state the current run needs instead of trusting whatever the previous run left
+# stored:
+#   site            reuse by name, then by URL (identity IS the name/URL)
+#   account         re-bind the credential this run holds and just verified
+#   downstream key  re-assert supportedModels ["*"] and enabled
+#   route           reuse by modelPattern
+# Each step prints which of the three it did -- created, reused or refreshed --
+# so a green run cannot hide a resource that was merely left alone. A short-lived
+# upstream credential is the case that made this necessary: skipping left the
+# expired value stored and the failure surfaced two steps later on balance,
+# looking like a product regression while a release candidate was being proved.
 #
 # Configuration (environment variables):
 #   METAPI_URL         admin base URL         (default http://127.0.0.1:4000)
@@ -245,10 +257,12 @@ fi
 
 # 4. site idempotent-create (platform explicit so a flaky detect cannot block)
 SITE_ID=""
+SITE_STATE="created"
 status="$(request GET "$METAPI_URL/api/sites" "" "$METAPI_AUTH_TOKEN")"
 if [ "$status" = "200" ]; then
   if idx="$(json_find_index name "$SITE_NAME" 2>/dev/null)"; then
     SITE_ID="$(json_value "[$idx].id" 2>/dev/null || true)"
+    SITE_STATE="reused"
   fi
 fi
 if [ -z "$SITE_ID" ]; then
@@ -267,13 +281,14 @@ if [ -z "$SITE_ID" ]; then
     if [ -z "$SITE_ID" ]; then
       if idx="$(json_find_index url "$UPSTREAM_URL" 2>/dev/null)"; then
         SITE_ID="$(json_value "[$idx].id" 2>/dev/null || true)"
+        SITE_STATE="reused-by-url"
         warn_step "site idempotent-create (reused siteId=$SITE_ID by URL match)"
       fi
     fi
   fi
 fi
 if [ -n "$SITE_ID" ]; then
-  pass_step "site idempotent-create (siteId=$SITE_ID)"
+  pass_step "site idempotent-create (siteId=$SITE_ID, $SITE_STATE)"
 else
   fail_step "site idempotent-create (no site id obtained)"
   evidence
@@ -294,8 +309,9 @@ else
   fail_step "verify-token skipped (no site id)"
 fi
 
-# 6. account idempotent-create
+# 6. account idempotent-create -- converge the credential, do not skip (#1209)
 ACCOUNT_ID=""
+ACCOUNT_STATE="created"
 if [ -n "$SITE_ID" ] && [ -n "$VERIFIED_TYPE" ]; then
   status="$(request GET "$METAPI_URL/api/accounts" "" "$METAPI_AUTH_TOKEN")"
   if [ "$status" = "200" ]; then
@@ -320,9 +336,29 @@ if [ -n "$SITE_ID" ] && [ -n "$VERIFIED_TYPE" ]; then
       fail_step "account create (HTTP $status)"
       evidence
     fi
+  else
+    # The account already exists, so it still carries whatever credential the
+    # previous run stored. On a platform whose credential is short-lived -- a
+    # sub2api session JWT -- that value is expired by now: verify-token passes
+    # because it uses the fresh token from the environment, while balance fails
+    # because it refreshes the STORED one, and the run dies two steps away from
+    # the thing it is actually testing (#1209). Re-bind the credential this run
+    # already holds and verified in step 5.
+    #
+    # Deliberately the same token and never a second issuance: sub2api bumps
+    # token_version per issuance, so signing another one would invalidate the
+    # token the rest of this run still needs. The refresh is printed rather than
+    # silent, so it cannot mask a real "account lost its credential" regression.
+    status="$(request PUT "$METAPI_URL/api/accounts/$ACCOUNT_ID" "{\"accessToken\":\"$UPSTREAM_TOKEN\",\"credentialMode\":\"$CREDENTIAL_MODE\"}" "$METAPI_AUTH_TOKEN")"
+    if [ "$status" = "200" ]; then
+      ACCOUNT_STATE="refreshed"
+    else
+      fail_step "account credential refresh (HTTP $status)"
+      evidence
+    fi
   fi
   if [ -n "$ACCOUNT_ID" ]; then
-    pass_step "account idempotent-create (accountId=$ACCOUNT_ID, tokenType=$VERIFIED_TYPE)"
+    pass_step "account idempotent-create (accountId=$ACCOUNT_ID, tokenType=$VERIFIED_TYPE, $ACCOUNT_STATE)"
   fi
 else
   fail_step "account idempotent-create skipped (no site id / token not verified)"
@@ -397,9 +433,33 @@ if [ "$status" = "200" ] || [ "$status" = "201" ]; then
   PROXY_TOKEN="$TOKEN_IMPORT_KEY"
   pass_step "token create ($TOKEN_NAME)"
 elif [ "$status" = "409" ]; then
-  # duplicate key: same fixed value from a previous run — reuse it
-  PROXY_TOKEN="$TOKEN_IMPORT_KEY"
-  pass_step "token create (HTTP 409 duplicate, reusing fixed key)"
+  # The key exists from a previous run. Reassert the relay policy instead of
+  # merely reusing it: an empty supportedModels list is intentionally deny-all,
+  # so a leftover key would silently block every model this run is about to
+  # relay. smoke.sh step 11 already converges this way (#1209).
+  status="$(request GET "$METAPI_URL/api/downstream-keys" "" "$METAPI_AUTH_TOKEN")"
+  key_id="$(python3 -c 'import json,sys; p=json.load(sys.stdin); name=sys.argv[1]; print(next(str(item.get("id", "")) for item in p.get("items", []) if isinstance(item, dict) and item.get("name") == name))' "$TOKEN_NAME" < "$RESP_BODY" 2>/dev/null || true)"
+  if [ "$status" = "200" ] && [ -n "$key_id" ]; then
+    status="$(request PUT "$METAPI_URL/api/downstream-keys/$key_id" '{"supportedModels":["*"],"enabled":true}' "$METAPI_AUTH_TOKEN")"
+    if [ "$status" = "200" ]; then
+      PROXY_TOKEN="$TOKEN_IMPORT_KEY"
+      pass_step "token reuse ($TOKEN_NAME, relay policy reasserted)"
+    else
+      fail_step "token reuse/update (HTTP $status, keyId=$key_id)"
+      evidence
+    fi
+  else
+    # A 409 with no record under this name means the fixed key VALUE belongs to a
+    # differently named record, so this script does not own it and cannot
+    # reassert its policy. That is a real topology here: two chains share
+    # TOKEN_IMPORT_KEY under different TOKEN_NAMEs, so whichever runs second
+    # always lands in this branch. Reusing the value is still correct -- the
+    # relay steps below prove it works -- but claiming the policy was checked
+    # would be a green that means nothing, and failing would red a run whose
+    # relay is fine. So: reuse, and say out loud what was not verified.
+    PROXY_TOKEN="$TOKEN_IMPORT_KEY"
+    warn_step "token reuse (HTTP 409: the fixed key is owned by a differently named record, relay policy NOT reasserted)"
+  fi
 else
   fail_step "token create (HTTP $status)"
   evidence
@@ -408,10 +468,12 @@ fi
 # 11. route create (idempotent by modelPattern lookup)
 if [ -n "$PROXY_TOKEN" ]; then
   ROUTE_ID=""
+  ROUTE_STATE="created"
   status="$(request GET "$METAPI_URL/api/routes/lite" "" "$METAPI_AUTH_TOKEN")"
   if [ "$status" = "200" ]; then
     if idx="$(json_find_index modelPattern "$ROUTE_MODEL" 2>/dev/null)"; then
       ROUTE_ID="$(json_value "[$idx].id" 2>/dev/null || true)"
+      ROUTE_STATE="reused"
     fi
   fi
   if [ -z "$ROUTE_ID" ]; then
@@ -422,9 +484,9 @@ if [ -n "$PROXY_TOKEN" ]; then
   fi
   if [ -n "$ROUTE_ID" ]; then
     if [ "$ROUTE_MODEL" = "$PROXY_MODEL" ] && [ -z "$first_model" ]; then
-      warn_step "route create (routeId=$ROUTE_ID, model=$ROUTE_MODEL) — upstream model list empty, used PROXY_MODEL"
+      warn_step "route create (routeId=$ROUTE_ID, model=$ROUTE_MODEL, $ROUTE_STATE) — upstream model list empty, used PROXY_MODEL"
     else
-      pass_step "route create (routeId=$ROUTE_ID, model=$ROUTE_MODEL)"
+      pass_step "route create (routeId=$ROUTE_ID, model=$ROUTE_MODEL, $ROUTE_STATE)"
     fi
   else
     fail_step "route create (no route id obtained)"


### PR DESCRIPTION
## The promise versus the behaviour

`verify-token-import.sh` documents itself as re-runnable and does look every resource up before creating it — but for **accounts** it only ever created. An account left over from a previous run kept whatever credential that run stored, and on a platform whose credential is short-lived (a sub2api session JWT) that value is expired by the next run:

```
[PASS] verify-token (tokenType=session)          <- uses the fresh token from the environment
[PASS] account idempotent-create (accountId=2)   <- leaves the expired one stored
[FAIL] balance (HTTP 502)                        <- refreshes the STORED one
       body: {"message":"balance refresh failed"}
== summary: 10 passed, 2 warned, 1 failed ==
```

The chain dies two steps away from what it is testing, at exactly the moment a release candidate is being proved.

## Reproduced live, fixed live

Real sub2api upstream, one issued session JWT reused for both runs (a second issuance would invalidate it), the stored credential deliberately aged first. Only the script changed:

| script | account step | balance | exit |
|---|---|---|---|
| `master` | `[PASS] account idempotent-create (accountId=2, tokenType=session)` | `[FAIL] balance (HTTP 502)` | **1** — 10 passed / 1 failed |
| this branch | `[PASS] account idempotent-create (accountId=2, tokenType=session, refreshed)` | `[PASS] balance (HTTP 200)` | **0** — 10 passed / 0 failed |

A third run converges again, so it is a property and not a one-off. The aged account also came back from `status=expired` on the successful refresh (a successful balance refresh un-expires; `isAccountDisabled` only treats `disabled` as blocking, so nothing here can pass by skipping).

The `master` column **is** the mutation probe: same live conditions, the create-or-skip behaviour, red.

## What changed

**Account step converges.** When the account exists, `PUT /api/accounts/{id}` with the credential this run already holds and verified, then assert. It reuses that token and never issues a second one, because sub2api bumps `token_version` per issuance. It prints `refreshed` rather than converging silently, so it cannot mask a real "account lost its credential" regression.

**Downstream key step converges when it owns the record.** A 409 reused the fixed key without re-asserting its policy, and an empty `supportedModels` is intentionally deny-all. `smoke.sh` already converges this way; this script now does too.

Worth recording, because the obvious port is wrong: copying `smoke.sh`'s stricter branch wholesale **reddens CI**. The sub2api and cliproxyapi chains share one fixed key value under different `TOKEN_NAME`s, so whichever runs second finds no record under its own name — `GET /api/downstream-keys` does not expose key values, so there is nothing to match on. When the script does not own the record it now reuses the value and says out loud that the policy was *not* re-asserted:

```
[WARN] token reuse (HTTP 409: the fixed key is owned by a differently named record, relay policy NOT reasserted)
```

That is a real topology, so failing a run whose relay demonstrably works would be wrong, and claiming a check that never happened would be worse.

**`smoke.sh` does not need the account fix, and now says so.** `POST /api/accounts/login` upserts — for a reused account it runs `UPDATE accounts SET access_token = <fresh>, status = 'active', …` (`handler/admin/accounts_auth.go`, reused-account branch), and on New API the adapter has already promoted the short-lived v1 login JWT to the durable dashboard PAT before it is stored. So the password chain refreshes its stored credential every run in the step that owns it, and a PUT there would rewrite the same value. The comment sits where a reader would otherwise "fix" it by symmetry. The issue's grep was right that neither script issues a PUT; the login chain does not need one.

**Every step now prints which of `created` / `reused` / `refreshed` it did**, so a green run cannot hide a resource that was merely left alone.

**Routes are unchanged** (create-or-reuse by `modelPattern`, in both scripts). No observed failure involves a stale route here, and `POST /api/routes/rebuild` is async, so inventing a wait for it in one script only would be churn without a defect behind it.

## The CI gate

`test-e2e` gains the aging re-run: age the **stored** credential, re-run the same chain with the same token, require green. Reverting the account step to create-or-skip turns that block red — the only reason it is worth its runtime. The aging PUT checks its own HTTP status before the re-run, so a probe that failed to age anything cannot pass silently while proving nothing.

`docs/testing.md` now states the converge semantics instead of a bare "idempotent".

Fixes #1209
