### PR TITLE
fix(backup): resync PostgreSQL id sequences after an import

### DIFF
--- a/handler/admin/settings_backup.go
+++ b/handler/admin/settings_backup.go
@@ -599,6 +599,21 @@ func importBackupTablesWithConn(conn backupImportConn, tables map[string]json.Ra
 			result.newDownstreamApiKeys = downstreamNamesForNewKeys(rows, downstreamCandidates, downstreamBefore, downstreamAfter)
 		}
 	}
+
+	// Rows were inserted with the ids they were exported with, which leaves
+	// PostgreSQL's serial sequences pointing below them: the next ordinary INSERT
+	// asks for an id the restore just occupied and fails on a unique constraint,
+	// naming a key rather than a sequence so nothing points back here. A restored
+	// deployment that cannot perform its first write is not a working restore, so
+	// this is fatal rather than a warning -- the schema was just migrated, which
+	// is the one case where a missing table cannot explain the failure. The
+	// migrator resyncs through the same helper for the same reason; SQLite needs
+	// nothing (see store.ResyncPGIDSequences).
+	if conn.DriverName() == "pgx" {
+		if err := store.ResyncPGIDSequences(conn); err != nil {
+			return nil, fmt.Errorf("import failed: resync id sequences: %w", err)
+		}
+	}
 	return result, nil
 }
 

