### PR TITLE
ci(e2e): gate the restore state, not just the import

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -803,6 +803,123 @@ jobs:
           print(f"mock upstream received a new exact relay event after restart ({before} -> {len(events)})")
           PY
 
+          echo "===== restore the exported backup into a FRESH data dir and re-prove the chain ====="
+          # Restore is the fourth state, and "the import answered 200" is not it: a
+          # backup that imports cleanly but cannot serve a request afterwards is a
+          # restore that only looks successful. Deleting tables has already broken
+          # old backups once in this project, so the proof is a real relay on the
+          # restored instance -- nothing re-created, re-bound or rebuilt by hand.
+          #
+          # Export carries every credential in the database, so it is a sensitive
+          # operation and additionally requires the master token in
+          # X-Admin-Confirm-Token; without it the answer is a 403 reauthRequired
+          # body, which then makes the import fail with a misleading "expected a
+          # JSON object with a tables field". Import itself is not gated.
+          backup_file="$RUNNER_TEMP/metapi-e2e-backup.json"
+          curl -fsS -H "Authorization: Bearer e2e-admin-token" \
+            -H "X-Admin-Confirm-Token: e2e-admin-token" \
+            http://127.0.0.1:4010/api/settings/backup/export -o "$backup_file"
+          python3 - "$backup_file" <<'PY'
+          import json, sys
+          with open(sys.argv[1], encoding="utf-8") as handle:
+              payload = json.load(handle)
+          tables = payload.get("tables") or {}
+          if not tables:
+              raise SystemExit(f"export carried no tables; top-level keys were {sorted(payload)!r}")
+          required = ["sites", "accounts", "account_tokens", "token_routes", "route_channels", "downstream_api_keys"]
+          missing = [name for name in required if name not in tables]
+          if missing:
+              raise SystemExit(f"export is missing tables the relay needs: {missing}")
+          print(f"export carries {len(tables)} tables including {required}")
+          PY
+
+          restore_dir="$(mktemp -d)/data"
+          AUTH_TOKEN=e2e-admin-token \
+          PROXY_TOKEN=e2e-proxy-token \
+          DATA_DIR="$restore_dir" \
+          PORT=4011 \
+          "$metapi_bin" >"$RUNNER_TEMP/metapi-e2e-restore.log" 2>&1 &
+          restore_pid=$!
+          restore_ready=
+          for i in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:4011/ready 2>/dev/null | grep -q '"status":"ok"'; then
+              restore_ready=1; echo "restore instance ready after ${i}s"; break
+            fi
+            sleep 1
+          done
+          if [ -z "$restore_ready" ]; then
+            echo "restore instance never became ready; log:"
+            cat "$RUNNER_TEMP/metapi-e2e-restore.log"
+            exit 1
+          fi
+
+          # Premise: before the import this instance must not be able to serve the
+          # chain, otherwise a green result below could come from an instance that
+          # was never empty.
+          pre_models="$(curl -sS -H "Authorization: Bearer sk-e2e-smoke-key" http://127.0.0.1:4011/v1/models \
+            | python3 -c '
+          import json, sys
+          try:
+              payload = json.loads(sys.stdin.read())
+          except Exception:
+              print(0); raise SystemExit
+          print(len(payload.get("data") or []))
+          ')"
+          if [ "$pre_models" != "0" ]; then
+            echo "the fresh instance already served $pre_models models before the import; the restore would prove nothing"
+            exit 1
+          fi
+          echo "fresh instance serves no models before the import, as required"
+
+          curl -fsS -X POST -H "Authorization: Bearer e2e-admin-token" -H "Content-Type: application/json" \
+            --data-binary @"$backup_file" http://127.0.0.1:4011/api/settings/backup/import \
+            | python3 -c '
+          import json, sys
+          payload = json.load(sys.stdin)
+          if not payload.get("success", False):
+              raise SystemExit(f"backup import did not report success: {payload!r}")
+          print("import ok; new downstream keys:", len(payload.get("newDownstreamApiKeys") or []),
+                "ignored tables:", payload.get("ignoredTables") or [])
+          '
+
+          mock_events_before_restore=$(wc -l < "$mock_log")
+          curl -fsS -H "Authorization: Bearer sk-e2e-smoke-key" http://127.0.0.1:4011/v1/models \
+            | python3 -c '
+          import json, sys
+          data = json.load(sys.stdin).get("data") or []
+          if not data:
+              raise SystemExit("/v1/models is empty after restore: the routing state did not come back with the backup")
+          print("models after restore:", [m.get("id") for m in data])
+          '
+          curl -fsS -X POST -H "Authorization: Bearer sk-e2e-smoke-key" \
+            -H "Content-Type: application/json" \
+            -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"restore-state"}]}' \
+            http://127.0.0.1:4011/v1/chat/completions \
+            | python3 -c '
+          import json, sys
+          payload = json.load(sys.stdin)
+          choice = (payload.get("choices") or [{}])[0]
+          content = (choice.get("message") or {}).get("content") or ""
+          if content != "metapi-e2e-marker":
+              raise SystemExit(f"completion after restore returned {content!r}, want the exact upstream marker; payload={payload!r}")
+          print("completion after restore carried the exact upstream marker")
+          '
+          python3 - "$mock_log" "$mock_events_before_restore" <<'PY'
+          import json, sys
+          path, before = sys.argv[1], int(sys.argv[2])
+          with open(path, encoding="utf-8") as handle:
+              events = [json.loads(line) for line in handle if line.strip()]
+          expected = {"path": "/v1/chat/completions", "model": "gpt-4o-mini"}
+          if len(events) <= before:
+              raise SystemExit(f"mock upstream saw no new request after the restore ({before} -> {len(events)})")
+          if expected not in events[before:]:
+              raise SystemExit(f"post-restore upstream requests did not include {expected!r}: {events[before:]!r}")
+          print(f"mock upstream received a new exact relay event after restore ({before} -> {len(events)})")
+          PY
+          kill "$restore_pid"
+          wait "$restore_pid" || true
+          echo "restore instance stopped; the exported backup stays in runner temp only"
+
   # Cross-platform runtime smoke: release binaries are cross-compiled for 5
   # targets but only linux/amd64 ever gets executed (release smoke step). This
   # job builds + boots the real binary on each shipped OS (macOS x64, Windows


