### PR TITLE
test(docs): fail the package-boundary gate when it scans nothing

### DIFF
--- a/docs/package_boundary_test.go
+++ b/docs/package_boundary_test.go
@@ -51,9 +51,30 @@ import (
 
 const modulePath = "github.com/deliciousbuding/metapi-go"
 
+// boundaryGroups are the twelve top-level domain packages the denylist below is
+// keyed on. TestPackageBoundaries asserts each one was really scanned, so a
+// future layout move that forgets this file fails loudly instead of passing
+// vacuously. A gate that scans nothing and reports no violations is not a
+// lenient gate, it is an absent one: that is the exact shape that let roughly
+// thirty release tags go green while their required shards ran zero tests.
+var boundaryGroups = []string{
+	"app", "auth", "config", "handler", "platform", "proxy", "router",
+	"routing", "scheduler", "service", "store", "transform",
+}
+
 func TestPackageBoundaries(t *testing.T) {
 	root := repoRoot(t)
-	violations := scanBoundaryViolations(t, root)
+	violations, scanned := scanBoundaryViolations(t, root)
+	var missing []string
+	for _, group := range boundaryGroups {
+		if scanned[group] == 0 {
+			missing = append(missing, group)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("gate would pass vacuously: no production Go files scanned for %v. "+
+			"The layout moved without updating ownerPackage/boundaryGroups in this file.", missing)
+	}
 	if len(violations) > 0 {
 		sort.Slice(violations, func(i, j int) bool {
 			if violations[i].pkg != violations[j].pkg {
@@ -195,17 +216,26 @@ func forbiddenImport(pkg, imp string) string {
 	return ""
 }
 
-func scanBoundaryViolations(t *testing.T, root string) []violation {
+func scanBoundaryViolations(t *testing.T, root string) ([]violation, map[string]int) {
 	t.Helper()
 	var out []violation
+	scanned := map[string]int{}
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
 			name := d.Name()
+			// .worktrees holds full checkouts of this same repository, so scanning
+			// it means parsing a second copy of every backend package and reporting
+			// a work-in-progress branch's violations under a confusing path: with
+			// two worktrees checked out the walk covered 732 production files
+			// against 366 in the repository proper. .dev-local is the private
+			// QA/runbook area, where a stray .go file is not production
+			// architecture and must not be treated as one.
 			if name == ".git" || name == "node_modules" || name == "dist" ||
-				name == ".claude" || name == "worktrees" || name == "vendor" {
+				name == ".claude" || name == "worktrees" || name == ".worktrees" ||
+				name == ".dev-local" || name == "vendor" {
 				return filepath.SkipDir
 			}
 			return nil
@@ -218,6 +248,11 @@ func scanBoundaryViolations(t *testing.T, root string) []violation {
 		pkg, ok := ownerPackage(relDir)
 		if !ok {
 			return nil
+		}
+		if i := strings.IndexByte(pkg, '/'); i >= 0 {
+			scanned[pkg[:i]]++
+		} else {
+			scanned[pkg]++
 		}
 		fset := token.NewFileSet()
 		f, perr := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
@@ -242,5 +277,5 @@ func scanBoundaryViolations(t *testing.T, root string) []violation {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return out
+	return out, scanned
 }


### PR DESCRIPTION
## Why

The forbidden-import gate could pass **vacuously**. `scanBoundaryViolations` walks the repository and reports denylist violations; if the walk covered no production Go files at all — because a domain directory moved or was renamed, or because this file simply stopped matching the layout — it returned an empty violation list and the test passed.

A gate that scans nothing and reports no violations is not a lenient gate, it is an absent one. That is precisely the shape that let roughly thirty release tags go green while their required shards ran **zero** tests (#1175): the check did not check its own premise. Nothing about the denylist rules changes here.

This was found while adjudicating a whole-repository layout move. The move itself was rejected — it bought nothing this repository can use — but it had to rewrite this gate to survive, and that rewrite contained the one genuinely good idea in it: assert the gate reached the packages it claims to police. The idea is kept; the move is not.

## What it does now

`TestPackageBoundaries` counts production files scanned per domain and fails when any of the twelve the denylist is keyed on was never reached:

```
gate would pass vacuously: no production Go files scanned for [store].
The layout moved without updating ownerPackage/boundaryGroups in this file.
```

## Probes

Each was required to go red, and each was restored byte-exactly (`git status` clean, full `./docs` package green afterwards):

| probe | what it broke | result |
|---|---|---|
| A | a stale name in `boundaryGroups` (`router` → `routerM`) | red: `no production Go files scanned for [routerM]` |
| B | the real failure mode — the walk stops descending into a domain directory (`store`) | red: `… for [store]` |
| C | the skip list swallows a real domain (`handler`) | red: `… for [handler]` |

Probe C is the one that keeps the second change honest: adding directories to a skip list is exactly how a gate gets quietly switched off, so the guard has to catch the skip list itself.

## Second fix: the walk skipped `worktrees` but not `.worktrees`

`.worktrees/` is where this repository's own checkouts live. With two of them checked out, the gate parsed **732** production Go files against **366** in the repository proper — two extra copies of every backend package — and a work-in-progress branch's violation would have been reported under a `.worktrees/<branch>/…` path that no reader could map back to the contract in `docs/architecture.md`.

`.dev-local` (private QA and runbooks) is skipped for the mirror-image reason: a stray `.go` file dropped there is not production architecture and must not be silently treated as one.

Test-only change; no product code, no rule relaxed.