--- a/handler/admin/settings_backup_pg_test.go
+++ b/handler/admin/settings_backup_pg_test.go
@@ -1,0 +1,98 @@
+//go:build integration
+
+package admin
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/deliciousbuding/metapi-go/internal/pgtest"
+	"github.com/deliciousbuding/metapi-go/store"
+)
+
+// TestBackupImportResyncsPostgresSequences is the PostgreSQL half of a restore.
+//
+// An export carries rows with the ids they were written with, so importing them
+// leaves every serial sequence pointing below the restored data. The next
+// ordinary INSERT then asks the sequence for an id the restore just occupied and
+// fails on a unique constraint -- an error that names a key, not a sequence, so
+// nothing in it points back at the import. A restored deployment that cannot
+// perform its first write is not a working restore, and it looks fine until
+// somebody tries to add a site.
+//
+// SQLite is deliberately not covered: AUTOINCREMENT updates sqlite_sequence on an
+// explicit insert and a plain INTEGER PRIMARY KEY derives max+1 by itself, so
+// there is nothing to resync (store.ResyncPGIDSequences documents both).
+func TestBackupImportResyncsPostgresSequences(t *testing.T) {
+	dsn := os.Getenv("PG_TEST_DSN")
+	if strings.TrimSpace(dsn) == "" {
+		t.Skip("PG_TEST_DSN not set; skipping PostgreSQL integration test")
+	}
+	db, err := store.Open(store.DialectPostgres, dsn, false)
+	if err != nil {
+		t.Fatalf("failed to open PostgreSQL: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	pgtest.Reset(t, db.DB)
+	if err := store.AutoMigrate(db); err != nil {
+		t.Fatalf("AutoMigrate failed: %v", err)
+	}
+
+	now := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	site := func(id int, name, url, platform string) string {
+		return `{"id":` + json.Number(strings.TrimSpace(itoaPG(id))).String() +
+			`,"name":"` + name + `","url":"` + url + `","platform":"` + platform +
+			`","status":"active","created_at":"` + now + `","updated_at":"` + now + `"}`
+	}
+	// Exactly what a real export looks like: explicit, low, contiguous ids.
+	payload := map[string]json.RawMessage{
+		"sites": json.RawMessage("[" +
+			site(1, "restored-a", "http://127.0.0.1:3000", "new-api") + "," +
+			site(2, "restored-b", "http://127.0.0.1:3004", "sub2api") + "," +
+			site(3, "restored-c", "http://127.0.0.1:3012", "openai") +
+			"]"),
+	}
+	if _, err := importBackupTablesWithConn(db.DB, payload); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	// The ordinary write path supplies no id, so PostgreSQL asks the sequence.
+	if _, err := db.Exec(db.Rebind(`INSERT INTO sites (name, url, platform, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)`),
+		"post-restore", "http://127.0.0.1:3001", "new-api", "active", now, now); err != nil {
+		t.Fatalf("first write after restore failed: %v (a duplicate key here means the import left the id sequences behind the rows it restored)", err)
+	}
+
+	var maxID, seq int64
+	if err := db.QueryRow(`SELECT MAX(id) FROM sites`).Scan(&maxID); err != nil {
+		t.Fatalf("read MAX(id): %v", err)
+	}
+	// pg_sequence_last_value takes the sequence's regclass; `FROM func()::regclass`
+	// is not valid PostgreSQL, which is worth writing down because it reads fine.
+	if err := db.QueryRow(`SELECT pg_sequence_last_value(pg_get_serial_sequence('sites', 'id')::regclass)`).Scan(&seq); err != nil {
+		t.Fatalf("read the sites id sequence: %v", err)
+	}
+	if maxID != 4 {
+		t.Fatalf("MAX(id) = %d, want 4 (three restored rows plus the post-restore write)", maxID)
+	}
+	if seq < maxID {
+		t.Fatalf("sequence last_value = %d is below MAX(id) = %d, so a later insert can still collide", seq, maxID)
+	}
+}
+
+func itoaPG(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/store/migrate_runner.go
+++ b/store/migrate_runner.go
@@ -383,15 +383,16 @@ func RunMigration(opts RunMigrationOptions) (*MigrationSummary, error) {
 		fmt.Fprintf(logw, "  Done: %d rows in %s\n", inserted, elapsed.Round(time.Millisecond))
 	}
 
-	// 10. Sync sequences (PostgreSQL only; SQLite AUTOINCREMENT handles itself)
+	// 10. Sync sequences (PostgreSQL only; SQLite AUTOINCREMENT handles itself).
+	// Shared with the backup import, which has the same problem: rows arrive with
+	// explicit ids and the sequences stay where they were.
 	if !toSQLite {
 		fmt.Fprintf(logw, "\nSyncing PostgreSQL sequences...\n")
-		for _, table := range sequenceTableNames() {
-			q := fmt.Sprintf(`SELECT setval(pg_get_serial_sequence('%s', 'id'), COALESCE((SELECT MAX("id") FROM "%s"), 1), TRUE)`, table, table)
-			if _, err := tx.Exec(q); err != nil {
-				// Table might not exist if migrations haven't run; warn but continue
-				fmt.Fprintf(logw, "  Warning: sync sequence for %s: %v\n", table, err)
-			}
+		if err := ResyncPGIDSequences(tx); err != nil {
+			// A target whose migrations have not all run can legitimately be missing
+			// a table; warn and continue, and the joined error names every table
+			// that could not be resynced.
+			fmt.Fprintf(logw, "  Warning: sync sequences: %v\n", err)
 		}
 	}
 

--- a/store/sequences.go
+++ b/store/sequences.go
@@ -1,0 +1,53 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// sequenceExecer is the slice of a transaction or connection that a sequence
+// resync needs. Both *sqlx.Tx (the SQLite→PostgreSQL migrator) and the backup
+// import's conn satisfy it, so this SQL has one owner instead of two copies that
+// can drift apart the next time a table is added.
+type sequenceExecer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
+// ResyncPGIDSequences advances every serial id sequence past the largest id now
+// stored, for the tables that have one.
+//
+// Bulk writers that insert explicit ids leave PostgreSQL's sequences behind: the
+// migrator copying a SQLite database over, and a backup import restoring rows
+// with the ids they were exported with. The next ordinary INSERT then asks the
+// sequence for a value the restore just occupied and fails with a duplicate key —
+// a deployment in that state works until its first write, which is the worst
+// moment to discover it, and the error names a constraint rather than a sequence
+// so nothing points back here.
+//
+// SQLite needs no help: AUTOINCREMENT updates sqlite_sequence on an explicit
+// insert, and a plain INTEGER PRIMARY KEY derives max+1 by itself.
+//
+// Table names come from the schema registry (AllTableNames filtered by
+// tableHasSerialID), never from a payload, which is why they are interpolated;
+// the migrator has always built this statement the same way.
+//
+// Failures are collected and returned together rather than aborting on the first,
+// so a caller running against a possibly-incomplete schema can report every table
+// it could not resync. The migrator warns and continues, because its target may
+// not have run every migration; a backup import treats the same error as fatal,
+// because there the schema was just migrated and a silently un-advanced sequence
+// is exactly the bug this prevents.
+func ResyncPGIDSequences(exec sequenceExecer) error {
+	var errs []error
+	for _, table := range sequenceTableNames() {
+		query := fmt.Sprintf(
+			`SELECT setval(pg_get_serial_sequence('%s', 'id'), COALESCE((SELECT MAX("id") FROM "%s"), 1), TRUE)`,
+			table, table,
+		)
+		if _, err := exec.Exec(query); err != nil {
+			errs = append(errs, fmt.Errorf("table %s: %w", table, err))
+		}
+	}
+	return errors.Join(errs...)
+}


### PR DESCRIPTION
Fixes #1217.

## The failure

A backup export carries rows with the ids they were written with. Importing one into PostgreSQL does not advance the serial sequences, so they stay where they were — typically at 1 on a fresh database. The next ordinary write asks for an id the restore just occupied:

```
ERROR: duplicate key value violates unique constraint "sites_pkey" (SQLSTATE 23505)
```

The restored deployment looks healthy right up to that point: the UI lists everything, `/v1/models` answers, a relay works. It fails on the **first write** — creating a site, binding an account, issuing a key — and the error names a constraint rather than a sequence, so nothing in it points back at the import.

## Why nobody noticed

The SQLite→PostgreSQL migrator already resynced sequences for exactly this reason (`store/migrate_runner.go`, step 10). The import path simply never did, and each carried its own copy of the reasoning. Restore was only ever asserted as a *data* round trip — `e2e/e2e_backup_test.go` compares rows and values — so nothing ever wrote to a restored database. #1216 added the relay-after-restore gate; this is the write-after-restore half.

## The fix

One helper, `store.ResyncPGIDSequences`, called by both the migrator and the import path, so the statement cannot drift the next time a table is added. It returns every failure joined instead of aborting on the first, which lets the two callers disagree about severity honestly:

- the **migrator** warns and continues, because its target may not have run every migration and a missing table is a legitimate outcome;
- the **import** treats it as fatal, because there the schema was just migrated, so a missing table cannot explain the failure — and a silently un-advanced sequence is precisely the bug being fixed.

SQLite gets nothing because it needs nothing: `AUTOINCREMENT` updates `sqlite_sequence` on an explicit insert, and a plain `INTEGER PRIMARY KEY` derives max+1 by itself. Both facts are written down where the next reader will look for them.

## Evidence — real PostgreSQL 16, not a mock

`TestBackupImportResyncsPostgresSequences` (integration-tagged, skipped without `PG_TEST_DSN`) imports three `sites` rows with ids 1–3 from a payload shaped like a genuine export, then inserts through the ordinary path with no id and asserts both the row and `pg_sequence_last_value`.

Mutation probe — the resync call removed from the import path:

```
--- FAIL: TestBackupImportResyncsPostgresSequences
    first write after restore failed: ERROR: duplicate key value violates
    unique constraint "sites_pkey" (SQLSTATE 23505)
```

Restored byte-exactly afterwards (`git status` clean) and green again. This is the failure an operator would have seen, reproduced on demand.

Regression, all against a real PostgreSQL with `PG_TEST_DSN` set:

```
build ./...            exit 0
vet  store handler/admin service/backup cmd/...   exit 0
ok   store             13.231s   (the migrator's own resync path)
ok   service/backup     0.614s
ok   handler/admin     55.743s
```

One detail recorded in the test because it reads fine and is not: a sequence's `last_value` is `pg_sequence_last_value(pg_get_serial_sequence(...)::regclass)`; `SELECT last_value FROM pg_get_serial_sequence(...)::regclass` is a syntax error at the cast.