### PR DESCRIPTION
Closes the last ungated state in #1215.

## Why

"Import answered 200" and "the restored deployment can serve a request" are different claims, and only the first was proven: `e2e/e2e_backup_test.go` asserts rows and values after a round trip, and nothing anywhere attempted a **relay** on a restored database.

The gap is not hypothetical. Deleting four dead tables broke the restore of every backup written before the deletion, and both branches that removed those tables turned the gate green by editing a *historical fixture* — changing the record of what an old build used to write — so the regression shipped. The rule that came out of it (genuine exports carry `metadata`; unknown tables in a real export are skipped and reported as `ignoredTables`; hand-written JSON with unknown keys still 400s) is worth exactly what an end-to-end restore assertion makes it worth.

## What it asserts

`test-e2e` exports a backup from the instance the chains just built, starts a second instance on a **fresh** data dir, imports it there, and re-proves the core chain on the restored instance with nothing re-created, re-bound or rebuilt by hand:

- the export carries the tables a relay needs (`sites`, `accounts`, `account_tokens`, `token_routes`, `route_channels`, `downstream_api_keys`);
- the fresh instance serves **zero** models *before* the import — otherwise a green result could come from an instance that was never empty;
- `/v1/models` is non-empty after it;
- one completion returns the **exact** upstream marker;
- the mock upstream received a **new** exact relay event, so a cached or replayed answer cannot be mistaken for a relay.

## Rehearsed live first

Against a deployment running release-homogeneous bytes (`sha256 a4f4b2d2…`, `v0.18.0`):

```
export http=200 size=93076 mode=600   top-level keys: ['metadata','tables','type']
second instance ready after 2s        models before import: 0 []
import http=200  success: True  newDownstreamApiKeys: 6
/v1/models: 1 ['e2e-smoke-route']
completion: {"id":"chatcmpl-mock-…","model":"gpt-3.5-turbo",
             "choices":[{"message":{"content":"mock upstream ok: received model=gpt-3.5-turbo"}}]}
[OK] relay works immediately after restore
```

No rebuild call was needed, which is worth recording: a router cache built at startup from an empty database was the obvious way for this to fail, and it does not.

The rehearsal also found the thing that would have made this gate *confusing* rather than wrong: export carries every credential in the database, so it is a sensitive operation (#1034) and additionally requires the master token in `X-Admin-Confirm-Token`. Without it you get a 403 `reauthRequired` body, and the import then fails with a misleading `expected a JSON object with a tables field` — two errors, neither naming the cause. Import itself is not gated. That is now a comment in the workflow, because the next person to touch this block would otherwise rediscover it the slow way.

The exported backup is treated as sensitive material throughout: mode 600, runner temp only, and deleted at the end of the rehearsal.

Cost: one extra server start and one export/import inside `test-e2e`. No product code changes.
